### PR TITLE
fix(cli): connector thread session routing & stale hub session

### DIFF
--- a/apps/cli/src/connectors/adapters/discord.test.ts
+++ b/apps/cli/src/connectors/adapters/discord.test.ts
@@ -228,7 +228,7 @@ describe("discordConnector", () => {
 		});
 	});
 
-	it("switches Discord thread state to the incoming participant without reusing the previous participant session", async () => {
+	it("updates Discord participant metadata without changing the thread session", async () => {
 		const dir = await mkdtemp(join(tmpdir(), "discord-participants-"));
 		const bindingsPath = join(dir, "threads.json");
 		const thread = createThread({
@@ -278,11 +278,13 @@ describe("discordConnector", () => {
 			errorLabel: "Discord",
 		});
 
-		const bob =
-			readBindings<TestDiscordState>(bindingsPath)["discord:user:bob"];
-		expect(bob?.state?.participantKey).toBe("discord:user:bob");
-		expect(bob?.state?.participantLabel).toBe("Bob");
-		expect(bob?.state?.sessionId).toBeUndefined();
+		const binding =
+			readBindings<TestDiscordState>(bindingsPath)[
+				"discord:guild:channel:thread"
+			];
+		expect(binding?.state?.participantKey).toBe("discord:user:bob");
+		expect(binding?.state?.participantLabel).toBe("Bob");
+		expect(binding?.state?.sessionId).toBe("session-alice");
 		expect(
 			readBindings<TestDiscordState>(bindingsPath)["discord:user:alice"]?.state
 				?.sessionId,

--- a/apps/cli/src/connectors/adapters/discord.ts
+++ b/apps/cli/src/connectors/adapters/discord.ts
@@ -53,7 +53,6 @@ import {
 	findBindingForParticipantKey,
 	findBindingForThread,
 	loadThreadState,
-	mergeThreadState,
 	persistMergedThreadState,
 	readBindings,
 } from "../thread-bindings";
@@ -564,43 +563,15 @@ async function postDiscordResolvedText(input: {
 	});
 }
 
-function resolveParticipantState(input: {
-	bindingsPath: string;
-	baseStartRequest: ChatStartSessionRequest;
+function resolveCurrentStateWithParticipant(input: {
+	currentState: DiscordThreadState;
 	participant: DiscordParticipant;
 }): DiscordThreadState {
-	const existing = findBindingForParticipantKey(
-		readBindings<DiscordThreadState>(input.bindingsPath),
-		input.participant.key,
-	)?.binding.state;
 	return {
-		...mergeThreadState<DiscordThreadState>(
-			undefined,
-			existing,
-			input.baseStartRequest,
-		),
+		...input.currentState,
 		participantKey: input.participant.key,
 		participantLabel: input.participant.label,
 	};
-}
-
-function resolveCurrentStateWithParticipant(input: {
-	currentState: DiscordThreadState;
-	bindingsPath: string;
-	baseStartRequest: ChatStartSessionRequest;
-	participant: DiscordParticipant;
-}): DiscordThreadState {
-	if (input.currentState.participantKey === input.participant.key) {
-		return {
-			...input.currentState,
-			participantLabel: input.participant.label,
-		};
-	}
-	return resolveParticipantState({
-		bindingsPath: input.bindingsPath,
-		baseStartRequest: input.baseStartRequest,
-		participant: input.participant,
-	});
 }
 
 async function persistDiscordThreadContext(input: {
@@ -624,8 +595,6 @@ async function persistDiscordThreadContext(input: {
 	);
 	const nextState = resolveCurrentStateWithParticipant({
 		currentState,
-		bindingsPath: input.bindingsPath,
-		baseStartRequest: input.baseStartRequest,
 		participant,
 	});
 	if (
@@ -1133,9 +1102,7 @@ class DiscordConnector extends ConnectorBase<
 				isSubscribedThreadMessage?: boolean;
 			},
 		) => {
-			const queueKey =
-				(await loadThreadState(thread, bindingsPath, startRequest))
-					.participantKey || thread.id;
+			const queueKey = thread.id;
 			const runTurn = async () => {
 				try {
 					await handleConnectorUserTurn({

--- a/apps/cli/src/connectors/adapters/discord.ts
+++ b/apps/cli/src/connectors/adapters/discord.ts
@@ -50,7 +50,7 @@ import {
 	type ConnectorMuteTarget,
 	type ConnectorThreadState,
 	clearBindingSessionIds,
-	findBindingForParticipantKey,
+	findBindingForDeliveryTarget,
 	findBindingForThread,
 	loadThreadState,
 	persistMergedThreadState,
@@ -638,20 +638,20 @@ async function deliverScheduledResult(input: {
 	const threadId =
 		typeof delivery.threadId === "string" ? delivery.threadId.trim() : "";
 	const bindingKey =
-		typeof delivery.bindingKey === "string"
-			? delivery.bindingKey.trim()
-			: typeof delivery.participantKey === "string"
-				? delivery.participantKey.trim()
-				: "";
-	if (!threadId && !bindingKey) {
+		typeof delivery.bindingKey === "string" ? delivery.bindingKey.trim() : "";
+	const participantKey =
+		typeof delivery.participantKey === "string"
+			? delivery.participantKey.trim()
+			: "";
+	if (!threadId && !bindingKey && !participantKey) {
 		return;
 	}
 	const bindings = readBindings<DiscordThreadState>(input.bindingsPath);
-	const match = bindingKey
-		? findBindingForParticipantKey(bindings, bindingKey)
-		: threadId
-			? { key: threadId, binding: bindings[threadId] }
-			: undefined;
+	const match = findBindingForDeliveryTarget(bindings, {
+		bindingKey,
+		threadId,
+		participantKey,
+	});
 	const binding = match?.binding;
 	if (!binding?.serializedThread) {
 		return;

--- a/apps/cli/src/connectors/adapters/gchat.test.ts
+++ b/apps/cli/src/connectors/adapters/gchat.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { __test__ } from "./gchat";
 
 describe("gchat binding lookup", () => {
-	it("falls back to channel identity when a restarted connector gets a new thread id", () => {
+	it("does not fall back to channel identity for a different space thread id", () => {
 		const result = __test__.findBindingForThread(
 			{
 				legacy_thread_id: {
@@ -21,17 +21,7 @@ describe("gchat binding lookup", () => {
 			},
 		);
 
-		expect(result).toEqual({
-			key: "legacy_thread_id",
-			binding: {
-				channelId: "space-123",
-				isDM: false,
-				serializedThread: "{}",
-				sessionId: "sess-1",
-				state: { sessionId: "sess-1", cwd: "/tmp/work" },
-				updatedAt: "2026-03-17T00:00:00.000Z",
-			},
-		});
+		expect(result).toBeUndefined();
 	});
 
 	it("prefers an exact thread id match over a channel fallback", () => {
@@ -65,7 +55,7 @@ describe("gchat binding lookup", () => {
 		expect(result?.binding.sessionId).toBe("sess-2");
 	});
 
-	it("reuses a binding by participant key across different spaces", () => {
+	it("does not reuse a binding by participant key across different spaces", () => {
 		const result = __test__.findBindingForThread(
 			{
 				"gchat:email:alice@example.com": {
@@ -91,7 +81,6 @@ describe("gchat binding lookup", () => {
 			},
 		);
 
-		expect(result?.key).toBe("gchat:email:alice@example.com");
-		expect(result?.binding.sessionId).toBe("sess-1");
+		expect(result).toBeUndefined();
 	});
 });

--- a/apps/cli/src/connectors/adapters/gchat.ts
+++ b/apps/cli/src/connectors/adapters/gchat.ts
@@ -590,9 +590,7 @@ class GoogleChatConnector extends ConnectorBase<
 			thread: Thread<GoogleChatThreadState>,
 			text: string,
 		) => {
-			const queueKey =
-				(await loadThreadState(thread, bindingsPath, startRequest))
-					.participantKey || thread.id;
+			const queueKey = thread.id;
 			const runTurn = async () => {
 				try {
 					await handleConnectorUserTurn({

--- a/apps/cli/src/connectors/adapters/gchat.ts
+++ b/apps/cli/src/connectors/adapters/gchat.ts
@@ -46,7 +46,7 @@ import {
 	type ConnectorBindingStore,
 	type ConnectorThreadState,
 	clearBindingSessionIds,
-	findBindingForParticipantKey,
+	findBindingForDeliveryTarget,
 	findBindingForThread,
 	loadThreadState,
 	persistMergedThreadState,
@@ -191,20 +191,20 @@ async function deliverScheduledResult(input: {
 	const threadId =
 		typeof delivery.threadId === "string" ? delivery.threadId.trim() : "";
 	const bindingKey =
-		typeof delivery.bindingKey === "string"
-			? delivery.bindingKey.trim()
-			: typeof delivery.participantKey === "string"
-				? delivery.participantKey.trim()
-				: "";
-	if (!threadId && !bindingKey) {
+		typeof delivery.bindingKey === "string" ? delivery.bindingKey.trim() : "";
+	const participantKey =
+		typeof delivery.participantKey === "string"
+			? delivery.participantKey.trim()
+			: "";
+	if (!threadId && !bindingKey && !participantKey) {
 		return;
 	}
 	const bindings = readBindings<GoogleChatThreadState>(input.bindingsPath);
-	const match = bindingKey
-		? findBindingForParticipantKey(bindings, bindingKey)
-		: threadId
-			? { key: threadId, binding: bindings[threadId] }
-			: undefined;
+	const match = findBindingForDeliveryTarget(bindings, {
+		bindingKey,
+		threadId,
+		participantKey,
+	});
 	const binding = match?.binding;
 	if (!binding?.serializedThread) {
 		return;

--- a/apps/cli/src/connectors/adapters/linear.test.ts
+++ b/apps/cli/src/connectors/adapters/linear.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { __test__ } from "./linear";
 
 describe("linear binding lookup", () => {
-	it("falls back to channel identity when a restarted connector gets a new thread id", () => {
+	it("does not fall back to channel identity for a different issue thread id", () => {
 		const result = __test__.findBindingForThread(
 			{
 				legacy_thread_id: {
@@ -21,17 +21,7 @@ describe("linear binding lookup", () => {
 			},
 		);
 
-		expect(result).toEqual({
-			key: "legacy_thread_id",
-			binding: {
-				channelId: "linear:issue:ISS-123",
-				isDM: false,
-				serializedThread: "{}",
-				sessionId: "sess-1",
-				state: { sessionId: "sess-1", cwd: "/tmp/work" },
-				updatedAt: "2026-03-17T00:00:00.000Z",
-			},
-		});
+		expect(result).toBeUndefined();
 	});
 
 	it("prefers an exact thread id match over a channel fallback", () => {
@@ -65,7 +55,7 @@ describe("linear binding lookup", () => {
 		expect(result?.binding.sessionId).toBe("sess-2");
 	});
 
-	it("reuses a binding by participant key across different issue threads", () => {
+	it("does not reuse a binding by participant key across different issue threads", () => {
 		const result = __test__.findBindingForThread(
 			{
 				"linear:user:user_123": {
@@ -91,7 +81,6 @@ describe("linear binding lookup", () => {
 			},
 		);
 
-		expect(result?.key).toBe("linear:user:user_123");
-		expect(result?.binding.sessionId).toBe("sess-1");
+		expect(result).toBeUndefined();
 	});
 });

--- a/apps/cli/src/connectors/adapters/linear.ts
+++ b/apps/cli/src/connectors/adapters/linear.ts
@@ -625,9 +625,7 @@ class LinearConnector extends ConnectorBase<
 			thread: Thread<LinearThreadState>,
 			text: string,
 		) => {
-			const queueKey =
-				(await loadThreadState(thread, bindingsPath, startRequest))
-					.participantKey || thread.id;
+			const queueKey = thread.id;
 			const runTurn = async () => {
 				try {
 					await handleConnectorUserTurn({

--- a/apps/cli/src/connectors/adapters/linear.ts
+++ b/apps/cli/src/connectors/adapters/linear.ts
@@ -42,7 +42,7 @@ import {
 	type ConnectorBindingStore,
 	type ConnectorThreadState,
 	clearBindingSessionIds,
-	findBindingForParticipantKey,
+	findBindingForDeliveryTarget,
 	findBindingForThread,
 	loadThreadState,
 	persistMergedThreadState,
@@ -229,20 +229,20 @@ async function deliverScheduledResult(input: {
 	const threadId =
 		typeof delivery.threadId === "string" ? delivery.threadId.trim() : "";
 	const bindingKey =
-		typeof delivery.bindingKey === "string"
-			? delivery.bindingKey.trim()
-			: typeof delivery.participantKey === "string"
-				? delivery.participantKey.trim()
-				: "";
-	if (!threadId && !bindingKey) {
+		typeof delivery.bindingKey === "string" ? delivery.bindingKey.trim() : "";
+	const participantKey =
+		typeof delivery.participantKey === "string"
+			? delivery.participantKey.trim()
+			: "";
+	if (!threadId && !bindingKey && !participantKey) {
 		return;
 	}
 	const bindings = readBindings<LinearThreadState>(input.bindingsPath);
-	const match = bindingKey
-		? findBindingForParticipantKey(bindings, bindingKey)
-		: threadId
-			? { key: threadId, binding: bindings[threadId] }
-			: undefined;
+	const match = findBindingForDeliveryTarget(bindings, {
+		bindingKey,
+		threadId,
+		participantKey,
+	});
 	const binding = match?.binding;
 	if (!binding?.serializedThread) {
 		return;

--- a/apps/cli/src/connectors/adapters/prompts.ts
+++ b/apps/cli/src/connectors/adapters/prompts.ts
@@ -29,7 +29,7 @@ export function getConnectorSystemRules(
 }
 
 const CONNECTOR_FIRST_CONTACT_MESSAGE = [
-	"Connected.",
+	"Connected to Cline.",
 	"Your chat history is kept separately for your account.",
 	"Send /new to start a fresh session or /whereami for thread details.",
 ].join("\n");

--- a/apps/cli/src/connectors/adapters/slack.test.ts
+++ b/apps/cli/src/connectors/adapters/slack.test.ts
@@ -63,12 +63,12 @@ describe("slack binding lookup", () => {
 		expect(options.appToken).toBe("xapp-token");
 	});
 
-	it("falls back to channel identity when a restarted connector gets a new thread id", () => {
+	it("falls back to DM channel identity when a restarted connector gets a new thread id", () => {
 		const result = __test__.findBindingForThread(
 			{
 				legacy_thread_id: {
 					channelId: "slack:C123",
-					isDM: false,
+					isDM: true,
 					serializedThread: "{}",
 					sessionId: "sess-1",
 					state: { sessionId: "sess-1", cwd: "/tmp/work", teamId: "T123" },
@@ -78,7 +78,7 @@ describe("slack binding lookup", () => {
 			{
 				id: "new_thread_id",
 				channelId: "slack:C123",
-				isDM: false,
+				isDM: true,
 			},
 		);
 
@@ -86,7 +86,7 @@ describe("slack binding lookup", () => {
 			key: "legacy_thread_id",
 			binding: {
 				channelId: "slack:C123",
-				isDM: false,
+				isDM: true,
 				serializedThread: "{}",
 				sessionId: "sess-1",
 				state: { sessionId: "sess-1", cwd: "/tmp/work", teamId: "T123" },
@@ -126,7 +126,7 @@ describe("slack binding lookup", () => {
 		expect(result?.binding.sessionId).toBe("sess-2");
 	});
 
-	it("reuses a binding by participant key across different threads", () => {
+	it("does not reuse a binding by participant key across different threads", () => {
 		const result = __test__.findBindingForThread(
 			{
 				[participantKey]: {
@@ -153,8 +153,7 @@ describe("slack binding lookup", () => {
 			},
 		);
 
-		expect(result?.key).toBe(participantKey);
-		expect(result?.binding.sessionId).toBe("sess-1");
+		expect(result).toBeUndefined();
 	});
 
 	it("builds Slack participant keys with a team scope", () => {

--- a/apps/cli/src/connectors/adapters/slack.ts
+++ b/apps/cli/src/connectors/adapters/slack.ts
@@ -51,7 +51,7 @@ import {
 	type ConnectorThreadBinding,
 	type ConnectorThreadState,
 	clearBindingSessionIds,
-	findBindingForParticipantKey,
+	findBindingForDeliveryTarget,
 	findBindingForThread,
 	loadThreadState,
 	persistMergedThreadState,
@@ -376,20 +376,20 @@ async function deliverScheduledResult(input: {
 	const threadId =
 		typeof delivery.threadId === "string" ? delivery.threadId.trim() : "";
 	const bindingKey =
-		typeof delivery.bindingKey === "string"
-			? delivery.bindingKey.trim()
-			: typeof delivery.participantKey === "string"
-				? delivery.participantKey.trim()
-				: "";
-	if (!threadId && !bindingKey) {
+		typeof delivery.bindingKey === "string" ? delivery.bindingKey.trim() : "";
+	const participantKey =
+		typeof delivery.participantKey === "string"
+			? delivery.participantKey.trim()
+			: "";
+	if (!threadId && !bindingKey && !participantKey) {
 		return;
 	}
 	const bindings = readBindings<SlackThreadState>(input.bindingsPath);
-	const match = bindingKey
-		? findBindingForParticipantKey(bindings, bindingKey)
-		: threadId
-			? { key: threadId, binding: bindings[threadId] }
-			: undefined;
+	const match = findBindingForDeliveryTarget(bindings, {
+		bindingKey,
+		threadId,
+		participantKey,
+	});
 	const binding = match?.binding;
 	const deliveryThreadId = match?.key || threadId || bindingKey;
 	if (!binding?.serializedThread) {

--- a/apps/cli/src/connectors/adapters/slack.ts
+++ b/apps/cli/src/connectors/adapters/slack.ts
@@ -826,7 +826,7 @@ class SlackConnector extends ConnectorBase<
 				bindingsPath,
 				startRequest,
 			);
-			const queueKey = currentState.participantKey || thread.id;
+			const queueKey = thread.id;
 			const runTurn = async () => {
 				try {
 					await withSlackTeamBotToken({

--- a/apps/cli/src/connectors/adapters/telegram.test.ts
+++ b/apps/cli/src/connectors/adapters/telegram.test.ts
@@ -363,7 +363,7 @@ describe("telegram binding lookup", () => {
 		expect(result?.binding.sessionId).toBe("sess-2");
 	});
 
-	it("reuses a binding by participant key across different chats", () => {
+	it("does not reuse a binding by participant key across different chats", () => {
 		const result = __test__.findBindingForThread(
 			{
 				"telegram:user:alice": {
@@ -389,7 +389,6 @@ describe("telegram binding lookup", () => {
 			},
 		);
 
-		expect(result?.key).toBe("telegram:user:alice");
-		expect(result?.binding.sessionId).toBe("sess-1");
+		expect(result).toBeUndefined();
 	});
 });

--- a/apps/cli/src/connectors/adapters/telegram.ts
+++ b/apps/cli/src/connectors/adapters/telegram.ts
@@ -42,7 +42,7 @@ import {
 	type ConnectorBindingStore,
 	type ConnectorThreadState,
 	clearBindingSessionIds,
-	findBindingForParticipantKey,
+	findBindingForDeliveryTarget,
 	findBindingForThread,
 	loadThreadState,
 	persistMergedThreadState,
@@ -293,20 +293,20 @@ async function deliverScheduledResult(input: {
 	const threadId =
 		typeof delivery.threadId === "string" ? delivery.threadId.trim() : "";
 	const bindingKey =
-		typeof delivery.bindingKey === "string"
-			? delivery.bindingKey.trim()
-			: typeof delivery.participantKey === "string"
-				? delivery.participantKey.trim()
-				: "";
-	if (!threadId && !bindingKey) {
+		typeof delivery.bindingKey === "string" ? delivery.bindingKey.trim() : "";
+	const participantKey =
+		typeof delivery.participantKey === "string"
+			? delivery.participantKey.trim()
+			: "";
+	if (!threadId && !bindingKey && !participantKey) {
 		return;
 	}
 	const bindings = readBindings<TelegramThreadState>(input.bindingsPath);
-	const match = bindingKey
-		? findBindingForParticipantKey(bindings, bindingKey)
-		: threadId
-			? { key: threadId, binding: bindings[threadId] }
-			: undefined;
+	const match = findBindingForDeliveryTarget(bindings, {
+		bindingKey,
+		threadId,
+		participantKey,
+	});
 	const binding = match?.binding;
 	const deliveryThreadId = match?.key || threadId;
 	if (!binding?.serializedThread) {

--- a/apps/cli/src/connectors/adapters/telegram.ts
+++ b/apps/cli/src/connectors/adapters/telegram.ts
@@ -788,9 +788,7 @@ class TelegramConnector extends ConnectorBase<
 			thread: Thread<TelegramThreadState>,
 			text: string,
 		) => {
-			const queueKey =
-				(await loadThreadState(thread, bindingsPath, startRequest))
-					.participantKey || thread.id;
+			const queueKey = thread.id;
 			const runTurn = async () => {
 				try {
 					await handleConnectorUserTurn({

--- a/apps/cli/src/connectors/adapters/whatsapp.test.ts
+++ b/apps/cli/src/connectors/adapters/whatsapp.test.ts
@@ -65,7 +65,7 @@ describe("whatsapp binding lookup", () => {
 		expect(result?.binding.sessionId).toBe("sess-2");
 	});
 
-	it("reuses a binding by participant key across different threads", () => {
+	it("does not reuse a binding by participant key across different threads", () => {
 		const result = __test__.findBindingForThread(
 			{
 				"whatsapp:user:15551234567": {
@@ -91,7 +91,6 @@ describe("whatsapp binding lookup", () => {
 			},
 		);
 
-		expect(result?.key).toBe("whatsapp:user:15551234567");
-		expect(result?.binding.sessionId).toBe("sess-1");
+		expect(result).toBeUndefined();
 	});
 });

--- a/apps/cli/src/connectors/adapters/whatsapp.ts
+++ b/apps/cli/src/connectors/adapters/whatsapp.ts
@@ -46,7 +46,7 @@ import {
 	type ConnectorBindingStore,
 	type ConnectorThreadState,
 	clearBindingSessionIds,
-	findBindingForParticipantKey,
+	findBindingForDeliveryTarget,
 	findBindingForThread,
 	loadThreadState,
 	persistMergedThreadState,
@@ -226,20 +226,20 @@ async function deliverScheduledResult(input: {
 	const threadId =
 		typeof delivery.threadId === "string" ? delivery.threadId.trim() : "";
 	const bindingKey =
-		typeof delivery.bindingKey === "string"
-			? delivery.bindingKey.trim()
-			: typeof delivery.participantKey === "string"
-				? delivery.participantKey.trim()
-				: "";
-	if (!threadId && !bindingKey) {
+		typeof delivery.bindingKey === "string" ? delivery.bindingKey.trim() : "";
+	const participantKey =
+		typeof delivery.participantKey === "string"
+			? delivery.participantKey.trim()
+			: "";
+	if (!threadId && !bindingKey && !participantKey) {
 		return;
 	}
 	const bindings = readBindings<WhatsAppThreadState>(input.bindingsPath);
-	const match = bindingKey
-		? findBindingForParticipantKey(bindings, bindingKey)
-		: threadId
-			? { key: threadId, binding: bindings[threadId] }
-			: undefined;
+	const match = findBindingForDeliveryTarget(bindings, {
+		bindingKey,
+		threadId,
+		participantKey,
+	});
 	const binding = match?.binding;
 	if (!binding?.serializedThread) {
 		return;

--- a/apps/cli/src/connectors/adapters/whatsapp.ts
+++ b/apps/cli/src/connectors/adapters/whatsapp.ts
@@ -597,9 +597,7 @@ class WhatsAppConnector extends ConnectorBase<
 			thread: Thread<WhatsAppThreadState>,
 			text: string,
 		) => {
-			const queueKey =
-				(await loadThreadState(thread, bindingsPath, startRequest))
-					.participantKey || thread.id;
+			const queueKey = thread.id;
 			const runTurn = async () => {
 				try {
 					await handleConnectorUserTurn({

--- a/apps/cli/src/connectors/connector-host.test.ts
+++ b/apps/cli/src/connectors/connector-host.test.ts
@@ -92,6 +92,11 @@ function createRuntimeClient(
 ) {
 	const startRuntimeSession = vi.fn(async () => ({ sessionId: "session-1" }));
 	const updateSession = vi.fn(async () => undefined);
+	const getSession = vi.fn(
+		async (sessionId: string): Promise<{ sessionId: string } | undefined> => ({
+			sessionId,
+		}),
+	);
 	const abortRuntimeSession = vi.fn(async () => undefined);
 	const deleteSession = vi.fn(async () => undefined);
 	const sendRuntimeSession = vi.fn(async () => ({
@@ -106,6 +111,7 @@ function createRuntimeClient(
 		client: {
 			startRuntimeSession,
 			updateSession,
+			getSession,
 			abortRuntimeSession,
 			stopRuntimeSession: abortRuntimeSession,
 			deleteSession,
@@ -115,6 +121,7 @@ function createRuntimeClient(
 		},
 		startRuntimeSession,
 		updateSession,
+		getSession,
 		sendRuntimeSession,
 		readMessages,
 	};
@@ -593,7 +600,8 @@ describe("handleConnectorUserTurn", () => {
 				metadata: expect.objectContaining({
 					delivery: expect.objectContaining({
 						adapter: "telegram",
-						bindingKey: "telegram:user:alice",
+						bindingKey: "thread-1",
+						participantKey: "telegram:user:alice",
 					}),
 				}),
 			}),
@@ -627,7 +635,8 @@ describe("handleConnectorUserTurn", () => {
 				metadata: {
 					delivery: {
 						adapter: "telegram",
-						bindingKey: "telegram:user:alice",
+						bindingKey: "thread-1",
+						participantKey: "telegram:user:alice",
 						threadId: "thread-1",
 					},
 				},
@@ -640,7 +649,8 @@ describe("handleConnectorUserTurn", () => {
 				metadata: {
 					delivery: {
 						adapter: "telegram",
-						bindingKey: "telegram:user:bob",
+						bindingKey: "thread-2",
+						participantKey: "telegram:user:bob",
 						threadId: "thread-2",
 					},
 				},
@@ -699,7 +709,8 @@ describe("handleConnectorUserTurn", () => {
 					delivery: expect.objectContaining({
 						adapter: "telegram",
 						threadId: "thread-1",
-						bindingKey: "telegram:user:alice",
+						bindingKey: "thread-1",
+						participantKey: "telegram:user:alice",
 						userName: "ClineAdapterBot",
 					}),
 				}),
@@ -1442,7 +1453,7 @@ describe("handleConnectorUserTurn", () => {
 		});
 		const runtime = createRuntimeClient("unused");
 		const activeTurns = new Map([
-			["other-turn-key", { sessionId: "session-1" }],
+			["other-turn-key", { sessionId: "session-1", threadId: "thread-1" }],
 		]);
 
 		await handleConnectorUserTurn({
@@ -1477,5 +1488,106 @@ describe("handleConnectorUserTurn", () => {
 			{ timeoutMs: null },
 		);
 		expect(posts.at(-1)).toEqual({ raw: "Steering current task." });
+	});
+
+	it("starts a normal turn when the active session is in a different thread", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "connector-host-test-"));
+		tempDirs.push(dir);
+		const bindingsPath = join(dir, "threads.json");
+		const { thread, posts } = createThread({
+			enableTools: true,
+			autoApproveTools: true,
+			cwd: "/tmp/work",
+			workspaceRoot: "/tmp/work",
+			welcomeSentAt: new Date().toISOString(),
+		});
+		const runtime = createRuntimeClient("normal reply");
+		const activeTurns = new Map([
+			["other-thread", { sessionId: "session-1", threadId: "other-thread" }],
+		]);
+
+		await handleConnectorUserTurn({
+			thread: thread as never,
+			text: "start work in this thread",
+			client: runtime.client as never,
+			pendingApprovals: new Map(),
+			baseStartRequest: baseStartRequest() as never,
+			explicitSystemPrompt: undefined,
+			clientId: "client-1",
+			logger: {
+				core: { debug: vi.fn(), log: vi.fn(), error: vi.fn() },
+			} as never,
+			transport: "telegram",
+			botUserName: "ClineAdapterBot",
+			requestStop: vi.fn(),
+			bindingsPath,
+			systemRules: "rules",
+			errorLabel: "Telegram",
+			getSessionMetadata: () => ({}),
+			reusedLogMessage: "reused",
+			activeTurns,
+			turnKey: "thread-1",
+		});
+
+		expect(runtime.startRuntimeSession).toHaveBeenCalled();
+		expect(runtime.sendRuntimeSession).toHaveBeenCalledWith(
+			"session-1",
+			expect.not.objectContaining({
+				delivery: "steer",
+			}),
+			{ timeoutMs: null },
+		);
+		expect(posts.at(-1)).toEqual({ raw: "normal reply" });
+	});
+
+	it("starts a fresh session when persisted thread session is missing from the hub", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "connector-host-test-"));
+		tempDirs.push(dir);
+		const bindingsPath = join(dir, "threads.json");
+		const { thread, posts, getState } = createThread({
+			sessionId: "stale-session",
+			enableTools: true,
+			autoApproveTools: true,
+			cwd: "/tmp/work",
+			workspaceRoot: "/tmp/work",
+			welcomeSentAt: new Date().toISOString(),
+		});
+		const runtime = createRuntimeClient("fresh reply");
+		runtime.getSession.mockResolvedValueOnce(undefined);
+
+		await handleConnectorUserTurn({
+			thread: thread as never,
+			text: "continue after hub restart",
+			client: runtime.client as never,
+			pendingApprovals: new Map(),
+			baseStartRequest: baseStartRequest() as never,
+			explicitSystemPrompt: undefined,
+			clientId: "client-1",
+			logger: {
+				core: { debug: vi.fn(), log: vi.fn(), error: vi.fn() },
+			} as never,
+			transport: "telegram",
+			botUserName: "ClineAdapterBot",
+			requestStop: vi.fn(),
+			bindingsPath,
+			systemRules: "rules",
+			errorLabel: "Telegram",
+			getSessionMetadata: () => ({}),
+			reusedLogMessage: "reused",
+			startedLogMessage: "started",
+			turnKey: "thread-1",
+		});
+
+		expect(runtime.getSession).toHaveBeenCalledWith("stale-session");
+		expect(runtime.startRuntimeSession).toHaveBeenCalled();
+		expect(runtime.sendRuntimeSession).toHaveBeenCalledWith(
+			"session-1",
+			expect.not.objectContaining({
+				delivery: "steer",
+			}),
+			{ timeoutMs: null },
+		);
+		expect(getState().sessionId).toBe("session-1");
+		expect(posts.at(-1)).toEqual({ raw: "fresh reply" });
 	});
 });

--- a/apps/cli/src/connectors/connector-host.ts
+++ b/apps/cli/src/connectors/connector-host.ts
@@ -749,9 +749,7 @@ export async function handleConnectorUserTurn<
 					`channelId=${input.thread.channelId}`,
 					`deliveryAdapter=${input.transport}`,
 					`deliveryThread=${input.thread.id}`,
-					...(effectiveCurrent.participantKey
-						? [`deliveryBindingKey=${effectiveCurrent.participantKey}`]
-						: []),
+					`deliveryBindingKey=${input.thread.id}`,
 					`deliveryChannel=${input.thread.channelId}`,
 					...(input.botUserName
 						? [`deliveryUserName=${input.botUserName}`]
@@ -789,11 +787,9 @@ export async function handleConnectorUserTurn<
 						delivery: {
 							adapter: input.transport,
 							threadId: input.thread.id,
+							bindingKey: input.thread.id,
 							...(current.participantKey
-								? {
-										bindingKey: current.participantKey,
-										participantKey: current.participantKey,
-									}
+								? { participantKey: current.participantKey }
 								: {}),
 							...(current.participantLabel
 								? { participantLabel: current.participantLabel }
@@ -832,11 +828,6 @@ export async function handleConnectorUserTurn<
 					].join("\n");
 				},
 				list: async () => {
-					const current = await loadThreadState(
-						input.thread,
-						input.bindingsPath,
-						input.baseStartRequest,
-					);
 					const schedules = await input.client.listSchedules({ limit: 200 });
 					const matching = schedules.filter((schedule) => {
 						const delivery = schedule.metadata?.delivery;
@@ -846,17 +837,9 @@ export async function handleConnectorUserTurn<
 							!Array.isArray(delivery)
 								? (delivery as Record<string, unknown>)
 								: undefined;
-						const deliveryBindingKey =
-							typeof deliveryRecord?.bindingKey === "string"
-								? deliveryRecord.bindingKey
-								: typeof deliveryRecord?.participantKey === "string"
-									? deliveryRecord.participantKey
-									: undefined;
 						return (
 							deliveryRecord?.adapter === input.transport &&
-							(current.participantKey
-								? deliveryBindingKey === current.participantKey
-								: deliveryRecord.threadId === input.thread.id)
+							deliveryRecord.threadId === input.thread.id
 						);
 					});
 					if (matching.length === 0) {
@@ -913,7 +896,9 @@ export async function handleConnectorUserTurn<
 		input.activeTurns?.get(turnKey) ??
 		(input.activeTurns && currentState.sessionId?.trim()
 			? Array.from(input.activeTurns.values()).find(
-					(turn) => turn.sessionId === currentState.sessionId?.trim(),
+					(turn) =>
+						turn.sessionId === currentState.sessionId?.trim() &&
+						turn.threadId === input.thread.id,
 				)
 			: undefined);
 	if (activeTurn?.sessionId?.trim()) {

--- a/apps/cli/src/connectors/session-runtime.ts
+++ b/apps/cli/src/connectors/session-runtime.ts
@@ -159,36 +159,57 @@ export async function getOrCreateSessionId<
 	);
 	const existing = threadState.sessionId?.trim();
 	if (existing) {
+		const existingSession = await input.client.getSession(existing);
+		if (existingSession) {
+			await persistMergedThreadState(
+				input.thread,
+				input.bindingsPath,
+				{
+					...threadState,
+					sessionId: existing,
+				},
+				input.errorLabel,
+			);
+			input.logger.core.log(input.reusedLogMessage, {
+				transport: input.transport,
+				threadId: input.thread.id,
+				sessionId: existing,
+			});
+			await dispatchConnectorHook(
+				input.hookCommand,
+				{
+					adapter: input.transport,
+					botUserName: input.hookBotUserName,
+					event: "session.reused",
+					payload: {
+						threadId: input.thread.id,
+						channelId: input.thread.channelId,
+						sessionId: existing,
+					},
+					ts: new Date().toISOString(),
+				},
+				input.logger,
+			);
+			return existing;
+		}
 		await persistMergedThreadState(
 			input.thread,
 			input.bindingsPath,
 			{
 				...threadState,
-				sessionId: existing,
+				sessionId: undefined,
 			},
 			input.errorLabel,
 		);
-		input.logger.core.log(input.reusedLogMessage, {
-			transport: input.transport,
-			threadId: input.thread.id,
-			sessionId: existing,
-		});
-		await dispatchConnectorHook(
-			input.hookCommand,
+		input.logger.core.log(
+			"Connector thread session missing; starting a new session",
 			{
-				adapter: input.transport,
-				botUserName: input.hookBotUserName,
-				event: "session.reused",
-				payload: {
-					threadId: input.thread.id,
-					channelId: input.thread.channelId,
-					sessionId: existing,
-				},
-				ts: new Date().toISOString(),
+				severity: "warn",
+				transport: input.transport,
+				threadId: input.thread.id,
+				sessionId: existing,
 			},
-			input.logger,
 		);
-		return existing;
 	}
 
 	const started = await input.client.startRuntimeSession(input.startRequest);

--- a/apps/cli/src/connectors/thread-bindings.test.ts
+++ b/apps/cli/src/connectors/thread-bindings.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
 	type ConnectorThreadState,
 	clearBindingSessionIds,
+	findBindingForDeliveryTarget,
 	isParticipantMuted,
 	isThreadMuted,
 	readBindingForThread,
@@ -123,6 +124,65 @@ describe("thread binding refresh", () => {
 		expect(
 			readBindings<TestState>(path)[participantKey]?.serializedThread,
 		).toContain("legacy_thread_id");
+	});
+
+	it("resolves schedule delivery targets by exact binding key before participant metadata", () => {
+		const path = createBindingsPath();
+		writeBindings<TestState>(path, {
+			"slack:C123:111.222": {
+				kind: "conversation",
+				channelId: "slack:C123",
+				isDM: false,
+				participantKey: "slack:team:T123:user:U123",
+				serializedThread: "{}",
+				sessionId: "sess-thread",
+				state: {
+					sessionId: "sess-thread",
+					participantKey: "slack:team:T123:user:U123",
+				},
+				updatedAt: "2026-03-17T00:00:00.000Z",
+			},
+		});
+
+		const match = findBindingForDeliveryTarget<TestState>(
+			readBindings<TestState>(path),
+			{
+				bindingKey: "slack:C123:111.222",
+				threadId: "slack:C123:111.222",
+				participantKey: "slack:team:T123:user:U123",
+			},
+		);
+
+		expect(match?.key).toBe("slack:C123:111.222");
+		expect(match?.binding.sessionId).toBe("sess-thread");
+	});
+
+	it("resolves schedule delivery targets by participant key when no exact thread binding exists", () => {
+		const path = createBindingsPath();
+		writeBindings<TestState>(path, {
+			"slack:team:T123:user:U123": {
+				channelId: "slack:C123",
+				isDM: true,
+				participantKey: "slack:team:T123:user:U123",
+				serializedThread: "{}",
+				sessionId: "sess-participant",
+				state: {
+					sessionId: "sess-participant",
+					participantKey: "slack:team:T123:user:U123",
+				},
+				updatedAt: "2026-03-17T00:00:00.000Z",
+			},
+		});
+
+		const match = findBindingForDeliveryTarget<TestState>(
+			readBindings<TestState>(path),
+			{
+				participantKey: "slack:team:T123:user:U123",
+			},
+		);
+
+		expect(match?.key).toBe("slack:team:T123:user:U123");
+		expect(match?.binding.sessionId).toBe("sess-participant");
 	});
 
 	it("stores mute state at thread scope instead of participant scope", () => {

--- a/apps/cli/src/connectors/thread-bindings.test.ts
+++ b/apps/cli/src/connectors/thread-bindings.test.ts
@@ -52,16 +52,16 @@ afterEach(() => {
 });
 
 describe("thread binding refresh", () => {
-	it("refreshes the serialized thread immediately when channel fallback rebinds a thread id", () => {
+	it("refreshes the serialized thread immediately when DM channel fallback rebinds a thread id", () => {
 		const path = createBindingsPath();
 		writeBindings<TestState>(path, {
 			legacy_thread_id: {
 				channelId: "slack:C123",
-				isDM: false,
+				isDM: true,
 				serializedThread: JSON.stringify({
 					id: "legacy_thread_id",
 					channelId: "slack:C123",
-					isDM: false,
+					isDM: true,
 				}),
 				sessionId: "sess-1",
 				state: { sessionId: "sess-1", teamId: "T123" },
@@ -74,7 +74,7 @@ describe("thread binding refresh", () => {
 			createThread({
 				id: "new_thread_id",
 				channelId: "slack:C123",
-				isDM: false,
+				isDM: true,
 			}),
 			"Slack",
 		);
@@ -85,7 +85,7 @@ describe("thread binding refresh", () => {
 		expect(bindings.new_thread_id?.serializedThread).toContain("new_thread_id");
 	});
 
-	it("refreshes the serialized thread when a participant-key binding matches a new thread id", () => {
+	it("does not rebind a different thread by participant key", () => {
 		const path = createBindingsPath();
 		const participantKey = "slack:team:T123:user:U123";
 		writeBindings<TestState>(path, {
@@ -119,10 +119,10 @@ describe("thread binding refresh", () => {
 			participantKey,
 		);
 
-		expect(binding?.serializedThread).toContain("new_thread_id");
+		expect(binding).toBeUndefined();
 		expect(
 			readBindings<TestState>(path)[participantKey]?.serializedThread,
-		).toContain("new_thread_id");
+		).toContain("legacy_thread_id");
 	});
 
 	it("stores mute state at thread scope instead of participant scope", () => {

--- a/apps/cli/src/connectors/thread-bindings.ts
+++ b/apps/cli/src/connectors/thread-bindings.ts
@@ -14,7 +14,7 @@ export type ConnectorThreadState = {
 };
 
 export type ConnectorThreadBinding<TState extends ConnectorThreadState> = {
-	kind?: "participant" | "thread" | "thread-participant-mute";
+	kind?: "conversation" | "participant" | "thread" | "thread-participant-mute";
 	channelId: string;
 	isDM: boolean;
 	participantKey?: string;
@@ -134,12 +134,9 @@ function clearSerializedThreadSessionId(serializedThread: string | undefined): {
 
 export function resolveThreadBindingKey(
 	thread: ConnectorBindingThreadIdentity,
-	state?: ConnectorThreadState | null,
+	_state?: ConnectorThreadState | null,
 ): string {
-	return (
-		normalizeParticipantKey(state?.participantKey ?? thread.participantKey) ??
-		thread.id
-	);
+	return thread.id;
 }
 
 export function readBindings<TState extends ConnectorThreadState>(
@@ -160,39 +157,12 @@ export function findBindingForThread<TState extends ConnectorThreadState>(
 	bindings: ConnectorBindingStore<TState>,
 	thread: ConnectorBindingThreadIdentity,
 ): { binding: ConnectorThreadBinding<TState>; key: string } | undefined {
-	const participantKey = normalizeParticipantKey(thread.participantKey);
-	if (participantKey) {
-		const exactThread = bindings[thread.id];
-		const exactThreadParticipantKey = normalizeParticipantKey(
-			exactThread?.participantKey ?? exactThread?.state?.participantKey,
-		);
-		if (
-			exactThread &&
-			!isControlBinding(exactThread) &&
-			exactThreadParticipantKey === participantKey
-		) {
-			return { key: thread.id, binding: exactThread };
-		}
-		const exactParticipant = bindings[participantKey];
-		if (exactParticipant && !isControlBinding(exactParticipant)) {
-			return { key: participantKey, binding: exactParticipant };
-		}
-		for (const [key, binding] of Object.entries(bindings)) {
-			if (isControlBinding(binding)) {
-				continue;
-			}
-			const bindingParticipantKey = normalizeParticipantKey(
-				binding.participantKey ?? binding.state?.participantKey,
-			);
-			if (bindingParticipantKey === participantKey) {
-				return { key, binding };
-			}
-		}
-		return undefined;
-	}
 	const exact = bindings[thread.id];
 	if (exact && !isControlBinding(exact)) {
 		return { key: thread.id, binding: exact };
+	}
+	if (!thread.isDM) {
+		return undefined;
 	}
 	for (const [key, binding] of Object.entries(bindings)) {
 		if (isControlBinding(binding)) {
@@ -282,29 +252,8 @@ export function persistThreadBinding<TState extends ConnectorThreadState>(
 		thread as ConnectorBindingThreadIdentity,
 		state,
 	);
-	for (const [key, binding] of Object.entries(bindings)) {
-		if (isControlBinding(binding)) {
-			continue;
-		}
-		const bindingParticipantKey = normalizeParticipantKey(
-			binding.participantKey ?? binding.state?.participantKey,
-		);
-		const matchesParticipant =
-			participantKey && bindingParticipantKey === participantKey;
-		const matchesLegacyKey = participantKey && key === thread.id;
-		const matchesLegacyThread =
-			!participantKey &&
-			binding.channelId === thread.channelId &&
-			binding.isDM === thread.isDM;
-		if (
-			key !== bindingKey &&
-			(matchesParticipant || matchesLegacyKey || matchesLegacyThread)
-		) {
-			delete bindings[key];
-		}
-	}
 	bindings[bindingKey] = {
-		kind: "participant",
+		kind: "conversation",
 		channelId: thread.channelId,
 		isDM: thread.isDM,
 		participantKey,

--- a/apps/cli/src/connectors/thread-bindings.ts
+++ b/apps/cli/src/connectors/thread-bindings.ts
@@ -480,6 +480,37 @@ export function findBindingForParticipantKey<
 	return undefined;
 }
 
+export function findBindingForDeliveryTarget<
+	TState extends ConnectorThreadState,
+>(
+	bindings: ConnectorBindingStore<TState>,
+	input: {
+		bindingKey?: string;
+		threadId?: string;
+		participantKey?: string;
+	},
+): { binding: ConnectorThreadBinding<TState>; key: string } | undefined {
+	const bindingKey = normalizeParticipantKey(input.bindingKey);
+	if (bindingKey) {
+		const exact = bindings[bindingKey];
+		if (exact && !isControlBinding(exact)) {
+			return { key: bindingKey, binding: exact };
+		}
+		const participantMatch = findBindingForParticipantKey(bindings, bindingKey);
+		if (participantMatch) {
+			return participantMatch;
+		}
+	}
+	const threadId = input.threadId?.trim();
+	if (threadId) {
+		const exact = bindings[threadId];
+		if (exact && !isControlBinding(exact)) {
+			return { key: threadId, binding: exact };
+		}
+	}
+	return findBindingForParticipantKey(bindings, input.participantKey);
+}
+
 export async function persistMergedThreadState<
 	TState extends ConnectorThreadState,
 >(


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

This fixes connector messages from separate chat threads being routed into the wrong active runtime session.

**Issue**

In Slack, if a user sent a message in a different thread while another thread was still processing, the new message could be treated as a steer message for the active task. Users could also see errors like:

```text
Slack bridge error: session not found: 1780596180501_ms45m
```

when a connector thread had a persisted session id that no longer existed in the hub, such as after a hub restart.

**Cause**

Connector conversation bindings and active turn queues were using participant identity as the primary key in several paths. That allowed messages from the same user in different chat threads to resolve to the same connector session/active turn.

Separately, persisted connector `sessionId` values were trusted without checking whether the hub still had that runtime session. After a hub restart, the connector could try to send input to a stale session id.

**Fix**

- Store connector conversation bindings by thread id instead of participant key.
- Key connector active turn queues by thread id across Slack, Discord, Telegram, Google Chat, Linear, and WhatsApp adapters.
- Only treat a follow-up as a steer message when the active turn belongs to the same thread.
- Keep participant key/label as metadata instead of using it as the conversation binding key.
- Validate a persisted session id with the hub before reusing it.
- If the persisted session is missing, clear it from thread state and start a fresh runtime session.
- Update schedule delivery metadata to target thread ids while preserving participant metadata.
- Add regression coverage for cross-thread active sessions and stale persisted session ids.


### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

**Verification**

```bash
bun -F @cline/cli typecheck
bunx vitest run apps/cli/src/connectors/connector-host.test.ts apps/cli/src/connectors/thread-bindings.test.ts apps/cli/src/connectors/adapters/slack.test.ts apps/cli/src/connectors/adapters/telegram.test.ts apps/cli/src/connectors/adapters/discord.test.ts apps/cli/src/connectors/adapters/gchat.test.ts apps/cli/src/connectors/adapters/linear.test.ts apps/cli/src/connectors/adapters/whatsapp.test.ts
```
### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
