### PR TITLE
fix(diff): preserve EOF newline state in replacements

### DIFF
--- a/apps/vscode/src/core/assistant-message/diff.test.ts
+++ b/apps/vscode/src/core/assistant-message/diff.test.ts
@@ -276,6 +276,18 @@ replaced
 		expect(result2).to.equal(expected)
 	})
 
+	it("preserves a single blank replacement for an entire file without a trailing newline", async () => {
+		const original = "line1"
+		const diff = ["------- SEARCH", "line1", "=======", "", "+++++++ REPLACE"].join("\n")
+		const expected = "\n"
+
+		const result1 = await cnfc(diff, original, true)
+		const result2 = await cnfc2(diff, original, true)
+
+		expect(result1.newContent).to.equal(expected)
+		expect(result2).to.equal(expected)
+	})
+
 	it("preserves an intentionally blank final replacement line", async () => {
 		const original = "line1\nline2"
 		const diff = ["------- SEARCH", "line2", "=======", "", "", "+++++++ REPLACE"].join("\n")

--- a/apps/vscode/src/core/assistant-message/diff.test.ts
+++ b/apps/vscode/src/core/assistant-message/diff.test.ts
@@ -252,6 +252,18 @@ replaced
 		}
 	})
 
+	it("does not append a trailing newline when replacing the final line of a file without one", async () => {
+		const original = "line1\nline2"
+		const diff = ["------- SEARCH", "line2", "=======", "updated line2", "+++++++ REPLACE"].join("\n")
+		const expected = "line1\nupdated line2"
+
+		const result1 = await cnfc(diff, original, true)
+		const result2 = await cnfc2(diff, original, true)
+
+		expect(result1.newContent).to.equal(expected)
+		expect(result2).to.equal(expected)
+	})
+
 	it("should handle missing final REPLACE marker when isFinal is true", async () => {
 		const original = "line1\nline2\nline3"
 		const diff = `------- SEARCH

--- a/apps/vscode/src/core/assistant-message/diff.test.ts
+++ b/apps/vscode/src/core/assistant-message/diff.test.ts
@@ -264,6 +264,30 @@ replaced
 		expect(result2).to.equal(expected)
 	})
 
+	it("preserves an intentionally added trailing newline at EOF", async () => {
+		const original = "line1\nline2"
+		const diff = ["------- SEARCH", "line2", "=======", "updated line2", "", "+++++++ REPLACE"].join("\n")
+		const expected = "line1\nupdated line2\n"
+
+		const result1 = await cnfc(diff, original, true)
+		const result2 = await cnfc2(diff, original, true)
+
+		expect(result1.newContent).to.equal(expected)
+		expect(result2).to.equal(expected)
+	})
+
+	it("preserves an intentionally blank final replacement line", async () => {
+		const original = "line1\nline2"
+		const diff = ["------- SEARCH", "line2", "=======", "", "", "+++++++ REPLACE"].join("\n")
+		const expected = "line1\n\n"
+
+		const result1 = await cnfc(diff, original, true)
+		const result2 = await cnfc2(diff, original, true)
+
+		expect(result1.newContent).to.equal(expected)
+		expect(result2).to.equal(expected)
+	})
+
 	it("should handle missing final REPLACE marker when isFinal is true", async () => {
 		const original = "line1\nline2\nline3"
 		const diff = `------- SEARCH

--- a/apps/vscode/src/core/assistant-message/diff.ts
+++ b/apps/vscode/src/core/assistant-message/diff.ts
@@ -197,7 +197,11 @@ function normalizeReplacementContentForMatchedRange(
 	originalContent: string,
 	searchEndIndex: number,
 ): string {
-	if (shouldTrimSyntheticReplacementNewline(originalContent, searchEndIndex) && replacementContent.endsWith("\n")) {
+	if (
+		shouldTrimSyntheticReplacementNewline(originalContent, searchEndIndex) &&
+		replacementContent.length > 1 &&
+		replacementContent.endsWith("\n")
+	) {
 		return replacementContent.slice(0, -1)
 	}
 
@@ -652,6 +656,7 @@ class NewFileContentConstructor {
 			if (
 				shouldTrimSyntheticReplacementNewline(this.originalContent, this.searchEndIndex) &&
 				this.result.length > this.currentReplaceStartIndex &&
+				this.result.length - this.currentReplaceStartIndex > 1 &&
 				this.result.endsWith("\n")
 			) {
 				this.result = this.result.slice(0, -1)

--- a/apps/vscode/src/core/assistant-message/diff.ts
+++ b/apps/vscode/src/core/assistant-message/diff.ts
@@ -62,7 +62,7 @@ function lineTrimmedFallbackMatch(originalContent: string, searchContent: string
 	let startLineNum = 0
 	let currentIndex = 0
 	while (currentIndex < startIndex && startLineNum < originalLines.length) {
-		currentIndex += originalLines[startLineNum].length + 1 // +1 for \n
+		currentIndex += getLineLengthWithTerminator(originalLines, startLineNum)
 		startLineNum++
 	}
 
@@ -86,13 +86,13 @@ function lineTrimmedFallbackMatch(originalContent: string, searchContent: string
 			// Find start character index
 			let matchStartIndex = 0
 			for (let k = 0; k < i; k++) {
-				matchStartIndex += originalLines[k].length + 1 // +1 for \n
+				matchStartIndex += getLineLengthWithTerminator(originalLines, k)
 			}
 
 			// Find end character index
 			let matchEndIndex = matchStartIndex
 			for (let k = 0; k < searchLines.length; k++) {
-				matchEndIndex += originalLines[i + k].length + 1 // +1 for \n
+				matchEndIndex += getLineLengthWithTerminator(originalLines, i + k)
 			}
 
 			return [matchStartIndex, matchEndIndex]
@@ -151,7 +151,7 @@ function blockAnchorFallbackMatch(originalContent: string, searchContent: string
 	let startLineNum = 0
 	let currentIndex = 0
 	while (currentIndex < startIndex && startLineNum < originalLines.length) {
-		currentIndex += originalLines[startLineNum].length + 1
+		currentIndex += getLineLengthWithTerminator(originalLines, startLineNum)
 		startLineNum++
 	}
 
@@ -170,18 +170,38 @@ function blockAnchorFallbackMatch(originalContent: string, searchContent: string
 		// Calculate exact character positions
 		let matchStartIndex = 0
 		for (let k = 0; k < i; k++) {
-			matchStartIndex += originalLines[k].length + 1
+			matchStartIndex += getLineLengthWithTerminator(originalLines, k)
 		}
 
 		let matchEndIndex = matchStartIndex
 		for (let k = 0; k < searchBlockSize; k++) {
-			matchEndIndex += originalLines[i + k].length + 1
+			matchEndIndex += getLineLengthWithTerminator(originalLines, i + k)
 		}
 
 		return [matchStartIndex, matchEndIndex]
 	}
 
 	return false
+}
+
+function getLineLengthWithTerminator(lines: string[], lineIndex: number): number {
+	return lines[lineIndex].length + (lineIndex < lines.length - 1 ? 1 : 0)
+}
+
+function shouldTrimSyntheticReplacementNewline(originalContent: string, searchEndIndex: number): boolean {
+	return originalContent.length > 0 && searchEndIndex === originalContent.length && !originalContent.endsWith("\n")
+}
+
+function normalizeReplacementContentForMatchedRange(
+	replacementContent: string,
+	originalContent: string,
+	searchEndIndex: number,
+): string {
+	if (shouldTrimSyntheticReplacementNewline(originalContent, searchEndIndex) && replacementContent.endsWith("\n")) {
+		return replacementContent.slice(0, -1)
+	}
+
+	return replacementContent
 }
 
 /**
@@ -403,7 +423,7 @@ async function constructNewFileContentV1(
 			replacements.push({
 				start: searchMatchIndex,
 				end: searchEndIndex,
-				content: currentReplaceContent,
+				content: normalizeReplacementContentForMatchedRange(currentReplaceContent, originalContent, searchEndIndex),
 			})
 
 			// If this was an in-order replacement, advance lastProcessedIndex
@@ -446,7 +466,7 @@ async function constructNewFileContentV1(
 			replacements.push({
 				start: searchMatchIndex,
 				end: searchEndIndex,
-				content: currentReplaceContent,
+				content: normalizeReplacementContentForMatchedRange(currentReplaceContent, originalContent, searchEndIndex),
 			})
 
 			// If this was an in-order replacement, advance lastProcessedIndex
@@ -506,6 +526,7 @@ class NewFileContentConstructor {
 	private currentSearchContent: string
 	private searchMatchIndex: number
 	private searchEndIndex: number
+	private currentReplaceStartIndex: number
 
 	constructor(originalContent: string, isFinal: boolean) {
 		this.originalContent = originalContent
@@ -517,6 +538,7 @@ class NewFileContentConstructor {
 		this.currentSearchContent = ""
 		this.searchMatchIndex = -1
 		this.searchEndIndex = -1
+		this.currentReplaceStartIndex = 0
 	}
 
 	private resetForNextBlock() {
@@ -525,6 +547,7 @@ class NewFileContentConstructor {
 		this.currentSearchContent = ""
 		this.searchMatchIndex = -1
 		this.searchEndIndex = -1
+		this.currentReplaceStartIndex = 0
 	}
 
 	private findLastMatchingLineIndex(regx: RegExp, lineLimit: number) {
@@ -626,6 +649,13 @@ class NewFileContentConstructor {
 				this.tryFixReplaceBlock(pendingNonStandardLineLimit)
 				canWritependingNonStandardLines && (this.pendingNonStandardLines.length = 0)
 			}
+			if (
+				shouldTrimSyntheticReplacementNewline(this.originalContent, this.searchEndIndex) &&
+				this.result.length > this.currentReplaceStartIndex &&
+				this.result.endsWith("\n")
+			) {
+				this.result = this.result.slice(0, -1)
+			}
 			this.lastProcessedIndex = this.searchEndIndex
 			this.resetForNextBlock()
 		} else {
@@ -717,6 +747,7 @@ class NewFileContentConstructor {
 		}
 		// Output everything up to the match location
 		this.result += this.originalContent.slice(this.lastProcessedIndex, this.searchMatchIndex)
+		this.currentReplaceStartIndex = this.result.length
 	}
 
 	private tryFixSearchBlock(lineLimit: number): number {


### PR DESCRIPTION
﻿### Related Issue

**Issue:** #4384

Also related to #11274, which reports unintended blank/new lines from `replace_in_file` edits.

### Description

`constructNewFileContent` currently represents SEARCH/REPLACE block lines by appending `\n` while parsing. That works for normal line-oriented edits, but it changes files that intentionally do not end with a trailing newline: replacing the final line of `"line1\nline2"` produces `"line1\nupdated line2\n"` even though the REPLACE block did not include an extra blank line.

This PR preserves the original EOF newline state for final-line replacements:

- fallback line matching now calculates match ranges using the real line terminator boundaries instead of always adding `+ 1`
- v1 replacement reconstruction trims only the parser-added synthetic newline when the matched original range ended at EOF without a newline
- v2 streaming reconstruction applies the same EOF normalization before closing the replacement block
- adds a regression test covering both v1 and v2 constructors

The behavior still allows adding a newline at EOF intentionally by including an extra blank line in the REPLACE block.

### Test Procedure

Ran the focused diff constructor tests locally from `apps/vscode`:

```sh
TS_NODE_PROJECT=./tsconfig.unit-test.json npx -y -p mocha@11.7.5 -p ts-node@10.9.2 -p typescript@5.9.3 -p chai@5.3.3 -p tsconfig-paths@4.2.0 mocha --no-config --require ts-node/register --require tsconfig-paths/register src/core/assistant-message/diff.test.ts src/core/assistant-message/diff_edge_cases.test.ts
```

Result: `32 passing`.

Also ran formatting/lint check on the touched files:

```sh
npx -y @biomejs/biome@2.4.5 check --config-path ./biome.jsonc --no-errors-on-unmatched --files-ignore-unknown=true --diagnostic-level=error src/core/assistant-message/diff.ts src/core/assistant-message/diff.test.ts
```

Result: `Checked 2 files ... No fixes applied.`

I did not run the full `npm test` suite locally; dependency installation in this workspace did not complete within the local timeout.

### Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Refactor Changes
-   [ ] Cosmetic Changes
-   [ ] Documentation update
-   [ ] Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable; this is a diff parser behavior fix covered by unit tests.

### Additional Notes

I used an AI coding assistant to help inspect the parser behavior and prepare this patch; I reviewed the change, reproduced the regression with a failing test first, and ran the targeted checks above.
