### PR TITLE
fix: Claude Code provider fails with certain models due to max_turns

### DIFF
--- a/src/core/api/providers/claude-code.ts
+++ b/src/core/api/providers/claude-code.ts
@@ -2,6 +2,7 @@ import { filterMessagesForClaudeCode } from "@/integrations/claude-code/message-
 import { runClaudeCode } from "@/integrations/claude-code/run"
 import { ClaudeCodeModelId, claudeCodeDefaultModelId, claudeCodeModels } from "@/shared/api"
 import { ClineStorageMessage } from "@/shared/messages/content"
+import { Logger } from "@/shared/services/Logger"
 import { type ApiHandler, CommonApiHandlerOptions } from ".."
 import { withRetry } from "../retry"
 import { type ApiStream, ApiStreamUsageChunk } from "../transform/stream"
@@ -61,6 +62,28 @@ export class ClaudeCodeHandler implements ApiHandler {
 			if (chunk.type === "system" && chunk.subtype === "init") {
 				// Based on my tests, subscription usage sets the `apiKeySource` to "none"
 				isPaidUsage = chunk.apiKeySource !== "none"
+				continue
+			}
+
+			// Handle error messages from Claude Code CLI
+			if (chunk.type === "error") {
+				const errorMessage = chunk.error?.message || chunk.message || JSON.stringify(chunk)
+				Logger.error("Claude Code error chunk received:", errorMessage)
+				throw new Error(`Claude Code error: ${errorMessage}`)
+			}
+
+			// Handle rate limit events
+			if (chunk.type === "rate_limit_event") {
+				const info = chunk.rate_limit_info
+				if (info.status === "rejected") {
+					const resetsAt = new Date(info.resetsAt * 1000).toLocaleTimeString()
+					throw new Error(
+						`Claude Code rate limit exceeded (${info.rateLimitType}). ` +
+							`Resets at ${resetsAt}.` +
+							(info.overageDisabledReason ? ` Overage disabled: ${info.overageDisabledReason}.` : ""),
+					)
+				}
+				Logger.log(`Claude Code rate limit status: ${info.status} (${info.rateLimitType})`)
 				continue
 			}
 

--- a/src/integrations/claude-code/run.ts
+++ b/src/integrations/claude-code/run.ts
@@ -55,6 +55,13 @@ export async function* runClaudeCode(options: ClaudeCodeOptions): AsyncGenerator
 		partialData: null,
 	}
 
+	// Track whether we've received a result chunk from Claude Code.
+	// When --max-turns 1 is set and the model produces a tool_use response (native tool calling),
+	// Claude Code exits with code 1 ("Reached maximum number of turns"). But by that point,
+	// the assistant message and result have already been streamed and yielded. In that case,
+	// the exit code 1 is expected and we should not throw.
+	let hasReceivedResult = false
+
 	try {
 		cProcess.stderr.on("data", (data) => {
 			processState.stderrLogs += data.toString()
@@ -80,6 +87,11 @@ export async function* runClaudeCode(options: ClaudeCodeOptions): AsyncGenerator
 					continue
 				}
 
+				// Track result chunks so we know the response is complete
+				if (typeof chunk !== "string" && chunk.type === "result") {
+					hasReceivedResult = true
+				}
+
 				yield chunk
 			}
 		}
