### PR TITLE
sdk: add ClineCore CLI agent example

### DIFF
--- a/sdk/apps/examples/README.md
+++ b/sdk/apps/examples/README.md
@@ -33,6 +33,7 @@ Requires Node.js 22+.
 |---------|-------------|----------|
 | [quickstart](./quickstart) | Send one prompt, stream the response. ~15 lines of code. | `Agent`, `subscribe`, `run()` |
 | [cli-agent](./cli-agent) | Interactive terminal chat with a shell tool. | `createTool`, multi-turn `run()`/`continue()`, streaming |
+| [cline-core-cli-agent](./cline-core-cli-agent) | Interactive terminal chat powered by ClineCore. | `ClineCore.create()`, `cline.start()`, `cline.send()`, built-in tools, streaming |
 
 ### Intermediate
 

--- a/sdk/apps/examples/cline-core-cli-agent/README.md
+++ b/sdk/apps/examples/cline-core-cli-agent/README.md
@@ -1,0 +1,57 @@
+# Cline Core CLI Agent
+
+An interactive terminal chat agent powered by the `ClineCore` runtime. This example is similar in spirit to [`cli-agent`](../cli-agent), but uses stateful ClineCore sessions and built-in runtime tools instead of the stateless `Agent` class, to leverage Cline's internal agent harness.
+
+## Getting started
+
+Install dependencies:
+
+```bash
+bun install
+bun run build:sdk
+```
+
+Set an API key:
+
+```bash
+export CLINE_API_KEY="sk_..."
+```
+
+Run:
+
+```bash
+bun dev
+```
+
+Type any message at the `you:` prompt to see a streaming response. Type `exit` to quit.
+
+## Optional model configuration
+
+The example defaults to Cline's gateway provider and Claude Sonnet:
+
+```bash
+export CLINE_PROVIDER_ID="cline"
+export CLINE_MODEL_ID="anthropic/claude-sonnet-4.6"
+```
+
+## What it does
+
+- Creates a local `ClineCore` runtime with `ClineCore.create()`
+- Starts one interactive session with `cline.start()`
+- Sends each user turn with `cline.send({ sessionId, prompt })`
+- Streams `agent_event` text to stdout as the assistant responds
+- Logs tool calls and tool results inline
+- Uses ClineCore's built-in tools instead of defining custom tools
+- Calls `cline.stop()` and `cline.dispose()` during shutdown
+
+## Concepts demonstrated
+
+- Stateful sessions with `ClineCore`
+- Multi-turn conversation using a single `sessionId`
+- `CoreSessionEvent` subscription via `cline.subscribe()`
+- Built-in runtime tools (`read_files`, `search_codebase`, `run_commands`, etc.)
+- Basic tool policies: file reads/search are auto-approved, other tools request approval
+
+## Notes
+
+Use this example when you want the full ClineCore runtime with sessions, persistence, and built-in tools. For the smallest possible SDK example, see [quickstart](../quickstart). For the lightweight stateless runtime, see [cli-agent](../cli-agent).

--- a/sdk/apps/examples/cline-core-cli-agent/package.json
+++ b/sdk/apps/examples/cline-core-cli-agent/package.json
@@ -1,0 +1,21 @@
+{
+	"name": "@cline/example-cline-core-cli-agent",
+	"version": "0.0.0",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "bun run src/index.ts",
+		"build:sdk": "bun run --cwd ../../.. build:sdk",
+		"build": "tsc",
+		"start": "node dist/index.js"
+	},
+	"dependencies": {
+		"@cline/sdk": "workspace:*"
+	},
+	"devDependencies": {
+		"typescript": "^5.9.3"
+	},
+	"engines": {
+		"node": ">=22"
+	}
+}

