### PR TITLE
feat(webview): populate model dropdown for OpenAI Compatible provider

### DIFF
--- a/apps/vscode/webview-ui/src/components/settings/__tests__/OpenAICompatible.spec.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/__tests__/OpenAICompatible.spec.tsx
@@ -60,10 +60,16 @@ describe("OpenAICompatibleProvider — model list", () => {
 
 		renderProvider()
 
-		// The dropdown appears once the fetched models arrive
-		const dropdown = await screen.findByRole("combobox")
+		// The dropdown is populated once the fetched models arrive (after the debounce)
+		await waitFor(
+			() =>
+				expect(within(screen.getByRole("combobox")).getAllByText("amazon/amazon.nova-lite-v1:0").length).toBeGreaterThan(
+					0,
+				),
+			{ timeout: 2000 },
+		)
+		const dropdown = screen.getByRole("combobox")
 		expect(within(dropdown).getAllByText("openai/gpt-4o").length).toBeGreaterThan(0)
-		expect(within(dropdown).getAllByText("amazon/amazon.nova-lite-v1:0").length).toBeGreaterThan(0)
 		// ...and the free-text fallback is gone
 		expect(screen.queryByPlaceholderText("Enter Model ID...")).not.toBeInTheDocument()
 	})
@@ -81,8 +87,8 @@ describe("OpenAICompatibleProvider — model list", () => {
 
 		renderProvider()
 
-		// Give the mount-time fetch a chance to resolve (to empty)
-		await waitFor(() => expect(ModelsServiceClient.refreshOpenAiModels).toHaveBeenCalled())
+		// Give the debounced fetch a chance to fire and resolve (to empty)
+		await waitFor(() => expect(ModelsServiceClient.refreshOpenAiModels).toHaveBeenCalled(), { timeout: 2000 })
 		expect(screen.getAllByPlaceholderText("Enter Model ID...").length).toBeGreaterThan(0)
 		expect(screen.queryByRole("combobox")).not.toBeInTheDocument()
 	})
@@ -102,8 +108,12 @@ describe("OpenAICompatibleProvider — model list", () => {
 
 		renderProvider()
 
-		const dropdown = await screen.findByRole("combobox")
+		// Wait for the fetched model to arrive; the custom (selected) ID is present from the start
+		await waitFor(
+			() => expect(within(screen.getByRole("combobox")).getAllByText("openai/gpt-4o").length).toBeGreaterThan(0),
+			{ timeout: 2000 },
+		)
+		const dropdown = screen.getByRole("combobox")
 		expect(within(dropdown).getAllByText("some/custom-model").length).toBeGreaterThan(0)
-		expect(within(dropdown).getAllByText("openai/gpt-4o").length).toBeGreaterThan(0)
 	})
 })

