### PR TITLE
fix(cli): satisfy config item hook lint

### DIFF
--- a/sdk/apps/cli/src/tui/root.tsx
+++ b/sdk/apps/cli/src/tui/root.tsx
@@ -194,18 +194,19 @@ function App(props: TuiProps) {
 		onSessionRestart: props.onSessionRestart,
 		refocusTextarea: () => refocusTextareaRef.current(),
 	});
+	const propsOnToggleConfigItem = props.onToggleConfigItem;
 	const onToggleConfigItem = useMemo<TuiProps["onToggleConfigItem"]>(() => {
-		if (!props.onToggleConfigItem) {
+		if (!propsOnToggleConfigItem) {
 			return undefined;
 		}
 		return async (item, options) => {
-			const data = await props.onToggleConfigItem?.(item, options);
+			const data = await propsOnToggleConfigItem(item, options);
 			if (data) {
 				setWorkflowSlashCommands(data.workflowSlashCommands);
 			}
 			return data;
 		};
-	}, [props.onToggleConfigItem]);
+	}, [propsOnToggleConfigItem]);
 
 	const openConfig = useConfigPanel({
 		dialog,


### PR DESCRIPTION
### Related Issue

Issue: N/A

### Description

This PR fixes a Biome lint failure currently present on main in the SDK CLI TUI root component.

The failing rule was lint/correctness/useExhaustiveDependencies. The memoized onToggleConfigItem callback depended on props.onToggleConfigItem, but the callback body captured props through props.onToggleConfigItem?. That made Biome treat the hook as depending on the broader props object while the dependency list named only the nested property.

The fix is intentionally small: copy props.onToggleConfigItem into a local const before the useMemo, then reference that const inside the memoized callback and in the dependency list. This keeps the runtime behavior the same while making the closure and dependency list match.

This is split into its own PR because the failure is inherited from main and was blocking unrelated PR checks after rebasing.

### Test Procedure

I verified the exact failing quality path locally:

```bash
npm run lint
npm run ci:check-all
```

Both commands pass after the change. The pre-commit hook also ran the SDK checks for the staged file:

```bash
bun run types
bun biome check --no-errors-on-unmatched --files-ignore-unknown=true
```

Those passed as part of commit creation.

### Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Refactor Changes
-   [ ] Cosmetic Changes
-   [ ] Documentation update
-   [ ] Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed contributor guidelines

### Screenshots

N/A

### Additional Notes

This PR does not change user-facing behavior. It only makes the hook dependency capture explicit so the current Biome rule set accepts the file.
