### PR TITLE
fix(sdk): pin SAP AI provider for smoke install

### DIFF
--- a/sdk/bun.lock
+++ b/sdk/bun.lock
@@ -350,7 +350,7 @@
         "@ai-sdk/provider": "^3.0.8",
         "@aws-sdk/credential-providers": "^3.922.0",
         "@cline/shared": "workspace:*",
-        "@jerome-benoit/sap-ai-provider": "^4.6.0",
+        "@jerome-benoit/sap-ai-provider": "4.6.9",
         "@langfuse/otel": "^4.0.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/sdk-trace-node": "^2.6.1",

--- a/sdk/packages/llms/package.json
+++ b/sdk/packages/llms/package.json
@@ -54,7 +54,7 @@
 		"@ai-sdk/provider": "^3.0.8",
 		"@aws-sdk/credential-providers": "^3.922.0",
 		"@cline/shared": "workspace:*",
-		"@jerome-benoit/sap-ai-provider": "^4.6.0",
+		"@jerome-benoit/sap-ai-provider": "4.6.9",
 		"@langfuse/otel": "^4.0.0",
 		"@opentelemetry/api": "^1.9.0",
 		"@opentelemetry/sdk-trace-node": "^2.6.1",


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Pins `@jerome-benoit/sap-ai-provider` to `4.6.9` in the SDK LLM package.

The SDK Node smoke test installs packed SDK tarballs into a temporary npm project. Because `@cline/llms` depended on `@jerome-benoit/sap-ai-provider` with `^4.6.0`, that smoke install floated to `4.7.0`, which added a `postinstall` script that invokes `patch-package`. The smoke project does not install `patch-package`, so CI fails during `npm install` before the SQLite smoke test can run.

This keeps the package on the already-locked `4.6.9` release so npm smoke installs match the working SDK lockfile behavior.

### Test Procedure

Ran the SDK build and smoke path locally:

```bash
cd sdk
bun install
bun run build:sdk
bun scripts/ci-node-smoke.ts
```

The smoke install completed and the script printed `SQLite smoke test passed`.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

This addresses the Linux SDK smoke failure. The Windows Vitest/libuv file watcher failure appears to be a separate issue and is intentionally not mixed into this dependency pin.
