### PR TITLE
docs: add QuickSilver Pro to OpenAI Compatible provider examples

### DIFF
--- a/docs/provider-config/openai-compatible.mdx
+++ b/docs/provider-config/openai-compatible.mdx
@@ -49,6 +49,19 @@ You'll find these settings in the Cline settings panel (click the ⚙️ icon):
 -   3. Set the Model ID: v0-1.0-md
 -   4. Click Verify to confirm the connection.
 
+### QuickSilver Pro in Cline:
+
+-   [QuickSilver Pro](https://quicksilverpro.io) is an OpenAI-compatible gateway for 12 frontier open-source models: DeepSeek V4 Flash / V4 Pro / V3 / R1, Qwen 3.5 / 3.6, Kimi K2.6, and the Gemini 2.5 / 3 family. Reasoning-by-default models (V4 Flash/Pro, R1, Qwen 3.6, Kimi K2.6) work as Cline's "Thinking" provider out of the box.
+
+-   ### Quickstart
+
+-   1. With the OpenAI Compatible provider selected, set the Base URL to `https://api.quicksilverpro.io/v1`.
+-   2. Paste in your [QuickSilver Pro API key](https://quicksilverpro.io/dashboard/).
+-   3. Set the Model ID to any QSP model — e.g. `deepseek-v4-pro` for refactors, `kimi-k2.6` for long-horizon planning, `deepseek-v4-flash` for cheap chat.
+-   4. Click Verify to confirm the connection.
+
+-   Full model list and pricing: [quicksilverpro.io/docs/integrations](https://quicksilverpro.io/docs/integrations/).
+
 ### Troubleshooting
 
 -   **"Invalid API Key":** Double-check that you've entered the API key correctly and that it's for the correct provider.


### PR DESCRIPTION
## Summary

Adds [QuickSilver Pro](https://quicksilverpro.io) to the OpenAI Compatible provider examples section, immediately after the existing v0 example. QSP hosts 12 frontier open-source models behind a standard OpenAI Chat Completions surface — DeepSeek V4 Flash/Pro, V3, R1, Qwen 3.5/3.6, Kimi K2.6, and the Gemini 2.5/3 family. Reasoning-by-default models work as Cline's "Thinking" provider out of the box.

## Configuration users follow

```
API Provider:  OpenAI Compatible
Base URL:      https://api.quicksilverpro.io/v1
API Key:       <your QSP key>
Model ID:      deepseek-v4-pro    (or any QSP model)
```

## Disclosure

I'm the maintainer of QSP — happy to revise the framing. Setup reference: <https://quicksilverpro.io/docs/integrations/>