### PR TITLE
ci: gate ext-jb-test-integration auto-trigger on PR author association

### DIFF
--- a/.github/workflows/ext-jb-test-integration.yml
+++ b/.github/workflows/ext-jb-test-integration.yml
@@ -15,9 +15,11 @@ jobs:
   trigger-integration-test:
     name: Run Tests
     runs-on: ubuntu-latest
-    # Run on PR open/reopen, or when someone comments /test-jetbrains on a PR
+    # Auto-run only for trusted PR authors. Anyone else needs a maintainer
+    # to opt their PR in by commenting /test-jetbrains.
     if: |
-      github.event_name == 'pull_request_target' ||
+      (github.event_name == 'pull_request_target' &&
+       contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.pull_request.author_association)) ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
        contains(github.event.comment.body, '/test-jetbrains') &&

--- a/.github/workflows/ext-jb-test-integration.yml
+++ b/.github/workflows/ext-jb-test-integration.yml
@@ -29,7 +29,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: 1998650
+          app-id: ${{ vars.CLINE_JETBRAINS_WORKFLOW_ID }}
           private-key: ${{ secrets.CLINE_JETBRAINS_WORKFLOW_KEY }}
           owner: cline
           repositories: intellij-plugin

--- a/.github/workflows/ext-jb-test-integration.yml
+++ b/.github/workflows/ext-jb-test-integration.yml
@@ -29,7 +29,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ vars.CLINE_JETBRAINS_WORKFLOW_ID }}
+          app-id: ${{ vars.CLINE_JETBRAINS_APP_ID }}
           private-key: ${{ secrets.CLINE_JETBRAINS_WORKFLOW_KEY }}
           owner: cline
           repositories: intellij-plugin

--- a/.github/workflows/ext-jb-test-integration.yml
+++ b/.github/workflows/ext-jb-test-integration.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ vars.CLINE_JETBRAINS_APP_ID }}
-          private-key: ${{ secrets.CLINE_JETBRAINS_WORKFLOW_KEY }}
+          private-key: ${{ secrets.CLINE_JETBRAINS_APP_KEY }}
           owner: cline
           repositories: intellij-plugin
 


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

Two small hardening tweaks to the JetBrains integration trigger workflow.

### Changes

1. **Apply the existing trust gate to the `pull_request_target` auto-trigger.**
   The `/test-jetbrains` comment path already requires the commenter to be a
   `MEMBER`, `OWNER`, or `COLLABORATOR`. This change extends the same check to
   PRs auto-triggered on open/reopen, so the trust model is consistent across
   both entry points. PRs from non-members no longer auto-run; a maintainer
   can opt them in with `/test-jetbrains` after reviewing.

2. **Replace the hardcoded App ID with the `CLINE_JETBRAINS_APP_ID`
   org variable.** Matches the convention already used in
   `cline/intellij-plugin` and lets us change the App ID without editing
   workflow code.

### Contributor impact

External-fork PRs no longer auto-trigger the JetBrains integration check.
If you're reviewing an external PR and want to run it, comment
`/test-jetbrains` on the PR.

### Validation

- YAML parses cleanly.
- The trust-allow-list expression is identical to the one already in use
  on the comment path (lines 28-30 of the same file pre-change).

Companion PR in `cline/intellij-plugin`: https://github.com/cline/intellij-plugin/pull/958

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