--- a/sdk/apps/examples/cline-core-cli-agent/src/index.ts
+++ b/sdk/apps/examples/cline-core-cli-agent/src/index.ts
@@ -1,0 +1,185 @@
+import * as readline from "node:readline";
+import {
+	type AgentEvent,
+	ClineCore,
+	type ToolApprovalRequest,
+} from "@cline/sdk";
+
+// ClineCore does not choose a model automatically; each session config must provide one.
+// These example defaults use the Cline gateway with Claude Sonnet, and can be overridden with env vars.
+const providerId = process.env.CLINE_PROVIDER_ID ?? "cline";
+const modelId = process.env.CLINE_MODEL_ID ?? "anthropic/claude-sonnet-4.6";
+const apiKey = process.env.CLINE_API_KEY;
+const cwd = process.cwd();
+
+const systemPrompt = `You are a helpful assistant in an interactive terminal chat.
+Be concise. You can use built-in tools to inspect files, search the workspace, and run shell commands when helpful.`;
+
+let cline: ClineCore | undefined;
+let unsubscribe: (() => void) | undefined;
+let activeSessionId: string | undefined;
+let hasPrintedAssistantPrefix = false;
+
+function printAssistantPrefix(): void {
+	if (!hasPrintedAssistantPrefix) {
+		process.stdout.write("\nagent: ");
+		hasPrintedAssistantPrefix = true;
+	}
+}
+
+function formatToolValue(value: unknown): string {
+	const output =
+		typeof value === "string" ? value : (JSON.stringify(value, null, 2) ?? "");
+	return output.length > 200 ? `${output.slice(0, 200)}...` : output;
+}
+
+function handleAgentEvent(event: AgentEvent): void {
+	switch (event.type) {
+		case "content_start":
+			if (event.contentType === "text" && event.text) {
+				printAssistantPrefix();
+				process.stdout.write(event.text);
+			}
+			if (event.contentType === "tool" && event.toolName) {
+				console.log(
+					`\n[tool] ${event.toolName}(${JSON.stringify(event.input ?? {})})`,
+				);
+			}
+			break;
+		case "content_update":
+			if (event.contentType === "tool" && event.toolName) {
+				console.log(
+					`[update] ${event.toolName}: ${formatToolValue(event.update)}`,
+				);
+			}
+			break;
+		case "content_end":
+			if (event.contentType === "tool" && event.toolName) {
+				if (event.error) {
+					console.log(`[error] ${event.toolName}: ${event.error}`);
+				} else {
+					console.log(`[result] ${formatToolValue(event.output)}`);
+				}
+			}
+			break;
+		case "notice":
+			console.log(`\n[notice] ${event.message}`);
+			break;
+		case "error":
+			console.error(`\n[error] ${event.error.message}`);
+			break;
+	}
+}
+
+async function ensureCline(): Promise<ClineCore> {
+	if (cline) {
+		return cline;
+	}
+
+	cline = await ClineCore.create({
+		clientName: "cline-core-cli-agent",
+		backendMode: "local",
+		capabilities: {
+			requestToolApproval,
+		},
+	});
+	unsubscribe = cline.subscribe((event) => {
+		if (event.type === "agent_event") {
+			handleAgentEvent(event.payload.event);
+		}
+	});
+	return cline;
+}
+
+const rl = readline.createInterface({
+	input: process.stdin,
+	output: process.stdout,
+});
+
+function ask(question: string): Promise<string> {
+	return new Promise((resolve) => {
+		rl.question(question, resolve);
+	});
+}
+
+async function requestToolApproval(request: ToolApprovalRequest) {
+	console.log(`\n[approval] ${request.toolName} wants to run:`);
+	console.log(formatToolValue(request.input));
+	const answer = await ask("Approve? [y/N] ");
+	const approved = answer.trim().toLowerCase() === "y";
+	return {
+		approved,
+		...(approved ? {} : { reason: "User denied tool execution" }),
+	};
+}
+
+function prompt(): Promise<string> {
+	return ask("\nyou: ");
+}
+
+async function startSession(): Promise<string> {
+	const runtime = await ensureCline();
+	const result = await runtime.start({
+		source: "cli",
+		interactive: true,
+		config: {
+			providerId,
+			modelId,
+			apiKey,
+			cwd,
+			workspaceRoot: cwd,
+			mode: "act",
+			systemPrompt,
+			maxIterations: 10,
+			enableTools: true,
+			enableSpawnAgent: false,
+			enableAgentTeams: false,
+			disableMcpSettingsTools: true,
+		},
+		toolPolicies: {
+			"*": { autoApprove: false },
+			read_files: { autoApprove: true },
+			search_codebase: { autoApprove: true },
+		},
+	});
+	return result.sessionId;
+}
+
+async function runTurn(input: string): Promise<void> {
+	activeSessionId ??= await startSession();
+	hasPrintedAssistantPrefix = false;
+	const runtime = await ensureCline();
+	await runtime.send({
+		sessionId: activeSessionId,
+		prompt: input,
+	});
+	console.log();
+}
+
+console.log("ClineCore CLI Agent (type 'exit' to quit)\n");
+console.log(`Provider: ${providerId}`);
+console.log(`Model:    ${modelId}`);
+console.log(`CWD:      ${cwd}`);
+
+try {
+	while (true) {
+		const input = await prompt();
+		const trimmed = input.trim();
+		if (trimmed.toLowerCase() === "exit") {
+			break;
+		}
+		if (!trimmed) {
+			continue;
+		}
+
+		await runTurn(trimmed);
+	}
+} finally {
+	rl.close();
+	unsubscribe?.();
+	if (activeSessionId && cline) {
+		await cline.stop(activeSessionId).catch(() => undefined);
+	}
+	await cline?.dispose();
+	console.log("Goodbye!");
+}

