### PR TITLE
fix(cli): use npm update for auto updates

### DIFF
--- a/apps/cli/src/commands/update.test.ts
+++ b/apps/cli/src/commands/update.test.ts
@@ -45,7 +45,7 @@ describe("getInstallationInfo", () => {
 		expect(getInstallationInfo("1.2.3")).toEqual({
 			packageManager: PackageManager.NPM,
 			packageName: "cline",
-			updateCommand: "npm install -g cline@latest",
+			updateCommand: "npm update -g cline",
 		});
 	});
 
@@ -57,7 +57,7 @@ describe("getInstallationInfo", () => {
 		expect(getInstallationInfo("1.2.3-nightly.456")).toEqual({
 			packageManager: PackageManager.NPM,
 			packageName: "cline",
-			updateCommand: "npm install -g cline@nightly",
+			updateCommand: "npm update -g cline",
 		});
 	});
 
@@ -75,11 +75,9 @@ describe("getInstallationInfo", () => {
 describe("withMinimumReleaseAgeBypass", () => {
 	it("adds the package-manager-specific cooldown bypass", () => {
 		expect(
-			withMinimumReleaseAgeBypass(
-				"npm install -g cline@latest",
-				PackageManager.NPM,
-			).command,
-		).toBe("npm install -g cline@latest --min-release-age=0");
+			withMinimumReleaseAgeBypass("npm update -g cline", PackageManager.NPM)
+				.command,
+		).toBe("npm update -g cline --min-release-age=0");
 		expect(
 			withMinimumReleaseAgeBypass("bun add -g cline@latest", PackageManager.BUN)
 				.command,

--- a/apps/cli/src/commands/update.test.ts
+++ b/apps/cli/src/commands/update.test.ts
@@ -45,7 +45,7 @@ describe("getInstallationInfo", () => {
 		expect(getInstallationInfo("1.2.3")).toEqual({
 			packageManager: PackageManager.NPM,
 			packageName: "cline",
-			updateCommand: "npm update -g cline",
+			updateCommand: "npm update -g cline --tag latest",
 		});
 	});
 
@@ -57,7 +57,7 @@ describe("getInstallationInfo", () => {
 		expect(getInstallationInfo("1.2.3-nightly.456")).toEqual({
 			packageManager: PackageManager.NPM,
 			packageName: "cline",
-			updateCommand: "npm update -g cline",
+			updateCommand: "npm update -g cline --tag nightly",
 		});
 	});
 
@@ -75,9 +75,11 @@ describe("getInstallationInfo", () => {
 describe("withMinimumReleaseAgeBypass", () => {
 	it("adds the package-manager-specific cooldown bypass", () => {
 		expect(
-			withMinimumReleaseAgeBypass("npm update -g cline", PackageManager.NPM)
-				.command,
-		).toBe("npm update -g cline --min-release-age=0");
+			withMinimumReleaseAgeBypass(
+				"npm update -g cline --tag latest",
+				PackageManager.NPM,
+			).command,
+		).toBe("npm update -g cline --tag latest --min-release-age=0");
 		expect(
 			withMinimumReleaseAgeBypass("bun add -g cline@latest", PackageManager.BUN)
 				.command,

--- a/apps/cli/src/commands/update.ts
+++ b/apps/cli/src/commands/update.ts
@@ -126,7 +126,7 @@ export function getInstallationInfo(currentVersion: string): InstallationInfo {
 			return {
 				packageManager: PackageManager.NPM,
 				packageName: DEFAULT_PACKAGE_NAME,
-				updateCommand: `npm install -g ${DEFAULT_PACKAGE_NAME}@${tag}`,
+				updateCommand: `npm update -g ${DEFAULT_PACKAGE_NAME}`,
 			};
 		}
 	} catch {
@@ -341,18 +341,25 @@ export function autoUpdateOnStartup(): void {
 	if (process.env.IS_DEV === "true") return;
 	if (process.env.CLINE_NO_AUTO_UPDATE === "1") return;
 
-	const { packageName, updateCommand } = getInstallationInfo(version);
+	const { packageName, packageManager, updateCommand } =
+		getInstallationInfo(version);
 	if (!updateCommand) return;
 
 	void (async () => {
 		try {
 			const latest = await getLatestVersion(packageName, version);
 			if (!latest || compareVersions(version, latest) >= 0) return;
-			const child = spawn(updateCommand, {
+			const autoUpdateCommand = withMinimumReleaseAgeBypass(
+				updateCommand,
+				packageManager,
+			);
+			const child = spawn(autoUpdateCommand.command, {
 				shell: true,
 				detached: true,
 				stdio: "ignore",
-				env: process.env,
+				env: autoUpdateCommand.env
+					? { ...process.env, ...autoUpdateCommand.env }
+					: process.env,
 			});
 			const exitCode = await waitForProcessExit(child);
 			if (exitCode === 0) {

--- a/apps/cli/src/commands/update.ts
+++ b/apps/cli/src/commands/update.ts
@@ -126,7 +126,7 @@ export function getInstallationInfo(currentVersion: string): InstallationInfo {
 			return {
 				packageManager: PackageManager.NPM,
 				packageName: DEFAULT_PACKAGE_NAME,
-				updateCommand: `npm update -g ${DEFAULT_PACKAGE_NAME}`,
+				updateCommand: `npm update -g ${DEFAULT_PACKAGE_NAME} --tag ${tag}`,
 			};
 		}
 	} catch {


### PR DESCRIPTION
### Related Issue

Issue: N/A, internal user report about the `cline` command temporarily becoming unavailable during background auto-update.

### Description

Users reported that the CLI could work normally, then a later `cline` invocation would fail with an unknown command style error, and then a few seconds or minutes later the command would work again. That timing points at the background auto-update path mutating the globally installed CLI while the user is trying to run it.

The npm-owned install detection previously returned `npm install -g cline@latest` or `npm install -g cline@nightly`. That is heavier than needed for an already installed global package and is more likely to rewrite the global install and command shim. This PR changes npm-owned installs to use `npm update -g cline` while preserving the release channel through npm's `--tag` flag.

The resulting npm auto-update commands are:

```bash
npm update -g cline --tag latest --min-release-age=0
npm update -g cline --tag nightly --min-release-age=0
```

One gotcha from testing: `npm update` only accepts package names. It rejects `cline@latest` with `EUPDATEARGS`, so the command must pass `cline` as the package name and `--tag latest` or `--tag nightly` separately.

This PR also applies the existing minimum-release-age bypass to startup auto-updates. That bypass was already used for manual `cline update`, but the background path spawned the raw update command.

The non-npm package manager commands are left unchanged, apart from the background path now using the same bypass helper and env handling that manual updates use.

### Test Procedure

Verified the focused updater tests pass:

```bash
bun -F @cline/cli test:unit -- src/commands/update.test.ts
```

Verified the CLI package typecheck passes:

```bash
bun -F @cline/cli typecheck
```

Verified npm accepts the latest command shape with a dry run against a temporary prefix:

```bash
tmpdir=$(mktemp -d) && mkdir -p "$tmpdir/lib" && npm update -g cline --tag latest --dry-run --min-release-age=0 --prefix "$tmpdir"; status=$?; rm -rf "$tmpdir"; exit $status
```

Also verified during debugging that `npm update -g cline@latest` fails with `EUPDATEARGS`, which is why this PR intentionally uses the package name plus `--tag` instead of a versioned package spec.

### Type of Change

-   [x] Bug fix, non-breaking change which fixes an issue
-   [ ] New feature, non-breaking change which adds functionality
-   [ ] Breaking change, fix or feature that would cause existing functionality to not work as expected
-   [ ] Refactor changes
-   [ ] Cosmetic changes
-   [ ] Documentation update
-   [ ] Workflow changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore
-   [x] Tests are passing for the focused CLI updater test and CLI typecheck
-   [x] I have reviewed the contributor guidelines

### Screenshots

N/A. CLI update command behavior only.

### Additional Notes

This keeps the fix intentionally narrow. It does not redesign background update staging, wrapper resolution, or postinstall behavior. The goal is only to stop using `npm install -g` for npm-owned auto-updates and to make the background path use the same release-age bypass helper as manual updates.
