### PR TITLE
Fix OpenAI-compatible cache token double counting

### DIFF
--- a/apps/vscode/src/core/api/providers/__tests__/litellm.test.ts
+++ b/apps/vscode/src/core/api/providers/__tests__/litellm.test.ts
@@ -246,6 +246,42 @@ describe("LiteLlmHandler", () => {
 				expect(callArgs.stream).to.equal(true)
 				expect(callArgs.stream_options).to.deep.equal({ include_usage: true })
 			})
+
+			it("normalizes OpenAI-style usage to non-cached input tokens", async () => {
+				fakeClient.chat.completions.create.resolves(
+					createAsyncIterable([
+						{
+							choices: [{ delta: { content: "test response" } }],
+						},
+						{
+							choices: [{}],
+							usage: {
+								prompt_tokens: 100,
+								completion_tokens: 50,
+								prompt_tokens_details: {
+									cached_tokens: 10,
+								},
+								prompt_cache_miss_tokens: 20,
+							},
+						},
+					]),
+				)
+
+				const chunks = []
+
+				for await (const chunk of handler.createMessage("Test System Prompt", [{ role: "user", content: "hello" }])) {
+					chunks.push(chunk)
+				}
+
+				const usage = chunks.find((chunk) => chunk.type === "usage")
+				expect(usage).to.include({
+					type: "usage",
+					inputTokens: 70,
+					outputTokens: 50,
+					cacheWriteTokens: 20,
+					cacheReadTokens: 10,
+				})
+			})
 		})
 	})
 

--- a/apps/vscode/src/core/api/providers/__tests__/openai.test.ts
+++ b/apps/vscode/src/core/api/providers/__tests__/openai.test.ts
@@ -1,0 +1,70 @@
+import { OpenAiHandler } from "@core/api/providers/openai"
+import { expect } from "chai"
+import sinon from "sinon"
+import { ClineStorageMessage } from "@/shared/messages/content"
+
+const fakeClient = {
+	chat: {
+		completions: {
+			create: sinon.stub(),
+		},
+	},
+}
+
+describe("OpenAiHandler", () => {
+	const createAsyncIterable = (data: unknown[] = []) => {
+		return {
+			[Symbol.asyncIterator]: async function* () {
+				yield* data
+			},
+		}
+	}
+
+	afterEach(() => {
+		sinon.restore()
+		fakeClient.chat.completions.create.reset()
+	})
+
+	it("normalizes OpenAI-compatible usage to non-cached input tokens", async () => {
+		fakeClient.chat.completions.create.resolves(
+			createAsyncIterable([
+				{
+					choices: [{ delta: { content: "test response" } }],
+				},
+				{
+					choices: [{}],
+					usage: {
+						prompt_tokens: 100,
+						completion_tokens: 50,
+						prompt_tokens_details: {
+							cached_tokens: 10,
+						},
+						prompt_cache_miss_tokens: 20,
+					},
+				},
+			]),
+		)
+
+		const handler = new OpenAiHandler({
+			openAiApiKey: "test-api-key",
+			openAiModelId: "claude-sonnet-via-compatible-api",
+		})
+		sinon.stub(handler as unknown as { ensureClient: () => typeof fakeClient }, "ensureClient").returns(fakeClient)
+
+		const messages: ClineStorageMessage[] = [{ role: "user", content: "hello" }]
+		const chunks = []
+
+		for await (const chunk of handler.createMessage("Test System Prompt", messages)) {
+			chunks.push(chunk)
+		}
+
+		const usage = chunks.find((chunk) => chunk.type === "usage")
+		expect(usage).to.include({
+			type: "usage",
+			inputTokens: 70,
+			outputTokens: 50,
+			cacheWriteTokens: 20,
+			cacheReadTokens: 10,
+		})
+	})
+})

--- a/apps/vscode/src/core/api/providers/litellm.ts
+++ b/apps/vscode/src/core/api/providers/litellm.ts
@@ -360,10 +360,17 @@ export class LiteLlmHandler implements ApiHandler {
 					prompt_cache_miss_tokens?: number
 					cache_read_input_tokens?: number
 					prompt_cache_hit_tokens?: number
+					prompt_tokens_details?: {
+						cached_tokens?: number
+					}
 				}
 
 				const cacheWriteTokens = usage.cache_creation_input_tokens || usage.prompt_cache_miss_tokens || 0
-				const cacheReadTokens = usage.cache_read_input_tokens || usage.prompt_cache_hit_tokens || 0
+				const cacheReadTokens =
+					usage.cache_read_input_tokens ||
+					usage.prompt_cache_hit_tokens ||
+					usage.prompt_tokens_details?.cached_tokens ||
+					0
 
 				// Calculate cost using the actual token usage including cache tokens
 				const totalCost =
