### PR TITLE
fix(llms): omit GLM reasoning controls for openai-compatible

### DIFF
--- a/sdk/packages/llms/src/providers/compat.test.ts
+++ b/sdk/packages/llms/src/providers/compat.test.ts
@@ -393,7 +393,10 @@ describe("createGatewayApiHandler.createMessage", () => {
 		expect(call).not.toHaveProperty("maxOutputTokens");
 	});
 
-	it("does not send routed GLM reasoning controls to generic openai-compatible providers", async () => {
+	it.each([
+		false,
+		true,
+	])("does not send GLM reasoning controls to generic openai-compatible providers when thinking=%s", async (thinking) => {
 		streamTextSpy.mockReturnValue({
 			fullStream: (async function* () {
 				yield { type: "finish", finishReason: "stop" };
@@ -406,7 +409,7 @@ describe("createGatewayApiHandler.createMessage", () => {
 			clientType: "openai-compatible",
 			modelId: "zai-org/GLM-5.1",
 			apiKey: "test-key",
-			thinking: false,
+			thinking,
 			modelInfo: {
 				id: "zai-org/GLM-5.1",
 				name: "GLM 5.1",
@@ -426,8 +429,14 @@ describe("createGatewayApiHandler.createMessage", () => {
 		expect(call?.providerOptions?.openaiCompatible).not.toHaveProperty(
 			"reasoning",
 		);
+		expect(call?.providerOptions?.openaiCompatible).not.toHaveProperty(
+			"thinking",
+		);
 		expect(call?.providerOptions?.["openai-compatible"]).not.toHaveProperty(
 			"reasoning",
+		);
+		expect(call?.providerOptions?.["openai-compatible"]).not.toHaveProperty(
+			"thinking",
 		);
 	});
 

--- a/sdk/packages/llms/src/providers/compat.test.ts
+++ b/sdk/packages/llms/src/providers/compat.test.ts
@@ -393,6 +393,44 @@ describe("createGatewayApiHandler.createMessage", () => {
 		expect(call).not.toHaveProperty("maxOutputTokens");
 	});
 
+	it("does not send routed GLM reasoning controls to generic openai-compatible providers", async () => {
+		streamTextSpy.mockReturnValue({
+			fullStream: (async function* () {
+				yield { type: "finish", finishReason: "stop" };
+			})(),
+			usage: Promise.resolve({ inputTokens: 1, outputTokens: 1 }),
+		});
+
+		const handler = createGatewayApiHandler({
+			providerId: "openai-compatible",
+			clientType: "openai-compatible",
+			modelId: "zai-org/GLM-5.1",
+			apiKey: "test-key",
+			thinking: false,
+			modelInfo: {
+				id: "zai-org/GLM-5.1",
+				name: "GLM 5.1",
+				capabilities: ["streaming", "reasoning"],
+			},
+		});
+
+		for await (const _chunk of handler.createMessage("", [
+			{ role: "user", content: "Hello" },
+		])) {
+			// Drain the stream so the provider request is executed.
+		}
+
+		const call = streamTextSpy.mock.calls.at(-1)?.[0] as
+			| { providerOptions?: Record<string, Record<string, unknown>> }
+			| undefined;
+		expect(call?.providerOptions?.openaiCompatible).not.toHaveProperty(
+			"reasoning",
+		);
+		expect(call?.providerOptions?.["openai-compatible"]).not.toHaveProperty(
+			"reasoning",
+		);
+	});
+
 	it("caps configured maxOutputTokens with the catalog model output limit", async () => {
 		streamTextSpy.mockReturnValue({
 			fullStream: (async function* () {

--- a/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
@@ -74,6 +74,12 @@ function hasGlmThinkingProviderRouting(
 	);
 }
 
+function isGenericOpenAiCompatibleProvider(
+	input: ProviderOptionMatchInput,
+): boolean {
+	return input.request.providerId === "openai-compatible";
+}
+
 function resolveFamilyThinkingType(
 	input: ProviderOptionMatchInput,
 	defaultWhenUnset: "enabled" | "disabled" | undefined,
@@ -337,6 +343,7 @@ const routedGlmReasoningRule: ProviderOptionRule = {
 	description:
 		"Routed GLM models use the generic reasoning include/exclude shape, not thinking.type.",
 	applies: (input) =>
+		!isGenericOpenAiCompatibleProvider(input) &&
 		!usesGlmThinkingProviderRouting(input) &&
 		isGlmModel(input.request, input.context),
 	suppresses: { genericThinking: true },

--- a/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
@@ -324,6 +324,19 @@ const nonGlmProviderRoutingSuppressionRule: ProviderOptionRule = {
 	build: () => undefined,
 };
 
+const genericOpenAiCompatibleGlmSuppressionRule: ProviderOptionRule = {
+	id: "provider.openai-compatible.glm.suppress-generic-reasoning",
+	phase: "provider",
+	description:
+		"Generic OpenAI-compatible GLM endpoints should not receive non-standard reasoning or thinking controls.",
+	applies: (input) =>
+		isGenericOpenAiCompatibleProvider(input) &&
+		input.request.reasoning?.enabled !== undefined &&
+		isGlmModel(input.request, input.context),
+	suppresses: { genericThinking: true, genericEffort: true },
+	build: () => undefined,
+};
+
 const nativeZaiGlmThinkingRule: ProviderOptionRule = {
 	id: "provider.routing.glm-thinking",
 	phase: "model-overlay",
@@ -378,6 +391,7 @@ export const PROVIDER_OPTION_RULES: ReadonlyArray<ProviderOptionRule> = [
 	deepSeekThinkingRule,
 	ollamaReasoningDefaultOnDisableRule,
 	nonGlmProviderRoutingSuppressionRule,
+	genericOpenAiCompatibleGlmSuppressionRule,
 	nativeZaiGlmThinkingRule,
 	routedGlmReasoningRule,
 ];


### PR DESCRIPTION
### Related Issue

**Issue:** #11086

### Description

This PR prevents the CLI SDK path from sending routed GLM `reasoning: { exclude: true }` provider options to generic `openai-compatible` providers. Strict OpenAI-compatible endpoints such as FriendliAI reject the extra `reasoning` field even though routed providers like OpenRouter/Cline/Vercel Gateway still use that shape.

The regression test goes through `createGatewayApiHandler.createMessage` so it covers the CLI compatibility path that builds the outgoing provider options.

### Test Procedure

Pre-fix regression failed with:

```
AssertionError: expected { strictJsonSchema: false, …(1) } to not have property "reasoning"
Received: { "exclude": true }
```

Post-fix validation:

```
bun -F @cline/llms test -- src/providers/compat.test.ts -t "does not send routed GLM reasoning controls"
bun -F @cline/llms test -- src/providers/compat.test.ts
bun -F @cline/llms test -- src/providers/routing/provider-options.test.ts
bun -F @cline/llms test -- src/providers/gateway.test.ts -t "routed GLM reasoning"
bun -F @cline/llms typecheck
bun biome check --diagnostic-level=error packages/llms/src/providers/routing/provider-option-rules.ts packages/llms/src/providers/compat.test.ts
```

All commands passed after the fix.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A, CLI/provider-options bug.

### Additional Notes

The existing routed GLM behavior for OpenRouter/Cline/Vercel Gateway is covered by the targeted gateway test and remains unchanged.
