### PR TITLE
fix(cli): defer empty session creation after reset

### DIFF
--- a/sdk/apps/cli/src/runtime/interactive/chat-command-runner.test.ts
+++ b/sdk/apps/cli/src/runtime/interactive/chat-command-runner.test.ts
@@ -42,6 +42,7 @@ function makeRuntime(): InteractiveChatCommandRuntime {
 	return {
 		forkCurrentSession: vi.fn(async () => undefined),
 		getActiveSessionId: vi.fn(() => "session-1"),
+		resetForNewSession: vi.fn(async () => {}),
 		restartEmpty: vi.fn(async () => {}),
 	};
 }
@@ -99,6 +100,34 @@ describe("runInteractiveChatCommand", () => {
 		expect(config.enableAgentTeams).toBe(true);
 		expect(config.teamName).toBeTruthy();
 		expect(runtime.restartEmpty).toHaveBeenCalledOnce();
+	});
+
+	it("resets slash new without eagerly restarting the runtime", async () => {
+		const config = makeConfig();
+		const runtime = makeRuntime();
+
+		const result = await runInteractiveChatCommand({
+			prompt: "/new",
+			enabled: true,
+			config,
+			host: chatCommandHost,
+			chatCommandState: makeState(config),
+			autoApproveAllRef: { current: false },
+			setInteractiveAutoApprove: () => {},
+			sessionRuntime: runtime,
+			stop: () => {},
+		});
+
+		expect(result).toEqual({
+			handled: true,
+			turnResult: {
+				usage: { inputTokens: 0, outputTokens: 0 },
+				iterations: 0,
+				commandOutput: "Started a fresh session.",
+			},
+		});
+		expect(runtime.resetForNewSession).toHaveBeenCalledOnce();
+		expect(runtime.restartEmpty).not.toHaveBeenCalled();
 	});
 
 	it("applies chat command state updates and returns command output", async () => {

--- a/sdk/apps/cli/src/runtime/interactive/chat-command-runner.ts
+++ b/sdk/apps/cli/src/runtime/interactive/chat-command-runner.ts
@@ -18,7 +18,10 @@ type AutoApproveRef = {
 
 export type InteractiveChatCommandRuntime = Pick<
 	ReturnType<typeof createInteractiveSessionRuntime>,
-	"forkCurrentSession" | "getActiveSessionId" | "restartEmpty"
+	| "forkCurrentSession"
+	| "getActiveSessionId"
+	| "resetForNewSession"
+	| "restartEmpty"
 >;
 
 export type InteractiveChatCommandResult =
@@ -79,7 +82,7 @@ export async function runInteractiveChatCommand(input: {
 			commandOutput = text;
 		},
 		reset: async () => {
-			await input.sessionRuntime.restartEmpty();
+			await input.sessionRuntime.resetForNewSession();
 		},
 		stop: async () => {
 			input.stop();

--- a/sdk/apps/cli/src/runtime/interactive/session-runtime.test.ts
+++ b/sdk/apps/cli/src/runtime/interactive/session-runtime.test.ts
@@ -94,7 +94,7 @@ function makeSwitchToActModeTool(): AgentTool {
 
 function makeManager() {
 	let startCount = 0;
-	const start = vi.fn(async () => {
+	const start = vi.fn(async (_input?: unknown) => {
 		startCount += 1;
 		const sessionId = `session-${startCount}`;
 		return {
@@ -124,12 +124,16 @@ function makeManager() {
 	};
 }
 
-function makeRuntime(manager: ReturnType<typeof makeManager>) {
+function makeRuntime(
+	manager: ReturnType<typeof makeManager>,
+	options: { resumeSessionId?: string } = {},
+) {
 	mockCreateCliCore.mockResolvedValue(manager);
 	const config = makeConfig();
 	return createInteractiveSessionRuntime({
 		config,
 		providerSettingsManager: {} as ProviderSettingsManager,
+		resumeSessionId: options.resumeSessionId,
 		chatCommandState: makeChatCommandState(config),
 		requestToolApproval: async (
 			_request: ToolApprovalRequest,
@@ -173,6 +177,47 @@ describe("createInteractiveSessionRuntime", () => {
 
 		expect(manager.start).toHaveBeenCalledTimes(2);
 		expect(runtime.getActiveSessionId()).toBe("session-2");
+	});
+
+	it("starts fresh after resetting an initially resumed session", async () => {
+		const manager = makeManager();
+		const runtime = makeRuntime(manager, {
+			resumeSessionId: "resumed-session",
+		});
+
+		await runtime.ensureReady();
+
+		expect(mockLoadInteractiveResumeMessages).toHaveBeenNthCalledWith(
+			1,
+			manager,
+			"resumed-session",
+		);
+		expect(manager.start).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining({
+				config: expect.objectContaining({
+					sessionId: "resumed-session",
+				}),
+			}),
+		);
+
+		await runtime.resetForNewSession();
+		await runtime.ensureReady();
+
+		expect(mockLoadInteractiveResumeMessages).toHaveBeenNthCalledWith(
+			2,
+			manager,
+			undefined,
+		);
+		expect(manager.start).toHaveBeenCalledTimes(2);
+		expect(manager.start).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining({
+				config: expect.not.objectContaining({
+					sessionId: "resumed-session",
+				}),
+			}),
+		);
 	});
 
 	it("keeps explicit empty restarts eager for config-driven restarts", async () => {

--- a/sdk/apps/cli/src/runtime/interactive/session-runtime.test.ts
+++ b/sdk/apps/cli/src/runtime/interactive/session-runtime.test.ts
@@ -1,0 +1,189 @@
+import type {
+	AgentEvent,
+	ProviderSettingsManager,
+	TeamEvent,
+	ToolApprovalRequest,
+	ToolApprovalResult,
+} from "@cline/core";
+import type { AgentTool } from "@cline/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChatCommandState } from "../../utils/chat-commands";
+import type { Config } from "../../utils/types";
+
+const {
+	mockCreateCliCore,
+	mockCreateRuntimeHooks,
+	mockLoadInteractiveResumeMessages,
+	mockSetActiveCliSession,
+} = vi.hoisted(() => ({
+	mockCreateCliCore: vi.fn(),
+	mockCreateRuntimeHooks: vi.fn(),
+	mockLoadInteractiveResumeMessages: vi.fn(),
+	mockSetActiveCliSession: vi.fn(),
+}));
+
+vi.mock("../../session/session", () => ({
+	createCliCore: mockCreateCliCore,
+}));
+
+vi.mock("../../utils/hooks", () => ({
+	createRuntimeHooks: mockCreateRuntimeHooks,
+}));
+
+vi.mock("../../utils/output", () => ({
+	setActiveCliSession: mockSetActiveCliSession,
+}));
+
+vi.mock("../../utils/resume", () => ({
+	loadInteractiveResumeMessages: mockLoadInteractiveResumeMessages,
+}));
+
+vi.mock("../../utils/approval", () => ({
+	submitAndExitInTerminal: vi.fn(),
+}));
+
+vi.mock("../active-runtime", () => ({
+	markAbortInProgress: vi.fn(),
+}));
+
+vi.mock("../session-events", () => ({
+	subscribeToAgentEvents: vi.fn(() => vi.fn()),
+	subscribeToPendingPromptEvents: vi.fn(() => vi.fn()),
+}));
+
+import { createInteractiveSessionRuntime } from "./session-runtime";
+
+function makeConfig(): Config {
+	return {
+		apiKey: "",
+		providerId: "cline",
+		modelId: "openai/gpt-5.3-codex",
+		verbose: false,
+		sandbox: false,
+		thinking: false,
+		outputMode: "text",
+		mode: "act",
+		systemPrompt: "",
+		enableTools: true,
+		enableSpawnAgent: true,
+		enableAgentTeams: false,
+		defaultToolAutoApprove: false,
+		toolPolicies: {},
+		cwd: "/tmp/work",
+		workspaceRoot: "/tmp/work",
+	};
+}
+
+function makeChatCommandState(config: Config): ChatCommandState {
+	return {
+		enableTools: config.enableTools,
+		autoApproveTools: config.defaultToolAutoApprove,
+		cwd: config.cwd,
+		workspaceRoot: config.workspaceRoot?.trim() || config.cwd,
+	};
+}
+
+function makeSwitchToActModeTool(): AgentTool {
+	return {
+		name: "switch_to_act_mode",
+		description: "Switch to act mode",
+		inputSchema: { type: "object", properties: {} },
+		execute: () => ({ ok: true }),
+	};
+}
+
+function makeManager() {
+	let startCount = 0;
+	const start = vi.fn(async () => {
+		startCount += 1;
+		const sessionId = `session-${startCount}`;
+		return {
+			sessionId,
+			manifest: {
+				session_id: sessionId,
+			},
+		};
+	});
+	return {
+		start,
+		stop: vi.fn(async () => {}),
+		send: vi.fn(),
+		getAccumulatedUsage: vi.fn(),
+		abort: vi.fn(),
+		dispose: vi.fn(),
+		get: vi.fn(),
+		readMessages: vi.fn(async () => []),
+		readTranscript: vi.fn(),
+		ingestHookEvent: vi.fn(),
+		subscribe: vi.fn(),
+		updateSessionModel: vi.fn(),
+		pendingPrompts: {
+			update: vi.fn(),
+		},
+		restore: vi.fn(),
+	};
+}
+
+function makeRuntime(manager: ReturnType<typeof makeManager>) {
+	mockCreateCliCore.mockResolvedValue(manager);
+	const config = makeConfig();
+	return createInteractiveSessionRuntime({
+		config,
+		providerSettingsManager: {} as ProviderSettingsManager,
+		chatCommandState: makeChatCommandState(config),
+		requestToolApproval: async (
+			_request: ToolApprovalRequest,
+		): Promise<ToolApprovalResult> => ({ approved: true }),
+		askQuestionRef: { current: null },
+		resolveMistakeLimitDecision: undefined,
+		switchToActModeTool: makeSwitchToActModeTool(),
+		onAgentEvent: (_event: AgentEvent) => {},
+		onTeamEvent: (_event: TeamEvent) => {},
+		onPendingPrompts: () => {},
+		onPendingPromptSubmitted: () => {},
+	});
+}
+
+describe("createInteractiveSessionRuntime", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockCreateRuntimeHooks.mockReturnValue({
+			hooks: undefined,
+			shutdown: vi.fn(async () => {}),
+		});
+		mockLoadInteractiveResumeMessages.mockResolvedValue([]);
+	});
+
+	it("defers creating the replacement session after a new-session reset", async () => {
+		const manager = makeManager();
+		const runtime = makeRuntime(manager);
+
+		await runtime.ensureReady();
+		expect(manager.start).toHaveBeenCalledOnce();
+		expect(runtime.getActiveSessionId()).toBe("session-1");
+
+		await runtime.resetForNewSession();
+
+		expect(manager.stop).toHaveBeenCalledWith("session-1");
+		expect(manager.start).toHaveBeenCalledOnce();
+		expect(runtime.getActiveSessionId()).toBe("");
+		expect(mockSetActiveCliSession).toHaveBeenLastCalledWith(undefined);
+
+		await runtime.ensureReady();
+
+		expect(manager.start).toHaveBeenCalledTimes(2);
+		expect(runtime.getActiveSessionId()).toBe("session-2");
+	});
+
+	it("keeps explicit empty restarts eager for config-driven restarts", async () => {
+		const manager = makeManager();
+		const runtime = makeRuntime(manager);
+
+		await runtime.ensureReady();
+		await runtime.restartEmpty();
+
+		expect(manager.stop).toHaveBeenCalledWith("session-1");
+		expect(manager.start).toHaveBeenCalledTimes(2);
+		expect(runtime.getActiveSessionId()).toBe("session-2");
+	});
+});

--- a/sdk/apps/cli/src/runtime/interactive/session-runtime.ts
+++ b/sdk/apps/cli/src/runtime/interactive/session-runtime.ts
@@ -74,8 +74,14 @@ export function createInteractiveSessionRuntime(input: {
 	let shutdownRequested = false;
 	let activeSessionId = "";
 	let abortRequested = false;
+	let sessionGeneration = 0;
 
 	const initialResumeSessionId = input.resumeSessionId?.trim() || undefined;
+
+	const clearActiveSession = (): void => {
+		activeSessionId = "";
+		setActiveCliSession(undefined);
+	};
 
 	const applyStartedSession = (started: StartedSession): void => {
 		setActiveCliSession({
@@ -155,6 +161,7 @@ export function createInteractiveSessionRuntime(input: {
 		initial: Message[] = [],
 		sessionMetadata?: Record<string, unknown>,
 	): Promise<void> => {
+		const generation = sessionGeneration;
 		const manager = await ensureSessionManager();
 		const started = await manager.start({
 			source: SessionSource.CLI,
@@ -168,6 +175,10 @@ export function createInteractiveSessionRuntime(input: {
 				onTeamRestored: () => {},
 			},
 		});
+		if (generation !== sessionGeneration) {
+			await manager.stop(started.sessionId).catch(() => {});
+			return;
+		}
 		applyStartedSession(started);
 	};
 
@@ -175,6 +186,7 @@ export function createInteractiveSessionRuntime(input: {
 		resumeId: string,
 		initial: Message[] | undefined,
 	): Promise<void> => {
+		const generation = sessionGeneration;
 		const manager = await ensureSessionManager();
 		const started = await manager.start({
 			source: SessionSource.CLI,
@@ -190,10 +202,17 @@ export function createInteractiveSessionRuntime(input: {
 				onTeamRestored: () => {},
 			},
 		});
+		if (generation !== sessionGeneration) {
+			await manager.stop(started.sessionId).catch(() => {});
+			return;
+		}
 		applyStartedSession(started);
 	};
 
 	const ensureReady = async (): Promise<void> => {
+		if (activeSessionId) {
+			return;
+		}
 		if (startupPromise) {
 			return await startupPromise;
 		}
@@ -226,8 +245,9 @@ export function createInteractiveSessionRuntime(input: {
 	};
 
 	const stopCurrentSession = async (): Promise<void> => {
-		if (sessionManager && activeSessionId) {
-			await sessionManager.stop(activeSessionId);
+		const sessionId = activeSessionId;
+		if (sessionManager && sessionId) {
+			await sessionManager.stop(sessionId);
 		}
 	};
 
@@ -262,7 +282,11 @@ export function createInteractiveSessionRuntime(input: {
 		messages: Message[],
 		sessionMetadata?: Record<string, unknown>,
 	): Promise<void> => {
+		sessionGeneration += 1;
+		startupPromise = undefined;
+		startupError = undefined;
 		await stopCurrentSession();
+		clearActiveSession();
 		await startFreshSession(messages, sessionMetadata);
 	};
 
@@ -273,6 +297,18 @@ export function createInteractiveSessionRuntime(input: {
 
 	const restartEmpty = async (): Promise<void> => {
 		await restartWithMessages([]);
+	};
+
+	const resetForNewSession = async (): Promise<void> => {
+		sessionGeneration += 1;
+		startupPromise = undefined;
+		startupError = undefined;
+		const manager = sessionManager;
+		const sessionId = activeSessionId;
+		clearActiveSession();
+		if (manager && sessionId) {
+			await manager.stop(sessionId);
+		}
 	};
 
 	const applyMode = async (mode: "plan" | "act"): Promise<void> => {
@@ -537,6 +573,7 @@ export function createInteractiveSessionRuntime(input: {
 		getAccumulatedUsage,
 		readCurrentMessages,
 		restartEmpty,
+		resetForNewSession,
 		restartWithMessages,
 		restartWithCurrentMessages,
 		resumeSession,

--- a/sdk/apps/cli/src/runtime/interactive/session-runtime.ts
+++ b/sdk/apps/cli/src/runtime/interactive/session-runtime.ts
@@ -78,7 +78,7 @@ export function createInteractiveSessionRuntime(input: {
 	// Bump this before resets and restarts so stale starts cannot become active.
 	let sessionStartGeneration = 0;
 
-	const initialResumeSessionId = input.resumeSessionId?.trim() || undefined;
+	let pendingResumeSessionId = input.resumeSessionId?.trim() || undefined;
 
 	const clearActiveSession = (): void => {
 		activeSessionId = "";
@@ -220,15 +220,19 @@ export function createInteractiveSessionRuntime(input: {
 		}
 		startupPromise = (async () => {
 			const manager = await ensureSessionManager();
+			const resumeSessionId = pendingResumeSessionId;
 			const initialMessages = await loadInteractiveResumeMessages(
 				manager,
-				input.resumeSessionId,
+				resumeSessionId,
 			);
 			if (shutdownRequested) {
 				return;
 			}
-			if (initialResumeSessionId) {
-				await startResumedSession(initialResumeSessionId, initialMessages);
+			if (resumeSessionId) {
+				await startResumedSession(resumeSessionId, initialMessages);
+				if (pendingResumeSessionId === resumeSessionId) {
+					pendingResumeSessionId = undefined;
+				}
 			} else {
 				await startFreshSession(initialMessages);
 			}
@@ -285,6 +289,7 @@ export function createInteractiveSessionRuntime(input: {
 		sessionMetadata?: Record<string, unknown>,
 	): Promise<void> => {
 		sessionStartGeneration += 1;
+		pendingResumeSessionId = undefined;
 		startupPromise = undefined;
 		startupError = undefined;
 		await stopCurrentSession();
@@ -303,6 +308,7 @@ export function createInteractiveSessionRuntime(input: {
 
 	const resetForNewSession = async (): Promise<void> => {
 		sessionStartGeneration += 1;
+		pendingResumeSessionId = undefined;
 		startupPromise = undefined;
 		startupError = undefined;
 		const manager = sessionManager;

--- a/sdk/apps/cli/src/runtime/interactive/session-runtime.ts
+++ b/sdk/apps/cli/src/runtime/interactive/session-runtime.ts
@@ -74,7 +74,9 @@ export function createInteractiveSessionRuntime(input: {
 	let shutdownRequested = false;
 	let activeSessionId = "";
 	let abortRequested = false;
-	let sessionGeneration = 0;
+	// A reset can happen while an earlier manager.start() is still in flight.
+	// Bump this before resets and restarts so stale starts cannot become active.
+	let sessionStartGeneration = 0;
 
 	const initialResumeSessionId = input.resumeSessionId?.trim() || undefined;
 
@@ -161,7 +163,7 @@ export function createInteractiveSessionRuntime(input: {
 		initial: Message[] = [],
 		sessionMetadata?: Record<string, unknown>,
 	): Promise<void> => {
-		const generation = sessionGeneration;
+		const generation = sessionStartGeneration;
 		const manager = await ensureSessionManager();
 		const started = await manager.start({
 			source: SessionSource.CLI,
@@ -175,7 +177,7 @@ export function createInteractiveSessionRuntime(input: {
 				onTeamRestored: () => {},
 			},
 		});
-		if (generation !== sessionGeneration) {
+		if (generation !== sessionStartGeneration) {
 			await manager.stop(started.sessionId).catch(() => {});
 			return;
 		}
@@ -186,7 +188,7 @@ export function createInteractiveSessionRuntime(input: {
 		resumeId: string,
 		initial: Message[] | undefined,
 	): Promise<void> => {
-		const generation = sessionGeneration;
+		const generation = sessionStartGeneration;
 		const manager = await ensureSessionManager();
 		const started = await manager.start({
 			source: SessionSource.CLI,
@@ -202,7 +204,7 @@ export function createInteractiveSessionRuntime(input: {
 				onTeamRestored: () => {},
 			},
 		});
-		if (generation !== sessionGeneration) {
+		if (generation !== sessionStartGeneration) {
 			await manager.stop(started.sessionId).catch(() => {});
 			return;
 		}
@@ -282,7 +284,7 @@ export function createInteractiveSessionRuntime(input: {
 		messages: Message[],
 		sessionMetadata?: Record<string, unknown>,
 	): Promise<void> => {
-		sessionGeneration += 1;
+		sessionStartGeneration += 1;
 		startupPromise = undefined;
 		startupError = undefined;
 		await stopCurrentSession();
@@ -300,7 +302,7 @@ export function createInteractiveSessionRuntime(input: {
 	};
 
 	const resetForNewSession = async (): Promise<void> => {
-		sessionGeneration += 1;
+		sessionStartGeneration += 1;
 		startupPromise = undefined;
 		startupError = undefined;
 		const manager = sessionManager;

--- a/sdk/apps/cli/src/runtime/run-interactive.ts
+++ b/sdk/apps/cli/src/runtime/run-interactive.ts
@@ -585,6 +585,9 @@ export async function runInteractive(
 			}
 			await applyModeChange(mode);
 		},
+		onNewSession: async () => {
+			await sessionRuntime.resetForNewSession();
+		},
 		onModelChange: async () => {
 			await sessionRuntime.ensureReady();
 			const existing = providerSettingsManager.getProviderSettings(

--- a/sdk/apps/cli/src/tui/root.tsx
+++ b/sdk/apps/cli/src/tui/root.tsx
@@ -244,7 +244,7 @@ function App(props: TuiProps) {
 			return;
 		}
 		try {
-			await props.onSessionRestart();
+			await props.onNewSession();
 			setAppView("home");
 		} catch (error) {
 			setAppView("chat");

--- a/sdk/apps/cli/src/tui/root.tsx
+++ b/sdk/apps/cli/src/tui/root.tsx
@@ -235,8 +235,14 @@ function App(props: TuiProps) {
 	});
 
 	const clearConversation = useCallback(async () => {
+		const shouldRestartSession = session.hasSubmitted;
 		session.clearEntries();
 		session.setHasSubmitted(false);
+		if (!shouldRestartSession) {
+			setAppView("home");
+			refocusTextareaRef.current();
+			return;
+		}
 		try {
 			await props.onSessionRestart();
 			setAppView("home");

--- a/sdk/apps/cli/src/tui/types.ts
+++ b/sdk/apps/cli/src/tui/types.ts
@@ -162,6 +162,7 @@ export interface TuiProps {
 	onCompactionModeChange: (mode: CliCompactionMode) => Promise<void>;
 	onModelChange: () => Promise<void>;
 	onModeChange: (mode: AgentMode) => Promise<void>;
+	onNewSession: () => Promise<void>;
 	onSessionRestart: () => Promise<void>;
 	onAccountChange: () => Promise<void>;
 	onResumeSession: (sessionId: string) => Promise<ResumedSessionResult>;


### PR DESCRIPTION
### Related Issue

Issue: #XXXX

### Description

This PR fixes the delay when starting a fresh CLI conversation from `/new` or from the TUI clear action.

The original investigation looked at Remote Config because recent CLI session startup work made it a plausible source of repeated delay. After adding local timing logs and reproducing the issue, the important result was that Remote Config was not the dominant cost for the observed `/new` and clear pause. The slow part was the CLI eagerly creating a replacement empty backend session before returning the UI to the blank chat screen. In hub-backed runs, that eager `session.create` path was taking roughly a second by itself.

For a new empty conversation, the UI does not need a replacement backend session immediately. It only needs the old session stopped, the active session id cleared, and the conversation UI reset. The next real prompt already goes through `ensureReady()`, so it can create the backend session right before sending.

Technical approach:

- Add `resetForNewSession()` to the interactive session runtime.
- Have `/new` use that lazy reset path instead of `restartEmpty()`.
- Have submitted TUI clear use the same lazy reset path.
- Skip backend work entirely when clearing an already-empty UI.
- Keep `restartEmpty()` and config-driven restart flows eager, because model, MCP, account, compaction, and team changes need an active backend session immediately.
- Add a session generation guard so stale in-flight session starts cannot become active after a reset.

The resulting patch is intentionally narrow. It does not change Remote Config behavior, provider selection, model selection, or hub session creation itself. It only stops paying the backend session creation cost at the moment the user is trying to clear the screen or start a fresh empty conversation.

### Test Procedure

Focused tests run from `sdk/apps/cli`:

```bash
bunx vitest run --config vitest.config.ts src/runtime/interactive/session-runtime.test.ts src/runtime/interactive/chat-command-runner.test.ts src/tui/hooks/use-local-command-actions.test.ts
```

Typecheck run from `sdk/apps/cli`:

```bash
bun run typecheck
```

Repository whitespace check:

```bash
git diff --check
```

The new tests cover these cases:

- `/new` uses the lazy reset path instead of eagerly restarting the runtime.
- `resetForNewSession()` stops and clears the active session, then defers replacement session creation until the next `ensureReady()`.
- `restartEmpty()` remains eager for config-driven restart flows.

### Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Refactor Changes
-   [ ] Cosmetic Changes
-   [ ] Documentation update
-   [ ] Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. This is CLI runtime behavior with unit coverage.

### Additional Notes

The full repo `npm test`, `npm run format`, and `npm run lint` commands were not run. The focused CLI tests, CLI typecheck, and `git diff --check` were run locally.
