### PR TITLE
fix(plugin-sandbox): expose CLINE_PLUGIN_IMPORT_TIMEOUT_MS env override (#11065)

### DIFF
--- a/sdk/packages/core/src/extensions/plugin/plugin-sandbox.test.ts
+++ b/sdk/packages/core/src/extensions/plugin/plugin-sandbox.test.ts
@@ -422,7 +422,6 @@ describe("plugin-sandbox", () => {
 			const envDir = await mkdtemp(
 				join(tmpdir(), "core-plugin-sandbox-import-env-"),
 			);
-			const previousEnv = process.env.CLINE_PLUGIN_IMPORT_TIMEOUT_MS;
 			try {
 				const pluginPath = join(envDir, "plugin-import-hang.mjs");
 				// Top-level await that never resolves — module import never
@@ -442,16 +441,12 @@ describe("plugin-sandbox", () => {
 				// Set env override well below the 4000 ms hardcoded default.
 				// If the env var isn't read, this test would block for ~4 s and
 				// the per-test timeout (3000 ms below) would fail it.
-				process.env.CLINE_PLUGIN_IMPORT_TIMEOUT_MS = "150";
+				vi.stubEnv("CLINE_PLUGIN_IMPORT_TIMEOUT_MS", "150");
 				await expect(
 					loadSandboxedPlugins({ pluginPaths: [pluginPath] }),
 				).rejects.toThrow(/timed out/i);
 			} finally {
-				if (previousEnv === undefined) {
-					delete process.env.CLINE_PLUGIN_IMPORT_TIMEOUT_MS;
-				} else {
-					process.env.CLINE_PLUGIN_IMPORT_TIMEOUT_MS = previousEnv;
-				}
+				vi.unstubAllEnvs();
 				await rm(envDir, { recursive: true, force: true });
 			}
 		},

--- a/sdk/packages/core/src/extensions/plugin/plugin-sandbox.test.ts
+++ b/sdk/packages/core/src/extensions/plugin/plugin-sandbox.test.ts
@@ -416,6 +416,48 @@ describe("plugin-sandbox", () => {
 		}
 	});
 
+	it(
+		"respects CLINE_PLUGIN_IMPORT_TIMEOUT_MS env var when options.importTimeoutMs is unset",
+		async () => {
+			const envDir = await mkdtemp(
+				join(tmpdir(), "core-plugin-sandbox-import-env-"),
+			);
+			const previousEnv = process.env.CLINE_PLUGIN_IMPORT_TIMEOUT_MS;
+			try {
+				const pluginPath = join(envDir, "plugin-import-hang.mjs");
+				// Top-level await that never resolves — module import never
+				// completes, so the initialize call must hit the timeout.
+				await writeFile(
+					pluginPath,
+					[
+						"await new Promise(() => {});",
+						"export default {",
+						"  name: 'sandbox-import-hang',",
+						"  manifest: { capabilities: ['tools'] },",
+						"};",
+					].join("\n"),
+					"utf8",
+				);
+
+				// Set env override well below the 4000 ms hardcoded default.
+				// If the env var isn't read, this test would block for ~4 s and
+				// the per-test timeout (3000 ms below) would fail it.
+				process.env.CLINE_PLUGIN_IMPORT_TIMEOUT_MS = "150";
+				await expect(
+					loadSandboxedPlugins({ pluginPaths: [pluginPath] }),
+				).rejects.toThrow(/timed out/i);
+			} finally {
+				if (previousEnv === undefined) {
+					delete process.env.CLINE_PLUGIN_IMPORT_TIMEOUT_MS;
+				} else {
+					process.env.CLINE_PLUGIN_IMPORT_TIMEOUT_MS = previousEnv;
+				}
+				await rm(envDir, { recursive: true, force: true });
+			}
+		},
+		3000,
+	);
+
 	it("forwards sandbox plugin events to the host", async () => {
 		const extension = sharedExtensions.get("sandbox-events");
 		const { tools, api } = createApiCapture();

--- a/sdk/packages/core/src/extensions/plugin/plugin-sandbox.ts
+++ b/sdk/packages/core/src/extensions/plugin/plugin-sandbox.ts
@@ -23,6 +23,12 @@ export type SandboxedPluginSetupContext = Pick<
 export interface PluginSandboxOptions extends PluginTargeting {
 	pluginPaths: string[];
 	exportName?: string;
+	/**
+	 * Max wall time for plugin module imports. Defaults to 4000 ms; falls back
+	 * to the `CLINE_PLUGIN_IMPORT_TIMEOUT_MS` env var when this option is not
+	 * set, allowing slower hosts (Windows cold-start, CI without warm caches)
+	 * to raise the ceiling without touching code.
+	 */
 	importTimeoutMs?: number;
 	hookTimeoutMs?: number;
 	contributionTimeoutMs?: number;
@@ -202,8 +208,21 @@ const BOOTSTRAP = resolveBootstrap();
 function withTimeoutFallback(
 	timeoutMs: number | undefined,
 	fallback: number,
+	envVarName?: string,
 ): number {
-	return typeof timeoutMs === "number" && timeoutMs > 0 ? timeoutMs : fallback;
+	if (typeof timeoutMs === "number" && timeoutMs > 0) {
+		return timeoutMs;
+	}
+	if (envVarName) {
+		const raw = process.env[envVarName];
+		if (raw) {
+			const parsed = Number.parseInt(raw, 10);
+			if (Number.isFinite(parsed) && parsed > 0) {
+				return parsed;
+			}
+		}
+	}
+	return fallback;
 }
 
 export async function loadSandboxedPlugins(
@@ -221,7 +240,11 @@ export async function loadSandboxedPlugins(
 			: { bootstrapScript: BOOTSTRAP.script }),
 		onEvent: options.onEvent,
 	});
-	const importTimeoutMs = withTimeoutFallback(options.importTimeoutMs, 4000);
+	const importTimeoutMs = withTimeoutFallback(
+		options.importTimeoutMs,
+		4000,
+		"CLINE_PLUGIN_IMPORT_TIMEOUT_MS",
+	);
 	const hookTimeoutMs = withTimeoutFallback(options.hookTimeoutMs, 3000);
 	const contributionTimeoutMs = withTimeoutFallback(
 		options.contributionTimeoutMs,

--- a/sdk/packages/core/src/extensions/plugin/plugin-sandbox.ts
+++ b/sdk/packages/core/src/extensions/plugin/plugin-sandbox.ts
@@ -216,8 +216,12 @@ function withTimeoutFallback(
 	if (envVarName) {
 		const raw = process.env[envVarName];
 		if (raw) {
-			const parsed = Number.parseInt(raw, 10);
-			if (Number.isFinite(parsed) && parsed > 0) {
+			// Number() is stricter than parseInt: it rejects values with
+			// trailing non-numeric characters (e.g. "4000ms" -> NaN) so a
+			// malformed env value falls back to the default instead of
+			// silently consuming its numeric prefix.
+			const parsed = Number(raw);
+			if (Number.isInteger(parsed) && parsed > 0) {
 				return parsed;
 			}
 		}


### PR DESCRIPTION
## Summary

Fixes #11065 — Windows cold-start exceeds the hardcoded 4000 ms `importTimeoutMs`, so every plugin (including Cline's own [`weather-metrics` example](https://github.com/cline/cline/blob/main/sdk/examples/plugins/weather-metrics.ts)) fails the initialize handshake and never registers.

Per @reneehuang1's note in the issue, this PR exposes an env var override — smallest blast radius, no default change, no new CLI surface.

## Change

`sdk/packages/core/src/extensions/plugin/plugin-sandbox.ts`:

- `withTimeoutFallback` now accepts an optional `envVarName`. If `options.importTimeoutMs` is unset, the helper reads a positive integer from that env var before falling back to the hardcoded default.
- `CLINE_PLUGIN_IMPORT_TIMEOUT_MS` is wired for the import-timeout path (the failure surface in #11065). Hook / contribution timeouts are unchanged in this PR — happy to extend in a follow-up if useful.
- JSDoc on `PluginSandboxOptions.importTimeoutMs` documents the env fallback.

Precedence: `options.importTimeoutMs` > env var > 4000 ms.

## Test

New regression in `plugin-sandbox.test.ts`:

- Plugin module hangs on top-level `await new Promise(() => {})` — module import never resolves.
- `CLINE_PLUGIN_IMPORT_TIMEOUT_MS=150`, vitest per-test timeout `3000` ms.
- If the env override were silently ignored, the hardcoded 4000 ms default would apply and the test would exceed vitest's 3 s timeout. The test passing therefore proves the env override engaged.

```
$ bun run test:unit -- src/extensions/plugin/plugin-sandbox.test.ts
 Test Files  1 passed (1)
      Tests  17 passed (17)
```

(Local: Windows 11, Node v24.3.0 via nvm4w, bun 1.3.1.)

## End-to-end verification

Will follow up in #11065 once a dev cline binary built from this branch lands in the same Windows environment that exhibited the original timeout. Open to guidance on whether to extend the env-var pattern to `hookTimeoutMs` / `contributionTimeoutMs` in this PR or as a follow-up.