### PR TITLE
Fix SDK task size in delete tooltip

### DIFF
--- a/apps/vscode/src/sdk/sdk-task-history.test.ts
+++ b/apps/vscode/src/sdk/sdk-task-history.test.ts
@@ -1,5 +1,6 @@
 import type { SessionHistoryRecord } from "@cline/core"
 import type { HistoryItem } from "@shared/HistoryItem"
+import getFolderSize from "get-folder-size"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { McpHub } from "@/services/mcp/McpHub"
 import type { TelemetryService } from "@/services/telemetry/TelemetryService"
@@ -53,13 +54,18 @@ vi.mock("./legacy-state-reader", () => ({
 	),
 }))
 
-vi.mock("./cline-session-factory", async (importOriginal) => ({
-	...(await importOriginal<typeof import("./cline-session-factory")>()),
+vi.mock("./cline-session-factory", () => ({
 	buildSessionConfig: vi.fn(async ({ cwd, workspaceRoot, mode }) => ({
 		cwd,
 		workspaceRoot,
 		mode,
 	})),
+}))
+
+vi.mock("get-folder-size", () => ({
+	default: {
+		loose: vi.fn(),
+	},
 }))
 
 describe("SdkTaskHistory", () => {
@@ -69,6 +75,7 @@ describe("SdkTaskHistory", () => {
 		legacyStateReaderMock.apiConversationHistory = []
 		legacyStateReaderMock.apiConversationHistoryByDataDir.clear()
 		vi.clearAllMocks()
+		vi.mocked(getFolderSize.loose).mockReset()
 	})
 
 	afterEach(() => {
@@ -222,6 +229,71 @@ describe("SdkTaskHistory", () => {
 		})
 	})
 
+	it("backfills SDK task size from the session artifact directory", async () => {
+		vi.mocked(getFolderSize.loose).mockResolvedValue(4096 as never)
+		const { history, updateSession } = makeHistory([
+			makeSessionRecord("task-1", {
+				metadata: { title: "Build feature" },
+				messagesPath: "/tmp/cline/sessions/task-1/task-1.messages.json",
+			}),
+		])
+
+		await expect(history.findHistoryItem("task-1")).resolves.toMatchObject({
+			id: "task-1",
+			size: 4096,
+		})
+
+		expect(getFolderSize.loose).toHaveBeenCalledWith("/tmp/cline/sessions/task-1", { bigint: false })
+		expect(updateSession).toHaveBeenCalledWith(
+			"task-1",
+			expect.objectContaining({
+				metadata: expect.objectContaining({
+					title: "Build feature",
+					size: 4096,
+				}),
+			}),
+		)
+	})
+
+	it("caches zero-byte SDK task size from the session artifact directory", async () => {
+		vi.mocked(getFolderSize.loose).mockResolvedValue(0 as never)
+		const { history, updateSession } = makeHistory([
+			makeSessionRecord("task-1", {
+				messagesPath: "/tmp/cline/sessions/task-1/task-1.messages.json",
+			}),
+		])
+
+		await expect(history.findHistoryItem("task-1")).resolves.toMatchObject({
+			id: "task-1",
+			size: 0,
+		})
+		await expect(history.findHistoryItem("task-1")).resolves.toMatchObject({
+			id: "task-1",
+			size: 0,
+		})
+
+		expect(getFolderSize.loose).toHaveBeenCalledTimes(1)
+		expect(updateSession).toHaveBeenCalledTimes(1)
+		expect(updateSession).toHaveBeenCalledWith(
+			"task-1",
+			expect.objectContaining({
+				metadata: expect.objectContaining({ size: 0 }),
+			}),
+		)
+	})
+
+	it("keeps existing SDK task size metadata without measuring artifacts", async () => {
+		const { history, updateSession } = makeHistory([makeSessionRecord("task-1", { metadata: { size: 2048 } })])
+
+		await expect(history.findHistoryItem("task-1")).resolves.toMatchObject({
+			id: "task-1",
+			size: 2048,
+		})
+
+		expect(getFolderSize.loose).not.toHaveBeenCalled()
+		expect(updateSession).not.toHaveBeenCalled()
+	})
+
 	it("returns undefined when a task is missing from SDK history", async () => {
 		const { history } = makeHistory([])
 
@@ -254,6 +326,43 @@ describe("SdkTaskHistory", () => {
 					tokensIn: 5,
 					totalCost: 0.02,
 				}),
+			}),
+		)
+	})
+
+	it("refreshes SDK task size from artifacts when updating history", async () => {
+		vi.mocked(getFolderSize.loose).mockResolvedValue(8192 as never)
+		const existing = makeSessionRecord("task-1", {
+			metadata: { size: 1024 },
+			messagesPath: "/tmp/cline/sessions/task-1/task-1.messages.json",
+		})
+		const { history, updateSession } = makeHistory([existing])
+
+		await history.updateTaskHistoryItem(makeHistoryItem("task-1", { size: 1024 }))
+
+		expect(getFolderSize.loose).toHaveBeenCalledWith("/tmp/cline/sessions/task-1", { bigint: false })
+		expect(updateSession).toHaveBeenCalledWith(
+			"task-1",
+			expect.objectContaining({
+				metadata: expect.objectContaining({ size: 8192 }),
+			}),
+		)
+	})
+
+	it("does not retry artifact size when refresh cannot read artifacts", async () => {
+		vi.mocked(getFolderSize.loose).mockRejectedValue(new Error("unreadable"))
+		const existing = makeSessionRecord("task-1", {
+			messagesPath: "/tmp/cline/sessions/task-1/task-1.messages.json",
+		})
+		const { history, updateSession } = makeHistory([existing])
+
+		await history.updateTaskHistoryItem(makeHistoryItem("task-1"))
+
+		expect(getFolderSize.loose).toHaveBeenCalledTimes(1)
+		expect(updateSession).toHaveBeenCalledWith(
+			"task-1",
+			expect.objectContaining({
+				metadata: expect.objectContaining({ size: 0 }),
 			}),
 		)
 	})

--- a/apps/vscode/src/sdk/sdk-task-history.test.ts
+++ b/apps/vscode/src/sdk/sdk-task-history.test.ts
@@ -282,33 +282,6 @@ describe("SdkTaskHistory", () => {
 		)
 	})
 
-it("caches zero-byte SDK task size from the session artifact directory", async () => {
-		vi.mocked(getFolderSize.loose).mockResolvedValue(0 as never)
-		const { history, updateSession } = makeHistory([
-			makeSessionRecord("task-1", {
-				messagesPath: "/tmp/cline/sessions/task-1/task-1.messages.json",
-			}),
-		])
-
-		await expect(history.findHistoryItem("task-1")).resolves.toMatchObject({
-			id: "task-1",
-			size: 0,
-		})
-		await expect(history.findHistoryItem("task-1")).resolves.toMatchObject({
-			id: "task-1",
-			size: 0,
-		})
-
-		expect(getFolderSize.loose).toHaveBeenCalledTimes(1)
-		expect(updateSession).toHaveBeenCalledTimes(1)
-		expect(updateSession).toHaveBeenCalledWith(
-			"task-1",
-			expect.objectContaining({
-				metadata: expect.objectContaining({ size: 0 }),
-			}),
-		)
-	})
-
 	it("keeps existing SDK task size metadata without measuring artifacts", async () => {
 		const { history, updateSession } = makeHistory([makeSessionRecord("task-1", { metadata: { size: 2048 } })])
 
@@ -357,7 +330,7 @@ it("caches zero-byte SDK task size from the session artifact directory", async (
 		)
 	})
 
-	it("refreshes SDK task size from artifacts when updating history", async () => {
+	it("keeps cached SDK task size when updating history without measuring artifacts", async () => {
 		vi.mocked(getFolderSize.loose).mockResolvedValue(8192 as never)
 		const existing = makeSessionRecord("task-1", {
 			metadata: { size: 1024 },
@@ -365,51 +338,29 @@ it("caches zero-byte SDK task size from the session artifact directory", async (
 		})
 		const { history, updateSession } = makeHistory([existing])
 
-		await history.updateTaskHistoryItem(makeHistoryItem("task-1", { size: 1024 }))
+		await history.updateTaskHistoryItem(makeHistoryItem("task-1"))
 
-		expect(getFolderSize.loose).toHaveBeenCalledWith("/tmp/cline/sessions/task-1", { bigint: false })
+		expect(getFolderSize.loose).not.toHaveBeenCalled()
 		expect(updateSession).toHaveBeenCalledWith(
 			"task-1",
 			expect.objectContaining({
-				metadata: expect.objectContaining({ size: 8192 }),
+				metadata: expect.objectContaining({ size: 1024 }),
 			}),
 		)
 	})
 
-	it("does not retry artifact size when refresh cannot read artifacts", async () => {
+	it("does not cache unavailable artifact size as zero", async () => {
 		vi.mocked(getFolderSize.loose).mockRejectedValue(new Error("unreadable"))
 		const existing = makeSessionRecord("task-1", {
 			messagesPath: "/tmp/cline/sessions/task-1/task-1.messages.json",
 		})
 		const { history, updateSession } = makeHistory([existing])
 
-		await history.updateTaskHistoryItem(makeHistoryItem("task-1"))
+		const result = await history.findHistoryItem("task-1")
 
+		expect(result?.size).toBeUndefined()
 		expect(getFolderSize.loose).toHaveBeenCalledTimes(1)
-		expect(updateSession).toHaveBeenCalledWith(
-			"task-1",
-			expect.objectContaining({
-				metadata: expect.objectContaining({ size: 0 }),
-			}),
-		)
-	})
-
-	it("does not retry artifact size when refresh cannot read artifacts", async () => {
-		vi.mocked(getFolderSize.loose).mockRejectedValue(new Error("unreadable"))
-		const existing = makeSessionRecord("task-1", {
-			messagesPath: "/tmp/cline/sessions/task-1/task-1.messages.json",
-		})
-		const { history, updateSession } = makeHistory([existing])
-
-		await history.updateTaskHistoryItem(makeHistoryItem("task-1"))
-
-		expect(getFolderSize.loose).toHaveBeenCalledTimes(1)
-		expect(updateSession).toHaveBeenCalledWith(
-			"task-1",
-			expect.objectContaining({
-				metadata: expect.objectContaining({ size: 0 }),
-			}),
-		)
+		expect(updateSession).not.toHaveBeenCalled()
 	})
 
 	it("deletes SDK sessions", async () => {

--- a/apps/vscode/src/sdk/sdk-task-history.test.ts
+++ b/apps/vscode/src/sdk/sdk-task-history.test.ts
@@ -282,6 +282,33 @@ describe("SdkTaskHistory", () => {
 		)
 	})
 
+it("caches zero-byte SDK task size from the session artifact directory", async () => {
+		vi.mocked(getFolderSize.loose).mockResolvedValue(0 as never)
+		const { history, updateSession } = makeHistory([
+			makeSessionRecord("task-1", {
+				messagesPath: "/tmp/cline/sessions/task-1/task-1.messages.json",
+			}),
+		])
+
+		await expect(history.findHistoryItem("task-1")).resolves.toMatchObject({
+			id: "task-1",
+			size: 0,
+		})
+		await expect(history.findHistoryItem("task-1")).resolves.toMatchObject({
+			id: "task-1",
+			size: 0,
+		})
+
+		expect(getFolderSize.loose).toHaveBeenCalledTimes(1)
+		expect(updateSession).toHaveBeenCalledTimes(1)
+		expect(updateSession).toHaveBeenCalledWith(
+			"task-1",
+			expect.objectContaining({
+				metadata: expect.objectContaining({ size: 0 }),
+			}),
+		)
+	})
+
 	it("keeps existing SDK task size metadata without measuring artifacts", async () => {
 		const { history, updateSession } = makeHistory([makeSessionRecord("task-1", { metadata: { size: 2048 } })])
 
@@ -345,6 +372,24 @@ describe("SdkTaskHistory", () => {
 			"task-1",
 			expect.objectContaining({
 				metadata: expect.objectContaining({ size: 8192 }),
+			}),
+		)
+	})
+
+	it("does not retry artifact size when refresh cannot read artifacts", async () => {
+		vi.mocked(getFolderSize.loose).mockRejectedValue(new Error("unreadable"))
+		const existing = makeSessionRecord("task-1", {
+			messagesPath: "/tmp/cline/sessions/task-1/task-1.messages.json",
+		})
+		const { history, updateSession } = makeHistory([existing])
+
+		await history.updateTaskHistoryItem(makeHistoryItem("task-1"))
+
+		expect(getFolderSize.loose).toHaveBeenCalledTimes(1)
+		expect(updateSession).toHaveBeenCalledWith(
+			"task-1",
+			expect.objectContaining({
+				metadata: expect.objectContaining({ size: 0 }),
 			}),
 		)
 	})

--- a/apps/vscode/src/sdk/sdk-task-history.ts
+++ b/apps/vscode/src/sdk/sdk-task-history.ts
@@ -234,8 +234,7 @@ function legacyApiHistoryToSdkMessages(apiHistory: unknown[], historyItem: Histo
 
 export function sessionHistoryRecordToHistoryItem(item: SessionHistoryRecord): HistoryItem {
 	const metadata = item.metadata
-	const size = metadataNumber(metadata, "size")
-	const historyItem: HistoryItem = {
+	return {
 		id: item.sessionId,
 		ts: dateStringToTimestamp(item.updatedAt ?? item.endedAt ?? item.startedAt),
 		task: formatDisplayUserInput(metadataString(metadata, "title") ?? item.prompt ?? ""),
@@ -244,14 +243,11 @@ export function sessionHistoryRecordToHistoryItem(item: SessionHistoryRecord): H
 		cacheWrites: metadataNumber(metadata, "cacheWrites") ?? 0,
 		cacheReads: metadataNumber(metadata, "cacheReads") ?? 0,
 		totalCost: metadataNumber(metadata, "totalCost") ?? 0,
+		size: metadataNumber(metadata, "size"),
 		isFavorited: metadataBoolean(metadata, "isFavorited") ?? metadataBoolean(metadata, "is_favorited") ?? false,
 		modelId: item.model || metadataString(metadata, "modelId") || "",
 		cwdOnTaskInitialization: item.cwd ?? item.workspaceRoot,
 	}
-	if (size !== undefined) {
-		historyItem.size = size
-	}
-	return historyItem
 }
 
 export class SdkTaskHistory {
@@ -597,20 +593,19 @@ export class SdkTaskHistory {
 	private async updateSession(sessionId: string, item: HistoryItem): Promise<void> {
 		await this.withHistoryHost(async (host) => {
 			const existing = await host.get(sessionId)
-			const resolvedSize = await this.resolveTaskSize(item, existing as SessionHistoryRecord | undefined, {
-				refreshArtifactSize: true,
-			})
-			const metadata = {
+			const metadata: Record<string, unknown> = {
 				...(existing?.metadata ?? {}),
 				title: item.task,
 				isFavorited: item.isFavorited ?? false,
-				size: resolvedSize ?? 0,
 				totalCost: item.totalCost ?? 0,
 				tokensIn: item.tokensIn ?? 0,
 				tokensOut: item.tokensOut ?? 0,
 				cacheWrites: item.cacheWrites ?? 0,
 				cacheReads: item.cacheReads ?? 0,
 				modelId: item.modelId ?? existing?.model ?? "",
+			}
+			if (item.size !== undefined) {
+				metadata.size = item.size
 			}
 			await host.update(sessionId, {
 				prompt: item.task,
@@ -640,11 +635,7 @@ export class SdkTaskHistory {
 			}
 
 			const historyItem = sessionHistoryRecordToHistoryItem(sdkRecord as SessionHistoryRecord)
-			const resolvedSize = await this.resolveTaskSize(historyItem, sdkRecord as SessionHistoryRecord)
-			if (resolvedSize !== undefined) {
-				historyItem.size = resolvedSize
-			}
-			await this.persistResolvedTaskSize(host, sdkRecord as SessionHistoryRecord, resolvedSize)
+			historyItem.size = await this.getCachedTaskSize(host, sdkRecord as SessionHistoryRecord)
 			return historyItem
 		})
 		if (sdkHistoryItem) {
@@ -717,32 +708,16 @@ export class SdkTaskHistory {
 		await this.updateTaskHistoryItem(historyItem)
 	}
 
-	private async resolveTaskSize(
-		item: HistoryItem,
-		record?: SessionHistoryRecord,
-		options: { refreshArtifactSize?: boolean } = {},
-	): Promise<number | undefined> {
-		let attemptedArtifactSize = false
-
-		if (options.refreshArtifactSize) {
-			const artifactSize = record ? await this.getSessionArtifactSize(record) : undefined
-			attemptedArtifactSize = true
-			if (artifactSize !== undefined) {
-				return artifactSize
-			}
+	private async getCachedTaskSize(host: VscodeSessionHost, record: SessionHistoryRecord): Promise<number | undefined> {
+		// metadata.size is a display cache: fill it when absent, and let explicit item.size updates replace it.
+		const cachedSize = metadataNumber(record.metadata, "size")
+		if (cachedSize !== undefined && cachedSize >= 0) {
+			return cachedSize
 		}
 
-		if (typeof item.size === "number" && Number.isFinite(item.size) && item.size >= 0) {
-			return item.size
-		}
-
-		const metadataSize = metadataNumber(record?.metadata, "size")
-		if (metadataSize !== undefined && metadataSize >= 0) {
-			return metadataSize
-		}
-
-		const artifactSize = record && !attemptedArtifactSize ? await this.getSessionArtifactSize(record) : undefined
+		const artifactSize = await this.getSessionArtifactSize(record)
 		if (artifactSize !== undefined) {
+			await this.cacheTaskSize(host, record, artifactSize)
 			return artifactSize
 		}
 
@@ -766,12 +741,8 @@ export class SdkTaskHistory {
 		}
 	}
 
-	private async persistResolvedTaskSize(
-		host: VscodeSessionHost,
-		record: SessionHistoryRecord,
-		size: number | undefined,
-	): Promise<void> {
-		if (size === undefined || !Number.isFinite(size) || size < 0 || metadataNumber(record.metadata, "size") === size) {
+	private async cacheTaskSize(host: VscodeSessionHost, record: SessionHistoryRecord, size: number): Promise<void> {
+		if (!Number.isFinite(size) || size < 0 || metadataNumber(record.metadata, "size") === size) {
 			return
 		}
 

--- a/apps/vscode/src/sdk/sdk-task-history.ts
+++ b/apps/vscode/src/sdk/sdk-task-history.ts
@@ -1,8 +1,10 @@
+import path from "node:path"
 import type { ClineCoreListHistoryOptions, SessionHistoryRecord } from "@cline/core"
 import type { Message as SdkMessage } from "@cline/llms"
 import { type ContentBlock, formatDisplayUserInput, type MessageWithMetadata } from "@cline/shared"
 import type { ClineMessage } from "@shared/ExtensionMessage"
 import type { HistoryItem } from "@shared/HistoryItem"
+import getFolderSize from "get-folder-size"
 import type { McpHub } from "@/services/mcp/McpHub"
 import type { TelemetryService } from "@/services/telemetry/TelemetryService"
 import { Logger } from "@/shared/services/Logger"
@@ -232,7 +234,8 @@ function legacyApiHistoryToSdkMessages(apiHistory: unknown[], historyItem: Histo
 
 export function sessionHistoryRecordToHistoryItem(item: SessionHistoryRecord): HistoryItem {
 	const metadata = item.metadata
-	return {
+	const size = metadataNumber(metadata, "size")
+	const historyItem: HistoryItem = {
 		id: item.sessionId,
 		ts: dateStringToTimestamp(item.updatedAt ?? item.endedAt ?? item.startedAt),
 		task: formatDisplayUserInput(metadataString(metadata, "title") ?? item.prompt ?? ""),
@@ -241,11 +244,14 @@ export function sessionHistoryRecordToHistoryItem(item: SessionHistoryRecord): H
 		cacheWrites: metadataNumber(metadata, "cacheWrites") ?? 0,
 		cacheReads: metadataNumber(metadata, "cacheReads") ?? 0,
 		totalCost: metadataNumber(metadata, "totalCost") ?? 0,
-		size: metadataNumber(metadata, "size") ?? 0,
 		isFavorited: metadataBoolean(metadata, "isFavorited") ?? metadataBoolean(metadata, "is_favorited") ?? false,
 		modelId: item.model || metadataString(metadata, "modelId") || "",
 		cwdOnTaskInitialization: item.cwd ?? item.workspaceRoot,
 	}
+	if (size !== undefined) {
+		historyItem.size = size
+	}
+	return historyItem
 }
 
 export class SdkTaskHistory {
@@ -591,11 +597,14 @@ export class SdkTaskHistory {
 	private async updateSession(sessionId: string, item: HistoryItem): Promise<void> {
 		await this.withHistoryHost(async (host) => {
 			const existing = await host.get(sessionId)
+			const resolvedSize = await this.resolveTaskSize(item, existing as SessionHistoryRecord | undefined, {
+				refreshArtifactSize: true,
+			})
 			const metadata = {
 				...(existing?.metadata ?? {}),
 				title: item.task,
 				isFavorited: item.isFavorited ?? false,
-				size: item.size ?? 0,
+				size: resolvedSize ?? 0,
 				totalCost: item.totalCost ?? 0,
 				tokensIn: item.tokensIn ?? 0,
 				tokensOut: item.tokensOut ?? 0,
@@ -624,9 +633,22 @@ export class SdkTaskHistory {
 	}
 
 	async findHistoryItem(taskId: string): Promise<HistoryItem | undefined> {
-		const sdkRecord = await this.withHistoryHost((host) => host.get(taskId))
-		if (sdkRecord && sdkRecord.isSubagent !== true) {
-			return sessionHistoryRecordToHistoryItem(sdkRecord as SessionHistoryRecord)
+		const sdkHistoryItem = await this.withHistoryHost(async (host) => {
+			const sdkRecord = await host.get(taskId)
+			if (!sdkRecord || sdkRecord.isSubagent === true) {
+				return undefined
+			}
+
+			const historyItem = sessionHistoryRecordToHistoryItem(sdkRecord as SessionHistoryRecord)
+			const resolvedSize = await this.resolveTaskSize(historyItem, sdkRecord as SessionHistoryRecord)
+			if (resolvedSize !== undefined) {
+				historyItem.size = resolvedSize
+			}
+			await this.persistResolvedTaskSize(host, sdkRecord as SessionHistoryRecord, resolvedSize)
+			return historyItem
+		})
+		if (sdkHistoryItem) {
+			return sdkHistoryItem
 		}
 
 		const legacyItem = this.findLegacyTask(taskId)?.item
@@ -693,5 +715,72 @@ export class SdkTaskHistory {
 		historyItem.ts = Date.now()
 
 		await this.updateTaskHistoryItem(historyItem)
+	}
+
+	private async resolveTaskSize(
+		item: HistoryItem,
+		record?: SessionHistoryRecord,
+		options: { refreshArtifactSize?: boolean } = {},
+	): Promise<number | undefined> {
+		let attemptedArtifactSize = false
+
+		if (options.refreshArtifactSize) {
+			const artifactSize = record ? await this.getSessionArtifactSize(record) : undefined
+			attemptedArtifactSize = true
+			if (artifactSize !== undefined) {
+				return artifactSize
+			}
+		}
+
+		if (typeof item.size === "number" && Number.isFinite(item.size) && item.size >= 0) {
+			return item.size
+		}
+
+		const metadataSize = metadataNumber(record?.metadata, "size")
+		if (metadataSize !== undefined && metadataSize >= 0) {
+			return metadataSize
+		}
+
+		const artifactSize = record && !attemptedArtifactSize ? await this.getSessionArtifactSize(record) : undefined
+		if (artifactSize !== undefined) {
+			return artifactSize
+		}
+
+		return undefined
+	}
+
+	private async getSessionArtifactSize(record: SessionHistoryRecord): Promise<number | undefined> {
+		const messagesPath = typeof record.messagesPath === "string" ? record.messagesPath.trim() : ""
+		if (!messagesPath) {
+			return undefined
+		}
+
+		try {
+			const size = await getFolderSize.loose(path.dirname(messagesPath), {
+				bigint: false,
+			})
+			return Number.isFinite(size) ? size : undefined
+		} catch (error) {
+			Logger.warn(`[SdkTaskHistory] Failed to calculate SDK session size: ${record.sessionId}`, error)
+			return undefined
+		}
+	}
+
+	private async persistResolvedTaskSize(
+		host: VscodeSessionHost,
+		record: SessionHistoryRecord,
+		size: number | undefined,
+	): Promise<void> {
+		if (size === undefined || !Number.isFinite(size) || size < 0 || metadataNumber(record.metadata, "size") === size) {
+			return
+		}
+
+		await host.update(record.sessionId, {
+			metadata: {
+				...(record.metadata ?? {}),
+				size,
+			},
+		})
+		this.invalidateMetadataHistoryCache()
 	}
 }

--- a/apps/vscode/webview-ui/src/components/chat/task-header/buttons/DeleteTaskButton.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/task-header/buttons/DeleteTaskButton.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { cn } from "@/lib/utils"
 import { TaskServiceClient } from "@/services/grpc-client"
-import { formatSize } from "@/utils/format"
+import { formatDeleteTaskSizeLabel } from "./formatDeleteTaskSizeLabel"
 
 const DeleteTaskButton: React.FC<{
 	taskId?: string
@@ -12,7 +12,7 @@ const DeleteTaskButton: React.FC<{
 	className?: string
 }> = ({ taskId, className, taskSize }) => (
 	<Tooltip>
-		<TooltipContent>{`Delete Task (size: ${taskSize ? formatSize(taskSize) : "--"})`}</TooltipContent>
+		<TooltipContent>{`Delete Task (size: ${formatDeleteTaskSizeLabel(taskSize)})`}</TooltipContent>
 		<TooltipTrigger className={cn("flex items-center", className)}>
 			<Button
 				aria-label="Delete Task"

--- a/apps/vscode/webview-ui/src/components/chat/task-header/buttons/formatDeleteTaskSizeLabel.test.ts
+++ b/apps/vscode/webview-ui/src/components/chat/task-header/buttons/formatDeleteTaskSizeLabel.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest"
+import { formatDeleteTaskSizeLabel } from "./formatDeleteTaskSizeLabel"
+
+describe("formatDeleteTaskSizeLabel", () => {
+	it("formats a zero byte task size", () => {
+		expect(formatDeleteTaskSizeLabel(0)).toBe("0 B")
+	})
+
+	it("formats a non-zero task size", () => {
+		expect(formatDeleteTaskSizeLabel(42)).toBe("42 B")
+	})
+
+	it("shows a placeholder when task size is unavailable", () => {
+		expect(formatDeleteTaskSizeLabel()).toBe("--")
+	})
+})

--- a/apps/vscode/webview-ui/src/components/chat/task-header/buttons/formatDeleteTaskSizeLabel.ts
+++ b/apps/vscode/webview-ui/src/components/chat/task-header/buttons/formatDeleteTaskSizeLabel.ts
@@ -1,0 +1,5 @@
+import { formatSize } from "@/utils/format"
+
+export function formatDeleteTaskSizeLabel(taskSize?: number) {
+	return taskSize === undefined ? "--" : formatSize(taskSize)
+}


### PR DESCRIPTION
### Related Issue

**Issue:** ENG-2052

### Description

Fixes the SDK migration path where the task header delete tooltip could show `--` instead of the task size.

<img width="336" height="178" alt="image" src="https://github.com/user-attachments/assets/37d19169-7f1d-4739-9f57-9152d23a36fe" />


SDK-backed task history now resolves missing task sizes from the persisted session artifact directory and writes the resolved size back to session metadata. The delete tooltip also formats an explicit `0` byte size as `0 B` instead of treating it as unavailable.

### Test Procedure

- `npm run check-types`
- `npx vitest run --config vitest.config.ts src/sdk/sdk-task-history.test.ts`
- `cd webview-ui && npx vitest run src/components/chat/task-header/buttons/formatDeleteTaskSizeLabel.test.ts`

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. Tooltip formatting and SDK history size backfill are covered by focused unit tests.

### Additional Notes

Targets the SDK migration `dpc/sdk-migration-simpler-login` branch; opening this against `main` would include the broader migration branch diff.
