### PR TITLE
fix(llms): revert implicit output cap regression

### DIFF
--- a/sdk/packages/llms/src/catalog/README.md
+++ b/sdk/packages/llms/src/catalog/README.md
@@ -77,14 +77,13 @@ while generating the catalog. Conceptually:
 safeOutputTokens = min(
 	modelReportedMaxOutput,
 	contextWindow - estimatedPromptTokens - reserveTokens,
-	productDefaultOutputCap,
 	userConfiguredOutputCap,
 )
 ```
 
-The SDK gateway currently uses `DEFAULT_GATEWAY_MAX_OUTPUT_TOKENS = 32_000` as
-the default product-level output cap when the request does not provide
-`request.options.maxTokens`.
+The SDK gateway only sends an output token limit when the caller provides
+`request.options.maxTokens` or an equivalent host configuration. Catalog
+metadata does not become a request parameter by itself.
 
 The exact request-limit policy belongs in the provider/gateway/core request
 path, not in generated catalog data.

--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -888,7 +888,9 @@ function createAiSdkProvider(kind: ProviderModuleKind): GatewayProviderFactory {
 					...(useSystemOption ? { system: systemPrompt } : {}),
 					tools: tools as never,
 					temperature: request.temperature,
-					maxOutputTokens: request.maxTokens,
+					...(request.maxTokens !== undefined
+						? { maxOutputTokens: request.maxTokens }
+						: {}),
 					abortSignal: request.signal,
 					experimental_telemetry: {
 						isEnabled: langfuse,

--- a/sdk/packages/llms/src/providers/compat.test.ts
+++ b/sdk/packages/llms/src/providers/compat.test.ts
@@ -356,7 +356,7 @@ describe("createGatewayApiHandler.createMessage", () => {
 		openaiCompatibleSpy.mockClear();
 	});
 
-	it("caps catalog maxTokens before passing maxOutputTokens to AI SDK", async () => {
+	it("does not convert catalog maxTokens into request maxOutputTokens", async () => {
 		streamTextSpy.mockReturnValue({
 			fullStream: (async function* () {
 				yield { type: "finish", finishReason: "stop" };
@@ -387,14 +387,13 @@ describe("createGatewayApiHandler.createMessage", () => {
 			// Drain the stream so the provider request is executed.
 		}
 
-		expect(streamTextSpy).toHaveBeenCalledWith(
-			expect.objectContaining({
-				maxOutputTokens: 32_000,
-			}),
-		);
+		const call = streamTextSpy.mock.calls.at(-1)?.[0] as
+			| { maxOutputTokens?: unknown }
+			| undefined;
+		expect(call).not.toHaveProperty("maxOutputTokens");
 	});
 
-	it("uses catalog maxTokens as the model output cap when below the default cap", async () => {
+	it("caps configured maxOutputTokens with the catalog model output limit", async () => {
 		streamTextSpy.mockReturnValue({
 			fullStream: (async function* () {
 				yield { type: "finish", finishReason: "stop" };
@@ -407,6 +406,7 @@ describe("createGatewayApiHandler.createMessage", () => {
 			clientType: "openai-compatible",
 			modelId: "small-output",
 			apiKey: "test-key",
+			maxOutputTokens: 16_000,
 			knownModels: {
 				"small-output": {
 					id: "small-output",

--- a/sdk/packages/llms/src/providers/gateway.test.ts
+++ b/sdk/packages/llms/src/providers/gateway.test.ts
@@ -1709,6 +1709,31 @@ describe("sdk-gateway", () => {
 		});
 	});
 
+	it("does not send maxOutputTokens to ChatGPT OAuth when the request omits max tokens", async () => {
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([
+				{ type: "finish", usage: { inputTokens: 1, outputTokens: 1 } },
+			]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [{ providerId: "openai-codex" }],
+		});
+
+		await collect(
+			await gateway.stream({
+				providerId: "openai-codex",
+				modelId: "gpt-5.4",
+				messages: baseMessages,
+			}),
+		);
+
+		const call = streamTextSpy.mock.calls.at(-1)?.[0] as
+			| { maxOutputTokens?: unknown }
+			| undefined;
+		expect(call).not.toHaveProperty("maxOutputTokens");
+	});
+
 	it("passes Codex instructions through provider options and removes the system message from messages", async () => {
 		streamTextSpy.mockReturnValue({
 			fullStream: makeStreamParts([

--- a/sdk/packages/llms/src/providers/gateway.test.ts
+++ b/sdk/packages/llms/src/providers/gateway.test.ts
@@ -2,7 +2,6 @@ import type { AgentMessage, AgentModelEvent } from "@cline/shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { normalizeModelsDevProviderModels } from "../catalog/catalog-live";
 import {
-	DEFAULT_GATEWAY_MAX_OUTPUT_TOKENS,
 	createGateway,
 	estimateRequestInputTokens,
 	resolveGatewayRequestMaxTokens,
@@ -143,15 +142,17 @@ describe("sdk-gateway", () => {
 		}
 	});
 
-	it("resolves request max tokens from explicit, model, default, and context caps", () => {
+	it("does not synthesize request max tokens from catalog metadata", () => {
 		expect(
 			resolveGatewayRequestMaxTokens({
 				requestedMaxTokens: undefined,
 				model: { maxOutputTokens: 202_800, contextWindow: 202_800 },
 				estimatedInputTokens: 1_000,
 			}),
-		).toBe(DEFAULT_GATEWAY_MAX_OUTPUT_TOKENS);
+		).toBeUndefined();
+	});
 
+	it("resolves explicit request max tokens from model and context caps", () => {
 		expect(
 			resolveGatewayRequestMaxTokens({
 				requestedMaxTokens: 8_192,
@@ -213,10 +214,10 @@ describe("sdk-gateway", () => {
 		expect(estimatedTokens).toBeGreaterThan(4_000);
 	});
 
-	it("applies a conservative default output cap for catalog models", async () => {
+	it("does not apply catalog output caps when the request omits max tokens", async () => {
 		const createProvider = vi.fn(() => ({
 			async *stream(request: { maxTokens?: number }) {
-				expect(request.maxTokens).toBe(DEFAULT_GATEWAY_MAX_OUTPUT_TOKENS);
+				expect(request.maxTokens).toBeUndefined();
 				yield { type: "finish", reason: "stop" } satisfies AgentModelEvent;
 			},
 		}));
@@ -1756,8 +1757,12 @@ describe("sdk-gateway", () => {
 			}),
 		);
 		const call = streamTextSpy.mock.calls.at(-1)?.[0] as
-			| { providerOptions?: Record<string, Record<string, unknown>> }
+			| {
+					maxOutputTokens?: unknown;
+					providerOptions?: Record<string, Record<string, unknown>>;
+			  }
 			| undefined;
+		expect(call).not.toHaveProperty("maxOutputTokens");
 		expect(call?.providerOptions?.openai).not.toHaveProperty("truncation");
 		expect(call?.providerOptions?.["openai-codex"]).not.toHaveProperty(
 			"truncation",

--- a/sdk/packages/llms/src/providers/gateway.ts
+++ b/sdk/packages/llms/src/providers/gateway.ts
@@ -19,7 +19,6 @@ import { GatewayRegistry } from "./registry";
 
 export type * from "@cline/shared";
 
-export const DEFAULT_GATEWAY_MAX_OUTPUT_TOKENS = 32_000;
 const GATEWAY_OUTPUT_RESERVE_TOKENS = 1_024;
 
 export interface Gateway {
@@ -156,7 +155,6 @@ export function resolveGatewayRequestMaxTokens(input: {
 	requestedMaxTokens?: number;
 	model: Pick<GatewayModelDefinition, "contextWindow" | "maxOutputTokens">;
 	estimatedInputTokens: number;
-	defaultMaxOutputTokens?: number;
 	outputReserveTokens?: number;
 	onContextOverflow?: (details: {
 		contextWindow: number;
@@ -164,19 +162,11 @@ export function resolveGatewayRequestMaxTokens(input: {
 		reserveTokens: number;
 	}) => void;
 }): number | undefined {
-	const caps: number[] = [];
-	if (isPositiveFiniteNumber(input.requestedMaxTokens)) {
-		caps.push(Math.floor(input.requestedMaxTokens));
-	} else {
-		const defaultMaxOutputTokens =
-			input.defaultMaxOutputTokens ?? DEFAULT_GATEWAY_MAX_OUTPUT_TOKENS;
-		if (
-			isPositiveFiniteNumber(input.model.maxOutputTokens) ||
-			isPositiveFiniteNumber(input.model.contextWindow)
-		) {
-			caps.push(defaultMaxOutputTokens);
-		}
+	if (!isPositiveFiniteNumber(input.requestedMaxTokens)) {
+		return undefined;
 	}
+
+	const caps: number[] = [Math.floor(input.requestedMaxTokens)];
 
 	if (isPositiveFiniteNumber(input.model.maxOutputTokens)) {
 		caps.push(Math.floor(input.model.maxOutputTokens));
@@ -276,22 +266,24 @@ export class DefaultGateway implements Gateway {
 			request.providerId,
 		);
 		const provider = await providerRecord.createProvider(providerRecord.config);
-		const maxTokens = resolveGatewayRequestMaxTokens({
-			requestedMaxTokens: request.maxTokens,
-			model: resolved.model,
-			estimatedInputTokens: estimateRequestInputTokens(request),
-			onContextOverflow: (details) => {
-				this.logger?.log(
-					"Estimated prompt tokens exceed model context window",
-					{
-						severity: "warn",
-						providerId: resolved.provider.id,
-						modelId: resolved.model.id,
-						...details,
+		const maxTokens = isPositiveFiniteNumber(request.maxTokens)
+			? resolveGatewayRequestMaxTokens({
+					requestedMaxTokens: request.maxTokens,
+					model: resolved.model,
+					estimatedInputTokens: estimateRequestInputTokens(request),
+					onContextOverflow: (details) => {
+						this.logger?.log(
+							"Estimated prompt tokens exceed model context window",
+							{
+								severity: "warn",
+								providerId: resolved.provider.id,
+								modelId: resolved.model.id,
+								...details,
+							},
+						);
 					},
-				);
-			},
-		});
+				})
+			: undefined;
 		const stream = await provider.stream(
 			{
 				...request,


### PR DESCRIPTION
This fixes a regression in the SDK/apps/cli ChatGPT OAuth provider where starting a chat and sending a message could fail with:

```text
Error: unsupported parameter: max_output_tokens
```

Regression source:

- The regression was introduced by Robin's PR #10946, commit `2508e76af`, `Fix SDK model catalog token-limit semantics ENG-2100`.
- The useful part of that PR was catalog-side: it preserved provider-reported output limits instead of inventing small generated catalog caps. This PR keeps that behavior.
- The breaking part was request-side: the SDK gateway started converting catalog metadata into a concrete `request.maxTokens` value even when the caller did not configure one.
- `ai-sdk.ts` already forwarded any defined `request.maxTokens` as AI SDK `maxOutputTokens`.
- Once the gateway began synthesizing `request.maxTokens`, the OpenAI Responses adapter serialized it as `max_output_tokens`.
- The ChatGPT OAuth Codex backend at `chatgpt.com/backend-api/codex` rejects that parameter, so the first message could fail before a response streamed.

What this PR changes:

- Removes the implicit gateway default output cap from the request path.
- Keeps model catalog `maxTokens` as model capability metadata, not as an automatic provider request parameter.
- Only resolves and forwards `request.maxTokens` when a caller or host configuration explicitly provides a max output cap.
- Still clamps an explicit max output cap against the catalog model output limit and estimated remaining context window.
- Updates the AI SDK request construction so `maxOutputTokens` is omitted entirely when `request.maxTokens` is absent.
- Adds a dedicated ChatGPT OAuth regression test asserting that `openai-codex` requests do not include `maxOutputTokens` when the request omitted max tokens.

Why this is a partial revert instead of a full revert:

- A full revert of #10946 would throw away the catalog correctness work.
- The actual regression was the new behavior that treated catalog metadata as request intent.
- This PR reverts that behavior while preserving the catalog metadata semantics from Robin's PR.

What should be investigated next:

- Whether the SDK should have a product-level default max output cap at all, and if so where that default should be expressed.
- Whether default output caps should be host-owned, provider-owned, model-owned, or caller-owned rather than synthesized globally in the gateway.
- Whether provider manifests need explicit transport capability metadata for request parameters like `maxOutputTokens`, so future request-policy work can avoid provider-id checks and avoid assuming Responses-shaped backends support every OpenAI Responses field.
- Whether ChatGPT OAuth Codex should eventually support `max_output_tokens`, or whether the SDK should permanently treat that backend as a Responses-like but not fully Responses-compatible transport.
- Whether live provider tests should include a minimal ChatGPT OAuth smoke test for unsupported request parameters.
