### PR TITLE
fix(vscode): compact Codex OAuth before input cap

### DIFF
--- a/apps/vscode/src/core/api/index.ts
+++ b/apps/vscode/src/core/api/index.ts
@@ -32,6 +32,7 @@ export interface ApiHandler {
 export interface ApiHandlerModel {
 	id: string
 	info: ModelInfo
+	providerId?: string
 }
 
 export interface ApiProviderInfo {

--- a/apps/vscode/src/core/context/context-management/__tests__/ContextManager.test.ts
+++ b/apps/vscode/src/core/context/context-management/__tests__/ContextManager.test.ts
@@ -3,10 +3,10 @@ import { ClineMessage } from "@shared/ExtensionMessage"
 import { expect } from "chai"
 import { ContextManager } from "../ContextManager"
 
-// Minimal mock for ApiHandler — only getModel().info.contextWindow is used by shouldCompactContextWindow
-function createMockApi(contextWindow: number) {
+// Minimal mock for ApiHandler — only getModel() fields are used by shouldCompactContextWindow
+function createMockApi(contextWindow: number, providerId?: string) {
 	return {
-		getModel: () => ({ id: "test-model", info: { contextWindow } }),
+		getModel: () => ({ id: "test-model", info: { contextWindow }, providerId }),
 	} as any
 }
 
@@ -490,6 +490,22 @@ describe("ContextManager", () => {
 
 			const result = contextManager.shouldCompactContextWindow(clineMessages, api, 0, 1.0)
 			expect(result).to.equal(true)
+		})
+
+		it("compacts OpenAI Codex OAuth 400K models before their 272K input cap", () => {
+			const api = createMockApi(400_000, "openai-codex")
+			const clineMessages: ClineMessage[] = [createApiReqMessage({ tokensIn: 250_000 })]
+
+			const result = contextManager.shouldCompactContextWindow(clineMessages, api, 0, 0.75)
+			expect(result).to.equal(true)
+		})
+
+		it("keeps the normal threshold for non-Codex 400K models", () => {
+			const api = createMockApi(400_000, "openai-native")
+			const clineMessages: ClineMessage[] = [createApiReqMessage({ tokensIn: 250_000 })]
+
+			const result = contextManager.shouldCompactContextWindow(clineMessages, api, 0, 0.75)
+			expect(result).to.equal(false)
 		})
 	})
 })

--- a/apps/vscode/src/core/context/context-management/context-window-utils.ts
+++ b/apps/vscode/src/core/context/context-management/context-window-utils.ts
@@ -7,7 +7,10 @@ import { ApiHandler } from "@core/api"
  * @returns An object containing the raw context window size and the effective max allowed size
  */
 export function getContextWindowInfo(api: ApiHandler) {
-	const contextWindow = api.getModel().info.contextWindow || 128_000
+	const model = api.getModel()
+	const contextWindow = model.info.contextWindow || 128_000
+	const isOpenAiCodexOAuth = model.providerId === "openai-codex"
+	const defaultMaxAllowedSize = Math.max(contextWindow - 40_000, contextWindow * 0.8)
 
 	let maxAllowedSize: number
 	switch (contextWindow) {
@@ -20,8 +23,12 @@ export function getContextWindowInfo(api: ApiHandler) {
 		case 200_000: // claude models
 			maxAllowedSize = contextWindow - 40_000
 			break
+		case 400_000:
+			// OpenAI Codex OAuth has a 272K input cap inside the 400K total context window.
+			maxAllowedSize = isOpenAiCodexOAuth ? 272_000 - 40_000 : defaultMaxAllowedSize
+			break
 		default:
-			maxAllowedSize = Math.max(contextWindow - 40_000, contextWindow * 0.8) // for deepseek, 80% of 64k meant only ~10k buffer which was too small and resulted in users getting context window errors.
+			maxAllowedSize = defaultMaxAllowedSize // for deepseek, 80% of 64k meant only ~10k buffer which was too small and resulted in users getting context window errors.
 	}
 
 	return { contextWindow, maxAllowedSize }

--- a/apps/vscode/src/sdk/sdk-api-handler.ts
+++ b/apps/vscode/src/sdk/sdk-api-handler.ts
@@ -93,5 +93,16 @@ export function buildSdkProviderConfig(
  * existing callers continue to work unchanged.
  */
 export function buildApiHandler(configuration: ApiConfiguration, mode: Mode, options?: BuildApiHandlerOptions): ApiHandler {
-	return createHandler(buildSdkProviderConfig(configuration, mode, options))
+	const providerConfig = buildSdkProviderConfig(configuration, mode, options)
+	const handler = createHandler(providerConfig)
+	const getModel = handler.getModel.bind(handler)
+
+	handler.getModel = () => {
+		return {
+			...getModel(),
+			providerId: providerConfig.providerId,
+		}
+	}
+
+	return handler
 }


### PR DESCRIPTION
### Related Issue

**Issue:** ENG-2116

### Description

This is a tactical workaround for the SDK Nightly extension while the broader compaction/context-window management work in ENG-1967 is in progress.

The SDK Codex catalog correctly reports `gpt-5.5` as a 400K total context model with a 272K input cap, but the VSCode extension still maps SDK model metadata into the legacy `ModelInfo` shape, which does not carry `maxInputTokens`. Legacy compaction can then derive its threshold from `contextWindow: 400_000` and land at 320K, which is still above the Codex OAuth input cap.

This PR preserves the SDK provider id on the VSCode-side handler model and applies the lower threshold only when the provider is `openai-codex` and the context window is 400K. Non-Codex 400K models keep the existing threshold behavior.

The real fix should preserve and budget against explicit input-token limits throughout compaction and context-window management.

### Test Procedure

- Added focused regression coverage for both sides of the workaround:
  - `openai-codex` / 400K compacts at 250K, below the 272K input cap.
  - non-Codex / 400K does not compact at 250K and keeps the normal threshold.
- `mise exec -- npm run test:unit -- --grep "400K"` passed.
- `mise exec -- npm run compile` passed.
- `ReadLints` on touched files passed.
- `git diff --check` passed.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - no UI changes.

### Additional Notes

This should be removed or replaced once ENG-1967 carries `maxInputTokens` through projection/compaction and budgets against that field directly.
