### PR TITLE
Add Gemini 3.5 Flash to Gemini and Vertex providers

### DIFF
--- a/src/core/api/providers/__tests__/gemini.test.ts
+++ b/src/core/api/providers/__tests__/gemini.test.ts
@@ -44,6 +44,51 @@ describe("GeminiHandler", () => {
 		requestArgs.config.should.have.property("maxOutputTokens", 8_192)
 	})
 
+	it("supports Gemini 3.5 Flash model metadata", async () => {
+		const handler = new GeminiHandler({
+			geminiApiKey: "test-api-key",
+			apiModelId: "gemini-3.5-flash",
+		})
+
+		const model = handler.getModel()
+		model.id.should.equal("gemini-3.5-flash")
+		model.info.contextWindow!.should.equal(1_048_576)
+		model.info.inputPrice!.should.equal(1.5)
+		model.info.outputPrice!.should.equal(9)
+		model.info.cacheReadsPrice!.should.equal(0.15)
+		model.info.supportsReasoning!.should.equal(true)
+
+		const generateContentStream = sinon.stub().resolves(
+			createAsyncIterable([
+				{
+					responseId: "resp-35",
+					usageMetadata: {
+						promptTokenCount: 10,
+						candidatesTokenCount: 20,
+						cachedContentTokenCount: 0,
+						thoughtsTokenCount: 0,
+					},
+				},
+			]),
+		)
+		sinon.stub(handler as any, "ensureClient").returns({
+			models: { generateContentStream },
+		} as any)
+
+		for await (const _chunk of handler.createMessage("system", [{ role: "user", content: "hi" }] as any)) {
+			// Consume stream to trigger request execution.
+		}
+
+		const requestArgs = generateContentStream.firstCall.args[0] as Record<string, any>
+		requestArgs.model.should.equal("gemini-3.5-flash")
+		requestArgs.config.should.have.property("maxOutputTokens", 8_192)
+		requestArgs.config.thinkingConfig.should.deepEqual({
+			thinkingBudget: undefined,
+			thinkingLevel: "LOW",
+			includeThoughts: true,
+		})
+	})
+
 	it("does not set maxOutputTokens for non-Flash models", async () => {
 		const handler = new GeminiHandler({
 			geminiApiKey: "test-api-key",

--- a/src/core/api/providers/__tests__/vertex.test.ts
+++ b/src/core/api/providers/__tests__/vertex.test.ts
@@ -1,0 +1,23 @@
+import "should"
+import { vertexGlobalModels } from "@shared/api"
+import { VertexHandler } from "../vertex"
+
+describe("VertexHandler", () => {
+	it("supports Gemini 3.5 Flash model metadata", () => {
+		const handler = new VertexHandler({
+			vertexProjectId: "test-project",
+			vertexRegion: "global",
+			apiModelId: "gemini-3.5-flash",
+		})
+
+		const model = handler.getModel()
+		model.id.should.equal("gemini-3.5-flash")
+		model.info.contextWindow!.should.equal(1_048_576)
+		model.info.inputPrice!.should.equal(1.5)
+		model.info.outputPrice!.should.equal(9)
+		model.info.cacheReadsPrice!.should.equal(0.15)
+		model.info.supportsGlobalEndpoint!.should.equal(true)
+		model.info.supportsReasoning!.should.equal(true)
+		vertexGlobalModels.should.have.property("gemini-3.5-flash")
+	})
+})

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -979,6 +979,22 @@ export const OPENROUTER_PROVIDER_PREFERENCES: Record<string, { order: string[]; 
 export type VertexModelId = keyof typeof vertexModels
 export const vertexDefaultModelId: VertexModelId = "gemini-3-pro-preview"
 export const vertexModels = {
+	"gemini-3.5-flash": {
+		maxTokens: 65536,
+		contextWindow: 1_048_576,
+		supportsImages: true,
+		supportsPromptCache: true,
+		supportsGlobalEndpoint: true,
+		inputPrice: 1.5,
+		outputPrice: 9.0,
+		cacheReadsPrice: 0.15,
+		temperature: 1.0,
+		supportsReasoning: true,
+		thinkingConfig: {
+			geminiThinkingLevel: "low",
+			supportsThinkingLevel: true,
+		},
+	},
 	"gemini-3.1-pro-preview": {
 		maxTokens: 8192,
 		contextWindow: 1_048_576,
@@ -1466,6 +1482,20 @@ export const openAiModelInfoSaneDefaults: OpenAiCompatibleModelInfo = {
 export type GeminiModelId = keyof typeof geminiModels
 export const geminiDefaultModelId: GeminiModelId = "gemini-3.1-pro-preview"
 export const geminiModels = {
+	"gemini-3.5-flash": {
+		maxTokens: 65536,
+		contextWindow: 1_048_576,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 1.5,
+		outputPrice: 9.0,
+		cacheReadsPrice: 0.15,
+		supportsReasoning: true,
+		thinkingConfig: {
+			geminiThinkingLevel: "low",
+			supportsThinkingLevel: true,
+		},
+	},
 	"gemini-3.1-pro-preview": {
 		maxTokens: 65536,
 		contextWindow: 1_048_576,

--- a/src/utils/__tests__/model-utils.test.ts
+++ b/src/utils/__tests__/model-utils.test.ts
@@ -147,6 +147,7 @@ describe("isPoolsideModelFamily", () => {
 describe("isGeminiFlashModel", () => {
 	it("should return true for Gemini Flash model IDs", () => {
 		isGeminiFlashModel("google/gemini-2.5-flash").should.equal(true)
+		isGeminiFlashModel("google/gemini-3.5-flash").should.equal(true)
 		isGeminiFlashModel("google/gemini-3-flash-preview").should.equal(true)
 		isGeminiFlashModel("google/gemini-2.5-flash-lite").should.equal(true)
 	})
@@ -158,6 +159,7 @@ describe("isGeminiFlashModel", () => {
 
 	it("should return true for direct Gemini provider IDs", () => {
 		isGeminiFlashModel("gemini-2.5-flash").should.equal(true)
+		isGeminiFlashModel("gemini-3.5-flash").should.equal(true)
 		isGeminiFlashModel("gemini-3-flash-preview").should.equal(true)
 	})
 


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Adds the new `gemini-3.5-flash` model to the extension's static Google Gemini and GCP Vertex provider catalogs.

The model metadata follows Google's current docs for the stable model id, 1,048,576-token context window, 65,536 max output tokens, thinking support, prompt cache support, and standard/global pricing. The Vertex entry is marked as global-endpoint capable so it appears when users select the global region.

### Test Procedure

- Verified Google AI and Google Cloud docs for the `gemini-3.5-flash` model id, limits, capabilities, and pricing.
- Ran focused unit tests:
  `TS_NODE_PROJECT=./tsconfig.unit-test.json NODE_OPTIONS='--loader ts-node/esm' npx mocha --no-config --require ts-node/register --require source-map-support/register --require ./src/test/requires.ts src/core/api/providers/__tests__/gemini.test.ts src/core/api/providers/__tests__/vertex.test.ts src/utils/__tests__/model-utils.test.ts`
- Ran `npx tsc --noEmit --pretty false`.
- Ran focused Biome lint and format checks on the changed files.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

This keeps the legacy extension provider lists in sync with the newer model catalog entry for Gemini 3.5 Flash.
