### PR TITLE
fix(vscode): reuse approved tool rows

### DIFF
--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -234,6 +234,8 @@ export class Controller {
 			// asks, ask_question, user_feedback) never collide with translator-minted ids.
 			getMinter: () => this.messageTranslatorState.getMinter(),
 			setTurnPhase: (phase, anchorTs) => this.turnStateTracker.set(phase, anchorTs),
+			recordApprovedToolMessage: (toolCallId, messageTs) =>
+				this.messageTranslatorState.recordApprovedToolMessageTs(toolCallId, messageTs),
 			shouldAutoApproveTool: (request) => {
 				const autoApprovalSettings = this.stateManager.getGlobalSettingsKey("autoApprovalSettings")
 				return autoApprovalSettings ? isToolAutoApproved(request.toolName, autoApprovalSettings, this.mcpHub) : false

--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -371,7 +371,10 @@ export class Controller {
 			// Bump the epoch synchronously before abort so straggler events from the cancelled
 			// turn carry the old epoch and are dropped by the webview. The resumable phase is set
 			// in SdkController.cancelTask before this runs.
-			raiseCancelFence: () => this.messageTranslatorState.getMinter().bumpEpoch(),
+			raiseCancelFence: () => {
+				this.messageTranslatorState.clearApprovedToolMessageTs()
+				this.messageTranslatorState.getMinter().bumpEpoch()
+			},
 			postStateToWebview: () => this.postStateToWebview(),
 		})
 		this.taskStart = new SdkTaskStartCoordinator({

--- a/apps/vscode/src/sdk/message-translator.test.ts
+++ b/apps/vscode/src/sdk/message-translator.test.ts
@@ -90,6 +90,15 @@ describe("MessageTranslatorState", () => {
 		expect(newToolTs).toBeGreaterThan(toolTs)
 	})
 
+	it("reset clears stale approved tool prompt rows", () => {
+		const state = new MessageTranslatorState()
+		state.recordApprovedToolMessageTs("approved-call", 42)
+
+		state.reset()
+
+		expect(state.consumeApprovedToolMessageTs("approved-call")).toBeUndefined()
+	})
+
 	it("reset() (per-iteration) does NOT clear attemptCompletionSeen — it is turn-scoped", () => {
 		// The agent can call the completion tool in one iteration and the loop then emits another
 		// `iteration_start` → state.reset() before the turn's `done` event. The completion signal
@@ -222,6 +231,173 @@ describe("translateSessionEvent — agent_event content_start", () => {
 			tool: "editedExistingFile",
 			path: "/src/app.ts",
 		})
+	})
+
+	it("reuses the approved command prompt row for the matching command lifecycle", () => {
+		const state = new MessageTranslatorState()
+		const approvedMessageTs = state.nextTs()
+		state.recordApprovedToolMessageTs("command-call", approvedMessageTs)
+
+		const startResult = translateSessionEvent(
+			{
+				type: "agent_event",
+				payload: {
+					sessionId: "session-1",
+					event: {
+						type: "content_start",
+						contentType: "tool",
+						toolName: "execute_command",
+						toolCallId: "command-call",
+						input: { command: "npm test" },
+					} as AgentEvent,
+				},
+			},
+			state,
+		)
+
+		expect(startResult.messages[0]).toMatchObject({
+			ts: approvedMessageTs,
+			type: "say",
+			say: "command",
+			partial: true,
+		})
+
+		const endResult = translateSessionEvent(
+			{
+				type: "agent_event",
+				payload: {
+					sessionId: "session-1",
+					event: {
+						type: "content_end",
+						contentType: "tool",
+						toolName: "execute_command",
+						toolCallId: "command-call",
+						output: [{ result: "passed", success: true }],
+					} as AgentEvent,
+				},
+			},
+			state,
+		)
+
+		expect(endResult.messages[0]).toMatchObject({
+			ts: approvedMessageTs,
+			type: "say",
+			say: "command",
+			partial: false,
+			commandCompleted: true,
+		})
+	})
+
+	it("reuses the approved MCP prompt row for the matching MCP tool lifecycle", () => {
+		const state = new MessageTranslatorState()
+		const approvedMessageTs = state.nextTs()
+		state.recordApprovedToolMessageTs("mcp-call", approvedMessageTs)
+
+		const startResult = translateSessionEvent(
+			{
+				type: "agent_event",
+				payload: {
+					sessionId: "session-1",
+					event: {
+						type: "content_start",
+						contentType: "tool",
+						toolName: "notion__notion-get-users",
+						toolCallId: "mcp-call",
+						input: { user_id: "self" },
+					} as AgentEvent,
+				},
+			},
+			state,
+		)
+
+		expect(startResult.messages[0]).toMatchObject({
+			ts: approvedMessageTs,
+			type: "say",
+			say: "use_mcp_server",
+			partial: true,
+		})
+
+		const endResult = translateSessionEvent(
+			{
+				type: "agent_event",
+				payload: {
+					sessionId: "session-1",
+					event: {
+						type: "content_end",
+						contentType: "tool",
+						toolName: "notion__notion-get-users",
+						toolCallId: "mcp-call",
+						output: "ok",
+					} as AgentEvent,
+				},
+			},
+			state,
+		)
+
+		expect(endResult.messages[0]).toMatchObject({
+			ts: approvedMessageTs,
+			type: "say",
+			say: "use_mcp_server",
+			partial: false,
+		})
+	})
+
+	it("consumes an approved prompt row only once", () => {
+		const state = new MessageTranslatorState()
+		const approvedMessageTs = state.nextTs()
+		state.recordApprovedToolMessageTs("approved-call", approvedMessageTs)
+
+		const firstStart = translateSessionEvent(
+			{
+				type: "agent_event",
+				payload: {
+					sessionId: "session-1",
+					event: {
+						type: "content_start",
+						contentType: "tool",
+						toolName: "editor",
+						toolCallId: "approved-call",
+						input: { path: "/src/app.ts", old_text: "a", new_text: "b" },
+					} as AgentEvent,
+				},
+			},
+			state,
+		)
+		translateSessionEvent(
+			{
+				type: "agent_event",
+				payload: {
+					sessionId: "session-1",
+					event: {
+						type: "content_end",
+						contentType: "tool",
+						toolName: "editor",
+						toolCallId: "approved-call",
+					} as AgentEvent,
+				},
+			},
+			state,
+		)
+
+		const secondStart = translateSessionEvent(
+			{
+				type: "agent_event",
+				payload: {
+					sessionId: "session-1",
+					event: {
+						type: "content_start",
+						contentType: "tool",
+						toolName: "editor",
+						toolCallId: "approved-call",
+						input: { path: "/src/app.ts", old_text: "b", new_text: "c" },
+					} as AgentEvent,
+				},
+			},
+			state,
+		)
+
+		expect(firstStart.messages[0].ts).toBe(approvedMessageTs)
+		expect(secondStart.messages[0].ts).not.toBe(approvedMessageTs)
 	})
 
 	it("translates text content_start to partial text message", () => {

--- a/apps/vscode/src/sdk/message-translator.test.ts
+++ b/apps/vscode/src/sdk/message-translator.test.ts
@@ -161,6 +161,69 @@ describe("translateSessionEvent — chunk events", () => {
 // ---------------------------------------------------------------------------
 
 describe("translateSessionEvent — agent_event content_start", () => {
+	it("reuses the approved tool prompt row for the matching tool lifecycle", () => {
+		const state = new MessageTranslatorState()
+		const approvedMessageTs = 42
+		state.recordApprovedToolMessageTs("approved-call", approvedMessageTs)
+
+		const startResult = translateSessionEvent(
+			{
+				type: "agent_event",
+				payload: {
+					sessionId: "session-1",
+					event: {
+						type: "content_start",
+						contentType: "tool",
+						toolName: "editor",
+						toolCallId: "approved-call",
+						input: {
+							path: "/src/app.ts",
+							old_text: "return false",
+							new_text: "return true",
+						},
+					} as AgentEvent,
+				},
+			},
+			state,
+		)
+
+		expect(startResult.messages).toHaveLength(1)
+		expect(startResult.messages[0]).toMatchObject({
+			ts: approvedMessageTs,
+			type: "say",
+			say: "tool",
+			partial: true,
+		})
+
+		const endResult = translateSessionEvent(
+			{
+				type: "agent_event",
+				payload: {
+					sessionId: "session-1",
+					event: {
+						type: "content_end",
+						contentType: "tool",
+						toolName: "editor",
+						toolCallId: "approved-call",
+					} as AgentEvent,
+				},
+			},
+			state,
+		)
+
+		expect(endResult.messages).toHaveLength(1)
+		expect(endResult.messages[0]).toMatchObject({
+			ts: approvedMessageTs,
+			type: "say",
+			say: "tool",
+			partial: false,
+		})
+		expect(JSON.parse(endResult.messages[0].text ?? "{}")).toMatchObject({
+			tool: "editedExistingFile",
+			path: "/src/app.ts",
+		})
+	})
+
 	it("translates text content_start to partial text message", () => {
 		const state = new MessageTranslatorState()
 		const event: CoreSessionEvent = {

--- a/apps/vscode/src/sdk/message-translator.ts
+++ b/apps/vscode/src/sdk/message-translator.ts
@@ -121,6 +121,8 @@ export class MessageTranslatorState {
 	private streamingToolInput: unknown | undefined
 	/** Stored tool name from content_start — used at content_end for consistency */
 	private streamingToolName: string | undefined
+	/** Approved tool-call ids mapped to the approval row that should be updated in place. */
+	private approvedToolMessageTsByCallId = new Map<string, number>()
 	/**
 	 * Process-wide id/seq/epoch authority. Shared with the interaction coordinator and history
 	 * rendering so that message ids never collide across generators. See message-id-minter.ts.
@@ -190,6 +192,28 @@ export class MessageTranslatorState {
 	setStreamingToolContext(toolName: string, input: unknown): void {
 		this.streamingToolName = toolName
 		this.streamingToolInput = input
+	}
+
+	/** Remember the approval prompt row for a tool call after the user approves it. */
+	recordApprovedToolMessageTs(toolCallId: string, messageTs: number): void {
+		this.approvedToolMessageTsByCallId.set(toolCallId, messageTs)
+	}
+
+	/** Reuse and remove a previously-approved prompt row for the matching tool event. */
+	consumeApprovedToolMessageTs(toolCallId: string | undefined): number | undefined {
+		if (!toolCallId) {
+			return undefined
+		}
+		const messageTs = this.approvedToolMessageTsByCallId.get(toolCallId)
+		if (messageTs !== undefined) {
+			this.approvedToolMessageTsByCallId.delete(toolCallId)
+		}
+		return messageTs
+	}
+
+	/** Force the active tool stream to update a known row instead of minting a new row. */
+	setStreamingToolTs(ts: number): void {
+		this.streamingToolTs = ts
 	}
 
 	/** Get the stored tool input (from content_start) */
@@ -282,6 +306,11 @@ export class MessageTranslatorState {
 			this.spawnAgentPromptsTs = this.nextTs()
 		}
 		return this.spawnAgentPromptsTs
+	}
+
+	/** Force the aggregated spawn-agent prompt row to update a known approval row. */
+	setSpawnAgentPromptsTs(ts: number): void {
+		this.spawnAgentPromptsTs = ts
 	}
 
 	/** Get or create the stable timestamp for subagent status messages */
@@ -841,6 +870,10 @@ function translateAgentEvent(event: AgentEvent, state: MessageTranslatorState): 
 					// Store tool context so content_end can use it
 					// (content_end doesn't carry the input)
 					state.setStreamingToolContext(toolName, input)
+					const approvedToolMessageTs = state.consumeApprovedToolMessageTs(event.toolCallId)
+					if (approvedToolMessageTs !== undefined) {
+						state.setStreamingToolTs(approvedToolMessageTs)
+					}
 
 					// ask_question (and ask_followup_question) is NOT a visual tool row: the
 					// SdkInteractionCoordinator services it and emits the proper ask:"followup"
@@ -890,6 +923,9 @@ function translateAgentEvent(event: AgentEvent, state: MessageTranslatorState): 
 						const taskPrompt = getStringField(parsedInput, "task") ?? ""
 						const callId = event.toolCallId ?? `spawn-${state.nextTs()}`
 						state.addSpawnAgent(callId, taskPrompt)
+						if (approvedToolMessageTs !== undefined) {
+							state.setSpawnAgentPromptsTs(approvedToolMessageTs)
+						}
 
 						// Emit the combined prompts list (replaces itself on each new spawn_agent)
 						const allPrompts = state.getSpawnAgentItems().map((e) => e.prompt)

--- a/apps/vscode/src/sdk/message-translator.ts
+++ b/apps/vscode/src/sdk/message-translator.ts
@@ -199,6 +199,11 @@ export class MessageTranslatorState {
 		this.approvedToolMessageTsByCallId.set(toolCallId, messageTs)
 	}
 
+	/** Clear approved prompt rows that no longer have a live tool event to consume them. */
+	clearApprovedToolMessageTs(): void {
+		this.approvedToolMessageTsByCallId.clear()
+	}
+
 	/** Reuse and remove a previously-approved prompt row for the matching tool event. */
 	consumeApprovedToolMessageTs(toolCallId: string | undefined): number | undefined {
 		if (!toolCallId) {
@@ -363,6 +368,7 @@ export class MessageTranslatorState {
 		this.streamingToolTs = undefined
 		this.streamingToolInput = undefined
 		this.streamingToolName = undefined
+		this.clearApprovedToolMessageTs()
 		this.clearSpawnAgents()
 	}
 

--- a/apps/vscode/src/sdk/sdk-interaction-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-interaction-coordinator.test.ts
@@ -17,10 +17,12 @@ describe("SdkInteractionCoordinator", () => {
 		const messages = new SdkMessageCoordinator({ getTask: () => task })
 		const listener = vi.fn()
 		const postStateToWebview = vi.fn().mockResolvedValue(undefined)
+		const recordApprovedToolMessage = vi.fn()
 		const coordinator = new SdkInteractionCoordinator({
 			messages,
 			getSessionId: () => "session-123",
 			postStateToWebview,
+			recordApprovedToolMessage,
 		})
 		messages.onSessionEvent(listener)
 
@@ -43,15 +45,18 @@ describe("SdkInteractionCoordinator", () => {
 		expect(listener).toHaveBeenCalledOnce()
 
 		expect(coordinator.resolvePendingToolApproval(undefined, "yesButtonClicked")).toBe(true)
+		expect(recordApprovedToolMessage).toHaveBeenCalledWith("tool-call", clineMessages[0].ts)
 		await expect(approvalPromise).resolves.toEqual({ approved: true })
 	})
 
 	it("resolves denied tool approval with the user reason", async () => {
 		const task = createTaskProxy("session-123", vi.fn(), vi.fn())
+		const recordApprovedToolMessage = vi.fn()
 		const coordinator = new SdkInteractionCoordinator({
 			messages: new SdkMessageCoordinator({ getTask: () => task }),
 			getSessionId: () => "session-123",
 			postStateToWebview: vi.fn().mockResolvedValue(undefined),
+			recordApprovedToolMessage,
 		})
 
 		const approvalPromise = coordinator.handleRequestToolApproval({
@@ -69,6 +74,7 @@ describe("SdkInteractionCoordinator", () => {
 		expect(clineMessages[0]).toMatchObject({ type: "ask", ask: "command", text: "npm test" })
 
 		expect(coordinator.resolvePendingToolApproval("too risky", "noButtonClicked")).toBe(true)
+		expect(recordApprovedToolMessage).not.toHaveBeenCalled()
 		await expect(approvalPromise).resolves.toEqual({ approved: false, reason: "too risky" })
 	})
 

--- a/apps/vscode/src/sdk/sdk-interaction-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-interaction-coordinator.test.ts
@@ -1,4 +1,6 @@
+import type { AgentEvent } from "@cline/shared"
 import { describe, expect, it, vi } from "vitest"
+import { MessageTranslatorState, translateSessionEvent } from "./message-translator"
 import { SdkInteractionCoordinator } from "./sdk-interaction-coordinator"
 import { SdkMessageCoordinator } from "./sdk-message-coordinator"
 import { createTaskProxy } from "./task-proxy"
@@ -49,6 +51,53 @@ describe("SdkInteractionCoordinator", () => {
 		await expect(approvalPromise).resolves.toEqual({ approved: true })
 	})
 
+	it("records the real approval row timestamp that the translator reuses", async () => {
+		const task = createTaskProxy("session-123", vi.fn(), vi.fn())
+		const messages = new SdkMessageCoordinator({ getTask: () => task })
+		const state = new MessageTranslatorState()
+		const coordinator = new SdkInteractionCoordinator({
+			messages,
+			getSessionId: () => "session-123",
+			postStateToWebview: vi.fn().mockResolvedValue(undefined),
+			getMinter: () => state.getMinter(),
+			recordApprovedToolMessage: (toolCallId, messageTs) => state.recordApprovedToolMessageTs(toolCallId, messageTs),
+		})
+
+		const approvalPromise = coordinator.handleRequestToolApproval({
+			agentId: "agent",
+			conversationId: "conversation",
+			iteration: 1,
+			toolCallId: "tool-call",
+			toolName: "editor",
+			input: { path: "calculator.py", old_text: "# comment", new_text: "" },
+			policy: { autoApprove: false },
+		})
+		await vi.waitFor(() => expect(task.messageStateHandler.getClineMessages()).toHaveLength(1))
+		const approvalTs = task.messageStateHandler.getClineMessages()[0].ts
+
+		expect(coordinator.resolvePendingToolApproval(undefined, "yesButtonClicked")).toBe(true)
+		await expect(approvalPromise).resolves.toEqual({ approved: true })
+
+		const result = translateSessionEvent(
+			{
+				type: "agent_event",
+				payload: {
+					sessionId: "session-123",
+					event: {
+						type: "content_start",
+						contentType: "tool",
+						toolName: "editor",
+						toolCallId: "tool-call",
+						input: { path: "calculator.py", old_text: "# comment", new_text: "" },
+					} as AgentEvent,
+				},
+			},
+			state,
+		)
+
+		expect(result.messages[0]).toMatchObject({ ts: approvalTs, type: "say", say: "tool", partial: true })
+	})
+
 	it("resolves denied tool approval with the user reason", async () => {
 		const task = createTaskProxy("session-123", vi.fn(), vi.fn())
 		const recordApprovedToolMessage = vi.fn()
@@ -81,11 +130,13 @@ describe("SdkInteractionCoordinator", () => {
 	it("auto-approves without emitting UI when the live settings allow the tool", async () => {
 		const task = createTaskProxy("session-123", vi.fn(), vi.fn())
 		const postStateToWebview = vi.fn().mockResolvedValue(undefined)
+		const recordApprovedToolMessage = vi.fn()
 		const coordinator = new SdkInteractionCoordinator({
 			messages: new SdkMessageCoordinator({ getTask: () => task }),
 			getSessionId: () => "session-123",
 			postStateToWebview,
 			shouldAutoApproveTool: () => true,
+			recordApprovedToolMessage,
 		})
 
 		await expect(
@@ -102,16 +153,19 @@ describe("SdkInteractionCoordinator", () => {
 
 		expect(task.messageStateHandler.getClineMessages()).toHaveLength(0)
 		expect(postStateToWebview).not.toHaveBeenCalled()
+		expect(recordApprovedToolMessage).not.toHaveBeenCalled()
 	})
 
 	it("auto-approves without emitting UI when the SDK policy already allows the tool", async () => {
 		const task = createTaskProxy("session-123", vi.fn(), vi.fn())
 		const postStateToWebview = vi.fn().mockResolvedValue(undefined)
+		const recordApprovedToolMessage = vi.fn()
 		const coordinator = new SdkInteractionCoordinator({
 			messages: new SdkMessageCoordinator({ getTask: () => task }),
 			getSessionId: () => "session-123",
 			postStateToWebview,
 			shouldAutoApproveTool: () => false,
+			recordApprovedToolMessage,
 		})
 
 		await expect(
@@ -128,6 +182,7 @@ describe("SdkInteractionCoordinator", () => {
 
 		expect(task.messageStateHandler.getClineMessages()).toHaveLength(0)
 		expect(postStateToWebview).not.toHaveBeenCalled()
+		expect(recordApprovedToolMessage).not.toHaveBeenCalled()
 	})
 
 	it("emits an MCP approval ask with server, tool, and arguments", async () => {

--- a/apps/vscode/src/sdk/sdk-interaction-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-interaction-coordinator.ts
@@ -20,6 +20,7 @@ export interface SdkInteractionCoordinatorOptions {
 	getSessionId: () => string
 	postStateToWebview: () => Promise<void>
 	shouldAutoApproveTool?: (request: ToolApprovalRequest) => boolean
+	recordApprovedToolMessage?: (toolCallId: string, messageTs: number) => void
 	/**
 	 * The process-wide id/seq/epoch authority, shared with the message translator. Optional so
 	 * existing tests that don't need cross-generator id uniqueness keep working; when omitted a
@@ -37,6 +38,12 @@ export interface SdkInteractionCoordinatorOptions {
 export class SdkInteractionCoordinator {
 	private pendingAskResolve: ((answer: string) => void) | undefined
 	private pendingToolApprovalResolve: ((result: { approved: boolean; reason?: string }) => void) | undefined
+	private pendingToolApprovalMessage:
+		| {
+				toolCallId: string
+				messageTs: number
+		  }
+		| undefined
 
 	constructor(private readonly options: SdkInteractionCoordinatorOptions) {}
 
@@ -57,6 +64,7 @@ export class SdkInteractionCoordinator {
 
 		return new Promise<{ approved: boolean; reason?: string }>((resolve) => {
 			this.pendingToolApprovalResolve = resolve
+			this.pendingToolApprovalMessage = { toolCallId: request.toolCallId, messageTs: toolAskMessage.ts }
 		})
 	}
 
@@ -91,9 +99,14 @@ export class SdkInteractionCoordinator {
 		}
 
 		const resolve = this.pendingToolApprovalResolve
+		const pendingMessage = this.pendingToolApprovalMessage
 		this.pendingToolApprovalResolve = undefined
+		this.pendingToolApprovalMessage = undefined
 		const approved = responseType === "yesButtonClicked"
 		Logger.log(`[SdkController] Resolving pending tool approval: approved=${approved} (responseType=${responseType})`)
+		if (approved && pendingMessage) {
+			this.options.recordApprovedToolMessage?.(pendingMessage.toolCallId, pendingMessage.messageTs)
+		}
 
 		// Approved or rejected, the agent resumes its turn — back to streaming. (On rejection
 		// the agent receives the denial and continues; the SDK drives the next phase.)
@@ -137,6 +150,7 @@ export class SdkInteractionCoordinator {
 
 	clearPending(reason: string): void {
 		this.pendingAskResolve = undefined
+		this.pendingToolApprovalMessage = undefined
 		if (this.pendingToolApprovalResolve) {
 			this.pendingToolApprovalResolve({ approved: false, reason })
 			this.pendingToolApprovalResolve = undefined


### PR DESCRIPTION
### Related Issue

**Issue:** ENG-2140

### Description

Approved SDK tool calls were rendered twice in the chat transcript: once as the manual approval prompt and again as the SDK tool lifecycle row after approval. This reuses the approved prompt row as the identity for the matching tool lifecycle event, so the webview updates the existing row in place instead of appending a duplicate.

The fix records the approved tool call id and approval message timestamp, then the message translator consumes that timestamp when the matching `content_start` / `content_end` events arrive. This applies to normal tools, commands, MCP tools, and the aggregated subagent approval row.


## After the fix new file and edit file work okay 

<img width="425" height="552" alt="image" src="https://github.com/user-attachments/assets/05970655-0cdb-4226-af80-c4d71dde98ee" />

<img width="461" height="483" alt="image" src="https://github.com/user-attachments/assets/f165627f-0825-4e5e-8844-75aac99bca34" />



### Test Procedure

- `npm run test:vitest` — 41 test files, 483 tests passed
- `npx tsc --noEmit --project tsconfig.json`
- `npm run lint`

Added regression coverage for reusing the approved tool prompt row across tool start and finish, and for recording only approved tool prompts.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not included. The regression is covered by SDK translator tests.

### Additional Notes

Full `npm test` was not run; this PR was validated with full Vitest, TypeScript, and lint.
