### PR TITLE
Fix SDK model catalog token-limit semantics ENG-2100

### DIFF
--- a/sdk/apps/cli/src/tests/cli/flags-behavior.test.ts
+++ b/sdk/apps/cli/src/tests/cli/flags-behavior.test.ts
@@ -28,7 +28,7 @@ test.describe("cline --model (interactive mode, flag ignored)", () => {
 
 	test("starts interactive mode", async ({ terminal }) => {
 		await waitForChatReady(terminal);
-		await expectVisible(terminal, "GPT-5.3-Codex");
+		await expectVisible(terminal, "GPT-5.3 Codex");
 	});
 });
 

--- a/sdk/packages/llms/README.md
+++ b/sdk/packages/llms/README.md
@@ -70,6 +70,9 @@ AI SDK provider implementations. Shared gateway contracts are exported from both
 Use `@cline/llms/models` when you need generated provider/model metadata for
 selection UIs, defaults, or validation.
 
+For generated catalog field semantics and token-limit behavior, see
+[`src/catalog/README.md`](./src/catalog/README.md).
+
 ## Entry Points
 
 - `@cline/llms`: runtime-focused convenience entrypoint

--- a/sdk/packages/llms/src/catalog/README.md
+++ b/sdk/packages/llms/src/catalog/README.md
@@ -1,0 +1,166 @@
+# Model Catalog Semantics
+
+The generated catalog is the SDK's normalized copy of provider and model
+metadata. Most built-in catalog data comes from [models.dev](https://models.dev)
+through `catalog-live.ts` and is written to `catalog.generated.ts` by the model
+generation scripts.
+
+This file documents the intended meaning of the token-limit fields and the
+boundary between catalog metadata and runtime request policy.
+
+## Source Fields
+
+`models.dev` exposes model limits under `limit`:
+
+```text
+limit.context  maximum context budget reported for the model
+limit.input    optional stricter prompt/input-token budget
+limit.output   maximum output tokens reported for generation
+```
+
+`limit.input` is not present for every model. When it is present, it should be
+treated as the best available prompt/input ceiling. When it is absent, the
+catalog falls back to `limit.context` for the prompt/input ceiling.
+
+## Cline Fields
+
+The catalog maps those source fields into `ModelInfo`:
+
+```text
+contextWindow   provider-reported context budget
+maxInputTokens  prompt/input-token budget used by compaction and diagnostics
+maxTokens       provider-reported output-token budget
+```
+
+These fields are not additive guarantees. In particular, this is valid catalog
+metadata:
+
+```text
+contextWindow:  200000
+maxInputTokens: 200000
+maxTokens:      128000
+```
+
+That means:
+
+```text
+the prompt may be allowed to approach 200000 tokens
+the model may be capable of generating up to 128000 tokens
+an individual request still needs prompt + output to fit the provider's rules
+```
+
+Do not infer that `maxInputTokens + maxTokens` must be less than or equal to
+`contextWindow`. Many provider catalogs expose separate maxima that share an
+underlying context budget.
+
+## Catalog Data vs Request Limits
+
+The catalog should describe reported model capabilities. It should avoid baking
+in Cline request defaults, product-level safety limits, or provider-specific
+workarounds unless there is no better place to represent a stable fact.
+
+The code that sends a model request is responsible for deciding how many output
+tokens to ask for on that specific turn. That decision can depend on:
+
+- actual prompt size for the current request
+- provider context-window behavior
+- product-level default output caps
+- user overrides such as `request.options.maxTokens`
+- tokenizer drift and hidden provider overhead
+- reasoning, tool, image, and formatting tokens
+
+For models where prompt and output tokens both have to fit into the same context
+window, the request limit should be based on the current prompt, not invented
+while generating the catalog. Conceptually:
+
+```text
+safeOutputTokens = min(
+	modelReportedMaxOutput,
+	contextWindow - estimatedPromptTokens - reserveTokens,
+	productDefaultOutputCap,
+	userConfiguredOutputCap,
+)
+```
+
+The SDK gateway currently uses `DEFAULT_GATEWAY_MAX_OUTPUT_TOKENS = 32_000` as
+the default product-level output cap when the request does not provide
+`request.options.maxTokens`.
+
+The exact request-limit policy belongs in the provider/gateway/core request
+path, not in generated catalog data.
+
+## Do Not Invent Output Limits
+
+The catalog generator should not turn ambiguous provider metadata into a new
+Cline output limit.
+
+For example, if a provider reports:
+
+```text
+limit.context = 202800
+limit.output  = 202800
+```
+
+the generated catalog should preserve that reported output limit:
+
+```text
+contextWindow:  202800
+maxInputTokens: 202800
+maxTokens:      202800
+```
+
+Cline may still ask for fewer output tokens on a given request. That belongs in
+the request path because only the request path knows the current prompt size and
+the user's configured output cap.
+
+## Generation Flow
+
+The generated catalog is produced from the live normalizer:
+
+```text
+models.dev/api.json
+	|
+	v
+src/catalog/catalog-live.ts
+	|
+	v
+scripts/generate-models.ts
+	|
+	v
+src/catalog/catalog.generated.ts
+```
+
+Use the package script when regenerating:
+
+```bash
+bun -F @cline/llms generate:models
+```
+
+Catalog changes should usually include tests in `catalog-live.test.ts` that
+document how source `limit` fields map to `ModelInfo`.
+
+## Provider Differences
+
+Provider token semantics are not uniform:
+
+- Some providers publish independent input and output caps.
+- Some providers publish only a context budget and a max generation parameter.
+- Some routed providers report limits that differ from the upstream model docs.
+- Some providers reject `prompt + requestedOutput > contextWindow`.
+- Some providers truncate, compress, or stop generation instead.
+- Reasoning tokens may count against output budgets.
+- Tool schemas, tool calls, images, and provider formatting can consume hidden
+  input or output budget.
+
+Because of those differences, catalog generation should preserve source
+metadata as much as possible, while runtime request policy should be conservative
+and observable.
+
+## Related Files
+
+- `catalog-live.ts`: normalizes live `models.dev` data.
+- `catalog-live.test.ts`: tests catalog normalization behavior.
+- `catalog.generated.ts`: checked-in generated provider/model catalog.
+- `../../scripts/generate-models.ts`: writes generated catalog output.
+- `../providers/ai-sdk.ts`: passes `maxOutputTokens` into AI SDK.
+- `../providers/gateway.ts`: resolves per-request/default `maxTokens`.

--- a/sdk/packages/llms/src/catalog/catalog-live.test.ts
+++ b/sdk/packages/llms/src/catalog/catalog-live.test.ts
@@ -34,7 +34,7 @@ describe("models-dev-catalog", () => {
 		).toBe(128_000);
 	});
 
