### PR TITLE
fix(cli): use Telegram numeric participant IDs

### DIFF
--- a/sdk/apps/cli/src/connectors/adapters/telegram.test.ts
+++ b/sdk/apps/cli/src/connectors/adapters/telegram.test.ts
@@ -38,6 +38,53 @@ describe("telegramConnector", () => {
 	});
 });
 
+describe("telegram participant resolution", () => {
+	it("uses the stable numeric Telegram user id when username is also present", () => {
+		const result = __test__.resolveTelegramParticipant({
+			message: {
+				from: {
+					id: 1201547643,
+					username: "AraFatKatze",
+					first_name: "Ara",
+				},
+			},
+		});
+
+		expect(result).toEqual({
+			key: "telegram:id:1201547643",
+			label: "arafatkatze",
+		});
+	});
+
+	it("falls back to username when Telegram does not provide a numeric user id", () => {
+		const result = __test__.resolveTelegramParticipant({
+			message: {
+				from: {
+					username: "Alice",
+				},
+			},
+		});
+
+		expect(result).toEqual({
+			key: "telegram:user:alice",
+			label: "alice",
+		});
+	});
+
+	it("accepts string numeric user ids from raw Telegram payloads", () => {
+		const result = __test__.resolveTelegramParticipant({
+			message: {
+				from: {
+					id: "1201547643",
+					username: "arafatkatze",
+				},
+			},
+		});
+
+		expect(result?.key).toBe("telegram:id:1201547643");
+	});
+});
+
 describe("telegram binding lookup", () => {
 	it("falls back to channel identity when a restarted connector gets a new thread id", () => {
 		const result = __test__.findBindingForThread(

--- a/sdk/apps/cli/src/connectors/adapters/telegram.ts
+++ b/sdk/apps/cli/src/connectors/adapters/telegram.ts
@@ -135,11 +135,11 @@ function resolveTelegramParticipant(
 	const lastName = readString(from?.last_name);
 	const label =
 		username || [firstName, lastName].filter(Boolean).join(" ") || userId;
-	if (username) {
-		return { key: `telegram:user:${username}`, label };
-	}
 	if (userId) {
 		return { key: `telegram:id:${userId}`, label };
+	}
+	if (username) {
+		return { key: `telegram:user:${username}`, label };
 	}
 	return undefined;
 }
@@ -957,6 +957,7 @@ export const telegramConnector: ConnectCommandDefinition =
 	new TelegramConnector();
 
 export const __test__ = {
+	resolveTelegramParticipant,
 	findBindingForThread: (
 		bindings: ConnectorBindingStore<TelegramThreadState>,
 		thread: Pick<Thread<TelegramThreadState>, "id" | "channelId" | "isDM"> & {


### PR DESCRIPTION
### Related Issue

**Issue:** [ENG-2072](https://linear.app/cline-bot/issue/ENG-2072/telegram-restrict-to-my-own-telegram-not-working-exact-same-id-worked)

### Description

Telegram access restriction setup asks users for their numeric Telegram user ID and builds hooks against `telegram:id:<id>`. The adapter, however, preferred `from.username` over `from.id` when both were present, so authorized users with Telegram usernames were emitted as `telegram:user:<username>` and denied by the generated numeric-ID hook.

This updates Telegram participant resolution to use the stable numeric `from.id` whenever Telegram provides it, while keeping the username fallback for payloads without an ID. It also adds regression coverage for numeric ID precedence, username fallback, and string-form IDs.

### Test Procedure

- `bun -F @cline/cli test:unit src/connectors/adapters/telegram.test.ts`
- `bun -F @cline/cli typecheck`
- `bun biome check sdk/apps/cli/src/connectors/adapters/telegram.ts sdk/apps/cli/src/connectors/adapters/telegram.test.ts --diagnostic-level=error`
- Pre-commit hook also ran `bun run types` and Biome for the staged files.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

The CLI wizard and connector docs already instruct users to restrict Telegram by numeric user ID (`telegram:id:<id>`). This change makes the runtime participant key match that documented setup.
