### PR TITLE
fix(llms): strip Cerebras reasoning history

### DIFF
--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -18,7 +18,11 @@ import { jsonSchema, streamText } from "ai";
 import { nanoid } from "nanoid";
 import { z } from "zod";
 import { extractErrorMessage } from "./format";
-import { isAnthropicCompatibleModel, resolveModelFamily } from "./model-facts";
+import {
+	isAnthropicCompatibleModel,
+	isCerebrasProvider,
+	resolveModelFamily,
+} from "./model-facts";
 import {
 	applyPromptCacheToLastTextPart,
 	shouldApplyPromptCache,
@@ -49,9 +53,9 @@ function buildCachedAiSdkMessages(
 	context: GatewayProviderContext,
 	systemPrompt?: string,
 ) {
-	const aiMessages = toAiSdkMessages(request.messages, systemPrompt) as Array<
-		Record<string, unknown>
-	>;
+	const aiMessages = toAiSdkMessages(request.messages, systemPrompt, {
+		includeReasoning: shouldIncludeReasoningHistory(request, context),
+	}) as Array<Record<string, unknown>>;
 	const includeAnthropic = isAnthropicCompatibleModel({
 		modelId: request.modelId,
 		family: resolveModelFamily(context),
@@ -71,6 +75,13 @@ function buildCachedAiSdkMessages(
 	return aiMessages;
 }
 
+function shouldIncludeReasoningHistory(
+	request: GatewayStreamRequest,
+	context: GatewayProviderContext,
+): boolean {
+	return !isCerebrasProvider(request, context);
+}
+
 async function ensureGatewayLangfuseTelemetry(
 	providerId: string,
 ): Promise<boolean> {
@@ -85,11 +96,14 @@ async function ensureGatewayLangfuseTelemetry(
 function toAiSdkMessages(
 	messages: readonly AgentMessage[],
 	systemPrompt?: string,
+	options?: { includeReasoning?: boolean },
 ) {
+	const includeReasoning = options?.includeReasoning ?? true;
 	const normalizedMessages: AiSdkFormatterMessage[] = [];
 
 	for (const message of messages) {
 		const content: AiSdkFormatterPart[] = [];
+		let skippedReasoning = false;
 		for (const part of message.content) {
 			if (part.type === "text") {
 				content.push({ type: "text", text: sanitizeSurrogates(part.text) });
@@ -97,6 +111,10 @@ function toAiSdkMessages(
 			}
 
 			if (part.type === "reasoning") {
+				if (!includeReasoning) {
+					skippedReasoning = true;
+					continue;
+				}
 				const metadata = part.metadata as Record<string, unknown> | undefined;
 				const signature = metadata?.signature;
 				const redactedData = metadata?.redactedData;
@@ -170,6 +188,8 @@ function toAiSdkMessages(
 
 		if (content.length > 0) {
 			normalizedMessages.push({ role: message.role, content });
+		} else if (!includeReasoning && skippedReasoning) {
+			continue;
 		} else if (message.role === "user" || message.role === "assistant") {
 			normalizedMessages.push({ role: message.role, content: "" });
 		}
@@ -890,7 +910,12 @@ function createAiSdkProvider(kind: ProviderModuleKind): GatewayProviderFactory {
 					model: provider.model(context.model.id) as never,
 					messages: (shouldApplyPromptCache(request, context)
 						? buildCachedAiSdkMessages(request, context, messagesSystemPrompt)
-						: toAiSdkMessages(request.messages, messagesSystemPrompt)) as never,
+						: toAiSdkMessages(request.messages, messagesSystemPrompt, {
+								includeReasoning: shouldIncludeReasoningHistory(
+									request,
+									context,
+								),
+							})) as never,
 					...(useSystemOption ? { system: systemPrompt } : {}),
 					tools: tools as never,
 					temperature: request.temperature,

--- a/sdk/packages/llms/src/providers/compat.test.ts
+++ b/sdk/packages/llms/src/providers/compat.test.ts
@@ -431,6 +431,60 @@ describe("createGatewayApiHandler.createMessage", () => {
 			}),
 		);
 	});
+
+	it("strips legacy thinking history before sending Cerebras requests", async () => {
+		streamTextSpy.mockReturnValue({
+			fullStream: (async function* () {
+				yield { type: "finish", finishReason: "stop" };
+			})(),
+			usage: Promise.resolve({ inputTokens: 1, outputTokens: 1 }),
+		});
+
+		const handler = createGatewayApiHandler({
+			providerId: "cerebras",
+			modelId: "zai-glm-4.7",
+			apiKey: "test-key",
+		});
+
+		for await (const _chunk of handler.createMessage("", [
+			{ role: "user", content: "hello" },
+			{
+				role: "assistant",
+				content: [
+					{ type: "thinking", thinking: "private trace" },
+					{ type: "text", text: "Hello from Cline" },
+				],
+			},
+			{
+				role: "assistant",
+				content: [{ type: "thinking", thinking: "drop me" }],
+			},
+			{ role: "user", content: "workd" },
+		])) {
+			// Drain the stream so the provider request is executed.
+		}
+
+		const call = streamTextSpy.mock.calls.at(-1)?.[0] as
+			| { messages?: unknown[] }
+			| undefined;
+		expect(call?.messages).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					role: "assistant",
+					content: [
+						expect.objectContaining({
+							type: "text",
+							text: "Hello from Cline",
+						}),
+					],
+				}),
+			]),
+		);
+		const serializedMessages = JSON.stringify(call?.messages);
+		expect(serializedMessages).not.toContain("reasoning");
+		expect(serializedMessages).not.toContain("private trace");
+		expect(serializedMessages).not.toContain("drop me");
+	});
 });
 
 /**

--- a/sdk/packages/llms/src/providers/gateway.test.ts
+++ b/sdk/packages/llms/src/providers/gateway.test.ts
@@ -722,6 +722,159 @@ describe("sdk-gateway", () => {
 		);
 	});
 
+	it("strips reasoning history before sending Cerebras follow-up requests", async () => {
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([
+				{ type: "finish", usage: { inputTokens: 1, outputTokens: 1 } },
+			]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [
+				{
+					providerId: "cerebras",
+					apiKey: "cerebras-key",
+				},
+			],
+		});
+
+		await collect(
+			await gateway.stream({
+				providerId: "cerebras",
+				modelId: "zai-glm-4.7",
+				messages: [
+					baseMessages[0],
+					{
+						id: "assistant_1",
+						role: "assistant",
+						content: [
+							{ type: "reasoning", text: "internal thinking" },
+							{ type: "text", text: "Hello!" },
+						],
+						createdAt: Date.now(),
+					},
+					{
+						id: "user_2",
+						role: "user",
+						content: [{ type: "text", text: "tell me more" }],
+						createdAt: Date.now(),
+					},
+				],
+			}),
+		);
+
+		const call = streamTextSpy.mock.calls.at(-1)?.[0] as
+			| { messages?: unknown }
+			| undefined;
+		expect(call?.messages).toEqual([
+			{ role: "user", content: [{ type: "text", text: "Hello" }] },
+			{ role: "assistant", content: [{ type: "text", text: "Hello!" }] },
+			{ role: "user", content: [{ type: "text", text: "tell me more" }] },
+		]);
+		expect(JSON.stringify(call?.messages)).not.toContain("reasoning");
+	});
+
+	it("omits Cerebras reasoning-only assistant history instead of sending empty assistant content", async () => {
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([
+				{ type: "finish", usage: { inputTokens: 1, outputTokens: 1 } },
+			]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [
+				{
+					providerId: "cerebras",
+					apiKey: "cerebras-key",
+				},
+			],
+		});
+
+		await collect(
+			await gateway.stream({
+				providerId: "cerebras",
+				modelId: "zai-glm-4.7",
+				messages: [
+					baseMessages[0],
+					{
+						id: "assistant_1",
+						role: "assistant",
+						content: [{ type: "reasoning", text: "internal thinking" }],
+						createdAt: Date.now(),
+					},
+					{
+						id: "user_2",
+						role: "user",
+						content: [{ type: "text", text: "tell me more" }],
+						createdAt: Date.now(),
+					},
+				],
+			}),
+		);
+
+		const call = streamTextSpy.mock.calls.at(-1)?.[0] as
+			| { messages?: unknown }
+			| undefined;
+		expect(call?.messages).toEqual([
+			{ role: "user", content: [{ type: "text", text: "Hello" }] },
+			{ role: "user", content: [{ type: "text", text: "tell me more" }] },
+		]);
+		expect(JSON.stringify(call?.messages)).not.toContain("reasoning");
+	});
+
+	it("strips reasoning history for Cerebras base URL aliases", async () => {
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([
+				{ type: "finish", usage: { inputTokens: 1, outputTokens: 1 } },
+			]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [
+				{
+					providerId: "openai-compatible",
+					apiKey: "cerebras-key",
+					baseUrl: "https://api.cerebras.ai",
+				},
+			],
+		});
+
+		await collect(
+			await gateway.stream({
+				providerId: "openai-compatible",
+				modelId: "zai-glm-4.7",
+				messages: [
+					baseMessages[0],
+					{
+						id: "assistant_1",
+						role: "assistant",
+						content: [
+							{ type: "reasoning", text: "internal thinking" },
+							{ type: "text", text: "Hello!" },
+						],
+						createdAt: Date.now(),
+					},
+					{
+						id: "user_2",
+						role: "user",
+						content: [{ type: "text", text: "tell me more" }],
+						createdAt: Date.now(),
+					},
+				],
+			}),
+		);
+
+		const call = streamTextSpy.mock.calls.at(-1)?.[0] as
+			| { messages?: unknown }
+			| undefined;
+		expect(call?.messages).toEqual([
+			{ role: "user", content: [{ type: "text", text: "Hello" }] },
+			{ role: "assistant", content: [{ type: "text", text: "Hello!" }] },
+			{ role: "user", content: [{ type: "text", text: "tell me more" }] },
+		]);
+		expect(JSON.stringify(call?.messages)).not.toContain("reasoning");
+	});
+
 	it("reads Anthropic cache usage from provider metadata", async () => {
 		streamTextSpy.mockReturnValue({
 			fullStream: makeStreamParts([

--- a/sdk/packages/llms/src/providers/model-facts.ts
+++ b/sdk/packages/llms/src/providers/model-facts.ts
@@ -27,6 +27,24 @@ function normalizedModelId(
 	return normalizeRoutingValue(request.modelId) ?? "";
 }
 
+function isProviderBaseOrigin(
+	context: GatewayProviderContext,
+	origin: string,
+): boolean {
+	const baseUrl = normalizeRoutingValue(
+		context.config.baseUrl ?? context.provider.api,
+	)?.replace(/\/+$/, "");
+	if (!baseUrl) {
+		return false;
+	}
+
+	try {
+		return new URL(baseUrl).origin.toLowerCase() === origin;
+	} catch {
+		return baseUrl === origin || baseUrl.startsWith(`${origin}/`);
+	}
+}
+
 function isAnthropicLineageValue(value: string | undefined): boolean {
 	const normalized = normalizeRoutingValue(value);
 	return normalized
@@ -194,6 +212,22 @@ export function isOllamaQwen3ModelIdFallback(
 	return (
 		request.providerId === "ollama" &&
 		normalizedModelId(request).includes("qwen3")
+	);
+}
+
+export function isCerebrasProvider(
+	request: Pick<GatewayStreamRequest, "providerId">,
+	context: GatewayProviderContext,
+): boolean {
+	const providerIds = [
+		request.providerId,
+		context.config.providerId,
+		context.provider.id,
+	].map((id) => id.toLowerCase());
+
+	return (
+		providerIds.includes("cerebras") ||
+		isProviderBaseOrigin(context, "https://api.cerebras.ai")
 	);
 }
 


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

Linear: ENG-2077

### Description

Fixes Cerbras follow-up requests failing when prior assistant messages include reasoning history. Cerebras can emit reasoning in responses, but rejects `assistant.reasoning_content` when that history is sent back on a later turn. This changes the AI SDK message conversion path to strip reasoning history only for Cerebras provider requests while preserving visible assistant text and tool history for context.

A regression test covers the second-turn history shape: user message, assistant message with reasoning plus text, then a follow-up user message. The test verifies the outgoing Cerebras request keeps assistant text and omits reasoning.



## AFter this fix we can do multiple turns with cerebras
<img width="435" height="927" alt="image" src="https://github.com/user-attachments/assets/b7bbbaaa-5753-411c-a548-be93c0ff1d45" />



### Test Procedure

- Ran `bun biome format --write packages/llms/src/providers/ai-sdk.ts packages/llms/src/providers/gateway.test.ts`.
- Ran `bun run test src/providers/gateway.test.ts` from `sdk/packages/llms`; all 66 gateway tests passed.
- Ran `bun run typecheck` from `sdk/packages/llms`; TypeScript passed.
- Live-tested Cerbras with a redacted BYOK key:
  - Request containing `assistant.reasoning_content` returned the expected 400 unsupported-property error.
  - The same follow-up payload without `reasoning_content` returned 200.
  - The local `@cline/llms` gateway path with a stored reasoning part in history finished normally with usage and no validation error.

Potentially affected behavior: providers that rely on reasoning replay should continue receiving reasoning history because the filtering is scoped to Cerebras provider ids and the Cerebras base URL.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - backend/provider request serialization fix.

### Additional Notes

This PR intentionally excludes unrelated local `apps/vscode/*` worktree changes.

