### PR TITLE
fix(agents): avoid Error-valued abort signal reason

### DIFF
--- a/sdk/packages/agents/src/agent-runtime.provider-form.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.provider-form.test.ts
@@ -121,7 +121,8 @@ describe("AgentRuntime (provider-form config + Agent alias)", () => {
 		await expect(runPromise).resolves.toMatchObject({
 			status: "aborted",
 		});
-		expect(abortReason).not.toEqual(new Error("user cancelled"));
+		expect(agent.snapshot().lastError).toBe("user cancelled");
+		expect(abortReason).toMatchObject({ name: "AbortError" });
 	});
 
 	it("createAgent() and new Agent() both return an AgentRuntime instance", () => {

--- a/sdk/packages/agents/src/agent-runtime.provider-form.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.provider-form.test.ts
@@ -122,6 +122,7 @@ describe("AgentRuntime (provider-form config + Agent alias)", () => {
 			status: "aborted",
 		});
 		expect(agent.snapshot().lastError).toBe("user cancelled");
+		expect(abortReason).toBeDefined();
 		expect(abortReason).toMatchObject({ name: "AbortError" });
 	});
 

--- a/sdk/packages/agents/src/agent-runtime.provider-form.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.provider-form.test.ts
@@ -83,13 +83,21 @@ describe("AgentRuntime (provider-form config + Agent alias)", () => {
 	});
 
 	it("forwards abort() to the active AgentRuntime", async () => {
+		let abortReason: unknown;
 		const model = new ScriptedModel([
 			async function* (request) {
 				yield { type: "text-delta", text: "partial" };
 				await new Promise<void>((resolve) => {
-					request.signal?.addEventListener("abort", () => resolve(), {
-						once: true,
-					});
+					request.signal?.addEventListener(
+						"abort",
+						() => {
+							abortReason = request.signal?.reason;
+							resolve();
+						},
+						{
+							once: true,
+						},
+					);
 				});
 				yield { type: "finish", reason: "aborted" };
 			},
@@ -113,6 +121,7 @@ describe("AgentRuntime (provider-form config + Agent alias)", () => {
 		await expect(runPromise).resolves.toMatchObject({
 			status: "aborted",
 		});
+		expect(abortReason).not.toEqual(new Error("user cancelled"));
 	});
 
 	it("createAgent() and new Agent() both return an AgentRuntime instance", () => {

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -1332,7 +1332,7 @@ export class AgentRuntime {
 
 	private normalizeAbortError(): Error {
 		const reason = this.abortController?.signal.reason;
-		if (reason instanceof Error) {
+		if (reason instanceof Error && reason.name !== "AbortError") {
 			return reason;
 		}
 		if (typeof reason === "string") {

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -399,7 +399,7 @@ export class AgentRuntime {
 						? undefined
 						: String(reason);
 		this.state.lastError = message ?? "Run aborted";
-		this.abortController.abort(new Error(this.state.lastError));
+		this.abortController.abort();
 	}
 
 	subscribe(listener: AgentEventListener): () => void {


### PR DESCRIPTION
### Related Issue

Issue: #XXXX

### Description

This PR prevents expected CLI/TUI abort cancellation from being carried through `AbortSignal.reason` as a custom `Error` object.

Problem:

- Pressing Esc in an interactive CLI session sends an expected abort request with the message `Interactive runtime abort requested`.
- `AgentRuntime.abort()` stored that message in state, but also passed a new `Error` object into `AbortController.abort(...)`.
- That made the abort signal carry `Error("Interactive runtime abort requested")` as `signal.reason`.
- In hub mode, that Error-valued abort reason could surface as an unhandled rejection during the async abort/provider/hook cleanup path.
- The hub daemon treats unhandled rejections as fatal, so a normal user cancellation could kill the shared hub process and leave clients with stale websocket/session state.

Technical approach:

- Keep preserving the user-facing abort message in `AgentRuntime.state.lastError`.
- Stop passing a custom `Error` object to `AbortController.abort(...)`.
- Let the abort signal use the platform default abort reason while runtime result/error normalization continues to use `state.lastError`.
- Updated the existing abort forwarding test to assert that abort still resolves as `status: "aborted"` without putting the custom user cancellation Error on the abort signal.

Decisions and gotchas:

- I intentionally did not add a daemon-level allowlist for `Interactive runtime abort requested`. That would prevent the daemon crash, but it would be a boundary mitigation rather than fixing the source of the Error-valued abort reason.
- I avoided changing `afterRun` hook semantics. Hook failures should not be broadly suppressed just because a run was aborted.
- The change keeps the runtime-facing abort message behavior through `state.lastError`, while avoiding leaking that message as `AbortSignal.reason`.

### Test Procedure

Ran targeted checks:

```bash
cd sdk/packages/agents
bun run test src/agent-runtime.provider-form.test.ts --testNamePattern "forwards abort"
bun run test src/agent-runtime.test.ts src/agent-runtime.provider-form.test.ts
bun run typecheck
bun run build
```

Also ran dependent package/build checks:

```bash
cd sdk/packages/core
bun run build

cd apps/cli
bun run build
```

Manual validation:

- Reproduced the original crash before the source-level fix in an isolated hub/TUI environment:
  - `run.abort`
  - `hook.afterRun`
  - `[hub-daemon] unhandledRejection: Error: Interactive runtime abort requested`
- Re-tested with the source-level fix in a clean isolated TUI environment.
- Confirmed the hub stayed alive and logs showed:
  - `hub unhandled abort: 0`
  - `hub any unhandledRejection: 0`
  - `hub fatal: 0`
  - `unknown/session not found: 0`
- Confirmed CLI-side abort completed as an aborted run rather than crashing:
  - `event: session.aborted`
  - `event: agent.run-finished`
  - `status: aborted`

Risk areas considered:

- Abort message preservation: `state.lastError` is still set before aborting, so result normalization still has the user-facing message.
- Abort propagation: `AbortController.abort()` still marks the signal aborted and existing tests confirm active runs resolve as aborted.
- Hub daemon behavior: no daemon policy was weakened; real unhandled rejections remain fatal.
- Hook behavior: no broad `afterRun` suppression was added.
- Low-level abort consumers: code that inspects `request.signal.reason` will now see the platform default abort reason rather than the custom user cancellation Error.

### Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Refactor Changes
-   [ ] Cosmetic Changes
-   [ ] Documentation update
-   [ ] Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable. This is runtime abort behavior.

### Additional Notes

No related issue was provided, so the issue placeholder is left as `#XXXX`.

The second checklist item is left unchecked because I did not run the full repo-wide template commands exactly. The focused tests/builds relevant to this change are listed above.
