### PR TITLE
test(sdk): fix Windows bash executor tests

### DIFF
--- a/sdk/packages/core/src/extensions/tools/executors/bash.test.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/bash.test.ts
@@ -15,6 +15,13 @@ function shellQuote(value: string): string {
 	return `'${value.replaceAll("'", `'\\''`)}'`;
 }
 
+function shellCommand(value: string): string {
+	if (process.platform === "win32") {
+		return `& ${shellQuote(value)}`;
+	}
+	return shellQuote(value);
+}
+
 describe("createBashExecutor", () => {
 	it("runs a simple command and returns stdout", async () => {
 		const bash = createBashExecutor();
@@ -29,7 +36,7 @@ describe("createBashExecutor", () => {
 
 	it("includes stderr in combined output on success", async () => {
 		const bash = createBashExecutor({ combineOutput: true });
-		const cmd = `${shellQuote(process.execPath)} -e "process.stdout.write('ok'); process.stderr.write('warn')"`;
+		const cmd = `${shellCommand(process.execPath)} -e "process.stdout.write('ok'); process.stderr.write('warn')"`;
 		const output = await bash(cmd, process.cwd(), ctx);
 		expect(output).toContain("ok");
 		expect(output).toContain("[stderr]");
@@ -38,7 +45,7 @@ describe("createBashExecutor", () => {
 
 	it("excludes stderr when combineOutput is false", async () => {
 		const bash = createBashExecutor({ combineOutput: false });
-		const cmd = `${shellQuote(process.execPath)} -e "process.stdout.write('ok'); process.stderr.write('warn')"`;
+		const cmd = `${shellCommand(process.execPath)} -e "process.stdout.write('ok'); process.stderr.write('warn')"`;
 		const output = await bash(cmd, process.cwd(), ctx);
 		expect(output.trim()).toBe("ok");
 	});
@@ -53,7 +60,7 @@ describe("createBashExecutor", () => {
 	it("truncates output exceeding maxOutputBytes", async () => {
 		const bash = createBashExecutor({ maxOutputBytes: 10 });
 		const output = await bash(
-			`${shellQuote(process.execPath)} -e "process.stdout.write('a'.repeat(100))"`,
+			`${shellCommand(process.execPath)} -e "process.stdout.write('a'.repeat(100))"`,
 			process.cwd(),
 			ctx,
 		);


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Fixes the Windows SDK CI failure in `@cline/core` bash executor tests.

PowerShell does not execute a quoted executable path followed by arguments unless it is invoked with the call operator. The failing CI command was parsed like an expression:

```text
'C:\hostedtoolcache\windows\node\24.16.0\x64\node.exe' -e "..."
```

This updates the test command helper to emit `& 'node.exe' ...` on Windows while preserving the existing shell quoting behavior on Unix.

The AGENTS watcher concern from https://github.com/cline/cline/pull/11103#issuecomment-4569309515 was already addressed on latest `main` when this branch was rebased, so this PR contains only the remaining Windows bash test fix.

### Test Procedure

- `bun run build:sdk`
- `bun -F @cline/core test:unit`
- `bun run lint`

`bun run lint` exits successfully. It still reports existing unrelated CLI lint warnings outside this PR's changed files.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

This targets the `sdk-test` Windows failure from GitHub Actions run https://github.com/cline/cline/actions/runs/26611405583.
