### PR TITLE
Centralize OAuth management to the SDK

### DIFF
--- a/apps/cli/src/acp/auth.ts
+++ b/apps/cli/src/acp/auth.ts
@@ -1,11 +1,6 @@
-import type { ProviderSettings, ProviderSettingsManager } from "@cline/core";
-import { getClineEnvironmentConfig } from "@cline/shared";
-import type { OAuthCredentials } from "../commands/auth";
-import {
-	getPersistedProviderApiKey,
-	saveOAuthProviderSettings,
-	toProviderApiKey,
-} from "../commands/auth";
+import type { ProviderSettingsManager } from "@cline/core";
+import { loginAndSaveProviderOAuthCredentials } from "@cline/core";
+import { getPersistedProviderApiKey } from "../commands/auth";
 import { writeDiagnostic } from "../utils/output";
 
 /**
@@ -30,37 +25,13 @@ export function isAcpAuthMethodId(id: string): id is AcpAuthMethodId {
  * If the OAuth flow requires interactive prompts (rare), defaults are used
  * when available; otherwise an error is thrown.
  */
-async function performOAuthLogin(
-	providerId: AcpAuthMethodId,
-	existingSettings: ProviderSettings | undefined,
-): Promise<OAuthCredentials> {
-	const [{ createOAuthClientCallbacks }, { default: open }, coreOAuth] =
-		await Promise.all([
-			import("@cline/core"),
-			import("open"),
-			import("@cline/core").then((m) => ({
-				loginClineOAuth: m.loginClineOAuth as (input: {
-					useWorkOSDeviceAuth?: boolean;
-					apiBaseUrl: string;
-					callbacks: {
-						onAuth: (info: { url: string; instructions?: string }) => void;
-						onPrompt: (prompt: {
-							message: string;
-							defaultValue?: string;
-						}) => Promise<string>;
-						onManualCodeInput?: () => Promise<string>;
-					};
-				}) => Promise<OAuthCredentials>,
-				loginOpenAICodex: m.loginOpenAICodex as (input: {
-					onAuth: (info: { url: string; instructions?: string }) => void;
-					onPrompt: (prompt: {
-						message: string;
-						defaultValue?: string;
-					}) => Promise<string>;
-					onManualCodeInput?: () => Promise<string>;
-				}) => Promise<OAuthCredentials>,
-			})),
-		]);
+async function performOAuthLogin(input: {
+	providerId: AcpAuthMethodId;
+	providerSettingsManager: ProviderSettingsManager;
+}): Promise<string> {
+	const [{ createOAuthClientCallbacks }, { default: open }] = await Promise.all(
+		[import("@cline/core"), import("open")],
+	);
 
 	const callbacks = createOAuthClientCallbacks({
 		onPrompt: ({ defaultValue }) => {
@@ -82,18 +53,18 @@ async function performOAuthLogin(
 		},
 	});
 
-	if (providerId === "cline") {
-		return coreOAuth.loginClineOAuth({
-			apiBaseUrl:
-				existingSettings?.baseUrl?.trim() ||
-				getClineEnvironmentConfig().apiBaseUrl,
-			callbacks,
-			useWorkOSDeviceAuth: true,
-		});
+	const settings = await loginAndSaveProviderOAuthCredentials(
+		input.providerSettingsManager,
+		input.providerId,
+		{ callbacks },
+	);
+	const apiKey = getPersistedProviderApiKey(input.providerId, settings);
+	if (!apiKey) {
+		throw new Error(
+			`OAuth login did not persist credentials for ${input.providerId}`,
+		);
 	}
-
-	// openai-codex
-	return coreOAuth.loginOpenAICodex(callbacks);
+	return apiKey;
 }
 
 export interface AcpAuthResult {
@@ -122,16 +93,10 @@ export async function authenticateAcpProvider(
 
 	// Perform a fresh OAuth login.
 	writeDiagnostic(`[acp/auth] Starting OAuth login for ${methodId}…`);
-	const credentials = await performOAuthLogin(methodId, existing);
-
-	saveOAuthProviderSettings(
+	const apiKey = await performOAuthLogin({
+		providerId: methodId,
 		providerSettingsManager,
-		methodId,
-		existing,
-		credentials,
-	);
-
-	const apiKey = toProviderApiKey(methodId, credentials);
+	});
 	writeDiagnostic(`[acp/auth] Successfully authenticated with ${methodId}`);
 	return { providerId: methodId, apiKey };
 }

--- a/apps/cli/src/commands/auth.test.ts
+++ b/apps/cli/src/commands/auth.test.ts
@@ -2,7 +2,11 @@ import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import type { ProviderSettingsManager } from "@cline/core";
 import { describe, expect, it, vi } from "vitest";
-import { getPersistedProviderApiKey, saveOAuthProviderSettings } from "./auth";
+import {
+	getPersistedProviderApiKey,
+	normalizeAuthProviderId,
+	saveOAuthProviderSettings,
+} from "./auth";
 
 describe("saveOAuthProviderSettings", () => {
 	it("preserves existing manual apiKey while updating OAuth tokens", () => {
@@ -64,6 +68,12 @@ describe("getPersistedProviderApiKey", () => {
 				},
 			}),
 		).toBe("workos:oauth-access");
+	});
+});
+
+describe("normalizeAuthProviderId", () => {
+	it("keeps CLI-only codex shorthand in CLI parsing", () => {
+		expect(normalizeAuthProviderId("codex")).toBe("openai-codex");
 	});
 });
 

--- a/apps/cli/src/commands/auth.ts
+++ b/apps/cli/src/commands/auth.ts
@@ -3,11 +3,13 @@ import {
 	BUILT_IN_PROVIDER,
 	createOAuthClientCallbacks,
 	ensureCustomProvidersLoaded,
+	getProviderAuthHandler,
 	listLocalProviders,
+	loginAndSaveProviderOAuthCredentials,
 	type ProviderSettings,
 	type ProviderSettingsManager,
+	saveProviderOAuthCredentials,
 } from "@cline/core";
-import { getClineEnvironmentConfig } from "@cline/shared";
 import { Command } from "commander";
 import open from "open";
 import React from "react";
@@ -35,40 +37,6 @@ const c = {
 	dim: "\x1b[2m",
 	cyan: "\x1b[36m",
 	green: "\x1b[32m",
-};
-
-type CoreOAuthApi = {
-	loginClineOAuth: (input: {
-		apiBaseUrl: string;
-		useWorkOSDeviceAuth?: boolean;
-		callbacks: {
-			onAuth: (info: { url: string; instructions?: string }) => void;
-			onPrompt: (prompt: {
-				message: string;
-				defaultValue?: string;
-			}) => Promise<string>;
-			onManualCodeInput?: () => Promise<string>;
-		};
-	}) => Promise<OAuthCredentials>;
-	loginOcaOAuth: (input: {
-		mode?: "internal" | "external";
-		callbacks: {
-			onAuth: (info: { url: string; instructions?: string }) => void;
-			onPrompt: (prompt: {
-				message: string;
-				defaultValue?: string;
-			}) => Promise<string>;
-			onManualCodeInput?: () => Promise<string>;
-		};
-	}) => Promise<OAuthCredentials>;
-	loginOpenAICodex: (input: {
-		onAuth: (info: { url: string; instructions?: string }) => void;
-		onPrompt: (prompt: {
-			message: string;
-			defaultValue?: string;
-		}) => Promise<string>;
-		onManualCodeInput?: () => Promise<string>;
-	}) => Promise<OAuthCredentials>;
 };
 
 type AuthIo = {
@@ -99,27 +67,6 @@ type ParsedAuthCommandArgs = {
 	baseurl?: string;
 	parseError?: string;
 };
-
-let cachedCoreOAuthApi: Promise<CoreOAuthApi> | undefined;
-
-async function getCoreOAuthApi(): Promise<CoreOAuthApi> {
-	if (!cachedCoreOAuthApi) {
-		cachedCoreOAuthApi = import("@cline/core").then((module) => {
-			const runtimeApi = module as Partial<CoreOAuthApi>;
-			if (
-				typeof runtimeApi.loginClineOAuth !== "function" ||
-				typeof runtimeApi.loginOcaOAuth !== "function" ||
-				typeof runtimeApi.loginOpenAICodex !== "function"
-			) {
-				throw new Error(
-					"Installed @cline/core does not expose OAuth login helpers required by the CLI",
-				);
-			}
-			return runtimeApi as CoreOAuthApi;
-		});
-	}
-	return cachedCoreOAuthApi;
-}
 
 /**
  * Create the `auth` subcommand for Commander.
@@ -272,64 +219,18 @@ function createOAuthCallbacks(io: AuthIo): {
 	});
 }
 
-async function loginWithOAuthProvider(
-	providerId: string,
-	existing: ProviderSettings | undefined,
-	io: AuthIo,
-): Promise<OAuthCredentials> {
-	const oauthApi = await getCoreOAuthApi();
-	const callbacks = createOAuthCallbacks(io);
-
-	if (providerId === "cline") {
-		return oauthApi.loginClineOAuth({
-			apiBaseUrl:
-				existing?.baseUrl?.trim() || getClineEnvironmentConfig().apiBaseUrl,
-			useWorkOSDeviceAuth: true,
-			callbacks,
-		});
-	}
-
-	if (providerId === "oca") {
-		const mode = existing?.oca?.mode;
-		return oauthApi.loginOcaOAuth({
-			mode,
-			callbacks,
-		});
-	}
-
-	if (providerId === "openai-codex") {
-		return oauthApi.loginOpenAICodex(callbacks);
-	}
-
-	throw new Error(
-		`Provider "${providerId}" does not support CLI OAuth flow (supported: cline, openai-codex, oca)`,
-	);
-}
-
 export function saveOAuthProviderSettings(
 	providerSettingsManager: ProviderSettingsManager,
 	providerId: string,
 	existing: ProviderSettings | undefined,
 	credentials: OAuthCredentials,
 ): ProviderSettings {
-	const auth = {
-		...(existing?.auth ?? {}),
-		accessToken: toProviderApiKey(providerId, credentials),
-		refreshToken: credentials.refresh,
-		accountId: credentials.accountId,
-	} as ProviderSettings["auth"] & { expiresAt?: number };
-	auth.expiresAt = credentials.expires;
-	const merged: ProviderSettings = {
-		...(existing ?? {
-			provider: providerId as ProviderSettings["provider"],
-		}),
-		provider: providerId as ProviderSettings["provider"],
-		auth,
-	};
-	providerSettingsManager.saveProviderSettings(merged, {
-		tokenSource: "oauth",
+	return saveProviderOAuthCredentials({
+		manager: providerSettingsManager,
+		providerId,
+		settings: existing,
+		credentials,
 	});
-	return merged;
 }
 
 export async function ensureOAuthProviderApiKey(input: {
@@ -348,19 +249,14 @@ export async function ensureOAuthProviderApiKey(input: {
 			selectedProviderSettings: input.existingSettings,
 		};
 	}
-	const credentials = await loginWithOAuthProvider(
-		input.providerId,
-		input.existingSettings,
-		input.io,
-	);
-	const selectedProviderSettings = saveOAuthProviderSettings(
+	const selectedProviderSettings = await loginAndSaveProviderOAuthCredentials(
 		input.providerSettingsManager,
 		input.providerId,
-		input.existingSettings,
-		credentials,
+		{ callbacks: createOAuthCallbacks(input.io) },
 	);
+	const handler = getProviderAuthHandler(input.providerId);
 	return {
-		apiKey: toProviderApiKey(input.providerId, credentials),
+		apiKey: handler?.getApiKey(selectedProviderSettings),
 		selectedProviderSettings,
 	};
 }
@@ -515,13 +411,10 @@ export async function runAuthProviderCommand(
 		return 1;
 	}
 	try {
-		const existing = providerSettingsManager.getProviderSettings(providerId);
-		const credentials = await loginWithOAuthProvider(providerId, existing, io);
-		saveOAuthProviderSettings(
+		await loginAndSaveProviderOAuthCredentials(
 			providerSettingsManager,
 			providerId,
-			existing,
-			credentials,
+			{ callbacks: createOAuthCallbacks(io) },
 		);
 		io.writeln(
 			`${c.green}You are now logged in to ${c.cyan}${providerId}${c.reset}`,

--- a/apps/cli/src/tui/cline-account.test.ts
+++ b/apps/cli/src/tui/cline-account.test.ts
@@ -32,6 +32,28 @@ vi.mock("@cline/core", () => {
 				coreMocks.saveProviderSettings(settings, options);
 			}
 		},
+		formatProviderOAuthApiKey: (
+			providerId: string,
+			credentials: { access: string },
+		) =>
+			providerId === "cline" && !credentials.access.startsWith("workos:")
+				? `workos:${credentials.access}`
+				: credentials.access,
+		getPersistedProviderApiKey: (
+			_providerId: string,
+			settings?: {
+				auth?: { accessToken?: string; apiKey?: string };
+				apiKey?: string;
+			},
+		) =>
+			settings?.auth?.accessToken?.trim() ||
+			settings?.apiKey?.trim() ||
+			settings?.auth?.apiKey?.trim() ||
+			undefined,
+		isOAuthProvider: (providerId: string) =>
+			providerId === "cline" ||
+			providerId === "oca" ||
+			providerId === "openai-codex",
 		getValidClineCredentials: coreMocks.getValidClineCredentials,
 	};
 });

--- a/apps/cli/src/tui/cline-account.test.ts
+++ b/apps/cli/src/tui/cline-account.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Config } from "../utils/types";
 
 const coreMocks = vi.hoisted(() => {
@@ -9,13 +9,14 @@ const coreMocks = vi.hoisted(() => {
 	return {
 		getProviderSettings: vi.fn(),
 		saveProviderSettings: vi.fn(),
-		getValidClineCredentials: vi.fn(),
 		serviceOptions,
 	};
 });
 
-vi.mock("@cline/core", () => {
+vi.mock("@cline/core", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@cline/core")>();
 	return {
+		...actual,
 		ClineAccountService: class {
 			constructor(options: {
 				apiBaseUrl: string;
@@ -32,29 +33,6 @@ vi.mock("@cline/core", () => {
 				coreMocks.saveProviderSettings(settings, options);
 			}
 		},
-		formatProviderOAuthApiKey: (
-			providerId: string,
-			credentials: { access: string },
-		) =>
-			providerId === "cline" && !credentials.access.startsWith("workos:")
-				? `workos:${credentials.access}`
-				: credentials.access,
-		getPersistedProviderApiKey: (
-			_providerId: string,
-			settings?: {
-				auth?: { accessToken?: string; apiKey?: string };
-				apiKey?: string;
-			},
-		) =>
-			settings?.auth?.accessToken?.trim() ||
-			settings?.apiKey?.trim() ||
-			settings?.auth?.apiKey?.trim() ||
-			undefined,
-		isOAuthProvider: (providerId: string) =>
-			providerId === "cline" ||
-			providerId === "oca" ||
-			providerId === "openai-codex",
-		getValidClineCredentials: coreMocks.getValidClineCredentials,
 	};
 });
 
@@ -81,15 +59,51 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
 	} as unknown as Config;
 }
 
+function mockFetchJson(body: unknown, status = 200): void {
+	vi.stubGlobal(
+		"fetch",
+		vi.fn(
+			async () =>
+				new Response(JSON.stringify(body), {
+					status,
+					headers: { "Content-Type": "application/json" },
+				}),
+		) as unknown as typeof fetch,
+	);
+}
+
 describe("createClineAccountService", () => {
 	beforeEach(() => {
+		vi.restoreAllMocks();
+		vi.unstubAllGlobals();
 		coreMocks.getProviderSettings.mockReset();
 		coreMocks.saveProviderSettings.mockReset();
-		coreMocks.getValidClineCredentials.mockReset();
 		coreMocks.serviceOptions.length = 0;
 	});
 
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.unstubAllGlobals();
+	});
+
 	it("refreshes persisted Cline OAuth credentials before creating the account service", async () => {
+		vi.spyOn(Date, "now").mockReturnValue(100_000);
+		mockFetchJson({
+			success: true,
+			data: {
+				accessToken: "new-access",
+				refreshToken: "new-refresh",
+				tokenType: "Bearer",
+				expiresAt: "2096-10-02T07:06:40.000Z",
+				userInfo: {
+					subject: "sub-new",
+					email: "new@example.com",
+					name: "New User",
+					clineUserId: "acct-new",
+					accounts: [],
+				},
+			},
+		});
 		coreMocks.getProviderSettings.mockReturnValue({
 			provider: "cline",
 			auth: {
@@ -99,26 +113,12 @@ describe("createClineAccountService", () => {
 				expiresAt: 1,
 			},
 		});
-		coreMocks.getValidClineCredentials.mockResolvedValue({
-			access: "new-access",
-			refresh: "new-refresh",
-			expires: 4_000_000_000_000,
-			accountId: "acct-new",
-		});
 
 		const { createClineAccountService } = await import("./cline-account");
 		const service = await createClineAccountService({ config: makeConfig() });
 
 		expect(service).toBeDefined();
-		expect(coreMocks.getValidClineCredentials).toHaveBeenCalledWith(
-			{
-				access: "old-access",
-				refresh: "refresh-token",
-				expires: 1,
-				accountId: "acct-old",
-			},
-			{ apiBaseUrl: "https://api.cline.bot" },
-		);
+		expect(globalThis.fetch).toHaveBeenCalled();
 		expect(coreMocks.saveProviderSettings).toHaveBeenCalledWith(
 			expect.objectContaining({
 				provider: "cline",
@@ -137,6 +137,14 @@ describe("createClineAccountService", () => {
 	});
 
 	it("asks the user to re-authenticate when Cline OAuth credentials cannot refresh", async () => {
+		vi.spyOn(Date, "now").mockReturnValue(100_000);
+		mockFetchJson(
+			{
+				error: "invalid_grant",
+				error_description: "refresh expired",
+			},
+			401,
+		);
 		coreMocks.getProviderSettings.mockReturnValue({
 			provider: "cline",
 			auth: {
@@ -145,7 +153,6 @@ describe("createClineAccountService", () => {
 				expiresAt: 1,
 			},
 		});
-		coreMocks.getValidClineCredentials.mockResolvedValue(null);
 
 		const { createClineAccountService } = await import("./cline-account");
 

--- a/apps/cli/src/tui/cline-account.ts
+++ b/apps/cli/src/tui/cline-account.ts
@@ -4,16 +4,18 @@ import {
 	type ClineAccountOrganizationBalance,
 	ClineAccountService,
 	type ClineAccountUser,
+	formatProviderOAuthApiKey,
+	getPersistedProviderApiKey,
+	getProviderOAuthCredentialsFromSettings,
 	getValidClineCredentials,
 	type ProviderSettings,
 	ProviderSettingsManager,
+	saveLocalProviderOAuthCredentials,
 } from "@cline/core";
 import { getClineEnvironmentConfig } from "@cline/shared";
 import { formatCreditBalance, normalizeCreditBalance } from "../utils/output";
-import { toProviderApiKey } from "../utils/provider-auth";
 import type { Config } from "../utils/types";
 
-const WORKOS_TOKEN_PREFIX = "workos:";
 export const CLINE_CREDITS_DASHBOARD_URL =
 	"https://app.cline.bot/dashboard/account?tab=credits";
 
@@ -69,26 +71,13 @@ function resolveClineAccountAuthToken(input: {
 	config: ClineAccountConfig;
 	clineProviderSettings?: ProviderSettings;
 }): string | undefined {
-	const persistedAccessToken =
-		input.clineProviderSettings?.auth?.accessToken?.trim() || "";
 	const configApiKey =
 		input.config.providerId === "cline" ? input.config.apiKey.trim() : "";
-	const settingsApiKey =
-		input.clineProviderSettings?.apiKey?.trim() ||
-		input.clineProviderSettings?.auth?.apiKey?.trim() ||
-		"";
-
-	let authToken = persistedAccessToken || configApiKey || settingsApiKey;
-	if (authToken.toLowerCase().startsWith("workos:workos:")) {
-		authToken = authToken.slice("workos:".length);
-	}
-	return authToken || undefined;
-}
-
-function stripWorkosTokenPrefix(accessToken: string): string {
-	return accessToken.toLowerCase().startsWith(WORKOS_TOKEN_PREFIX)
-		? accessToken.slice(WORKOS_TOKEN_PREFIX.length)
-		: accessToken;
+	return (
+		getPersistedProviderApiKey("cline", input.clineProviderSettings) ||
+		configApiKey ||
+		undefined
+	);
 }
 
 async function resolveValidClineAccountAuthToken(input: {
@@ -98,43 +87,26 @@ async function resolveValidClineAccountAuthToken(input: {
 	apiBaseUrl: string;
 }): Promise<string | undefined> {
 	const settings = input.clineProviderSettings;
-	const auth = settings?.auth;
-	const accessToken = auth?.accessToken?.trim();
-	const refreshToken = auth?.refreshToken?.trim();
-	if (settings && auth && accessToken && refreshToken) {
-		const credentials = await getValidClineCredentials(
-			{
-				access: stripWorkosTokenPrefix(accessToken),
-				refresh: refreshToken,
-				expires: auth.expiresAt ?? Date.now() - 1,
-				accountId: auth.accountId,
-			},
-			{ apiBaseUrl: input.apiBaseUrl },
-		);
-		if (!credentials) {
+	const credentials = settings
+		? getProviderOAuthCredentialsFromSettings("cline", settings)
+		: null;
+	if (settings && credentials) {
+		const nextCredentials = await getValidClineCredentials(credentials, {
+			apiBaseUrl: input.apiBaseUrl,
+		});
+		if (!nextCredentials) {
 			throw new Error(
 				"Cline account requires re-authentication. Run cline auth cline.",
 			);
 		}
-		const nextAccessToken = toProviderApiKey("cline", credentials);
-		if (
-			nextAccessToken !== accessToken ||
-			credentials.refresh !== refreshToken ||
-			credentials.accountId !== auth.accountId ||
-			credentials.expires !== auth.expiresAt
-		) {
-			input.manager.saveProviderSettings(
-				{
-					...settings,
-					auth: {
-						...(settings.auth ?? {}),
-						accessToken: nextAccessToken,
-						refreshToken: credentials.refresh,
-						accountId: credentials.accountId,
-						expiresAt: credentials.expires,
-					},
-				},
-				{ setLastUsed: false, tokenSource: "oauth" },
+		const nextAccessToken = formatProviderOAuthApiKey("cline", nextCredentials);
+		if (nextCredentials !== credentials) {
+			saveLocalProviderOAuthCredentials(
+				input.manager,
+				"cline",
+				settings,
+				nextCredentials,
+				{ setLastUsed: false },
 			);
 		}
 		return nextAccessToken;

--- a/apps/cli/src/tui/components/dialogs/provider-picker.tsx
+++ b/apps/cli/src/tui/components/dialogs/provider-picker.tsx
@@ -1,6 +1,7 @@
 import {
 	completeClineDeviceAuth,
 	getProviderConfigFields,
+	isOAuthProvider,
 	listLocalProviders,
 	loginLocalProvider,
 	type ProviderConfigFieldKey,
@@ -21,7 +22,6 @@ import {
 	checkCodexCliInstalled,
 	isOpenAICodexCliProvider,
 } from "../../../utils/codex-cli";
-import { isOAuthProvider } from "../../../utils/provider-auth";
 import { palette } from "../../palette";
 import {
 	getDefaultAwsRegion,
@@ -671,7 +671,7 @@ export function OAuthLoginContent(
 						if (!isActiveAuthAttempt(attempt)) return;
 						saveLocalProviderOAuthCredentials(
 							manager,
-							providerId as "cline" | "oca" | "openai-codex",
+							providerId,
 							existing,
 							credentials,
 						);
@@ -705,30 +705,24 @@ export function OAuthLoginContent(
 		const manager = new ProviderSettingsManager();
 		const existing = manager.getProviderSettings(providerId);
 
-		loginLocalProvider(
-			providerId as "cline" | "oca" | "openai-codex",
-			existing,
-			(url: string) => {
-				setAuthUrl(url);
-				setStatus("Waiting for authentication in browser...");
-				try {
-					void open(url, { wait: false }).catch(() => {
-						setStatus(
-							"Could not open browser automatically. Open the URL below.",
-						);
-					});
-				} catch {
+		loginLocalProvider(providerId, existing, (url: string) => {
+			setAuthUrl(url);
+			setStatus("Waiting for authentication in browser...");
+			try {
+				void open(url, { wait: false }).catch(() => {
 					setStatus(
 						"Could not open browser automatically. Open the URL below.",
 					);
-				}
-			},
-		)
+				});
+			} catch {
+				setStatus("Could not open browser automatically. Open the URL below.");
+			}
+		})
 			.then((credentials) => {
 				if (!isActiveAuthAttempt(attempt)) return;
 				saveLocalProviderOAuthCredentials(
 					manager,
-					providerId as "cline" | "oca" | "openai-codex",
+					providerId,
 					existing,
 					credentials,
 				);

--- a/apps/cli/src/tui/views/onboarding/auth.ts
+++ b/apps/cli/src/tui/views/onboarding/auth.ts
@@ -1,6 +1,7 @@
 import {
 	completeClineDeviceAuth,
 	type ITelemetryService,
+	isOAuthProvider,
 	loginLocalProvider,
 	type ProviderSettingsManager,
 	saveLocalProviderOAuthCredentials,
@@ -9,16 +10,12 @@ import {
 import { getClineEnvironmentConfig } from "@cline/shared";
 import open from "open";
 
-export type OnboardingOAuthProviderId = "cline" | "oca" | "openai-codex";
+export type OnboardingOAuthProviderId = string;
 
 export function isOnboardingOAuthProviderId(
 	providerId: string,
 ): providerId is OnboardingOAuthProviderId {
-	return (
-		providerId === "cline" ||
-		providerId === "oca" ||
-		providerId === "openai-codex"
-	);
+	return isOAuthProvider(providerId);
 }
 
 export function runOAuthAuthFlow(input: {

--- a/apps/cli/src/utils/provider-auth.ts
+++ b/apps/cli/src/utils/provider-auth.ts
@@ -1,14 +1,13 @@
-import { Llms, type ProviderSettings } from "@cline/core";
-import { isOAuthProviderId } from "@cline/shared";
+import {
+	formatProviderOAuthApiKey,
+	getPersistedProviderApiKey as getCorePersistedProviderApiKey,
+	isOAuthProvider,
+	Llms,
+	type ProviderOAuthCredentials,
+	type ProviderSettings,
+} from "@cline/core";
 
-export type OAuthCredentials = {
-	access: string;
-	refresh: string;
-	expires: number;
-	accountId?: string;
-	email?: string;
-	metadata?: Record<string, unknown>;
-};
+export type OAuthCredentials = ProviderOAuthCredentials;
 
 export function normalizeProviderId(providerId: string): string {
 	return Llms.normalizeProviderId(providerId.trim());
@@ -22,42 +21,20 @@ export function normalizeAuthProviderId(providerId: string): string {
 	return normalizeProviderId(normalized);
 }
 
-/**
- * Re-exports `isOAuthProviderId` from `@cline/shared` so the CLI has a
- * single source of truth for the OAuth provider list. Existing call sites
- * keep their `isOAuthProvider` import name.
- */
-export const isOAuthProvider = isOAuthProviderId;
+export { isOAuthProvider };
 
 export function toProviderApiKey(
 	providerId: string,
 	credentials: Pick<OAuthCredentials, "access">,
 ): string {
-	if (providerId === "cline") {
-		return credentials.access.startsWith("workos:")
-			? credentials.access
-			: `workos:${credentials.access}`;
-	}
-	return credentials.access;
+	return formatProviderOAuthApiKey(providerId, credentials);
 }
 
 export function getPersistedProviderApiKey(
 	providerId: string,
 	settings?: ProviderSettings,
 ): string | undefined {
-	const accessToken = settings?.auth?.accessToken?.trim();
-	if (accessToken) {
-		return toProviderApiKey(providerId, { access: accessToken });
-	}
-	const shorthandKey = settings?.apiKey?.trim();
-	if (shorthandKey) {
-		return shorthandKey;
-	}
-	const authKey = settings?.auth?.apiKey?.trim();
-	if (authKey) {
-		return authKey;
-	}
-	return undefined;
+	return getCorePersistedProviderApiKey(providerId, settings);
 }
 
 /**
@@ -76,7 +53,7 @@ export function isProviderConfigured(
 	settings: ProviderSettings | undefined,
 ): boolean {
 	if (!settings) return false;
-	if (isOAuthProviderId(providerId)) {
+	if (isOAuthProvider(providerId)) {
 		return Boolean(settings.auth?.accessToken?.trim());
 	}
 	if (getPersistedProviderApiKey(providerId, settings)) return true;

--- a/apps/cline-hub/src/server/desktop-commands.ts
+++ b/apps/cline-hub/src/server/desktop-commands.ts
@@ -6,14 +6,13 @@ import {
 	executeClineAccountAction,
 	getLocalProviderModels,
 	listLocalProviders,
-	loginLocalProvider,
+	loginAndSaveLocalProviderOAuthCredentials,
 	normalizeOAuthProvider,
 	type ProviderCapability,
 	type ProviderClient,
 	type ProviderProtocol,
 	readGlobalSettings,
 	resolveLocalClineAuthToken,
-	saveLocalProviderOAuthCredentials,
 	saveLocalProviderSettings,
 	setDisabledPlugin,
 	setDisabledTools,
@@ -116,17 +115,10 @@ export async function handleDesktopCommand(
 	}
 	if (command === "run_provider_oauth_login") {
 		const providerId = normalizeOAuthProvider(String(args?.provider ?? ""));
-		const existing = providerSettingsManager.getProviderSettings(providerId);
-		const credentials = await loginLocalProvider(
-			providerId,
-			existing,
-			openExternalUrl,
-		);
-		const saved = saveLocalProviderOAuthCredentials(
+		const saved = await loginAndSaveLocalProviderOAuthCredentials(
 			providerSettingsManager,
 			providerId,
-			existing,
-			credentials,
+			openExternalUrl,
 		);
 		return {
 			provider: providerId,

--- a/apps/cline-hub/src/server/providers.ts
+++ b/apps/cline-hub/src/server/providers.ts
@@ -4,9 +4,8 @@ import {
 	getLocalProviderModels,
 	Llms,
 	listLocalProviders,
-	loginLocalProvider,
+	loginAndSaveLocalProviderOAuthCredentials,
 	normalizeOAuthProvider,
-	saveLocalProviderOAuthCredentials,
 	saveLocalProviderSettings,
 } from "@cline/core";
 import type {
@@ -134,17 +133,10 @@ export async function runProviderOAuthLogin(
 	providerId: string,
 ): Promise<void> {
 	const normalized = normalizeOAuthProvider(providerId);
-	const existing = providerSettingsManager.getProviderSettings(normalized);
-	const credentials = await loginLocalProvider(
-		normalized,
-		existing,
-		openExternalUrl,
-	);
-	const saved = saveLocalProviderOAuthCredentials(
+	const saved = await loginAndSaveLocalProviderOAuthCredentials(
 		providerSettingsManager,
 		normalized,
-		existing,
-		credentials,
+		openExternalUrl,
 	);
 	ctx.send(peer, {
 		type: "provider_oauth_login_done",

--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -31,7 +31,7 @@ import {
 	listHookConfigFiles,
 	listLocalProviders,
 	listPluginTools,
-	loginLocalProvider,
+	loginAndSaveLocalProviderOAuthCredentials,
 	normalizeOAuthProvider,
 	ProviderSettingsManager,
 	readGlobalSettings,
@@ -40,7 +40,6 @@ import {
 	resolveSessionBackend,
 	resolveAgentConfigSearchPaths as resolveSharedAgentConfigSearchPaths,
 	SqliteSessionStore,
-	saveLocalProviderOAuthCredentials,
 	saveLocalProviderSettings,
 	sendHubCommand,
 	setDisabledPlugin,
@@ -1012,10 +1011,9 @@ export async function handleCommand(
 	if (command === "run_provider_oauth_login") {
 		const providerId = normalizeOAuthProvider(String(args?.provider ?? ""));
 		const manager = new ProviderSettingsManager();
-		const existing = manager.getProviderSettings(providerId);
-		const credentials = await loginLocalProvider(
+		const saved = await loginAndSaveLocalProviderOAuthCredentials(
+			manager,
 			providerId,
-			existing,
 			(url) => {
 				const platform = process.platform;
 				const spawned =
@@ -1032,12 +1030,6 @@ export async function handleCommand(
 								});
 				spawned.unref();
 			},
-		);
-		const saved = saveLocalProviderOAuthCredentials(
-			manager,
-			providerId,
-			existing,
-			credentials,
 		);
 		return {
 			provider: providerId,

--- a/sdk/packages/core/src/auth/cline.test.ts
+++ b/sdk/packages/core/src/auth/cline.test.ts
@@ -22,7 +22,6 @@ const socketBindingSupported = await (async () => {
 		return false;
 	}
 })();
-const _socketIt = socketBindingSupported ? it : it.skip;
 
 function createCredentials(
 	overrides: Partial<ClineOAuthCredentials> = {},

--- a/sdk/packages/core/src/auth/cline.ts
+++ b/sdk/packages/core/src/auth/cline.ts
@@ -10,11 +10,7 @@ import {
 	identifyAccount,
 } from "../services/telemetry/core-events";
 import { startLocalOAuthServer } from "./server";
-import type {
-	OAuthCredentials,
-	OAuthLoginCallbacks,
-	OAuthProviderInterface,
-} from "./types";
+import type { OAuthCredentials, OAuthLoginCallbacks } from "./types";
 import {
 	isCredentialLikelyExpired,
 	parseAuthorizationInput,
@@ -700,23 +696,4 @@ export async function getValidClineCredentials(
 		}
 		return null;
 	}
-}
-
-export function createClineOAuthProvider(
-	options: ClineOAuthProviderOptions,
-): OAuthProviderInterface {
-	return {
-		id: "cline",
-		name: "Cline Account",
-		usesCallbackServer: !(options.useWorkOSDeviceAuth ?? true),
-		async login(callbacks) {
-			return loginClineOAuth({ ...options, callbacks });
-		},
-		async refreshToken(credentials) {
-			return refreshClineToken(credentials as ClineOAuthCredentials, options);
-		},
-		getApiKey(credentials) {
-			return `workos:${credentials.access}`;
-		},
-	};
 }

--- a/sdk/packages/core/src/auth/codex.test.ts
+++ b/sdk/packages/core/src/auth/codex.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	getValidOpenAICodexCredentials,
-	normalizeOpenAICodexCredentials,
 	refreshOpenAICodexToken,
 } from "./codex";
 import type { OAuthCredentials } from "./types";
@@ -136,19 +135,6 @@ describe("auth/codex token lifecycle", () => {
 		});
 		expect(result).toBe(current);
 		nowSpy.mockRestore();
-	});
-
-	it("normalizes credentials by deriving accountId from access token", () => {
-		const accessToken = createJwt({
-			"https://api.openai.com/auth": { chatgpt_account_id: "acct-derived" },
-		});
-		const normalized = normalizeOpenAICodexCredentials({
-			access: accessToken,
-			refresh: "refresh",
-			expires: 1,
-		});
-		expect(normalized.accountId).toBe("acct-derived");
-		expect(normalized.metadata).toMatchObject({ provider: "openai-codex" });
 	});
 
 	it("refreshOpenAICodexToken throws when response is structurally invalid", async () => {

--- a/sdk/packages/core/src/auth/codex.ts
+++ b/sdk/packages/core/src/auth/codex.ts
@@ -15,12 +15,7 @@ import {
 	identifyAccount,
 } from "../services/telemetry/core-events";
 import { startLocalOAuthServer } from "./server";
-import type {
-	OAuthCredentials,
-	OAuthLoginCallbacks,
-	OAuthPrompt,
-	OAuthProviderInterface,
-} from "./types";
+import type { OAuthCredentials, OAuthPrompt } from "./types";
 import {
 	decodeJwtPayload,
 	getProofKey,
@@ -442,50 +437,3 @@ export async function getValidOpenAICodexCredentials(
 		return null;
 	}
 }
-
-export function isOpenAICodexTokenExpired(
-	credentials: OAuthCredentials,
-	refreshBufferMs: number = OPENAI_CODEX_OAUTH_CONFIG.refreshBufferMs,
-): boolean {
-	return isCredentialLikelyExpired(credentials, refreshBufferMs);
-}
-
-export function normalizeOpenAICodexCredentials(
-	credentials: OAuthCredentials,
-): OAuthCredentials {
-	const accountId = credentials.accountId ?? getAccountId(credentials.access);
-	if (!accountId) {
-		throw new Error("Failed to extract accountId from token");
-	}
-	return {
-		...credentials,
-		accountId,
-		metadata: {
-			...(credentials.metadata ?? {}),
-			provider: "openai-codex",
-		},
-	};
-}
-
-export const openaiCodexOAuthProvider: OAuthProviderInterface = {
-	id: "openai-codex",
-	name: "ChatGPT Plus/Pro (ChatGPT Subscription)",
-	usesCallbackServer: true,
-
-	async login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
-		return loginOpenAICodex({
-			onAuth: callbacks.onAuth,
-			onPrompt: callbacks.onPrompt,
-			onProgress: callbacks.onProgress,
-			onManualCodeInput: callbacks.onManualCodeInput,
-		});
-	},
-
-	async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
-		return refreshOpenAICodexToken(credentials.refresh, credentials);
-	},
-
-	getApiKey(credentials: OAuthCredentials): string {
-		return credentials.access;
-	},
-};

--- a/sdk/packages/core/src/auth/oca.ts
+++ b/sdk/packages/core/src/auth/oca.ts
@@ -12,8 +12,6 @@ import { startLocalOAuthServer } from "./server";
 import type {
 	OAuthCredentials,
 	OAuthLoginCallbacks,
-	OAuthProviderInterface,
-	OcaClientMetadata,
 	OcaMode,
 	OcaOAuthConfig,
 	OcaOAuthProviderOptions,
@@ -524,65 +522,4 @@ export async function getValidOcaCredentials(
 		}
 		return null;
 	}
-}
-
-export function createOcaOAuthProvider(
-	options: OcaOAuthProviderOptions = {},
-): OAuthProviderInterface {
-	return {
-		id: "oca",
-		name: "Oracle Code Assist",
-		usesCallbackServer: true,
-		async login(callbacks) {
-			return loginOcaOAuth({ ...options, callbacks });
-		},
-		async refreshToken(credentials) {
-			return refreshOcaToken(credentials, options);
-		},
-		getApiKey(credentials) {
-			return credentials.access;
-		},
-	};
-}
-
-export async function generateOcaOpcRequestId(
-	taskId: string,
-	token: string,
-): Promise<string> {
-	const encoder = new TextEncoder();
-	const hash8 = async (value: string): Promise<string> => {
-		const digest = await crypto.subtle.digest("SHA-256", encoder.encode(value));
-		return Array.from(new Uint8Array(digest).slice(0, 4), (byte) =>
-			byte.toString(16).padStart(2, "0"),
-		).join("");
-	};
-
-	const [tokenHex, taskHex] = await Promise.all([hash8(token), hash8(taskId)]);
-	const timestampHex = Math.floor(Date.now() / 1000)
-		.toString(16)
-		.padStart(8, "0");
-	const randomPart = new Uint32Array(1);
-	crypto.getRandomValues(randomPart);
-	const randomHex = (randomPart[0] ?? 0).toString(16).padStart(8, "0");
-	return tokenHex + taskHex + timestampHex + randomHex;
-}
-
-export async function createOcaRequestHeaders(input: {
-	accessToken: string;
-	taskId: string;
-	metadata?: OcaClientMetadata;
-}): Promise<Record<string, string>> {
-	const opcRequestId = await generateOcaOpcRequestId(
-		input.taskId,
-		input.accessToken,
-	);
-	return {
-		Authorization: `Bearer ${input.accessToken}`,
-		"Content-Type": "application/json",
-		client: input.metadata?.client ?? "Cline",
-		"client-version": input.metadata?.clientVersion ?? "unknown",
-		"client-ide": input.metadata?.clientIde ?? "unknown",
-		"client-ide-version": input.metadata?.clientIdeVersion ?? "unknown",
-		[OCI_HEADER_OPC_REQUEST_ID]: opcRequestId,
-	};
 }

--- a/sdk/packages/core/src/auth/provider-auth-registry.test.ts
+++ b/sdk/packages/core/src/auth/provider-auth-registry.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	formatProviderOAuthApiKey,
+	getPersistedProviderApiKey,
+	getProviderAuthHandler,
+	getProviderAuthStorageId,
+	isOAuthProvider,
+	loginAndSaveProviderOAuthCredentials,
+} from "./provider-auth-registry";
+
+const { loginClineOAuth } = vi.hoisted(() => ({
+	loginClineOAuth: vi.fn(),
+}));
+
+vi.mock("./cline", () => ({
+	getValidClineCredentials: vi.fn(),
+	loginClineOAuth,
+}));
+
+vi.mock("./oca", () => ({
+	getValidOcaCredentials: vi.fn(),
+	loginOcaOAuth: vi.fn(),
+}));
+
+vi.mock("./codex", () => ({
+	getValidOpenAICodexCredentials: vi.fn(),
+	loginOpenAICodex: vi.fn(),
+}));
+
+describe("provider auth registry", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("returns handlers for managed OAuth providers only", () => {
+		expect(getProviderAuthHandler("cline")?.providerId).toBe("cline");
+		expect(getProviderAuthHandler("oca")?.providerId).toBe("oca");
+		expect(getProviderAuthHandler("openai-codex")?.providerId).toBe(
+			"openai-codex",
+		);
+		expect(getProviderAuthHandler("openai-codex-cli")).toBeUndefined();
+		expect(isOAuthProvider("openai-codex-cli")).toBe(false);
+	});
+
+	it("returns storage provider IDs from handlers", () => {
+		expect(getProviderAuthStorageId("cline")).toBe("cline");
+		expect(getProviderAuthStorageId("oca")).toBe("oca");
+		expect(getProviderAuthStorageId("openai-codex")).toBe("openai-codex");
+		expect(getProviderAuthStorageId("openai-codex-cli")).toBeUndefined();
+	});
+
+	it("formats Cline WorkOS tokens without double-prefixing", () => {
+		expect(formatProviderOAuthApiKey("cline", { access: "abc" })).toBe(
+			"workos:abc",
+		);
+		expect(formatProviderOAuthApiKey("cline", { access: "workos:abc" })).toBe(
+			"workos:abc",
+		);
+		expect(
+			getPersistedProviderApiKey("cline", {
+				provider: "cline",
+				auth: { accessToken: "abc" },
+			}),
+		).toBe("workos:abc");
+	});
+
+	it("login/save stores credentials under handler storageProviderId", async () => {
+		loginClineOAuth.mockResolvedValueOnce({
+			access: "new-access",
+			refresh: "new-refresh",
+			expires: 4_000_000_000_000,
+			accountId: "acct-new",
+		});
+		const getProviderSettings = vi.fn().mockReturnValue({
+			provider: "cline",
+			apiKey: "manual-key",
+		});
+		const saveProviderSettings = vi.fn();
+		const manager = {
+			getProviderSettings,
+			saveProviderSettings,
+		} as never;
+
+		const saved = await loginAndSaveProviderOAuthCredentials(manager, "cline", {
+			callbacks: {
+				onAuth: vi.fn(),
+				onPrompt: vi.fn(async () => ""),
+			},
+		});
+
+		expect(getProviderSettings).toHaveBeenCalledWith("cline");
+		expect(saved).toMatchObject({
+			provider: "cline",
+			apiKey: "manual-key",
+			auth: {
+				accessToken: "workos:new-access",
+				refreshToken: "new-refresh",
+				accountId: "acct-new",
+				expiresAt: 4_000_000_000_000,
+			},
+		});
+		expect(saveProviderSettings).toHaveBeenCalledWith(
+			expect.objectContaining({ provider: "cline" }),
+			{ tokenSource: "oauth" },
+		);
+	});
+});

--- a/sdk/packages/core/src/auth/provider-auth-registry.ts
+++ b/sdk/packages/core/src/auth/provider-auth-registry.ts
@@ -1,0 +1,372 @@
+import {
+	getClineEnvironmentConfig,
+	type ITelemetryService,
+} from "@cline/shared";
+import type { ProviderSettingsManager } from "../services/storage/provider-settings-manager";
+import type { ProviderSettings } from "../types/provider-settings";
+import {
+	type ClineOAuthCredentials,
+	getValidClineCredentials,
+	loginClineOAuth,
+} from "./cline";
+import { getValidOpenAICodexCredentials, loginOpenAICodex } from "./codex";
+import { getValidOcaCredentials, loginOcaOAuth } from "./oca";
+import type { OAuthCredentials, OAuthLoginCallbacks } from "./types";
+import { decodeJwtPayload } from "./utils";
+
+const WORKOS_TOKEN_PREFIX = "workos:";
+
+export type ProviderOAuthCredentials = OAuthCredentials;
+
+export interface ProviderAuthLoginInput {
+	settings?: ProviderSettings;
+	callbacks: OAuthLoginCallbacks;
+	telemetry?: ITelemetryService;
+}
+
+export interface ProviderAuthRefreshInput {
+	settings: ProviderSettings;
+	credentials: ProviderOAuthCredentials;
+	forceRefresh?: boolean;
+	telemetry?: ITelemetryService;
+}
+
+export interface ProviderAuthSaveCredentialsInput {
+	manager: ProviderSettingsManager;
+	settings?: ProviderSettings;
+	credentials: ProviderOAuthCredentials;
+}
+
+export interface ProviderAuthHandler {
+	providerId: string;
+	storageProviderId: string;
+	getApiKey(settings: ProviderSettings | undefined): string | undefined;
+	login(input: ProviderAuthLoginInput): Promise<ProviderOAuthCredentials>;
+	refresh(
+		input: ProviderAuthRefreshInput,
+	): Promise<ProviderOAuthCredentials | null>;
+	saveCredentials(input: ProviderAuthSaveCredentialsInput): ProviderSettings;
+	isConfigured(settings: ProviderSettings | undefined): boolean;
+}
+
+function hasText(value: string | undefined): value is string {
+	return typeof value === "string" && value.trim().length > 0;
+}
+
+function formatClineApiKey(accessToken: string): string {
+	const token = accessToken.trim();
+	return token.toLowerCase().startsWith(WORKOS_TOKEN_PREFIX)
+		? token
+		: `${WORKOS_TOKEN_PREFIX}${token}`;
+}
+
+function stripClineApiKeyPrefix(accessToken: string): string {
+	const token = accessToken.trim();
+	return token.toLowerCase().startsWith(WORKOS_TOKEN_PREFIX)
+		? token.slice(WORKOS_TOKEN_PREFIX.length)
+		: token;
+}
+
+function readExpiryFromToken(accessToken: string): number | null {
+	const payload = decodeJwtPayload(accessToken);
+	const exp = payload?.exp;
+	if (typeof exp === "number" && exp > 0) {
+		return exp * 1000;
+	}
+	return null;
+}
+
+function deriveCredentialExpiry(
+	settings: ProviderSettings,
+	normalizedAccessToken: string,
+): number {
+	const explicitExpiry = settings.auth?.expiresAt;
+	if (
+		typeof explicitExpiry === "number" &&
+		Number.isFinite(explicitExpiry) &&
+		explicitExpiry > 0
+	) {
+		return explicitExpiry;
+	}
+
+	const jwtExpiry = readExpiryFromToken(normalizedAccessToken);
+	if (jwtExpiry) {
+		return jwtExpiry;
+	}
+
+	// Unknown expiry should trigger refresh on next resolution.
+	return Date.now() - 1;
+}
+
+function createCredentialsFromSettings(
+	settings: ProviderSettings,
+	options?: { normalizeAccessToken?: (accessToken: string) => string },
+): ProviderOAuthCredentials | null {
+	const rawAccess = settings.auth?.accessToken?.trim();
+	const refreshToken = settings.auth?.refreshToken?.trim();
+	if (!rawAccess || !refreshToken) {
+		return null;
+	}
+	const access = options?.normalizeAccessToken?.(rawAccess) ?? rawAccess;
+	if (!access) {
+		return null;
+	}
+
+	return {
+		access,
+		refresh: refreshToken,
+		expires: deriveCredentialExpiry(settings, access),
+		accountId: settings.auth?.accountId,
+	};
+}
+
+function saveOAuthCredentials(input: {
+	manager: ProviderSettingsManager;
+	storageProviderId: string;
+	settings?: ProviderSettings;
+	credentials: ProviderOAuthCredentials;
+	formatAccessToken?: (accessToken: string) => string;
+	setLastUsed?: boolean;
+	save?: boolean;
+}): ProviderSettings {
+	const accessToken =
+		input.formatAccessToken?.(input.credentials.access) ??
+		input.credentials.access;
+	const auth = {
+		...(input.settings?.auth ?? {}),
+		accessToken,
+		refreshToken: input.credentials.refresh,
+		accountId: input.credentials.accountId,
+		expiresAt: input.credentials.expires,
+	};
+
+	const merged: ProviderSettings = {
+		...(input.settings ?? {
+			provider: input.storageProviderId as ProviderSettings["provider"],
+		}),
+		provider: input.storageProviderId as ProviderSettings["provider"],
+		auth,
+	};
+	if (input.save !== false) {
+		input.manager.saveProviderSettings(merged, {
+			...(input.setLastUsed === undefined
+				? {}
+				: { setLastUsed: input.setLastUsed }),
+			tokenSource: "oauth",
+		});
+	}
+	return merged;
+}
+
+function createOAuthHandler(input: {
+	providerId: string;
+	storageProviderId?: string;
+	formatAccessToken?: (accessToken: string) => string;
+	normalizeStoredAccessToken?: (accessToken: string) => string;
+	login: (input: ProviderAuthLoginInput) => Promise<ProviderOAuthCredentials>;
+	refresh: (
+		input: ProviderAuthRefreshInput,
+	) => Promise<ProviderOAuthCredentials | null>;
+}): ProviderAuthHandler {
+	const storageProviderId = input.storageProviderId ?? input.providerId;
+	return {
+		providerId: input.providerId,
+		storageProviderId,
+		getApiKey(settings) {
+			const accessToken = settings?.auth?.accessToken?.trim();
+			if (accessToken) {
+				return input.formatAccessToken?.(accessToken) ?? accessToken;
+			}
+
+			return (
+				settings?.apiKey?.trim() || settings?.auth?.apiKey?.trim() || undefined
+			);
+		},
+		login: input.login,
+		refresh: input.refresh,
+		saveCredentials(saveInput) {
+			return saveOAuthCredentials({
+				...saveInput,
+				storageProviderId,
+				formatAccessToken: input.formatAccessToken,
+			});
+		},
+		isConfigured(settings) {
+			return hasText(settings?.auth?.accessToken);
+		},
+	};
+}
+
+const providerAuthHandlers = [
+	createOAuthHandler({
+		providerId: "cline",
+		formatAccessToken: formatClineApiKey,
+		normalizeStoredAccessToken: stripClineApiKeyPrefix,
+		login: ({ settings, callbacks, telemetry }) =>
+			loginClineOAuth({
+				apiBaseUrl:
+					settings?.baseUrl?.trim() || getClineEnvironmentConfig().apiBaseUrl,
+				useWorkOSDeviceAuth: true,
+				callbacks,
+				telemetry,
+			}),
+		refresh: ({ settings, credentials, forceRefresh, telemetry }) =>
+			getValidClineCredentials(
+				credentials as ClineOAuthCredentials,
+				{
+					apiBaseUrl:
+						settings.baseUrl?.trim() || getClineEnvironmentConfig().apiBaseUrl,
+					telemetry,
+				},
+				{ forceRefresh },
+			),
+	}),
+	createOAuthHandler({
+		providerId: "oca",
+		login: ({ settings, callbacks, telemetry }) =>
+			loginOcaOAuth({ mode: settings?.oca?.mode, callbacks, telemetry }),
+		refresh: ({ settings, credentials, forceRefresh, telemetry }) =>
+			getValidOcaCredentials(
+				credentials,
+				{ forceRefresh, telemetry },
+				{ mode: settings.oca?.mode, telemetry },
+			),
+	}),
+	createOAuthHandler({
+		providerId: "openai-codex",
+		login: ({ callbacks, telemetry }) =>
+			loginOpenAICodex({
+				onAuth: callbacks.onAuth,
+				onPrompt: callbacks.onPrompt,
+				onProgress: callbacks.onProgress,
+				onManualCodeInput: callbacks.onManualCodeInput,
+				telemetry,
+			}),
+		refresh: ({ credentials, forceRefresh, telemetry }) =>
+			getValidOpenAICodexCredentials(credentials, { forceRefresh, telemetry }),
+	}),
+] as const satisfies readonly ProviderAuthHandler[];
+
+const providerAuthHandlerById = new Map<string, ProviderAuthHandler>(
+	providerAuthHandlers.map((handler) => [handler.providerId, handler]),
+);
+
+export function getProviderAuthHandler(
+	providerId: string,
+): ProviderAuthHandler | undefined {
+	return providerAuthHandlerById.get(providerId.trim().toLowerCase());
+}
+
+export function isOAuthProvider(providerId: string): boolean {
+	return getProviderAuthHandler(providerId) !== undefined;
+}
+
+export function getProviderAuthStorageId(
+	providerId: string,
+): string | undefined {
+	return getProviderAuthHandler(providerId)?.storageProviderId;
+}
+
+export function resolveProviderApiKeyFromSettings(
+	manager: ProviderSettingsManager,
+	providerId: string,
+): string | undefined {
+	const handler = getProviderAuthHandler(providerId);
+	const storageProviderId = handler?.storageProviderId ?? providerId;
+	const settings = manager.getProviderSettings(storageProviderId);
+	return (
+		handler?.getApiKey(settings) ??
+		getPersistedProviderApiKey(providerId, settings)
+	);
+}
+
+export async function loginAndSaveProviderOAuthCredentials(
+	manager: ProviderSettingsManager,
+	providerId: string,
+	input: {
+		callbacks: OAuthLoginCallbacks;
+		telemetry?: ITelemetryService;
+	},
+): Promise<ProviderSettings> {
+	const handler = getProviderAuthHandler(providerId);
+	if (!handler) {
+		throw new Error(`Provider "${providerId}" does not support OAuth login`);
+	}
+	const existing = manager.getProviderSettings(handler.storageProviderId);
+	const credentials = await handler.login({
+		settings: existing,
+		callbacks: input.callbacks,
+		telemetry: input.telemetry,
+	});
+	return handler.saveCredentials({ manager, settings: existing, credentials });
+}
+
+export function getProviderOAuthCredentialsFromSettings(
+	providerId: string,
+	settings: ProviderSettings,
+): ProviderOAuthCredentials | null {
+	const handler = getProviderAuthHandler(providerId);
+	if (!handler) return null;
+	return createCredentialsFromSettings(settings, {
+		normalizeAccessToken:
+			providerId === "cline" ? stripClineApiKeyPrefix : undefined,
+	});
+}
+
+export function saveProviderOAuthCredentials(input: {
+	manager: ProviderSettingsManager;
+	providerId: string;
+	settings?: ProviderSettings;
+	credentials: ProviderOAuthCredentials;
+	setLastUsed?: boolean;
+	save?: boolean;
+}): ProviderSettings {
+	const handler = getProviderAuthHandler(input.providerId);
+	if (!handler) {
+		throw new Error(
+			`Provider "${input.providerId}" does not support OAuth credentials`,
+		);
+	}
+	return saveOAuthCredentials({
+		manager: input.manager,
+		storageProviderId: handler.storageProviderId,
+		settings: input.settings,
+		credentials: input.credentials,
+		formatAccessToken:
+			input.providerId === "cline" ? formatClineApiKey : undefined,
+		setLastUsed: input.setLastUsed,
+		save: input.save,
+	});
+}
+
+export function getPersistedProviderApiKey(
+	providerId: string,
+	settings?: ProviderSettings,
+): string | undefined {
+	const handler = getProviderAuthHandler(providerId);
+	if (handler) {
+		return handler.getApiKey(settings);
+	}
+
+	return (
+		settings?.auth?.accessToken?.trim() ||
+		settings?.apiKey?.trim() ||
+		settings?.auth?.apiKey?.trim() ||
+		undefined
+	);
+}
+
+export function formatProviderOAuthApiKey(
+	providerId: string,
+	credentials: Pick<ProviderOAuthCredentials, "access">,
+): string {
+	const handler = getProviderAuthHandler(providerId);
+	if (!handler) return credentials.access;
+
+	return (
+		handler.getApiKey({
+			provider: handler.storageProviderId,
+			auth: { accessToken: credentials.access },
+		}) ?? credentials.access
+	);
+}

--- a/sdk/packages/core/src/auth/provider-auth-registry.ts
+++ b/sdk/packages/core/src/auth/provider-auth-registry.ts
@@ -49,6 +49,7 @@ export interface ProviderAuthHandler {
 	): Promise<ProviderOAuthCredentials | null>;
 	saveCredentials(input: ProviderAuthSaveCredentialsInput): ProviderSettings;
 	isConfigured(settings: ProviderSettings | undefined): boolean;
+	normalizeStoredAccessToken?(accessToken: string): string;
 }
 
 function formatClineApiKey(accessToken: string): string {
@@ -192,6 +193,7 @@ function createOAuthHandler(input: {
 		isConfigured(settings) {
 			return !!settings?.auth?.accessToken;
 		},
+		normalizeStoredAccessToken: input.normalizeStoredAccessToken,
 	};
 }
 
@@ -306,8 +308,7 @@ export function getProviderOAuthCredentialsFromSettings(
 	const handler = getProviderAuthHandler(providerId);
 	if (!handler) return null;
 	return createCredentialsFromSettings(settings, {
-		normalizeAccessToken:
-			providerId === "cline" ? stripClineApiKeyPrefix : undefined,
+		normalizeAccessToken: handler.normalizeStoredAccessToken,
 	});
 }
 

--- a/sdk/packages/core/src/auth/provider-auth-registry.ts
+++ b/sdk/packages/core/src/auth/provider-auth-registry.ts
@@ -35,6 +35,8 @@ export interface ProviderAuthSaveCredentialsInput {
 	manager: ProviderSettingsManager;
 	settings?: ProviderSettings;
 	credentials: ProviderOAuthCredentials;
+	setLastUsed?: boolean;
+	save?: boolean;
 }
 
 export interface ProviderAuthHandler {
@@ -323,13 +325,10 @@ export function saveProviderOAuthCredentials(input: {
 			`Provider "${input.providerId}" does not support OAuth credentials`,
 		);
 	}
-	return saveOAuthCredentials({
+	return handler.saveCredentials({
 		manager: input.manager,
-		storageProviderId: handler.storageProviderId,
 		settings: input.settings,
 		credentials: input.credentials,
-		formatAccessToken:
-			input.providerId === "cline" ? formatClineApiKey : undefined,
 		setLastUsed: input.setLastUsed,
 		save: input.save,
 	});

--- a/sdk/packages/core/src/auth/provider-auth-registry.ts
+++ b/sdk/packages/core/src/auth/provider-auth-registry.ts
@@ -49,10 +49,6 @@ export interface ProviderAuthHandler {
 	isConfigured(settings: ProviderSettings | undefined): boolean;
 }
 
-function hasText(value: string | undefined): value is string {
-	return typeof value === "string" && value.trim().length > 0;
-}
-
 function formatClineApiKey(accessToken: string): string {
 	const token = accessToken.trim();
 	return token.toLowerCase().startsWith(WORKOS_TOKEN_PREFIX)
@@ -192,7 +188,7 @@ function createOAuthHandler(input: {
 			});
 		},
 		isConfigured(settings) {
-			return hasText(settings?.auth?.accessToken);
+			return !!settings?.auth?.accessToken;
 		},
 	};
 }

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -40,7 +40,6 @@ export type {
 	ListProvidersActionRequest,
 	Message,
 	MessageWithMetadata,
-	OAuthProviderId,
 	ProviderActionRequest,
 	ProviderCatalogResponse,
 	ProviderListItem,
@@ -139,6 +138,22 @@ export {
 	loginOcaOAuth,
 	refreshOcaToken,
 } from "./auth/oca";
+export {
+	formatProviderOAuthApiKey,
+	getPersistedProviderApiKey,
+	getProviderAuthHandler,
+	getProviderAuthStorageId,
+	getProviderOAuthCredentialsFromSettings,
+	isOAuthProvider,
+	loginAndSaveProviderOAuthCredentials,
+	type ProviderAuthHandler,
+	type ProviderAuthLoginInput,
+	type ProviderAuthRefreshInput,
+	type ProviderAuthSaveCredentialsInput,
+	type ProviderOAuthCredentials,
+	resolveProviderApiKeyFromSettings,
+	saveProviderOAuthCredentials,
+} from "./auth/provider-auth-registry";
 export type {
 	LocalOAuthServer,
 	LocalOAuthServerOptions,
@@ -453,6 +468,7 @@ export {
 	ensureCustomProvidersLoaded,
 	getLocalProviderModels,
 	listLocalProviders,
+	loginAndSaveLocalProviderOAuthCredentials,
 	loginLocalProvider,
 	normalizeOAuthProvider,
 	refreshProviderModelsFromSource,

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -123,16 +123,10 @@ export {
 } from "./auth/cline";
 export {
 	getValidOpenAICodexCredentials,
-	isOpenAICodexTokenExpired,
 	loginOpenAICodex,
-	normalizeOpenAICodexCredentials,
-	openaiCodexOAuthProvider,
 	refreshOpenAICodexToken,
 } from "./auth/codex";
 export {
-	createOcaOAuthProvider,
-	createOcaRequestHeaders,
-	generateOcaOpcRequestId,
 	getValidOcaCredentials,
 	loginOcaOAuth,
 	refreshOcaToken,

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -116,7 +116,6 @@ export {
 } from "./auth/client";
 export {
 	completeClineDeviceAuth,
-	createClineOAuthProvider,
 	getValidClineCredentials,
 	loginClineOAuth,
 	refreshClineToken,

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -13,6 +13,7 @@ import {
 	normalizeUserInput,
 } from "@cline/shared";
 import { setHomeDirIfUnset } from "@cline/shared/storage";
+import { isOAuthProvider } from "../../auth/provider-auth-registry";
 import { createContextCompactionPrepareTurn } from "../../extensions/context/compaction";
 import type { ToolExecutors } from "../../extensions/tools";
 import { DefaultToolNames } from "../../extensions/tools";
@@ -1533,7 +1534,10 @@ export class LocalRuntimeHost implements RuntimeHost {
 		try {
 			return await run();
 		} catch (error) {
-			if (!isLikelyAuthError(error, session.config.providerId)) {
+			if (
+				!isOAuthProvider(session.config.providerId) ||
+				!isLikelyAuthError(error)
+			) {
 				throw error;
 			}
 			await this.syncOAuthCredentials(session, { forceRefresh: true });

--- a/sdk/packages/core/src/runtime/orchestration/runtime-oauth-token-manager.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-oauth-token-manager.ts
@@ -1,102 +1,13 @@
+import type { ITelemetryService } from "@cline/shared";
 import {
-	getClineEnvironmentConfig,
-	type ITelemetryService,
-	isOAuthProviderId,
-	type OAuthProviderId,
-} from "@cline/shared";
-import {
-	type ClineOAuthCredentials,
-	getValidClineCredentials,
-} from "../../auth/cline";
-import { getValidOpenAICodexCredentials } from "../../auth/codex";
-import { getValidOcaCredentials } from "../../auth/oca";
-import { decodeJwtPayload } from "../../auth/utils";
+	getProviderAuthHandler,
+	getProviderOAuthCredentialsFromSettings,
+	saveProviderOAuthCredentials,
+} from "../../auth/provider-auth-registry";
 import { ProviderSettingsManager } from "../../services/storage/provider-settings-manager";
 import type { ProviderSettings } from "../../types/provider-settings";
 
-const WORKOS_TOKEN_PREFIX = "workos:";
-
-type ManagedOAuthProviderId = OAuthProviderId;
-
-function toStoredAccessToken(
-	providerId: ManagedOAuthProviderId,
-	accessToken: string,
-): string {
-	if (providerId === "cline") {
-		return `${WORKOS_TOKEN_PREFIX}${accessToken}`;
-	}
-	return accessToken;
-}
-
-function fromStoredAccessToken(
-	providerId: ManagedOAuthProviderId,
-	accessToken: string,
-): string {
-	if (
-		providerId === "cline" &&
-		accessToken.toLowerCase().startsWith(WORKOS_TOKEN_PREFIX)
-	) {
-		return accessToken.slice(WORKOS_TOKEN_PREFIX.length);
-	}
-	return accessToken;
-}
-
-function readExpiryFromToken(accessToken: string): number | null {
-	const payload = decodeJwtPayload(accessToken);
-	const exp = payload?.exp;
-	if (typeof exp === "number" && exp > 0) {
-		return exp * 1000;
-	}
-	return null;
-}
-
-function deriveCredentialExpiry(
-	settings: ProviderSettings,
-	normalizedAccessToken: string,
-): number {
-	const explicitExpiry = (
-		settings.auth as
-			| (ProviderSettings["auth"] & { expiresAt?: number })
-			| undefined
-	)?.expiresAt;
-	if (
-		typeof explicitExpiry === "number" &&
-		Number.isFinite(explicitExpiry) &&
-		explicitExpiry > 0
-	) {
-		return explicitExpiry;
-	}
-
-	const jwtExpiry = readExpiryFromToken(normalizedAccessToken);
-	if (jwtExpiry) {
-		return jwtExpiry;
-	}
-
-	// Unknown expiry should trigger refresh on next resolution.
-	return Date.now() - 1;
-}
-
-function toCredentials(
-	providerId: ManagedOAuthProviderId,
-	settings: ProviderSettings,
-): ClineOAuthCredentials | null {
-	const rawAccess = settings.auth?.accessToken?.trim();
-	const refreshToken = settings.auth?.refreshToken?.trim();
-	if (!rawAccess || !refreshToken) {
-		return null;
-	}
-	const access = fromStoredAccessToken(providerId, rawAccess);
-	if (!access) {
-		return null;
-	}
-
-	return {
-		access,
-		refresh: refreshToken,
-		expires: deriveCredentialExpiry(settings, access),
-		accountId: settings.auth?.accountId,
-	};
-}
+type ManagedOAuthProviderId = string;
 
 function authSettingsEqual(
 	a: ProviderSettings["auth"] | undefined,
@@ -156,10 +67,11 @@ export class RuntimeOAuthTokenManager {
 		providerId: string;
 		forceRefresh?: boolean;
 	}): Promise<RuntimeOAuthResolution | null> {
-		if (!isOAuthProviderId(input.providerId)) {
+		const handler = getProviderAuthHandler(input.providerId);
+		if (!handler) {
 			return null;
 		}
-		return this.resolveWithSingleFlight(input.providerId, input.forceRefresh);
+		return this.resolveWithSingleFlight(handler.providerId, input.forceRefresh);
 	}
 
 	private async resolveWithSingleFlight(
@@ -185,42 +97,43 @@ export class RuntimeOAuthTokenManager {
 		providerId: ManagedOAuthProviderId,
 		forceRefresh: boolean,
 	): Promise<RuntimeOAuthResolution | null> {
-		const settings =
-			this.providerSettingsManager.getProviderSettings(providerId);
+		const handler = getProviderAuthHandler(providerId);
+		if (!handler) {
+			return null;
+		}
+		const settings = this.providerSettingsManager.getProviderSettings(
+			handler.storageProviderId,
+		);
 		if (!settings) {
 			return null;
 		}
 
-		const currentCredentials = toCredentials(providerId, settings);
+		const currentCredentials = getProviderOAuthCredentialsFromSettings(
+			providerId,
+			settings,
+		);
 		if (!currentCredentials) {
 			return null;
 		}
 
-		const nextCredentials = await this.resolveCredentials(
-			providerId,
+		const nextCredentials = await handler.refresh({
 			settings,
-			currentCredentials,
+			credentials: currentCredentials,
 			forceRefresh,
-		);
+			telemetry: this.telemetry,
+		});
 		if (!nextCredentials) {
 			throw new OAuthReauthRequiredError(providerId);
 		}
 
-		const persistedAccessToken = toStoredAccessToken(
+		const nextSettings: ProviderSettings = saveProviderOAuthCredentials({
+			manager: this.providerSettingsManager,
 			providerId,
-			nextCredentials.access,
-		);
-		const nextAuth = {
-			...(settings.auth ?? {}),
-			accessToken: persistedAccessToken,
-			refreshToken: nextCredentials.refresh,
-			accountId: nextCredentials.accountId,
-		} as ProviderSettings["auth"] & { expiresAt?: number };
-		nextAuth.expiresAt = nextCredentials.expires;
-		const nextSettings: ProviderSettings = {
-			...settings,
-			auth: nextAuth,
-		};
+			settings,
+			credentials: nextCredentials,
+			setLastUsed: false,
+			save: false,
+		});
 		const wasRefreshed = !authSettingsEqual(settings.auth, nextSettings.auth);
 		if (wasRefreshed) {
 			this.providerSettingsManager.saveProviderSettings(nextSettings, {
@@ -231,39 +144,9 @@ export class RuntimeOAuthTokenManager {
 
 		return {
 			providerId,
-			apiKey: persistedAccessToken,
+			apiKey: handler.getApiKey(nextSettings) ?? nextCredentials.access,
 			accountId: nextCredentials.accountId,
 			refreshed: wasRefreshed,
 		};
-	}
-
-	private async resolveCredentials(
-		providerId: ManagedOAuthProviderId,
-		settings: ProviderSettings,
-		currentCredentials: ClineOAuthCredentials,
-		forceRefresh: boolean,
-	): Promise<ClineOAuthCredentials | null> {
-		if (providerId === "cline") {
-			return getValidClineCredentials(
-				currentCredentials,
-				{
-					apiBaseUrl:
-						settings.baseUrl?.trim() || getClineEnvironmentConfig().apiBaseUrl,
-					telemetry: this.telemetry,
-				},
-				{ forceRefresh },
-			);
-		}
-		if (providerId === "oca") {
-			return getValidOcaCredentials(
-				currentCredentials,
-				{ forceRefresh, telemetry: this.telemetry },
-				{ mode: settings.oca?.mode, telemetry: this.telemetry },
-			);
-		}
-		return getValidOpenAICodexCredentials(currentCredentials, {
-			forceRefresh,
-			telemetry: this.telemetry,
-		});
 	}
 }

--- a/sdk/packages/core/src/services/providers/local-provider-service.test.ts
+++ b/sdk/packages/core/src/services/providers/local-provider-service.test.ts
@@ -1248,8 +1248,7 @@ describe("normalizeOAuthProvider", () => {
 		expect(normalizeOAuthProvider("OCA")).toBe("oca");
 	});
 
-	it("normalizes 'codex' and 'openai-codex' to 'openai-codex'", () => {
-		expect(normalizeOAuthProvider("codex")).toBe("openai-codex");
+	it("normalizes 'openai-codex' to 'openai-codex'", () => {
 		expect(normalizeOAuthProvider("openai-codex")).toBe("openai-codex");
 		expect(normalizeOAuthProvider("OPENAI-CODEX")).toBe("openai-codex");
 	});

--- a/sdk/packages/core/src/services/providers/local-provider-service.ts
+++ b/sdk/packages/core/src/services/providers/local-provider-service.ts
@@ -1,20 +1,21 @@
 import * as LlmsModels from "@cline/llms";
-import {
-	type AddProviderActionRequest,
-	getClineEnvironmentConfig,
-	type ITelemetryService,
-	type OAuthProviderId,
-	type ProviderCapability,
-	type ProviderConfigField,
-	type ProviderConfigFieldPrimitive,
-	type ProviderListItem,
-	type ProviderModel,
-	type SaveProviderSettingsActionRequest,
+import type {
+	AddProviderActionRequest,
+	ITelemetryService,
+	ProviderCapability,
+	ProviderConfigField,
+	ProviderConfigFieldPrimitive,
+	ProviderListItem,
+	ProviderModel,
+	SaveProviderSettingsActionRequest,
 } from "@cline/shared";
 import { createOAuthClientCallbacks } from "../../auth/client";
-import { loginClineOAuth } from "../../auth/cline";
-import { loginOpenAICodex } from "../../auth/codex";
-import { loginOcaOAuth } from "../../auth/oca";
+import {
+	getProviderAuthHandler,
+	loginAndSaveProviderOAuthCredentials,
+	type ProviderOAuthCredentials,
+	saveProviderOAuthCredentials,
+} from "../../auth/provider-auth-registry";
 import { resolveProviderConfig } from "../../services/llms/provider-defaults";
 import type {
 	ModelInfo,
@@ -849,39 +850,23 @@ export async function refreshProviderModelsFromSource(
 	return { providerId: id, refreshed: true, modelsCount: result.modelsCount };
 }
 
-export function normalizeOAuthProvider(provider: string): OAuthProviderId {
+export function normalizeOAuthProvider(provider: string): string {
 	const normalized = provider.trim().toLowerCase();
-	if (normalized === "codex" || normalized === "openai-codex")
-		return "openai-codex";
-	if (normalized === "cline" || normalized === "oca") return normalized;
-	throw new Error(
-		`provider "${provider}" does not support OAuth login (supported: cline, oca, openai-codex)`,
-	);
-}
-
-function toProviderApiKey(
-	providerId: OAuthProviderId,
-	credentials: { access: string },
-): string {
-	if (providerId === "cline") {
-		return credentials.access.startsWith("workos:")
-			? credentials.access
-			: `workos:${credentials.access}`;
-	}
-	return credentials.access;
+	const handler = getProviderAuthHandler(normalized);
+	if (handler) return handler.providerId;
+	throw new Error(`provider "${provider}" does not support OAuth login`);
 }
 
 export async function loginLocalProvider(
-	providerId: OAuthProviderId,
+	providerId: string,
 	existing: ProviderSettings | undefined,
 	openUrl: (url: string) => void,
 	telemetry?: ITelemetryService,
-): Promise<{
-	access: string;
-	refresh: string;
-	expires: number;
-	accountId?: string;
-}> {
+): Promise<ProviderOAuthCredentials> {
+	const handler = getProviderAuthHandler(providerId);
+	if (!handler) {
+		throw new Error(`provider "${providerId}" does not support OAuth login`);
+	}
 	const callbacks = createOAuthClientCallbacks({
 		onPrompt: async (prompt) => prompt.defaultValue ?? "",
 		openUrl,
@@ -889,55 +874,40 @@ export async function loginLocalProvider(
 			throw error instanceof Error ? error : new Error(String(error));
 		},
 	});
-
-	if (providerId === "cline") {
-		return loginClineOAuth({
-			apiBaseUrl:
-				existing?.baseUrl?.trim() || getClineEnvironmentConfig().apiBaseUrl,
-			useWorkOSDeviceAuth: true,
-			callbacks,
-			telemetry,
-		});
-	}
-	if (providerId === "oca")
-		return loginOcaOAuth({ mode: existing?.oca?.mode, callbacks, telemetry });
-	return loginOpenAICodex({
-		onAuth: callbacks.onAuth,
-		onPrompt: callbacks.onPrompt,
-		onProgress: callbacks.onProgress,
-		onManualCodeInput: callbacks.onManualCodeInput,
-		telemetry,
-	});
+	return handler.login({ settings: existing, callbacks, telemetry });
 }
 
 export function saveLocalProviderOAuthCredentials(
 	manager: ProviderSettingsManager,
-	providerId: OAuthProviderId,
+	providerId: string,
 	existing: ProviderSettings | undefined,
-	credentials: {
-		access: string;
-		refresh: string;
-		expires: number;
-		accountId?: string;
-	},
+	credentials: ProviderOAuthCredentials,
 ): ProviderSettings {
-	const auth = {
-		...(existing?.auth ?? {}),
-		accessToken: toProviderApiKey(providerId, credentials),
-		refreshToken: credentials.refresh,
-		accountId: credentials.accountId,
-		expiresAt: credentials.expires,
-	} as ProviderSettings["auth"] & { expiresAt?: number };
+	return saveProviderOAuthCredentials({
+		manager,
+		providerId,
+		settings: existing,
+		credentials,
+	});
+}
 
-	const merged: ProviderSettings = {
-		...(existing ?? {
-			provider: providerId as ProviderSettings["provider"],
-		}),
-		provider: providerId as ProviderSettings["provider"],
-		auth,
-	};
-	manager.saveProviderSettings(merged, { tokenSource: "oauth" });
-	return merged;
+export async function loginAndSaveLocalProviderOAuthCredentials(
+	manager: ProviderSettingsManager,
+	providerId: string,
+	openUrl: (url: string) => void,
+	telemetry?: ITelemetryService,
+): Promise<ProviderSettings> {
+	const callbacks = createOAuthClientCallbacks({
+		onPrompt: async (prompt) => prompt.defaultValue ?? "",
+		openUrl,
+		onOpenUrlError: ({ error }) => {
+			throw error instanceof Error ? error : new Error(String(error));
+		},
+	});
+	return loginAndSaveProviderOAuthCredentials(manager, providerId, {
+		callbacks,
+		telemetry,
+	});
 }
 
 export function resolveLocalClineAuthToken(

--- a/sdk/packages/core/src/services/providers/local-provider-service.ts
+++ b/sdk/packages/core/src/services/providers/local-provider-service.ts
@@ -882,12 +882,14 @@ export function saveLocalProviderOAuthCredentials(
 	providerId: string,
 	existing: ProviderSettings | undefined,
 	credentials: ProviderOAuthCredentials,
+	options?: { setLastUsed?: boolean },
 ): ProviderSettings {
 	return saveProviderOAuthCredentials({
 		manager,
 		providerId,
 		settings: existing,
 		credentials,
+		setLastUsed: options?.setLastUsed,
 	});
 }
 

--- a/sdk/packages/core/src/services/providers/provider-config-fields.ts
+++ b/sdk/packages/core/src/services/providers/provider-config-fields.ts
@@ -1,5 +1,5 @@
 import * as LlmsModels from "@cline/llms";
-import { isOAuthProviderId } from "@cline/shared";
+import { isOAuthProvider } from "../../auth/provider-auth-registry";
 
 export type ProviderConfigFieldKey =
 	| "apiKey"
@@ -186,7 +186,7 @@ export function getProviderConfigFields(
 	providerId: string,
 ): ProviderConfigFields {
 	const id = LlmsModels.normalizeProviderId(providerId);
-	if (isOAuthProviderId(id)) {
+	if (isOAuthProvider(id)) {
 		return { providerId: id, authMethod: "oauth", fields: {} };
 	}
 

--- a/sdk/packages/shared/src/index.browser.ts
+++ b/sdk/packages/shared/src/index.browser.ts
@@ -343,12 +343,6 @@ export type { RuntimeEnv } from "./session/runtime-env";
 export * from "./session/workspace";
 export * from "./team";
 export { createTool } from "./tools/create";
-export type { OAuthProviderId } from "./types/auth";
-export {
-	AUTH_ERROR_PATTERNS,
-	isLikelyAuthError,
-	isOAuthProviderId,
-	OAUTH_PROVIDER_IDS,
-} from "./types/auth";
+export { AUTH_ERROR_PATTERNS, isLikelyAuthError } from "./types/auth";
 // VCR is Node-only (uses node:fs, node:path), excluded from browser build
 export type { VcrRecording } from "./types/vcr";

--- a/sdk/packages/shared/src/index.ts
+++ b/sdk/packages/shared/src/index.ts
@@ -394,11 +394,5 @@ export * from "./session/workspace";
 export * from "./team";
 export { createTool } from "./tools/create";
 export * from "./types";
-export type { OAuthProviderId } from "./types/auth";
-export {
-	AUTH_ERROR_PATTERNS,
-	isLikelyAuthError,
-	isOAuthProviderId,
-	OAUTH_PROVIDER_IDS,
-} from "./types/auth";
+export { AUTH_ERROR_PATTERNS, isLikelyAuthError } from "./types/auth";
 export { initVcr } from "./vcr";

--- a/sdk/packages/shared/src/rpc/runtime.ts
+++ b/sdk/packages/shared/src/rpc/runtime.ts
@@ -208,8 +208,6 @@ export interface ProviderModelsResponse {
 	models: ProviderModel[];
 }
 
-import type { OAuthProviderId } from "../types/auth";
-
 export const ProviderCapabilitySchema = z.enum([
 	"reasoning",
 	"prompt-cache",
@@ -424,6 +422,6 @@ export type ProviderActionRequest =
 	| ClineAccountActionRequest;
 
 export interface ProviderOAuthLoginResponse {
-	provider: OAuthProviderId;
+	provider: string;
 	accessToken: string;
 }

--- a/sdk/packages/shared/src/types/auth.ts
+++ b/sdk/packages/shared/src/types/auth.ts
@@ -1,23 +1,7 @@
 /**
- * Canonical list of OAuth provider IDs managed by the platform.
- * Derive sets, types, and guards from this single source of truth.
- */
-export const OAUTH_PROVIDER_IDS = ["cline", "oca", "openai-codex"] as const;
-
-export type OAuthProviderId = (typeof OAUTH_PROVIDER_IDS)[number];
-
-/**
- * Check whether a provider ID is a managed OAuth provider.
- */
-export function isOAuthProviderId(
-	providerId: string,
-): providerId is OAuthProviderId {
-	return (OAUTH_PROVIDER_IDS as readonly string[]).includes(providerId);
-}
-
-/**
  * Error‑message sub-strings that indicate an auth / credential failure.
- * Used to decide whether a failed API call should trigger an OAuth refresh.
+ * Used with provider auth handlers to decide whether a failed API call should
+ * trigger an OAuth refresh.
  */
 export const AUTH_ERROR_PATTERNS = [
 	"401",
@@ -30,11 +14,9 @@ export const AUTH_ERROR_PATTERNS = [
 ] as const;
 
 /**
- * Returns `true` when `error` looks like an authentication failure
- * *and* the provider is a managed OAuth provider.
+ * Returns `true` when `error` looks like an authentication failure.
  */
-export function isLikelyAuthError(error: unknown, providerId: string): boolean {
-	if (!isOAuthProviderId(providerId)) return false;
+export function isLikelyAuthError(error: unknown): boolean {
 	const message =
 		error instanceof Error ? error.message.toLowerCase() : String(error);
 	return AUTH_ERROR_PATTERNS.some((pattern) => message.includes(pattern));


### PR DESCRIPTION
### Description

This PR prepares our SDK to introduce OAuth providers easily. Essentially, it ensures clients do not need provider-specific logic, so it's easier to add new providers.

We also remove the `codex` mapping from the SDK itself, since it's only needed in the CLI/clients that support it, and we shouldn't bring in legacy logic when it's not needed. It's better to map at the highest level possible than to need to map everywhere.

### Test Procedure

I tested locally that OAuth workflows still work in the CLI.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)