### PR TITLE
fix(sdk): serialize Codex OAuth refresh

### DIFF
--- a/sdk/bun.lock
+++ b/sdk/bun.lock
@@ -19,7 +19,7 @@
     },
     "apps/cli": {
       "name": "@cline/cli",
-      "version": "3.0.14",
+      "version": "3.0.15",
       "bin": {
         "cline": "src/index.ts",
       },
@@ -393,12 +393,14 @@
         "jiti": "^2.7.0",
         "nanoid": "^5.1.7",
         "node-machine-id": "^1.1.12",
+        "proper-lockfile": "^4.1.2",
         "simple-git": "3.36.0",
         "ws": "^8.20.0",
         "yaml": "^2.8.2",
         "zod": "^4.3.6",
       },
       "devDependencies": {
+        "@types/proper-lockfile": "^4.1.4",
         "@types/ws": "^8.18.1",
       },
     },
@@ -1560,6 +1562,8 @@
     "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
 
     "@types/prop-types": ["@types/prop-types@15.7.15", "", {}, "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="],
+
+    "@types/proper-lockfile": ["@types/proper-lockfile@4.1.4", "", { "dependencies": { "@types/retry": "*" } }, "sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ=="],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 

--- a/sdk/packages/core/package.json
+++ b/sdk/packages/core/package.json
@@ -62,12 +62,14 @@
 		"jiti": "^2.7.0",
 		"node-machine-id": "^1.1.12",
 		"nanoid": "^5.1.7",
