### PR TITLE
Fix approval chat replies rendering as tool errors

### DIFF
--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -300,6 +300,10 @@ export class Controller {
 					toolCallId,
 					messageTs,
 				),
+			recordUserMessageToolApprovalDenial: (toolCallId) =>
+				this.messageTranslatorState.recordUserMessageToolApprovalDenial(
+					toolCallId,
+				),
 			shouldAutoApproveTool: (request) => {
 				const autoApprovalSettings = this.stateManager.getGlobalSettingsKey(
 					"autoApprovalSettings",

--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -300,9 +300,11 @@ export class Controller {
 					toolCallId,
 					messageTs,
 				),
-			recordUserMessageToolApprovalDenial: (toolCallId) =>
-				this.messageTranslatorState.recordUserMessageToolApprovalDenial(
+			recordDeniedToolApproval: (toolCallId, toolName, reason) =>
+				this.messageTranslatorState.recordDeniedToolApproval(
 					toolCallId,
+					toolName,
+					reason,
 				),
 			shouldAutoApproveTool: (request) => {
 				const autoApprovalSettings = this.stateManager.getGlobalSettingsKey(

--- a/apps/vscode/src/sdk/message-translator-approval-denial.test.ts
+++ b/apps/vscode/src/sdk/message-translator-approval-denial.test.ts
@@ -1,0 +1,72 @@
+import type { CoreSessionEvent } from "@cline/core"
+import type { AgentEvent } from "@cline/shared"
+import { describe, expect, it } from "vitest"
+import { MessageTranslatorState, translateSessionEvent } from "./message-translator"
+import { USER_MESSAGE_TOOL_APPROVAL_DENIAL_REASON } from "./tool-approval-denial"
+
+describe("translateSessionEvent - user-message tool approval denial", () => {
+	it("suppresses tool lifecycle events for approval replies routed as user feedback", () => {
+		const state = new MessageTranslatorState()
+		state.recordUserMessageToolApprovalDenial("call-1")
+
+		const startEvent: CoreSessionEvent = {
+			type: "agent_event",
+			payload: {
+				sessionId: "session-1",
+				event: {
+					type: "content_start",
+					contentType: "tool",
+					toolName: "fetch_web_content",
+					toolCallId: "call-1",
+					input: {
+						requests: [{ url: "https://example.com", prompt: "Read it" }],
+					},
+				} as AgentEvent,
+			},
+		}
+		const endEvent: CoreSessionEvent = {
+			type: "agent_event",
+			payload: {
+				sessionId: "session-1",
+				event: {
+					type: "content_end",
+					contentType: "tool",
+					toolName: "fetch_web_content",
+					toolCallId: "call-1",
+					error: USER_MESSAGE_TOOL_APPROVAL_DENIAL_REASON,
+				} as AgentEvent,
+			},
+		}
+
+		const startResult = translateSessionEvent(startEvent, state)
+		const endResult = translateSessionEvent(endEvent, state)
+
+		expect(startResult.messages).toHaveLength(0)
+		expect(endResult.messages).toHaveLength(0)
+		expect(endResult.toolError).toBeUndefined()
+		expect(endResult.toolSuccess).toBeUndefined()
+	})
+
+	it("suppresses mistake errors caused by approval replies routed as user feedback", () => {
+		const state = new MessageTranslatorState()
+		const event: CoreSessionEvent = {
+			type: "agent_event",
+			payload: {
+				sessionId: "session-1",
+				event: {
+					type: "error",
+					error: new Error(
+						`1 tool call(s) failed: [fetch_web_content] {"error":"${USER_MESSAGE_TOOL_APPROVAL_DENIAL_REASON}"}`,
+					),
+					recoverable: true,
+					iteration: 1,
+				} as AgentEvent,
+			},
+		}
+
+		const result = translateSessionEvent(event, state)
+
+		expect(result.messages).toHaveLength(0)
+		expect(result.turnComplete).toBe(false)
+	})
+})

--- a/apps/vscode/src/sdk/message-translator-approval-denial.test.ts
+++ b/apps/vscode/src/sdk/message-translator-approval-denial.test.ts
@@ -2,12 +2,12 @@ import type { CoreSessionEvent } from "@cline/core"
 import type { AgentEvent } from "@cline/shared"
 import { describe, expect, it } from "vitest"
 import { MessageTranslatorState, translateSessionEvent } from "./message-translator"
-import { USER_MESSAGE_TOOL_APPROVAL_DENIAL_REASON } from "./tool-approval-denial"
+import { DEFAULT_TOOL_APPROVAL_DENIAL_REASON, USER_MESSAGE_TOOL_APPROVAL_DENIAL_REASON } from "./tool-approval-denial"
 
 describe("translateSessionEvent - user-message tool approval denial", () => {
 	it("suppresses tool lifecycle events for approval replies routed as user feedback", () => {
 		const state = new MessageTranslatorState()
-		state.recordUserMessageToolApprovalDenial("call-1")
+		state.recordDeniedToolApproval("call-1", "fetch_web_content", USER_MESSAGE_TOOL_APPROVAL_DENIAL_REASON)
 
 		const startEvent: CoreSessionEvent = {
 			type: "agent_event",
@@ -45,6 +45,47 @@ describe("translateSessionEvent - user-message tool approval denial", () => {
 		expect(endResult.messages).toHaveLength(0)
 		expect(endResult.toolError).toBeUndefined()
 		expect(endResult.toolSuccess).toBeUndefined()
+	})
+
+	it("suppresses generic no-button approval denials", () => {
+		const state = new MessageTranslatorState()
+		state.recordDeniedToolApproval("call-1", "fetch_web_content", DEFAULT_TOOL_APPROVAL_DENIAL_REASON)
+
+		const endEvent: CoreSessionEvent = {
+			type: "agent_event",
+			payload: {
+				sessionId: "session-1",
+				event: {
+					type: "content_end",
+					contentType: "tool",
+					toolName: "fetch_web_content",
+					toolCallId: "call-1",
+					error: `{"error":"${DEFAULT_TOOL_APPROVAL_DENIAL_REASON}"}`,
+				} as AgentEvent,
+			},
+		}
+		const mistakeEvent: CoreSessionEvent = {
+			type: "agent_event",
+			payload: {
+				sessionId: "session-1",
+				event: {
+					type: "error",
+					error: new Error(
+						`1 tool call(s) failed: [fetch_web_content] {"error":"${DEFAULT_TOOL_APPROVAL_DENIAL_REASON}"}`,
+					),
+					recoverable: true,
+					iteration: 1,
+				} as AgentEvent,
+			},
+		}
+
+		const endResult = translateSessionEvent(endEvent, state)
+		const mistakeResult = translateSessionEvent(mistakeEvent, state)
+
+		expect(endResult.messages).toHaveLength(0)
+		expect(endResult.toolError).toBeUndefined()
+		expect(mistakeResult.messages).toHaveLength(0)
+		expect(mistakeResult.turnComplete).toBe(false)
 	})
 
 	it("suppresses mistake errors caused by approval replies routed as user feedback", () => {

--- a/apps/vscode/src/sdk/message-translator.ts
+++ b/apps/vscode/src/sdk/message-translator.ts
@@ -215,7 +215,12 @@ export class MessageTranslatorState {
 		return toolCallId !== undefined && this.deniedToolApprovalsByCallId.has(toolCallId)
 	}
 
-	consumeDeniedToolApproval(toolCallId: string | undefined): boolean {
+	/**
+	 * Returns true when the given toolCallId was previously denied and its events should be
+	 * suppressed. This intentionally does not remove the entry because the denial must persist
+	 * past content_end so the follow-on error event can also be suppressed.
+	 */
+	checkDeniedToolApproval(toolCallId: string | undefined): boolean {
 		if (toolCallId === undefined || !this.deniedToolApprovalsByCallId.has(toolCallId)) {
 			return false
 		}
@@ -1078,7 +1083,7 @@ function translateAgentEvent(event: AgentEvent, state: MessageTranslatorState): 
 				case "tool": {
 					const toolName = event.toolName ?? "unknown"
 
-					if (state.consumeDeniedToolApproval(event.toolCallId) || isKnownToolApprovalDenial(event.error)) {
+					if (state.checkDeniedToolApproval(event.toolCallId) || isKnownToolApprovalDenial(event.error)) {
 						state.clearStreamingTool()
 						break
 					}

--- a/apps/vscode/src/sdk/message-translator.ts
+++ b/apps/vscode/src/sdk/message-translator.ts
@@ -42,6 +42,7 @@ import type {
 } from "@shared/ExtensionMessage"
 import { Logger } from "@shared/services/Logger"
 import { MessageIdMinter } from "./message-id-minter"
+import { isUserMessageToolApprovalDenial } from "./tool-approval-denial"
 
 // ---------------------------------------------------------------------------
 // Translation result
@@ -123,6 +124,8 @@ export class MessageTranslatorState {
 	private streamingToolName: string | undefined
 	/** Approved tool-call ids mapped to the approval row that should be updated in place. */
 	private approvedToolMessageTsByCallId = new Map<string, number>()
+	/** Tool calls rejected only to route a typed approval reply as normal user feedback. */
+	private userMessageDeniedToolCallIds = new Set<string>()
 	/**
 	 * Process-wide id/seq/epoch authority. Shared with the interaction coordinator and history
 	 * rendering so that message ids never collide across generators. See message-id-minter.ts.
@@ -202,6 +205,22 @@ export class MessageTranslatorState {
 	/** Clear approved prompt rows that no longer have a live tool event to consume them. */
 	clearApprovedToolMessageTs(): void {
 		this.approvedToolMessageTsByCallId.clear()
+	}
+
+	recordUserMessageToolApprovalDenial(toolCallId: string): void {
+		this.userMessageDeniedToolCallIds.add(toolCallId)
+	}
+
+	isUserMessageToolApprovalDenied(toolCallId: string | undefined): boolean {
+		return toolCallId !== undefined && this.userMessageDeniedToolCallIds.has(toolCallId)
+	}
+
+	consumeUserMessageToolApprovalDenial(toolCallId: string | undefined): boolean {
+		if (toolCallId === undefined || !this.userMessageDeniedToolCallIds.has(toolCallId)) {
+			return false
+		}
+		this.userMessageDeniedToolCallIds.delete(toolCallId)
+		return true
 	}
 
 	/** Reuse and remove a previously-approved prompt row for the matching tool event. */
@@ -369,6 +388,7 @@ export class MessageTranslatorState {
 		this.streamingToolInput = undefined
 		this.streamingToolName = undefined
 		this.clearApprovedToolMessageTs()
+		this.userMessageDeniedToolCallIds.clear()
 		this.clearSpawnAgents()
 	}
 
@@ -873,6 +893,10 @@ function translateAgentEvent(event: AgentEvent, state: MessageTranslatorState): 
 					const toolName = event.toolName ?? "unknown"
 					const input = event.input
 
+					if (state.isUserMessageToolApprovalDenied(event.toolCallId)) {
+						break
+					}
+
 					// Store tool context so content_end can use it
 					// (content_end doesn't carry the input)
 					state.setStreamingToolContext(toolName, input)
@@ -1050,6 +1074,14 @@ function translateAgentEvent(event: AgentEvent, state: MessageTranslatorState): 
 				}
 				case "tool": {
 					const toolName = event.toolName ?? "unknown"
+
+					if (
+						state.consumeUserMessageToolApprovalDenial(event.toolCallId) ||
+						isUserMessageToolApprovalDenial(event.error)
+					) {
+						state.clearStreamingTool()
+						break
+					}
 
 					// ask_question is serviced by the interaction coordinator (see content_start);
 					// it produces no transcript row of its own, so its content_end is a no-op.
@@ -1332,6 +1364,10 @@ function translateAgentEvent(event: AgentEvent, state: MessageTranslatorState): 
 		}
 
 		case "error": {
+			if (isUserMessageToolApprovalDenial(event.error)) {
+				break
+			}
+
 			// Serialize the error message for the webview's ErrorRow to parse.
 			// The webview uses ClineError.parse() on the `api_req_failed` text to
 			// detect special error types (insufficient credits, spend limit, auth,
@@ -1441,7 +1477,7 @@ export function translateSessionEvent(event: CoreSessionEvent, state: MessageTra
 			if (agentEvent.type === "done") {
 				result.turnComplete = true
 			}
-			if (agentEvent.type === "error") {
+			if (agentEvent.type === "error" && !isUserMessageToolApprovalDenial(agentEvent.error)) {
 				result.turnComplete = true
 			}
 
@@ -1449,9 +1485,9 @@ export function translateSessionEvent(event: CoreSessionEvent, state: MessageTra
 			// A content_end event with contentType "tool" signals a completed
 			// tool call — if event.error is set, the tool failed.
 			if (agentEvent.type === "content_end" && agentEvent.contentType === "tool") {
-				if (agentEvent.error) {
+				if (agentEvent.error && !isUserMessageToolApprovalDenial(agentEvent.error)) {
 					result.toolError = true
-				} else {
+				} else if (!agentEvent.error) {
 					result.toolSuccess = true
 				}
 			}

--- a/apps/vscode/src/sdk/message-translator.ts
+++ b/apps/vscode/src/sdk/message-translator.ts
@@ -42,7 +42,7 @@ import type {
 } from "@shared/ExtensionMessage"
 import { Logger } from "@shared/services/Logger"
 import { MessageIdMinter } from "./message-id-minter"
-import { isUserMessageToolApprovalDenial } from "./tool-approval-denial"
+import { isDeniedToolApprovalMistake, isKnownToolApprovalDenial } from "./tool-approval-denial"
 
 // ---------------------------------------------------------------------------
 // Translation result
@@ -124,8 +124,8 @@ export class MessageTranslatorState {
 	private streamingToolName: string | undefined
 	/** Approved tool-call ids mapped to the approval row that should be updated in place. */
 	private approvedToolMessageTsByCallId = new Map<string, number>()
-	/** Tool calls rejected only to route a typed approval reply as normal user feedback. */
-	private userMessageDeniedToolCallIds = new Set<string>()
+	/** Tool calls rejected by the user; they should not render as red tool failures. */
+	private deniedToolApprovalsByCallId = new Map<string, { toolName: string; reason: string }>()
 	/**
 	 * Process-wide id/seq/epoch authority. Shared with the interaction coordinator and history
 	 * rendering so that message ids never collide across generators. See message-id-minter.ts.
@@ -207,20 +207,23 @@ export class MessageTranslatorState {
 		this.approvedToolMessageTsByCallId.clear()
 	}
 
-	recordUserMessageToolApprovalDenial(toolCallId: string): void {
-		this.userMessageDeniedToolCallIds.add(toolCallId)
+	recordDeniedToolApproval(toolCallId: string, toolName: string, reason: string): void {
+		this.deniedToolApprovalsByCallId.set(toolCallId, { toolName, reason })
 	}
 
-	isUserMessageToolApprovalDenied(toolCallId: string | undefined): boolean {
-		return toolCallId !== undefined && this.userMessageDeniedToolCallIds.has(toolCallId)
+	isToolApprovalDenied(toolCallId: string | undefined): boolean {
+		return toolCallId !== undefined && this.deniedToolApprovalsByCallId.has(toolCallId)
 	}
 
-	consumeUserMessageToolApprovalDenial(toolCallId: string | undefined): boolean {
-		if (toolCallId === undefined || !this.userMessageDeniedToolCallIds.has(toolCallId)) {
+	consumeDeniedToolApproval(toolCallId: string | undefined): boolean {
+		if (toolCallId === undefined || !this.deniedToolApprovalsByCallId.has(toolCallId)) {
 			return false
 		}
-		this.userMessageDeniedToolCallIds.delete(toolCallId)
 		return true
+	}
+
+	isSuppressedToolApprovalDenial(value: unknown): boolean {
+		return isDeniedToolApprovalMistake(value, this.deniedToolApprovalsByCallId.values())
 	}
 
 	/** Reuse and remove a previously-approved prompt row for the matching tool event. */
@@ -388,7 +391,7 @@ export class MessageTranslatorState {
 		this.streamingToolInput = undefined
 		this.streamingToolName = undefined
 		this.clearApprovedToolMessageTs()
-		this.userMessageDeniedToolCallIds.clear()
+		this.deniedToolApprovalsByCallId.clear()
 		this.clearSpawnAgents()
 	}
 
@@ -893,7 +896,7 @@ function translateAgentEvent(event: AgentEvent, state: MessageTranslatorState): 
 					const toolName = event.toolName ?? "unknown"
 					const input = event.input
 
-					if (state.isUserMessageToolApprovalDenied(event.toolCallId)) {
+					if (state.isToolApprovalDenied(event.toolCallId)) {
 						break
 					}
 
@@ -1075,10 +1078,7 @@ function translateAgentEvent(event: AgentEvent, state: MessageTranslatorState): 
 				case "tool": {
 					const toolName = event.toolName ?? "unknown"
 
-					if (
-						state.consumeUserMessageToolApprovalDenial(event.toolCallId) ||
-						isUserMessageToolApprovalDenial(event.error)
-					) {
+					if (state.consumeDeniedToolApproval(event.toolCallId) || isKnownToolApprovalDenial(event.error)) {
 						state.clearStreamingTool()
 						break
 					}
@@ -1364,7 +1364,7 @@ function translateAgentEvent(event: AgentEvent, state: MessageTranslatorState): 
 		}
 
 		case "error": {
-			if (isUserMessageToolApprovalDenial(event.error)) {
+			if (state.isSuppressedToolApprovalDenial(event.error)) {
 				break
 			}
 
@@ -1477,7 +1477,7 @@ export function translateSessionEvent(event: CoreSessionEvent, state: MessageTra
 			if (agentEvent.type === "done") {
 				result.turnComplete = true
 			}
-			if (agentEvent.type === "error" && !isUserMessageToolApprovalDenial(agentEvent.error)) {
+			if (agentEvent.type === "error" && !state.isSuppressedToolApprovalDenial(agentEvent.error)) {
 				result.turnComplete = true
 			}
 
@@ -1485,7 +1485,11 @@ export function translateSessionEvent(event: CoreSessionEvent, state: MessageTra
 			// A content_end event with contentType "tool" signals a completed
 			// tool call — if event.error is set, the tool failed.
 			if (agentEvent.type === "content_end" && agentEvent.contentType === "tool") {
-				if (agentEvent.error && !isUserMessageToolApprovalDenial(agentEvent.error)) {
+				if (
+					agentEvent.error &&
+					!isKnownToolApprovalDenial(agentEvent.error) &&
+					!state.isToolApprovalDenied(agentEvent.toolCallId)
+				) {
 					result.toolError = true
 				} else if (!agentEvent.error) {
 					result.toolSuccess = true

--- a/apps/vscode/src/sdk/sdk-followup-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-followup-coordinator.test.ts
@@ -83,6 +83,34 @@ describe("SdkFollowupCoordinator", () => {
 		)
 	})
 
+	it("queues a message response after a pending tool approval is rejected", async () => {
+		const activeSession = makeActiveSession({ isRunning: true })
+		const { coordinator, options } = makeCoordinator({ activeSession })
+		options.interactions.resolvePendingToolApproval.mockReturnValue(false)
+
+		await coordinator.askResponse("just give me an answer", undefined, undefined, "messageResponse")
+
+		expect(options.interactions.resolvePendingToolApproval).toHaveBeenCalledWith("just give me an answer", "messageResponse")
+		expect(options.messages.appendAndEmit).toHaveBeenCalledWith(
+			[
+				expect.objectContaining({
+					type: "say",
+					say: "user_feedback",
+					text: "just give me an answer",
+				}),
+			],
+			{ type: "status", payload: { sessionId: "session-123", status: "running" } },
+		)
+		expect(options.sessions.fireAndForgetSend).toHaveBeenCalledWith(
+			activeSession.sdkHost,
+			"session-123",
+			"resolved: just give me an answer",
+			undefined,
+			undefined,
+			"queue",
+		)
+	})
+
 	it("resumes a displayed task before sending a follow-up when there is no live session", async () => {
 		const task = makeTask("task-1")
 		const historyItem = {

--- a/apps/vscode/src/sdk/sdk-interaction-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-interaction-coordinator.test.ts
@@ -4,6 +4,7 @@ import { MessageTranslatorState, translateSessionEvent } from "./message-transla
 import { SdkInteractionCoordinator } from "./sdk-interaction-coordinator"
 import { SdkMessageCoordinator } from "./sdk-message-coordinator"
 import { createTaskProxy } from "./task-proxy"
+import { USER_MESSAGE_TOOL_APPROVAL_DENIAL_REASON } from "./tool-approval-denial"
 
 vi.mock("./webview-grpc-bridge", () => ({
 	pushMessageToWebview: vi.fn().mockResolvedValue(undefined),
@@ -130,11 +131,13 @@ describe("SdkInteractionCoordinator", () => {
 	it("routes message responses as follow-ups instead of tool denial text", async () => {
 		const task = createTaskProxy("session-123", vi.fn(), vi.fn())
 		const setTurnPhase = vi.fn()
+		const recordUserMessageToolApprovalDenial = vi.fn()
 		const coordinator = new SdkInteractionCoordinator({
 			messages: new SdkMessageCoordinator({ getTask: () => task }),
 			getSessionId: () => "session-123",
 			postStateToWebview: vi.fn().mockResolvedValue(undefined),
 			setTurnPhase,
+			recordUserMessageToolApprovalDenial,
 		})
 
 		const approvalPromise = coordinator.handleRequestToolApproval({
@@ -149,7 +152,11 @@ describe("SdkInteractionCoordinator", () => {
 		await vi.waitFor(() => expect(task.messageStateHandler.getClineMessages()).toHaveLength(1))
 
 		expect(coordinator.resolvePendingToolApproval("just give me an answer", "messageResponse")).toBe(false)
-		await expect(approvalPromise).resolves.toEqual({ approved: false, reason: "User denied the tool execution" })
+		await expect(approvalPromise).resolves.toEqual({
+			approved: false,
+			reason: USER_MESSAGE_TOOL_APPROVAL_DENIAL_REASON,
+		})
+		expect(recordUserMessageToolApprovalDenial).toHaveBeenCalledWith("tool-call")
 		expect(setTurnPhase).toHaveBeenLastCalledWith("streaming")
 	})
 

--- a/apps/vscode/src/sdk/sdk-interaction-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-interaction-coordinator.test.ts
@@ -4,7 +4,7 @@ import { MessageTranslatorState, translateSessionEvent } from "./message-transla
 import { SdkInteractionCoordinator } from "./sdk-interaction-coordinator"
 import { SdkMessageCoordinator } from "./sdk-message-coordinator"
 import { createTaskProxy } from "./task-proxy"
-import { USER_MESSAGE_TOOL_APPROVAL_DENIAL_REASON } from "./tool-approval-denial"
+import { DEFAULT_TOOL_APPROVAL_DENIAL_REASON, USER_MESSAGE_TOOL_APPROVAL_DENIAL_REASON } from "./tool-approval-denial"
 
 vi.mock("./webview-grpc-bridge", () => ({
 	pushMessageToWebview: vi.fn().mockResolvedValue(undefined),
@@ -102,11 +102,13 @@ describe("SdkInteractionCoordinator", () => {
 	it("resolves denied tool approval with the user reason", async () => {
 		const task = createTaskProxy("session-123", vi.fn(), vi.fn())
 		const recordApprovedToolMessage = vi.fn()
+		const recordDeniedToolApproval = vi.fn()
 		const coordinator = new SdkInteractionCoordinator({
 			messages: new SdkMessageCoordinator({ getTask: () => task }),
 			getSessionId: () => "session-123",
 			postStateToWebview: vi.fn().mockResolvedValue(undefined),
 			recordApprovedToolMessage,
+			recordDeniedToolApproval,
 		})
 
 		const approvalPromise = coordinator.handleRequestToolApproval({
@@ -125,19 +127,20 @@ describe("SdkInteractionCoordinator", () => {
 
 		expect(coordinator.resolvePendingToolApproval("too risky", "noButtonClicked")).toBe(true)
 		expect(recordApprovedToolMessage).not.toHaveBeenCalled()
+		expect(recordDeniedToolApproval).toHaveBeenCalledWith("tool-call", "execute_command", "too risky")
 		await expect(approvalPromise).resolves.toEqual({ approved: false, reason: "too risky" })
 	})
 
 	it("routes message responses as follow-ups instead of tool denial text", async () => {
 		const task = createTaskProxy("session-123", vi.fn(), vi.fn())
 		const setTurnPhase = vi.fn()
-		const recordUserMessageToolApprovalDenial = vi.fn()
+		const recordDeniedToolApproval = vi.fn()
 		const coordinator = new SdkInteractionCoordinator({
 			messages: new SdkMessageCoordinator({ getTask: () => task }),
 			getSessionId: () => "session-123",
 			postStateToWebview: vi.fn().mockResolvedValue(undefined),
 			setTurnPhase,
-			recordUserMessageToolApprovalDenial,
+			recordDeniedToolApproval,
 		})
 
 		const approvalPromise = coordinator.handleRequestToolApproval({
@@ -156,8 +159,45 @@ describe("SdkInteractionCoordinator", () => {
 			approved: false,
 			reason: USER_MESSAGE_TOOL_APPROVAL_DENIAL_REASON,
 		})
-		expect(recordUserMessageToolApprovalDenial).toHaveBeenCalledWith("tool-call")
+		expect(recordDeniedToolApproval).toHaveBeenCalledWith(
+			"tool-call",
+			"fetch_web_content",
+			USER_MESSAGE_TOOL_APPROVAL_DENIAL_REASON,
+		)
 		expect(setTurnPhase).toHaveBeenLastCalledWith("streaming")
+	})
+
+	it("records generic no-button approval denials for UI suppression", async () => {
+		const task = createTaskProxy("session-123", vi.fn(), vi.fn())
+		const recordDeniedToolApproval = vi.fn()
+		const coordinator = new SdkInteractionCoordinator({
+			messages: new SdkMessageCoordinator({ getTask: () => task }),
+			getSessionId: () => "session-123",
+			postStateToWebview: vi.fn().mockResolvedValue(undefined),
+			recordDeniedToolApproval,
+		})
+
+		const approvalPromise = coordinator.handleRequestToolApproval({
+			agentId: "agent",
+			conversationId: "conversation",
+			iteration: 1,
+			toolCallId: "tool-call",
+			toolName: "fetch_web_content",
+			input: { requests: [{ url: "https://example.com", prompt: "read it" }] },
+			policy: { autoApprove: false },
+		})
+		await vi.waitFor(() => expect(task.messageStateHandler.getClineMessages()).toHaveLength(1))
+
+		expect(coordinator.resolvePendingToolApproval(undefined, "noButtonClicked")).toBe(true)
+		await expect(approvalPromise).resolves.toEqual({
+			approved: false,
+			reason: DEFAULT_TOOL_APPROVAL_DENIAL_REASON,
+		})
+		expect(recordDeniedToolApproval).toHaveBeenCalledWith(
+			"tool-call",
+			"fetch_web_content",
+			DEFAULT_TOOL_APPROVAL_DENIAL_REASON,
+		)
 	})
 
 	it("auto-approves without emitting UI when the live settings allow the tool", async () => {

--- a/apps/vscode/src/sdk/sdk-interaction-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-interaction-coordinator.test.ts
@@ -127,6 +127,32 @@ describe("SdkInteractionCoordinator", () => {
 		await expect(approvalPromise).resolves.toEqual({ approved: false, reason: "too risky" })
 	})
 
+	it("routes message responses as follow-ups instead of tool denial text", async () => {
+		const task = createTaskProxy("session-123", vi.fn(), vi.fn())
+		const setTurnPhase = vi.fn()
+		const coordinator = new SdkInteractionCoordinator({
+			messages: new SdkMessageCoordinator({ getTask: () => task }),
+			getSessionId: () => "session-123",
+			postStateToWebview: vi.fn().mockResolvedValue(undefined),
+			setTurnPhase,
+		})
+
+		const approvalPromise = coordinator.handleRequestToolApproval({
+			agentId: "agent",
+			conversationId: "conversation",
+			iteration: 1,
+			toolCallId: "tool-call",
+			toolName: "fetch_web_content",
+			input: { requests: [{ url: "https://example.com", prompt: "read it" }] },
+			policy: { autoApprove: false },
+		})
+		await vi.waitFor(() => expect(task.messageStateHandler.getClineMessages()).toHaveLength(1))
+
+		expect(coordinator.resolvePendingToolApproval("just give me an answer", "messageResponse")).toBe(false)
+		await expect(approvalPromise).resolves.toEqual({ approved: false, reason: "User denied the tool execution" })
+		expect(setTurnPhase).toHaveBeenLastCalledWith("streaming")
+	})
+
 	it("auto-approves without emitting UI when the live settings allow the tool", async () => {
 		const task = createTaskProxy("session-123", vi.fn(), vi.fn())
 		const postStateToWebview = vi.fn().mockResolvedValue(undefined)

--- a/apps/vscode/src/sdk/sdk-interaction-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-interaction-coordinator.ts
@@ -102,14 +102,23 @@ export class SdkInteractionCoordinator {
 		const pendingMessage = this.pendingToolApprovalMessage
 		this.pendingToolApprovalResolve = undefined
 		this.pendingToolApprovalMessage = undefined
+
+		if (responseType === "messageResponse") {
+			Logger.log("[SdkController] Rejecting pending tool approval from user message and routing message as follow-up")
+			this.options.setTurnPhase?.("streaming")
+			resolve({ approved: false, reason: "User denied the tool execution" })
+			// The approval was resolved, but the chat message still needs normal follow-up routing.
+			return false
+		}
+
 		const approved = responseType === "yesButtonClicked"
 		Logger.log(`[SdkController] Resolving pending tool approval: approved=${approved} (responseType=${responseType})`)
 		if (approved && pendingMessage) {
 			this.options.recordApprovedToolMessage?.(pendingMessage.toolCallId, pendingMessage.messageTs)
 		}
 
-		// Approved or rejected, the agent resumes its turn — back to streaming. (On rejection
-		// the agent receives the denial and continues; the SDK drives the next phase.)
+		// Approved or rejected by approval controls, the agent resumes its turn and returns to streaming.
+		// On rejection the agent receives the denial and continues; the SDK drives the next phase.
 		this.options.setTurnPhase?.("streaming")
 		resolve({
 			approved,

--- a/apps/vscode/src/sdk/sdk-interaction-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-interaction-coordinator.ts
@@ -4,7 +4,7 @@ import { Logger } from "@/shared/services/Logger"
 import { MessageIdMinter } from "./message-id-minter"
 import { buildToolApprovalAskMessage } from "./message-translator"
 import type { SdkMessageCoordinator } from "./sdk-message-coordinator"
-import { USER_MESSAGE_TOOL_APPROVAL_DENIAL_REASON } from "./tool-approval-denial"
+import { DEFAULT_TOOL_APPROVAL_DENIAL_REASON, USER_MESSAGE_TOOL_APPROVAL_DENIAL_REASON } from "./tool-approval-denial"
 
 export interface ToolApprovalRequest {
 	agentId: string
@@ -22,7 +22,7 @@ export interface SdkInteractionCoordinatorOptions {
 	postStateToWebview: () => Promise<void>
 	shouldAutoApproveTool?: (request: ToolApprovalRequest) => boolean
 	recordApprovedToolMessage?: (toolCallId: string, messageTs: number) => void
-	recordUserMessageToolApprovalDenial?: (toolCallId: string) => void
+	recordDeniedToolApproval?: (toolCallId: string, toolName: string, reason: string) => void
 	/**
 	 * The process-wide id/seq/epoch authority, shared with the message translator. Optional so
 	 * existing tests that don't need cross-generator id uniqueness keep working; when omitted a
@@ -44,6 +44,7 @@ export class SdkInteractionCoordinator {
 		| {
 				toolCallId: string
 				messageTs: number
+				toolName: string
 		  }
 		| undefined
 
@@ -66,7 +67,11 @@ export class SdkInteractionCoordinator {
 
 		return new Promise<{ approved: boolean; reason?: string }>((resolve) => {
 			this.pendingToolApprovalResolve = resolve
-			this.pendingToolApprovalMessage = { toolCallId: request.toolCallId, messageTs: toolAskMessage.ts }
+			this.pendingToolApprovalMessage = {
+				toolCallId: request.toolCallId,
+				messageTs: toolAskMessage.ts,
+				toolName: request.toolName,
+			}
 		})
 	}
 
@@ -109,7 +114,11 @@ export class SdkInteractionCoordinator {
 			Logger.log("[SdkController] Rejecting pending tool approval from user message and routing message as follow-up")
 			this.options.setTurnPhase?.("streaming")
 			if (pendingMessage) {
-				this.options.recordUserMessageToolApprovalDenial?.(pendingMessage.toolCallId)
+				this.options.recordDeniedToolApproval?.(
+					pendingMessage.toolCallId,
+					pendingMessage.toolName,
+					USER_MESSAGE_TOOL_APPROVAL_DENIAL_REASON,
+				)
 			}
 			resolve({ approved: false, reason: USER_MESSAGE_TOOL_APPROVAL_DENIAL_REASON })
 			// The approval was resolved, but the chat message still needs normal follow-up routing.
@@ -125,9 +134,13 @@ export class SdkInteractionCoordinator {
 		// Approved or rejected by approval controls, the agent resumes its turn and returns to streaming.
 		// On rejection the agent receives the denial and continues; the SDK drives the next phase.
 		this.options.setTurnPhase?.("streaming")
+		const denialReason = prompt || DEFAULT_TOOL_APPROVAL_DENIAL_REASON
+		if (!approved && pendingMessage) {
+			this.options.recordDeniedToolApproval?.(pendingMessage.toolCallId, pendingMessage.toolName, denialReason)
+		}
 		resolve({
 			approved,
-			...(approved ? {} : { reason: prompt || "User denied the tool execution" }),
+			...(approved ? {} : { reason: denialReason }),
 		})
 		return true
 	}

--- a/apps/vscode/src/sdk/sdk-interaction-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-interaction-coordinator.ts
@@ -4,6 +4,7 @@ import { Logger } from "@/shared/services/Logger"
 import { MessageIdMinter } from "./message-id-minter"
 import { buildToolApprovalAskMessage } from "./message-translator"
 import type { SdkMessageCoordinator } from "./sdk-message-coordinator"
+import { USER_MESSAGE_TOOL_APPROVAL_DENIAL_REASON } from "./tool-approval-denial"
 
 export interface ToolApprovalRequest {
 	agentId: string
@@ -21,6 +22,7 @@ export interface SdkInteractionCoordinatorOptions {
 	postStateToWebview: () => Promise<void>
 	shouldAutoApproveTool?: (request: ToolApprovalRequest) => boolean
 	recordApprovedToolMessage?: (toolCallId: string, messageTs: number) => void
+	recordUserMessageToolApprovalDenial?: (toolCallId: string) => void
 	/**
 	 * The process-wide id/seq/epoch authority, shared with the message translator. Optional so
 	 * existing tests that don't need cross-generator id uniqueness keep working; when omitted a
@@ -106,7 +108,10 @@ export class SdkInteractionCoordinator {
 		if (responseType === "messageResponse") {
 			Logger.log("[SdkController] Rejecting pending tool approval from user message and routing message as follow-up")
 			this.options.setTurnPhase?.("streaming")
-			resolve({ approved: false, reason: "User denied the tool execution" })
+			if (pendingMessage) {
+				this.options.recordUserMessageToolApprovalDenial?.(pendingMessage.toolCallId)
+			}
+			resolve({ approved: false, reason: USER_MESSAGE_TOOL_APPROVAL_DENIAL_REASON })
 			// The approval was resolved, but the chat message still needs normal follow-up routing.
 			return false
 		}

--- a/apps/vscode/src/sdk/tool-approval-denial.ts
+++ b/apps/vscode/src/sdk/tool-approval-denial.ts
@@ -1,0 +1,18 @@
+export const USER_MESSAGE_TOOL_APPROVAL_DENIAL_REASON = "Tool execution was cancelled because the user sent a follow-up message."
+
+export function isUserMessageToolApprovalDenial(value: unknown): boolean {
+	if (typeof value === "string") {
+		return value.includes(USER_MESSAGE_TOOL_APPROVAL_DENIAL_REASON)
+	}
+
+	if (value instanceof Error) {
+		return value.message.includes(USER_MESSAGE_TOOL_APPROVAL_DENIAL_REASON)
+	}
+
+	if (value && typeof value === "object" && "message" in value) {
+		const message = (value as { message?: unknown }).message
+		return typeof message === "string" && message.includes(USER_MESSAGE_TOOL_APPROVAL_DENIAL_REASON)
+	}
+
+	return false
+}

--- a/apps/vscode/src/sdk/tool-approval-denial.ts
+++ b/apps/vscode/src/sdk/tool-approval-denial.ts
@@ -1,17 +1,49 @@
+export const DEFAULT_TOOL_APPROVAL_DENIAL_REASON = "User denied the tool execution"
 export const USER_MESSAGE_TOOL_APPROVAL_DENIAL_REASON = "Tool execution was cancelled because the user sent a follow-up message."
 
-export function isUserMessageToolApprovalDenial(value: unknown): boolean {
+function getMessage(value: unknown): string | undefined {
 	if (typeof value === "string") {
-		return value.includes(USER_MESSAGE_TOOL_APPROVAL_DENIAL_REASON)
+		return value
 	}
 
 	if (value instanceof Error) {
-		return value.message.includes(USER_MESSAGE_TOOL_APPROVAL_DENIAL_REASON)
+		return value.message
 	}
 
 	if (value && typeof value === "object" && "message" in value) {
 		const message = (value as { message?: unknown }).message
-		return typeof message === "string" && message.includes(USER_MESSAGE_TOOL_APPROVAL_DENIAL_REASON)
+		return typeof message === "string" ? message : undefined
+	}
+
+	return undefined
+}
+
+export function isKnownToolApprovalDenial(value: unknown): boolean {
+	const message = getMessage(value)
+	if (!message) {
+		return false
+	}
+
+	return message.includes(USER_MESSAGE_TOOL_APPROVAL_DENIAL_REASON) || message.includes(DEFAULT_TOOL_APPROVAL_DENIAL_REASON)
+}
+
+export function isDeniedToolApprovalMistake(
+	value: unknown,
+	deniedApprovals: Iterable<{ toolName: string; reason: string }>,
+): boolean {
+	const message = getMessage(value)
+	if (!message) {
+		return false
+	}
+
+	if (isKnownToolApprovalDenial(message)) {
+		return true
+	}
+
+	for (const { toolName, reason } of deniedApprovals) {
+		if (message.includes(`[${toolName}]`) && message.includes(reason)) {
+			return true
+		}
 	}
 
 	return false


### PR DESCRIPTION
### Related Issue

**Issue:** CLINE-2299

### Description

Fixes the SDK approval flow where free-form chat text entered while a tool approval is pending was treated as the tool denial reason. That caused replies like `just give me an answer` to render as a failed `fetch_web_content` tool result instead of as a user message.

This change resolves a pending approval with the generic denial reason when the response type is `messageResponse`, then returns control to the normal follow-up path so the typed text is rendered and queued as `user_feedback`.


## After this PR interrupiton by chat message works
<img width="342" height="392" alt="image" src="https://github.com/user-attachments/assets/66f57fa8-ec08-4da4-a6b1-4796b4202722" />


## Webfetch denial also works

<img width="336" height="446" alt="image" src="https://github.com/user-attachments/assets/c107a280-757e-456b-b51e-f9649ebfd327" />



### Test Procedure

- `npm run test:vitest -- src/sdk/sdk-interaction-coordinator.test.ts src/sdk/sdk-followup-coordinator.test.ts`
- `npm run test:vitest -- src/sdk`
- `./node_modules/.bin/biome check --config-path biome.jsonc src/sdk/sdk-interaction-coordinator.ts src/sdk/sdk-interaction-coordinator.test.ts src/sdk/sdk-followup-coordinator.test.ts --no-errors-on-unmatched --files-ignore-unknown=true --diagnostic-level=error`
- `git diff --check`

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - SDK adapter behavior fix covered by unit tests.

### Additional Notes

Opened against `dpc/sdk-migration-simpler-login` because `main` does not currently contain the SDK adapter files changed by this fix.

I ran the focused SDK adapter tests, the full `src/sdk` Vitest suite, `git diff --check`, and the extension-config Biome check for the touched files. I did not run the full repository `npm test` or full format/lint pipeline.
