### PR TITLE
fix(cli): version hub compatibility by cli release

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -8,7 +8,11 @@ import {
 	cleanupActiveRuntime,
 	isAbortInProgress,
 } from "./runtime/active-runtime";
+import { configureCliHubCompatibility } from "./utils/hub-compatibility";
 import { writeErr } from "./utils/output";
+
+// Configure hub compatibility before any SDK hub discovery or daemon startup.
+configureCliHubCompatibility();
 
 // Initialize VCR before any HTTP requests are made.
 // Set CLINE_VCR=record|playback and CLINE_VCR_CASSETTE=<path> to enable.

--- a/apps/cli/src/utils/hub-compatibility.test.ts
+++ b/apps/cli/src/utils/hub-compatibility.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { version } from "../../package.json";
+import { configureCliHubCompatibility } from "./hub-compatibility";
+
+describe("configureCliHubCompatibility", () => {
+	it("uses the CLI release version as the hub build id", () => {
+		const env: NodeJS.ProcessEnv = {};
+
+		configureCliHubCompatibility(env);
+
+		expect(env.CLINE_HUB_BUILD_ID).toBe(`cli:${version}`);
+	});
+
+	it("preserves an explicit hub build id override", () => {
+		const env: NodeJS.ProcessEnv = {
+			CLINE_HUB_BUILD_ID: "custom-build",
+		};
+
+		configureCliHubCompatibility(env);
+
+		expect(env.CLINE_HUB_BUILD_ID).toBe("custom-build");
+	});
+
+	it("replaces a blank hub build id override", () => {
+		const env: NodeJS.ProcessEnv = {
+			CLINE_HUB_BUILD_ID: "   ",
+		};
+
+		configureCliHubCompatibility(env);
+
+		expect(env.CLINE_HUB_BUILD_ID).toBe(`cli:${version}`);
+	});
+});

--- a/apps/cli/src/utils/hub-compatibility.ts
+++ b/apps/cli/src/utils/hub-compatibility.ts
@@ -1,0 +1,17 @@
+import { version } from "../../package.json";
+
+const CLINE_HUB_BUILD_ID_ENV = "CLINE_HUB_BUILD_ID";
+
+export function configureCliHubCompatibility(
+	env: NodeJS.ProcessEnv = process.env,
+): void {
+	if (env[CLINE_HUB_BUILD_ID_ENV]?.trim()) {
+		return;
+	}
+
+	// The SDK defaults hub compatibility to @cline/core's version, but published
+	// CLI releases can change CLI-owned hub behavior while @cline/core stays on
+	// the same workspace package version. Stamp local hubs with the CLI release
+	// before any SDK hub code probes or spawns the daemon.
+	env[CLINE_HUB_BUILD_ID_ENV] = `cli:${version}`;
+}


### PR DESCRIPTION
### Related Issue

Issue: #XXXX

### Description

This fixes stale local hub reuse after published CLI updates.

The hub compatibility check already compares a `buildId`, but the SDK default comes from `@cline/core` version. That was not enough for the npm-published CLI because multiple CLI releases can ship CLI-owned hub behavior changes while `@cline/core` stays on the same workspace package version. In that case, installing a newer `cline` could still connect to an older background hub daemon, which left users on stale hub behavior until they manually killed the daemon.

The CLI now configures the SDK's existing `CLINE_HUB_BUILD_ID` override at process startup using the published CLI version. This happens before any SDK hub discovery or daemon startup, so the existing SDK compatibility logic can retire mismatched daemons and spawn a fresh hub for the installed CLI release. Explicit `CLINE_HUB_BUILD_ID` overrides are still respected for tests or custom embedding scenarios.

### Test Procedure

Ran:

- `bun -F @cline/cli test:unit src/utils/hub-compatibility.test.ts`
- `bun -F @cline/cli typecheck`
- `bun biome check --no-errors-on-unmatched --files-ignore-unknown=true apps/cli/src/index.ts apps/cli/src/utils/hub-compatibility.ts apps/cli/src/utils/hub-compatibility.test.ts`

I also previously verified the packaged npm-style binary published `buildId: "cli:3.0.17"` in the hub discovery record.

### Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Refactor Changes
-   [ ] Cosmetic Changes
-   [ ] Documentation update
-   [ ] Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. This is a CLI hub compatibility fix with no visual UI change.

### Additional Notes

This intentionally lives in the CLI rather than changing the SDK default. The SDK should continue to default to `@cline/core` version for generic SDK embedders, while the published CLI can stamp its own release identity through the SDK-supported environment override.
