### PR TITLE
improve cline provider migration

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -345,7 +345,7 @@
     },
     "apps/vscode": {
       "name": "claude-dev",
-      "version": "3.86.2",
+      "version": "3.87.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.37.0",
         "@anthropic-ai/vertex-sdk": "^0.6.4",

--- a/sdk/packages/core/src/services/storage/provider-settings-legacy-migration.test.ts
+++ b/sdk/packages/core/src/services/storage/provider-settings-legacy-migration.test.ts
@@ -177,6 +177,56 @@ describe("migrateLegacyProviderSettings", () => {
 		);
 	});
 
+	it("migrates legacy Cline OAuth account auth even without a clineApiKey", () => {
+		const tempDir = mkdtempSync(
+			path.join(os.tmpdir(), "core-legacy-provider-"),
+		);
+		tempDirs.push(tempDir);
+		const providersPath = path.join(tempDir, "provider-settings.json");
+		const manager = new ProviderSettingsManager({ filePath: providersPath });
+
+		writeFileSync(
+			path.join(tempDir, "globalState.json"),
+			JSON.stringify(
+				{
+					mode: "act",
+					actModeApiProvider: "anthropic",
+				},
+				null,
+				2,
+			),
+		);
+		writeFileSync(
+			path.join(tempDir, "secrets.json"),
+			JSON.stringify(
+				{
+					"cline:clineAccountId": makeClineAccountJson({
+						idToken: "legacy-cline-access",
+						refreshToken: "legacy-cline-refresh",
+						expiresAt: 1_750_000_000,
+						userId: "user-123",
+					}),
+				},
+				null,
+				2,
+			),
+		);
+
+		const result = migrateLegacyProviderSettings({
+			providerSettingsManager: manager,
+			dataDir: tempDir,
+		});
+
+		expect(result.migrated).toBe(true);
+		expect(manager.getProviderSettings("cline")?.auth).toEqual({
+			accessToken: "legacy-cline-access",
+			refreshToken: "legacy-cline-refresh",
+			expiresAt: 1_750_000_000_000,
+			accountId: "user-123",
+		});
+		expect(manager.read().providers.cline?.tokenSource).toBe("migration");
+	});
+
 	it("migrates legacy OpenAI-compatible config into the openai-compatible provider", () => {
 		const tempDir = mkdtempSync(
 			path.join(os.tmpdir(), "core-legacy-provider-"),
@@ -522,12 +572,19 @@ describe("resolveLegacyClineAuth", () => {
 		expect(result?.accessToken).toBe("tok-abc");
 	});
 
-	it("preserves expiresAt as a number", () => {
+	it("preserves millisecond expiresAt values", () => {
 		const result = resolveLegacyClineAuth(
 			makeClineAccountJson({ expiresAt: 9999999999999 }),
 		);
 		expect(result?.expiresAt).toBe(9999999999999);
 		expect(typeof result?.expiresAt).toBe("number");
+	});
+
+	it("normalizes classic second-based expiresAt values to milliseconds", () => {
+		const result = resolveLegacyClineAuth(
+			makeClineAccountJson({ expiresAt: 1_750_000_000 }),
+		);
+		expect(result?.expiresAt).toBe(1_750_000_000_000);
 	});
 
 	it("maps userInfo.id to accountId", () => {

--- a/sdk/packages/core/src/services/storage/provider-settings-legacy-migration.ts
+++ b/sdk/packages/core/src/services/storage/provider-settings-legacy-migration.ts
@@ -211,10 +211,19 @@ export function resolveLegacyClineAuth(
 		if (!data) {
 			return undefined;
 		}
+		const expiresAt =
+			typeof data.expiresAt === "number" && Number.isFinite(data.expiresAt)
+				? // Classic VS Code auth stored expiresAt in seconds; providers.json uses
+					// milliseconds. Preserve millisecond-looking values for compatibility
+					// with tests/older migration attempts.
+					data.expiresAt < 10_000_000_000
+					? data.expiresAt * 1000
+					: data.expiresAt
+				: undefined;
 		return {
 			accessToken: data.idToken,
 			refreshToken: data.refreshToken,
-			expiresAt: data.expiresAt,
+			expiresAt,
 			accountId: data.userInfo?.id,
 		};
 	} catch {
@@ -672,6 +681,16 @@ function collectCandidateProviderIds(
 		candidates.add("vertex");
 	}
 	if (trimNonEmpty(legacySecrets.clineApiKey)) candidates.add("cline");
+	const legacyClineAuth = resolveLegacyClineAuth(
+		trimNonEmpty(legacySecrets["cline:clineAccountId"]),
+	);
+	if (
+		legacyClineAuth?.accessToken ||
+		legacyClineAuth?.refreshToken ||
+		legacyClineAuth?.accountId
+	) {
+		candidates.add("cline");
+	}
 	if (trimNonEmpty(legacySecrets.ocaApiKey)) candidates.add("oca");
 	if (
 		trimNonEmpty(legacySecrets.sapAiCoreClientId) ||


### PR DESCRIPTION
## Summary

Fixes SDK provider migration for users who were already signed in to Cline before the SDK-backed extension. Legacy OAuth credentials are stored in `secrets.json` under `cline:clineAccountId`, but migration only considered the Cline provider when `clineApiKey` existed, so OAuth-only users appeared logged out after upgrade.

This updates migration to treat legacy Cline account auth as a provider candidate, migrate those tokens into SDK `providers.json`, normalize legacy expiry timestamps, and adds regression coverage.

Manual Tests:
- rm-rf my .cline folder, logged in with cline stable extension and then opened up cline sdk-extension and verified that I could run inference with no additional login
