### PR TITLE
feat: add skills bundled with plugins

### DIFF
--- a/docs/sdk/guides/writing-plugins.mdx
+++ b/docs/sdk/guides/writing-plugins.mdx
@@ -284,6 +284,21 @@ Users can also install package plugins from git, npm, or a local path:
 cline plugin install https://github.com/your-org/cline-github-plugin.git
 ```
 
+## Bundling Skills
+
+Package plugins can include skills by adding a top-level `skills/` directory next to `package.json`:
+
+```txt
+cline-github-plugin/
+  package.json
+  github-plugin.ts
+  skills/
+    triage/
+      SKILL.md
+```
+
+Each bundled skill follows the same directory format as any other [Cline skill](/customization/skills). When the plugin is installed or loaded through `pluginPaths`, Cline discovers those skills automatically.
+
 See [Plugins](/customization/plugins) for the full manifest format, directory layout, and the [typescript-lsp-plugin](https://github.com/cline/typescript-lsp-plugin) for a complete working example.
 
 ## Plugin Design Guidelines

--- a/sdk/apps/cli/src/commands/config.ts
+++ b/sdk/apps/cli/src/commands/config.ts
@@ -30,6 +30,18 @@ function resolveCliAgentConfigSearchPaths(cwd: string): string[] {
 	return [join(cwd, ".cline", "agents"), join(clineDir, "agents")];
 }
 
+function createConfigUserInstructionService(cwd: string) {
+	return createUserInstructionConfigService({
+		skills: {
+			workspacePath: cwd,
+			includePluginSkills: true,
+			cwd,
+		},
+		rules: { workspacePath: cwd },
+		workflows: { workspacePath: cwd },
+	});
+}
+
 async function runWorkflowsConfigCommand(
 	cwd: string,
 	outputMode: CliOutputMode,
@@ -39,11 +51,7 @@ async function runWorkflowsConfigCommand(
 		string,
 		{ id: string; name: string; instructions: string; path: string }
 	>();
-	const service = createUserInstructionConfigService({
-		skills: { workspacePath: cwd },
-		rules: { workspacePath: cwd },
-		workflows: { workspacePath: cwd },
-	});
+	const service = createConfigUserInstructionService(cwd);
 	try {
 		await service.start();
 		for (const record of service.listRecords<WorkflowConfig>("workflow")) {
@@ -90,11 +98,7 @@ async function runRulesConfigCommand(
 		string,
 		{ name: string; instructions: string; path: string }
 	>();
-	const service = createUserInstructionConfigService({
-		skills: { workspacePath: cwd },
-		rules: { workspacePath: cwd },
-		workflows: { workspacePath: cwd },
-	});
+	const service = createConfigUserInstructionService(cwd);
 	try {
 		await service.start();
 		for (const record of service.listRecords<RuleConfig>("rule")) {
@@ -142,11 +146,7 @@ async function runSkillsConfigCommand(
 			path: string;
 		}
 	>();
-	const service = createUserInstructionConfigService({
-		skills: { workspacePath: cwd },
-		rules: { workspacePath: cwd },
-		workflows: { workspacePath: cwd },
-	});
+	const service = createConfigUserInstructionService(cwd);
 	try {
 		await service.start();
 		for (const record of service.listRecords<SkillConfig>("skill")) {
@@ -420,11 +420,7 @@ async function runToolsConfigCommand(
 async function loadInteractiveConfigDataForCommand(
 	cwd: string,
 ): Promise<Awaited<ReturnType<typeof loadInteractiveConfigData>>> {
-	const userInstructionService = createUserInstructionConfigService({
-		skills: { workspacePath: cwd },
-		rules: { workspacePath: cwd },
-		workflows: { workspacePath: cwd },
-	});
+	const userInstructionService = createConfigUserInstructionService(cwd);
 	try {
 		await userInstructionService.start();
 		return await loadInteractiveConfigData({

--- a/sdk/apps/cli/src/main.ts
+++ b/sdk/apps/cli/src/main.ts
@@ -758,7 +758,11 @@ export async function runCli(): Promise<void> {
 	} = await loadCliRuntimeModules();
 
 	const userInstructionService = createUserInstructionConfigService({
-		skills: { workspacePath: workspaceRoot },
+		skills: {
+			workspacePath: workspaceRoot,
+			includePluginSkills: true,
+			cwd,
+		},
 		rules: { workspacePath: workspaceRoot },
 		workflows: { workspacePath: workspaceRoot },
 	});

--- a/sdk/apps/cli/src/runtime/interactive/session-runtime.ts
+++ b/sdk/apps/cli/src/runtime/interactive/session-runtime.ts
@@ -173,7 +173,6 @@ export function createInteractiveSessionRuntime(input: {
 			initialMessages: initial,
 			...(sessionMetadata ? { sessionMetadata } : {}),
 			localRuntime: {
-				userInstructionService: input.userInstructionService,
 				onTeamRestored: () => {},
 			},
 		});
@@ -200,7 +199,6 @@ export function createInteractiveSessionRuntime(input: {
 			interactive: true,
 			initialMessages: initial,
 			localRuntime: {
-				userInstructionService: input.userInstructionService,
 				onTeamRestored: () => {},
 			},
 		});
@@ -497,7 +495,6 @@ export function createInteractiveSessionRuntime(input: {
 				toolPolicies: input.config.toolPolicies,
 				interactive: true,
 				localRuntime: {
-					userInstructionService: input.userInstructionService,
 					onTeamRestored: () => {},
 				},
 			},

--- a/sdk/apps/cli/src/runtime/run-agent.test.ts
+++ b/sdk/apps/cli/src/runtime/run-agent.test.ts
@@ -174,6 +174,17 @@ describe("runAgent", () => {
 				prompt: "prompt",
 			}),
 		);
+		const startInput = sessionManagerMocks.start.mock.calls[0]?.[0] as
+			| { localRuntime?: Record<string, unknown> }
+			| undefined;
+		expect(startInput?.localRuntime).toEqual(
+			expect.objectContaining({
+				onTeamRestored: expect.any(Function),
+			}),
+		);
+		expect(startInput?.localRuntime).not.toHaveProperty(
+			"userInstructionService",
+		);
 	});
 
 	it("registers CLI capability factory through the CLI core facade", async () => {

--- a/sdk/apps/cli/src/runtime/run-agent.ts
+++ b/sdk/apps/cli/src/runtime/run-agent.ts
@@ -288,7 +288,6 @@ export async function runAgent(
 			userFiles: userFiles.length > 0 ? userFiles : undefined,
 			interactive: false,
 			localRuntime: {
-				userInstructionService,
 				onTeamRestored: () => emitTeamRestored(config),
 			},
 		});

--- a/sdk/packages/core/src/extensions/config/user-instruction-config-loader.ts
+++ b/sdk/packages/core/src/extensions/config/user-instruction-config-loader.ts
@@ -11,6 +11,7 @@ import {
 	WORKFLOWS_CONFIG_DIRECTORY_NAME,
 } from "@cline/shared/storage";
 import YAML from "yaml";
+import { resolveAgentPluginSkillDirectories } from "../plugin/plugin-config-loader";
 import {
 	type UnifiedConfigDefinition,
 	type UnifiedConfigFileCandidate,
@@ -82,6 +83,9 @@ export interface CreateInstructionWatcherOptions {
 export interface CreateSkillsConfigDefinitionOptions {
 	directories?: ReadonlyArray<string>;
 	workspacePath?: string;
+	includePluginSkills?: boolean;
+	pluginPaths?: ReadonlyArray<string>;
+	cwd?: string;
 }
 
 export interface CreateRulesConfigDefinitionOptions {
@@ -110,6 +114,39 @@ function isIgnorableDirectoryError(error: unknown): boolean {
 
 function isMarkdownFile(fileName: string): boolean {
 	return MARKDOWN_EXTENSIONS.has(extname(fileName).toLowerCase());
+}
+
+function dedupeDirectoryPaths(directories: ReadonlyArray<string>): string[] {
+	const deduped: string[] = [];
+	const seen = new Set<string>();
+	for (const directory of directories) {
+		const normalized = resolve(directory);
+		if (seen.has(normalized)) {
+			continue;
+		}
+		seen.add(normalized);
+		deduped.push(directory);
+	}
+	return deduped;
+}
+
+function resolveSkillDirectories(
+	options?: CreateSkillsConfigDefinitionOptions,
+): string[] {
+	const directories = [
+		...(options?.directories ??
+			resolveSkillsConfigSearchPaths(options?.workspacePath)),
+	];
+	if (options?.includePluginSkills) {
+		directories.push(
+			...resolveAgentPluginSkillDirectories({
+				pluginPaths: options.pluginPaths,
+				workspacePath: options.workspacePath,
+				cwd: options.cwd ?? options.workspacePath,
+			}),
+		);
+	}
+	return dedupeDirectoryPaths(directories);
 }
 
 async function discoverManagedPluginRoots(
@@ -480,16 +517,16 @@ async function discoverManagedWorkflowFiles(
 export function createSkillsConfigDefinition(
 	options?: CreateSkillsConfigDefinitionOptions,
 ): UnifiedConfigDefinition<"skill", SkillConfig> {
-	const directories =
-		options?.directories ??
-		resolveSkillsConfigSearchPaths(options?.workspacePath);
+	const directories = resolveSkillDirectories(options);
 	const managedRoot = options?.workspacePath
 		? join(options.workspacePath, ".cline")
 		: undefined;
 
 	return {
 		type: "skill",
-		directories: managedRoot ? [...directories, managedRoot] : directories,
+		directories: managedRoot
+			? dedupeDirectoryPaths([...directories, managedRoot])
+			: directories,
 		discoverFiles: discoverSkillFiles,
 		includeFile: (fileName) => fileName === SKILL_FILE_NAME,
 		parseFile: (context) =>

--- a/sdk/packages/core/src/extensions/config/user-instruction-config-loader.ts
+++ b/sdk/packages/core/src/extensions/config/user-instruction-config-loader.ts
@@ -84,6 +84,7 @@ export interface CreateSkillsConfigDefinitionOptions {
 	directories?: ReadonlyArray<string>;
 	workspacePath?: string;
 	includePluginSkills?: boolean;
+	pluginSkillDirectories?: ReadonlyArray<string>;
 	pluginPaths?: ReadonlyArray<string>;
 	cwd?: string;
 }
@@ -137,7 +138,9 @@ function resolveSkillDirectories(
 		...(options?.directories ??
 			resolveSkillsConfigSearchPaths(options?.workspacePath)),
 	];
-	if (options?.includePluginSkills) {
+	if (options?.pluginSkillDirectories) {
+		directories.push(...options.pluginSkillDirectories);
+	} else if (options?.includePluginSkills) {
 		directories.push(
 			...resolveAgentPluginSkillDirectories({
 				pluginPaths: options.pluginPaths,

--- a/sdk/packages/core/src/extensions/plugin/plugin-config-loader.test.ts
+++ b/sdk/packages/core/src/extensions/plugin/plugin-config-loader.test.ts
@@ -9,6 +9,7 @@ import {
 	resolveAgentPluginSkillDirectories,
 	resolveAndLoadAgentPlugins,
 	resolvePluginConfigSearchPaths,
+	resolvePluginSkillDirectoriesFromPaths,
 } from "./plugin-config-loader";
 
 describe("plugin-config-loader", () => {
@@ -151,6 +152,86 @@ describe("plugin-config-loader", () => {
 			});
 
 			expect(resolved).toEqual([join(pluginDir, "skills")]);
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+
+	it("skips missing configured plugin paths while resolving bundled skill directories", async () => {
+		const root = await mkdtemp(join(tmpdir(), "core-plugin-config-loader-"));
+		try {
+			process.env.HOME = root;
+			setHomeDir(root);
+			const pluginDir = join(root, "plugin-package");
+			const srcDir = join(pluginDir, "src");
+			const skillDir = join(pluginDir, "skills", "review");
+			await mkdir(srcDir, { recursive: true });
+			await mkdir(skillDir, { recursive: true });
+			await writeFile(
+				join(pluginDir, "package.json"),
+				JSON.stringify({
+					name: "plugin-package",
+					private: true,
+					cline: {
+						plugins: [
+							{
+								paths: ["./src/index.ts"],
+								capabilities: ["tools"],
+							},
+						],
+					},
+				}),
+				"utf8",
+			);
+			await writeFile(join(srcDir, "index.ts"), "export default {}", "utf8");
+			await writeFile(
+				join(skillDir, "SKILL.md"),
+				"---\nname: review\n---\nReview skill.",
+				"utf8",
+			);
+
+			const resolved = resolveAgentPluginSkillDirectories({
+				pluginPaths: ["./missing-plugin", "./plugin-package"],
+				cwd: root,
+				workspacePath: join(root, "workspace"),
+			});
+
+			expect(resolved).toEqual([join(pluginDir, "skills")]);
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+
+	it("resolves bundled skill directories from active plugin paths", async () => {
+		const root = await mkdtemp(join(tmpdir(), "core-plugin-config-loader-"));
+		try {
+			const pluginDir = join(root, "plugin-package");
+			const srcDir = join(pluginDir, "src");
+			const skillDir = join(pluginDir, "skills", "review");
+			await mkdir(srcDir, { recursive: true });
+			await mkdir(skillDir, { recursive: true });
+			await writeFile(
+				join(pluginDir, "package.json"),
+				JSON.stringify({
+					name: "plugin-package",
+					private: true,
+					cline: {
+						plugins: [{ paths: ["./src/index.ts"] }],
+					},
+				}),
+				"utf8",
+			);
+			const pluginPath = join(srcDir, "index.ts");
+			await writeFile(pluginPath, "export default {}", "utf8");
+			await writeFile(
+				join(skillDir, "SKILL.md"),
+				"---\nname: review\n---\nReview skill.",
+				"utf8",
+			);
+
+			expect(resolvePluginSkillDirectoriesFromPaths([pluginPath])).toEqual([
+				join(pluginDir, "skills"),
+			]);
 		} finally {
 			await rm(root, { recursive: true, force: true });
 		}
@@ -310,9 +391,59 @@ describe("plugin-config-loader", () => {
 			);
 			expect(testPlugins).toHaveLength(1);
 			expect(testPlugins[0]?.manifest.capabilities).toEqual(["commands"]);
+			expect(loaded.pluginPaths).toEqual([second]);
 			expect(loaded.failures).toHaveLength(1);
 			expect(loaded.warnings).toHaveLength(1);
 			expect(loaded.warnings[0]?.overriddenPluginPath).toBe(first);
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+
+	it("reports only provider and model compatible active plugin paths", async () => {
+		const root = await mkdtemp(join(tmpdir(), "core-plugin-config-loader-"));
+		try {
+			process.env.HOME = root;
+			setHomeDir(root);
+			const compatible = join(root, "compatible.js");
+			const incompatible = join(root, "incompatible.js");
+			await writeFile(
+				compatible,
+				`export default {
+	name: 'compatible-plugin',
+	manifest: {
+		capabilities: ['tools'],
+		providerIds: ['cline'],
+		modelIds: ['anthropic/claude-haiku-4.5']
+	}
+};`,
+				"utf8",
+			);
+			await writeFile(
+				incompatible,
+				`export default {
+	name: 'incompatible-plugin',
+	manifest: {
+		capabilities: ['tools'],
+		providerIds: ['openai'],
+		modelIds: ['gpt-5.4']
+	}
+};`,
+				"utf8",
+			);
+
+			const loaded = await resolveAndLoadAgentPlugins({
+				mode: "in_process",
+				pluginPaths: [compatible, incompatible],
+				cwd: root,
+				providerId: "cline",
+				modelId: "anthropic/claude-haiku-4.5",
+			});
+
+			expect(loaded.extensions.map((plugin) => plugin.name)).toEqual([
+				"compatible-plugin",
+			]);
+			expect(loaded.pluginPaths).toEqual([compatible]);
 		} finally {
 			await rm(root, { recursive: true, force: true });
 		}

--- a/sdk/packages/core/src/extensions/plugin/plugin-config-loader.test.ts
+++ b/sdk/packages/core/src/extensions/plugin/plugin-config-loader.test.ts
@@ -237,6 +237,35 @@ describe("plugin-config-loader", () => {
 		}
 	});
 
+	it("does not resolve ancestor skills from unrelated package roots", async () => {
+		const root = await mkdtemp(join(tmpdir(), "core-plugin-config-loader-"));
+		try {
+			const pluginSrcDir = join(root, "packages", "myplugin", "src");
+			const rootSkillDir = join(root, "skills", "private-root-skill");
+			await mkdir(pluginSrcDir, { recursive: true });
+			await mkdir(rootSkillDir, { recursive: true });
+			await writeFile(
+				join(root, "package.json"),
+				JSON.stringify({
+					name: "monorepo-root",
+					private: true,
+				}),
+				"utf8",
+			);
+			const pluginPath = join(pluginSrcDir, "index.ts");
+			await writeFile(pluginPath, "export default {}", "utf8");
+			await writeFile(
+				join(rootSkillDir, "SKILL.md"),
+				"---\nname: private-root-skill\n---\nPrivate root skill.",
+				"utf8",
+			);
+
+			expect(resolvePluginSkillDirectoriesFromPaths([pluginPath])).toEqual([]);
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+
 	it("resolves bundled skill directories from installed plugin wrappers", async () => {
 		const home = await mkdtemp(
 			join(tmpdir(), "core-plugin-config-loader-home-"),

--- a/sdk/packages/core/src/extensions/plugin/plugin-config-loader.test.ts
+++ b/sdk/packages/core/src/extensions/plugin/plugin-config-loader.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
 	discoverPluginModulePaths,
 	resolveAgentPluginPaths,
+	resolveAgentPluginSkillDirectories,
 	resolveAndLoadAgentPlugins,
 	resolvePluginConfigSearchPaths,
 } from "./plugin-config-loader";
@@ -107,6 +108,106 @@ describe("plugin-config-loader", () => {
 			expect(resolved).not.toContain(ignoredEntry);
 		} finally {
 			await rm(root, { recursive: true, force: true });
+		}
+	});
+
+	it("resolves bundled skill directories from configured plugin packages", async () => {
+		const root = await mkdtemp(join(tmpdir(), "core-plugin-config-loader-"));
+		try {
+			process.env.HOME = root;
+			setHomeDir(root);
+			const pluginDir = join(root, "plugin-package");
+			const srcDir = join(pluginDir, "src");
+			const skillDir = join(pluginDir, "skills", "review");
+			await mkdir(srcDir, { recursive: true });
+			await mkdir(skillDir, { recursive: true });
+			await writeFile(
+				join(pluginDir, "package.json"),
+				JSON.stringify({
+					name: "plugin-package",
+					private: true,
+					cline: {
+						plugins: [
+							{
+								paths: ["./src/index.ts"],
+								capabilities: ["tools"],
+							},
+						],
+					},
+				}),
+				"utf8",
+			);
+			await writeFile(join(srcDir, "index.ts"), "export default {}", "utf8");
+			await writeFile(
+				join(skillDir, "SKILL.md"),
+				"---\nname: review\n---\nReview skill.",
+				"utf8",
+			);
+
+			const resolved = resolveAgentPluginSkillDirectories({
+				pluginPaths: ["./plugin-package"],
+				cwd: root,
+				workspacePath: join(root, "workspace"),
+			});
+
+			expect(resolved).toEqual([join(pluginDir, "skills")]);
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+
+	it("resolves bundled skill directories from installed plugin wrappers", async () => {
+		const home = await mkdtemp(
+			join(tmpdir(), "core-plugin-config-loader-home-"),
+		);
+		const workspace = await mkdtemp(
+			join(tmpdir(), "core-plugin-config-loader-workspace-"),
+		);
+		try {
+			process.env.HOME = home;
+			setHomeDir(home);
+			const installRoot = join(
+				workspace,
+				".cline",
+				"plugins",
+				"_installed",
+				"local",
+				"demo",
+			);
+			const packageRoot = join(installRoot, "package");
+			const skillDir = join(packageRoot, "skills", "review");
+			await mkdir(skillDir, { recursive: true });
+			await writeFile(
+				join(installRoot, "package.json"),
+				JSON.stringify({
+					name: "cline-installed-plugin-demo",
+					private: true,
+					cline: {
+						plugins: [{ paths: ["./package/index.ts"] }],
+					},
+				}),
+				"utf8",
+			);
+			await writeFile(
+				join(packageRoot, "index.ts"),
+				"export default {}",
+				"utf8",
+			);
+			await writeFile(
+				join(skillDir, "SKILL.md"),
+				"---\nname: review\n---\nReview skill.",
+				"utf8",
+			);
+
+			const resolved = resolveAgentPluginSkillDirectories({
+				workspacePath: workspace,
+				cwd: workspace,
+			});
+
+			expect(resolved).toEqual([join(packageRoot, "skills")]);
+		} finally {
+			await rm(home, { recursive: true, force: true });
+			await rm(workspace, { recursive: true, force: true });
 		}
 	});
 

--- a/sdk/packages/core/src/extensions/plugin/plugin-config-loader.ts
+++ b/sdk/packages/core/src/extensions/plugin/plugin-config-loader.ts
@@ -1,4 +1,4 @@
-import { existsSync, statSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
 import type {
 	AgentConfig,
@@ -88,10 +88,59 @@ function resolveConfiguredPluginModulePathsBestEffort(
 	return resolvedPaths;
 }
 
-function isInstalledPackageDirectory(path: string): boolean {
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function readDeclaredPluginEntryPaths(packageRoot: string): string[] {
+	try {
+		const parsed = JSON.parse(
+			readFileSync(join(packageRoot, PACKAGE_JSON_FILE_NAME), "utf8"),
+		) as unknown;
+		if (!isRecord(parsed) || !isRecord(parsed.cline)) {
+			return [];
+		}
+		const entries = parsed.cline.plugins;
+		if (!Array.isArray(entries)) {
+			return [];
+		}
+		const paths: string[] = [];
+		for (const entry of entries) {
+			if (typeof entry === "string") {
+				paths.push(entry);
+				continue;
+			}
+			if (!isRecord(entry) || !Array.isArray(entry.paths)) {
+				continue;
+			}
+			for (const path of entry.paths) {
+				if (typeof path === "string") {
+					paths.push(path);
+				}
+			}
+		}
+		return paths;
+	} catch {
+		return [];
+	}
+}
+
+function packageDeclaresPluginEntry(
+	packageRoot: string,
+	entryPath: string,
+): boolean {
+	const normalizedEntryPath = resolve(entryPath);
+	return readDeclaredPluginEntryPaths(packageRoot).some(
+		(declaredPath) =>
+			resolve(packageRoot, declaredPath) === normalizedEntryPath,
+	);
+}
+
+function isInstalledPackageDirectory(path: string, entryPath: string): boolean {
 	return (
 		basename(path) === INSTALLED_PACKAGE_DIRECTORY_NAME &&
-		existsSync(join(dirname(path), PACKAGE_JSON_FILE_NAME))
+		existsSync(join(dirname(path), PACKAGE_JSON_FILE_NAME)) &&
+		packageDeclaresPluginEntry(dirname(path), entryPath)
 	);
 }
 
@@ -101,11 +150,18 @@ function collectPluginSkillRootCandidates(entryPath: string): string[] {
 	let current = dirname(normalizedEntryPath);
 
 	while (true) {
-		if (isInstalledPackageDirectory(current)) {
+		if (isInstalledPackageDirectory(current, normalizedEntryPath)) {
 			candidates.push(current);
+			break;
 		}
 		if (existsSync(join(current, PACKAGE_JSON_FILE_NAME))) {
-			candidates.push(current);
+			// Do not keep walking after the first package boundary. A monorepo
+			// plugin entry can live under packages/foo/src/index.ts with no local
+			// package.json; climbing to the workspace root would expose unrelated
+			// root skills/. Only package manifests that declare this entry own skills.
+			if (packageDeclaresPluginEntry(current, normalizedEntryPath)) {
+				candidates.push(current);
+			}
 			break;
 		}
 
@@ -116,7 +172,6 @@ function collectPluginSkillRootCandidates(entryPath: string): string[] {
 		current = parent;
 	}
 
-	candidates.push(dirname(normalizedEntryPath));
 	return dedupePaths(candidates);
 }
 

--- a/sdk/packages/core/src/extensions/plugin/plugin-config-loader.ts
+++ b/sdk/packages/core/src/extensions/plugin/plugin-config-loader.ts
@@ -60,6 +60,34 @@ function dedupePaths(paths: Iterable<string>): string[] {
 	return deduped;
 }
 
+function mergePluginPaths(paths: Iterable<string>): string[] {
+	const deduped = dedupePaths(paths);
+	return filterDisabledPluginPaths(deduped);
+}
+
+function resolveDiscoveredPluginPaths(
+	workspacePath: string | undefined,
+): string[] {
+	return resolvePluginConfigSearchPaths(workspacePath)
+		.flatMap((directoryPath) => discoverPluginModulePaths(directoryPath))
+		.filter((path) => existsSync(path));
+}
+
+function resolveConfiguredPluginModulePathsBestEffort(
+	pluginPaths: ReadonlyArray<string>,
+	cwd: string,
+): string[] {
+	const resolvedPaths: string[] = [];
+	for (const pluginPath of pluginPaths) {
+		try {
+			resolvedPaths.push(
+				...resolveConfiguredPluginModulePaths([pluginPath], cwd),
+			);
+		} catch {}
+	}
+	return resolvedPaths;
+}
+
 function isInstalledPackageDirectory(path: string): boolean {
 	return (
 		basename(path) === INSTALLED_PACKAGE_DIRECTORY_NAME &&
@@ -96,33 +124,37 @@ export function resolveAgentPluginPaths(
 	options: ResolveAgentPluginPathsOptions = {},
 ): string[] {
 	const cwd = options.cwd ?? process.cwd();
-	const discoveredFromSearchPaths = resolvePluginConfigSearchPaths(
+	const discoveredFromSearchPaths = resolveDiscoveredPluginPaths(
 		options.workspacePath,
-	)
-		.flatMap((directoryPath) => discoverPluginModulePaths(directoryPath))
-		.filter((path) => existsSync(path));
+	);
 	const configuredPaths = resolveConfiguredPluginModulePaths(
 		options.pluginPaths ?? [],
 		cwd,
 	);
 
-	const deduped: string[] = [];
-	const seen = new Set<string>();
-	for (const path of [...configuredPaths, ...discoveredFromSearchPaths]) {
-		if (seen.has(path)) {
-			continue;
-		}
-		seen.add(path);
-		deduped.push(path);
-	}
-	return filterDisabledPluginPaths(deduped);
+	return mergePluginPaths([...configuredPaths, ...discoveredFromSearchPaths]);
 }
 
-export function resolveAgentPluginSkillDirectories(
+function resolveAgentPluginPathsBestEffort(
 	options: ResolveAgentPluginPathsOptions = {},
 ): string[] {
+	const cwd = options.cwd ?? process.cwd();
+	const discoveredFromSearchPaths = resolveDiscoveredPluginPaths(
+		options.workspacePath,
+	);
+	const configuredPaths = resolveConfiguredPluginModulePathsBestEffort(
+		options.pluginPaths ?? [],
+		cwd,
+	);
+
+	return mergePluginPaths([...configuredPaths, ...discoveredFromSearchPaths]);
+}
+
+export function resolvePluginSkillDirectoriesFromPaths(
+	pluginPaths: ReadonlyArray<string>,
+): string[] {
 	const directories: string[] = [];
-	for (const pluginPath of resolveAgentPluginPaths(options)) {
+	for (const pluginPath of pluginPaths) {
 		for (const root of collectPluginSkillRootCandidates(pluginPath)) {
 			const skillDirectory = join(root, SKILLS_CONFIG_DIRECTORY_NAME);
 			if (isDirectory(skillDirectory)) {
@@ -131,6 +163,14 @@ export function resolveAgentPluginSkillDirectories(
 		}
 	}
 	return dedupePaths(directories);
+}
+
+export function resolveAgentPluginSkillDirectories(
+	options: ResolveAgentPluginPathsOptions = {},
+): string[] {
+	return resolvePluginSkillDirectoriesFromPaths(
+		resolveAgentPluginPathsBestEffort(options),
+	);
 }
 
 export interface ResolveAndLoadAgentPluginsOptions
@@ -161,12 +201,13 @@ export async function resolveAndLoadAgentPlugins(
 ): Promise<
 	{
 		extensions: AgentPlugin[];
+		pluginPaths: string[];
 		shutdown?: () => Promise<void>;
 	} & PluginLoadDiagnostics
 > {
 	const paths = resolveAgentPluginPaths(options);
 	if (paths.length === 0) {
-		return { extensions: [], failures: [], warnings: [] };
+		return { extensions: [], failures: [], warnings: [], pluginPaths: [] };
 	}
 
 	if (options.mode === "in_process") {
@@ -186,6 +227,7 @@ export async function resolveAndLoadAgentPlugins(
 		return {
 			extensions: report.plugins,
 			failures: report.failures,
+			pluginPaths: report.pluginPaths,
 			warnings: report.warnings,
 		};
 	}
@@ -210,6 +252,7 @@ export async function resolveAndLoadAgentPlugins(
 		extensions: sandboxed.extensions ?? [],
 		shutdown: sandboxed.shutdown,
 		failures: sandboxed.failures,
+		pluginPaths: sandboxed.pluginPaths,
 		warnings: sandboxed.warnings,
 	};
 }

--- a/sdk/packages/core/src/extensions/plugin/plugin-config-loader.ts
+++ b/sdk/packages/core/src/extensions/plugin/plugin-config-loader.ts
@@ -1,4 +1,5 @@
-import { existsSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
 import type {
 	AgentConfig,
 	PluginSetupContext,
@@ -8,6 +9,7 @@ import {
 	discoverPluginModulePaths as discoverPluginModulePathsFromShared,
 	resolveConfiguredPluginModulePaths,
 	resolvePluginConfigSearchPaths as resolvePluginConfigSearchPathsFromShared,
+	SKILLS_CONFIG_DIRECTORY_NAME,
 } from "@cline/shared/storage";
 import { filterDisabledPluginPaths } from "../../services/global-settings";
 import type { PluginLoadDiagnostics } from "./plugin-load-report";
@@ -16,6 +18,9 @@ import { loadSandboxedPlugins } from "./plugin-sandbox";
 import type { PluginTargeting } from "./plugin-targeting";
 
 type AgentPlugin = NonNullable<AgentConfig["extensions"]>[number];
+
+const PACKAGE_JSON_FILE_NAME = "package.json";
+const INSTALLED_PACKAGE_DIRECTORY_NAME = "package";
 
 export function resolvePluginConfigSearchPaths(
 	workspacePath?: string,
@@ -31,6 +36,60 @@ export interface ResolveAgentPluginPathsOptions {
 	pluginPaths?: ReadonlyArray<string>;
 	workspacePath?: string;
 	cwd?: string;
+}
+
+function isDirectory(path: string): boolean {
+	try {
+		return existsSync(path) && statSync(path).isDirectory();
+	} catch {
+		return false;
+	}
+}
+
+function dedupePaths(paths: Iterable<string>): string[] {
+	const deduped: string[] = [];
+	const seen = new Set<string>();
+	for (const path of paths) {
+		const normalizedPath = resolve(path);
+		if (seen.has(normalizedPath)) {
+			continue;
+		}
+		seen.add(normalizedPath);
+		deduped.push(normalizedPath);
+	}
+	return deduped;
+}
+
+function isInstalledPackageDirectory(path: string): boolean {
+	return (
+		basename(path) === INSTALLED_PACKAGE_DIRECTORY_NAME &&
+		existsSync(join(dirname(path), PACKAGE_JSON_FILE_NAME))
+	);
+}
+
+function collectPluginSkillRootCandidates(entryPath: string): string[] {
+	const normalizedEntryPath = resolve(entryPath);
+	const candidates: string[] = [];
+	let current = dirname(normalizedEntryPath);
+
+	while (true) {
+		if (isInstalledPackageDirectory(current)) {
+			candidates.push(current);
+		}
+		if (existsSync(join(current, PACKAGE_JSON_FILE_NAME))) {
+			candidates.push(current);
+			break;
+		}
+
+		const parent = dirname(current);
+		if (parent === current) {
+			break;
+		}
+		current = parent;
+	}
+
+	candidates.push(dirname(normalizedEntryPath));
+	return dedupePaths(candidates);
 }
 
 export function resolveAgentPluginPaths(
@@ -57,6 +116,21 @@ export function resolveAgentPluginPaths(
 		deduped.push(path);
 	}
 	return filterDisabledPluginPaths(deduped);
+}
+
+export function resolveAgentPluginSkillDirectories(
+	options: ResolveAgentPluginPathsOptions = {},
+): string[] {
+	const directories: string[] = [];
+	for (const pluginPath of resolveAgentPluginPaths(options)) {
+		for (const root of collectPluginSkillRootCandidates(pluginPath)) {
+			const skillDirectory = join(root, SKILLS_CONFIG_DIRECTORY_NAME);
+			if (isDirectory(skillDirectory)) {
+				directories.push(skillDirectory);
+			}
+		}
+	}
+	return dedupePaths(directories);
 }
 
 export interface ResolveAndLoadAgentPluginsOptions

--- a/sdk/packages/core/src/extensions/plugin/plugin-loader.ts
+++ b/sdk/packages/core/src/extensions/plugin/plugin-loader.ts
@@ -162,6 +162,7 @@ export async function loadAgentPluginsFromPathsWithDiagnostics(
 	options: LoadAgentPluginFromPathOptions & PluginTargeting = {},
 ): Promise<{
 	plugins: AgentExtension[];
+	pluginPaths: string[];
 	failures: PluginInitializationFailure[];
 	warnings: PluginInitializationWarning[];
 }> {
@@ -201,10 +202,12 @@ export async function loadAgentPluginsFromPathsWithDiagnostics(
 		}
 	}
 
+	const loadedEntries = [...loadedByName.values()].sort(
+		(left, right) => left.order - right.order,
+	);
 	return {
-		plugins: [...loadedByName.values()]
-			.sort((left, right) => left.order - right.order)
-			.map((entry) => entry.plugin),
+		plugins: loadedEntries.map((entry) => entry.plugin),
+		pluginPaths: loadedEntries.map((entry) => entry.pluginPath),
 		failures,
 		warnings,
 	};

--- a/sdk/packages/core/src/extensions/plugin/plugin-sandbox.ts
+++ b/sdk/packages/core/src/extensions/plugin/plugin-sandbox.ts
@@ -221,6 +221,7 @@ export async function loadSandboxedPlugins(
 ): Promise<
 	{
 		extensions: AgentConfig["extensions"];
+		pluginPaths: string[];
 		shutdown: () => Promise<void>;
 	} & PluginLoadDiagnostics
 > {
@@ -330,6 +331,7 @@ export async function loadSandboxedPlugins(
 	return {
 		extensions,
 		failures: initialized.failures,
+		pluginPaths: descriptors.map((descriptor) => descriptor.pluginPath),
 		shutdown: async () => {
 			await sandbox.shutdown();
 		},

--- a/sdk/packages/core/src/runtime/orchestration/runtime-builder.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-builder.test.ts
@@ -606,6 +606,64 @@ Use the review plugin guidance.`,
 		await runtime.shutdown("test");
 	});
 
