### PR TITLE
test(core): skip chmod-based plugin uninstall failure test on Windows

### DIFF
--- a/sdk/packages/core/src/services/plugin-uninstall.test.ts
+++ b/sdk/packages/core/src/services/plugin-uninstall.test.ts
@@ -126,29 +126,34 @@ describe("plugin uninstall service", () => {
 		expect(existsSync(pluginPath)).toBe(false);
 	});
 
-	it("keeps disabled plugin settings if file deletion fails", async () => {
-		const pluginRoot = join(home, ".cline", "plugins");
-		const pluginPath = join(pluginRoot, "locked-plugin.ts");
-		await mkdir(pluginRoot, { recursive: true });
-		await writeFile(
-			pluginPath,
-			"export default { name: 'locked', manifest: { capabilities: ['tools'] } };",
-			"utf8",
-		);
-		writeGlobalSettings({ disabledPlugins: [pluginPath] });
-		chmodSync(pluginRoot, 0o555);
+	// chmod-based deletion failure cannot be simulated on Windows, where read-only
+	// directory permissions do not prevent removing files inside them.
+	it.skipIf(process.platform === "win32")(
+		"keeps disabled plugin settings if file deletion fails",
+		async () => {
+			const pluginRoot = join(home, ".cline", "plugins");
+			const pluginPath = join(pluginRoot, "locked-plugin.ts");
+			await mkdir(pluginRoot, { recursive: true });
+			await writeFile(
+				pluginPath,
+				"export default { name: 'locked', manifest: { capabilities: ['tools'] } };",
+				"utf8",
+			);
+			writeGlobalSettings({ disabledPlugins: [pluginPath] });
+			chmodSync(pluginRoot, 0o555);
 
-		try {
-			await expect(uninstallPlugin({ path: pluginPath })).rejects.toThrow();
-			expect(existsSync(pluginPath)).toBe(true);
-			expect(readGlobalSettings()).toEqual({
-				disabledPlugins: [pluginPath],
-				telemetryOptOut: false,
-			});
-		} finally {
-			chmodSync(pluginRoot, 0o755);
-		}
-	});
+			try {
+				await expect(uninstallPlugin({ path: pluginPath })).rejects.toThrow();
+				expect(existsSync(pluginPath)).toBe(true);
+				expect(readGlobalSettings()).toEqual({
+					disabledPlugins: [pluginPath],
+					telemetryOptOut: false,
+				});
+			} finally {
+				chmodSync(pluginRoot, 0o755);
+			}
+		},
+	);
 
 	it("reports unmatched names clearly", async () => {
 		await expect(uninstallPlugin({ name: "missing-plugin" })).rejects.toThrow(


### PR DESCRIPTION
### Related Issue

No issue. Minor test fix discovered while cutting an SDK release.

### Description

The SDK publish workflow was failing on the `windows-latest` test job, which blocked publishing. The failing test is `plugin uninstall service > keeps disabled plugin settings if file deletion fails` in `sdk/packages/core/src/services/plugin-uninstall.test.ts`.

The test simulates a file-deletion failure by `chmodSync(pluginRoot, 0o555)` on the plugin's parent directory, then asserts that `uninstallPlugin` rejects and leaves the disabled-plugin settings untouched. This works on POSIX, where removing a file requires write permission on its parent directory, so a read-only parent makes the unlink fail.

On Windows, `chmod` does not map to the same semantics: a read-only directory does not prevent removing files inside it, so the unlink succeeds, `uninstallPlugin` resolves instead of rejecting, and the assertion fails:

```
AssertionError: promise resolved "{ name: 'locked-plugin', …(3) }" instead of rejecting
```

The behavior under test (preserve disabled-plugin settings when deletion fails) is still fully exercised on POSIX. There is no portable way to force a deletion failure via `chmod` on Windows, so this change skips just this one case on `win32` using the repo's existing `it.skipIf(process.platform === "win32")` pattern (same approach already used elsewhere in the core test suite, e.g. `hub/discovery/index.test.ts` and `executors/bash.test.ts`). The other three tests in the file continue to run on all platforms.

### Test Procedure

- Ran `bun run test:unit src/services/plugin-uninstall.test.ts` in `sdk/packages/core` on Linux: all 4 tests pass.
- On Windows CI, the incompatible case will now be skipped while the remaining three run, unblocking the SDK publish workflow.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing and code is formatted and linted
-   [x] I have reviewed contributor guidelines