### PR TITLE
Fix delete task tooltip size display

### DIFF
--- a/apps/vscode/webview-ui/src/components/chat/task-header/buttons/DeleteTaskButton.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/task-header/buttons/DeleteTaskButton.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { cn } from "@/lib/utils"
 import { TaskServiceClient } from "@/services/grpc-client"
-import { formatSize } from "@/utils/format"
+import { formatDeleteTaskSizeLabel } from "./formatDeleteTaskSizeLabel"
 
 const DeleteTaskButton: React.FC<{
 	taskId?: string
@@ -12,7 +12,7 @@ const DeleteTaskButton: React.FC<{
 	className?: string
 }> = ({ taskId, className, taskSize }) => (
 	<Tooltip>
-		<TooltipContent>{`Delete Task (size: ${taskSize ? formatSize(taskSize) : "--"})`}</TooltipContent>
+		<TooltipContent>{`Delete Task (size: ${formatDeleteTaskSizeLabel(taskSize)})`}</TooltipContent>
 		<TooltipTrigger className={cn("flex items-center", className)}>
 			<Button
 				aria-label="Delete Task"

--- a/apps/vscode/webview-ui/src/components/chat/task-header/buttons/formatDeleteTaskSizeLabel.test.ts
+++ b/apps/vscode/webview-ui/src/components/chat/task-header/buttons/formatDeleteTaskSizeLabel.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest"
+import { formatDeleteTaskSizeLabel } from "./formatDeleteTaskSizeLabel"
+
+describe("formatDeleteTaskSizeLabel", () => {
+	it("formats a zero byte task size", () => {
+		expect(formatDeleteTaskSizeLabel(0)).toBe("0 B")
+	})
+
+	it("formats a non-zero task size", () => {
+		expect(formatDeleteTaskSizeLabel(42)).toBe("42 B")
+	})
+
+	it("shows a placeholder when task size is unavailable", () => {
+		expect(formatDeleteTaskSizeLabel()).toBe("--")
+	})
+})

--- a/apps/vscode/webview-ui/src/components/chat/task-header/buttons/formatDeleteTaskSizeLabel.ts
+++ b/apps/vscode/webview-ui/src/components/chat/task-header/buttons/formatDeleteTaskSizeLabel.ts
@@ -1,0 +1,5 @@
+import { formatSize } from "@/utils/format"
+
+export function formatDeleteTaskSizeLabel(taskSize?: number) {
+	return taskSize === undefined ? "--" : formatSize(taskSize)
+}


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Fixes the delete task tooltip so it treats a task size of `0` as a known size instead of falling back to the unknown-size placeholder. The tooltip now shows `Delete Task (size: 0 B)` for zero-byte tasks while still showing `--` when no task size is available.

### Test Procedure

- Ran `npm test -- src/components/chat/task-header/buttons/formatDeleteTaskSizeLabel.test.ts` in `apps/vscode/webview-ui`.
- Ran scoped Biome check for the touched files with `apps/vscode/biome.jsonc`.
- Ran `npm run build` in `apps/vscode/webview-ui` after generating protobuf clients through the VS Code package setup.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - tooltip text formatting bug fix covered by focused test.

### Additional Notes

The full webview build requires generated protobuf clients. In this environment, `grpc-tools` needed to be rebuilt with scripts enabled because npm was configured with `ignore-scripts=true`; after that, `npm run protos` generated the required ignored client files and the webview build passed.
