### PR TITLE
fix: unescape shell command entities

### DIFF
--- a/apps/vscode/src/core/api/transform/__tests__/o1-format.test.ts
+++ b/apps/vscode/src/core/api/transform/__tests__/o1-format.test.ts
@@ -1,0 +1,76 @@
+import { strict as assert } from "node:assert"
+import { describe, it } from "mocha"
+import { convertO1ResponseToAnthropicMessage } from "../o1-format"
+
+describe("convertO1ResponseToAnthropicMessage", () => {
+	it("unescapes execute_command command input", () => {
+		const message = convertO1ResponseToAnthropicMessage({
+			id: "chatcmpl-test",
+			model: "o1-test",
+			choices: [
+				{
+					finish_reason: "stop",
+					index: 0,
+					message: {
+						role: "assistant",
+						content: `
+I'll run it.
+
+<execute_command>
+<command>echo &quot;ok&quot; &amp;&amp; cat input.txt &gt; out.txt</command>
+</execute_command>
+`,
+						refusal: null,
+					},
+				},
+			],
+			usage: {
+				prompt_tokens: 1,
+				completion_tokens: 1,
+				total_tokens: 2,
+			},
+		} as any)
+
+		const tool = message.content.find((block) => block.type === "tool_use") as any
+
+		assert.ok(tool)
+		assert.equal(tool.name, "execute_command")
+		assert.equal(tool.input.command, 'echo "ok" && cat input.txt > out.txt')
+	})
+
+	it("leaves non-command tool input untouched", () => {
+		const message = convertO1ResponseToAnthropicMessage({
+			id: "chatcmpl-test",
+			model: "o1-test",
+			choices: [
+				{
+					finish_reason: "stop",
+					index: 0,
+					message: {
+						role: "assistant",
+						content: `
+I'll write the file.
+
+<write_to_file>
+<path>snippet.txt</path>
+<content>const text = &quot;ok&quot; &amp;&amp; keepHtmlEscaped;</content>
+</write_to_file>
+`,
+						refusal: null,
+					},
+				},
+			],
+			usage: {
+				prompt_tokens: 1,
+				completion_tokens: 1,
+				total_tokens: 2,
+			},
+		} as any)
+
+		const tool = message.content.find((block) => block.type === "tool_use") as any
+
+		assert.ok(tool)
+		assert.equal(tool.name, "write_to_file")
+		assert.equal(tool.input.content, "const text = &quot;ok&quot; &amp;&amp; keepHtmlEscaped;")
+	})
+})

--- a/apps/vscode/src/core/api/transform/o1-format.ts
+++ b/apps/vscode/src/core/api/transform/o1-format.ts
@@ -1,6 +1,8 @@
 import type { Anthropic } from "@anthropic-ai/sdk";
+import { ClineDefaultTool } from "@shared/tools";
 import type OpenAI from "openai";
 import { Logger } from "@/shared/services/Logger";
