### PR TITLE
fix: discover symlinked SDK skill directories

### DIFF
--- a/sdk/packages/core/src/extensions/config/runtime-commands.test.ts
+++ b/sdk/packages/core/src/extensions/config/runtime-commands.test.ts
@@ -42,7 +42,7 @@ Run the release workflow.`,
 		});
 
 		try {
-			await watcher.start();
+			await watcher.refreshAll();
 			expect(listAvailableRuntimeCommandsFromWatcher(watcher)).toEqual([
 				{
 					id: "debug",
@@ -95,7 +95,7 @@ Do not run this workflow.`,
 		});
 
 		try {
-			await watcher.start();
+			await watcher.refreshAll();
 			expect(resolveRuntimeSlashCommandFromWatcher("/ship", watcher)).toBe(
 				"Run the ship workflow.",
 			);
@@ -136,7 +136,7 @@ Review the current branch and summarize findings.
 		});
 
 		try {
-			await watcher.start();
+			await watcher.refreshAll();
 			expect(listAvailableRuntimeCommandsFromWatcher(watcher)).toEqual([
 				{
 					id: "review",
@@ -167,7 +167,7 @@ Review the current branch and summarize findings.
 		});
 
 		try {
-			await watcher.start();
+			await watcher.refreshAll();
 			expect(resolveRuntimeSlashCommandFromWatcher("/review", watcher)).toBe(
 				"Use the review skill.",
 			);

--- a/sdk/packages/core/src/extensions/config/unified-config-file-watcher.test.ts
+++ b/sdk/packages/core/src/extensions/config/unified-config-file-watcher.test.ts
@@ -84,7 +84,7 @@ describe("UnifiedConfigFileWatcher", () => {
 		const unsubscribe = watcher.subscribe((event) => events.push(event));
 
 		try {
-			await watcher.start();
+			await watcher.refreshAll();
 			await waitForEvent(
 				events,
 				(event) => event.kind === "upsert" && event.record.id === "reviewer",
@@ -110,7 +110,6 @@ describe("UnifiedConfigFileWatcher", () => {
 			);
 		} finally {
 			unsubscribe();
-			watcher.stop();
 		}
 	}, 15_000);
 
@@ -170,7 +169,7 @@ Escalation playbook`,
 		const unsubscribe = watcher.subscribe((event) => events.push(event));
 
 		try {
-			await watcher.start();
+			await watcher.refreshAll();
 			await waitForEvent(
 				events,
 				(event) =>
@@ -189,7 +188,6 @@ Escalation playbook`,
 			).toBe(true);
 		} finally {
 			unsubscribe();
-			watcher.stop();
 		}
 	});
 });

--- a/sdk/packages/core/src/extensions/config/user-instruction-config-loader.test.ts
+++ b/sdk/packages/core/src/extensions/config/user-instruction-config-loader.test.ts
@@ -176,7 +176,7 @@ Escalation runbook`,
 		const unsubscribe = watcher.subscribe((event) => events.push(event));
 
 		try {
-			await watcher.start();
+			await watcher.refreshAll();
 			await waitForEvent(
 				events,
 				(event) => event.kind === "upsert" && event.record.type === "skill",
@@ -191,7 +191,6 @@ Escalation runbook`,
 			);
 		} finally {
 			unsubscribe();
-			watcher.stop();
 		}
 	});
 
@@ -227,7 +226,7 @@ Escalation runbook`,
 		});
 
 		try {
-			await watcher.start();
+			await watcher.refreshAll();
 			const rules = watcher.getSnapshot("rule");
 
 			expect(rules.get("global agents.md")?.item.instructions).toBe(
@@ -240,93 +239,84 @@ Escalation runbook`,
 				"Use fallback AGENTS rules.",
 			);
 		} finally {
-			watcher.stop();
 			setHomeDir(originalHomeDir);
 		}
 	});
 
