### PR TITLE
feat(sdk): add AGIone provider

### DIFF
--- a/sdk/packages/core/src/services/llms/provider-defaults.test.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.test.ts
@@ -211,6 +211,59 @@ describe("resolveProviderConfig", () => {
 		);
 	});
 
+	it("loads AGIone models from the authenticated models endpoint", async () => {
+		const fetchMock = vi.fn(async () => {
+			return new Response(
+				JSON.stringify({
+					data: [
+						{
+							id: "deepseek/deepseek-v4-pro/d3462",
+							model: "deepseek/deepseek-v4-pro/d3462",
+						},
+					],
+				}),
+				{
+					status: 200,
+					headers: { "content-type": "application/json" },
+				},
+			);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const resolved = await resolveProviderConfig(
+			"agione",
+			{ failOnError: true, cacheTtlMs: 0 },
+			{
+				providerId: "agione",
+				modelId: "deepseek/deepseek-v4-pro/d3462",
+				apiKey: "agione-key",
+				baseUrl: "https://agione.pro/hyperone/xapi/api/v1/",
+			},
+		);
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			"https://agione.pro/hyperone/xapi/api/models",
+			expect.objectContaining({
+				method: "GET",
+				headers: expect.objectContaining({
+					Authorization: "Bearer agione-key",
+				}),
+			}),
+		);
+		expect(resolved?.knownModels?.["deepseek/deepseek-v4-pro/d3462"]).toEqual(
+			expect.objectContaining({
+				name: "deepseek/deepseek-v4-pro/d3462",
+				maxInputTokens: 128_000,
+				capabilities: expect.arrayContaining([
+					"streaming",
+					"tools",
+					"reasoning",
+				]),
+				status: "active",
+			}),
+		);
+	});
+
 	it("derives ChatGPT subscription models from the generated OpenAI catalog", async () => {
 		const resolved = await resolveProviderConfig("openai-codex");
 		const openAiResolved = await resolveProviderConfig("openai-native");

--- a/sdk/packages/core/src/services/llms/provider-defaults.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.ts
@@ -358,6 +358,12 @@ interface HicapModelResponse {
 	id?: string;
 }
 
+interface AgioneModelResponse {
+	id?: string;
+	model?: string;
+	created?: number;
+}
+
 interface PoolsideModelResponse {
 	id?: string;
 	name?: string;
@@ -416,6 +422,47 @@ async function fetchHicapPrivateModels(
 			maxInputTokens: 128_000,
 			supportsImages: true,
 			supportsPromptCache: true,
+		});
+	}
+	return models;
+}
+
+function normalizeAgioneModelsBaseUrl(baseUrl: string | undefined): string {
+	const raw =
+		normalizeBaseUrl(baseUrl) || "https://agione.pro/hyperone/xapi/api/v1";
+	const normalized = raw.replace(/\/+$/, "");
+	return normalized.endsWith("/v1") ? normalized.slice(0, -3) : normalized;
+}
+
+async function fetchAgionePrivateModels(
+	config: ProviderConfig,
+	token: string,
+): Promise<Record<string, ModelInfo>> {
+	const baseUrl = normalizeAgioneModelsBaseUrl(config.baseUrl);
+	const endpoint = `${baseUrl.replace(/\/+$/, "")}/models`;
+	const response = await fetchWithTimeout(endpoint, {
+		method: "GET",
+		headers: {
+			Authorization: `Bearer ${token}`,
+			accept: "application/json",
+		},
+	});
+	if (!response.ok) {
+		throw new Error(`AGIone model refresh failed: HTTP ${response.status}`);
+	}
+
+	const payload = (await response.json()) as { data?: AgioneModelResponse[] };
+	const entries = payload?.data ?? [];
+	const models: Record<string, ModelInfo> = {};
+	for (const model of entries) {
+		const id = (model.id ?? model.model)?.trim();
+		if (!id) {
+			continue;
+		}
+		models[id] = buildModelFromPrivateSource(id, {
+			name: id,
+			maxInputTokens: 128_000,
+			supportsReasoning: true,
 		});
 	}
 	return models;
@@ -587,6 +634,7 @@ const PRIVATE_PROVIDER_MODEL_FETCHERS: Record<
 	string,
 	PrivateProviderModelFetcher
 > = {
+	agione: fetchAgionePrivateModels,
 	baseten: fetchBasetenPrivateModels,
 	hicap: fetchHicapPrivateModels,
 	litellm: fetchLiteLlmPrivateModels,

--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -517,6 +517,16 @@ const OPENAI_COMPATIBLE_SPECS: BuiltinSpec[] = [
 		defaults: { baseUrl: "https://inference.poolside.ai/v1" },
 	},
 	{
+		id: "agione",
+		name: "AGIone",
+		description: "OpenAI-compatible inference endpoint",
+		family: "openai-compatible",
+		capabilities: ["tools", "reasoning"],
+		defaultModelId: "deepseek/deepseek-v4-pro/d3462",
+		apiKeyEnv: ["AGIONE_API_KEY"],
+		defaults: { baseUrl: "https://agione.pro/hyperone/xapi/api/v1" },
+	},
+	{
 		id: "cerebras",
 		name: "Cerebras",
 		description: "Fast inference on Cerebras wafer-scale chips",

--- a/sdk/packages/llms/src/providers/ids.test.ts
+++ b/sdk/packages/llms/src/providers/ids.test.ts
@@ -107,6 +107,28 @@ describe("provider-ids", () => {
 		});
 	});
 
+	it("registers AGIone as an OpenAI-compatible built-in provider", async () => {
+		expect(BUILT_IN_PROVIDER_IDS).toContain("agione");
+
+		await expect(getProvider("agione")).resolves.toMatchObject({
+			id: "agione",
+			name: "AGIone",
+			baseUrl: "https://agione.pro/hyperone/xapi/api/v1",
+			defaultModelId: "deepseek/deepseek-v4-pro/d3462",
+			client: "openai-compatible",
+		});
+		await expect(getModelsForProvider("agione")).resolves.toHaveProperty(
+			"deepseek/deepseek-v4-pro/d3462",
+		);
+
+		const registration = BUILTIN_PROVIDER_REGISTRATIONS.find(
+			(item) => item.manifest.id === "agione",
+		);
+		await expect(registration?.loadProvider?.()).resolves.toMatchObject({
+			createProvider: createOpenAICompatibleProvider,
+		});
+	});
+
 	it("routes Responses API built-ins through the OpenAI provider factory", async () => {
 		for (const providerId of ["litellm", "v0"]) {
 			const provider = await getProvider(providerId);

--- a/sdk/packages/llms/src/providers/ids.ts
+++ b/sdk/packages/llms/src/providers/ids.ts
@@ -31,6 +31,7 @@ export enum BUILT_IN_PROVIDER {
 	FIREWORKS = "fireworks",
 	GROQ = "groq",
 	POOLSIDE = "poolside",
+	AGIONE = "agione",
 	CEREBRAS = "cerebras",
 	SAMBANOVA = "sambanova",
 	NEBIUS = "nebius",


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

**Issue:** N/A

### Description

Adds AGIone as a built-in OpenAI-compatible SDK provider preset.

This follows the existing built-in OpenAI-compatible provider pattern: AGIone gets a provider id, default base URL, `AGIONE_API_KEY` env var, default model, registry coverage, and authenticated `/models` refresh support. The `/models` endpoint is exposed at `https://agione.pro/hyperone/xapi/api/models`, so the refresh helper trims a trailing `/v1` from the configured chat-completions base URL before requesting model metadata.

Submitted by the AGIone team (agione.pro).

### Test Procedure

Ran focused SDK checks:

```bash
bun -F @cline/llms test src/providers/ids.test.ts
bun -F @cline/core test:unit -- src/services/llms/provider-defaults.test.ts
bun -F @cline/llms typecheck
bun -F @cline/core typecheck
bun biome check --diagnostic-level=error sdk/packages/llms/src/providers/ids.ts sdk/packages/llms/src/providers/builtins.ts sdk/packages/llms/src/providers/ids.test.ts sdk/packages/core/src/services/llms/provider-defaults.ts sdk/packages/core/src/services/llms/provider-defaults.test.ts
```

Also validated the default model against AGIone's OpenAI-compatible chat-completions endpoint using `AGIONE_API_KEY` from the environment:

```text
model: deepseek/deepseek-v4-pro/d3462
baseUrl: https://agione.pro/hyperone/xapi/api/v1
reply: cline-agione-ok
```

Secret scan for this commit:

```bash
gitleaks git --no-banner --redact --log-opts='origin/main..HEAD'
```

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — SDK provider metadata and model-refresh support only.

### Additional Notes

This does not add a new dependency. The provider uses Cline's existing OpenAI-compatible SDK path.
