### PR TITLE
fix(cli): show loading dialog for history resume

### DIFF
--- a/sdk/apps/cli/src/tui/hooks/use-local-command-actions.tsx
+++ b/sdk/apps/cli/src/tui/hooks/use-local-command-actions.tsx
@@ -6,6 +6,7 @@ import type { SlashCommandRegistry } from "../commands/slash-command-registry";
 import { resolveSlashCommand } from "../commands/slash-command-registry";
 import { ForkConfirmContent } from "../components/dialogs/fork-confirm";
 import { HelpDialogContent } from "../components/dialogs/help-dialog";
+import { withLoadingDialog } from "../components/dialogs/loading-dialog";
 import { useSession } from "../contexts/session-context";
 import type { AppView, TuiProps } from "../types";
 import { formatCompactionStatus } from "../utils/compaction-status";
@@ -62,28 +63,30 @@ export function useLocalCommandActions(input: {
 		});
 		if (sessionId) {
 			try {
-				const result = await onResumeSession(sessionId);
-				const { messages } = result;
-				const entries = hydrateSessionMessages(messages);
-				if (entries.length === 0) {
-					session.appendEntry({
-						kind: "error",
-						text: `Session ${sessionId} has no messages to resume.`,
-					});
-				} else {
-					session.clearEntries();
-					for (const entry of entries) {
-						session.appendEntry(entry);
+				await withLoadingDialog(dialog, "Loading session...", async () => {
+					const result = await onResumeSession(sessionId);
+					const { messages } = result;
+					const entries = hydrateSessionMessages(messages);
+					if (entries.length === 0) {
+						session.appendEntry({
+							kind: "error",
+							text: `Session ${sessionId} has no messages to resume.`,
+						});
+					} else {
+						session.clearEntries();
+						for (const entry of entries) {
+							session.appendEntry(entry);
+						}
+						if (typeof result.currentContextSize === "number") {
+							session.setLastTotalTokens(result.currentContextSize);
+						}
+						if (typeof result.totalCost === "number") {
+							session.setLastTotalCost(result.totalCost);
+						}
+						session.setHasSubmitted(true);
+						setAppView("chat");
 					}
-					if (typeof result.currentContextSize === "number") {
-						session.setLastTotalTokens(result.currentContextSize);
-					}
-					if (typeof result.totalCost === "number") {
-						session.setLastTotalCost(result.totalCost);
-					}
-					session.setHasSubmitted(true);
-					setAppView("chat");
-				}
+				});
 			} catch (error) {
 				session.appendEntry({
 					kind: "error",


### PR DESCRIPTION
### Related Issue

Issue: #XXXX

### Description

This fixes a CLI TUI gap after selecting a session from `/history`. The history picker closes immediately, then resuming the selected session can take a second or two while the runtime loads the session and the TUI hydrates transcript entries. During that gap the chat surface looked idle, which made the selection feel like it had not registered.

The change reuses the loading dialog helper that was recently added for model and settings transitions. After the history dialog resolves a session id, the resume and hydration block now runs inside `withLoadingDialog(dialog, "Loading session...", ...)`. The existing success and error behavior stays in the same place: empty sessions still append the same error entry, successful sessions still clear the current entries, hydrate the selected messages, restore token and cost metadata, mark the session submitted, and switch to the chat view.

I considered adding a status entry to the transcript, but that would leave historical UI noise after every resume. A modal loading dialog fits the surrounding flow better because this is a transient transition between dialogs and the chat view.

### Test Procedure

- Ran `bun run test:unit src/tui/components/dialogs/loading-dialog.test.ts src/tui/hooks/use-local-command-actions.test.ts` from `sdk/apps/cli`.
- Ran `bun run typecheck` from `sdk/apps/cli`.
- Verified the branch diff against `origin/main` contains only the intended CLI TUI hook change after rebasing onto the current `origin/main`.

The main risk is regressing local slash command dialog flow, especially if the loading dialog is not closed on resume failure. The existing `withLoadingDialog` helper closes in `finally`, and the focused loading dialog tests cover success and failure cleanup.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

No screenshots included. This is a terminal transition state change that reuses the existing loading dialog.

### Additional Notes

I did not run the full `npm test`, format, or lint commands. I ran the focused CLI unit tests that cover the loading dialog lifecycle and local slash command action dispatch, plus the CLI typecheck.
