### PR TITLE
feat(ollama): add configurable thinking mode toggle to settings

### DIFF
--- a/apps/vscode/proto/cline/models.proto
+++ b/apps/vscode/proto/cline/models.proto
@@ -600,7 +600,7 @@ message ModelsApiConfiguration {
   optional string nous_research_api_key = 85;
   optional bool azure_identity = 86;
   optional string wandb_api_key = 87;
-  optional bool ollama_thinking = 88;
+  optional string ollama_thinking = 88;
 
   // Plan mode configurations
   optional ApiProvider plan_mode_api_provider = 100;

--- a/apps/vscode/proto/cline/models.proto
+++ b/apps/vscode/proto/cline/models.proto
@@ -600,6 +600,7 @@ message ModelsApiConfiguration {
   optional string nous_research_api_key = 85;
   optional bool azure_identity = 86;
   optional string wandb_api_key = 87;
+  optional bool ollama_thinking = 88;
 
   // Plan mode configurations
   optional ApiProvider plan_mode_api_provider = 100;

--- a/apps/vscode/src/core/api/index.ts
+++ b/apps/vscode/src/core/api/index.ts
@@ -157,6 +157,7 @@ function createHandlerForProvider(
 				ollamaApiKey: options.ollamaApiKey,
 				ollamaModelId: mode === "plan" ? options.planModeOllamaModelId : options.actModeOllamaModelId,
 				ollamaApiOptionsCtxNum: options.ollamaApiOptionsCtxNum,
+				ollamaThinking: options.ollamaThinking,
 				requestTimeoutMs: options.requestTimeoutMs,
 			})
 		case "lmstudio":

--- a/apps/vscode/src/core/api/providers/ollama.ts
+++ b/apps/vscode/src/core/api/providers/ollama.ts
@@ -16,6 +16,7 @@ interface OllamaHandlerOptions extends CommonApiHandlerOptions {
 	ollamaApiKey?: string
 	ollamaModelId?: string
 	ollamaApiOptionsCtxNum?: string
+	ollamaThinking?: boolean
 	requestTimeoutMs?: number
 }
 
@@ -73,6 +74,7 @@ export class OllamaHandler implements ApiHandler {
 				model: this.getModel().id,
 				messages: ollamaMessages,
 				stream: true,
+				think: this.options.ollamaThinking ?? true,
 				options: {
 					num_ctx: Number(this.options.ollamaApiOptionsCtxNum),
 				},

--- a/apps/vscode/src/core/api/providers/ollama.ts
+++ b/apps/vscode/src/core/api/providers/ollama.ts
@@ -16,7 +16,7 @@ interface OllamaHandlerOptions extends CommonApiHandlerOptions {
 	ollamaApiKey?: string
 	ollamaModelId?: string
 	ollamaApiOptionsCtxNum?: string
-	ollamaThinking?: boolean
+	ollamaThinking?: boolean | 'high' | 'medium' | 'low' | undefined
 	requestTimeoutMs?: number
 }
 
@@ -74,7 +74,7 @@ export class OllamaHandler implements ApiHandler {
 				model: this.getModel().id,
 				messages: ollamaMessages,
 				stream: true,
-				think: this.options.ollamaThinking ?? true,
+				...(this.options.ollamaThinking !== undefined && { think: this.options.ollamaThinking }),
 				options: {
 					num_ctx: Number(this.options.ollamaApiOptionsCtxNum),
 				},

--- a/apps/vscode/src/core/api/providers/ollama.ts
+++ b/apps/vscode/src/core/api/providers/ollama.ts
@@ -16,7 +16,7 @@ interface OllamaHandlerOptions extends CommonApiHandlerOptions {
 	ollamaApiKey?: string
 	ollamaModelId?: string
 	ollamaApiOptionsCtxNum?: string
-	ollamaThinking?: boolean | 'high' | 'medium' | 'low' | undefined
+	ollamaThinking?: string
 	requestTimeoutMs?: number
 }
 
@@ -69,12 +69,21 @@ export class OllamaHandler implements ApiHandler {
 				setTimeout(() => reject(new Error(`Ollama request timed out after ${timeoutMs / 1000} seconds`)), timeoutMs)
 			})
 
+			const lookup: Record<string, boolean | "high" | "medium" | "low" | undefined> = {
+				"":       undefined,
+				"true":   true,
+				"false":  false,
+				"high":   "high",
+				"medium": "medium",
+				"low":    "low",
+			}
+
 			// Create the actual API request promise
 			const apiPromise = client.chat({
 				model: this.getModel().id,
 				messages: ollamaMessages,
 				stream: true,
-				...(this.options.ollamaThinking !== undefined && { think: this.options.ollamaThinking }),
+				...(this.options.ollamaThinking !== undefined && { think: lookup[this.options.ollamaThinking] }),
 				options: {
 					num_ctx: Number(this.options.ollamaApiOptionsCtxNum),
 				},

--- a/apps/vscode/src/shared/proto-conversions/models/api-configuration-conversion.ts
+++ b/apps/vscode/src/shared/proto-conversions/models/api-configuration-conversion.ts
@@ -459,6 +459,7 @@ export function convertApiConfigurationToProto(config: ApiConfiguration): ProtoA
 		ollamaBaseUrl: config.ollamaBaseUrl,
 		ollamaApiKey: config.ollamaApiKey,
 		ollamaApiOptionsCtxNum: config.ollamaApiOptionsCtxNum,
+		ollamaThinking: config.ollamaThinking,
 		lmStudioBaseUrl: config.lmStudioBaseUrl,
 		lmStudioMaxTokens: config.lmStudioMaxTokens,
 		geminiApiKey: config.geminiApiKey,

--- a/apps/vscode/src/shared/storage/state-keys.ts
+++ b/apps/vscode/src/shared/storage/state-keys.ts
@@ -117,6 +117,7 @@ const API_HANDLER_SETTINGS_FIELDS = {
 	openAiBaseUrl: { default: undefined as string | undefined },
 	ollamaBaseUrl: { default: undefined as string | undefined },
 	ollamaApiOptionsCtxNum: { default: undefined as string | undefined },
+	ollamaThinking: { default: undefined as boolean | undefined },
 	lmStudioBaseUrl: { default: undefined as string | undefined },
 	lmStudioMaxTokens: { default: undefined as string | undefined },
 	geminiBaseUrl: { default: undefined as string | undefined },

--- a/apps/vscode/src/shared/storage/state-keys.ts
+++ b/apps/vscode/src/shared/storage/state-keys.ts
@@ -117,7 +117,7 @@ const API_HANDLER_SETTINGS_FIELDS = {
 	openAiBaseUrl: { default: undefined as string | undefined },
 	ollamaBaseUrl: { default: undefined as string | undefined },
 	ollamaApiOptionsCtxNum: { default: undefined as string | undefined },
-	ollamaThinking: { default: undefined as boolean | undefined },
+	ollamaThinking: { default: undefined as boolean | undefined | "high" | "medium" | "low" },
 	lmStudioBaseUrl: { default: undefined as string | undefined },
 	lmStudioMaxTokens: { default: undefined as string | undefined },
 	geminiBaseUrl: { default: undefined as string | undefined },

--- a/apps/vscode/src/shared/storage/state-keys.ts
+++ b/apps/vscode/src/shared/storage/state-keys.ts
@@ -117,7 +117,7 @@ const API_HANDLER_SETTINGS_FIELDS = {
 	openAiBaseUrl: { default: undefined as string | undefined },
 	ollamaBaseUrl: { default: undefined as string | undefined },
 	ollamaApiOptionsCtxNum: { default: undefined as string | undefined },
-	ollamaThinking: { default: undefined as boolean | undefined | "high" | "medium" | "low" },
+	ollamaThinking: { default: undefined as string | undefined },
 	lmStudioBaseUrl: { default: undefined as string | undefined },
 	lmStudioMaxTokens: { default: undefined as string | undefined },
 	geminiBaseUrl: { default: undefined as string | undefined },

--- a/apps/vscode/webview-ui/src/components/settings/providers/OllamaProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/OllamaProvider.tsx
@@ -1,6 +1,6 @@
 import { StringRequest } from "@shared/proto/cline/common"
 import { Mode } from "@shared/storage/types"
-import { VSCodeLink } from "@vscode/webview-ui-toolkit/react"
+import { VSCodeCheckbox, VSCodeLink } from "@vscode/webview-ui-toolkit/react"
 import { useCallback, useEffect, useState } from "react"
 import { useInterval } from "react-use"
 import UseCustomPromptCheckbox from "@/components/settings/UseCustomPromptCheckbox"
@@ -124,6 +124,12 @@ export const OllamaProvider = ({ showModelOptions, isPopup, currentMode }: Ollam
 					</p>
 				</>
 			)}
+
+			<VSCodeCheckbox
+				checked={apiConfiguration?.ollamaThinking ?? true}
+				onChange={(e: any) => handleFieldChange("ollamaThinking", e.target.checked)}>
+				<span className="font-semibold">Enable thinking</span>
+			</VSCodeCheckbox>
 
 			<UseCustomPromptCheckbox providerId="ollama" />
 

--- a/apps/vscode/webview-ui/src/components/settings/providers/OllamaProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/OllamaProvider.tsx
@@ -127,25 +127,18 @@ export const OllamaProvider = ({ showModelOptions, isPopup, currentMode }: Ollam
 
 			<span className="font-semibold">Thinking mode</span>
 			<VSCodeDropdown
+				id="ollama-provider-thinking"
 				value={String(apiConfiguration?.ollamaThinking ?? "")}
 				onChange={(e: any) => {
-					const lookup: Record<string, boolean | "high" | "medium" | "low" | undefined> = {
-						"":       undefined,
-						"true":   true,
-						"false":  false,
-						"high":   "high",
-						"medium": "medium",
-						"low":    "low",
-					}
-					handleFieldChange("ollamaThinking", lookup[e.target.value] ?? undefined)
+					handleFieldChange("ollamaThinking", e.target.value)
 				}}
 				style={{ width: "100%" }}>
-				<VSCodeOption value="">Default (unset)</VSCodeOption>
-				<VSCodeOption value="true">Enabled</VSCodeOption>
-				<VSCodeOption value="false">Disabled</VSCodeOption>
-				<VSCodeOption value="high">High (for gpt-oss)</VSCodeOption>
-				<VSCodeOption value="medium">Medium (for gpt-oss)</VSCodeOption>
-				<VSCodeOption value="low">Low (for gpt-oss)</VSCodeOption>
+				<VSCodeOption key="" value="">Default (unset)</VSCodeOption>
+				<VSCodeOption key="true" value="true">Enabled</VSCodeOption>
+				<VSCodeOption key="false" value="false">Disabled</VSCodeOption>
+				<VSCodeOption key="high" value="high">High (for gpt-oss)</VSCodeOption>
+				<VSCodeOption key="medium" value="medium">Medium (for gpt-oss)</VSCodeOption>
+				<VSCodeOption key="low" value="low">Low (for gpt-oss)</VSCodeOption>
 			</VSCodeDropdown>
 
 			<p
@@ -154,7 +147,7 @@ export const OllamaProvider = ({ showModelOptions, isPopup, currentMode }: Ollam
 					marginTop: "5px",
 					color: "var(--vscode-descriptionForeground)",
 				}}>
-				Thinking mode of the selected Model
+				Thinking mode of the selected model
 			</p>
 
 			<UseCustomPromptCheckbox providerId="ollama" />

--- a/apps/vscode/webview-ui/src/components/settings/providers/OllamaProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/OllamaProvider.tsx
@@ -1,6 +1,6 @@
 import { StringRequest } from "@shared/proto/cline/common"
 import { Mode } from "@shared/storage/types"
-import { VSCodeCheckbox, VSCodeLink } from "@vscode/webview-ui-toolkit/react"
+import { VSCodeDropdown, VSCodeLink, VSCodeOption } from "@vscode/webview-ui-toolkit/react"
 import { useCallback, useEffect, useState } from "react"
 import { useInterval } from "react-use"
 import UseCustomPromptCheckbox from "@/components/settings/UseCustomPromptCheckbox"
@@ -125,11 +125,37 @@ export const OllamaProvider = ({ showModelOptions, isPopup, currentMode }: Ollam
 				</>
 			)}
 
-			<VSCodeCheckbox
-				checked={apiConfiguration?.ollamaThinking ?? true}
-				onChange={(e: any) => handleFieldChange("ollamaThinking", e.target.checked)}>
-				<span className="font-semibold">Enable thinking</span>
-			</VSCodeCheckbox>
+			<span className="font-semibold">Thinking mode</span>
+			<VSCodeDropdown
+				value={String(apiConfiguration?.ollamaThinking ?? "")}
+				onChange={(e: any) => {
+					const lookup: Record<string, boolean | "high" | "medium" | "low" | undefined> = {
+						"":       undefined,
+						"true":   true,
+						"false":  false,
+						"high":   "high",
+						"medium": "medium",
+						"low":    "low",
+					}
+					handleFieldChange("ollamaThinking", lookup[e.target.value] ?? undefined)
+				}}
+				style={{ width: "100%" }}>
+				<VSCodeOption value="">Default (unset)</VSCodeOption>
+				<VSCodeOption value="true">Enabled</VSCodeOption>
+				<VSCodeOption value="false">Disabled</VSCodeOption>
+				<VSCodeOption value="high">High (for gpt-oss)</VSCodeOption>
+				<VSCodeOption value="medium">Medium (for gpt-oss)</VSCodeOption>
+				<VSCodeOption value="low">Low (for gpt-oss)</VSCodeOption>
+			</VSCodeDropdown>
+
+			<p
+				style={{
+					fontSize: "12px",
+					marginTop: "5px",
+					color: "var(--vscode-descriptionForeground)",
+				}}>
+				Thinking mode of the selected Model
+			</p>
 
 			<UseCustomPromptCheckbox providerId="ollama" />
 


### PR DESCRIPTION
Added an option to enable or disable thinking mode for Ollama

- Define ollama_thinking in models.proto and extend OllamaHandlerOptions
- Pass the flag to the Ollama API to control the `think` request parameter
- Add a settings UI checkbox to enable or disable the feature Defaults to enabled to leverage built-in reasoning capabilities when available.

I think this has been discussed in #4628

### Related Issue

No related issues I know about, but there is a discussion:

**Discussion:** #4628


### Description

#### What problem does this PR solve?

Right now, thinking is always enabled when using Ollama. That means usually better but also slower answers from the LLM. This PR makes it possible to disable thinking.

#### Why were these changes introduced and what purpose do they serve?

Improve performance for Ollama users.

#### For larger changes, provide context about your approach and reasoning

That's a very small change

### Test Procedure

Tested it locally with qwen3.6:35b and verified that the requests go through as planned using a network sniffer. By default, thinking is enabled, which should not break anything.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

Tests are not passing due to an unrelated problem currently in the main branch. The current code in the main branch is also not properly formatted, at least I get errors when I run the linter there.

### Screenshots

<img width="712" height="961" alt="Bildschirmfoto vom 2026-06-07 18-29-26" src="https://github.com/user-attachments/assets/5c9dc221-d727-483b-9192-35f3036e3675" />

### Additional Notes

Feel free to reformat this PR.