### PR TITLE
Fix MiniMax M3 thinking controls across gateways [ENG-2163]

### DIFF
--- a/sdk/packages/llms/src/providers/builtins.test.ts
+++ b/sdk/packages/llms/src/providers/builtins.test.ts
@@ -116,4 +116,22 @@ describe("built-in provider metadata", () => {
 			}
 		}
 	});
+
+	it("routes direct MiniMax M3 through MiniMax thinking metadata", async () => {
+		await expect(getProvider("minimax")).resolves.toMatchObject({
+			metadata: {
+				routing: {
+					reasoning: {
+						format: "minimax-thinking",
+						routes: [
+							expect.objectContaining({
+								matcher: "model-id",
+								modelId: "MiniMax-M3",
+							}),
+						],
+					},
+				},
+			},
+		});
+	});
 });

--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -23,6 +23,7 @@ import {
 	QWEN_CACHE_ROUTING_METADATA,
 } from "./routing/anthropic-compatible";
 import { GLM_THINKING_ROUTING_METADATA } from "./routing/glm-thinking";
+import { MINIMAX_THINKING_ROUTING_METADATA } from "./routing/minimax-thinking";
 
 export const DEFAULT_INTERNAL_OCA_BASE_URL =
 	"https://code-internal.aiservice.us-chicago-1.oci.oraclecloud.com/20250206/app/litellm";
