### PR TITLE
feat: add DeepSeek V4 models

### DIFF
--- a/src/core/api/providers/deepseek.ts
+++ b/src/core/api/providers/deepseek.ts
@@ -81,10 +81,10 @@ export class DeepSeekHandler implements ApiHandler {
 		const client = this.ensureClient()
 		const model = this.getModel()
 
-		const isDeepseekReasoner = model.id.includes("deepseek-reasoner")
+		const isDeepSeekThinkingModel = model.id.includes("deepseek-reasoner") || model.id.startsWith("deepseek-v4-")
 
 		const convertedMessages = convertToOpenAiMessages(messages)
-		const openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = isDeepseekReasoner
+		const openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = isDeepSeekThinkingModel
 			? [{ role: "system", content: systemPrompt }, ...addReasoningContent(convertedMessages, messages)]
 			: [{ role: "system", content: systemPrompt }, ...convertedMessages]
 
@@ -94,8 +94,8 @@ export class DeepSeekHandler implements ApiHandler {
 			messages: openAiMessages,
 			stream: true,
 			stream_options: { include_usage: true },
-			// Only set temperature for non-reasoner models
-			...(model.id === "deepseek-reasoner" ? {} : { temperature: 0 }),
+			// Only set temperature for non-thinking models
+			...(isDeepSeekThinkingModel ? {} : { temperature: 0 }),
 			...getOpenAIToolParams(tools),
 		})
 

--- a/src/core/api/providers/deepseek.ts
+++ b/src/core/api/providers/deepseek.ts
@@ -81,7 +81,8 @@ export class DeepSeekHandler implements ApiHandler {
 		const client = this.ensureClient()
 		const model = this.getModel()
 
-		const isDeepSeekThinkingModel = model.id.includes("deepseek-reasoner") || model.id.startsWith("deepseek-v4-")
+		const isDeepSeekThinkingModel =
+			model.id.includes("deepseek-reasoner") || model.id === "deepseek-v4-flash" || model.id === "deepseek-v4-pro"
 
 		const convertedMessages = convertToOpenAiMessages(messages)
 		const openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = isDeepSeekThinkingModel

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -2229,7 +2229,7 @@ export const deepSeekModels = {
 		supportsImages: false,
 		supportsPromptCache: true,
 		supportsReasoning: true,
-		inputPrice: 0.14,
+		inputPrice: 0, // all input is either a cache hit or miss
 		outputPrice: 0.28,
 		cacheWritesPrice: 0.14,
 		cacheReadsPrice: 0.0028,
@@ -2240,7 +2240,7 @@ export const deepSeekModels = {
 		supportsImages: false,
 		supportsPromptCache: true,
 		supportsReasoning: true,
-		inputPrice: 0.435,
+		inputPrice: 0, // all input is either a cache hit or miss
 		outputPrice: 0.87,
 		cacheWritesPrice: 0.435,
 		cacheReadsPrice: 0.003625,

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -2223,6 +2223,28 @@ export const azureOpenAiDefaultApiVersion = "2024-08-01-preview"
 export type DeepSeekModelId = keyof typeof deepSeekModels
 export const deepSeekDefaultModelId: DeepSeekModelId = "deepseek-chat"
 export const deepSeekModels = {
+	"deepseek-v4-flash": {
+		maxTokens: 384_000,
+		contextWindow: 1_000_000,
+		supportsImages: false,
+		supportsPromptCache: true,
+		supportsReasoning: true,
+		inputPrice: 0.14,
+		outputPrice: 0.28,
+		cacheWritesPrice: 0.14,
+		cacheReadsPrice: 0.0028,
+	},
+	"deepseek-v4-pro": {
+		maxTokens: 384_000,
+		contextWindow: 1_000_000,
+		supportsImages: false,
+		supportsPromptCache: true,
+		supportsReasoning: true,
+		inputPrice: 0.435,
+		outputPrice: 0.87,
+		cacheWritesPrice: 0.435,
+		cacheReadsPrice: 0.003625,
+	},
 	"deepseek-chat": {
 		maxTokens: 8_000,
 		contextWindow: 128_000,


### PR DESCRIPTION
### Related Issue

Issue: #XXXX

### Description

DeepSeek has introduced `deepseek-v4-flash` and `deepseek-v4-pro` as the current model ids for the direct DeepSeek API. The extension still only exposed the older `deepseek-chat` and `deepseek-reasoner` ids in the DeepSeek provider model list, so users could not select the new models from settings.

This PR adds both V4 model ids to the static DeepSeek model registry with their published context window, max output, prompt cache support, reasoning support, and current token pricing. It keeps `deepseek-chat` as the default so existing users are not migrated unexpectedly.

The DeepSeek handler already has special handling for `deepseek-reasoner` conversations because DeepSeek reasoning responses can include `reasoning_content` that needs to be replayed for tool-call turns. Since the V4 models default to thinking mode, this PR also routes `deepseek-v4-flash` and `deepseek-v4-pro` through that same existing thinking-message path and avoids forcing temperature on those thinking models.

I intentionally did not add new settings UI, change the provider base URL, change the default model, or change legacy model behavior. This keeps the change scoped to making the new DeepSeek ids selectable and usable through the current direct provider.

### Test Procedure

I verified the shared model registry and DeepSeek handler changes with focused local checks:

- `npx biome check src/shared/api.ts src/core/api/providers/deepseek.ts --no-errors-on-unmatched --files-ignore-unknown=true --diagnostic-level=error`
- `npx tsc --noEmit`
- `cd webview-ui && npx tsc --noEmit`

The main thing that could break is direct DeepSeek request formatting for existing users. Existing `deepseek-chat` and `deepseek-reasoner` ids remain in the registry, the default remains `deepseek-chat`, and the new V4 ids only extend the thinking-path condition that was already used for `deepseek-reasoner`.

I did not run a live DeepSeek API smoke test because that requires a DeepSeek API key in this environment.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

No screenshots. This is a provider model-list and request handling update.

### Additional Notes

DeepSeek’s docs indicate the older `deepseek-chat` and `deepseek-reasoner` names remain compatibility aliases for now, so this PR keeps them available rather than replacing them.
