### PR TITLE
feat(api): add MiniMax-M3 to anthropicModels registry

### DIFF
--- a/apps/vscode/src/shared/api.ts
+++ b/apps/vscode/src/shared/api.ts
@@ -166,6 +166,17 @@ export const anthropicDefaultModelId: AnthropicModelId = "claude-sonnet-4-5-2025
 export const ANTHROPIC_MIN_THINKING_BUDGET = 1_024
 export const ANTHROPIC_MAX_THINKING_BUDGET = 6_000
 export const anthropicModels = {
+	"MiniMax-M3": {
+		maxTokens: 196_608,
+		contextWindow: 512_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		supportsReasoning: true,
+		inputPrice: 0.3,
+		outputPrice: 1.2,
+		cacheWritesPrice: 0.375,
+		cacheReadsPrice: 0.06,
+	},
 	"claude-sonnet-4-6": {
 		maxTokens: 64_000,
 		contextWindow: 200_000,


### PR DESCRIPTION
Adds MiniMax-M3 to anthropicModels registry so Custom Model ID path returns proper caps (contextWindow 512_000, maxTokens 196_608, supportsImages true, supportsReasoning true) instead of 200K/8192/no-images fallback. Verified against M3 staging endpoint. First-class MINIMAX provider is a larger followup; this PR is the minimum unblock for the Anthropic + Custom Model ID UX.