### PR TITLE
chore(vscode): remove explain changes entry points

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -229,26 +229,9 @@
 				"command": "cline.reconstructTaskHistory",
 				"title": "Reconstruct Task History",
 				"category": "Cline"
-			},
-			{
-				"command": "cline.reviewComment.reply",
-				"title": "Reply",
-				"category": "Cline",
-				"enablement": "!commentIsEmpty"
-			},
-			{
-				"command": "cline.reviewComment.addToChat",
-				"title": "Add to Cline Chat",
-				"category": "Cline",
-				"icon": "$(link-external)"
 			}
 		],
 		"keybindings": [
-			{
-				"command": "editor.action.submitComment",
-				"key": "enter",
-				"when": "commentEditorFocused && commentController == cline-ai-review && !commentIsEmpty"
-			},
 			{
 				"command": "cline.addToChat",
 				"key": "cmd+'",
@@ -350,24 +333,6 @@
 				{
 					"command": "cline.abortGitCommitMessage",
 					"when": "config.git.enabled && cline.isGeneratingCommit"
-				},
-				{
-					"command": "cline.reviewComment.reply",
-					"when": "false"
-				}
-			],
-			"comments/commentThread/context": [
-				{
-					"command": "cline.reviewComment.reply",
-					"group": "inline",
-					"when": "commentController == cline-ai-review"
-				}
-			],
-			"comments/commentThread/title": [
-				{
-					"command": "cline.reviewComment.addToChat",
-					"group": "inline",
-					"when": "commentController == cline-ai-review"
 				}
 			]
 		},

--- a/apps/vscode/src/hosts/vscode/review/VscodeCommentReviewController.ts
+++ b/apps/vscode/src/hosts/vscode/review/VscodeCommentReviewController.ts
@@ -1,5 +1,4 @@
 import * as vscode from "vscode"
-import { sendAddToInputEvent } from "@/core/controller/ui/subscribeToAddToInput"
 import { CommentReviewController, type OnReplyCallback, type ReviewComment } from "@/integrations/editor/CommentReviewController"
 import { Logger } from "@/shared/services/Logger"
 import { DIFF_VIEW_URI_SCHEME } from "../VscodeDiffViewProvider"
@@ -18,10 +17,6 @@ const CLINE_AVATAR_URL = "https://avatars.githubusercontent.com/u/184127137"
 export class VscodeCommentReviewController extends CommentReviewController implements vscode.Disposable {
 	private commentController: vscode.CommentController
 	private threads: Map<string, vscode.CommentThread> = new Map()
-	/** Maps thread to its absolute file path (needed because virtual URIs don't contain the full path) */
-	private threadFilePaths: Map<vscode.CommentThread, string> = new Map()
-	private onReplyCallback?: OnReplyCallback
-	private disposables: vscode.Disposable[] = []
 
 	/** The currently streaming comment thread */
 	private streamingThread: vscode.CommentThread | null = null
@@ -31,42 +26,13 @@ export class VscodeCommentReviewController extends CommentReviewController imple
 		super()
 		// Create the comment controller
 		this.commentController = vscode.comments.createCommentController("cline-ai-review", "Cline AI Review")
-
-		// Configure options for the reply input
-		this.commentController.options = {
-			placeHolder: "Ask a question about this code...",
-			prompt: "Reply to Cline",
-		}
-
-		// Configure the commenting range provider (optional - allows commenting on any line)
-		this.commentController.commentingRangeProvider = {
-			provideCommentingRanges: (document: vscode.TextDocument, _token: vscode.CancellationToken): vscode.Range[] => {
-				// Allow commenting on any line in the document
-				const lineCount = document.lineCount
-				return [new vscode.Range(0, 0, lineCount - 1, 0)]
-			},
-		}
-
-		// Register reply command - this is called when user clicks the Reply button
-		this.disposables.push(
-			vscode.commands.registerCommand("cline.reviewComment.reply", async (reply: vscode.CommentReply) => {
-				await this.handleReply(reply)
-			}),
-		)
-
-		// Register add to chat command - sends the conversation to Cline's main chat
-		this.disposables.push(
-			vscode.commands.registerCommand("cline.reviewComment.addToChat", async (thread: vscode.CommentThread) => {
-				await this.handleAddToChat(thread)
-			}),
-		)
 	}
 
 	/**
 	 * Set the callback for handling user replies
 	 */
