### PR TITLE
fix: prevent task history entry missing when sending only attachments

### DIFF
--- a/src/core/controller/task/getTaskHistory.ts
+++ b/src/core/controller/task/getTaskHistory.ts
@@ -19,8 +19,11 @@ export async function getTaskHistory(controller: Controller, request: GetTaskHis
 
 		// Apply filters
 		let filteredTasks = taskHistory.filter((item) => {
-			// Basic filter: must have timestamp and task content
-			const hasRequiredFields = item.ts && item.task
+			// Basic filter: must have timestamp. We use a truthy check on task
+			// to filter out corrupted entries, but allow empty-string task values
+			// since they represent valid tasks (e.g. attachments-only messages)
+			// that may exist from older versions before the fallback description fix.
+			const hasRequiredFields = !!item.ts
 			if (!hasRequiredFields) {
 				return false
 			}

--- a/src/core/controller/task/getTaskHistory.ts
+++ b/src/core/controller/task/getTaskHistory.ts
@@ -19,10 +19,9 @@ export async function getTaskHistory(controller: Controller, request: GetTaskHis
 
 		// Apply filters
 		let filteredTasks = taskHistory.filter((item) => {
-			// Basic filter: must have timestamp. We use a truthy check on task
-			// to filter out corrupted entries, but allow empty-string task values
-			// since they represent valid tasks (e.g. attachments-only messages)
-			// that may exist from older versions before the fallback description fix.
+			// Basic filter: must have timestamp. Legacy entries may have an empty
+			// or missing task field (e.g. from attachments-only messages before the
+			// fallback description fix), so we only guard on timestamp here.
 			const hasRequiredFields = !!item.ts
 			if (!hasRequiredFields) {
 				return false
@@ -63,7 +62,7 @@ export async function getTaskHistory(controller: Controller, request: GetTaskHis
 		if (searchQuery) {
 			// Simple search implementation
 			const query = searchQuery.toLowerCase()
-			filteredTasks = filteredTasks.filter((item) => item.task.toLowerCase().includes(query))
+			filteredTasks = filteredTasks.filter((item) => (item.task ?? "").toLowerCase().includes(query))
 		}
 
 		// Calculate total count before sorting

--- a/src/core/task/message-state.ts
+++ b/src/core/task/message-state.ts
@@ -82,6 +82,27 @@ export class MessageStateHandler extends EventEmitter<MessageStateHandlerEvents>
 	}
 
 	/**
+	 * Generate a fallback task description when the user sends only attachments
+	 * without any text content, ensuring the history entry has a meaningful display text
+	 * so it won't be filtered out by the falsy `task` check in getTaskHistory.
+	 */
+	private generateFallbackTaskDescription(taskMessage: ClineMessage): string {
+		const imageCount = taskMessage.images?.length ?? 0
+		const fileCount = taskMessage.files?.length ?? 0
+
+		if (imageCount > 0 && fileCount > 0) {
+			return `[${imageCount} image(s), ${fileCount} file(s)]`
+		}
+		if (imageCount > 0) {
+			return `[${imageCount} image(s)]`
+		}
+		if (fileCount > 0) {
+			return `[${fileCount} file(s)]`
+		}
+		return "New Task"
+	}
+
+	/**
 	 * Execute function with exclusive lock on message state
 	 * Use this for ANY state modification to prevent race conditions
 	 * This follows the same pattern as Task.withStateLock for consistency
@@ -146,7 +167,7 @@ export class MessageStateHandler extends EventEmitter<MessageStateHandlerEvents>
 				id: this.taskId,
 				ulid: this.ulid,
 				ts: lastRelevantMessage.ts,
-				task: taskMessage.text ?? "",
+				task: taskMessage.text || this.generateFallbackTaskDescription(taskMessage),
 				tokensIn: apiMetrics.totalTokensIn,
 				tokensOut: apiMetrics.totalTokensOut,
 				cacheWrites: apiMetrics.totalCacheWrites,


### PR DESCRIPTION
## Bug Description

When a user sends a message with **only attachments (images/files) and no text**, the task runs correctly in the chat view but **does not appear in the task history view**.

## Root Cause

The bug has two contributing factors:

1. **Empty task field in history item**: In MessageStateHandler.saveClineMessagesAndUpdateHistoryInternal(), the history item's task field is set to taskMessage.text ?? "". When the user sends only attachments with no text, this results in task: "" (empty string).

2. **Falsy filter in getTaskHistory**: The history filter checks item.ts && item.task. Since empty string "" is falsy in JavaScript, the condition evaluates to false, and the task entry is filtered out from the history view.

### Flow

User sends only attachments → messageToSend = "" → newTask(text="") → taskMessage.text = "" → HistoryItem.task = "" → getTaskHistory filter: "" is falsy → task NOT shown in history

## Fix

### 1. Add fallback task description (message-state.ts)

Added generateFallbackTaskDescription() method that produces a meaningful description when text is empty but attachments exist:
- [2 image(s)] — when only images are attached
- [3 file(s)] — when only files are attached
- [1 image(s), 2 file(s)] — when both are attached
- "New Task" — as a final fallback

Changed the task field assignment from:
```ts
task: taskMessage.text ?? ""
```
to:
```ts
task: taskMessage.text || this.generateFallbackTaskDescription(taskMessage)
```

### 2. Relax history filter (getTaskHistory.ts)

Changed the filter from:
```ts
const hasRequiredFields = item.ts && item.task
```
to:
```ts
const hasRequiredFields = !!item.ts
```

This is a defensive fix — even if legacy entries have an empty task string (from older versions before this fix), they will still appear in the history view rather than being silently hidden.

## Testing

- Send a message with only an image attached (no text) → task should now appear in history with description [1 image(s)]
- Send a message with only a file attached → task appears with [1 file(s)]
- Send a message with both images and files → task appears with [1 image(s), 1 file(s)]
- Send a normal text message → behavior unchanged, task field shows the user text