### PR TITLE
Update diff to 8.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -115,7 +115,6 @@
 				"@types/better-sqlite3": "^7.6.13",
 				"@types/chai": "^5.0.1",
 				"@types/clone-deep": "^4.0.4",
-				"@types/diff": "^5.2.1",
 				"@types/get-folder-size": "^3.0.4",
 				"@types/js-yaml": "^4.0.9",
 				"@types/mocha": "^10.0.7",
@@ -7203,13 +7202,6 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
 			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@types/diff": {
-			"version": "5.2.3",
-			"resolved": "https://registry.npmjs.org/@types/diff/-/diff-5.2.3.tgz",
-			"integrity": "sha512-K0Oqlrq3kQMaO2RhfrNQX5trmt+XLyom88zS0u84nnIcLvFnRUMRRHmrGny5GSM+kNO9IZLARsdQHDzkhAgmrQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -19856,16 +19848,6 @@
 				"@swc/wasm": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/ts-node/node_modules/diff": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
-			"integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=0.3.1"
 			}
 		},
 		"node_modules/ts-poet": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
 				"chrome-launcher": "^1.1.2",
 				"clone-deep": "^4.0.1",
 				"default-shell": "^2.2.0",
-				"diff": "^5.2.0",
+				"diff": "8.0.4",
 				"exceljs": "^4.4.0",
 				"execa": "^9.5.2",
 				"fast-deep-equal": "^3.1.3",
@@ -10155,9 +10155,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/diff": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
-			"integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+			"integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.3.1"
@@ -15376,16 +15376,6 @@
 				"balanced-match": "^1.0.0"
 			}
 		},
-		"node_modules/mocha/node_modules/diff": {
-			"version": "8.0.4",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-			"integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=0.3.1"
-			}
-		},
 		"node_modules/mocha/node_modules/find-up": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -18767,16 +18757,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/sinon"
-			}
-		},
-		"node_modules/sinon/node_modules/diff": {
-			"version": "8.0.4",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-			"integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=0.3.1"
 			}
 		},
 		"node_modules/sinon/node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -539,7 +539,7 @@
 		"chrome-launcher": "^1.1.2",
 		"clone-deep": "^4.0.1",
 		"default-shell": "^2.2.0",
-		"diff": "^5.2.0",
+		"diff": "8.0.4",
 		"exceljs": "^4.4.0",
 		"execa": "^9.5.2",
 		"fast-deep-equal": "^3.1.3",
@@ -593,9 +593,7 @@
 		"js-yaml": "^4.1.1",
 		"serialize-javascript": ">=7.0.3",
 		"protobufjs": "7.5.5",
-		"mocha": {
-			"diff": ">=8.0.3"
-		}
+		"diff": "8.0.4"
 	},
 	"c8": {
 		"reporter": [

--- a/package.json
+++ b/package.json
@@ -449,7 +449,6 @@
 		"@types/better-sqlite3": "^7.6.13",
 		"@types/chai": "^5.0.1",
 		"@types/clone-deep": "^4.0.4",
-		"@types/diff": "^5.2.1",
 		"@types/get-folder-size": "^3.0.4",
 		"@types/js-yaml": "^4.0.9",
 		"@types/mocha": "^10.0.7",


### PR DESCRIPTION
### Description

We have been mostly using diff 8.0.4 in dev environments for a while, but not in the main extension. If we want to move to bun, we can't have nested overrides, which means we either:
- Go back to a vulnerable version of the dependency
- Move the override to everything.

### Test Procedure

Verified with Cline that there aren't any breaking changes to our usage.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)