### PR TITLE
fix(cli): avoid option right fork shortcut

### DIFF
--- a/sdk/apps/cli/src/tui/components/dialogs/command-palette-items.ts
+++ b/sdk/apps/cli/src/tui/components/dialogs/command-palette-items.ts
@@ -87,7 +87,7 @@ const ACTION_ITEMS: Array<{
 	{
 		action: "fork",
 		label: "Create Session Fork",
-		shortcut: "Opt+F",
+		shortcut: "Opt+R",
 		description: "Branch the current conversation into a new session",
 		keywords: ["fork", "session", "branch"],
 		requiresFork: true,

--- a/sdk/apps/cli/src/tui/components/dialogs/command-palette.test.ts
+++ b/sdk/apps/cli/src/tui/components/dialogs/command-palette.test.ts
@@ -114,4 +114,27 @@ describe("command palette", () => {
 			})?.label,
 		).toBe("Open Help");
 	});
+
+	it("keeps option right available for word navigation", () => {
+		const items = buildCommandPaletteItems({
+			canForkSession: true,
+		});
+
+		expect(
+			findCommandPaletteShortcut(items, {
+				name: "f",
+				meta: false,
+				option: true,
+				shift: false,
+			}),
+		).toBeUndefined();
+		expect(
+			findCommandPaletteShortcut(items, {
+				name: "r",
+				meta: false,
+				option: true,
+				shift: false,
+			})?.label,
+		).toBe("Create Session Fork");
+	});
 });


### PR DESCRIPTION
### Related Issue

Issue: #XXXX

### Description

This fixes a CLI TUI shortcut collision where the command palette treated `Opt+F` as `Create Session Fork`. In terminals that encode Option+Right as an option/meta `f` key event, trying to move the cursor forward by one word opened the fork confirmation dialog instead of allowing normal input navigation.

Technical approach:

- Moved the `Create Session Fork` command palette shortcut from `Opt+F` to `Opt+R`.
- Kept the `/fork` slash command unchanged.
- Left the command palette shortcut resolver unchanged so existing palette behavior continues to work for other actions.

Debugging journey:

- Traced the reported dialog text to the fork confirmation content in the CLI TUI.
- Followed the fork action back to the command palette item list.
- Found that shortcut matching accepts either `meta` or `option` key events and compares the final shortcut key directly, so an Option+Right event that arrives as `f` matched the old `Opt+F` fork shortcut.

Gotchas discovered:

- Option+Left commonly arrives as `b`, which did not have a command palette binding, so only Option+Right exposed the collision.
- The fix avoids touching textarea word navigation or terminal input handling. It only removes the conflicting accelerator.

### Test Procedure

Ran the focused CLI TUI command palette test on the PR branch:

```sh
bunx vitest run --config vitest.config.ts src/tui/components/dialogs/command-palette.test.ts
```

Result: 1 test file passed, 6 tests passed.

The new regression test verifies that an option `f` key event no longer resolves to `Create Session Fork`, while option `r` still provides a direct fork shortcut.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable. This is terminal keyboard shortcut behavior covered by a unit test.

### Additional Notes

I ran the targeted Vitest file only. Full `npm test`, format, and lint were not run locally for this small CLI shortcut change.
