### PR TITLE
fix: decode escaped command operators

### DIFF
--- a/apps/vscode/src/core/task/tools/handlers/ExecuteCommandToolHandler.ts
+++ b/apps/vscode/src/core/task/tools/handlers/ExecuteCommandToolHandler.ts
@@ -113,17 +113,14 @@ export class ExecuteCommandToolHandler implements IFullyManagedTool {
 
 		config.taskState.consecutiveMistakeCount = 0
 
+		command = applyModelContentFixes(command, config.api.getModel().id)
+
 		// Handling of timeout while in yolo mode or background exec mode
 		timeoutSeconds = resolveCommandTimeoutSeconds(
 			command,
 			timeoutParam,
 			config.yoloModeToggled || config.vscodeTerminalExecutionMode === "backgroundExec",
 		)
-
-		// Pre-process command for certain models
-		if (config.api.getModel().id.includes("gemini")) {
-			command = applyModelContentFixes(command)
-		}
 
 		// Handle multi-workspace command execution
 		let executionDir: string = config.cwd

--- a/apps/vscode/src/core/task/tools/handlers/__tests__/ExecuteCommandToolHandler.timeout.test.ts
+++ b/apps/vscode/src/core/task/tools/handlers/__tests__/ExecuteCommandToolHandler.timeout.test.ts
@@ -1,6 +1,56 @@
 import assert from "node:assert/strict"
 import { describe, it } from "mocha"
-import { isLikelyLongRunningCommand, resolveCommandTimeoutSeconds } from "../ExecuteCommandToolHandler"
+import { ExecuteCommandToolHandler, isLikelyLongRunningCommand, resolveCommandTimeoutSeconds } from "../ExecuteCommandToolHandler"
+
+type ExecuteCommandCallback = (command: string, timeoutSeconds?: number) => Promise<[boolean, string]>
+
+function createConfig(modelId: string, executeCommandTool: ExecuteCommandCallback, yoloMode = false) {
+	return {
+		ulid: "test-ulid",
+		taskId: "test-task",
+		cwd: "/repo",
+		mode: "act",
+		strictPlanModeEnabled: false,
+		yoloModeToggled: yoloMode,
+		doubleCheckCompletionEnabled: false,
+		vscodeTerminalExecutionMode: "vscodeTerminal",
+		enableParallelToolCalling: false,
+		isSubagentExecution: false,
+		taskState: {
+			consecutiveMistakeCount: 0,
+			didRejectTool: false,
+			abort: false,
+			fileReadCache: new Map(),
+			userMessageContent: [],
+		},
+		api: {
+			getModel: () => ({ id: modelId }),
+		},
+		services: {
+			stateManager: {
+				getApiConfiguration: () => ({}),
+				getGlobalSettingsKey: (key: string) => (key === "hooksEnabled" ? false : "act"),
+			},
+			commandPermissionController: {
+				validateCommand: () => ({ allowed: true }),
+			},
+			clineIgnoreController: {
+				validateCommand: () => undefined,
+			},
+		},
+		autoApprover: {
+			shouldAutoApproveTool: () => [true, false],
+		},
+		autoApprovalSettings: {
+			enableNotifications: false,
+		},
+		callbacks: {
+			removeLastPartialMessageIfExistsWithType: async () => undefined,
+			say: async () => undefined,
+			executeCommandTool,
+		},
+	} as any
+}
 
 describe("ExecuteCommandToolHandler timeout policy", () => {
 	it("returns undefined when managed timeout is disabled", () => {
@@ -27,5 +77,76 @@ describe("ExecuteCommandToolHandler timeout policy", () => {
 		assert.equal(isLikelyLongRunningCommand("cargo build --release"), true)
 		assert.equal(isLikelyLongRunningCommand("docker build ."), true)
 		assert.equal(isLikelyLongRunningCommand("pytest -q"), true)
+	})
+
+	it("decodes escaped shell operators for non-Claude models before execution", async () => {
+		let executedCommand = ""
+		let executionTimeout: number | undefined
+		const handler = new ExecuteCommandToolHandler({} as any)
+		const config = createConfig(
+			"xai/grok-4-1-fast-reasoning",
+			async (command: string, timeoutSeconds?: number) => {
+				executedCommand = command
+				executionTimeout = timeoutSeconds
+				return [false, "ok"]
+			},
+			true,
+		)
+
+		await handler.execute(config, {
+			name: "execute_command",
+			params: {
+				command: "echo first &amp;&amp; echo second 2&gt;/tmp/out",
+				requires_approval: "false",
+			},
+			isNativeToolCall: false,
+		} as any)
+
+		assert.equal(executedCommand, "echo first && echo second 2>/tmp/out")
+		assert.equal(executionTimeout, 30)
+	})
+
+	it("keeps Claude command text unchanged", async () => {
+		let executedCommand = ""
+		const handler = new ExecuteCommandToolHandler({} as any)
+		const config = createConfig("claude-3-5-sonnet-20241022", async (command: string) => {
+			executedCommand = command
+			return [false, "ok"]
+		})
+
+		await handler.execute(config, {
+			name: "execute_command",
+			params: {
+				command: "echo first &amp;&amp; echo second",
+				requires_approval: "false",
+			},
+			isNativeToolCall: false,
+		} as any)
+
+		assert.equal(executedCommand, "echo first &amp;&amp; echo second")
+	})
+
+	it("uses decoded commands for timeout heuristics", async () => {
+		let executionTimeout: number | undefined
+		const handler = new ExecuteCommandToolHandler({} as any)
+		const config = createConfig(
+			"xai/grok-4-1-fast-reasoning",
+			async (_command: string, timeoutSeconds?: number) => {
+				executionTimeout = timeoutSeconds
+				return [false, "ok"]
+			},
+			true,
+		)
+
+		await handler.execute(config, {
+			name: "execute_command",
+			params: {
+				command: "npm run build &amp;&amp; npm test",
+				requires_approval: "false",
+			},
+			isNativeToolCall: false,
+		} as any)
+
+		assert.equal(executionTimeout, 300)
 	})
 })


### PR DESCRIPTION
### Related Issue

**Issue:** #11266

### Description

This fixes escaped shell operators reaching the terminal for non-Claude, non-Gemini models.

`applyModelContentFixes()` already decodes model-emitted HTML entities and skips Claude models, but `execute_command` only called it for Gemini model IDs. That left providers such as xAI/Grok able to pass commands like `&amp;&amp;` and `2&gt;` straight into the shell, where zsh treats them as invalid syntax.

This PR runs the same command pre-processing path for every model and passes the actual model ID so Claude remains unchanged.

### Test Procedure

Ran:

- `npm run test:unit -- --grep "ExecuteCommandToolHandler timeout policy"`
- `npx biome lint src/core/task/tools/handlers/ExecuteCommandToolHandler.ts src/core/task/tools/handlers/__tests__/ExecuteCommandToolHandler.timeout.test.ts --no-errors-on-unmatched --files-ignore-unknown=true --diagnostic-level=error`
- `git diff --check origin/main...HEAD`
- `npm run check-types`

`npm run check-types` passed. Its `postprotos` step reformatted generated/controller files as a side effect, so I reverted those generated formatting changes before committing. The PR diff is limited to the command handler and its unit test.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable; this is command handling logic.

### Additional Notes

I did not run full `npm test` or `npm run format`. The targeted unit test covers a Grok-style model command containing `&amp;&amp;` and `2&gt;`, and verifies the final command sent for execution uses raw shell syntax.