### PR TITLE
feat: add Kimi K2.6 to Moonshot provider

### DIFF
--- a/apps/vscode/src/core/api/providers/__tests__/moonshot.test.ts
+++ b/apps/vscode/src/core/api/providers/__tests__/moonshot.test.ts
@@ -1,0 +1,53 @@
+import "should"
+import { moonshotModels } from "@shared/api"
+import type { ClineStorageMessage } from "@shared/messages/content"
+import sinon from "sinon"
+import { MoonshotHandler } from "../moonshot"
+
+interface MoonshotRequestPayload {
+	model: string
+	temperature: number
+	max_tokens: number
+}
+
+describe("MoonshotHandler", () => {
+	afterEach(() => {
+		sinon.restore()
+	})
+
+	const createAsyncIterable = (data: unknown[] = []): AsyncIterable<unknown> => ({
+		[Symbol.asyncIterator]: async function* () {
+			yield* data
+		},
+	})
+
+	it("supports kimi-k2.6 model metadata", async () => {
+		const handler = new MoonshotHandler({
+			moonshotApiKey: "test-api-key",
+			apiModelId: "kimi-k2.6",
+		})
+
+		const model = handler.getModel()
+		model.id.should.equal("kimi-k2.6")
+		model.info.should.deepEqual(moonshotModels["kimi-k2.6"])
+
+		const createStub = sinon.stub().resolves(createAsyncIterable([]))
+		sinon.stub(handler as unknown as { ensureClient: () => unknown }, "ensureClient").returns({
+			chat: {
+				completions: {
+					create: createStub,
+				},
+			},
+		})
+
+		const messages: ClineStorageMessage[] = [{ role: "user", content: "hi" }]
+		for await (const _chunk of handler.createMessage("system", messages)) {
+			// Consume stream to trigger request execution.
+		}
+
+		const payload = createStub.firstCall.args[0] as MoonshotRequestPayload
+		payload.model.should.equal("kimi-k2.6")
+		payload.temperature.should.equal(moonshotModels["kimi-k2.6"].temperature)
+		payload.max_tokens.should.equal(moonshotModels["kimi-k2.6"].maxTokens)
+	})
+})

--- a/apps/vscode/src/shared/api.ts
+++ b/apps/vscode/src/shared/api.ts
@@ -4510,6 +4510,16 @@ export const sapAiCoreModels = {
 // Moonshot AI Studio
 // https://platform.moonshot.ai/docs/pricing/chat
 export const moonshotModels = {
+	"kimi-k2.6": {
+		maxTokens: 32_000,
+		contextWindow: 262_144,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 0.95,
+		outputPrice: 4.0,
+		cacheReadsPrice: 0.16,
+		temperature: 1.0,
+	},
 	"kimi-k2.5": {
 		maxTokens: 32_000,
 		contextWindow: 262_144,


### PR DESCRIPTION
### Related Issue

**Issue:** #10544

### Description

Adds `kimi-k2.6` to the native Moonshot provider model catalog. The existing `MoonshotHandler` already reads `moonshotModels` and sends the configured model temperature, so this registers Kimi K2.6 with `temperature: 1.0` without touching the OpenAI Compatible provider.

Changes:
- Add `kimi-k2.6` metadata to `moonshotModels`
- Add a Moonshot provider unit test covering model selection and outgoing payload parameters

### Test Procedure

- `cd apps/vscode && npm run protos`
- `cd apps/vscode && npx tsc --noEmit --project tsconfig.unit-test.json --pretty false`
- `cd apps/vscode && npm run format:fix`
- `cd apps/vscode && TS_NODE_PROJECT=./tsconfig.unit-test.json TS_NODE_TRANSPILE_ONLY=true TS_NODE_EXPERIMENTAL_RESOLVER=true node --loader ts-node/esm --experimental-specifier-resolution=node node_modules/mocha/bin/mocha src/core/api/providers/__tests__/moonshot.test.ts`

The final Mocha invocation uses the local ESM loader setup needed in this worktree and passed the configured unit-test suite: 1452 passing. I did not run VS Code integration tests or the full lint script locally.

Live Moonshot smoke tests with a maintainer-provided key, without logging or committing the key:
- Raw Moonshot API call to `https://api.moonshot.ai/v1/chat/completions` with `model: kimi-k2.6`, `temperature: 1`, `max_tokens: 200` returned HTTP 200, `finish_reason: stop`, visible content `4`, and usage `prompt_tokens: 32`, `completion_tokens: 48`.
- Cline `MoonshotHandler` smoke test selected `kimi-k2.6`, used configured temperature `1`, returned visible content `8`, emitted reasoning chunks, and reported usage `inputTokens: 32`, `outputTokens: 47`.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - provider metadata and unit-test only.

### Additional Notes

This PR intentionally does not modify `apps/vscode/src/core/api/providers/openai.ts` or OpenAI Compatible behavior. No API key is committed; users provide their Moonshot key through the existing Moonshot provider settings.
