### PR TITLE
fix: remove demo runner from weather metrics example

### DIFF
--- a/sdk/examples/plugins/weather-metrics.ts
+++ b/sdk/examples/plugins/weather-metrics.ts
@@ -17,7 +17,7 @@
  *   ANTHROPIC_API_KEY=sk-... bun run examples/plugins/weather-plugin.example.ts
  */
 
-import { type AgentPlugin, ClineCore, createTool } from "@cline/core";
+import { type AgentPlugin, createTool } from "@cline/core";
 
 // ---------------------------------------------------------------------------
 // Plugin-level state — populated from setup context and available to all hook
@@ -148,46 +148,5 @@ const plugin: AgentPlugin = {
 	},
 };
 
-async function runDemo(): Promise<void> {
-	const sessionManager = await ClineCore.create({ backendMode: "local" });
-
-	try {
-		const result = await sessionManager.start({
-			config: {
-				providerId: "anthropic",
-				modelId: "claude-sonnet-4-6",
-				apiKey: process.env.ANTHROPIC_API_KEY ?? "",
-				cwd: process.cwd(),
-				enableTools: true,
-				enableSpawnAgent: false,
-				enableAgentTeams: false,
-				systemPrompt: "You are a helpful assistant. Use tools when needed.",
-				extensions: [plugin],
-				// extensionContext.workspace is the authoritative source for
-				// workspaceInfo that flows into setup(api, ctx). The CLI
-				// and VS Code hosts populate this automatically from their runtime
-				// state. When using the SDK directly, set it explicitly so plugins
-				// always receive accurate workspace metadata.
-				extensionContext: {
-					workspace: {
-						rootPath: process.cwd(),
-						cwd: process.cwd(),
-					},
-				},
-			},
-			prompt: "What's the weather like in Tokyo and Paris?",
-			interactive: false,
-		});
-
-		console.log(`\n${result.result?.text ?? ""}`);
-	} finally {
-		await sessionManager.dispose();
-	}
-}
-
-if (import.meta.main) {
-	await runDemo();
-}
-
-export { plugin, runDemo };
+export { plugin };
 export default plugin;


### PR DESCRIPTION


<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** part of ENG-2073

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Remove the embedded runDemo entry point, ClineCore import, and runDemo export so the weather metrics example behaves as a plugin-only module.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

Tool from weather and metrics plugin now shows up under Tools

<img width="986" height="496" alt="image" src="https://github.com/user-attachments/assets/59016f63-8c90-4fe6-9a4a-6ce4ee908208" />


### Additional Notes

<!-- Add any additional notes for reviewers -->
