### PR TITLE
fix(core): discover skills materialized as directory symlinks

### DIFF
--- a/sdk/packages/core/src/extensions/config/user-instruction-config-loader.test.ts
+++ b/sdk/packages/core/src/extensions/config/user-instruction-config-loader.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -250,6 +250,48 @@ Use the security review checklist.`,
 					skill.item.instructions.includes("security review checklist"),
 				),
 			).toBe(true);
+		} finally {
+			watcher.stop();
+		}
+	});
+
+	it("discovers a skill materialized as a directory symlink", async () => {
+		const tempRoot = await mkdtemp(
+			join(tmpdir(), "core-user-instructions-skill-symlink-"),
+		);
+		tempRoots.push(tempRoot);
+
+		// Real skill source, outside the directory the discovery scans.
+		const sourceSkillDir = join(tempRoot, "source", "my-skill");
+		await mkdir(sourceSkillDir, { recursive: true });
+		await writeFile(
+			join(sourceSkillDir, "SKILL.md"),
+			`---
+name: my-skill
+description: Skill materialized via a directory symlink
+---
+Instructions for my-skill.`,
+		);
+
+		// The directory the discovery scans contains only a directory symlink
+		// pointing at the real source. Since Dirent.isDirectory() is false for a
+		// symlink, the entry is only discovered because the loader resolves it
+		// with stat().
+		const skillsDir = join(tempRoot, "skills");
+		await mkdir(skillsDir, { recursive: true });
+		await symlink(sourceSkillDir, join(skillsDir, "my-skill"));
+
+		const watcher = createUserInstructionConfigWatcher({
+			skills: { directories: [skillsDir] },
+		});
+
+		try {
+			await watcher.start();
+			const skills = watcher.getSnapshot("skill");
+			const skill = skills.get("my-skill");
+
+			expect(skill?.item.instructions).toBe("Instructions for my-skill.");
+			expect(skill?.filePath).toBe(join(skillsDir, "my-skill", "SKILL.md"));
 		} finally {
 			watcher.stop();
 		}

--- a/sdk/packages/core/src/extensions/config/user-instruction-config-loader.ts
+++ b/sdk/packages/core/src/extensions/config/user-instruction-config-loader.ts
@@ -326,7 +326,23 @@ async function discoverSkillFiles(
 		const entries = await readdir(directoryPath, { withFileTypes: true });
 		const candidates: UnifiedConfigFileCandidate[] = [];
 		for (const entry of entries) {
-			if (entry.isFile() && entry.name === SKILL_FILE_NAME) {
+			let isFile = entry.isFile();
+			let isDirectory = entry.isDirectory();
+			// readdir({ withFileTypes }) does not follow symlinks, so
+			// Dirent.isDirectory()/isFile() are false for a symlink. Resolve the
+			// link target with stat() so skills materialized as a directory
+			// symlink (or a symlinked SKILL.md) are still discovered. A broken
+			// symlink throws in stat(), in which case we skip the entry.
+			if (entry.isSymbolicLink()) {
+				try {
+					const target = await stat(join(directoryPath, entry.name));
+					isFile = target.isFile();
+					isDirectory = target.isDirectory();
+				} catch {
+					continue;
+				}
+			}
+			if (isFile && entry.name === SKILL_FILE_NAME) {
 				candidates.push({
 					directoryPath,
 					fileName: entry.name,
@@ -334,7 +350,7 @@ async function discoverSkillFiles(
 				});
 				continue;
 			}
-			if (entry.isDirectory()) {
+			if (isDirectory) {
 				candidates.push({
 					directoryPath: join(directoryPath, entry.name),
 					fileName: SKILL_FILE_NAME,


### PR DESCRIPTION
## Problem

`discoverSkillFiles` (in `sdk/packages/core/src/extensions/config/user-instruction-config-loader.ts`) scans the skills directory with `readdir(dir, { withFileTypes: true })` and keeps entries based on `Dirent.isDirectory()` / `Dirent.isFile()`.

`withFileTypes` does **not** follow symlinks, so for a symlink those predicates are `false`. As a result, a skill materialized as a **directory symlink** (or a symlinked `SKILL.md`) is silently skipped — it never shows up in `/skills`.

This is easy to hit when a skill is centrally managed and exposed via a symlink. For example, a tool that keeps a single source of truth and links `~/.cline/skills/<skill>` to it: every runtime that follows symlinked skill dirs picks it up, but Cline silently doesn't.

## Fix

When an entry is a symlink, resolve its target with `stat()` and use the resolved file/directory flags for the existing checks. A broken symlink throws in `stat()`, in which case the entry is skipped. The shape of the discovered candidates is unchanged.

```ts
let isFile = entry.isFile();
let isDirectory = entry.isDirectory();
if (entry.isSymbolicLink()) {
    try {
        const target = await stat(join(directoryPath, entry.name));
        isFile = target.isFile();
        isDirectory = target.isDirectory();
    } catch {
        continue;
    }
}
```

## Test

Adds `discovers a skill materialized as a directory symlink` to `user-instruction-config-loader.test.ts`: it creates a real skill source outside the scanned directory, symlinks it into the skills directory, and asserts via the public `createUserInstructionConfigWatcher` API that the skill is discovered (correct `instructions` and `filePath`).

## Validation

- `vitest run` for the loader: 7/7 passing (incl. the new test).
- `biome check` clean on both files.
- `tsc -p tsconfig.dev.json --noEmit` clean.