### PR TITLE
fix(a11y): use radio group ARIA roles for Plan/Act mode toggle

### DIFF
--- a/apps/vscode/src/test/e2e/README.md
+++ b/apps/vscode/src/test/e2e/README.md
@@ -140,8 +140,8 @@ await sidebar.getByTestId("send-button").click()
 
 #### Mode Switching
 ```typescript
-const actButton = sidebar.getByRole("switch", { name: "Act" })
-const planButton = sidebar.getByRole("switch", { name: "Plan" })
+const actButton = sidebar.getByRole("radio", { name: "Act" })
+const planButton = sidebar.getByRole("radio", { name: "Plan" })
 await actButton.click() // Switch to Plan mode
 ```
 

--- a/apps/vscode/src/test/e2e/chat.test.ts
+++ b/apps/vscode/src/test/e2e/chat.test.ts
@@ -25,8 +25,8 @@ e2e("Chat - can send messages and switch between modes", async ({ helper, sideba
 
 	// Makes sure the act and plan switches are working correctly
 	// Aria-checked state should be true for Act and false for Plan
-	const actButton = sidebar.getByRole("switch", { name: "Act" })
-	const planButton = sidebar.getByRole("switch", { name: "Plan" })
+	const actButton = sidebar.getByRole("radio", { name: "Act" })
+	const planButton = sidebar.getByRole("radio", { name: "Plan" })
 
 	// Act button should be active. It doesn't have c
 	await expect(actButton).toHaveAttribute("aria-checked", "true")

--- a/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1018,39 +1018,64 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			[updateCursorPosition],
 		)
 
-		const onModeToggle = useCallback(() => {
-			void (async () => {
-				const convertedProtoMode = mode === "plan" ? PlanActMode.ACT : PlanActMode.PLAN
-				const submittedText = inputValue
-				const submittedImages = selectedImages
-				const submittedFiles = selectedFiles
-				const response = await StateServiceClient.togglePlanActModeProto(
-					TogglePlanActModeRequest.create({
-						mode: convertedProtoMode,
-						chatContent: {
-							message: submittedText.trim() ? submittedText : undefined,
-							images: submittedImages,
-							files: submittedFiles,
-						},
-					}),
-				)
-				// Focus the textarea after mode toggle with slight delay
-				setTimeout(() => {
-					if (response.value) {
-						// The toggle consumed the composer content as the continuation
-						// message. Clear only what was submitted: the rebuild can take a
-						// moment and the user may have typed or attached new content in
-						// the meantime, which must not be wiped.
-						if ((textAreaRef.current?.value ?? "") === submittedText) {
-							setInputValue("")
+		const setMode = useCallback(
+			(targetMode: "plan" | "act") => {
+				// No-op if already in the target mode (e.g. re-selecting the active radio),
+				// which avoids a redundant togglePlanActModeProto round-trip and focus shift.
+				if (targetMode === mode) {
+					return
+				}
+				void (async () => {
+					const convertedProtoMode = targetMode === "plan" ? PlanActMode.PLAN : PlanActMode.ACT
+					const submittedText = inputValue
+					const submittedImages = selectedImages
+					const submittedFiles = selectedFiles
+					const response = await StateServiceClient.togglePlanActModeProto(
+						TogglePlanActModeRequest.create({
+							mode: convertedProtoMode,
+							chatContent: {
+								message: submittedText.trim() ? submittedText : undefined,
+								images: submittedImages,
+								files: submittedFiles,
+							},
+						}),
+					)
+					// Focus the textarea after mode toggle with slight delay
+					setTimeout(() => {
+						if (response.value) {
+							// The toggle consumed the composer content as the continuation
+							// message. Clear only what was submitted: the rebuild can take a
+							// moment and the user may have typed or attached new content in
+							// the meantime, which must not be wiped.
+							if ((textAreaRef.current?.value ?? "") === submittedText) {
+								setInputValue("")
+							}
+							setSelectedImages((current) => (current === submittedImages ? [] : current))
+							setSelectedFiles((current) => (current === submittedFiles ? [] : current))
 						}
-						setSelectedImages((current) => (current === submittedImages ? [] : current))
-						setSelectedFiles((current) => (current === submittedFiles ? [] : current))
-					}
-					textAreaRef.current?.focus()
-				}, 100)
-			})()
-		}, [mode, inputValue, selectedImages, selectedFiles, setInputValue, setSelectedImages, setSelectedFiles])
+						textAreaRef.current?.focus()
+					}, 100)
+				})()
+			},
+			[mode, inputValue, selectedImages, selectedFiles, setInputValue, setSelectedImages, setSelectedFiles],
+		)
+
+		const onModeToggle = useCallback(() => {
+			setMode(mode === "plan" ? "act" : "plan")
+		}, [mode, setMode])
+
+		const onRadioGroupKeyDown = useCallback(
+			(e: React.KeyboardEvent<HTMLDivElement>) => {
+				if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+					e.preventDefault()
+					setMode("plan")
+				} else if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+					e.preventDefault()
+					setMode("act")
+				}
+			},
+			[setMode],
+		)
 
 		useShortcut(usePlatform().togglePlanActKeys, onModeToggle, { disableTextInputs: false }) // important that we don't disable the text input here
 
@@ -1633,21 +1658,40 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 							</p>
 						</TooltipContent>
 						<TooltipTrigger>
-							<SwitchContainer data-testid="mode-switch" disabled={false} onClick={onModeToggle}>
+							<SwitchContainer
+								aria-label="Cline mode"
+								data-testid="mode-switch"
+								disabled={false}
+								onKeyDown={onRadioGroupKeyDown}
+								role="radiogroup">
 								<Slider isAct={mode === "act"} isPlan={mode === "plan"} />
-								{["Plan", "Act"].map((m) => (
-									<div
-										aria-checked={mode === m.toLowerCase()}
-										className={cn(
-											"pt-0.5 pb-px px-2 z-10 text-xs w-1/2 text-center bg-transparent",
-											mode === m.toLowerCase() ? "text-white" : "text-input-foreground",
-										)}
-										onMouseLeave={() => setShownTooltipMode(null)}
-										onMouseOver={() => setShownTooltipMode(m.toLowerCase() === "plan" ? "plan" : "act")}
-										role="switch">
-										{m}
-									</div>
-								))}
+								{(["Plan", "Act"] as const).map((m) => {
+									const mLower = m.toLowerCase() as "plan" | "act"
+									const isChecked = mode === mLower
+									return (
+										<div
+											aria-checked={isChecked}
+											aria-label={m}
+											className={cn(
+												"pt-0.5 pb-px px-2 z-10 text-xs w-1/2 text-center bg-transparent",
+												isChecked ? "text-white" : "text-input-foreground",
+											)}
+											key={m}
+											onClick={() => setMode(mLower)}
+											onKeyDown={(e) => {
+												if (e.key === " " || e.key === "Enter") {
+													e.preventDefault()
+													setMode(mLower)
+												}
+											}}
+											onMouseLeave={() => setShownTooltipMode(null)}
+											onMouseOver={() => setShownTooltipMode(mLower)}
+											role="radio"
+											tabIndex={isChecked ? 0 : -1}>
+											{m}
+										</div>
+									)
+								})}
 							</SwitchContainer>
 						</TooltipTrigger>
 					</Tooltip>


### PR DESCRIPTION
Screen readers announced the Plan/Act buttons as "clickable" with no state information. Replace the incorrect role="switch" with a proper role="radiogroup" container and role="radio" items so assistive technology announces e.g. "Plan, radio button, checked" / "Act, radio button, not checked".

Changes:
- SwitchContainer gets role="radiogroup" + aria-label="Cline mode"
- Each option div gets role="radio", aria-checked, aria-label, tabIndex (checked item tabIndex=0, unchecked -1 per roving-tabindex pattern)
- Container onKeyDown handles ArrowLeft/Up → Plan, ArrowRight/Down → Act
- Each radio also responds to Space/Enter to select that specific mode
- Refactor: extract setMode(target) helper so both click and keyboard can set a specific mode; onModeToggle now delegates to setMode

Closes #4932

<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
