### PR TITLE
fix(chat): block image paste/drop and show error when model lacks ima…

### DIFF
--- a/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -80,6 +80,7 @@ interface ChatTextAreaProps {
 	onSend: () => void
 	onSelectFilesAndImages: () => void
 	shouldDisableFilesAndImages: boolean
+	supportsImages: boolean
 	onHeightChange?: (height: number) => void
 	onFocusChange?: (isFocused: boolean) => void
 }
@@ -207,6 +208,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			onSend,
 			onSelectFilesAndImages,
 			shouldDisableFilesAndImages,
+			supportsImages,
 			onHeightChange,
 			onFocusChange,
 		},
@@ -254,6 +256,8 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 		const unsupportedFileTimerRef = useRef<NodeJS.Timeout | null>(null)
 		const [showDimensionError, setShowDimensionError] = useState(false)
 		const dimensionErrorTimerRef = useRef<NodeJS.Timeout | null>(null)
+		const [showImageUnsupportedError, setShowImageUnsupportedError] = useState(false)
+		const imageUnsupportedErrorTimerRef = useRef<NodeJS.Timeout | null>(null)
 
 		const [fileSearchResults, setFileSearchResults] = useState<SearchResult[]>([])
 		const [searchLoading, setSearchLoading] = useState(false)
@@ -841,6 +845,17 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			}, 3000)
 		}, [])
 
+		const showImageUnsupportedErrorMessage = useCallback(() => {
+			setShowImageUnsupportedError(true)
+			if (imageUnsupportedErrorTimerRef.current) {
+				clearTimeout(imageUnsupportedErrorTimerRef.current)
+			}
+			imageUnsupportedErrorTimerRef.current = setTimeout(() => {
+				setShowImageUnsupportedError(false)
+				imageUnsupportedErrorTimerRef.current = null
+			}, 3000)
+		}, [])
+
 		const handlePaste = useCallback(
 			async (e: React.ClipboardEvent) => {
 				const items = e.clipboardData.items
@@ -876,6 +891,11 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					const [type, subtype] = item.type.split("/")
 					return type === "image" && acceptedTypes.includes(subtype)
 				})
+				if (!supportsImages && imageItems.length > 0) {
+					e.preventDefault()
+					showImageUnsupportedErrorMessage()
+					return
+				}
 				if (!shouldDisableFilesAndImages && imageItems.length > 0) {
 					e.preventDefault()
 					const imagePromises = imageItems.map((item) => {
@@ -927,6 +947,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			},
 			[
 				shouldDisableFilesAndImages,
+				supportsImages,
 				setSelectedImages,
 				selectedImages,
 				selectedFiles,
@@ -934,6 +955,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				setInputValue,
 				inputValue,
 				showDimensionErrorMessage,
+				showImageUnsupportedErrorMessage,
 			],
 		)
 
@@ -1284,7 +1306,16 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				return type === "image" && acceptedTypes.includes(subtype)
 			})
 
-			if (shouldDisableFilesAndImages || imageFiles.length === 0) {
+			if (imageFiles.length === 0) {
+				return
+			}
+
+			if (!supportsImages) {
+				showImageUnsupportedErrorMessage()
+				return
+			}
+
+			if (shouldDisableFilesAndImages) {
 				return
 			}
 
@@ -1378,6 +1409,14 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					{showUnsupportedFileError && (
 						<div className="absolute inset-2.5 bg-[rgba(var(--vscode-errorForeground-rgb),0.1)] border-2 border-error rounded-xs flex items-center justify-center z-10 pointer-events-none">
 							<span className="text-error font-bold text-xs">Files other than images are currently disabled</span>
+						</div>
+					)}
+					{showImageUnsupportedError && (
+						<div className="absolute inset-2.5 bg-[rgba(var(--vscode-errorForeground-rgb),0.1)] border-2 border-error rounded-xs flex items-center justify-center z-10 pointer-events-none">
+							<span className="text-error font-bold text-xs text-center">
+								The current model does not support images. Enable &quot;Supports images&quot; in model settings to
+								use this feature.
+							</span>
 						</div>
 					)}
 					{showSlashCommandsMenu && (

--- a/apps/vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -390,6 +390,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 					scrollBehavior={scrollBehavior}
 					selectFilesAndImages={selectFilesAndImages}
 					shouldDisableFilesAndImages={shouldDisableFilesAndImages}
+					supportsImages={selectedModelInfo.supportsImages || false}
 				/>
 			</footer>
 		</ChatLayout>

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/InputSection.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/InputSection.tsx
@@ -9,6 +9,7 @@ interface InputSectionProps {
 	scrollBehavior: ScrollBehavior
 	placeholderText: string
 	shouldDisableFilesAndImages: boolean
+	supportsImages: boolean
 	selectFilesAndImages: () => Promise<void>
 }
 
@@ -21,6 +22,7 @@ export const InputSection: React.FC<InputSectionProps> = ({
 	scrollBehavior,
 	placeholderText,
 	shouldDisableFilesAndImages,
+	supportsImages,
 	selectFilesAndImages,
 }) => {
 	const {
@@ -72,6 +74,7 @@ export const InputSection: React.FC<InputSectionProps> = ({
 				setSelectedFiles={setSelectedFiles}
 				setSelectedImages={setSelectedImages}
 				shouldDisableFilesAndImages={shouldDisableFilesAndImages}
+				supportsImages={supportsImages}
 			/>
 		</>
 	)


### PR DESCRIPTION
…ge support

When `supportsImages` is disabled for the current model, pasting or dropping an image silently added it to the message and caused the extension to retry against a non-multimodal backend (issue #8635).

Now a 3-second inline error overlay is shown — matching the existing dimension-error and unsupported-file-error patterns — and the image is not attached. The `supportsImages` flag is threaded from `ChatView` → `InputSection` → `ChatTextArea` as a new prop.

Closes #8635

<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
