### PR TITLE
docs(sdk): clarify single-file vs package plugin shapes

### DIFF
--- a/docs/sdk/guides/writing-plugins.mdx
+++ b/docs/sdk/guides/writing-plugins.mdx
@@ -257,12 +257,15 @@ Single-file plugins can be installed directly from a file URL:
 cline plugin install https://github.com/your-org/your-repo/blob/main/plugins/github-plugin.ts
 ```
 
-For package or repository distribution, add a `cline` field to your `package.json` that declares entry points. Dependencies under the `@cline/` scope are provided by the host runtime. The installer automatically strips these from the plugin's dependency list before running `npm install`, so declare any `@cline/*` package your plugin imports as an optional peer dependency:
+Single-file plugins can only import Node builtins and `@cline/*`. As soon as you need an npm dependency (`zod`, an HTTP client, etc.) you must ship as a package: a directory with a `package.json` that declares a `cline` field for entry points and your runtime `dependencies`. Dependencies under the `@cline/` scope are provided by the host runtime -- the installer strips these and runs `npm install` for the rest, so declare any `@cline/*` package you import as an optional peer dependency:
 
 ```json
 {
   "cline": {
     "plugins": [{ "paths": ["./github-plugin.ts"], "capabilities": ["tools", "hooks"] }]
+  },
+  "dependencies": {
+    "@octokit/rest": "^21.0.0"
   },
   "peerDependencies": {
     "@cline/sdk": "*"

--- a/docs/sdk/plugin-install.mdx
+++ b/docs/sdk/plugin-install.mdx
@@ -132,7 +132,7 @@ await cline.start({
 })
 ```
 
-Plugin files must export an `AgentPlugin` as the default export.
+Plugin files must export an `AgentPlugin` as the default export. `pluginPaths` also accepts a package directory -- the SDK reads `package.json` and follows the `cline.plugins` entries, so you can `npm install` once inside a package and iterate without re-running `cline plugin install` on every edit.
 
 ### Using `plugins` (Agent Runtime)
 


### PR DESCRIPTION
### Related Issue

None - small doc gap surfaced by an SDK plugin author who could not figure out how to use npm dependencies in a plugin.

### Description

Two single-sentence additions to the existing plugin docs:

- \`docs/sdk/guides/writing-plugins.mdx\`: notes that single-file plugins can only import Node builtins and \`@cline/*\`, and adds \`dependencies\` to the example \`package.json\` so the deps story is visible.
- \`docs/sdk/plugin-install.mdx\`: notes that \`pluginPaths\` accepts a package directory (already supported by \`resolveConfiguredPluginModulePaths\` in \`@cline/shared/storage\`, just undocumented), which is the fast iteration loop for plugins with deps.

Paired with [cline/sdk-skill#6](https://github.com/cline/sdk-skill/pull/6), which makes equivalent updates to the SDK skill.

### Type of Change

-   [x] 📚 Documentation update

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)