### PR TITLE
fix(vscode): wire auto compact into SDK sessions

### DIFF
--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -2,8 +2,9 @@ import fs from "node:fs"
 import os from "node:os"
 import path from "node:path"
 import type { CoreSessionConfig } from "@cline/core"
-import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import {
+	buildSessionConfig,
 	buildResumeSessionInput,
 	buildStartSessionInput,
 	createHistoryItemFromSession,
@@ -14,6 +15,56 @@ import {
 	updateHistoryItem,
 } from "./cline-session-factory"
 
+const mocks = vi.hoisted(() => {
+	const providerSettingsManager = {
+		getLastUsedProviderSettings: vi.fn(() => undefined),
+		getProviderSettings: vi.fn(() => undefined),
+		saveProviderSettings: vi.fn(),
+	}
+
+	return {
+		getDistinctId: vi.fn(() => "test-distinct-id"),
+		getProviderSettingsManager: vi.fn(() => providerSettingsManager),
+		providerSettingsManager,
+		stateManager: {
+			getApiConfiguration: vi.fn(() => ({
+				actModeApiProvider: "anthropic",
+				actModeApiModelId: "claude-sonnet-4-6",
+				apiKey: "test-key",
+			})),
+			getGlobalSettingsKey: vi.fn((key: string) => {
+				if (key === "subagentsEnabled" || key === "useAutoCondense") {
+					return false
+				}
+				return undefined
+			}),
+		},
+	}
+})
+
+vi.mock("@/core/storage/StateManager", () => ({
+	StateManager: {
+		get: () => mocks.stateManager,
+	},
+}))
+
+vi.mock("@/services/logging/distinctId", () => ({
+	getDistinctId: mocks.getDistinctId,
+}))
+
+vi.mock("./provider-migration", () => ({
+	getProviderSettingsManager: mocks.getProviderSettingsManager,
+}))
+
+vi.mock("@shared/services/Logger", () => ({
+	Logger: {
+		debug: vi.fn(),
+		log: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	},
+}))
+
 // ---------------------------------------------------------------------------
 // Test helpers
 // ---------------------------------------------------------------------------
@@ -22,6 +73,20 @@ let tempDir: string
 
 beforeEach(() => {
 	tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "cline-session-factory-"))
+	vi.clearAllMocks()
+	mocks.stateManager.getApiConfiguration.mockReturnValue({
+		actModeApiProvider: "anthropic",
+		actModeApiModelId: "claude-sonnet-4-6",
+		apiKey: "test-key",
+	})
+	mocks.stateManager.getGlobalSettingsKey.mockImplementation((key: string) => {
+		if (key === "subagentsEnabled" || key === "useAutoCondense") {
+			return false
+		}
+		return undefined
+	})
+	mocks.providerSettingsManager.getLastUsedProviderSettings.mockReturnValue(undefined)
+	mocks.providerSettingsManager.getProviderSettings.mockReturnValue(undefined)
 })
 
 afterEach(() => {
@@ -199,6 +264,64 @@ describe("normalizeProviderReasoningSettings", () => {
 		const result = normalizeProviderReasoningSettings({ effort: "medium" })
 
 		expect(result).toEqual({ reasoningEffort: "medium" })
+	})
+})
+
+// ---------------------------------------------------------------------------
+// buildSessionConfig
+// ---------------------------------------------------------------------------
+
+describe("buildSessionConfig", () => {
+	it("enables basic SDK compaction when global useAutoCondense is true", async () => {
+		mocks.stateManager.getGlobalSettingsKey.mockImplementation((key: string) => {
+			if (key === "useAutoCondense") {
+				return true
+			}
+			if (key === "subagentsEnabled") {
+				return false
+			}
+			return undefined
+		})
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+
+		expect(config.compaction).toEqual({
+			enabled: true,
+			strategy: "basic",
+		})
+	})
+
+	it("does not enable SDK compaction when global useAutoCondense is false", async () => {
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+
+		expect(config.compaction).toBeUndefined()
+	})
+
+	it("lets task useAutoCondense override the global setting", async () => {
+		mocks.stateManager.getGlobalSettingsKey.mockImplementation((key: string) => {
+			if (key === "useAutoCondense") {
+				return true
+			}
+			if (key === "subagentsEnabled") {
+				return false
+			}
+			return undefined
+		})
+
+		const disabledConfig = await buildSessionConfig({
+			cwd: "/tmp/workspace",
+			taskSettings: { useAutoCondense: false },
+		})
+		const enabledConfig = await buildSessionConfig({
+			cwd: "/tmp/workspace",
+			taskSettings: { useAutoCondense: true },
+		})
+
+		expect(disabledConfig.compaction).toBeUndefined()
+		expect(enabledConfig.compaction).toEqual({
+			enabled: true,
+			strategy: "basic",
+		})
 	})
 })
 

--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -4,8 +4,8 @@ import path from "node:path"
 import type { CoreSessionConfig } from "@cline/core"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import {
-	buildSessionConfig,
 	buildResumeSessionInput,
+	buildSessionConfig,
 	buildStartSessionInput,
 	createHistoryItemFromSession,
 	getDefaultModelIdForProvider,
@@ -32,7 +32,7 @@ const mocks = vi.hoisted(() => {
 				actModeApiModelId: "claude-sonnet-4-6",
 				apiKey: "test-key",
 			})),
