### PR TITLE
feat(sdk): support global AGENTS rules

### DIFF
--- a/docs/customization/cline-rules.mdx
+++ b/docs/customization/cline-rules.mdx
@@ -26,7 +26,7 @@ Cline recognizes rules from multiple sources, so you can use existing rule files
 | Cline Rules | `.clinerules/` | Primary rule format |
 | Cursor Rules | `.cursorrules` | Automatically detected |
 | Windsurf Rules | `.windsurfrules` | Automatically detected |
-| AGENTS.md | `AGENTS.md` | [Standard format](https://agents.md/) for cross-tool compatibility |
+| AGENTS.md | `AGENTS.md`, `~/.agents/AGENTS.md` | [Standard format](https://agents.md/) for cross-tool compatibility |
 
 All detected rule types appear in the Rules panel, where you can toggle them individually.
 
@@ -37,7 +37,7 @@ Rules can be stored in two locations: your project workspace or globally on your
 
 **Workspace rules** go in `.clinerules/` at your project root. Use these for team standards, project-specific constraints, and anything you want to share with collaborators via version control.
 
-**Global rules** go in your system's Cline Rules directory. Use these for personal preferences that apply across all projects.
+**Global rules** go in your system's Cline Rules directory. Use these for personal preferences that apply across all projects. Cline also reads cross-tool global AGENTS instructions from `~/.agents/AGENTS.md`.
 
 ```text
 your-project/

--- a/sdk/packages/core/src/extensions/config/user-instruction-config-loader.test.ts
+++ b/sdk/packages/core/src/extensions/config/user-instruction-config-loader.test.ts
@@ -61,6 +61,11 @@ describe("user instruction config loader", () => {
 				join(workspacePath, ".cline", "rules"),
 			]),
 		);
+		expect(
+			resolveRulesConfigSearchPaths(workspacePath).some((path) =>
+				path.endsWith(join(".agents", "AGENTS.md")),
+			),
+		).toBe(true);
 		const paths = resolveWorkflowsConfigSearchPaths(workspacePath);
 		expect(paths).toContain(join(workspacePath, ".clinerules", "workflows"));
 		expect(paths).toContain(join(workspacePath, ".cline", "workflows"));
@@ -182,6 +187,43 @@ Escalation runbook`,
 			);
 		} finally {
 			unsubscribe();
+			watcher.stop();
+		}
+	});
+
+	it("loads global and workspace AGENTS.md rules without clobbering either source", async () => {
+		const tempRoot = await mkdtemp(
+			join(tmpdir(), "core-user-instructions-agents-"),
+		);
+		tempRoots.push(tempRoot);
+
+		const globalAgentsDir = join(tempRoot, "home", ".agents");
+		const workspaceRoot = join(tempRoot, "workspace");
+		await mkdir(globalAgentsDir, { recursive: true });
+		await mkdir(workspaceRoot, { recursive: true });
+		const globalAgentsPath = join(globalAgentsDir, "AGENTS.md");
+		const workspaceAgentsPath = join(workspaceRoot, "AGENTS.md");
+		await writeFile(globalAgentsPath, "Use global AGENTS rules.");
+		await writeFile(workspaceAgentsPath, "Use workspace AGENTS rules.");
+
+		const watcher = createUserInstructionConfigWatcher({
+			rules: {
+				directories: [globalAgentsPath, workspaceAgentsPath],
+				workspacePath: workspaceRoot,
+			},
+		});
+
+		try {
+			await watcher.start();
+			const rules = watcher.getSnapshot("rule");
+
+			expect(rules.get("global agents.md")?.item.instructions).toBe(
+				"Use global AGENTS rules.",
+			);
+			expect(rules.get("workspace agents.md")?.item.instructions).toBe(
+				"Use workspace AGENTS rules.",
+			);
+		} finally {
 			watcher.stop();
 		}
 	});

