### PR TITLE
Fix Discord connector registration

### DIFF
--- a/docs/cli/connectors.mdx
+++ b/docs/cli/connectors.mdx
@@ -85,10 +85,115 @@ Each Slack thread maps to an agent session, so the agent maintains conversation 
 
 ## Discord
 
-Requires an application ID, bot token, public key, and public base URL.
+Requires a Discord application ID, bot token, public key, and public base URL.
+The connector listens for Discord interactions at `/api/webhooks/discord` and
+also starts a Discord gateway listener for mentions, replies, reactions, and DMs.
+
+<Steps>
+  <Step title="Create a Discord application and bot">
+    Open [Discord Developer Portal](https://discord.com/developers/applications)
+    and create an application.
+
+    1. In **General Information**, copy the **Application ID** and **Public Key**.
+    2. In **Bot**, create a bot if one does not exist, then reset and copy the bot token.
+    3. Enable **Message Content Intent** if you want normal messages, replies, and DMs to include text content.
+  </Step>
+
+  <Step title="Expose a public base URL">
+    For local development, use a tunnel such as ngrok:
+
+    ```bash
+    ngrok http 8788
+    ```
+
+    Copy the HTTPS forwarding URL. This is your connector base URL, for example
+    `https://1234-5678.ngrok-free.app`.
+  </Step>
+
+  <Step title="Start the connector">
+    ```bash
+    cline connect discord \
+      --application-id <ID> \
+      --bot-token <TOKEN> \
+      --public-key <KEY> \
+      --base-url <URL> \
+      --port 8788 \
+      --cwd /path/to/repo \
+      --enable-tools
+    ```
+
+    `--app-id` is an alias for `--application-id`, and `--token` is an alias for
+    `--bot-token`.
+
+    `--enable-tools` allows the agent to inspect files, run commands, edit code,
+    and prepare PRs from Discord. Omit it if the bot should only chat.
+  </Step>
+
+  <Step title="Configure the Discord interactions endpoint">
+    In the Discord Developer Portal, set **Interactions Endpoint URL** to:
+
+    ```text
+    <base-url>/api/webhooks/discord
+    ```
+
+    For example:
+
+    ```text
+    https://1234-5678.ngrok-free.app/api/webhooks/discord
+    ```
+
+    You can verify the connector is reachable with:
+
+    ```bash
+    curl <base-url>/health
+    ```
+  </Step>
+
+  <Step title="Invite the bot to a test server">
+    In **OAuth2 > URL Generator**, select the `bot` and
+    `applications.commands` scopes, then give the bot permission to send
+    messages and read message history. Open the generated URL and install the bot
+    into your test server.
+  </Step>
+
+  <Step title="Chat with the bot">
+    Mention the bot in a server channel, reply in a bot-created thread, or DM the
+    bot. Each Discord conversation keeps its own agent session and context.
+  </Step>
+</Steps>
+
+### Discord Command Reference
+
+Send these commands in Discord:
+
+| Command | Description |
+|---------|-------------|
+| `/help` or `/start` | Show connector help |
+| `/new` or `/clear` | Start a fresh session for this Discord conversation |
+| `/whereami` | Show thread, channel, DM state, `cwd`, `workspaceRoot`, tools, and yolo state |
+| `/tools [on\|off\|toggle]` | View or change whether repo/file/shell tools are allowed |
+| `/yolo [on\|off\|toggle]` | View or change automatic tool approval |
+| `/cwd [path]` | View or change the working directory for this conversation |
+| `/schedule create/list/trigger/delete` | Manage scheduled workflows targeting this conversation |
+| `/abort` | Stop the current task |
+| `/exit` | Stop the connector |
+
+Normal messages are treated as agent tasks. If a task is already running, normal
+messages steer the active task.
+
+### Discord Security
+
+By default, anyone who can reach the bot can ask it to run tasks. Restrict access
+with `--hook-command`. The hook receives the Discord user as a participant key
+such as `discord:user:123456789`.
 
 ```bash
-cline connect discord --app-id <ID> --token <TOKEN> --public-key <KEY> --base-url <URL>
+cline connect discord \
+  --application-id <ID> \
+  --bot-token <TOKEN> \
+  --public-key <KEY> \
+  --base-url <URL> \
+  --hook-command 'jq -r ".payload.actor.participantKey" | grep -q "discord:user:123456789" && echo "{\"action\":\"allow\"}" || echo "{\"action\":\"deny\",\"message\":\"unauthorized\"}"'
 ```
 
 ## Google Chat

--- a/sdk/apps/cli/src/connectors/adapters/discord.test.ts
+++ b/sdk/apps/cli/src/connectors/adapters/discord.test.ts
@@ -46,6 +46,86 @@ describe("discordConnector", () => {
 		expect(options.botToken).toBe("other-token");
 	});
 
+	it("builds empty-runtime fallback replies from the current Discord turn", async () => {
+		const priorMessages = [
+			{
+				role: "user",
+				content: [{ type: "text", text: "previous question" }],
+			},
+			{
+				role: "assistant",
+				content: [{ type: "text", text: "Previous reply." }],
+			},
+		];
+		const currentMessages = [
+			...priorMessages,
+			{
+				role: "user",
+				content: [{ type: "text", text: "read README.md" }],
+			},
+			{
+				role: "assistant",
+				content: [{ type: "text", text: "Summary from saved session." }],
+			},
+		];
+		const client = {
+			readMessages: vi
+				.fn()
+				.mockResolvedValueOnce(priorMessages)
+				.mockResolvedValueOnce(currentMessages),
+		};
+
+		const resolveFallbackText =
+			await __test__.createDiscordEmptyRuntimeReplyResolver({
+				client: client as never,
+				sessionId: "session-1",
+			});
+
+		await expect(resolveFallbackText?.()).resolves.toBe(
+			"Summary from saved session.",
+		);
+		expect(client.readMessages).toHaveBeenCalledTimes(2);
+	});
+
+	it("does not reuse prior Discord replies as empty-runtime fallback text", async () => {
+		const priorMessages = [
+			{
+				role: "user",
+				content: [{ type: "text", text: "previous question" }],
+			},
+			{
+				role: "assistant",
+				content: [{ type: "text", text: "Previous reply." }],
+			},
+		];
+		const currentMessages = [
+			...priorMessages,
+			{
+				role: "user",
+				content: [{ type: "text", text: "run ls /tmp" }],
+			},
+			{
+				role: "tool",
+				content: [{ type: "text", text: "tool output" }],
+			},
+		];
+		const client = {
+			readMessages: vi
+				.fn()
+				.mockResolvedValueOnce(priorMessages)
+				.mockResolvedValueOnce(currentMessages),
+		};
+
+		const resolveFallbackText =
+			await __test__.createDiscordEmptyRuntimeReplyResolver({
+				client: client as never,
+				sessionId: "session-1",
+			});
+
+		await expect(resolveFallbackText?.()).resolves.toBeUndefined();
+		expect(client.readMessages).toHaveBeenCalledTimes(2);
+	});
+
 	it("restores persisted thread subscriptions once on startup", async () => {
 		const dir = await mkdtemp(join(tmpdir(), "discord-bindings-"));
 		const bindingsPath = join(dir, "threads.json");

--- a/sdk/apps/cli/src/connectors/adapters/discord.test.ts
+++ b/sdk/apps/cli/src/connectors/adapters/discord.test.ts
@@ -1,0 +1,115 @@
+import { writeFileSync } from "node:fs";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ConnectDiscordOptions } from "@cline/shared";
+import { describe, expect, it, vi } from "vitest";
+import { __test__, discordConnector } from "./discord";
+
+const parseDiscordArgs = (rawArgs: string[]): ConnectDiscordOptions =>
+	(
+		discordConnector as unknown as {
+			parseArgs(rawArgs: string[]): ConnectDiscordOptions;
+		}
+	).parseArgs(rawArgs);
+
+describe("discordConnector", () => {
+	it("accepts the documented app id and token aliases", () => {
+		const options = parseDiscordArgs([
+			"--app-id",
+			"app-123",
+			"--token",
+			"bot-token",
+			"--public-key",
+			"public-key",
+			"--base-url",
+			"https://example.test",
+		]);
+
+		expect(options.applicationId).toBe("app-123");
+		expect(options.botToken).toBe("bot-token");
+		expect(options.publicKey).toBe("public-key");
+		expect(options.baseUrl).toBe("https://example.test");
+	});
+
+	it("keeps accepting the explicit application id and bot token options", () => {
+		const options = parseDiscordArgs([
+			"--application-id",
+			"app-456",
+			"--bot-token",
+			"other-token",
+			"--public-key",
+			"public-key",
+		]);
+
+		expect(options.applicationId).toBe("app-456");
+		expect(options.botToken).toBe("other-token");
+	});
+
+	it("restores persisted thread subscriptions once on startup", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "discord-bindings-"));
+		const bindingsPath = join(dir, "threads.json");
+		const subscribe = vi.fn(async () => undefined);
+		const threads = new Map([
+			[
+				"thread-1",
+				{
+					id: "thread-1",
+					subscribe,
+				},
+			],
+		]);
+		const bot = {
+			reviver: () => (_key: string, value: unknown) => {
+				if (
+					value &&
+					typeof value === "object" &&
+					(value as { _type?: string })._type === "chat:Thread"
+				) {
+					return threads.get((value as { id: string }).id) ?? value;
+				}
+				return value;
+			},
+		};
+		const logger = {
+			core: { log: vi.fn() },
+		} as unknown as Parameters<
+			typeof __test__.restoreDiscordThreadSubscriptions
+		>[0]["logger"];
+
+		writeFileSync(
+			bindingsPath,
+			JSON.stringify({
+				"discord:user:1": {
+					channelId: "discord:g:c",
+					isDM: false,
+					participantKey: "discord:user:1",
+					serializedThread: JSON.stringify({
+						_type: "chat:Thread",
+						id: "thread-1",
+					}),
+					updatedAt: "2026-05-26T00:00:00.000Z",
+				},
+				duplicate: {
+					channelId: "discord:g:c",
+					isDM: false,
+					serializedThread: JSON.stringify({
+						_type: "chat:Thread",
+						id: "thread-1",
+					}),
+					updatedAt: "2026-05-26T00:00:00.000Z",
+				},
+			}),
+		);
+
+		const restored = await __test__.restoreDiscordThreadSubscriptions({
+			bot,
+			bindingsPath,
+			logger,
+		});
+
+		expect(restored).toBe(1);
+		expect(subscribe).toHaveBeenCalledTimes(1);
+		expect(logger.core.log).not.toHaveBeenCalled();
+	});
+});

