### PR TITLE
fix(vscode): fix DeepSeek provider V4 reasoning

### DIFF
--- a/apps/vscode/src/core/api/providers/deepseek.ts
+++ b/apps/vscode/src/core/api/providers/deepseek.ts
@@ -81,11 +81,12 @@ export class DeepSeekHandler implements ApiHandler {
 		const client = this.ensureClient()
 		const model = this.getModel()
 
+		const isDeepSeekReasonerModel = model.id.includes("deepseek-reasoner")
 		const isDeepSeekThinkingModel =
-			model.id.includes("deepseek-reasoner") || model.id === "deepseek-v4-flash" || model.id === "deepseek-v4-pro"
+			isDeepSeekReasonerModel || model.id === "deepseek-v4-flash" || model.id === "deepseek-v4-pro"
 
 		const convertedMessages = convertToOpenAiMessages(messages)
-		const openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = isDeepSeekThinkingModel
+		const openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = isDeepSeekReasonerModel
 			? [{ role: "system", content: systemPrompt }, ...addReasoningContent(convertedMessages, messages)]
 			: [{ role: "system", content: systemPrompt }, ...convertedMessages]
 
@@ -104,6 +105,13 @@ export class DeepSeekHandler implements ApiHandler {
 
 		for await (const chunk of stream) {
 			const delta = chunk.choices?.[0]?.delta
+			if (delta && "reasoning_content" in delta && delta.reasoning_content) {
+				yield {
+					type: "reasoning",
+					reasoning: (delta.reasoning_content as string | undefined) || "",
+				}
+			}
+
 			if (delta?.content) {
 				yield {
 					type: "text",
@@ -113,13 +121,6 @@ export class DeepSeekHandler implements ApiHandler {
 
 			if (delta?.tool_calls) {
 				yield* toolCallProcessor.processToolCallDeltas(delta.tool_calls)
-			}
-
-			if (delta && "reasoning_content" in delta && delta.reasoning_content) {
-				yield {
-					type: "reasoning",
-					reasoning: (delta.reasoning_content as string | undefined) || "",
-				}
 			}
 
 			if (chunk.usage) {


### PR DESCRIPTION
### Related Issue

Issue: https://github.com/cline/cline/issues/11339

### Description

This PR fixes DeepSeek direct provider handling for the V4 models in the VS Code extension.

The previous provider logic used one broad `isDeepSeekThinkingModel` flag for both response streaming behavior and request message formatting. That meant `deepseek-v4-pro` and `deepseek-v4-flash` went through the same `addReasoningContent` path as `deepseek-reasoner`.

That replay helper is specific to the older R1 reasoner format. V4 models still stream `reasoning_content`, so they should keep the existing thinking stream behavior, but they should not have prior Cline thinking blocks injected into outgoing OpenAI messages through the R1 replay transform.

The fix keeps the behavior intentionally narrow:

- `deepseek-reasoner` continues to use `addReasoningContent`.
- `deepseek-v4-pro` and `deepseek-v4-flash` remain thinking models for temperature handling.
- V4 models now use the normal converted OpenAI messages instead of the R1 replay path.
- Reasoning stream chunks are yielded before text chunks when both fields are present in the same streamed delta, which keeps the task stream ordering stable for inline DeepSeek reasoning responses.

No UI, webview, settings, model metadata, prompt registry, or public API changes are included.

### Test Procedure

- Ran `npx biome check --config-path ./apps/vscode/biome.jsonc --no-errors-on-unmatched --files-ignore-unknown=true apps/vscode/src/core/api/providers/deepseek.ts` from the repository root.
- Verified the branch diff against `origin/main` contains only `apps/vscode/src/core/api/providers/deepseek.ts`.
- Did not run the full unit test suite because this task worktree does not have the required `apps/vscode` package dependencies installed locally.

The affected surface is limited to the direct DeepSeek provider. Existing `deepseek-reasoner` behavior is preserved by keeping the R1 replay transform behind a separate reasoner-only flag.

### Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Refactor Changes
-   [ ] Cosmetic Changes
-   [ ] Documentation update
-   [ ] Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. This is provider stream and request formatting logic only.

### Additional Notes

The initial local branch was based on a detached commit that was not current with `origin/main`, so I created a clean PR branch from `origin/main` and cherry-picked only this DeepSeek fix onto it before pushing.
