### PR TITLE
Fix VS Code nightly publish workflows

### DIFF
--- a/.github/workflows/ext-vscode-publish-nightly.yml
+++ b/.github/workflows/ext-vscode-publish-nightly.yml
@@ -20,6 +20,7 @@ jobs:
     if: github.repository == 'cline/cline' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dpc/sdk-migration-simpler-login')
     permissions:
       contents: read
+      pull-requests: read
     uses: ./.github/workflows/ext-vscode-test.yml
 
   publish:


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Fixes the `ext-vscode-publish-nightly` startup failure by passing `pull-requests: read` to the reusable `ext-vscode-test.yml` workflow.

The called test workflow declares `pull-requests: read` for PR path filtering, and reusable workflows cannot elevate token permissions beyond what the caller grants. Without this permission in the caller job, GitHub can fail the workflow before any jobs start.

After rebasing on latest `main`, the separate SDK nightly workflow has already been removed upstream, so this PR no longer touches it.

### Test Procedure

- Inspected the failed nightly run and confirmed it was a GitHub Actions `startup_failure` with no jobs.
- Parsed the changed workflow YAML locally with Ruby YAML.
- Ran `git diff --check`.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - workflow-only change.

### Additional Notes

I did not run the full npm test/lint suite because this PR only changes a GitHub Actions workflow permission. The meaningful validation is rerunning the affected nightly publish workflow.
