### PR TITLE
fix: restore Bedrock image bytes from history

### DIFF
--- a/src/core/api/providers/__tests__/bedrock.test.ts
+++ b/src/core/api/providers/__tests__/bedrock.test.ts
@@ -218,6 +218,58 @@ describe("AwsBedrockHandler", () => {
 		})
 	})
 
+	describe("formatMessagesForConverseAPI", () => {
+		it("should restore image bytes from JSON-serialized Uint8Array data", () => {
+			const handler = new AwsBedrockHandler(mockOptions)
+			const messages: ClineStorageMessage[] = [
+				{
+					role: "user",
+					content: [
+						{
+							type: "image",
+							source: {
+								type: "base64",
+								media_type: "image/png",
+								data: { "0": 82, "1": 73, "2": 70, "3": 70 },
+							},
+						},
+					],
+				} as unknown as ClineStorageMessage,
+			]
+
+			const formattedMessages = handler["formatMessagesForConverseAPI"](messages)
+			const bytes = (formattedMessages[0].content?.[0] as any).image?.source.bytes
+
+			should.exist(bytes)
+			Array.from(bytes as Uint8Array).should.deepEqual([82, 73, 70, 70])
+		})
+
+		it("should restore image bytes from JSON-serialized Buffer data", () => {
+			const handler = new AwsBedrockHandler(mockOptions)
+			const messages: ClineStorageMessage[] = [
+				{
+					role: "user",
+					content: [
+						{
+							type: "image",
+							source: {
+								type: "base64",
+								media_type: "image/png",
+								data: { type: "Buffer", data: [82, 73, 70, 70] },
+							},
+						},
+					],
+				} as unknown as ClineStorageMessage,
+			]
+
+			const formattedMessages = handler["formatMessagesForConverseAPI"](messages)
+			const bytes = (formattedMessages[0].content?.[0] as any).image?.source.bytes
+
+			should.exist(bytes)
+			Array.from(bytes as Uint8Array).should.deepEqual([82, 73, 70, 70])
+		})
+	})
+
 	const mockOptions: AwsBedrockHandlerOptions = {
 		apiModelId: "anthropic.claude-3-7-sonnet-20250219-v1:0",
 		awsRegion: "us-east-1",

--- a/src/core/api/providers/__tests__/bedrock.test.ts
+++ b/src/core/api/providers/__tests__/bedrock.test.ts
@@ -268,6 +268,54 @@ describe("AwsBedrockHandler", () => {
 			should.exist(bytes)
 			Array.from(bytes as Uint8Array).should.deepEqual([82, 73, 70, 70])
 		})
+
+		it("should reject malformed JSON-serialized Buffer data", () => {
+			const handler = new AwsBedrockHandler(mockOptions)
+			const messages: ClineStorageMessage[] = [
+				{
+					role: "user",
+					content: [
+						{
+							type: "image",
+							source: {
+								type: "base64",
+								media_type: "image/png",
+								data: { type: "Buffer", data: ["R", "I", "F", "F"] },
+							},
+						},
+					],
+				} as unknown as ClineStorageMessage,
+			]
+
+			const formattedMessages = handler["formatMessagesForConverseAPI"](messages)
+			const text = (formattedMessages[0].content?.[0] as any).text
+
+			text.should.startWith("[ERROR: Failed to process image - Unsupported image data format]")
+		})
+
+		it("should reject numeric-key image data with empty keys", () => {
+			const handler = new AwsBedrockHandler(mockOptions)
+			const messages: ClineStorageMessage[] = [
+				{
+					role: "user",
+					content: [
+						{
+							type: "image",
+							source: {
+								type: "base64",
+								media_type: "image/png",
+								data: { "": 82 },
+							},
+						},
+					],
+				} as unknown as ClineStorageMessage,
+			]
+
+			const formattedMessages = handler["formatMessagesForConverseAPI"](messages)
+			const text = (formattedMessages[0].content?.[0] as any).text
+
+			text.should.startWith("[ERROR: Failed to process image - Unsupported image data format]")
+		})
 	})
 
 	const mockOptions: AwsBedrockHandlerOptions = {

--- a/src/core/api/providers/bedrock.ts
+++ b/src/core/api/providers/bedrock.ts
@@ -115,7 +115,7 @@ interface ContentItem {
 	type: SupportedContentType
 	text?: string
 	source?: {
-		data: string | Buffer | Uint8Array
+		data: unknown
 		media_type?: string
 	}
 }
@@ -1082,16 +1082,7 @@ export class AwsBedrockHandler implements ApiHandler {
 
 		// Get image data with improved error handling
 		try {
-			if (typeof item.source.data === "string") {
-				// Handle base64 encoded data
-				const base64Data = item.source.data.replace(/^data:image\/\w+;base64,/, "")
-				imageData = new Uint8Array(Buffer.from(base64Data, "base64"))
-			} else if (item.source.data && typeof item.source.data === "object") {
-				// Try to convert to Uint8Array
-				imageData = new Uint8Array(Buffer.from(item.source.data as Buffer | Uint8Array))
-			} else {
-				throw new Error("Unsupported image data format")
-			}
+			imageData = this.normalizeImageData(item.source.data)
 
 			return {
 				image: {
@@ -1109,6 +1100,53 @@ export class AwsBedrockHandler implements ApiHandler {
 				text: `[ERROR: Failed to process image - ${error instanceof Error ? error.message : "Unknown error"}]`,
 			}
 		}
+	}
+
+	private normalizeImageData(data: unknown): Uint8Array {
+		if (typeof data === "string") {
+			const base64Data = data.replace(/^data:image\/\w+;base64,/, "")
+			return new Uint8Array(Buffer.from(base64Data, "base64"))
+		}
+
+		if (data instanceof Uint8Array) {
+			return new Uint8Array(data)
+		}
+
+		if (data instanceof ArrayBuffer) {
+			return new Uint8Array(data)
+		}
+
+		if (Array.isArray(data) && data.every((value) => Number.isInteger(value))) {
+			return Uint8Array.from(data)
+		}
+
+		if (data && typeof data === "object") {
+			const maybeBufferJson = data as { type?: unknown; data?: unknown }
+			if (
+				maybeBufferJson.type === "Buffer" &&
+				Array.isArray(maybeBufferJson.data) &&
+				maybeBufferJson.data.every((value) => typeof value === "number" && Number.isInteger(value))
+			) {
+				return Uint8Array.from(maybeBufferJson.data as number[])
+			}
+
+			const entries = Object.entries(data)
+				.filter(([key]) => key.length > 0)
+				.map(([key, value]) => [Number(key), value] as const)
+				.sort(([left], [right]) => left - right)
+
+			if (
+				entries.length > 0 &&
+				entries.every(
+					([key, value], index) =>
+						Number.isInteger(key) && key === index && typeof value === "number" && Number.isInteger(value),
+				)
+			) {
+				return Uint8Array.from(entries.map(([, value]) => value as number))
+			}
+		}
+
+		throw new Error("Unsupported image data format")
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes Bedrock Converse image replay when screenshot data has been round-tripped through JSON history.

## What changed

- Normalizes image data before sending it to Bedrock
- Supports base64 strings, Uint8Array/ArrayBuffer, Buffer JSON, and numeric-key JSON objects such as `{ "0": 82, "1": 73 }`
- Adds regression coverage for JSON-serialized Uint8Array and Buffer image data

## Validation

- `npm run check-types -- --pretty false`
- `npx tsx -r tsconfig-paths/register -e '...'` smoke for numeric-key image bytes normalization

Fixes #10926
