### PR TITLE
fix(api): coalesce streaming usage chunks

### DIFF
--- a/apps/vscode/src/core/api/providers/openai.ts
+++ b/apps/vscode/src/core/api/providers/openai.ts
@@ -12,6 +12,7 @@ import { convertToOpenAiMessages } from "../transform/openai-format"
 import { convertToR1Format } from "../transform/r1-format"
 import { ApiStream } from "../transform/stream"
 import { getOpenAIToolParams, ToolCallProcessor } from "../transform/tool-call-processor"
+import { OpenAiStreamUsageTracker } from "./utils/openai-stream-usage"
 
 interface OpenAiHandlerOptions extends CommonApiHandlerOptions {
 	openAiApiKey?: string
@@ -145,6 +146,7 @@ export class OpenAiHandler implements ApiHandler {
 		})
 
 		const toolCallProcessor = new ToolCallProcessor()
+		const usageTracker = new OpenAiStreamUsageTracker()
 
 		for await (const chunk of stream) {
 			const delta = chunk.choices?.[0]?.delta
@@ -167,15 +169,13 @@ export class OpenAiHandler implements ApiHandler {
 			}
 
 			if (chunk.usage) {
-				yield {
-					type: "usage",
-					inputTokens: chunk.usage.prompt_tokens || 0,
-					outputTokens: chunk.usage.completion_tokens || 0,
-					cacheReadTokens: chunk.usage.prompt_tokens_details?.cached_tokens || 0,
-					// @ts-expect-error-next-line
-					cacheWriteTokens: chunk.usage.prompt_cache_miss_tokens || 0,
-				}
+				usageTracker.record(chunk.usage)
 			}
+		}
+
+		const usageChunk = usageTracker.getUsageChunk()
+		if (usageChunk) {
+			yield usageChunk
 		}
 	}
 

--- a/apps/vscode/src/core/api/providers/utils/__tests__/openai-stream-usage.test.ts
+++ b/apps/vscode/src/core/api/providers/utils/__tests__/openai-stream-usage.test.ts
@@ -1,0 +1,44 @@
+import { expect } from "chai"
+import { OpenAiStreamUsageTracker } from "../openai-stream-usage"
+
+describe("OpenAiStreamUsageTracker", () => {
+	it("keeps only the final usage values from a streaming response", () => {
+		const tracker = new OpenAiStreamUsageTracker()
+
+		tracker.record({ prompt_tokens: 100, completion_tokens: 1 })
+		tracker.record({ prompt_tokens: 100, completion_tokens: 2 })
+
+		expect(tracker.getUsageChunk()).to.deep.equal({
+			type: "usage",
+			inputTokens: 100,
+			outputTokens: 2,
+			cacheReadTokens: 0,
+			cacheWriteTokens: 0,
+		})
+	})
+
+	it("maps cache token details from the final usage values", () => {
+		const tracker = new OpenAiStreamUsageTracker()
+
+		tracker.record({
+			prompt_tokens: 100,
+			completion_tokens: 2,
+			prompt_tokens_details: { cached_tokens: 40 },
+			prompt_cache_miss_tokens: 10,
+		})
+
+		expect(tracker.getUsageChunk()).to.deep.equal({
+			type: "usage",
+			inputTokens: 100,
+			outputTokens: 2,
+			cacheReadTokens: 40,
+			cacheWriteTokens: 10,
+		})
+	})
+
+	it("omits usage when the stream never reported usage", () => {
+		const tracker = new OpenAiStreamUsageTracker()
+
+		expect(tracker.getUsageChunk()).to.equal(undefined)
+	})
+})

--- a/apps/vscode/src/core/api/providers/utils/openai-stream-usage.ts
+++ b/apps/vscode/src/core/api/providers/utils/openai-stream-usage.ts
@@ -1,0 +1,34 @@
+import { ApiStreamUsageChunk } from "../../transform/stream"
+
+export interface OpenAiStreamUsage {
+	prompt_tokens?: number | null
+	completion_tokens?: number | null
+	prompt_tokens_details?: {
+		cached_tokens?: number | null
+	} | null
+	prompt_cache_miss_tokens?: number | null
+}
+
+export class OpenAiStreamUsageTracker {
+	private lastUsage: OpenAiStreamUsage | undefined
+
+	record(usage: OpenAiStreamUsage | null | undefined): void {
+		if (usage) {
+			this.lastUsage = usage
+		}
+	}
+
+	getUsageChunk(): ApiStreamUsageChunk | undefined {
+		if (!this.lastUsage) {
+			return undefined
+		}
+
+		return {
+			type: "usage",
+			inputTokens: this.lastUsage.prompt_tokens || 0,
+			outputTokens: this.lastUsage.completion_tokens || 0,
+			cacheReadTokens: this.lastUsage.prompt_tokens_details?.cached_tokens || 0,
+			cacheWriteTokens: this.lastUsage.prompt_cache_miss_tokens || 0,
+		}
+	}
+}