+		"proper-lockfile": "^4.1.2",
 		"simple-git": "3.36.0",
 		"ws": "^8.20.0",
 		"yaml": "^2.8.2",
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {
+		"@types/proper-lockfile": "^4.1.4",
 		"@types/ws": "^8.18.1"
 	},
 	"engines": {

--- a/sdk/packages/core/src/auth/codex.test.ts
+++ b/sdk/packages/core/src/auth/codex.test.ts
@@ -55,22 +55,20 @@ describe("auth/codex token lifecycle", () => {
 		const accessToken = createJwt({
 			"https://api.openai.com/auth": { chatgpt_account_id: "acct-new" },
 		});
-		vi.stubGlobal(
-			"fetch",
-			vi.fn(
-				async () =>
-					new Response(
-						JSON.stringify({
-							access_token: accessToken,
-							refresh_token: "refresh-new",
-							expires_in: 3600,
-							email: "new@example.com",
-							id_token: idToken,
-						}),
-						{ status: 200, headers: { "Content-Type": "application/json" } },
-					),
-			),
+		const fetchMock = vi.fn(
+			async (_input: string | URL | Request, _init?: RequestInit) =>
+				new Response(
+					JSON.stringify({
+						access_token: accessToken,
+						refresh_token: "refresh-new",
+						expires_in: 3600,
+						email: "new@example.com",
+						id_token: idToken,
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				),
 		);
+		vi.stubGlobal("fetch", fetchMock);
 
 		const current = createCredentials({ expires: 110_000 });
 		const result = await getValidOpenAICodexCredentials(current);
@@ -81,11 +79,15 @@ describe("auth/codex token lifecycle", () => {
 			email: "new@example.com",
 			metadata: { provider: "openai-codex" },
 		});
+		expect(fetchMock.mock.calls[0]?.[1]?.headers).toMatchObject({
+			"User-Agent": expect.stringMatching(/^cline-sdk\//),
+		});
 		nowSpy.mockRestore();
 	});
 
 	it("returns null on invalid_grant refresh errors", async () => {
 		const nowSpy = vi.spyOn(Date, "now").mockReturnValue(100_000);
+		const onInvalidGrant = vi.fn();
 		vi.stubGlobal(
 			"fetch",
 			vi.fn(
@@ -105,8 +107,10 @@ describe("auth/codex token lifecycle", () => {
 
 		const result = await getValidOpenAICodexCredentials(
 			createCredentials({ expires: 120_000 }),
+			{ onInvalidGrant },
 		);
 		expect(result).toBeNull();
+		expect(onInvalidGrant).toHaveBeenCalledOnce();
 		nowSpy.mockRestore();
 	});
 

--- a/sdk/packages/core/src/auth/codex.ts
+++ b/sdk/packages/core/src/auth/codex.ts
@@ -7,6 +7,7 @@
 
 import type { ITelemetryService } from "@cline/shared";
 import { nanoid } from "nanoid";
+import corePackage from "../../package.json";
 import {
 	captureAuthFailed,
 	captureAuthLoggedOut,
@@ -42,6 +43,7 @@ export const OPENAI_CODEX_OAUTH_CONFIG = {
 	retryableTokenGraceMs: 30 * 1000,
 	httpTimeoutMs: 30 * 1000,
 } as const;
+const OPENAI_CODEX_USER_AGENT = `cline-sdk/${corePackage.version}`;
 
 type CodexTokenSuccess = {
 	type: "success";
@@ -55,6 +57,7 @@ type CodexTokenFailure = { type: "failed" };
 type CodexTokenResult = CodexTokenSuccess | CodexTokenFailure;
 export type RefreshTokenResolution = {
 	forceRefresh?: boolean;
+	onInvalidGrant?: () => void;
 	refreshBufferMs?: number;
 	retryableTokenGraceMs?: number;
 };
@@ -97,7 +100,10 @@ async function exchangeAuthorizationCode(
 ): Promise<CodexTokenResult> {
 	const response = await fetch(OPENAI_CODEX_OAUTH_CONFIG.tokenEndpoint, {
 		method: "POST",
-		headers: { "Content-Type": "application/x-www-form-urlencoded" },
+		headers: {
+			"Content-Type": "application/x-www-form-urlencoded",
+			"User-Agent": OPENAI_CODEX_USER_AGENT,
+		},
 		body: new URLSearchParams({
 			grant_type: "authorization_code",
 			client_id: OPENAI_CODEX_OAUTH_CONFIG.clientId,
@@ -144,7 +150,10 @@ async function refreshAccessToken(
 	try {
 		const response = await fetch(OPENAI_CODEX_OAUTH_CONFIG.tokenEndpoint, {
 			method: "POST",
-			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+			headers: {
+				"Content-Type": "application/x-www-form-urlencoded",
+				"User-Agent": OPENAI_CODEX_USER_AGENT,
+			},
 			body: new URLSearchParams({
 				grant_type: "refresh_token",
 				refresh_token: refreshToken,
@@ -433,6 +442,7 @@ export async function getValidOpenAICodexCredentials(
 			error instanceof OpenAICodexOAuthTokenError &&
 			error.isLikelyInvalidGrant()
 		) {
+			options?.onInvalidGrant?.();
 			captureAuthLoggedOut(options?.telemetry, "openai-codex", "invalid_grant");
 			return null;
 		}

--- a/sdk/packages/core/src/runtime/orchestration/fixtures/runtime-oauth-token-worker.ts
+++ b/sdk/packages/core/src/runtime/orchestration/fixtures/runtime-oauth-token-worker.ts
@@ -1,0 +1,18 @@
+import { ProviderSettingsManager } from "../../../services/storage/provider-settings-manager";
+import { RuntimeOAuthTokenManager } from "../runtime-oauth-token-manager";
+
+const [filePath, tokenEndpoint] = process.argv.slice(2);
+if (!filePath || !tokenEndpoint) {
+	throw new Error("Expected providers.json path and token endpoint");
+}
+
+const nativeFetch = globalThis.fetch;
+globalThis.fetch = (_input, init) => nativeFetch(tokenEndpoint, init);
+
+const manager = new RuntimeOAuthTokenManager({
+	providerSettingsManager: new ProviderSettingsManager({ filePath }),
+});
+const result = await manager.resolveProviderApiKey({
+	providerId: "openai-codex",
+});
+process.stdout.write(`${JSON.stringify(result)}\n`);

--- a/sdk/packages/core/src/runtime/orchestration/runtime-oauth-token-manager.integration.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-oauth-token-manager.integration.test.ts
@@ -469,6 +469,44 @@ describe("RuntimeOAuthTokenManager Codex refresh transaction", () => {
 		});
 	});
 
+	it("does not restore a provider removed while refreshed auth is being saved", async () => {
+		const filePath = createFilePath();
+		const storedManager = seedSettings(filePath);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => createTokenResponse()),
+		);
+		const providerSettingsManager = new ProviderSettingsManager({ filePath });
+		const write = providerSettingsManager.write.bind(providerSettingsManager);
+		let injectedRemoval = false;
+		vi.spyOn(providerSettingsManager, "write").mockImplementation(
+			(state, options) => {
+				const codexSettings = state.providers["openai-codex"]?.settings;
+				if (
+					!injectedRemoval &&
+					options?.allowOpenAICodexAuthReplacement &&
+					codexSettings?.auth?.accessToken === "access-new"
+				) {
+					injectedRemoval = true;
+					const storedState = storedManager.read();
+					delete storedState.providers["openai-codex"];
+					storedState.lastUsedProvider = undefined;
+					storedManager.write(storedState, {
+						allowOpenAICodexAuthReplacement: true,
+					});
+				}
+				return write(state, options);
+			},
+		);
+		const manager = new RuntimeOAuthTokenManager({ providerSettingsManager });
+
+		await expect(
+			manager.resolveProviderApiKey({ providerId: "openai-codex" }),
+		).rejects.toBeInstanceOf(OAuthReauthRequiredError);
+		expect(injectedRemoval).toBe(true);
+		expect(storedManager.getProviderSettings("openai-codex")).toBeUndefined();
+	});
+
 	it("preserves stored auth after a transient refresh failure", async () => {
 		const filePath = createFilePath();
 		const storedManager = seedSettings(filePath);

--- a/sdk/packages/core/src/runtime/orchestration/runtime-oauth-token-manager.integration.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-oauth-token-manager.integration.test.ts
@@ -1,0 +1,454 @@
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ProviderSettingsManager } from "../../services/storage/provider-settings-manager";
+import {
+	OAuthReauthRequiredError,
+	RuntimeOAuthTokenManager,
+} from "./runtime-oauth-token-manager";
+
+const workerPath = fileURLToPath(
+	new URL("./fixtures/runtime-oauth-token-worker.ts", import.meta.url),
+);
+const currentDir = dirname(fileURLToPath(import.meta.url));
+
+function createDeferred(): { promise: Promise<void>; resolve: () => void } {
+	let resolve!: () => void;
+	const promise = new Promise<void>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}
+
+function createTokenResponse(
+	accessToken = "access-new",
+	refreshToken = "refresh-new",
+): Response {
+	return new Response(
+		JSON.stringify({
+			access_token: accessToken,
+			refresh_token: refreshToken,
+			expires_in: 3600,
+		}),
+		{ status: 200, headers: { "Content-Type": "application/json" } },
+	);
+}
+
+function createInvalidGrantResponse(): Response {
+	return new Response(
+		JSON.stringify({
+			error: "invalid_grant",
+			error_description: "refresh token already used",
+		}),
+		{ status: 400, headers: { "Content-Type": "application/json" } },
+	);
+}
+
+function readSubmittedRefreshToken(init?: RequestInit): string | null {
+	return new URLSearchParams(init?.body?.toString()).get("refresh_token");
+}
+
+function createSettings(
+	accessToken = "access-old",
+	refreshToken = "refresh-old",
+	expiresAt = Date.now() - 1_000,
+) {
+	return {
+		provider: "openai-codex" as const,
+		auth: {
+			accessToken,
+			refreshToken,
+			expiresAt,
+			accountId: "acct-old",
+		},
+	};
+}
+
+function seedSettings(filePath: string): ProviderSettingsManager {
+	const manager = new ProviderSettingsManager({ filePath });
+	manager.saveProviderSettings(createSettings(), { tokenSource: "oauth" });
+	return manager;
+}
+
+function runWorker(
+	filePath: string,
+	tokenEndpoint: string,
+): Promise<{ apiKey: string } | null> {
+	return new Promise((resolve, reject) => {
+		const child = spawn("bun", [workerPath, filePath, tokenEndpoint], {
+			cwd: join(currentDir, "../../../../.."),
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		let stdout = "";
+		let stderr = "";
+		child.stdout.on("data", (chunk) => {
+			stdout += chunk.toString();
+		});
+		child.stderr.on("data", (chunk) => {
+			stderr += chunk.toString();
+		});
+		child.on("error", reject);
+		child.on("close", (code) => {
+			if (code !== 0) {
+				reject(new Error(`Worker exited ${code}: ${stderr}`));
+				return;
+			}
+			resolve(JSON.parse(stdout) as { apiKey: string } | null);
+		});
+	});
+}
+
+async function listen(server: Server): Promise<string> {
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => resolve());
+	});
+	const address = server.address();
+	if (!address || typeof address === "string") {
+		throw new Error("Expected TCP server address");
+	}
+	return `http://127.0.0.1:${address.port}/token`;
+}
+
+async function close(server: Server): Promise<void> {
+	await new Promise<void>((resolve, reject) => {
+		server.close((error) => (error ? reject(error) : resolve()));
+	});
+}
+
+describe("RuntimeOAuthTokenManager Codex refresh transaction", () => {
+	const tempDirs: string[] = [];
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+		for (const dir of tempDirs.splice(0)) {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	function createFilePath(): string {
+		const dir = mkdtempSync(join(tmpdir(), "cline-runtime-oauth-"));
+		tempDirs.push(dir);
+		return join(dir, "settings", "providers.json");
+	}
+
+	it("serializes two runtime managers sharing providers.json", async () => {
+		const filePath = createFilePath();
+		seedSettings(filePath);
+		const submissions: string[] = [];
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+				submissions.push(readSubmittedRefreshToken(init) ?? "");
+				return createTokenResponse();
+			}),
+		);
+		const first = new RuntimeOAuthTokenManager({
+			providerSettingsManager: new ProviderSettingsManager({ filePath }),
+		});
+		const second = new RuntimeOAuthTokenManager({
+			providerSettingsManager: new ProviderSettingsManager({ filePath }),
+		});
+
+		await expect(
+			Promise.all([
+				first.resolveProviderApiKey({ providerId: "openai-codex" }),
+				second.resolveProviderApiKey({ providerId: "openai-codex" }),
+			]),
+		).resolves.toMatchObject([
+			{ apiKey: "access-new" },
+			{ apiKey: "access-new" },
+		]);
+		expect(submissions).toEqual(["refresh-old"]);
+	});
+
+	it("does not restore a consumed refresh token from a stale settings save", async () => {
+		const filePath = createFilePath();
+		const storedManager = seedSettings(filePath);
+		const staleSettings =
+			storedManager.getProviderSettings("openai-codex") ?? createSettings();
+		const submissions: string[] = [];
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+				submissions.push(readSubmittedRefreshToken(init) ?? "");
+				return createTokenResponse();
+			}),
+		);
+		const manager = new RuntimeOAuthTokenManager({
+			providerSettingsManager: new ProviderSettingsManager({ filePath }),
+		});
+
+		await expect(
+			manager.resolveProviderApiKey({ providerId: "openai-codex" }),
+		).resolves.toMatchObject({ apiKey: "access-new" });
+		storedManager.saveProviderSettings({
+			...staleSettings,
+			model: "gpt-5.4",
+		});
+		await expect(
+			new RuntimeOAuthTokenManager({
+				providerSettingsManager: new ProviderSettingsManager({ filePath }),
+			}).resolveProviderApiKey({ providerId: "openai-codex" }),
+		).resolves.toMatchObject({ apiKey: "access-new" });
+		expect(submissions).toEqual(["refresh-old"]);
+		expect(storedManager.getProviderSettings("openai-codex")).toMatchObject({
+			model: "gpt-5.4",
+			auth: {
+				accessToken: "access-new",
+				refreshToken: "refresh-new",
+			},
+		});
+	});
+
+	it("lets a forced waiter adopt another manager's rotated credentials", async () => {
+		const filePath = createFilePath();
+		const manager = seedSettings(filePath);
+		manager.saveProviderSettings(
+			createSettings(
+				"access-current",
+				"refresh-current",
+				Date.now() + 3_600_000,
+			),
+			{ tokenSource: "oauth" },
+		);
+		const submissions: string[] = [];
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+				submissions.push(readSubmittedRefreshToken(init) ?? "");
+				return createTokenResponse();
+			}),
+		);
+		const first = new RuntimeOAuthTokenManager({
+			providerSettingsManager: new ProviderSettingsManager({ filePath }),
+		});
+		const second = new RuntimeOAuthTokenManager({
+			providerSettingsManager: new ProviderSettingsManager({ filePath }),
+		});
+
+		await expect(
+			Promise.all([
+				first.resolveProviderApiKey({
+					providerId: "openai-codex",
+					forceRefresh: true,
+				}),
+				second.resolveProviderApiKey({
+					providerId: "openai-codex",
+					forceRefresh: true,
+				}),
+			]),
+		).resolves.toMatchObject([
+			{ apiKey: "access-new" },
+			{ apiKey: "access-new" },
+		]);
+		expect(submissions).toEqual(["refresh-current"]);
+	});
+
+	it("keeps the lock alive while a delayed refresh response is in flight", async () => {
+		const filePath = createFilePath();
+		seedSettings(filePath);
+		const submissions: string[] = [];
+		const responseGate = createDeferred();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+				submissions.push(readSubmittedRefreshToken(init) ?? "");
+				await responseGate.promise;
+				return createTokenResponse();
+			}),
+		);
+		const lockOptions = { staleMs: 2_000, updateMs: 1_000 };
+		const first = new RuntimeOAuthTokenManager({
+			providerSettingsManager: new ProviderSettingsManager({ filePath }),
+			refreshLockOptions: lockOptions,
+		});
+		const second = new RuntimeOAuthTokenManager({
+			providerSettingsManager: new ProviderSettingsManager({ filePath }),
+			refreshLockOptions: lockOptions,
+		});
+
+		const firstResolution = first.resolveProviderApiKey({
+			providerId: "openai-codex",
+		});
+		await vi.waitFor(() => {
+			expect(submissions).toEqual(["refresh-old"]);
+		});
+		await new Promise((resolve) => setTimeout(resolve, 2_400));
+		const secondResolution = second.resolveProviderApiKey({
+			providerId: "openai-codex",
+		});
+		await new Promise((resolve) => setTimeout(resolve, 150));
+		expect(submissions).toEqual(["refresh-old"]);
+
+		responseGate.resolve();
+		await expect(
+			Promise.all([firstResolution, secondResolution]),
+		).resolves.toMatchObject([
+			{ apiKey: "access-new" },
+			{ apiKey: "access-new" },
+		]);
+		expect(submissions).toEqual(["refresh-old"]);
+	}, 10_000);
+
+	it("preserves newer stored auth after a stale invalid_grant response", async () => {
+		const filePath = createFilePath();
+		const externalManager = seedSettings(filePath);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => {
+				externalManager.saveProviderSettings(
+					createSettings(
+						"access-winner",
+						"refresh-winner",
+						Date.now() + 3_600_000,
+					),
+					{ tokenSource: "oauth" },
+				);
+				return createInvalidGrantResponse();
+			}),
+		);
+		const manager = new RuntimeOAuthTokenManager({
+			providerSettingsManager: new ProviderSettingsManager({ filePath }),
+		});
+
+		await expect(
+			manager.resolveProviderApiKey({ providerId: "openai-codex" }),
+		).rejects.toBeInstanceOf(OAuthReauthRequiredError);
+		expect(
+			externalManager.getProviderSettings("openai-codex")?.auth,
+		).toMatchObject({
+			accessToken: "access-winner",
+			refreshToken: "refresh-winner",
+		});
+	});
+
+	it("preserves newer stored auth with the same refresh token after a stale invalid_grant response", async () => {
+		const filePath = createFilePath();
+		const externalManager = seedSettings(filePath);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => {
+				externalManager.saveProviderSettings(
+					createSettings(
+						"access-winner",
+						"refresh-old",
+						Date.now() + 3_600_000,
+					),
+					{ tokenSource: "oauth" },
+				);
+				return createInvalidGrantResponse();
+			}),
+		);
+		const manager = new RuntimeOAuthTokenManager({
+			providerSettingsManager: new ProviderSettingsManager({ filePath }),
+		});
+
+		await expect(
+			manager.resolveProviderApiKey({ providerId: "openai-codex" }),
+		).rejects.toBeInstanceOf(OAuthReauthRequiredError);
+		expect(
+			externalManager.getProviderSettings("openai-codex")?.auth,
+		).toMatchObject({
+			accessToken: "access-winner",
+			refreshToken: "refresh-old",
+		});
+	});
+
+	it("clears rejected auth when durable credentials still match", async () => {
+		const filePath = createFilePath();
+		const storedManager = seedSettings(filePath);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => createInvalidGrantResponse()),
+		);
+		const manager = new RuntimeOAuthTokenManager({
+			providerSettingsManager: new ProviderSettingsManager({ filePath }),
+		});
+
+		await expect(
+			manager.resolveProviderApiKey({ providerId: "openai-codex" }),
+		).rejects.toBeInstanceOf(OAuthReauthRequiredError);
+		expect(
+			storedManager.getProviderSettings("openai-codex")?.auth,
+		).toBeUndefined();
+	});
+
+	it("preserves stored auth after a transient refresh failure", async () => {
+		const filePath = createFilePath();
+		const storedManager = seedSettings(filePath);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response(
+						JSON.stringify({
+							error: "server_error",
+							error_description: "try again",
+						}),
+						{
+							status: 500,
+							headers: { "Content-Type": "application/json" },
+						},
+					),
+			),
+		);
+		const manager = new RuntimeOAuthTokenManager({
+			providerSettingsManager: new ProviderSettingsManager({ filePath }),
+		});
+
+		await expect(
+			manager.resolveProviderApiKey({ providerId: "openai-codex" }),
+		).rejects.toBeInstanceOf(OAuthReauthRequiredError);
+		expect(
+			storedManager.getProviderSettings("openai-codex")?.auth,
+		).toMatchObject({
+			accessToken: "access-old",
+			refreshToken: "refresh-old",
+		});
+	});
+
+	it("serializes spawned workers sharing providers.json", async () => {
+		const filePath = createFilePath();
+		seedSettings(filePath);
+		const submissions: string[] = [];
+		const server = createServer((request, response) => {
+			let body = "";
+			request.setEncoding("utf8");
+			request.on("data", (chunk) => {
+				body += chunk;
+			});
+			request.on("end", () => {
+				submissions.push(new URLSearchParams(body).get("refresh_token") ?? "");
+				response.writeHead(200, { "Content-Type": "application/json" });
+				response.end(
+					JSON.stringify({
+						access_token: "access-new",
+						refresh_token: "refresh-new",
+						expires_in: 3600,
+					}),
+				);
+			});
+		});
+		const tokenEndpoint = await listen(server);
+		try {
+			await expect(
+				Promise.all([
+					runWorker(filePath, tokenEndpoint),
+					runWorker(filePath, tokenEndpoint),
+				]),
+			).resolves.toMatchObject([
+				{ apiKey: "access-new" },
+				{ apiKey: "access-new" },
+			]);
+		} finally {
+			await close(server);
+		}
+		expect(submissions).toEqual(["refresh-old"]);
+	}, 15_000);
+});

