### PR TITLE
test(llms): align ChatGPT subscription model expectations

### DIFF
--- a/sdk/packages/llms/src/providers/builtins.test.ts
+++ b/sdk/packages/llms/src/providers/builtins.test.ts
@@ -70,15 +70,15 @@ describe("built-in provider metadata", () => {
 			expect.arrayContaining([
 				"gpt-5.5",
 				"gpt-5.5-pro",
-				"gpt-5.2",
-				"gpt-5.3-codex",
-				"gpt-5.3-codex-spark",
 				"gpt-5.4",
 				"gpt-5.4-mini",
 			]),
 		);
 		expect(modelIds).not.toContain("gpt-5.1-codex-max");
+		expect(modelIds).not.toContain("gpt-5.2");
 		expect(modelIds).not.toContain("gpt-5.2-codex");
+		expect(modelIds).not.toContain("gpt-5.3-codex");
+		expect(modelIds).not.toContain("gpt-5.3-codex-spark");
 		expect(modelIds).not.toContain("gpt-5.4-nano");
 		expect(modelIds).not.toContain("o3");
 		expect(chatGptModels["gpt-5.5"]).toEqual(
@@ -91,13 +91,6 @@ describe("built-in provider metadata", () => {
 		expect(chatGptModels["gpt-5.4"]).toEqual(
 			expect.objectContaining({
 				name: "GPT-5.4",
-				maxInputTokens: expect.any(Number),
-				contextWindow: expect.any(Number),
-			}),
-		);
-		expect(chatGptModels["gpt-5.3-codex"]).toEqual(
-			expect.objectContaining({
-				name: "GPT-5.3 Codex",
 				maxInputTokens: expect.any(Number),
 				contextWindow: expect.any(Number),
 			}),


### PR DESCRIPTION
### Related Issue

Issue: N/A, small CI test fix.

### Description

This fixes a stale SDK test expectation left behind after `Clean-up the Codex model list (#11342)`.

That cleanup removed older ChatGPT subscription model IDs from the OpenAI Codex allowlist, including `gpt-5.2`, `gpt-5.3-codex`, and `gpt-5.3-codex-spark`. The production filter now correctly returns only the current allowlisted models plus future `gpt-5.x` models above `5.4`, but `sdk/packages/llms/src/providers/builtins.test.ts` still expected the removed IDs to be present.

The failing CI check was `sdk-test`, specifically:

```text
@cline/llms:test src/providers/builtins.test.ts > built-in provider metadata > derives ChatGPT subscription models from the generated OpenAI catalog
```

This PR updates the assertion to match the current allowlist and adds explicit negative checks for the removed IDs, so the test now documents that those models are intentionally filtered out.

### Test Procedure

Ran the focused failing test in a clean worktree based on current `origin/main`:

```sh
RAYON_NUM_THREADS=1 VITEST_MAX_THREADS=1 bun -F @cline/llms test src/providers/builtins.test.ts --maxWorkers=1
```

Result: passed, 1 test file and 4 tests.

Ran Biome on the edited test file:

```sh
bun biome check --diagnostic-level=error --no-errors-on-unmatched --files-ignore-unknown=true sdk/packages/llms/src/providers/builtins.test.ts
```

Result: passed.

### Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Refactor Changes
-   [ ] Cosmetic Changes
-   [ ] Documentation update
-   [ ] Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A, test-only change.

### Additional Notes

This PR is intentionally separate from the structured CLI error handling PR so it can land on `main` first. After it merges, the structured error PR can rebase on top of `main` without carrying this unrelated test fix.
