### PR TITLE
Fix Azure Foundry API version for CLI

### DIFF
--- a/apps/cli/src/commands/auth.test.ts
+++ b/apps/cli/src/commands/auth.test.ts
@@ -5,8 +5,34 @@ import { describe, expect, it, vi } from "vitest";
 import {
 	getPersistedProviderApiKey,
 	normalizeAuthProviderId,
+	parseAuthCommandArgs,
 	saveOAuthProviderSettings,
 } from "./auth";
+
+describe("parseAuthCommandArgs", () => {
+	it("parses Azure API version quick setup option", () => {
+		expect(
+			parseAuthCommandArgs([
+				"--provider",
+				"openai-compatible",
+				"--apikey",
+				"key",
+				"--modelid",
+				"gpt-4.1",
+				"--baseurl",
+				"https://example.openai.azure.com/openai/deployments/gpt-4.1",
+				"--azure-api-version",
+				"2025-01-01-preview",
+			]),
+		).toMatchObject({
+			explicitProvider: "openai-compatible",
+			apikey: "key",
+			modelid: "gpt-4.1",
+			baseurl: "https://example.openai.azure.com/openai/deployments/gpt-4.1",
+			azureApiVersion: "2025-01-01-preview",
+		});
+	});
+});
 
 describe("saveOAuthProviderSettings", () => {
 	it("preserves existing manual apiKey while updating OAuth tokens", () => {

--- a/apps/cli/src/commands/auth.ts
+++ b/apps/cli/src/commands/auth.ts
@@ -49,6 +49,7 @@ type AuthQuickSetupInput = {
 	apikey: string;
 	modelid: string;
 	baseurl?: string;
+	azureApiVersion?: string;
 };
 
 type AuthCommandInput = {
@@ -58,6 +59,7 @@ type AuthCommandInput = {
 	apikey?: string;
 	modelid?: string;
 	baseurl?: string;
+	azureApiVersion?: string;
 };
 
 type ParsedAuthCommandArgs = {
@@ -65,6 +67,7 @@ type ParsedAuthCommandArgs = {
 	apikey?: string;
 	modelid?: string;
 	baseurl?: string;
+	azureApiVersion?: string;
 	parseError?: string;
 };
 
@@ -84,7 +87,8 @@ export function createAuthCommand(): Command {
 		.option("-p, --provider <id>", "provider id")
 		.option("-k, --apikey <key>", "API key")
 		.option("-m, --modelid <id>", "model id")
-		.option("-b, --baseurl <url>", "base URL");
+		.option("-b, --baseurl <url>", "base URL")
+		.option("--azure-api-version <version>", "Azure API version");
 	return cmd;
 }
 
@@ -101,6 +105,7 @@ export function parseAuthCommandArgs(args: string[]): ParsedAuthCommandArgs {
 		apikey?: string;
 		modelid?: string;
 		baseurl?: string;
+		azureApiVersion?: string;
 	}>();
 	const positionalProvider = cmd.args[0];
 	return {
@@ -108,6 +113,7 @@ export function parseAuthCommandArgs(args: string[]): ParsedAuthCommandArgs {
 		apikey: opts.apikey,
 		modelid: opts.modelid,
 		baseurl: opts.baseurl,
+		azureApiVersion: opts.azureApiVersion,
 	};
 }
 
@@ -147,6 +153,12 @@ async function ensureQuickSetupInputValid(
 	) {
 		return "base URL is only supported for OpenAI and OpenAI-compatible providers";
 	}
+	if (
+		input.azureApiVersion?.trim() &&
+		normalizedProvider !== BUILT_IN_PROVIDER.OPENAI_COMPATIBLE
+	) {
+		return "Azure API version is only supported for OpenAI-compatible providers";
+	}
 	return undefined;
 }
 
@@ -156,6 +168,7 @@ function saveQuickAuthProviderSettings(input: {
 	apikey: string;
 	modelid: string;
 	baseurl?: string;
+	azureApiVersion?: string;
 }): void {
 	const existing = input.providerSettingsManager.getProviderSettings(
 		input.providerId,
@@ -170,6 +183,12 @@ function saveQuickAuthProviderSettings(input: {
 	};
 	if (input.baseurl?.trim()) {
 		nextSettings.baseUrl = input.baseurl.trim();
+	}
+	if (input.azureApiVersion?.trim()) {
+		nextSettings.azure = {
+			...(nextSettings.azure ?? {}),
+			apiVersion: input.azureApiVersion.trim(),
+		};
 	}
 	input.providerSettingsManager.saveProviderSettings(nextSettings);
 }
@@ -266,12 +285,14 @@ async function runQuickAuthSetup(input: AuthCommandInput): Promise<number> {
 	const apikey = input.apikey?.trim() ?? "";
 	const modelid = input.modelid?.trim() ?? "";
 	const baseurl = input.baseurl?.trim();
+	const azureApiVersion = input.azureApiVersion?.trim();
 	const validationError = await ensureQuickSetupInputValid(
 		{
 			provider: providerId,
 			apikey,
 			modelid,
 			baseurl,
+			azureApiVersion,
 		},
 		input.providerSettingsManager,
 	);
@@ -285,6 +306,7 @@ async function runQuickAuthSetup(input: AuthCommandInput): Promise<number> {
 		apikey,
 		modelid,
 		baseurl,
+		azureApiVersion,
 	});
 	input.io.writeln(
 		`${c.green}Provider configured:${c.reset} ${c.cyan}${providerId}${c.reset} (${modelid})`,
@@ -369,12 +391,13 @@ export async function runAuthCommand(input: AuthCommandInput): Promise<number> {
 	const hasQuickSetupFlags =
 		typeof input.apikey === "string" ||
 		typeof input.modelid === "string" ||
-		typeof input.baseurl === "string";
+		typeof input.baseurl === "string" ||
+		typeof input.azureApiVersion === "string";
 
 	if (hasQuickSetupFlags) {
 		if (!input.explicitProvider?.trim()) {
 			input.io.writeErr(
-				"auth quick setup requires --provider <id> when using --apikey/--modelid/--baseurl",
+				"auth quick setup requires --provider <id> when using --apikey/--modelid/--baseurl/--azure-api-version",
 			);
 			return 1;
 		}

--- a/apps/cli/src/commands/rpc-runtime/provider-registry.test.ts
+++ b/apps/cli/src/commands/rpc-runtime/provider-registry.test.ts
@@ -78,6 +78,74 @@ describe("saveLocalProviderSettings", () => {
 		);
 	});
 
+	it("merges and clears Azure provider settings", () => {
+		const save = vi.fn();
+		const manager = {
+			read: vi.fn().mockReturnValue({
+				providers: {},
+			}),
+			write: vi.fn(),
+			getFilePath: vi.fn().mockReturnValue("/tmp/providers.json"),
+			getProviderSettings: vi.fn().mockReturnValue({
+				provider: "openai-compatible",
+				azure: {
+					apiVersion: "2024-10-21",
+					useIdentity: true,
+				},
+			}),
+			saveProviderSettings: save,
+		};
+
+		saveLocalProviderSettings(
+			manager as unknown as ProviderSettingsManager,
+			{
+				action: "saveProviderSettings",
+				providerId: "openai-compatible",
+				azure: {
+					apiVersion: "2025-01-01-preview",
+				},
+			} as SaveProviderSettingsActionRequest,
+		);
+
+		expect(save).toHaveBeenCalledTimes(1);
+		expect(save).toHaveBeenCalledWith(
+			{
+				provider: "openai-compatible",
+				azure: {
+					apiVersion: "2025-01-01-preview",
+					useIdentity: true,
+				},
+			},
+			{ setLastUsed: false },
+		);
+
+		save.mockClear();
+		manager.getProviderSettings.mockReturnValue({
+			provider: "openai-compatible",
+			azure: {
+				apiVersion: "2025-01-01-preview",
+			},
+		});
+
+		saveLocalProviderSettings(
+			manager as unknown as ProviderSettingsManager,
+			{
+				action: "saveProviderSettings",
+				providerId: "openai-compatible",
+				azure: {
+					apiVersion: "",
+				},
+			} as SaveProviderSettingsActionRequest,
+		);
+
+		expect(save).toHaveBeenCalledWith(
+			{
+				provider: "openai-compatible",
+			},
+			{ setLastUsed: false },
+		);
+	});
+
 	it("keeps OAuth auth fields when updating manual apiKey", () => {
 		const save = vi.fn();
 		const manager = {

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -152,6 +152,7 @@ export async function runCli(): Promise<void> {
 		.option("-k, --apikey <key>", "API key")
 		.option("-m, --modelid <id>", "Model ID")
 		.option("-b, --baseurl <url>", "Base URL")
+		.option("--azure-api-version <version>", "Azure API version")
 		.option("--config <dir>", "configuration directory")
 		.option("-c, --cwd <path>", "Working directory")
 		.option(
@@ -165,6 +166,7 @@ export async function runCli(): Promise<void> {
 				apikey?: string;
 				modelid?: string;
 				baseurl?: string;
+				azureApiVersion?: string;
 				config?: string;
 				cwd?: string;
 				dataDir?: string;
@@ -195,6 +197,7 @@ export async function runCli(): Promise<void> {
 				apikey: opts.apikey,
 				modelid: opts.modelid,
 				baseurl: opts.baseurl,
+				azureApiVersion: opts.azureApiVersion,
 				io,
 			});
 		});

--- a/apps/cli/src/tui/components/dialogs/provider-picker.tsx
+++ b/apps/cli/src/tui/components/dialogs/provider-picker.tsx
@@ -27,6 +27,7 @@ import {
 	getDefaultAwsRegion,
 	type ProviderConfigValues,
 	resolveProviderConfigAwsRegion,
+	resolveProviderConfigAzure,
 	resolveProviderConfigGcp,
 	resolveProviderConfigSap,
 	updateProviderConfigValue,
@@ -316,6 +317,7 @@ export function UseExistingOrReconfigureContent(
 const DEFAULT_FIELD_LABELS: Partial<Record<ProviderConfigFieldKey, string>> = {
 	apiKey: "API key",
 	baseUrl: "Base URL",
+	azureApiVersion: "Azure API Version",
 	awsRegion: "AWS Region",
 	awsProfile: "AWS Profile Name",
 	gcpProjectId: "Google Cloud Project ID",
@@ -332,6 +334,7 @@ const DEFAULT_FIELD_PLACEHOLDERS: Partial<
 > = {
 	apiKey: "sk-...",
 	baseUrl: "",
+	azureApiVersion: "2025-01-01-preview",
 	awsRegion: "us-east-1",
 	awsProfile: "default",
 	gcpProjectId: "my-gcp-project",
@@ -349,6 +352,7 @@ const FIELD_ORDER: ProviderConfigFieldKey[] = [
 	"gcpProjectId",
 	"gcpRegion",
 	"baseUrl",
+	"azureApiVersion",
 	"apiKey",
 	"awsProfile",
 	"sapClientId",
@@ -405,6 +409,10 @@ export function ProviderConfigInputContent(
 				config.fields.baseUrl?.defaultValue ??
 				"";
 		}
+		if (config.fields.azureApiVersion) {
+			initial.azureApiVersion =
+				existingSettings?.azure?.apiVersion?.trim() ?? "";
+		}
 		if (config.fields.awsRegion) {
 			const ep = existingSettings?.aws?.profile?.trim() ?? "";
 			initial.awsRegion =
@@ -444,6 +452,7 @@ export function ProviderConfigInputContent(
 	const submit = () => {
 		const apiKey = values.apiKey?.trim();
 		const awsProfile = values.awsProfile?.trim();
+		const hasAzureFields = config.fields.azureApiVersion;
 		const hasAwsFields = config.fields.awsRegion || config.fields.awsProfile;
 		const hasGcpFields = config.fields.gcpProjectId || config.fields.gcpRegion;
 		const hasSapFields =
@@ -456,6 +465,7 @@ export function ProviderConfigInputContent(
 			providerId,
 			apiKey: config.fields.apiKey ? apiKey : undefined,
 			baseUrl: config.fields.baseUrl ? values.baseUrl?.trim() : undefined,
+			azure: hasAzureFields ? resolveProviderConfigAzure(values) : undefined,
 			aws: hasAwsFields
 				? {
 						region: resolveProviderConfigAwsRegion(values),

--- a/apps/cli/src/tui/utils/provider-config-values.test.ts
+++ b/apps/cli/src/tui/utils/provider-config-values.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
 	getDefaultAwsRegion,
 	resolveProviderConfigAwsRegion,
+	resolveProviderConfigAzure,
 	resolveProviderConfigGcp,
 	resolveProviderConfigSap,
 	updateProviderConfigValue,
@@ -68,7 +69,9 @@ describe("provider config values", () => {
 	});
 
 	it("resolves Vertex GCP field values into GCP settings", () => {
-		expect(resolveProviderConfigGcp({ gcpRegion: "us-central1" })).toBeUndefined();
+		expect(
+			resolveProviderConfigGcp({ gcpRegion: "us-central1" }),
+		).toBeUndefined();
 		expect(
 			resolveProviderConfigGcp({
 				gcpProjectId: " project ",
@@ -92,6 +95,26 @@ describe("provider config values", () => {
 			tokenUrl: "https://auth.example",
 			resourceGroup: "default",
 			deploymentId: "deployment",
+		});
+	});
+
+	it("resolves Azure API version into Azure settings", () => {
+		expect(
+			resolveProviderConfigAzure({
+				azureApiVersion: " 2025-01-01-preview ",
+			}),
+		).toEqual({
+			apiVersion: "2025-01-01-preview",
+		});
+	});
+
+	it("keeps blank Azure API version so persisted settings can be cleared", () => {
+		expect(
+			resolveProviderConfigAzure({
+				azureApiVersion: "   ",
+			}),
+		).toEqual({
+			apiVersion: "",
 		});
 	});
 });

--- a/apps/cli/src/tui/utils/provider-config-values.ts
+++ b/apps/cli/src/tui/utils/provider-config-values.ts
@@ -56,6 +56,12 @@ export function resolveProviderConfigSap(values: ProviderConfigValues):
 		: undefined;
 }
 
+export function resolveProviderConfigAzure(values: ProviderConfigValues): {
+	apiVersion?: string;
+} {
+	return { apiVersion: values.azureApiVersion?.trim() ?? "" };
+}
+
 export function updateProviderConfigValue(
 	previous: ProviderConfigValues,
 	field: ProviderConfigFieldKey,

--- a/apps/cli/src/tui/views/onboarding/controller.ts
+++ b/apps/cli/src/tui/views/onboarding/controller.ts
@@ -32,6 +32,7 @@ import {
 	getDefaultAwsRegion,
 	type ProviderConfigValues,
 	resolveProviderConfigAwsRegion,
+	resolveProviderConfigAzure,
 	resolveProviderConfigSap,
 	updateProviderConfigValue,
 } from "../../utils/provider-config-values";
@@ -382,6 +383,10 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 					config.fields.baseUrl?.defaultValue ??
 					"";
 			}
+			if (config.fields.azureApiVersion) {
+				initialValues.azureApiVersion =
+					existing?.azure?.apiVersion?.trim() ?? "";
+			}
 			if (config.fields.awsRegion) {
 				const existingProfile = existing?.aws?.profile?.trim() ?? "";
 				initialValues.awsRegion =
@@ -444,6 +449,7 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 		// surfaced when the model picker / first turn runs.
 		const apiKey = byoValues.apiKey?.trim();
 		const awsProfile = byoValues.awsProfile?.trim();
+		const hasAzureFields = byoFields.azureApiVersion;
 		const hasAwsFields = byoFields.awsRegion || byoFields.awsProfile;
 		const hasSapFields =
 			byoFields.sapClientId ||
@@ -456,6 +462,7 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 			providerId: activeProviderId,
 			apiKey: byoFields.apiKey ? apiKey : undefined,
 			baseUrl: byoFields.baseUrl ? byoValues.baseUrl?.trim() : undefined,
+			azure: hasAzureFields ? resolveProviderConfigAzure(byoValues) : undefined,
 			aws: hasAwsFields
 				? {
 						region: resolveProviderConfigAwsRegion(byoValues),

--- a/apps/cli/src/tui/views/onboarding/fields.ts
+++ b/apps/cli/src/tui/views/onboarding/fields.ts
@@ -4,6 +4,7 @@ import type { ProviderConfigFieldKey } from "@cline/core";
 export const FIELD_ORDER: ProviderConfigFieldKey[] = [
 	"awsRegion",
 	"baseUrl",
+	"azureApiVersion",
 	"apiKey",
 	"awsProfile",
 	"sapClientId",

--- a/apps/cli/src/tui/views/onboarding/screens.tsx
+++ b/apps/cli/src/tui/views/onboarding/screens.tsx
@@ -222,6 +222,7 @@ import type {
 const DEFAULT_FIELD_LABELS: Partial<Record<ProviderConfigFieldKey, string>> = {
 	apiKey: "API key",
 	baseUrl: "Base URL",
+	azureApiVersion: "Azure API Version",
 	awsRegion: "AWS Region",
 	awsProfile: "AWS Profile Name",
 	sapClientId: "Client ID",
@@ -236,6 +237,7 @@ const DEFAULT_FIELD_PLACEHOLDERS: Partial<
 > = {
 	apiKey: "Paste your API key here...",
 	baseUrl: "",
+	azureApiVersion: "2025-01-01-preview",
 	awsRegion: "us-east-1",
 	awsProfile: "default",
 	sapClientId: "sb-...|xsuaa_std!b...",

--- a/sdk/packages/agents/src/agent-runtime.provider-form.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.provider-form.test.ts
@@ -73,12 +73,39 @@ describe("AgentRuntime (provider-form config + Agent alias)", () => {
 					apiKey: "test-key",
 					baseUrl: undefined,
 					headers: undefined,
+					options: undefined,
 				},
 			],
 		});
 		expect(createAgentModel).toHaveBeenCalledWith({
 			providerId: "openai",
 			modelId: "gpt-5",
+		});
+	});
+
+	it("passes provider options through to the llms gateway", () => {
+		const model = new ScriptedModel([]);
+		createAgentModel.mockReturnValue(model);
+
+		new Agent({
+			providerId: "openai-compatible",
+			modelId: "gpt-4.1",
+			apiKey: "test-key",
+			baseUrl: "https://example.openai.azure.com/openai/deployments/gpt-4.1",
+			options: { apiVersion: "2025-01-01-preview" },
+		});
+
+		expect(createGateway).toHaveBeenCalledWith({
+			providerConfigs: [
+				{
+					providerId: "openai-compatible",
+					apiKey: "test-key",
+					baseUrl:
+						"https://example.openai.azure.com/openai/deployments/gpt-4.1",
+					headers: undefined,
+					options: { apiVersion: "2025-01-01-preview" },
+				},
+			],
 		});
 	});
 

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -1,4 +1,4 @@
-import { createGateway } from "@cline/llms";
+import { createGateway, type GatewayProviderSettings } from "@cline/llms";
 import type {
 	AgentAfterToolResult,
 	AgentBeforeModelResult,
@@ -64,6 +64,8 @@ export interface AgentRuntimeConfigWithProvider
 	baseUrl?: string;
 	/** Additional headers for API requests */
 	headers?: Record<string, string>;
+	/** Provider-specific gateway options */
+	options?: GatewayProviderSettings["options"];
 }
 
 /**
@@ -88,9 +90,10 @@ function resolveRuntimeConfig(
 	if (hasPrebuiltModel(config)) {
 		return config;
 	}
-	const { providerId, modelId, apiKey, baseUrl, headers, ...rest } = config;
+	const { providerId, modelId, apiKey, baseUrl, headers, options, ...rest } =
+		config;
 	const gateway = createGateway({
-		providerConfigs: [{ providerId, apiKey, baseUrl, headers }],
+		providerConfigs: [{ providerId, apiKey, baseUrl, headers, options }],
 		telemetry: rest.telemetry,
 	});
 	const model = gateway.createAgentModel({ providerId, modelId });

--- a/sdk/packages/core/src/services/llms/handler-factory.test.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.test.ts
@@ -243,6 +243,75 @@ describe("createAgentModelFromConfig", () => {
 		);
 	});
 
+	it("forwards Azure settings as OpenAI-compatible gateway provider options", async () => {
+		const { createAgentModelFromConfig } = await import("./handler-factory");
+
+		createAgentModelFromConfig(
+			{
+				providerId: "openai-compatible",
+				modelId: "gpt-4.1",
+				systemPrompt: "",
+				tools: [],
+				providerConfig: {
+					providerId: "openai-compatible",
+					modelId: "gpt-4.1",
+					azure: {
+						apiVersion: "2025-01-01-preview",
+						useIdentity: false,
+					},
+				},
+			},
+			undefined,
+		);
+
+		expect(gatewayMock.createGateway).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				providerConfigs: [
+					expect.objectContaining({
+						providerId: "openai-compatible",
+						options: expect.objectContaining({
+							apiVersion: "2025-01-01-preview",
+							useIdentity: false,
+						}),
+					}),
+				],
+			}),
+		);
+	});
+
+	it("does not forward Azure settings for non-OpenAI-compatible providers", async () => {
+		const { createAgentModelFromConfig } = await import("./handler-factory");
+
+		createAgentModelFromConfig(
+			{
+				providerId: "anthropic",
+				modelId: "claude-3-5-sonnet",
+				systemPrompt: "",
+				tools: [],
+				providerConfig: {
+					providerId: "anthropic",
+					modelId: "claude-3-5-sonnet",
+					azure: {
+						apiVersion: "2025-01-01-preview",
+						useIdentity: false,
+					},
+				},
+			},
+			undefined,
+		);
+
+		expect(gatewayMock.createGateway).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				providerConfigs: [
+					expect.objectContaining({
+						providerId: "anthropic",
+						options: undefined,
+					}),
+				],
+			}),
+		);
+	});
+
 	it("uses a registered handler (adapter) instead of the gateway, building it lazily", async () => {
 		const { createAgentModelFromConfig } = await import("./handler-factory");
 

--- a/sdk/packages/core/src/services/llms/handler-factory.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.ts
@@ -25,6 +25,13 @@ function compactOptions(
 	return Object.keys(compacted).length > 0 ? compacted : undefined;
 }
 
+function usesOpenAICompatibleClient(config: ProviderConfig): boolean {
+	return (
+		config.providerId === "openai-compatible" ||
+		config.clientType === "openai-compatible"
+	);
+}
+
 function buildGatewayProviderOptions(
 	config: ProviderConfig,
 ): Record<string, unknown> | undefined {
@@ -34,6 +41,13 @@ function buildGatewayProviderOptions(
 		openRouterProviderSorting: config.openRouterProviderSorting,
 		modelCatalog: config.modelCatalog,
 	};
+
+	if (usesOpenAICompatibleClient(config)) {
+		Object.assign(options, {
+			apiVersion: config.azure?.apiVersion,
+			useIdentity: config.azure?.useIdentity,
+		});
+	}
 
 	if (config.providerId === "bedrock") {
 		Object.assign(options, {

--- a/sdk/packages/core/src/services/providers/provider-config-fields.test.ts
+++ b/sdk/packages/core/src/services/providers/provider-config-fields.test.ts
@@ -84,14 +84,20 @@ describe("getProviderConfigFields", () => {
 		expect(result.fields).toEqual({});
 	});
 
-	it("returns api-key auth with apiKey + baseUrl for OpenAI Compatible", () => {
+	it("returns api-key auth with apiKey, baseUrl, and Azure API version for OpenAI Compatible", () => {
 		const result = getProviderConfigFields("openai-compatible");
 		expect(result.providerId).toBe("openai-compatible");
 		expect(result.authMethod).toBe("api-key");
+		expect(result.description).toMatch(/Azure AI Foundry/i);
 		expect(result.fields.apiKey).toEqual({});
 		expect(result.fields.baseUrl?.defaultValue).toBe(
 			"https://api.openai.com/v1",
 		);
+		expect(result.fields.azureApiVersion).toMatchObject({
+			label: "Azure API Version (optional)",
+			placeholder: "2025-01-01-preview",
+			optional: true,
+		});
 	});
 
 	it("returns Vertex GCP config fields with optional API key", () => {

--- a/sdk/packages/core/src/services/providers/provider-config-fields.ts
+++ b/sdk/packages/core/src/services/providers/provider-config-fields.ts
@@ -4,6 +4,7 @@ import { isOAuthProvider } from "../../auth/provider-auth-registry";
 export type ProviderConfigFieldKey =
 	| "apiKey"
 	| "baseUrl"
+	| "azureApiVersion"
 	| "awsRegion"
 	| "awsProfile"
 	| "gcpProjectId"
@@ -35,6 +36,7 @@ export interface ProviderConfigFields {
 const FIELD_KEYS: ProviderConfigFieldKey[] = [
 	"apiKey",
 	"baseUrl",
+	"azureApiVersion",
 	"awsRegion",
 	"awsProfile",
 	"gcpProjectId",
@@ -57,6 +59,18 @@ interface ProviderConfigFieldMetadata {
 const PROVIDER_CONFIG_FIELD_METADATA: Partial<
 	Record<string, ProviderConfigFieldMetadata>
 > = {
+	"openai-compatible": {
+		description:
+			"For Azure AI Foundry deployments, use a Base URL ending at /openai/deployments/<deployment> and set the Azure API version.",
+		fields: {
+			azureApiVersion: {
+				label: "Azure API Version (optional)",
+				placeholder: "2025-01-01-preview",
+				note: "Required for Azure AI Foundry deployment URLs.",
+				optional: true,
+			},
+		},
+	},
 	vertex: {
 		mode: "replace",
 		description:

--- a/sdk/packages/llms/src/providers/compat.test.ts
+++ b/sdk/packages/llms/src/providers/compat.test.ts
@@ -431,6 +431,90 @@ describe("createGatewayApiHandler.createMessage", () => {
 			}),
 		);
 	});
+
+	it("adds Azure API version to deployment-style OpenAI-compatible requests", async () => {
+		streamTextSpy.mockReturnValue({
+			fullStream: (async function* () {
+				yield { type: "finish", finishReason: "stop" };
+			})(),
+			usage: Promise.resolve({ inputTokens: 1, outputTokens: 1 }),
+		});
+		const providerFetch = vi.fn(
+			async () => new Response("{}"),
+		) as unknown as typeof fetch;
+
+		const handler = createGatewayApiHandler({
+			providerId: "openai-compatible",
+			clientType: "openai-compatible",
+			modelId: "gpt-4.1",
+			apiKey: "test-key",
+			baseUrl: "https://example.openai.azure.com/openai/deployments/gpt-4.1",
+			fetch: providerFetch,
+			azure: { apiVersion: "2025-01-01-preview" },
+		});
+
+		for await (const _chunk of handler.createMessage("", [
+			{ role: "user", content: "Hello" },
+		])) {
+			// Drain the stream so the provider is constructed.
+		}
+
+		const factoryConfig = openaiCompatibleFactorySpy.mock.calls.at(-1)?.[0] as
+			| { fetch?: typeof fetch }
+			| undefined;
+		expect(factoryConfig?.fetch).toEqual(expect.any(Function));
+
+		await factoryConfig?.fetch?.(
+			"https://example.openai.azure.com/openai/deployments/gpt-4.1/chat/completions",
+			{ method: "POST" },
+		);
+
+		expect(providerFetch).toHaveBeenCalledWith(
+			"https://example.openai.azure.com/openai/deployments/gpt-4.1/chat/completions?api-version=2025-01-01-preview",
+			{ method: "POST" },
+		);
+	});
+
+	it("does not add Azure API version to OpenAI v1-compatible requests", async () => {
+		streamTextSpy.mockReturnValue({
+			fullStream: (async function* () {
+				yield { type: "finish", finishReason: "stop" };
+			})(),
+			usage: Promise.resolve({ inputTokens: 1, outputTokens: 1 }),
+		});
+		const providerFetch = vi.fn(
+			async () => new Response("{}"),
+		) as unknown as typeof fetch;
+
+		const handler = createGatewayApiHandler({
+			providerId: "openai-compatible",
+			clientType: "openai-compatible",
+			modelId: "gpt-4.1",
+			apiKey: "test-key",
+			baseUrl: "https://example.openai.azure.com/openai/v1",
+			fetch: providerFetch,
+			azure: { apiVersion: "2025-01-01-preview" },
+		});
+
+		for await (const _chunk of handler.createMessage("", [
+			{ role: "user", content: "Hello" },
+		])) {
+			// Drain the stream so the provider is constructed.
+		}
+
+		const factoryConfig = openaiCompatibleFactorySpy.mock.calls.at(-1)?.[0] as
+			| { fetch?: typeof fetch }
+			| undefined;
+		await factoryConfig?.fetch?.(
+			"https://example.openai.azure.com/openai/v1/chat/completions",
+			{ method: "POST" },
+		);
+
+		expect(providerFetch).toHaveBeenCalledWith(
+			"https://example.openai.azure.com/openai/v1/chat/completions",
+			{ method: "POST" },
+		);
+	});
 });
 
 /**

--- a/sdk/packages/llms/src/providers/vendors/openai-compatible.ts
+++ b/sdk/packages/llms/src/providers/vendors/openai-compatible.ts
@@ -9,6 +9,70 @@ import { resolveApiKey } from "../http";
 import { splitToolImagesMiddleware } from "../middleware/split-tool-images";
 import type { ProviderFactoryResult } from "./types";
 
+type FetchInput = Parameters<typeof fetch>[0];
+type FetchWithOptionalPreconnect = typeof fetch & {
+	preconnect?: (...args: unknown[]) => unknown;
+};
+
+function readAzureApiVersion(
+	config: GatewayResolvedProviderConfig,
+): string | undefined {
+	const apiVersion = config.options?.apiVersion;
+	if (typeof apiVersion !== "string") {
+		return undefined;
+	}
+	const trimmed = apiVersion.trim();
+	return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function shouldAddAzureApiVersion(url: URL): boolean {
+	return (
+		url.pathname.startsWith("/openai/deployments/") &&
+		!url.searchParams.has("api-version")
+	);
+}
+
+function withAzureApiVersion(
+	input: FetchInput,
+	apiVersion: string,
+): FetchInput {
+	let url: URL;
+	try {
+		url = new URL(input instanceof Request ? input.url : input.toString());
+	} catch {
+		return input;
+	}
+	if (!shouldAddAzureApiVersion(url)) {
+		return input;
+	}
+	url.searchParams.set("api-version", apiVersion);
+	if (input instanceof Request) {
+		return new Request(url.toString(), input);
+	}
+	return (typeof input === "string" ? url.toString() : url) as FetchInput;
+}
+
+function createAzureApiVersionFetch(
+	config: GatewayResolvedProviderConfig,
+): typeof fetch | undefined {
+	const apiVersion = readAzureApiVersion(config);
+	if (!apiVersion) {
+		return config.fetch;
+	}
+	const baseFetch = config.fetch ?? globalThis.fetch;
+	if (!baseFetch) {
+		return config.fetch;
+	}
+	const azureFetch = ((input, init) =>
+		baseFetch(withAzureApiVersion(input, apiVersion), init)) as typeof fetch;
+	const baseFetchWithPreconnect = baseFetch as FetchWithOptionalPreconnect;
+	(azureFetch as FetchWithOptionalPreconnect).preconnect =
+		typeof baseFetchWithPreconnect.preconnect === "function"
+			? baseFetchWithPreconnect.preconnect.bind(baseFetch)
+			: () => undefined;
+	return azureFetch;
+}
+
 export async function createOpenAICompatibleProviderModule(
 	config: GatewayResolvedProviderConfig,
 	context: GatewayProviderContext,
@@ -18,12 +82,13 @@ export async function createOpenAICompatibleProviderModule(
 	// authoritative error and is surfaced to the user as-is. This keeps
 	// `llms` unopinionated about which providers do or don't need a key.
 	const apiKey = await resolveApiKey(config);
+	const fetch = createAzureApiVersionFetch(config);
 	const provider = createOpenAICompatible({
 		name: context.provider.id,
 		apiKey,
 		...(config.baseUrl ? { baseURL: config.baseUrl } : {}),
 		...(config.headers ? { headers: config.headers } : {}),
-		...(config.fetch ? { fetch: config.fetch } : {}),
+		...(fetch ? { fetch } : {}),
 		includeUsage: true,
 	} as never);
 	return {


### PR DESCRIPTION
### Related Issue

**Issue:** CLINE-2370 (Linear): Azure AI Foundry profile authentication broken in CLI 3.0.15

### Description

Fixes Azure AI Foundry deployment-style OpenAI-compatible URLs in the CLI path, including fresh CLI/TUI setup.

The CLI/core runtime now preserves and forwards `azure.apiVersion` into gateway provider options for OpenAI-compatible provider/client configs. The OpenAI-compatible provider appends the configured Azure `api-version` only for Azure deployment-style request paths under `/openai/deployments/...` that do not already include `api-version`, leaving `/openai/v1` compatible URLs unchanged.

This PR also fixes the setup gap Robin called out:

- adds an optional Azure API version field for `openai-compatible` provider configuration
- wires that field through onboarding and provider-picker TUI save paths into `azure.apiVersion`
- adds `cline auth --azure-api-version <version>` for non-interactive quick setup
- documents in the setup copy that Azure deployment Base URL should stop at `/openai/deployments/<deployment>`
- preserves clearing behavior when the Azure API version field is blank

### Test Procedure

Passed:

- `bunx vitest run src/providers/compat.test.ts --config vitest.config.ts` from `sdk/packages/llms` (11 tests)
- `bunx vitest run src/agent-runtime.provider-form.test.ts --config vitest.config.ts` from `sdk/packages/agents` (6 tests)
- `bunx vitest run src/services/llms/handler-factory.test.ts --config vitest.config.ts` from `sdk/packages/core` (8 tests)
- `bunx vitest run src/services/providers/provider-config-fields.test.ts --config vitest.config.ts` from `sdk/packages/core` (12 tests)
- `bunx vitest run src/tui/utils/provider-config-values.test.ts src/commands/rpc-runtime/provider-registry.test.ts src/commands/auth.test.ts --config vitest.config.ts` from `apps/cli` (14 tests)
- `bun --parallel -F '*' typecheck`
- `bun biome check --diagnostic-level=error` on touched files
- `bun run build`
- Live CLI smoke with isolated temp provider settings against an Azure Foundry `gpt-4.1` deployment-style base URL returned `AZURE_SMOKE_OK` from the rebuilt CLI bundle.

Noted while preparing the PR: repository-wide `npm test`/lint commands currently fail in unrelated areas (CLI distribution package shape test and existing Biome a11y/noBannedTypes lint findings). The focused tests/checks above cover this change.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality not to work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - backend/CLI provider configuration fix.

### Additional Notes

The live smoke used temporary local config/state and did not modify the user's normal Cline configuration. The Azure API key used for validation was provided in chat and should be rotated after review.
