### PR TITLE
fix: allow skills plugin capability

### DIFF
--- a/sdk/examples/plugins/README.md
+++ b/sdk/examples/plugins/README.md
@@ -134,6 +134,8 @@ Declare what the plugin uses in `manifest.capabilities`. Each one unlocks one pa
 | ------------------ | --------------- |
 | `tools`            | `api.registerTool()` |
 | `commands`         | `api.registerCommand()` |
+| `rules`            | `api.registerRule()` |
+| `skills`           | bundled skills discovered from the plugin package |
 | `providers`        | `api.registerProvider()` |
 | `messageBuilders`  | `api.registerMessageBuilder()` |
 | `automationEvents` | `api.registerAutomationEventType()` and `ctx.automation?.ingestEvent()` |

--- a/sdk/packages/shared/src/extensions/contribution-registry.test.ts
+++ b/sdk/packages/shared/src/extensions/contribution-registry.test.ts
@@ -2,6 +2,27 @@ import { describe, expect, it, vi } from "vitest";
 import { createContributionRegistry } from "./contribution-registry";
 
 describe("ContributionRegistry automation event contributions", () => {
+	it("accepts skills-only plugins without setup contributions", async () => {
+		const registry = createContributionRegistry({
+			extensions: [
+				{
+					name: "skill-pack",
+					manifest: { capabilities: ["skills"] },
+				},
+			],
+		});
+
+		await expect(registry.initialize()).resolves.toBeUndefined();
+		expect(registry.getRegistrySnapshot()).toMatchObject({
+			tools: [],
+			commands: [],
+			rules: [],
+			messageBuilder: [],
+			providers: [],
+			automationEventTypes: [],
+		});
+	});
+
 	it("registers automation event types declared by plugins", async () => {
 		const registry = createContributionRegistry({
 			extensions: [

--- a/sdk/packages/shared/src/extensions/contribution-registry.ts
+++ b/sdk/packages/shared/src/extensions/contribution-registry.ts
@@ -135,6 +135,7 @@ const ExtensionCapabilityOptions = [
 	"tools",
 	"commands",
 	"rules",
+	"skills",
 	"messageBuilders",
 	"providers",
 	"automationEvents",


### PR DESCRIPTION
### Related Issue

Issue: #XXXX

### Description

This PR fixes a plugin startup crash when an installed plugin declares `manifest.capabilities: ["skills"]`.

The issue showed up while testing the new plugin install flow locally with the official Linear plugin installed. Cline crashed during startup before the plugin could contribute anything useful because the shared contribution registry only accepted `hooks`, `tools`, `commands`, `rules`, `messageBuilders`, `providers`, and `automationEvents`. The Linear plugin package declares `skills` because it bundles skill files, so manifest validation rejected it with `unsupported capability "skills"`.

The fix is intentionally small:

- Add `skills` to the shared `ExtensionCapabilityOptions` list so plugin manifests can declare skill bundles.
- Add a regression test for a skills-only plugin that has no `setup()` contributions.
- Update the SDK plugin examples capability table so `rules` and `skills` are documented alongside the existing capabilities.

This treats `skills` like a declarative package capability. It does not add a new setup API such as `api.registerSkill()`, and it does not change how bundled skills are discovered. Plugins that include a top-level `skills/` directory can now declare the capability without causing startup validation to fail. Plugins that also register tools, rules, providers, or other setup contributions still need to declare those capabilities as before.

Debugging notes:

- Running `cline` with the installed Linear plugin crashed shortly after startup.
- The local logs showed `Invalid manifest for extension "linear": unsupported capability "skills"`.
- Temporarily disabling the Linear plugin allowed startup to continue, which narrowed the crash to manifest validation.
- After adding the capability and rebuilding the SDK, Cline launched with the Linear plugin enabled and `linear-sdk-scripting` appeared in `cline config skills --json`.

### Test Procedure

- `bun -F @cline/shared test -- contribution-registry.test.ts`
- `bun -F @cline/shared typecheck`
- `bun run build:sdk`
- Restarted the `/workspace/cline` hub and launched `cline` with the installed Linear plugin enabled.
- Verified `cline` stayed running instead of crashing during startup.
- Verified `linear-sdk-scripting` appears in `cline config skills --json`.
- `bun run lint`
  - Exited successfully.
  - Reported existing warnings in unrelated CLI TUI files.
- `bun run test`
  - Failed outside this change.
  - `@cline/shared` passed 17 files and 166 tests.
  - `@cline/agents` passed 2 files and 34 tests.
  - `@cline/llms` had a timeout in `src/providers/vendors/community.test.ts`.
  - `@cline/core` had unrelated failures including `hasRegisteredHandler is not a function` in `session-runtime-orchestrator.test.ts` and startup or hub fetch wiring timeouts.
  - `@cline/cli` exited with code 130 after the parallel package failure interrupted the run.

### Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Refactor Changes
-   [ ] Cosmetic Changes
-   [x] Documentation update
-   [ ] Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. This is a plugin manifest validation change with no UI surface.

### Additional Notes

No linked issue. This was found while locally testing plugin installation before publishing the next npm release.
