### PR TITLE
fix(cli): name installed plugin wrappers from source

### DIFF
--- a/apps/cli/src/commands/plugin.test.ts
+++ b/apps/cli/src/commands/plugin.test.ts
@@ -239,6 +239,10 @@ describe("plugin install command", () => {
 		expect(readFileSync(result.entryPaths[0] ?? "", "utf8")).toContain(
 			"official-web-search",
 		);
+		const wrapperManifest = JSON.parse(
+			readFileSync(join(result.installPath, "package.json"), "utf8"),
+		) as { name?: string };
+		expect(wrapperManifest.name).toBe("web-search");
 		expect(existsSync(join(result.installPath, "repo"))).toBe(false);
 		expect(
 			existsSync(join(result.installPath, "package", "other-plugin")),
@@ -328,6 +332,10 @@ describe("plugin install command", () => {
 		expect(result.installPath).toContain(
 			join(workspace, ".cline", "plugins", "_installed", "local"),
 		);
+		const wrapperManifest = JSON.parse(
+			readFileSync(join(result.installPath, "package.json"), "utf8"),
+		) as { name?: string };
+		expect(wrapperManifest.name).toBe("web-search");
 		expect(readFileSync(result.entryPaths[0] ?? "", "utf8")).toContain(
 			"local-web-search",
 		);
@@ -456,7 +464,8 @@ describe("plugin install command", () => {
 
 		const wrapperManifest = JSON.parse(
 			readFileSync(join(result.installPath, "package.json"), "utf8"),
-		) as { cline?: { plugins?: Array<{ paths?: string[] }> } };
+		) as { name?: string; cline?: { plugins?: Array<{ paths?: string[] }> } };
+		expect(wrapperManifest.name).toBe("plugin-package");
 		expect(wrapperManifest.cline?.plugins?.[0]?.paths).toHaveLength(1);
 		expect(wrapperManifest.cline?.plugins?.[0]?.paths?.[0]).toContain(
 			"package/index.ts",

--- a/apps/cli/src/commands/plugin.ts
+++ b/apps/cli/src/commands/plugin.ts
@@ -12,7 +12,15 @@ import {
 } from "node:fs";
 import { cp, mkdir, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { basename, dirname, join, relative, resolve, sep } from "node:path";
+import {
+	basename,
+	dirname,
+	extname,
+	join,
+	relative,
+	resolve,
+	sep,
+} from "node:path";
 import { type PluginUninstallOptions, uninstallPlugin } from "@cline/core";
 import {
 	isPluginModulePath,
@@ -469,6 +477,25 @@ function getInstallSourceKey(
 	return `local:${resolve(cwd, resolveHomePath(parsed.path))}`;
 }
 
+function getWrapperPackageName(
+	parsed: ParsedPluginSource,
+	cwd: string,
+): string {
+	if (parsed.type === "npm") {
+		return parsed.name;
+	}
+	if (parsed.type === "git") {
+		return sanitizeSegment(basename(parsed.path));
+	}
+	if (parsed.type === "remote") {
+		return sanitizeSegment(basename(parsed.filename, extname(parsed.filename)));
+	}
+	if (parsed.type === "official") {
+		return parsed.slug;
+	}
+	return sanitizeSegment(basename(resolve(cwd, resolveHomePath(parsed.path))));
+}
+
 async function runCommand(
 	command: string,
 	args: string[],
@@ -665,6 +692,7 @@ function toWrapperEntryPaths(
 async function writeWrapperManifest(
 	wrapperRoot: string,
 	packageRoot: string,
+	packageName: string,
 ): Promise<string[]> {
 	const entryPaths = toWrapperEntryPaths(wrapperRoot, packageRoot);
 	await writeFile(
@@ -672,7 +700,7 @@ async function writeWrapperManifest(
 		JSON.stringify(
 			{
 				...WRAPPER_PACKAGE_JSON,
-				name: `cline-installed-plugin-${hashSource(wrapperRoot)}`,
+				name: packageName,
 				cline: {
 					plugins: [{ paths: entryPaths }],
 				},
@@ -988,6 +1016,7 @@ export async function installPlugin(
 	);
 	const sourceKey = getInstallSourceKey(parsed, cwd, officialPluginsRepo);
 	const installPath = getInstallPath(pluginRoot, parsed, sourceKey);
+	const wrapperPackageName = getWrapperPackageName(parsed, cwd);
 	const stagingParent = join(pluginRoot, INSTALLS_DIRECTORY_NAME, ".tmp");
 	const stagingRoot = join(
 		stagingParent,
@@ -1030,7 +1059,11 @@ export async function installPlugin(
 				? collectPluginEntries(stagingRoot).map(
 						(entry) => `./${toPosixPath(relative(stagingRoot, entry))}`,
 					)
-				: await writeWrapperManifest(stagingRoot, packageRoot);
+				: await writeWrapperManifest(
+						stagingRoot,
+						packageRoot,
+						wrapperPackageName,
+					);
 		if (entryPaths.length === 0) {
 			throw new Error(`No plugin entry files found for ${source}`);
 		}


### PR DESCRIPTION
### Related Issue

Issue: N/A

Small bug fix for plugin install metadata.

### Description

New installed package-backed plugins currently get a generated wrapper `package.json` named `cline-installed-plugin-...`. That wrapper is useful for pointing Cline at staged plugin entry files, but the package name leaks into user-facing config surfaces when the installed plugin content does not include its own `package.json`.

This shows up most clearly for official single-file plugins such as `nanobanana` and `speak`. `cline plugin install nanobanana` creates an installed folder whose wrapper points at `package/index.ts`. Since `package/` has no package manifest, the settings data loader walks upward, finds the generated wrapper manifest, and displays `cline-installed-plugin-...` instead of the install slug users actually chose.

This PR changes the installer so newly generated wrapper manifests use a meaningful source-derived package name:

```text
official slug: speak
local directory: web-search
git repo: repo basename
npm package: npm package name
remote file: filename without extension
```

The plugin entry paths and install layout stay the same. This only changes the metadata written to the generated wrapper manifest. Existing installs are not migrated, so users who already hit the old name need to reinstall with `--force` to see the corrected name.

I chose the installer-level fix instead of adding special cases to the settings UI because the wrapper manifest is the source of the bad metadata. Writing a better wrapper name makes the installed files easier to inspect and keeps existing display logic simple.

### Test Procedure

I added assertions to the plugin install command tests to verify wrapper manifest names for:

- official slug installs
- local directory installs
- package-backed installs

I also ran the focused installer test file:

```bash
bunx vitest run src/commands/plugin.test.ts --config vitest.config.ts
```

Then I ran formatting and type safety checks on the touched files and CLI package:

```bash
bun biome check --diagnostic-level=error apps/cli/src/commands/plugin.ts apps/cli/src/commands/plugin.test.ts
bun -F @cline/cli typecheck
```

The pre-commit hook also ran gitleaks, repository type checks, and Biome on the staged files before commit.

### Type of Change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Breaking change
-   [ ] Refactor Changes
-   [ ] Cosmetic Changes
-   [ ] Documentation update
-   [ ] Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore
-   [x] Tests are passing and code is formatted and linted
-   [x] I have reviewed contributor guidelines

### Screenshots

N/A. This is CLI installer metadata.

### Additional Notes

This intentionally does not migrate existing `_installed` plugin directories. The new name is applied when the installer writes a new wrapper manifest.