### PR TITLE
fix(cli): stabilize core tests on Windows

### DIFF
--- a/sdk/packages/core/src/extensions/tools/executors/bash.test.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/bash.test.ts
@@ -8,6 +8,13 @@ const ctx: AgentToolContext = {
 	iteration: 1,
 };
 
+function shellQuote(value: string): string {
+	if (process.platform === "win32") {
+		return `'${value.replaceAll("'", "''")}'`;
+	}
+	return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
 describe("createBashExecutor", () => {
 	it("runs a simple command and returns stdout", async () => {
 		const bash = createBashExecutor();
@@ -22,7 +29,7 @@ describe("createBashExecutor", () => {
 
 	it("includes stderr in combined output on success", async () => {
 		const bash = createBashExecutor({ combineOutput: true });
-		const cmd = `${process.execPath} -e "process.stdout.write('ok'); process.stderr.write('warn')"`;
+		const cmd = `${shellQuote(process.execPath)} -e "process.stdout.write('ok'); process.stderr.write('warn')"`;
 		const output = await bash(cmd, process.cwd(), ctx);
 		expect(output).toContain("ok");
 		expect(output).toContain("[stderr]");
@@ -31,7 +38,7 @@ describe("createBashExecutor", () => {
 
 	it("excludes stderr when combineOutput is false", async () => {
 		const bash = createBashExecutor({ combineOutput: false });
-		const cmd = `${process.execPath} -e "process.stdout.write('ok'); process.stderr.write('warn')"`;
+		const cmd = `${shellQuote(process.execPath)} -e "process.stdout.write('ok'); process.stderr.write('warn')"`;
 		const output = await bash(cmd, process.cwd(), ctx);
 		expect(output.trim()).toBe("ok");
 	});
@@ -46,7 +53,7 @@ describe("createBashExecutor", () => {
 	it("truncates output exceeding maxOutputBytes", async () => {
 		const bash = createBashExecutor({ maxOutputBytes: 10 });
 		const output = await bash(
-			`${process.execPath} -e "process.stdout.write('a'.repeat(100))"`,
+			`${shellQuote(process.execPath)} -e "process.stdout.write('a'.repeat(100))"`,
 			process.cwd(),
 			ctx,
 		);

--- a/sdk/packages/core/src/hub/daemon/index.test.ts
+++ b/sdk/packages/core/src/hub/daemon/index.test.ts
@@ -87,6 +87,7 @@ describe("ensureDetachedHubServer", () => {
 	const fetchMock = vi.fn(async () => ({ ok: true }));
 
 	beforeEach(() => {
+		delete process.env[CLINE_RUN_AS_HUB_DAEMON_ENV];
 		vi.stubGlobal("fetch", fetchMock);
 	});
 

--- a/sdk/packages/core/src/hub/daemon/index.ts
+++ b/sdk/packages/core/src/hub/daemon/index.ts
@@ -59,13 +59,23 @@ function isCompatibleHubRecord(record: HubServerDiscoveryRecord): boolean {
 	return !!recordBuildId && recordBuildId === resolveHubBuildId();
 }
 
+async function safeProbeHubServer(
+	url: string,
+): Promise<HubServerDiscoveryRecord | undefined> {
+	try {
+		return await probeHubServer(url);
+	} catch {
+		return undefined;
+	}
+}
+
 async function waitForHubToRetire(
 	url: string,
 	timeoutMs: number,
 ): Promise<boolean> {
 	const deadline = Date.now() + timeoutMs;
 	while (Date.now() < deadline) {
-		const healthy = await probeHubServer(url).catch(() => undefined);
+		const healthy = await safeProbeHubServer(url);
 		if (!healthy?.url) {
 			return true;
 		}
@@ -207,7 +217,7 @@ export function prewarmDetachedHubServer(
 	void readHubDiscovery(owner.discoveryPath)
 		.then(async (discovered) => {
 			if (discovered?.url) {
-				const healthy = await probeHubServer(discovered.url);
+				const healthy = await safeProbeHubServer(discovered.url);
 				if (
 					healthy?.url &&
 					isCompatibleHubRecord(healthy) &&
@@ -226,7 +236,7 @@ export function prewarmDetachedHubServer(
 					await clearHubDiscovery(owner.discoveryPath).catch(() => undefined);
 				}
 			}
-			const expected = await probeHubServer(expectedUrl);
+			const expected = await safeProbeHubServer(expectedUrl);
 			if (expected?.url) {
 				await retireIncompatibleHub(expected, owner.discoveryPath);
 			}
@@ -276,7 +286,7 @@ export async function ensureDetachedHubServer(
 	};
 	const discovered = await readHubDiscovery(owner.discoveryPath);
 	if (discovered?.url) {
-		const healthy = await probeHubServer(discovered.url);
+		const healthy = await safeProbeHubServer(discovered.url);
 		if (
 			healthy?.url &&
 			isCompatibleHubRecord(healthy) &&
@@ -298,7 +308,7 @@ export async function ensureDetachedHubServer(
 			await clearHubDiscovery(owner.discoveryPath).catch(() => undefined);
 		}
 	}
-	const expected = await probeHubServer(expectedUrl);
+	const expected = await safeProbeHubServer(expectedUrl);
 	if (expected?.url) {
 		await retireIncompatibleHub(expected, owner.discoveryPath);
 	}
@@ -311,7 +321,7 @@ export async function ensureDetachedHubServer(
 	while (Date.now() < deadline) {
 		const nextDiscovery = await readHubDiscovery(owner.discoveryPath);
 		if (nextDiscovery?.url) {
-			const healthy = await probeHubServer(nextDiscovery.url);
+			const healthy = await safeProbeHubServer(nextDiscovery.url);
 			if (
 				healthy?.url &&
 				isCompatibleHubRecord(healthy) &&
@@ -325,7 +335,7 @@ export async function ensureDetachedHubServer(
 				});
 			}
 		}
-		const nextExpected = await probeHubServer(expectedUrl);
+		const nextExpected = await safeProbeHubServer(expectedUrl);
 		if (nextExpected?.url && !isCompatibleHubRecord(nextExpected)) {
 			await retireIncompatibleHub(nextExpected, owner.discoveryPath);
 		}

--- a/sdk/packages/core/src/services/workspace/file-indexer.ts
+++ b/sdk/packages/core/src/services/workspace/file-indexer.ts
@@ -59,14 +59,6 @@ function canUseFileIndexWorker(): boolean {
 		return false;
 	}
 
-	// Vitest already runs tests inside worker pools. Spawning a second worker from a
-	// transformed TypeScript module is especially fragile on Windows and can abort
-	// the Vitest worker process before an assertion failure is reported. The
-	// synchronous fallback is deterministic and fast enough for tests.
-	if (process.env.VITEST) {
-		return false;
-	}
-
 	return true;
 }
 

--- a/sdk/packages/core/src/services/workspace/file-indexer.ts
+++ b/sdk/packages/core/src/services/workspace/file-indexer.ts
@@ -54,6 +54,22 @@ interface IndexResponseMessage {
 
 const CACHE = new Map<string, CacheEntry>();
 
+function canUseFileIndexWorker(): boolean {
+	if (!isMainThread) {
+		return false;
+	}
+
+	// Vitest already runs tests inside worker pools. Spawning a second worker from a
+	// transformed TypeScript module is especially fragile on Windows and can abort
+	// the Vitest worker process before an assertion failure is reported. The
+	// synchronous fallback is deterministic and fast enough for tests.
+	if (process.env.VITEST) {
+		return false;
+	}
+
+	return true;
+}
+
 function pruneStaleCacheEntries(now: number): void {
 	if (CACHE.size <= 1) {
 		return;
@@ -276,7 +292,7 @@ startWorkerServer();
 let workerClient: FileIndexWorkerClient | null | undefined;
 
 function getWorkerClient(): FileIndexWorkerClient | null {
-	if (!isMainThread) {
+	if (!canUseFileIndexWorker()) {
 		return null;
 	}
 	if (workerClient === undefined) {


### PR DESCRIPTION


<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Avoid several Windows-specific failure modes in the core CLI test suite.

Vitest already runs test files inside worker pools. The workspace file indexer was lazily spawning a nested worker from a transformed TypeScript module via import.meta.url, which is fragile on Windows and can cause Vitest to report only a generic worker fork crash. Disable that worker path under VITEST and use the deterministic fallback indexer for tests.

Quote process.execPath in bash executor shell-string tests. Windows Node/Bun paths commonly contain spaces, so unquoted command strings can fail under PowerShell or cmd even though they work on Unix paths.

Make detached hub probing defensive by routing probeHubServer calls through a safe wrapper, so rejected or malformed probe results are treated as unreachable instead of destabilizing startup/prewarm flows.

Also clear CLINE_RUN_AS_HUB_DAEMON in daemon test setup so tests do not inherit daemon-mode state from the surrounding CLI environment except where explicitly set.

Validation: bunx vitest run --config vitest.config.ts src/hub/daemon/index.test.ts src/services/workspace/file-indexer.test.ts src/services/workspace/mention-enricher.test.ts src/extensions/tools/executors/bash.test.ts --reporter=dot

Validation: bun run typecheck

Validation: bun run test:unit

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
