### PR TITLE
allow baseUrl field for anthropic vendor-type providers

### DIFF
--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -952,7 +952,7 @@ export const BUILTIN_SPECS: BuiltinSpec[] = [
 		defaultModelId: "MiniMax-M2.5",
 		apiKeyEnv: ["MINIMAX_API_KEY"],
 		modelsProviderId: "minimax",
-		defaults: { baseUrl: "https://api.minimax.io/anthropic" },
+		defaults: { baseUrl: "https://api.minimax.io/anthropic/v1" },
 		metadata: ANTHROPIC_ROUTING_METADATA,
 	},
 	{

--- a/sdk/packages/llms/src/providers/vendors/anthropic.test.ts
+++ b/sdk/packages/llms/src/providers/vendors/anthropic.test.ts
@@ -1,0 +1,70 @@
+import type {
+	GatewayProviderContext,
+	GatewayResolvedProviderConfig,
+} from "@cline/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createAnthropicProviderModule } from "./anthropic";
+
+const createAnthropicMock = vi.hoisted(() => vi.fn());
+const anthropicModelMock = vi.hoisted(() =>
+	vi.fn((modelId: string) => ({ provider: "anthropic", modelId })),
+);
+
+vi.mock("@ai-sdk/anthropic", () => ({
+	createAnthropic: createAnthropicMock,
+}));
+
+describe("createAnthropicProviderModule", () => {
+	beforeEach(() => {
+		createAnthropicMock.mockReset();
+		createAnthropicMock.mockReturnValue(anthropicModelMock);
+		anthropicModelMock.mockClear();
+	});
+
+	it("passes custom base URLs to Anthropic-compatible providers", async () => {
+		const provider = await createAnthropicProviderModule(
+			config({
+				apiKey: "minimax-api-key",
+				baseUrl: "https://api.minimax.io/anthropic",
+			}),
+			context("minimax"),
+		);
+
+		provider.model("MiniMax-M2.5");
+
+		expect(createAnthropicMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				apiKey: "minimax-api-key",
+				baseURL: "https://api.minimax.io/anthropic",
+				name: "minimax",
+			}),
+		);
+		expect(anthropicModelMock).toHaveBeenCalledWith("MiniMax-M2.5");
+	});
+});
+
+function config(
+	overrides: Partial<GatewayResolvedProviderConfig>,
+): GatewayResolvedProviderConfig {
+	return {
+		providerId: "minimax",
+		...overrides,
+	};
+}
+
+function context(providerId: string): GatewayProviderContext {
+	return {
+		provider: {
+			id: providerId,
+			name: "MiniMax",
+			defaultModelId: "MiniMax-M2.5",
+			models: [],
+		},
+		model: {
+			providerId,
+			id: "MiniMax-M2.5",
+			name: "MiniMax-M2.5",
+		},
+		config: config({}),
+	};
+}

--- a/sdk/packages/llms/src/providers/vendors/anthropic.ts
+++ b/sdk/packages/llms/src/providers/vendors/anthropic.ts
@@ -13,6 +13,7 @@ export async function createAnthropicProviderModule(
 	const apiKey = await resolveApiKey(config);
 	const provider = createAnthropic({
 		apiKey,
+		baseURL: config.baseUrl,
 		headers: config.headers,
 		fetch: config.fetch,
 		name: context.provider.id,


### PR DESCRIPTION
## Summary

Fixes Anthropic-compatible providers (notably MiniMax) using the wrong endpoint. The Anthropic AI SDK vendor adapter was ignoring the resolved `baseUrl`, so MiniMax requests fell back to `https://api.anthropic.com/v1` and sent MiniMax keys to Anthropic, causing `invalid x-api-key`. Also fixes minimax's default baseUrl

This passes the resolved `baseUrl` through as `baseURL` and adds gateway coverage to ensure MiniMax uses `https://api.minimax.io/anthropic`.

## Testing

- `bun test sdk/packages/llms/src/providers/gateway.test.ts --runInBand`
