### PR TITLE
fix: empty SDK message content replay for Bedrock CLINE-2373

### DIFF
--- a/sdk/packages/core/src/runtime/config/agent-message-codec.test.ts
+++ b/sdk/packages/core/src/runtime/config/agent-message-codec.test.ts
@@ -1,3 +1,4 @@
+import { EMPTY_CONTENT_TEXT } from "@cline/shared";
 import { describe, expect, it } from "vitest";
 import { messageToAgentMessages } from "./agent-message-codec";
 
@@ -14,7 +15,7 @@ describe("agent message codec", () => {
 			{
 				id: "empty",
 				role: "assistant",
-				content: [{ type: "text", text: "ERROR: EMPTY CONTENT" }],
+				content: [{ type: "text", text: EMPTY_CONTENT_TEXT }],
 				createdAt: 1,
 				metadata: undefined,
 				modelInfo: undefined,
@@ -32,7 +33,25 @@ describe("agent message codec", () => {
 			{
 				id: "blank",
 				role: "user",
-				content: [{ type: "text", text: "ERROR: EMPTY CONTENT" }],
+				content: [{ type: "text", text: EMPTY_CONTENT_TEXT }],
+				createdAt: 1,
+				metadata: undefined,
+				modelInfo: undefined,
+				metrics: undefined,
+			},
+		]);
+		expect(
+			messageToAgentMessages({
+				id: "whitespace",
+				role: "assistant",
+				ts: 1,
+				content: "   \n\t  ",
+			}),
+		).toEqual([
+			{
+				id: "whitespace",
+				role: "assistant",
+				content: [{ type: "text", text: EMPTY_CONTENT_TEXT }],
 				createdAt: 1,
 				metadata: undefined,
 				modelInfo: undefined,

--- a/sdk/packages/core/src/runtime/config/agent-message-codec.test.ts
+++ b/sdk/packages/core/src/runtime/config/agent-message-codec.test.ts
@@ -2,6 +2,45 @@ import { describe, expect, it } from "vitest";
 import { messageToAgentMessages } from "./agent-message-codec";
 
 describe("agent message codec", () => {
+	it("replaces empty persisted messages with an explicit error text part", () => {
+		expect(
+			messageToAgentMessages({
+				id: "empty",
+				role: "assistant",
+				ts: 1,
+				content: [],
+			}),
+		).toEqual([
+			{
+				id: "empty",
+				role: "assistant",
+				content: [{ type: "text", text: "ERROR: EMPTY CONTENT" }],
+				createdAt: 1,
+				metadata: undefined,
+				modelInfo: undefined,
+				metrics: undefined,
+			},
+		]);
+		expect(
+			messageToAgentMessages({
+				id: "blank",
+				role: "user",
+				ts: 1,
+				content: "",
+			}),
+		).toEqual([
+			{
+				id: "blank",
+				role: "user",
+				content: [{ type: "text", text: "ERROR: EMPTY CONTENT" }],
+				createdAt: 1,
+				metadata: undefined,
+				modelInfo: undefined,
+				metrics: undefined,
+			},
+		]);
+	});
+
 	it("preserves mixed tool result and user text order", () => {
 		const messages = messageToAgentMessages({
 			id: "msg_mixed",

--- a/sdk/packages/core/src/runtime/config/agent-message-codec.ts
+++ b/sdk/packages/core/src/runtime/config/agent-message-codec.ts
@@ -13,8 +13,7 @@ import type {
 	ToolResultContent,
 	ToolUseContent,
 } from "@cline/shared";
-
-const EMPTY_CONTENT_TEXT = "ERROR: EMPTY CONTENT";
+import { EMPTY_CONTENT_TEXT } from "@cline/shared";
 
 export function messageToAgentMessages(
 	message: MessageWithMetadata,
@@ -135,7 +134,7 @@ export function agentMessagesToMessages(
 
 function normalizeContentBlocks(content: Message["content"]): ContentBlock[] {
 	if (typeof content === "string") {
-		return content.length > 0
+		return content.trim().length > 0
 			? [{ type: "text", text: content } as TextContent]
 			: [];
 	}

--- a/sdk/packages/core/src/runtime/config/agent-message-codec.ts
+++ b/sdk/packages/core/src/runtime/config/agent-message-codec.ts
@@ -14,6 +14,8 @@ import type {
 	ToolUseContent,
 } from "@cline/shared";
 
+const EMPTY_CONTENT_TEXT = "ERROR: EMPTY CONTENT";
+
 export function messageToAgentMessages(
 	message: MessageWithMetadata,
 ): AgentMessage[] {
@@ -48,7 +50,7 @@ export function messageToAgentMessages(
 		out.push({
 			id: baseId,
 			role: message.role,
-			content: [],
+			content: [{ type: "text", text: EMPTY_CONTENT_TEXT }],
 			createdAt: message.ts ?? Date.now(),
 			metadata: message.metadata,
 			modelInfo: message.modelInfo,

--- a/sdk/packages/shared/src/index.browser.ts
+++ b/sdk/packages/shared/src/index.browser.ts
@@ -86,6 +86,7 @@ export type {
 	AiSdkMessagePart,
 } from "./llms/ai-sdk-format";
 export {
+	EMPTY_CONTENT_TEXT,
 	formatMessagesForAiSdk,
 	sanitizeSurrogates,
 	toAiSdkToolResultOutput,

--- a/sdk/packages/shared/src/index.ts
+++ b/sdk/packages/shared/src/index.ts
@@ -100,6 +100,7 @@ export type {
 	AiSdkMessagePart,
 } from "./llms/ai-sdk-format";
 export {
+	EMPTY_CONTENT_TEXT,
 	formatMessagesForAiSdk,
 	sanitizeSurrogates,
 	toAiSdkToolResultOutput,

--- a/sdk/packages/shared/src/llms/ai-sdk-format.test.ts
+++ b/sdk/packages/shared/src/llms/ai-sdk-format.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+	EMPTY_CONTENT_TEXT,
 	formatMessagesForAiSdk,
 	sanitizeSurrogates,
 	toAiSdkToolResultOutput,
@@ -48,11 +49,11 @@ describe("formatMessagesForAiSdk", () => {
 		expect(messages).toEqual([
 			{
 				role: "user",
-				content: [{ type: "text", text: "ERROR: EMPTY CONTENT" }],
+				content: [{ type: "text", text: EMPTY_CONTENT_TEXT }],
 			},
 			{
 				role: "assistant",
-				content: [{ type: "text", text: "ERROR: EMPTY CONTENT" }],
+				content: [{ type: "text", text: EMPTY_CONTENT_TEXT }],
 			},
 			{
 				role: "user",
@@ -69,7 +70,7 @@ describe("formatMessagesForAiSdk", () => {
 		expect(messages).toEqual([
 			{
 				role: "assistant",
-				content: [{ type: "text", text: "ERROR: EMPTY CONTENT" }],
+				content: [{ type: "text", text: EMPTY_CONTENT_TEXT }],
 			},
 		]);
 	});

--- a/sdk/packages/shared/src/llms/ai-sdk-format.test.ts
+++ b/sdk/packages/shared/src/llms/ai-sdk-format.test.ts
@@ -38,6 +38,42 @@ describe("formatMessagesForAiSdk", () => {
 		]);
 	});
 
+	it("replaces empty string user and assistant messages with explicit error text", () => {
+		const messages = formatMessagesForAiSdk(undefined, [
+			{ role: "user", content: "" },
+			{ role: "assistant", content: "   \n\t  " },
+			{ role: "user", content: [{ type: "text", text: "continue" }] },
+		]);
+
+		expect(messages).toEqual([
+			{
+				role: "user",
+				content: [{ type: "text", text: "ERROR: EMPTY CONTENT" }],
+			},
+			{
+				role: "assistant",
+				content: [{ type: "text", text: "ERROR: EMPTY CONTENT" }],
+			},
+			{
+				role: "user",
+				content: [{ type: "text", text: "continue" }],
+			},
+		]);
+	});
+
+	it("replaces empty content arrays with explicit error text", () => {
+		const messages = formatMessagesForAiSdk(undefined, [
+			{ role: "assistant", content: [] },
+		]);
+
+		expect(messages).toEqual([
+			{
+				role: "assistant",
+				content: [{ type: "text", text: "ERROR: EMPTY CONTENT" }],
+			},
+		]);
+	});
+
 	it("preserves providerOptions on text parts", () => {
 		const messages = formatMessagesForAiSdk(undefined, [
 			{

--- a/sdk/packages/shared/src/llms/ai-sdk-format.ts
+++ b/sdk/packages/shared/src/llms/ai-sdk-format.ts
@@ -61,6 +61,8 @@ export interface AiSdkFormatterMessage {
 	content: string | AiSdkFormatterPart[];
 }
 
+const EMPTY_CONTENT_TEXT = "ERROR: EMPTY CONTENT";
+
 export type AiSdkMessagePart = Record<string, unknown>;
 export type AiSdkMessage = {
 	role: "system" | "user" | "assistant" | "tool";
@@ -290,6 +292,13 @@ export function formatMessagesForAiSdk(
 		const contentParts = message.content;
 
 		if (typeof contentParts === "string") {
+			if (contentParts.trim().length === 0) {
+				result.push({
+					role: message.role,
+					content: [{ type: "text", text: EMPTY_CONTENT_TEXT }],
+				});
+				continue;
+			}
 			result.push({
 				role: message.role,
 				content: sanitizeSurrogates(contentParts),
@@ -299,6 +308,14 @@ export function formatMessagesForAiSdk(
 
 		const messageParts: AiSdkMessagePart[] = [];
 		const toolResultParts: AiSdkMessagePart[] = [];
+		if (contentParts.length === 0) {
+			result.push({
+				role: message.role,
+				content: [{ type: "text", text: EMPTY_CONTENT_TEXT }],
+			});
+			continue;
+		}
+
 		for (const part of contentParts) {
 			switch (part.type) {
 				case "text":

--- a/sdk/packages/shared/src/llms/ai-sdk-format.ts
+++ b/sdk/packages/shared/src/llms/ai-sdk-format.ts
@@ -61,7 +61,7 @@ export interface AiSdkFormatterMessage {
 	content: string | AiSdkFormatterPart[];
 }
 
-const EMPTY_CONTENT_TEXT = "ERROR: EMPTY CONTENT";
+export const EMPTY_CONTENT_TEXT = "ERROR: EMPTY CONTENT";
 
 export type AiSdkMessagePart = Record<string, unknown>;
 export type AiSdkMessage = {


### PR DESCRIPTION


<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** https://github.com/cline/cline/issues/11249

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

This fixes SDK message formatting when persisted conversation history contains an empty user or assistant message, such as after an interrupted task is resumed.

Instead of dropping the message turn, the SDK now preserves it and inserts a text content block:

ERROR: EMPTY CONTENT

This prevents providers like Amazon Bedrock from rejecting replayed history with empty content arrays while avoiding message removal that could affect provider turn ordering.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
