### PR TITLE
Format vscode using biome higher order rules

### DIFF
--- a/apps/biome.json
+++ b/apps/biome.json
@@ -1,7 +1,9 @@
 {
 	"$schema": "https://biomejs.dev/schemas/2.4.5/schema.json",
 	"root": false,
-	"extends": ["../sdk/biome.json"],
+	"extends": [
+		"../sdk/biome.json"
+	],
 	"linter": {
 		"rules": {
 			"a11y": {

--- a/apps/vscode/biome.jsonc
+++ b/apps/vscode/biome.jsonc
@@ -50,8 +50,8 @@
 				"useEnumInitializers": "off",
 				"useSelfClosingElements": "info",
 				"useSingleVarDeclarator": "off",
-				"useNumberNamespace": "info",
-				"noInferrableTypes": "info",
+				"useNumberNamespace": "off",
+				"noInferrableTypes": "off",
 				"useTemplate": "info",
 				"noUselessElse": "info"
 			},

--- a/biome.json
+++ b/biome.json
@@ -15,5 +15,109 @@
     },
     "linter": {
         "enabled": true
-    }
+    },
+    "overrides": [
+        {
+            "includes": [
+                "apps/vscode/**"
+            ],
+            "assist": {
+                "enabled": true,
+                "actions": {
+                    "source": {
+                        "organizeImports": "on",
+                        "useSortedAttributes": "on"
+                    }
+                }
+            },
+            "linter": {
+                "rules": {
+                    "recommended": true,
+                    "correctness": {
+                        "useExhaustiveDependencies": "info",
+                        "noUndeclaredVariables": "off",
+                        "noEmptyPattern": "info",
+                        "useJsxKeyInIterable": "off",
+                        "noInnerDeclarations": "off",
+                        "useHookAtTopLevel": "info",
+                        "useYield": "info",
+                        "noConstructorReturn": "off",
+                        "noInvalidPositionAtImportRule": "off",
+                        "noSwitchDeclarations": "off",
+                        "noUnusedImports": "error"
+                    },
+                    "a11y": "info",
+                    "style": {
+                        "useNodejsImportProtocol": "off",
+                        "useImportType": "off",
+                        "useBlockStatements": "off",
+                        "useNamingConvention": "off",
+                        "useThrowOnlyError": "info",
+                        "useConsistentArrayType": "off",
+                        "noParameterAssign": "off",
+                        "useAsConstAssertion": "off",
+                        "useDefaultParameterLast": "off",
+                        "noNonNullAssertion": "info",
+                        "useEnumInitializers": "off",
+                        "useSelfClosingElements": "info",
+                        "useSingleVarDeclarator": "off",
+                        "useNumberNamespace": "off",
+                        "noInferrableTypes": "off",
+                        "useTemplate": "info",
+                        "noUselessElse": "info"
+                    },
+                    "suspicious": {
+                        "noDoubleEquals": "warn",
+                        "noImplicitAnyLet": "info",
+                        "noThenProperty": "off",
+                        "noAsyncPromiseExecutor": "info",
+                        "noImportAssign": "off",
+                        "noExplicitAny": "info",
+                        "noControlCharactersInRegex": "warn",
+                        "noShadowRestrictedNames": "off",
+                        "noArrayIndexKey": "info",
+                        "noAssignInExpressions": "info",
+                        "useIterableCallbackReturn": "info"
+                    },
+                    "complexity": {
+                        "noUselessConstructor": "info",
+                        "useOptionalChain": "info",
+                        "noBannedTypes": "warn",
+                        "useLiteralKeys": "info",
+                        "noUselessCatch": "info",
+                        "noUselessSwitchCase": "info",
+                        "noStaticOnlyClass": "info"
+                    },
+                    "security": {
+                        "noDangerouslySetInnerHtml": "info"
+                    }
+                }
+            },
+            "formatter": {
+                "enabled": true,
+                "indentStyle": "tab",
+                "indentWidth": 4,
+                "lineWidth": 130,
+                "lineEnding": "lf",
+                "formatWithErrors": true
+            },
+            "javascript": {
+                "formatter": {
+                    "semicolons": "asNeeded",
+                    "arrowParentheses": "always",
+                    "bracketSameLine": true,
+                    "bracketSpacing": true,
+                    "jsxQuoteStyle": "double",
+                    "quoteProperties": "asNeeded",
+                    "trailingCommas": "all"
+                }
+            },
+            "json": {
+                "formatter": {
+                    "trailingCommas": "none",
+                    "expand": "always"
+                }
+            }
+        }
+    ]
 }


### PR DESCRIPTION
Right now, the biome extension breaks on VS Code files because it uses other rules to format the app. This PR fixes it.