### PR TITLE
fix: invert MCP per-tool auto-approve checkbox visibility

### DIFF
--- a/apps/vscode/webview-ui/src/components/mcp/configuration/tabs/installed/server-row/McpToolRow.tsx
+++ b/apps/vscode/webview-ui/src/components/mcp/configuration/tabs/installed/server-row/McpToolRow.tsx
@@ -50,7 +50,7 @@ const McpToolRow = ({ tool, serverName }: McpToolRowProps) => {
 					<span className="codicon codicon-symbol-method" style={{ marginRight: "6px", flexShrink: 0 }}></span>
 					<span style={{ fontWeight: 500, overflow: "hidden", textOverflow: "ellipsis" }}>{tool.name}</span>
 				</div>
-				{serverName && autoApprovalSettings.actions.useMcp && (
+				{serverName && !autoApprovalSettings.actions.useMcp && (
 					<VSCodeCheckbox
 						checked={tool.autoApprove ?? false}
 						data-tool={tool.name}

--- a/apps/vscode/webview-ui/src/components/mcp/configuration/tabs/installed/server-row/ServerRow.tsx
+++ b/apps/vscode/webview-ui/src/components/mcp/configuration/tabs/installed/server-row/ServerRow.tsx
@@ -328,7 +328,7 @@ const ServerRow = ({
 							<VSCodePanelView id="tools-view">
 								{server.tools && server.tools.length > 0 ? (
 									<div className="flex flex-col gap-2 w-full pt-2">
-										{server.name && autoApprovalSettings.actions.useMcp && (
+										{server.name && !autoApprovalSettings.actions.useMcp && (
 											<VSCodeCheckbox
 												checked={server.tools.every((tool) => tool.autoApprove)}
 												className="mb-1 text-xs"


### PR DESCRIPTION
### Related Issue

**Issue:** #10187

### Description

Per-tool auto-approve checkboxes for MCP tools were hidden when the global "Use MCP servers" auto-approve toggle was OFF, and shown when it was ON — the exact opposite of what's useful.

When `useMcp` is ON, all MCP tools are already auto-approved globally, making per-tool checkboxes redundant. When `useMcp` is OFF, per-tool checkboxes are the only way to selectively auto-approve specific tools — but they were hidden.

The fix inverts the visibility condition `autoApprovalSettings.actions.useMcp` → `!autoApprovalSettings.actions.useMcp` in:
- `McpToolRow.tsx:53` (per-tool auto-approve checkbox)
- `ServerRow.tsx:326` ("Auto-approve all tools" checkbox)

The backend logic in `UseMcpToolHandler.ts:93` already correctly uses OR logic (`shouldAutoApproveTool || isToolAutoApproved`), so only the UI visibility was wrong.

### Test Procedure

1. Open Cline sidebar → Auto-approve menu → turn OFF "Use MCP servers"
2. Go to MCP Servers settings → verify per-tool auto-approve checkboxes are now visible
3. Enable auto-approve for specific tools → trigger MCP tool calls → verify only approved tools auto-run
4. Turn ON "Use MCP servers" → verify per-tool checkboxes are hidden (redundant since all are auto-approved)

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

#### Before (useMcp OFF — checkboxes hidden, no way to selectively approve):
See issue #10187 screenshots

#### After (useMcp OFF — checkboxes now visible for selective approval):
<img width="494" height="616" alt="image" src="https://github.com/user-attachments/assets/5dc1ec10-1408-485a-be88-253a6fa1544b" />

After checking the "Auto-approve" checkbox on a tool, later calls to that same tool are indeed automatically approved.

If "Use MCP servers" is ON, the checkboxes are hidden, since they have no use and all MCP calls are going to be auto-approved.
<img width="500" height="638" alt="image" src="https://github.com/user-attachments/assets/79c3b5bc-dcfa-49c3-aebb-d4bc0465cf54" />

### Additional Notes

This is a 2-line fix (adding `!` to invert two conditions). Related to #9357 which was previously closed as "Not a bug" but appears to be the same root cause.