### PR TITLE
fix(cli): show MCP OAuth errors in TUI

### DIFF
--- a/sdk/apps/cli/src/runtime/interactive/config-data.test.ts
+++ b/sdk/apps/cli/src/runtime/interactive/config-data.test.ts
@@ -538,6 +538,56 @@ Find installable skills.`,
 		).toBe(false);
 	});
 
+	it("surfaces MCP OAuth status and errors", async () => {
+		const tempRoot = await mkdtemp(join(tmpdir(), "cli-config-data-"));
+		tempRoots.push(tempRoot);
+		const settingsPath = join(tempRoot, "cline_mcp_settings.json");
+		process.env.CLINE_MCP_SETTINGS_PATH = settingsPath;
+		await writeFile(
+			settingsPath,
+			`${JSON.stringify(
+				{
+					mcpServers: {
+						linear: {
+							transport: {
+								type: "streamableHttp",
+								url: "https://mcp.linear.app/mcp",
+							},
+							oauth: {
+								lastError: "OAuth authorization failed",
+							},
+						},
+						docs: {
+							transport: {
+								type: "sse",
+								url: "https://mcp.example.com/sse",
+							},
+							oauth: {
+								tokens: {
+									access_token: "token",
+								},
+							},
+						},
+					},
+				},
+				null,
+				2,
+			)}\n`,
+		);
+		const loader = createInteractiveConfigDataLoader({
+			config: createConfig(tempRoot),
+		});
+
+		const data = await loader.loadConfigData();
+		const linear = data.mcp.find((item) => item.name === "linear");
+		const docs = data.mcp.find((item) => item.name === "docs");
+
+		expect(linear?.description).toBe("streamableHttp, oauth error");
+		expect(linear?.loadError).toBe("OAuth authorization failed");
+		expect(docs?.description).toBe("sse, oauth authorized");
+		expect(docs?.loadError).toBeUndefined();
+	});
+
 	it("does not toggle workflow items", async () => {
 		const tempRoot = await mkdtemp(join(tmpdir(), "cli-config-data-"));
 		tempRoots.push(tempRoot);

--- a/sdk/apps/cli/src/tui/components/dialogs/mcp-manager-dialog.test.ts
+++ b/sdk/apps/cli/src/tui/components/dialogs/mcp-manager-dialog.test.ts
@@ -3,7 +3,11 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { getMcpManagerFooterText, toggleMcpServer } from "./mcp-manager-dialog";
+import {
+	getMcpManagerEntryStatus,
+	getMcpManagerFooterText,
+	toggleMcpServer,
+} from "./mcp-manager-dialog";
 
 interface SetMcpServerDisabledOptions {
 	filePath?: string;
@@ -124,5 +128,19 @@ describe("mcp manager dialog helpers", () => {
 		);
 		expect(getMcpManagerFooterText(true)).not.toContain("delete");
 		expect(getMcpManagerFooterText(false)).toBe("Esc to go back");
+	});
+
+	it("shows OAuth errors before general MCP status", () => {
+		expect(
+			getMcpManagerEntryStatus({
+				description: "streamableHttp, oauth authorized",
+			}),
+		).toBe("streamableHttp, oauth authorized");
+		expect(
+			getMcpManagerEntryStatus({
+				description: "streamableHttp, oauth authorized",
+				lastError: "OAuth authorization failed",
+			}),
+		).toBe("oauth error");
 	});
 });

--- a/sdk/apps/cli/src/tui/components/dialogs/mcp-manager-dialog.tsx
+++ b/sdk/apps/cli/src/tui/components/dialogs/mcp-manager-dialog.tsx
@@ -11,6 +11,8 @@ export interface McpEntry {
 	name: string;
 	path: string;
 	enabled?: boolean;
+	description?: string;
+	lastError?: string;
 }
 
 export type McpServerToggleResult =
@@ -25,6 +27,12 @@ export function getMcpManagerFooterText(hasServers: boolean): string {
 	return hasServers
 		? "Space toggle selected, Esc to go back"
 		: "Esc to go back";
+}
+
+export function getMcpManagerEntryStatus(
+	server: Pick<McpEntry, "description" | "lastError">,
+): string {
+	return server.lastError ? "oauth error" : (server.description ?? "");
 }
 
 export function toggleMcpServer(server: McpEntry): McpServerToggleResult {
@@ -62,6 +70,7 @@ export function McpManagerContent(
 
 	const settingsPath = servers[0]?.path ?? resolveDefaultMcpSettingsPath();
 	const itemCount = servers.length;
+	const selectedServer = servers[selected];
 
 	useDialogKeyboard((key) => {
 		if (key.name === "escape") {
@@ -123,19 +132,30 @@ export function McpManagerContent(
 							typeof srv.enabled === "boolean" ? srv.enabled : true;
 						const enabledIcon =
 							typeof srv.enabled === "boolean" ? (enabled ? "● " : "○ ") : "";
-						const rowColor =
-							enabled && typeof srv.enabled === "boolean"
-								? palette.success
-								: isSel
-									? "cyan"
-									: "gray";
+						const status = getMcpManagerEntryStatus(srv);
+						let rowColor = isSel ? "cyan" : "gray";
+						if (enabled && typeof srv.enabled === "boolean") {
+							rowColor = palette.success;
+						}
+						if (srv.lastError) {
+							rowColor = palette.error;
+						}
 						return (
-							<box key={srv.name} flexDirection="row">
+							<box
+								key={srv.name}
+								flexDirection="row"
+								justifyContent="space-between"
+							>
 								<text fg={rowColor}>
 									{isSel ? "\u25b8 " : "  "}
 									{enabledIcon}
 									{srv.name}
 								</text>
+								{status && (
+									<text fg={srv.lastError ? palette.error : "gray"}>
+										{status}
+									</text>
+								)}
 							</box>
 						);
 					})}
@@ -152,6 +172,16 @@ export function McpManagerContent(
 				<text fg={palette.error} marginTop={1}>
 					{error}
 				</text>
+			)}
+
+			{selectedServer?.lastError && (
+				<box flexDirection="column" marginTop={1}>
+					<text fg={palette.error}>OAuth error</text>
+					<text fg={palette.error}>{selectedServer.lastError}</text>
+					<text fg="gray">
+						Run cline mcp and choose Authorize OAuth to retry.
+					</text>
+				</box>
 			)}
 
 			<text fg="gray" marginTop={1}>

--- a/sdk/apps/cli/src/tui/hooks/use-mcp-manager.tsx
+++ b/sdk/apps/cli/src/tui/hooks/use-mcp-manager.tsx
@@ -15,6 +15,8 @@ function toMcpEntries(items: InteractiveConfigItem[]): McpEntry[] {
 		name: item.name,
 		path: item.path,
 		enabled: item.enabled,
+		description: item.description,
+		lastError: item.loadError,
 	}));
 }
 

--- a/sdk/apps/cli/src/tui/interactive-config.ts
+++ b/sdk/apps/cli/src/tui/interactive-config.ts
@@ -6,6 +6,7 @@ import {
 	hasMcpSettingsFile,
 	listHookConfigFiles,
 	listPluginToolsWithDiagnostics,
+	type McpServerRegistration,
 	type PluginInitializationFailure,
 	type RuleConfig,
 	readGlobalSettings,
@@ -134,6 +135,33 @@ function toSorted<T extends InteractiveConfigItem>(items: T[]): T[] {
 		}
 		return a.name.localeCompare(b.name);
 	});
+}
+
+function getMcpAuthLabel(registration: McpServerRegistration): string {
+	if (registration.transport.type === "stdio") {
+		return "local";
+	}
+	if (registration.oauth?.lastError) {
+		return "oauth error";
+	}
+	const accessToken = registration.oauth?.tokens?.access_token;
+	if (typeof accessToken === "string" && accessToken.trim().length > 0) {
+		return "oauth authorized";
+	}
+	if (registration.oauth && Object.keys(registration.oauth).length > 0) {
+		return "oauth pending";
+	}
+	if (
+		registration.transport.headers &&
+		Object.keys(registration.transport.headers).length > 0
+	) {
+		return "static headers";
+	}
+	return "no auth";
+}
+
+function getMcpDescription(registration: McpServerRegistration): string {
+	return `${registration.transport.type}, ${getMcpAuthLabel(registration)}`;
 }
 
 function loadAgentConfigItems(workspaceRoot: string): InteractiveConfigItem[] {
@@ -367,7 +395,8 @@ export async function loadInteractiveConfigData(input: {
 					enabled: registration.disabled !== true,
 					kind: "mcp",
 					source: detectSource(mcpSettingsPath, input.workspaceRoot),
-					description: registration.transport.type,
+					description: getMcpDescription(registration),
+					loadError: registration.oauth?.lastError,
 				});
 			}
 		} catch {

--- a/sdk/apps/cli/src/tui/views/config-view.tsx
+++ b/sdk/apps/cli/src/tui/views/config-view.tsx
@@ -420,7 +420,12 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 						enabled: item.enabled,
 						description: item.description,
 						item,
-						rightLabel: getPluginLoadErrorLabel(item),
+						rightLabel:
+							activeTab === "mcp"
+								? item.loadError
+									? "oauth error"
+									: item.description
+								: getPluginLoadErrorLabel(item),
 					});
 				}
 				if (activeTab === "plugins" && pluginToolsLoading) {

--- a/sdk/apps/cli/src/tui/views/config-view.tsx
+++ b/sdk/apps/cli/src/tui/views/config-view.tsx
@@ -13,6 +13,7 @@ import {
 	getNextCliCompactionMode,
 } from "../../utils/compaction-mode";
 import type { CliCompactionMode, Config } from "../../utils/types";
+import { getMcpManagerEntryStatus } from "../components/dialogs/mcp-manager-dialog";
 import { resolveModelDisplayName } from "../components/status-bar";
 import { getModeAccent, palette } from "../palette";
 import {
@@ -422,9 +423,10 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 						item,
 						rightLabel:
 							activeTab === "mcp"
-								? item.loadError
-									? "oauth error"
-									: item.description
+								? getMcpManagerEntryStatus({
+										description: item.description,
+										lastError: item.loadError,
+									})
 								: getPluginLoadErrorLabel(item),
 					});
 				}


### PR DESCRIPTION
This is a small CLI UX fix from direct feedback about failed OAuth MCP servers being too hard to diagnose from the TUI.

<img width="445" height="229" alt="Google Chrome 2026-06-01 16 46 18" src="https://github.com/user-attachments/assets/ddc9119c-96f0-4bbc-92ce-105080f25f39" />
<img width="451" height="406" alt="image" src="https://github.com/user-attachments/assets/778030a9-402c-440d-8854-598e4bbb0bd2" />


### Description

When a user configures a remote MCP server that requires OAuth, such as the Linear MCP server, core already persists authorization failures into the MCP settings file as `oauth.lastError`. The standalone `cline mcp` wizard can show that state, but the interactive TUI only mapped MCP entries down to name, path, and enabled state. That meant a failed OAuth server looked like an ordinary enabled server in `/mcp` and Settings > MCP, even though the runtime had already recorded enough information to explain what went wrong.

This PR keeps the change intentionally small and reuses the existing data flow. The interactive config loader now derives a compact MCP auth status from the resolved MCP registration, such as `local`, `oauth authorized`, `oauth pending`, `oauth error`, `static headers`, or `no auth`. If the registration has `oauth.lastError`, that value is passed through as `loadError`, which lets the existing Settings UI render the MCP row as errored and show the error detail without adding a separate diagnostics model.

The `/mcp` dialog now receives that same description and error state. It shows the compact auth status on the right side of each row, colors failed OAuth rows with the existing error color, and displays the selected server's saved OAuth error with the existing retry path: run `cline mcp` and choose `Authorize OAuth`. I intentionally did not embed the OAuth browser callback flow directly into the TUI in this PR. The existing wizard already owns add, edit, delete, and OAuth authorization, and moving that into the React TUI would be a larger interaction change than needed to make failures visible.

The main behavioral result is that once core records an OAuth failure during MCP tool loading or tool use, the TUI surfaces it in both MCP management views instead of silently presenting the server as healthy.

### Test Procedure

Ran the focused test coverage for the changed paths:

```bash
bunx vitest run --config vitest.config.ts src/runtime/interactive/config-data.test.ts src/tui/components/dialogs/mcp-manager-dialog.test.ts
```

That covers the config loader surfacing `oauth.lastError` as MCP `loadError`, auth status labels for OAuth-authorized and OAuth-error servers, and the `/mcp` dialog status helper that prioritizes OAuth errors over general status text.

Ran the CLI typecheck:

```bash
bun run typecheck
```

Also checked whitespace with:

```bash
git diff --check origin/main..HEAD
```

Manual smoke path for reviewers:

- Add a remote HTTP MCP server with OAuth through `cline mcp`, for example Linear at `https://mcp.linear.app/mcp`.
- Cause OAuth to fail, or manually set `oauth.lastError` on the server entry in `cline_mcp_settings.json`.
- Open the interactive CLI and then `/mcp`.
- Confirm the row shows `oauth error`, is styled as an error, and selecting it shows the saved OAuth failure plus the `Authorize OAuth` retry guidance.
- Open Settings > MCP and confirm the same MCP entry appears as an errored row with the error detail available through the existing details view.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not included. This is a TUI rendering change and was validated through focused unit coverage plus the manual smoke path above.

### Additional Notes

The PR deliberately avoids adding runtime MCP events or a new in-TUI OAuth wizard. Core already persists the failure state, and the existing `cline mcp` wizard already has the retry action. This keeps the fix small while still making the failure actionable for users.