--- a/sdk/packages/core/src/runtime/orchestration/runtime-oauth-token-manager.integration.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-oauth-token-manager.integration.test.ts
@@ -379,6 +379,52 @@ describe("RuntimeOAuthTokenManager Codex refresh transaction", () => {
 		).toBeUndefined();
 	});
 
+	it("preserves re-authentication that lands while rejected auth is being cleared", async () => {
+		const filePath = createFilePath();
+		const storedManager = seedSettings(filePath);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => createInvalidGrantResponse()),
+		);
+		const providerSettingsManager = new ProviderSettingsManager({ filePath });
+		const write = providerSettingsManager.write.bind(providerSettingsManager);
+		let injectedReauthentication = false;
+		vi.spyOn(providerSettingsManager, "write").mockImplementation(
+			(state, options) => {
+				const codexSettings =
+					state.providers["openai-codex"]?.settings;
+				if (
+					!injectedReauthentication &&
+					options?.allowOpenAICodexAuthReplacement &&
+					!codexSettings?.auth
+				) {
+					injectedReauthentication = true;
+					storedManager.saveProviderSettings(
+						createSettings(
+							"access-reauth",
+							"refresh-reauth",
+							Date.now() + 3_600_000,
+						),
+						{ tokenSource: "oauth" },
+					);
+				}
+				return write(state, options);
+			},
+		);
+		const manager = new RuntimeOAuthTokenManager({ providerSettingsManager });
+
+		await expect(
+			manager.resolveProviderApiKey({ providerId: "openai-codex" }),
+		).rejects.toBeInstanceOf(OAuthReauthRequiredError);
+		expect(injectedReauthentication).toBe(true);
+		expect(
+			storedManager.getProviderSettings("openai-codex")?.auth,
+		).toMatchObject({
+			accessToken: "access-reauth",
+			refreshToken: "refresh-reauth",
+		});
+	});
+
 	it("preserves stored auth after a transient refresh failure", async () => {
 		const filePath = createFilePath();
 		const storedManager = seedSettings(filePath);

--- a/sdk/packages/core/src/runtime/orchestration/runtime-oauth-token-manager.integration.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-oauth-token-manager.integration.test.ts
@@ -391,8 +391,7 @@ describe("RuntimeOAuthTokenManager Codex refresh transaction", () => {
 		let injectedReauthentication = false;
 		vi.spyOn(providerSettingsManager, "write").mockImplementation(
 			(state, options) => {
-				const codexSettings =
-					state.providers["openai-codex"]?.settings;
+				const codexSettings = state.providers["openai-codex"]?.settings;
 				if (
 					!injectedReauthentication &&
 					options?.allowOpenAICodexAuthReplacement &&
@@ -416,6 +415,51 @@ describe("RuntimeOAuthTokenManager Codex refresh transaction", () => {
 		await expect(
 			manager.resolveProviderApiKey({ providerId: "openai-codex" }),
 		).rejects.toBeInstanceOf(OAuthReauthRequiredError);
+		expect(injectedReauthentication).toBe(true);
+		expect(
+			storedManager.getProviderSettings("openai-codex")?.auth,
+		).toMatchObject({
+			accessToken: "access-reauth",
+			refreshToken: "refresh-reauth",
+		});
+	});
+
+	it("preserves and adopts re-authentication that lands while refreshed auth is being saved", async () => {
+		const filePath = createFilePath();
+		const storedManager = seedSettings(filePath);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => createTokenResponse()),
+		);
+		const providerSettingsManager = new ProviderSettingsManager({ filePath });
+		const write = providerSettingsManager.write.bind(providerSettingsManager);
+		let injectedReauthentication = false;
+		vi.spyOn(providerSettingsManager, "write").mockImplementation(
+			(state, options) => {
+				const codexSettings = state.providers["openai-codex"]?.settings;
+				if (
+					!injectedReauthentication &&
+					options?.allowOpenAICodexAuthReplacement &&
+					codexSettings?.auth?.accessToken === "access-new"
+				) {
+					injectedReauthentication = true;
+					storedManager.saveProviderSettings(
+						createSettings(
+							"access-reauth",
+							"refresh-reauth",
+							Date.now() + 3_600_000,
+						),
+						{ tokenSource: "oauth" },
+					);
+				}
+				return write(state, options);
+			},
+		);
+		const manager = new RuntimeOAuthTokenManager({ providerSettingsManager });
+
+		await expect(
+			manager.resolveProviderApiKey({ providerId: "openai-codex" }),
+		).resolves.toMatchObject({ apiKey: "access-reauth" });
 		expect(injectedReauthentication).toBe(true);
 		expect(
 			storedManager.getProviderSettings("openai-codex")?.auth,

--- a/sdk/packages/core/src/runtime/orchestration/runtime-oauth-token-manager.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-oauth-token-manager.test.ts
@@ -8,14 +8,17 @@ const {
 	getValidOpenAICodexCredentials,
 	getValidClineCredentials,
 	getValidOcaCredentials,
+	isOpenAICodexTokenExpired,
 } = vi.hoisted(() => ({
 	getValidOpenAICodexCredentials: vi.fn(),
 	getValidClineCredentials: vi.fn(),
 	getValidOcaCredentials: vi.fn(),
+	isOpenAICodexTokenExpired: vi.fn().mockReturnValue(true),
 }));
 
 vi.mock("../../auth/codex", () => ({
 	getValidOpenAICodexCredentials,
+	isOpenAICodexTokenExpired,
 }));
 
 vi.mock("../../auth/cline", () => ({
@@ -29,6 +32,7 @@ vi.mock("../../auth/oca", () => ({
 describe("RuntimeOAuthTokenManager", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		isOpenAICodexTokenExpired.mockReturnValue(true);
 	});
 
 	it("refreshes and persists OpenAI Codex OAuth credentials", async () => {
@@ -54,6 +58,10 @@ describe("RuntimeOAuthTokenManager", () => {
 			providerSettingsManager: {
 				getProviderSettings,
 				saveProviderSettings,
+				withProviderRefreshLock: vi.fn(
+					async (_providerId: string, callback: () => Promise<unknown>) =>
+						callback(),
+				),
 			} as never,
 		});
 
@@ -93,6 +101,10 @@ describe("RuntimeOAuthTokenManager", () => {
 					},
 				}),
 				saveProviderSettings: vi.fn(),
+				withProviderRefreshLock: vi.fn(
+					async (_providerId: string, callback: () => Promise<unknown>) =>
+						callback(),
+				),
 			} as never,
 		});
 
@@ -122,6 +134,10 @@ describe("RuntimeOAuthTokenManager", () => {
 					},
 				}),
 				saveProviderSettings: vi.fn(),
+				withProviderRefreshLock: vi.fn(
+					async (_providerId: string, callback: () => Promise<unknown>) =>
+						callback(),
+				),
 			} as never,
 		});
 
@@ -133,5 +149,65 @@ describe("RuntimeOAuthTokenManager", () => {
 		expect(first?.apiKey).toBe("access-new");
 		expect(second?.apiKey).toBe("access-new");
 		expect(getValidOpenAICodexCredentials).toHaveBeenCalledTimes(1);
+	});
+
+	it("runs a strict forced refresh after an ordinary in-flight refresh", async () => {
+		let releaseFirstRefresh!: () => void;
+		const firstRefresh = new Promise<void>((resolve) => {
+			releaseFirstRefresh = resolve;
+		});
+		getValidOpenAICodexCredentials
+			.mockImplementationOnce(async () => {
+				await firstRefresh;
+				return {
+					access: "access-new",
+					refresh: "refresh-new",
+					expires: Date.now() + 60_000,
+				};
+			})
+			.mockResolvedValueOnce({
+				access: "access-forced",
+				refresh: "refresh-forced",
+				expires: Date.now() + 60_000,
+			});
+		const stored = {
+			provider: "openai-codex",
+			auth: {
+				accessToken: "access-old",
+				refreshToken: "refresh-old",
+				expiresAt: Date.now() - 1_000,
+			},
+		};
+		const manager = new RuntimeOAuthTokenManager({
+			providerSettingsManager: {
+				getProviderSettings: vi.fn().mockReturnValue(stored),
+				saveProviderSettings: vi.fn(),
+				withProviderRefreshLock: vi.fn(
+					async (_providerId: string, callback: () => Promise<unknown>) =>
+						callback(),
+				),
+			} as never,
+		});
+
+		const ordinary = manager.resolveProviderApiKey({
+			providerId: "openai-codex",
+		});
+		await vi.waitFor(() => {
+			expect(getValidOpenAICodexCredentials).toHaveBeenCalledTimes(1);
+		});
+		const forced = manager.resolveProviderApiKey({
+			providerId: "openai-codex",
+			forceRefresh: true,
+		});
+		releaseFirstRefresh();
+
+		await expect(Promise.all([ordinary, forced])).resolves.toMatchObject([
+			{ apiKey: "access-new" },
+			{ apiKey: "access-forced" },
+		]);
+		expect(getValidOpenAICodexCredentials).toHaveBeenCalledTimes(2);
+		expect(getValidOpenAICodexCredentials.mock.calls[1]?.[1]).toMatchObject({
+			forceRefresh: true,
+		});
 	});
 });

--- a/sdk/packages/core/src/runtime/orchestration/runtime-oauth-token-manager.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-oauth-token-manager.test.ts
@@ -210,4 +210,54 @@ describe("RuntimeOAuthTokenManager", () => {
 			forceRefresh: true,
 		});
 	});
+
+	it("does not replay an ambiguous failed refresh for a forced waiter", async () => {
+		let releaseRefresh!: () => void;
+		const refreshBarrier = new Promise<void>((resolve) => {
+			releaseRefresh = resolve;
+		});
+		getValidOpenAICodexCredentials.mockImplementationOnce(async () => {
+			await refreshBarrier;
+			return null;
+		});
+		const manager = new RuntimeOAuthTokenManager({
+			providerSettingsManager: {
+				getProviderSettings: vi.fn().mockReturnValue({
+					provider: "openai-codex",
+					auth: {
+						accessToken: "access-old",
+						refreshToken: "refresh-old",
+						expiresAt: Date.now() - 1_000,
+					},
+				}),
+				saveProviderSettings: vi.fn(),
+				withProviderRefreshLock: vi.fn(
+					async (_providerId: string, callback: () => Promise<unknown>) =>
+						callback(),
+				),
+			} as never,
+		});
+
+		const ordinary = manager.resolveProviderApiKey({
+			providerId: "openai-codex",
+		});
+		await vi.waitFor(() => {
+			expect(getValidOpenAICodexCredentials).toHaveBeenCalledTimes(1);
+		});
+		const forced = manager.resolveProviderApiKey({
+			providerId: "openai-codex",
+			forceRefresh: true,
+		});
+		const ordinaryRejection = expect(ordinary).rejects.toBeInstanceOf(
+			OAuthReauthRequiredError,
+		);
+		const forcedRejection = expect(forced).rejects.toBeInstanceOf(
+			OAuthReauthRequiredError,
+		);
+		releaseRefresh();
+
+		await ordinaryRejection;
+		await forcedRejection;
+		expect(getValidOpenAICodexCredentials).toHaveBeenCalledTimes(1);
+	});
 });

--- a/sdk/packages/core/src/runtime/orchestration/runtime-oauth-token-manager.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-oauth-token-manager.test.ts
@@ -29,6 +29,14 @@ vi.mock("../../auth/oca", () => ({
 	getValidOcaCredentials,
 }));
 
+function createPersistingSaveProviderSettings() {
+	return vi.fn((settings: unknown) => ({
+		providers: {
+			"openai-codex": { settings },
+		},
+	}));
+}
+
 describe("RuntimeOAuthTokenManager", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -45,7 +53,7 @@ describe("RuntimeOAuthTokenManager", () => {
 				accountId: "acct-old",
 			},
 		});
-		const saveProviderSettings = vi.fn();
+		const saveProviderSettings = createPersistingSaveProviderSettings();
 
 		getValidOpenAICodexCredentials.mockResolvedValueOnce({
 			access: "access-new",
@@ -84,7 +92,16 @@ describe("RuntimeOAuthTokenManager", () => {
 					expiresAt: 4_000_000_000_000,
 				}),
 			}),
-			{ setLastUsed: false, tokenSource: "oauth" },
+			{
+				setLastUsed: false,
+				tokenSource: "oauth",
+				expectedOpenAICodexAuth: {
+					accessToken: "access-old",
+					refreshToken: "refresh-old",
+					expiresAt: expect.any(Number),
+					accountId: "acct-old",
+				},
+			},
 		);
 	});
 