-			getGlobalSettingsKey: vi.fn((key: string) => {
+			getGlobalSettingsKey: vi.fn((key: string): boolean | undefined => {
 				if (key === "subagentsEnabled" || key === "useAutoCondense") {
 					return false
 				}

--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -298,9 +298,10 @@ describe("buildSessionConfig", () => {
 	})
 
 	it("lets task useAutoCondense override the global setting", async () => {
+		let globalUseAutoCondense = true
 		mocks.stateManager.getGlobalSettingsKey.mockImplementation((key: string) => {
 			if (key === "useAutoCondense") {
-				return true
+				return globalUseAutoCondense
 			}
 			if (key === "subagentsEnabled") {
 				return false
@@ -308,10 +309,14 @@ describe("buildSessionConfig", () => {
 			return undefined
 		})
 
+		// Task `false` overrides global `true`.
 		const disabledConfig = await buildSessionConfig({
 			cwd: "/tmp/workspace",
 			taskSettings: { useAutoCondense: false },
 		})
+
+		// Task `true` overrides global `false`.
+		globalUseAutoCondense = false
 		const enabledConfig = await buildSessionConfig({
 			cwd: "/tmp/workspace",
 			taskSettings: { useAutoCondense: true },

--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -557,6 +557,8 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 
 	const stateManager = StateManager.get()
 	const globalSubagentsEnabled = stateManager.getGlobalSettingsKey("subagentsEnabled") ?? false
+	const globalUseAutoCondense = stateManager.getGlobalSettingsKey("useAutoCondense") ?? false
+	const useAutoCondense = input.taskSettings?.useAutoCondense ?? globalUseAutoCondense
 
 	// Core resolves providers against the SDK registry, which uses the SDK's
 	// own provider id spelling (e.g. "openai-compatible" rather than the
@@ -589,6 +591,14 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 		enableTools: true,
 		enableSpawnAgent: input.taskSettings?.subagentsEnabled ?? globalSubagentsEnabled,
 		enableAgentTeams: false,
+		...(useAutoCondense
+			? {
+					compaction: {
+						enabled: true,
+						strategy: "basic",
+					},
+				}
+			: {}),
 		disableMcpSettingsTools: true,
 		mode: mode === "plan" ? "plan" : "act",
 		...reasoningConfig,

--- a/apps/vscode/src/sdk/sdk-task-start-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-task-start-coordinator.test.ts
@@ -61,6 +61,25 @@ describe("SdkTaskStartCoordinator", () => {
 		expect(options.sessions.startNewSession).not.toHaveBeenCalled()
 	})
 
+	it.each([true, false])("forwards task useAutoCondense=%s into SDK session config inputs", async (useAutoCondense) => {
+		const { coordinator, options } = makeCoordinator()
+		const taskSettings = { useAutoCondense }
+
+		await coordinator.initTask("hello", undefined, undefined, undefined, taskSettings)
+
+		expect(options.sessionConfigBuilder.build).toHaveBeenCalledWith(
+			expect.objectContaining({
+				taskSettings,
+			}),
+		)
+		expect(options.buildStartSessionInput).toHaveBeenCalledWith(
+			expect.any(Object),
+			expect.objectContaining({
+				taskSettings,
+			}),
+		)
+	})
+
 	it("reinitializes an existing task with preserved initial messages", async () => {
 		const historyItem: HistoryItem = {
 			id: "task-1",


### PR DESCRIPTION
### Related Issue

**Issue:** [ENG-2136](https://linear.app/cline-bot/issue/ENG-2136/wire-auto-compact-setting-into-vs-code-sdk-session-compaction)

### Description

SDK-backed VS Code sessions were ignoring the Auto Compact setting because `buildSessionConfig` only mapped `subagentsEnabled` from VS Code task/global settings into `CoreSessionConfig`.

This PR maps the effective `useAutoCondense` setting into SDK compaction config for VS Code sessions:

- Reads task-specific `useAutoCondense` when present, otherwise falls back to global state.
- Enables SDK compaction with `{ enabled: true, strategy: "basic" }` only when Auto Compact is enabled.
- Adds factory coverage for enabled, disabled, and task override behavior.
- Adds task-start boundary coverage that preserves both `useAutoCondense: true` and `false` into SDK session config inputs.

### Test Procedure

Ran focused VS Code SDK session config tests:

```sh
cd /Users/robin/.cursor/worktrees/cline/awwy/apps/vscode
bunx vitest run --config vitest.config.ts src/sdk/cline-session-factory.test.ts src/sdk/sdk-task-start-coordinator.test.ts
```

Ran focused SDK compaction regression tests:

```sh
cd /Users/robin/.cursor/worktrees/cline/awwy/sdk/packages/core
bunx vitest run --config vitest.config.ts src/extensions/context/compaction.test.ts
```

Both passed.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - SDK session config wiring only.

### Additional Notes

This is based on `dpc/sdk-migration-simpler-login`, where the VS Code SDK session factory already exists. It is not stacked on #11194.

Architecture acknowledgment: task-specific settings are only present on new-task starts in this path. Resumed sessions fall back to global state here, matching the existing `subagentsEnabled` mapping. That is the narrow fix for this setting; if more VS Code settings are mapped into `CoreSessionConfig`, centralizing effective task/global setting resolution would be a good follow-up.
