### PR TITLE
feat: add MiniMax M3 model

### DIFF
--- a/apps/vscode/src/shared/api.ts
+++ b/apps/vscode/src/shared/api.ts
@@ -5197,6 +5197,34 @@ export const qwenCodeDefaultModelId: QwenCodeModelId = "qwen3-coder-plus"
 export type MinimaxModelId = keyof typeof minimaxModels
 export const minimaxDefaultModelId: MinimaxModelId = "MiniMax-M2.7"
 export const minimaxModels = {
+	"MiniMax-M3": {
+		maxTokens: 32_000,
+		contextWindow: 1_000_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		supportsReasoning: true,
+		inputPrice: 0.6,
+		outputPrice: 2.4,
+		cacheWritesPrice: 0.6,
+		cacheReadsPrice: 0.12,
+		tiers: [
+			{
+				contextWindow: 512_000,
+				inputPrice: 0.6,
+				outputPrice: 2.4,
+				cacheWritesPrice: 0.6,
+				cacheReadsPrice: 0.12,
+			},
+			{
+				contextWindow: Number.MAX_SAFE_INTEGER,
+				inputPrice: 1.2,
+				outputPrice: 4.8,
+				cacheWritesPrice: 1.2,
+				cacheReadsPrice: 0.24,
+			},
+		],
+		description: "Latest M-series model for coding, agentic reasoning, tool use, and long-context multimodal tasks",
+	},
 	"MiniMax-M2.7": {
 		maxTokens: 128_000,
 		contextWindow: 192_000,


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Adds `MiniMax-M3` to the VS Code extension's MiniMax provider model catalog so it appears in the MiniMax settings model picker and can be selected by users.

The new model entry uses MiniMax's Anthropic-compatible model id, 1M context window, reasoning support, image support, prompt cache pricing, and tiered pricing for requests above 512k input tokens based on the current MiniMax API docs.

References:
- https://platform.minimax.io/docs/api-reference/text-anthropic-api
- https://platform.minimax.io/docs/api-reference/api-overview
- https://platform.minimax.io/docs/guides/pricing-paygo

### Test Procedure

- Installed extension dependencies with `npm ci` in `apps/vscode`.
- Installed webview dependencies with `npm ci` in `apps/vscode/webview-ui`.
- Ran `npm run protos` in `apps/vscode` after adding a temporary ignored `node_modules/grpc-tools/bin/protoc` symlink to the system `/opt/homebrew/bin/protoc`, because the `grpc-tools` install under local Node 25 did not include its bundled native binary.
- Ran `npx tsc --noEmit` in `apps/vscode`.
- Ran `npx tsc --noEmit` in `apps/vscode/webview-ui`.
- Ran `npx biome check --changed --no-errors-on-unmatched --files-ignore-unknown=true --diagnostic-level=error` in `apps/vscode`.

Full `npm test` was not run for this metadata-only provider catalog change.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - model catalog metadata change only.

### Additional Notes

Kept the existing MiniMax default model as `MiniMax-M2.7` to avoid changing existing users' default provider behavior; `MiniMax-M3` is added as a selectable option.