--- a/sdk/packages/core/src/extensions/config/user-instruction-config-loader.test.ts
+++ b/sdk/packages/core/src/extensions/config/user-instruction-config-loader.test.ts
@@ -197,18 +197,26 @@ Escalation runbook`,
 		);
 		tempRoots.push(tempRoot);
 
-		const globalAgentsDir = join(tempRoot, "home", ".agents");
+		const globalAgentsDir = join(tempRoot, "home", ".Agents");
+		const fallbackAgentsDir = join(tempRoot, "other");
 		const workspaceRoot = join(tempRoot, "workspace");
 		await mkdir(globalAgentsDir, { recursive: true });
+		await mkdir(fallbackAgentsDir, { recursive: true });
 		await mkdir(workspaceRoot, { recursive: true });
 		const globalAgentsPath = join(globalAgentsDir, "AGENTS.md");
+		const fallbackAgentsPath = join(fallbackAgentsDir, "AGENTS.md");
 		const workspaceAgentsPath = join(workspaceRoot, "AGENTS.md");
 		await writeFile(globalAgentsPath, "Use global AGENTS rules.");
+		await writeFile(fallbackAgentsPath, "Use fallback AGENTS rules.");
 		await writeFile(workspaceAgentsPath, "Use workspace AGENTS rules.");
 
 		const watcher = createUserInstructionConfigWatcher({
 			rules: {
-				directories: [globalAgentsPath, workspaceAgentsPath],
+				directories: [
+					globalAgentsPath,
+					workspaceAgentsPath,
+					fallbackAgentsPath,
+				],
 				workspacePath: workspaceRoot,
 			},
 		});
@@ -222,6 +230,9 @@ Escalation runbook`,
 			);
 			expect(rules.get("workspace agents.md")?.item.instructions).toBe(
 				"Use workspace AGENTS rules.",
+			);
+			expect(rules.get("agents")?.item.instructions).toBe(
+				"Use fallback AGENTS rules.",
 			);
 		} finally {
 			watcher.stop();

--- a/sdk/packages/core/src/extensions/config/user-instruction-config-loader.test.ts
+++ b/sdk/packages/core/src/extensions/config/user-instruction-config-loader.test.ts
@@ -1,6 +1,10 @@
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
+import {
+	resolveGlobalAgentsRulesPath,
+	setHomeDir,
+} from "@cline/shared/storage";
 import { afterEach, describe, expect, it } from "vitest";
 import {
 	createRulesConfigDefinition,
@@ -197,13 +201,14 @@ Escalation runbook`,
 		);
 		tempRoots.push(tempRoot);
 
-		const globalAgentsDir = join(tempRoot, "home", ".Agents");
-		const fallbackAgentsDir = join(tempRoot, "other");
+		const originalHomeDir = process.env.HOME?.trim() || homedir();
+		setHomeDir(join(tempRoot, "home"));
+		const globalAgentsPath = resolveGlobalAgentsRulesPath();
+		const fallbackAgentsDir = join(tempRoot, "other", ".agents");
 		const workspaceRoot = join(tempRoot, "workspace");
-		await mkdir(globalAgentsDir, { recursive: true });
+		await mkdir(join(tempRoot, "home", ".agents"), { recursive: true });
 		await mkdir(fallbackAgentsDir, { recursive: true });
 		await mkdir(workspaceRoot, { recursive: true });
-		const globalAgentsPath = join(globalAgentsDir, "AGENTS.md");
 		const fallbackAgentsPath = join(fallbackAgentsDir, "AGENTS.md");
 		const workspaceAgentsPath = join(workspaceRoot, "AGENTS.md");
 		await writeFile(globalAgentsPath, "Use global AGENTS rules.");
@@ -236,6 +241,7 @@ Escalation runbook`,
 			);
 		} finally {
 			watcher.stop();
+			setHomeDir(originalHomeDir);
 		}
 	});
 