--- a/apps/vscode/webview-ui/src/components/settings/__tests__/OpenAICompatible.spec.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/__tests__/OpenAICompatible.spec.tsx
@@ -1,0 +1,109 @@
+import { render, screen, waitFor, within } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { useExtensionState } from "@/context/ExtensionStateContext"
+import { ModelsServiceClient } from "@/services/grpc-client"
+import { OpenAICompatibleProvider } from "../providers/OpenAICompatible"
+
+// Mock the gRPC client used to fetch the provider's model list
+vi.mock("@/services/grpc-client", () => ({
+	ModelsServiceClient: {
+		refreshOpenAiModels: vi.fn(),
+	},
+}))
+
+// Mock the config handlers (we only assert on rendering here)
+vi.mock("../utils/useApiConfigurationHandlers", () => ({
+	useApiConfigurationHandlers: () => ({
+		handleFieldChange: vi.fn(),
+		handleModeFieldChange: vi.fn(),
+	}),
+}))
+
+// Mock the extension state so we can drive apiConfiguration per test
+vi.mock("../../../context/ExtensionStateContext", async (importOriginal) => {
+	const actual = (await importOriginal()) as Record<string, any>
+	return {
+		...actual,
+		useExtensionState: vi.fn(),
+	}
+})
+
+const mockState = (apiConfiguration: Record<string, any>) => {
+	vi.mocked(useExtensionState).mockReturnValue({
+		apiConfiguration,
+		remoteConfigSettings: undefined,
+		setApiConfiguration: vi.fn(),
+	} as any)
+}
+
+const renderProvider = () => render(<OpenAICompatibleProvider currentMode="plan" showModelOptions={false} />)
+
+describe("OpenAICompatibleProvider — model list", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		//@ts-expect-error - vscode is not defined in the test global namespace
+		global.vscode = { postMessage: vi.fn() }
+	})
+
+	it("renders a model dropdown populated from the fetched /models list", async () => {
+		vi.mocked(ModelsServiceClient.refreshOpenAiModels).mockResolvedValue({
+			values: ["openai/gpt-4o", "amazon/amazon.nova-lite-v1:0"],
+		} as any)
+		mockState({
+			planModeApiProvider: "openai",
+			actModeApiProvider: "openai",
+			openAiBaseUrl: "https://api.edenai.run/v3",
+			openAiApiKey: "test-key",
+			planModeOpenAiModelId: "openai/gpt-4o",
+			actModeOpenAiModelId: "openai/gpt-4o",
+		})
+
+		renderProvider()
+
+		// The dropdown appears once the fetched models arrive
+		const dropdown = await screen.findByRole("combobox")
+		expect(within(dropdown).getAllByText("openai/gpt-4o").length).toBeGreaterThan(0)
+		expect(within(dropdown).getAllByText("amazon/amazon.nova-lite-v1:0").length).toBeGreaterThan(0)
+		// ...and the free-text fallback is gone
+		expect(screen.queryByPlaceholderText("Enter Model ID...")).not.toBeInTheDocument()
+	})
+
+	it("falls back to the free-text Model ID field when no models are returned", async () => {
+		vi.mocked(ModelsServiceClient.refreshOpenAiModels).mockResolvedValue({ values: [] } as any)
+		mockState({
+			planModeApiProvider: "openai",
+			actModeApiProvider: "openai",
+			openAiBaseUrl: "https://example.com/v1",
+			openAiApiKey: "test-key",
+			planModeOpenAiModelId: "",
+			actModeOpenAiModelId: "",
+		})
+
+		renderProvider()
+
+		// Give the mount-time fetch a chance to resolve (to empty)
+		await waitFor(() => expect(ModelsServiceClient.refreshOpenAiModels).toHaveBeenCalled())
+		expect(screen.getAllByPlaceholderText("Enter Model ID...").length).toBeGreaterThan(0)
+		expect(screen.queryByRole("combobox")).not.toBeInTheDocument()
+	})
+
+	it("keeps a manually-entered model ID selectable even if it isn't in the fetched list", async () => {
+		vi.mocked(ModelsServiceClient.refreshOpenAiModels).mockResolvedValue({
+			values: ["openai/gpt-4o"],
+		} as any)
+		mockState({
+			planModeApiProvider: "openai",
+			actModeApiProvider: "openai",
+			openAiBaseUrl: "https://api.edenai.run/v3",
+			openAiApiKey: "test-key",
+			planModeOpenAiModelId: "some/custom-model",
+			actModeOpenAiModelId: "some/custom-model",
+		})
+
+		renderProvider()
+
+		const dropdown = await screen.findByRole("combobox")
+		expect(within(dropdown).getAllByText("some/custom-model").length).toBeGreaterThan(0)
+		expect(within(dropdown).getAllByText("openai/gpt-4o").length).toBeGreaterThan(0)
+	})
+})

