### PR TITLE
docs: add RunAPI OpenAI-compatible example

### DIFF
--- a/docs/provider-config/openai-compatible.mdx
+++ b/docs/provider-config/openai-compatible.mdx
@@ -49,6 +49,17 @@ You'll find these settings in the Cline settings panel (click the ⚙️ icon):
 -   3. Set the Model ID: v0-1.0-md
 -   4. Click Verify to confirm the connection.
 
+### RunAPI in Cline
+
+-   RunAPI can be used in Cline with the OpenAI Compatible provider.
+
+-   ### Quickstart
+
+-   1. With the OpenAI Compatible provider selected, set the Base URL to https://api.runapi.ai/v1.
+-   2. Paste in your RunAPI API key.
+-   3. Set the Model ID using a model from [RunAPI models](https://runapi.ai/models.md).
+-   4. Click Verify to confirm the connection.
+
 ### Troubleshooting
 
 -   **"Invalid API Key":** Double-check that you've entered the API key correctly and that it's for the correct provider.

--- a/docs/provider-config/openai-compatible.mdx
+++ b/docs/provider-config/openai-compatible.mdx
@@ -55,7 +55,7 @@ You'll find these settings in the Cline settings panel (click the ⚙️ icon):
 
 -   ### Quickstart
 
--   1. With the OpenAI Compatible provider selected, set the Base URL to https://api.runapi.ai/v1.
+-   1. With the OpenAI Compatible provider selected, set the Base URL to https://runapi.ai/v1.
 -   2. Paste in your RunAPI API key.
 -   3. Set the Model ID using a model from [RunAPI models](https://runapi.ai/models.md).
 -   4. Click Verify to confirm the connection.

--- a/docs/provider-config/openai-compatible.mdx
+++ b/docs/provider-config/openai-compatible.mdx
@@ -57,7 +57,7 @@ You'll find these settings in the Cline settings panel (click the ⚙️ icon):
 
 -   1. With the OpenAI Compatible provider selected, set the Base URL to https://runapi.ai/v1.
 -   2. Paste in your RunAPI API key.
--   3. Set the Model ID using a model from [RunAPI models](https://runapi.ai/models.md).
+-   3. Set the Model ID using a model from [RunAPI models](https://runapi.ai/models).
 -   4. Click Verify to confirm the connection.
 
 ### Troubleshooting


### PR DESCRIPTION
### Related Issue

N/A. Docs-only provider setup example.

### Description

Adds a short RunAPI example to the OpenAI Compatible provider docs, using the RunAPI base URL and model list.

### Test Procedure

Docs-only change. I reviewed the rendered markdown diff and did not run install, build, or test commands.

### Type of Change

-   [x] 📚 Documentation update

### Pre-flight Checklist

-   [x] Changes are limited to a single docs update
