### PR TITLE
fix(telemetry): forward CLINE_OTEL_RESOURCE_ATTRIBUTES to the OTEL resource

### DIFF
--- a/apps/vscode/src/services/telemetry/providers/opentelemetry/OpenTelemetryClientProvider.ts
+++ b/apps/vscode/src/services/telemetry/providers/opentelemetry/OpenTelemetryClientProvider.ts
@@ -52,13 +52,21 @@ export class OpenTelemetryClientProvider {
 			const headerCount = Object.keys(config.otlpHeaders).length
 			// In debug mode, show that headers are configured and their total length
 			Logger.log(`[OTEL DEBUG]   - OTLP Headers: ${headerCount} headers configured`)
+		}
+
+		if (isDebugMode) {
+			if (config.resourceAttributes) {
+				const attrCount = Object.keys(config.resourceAttributes).length
+				Logger.log(`[OTEL DEBUG]   - Resource Attributes: ${attrCount} attribute(s) configured`)
+			}
 			Logger.log("[OTEL DEBUG] ================================================")
 		}
 
-		// Create resource with service information
+		// Create resource with service information, merged with any user-supplied resource attributes
 		const resource = new Resource({
 			[ATTR_SERVICE_NAME]: "cline",
 			[ATTR_SERVICE_VERSION]: ExtensionRegistryInfo.version,
+			...config.resourceAttributes,
 		})
 
 		// Initialize metrics if configured

--- a/apps/vscode/src/shared/services/config/otel-config.ts
+++ b/apps/vscode/src/shared/services/config/otel-config.ts
@@ -85,6 +85,13 @@ export interface OpenTelemetryClientConfig {
 	 * Maximum queue size for log records (default: 2048)
 	 */
 	logMaxQueueSize?: number
+
+	/**
+	 * Additional resource attributes to include in the OTEL Resource.
+	 * Parsed from CLINE_OTEL_RESOURCE_ATTRIBUTES (comma-separated key=value pairs).
+	 * Example: "deployment.environment=production,team=backend"
+	 */
+	resourceAttributes?: Record<string, string>
 }
 
 /**
@@ -162,6 +169,7 @@ function getOtelConfig(): OpenTelemetryClientConfig {
  * - CLINE_OTEL_LOG_BATCH_SIZE: Maximum batch size for log records (default: 512)
  * - CLINE_OTEL_LOG_BATCH_TIMEOUT: Maximum time to wait before exporting logs in ms (default: 5000)
  * - CLINE_OTEL_LOG_MAX_QUEUE_SIZE: Maximum queue size for log records (default: 2048)
+ * - CLINE_OTEL_RESOURCE_ATTRIBUTES: Comma-separated resource attribute key=value pairs (e.g., "deployment.environment=prod,team=backend")
  *
  * @private
  * @see .env.example for development setup
@@ -193,6 +201,9 @@ function getRuntimeOtelConfig(): OpenTelemetryClientConfig {
 			: undefined,
 		otlpHeaders: process.env.CLINE_OTEL_EXPORTER_OTLP_HEADERS
 			? parseKeyPairsIntoRecord(process.env.CLINE_OTEL_EXPORTER_OTLP_HEADERS)
+			: undefined,
+		resourceAttributes: process.env.CLINE_OTEL_RESOURCE_ATTRIBUTES
+			? parseKeyPairsIntoRecord(process.env.CLINE_OTEL_RESOURCE_ATTRIBUTES)
 			: undefined,
 	}
 }


### PR DESCRIPTION
Closes #8586.

Cline reads several `CLINE_OTEL_*` env vars for custom OpenTelemetry export but ignored `CLINE_OTEL_RESOURCE_ATTRIBUTES`, so user-supplied resource attributes never reached the configured endpoint. This parses it with the existing `parseKeyPairsIntoRecord` helper (same as `otlpHeaders`) and merges the result into the OTEL `Resource`.

**Testing:** `tsc --noEmit` passes. Set `CLINE_OTEL_RESOURCE_ATTRIBUTES="deployment.environment=prod,team=backend"` with your OTLP endpoint vars and confirm the attributes appear on exported telemetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
