### PR TITLE
fix(cli): show skills in slash autocomplete

### DIFF
--- a/sdk/apps/cli/src/tui/commands/slash-command-registry.test.ts
+++ b/sdk/apps/cli/src/tui/commands/slash-command-registry.test.ts
@@ -74,7 +74,7 @@ describe("slash command registry", () => {
 		);
 	});
 
-	it("keeps skills and workflows activatable without showing them in autocomplete", () => {
+	it("surfaces skills and workflows in autocomplete and the skills picker", () => {
 		const registry = buildSlashCommandRegistry({
 			workflowSlashCommands: [
 				{
@@ -118,7 +118,7 @@ describe("slash command registry", () => {
 		});
 		expect(
 			getVisibleUserSlashCommands(registry).map((cmd) => cmd.name),
-		).toEqual([]);
+		).toEqual(["review", "release"]);
 		expect(
 			getInvokableUserSlashCommands(registry).map((cmd) => cmd.name),
 		).toEqual(["review", "release"]);
@@ -126,14 +126,17 @@ describe("slash command registry", () => {
 		expect(review).toMatchObject({
 			source: "skill",
 			execution: "user-command",
-			visible: false,
-			selectable: false,
+			visible: true,
+			selectable: true,
 		});
+		expect(review ? formatSlashCommandAutocompleteValue(review) : "").toBe(
+			"/review ",
+		);
 		expect(resolveSlashCommand(registry, "release")).toMatchObject({
 			source: "workflow",
 			execution: "user-command",
-			visible: false,
-			selectable: false,
+			visible: true,
+			selectable: true,
 		});
 	});
 

--- a/sdk/apps/cli/src/tui/commands/slash-command-registry.ts
+++ b/sdk/apps/cli/src/tui/commands/slash-command-registry.ts
@@ -165,7 +165,6 @@ function entryFromRuntimeCommand(
 		command.kind === "skill" || command.kind === "workflow"
 			? "user-command"
 			: "runtime";
-	const visible = execution !== "user-command";
 	return {
 		name,
 		description: command.description ?? "",
@@ -173,8 +172,8 @@ function entryFromRuntimeCommand(
 		source,
 		kind: command.kind,
 		execution,
-		visible,
-		selectable: visible,
+		visible: true,
+		selectable: true,
 	};
 }
 


### PR DESCRIPTION
### Related Issue

Issue: #XXXX

### Description

This restores CLI skill and workflow entries to the slash autocomplete dropdown.

The behavior changed when the `/skills` picker was introduced. At that point the registry kept skill and workflow slash commands invokable, but marked them as not visible and not selectable, which meant `getVisibleUserSlashCommands()` returned an empty list for autocomplete. Manual `/skill` expansion and the `/skills` picker still worked, but typing `/` no longer surfaced the user's enabled skills directly in the dropdown.

The fix keeps the picker path intact while making runtime skill and workflow commands visible/selectable again. That allows the autocomplete hook to receive them through the existing `skillCommands` path and show them under the existing Skills section. Selected skill commands still insert the compact `/skill ` form, and submit-time expansion continues to convert that compact prompt into the model-facing `user_command` payload.

The main gotcha was branch hygiene. This worktree started from a detached HEAD that was not descended from current `main`, so the first pushed branch would have produced a noisy PR diff. I rebased the single autocomplete commit onto `origin/main` in this task worktree and updated the branch with `--force-with-lease` so the final PR contains only the intended two-file change.

### Test Procedure

Ran the focused CLI tests that cover the changed registry behavior and the autocomplete path:

```bash
bun --cwd sdk/apps/cli vitest run --config vitest.config.ts src/tui/commands/slash-command-registry.test.ts src/tui/hooks/use-autocomplete.test.ts
```

Result: 2 test files passed, 16 tests passed.

I also checked the final branch diff against `origin/main`; it only includes `slash-command-registry.ts` and `slash-command-registry.test.ts`.

Potentially affected functionality:

- `/` autocomplete ordering and grouping, verified through the registry and autocomplete tests.
- Manual `/skill ...` submission, left on the same `user-command` execution path.
- `/skills` picker, left on `getInvokableUserSlashCommands()` so it still receives skill/workflow commands.

Full CLI suite, format, and lint were not run for this small targeted fix.

### Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Refactor Changes
-   [ ] Cosmetic Changes
-   [ ] Documentation update
-   [ ] Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not included. This is a registry visibility change covered by focused tests rather than a visual styling change.

### Additional Notes

The `/skills` command remains useful as a searchable picker and marketplace entry point. This PR restores the faster direct autocomplete path for users who expect enabled skills to appear when typing `/`.
