### PR TITLE
fix(vscode): expand remote workflow/skill slash commands before send ENG-2036

### DIFF
--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -7,7 +7,13 @@
 import * as fs from "node:fs/promises"
 import * as os from "node:os"
 import * as path from "node:path"
-import { type PreparedRemoteConfigCoreIntegration, type SessionHistoryRecord, setTelemetryOptOutGlobally } from "@cline/core"
+import {
+	createUserInstructionConfigService,
+	type PreparedRemoteConfigCoreIntegration,
+	type SessionHistoryRecord,
+	setTelemetryOptOutGlobally,
+	type UserInstructionConfigService,
+} from "@cline/core"
 import { formatDisplayUserInput, type RemoteConfig, type RemoteConfigBundle } from "@cline/shared"
 import type { ModelInfo } from "@shared/api"
 import type { ChatContent } from "@shared/ChatContent"
@@ -196,6 +202,18 @@ export class Controller {
 	// Timer for periodic remote config fetching (enterprise policy enforcement)
 	private remoteConfigTimer?: NodeJS.Timeout
 	private remoteConfigCoreIntegration?: PreparedRemoteConfigCoreIntegration
+
+	// Watches user-instruction files (workflows/skills/rules), including those
+	// materialized by remote config under `.cline/remote-config/`. Used to expand
+	// `/workflow` and `/skill` slash commands into their instruction bodies before
+	// the prompt reaches the model — the same mechanism the CLI uses in
+	// `buildUserInputMessage`. The agent loop never auto-expands commands, so this
+	// host-side expansion is required. Created lazily (memoized as a promise to be
+	// race-free under concurrent first sends) and rebuilt if the workspace root
+	// changes.
+	private userInstructionService?: Promise<UserInstructionConfigService>
+	private userInstructionServiceRoot?: string
+	private isDisposed = false
 
 	get remoteConfig(): RemoteConfig | undefined {
 		return this.remoteConfigCoreIntegration?.prepared.bundle?.remoteConfig
@@ -545,6 +563,10 @@ export class Controller {
 		await refreshSdkRemoteConfig(this, {
 			workspacePath: await this.getRemoteConfigWorkspacePath(),
 		})
+		// Remote config may have materialized new workflows/skills/rules under
+		// `.cline/remote-config/`. Refresh the watcher so slash-command expansion
+		// sees them without waiting on filesystem events.
+		await this.refreshUserInstructionWatchers()
 	}
 
 	async setRemoteConfigCoreIntegration(integration: PreparedRemoteConfigCoreIntegration | undefined): Promise<void> {
@@ -567,6 +589,12 @@ export class Controller {
 			this.remoteConfigTimer = undefined
 		}
 		await this.setRemoteConfigCoreIntegration(undefined)
+		this.isDisposed = true
+		const userInstructionServicePromise = this.userInstructionService
+		this.userInstructionService = undefined
+		if (userInstructionServicePromise) {
+			await userInstructionServicePromise.then((service) => service.stop()).catch(() => {})
+		}
 		this.messages.cancelPendingSave()
 		// Clear MCP tool list change callback before disposing McpHub
 		this.mcpHub?.clearToolListChangeCallback()
@@ -579,10 +607,84 @@ export class Controller {
 		Logger.log("[SdkController] Disposed")
 	}
 
-	// ---- Context mention resolution ----
+	// ---- Slash command + context mention resolution ----
 
 	/**
-	 * Resolve `@` context mentions in user text before sending to the SDK.
+	 * Lazily create (or rebuild on workspace-root change) the user-instruction
+	 * watcher. Pointed at the workspace root so it discovers both local config
+	 * (`.clinerules/workflows`, `.cline/workflows`, …) and remote-config files
+	 * materialized under `<root>/.cline/remote-config/{workflows,skills,rules}`.
+	 *
+	 * `workspaceRoot` is resolved by the caller so the memoization check below runs
+	 * synchronously on entry — there is no `await` before the assignment, so
+	 * concurrent callers cannot create two competing watchers.
+	 */
+	private ensureUserInstructionService(workspaceRoot: string): Promise<UserInstructionConfigService> {
+		if (this.userInstructionService && this.userInstructionServiceRoot === workspaceRoot) {
+			return this.userInstructionService
+		}
+		// Workspace root changed: stop the previous watcher once it settles.
+		const previous = this.userInstructionService
+		if (previous) {
+			previous.then((service) => service.stop()).catch(() => {})
+		}
+		this.userInstructionServiceRoot = workspaceRoot
+		this.userInstructionService = (async () => {
+			const service = createUserInstructionConfigService({
+				workflows: { workspacePath: workspaceRoot },
+				skills: { workspacePath: workspaceRoot },
+				rules: { workspacePath: workspaceRoot },
+			})
+			// start() runs the initial scan; await so the snapshot is populated
+			// before the first resolveRuntimeSlashCommand call.
+			await service.start().catch((error) => {
+				Logger.warn("[SdkController] Failed to start user instruction watcher:", error)
+			})
+			return service
+		})()
+		return this.userInstructionService
+	}
+
+	/**
+	 * Expand a leading `/workflow` or `/skill` slash command into its instruction
+	 * body. Mirrors the CLI's `buildUserInputMessage`. Returns the input unchanged
+	 * if it is not a known command or expansion fails.
+	 */
+	private async resolveSlashCommands(text: string): Promise<string> {
+		if (this.isDisposed) {
+			return text
+		}
+		try {
+			const workspaceRoot = await this.getWorkspaceRoot()
+			const service = await this.ensureUserInstructionService(workspaceRoot)
+			return service.resolveRuntimeSlashCommand(text)
+		} catch (error) {
+			Logger.warn("[SdkController] Slash command resolution failed, using raw text:", error)
+			return text
+		}
+	}
+
+	/**
+	 * Refresh the user-instruction watcher after remote config is (re)materialized
+	 * so newly written workflows/skills/rules are picked up immediately rather than
+	 * waiting on filesystem watch events.
+	 */
+	private async refreshUserInstructionWatchers(): Promise<void> {
+		const servicePromise = this.userInstructionService
+		if (!servicePromise) {
+			return
+		}
+		try {
+			const service = await servicePromise
+			await Promise.all([service.refreshType("workflow"), service.refreshType("skill"), service.refreshType("rule")])
+		} catch (error) {
+			Logger.warn("[SdkController] Failed to refresh user instruction watchers:", error)
+		}
+	}
+
+	/**
+	 * Expand slash commands, then resolve `@` context mentions in user text
+	 * before sending to the SDK.
 	 *
 	 * `parseMentions()` inlines file content (`@/path`), URL content
 	 * (`@https://...`), diagnostics (`@problems`), git state (`@git-changes`),
@@ -592,9 +694,11 @@ export class Controller {
 	 * mentions, so the LLM would otherwise never see the referenced content.
 	 */
 	private async resolveContextMentions(text: string): Promise<string> {
-		// Quick check: skip if there are no @ mentions
-		if (!mentionRegexGlobal.test(text)) {
-			return text
+		const withCommands = await this.resolveSlashCommands(text)
+
+		// Quick check: skip mention parsing if there are no @ mentions
+		if (!mentionRegexGlobal.test(withCommands)) {
+			return withCommands
 		}
 		// Reset lastIndex since RegExp.test() advances it for global regexes
 		mentionRegexGlobal.lastIndex = 0
@@ -603,12 +707,12 @@ export class Controller {
 			const cwd = await this.getWorkspaceRoot()
 			const urlContentFetcher = new UrlContentFetcher()
 			const workspaceManager = await this.ensureWorkspaceManager()
-			const resolved = await parseMentions(text, cwd, urlContentFetcher, undefined, workspaceManager)
+			const resolved = await parseMentions(withCommands, cwd, urlContentFetcher, undefined, workspaceManager)
 			Logger.log(`[SdkController] Resolved context mentions (${text.length} → ${resolved.length} chars)`)
 			return resolved
 		} catch (error) {
 			Logger.error("[SdkController] Failed to resolve context mentions, using raw text:", error)
-			return text
+			return withCommands
 		}
 	}
 

--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -620,6 +620,11 @@ export class Controller {
 	 * concurrent callers cannot create two competing watchers.
 	 */
 	private ensureUserInstructionService(workspaceRoot: string): Promise<UserInstructionConfigService> {
+		// dispose() may have run during an awaited gap in the caller. Don't
+		// resurrect a watcher the dispose path will never stop again.
+		if (this.isDisposed) {
+			return Promise.reject(new Error("Controller disposed"))
+		}
 		if (this.userInstructionService && this.userInstructionServiceRoot === workspaceRoot) {
 			return this.userInstructionService
 		}
@@ -708,7 +713,7 @@ export class Controller {
 			const urlContentFetcher = new UrlContentFetcher()
 			const workspaceManager = await this.ensureWorkspaceManager()
 			const resolved = await parseMentions(withCommands, cwd, urlContentFetcher, undefined, workspaceManager)
-			Logger.log(`[SdkController] Resolved context mentions (${text.length} → ${resolved.length} chars)`)
+			Logger.log(`[SdkController] Resolved context mentions (${withCommands.length} → ${resolved.length} chars)`)
 			return resolved
 		} catch (error) {
 			Logger.error("[SdkController] Failed to resolve context mentions, using raw text:", error)


### PR DESCRIPTION
### Related Issue

**Issue:** ENG-2036 — Remote Config Workflows don't work well (Linear)

### Description

In the SDK-backed VS Code extension, a `/workflow` (or `/skill`) slash command typed into chat was sent to the model **verbatim** — the command was never expanded into its instruction body, so remote-config workflows never actually ran (the model would improvise instead of executing the workflow).

Root cause: slash-command expansion is host-driven. The agent loop never auto-expands commands, and the controller's pre-send path (`resolveContextMentions`) only resolved `@` mentions — it did no command expansion. The CLI does this expansion in `buildUserInputMessage` via the SDK's `UserInstructionConfigService`; the extension had no equivalent.

Fix: give the controller a `UserInstructionConfigService` (from `@cline/core`) that watches the workspace root — including remote-config files materialized under `<root>/.cline/remote-config/{workflows,skills,rules}` — and expand the leading slash command before the prompt reaches the model.

- Lazily created and memoized as a promise (race-free under concurrent first sends), rebuilt if the workspace root changes, and stopped on `dispose()`.
- Watchers are refreshed after each remote-config sync so newly materialized workflows/skills/rules are picked up without waiting on filesystem events.
- Covers workflows, skills, and rules, aligning extension behavior with the CLI.

This replaces an earlier stop-gap (`resolve-workflow-slash-command.ts`) that expanded commands directly from `StateManager`; that file and its test were removed in favor of the SDK-aligned mechanism.

### Test Procedure

- `npx tsc --noEmit` in `apps/vscode` — passes.
- Vitest unit suite and Biome lint — pass.
- Verified no stray references to the removed stop-gap utility remain.
- Manually confirmed a remote `/write-poem` workflow now expands to its instruction body before reaching the model (previously sent as raw `/write-poem`).

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore
-   [x] Tests are passing and code is formatted and linted
-   [x] I have reviewed contributor guidelines

### Additional Notes

Targets the `dpc/sdk-migration-simpler-login` migration branch. The SDK/CLI-side groundwork is tracked separately in ENG-2036.

### Screenshots

<img width="425" height="121" alt="Screenshot 2026-06-09 at 12 23 56 PM" src="https://github.com/user-attachments/assets/7bfa7a05-790b-4405-9c1c-e4577b13157b" />
<img width="433" height="211" alt="Screenshot 2026-06-09 at 12 24 13 PM" src="https://github.com/user-attachments/assets/753fcc4b-8069-4b17-a23b-b25868ef0f2c" />
<img width="969" height="336" alt="Screenshot 2026-06-09 at 12 24 23 PM" src="https://github.com/user-attachments/assets/a01d31ea-681f-4e88-96c9-e32984dd0675" />
