### PR TITLE
Fix OpenAI-compatible empty response handling

### DIFF
--- a/apps/vscode/src/core/api/transform/__tests__/thinking-traces.test.ts
+++ b/apps/vscode/src/core/api/transform/__tests__/thinking-traces.test.ts
@@ -198,6 +198,37 @@ describe("Thinking Trace Preservation", () => {
 			assistantMsg.role.should.equal("assistant")
 			assistantMsg.content.should.equal("DATA chunks are sequential.")
 		})
+
+		it("should fall back to summary text for empty thinking blocks", () => {
+			const messages: ClineStorageMessage[] = [
+				{
+					role: "assistant",
+					content: [
+						{
+							type: "thinking",
+							thinking: "",
+							signature: "",
+							summary: [
+								{
+									type: "reasoning.text",
+									text: "Reasoning captured in summary.",
+									signature: "sig",
+									format: "anthropic-claude-v1",
+									index: 0,
+								},
+							],
+						} as ClineAssistantThinkingBlock,
+					],
+				},
+			]
+
+			const result = convertToR1Format(messages)
+
+			result.should.have.length(1)
+			const assistantMsg = result[0] as any
+			assistantMsg.role.should.equal("assistant")
+			assistantMsg.content.should.equal("Reasoning captured in summary.")
+		})
 	})
 
 	describe("sanitizeGeminiMessages", () => {

--- a/apps/vscode/src/core/api/transform/__tests__/thinking-traces.test.ts
+++ b/apps/vscode/src/core/api/transform/__tests__/thinking-traces.test.ts
@@ -14,6 +14,7 @@ import "should"
 import { ClineAssistantThinkingBlock, ClineStorageMessage, ClineTextContentBlock } from "@/shared/messages/content"
 import { sanitizeAnthropicMessages } from "../anthropic-format"
 import { convertToOpenAiMessages, sanitizeGeminiMessages } from "../openai-format"
+import { convertToR1Format } from "../r1-format"
 
 describe("Thinking Trace Preservation", () => {
 	describe("convertToOpenAiMessages", () => {
@@ -74,6 +75,29 @@ describe("Thinking Trace Preservation", () => {
 			// The thinking block content should be preserved in some form
 			// (exact handling depends on implementation)
 			assistantMsg.content.should.containEql("Here's my answer.")
+		})
+
+		it("should convert thinking-only assistant history to non-empty content", () => {
+			const messages: ClineStorageMessage[] = [
+				{
+					role: "assistant",
+					content: [
+						{
+							type: "thinking",
+							thinking: "Need to inspect the WAV chunks first.",
+							signature: "",
+						} as ClineAssistantThinkingBlock,
+					],
+				},
+			]
+
+			const result = convertToOpenAiMessages(messages)
+
+			result.should.have.length(1)
+			const assistantMsg = result[0] as any
+			assistantMsg.role.should.equal("assistant")
+			assistantMsg.content.should.equal("Need to inspect the WAV chunks first.")
+			;(assistantMsg.tool_calls === undefined).should.be.true()
 		})
 
 		it("should consolidate multiple reasoning_details entries", () => {
@@ -149,6 +173,30 @@ describe("Thinking Trace Preservation", () => {
 			// Should only have the valid reasoning entry
 			assistantMsg.reasoning_details.should.have.length(1)
 			assistantMsg.reasoning_details[0].type.should.equal("reasoning.text")
+		})
+	})
+
+	describe("convertToR1Format", () => {
+		it("should preserve thinking-only assistant history as text content", () => {
+			const messages: ClineStorageMessage[] = [
+				{
+					role: "assistant",
+					content: [
+						{
+							type: "thinking",
+							thinking: "DATA chunks are sequential.",
+							signature: "",
+						} as ClineAssistantThinkingBlock,
+					],
+				},
+			]
+
+			const result = convertToR1Format(messages)
+
+			result.should.have.length(1)
+			const assistantMsg = result[0] as any
+			assistantMsg.role.should.equal("assistant")
+			assistantMsg.content.should.equal("DATA chunks are sequential.")
 		})
 	})
 

--- a/apps/vscode/src/core/api/transform/__tests__/tool-parsing.test.ts
+++ b/apps/vscode/src/core/api/transform/__tests__/tool-parsing.test.ts
@@ -193,6 +193,26 @@ describe("Tool Call Parsing", () => {
 			msg.content.should.equal("Line 1\nLine 2")
 		})
 
+		it("should sanitize unsafe control characters from tool results", () => {
+			const messages: ClineStorageMessage[] = [
+				{
+					role: "user",
+					content: [
+						{
+							type: "tool_result",
+							tool_use_id: "tool_123",
+							content: "\u001b[31mchunk=['\x00DATA']\u001b[0m\x07",
+						} as ClineUserToolResultContentBlock,
+					],
+				},
+			]
+
+			const result = convertToOpenAiMessages(messages)
+
+			const msg = result[0] as OpenAI.Chat.ChatCompletionToolMessageParam
+			msg.content.should.equal("chunk=['DATA']")
+		})
+
 		it("should set content to null when only tool_calls present", () => {
 			const messages: ClineStorageMessage[] = [
 				{

--- a/apps/vscode/src/core/api/transform/openai-format.ts
+++ b/apps/vscode/src/core/api/transform/openai-format.ts
@@ -11,9 +11,38 @@ import {
 	ClineUserToolResultContentBlock,
 } from "@/shared/messages/content"
 import { Logger } from "@/shared/services/Logger"
+import { sanitizeTextForModelInput } from "@/utils/string"
 
 // OpenAI API has a maximum tool call ID length of 40 characters
 const MAX_TOOL_CALL_ID_LENGTH = 40
+
+function appendReasoningDetails(reasoningDetails: any[], details: unknown): void {
+	if (!details) {
+		return
+	}
+	if (Array.isArray(details)) {
+		reasoningDetails.push(...details)
+	} else {
+		reasoningDetails.push(details)
+	}
+}
+
+function extractReasoningText(details: unknown): string {
+	if (!Array.isArray(details)) {
+		return ""
+	}
+
+	return details
+		.map((detail) => {
+			const text = detail && typeof detail === "object" && "text" in detail ? (detail as { text?: unknown }).text : undefined
+			if (typeof text === "string") {
+				return sanitizeTextForModelInput(text)
+			}
+			return ""
+		})
+		.filter((text) => text.trim().length > 0)
+		.join("\n")
+}
 
 /**
  * Determines if a given tool ID follows the OpenAI Responses API format for tool calls.
@@ -74,7 +103,7 @@ export function convertToOpenAiMessages(
 		if (typeof anthropicMessage.content === "string") {
 			openAiMessages.push({
 				role: anthropicMessage.role,
-				content: anthropicMessage.content,
+				content: sanitizeTextForModelInput(anthropicMessage.content),
 			})
 		} else {
 			// image_url.url is base64 encoded image data
@@ -108,7 +137,7 @@ export function convertToOpenAiMessages(
 					let content: string
 
 					if (typeof toolMessage.content === "string") {
-						content = toolMessage.content
+						content = sanitizeTextForModelInput(toolMessage.content)
 					} else if (Array.isArray(toolMessage.content)) {
 						content =
 							toolMessage.content
@@ -117,7 +146,7 @@ export function convertToOpenAiMessages(
 										toolResultImages.push(part)
 										return "(see following user message for image)"
 									}
-									return part.text
+									return sanitizeTextForModelInput(part.text)
 								})
 								.join("\n") ?? ""
 					} else {
@@ -162,59 +191,59 @@ export function convertToOpenAiMessages(
 									},
 								}
 							}
-							return { type: "text", text: part.text }
+							return { type: "text", text: sanitizeTextForModelInput(part.text) }
 						}),
 					})
 				}
 			} else if (anthropicMessage.role === "assistant") {
-				const { nonToolMessages, toolMessages } = anthropicMessage.content.reduce<{
-					nonToolMessages: (
-						| ClineTextContentBlock
-						| ClineImageContentBlock
-						| ClineAssistantThinkingBlock
-						| ClineAssistantRedactedThinkingBlock
-					)[]
+				const { nonToolMessages, toolMessages, thinkingMessages, redactedThinkingMessages } = anthropicMessage.content.reduce<{
+					nonToolMessages: (ClineTextContentBlock | ClineImageContentBlock)[]
 					toolMessages: ClineAssistantToolUseBlock[]
+					thinkingMessages: ClineAssistantThinkingBlock[]
+					redactedThinkingMessages: ClineAssistantRedactedThinkingBlock[]
 				}>(
 					(acc, part) => {
 						if (part.type === "tool_use") {
 							acc.toolMessages.push(part)
+						} else if (part.type === "thinking") {
+							acc.thinkingMessages.push(part)
+						} else if (part.type === "redacted_thinking") {
+							acc.redactedThinkingMessages.push(part)
 						} else if (part.type === "text" || part.type === "image") {
 							acc.nonToolMessages.push(part)
 						} // assistant cannot send tool_result messages
 						return acc
 					},
-					{ nonToolMessages: [], toolMessages: [] },
+					{ nonToolMessages: [], toolMessages: [], thinkingMessages: [], redactedThinkingMessages: [] },
 				)
 
 				// Process non-tool messages
 				let content: string | undefined
 				const reasoningDetails: any[] = []
-				const thinkingBlock = []
 				if (nonToolMessages.length > 0) {
 					nonToolMessages.forEach((part) => {
 						const anyPart = part as any
 						if (part.type === "text" && anyPart.reasoning_details) {
-							if (Array.isArray(anyPart.reasoning_details)) {
-								reasoningDetails.push(...anyPart.reasoning_details)
-							} else {
-								reasoningDetails.push(anyPart.reasoning_details)
-							}
-						}
-						if (part.type === "thinking" && part.thinking) {
-							// Reasoning details should have been moved to the text block
-							thinkingBlock.push(part)
+							appendReasoningDetails(reasoningDetails, anyPart.reasoning_details)
 						}
 					})
 					content = nonToolMessages
 						.map((part) => {
 							if (part.type === "text" && part.text) {
-								return part.text
+								return sanitizeTextForModelInput(part.text)
 							}
 							return ""
 						})
 						.join("\n")
 				}
+				const thinkingContent = thinkingMessages
+					.map((part) => {
+						appendReasoningDetails(reasoningDetails, part.summary)
+						const thinkingText = sanitizeTextForModelInput(part.thinking || "")
+						return thinkingText.trim().length > 0 ? thinkingText : extractReasoningText(part.summary)
+					})
+					.filter((text) => text.trim().length > 0)
+					.join("\n")
 
 				// Process tool use messages
 				const tool_calls: OpenAI.Chat.ChatCompletionMessageToolCall[] = toolMessages.map((toolMessage) => {
@@ -254,7 +283,13 @@ export function convertToOpenAiMessages(
 				// Set content to blank when tool_calls are present but content has no text, per OpenAI API spec
 				const hasToolCalls = tool_calls.length > 0
 				const hasMeaningfulContent = content !== undefined && content.trim() !== ""
-				const finalContent = hasMeaningfulContent ? content : hasToolCalls ? null : undefined
+				const fallbackThinkingContent =
+					thinkingContent.trim().length > 0
+						? thinkingContent
+						: redactedThinkingMessages.length > 0
+							? "[redacted reasoning]"
+							: undefined
+				const finalContent = hasMeaningfulContent ? content : hasToolCalls ? null : fallbackThinkingContent
 
 				const consolidatedReasoningDetails =
 					reasoningDetails.length > 0 ? consolidateReasoningDetails(reasoningDetails as any) : []
@@ -330,7 +365,7 @@ function consolidateReasoningDetails(reasoningDetails: ReasoningDetail[]): Reaso
 
 		for (const detail of details) {
 			if (detail.text) {
-				concatenatedText += detail.text
+				concatenatedText += sanitizeTextForModelInput(detail.text)
 			}
 			// Keep the signature from the last item that has one
 			if (detail.signature) {

--- a/apps/vscode/src/core/api/transform/openai-format.ts
+++ b/apps/vscode/src/core/api/transform/openai-format.ts
@@ -11,7 +11,7 @@ import {
 	ClineUserToolResultContentBlock,
 } from "@/shared/messages/content"
 import { Logger } from "@/shared/services/Logger"
-import { sanitizeTextForModelInput } from "@/utils/string"
+import { extractReasoningText, sanitizeTextForModelInput } from "@/utils/string"
 
 // OpenAI API has a maximum tool call ID length of 40 characters
 const MAX_TOOL_CALL_ID_LENGTH = 40
@@ -25,23 +25,6 @@ function appendReasoningDetails(reasoningDetails: any[], details: unknown): void
 	} else {
 		reasoningDetails.push(details)
 	}
-}
-
-function extractReasoningText(details: unknown): string {
-	if (!Array.isArray(details)) {
-		return ""
-	}
-
-	return details
-		.map((detail) => {
-			const text = detail && typeof detail === "object" && "text" in detail ? (detail as { text?: unknown }).text : undefined
-			if (typeof text === "string") {
-				return sanitizeTextForModelInput(text)
-			}
-			return ""
-		})
-		.filter((text) => text.trim().length > 0)
-		.join("\n")
 }
 
 /**
@@ -196,26 +179,27 @@ export function convertToOpenAiMessages(
 					})
 				}
 			} else if (anthropicMessage.role === "assistant") {
-				const { nonToolMessages, toolMessages, thinkingMessages, redactedThinkingMessages } = anthropicMessage.content.reduce<{
-					nonToolMessages: (ClineTextContentBlock | ClineImageContentBlock)[]
-					toolMessages: ClineAssistantToolUseBlock[]
-					thinkingMessages: ClineAssistantThinkingBlock[]
-					redactedThinkingMessages: ClineAssistantRedactedThinkingBlock[]
-				}>(
-					(acc, part) => {
-						if (part.type === "tool_use") {
-							acc.toolMessages.push(part)
-						} else if (part.type === "thinking") {
-							acc.thinkingMessages.push(part)
-						} else if (part.type === "redacted_thinking") {
-							acc.redactedThinkingMessages.push(part)
-						} else if (part.type === "text" || part.type === "image") {
-							acc.nonToolMessages.push(part)
-						} // assistant cannot send tool_result messages
-						return acc
-					},
-					{ nonToolMessages: [], toolMessages: [], thinkingMessages: [], redactedThinkingMessages: [] },
-				)
+				const { nonToolMessages, toolMessages, thinkingMessages, redactedThinkingMessages } =
+					anthropicMessage.content.reduce<{
+						nonToolMessages: (ClineTextContentBlock | ClineImageContentBlock)[]
+						toolMessages: ClineAssistantToolUseBlock[]
+						thinkingMessages: ClineAssistantThinkingBlock[]
+						redactedThinkingMessages: ClineAssistantRedactedThinkingBlock[]
+					}>(
+						(acc, part) => {
+							if (part.type === "tool_use") {
+								acc.toolMessages.push(part)
+							} else if (part.type === "thinking") {
+								acc.thinkingMessages.push(part)
+							} else if (part.type === "redacted_thinking") {
+								acc.redactedThinkingMessages.push(part)
+							} else if (part.type === "text" || part.type === "image") {
+								acc.nonToolMessages.push(part)
+							} // assistant cannot send tool_result messages
+							return acc
+						},
+						{ nonToolMessages: [], toolMessages: [], thinkingMessages: [], redactedThinkingMessages: [] },
+					)
 
 				// Process non-tool messages
 				let content: string | undefined

--- a/apps/vscode/src/core/api/transform/r1-format.ts
+++ b/apps/vscode/src/core/api/transform/r1-format.ts
@@ -1,6 +1,7 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import OpenAI from "openai"
 import { ClineAssistantThinkingBlock, ClineStorageMessage } from "@/shared/messages/content"
+import { sanitizeTextForModelInput } from "@/utils/string"
 
 /**
  * DeepSeek Reasoner message format with reasoning_content support.
@@ -81,7 +82,13 @@ export function convertToR1Format(messages: Anthropic.Messages.MessageParam[]): 
 
 			message.content.forEach((part) => {
 				if (part.type === "text") {
-					textParts.push(part.text)
+					textParts.push(sanitizeTextForModelInput(part.text))
+				}
+				if (message.role === "assistant" && part.type === "thinking") {
+					const thinkingText = sanitizeTextForModelInput(part.thinking || "")
+					if (thinkingText.trim().length > 0) {
+						textParts.push(thinkingText)
+					}
 				}
 				if (part.type === "image") {
 					hasImages = true
@@ -103,7 +110,7 @@ export function convertToR1Format(messages: Anthropic.Messages.MessageParam[]): 
 				messageContent = textParts.join("\n")
 			}
 		} else {
-			messageContent = message.content
+			messageContent = sanitizeTextForModelInput(message.content)
 		}
 
 		// If the last message has the same role, merge the content

--- a/apps/vscode/src/core/api/transform/r1-format.ts
+++ b/apps/vscode/src/core/api/transform/r1-format.ts
@@ -10,6 +10,20 @@ export type DeepSeekReasonerMessage = OpenAI.Chat.ChatCompletionMessageParam & {
 	reasoning_content?: string
 }
 
+function extractReasoningText(details: unknown): string {
+	if (!Array.isArray(details)) {
+		return ""
+	}
+
+	return details
+		.map((detail) => {
+			const text = detail && typeof detail === "object" && "text" in detail ? (detail as { text?: unknown }).text : undefined
+			return typeof text === "string" ? sanitizeTextForModelInput(text) : ""
+		})
+		.filter((text) => text.trim().length > 0)
+		.join("\n")
+}
+
 /**
  * Adds reasoning_content to OpenAI messages for DeepSeek Reasoner.
  * Per DeepSeek API: reasoning_content should be passed back during tool calling in the same turn,
@@ -86,8 +100,12 @@ export function convertToR1Format(messages: Anthropic.Messages.MessageParam[]): 
 				}
 				if (message.role === "assistant" && part.type === "thinking") {
 					const thinkingText = sanitizeTextForModelInput(part.thinking || "")
-					if (thinkingText.trim().length > 0) {
-						textParts.push(thinkingText)
+					const reasoningText =
+						thinkingText.trim().length > 0
+							? thinkingText
+							: extractReasoningText((part as ClineAssistantThinkingBlock).summary)
+					if (reasoningText.trim().length > 0) {
+						textParts.push(reasoningText)
 					}
 				}
 				if (part.type === "image") {

--- a/apps/vscode/src/core/api/transform/r1-format.ts
+++ b/apps/vscode/src/core/api/transform/r1-format.ts
@@ -1,27 +1,13 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import OpenAI from "openai"
 import { ClineAssistantThinkingBlock, ClineStorageMessage } from "@/shared/messages/content"
-import { sanitizeTextForModelInput } from "@/utils/string"
+import { extractReasoningText, sanitizeTextForModelInput } from "@/utils/string"
 
 /**
  * DeepSeek Reasoner message format with reasoning_content support.
  */
 export type DeepSeekReasonerMessage = OpenAI.Chat.ChatCompletionMessageParam & {
 	reasoning_content?: string
-}
-
-function extractReasoningText(details: unknown): string {
-	if (!Array.isArray(details)) {
-		return ""
-	}
-
-	return details
-		.map((detail) => {
-			const text = detail && typeof detail === "object" && "text" in detail ? (detail as { text?: unknown }).text : undefined
-			return typeof text === "string" ? sanitizeTextForModelInput(text) : ""
-		})
-		.filter((text) => text.trim().length > 0)
-		.join("\n")
 }
 
 /**

--- a/apps/vscode/src/core/task/index.ts
+++ b/apps/vscode/src/core/task/index.ts
@@ -3100,7 +3100,12 @@ export class Task {
 			// toolUseHandler may have accumulated tool_use blocks even when useNativeToolCalls is false
 			// (e.g., from Claude Code provider when the model returns native tool_use blocks).
 			const hasAccumulatedToolCalls = toolUseHandler.getAllFinalizedToolUses().length > 0
-			const assistantHasContent = assistantMessage.length > 0 || this.useNativeToolCalls || hasAccumulatedToolCalls
+			const redactedThinkingContent = reasonsHandler.getRedactedThinking()
+			const thinkingBlock = reasonsHandler.getCurrentReasoning()
+			const hasReasoningContent =
+				!!thinkingBlock?.thinking.trim() || !!thinkingBlock?.summary?.length || redactedThinkingContent.length > 0
+			const assistantHasContent =
+				assistantMessage.length > 0 || this.useNativeToolCalls || hasAccumulatedToolCalls || hasReasoningContent
 			if (assistantHasContent) {
 				telemetryService.captureConversationTurnEvent(
 					this.ulid,
@@ -3112,9 +3117,6 @@ export class Task {
 					this.useNativeToolCalls,
 				)
 
-				const { reasonsHandler } = this.streamHandler.getHandlers()
-				const redactedThinkingContent = reasonsHandler.getRedactedThinking()
-
 				const requestId = this.streamHandler.requestId
 
 				// Build content array with thinking blocks, text (if any), and tool use blocks
@@ -3125,7 +3127,6 @@ export class Task {
 					...redactedThinkingContent,
 				]
 				// Add thinking block from the reasoning handler if available
-				const thinkingBlock = reasonsHandler.getCurrentReasoning()
 				if (thinkingBlock) {
 					assistantContent.push({ ...thinkingBlock })
 				}

--- a/apps/vscode/src/core/task/tools/utils/ToolResultUtils.ts
+++ b/apps/vscode/src/core/task/tools/utils/ToolResultUtils.ts
@@ -4,6 +4,7 @@ import { ToolResponse } from "@core/task"
 import { processFilesIntoText } from "@/integrations/misc/extract-text"
 import { ClineAsk } from "@/shared/ExtensionMessage"
 import { Logger } from "@/shared/services/Logger"
+import { sanitizeTextForModelInput } from "@/utils/string"
 import type { ToolExecutorCoordinator } from "../ToolExecutorCoordinator"
 import { TaskConfig } from "../types/TaskConfig"
 
@@ -22,8 +23,10 @@ export class ToolResultUtils {
 		coordinator?: ToolExecutorCoordinator,
 		toolUseIdMap?: Map<string, string>,
 	): void {
-		if (typeof content === "string") {
-			const resultText = content || "(tool did not return anything)"
+		const sanitizedContent = ToolResultUtils.sanitizeToolResponseContent(content)
+
+		if (typeof sanitizedContent === "string") {
+			const resultText = sanitizedContent || "(tool did not return anything)"
 
 			// Try to get description from coordinator first, otherwise use the provided function
 			const description = coordinator
@@ -55,21 +58,38 @@ export class ToolResultUtils {
 
 			// If using backward-compatible "cline" ID and content is an array, spread it directly
 			// instead of wrapping it (which would cause JSON.stringify in createToolResultBlock)
-			if ((toolUseId === "cline" || !toolUseId) && Array.isArray(content)) {
-				userMessageContent.push(...content)
+			if ((toolUseId === "cline" || !toolUseId) && Array.isArray(sanitizedContent)) {
+				userMessageContent.push(...sanitizedContent)
 			} else {
-				userMessageContent.push(ToolResultUtils.createToolResultBlock(content, toolUseId, block.call_id))
+				userMessageContent.push(ToolResultUtils.createToolResultBlock(sanitizedContent, toolUseId, block.call_id))
 			}
 		}
 	}
 
+	private static sanitizeToolResponseContent(content: ToolResponse): ToolResponse {
+		if (typeof content === "string") {
+			return sanitizeTextForModelInput(content)
+		}
+		if (Array.isArray(content)) {
+			return content.map((block) => {
+				if (block.type === "text") {
+					return { ...block, text: sanitizeTextForModelInput(block.text) }
+				}
+				return block
+			})
+		}
+		return content
+	}
+
 	private static createToolResultBlock(content: ToolResponse, id?: string, call_id?: string) {
+		const sanitizedContent = ToolResultUtils.sanitizeToolResponseContent(content)
+
 		// If id is "cline", we treat it as a plain text result for backward compatibility
 		// as we cannot find any existing tool call that matches this id.
 		if (id === "cline" || !id) {
 			return {
 				type: "text",
-				text: typeof content === "string" ? content : JSON.stringify(content, null, 2),
+				text: typeof sanitizedContent === "string" ? sanitizedContent : JSON.stringify(sanitizedContent, null, 2),
 			}
 		}
 
@@ -80,7 +100,7 @@ export class ToolResultUtils {
 			type: "tool_result",
 			tool_use_id: id,
 			call_id: call_id,
-			content: typeof content === "string" ? content : content,
+			content: sanitizedContent,
 		}
 	}
 
@@ -112,10 +132,10 @@ export class ToolResultUtils {
 		if (typeof content === "string") {
 			userMessageContent.push({
 				type: "text",
-				text: content,
+				text: sanitizeTextForModelInput(content),
 			})
 		} else {
-			userMessageContent.push(...content)
+			userMessageContent.push(...(ToolResultUtils.sanitizeToolResponseContent(content) as typeof content))
 		}
 	}
 

--- a/apps/vscode/src/core/task/tools/utils/ToolResultUtils.ts
+++ b/apps/vscode/src/core/task/tools/utils/ToolResultUtils.ts
@@ -29,12 +29,13 @@ export class ToolResultUtils {
 			const resultText = sanitizedContent || "(tool did not return anything)"
 
 			// Try to get description from coordinator first, otherwise use the provided function
-			const description = coordinator
+			const rawDescription = coordinator
 				? (() => {
 						const handler = coordinator.getHandler(block.name)
 						return handler ? handler.getDescription(block) : toolDescription(block)
 					})()
 				: toolDescription(block)
+			const description = sanitizeTextForModelInput(rawDescription)
 
 			// Get tool_use_id from map using call_id, or use "cline" as fallback for backward compatibility
 			const toolUseId = toolUseIdMap?.get(block.call_id || "") || "cline"
@@ -82,14 +83,12 @@ export class ToolResultUtils {
 	}
 
 	private static createToolResultBlock(content: ToolResponse, id?: string, call_id?: string) {
-		const sanitizedContent = ToolResultUtils.sanitizeToolResponseContent(content)
-
 		// If id is "cline", we treat it as a plain text result for backward compatibility
 		// as we cannot find any existing tool call that matches this id.
 		if (id === "cline" || !id) {
 			return {
 				type: "text",
-				text: typeof sanitizedContent === "string" ? sanitizedContent : JSON.stringify(sanitizedContent, null, 2),
+				text: typeof content === "string" ? content : JSON.stringify(content, null, 2),
 			}
 		}
 
@@ -100,7 +99,7 @@ export class ToolResultUtils {
 			type: "tool_result",
 			tool_use_id: id,
 			call_id: call_id,
-			content: sanitizedContent,
+			content,
 		}
 	}
 
@@ -129,13 +128,14 @@ export class ToolResultUtils {
 			: "The user provided additional content:"
 
 		const content = formatResponse.toolResult(feedbackText, images, hasMeaningfulFileContent ? fileContentString : undefined)
-		if (typeof content === "string") {
+		const sanitizedContent = ToolResultUtils.sanitizeToolResponseContent(content)
+		if (typeof sanitizedContent === "string") {
 			userMessageContent.push({
 				type: "text",
-				text: sanitizeTextForModelInput(content),
+				text: sanitizedContent,
 			})
 		} else {
-			userMessageContent.push(...(ToolResultUtils.sanitizeToolResponseContent(content) as typeof content))
+			userMessageContent.push(...sanitizedContent)
 		}
 	}
 

--- a/apps/vscode/src/integrations/terminal/CommandOrchestrator.ts
+++ b/apps/vscode/src/integrations/terminal/CommandOrchestrator.ts
@@ -21,6 +21,7 @@ import { ClineTempManager } from "@services/temp"
 import { COMMAND_CANCEL_TOKEN } from "@shared/ExtensionMessage"
 import * as fs from "fs"
 import { Logger } from "@/shared/services/Logger"
+import { sanitizeTextForModelInput } from "@/utils/string"
 import {
 	BUFFER_STUCK_TIMEOUT_MS,
 	CHUNK_BYTE_SIZE,
@@ -230,7 +231,7 @@ export async function orchestrateCommandExecution(
 
 						// Set early return result BEFORE resuming the process
 						// This prevents the orchestrator's listener from processing new lines
-						const result = terminalManager.processOutput(outputLines)
+						const result = sanitizeTextForModelInput(terminalManager.processOutput(outputLines))
 						const logMsg = trackingResult?.logFilePath ? `Log file: ${trackingResult.logFilePath}\n` : ""
 						const outputMsg = result.length > 0 ? `Output so far:\n${result}` : ""
 
@@ -506,7 +507,7 @@ export async function orchestrateCommandExecution(
 
 						// Set early return result BEFORE resuming the process
 						// This prevents the orchestrator's listener from processing new lines
-						const result = terminalManager.processOutput(outputLines)
+						const result = sanitizeTextForModelInput(terminalManager.processOutput(outputLines))
 						const logMsg = trackingResult?.logFilePath ? `Log file: ${trackingResult.logFilePath}\n` : ""
 						const outputMsg = result.length > 0 ? `Output so far:\n${result}` : ""
 
@@ -538,7 +539,7 @@ export async function orchestrateCommandExecution(
 
 					// Process any output we captured before timeout
 					await setTimeoutPromise(50)
-					const result = terminalManager.processOutput(outputLines)
+					const result = sanitizeTextForModelInput(terminalManager.processOutput(outputLines))
 
 					return {
 						userRejected: false,
@@ -591,6 +592,7 @@ export async function orchestrateCommandExecution(
 		result = terminalManager.processOutput(outputLines)
 		resultOutputLines = outputLines
 	}
+	result = sanitizeTextForModelInput(result)
 
 	if (didCancelViaUi) {
 		return {

--- a/apps/vscode/src/utils/string.test.ts
+++ b/apps/vscode/src/utils/string.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "mocha"
 import "should"
-import { fixModelHtmlEscaping, removeInvalidChars } from "./string"
+import { fixModelHtmlEscaping, removeInvalidChars, sanitizeTextForModelInput } from "./string"
 
 describe("fixModelHtmlEscaping", () => {
 	it("should convert &gt; to >", () => {
@@ -53,5 +53,19 @@ describe("removeInvalidChars", () => {
 
 	it("should return unchanged string when no replacement characters are present", () => {
 		removeInvalidChars("normal string").should.equal("normal string")
+	})
+})
+
+describe("sanitizeTextForModelInput", () => {
+	it("should remove ANSI escapes and unsafe control characters", () => {
+		const text = "\u001b[31mred\u001b[0m\x00chunk\x07\x7f"
+
+		sanitizeTextForModelInput(text).should.equal("redchunk")
+	})
+
+	it("should preserve normal whitespace", () => {
+		const text = "line 1\nline 2\tcolumn\rreturn"
+
+		sanitizeTextForModelInput(text).should.equal(text)
 	})
 })

--- a/apps/vscode/src/utils/string.test.ts
+++ b/apps/vscode/src/utils/string.test.ts
@@ -63,6 +63,12 @@ describe("sanitizeTextForModelInput", () => {
 		sanitizeTextForModelInput(text).should.equal("redchunk")
 	})
 
+	it("should remove OSC terminal escapes while preserving visible text", () => {
+		const text = "\u001b]8;;https://example.com\x07link text\u001b]8;;\x07 and \u001b]0;title\x07content"
+
+		sanitizeTextForModelInput(text).should.equal("link text and content")
+	})
+
 	it("should preserve normal whitespace", () => {
 		const text = "line 1\nline 2\tcolumn\rreturn"
 

--- a/apps/vscode/src/utils/string.test.ts
+++ b/apps/vscode/src/utils/string.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "mocha"
 import "should"
-import { fixModelHtmlEscaping, removeInvalidChars, sanitizeTextForModelInput } from "./string"
+import { extractReasoningText, fixModelHtmlEscaping, removeInvalidChars, sanitizeTextForModelInput } from "./string"
 
 describe("fixModelHtmlEscaping", () => {
 	it("should convert &gt; to >", () => {
@@ -73,5 +73,21 @@ describe("sanitizeTextForModelInput", () => {
 		const text = "line 1\nline 2\tcolumn\rreturn"
 
 		sanitizeTextForModelInput(text).should.equal(text)
+	})
+})
+
+describe("extractReasoningText", () => {
+	it("should sanitize and join text reasoning details", () => {
+		const details = [
+			{ type: "reasoning.text", text: "\u001b[31mfirst\u001b[0m" },
+			{ type: "reasoning.encrypted", data: "ignored" },
+			{ type: "reasoning.text", text: "second\x00" },
+		]
+
+		extractReasoningText(details).should.equal("first\nsecond")
+	})
+
+	it("should ignore non-array reasoning details", () => {
+		extractReasoningText({ text: "ignored" }).should.equal("")
 	})
 })

--- a/apps/vscode/src/utils/string.ts
+++ b/apps/vscode/src/utils/string.ts
@@ -21,12 +21,19 @@ export function removeInvalidChars(text: string): string {
 	return text.replace(/\uFFFD/g, "")
 }
 
+const ANSI_SEQUENCE_TERMINATOR = "(?:\\u0007|\\u001B\\u005C|\\u009C)"
+const ANSI_ESCAPE_PATTERN = new RegExp(
+	[
+		`[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]+)*|[a-zA-Z\\d]+(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?${ANSI_SEQUENCE_TERMINATOR})`,
+		"(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-nq-uy=><~]))",
+	].join("|"),
+	"g",
+)
+
 /**
  * Removes terminal/control characters that can poison provider-bound prompts while preserving
  * normal whitespace used for readable file and command output.
  */
 export function sanitizeTextForModelInput(text: string): string {
-	return text
-		.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "")
-		.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, "")
+	return text.replace(ANSI_ESCAPE_PATTERN, "").replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, "")
 }

--- a/apps/vscode/src/utils/string.ts
+++ b/apps/vscode/src/utils/string.ts
@@ -37,3 +37,18 @@ const ANSI_ESCAPE_PATTERN = new RegExp(
 export function sanitizeTextForModelInput(text: string): string {
 	return text.replace(ANSI_ESCAPE_PATTERN, "").replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, "")
 }
+
+export function extractReasoningText(details: unknown): string {
+	if (!Array.isArray(details)) {
+		return ""
+	}
+
+	return details
+		.map((detail) => {
+			const text =
+				detail && typeof detail === "object" && "text" in detail ? (detail as { text?: unknown }).text : undefined
+			return typeof text === "string" ? sanitizeTextForModelInput(text) : ""
+		})
+		.filter((text) => text.trim().length > 0)
+		.join("\n")
+}

--- a/apps/vscode/src/utils/string.ts
+++ b/apps/vscode/src/utils/string.ts
@@ -20,3 +20,13 @@ export function fixModelHtmlEscaping(text: string): string {
 export function removeInvalidChars(text: string): string {
 	return text.replace(/\uFFFD/g, "")
 }
+
+/**
+ * Removes terminal/control characters that can poison provider-bound prompts while preserving
+ * normal whitespace used for readable file and command output.
+ */
+export function sanitizeTextForModelInput(text: string): string {
+	return text
+		.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "")
+		.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, "")
+}


### PR DESCRIPTION
## Summary

Fixes an OpenAI-compatible invalid response failure where Cline could display streamed reasoning, then treat the response as empty and poison the next request with a thinking-only assistant history message.

This was reproduced with a local OpenAI-compatible Qwen reasoning model on Windows. Terminal output from binary-ish inspection included NUL/control characters, the model returned reasoning-only deltas, and the next OpenAI-compatible request failed with `400 Assistant message must contain either 'content' or 'tool_calls'`.

## Changes

- Add `sanitizeTextForModelInput()` to remove ANSI escapes and unsafe control characters while preserving normal whitespace.
- Sanitize completed tool-result content before it is added to conversation history, plus command output before it is returned as model-bound text.
- Sanitize OpenAI/R1 formatted text and tool-result history so resumed tasks with poisoned history can recover.
- Convert thinking-only assistant history to non-empty OpenAI/R1 text content instead of sending an assistant message with neither `content` nor `tool_calls`.
- Treat streamed reasoning/thinking as assistant content so a reasoning-only stream does not trigger `empty_assistant_message`.
- Add unit coverage for sanitizer behavior, sanitized tool results, and thinking-only OpenAI/R1 history conversion.

## Testing

Not run locally: this Windows shell does not have `node`/`npm` on PATH.

Patch was validated against the installed extension bundle first, and the reporter confirmed the original invalid API response loop is fixed locally.

(Fixed by GPT5.5 - I trust this model!)

<img width="2529" height="618" alt="image" src="https://github.com/user-attachments/assets/1f36c408-e226-4eac-966a-ce5f5cb658f2" />