+	it("uses explicit plugin skill directories instead of rediscovering plugins", async () => {
+		const cwd = mkdtempSync(
+			join(tmpdir(), "runtime-builder-active-plugin-skills-"),
+		);
+		process.env.HOME = cwd;
+		setHomeDir(cwd);
+		const pluginDir = join(cwd, ".cline", "plugins", "review-plugin");
+		const skillRoot = join(pluginDir, "skills");
+		const skillDir = join(skillRoot, "review");
+		mkdirSync(skillDir, { recursive: true });
+		writeFileSync(
+			join(pluginDir, "package.json"),
+			JSON.stringify({
+				name: "review-plugin",
+				private: true,
+				cline: {
+					plugins: [{ paths: ["./index.ts"] }],
+				},
+			}),
+			"utf8",
+		);
+		writeFileSync(join(pluginDir, "index.ts"), "export default {}", "utf8");
+		writeFileSync(
+			join(skillDir, "SKILL.md"),
+			`---
+name: review
+description: Review code
+---
+Use the review plugin guidance.`,
+			"utf8",
+		);
+
+		const inactiveRuntime = await new DefaultRuntimeBuilder().build({
+			config: makeBaseConfig({ cwd }),
+			pluginSkillDirectories: [],
+		});
+		const inactiveExtensionTools = await collectExtensionTools(
+			inactiveRuntime.extensions,
+		);
+		expect(inactiveExtensionTools.map((tool) => tool.name)).not.toContain(
+			"skills",
+		);
+		await inactiveRuntime.shutdown("test");
+
+		const activeRuntime = await new DefaultRuntimeBuilder().build({
+			config: makeBaseConfig({ cwd }),
+			pluginSkillDirectories: [skillRoot],
+		});
+		const activeExtensionTools = await collectExtensionTools(
+			activeRuntime.extensions,
+		);
+		const skillsTool = activeExtensionTools.find(
+			(tool) => tool.name === "skills",
+		);
+		expect(skillsTool).toBeDefined();
+		await activeRuntime.shutdown("test");
+	});
+
 	it("does not include bundled plugin skills when plugins are disabled", async () => {
 		const cwd = mkdtempSync(
 			join(tmpdir(), "runtime-builder-plugin-skills-disabled-"),

--- a/sdk/packages/core/src/runtime/orchestration/runtime-builder.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-builder.test.ts
@@ -7,6 +7,7 @@ import {
 	createContributionRegistry,
 	type Message,
 } from "@cline/shared";
+import { setHomeDir } from "@cline/shared/storage";
 import { afterEach, describe, expect, it } from "vitest";
 import { createUserInstructionConfigService } from "../../extensions/config";
 import { TelemetryService } from "../../services/telemetry/TelemetryService";
@@ -53,9 +54,12 @@ async function collectExtensionTools(
 }
 
 describe("DefaultRuntimeBuilder", () => {
+	const previousHome = process.env.HOME;
 	const previousGlobalSettingsPath = process.env.CLINE_GLOBAL_SETTINGS_PATH;
 
 	afterEach(() => {
+		process.env.HOME = previousHome;
+		setHomeDir(previousHome ?? "~");
 		process.env.CLINE_GLOBAL_SETTINGS_PATH = previousGlobalSettingsPath;
 	});
 
@@ -542,6 +546,104 @@ Use conventional commits.`,
 
 		expect(runtime.tools.map((tool) => tool.name)).not.toContain("skills");
 		expect(extensionTools.map((tool) => tool.name)).toContain("skills");
+		await runtime.shutdown("test");
+	});
+
+	it("includes skills bundled in discovered plugin packages", async () => {
+		const cwd = mkdtempSync(join(tmpdir(), "runtime-builder-plugin-skills-"));
+		process.env.HOME = cwd;
+		setHomeDir(cwd);
+		const pluginDir = join(cwd, ".cline", "plugins", "review-plugin");
+		const skillDir = join(pluginDir, "skills", "review");
+		mkdirSync(skillDir, { recursive: true });
+		writeFileSync(
+			join(pluginDir, "package.json"),
+			JSON.stringify(
+				{
+					name: "review-plugin",
+					private: true,
+					cline: {
+						plugins: [{ paths: ["./index.ts"] }],
+					},
+				},
+				null,
+				2,
+			),
+			"utf8",
+		);
+		writeFileSync(join(pluginDir, "index.ts"), "export default {}", "utf8");
+		writeFileSync(
+			join(skillDir, "SKILL.md"),
+			`---
+name: review
+description: Review code
+---
+Use the review plugin guidance.`,
+			"utf8",
+		);
+
+		const runtime = await new DefaultRuntimeBuilder().build({
+			config: makeBaseConfig({ cwd }),
+		});
+		const extensionTools = await collectExtensionTools(runtime.extensions);
+		const skillsTool = extensionTools.find((tool) => tool.name === "skills");
+		expect(skillsTool).toBeDefined();
+		if (!skillsTool) {
+			throw new Error("Expected skills tool.");
+		}
+
+		const result = await skillsTool.execute(
+			{ skill: "review" },
+			{
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 1,
+			},
+		);
+		expect(result).toContain("<command-name>review</command-name>");
+		expect(result).toContain("Use the review plugin guidance.");
+
+		await runtime.shutdown("test");
+	});
+
+	it("does not include bundled plugin skills when plugins are disabled", async () => {
+		const cwd = mkdtempSync(
+			join(tmpdir(), "runtime-builder-plugin-skills-disabled-"),
+		);
+		process.env.HOME = cwd;
+		setHomeDir(cwd);
+		const pluginDir = join(cwd, ".cline", "plugins", "review-plugin");
+		const skillDir = join(pluginDir, "skills", "review");
+		mkdirSync(skillDir, { recursive: true });
+		writeFileSync(
+			join(pluginDir, "package.json"),
+			JSON.stringify({
+				name: "review-plugin",
+				private: true,
+				cline: {
+					plugins: [{ paths: ["./index.ts"] }],
+				},
+			}),
+			"utf8",
+		);
+		writeFileSync(join(pluginDir, "index.ts"), "export default {}", "utf8");
+		writeFileSync(
+			join(skillDir, "SKILL.md"),
+			`---
+name: review
+---
+Use the review plugin guidance.`,
+			"utf8",
+		);
+
+		const runtime = await new DefaultRuntimeBuilder().build({
+			config: makeBaseConfig({ cwd }),
+			configExtensions: ["skills"],
+		});
+		const extensionTools = await collectExtensionTools(runtime.extensions);
+
+		expect(extensionTools.map((tool) => tool.name)).not.toContain("skills");
+
 		await runtime.shutdown("test");
 	});
 

--- a/sdk/packages/core/src/runtime/orchestration/runtime-builder.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-builder.ts
@@ -317,6 +317,7 @@ export class DefaultRuntimeBuilder implements RuntimeBuilder {
 		const rulesEnabled = hasConfigExtension(configExtensions, "rules");
 		const skillsEnabled = hasConfigExtension(configExtensions, "skills");
 		const workflowsEnabled = hasConfigExtension(configExtensions, "workflows");
+		const pluginsEnabled = hasConfigExtension(configExtensions, "plugins");
 		const userInstructionsEnabled =
 			rulesEnabled || skillsEnabled || workflowsEnabled;
 		let teamToolsRegistered = false;
@@ -328,7 +329,14 @@ export class DefaultRuntimeBuilder implements RuntimeBuilder {
 
 		if (!userInstructionService && userInstructionsEnabled) {
 			userInstructionService = createUserInstructionConfigService({
-				skills: { workspacePath: config.cwd },
+				skills: skillsEnabled
+					? {
+							workspacePath: config.cwd,
+							includePluginSkills: pluginsEnabled,
+							pluginPaths: config.pluginPaths,
+							cwd: config.cwd,
+						}
+					: { workspacePath: config.cwd },
 				rules: { workspacePath: config.cwd },
 				workflows: { workspacePath: config.cwd },
 			});

--- a/sdk/packages/core/src/runtime/orchestration/runtime-builder.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-builder.ts
@@ -333,6 +333,9 @@ export class DefaultRuntimeBuilder implements RuntimeBuilder {
 					? {
 							workspacePath: config.cwd,
 							includePluginSkills: pluginsEnabled,
+							pluginSkillDirectories: pluginsEnabled
+								? input.pluginSkillDirectories
+								: undefined,
 							pluginPaths: config.pluginPaths,
 							cwd: config.cwd,
 						}

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime.ts
@@ -52,6 +52,7 @@ export interface RuntimeBuilderInput {
 	createSpawnTool?: () => AgentTool;
 	onTeamRestored?: () => void;
 	userInstructionService?: UserInstructionConfigService;
+	pluginSkillDirectories?: ReadonlyArray<string>;
 	configExtensions?: RuntimeConfigExtensionKind[];
 	toolExecutors?: Partial<ToolExecutors>;
 	workspaceManager?: WorkspaceManager;

--- a/sdk/packages/core/src/services/local-runtime-bootstrap.test.ts
+++ b/sdk/packages/core/src/services/local-runtime-bootstrap.test.ts
@@ -143,8 +143,10 @@ describe("prepareLocalRuntimeBootstrap", () => {
 					},
 				],
 				failures: [],
+				pluginPaths: [],
 				warnings: [],
 			})),
+			resolvePluginSkillDirectoriesFromPaths: vi.fn(() => []),
 		}));
 
 		const { prepareLocalRuntimeBootstrap } = await import(
@@ -228,9 +230,14 @@ describe("prepareLocalRuntimeBootstrap", () => {
 									},
 								],
 					failures: [],
+					pluginPaths:
+						providerId === "cline" && modelId === "anthropic/claude-haiku-4.5"
+							? ["/tmp/compatible-plugin.js"]
+							: [],
 					warnings: [],
 				}),
 			),
+			resolvePluginSkillDirectoriesFromPaths: vi.fn(() => []),
 		}));
 
 		const { prepareLocalRuntimeBootstrap } = await import(
@@ -267,6 +274,51 @@ describe("prepareLocalRuntimeBootstrap", () => {
 		);
 
 		expect(registeredTools).toEqual(["compatible_tool"]);
+	});
+
+	it("threads active plugin skill directories into the runtime builder input", async () => {
+		vi.resetModules();
+		resetModulesAfterEach = true;
+		const activePluginPath = "/tmp/review-plugin/index.js";
+		const activeSkillDirectory = "/tmp/review-plugin/skills";
+		const resolvePluginSkillDirectoriesFromPaths = vi.fn(() => [
+			activeSkillDirectory,
+		]);
+		vi.doMock("../extensions/plugin/plugin-config-loader", () => ({
+			resolveAndLoadAgentPlugins: vi.fn(async () => ({
+				extensions: [],
+				failures: [],
+				pluginPaths: [activePluginPath],
+				warnings: [],
+			})),
+			resolvePluginSkillDirectoriesFromPaths,
+		}));
+
+		const { prepareLocalRuntimeBootstrap } = await import(
+			"./local-runtime-bootstrap"
+		);
+		const bootstrap = await prepareLocalRuntimeBootstrap({
+			input: createStartInput(),
+			localRuntime: {
+				configExtensions: ["plugins", "skills"],
+			},
+			sessionId: "sess-1",
+			providerSettingsManager: createProviderSettingsManager() as never,
+			defaultTelemetry: undefined,
+			defaultToolPolicies: undefined,
+			onPluginEvent: () => {},
+			onTeamEvent: () => {},
+			createSpawnTool,
+			readSessionMetadata: async () => undefined,
+			writeSessionMetadata: async () => {},
+		});
+
+		expect(resolvePluginSkillDirectoriesFromPaths).toHaveBeenCalledWith([
+			activePluginPath,
+		]);
+		expect(bootstrap.runtimeBuilderInput.pluginSkillDirectories).toEqual([
+			activeSkillDirectory,
+		]);
 	});
 
 	it("threads defaultFetch into providerConfig.fetch", async () => {

--- a/sdk/packages/core/src/services/local-runtime-bootstrap.ts
+++ b/sdk/packages/core/src/services/local-runtime-bootstrap.ts
@@ -11,7 +11,10 @@ import type {
 } from "@cline/shared";
 import { hasRuntimeConfigExtension } from "@cline/shared";
 import { decodeJwtPayload } from "../auth/utils";
-import { resolveAndLoadAgentPlugins } from "../extensions/plugin/plugin-config-loader";
+import {
+	resolveAndLoadAgentPlugins,
+	resolvePluginSkillDirectoriesFromPaths,
+} from "../extensions/plugin/plugin-config-loader";
 import type {
 	PluginInitializationFailure,
 	PluginInitializationWarning,
@@ -383,6 +386,9 @@ export async function prepareLocalRuntimeBootstrap(
 			filterExtensionToolRegistrations(loadedPlugins?.extensions),
 		),
 	);
+	const pluginSkillDirectories = hasConfigExtension(configExtensions, "plugins")
+		? resolvePluginSkillDirectoriesFromPaths(loadedPlugins?.pluginPaths ?? [])
+		: undefined;
 	const baseConfig: CoreSessionConfig = {
 		...input.config,
 		...(localConfig ?? {}),
@@ -453,6 +459,7 @@ export async function prepareLocalRuntimeBootstrap(
 			createSpawnTool,
 			onTeamRestored: onTeamRestored,
 			userInstructionService: userInstructionService,
+			pluginSkillDirectories,
 			configExtensions: configExtensions,
 			toolExecutors: effectiveToolExecutors,
 			workspaceManager,

--- a/sdk/packages/core/src/settings/settings-service.ts
+++ b/sdk/packages/core/src/settings/settings-service.ts
@@ -76,8 +76,13 @@ async function withUserInstructionService<T>(
 	if (!workspaceRoot) {
 		return await run(undefined);
 	}
+	const cwd = input.cwd?.trim() || workspaceRoot;
 	const service = createUserInstructionConfigService({
-		skills: { workspacePath: workspaceRoot },
+		skills: {
+			workspacePath: workspaceRoot,
+			includePluginSkills: true,
+			cwd,
+		},
 		rules: { workspacePath: workspaceRoot },
 		workflows: { workspacePath: workspaceRoot },
 	});


### PR DESCRIPTION
A plugin package can include a normal skill directory under `skills/`, and Cline will discover those skills when the plugin is installed or loaded. Plugin authors do not need to call a registration API, copy files into a managed config directory, or invent a plugin-specific skill format.

For example:

```txt
cline-github-plugin/
  package.json
  index.ts
  skills/
    triage/
      SKILL.md
```

That `SKILL.md` is parsed by the existing skill loader, with the same frontmatter and instruction-body behavior as workspace, global, and managed skills. The plugin system only contributes more skill search roots.

The main design choice here is to keep bundled skills file-backed. Earlier iterations explored an imperative plugin API, but that made skills feel different from the rest of the skill ecosystem and raised awkward questions about progressive disclosure files, package assets, update behavior, and uninstall cleanup. The final version instead follows the shape of existing plugin and instruction discovery:

- Resolve plugin entry files using the existing plugin discovery path.
- Derive likely package roots from those entry files.
- Add `<plugin root>/skills` to the skill loader when that directory exists.
- Let the existing skill parser, settings list, runtime extension, and `/skills` flow handle the rest.

The package-root derivation is the only non-obvious part. Plugin discovery currently returns entry files, not package roots, so this PR walks upward from each resolved plugin entry until it finds a package boundary. It also handles the CLI installer wrapper layout, where installed packages live under `.cline/plugins/_installed/.../package` and the wrapper `package.json` points at `./package/index.ts`. That matters for `cline plugin install <local path>`, git installs, and npm installs because the skill files need to be discovered from the copied or installed package contents, not the wrapper itself.

Runtime behavior is gated the same way plugins already are. If a runtime disables the `plugins` config extension, bundled plugin skills are not added. Normal workspace and global skills still work through the existing `skills` config extension. Disabled plugins are filtered before their skill directories are considered.

The CLI config command and core settings service were updated to use the same plugin-skill-aware instruction service as runtime startup, so `cline config skills`, settings views, and the interactive `/skills` picker agree on what is available.

Docs now show the package layout for bundled skills and link authors to the normal skills documentation for the actual skill format. One packaging caveat for authors is that published npm packages must include the `skills/` directory in their tarball if they use `files` or `.npmignore`.
