### PR TITLE
feat(cerebras): remove deprecated qwen-3-235b model

### DIFF
--- a/apps/vscode/src/core/api/providers/cerebras.ts
+++ b/apps/vscode/src/core/api/providers/cerebras.ts
@@ -251,9 +251,6 @@ export class CerebrasHandler implements ApiHandler {
 			case "qwen-3-coder-480b":
 			case "qwen-3-coder-480b-free":
 				return { requestsPerMinute: 10, tokensPerMinute: 150_000 }
-			case "qwen-3-235b-a22b-instruct-2507":
-			case "qwen-3-235b-a22b-thinking-2507":
-				return { requestsPerMinute: 30, tokensPerMinute: 60_000 }
 			case "gpt-oss-120b":
 				return { requestsPerMinute: 30, tokensPerMinute: 64_000 }
 			default:

--- a/apps/vscode/src/shared/api.ts
+++ b/apps/vscode/src/shared/api.ts
@@ -4041,15 +4041,6 @@ export const cerebrasModels = {
 		outputPrice: 0,
 		description: "Intelligent general purpose model with 3,000 tokens/s",
 	},
-	"qwen-3-235b-a22b-instruct-2507": {
-		maxTokens: 64000,
-		contextWindow: 64000,
-		supportsImages: false,
-		supportsPromptCache: false,
-		inputPrice: 0,
-		outputPrice: 0,
-		description: "Intelligent model with ~1400 tokens/s",
-	},
 } as const satisfies Record<string, ModelInfo>
 
 // Groq


### PR DESCRIPTION
## Summary
- remove the deprecated `qwen-3-235b-a22b-instruct-2507` Cerebras model from the shared catalog
- drop the now-unused Cerebras rate-limit branch for that model

## Testing
- `npx tsc --noEmit` in `apps/vscode`
- `npx tsc --noEmit` in `apps/vscode/webview-ui`
- `npm run check-types` is currently blocked by unrelated existing Biome config errors in this checkout