@@ -953,7 +954,7 @@ export const BUILTIN_SPECS: BuiltinSpec[] = [
 		apiKeyEnv: ["MINIMAX_API_KEY"],
 		modelsProviderId: "minimax",
 		defaults: { baseUrl: "https://api.minimax.io/anthropic/v1" },
-		metadata: ANTHROPIC_ROUTING_METADATA,
+		metadata: MINIMAX_THINKING_ROUTING_METADATA,
 	},
 	{
 		id: "opencode",

--- a/sdk/packages/llms/src/providers/model-facts.ts
+++ b/sdk/packages/llms/src/providers/model-facts.ts
@@ -217,6 +217,18 @@ export function isGlmModel(
 	return family.includes("glm") || normalizedModelId(request).includes("glm");
 }
 
+export function isMiniMaxM3Model(
+	request: Pick<GatewayStreamRequest, "modelId">,
+	context: GatewayProviderContext,
+): boolean {
+	const modelId = normalizedModelId(request);
+	const family = normalizedFamily(context);
+	const isM3ModelId =
+		modelId === "minimax-m3" || modelId.endsWith("/minimax-m3");
+
+	return isM3ModelId || (family === "minimax-m3" && !modelId);
+}
+
 export function isKimiK26Family(context: GatewayProviderContext): boolean {
 	return normalizedFamily(context) === "kimi-k2.6";
 }

--- a/sdk/packages/llms/src/providers/model-facts.ts
+++ b/sdk/packages/llms/src/providers/model-facts.ts
@@ -219,14 +219,11 @@ export function isGlmModel(
 
 export function isMiniMaxM3Model(
 	request: Pick<GatewayStreamRequest, "modelId">,
-	context: GatewayProviderContext,
+	_context: GatewayProviderContext,
 ): boolean {
 	const modelId = normalizedModelId(request);
-	const family = normalizedFamily(context);
-	const isM3ModelId =
-		modelId === "minimax-m3" || modelId.endsWith("/minimax-m3");
 
-	return isM3ModelId || (family === "minimax-m3" && !modelId);
+	return modelId === "minimax-m3" || modelId === "minimax/minimax-m3";
 }
 
 export function isKimiK26Family(context: GatewayProviderContext): boolean {

--- a/sdk/packages/llms/src/providers/routing/minimax-thinking.ts
+++ b/sdk/packages/llms/src/providers/routing/minimax-thinking.ts
@@ -1,0 +1,78 @@
+import type {
+	GatewayProviderMetadata,
+	GatewayStreamRequest,
+} from "@cline/shared";
+import {
+	buildProviderAndAliasPatch,
+	type ProviderOptionsPatch,
+} from "./utils";
+
+export const MINIMAX_THINKING_ROUTING_METADATA: GatewayProviderMetadata = {
+	routing: {
+		promptCache: {
+			format: "anthropic-cache-control",
+			routes: [{ matcher: "anthropic-compatible" }],
+		},
+		reasoning: {
+			format: "minimax-thinking",
+			routes: [
+				{
+					matcher: "model-id",
+					modelId: "MiniMax-M3",
+					requiredCapability: "reasoning",
+				},
+			],
+		},
+	},
+};
+
+function buildMiniMaxThinkingOptions(request: GatewayStreamRequest) {
+	if (request.reasoning?.enabled === true) {
+		return { thinking: { type: "adaptive" } };
+	}
+	if (request.reasoning?.enabled === false) {
+		return { thinking: { type: "disabled" } };
+	}
+	return undefined;
+}
+
+function buildMiniMaxGatewayReasoningOptions(request: GatewayStreamRequest) {
+	if (request.reasoning?.enabled === true) {
+		return { reasoning: { enabled: true } };
+	}
+	if (request.reasoning?.enabled === false) {
+		return { reasoning: { exclude: true } };
+	}
+	return undefined;
+}
+
+export function buildMiniMaxThinkingProviderOptionsPatch(
+	request: GatewayStreamRequest,
+	providerOptionsKey: string,
+): ProviderOptionsPatch | undefined {
+	const thinking = buildMiniMaxThinkingOptions(request);
+	if (!thinking) {
+		return undefined;
+	}
+	return {
+		openaiCompatible: thinking,
+		[request.providerId]: thinking,
+		...(providerOptionsKey !== request.providerId
+			? { [providerOptionsKey]: thinking }
+			: {}),
+	};
+}
+
+export function buildMiniMaxGatewayReasoningProviderOptionsPatch(
+	request: GatewayStreamRequest,
+	providerOptionsKey: string,
+): ProviderOptionsPatch | undefined {
+	const reasoning = buildMiniMaxGatewayReasoningOptions(request);
+	return reasoning
+		? buildProviderAndAliasPatch({
+				providerId: request.providerId,
+				providerOptionsKey,
+				bucketOptions: reasoning,
+			})
+		: undefined;
+}

--- a/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
@@ -5,6 +5,7 @@ import {
 	isGeminiProModel,
 	isGlmModel,
 	isKimiK26Family as isKimiK26FamilyFact,
+	isMiniMaxM3Model,
 	isMoonshotKimiModelIdFallback,
 	modelReasoningDefaultsOn,
 	providerReasoningRouteMatches,
@@ -16,6 +17,10 @@ import {
 	buildNativeGlmThinkingProviderOptionsPatch,
 	buildRoutedGlmReasoningProviderOptionsPatch,
 } from "./glm-thinking";
+import {
+	buildMiniMaxGatewayReasoningProviderOptionsPatch,
+	buildMiniMaxThinkingProviderOptionsPatch,
+} from "./minimax-thinking";
 import type {
 	MatchedProviderOptionRule,
 	ProviderOptionBuildInput,
@@ -44,6 +49,10 @@ function isDeepSeekModelOrProviderDefault(
 	return (
 		isDeepSeekFamily(input.context) || input.request.providerId === "deepseek"
 	);
+}
+
+function isMiniMaxM3(input: ProviderOptionMatchInput): boolean {
+	return isMiniMaxM3Model(input.request, input.context);
 }
 
 function isOllamaReasoningDefaultOnDisable(
@@ -75,6 +84,16 @@ function hasGlmThinkingProviderRouting(
 	return (
 		input.context.provider.metadata?.routing?.reasoning?.format ===
 		"glm-thinking"
+	);
+}
+
+function usesMiniMaxThinkingProviderRouting(
+	input: ProviderOptionMatchInput,
+): boolean {
+	return providerReasoningRouteMatches(
+		"minimax-thinking",
+		input.request,
+		input.context,
 	);
 }
 
@@ -267,6 +286,31 @@ const openRouterReasoningRule: ProviderOptionRule = {
 		),
 };
 
+const clineMiniMaxM3GatewayReasoningRule: ProviderOptionRule = {
+	id: "provider.cline.minimax-m3.gateway-reasoning",
+	phase: "provider-reasoning",
+	description:
+		"Cline-routed MiniMax M3 keeps the gateway reasoning shape instead of leaking generic thinking.",
+	applies: (input) => input.request.providerId === "cline" && isMiniMaxM3(input),
+	suppresses: { genericThinking: true, genericEffort: true },
+	build: () => undefined,
+};
+
+const vercelMiniMaxM3GatewayReasoningRule: ProviderOptionRule = {
+	id: "provider.vercel-ai-gateway.minimax-m3.gateway-reasoning",
+	phase: "provider-reasoning",
+	description:
+		"Vercel-routed MiniMax M3 uses the gateway reasoning include/exclude shape.",
+	applies: (input) =>
+		input.request.providerId === "vercel-ai-gateway" && isMiniMaxM3(input),
+	suppresses: { genericThinking: true, genericEffort: true },
+	build: (input) =>
+		buildMiniMaxGatewayReasoningProviderOptionsPatch(
+			input.request,
+			input.providerOptionsKey,
+		),
+};
+
 const geminiThinkingRule: ProviderOptionRule = {
 	id: "provider.google-gemini.thinking-config",
 	phase: "provider",
@@ -403,6 +447,19 @@ const nativeZaiGlmThinkingRule: ProviderOptionRule = {
 		),
 };
 
+const miniMaxThinkingRule: ProviderOptionRule = {
+	id: "provider.routing.minimax-thinking",
+	phase: "model-overlay",
+	description: "Direct MiniMax M3 uses thinking.type adaptive/disabled.",
+	applies: usesMiniMaxThinkingProviderRouting,
+	suppresses: { genericThinking: true, genericEffort: true },
+	build: (input) =>
+		buildMiniMaxThinkingProviderOptionsPatch(
+			input.request,
+			input.providerOptionsKey,
+		),
+};
+
 const routedGlmReasoningRule: ProviderOptionRule = {
 	id: "family.glm.routed-reasoning",
 	phase: "model-overlay",
@@ -437,6 +494,8 @@ export const PROVIDER_OPTION_RULES: ReadonlyArray<ProviderOptionRule> = [
 	genericProviderFanoutRule,
 	clineGatewayReasoningRule,
 	openRouterReasoningRule,
+	clineMiniMaxM3GatewayReasoningRule,
+	vercelMiniMaxM3GatewayReasoningRule,
 	geminiThinkingRule,
 	clineReasoningDisabledThinkingRule,
 	kimiK26ThinkingRule,
@@ -444,6 +503,7 @@ export const PROVIDER_OPTION_RULES: ReadonlyArray<ProviderOptionRule> = [
 	ollamaReasoningDefaultOnDisableRule,
 	nonGlmProviderRoutingSuppressionRule,
 	nativeZaiGlmThinkingRule,
+	miniMaxThinkingRule,
 	routedGlmReasoningRule,
 ];
 

--- a/sdk/packages/llms/src/providers/routing/provider-options.test.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-options.test.ts
@@ -4,6 +4,7 @@ import type {
 } from "@cline/shared";
 import { describe, expect, it } from "vitest";
 import { GLM_THINKING_ROUTING_METADATA } from "./glm-thinking";
+import { MINIMAX_THINKING_ROUTING_METADATA } from "./minimax-thinking";
 import {
 	composeAiSdkProviderOptions,
 	mergeProviderOptionPatches,
@@ -1225,6 +1226,210 @@ describe("composeAiSdkProviderOptions: family/provider thinking patches", () => 
 			expect: [
 				{ bucket: "openai-compatible", lacks: ["thinking"] },
 				{ bucket: "openaiCompatible", lacks: ["thinking"] },
+			],
+		},
+		{
+			name: "openrouter MiniMax M3 reasoning enabled -> OpenRouter reasoning shape",
+			request: {
+				providerId: "openrouter",
+				modelId: "minimax/minimax-m3",
+				reasoning: { enabled: true },
+			},
+			context: {
+				family: "minimax",
+				capabilities: ["reasoning"],
+			},
+			expect: [
+				{
+					bucket: "openrouter",
+					has: { reasoning: { enabled: true } },
+					lacks: ["thinking", "effort", "reasoningEffort"],
+				},
+				{
+					bucket: "openaiCompatible",
+					lacks: ["thinking", "reasoning", "effort", "reasoningEffort"],
+				},
+			],
+		},
+		{
+			name: "openrouter MiniMax M3 reasoning disabled -> OpenRouter reasoning.exclude",
+			request: {
+				providerId: "openrouter",
+				modelId: "minimax/minimax-m3",
+				reasoning: { enabled: false },
+			},
+			context: {
+				family: "minimax",
+				capabilities: ["reasoning"],
+			},
+			expect: [
+				{
+					bucket: "openrouter",
+					has: { reasoning: { exclude: true } },
+					lacks: ["thinking"],
+				},
+				{
+					bucket: "openaiCompatible",
+					lacks: ["thinking", "reasoning"],
+				},
+			],
+		},
+		{
+			name: "vercel MiniMax M3 reasoning enabled -> gateway reasoning shape",
+			request: {
+				providerId: "vercel-ai-gateway",
+				modelId: "minimax/minimax-m3",
+				reasoning: { enabled: true, effort: "high" },
+			},
+			context: {
+				family: "minimax",
+				capabilities: ["reasoning"],
+			},
+			expect: [
+				{
+					bucket: "vercel-ai-gateway",
+					has: { reasoning: { enabled: true } },
+					lacks: ["thinking", "effort", "reasoningEffort", "reasoningSummary"],
+				},
+				{
+					bucket: "vercelAiGateway",
+					has: { reasoning: { enabled: true } },
+					lacks: ["thinking", "effort", "reasoningEffort", "reasoningSummary"],
+				},
+			],
+		},
+		{
+			name: "vercel MiniMax M3 reasoning disabled -> gateway reasoning.exclude",
+			request: {
+				providerId: "vercel-ai-gateway",
+				modelId: "minimax/minimax-m3",
+				reasoning: { enabled: false },
+			},
+			context: {
+				family: "minimax",
+				capabilities: ["reasoning"],
+			},
+			expect: [
+				{
+					bucket: "vercel-ai-gateway",
+					has: { reasoning: { exclude: true } },
+					lacks: ["thinking"],
+				},
+				{
+					bucket: "vercelAiGateway",
+					has: { reasoning: { exclude: true } },
+					lacks: ["thinking"],
+				},
+			],
+		},
+		{
+			name: "vercel MiniMax M3 sibling id -> no MiniMax M3 gateway exception",
+			request: {
+				providerId: "vercel-ai-gateway",
+				modelId: "minimax/minimax-m3-pro",
+				reasoning: { enabled: true },
+			},
+			context: {
+				family: "minimax",
+				capabilities: ["reasoning"],
+			},
+			expect: [
+				{
+					bucket: "vercel-ai-gateway",
+					has: { thinking: { type: "adaptive" } },
+					lacks: ["reasoning"],
+				},
+			],
+		},
+		{
+			name: "cline MiniMax M3 reasoning enabled -> gateway reasoning without thinking leak",
+			request: {
+				providerId: "cline",
+				modelId: "minimax/minimax-m3",
+				reasoning: { enabled: true, effort: "high" },
+			},
+			context: {
+				family: "minimax",
+				capabilities: ["reasoning"],
+			},
+			expect: [
+				{
+					bucket: "cline",
+					has: { reasoning: { enabled: true, effort: "high" } },
+					lacks: ["thinking", "effort", "reasoningEffort", "reasoningSummary"],
+				},
+				{
+					bucket: "openaiCompatible",
+					lacks: ["thinking", "reasoning", "effort", "reasoningEffort"],
+				},
+			],
+		},
+		{
+			name: "cline MiniMax M3 reasoning disabled -> gateway reasoning disabled",
+			request: {
+				providerId: "cline",
+				modelId: "minimax/minimax-m3",
+				reasoning: { enabled: false },
+			},
+			context: {
+				family: "minimax",
+				capabilities: ["reasoning"],
+			},
+			expect: [
+				{
+					bucket: "cline",
+					has: { reasoning: { enabled: false } },
+					lacks: ["thinking"],
+				},
+				{
+					bucket: "openaiCompatible",
+					lacks: ["thinking", "reasoning"],
+				},
+			],
+		},
+		{
+			name: "direct MiniMax M3 reasoning disabled -> thinking.type=disabled",
+			request: {
+				providerId: "minimax",
+				modelId: "MiniMax-M3",
+				reasoning: { enabled: false },
+			},
+			context: {
+				family: "minimax",
+				capabilities: ["reasoning"],
+				metadata: MINIMAX_THINKING_ROUTING_METADATA,
+			},
+			expect: [
+				{ bucket: "minimax", has: { thinking: { type: "disabled" } } },
+				{
+					bucket: "openaiCompatible",
+					has: { thinking: { type: "disabled" } },
+				},
+			],
+		},
+		{
+			name: "direct MiniMax M3 reasoning enabled -> thinking.type=adaptive",
+			request: {
+				providerId: "minimax",
+				modelId: "MiniMax-M3",
+				reasoning: { enabled: true, effort: "high" },
+			},
+			context: {
+				family: "minimax",
+				capabilities: ["reasoning"],
+				metadata: MINIMAX_THINKING_ROUTING_METADATA,
+			},
+			expect: [
+				{
+					bucket: "minimax",
+					has: { thinking: { type: "adaptive" } },
+					lacks: ["effort", "reasoningEffort", "reasoningSummary"],
+				},
+				{
+					bucket: "openaiCompatible",
+					has: { thinking: { type: "adaptive" } },
+					lacks: ["effort", "reasoningEffort", "reasoningSummary"],
+				},
 			],
 		},
 		// Ollama Qwen3: model behavior fact first, documented dynamic fallback second.

--- a/sdk/packages/llms/src/providers/routing/provider-options.test.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-options.test.ts
@@ -1400,10 +1400,15 @@ describe("composeAiSdkProviderOptions: family/provider thinking patches", () => 
 				metadata: MINIMAX_THINKING_ROUTING_METADATA,
 			},
 			expect: [
-				{ bucket: "minimax", has: { thinking: { type: "disabled" } } },
+				{
+					bucket: "minimax",
+					has: { thinking: { type: "disabled" } },
+					lacks: ["reasoning", "effort", "reasoningEffort", "reasoningSummary"],
+				},
 				{
 					bucket: "openaiCompatible",
 					has: { thinking: { type: "disabled" } },
+					lacks: ["reasoning", "effort", "reasoningEffort", "reasoningSummary"],
 				},
 			],
 		},
@@ -1423,12 +1428,60 @@ describe("composeAiSdkProviderOptions: family/provider thinking patches", () => 
 				{
 					bucket: "minimax",
 					has: { thinking: { type: "adaptive" } },
-					lacks: ["effort", "reasoningEffort", "reasoningSummary"],
+					lacks: ["reasoning", "effort", "reasoningEffort", "reasoningSummary"],
 				},
 				{
 					bucket: "openaiCompatible",
 					has: { thinking: { type: "adaptive" } },
-					lacks: ["effort", "reasoningEffort", "reasoningSummary"],
+					lacks: ["reasoning", "effort", "reasoningEffort", "reasoningSummary"],
+				},
+			],
+		},
+		{
+			name: "direct MiniMax M2.5 reasoning enabled -> existing generic adaptive thinking",
+			request: {
+				providerId: "minimax",
+				modelId: "MiniMax-M2.5",
+				reasoning: { enabled: true },
+			},
+			context: {
+				family: "minimax",
+				capabilities: ["reasoning"],
+				metadata: MINIMAX_THINKING_ROUTING_METADATA,
+			},
+			expect: [
+				{
+					bucket: "minimax",
+					has: { thinking: { type: "adaptive" } },
+					lacks: ["reasoning"],
+				},
+				{
+					bucket: "openaiCompatible",
+					has: { thinking: { type: "adaptive" } },
+					lacks: ["reasoning"],
+				},
+			],
+		},
+		{
+			name: "direct MiniMax M2.7 reasoning disabled -> no MiniMax M3 disabled exception",
+			request: {
+				providerId: "minimax",
+				modelId: "MiniMax-M2.7",
+				reasoning: { enabled: false },
+			},
+			context: {
+				family: "minimax",
+				capabilities: ["reasoning"],
+				metadata: MINIMAX_THINKING_ROUTING_METADATA,
+			},
+			expect: [
+				{
+					bucket: "minimax",
+					lacks: ["thinking", "reasoning", "effort", "reasoningEffort"],
+				},
+				{
+					bucket: "openaiCompatible",
+					lacks: ["thinking", "reasoning", "effort", "reasoningEffort"],
 				},
 			],
 		},

--- a/sdk/packages/llms/src/providers/vendors/anthropic.test.ts
+++ b/sdk/packages/llms/src/providers/vendors/anthropic.test.ts
@@ -41,6 +41,26 @@ describe("createAnthropicProviderModule", () => {
 		);
 		expect(anthropicModelMock).toHaveBeenCalledWith("MiniMax-M2.5");
 	});
+
+	it("does not wrap fetch for non-MiniMax Anthropic-compatible providers", async () => {
+		const customFetch = vi.fn<typeof fetch>();
+
+		await createAnthropicProviderModule(
+			config({
+				providerId: "anthropic",
+				apiKey: "anthropic-api-key",
+				fetch: customFetch,
+			}),
+			context("anthropic"),
+		);
+
+		expect(createAnthropicMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				name: "anthropic",
+				fetch: customFetch,
+			}),
+		);
+	});
 });
 
 function config(
@@ -65,6 +85,6 @@ function context(providerId: string): GatewayProviderContext {
 			id: "MiniMax-M2.5",
 			name: "MiniMax-M2.5",
 		},
-		config: config({}),
+		config: config({ providerId }),
 	};
 }