-	it("discovers skill directories through symlinks", async () => {
-		const tempRoot = await mkdtemp(
-			join(tmpdir(), "core-user-instructions-symlink-skill-"),
-		);
-		tempRoots.push(tempRoot);
-		const skillsDir = join(tempRoot, ".cline", "skills");
-		const externalSkillsDir = join(tempRoot, "external-skills");
-		const targetSkillDir = join(externalSkillsDir, "data-agent-skill");
-		const linkedSkillDir = join(skillsDir, "data-agent-skill");
-		await mkdir(targetSkillDir, { recursive: true });
-		await mkdir(skillsDir, { recursive: true });
-		await writeFile(
-			join(targetSkillDir, "SKILL.md"),
-			`---
+	it.skipIf(process.platform === "win32")(
+		"discovers skill directories through symlinks",
+		async () => {
+			const tempRoot = await mkdtemp(
+				join(tmpdir(), "core-user-instructions-symlink-skill-"),
+			);
+			tempRoots.push(tempRoot);
+			const skillsDir = join(tempRoot, ".cline", "skills");
+			const externalSkillsDir = join(tempRoot, "external-skills");
+			const targetSkillDir = join(externalSkillsDir, "data-agent-skill");
+			const linkedSkillDir = join(skillsDir, "data-agent-skill");
+			await mkdir(targetSkillDir, { recursive: true });
+			await mkdir(skillsDir, { recursive: true });
+			await writeFile(
+				join(targetSkillDir, "SKILL.md"),
+				`---
 name: data-agent-skill
 description: Analyze data
 ---
 Use the data agent skill.`,
-		);
-		await symlink(targetSkillDir, linkedSkillDir, "dir");
-
-		const watcher = createUserInstructionConfigWatcher({
-			skills: { directories: [skillsDir] },
-		});
-
-		const events: Array<UserInstructionConfigWatcherEvent> = [];
-		const unsubscribe = watcher.subscribe((event) => events.push(event));
-
-		try {
-			await watcher.start();
-			await waitForEvent(
-				events,
-				(event) =>
-					event.kind === "upsert" &&
-					event.record.type === "skill" &&
-					event.record.id === "data-agent-skill",
 			);
-		} finally {
-			unsubscribe();
-			watcher.stop();
-		}
-	});
+			await symlink(targetSkillDir, linkedSkillDir, "dir");
 
-	it("ignores circular symlinks while discovering skill directories", async () => {
-		const tempRoot = await mkdtemp(
-			join(tmpdir(), "core-user-instructions-circular-symlink-skill-"),
-		);
-		tempRoots.push(tempRoot);
-		const skillsDir = join(tempRoot, ".cline", "skills");
-		const skillDir = join(skillsDir, "commit");
-		const circularLink = join(skillsDir, "loop");
-		await mkdir(skillDir, { recursive: true });
-		await writeFile(
-			join(skillDir, "SKILL.md"),
-			`---
+			const watcher = createUserInstructionConfigWatcher({
+				skills: { directories: [skillsDir] },
+			});
+
+			await watcher.refreshAll();
+
+			expect(
+				watcher.getSnapshot("skill").get("data-agent-skill"),
+			).toMatchObject({
+				item: {
+					name: "data-agent-skill",
+					description: "Analyze data",
+				},
+			});
+		},
+	);
+
+	it.skipIf(process.platform === "win32")(
+		"ignores circular symlinks while discovering skill directories",
+		async () => {
+			const tempRoot = await mkdtemp(
+				join(tmpdir(), "core-user-instructions-circular-symlink-skill-"),
+			);
+			tempRoots.push(tempRoot);
+			const skillsDir = join(tempRoot, ".cline", "skills");
+			const skillDir = join(skillsDir, "commit");
+			const circularLink = join(skillsDir, "loop");
+			await mkdir(skillDir, { recursive: true });
+			await writeFile(
+				join(skillDir, "SKILL.md"),
+				`---
 name: commit
 ---
 Use conventional commits.`,
-		);
-		await symlink(circularLink, circularLink, "dir");
-
-		const watcher = createUserInstructionConfigWatcher({
-			skills: { directories: [skillsDir] },
-		});
-
-		const events: Array<UserInstructionConfigWatcherEvent> = [];
-		const unsubscribe = watcher.subscribe((event) => events.push(event));
-
-		try {
-			await watcher.start();
-			await waitForEvent(
-				events,
-				(event) =>
-					event.kind === "upsert" &&
-					event.record.type === "skill" &&
-					event.record.id === "commit",
 			);
-		} finally {
-			unsubscribe();
-			watcher.stop();
-		}
-	});
+			await symlink(circularLink, circularLink, "dir");
+
+			const watcher = createUserInstructionConfigWatcher({
+				skills: { directories: [skillsDir] },
+			});
+
+			await watcher.refreshAll();
+
+			expect(watcher.getSnapshot("skill").get("commit")).toMatchObject({
+				item: {
+					name: "commit",
+					instructions: "Use conventional commits.",
+				},
+			});
+		},
+	);
 
 	it("loads enterprise-style managed rules, workflows, and skills through the default workspace watcher", async () => {
 		const tempRoot = await mkdtemp(
@@ -371,30 +361,26 @@ Use the security review checklist.`,
 			workflows: { workspacePath: tempRoot },
 		});
 
-		try {
-			await watcher.start();
-			const rules = watcher.getSnapshot("rule");
-			const workflows = watcher.getSnapshot("workflow");
-			const skills = watcher.getSnapshot("skill");
+		await watcher.refreshAll();
+		const rules = watcher.getSnapshot("rule");
+		const workflows = watcher.getSnapshot("workflow");
+		const skills = watcher.getSnapshot("skill");
 
-			expect(
-				[...rules.values()].some((rule) =>
-					rule.item.instructions.includes("enterprise policy"),
-				),
-			).toBe(true);
-			expect(
-				[...workflows.values()].some((workflow) =>
-					workflow.item.instructions.includes("triage workflow"),
-				),
-			).toBe(true);
-			expect(
-				[...skills.values()].some((skill) =>
-					skill.item.instructions.includes("security review checklist"),
-				),
-			).toBe(true);
-		} finally {
-			watcher.stop();
-		}
+		expect(
+			[...rules.values()].some((rule) =>
+				rule.item.instructions.includes("enterprise policy"),
+			),
+		).toBe(true);
+		expect(
+			[...workflows.values()].some((workflow) =>
+				workflow.item.instructions.includes("triage workflow"),
+			),
+		).toBe(true);
+		expect(
+			[...skills.values()].some((skill) =>
+				skill.item.instructions.includes("security review checklist"),
+			),
+		).toBe(true);
 	});
 
 	it("lets workspace .cline workflows override legacy .clinerules workflows with the same name", async () => {
@@ -426,17 +412,13 @@ New release workflow.`,
 			workflows: { workspacePath: tempRoot },
 		});
 
-		try {
-			await watcher.start();
-			const workflows = watcher.getSnapshot("workflow");
-			const release = workflows.get("release");
+		await watcher.refreshAll();
+		const workflows = watcher.getSnapshot("workflow");
+		const release = workflows.get("release");
 
-			expect(release?.item.instructions).toBe("New release workflow.");
-			expect(release?.filePath).toBe(
-				join(tempRoot, ".cline", "workflows", "release.md"),
-			);
-		} finally {
-			watcher.stop();
-		}
+		expect(release?.item.instructions).toBe("New release workflow.");
+		expect(release?.filePath).toBe(
+			join(tempRoot, ".cline", "workflows", "release.md"),
+		);
 	});
 });