+import { fixModelHtmlEscaping } from "@/utils/string";
 
 const o1SystemPrompt = (systemPrompt: string) => `
 # System Prompt
@@ -320,7 +322,7 @@ function parseToolCall(toolName: string, content: string): ToolCall | null {
 	while ((match = paramRegex.exec(innerContent)) !== null) {
 		const [, paramName, paramValue] = match;
 		// Preserve newlines and trim only leading/trailing whitespace
-		tool_input[paramName] = paramValue.replace(/^\s+|\s+$/g, "");
+		tool_input[paramName] = normalizeToolInput(toolName, paramName, paramValue.replace(/^\s+|\s+$/g, ""));
 	}
 
 	// Validate required parameters
@@ -354,6 +356,14 @@ function validateToolInput(
 		default:
 			return false;
 	}
+}
+
+function normalizeToolInput(toolName: string, paramName: string, value: string): string {
+	if (toolName === ClineDefaultTool.BASH && paramName === "command") {
+		return fixModelHtmlEscaping(value)
+	}
+
+	return value
 }
 
 // Example usage:

--- a/apps/vscode/src/core/assistant-message/__tests__/parse-assistant-message.test.ts
+++ b/apps/vscode/src/core/assistant-message/__tests__/parse-assistant-message.test.ts
@@ -1,0 +1,32 @@
+import { strict as assert } from "node:assert"
+import { describe, it } from "mocha"
+import { parseAssistantMessageV2 } from "../parse-assistant-message"
+
+describe("parseAssistantMessageV2", () => {
+	it("unescapes HTML entities in execute_command commands", () => {
+		const [block] = parseAssistantMessageV2(`
+<execute_command>
+<command>printf &quot;ok&quot; &amp;&amp; grep foo input.txt &gt; out.txt</command>
+<requires_approval>false</requires_approval>
+</execute_command>
+`)
+
+		assert.equal(block.type, "tool_use")
+		assert.equal(block.name, "execute_command")
+		assert.equal(block.params.command, 'printf "ok" && grep foo input.txt > out.txt')
+		assert.equal(block.params.requires_approval, "false")
+	})
+
+	it("leaves non-command tool content untouched", () => {
+		const [block] = parseAssistantMessageV2(`
+<write_to_file>
+<path>index.html</path>
+<content>&lt;div&gt;A &amp;&amp; B&lt;/div&gt;</content>
+</write_to_file>
+`)
+
+		assert.equal(block.type, "tool_use")
+		assert.equal(block.name, "write_to_file")
+		assert.equal(block.params.content, "&lt;div&gt;A &amp;&amp; B&lt;/div&gt;")
+	})
+})

--- a/apps/vscode/src/core/assistant-message/parse-assistant-message.ts
+++ b/apps/vscode/src/core/assistant-message/parse-assistant-message.ts
@@ -1,4 +1,5 @@
 import { ClineDefaultTool, getToolUseNames } from "@shared/tools"
+import { fixModelHtmlEscaping } from "@utils/string"
 import { nanoid } from "nanoid"
 import { AssistantMessageContent, TextStreamContent, ToolParamName, ToolUse, toolParamNames } from "." // Assuming types are defined in index.ts or a similar file
 
@@ -66,7 +67,7 @@ export function parseAssistantMessageV2(assistantMessage: string): AssistantMess
 						currentCharIndex - closeTag.length + 1, // End before the closing tag
 					)
 					.trim()
-				currentToolUse.params[currentParamName] = value
+				currentToolUse.params[currentParamName] = normalizeToolParam(currentToolUse.name, currentParamName, value)
 				currentParamName = undefined // Go back to parsing tool content
 				// We don't continue loop here, need to check for tool close or other params at index i
 			} else {
@@ -213,9 +214,10 @@ export function parseAssistantMessageV2(assistantMessage: string): AssistantMess
 
 	// Finalize any open parameter within an open tool use
 	if (currentToolUse && currentParamName) {
-		currentToolUse.params[currentParamName] = assistantMessage
+		const value = assistantMessage
 			.slice(currentParamValueStart) // From param start to end of string
 			.trim()
+		currentToolUse.params[currentParamName] = normalizeToolParam(currentToolUse.name, currentParamName, value)
 		// Tool use remains partial
 	}
 
@@ -237,4 +239,12 @@ export function parseAssistantMessageV2(assistantMessage: string): AssistantMess
 	}
 
 	return contentBlocks
+}
+
+function normalizeToolParam(toolName: ClineDefaultTool, paramName: ToolParamName, value: string): string {
+	if (toolName === ClineDefaultTool.BASH && paramName === "command") {
+		return fixModelHtmlEscaping(value)
+	}
+
+	return value
 }


### PR DESCRIPTION
## Summary
- decode model-emitted HTML entities for `execute_command` command parameters
- cover both the main assistant-message parser and the O1 XML conversion path
- leave non-command tool content untouched so file content such as HTML/XML is not rewritten

## Verification
- `node -r ts-node/register -r tsconfig-paths/register -e "..."` direct behavior assertions for parser and O1 conversion
- `npx biome check --config-path ./biome.jsonc --diagnostic-level=error src/core/assistant-message/parse-assistant-message.ts src/core/api/transform/o1-format.ts src/core/assistant-message/__tests__/parse-assistant-message.test.ts src/core/api/transform/__tests__/o1-format.test.ts`
- `npx tsc --noEmit --project tsconfig.unit-test.json`
- `git diff --check`

Note: `npm run test:unit -- --grep ...` did not reach the assertions locally because Mocha/Node loaded `.ts` specs through an ESM path that missed the repo's TS alias hook. The direct `ts-node/register` assertion above validates the changed production paths.

Refs #11266
