### PR TITLE
feat(zai): add Coding Plan API endpoint support

### DIFF
--- a/apps/vscode/src/core/api/providers/zai.ts
+++ b/apps/vscode/src/core/api/providers/zai.ts
@@ -32,7 +32,20 @@ export class ZAiHandler implements ApiHandler {
 	}
 
 	private useChinaApi(): boolean {
-		return this.options.zaiApiLine === "china"
+		return this.options.zaiApiLine === "china" || this.options.zaiApiLine === "coding-china"
+	}
+
+	private getBaseUrl(): string {
+		switch (this.options.zaiApiLine) {
+			case "china":
+				return "https://open.bigmodel.cn/api/paas/v4"
+			case "coding-international":
+				return "https://api.z.ai/api/coding/paas/v4"
+			case "coding-china":
+				return "https://open.bigmodel.cn/api/coding/paas/v4"
+			default:
+				return "https://api.z.ai/api/paas/v4"
+		}
 	}
 
 	private ensureClient(): OpenAI {
@@ -42,7 +55,7 @@ export class ZAiHandler implements ApiHandler {
 			}
 			try {
 				this.client = createOpenAIClient({
-					baseURL: this.useChinaApi() ? "https://open.bigmodel.cn/api/paas/v4" : "https://api.z.ai/api/paas/v4",
+					baseURL: this.getBaseUrl(),
 					apiKey: this.options.zaiApiKey,
 					defaultHeaders: {
 						"HTTP-Referer": "https://cline.bot",

--- a/apps/vscode/webview-ui/src/components/settings/providers/ZAiProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/ZAiProvider.tsx
@@ -30,7 +30,10 @@ export const ZAiProvider = ({ showModelOptions, isPopup, currentMode }: ZAiProvi
 
 	// Determine which models to use based on API line selection
 	const zaiModels = useMemo(
-		() => (apiConfiguration?.zaiApiLine === "china" ? mainlandZAiModels : internationalZAiModels),
+		() =>
+			apiConfiguration?.zaiApiLine === "china" || apiConfiguration?.zaiApiLine === "coding-china"
+				? mainlandZAiModels
+				: internationalZAiModels,
 		[apiConfiguration?.zaiApiLine],
 	)
 
@@ -48,8 +51,10 @@ export const ZAiProvider = ({ showModelOptions, isPopup, currentMode }: ZAiProvi
 						position: "relative",
 					}}
 					value={apiConfiguration?.zaiApiLine || "international"}>
-					<VSCodeOption value="international">api.z.ai</VSCodeOption>
-					<VSCodeOption value="china">open.bigmodel.cn</VSCodeOption>
+					<VSCodeOption value="international">api.z.ai (Standard)</VSCodeOption>
+					<VSCodeOption value="china">open.bigmodel.cn (Standard)</VSCodeOption>
+					<VSCodeOption value="coding-international">api.z.ai (Coding Plan)</VSCodeOption>
+					<VSCodeOption value="coding-china">open.bigmodel.cn (Coding Plan)</VSCodeOption>
 				</VSCodeDropdown>
 			</DropdownContainer>
 			<p
@@ -58,15 +63,15 @@ export const ZAiProvider = ({ showModelOptions, isPopup, currentMode }: ZAiProvi
 					marginTop: 3,
 					color: "var(--vscode-descriptionForeground)",
 				}}>
-				Please select the appropriate API entrypoint based on your location. If you are in China, choose open.bigmodel.cn
-				. Otherwise, choose api.z.ai.
+				Select your API entrypoint. Choose a "Coding Plan" option if you have a GLM Coding Plan subscription; otherwise
+				choose "Standard".
 			</p>
 			<ApiKeyField
 				initialValue={apiConfiguration?.zaiApiKey || ""}
 				onChange={(value) => handleFieldChange("zaiApiKey", value)}
 				providerName="Z AI"
 				signupUrl={
-					apiConfiguration?.zaiApiLine === "china"
+					apiConfiguration?.zaiApiLine === "china" || apiConfiguration?.zaiApiLine === "coding-china"
 						? "https://open.bigmodel.cn/console/overview"
 						: "https://z.ai/manage-apikey/apikey-list"
 				}

--- a/apps/vscode/webview-ui/src/components/settings/utils/providerUtils.ts
+++ b/apps/vscode/webview-ui/src/components/settings/utils/providerUtils.ts
@@ -135,7 +135,9 @@ export function getModelsForProvider(
 		case "huawei-cloud-maas":
 			return huaweiCloudMaasModels
 		case "zai":
-			return apiConfiguration?.zaiApiLine === "china" ? mainlandZAiModels : internationalZAiModels
+			return apiConfiguration?.zaiApiLine === "china" || apiConfiguration?.zaiApiLine === "coding-china"
+				? mainlandZAiModels
+				: internationalZAiModels
 		case "fireworks":
 			return fireworksModels
 		case "minimax":
@@ -455,9 +457,14 @@ export function normalizeApiConfiguration(
 				selectedModelInfo: vercelModelInfo || openRouterDefaultModelInfo,
 			}
 		case "zai":
-			const zaiModels = apiConfiguration?.zaiApiLine === "china" ? mainlandZAiModels : internationalZAiModels
+			const zaiModels =
+				apiConfiguration?.zaiApiLine === "china" || apiConfiguration?.zaiApiLine === "coding-china"
+					? mainlandZAiModels
+					: internationalZAiModels
 			const zaiDefaultId =
-				apiConfiguration?.zaiApiLine === "china" ? mainlandZAiDefaultModelId : internationalZAiDefaultModelId
+				apiConfiguration?.zaiApiLine === "china" || apiConfiguration?.zaiApiLine === "coding-china"
+					? mainlandZAiDefaultModelId
+					: internationalZAiDefaultModelId
 			return getProviderData(zaiModels, zaiDefaultId)
 		case "fireworks":
 			const fireworksModelId =


### PR DESCRIPTION
Closes #6761.

Z AI's Coding Plan subscription uses a distinct base path (`/api/coding/paas/v4`) vs. the standard pay-as-you-go path (`/api/paas/v4`). Without it, Coding Plan subscribers are billed against their token balance and hit HTTP 429 at zero balance.

Adds two entrypoint options to the Z AI settings dropdown — **api.z.ai (Coding Plan)** and **open.bigmodel.cn (Coding Plan)** — mapped to new `zaiApiLine` values `coding-international` / `coding-china`. Reuses the existing `zaiApiLine` string field, so **no proto change**.

**Test plan**
- Z AI provider settings show 4 entrypoints (Standard + Coding Plan × 2 regions).
- `coding-international` → `https://api.z.ai/api/coding/paas/v4`; `coding-china` → `https://open.bigmodel.cn/api/coding/paas/v4`.
- Existing `international`/`china` still route to the standard endpoints; model selector unchanged per region.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
