### PR TITLE
feat(cli): group plugin skills in settings

### DIFF
--- a/sdk/apps/cli/src/runtime/interactive/config-data.test.ts
+++ b/sdk/apps/cli/src/runtime/interactive/config-data.test.ts
@@ -494,6 +494,93 @@ Find installable skills.`,
 		expect(plugin?.name).toBe("cline-sdk-portable-agents");
 	});
 
+	it("marks bundled package skills with their plugin owner", async () => {
+		const tempRoot = await mkdtemp(join(tmpdir(), "cli-config-data-"));
+		tempRoots.push(tempRoot);
+		const installRoot = join(
+			tempRoot,
+			".cline",
+			"plugins",
+			"_installed",
+			"git",
+			"github.com",
+			"demo",
+		);
+		const packageDir = join(installRoot, "package");
+		const skillPath = join(packageDir, "skills", "review", "SKILL.md");
+		const pluginPath = join(packageDir, "index.ts");
+		await mkdir(join(packageDir, "skills", "review"), { recursive: true });
+		await writeFile(
+			join(installRoot, "package.json"),
+			JSON.stringify(
+				{
+					name: "cline-installed-plugin-demo",
+					cline: {
+						plugins: [{ paths: ["./package/index.ts"] }],
+					},
+				},
+				null,
+				2,
+			),
+		);
+		await writeFile(
+			join(packageDir, "package.json"),
+			JSON.stringify(
+				{
+					name: "cline-sdk-portable-agents",
+				},
+				null,
+				2,
+			),
+		);
+		await writeFile(pluginPath, "export default {};\n");
+		await writeFile(
+			skillPath,
+			`---
+name: review
+---
+Review with the bundled skill.`,
+		);
+		const userInstructionService = {
+			listRuntimeCommands() {
+				return [];
+			},
+			listRecords(type: string) {
+				if (type !== "skill") {
+					return [];
+				}
+				return [
+					{
+						id: "review",
+						type: "skill",
+						filePath: skillPath,
+						item: {
+							name: "review",
+							disabled: false,
+							description: "Review code",
+							instructions: "Review with the bundled skill.",
+							frontmatter: {},
+						},
+					},
+				];
+			},
+		} as unknown as UserInstructionConfigService;
+		const loader = createInteractiveConfigDataLoader({
+			config: createConfig(tempRoot),
+			userInstructionService,
+		});
+
+		const data = await loader.loadConfigData({ includePluginTools: false });
+		const skill = data.skills.find((item) => item.path === skillPath);
+
+		expect(skill).toMatchObject({
+			name: "review",
+			pluginName: "cline-sdk-portable-agents",
+			pluginPath,
+			source: "workspace-plugin",
+		});
+	});
+
 	it("toggles MCP server enabled state through core settings", async () => {
 		const tempRoot = await mkdtemp(join(tmpdir(), "cli-config-data-"));
 		tempRoots.push(tempRoot);

--- a/sdk/apps/cli/src/tui/interactive-config.ts
+++ b/sdk/apps/cli/src/tui/interactive-config.ts
@@ -1,5 +1,13 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { basename, dirname, extname, join, resolve } from "node:path";
+import {
+	basename,
+	dirname,
+	extname,
+	isAbsolute,
+	join,
+	relative,
+	resolve,
+} from "node:path";
 import {
 	type BuiltinToolAvailabilityContext,
 	discoverPluginModulePaths,
@@ -14,6 +22,7 @@ import {
 	resolveDefaultMcpSettingsPath,
 	resolveMcpServerRegistrations,
 	resolvePluginConfigSearchPaths,
+	resolvePluginSkillDirectoriesFromPaths,
 	type SkillConfig,
 	type UserInstructionConfigService,
 	type WorkflowConfig,
@@ -55,6 +64,7 @@ export interface InteractiveConfigItem {
 	toolNames?: string[];
 	configKind?: "tool" | "plugin";
 	pluginName?: string;
+	pluginPath?: string;
 	loadError?: string;
 	loadErrorPhase?: PluginInitializationFailure["phase"];
 	source:
@@ -252,6 +262,56 @@ function getPluginDisplayName(filePath: string): string {
 	return basename(filePath, extname(filePath));
 }
 
+function isPathWithin(parentPath: string, childPath: string): boolean {
+	const relativePath = relative(resolve(parentPath), resolve(childPath));
+	return (
+		relativePath === "" ||
+		(!relativePath.startsWith("..") && !isAbsolute(relativePath))
+	);
+}
+
+type PluginSkillOwner = {
+	directory: string;
+	pluginName: string;
+	pluginPath: string;
+	source: "global-plugin" | "workspace-plugin";
+};
+
+function buildPluginSkillOwners(
+	plugins: readonly InteractiveConfigItem[],
+): PluginSkillOwner[] {
+	const owners: PluginSkillOwner[] = [];
+	for (const plugin of plugins) {
+		if (
+			plugin.kind !== "plugin" ||
+			(plugin.source !== "workspace-plugin" &&
+				plugin.source !== "global-plugin")
+		) {
+			continue;
+		}
+		for (const directory of resolvePluginSkillDirectoriesFromPaths([
+			plugin.path,
+		])) {
+			owners.push({
+				directory,
+				pluginName: plugin.name,
+				pluginPath: plugin.path,
+				source: plugin.source,
+			});
+		}
+	}
+	return owners.sort(
+		(left, right) => right.directory.length - left.directory.length,
+	);
+}
+
+function findPluginSkillOwner(
+	filePath: string,
+	owners: readonly PluginSkillOwner[],
+): PluginSkillOwner | undefined {
+	return owners.find((owner) => isPathWithin(owner.directory, filePath));
+}
+
 function formatPluginFailure(failure: PluginInitializationFailure): string {
 	return `${failure.phase === "setup" ? "setup failed" : "load failed"}: ${failure.message}`;
 }
@@ -301,51 +361,6 @@ export async function loadInteractiveConfigData(input: {
 		input.userInstructionService,
 	);
 
-	if (input.userInstructionService) {
-		for (const record of input.userInstructionService.listRecords<WorkflowConfig>(
-			"workflow",
-		)) {
-			const workflow = record.item;
-			workflows.push({
-				id: record.id,
-				name: workflow.name,
-				path: record.filePath,
-				enabled: workflow.disabled !== true,
-				kind: "workflow",
-				source: detectSource(record.filePath, input.workspaceRoot),
-				description: workflow.instructions,
-			});
-		}
-		for (const record of input.userInstructionService.listRecords<RuleConfig>(
-			"rule",
-		)) {
-			const rule = record.item;
-			rules.push({
-				id: record.id,
-				name: rule.name,
-				path: record.filePath,
-				enabled: rule.disabled !== true,
-				kind: "rule",
-				source: detectSource(record.filePath, input.workspaceRoot),
-				description: rule.instructions,
-			});
-		}
-		for (const record of input.userInstructionService.listRecords<SkillConfig>(
-			"skill",
-		)) {
-			const skill = record.item;
-			skills.push({
-				id: record.id,
-				name: skill.name,
-				path: record.filePath,
-				enabled: skill.disabled !== true,
-				kind: "skill",
-				source: detectSource(record.filePath, input.workspaceRoot),
-				description: skill.description,
-			});
-		}
-	}
-
 	for (const hook of listHookConfigFiles(input.cwd)) {
 		hooks.push({
 			id: hook.path,
@@ -379,6 +394,61 @@ export async function loadInteractiveConfigData(input: {
 			}
 		} catch {
 			// Best effort: skip unreadable plugin roots.
+		}
+	}
+
+	const pluginSkillOwners = buildPluginSkillOwners(plugins);
+
+	if (input.userInstructionService) {
+		for (const record of input.userInstructionService.listRecords<WorkflowConfig>(
+			"workflow",
+		)) {
+			const workflow = record.item;
+			workflows.push({
+				id: record.id,
+				name: workflow.name,
+				path: record.filePath,
+				enabled: workflow.disabled !== true,
+				kind: "workflow",
+				source: detectSource(record.filePath, input.workspaceRoot),
+				description: workflow.instructions,
+			});
+		}
+		for (const record of input.userInstructionService.listRecords<RuleConfig>(
+			"rule",
+		)) {
+			const rule = record.item;
+			rules.push({
+				id: record.id,
+				name: rule.name,
+				path: record.filePath,
+				enabled: rule.disabled !== true,
+				kind: "rule",
+				source: detectSource(record.filePath, input.workspaceRoot),
+				description: rule.instructions,
+			});
+		}
+		for (const record of input.userInstructionService.listRecords<SkillConfig>(
+			"skill",
+		)) {
+			const skill = record.item;
+			const pluginOwner = findPluginSkillOwner(
+				record.filePath,
+				pluginSkillOwners,
+			);
+			skills.push({
+				id: record.id,
+				name: skill.name,
+				path: record.filePath,
+				enabled: skill.disabled !== true,
+				kind: "skill",
+				source:
+					pluginOwner?.source ??
+					detectSource(record.filePath, input.workspaceRoot),
+				description: skill.description,
+				pluginName: pluginOwner?.pluginName,
+				pluginPath: pluginOwner?.pluginPath,
+			});
 		}
 	}
 

--- a/sdk/apps/cli/src/tui/views/config-view.tsx
+++ b/sdk/apps/cli/src/tui/views/config-view.tsx
@@ -143,7 +143,7 @@ function groupToolItems(
 ): Array<[string, InteractiveConfigItem[]]> {
 	const groups = new Map<string, InteractiveConfigItem[]>();
 	for (const item of items) {
-		const groupKey = `${item.source}:${item.path}:${item.pluginName}`;
+		const groupKey = `${item.source}:${item.pluginPath ?? item.path}:${item.pluginName}`;
 		const group = groups.get(groupKey) ?? [];
 		group.push(item);
 		groups.set(groupKey, group);
@@ -207,6 +207,25 @@ function appendToolGroupRows(
 	}
 }
 
+function appendExtRows(
+	rows: ConfigRow[],
+	items: InteractiveConfigItem[],
+	indent?: number,
+): void {
+	for (const item of sortBySourceThenName(items)) {
+		rows.push({
+			kind: "ext",
+			name: item.name,
+			path: item.path,
+			source: item.source,
+			enabled: item.enabled,
+			description: item.description,
+			item,
+			indent,
+		});
+	}
+}
+
 function appendToolRows(
 	rows: ConfigRow[],
 	items: InteractiveConfigItem[],
@@ -216,17 +235,7 @@ function appendToolRows(
 	);
 	if (builtinTools.length > 0) {
 		rows.push({ kind: "head", label: "Built-in" });
-		for (const item of builtinTools) {
-			rows.push({
-				kind: "ext",
-				name: item.name,
-				path: item.path,
-				source: item.source,
-				enabled: item.enabled,
-				description: item.description,
-				item,
-			});
-		}
+		appendExtRows(rows, builtinTools);
 	}
 
 	const pluginGroups = groupToolItems(items.filter((item) => item.pluginName));
@@ -237,6 +246,36 @@ function appendToolRows(
 			pluginGroups,
 			getSharedToolNames(items.filter((item) => item.pluginName)),
 		);
+	}
+}
+
+function appendSkillRows(
+	rows: ConfigRow[],
+	items: InteractiveConfigItem[],
+): void {
+	const detectedItems = items.filter((item) => !item.pluginName);
+	if (detectedItems.length > 0) {
+		rows.push({ kind: "head", label: "Detected" });
+		appendExtRows(rows, detectedItems);
+	}
+
+	const pluginItems = items.filter((item) => item.pluginName);
+	const pluginGroups = groupToolItems(pluginItems);
+	if (pluginGroups.length > 0) {
+		rows.push({ kind: "head", label: "Plugins" });
+		for (const [, groupItems] of pluginGroups) {
+			const first = groupItems[0];
+			const enabledCount = groupItems.filter(
+				(item) => item.enabled !== false,
+			).length;
+			rows.push({
+				kind: "tool-group",
+				label: first?.pluginName ?? "plugin",
+				rightLabel: `${enabledCount}/${groupItems.length} skills enabled`,
+				indent: 2,
+			});
+			appendExtRows(rows, groupItems, 4);
+		}
 	}
 }
 
@@ -427,6 +466,8 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 						text: pluginToolsError,
 					});
 				}
+			} else if (activeTab === "skills") {
+				appendSkillRows(r, activeItems);
 			} else {
 				for (const item of activeItems) {
 					r.push({

--- a/sdk/packages/core/src/extensions/index.ts
+++ b/sdk/packages/core/src/extensions/index.ts
@@ -4,6 +4,7 @@ export {
 	resolveAgentPluginPaths,
 	resolveAndLoadAgentPlugins,
 	resolvePluginConfigSearchPaths,
+	resolvePluginSkillDirectoriesFromPaths,
 } from "./plugin/plugin-config-loader";
 export type {
 	PluginInitializationFailure,

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -197,6 +197,7 @@ export {
 	resolveAgentPluginPaths,
 	resolveAndLoadAgentPlugins,
 	resolvePluginConfigSearchPaths,
+	resolvePluginSkillDirectoriesFromPaths,
 } from "./extensions";
 export type {
 	AvailableRuntimeCommand,

--- a/sdk/packages/core/src/types.ts
+++ b/sdk/packages/core/src/types.ts
@@ -23,6 +23,7 @@ export {
 	resolveAgentPluginPaths,
 	resolveAndLoadAgentPlugins,
 	resolvePluginConfigSearchPaths,
+	resolvePluginSkillDirectoriesFromPaths,
 } from "./extensions";
 export type {
 	CreateInstructionWatcherOptions,


### PR DESCRIPTION
### Related Issue

Issue: #XXXX

### Description

This is a follow-up to plugin-bundled skills. After that change, the Settings dialog could discover plugin skills, but the Skills tab still presented detected skills and workflows as one flat list. The Tools tab already separates built-in tools from plugin tools and nests plugin tool rows under plugin names. This PR applies the same shape to plugin-bundled skills.

Technical approach:

- Extend CLI config items with optional plugin ownership metadata.
- Export `resolvePluginSkillDirectoriesFromPaths` from the core barrels so the CLI settings loader can reuse the runtime plugin skill ownership logic.
- In `loadInteractiveConfigData`, discover plugin entries before reading instruction records, build an ownership index from each plugin entry to its `skills/` directory, and annotate skill rows whose `SKILL.md` lives under a bundled plugin skill directory.
- In `ConfigPanelContent`, keep normal workspace and global skills under a `Detected` section, then render plugin-owned skills under `Plugins`, grouped by plugin name with the same nested row style used for plugin tools.

Non-obvious details:

- The settings loader should not import plugin modules just to group skills. This uses filesystem ownership from discovered plugin entry paths instead.
- Installed package plugins use a wrapper package that points into `./package/index.ts`. Reusing the core helper keeps that layout aligned with runtime behavior.
- Skill toggling is unchanged because skill rows still keep `kind: "skill"` and their original `SKILL.md` path.

### Test Procedure

Ran these checks locally:

```bash
bunx vitest run src/runtime/interactive/config-data.test.ts src/tui/views/config-view.test.ts --config vitest.config.ts
cd sdk/packages/core && bun run typecheck
cd sdk/apps/cli && bun run typecheck
bun biome check --diagnostic-level=error sdk/apps/cli/src/tui/interactive-config.ts sdk/apps/cli/src/tui/views/config-view.tsx sdk/apps/cli/src/runtime/interactive/config-data.test.ts sdk/packages/core/src/extensions/index.ts sdk/packages/core/src/index.ts sdk/packages/core/src/types.ts
git diff --check
```

The focused config data test now covers package-backed plugin skills and verifies that the skill row is attributed to the owning plugin. The view helper tests still cover settings tab behavior and inline toggle affordances.

### Type of Change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Refactor Changes
-   [x] Cosmetic Changes
-   [ ] Documentation update
-   [ ] Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Targeted tests, typechecks, formatting, and lint checks are passing
-   [ ] I have reviewed contributor guidelines

### Screenshots

Not captured. This is a terminal Settings dialog layout change. Reviewers can verify it by opening `/settings`, selecting `Skills`, and using a workspace with at least one plugin-bundled skill.

### Additional Notes

No known follow-up is required. The implementation intentionally keeps plugin skill grouping filesystem-based so opening Settings does not need to execute plugin code.
