### PR TITLE
fix: Bedrock legacy migration for awsProfile

### DIFF
--- a/sdk/packages/core/src/services/storage/provider-settings-legacy-migration.test.ts
+++ b/sdk/packages/core/src/services/storage/provider-settings-legacy-migration.test.ts
@@ -296,6 +296,62 @@ describe("migrateLegacyProviderSettings", () => {
 		});
 		expect(manager.getProviderSettings("openai")).toBeUndefined();
 	});
+
+	it("migrates Bedrock profile auth profile names without requiring legacy awsUseProfile", () => {
+		const tempDir = mkdtempSync(
+			path.join(os.tmpdir(), "core-legacy-provider-"),
+		);
+		tempDirs.push(tempDir);
+		const providersPath = path.join(tempDir, "provider-settings.json");
+		const manager = new ProviderSettingsManager({ filePath: providersPath });
+
+		writeFileSync(
+			path.join(tempDir, "globalState.json"),
+			JSON.stringify(
+				{
+					mode: "act",
+					actModeApiProvider: "bedrock",
+					actModeApiModelId: "global.anthropic.claude-opus-4-6-v1",
+					awsRegion: "us-east-1",
+					awsAuthentication: "profile",
+					awsProfile: "bedrock",
+					awsBedrockUsePromptCache: true,
+					awsUseCrossRegionInference: true,
+					awsUseGlobalInference: false,
+					actModeAwsBedrockCustomModelBaseId:
+						"anthropic.claude-sonnet-4-5-20250929-v1:0",
+				},
+				null,
+				2,
+			),
+		);
+		writeFileSync(path.join(tempDir, "secrets.json"), JSON.stringify({}));
+
+		const result = migrateLegacyProviderSettings({
+			providerSettingsManager: manager,
+			dataDir: tempDir,
+		});
+
+		expect(result).toMatchObject({
+			migrated: true,
+			providerCount: 1,
+			lastUsedProvider: "bedrock",
+		});
+		expect(manager.getProviderSettings("bedrock")).toEqual({
+			provider: "bedrock",
+			model: "global.anthropic.claude-opus-4-6-v1",
+			aws: {
+				region: "us-east-1",
+				authentication: "profile",
+				profile: "bedrock",
+				usePromptCache: true,
+				useCrossRegionInference: true,
+				useGlobalInference: false,
+				customModelBaseId: "anthropic.claude-sonnet-4-5-20250929-v1:0",
+			},
+		});
+		expect(manager.read().providers.bedrock?.tokenSource).toBe("migration");
+	});
 });
 
 // =============================================================================

--- a/sdk/packages/core/src/services/storage/provider-settings-legacy-migration.ts
+++ b/sdk/packages/core/src/services/storage/provider-settings-legacy-migration.ts
@@ -490,13 +490,16 @@ function buildLegacyProviderSettings(
 		providerSpecific.headers = legacyGlobalState.openAiHeaders;
 	}
 	if (providerId === "bedrock") {
+		const useBedrockProfile =
+			legacyGlobalState.awsAuthentication === "profile" ||
+			legacyGlobalState.awsUseProfile === true;
 		providerSpecific.aws = {
 			accessKey: trimNonEmpty(legacySecrets.awsAccessKey),
 			secretKey: trimNonEmpty(legacySecrets.awsSecretKey),
 			sessionToken: trimNonEmpty(legacySecrets.awsSessionToken),
 			region: trimNonEmpty(legacyGlobalState.awsRegion),
 			authentication: legacyGlobalState.awsAuthentication,
-			profile: legacyGlobalState.awsUseProfile
+			profile: useBedrockProfile
 				? trimNonEmpty(legacyGlobalState.awsProfile)
 				: undefined,
 			usePromptCache: legacyGlobalState.awsBedrockUsePromptCache,
@@ -657,7 +660,10 @@ function collectCandidateProviderIds(
 	if (trimNonEmpty(legacySecrets.ollamaApiKey)) candidates.add("ollama");
 	if (
 		trimNonEmpty(legacySecrets.awsAccessKey) ||
-		trimNonEmpty(legacySecrets.awsBedrockApiKey)
+		trimNonEmpty(legacySecrets.awsBedrockApiKey) ||
+		legacyGlobalState.awsAuthentication !== undefined ||
+		legacyGlobalState.awsUseProfile === true ||
+		trimNonEmpty(legacyGlobalState.awsProfile)
 	)
 		candidates.add("bedrock");
 	if (


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:**  https://github.com/cline/cline/issues/10770

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

The new Bedrock path is not failing because credential_process is unsupported. Both old and new code use AWS SDK v3’s fromNodeProviderChain, which can load credential_process.

The practical difference is that the migrated config does not include the AWS profile name:

```
"aws": {
  "region": "us-east-1",
  "authentication": "profile"
}
```

There is no `"profile": "bedrock"` So the new llms provider never targets [profile bedrock]. It calls fromNodeProviderChain({ ignoreCache: true, clientConfig: { region } }), which means AWS SDK will use AWS_PROFILE if present, otherwise default.

## Cause

The migration code only migrates awsProfile when legacy awsUseProfile is true. But the old extension treats profile auth as active when awsAuthentication === "profile" too:

```
profile:
  legacyGlobalState.awsAuthentication === "profile" || legacyGlobalState.awsUseProfile
    ? trimNonEmpty(legacyGlobalState.awsProfile)
    : undefined
```

## Fixes

The migration now preserves awsProfile when awsAuthentication === "profile", even if the old awsUseProfile flag is missing. It also treats profile-based Bedrock settings as enough to migrate Bedrock without static AWS keys.


### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
