### PR TITLE
fix(cli): make config footer toggle hint contextual ENG-2033

### DIFF
--- a/sdk/apps/cli/src/tui/views/config-view-helpers.ts
+++ b/sdk/apps/cli/src/tui/views/config-view-helpers.ts
@@ -162,8 +162,35 @@ export function isInlineConfigAction(
 	return action?.kind === "toggle-item";
 }
 
-export function getConfigFooterText(): string {
-	return "←/→ switch tabs, ↑/↓ navigate, Tab/Enter select, Space toggle, Esc close";
+export function canToggleConfigFooterRow(
+	row:
+		| { kind: "toggle" }
+		| { kind: "ext"; enabled?: boolean; item: InteractiveConfigItem }
+		| { kind: string }
+		| undefined,
+): boolean {
+	if (!row) {
+		return false;
+	}
+	if (row.kind === "toggle") {
+		return true;
+	}
+	return (
+		row.kind === "ext" &&
+		"item" in row &&
+		typeof row.enabled === "boolean" &&
+		isToggleableConfigItem(row.item)
+	);
+}
+
+export function getConfigFooterText({
+	canToggle = false,
+}: {
+	canToggle?: boolean;
+} = {}): string {
+	return canToggle
+		? "←/→ switch tabs, ↑/↓ navigate, Tab/Enter select, Space toggle, Esc close"
+		: "←/→ switch tabs, ↑/↓ navigate, Tab/Enter select, Esc close";
 }
 
 export function getConfigItemDisplayName(name: string): string {

--- a/sdk/apps/cli/src/tui/views/config-view.test.ts
+++ b/sdk/apps/cli/src/tui/views/config-view.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { InteractiveConfigItem } from "../../tui/interactive-config";
 import {
+	canToggleConfigFooterRow,
 	getAdjacentConfigTab,
 	getConfigFooterText,
 	getConfigItemDisplayName,
@@ -34,6 +35,12 @@ describe("config view helpers", () => {
 		expect(isToggleableConfigItem(createItem({ kind: "workflow" }))).toBe(
 			false,
 		);
+	});
+
+	it("does not treat rule, agent, or hook rows as toggleable", () => {
+		expect(isToggleableConfigItem(createItem({ kind: "rule" }))).toBe(false);
+		expect(isToggleableConfigItem(createItem({ kind: "agent" }))).toBe(false);
+		expect(isToggleableConfigItem(createItem({ kind: "hook" }))).toBe(false);
 	});
 
 	it("keeps plugin tool rows toggleable", () => {
@@ -75,8 +82,38 @@ describe("config view helpers", () => {
 		});
 	});
 
-	it("mentions Space toggle in the footer", () => {
-		expect(getConfigFooterText()).toContain("Space toggle");
+	it("mentions Space toggle in the footer for toggleable rows", () => {
+		expect(getConfigFooterText({ canToggle: true })).toContain("Space toggle");
+	});
+
+	it("omits Space toggle in the footer for non-toggleable rows", () => {
+		expect(getConfigFooterText({ canToggle: false })).not.toContain(
+			"Space toggle",
+		);
+		expect(getConfigFooterText()).not.toContain("Space toggle");
+	});
+
+	it("derives footer toggle affordance from selected row behavior", () => {
+		const skill = createItem({ kind: "skill" });
+		const hook = createItem({ kind: "hook" });
+
+		expect(canToggleConfigFooterRow({ kind: "provider" })).toBe(false);
+		expect(canToggleConfigFooterRow({ kind: "toggle" })).toBe(true);
+		expect(
+			canToggleConfigFooterRow({
+				kind: "ext",
+				enabled: skill.enabled,
+				item: skill,
+			}),
+		).toBe(true);
+		expect(
+			canToggleConfigFooterRow({
+				kind: "ext",
+				enabled: hook.enabled,
+				item: hook,
+			}),
+		).toBe(false);
+		expect(canToggleConfigFooterRow({ kind: "mcp-manager" })).toBe(false);
 	});
 
 	it("supports restoring and advancing the active settings tab", () => {
@@ -109,7 +146,7 @@ describe("config view helpers", () => {
 		expect(
 			isInlineConfigAction(resolveConfigItemSelectAction(builtinTool)),
 		).toBe(true);
-		expect(getConfigFooterText()).not.toContain("details");
+		expect(getConfigFooterText({ canToggle: true })).not.toContain("details");
 	});
 
 	it("returns item names without decoration", () => {

--- a/sdk/apps/cli/src/tui/views/config-view.tsx
+++ b/sdk/apps/cli/src/tui/views/config-view.tsx
@@ -17,6 +17,7 @@ import { resolveModelDisplayName } from "../components/status-bar";
 import { getModeAccent, palette } from "../palette";
 import {
 	type ConfigAction,
+	canToggleConfigFooterRow,
 	getAdjacentConfigTab,
 	getConfigFooterText,
 	getConfigItemDisplayName,
@@ -451,6 +452,8 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 
 	const clampedNavPos = Math.min(navPos, Math.max(0, navIndices.length - 1));
 	const selectedRowIdx = navIndices[clampedNavPos] ?? 0;
+	const selectedRow = rows[selectedRowIdx];
+	const canToggleSelectedRow = canToggleConfigFooterRow(selectedRow);
 
 	const setNavPosition = (nextNavPos: number) => {
 		setNavPos(nextNavPos);
@@ -774,7 +777,11 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 			<text> </text>
 			{toggleError && <text fg="red">{toggleError}</text>}
 			<text fg="gray">
-				<em>{togglingItemId ? "Applying settings" : getConfigFooterText()}</em>
+				<em>
+					{togglingItemId
+						? "Applying settings"
+						: getConfigFooterText({ canToggle: canToggleSelectedRow })}
+				</em>
 			</text>
 		</box>
 	);


### PR DESCRIPTION
### Related Issue

**Issue:** ENG-2033

### Description

Updates the SDK CLI interactive config view footer so `Space toggle` is only shown when the currently selected row can actually toggle.

This keeps hooks, rules, agents, workflows, provider/model rows, and the MCP manager row non-toggleable while removing the misleading footer affordance for those rows. General setting rows and toggleable config items continue to show the toggle hint.

### Test Procedure

Ran focused SDK CLI validation from `sdk/`:

```bash
bun test apps/cli/src/tui/views/config-view.test.ts
bun -F @cline/cli typecheck
bun biome check apps/cli/src/tui/views/config-view-helpers.ts apps/cli/src/tui/views/config-view.tsx apps/cli/src/tui/views/config-view.test.ts
```

The config-view test now covers both the footer text helper and the selected-row affordance decision used by the config view.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="558" height="244" alt="Screenshot 2026-05-21 at 6 53 55 PM" src="https://github.com/user-attachments/assets/fed51714-0beb-4bb6-96ad-9e807ffb5823" />
<img width="561" height="254" alt="Screenshot 2026-05-21 at 6 54 00 PM" src="https://github.com/user-attachments/assets/dcacf978-4779-42f9-838d-0e415ab2b09a" />
<img width="564" height="131" alt="Screenshot 2026-05-21 at 6 54 09 PM" src="https://github.com/user-attachments/assets/bf25027e-def4-49e1-87a0-65eca2c3b8f2" />
<img width="564" height="125" alt="Screenshot 2026-05-21 at 6 54 13 PM" src="https://github.com/user-attachments/assets/a874d8aa-7ed8-478c-a507-7deb3f0c6a95" />
<img width="559" height="130" alt="Screenshot 2026-05-21 at 6 54 24 PM" src="https://github.com/user-attachments/assets/360a8f4d-1fcb-4a30-af8d-f49df4d60374" />
<img width="554" height="557" alt="Screenshot 2026-05-21 at 6 54 53 PM" src="https://github.com/user-attachments/assets/bb6f0645-e206-4198-a048-bb2b6b260068" />
<img width="555" height="146" alt="Screenshot 2026-05-21 at 6 55 00 PM" src="https://github.com/user-attachments/assets/798ecbf3-d11c-459b-b9de-2d731b13df67" />
<img width="559" height="192" alt="Screenshot 2026-05-21 at 6 55 09 PM" src="https://github.com/user-attachments/assets/9f9353b3-7a6e-4fdc-86f7-eecde506f950" />
<img width="556" height="182" alt="Screenshot 2026-05-21 at 6 55 15 PM" src="https://github.com/user-attachments/assets/dc3bee6d-da90-4774-88ef-d9213fec3877" />


### Additional Notes

This intentionally does not add hook toggling. Hooks remain non-toggleable; the UI now avoids advertising a toggle action for them.
