### PR TITLE
feat(sdk): add Poolside provider

### DIFF
--- a/sdk/packages/core/src/services/llms/provider-defaults.test.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.test.ts
@@ -147,6 +147,70 @@ describe("resolveProviderConfig", () => {
 		expect(Object.keys(resolved?.knownModels ?? {})).toEqual(["local-llama"]);
 	});
 
+	it("loads Poolside models from the authenticated models endpoint", async () => {
+		const fetchMock = vi.fn(async () => {
+			return new Response(
+				JSON.stringify({
+					data: [
+						{
+							id: "poolside/laguna-xs.2",
+							name: "Poolside: Laguna XS.2",
+							description: "Poolside coding model",
+							context_length: 131_072,
+							max_completion_tokens: 8192,
+							supported_features: ["tools", "reasoning"],
+							supported_sampling_parameters: ["temperature"],
+							input_modalities: ["text"],
+							pricing: { prompt: "0", completion: "0" },
+						},
+					],
+				}),
+				{
+					status: 200,
+					headers: { "content-type": "application/json" },
+				},
+			);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const resolved = await resolveProviderConfig(
+			"poolside",
+			{ failOnError: true, cacheTtlMs: 0 },
+			{
+				providerId: "poolside",
+				modelId: "poolside/laguna-m.1",
+				apiKey: "poolside-key",
+				baseUrl: "https://inference.poolside.ai/v1",
+			},
+		);
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			"https://inference.poolside.ai/v1/models",
+			expect.objectContaining({
+				method: "GET",
+				headers: expect.objectContaining({
+					Authorization: "Bearer poolside-key",
+				}),
+			}),
+		);
+		expect(resolved?.knownModels?.["poolside/laguna-xs.2"]).toEqual(
+			expect.objectContaining({
+				name: "Poolside: Laguna XS.2",
+				contextWindow: 131_072,
+				maxInputTokens: 131_072,
+				maxTokens: 8192,
+				capabilities: expect.arrayContaining([
+					"streaming",
+					"tools",
+					"reasoning",
+					"temperature",
+				]),
+				pricing: { input: 0, output: 0 },
+				status: "active",
+			}),
+		);
+	});
+
 	it("derives ChatGPT subscription models from the generated OpenAI catalog", async () => {
 		const resolved = await resolveProviderConfig("openai-codex");
 		const openAiResolved = await resolveProviderConfig("openai-native");

--- a/sdk/packages/core/src/services/llms/provider-defaults.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.ts
@@ -358,6 +358,34 @@ interface HicapModelResponse {
 	id?: string;
 }
 
+interface PoolsideModelResponse {
+	id?: string;
+	name?: string;
+	description?: string;
+	context_length?: number;
+	max_completion_tokens?: number;
+	supported_features?: string[];
+	supported_sampling_parameters?: string[];
+	input_modalities?: string[];
+	pricing?: {
+		prompt?: number | string;
+		completion?: number | string;
+	};
+}
+
+function parseOptionalNumber(
+	value: number | string | undefined,
+): number | undefined {
+	if (typeof value === "number") {
+		return Number.isFinite(value) ? value : undefined;
+	}
+	if (typeof value === "string") {
+		const parsed = Number(value);
+		return Number.isFinite(parsed) ? parsed : undefined;
+	}
+	return undefined;
+}
+
 async function fetchHicapPrivateModels(
 	_config: ProviderConfig,
 	token: string,
@@ -389,6 +417,81 @@ async function fetchHicapPrivateModels(
 			supportsImages: true,
 			supportsPromptCache: true,
 		});
+	}
+	return models;
+}
+
+async function fetchPoolsidePrivateModels(
+	config: ProviderConfig,
+	token: string,
+): Promise<Record<string, ModelInfo>> {
+	const baseUrl =
+		normalizeBaseUrl(config.baseUrl) || "https://inference.poolside.ai/v1";
+	const endpoint = `${baseUrl.replace(/\/+$/, "")}/models`;
+	const response = await fetchWithTimeout(endpoint, {
+		method: "GET",
+		headers: {
+			Authorization: `Bearer ${token}`,
+			accept: "application/json",
+		},
+	});
+	if (!response.ok) {
+		throw new Error(`Poolside model refresh failed: HTTP ${response.status}`);
+	}
+
+	const payload = (await response.json()) as { data?: PoolsideModelResponse[] };
+	const entries = payload?.data ?? [];
+	const models: Record<string, ModelInfo> = {};
+	for (const model of entries) {
+		const id = model.id?.trim();
+		if (!id) {
+			continue;
+		}
+
+		const supportedFeatures = model.supported_features ?? [];
+		const supportedSamplingParameters =
+			model.supported_sampling_parameters ?? [];
+		const inputModalities = model.input_modalities ?? [];
+		const capabilities: NonNullable<ModelInfo["capabilities"]> = ["streaming"];
+		includeCapability(
+			capabilities,
+			"tools",
+			supportedFeatures.includes("tools"),
+		);
+		includeCapability(
+			capabilities,
+			"reasoning",
+			supportedFeatures.includes("reasoning"),
+		);
+		includeCapability(
+			capabilities,
+			"temperature",
+			supportedSamplingParameters.includes("temperature"),
+		);
+		includeCapability(
+			capabilities,
+			"images",
+			inputModalities.includes("image"),
+		);
+
+		const pricing = {
+			input: parseOptionalNumber(model.pricing?.prompt),
+			output: parseOptionalNumber(model.pricing?.completion),
+		};
+		models[id] = {
+			id,
+			name: model.name ?? id,
+			description: model.description,
+			contextWindow: model.context_length,
+			maxInputTokens: model.context_length,
+			maxTokens: model.max_completion_tokens,
+			capabilities,
+			pricing:
+				pricing.input !== undefined || pricing.output !== undefined
+					? pricing
+					: undefined,
+			status: "active",
+		};
 	}
 	return models;
 }
@@ -487,6 +590,7 @@ const PRIVATE_PROVIDER_MODEL_FETCHERS: Record<
 	baseten: fetchBasetenPrivateModels,
 	hicap: fetchHicapPrivateModels,
 	litellm: fetchLiteLlmPrivateModels,
+	poolside: fetchPoolsidePrivateModels,
 };
 
 const PUBLIC_MODELS_CACHE = new Map<

