### PR TITLE
fix(core): restore detached hub port fallback

### DIFF
--- a/sdk/packages/core/src/hub/client/index.test.ts
+++ b/sdk/packages/core/src/hub/client/index.test.ts
@@ -758,6 +758,9 @@ describe("resolveCompatibleLocalHubUrl", () => {
 	afterEach(() => {
 		vi.unstubAllGlobals();
 		delete process.env.CLINE_HUB_BUILD_ID;
+		delete process.env.CLINE_HUB_HOST;
+		delete process.env.CLINE_HUB_PATHNAME;
+		delete process.env.CLINE_HUB_PORT;
 		vi.resetModules();
 	});
 
@@ -892,7 +895,9 @@ describe("resolveCompatibleLocalHubUrl", () => {
 		);
 	});
 
-	it("starts missing local hubs through the retrying daemon spawn API", async () => {
+	it("uses fallback ports for managed local hubs with host and pathname overrides", async () => {
+		process.env.CLINE_HUB_HOST = "localhost";
+		process.env.CLINE_HUB_PATHNAME = "/custom-hub";
 		vi.stubGlobal("WebSocket", MockWebSocket);
 		const spawnDetachedHubServerWithRetryMock = vi.fn(async () => undefined);
 		const record = {
@@ -941,6 +946,7 @@ describe("resolveCompatibleLocalHubUrl", () => {
 		).resolves.toBe("ws://127.0.0.1:25464/hub");
 		expect(spawnDetachedHubServerWithRetryMock).toHaveBeenCalledWith(
 			"/tmp/project",
+			{ port: 0 },
 		);
 		expect(
 			spawnDetachedHubServerWithRetryMock.mock.invocationCallOrder[0],
@@ -948,6 +954,59 @@ describe("resolveCompatibleLocalHubUrl", () => {
 		expect(
 			spawnDetachedHubServerWithRetryMock.mock.invocationCallOrder[0],
 		).toBeLessThan(readHubDiscoveryMock.mock.invocationCallOrder[1]);
+	});
+
+	it("keeps explicit local hub ports strict during managed startup", async () => {
+		process.env.CLINE_HUB_PORT = "31000";
+		vi.stubGlobal("WebSocket", MockWebSocket);
+		const spawnDetachedHubServerWithRetryMock = vi.fn(async () => undefined);
+		const record = {
+			hubId: "hub-test",
+			protocolVersion: "v1",
+			buildId: "test-build",
+			authToken: "token",
+			host: "127.0.0.1",
+			port: 31000,
+			url: "ws://127.0.0.1:31000/hub",
+			startedAt: new Date().toISOString(),
+			updatedAt: new Date().toISOString(),
+		};
+		const readHubDiscoveryMock = vi
+			.fn()
+			.mockResolvedValueOnce(undefined)
+			.mockResolvedValueOnce(record);
+		vi.doMock("../daemon", () => ({
+			spawnDetachedHubServerWithRetry: spawnDetachedHubServerWithRetryMock,
+		}));
+		vi.doMock("../discovery/workspace", () => ({
+			resolveSharedHubOwnerContext: () => ({
+				ownerId: "hub-test",
+				discoveryPath: "/tmp/hub-discovery.json",
+			}),
+		}));
+		vi.doMock("../discovery", async () => {
+			const actual =
+				await vi.importActual<typeof import("../discovery")>("../discovery");
+			return {
+				...actual,
+				resolveHubBuildId: () => "test-build",
+				readHubDiscovery: readHubDiscoveryMock,
+				probeHubServer: vi.fn(async () => record),
+				clearHubDiscovery: vi.fn(async () => undefined),
+			};
+		});
+
+		const { ensureCompatibleLocalHubUrl } = await import(".");
+
+		await expect(
+			ensureCompatibleLocalHubUrl({
+				workspaceRoot: "/tmp/project",
+				cwd: "/tmp/project",
+			}),
+		).resolves.toBe("ws://127.0.0.1:31000/hub");
+		expect(spawnDetachedHubServerWithRetryMock).toHaveBeenCalledWith(
+			"/tmp/project",
+		);
 	});
 
 	it("does not restart explicit local endpoints after startup timeout", async () => {

--- a/sdk/packages/core/src/hub/client/index.ts
+++ b/sdk/packages/core/src/hub/client/index.ts
@@ -19,6 +19,7 @@ import {
 	readHubDiscovery,
 	resolveHubBuildId,
 } from "../discovery";
+import type { HubEndpointOverrides } from "../discovery/defaults";
 import { resolveSharedHubOwnerContext } from "../discovery/workspace";
 
 type PendingReply = {
@@ -51,6 +52,15 @@ function getWebSocketCtor(): WebSocketCtor {
 		);
 	}
 	return ctor;
+}
+
+function resolveManagedDetachedHubSpawnEndpoint():
+	| HubEndpointOverrides
+	| undefined {
+	if (process.env.CLINE_HUB_PORT?.trim()) {
+		return undefined;
+	}
+	return { port: 0 };
 }
 
 function decodeSocketData(data: unknown): string {
@@ -1005,7 +1015,17 @@ export async function ensureCompatibleLocalHubUrl(
 		return undefined;
 	}
 	const owner = resolveSharedHubOwnerContext();
-	await spawnDetachedHubServerWithRetry(options.workspaceRoot ?? process.cwd());
+	const spawnEndpoint = resolveManagedDetachedHubSpawnEndpoint();
+	if (spawnEndpoint) {
+		await spawnDetachedHubServerWithRetry(
+			options.workspaceRoot ?? process.cwd(),
+			spawnEndpoint,
+		);
+	} else {
+		await spawnDetachedHubServerWithRetry(
+			options.workspaceRoot ?? process.cwd(),
+		);
+	}
 	return await waitForCompatibleHubUrl(owner);
 }
 

--- a/sdk/packages/core/src/hub/daemon/index.test.ts
+++ b/sdk/packages/core/src/hub/daemon/index.test.ts
@@ -101,16 +101,21 @@ describe("ensureDetachedHubServer", () => {
 		}
 	});
 
-	it("starts the daemon on the resolved default hub port", async () => {
+	it("lets the daemon bind port 0 when the default endpoint is occupied", async () => {
 		readHubDiscovery.mockResolvedValueOnce(undefined).mockResolvedValueOnce({
-			url: "ws://127.0.0.1:25463/hub",
+			url: "ws://127.0.0.1:5555/hub",
 			buildId: "current-build",
 			authToken: "new-token",
 		});
-		probeHubServer.mockResolvedValueOnce(undefined).mockResolvedValueOnce({
-			url: "ws://127.0.0.1:25463/hub",
-			buildId: "current-build",
-		});
+		probeHubServer
+			.mockResolvedValueOnce({
+				url: "ws://127.0.0.1:25463/hub",
+				buildId: "current-build",
+			})
+			.mockResolvedValueOnce({
+				url: "ws://127.0.0.1:5555/hub",
+				buildId: "current-build",
+			});
 		verifyHubConnection.mockResolvedValueOnce(true);
 
 		const { ensureDetachedHubServer } = await import(".");
@@ -123,13 +128,40 @@ describe("ensureDetachedHubServer", () => {
 			| undefined;
 
 		expect(result).toEqual({
-			url: "ws://127.0.0.1:25463/hub",
+			url: "ws://127.0.0.1:5555/hub",
 			authToken: "new-token",
 		});
 		expect(spawn).toHaveBeenCalledOnce();
 		expect(spawnArgs).toContain("--port");
-		expect(spawnArgs).toContain("25463");
+		expect(spawnArgs).toContain("0");
 		expect(spawnOptions?.env?.[CLINE_RUN_AS_HUB_DAEMON_ENV]).toBe("1");
+	});
+
+	it("keeps an explicit detached hub port fixed", async () => {
+		readHubDiscovery.mockResolvedValueOnce(undefined).mockResolvedValueOnce({
+			url: "ws://127.0.0.1:31000/hub",
+			buildId: "current-build",
+			authToken: "new-token",
+		});
+		probeHubServer.mockResolvedValueOnce(undefined).mockResolvedValueOnce({
+			url: "ws://127.0.0.1:31000/hub",
+			buildId: "current-build",
+		});
+		verifyHubConnection.mockResolvedValueOnce(true);
+
+		const { ensureDetachedHubServer } = await import(".");
+		const result = await ensureDetachedHubServer("/workspace", { port: 31000 });
+		const spawnCalls = (spawn as unknown as { mock: { calls: unknown[][] } })
+			.mock.calls;
+		const spawnArgs = spawnCalls[0]?.[1] as string[] | undefined;
+
+		expect(result).toEqual({
+			url: "ws://127.0.0.1:31000/hub",
+			authToken: "new-token",
+		});
+		expect(spawn).toHaveBeenCalledOnce();
+		expect(spawnArgs).toContain("--port");
+		expect(spawnArgs).toContain("31000");
 	});
 
 	it("retries a transient ETXTBSY spawn failure while starting the detached daemon", async () => {

--- a/sdk/packages/core/src/hub/daemon/index.ts
+++ b/sdk/packages/core/src/hub/daemon/index.ts
@@ -206,6 +206,8 @@ export function prewarmDetachedHubServer(
 		return;
 	}
 	const owner = resolveSharedHubOwnerContext();
+	const hasExplicitPort =
+		endpoint.port !== undefined || !!process.env.CLINE_HUB_PORT?.trim();
 	const resolvedEndpoint = resolveHubEndpointOptions(endpoint);
 	const expectedUrl = createHubServerUrl(
 		resolvedEndpoint.host,
@@ -238,7 +240,12 @@ export function prewarmDetachedHubServer(
 			if (expected?.url) {
 				await retireIncompatibleHub(expected, owner.discoveryPath);
 			}
-			await spawnDetachedHubServerWithRetry(workspaceRoot, resolvedEndpoint);
+			const shouldUseFallbackPort =
+				!hasExplicitPort && resolvedEndpoint.port !== 0;
+			const spawnEndpoint = shouldUseFallbackPort
+				? { ...resolvedEndpoint, port: 0 }
+				: resolvedEndpoint;
+			await spawnDetachedHubServerWithRetry(workspaceRoot, spawnEndpoint);
 		})
 		.catch(() => {
 			// best-effort prewarm only
@@ -259,6 +266,9 @@ export async function ensureDetachedHubServer(
 		endpointOverrides.host !== undefined ||
 		endpointOverrides.port !== undefined ||
 		endpointOverrides.pathname !== undefined ||
+		!!process.env.CLINE_HUB_PORT?.trim();
+	const hasExplicitPort =
+		endpointOverrides.port !== undefined ||
 		!!process.env.CLINE_HUB_PORT?.trim();
 	const endpoint = resolveHubEndpointOptions(endpointOverrides);
 	const expectedUrl = createHubServerUrl(
@@ -302,7 +312,11 @@ export async function ensureDetachedHubServer(
 	if (expected?.url) {
 		await retireIncompatibleHub(expected, owner.discoveryPath);
 	}
-	await spawnDetachedHubServerWithRetry(workspaceRoot, endpoint);
+	const shouldUseFallbackPort = !hasExplicitPort && endpoint.port !== 0;
+	const spawnEndpoint = shouldUseFallbackPort
+		? { ...endpoint, port: 0 }
+		: endpoint;
+	await spawnDetachedHubServerWithRetry(workspaceRoot, spawnEndpoint);
 	const deadline = Date.now() + HUB_STARTUP_TIMEOUT_MS;
 	while (Date.now() < deadline) {
 		const nextDiscovery = await readHubDiscovery(owner.discoveryPath);


### PR DESCRIPTION
### Related Issue

Issue: #XXXX

Related review discussion: https://github.com/cline/cline/pull/11324#issuecomment-4640960179

### Description

This PR restores detached local Hub fallback behavior that existed before the cleanup PR changed default Hub startup to always use the resolved default port.

Plain-English context: the Hub is a local background WebSocket server. CLI commands and connector processes use it as shared runtime state. When a Hub starts, it writes a discovery record containing its URL, pid, and auth token. Later CLI processes read that record so they can reconnect to the existing Hub instead of starting another one.

The parent PR changes shared discovery ownership to include the build environment. That is useful because it avoids production and development builds sharing one discovery record. The tricky transition case is that an older Hub can still be running on the default port while the new CLI looks in a different discovery location and cannot find the old discovery record/token.

Before the parent PR, default Hub startup handled default-port collisions defensively. If the user had not explicitly configured a port, Cline could spawn the detached daemon with `port: 0`. In Node, passing port `0` means asking the operating system to choose any free port. After the new Hub starts, it writes the actual selected port into discovery, and later CLI processes connect through that discovery record.

The parent PR removed that fallback in detached startup. That created a failure mode where a replacement detached daemon can be spawned on the same default port that the old Hub already owns. The detached daemon calls `startHubWebSocketServer()` directly, so it does not get the `allowPortFallback` behavior from `ensureHubWebSocketServer()`. In that state, the daemon can fail to bind and the caller can time out waiting for compatible Hub discovery.

The first version of this PR restored the fallback in the two daemon-facing startup paths:

```ts
ensureDetachedHubServer(...)
prewarmDetachedHubServer(...)
```

During a follow-up review, we found a third detached startup path in the client layer:

```ts
ensureCompatibleLocalHubUrl(...) -> spawnDetachedHubServerWithRetry(workspaceRoot)
```

That helper is easy to mistake for a passive lookup function, but it is not only a lookup. If it cannot find a compatible local Hub, it can start one. This matters because `ensureCompatibleLocalHubUrl()` is used by hub-mode runtime startup and by `NodeHubClient` recovery when a remembered local Hub URL stops working.

The missed bug scenario was:

1. User has no explicit Hub port configured.
2. The default Hub port is already occupied, for example by an old or incompatible Hub left over from before the upgrade.
3. Cline enters hub-mode startup or tries to recover a local Hub connection through `ensureCompatibleLocalHubUrl()`.
4. That helper starts the detached Hub without passing `{ port: 0 }`.
5. The new Hub tries the default port again instead of asking the OS for any available port, so the fallback behavior from the rest of this PR is bypassed.

This PR now applies the same rule across detached startup paths:

```txt
User explicitly sets CLINE_HUB_PORT or an endpoint port override:
  Respect it strictly.

Cline is managing the default Hub port automatically:
  If the default port is already occupied, fall back to an ephemeral port.
```

For the client-side path, the rule is intentionally small:

```ts
function resolveManagedDetachedHubSpawnEndpoint(): HubEndpointOverrides | undefined {
  if (process.env.CLINE_HUB_PORT?.trim()) {
    return undefined;
  }
  return { port: 0 };
}
```

Then `ensureCompatibleLocalHubUrl()` starts unmanaged/default Hubs with the fallback endpoint:

```ts
const spawnEndpoint = resolveManagedDetachedHubSpawnEndpoint();
if (spawnEndpoint) {
  await spawnDetachedHubServerWithRetry(workspaceRoot, spawnEndpoint);
} else {
  await spawnDetachedHubServerWithRetry(workspaceRoot);
}
```

Technical approach:

- Restore `hasExplicitPort` detection in detached Hub prewarm and ensure paths.
- Use `{ ...endpoint, port: 0 }` only when no explicit port is configured and the resolved port is not already `0`.
- Apply the same managed/default fallback rule to `ensureCompatibleLocalHubUrl()` so hub-mode startup and `NodeHubClient` recovery do not bypass the daemon fallback behavior.
- Keep explicit port behavior strict through `CLINE_HUB_PORT` and explicit endpoint port overrides.
- Keep host/pathname-only overrides compatible with port fallback. Those settings customize the endpoint shape, but they do not mean the user intentionally pinned the port.
- Preserve explicit endpoint-string behavior. If a caller supplies an explicit endpoint URL, this helper does not auto-spawn a replacement Hub.
- Add regression coverage for occupied default-port startup, explicit port strictness, client-side compatible startup, and host/pathname-only overrides.

### Test Procedure

Ran the focused client, daemon, and workspace discovery tests:

```txt
bunx vitest run src/hub/client/index.test.ts src/hub/daemon/index.test.ts src/hub/discovery/workspace.test.ts --config vitest.config.ts
```

Result: 3 test files passed, 29 tests passed.

Ran the core TypeScript check:

```txt
bun tsc -p tsconfig.dev.json --noEmit
```

Result: passed.

Ran the focused Biome check for touched client files:

```txt
bun biome check --diagnostic-level=error sdk/packages/core/src/hub/client/index.ts sdk/packages/core/src/hub/client/index.test.ts
```

Result: passed.

I also ran:

```txt
git diff --check
```

Result: passed.

### Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Refactor Changes
-   [ ] Cosmetic Changes
-   [ ] Documentation update
-   [ ] Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

Note: I ran focused tests, a focused Biome check, `git diff --check`, and the package TypeScript check rather than the full `npm test`, `npm run format`, and `npm run lint` commands.

### Screenshots

Not applicable. This is a backend Hub startup behavior fix.

### Additional Notes

This is intended as a small targeted PR against `bee/cleanhub` so the parent cleanup PR can keep its prod/dev discovery separation while preserving the old default-port fallback safety net.
