### PR TITLE
fix(openai): fallback token estimation when provider returns usage: null

### DIFF
--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -11,6 +11,7 @@ import {
 	type AiSdkFormatterMessage,
 	type AiSdkFormatterPart,
 	captureSdkError,
+	estimateTokens,
 	formatMessagesForAiSdk,
 	sanitizeSurrogates,
 } from "@cline/shared";
@@ -18,6 +19,7 @@ import { jsonSchema, streamText } from "ai";
 import { nanoid } from "nanoid";
 import { z } from "zod";
 import { extractErrorMessage } from "./format";
+import { estimateRequestInputTokens } from "./gateway";
 import {
 	isAnthropicCompatibleModel,
 	isCerebrasProvider,
@@ -865,6 +867,9 @@ async function* emitAiSdkEvents(
 	let streamError: string | undefined;
 	let finishUsage: unknown;
 	let finishProviderMetadata: unknown;
+	// Accumulate streamed output text so we can estimate output tokens when the
+	// provider returns no usage (some OpenAI-compatible gateways send usage: null).
+	let accumulatedText = "";
 
 	try {
 		if (stream.fullStream) {
@@ -875,6 +880,7 @@ async function* emitAiSdkEvents(
 						(part.text as string | undefined) ??
 						(part.delta as string | undefined);
 					if (text) {
+						accumulatedText += text;
 						yield { type: "text-delta", text };
 					}
 					continue;
@@ -886,6 +892,7 @@ async function* emitAiSdkEvents(
 						(part.text as string | undefined) ??
 						(part.reasoning as string | undefined);
 					if (text) {
+						accumulatedText += text;
 						yield {
 							type: "reasoning-delta",
 							text,
@@ -983,6 +990,7 @@ async function* emitAiSdkEvents(
 			}
 		} else if (stream.textStream) {
 			for await (const text of stream.textStream) {
+				accumulatedText += text;
 				yield { type: "text-delta", text };
 			}
 		}
@@ -1018,6 +1026,21 @@ async function* emitAiSdkEvents(
 		yield {
 			type: "usage",
 			usage: normalizeUsage(usageToEmit, metadataToUse, pricingValue),
+		};
+	} else if (!streamError) {
+		// Some OpenAI-compatible gateways return usage: null on every response,
+		// so no usage event is ever produced and the context-window indicator
+		// stays at 0%. Fall back to an estimate from the serialised request
+		// (input) and the accumulated streamed text (output), using the shared
+		// chars-per-token heuristic.
+		yield {
+			type: "usage",
+			usage: {
+				inputTokens: estimateRequestInputTokens(request),
+				outputTokens: estimateTokens(accumulatedText.length),
+				cacheReadTokens: 0,
+				cacheWriteTokens: 0,
+			},
 		};
 	}
 


### PR DESCRIPTION
Some OpenAI-compatible gateways return `"usage": null` in every streaming response. This left the context-window progress bar stuck at 0% because no usage event was ever emitted.

After the stream loop, check whether a usage chunk was received. If not, estimate input tokens from the serialised openAiMessages text and output tokens from the accumulated streaming text using the same ~4 chars/token heuristic already established in vscode-lm.ts, bedrock.ts, and gemini.ts. No new dependency is introduced.

Closes #9433

<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
