### PR TITLE
fix(tools): accept and apply per-call timeout in run_commands

### DIFF
--- a/sdk/packages/core/src/extensions/tools/definitions.test.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.test.ts
@@ -1,11 +1,20 @@
+import { zodToJsonSchema } from "@cline/shared";
 import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 import {
+	createBashTool,
 	createDefaultTools,
 	createReadFilesTool,
 	createSkillsTool,
 	createWindowsShellTool,
 } from "./definitions";
-import { INPUT_ARG_CHAR_LIMIT } from "./schemas";
+import {
+	INPUT_ARG_CHAR_LIMIT,
+	RUN_COMMANDS_TIMEOUT_MAX_MS,
+	RUN_COMMANDS_TIMEOUT_MIN_MS,
+	RunCommandsInputSchema,
+	StructuredCommandsInputSchema,
+} from "./schemas";
 import type { SkillsExecutorWithMetadata } from "./types";
 
 function createMockSkillsExecutor(
@@ -550,6 +559,167 @@ describe("default run_commands tool", () => {
 				iteration: 1,
 			}),
 		);
+	});
+
+	describe("timeout handling", () => {
+		// Reproduce the validation path used by ai-sdk.ts: JSON Schema is
+		// generated via the project's zodToJsonSchema wrapper (the same one
+		// createBashTool stores on inputSchema), then round-tripped through
+		// z.fromJSONSchema before being parsed. Using the wrapper here — not
+		// Zod's built-in z.toJSONSchema — is what makes this test actually
+		// guard against the original `Unrecognized key: "timeout"` regression.
+		function parseViaAiSdkPath(
+			schema:
+				| typeof RunCommandsInputSchema
+				| typeof StructuredCommandsInputSchema,
+			value: unknown,
+		) {
+			const json = zodToJsonSchema(schema);
+			return z.fromJSONSchema(json).safeParse(value);
+		}
+
+		it("emits additionalProperties: true via the project's zodToJsonSchema", () => {
+			// Without this, the schema change would silently fail to take effect
+			// because ai-sdk.ts uses the JSON Schema produced here for validation.
+			const json = zodToJsonSchema(RunCommandsInputSchema) as {
+				additionalProperties?: unknown;
+			};
+			expect(json.additionalProperties).not.toBe(false);
+			const structuredJson = zodToJsonSchema(StructuredCommandsInputSchema) as {
+				additionalProperties?: unknown;
+			};
+			expect(structuredJson.additionalProperties).not.toBe(false);
+		});
+
+		it("accepts payloads with timeout (the GPT-5.5 regression)", () => {
+			const payload = {
+				commands: [
+					"cd /tmp && python3 -m unittest discover -s app/tests -p 'test_*.py' -v",
+				],
+				timeout: 120000,
+			};
+			expect(parseViaAiSdkPath(RunCommandsInputSchema, payload).success).toBe(
+				true,
+			);
+			expect(
+				parseViaAiSdkPath(StructuredCommandsInputSchema, payload).success,
+			).toBe(true);
+		});
+
+		it("tolerates unrecognised passthrough keys without rejecting the call", () => {
+			const payload = {
+				commands: ["echo ok"],
+				timeout: 5000,
+				working_directory: "/tmp",
+				cwd: "/tmp",
+			};
+			expect(parseViaAiSdkPath(RunCommandsInputSchema, payload).success).toBe(
+				true,
+			);
+		});
+
+		it("uses the supplied timeout when the command outlives it", async () => {
+			vi.useFakeTimers();
+			try {
+				const tool = createBashTool(() => new Promise<string>(() => {}));
+				const requested = RUN_COMMANDS_TIMEOUT_MIN_MS * 5;
+				const pending = tool.execute(
+					{ commands: ["sleep 999"], timeout: requested } as never,
+					{ agentId: "a", conversationId: "c", iteration: 1 },
+				);
+				await vi.advanceTimersByTimeAsync(requested + 1);
+				const result = await pending;
+				expect(result[0]?.success).toBe(false);
+				expect(result[0]?.error).toMatch(
+					new RegExp(`timed out after ${requested}ms`),
+				);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it("clamps below-range timeout up to the minimum", async () => {
+			vi.useFakeTimers();
+			try {
+				const tool = createBashTool(() => new Promise<string>(() => {}));
+				const pending = tool.execute(
+					{ commands: ["sleep"], timeout: 1 } as never,
+					{ agentId: "a", conversationId: "c", iteration: 1 },
+				);
+				await vi.advanceTimersByTimeAsync(RUN_COMMANDS_TIMEOUT_MIN_MS + 1);
+				const result = await pending;
+				expect(result[0]?.success).toBe(false);
+				expect(result[0]?.error).toMatch(
+					new RegExp(`timed out after ${RUN_COMMANDS_TIMEOUT_MIN_MS}ms`),
+				);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it("clamps above-range timeout down to the maximum", async () => {
+			vi.useFakeTimers();
+			try {
+				const tool = createBashTool(() => new Promise<string>(() => {}));
+				const pending = tool.execute(
+					{
+						commands: ["sleep"],
+						timeout: RUN_COMMANDS_TIMEOUT_MAX_MS * 10,
+					} as never,
+					{ agentId: "a", conversationId: "c", iteration: 1 },
+				);
+				await vi.advanceTimersByTimeAsync(RUN_COMMANDS_TIMEOUT_MAX_MS + 1);
+				const result = await pending;
+				expect(result[0]?.success).toBe(false);
+				expect(result[0]?.error).toMatch(
+					new RegExp(`timed out after ${RUN_COMMANDS_TIMEOUT_MAX_MS}ms`),
+				);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it("falls back to the workspace default when timeout is omitted", async () => {
+			vi.useFakeTimers();
+			try {
+				const tool = createBashTool(() => new Promise<string>(() => {}), {
+					bashTimeoutMs: 7_500,
+				});
+				const pending = tool.execute({ commands: ["sleep"] } as never, {
+					agentId: "a",
+					conversationId: "c",
+					iteration: 1,
+				});
+				await vi.advanceTimersByTimeAsync(7_501);
+				const result = await pending;
+				expect(result[0]?.success).toBe(false);
+				expect(result[0]?.error).toMatch(/timed out after 7500ms/);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it("respects timeout for createWindowsShellTool", async () => {
+			vi.useFakeTimers();
+			try {
+				const tool = createWindowsShellTool(
+					() => new Promise<string>(() => {}),
+				);
+				const requested = RUN_COMMANDS_TIMEOUT_MIN_MS * 3;
+				const pending = tool.execute(
+					{ commands: ["sleep"], timeout: requested } as never,
+					{ agentId: "a", conversationId: "c", iteration: 1 },
+				);
+				await vi.advanceTimersByTimeAsync(requested + 1);
+				const result = await pending;
+				expect(result[0]?.success).toBe(false);
+				expect(result[0]?.error).toMatch(
+					new RegExp(`timed out after ${requested}ms`),
+				);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
 	});
 });
 

--- a/sdk/packages/core/src/extensions/tools/definitions.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.ts
@@ -32,6 +32,8 @@ import {
 	FetchWebContentInputSchema,
 	type ReadFilesInput,
 	ReadFilesInputSchema,
+	RUN_COMMANDS_TIMEOUT_MAX_MS,
+	RUN_COMMANDS_TIMEOUT_MIN_MS,
 	type RunCommandsInput,
 	RunCommandsInputSchema,
 	RunCommandsInputUnionSchema,
@@ -203,7 +205,7 @@ export function createBashTool(
 	executor: BashExecutor,
 	config: Pick<DefaultToolsConfig, "cwd" | "bashTimeoutMs"> = {},
 ): AgentTool<RunCommandsInput, ToolOperationResult[]> {
-	const timeoutMs = config.bashTimeoutMs ?? 30000;
+	const defaultTimeoutMs = config.bashTimeoutMs ?? 30000;
 	const cwd = config.cwd ?? process.cwd();
 
 	return createTool<RunCommandsInput, ToolOperationResult[]>({
@@ -212,9 +214,13 @@ export function createBashTool(
 			"Run shell commands from the root of the workspace. " +
 			"Use for listing files, checking git status, running builds, executing tests, etc. " +
 			"Commands should be properly shell-escaped and targeted to avoid error or timeout. " +
-			"For long-running commands, run them in background and redirect output to a tmp file that you can read from later.",
+			"For long-running commands, run them in background and redirect output to a tmp file that you can read from later. " +
+			`Optional \`timeout\` field (milliseconds, ${RUN_COMMANDS_TIMEOUT_MIN_MS}-${RUN_COMMANDS_TIMEOUT_MAX_MS}) overrides the default per-command timeout.`,
 		inputSchema: zodToJsonSchema(RunCommandsInputSchema),
-		timeoutMs: timeoutMs * 2,
+		timeoutMs: Math.max(
+			defaultTimeoutMs * 2,
+			RUN_COMMANDS_TIMEOUT_MAX_MS + 30_000,
+		),
 		retryable: false, // Shell commands often have side effects
 		maxRetries: 0,
 		execute: async (input, context) => {
@@ -234,13 +240,18 @@ export function createBashTool(
 				commands = [validate.cmd];
 			}
 
+			const effectiveTimeoutMs = resolveRunCommandsTimeoutMs(
+				input,
+				defaultTimeoutMs,
+			);
+
 			return Promise.all(
 				commands.map(async (command: string): Promise<ToolOperationResult> => {
 					try {
 						const output = await withTimeout(
 							executor(command, cwd, context),
-							timeoutMs,
-							`Command timed out after ${timeoutMs}ms`,
+							effectiveTimeoutMs,
+							`Command timed out after ${effectiveTimeoutMs}ms`,
 						);
 						return {
 							query: command,
@@ -271,7 +282,7 @@ export function createWindowsShellTool(
 	executor: BashExecutor,
 	config: Pick<DefaultToolsConfig, "cwd" | "bashTimeoutMs"> = {},
 ): AgentTool<StructuredCommandInput, ToolOperationResult[]> {
-	const timeoutMs = config.bashTimeoutMs ?? 30000;
+	const defaultTimeoutMs = config.bashTimeoutMs ?? 30000;
 	const cwd = config.cwd ?? process.cwd();
 
 	return createTool<StructuredCommandInput, ToolOperationResult[]>({
@@ -279,21 +290,29 @@ export function createWindowsShellTool(
 		description:
 			"Run shell commands from the root of the workspacein Windows environment. " +
 			"Use for listing files, checking git status, running builds, executing tests, etc. " +
-			"Prefer structured { command, args } entries for portability; plain string commands should be properly shell-escaped.",
+			"Prefer structured { command, args } entries for portability; plain string commands should be properly shell-escaped. " +
+			`Optional \`timeout\` field (milliseconds, ${RUN_COMMANDS_TIMEOUT_MIN_MS}-${RUN_COMMANDS_TIMEOUT_MAX_MS}) overrides the default per-command timeout.`,
 		inputSchema: zodToJsonSchema(StructuredCommandsInputSchema),
-		timeoutMs: timeoutMs * 2,
+		timeoutMs: Math.max(
+			defaultTimeoutMs * 2,
+			RUN_COMMANDS_TIMEOUT_MAX_MS + 30_000,
+		),
 		retryable: false, // Shell commands often have side effects
 		maxRetries: 0,
 		execute: async (input, context) => {
 			const commands = normalizeRunCommandsInput(input);
+			const effectiveTimeoutMs = resolveRunCommandsTimeoutMs(
+				input,
+				defaultTimeoutMs,
+			);
 
 			return Promise.all(
 				commands.map(async (command): Promise<ToolOperationResult> => {
 					try {
 						const output = await withTimeout(
 							executor(command, cwd, context),
-							timeoutMs,
-							`Command timed out after ${timeoutMs}ms`,
+							effectiveTimeoutMs,
+							`Command timed out after ${effectiveTimeoutMs}ms`,
 						);
 						return {
 							query: formatRunCommandQuery(command),
@@ -313,6 +332,31 @@ export function createWindowsShellTool(
 			);
 		},
 	});
+}
+
+/**
+ * Extract an optional `timeout` (milliseconds) from raw tool input and clamp
+ * it to the supported range, falling back to the workspace default when
+ * absent or invalid. Tolerates payloads from models that emit `timeout`
+ * alongside `commands` (e.g. GPT-5 family shell tool variants); the schema
+ * validates `timeout` as a number, so non-finite values can only arise from
+ * unusual call paths and are defended against here.
+ */
+function resolveRunCommandsTimeoutMs(
+	input: unknown,
+	defaultTimeoutMs: number,
+): number {
+	if (input === null || typeof input !== "object") {
+		return defaultTimeoutMs;
+	}
+	const raw = (input as { timeout?: unknown }).timeout;
+	if (typeof raw !== "number" || !Number.isFinite(raw)) {
+		return defaultTimeoutMs;
+	}
+	return Math.min(
+		Math.max(Math.trunc(raw), RUN_COMMANDS_TIMEOUT_MIN_MS),
+		RUN_COMMANDS_TIMEOUT_MAX_MS,
+	);
 }
 
 /**

--- a/sdk/packages/core/src/extensions/tools/schemas.ts
+++ b/sdk/packages/core/src/extensions/tools/schemas.ts
@@ -102,13 +102,29 @@ const CommandInputSchema = z
 		`The non-interactive shell command to execute - MUST keep input short and concise (within ${INPUT_ARG_CHAR_LIMIT * 2} characters) to avoid timeouts.`,
 	);
 
+export const RUN_COMMANDS_TIMEOUT_MIN_MS = 1_000;
+export const RUN_COMMANDS_TIMEOUT_MAX_MS = 600_000;
+
+const RunCommandsTimeoutSchema = z
+	.number()
+	.optional()
+	.describe(
+		`Optional per-call timeout in milliseconds. Clamped to [${RUN_COMMANDS_TIMEOUT_MIN_MS}, ${RUN_COMMANDS_TIMEOUT_MAX_MS}]. If omitted, the workspace default applies.`,
+	);
+
 /**
- * Schema for run_commands tool input
+ * Schema for run_commands tool input.
+ *
+ * Uses `looseObject` so model-supplied keys that are not part of the contract
+ * (e.g. some OpenAI/Codex shell tool variants emit `timeout`) round-trip
+ * through zodToJsonSchema as `additionalProperties: true` and are not rejected
+ * before reaching `execute`. Recognised optional keys are declared explicitly.
  */
-export const RunCommandsInputSchema = z.object({
+export const RunCommandsInputSchema = z.looseObject({
 	commands: z
 		.array(CommandInputSchema)
 		.describe("Array of shell commands to execute"),
+	timeout: RunCommandsTimeoutSchema,
 });
 
 /**
@@ -139,14 +155,17 @@ export const StructuredCommandEntrySchema = z.union([
 	StructuredCommandInputSchema,
 ]);
 /**
- * Schema for run_commands tool input
+ * Schema for run_commands tool input.
+ *
+ * See `RunCommandsInputSchema` for the rationale behind `looseObject`.
  */
-export const StructuredCommandsInputSchema = z.object({
+export const StructuredCommandsInputSchema = z.looseObject({
 	commands: z
 		.array(StructuredCommandEntrySchema)
 		.describe(
 			"Array of commands to execute. Prefer structured { command, args } entries for portability; plain strings are still supported and are interpreted by the active shell.",
 		),
+	timeout: RunCommandsTimeoutSchema,
 });
 
 /**


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #10743

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

 GPT-5.5 (and other models trained against the OpenAI/Codex shell-tool spec) consistently emit timeout alongside commands:

 `{ "commands": ["pytest -v"], "timeout": 120000 }`

  The strict z.object schema rejected the payload with Unrecognized key: "timeout" before the call ever reached execute. The model would retry without timeout and succeed, but the first attempt always failed and broke the workflow.

####  Root cause

  RunCommandsInputSchema is exposed to the LLM as JSON Schema via zodToJsonSchema(...). With a plain z.object, the output carries additionalProperties: false, so the AI SDK's z.fromJSONSchema(...).safeParse(...) rejects any unknown key
  hard.

  This is not a model hallucination. The OpenAI / Codex canonical shell tool genuinely declares timeout, so models trained against it carry a strong prior that any run_commands-shaped tool should accept one. Cline's schema was the outlier
   — the fix aligns the contract with the de facto industry shape rather than fighting the model through prompting (which would not survive new sessions or upgrades).

#### What this commit does

  1. Declares timeout as a first-class optional field on RunCommandsInputSchema / StructuredCommandsInputSchema (z.number().optional(), clamped server-side to [1_000, 600_000] ms).
  2. Actually applies it: a new resolveRunCommandsTimeoutMs(input, default) extracts and clamps the value, then drives withTimeout(...). timeout: 120000 really gets 120 s, not the default 30 s.
  3. Switches to z.looseObject as forward-proofing — future drift on other unknown keys (cwd, env, shell, …) will be silently ignored rather than fail hard.

  The outer createTool({ timeoutMs }) watchdog is raised from `defaultTimeoutMs * 2` to `max(defaultTimeoutMs * 2, MAX + 30s) `so the inner per-call timeout is never killed first.


### Test Procedure
<img width="1546" height="1224" alt="image" src="https://github.com/user-attachments/assets/9624b8e6-e6b4-460b-9d86-607455e5aa90" />

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->
