### PR TITLE
fix(cli): recover stale interactive sessions and suppress shutdown races

### DIFF
--- a/apps/cli/src/runtime/interactive/session-runtime.test.ts
+++ b/apps/cli/src/runtime/interactive/session-runtime.test.ts
@@ -5,6 +5,7 @@ import type {
 	ToolApprovalRequest,
 	ToolApprovalResult,
 } from "@cline/core";
+import { SessionNotFoundError } from "@cline/core";
 import type { AgentTool, Message } from "@cline/shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChatCommandState } from "../../utils/chat-commands";
@@ -257,7 +258,7 @@ describe("createInteractiveSessionRuntime", () => {
 		];
 		manager.readMessages.mockResolvedValue(messages);
 		manager.send
-			.mockRejectedValueOnce(new Error("session not found: session-1"))
+			.mockRejectedValueOnce(new SessionNotFoundError("session-1"))
 			.mockResolvedValueOnce(makeTurnResult());
 		const runtime = makeRuntime(manager);
 

--- a/apps/cli/src/runtime/interactive/session-runtime.test.ts
+++ b/apps/cli/src/runtime/interactive/session-runtime.test.ts
@@ -140,6 +140,16 @@ function makeTurnResult() {
 	};
 }
 
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	let reject!: (error?: unknown) => void;
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
+	});
+	return { promise, resolve, reject };
+}
+
 function makeRuntime(
 	manager: ReturnType<typeof makeManager>,
 	options: { resumeSessionId?: string } = {},
@@ -286,5 +296,45 @@ describe("createInteractiveSessionRuntime", () => {
 			expect.objectContaining({ sessionId: "session-2" }),
 		);
 		expect(runtime.getActiveSessionId()).toBe("session-2");
+	});
+
+	it("waits for missing-session recovery before cleanup disposes the manager", async () => {
+		const manager = makeManager();
+		const recoveryRead = deferred<Message[]>();
+		manager.readMessages
+			.mockImplementationOnce(() => recoveryRead.promise)
+			.mockResolvedValue([]);
+		manager.get.mockResolvedValue(undefined);
+		manager.getAccumulatedUsage.mockResolvedValue(undefined);
+		manager.send.mockRejectedValueOnce(new SessionNotFoundError("session-1"));
+		const runtime = makeRuntime(manager);
+
+		await runtime.ensureReady();
+		const sendPromise = runtime
+			.sendCurrentTurn({
+				prompt: "second hi",
+				mode: "act",
+			})
+			.catch((error) => error);
+		await vi.waitFor(() => {
+			expect(manager.readMessages).toHaveBeenCalledWith("session-1");
+		});
+
+		let cleanupSettled = false;
+		const cleanupPromise = runtime.cleanup().finally(() => {
+			cleanupSettled = true;
+		});
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		expect(cleanupSettled).toBe(false);
+		expect(manager.get).not.toHaveBeenCalled();
+		expect(manager.dispose).not.toHaveBeenCalled();
+
+		recoveryRead.resolve([]);
+		await cleanupPromise;
+		const sendError = await sendPromise;
+
+		expect(sendError).toBeInstanceOf(SessionNotFoundError);
+		expect(manager.dispose).toHaveBeenCalledWith("cli_interactive_shutdown");
 	});
 });

--- a/apps/cli/src/runtime/interactive/session-runtime.test.ts
+++ b/apps/cli/src/runtime/interactive/session-runtime.test.ts
@@ -5,7 +5,7 @@ import type {
 	ToolApprovalRequest,
 	ToolApprovalResult,
 } from "@cline/core";
-import type { AgentTool } from "@cline/shared";
+import type { AgentTool, Message } from "@cline/shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChatCommandState } from "../../utils/chat-commands";
 import type { Config } from "../../utils/types";
