### PR TITLE
Add API request checkpoint telemetry

### DIFF
--- a/apps/vscode/src/core/task/index.ts
+++ b/apps/vscode/src/core/task/index.ts
@@ -2017,21 +2017,78 @@ export class Task {
 			// saves task history item which we use to keep track of conversation history deleted range
 		}
 
+		const apiRequestCheckpointBase = {
+			ulid: this.ulid,
+			taskId: this.taskId,
+			provider: providerInfo.providerId,
+			model: providerInfo.model.id,
+			mode: providerInfo.mode,
+			apiRequestCount: this.taskState.apiRequestCount,
+			isNativeToolCall: this.useNativeToolCalls,
+		}
+		const apiRequestStartTime = performance.now()
+
+		telemetryService.captureApiRequestCheckpoint({
+			...apiRequestCheckpointBase,
+			stage: "create_message_start",
+			requestId: this.getApiRequestIdSafe(),
+		})
+
 		// Response API requires native tool calls to be enabled
 		const stream = this.api.createMessage(systemPrompt, contextManagementMetadata.truncatedConversationHistory, tools)
+
+		telemetryService.captureApiRequestCheckpoint({
+			...apiRequestCheckpointBase,
+			stage: "stream_created",
+			requestId: this.getApiRequestIdSafe(),
+			durationMs: Math.round(performance.now() - apiRequestStartTime),
+		})
 
 		const iterator = stream[Symbol.asyncIterator]()
 
 		try {
 			// awaiting first chunk to see if it will throw an error
 			this.taskState.isWaitingForFirstChunk = true
+
+			telemetryService.captureApiRequestCheckpoint({
+				...apiRequestCheckpointBase,
+				stage: "first_chunk_wait_start",
+				requestId: this.getApiRequestIdSafe(),
+				durationMs: Math.round(performance.now() - apiRequestStartTime),
+			})
+
 			const firstChunk = await iterator.next()
+			const firstChunkType =
+				firstChunk.value && typeof firstChunk.value === "object" && "type" in firstChunk.value
+					? String((firstChunk.value as { type?: unknown }).type)
+					: undefined
+
+			telemetryService.captureApiRequestCheckpoint({
+				...apiRequestCheckpointBase,
+				stage: "first_chunk_received",
+				requestId: this.getApiRequestIdSafe(),
+				durationMs: Math.round(performance.now() - apiRequestStartTime),
+				firstChunkType,
+			})
+
 			yield firstChunk.value
 			this.taskState.isWaitingForFirstChunk = false
 		} catch (error) {
 			const isContextWindowExceededError = checkContextWindowExceededError(error)
 			const { model, providerId } = this.getCurrentProviderInfo()
 			const clineError = ErrorService.get().toClineError(error, model.id, providerId)
+			const errorType = ClineError.getErrorType(clineError)
+
+			telemetryService.captureApiRequestCheckpoint({
+				...apiRequestCheckpointBase,
+				stage: "first_chunk_error",
+				requestId: clineError._error.request_id ?? this.getApiRequestIdSafe(),
+				durationMs: Math.round(performance.now() - apiRequestStartTime),
+				errorType,
+				errorStatus: clineError._error.status,
+				errorCode: clineError._error.code,
+				errorMessage: clineError.message,
+			})
 
 			// Capture provider failure telemetry using clineError
 			ErrorService.get().logMessage(clineError.message)

--- a/apps/vscode/src/services/telemetry/TelemetryService.ts
+++ b/apps/vscode/src/services/telemetry/TelemetryService.ts
@@ -264,6 +264,8 @@ export class TelemetryService {
 			GEMINI_API_PERFORMANCE: "task.gemini_api_performance",
 			// Tracks when API providers return errors
 			PROVIDER_API_ERROR: "task.provider_api_error",
+			// Tracks client-side API request progress before provider output exists
+			API_REQUEST_CHECKPOINT: "task.api_request_checkpoint",
 			// Tracks when users enable the focus chain feature
 			FOCUS_CHAIN_ENABLED: "task.focus_chain_enabled",
 			// Tracks when users disable the focus chain feature
@@ -1398,6 +1400,36 @@ export class TelemetryService {
 		}
 		const errorCount = this.incrementTaskCounter(this.taskErrorCounts, args.ulid)
 		this.recordHistogram(TelemetryService.METRICS.ERRORS.PER_TASK, errorCount, errorAttributes)
+	}
+
+	/**
+	 * Records client-side API request progress for diagnosing pre-first-token failures.
+	 */
+	public captureApiRequestCheckpoint(args: {
+		ulid: string
+		taskId: string
+		stage: string
+		provider?: string
+		model?: string
+		mode?: Mode
+		requestId?: string
+		apiRequestCount?: number
+		durationMs?: number
+		firstChunkType?: string
+		errorType?: string
+		errorStatus?: number
+		errorCode?: string
+		errorMessage?: string
+		isNativeToolCall?: boolean
+	}) {
+		this.capture({
+			event: TelemetryService.EVENTS.TASK.API_REQUEST_CHECKPOINT,
+			properties: {
+				...args,
+				errorMessage: args.errorMessage?.substring(0, MAX_ERROR_MESSAGE_LENGTH),
+				timestamp: new Date().toISOString(),
+			},
+		})
 	}
 
 	/**


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Adds client-side checkpoint telemetry around the Cline provider API request path so pre-first-token failures can be separated from provider output failures.

The new `task.api_request_checkpoint` event records:

- request creation start
- stream object creation
- first-chunk wait start
- first chunk received
- first-chunk error details

The event includes task/request context such as task ID, provider, model, mode, API request count, duration, first chunk type, and bounded error metadata.

### Test Procedure

- Ran `git diff --check`.
- Attempted `npm run check-types` from `apps/vscode`; it currently stops during `npm run protos` because `grpc-tools` is missing the expected `node_modules/grpc-tools/bin/protoc` binary in this worktree, before TypeScript checking starts.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - telemetry-only change.

### Additional Notes

This is paired with a core-platform backend telemetry PR so future stalled inference investigations can join client checkpoints to backend/provider checkpoints.
