### PR TITLE
Improve bug report form: rename surface dropdown, add IDE/CLI diagnostics

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,10 +7,10 @@ body:
       value: |
         **Important:** All bug reports must be reproducible using Claude Sonnet 4.5. Cline uses complex prompts so less capable models may not work as expected.
   - type: dropdown
-    id: plugin-type
+    id: cline-surface
     attributes:
-      label: Plugin Type
-      description: Which plugin are you reporting a bug for?
+      label: Cline Surface
+      description: Which Cline surface are you reporting a bug for?
       options:
         - VSCode Extension
         - JetBrains Plugin
@@ -57,6 +57,18 @@ body:
       label: Provider/Model
       description: What provider and model were you using when the issue occurred?
       placeholder: 'e.g., cline:anthropic/claude-sonnet-4.5, gemini:gemini-2.5-pro-exp-03-25'
+    validations:
+      required: false
+  - type: textarea
+    id: ide-diagnostics
+    attributes:
+      label: IDE / CLI Diagnostics
+      description: |
+        Paste the "About" diagnostics for your Cline surface. This captures the IDE build, runtime, and host details we need.
+        - VSCode Extension: open `Help → About` (Windows/Linux) or `Code → About Visual Studio Code` (macOS), then copy the info.
+        - JetBrains Plugin: open `Help → About` (Windows/Linux) or `<IDE name> → About` (macOS), then click `Copy` to grab build, runtime, OS, memory, and cores.
+        - CLI: there is no About dialog. Run `cline --version` and paste the output.
+      placeholder: Paste the copied About info or `cline --version` output here.
     validations:
       required: false
   - type: textarea

--- a/.github/workflows/repo-label-issues.yml
+++ b/.github/workflows/repo-label-issues.yml
@@ -17,7 +17,7 @@ jobs:
             const labels = context.payload.issue.labels.map(l => l.name);
 
             // Check if JetBrains Plugin is selected
-            if (body.match(/###\s*Plugin Type\s*\n+JetBrains Plugin/i)) {
+            if (body.match(/###\s*Cline Surface\s*\n+JetBrains Plugin/i)) {
               if (!labels.includes('JetBrains')) {
                 await github.rest.issues.addLabels({
                   owner: context.repo.owner,
@@ -29,7 +29,7 @@ jobs:
             }
 
             // Check if VSCode Extension is selected
-            if (body.match(/###\s*Plugin Type\s*\n+VSCode Extension/i)) {
+            if (body.match(/###\s*Cline Surface\s*\n+VSCode Extension/i)) {
               if (!labels.includes('VS Code')) {
                 await github.rest.issues.addLabels({
                   owner: context.repo.owner,
@@ -41,7 +41,7 @@ jobs:
             }
 
             // Check if CLI is selected
-            if (body.match(/###\s*Plugin Type\s*\n+CLI/i)) {
+            if (body.match(/###\s*Cline Surface\s*\n+CLI/i)) {
               if (!labels.includes('CLI')) {
                 await github.rest.issues.addLabels({
                   owner: context.repo.owner,


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

Two small improvements to the generic bug report template:

 - Renamed the "Plugin Type" dropdown to "Cline Surface." CLI isn't a plugin, so the old label was inaccurate. The option values (VSCode Extension / JetBrains Plugin / CLI) keep each choice unambiguous.
 - Added an "IDE / CLI Diagnostics" field with per-surface copy-paste steps for grabbing About info: VSCode Help → About, JetBrains Help → About (Copy button), and a CLI exception using cline --version.


<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
