### PR TITLE
fix: route Poolside Laguna models through next-gen prompts

### DIFF
--- a/src/utils/__tests__/model-utils.test.ts
+++ b/src/utils/__tests__/model-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "mocha"
 import "should"
-import type { ApiHandlerModel } from "@core/api"
+import type { ApiHandlerModel, ApiProviderInfo } from "@core/api"
 import {
 	GEMINI_FLASH_MAX_OUTPUT_TOKENS,
 	isClaude4PlusModelFamily,
@@ -8,12 +8,20 @@ import {
 	isGLMModelFamily,
 	isGPT5ModelFamily,
 	isGptOssModelFamily,
+	isNativeToolCallingConfig,
+	isNextGenModelFamily,
+	isPoolsideModelFamily,
 	modelDoesntSupportWebp,
 	shouldSkipReasoningForModel,
 } from "../model-utils"
 
 // Minimal helper — modelDoesntSupportWebp only reads apiHandlerModel.id
-const m = (id: string): ApiHandlerModel => ({ id, info: {} as any })
+const m = (id: string): ApiHandlerModel => ({ id, info: { supportsPromptCache: false } })
+const providerInfo = (providerId: string, modelId: string): ApiProviderInfo => ({
+	providerId,
+	model: m(modelId),
+	mode: "act",
+})
 
 describe("shouldSkipReasoningForModel", () => {
 	it("should return true for grok-4 models", () => {
@@ -113,6 +121,26 @@ describe("isGptOssModelFamily", () => {
 		isGptOssModelFamily("gpt-5").should.equal(false)
 		isGptOssModelFamily("gpt-4o").should.equal(false)
 		isGptOssModelFamily("claude-sonnet-4").should.equal(false)
+	})
+})
+
+describe("isPoolsideModelFamily", () => {
+	it("should return true for Laguna model IDs", () => {
+		isPoolsideModelFamily("poolside/laguna-m.1").should.equal(true)
+		isPoolsideModelFamily("laguna-enterprise").should.equal(true)
+		isPoolsideModelFamily("LAGUNA").should.equal(true)
+	})
+
+	it("should return false for non-Poolside model IDs", () => {
+		isPoolsideModelFamily("gpt-5").should.equal(false)
+		isPoolsideModelFamily("deepseek-chat").should.equal(false)
+		isPoolsideModelFamily("claude-sonnet-4").should.equal(false)
+	})
+
+	it("should qualify Laguna models for next-gen and native tool calling paths", () => {
+		isNextGenModelFamily("poolside/laguna-m.1").should.equal(true)
+		isNativeToolCallingConfig(providerInfo("openai-compatible", "poolside/laguna-m.1"), true).should.equal(true)
+		isNativeToolCallingConfig(providerInfo("openai-compatible", "poolside/laguna-m.1"), false).should.equal(false)
 	})
 })
 

--- a/src/utils/model-utils.ts
+++ b/src/utils/model-utils.ts
@@ -189,6 +189,11 @@ export function isDeepSeekNativeModelFamily(id: string): boolean {
 	return modelId.includes("deepseek-chat") || modelId.includes("deepseek-reasoner")
 }
 
+export function isPoolsideModelFamily(id: string): boolean {
+	const modelId = normalize(id)
+	return modelId.includes("laguna")
+}
+
 export function isNextGenModelFamily(id: string): boolean {
 	const modelId = normalize(id)
 	return (
@@ -201,7 +206,8 @@ export function isNextGenModelFamily(id: string): boolean {
 		isGemini3ModelFamily(modelId) ||
 		isNextGenOpenSourceModelFamily(modelId) ||
 		isDeepSeek32ModelFamily(modelId) ||
-		isDeepSeekNativeModelFamily(modelId)
+		isDeepSeekNativeModelFamily(modelId) ||
+		isPoolsideModelFamily(modelId)
 	)
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #7680

### Description

Recognizes Poolside Laguna model IDs as next-gen model family IDs so they can use Cline's next-gen prompt and native tool calling path instead of falling back to XML-style tool instructions.

This is intentionally separate from the SDK Poolside provider PR and only touches the existing model-family utility plus coverage for the native tool gating behavior.

### Test Procedure

- Ran `npm run protos` to generate local protobuf TypeScript required by the test import graph.
- Ran `PATH=/Users/ara2/.local/share/mise/installs/node/22.22.2/bin:$PATH npm run test:unit -- --grep "isPoolsideModelFamily"` — 3 passing.
- Ran `PATH=/Users/ara2/.local/share/mise/installs/node/22.22.2/bin:$PATH npm run test:unit -- src/utils/__tests__/model-utils.test.ts` — unit suite completed with 1447 passing.
- Ran `PATH=/Users/ara2/.local/share/mise/installs/node/22.22.2/bin:$PATH npx tsc --noEmit`.
- Ran `PATH=/Users/ara2/.local/share/mise/installs/node/22.22.2/bin:$PATH npx biome check src/utils/model-utils.ts src/utils/__tests__/model-utils.test.ts`.
- Ran a direct TypeScript smoke check confirming `poolside/laguna-m.1` returns true for `isPoolsideModelFamily`, true for `isNextGenModelFamily`, and true for `isNativeToolCallingConfig` when native tools are enabled via `openai-compatible`.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - model routing logic only.

### Additional Notes

This PR covers Laguna model-family detection for the existing next-gen/native-tool codepath. It does not add a separate Poolside extension provider.
