### PR TITLE
Fix follow-up option parsing for malformed inputs

### DIFF
--- a/apps/vscode/src/shared/__tests__/array.test.ts
+++ b/apps/vscode/src/shared/__tests__/array.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict"
+import { describe, it } from "mocha"
+import { parsePartialArrayString } from "../array"
+
+describe("parsePartialArrayString", () => {
+	it("parses complete JSON string arrays", () => {
+		assert.deepEqual(parsePartialArrayString('["Read all files", "Pick files"]'), ["Read all files", "Pick files"])
+	})
+
+	it("parses partial array strings", () => {
+		assert.deepEqual(parsePartialArrayString('["Read all files", "Pick'), ["Read all files", "Pick"])
+	})
+
+	it("returns an empty array for complete JSON values that are not arrays", () => {
+		assert.deepEqual(parsePartialArrayString('{"files":["README.md"]}'), [])
+		assert.deepEqual(parsePartialArrayString("null"), [])
+		assert.deepEqual(parsePartialArrayString('"Read README.md"'), [])
+	})
+
+	it("accepts runtime array values and keeps only string options", () => {
+		assert.deepEqual(parsePartialArrayString(["Read all files", 42, "Pick files"]), ["Read all files", "Pick files"])
+	})
+})

--- a/apps/vscode/src/shared/array.ts
+++ b/apps/vscode/src/shared/array.ts
@@ -25,13 +25,22 @@ export function findLast<T>(array: Array<T>, predicate: (value: T, index: number
  * Converts a partial or complete stringified array into an actual array.
  * Handles both complete JSON strings and incomplete array strings.
  * Splits on the specific tokens: ["  ", "  "]
- * @param arrayString A string representation of an array, which may be incomplete
+ * @param arrayString A string representation of an array, which may be incomplete, or a runtime array value
  * @returns Array of strings parsed from the input
  */
-export function parsePartialArrayString(arrayString: string): string[] {
+export function parsePartialArrayString(arrayString: unknown): string[] {
+	if (Array.isArray(arrayString)) {
+		return arrayString.filter((item): item is string => typeof item === "string")
+	}
+
+	if (typeof arrayString !== "string") {
+		return []
+	}
+
 	try {
 		// Try parsing as complete JSON first
-		return JSON.parse(arrayString)
+		const parsed = JSON.parse(arrayString)
+		return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === "string") : []
 	} catch {
 		// If JSON parsing fails, handle as partial string
 		const trimmed = arrayString.trim()


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

Fixes a crash in `ask_followup_question` when a model returns a malformed `options` value such as an object instead of a string array.

`parsePartialArrayString` was typed as returning `string[]`, but complete JSON parsing returned the raw `JSON.parse` result. That allowed non-array values to flow into follow-up and plan-mode handlers, where option-selection checks call `.includes(...)`.

This change makes the parser return string arrays only, tolerate runtime array values, and fall back to `[]` for malformed or non-array inputs.

### Test Procedure

- `TS_NODE_PROJECT=./tsconfig.unit-test.json mise exec node@22 -- npx mocha --no-config --extension ts --require ts-node/register --require source-map-support/register --require ./src/test/requires.ts "src/shared/__tests__/array.test.ts"`
- `mise exec node@22 -- npm run test:unit -- --grep "parsePartialArrayString"`
- `mise exec node@22 -- npx tsc --noEmit --project tsconfig.json`
- `mise exec node@22 -- npm run lint`

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!--
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

N/A - parser-only bug fix.

### Additional Notes

The full `npm test` / `npm run format` pre-flight was not run locally; targeted regression tests, TypeScript, and lint passed.
