### PR TITLE
feat(sdk): add Poolside provider

### DIFF
--- a/sdk/packages/core/src/services/llms/provider-defaults.test.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.test.ts
@@ -147,6 +147,73 @@ describe("resolveProviderConfig", () => {
 		expect(Object.keys(resolved?.knownModels ?? {})).toEqual(["local-llama"]);
 	});
 
+	it("loads Poolside deployment models through the OpenAI-compatible models endpoint", async () => {
+		const fetchMock = vi.fn(async () => {
+			return new Response(
+				JSON.stringify({
+					data: [
+						{
+							id: "laguna-enterprise",
+							context_length: 131_072,
+							max_completion_tokens: 8192,
+							supported_features: ["reasoning", "images"],
+						},
+					],
+				}),
+				{
+					status: 200,
+					headers: { "content-type": "application/json" },
+				},
+			);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const resolved = await resolveProviderConfig(
+			"poolside",
+			{ failOnError: true, cacheTtlMs: 60_000 },
+			{
+				providerId: "poolside",
+				modelId: "laguna-enterprise",
+				apiKey: "poolside-key",
+				baseUrl: "https://deployment.example.com/v1/",
+			},
+		);
+
+		await resolveProviderConfig(
+			"poolside",
+			{ failOnError: true, cacheTtlMs: 60_000 },
+			{
+				providerId: "poolside",
+				modelId: "laguna-enterprise",
+				apiKey: "poolside-key",
+				baseUrl: "https://deployment.example.com/v1",
+			},
+		);
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			"https://deployment.example.com/v1/models",
+			expect.objectContaining({
+				method: "GET",
+				headers: expect.objectContaining({
+					Authorization: "Bearer poolside-key",
+				}),
+			}),
+		);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(resolved?.knownModels?.["laguna-enterprise"]).toMatchObject({
+			id: "laguna-enterprise",
+			contextWindow: 131_072,
+			maxInputTokens: 131_072,
+			maxTokens: 8192,
+			capabilities: expect.arrayContaining([
+				"streaming",
+				"tools",
+				"reasoning",
+				"images",
+			]),
+		});
+	});
+
 	it("derives ChatGPT subscription models from the generated OpenAI catalog", async () => {
 		const resolved = await resolveProviderConfig("openai-codex");
 		const openAiResolved = await resolveProviderConfig("openai-native");

--- a/sdk/packages/core/src/services/llms/provider-defaults.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.ts
@@ -35,11 +35,13 @@ function cloneKnownModels(
 function isOpenAICompatibleManifest(
 	manifest: BuiltInProviderManifest,
 ): boolean {
+	if (manifest.client === "openai-compatible") {
+		return true;
+	}
 	if (manifest.baseUrl.length === 0) {
 		return false;
 	}
 	switch (manifest.client) {
-		case "openai-compatible":
 		case "openai":
 		case "openai-r1":
 		case "fetch":
@@ -204,7 +206,7 @@ function resolveCatalogModels(
 }
 
 function normalizeBaseUrl(baseUrl: string | undefined): string {
-	const value = baseUrl?.trim();
+	const value = baseUrl?.trim().replace(/\/+$/, "");
 	return value && value.length > 0 ? value : "";
 }
 
@@ -358,6 +360,16 @@ interface HicapModelResponse {
 	id?: string;
 }
 
+interface PoolsideModelResponse {
+	id?: string;
+	name?: string;
+	context_length?: number;
+	contextWindow?: number;
+	max_completion_tokens?: number;
+	max_output_tokens?: number;
+	supported_features?: string[];
+}
+
 async function fetchHicapPrivateModels(
 	_config: ProviderConfig,
 	token: string,
@@ -388,6 +400,51 @@ async function fetchHicapPrivateModels(
 			maxInputTokens: 128_000,
 			supportsImages: true,
 			supportsPromptCache: true,
+		});
+	}
+	return models;
+}
+
+async function fetchPoolsidePrivateModels(
+	config: ProviderConfig,
+	token: string,
+): Promise<Record<string, ModelInfo>> {
+	const baseUrl = normalizeBaseUrl(config.baseUrl);
+	if (!baseUrl) {
+		return {};
+	}
+
+	const response = await fetchWithTimeout(`${baseUrl}/models`, {
+		method: "GET",
+		headers: {
+			accept: "application/json",
+			Authorization: `Bearer ${token}`,
+		},
+	});
+	if (!response.ok) {
+		throw new Error(`Poolside model refresh failed: HTTP ${response.status}`);
+	}
+
+	const payload = (await response.json()) as {
+		data?: PoolsideModelResponse[];
+	};
+	const entries = payload?.data ?? [];
+	const models: Record<string, ModelInfo> = {};
+	for (const model of entries) {
+		const id = model.id?.trim();
+		if (!id) {
+			continue;
+		}
+		const features = model.supported_features ?? [];
+		models[id] = buildModelFromPrivateSource(id, {
+			name: model.name?.trim() || id,
+			contextWindow: model.context_length ?? model.contextWindow,
+			maxInputTokens: model.context_length ?? model.contextWindow,
+			maxTokens: model.max_completion_tokens ?? model.max_output_tokens,
+			supportsReasoning:
+				features.includes("reasoning") || features.includes("reasoning_effort"),
+			supportsImages:
+				features.includes("vision") || features.includes("images"),
 		});
 	}
 	return models;
@@ -487,6 +544,7 @@ const PRIVATE_PROVIDER_MODEL_FETCHERS: Record<
 	baseten: fetchBasetenPrivateModels,
 	hicap: fetchHicapPrivateModels,
 	litellm: fetchLiteLlmPrivateModels,
+	poolside: fetchPoolsidePrivateModels,
 };
 
 const PUBLIC_MODELS_CACHE = new Map<

--- a/sdk/packages/core/src/services/providers/local-provider-service.test.ts
+++ b/sdk/packages/core/src/services/providers/local-provider-service.test.ts
@@ -1360,6 +1360,16 @@ describe("getProviderConfigFields", () => {
 		);
 	});
 
+	it("returns api-key auth with editable baseUrl for Poolside deployments", () => {
+		const result = getProviderConfigFields("poolside");
+		expect(result.providerId).toBe("poolside");
+		expect(result.authMethod).toBe("api-key");
+		expect(result.fields.apiKey).toEqual({});
+		expect(result.fields.baseUrl).toMatchObject({
+			placeholder: "https://<api-domain>/v1",
+		});
+	});
+
 	it("returns api-key auth with awsRegion, apiKey, and awsProfile for bedrock", () => {
 		const result = getProviderConfigFields("bedrock");
 		expect(result.providerId).toBe("bedrock");

--- a/sdk/packages/core/src/services/providers/local-provider-service.ts
+++ b/sdk/packages/core/src/services/providers/local-provider-service.ts
@@ -832,14 +832,17 @@ const EDITABLE_BASE_URL_PROVIDER_IDS = new Set([
 	"lmstudio",
 	"litellm",
 	"openai-compatible",
+	"poolside",
 ]);
 
 function shouldExposeBaseUrlField(
 	providerId: string,
 	collection: LlmsModels.ModelCollection | undefined,
 ): boolean {
-	if (!collection?.provider.baseUrl) return false;
-	if (collection.provider.source !== "system") return true;
+	if (!collection) return false;
+	if (collection.provider.source !== "system") {
+		return Boolean(collection.provider.baseUrl);
+	}
 	return EDITABLE_BASE_URL_PROVIDER_IDS.has(providerId);
 }
 
@@ -905,7 +908,10 @@ export function getProviderConfigFields(
 	const defaultBaseUrl = collection?.provider.baseUrl;
 	const fields: ProviderConfigFields["fields"] = { apiKey: {} };
 	if (shouldExposeBaseUrlField(id, collection)) {
-		fields.baseUrl = { defaultValue: defaultBaseUrl };
+		fields.baseUrl = {
+			defaultValue: defaultBaseUrl,
+			placeholder: collection?.provider.baseUrlPlaceholder,
+		};
 	}
 
 	return { providerId: id, authMethod: "api-key", fields };

--- a/sdk/packages/llms/src/catalog/types.ts
+++ b/sdk/packages/llms/src/catalog/types.ts
@@ -78,6 +78,7 @@ export const ProviderInfoSchema = z.object({
 	description: z.string().optional(),
 	protocol: ProviderProtocolSchema.optional(),
 	baseUrl: z.string().optional(),
+	baseUrlPlaceholder: z.string().optional(),
 	modelsSourceUrl: z.string().optional(),
 	defaultModelId: z.string(),
 	capabilities: z.array(ProviderCapabilitySchema).optional(),

--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -58,6 +58,7 @@ export interface BuiltinSpec {
 	apiKeyEnv?: readonly string[];
 	modelsSourceUrl?: string;
 	docsUrl?: string;
+	baseUrlPlaceholder?: string;
 	defaults?: GatewayProviderSettings;
 	metadata?: GatewayProviderMetadata;
 }
@@ -454,6 +455,17 @@ const OPENAI_COMPATIBLE_SPECS: BuiltinSpec[] = [
 		defaults: { baseUrl: "https://inference-api.nousresearch.com/v1" },
 	},
 	{
+		id: "poolside",
+		name: "Poolside",
+		description: "Poolside deployment OpenAI-compatible API",
+		family: "openai-compatible",
+		capabilities: ["tools"],
+		defaultModelId: "default",
+		apiKeyEnv: ["POOLSIDE_API_KEY"],
+		docsUrl: "https://docs.poolside.ai/api/openai-api-examples",
+		baseUrlPlaceholder: "https://<api-domain>/v1",
+	},
+	{
 		id: "huawei-cloud-maas",
 		name: "Huawei Cloud MaaS",
 		description: "Huawei's model-as-a-service platform",
@@ -825,6 +837,7 @@ function toModelCollection(spec: BuiltinSpec): ModelCollection {
 			description: spec.description,
 			protocol: spec.protocol ?? inferProtocol(spec),
 			baseUrl: spec.defaults?.baseUrl,
+			baseUrlPlaceholder: spec.baseUrlPlaceholder,
 			modelsSourceUrl: spec.modelsSourceUrl,
 			defaultModelId,
 			capabilities,

--- a/sdk/packages/llms/src/providers/gateway.test.ts
+++ b/sdk/packages/llms/src/providers/gateway.test.ts
@@ -100,6 +100,7 @@ const baseMessages: AgentMessage[] = [
 	},
 ];
 const originalOpenRouterApiKey = process.env.OPENROUTER_API_KEY;
+const originalPoolsideApiKey = process.env.POOLSIDE_API_KEY;
 
 describe("sdk-gateway", () => {
 	beforeEach(() => {
@@ -135,6 +136,11 @@ describe("sdk-gateway", () => {
 			delete process.env.OPENROUTER_API_KEY;
 		} else {
 			process.env.OPENROUTER_API_KEY = originalOpenRouterApiKey;
+		}
+		if (originalPoolsideApiKey === undefined) {
+			delete process.env.POOLSIDE_API_KEY;
+		} else {
+			process.env.POOLSIDE_API_KEY = originalPoolsideApiKey;
 		}
 	});
 
@@ -187,6 +193,7 @@ describe("sdk-gateway", () => {
 		expect(providerIds).toContain("bedrock");
 		expect(providerIds).toContain("openrouter");
 		expect(providerIds).toContain("aihubmix");
+		expect(providerIds).toContain("poolside");
 		expect(providerIds).toContain("claude-code");
 		expect(providerIds).toContain("openai-codex");
 
@@ -3036,6 +3043,41 @@ describe("sdk-gateway", () => {
 			type: "text-delta",
 			text: "OpenRouter",
 		});
+	});
+
+	it("preserves Poolside deployment OpenAI-compatible base URLs", async () => {
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([
+				{ type: "text-delta", textDelta: "Poolside" },
+				{ type: "finish", usage: { inputTokens: 3, outputTokens: 1 } },
+			]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [
+				{
+					providerId: "poolside",
+					apiKey: "poolside-key",
+					baseUrl: "https://deployment.example.com/v1/",
+				},
+			],
+		});
+
+		await collect(
+			await gateway.stream({
+				providerId: "poolside",
+				modelId: "laguna",
+				messages: baseMessages,
+			}),
+		);
+
+		expect(openaiCompatibleFactorySpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				apiKey: "poolside-key",
+				baseURL: "https://deployment.example.com/v1",
+				name: "poolside",
+			}),
+		);
 	});
 
 	it("allows unregistered model ids on known providers", async () => {

--- a/sdk/packages/llms/src/providers/ids.test.ts
+++ b/sdk/packages/llms/src/providers/ids.test.ts
@@ -81,6 +81,27 @@ describe("provider-ids", () => {
 		);
 	});
 
+	it("registers Poolside as a deployment-configured OpenAI-compatible provider", async () => {
+		expect(BUILT_IN_PROVIDER_IDS).toContain("poolside");
+
+		await expect(getProvider("poolside")).resolves.toMatchObject({
+			id: "poolside",
+			name: "Poolside",
+			defaultModelId: "default",
+			client: "openai-compatible",
+			protocol: "openai-chat",
+			env: ["POOLSIDE_API_KEY"],
+			baseUrlPlaceholder: "https://<api-domain>/v1",
+		});
+
+		const registration = BUILTIN_PROVIDER_REGISTRATIONS.find(
+			(item) => item.manifest.id === "poolside",
+		);
+		await expect(registration?.loadProvider?.()).resolves.toMatchObject({
+			createProvider: createOpenAICompatibleProvider,
+		});
+	});
+
 	it("routes Responses API built-ins through the OpenAI provider factory", async () => {
 		for (const providerId of ["litellm", "v0"]) {
 			const provider = await getProvider(providerId);

--- a/sdk/packages/llms/src/providers/ids.ts
+++ b/sdk/packages/llms/src/providers/ids.ts
@@ -42,6 +42,7 @@ export enum BUILT_IN_PROVIDER {
 	AIHUBMIX = "aihubmix",
 	HICAP = "hicap",
 	NOUS_RESEARCH = "nousResearch",
+	POOLSIDE = "poolside",
 	HUAWEI_CLOUD_MAAS = "huawei-cloud-maas",
 	WANDB = "wandb",
 	XIAOMI = "xiaomi",

--- a/sdk/packages/llms/src/providers/vendors/openai-compatible.ts
+++ b/sdk/packages/llms/src/providers/vendors/openai-compatible.ts
@@ -9,6 +9,14 @@ import { resolveApiKey } from "../http";
 import { splitToolImagesMiddleware } from "../middleware/split-tool-images";
 import type { ProviderFactoryResult } from "./types";
 
+function normalizeBaseUrl(baseUrl: string | undefined): string | undefined {
+	const trimmed = baseUrl?.trim().replace(/\/+$/, "");
+	if (!trimmed) {
+		return undefined;
+	}
+	return trimmed;
+}
+
 export async function createOpenAICompatibleProviderModule(
 	config: GatewayResolvedProviderConfig,
 	context: GatewayProviderContext,
@@ -18,10 +26,11 @@ export async function createOpenAICompatibleProviderModule(
 	// authoritative error and is surfaced to the user as-is. This keeps
 	// `llms` unopinionated about which providers do or don't need a key.
 	const apiKey = await resolveApiKey(config);
+	const baseUrl = normalizeBaseUrl(config.baseUrl);
 	const provider = createOpenAICompatible({
 		name: context.provider.id,
 		apiKey,
-		...(config.baseUrl ? { baseURL: config.baseUrl } : {}),
+		...(baseUrl ? { baseURL: baseUrl } : {}),
 		...(config.headers ? { headers: config.headers } : {}),
 		...(config.fetch ? { fetch: config.fetch } : {}),
 		includeUsage: true,


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #7680

### Description

Adds Poolside as an SDK built-in provider using the existing OpenAI-compatible provider path.

This is scoped to the new SDK packages only. It registers the `poolside` provider, exposes `POOLSIDE_API_KEY`, keeps Poolside deployment base URLs configurable, preserves configured `/v1` base URLs, and adds SDK model refresh support through the OpenAI-compatible `/models` endpoint.

### Test Procedure

- Ran `bun --cwd sdk biome check packages/llms/src/providers/ids.ts packages/llms/src/providers/builtins.ts packages/llms/src/providers/vendors/openai-compatible.ts packages/llms/src/providers/ids.test.ts packages/llms/src/providers/gateway.test.ts packages/core/src/services/llms/provider-defaults.ts packages/core/src/services/llms/provider-defaults.test.ts packages/core/src/services/providers/local-provider-service.ts packages/core/src/services/providers/local-provider-service.test.ts`
- Ran `cd sdk/packages/llms && bunx vitest run src/providers/ids.test.ts src/providers/gateway.test.ts --config vitest.config.ts`
- Ran `cd sdk/packages/core && bunx vitest run src/services/llms/provider-defaults.test.ts src/services/providers/local-provider-service.test.ts --config vitest.config.ts`
- Ran `bun --cwd sdk -F @cline/llms typecheck`
- Ran `bun --cwd sdk -F @cline/core typecheck`
- Ran a live SDK smoke test against `https://inference.poolside.ai/v1` with `poolside/laguna-m.1`; the SDK stream returned `poolside-ok` and finished with `stop`.
- Ran a live three-turn SDK conversation against the same endpoint/model; the turns returned `remembered`, `sdk-turn-blue`, and `sdk-turn-blue-ok`, and all turns finished with `stop`.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - SDK-only provider support.

### Additional Notes

This intentionally does not port the legacy extension provider settings, proto, or UI changes from #7680.
