### PR TITLE
Fix CLI hook dependency lint failure

### DIFF
--- a/sdk/apps/cli/src/tui/root.tsx
+++ b/sdk/apps/cli/src/tui/root.tsx
@@ -194,18 +194,19 @@ function App(props: TuiProps) {
 		onSessionRestart: props.onSessionRestart,
 		refocusTextarea: () => refocusTextareaRef.current(),
 	});
+	const toggleConfigItem = props.onToggleConfigItem;
 	const onToggleConfigItem = useMemo<TuiProps["onToggleConfigItem"]>(() => {
-		if (!props.onToggleConfigItem) {
+		if (!toggleConfigItem) {
 			return undefined;
 		}
 		return async (item, options) => {
-			const data = await props.onToggleConfigItem?.(item, options);
+			const data = await toggleConfigItem(item, options);
 			if (data) {
 				setWorkflowSlashCommands(data.workflowSlashCommands);
 			}
 			return data;
 		};
-	}, [props.onToggleConfigItem]);
+	}, [toggleConfigItem]);
 
 	const openConfig = useConfigPanel({
 		dialog,


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Fixes a Biome `lint/correctness/useExhaustiveDependencies` failure in the SDK CLI TUI.

The hook previously closed over the full `props` object while listing only `props.onToggleConfigItem` in the dependency array. Biome flags that as an invalid hook dependency shape. This stores the callback in a local const and has the memo depend on that const directly, preserving behavior while satisfying the lint rule.

This was observed blocking CI on #10955, but the failing file is not part of that PR's Gemini provider changes.

### Test Procedure

- `npx biome lint --no-errors-on-unmatched --files-ignore-unknown=true --diagnostic-level=error sdk/apps/cli/src/tui/root.tsx`
- `npm run lint`
- `npm run ci:check-all`

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - no UI changes.

### Additional Notes

This is intentionally separate from the Gemini 3.5 Flash provider PR so that CI can be fixed independently.
