### PR TITLE
feat(mcp): include server-level instructions in model context

### DIFF
--- a/apps/vscode/src/core/prompts/system-prompt/components/mcp.ts
+++ b/apps/vscode/src/core/prompts/system-prompt/components/mcp.ts
@@ -50,6 +50,15 @@ async function getMcpServers(servers: McpServer[], variant: PromptVariant, conte
 	})
 }
 
+/**
+ * MCP server instructions are server-controlled, untrusted text. Neutralize markdown
+ * ATX headings so a malicious or compromised server cannot inject synthetic sections
+ * (e.g. "### Available Tools") into the system prompt alongside the real ones.
+ */
+function sanitizeMcpServerInstructions(instructions: string): string {
+	return instructions.replace(/^[ \t]*#{1,6}[ \t]+/gm, "")
+}
+
 function formatMcpServersList(servers: McpServer[]): string {
 	return servers
 		.filter((server) => server.status === "connected")
@@ -77,7 +86,10 @@ function formatMcpServersList(servers: McpServer[]): string {
 				?.map((prompt) => {
 					const argsStr = prompt.arguments?.length
 						? `\n    Arguments: ${prompt.arguments
-								.map((arg) => `${arg.name}${arg.required ? " (required)" : ""}${arg.description ? `: ${arg.description}` : ""}`)
+								.map(
+									(arg) =>
+										`${arg.name}${arg.required ? " (required)" : ""}${arg.description ? `: ${arg.description}` : ""}`,
+								)
 								.join(", ")}`
 						: ""
 					const title = prompt.title ? ` (${prompt.title})` : ""
@@ -91,6 +103,9 @@ function formatMcpServersList(servers: McpServer[]): string {
 				`## ${server.name}` +
 				(config.command
 					? ` (\`${config.command}${config.args && Array.isArray(config.args) ? ` ${config.args.join(" ")}` : ""}\`)`
+					: "") +
+				(server.instructions
+					? `\n\n### Server Instructions\n${sanitizeMcpServerInstructions(server.instructions)}`
 					: "") +
 				(tools ? `\n\n### Available Tools\n${tools}` : "") +
 				(templates ? `\n\n### Resource Templates\n${templates}` : "") +

--- a/apps/vscode/src/services/mcp/McpHub.ts
+++ b/apps/vscode/src/services/mcp/McpHub.ts
@@ -653,6 +653,12 @@ export class McpHub {
 				Logger.error(`[MCP Debug] Error setting notification handlers for ${name}:`, error)
 			}
 
+			// Capture server-level instructions from the MCP initialize response
+			const serverInstructions = connection.client.getInstructions?.()
+			if (serverInstructions) {
+				connection.server.instructions = serverInstructions
+			}
+
 			// Initial fetch of tools, resources, and prompts
 			connection.server.tools = await this.fetchToolsList(name)
 			connection.server.resources = await this.fetchResourcesList(name)

--- a/apps/vscode/src/shared/mcp.ts
+++ b/apps/vscode/src/shared/mcp.ts
@@ -22,6 +22,12 @@ export type McpServer = {
 	uid?: string
 	oauthRequired?: boolean
 	oauthAuthStatus?: McpOAuthAuthStatus
+	/**
+	 * Server-level instructions from the MCP initialize response.
+	 * These are provided by the server to guide how it should be used.
+	 * @see https://modelcontextprotocol.io/specification/2025-03-26/basic/lifecycle
+	 */
+	instructions?: string
 }
 
 export type McpOAuthAuthStatus = "authenticated" | "unauthenticated" | "pending"


### PR DESCRIPTION
Closes #8797.

MCP servers can expose an `instructions` field in their `initialize` response (per the [MCP spec lifecycle](https://modelcontextprotocol.io/specification/2025-03-26/basic/lifecycle)), but Cline never captured or used it. After connecting, `McpHub` now reads `client.getInstructions()` (already provided by the `@modelcontextprotocol/sdk` `Client`) and stores it on the `McpServer`; the MCP system-prompt section renders a `### Server Instructions` block when present. No proto change.

**Testing:** `tsc --noEmit` passes (extension + webview). Configure an MCP server that returns `instructions` in its initialize response and verify the system prompt includes a `### Server Instructions` section; servers without instructions are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
