### PR TITLE
chore: bump version and update changelog (v3.86.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.86.1]
+
+### Fixed
+
+- Fix `@` file mentions failing to find files in some environments (notably VS Code Remote SSH, and after certain VS Code updates) by keeping the file-search fallback alive when the workspace index or bundled ripgrep binary is unavailable.
+
 ## [3.86.0]
 
 ### Added

--- a/apps/vscode/package-lock.json
+++ b/apps/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "claude-dev",
-	"version": "3.86.0",
+	"version": "3.86.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "claude-dev",
-			"version": "3.86.0",
+			"version": "3.86.1",
 			"license": "Apache-2.0",
 			"workspaces": [
 				"."

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -2,7 +2,7 @@
 	"name": "claude-dev",
 	"displayName": "Cline",
 	"description": "Autonomous coding agent right in your IDE, capable of creating/editing files, running commands, using the browser, and more with your permission every step of the way.",
-	"version": "3.86.0",
+	"version": "3.86.1",
 	"icon": "assets/icons/icon.png",
 	"workspaces": [
 		"."


### PR DESCRIPTION
### Related Issue

**Issue:** #11142, #11105

### Description

Release prep for v3.86.1. Bumps the VS Code extension version (`apps/vscode/package.json` + `package-lock.json`) from 3.86.0 to 3.86.1 and adds the corresponding `CHANGELOG.md` section.

This is a patch release shipping the `@` file-mention fix from #11166. Multiple users reported on Reddit and GitHub that the `@` file-mention picker returned "No results found" / failed to find files, particularly on VS Code Remote SSH (#11142) and after certain VS Code updates (#11105). #11166 keeps the file-search fallback alive when the host workspace index or the bundled ripgrep binary is unavailable, restoring `@` mentions in those environments.

Only one in-product change landed on the extension since v3.86.0 (#11166), so the changelog has a single Fixed entry.

### Test Procedure

No code changes here beyond the version bump and changelog. The underlying fix (#11166) is covered by its own regression tests in `apps/vscode/src/test/services/search/file-search.test.ts` (open-tabs RPC failure and missing-bundled-ripgrep fallback paths). Standard CI runs on this PR.

### Type of Change

-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

After this merges, the release is published by manually dispatching the `ext-vscode-publish-stable` workflow from `main` with tag `v3.86.1` (auto-create tag enabled).