@@ -376,7 +383,7 @@ export class LiteLlmHandler implements ApiHandler {
 
 				yield {
 					type: "usage",
-					inputTokens: usage.prompt_tokens || 0,
+					inputTokens: Math.max(0, (usage.prompt_tokens || 0) - cacheWriteTokens - cacheReadTokens),
 					outputTokens: usage.completion_tokens || 0,
 					cacheWriteTokens: cacheWriteTokens > 0 ? cacheWriteTokens : undefined,
 					cacheReadTokens: cacheReadTokens > 0 ? cacheReadTokens : undefined,

--- a/apps/vscode/src/core/api/providers/openai.ts
+++ b/apps/vscode/src/core/api/providers/openai.ts
@@ -167,13 +167,15 @@ export class OpenAiHandler implements ApiHandler {
 			}
 
 			if (chunk.usage) {
+				const cacheReadTokens = chunk.usage.prompt_tokens_details?.cached_tokens || 0
+				// @ts-expect-error-next-line
+				const cacheWriteTokens = chunk.usage.prompt_cache_miss_tokens || 0
 				yield {
 					type: "usage",
-					inputTokens: chunk.usage.prompt_tokens || 0,
+					inputTokens: Math.max(0, (chunk.usage.prompt_tokens || 0) - cacheReadTokens - cacheWriteTokens),
 					outputTokens: chunk.usage.completion_tokens || 0,
-					cacheReadTokens: chunk.usage.prompt_tokens_details?.cached_tokens || 0,
-					// @ts-expect-error-next-line
-					cacheWriteTokens: chunk.usage.prompt_cache_miss_tokens || 0,
+					cacheReadTokens,
+					cacheWriteTokens,
 				}
 			}
 		}

--- a/apps/vscode/src/core/context/context-management/__tests__/ContextManager.test.ts
+++ b/apps/vscode/src/core/context/context-management/__tests__/ContextManager.test.ts
@@ -475,6 +475,39 @@ describe("ContextManager", () => {
 			expect(result).to.equal(true)
 		})
 
+		it("does not compact when OpenAI-style provider metrics report only non-cached input tokens", () => {
+			const api = createMockApi(200_000)
+			const clineMessages: ClineMessage[] = [
+				createApiReqMessage({
+					tokensIn: 1_000,
+					tokensOut: 500,
+					cacheWrites: 0,
+					cacheReads: 148_000,
+				}),
+			]
+
+			const result = contextManager.shouldCompactContextWindow(clineMessages, api, 0, 0.75)
+			expect(result).to.equal(false)
+		})
+
+		it("reports telemetry from normalized non-cached input and cache reads", () => {
+			const api = createMockApi(200_000)
+			const clineMessages: ClineMessage[] = [
+				createApiReqMessage({
+					tokensIn: 1_000,
+					tokensOut: 500,
+					cacheWrites: 0,
+					cacheReads: 148_000,
+				}),
+			]
+
+			const telemetry = contextManager.getContextTelemetryData(clineMessages, api, 0)
+			expect(telemetry).to.deep.equal({
+				tokensUsed: 149_500,
+				maxContextWindow: 200_000,
+			})
+		})
+
 		it("returns false when previousApiReqIndex is negative", () => {
 			const api = createMockApi(200_000)
 			const clineMessages: ClineMessage[] = [createApiReqMessage({ tokensIn: 200_000 })]

--- a/apps/vscode/src/shared/__tests__/getApiMetrics.test.ts
+++ b/apps/vscode/src/shared/__tests__/getApiMetrics.test.ts
@@ -100,4 +100,23 @@ describe("getLastApiReqTotalTokens", () => {
 		const total = getLastApiReqTotalTokens(messages)
 		assert.equal(total, 23)
 	})
+
+	it("uses normalized non-cached input tokens with separately reported cache tokens", () => {
+		const messages: ClineMessage[] = [
+			{
+				ts: 1,
+				type: "say",
+				say: "api_req_started",
+				text: JSON.stringify({
+					tokensIn: 1_068,
+					tokensOut: 1_029,
+					cacheWrites: 0,
+					cacheReads: 148_167,
+				}),
+			},
+		]
+
+		const total = getLastApiReqTotalTokens(messages)
+		assert.equal(total, 150_264)
+	})
 })


### PR DESCRIPTION
### Related Issue

**Issue:** #11037

### Description

This normalizes OpenAI-compatible usage chunks so `inputTokens` reports only non-cached prompt tokens when cache read/write counts are reported separately.

The change applies to both the OpenAI-compatible provider and LiteLLM, including LiteLLM responses that report cache reads with `prompt_tokens_details.cached_tokens`.

### Test Procedure

- `git diff --check`
- `cd apps/vscode && npx biome check src/core/api/providers/openai.ts src/core/api/providers/litellm.ts src/core/api/providers/__tests__/openai.test.ts src/core/api/providers/__tests__/litellm.test.ts src/core/context/context-management/__tests__/ContextManager.test.ts src/shared/__tests__/getApiMetrics.test.ts --no-errors-on-unmatched --files-ignore-unknown=true --diagnostic-level=error`

I also tried to run the targeted Mocha/TypeScript tests locally, but this Windows machine is missing generated proto modules. Running `npm run protos` failed in `grpc-tools`' bundled `protoc.exe` with exit code `-1073741819`, so the executable test run is left for CI.

### Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Refactor Changes
-   [ ] Cosmetic Changes
-   [ ] Documentation update
-   [ ] Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A, provider usage accounting change only.

### Additional Notes

The unchecked test item above is because full local test execution is blocked by generated proto setup on this machine; the targeted formatting/lint check passed.
