### PR TITLE
fix(cli): clear abort indicator immediately

### DIFF
--- a/apps/cli/src/tui/hooks/use-root-keyboard.ts
+++ b/apps/cli/src/tui/hooks/use-root-keyboard.ts
@@ -234,6 +234,8 @@ export function useRootKeyboard(input: {
 				const abortStarted = input.onAbort();
 				if (abortStarted) {
 					session.setAbortRequested(true);
+					session.setIsStreaming(false);
+					session.closeInlineStream();
 				}
 			} else if (selectedQueuedPromptId) {
 				queuedSelection.select(null);


### PR DESCRIPTION
### Related Issue

Issue: #XXXX

### Description

This fixes the visible delay after pressing Esc to cancel a running CLI request.

The abort command was being sent immediately and the hub processed it quickly, but the TUI only hid `Thinking... (esc to cancel)` after the backend emitted terminal events or the submit flow finished unwinding. On the packaged CLI path, that cleanup could take a second or two, making cancellation look laggy even though abort had already started.

When `onAbort()` reports that abort has started, the keyboard handler now clears the local streaming state and closes the active inline stream immediately. The actual run lifecycle still uses the existing backend completion path, but the cancel affordance now reflects the user's action right away.

### Test Procedure

Ran:

- `bun -F @cline/cli test:unit src/tui/hooks/use-root-keyboard.test.ts`
- `bun -F @cline/cli typecheck`
- `bun biome check --no-errors-on-unmatched --files-ignore-unknown=true apps/cli/src/tui/hooks/use-root-keyboard.ts`

I also manually tested the npm-style installed CLI and verified Esc now removes the `Thinking... (esc to cancel)` indicator immediately.

### Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Refactor Changes
-   [ ] Cosmetic Changes
-   [ ] Documentation update
-   [ ] Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. This changes transient TUI state after Esc cancel, not layout.

### Additional Notes

This PR is intentionally separate from the hub compatibility fix. It addresses the remaining UI feedback delay after the correct hub is running.
