### PR TITLE
fix: respect MCP server timeout during discovery

### DIFF
--- a/apps/vscode/src/services/mcp/McpHub.ts
+++ b/apps/vscode/src/services/mcp/McpHub.ts
@@ -43,7 +43,6 @@ import { Logger } from "@/shared/services/Logger"
 import { expandEnvironmentVariables } from "@/utils/envExpansion"
 import { getServerAuthHash } from "@/utils/mcpAuth"
 import { TelemetryService } from "../telemetry/TelemetryService"
-import { DEFAULT_REQUEST_TIMEOUT_MS } from "./constants"
 import { McpOAuthManager } from "./McpOAuthManager"
 import { StreamableHttpReconnectHandler } from "./StreamableHttpReconnectHandler"
 import { BaseConfigSchema, McpSettingsSchema, ServerConfigSchema } from "./schemas"
@@ -1228,7 +1227,7 @@ export class McpHub {
 			},
 			GetPromptResultSchema,
 			{
-				timeout: DEFAULT_REQUEST_TIMEOUT_MS,
+				timeout: this.getServerRequestTimeout(connection),
 			},
 		)
 

--- a/apps/vscode/src/services/mcp/McpHub.ts
+++ b/apps/vscode/src/services/mcp/McpHub.ts
@@ -674,6 +674,17 @@ export class McpHub {
 		connection.server.error = newError //.slice(0, 800)
 	}
 