--- a/apps/vscode/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
@@ -3,7 +3,7 @@ import { azureOpenAiDefaultApiVersion, openAiModelInfoSaneDefaults } from "@shar
 import { OpenAiModelsRequest } from "@shared/proto/cline/models"
 import { Mode } from "@shared/storage/types"
 import { VSCodeButton, VSCodeCheckbox, VSCodeDropdown, VSCodeOption } from "@vscode/webview-ui-toolkit/react"
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { Tooltip } from "@/components/ui/tooltip"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { ModelsServiceClient } from "@/services/grpc-client"
@@ -55,55 +55,37 @@ export const OpenAICompatibleProvider = ({ showModelOptions, isPopup, currentMod
 	// Get mode-specific fields
 	const { openAiModelInfo } = getModeSpecificFields(apiConfiguration, currentMode)
 
-	// Debounced function to refresh OpenAI models (prevents excessive API calls while typing)
-	const debounceTimerRef = useRef<NodeJS.Timeout | null>(null)
-
+	// Refresh the model list whenever the Base URL / API key change (and on mount when
+	// already configured). A single debounced effect with a cleanup guard ensures only the
+	// latest request's result is applied, so a slow in-flight fetch can't overwrite newer
+	// results with stale ones.
+	const openAiBaseUrl = apiConfiguration?.openAiBaseUrl
+	const openAiApiKey = apiConfiguration?.openAiApiKey
 	useEffect(() => {
-		return () => {
-			if (debounceTimerRef.current) {
-				clearTimeout(debounceTimerRef.current)
-			}
-		}
-	}, [])
-
-	const debouncedRefreshOpenAiModels = useCallback((baseUrl?: string, apiKey?: string) => {
-		if (debounceTimerRef.current) {
-			clearTimeout(debounceTimerRef.current)
+		if (!openAiBaseUrl || !openAiApiKey) {
+			return
 		}
 
-		if (baseUrl && apiKey) {
-			debounceTimerRef.current = setTimeout(() => {
-				ModelsServiceClient.refreshOpenAiModels(
-					OpenAiModelsRequest.create({
-						baseUrl,
-						apiKey,
-					}),
-				)
-					.then((response) => {
-						setOpenAiModels(response?.values ?? [])
-					})
-					.catch((error) => {
-						console.error("Failed to refresh OpenAI models:", error)
-					})
-			}, 500)
-		}
-	}, [])
-
-	// Populate the model list on mount when the provider is already configured
-	useEffect(() => {
-		const baseUrl = apiConfiguration?.openAiBaseUrl
-		const apiKey = apiConfiguration?.openAiApiKey
-		if (baseUrl && apiKey) {
-			ModelsServiceClient.refreshOpenAiModels(OpenAiModelsRequest.create({ baseUrl, apiKey }))
+		let ignore = false
+		const timer = setTimeout(() => {
+			ModelsServiceClient.refreshOpenAiModels(OpenAiModelsRequest.create({ baseUrl: openAiBaseUrl, apiKey: openAiApiKey }))
 				.then((response) => {
-					setOpenAiModels(response?.values ?? [])
+					if (!ignore) {
+						setOpenAiModels(response?.values ?? [])
+					}
 				})
 				.catch((error) => {
-					console.error("Failed to refresh OpenAI models:", error)
+					if (!ignore) {
+						console.error("Failed to refresh OpenAI models:", error)
+					}
 				})
+		}, 500)
+
+		return () => {
+			ignore = true
+			clearTimeout(timer)
 		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [])
+	}, [openAiBaseUrl, openAiApiKey])
 
 	return (
 		<div>
@@ -121,7 +103,6 @@ export const OpenAICompatibleProvider = ({ showModelOptions, isPopup, currentMod
 							initialValue={apiConfiguration?.openAiBaseUrl || ""}
 							onChange={(value) => {
 								handleFieldChange("openAiBaseUrl", value)
-								debouncedRefreshOpenAiModels(value, apiConfiguration?.openAiApiKey)
 							}}
 							placeholder={"Enter base URL..."}
 							style={{ width: "100%", marginBottom: 10 }}
@@ -138,7 +119,6 @@ export const OpenAICompatibleProvider = ({ showModelOptions, isPopup, currentMod
 				initialValue={apiConfiguration?.openAiApiKey || ""}
 				onChange={(value) => {
 					handleFieldChange("openAiApiKey", value)
-					debouncedRefreshOpenAiModels(apiConfiguration?.openAiBaseUrl, value)
 				}}
 				providerName="OpenAI Compatible"
 			/>

--- a/apps/vscode/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
@@ -2,8 +2,8 @@ import { TooltipContent, TooltipTrigger } from "@radix-ui/react-tooltip"
 import { azureOpenAiDefaultApiVersion, openAiModelInfoSaneDefaults } from "@shared/api"
 import { OpenAiModelsRequest } from "@shared/proto/cline/models"
 import { Mode } from "@shared/storage/types"
-import { VSCodeButton, VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react"
-import { useCallback, useEffect, useRef, useState } from "react"
+import { VSCodeButton, VSCodeCheckbox, VSCodeDropdown, VSCodeOption } from "@vscode/webview-ui-toolkit/react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { Tooltip } from "@/components/ui/tooltip"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { ModelsServiceClient } from "@/services/grpc-client"
@@ -12,6 +12,7 @@ import { ApiKeyField } from "../common/ApiKeyField"
 import { BaseUrlField } from "../common/BaseUrlField"
 import { DebouncedTextField } from "../common/DebouncedTextField"
 import { ModelInfoView } from "../common/ModelInfoView"
+import { DropdownContainer } from "../common/ModelSelector"
 import ReasoningEffortSelector from "../ReasoningEffortSelector"
 import { parsePrice } from "../utils/pricingUtils"
 import { getModeSpecificFields, normalizeApiConfiguration, supportsReasoningEffortForModelId } from "../utils/providerUtils"
@@ -35,9 +36,21 @@ export const OpenAICompatibleProvider = ({ showModelOptions, isPopup, currentMod
 
 	const [modelConfigurationSelected, setModelConfigurationSelected] = useState(false)
 
+	// Model IDs fetched from the provider's /models endpoint
+	const [openAiModels, setOpenAiModels] = useState<string[]>([])
+
 	// Get the normalized configuration
 	const { selectedModelId, selectedModelInfo } = normalizeApiConfiguration(apiConfiguration, currentMode)
 	const showReasoningEffort = supportsReasoningEffortForModelId(selectedModelId, true)
+
+	// Keep a manually-entered model ID selectable even if the provider doesn't list it
+	const modelOptions = useMemo(() => {
+		const ids = [...openAiModels]
+		if (selectedModelId && !ids.includes(selectedModelId)) {
+			ids.unshift(selectedModelId)
+		}
+		return ids
+	}, [openAiModels, selectedModelId])
 
 	// Get mode-specific fields
 	const { openAiModelInfo } = getModeSpecificFields(apiConfiguration, currentMode)
@@ -65,11 +78,31 @@ export const OpenAICompatibleProvider = ({ showModelOptions, isPopup, currentMod
 						baseUrl,
 						apiKey,
 					}),
-				).catch((error) => {
-					console.error("Failed to refresh OpenAI models:", error)
-				})
+				)
+					.then((response) => {
+						setOpenAiModels(response?.values ?? [])
+					})
+					.catch((error) => {
+						console.error("Failed to refresh OpenAI models:", error)
+					})
 			}, 500)
 		}
+	}, [])
+
+	// Populate the model list on mount when the provider is already configured
+	useEffect(() => {
+		const baseUrl = apiConfiguration?.openAiBaseUrl
+		const apiKey = apiConfiguration?.openAiApiKey
+		if (baseUrl && apiKey) {
+			ModelsServiceClient.refreshOpenAiModels(OpenAiModelsRequest.create({ baseUrl, apiKey }))
+				.then((response) => {
+					setOpenAiModels(response?.values ?? [])
+				})
+				.catch((error) => {
+					console.error("Failed to refresh OpenAI models:", error)
+				})
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [])
 
 	return (
@@ -110,15 +143,42 @@ export const OpenAICompatibleProvider = ({ showModelOptions, isPopup, currentMod
 				providerName="OpenAI Compatible"
 			/>
 
-			<DebouncedTextField
-				initialValue={selectedModelId || ""}
-				onChange={(value) =>
-					handleModeFieldChange({ plan: "planModeOpenAiModelId", act: "actModeOpenAiModelId" }, value, currentMode)
-				}
-				placeholder={"Enter Model ID..."}
-				style={{ width: "100%", marginBottom: 10 }}>
-				<span style={{ fontWeight: 500 }}>Model ID</span>
-			</DebouncedTextField>
+			{modelOptions.length > 0 ? (
+				<div className="mb-2.5">
+					<label htmlFor="openai-model-id">
+						<span style={{ fontWeight: 500 }}>Model ID</span>
+					</label>
+					<DropdownContainer className="dropdown-container" zIndex={10}>
+						<VSCodeDropdown
+							className="w-full"
+							id="openai-model-id"
+							onChange={(e: any) =>
+								handleModeFieldChange(
+									{ plan: "planModeOpenAiModelId", act: "actModeOpenAiModelId" },
+									e?.target?.value ?? "",
+									currentMode,
+								)
+							}
+							value={selectedModelId}>
+							{modelOptions.map((modelId) => (
+								<VSCodeOption className="break-words whitespace-normal max-w-full" key={modelId} value={modelId}>
+									{modelId}
+								</VSCodeOption>
+							))}
+						</VSCodeDropdown>
+					</DropdownContainer>
+				</div>
+			) : (
+				<DebouncedTextField
+					initialValue={selectedModelId || ""}
+					onChange={(value) =>
+						handleModeFieldChange({ plan: "planModeOpenAiModelId", act: "actModeOpenAiModelId" }, value, currentMode)
+					}
+					placeholder={"Enter Model ID..."}
+					style={{ width: "100%", marginBottom: 10 }}>
+					<span style={{ fontWeight: 500 }}>Model ID</span>
+				</DebouncedTextField>
+			)}
 
 			{/* OpenAI Compatible Custom Headers */}
 			{(() => {


### PR DESCRIPTION
### Related Issue

**Feature Request discussion:** https://github.com/cline/cline/discussions/11179

### Description

The **OpenAI Compatible** provider already fetches the provider's model list, but the result is silently discarded — so users only ever get a free-text **Model ID** box and have to know/type exact IDs by hand.

Concretely, on the current `main`:

- `OpenAICompatible.tsx` calls `ModelsServiceClient.refreshOpenAiModels(...)` whenever the Base URL or API key changes, but only attaches a `.catch(...)` — the resolved `StringArray` of model IDs is thrown away.
- `refreshOpenAiModels` (controller) does fetch `${baseUrl}/models` and parses `response.data.data.map(m => m.id)` correctly.
- `ExtensionStateContext` even declares `openAiModels: string[]`, but its setter is never called — it's dead state.

So the model list is fetched and then goes nowhere; the UI has nothing to render a picker from.

This PR wires the fetched list into a model **dropdown**, mirroring the existing, proven pattern in `LMStudioProvider.tsx` (dropdown when models are available, free-text field as fallback):

- Capture the `refreshOpenAiModels` result into local state and render a `VSCodeDropdown` of model IDs.
- Also fetch on mount when the provider is already configured, so the dropdown is populated without having to re-edit a field.
- Fall back to the existing free-text `Model ID` field when the provider exposes no `/models` (or it's empty/unreachable) — fully backward compatible.
- A manually-entered model ID that isn't in the returned list is preserved as a selected option, so custom IDs are never silently dropped.

### Test Procedure

Tested against an OpenAI-compatible endpoint whose `/models` returns the standard `{ "object": "list", "data": [ { "id": "..." } ] }` shape:

- **With a `/models`-capable provider** (Base URL + API key set): the Model ID field renders as a dropdown populated with the provider's model IDs; selecting one persists correctly in both Plan and Act modes.
- **Already-configured provider on reopen**: dropdown is populated on mount (no need to re-type the Base URL).
- **Provider without `/models` / empty / unreachable**: gracefully falls back to the original free-text Model ID field — no regression.
- **Custom ID not in the list**: the existing/typed model ID stays selected (added as an option), so nothing is lost.
- `cd apps/vscode/webview-ui && npx tsc --noEmit` passes; `npm run format` / `npm run lint` clean.

### Type of Change

-   [x] ✨ New feature (non-breaking change which adds functionality)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore
-   [x] Tests are passing and code is formatted and linted
-   [x] I have reviewed contributor guidelines

### Screenshots

<!-- Add a before (free-text Model ID) / after (dropdown of models) screenshot here. -->

### Additional Notes

Implementation deliberately mirrors `LMStudioProvider.tsx` for consistency and reviewability. If maintainers would prefer always keeping a free-text field available alongside the dropdown (for providers whose `/models` is incomplete), that's an easy follow-up — happy to adjust.
