### PR TITLE
chore: bump version and update changelog (v3.88.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [3.88.0]
+
+### Added
+
+- Add the latest Fireworks AI serverless models and update the default Fireworks model to Kimi K2.6.
+
+### Fixed
+
+- Fix MCP server delete/add flows so settings writes do not cause the MCP server list to be emptied by the file watcher.
+- Remove stale Fireworks AI models and correct Fireworks model metadata and cache pricing.
+
+### Changed
+
+- Always use the upstream Cline recommended models endpoint instead of gating it behind a feature flag.
+
 ## [3.87.0]
 
 ### Added

--- a/apps/vscode/package-lock.json
+++ b/apps/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "claude-dev",
-	"version": "3.87.0",
+	"version": "3.88.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "claude-dev",
-			"version": "3.87.0",
+			"version": "3.88.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.37.0",

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -2,7 +2,7 @@
 	"name": "claude-dev",
 	"displayName": "Cline",
 	"description": "Autonomous coding agent right in your IDE, capable of creating/editing files, running commands, using the browser, and more with your permission every step of the way.",
-	"version": "3.87.0",
+	"version": "3.88.0",
 	"icon": "assets/icons/icon.png",
 	"engines": {
 		"vscode": "^1.84.0"


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Release prep for v3.88.0. Bumps the VS Code extension version (`apps/vscode/package.json` + `package-lock.json`) from 3.87.0 to 3.88.0 and adds the corresponding `CHANGELOG.md` section.

This release includes the VS Code extension changes that landed after v3.87.0:

- Fireworks AI model registry sync with current platform offerings (#11173)
- MCP settings write guard so delete/add flows do not empty the server list (#11240)
- Removal of the upstream recommended models feature flag (#11315)

The changelog intentionally excludes CLI- and SDK-only changes that are not relevant to the VS Code extension release notes.

### Test Procedure

No code changes here beyond the version bump and changelog. The underlying changes are covered by their own PR test procedures. For this release-prep branch, I verified the diff scope and whitespace with:

```bash
git diff --stat origin/main..HEAD
git diff --check origin/main..HEAD
```

Standard CI should run on this PR.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality not to work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - release prep only.

### Additional Notes

After this merges, the release is published by manually dispatching the `ext-vscode-publish-stable` workflow from `main` with tag `v3.88.0` (auto-create tag enabled).
