### PR TITLE
fix(cli): load Bedrock profile credentials

### DIFF
--- a/sdk/apps/cli/src/tui/components/dialogs/provider-picker.tsx
+++ b/sdk/apps/cli/src/tui/components/dialogs/provider-picker.tsx
@@ -25,6 +25,7 @@ import { isOAuthProvider } from "../../../utils/provider-auth";
 import { palette } from "../../palette";
 import { getProviderSection } from "../../utils/provider-sections";
 import {
+	getNextProviderConfigField,
 	getDefaultAwsRegion,
 	resolveProviderConfigAwsRegion,
 	updateProviderConfigValue,
@@ -330,9 +331,9 @@ const DEFAULT_FIELD_PLACEHOLDERS: Partial<
 /** Render order for cycling focus with Tab. */
 const FIELD_ORDER: ProviderConfigFieldKey[] = [
 	"awsRegion",
+	"awsProfile",
 	"baseUrl",
 	"apiKey",
-	"awsProfile",
 ];
 
 export type ProviderConfigInputFields = Partial<
@@ -399,6 +400,16 @@ export function ProviderConfigInputContent(
 	);
 
 	const submit = () => {
+		const nextField = getNextProviderConfigField(
+			config.fields,
+			FIELD_ORDER,
+			focusedField,
+		);
+		if (nextField) {
+			setFocusedField(nextField);
+			return;
+		}
+
 		const apiKey = values.apiKey?.trim();
 		const awsProfile = values.awsProfile?.trim();
 		const hasAwsFields = config.fields.awsRegion || config.fields.awsProfile;
@@ -465,9 +476,7 @@ export function ProviderConfigInputContent(
 							<input
 								value={values[key] ?? ""}
 								onInput={(v: string) =>
-									setValues((prev) =>
-										updateProviderConfigValue(prev, key, v),
-									)
+									setValues((prev) => updateProviderConfigValue(prev, key, v))
 								}
 								placeholder={placeholder}
 								flexGrow={1}
@@ -481,7 +490,7 @@ export function ProviderConfigInputContent(
 			<text fg="gray">
 				<em>
 					{fieldKeys.length > 1
-						? "Tab to switch fields, Enter to save, Esc to go back"
+						? "Tab to switch fields, Enter to continue, Esc to go back"
 						: "Enter to save, Esc to go back"}
 				</em>
 			</text>

--- a/sdk/apps/cli/src/tui/components/dialogs/provider-picker.tsx
+++ b/sdk/apps/cli/src/tui/components/dialogs/provider-picker.tsx
@@ -31,6 +31,7 @@ import {
 	updateProviderConfigValue,
 	type ProviderConfigValues,
 } from "../../utils/provider-config-values";
+import { FIELD_ORDER } from "../../views/onboarding/fields";
 import {
 	getSearchableListRowsWindow,
 	type SearchableItem,
@@ -328,14 +329,6 @@ const DEFAULT_FIELD_PLACEHOLDERS: Partial<
 	awsProfile: "default",
 };
 
-/** Render order for cycling focus with Tab. */
-const FIELD_ORDER: ProviderConfigFieldKey[] = [
-	"awsRegion",
-	"awsProfile",
-	"baseUrl",
-	"apiKey",
-];
-
 export type ProviderConfigInputFields = Partial<
 	Record<ProviderConfigFieldKey, ProviderConfigFieldRequirement>
 >;
@@ -398,13 +391,13 @@ export function ProviderConfigInputContent(
 	const [focusedField, setFocusedField] = useState<ProviderConfigFieldKey>(
 		() => fieldKeys[0] ?? "apiKey",
 	);
+	const nextField = getNextProviderConfigField(
+		config.fields,
+		FIELD_ORDER,
+		focusedField,
+	);
 
 	const submit = () => {
-		const nextField = getNextProviderConfigField(
-			config.fields,
-			FIELD_ORDER,
-			focusedField,
-		);
 		if (nextField) {
 			setFocusedField(nextField);
 			return;
@@ -490,7 +483,7 @@ export function ProviderConfigInputContent(
 			<text fg="gray">
 				<em>
 					{fieldKeys.length > 1
-						? "Tab to switch fields, Enter to continue, Esc to go back"
+						? `Tab to switch fields, Enter to ${nextField ? "continue" : "save"}, Esc to go back`
 						: "Enter to save, Esc to go back"}
 				</em>
 			</text>

--- a/sdk/apps/cli/src/tui/utils/provider-config-values.test.ts
+++ b/sdk/apps/cli/src/tui/utils/provider-config-values.test.ts
@@ -3,10 +3,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+	getNextProviderConfigField,
 	getDefaultAwsRegion,
 	resolveProviderConfigAwsRegion,
 	updateProviderConfigValue,
 } from "./provider-config-values";
+import { FIELD_ORDER } from "../views/onboarding/fields";
 
 const originalEnv = { ...process.env };
 
@@ -63,5 +65,25 @@ describe("provider config values", () => {
 				awsRegion: "",
 			}),
 		).toBe("us-west-2");
+	});
+
+	it("advances Bedrock profile input before the optional API key", () => {
+		expect(
+			getNextProviderConfigField(
+				{ awsRegion: {}, apiKey: {}, awsProfile: {} },
+				FIELD_ORDER,
+				"awsRegion",
+			),
+		).toBe("awsProfile");
+	});
+
+	it("returns undefined after the last visible provider config field", () => {
+		expect(
+			getNextProviderConfigField(
+				{ awsRegion: {}, awsProfile: {} },
+				FIELD_ORDER,
+				"awsProfile",
+			),
+		).toBeUndefined();
 	});
 });

--- a/sdk/apps/cli/src/tui/utils/provider-config-values.ts
+++ b/sdk/apps/cli/src/tui/utils/provider-config-values.ts
@@ -20,6 +20,20 @@ export function resolveProviderConfigAwsRegion(
 	return values.awsRegion?.trim() || getDefaultAwsRegion(values.awsProfile);
 }
 
+export function getNextProviderConfigField(
+	fields: Partial<Record<ProviderConfigFieldKey, unknown>>,
+	fieldOrder: readonly ProviderConfigFieldKey[],
+	currentField: ProviderConfigFieldKey,
+): ProviderConfigFieldKey | undefined {
+	const visible = fieldOrder.filter((field) => fields[field] !== undefined);
+	const currentIndex = visible.indexOf(currentField);
+	if (currentIndex === -1 || currentIndex >= visible.length - 1) {
+		return undefined;
+	}
+
+	return visible[currentIndex + 1];
+}
+
 export function updateProviderConfigValue(
 	previous: ProviderConfigValues,
 	field: ProviderConfigFieldKey,

--- a/sdk/apps/cli/src/tui/views/onboarding/controller.ts
+++ b/sdk/apps/cli/src/tui/views/onboarding/controller.ts
@@ -30,6 +30,7 @@ import {
 import { palette } from "../../palette";
 import { getProviderSection } from "../../utils/provider-sections";
 import {
+	getNextProviderConfigField,
 	getDefaultAwsRegion,
 	resolveProviderConfigAwsRegion,
 	updateProviderConfigValue,
@@ -454,6 +455,20 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 		transitionToModelPicker,
 	]);
 
+	const submitByoConfigField = useCallback(() => {
+		const nextField = getNextProviderConfigField(
+			byoFields,
+			FIELD_ORDER,
+			byoFocusedField,
+		);
+		if (nextField) {
+			setByoFocusedField(nextField);
+			return;
+		}
+
+		saveByoConfig();
+	}, [byoFields, byoFocusedField, saveByoConfig]);
+
 	const completeModelSelection = useCallback(
 		(modelId: string) => {
 			const existing =
@@ -614,7 +629,7 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 		loadModelsForProvider,
 		saveClineModelSelection,
 		saveCodexCliConfig,
-		saveByoConfig,
+		saveByoConfig: submitByoConfigField,
 		saveModelSelection,
 		saveThinkingLevel,
 	});
@@ -659,7 +674,7 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 		providerList,
 		providersLoading,
 		recommendedLoading: recommended.loading,
-		saveByoConfig,
+		saveByoConfig: submitByoConfigField,
 		saveCodexCliConfig,
 		saveCustomModelId,
 		selectedModelName,

--- a/sdk/apps/cli/src/tui/views/onboarding/fields.ts
+++ b/sdk/apps/cli/src/tui/views/onboarding/fields.ts
@@ -3,7 +3,7 @@ import type { ProviderConfigFieldKey } from "@cline/core";
 /** Render order for provider config fields and Tab cycling. */
 export const FIELD_ORDER: ProviderConfigFieldKey[] = [
 	"awsRegion",
+	"awsProfile",
 	"baseUrl",
 	"apiKey",
-	"awsProfile",
 ];

--- a/sdk/apps/cli/src/tui/views/onboarding/screens.tsx
+++ b/sdk/apps/cli/src/tui/views/onboarding/screens.tsx
@@ -19,6 +19,7 @@ import {
 } from "../../components/tracked-robot";
 import { useTerminalBackground } from "../../hooks/use-terminal-background";
 import { getDefaultForeground, palette } from "../../palette";
+import { getNextProviderConfigField } from "../../utils/provider-config-values";
 import { FIELD_ORDER } from "./fields";
 import { MAIN_MENU, THINKING_LEVELS } from "./model";
 
@@ -253,6 +254,11 @@ export function OnboardingProviderConfigScreen(props: {
 	const visibleFields = FIELD_ORDER.filter(
 		(key) => props.fields[key] !== undefined,
 	);
+	const nextField = getNextProviderConfigField(
+		props.fields,
+		FIELD_ORDER,
+		props.focusedField,
+	);
 
 	return (
 		<OnboardingFrame
@@ -309,7 +315,7 @@ export function OnboardingProviderConfigScreen(props: {
 				<text fg="gray">
 					<em>
 						{visibleFields.length > 1
-							? "Tab to switch fields, Enter to continue, Esc to go back, Ctrl+C to exit"
+							? `Tab to switch fields, Enter to ${nextField ? "continue" : "save"}, Esc to go back, Ctrl+C to exit`
 							: "Enter to save, Esc to go back, Ctrl+C to exit"}
 					</em>
 				</text>

--- a/sdk/apps/cli/src/tui/views/onboarding/screens.tsx
+++ b/sdk/apps/cli/src/tui/views/onboarding/screens.tsx
@@ -309,7 +309,7 @@ export function OnboardingProviderConfigScreen(props: {
 				<text fg="gray">
 					<em>
 						{visibleFields.length > 1
-							? "Tab to switch fields, Enter to save, Esc to go back, Ctrl+C to exit"
+							? "Tab to switch fields, Enter to continue, Esc to go back, Ctrl+C to exit"
 							: "Enter to save, Esc to go back, Ctrl+C to exit"}
 					</em>
 				</text>

--- a/src/core/api/providers/__tests__/bedrock.test.ts
+++ b/src/core/api/providers/__tests__/bedrock.test.ts
@@ -1,6 +1,7 @@
 import { ConverseStreamCommand } from "@aws-sdk/client-bedrock-runtime"
 import { bedrockModels, vertexGlobalModels, vertexModels } from "@shared/api"
 import should from "should"
+import sinon from "sinon"
 import { Readable } from "stream"
 import type { ClineStorageMessage } from "@/shared/messages/content"
 import type { AwsBedrockHandlerOptions } from "../bedrock"
@@ -201,6 +202,58 @@ describe("AwsBedrockHandler", () => {
 			)
 
 			process.env["AWS_BEARER_TOKEN_BEDROCK"]!.should.equal(preAWSProfile)
+		})
+	})
+
+	describe("AWS profile credentials", () => {
+		const originalEnv = { ...process.env }
+
+		afterEach(() => {
+			sinon.restore()
+			process.env = { ...originalEnv }
+		})
+
+		it("loads shared AWS config before resolving profile credentials", async () => {
+			process.env.AWS_SDK_LOAD_CONFIG = "0"
+			const handler = new AwsBedrockHandler({
+				...mockOptions,
+				awsAuthentication: "profile",
+				awsUseProfile: true,
+				awsProfile: "bedrock",
+			})
+			let capturedOptions: any
+			let capturedEnv: Record<string, string | undefined> | undefined
+
+			sinon.stub(handler as any, "createAwsCredentialProvider").callsFake((options: any) => {
+				capturedOptions = options
+				return async () => {
+					capturedEnv = {
+						AWS_PROFILE: process.env.AWS_PROFILE,
+						AWS_REGION: process.env.AWS_REGION,
+						AWS_SDK_LOAD_CONFIG: process.env.AWS_SDK_LOAD_CONFIG,
+					}
+					return {
+						accessKeyId: "test-access-key",
+						secretAccessKey: "test-secret-key",
+						sessionToken: "test-session-token",
+					}
+				}
+			})
+
+			const credentials = await (handler as any).getAwsCredentials()
+
+			credentials.should.deepEqual({
+				accessKeyId: "test-access-key",
+				secretAccessKey: "test-secret-key",
+				sessionToken: "test-session-token",
+			})
+			capturedOptions.profile.should.equal("bedrock")
+			capturedOptions.ignoreCache.should.equal(true)
+			should.exist(capturedEnv)
+			capturedEnv!.AWS_PROFILE!.should.equal("bedrock")
+			capturedEnv!.AWS_REGION!.should.equal("us-east-1")
+			capturedEnv!.AWS_SDK_LOAD_CONFIG!.should.equal("1")
+			process.env.AWS_SDK_LOAD_CONFIG!.should.equal("0")
 		})
 	})
 

--- a/src/core/api/providers/bedrock.ts
+++ b/src/core/api/providers/bedrock.ts
@@ -263,12 +263,11 @@ export class AwsBedrockHandler implements ApiHandler {
 			}
 		}
 
-		// Create AWS credentials by executing an AWS provider chain
-		const providerChain = fromNodeProviderChain(providerOptions)
 		return await AwsBedrockHandler.withTempEnv(
 			() => {
 				AwsBedrockHandler.setEnv("AWS_REGION", this.options.awsRegion)
 				if (useProfile) {
+					AwsBedrockHandler.setEnv("AWS_SDK_LOAD_CONFIG", "1")
 					AwsBedrockHandler.setEnv("AWS_PROFILE", this.options.awsProfile)
 				} else {
 					delete process.env["AWS_PROFILE"]
@@ -277,8 +276,12 @@ export class AwsBedrockHandler implements ApiHandler {
 					AwsBedrockHandler.setEnv("AWS_SESSION_TOKEN", this.options.awsSessionToken)
 				}
 			},
-			() => providerChain(),
+			() => this.createAwsCredentialProvider(providerOptions)(),
 		)
+	}
+
+	private createAwsCredentialProvider(providerOptions: ProviderChainOptions) {
+		return fromNodeProviderChain(providerOptions)
 	}
 
 	/**


### PR DESCRIPTION
### Related Issue

Fixes #10930

### Description

Bedrock profile auth now builds the credential provider after the temporary AWS environment is applied, and enables shared AWS config loading so profiles backed by `credential_process` in `~/.aws/config` are included.

The CLI provider forms also advance through the AWS profile field before saving, so profile auth does not accidentally persist only the region when users press Enter during setup.

### Test Procedure

- `npm run compile`
- `git diff --check`
- `npx tsx -e 'import { FIELD_ORDER } from "./sdk/apps/cli/src/tui/views/onboarding/fields"; import { getNextProviderConfigField } from "./sdk/apps/cli/src/tui/utils/provider-config-values"; const next = getNextProviderConfigField({ awsRegion: {}, apiKey: {}, awsProfile: {} }, FIELD_ORDER, "awsRegion"); if (next !== "awsProfile") throw new Error(`expected awsProfile, got ${next}`); console.log(next)'`