### PR TITLE
fix(sdk): make model-not-found API errors actionable in the webview

### DIFF
--- a/apps/vscode/src/sdk/message-translator.test.ts
+++ b/apps/vscode/src/sdk/message-translator.test.ts
@@ -1113,6 +1113,89 @@ describe("translateSessionEvent — agent_event error", () => {
 		expect(parsed.code).toBe("SPEND_LIMIT_EXCEEDED")
 		expect(parsed.providerId).toBe("cline")
 	})
+
+	it("rewrites Anthropic bare 'model: <id>' 404 into an actionable message", () => {
+		const state = new MessageTranslatorState(undefined, () => "anthropic")
+		const event: CoreSessionEvent = {
+			type: "agent_event",
+			payload: {
+				sessionId: "session-1",
+				event: {
+					type: "error",
+					error: { message: "model: claude-3-haiku-20240307" },
+				} as AgentEvent,
+			},
+		}
+
+		const result = translateSessionEvent(event, state)
+		expect(result.messages).toHaveLength(2)
+
+		const failedText = result.messages[1].text!
+		expect(failedText).toContain("claude-3-haiku-20240307")
+		expect(failedText).toContain("was not found")
+		expect(failedText).toContain("API Configuration settings")
+	})
+
+	it("rewrites a 'model not found' message into an actionable message", () => {
+		const state = new MessageTranslatorState()
+		const event: CoreSessionEvent = {
+			type: "agent_event",
+			payload: {
+				sessionId: "session-1",
+				event: {
+					type: "error",
+					error: { message: "The model `gpt-foo` does not exist" },
+				} as AgentEvent,
+			},
+		}
+
+		const result = translateSessionEvent(event, state)
+		expect(result.messages).toHaveLength(2)
+
+		const failedText = result.messages[1].text!
+		expect(failedText).toContain("gpt-foo")
+		expect(failedText).toContain("API Configuration settings")
+	})
+
+	it("does not rewrite an unrelated error that merely mentions a model", () => {
+		const state = new MessageTranslatorState()
+		const rawMessage = "The requested feature model is not available in your plan"
+		const event: CoreSessionEvent = {
+			type: "agent_event",
+			payload: {
+				sessionId: "session-1",
+				event: {
+					type: "error",
+					error: { message: rawMessage },
+				} as AgentEvent,
+			},
+		}
+
+		const result = translateSessionEvent(event, state)
+		const failedText = result.messages[1].text!
+		expect(failedText).toBe(rawMessage)
+		expect(failedText).not.toContain("API Configuration settings")
+	})
+
+	it("leaves an auth error mentioning a model untouched", () => {
+		const state = new MessageTranslatorState()
+		const rawMessage = "Invalid API key for model gpt-4"
+		const event: CoreSessionEvent = {
+			type: "agent_event",
+			payload: {
+				sessionId: "session-1",
+				event: {
+					type: "error",
+					error: { message: rawMessage },
+				} as AgentEvent,
+			},
+		}
+
+		const result = translateSessionEvent(event, state)
+		const failedText = result.messages[1].text!
+		expect(failedText).toBe(rawMessage)
+		expect(failedText).not.toContain("API Configuration settings")
+	})
 })
 
 // ---------------------------------------------------------------------------

--- a/apps/vscode/src/sdk/message-translator.ts
+++ b/apps/vscode/src/sdk/message-translator.ts
@@ -1876,15 +1876,35 @@ export function historyItemToSessionFields(item: {
 	}
 }
 
+const MODEL_NOT_FOUND_GUIDANCE =
+	"This model may be retired or unavailable on your account. Switch to a different model in API Configuration settings, then retry."
+
 /**
- * Reshape an SDK error into the serialized ClineError JSON format the webview
- * expects. The webview's ErrorRow uses ClineError.parse() which needs specific
- * fields (`code`, `providerId`, `details`) to detect error types and render
- * appropriate UI (e.g. "Buy Credits" button for insufficient credits).
- *
- * The SDK error's `message` may contain embedded JSON from the API response.
- * We try to extract it and produce a proper ClineError-serialized payload.
- * If parsing fails, we fall back to the raw error message.
+ * Rewrite a model-not-found error into actionable guidance, or undefined if the
+ * message is not one. The provider's HTTP status is stripped upstream, so this
+ * matches on text rather than a status code.
+ */
+function describeModelNotFoundError(rawMessage: string): string | undefined {
+	// Anthropic's 404 body collapses to a bare "model: <id>" label.
+	const bareModelLabel = rawMessage.match(/^\s*model:\s*(\S+)\s*$/i)
+	if (bareModelLabel) {
+		return `Model "${bareModelLabel[1]}" was not found. ${MODEL_NOT_FOUND_GUIDANCE}`
+	}
+
+	// Keep the not-found signal in the same clause as "model" so errors that
+	// merely mention one (plan gating, deprecated features) are left untouched.
+	const modelNotFound = /\bmodel\b[^.,;:]*\b(not[ _]?found|does not exist|no such model|unknown model)\b/i
+	if (modelNotFound.test(rawMessage)) {
+		return `${rawMessage} ${MODEL_NOT_FOUND_GUIDANCE}`
+	}
+
+	return undefined
+}
+
+/**
+ * Reshape an SDK error into the serialized ClineError JSON the webview's
+ * ErrorRow expects (`code`, `providerId`, `details`), extracting structured
+ * info from the error message when present and falling back to raw text.
  */
 export function reshapeErrorForWebview(
 	error: { message?: string; status?: number; code?: string },
@@ -1948,6 +1968,10 @@ export function reshapeErrorForWebview(
 					message: rawMessage,
 				},
 			})
+		}
+		const notFoundMessage = describeModelNotFoundError(rawMessage)
+		if (notFoundMessage) {
+			return notFoundMessage
 		}
 		return rawMessage
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description


#### Make model-not-found API errors actionable
##### Problem
Selecting a retired/unavailable model (e.g. Anthropic returns HTTP 404 for claude-3-haiku-20240307) surfaced a cryptic red model: claude-3-haiku-20240307 label in chat. The SDK strips the HTTP status, so reshapeErrorForWebview fell through to the raw string — no indication the model is gone or how to recover.
##### Fix
Detect model-not-found errors in the plain-text branch of reshapeErrorForWebview and rewrite them into a clear sentence that names the model and tells the user to switch models in API Configuration settings, then retry (switch framed as a precondition so users don't loop on the Retry button).
Detection is text-based (status unavailable here) and anchored to the word "model" + a not-found signal, so unrelated errors that merely mention a model (plan gating, deprecated features) pass through untouched.

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

Original repro: Try Anthropic provider and set `claude-3-haiku-20240307`, then send a prompt.

Added cases for the bare model: <id> form, a generic does not exist form, and two negative cases (plan gating + auth error mentioning a model) that must remain unchanged. 105/105 passing, typecheck clean.



<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

| Before | After |
| --- | --- |
| <img width="1400" height="1634" alt="image" src="https://github.com/user-attachments/assets/c631ee71-09d4-4b7c-ad8b-fb16cd728f16" /> | <img width="1158" height="1210" alt="image" src="https://github.com/user-attachments/assets/52c4bedf-f124-456f-9c9d-daf6c456d673" /> | 

### Additional Notes

<!-- Add any additional notes for reviewers -->