--- a/sdk/apps/examples/cline-core-cli-agent/tsconfig.json
+++ b/sdk/apps/examples/cline-core-cli-agent/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"extends": "../../tsconfig.apps.json",
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"outDir": "dist",
+		"strict": true,
+		"skipLibCheck": true,
+		"esModuleInterop": true
+	},
+	"include": ["src"]
+}

--- a/sdk/bun.lock
+++ b/sdk/bun.lock
@@ -66,6 +66,16 @@
         "typescript": "^5.9.3",
       },
     },
+    "apps/examples/cline-core-cli-agent": {
+      "name": "@cline/example-cline-core-cli-agent",
+      "version": "0.0.0",
+      "dependencies": {
+        "@cline/sdk": "workspace:*",
+      },
+      "devDependencies": {
+        "typescript": "^5.9.3",
+      },
+    },
     "apps/examples/code-review-bot": {
       "name": "@cline/example-code-review-bot",
       "version": "0.0.0",
@@ -181,6 +191,17 @@
       "version": "0.0.0",
       "dependencies": {
         "@cline/sdk": "workspace:*",
+      },
+      "devDependencies": {
+        "typescript": "^5.9.3",
+      },
+    },
+    "apps/examples/security-review-bot": {
+      "name": "@cline/example-security-review-bot",
+      "version": "0.0.0",
+      "dependencies": {
+        "@cline/sdk": "workspace:*",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
         "typescript": "^5.9.3",
@@ -605,11 +626,15 @@
 
     "@cline/example-cli-agent": ["@cline/example-cli-agent@workspace:apps/examples/cli-agent"],
 
+    "@cline/example-cline-core-cli-agent": ["@cline/example-cline-core-cli-agent@workspace:apps/examples/cline-core-cli-agent"],
+
     "@cline/example-code-review-bot": ["@cline/example-code-review-bot@workspace:apps/examples/code-review-bot"],
 
     "@cline/example-multi-agent": ["@cline/example-multi-agent@workspace:apps/examples/multi-agent"],
 
     "@cline/example-quickstart": ["@cline/example-quickstart@workspace:apps/examples/quickstart"],
+
+    "@cline/example-security-review-bot": ["@cline/example-security-review-bot@workspace:apps/examples/security-review-bot"],
 
     "@cline/llms": ["@cline/llms@workspace:packages/llms"],
 


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Adds a new SDK example CLI agent that uses `ClineCore`, as a separate comparison point to the existing CLI agent example built using `Agent`.

This PR includes:

- A new `sdk/apps/examples/cline-core-cli-agent` package
- A README explaining setup and usage
- The TypeScript CLI entrypoint for running the ClineCore-based agent
- Registration in the SDK examples README
- The associated `sdk/bun.lock` workspace update

### Test Procedure

- Verified the branch contains only the isolated ClineCore CLI agent example changes relative to `main`.
- The commit hook ran `bun run types` and `bun biome check --no-errors-on-unmatched --files-ignore-unknown=true` successfully for the staged lockfile update.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — CLI SDK example only.

### Additional Notes

Split out from `renee/more-updates` so it can be reviewed separately from the existing PR.