--- a/sdk/packages/llms/src/providers/vendors/anthropic.ts
+++ b/sdk/packages/llms/src/providers/vendors/anthropic.ts
@@ -1,9 +1,15 @@
 import { createAnthropic } from "@ai-sdk/anthropic";
+import type { LanguageModelV3 } from "@ai-sdk/provider";
 import type {
 	GatewayProviderContext,
 	GatewayResolvedProviderConfig,
 } from "@cline/shared";
+import { wrapLanguageModel } from "ai";
 import { resolveApiKey } from "../http";
+import {
+	createMiniMaxThinkingFetch,
+	miniMaxThinkingDisabledMiddleware,
+} from "./minimax-thinking";
 import type { ProviderFactoryResult } from "./types";
 
 export async function createAnthropicProviderModule(
@@ -11,14 +17,23 @@ export async function createAnthropicProviderModule(
 	context: GatewayProviderContext,
 ): Promise<ProviderFactoryResult> {
 	const apiKey = await resolveApiKey(config);
+	const isMiniMax = context.provider.id === "minimax";
 	const provider = createAnthropic({
 		apiKey,
 		baseURL: config.baseUrl,
 		headers: config.headers,
-		fetch: config.fetch,
+		fetch: isMiniMax ? createMiniMaxThinkingFetch(config.fetch) : config.fetch,
 		name: context.provider.id,
 	});
 	return {
-		model: (modelId) => provider(modelId),
+		model: (modelId) => {
+			const model = provider(modelId);
+			return isMiniMax
+				? wrapLanguageModel({
+						model: model as LanguageModelV3,
+						middleware: miniMaxThinkingDisabledMiddleware,
+					})
+				: model;
+		},
 	};
 }

--- a/sdk/packages/llms/src/providers/vendors/minimax-thinking.test.ts
+++ b/sdk/packages/llms/src/providers/vendors/minimax-thinking.test.ts
@@ -6,6 +6,20 @@ import {
 } from "./minimax-thinking";
 
 describe("MiniMax thinking shim", () => {
+	it("preserves fetch preconnect when the runtime exposes it", () => {
+		const preconnect = vi.fn();
+		const baseFetch = Object.assign(vi.fn(async () => new Response("{}")), {
+			preconnect,
+		}) as unknown as typeof fetch;
+
+		const wrappedFetch = createMiniMaxThinkingFetch(baseFetch) as typeof fetch & {
+			preconnect?: (url: string) => void;
+		};
+		wrappedFetch.preconnect?.("https://api.minimax.io");
+
+		expect(preconnect).toHaveBeenCalledWith("https://api.minimax.io");
+	});
+
 	it("marks MiniMax requests whose provider options disable thinking", async () => {
 		const result = await miniMaxThinkingDisabledMiddleware.transformParams?.({
 			type: "stream",

--- a/sdk/packages/llms/src/providers/vendors/minimax-thinking.test.ts
+++ b/sdk/packages/llms/src/providers/vendors/minimax-thinking.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	createMiniMaxThinkingFetch,
+	MINIMAX_THINKING_DISABLED_HEADER,
+	miniMaxThinkingDisabledMiddleware,
+} from "./minimax-thinking";
+
+describe("MiniMax thinking shim", () => {
+	it("marks MiniMax requests whose provider options disable thinking", async () => {
+		const result = await miniMaxThinkingDisabledMiddleware.transformParams?.({
+			type: "stream",
+			model: {} as never,
+			params: {
+				providerOptions: {
+					minimax: { thinking: { type: "disabled" } },
+				},
+			} as never,
+		});
+
+		expect(result).toEqual(
+			expect.objectContaining({
+				headers: expect.objectContaining({
+					[MINIMAX_THINKING_DISABLED_HEADER]: "1",
+				}),
+			}),
+		);
+	});
+
+	it("injects explicit disabled thinking and strips the private marker header", async () => {
+		const baseFetch = vi.fn(async () => new Response("{}"));
+		const wrappedFetch = createMiniMaxThinkingFetch(baseFetch);
+
+		await wrappedFetch("https://api.minimax.io/anthropic/v1/messages", {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				[MINIMAX_THINKING_DISABLED_HEADER]: "1",
+			},
+			body: JSON.stringify({
+				model: "MiniMax-M3",
+				messages: [],
+			}),
+		});
+
+		const init = baseFetch.mock.calls[0]?.[1];
+		expect(new Headers(init?.headers).has(MINIMAX_THINKING_DISABLED_HEADER)).toBe(
+			false,
+		);
+		expect(JSON.parse(String(init?.body))).toEqual(
+			expect.objectContaining({
+				thinking: { type: "disabled" },
+			}),
+		);
+	});
+});

--- a/sdk/packages/llms/src/providers/vendors/minimax-thinking.ts
+++ b/sdk/packages/llms/src/providers/vendors/minimax-thinking.ts
@@ -6,6 +6,10 @@ import type {
 export const MINIMAX_THINKING_DISABLED_HEADER =
 	"x-cline-minimax-thinking-disabled";
 
+type FetchWithOptionalPreconnect = typeof fetch & {
+	preconnect?: (...args: unknown[]) => unknown;
+};
+
 function getMiniMaxThinkingType(providerOptions: unknown): string | undefined {
 	const options =
 		providerOptions && typeof providerOptions === "object"
@@ -59,7 +63,7 @@ function writeBody(body: unknown): string {
 }
 
 export function createMiniMaxThinkingFetch(baseFetch: typeof fetch = fetch) {
-	return async (
+	const wrappedFetch = (async (
 		input: Parameters<typeof fetch>[0],
 		init?: Parameters<typeof fetch>[1],
 	) => {
@@ -89,5 +93,12 @@ export function createMiniMaxThinkingFetch(baseFetch: typeof fetch = fetch) {
 			headers,
 			body: nextBody,
 		});
-	};
+	}) as typeof fetch;
+	const sourceFetch = baseFetch as FetchWithOptionalPreconnect;
+	(wrappedFetch as FetchWithOptionalPreconnect).preconnect =
+		typeof sourceFetch.preconnect === "function"
+			? sourceFetch.preconnect.bind(baseFetch)
+			: () => {};
+
+	return wrappedFetch;
 }

--- a/sdk/packages/llms/src/providers/vendors/minimax-thinking.ts
+++ b/sdk/packages/llms/src/providers/vendors/minimax-thinking.ts
@@ -1,0 +1,93 @@
+import type {
+	LanguageModelV3CallOptions,
+	LanguageModelV3Middleware,
+} from "@ai-sdk/provider";
+
+export const MINIMAX_THINKING_DISABLED_HEADER =
+	"x-cline-minimax-thinking-disabled";
+
+function getMiniMaxThinkingType(providerOptions: unknown): string | undefined {
+	const options =
+		providerOptions && typeof providerOptions === "object"
+			? (providerOptions as Record<string, unknown>)
+			: {};
+	const minimax =
+		options.minimax && typeof options.minimax === "object"
+			? (options.minimax as Record<string, unknown>)
+			: undefined;
+	const thinking =
+		minimax?.thinking && typeof minimax.thinking === "object"
+			? (minimax.thinking as Record<string, unknown>)
+			: undefined;
+	return typeof thinking?.type === "string" ? thinking.type : undefined;
+}
+
+export const miniMaxThinkingDisabledMiddleware: LanguageModelV3Middleware = {
+	specificationVersion: "v3",
+	transformParams: async ({ params }) => {
+		if (getMiniMaxThinkingType(params.providerOptions) !== "disabled") {
+			return params;
+		}
+
+		return {
+			...params,
+			headers: {
+				...params.headers,
+				[MINIMAX_THINKING_DISABLED_HEADER]: "1",
+			},
+		} satisfies LanguageModelV3CallOptions;
+	},
+};
+
+async function readBody(
+	body: NonNullable<Parameters<typeof fetch>[1]>["body"],
+): Promise<unknown> {
+	if (typeof body === "string") {
+		return JSON.parse(body) as unknown;
+	}
+	if (body instanceof Uint8Array) {
+		return JSON.parse(new TextDecoder().decode(body)) as unknown;
+	}
+	if (body instanceof ArrayBuffer) {
+		return JSON.parse(new TextDecoder().decode(body)) as unknown;
+	}
+	return undefined;
+}
+
+function writeBody(body: unknown): string {
+	return JSON.stringify(body);
+}
+
+export function createMiniMaxThinkingFetch(baseFetch: typeof fetch = fetch) {
+	return async (
+		input: Parameters<typeof fetch>[0],
+		init?: Parameters<typeof fetch>[1],
+	) => {
+		const headers = new Headers(init?.headers);
+		const shouldInject =
+			headers.get(MINIMAX_THINKING_DISABLED_HEADER) === "1";
+		if (!shouldInject) {
+			return baseFetch(input, init);
+		}
+
+		headers.delete(MINIMAX_THINKING_DISABLED_HEADER);
+		const body = await readBody(init?.body);
+		const bodyRecord =
+			body && typeof body === "object" && !Array.isArray(body)
+				? (body as Record<string, unknown>)
+				: undefined;
+		const nextBody =
+			bodyRecord && bodyRecord.thinking === undefined
+				? writeBody({
+						...bodyRecord,
+						thinking: { type: "disabled" },
+					})
+				: init?.body;
+
+		return baseFetch(input, {
+			...init,
+			headers,
+			body: nextBody,
+		});
+	};
+}

--- a/sdk/packages/llms/src/tests/provider-live-minimax-routing.test.ts
+++ b/sdk/packages/llms/src/tests/provider-live-minimax-routing.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it } from "vitest";
+import { createHandlerAsync, type ProviderConfig } from "../providers";
+
+type ReasoningControl = { enabled: boolean };
+
+type LiveCase = {
+	label: string;
+	config: ProviderConfig;
+	expectedBody: Record<string, unknown>;
+	unexpectedBodyKeys?: string[];
+};
+
+type LiveMetrics = {
+	usageSeen: boolean;
+	reasoningChunks: number;
+};
+
+type CapturedRequest = {
+	url: string;
+	body: unknown;
+};
+
+const LIVE_TEST_ENABLED = process.env.LLMS_LIVE_MINIMAX_ROUTING_TESTS === "1";
+const PROVIDER_TIMEOUT_MS = Number(
+	process.env.LLMS_LIVE_PROVIDER_TIMEOUT_MS ?? "120000",
+);
+const DEFAULT_PROMPT =
+	"What is 12*13? Answer with only the number and no explanation.";
+
+function readRequiredEnv(name: string): string {
+	const value = process.env[name]?.trim();
+	if (!value) {
+		throw new Error(`Set ${name} to run MiniMax M3 live routing tests.`);
+	}
+	return value;
+}
+
+function makeConfig(options: {
+	providerId: string;
+	modelId: string;
+	apiKeyEnv: string;
+	reasoning: ReasoningControl;
+	fetch: typeof fetch;
+}): ProviderConfig {
+	return {
+		providerId: options.providerId,
+		modelId: options.modelId,
+		apiKey: readRequiredEnv(options.apiKeyEnv),
+		fetch: options.fetch,
+		thinking: options.reasoning.enabled,
+		maxOutputTokens: 64,
+	};
+}
+
+async function readRequestBody(body: unknown): Promise<Record<string, unknown>> {
+	if (typeof body === "string") {
+		return JSON.parse(body) as Record<string, unknown>;
+	}
+	if (body instanceof Uint8Array) {
+		return JSON.parse(new TextDecoder().decode(body)) as Record<
+			string,
+			unknown
+		>;
+	}
+	if (body instanceof ArrayBuffer) {
+		return JSON.parse(new TextDecoder().decode(body)) as Record<
+			string,
+			unknown
+		>;
+	}
+	return body && typeof body === "object"
+		? (body as Record<string, unknown>)
+		: {};
+}
+
+async function runLiveRequest(config: ProviderConfig): Promise<LiveMetrics> {
+	const handler = await createHandlerAsync(config);
+	const metrics: LiveMetrics = { usageSeen: false, reasoningChunks: 0 };
+	const stream = handler.createMessage("You are concise.", [
+		{ role: "user", content: DEFAULT_PROMPT },
+	]);
+
+	for await (const chunk of stream) {
+		if (chunk.type === "usage") {
+			metrics.usageSeen = true;
+		}
+		if (chunk.type === "reasoning") {
+			metrics.reasoningChunks += 1;
+		}
+		if (chunk.type === "done" && !chunk.success) {
+			throw new Error(chunk.error ?? "done chunk reported success=false");
+		}
+	}
+
+	return metrics;
+}
+
+function buildCases(): LiveCase[] {
+	const cases: LiveCase[] = [];
+	const addCase = (options: {
+		label: string;
+		providerId: string;
+		modelId: string;
+		apiKeyEnv: string;
+		reasoning: ReasoningControl;
+		expectedBody: Record<string, unknown>;
+		unexpectedBodyKeys?: string[];
+	}) => {
+		const captured: CapturedRequest[] = [];
+		const captureFetch: typeof fetch = async (input, init) => {
+			captured.push({ url: String(input), body: init?.body });
+			return fetch(input, init);
+		};
+		const config = makeConfig({ ...options, fetch: captureFetch });
+		cases.push({
+			label: options.label,
+			config: {
+				...config,
+				metadata: {
+					...(config.metadata ?? {}),
+					get capturedRequests() {
+						return captured;
+					},
+				},
+			},
+			expectedBody: options.expectedBody,
+			unexpectedBodyKeys: options.unexpectedBodyKeys,
+		});
+	};
+
+	addCase({
+		label: "direct MiniMax M3 reasoning enabled",
+		providerId: "minimax",
+		modelId: "MiniMax-M3",
+		apiKeyEnv: "MINIMAX_API_KEY",
+		reasoning: { enabled: true },
+		expectedBody: { thinking: { type: "adaptive" } },
+	});
+	addCase({
+		label: "direct MiniMax M3 reasoning disabled",
+		providerId: "minimax",
+		modelId: "MiniMax-M3",
+		apiKeyEnv: "MINIMAX_API_KEY",
+		reasoning: { enabled: false },
+		expectedBody: { thinking: { type: "disabled" } },
+	});
+	addCase({
+		label: "OpenRouter MiniMax M3 reasoning enabled",
+		providerId: "openrouter",
+		modelId: "minimax/minimax-m3",
+		apiKeyEnv: "OPENROUTER_API_KEY",
+		reasoning: { enabled: true },
+		expectedBody: { reasoning: { enabled: true } },
+		unexpectedBodyKeys: ["thinking"],
+	});
+	addCase({
+		label: "OpenRouter MiniMax M3 reasoning disabled",
+		providerId: "openrouter",
+		modelId: "minimax/minimax-m3",
+		apiKeyEnv: "OPENROUTER_API_KEY",
+		reasoning: { enabled: false },
+		expectedBody: { reasoning: { exclude: true } },
+		unexpectedBodyKeys: ["thinking"],
+	});
+	addCase({
+		label: "Vercel AI Gateway MiniMax M3 reasoning enabled",
+		providerId: "vercel-ai-gateway",
+		modelId: "minimax/minimax-m3",
+		apiKeyEnv: "AI_GATEWAY_API_KEY",
+		reasoning: { enabled: true },
+		expectedBody: { reasoning: { enabled: true } },
+		unexpectedBodyKeys: ["thinking"],
+	});
+	addCase({
+		label: "Vercel AI Gateway MiniMax M3 reasoning disabled",
+		providerId: "vercel-ai-gateway",
+		modelId: "minimax/minimax-m3",
+		apiKeyEnv: "AI_GATEWAY_API_KEY",
+		reasoning: { enabled: false },
+		expectedBody: { reasoning: { exclude: true } },
+		unexpectedBodyKeys: ["thinking"],
+	});
+	addCase({
+		label: "Cline Gateway MiniMax M3 reasoning enabled",
+		providerId: "cline",
+		modelId: "minimax/minimax-m3",
+		apiKeyEnv: "CLINE_API_KEY",
+		reasoning: { enabled: true },
+		expectedBody: { reasoning: { enabled: true } },
+		unexpectedBodyKeys: ["thinking"],
+	});
+	addCase({
+		label: "Cline Gateway MiniMax M3 reasoning disabled",
+		providerId: "cline",
+		modelId: "minimax/minimax-m3",
+		apiKeyEnv: "CLINE_API_KEY",
+		reasoning: { enabled: false },
+		expectedBody: { reasoning: { enabled: false } },
+		unexpectedBodyKeys: ["thinking"],
+	});
+
+	return cases;
+}
+
+function getCapturedRequests(config: ProviderConfig): CapturedRequest[] {
+	const metadata = config.metadata as
+		| { capturedRequests?: CapturedRequest[] }
+		| undefined;
+	return metadata?.capturedRequests ?? [];
+}
+
+describe("live MiniMax M3 provider routing mechanics", () => {
+	const runLive = LIVE_TEST_ENABLED ? it : it.skip;
+
+	runLive(
+		"sends explicit reasoning controls for every MiniMax M3 route",
+		async () => {
+			const failures: string[] = [];
+
+			for (const liveCase of buildCases()) {
+				try {
+					const metrics = await runLiveRequest(liveCase.config);
+					expect(metrics.usageSeen, liveCase.label).toBe(true);
+					const request = getCapturedRequests(liveCase.config).at(-1);
+					expect(request, liveCase.label).toBeDefined();
+					const body = await readRequestBody(request?.body);
+					expect(body, liveCase.label).toEqual(
+						expect.objectContaining(liveCase.expectedBody),
+					);
+					for (const key of liveCase.unexpectedBodyKeys ?? []) {
+						expect(body, liveCase.label).not.toHaveProperty(key);
+					}
+				} catch (error) {
+					failures.push(
+						`${liveCase.label}: ${
+							error instanceof Error ? error.message : String(error)
+						}`,
+					);
+				}
+			}
+
+			if (failures.length > 0) {
+				throw new Error(
+					`MiniMax M3 routing failures (${failures.length}):\n${failures.join(
+						"\n",
+					)}`,
+				);
+			}
+		},
+		PROVIDER_TIMEOUT_MS,
+	);
+});

--- a/sdk/packages/llms/src/tests/provider-live-minimax-routing.test.ts
+++ b/sdk/packages/llms/src/tests/provider-live-minimax-routing.test.ts
@@ -135,6 +135,12 @@ function buildCases(): LiveCase[] {
 		apiKeyEnv: "MINIMAX_API_KEY",
 		reasoning: { enabled: true },
 		expectedBody: { thinking: { type: "adaptive" } },
+		unexpectedBodyKeys: [
+			"reasoning",
+			"effort",
+			"reasoningEffort",
+			"reasoningSummary",
+		],
 	});
 	addCase({
 		label: "direct MiniMax M3 reasoning disabled",
@@ -143,6 +149,12 @@ function buildCases(): LiveCase[] {
 		apiKeyEnv: "MINIMAX_API_KEY",
 		reasoning: { enabled: false },
 		expectedBody: { thinking: { type: "disabled" } },
+		unexpectedBodyKeys: [
+			"reasoning",
+			"effort",
+			"reasoningEffort",
+			"reasoningSummary",
+		],
 	});
 	addCase({
 		label: "OpenRouter MiniMax M3 reasoning enabled",

--- a/sdk/packages/shared/src/llms/gateway.ts
+++ b/sdk/packages/shared/src/llms/gateway.ts
@@ -35,7 +35,10 @@ export type GatewayModelCapability =
 export type GatewayPromptCacheStrategy = "anthropic-automatic";
 export type GatewayUsageCostDisplay = "show" | "hide";
 export type GatewayPromptCacheFormat = "anthropic-cache-control";
-export type GatewayReasoningFormat = "anthropic-thinking" | "glm-thinking";
+export type GatewayReasoningFormat =
+	| "anthropic-thinking"
+	| "glm-thinking"
+	| "minimax-thinking";
 export type GatewayModelRoute =
 	| { matcher: "anthropic-compatible" }
 	| {


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Fixes MiniMax M3 thinking/reasoning controls across the SDK provider routes using a live-test-first workflow.

The live MiniMax M3 routing test was first run against the unpatched code and proved these outbound request mechanics were wrong:

- Direct `minimax` with reasoning disabled omitted `thinking: { type: "disabled" }`.
- `vercel-ai-gateway` MiniMax M3 enabled/disabled omitted the gateway `reasoning` control.
- `cline` MiniMax M3 enabled leaked a generic `thinking` field beside the Cline Gateway `reasoning` control.

OpenRouter MiniMax M3 already passed the pre-fix live test with `reasoning.enabled` / `reasoning.exclude`, so this PR leaves OpenRouter mechanics unchanged.

The fix adds MiniMax M3-specific routing metadata and provider-option rules, plus a narrow direct-MiniMax shim for the AI SDK Anthropic provider path because the current AI SDK serializes `thinking.type=enabled|adaptive` but drops `thinking.type=disabled`.

### Test Procedure

Pre-fix proof:

- `LLMS_LIVE_MINIMAX_ROUTING_TESTS=1 LLMS_LIVE_PROVIDER_TIMEOUT_MS=180000 bunx vitest run --config vitest.config.ts src/tests/provider-live-minimax-routing.test.ts --reporter verbose`
- Failed on direct MiniMax disabled, Vercel enabled/disabled, and Cline enabled request mechanics.
- OpenRouter enabled/disabled passed before any implementation change.

Post-fix verification:

- `bun run typecheck`
- `bunx vitest run --config vitest.config.ts src/providers/builtins.test.ts src/providers/routing/provider-options.test.ts src/providers/vendors/minimax-thinking.test.ts src/providers/vendors/anthropic.test.ts --reporter verbose`
- `LLMS_LIVE_MINIMAX_ROUTING_TESTS=1 LLMS_LIVE_PROVIDER_TIMEOUT_MS=180000 bunx vitest run --config vitest.config.ts src/tests/provider-live-minimax-routing.test.ts --reporter verbose`

Additional checks run during development:

- `bunx vitest run --config vitest.config.ts src/providers/gateway.test.ts --reporter verbose`
- `git diff --check -- sdk`

The live test now passes across all 8 MiniMax M3 cases: direct MiniMax, OpenRouter, Vercel AI Gateway, and Cline Gateway, each with reasoning enabled and disabled.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - SDK provider routing change.

### Additional Notes

Claude Code was consulted on the strategy and diff. It agreed the fix is evidence-driven and correctly scoped. It recommended tracking MiniMax M2.x disabled-thinking behavior separately, but not changing it here without its own live failing test.
