### PR TITLE
Fix Getting Started link in marketplace README

### DIFF
--- a/apps/vscode/README.marketplace.md
+++ b/apps/vscode/README.marketplace.md
@@ -19,7 +19,7 @@ English | <a href="https://github.com/cline/cline/blob/main/locales/es/README.md
 <a href="https://github.com/cline/cline/discussions/categories/feature-requests?discussions_q=is%3Aopen+category%3A%22Feature+Requests%22+sort%3Atop" target="_blank"><strong>Feature Requests</strong></a>
 </td>
 <td align="center">
-<a href="https://docs.cline.bot/getting-started/for-new-coders" target="_blank"><strong>Getting Started</strong></a>
+<a href="https://docs.cline.bot/getting-started/installing-cline" target="_blank"><strong>Getting Started</strong></a>
 </td>
 </tbody>
 </table>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -371,6 +371,10 @@
 			"destination": "/getting-started/installing-cline"
 		},
 		{
+			"source": "/getting-started/for-new-coders",
+			"destination": "/getting-started/installing-cline"
+		},
+		{
 			"source": "/getting-started/overview",
 			"destination": "/cline-overview"
 		},


### PR DESCRIPTION
### Related Issue

**Issue:** #9888

### Description

Updates the Marketplace README Getting Started link to the current installing guide and adds a redirect for the old `/getting-started/for-new-coders` path.

### Test Procedure

- Confirmed the old docs URL returns 404
- Confirmed `https://docs.cline.bot/getting-started/installing-cline` returns 200
- Parsed `docs/docs.json` with `JSON.parse`
- Ran `git diff --check`

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

Docs-only link fix; no application code changed.