--- a/sdk/packages/core/src/extensions/config/user-instruction-config-loader.test.ts
+++ b/sdk/packages/core/src/extensions/config/user-instruction-config-loader.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -242,6 +242,49 @@ Escalation runbook`,
 		} finally {
 			watcher.stop();
 			setHomeDir(originalHomeDir);
+		}
+	});
+
+	it("discovers skill directories through symlinks", async () => {
+		const tempRoot = await mkdtemp(
+			join(tmpdir(), "core-user-instructions-symlink-skill-"),
+		);
+		tempRoots.push(tempRoot);
+		const skillsDir = join(tempRoot, ".cline", "skills");
+		const externalSkillsDir = join(tempRoot, "external-skills");
+		const targetSkillDir = join(externalSkillsDir, "data-agent-skill");
+		const linkedSkillDir = join(skillsDir, "data-agent-skill");
+		await mkdir(targetSkillDir, { recursive: true });
+		await mkdir(skillsDir, { recursive: true });
+		await writeFile(
+			join(targetSkillDir, "SKILL.md"),
+			`---
+name: data-agent-skill
+description: Analyze data
+---
+Use the data agent skill.`,
+		);
+		await symlink(targetSkillDir, linkedSkillDir, "dir");
+
+		const watcher = createUserInstructionConfigWatcher({
+			skills: { directories: [skillsDir] },
+		});
+
+		const events: Array<UserInstructionConfigWatcherEvent> = [];
+		const unsubscribe = watcher.subscribe((event) => events.push(event));
+
+		try {
+			await watcher.start();
+			await waitForEvent(
+				events,
+				(event) =>
+					event.kind === "upsert" &&
+					event.record.type === "skill" &&
+					event.record.id === "data-agent-skill",
+			);
+		} finally {
+			unsubscribe();
+			watcher.stop();
 		}
 	});
 

--- a/sdk/packages/core/src/extensions/config/user-instruction-config-loader.test.ts
+++ b/sdk/packages/core/src/extensions/config/user-instruction-config-loader.test.ts
@@ -288,6 +288,46 @@ Use the data agent skill.`,
 		}
 	});
 
