### PR TITLE
fix(cli): clarify Cline session timeout message

### DIFF
--- a/sdk/apps/cli/src/tui/hooks/use-agent-events.ts
+++ b/sdk/apps/cli/src/tui/hooks/use-agent-events.ts
@@ -29,6 +29,19 @@ interface AgentEventDeps {
 	verbose: boolean;
 }
 
+// FIXME: Replace this brittle error-string parsing with a structured auth error.
+const CLINE_REAUTH_ERROR_MESSAGE = "cline requires re-authentication.";
+
+export const CLINE_SESSION_TIMED_OUT_MESSAGE =
+	"Your Cline session has timed out. Please use /account to log back in.";
+
+export function createAgentFailureEntry(message: string): ChatEntry {
+	if (message.trim().toLowerCase() === CLINE_REAUTH_ERROR_MESSAGE) {
+		return { kind: "status", text: CLINE_SESSION_TIMED_OUT_MESSAGE };
+	}
+	return { kind: "error", text: message };
+}
+
 export function useAgentEventHandlers(deps: AgentEventDeps) {
 	const {
 		appendEntry,
@@ -171,7 +184,7 @@ export function useAgentEventHandlers(deps: AgentEventDeps) {
 					turnErrorReportedRef.current = true;
 					onTurnErrorReported(true);
 					if (!event.recoverable || verbose) {
-						appendEntry({ kind: "error", text: event.error.message });
+						appendEntry(createAgentFailureEntry(event.error.message));
 					}
 					break;
 				case "notice":


### PR DESCRIPTION
### Related Issue

Issue: #XXXX

### Description

When a user is signed out of the Cline provider in the SDK CLI, the chat TUI currently surfaces the runtime provider failure as a raw error message:

```text
Error: cline requires re-authentication.
```

This is technically accurate but not useful in the chat UI. The user needs to know that their Cline session timed out and that the account dialog is the path back to a working session.

This PR maps that specific Cline provider re-authentication failure to a normal status entry:

```text
Your Cline session has timed out. Please use /account to log back in.
```

Other agent errors continue to flow through the existing error entry path unchanged. The implementation intentionally keeps the change scoped to the TUI event handler. There is a FIXME above the string match because the current runtime only gives the TUI an error message string, and this should eventually become a structured auth error instead of brittle string parsing.

### Test Procedure

I verified the CLI TypeScript project still typechecks:

```bash
bun run typecheck
```

I also checked the diff for whitespace issues:

```bash
sleep 1 && git diff --check
```

The risky behavior here is accidentally changing how generic errors render in the TUI. I checked that the generic path still returns `{ kind: "error", text: message }`, while only the exact `cline requires re-authentication.` message is converted to a status entry.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. This is a terminal text message change.

### Additional Notes

I did not run the full repository test, format, or lint suite. I ran the SDK CLI typecheck and `git diff --check` for this narrow change.
