### PR TITLE
fix(cli): clear connector sessions on hub shutdown

### DIFF
--- a/sdk/apps/cli/src/connectors/adapters/discord.ts
+++ b/sdk/apps/cli/src/connectors/adapters/discord.ts
@@ -975,11 +975,14 @@ class DiscordConnector extends ConnectorBase<
 
 		const statePath = this.resolveConnectorStatePath(options.applicationId);
 		const bindingsPath = this.resolveBindingsPath(options.applicationId);
-		this.removeStaleState(
+		const staleState = this.removeStaleState(
 			statePath,
 			(path) => this.readConnectorState(path),
 			(state) => state.pid,
 		);
+		if (staleState) {
+			clearBindingSessionIds<DiscordThreadState>(bindingsPath);
+		}
 		if (
 			await this.maybeRunInBackground({
 				rawArgs,
@@ -1483,6 +1486,7 @@ class DiscordConnector extends ConnectorBase<
 		}
 
 		await stopPromise;
+		clearBindingSessionIds<DiscordThreadState>(bindingsPath);
 		gatewayAbortController.abort();
 		stopTaskUpdateStream();
 		stopEventStream();

--- a/sdk/apps/cli/src/connectors/adapters/gchat.ts
+++ b/sdk/apps/cli/src/connectors/adapters/gchat.ts
@@ -416,11 +416,14 @@ class GoogleChatConnector extends ConnectorBase<
 	): Promise<number> {
 		const statePath = this.resolveConnectorStatePath(options.userName);
 		const bindingsPath = this.resolveBindingsPath(options.userName);
-		this.removeStaleState(
+		const staleState = this.removeStaleState(
 			statePath,
 			(path) => this.readConnectorState(path),
 			(state) => state.pid,
 		);
+		if (staleState) {
+			clearBindingSessionIds<GoogleChatThreadState>(bindingsPath);
+		}
 		if (
 			await this.maybeRunInBackground({
 				rawArgs,
@@ -816,6 +819,7 @@ class GoogleChatConnector extends ConnectorBase<
 		io.writeln(`[gchat] configure Google Chat App URL: ${endpointUrl}`);
 
 		await stopPromise;
+		clearBindingSessionIds<GoogleChatThreadState>(bindingsPath);
 		stopTaskUpdateStream();
 		stopEventStream();
 		await server.close();

--- a/sdk/apps/cli/src/connectors/adapters/linear.ts
+++ b/sdk/apps/cli/src/connectors/adapters/linear.ts
@@ -484,11 +484,14 @@ class LinearConnector extends ConnectorBase<
 	): Promise<number> {
 		const statePath = this.resolveConnectorStatePath(options.userName);
 		const bindingsPath = this.resolveBindingsPath(options.userName);
-		this.removeStaleState(
+		const staleState = this.removeStaleState(
 			statePath,
 			(path) => this.readConnectorState(path),
 			(state) => state.pid,
 		);
+		if (staleState) {
+			clearBindingSessionIds<LinearThreadState>(bindingsPath);
+		}
 		if (
 			await this.maybeRunInBackground({
 				rawArgs,
@@ -853,6 +856,7 @@ class LinearConnector extends ConnectorBase<
 		io.writeln(`[linear] configure Linear webhook URL: ${webhookUrl}`);
 
 		await stopPromise;
+		clearBindingSessionIds<LinearThreadState>(bindingsPath);
 		stopTaskUpdateStream();
 		stopEventStream();
 		await server.close();

--- a/sdk/apps/cli/src/connectors/adapters/slack.ts
+++ b/sdk/apps/cli/src/connectors/adapters/slack.ts
@@ -581,11 +581,14 @@ class SlackConnector extends ConnectorBase<
 		const statePath = this.resolveConnectorStatePath(options.userName);
 		const bindingsPath = this.resolveBindingsPath(options.userName);
 		const stateStorePath = this.resolveStateStorePath(options.userName);
-		this.removeStaleState(
+		const staleState = this.removeStaleState(
 			statePath,
 			(path) => this.readConnectorState(path),
 			(state) => state.pid,
 		);
+		if (staleState) {
+			clearBindingSessionIds<SlackThreadState>(bindingsPath);
+		}
 		if (
 			await this.maybeRunInBackground({
 				rawArgs,
@@ -1056,6 +1059,7 @@ class SlackConnector extends ConnectorBase<
 		);
 
 		await stopPromise;
+		clearBindingSessionIds<SlackThreadState>(bindingsPath);
 		stopTaskUpdateStream();
 		stopEventStream();
 		await server.close();

--- a/sdk/apps/cli/src/connectors/adapters/telegram.ts
+++ b/sdk/apps/cli/src/connectors/adapters/telegram.ts
@@ -609,11 +609,14 @@ class TelegramConnector extends ConnectorBase<
 			: [...rawArgs, "--bot-username", resolvedBotUsername];
 		const statePath = this.resolveConnectorStatePath(options.botUsername);
 		const bindingsPath = this.resolveBindingsPath(options.botUsername);
-		this.removeStaleState(
+		const staleState = this.removeStaleState(
 			statePath,
 			(path) => this.readConnectorState(path),
 			(state) => state.pid,
 		);
+		if (staleState) {
+			clearBindingSessionIds<TelegramThreadState>(bindingsPath);
+		}
 		if (
 			await this.maybeRunInBackground({
 				rawArgs: backgroundArgs,
@@ -1058,6 +1061,7 @@ class TelegramConnector extends ConnectorBase<
 		process.on("SIGTERM", shutdown);
 
 		await stopPromise;
+		clearBindingSessionIds<TelegramThreadState>(bindingsPath);
 
 		stopTaskUpdateStream();
 		stopEventStream();

--- a/sdk/apps/cli/src/connectors/adapters/whatsapp.ts
+++ b/sdk/apps/cli/src/connectors/adapters/whatsapp.ts
@@ -455,11 +455,14 @@ class WhatsAppConnector extends ConnectorBase<
 		});
 		const statePath = this.resolveConnectorStatePath(instanceKey);
 		const bindingsPath = this.resolveBindingsPath(instanceKey);
-		this.removeStaleState(
+		const staleState = this.removeStaleState(
 			statePath,
 			(path) => this.readConnectorState(path),
 			(state) => state.pid,
 		);
+		if (staleState) {
+			clearBindingSessionIds<WhatsAppThreadState>(bindingsPath);
+		}
 		if (
 			await this.maybeRunInBackground({
 				rawArgs,
@@ -842,6 +845,7 @@ class WhatsAppConnector extends ConnectorBase<
 		io.writeln(`[whatsapp] configure WhatsApp webhook URL: ${endpointUrl}`);
 
 		await stopPromise;
+		clearBindingSessionIds<WhatsAppThreadState>(bindingsPath);
 		stopTaskUpdateStream();
 		stopEventStream();
 		await server.close();

--- a/sdk/apps/cli/src/connectors/base.ts
+++ b/sdk/apps/cli/src/connectors/base.ts
@@ -124,11 +124,13 @@ export abstract class ConnectorBase<Options, State>
 		statePath: string,
 		readState: (path: string) => State | undefined,
 		getPid: (state: State) => number,
-	): void {
+	): State | undefined {
 		const state = readState(statePath);
 		if (state && !isProcessRunning(getPid(state))) {
 			this.removeStateFile(statePath);
+			return state;
 		}
+		return undefined;
 	}
 
 	protected async maybeRunInBackground(input: {

--- a/sdk/apps/cli/src/connectors/thread-bindings.test.ts
+++ b/sdk/apps/cli/src/connectors/thread-bindings.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import type { Thread } from "chat";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+	clearBindingSessionIds,
 	type ConnectorThreadState,
 	readBindingForThread,
 	readBindings,
@@ -118,5 +119,45 @@ describe("thread binding refresh", () => {
 		expect(
 			readBindings<TestState>(path)[participantKey]?.serializedThread,
 		).toContain("new_thread_id");
+	});
+});
+
+describe("clearBindingSessionIds", () => {
+	it("clears session ids from bindings and serialized thread state", () => {
+		const path = createBindingsPath();
+		writeBindings<TestState>(path, {
+			thread_1: {
+				channelId: "discord:C123",
+				isDM: false,
+				serializedThread: JSON.stringify({
+					id: "thread_1",
+					channelId: "discord:C123",
+					isDM: false,
+					sessionId: "legacy-root-session",
+					state: {
+						sessionId: "sess-1",
+						cwd: "/tmp/work",
+						teamId: "T123",
+					},
+				}),
+				sessionId: "sess-1",
+				state: { sessionId: "sess-1", cwd: "/tmp/work", teamId: "T123" },
+				updatedAt: "2026-03-17T00:00:00.000Z",
+			},
+		});
+
+		clearBindingSessionIds<TestState>(path);
+
+		const binding = readBindings<TestState>(path).thread_1;
+		expect(binding?.sessionId).toBeUndefined();
+		expect(binding?.state?.sessionId).toBeUndefined();
+		expect(binding?.state?.cwd).toBe("/tmp/work");
+		const serializedThread = JSON.parse(binding?.serializedThread ?? "{}") as {
+			sessionId?: string;
+			state?: TestState;
+		};
+		expect(serializedThread.sessionId).toBeUndefined();
+		expect(serializedThread.state?.sessionId).toBeUndefined();
+		expect(serializedThread.state?.cwd).toBe("/tmp/work");
 	});
 });

--- a/sdk/apps/cli/src/connectors/thread-bindings.ts
+++ b/sdk/apps/cli/src/connectors/thread-bindings.ts
@@ -64,6 +64,39 @@ function readSerializedThreadIdentity(
 	}
 }
 
+function clearSerializedThreadSessionId(
+	serializedThread: string | undefined,
+): { serializedThread: string | undefined; updated: boolean } {
+	if (!serializedThread?.trim()) {
+		return { serializedThread, updated: false };
+	}
+	try {
+		const parsed = JSON.parse(serializedThread) as unknown;
+		if (!parsed || typeof parsed !== "object") {
+			return { serializedThread, updated: false };
+		}
+		const record = parsed as Record<string, unknown>;
+		let updated = false;
+		if ("sessionId" in record) {
+			delete record.sessionId;
+			updated = true;
+		}
+		if (record.state && typeof record.state === "object") {
+			const state = record.state as Record<string, unknown>;
+			if ("sessionId" in state) {
+				delete state.sessionId;
+				updated = true;
+			}
+		}
+		return {
+			serializedThread: updated ? JSON.stringify(parsed) : serializedThread,
+			updated,
+		};
+	} catch {
+		return { serializedThread, updated: false };
+	}
+}
+
 export function resolveThreadBindingKey(
 	thread: ConnectorBindingThreadIdentity,
 	state?: ConnectorThreadState | null,
@@ -334,10 +367,19 @@ export function clearBindingSessionIds<TState extends ConnectorThreadState>(
 	const bindings = readBindings<TState>(path);
 	let updated = false;
 	for (const binding of Object.values(bindings)) {
-		if (binding.sessionId || binding.state?.sessionId) {
-			binding.sessionId = undefined;
+		if ("sessionId" in binding) {
+			delete binding.sessionId;
+			updated = true;
+		}
+		if (binding.state && "sessionId" in binding.state) {
+			delete binding.state.sessionId;
+			updated = true;
+		}
+		const serialized = clearSerializedThreadSessionId(binding.serializedThread);
+		if (serialized.updated) {
+			binding.serializedThread = serialized.serializedThread ?? "";
 			if (binding.state) {
-				binding.state.sessionId = undefined;
+				delete binding.state.sessionId;
 			}
 			updated = true;
 		}


### PR DESCRIPTION
### Related Issue

**Issue:** #11061

### Description

This fixes stale connector session reuse after the local hub or connector process shuts down.

The binding cleanup now removes session IDs from both the top-level connector binding state and the serialized thread snapshot. The connector base also reports when stale process state was removed, so adapters can clear their persisted session IDs before starting again.

The shutdown cleanup is applied across the hub-backed connector adapters: Discord, Slack, Telegram, Linear, Google Chat, and WhatsApp.

### Test Procedure

- `cd sdk/apps/cli && bun vitest run --config vitest.config.ts src/connectors/**/*.test.ts`
  - 14 test files passed
  - 92 tests passed
- `cd sdk/apps/cli && bun run typecheck`
- `git diff --check`

I also ran `cd sdk && bun install` after switching onto latest `origin/main` because a newly added SAP provider dependency was not installed locally. That did not change tracked files.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. CLI connector lifecycle fix.

### Additional Notes

I ran targeted CLI connector validation and typecheck locally. I did not run the full repository `npm test`, `npm run format`, or `npm run lint` commands.