--- a/sdk/apps/cli/src/connectors/adapters/discord.ts
+++ b/sdk/apps/cli/src/connectors/adapters/discord.ts
@@ -39,6 +39,7 @@ import {
 } from "../runtime-turn";
 import {
 	buildConnectorStartRequest,
+	readSessionMessageCount,
 	readSessionReplyText,
 	stopConnectorSessions,
 } from "../session-runtime";
@@ -106,6 +107,23 @@ async function buildDiscordStartRequest(
 		loggerConfig,
 		systemRules: DISCORD_SYSTEM_RULES,
 	});
+}
+
+async function createDiscordEmptyRuntimeReplyResolver(input: {
+	client: HubSessionClient;
+	sessionId: string;
+}): Promise<(() => Promise<string | undefined>) | undefined> {
+	const minMessageIndex = await readSessionMessageCount(
+		input.client,
+		input.sessionId,
+	);
+	if (minMessageIndex === undefined) {
+		return async () => undefined;
+	}
+	return () =>
+		readSessionReplyText(input.client, input.sessionId, {
+			minMessageIndex,
+		});
 }
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
@@ -663,6 +681,8 @@ class DiscordConnector extends ConnectorBase<
 						chatCommandHost,
 						activeTurns,
 						turnKey: queueKey,