--- a/apps/vscode/src/core/api/providers/utils/openai-stream-usage.ts
+++ b/apps/vscode/src/core/api/providers/utils/openai-stream-usage.ts
@@ -25,10 +25,10 @@ export class OpenAiStreamUsageTracker {
 
 		return {
 			type: "usage",
-			inputTokens: this.lastUsage.prompt_tokens || 0,
-			outputTokens: this.lastUsage.completion_tokens || 0,
-			cacheReadTokens: this.lastUsage.prompt_tokens_details?.cached_tokens || 0,
-			cacheWriteTokens: this.lastUsage.prompt_cache_miss_tokens || 0,
+			inputTokens: this.lastUsage.prompt_tokens ?? 0,
+			outputTokens: this.lastUsage.completion_tokens ?? 0,
+			cacheReadTokens: this.lastUsage.prompt_tokens_details?.cached_tokens ?? 0,
+			cacheWriteTokens: this.lastUsage.prompt_cache_miss_tokens ?? 0,
 		}
 	}
 }

--- a/apps/vscode/src/core/api/providers/zai.ts
+++ b/apps/vscode/src/core/api/providers/zai.ts
@@ -17,6 +17,7 @@ import { withRetry } from "../retry"
 import { convertToOpenAiMessages } from "../transform/openai-format"
 import { ApiStream } from "../transform/stream"
 import { getOpenAIToolParams, ToolCallProcessor } from "../transform/tool-call-processor"
+import { OpenAiStreamUsageTracker } from "./utils/openai-stream-usage"
 
 interface ZAiHandlerOptions extends CommonApiHandlerOptions {
 	zaiApiLine?: string
@@ -92,6 +93,7 @@ export class ZAiHandler implements ApiHandler {
 		})
 
 		const toolCallProcessor = new ToolCallProcessor()
+		const usageTracker = new OpenAiStreamUsageTracker()
 
 		for await (const chunk of stream) {
 			const delta = chunk.choices?.[0]?.delta
@@ -107,14 +109,13 @@ export class ZAiHandler implements ApiHandler {
 			}
 
 			if (chunk.usage) {
-				yield {
-					type: "usage",
-					inputTokens: chunk.usage.prompt_tokens || 0,
-					outputTokens: chunk.usage.completion_tokens || 0,
-					cacheReadTokens: chunk.usage.prompt_tokens_details?.cached_tokens || 0,
-					cacheWriteTokens: 0,
-				}
+				usageTracker.record(chunk.usage)
 			}
+		}
+
+		const usageChunk = usageTracker.getUsageChunk()
+		if (usageChunk) {
+			yield usageChunk
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- coalesce streaming usage chunks for OpenAI-compatible and Z AI providers so only the final usage totals are emitted
- prevent local OpenAI-compatible servers that attach cumulative usage to every token chunk from inflating Cline's context/token accounting
- add regression coverage for cumulative streaming usage values, including cache token fields

Fixes #10148

## Testing

- `TS_NODE_PROJECT='./tsconfig.unit-test.json' ./node_modules/.bin/mocha.cmd --no-config --require ts-node/register --require tsconfig-paths/register src/core/api/providers/utils/__tests__/openai-stream-usage.test.ts --timeout 10000 --exit`
- `npx -y @biomejs/biome@2.4.5 check --config-path ./biome.jsonc --no-errors-on-unmatched --files-ignore-unknown=true src/core/api/providers/openai.ts src/core/api/providers/zai.ts src/core/api/providers/utils/openai-stream-usage.ts src/core/api/providers/utils/__tests__/openai-stream-usage.test.ts`
- `npx -y -p typescript@5.9.3 tsc --noEmit --pretty false --project tsconfig.unit-test.json`
- `git diff --check`