### PR TITLE
feat(sdk): add Claude Fable 5 model support

### DIFF
--- a/sdk/packages/llms/src/catalog/catalog.generated.ts
+++ b/sdk/packages/llms/src/catalog/catalog.generated.ts
@@ -14,7 +14,7 @@ export const GENERATED_PROVIDER_MODELS: {
 	version: number;
 	providers: Record<string, Record<string, ModelInfo>>;
 } = {
-	version: 1780978764194,
+	version: 1781029304816,
 	providers: {
 		aihubmix: {
 			"glm-5v-turbo": {
@@ -1125,6 +1125,22 @@ export const GENERATED_PROVIDER_MODELS: {
 			},
 		},
 		anthropic: {
+			"claude-fable-5": {
+				id: "claude-fable-5",
+				name: "Claude Fable 5",
+				contextWindow: 1000000,
+				maxInputTokens: 1000000,
+				maxTokens: 128000,
+				capabilities: ["images", "files", "tools", "reasoning", "prompt-cache"],
+				pricing: {
+					input: 10,
+					output: 50,
+					cacheRead: 1,
+					cacheWrite: 12.5,
+				},
+				releaseDate: "2026-06-09",
+				family: "claude-fable",
+			},
 			"claude-opus-4-8": {
 				id: "claude-opus-4-8",
 				name: "Claude Opus 4.8",
@@ -11313,6 +11329,29 @@ export const GENERATED_PROVIDER_MODELS: {
 				},
 				releaseDate: "2026-05-29",
 			},
+			"anthropic/claude-fable-5": {
+				id: "anthropic/claude-fable-5",
+				name: "Claude Fable 5",
+				contextWindow: 1000000,
+				maxInputTokens: 1000000,
+				maxTokens: 128000,
+				capabilities: [
+					"images",
+					"files",
+					"tools",
+					"reasoning",
+					"structured_output",
+					"prompt-cache",
+				],
+				pricing: {
+					input: 10,
+					output: 50,
+					cacheRead: 1,
+					cacheWrite: 12.5,
+				},
+				releaseDate: "2026-06-09",
+				family: "claude",
+			},
 			"anthropic/claude-opus-4.8": {
 				id: "anthropic/claude-opus-4.8",
 				name: "Claude Opus 4.8",
@@ -18015,6 +18054,29 @@ export const GENERATED_PROVIDER_MODELS: {
 			},
 		},
 		"vercel-ai-gateway": {
+			"anthropic/claude-fable-5": {
+				id: "anthropic/claude-fable-5",
+				name: "Claude Fable 5",
+				contextWindow: 1000000,
+				maxInputTokens: 1000000,
+				maxTokens: 128000,
+				capabilities: [
+					"images",
+					"files",
+					"tools",
+					"reasoning",
+					"temperature",
+					"prompt-cache",
+				],
+				pricing: {
+					input: 10,
+					output: 50,
+					cacheRead: 1,
+					cacheWrite: 12.5,
+				},
+				releaseDate: "2026-06-09",
+				family: "claude",
+			},
 			"nvidia/nemotron-3-ultra-550b-a55b": {
 				id: "nvidia/nemotron-3-ultra-550b-a55b",
 				name: "Nemotron 3 Ultra",

--- a/sdk/packages/llms/src/providers/builtins.test.ts
+++ b/sdk/packages/llms/src/providers/builtins.test.ts
@@ -97,6 +97,51 @@ describe("built-in provider metadata", () => {
 		);
 	});
 
+	it("includes Claude Fable 5 in Anthropic, OpenRouter, Vercel AI Gateway, and Cline model lists", async () => {
+		const anthropicModels = await getModelsForProvider("anthropic");
+		const openRouterModels = await getModelsForProvider("openrouter");
+		const vercelModels = await getModelsForProvider("vercel-ai-gateway");
+		const clineModels = await getModelsForProvider("cline");
+
+		expect(anthropicModels["claude-fable-5"]).toEqual(
+			expect.objectContaining({
+				name: "Claude Fable 5",
+				contextWindow: 1_000_000,
+				maxTokens: 128_000,
+				capabilities: expect.arrayContaining([
+					"tools",
+					"reasoning",
+					"prompt-cache",
+				]),
+				pricing: expect.objectContaining({
+					input: 10,
+					output: 50,
+					cacheRead: 1,
+					cacheWrite: 12.5,
+				}),
+			}),
+		);
+		expect(openRouterModels["anthropic/claude-fable-5"]).toEqual(
+			expect.objectContaining({
+				id: "anthropic/claude-fable-5",
+				name: "Claude Fable 5",
+				contextWindow: 1_000_000,
+				maxTokens: 128_000,
+			}),
+		);
+		expect(vercelModels["anthropic/claude-fable-5"]).toEqual(
+			expect.objectContaining({
+				id: "anthropic/claude-fable-5",
+				name: "Claude Fable 5",
+				contextWindow: 1_000_000,
+			}),
+		);
+		expect(clineModels["anthropic/claude-fable-5"]).toEqual(
+			openRouterModels["anthropic/claude-fable-5"],
+		);
+		expect(clineModels["anthropic/claude-opus-4.8"]).toBeDefined();
+	});
+
 	it("routes native Z.AI providers through GLM thinking metadata", async () => {
 		for (const providerId of ["zai", "zai-coding-plan"] as const) {
 			await expect(getProvider(providerId)).resolves.toMatchObject({


### PR DESCRIPTION
## Summary
- add Claude Fable 5 to the SDK model catalog for Anthropic, OpenRouter, and Vercel AI Gateway
- keep Cline CLI support on the existing OpenRouter-backed model list so `anthropic/claude-fable-5` is discoverable without Cline-specific special casing
- add registry coverage for Anthropic, OpenRouter, Vercel AI Gateway, and Cline model discovery

Note: `models.dev` currently includes Fable for Anthropic and Vercel AI Gateway, but not OpenRouter yet. OpenRouter's live model page already exposes `anthropic/claude-fable-5`, so this catalog update includes the OpenRouter entry directly.

## Tests
- `bun -F @cline/llms test src/providers/builtins.test.ts`
- `bun -F @cline/llms typecheck`
- pre-commit: `bun run types`, `bun biome check --no-errors-on-unmatched --files-ignore-unknown=true`