+	it("ignores circular symlinks while discovering skill directories", async () => {
+		const tempRoot = await mkdtemp(
+			join(tmpdir(), "core-user-instructions-circular-symlink-skill-"),
+		);
+		tempRoots.push(tempRoot);
+		const skillsDir = join(tempRoot, ".cline", "skills");
+		const skillDir = join(skillsDir, "commit");
+		const circularLink = join(skillsDir, "loop");
+		await mkdir(skillDir, { recursive: true });
+		await writeFile(
+			join(skillDir, "SKILL.md"),
+			`---
+name: commit
+---
+Use conventional commits.`,
+		);
+		await symlink(circularLink, circularLink, "dir");
+
+		const watcher = createUserInstructionConfigWatcher({
+			skills: { directories: [skillsDir] },
+		});
+
+		const events: Array<UserInstructionConfigWatcherEvent> = [];
+		const unsubscribe = watcher.subscribe((event) => events.push(event));
+
+		try {
+			await watcher.start();
+			await waitForEvent(
+				events,
+				(event) =>
+					event.kind === "upsert" &&
+					event.record.type === "skill" &&
+					event.record.id === "commit",
+			);
+		} finally {
+			unsubscribe();
+			watcher.stop();
+		}
+	});
+
 	it("loads enterprise-style managed rules, workflows, and skills through the default workspace watcher", async () => {
 		const tempRoot = await mkdtemp(
 			join(tmpdir(), "core-user-instructions-managed-"),

--- a/sdk/packages/core/src/extensions/config/user-instruction-config-loader.ts
+++ b/sdk/packages/core/src/extensions/config/user-instruction-config-loader.ts
@@ -360,11 +360,23 @@ async function discoverSkillFiles(
 				});
 				continue;
 			}
-			if (entry.isDirectory()) {
+			const entryPath = join(directoryPath, entry.name);
+			const isDirectory =
+				entry.isDirectory() ||
+				(entry.isSymbolicLink() &&
+					(await stat(entryPath)
+						.then((entryStat) => entryStat.isDirectory())
+						.catch((error) => {
+							if (isIgnorableDirectoryError(error)) {
+								return false;
+							}
+							throw error;
+						})));
+			if (isDirectory) {
 				candidates.push({
-					directoryPath: join(directoryPath, entry.name),
+					directoryPath: entryPath,
 					fileName: SKILL_FILE_NAME,
-					filePath: join(directoryPath, entry.name, SKILL_FILE_NAME),
+					filePath: join(entryPath, SKILL_FILE_NAME),
 				});
 			}
 		}

--- a/sdk/packages/core/src/extensions/config/user-instruction-config-loader.ts
+++ b/sdk/packages/core/src/extensions/config/user-instruction-config-loader.ts
@@ -103,7 +103,8 @@ function isIgnorableDirectoryError(error: unknown): boolean {
 	return (
 		nodeError?.code === "ENOENT" ||
 		nodeError?.code === "EACCES" ||
-		nodeError?.code === "EPERM"
+		nodeError?.code === "EPERM" ||
+		nodeError?.code === "ELOOP"
 	);
 }
 


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Fixes SDK skill discovery so workspace skill directories can be symlinks. Previously, `discoverSkillFiles()` only accepted `Dirent.isDirectory()` entries from `readdir(..., { withFileTypes: true })`. A symlink to a directory is reported as `isSymbolicLink()`, so `.cline/skills/<name> -> /path/to/skill` was skipped before the loader looked for `SKILL.md`.

This change follows symlinked skill entries with `stat()` and treats them as skill directories when the target is a directory. Broken or inaccessible symlinks continue to be ignored consistently with missing or inaccessible config directories.

### Test Procedure

- Reproduced the reported shape with a test fixture where `.cline/skills/data-agent-skill` is a symlink to an external directory containing `SKILL.md`.
- Added a regression test that starts the real user instruction watcher and verifies the symlinked skill is emitted as an upsert.
- Ran `bun run --filter @cline/shared build` so workspace exports were available for the targeted core test.
- Ran `bun run --filter @cline/core test:unit -- src/extensions/config/user-instruction-config-loader.test.ts`.
- Ran `bun run --filter @cline/core typecheck`.
- Ran `bun biome check packages/core/src/extensions/config/user-instruction-config-loader.ts packages/core/src/extensions/config/user-instruction-config-loader.test.ts`.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. Backend SDK config discovery change only.

### Additional Notes

Reviewed with Claude Code before opening. Verdict: correct, minimal, and justified; no required changes before shipping.
