### PR TITLE
fix(sdk): keep hub daemon alive on runtime abort

### DIFF
--- a/sdk/packages/agents/src/agent-runtime.provider-form.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.provider-form.test.ts
@@ -6,7 +6,7 @@ import type {
 	AgentRuntimeEvent,
 } from "@cline/shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { AgentRuntime } from "./agent-runtime";
+import { AgentRuntime, AgentRuntimeAbortError } from "./agent-runtime";
 import { Agent, createAgent } from "./index";
 
 const { createAgentModel, createGateway } = vi.hoisted(() => {
@@ -83,13 +83,19 @@ describe("AgentRuntime (provider-form config + Agent alias)", () => {
 	});
 
 	it("forwards abort() to the active AgentRuntime", async () => {
+		let abortReason: unknown;
 		const model = new ScriptedModel([
 			async function* (request) {
 				yield { type: "text-delta", text: "partial" };
 				await new Promise<void>((resolve) => {
-					request.signal?.addEventListener("abort", () => resolve(), {
-						once: true,
-					});
+					request.signal?.addEventListener(
+						"abort",
+						() => {
+							abortReason = request.signal?.reason;
+							resolve();
+						},
+						{ once: true },
+					);
 				});
 				yield { type: "finish", reason: "aborted" };
 			},
@@ -113,6 +119,12 @@ describe("AgentRuntime (provider-form config + Agent alias)", () => {
 		await expect(runPromise).resolves.toMatchObject({
 			status: "aborted",
 		});
+		expect(abortReason).toBeInstanceOf(AgentRuntimeAbortError);
+		if (!(abortReason instanceof AgentRuntimeAbortError)) {
+			throw new Error("expected agent runtime abort reason");
+		}
+		expect(abortReason.message).toBe("user cancelled");
+		expect(abortReason.reason).toBe("user cancelled");
 	});
 
 	it("createAgent() and new Agent() both return an AgentRuntime instance", () => {

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -217,6 +217,24 @@ class ControlledStopError extends Error {
 	}
 }
 
+export class AgentRuntimeAbortError extends Error {
+	readonly reason?: unknown;
+
+	constructor(reason?: unknown) {
+		const message =
+			typeof reason === "string"
+				? reason
+				: reason instanceof Error
+					? reason.message
+					: reason === undefined
+						? "Run aborted"
+						: String(reason);
+		super(message);
+		this.name = "AgentRuntimeAbortError";
+		this.reason = reason;
+	}
+}
+
 const DEFAULT_USAGE: AgentUsage = {
 	inputTokens: 0,
 	outputTokens: 0,
@@ -390,16 +408,12 @@ export class AgentRuntime {
 		if (!this.abortController) {
 			return;
 		}
-		const message =
-			typeof reason === "string"
+		const abortError =
+			reason instanceof AgentRuntimeAbortError
 				? reason
-				: reason instanceof Error
-					? reason.message
-					: reason === undefined
-						? undefined
-						: String(reason);
-		this.state.lastError = message ?? "Run aborted";
-		this.abortController.abort(new Error(this.state.lastError));
+				: new AgentRuntimeAbortError(reason);
+		this.state.lastError = abortError.message;
+		this.abortController.abort(abortError);
 	}
 
 	subscribe(listener: AgentEventListener): () => void {

--- a/sdk/packages/agents/src/index.ts
+++ b/sdk/packages/agents/src/index.ts
@@ -51,6 +51,7 @@ export type {
 export {
 	Agent,
 	AgentRuntime,
+	AgentRuntimeAbortError,
 	createAgent,
 	createAgentRuntime,
 } from "./agent-runtime";

--- a/sdk/packages/core/src/hub/daemon/entry.ts
+++ b/sdk/packages/core/src/hub/daemon/entry.ts
@@ -1,3 +1,4 @@
+import { AgentRuntimeAbortError } from "@cline/agents";
 import { initVcr } from "@cline/shared";
 import { createLocalHubScheduleRuntimeHandlers } from "../daemon/runtime-handlers";
 import { resolveHubEndpointOptions } from "../discovery/defaults";
@@ -106,6 +107,12 @@ async function main(): Promise<void> {
 		shutdownFatal("uncaughtException", error);
 	});
 	process.on("unhandledRejection", (reason) => {
+		if (reason instanceof AgentRuntimeAbortError) {
+			process.stderr.write(
+				`[hub-daemon] ignored agent runtime abort rejection: ${reason.message}\n`,
+			);
+			return;
+		}
 		shutdownFatal("unhandledRejection", reason);
 	});
 


### PR DESCRIPTION
### Related Issue

Issue: #XXXX

### Description

This fixes a CLI/hub abort regression where pressing Esc during `thinking... (esc to cancel)` could leave the CLI in a broken state and later produce errors like:

```text
error: session not found: <sessionId>
```

The short version: Esc was reaching the runtime. The hub daemon was dying after the abort because an expected AgentRuntime abort rejection escaped as an `unhandledRejection`. After the daemon restarted or the CLI reconnected, the CLI still had an in-memory `activeSessionId` for the old daemon runtime, so the next `run.start` was sent to a hub process that did not know that session.

This PR makes runtime aborts typed at the source and teaches only the hub daemon fatal rejection boundary to ignore that typed abort. It avoids message string matching, timing windows, and broad suppression of unrelated failures.

What changed:

- Added `AgentRuntimeAbortError` in `@cline/agents`.
- `AgentRuntime.abort()` now passes that typed error to `AbortController.abort()`.
- The hub daemon `unhandledRejection` handler ignores only `AgentRuntimeAbortError`.
- Existing unexpected unhandled rejections still go through `shutdownFatal`.
- The existing provider-form abort test now verifies the abort signal reason is typed.

Why this is intentionally small:

- No TUI key handling changes.
- No `run.abort` protocol changes.
- No session lifecycle changes.
- No error string allowlist.
- No grace timer.
- No broad `AbortError` suppression.

#### What the repro showed

The repro sequence was roughly:

```text
1. Start CLI and send a message.
2. Send a second message.
3. Press Esc while thinking.
4. CLI appears stuck or does not render expected output.
5. Later sends produce session not found.
```

The useful log sequence before the fix looked like this:

```text
run.start session=<id>
run.abort session=<id> ok=true
hub-daemon unhandledRejection: Error: Interactive runtime abort requested
run.start session=<same id>
command.error session not found: <same id>
```

That means the Esc path did not fail at the keyboard layer. The daemon accepted `run.abort` and returned success. The failure happened immediately after, when the runtime abort rejection reached the daemon process-level `unhandledRejection` handler and caused fatal shutdown.

#### How Esc to cancel works

High-level flow:

```mermaid
sequenceDiagram
    participant User
    participant TUI
    participant CLI as CLI session runtime
    participant Hub as Hub client/server
    participant Host as LocalRuntimeHost
    participant Runtime as SessionRuntime
    participant Agent as AgentRuntime
    participant Model as Model stream

    User->>TUI: press Esc while thinking
    TUI->>CLI: abortAll()
    CLI->>Hub: run.abort(sessionId, reason)
    Hub->>Host: abort(sessionId, reason)
    Host->>Runtime: abort(reason)
    Runtime->>Agent: abort(reason)
    Agent->>Model: AbortSignal aborts stream
    Model-->>Agent: stream unwinds as aborted
    Agent-->>Runtime: run result status=aborted
    Runtime-->>Hub: run.start completes cleanly
```

More concretely:

```text
Esc key
  -> interactive session runtime abortAll()
  -> sessionManager.abort(activeSessionId, Error("Interactive runtime abort requested"))
  -> hub command run.abort
  -> LocalRuntimeHost.abort(sessionId, reason)
  -> SessionRuntime.abort(reason)
  -> active AgentRuntime.abort(reason)
  -> AbortController.abort(reason)
  -> provider stream and hooks unwind
```

The main run promise already handles abort as a normal terminal outcome. The problem is that cancellation can also create orphan promise rejections in streaming or hook teardown code outside the awaited run promise chain.

The CLI process already has special abort handling in `apps/cli/src/runtime/active-runtime.ts` because those orphan rejections can otherwise surface through process-level `unhandledRejection` listeners and disrupt OpenTUI. The hub daemon had its own fatal `unhandledRejection` boundary and did not know which abort rejections were expected.

#### Why the old behavior broke the session

Before this PR:

```mermaid
flowchart TD
    A[Esc pressed] --> B[run.abort reaches daemon]
    B --> C[AgentRuntime aborts model stream]
    C --> D[orphan rejection escapes]
    D --> E[daemon unhandledRejection]
    E --> F[shutdownFatal]
    F --> G[daemon exits]
    G --> H[CLI reconnects or starts another hub]
    H --> I[CLI still has old activeSessionId]
    I --> J[run.start]
    J --> K[session not found]
```

The raw TUI weirdness was downstream of the daemon lifecycle break. Once the daemon died, the CLI was still rendering an interactive session whose hub-backed runtime state no longer existed in that process.

#### Why this fix works

After this PR:

```mermaid
flowchart TD
    A[AgentRuntime.abort] --> B[create AgentRuntimeAbortError]
    B --> C[AbortController.abort typed reason]
    C --> D[orphan rejection reaches daemon]
    D --> E{is AgentRuntimeAbortError}
    E -->|yes| F[ignore expected abort rejection]
    E -->|no| G[shutdownFatal]
    F --> H[daemon stays alive]
    H --> I[same session can continue]
```

The important part is where the type is introduced. The abort starts inside the SDK, so we can tag the abort at the source instead of guessing at the daemon boundary.

This gives the daemon a narrow, structural test:

```text
reason instanceof AgentRuntimeAbortError
```

That is better than matching error message strings such as `Interactive runtime abort requested` or `Run aborted`, because callers can pass different abort reasons and those strings are not a stable protocol. The daemon still fatal-crashes on unrelated unhandled rejections, which preserves the existing fail-fast behavior for real daemon bugs.

#### Why this appeared around 3.0.15

I compared the `cli-v3.0.14..cli-v3.0.15` release window for the relevant paths.

I did not find changes in:

- `AgentRuntime`
- interactive session runtime abort handling
- active CLI abort suppression
- local runtime host abort handling
- chat view key handling

The relevant release-window changes were around hub lifecycle and discovery:

- `fad8271f4 feat: Cline Hub web app (#10969)` added Cline Hub web app work and added `coreVersion` to hub version/discovery payloads.
- `b87f61f9e fix(cli): stabilize core tests on Windows (#11125)` changed detached hub probing to use `safeProbeHubServer`, treating probe failures as unavailable instead of letting probe errors escape.

My read is that the abort rejection bug was latent, but 3.0.15 made the detached hub lifecycle and reconnect path more visible in this workflow. The repro did not require OpenTUI key handling to regress. Esc was sent, `run.abort` was accepted, and then the daemon died on an expected abort rejection. The visible `session not found` error was a later symptom of reconnecting with a stale in-memory session id.

#### Tradeoffs and gotchas

This uses `instanceof AgentRuntimeAbortError` inside the daemon. In the current hub daemon process, `@cline/agents` is loaded through one package graph, so the check is structural enough for this boundary. If the daemon ever loads multiple physical copies of `@cline/agents` in one process, this could be replaced with a shared symbol marker. I did not add that now because it would add complexity without evidence this process has duplicate package instances.

This intentionally does not ignore generic `AbortError`, `DOMException`, or arbitrary errors named `AbortError`. Those can come from unrelated code paths and should not bypass the daemon fatal handler unless they are known to be AgentRuntime aborts.

### Test Procedure

Automated verification run after rebasing onto current `origin/main`:

```text
bun vitest run --config vitest.config.ts src/agent-runtime.provider-form.test.ts
bun vitest run --config vitest.config.ts sdk/packages/core/src/hub/daemon/index.test.ts
bun biome check --diagnostic-level=error sdk/packages/agents/src/agent-runtime.ts sdk/packages/agents/src/index.ts sdk/packages/agents/src/agent-runtime.provider-form.test.ts sdk/packages/core/src/hub/daemon/entry.ts
bun -F @cline/agents typecheck
bun -F @cline/core typecheck
sleep 1 && git diff --check
```

Manual/log verification:

```text
before:
run.abort ok=true
hub-daemon unhandledRejection: Error: Interactive runtime abort requested
later run.start -> session not found

after:
run.abort ok=true
hub-daemon ignored agent runtime abort rejection: Interactive runtime abort requested
run.start ok=true
session.get ok=true
next run.start ok=true
```

What could break:

- Abort result propagation from `AgentRuntime.abort()`.
- The daemon fatal error boundary.
- Package exports from `@cline/agents`.

How this was checked:

- Existing abort flow still resolves with `status: "aborted"`.
- The abort signal reason is now asserted to be `AgentRuntimeAbortError`.
- Daemon tests still pass.
- Typechecks pass for both changed packages.
- Unrelated unhandled rejections are still passed to `shutdownFatal` because the daemon only ignores the typed runtime abort error.

### Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Refactor Changes
-   [ ] Cosmetic Changes
-   [ ] Documentation update
-   [ ] Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable. This is a CLI/runtime daemon fix with log-based verification.

### Additional Notes

The earlier debugging patch used broad hub logs and briefly tried suppressing expected abort rejections by matching message strings. That proved the failure mode, but it was too brittle to keep. This final version removes that approach and instead tags the abort where it originates.

The remaining daemon log line is intentional:

```text
[hub-daemon] ignored agent runtime abort rejection: <message>
```

That gives maintainers a breadcrumb when an expected runtime abort produces an orphan rejection, without hiding unexpected daemon failures.
