### PR TITLE
feat(runtime): track idle and pending session states

### DIFF
--- a/sdk/apps/cli/src/tui/views/history-view.tsx
+++ b/sdk/apps/cli/src/tui/views/history-view.tsx
@@ -11,10 +11,7 @@ import type { ChoiceContext } from "@opentui-ui/dialog";
 import { useDialogKeyboard } from "@opentui-ui/dialog/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { listSessions } from "../../session/session";
-import {
-	formatSessionStatusLabel,
-	mergeHistoryStatusRows,
-} from "../../utils/history-format";
+import { mergeHistoryStatusRows } from "../../utils/history-format";
 import { formatUsd } from "../../utils/output";
 import { shouldShowCliUsageCost } from "../../utils/usage-cost-display";
 import { palette } from "../palette";
@@ -76,25 +73,6 @@ type HistoryListContentProps = HistoryListActions & {
 		handler: (key: HistoryKeyEvent | undefined) => void,
 	) => void;
 };
-
-function getStatusColor(
-	status: SessionHistoryRecord["status"],
-	selected: boolean,
-): string {
-	if (selected) {
-		return palette.textOnSelection;
-	}
-	switch (status) {
-		case "running":
-			return palette.success;
-		case "failed":
-			return "red";
-		case "cancelled":
-			return "yellow";
-		case "completed":
-			return "gray";
-	}
-}
 
 function HistoryListContent({
 	initialRows,
@@ -353,7 +331,6 @@ function HistoryListContent({
 					const showCost = shouldShowCliUsageCost(row.provider);
 					const title = formatTitle(row, titleMaxLen);
 					const date = formatRelativeDate(row.startedAt);
-					const status = formatSessionStatusLabel(row.status);
 
 					return (
 						<box
@@ -376,11 +353,6 @@ function HistoryListContent({
 								flexGrow={1}
 							>
 								{title}
-							</text>
-							<text fg={getStatusColor(row.status, isSel)} flexShrink={0}>
-								{"  ["}
-								{status}
-								{"]"}
 							</text>
 							{showCost && cost != null && cost > 0 && (
 								<text

--- a/sdk/packages/core/src/hub/client/index.ts
+++ b/sdk/packages/core/src/hub/client/index.ts
@@ -914,7 +914,11 @@ function hasActiveHubSessions(payload: unknown): boolean {
 			status?: unknown;
 			participants?: unknown;
 		};
-		if (record.status === "running" || record.status === "idle") {
+		if (
+			record.status === "running" ||
+			record.status === "idle" ||
+			record.status === "pending"
+		) {
 			return true;
 		}
 		return Array.isArray(record.participants) && record.participants.length > 0;

--- a/sdk/packages/core/src/hub/runtime-host/hub-runtime-host.ts
+++ b/sdk/packages/core/src/hub/runtime-host/hub-runtime-host.ts
@@ -54,7 +54,11 @@ import type {
 	CoreSettingsSnapshot,
 	CoreSettingsToggleInput,
 } from "../../settings";
-import { SessionSource, type SessionStatus } from "../../types/common";
+import {
+	isNonTerminalSessionStatus,
+	SessionSource,
+	type SessionStatus,
+} from "../../types/common";
 import type {
 	CoreSessionEvent,
 	SessionPendingPrompt,
@@ -1691,7 +1695,10 @@ export class HubRuntimeHost implements RuntimeHost {
 						reason,
 					},
 				});
-				if (snapshot?.interactive === true && snapshot.status === "running") {
+				if (
+					snapshot?.interactive === true &&
+					isNonTerminalSessionStatus(snapshot.status)
+				) {
 					return;
 				}
 				this.events.emit({

--- a/sdk/packages/core/src/hub/server/hub-session-records.ts
+++ b/sdk/packages/core/src/hub/server/hub-session-records.ts
@@ -16,6 +16,10 @@ function mapLocalStatusToHubStatus(
 	status: LocalSessionRecord["status"],
 ): HubSessionRecord["status"] {
 	switch (status) {
+		case "idle":
+			return "idle";
+		case "pending":
+			return "pending";
 		case "completed":
 			return "completed";
 		case "failed":

--- a/sdk/packages/core/src/runtime/host/history.test.ts
+++ b/sdk/packages/core/src/runtime/host/history.test.ts
@@ -283,7 +283,7 @@ describe("session history", () => {
 		);
 
 		expect(list).toHaveBeenCalledWith(20);
-		expect(readSessionMessages).toHaveBeenCalledWith("sess_lightweight");
+		expect(readSessionMessages).not.toHaveBeenCalled();
 		expect(rows).toEqual([
 			expect.objectContaining({
 				sessionId: "sess_lightweight",
@@ -415,7 +415,7 @@ describe("session history", () => {
 		]);
 	});
 
-	it("filters backend history rows without readable messages", async () => {
+	it("keeps backend history rows even when messages are empty or unreadable", async () => {
 		const fullMessagesPath = await writeMessagesFile("full.messages.json");
 		const emptyMessagesPath = await writeMessagesFile(
 			"empty.messages.json",
@@ -442,7 +442,11 @@ describe("session history", () => {
 		);
 
 		expect(listSessions).toHaveBeenCalledWith(20);
-		expect(rows.map((row) => row.sessionId)).toEqual(["sess_full"]);
+		expect(rows.map((row) => row.sessionId)).toEqual([
+			"sess_full",
+			"sess_empty",
+			"sess_unreadable",
+		]);
 	});
 
 	it("lists directly from a session backend without a runtime host", async () => {

--- a/sdk/packages/core/src/runtime/host/history.test.ts
+++ b/sdk/packages/core/src/runtime/host/history.test.ts
@@ -100,6 +100,22 @@ async function writeManifest(
 	);
 }
 
+async function writeMessagesFile(
+	filename: string,
+	messages: unknown[] = [{ role: "user", content: "hi" }],
+): Promise<string> {
+	if (!tempSessionDataDir) {
+		tempSessionDataDir = await mkdtemp(join(tmpdir(), "cline-core-history-"));
+	}
+	const path = join(tempSessionDataDir, filename);
+	await writeFile(
+		path,
+		`${JSON.stringify({ version: 1, messages }, null, 2)}\n`,
+		"utf8",
+	);
+	return path;
+}
+
 describe("session history", () => {
 	afterEach(async () => {
 		vi.clearAllMocks();
@@ -183,7 +199,9 @@ describe("session history", () => {
 	});
 
 	it("falls back to nested metadata provider/model ids before reading messages", async () => {
-		const readSessionMessages = vi.fn().mockResolvedValue([]);
+		const readSessionMessages = vi
+			.fn()
+			.mockResolvedValue([{ role: "user" as const, content: "hi" }]);
 
 		const [row] = await hydrateSessionHistory({ readSessionMessages }, [
 			createRow({
@@ -202,7 +220,9 @@ describe("session history", () => {
 	});
 
 	it("preserves host ordering when no manifest fallback rows are merged", async () => {
-		const readSessionMessages = vi.fn().mockResolvedValue([]);
+		const readSessionMessages = vi
+			.fn()
+			.mockResolvedValue([{ role: "user" as const, content: "hi" }]);
 		const first = createRow({
 			sessionId: "sess_first",
 			startedAt: "2026-04-19T00:00:00.000Z",
@@ -263,7 +283,7 @@ describe("session history", () => {
 		);
 
 		expect(list).toHaveBeenCalledWith(20);
-		expect(readSessionMessages).not.toHaveBeenCalled();
+		expect(readSessionMessages).toHaveBeenCalledWith("sess_lightweight");
 		expect(rows).toEqual([
 			expect.objectContaining({
 				sessionId: "sess_lightweight",
@@ -274,7 +294,67 @@ describe("session history", () => {
 		]);
 	});
 
+	it("projects legacy interactive running sessions with completed assistant turns as idle", async () => {
+		const list = vi.fn().mockResolvedValue([
+			createRow({
+				sessionId: "sess_legacy_idle",
+				status: "running",
+				interactive: true,
+				provider: "cline",
+				model: "anthropic/claude-sonnet-4.6",
+			}),
+		]);
+		const readSessionMessages = vi.fn().mockResolvedValue([
+			{ role: "user" as const, content: "hi" },
+			{
+				role: "assistant" as const,
+				content: [{ type: "text", text: "hello" }],
+			},
+		]);
+
+		const rows = await listSessionHistory(
+			{ listSessions: list, readSessionMessages },
+			{ limit: 10, hydrate: false },
+		);
+
+		expect(readSessionMessages).toHaveBeenCalledWith("sess_legacy_idle");
+		expect(rows).toEqual([
+			expect.objectContaining({
+				sessionId: "sess_legacy_idle",
+				status: "idle",
+			}),
+		]);
+	});
+
+	it("keeps legacy interactive running sessions running when the last turn is not complete", async () => {
+		const list = vi.fn().mockResolvedValue([
+			createRow({
+				sessionId: "sess_legacy_running",
+				status: "running",
+				interactive: true,
+				provider: "cline",
+				model: "anthropic/claude-sonnet-4.6",
+			}),
+		]);
+		const readSessionMessages = vi
+			.fn()
+			.mockResolvedValue([{ role: "user" as const, content: "keep going" }]);
+
+		const rows = await listSessionHistory(
+			{ listSessions: list, readSessionMessages },
+			{ limit: 10, hydrate: false },
+		);
+
+		expect(rows).toEqual([
+			expect.objectContaining({
+				sessionId: "sess_legacy_running",
+				status: "running",
+			}),
+		]);
+	});
+
 	it("filters child sessions from history by default", async () => {
+		const rootMessagesPath = await writeMessagesFile("root.messages.json");
 		const listSessions = vi.fn().mockResolvedValue([
 			createBackendRow({
 				sessionId: "root-session__teamtask__java-haiku-agent__abc123",
@@ -292,6 +372,7 @@ describe("session history", () => {
 			}),
 			createBackendRow({
 				sessionId: "root-session",
+				messagesPath: rootMessagesPath,
 			}),
 		]);
 
@@ -305,6 +386,8 @@ describe("session history", () => {
 	});
 
 	it("can include child sessions when explicitly requested", async () => {
+		const childMessagesPath = await writeMessagesFile("child.messages.json");
+		const rootMessagesPath = await writeMessagesFile("root.messages.json");
 		const listSessions = vi.fn().mockResolvedValue([
 			createBackendRow({
 				sessionId: "root-session__teamtask__java-haiku-agent__abc123",
@@ -312,9 +395,11 @@ describe("session history", () => {
 				parentAgentId: "lead",
 				agentId: "java-haiku-agent",
 				isSubagent: true,
+				messagesPath: childMessagesPath,
 			}),
 			createBackendRow({
 				sessionId: "root-session",
+				messagesPath: rootMessagesPath,
 			}),
 		]);
 
@@ -330,15 +415,20 @@ describe("session history", () => {
 		]);
 	});
 
-	it("keeps backend history listing lightweight without validating message artifacts", async () => {
+	it("filters backend history rows without readable messages", async () => {
+		const fullMessagesPath = await writeMessagesFile("full.messages.json");
+		const emptyMessagesPath = await writeMessagesFile(
+			"empty.messages.json",
+			[],
+		);
 		const listSessions = vi.fn().mockResolvedValue([
 			createBackendRow({
 				sessionId: "sess_full",
-				messagesPath: "/tmp/full.messages.json",
+				messagesPath: fullMessagesPath,
 			}),
 			createBackendRow({
 				sessionId: "sess_empty",
-				messagesPath: "/tmp/empty.messages.json",
+				messagesPath: emptyMessagesPath,
 			}),
 			createBackendRow({
 				sessionId: "sess_unreadable",
@@ -352,11 +442,7 @@ describe("session history", () => {
 		);
 
 		expect(listSessions).toHaveBeenCalledWith(20);
-		expect(rows.map((row) => row.sessionId)).toEqual([
-			"sess_full",
-			"sess_empty",
-			"sess_unreadable",
-		]);
+		expect(rows.map((row) => row.sessionId)).toEqual(["sess_full"]);
 	});
 
 	it("lists directly from a session backend without a runtime host", async () => {

--- a/sdk/packages/core/src/runtime/host/history.ts
+++ b/sdk/packages/core/src/runtime/host/history.ts
@@ -383,23 +383,21 @@ function shouldProjectLegacyRunningSessionAsIdle(
 	);
 }
 
-async function filterAndProjectHistoryRows(
+async function projectLegacyRunningRowsAsIdle(
 	host: Pick<RuntimeHost, "readSessionMessages">,
 	rows: SessionRecord[],
 ): Promise<SessionRecord[]> {
-	const prepared = await Promise.all(
-		rows.map(async (row) => ({
-			row,
-			messages: await host.readSessionMessages(row.sessionId),
-		})),
-	);
-	return prepared
-		.filter(({ messages }) => messages.length > 0)
-		.map(({ row, messages }) =>
-			shouldProjectLegacyRunningSessionAsIdle(row, messages)
+	return await Promise.all(
+		rows.map(async (row) => {
+			if (row.status !== "running" || row.interactive !== true) {
+				return row;
+			}
+			const messages = await host.readSessionMessages(row.sessionId);
+			return shouldProjectLegacyRunningSessionAsIdle(row, messages)
 				? { ...row, status: "idle" }
-				: row,
-		);
+				: row;
+		}),
+	);
 }
 
 export async function hydrateSessionHistory(
@@ -459,7 +457,7 @@ export async function listSessionHistory(
 			: Array.from(merged.values())
 					.sort((left, right) => right.startedAt.localeCompare(left.startedAt))
 					.slice(0, limit);
-	const projectedRows = await filterAndProjectHistoryRows(host, rows);
+	const projectedRows = await projectLegacyRunningRowsAsIdle(host, rows);
 	if (options.hydrate === false) {
 		return projectedRows.map((row) => normalizeHistoryRow(row));
 	}

--- a/sdk/packages/core/src/runtime/host/history.ts
+++ b/sdk/packages/core/src/runtime/host/history.ts
@@ -357,6 +357,51 @@ function normalizeHistoryRow(
 	};
 }
 
+function messageContainsToolCall(message: LlmsProviders.Message): boolean {
+	const content = message.content;
+	if (!Array.isArray(content)) {
+		return false;
+	}
+	return content.some(
+		(part) =>
+			!!part &&
+			typeof part === "object" &&
+			(part as { type?: unknown }).type === "tool-call",
+	);
+}
+
+function shouldProjectLegacyRunningSessionAsIdle(
+	row: SessionRecord,
+	messages: LlmsProviders.Message[],
+): boolean {
+	if (row.status !== "running" || row.interactive !== true) {
+		return false;
+	}
+	const lastMessage = messages.at(-1);
+	return (
+		lastMessage?.role === "assistant" && !messageContainsToolCall(lastMessage)
+	);
+}
+
+async function filterAndProjectHistoryRows(
+	host: Pick<RuntimeHost, "readSessionMessages">,
+	rows: SessionRecord[],
+): Promise<SessionRecord[]> {
+	const prepared = await Promise.all(
+		rows.map(async (row) => ({
+			row,
+			messages: await host.readSessionMessages(row.sessionId),
+		})),
+	);
+	return prepared
+		.filter(({ messages }) => messages.length > 0)
+		.map(({ row, messages }) =>
+			shouldProjectLegacyRunningSessionAsIdle(row, messages)
+				? { ...row, status: "idle" }
+				: row,
+		);
+}
+
 export async function hydrateSessionHistory(
 	host: Pick<RuntimeHost, "readSessionMessages">,
 	rows: SessionRecord[],
@@ -414,10 +459,11 @@ export async function listSessionHistory(
 			: Array.from(merged.values())
 					.sort((left, right) => right.startedAt.localeCompare(left.startedAt))
 					.slice(0, limit);
+	const projectedRows = await filterAndProjectHistoryRows(host, rows);
 	if (options.hydrate === false) {
-		return rows.map((row) => normalizeHistoryRow(row));
+		return projectedRows.map((row) => normalizeHistoryRow(row));
 	}
-	return await hydrateSessionHistory(host, rows);
+	return await hydrateSessionHistory(host, projectedRows);
 }
 
 async function readManifestMessagesPath(

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
@@ -374,7 +374,7 @@ describe("LocalRuntimeHost", () => {
 			} as never,
 			runtimeBuilder: runtimeBuilder as never,
 			createAgent: (config) => {
-				expect(config.requestToolApproval).toBe(requestToolApproval);
+				expect(typeof config.requestToolApproval).toBe("function");
 				return agent as never;
 			},
 		});
@@ -401,6 +401,124 @@ describe("LocalRuntimeHost", () => {
 			undefined,
 			undefined,
 		);
+	});
+
+	it("marks interactive sessions pending while awaiting tool approval", async () => {
+		const sessionId = "sess-pending-approval-status";
+		const manifest = createManifest(sessionId);
+		let resolveApproval:
+			| ((result: { approved: boolean; reason?: string }) => void)
+			| undefined;
+		const requestToolApproval = vi.fn(
+			() =>
+				new Promise<{ approved: boolean; reason?: string }>((resolve) => {
+					resolveApproval = resolve;
+				}),
+		);
+		let capturedConfig: AgentConfig | undefined;
+		const updateSessionStatus = vi.fn().mockResolvedValue({ updated: true });
+		const runtimeBuilder = {
+			build: vi.fn().mockReturnValue({
+				tools: [],
+				shutdown: vi.fn(),
+			}),
+		};
+		const agent = {
+			run: vi.fn(async () => {
+				const approval = await capturedConfig?.requestToolApproval?.({
+					sessionId,
+					agentId: "agent-root-1",
+					conversationId: "conv-root-1",
+					iteration: 1,
+					toolCallId: "call-approval-1",
+					toolName: "edit_file",
+					input: { path: "README.md" },
+					policy: { autoApprove: false },
+				});
+				expect(approval?.approved).toBe(true);
+				return createResult();
+			}),
+			continue: vi.fn().mockResolvedValue(createResult()),
+			getMessages: vi.fn().mockReturnValue([]),
+			getAgentId: vi.fn().mockReturnValue("agent-root-1"),
+			getConversationId: vi.fn().mockReturnValue("conv-root-1"),
+			abort: vi.fn(),
+			subscribeEvents: vi.fn().mockReturnValue(() => {}),
+			canStartRun: vi.fn().mockReturnValue(true),
+			shutdown: vi.fn().mockResolvedValue(undefined),
+		};
+		const manager = new RuntimeHostUnderTest({
+			distinctId,
+			sessionService: {
+				ensureSessionsDir: vi.fn().mockReturnValue("/tmp/sessions"),
+				createRootSessionWithArtifacts: vi.fn().mockResolvedValue({
+					manifestPath: "/tmp/manifest.json",
+					messagesPath: "/tmp/messages.json",
+					manifest,
+				}),
+				persistSessionMessages: vi.fn(),
+				updateSessionStatus,
+				writeSessionManifest: vi.fn(),
+				listSessions: vi.fn().mockResolvedValue([]),
+				deleteSession: vi.fn().mockResolvedValue({ deleted: true }),
+			} as never,
+			runtimeBuilder: runtimeBuilder as never,
+			createAgent: (config) => {
+				capturedConfig = config;
+				return agent as never;
+			},
+		});
+		const pendingStatus = new Promise<void>((resolve) => {
+			manager.subscribe((event) => {
+				if (
+					event.type === "status" &&
+					event.payload.sessionId === sessionId &&
+					event.payload.status === "pending"
+				) {
+					resolve();
+				}
+			});
+		});
+
+		const started = manager.startSession(
+			normalizeStartInput({
+				config: createConfig({ sessionId }),
+				prompt: "hello",
+				interactive: true,
+				capabilities: { requestToolApproval },
+			}),
+		);
+		await pendingStatus;
+
+		await expect(manager.getSession(sessionId)).resolves.toMatchObject({
+			sessionId,
+			status: "pending",
+		});
+		resolveApproval?.({ approved: true });
+		await started;
+
+		expect(updateSessionStatus).toHaveBeenNthCalledWith(
+			1,
+			sessionId,
+			"pending",
+			null,
+		);
+		expect(updateSessionStatus).toHaveBeenNthCalledWith(
+			2,
+			sessionId,
+			"running",
+			null,
+		);
+		expect(updateSessionStatus).toHaveBeenNthCalledWith(
+			3,
+			sessionId,
+			"idle",
+			null,
+		);
+		await expect(manager.getSession(sessionId)).resolves.toMatchObject({
+			sessionId,
+			status: "idle",
+		});
 	});
 
 	it("ingests automation events emitted by sandbox plugins during setup", async () => {
@@ -688,7 +806,7 @@ describe("LocalRuntimeHost", () => {
 		expect(sessionService.readSessionManifest).toHaveBeenCalledWith(sessionId);
 	});
 
-	it("keeps interactive sessions running after a completed turn", async () => {
+	it("marks interactive sessions idle after a completed turn", async () => {
 		const sessionId = "sess-interactive-turn-status";
 		const manifest = createManifest(sessionId);
 		const sessionService = {
@@ -703,7 +821,7 @@ describe("LocalRuntimeHost", () => {
 				.fn()
 				.mockImplementation(async (_sessionId: string, status: string) => ({
 					updated: true,
-					...(status === "running"
+					...(status === "running" || status === "idle" || status === "pending"
 						? {}
 						: { endedAt: "2026-01-01T00:00:05.000Z" }),
 				})),
@@ -741,10 +859,14 @@ describe("LocalRuntimeHost", () => {
 			}),
 		);
 
-		expect(sessionService.updateSessionStatus).not.toHaveBeenCalled();
+		expect(sessionService.updateSessionStatus).toHaveBeenCalledWith(
+			sessionId,
+			"idle",
+			null,
+		);
 		await expect(manager.getSession(sessionId)).resolves.toMatchObject({
 			sessionId,
-			status: "running",
+			status: "idle",
 		});
 		expect(agent.shutdown).not.toHaveBeenCalled();
 		expect(runtime.shutdown).not.toHaveBeenCalled();
@@ -2223,13 +2345,30 @@ describe("LocalRuntimeHost", () => {
 		});
 		await expect(manager.getSession(sessionId)).resolves.toMatchObject({
 			sessionId,
-			status: "running",
+			status: "idle",
 		});
 		expect(run).toHaveBeenCalledTimes(1);
 		expect(continueTurn).toHaveBeenCalledTimes(1);
 		expect(agent.shutdown).not.toHaveBeenCalled();
 		expect(runtime.shutdown).not.toHaveBeenCalled();
-		expect(sessionService.updateSessionStatus).not.toHaveBeenCalled();
+		expect(sessionService.updateSessionStatus).toHaveBeenNthCalledWith(
+			1,
+			sessionId,
+			"idle",
+			null,
+		);
+		expect(sessionService.updateSessionStatus).toHaveBeenNthCalledWith(
+			2,
+			sessionId,
+			"running",
+			null,
+		);
+		expect(sessionService.updateSessionStatus).toHaveBeenNthCalledWith(
+			3,
+			sessionId,
+			"idle",
+			null,
+		);
 		expect(events).not.toContainEqual(
 			expect.objectContaining({
 				type: "ended",
@@ -2922,7 +3061,13 @@ describe("LocalRuntimeHost", () => {
 			"running",
 			null,
 		);
-		expect(updateSessionStatus).toHaveBeenCalledTimes(1);
+		expect(updateSessionStatus).toHaveBeenNthCalledWith(
+			2,
+			sessionId,
+			"idle",
+			null,
+		);
+		expect(updateSessionStatus).toHaveBeenCalledTimes(2);
 		const persistedMetadata = updateSession.mock.calls[0]?.[0]
 			.metadata as Record<string, unknown>;
 		expect(persistedMetadata.title).toBe("saved title");

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -62,7 +62,11 @@ import {
 	shouldAutoContinueTeamRuns,
 	waitForTeamRunUpdates,
 } from "../../session/team";
-import { SessionSource, type SessionStatus } from "../../types/common";
+import {
+	isNonTerminalSessionStatus,
+	SessionSource,
+	type SessionStatus,
+} from "../../types/common";
 import type { CoreSessionConfig } from "../../types/config";
 import type { CoreSessionEvent } from "../../types/events";
 import type { ActiveSession, PreparedTurnInput } from "../../types/session";
@@ -438,7 +442,29 @@ export class LocalRuntimeHost implements RuntimeHost {
 			initialMessages: bootstrap.effectiveInput.initialMessages,
 			userFileContentLoader: loadUserFileContent,
 			toolPolicies: bootstrap.toolPolicies,
-			requestToolApproval: bootstrap.requestToolApproval,
+			requestToolApproval: bootstrap.requestToolApproval
+				? async (request) => {
+						const requestToolApproval = bootstrap.requestToolApproval;
+						const liveSession = this.sessions.get(sessionId);
+						if (liveSession) {
+							await this.markTurnPending(liveSession);
+						}
+						try {
+							if (!requestToolApproval) {
+								return {
+									approved: false,
+									reason: "Tool approval callback is not configured.",
+								};
+							}
+							return await requestToolApproval(request);
+						} finally {
+							const currentSession = this.sessions.get(sessionId);
+							if (currentSession?.status === "pending") {
+								await this.markTurnRunning(currentSession);
+							}
+						}
+					}
+				: undefined,
 			telemetry: configWithProvider.telemetry,
 			onConsecutiveMistakeLimitReached:
 				configWithProvider.onConsecutiveMistakeLimitReached,
@@ -744,7 +770,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 			event: "session.stopped",
 			properties: { sessionId },
 		});
-		if (session.interactive && session.status !== "running") {
+		if (session.interactive && !isNonTerminalSessionStatus(session.status)) {
 			await this.releaseSessionRuntime(session, "session_stop");
 			return;
 		}
@@ -773,7 +799,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 		if (sessions.length === 0) return;
 		await Promise.allSettled(
 			sessions.map((session) =>
-				session.interactive && session.status !== "running"
+				session.interactive && !isNonTerminalSessionStatus(session.status)
 					? this.releaseSessionRuntime(session, reason)
 					: session.interactive && session.agent.canStartRun()
 						? this.shutdownSession(session, {
@@ -963,7 +989,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 	): Promise<void> {
 		if (hasPendingTeamRunWork(session)) return;
 		session.lastInteractiveTurnFinishReason = finishReason;
-		await this.markTurnRunning(session);
+		await this.markTurnIdle(session);
 		session.aborting = false;
 	}
 
@@ -1251,6 +1277,16 @@ export class LocalRuntimeHost implements RuntimeHost {
 		await this.updateStatus(session, "running", null);
 	}
 
+	private async markTurnPending(session: ActiveSession): Promise<void> {
+		if (session.status === "pending") return;
+		await this.updateStatus(session, "pending", null);
+	}
+
+	private async markTurnIdle(session: ActiveSession): Promise<void> {
+		if (session.status === "idle") return;
+		await this.updateStatus(session, "idle", null);
+	}
+
 	private async persistSessionMetadata(
 		sessionId: string,
 		resolveMetadata: (
@@ -1464,7 +1500,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 				session.sessionId,
 			)) ?? session.artifacts.manifest;
 		latestManifest.status = status;
-		if (status === "running") {
+		if (isNonTerminalSessionStatus(status)) {
 			delete latestManifest.ended_at;
 			latestManifest.exit_code = null;
 		} else {
@@ -1474,7 +1510,9 @@ export class LocalRuntimeHost implements RuntimeHost {
 		session.artifacts.manifest = latestManifest;
 		session.status = status;
 		session.updatedAt = result.endedAt ?? nowIso();
-		session.endedAt = status === "running" ? null : latestManifest.ended_at;
+		session.endedAt = isNonTerminalSessionStatus(status)
+			? null
+			: latestManifest.ended_at;
 		session.exitCode = latestManifest.exit_code;
 		await this.invoke<void>(
 			"writeSessionManifest",

--- a/sdk/packages/core/src/services/storage/sqlite-session-store.ts
+++ b/sdk/packages/core/src/services/storage/sqlite-session-store.ts
@@ -11,7 +11,10 @@ import {
 	toBoolInt,
 } from "@cline/shared/db";
 import { resolveDbDataDir } from "@cline/shared/storage";
-import type { SessionStatus } from "../../types/common";
+import {
+	isNonTerminalSessionStatus,
+	type SessionStatus,
+} from "../../types/common";
 import type { SessionRecord } from "../../types/sessions";
 import type { SessionStore } from "../../types/storage";
 
@@ -178,11 +181,10 @@ export class SqliteSessionStore implements SessionStore {
 		this.update({
 			sessionId,
 			status,
-			endedAt: status === "running" ? null : nowIso(),
-			exitCode:
-				status === "running"
-					? null
-					: (exitCode ?? (status === "failed" ? 1 : 0)),
+			endedAt: isNonTerminalSessionStatus(status) ? null : nowIso(),
+			exitCode: isNonTerminalSessionStatus(status)
+				? null
+				: (exitCode ?? (status === "failed" ? 1 : 0)),
 		});
 	}
 

--- a/sdk/packages/core/src/session/services/persistence-service.ts
+++ b/sdk/packages/core/src/session/services/persistence-service.ts
@@ -19,7 +19,11 @@ import {
 	withLatestAssistantTurnMetadata,
 	withOccRetry,
 } from "../../services/session-data";
-import type { SessionStatus } from "../../types/common";
+import {
+	isNonTerminalSessionStatus,
+	type SessionStatus,
+	type TerminalSessionStatus,
+} from "../../types/common";
 import type {
 	PersistedSessionUpdateInput,
 	SessionMessagesArtifactUploader,
@@ -180,17 +184,16 @@ export class UnifiedSessionPersistenceService {
 		const result = await withOccRetry(
 			() => this.adapter.getSession(sessionId),
 			async (row) => {
-				endedAt = status === "running" ? undefined : nowIso();
+				endedAt = isNonTerminalSessionStatus(status) ? undefined : nowIso();
 				return this.adapter.updateSession({
 					sessionId,
 					status,
 					endedAt: endedAt ?? null,
-					exitCode:
-						status === "running"
-							? null
-							: typeof exitCode === "number"
-								? exitCode
-								: null,
+					exitCode: isNonTerminalSessionStatus(status)
+						? null
+						: typeof exitCode === "number"
+							? exitCode
+							: null,
 					expectedStatusLock: row.statusLock,
 				});
 			},
@@ -336,7 +339,7 @@ export class UnifiedSessionPersistenceService {
 
 	applyStatusToRunningChildSessions(
 		parentSessionId: string,
-		status: Exclude<SessionStatus, "running">,
+		status: TerminalSessionStatus,
 	): Promise<void> {
 		return this.teamChildren.applyStatusToRunningChildSessions(
 			parentSessionId,
@@ -416,7 +419,12 @@ export class UnifiedSessionPersistenceService {
 	private async reconcileDeadRunningSession(
 		row: SessionRow,
 	): Promise<SessionRow | undefined> {
-		if (row.status !== "running" || this.isPidAlive(row.pid)) return row;
+		if (
+			isNonTerminalSessionStatus(row.status) === false ||
+			this.isPidAlive(row.pid)
+		) {
+			return row;
+		}
 
 		const detectedAt = nowIso();
 		const reason = UnifiedSessionPersistenceService.STALE_REASON;
@@ -424,7 +432,7 @@ export class UnifiedSessionPersistenceService {
 		for (let attempt = 0; attempt < OCC_MAX_RETRIES; attempt++) {
 			const latest = await this.adapter.getSession(row.sessionId);
 			if (!latest) return undefined;
-			if (latest.status !== "running") return latest;
+			if (isNonTerminalSessionStatus(latest.status) === false) return latest;
 
 			const nextMetadata = {
 				...(latest.metadata ?? {}),
@@ -501,10 +509,17 @@ export class UnifiedSessionPersistenceService {
 	}
 
 	async reconcileDeadSessions(limit = 2000): Promise<number> {
-		const rows = await this.adapter.listSessions({
-			limit: Math.max(1, Math.floor(limit)),
-			status: "running",
-		});
+		const requestedLimit = Math.max(1, Math.floor(limit));
+		const rows = (
+			await Promise.all(
+				(["idle", "running", "pending"] as const).map((status) =>
+					this.adapter.listSessions({
+						limit: requestedLimit,
+						status,
+					}),
+				),
+			)
+		).flat();
 		let reconciled = 0;
 		for (const row of rows) {
 			const updated = await this.reconcileDeadRunningSession(row);

--- a/sdk/packages/core/src/session/team/team-child-session-manager.ts
+++ b/sdk/packages/core/src/session/team/team-child-session-manager.ts
@@ -12,7 +12,11 @@ import type {
 import type { HookEventPayload } from "../../hooks";
 import { nowIso } from "../../services/session-artifacts";
 import { resolveMetadataWithTitle } from "../../services/session-data";
-import type { SessionStatus } from "../../types/common";
+import {
+	isNonTerminalSessionStatus,
+	type SessionStatus,
+	type TerminalSessionStatus,
+} from "../../types/common";
 import type {
 	SessionPersistenceAdapter,
 	StoredMessageWithMetadata,
@@ -225,8 +229,12 @@ export class TeamChildSessionManager {
 	): Promise<void> {
 		const row = await this.adapter.getSession(subSessionId);
 		if (!row) return;
-		const endedAt = status === "running" ? null : nowIso();
-		const exitCode = status === "running" ? null : status === "failed" ? 1 : 0;
+		const endedAt = isNonTerminalSessionStatus(status) ? null : nowIso();
+		const exitCode = isNonTerminalSessionStatus(status)
+			? null
+			: status === "failed"
+				? 1
+				: 0;
 		await this.adapter.updateSession({
 			sessionId: subSessionId,
 			status,
@@ -238,7 +246,7 @@ export class TeamChildSessionManager {
 
 	async applyStatusToRunningChildSessions(
 		parentSessionId: string,
-		status: Exclude<SessionStatus, "running">,
+		status: TerminalSessionStatus,
 	): Promise<void> {
 		if (!parentSessionId) return;
 		const rows = await this.adapter.listSessions({

--- a/sdk/packages/core/src/types/chat-schema.ts
+++ b/sdk/packages/core/src/types/chat-schema.ts
@@ -22,6 +22,7 @@ export const ChatSessionStatusSchema = z.enum([
 	"idle",
 	"starting",
 	"running",
+	"pending",
 	"stopping",
 	"completed",
 	"cancelled",

--- a/sdk/packages/core/src/types/common.ts
+++ b/sdk/packages/core/src/types/common.ts
@@ -4,6 +4,34 @@ export const SESSION_STATUSES = SESSION_STATUS_VALUES;
 
 export type SessionStatus = (typeof SESSION_STATUSES)[number];
 
+export const NON_TERMINAL_SESSION_STATUSES = [
+	"idle",
+	"running",
+	"pending",
+] as const satisfies readonly SessionStatus[];
+
+export type NonTerminalSessionStatus =
+	(typeof NON_TERMINAL_SESSION_STATUSES)[number];
+
+export type TerminalSessionStatus = Exclude<
+	SessionStatus,
+	NonTerminalSessionStatus
+>;
+
+export function isTerminalSessionStatus(
+	status: SessionStatus,
+): status is TerminalSessionStatus {
+	return !NON_TERMINAL_SESSION_STATUSES.includes(
+		status as NonTerminalSessionStatus,
+	);
+}
+
+export function isNonTerminalSessionStatus(
+	status: SessionStatus,
+): status is NonTerminalSessionStatus {
+	return !isTerminalSessionStatus(status);
+}
+
 export const SessionSource = {
 	CORE: "core",
 	CLI: "cli",

--- a/sdk/packages/shared/src/hub.ts
+++ b/sdk/packages/shared/src/hub.ts
@@ -19,6 +19,7 @@ export type HubTransportKind =
 export type HubRuntimeStatus =
 	| "idle"
 	| "running"
+	| "pending"
 	| "completed"
 	| "aborted"
 	| "failed";

--- a/sdk/packages/shared/src/session/records.ts
+++ b/sdk/packages/shared/src/session/records.ts
@@ -1,5 +1,7 @@
 export const SESSION_STATUS_VALUES = [
+	"idle",
 	"running",
+	"pending",
 	"completed",
 	"failed",
 	"cancelled",


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Propagate idle and pending as non-terminal session statuses across the CLI, hub records, and active-session checks. Update runtime handling so interactive sessions remain active while idle or awaiting approval instead of being treated as ended.

Removed `status` from showing up in `cline history` for now.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

After

<img width="733" height="257" alt="image" src="https://github.com/user-attachments/assets/f4581c42-239c-458c-8c2b-a0b840860d34" />

Before

<img width="731" height="252" alt="image" src="https://github.com/user-attachments/assets/dd38e596-4b78-4337-a47b-f6f45578c823" />

### Additional Notes

<!-- Add any additional notes for reviewers -->