+	private getServerRequestTimeout(connection: McpConnection): number {
+		try {
+			const config = JSON.parse(connection.server.config)
+			const parsedConfig = ServerConfigSchema.parse(config)
+			return secondsToMs(parsedConfig.timeout)
+		} catch (error) {
+			Logger.error(`Failed to parse timeout configuration for server ${connection.server.name}: ${error}`)
+			return secondsToMs(DEFAULT_MCP_TIMEOUT_SECONDS)
+		}
+	}
+
 	private async fetchToolsList(serverName: string): Promise<McpTool[]> {
 		try {
 			const connection = this.connections.find((conn) => conn.server.name === serverName)
@@ -688,7 +699,7 @@ export class McpHub {
 			}
 
 			const response = await connection.client.request({ method: "tools/list" }, ListToolsResultSchema, {
-				timeout: DEFAULT_REQUEST_TIMEOUT_MS,
+				timeout: this.getServerRequestTimeout(connection),
 			})
 
 			// Get autoApprove settings
@@ -720,7 +731,7 @@ export class McpHub {
 			}
 
 			const response = await connection.client.request({ method: "resources/list" }, ListResourcesResultSchema, {
-				timeout: DEFAULT_REQUEST_TIMEOUT_MS,
+				timeout: this.getServerRequestTimeout(connection),
 			})
 			return response?.resources || []
 		} catch (_error) {
@@ -742,7 +753,7 @@ export class McpHub {
 				{ method: "resources/templates/list" },
 				ListResourceTemplatesResultSchema,
 				{
-					timeout: DEFAULT_REQUEST_TIMEOUT_MS,
+					timeout: this.getServerRequestTimeout(connection),
 				},
 			)
 
@@ -763,7 +774,7 @@ export class McpHub {
 			}
 
 			const response = await connection.client.request({ method: "prompts/list" }, ListPromptsResultSchema, {
-				timeout: DEFAULT_REQUEST_TIMEOUT_MS,
+				timeout: this.getServerRequestTimeout(connection),
 			})
 
 			return (response?.prompts || []).map((prompt) => ({
@@ -1247,15 +1258,7 @@ export class McpHub {
 			throw new Error(`Server "${serverName}" is disabled and cannot be used`)
 		}
 
-		let timeout = secondsToMs(DEFAULT_MCP_TIMEOUT_SECONDS) // sdk expects ms
-
-		try {
-			const config = JSON.parse(connection.server.config)
-			const parsedConfig = ServerConfigSchema.parse(config)
-			timeout = secondsToMs(parsedConfig.timeout)
-		} catch (error) {
-			Logger.error(`Failed to parse timeout configuration for server ${serverName}: ${error}`)
-		}
+		const timeout = this.getServerRequestTimeout(connection)
 
 		this.telemetryService.captureMcpToolCall(
 			ulid,

--- a/apps/vscode/src/services/mcp/__tests__/McpHub.fetchToolsList.test.ts
+++ b/apps/vscode/src/services/mcp/__tests__/McpHub.fetchToolsList.test.ts
@@ -3,9 +3,11 @@ import "should"
 import sinon from "sinon"
 import { McpHub } from "../McpHub"
 
-function createMcpHub(config: string) {
+function createMcpHub(config: string, response?: unknown) {
 	const client = {
-		request: sinon.stub().rejects(new Error("stop after recording request options")),
+		request: response
+			? sinon.stub().resolves(response)
+			: sinon.stub().rejects(new Error("stop after recording request options")),
 	}
 
 	const connection = {
@@ -53,5 +55,17 @@ describe("McpHub MCP discovery requests", () => {
 			client.request.firstCall.args[0].method.should.equal(method)
 			client.request.firstCall.args[2].timeout.should.equal(30_000)
 		}
+	})
+
+	it("should use the configured MCP server timeout for prompts/get requests", async () => {
+		const { hub, client } = createMcpHub(JSON.stringify({ type: "stdio", command: "test", timeout: 40 }), {
+			messages: [],
+		})
+
+		await hub.getPrompt("test-server", "slow_prompt")
+
+		client.request.calledOnce.should.be.true()
+		client.request.firstCall.args[0].method.should.equal("prompts/get")
+		client.request.firstCall.args[2].timeout.should.equal(40_000)
 	})
 })

--- a/apps/vscode/src/services/mcp/__tests__/McpHub.fetchToolsList.test.ts
+++ b/apps/vscode/src/services/mcp/__tests__/McpHub.fetchToolsList.test.ts
@@ -1,0 +1,57 @@
+import { describe, it } from "mocha"
+import "should"
+import sinon from "sinon"
+import { McpHub } from "../McpHub"
+
+function createMcpHub(config: string) {
+	const client = {
+		request: sinon.stub().rejects(new Error("stop after recording request options")),
+	}
+
+	const connection = {
+		server: {
+			name: "test-server",
+			config,
+			status: "connected",
+			disabled: false,
+		},
+		client,
+		transport: {},
+	}
+
+	const hub = Object.create(McpHub.prototype) as McpHub
+	;(hub as any).connections = [connection]
+
+	return { hub, client }
+}
+
+describe("McpHub MCP discovery requests", () => {
+	it("should use the configured MCP server timeout for tools/list requests", async () => {
+		const { hub, client } = createMcpHub(JSON.stringify({ type: "stdio", command: "test", timeout: 20 }))
+
+		await (hub as any).fetchToolsList("test-server")
+
+		client.request.calledOnce.should.be.true()
+		client.request.firstCall.args[0].method.should.equal("tools/list")
+		client.request.firstCall.args[2].timeout.should.equal(20_000)
+	})
+
+	it("should use the configured MCP server timeout for resource and prompt discovery requests", async () => {
+		const config = JSON.stringify({ type: "stdio", command: "test", timeout: 30 })
+		const methods = [
+			{ call: "fetchResourcesList", method: "resources/list" },
+			{ call: "fetchResourceTemplatesList", method: "resources/templates/list" },
+			{ call: "fetchPromptsList", method: "prompts/list" },
+		]
+
+		for (const { call, method } of methods) {
+			const { hub, client } = createMcpHub(config)
+
+			await (hub as any)[call]("test-server")
+
+			client.request.calledOnce.should.be.true()
+			client.request.firstCall.args[0].method.should.equal(method)
+			client.request.firstCall.args[2].timeout.should.equal(30_000)
+		}
+	})
+})


### PR DESCRIPTION
### Related Issue

**Issue:** #7635

### Description

This PR fixes MCP discovery requests using the fixed internal 5s timeout instead of the timeout configured for the MCP server.

Currently, `tools/call` already respects the per-server MCP timeout from the server config, but the initial MCP discovery requests still use `DEFAULT_REQUEST_TIMEOUT_MS` (`5000ms`). This can cause slow MCP servers to fail during connection or discovery even when the user has configured a longer timeout.

This change introduces a shared helper for resolving the per-server MCP request timeout and uses it for the initial discovery calls:

- `tools/list`
- `resources/list`
- `resources/templates/list`
- `prompts/list`

It also reuses the same helper in `callTool()` so timeout parsing stays consistent across MCP request paths.

### Test Procedure

I verified the change with the following checks:

- Ran `git diff --check` successfully.
- Ran Biome against the changed files:

```bash
npx biome check src/services/mcp/McpHub.ts src/services/mcp/__tests__/McpHub.fetchToolsList.test.ts --no-errors-on-unmatched --files-ignore-unknown=true