@@ -112,7 +112,7 @@ function makeManager() {
 		abort: vi.fn(),
 		dispose: vi.fn(),
 		get: vi.fn(),
-		readMessages: vi.fn(async () => []),
+		readMessages: vi.fn(async (): Promise<Message[]> => []),
 		readTranscript: vi.fn(),
 		ingestHookEvent: vi.fn(),
 		subscribe: vi.fn(),
@@ -121,6 +121,21 @@ function makeManager() {
 			update: vi.fn(),
 		},
 		restore: vi.fn(),
+	};
+}
+
+function makeTurnResult() {
+	return {
+		text: "ok",
+		usage: { inputTokens: 0, outputTokens: 0 },
+		messages: [],
+		toolCalls: [],
+		iterations: 1,
+		finishReason: "completed" as const,
+		model: { id: "openai/gpt-5.3-codex", provider: "cline" },
+		startedAt: new Date("2026-01-01T00:00:00.000Z"),
+		endedAt: new Date("2026-01-01T00:00:00.100Z"),
+		durationMs: 100,
 	};
 }
 
@@ -229,6 +244,46 @@ describe("createInteractiveSessionRuntime", () => {
 
 		expect(manager.stop).toHaveBeenCalledWith("session-1");
 		expect(manager.start).toHaveBeenCalledTimes(2);
+		expect(runtime.getActiveSessionId()).toBe("session-2");
+	});
+
+	it("recovers and retries when the active interactive session disappeared", async () => {
+		const manager = makeManager();
+		const messages = [
+			{
+				role: "user" as const,
+				content: [{ type: "text" as const, text: "hi" }],
+			},
+		];
+		manager.readMessages.mockResolvedValue(messages);
+		manager.send
+			.mockRejectedValueOnce(new Error("session not found: session-1"))
+			.mockResolvedValueOnce(makeTurnResult());
+		const runtime = makeRuntime(manager);
+
+		await runtime.ensureReady();
+		const result = await runtime.sendCurrentTurn({
+			prompt: "second hi",
+			mode: "act",
+		});
+
+		expect(result?.finishReason).toBe("completed");
+		expect(manager.readMessages).toHaveBeenCalledWith("session-1");
+		expect(manager.start).toHaveBeenCalledTimes(2);
+		expect(manager.start).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining({
+				initialMessages: messages,
+			}),
+		);
+		expect(manager.send).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining({ sessionId: "session-1" }),
+		);
+		expect(manager.send).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining({ sessionId: "session-2" }),
+		);
 		expect(runtime.getActiveSessionId()).toBe("session-2");
 	});
 });