-	it("discounts max output tokens only when the raw context limit matches output", () => {
+	it("preserves reported output limits even when context matches output", () => {
 		const providerModels = normalizeModelsDevProviderModels({
 			openai: {
 				models: {
@@ -62,7 +62,7 @@ describe("models-dev-catalog", () => {
 		).toBe(272_000);
 		expect(
 			providerModels["openai-native"]?.["context-output-equal"]?.maxTokens,
-		).toBe(204);
+		).toBe(4096);
 	});
 
 	it("normalizes payload with model filtering and defaults", () => {
@@ -174,7 +174,7 @@ describe("models-dev-catalog", () => {
 					name: "claude-defaults",
 					contextWindow: undefined,
 					maxInputTokens: 4096,
-					maxTokens: 204,
+					maxTokens: 4096,
 					capabilities: ["tools"],
 					pricing: {
 						input: 0,
@@ -191,7 +191,7 @@ describe("models-dev-catalog", () => {
 					name: "claude-older",
 					contextWindow: undefined,
 					maxInputTokens: 4096,
-					maxTokens: 204,
+					maxTokens: 4096,
 					capabilities: ["tools"],
 					pricing: {
 						input: 0,

--- a/sdk/packages/llms/src/catalog/catalog-live.ts
+++ b/sdk/packages/llms/src/catalog/catalog-live.ts
@@ -86,7 +86,7 @@ function toCapabilities(model: ModelsDevModel): ModelInfo["capabilities"] {
 	) {
 		capabilities.push("prompt-cache");
 	}
-	return capabilities;
+	return Array.from(new Set(capabilities));
 }
 
 function toStatus(status: string | undefined): ModelInfo["status"] {
@@ -114,20 +114,16 @@ export function resolveMaxInputTokens(
 
 function toModelInfo(modelId: string, model: ModelsDevModel): ModelInfo {
 	// If context or output limits are missing, default to DEFAULT_MAX_INPUT_TOKENS and DEFAULT_MAX_TOKENS respectively.
-	// If context and max are the same value, assume max tokens should be 5% of that value to avoid overallocation.
 	const maxInputTokens = resolveMaxInputTokens(model.limit);
 	const outputToken = model.limit?.output ?? DEFAULT_MAX_TOKENS;
 	const rawContextLimit = model.limit?.context;
-	const discountContextLimit = rawContextLimit ?? DEFAULT_MAX_INPUT_TOKENS;
-	const discounted =
-		discountContextLimit === outputToken ? outputToken * 0.05 : outputToken;
 
 	return {
 		id: modelId,
 		name: model.name || modelId,
 		contextWindow: rawContextLimit,
 		maxInputTokens,
-		maxTokens: Math.floor(discounted),
+		maxTokens: Math.floor(outputToken),
 		capabilities: toCapabilities(model),
 		pricing: {
 			input: model.cost?.input ?? 0,

--- a/sdk/packages/llms/src/catalog/catalog.generated.ts
+++ b/sdk/packages/llms/src/catalog/catalog.generated.ts
@@ -14,7 +14,7 @@ export const GENERATED_PROVIDER_MODELS: {
 	version: number;
 	providers: Record<string, Record<string, ModelInfo>>;
 } = {
-	version: 1779302019893,
+	version: 1779326530734,
 	providers: {
 		aihubmix: {
 			"glm-5v-turbo": {
@@ -114,7 +114,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Grok 4.3",
 				contextWindow: 1000000,
 				maxInputTokens: 1000000,
-				maxTokens: 50000,
+				maxTokens: 1000000,
 				capabilities: [
 					"images",
 					"tools",
@@ -1669,7 +1669,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Kimi K2.6",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: [
 					"images",
 					"tools",
@@ -1708,7 +1708,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "MiniMax-M2.5",
 				contextWindow: 204000,
 				maxInputTokens: 204000,
-				maxTokens: 10200,
+				maxTokens: 204000,
 				capabilities: ["tools", "reasoning", "temperature"],
 				pricing: {
 					input: 0.3,
@@ -1772,7 +1772,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "GLM 4.6",
 				contextWindow: 200000,
 				maxInputTokens: 200000,
-				maxTokens: 10000,
+				maxTokens: 200000,
 				capabilities: ["tools", "temperature"],
 				pricing: {
 					input: 0.6,
@@ -1804,7 +1804,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "GPT OSS 120B",
 				contextWindow: 128000,
 				maxInputTokens: 128000,
-				maxTokens: 6400,
+				maxTokens: 128000,
 				capabilities: ["tools", "reasoning", "temperature"],
 				pricing: {
 					input: 0.1,
@@ -2738,7 +2738,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Qwen/Qwen3-VL-235B-A22B-Instruct",
 				contextWindow: 262000,
 				maxInputTokens: 262000,
-				maxTokens: 13100,
+				maxTokens: 262000,
 				capabilities: ["images", "tools", "structured_output", "temperature"],
 				pricing: {
 					input: 0.3,
@@ -2935,7 +2935,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Qwen3 32B (dense)",
 				contextWindow: 16384,
 				maxInputTokens: 16384,
-				maxTokens: 819,
+				maxTokens: 16384,
 				capabilities: [
 					"tools",
 					"reasoning",
@@ -2988,7 +2988,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Qwen/Qwen3-Next-80B-A3B-Instruct",
 				contextWindow: 262000,
 				maxInputTokens: 262000,
-				maxTokens: 13100,
+				maxTokens: 262000,
 				capabilities: ["tools", "structured_output", "temperature"],
 				pricing: {
 					input: 0.14,
@@ -3655,7 +3655,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Kimi K2.6",
 				contextWindow: 262000,
 				maxInputTokens: 262000,
-				maxTokens: 13100,
+				maxTokens: 262000,
 				capabilities: [
 					"images",
 					"tools",
@@ -3677,7 +3677,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "MiniMax-M2.7",
 				contextWindow: 196608,
 				maxInputTokens: 196608,
-				maxTokens: 9830,
+				maxTokens: 196608,
 				capabilities: ["tools", "reasoning", "temperature", "prompt-cache"],
 				pricing: {
 					input: 0.3,
@@ -3731,7 +3731,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "MiniMax-M2.5",
 				contextWindow: 196608,
 				maxInputTokens: 196608,
-				maxTokens: 9830,
+				maxTokens: 196608,
 				capabilities: ["tools", "reasoning", "temperature", "prompt-cache"],
 				pricing: {
 					input: 0.3,
@@ -3763,7 +3763,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Kimi K2.5",
 				contextWindow: 256000,
 				maxInputTokens: 256000,
-				maxTokens: 12800,
+				maxTokens: 256000,
 				capabilities: [
 					"images",
 					"tools",
@@ -3785,7 +3785,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Kimi K2.5 Turbo",
 				contextWindow: 256000,
 				maxInputTokens: 256000,
-				maxTokens: 12800,
+				maxTokens: 256000,
 				capabilities: ["images", "tools", "reasoning", "temperature"],
 				pricing: {
 					input: 0,
@@ -3801,7 +3801,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "MiniMax-M2.1",
 				contextWindow: 200000,
 				maxInputTokens: 200000,
-				maxTokens: 10000,
+				maxTokens: 200000,
 				capabilities: ["tools", "reasoning", "temperature", "prompt-cache"],
 				pricing: {
 					input: 0.3,
@@ -3817,7 +3817,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "GLM 4.7",
 				contextWindow: 198000,
 				maxInputTokens: 198000,
-				maxTokens: 9900,
+				maxTokens: 198000,
 				capabilities: ["tools", "reasoning", "temperature", "prompt-cache"],
 				pricing: {
 					input: 0.6,
@@ -3833,7 +3833,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "DeepSeek V3.2",
 				contextWindow: 160000,
 				maxInputTokens: 160000,
-				maxTokens: 8000,
+				maxTokens: 160000,
 				capabilities: ["tools", "reasoning", "temperature", "prompt-cache"],
 				pricing: {
 					input: 0.56,
@@ -3849,7 +3849,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Kimi K2 Thinking",
 				contextWindow: 256000,
 				maxInputTokens: 256000,
-				maxTokens: 12800,
+				maxTokens: 256000,
 				capabilities: ["tools", "reasoning", "temperature", "prompt-cache"],
 				pricing: {
 					input: 0.6,
@@ -3865,7 +3865,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "DeepSeek V3.1",
 				contextWindow: 163840,
 				maxInputTokens: 163840,
-				maxTokens: 8192,
+				maxTokens: 163840,
 				capabilities: ["tools", "reasoning", "temperature"],
 				pricing: {
 					input: 0.56,
@@ -3913,7 +3913,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "GLM 4.5 Air",
 				contextWindow: 131072,
 				maxInputTokens: 131072,
-				maxTokens: 6553,
+				maxTokens: 131072,
 				capabilities: ["tools", "reasoning", "temperature"],
 				pricing: {
 					input: 0.22,
@@ -3929,7 +3929,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "GLM 4.5",
 				contextWindow: 131072,
 				maxInputTokens: 131072,
-				maxTokens: 6553,
+				maxTokens: 131072,
 				capabilities: ["tools", "reasoning", "temperature"],
 				pricing: {
 					input: 0.55,
@@ -4496,7 +4496,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Llama 3.1 8B Instant",
 				contextWindow: 131072,
 				maxInputTokens: 131072,
-				maxTokens: 6553,
+				maxTokens: 131072,
 				capabilities: ["tools", "temperature"],
 				pricing: {
 					input: 0.05,
@@ -4536,7 +4536,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Kimi-K2.6",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: [
 					"images",
 					"tools",
@@ -4660,7 +4660,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Kimi-K2.5",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: [
 					"images",
 					"tools",
@@ -4746,7 +4746,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Kimi-K2-Thinking",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: ["tools", "reasoning", "temperature", "prompt-cache"],
 				pricing: {
 					input: 0.6,
@@ -4874,7 +4874,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "DeepSeek-R1-0528",
 				contextWindow: 163840,
 				maxInputTokens: 163840,
-				maxTokens: 8192,
+				maxTokens: 163840,
 				capabilities: ["tools", "reasoning", "temperature"],
 				pricing: {
 					input: 3,
@@ -5003,7 +5003,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "IBM: Granite 4.1 8B",
 				contextWindow: 131072,
 				maxInputTokens: 131072,
-				maxTokens: 6553,
+				maxTokens: 131072,
 				capabilities: ["tools", "temperature", "prompt-cache"],
 				pricing: {
 					input: 0.05,
@@ -5018,7 +5018,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Mistral: Mistral Medium 3.5",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: [
 					"images",
 					"tools",
@@ -5192,7 +5192,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "MoonshotAI: Kimi Latest",
 				contextWindow: 262142,
 				maxInputTokens: 262142,
-				maxTokens: 13107,
+				maxTokens: 262142,
 				capabilities: [
 					"images",
 					"tools",
@@ -5399,7 +5399,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Tencent: Hy3 Preview",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: ["tools", "reasoning", "temperature", "prompt-cache"],
 				pricing: {
 					input: 0.066,
@@ -5540,7 +5540,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Google: Gemma 4 26B A4B",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: ["images", "tools", "reasoning", "temperature"],
 				pricing: {
 					input: 0.12,
@@ -5570,7 +5570,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Arcee AI: Trinity Large Thinking",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: ["tools", "reasoning", "temperature"],
 				pricing: {
 					input: 0.22,
@@ -5606,7 +5606,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "xAI: Grok 4.20",
 				contextWindow: 2000000,
 				maxInputTokens: 2000000,
-				maxTokens: 100000,
+				maxTokens: 2000000,
 				capabilities: [
 					"images",
 					"files",
@@ -5658,7 +5658,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Reka Edge",
 				contextWindow: 16384,
 				maxInputTokens: 16384,
-				maxTokens: 819,
+				maxTokens: 16384,
 				capabilities: ["images", "tools", "temperature"],
 				pricing: {
 					input: 0.1,
@@ -5758,7 +5758,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Mistral: Mistral Small 4",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: [
 					"images",
 					"tools",
@@ -5869,7 +5869,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "NVIDIA: Nemotron 3 Super (free)",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: ["tools", "reasoning", "temperature"],
 				pricing: {
 					input: 0,
@@ -5884,7 +5884,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "NVIDIA: Nemotron 3 Super",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: ["tools", "reasoning", "temperature", "prompt-cache"],
 				pricing: {
 					input: 0.1,
@@ -6169,7 +6169,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "MiniMax: MiniMax M2.5",
 				contextWindow: 196608,
 				maxInputTokens: 196608,
-				maxTokens: 9830,
+				maxTokens: 196608,
 				capabilities: ["tools", "reasoning", "temperature", "prompt-cache"],
 				pricing: {
 					input: 0.25,
@@ -6250,7 +6250,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "StepFun: Step 3.5 Flash",
 				contextWindow: 256000,
 				maxInputTokens: 256000,
-				maxTokens: 12800,
+				maxTokens: 256000,
 				capabilities: ["tools", "reasoning", "temperature", "prompt-cache"],
 				pricing: {
 					input: 0.1,
@@ -6573,7 +6573,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Arcee AI: Trinity Mini",
 				contextWindow: 131072,
 				maxInputTokens: 131072,
-				maxTokens: 6553,
+				maxTokens: 131072,
 				capabilities: ["tools", "reasoning", "temperature"],
 				pricing: {
 					input: 0.045,
@@ -6603,7 +6603,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Prime Intellect: INTELLECT-3",
 				contextWindow: 131072,
 				maxInputTokens: 131072,
-				maxTokens: 6553,
+				maxTokens: 131072,
 				capabilities: ["tools", "reasoning", "temperature"],
 				pricing: {
 					input: 0.2,
@@ -6760,7 +6760,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "MiniMax: MiniMax M2",
 				contextWindow: 196608,
 				maxInputTokens: 196608,
-				maxTokens: 9830,
+				maxTokens: 196608,
 				capabilities: ["tools", "reasoning", "temperature", "prompt-cache"],
 				pricing: {
 					input: 0.255,
@@ -6916,7 +6916,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Z.ai: GLM 4.6",
 				contextWindow: 204800,
 				maxInputTokens: 204800,
-				maxTokens: 10240,
+				maxTokens: 204800,
 				capabilities: ["tools", "reasoning", "temperature", "prompt-cache"],
 				pricing: {
 					input: 0.39,
@@ -6931,7 +6931,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Z.ai: GLM 4.6V",
 				contextWindow: 131072,
 				maxInputTokens: 131072,
-				maxTokens: 6553,
+				maxTokens: 131072,
 				capabilities: ["images", "tools", "reasoning", "temperature"],
 				pricing: {
 					input: 0.3,
@@ -7035,7 +7035,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Tongyi DeepResearch 30B A3B",
 				contextWindow: 131072,
 				maxInputTokens: 131072,
-				maxTokens: 6553,
+				maxTokens: 131072,
 				capabilities: ["tools", "reasoning", "temperature"],
 				pricing: {
 					input: 0.09,
@@ -7221,7 +7221,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "StepFun: Step 3.5 Flash (free)",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: ["tools", "reasoning", "temperature"],
 				pricing: {
 					input: 0,
@@ -7459,7 +7459,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Qwen: Qwen3 30B A3B Instruct 2507",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: ["tools", "temperature", "prompt-cache"],
 				pricing: {
 					input: 0.09,
@@ -7519,7 +7519,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Qwen: Qwen3 235B A22B Thinking 2507",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: ["tools", "reasoning", "temperature"],
 				pricing: {
 					input: 0.11,
@@ -7691,7 +7691,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Mistral: Mistral Small 3.2 24B",
 				contextWindow: 131072,
 				maxInputTokens: 131072,
-				maxTokens: 6553,
+				maxTokens: 131072,
 				capabilities: ["images", "tools", "temperature", "prompt-cache"],
 				pricing: {
 					input: 0.06,
@@ -8044,7 +8044,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Qwen: Qwen3 14B",
 				contextWindow: 40960,
 				maxInputTokens: 40960,
-				maxTokens: 2048,
+				maxTokens: 40960,
 				capabilities: ["tools", "reasoning", "temperature", "prompt-cache"],
 				pricing: {
 					input: 0.06,
@@ -8074,7 +8074,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Qwen: Qwen3 30B A3B",
 				contextWindow: 40960,
 				maxInputTokens: 40960,
-				maxTokens: 2048,
+				maxTokens: 40960,
 				capabilities: ["tools", "reasoning", "temperature", "prompt-cache"],
 				pricing: {
 					input: 0.08,
@@ -8171,7 +8171,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Mistral: Saba",
 				contextWindow: 32768,
 				maxInputTokens: 32768,
-				maxTokens: 1638,
+				maxTokens: 32768,
 				capabilities: ["tools", "temperature"],
 				pricing: {
 					input: 0.2,
@@ -8372,7 +8372,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "DeepSeek: DeepSeek V3",
 				contextWindow: 163840,
 				maxInputTokens: 163840,
-				maxTokens: 8192,
+				maxTokens: 163840,
 				capabilities: ["tools", "temperature", "prompt-cache"],
 				pricing: {
 					input: 0.32,
@@ -8417,7 +8417,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Qwen: Qwen3 32B",
 				contextWindow: 40960,
 				maxInputTokens: 40960,
-				maxTokens: 2048,
+				maxTokens: 40960,
 				capabilities: ["tools", "reasoning", "temperature", "prompt-cache"],
 				pricing: {
 					input: 0.08,
@@ -8483,7 +8483,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "TheDrummer: UnslopNemo 12B",
 				contextWindow: 32768,
 				maxInputTokens: 32768,
-				maxTokens: 1638,
+				maxTokens: 32768,
 				capabilities: ["tools", "temperature"],
 				pricing: {
 					input: 0.4,
@@ -8528,7 +8528,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "TheDrummer: Rocinante 12B",
 				contextWindow: 32768,
 				maxInputTokens: 32768,
-				maxTokens: 1638,
+				maxTokens: 32768,
 				capabilities: ["tools", "temperature"],
 				pricing: {
 					input: 0.17,
@@ -8684,7 +8684,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Meta: Llama 3.1 8B Instruct",
 				contextWindow: 16384,
 				maxInputTokens: 16384,
-				maxTokens: 819,
+				maxTokens: 16384,
 				capabilities: ["tools", "temperature"],
 				pricing: {
 					input: 0.02,
@@ -8809,7 +8809,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Sao10k: Llama 3 Euryale 70B v2.1",
 				contextWindow: 8192,
 				maxInputTokens: 8192,
-				maxTokens: 409,
+				maxTokens: 8192,
 				capabilities: ["tools", "temperature"],
 				pricing: {
 					input: 1.48,
@@ -9205,7 +9205,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Kimi K2.6",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: [
 					"images",
 					"tools",
@@ -9228,7 +9228,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Kimi K2.5",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: [
 					"images",
 					"tools",
@@ -9250,7 +9250,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Kimi K2 Thinking",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: ["tools", "reasoning", "temperature", "prompt-cache"],
 				pricing: {
 					input: 0.6,
@@ -9266,7 +9266,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Kimi K2 Thinking Turbo",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: ["tools", "reasoning", "temperature", "prompt-cache"],
 				pricing: {
 					input: 1.15,
@@ -9282,7 +9282,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Kimi K2 0905",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: ["tools", "temperature", "prompt-cache"],
 				pricing: {
 					input: 0.6,
@@ -9298,7 +9298,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Kimi K2 Turbo",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: ["tools", "temperature", "prompt-cache"],
 				pricing: {
 					input: 2.4,
@@ -9935,7 +9935,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "deepseek-v4-flash",
 				contextWindow: 1048576,
 				maxInputTokens: 1048576,
-				maxTokens: 52428,
+				maxTokens: 1048576,
 				capabilities: ["tools", "reasoning"],
 				pricing: {
 					input: 0,
@@ -9951,7 +9951,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "deepseek-v4-pro",
 				contextWindow: 1048576,
 				maxInputTokens: 1048576,
-				maxTokens: 52428,
+				maxTokens: 1048576,
 				capabilities: ["tools", "reasoning"],
 				pricing: {
 					input: 0,
@@ -9967,7 +9967,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "kimi-k2.6",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: ["images", "tools", "reasoning"],
 				pricing: {
 					input: 0,
@@ -9983,7 +9983,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "gemma4:31b",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: ["images", "tools", "reasoning"],
 				pricing: {
 					input: 0,
@@ -10015,7 +10015,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "minimax-m2.7",
 				contextWindow: 196608,
 				maxInputTokens: 196608,
-				maxTokens: 9830,
+				maxTokens: 196608,
 				capabilities: ["tools", "reasoning"],
 				pricing: {
 					input: 0,
@@ -10111,7 +10111,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "kimi-k2.5",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: ["images", "tools", "reasoning"],
 				pricing: {
 					input: 0,
@@ -10191,7 +10191,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "devstral-2:123b",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: ["tools"],
 				pricing: {
 					input: 0,
@@ -10207,7 +10207,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "devstral-small-2:24b",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: ["images", "tools"],
 				pricing: {
 					input: 0,
@@ -10239,7 +10239,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "mistral-large-3:675b",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: ["images", "tools"],
 				pricing: {
 					input: 0,
@@ -10271,7 +10271,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "kimi-k2-thinking",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: ["tools", "reasoning"],
 				pricing: {
 					input: 0,
@@ -10367,7 +10367,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "deepseek-v3.1:671b",
 				contextWindow: 163840,
 				maxInputTokens: 163840,
-				maxTokens: 8192,
+				maxTokens: 163840,
 				capabilities: ["tools", "reasoning"],
 				pricing: {
 					input: 0,
@@ -10431,7 +10431,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "kimi-k2:1t",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: ["tools"],
 				pricing: {
 					input: 0,
@@ -11333,7 +11333,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "GPT-4",
 				contextWindow: 8192,
 				maxInputTokens: 8192,
-				maxTokens: 409,
+				maxTokens: 8192,
 				capabilities: ["tools", "temperature"],
 				pricing: {
 					input: 30,
@@ -11491,7 +11491,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Granite 4.1 8B",
 				contextWindow: 131072,
 				maxInputTokens: 131072,
-				maxTokens: 6553,
+				maxTokens: 131072,
 				capabilities: [
 					"tools",
 					"structured_output",
@@ -11512,7 +11512,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Mistral Medium 3.5",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: [
 					"images",
 					"files",
@@ -11535,7 +11535,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Grok 4.3",
 				contextWindow: 1000000,
 				maxInputTokens: 1000000,
-				maxTokens: 50000,
+				maxTokens: 1000000,
 				capabilities: [
 					"images",
 					"tools",
@@ -11716,7 +11716,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "MoonshotAI Kimi Latest",
 				contextWindow: 262142,
 				maxInputTokens: 262142,
-				maxTokens: 13107,
+				maxTokens: 262142,
 				capabilities: [
 					"images",
 					"tools",
@@ -11829,7 +11829,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Qwen3.6 35B A3B",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: [
 					"images",
 					"tools",
@@ -12022,7 +12022,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Hy3 preview",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: ["tools", "reasoning", "temperature", "prompt-cache"],
 				pricing: {
 					input: 0.066,
@@ -12126,7 +12126,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Kimi K2.6",
 				contextWindow: 262142,
 				maxInputTokens: 262142,
-				maxTokens: 13107,
+				maxTokens: 262142,
 				capabilities: [
 					"images",
 					"tools",
@@ -12196,7 +12196,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "GLM 5.1",
 				contextWindow: 202800,
 				maxInputTokens: 202800,
-				maxTokens: 10140,
+				maxTokens: 202800,
 				capabilities: [
 					"tools",
 					"reasoning",
@@ -12217,7 +12217,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Gemma 4 26B A4B ",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: [
 					"images",
 					"tools",
@@ -12316,7 +12316,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Trinity Large Thinking",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: [
 					"tools",
 					"reasoning",
@@ -12376,7 +12376,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Grok 4.20",
 				contextWindow: 2000000,
 				maxInputTokens: 2000000,
-				maxTokens: 100000,
+				maxTokens: 2000000,
 				capabilities: [
 					"images",
 					"files",
@@ -12421,7 +12421,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Reka Edge",
 				contextWindow: 16384,
 				maxInputTokens: 16384,
-				maxTokens: 819,
+				maxTokens: 16384,
 				capabilities: ["images", "tools", "structured_output", "temperature"],
 				pricing: {
 					input: 0.1,
@@ -12542,7 +12542,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Mistral Small 4",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: [
 					"images",
 					"tools",
@@ -12581,7 +12581,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Nemotron 3 Super",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: ["tools", "reasoning", "temperature"],
 				pricing: {
 					input: 0.09,
@@ -12597,7 +12597,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Nemotron 3 Super (free)",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: [
 					"tools",
 					"reasoning",
@@ -13027,7 +13027,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "MiniMax M2.5",
 				contextWindow: 196608,
 				maxInputTokens: 196608,
-				maxTokens: 9830,
+				maxTokens: 196608,
 				capabilities: [
 					"tools",
 					"reasoning",
@@ -13131,7 +13131,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Qwen3 Coder Next",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: [
 					"tools",
 					"structured_output",
@@ -13189,7 +13189,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Trinity Large Preview",
 				contextWindow: 131000,
 				maxInputTokens: 131000,
-				maxTokens: 6550,
+				maxTokens: 131000,
 				capabilities: ["tools", "structured_output", "temperature"],
 				pricing: {
 					input: 0.15,
@@ -13205,7 +13205,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Kimi K2.5",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: [
 					"images",
 					"tools",
@@ -13228,7 +13228,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Solar Pro 3",
 				contextWindow: 128000,
 				maxInputTokens: 128000,
-				maxTokens: 6400,
+				maxTokens: 128000,
 				capabilities: [
 					"tools",
 					"reasoning",
@@ -13370,7 +13370,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "MiniMax M2.1",
 				contextWindow: 196608,
 				maxInputTokens: 196608,
-				maxTokens: 9830,
+				maxTokens: 196608,
 				capabilities: [
 					"tools",
 					"reasoning",
@@ -13454,7 +13454,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Nemotron 3 Nano 30B A3B (free)",
 				contextWindow: 256000,
 				maxInputTokens: 256000,
-				maxTokens: 12800,
+				maxTokens: 256000,
 				capabilities: ["tools", "reasoning", "temperature"],
 				pricing: {
 					input: 0,
@@ -13553,7 +13553,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Devstral 2 2512",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: [
 					"files",
 					"tools",
@@ -13628,7 +13628,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Rnj 1 Instruct",
 				contextWindow: 32768,
 				maxInputTokens: 32768,
-				maxTokens: 1638,
+				maxTokens: 32768,
 				capabilities: ["tools", "structured_output", "temperature"],
 				pricing: {
 					input: 0.15,
@@ -13682,7 +13682,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Ministral 3 14B 2512",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: [
 					"images",
 					"tools",
@@ -13704,7 +13704,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Ministral 3 3B 2512",
 				contextWindow: 131072,
 				maxInputTokens: 131072,
-				maxTokens: 6553,
+				maxTokens: 131072,
 				capabilities: [
 					"images",
 					"tools",
@@ -13726,7 +13726,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Ministral 3 8B 2512",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: [
 					"images",
 					"tools",
@@ -13748,7 +13748,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Trinity Mini",
 				contextWindow: 131072,
 				maxInputTokens: 131072,
-				maxTokens: 6553,
+				maxTokens: 131072,
 				capabilities: [
 					"tools",
 					"reasoning",
@@ -13791,7 +13791,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Mistral Large 3 2512",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: [
 					"images",
 					"files",
@@ -13814,7 +13814,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "INTELLECT-3",
 				contextWindow: 131072,
 				maxInputTokens: 131072,
-				maxTokens: 6553,
+				maxTokens: 131072,
 				capabilities: [
 					"tools",
 					"reasoning",
@@ -13948,7 +13948,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Kimi K2 Thinking",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: [
 					"tools",
 					"reasoning",
@@ -13985,7 +13985,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Voxtral Small 24B 2507",
 				contextWindow: 32000,
 				maxInputTokens: 32000,
-				maxTokens: 1600,
+				maxTokens: 32000,
 				capabilities: [
 					"files",
 					"tools",
@@ -14023,7 +14023,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Nemotron Nano 12B 2 VL (free)",
 				contextWindow: 128000,
 				maxInputTokens: 128000,
-				maxTokens: 6400,
+				maxTokens: 128000,
 				capabilities: ["images", "tools", "reasoning", "temperature"],
 				pricing: {
 					input: 0,
@@ -14039,7 +14039,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "MiniMax M2",
 				contextWindow: 196608,
 				maxInputTokens: 196608,
-				maxTokens: 9830,
+				maxTokens: 196608,
 				capabilities: [
 					"tools",
 					"reasoning",
@@ -14473,7 +14473,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Tongyi DeepResearch 30B A3B",
 				contextWindow: 131072,
 				maxInputTokens: 131072,
-				maxTokens: 6553,
+				maxTokens: 131072,
 				capabilities: [
 					"tools",
 					"reasoning",
@@ -14527,7 +14527,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Qwen3 Next 80B A3B Instruct (free)",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: ["tools", "structured_output", "temperature"],
 				pricing: {
 					input: 0,
@@ -14623,7 +14623,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Nemotron Nano 9B V2 (free)",
 				contextWindow: 128000,
 				maxInputTokens: 128000,
-				maxTokens: 6400,
+				maxTokens: 128000,
 				capabilities: [
 					"tools",
 					"reasoning",
@@ -14644,7 +14644,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Kimi K2 0905",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: ["tools", "structured_output", "temperature"],
 				pricing: {
 					input: 0.6,
@@ -14660,7 +14660,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Qwen3 30B A3B Thinking 2507",
 				contextWindow: 131072,
 				maxInputTokens: 131072,
-				maxTokens: 6553,
+				maxTokens: 131072,
 				capabilities: [
 					"tools",
 					"reasoning",
@@ -14927,7 +14927,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "gpt-oss-120b (free)",
 				contextWindow: 131072,
 				maxInputTokens: 131072,
-				maxTokens: 6553,
+				maxTokens: 131072,
 				capabilities: ["tools", "reasoning", "temperature"],
 				pricing: {
 					input: 0,
@@ -14943,7 +14943,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "gpt-oss-20b",
 				contextWindow: 131072,
 				maxInputTokens: 131072,
-				maxTokens: 6553,
+				maxTokens: 131072,
 				capabilities: [
 					"tools",
 					"reasoning",
@@ -14980,7 +14980,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Codestral 2508",
 				contextWindow: 256000,
 				maxInputTokens: 256000,
-				maxTokens: 12800,
+				maxTokens: 256000,
 				capabilities: [
 					"files",
 					"tools",
@@ -15018,7 +15018,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Qwen3 30B A3B Instruct 2507",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: ["tools", "structured_output", "temperature"],
 				pricing: {
 					input: 0.09,
@@ -15103,7 +15103,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "GLM 4 32B ",
 				contextWindow: 128000,
 				maxInputTokens: 128000,
-				maxTokens: 6400,
+				maxTokens: 128000,
 				capabilities: ["tools", "temperature"],
 				pricing: {
 					input: 0.1,
@@ -15135,7 +15135,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Qwen3 Coder 480B A35B (free)",
 				contextWindow: 262000,
 				maxInputTokens: 262000,
-				maxTokens: 13100,
+				maxTokens: 262000,
 				capabilities: ["tools", "temperature"],
 				pricing: {
 					input: 0,
@@ -15207,7 +15207,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Devstral Medium",
 				contextWindow: 131072,
 				maxInputTokens: 131072,
-				maxTokens: 6553,
+				maxTokens: 131072,
 				capabilities: [
 					"files",
 					"tools",
@@ -15229,7 +15229,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Devstral Small 1.1",
 				contextWindow: 131072,
 				maxInputTokens: 131072,
-				maxTokens: 6553,
+				maxTokens: 131072,
 				capabilities: [
 					"files",
 					"tools",
@@ -15469,7 +15469,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Mistral Medium 3",
 				contextWindow: 131072,
 				maxInputTokens: 131072,
-				maxTokens: 6553,
+				maxTokens: 131072,
 				capabilities: [
 					"images",
 					"files",
@@ -15507,7 +15507,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Qwen3 14B",
 				contextWindow: 40960,
 				maxInputTokens: 40960,
-				maxTokens: 2048,
+				maxTokens: 40960,
 				capabilities: [
 					"tools",
 					"reasoning",
@@ -15837,7 +15837,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Saba",
 				contextWindow: 32768,
 				maxInputTokens: 32768,
-				maxTokens: 1638,
+				maxTokens: 32768,
 				capabilities: [
 					"files",
 					"tools",
@@ -16105,7 +16105,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Mistral Large 2407",
 				contextWindow: 131072,
 				maxInputTokens: 131072,
-				maxTokens: 6553,
+				maxTokens: 131072,
 				capabilities: [
 					"files",
 					"tools",
@@ -16127,7 +16127,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Mistral Large 2411",
 				contextWindow: 131072,
 				maxInputTokens: 131072,
-				maxTokens: 6553,
+				maxTokens: 131072,
 				capabilities: [
 					"files",
 					"tools",
@@ -16149,7 +16149,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Pixtral Large 2411",
 				contextWindow: 131072,
 				maxInputTokens: 131072,
-				maxTokens: 6553,
+				maxTokens: 131072,
 				capabilities: [
 					"images",
 					"files",
@@ -16172,7 +16172,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "UnslopNemo 12B",
 				contextWindow: 32768,
 				maxInputTokens: 32768,
-				maxTokens: 1638,
+				maxTokens: 32768,
 				capabilities: ["tools", "structured_output", "temperature"],
 				pricing: {
 					input: 0.4,
@@ -16203,7 +16203,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Qwen2.5 7B Instruct",
 				contextWindow: 32768,
 				maxInputTokens: 32768,
-				maxTokens: 1638,
+				maxTokens: 32768,
 				capabilities: ["tools", "temperature"],
 				pricing: {
 					input: 0.04,
@@ -16219,7 +16219,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Rocinante 12B",
 				contextWindow: 32768,
 				maxInputTokens: 32768,
-				maxTokens: 1638,
+				maxTokens: 32768,
 				capabilities: ["tools", "structured_output", "temperature"],
 				pricing: {
 					input: 0.17,
@@ -16337,7 +16337,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Llama 3.1 8B Instruct",
 				contextWindow: 16384,
 				maxInputTokens: 16384,
-				maxTokens: 819,
+				maxTokens: 16384,
 				capabilities: ["tools", "structured_output", "temperature"],
 				pricing: {
 					input: 0.02,
@@ -16353,7 +16353,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Mistral Nemo",
 				contextWindow: 131072,
 				maxInputTokens: 131072,
-				maxTokens: 6553,
+				maxTokens: 131072,
 				capabilities: ["tools", "structured_output", "temperature"],
 				pricing: {
 					input: 0.02,
@@ -16415,7 +16415,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Llama 3 Euryale 70B v2.1",
 				contextWindow: 8192,
 				maxInputTokens: 8192,
-				maxTokens: 409,
+				maxTokens: 8192,
 				capabilities: ["tools", "temperature"],
 				pricing: {
 					input: 1.48,
@@ -16475,7 +16475,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Mixtral 8x22B Instruct",
 				contextWindow: 65536,
 				maxInputTokens: 65536,
-				maxTokens: 3276,
+				maxTokens: 65536,
 				capabilities: [
 					"files",
 					"tools",
@@ -16529,7 +16529,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Mistral Large",
 				contextWindow: 128000,
 				maxInputTokens: 128000,
-				maxTokens: 6400,
+				maxTokens: 128000,
 				capabilities: [
 					"files",
 					"tools",
@@ -16583,7 +16583,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Auto Router",
 				contextWindow: 2000000,
 				maxInputTokens: 2000000,
-				maxTokens: 100000,
+				maxTokens: 2000000,
 				capabilities: [
 					"images",
 					"files",
@@ -18117,7 +18117,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Qwen3 Coder Next FP8",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: ["tools", "reasoning", "temperature"],
 				pricing: {
 					input: 0.5,
@@ -18133,7 +18133,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Kimi K2.5",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: ["images", "tools", "reasoning", "temperature"],
 				pricing: {
 					input: 0.5,
@@ -18149,7 +18149,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Rnj-1 Instruct",
 				contextWindow: 32768,
 				maxInputTokens: 32768,
-				maxTokens: 1638,
+				maxTokens: 32768,
 				capabilities: ["tools", "temperature"],
 				pricing: {
 					input: 0.15,
@@ -18165,7 +18165,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "DeepSeek V3.1",
 				contextWindow: 131072,
 				maxInputTokens: 131072,
-				maxTokens: 6553,
+				maxTokens: 131072,
 				capabilities: ["tools", "reasoning", "temperature"],
 				pricing: {
 					input: 0.6,
@@ -18181,7 +18181,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "GPT OSS 120B",
 				contextWindow: 131072,
 				maxInputTokens: 131072,
-				maxTokens: 6553,
+				maxTokens: 131072,
 				capabilities: ["tools", "reasoning", "temperature"],
 				pricing: {
 					input: 0.15,
@@ -18197,7 +18197,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Qwen3 235B A22B Instruct 2507 FP8",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: ["tools", "reasoning", "temperature"],
 				pricing: {
 					input: 0.2,
@@ -18213,7 +18213,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Qwen3 Coder 480B A35B Instruct",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: ["tools", "temperature"],
 				pricing: {
 					input: 2,
@@ -18229,7 +18229,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "DeepSeek V3",
 				contextWindow: 131072,
 				maxInputTokens: 131072,
-				maxTokens: 6553,
+				maxTokens: 131072,
 				capabilities: ["tools", "reasoning", "temperature"],
 				pricing: {
 					input: 1.25,
@@ -18245,7 +18245,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Llama 3.3 70B",
 				contextWindow: 131072,
 				maxInputTokens: 131072,
-				maxTokens: 6553,
+				maxTokens: 131072,
 				capabilities: ["tools", "temperature"],
 				pricing: {
 					input: 0.88,
@@ -18336,7 +18336,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Grok 4.3",
 				contextWindow: 1000000,
 				maxInputTokens: 1000000,
-				maxTokens: 50000,
+				maxTokens: 1000000,
 				capabilities: [
 					"images",
 					"files",
@@ -18430,7 +18430,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Qwen 3.6 27B",
 				contextWindow: 256000,
 				maxInputTokens: 256000,
-				maxTokens: 12800,
+				maxTokens: 256000,
 				capabilities: ["images", "files", "tools", "reasoning", "temperature"],
 				pricing: {
 					input: 0.6,
@@ -18507,7 +18507,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Kimi K2.6",
 				contextWindow: 262000,
 				maxInputTokens: 262000,
-				maxTokens: 13100,
+				maxTokens: 262000,
 				capabilities: [
 					"images",
 					"files",
@@ -18546,7 +18546,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "GLM 5.1",
 				contextWindow: 202752,
 				maxInputTokens: 202752,
-				maxTokens: 10137,
+				maxTokens: 202752,
 				capabilities: [
 					"images",
 					"files",
@@ -18663,7 +18663,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Kat Coder Pro V2",
 				contextWindow: 256000,
 				maxInputTokens: 256000,
-				maxTokens: 12800,
+				maxTokens: 256000,
 				capabilities: ["tools", "reasoning", "temperature", "prompt-cache"],
 				pricing: {
 					input: 0.3,
@@ -18786,7 +18786,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Mistral Small (latest)",
 				contextWindow: 256000,
 				maxInputTokens: 256000,
-				maxTokens: 12800,
+				maxTokens: 256000,
 				capabilities: ["images", "tools", "reasoning", "temperature"],
 				pricing: {
 					input: 0.15,
@@ -18834,7 +18834,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Grok 4.20 Multi Agent Beta",
 				contextWindow: 2000000,
 				maxInputTokens: 2000000,
-				maxTokens: 100000,
+				maxTokens: 2000000,
 				capabilities: ["tools", "reasoning", "temperature", "prompt-cache"],
 				pricing: {
 					input: 2,
@@ -18850,7 +18850,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Grok 4.20 Beta Non-Reasoning",
 				contextWindow: 2000000,
 				maxInputTokens: 2000000,
-				maxTokens: 100000,
+				maxTokens: 2000000,
 				capabilities: [
 					"images",
 					"files",
@@ -18872,7 +18872,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Grok 4.20 Beta Reasoning",
 				contextWindow: 2000000,
 				maxInputTokens: 2000000,
-				maxTokens: 100000,
+				maxTokens: 2000000,
 				capabilities: [
 					"images",
 					"files",
@@ -18895,7 +18895,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Grok 4.20 Multi-Agent",
 				contextWindow: 2000000,
 				maxInputTokens: 2000000,
-				maxTokens: 100000,
+				maxTokens: 2000000,
 				capabilities: ["tools", "reasoning", "temperature", "prompt-cache"],
 				pricing: {
 					input: 2,
@@ -18911,7 +18911,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Grok 4.20 Non-Reasoning",
 				contextWindow: 2000000,
 				maxInputTokens: 2000000,
-				maxTokens: 100000,
+				maxTokens: 2000000,
 				capabilities: [
 					"images",
 					"files",
@@ -18933,7 +18933,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Grok 4.20 Reasoning",
 				contextWindow: 2000000,
 				maxInputTokens: 2000000,
-				maxTokens: 100000,
+				maxTokens: 2000000,
 				capabilities: [
 					"images",
 					"files",
@@ -19064,7 +19064,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Mercury 2",
 				contextWindow: 128000,
 				maxInputTokens: 128000,
-				maxTokens: 6400,
+				maxTokens: 128000,
 				capabilities: ["tools", "reasoning", "temperature", "prompt-cache"],
 				pricing: {
 					input: 0.25,
@@ -19243,7 +19243,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Kimi K2.5",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: ["images", "tools", "reasoning", "temperature"],
 				pricing: {
 					input: 0.6,
@@ -19314,7 +19314,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Devstral 2",
 				contextWindow: 256000,
 				maxInputTokens: 256000,
-				maxTokens: 12800,
+				maxTokens: 256000,
 				capabilities: ["tools", "temperature"],
 				pricing: {
 					input: 0,
@@ -19369,7 +19369,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "INTELLECT 3",
 				contextWindow: 131072,
 				maxInputTokens: 131072,
-				maxTokens: 6553,
+				maxTokens: 131072,
 				capabilities: ["tools", "reasoning", "temperature"],
 				pricing: {
 					input: 0.2,
@@ -19431,7 +19431,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Kimi K2 Thinking",
 				contextWindow: 216144,
 				maxInputTokens: 216144,
-				maxTokens: 10807,
+				maxTokens: 216144,
 				capabilities: ["tools", "reasoning", "temperature", "prompt-cache"],
 				pricing: {
 					input: 0.47,
@@ -19447,7 +19447,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Kimi K2 Thinking Turbo",
 				contextWindow: 262114,
 				maxInputTokens: 262114,
-				maxTokens: 13105,
+				maxTokens: 262114,
 				capabilities: ["tools", "reasoning", "temperature", "prompt-cache"],
 				pricing: {
 					input: 1.15,
@@ -19463,7 +19463,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "MiniMax M2",
 				contextWindow: 262114,
 				maxInputTokens: 262114,
-				maxTokens: 13105,
+				maxTokens: 262114,
 				capabilities: ["tools", "reasoning", "temperature", "prompt-cache"],
 				pricing: {
 					input: 0.27,
@@ -19634,7 +19634,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "DeepSeek V3.2 Exp",
 				contextWindow: 163840,
 				maxInputTokens: 163840,
-				maxTokens: 8192,
+				maxTokens: 163840,
 				capabilities: ["tools", "reasoning", "temperature"],
 				pricing: {
 					input: 0.27,
@@ -19910,7 +19910,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Nvidia Nemotron Nano 9B V2",
 				contextWindow: 131072,
 				maxInputTokens: 131072,
-				maxTokens: 6553,
+				maxTokens: 131072,
 				capabilities: ["tools", "reasoning", "temperature"],
 				pricing: {
 					input: 0.04,
@@ -19926,7 +19926,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "GLM 4.5V",
 				contextWindow: 66000,
 				maxInputTokens: 66000,
-				maxTokens: 3300,
+				maxTokens: 66000,
 				capabilities: ["images", "tools", "reasoning", "temperature"],
 				pricing: {
 					input: 0.6,
@@ -20194,7 +20194,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "GPT OSS 120B",
 				contextWindow: 131072,
 				maxInputTokens: 131072,
-				maxTokens: 6553,
+				maxTokens: 131072,
 				capabilities: ["tools", "reasoning", "temperature"],
 				pricing: {
 					input: 0.1,
@@ -20226,7 +20226,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "GLM 4.5",
 				contextWindow: 131072,
 				maxInputTokens: 131072,
-				maxTokens: 6553,
+				maxTokens: 131072,
 				capabilities: ["tools", "reasoning", "temperature"],
 				pricing: {
 					input: 0.6,
@@ -20258,7 +20258,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Qwen3 Coder Plus",
 				contextWindow: 1000000,
 				maxInputTokens: 1000000,
-				maxTokens: 50000,
+				maxTokens: 1000000,
 				capabilities: ["tools", "temperature"],
 				pricing: {
 					input: 1,
@@ -20274,7 +20274,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Qwen3 Coder Next",
 				contextWindow: 256000,
 				maxInputTokens: 256000,
-				maxTokens: 12800,
+				maxTokens: 256000,
 				capabilities: ["tools", "reasoning", "temperature"],
 				pricing: {
 					input: 0.5,
@@ -20524,7 +20524,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Devstral Small 2",
 				contextWindow: 256000,
 				maxInputTokens: 256000,
-				maxTokens: 12800,
+				maxTokens: 256000,
 				capabilities: ["tools", "temperature"],
 				pricing: {
 					input: 0,
@@ -20781,7 +20781,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Qwen3 235B A22B Thinking 2507",
 				contextWindow: 262114,
 				maxInputTokens: 262114,
-				maxTokens: 13105,
+				maxTokens: 262114,
 				capabilities: ["images", "files", "tools", "reasoning", "temperature"],
 				pricing: {
 					input: 0.3,
@@ -20893,7 +20893,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Magistral Small",
 				contextWindow: 128000,
 				maxInputTokens: 128000,
-				maxTokens: 6400,
+				maxTokens: 128000,
 				capabilities: ["tools", "reasoning", "temperature"],
 				pricing: {
 					input: 0.5,
@@ -21028,7 +21028,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Trinity Large Preview",
 				contextWindow: 131000,
 				maxInputTokens: 131000,
-				maxTokens: 6550,
+				maxTokens: 131000,
 				capabilities: ["tools", "temperature"],
 				pricing: {
 					input: 0.25,
@@ -21229,7 +21229,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Nvidia Nemotron Nano 12B V2 VL",
 				contextWindow: 131072,
 				maxInputTokens: 131072,
-				maxTokens: 6553,
+				maxTokens: 131072,
 				capabilities: ["images", "tools", "reasoning", "temperature"],
 				pricing: {
 					input: 0.2,
@@ -21261,7 +21261,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Pixtral Large (latest)",
 				contextWindow: 128000,
 				maxInputTokens: 128000,
-				maxTokens: 6400,
+				maxTokens: 128000,
 				capabilities: ["images", "tools", "temperature"],
 				pricing: {
 					input: 2,
@@ -21321,7 +21321,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Ministral 3B (latest)",
 				contextWindow: 128000,
 				maxInputTokens: 128000,
-				maxTokens: 6400,
+				maxTokens: 128000,
 				capabilities: ["tools", "temperature"],
 				pricing: {
 					input: 0.04,
@@ -21337,7 +21337,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Ministral 8B (latest)",
 				contextWindow: 128000,
 				maxInputTokens: 128000,
-				maxTokens: 6400,
+				maxTokens: 128000,
 				capabilities: ["tools", "temperature"],
 				pricing: {
 					input: 0.1,
@@ -21385,7 +21385,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Pixtral 12B",
 				contextWindow: 128000,
 				maxInputTokens: 128000,
-				maxTokens: 6400,
+				maxTokens: 128000,
 				capabilities: ["images", "tools", "temperature"],
 				pricing: {
 					input: 0.15,
@@ -21395,22 +21395,6 @@ export const GENERATED_PROVIDER_MODELS: {
 				},
 				releaseDate: "2024-09-01",
 				family: "pixtral",
-			},
-			"xai/grok-2-vision": {
-				id: "xai/grok-2-vision",
-				name: "Grok 2 Vision",
-				contextWindow: 8192,
-				maxInputTokens: 8192,
-				maxTokens: 4096,
-				capabilities: ["images", "tools", "temperature", "prompt-cache"],
-				pricing: {
-					input: 2,
-					output: 10,
-					cacheRead: 2,
-					cacheWrite: 0,
-				},
-				releaseDate: "2024-08-20",
-				family: "grok",
 			},
 			"meta/llama-3.1-70b": {
 				id: "meta/llama-3.1-70b",
@@ -21559,7 +21543,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Mixtral 8x22B",
 				contextWindow: 64000,
 				maxInputTokens: 64000,
-				maxTokens: 3200,
+				maxTokens: 64000,
 				capabilities: ["tools", "temperature"],
 				pricing: {
 					input: 2,
@@ -21928,7 +21912,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "NVIDIA Nemotron 3 Super 120B",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: ["tools", "structured_output", "temperature"],
 				pricing: {
 					input: 0.2,
@@ -21944,7 +21928,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "MiniMax M2.5",
 				contextWindow: 196608,
 				maxInputTokens: 196608,
-				maxTokens: 9830,
+				maxTokens: 196608,
 				capabilities: ["tools", "structured_output", "temperature"],
 				pricing: {
 					input: 0.3,
@@ -21960,7 +21944,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "GLM 5",
 				contextWindow: 200000,
 				maxInputTokens: 200000,
-				maxTokens: 10000,
+				maxTokens: 200000,
 				capabilities: ["tools", "structured_output", "temperature"],
 				pricing: {
 					input: 1,
@@ -21976,7 +21960,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Kimi K2.5",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: [
 					"images",
 					"tools",
@@ -21998,7 +21982,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "DeepSeek V3.1",
 				contextWindow: 161000,
 				maxInputTokens: 161000,
-				maxTokens: 8050,
+				maxTokens: 161000,
 				capabilities: ["tools", "structured_output", "temperature"],
 				pricing: {
 					input: 0.55,
@@ -22014,7 +21998,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "gpt-oss-120b",
 				contextWindow: 131072,
 				maxInputTokens: 131072,
-				maxTokens: 6553,
+				maxTokens: 131072,
 				capabilities: ["tools", "structured_output", "temperature"],
 				pricing: {
 					input: 0.15,
@@ -22030,7 +22014,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "gpt-oss-20b",
 				contextWindow: 131072,
 				maxInputTokens: 131072,
-				maxTokens: 6553,
+				maxTokens: 131072,
 				capabilities: ["tools", "structured_output", "temperature"],
 				pricing: {
 					input: 0.05,
@@ -22046,7 +22030,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Qwen3 30B A3B Instruct 2507",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: ["tools", "structured_output", "temperature"],
 				pricing: {
 					input: 0.1,
@@ -22062,7 +22046,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Qwen3-235B-A22B-Thinking-2507",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: [
 					"tools",
 					"reasoning",
@@ -22083,7 +22067,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Qwen3-Coder-480B-A35B-Instruct",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: ["tools", "structured_output", "temperature"],
 				pricing: {
 					input: 1,
@@ -22099,7 +22083,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "OpenPipe Qwen3 14B Instruct",
 				contextWindow: 32768,
 				maxInputTokens: 32768,
-				maxTokens: 1638,
+				maxTokens: 32768,
 				capabilities: ["tools", "structured_output", "temperature"],
 				pricing: {
 					input: 0.05,
@@ -22115,7 +22099,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Qwen3 235B A22B Instruct 2507",
 				contextWindow: 262144,
 				maxInputTokens: 262144,
-				maxTokens: 13107,
+				maxTokens: 262144,
 				capabilities: ["tools", "structured_output", "temperature"],
 				pricing: {
 					input: 0.1,
@@ -22131,7 +22115,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Llama 4 Scout 17B 16E Instruct",
 				contextWindow: 64000,
 				maxInputTokens: 64000,
-				maxTokens: 3200,
+				maxTokens: 64000,
 				capabilities: [
 					"images",
 					"tools",
@@ -22153,7 +22137,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Phi-4-mini-instruct",
 				contextWindow: 128000,
 				maxInputTokens: 128000,
-				maxTokens: 6400,
+				maxTokens: 128000,
 				capabilities: [
 					"tools",
 					"reasoning",
@@ -22174,7 +22158,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Llama-3.3-70B-Instruct",
 				contextWindow: 128000,
 				maxInputTokens: 128000,
-				maxTokens: 6400,
+				maxTokens: 128000,
 				capabilities: [
 					"tools",
 					"reasoning",
@@ -22195,7 +22179,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Llama 3.1 70B",
 				contextWindow: 128000,
 				maxInputTokens: 128000,
-				maxTokens: 6400,
+				maxTokens: 128000,
 				capabilities: ["tools", "structured_output", "temperature"],
 				pricing: {
 					input: 0.8,
@@ -22211,7 +22195,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Meta-Llama-3.1-8B-Instruct",
 				contextWindow: 128000,
 				maxInputTokens: 128000,
-				maxTokens: 6400,
+				maxTokens: 128000,
 				capabilities: [
 					"tools",
 					"reasoning",
@@ -22234,9 +22218,10 @@ export const GENERATED_PROVIDER_MODELS: {
 				name: "Grok Build 0.1",
 				contextWindow: 256000,
 				maxInputTokens: 256000,
-				maxTokens: 12800,
+				maxTokens: 256000,
 				capabilities: [
 					"images",
+					"files",
 					"tools",
 					"reasoning",
 					"structured_output",
@@ -22260,6 +22245,7 @@ export const GENERATED_PROVIDER_MODELS: {
 				maxTokens: 30000,
 				capabilities: [
 					"images",
+					"files",
 					"tools",
 					"reasoning",
 					"temperature",
@@ -22271,7 +22257,7 @@ export const GENERATED_PROVIDER_MODELS: {
 					cacheRead: 0.2,
 					cacheWrite: 0,
 				},
-				releaseDate: "2026-05-01",
+				releaseDate: "2026-04-17",
 				family: "grok",
 			},
 			"grok-4.20-0309-non-reasoning": {
@@ -22280,10 +22266,16 @@ export const GENERATED_PROVIDER_MODELS: {
 				contextWindow: 2000000,
 				maxInputTokens: 2000000,
 				maxTokens: 30000,
-				capabilities: ["images", "tools", "temperature", "prompt-cache"],
+				capabilities: [
+					"images",
+					"files",
+					"tools",
+					"temperature",
+					"prompt-cache",
+				],
 				pricing: {
-					input: 2,
-					output: 6,
+					input: 1.25,
+					output: 2.5,
 					cacheRead: 0.2,
 					cacheWrite: 0,
 				},
@@ -22298,146 +22290,19 @@ export const GENERATED_PROVIDER_MODELS: {
 				maxTokens: 30000,
 				capabilities: [
 					"images",
+					"files",
 					"tools",
 					"reasoning",
 					"temperature",
 					"prompt-cache",
 				],
 				pricing: {
-					input: 2,
-					output: 6,
+					input: 1.25,
+					output: 2.5,
 					cacheRead: 0.2,
 					cacheWrite: 0,
 				},
 				releaseDate: "2026-03-09",
-				family: "grok",
-			},
-			"grok-2-1212": {
-				id: "grok-2-1212",
-				name: "Grok 2 (1212)",
-				contextWindow: 131072,
-				maxInputTokens: 131072,
-				maxTokens: 8192,
-				capabilities: ["tools", "temperature", "prompt-cache"],
-				pricing: {
-					input: 2,
-					output: 10,
-					cacheRead: 2,
-					cacheWrite: 0,
-				},
-				releaseDate: "2024-12-12",
-				family: "grok",
-			},
-			"grok-beta": {
-				id: "grok-beta",
-				name: "Grok Beta",
-				contextWindow: 131072,
-				maxInputTokens: 131072,
-				maxTokens: 4096,
-				capabilities: ["tools", "temperature", "prompt-cache"],
-				pricing: {
-					input: 5,
-					output: 15,
-					cacheRead: 5,
-					cacheWrite: 0,
-				},
-				releaseDate: "2024-11-01",
-				family: "grok-beta",
-			},
-			"grok-vision-beta": {
-				id: "grok-vision-beta",
-				name: "Grok Vision Beta",
-				contextWindow: 8192,
-				maxInputTokens: 8192,
-				maxTokens: 4096,
-				capabilities: ["images", "tools", "temperature", "prompt-cache"],
-				pricing: {
-					input: 5,
-					output: 15,
-					cacheRead: 5,
-					cacheWrite: 0,
-				},
-				releaseDate: "2024-11-01",
-				family: "grok-vision",
-			},
-			"grok-2": {
-				id: "grok-2",
-				name: "Grok 2",
-				contextWindow: 131072,
-				maxInputTokens: 131072,
-				maxTokens: 8192,
-				capabilities: ["tools", "temperature", "prompt-cache"],
-				pricing: {
-					input: 2,
-					output: 10,
-					cacheRead: 2,
-					cacheWrite: 0,
-				},
-				releaseDate: "2024-08-20",
-				family: "grok",
-			},
-			"grok-2-latest": {
-				id: "grok-2-latest",
-				name: "Grok 2 Latest",
-				contextWindow: 131072,
-				maxInputTokens: 131072,
-				maxTokens: 8192,
-				capabilities: ["tools", "temperature", "prompt-cache"],
-				pricing: {
-					input: 2,
-					output: 10,
-					cacheRead: 2,
-					cacheWrite: 0,
-				},
-				releaseDate: "2024-08-20",
-				family: "grok",
-			},
-			"grok-2-vision": {
-				id: "grok-2-vision",
-				name: "Grok 2 Vision",
-				contextWindow: 8192,
-				maxInputTokens: 8192,
-				maxTokens: 4096,
-				capabilities: ["images", "tools", "temperature", "prompt-cache"],
-				pricing: {
-					input: 2,
-					output: 10,
-					cacheRead: 2,
-					cacheWrite: 0,
-				},
-				releaseDate: "2024-08-20",
-				family: "grok",
-			},
-			"grok-2-vision-1212": {
-				id: "grok-2-vision-1212",
-				name: "Grok 2 Vision (1212)",
-				contextWindow: 8192,
-				maxInputTokens: 8192,
-				maxTokens: 4096,
-				capabilities: ["images", "tools", "temperature", "prompt-cache"],
-				pricing: {
-					input: 2,
-					output: 10,
-					cacheRead: 2,
-					cacheWrite: 0,
-				},
-				releaseDate: "2024-08-20",
-				family: "grok",
-			},
-			"grok-2-vision-latest": {
-				id: "grok-2-vision-latest",
-				name: "Grok 2 Vision Latest",
-				contextWindow: 8192,
-				maxInputTokens: 8192,
-				maxTokens: 4096,
-				capabilities: ["images", "tools", "temperature", "prompt-cache"],
-				pricing: {
-					input: 2,
-					output: 10,
-					cacheRead: 2,
-					cacheWrite: 0,
-				},
-				releaseDate: "2024-08-20",
 				family: "grok",
 			},
 		},

--- a/sdk/packages/llms/src/providers/compat.test.ts
+++ b/sdk/packages/llms/src/providers/compat.test.ts
@@ -1,6 +1,56 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createGatewayApiHandler, toGatewayRequestMessages } from "./compat";
 import type { Message } from "./types";
+
+const streamTextSpy = vi.fn();
+const openaiCompatibleFactorySpy = vi.fn();
+const openaiCompatibleSpy = vi.fn((modelId: string) => ({
+	modelId,
+	family: "openai-compatible",
+}));
+
+vi.mock("ai", () => ({
+	jsonSchema: (schema: unknown, options: unknown) => ({
+		jsonSchema: schema,
+		...(options && typeof options === "object" ? options : {}),
+	}),
+	streamText: (input: unknown) => streamTextSpy(input),
+	wrapLanguageModel: ({ model }: { model: unknown }) => model,
+}));
+
+vi.mock("@ai-sdk/openai-compatible", () => ({
+	createOpenAICompatible: (config: unknown) => {
+		openaiCompatibleFactorySpy(config);
+		return (modelId: string) => openaiCompatibleSpy(modelId);
+	},
+}));
+
+vi.mock("@ai-sdk/openai", () => ({
+	createOpenAI: () => ({
+		responses: (modelId: string) => ({ modelId, family: "openai" }),
+	}),
+}));
+
+vi.mock("@ai-sdk/anthropic", () => ({
+	createAnthropic: () => (modelId: string) => ({
+		modelId,
+		family: "anthropic",
+	}),
+}));
+
+vi.mock("@ai-sdk/google", () => ({
+	createGoogleGenerativeAI: () => (modelId: string) => ({
+		modelId,
+		family: "google",
+	}),
+}));
+
+vi.mock("ai-sdk-provider-codex-cli", () => ({
+	createCodexExec: () => (modelId: string) => ({
+		modelId,
+		family: "openai-codex",
+	}),
+}));
 
 describe("createGatewayApiHandler.getMessages", () => {
 	it("preserves structured tool_result content for gateway requests", () => {
@@ -296,6 +346,90 @@ describe("createGatewayApiHandler.getMessages", () => {
 				},
 			],
 		});
+	});
+});
+
+describe("createGatewayApiHandler.createMessage", () => {
+	beforeEach(() => {
+		streamTextSpy.mockReset();
+		openaiCompatibleFactorySpy.mockReset();
+		openaiCompatibleSpy.mockClear();
+	});
+
+	it("caps catalog maxTokens before passing maxOutputTokens to AI SDK", async () => {
+		streamTextSpy.mockReturnValue({
+			fullStream: (async function* () {
+				yield { type: "finish", finishReason: "stop" };
+			})(),
+			usage: Promise.resolve({ inputTokens: 1, outputTokens: 1 }),
+		});
+
+		const handler = createGatewayApiHandler({
+			providerId: "openrouter",
+			clientType: "openai-compatible",
+			modelId: "z-ai/glm-5.1",
+			apiKey: "test-key",
+			knownModels: {
+				"z-ai/glm-5.1": {
+					id: "z-ai/glm-5.1",
+					name: "GLM 5.1",
+					contextWindow: 202_800,
+					maxInputTokens: 202_800,
+					maxTokens: 202_800,
+					capabilities: ["tools"],
+				},
+			},
+		});
+
+		for await (const _chunk of handler.createMessage("", [
+			{ role: "user", content: "Hello" },
+		])) {
+			// Drain the stream so the provider request is executed.
+		}
+
+		expect(streamTextSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				maxOutputTokens: 32_000,
+			}),
+		);
+	});
+
+	it("uses catalog maxTokens as the model output cap when below the default cap", async () => {
+		streamTextSpy.mockReturnValue({
+			fullStream: (async function* () {
+				yield { type: "finish", finishReason: "stop" };
+			})(),
+			usage: Promise.resolve({ inputTokens: 1, outputTokens: 1 }),
+		});
+
+		const handler = createGatewayApiHandler({
+			providerId: "openrouter",
+			clientType: "openai-compatible",
+			modelId: "small-output",
+			apiKey: "test-key",
+			knownModels: {
+				"small-output": {
+					id: "small-output",
+					name: "Small Output",
+					contextWindow: 202_800,
+					maxInputTokens: 202_800,
+					maxTokens: 8_192,
+					capabilities: ["tools"],
+				},
+			},
+		});
+
+		for await (const _chunk of handler.createMessage("", [
+			{ role: "user", content: "Hello" },
+		])) {
+			// Drain the stream so the provider request is executed.
+		}
+
+		expect(streamTextSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				maxOutputTokens: 8_192,
+			}),
+		);
 	});
 });
 

--- a/sdk/packages/llms/src/providers/gateway.test.ts
+++ b/sdk/packages/llms/src/providers/gateway.test.ts
@@ -1,7 +1,12 @@
 import type { AgentMessage, AgentModelEvent } from "@cline/shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { normalizeModelsDevProviderModels } from "../catalog/catalog-live";
-import { createGateway } from "./gateway";
+import {
+	DEFAULT_GATEWAY_MAX_OUTPUT_TOKENS,
+	createGateway,
+	estimateRequestInputTokens,
+	resolveGatewayRequestMaxTokens,
+} from "./gateway";
 
 const streamTextSpy = vi.fn();
 const openaiCompatibleFactorySpy = vi.fn();
@@ -136,6 +141,117 @@ describe("sdk-gateway", () => {
 		} else {
 			process.env.OPENROUTER_API_KEY = originalOpenRouterApiKey;
 		}
+	});
+
+	it("resolves request max tokens from explicit, model, default, and context caps", () => {
+		expect(
+			resolveGatewayRequestMaxTokens({
+				requestedMaxTokens: undefined,
+				model: { maxOutputTokens: 202_800, contextWindow: 202_800 },
+				estimatedInputTokens: 1_000,
+			}),
+		).toBe(DEFAULT_GATEWAY_MAX_OUTPUT_TOKENS);
+
+		expect(
+			resolveGatewayRequestMaxTokens({
+				requestedMaxTokens: 8_192,
+				model: { maxOutputTokens: 202_800, contextWindow: 202_800 },
+				estimatedInputTokens: 1_000,
+			}),
+		).toBe(8_192);
+
+		expect(
+			resolveGatewayRequestMaxTokens({
+				requestedMaxTokens: 202_800,
+				model: { maxOutputTokens: 202_800, contextWindow: 202_800 },
+				estimatedInputTokens: 201_500,
+				outputReserveTokens: 1_024,
+			}),
+		).toBe(276);
+
+		expect(
+			resolveGatewayRequestMaxTokens({
+				requestedMaxTokens: undefined,
+				model: {},
+				estimatedInputTokens: 1_000,
+			}),
+		).toBeUndefined();
+	});
+
+	it("does not collapse to one output token when estimated input exceeds context", () => {
+		const onContextOverflow = vi.fn();
+
+		expect(
+			resolveGatewayRequestMaxTokens({
+				requestedMaxTokens: 8_192,
+				model: { maxOutputTokens: 202_800, contextWindow: 10_000 },
+				estimatedInputTokens: 9_500,
+				outputReserveTokens: 1_024,
+				onContextOverflow,
+			}),
+		).toBeUndefined();
+		expect(onContextOverflow).toHaveBeenCalledWith({
+			contextWindow: 10_000,
+			estimatedInputTokens: 9_500,
+			reserveTokens: 1_024,
+		});
+	});
+
+	it("keeps estimating when request tools cannot be JSON stringified", () => {
+		const circularTool = {
+			name: "large_tool",
+			description: "x".repeat(12_000),
+		} as Record<string, unknown>;
+		circularTool.self = circularTool;
+
+		const estimatedTokens = estimateRequestInputTokens({
+			systemPrompt: "system",
+			messages: baseMessages,
+			tools: [circularTool] as never,
+		});
+
+		expect(estimatedTokens).toBeGreaterThan(4_000);
+	});
+
+	it("applies a conservative default output cap for catalog models", async () => {
+		const createProvider = vi.fn(() => ({
+			async *stream(request: { maxTokens?: number }) {
+				expect(request.maxTokens).toBe(DEFAULT_GATEWAY_MAX_OUTPUT_TOKENS);
+				yield { type: "finish", reason: "stop" } satisfies AgentModelEvent;
+			},
+		}));
+
+		const gateway = createGateway({
+			builtins: false,
+			providers: [
+				{
+					manifest: {
+						id: "custom-provider",
+						name: "CustomProvider",
+						defaultModelId: "large-output",
+						models: [
+							{
+								id: "large-output",
+								name: "Large Output",
+								providerId: "custom-provider",
+								contextWindow: 202_800,
+								maxInputTokens: 202_800,
+								maxOutputTokens: 202_800,
+							},
+						],
+					},
+					createProvider,
+				},
+			],
+		});
+
+		await collect(
+			await gateway.stream({
+				providerId: "custom-provider",
+				modelId: "large-output",
+				messages: baseMessages,
+			}),
+		);
 	});
 
 	it("keeps custom provider loading lazy until first use", async () => {

--- a/sdk/packages/llms/src/providers/gateway.ts
+++ b/sdk/packages/llms/src/providers/gateway.ts
@@ -1,9 +1,12 @@
+import { estimateTokens } from "@cline/shared";
 import type {
+	AgentMessage,
 	AgentModel,
 	AgentModelEvent,
 	AgentModelRequest,
 	BasicLogger,
 	GatewayConfig,
+	GatewayModelDefinition,
 	GatewayModelHandleOptions,
 	GatewayModelSelection,
 	GatewayProviderRegistration,
@@ -15,6 +18,9 @@ import { BUILTIN_PROVIDER_REGISTRATIONS } from "./builtins-runtime";
 import { GatewayRegistry } from "./registry";
 
 export type * from "@cline/shared";
+
+export const DEFAULT_GATEWAY_MAX_OUTPUT_TOKENS = 32_000;
+const GATEWAY_OUTPUT_RESERVE_TOKENS = 1_024;
 
 export interface Gateway {
 	registerProvider(registration: GatewayProviderRegistration): this;
@@ -97,6 +103,108 @@ class GatewayModelAdapter implements AgentModel {
 	}
 }
 
+function isPositiveFiniteNumber(value: unknown): value is number {
+	return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+function safeStringify(value: unknown): string {
+	const seen = new WeakSet<object>();
+	try {
+		return (
+			JSON.stringify(value, (_key, nestedValue: unknown) => {
+				if (typeof nestedValue === "bigint") {
+					return nestedValue.toString();
+				}
+				if (typeof nestedValue !== "object" || nestedValue === null) {
+					return nestedValue;
+				}
+				if (seen.has(nestedValue)) {
+					return "[Circular]";
+				}
+				seen.add(nestedValue);
+				return nestedValue;
+			}) ?? ""
+		);
+	} catch {
+		return String(value ?? "");
+	}
+}
+
+export function estimateRequestInputTokens(
+	request: Pick<GatewayStreamRequest, "systemPrompt" | "messages" | "tools">,
+): number {
+	let serialized: string;
+	try {
+		serialized = JSON.stringify({
+			systemPrompt: request.systemPrompt,
+			messages: request.messages,
+			tools: request.tools,
+		});
+	} catch {
+		serialized = [
+			safeStringify(request.systemPrompt),
+			safeStringify(request.messages as readonly AgentMessage[]),
+			safeStringify(request.tools),
+		].join("\n");
+	}
+	// This deliberately over-estimates a little so the context cap leaves room
+	// for provider formatting, tool schema overhead, and tokenizer drift.
+	return estimateTokens(serialized.length);
+}
+
+export function resolveGatewayRequestMaxTokens(input: {
+	requestedMaxTokens?: number;
+	model: Pick<GatewayModelDefinition, "contextWindow" | "maxOutputTokens">;
+	estimatedInputTokens: number;
+	defaultMaxOutputTokens?: number;
+	outputReserveTokens?: number;
+	onContextOverflow?: (details: {
+		contextWindow: number;
+		estimatedInputTokens: number;
+		reserveTokens: number;
+	}) => void;
+}): number | undefined {
+	const caps: number[] = [];
+	if (isPositiveFiniteNumber(input.requestedMaxTokens)) {
+		caps.push(Math.floor(input.requestedMaxTokens));
+	} else {
+		const defaultMaxOutputTokens =
+			input.defaultMaxOutputTokens ?? DEFAULT_GATEWAY_MAX_OUTPUT_TOKENS;
+		if (
+			isPositiveFiniteNumber(input.model.maxOutputTokens) ||
+			isPositiveFiniteNumber(input.model.contextWindow)
+		) {
+			caps.push(defaultMaxOutputTokens);
+		}
+	}
+
+	if (isPositiveFiniteNumber(input.model.maxOutputTokens)) {
+		caps.push(Math.floor(input.model.maxOutputTokens));
+	}
+
+	if (isPositiveFiniteNumber(input.model.contextWindow)) {
+		const reserveTokens =
+			input.outputReserveTokens ?? GATEWAY_OUTPUT_RESERVE_TOKENS;
+		const remainingContext =
+			input.model.contextWindow - input.estimatedInputTokens - reserveTokens;
+		if (remainingContext <= 0) {
+			input.onContextOverflow?.({
+				contextWindow: input.model.contextWindow,
+				estimatedInputTokens: input.estimatedInputTokens,
+				reserveTokens,
+			});
+			return undefined;
+		}
+		caps.push(Math.floor(remainingContext));
+	}
+
+	if (caps.length === 0) {
+		return undefined;
+	}
+
+	return Math.max(1, Math.floor(Math.min(...caps)));
+}
+
 export class DefaultGateway implements Gateway {
 	private readonly registry: GatewayRegistry;
 	private readonly logger: BasicLogger | undefined;
@@ -168,11 +276,28 @@ export class DefaultGateway implements Gateway {
 			request.providerId,
 		);
 		const provider = await providerRecord.createProvider(providerRecord.config);
+		const maxTokens = resolveGatewayRequestMaxTokens({
+			requestedMaxTokens: request.maxTokens,
+			model: resolved.model,
+			estimatedInputTokens: estimateRequestInputTokens(request),
+			onContextOverflow: (details) => {
+				this.logger?.log(
+					"Estimated prompt tokens exceed model context window",
+					{
+						severity: "warn",
+						providerId: resolved.provider.id,
+						modelId: resolved.model.id,
+						...details,
+					},
+				);
+			},
+		});
 		const stream = await provider.stream(
 			{
 				...request,
 				modelId: resolved.model.id,
 				providerId: resolved.provider.id,
+				maxTokens,
 			},
 			{
 				provider: resolved.provider,


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

Linear: [ENG-2100](https://linear.app/cline-bot/issue/ENG-2100/fix-sdk-model-catalog-token-limit-semantics-and-gateway-request-caps)

Related context: #10934

### Description

This PR fixes SDK model catalog token-limit semantics around `models.dev` output limits.

Previously the live catalog normalizer applied a 5% discount to `maxTokens` whenever the provider-reported context limit matched the provider-reported output limit. That produced generated entries such as:

```ts
contextWindow: 202800,
maxInputTokens: 202800,
maxTokens: 10140,
```

The discounted value was not provider metadata, and it still did not guarantee `prompt + output <= contextWindow`. This PR changes the boundary:

- The generated catalog preserves provider-reported output limits.
- Gateway request construction applies conservative per-request output caps.
- Catalog field semantics are documented in `sdk/packages/llms/src/catalog/README.md`.

The gateway now resolves request `maxTokens` from:

- explicit request/user cap when provided
- model `maxOutputTokens`
- default SDK output cap of `32_000`
- remaining context after estimated prompt tokens and reserve

If estimated prompt tokens already exceed the model context window after reserve, the gateway logs a warning and leaves `maxTokens` undefined so the provider can surface the real prompt-too-large failure instead of silently requesting one output token.

The generated catalog refresh is isolated in its own commit. That file includes both the behavior change output and normal upstream `models.dev` churn.

Follow-up reserved-output-budget compaction work is tracked separately in [ENG-2101](https://linear.app/cline-bot/issue/ENG-2101/add-reserved-output-budget-to-sdk-compaction-prompt-packing).

### Test Procedure

Run from `sdk/`:

```bash
bun -F @cline/llms test src/providers/compat.test.ts src/catalog/catalog-live.test.ts src/providers/gateway.test.ts
bun -F @cline/llms typecheck
git diff --check HEAD~2..HEAD
```

Results:

- Focused llms tests passed: 77 tests.
- llms typecheck passed.
- Diff hygiene passed.

I also consulted Claude twice on the implementation. It initially flagged a silent `maxTokens: 1` overflow case, which is now fixed and covered by tests. It later flagged that the first chain test only proved default capping, so I added a value-sensitive test proving `ModelInfo.maxTokens` maps through to the gateway model output cap when below the default cap.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. SDK behavior and generated catalog changes only.

### Additional Notes

Commit split:

1. `fix(llms): preserve catalog output limits` - source, docs, and tests.
2. `chore(llms): regenerate model catalog` - generated catalog refresh only.
