### PR TITLE
test(core): cover configured subagent skill isolation

### DIFF
--- a/sdk/packages/core/src/runtime/orchestration/runtime-builder.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-builder.test.ts
@@ -132,6 +132,60 @@ You are a code reviewer.`,
 		expect(runtime.tools.map((tool) => tool.name)).toContain("spawn_agent");
 	});
 
+	it("does not register root skills when only configured agents declare skills", async () => {
+		const tempHome = mkdtempSync(join(tmpdir(), "cline-agent-home-"));
+		const workspaceRoot = mkdtempSync(join(tmpdir(), "cline-agent-workspace-"));
+		const cwd = join(workspaceRoot, "packages", "app");
+		tempDirs.push(tempHome, workspaceRoot);
+		setHomeDir(tempHome);
+		mkdirSync(cwd, { recursive: true });
+
+		const agentsDir = join(workspaceRoot, ".cline", "agents");
+		const skillDir = join(workspaceRoot, ".cline", "skills", "review");
+		mkdirSync(agentsDir, { recursive: true });
+		mkdirSync(skillDir, { recursive: true });
+		writeFileSync(
+			join(agentsDir, "code-reviewer.yml"),
+			`---
+name: code-reviewer
+description: Reviews code
+tools: use_skill
+skills: review
+---
+You are a code reviewer.`,
+			"utf8",
+		);
+		writeFileSync(
+			join(skillDir, "SKILL.md"),
+			`---
+name: review
+---
+Use the review guidance.`,
+			"utf8",
+		);
+
+		const runtime = await new DefaultRuntimeBuilder().build({
+			config: makeBaseConfig({
+				cwd,
+				workspaceRoot,
+				enableSpawnAgent: true,
+			}),
+			configExtensions: [],
+			createSpawnTool: makeSpawnTool,
+		});
+
+		expect(runtime.tools.map((tool) => tool.name)).toContain(
+			"subagent_code_reviewer",
+		);
+		expect(runtime.tools.map((tool) => tool.name)).not.toContain("skills");
+		expect(
+			(await collectExtensionTools(runtime.extensions)).map(
+				(tool) => tool.name,
+			),
+		).not.toContain("skills");
+		await runtime.shutdown("test");
+	});
+
 	it("forwards telemetry for downstream runtime consumers", async () => {
 		const telemetry = new TelemetryService();
 		const runtime = await new DefaultRuntimeBuilder().build({


### PR DESCRIPTION
### Related Issue

Issue: #11368

### Description

This PR adds a focused regression test for the configured-agent skills behavior discussed on PR #11368.

The base PR now already contains the code-side fixes for the critical configured-agent issues: approval forwarding, workspace-root-based configured-agent skill discovery, root-session skill isolation, lifecycle callback threading, and optional `createSkillsExecutor` compatibility. This follow-up keeps the branch small and adds coverage for the most important behavior boundary: a configured subagent declaring `skills:` should be able to load its own skill service needs without registering the root session's skills tool when the root session opted out of skills extensions.

The test builds a workspace where the session `cwd` is a subdirectory and `workspaceRoot` contains both `.cline/agents` and `.cline/skills`. It then starts the runtime with `configExtensions: []`, verifies the configured subagent tool still registers, and verifies no root-level `skills` tool is exposed through runtime tools or extension tools.

### Test Procedure

Ran the focused runtime-builder test file:

```bash
bunx vitest run --config vitest.config.ts src/runtime/orchestration/runtime-builder.test.ts
```

Also checked the patch for whitespace errors:

```bash
git diff --check origin/bee/subagent-profile...HEAD
```

This specifically covers the regression where configured-agent `skills:` could previously alter root-session skill registration. The rest of the configured-agent fix behavior is already present in the base PR branch.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. This is SDK runtime test coverage only.

### Additional Notes

This PR is intentionally small and targets `bee/subagent-profile` rather than `main`, so it can be reviewed as a companion fix for PR #11368.
