### PR TITLE
fix: keep file search fallback alive

### DIFF
--- a/apps/vscode/src/services/search/file-search.ts
+++ b/apps/vscode/src/services/search/file-search.ts
@@ -38,7 +38,7 @@ export async function executeRipgrepForFiles(
 	workspacePath: string,
 	limit = 5000,
 ): Promise<{ path: string; type: "file" | "folder"; label?: string }[]> {
-	const rgPath = await getBinaryLocation("rg")
+	const rgPath = await resolveRipgrepPath()
 
 	return new Promise((resolve, reject) => {
 		// Arguments for ripgrep to list files, follow symlinks, include hidden, and exclude common directories
@@ -142,11 +142,45 @@ export async function executeRipgrepForFiles(
 	})
 }
 
+async function resolveRipgrepPath(): Promise<string> {
+	try {
+		return await getBinaryLocation("rg")
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		const fallback = await findSystemRipgrep()
+		Logger.warn(`[file-search] bundled ripgrep unavailable, trying ${fallback}: ${message}`)
+		return fallback
+	}
+}
+
+async function findSystemRipgrep(): Promise<string> {
+	const fallback = process.platform === "win32" ? "rg.exe" : "rg"
+	const candidates =
+		process.platform === "win32" ? [] : ["/usr/bin/rg", "/opt/homebrew/bin/rg", "/usr/local/bin/rg"]
+
+	for (const candidate of candidates) {
+		try {
+			await fs.promises.access(candidate, fs.constants.X_OK)
+			return candidate
+		} catch {
+			// Keep looking; the bare command is the final PATH-based fallback.
+		}
+	}
+
+	return fallback
+}
+
 // Get currently active/open files from VSCode tabs using hostbridge
 async function getActiveFiles(): Promise<Set<string>> {
-	const request = GetOpenTabsRequest.create({})
-	const response = await HostProvider.window.getOpenTabs(request)
-	return new Set(response.paths)
+	try {
+		const request = GetOpenTabsRequest.create({})
+		const response = await HostProvider.window.getOpenTabs(request)
+		return new Set(response.paths)
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		Logger.warn(`[file-search] failed to read open tabs, continuing without active-file boost: ${message}`)
+		return new Set()
+	}
 }
 
 // Maximum number of candidates to ask the host for. The result is filtered &

--- a/apps/vscode/src/test/services/search/file-search.test.ts
+++ b/apps/vscode/src/test/services/search/file-search.test.ts
@@ -28,6 +28,8 @@ describe("File Search", () => {
 		const accessStub = sandbox.stub(fs.promises, "access")
 		accessStub.withArgs("/mock/path/rg").resolves()
 		accessStub.withArgs("/mock/path/rg.exe").resolves()
+		accessStub.withArgs("/mock/path/to/binary/rg").resolves()
+		accessStub.withArgs("/mock/path/to/binary/rg.exe").resolves()
 
 		setVscodeHostProviderMock()
 	})
@@ -163,6 +165,46 @@ describe("File Search", () => {
 			should(err).have.property("name", "RipgrepError")
 			should(err.stderr).match(/No such file or directory/)
 		})
+
+		it("falls back to a system ripgrep when the bundled binary path is missing", async () => {
+			setVscodeHostProviderMock({
+				getBinaryLocation: async () => "/missing/rg",
+			})
+
+			const accessStub = fs.promises.access as sinon.SinonStub
+			accessStub.withArgs("/missing/rg").rejects(new Error("missing"))
+			accessStub.withArgs("/usr/bin/rg", fs.constants.X_OK).resolves()
+
+			const mockStdout = new Readable({
+				read() {
+					this.push("/workspace/src/main.ts\n")
+					this.push(null)
+				},
+			})
+			const mockStderr = new Readable({
+				read() {
+					this.push(null)
+				},
+			})
+
+			spawnStub.returns({
+				stdout: mockStdout,
+				stderr: mockStderr,
+				on: function (event: string, callback: Function) {
+					if (event === "exit") {
+						setImmediate(() => callback(0))
+					}
+					return this
+				},
+				kill: () => {},
+			} as unknown as childProcess.ChildProcess)
+
+			const result = await fileSearch.executeRipgrepForFiles("/workspace", 5000)
+			const expectedPath = process.platform === "win32" ? "src\\main.ts" : "src/main.ts"
+
+			should(spawnStub.firstCall.args[0]).equal(process.platform === "win32" ? "rg.exe" : "/usr/bin/rg")
+			should(result).containDeep([{ path: expectedPath, type: "file", label: "main.ts" }])
+		})
 	})
 
 	describe("searchWorkspaceFiles", () => {
@@ -208,6 +250,41 @@ describe("File Search", () => {
 			const srcEntries = result.items.filter((item) => item.path === "src")
 			should(srcEntries).have.length(1)
 			should(srcEntries[0]).have.properties({ path: "src", type: "folder" })
+		})
+
+		it("continues search when the host cannot return open tabs", async () => {
+			sandbox.stub(HostProvider.window, "getOpenTabs").rejects(new Error("getOpenTabs unavailable"))
+			sandbox.stub(HostProvider.workspace, "searchWorkspaceItems").rejects({ code: 12, message: "not implemented" })
+
+			const mockStdout = new Readable({
+				read() {
+					this.push("/workspace/src/main.ts\n")
+					this.push(null)
+				},
+			})
+			const mockStderr = new Readable({
+				read() {
+					this.push(null)
+				},
+			})
+
+			spawnStub.returns({
+				stdout: mockStdout,
+				stderr: mockStderr,
+				on: function (event: string, callback: Function) {
+					if (event === "exit") {
+						setImmediate(() => callback(0))
+					}
+					return this
+				},
+				kill: () => {},
+			} as unknown as childProcess.ChildProcess)
+
+			const result = await fileSearch.searchWorkspaceFiles("", "/workspace", 20)
+			const expectedPath = process.platform === "win32" ? "src\\main.ts" : "src/main.ts"
+
+			should(result.source).equal("ripgrep")
+			should(result.items).containDeep([{ path: expectedPath, type: "file", label: "main.ts" }])
 		})
 
 		it("should apply fuzzy matching for non-empty query", async () => {


### PR DESCRIPTION
﻿## Summary
- keep file search running when the host open-tabs RPC is unavailable
- fall back from a missing bundled ripgrep path to system `rg`
- add regressions for both fallback paths

## Context
Fixes #11142. Also covers the VS Code host-search failure mode discussed in #11105.

## To verify
- npm ci
- npm run check-types
- npx biome lint --no-errors-on-unmatched --files-ignore-unknown=true --diagnostic-level=error src/services/search/file-search.ts src/test/services/search/file-search.test.ts
- npx biome format --no-errors-on-unmatched --files-ignore-unknown=true --diagnostic-level=error src/services/search/file-search.ts src/test/services/search/file-search.test.ts
- $env:TS_NODE_PROJECT='./tsconfig.unit-test.json'; npx mocha --no-config --require ts-node/register --require tsconfig-paths/register --require source-map-support/register --require ./src/test/requires.ts src/test/services/search/file-search.test.ts

Note: `npm run test:unit -- --grep "File Search"` currently loads unrelated unit files first and fails on an existing `@shared/api` alias-resolution error before this test file runs, so I used a direct Mocha invocation for the target file.
