### PR TITLE
fix(cli): prevent double text in TUI output

### DIFF
--- a/apps/cli/src/runtime/interactive/session-runtime.test.ts
+++ b/apps/cli/src/runtime/interactive/session-runtime.test.ts
@@ -16,11 +16,15 @@ const {
 	mockCreateRuntimeHooks,
 	mockLoadInteractiveResumeMessages,
 	mockSetActiveCliSession,
+	mockSubscribeToAgentEvents,
+	mockSubscribeToPendingPromptEvents,
 } = vi.hoisted(() => ({
 	mockCreateCliCore: vi.fn(),
 	mockCreateRuntimeHooks: vi.fn(),
 	mockLoadInteractiveResumeMessages: vi.fn(),
 	mockSetActiveCliSession: vi.fn(),
+	mockSubscribeToAgentEvents: vi.fn(() => vi.fn()),
+	mockSubscribeToPendingPromptEvents: vi.fn(() => vi.fn()),
 }));
 
 vi.mock("../../session/session", () => ({
@@ -48,8 +52,8 @@ vi.mock("../active-runtime", () => ({
 }));
 
 vi.mock("../session-events", () => ({
-	subscribeToAgentEvents: vi.fn(() => vi.fn()),
-	subscribeToPendingPromptEvents: vi.fn(() => vi.fn()),
+	subscribeToAgentEvents: mockSubscribeToAgentEvents,
+	subscribeToPendingPromptEvents: mockSubscribeToPendingPromptEvents,
 }));
 
 import { createInteractiveSessionRuntime } from "./session-runtime";
@@ -203,6 +207,19 @@ describe("createInteractiveSessionRuntime", () => {
 
 		expect(manager.start).toHaveBeenCalledTimes(2);
 		expect(runtime.getActiveSessionId()).toBe("session-2");
+	});
+
+	it("subscribes agent events to the active interactive session only", async () => {
+		const manager = makeManager();
+		const runtime = makeRuntime(manager);
+
+		await runtime.ensureReady();
+
+		expect(mockSubscribeToAgentEvents).toHaveBeenCalledWith(
+			manager,
+			expect.any(Function),
+			{ sessionId: "session-1" },
+		);
 	});
 
 	it("starts fresh after resetting an initially resumed session", async () => {

--- a/apps/cli/src/runtime/interactive/session-runtime.ts
+++ b/apps/cli/src/runtime/interactive/session-runtime.ts
@@ -83,11 +83,21 @@ export function createInteractiveSessionRuntime(input: {
 	let pendingResumeSessionId = input.resumeSessionId?.trim() || undefined;
 
 	const clearActiveSession = (): void => {
+		unsubscribeAgent();
+		unsubscribeAgent = () => {};
 		activeSessionId = "";
 		setActiveCliSession(undefined);
 	};
 
 	const applyStartedSession = (started: StartedSession): void => {
+		if (sessionManager) {
+			unsubscribeAgent();
+			unsubscribeAgent = subscribeToAgentEvents(
+				sessionManager,
+				input.onAgentEvent,
+				{ sessionId: started.sessionId },
+			);
+		}
 		setActiveCliSession({
 			manifest: started.manifest,
 		});
@@ -140,7 +150,6 @@ export function createInteractiveSessionRuntime(input: {
 				await manager.ingestHookEvent(payload);
 			},
 		});
-		unsubscribeAgent = subscribeToAgentEvents(manager, input.onAgentEvent);
 		unsubscribePendingPrompts = subscribeToPendingPromptEvents(manager, {
 			onPendingPrompts: input.onPendingPrompts,
 			onPendingPromptSubmitted: input.onPendingPromptSubmitted,


### PR DESCRIPTION
### Related Issue

Issue: #XXXX

### Description

This fixes the double text TUI issue in `apps/cli`, where assistant output could render as repeated fragments in the terminal, even though the underlying model logs contained normal text. The reported case happened with the Cline provider and GPT 5.5, but the root cause was in CLI interactive event routing rather than provider output or markdown rendering.

The interactive runtime was subscribing to all agent events from the session manager. That meant the visible TUI transcript could receive agent-event traffic that did not belong to the active interactive session.

Hooks were related indirectly. Hook-heavy runs create extra runtime activity around tool execution, hook ingestion, and session-manager event flow. With a manager-wide agent-event subscription, that extra activity could leak into the active TUI transcript and show up as duplicated rendered text. The hook system was not appending duplicate text itself. It exposed that the interactive TUI subscription boundary was too broad.

The fix scopes agent-event delivery to the active interactive session:

- When an interactive session starts or resumes, subscribe to agent events with the active session id.
- When the active session is cleared, unsubscribe from the previous agent-event stream.
- Keep pending prompt subscriptions global, because pending prompt handling is intentionally manager-level behavior.

This preserves hook behavior while preventing unrelated session-manager events from being rendered into the active terminal transcript.

### Test Procedure

I reproduced the underlying failure mode with a focused regression test against the interactive session runtime. The test asserts that `subscribeToAgentEvents` is called with `{ sessionId: "session-1" }` for the active interactive session. Before the runtime change, this failed because the subscription was manager-wide. After the fix, it passes.

Verification run locally:

```bash
timeout 30s ./node_modules/.bin/vitest run src/runtime/interactive/session-runtime.test.ts --config vitest.config.ts --reporter verbose
timeout 120s bun run typecheck
timeout 60s bun biome check apps/cli/src/runtime/interactive/session-runtime.ts apps/cli/src/runtime/interactive/session-runtime.test.ts
```

All checks passed. I also scanned the changed files for the repository's forbidden type assertion pattern, double-asterisk markdown formatting, and the long dash character.

The main risk area is interactive CLI session lifecycle behavior, especially switching, resetting, or recovering sessions. The regression test covers the new subscription contract, and the existing tests still cover reset, resume, eager restart, disappeared-session recovery, and disposal behavior.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable. This is a CLI runtime event-routing fix covered by automated tests.

### Additional Notes

The earlier tempting workaround was to deduplicate repeated streamed chunks after they reached the TUI. This PR avoids that approach because it would hide symptoms in rendering code while leaving the event boundary wrong. Scoping the subscription to the active session fixes the source of the leaked events and keeps the renderer behavior unchanged.
