### PR TITLE
Fix disabled skill availability in SDK CLI ENG-2058

### DIFF
--- a/sdk/apps/cli/src/runtime/interactive/config-data.test.ts
+++ b/sdk/apps/cli/src/runtime/interactive/config-data.test.ts
@@ -4,6 +4,10 @@ import { join } from "node:path";
 import type { UserInstructionConfigService } from "@cline/core";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+	buildSlashCommandRegistry,
+	expandUserCommandPrompt,
+} from "../../tui/commands/slash-command-registry";
+import {
 	applyPluginFailures,
 	type InteractiveConfigItem,
 } from "../../tui/interactive-config";
@@ -91,6 +95,19 @@ Use this skill.`,
 				calls.push(`refreshType:${type}`);
 				refreshed = true;
 			},
+			listRuntimeCommands() {
+				calls.push("listRuntimeCommands");
+				return refreshed
+					? []
+					: [
+							{
+								name: "skill-one",
+								instructions: "Use this skill.",
+								description: "Skill one",
+								kind: "skill",
+							},
+						];
+			},
 			listRecords(type: string) {
 				calls.push(`listRecords:${type}`);
 				if (type !== "skill") {
@@ -130,10 +147,95 @@ Use this skill.`,
 
 		expect(written).toContain("disabled: true");
 		expect(data?.skills[0]?.enabled).toBe(false);
+		expect(
+			data?.workflowSlashCommands.map((command) => command.name),
+		).not.toContain("skill-one");
 		expect(calls).toContain("refreshType:skill");
 		expect(calls.lastIndexOf("listRecords:skill")).toBeGreaterThan(
 			calls.indexOf("refreshType:skill"),
 		);
