### PR TITLE
fix: cap search_codebase output

### DIFF
--- a/sdk/packages/core/src/extensions/tools/executors/search.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/search.ts
@@ -131,7 +131,11 @@ function truncateOutput(output: string, maxOutputBytes: number): string {
 		return output;
 	}
 
-	return `${output.slice(0, maxOutputBytes)}\n\n[Output truncated: ${outputSize} bytes total, showing first ${maxOutputBytes} bytes]`;
+	const truncated = Buffer.from(output, "utf8")
+		.subarray(0, maxOutputBytes)
+		.toString("utf8")
+		.replace(/\uFFFD$/u, "");
+	return `${truncated}\n\n[Output truncated: ${outputSize} bytes total, showing first ${maxOutputBytes} bytes]`;
 }
 
 let rgAvailable: boolean | null = null;

--- a/sdk/packages/core/src/extensions/tools/executors/search.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/search.ts
@@ -44,6 +44,12 @@ export interface SearchExecutorOptions {
 	 * @default 20
 	 */
 	maxDepth?: number;
+
+	/**
+	 * Maximum output size in bytes
+	 * @default 1_000_000 (1MB)
+	 */
+	maxOutputBytes?: number;
 }
 
 const DEFAULT_INCLUDE_EXTENSIONS = [
@@ -117,6 +123,15 @@ interface SearchMatch {
 	column: number;
 	match: string;
 	context: string[];
+}
+
+function truncateOutput(output: string, maxOutputBytes: number): string {
+	const outputSize = Buffer.byteLength(output);
+	if (outputSize <= maxOutputBytes) {
+		return output;
+	}
+
+	return `${output.slice(0, maxOutputBytes)}\n\n[Output truncated: ${outputSize} bytes total, showing first ${maxOutputBytes} bytes]`;
 }
 
 let rgAvailable: boolean | null = null;
@@ -311,6 +326,7 @@ export function createSearchExecutor(
 		maxResults = 100,
 		contextLines = 2,
 		maxDepth = 20,
+		maxOutputBytes = 1_000_000,
 	} = options;
 	const excludeDirsSet = new Set(excludeDirs);
 	const includeExtensionsSet = new Set(
@@ -359,7 +375,7 @@ export function createSearchExecutor(
 				);
 			}
 
-			return resultLines.join("\n");
+			return truncateOutput(resultLines.join("\n"), maxOutputBytes);
 		}
 
 		// Fallback to manual regex search
@@ -445,7 +461,10 @@ export function createSearchExecutor(
 
 		// Format results
 		if (matches.length === 0) {
-			return `No results found for pattern: ${query}\nSearched ${totalFilesSearched} files.`;
+			return truncateOutput(
+				`No results found for pattern: ${query}\nSearched ${totalFilesSearched} files.`,
+				maxOutputBytes,
+			);
 		}
 
 		const resultLines: string[] = [
@@ -466,6 +485,6 @@ export function createSearchExecutor(
 			);
 		}
 
-		return resultLines.join("\n");
+		return truncateOutput(resultLines.join("\n"), maxOutputBytes);
 	};
 }


### PR DESCRIPTION
### Related Issue

Issue: #XXXX

### Description

This fixes a prompt overflow failure mode in the SDK CLI product when `search_codebase` returns a very large result.

The issue came up because `run_commands` already protects the model-facing tool result with a `maxOutputBytes` cap, but `search_codebase` only limited the number of matches. A broad search could still produce very large formatted output when matching lines or context lines were long, then that raw output would be fed into the next model request and could trigger an API prompt length error.

The change keeps the implementation intentionally aligned with the existing `run_commands` behavior:

- Add `maxOutputBytes` to `SearchExecutorOptions`.
- Default it to `1_000_000` bytes.
- Truncate the final formatted search output before returning it to the agent.
- Use the same truncation notice format as `run_commands`.

I initially considered a lower search-specific cap, but that would make `search_codebase` behave differently from `run_commands` and would be a more opinionated behavior change. This PR keeps the behavior pragmatic and minimal while still preventing unbounded search output.

One implementation detail worth calling out: this truncates the formatted output returned by each search executor invocation. It does not change result ranking, search matching, file indexing, or the CLI display preview.

### Test Procedure

Validation performed locally:

- Ran `bunx biome format --write sdk/packages/core/src/extensions/tools/executors/search.ts`.
- Ran `bun run typecheck` from `sdk/packages/core`.

Risk considered:

- Existing search behavior should remain unchanged for normal-sized results because the output is returned as-is when under the 1 MB cap.
- Oversized search results now return a truncated prefix plus an explicit truncation notice, matching the established shell command behavior.
- The public executor option shape only gains an optional field, so existing callers do not need changes.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. This is a non-UI SDK CLI tool executor change.

### Additional Notes

The full repository test suite and lint were not run locally. The targeted package typecheck passed.