@@ -100,7 +117,7 @@ describe("RuntimeOAuthTokenManager", () => {
 						expiresAt: Date.now() - 1_000,
 					},
 				}),
-				saveProviderSettings: vi.fn(),
+				saveProviderSettings: createPersistingSaveProviderSettings(),
 				withProviderRefreshLock: vi.fn(
 					async (_providerId: string, callback: () => Promise<unknown>) =>
 						callback(),
@@ -133,7 +150,7 @@ describe("RuntimeOAuthTokenManager", () => {
 						expiresAt: Date.now() - 1_000,
 					},
 				}),
-				saveProviderSettings: vi.fn(),
+				saveProviderSettings: createPersistingSaveProviderSettings(),
 				withProviderRefreshLock: vi.fn(
 					async (_providerId: string, callback: () => Promise<unknown>) =>
 						callback(),
@@ -181,7 +198,7 @@ describe("RuntimeOAuthTokenManager", () => {
 		const manager = new RuntimeOAuthTokenManager({
 			providerSettingsManager: {
 				getProviderSettings: vi.fn().mockReturnValue(stored),
-				saveProviderSettings: vi.fn(),
+				saveProviderSettings: createPersistingSaveProviderSettings(),
 				withProviderRefreshLock: vi.fn(
 					async (_providerId: string, callback: () => Promise<unknown>) =>
 						callback(),

--- a/sdk/packages/core/src/runtime/orchestration/runtime-oauth-token-manager.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-oauth-token-manager.ts
@@ -307,13 +307,12 @@ export class RuntimeOAuthTokenManager {
 				const persistedSettings =
 					persistedState.providers[providerId]?.settings;
 				if (
-					persistedSettings &&
+					!persistedSettings ||
 					!oauthAuthSettingsEqual(persistedSettings.auth, nextSettings.auth)
 				) {
-					const winnerCredentials = toCredentials(
-						providerId,
-						persistedSettings,
-					);
+					const winnerCredentials = persistedSettings
+						? toCredentials(providerId, persistedSettings)
+						: null;
 					if (!winnerCredentials) {
 						throw new OAuthReauthRequiredError(providerId);
 					}

--- a/sdk/packages/core/src/runtime/orchestration/runtime-oauth-token-manager.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-oauth-token-manager.ts
@@ -8,10 +8,16 @@ import {
 	type ClineOAuthCredentials,
 	getValidClineCredentials,
 } from "../../auth/cline";
-import { getValidOpenAICodexCredentials } from "../../auth/codex";
+import {
+	getValidOpenAICodexCredentials,
+	isOpenAICodexTokenExpired,
+} from "../../auth/codex";
 import { getValidOcaCredentials } from "../../auth/oca";
 import { decodeJwtPayload } from "../../auth/utils";
-import { ProviderSettingsManager } from "../../services/storage/provider-settings-manager";
+import {
+	ProviderSettingsManager,
+	type ProviderSettingsRefreshLockOptions,
+} from "../../services/storage/provider-settings-manager";
 import type { ProviderSettings } from "../../types/provider-settings";
 
 const WORKOS_TOKEN_PREFIX = "workos:";
@@ -140,16 +146,22 @@ export class RuntimeOAuthTokenManager {
 	private readonly telemetry?: ITelemetryService;
 	private readonly refreshInFlight = new Map<
 		ManagedOAuthProviderId,
-		Promise<RuntimeOAuthResolution | null>
+		{
+			forceRefresh: boolean;
+			promise: Promise<RuntimeOAuthResolution | null>;
+		}
 	>();
+	private readonly refreshLockOptions?: ProviderSettingsRefreshLockOptions;
 
 	constructor(options?: {
 		providerSettingsManager?: ProviderSettingsManager;
 		telemetry?: ITelemetryService;
+		refreshLockOptions?: ProviderSettingsRefreshLockOptions;
 	}) {
 		this.providerSettingsManager =
 			options?.providerSettingsManager ?? new ProviderSettingsManager();
 		this.telemetry = options?.telemetry;
+		this.refreshLockOptions = options?.refreshLockOptions;
 	}
 
 	public async resolveProviderApiKey(input: {
@@ -168,16 +180,24 @@ export class RuntimeOAuthTokenManager {
 	): Promise<RuntimeOAuthResolution | null> {
 		const currentInFlight = this.refreshInFlight.get(providerId);
 		if (currentInFlight) {
-			return currentInFlight;
+			const resolution = await currentInFlight.promise;
+			return forceRefresh && !currentInFlight.forceRefresh
+				? this.resolveWithSingleFlight(providerId, true)
+				: resolution;
 		}
 		const pending = this.resolveProviderApiKeyInternal(providerId, forceRefresh)
 			.catch((error) => {
 				throw error;
 			})
 			.finally(() => {
-				this.refreshInFlight.delete(providerId);
+				if (this.refreshInFlight.get(providerId)?.promise === pending) {
+					this.refreshInFlight.delete(providerId);
+				}
 			});
-		this.refreshInFlight.set(providerId, pending);
+		this.refreshInFlight.set(providerId, {
+			forceRefresh,
+			promise: pending,
+		});
 		return pending;
 	}
 
@@ -196,14 +216,79 @@ export class RuntimeOAuthTokenManager {
 			return null;
 		}
 
-		const nextCredentials = await this.resolveCredentials(
+		if (
+			providerId === "openai-codex" &&
+			(forceRefresh || isOpenAICodexTokenExpired(currentCredentials))
+		) {
+			return this.providerSettingsManager.withProviderRefreshLock(
+				providerId,
+				async () => {
+					const storedSettings =
+						this.providerSettingsManager.getProviderSettings(providerId);
+					if (!storedSettings) {
+						return null;
+					}
+					const storedCredentials = toCredentials(providerId, storedSettings);
+					if (!storedCredentials) {
+						return null;
+					}
+					const storedAuthChanged = !authSettingsEqual(
+						settings.auth,
+						storedSettings.auth,
+					);
+					return this.resolveAndPersistCredentials(
+						providerId,
+						storedSettings,
+						storedCredentials,
+						forceRefresh && !storedAuthChanged,
+					);
+				},
+				this.refreshLockOptions,
+			);
+		}
+
+		return this.resolveAndPersistCredentials(
 			providerId,
 			settings,
 			currentCredentials,
 			forceRefresh,
 		);
+	}
+
+	private async resolveAndPersistCredentials(
+		providerId: ManagedOAuthProviderId,
+		settings: ProviderSettings,
+		currentCredentials: ClineOAuthCredentials,
+		forceRefresh: boolean,
+	): Promise<RuntimeOAuthResolution> {
+		let invalidGrant = false;
+		const nextCredentials = await this.resolveCredentials(
+			providerId,
+			settings,
+			currentCredentials,
+			forceRefresh,
+			() => {
+				invalidGrant = true;
+			},
+		);
 		if (!nextCredentials) {
+			if (providerId === "openai-codex" && invalidGrant) {
+				this.clearAuthIfUnchanged(providerId, settings.auth);
+			}
 			throw new OAuthReauthRequiredError(providerId);
+		}
+
+		const latestSettings =
+			this.providerSettingsManager.getProviderSettings(providerId);
+		if (
+			latestSettings &&
+			!authSettingsEqual(settings.auth, latestSettings.auth)
+		) {
+			const latestCredentials = toCredentials(providerId, latestSettings);
+			if (!latestCredentials) {
+				throw new OAuthReauthRequiredError(providerId);
+			}
+			return this.toResolution(providerId, latestCredentials, true);
 		}
 
 		const persistedAccessToken = toStoredAccessToken(
@@ -218,7 +303,7 @@ export class RuntimeOAuthTokenManager {
 		} as ProviderSettings["auth"] & { expiresAt?: number };
 		nextAuth.expiresAt = nextCredentials.expires;
 		const nextSettings: ProviderSettings = {
-			...settings,
+			...(latestSettings ?? settings),
 			auth: nextAuth,
 		};
 		const wasRefreshed = !authSettingsEqual(settings.auth, nextSettings.auth);
@@ -229,11 +314,38 @@ export class RuntimeOAuthTokenManager {
 			});
 		}
 
+		return this.toResolution(providerId, nextCredentials, wasRefreshed);
+	}
+
+	private clearAuthIfUnchanged(
+		providerId: ManagedOAuthProviderId,
+		failedAuth: ProviderSettings["auth"],
+	): void {
+		const latestSettings =
+			this.providerSettingsManager.getProviderSettings(providerId);
+		if (
+			!latestSettings ||
+			!authSettingsEqual(latestSettings.auth, failedAuth)
+		) {
+			return;
+		}
+		const { auth: _auth, ...settingsWithoutAuth } = latestSettings;
+		this.providerSettingsManager.saveProviderSettings(settingsWithoutAuth, {
+			setLastUsed: false,
+			tokenSource: "oauth",
+		});
+	}
+
+	private toResolution(
+		providerId: ManagedOAuthProviderId,
+		credentials: ClineOAuthCredentials,
+		refreshed: boolean,
+	): RuntimeOAuthResolution {
 		return {
 			providerId,
-			apiKey: persistedAccessToken,
-			accountId: nextCredentials.accountId,
-			refreshed: wasRefreshed,
+			apiKey: toStoredAccessToken(providerId, credentials.access),
+			accountId: credentials.accountId,
+			refreshed,
 		};
 	}
 
@@ -242,6 +354,7 @@ export class RuntimeOAuthTokenManager {
 		settings: ProviderSettings,
 		currentCredentials: ClineOAuthCredentials,
 		forceRefresh: boolean,
+		onInvalidGrant: () => void,
 	): Promise<ClineOAuthCredentials | null> {
 		if (providerId === "cline") {
 			return getValidClineCredentials(
@@ -263,6 +376,7 @@ export class RuntimeOAuthTokenManager {
 		}
 		return getValidOpenAICodexCredentials(currentCredentials, {
 			forceRefresh,
+			onInvalidGrant,
 			telemetry: this.telemetry,
 		});
 	}

--- a/sdk/packages/core/src/runtime/orchestration/runtime-oauth-token-manager.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-oauth-token-manager.ts
@@ -172,10 +172,10 @@ export class RuntimeOAuthTokenManager {
 			providerId,
 			forceRefresh,
 		).finally(() => {
-				if (this.refreshInFlight.get(providerId)?.promise === pending) {
-					this.refreshInFlight.delete(providerId);
-				}
-			});
+			if (this.refreshInFlight.get(providerId)?.promise === pending) {
+				this.refreshInFlight.delete(providerId);
+			}
+		});
 		this.refreshInFlight.set(providerId, {
 			forceRefresh,
 			promise: pending,
@@ -292,14 +292,40 @@ export class RuntimeOAuthTokenManager {
 			settings.auth,
 			nextSettings.auth,
 		);
+		let persistedCredentials = nextCredentials;
 		if (wasRefreshed) {
-			this.providerSettingsManager.saveProviderSettings(nextSettings, {
-				setLastUsed: false,
-				tokenSource: "oauth",
-			});
+			const persistedState = this.providerSettingsManager.saveProviderSettings(
+				nextSettings,
+				{
+					setLastUsed: false,
+					tokenSource: "oauth",
+					expectedOpenAICodexAuth:
+						providerId === "openai-codex" ? settings.auth : undefined,
+				},
+			);
+			if (providerId === "openai-codex") {
+				const persistedSettings =
+					persistedState.providers[providerId]?.settings;
+				if (
+					persistedSettings &&
+					!openAICodexAuthSettingsEqual(
+						persistedSettings.auth,
+						nextSettings.auth,
+					)
+				) {
+					const winnerCredentials = toCredentials(
+						providerId,
+						persistedSettings,
+					);
+					if (!winnerCredentials) {
+						throw new OAuthReauthRequiredError(providerId);
+					}
+					persistedCredentials = winnerCredentials;
+				}
+			}
 		}
 
-		return this.toResolution(providerId, nextCredentials, wasRefreshed);
+		return this.toResolution(providerId, persistedCredentials, wasRefreshed);
 	}
 
 	private clearAuthIfUnchanged(

--- a/sdk/packages/core/src/runtime/orchestration/runtime-oauth-token-manager.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-oauth-token-manager.ts
@@ -15,7 +15,7 @@ import {
 import { getValidOcaCredentials } from "../../auth/oca";
 import { decodeJwtPayload } from "../../auth/utils";
 import {
-	openAICodexAuthSettingsEqual,
+	oauthAuthSettingsEqual,
 	ProviderSettingsManager,
 	type ProviderSettingsRefreshLockOptions,
 } from "../../services/storage/provider-settings-manager";
@@ -214,7 +214,7 @@ export class RuntimeOAuthTokenManager {
 					if (!storedCredentials) {
 						return null;
 					}
-					const storedAuthChanged = !openAICodexAuthSettingsEqual(
+					const storedAuthChanged = !oauthAuthSettingsEqual(
 						settings.auth,
 						storedSettings.auth,
 					);
@@ -264,7 +264,7 @@ export class RuntimeOAuthTokenManager {
 			this.providerSettingsManager.getProviderSettings(providerId);
 		if (
 			latestSettings &&
-			!openAICodexAuthSettingsEqual(settings.auth, latestSettings.auth)
+			!oauthAuthSettingsEqual(settings.auth, latestSettings.auth)
 		) {
 			const latestCredentials = toCredentials(providerId, latestSettings);
 			if (!latestCredentials) {
@@ -288,7 +288,7 @@ export class RuntimeOAuthTokenManager {
 			...(latestSettings ?? settings),
 			auth: nextAuth,
 		};
-		const wasRefreshed = !openAICodexAuthSettingsEqual(
+		const wasRefreshed = !oauthAuthSettingsEqual(
 			settings.auth,
 			nextSettings.auth,
 		);
@@ -308,10 +308,7 @@ export class RuntimeOAuthTokenManager {
 					persistedState.providers[providerId]?.settings;
 				if (
 					persistedSettings &&
-					!openAICodexAuthSettingsEqual(
-						persistedSettings.auth,
-						nextSettings.auth,
-					)
+					!oauthAuthSettingsEqual(persistedSettings.auth, nextSettings.auth)
 				) {
 					const winnerCredentials = toCredentials(
 						providerId,
@@ -336,7 +333,7 @@ export class RuntimeOAuthTokenManager {
 			this.providerSettingsManager.getProviderSettings(providerId);
 		if (
 			!latestSettings ||
-			!openAICodexAuthSettingsEqual(latestSettings.auth, failedAuth)
+			!oauthAuthSettingsEqual(latestSettings.auth, failedAuth)
 		) {
 			return;
 		}

--- a/sdk/packages/core/src/runtime/orchestration/runtime-oauth-token-manager.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-oauth-token-manager.ts
@@ -185,11 +185,10 @@ export class RuntimeOAuthTokenManager {
 				? this.resolveWithSingleFlight(providerId, true)
 				: resolution;
 		}
-		const pending = this.resolveProviderApiKeyInternal(providerId, forceRefresh)
-			.catch((error) => {
-				throw error;
-			})
-			.finally(() => {
+		const pending = this.resolveProviderApiKeyInternal(
+			providerId,
+			forceRefresh,
+		).finally(() => {
 				if (this.refreshInFlight.get(providerId)?.promise === pending) {
 					this.refreshInFlight.delete(providerId);
 				}

--- a/sdk/packages/core/src/runtime/orchestration/runtime-oauth-token-manager.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-oauth-token-manager.ts
@@ -15,6 +15,7 @@ import {
 import { getValidOcaCredentials } from "../../auth/oca";
 import { decodeJwtPayload } from "../../auth/utils";
 import {
+	openAICodexAuthSettingsEqual,
 	ProviderSettingsManager,
 	type ProviderSettingsRefreshLockOptions,
 } from "../../services/storage/provider-settings-manager";
@@ -102,24 +103,6 @@ function toCredentials(
 		expires: deriveCredentialExpiry(settings, access),
 		accountId: settings.auth?.accountId,
 	};
-}
-
-function authSettingsEqual(
-	a: ProviderSettings["auth"] | undefined,
-	b: ProviderSettings["auth"] | undefined,
-): boolean {
-	const aExpiry = (
-		a as (ProviderSettings["auth"] & { expiresAt?: number }) | undefined
-	)?.expiresAt;
-	const bExpiry = (
-		b as (ProviderSettings["auth"] & { expiresAt?: number }) | undefined
-	)?.expiresAt;
-	return (
-		a?.accessToken === b?.accessToken &&
-		a?.refreshToken === b?.refreshToken &&
-		a?.accountId === b?.accountId &&
-		aExpiry === bExpiry
-	);
 }
 
 export class OAuthReauthRequiredError extends Error {
@@ -231,7 +214,7 @@ export class RuntimeOAuthTokenManager {
 					if (!storedCredentials) {
 						return null;
 					}
-					const storedAuthChanged = !authSettingsEqual(
+					const storedAuthChanged = !openAICodexAuthSettingsEqual(
 						settings.auth,
 						storedSettings.auth,
 					);
@@ -281,7 +264,7 @@ export class RuntimeOAuthTokenManager {
 			this.providerSettingsManager.getProviderSettings(providerId);
 		if (
 			latestSettings &&
-			!authSettingsEqual(settings.auth, latestSettings.auth)
+			!openAICodexAuthSettingsEqual(settings.auth, latestSettings.auth)
 		) {
 			const latestCredentials = toCredentials(providerId, latestSettings);
 			if (!latestCredentials) {
@@ -305,7 +288,10 @@ export class RuntimeOAuthTokenManager {
 			...(latestSettings ?? settings),
 			auth: nextAuth,
 		};
-		const wasRefreshed = !authSettingsEqual(settings.auth, nextSettings.auth);
+		const wasRefreshed = !openAICodexAuthSettingsEqual(
+			settings.auth,
+			nextSettings.auth,
+		);
 		if (wasRefreshed) {
 			this.providerSettingsManager.saveProviderSettings(nextSettings, {
 				setLastUsed: false,
@@ -324,7 +310,7 @@ export class RuntimeOAuthTokenManager {
 			this.providerSettingsManager.getProviderSettings(providerId);
 		if (
 			!latestSettings ||
-			!authSettingsEqual(latestSettings.auth, failedAuth)
+			!openAICodexAuthSettingsEqual(latestSettings.auth, failedAuth)
 		) {
 			return;
 		}
@@ -332,6 +318,7 @@ export class RuntimeOAuthTokenManager {
 		this.providerSettingsManager.saveProviderSettings(settingsWithoutAuth, {
 			setLastUsed: false,
 			tokenSource: "oauth",
+			expectedOpenAICodexAuth: failedAuth,
 		});
 	}
 

--- a/sdk/packages/core/src/services/providers/local-provider-service.ts
+++ b/sdk/packages/core/src/services/providers/local-provider-service.ts
@@ -329,7 +329,11 @@ function removeProviderFromSettingsState(
 		delete state.lastUsedProvider;
 		mutated = true;
 	}
-	if (mutated) manager.write(state);
+	if (mutated) {
+		manager.write(state, {
+			allowOpenAICodexAuthReplacement: providerId === "openai-codex",
+		});
+	}
 	LlmsModels.unregisterProvider(providerId);
 }
 
@@ -759,7 +763,9 @@ export function saveLocalProviderSettings(
 		const state = manager.read();
 		delete state.providers[providerId];
 		if (state.lastUsedProvider === providerId) delete state.lastUsedProvider;
-		manager.write(state);
+		manager.write(state, {
+			allowOpenAICodexAuthReplacement: providerId === "openai-codex",
+		});
 		return { providerId, enabled: false, settingsPath: manager.getFilePath() };
 	}
 

--- a/sdk/packages/core/src/services/storage/fixtures/provider-settings-writer.ts
+++ b/sdk/packages/core/src/services/storage/fixtures/provider-settings-writer.ts
@@ -1,0 +1,21 @@
+import { ProviderSettingsManager } from "../provider-settings-manager";
+
+const [filePath, iterationsValue] = process.argv.slice(2);
+if (!filePath || !iterationsValue) {
+	throw new Error("Expected providers.json path and iteration count");
+}
+
+const iterations = Number.parseInt(iterationsValue, 10);
+if (!Number.isInteger(iterations) || iterations <= 0) {
+	throw new Error("Expected a positive iteration count");
+}
+
+const manager = new ProviderSettingsManager({ filePath });
+const padding = "x".repeat(512 * 1024);
+for (let iteration = 0; iteration < iterations; iteration += 1) {
+	manager.saveProviderSettings({
+		provider: "anthropic",
+		model: `model-${iteration}`,
+		apiKey: `${iteration}-${padding}`,
+	});
+}

--- a/sdk/packages/core/src/services/storage/provider-settings-manager.test.ts
+++ b/sdk/packages/core/src/services/storage/provider-settings-manager.test.ts
@@ -434,6 +434,48 @@ describe("ProviderSettingsManager", () => {
 		});
 	});
 
+	it("does not restore OpenAI Codex OAuth auth during a conditional save after removal", () => {
+		const tempDir = mkdtempSync(
+			path.join(os.tmpdir(), "core-provider-settings-"),
+		);
+		tempDirs.push(tempDir);
+		const filePath = path.join(tempDir, "provider-settings.json");
+		const manager = new ProviderSettingsManager({ filePath });
+		const staleSettings = {
+			provider: "openai-codex" as const,
+			auth: {
+				accessToken: "access-old",
+				refreshToken: "refresh-old",
+				expiresAt: Date.now() - 1_000,
+			},
+		};
+		manager.saveProviderSettings(staleSettings, { tokenSource: "oauth" });
+		const removedState = manager.read();
+		delete removedState.providers["openai-codex"];
+		removedState.lastUsedProvider = undefined;
+		manager.write(removedState, {
+			allowOpenAICodexAuthReplacement: true,
+		});
+
+		const persisted = manager.saveProviderSettings(
+			{
+				...staleSettings,
+				auth: {
+					accessToken: "access-new",
+					refreshToken: "refresh-new",
+					expiresAt: Date.now() + 3_600_000,
+				},
+			},
+			{
+				tokenSource: "oauth",
+				expectedOpenAICodexAuth: staleSettings.auth,
+			},
+		);
+
+		expect(persisted.providers["openai-codex"]).toBeUndefined();
+		expect(persisted.lastUsedProvider).toBeUndefined();
+	});
+
 	it("ignores invalid persisted JSON and falls back to empty state", () => {
 		const tempDir = mkdtempSync(
 			path.join(os.tmpdir(), "core-provider-settings-"),

--- a/sdk/packages/core/src/services/storage/provider-settings-manager.test.ts
+++ b/sdk/packages/core/src/services/storage/provider-settings-manager.test.ts
@@ -1,9 +1,47 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { spawn } from "node:child_process";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import * as LlmsModels from "@cline/llms";
 import { afterEach, describe, expect, it } from "vitest";
 import { ProviderSettingsManager } from "./provider-settings-manager";
+
+const writerPath = fileURLToPath(
+	new URL("./fixtures/provider-settings-writer.ts", import.meta.url),
+);
+const sdkDir = path.join(
+	path.dirname(fileURLToPath(import.meta.url)),
+	"../../../../..",
+);
+
+function runWriter(filePath: string, iterations: number): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const child = spawn("bun", [writerPath, filePath, String(iterations)], {
+			cwd: sdkDir,
+			stdio: ["ignore", "ignore", "pipe"],
+		});
+		let stderr = "";
+		child.stderr.on("data", (chunk) => {
+			stderr += chunk.toString();
+		});
+		child.on("error", reject);
+		child.on("close", (code) => {
+			if (code !== 0) {
+				reject(new Error(`Writer exited ${code}: ${stderr}`));
+				return;
+			}
+			resolve();
+		});
+	});
+}
 
 describe("ProviderSettingsManager", () => {
 	const tempDirs: string[] = [];
@@ -337,6 +375,65 @@ describe("ProviderSettingsManager", () => {
 		expect(manager.read().providers["openai-codex"]?.tokenSource).toBe("oauth");
 	});
 
+	it("preserves durable OpenAI Codex OAuth auth during ordinary settings writes", () => {
+		const tempDir = mkdtempSync(
+			path.join(os.tmpdir(), "core-provider-settings-"),
+		);
+		tempDirs.push(tempDir);
+		const filePath = path.join(tempDir, "provider-settings.json");
+		const manager = new ProviderSettingsManager({ filePath });
+		manager.saveProviderSettings(
+			{
+				provider: "openai-codex",
+				auth: {
+					accessToken: "access-old",
+					refreshToken: "refresh-old",
+					expiresAt: Date.now() - 1_000,
+				},
+			},
+			{ tokenSource: "oauth" },
+		);
+		const staleState = manager.read();
+		manager.saveProviderSettings(
+			{
+				provider: "openai-codex",
+				auth: {
+					accessToken: "access-new",
+					refreshToken: "refresh-new",
+					expiresAt: Date.now() + 3_600_000,
+				},
+			},
+			{ tokenSource: "oauth" },
+		);
+
+		const persisted = manager.saveProviderSettings({
+			provider: "openai-codex",
+			model: "gpt-5.4",
+			auth: {
+				accessToken: "access-old",
+				refreshToken: "refresh-old",
+				expiresAt: Date.now() - 1_000,
+			},
+		});
+
+		expect(persisted.providers["openai-codex"]?.settings.auth).toMatchObject({
+			accessToken: "access-new",
+			refreshToken: "refresh-new",
+		});
+		expect(manager.getProviderSettings("openai-codex")).toMatchObject({
+			model: "gpt-5.4",
+			auth: {
+				accessToken: "access-new",
+				refreshToken: "refresh-new",
+			},
+		});
+		manager.write(staleState);
+		expect(manager.getProviderSettings("openai-codex")?.auth).toMatchObject({
+			accessToken: "access-new",
+			refreshToken: "refresh-new",
+		});
+	});
+
 	it("ignores invalid persisted JSON and falls back to empty state", () => {
 		const tempDir = mkdtempSync(
 			path.join(os.tmpdir(), "core-provider-settings-"),
@@ -351,4 +448,48 @@ describe("ProviderSettingsManager", () => {
 			providers: {},
 		});
 	});
+
+	it("keeps providers.json parseable during concurrent writes", async () => {
+		const tempDir = mkdtempSync(
+			path.join(os.tmpdir(), "core-provider-settings-"),
+		);
+		tempDirs.push(tempDir);
+		const filePath = path.join(tempDir, "settings", "providers.json");
+		const manager = new ProviderSettingsManager({ filePath });
+		manager.saveProviderSettings({
+			provider: "anthropic",
+			model: "initial",
+			apiKey: "initial",
+		});
+		let reads = 0;
+		let complete = false;
+		const completed = runWriter(filePath, 30).then(() => {
+			complete = true;
+		});
+
+		while (!complete) {
+			if (existsSync(filePath)) {
+				expect(() => JSON.parse(readFileSync(filePath, "utf8"))).not.toThrow();
+				reads += 1;
+			}
+			await new Promise((resolve) => setTimeout(resolve, 1));
+		}
+		await completed;
+		expect(reads).toBeGreaterThan(0);
+		expect(manager.getProviderSettings("anthropic")?.model).toBe("model-29");
+	}, 15_000);
+
+	it("serializes concurrent settings writers", async () => {
+		const tempDir = mkdtempSync(
+			path.join(os.tmpdir(), "core-provider-settings-"),
+		);
+		tempDirs.push(tempDir);
+		const filePath = path.join(tempDir, "settings", "providers.json");
+		const manager = new ProviderSettingsManager({ filePath });
+
+		await Promise.all([runWriter(filePath, 30), runWriter(filePath, 30)]);
+
+		expect(() => JSON.parse(readFileSync(filePath, "utf8"))).not.toThrow();
+		expect(manager.getProviderSettings("anthropic")?.model).toBe("model-29");
+	}, 15_000);
 });

--- a/sdk/packages/core/src/services/storage/provider-settings-manager.test.ts
+++ b/sdk/packages/core/src/services/storage/provider-settings-manager.test.ts
@@ -449,6 +449,45 @@ describe("ProviderSettingsManager", () => {
 		});
 	});
 
+	it("recovers a replacement backup when the primary settings file is absent", () => {
+		const tempDir = mkdtempSync(
+			path.join(os.tmpdir(), "core-provider-settings-"),
+		);
+		tempDirs.push(tempDir);
+		const filePath = path.join(tempDir, "settings", "providers.json");
+		mkdirSync(path.dirname(filePath), { recursive: true });
+		writeFileSync(
+			`${filePath}.backup`,
+			JSON.stringify({
+				version: 1,
+				providers: {
+					anthropic: {
+						settings: {
+							provider: "anthropic",
+							model: "backup-model",
+						},
+						updatedAt: new Date().toISOString(),
+						tokenSource: "manual",
+					},
+				},
+			}),
+		);
+
+		const manager = new ProviderSettingsManager({ filePath });
+		expect(manager.getProviderSettings("anthropic")?.model).toBe(
+			"backup-model",
+		);
+
+		manager.saveProviderSettings({
+			provider: "anthropic",
+			model: "new-model",
+		});
+
+		expect(existsSync(filePath)).toBe(true);
+		expect(existsSync(`${filePath}.backup`)).toBe(false);
+		expect(manager.getProviderSettings("anthropic")?.model).toBe("new-model");
+	});
+
 	it("keeps providers.json parseable during concurrent writes", async () => {
 		const tempDir = mkdtempSync(
 			path.join(os.tmpdir(), "core-provider-settings-"),

--- a/sdk/packages/core/src/services/storage/provider-settings-manager.ts
+++ b/sdk/packages/core/src/services/storage/provider-settings-manager.ts
@@ -1,12 +1,16 @@
+import { randomUUID } from "node:crypto";
 import {
 	chmodSync,
 	existsSync,
 	mkdirSync,
 	readFileSync,
+	renameSync,
+	rmSync,
 	writeFileSync,
 } from "node:fs";
 import { basename, dirname } from "node:path";
 import { resolveProviderSettingsPath } from "@cline/shared/storage";
+import lockfile from "proper-lockfile";
 import { getLiveModelsCatalog } from "../..";
 import {
 	emptyStoredProviderSettings,
@@ -25,6 +29,11 @@ import {
 } from "../providers/local-provider-registry";
 import { migrateLegacyProviderSettings } from "./provider-settings-legacy-migration";
 
+const SETTINGS_WRITE_LOCK_STALE_MS = 10_000;
+const SETTINGS_WRITE_LOCK_TIMEOUT_MS = 12_000;
+const SETTINGS_WRITE_LOCK_RETRY_MS = 10;
+const syncWaitBuffer = new Int32Array(new SharedArrayBuffer(4));
+
 function nowIso(): string {
 	return new Date().toISOString();
 }
@@ -39,6 +48,16 @@ export interface SaveProviderSettingsOptions {
 	tokenSource?: ProviderTokenSource;
 }
 
+export interface WriteProviderSettingsOptions {
+	allowOpenAICodexAuthReplacement?: boolean;
+}
+
+export interface ProviderSettingsRefreshLockOptions {
+	staleMs?: number;
+	updateMs?: number;
+	retries?: number;
+}
+
 function inferLegacyDataDir(filePath: string): string | undefined {
 	if (basename(filePath) !== "providers.json") {
 		return undefined;
@@ -48,6 +67,80 @@ function inferLegacyDataDir(filePath: string): string | undefined {
 		return undefined;
 	}
 	return dirname(settingsDir);
+}
+
+function isLockHeldError(error: unknown): boolean {
+	return error instanceof Error && "code" in error && error.code === "ELOCKED";
+}
+
+function withSettingsWriteLock<T>(filePath: string, callback: () => T): T {
+	const lockTarget = `${filePath}.write`;
+	const dir = dirname(lockTarget);
+	if (!existsSync(dir)) {
+		mkdirSync(dir, { recursive: true, mode: 0o700 });
+	}
+	const startedAt = Date.now();
+	let release: (() => void) | undefined;
+	while (!release) {
+		try {
+			release = lockfile.lockSync(lockTarget, {
+				stale: SETTINGS_WRITE_LOCK_STALE_MS,
+				realpath: false,
+			});
+		} catch (error) {
+			if (
+				!isLockHeldError(error) ||
+				Date.now() - startedAt >= SETTINGS_WRITE_LOCK_TIMEOUT_MS
+			) {
+				throw error;
+			}
+			Atomics.wait(syncWaitBuffer, 0, 0, SETTINGS_WRITE_LOCK_RETRY_MS);
+		}
+	}
+	try {
+		return callback();
+	} finally {
+		release();
+	}
+}
+
+function preserveDurableOpenAICodexEntry(
+	state: StoredProviderSettings,
+	durableState: StoredProviderSettings,
+	options: WriteProviderSettingsOptions,
+): StoredProviderSettings {
+	const durableEntry = durableState.providers["openai-codex"];
+	if (
+		options.allowOpenAICodexAuthReplacement ||
+		durableEntry?.tokenSource !== "oauth" ||
+		!durableEntry.settings.auth
+	) {
+		return state;
+	}
+	const nextEntry = state.providers["openai-codex"];
+	if (!nextEntry) {
+		return {
+			...state,
+			providers: {
+				...state.providers,
+				"openai-codex": durableEntry,
+			},
+		};
+	}
+	return {
+		...state,
+		providers: {
+			...state.providers,
+			"openai-codex": {
+				...nextEntry,
+				settings: {
+					...nextEntry.settings,
+					auth: durableEntry.settings.auth,
+				},
+				tokenSource: durableEntry.tokenSource,
+			},
+		},
+	};
 }
 
 export class ProviderSettingsManager {
@@ -100,24 +193,65 @@ export class ProviderSettingsManager {
 		return emptyStoredProviderSettings();
 	}
 
-	write(state: StoredProviderSettings): void {
-		const normalized = StoredProviderSettingsSchema.parse(state);
-		const dir = dirname(this.filePath);
+	write(
+		state: StoredProviderSettings,
+		options: WriteProviderSettingsOptions = {},
+	): StoredProviderSettings {
+		const parsed = StoredProviderSettingsSchema.parse(state);
+		return withSettingsWriteLock(this.filePath, () => {
+			const normalized = preserveDurableOpenAICodexEntry(
+				parsed,
+				this.read(),
+				options,
+			);
+			const tempPath = `${this.filePath}.${process.pid}.${randomUUID()}.tmp`;
+			try {
+				writeFileSync(tempPath, `${JSON.stringify(normalized, null, 2)}\n`, {
+					encoding: "utf8",
+					mode: 0o600,
+				});
+				// Restrict file to owner-only read/write (best-effort; no-op on Windows).
+				try {
+					chmodSync(tempPath, 0o600);
+				} catch {
+					// Ignore — Windows does not support POSIX chmod.
+				}
+				renameSync(tempPath, this.filePath);
+			} finally {
+				rmSync(tempPath, { force: true });
+			}
+			registerConfiguredProvidersFromSettings(normalized);
+			return normalized;
+		});
+	}
+
+	async withProviderRefreshLock<T>(
+		providerId: string,
+		callback: () => Promise<T>,
+		options: ProviderSettingsRefreshLockOptions = {},
+	): Promise<T> {
+		const lockTarget = `${this.filePath}.${providerId.replace(/[^a-zA-Z0-9_.-]+/g, "_")}.refresh`;
+		const dir = dirname(lockTarget);
 		if (!existsSync(dir)) {
 			mkdirSync(dir, { recursive: true, mode: 0o700 });
 		}
-		writeFileSync(
-			this.filePath,
-			`${JSON.stringify(normalized, null, 2)}\n`,
-			"utf8",
-		);
-		// Restrict file to owner-only read/write (best-effort; no-op on Windows).
+		const release = await lockfile.lock(lockTarget, {
+			stale: options.staleMs ?? 60_000,
+			update: options.updateMs ?? 10_000,
+			realpath: false,
+			retries: {
+				retries: options.retries ?? 60,
+				factor: 1.2,
+				minTimeout: 100,
+				maxTimeout: 1_000,
+				randomize: true,
+			},
+		});
 		try {
-			chmodSync(this.filePath, 0o600);
-		} catch {
-			// Ignore — Windows does not support POSIX chmod.
+			return await callback();
+		} finally {
+			await release();
 		}
-		registerConfiguredProvidersFromSettings(normalized);
 	}
 
 	saveProviderSettings(
@@ -145,8 +279,9 @@ export class ProviderSettingsManager {
 				? providerId
 				: previous.lastUsedProvider,
 		};
-		this.write(next);
-		return next;
+		return this.write(next, {
+			allowOpenAICodexAuthReplacement: options.tokenSource === "oauth",
+		});
 	}
 
 	getProviderSettings(providerId: string): ProviderSettings | undefined {

--- a/sdk/packages/core/src/services/storage/provider-settings-manager.ts
+++ b/sdk/packages/core/src/services/storage/provider-settings-manager.ts
@@ -32,7 +32,9 @@ import { migrateLegacyProviderSettings } from "./provider-settings-legacy-migrat
 const SETTINGS_WRITE_LOCK_STALE_MS = 10_000;
 const SETTINGS_WRITE_LOCK_TIMEOUT_MS = 12_000;
 const SETTINGS_WRITE_LOCK_RETRY_MS = 10;
+const WINDOWS_FILE_REPLACE_TIMEOUT_MS = 1_000;
 const syncWaitBuffer = new Int32Array(new SharedArrayBuffer(4));
+const invalidStoredProviderSettings = Symbol("invalidStoredProviderSettings");
 
 function nowIso(): string {
 	return new Date().toISOString();
@@ -71,6 +73,96 @@ function inferLegacyDataDir(filePath: string): string | undefined {
 
 function isLockHeldError(error: unknown): boolean {
 	return error instanceof Error && "code" in error && error.code === "ELOCKED";
+}
+
+function getSettingsBackupPath(filePath: string): string {
+	return `${filePath}.backup`;
+}
+
+function readStoredProviderSettings(
+	filePath: string,
+): StoredProviderSettings | typeof invalidStoredProviderSettings | undefined {
+	try {
+		const raw = readFileSync(filePath, "utf8");
+		const parsed = JSON.parse(raw) as unknown;
+		const result = StoredProviderSettingsSchema.safeParse(parsed);
+		return result.success ? result.data : invalidStoredProviderSettings;
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+			return undefined;
+		}
+		return invalidStoredProviderSettings;
+	}
+}
+
+function isWindowsFileMutationError(error: unknown): boolean {
+	return (
+		process.platform === "win32" &&
+		error instanceof Error &&
+		"code" in error &&
+		(error.code === "EPERM" ||
+			error.code === "EACCES" ||
+			error.code === "EEXIST" ||
+			error.code === "ENOTEMPTY")
+	);
+}
+
+function retryWindowsFileMutation(callback: () => void): void {
+	const startedAt = Date.now();
+	while (true) {
+		try {
+			callback();
+			return;
+		} catch (error) {
+			if (
+				!isWindowsFileMutationError(error) ||
+				Date.now() - startedAt >= WINDOWS_FILE_REPLACE_TIMEOUT_MS
+			) {
+				throw error;
+			}
+			Atomics.wait(syncWaitBuffer, 0, 0, SETTINGS_WRITE_LOCK_RETRY_MS);
+		}
+	}
+}
+
+function removeFileBestEffort(filePath: string): void {
+	try {
+		rmSync(filePath, { force: true });
+	} catch {
+		// A completed replacement remains durable even if backup cleanup fails.
+	}
+}
+
+function replaceSettingsFile(tempPath: string, filePath: string): void {
+	const backupPath = getSettingsBackupPath(filePath);
+	try {
+		renameSync(tempPath, filePath);
+		removeFileBestEffort(backupPath);
+		return;
+	} catch (error) {
+		if (!isWindowsFileMutationError(error) || !existsSync(filePath)) {
+			throw error;
+		}
+	}
+
+	// Bun on Windows cannot replace an existing file with renameSync. Keep a
+	// stable backup so reads and a later process can recover if replacement fails.
+	retryWindowsFileMutation(() => rmSync(backupPath, { force: true }));
+	retryWindowsFileMutation(() => renameSync(filePath, backupPath));
+	try {
+		retryWindowsFileMutation(() => renameSync(tempPath, filePath));
+	} catch (error) {
+		try {
+			retryWindowsFileMutation(() => renameSync(backupPath, filePath));
+		} catch (restoreError) {
+			throw new AggregateError(
+				[error, restoreError],
+				`Failed to replace ${filePath} and restore its backup`,
+			);
+		}
+		throw error;
+	}
+	removeFileBestEffort(backupPath);
 }
 
 function withSettingsWriteLock<T>(filePath: string, callback: () => T): T {
@@ -174,20 +266,25 @@ export class ProviderSettingsManager {
 	}
 
 	read(): StoredProviderSettings {
-		if (!existsSync(this.filePath)) {
-			return emptyStoredProviderSettings();
-		}
-
-		try {
-			const raw = readFileSync(this.filePath, "utf8");
-			const parsed = JSON.parse(raw) as unknown;
-			const result = StoredProviderSettingsSchema.safeParse(parsed);
-			if (result.success) {
-				registerConfiguredProvidersFromSettings(result.data);
-				return result.data;
+		for (let attempt = 0; attempt < 2; attempt += 1) {
+			const primaryState = readStoredProviderSettings(this.filePath);
+			if (primaryState === invalidStoredProviderSettings) {
+				return emptyStoredProviderSettings();
 			}
-		} catch {
-			// Invalid content falls back to a clean state.
+			if (primaryState) {
+				registerConfiguredProvidersFromSettings(primaryState);
+				return primaryState;
+			}
+			const backupState = readStoredProviderSettings(
+				getSettingsBackupPath(this.filePath),
+			);
+			if (backupState === invalidStoredProviderSettings) {
+				return emptyStoredProviderSettings();
+			}
+			if (backupState) {
+				registerConfiguredProvidersFromSettings(backupState);
+				return backupState;
+			}
 		}
 
 		return emptyStoredProviderSettings();
@@ -216,7 +313,7 @@ export class ProviderSettingsManager {
 				} catch {
 					// Ignore — Windows does not support POSIX chmod.
 				}
-				renameSync(tempPath, this.filePath);
+				replaceSettingsFile(tempPath, this.filePath);
 			} finally {
 				rmSync(tempPath, { force: true });
 			}

--- a/sdk/packages/core/src/services/storage/provider-settings-manager.ts
+++ b/sdk/packages/core/src/services/storage/provider-settings-manager.ts
@@ -50,10 +50,12 @@ export interface ProviderSettingsManagerOptions {
 export interface SaveProviderSettingsOptions {
 	setLastUsed?: boolean;
 	tokenSource?: ProviderTokenSource;
+	expectedOpenAICodexAuth?: NonNullable<ProviderSettings["auth"]>;
 }
 
 export interface WriteProviderSettingsOptions {
 	allowOpenAICodexAuthReplacement?: boolean;
+	expectedOpenAICodexAuth?: NonNullable<ProviderSettings["auth"]>;
 }
 
 export interface ProviderSettingsRefreshLockOptions {
@@ -198,14 +200,39 @@ function withSettingsWriteLock<T>(filePath: string, callback: () => T): T {
 	}
 }
 
+export function openAICodexAuthSettingsEqual(
+	a: ProviderSettings["auth"] | undefined,
+	b: ProviderSettings["auth"] | undefined,
+): boolean {
+	const aExpiry = (
+		a as (ProviderSettings["auth"] & { expiresAt?: number }) | undefined
+	)?.expiresAt;
+	const bExpiry = (
+		b as (ProviderSettings["auth"] & { expiresAt?: number }) | undefined
+	)?.expiresAt;
+	return (
+		a?.accessToken === b?.accessToken &&
+		a?.refreshToken === b?.refreshToken &&
+		a?.accountId === b?.accountId &&
+		aExpiry === bExpiry
+	);
+}
+
 function preserveDurableOpenAICodexEntry(
 	state: StoredProviderSettings,
 	durableState: StoredProviderSettings,
 	options: WriteProviderSettingsOptions,
 ): StoredProviderSettings {
 	const durableEntry = durableState.providers["openai-codex"];
+	const conditionalReplacementMismatch =
+		options.expectedOpenAICodexAuth !== undefined &&
+		!openAICodexAuthSettingsEqual(
+			durableEntry?.settings.auth,
+			options.expectedOpenAICodexAuth,
+		);
 	if (
-		options.allowOpenAICodexAuthReplacement ||
+		(options.allowOpenAICodexAuthReplacement &&
+			!conditionalReplacementMismatch) ||
 		durableEntry?.tokenSource !== "oauth" ||
 		!durableEntry.settings.auth
 	) {
@@ -385,6 +412,7 @@ export class ProviderSettingsManager {
 		};
 		return this.write(next, {
 			allowOpenAICodexAuthReplacement: options.tokenSource === "oauth",
+			expectedOpenAICodexAuth: options.expectedOpenAICodexAuth,
 		});
 	}
 

--- a/sdk/packages/core/src/services/storage/provider-settings-manager.ts
+++ b/sdk/packages/core/src/services/storage/provider-settings-manager.ts
@@ -200,7 +200,7 @@ function withSettingsWriteLock<T>(filePath: string, callback: () => T): T {
 	}
 }
 
-export function openAICodexAuthSettingsEqual(
+export function oauthAuthSettingsEqual(
 	a: ProviderSettings["auth"] | undefined,
 	b: ProviderSettings["auth"] | undefined,
 ): boolean {
@@ -226,7 +226,7 @@ function preserveDurableOpenAICodexEntry(
 	const durableEntry = durableState.providers["openai-codex"];
 	const conditionalReplacementMismatch =
 		options.expectedOpenAICodexAuth !== undefined &&
-		!openAICodexAuthSettingsEqual(
+		!oauthAuthSettingsEqual(
 			durableEntry?.settings.auth,
 			options.expectedOpenAICodexAuth,
 		);
@@ -295,6 +295,8 @@ export class ProviderSettingsManager {
 	}
 
 	read(): StoredProviderSettings {
+		// Retry once because Windows backup-and-replace can advance between probes:
+		// primary may be absent before promotion, then backup removed after promotion.
 		for (let attempt = 0; attempt < 2; attempt += 1) {
 			const primaryState = readStoredProviderSettings(this.filePath);
 			if (primaryState === invalidStoredProviderSettings) {

--- a/sdk/packages/core/src/services/storage/provider-settings-manager.ts
+++ b/sdk/packages/core/src/services/storage/provider-settings-manager.ts
@@ -230,9 +230,21 @@ function preserveDurableOpenAICodexEntry(
 			durableEntry?.settings.auth,
 			options.expectedOpenAICodexAuth,
 		);
+	if (conditionalReplacementMismatch) {
+		const providers = { ...state.providers };
+		if (durableEntry) {
+			providers["openai-codex"] = durableEntry;
+		} else {
+			delete providers["openai-codex"];
+		}
+		return {
+			...state,
+			providers,
+			lastUsedProvider: durableState.lastUsedProvider,
+		};
+	}
 	if (
-		(options.allowOpenAICodexAuthReplacement &&
-			!conditionalReplacementMismatch) ||
+		options.allowOpenAICodexAuthReplacement ||
 		durableEntry?.tokenSource !== "oauth" ||
 		!durableEntry.settings.auth
 	) {

--- a/sdk/packages/core/src/services/storage/provider-settings-manager.ts
+++ b/sdk/packages/core/src/services/storage/provider-settings-manager.ts
@@ -32,6 +32,8 @@ import { migrateLegacyProviderSettings } from "./provider-settings-legacy-migrat
 const SETTINGS_WRITE_LOCK_STALE_MS = 10_000;
 const SETTINGS_WRITE_LOCK_TIMEOUT_MS = 12_000;
 const SETTINGS_WRITE_LOCK_RETRY_MS = 10;
+const PROVIDER_REFRESH_LOCK_MIN_STALE_MS =
+	SETTINGS_WRITE_LOCK_TIMEOUT_MS * 2 + SETTINGS_WRITE_LOCK_RETRY_MS;
 const WINDOWS_FILE_REPLACE_TIMEOUT_MS = 1_000;
 const syncWaitBuffer = new Int32Array(new SharedArrayBuffer(4));
 const invalidStoredProviderSettings = Symbol("invalidStoredProviderSettings");
@@ -332,9 +334,14 @@ export class ProviderSettingsManager {
 		if (!existsSync(dir)) {
 			mkdirSync(dir, { recursive: true, mode: 0o700 });
 		}
+		// A synchronous settings-write wait can delay the async lock heartbeat.
+		const stale = Math.max(
+			options.staleMs ?? 60_000,
+			PROVIDER_REFRESH_LOCK_MIN_STALE_MS,
+		);
 		const release = await lockfile.lock(lockTarget, {
-			stale: options.staleMs ?? 60_000,
-			update: options.updateMs ?? 10_000,
+			stale,
+			update: Math.min(options.updateMs ?? 10_000, stale / 2),
 			realpath: false,
 			retries: {
 				retries: options.retries ?? 60,


### PR DESCRIPTION
## Summary

- serialize ChatGPT Codex OAuth refresh transactions across SDK/CLI processes with a per-provider lock, a fresh durable reread, winner adoption, and conditional `invalid_grant` cleanup
- serialize `providers.json` writes, preserve durable Codex OAuth auth and removals against stale ordinary writes and conditional OAuth replacement races, and replace settings through temp files with a Windows Bun backup-and-replace recovery path
- keep ambiguous failed refreshes single-attempt even when a forced waiter is queued, and bound refresh-lock stale time against synchronous write contention
- send `User-Agent: cline-sdk/<version>` on Codex OAuth token requests
- add deterministic same-process, multi-manager, multi-process, delayed-response, stale-save rollback, concurrent re-authentication during cleanup and successful saves, concurrent removal, invalid-grant, transient-failure, forced-waiter, Windows recovery, atomic-write, and writer-contention regressions

## Validation

- `bunx vitest run --config vitest.config.ts src/runtime/orchestration/runtime-oauth-token-manager.test.ts src/runtime/orchestration/runtime-oauth-token-manager.integration.test.ts src/auth/codex.test.ts src/services/storage/provider-settings-manager.test.ts` (`37` tests)
- `bunx vitest run --config vitest.config.ts src/services/providers/local-provider-service.test.ts -t "treats empty baseUrl and apiKey as a delete request for existing provider|disabling a provider removes it from settings|disabling a last-used provider also clears lastUsedProvider|removes provider from registry and local settings"`
- five repeated OAuth/storage chaos rounds after the final review changes
- `bunx biome check <changed files>`
- `git diff --check`
- `bun -F @cline/core typecheck`
- `bun run build:sdk`
- `bun -F @cline/cli build`
- `bun --parallel -F './packages/**' -F @cline/cli typecheck`
- `bun scripts/check-publish.ts`
- `node --input-type=module -e 'import("./sdk/packages/core/dist/index.js")'`
- `CLINE_BUILD_ENV=development bun --conditions=development ./src/index.ts --help`
- GitHub `sdk-test`: quality checks, Linux Node 24, and Windows Node 24 passed

## Existing upstream blockers

- `bun run check` stops on 10 Biome errors in unrelated existing files.
- `bun -F @cline/core test:unit` passes 958 tests with 4 skipped, then fails one unrelated `local-runtime-host.test.ts` temp-directory cleanup with `EACCES`.

## Lockfile note

Regenerating `sdk/bun.lock` also realigns the existing CLI workspace version entry from `3.0.14` to the current `sdk/apps/cli/package.json` version `3.0.15`.
