### PR TITLE
Prevent terminal output context bloat

### DIFF
--- a/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalManager.ts
+++ b/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalManager.ts
@@ -2,6 +2,7 @@ import { arePathsEqual } from "@utils/path"
 import { getShellForProfile } from "@utils/shell"
 import pWaitFor from "p-wait-for"
 import * as vscode from "vscode"
+import { formatTerminalOutput } from "@/integrations/terminal/outputFormatter"
 import {
 	TerminalInfo as ITerminalInfo,
 	ITerminalManager,
@@ -365,13 +366,7 @@ export class VscodeTerminalManager implements ITerminalManager {
 
 	public processOutput(outputLines: string[], overrideLimit?: number): string {
 		const limit = overrideLimit !== undefined ? overrideLimit : this.terminalOutputLineLimit
-		if (outputLines.length > limit) {
-			const halfLimit = Math.floor(limit / 2)
-			const start = outputLines.slice(0, halfLimit)
-			const end = outputLines.slice(outputLines.length - halfLimit)
-			return `${start.join("\n")}\n... (output truncated) ...\n${end.join("\n")}`.trim()
-		}
-		return outputLines.join("\n").trim()
+		return formatTerminalOutput(outputLines, limit)
 	}
 
 	setDefaultTerminalProfile(profileId: string): { closedCount: number; busyTerminals: TerminalInfo[] } {

--- a/apps/vscode/src/integrations/terminal/__tests__/outputFormatter.test.ts
+++ b/apps/vscode/src/integrations/terminal/__tests__/outputFormatter.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict"
+import { describe, it } from "mocha"
+import { formatTerminalOutput } from "../outputFormatter"
+
+describe("formatTerminalOutput", () => {
+	it("preserves normal CRLF output as lines", () => {
+		const result = formatTerminalOutput(["one\r\ntwo", "three"], 10)
+
+		assert.equal(result, "one\ntwo\nthree")
+	})
+
+	it("truncates carriage-return progress updates by output line limit", () => {
+		const progress = Array.from({ length: 1_000 }, (_, index) => `Frame ${index} spheres=14752 elapsed=900s`).join("\r")
+
+		const result = formatTerminalOutput([progress], 10)
+
+		assert.match(result, /\.\.\. \(output truncated\) \.\.\./)
+		assert.equal(result.match(/Frame \d+ spheres=/g)?.length, 10)
+	})
+
+	it("caps a single oversized terminal line", () => {
+		const result = formatTerminalOutput([`start ${"x".repeat(10_000)} end`], 10)
+
+		assert.match(result, /\.\.\. \(line truncated, \d+ chars omitted\) \.\.\./)
+		assert.ok(result.length <= 4_096)
+		assert.ok(result.startsWith("start "))
+		assert.ok(result.endsWith(" end"))
+	})
+
+	it("caps total command output after line truncation", () => {
+		const lines = Array.from({ length: 2_000 }, (_, index) => `line ${index} ${"x".repeat(100)}`)
+
+		const result = formatTerminalOutput(lines, 2_000)
+
+		assert.match(result, /\.\.\. \(command output truncated, \d+ chars omitted\) \.\.\./)
+		assert.ok(result.length <= 65_536)
+	})
+})

--- a/apps/vscode/src/integrations/terminal/__tests__/outputFormatter.test.ts
+++ b/apps/vscode/src/integrations/terminal/__tests__/outputFormatter.test.ts
@@ -18,6 +18,12 @@ describe("formatTerminalOutput", () => {
 		assert.equal(result.match(/Frame \d+ spheres=/g)?.length, 10)
 	})
 
+	it("handles a one-line output limit without tail lines", () => {
+		const result = formatTerminalOutput(["first", "second", "third"], 1)
+
+		assert.equal(result, "first\n... (output truncated) ...")
+	})
+
 	it("caps a single oversized terminal line", () => {
 		const result = formatTerminalOutput([`start ${"x".repeat(10_000)} end`], 10)
 
@@ -25,6 +31,14 @@ describe("formatTerminalOutput", () => {
 		assert.ok(result.length <= 4_096)
 		assert.ok(result.startsWith("start "))
 		assert.ok(result.endsWith(" end"))
+	})
+
+	it("strictly caps oversized terminal lines across omitted-count digit boundaries", () => {
+		for (const extraChars of [9, 10, 99, 100, 999, 1_000]) {
+			const result = formatTerminalOutput(["x".repeat(4_096 + extraChars)], 10)
+
+			assert.ok(result.length <= 4_096, `expected ${result.length} <= 4096 for ${extraChars} extra chars`)
+		}
 	})
 
 	it("caps total command output after line truncation", () => {

--- a/apps/vscode/src/integrations/terminal/outputFormatter.ts
+++ b/apps/vscode/src/integrations/terminal/outputFormatter.ts
@@ -6,20 +6,19 @@ function truncateMiddle(text: string, maxChars: number, reason: string): string 
 		return text
 	}
 
-	let omitted = 0
-	let headChars = 0
-	let tailChars = 0
-	let marker = ""
+	const markerFor = (omitted: number) => `\n... (${reason}, ${omitted} chars omitted) ...\n`
+	const maxMarker = markerFor(text.length)
 
-	for (let i = 0; i < 3; i++) {
-		marker = `\n... (${reason}, ${omitted} chars omitted) ...\n`
-		const remainingChars = Math.max(0, maxChars - marker.length)
-		headChars = Math.ceil(remainingChars / 2)
-		tailChars = Math.floor(remainingChars / 2)
-		omitted = text.length - headChars - tailChars
+	if (maxMarker.length >= maxChars) {
+		return text.slice(0, maxChars)
 	}
 
-	marker = `\n... (${reason}, ${omitted} chars omitted) ...\n`
+	const remainingChars = maxChars - maxMarker.length
+	const headChars = Math.ceil(remainingChars / 2)
+	const tailChars = Math.floor(remainingChars / 2)
+	const omitted = text.length - headChars - tailChars
+	const marker = markerFor(omitted)
+
 	return `${text.slice(0, headChars)}${marker}${tailChars > 0 ? text.slice(-tailChars) : ""}`
 }
 

--- a/apps/vscode/src/integrations/terminal/outputFormatter.ts
+++ b/apps/vscode/src/integrations/terminal/outputFormatter.ts
@@ -1,0 +1,48 @@
+const MAX_TERMINAL_OUTPUT_LINE_CHARS = 4096
+const MAX_TERMINAL_OUTPUT_CHARS = 65_536
+
+function truncateMiddle(text: string, maxChars: number, reason: string): string {
+	if (text.length <= maxChars) {
+		return text
+	}
+
+	let omitted = 0
+	let headChars = 0
+	let tailChars = 0
+	let marker = ""
+
+	for (let i = 0; i < 3; i++) {
+		marker = `\n... (${reason}, ${omitted} chars omitted) ...\n`
+		const remainingChars = Math.max(0, maxChars - marker.length)
+		headChars = Math.ceil(remainingChars / 2)
+		tailChars = Math.floor(remainingChars / 2)
+		omitted = text.length - headChars - tailChars
+	}
+
+	marker = `\n... (${reason}, ${omitted} chars omitted) ...\n`
+	return `${text.slice(0, headChars)}${marker}${tailChars > 0 ? text.slice(-tailChars) : ""}`
+}
+
+function normalizeTerminalOutputLines(outputLines: string[]): string[] {
+	return outputLines.flatMap((line) => line.split(/\r\n|\n|\r/))
+}
+
+export function formatTerminalOutput(outputLines: string[], lineLimit: number): string {
+	const normalizedLineLimit = Math.max(1, Math.floor(lineLimit))
+	const normalizedLines = normalizeTerminalOutputLines(outputLines).map((line) =>
+		truncateMiddle(line, MAX_TERMINAL_OUTPUT_LINE_CHARS, "line truncated"),
+	)
+
+	let result: string
+	if (normalizedLines.length > normalizedLineLimit) {
+		const startLimit = Math.ceil(normalizedLineLimit / 2)
+		const endLimit = Math.floor(normalizedLineLimit / 2)
+		const start = normalizedLines.slice(0, startLimit)
+		const end = endLimit > 0 ? normalizedLines.slice(normalizedLines.length - endLimit) : []
+		result = `${start.join("\n")}\n... (output truncated) ...\n${end.join("\n")}`
+	} else {
+		result = normalizedLines.join("\n")
+	}
+
+	return truncateMiddle(result.trim(), MAX_TERMINAL_OUTPUT_CHARS, "command output truncated")
+}

--- a/apps/vscode/src/integrations/terminal/standalone/StandaloneTerminalManager.ts
+++ b/apps/vscode/src/integrations/terminal/standalone/StandaloneTerminalManager.ts
@@ -15,6 +15,7 @@
 import { ClineTempManager } from "@services/temp"
 import * as fs from "fs"
 import { BACKGROUND_COMMAND_TIMEOUT_MS, DEFAULT_TERMINAL_OUTPUT_LINE_LIMIT } from "../constants"
+import { formatTerminalOutput } from "../outputFormatter"
 import type { BackgroundCommand, ITerminalManager, TerminalInfo, TerminalProcessResultPromise } from "../types"
 import { StandaloneTerminalProcess } from "./StandaloneTerminalProcess"
 import { StandaloneTerminalRegistry } from "./StandaloneTerminalRegistry"
@@ -224,13 +225,7 @@ export class StandaloneTerminalManager implements ITerminalManager {
 	 */
 	processOutput(outputLines: string[], overrideLimit?: number): string {
 		const limit = overrideLimit !== undefined ? overrideLimit : this.terminalOutputLineLimit
-		if (outputLines.length > limit) {
-			const halfLimit = Math.floor(limit / 2)
-			const start = outputLines.slice(0, halfLimit)
-			const end = outputLines.slice(outputLines.length - halfLimit)
-			return `${start.join("\n")}\n... (output truncated) ...\n${end.join("\n")}`.trim()
-		}
-		return outputLines.join("\n").trim()
+		return formatTerminalOutput(outputLines, limit)
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Add a shared terminal output formatter for VS Code and standalone terminal managers.
- Treat `\r\n`, `\n`, and standalone `\r` as output line separators before truncating.
- Cap oversized single output lines and final command-result text so carriage-return progress streams cannot bloat task history.

## Problem

Some long-running terminal commands print progress by rewriting the same line with standalone carriage returns. The previous formatter truncated by counting collected output entries as lines, so a carriage-return progress stream could be preserved as one very large logical line and sent back in the next model request.

That can make a normal retry request exceed the model context window even though the command output is just repeated progress status.

## Testing

- `npm ci --ignore-scripts`
- `npm rebuild grpc-tools`
- `npm run protos`
- `npx tsc --noEmit --project tsconfig.json`
- `npx biome check apps/vscode/src/integrations/terminal/outputFormatter.ts apps/vscode/src/integrations/terminal/__tests__/outputFormatter.test.ts apps/vscode/src/integrations/terminal/standalone/StandaloneTerminalManager.ts apps/vscode/src/hosts/vscode/terminal/VscodeTerminalManager.ts`
- Manual formatter assertions with `ts-node --transpile-only`