-	setOnReplyCallback(callback: OnReplyCallback): void {
-		this.onReplyCallback = callback
+	setOnReplyCallback(_callback: OnReplyCallback): void {
+		// Replies are disabled for generated review comments.
 	}
 
 	/**
@@ -114,14 +80,12 @@ export class VscodeCommentReviewController extends CommentReviewController imple
 		const thread = this.commentController.createCommentThread(uri, range, [commentObj])
 
 		// Configure thread
-		thread.canReply = true
+		thread.canReply = false
 		thread.collapsibleState = vscode.CommentThreadCollapsibleState.Expanded
 
 		// Store for later management
 		const threadKey = this.getThreadKey(comment.filePath, comment.startLine, comment.endLine)
 		this.threads.set(threadKey, thread)
-		// Store absolute file path for reply handling (virtual URIs don't contain the full path)
-		this.threadFilePaths.set(thread, comment.filePath)
 	}
 
 	/**
@@ -159,7 +123,7 @@ export class VscodeCommentReviewController extends CommentReviewController imple
 
 		// Create the thread
 		const thread = this.commentController.createCommentThread(uri, range, [commentObj])
-		thread.canReply = true
+		thread.canReply = false
 		thread.collapsibleState = vscode.CommentThreadCollapsibleState.Expanded
 
 		// Store for streaming updates
@@ -169,7 +133,6 @@ export class VscodeCommentReviewController extends CommentReviewController imple
 		// Store for later management
 		const threadKey = this.getThreadKey(filePath, startLine, endLine)
 		this.threads.set(threadKey, thread)
-		this.threadFilePaths.set(thread, filePath)
 
 		// Open the virtual document and scroll to show the comment in center (only if requested)
 		if (revealComment) {
@@ -263,7 +226,6 @@ export class VscodeCommentReviewController extends CommentReviewController imple
 	 */
 	clearAllComments(): void {
 		for (const thread of this.threads.values()) {
-			this.threadFilePaths.delete(thread)
 			thread.dispose()
 		}
 		this.threads.clear()
@@ -276,7 +238,6 @@ export class VscodeCommentReviewController extends CommentReviewController imple
 		const keysToRemove: string[] = []
 		for (const [key, thread] of this.threads.entries()) {
 			if (key.startsWith(filePath + ":")) {
-				this.threadFilePaths.delete(thread)
 				thread.dispose()
 				keysToRemove.push(key)
 			}
@@ -291,122 +252,6 @@ export class VscodeCommentReviewController extends CommentReviewController imple
 	 */
 	getThreadCount(): number {
 		return this.threads.size
-	}
-
-	/**
-	 * Handle a reply from the user
-	 */
-	private async handleReply(reply: vscode.CommentReply): Promise<void> {
-		const thread = reply.thread
-		const replyText = reply.text
-
-		// Add user's reply to the thread immediately
-		const userComment: vscode.Comment = {
-			body: new vscode.MarkdownString(replyText),
-			mode: vscode.CommentMode.Preview,
-			author: {
-				name: "You",
-			},
-		}
-		thread.comments = [...thread.comments, userComment]
-
-		// If we have a callback, get AI response
-		if (this.onReplyCallback) {
-			// Use stored absolute path (virtual URIs don't contain the full path)
-			const filePath = this.threadFilePaths.get(thread) || thread.uri.fsPath
-			const startLine = thread.range.start.line
-			const endLine = thread.range.end.line
-
-			// Collect existing comments for context (exclude the user's reply we just added)
-			const existingComments = thread.comments.slice(0, -1).map((c) => {
-				const author = c.author.name
-				const body = typeof c.body === "string" ? c.body : c.body.value
-				return `${author}: ${body}`
-			})
-
-			// Add an empty streaming comment that will be updated as chunks arrive
-			let streamingContent = ""
-			const updateStreamingComment = (content: string) => {
-				const streamingComment: vscode.Comment = {
-					body: new vscode.MarkdownString(content || "_Thinking..._"),
-					mode: vscode.CommentMode.Preview,
-					author: {
-						name: "Cline",
-						iconPath: vscode.Uri.parse(CLINE_AVATAR_URL),
-					},
-				}
-				thread.comments = [...thread.comments.slice(0, -1), streamingComment]
-			}
-
-			// Add initial thinking placeholder
-			const thinkingComment: vscode.Comment = {
-				body: new vscode.MarkdownString("_Thinking..._"),
-				mode: vscode.CommentMode.Preview,
-				author: {
-					name: "Cline",
-					iconPath: vscode.Uri.parse(CLINE_AVATAR_URL),
-				},
-			}
-			thread.comments = [...thread.comments, thinkingComment]
-
-			// Fire off the AI request with streaming callback
-			this.onReplyCallback(filePath, startLine, endLine, replyText, existingComments, (chunk) => {
-				// Append chunk and update the comment
-				streamingContent += chunk
-				updateStreamingComment(streamingContent)
-			})
-				.then(() => {
-					// Ensure final content is displayed
-					if (streamingContent) {
-						updateStreamingComment(streamingContent)
-					}
-				})
-				.catch((error) => {
-					// Show error
-					const errorComment: vscode.Comment = {
-						body: new vscode.MarkdownString(
-							`_Error getting response: ${error instanceof Error ? error.message : "Unknown error"}_`,
-						),
-						mode: vscode.CommentMode.Preview,
-						author: {
-							name: "Cline",
-							iconPath: vscode.Uri.parse(CLINE_AVATAR_URL),
-						},
-					}
-					thread.comments = [...thread.comments.slice(0, -1), errorComment]
-				})
-		}
-	}
-
-	/**
-	 * Handle adding the thread conversation to Cline's main chat
-	 */
-	private async handleAddToChat(thread: vscode.CommentThread): Promise<void> {
-		const filePath = this.threadFilePaths.get(thread) || thread.uri.fsPath
-		const startLine = thread.range.start.line + 1 // Convert to 1-indexed for display
-		const endLine = thread.range.end.line + 1
-
-		// Collect all comments from the thread
-		const conversation = thread.comments
-			.map((c) => {
-				const author = c.author.name === "You" ? "User" : c.author.name
-				const body = typeof c.body === "string" ? c.body : c.body.value
-				return `**${author}:** ${body}`
-			})
-			.join("\n\n")
-
-		// Format the context message
-		const contextMessage = `The following is a conversation from a code review comment on \`${filePath}\` (lines ${startLine}-${endLine}). The user would like to continue this discussion with you:
-
----
-
-${conversation}
-
----
-
-Please continue helping the user with their question about this code.`
-
-		await sendAddToInputEvent(contextMessage)
 	}
 
 	private getThreadKey(filePath: string, startLine: number, endLine: number): string {
@@ -443,9 +288,6 @@ Please continue helping the user with their question about this code.`
 	dispose(): void {
 		this.clearAllComments()
 		this.commentController.dispose()
-		for (const disposable of this.disposables) {
-			disposable.dispose()
-		}
 	}
 }
 

--- a/apps/vscode/src/shared/slashCommands.ts
+++ b/apps/vscode/src/shared/slashCommands.ts
@@ -39,13 +39,7 @@ export const BASE_SLASH_COMMANDS: SlashCommand[] = [
 ]
 
 // VS Code-only slash commands
-export const VSCODE_ONLY_COMMANDS: SlashCommand[] = [
-	{
-		name: "explain-changes",
-		description: "Explain code changes between git refs (PRs, commits, branches, etc.)",
-		section: "default",
-	},
-]
+export const VSCODE_ONLY_COMMANDS: SlashCommand[] = []
 
 // CLI-only slash commands (handled locally, not sent to backend)
 export const CLI_ONLY_COMMANDS: SlashCommand[] = [

--- a/apps/vscode/webview-ui/src/components/chat/ChatRow.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatRow.tsx
@@ -158,7 +158,6 @@ export const ChatRowContent = memo(
 			showFeatureTips,
 		} = useExtensionState()
 		const [seeNewChangesDisabled, setSeeNewChangesDisabled] = useState(false)
-		const [explainChangesDisabled, setExplainChangesDisabled] = useState(false)
 		const [quoteButtonState, setQuoteButtonState] = useState<QuoteButtonState>({
 			visible: false,
 			top: 0,
@@ -235,7 +234,6 @@ export const ChatRowContent = memo(
 		useEffect(() => {
 			return onRelinquishControl(() => {
 				setSeeNewChangesDisabled(false)
-				setExplainChangesDisabled(false)
 			})
 		}, [onRelinquishControl])
 
@@ -1025,13 +1023,11 @@ export const ChatRowContent = memo(
 
 						return (
 							<CompletionOutputRow
-								explainChangesDisabled={explainChangesDisabled}
 								handleQuoteClick={handleQuoteClick}
 								headClassNames={HEADER_CLASSNAMES}
 								messageTs={message.ts}
 								quoteButtonState={quoteButtonState}
 								seeNewChangesDisabled={seeNewChangesDisabled}
-								setExplainChangesDisabled={setExplainChangesDisabled}
 								setSeeNewChangesDisabled={setSeeNewChangesDisabled}
 								showActionRow={message.partial !== true && hasChanges}
 								text={text || ""}
@@ -1172,13 +1168,11 @@ export const ChatRowContent = memo(
 							const text = hasChanges ? message.text.slice(0, -COMPLETION_RESULT_CHANGES_FLAG.length) : message.text
 							return (
 								<CompletionOutputRow
-									explainChangesDisabled={explainChangesDisabled}
 									handleQuoteClick={handleQuoteClick}
 									headClassNames={HEADER_CLASSNAMES}
 									messageTs={message.ts}
 									quoteButtonState={quoteButtonState}
 									seeNewChangesDisabled={seeNewChangesDisabled}
-									setExplainChangesDisabled={setExplainChangesDisabled}
 									setSeeNewChangesDisabled={setSeeNewChangesDisabled}
 									showActionRow={message.partial !== true && hasChanges}
 									text={text || ""}

--- a/apps/vscode/webview-ui/src/components/chat/CompletionOutputRow.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/CompletionOutputRow.tsx
@@ -3,7 +3,6 @@ import { cn } from "@/lib/utils"
 import { MarkdownRow } from "./MarkdownRow"
 import { Int64Request } from "@shared/proto/cline/common"
 import { CheckIcon } from "lucide-react"
-import { PLATFORM_CONFIG, PlatformType } from "@/config/platform.config"
 import { TaskServiceClient } from "@/services/grpc-client"
 import { CopyButton } from "../common/CopyButton"
 import SuccessButton from "../common/SuccessButton"
@@ -18,8 +17,6 @@ interface CompletionOutputRowProps {
 	showActionRow?: boolean
 	seeNewChangesDisabled: boolean
 	setSeeNewChangesDisabled: (value: boolean) => void
-	explainChangesDisabled: boolean
-	setExplainChangesDisabled: (value: boolean) => void
 	messageTs: number
 }
 
@@ -31,8 +28,6 @@ export const CompletionOutputRow = memo(
 		showActionRow,
 		seeNewChangesDisabled,
 		setSeeNewChangesDisabled,
-		explainChangesDisabled,
-		setExplainChangesDisabled,
 		messageTs,
 		handleQuoteClick,
 	}: CompletionOutputRowProps) => {
@@ -60,10 +55,8 @@ export const CompletionOutputRow = memo(
 				{/* Action Buttons */}
 				{showActionRow && (
 					<CompletionOutputActionRow
-						explainChangesDisabled={explainChangesDisabled}
 						messageTs={messageTs}
 						seeNewChangesDisabled={seeNewChangesDisabled}
-						setExplainChangesDisabled={setExplainChangesDisabled}
 						setSeeNewChangesDisabled={setSeeNewChangesDisabled}
 					/>
 				)}
@@ -78,14 +71,10 @@ const CompletionOutputActionRow = memo(
 	({
 		seeNewChangesDisabled,
 		setSeeNewChangesDisabled,
-		explainChangesDisabled,
-		setExplainChangesDisabled,
 		messageTs,
 	}: {
 		seeNewChangesDisabled: boolean
 		setSeeNewChangesDisabled: (value: boolean) => void
-		explainChangesDisabled: boolean
-		setExplainChangesDisabled: (value: boolean) => void
 		messageTs: number
 	}) => {
 		return (
@@ -107,28 +96,6 @@ const CompletionOutputActionRow = memo(
 					<i className="codicon codicon-new-file" style={{ marginRight: 6 }} />
 					View Changes
 				</SuccessButton>
-
-				{PLATFORM_CONFIG.type === PlatformType.VSCODE && (
-					<SuccessButton
-						disabled={explainChangesDisabled}
-						onClick={() => {
-							setExplainChangesDisabled(true)
-							TaskServiceClient.explainChanges({
-								metadata: {},
-								messageTs,
-							}).catch((err) => {
-								console.error("Failed to explain changes:", err)
-								setExplainChangesDisabled(false)
-							})
-						}}
-						style={{
-							cursor: explainChangesDisabled ? "wait" : "pointer",
-							width: "100%",
-						}}>
-						<i className="codicon codicon-comment-discussion" style={{ marginRight: 6 }} />
-						{explainChangesDisabled ? "Explaining..." : "Explain Changes"}
-					</SuccessButton>
-				)}
 			</div>
 		)
 	},


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Removes the VS Code Explain Changes feature surfaces for now:

- Removes the task completion "Explain Changes" action button and its webview state/RPC wiring.
- Removes `/explain-changes` from VS Code slash command suggestions.
- Removes the generated review-comment reply/add-to-chat VS Code command contributions and disables replies on generated review comments.

This keeps the normal "View Changes" completion action intact while removing the Explain Changes and "Reply to Cline" entry points.

### Test Procedure

- Parsed `apps/vscode/package.json` with Node to verify the manifest remains valid JSON.
- Ran `git diff --check` successfully.
- Searched the edited UI, shared command, manifest, and review-controller paths to confirm the removed strings and command references are gone.
- Attempted `npm run check-types` from `apps/vscode`, but it could not run in this worktree because dependencies are not installed; proto generation failed while resolving the missing `chalk` package.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. This removes VS Code UI/menu entry points rather than adding new UI.

### Additional Notes

Local full type-checking was blocked by missing dependencies in the worktree, so CI should provide the complete verification run.