@@ -98,9 +110,30 @@ export async function* runClaudeCode(options: ClaudeCodeOptions): AsyncGenerator
 			)
 		}
 	} catch (err) {
+		// When --max-turns 1 is set and the model uses native tool calling instead of
+		// XML-formatted text tool calls, Claude Code exits with code 1 ("Reached maximum
+		// number of turns"). If we already received and yielded the result chunk, the
+		// response is complete — suppress the error and let the generator end normally.
+		if (hasReceivedResult && (err as any)?.exitCode === 1) {
+			Logger.log("Claude Code exited with max_turns limit — response already yielded, suppressing error.")
+			return
+		}
+
 		Logger.error(`Error during Claude Code execution:`, err)
 
-		if (processState.stderrLogs.includes("unknown option '--system-prompt-file'")) {
+		// Collect all available error details from multiple sources.
+		// execa attaches stderr/stdout to the error object, and we also capture stderr via our stream listener.
+		const execaStderr = (err as any)?.stderr?.trim?.() || ""
+		const execaStdout = (err as any)?.stdout?.trim?.() || ""
+		const collectedStderr = processState.stderrLogs?.trim() || ""
+		// Use the most informative stderr source available
+		const stderrContent = collectedStderr || execaStderr
+
+		Logger.error(
+			`Claude Code error details — stderr: ${stderrContent || "(empty)"}, stdout tail: ${execaStdout?.slice?.(-500) || "(empty)"}`,
+		)
+
+		if (stderrContent.includes("unknown option '--system-prompt-file'")) {
 			throw new Error(`The Claude Code executable is outdated. Please update it to the latest version.`, {
 				cause: err,
 			})
@@ -141,7 +174,13 @@ Anthropic is aware of this issue and is considering a fix: https://github.com/an
 			if (startOfCommand !== -1) {
 				const messageWithoutCommand = err.message.slice(0, startOfCommand).trim()
 
-				throw new Error(`${messageWithoutCommand}\n${processState.stderrLogs?.trim()}`, { cause: err })
+				// Build a descriptive error message using all available error sources
+				const errorDetails = stderrContent || execaStdout?.slice?.(-500) || ""
+				const errorSuffix = errorDetails
+					? `\n${errorDetails}`
+					: "\nNo error details available. Check the Output panel (Cline) for more information."
+
+				throw new Error(`${messageWithoutCommand}${errorSuffix}`, { cause: err })
 			}
 		}
 
@@ -160,23 +199,50 @@ Anthropic is aware of this issue and is considering a fix: https://github.com/an
 
 // We want the model to use our custom tool format instead of built-in tools.
 // Disabling built-in tools prevents tool-only responses and ensures text output.
+// This list must include ALL Claude Code built-in tools with correct PascalCase names.
+// If a tool is not disallowed, the model may call it natively, consuming the single
+// allowed turn (--max-turns 1) and causing a "Reached maximum number of turns" error.
 const claudeCodeTools = [
+	// Core tools
 	"Task",
 	"Bash",
+	"PowerShell",
 	"Glob",
 	"Grep",
 	"LS",
-	"exit_plan_mode",
 	"Read",
 	"Edit",
 	"MultiEdit",
 	"Write",
+	// Notebook tools
 	"NotebookRead",
 	"NotebookEdit",
+	// Web tools
 	"WebFetch",
+	"WebSearch",
+	// Todo tools
 	"TodoRead",
 	"TodoWrite",
-	"WebSearch",
+	// Interactive tools
+	"AskUserQuestion",
+	"ToolSearch",
+	"Skill",
+	"Monitor",
+	// Plan/worktree tools
+	"EnterPlanMode",
+	"ExitPlanMode",
+	"EnterWorktree",
+	"ExitWorktree",
+	// Task management tools
+	"TaskOutput",
+	"TaskStop",
+	// Scheduling/notification tools
+	"CronCreate",
+	"CronDelete",
+	"CronList",
+	"PushNotification",
+	"RemoteTrigger",
+	"ScheduleWakeup",
 ].join(",")
 
 const CLAUDE_CODE_TIMEOUT = 600000 // 10 minutes

--- a/src/integrations/claude-code/types.ts
+++ b/src/integrations/claude-code/types.ts
@@ -17,6 +17,27 @@ type AssistantMessage = {
 
 type ErrorMessage = {
 	type: "error"
+	error?: {
+		message?: string
+		type?: string
+		code?: string
+	}
+	message?: string
+	subtype?: string
+	session_id?: string
+}
+
+type RateLimitEvent = {
+	type: "rate_limit_event"
+	rate_limit_info: {
+		status: "allowed" | "rejected" | string
+		resetsAt: number
+		rateLimitType: string
+		overageStatus?: string
+		overageDisabledReason?: string
+		isUsingOverage?: boolean
+	}
+	session_id?: string
 }
 
 type ResultMessage = {
@@ -31,4 +52,4 @@ type ResultMessage = {
 	session_id: string
 }
 
-export type ClaudeCodeMessage = InitMessage | AssistantMessage | ErrorMessage | ResultMessage
+export type ClaudeCodeMessage = InitMessage | AssistantMessage | ErrorMessage | ResultMessage | RateLimitEvent


### PR DESCRIPTION
…error

When using Claude Code with --max-turns 1, some models (e.g. claude-opus-4-5, claude-sonnet-4-6) produce native tool_use responses instead of XML text, causing Claude Code to exit with code 1 (Reached maximum number of turns).

Changes:
- Suppress exit code 1 when result was already yielded (response is complete)
- Expand disallowed tools list to cover all Claude Code built-in tools
- Handle previously ignored error and rate_limit_event chunk types
- Improve error capture to show actual details instead of generic message

<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #10929 and #10135 

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve? https://github.com/cline/cline/issues/10929
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change? Tested with local development and claude code
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
