### PR TITLE
feat: add plugin uninstall ability

### DIFF
--- a/apps/cli/src/commands/plugin.test.ts
+++ b/apps/cli/src/commands/plugin.test.ts
@@ -21,6 +21,7 @@ import {
 	isOfficialPluginSlug,
 	parsePluginSource,
 	runPluginInstallCommand,
+	runPluginUninstallCommand,
 } from "./plugin";
 
 type FetchCall = (
@@ -591,6 +592,54 @@ describe("plugin install command", () => {
 		expect(
 			readFileSync(join(first.installPath, "package", "index.ts"), "utf8"),
 		).toContain("installed-v1");
+	});
+
+	it("uninstalls a package plugin by package name", async () => {
+		const source = join(root, "uninstall-package");
+		const npmCommandPath = join(root, "fake-npm.sh");
+		await mkdir(source, { recursive: true });
+		await writeFile(
+			join(source, "package.json"),
+			JSON.stringify(
+				{
+					name: "cli-uninstall-plugin",
+					cline: {
+						plugins: [{ paths: ["./index.ts"], capabilities: ["tools"] }],
+					},
+				},
+				null,
+				2,
+			),
+			"utf8",
+		);
+		await writeFile(
+			join(source, "index.ts"),
+			"export default { name: 'cli-uninstall-plugin', manifest: { capabilities: ['tools'] } };",
+			"utf8",
+		);
+		writeFileSync(npmCommandPath, "#!/bin/sh\nexit 0\n", {
+			encoding: "utf8",
+			mode: 0o755,
+		});
+
+		const installed = await installPlugin({
+			source,
+			npmCommand: npmCommandPath,
+		});
+		const output: string[] = [];
+		const code = await runPluginUninstallCommand({
+			name: "cli-uninstall-plugin",
+			io: {
+				writeln: (text = "") => output.push(text),
+				writeErr: (text) => output.push(text),
+			},
+		});
+
+		expect(code).toBe(0);
+		expect(existsSync(installed.installPath)).toBe(false);
+		expect(output.join("\n")).toContain(
+			"Uninstalled plugin cli-uninstall-plugin",
+		);
 	});
 
 	it("prints JSON output for command callers", async () => {

--- a/apps/cli/src/commands/plugin.ts
+++ b/apps/cli/src/commands/plugin.ts
@@ -13,6 +13,7 @@ import {
 import { cp, mkdir, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, dirname, join, relative, resolve, sep } from "node:path";
+import { type PluginUninstallOptions, uninstallPlugin } from "@cline/core";
 import {
 	isPluginModulePath,
 	resolveClineDir,
@@ -1057,6 +1058,25 @@ export async function runPluginInstallCommand(
 		}
 		options.io?.writeln(`Installed plugin from ${result.source}`);
 		options.io?.writeln(`  Path: ${result.installPath}`);
+		return 0;
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		options.io?.writeErr(message);
+		return 1;
+	}
+}
+
+export async function runPluginUninstallCommand(
+	options: PluginUninstallOptions & { json?: boolean; io?: PluginInstallIo },
+): Promise<number> {
+	try {
+		const result = await uninstallPlugin(options);
+		if (options.json) {
+			process.stdout.write(JSON.stringify(result));
+			return 0;
+		}
+		options.io?.writeln(`Uninstalled plugin ${result.name}`);
+		options.io?.writeln(`  Removed: ${result.installPath}`);
 		return 0;
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -284,6 +284,30 @@ export async function runCli(): Promise<void> {
 				io,
 			});
 		});
+	const pluginUninstallCmd = pluginCmd
+		.command("uninstall")
+		.alias("remove")
+		.alias("rm")
+		.description("Uninstall a Cline Plugin by name or path")
+		.argument("<name>", "plugin package name, installed slug, or plugin path")
+		.option("--json", "Output as JSON")
+		.option(
+			"--cwd <path>",
+			"Search <path>/.cline/plugins before global plugins",
+		)
+		.action(async (name: string) => {
+			const opts = pluginUninstallCmd.opts<{
+				json?: boolean;
+				cwd?: string;
+			}>();
+			const { runPluginUninstallCommand } = await import("./commands/plugin");
+			ctx.exitCode = await runPluginUninstallCommand({
+				name,
+				cwd: opts.cwd,
+				json: opts.json === true || program.opts().json === true,
+				io,
+			});
+		});
 	const connectCmd = program
 		.command("connect")
 		.description("Connect to an external channel")

--- a/apps/cli/src/runtime/interactive/config-data.test.ts
+++ b/apps/cli/src/runtime/interactive/config-data.test.ts
@@ -455,6 +455,112 @@ Find installable skills.`,
 		).toBe(true);
 	});
 
+	it("deletes a package-backed plugin and refreshes bundled slash commands", async () => {
+		const tempRoot = await mkdtemp(join(tmpdir(), "cli-config-data-"));
+		tempRoots.push(tempRoot);
+		process.env.CLINE_GLOBAL_SETTINGS_PATH = join(
+			tempRoot,
+			"global-settings.json",
+		);
+		const packageDir = join(tempRoot, ".cline", "plugins", "delete-plugin");
+		const pluginPath = join(packageDir, "index.ts");
+		const skillPath = join(packageDir, "skills", "erase", "SKILL.md");
+		await mkdir(join(packageDir, "skills", "erase"), { recursive: true });
+		await writeFile(
+			join(packageDir, "package.json"),
+			JSON.stringify(
+				{
+					name: "delete-plugin",
+					cline: {
+						plugins: [{ paths: ["./index.ts"] }],
+					},
+				},
+				null,
+				2,
+			),
+		);
+		await writeFile(pluginPath, "export default {};\n");
+		await writeFile(
+			skillPath,
+			`---
+name: erase
+---
+Erase stale plugin commands.`,
+		);
+		await writeFile(
+			process.env.CLINE_GLOBAL_SETTINGS_PATH,
+			JSON.stringify({ disabledPlugins: [pluginPath] }, null, 2),
+		);
+		const refreshCalls: string[] = [];
+		let refreshed = false;
+		const userInstructionService = {
+			async refreshType(type: string) {
+				refreshCalls.push(type);
+				refreshed = true;
+			},
+			listRuntimeCommands() {
+				return refreshed
+					? []
+					: [
+							{
+								name: "erase",
+								instructions: "Erase stale plugin commands.",
+								description: "Erase",
+								kind: "skill",
+							},
+						];
+			},
+			listRecords(type: string) {
+				if (type !== "skill") {
+					return [];
+				}
+				return [
+					{
+						id: "erase",
+						type: "skill",
+						filePath: skillPath,
+						item: {
+							name: "erase",
+							disabled: false,
+							description: "Erase",
+							instructions: "Erase stale plugin commands.",
+							frontmatter: {},
+						},
+					},
+				];
+			},
+		} as unknown as UserInstructionConfigService;
+		const loader = createInteractiveConfigDataLoader({
+			config: createConfig(tempRoot),
+			userInstructionService,
+		});
+		const data = await loader.loadConfigData({ includePluginTools: false });
+		const plugin = data.plugins.find((item) => item.path === pluginPath);
+		if (!plugin) {
+			throw new Error("Expected package plugin to be listed");
+		}
+
+		const nextData = await loader.onDeleteConfigItem(plugin, {
+			includePluginTools: false,
+		});
+		const settings = JSON.parse(
+			await readFile(process.env.CLINE_GLOBAL_SETTINGS_PATH, "utf8"),
+		) as { disabledPlugins?: string[] };
+
+		await expect(readFile(pluginPath, "utf8")).rejects.toThrow();
+		await expect(readFile(skillPath, "utf8")).rejects.toThrow();
+		expect(settings.disabledPlugins).toBeUndefined();
+		expect(refreshCalls).toEqual(
+			expect.arrayContaining(["workflow", "rule", "skill"]),
+		);
+		expect(nextData?.plugins.some((item) => item.path === pluginPath)).toBe(
+			false,
+		);
+		expect(
+			nextData?.workflowSlashCommands.map((command) => command.name),
+		).not.toContain("erase");
+	});
+
 	it("uses the package name for package-backed plugin entries", async () => {
 		const tempRoot = await mkdtemp(join(tmpdir(), "cli-config-data-"));
 		tempRoots.push(tempRoot);

--- a/apps/cli/src/runtime/interactive/config-data.ts
+++ b/apps/cli/src/runtime/interactive/config-data.ts
@@ -3,6 +3,7 @@ import {
 	setDisabledPlugin,
 	setDisabledTools,
 	type UserInstructionConfigService,
+	uninstallPlugin,
 } from "@cline/core";
 import {
 	type InteractiveConfigData,
@@ -35,6 +36,18 @@ export function createInteractiveConfigDataLoader(input: {
 			availabilityContext: availabilityContext(),
 			includePluginTools: options.includePluginTools,
 		});
+
+	const refreshUserInstructionConfigs = async (): Promise<void> => {
+		const service = input.userInstructionService;
+		if (!service) {
+			return;
+		}
+		await Promise.all([
+			service.refreshType("workflow"),
+			service.refreshType("rule"),
+			service.refreshType("skill"),
+		]);
+	};
 
 	const onToggleConfigItem = async (
 		item: InteractiveConfigItem,
@@ -106,8 +119,26 @@ export function createInteractiveConfigDataLoader(input: {
 		return undefined;
 	};
 
+	const onDeleteConfigItem = async (
+		item: InteractiveConfigItem,
+		options: LoadInteractiveConfigDataOptions = {},
+	): Promise<InteractiveConfigData | undefined> => {
+		if (item.kind !== "plugin") {
+			return undefined;
+		}
+		await uninstallPlugin({
+			path: item.path,
+			name: item.name,
+			cwd: input.config.cwd,
+			workspaceRoot: workspaceRoot(),
+		});
+		await refreshUserInstructionConfigs();
+		return await loadConfigData(options);
+	};
+
 	return {
 		loadConfigData,
 		onToggleConfigItem,
+		onDeleteConfigItem,
 	};
 }

--- a/apps/cli/src/runtime/run-interactive.ts
+++ b/apps/cli/src/runtime/run-interactive.ts
@@ -322,6 +322,18 @@ export async function runInteractive(
 		}
 		return data;
 	};
+	const onDeleteConfigItem = async (
+		item: InteractiveConfigItem,
+		options: LoadInteractiveConfigDataOptions = {},
+	): Promise<
+		Awaited<ReturnType<typeof configDataLoader.onDeleteConfigItem>>
+	> => {
+		const data = await configDataLoader.onDeleteConfigItem(item, options);
+		if (data && shouldRefreshInteractiveSessionForConfigItem(item)) {
+			await refreshInteractiveSessionPolicies();
+		}
+		return data;
+	};
 	const toQueuedPromptItem = (prompt: {
 		id: string;
 		prompt: string;
@@ -397,6 +409,7 @@ export async function runInteractive(
 			}),
 		loadConfigData: configDataLoader.loadConfigData,
 		onToggleConfigItem,
+		onDeleteConfigItem,
 		subscribeToEvents: ({
 			onAgentEvent: onAgent,
 			onTeamEvent: onTeam,

--- a/apps/cli/src/tui/components/dialogs/config-dialogs.tsx
+++ b/apps/cli/src/tui/components/dialogs/config-dialogs.tsx
@@ -137,3 +137,54 @@ export function ExtDetailContent(
 		</box>
 	);
 }
+
+export function DeleteConfigItemConfirmContent(
+	props: ChoiceContext<boolean> & {
+		item: InteractiveConfigItem;
+	},
+) {
+	useDialogKeyboard((key) => {
+		if (key.name === "return" || key.name === "y") {
+			props.resolve(true);
+		} else if (key.name === "escape" || key.name === "n") {
+			props.dismiss();
+		}
+	}, props.dialogId);
+
+	return (
+		<box flexDirection="column" paddingX={1}>
+			<text>Delete plugin {props.item.name}?</text>
+			<text fg="gray" marginTop={1}>
+				This removes the installed plugin files from {props.item.path}.
+			</text>
+			<text fg="gray" marginTop={1}>
+				<em>Y/Enter to confirm, N/Esc to cancel</em>
+			</text>
+		</box>
+	);
+}
+
+export function ConfigErrorContent(
+	props: ChoiceContext<void> & {
+		title: string;
+		message: string;
+	},
+) {
+	useDialogKeyboard((key) => {
+		if (key.name === "return" || key.name === "escape") {
+			props.dismiss();
+		}
+	}, props.dialogId);
+
+	return (
+		<box flexDirection="column" paddingX={1}>
+			<text fg="red">{props.title}</text>
+			<text fg="gray" marginTop={1}>
+				{props.message}
+			</text>
+			<text fg="gray" marginTop={1}>
+				<em>Enter/Esc to close</em>
+			</text>
+		</box>
+	);
+}

--- a/apps/cli/src/tui/hooks/use-config-panel.tsx
+++ b/apps/cli/src/tui/hooks/use-config-panel.tsx
@@ -9,7 +9,11 @@ import type {
 	LoadInteractiveConfigDataOptions,
 } from "../../tui/interactive-config";
 import type { CliCompactionMode, Config } from "../../utils/types";
-import { ExtDetailContent } from "../components/dialogs/config-dialogs";
+import {
+	ConfigErrorContent,
+	DeleteConfigItemConfirmContent,
+	ExtDetailContent,
+} from "../components/dialogs/config-dialogs";
 import { withLoadingDialog } from "../components/dialogs/loading-dialog";
 import { ConfigPanelContent } from "../views/config-view";
 import type { ConfigAction } from "../views/config-view-helpers";
@@ -32,6 +36,10 @@ export function useConfigPanel(opts: {
 		options?: LoadInteractiveConfigDataOptions,
 	) => Promise<InteractiveConfigData>;
 	onToggleConfigItem?: (
+		item: InteractiveConfigItem,
+		options?: LoadInteractiveConfigDataOptions,
+	) => Promise<InteractiveConfigData | undefined>;
+	onDeleteConfigItem?: (
 		item: InteractiveConfigItem,
 		options?: LoadInteractiveConfigDataOptions,
 	) => Promise<InteractiveConfigData | undefined>;
@@ -90,6 +98,7 @@ export function useConfigPanel(opts: {
 								activeTab = tab;
 							}}
 							onToggleConfigItem={opts.onToggleConfigItem}
+							onDeleteConfigItem={opts.onDeleteConfigItem}
 							onToggleMode={opts.toggleMode}
 							onToggleAutoApprove={opts.toggleAutoApprove}
 							onSetCompactionMode={opts.setCompactionMode}
@@ -111,6 +120,38 @@ export function useConfigPanel(opts: {
 					await opts.openModelSelector({ onCancel: () => {} });
 				} else if (action.kind === "toggle-item") {
 					await opts.onToggleConfigItem?.(action.item);
+				} else if (action.kind === "delete-item") {
+					const confirmed = await opts.dialog.choice<boolean>({
+						closeOnEscape: true,
+						content: (ctx: ChoiceContext<boolean>) => (
+							<DeleteConfigItemConfirmContent {...ctx} item={action.item} />
+						),
+					});
+					if (confirmed && opts.onDeleteConfigItem) {
+						try {
+							await withLoadingDialog(
+								opts.dialog,
+								`Deleting ${action.item.name}...`,
+								async () =>
+									await opts.onDeleteConfigItem?.(action.item, {
+										includePluginTools: false,
+									}),
+							);
+						} catch (error) {
+							await opts.dialog.choice<void>({
+								closeOnEscape: true,
+								content: (ctx: ChoiceContext<void>) => (
+									<ConfigErrorContent
+										{...ctx}
+										title="Plugin delete failed"
+										message={
+											error instanceof Error ? error.message : String(error)
+										}
+									/>
+								),
+							});
+						}
+					}
 				} else if (action.kind === "ext-detail") {
 					await opts.dialog.choice<void>({
 						style: { maxHeight: opts.termHeight - 2 },

--- a/apps/cli/src/tui/root.tsx
+++ b/apps/cli/src/tui/root.tsx
@@ -207,6 +207,19 @@ function App(props: TuiProps) {
 			return data;
 		};
 	}, [propsOnToggleConfigItem]);
+	const propsOnDeleteConfigItem = props.onDeleteConfigItem;
+	const onDeleteConfigItem = useMemo<TuiProps["onDeleteConfigItem"]>(() => {
+		if (!propsOnDeleteConfigItem) {
+			return undefined;
+		}
+		return async (item, options) => {
+			const data = await propsOnDeleteConfigItem(item, options);
+			if (data) {
+				setWorkflowSlashCommands(data.workflowSlashCommands);
+			}
+			return data;
+		};
+	}, [propsOnDeleteConfigItem]);
 
 	const openConfig = useConfigPanel({
 		dialog,
@@ -219,6 +232,7 @@ function App(props: TuiProps) {
 		termHeight,
 		loadConfigData: props.loadConfigData,
 		onToggleConfigItem,
+		onDeleteConfigItem,
 		openModelSelector,
 		openMcpManager,
 		refocusTextarea: () => refocusTextareaRef.current(),

--- a/apps/cli/src/tui/types.ts
+++ b/apps/cli/src/tui/types.ts
@@ -137,6 +137,10 @@ export interface TuiProps {
 		item: InteractiveConfigItem,
 		options?: LoadInteractiveConfigDataOptions,
 	) => Promise<InteractiveConfigData | undefined>;
+	onDeleteConfigItem?: (
+		item: InteractiveConfigItem,
+		options?: LoadInteractiveConfigDataOptions,
+	) => Promise<InteractiveConfigData | undefined>;
 	subscribeToEvents: (handlers: {
 		onAgentEvent: (event: AgentEvent) => void;
 		onTeamEvent: (event: TeamEvent) => void;

--- a/apps/cli/src/tui/views/config-view-helpers.ts
+++ b/apps/cli/src/tui/views/config-view-helpers.ts
@@ -9,6 +9,7 @@ export type ConfigAction =
 	| { kind: "open-provider" }
 	| { kind: "open-model" }
 	| { kind: "toggle-item"; item: InteractiveConfigItem }
+	| { kind: "delete-item"; item: InteractiveConfigItem }
 	| {
 			kind: "ext-detail";
 			item: InteractiveConfigItem;
@@ -130,6 +131,10 @@ export function isToggleableConfigItem(item: InteractiveConfigItem): boolean {
 	return isToggleableInteractiveConfigItem(item);
 }
 
+export function isDeletableConfigItem(item: InteractiveConfigItem): boolean {
+	return item.kind === "plugin";
+}
+
 export function resolveConfigItemSelectAction(
 	item: InteractiveConfigItem,
 ): ConfigAction {
@@ -154,6 +159,15 @@ export function resolveConfigItemToggleAction(
 		return undefined;
 	}
 	return { kind: "toggle-item", item };
+}
+
+export function resolveConfigItemDeleteAction(
+	item: InteractiveConfigItem,
+): ConfigAction | undefined {
+	if (!isDeletableConfigItem(item)) {
+		return undefined;
+	}
+	return { kind: "delete-item", item };
 }
 
 export function isInlineConfigAction(
@@ -183,14 +197,33 @@ export function canToggleConfigFooterRow(
 	);
 }
 
+export function canDeleteConfigFooterRow(
+	row:
+		| { kind: "ext"; item: InteractiveConfigItem }
+		| { kind: string }
+		| undefined,
+): boolean {
+	return (
+		row?.kind === "ext" && "item" in row && isDeletableConfigItem(row.item)
+	);
+}
+
 export function getConfigFooterText({
 	canToggle = false,
+	canDelete = false,
 }: {
 	canToggle?: boolean;
+	canDelete?: boolean;
 } = {}): string {
-	return canToggle
-		? "←/→ switch tabs, ↑/↓ navigate, Tab/Enter select, Space toggle, Esc close"
-		: "←/→ switch tabs, ↑/↓ navigate, Tab/Enter select, Esc close";
+	const actions = ["←/→ switch tabs", "↑/↓ navigate", "Tab/Enter select"];
+	if (canToggle) {
+		actions.push("Space toggle");
+	}
+	if (canDelete) {
+		actions.push("D delete");
+	}
+	actions.push("Esc close");
+	return actions.join(", ");
 }
 
 export function getConfigItemDisplayName(name: string): string {

--- a/apps/cli/src/tui/views/config-view.tsx
+++ b/apps/cli/src/tui/views/config-view.tsx
@@ -18,6 +18,7 @@ import { resolveModelDisplayName } from "../components/status-bar";
 import { getModeAccent, palette } from "../palette";
 import {
 	type ConfigAction,
+	canDeleteConfigFooterRow,
 	canToggleConfigFooterRow,
 	getAdjacentConfigTab,
 	getConfigFooterText,
@@ -26,6 +27,7 @@ import {
 	isInlineConfigAction,
 	isToggleableConfigItem,
 	resolveActiveConfigItems,
+	resolveConfigItemDeleteAction,
 	resolveConfigItemSelectAction,
 	resolveConfigItemToggleAction,
 	resolveInitialConfigTab,
@@ -130,6 +132,10 @@ export interface ConfigPanelProps extends ChoiceContext<ConfigAction> {
 	initialTab?: InteractiveConfigTab;
 	onActiveTabChange?: (tab: InteractiveConfigTab) => void;
 	onToggleConfigItem?: (
+		item: InteractiveConfigItem,
+		options?: LoadInteractiveConfigDataOptions,
+	) => Promise<InteractiveConfigData | undefined>;
+	onDeleteConfigItem?: (
 		item: InteractiveConfigItem,
 		options?: LoadInteractiveConfigDataOptions,
 	) => Promise<InteractiveConfigData | undefined>;
@@ -518,6 +524,9 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 	const selectedRowIdx = navIndices[clampedNavPos] ?? 0;
 	const selectedRow = rows[selectedRowIdx];
 	const canToggleSelectedRow = canToggleConfigFooterRow(selectedRow);
+	const canDeleteSelectedRow = Boolean(
+		props.onDeleteConfigItem && canDeleteConfigFooterRow(selectedRow),
+	);
 
 	const setNavPosition = (nextNavPos: number) => {
 		setNavPos(nextNavPos);
@@ -618,6 +627,20 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 		}
 	};
 
+	const handleDeleteSelected = () => {
+		if (!props.onDeleteConfigItem) {
+			return;
+		}
+		const row = rows[selectedRowIdx];
+		if (!row || row.kind !== "ext") {
+			return;
+		}
+		const action = resolveConfigItemDeleteAction(row.item);
+		if (action) {
+			resolve(action);
+		}
+	};
+
 	useDialogKeyboard((key) => {
 		if (key.name === "escape") {
 			dismiss();
@@ -646,6 +669,16 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 		}
 		if (key.name === "space") {
 			handleToggleSelected();
+			return;
+		}
+		if (
+			key.name === "d" &&
+			!key.ctrl &&
+			!key.meta &&
+			!key.option &&
+			!key.shift
+		) {
+			handleDeleteSelected();
 			return;
 		}
 		if (key.name === "return" || key.name === "tab") {
@@ -844,7 +877,10 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 				<em>
 					{togglingItemId
 						? "Applying settings"
-						: getConfigFooterText({ canToggle: canToggleSelectedRow })}
+						: getConfigFooterText({
+								canToggle: canToggleSelectedRow,
+								canDelete: canDeleteSelectedRow,
+							})}
 				</em>
 			</text>
 		</box>

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -436,6 +436,11 @@ export {
 	listPluginTools,
 	listPluginToolsWithDiagnostics,
 } from "./services/plugin-tools";
+export type {
+	PluginUninstallOptions,
+	PluginUninstallResult,
+} from "./services/plugin-uninstall";
+export { uninstallPlugin } from "./services/plugin-uninstall";
 export {
 	addLocalProvider,
 	type DeleteLocalProviderRequest,

--- a/sdk/packages/core/src/services/plugin-uninstall.test.ts
+++ b/sdk/packages/core/src/services/plugin-uninstall.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, rmSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -124,6 +124,30 @@ describe("plugin uninstall service", () => {
 
 		expect(result.installPath).toBe(pluginPath);
 		expect(existsSync(pluginPath)).toBe(false);
+	});
+
+	it("keeps disabled plugin settings if file deletion fails", async () => {
+		const pluginRoot = join(home, ".cline", "plugins");
+		const pluginPath = join(pluginRoot, "locked-plugin.ts");
+		await mkdir(pluginRoot, { recursive: true });
+		await writeFile(
+			pluginPath,
+			"export default { name: 'locked', manifest: { capabilities: ['tools'] } };",
+			"utf8",
+		);
+		writeGlobalSettings({ disabledPlugins: [pluginPath] });
+		chmodSync(pluginRoot, 0o555);
+
+		try {
+			await expect(uninstallPlugin({ path: pluginPath })).rejects.toThrow();
+			expect(existsSync(pluginPath)).toBe(true);
+			expect(readGlobalSettings()).toEqual({
+				disabledPlugins: [pluginPath],
+				telemetryOptOut: false,
+			});
+		} finally {
+			chmodSync(pluginRoot, 0o755);
+		}
 	});
 
 	it("reports unmatched names clearly", async () => {

--- a/sdk/packages/core/src/services/plugin-uninstall.test.ts
+++ b/sdk/packages/core/src/services/plugin-uninstall.test.ts
@@ -1,0 +1,134 @@
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setClineDir, setHomeDir } from "@cline/shared/storage";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readGlobalSettings, writeGlobalSettings } from "./global-settings";
+import { uninstallPlugin } from "./plugin-uninstall";
+
+describe("plugin uninstall service", () => {
+	let root = "";
+	let home = "";
+	let originalHome: string | undefined;
+	let originalClineDir: string | undefined;
+	let originalClineDataDir: string | undefined;
+	let originalGlobalSettingsPath: string | undefined;
+
+	beforeEach(() => {
+		root = mkdtempSync(join(tmpdir(), "core-plugin-uninstall-"));
+		home = join(root, "home");
+		originalHome = process.env.HOME;
+		originalClineDir = process.env.CLINE_DIR;
+		originalClineDataDir = process.env.CLINE_DATA_DIR;
+		originalGlobalSettingsPath = process.env.CLINE_GLOBAL_SETTINGS_PATH;
+		process.env.HOME = home;
+		process.env.CLINE_DIR = join(home, ".cline");
+		process.env.CLINE_DATA_DIR = join(home, ".cline", "data");
+		process.env.CLINE_GLOBAL_SETTINGS_PATH = join(
+			home,
+			".cline",
+			"data",
+			"settings",
+			"global-settings.json",
+		);
+		setHomeDir(home);
+		setClineDir(process.env.CLINE_DIR);
+	});
+
+	afterEach(() => {
+		if (originalHome === undefined) {
+			delete process.env.HOME;
+		} else {
+			process.env.HOME = originalHome;
+		}
+		if (originalClineDir === undefined) {
+			delete process.env.CLINE_DIR;
+		} else {
+			process.env.CLINE_DIR = originalClineDir;
+		}
+		if (originalClineDataDir === undefined) {
+			delete process.env.CLINE_DATA_DIR;
+		} else {
+			process.env.CLINE_DATA_DIR = originalClineDataDir;
+		}
+		if (originalGlobalSettingsPath === undefined) {
+			delete process.env.CLINE_GLOBAL_SETTINGS_PATH;
+		} else {
+			process.env.CLINE_GLOBAL_SETTINGS_PATH = originalGlobalSettingsPath;
+		}
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	it("uninstalls an installed package plugin by package name", async () => {
+		const installPath = join(
+			home,
+			".cline",
+			"plugins",
+			"_installed",
+			"local",
+			"bundled-skills-demo-123456789abc",
+		);
+		const entryPath = join(installPath, "package", "index.ts");
+		await mkdir(join(installPath, "package"), { recursive: true });
+		await writeFile(
+			join(installPath, "package.json"),
+			JSON.stringify(
+				{
+					name: "cline-installed-plugin-test",
+					cline: {
+						plugins: [{ paths: ["./package/index.ts"] }],
+					},
+				},
+				null,
+				2,
+			),
+			"utf8",
+		);
+		await writeFile(
+			join(installPath, "package", "package.json"),
+			JSON.stringify({ name: "cline-internal-bundled-skills-demo" }, null, 2),
+			"utf8",
+		);
+		await writeFile(
+			entryPath,
+			"export default { name: 'demo', manifest: { capabilities: ['skills'] } };",
+			"utf8",
+		);
+		writeGlobalSettings({
+			disabledPlugins: [entryPath, "/tmp/other-plugin.ts"],
+		});
+
+		const result = await uninstallPlugin({
+			name: "cline-internal-bundled-skills-demo",
+		});
+
+		expect(result.installPath).toBe(installPath);
+		expect(existsSync(installPath)).toBe(false);
+		expect(readGlobalSettings()).toEqual({
+			disabledPlugins: ["/tmp/other-plugin.ts"],
+			telemetryOptOut: false,
+		});
+	});
+
+	it("uninstalls a direct plugin file by path", async () => {
+		const pluginPath = join(home, ".cline", "plugins", "direct-plugin.ts");
+		await mkdir(join(home, ".cline", "plugins"), { recursive: true });
+		await writeFile(
+			pluginPath,
+			"export default { name: 'direct', manifest: { capabilities: ['tools'] } };",
+			"utf8",
+		);
+
+		const result = await uninstallPlugin({ path: pluginPath });
+
+		expect(result.installPath).toBe(pluginPath);
+		expect(existsSync(pluginPath)).toBe(false);
+	});
+
+	it("reports unmatched names clearly", async () => {
+		await expect(uninstallPlugin({ name: "missing-plugin" })).rejects.toThrow(
+			/No plugin found matching "missing-plugin"/,
+		);
+	});
+});

--- a/sdk/packages/core/src/services/plugin-uninstall.ts
+++ b/sdk/packages/core/src/services/plugin-uninstall.ts
@@ -407,11 +407,11 @@ export async function uninstallPlugin(
 			`Plugin install path does not exist: ${candidate.installPath}`,
 		);
 	}
-	cleanupDisabledPluginPaths(candidate);
 	rmSync(candidate.installPath, {
 		recursive: stats.isDirectory(),
 		force: true,
 	});
+	cleanupDisabledPluginPaths(candidate);
 	if (candidate.installed) {
 		cleanupEmptyInstallParents(candidate.installPath);
 	}

--- a/sdk/packages/core/src/services/plugin-uninstall.ts
+++ b/sdk/packages/core/src/services/plugin-uninstall.ts
@@ -1,0 +1,425 @@
+import {
+	existsSync,
+	readdirSync,
+	readFileSync,
+	rmdirSync,
+	rmSync,
+	statSync,
+} from "node:fs";
+import {
+	basename,
+	dirname,
+	extname,
+	isAbsolute,
+	join,
+	relative,
+	resolve,
+	sep,
+} from "node:path";
+import {
+	discoverPluginModulePaths,
+	resolvePluginConfigSearchPaths,
+} from "@cline/shared/storage";
+import { readGlobalSettings, writeGlobalSettings } from "./global-settings";
+
+export interface PluginUninstallOptions {
+	name?: string;
+	path?: string;
+	cwd?: string;
+	workspaceRoot?: string;
+}
+
+export interface PluginUninstallResult {
+	name: string;
+	installPath: string;
+	removedPaths: string[];
+	entryPaths: string[];
+}
+
+interface PluginUninstallCandidate {
+	installPath: string;
+	entryPaths: string[];
+	names: string[];
+	installed: boolean;
+}
+
+const INSTALLS_DIRECTORY_NAME = "_installed";
+const PACKAGE_DIRECTORY_NAME = "package";
+const INSTALL_KIND_DEPTHS = new Map<string, number>([
+	["git", 2],
+	["local", 1],
+	["npm", 1],
+	["official", 1],
+	["remote", 1],
+]);
+
+function normalizeMatchValue(value: string): string {
+	return value.trim().toLowerCase();
+}
+
+function addName(names: Set<string>, value: string | undefined): void {
+	const trimmed = value?.trim();
+	if (!trimmed) {
+		return;
+	}
+	names.add(trimmed);
+}
+
+function stripInstallHash(value: string): string {
+	return value.replace(/-[0-9a-f]{12}$/i, "");
+}
+
+function withoutExtension(value: string): string {
+	const extension = extname(value);
+	return extension ? value.slice(0, -extension.length) : value;
+}
+
+function readPackageName(packageJsonPath: string): string | undefined {
+	if (!existsSync(packageJsonPath)) {
+		return undefined;
+	}
+	try {
+		const parsed = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+			name?: unknown;
+		};
+		return typeof parsed.name === "string" ? parsed.name.trim() : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function isInsidePath(childPath: string, parentPath: string): boolean {
+	const relativePath = relative(parentPath, childPath);
+	return (
+		relativePath === "" ||
+		(!relativePath.startsWith("..") && !isAbsolute(relativePath))
+	);
+}
+
+function resolveInstalledRootFromPath(filePath: string): string | undefined {
+	const absolutePath = resolve(filePath);
+	const parts = absolutePath.split(sep);
+	const installedIndex = parts.lastIndexOf(INSTALLS_DIRECTORY_NAME);
+	if (installedIndex < 0) {
+		return undefined;
+	}
+	const kind = parts[installedIndex + 1];
+	if (!kind) {
+		return undefined;
+	}
+	const depth = INSTALL_KIND_DEPTHS.get(kind) ?? 1;
+	const endIndex = installedIndex + 2 + depth;
+	if (parts.length < endIndex) {
+		return undefined;
+	}
+	const root = parts.slice(0, endIndex).join(sep) || sep;
+	return existsSync(root) ? root : undefined;
+}
+
+function safeReadDir(directoryPath: string) {
+	try {
+		return readdirSync(directoryPath, { withFileTypes: true });
+	} catch {
+		return [];
+	}
+}
+
+function collectInstalledRoots(pluginRoot: string): string[] {
+	const installedRoot = join(pluginRoot, INSTALLS_DIRECTORY_NAME);
+	if (!existsSync(installedRoot)) {
+		return [];
+	}
+	const roots: string[] = [];
+	for (const kindEntry of safeReadDir(installedRoot)) {
+		if (!kindEntry.isDirectory()) {
+			continue;
+		}
+		const kindPath = join(installedRoot, kindEntry.name);
+		if (kindEntry.name === "git") {
+			for (const hostEntry of safeReadDir(kindPath)) {
+				if (!hostEntry.isDirectory()) {
+					continue;
+				}
+				const hostPath = join(kindPath, hostEntry.name);
+				for (const installEntry of safeReadDir(hostPath)) {
+					if (installEntry.isDirectory()) {
+						roots.push(join(hostPath, installEntry.name));
+					}
+				}
+			}
+			continue;
+		}
+		for (const installEntry of safeReadDir(kindPath)) {
+			if (installEntry.isDirectory()) {
+				roots.push(join(kindPath, installEntry.name));
+			}
+		}
+	}
+	return roots.sort((left, right) => left.localeCompare(right));
+}
+
+function discoverEntriesWithin(root: string): string[] {
+	try {
+		return discoverPluginModulePaths(root);
+	} catch {
+		return [];
+	}
+}
+
+function createInstalledCandidate(
+	installPath: string,
+): PluginUninstallCandidate {
+	const entryPaths = discoverEntriesWithin(installPath);
+	const names = new Set<string>();
+	addName(names, basename(installPath));
+	addName(names, stripInstallHash(basename(installPath)));
+	addName(names, readPackageName(join(installPath, "package.json")));
+	addName(
+		names,
+		readPackageName(join(installPath, PACKAGE_DIRECTORY_NAME, "package.json")),
+	);
+	for (const entryPath of entryPaths) {
+		addName(names, basename(entryPath));
+		addName(names, withoutExtension(basename(entryPath)));
+	}
+	return {
+		installPath,
+		entryPaths,
+		names: [...names].sort((left, right) => left.localeCompare(right)),
+		installed: true,
+	};
+}
+
+function resolveDirectPluginInstallPath(
+	filePath: string,
+	pluginRoots: string[],
+): string | undefined {
+	const absolutePath = resolve(filePath);
+	const pluginRoot = pluginRoots.find((root) =>
+		isInsidePath(absolutePath, root),
+	);
+	if (!pluginRoot) {
+		return undefined;
+	}
+	let current = dirname(absolutePath);
+	while (current !== pluginRoot && current !== dirname(current)) {
+		if (existsSync(join(current, "package.json"))) {
+			return current;
+		}
+		current = dirname(current);
+	}
+	const filename = basename(absolutePath);
+	if (
+		(filename === "index.ts" || filename === "index.js") &&
+		dirname(absolutePath) !== pluginRoot
+	) {
+		return dirname(absolutePath);
+	}
+	return absolutePath;
+}
+
+function createDirectCandidate(
+	entryPath: string,
+	pluginRoots: string[],
+): PluginUninstallCandidate | undefined {
+	const installPath = resolveDirectPluginInstallPath(entryPath, pluginRoots);
+	if (!installPath) {
+		return undefined;
+	}
+	const names = new Set<string>();
+	addName(names, basename(entryPath));
+	addName(names, withoutExtension(basename(entryPath)));
+	addName(names, basename(installPath));
+	addName(names, withoutExtension(basename(installPath)));
+	addName(names, readPackageName(join(installPath, "package.json")));
+	return {
+		installPath,
+		entryPaths: [entryPath],
+		names: [...names].sort((left, right) => left.localeCompare(right)),
+		installed: false,
+	};
+}
+
+function getPluginRoots(options: PluginUninstallOptions): string[] {
+	const workspaceRoot =
+		options.workspaceRoot?.trim() || options.cwd?.trim() || process.cwd();
+	return resolvePluginConfigSearchPaths(workspaceRoot).filter((directory) =>
+		existsSync(directory),
+	);
+}
+
+function collectCandidates(pluginRoots: string[]): PluginUninstallCandidate[] {
+	const candidatesByInstallPath = new Map<string, PluginUninstallCandidate>();
+
+	for (const pluginRoot of pluginRoots) {
+		for (const installPath of collectInstalledRoots(pluginRoot)) {
+			candidatesByInstallPath.set(
+				installPath,
+				createInstalledCandidate(installPath),
+			);
+		}
+		for (const entryPath of discoverEntriesWithin(pluginRoot)) {
+			const installedRoot = resolveInstalledRootFromPath(entryPath);
+			if (installedRoot) {
+				if (!candidatesByInstallPath.has(installedRoot)) {
+					candidatesByInstallPath.set(
+						installedRoot,
+						createInstalledCandidate(installedRoot),
+					);
+				}
+				continue;
+			}
+			const directCandidate = createDirectCandidate(entryPath, pluginRoots);
+			if (directCandidate) {
+				candidatesByInstallPath.set(
+					directCandidate.installPath,
+					directCandidate,
+				);
+			}
+		}
+	}
+
+	return [...candidatesByInstallPath.values()].sort((left, right) =>
+		left.installPath.localeCompare(right.installPath),
+	);
+}
+
+function candidateMatchesName(
+	candidate: PluginUninstallCandidate,
+	name: string,
+): boolean {
+	const normalizedName = normalizeMatchValue(name);
+	if (!normalizedName) {
+		return false;
+	}
+	if (normalizeMatchValue(candidate.installPath) === normalizedName) {
+		return true;
+	}
+	return candidate.names.some(
+		(candidateName) => normalizeMatchValue(candidateName) === normalizedName,
+	);
+}
+
+function findCandidateByPath(
+	path: string,
+	candidates: PluginUninstallCandidate[],
+	pluginRoots: string[],
+): PluginUninstallCandidate | undefined {
+	const absolutePath = resolve(path);
+	for (const candidate of candidates) {
+		if (isInsidePath(absolutePath, candidate.installPath)) {
+			return candidate;
+		}
+		if (
+			candidate.entryPaths.some(
+				(entryPath) => resolve(entryPath) === absolutePath,
+			)
+		) {
+			return candidate;
+		}
+	}
+	const installedRoot = resolveInstalledRootFromPath(absolutePath);
+	if (installedRoot) {
+		return createInstalledCandidate(installedRoot);
+	}
+	if (existsSync(absolutePath)) {
+		return createDirectCandidate(absolutePath, pluginRoots);
+	}
+	return undefined;
+}
+
+function cleanupDisabledPluginPaths(candidate: PluginUninstallCandidate): void {
+	const settings = readGlobalSettings();
+	const disabledPlugins = settings.disabledPlugins;
+	if (!disabledPlugins?.length) {
+		return;
+	}
+	const remaining = disabledPlugins.filter((pluginPath) => {
+		const absolutePath = resolve(pluginPath);
+		if (isInsidePath(absolutePath, candidate.installPath)) {
+			return false;
+		}
+		return !candidate.entryPaths.some(
+			(entryPath) => resolve(entryPath) === absolutePath,
+		);
+	});
+	if (remaining.length === disabledPlugins.length) {
+		return;
+	}
+	writeGlobalSettings({ ...settings, disabledPlugins: remaining });
+}
+
+function cleanupEmptyInstallParents(installPath: string): void {
+	let current = dirname(installPath);
+	while (
+		current !== dirname(current) &&
+		basename(current) !== INSTALLS_DIRECTORY_NAME
+	) {
+		try {
+			rmdirSync(current);
+		} catch {
+			return;
+		}
+		current = dirname(current);
+	}
+}
+
+function describeCandidate(candidate: PluginUninstallCandidate): string {
+	const primaryName = candidate.names[0] ?? basename(candidate.installPath);
+	return `${primaryName} at ${candidate.installPath}`;
+}
+
+export async function uninstallPlugin(
+	options: PluginUninstallOptions,
+): Promise<PluginUninstallResult> {
+	const pluginRoots = getPluginRoots(options);
+	const candidates = collectCandidates(pluginRoots);
+	const explicitPath = options.path?.trim();
+	const requestedName = options.name?.trim();
+
+	let candidate: PluginUninstallCandidate | undefined;
+	if (explicitPath) {
+		candidate = findCandidateByPath(explicitPath, candidates, pluginRoots);
+		if (!candidate) {
+			throw new Error(`No plugin found at ${explicitPath}`);
+		}
+	} else {
+		if (!requestedName) {
+			throw new Error("plugin uninstall requires a plugin name");
+		}
+		const matches = candidates.filter((item) =>
+			candidateMatchesName(item, requestedName),
+		);
+		if (matches.length === 0) {
+			throw new Error(`No plugin found matching "${requestedName}"`);
+		}
+		if (matches.length > 1) {
+			throw new Error(
+				`Multiple plugins match "${requestedName}": ${matches.map(describeCandidate).join(", ")}`,
+			);
+		}
+		candidate = matches[0];
+	}
+
+	const stats = statSync(candidate.installPath, { throwIfNoEntry: false });
+	if (!stats) {
+		throw new Error(
+			`Plugin install path does not exist: ${candidate.installPath}`,
+		);
+	}
+	cleanupDisabledPluginPaths(candidate);
+	rmSync(candidate.installPath, {
+		recursive: stats.isDirectory(),
+		force: true,
+	});
+	if (candidate.installed) {
+		cleanupEmptyInstallParents(candidate.installPath);
+	}
+	return {
+		name:
+			requestedName || candidate.names[0] || basename(candidate.installPath),
+		installPath: candidate.installPath,
+		removedPaths: [candidate.installPath],
+		entryPaths: candidate.entryPaths,
+	};
+}


### PR DESCRIPTION
This PR adds a first-class uninstall path for Cline plugins.

The immediate problem is that `cline plugin install` can place plugins into the managed `_installed` directory, but users do not have an equivalent command or settings action to remove them. That leaves people manually deleting directories under `~/.cline/plugins/_installed`, which is easy to get wrong and also leaves stale disabled-plugin entries behind in global settings.

The implementation adds a shared uninstall service in `@cline/core` and uses it from the CLI:

- `cline plugin uninstall <name>`
- Aliases: `cline plugin remove <name>` and `cline plugin rm <name>`
- `--json` output for scripts and smoke tests
- `--cwd <path>` for resolving workspace plugin roots outside the current process cwd

The terminal `/settings` plugin tab now also exposes uninstall from the CLI TUI. When the selected row is a plugin, the footer shows `D delete`. Pressing `d` opens an are-you-sure dialog with `Y/Enter` to confirm and `N/Esc` to cancel. On confirm, the TUI calls the same core uninstall service, refreshes instruction config caches, reloads settings data, and restarts the active interactive session policies so removed plugin tools or bundled skills stop being available.

The resolver accepts plugin package names, installed slugs, wrapper names, direct plugin filenames, and explicit paths. For installed plugins, it removes the managed install root. For direct plugin files under known plugin roots, it removes the file or package directory. It also removes matching paths from `disabledPlugins` in global settings so a future reinstall does not inherit stale disabled state.

Debugging and design notes:

- Installed package plugins expose the useful package name in the inner `package/package.json`, not always the wrapper package name.
- The CLI command is name-first, but still supports path-shaped names through the same resolver.
- The TUI settings panel already has the selected plugin path, so the delete flow calls uninstall by path for accuracy.
- Plugin-owned skills and slash commands can remain cached if the user instruction service is not refreshed after deleting files. The TUI delete path now refreshes workflow, rule, and skill config types before reloading settings data.
- Ambiguous name matches fail with a clear error instead of deleting the wrong plugin.
- An earlier local version wired this into cline-hub webview settings. That was removed because `bun run dev` in `apps/cli` renders the terminal TUI settings panel, not the cline-hub settings webview.