--- a/apps/cli/src/runtime/interactive/session-runtime.ts
+++ b/apps/cli/src/runtime/interactive/session-runtime.ts
@@ -602,6 +602,7 @@ export function createInteractiveSessionRuntime(input: {
 			let exitSummary: InteractiveExitSummary | undefined;
 			try {
 				await startupPromise?.catch(() => {});
+				await missingSessionRecoveryPromise?.catch(() => {});
 			} finally {
 				unsubscribeAgent();
 				unsubscribePendingPrompts();

--- a/apps/cli/src/runtime/interactive/session-runtime.ts
+++ b/apps/cli/src/runtime/interactive/session-runtime.ts
@@ -48,6 +48,22 @@ type AskQuestionRef = {
 	current: ((question: string, options: string[]) => Promise<string>) | null;
 };
 
+function isMissingSessionError(error: unknown): boolean {
+	const message =
+		error instanceof Error
+			? error.message
+			: typeof error === "string"
+				? error
+				: "";
+	const normalized = message.trim().toLowerCase();
+	return (
+		normalized.includes("session_not_found") ||
+		normalized.includes("session not found") ||
+		normalized.includes("unknown session:") ||
+		/^session .+ was not found\.$/.test(normalized)
+	);
+}
+
 export function createInteractiveSessionRuntime(input: {
 	config: Config;
 	providerSettingsManager: ProviderSettingsManager;
@@ -74,6 +90,7 @@ export function createInteractiveSessionRuntime(input: {
 	let shutdownRequested = false;
 	let activeSessionId = "";
 	let abortRequested = false;
+	let missingSessionRecoveryPromise: Promise<void> | undefined;
 	// A reset can happen while an earlier manager.start() is still in flight.
 	// Bump this before resets and restarts so stale starts cannot become active.
 	let sessionStartGeneration = 0;
@@ -248,6 +265,37 @@ export function createInteractiveSessionRuntime(input: {
 		return (await sessionManager.readMessages(activeSessionId)) ?? [];
 	};
 
+	const recoverMissingActiveSession = async (error: unknown): Promise<void> => {
+		if (missingSessionRecoveryPromise) {
+			return await missingSessionRecoveryPromise;
+		}
+		missingSessionRecoveryPromise = (async () => {
+			const manager = sessionManager;
+			const missingSessionId = activeSessionId;
+			if (!manager || !missingSessionId || shutdownRequested) {
+				return;
+			}
+			const messages = await manager
+				.readMessages(missingSessionId)
+				.catch(() => []);
+			input.config.logger?.log("Recovering missing interactive session", {
+				sessionId: missingSessionId,
+				messageCount: messages.length,
+				error,
+				severity: "warn",
+			});
+			sessionStartGeneration += 1;
+			pendingResumeSessionId = undefined;
+			startupPromise = undefined;
+			startupError = undefined;
+			clearActiveSession();
+			await startFreshSession(messages);
+		})().finally(() => {
+			missingSessionRecoveryPromise = undefined;
+		});
+		return await missingSessionRecoveryPromise;
+	};
+
 	const stopCurrentSession = async (): Promise<void> => {
 		const sessionId = activeSessionId;
 		if (sessionManager && sessionId) {
@@ -334,10 +382,29 @@ export function createInteractiveSessionRuntime(input: {
 				? startupError
 				: new Error("interactive session manager is unavailable");
 		}
-		return await sessionManager.send({
-			sessionId: activeSessionId,
-			...turnInput,
-		});
+		const manager = sessionManager;
+		try {
+			return await manager.send({
+				sessionId: activeSessionId,
+				...turnInput,
+			});
+		} catch (error) {
+			if (
+				abortRequested ||
+				shutdownRequested ||
+				!isMissingSessionError(error)
+			) {
+				throw error;
+			}
+			await recoverMissingActiveSession(error);
+			if (!activeSessionId || abortRequested || shutdownRequested) {
+				throw error;
+			}
+			return await manager.send({
+				sessionId: activeSessionId,
+				...turnInput,
+			});
+		}
 	};
 
 	const updatePendingPrompt = async (input: {
@@ -556,14 +623,13 @@ export function createInteractiveSessionRuntime(input: {
 			}
 			try {
 				exitSummary = await getExitSummary();
+				// Mark hooks shut down before session disposal so late abort/stop
+				// emissions cannot dispatch over a closing hub transport.
+				await runtimeHooks?.shutdown();
 				await stopCurrentSession();
 			} finally {
-				try {
-					if (sessionManager) {
-						await sessionManager.dispose("cli_interactive_shutdown");
-					}
-				} finally {
-					await runtimeHooks?.shutdown();
+				if (sessionManager) {
+					await sessionManager.dispose("cli_interactive_shutdown");
 				}
 			}
 			return exitSummary;

--- a/apps/cli/src/runtime/interactive/session-runtime.ts
+++ b/apps/cli/src/runtime/interactive/session-runtime.ts
@@ -1,6 +1,7 @@
 import {
 	type AgentEvent,
 	type CheckpointEntry,
+	isSessionNotFoundError,
 	type PendingPromptMutationResult,
 	type ProviderSettingsManager,
 	readSessionCheckpointHistory,
@@ -47,22 +48,6 @@ type CurrentTurnResult = Awaited<ReturnType<CliCore["send"]>>;
 type AskQuestionRef = {
 	current: ((question: string, options: string[]) => Promise<string>) | null;
 };
-
-function isMissingSessionError(error: unknown): boolean {
-	const message =
-		error instanceof Error
-			? error.message
-			: typeof error === "string"
-				? error
-				: "";
-	const normalized = message.trim().toLowerCase();
-	return (
-		normalized.includes("session_not_found") ||
-		normalized.includes("session not found") ||
-		normalized.includes("unknown session:") ||
-		/^session .+ was not found\.$/.test(normalized)
-	);
-}
 
 export function createInteractiveSessionRuntime(input: {
 	config: Config;
@@ -392,7 +377,7 @@ export function createInteractiveSessionRuntime(input: {
 			if (
 				abortRequested ||
 				shutdownRequested ||
-				!isMissingSessionError(error)
+				!isSessionNotFoundError(error)
 			) {
 				throw error;
 			}

--- a/apps/cli/src/runtime/run-agent.ts
+++ b/apps/cli/src/runtime/run-agent.ts
@@ -228,11 +228,11 @@ export async function runAgent(
 			process.off("SIGINT", handleSigint);
 			process.off("SIGTERM", handleSigterm);
 			unsubscribe();
+			await runtimeHooks.shutdown().catch(() => {});
 			if (activeSessionId) {
 				await sessionManager.stop(activeSessionId).catch(() => {});
 			}
 			await sessionManager.dispose("cli_run_shutdown").catch(() => {});
-			await runtimeHooks.shutdown().catch(() => {});
 			setActiveRuntimeAbort(undefined);
 		})();
 		return cleanupDone;

--- a/apps/cli/src/utils/hooks.test.ts
+++ b/apps/cli/src/utils/hooks.test.ts
@@ -215,4 +215,21 @@ describe("createRuntimeHooks", () => {
 		expect(outputMocks.write).toHaveBeenCalledWith("\n[hook:prompt_submit]\n");
 		expect(eventMocks.closeInlineStreamIfNeeded).toHaveBeenCalledTimes(2);
 	});
+
+	it("does not dispatch hooks after shutdown", async () => {
+		const dispatchHookEvent = vi.fn().mockResolvedValue(undefined);
+		const runtimeHooks = createRuntimeHooks({
+			yolo: false,
+			cwd: "/workspace",
+			workspaceRoot: "/workspace",
+			verbose: true,
+			dispatchHookEvent,
+		});
+
+		await runtimeHooks.shutdown();
+		await emitRunStartAndPrompt(runtimeHooks.hooks!);
+
+		expect(dispatchHookEvent).not.toHaveBeenCalled();
+		expect(outputMocks.write).not.toHaveBeenCalled();
+	});
 });

--- a/apps/cli/src/utils/hooks.ts
+++ b/apps/cli/src/utils/hooks.ts
@@ -138,13 +138,23 @@ async function dispatchHookPayload(
 	payload: HookEventPayload,
 	options: {
 		dispatchHookEvent: (payload: HookEventPayload) => Promise<void>;
+		isShuttingDown: () => boolean;
 		verbose: boolean;
 	},
 ): Promise<void> {
+	if (options.isShuttingDown()) {
+		return;
+	}
 	try {
 		await options.dispatchHookEvent(payload);
+		if (options.isShuttingDown()) {
+			return;
+		}
 		writeHookInvocation(payload, { verbose: options.verbose });
 	} catch (error) {
+		if (options.isShuttingDown()) {
+			return;
+		}
 		if (isDev) {
 			writeErr(
 				`hook dispatch failed: ${error instanceof Error ? error.message : String(error)}`,
@@ -172,6 +182,8 @@ export function createRuntimeHooks(options: {
 	const verbose = options.verbose === true;
 	const cwd = options.cwd?.trim() || process.cwd();
 	const workspaceRoot = options.workspaceRoot?.trim() || cwd;
+	let shuttingDown = false;
+	const isShuttingDown = () => shuttingDown;
 	return {
 		hooks: {
 			beforeRun: async (ctx) => {
@@ -197,6 +209,7 @@ export function createRuntimeHooks(options: {
 							},
 					{
 						dispatchHookEvent: options.dispatchHookEvent,
+						isShuttingDown,
 						verbose,
 					},
 				);
@@ -223,6 +236,7 @@ export function createRuntimeHooks(options: {
 					},
 					{
 						dispatchHookEvent: options.dispatchHookEvent,
+						isShuttingDown,
 						verbose,
 					},
 				);
@@ -261,6 +275,7 @@ export function createRuntimeHooks(options: {
 					},
 					{
 						dispatchHookEvent: options.dispatchHookEvent,
+						isShuttingDown,
 						verbose,
 					},
 				);
@@ -279,6 +294,7 @@ export function createRuntimeHooks(options: {
 						},
 						{
 							dispatchHookEvent: options.dispatchHookEvent,
+							isShuttingDown,
 							verbose,
 						},
 					);
@@ -306,6 +322,7 @@ export function createRuntimeHooks(options: {
 							},
 					{
 						dispatchHookEvent: options.dispatchHookEvent,
+						isShuttingDown,
 						verbose,
 					},
 				);
@@ -328,11 +345,14 @@ export function createRuntimeHooks(options: {
 					},
 					{
 						dispatchHookEvent: options.dispatchHookEvent,
+						isShuttingDown,
 						verbose,
 					},
 				);
 			},
 		},
-		shutdown: async () => {},
+		shutdown: async () => {
+			shuttingDown = true;
+		},
 	};
 }

--- a/sdk/packages/core/src/hub/client/index.ts
+++ b/sdk/packages/core/src/hub/client/index.ts
@@ -7,6 +7,10 @@ import {
 	type HubTransportFrame,
 	resolveHubCommandTimeoutMs,
 } from "@cline/shared";
+import {
+	SESSION_NOT_FOUND_ERROR_CODE,
+	SessionNotFoundError,
+} from "../../runtime/host/runtime-host";
 import { spawnDetachedHubServerWithRetry } from "../daemon";
 import {
 	clearHubDiscovery,
@@ -537,6 +541,14 @@ export class NodeHubClient {
 		}
 		const resolved = await reply;
 		if (!resolved.ok) {
+			if (resolved.error?.code === SESSION_NOT_FOUND_ERROR_CODE) {
+				const targetSessionId =
+					sessionId ??
+					(typeof payload?.sessionId === "string"
+						? payload.sessionId
+						: undefined);
+				throw new SessionNotFoundError(targetSessionId, resolved.error.message);
+			}
 			throw new HubCommandError(
 				command,
 				resolved.error?.code,

--- a/sdk/packages/core/src/hub/client/session-client.ts
+++ b/sdk/packages/core/src/hub/client/session-client.ts
@@ -8,6 +8,7 @@ import type {
 	TeamProgressProjectionEvent,
 } from "@cline/shared";
 import type { CheckpointEntry } from "../../hooks/checkpoint-hooks";
+import { isSessionNotFoundError } from "../../runtime/host/runtime-host";
 import { NodeHubClient } from "../client";
 
 type ScheduleClientRecord = Record<string, unknown> & {
@@ -414,11 +415,15 @@ export class HubSessionClient {
 
 	async getSession(sessionId: string): Promise<HubSessionRow | undefined> {
 		await this.ensureMetadataApplied();
-		const reply = await this.client.command(
-			"session.get",
-			undefined,
-			sessionId,
-		);
+		let reply: Awaited<ReturnType<NodeHubClient["command"]>>;
+		try {
+			reply = await this.client.command("session.get", undefined, sessionId);
+		} catch (error) {
+			if (isSessionNotFoundError(error)) {
+				return undefined;
+			}
+			throw error;
+		}
 		return extractSessionRow(reply.payload);
 	}
 

--- a/sdk/packages/core/src/hub/runtime-host/hub-runtime-host.ts
+++ b/sdk/packages/core/src/hub/runtime-host/hub-runtime-host.ts
@@ -39,6 +39,7 @@ import type {
 	StartSessionInput,
 	StartSessionResult,
 } from "../../runtime/host/runtime-host";
+import { isSessionNotFoundError } from "../../runtime/host/runtime-host";
 import { RuntimeHostEventBus } from "../../runtime/host/runtime-host-support";
 import {
 	type SessionManifest,
@@ -1183,11 +1184,15 @@ export class HubRuntimeHost implements RuntimeHost {
 	}
 
 	async getSession(sessionId: string): Promise<SessionRecord | undefined> {
-		const reply = await this.client.command(
-			"session.get",
-			undefined,
-			sessionId,
-		);
+		let reply: Awaited<ReturnType<NodeHubClient["command"]>>;
+		try {
+			reply = await this.client.command("session.get", undefined, sessionId);
+		} catch (error) {
+			if (isSessionNotFoundError(error)) {
+				return undefined;
+			}
+			throw error;
+		}
 		return sessionRecordFromPayload(reply.payload);
 	}
 

--- a/sdk/packages/core/src/hub/server/boundary.test.ts
+++ b/sdk/packages/core/src/hub/server/boundary.test.ts
@@ -1,8 +1,9 @@
 import type { AgentToolContext, HubEventEnvelope } from "@cline/shared";
 import { describe, expect, it, vi } from "vitest";
-import type {
-	StartSessionInput,
-	StartSessionResult,
+import {
+	SessionNotFoundError,
+	type StartSessionInput,
+	type StartSessionResult,
 } from "../../runtime/host/runtime-host";
 import { createLocalHubScheduleRuntimeHandlers } from "../daemon/runtime-handlers";
 import { HubServerTransport } from "../server";
@@ -849,6 +850,58 @@ describe("HubServerTransport boundaries", () => {
 				}),
 			]),
 		);
+	});
+
+	it("returns session_not_found when a run starts against a stale active session", async () => {
+		const runTurn = vi
+			.fn()
+			.mockRejectedValue(new SessionNotFoundError("stale-session"));
+		const transport = createTransport({
+			sessionHost: {
+				runTurn,
+				getSession: vi.fn().mockResolvedValue({
+					sessionId: "stale-session",
+					source: "cli",
+					pid: 123,
+					startedAt: new Date(0).toISOString(),
+					status: "running",
+					interactive: true,
+					provider: "cline",
+					model: "test-model",
+					cwd: "/tmp/project",
+					workspaceRoot: "/tmp/project",
+					enableTools: true,
+					enableSpawn: true,
+					enableTeams: false,
+					updatedAt: new Date(0).toISOString(),
+				}),
+			},
+		});
+		const events: HubEventEnvelope[] = [];
+		transport.subscribe("client-1", (event) => events.push(event));
+
+		const reply = await transport.handleCommand({
+			version: "v1",
+			requestId: "req-stale-run",
+			command: "run.start",
+			clientId: "client-1",
+			sessionId: "stale-session",
+			payload: { prompt: "continue" },
+		});
+
+		expect(runTurn).toHaveBeenCalledWith(
+			expect.objectContaining({ sessionId: "stale-session" }),
+		);
+		expect(reply).toMatchObject({
+			version: "v1",
+			requestId: "req-stale-run",
+			ok: false,
+			error: {
+				code: "session_not_found",
+				message: "session not found: stale-session",
+			},
+		});
+		expect(events.some((event) => event.event === "run.failed")).toBe(false);
 	});
 
 	it("forwards run file attachment paths to the session host", async () => {

--- a/sdk/packages/core/src/hub/server/handlers/run-handlers.ts
+++ b/sdk/packages/core/src/hub/server/handlers/run-handlers.ts
@@ -5,7 +5,11 @@ import type {
 	HubReplyEnvelope,
 } from "@cline/shared";
 import { parseHookEventPayload } from "../../../hooks";
-import type { SendSessionInput } from "../../../runtime/host/runtime-host";
+import {
+	isSessionNotFoundError,
+	SESSION_NOT_FOUND_ERROR_CODE,
+	type SendSessionInput,
+} from "../../../runtime/host/runtime-host";
 import { logHubMessage } from "../hub-server-logging";
 import { cancelPendingApprovals } from "./approval-handlers";
 import { cancelPendingCapabilityRequests } from "./capability-handlers";
@@ -33,6 +37,18 @@ function errorMessageForResult(result: AgentResult): string | undefined {
 	}
 	const text = result.text.trim();
 	return text || undefined;
+}
+
+function sessionNotFoundReply(
+	envelope: HubCommandEnvelope,
+	sessionId: string,
+	error?: unknown,
+): HubReplyEnvelope {
+	const message =
+		error instanceof Error && error.message.trim()
+			? error.message
+			: `Unknown session: ${sessionId}`;
+	return errorReply(envelope, SESSION_NOT_FOUND_ERROR_CODE, message);
 }
 
 function parseTurnMode(mode?: unknown): AgentMode | undefined {
@@ -221,6 +237,9 @@ export async function handleSessionInput(
 			"run.start.reply"
 		) {
 			ctx.suppressNextTerminalEventBySession.delete(sessionId);
+		}
+		if (isSessionNotFoundError(error)) {
+			return sessionNotFoundReply(envelope, sessionId, error);
 		}
 		ctx.publish(
 			ctx.buildEvent(

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -385,7 +385,12 @@ export type {
 	StartSessionInput,
 	StartSessionResult,
 } from "./runtime/host/runtime-host";
-export { splitCoreSessionConfig } from "./runtime/host/runtime-host";
+export {
+	isSessionNotFoundError,
+	SESSION_NOT_FOUND_ERROR_CODE,
+	SessionNotFoundError,
+	splitCoreSessionConfig,
+} from "./runtime/host/runtime-host";
 export {
 	createTeamName,
 	DefaultRuntimeBuilder,

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -110,6 +110,7 @@ import type {
 	StartSessionInput,
 	StartSessionResult,
 } from "./runtime-host";
+import { SessionNotFoundError } from "./runtime-host";
 import {
 	cloneAccumulatedUsage,
 	RuntimeHostEventBus,
@@ -1573,7 +1574,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 	private getSessionOrThrow(sessionId: string): ActiveSession {
 		const session = this.sessions.get(sessionId);
 		if (!session) {
-			const error = new Error(`session not found: ${sessionId}`);
+			const error = new SessionNotFoundError(sessionId);
 			captureSdkError(this.defaultTelemetry, {
 				component: "core",
 				operation: "session.active_lookup",

--- a/sdk/packages/core/src/runtime/host/runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/runtime-host.ts
@@ -17,6 +17,35 @@ import type {
 import type { SessionRecord } from "../../types/sessions";
 import type { RuntimeCapabilities } from "../capabilities";
 
+export const SESSION_NOT_FOUND_ERROR_CODE = "session_not_found";
+
+export class SessionNotFoundError extends Error {
+	readonly code = SESSION_NOT_FOUND_ERROR_CODE;
+
+	constructor(
+		readonly sessionId?: string,
+		message?: string,
+	) {
+		super(
+			message ??
+				(sessionId ? `session not found: ${sessionId}` : "session not found"),
+		);
+		this.name = "SessionNotFoundError";
+	}
+}
+
+export function isSessionNotFoundError(
+	error: unknown,
+): error is SessionNotFoundError {
+	return (
+		error instanceof SessionNotFoundError ||
+		(typeof error === "object" &&
+			error !== null &&
+			"code" in error &&
+			(error as { code?: unknown }).code === SESSION_NOT_FOUND_ERROR_CODE)
+	);
+}
+
 type LocalOnlyCoreSessionConfigKeys =
 	| "hooks"
 	| "logger"


### PR DESCRIPTION
…ok races

This fixes the CLI/TUI regression introduced between `3.0.14` and `3.0.15` where the interactive CLI could enter a broken state after stopping and restarting Cline Hub, then attempting to cancel a request with Escape.

The affected release window was:

- `49e8c1b32` / `v3.0.14`: known-good baseline
- `c33c3176e` / `v3.0.15`: release containing the regression
- `fad8271f4 feat: Cline Hub web app (#10969)`: relevant behavior change in the window

The Hub web app change introduced new Hub-backed runtime/session lifecycle behavior. After Ctrl+C or Hub shutdown, the CLI could still retain an `activeSessionId` that no longer existed in the Hub/runtime process. On the next interactive send, the CLI attempted to reuse that stale session and received `session not found`. Because cancellation also targeted the stale session, Escape stopped working and OpenTUI ended up receiving failures during input handling, which made the TUI look corrupted.

The same lifecycle issue also explains the Ctrl+C errors:

```text
error: hook dispatch failed: Hub connection closed (code=1006, reason=Connection ended)
error: WebSocket connection to 'ws://127.0.0.1:50168/hub' failed: Failed to connect
```

Those were caused by late hook dispatches racing against Hub shutdown. The CLI was still trying to send hook events over a Hub WebSocket that had already closed.

**What changed**

- Added missing-session recovery in the interactive runtime.
  - Detects `session not found` / stale session errors.
  - Reads any recoverable messages from the missing session.
  - Clears the stale active session state.
  - Starts a new interactive runtime session.
  - Retries the current turn once against the fresh session.

- Made hook dispatch shutdown-aware.
  - Runtime hooks now mark themselves as shutting down before session disposal.
  - Hook dispatches are skipped once shutdown begins.
  - Dispatch failures during shutdown are suppressed, since the Hub transport closing is expected at that point.

- Reordered CLI cleanup.
  - Hooks are shut down before stopping/disposing runtime sessions.
  - This prevents abort/stop lifecycle events from trying to dispatch over a closing Hub connection.

**Regression coverage**

Added tests for:

- Recovering from a disappeared active interactive session and retrying against a new session.
- Ensuring hook events are not dispatched after shutdown begins.

**Verification**

Passed:

```text
bunx vitest run apps/cli/src/utils/hooks.test.ts apps/cli/src/runtime/interactive/session-runtime.test.ts
bun -F @cline/cli typecheck
bun -F @cline/cli test:unit
bun -F @cline/cli test:e2e:cli:tui
git diff --check
```

<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
