### PR TITLE
fix(cli): scroll inline ask question responses

### DIFF
--- a/apps/cli/src/tui/components/inline-tool-response.tsx
+++ b/apps/cli/src/tui/components/inline-tool-response.tsx
@@ -1,5 +1,6 @@
+import type { ScrollBoxRenderable } from "@opentui/core";
 import { useKeyboard, useTerminalDimensions } from "@opentui/react";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { palette } from "../palette";
 import type { RuntimeToolInteraction } from "../types";
 import { formatApprovalParams } from "./dialogs/tool-approval";
@@ -22,23 +23,92 @@ function keyToText(name: string): string {
 	return name === "space" ? " " : name;
 }
 
+function getToolShellMaxHeight(terminalHeight: number): number {
+	return Math.max(7, Math.min(14, Math.floor(terminalHeight * 0.38)));
+}
+
+function getAskQuestionShellMaxHeight(terminalHeight: number): number {
+	const preferredHeight = Math.max(11, Math.floor(terminalHeight * 0.58));
+	const availableHeight = Math.max(7, terminalHeight - 3);
+	return Math.min(18, preferredHeight, availableHeight);
+}
+
+function getAskQuestionBodyHeight(shellMaxHeight: number): number {
+	return Math.max(1, shellMaxHeight - 4);
+}
+
+function countWrappedRows(text: string, width: number): number {
+	const safeWidth = Math.max(1, width);
+	const paragraphs = text.split("\n");
+	let rows = 0;
+
+	for (const paragraph of paragraphs) {
+		rows += 1;
+		let lineWidth = 0;
+		const words = paragraph.trim().split(/\s+/).filter(Boolean);
+
+		for (const word of words) {
+			const wordWidth = Bun.stringWidth(word);
+			if (lineWidth === 0) {
+				rows += Math.max(0, Math.ceil(wordWidth / safeWidth) - 1);
+				lineWidth = wordWidth % safeWidth || safeWidth;
+				continue;
+			}
+
+			if (lineWidth + 1 + wordWidth <= safeWidth) {
+				lineWidth += 1 + wordWidth;
+				continue;
+			}
+
+			rows += 1;
+			rows += Math.max(0, Math.ceil(wordWidth / safeWidth) - 1);
+			lineWidth = wordWidth % safeWidth || safeWidth;
+		}
+	}
+
+	return rows;
+}
+
+function getAskQuestionContentHeight(input: {
+	terminalWidth: number;
+	question: string;
+	options: string[];
+	customText: string;
+}): number {
+	const questionWidth = Math.max(1, input.terminalWidth - 3);
+	const optionTextWidth = Math.max(1, input.terminalWidth - 7);
+	const questionRows = countWrappedRows(input.question, questionWidth);
+	const optionRows = input.options.reduce(
+		(rows, option) => rows + countWrappedRows(option, optionTextWidth),
+		0,
+	);
+	const customRows = countWrappedRows(input.customText, optionTextWidth);
+	return questionRows + 1 + optionRows + customRows;
+}
+
+function getAskQuestionChoiceId(interactionId: number, index: number): string {
+	return `ask-question-${interactionId.toString()}-choice-${index.toString()}`;
+}
+
 function Shell(
 	props: Pick<
 		InlineToolResponseProps,
 		"accent" | "inputBackground" | "inputForeground"
 	> & {
 		title: string;
+		maxHeight?: number;
 		children: React.ReactNode;
 	},
 ) {
 	const { height } = useTerminalDimensions();
-	const maxHeight = Math.max(7, Math.min(14, Math.floor(height * 0.38)));
+	const maxHeight = props.maxHeight ?? getToolShellMaxHeight(height);
 
 	return (
 		<box
 			flexDirection="column"
 			width="100%"
 			maxHeight={maxHeight}
+			overflow="hidden"
 			backgroundColor={props.inputBackground}
 			paddingX={1}
 			paddingY={1}
@@ -59,6 +129,7 @@ function ChoiceButton(props: {
 	onPress: () => void;
 }) {
 	return (
+		// biome-ignore lint/a11y/noStaticElementInteractions: OpenTUI boxes handle terminal mouse input.
 		<box
 			paddingX={1}
 			backgroundColor={props.selected ? palette.selection : undefined}
@@ -155,9 +226,11 @@ function AskQuestionResponse(
 	},
 ) {
 	const { interaction } = props;
+	const { height, width } = useTerminalDimensions();
 	const [selected, setSelected] = useState(0);
 	const [customValue, setCustomValue] = useState("");
 	const [customEmptyAttempted, setCustomEmptyAttempted] = useState(false);
+	const scrollRef = useRef<ScrollBoxRenderable | null>(null);
 	const selectedRef = useRef(0);
 	const customValueRef = useRef("");
 	const interactionId = interaction.id;
@@ -165,6 +238,24 @@ function AskQuestionResponse(
 	const customIndex = interaction.options.length;
 	const isTyping = selected === customIndex;
 	const totalChoices = interaction.options.length + 1;
+	const shellMaxHeight = getAskQuestionShellMaxHeight(height);
+	const maxBodyHeight = getAskQuestionBodyHeight(shellMaxHeight);
+	const customText = isTyping
+		? customValue
+			? `${customValue}|`
+			: customEmptyAttempted
+				? "Type a response first..."
+				: "Type a response..."
+		: "Type a response...";
+	const bodyHeight = Math.min(
+		maxBodyHeight,
+		getAskQuestionContentHeight({
+			terminalWidth: width,
+			question: interaction.question,
+			options: interaction.options,
+			customText,
+		}),
+	);
 
 	const selectIndex = useCallback(
 		(index: number) => {
@@ -191,6 +282,16 @@ function AskQuestionResponse(
 		},
 		[interactionId, onResolveAskQuestion],
 	);
+
+	useEffect(() => {
+		const choiceId = getAskQuestionChoiceId(interactionId, selected);
+		const scrollSelectedChoiceIntoView = () => {
+			scrollRef.current?.scrollChildIntoView(choiceId);
+		};
+
+		scrollSelectedChoiceIntoView();
+		queueMicrotask(scrollSelectedChoiceIntoView);
+	}, [interactionId, selected]);
 
 	useKeyboard((key) => {
 		const typing = selectedRef.current === customIndex;
@@ -261,64 +362,90 @@ function AskQuestionResponse(
 			accent={props.accent}
 			inputBackground={props.inputBackground}
 			inputForeground={props.inputForeground}
+			maxHeight={shellMaxHeight}
 		>
-			<text fg={props.inputForeground} selectable>
-				{interaction.question}
-			</text>
+			<scrollbox
+				ref={scrollRef}
+				height={bodyHeight}
+				width="100%"
+				scrollY
+				scrollX={false}
+				viewportOptions={{ overflow: "hidden" }}
+				contentOptions={{ flexDirection: "column" }}
+			>
+				<box flexDirection="column" gap={1} flexShrink={0} width="100%">
+					<text fg={props.inputForeground} selectable flexShrink={0}>
+						{interaction.question}
+					</text>
 
-			<box flexDirection="column">
-				{interaction.options.map((option, index) => {
-					const optionSelected = !isTyping && selected === index;
-					return (
+					<box flexDirection="column" flexShrink={0} width="100%">
+						{interaction.options.map((option, index) => {
+							const optionSelected = !isTyping && selected === index;
+							return (
+								// biome-ignore lint/a11y/noStaticElementInteractions: OpenTUI boxes handle terminal mouse input.
+								<box
+									id={getAskQuestionChoiceId(interactionId, index)}
+									key={`${index.toString()}:${option}`}
+									paddingX={1}
+									flexDirection="row"
+									gap={1}
+									flexShrink={0}
+									width="100%"
+									backgroundColor={
+										optionSelected ? palette.selection : undefined
+									}
+									onMouseDown={() => resolveAnswer(option)}
+								>
+									<text
+										fg={optionSelected ? palette.textOnSelection : "gray"}
+										flexShrink={0}
+									>
+										{optionSelected ? ">" : " "}
+									</text>
+									<text
+										fg={
+											optionSelected
+												? palette.textOnSelection
+												: props.inputForeground
+										}
+										flexGrow={1}
+										flexShrink={1}
+									>
+										{option}
+									</text>
+								</box>
+							);
+						})}
+						{/* biome-ignore lint/a11y/noStaticElementInteractions: OpenTUI boxes handle terminal mouse input. */}
 						<box
-							key={`${index.toString()}:${option}`}
+							id={getAskQuestionChoiceId(interactionId, customIndex)}
 							paddingX={1}
 							flexDirection="row"
 							gap={1}
-							backgroundColor={optionSelected ? palette.selection : undefined}
-							onMouseDown={() => resolveAnswer(option)}
+							flexShrink={0}
+							width="100%"
+							backgroundColor={isTyping ? palette.selection : undefined}
+							onMouseDown={() => selectIndex(customIndex)}
 						>
 							<text
-								fg={optionSelected ? palette.textOnSelection : "gray"}
+								fg={isTyping ? palette.textOnSelection : "gray"}
 								flexShrink={0}
 							>
-								{optionSelected ? ">" : " "}
+								{isTyping ? ">" : " "}
 							</text>
-							<text
-								fg={
-									optionSelected
-										? palette.textOnSelection
-										: props.inputForeground
-								}
-							>
-								{option}
-							</text>
+							{isTyping ? (
+								<text fg={palette.textOnSelection} flexGrow={1} flexShrink={1}>
+									{customText}
+								</text>
+							) : (
+								<text fg={props.inputPlaceholder} flexGrow={1} flexShrink={1}>
+									Type a response...
+								</text>
+							)}
 						</box>
-					);
-				})}
-				<box
-					paddingX={1}
-					flexDirection="row"
-					gap={1}
-					backgroundColor={isTyping ? palette.selection : undefined}
-					onMouseDown={() => selectIndex(customIndex)}
-				>
-					<text fg={isTyping ? palette.textOnSelection : "gray"} flexShrink={0}>
-						{isTyping ? ">" : " "}
-					</text>
-					{isTyping ? (
-						<text fg={palette.textOnSelection} flexGrow={1}>
-							{customValue
-								? `${customValue}|`
-								: customEmptyAttempted
-									? "Type a response first..."
-									: "Type a response..."}
-						</text>
-					) : (
-						<text fg={props.inputPlaceholder}>Type a response...</text>
-					)}
+					</box>
 				</box>
-			</box>
+			</scrollbox>
 		</Shell>
 	);
 }

--- a/apps/cli/src/tui/components/inline-tool-response.tsx
+++ b/apps/cli/src/tui/components/inline-tool-response.tsx
@@ -37,6 +37,37 @@ function getAskQuestionBodyHeight(shellMaxHeight: number): number {
 	return Math.max(1, shellMaxHeight - 4);
 }
 
+function addWrappedWidth(input: {
+	rows: number;
+	lineWidth: number;
+	width: number;
+	maxWidth: number;
+}): { rows: number; lineWidth: number } {
+	if (input.width <= 0) {
+		return { rows: input.rows, lineWidth: input.lineWidth };
+	}
+
+	let rows = input.rows;
+	let remainingWidth = input.width;
+	let lineWidth = input.lineWidth;
+
+	if (lineWidth > 0) {
+		const availableWidth = input.maxWidth - lineWidth;
+		if (remainingWidth <= availableWidth) {
+			return { rows, lineWidth: lineWidth + remainingWidth };
+		}
+
+		remainingWidth -= Math.max(0, availableWidth);
+		rows += 1;
+		lineWidth = 0;
+	}
+
+	rows += Math.max(0, Math.ceil(remainingWidth / input.maxWidth) - 1);
+	lineWidth = remainingWidth % input.maxWidth || input.maxWidth;
+
+	return { rows, lineWidth };
+}
+
 function countWrappedRows(text: string, width: number): number {
 	const safeWidth = Math.max(1, width);
 	const paragraphs = text.split("\n");
@@ -45,24 +76,29 @@ function countWrappedRows(text: string, width: number): number {
 	for (const paragraph of paragraphs) {
 		rows += 1;
 		let lineWidth = 0;
-		const words = paragraph.trim().split(/\s+/).filter(Boolean);
+		const tokens = paragraph.match(/\s+|\S+/g) ?? [];
 
-		for (const word of words) {
-			const wordWidth = Bun.stringWidth(word);
-			if (lineWidth === 0) {
-				rows += Math.max(0, Math.ceil(wordWidth / safeWidth) - 1);
-				lineWidth = wordWidth % safeWidth || safeWidth;
-				continue;
+		for (const token of tokens) {
+			const tokenWidth = Bun.stringWidth(token);
+			const isWhitespace = /^\s+$/.test(token);
+
+			if (
+				!isWhitespace &&
+				lineWidth > 0 &&
+				lineWidth + tokenWidth > safeWidth
+			) {
+				rows += 1;
+				lineWidth = 0;
 			}
 
-			if (lineWidth + 1 + wordWidth <= safeWidth) {
-				lineWidth += 1 + wordWidth;
-				continue;
-			}
-
-			rows += 1;
-			rows += Math.max(0, Math.ceil(wordWidth / safeWidth) - 1);
-			lineWidth = wordWidth % safeWidth || safeWidth;
+			const next = addWrappedWidth({
+				rows,
+				lineWidth,
+				width: tokenWidth,
+				maxWidth: safeWidth,
+			});
+			rows = next.rows;
+			lineWidth = next.lineWidth;
 		}
 	}
 
@@ -97,6 +133,7 @@ function Shell(
 	> & {
 		title: string;
 		maxHeight?: number;
+		overflow?: "hidden";
 		children: React.ReactNode;
 	},
 ) {
@@ -108,7 +145,7 @@ function Shell(
 			flexDirection="column"
 			width="100%"
 			maxHeight={maxHeight}
-			overflow="hidden"
+			overflow={props.overflow}
 			backgroundColor={props.inputBackground}
 			paddingX={1}
 			paddingY={1}
@@ -285,12 +322,22 @@ function AskQuestionResponse(
 
 	useEffect(() => {
 		const choiceId = getAskQuestionChoiceId(interactionId, selected);
+		let canceled = false;
 		const scrollSelectedChoiceIntoView = () => {
+			if (canceled) {
+				return;
+			}
+
 			scrollRef.current?.scrollChildIntoView(choiceId);
 		};
 
 		scrollSelectedChoiceIntoView();
 		queueMicrotask(scrollSelectedChoiceIntoView);
+		const timeout = setTimeout(scrollSelectedChoiceIntoView, 0);
+		return () => {
+			canceled = true;
+			clearTimeout(timeout);
+		};
 	}, [interactionId, selected]);
 
 	useKeyboard((key) => {
@@ -363,6 +410,7 @@ function AskQuestionResponse(
 			inputBackground={props.inputBackground}
 			inputForeground={props.inputForeground}
 			maxHeight={shellMaxHeight}
+			overflow="hidden"
 		>
 			<scrollbox
 				ref={scrollRef}


### PR DESCRIPTION
### Related Issue

Issue: #XXXX

### Description

This fixes a CLI TUI rendering bug in the inline ask-question response. The ask-question panel was using the same compact shell height as other inline tool responses. That worked for short approvals, but it was too tight for a question plus multiple options and the custom response row.

The failure mode showed up with three options when the second option wrapped. The parent panel did not allocate enough vertical space, Yoga compressed rows, and OpenTUI text rendering could paint the wrapped second option into the next row. Visually, the second and third options appeared to render on the same line or with corrupted characters. Navigating again forced another repaint/layout pass, which made the issue appear intermittent.

The fix keeps the outer inline shell bounded, but makes ask-question content scrollable inside that shell. Ask-question now gets a content-aware body height: it estimates wrapped rows for the question, options, and custom answer prompt, then uses the smaller of that content height and the terminal-dependent maximum. That keeps normal prompts snug to their content, while longer prompts or larger option sets scroll cleanly.

The implementation also prevents option rows from shrinking, clips overflow at the shell and viewport, and scrolls the selected option into view after keyboard navigation. Tool approval prompts keep their previous compact height behavior.

### Test Procedure

Tested the original repro with a headless OpenTUI render:

```sh
bun --conditions=development -e '<render InlineToolResponse ask_question with three options at width 60 height 14>'
```

The check verified:

- The first option, wrapped second option, third option, and custom response prompt all render in order.
- Pressing down once selects the second option without corrupting or merging the third option.
- On a taller terminal, the ask-question panel stays fitted to content instead of reserving empty max-height space.
- With twelve options, keyboard navigation scrolls option 11 into view and Enter resolves that selected answer.

Also ran:

```sh
bun run typecheck
bun biome check --no-errors-on-unmatched --files-ignore-unknown=true apps/cli/src/tui/components/inline-tool-response.tsx
```

The pre-commit hook also passed gitleaks, type checks, and Biome for the staged CLI file.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not included. This is a terminal layout fix verified with headless OpenTUI render checks against the failing ask-question option layout.

### Additional Notes

The height calculation intentionally stays local to the inline ask-question component. OpenTUI scrollbox layout still expands to the provided height, so the component now computes a fitted height explicitly instead of relying on maxHeight alone.
