### PR TITLE
Fix auto-approved command running state

### DIFF
--- a/apps/vscode/esbuild.mjs
+++ b/apps/vscode/esbuild.mjs
@@ -21,6 +21,7 @@ const aliasResolverPlugin = {
 		const aliases = {
 			"@": path.resolve(__dirname, "src"),
 			"@core": path.resolve(__dirname, "src/core"),
+			"@generated": path.resolve(__dirname, "src/generated"),
 			"@integrations": path.resolve(__dirname, "src/integrations"),
 			"@services": path.resolve(__dirname, "src/services"),
 			"@shared": path.resolve(__dirname, "src/shared"),

--- a/apps/vscode/src/shared/combineCommandSequences.ts
+++ b/apps/vscode/src/shared/combineCommandSequences.ts
@@ -1,4 +1,4 @@
-import { ClineMessage } from "./ExtensionMessage"
+import type { ClineMessage } from "./ExtensionMessage"
 
 /**
  * Combines sequences of command and command_output messages in an array of ClineMessages.

--- a/apps/vscode/webview-ui/src/components/chat/ChatRow.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatRow.tsx
@@ -1,4 +1,3 @@
-import { COMMAND_OUTPUT_STRING } from "@shared/combineCommandSequences"
 import {
 	ClineApiReqInfo,
 	ClineAskQuestion,
@@ -65,6 +64,7 @@ import SearchResultsDisplay from "./SearchResultsDisplay"
 import SubagentStatusRow from "./SubagentStatusRow"
 import { ThinkingRow } from "./ThinkingRow"
 import UserMessage from "./UserMessage"
+import { getCommandRowState } from "./commandRowState"
 
 const HEADER_CLASSNAMES = "flex items-center gap-2.5 mb-3"
 
@@ -216,14 +216,8 @@ export const ChatRowContent = memo(
 
 		const type = message.type === "ask" ? message.ask : message.say
 
-		const isCommandMessage = type === "command"
-		// Check if command has output to determine if it's actually executing
-		const commandHasOutput = message.text?.includes(COMMAND_OUTPUT_STRING) ?? false
-		// A command is executing if it has output but hasn't completed yet
-		const isCommandExecuting = isCommandMessage && !message.commandCompleted && commandHasOutput
-		// A command is pending if it hasn't started (no output) and hasn't completed
-		const isCommandPending = isCommandMessage && isLast && !message.commandCompleted && !commandHasOutput
-		const isCommandCompleted = isCommandMessage && message.commandCompleted === true
+		const { isCommandMessage, isCommandCompleted, isCommandExecuting, isCommandPending, title: commandTitle } =
+			getCommandRowState(message, isLast, isRequestInProgress)
 
 		const isMcpServerResponding = isLast && lastModifiedMessage?.say === "mcp_server_request_started"
 
@@ -324,8 +318,8 @@ export const ChatRowContent = memo(
 					]
 				case "command":
 					return [
-						<TerminalIcon className="text-foreground size-2" />,
-						<span className="font-bold text-foreground">Cline wants to execute this command:</span>,
+						isCommandExecuting ? <ProgressIndicator /> : <TerminalIcon className="text-foreground size-2" />,
+						<span className="font-bold text-foreground">{commandTitle}</span>,
 					]
 				case "use_mcp_server":
 					const mcpServerUse = JSON.parse(message.text || "{}") as ClineAskUseMcpServer
@@ -366,6 +360,7 @@ export const ChatRowContent = memo(
 			apiRequestFailedMessage,
 			isCommandExecuting,
 			isCommandPending,
+			isCommandCompleted,
 			apiReqCancelReason,
 			isMcpServerResponding,
 			message.text,

--- a/apps/vscode/webview-ui/src/components/chat/commandRowState.test.ts
+++ b/apps/vscode/webview-ui/src/components/chat/commandRowState.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest"
+import { getCommandRowState } from "./commandRowState"
+
+describe("getCommandRowState", () => {
+	it("shows an auto-approved command with no output yet as running", () => {
+		const state = getCommandRowState(
+			{
+				partial: true,
+				say: "command",
+				text: "sleep 30",
+				type: "say",
+			},
+			true,
+			true,
+		)
+
+		expect(state.isCommandExecuting).toBe(true)
+		expect(state.isCommandPending).toBe(false)
+		expect(state.title).toBe("Cline is executing this command:")
+	})
+
+	it("keeps a command approval prompt pending before execution", () => {
+		const state = getCommandRowState(
+			{
+				ask: "command",
+				text: "npm install",
+				type: "ask",
+			},
+			true,
+		)
+
+		expect(state.isCommandExecuting).toBe(false)
+		expect(state.isCommandPending).toBe(true)
+		expect(state.title).toBe("Cline wants to execute this command:")
+	})
+
+	it("treats command rows with output as running until marked completed", () => {
+		const state = getCommandRowState(
+			{
+				ask: "command",
+				text: "npm test\nOutput:\nrunning tests",
+				type: "ask",
+			},
+			true,
+		)
+
+		expect(state.isCommandExecuting).toBe(true)
+		expect(state.isCommandPending).toBe(false)
+		expect(state.title).toBe("Cline is executing this command:")
+	})
+
+	it("shows completed command rows as executed", () => {
+		const state = getCommandRowState(
+			{
+				commandCompleted: true,
+				say: "command",
+				text: "echo ok\nOutput:\nok",
+				type: "say",
+			},
+			true,
+		)
+
+		expect(state.isCommandCompleted).toBe(true)
+		expect(state.isCommandExecuting).toBe(false)
+		expect(state.title).toBe("Cline executed this command:")
+	})
+})

--- a/apps/vscode/webview-ui/src/components/chat/commandRowState.ts
+++ b/apps/vscode/webview-ui/src/components/chat/commandRowState.ts
@@ -1,0 +1,50 @@
+import { COMMAND_OUTPUT_STRING } from "@shared/combineCommandSequences"
+
+export interface CommandRowMessage {
+	ask?: string
+	commandCompleted?: boolean
+	partial?: boolean
+	say?: string
+	text?: string
+	type?: string
+}
+
+export interface CommandRowState {
+	isCommandCompleted: boolean
+	isCommandExecuting: boolean
+	isCommandMessage: boolean
+	isCommandPending: boolean
+	title: string | undefined
+}
+
+export function getCommandRowState(
+	message: CommandRowMessage,
+	isLast: boolean,
+	isRequestInProgress?: boolean,
+): CommandRowState {
+	const type = message.type === "ask" ? message.ask : message.say
+	const isCommandMessage = type === "command"
+	const commandHasOutput = message.text?.includes(COMMAND_OUTPUT_STRING) ?? false
+	const isCommandCompleted = isCommandMessage && message.commandCompleted === true
+	const isCommandExecuting =
+		isCommandMessage &&
+		!isCommandCompleted &&
+		(commandHasOutput ||
+			(message.type === "say" && (message.partial === true || (isLast && isRequestInProgress === true))))
+	const isCommandPending = isCommandMessage && isLast && !isCommandCompleted && !isCommandExecuting
+	const title = !isCommandMessage
+		? undefined
+		: isCommandCompleted
+			? "Cline executed this command:"
+			: isCommandExecuting
+				? "Cline is executing this command:"
+				: "Cline wants to execute this command:"
+
+	return {
+		isCommandCompleted,
+		isCommandExecuting,
+		isCommandMessage,
+		isCommandPending,
+		title,
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

Fixes command rows for auto-approved terminal commands in the SDK-backed VS Code chat UI.

Auto-approved command starts are rendered as partial `say: "command"` rows before any terminal output is available. The previous ChatRow logic only treated commands as running after an `Output:` marker appeared, so long-running no-output commands stayed visually stuck on the approval wording and pending state.

This PR centralizes command-row state derivation and updates the command header/status so auto-approved commands show as executing immediately, approval prompts remain pending, and completed commands show executed wording.

### Test Procedure

Ran focused webview regression tests:

```sh
cd apps/vscode/webview-ui
npm test -- commandRowState.test.ts
```

This covers auto-approved no-output command starts, approval prompts, command output before completion, and completed command rows.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - covered by focused state regression tests.

### Additional Notes

Related Linear issue: CLINE-2298.

Full `apps/vscode` dependency install was not completed in this local worktree because `npm ci` failed resolving `eventsource-parser@3.1.0`; the focused webview dependency install and targeted test passed.