+	});
+
+	it("returns refreshed slash commands so disabled skills stop expanding before submit", async () => {
+		const tempRoot = await mkdtemp(join(tmpdir(), "cli-config-data-"));
+		tempRoots.push(tempRoot);
+		const skillPath = join(tempRoot, "SKILL.md");
+		await writeFile(
+			skillPath,
+			`---
+name: find-skills
+---
+Find installable skills.`,
+		);
+
+		let refreshed = false;
+		const userInstructionService = {
+			async refreshType() {
+				refreshed = true;
+			},
+			listRuntimeCommands() {
+				return refreshed
+					? []
+					: [
+							{
+								name: "find-skills",
+								instructions: "Find installable skills.",
+								description: "Find skills",
+								kind: "skill",
+							},
+						];
+			},
+			listRecords(type: string) {
+				if (type !== "skill") {
+					return [];
+				}
+				return [
+					{
+						id: "find-skills",
+						type: "skill",
+						filePath: skillPath,
+						item: {
+							name: "find-skills",
+							disabled: refreshed,
+							description: "Find skills",
+							instructions: "Find installable skills.",
+							frontmatter: {},
+						},
+					},
+				];
+			},
+		} as unknown as UserInstructionConfigService;
+		const loader = createInteractiveConfigDataLoader({
+			config: createConfig(tempRoot),
+			userInstructionService,
+		});
+		const initialData = await loader.loadConfigData();
+		const initialRegistry = buildSlashCommandRegistry({
+			workflowSlashCommands: initialData.workflowSlashCommands,
+		});
+
+		expect(
+			expandUserCommandPrompt("/find-skills what can u do?", initialRegistry),
+		).toContain("<user_command");
+
+		const nextData = await loader.onToggleConfigItem({
+			id: "find-skills",
+			name: "find-skills",
+			path: skillPath,
+			enabled: true,
+			source: "workspace",
+			kind: "skill",
+		});
+		const refreshedRegistry = buildSlashCommandRegistry({
+			workflowSlashCommands: nextData?.workflowSlashCommands,
+		});
+
+		expect(
+			nextData?.workflowSlashCommands.map((command) => command.name),
+		).not.toContain("find-skills");
+		expect(
+			expandUserCommandPrompt("/find-skills what can u do?", refreshedRegistry),
+		).toBe("/find-skills what can u do?");
 	});
 
 	it("keeps plugin tool toggle behavior", async () => {

--- a/sdk/apps/cli/src/tui/commands/slash-command-registry.test.ts
+++ b/sdk/apps/cli/src/tui/commands/slash-command-registry.test.ts
@@ -166,6 +166,32 @@ describe("slash command registry", () => {
 		expect(expandUserCommandPrompt("/settings", registry)).toBe("/settings");
 	});
 
+	it("does not expand commands omitted from a refreshed user-command registry", () => {
+		const staleRegistry = buildSlashCommandRegistry({
+			workflowSlashCommands: [
+				{
+					name: "find-skills",
+					instructions: "Find installable skills.",
+					description: "Find skills",
+					kind: "skill",
+				},
+			],
+		});
+		const refreshedRegistry = buildSlashCommandRegistry({
+			workflowSlashCommands: [],
+		});
+
+		expect(
+			expandUserCommandPrompt("/find-skills what can u do?", staleRegistry),
+		).toContain("<user_command");
+		expect(
+			resolveSlashCommand(refreshedRegistry, "find-skills"),
+		).toBeUndefined();
+		expect(
+			expandUserCommandPrompt("/find-skills what can u do?", refreshedRegistry),
+		).toBe("/find-skills what can u do?");
+	});
+
 	it("hides fork from autocomplete until a session has messages", () => {
 		const emptySessionRegistry = buildSlashCommandRegistry({ canFork: false });
 		const activeSessionRegistry = buildSlashCommandRegistry({ canFork: true });

--- a/sdk/apps/cli/src/tui/hooks/use-config-panel.tsx
+++ b/sdk/apps/cli/src/tui/hooks/use-config-panel.tsx
@@ -43,6 +43,7 @@ export function useConfigPanel(opts: {
 			plugins: [] as InteractiveConfigItem[],
 			mcp: [] as InteractiveConfigItem[],
 			tools: [] as InteractiveConfigItem[],
+			workflowSlashCommands: [],
 		}),
 		[],
 	);

--- a/sdk/apps/cli/src/tui/interactive-config.ts
+++ b/sdk/apps/cli/src/tui/interactive-config.ts
@@ -18,6 +18,10 @@ import {
 	type WorkflowConfig,
 } from "@cline/core";
 import { getToolCatalog } from "../runtime/tools";
+import {
+	type InteractiveSlashCommand,
+	listInteractiveSlashCommands,
+} from "./interactive-welcome";
 
 export type InteractiveConfigTab =
 	| "general"
@@ -70,6 +74,7 @@ export interface InteractiveConfigData {
 	plugins: InteractiveConfigItem[];
 	mcp: InteractiveConfigItem[];
 	tools: InteractiveConfigItem[];
+	workflowSlashCommands: InteractiveSlashCommand[];
 }
 
 export interface LoadInteractiveConfigDataOptions {
@@ -264,6 +269,9 @@ export async function loadInteractiveConfigData(input: {
 	const plugins: InteractiveConfigItem[] = [];
 	const mcp: InteractiveConfigItem[] = [];
 	const tools: InteractiveConfigItem[] = [];
+	const workflowSlashCommands = listInteractiveSlashCommands(
+		input.userInstructionService,
+	);
 
 	if (input.userInstructionService) {
 		for (const record of input.userInstructionService.listRecords<WorkflowConfig>(
@@ -425,5 +433,6 @@ export async function loadInteractiveConfigData(input: {
 		plugins: toSorted(plugins.filter((item) => existsSync(item.path))),
 		mcp: toSorted(mcp.filter((item) => existsSync(item.path))),
 		tools: toSorted(tools),
+		workflowSlashCommands,
 	};
 }

--- a/sdk/apps/cli/src/tui/root.tsx
+++ b/sdk/apps/cli/src/tui/root.tsx
@@ -87,6 +87,9 @@ function App(props: TuiProps) {
 			: "home";
 	});
 	const [toast, setToast] = useState<ToastState | null>(null);
+	const [workflowSlashCommands, setWorkflowSlashCommands] = useState(
+		props.workflowSlashCommands,
+	);
 	const toastTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const checkpointRestoreInFlightRef = useRef(false);
 
@@ -102,13 +105,17 @@ function App(props: TuiProps) {
 		[appView, props.initialPrompt, session.entries],
 	);
 
+	useEffect(() => {
+		setWorkflowSlashCommands(props.workflowSlashCommands);
+	}, [props.workflowSlashCommands]);
+
 	const {
 		registry: slashCommandRegistry,
 		systemCommands,
 		skillCommands,
 		invokableSkillCommands,
 	} = useSlashCommands({
-		workflowSlashCommands: props.workflowSlashCommands,
+		workflowSlashCommands,
 		loadAdditionalSlashCommands: props.loadAdditionalSlashCommands,
 		canFork: canForkSession,
 	});
@@ -187,6 +194,18 @@ function App(props: TuiProps) {
 		onSessionRestart: props.onSessionRestart,
 		refocusTextarea: () => refocusTextareaRef.current(),
 	});
+	const onToggleConfigItem = useMemo<TuiProps["onToggleConfigItem"]>(() => {
+		if (!props.onToggleConfigItem) {
+			return undefined;
+		}
+		return async (item, options) => {
+			const data = await props.onToggleConfigItem?.(item, options);
+			if (data) {
+				setWorkflowSlashCommands(data.workflowSlashCommands);
+			}
+			return data;
+		};
+	}, [props.onToggleConfigItem]);
 
 	const openConfig = useConfigPanel({
 		dialog,
@@ -198,7 +217,7 @@ function App(props: TuiProps) {
 		setCompactionMode: session.setCompactionMode,
 		termHeight,
 		loadConfigData: props.loadConfigData,
-		onToggleConfigItem: props.onToggleConfigItem,
+		onToggleConfigItem,
 		openModelSelector,
 		openMcpManager,
 		refocusTextarea: () => refocusTextareaRef.current(),

--- a/sdk/packages/core/src/extensions/config/user-instruction-service.ts
+++ b/sdk/packages/core/src/extensions/config/user-instruction-service.ts
@@ -102,8 +102,8 @@ class DefaultUserInstructionConfigService
 	}
 
 	hasConfiguredSkills(allowedSkillNames?: ReadonlyArray<string>): boolean {
-		return (
-			getConfiguredSkillsFromWatcher(this.watcher, allowedSkillNames).length > 0
+		return getConfiguredSkillsFromWatcher(this.watcher, allowedSkillNames).some(
+			(skill) => !skill.disabled,
 		);
 	}
 

--- a/sdk/packages/core/src/runtime/orchestration/runtime-builder.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-builder.test.ts
@@ -8,6 +8,7 @@ import {
 	type Message,
 } from "@cline/shared";
 import { afterEach, describe, expect, it } from "vitest";
+import { createUserInstructionConfigService } from "../../extensions/config";
 import { TelemetryService } from "../../services/telemetry/TelemetryService";
 import type { CoreSessionConfig } from "../../types/config";
 import { DefaultRuntimeBuilder } from "./runtime-builder";
@@ -690,6 +691,36 @@ Review skill.`,
 		);
 		expect(blocked).toContain('Skill "review" not found.');
 		expect(blocked).toContain("Available skills: commit");
+
+		await runtime.shutdown("test");
+	});
+
+	it("does not register the skills tool when all configured skills are disabled", async () => {
+		const cwd = mkdtempSync(join(tmpdir(), "runtime-disabled-skills-"));
+		const skillDir = join(cwd, ".cline", "skills", "review");
+		mkdirSync(skillDir, { recursive: true });
+		writeFileSync(
+			join(skillDir, "SKILL.md"),
+			`---
+name: review
+disabled: true
+---
+Review skill.`,
+			"utf8",
+		);
+		const userInstructionService = createUserInstructionConfigService({
+			skills: { directories: [join(cwd, ".cline", "skills")] },
+			rules: { directories: [] },
+			workflows: { directories: [] },
+		});
+
+		const runtime = await new DefaultRuntimeBuilder().build({
+			config: makeBaseConfig({ cwd }),
+			userInstructionService,
+		});
+
+		const extensionTools = await collectExtensionTools(runtime.extensions);
+		expect(extensionTools.map((tool) => tool.name)).not.toContain("skills");
 
 		await runtime.shutdown("test");
 	});

--- a/sdk/packages/core/src/runtime/orchestration/runtime-builder.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-builder.ts
@@ -342,8 +342,7 @@ export class DefaultRuntimeBuilder implements RuntimeBuilder {
 			normalized.enableTools &&
 			skillsEnabled &&
 			Boolean(userInstructionService) &&
-			(userInstructionServiceProvided ||
-				userInstructionService?.hasConfiguredSkills(config.skills) === true) &&
+			userInstructionService?.hasConfiguredSkills(config.skills) === true &&
 			isSkillsToolEnabledForSession({
 				cwd: config.cwd,
 				providerId: config.providerId,


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

**Issue:** ENG-2058

### Description

Fixes disabled SDK skills still being invokable from the interactive CLI after toggling them off in Settings.

The TUI previously built its slash-command registry from a one-time startup snapshot. Disabling a skill refreshed the core watcher, but the pre-submit TUI expansion path could still expand `/skill-name ...` into a stale `<user_command>` block with cached skill instructions. This now carries refreshed slash commands through interactive config data and updates the TUI registry after settings toggles, so disabled skills stop expanding immediately.

This also keeps the runtime-side availability cleanup: only enabled configured skills count when deciding whether to register the model-facing `skills` tool, including when a user-instruction service is provided by the host.

### Test Procedure

- `cd /Users/robin/dev/cline/sdk && bun -F @cline/cli test:unit -- src/tui/components/dialogs/command-palette.test.ts src/runtime/interactive/config-data.test.ts src/tui/commands/slash-command-registry.test.ts`
- `cd /Users/robin/dev/cline/sdk && bun -F @cline/cli typecheck`
- `cd /Users/robin/dev/cline/sdk && bun -F @cline/core typecheck`
- `cd /Users/robin/dev/cline/sdk && bun -F @cline/cli test:unit`
- `cd /Users/robin/dev/cline/sdk && bun -F @cline/core test:unit -- src/extensions/config/runtime-commands.test.ts src/settings/settings-service.test.ts src/runtime/orchestration/runtime-builder.test.ts`
- `cd /Users/robin/dev/cline/sdk && bun biome check apps/cli/src/runtime/interactive/config-data.test.ts apps/cli/src/tui/commands/slash-command-registry.test.ts apps/cli/src/tui/hooks/use-config-panel.tsx apps/cli/src/tui/interactive-config.ts apps/cli/src/tui/root.tsx packages/core/src/extensions/config/user-instruction-service.ts packages/core/src/runtime/orchestration/runtime-builder.ts packages/core/src/runtime/orchestration/runtime-builder.test.ts`
- Pre-commit hook also ran `bun run types` and Biome checks successfully.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

# on
<img width="217" height="260" alt="Screenshot 2026-05-18 at 5 33 22 PM" src="https://github.com/user-attachments/assets/e4e203d3-5fe2-40f4-8214-aab62eb4494f" />

# off
<img width="218" height="178" alt="Screenshot 2026-05-18 at 5 34 07 PM" src="https://github.com/user-attachments/assets/06698cbc-ee4d-4523-9b52-0e057012a97d" />
<img width="287" height="269" alt="Screenshot 2026-05-18 at 5 34 20 PM" src="https://github.com/user-attachments/assets/e1e178f7-9877-4f1e-a561-083b759fc432" />



### Additional Notes

Scoped to SDK CLI/core skill availability paths.
