### PR TITLE
Update most basic contributing stuff

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ We also welcome contributions to our [documentation](https://github.com/cline/cl
 3. Install [bun](https://bun.com)
 4. Install the necessary dependencies for the extension and webview-gui:
     ```bash
-    npm run install:all
+    cd apps/vscode && npm run install:all && cd ../..
     cd sdk && bun run build && cd ..
     ```
 5. Generate Protocol Buffer files (required before first build):
@@ -61,7 +61,7 @@ We also welcome contributions to our [documentation](https://github.com/cline/cl
 2. Push your branch and create a PR on GitHub. Our CI will:
    - Run tests and checks
 3. Testing
-    - Run `npm run test` to run tests locally. 
+    - Run `cd apps/vscode && npm run test` to run tests locally. 
     - Before submitting PR, run `npm run format:fix` to format your code
 
 ### Extension
@@ -73,6 +73,7 @@ We also welcome contributions to our [documentation](https://github.com/cline/cl
     - If you dismissed the prompts, you can install them manually from the Extensions panel
 
 2. **Local Development**
+    - cd into the vscode extension, `cd apps/vscode`
     - Run `npm run install:all` to install dependencies
     - Run `npm run protos` to generate Protocol Buffer files (required before first build)
     - Run `npm run test` to run tests locally


### PR DESCRIPTION
This very small PR updates the most basic contributing commands to guide the user to the proper place. There will be a continuation with the move to `bun`, to make it so that all scripts can be run from the root and do what we intend to do, at which time I will finish updating the guides.