--- a/sdk/packages/core/src/extensions/config/user-instruction-config-loader.ts
+++ b/sdk/packages/core/src/extensions/config/user-instruction-config-loader.ts
@@ -3,6 +3,7 @@ import { basename, dirname, extname, join, resolve } from "node:path";
 import {
 	AGENTS_RULES_FILE_NAME,
 	RULES_CONFIG_DIRECTORY_NAME,
+	resolveGlobalAgentsRulesPath,
 	resolveRulesConfigSearchPaths as resolveRulesConfigSearchPathsFromShared,
 	resolveSkillsConfigSearchPaths as resolveSkillsConfigSearchPathsFromShared,
 	resolveWorkflowsConfigSearchPaths as resolveWorkflowsConfigSearchPathsFromShared,
@@ -226,7 +227,7 @@ function resolveRuleFallbackName(
 		return "Workspace AGENTS.md";
 	}
 
-	if (basename(context.directoryPath).toLowerCase() === ".agents") {
+	if (resolve(context.filePath) === resolve(resolveGlobalAgentsRulesPath())) {
 		return "Global AGENTS.md";
 	}
 

--- a/sdk/packages/core/src/extensions/config/user-instruction-config-loader.ts
+++ b/sdk/packages/core/src/extensions/config/user-instruction-config-loader.ts
@@ -226,11 +226,11 @@ function resolveRuleFallbackName(
 		return "Workspace AGENTS.md";
 	}
 
-	if (basename(context.directoryPath) === ".agents") {
+	if (basename(context.directoryPath).toLowerCase() === ".agents") {
 		return "Global AGENTS.md";
 	}
 
-	return AGENTS_RULES_FILE_NAME;
+	return basename(context.filePath, extname(context.filePath));
 }
 
 export function parseSkillConfigFromMarkdown(

--- a/sdk/packages/core/src/extensions/config/user-instruction-config-loader.ts
+++ b/sdk/packages/core/src/extensions/config/user-instruction-config-loader.ts
@@ -1,6 +1,7 @@
 import { readdir, readFile, stat } from "node:fs/promises";
-import { basename, dirname, extname, join } from "node:path";
+import { basename, dirname, extname, join, resolve } from "node:path";
 import {
+	AGENTS_RULES_FILE_NAME,
 	RULES_CONFIG_DIRECTORY_NAME,
 	resolveRulesConfigSearchPaths as resolveRulesConfigSearchPathsFromShared,
 	resolveSkillsConfigSearchPaths as resolveSkillsConfigSearchPathsFromShared,
@@ -12,6 +13,7 @@ import YAML from "yaml";
 import {
 	type UnifiedConfigDefinition,
 	type UnifiedConfigFileCandidate,
+	type UnifiedConfigFileContext,
 	UnifiedConfigFileWatcher,
 	type UnifiedConfigWatcherEvent,
 } from "./unified-config-file-watcher";
@@ -206,6 +208,29 @@ function parseBooleanField(
 		throw new Error(`Frontmatter field '${fieldName}' must be a boolean.`);
 	}
 	return value;
+}
+
+function resolveRuleFallbackName(
+	context: UnifiedConfigFileContext<"rule">,
+	workspacePath?: string,
+): string {
+	const fileName = basename(context.filePath);
+	if (fileName.toLowerCase() !== AGENTS_RULES_FILE_NAME.toLowerCase()) {
+		return basename(context.filePath, extname(context.filePath));
+	}
+
+	if (
+		workspacePath &&
+		resolve(context.filePath) === resolve(workspacePath, AGENTS_RULES_FILE_NAME)
+	) {
+		return "Workspace AGENTS.md";
+	}
+
+	if (basename(context.directoryPath) === ".agents") {
+		return "Global AGENTS.md";
+	}
+
+	return AGENTS_RULES_FILE_NAME;
 }
 
 export function parseSkillConfigFromMarkdown(
@@ -483,7 +508,7 @@ export function createRulesConfigDefinition(
 		parseFile: (context) =>
 			parseRuleConfigFromMarkdown(
 				context.content,
-				basename(context.filePath, extname(context.filePath)),
+				resolveRuleFallbackName(context, options?.workspacePath),
 			),
 		resolveId: (rule) => normalizeName(rule.name),
 	};

--- a/sdk/packages/shared/src/storage/index.ts
+++ b/sdk/packages/shared/src/storage/index.ts
@@ -1,6 +1,7 @@
 export { resolveExistingFilePath } from "./path-resolution";
 export {
 	AGENT_CONFIG_DIRECTORY_NAME,
+	AGENTS_RULES_FILE_NAME,
 	CLINE_MCP_SETTINGS_FILE_NAME,
 	type CronSpecsScope,
 	discoverPluginModulePaths,
@@ -23,6 +24,7 @@ export {
 	resolveDbDataDir,
 	resolveDocumentsClineDirectoryPath,
 	resolveDocumentsExtensionPath,
+	resolveGlobalAgentsRulesPath,
 	resolveGlobalCronSpecsDir,
 	resolveGlobalSettingsPath,
 	resolveHooksConfigSearchPaths,

--- a/sdk/packages/shared/src/storage/paths.test.ts
+++ b/sdk/packages/shared/src/storage/paths.test.ts
@@ -8,6 +8,7 @@ import {
 	resolveAgentsConfigDirPath,
 	resolveClineDataDir,
 	resolveDbDataDir,
+	resolveGlobalAgentsRulesPath,
 	resolveGlobalSettingsPath,
 	resolveHooksConfigSearchPaths,
 	resolveMcpSettingsPath,
@@ -153,6 +154,7 @@ describe("storage path resolution", () => {
 
 		expect(resolveRulesConfigSearchPaths()).toEqual(
 			expect.arrayContaining([
+				resolveGlobalAgentsRulesPath(),
 				join("/tmp/home", ".cline", RULES_CONFIG_DIRECTORY_NAME),
 			]),
 		);

--- a/sdk/packages/shared/src/storage/paths.ts
+++ b/sdk/packages/shared/src/storage/paths.ts
@@ -21,6 +21,7 @@ export const SKILLS_CONFIG_DIRECTORY_NAME = "skills";
 export const RULES_CONFIG_DIRECTORY_NAME = "rules";
 export const WORKFLOWS_CONFIG_DIRECTORY_NAME = "workflows";
 export const PLUGINS_DIRECTORY_NAME = "plugins";
+export const AGENTS_RULES_FILE_NAME = "AGENTS.md";
 
 export const CLINE_MCP_SETTINGS_FILE_NAME = "cline_mcp_settings.json";
 
@@ -351,6 +352,10 @@ export function resolveSkillsConfigSearchPaths(
 	]);
 }
 
+export function resolveGlobalAgentsRulesPath(): string {
+	return join(HOME_DIR, LEGACY_AGENT_SKILLS_CONFIG_DIR, AGENTS_RULES_FILE_NAME);
+}
+
 export function resolveRulesConfigSearchPaths(
 	workspacePath?: string,
 ): string[] {
@@ -361,11 +366,12 @@ export function resolveRulesConfigSearchPaths(
 			]
 		: [];
 	const workspaceAgentsFile = workspacePath
-		? [join(workspacePath, "AGENTS.md")]
+		? [join(workspacePath, AGENTS_RULES_FILE_NAME)]
 		: [];
 	return dedupePaths([
 		...workspaceAgentsFile,
 		...wsPaths,
+		resolveGlobalAgentsRulesPath(),
 		join(resolveClineDir(), RULES_CONFIG_DIRECTORY_NAME),
 		resolveDocumentsExtensionPath("Rules"),
 	]);


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Adds SDK support for cross-tool global AGENTS instructions at `~/.agents/AGENTS.md` by including that file in the default rules search paths.

This also makes fallback rule names for AGENTS files source-aware so `~/.agents/AGENTS.md` and workspace `AGENTS.md` can both be loaded without clobbering each other when neither file declares a frontmatter `name`.

Docs are updated to list the global AGENTS location.

### Test Procedure

- `bun biome check --diagnostic-level=error packages/shared/src/storage/paths.ts packages/shared/src/storage/index.ts packages/shared/src/storage/paths.test.ts packages/core/src/extensions/config/user-instruction-config-loader.ts packages/core/src/extensions/config/user-instruction-config-loader.test.ts ../docs/customization/cline-rules.mdx`
- `bun --filter @cline/shared test:unit -- src/storage/paths.test.ts`
- `bun --filter @cline/core test:unit -- src/extensions/config/user-instruction-config-loader.test.ts`
- `bun --filter @cline/shared typecheck`
- `bun --filter @cline/core typecheck`

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

No UI changes.
