### PR TITLE
fix(cli): accept dash-prefixed prompts after separator

### DIFF
--- a/sdk/apps/cli/src/commands/program.ts
+++ b/sdk/apps/cli/src/commands/program.ts
@@ -232,7 +232,7 @@ export function commanderToParsedArgs(program: Command): ParsedArgs {
 	if (opts.id !== undefined) result.id = opts.id;
 
 	// Positional args → prompt
-	const positional = program.args.filter((a) => !a.startsWith("-"));
+	const positional = program.args;
 	if (positional.length > 0) {
 		result.prompt = positional.join(" ");
 	}

--- a/sdk/apps/cli/src/main.test.ts
+++ b/sdk/apps/cli/src/main.test.ts
@@ -657,6 +657,27 @@ describe("runCli lightweight command dispatch", () => {
 		expect(runtimeMocks.runInteractive).not.toHaveBeenCalled();
 	});
 
+	it("treats dash-prefixed positional text after -- as a prompt", async () => {
+		forcePromptModeInput();
+		process.argv = [
+			"bun",
+			"src/index.ts",
+			"--",
+			"- You are given a PyTorch state dictionary.",
+		];
+
+		const { runCli } = await import("./main");
+
+		await expect(runCli()).resolves.toBeUndefined();
+		expect(runtimeMocks.runAgent).toHaveBeenCalledTimes(1);
+		expect(runtimeMocks.runAgent).toHaveBeenCalledWith(
+			"- You are given a PyTorch state dictionary.",
+			expect.any(Object),
+			expect.anything(),
+		);
+		expect(runtimeMocks.runInteractive).not.toHaveBeenCalled();
+	});
+
 	it("applies --auto-approve as a runtime policy without changing the config default", async () => {
 		process.argv = ["bun", "src/index.ts", "--auto-approve", "false"];
 


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

Fixes CLI prompt parsing when the positional prompt is passed after `--` and starts with a dash.

Previously, Cline accepted Commander positional args and then filtered out every positional token beginning with `-`. That made valid benchmark prompts such as `cline -- '- You are given ...'` look like missing prompts, causing the CLI to fall into interactive mode and fail in non-TTY runners.

This preserves Commander positional args as the prompt and adds a regression test for dash-prefixed prompt text after `--`.

### Test Procedure

- Confirmed the new regression test failed before the parser fix because `runAgent` was not called.
- Ran `bun -F @cline/cli test:unit -- src/main.test.ts -t "treats dash-prefixed positional text after -- as a prompt"`.
- Ran `bun -F @cline/cli test:unit -- src/main.test.ts`.
- Ran `bun biome check --write apps/cli/src/commands/program.ts apps/cli/src/main.test.ts`.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - CLI parsing fix.

### Additional Notes

This is based on `origin/main`.