+						createEmptyRuntimeReplyResolver:
+							createDiscordEmptyRuntimeReplyResolver,
 						getSessionMetadata: (currentThread, _clientId, currentState) => ({
 							userName: options.userName,
 							applicationId: options.applicationId,
@@ -963,6 +983,7 @@ export const discordConnector: ConnectCommandDefinition =
 	new DiscordConnector();
 
 export const __test__ = {
+	createDiscordEmptyRuntimeReplyResolver,
 	findBindingForThread: (
 		bindings: ConnectorBindingStore<DiscordThreadState>,
 		thread: Pick<Thread<DiscordThreadState>, "id" | "channelId" | "isDM"> & {

--- a/sdk/apps/cli/src/connectors/adapters/discord.ts
+++ b/sdk/apps/cli/src/connectors/adapters/discord.ts
@@ -240,6 +240,50 @@ async function deliverScheduledResult(input: {
 	await thread.post(body);
 }
 
+function isRestorableThread(
+	value: unknown,
+): value is Thread<DiscordThreadState> & { subscribe(): Promise<void> } {
+	return (
+		Boolean(value) &&
+		typeof value === "object" &&
+		typeof (value as Thread<DiscordThreadState>).id === "string" &&
+		typeof (value as Thread<DiscordThreadState>).subscribe === "function"
+	);
+}
+
+async function restoreDiscordThreadSubscriptions(input: {
+	bot: Pick<Chat, "reviver">;
+	bindingsPath: string;
+	logger: ReturnType<typeof createCliLoggerAdapter>;
+}): Promise<number> {
+	const bindings = readBindings<DiscordThreadState>(input.bindingsPath);
+	const restoredThreadIds = new Set<string>();
+	for (const binding of Object.values(bindings)) {
+		if (!binding.serializedThread?.trim()) {
+			continue;
+		}
+		try {
+			const thread = JSON.parse(
+				binding.serializedThread,
+				input.bot.reviver(),
+			) as unknown;
+			if (!isRestorableThread(thread) || restoredThreadIds.has(thread.id)) {
+				continue;
+			}
+			await thread.subscribe();
+			restoredThreadIds.add(thread.id);
+		} catch (error) {
+			input.logger.core.log("Failed to restore Discord thread subscription", {
+				severity: "warn",
+				error: error instanceof Error ? error.message : String(error),
+				channelId: binding.channelId,
+				participantKey: binding.participantKey,
+			});
+		}
+	}
+	return restoredThreadIds.size;
+}
+
 class DiscordConnector extends ConnectorBase<
 	ConnectDiscordOptions,
 	DiscordConnectorState
@@ -257,7 +301,9 @@ class DiscordConnector extends ConnectorBase<
 			.usage("--base-url <PUBLIC_BASE_URL> [options]")
 			.option("--user-name <name>", "Discord bot username label")
 			.option("--application-id <id>", "Discord application id")
+			.option("--app-id <id>", "Alias for --application-id")
 			.option("--bot-token <token>", "Discord bot token")
+			.option("--token <token>", "Alias for --bot-token")
 			.option("--public-key <key>", "Discord application public key")
 			.option(
 				"--mention-role-ids <ids>",
@@ -303,7 +349,9 @@ class DiscordConnector extends ConnectorBase<
 		const opts = command.opts<{
 			userName?: string;
 			applicationId?: string;
+			appId?: string;
 			botToken?: string;
+			token?: string;
 			publicKey?: string;
 			mentionRoleIds?: string;
 			cwd?: string;
@@ -339,10 +387,14 @@ class DiscordConnector extends ConnectorBase<
 				"cline-discord",
 			applicationId:
 				opts.applicationId?.trim() ||
+				opts.appId?.trim() ||
 				process.env.DISCORD_APPLICATION_ID?.trim() ||
 				"",
 			botToken:
-				opts.botToken?.trim() || process.env.DISCORD_BOT_TOKEN?.trim() || "",
+				opts.botToken?.trim() ||
+				opts.token?.trim() ||
+				process.env.DISCORD_BOT_TOKEN?.trim() ||
+				"",
 			publicKey:
 				opts.publicKey?.trim() || process.env.DISCORD_PUBLIC_KEY?.trim() || "",
 			mentionRoleIds: mentionRoleIds.length > 0 ? mentionRoleIds : undefined,
@@ -766,6 +818,11 @@ class DiscordConnector extends ConnectorBase<
 		});
 
 		await bot.initialize();
+		const restoredSubscriptionCount = await restoreDiscordThreadSubscriptions({
+			bot,
+			bindingsPath,
+			logger: loggerAdapter,
+		});
 		const stopTaskUpdateStream =
 			startConnectorTaskUpdateRelay<DiscordThreadState>({
 				client,
@@ -883,6 +940,11 @@ class DiscordConnector extends ConnectorBase<
 		io.writeln(
 			"[discord] gateway listener started for mentions, replies, reactions, and DMs",
 		);
+		if (restoredSubscriptionCount > 0) {
+			io.writeln(
+				`[discord] restored ${restoredSubscriptionCount} thread subscription${restoredSubscriptionCount === 1 ? "" : "s"}`,
+			);
+		}
 
 		await stopPromise;
 		gatewayAbortController.abort();
@@ -907,4 +969,5 @@ export const __test__ = {
 			participantKey?: string;
 		},
 	) => findBindingForThread(bindings, thread),
+	restoreDiscordThreadSubscriptions,
 };

--- a/sdk/apps/cli/src/connectors/common.test.ts
+++ b/sdk/apps/cli/src/connectors/common.test.ts
@@ -1,7 +1,11 @@
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { __test__, readSessionReplyText } from "./common";
+import {
+	__test__,
+	readSessionMessageCount,
+	readSessionReplyText,
+} from "./common";
 
 describe("spawnDetachedConnector", () => {
 	it("preserves the connect subcommand when building detached connector args", () => {
@@ -106,5 +110,64 @@ describe("readSessionReplyText", () => {
 		await expect(
 			readSessionReplyText(client as never, "session-1"),
 		).resolves.toBe("latest reply");
+	});
+
+	it("can restrict fallback replies to messages after a known boundary", async () => {
+		const client = {
+			readMessages: async () => [
+				{
+					role: "assistant",
+					content: [{ type: "text", text: "previous reply" }],
+				},
+				{
+					role: "user",
+					content: [{ type: "text", text: "next question" }],
+				},
+				{
+					role: "assistant",
+					content: [{ type: "text", text: "current reply" }],
+				},
+			],
+		};
+
+		await expect(
+			readSessionReplyText(client as never, "session-1", {
+				minMessageIndex: 1,
+			}),
+		).resolves.toBe("current reply");
+	});
+
+	it("does not read prior assistant replies before the boundary", async () => {
+		const client = {
+			readMessages: async () => [
+				{
+					role: "assistant",
+					content: [{ type: "text", text: "previous reply" }],
+				},
+				{
+					role: "user",
+					content: [{ type: "text", text: "next question" }],
+				},
+			],
+		};
+
+		await expect(
+			readSessionReplyText(client as never, "session-1", {
+				minMessageIndex: 1,
+			}),
+		).resolves.toBeUndefined();
+	});
+
+	it("reads the session message count through the hub session client", async () => {
+		const client = {
+			readMessages: async () => [
+				{ role: "user", content: "one" },
+				{ role: "assistant", content: "two" },
+			],
+		};
+
+		await expect(
+			readSessionMessageCount(client as never, "session-1"),
+		).resolves.toBe(2);
 	});
 });

--- a/sdk/apps/cli/src/connectors/common.ts
+++ b/sdk/apps/cli/src/connectors/common.ts
@@ -327,15 +327,31 @@ function extractMessageReplyText(message: unknown): string | undefined {
 export async function readSessionReplyText(
 	client: HubSessionClient,
 	sessionId: string,
+	options: { minMessageIndex?: number } = {},
 ): Promise<string | undefined> {
 	try {
 		const messages = await client.readMessages(sessionId);
-		for (let index = messages.length - 1; index >= 0; index -= 1) {
+		const minMessageIndex = Math.max(0, options.minMessageIndex ?? 0);
+		for (
+			let index = messages.length - 1;
+			index >= minMessageIndex;
+			index -= 1
+		) {
 			const text = extractMessageReplyText(messages[index]);
 			if (text) {
 				return text;
 			}
 		}
+	} catch {}
+	return undefined;
+}
+
+export async function readSessionMessageCount(
+	client: HubSessionClient,
+	sessionId: string,
+): Promise<number | undefined> {
+	try {
+		return (await client.readMessages(sessionId)).length;
 	} catch {}
 	return undefined;
 }

--- a/sdk/apps/cli/src/connectors/connector-host.test.ts
+++ b/sdk/apps/cli/src/connectors/connector-host.test.ts
@@ -631,7 +631,7 @@ describe("handleConnectorUserTurn", () => {
 		expect(posts).not.toContainEqual({ raw: "**Formatted** reply" });
 	});
 
-	it("posts Discord replies from session history when the runtime stream is empty", async () => {
+	it("posts adapter fallback replies when the runtime stream is empty", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "connector-host-test-"));
 		tempDirs.push(dir);
 		const bindingsPath = join(dir, "threads.json");
@@ -641,31 +641,13 @@ describe("handleConnectorUserTurn", () => {
 			cwd: "/tmp/work",
 			workspaceRoot: "/tmp/work",
 		});
-		const priorMessages = [
-			{
-				role: "user",
-				content: [{ type: "text", text: "previous question" }],
-			},
-			{
-				role: "assistant",
-				content: [{ type: "text", text: "Previous reply." }],
-			},
-		];
-		const currentMessages = [
-			...priorMessages,
-			{
-				role: "user",
-				content: [{ type: "text", text: "read README.md" }],
-			},
-			{
-				role: "assistant",
-				content: [{ type: "text", text: "Summary from saved session." }],
-			},
-		];
 		const runtime = createRuntimeClient("");
-		runtime.readMessages
-			.mockResolvedValueOnce(priorMessages)
-			.mockResolvedValueOnce(currentMessages);
+		const resolveFallbackText = vi.fn(
+			async () => "Summary from adapter fallback.",
+		);
+		const createEmptyRuntimeReplyResolver = vi.fn(
+			async () => resolveFallbackText,
+		);
 
 		await handleConnectorUserTurn({
 			thread: thread as never,
@@ -690,13 +672,19 @@ describe("handleConnectorUserTurn", () => {
 			getSessionMetadata: () => ({}),
 			reusedLogMessage: "reused",
 			startedLogMessage: "started",
+			createEmptyRuntimeReplyResolver,
 		});
 
-		expect(runtime.readMessages).toHaveBeenCalledTimes(2);
-		expect(posts.at(-1)).toBe("Summary from saved session.");
+		expect(createEmptyRuntimeReplyResolver).toHaveBeenCalledWith({
+			client: runtime.client,
+			sessionId: "session-1",
+		});
+		expect(resolveFallbackText).toHaveBeenCalledTimes(1);
+		expect(runtime.readMessages).not.toHaveBeenCalled();
+		expect(posts.at(-1)).toBe("Summary from adapter fallback.");
 	});
 
-	it("does not post stale Discord replies when no current-turn reply exists", async () => {
+	it("does not post stale fallback replies when no current-turn reply exists", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "connector-host-test-"));
 		tempDirs.push(dir);
 		const bindingsPath = join(dir, "threads.json");
@@ -706,31 +694,11 @@ describe("handleConnectorUserTurn", () => {
 			cwd: "/tmp/work",
 			workspaceRoot: "/tmp/work",
 		});
-		const priorMessages = [
-			{
-				role: "user",
-				content: [{ type: "text", text: "previous question" }],
-			},
-			{
-				role: "assistant",
-				content: [{ type: "text", text: "Previous reply." }],
-			},
-		];
-		const currentMessages = [
-			...priorMessages,
-			{
-				role: "user",
-				content: [{ type: "text", text: "run ls /tmp" }],
-			},
-			{
-				role: "tool",
-				content: [{ type: "text", text: "tool output" }],
-			},
-		];
 		const runtime = createRuntimeClient("");
-		runtime.readMessages
-			.mockResolvedValueOnce(priorMessages)
-			.mockResolvedValueOnce(currentMessages);
+		const resolveFallbackText = vi.fn(async () => undefined);
+		const createEmptyRuntimeReplyResolver = vi.fn(
+			async () => resolveFallbackText,
+		);
 
 		await expect(
 			handleConnectorUserTurn({
@@ -756,10 +724,16 @@ describe("handleConnectorUserTurn", () => {
 				getSessionMetadata: () => ({}),
 				reusedLogMessage: "reused",
 				startedLogMessage: "started",
+				createEmptyRuntimeReplyResolver,
 			}),
 		).rejects.toThrow("Runtime completed without assistant reply text.");
 
-		expect(runtime.readMessages).toHaveBeenCalledTimes(2);
+		expect(createEmptyRuntimeReplyResolver).toHaveBeenCalledWith({
+			client: runtime.client,
+			sessionId: "session-1",
+		});
+		expect(resolveFallbackText).toHaveBeenCalledTimes(1);
+		expect(runtime.readMessages).not.toHaveBeenCalled();
 		expect(posts).not.toContain("Previous reply.");
 	});
 

--- a/sdk/apps/cli/src/connectors/connector-host.test.ts
+++ b/sdk/apps/cli/src/connectors/connector-host.test.ts
@@ -641,12 +641,31 @@ describe("handleConnectorUserTurn", () => {
 			cwd: "/tmp/work",
 			workspaceRoot: "/tmp/work",
 		});
-		const runtime = createRuntimeClient("", [
+		const priorMessages = [
+			{
+				role: "user",
+				content: [{ type: "text", text: "previous question" }],
+			},
+			{
+				role: "assistant",
+				content: [{ type: "text", text: "Previous reply." }],
+			},
+		];
+		const currentMessages = [
+			...priorMessages,
+			{
+				role: "user",
+				content: [{ type: "text", text: "read README.md" }],
+			},
 			{
 				role: "assistant",
 				content: [{ type: "text", text: "Summary from saved session." }],
 			},
-		]);
+		];
+		const runtime = createRuntimeClient("");
+		runtime.readMessages
+			.mockResolvedValueOnce(priorMessages)
+			.mockResolvedValueOnce(currentMessages);
 
 		await handleConnectorUserTurn({
 			thread: thread as never,
@@ -673,8 +692,121 @@ describe("handleConnectorUserTurn", () => {
 			startedLogMessage: "started",
 		});
 
-		expect(runtime.readMessages).toHaveBeenCalledWith("session-1");
+		expect(runtime.readMessages).toHaveBeenCalledTimes(2);
 		expect(posts.at(-1)).toBe("Summary from saved session.");
+	});
+
+	it("does not post stale Discord replies when no current-turn reply exists", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "connector-host-test-"));
+		tempDirs.push(dir);
+		const bindingsPath = join(dir, "threads.json");
+		const { thread, posts } = createThread({
+			enableTools: true,
+			autoApproveTools: true,
+			cwd: "/tmp/work",
+			workspaceRoot: "/tmp/work",
+		});
+		const priorMessages = [
+			{
+				role: "user",
+				content: [{ type: "text", text: "previous question" }],
+			},
+			{
+				role: "assistant",
+				content: [{ type: "text", text: "Previous reply." }],
+			},
+		];
+		const currentMessages = [
+			...priorMessages,
+			{
+				role: "user",
+				content: [{ type: "text", text: "run ls /tmp" }],
+			},
+			{
+				role: "tool",
+				content: [{ type: "text", text: "tool output" }],
+			},
+		];
+		const runtime = createRuntimeClient("");
+		runtime.readMessages
+			.mockResolvedValueOnce(priorMessages)
+			.mockResolvedValueOnce(currentMessages);
+
+		await expect(
+			handleConnectorUserTurn({
+				thread: thread as never,
+				text: "run ls /tmp",
+				client: runtime.client as never,
+				pendingApprovals: new Map(),
+				baseStartRequest: baseStartRequest({
+					enableTools: true,
+					autoApproveTools: true,
+				}) as never,
+				explicitSystemPrompt: undefined,
+				clientId: "client-1",
+				logger: {
+					core: { debug: vi.fn(), log: vi.fn(), error: vi.fn() },
+				} as never,
+				transport: "discord",
+				botUserName: "ClineAdapterBot",
+				requestStop: vi.fn(),
+				bindingsPath,
+				systemRules: "rules",
+				errorLabel: "Discord",
+				getSessionMetadata: () => ({}),
+				reusedLogMessage: "reused",
+				startedLogMessage: "started",
+			}),
+		).rejects.toThrow("Runtime completed without assistant reply text.");
+
+		expect(runtime.readMessages).toHaveBeenCalledTimes(2);
+		expect(posts).not.toContain("Previous reply.");
+	});
+
+	it("keeps Telegram empty-stream behavior from reading session history", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "connector-host-test-"));
+		tempDirs.push(dir);
+		const bindingsPath = join(dir, "threads.json");
+		const { thread, posts } = createThread({
+			enableTools: true,
+			autoApproveTools: true,
+			cwd: "/tmp/work",
+			workspaceRoot: "/tmp/work",
+		});
+		const runtime = createRuntimeClient("", [
+			{
+				role: "assistant",
+				content: [{ type: "text", text: "Previous reply." }],
+			},
+		]);
+
+		await handleConnectorUserTurn({
+			thread: thread as never,
+			text: "run ls /tmp",
+			client: runtime.client as never,
+			pendingApprovals: new Map(),
+			baseStartRequest: baseStartRequest({
+				enableTools: true,
+				autoApproveTools: true,
+			}) as never,
+			explicitSystemPrompt: undefined,
+			clientId: "client-1",
+			logger: {
+				core: { debug: vi.fn(), log: vi.fn(), error: vi.fn() },
+			} as never,
+			transport: "telegram",
+			botUserName: "ClineAdapterBot",
+			requestStop: vi.fn(),
+			bindingsPath,
+			systemRules: "rules",
+			errorLabel: "Telegram",
+			getSessionMetadata: () => ({}),
+			reusedLogMessage: "reused",
+			startedLogMessage: "started",
+		});
+
+		expect(runtime.readMessages).not.toHaveBeenCalled();
+		expect(posts.at(-1)).toEqual({ raw: " " });
 	});
 
 	it("steers active Telegram turns without the hub command timeout", async () => {

--- a/sdk/apps/cli/src/connectors/connector-host.test.ts
+++ b/sdk/apps/cli/src/connectors/connector-host.test.ts
@@ -81,7 +81,15 @@ function baseStartRequest(overrides: Partial<TestState> = {}) {
 	};
 }
 
-function createRuntimeClient(responseText: string) {
+function createRuntimeClient(
+	responseText: string,
+	messages: unknown[] = [
+		{
+			role: "assistant",
+			content: [{ type: "text", text: responseText }],
+		},
+	],
+) {
 	const startRuntimeSession = vi.fn(async () => ({ sessionId: "session-1" }));
 	const updateSession = vi.fn(async () => undefined);
 	const sendRuntimeSession = vi.fn(async () => ({
@@ -91,16 +99,19 @@ function createRuntimeClient(responseText: string) {
 			iterations: 1,
 		},
 	}));
+	const readMessages = vi.fn(async () => messages);
 	return {
 		client: {
 			startRuntimeSession,
 			updateSession,
 			sendRuntimeSession,
+			readMessages,
 			streamEvents: vi.fn(() => () => undefined),
 		},
 		startRuntimeSession,
 		updateSession,
 		sendRuntimeSession,
+		readMessages,
 	};
 }
 
@@ -618,6 +629,52 @@ describe("handleConnectorUserTurn", () => {
 			text: "**Formatted** reply",
 		});
 		expect(posts).not.toContainEqual({ raw: "**Formatted** reply" });
+	});
+
+	it("posts Discord replies from session history when the runtime stream is empty", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "connector-host-test-"));
+		tempDirs.push(dir);
+		const bindingsPath = join(dir, "threads.json");
+		const { thread, posts } = createThread({
+			enableTools: true,
+			autoApproveTools: true,
+			cwd: "/tmp/work",
+			workspaceRoot: "/tmp/work",
+		});
+		const runtime = createRuntimeClient("", [
+			{
+				role: "assistant",
+				content: [{ type: "text", text: "Summary from saved session." }],
+			},
+		]);
+
+		await handleConnectorUserTurn({
+			thread: thread as never,
+			text: "read README.md",
+			client: runtime.client as never,
+			pendingApprovals: new Map(),
+			baseStartRequest: baseStartRequest({
+				enableTools: true,
+				autoApproveTools: true,
+			}) as never,
+			explicitSystemPrompt: undefined,
+			clientId: "client-1",
+			logger: {
+				core: { debug: vi.fn(), log: vi.fn(), error: vi.fn() },
+			} as never,
+			transport: "discord",
+			botUserName: "ClineAdapterBot",
+			requestStop: vi.fn(),
+			bindingsPath,
+			systemRules: "rules",
+			errorLabel: "Discord",
+			getSessionMetadata: () => ({}),
+			reusedLogMessage: "reused",
+			startedLogMessage: "started",
+		});
+
+		expect(runtime.readMessages).toHaveBeenCalledWith("session-1");
+		expect(posts.at(-1)).toBe("Summary from saved session.");
 	});
 
 	it("steers active Telegram turns without the hub command timeout", async () => {

--- a/sdk/apps/cli/src/connectors/connector-host.ts
+++ b/sdk/apps/cli/src/connectors/connector-host.ts
@@ -27,6 +27,7 @@ import {
 	buildThreadStartRequest,
 	clearSession,
 	getOrCreateSessionId,
+	readSessionMessageCount,
 	readSessionReplyText,
 } from "./session-runtime";
 import {
@@ -727,6 +728,10 @@ export async function handleConnectorUserTurn<
 		prompt,
 		attachments: buildAttachments({ userImages, userFiles }),
 	};
+	const fallbackMessageStartIndex =
+		input.transport === "discord"
+			? await readSessionMessageCount(input.client, sessionId)
+			: undefined;
 
 	input.activeTurns?.set(turnKey, { sessionId });
 	await input.thread.startTyping();
@@ -789,7 +794,12 @@ export async function handleConnectorUserTurn<
 				},
 			}),
 			postFinalReply,
-			async () => readSessionReplyText(input.client, sessionId),
+			input.transport === "discord" && fallbackMessageStartIndex !== undefined
+				? async () =>
+						readSessionReplyText(input.client, sessionId, {
+							minMessageIndex: fallbackMessageStartIndex,
+						})
+				: undefined,
 		);
 	} finally {
 		input.pendingApprovals.delete(input.thread.id);

--- a/sdk/apps/cli/src/connectors/connector-host.ts
+++ b/sdk/apps/cli/src/connectors/connector-host.ts
@@ -27,8 +27,6 @@ import {
 	buildThreadStartRequest,
 	clearSession,
 	getOrCreateSessionId,
-	readSessionMessageCount,
-	readSessionReplyText,
 } from "./session-runtime";
 import {
 	type ConnectorThreadState,
@@ -41,6 +39,16 @@ import {
 export type ActiveConnectorTurn = {
 	sessionId: string;
 };
+
+type EmptyRuntimeReplyResolver = () => Promise<string | undefined>;
+
+type EmptyRuntimeReplyResolverFactory = (input: {
+	client: HubSessionClient;
+	sessionId: string;
+}) =>
+	| Promise<EmptyRuntimeReplyResolver | undefined>
+	| EmptyRuntimeReplyResolver
+	| undefined;
 
 function connectorTextPayload(
 	transport: string,
@@ -91,7 +99,7 @@ async function postConnectorRuntimeReply<TState extends ConnectorThreadState>(
 	postFinalReply?: (text: string) => Promise<void>,
 	resolveFallbackText?: () => Promise<string | undefined>,
 ): Promise<void> {
-	if (transport !== "telegram" && transport !== "discord") {
+	if (transport !== "telegram" && !postFinalReply && !resolveFallbackText) {
 		await thread.post(stream);
 		return;
 	}
@@ -103,7 +111,7 @@ async function postConnectorRuntimeReply<TState extends ConnectorThreadState>(
 	if (!text.trim()) {
 		text = (await resolveFallbackText?.())?.trim() || "";
 	}
-	if (transport === "discord" && !text.trim()) {
+	if (resolveFallbackText && !text.trim()) {
 		throw new Error("Runtime completed without assistant reply text.");
 	}
 	if (postFinalReply) {
@@ -180,6 +188,7 @@ export async function handleConnectorUserTurn<
 		thread: Thread<TState>;
 		text: string;
 	}) => Promise<void>;
+	createEmptyRuntimeReplyResolver?: EmptyRuntimeReplyResolverFactory;
 	onReplyCompleted?: (result: {
 		sessionId: string;
 		threadId: string;
@@ -728,10 +737,10 @@ export async function handleConnectorUserTurn<
 		prompt,
 		attachments: buildAttachments({ userImages, userFiles }),
 	};
-	const fallbackMessageStartIndex =
-		input.transport === "discord"
-			? await readSessionMessageCount(input.client, sessionId)
-			: undefined;
+	const resolveFallbackText = await input.createEmptyRuntimeReplyResolver?.({
+		client: input.client,
+		sessionId,
+	});
 
 	input.activeTurns?.set(turnKey, { sessionId });
 	await input.thread.startTyping();
@@ -794,12 +803,7 @@ export async function handleConnectorUserTurn<
 				},
 			}),
 			postFinalReply,
-			input.transport === "discord" && fallbackMessageStartIndex !== undefined
-				? async () =>
-						readSessionReplyText(input.client, sessionId, {
-							minMessageIndex: fallbackMessageStartIndex,
-						})
-				: undefined,
+			resolveFallbackText,
 		);
 	} finally {
 		input.pendingApprovals.delete(input.thread.id);

--- a/sdk/apps/cli/src/connectors/connector-host.ts
+++ b/sdk/apps/cli/src/connectors/connector-host.ts
@@ -27,6 +27,7 @@ import {
 	buildThreadStartRequest,
 	clearSession,
 	getOrCreateSessionId,
+	readSessionReplyText,
 } from "./session-runtime";
 import {
 	type ConnectorThreadState,
@@ -87,8 +88,9 @@ async function postConnectorRuntimeReply<TState extends ConnectorThreadState>(
 	transport: string,
 	stream: AsyncIterable<string>,
 	postFinalReply?: (text: string) => Promise<void>,
+	resolveFallbackText?: () => Promise<string | undefined>,
 ): Promise<void> {
-	if (transport !== "telegram") {
+	if (transport !== "telegram" && transport !== "discord") {
 		await thread.post(stream);
 		return;
 	}
@@ -96,6 +98,12 @@ async function postConnectorRuntimeReply<TState extends ConnectorThreadState>(
 	let text = "";
 	for await (const chunk of stream) {
 		text += chunk;
+	}
+	if (!text.trim()) {
+		text = (await resolveFallbackText?.())?.trim() || "";
+	}
+	if (transport === "discord" && !text.trim()) {
+		throw new Error("Runtime completed without assistant reply text.");
 	}
 	if (postFinalReply) {
 		await postFinalReply(text);
@@ -781,6 +789,7 @@ export async function handleConnectorUserTurn<
 				},
 			}),
 			postFinalReply,
+			async () => readSessionReplyText(input.client, sessionId),
 		);
 	} finally {
 		input.pendingApprovals.delete(input.thread.id);

--- a/sdk/apps/cli/src/connectors/registry.test.ts
+++ b/sdk/apps/cli/src/connectors/registry.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { getConnector, listConnectors } from "./registry";
+
+describe("connector registry", () => {
+	it("registers the Discord connector", async () => {
+		expect(listConnectors().map((connector) => connector.name)).toContain(
+			"discord",
+		);
+
+		await expect(getConnector("discord")).resolves.toMatchObject({
+			name: "discord",
+		});
+	});
+});

--- a/sdk/apps/cli/src/connectors/registry.ts
+++ b/sdk/apps/cli/src/connectors/registry.ts
@@ -8,6 +8,15 @@ type ConnectorRegistryEntry = {
 
 const registry = new Map<string, ConnectorRegistryEntry>([
 	[
+		"discord",
+		{
+			name: "discord",
+			description:
+				"Discord interactions and gateway bridge backed by RPC runtime sessions",
+			load: async () => (await import("./adapters/discord")).discordConnector,
+		},
+	],
+	[
 		"gchat",
 		{
 			name: "gchat",

--- a/sdk/apps/cli/src/connectors/session-runtime.ts
+++ b/sdk/apps/cli/src/connectors/session-runtime.ts
@@ -20,6 +20,7 @@ import { resolveWorkspaceRoot } from "../utils/helpers";
 import {
 	parseLocalRowMetadata,
 	parseRowMetadata,
+	readSessionMessageCount,
 	readSessionReplyText,
 } from "./common";
 import { dispatchConnectorHook } from "./hooks";
@@ -336,4 +337,4 @@ export async function stopConnectorSessions(input: {
 	return filtered.length;
 }
 
-export { readSessionReplyText };
+export { readSessionMessageCount, readSessionReplyText };

--- a/sdk/apps/cli/src/wizards/connect/platforms.ts
+++ b/sdk/apps/cli/src/wizards/connect/platforms.ts
@@ -184,7 +184,10 @@ export const PLATFORMS: PlatformDef[] = [
 				label: "Public base URL",
 				placeholder: "https://example.com",
 				required: true,
-				help: ["Set this as the Interactions Endpoint URL"],
+				help: [
+					"Your public connector base URL, for example from ngrok",
+					"Set the Discord Interactions Endpoint URL to <base-url>/api/webhooks/discord",
+				],
 			},
 		],
 	},

--- a/sdk/apps/cli/src/wizards/connect/platforms.ts
+++ b/sdk/apps/cli/src/wizards/connect/platforms.ts
@@ -185,8 +185,8 @@ export const PLATFORMS: PlatformDef[] = [
 				placeholder: "https://example.com",
 				required: true,
 				help: [
-					"Your public connector base URL, for example from ngrok",
-					"Set the Discord Interactions Endpoint URL to <base-url>/api/webhooks/discord",
+					"Base URL for the connector",
+					"For Discord, set the Interactions Endpoint URL to <base-url>/api/webhooks/discord",
 				],
 			},
 		],


### PR DESCRIPTION
### Related Issue

**Issue:** #11061

### Description

Registers the Discord connector in the CLI connector registry so `cline connect discord` resolves instead of failing with `unknown connect adapter "discord"`.

This also aligns the CLI with the documented command by accepting `--app-id` and `--token` as aliases for `--application-id` and `--bot-token`.

During live Discord testing, two follow-on connector issues showed up and are covered here:

- Restores persisted Discord thread subscriptions on connector startup, so follow-up messages in existing Discord conversations keep working after restart.
- Falls back to saved session history before posting a Discord final reply when the runtime stream is empty, avoiding Discord API error `50006` for empty messages.

### Test Procedure

- Ran `bun run typecheck` in `sdk/apps/cli`.
- Ran `bun run test:unit -- src/connectors/connector-host.test.ts src/connectors/registry.test.ts src/connectors/adapters/discord.test.ts` in `sdk/apps/cli`.
- Ran `git diff --check`.
- Live-tested the Discord connector through a local ngrok-backed Discord app:
  - `/whereami` in an existing server thread after connector restart.
  - README file-read request that previously produced Discord empty-message error `50006`.
  - shell `pwd` tool request.
  - direct-message request and reply.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - CLI connector behavior only.

### Additional Notes

I did not run the full repository `npm test`, `npm run format`, or `npm run lint`; the targeted CLI unit tests, CLI typecheck, and whitespace check passed.
