### PR TITLE
Fix OTEL variable bundling

### DIFF
--- a/sdk/packages/shared/src/services/telemetry-config.ts
+++ b/sdk/packages/shared/src/services/telemetry-config.ts
@@ -6,20 +6,26 @@ export interface ClineTelemetryServiceConfig extends OpenTelemetryClientConfig {
 }
 
 function getTelemetryBuildTimeConfig(): OpenTelemetryClientConfig {
+	if (!process.env) {
+		return {
+			enabled: false,
+		};
+	}
+
 	return {
 		enabled:
-			process?.env?.OTEL_TELEMETRY_ENABLED === "1" ||
-			process?.env?.OTEL_TELEMETRY_ENABLED === "true",
-		metricsExporter: process?.env?.OTEL_METRICS_EXPORTER || "otlp",
-		logsExporter: process?.env?.OTEL_LOGS_EXPORTER || "otlp",
-		tracesExporter: process?.env?.OTEL_TRACES_EXPORTER,
-		otlpProtocol: process?.env?.OTEL_EXPORTER_OTLP_PROTOCOL || "http/json",
-		otlpEndpoint: process?.env?.OTEL_EXPORTER_OTLP_ENDPOINT,
-		metricExportInterval: process?.env?.OTEL_METRIC_EXPORT_INTERVAL
-			? Number.parseInt(process?.env?.OTEL_METRIC_EXPORT_INTERVAL, 10)
+			process.env.OTEL_TELEMETRY_ENABLED === "1" ||
+			process.env.OTEL_TELEMETRY_ENABLED === "true",
+		metricsExporter: process.env.OTEL_METRICS_EXPORTER || "otlp",
+		logsExporter: process.env.OTEL_LOGS_EXPORTER || "otlp",
+		tracesExporter: process.env.OTEL_TRACES_EXPORTER,
+		otlpProtocol: process.env.OTEL_EXPORTER_OTLP_PROTOCOL || "http/json",
+		otlpEndpoint: process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
+		metricExportInterval: process.env.OTEL_METRIC_EXPORT_INTERVAL
+			? Number.parseInt(process.env.OTEL_METRIC_EXPORT_INTERVAL, 10)
 			: undefined,
-		otlpHeaders: process?.env?.OTEL_EXPORTER_OTLP_HEADERS
-			? parseKeyPairsIntoRecord(process?.env?.OTEL_EXPORTER_OTLP_HEADERS)
+		otlpHeaders: process.env.OTEL_EXPORTER_OTLP_HEADERS
+			? parseKeyPairsIntoRecord(process.env.OTEL_EXPORTER_OTLP_HEADERS)
 			: undefined,
 	};
 }


### PR DESCRIPTION
OTEL variables are replaced at build time using the string `process.env.VARNAME`. The current checks break it.

This PR fixes them.