--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -330,6 +330,16 @@ const OPENAI_COMPATIBLE_SPECS: BuiltinSpec[] = [
 		defaults: { baseUrl: "https://api.groq.com/openai/v1" },
 	},
 	{
+		id: "poolside",
+		name: "Poolside",
+		description: "OpenAI-compatible code intelligence models",
+		family: "openai-compatible",
+		capabilities: ["tools", "reasoning"],
+		defaultModelId: "poolside/laguna-m.1",
+		apiKeyEnv: ["POOLSIDE_API_KEY"],
+		defaults: { baseUrl: "https://inference.poolside.ai/v1" },
+	},
+	{
 		id: "cerebras",
 		name: "Cerebras",
 		description: "Fast inference on Cerebras wafer-scale chips",

--- a/sdk/packages/llms/src/providers/ids.test.ts
+++ b/sdk/packages/llms/src/providers/ids.test.ts
@@ -81,6 +81,28 @@ describe("provider-ids", () => {
 		);
 	});
 
+	it("registers Poolside as an OpenAI-compatible built-in provider", async () => {
+		expect(BUILT_IN_PROVIDER_IDS).toContain("poolside");
+
+		await expect(getProvider("poolside")).resolves.toMatchObject({
+			id: "poolside",
+			name: "Poolside",
+			baseUrl: "https://inference.poolside.ai/v1",
+			defaultModelId: "poolside/laguna-m.1",
+			client: "openai-compatible",
+		});
+		await expect(getModelsForProvider("poolside")).resolves.toHaveProperty(
+			"poolside/laguna-m.1",
+		);
+
+		const registration = BUILTIN_PROVIDER_REGISTRATIONS.find(
+			(item) => item.manifest.id === "poolside",
+		);
+		await expect(registration?.loadProvider?.()).resolves.toMatchObject({
+			createProvider: createOpenAICompatibleProvider,
+		});
+	});
+
 	it("routes Responses API built-ins through the OpenAI provider factory", async () => {
 		for (const providerId of ["litellm", "v0"]) {
 			const provider = await getProvider(providerId);

--- a/sdk/packages/llms/src/providers/ids.ts
+++ b/sdk/packages/llms/src/providers/ids.ts
@@ -30,6 +30,7 @@ export enum BUILT_IN_PROVIDER {
 	TOGETHER = "together",
 	FIREWORKS = "fireworks",
 	GROQ = "groq",
+	POOLSIDE = "poolside",
 	CEREBRAS = "cerebras",
 	SAMBANOVA = "sambanova",
 	NEBIUS = "nebius",


### PR DESCRIPTION
### Related Issue

**Issue:** #10908

### Description

Registers Poolside as a built-in SDK CLI/TUI provider.

This adds `poolside` to the SDK provider registry as an OpenAI-compatible provider with:

- default endpoint: `https://inference.poolside.ai/v1`
- default model: `poolside/laguna-m.1`
- provider env var: `POOLSIDE_API_KEY`

Poolside model metadata is loaded from the authenticated `https://inference.poolside.ai/v1/models` endpoint when provider config is resolved, so the SDK no longer hardcodes the Poolside model list in `@cline/llms`.

This PR intentionally does not change the desktop/webview provider picker.

### Test Procedure

- `cd sdk && bun -F @cline/llms test src/providers/ids.test.ts`
- `cd sdk/packages/core && bunx --bun vitest run --config vitest.config.ts src/services/llms/provider-defaults.test.ts`
- `cd sdk && bunx --bun @biomejs/biome lint packages/llms/src/providers/builtins.ts packages/llms/src/providers/ids.test.ts packages/core/src/services/llms/provider-defaults.ts packages/core/src/services/llms/provider-defaults.test.ts --diagnostic-level=error`
- `cd sdk && bun run build:sdk`
- Verified the Poolside `/v1/models` resolver path returns `poolside/laguna-m.1` and `poolside/laguna-xs.2` with tools/reasoning/temperature metadata.
- Verified `listLocalProviders()` returns `poolside` with the default base URL and model.
- Earlier live SDK CLI inference with `--provider poolside` returned `poolside-ok`.
- Earlier SDK CLI/TUI provider picker search for `poolside` showed `Poolside`.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->\n\n-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)\n-   [x] ✨ New feature (non-breaking change which adds functionality)\n-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)\n-   [ ] ♻️ Refactor Changes\n-   [ ] 💅 Cosmetic Changes\n-   [ ] 📚 Documentation update\n-   [ ] 🏃 Workflow Changes\n\n### Pre-flight Checklist\n\n<!-- Put an 'x' in all boxes that apply -->\n\n-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)\n-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)\n-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)\n\n### Screenshots\n\nNot included. This is SDK CLI/TUI provider registry plumbing.\n\n### Additional Notes\n\nThe PR is limited to SDK provider registry and provider config model-resolution plumbing.