### PR TITLE
fix(webview): use consistent reasoning selector component in extension provider settings

### DIFF
--- a/apps/vscode/webview-ui/src/components/settings/providers/GenericProviderSettings.test.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/GenericProviderSettings.test.tsx
@@ -1,5 +1,6 @@
 import { ApiFormat } from "@shared/proto/cline/models"
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import type { ChangeEventHandler, ReactNode } from "react"
 import { describe, expect, it, vi } from "vitest"
 import { useProviderConfig } from "@/hooks/useProviderConfig"
 import { useProviderModels } from "@/hooks/useProviderModels"
@@ -12,6 +13,41 @@ vi.mock("@/hooks/useProviderModels", () => ({
 vi.mock("@/hooks/useProviderConfig", () => ({
 	useProviderConfig: vi.fn(),
 }))
+
+// The reasoning effort selector reads the extension state for the current
+// mode-specific reasoning effort value.
+vi.mock("@/context/ExtensionStateContext", () => ({
+	useExtensionState: () => ({ apiConfiguration: {}, planActSeparateModelsSetting: false }),
+}))
+
+// Render the dropdown web components as native elements so value/change
+// behavior is observable in jsdom. Other toolkit components stay real.
+vi.mock("@vscode/webview-ui-toolkit/react", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@vscode/webview-ui-toolkit/react")>()
+	return {
+		...actual,
+		VSCodeDropdown: ({
+			children,
+			id,
+			onChange,
+			value,
+			"aria-label": ariaLabel,
+		}: {
+			children?: ReactNode
+			id?: string
+			onChange?: ChangeEventHandler<HTMLSelectElement>
+			value?: string
+			"aria-label"?: string
+		}) => (
+			<select aria-label={ariaLabel} id={id} onChange={onChange} value={value}>
+				{children}
+			</select>
+		),
+		VSCodeOption: ({ children, value }: { children?: ReactNode; value?: string }) => (
+			<option value={value}>{children}</option>
+		),
+	}
+})
 
 describe("GenericProviderSettings", () => {
 	it("renders catalog-backed provider settings and commits full model selections", async () => {
@@ -51,6 +87,7 @@ describe("GenericProviderSettings", () => {
 		)
 
 		expect(screen.getByLabelText("Model")).toHaveValue("deepseek-chat")
+		expect(screen.queryByText("Reasoning Effort")).not.toBeInTheDocument()
 		fireEvent.change(screen.getByLabelText("Model"), { target: { value: "deepseek-reasoner" } })
 
 		await waitFor(() => expect(commitSelection).toHaveBeenCalledTimes(1))
@@ -61,6 +98,42 @@ describe("GenericProviderSettings", () => {
 		})
 		expect(useProviderModels).toHaveBeenCalledWith("deepseek")
 		expect(useProviderConfig).toHaveBeenCalledWith("deepseek")
+	})
+
+	it("renders a reasoning effort selector when the selected model supports reasoning", () => {
+		vi.mocked(useProviderModels).mockReturnValue({
+			models: {
+				"deepseek-reasoner": {
+					name: "DeepSeek Reasoner",
+					supportsPromptCache: true,
+					contextWindow: 128_000,
+					supportsReasoning: true,
+				},
+			},
+			defaultModelId: "deepseek-reasoner",
+			isLoading: false,
+			isStale: false,
+			error: undefined,
+			refresh: vi.fn(),
+			fingerprint: "fingerprint",
+		})
+		vi.mocked(useProviderConfig).mockReturnValue({
+			config: undefined,
+			write: vi.fn(async () => undefined),
+			commitSelection: vi.fn(),
+		})
+
+		render(
+			<GenericProviderSettings
+				allowsCustomIds={false}
+				currentMode="act"
+				providerId="deepseek"
+				providerName="DeepSeek"
+				showModelOptions={true}
+			/>,
+		)
+
+		expect(screen.getByText("Reasoning Effort")).toBeInTheDocument()
 	})
 
 	it("shows saved API keys as masked and does not clear them on mount", async () => {

--- a/apps/vscode/webview-ui/src/components/settings/providers/GenericProviderSettings.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/GenericProviderSettings.tsx
@@ -6,6 +6,7 @@ import { useProviderModels } from "@/hooks/useProviderModels"
 import { ApiKeyField } from "../common/ApiKeyField"
 import { BaseUrlField } from "../common/BaseUrlField"
 import { ModelInfoView } from "../common/ModelInfoView"
+import ReasoningEffortSelector from "../ReasoningEffortSelector"
 import { useProviderApiKeyField } from "../utils/useProviderApiKeyField"
 import { type ModelPickerSelection, ModelPickerWithManualEntry } from "./ModelPickerWithManualEntry"
 
@@ -95,6 +96,20 @@ export const GenericProviderSettings = ({
 						onSelect={handleModelSelect}
 						selectedModel={selectedModel}
 					/>
+
+					{selectedModel.modelInfo.supportsReasoning === true && (
+						<ReasoningEffortSelector
+							currentMode={currentMode}
+							onEffortChange={(effort) => {
+								void write({
+									reasoning: {
+										enabled: effort !== "none",
+										effort: effort !== "none" ? effort : undefined,
+									},
+								}).catch((err) => console.error(`Failed to update ${providerName} reasoning effort:`, err))
+							}}
+						/>
+					)}
 
 					<ModelInfoView
 						isPopup={isPopup}

--- a/apps/vscode/webview-ui/src/components/settings/providers/ModelPickerWithManualEntry.test.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/ModelPickerWithManualEntry.test.tsx
@@ -1,6 +1,55 @@
 import { fireEvent, render, screen } from "@testing-library/react"
+import type { ChangeEventHandler, FormEventHandler, KeyboardEventHandler, ReactNode } from "react"
 import { describe, expect, it, vi } from "vitest"
 import { type ModelPickerSelection, ModelPickerWithManualEntry } from "./ModelPickerWithManualEntry"
+
+// Render the toolkit web components as native elements so value/change
+// behavior is observable in jsdom.
+vi.mock("@vscode/webview-ui-toolkit/react", () => ({
+	VSCodeDropdown: ({
+		children,
+		id,
+		onChange,
+		value,
+		"aria-label": ariaLabel,
+	}: {
+		children?: ReactNode
+		id?: string
+		onChange?: ChangeEventHandler<HTMLSelectElement>
+		value?: string
+		"aria-label"?: string
+	}) => (
+		<select aria-label={ariaLabel} id={id} onChange={onChange} value={value}>
+			{children}
+		</select>
+	),
+	VSCodeOption: ({ children, value }: { children?: ReactNode; value?: string }) => <option value={value}>{children}</option>,
+	VSCodeTextField: ({
+		children,
+		id,
+		onInput,
+		onKeyDown,
+		placeholder,
+		value,
+	}: {
+		children?: ReactNode
+		id?: string
+		onInput?: FormEventHandler<HTMLInputElement>
+		onKeyDown?: KeyboardEventHandler<HTMLInputElement>
+		placeholder?: string
+		value?: string
+	}) => (
+		<div>
+			<label htmlFor={id}>{children}</label>
+			<input id={id} onChange={onInput} onKeyDown={onKeyDown} placeholder={placeholder} value={value} />
+		</div>
+	),
+	VSCodeButton: ({ children, onClick }: { children?: ReactNode; onClick?: () => void }) => (
+		<button onClick={onClick} type="button">
+			{children}
+		</button>
+	),
+}))
 
 const selectedModel: ModelPickerSelection = {
 	providerId: "ollama",

--- a/apps/vscode/webview-ui/src/components/settings/providers/ModelPickerWithManualEntry.test.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/ModelPickerWithManualEntry.test.tsx
@@ -198,6 +198,100 @@ describe("ModelPickerWithManualEntry", () => {
 		expect(onSelect).not.toHaveBeenCalled()
 	})
 
+	it("prefills the custom field when the committed selection hydrates after mount", () => {
+		const { rerender } = render(
+			<ModelPickerWithManualEntry
+				allowsCustomIds={true}
+				error={undefined}
+				isLoading={true}
+				isStale={false}
+				models={{}}
+				onSelect={vi.fn()}
+				selectedModel={{ ...selectedModel, modelId: "" }}
+			/>,
+		)
+
+		expect(screen.getByLabelText("Custom model ID")).toHaveValue("")
+
+		rerender(
+			<ModelPickerWithManualEntry
+				allowsCustomIds={true}
+				error={undefined}
+				isLoading={false}
+				isStale={false}
+				models={models}
+				onSelect={vi.fn()}
+				selectedModel={{ ...selectedModel, modelId: "my-fast-model" }}
+			/>,
+		)
+
+		expect(screen.getByLabelText("Custom model ID")).toHaveValue("my-fast-model")
+	})
+
+	it("clears the custom field when the hydrated selection is in the catalog", () => {
+		const { rerender } = render(
+			<ModelPickerWithManualEntry
+				allowsCustomIds={true}
+				error={undefined}
+				isLoading={true}
+				isStale={false}
+				models={{}}
+				onSelect={vi.fn()}
+				selectedModel={{ ...selectedModel, modelId: "llama3" }}
+			/>,
+		)
+
+		// Lazy init captured "llama3" while the catalog was empty.
+		expect(screen.getByLabelText("Custom model ID")).toHaveValue("llama3")
+
+		rerender(
+			<ModelPickerWithManualEntry
+				allowsCustomIds={true}
+				error={undefined}
+				isLoading={false}
+				isStale={false}
+				models={models}
+				onSelect={vi.fn()}
+				selectedModel={{ ...selectedModel, modelId: "llama3" }}
+			/>,
+		)
+
+		fireEvent.change(screen.getByLabelText("Model"), { target: { value: "__custom__" } })
+		expect(screen.getByLabelText("Custom model ID")).toHaveValue("")
+	})
+
+	it("does not reset the custom field while the user is typing", () => {
+		const { rerender } = render(
+			<ModelPickerWithManualEntry
+				allowsCustomIds={true}
+				error={undefined}
+				isLoading={false}
+				isStale={false}
+				models={{}}
+				onSelect={vi.fn()}
+				selectedModel={{ ...selectedModel, modelId: "my-fast-model" }}
+			/>,
+		)
+
+		fireEvent.change(screen.getByLabelText("Custom model ID"), { target: { value: "my-fast" } })
+
+		// A re-render with a fresh models object identity (catalog still
+		// loading) must not clobber the in-progress input.
+		rerender(
+			<ModelPickerWithManualEntry
+				allowsCustomIds={true}
+				error={undefined}
+				isLoading={false}
+				isStale={false}
+				models={{}}
+				onSelect={vi.fn()}
+				selectedModel={{ ...selectedModel, modelId: "my-fast-model" }}
+			/>,
+		)
+
+		expect(screen.getByLabelText("Custom model ID")).toHaveValue("my-fast")
+	})
+
 	it("does not auto-select while model props change during refresh", () => {
 		const onSelect = vi.fn()
 		const { rerender } = render(

--- a/apps/vscode/webview-ui/src/components/settings/providers/ModelPickerWithManualEntry.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/ModelPickerWithManualEntry.tsx
@@ -1,6 +1,8 @@
 import { type ModelInfo, openAiModelInfoSafeDefaults } from "@shared/api"
+import { VSCodeButton, VSCodeDropdown, VSCodeOption, VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
 import { useState } from "react"
 import type { ProviderId } from "@/context/ExtensionStateContext"
+import { DropdownContainer } from "../common/ModelSelector"
 
 export interface ModelPickerSelection {
 	providerId: ProviderId
@@ -35,11 +37,17 @@ export function ModelPickerWithManualEntry({
 	onSelect,
 }: ModelPickerWithManualEntryProps) {
 	const [isManualEntryVisible, setIsManualEntryVisible] = useState(false)
+	const [customModelId, setCustomModelId] = useState(() => (selectedModel.modelId in models ? "" : selectedModel.modelId))
 	const modelIds = Object.keys(models).sort((a, b) => a.localeCompare(b))
 	const hasModels = modelIds.length > 0
 	const selectedModelInList = selectedModel.modelId in models
 	const showManualEntry =
 		allowsCustomIds && (isManualEntryVisible || !hasModels || isLoading || Boolean(error) || !selectedModelInList)
+
+	// Force VSCodeDropdown to re-initialize after async catalog/selection
+	// hydration, otherwise it ignores the value prop for dynamically rendered
+	// options. https://github.com/microsoft/vscode-webview-ui-toolkit/issues/433
+	const dropdownKey = `${selectedModel.modelId}:${modelIds.join("\u0000")}`
 
 	const commitCustomModel = (modelId: string) => {
 		const trimmed = modelId.trim()
@@ -65,32 +73,36 @@ export function ModelPickerWithManualEntry({
 			{error && <div role="alert">{error}</div>}
 
 			{hasModels && (
-				<select
-					aria-label="Model"
-					id="provider-model-picker"
-					onChange={(event) => {
-						const modelId = event.target.value
-						if (modelId === "__custom__") {
-							setIsManualEntryVisible(true)
-							return
-						}
-						const modelInfo = models[modelId]
-						if (modelInfo) {
-							setIsManualEntryVisible(false)
-							onSelect({ providerId: selectedModel.providerId, modelId, modelInfo })
-						}
-					}}
-					value={selectedModelInList ? selectedModel.modelId : ""}>
-					{!selectedModelInList && allowsCustomIds && selectedModel.modelId && (
-						<option value="">{selectedModel.modelId} (not in current list)</option>
-					)}
-					{modelIds.map((modelId) => (
-						<option key={modelId} value={modelId}>
-							{modelId}
-						</option>
-					))}
-					{allowsCustomIds && <option value="__custom__">Use custom model ID…</option>}
-				</select>
+				<DropdownContainer className="dropdown-container">
+					<VSCodeDropdown
+						aria-label="Model"
+						className="w-full"
+						id="provider-model-picker"
+						key={dropdownKey}
+						onChange={(event) => {
+							const modelId = (event.target as HTMLSelectElement).value
+							if (modelId === "__custom__") {
+								setIsManualEntryVisible(true)
+								return
+							}
+							const modelInfo = models[modelId]
+							if (modelInfo) {
+								setIsManualEntryVisible(false)
+								onSelect({ providerId: selectedModel.providerId, modelId, modelInfo })
+							}
+						}}
+						value={selectedModelInList ? selectedModel.modelId : ""}>
+						{!selectedModelInList && allowsCustomIds && selectedModel.modelId && (
+							<VSCodeOption value="">{selectedModel.modelId} (not in current list)</VSCodeOption>
+						)}
+						{modelIds.map((modelId) => (
+							<VSCodeOption className="break-words whitespace-normal max-w-full" key={modelId} value={modelId}>
+								{modelId}
+							</VSCodeOption>
+						))}
+						{allowsCustomIds && <VSCodeOption value="__custom__">Use custom model ID…</VSCodeOption>}
+					</VSCodeDropdown>
+				</DropdownContainer>
 			)}
 
 			{!selectedModelInList && selectedModel.modelId && hasModels && (
@@ -98,24 +110,26 @@ export function ModelPickerWithManualEntry({
 			)}
 
 			{showManualEntry && (
-				<form
-					onSubmit={(event) => {
-						event.preventDefault()
-						const form = event.currentTarget
-						const input = form.elements.namedItem("customModelId")
-						commitCustomModel(input instanceof HTMLInputElement ? input.value : "")
-					}}>
-					<label htmlFor="custom-model-id">Custom model ID</label>
-					<div style={{ display: "flex", gap: 6 }}>
-						<input
-							defaultValue={!selectedModelInList ? selectedModel.modelId : ""}
-							id="custom-model-id"
-							name="customModelId"
-							placeholder="Enter custom model ID"
-						/>
-						<button type="submit">Use custom model</button>
-					</div>
-				</form>
+				<div style={{ display: "flex", gap: 6, alignItems: "flex-end" }}>
+					<VSCodeTextField
+						id="custom-model-id"
+						onInput={(event) => {
+							setCustomModelId((event.target as HTMLInputElement).value)
+						}}
+						onKeyDown={(event) => {
+							if (event.key === "Enter") {
+								commitCustomModel(customModelId)
+							}
+						}}
+						placeholder="Enter custom model ID"
+						style={{ flexGrow: 1 }}
+						value={customModelId}>
+						<span className="font-medium">Custom model ID</span>
+					</VSCodeTextField>
+					<VSCodeButton appearance="secondary" onClick={() => commitCustomModel(customModelId)}>
+						Use custom model
+					</VSCodeButton>
+				</div>
 			)}
 		</div>
 	)

--- a/apps/vscode/webview-ui/src/components/settings/providers/ModelPickerWithManualEntry.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/ModelPickerWithManualEntry.tsx
@@ -1,6 +1,6 @@
 import { type ModelInfo, openAiModelInfoSafeDefaults } from "@shared/api"
 import { VSCodeButton, VSCodeDropdown, VSCodeOption, VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import type { ProviderId } from "@/context/ExtensionStateContext"
 import { DropdownContainer } from "../common/ModelSelector"
 
@@ -41,6 +41,15 @@ export function ModelPickerWithManualEntry({
 	const modelIds = Object.keys(models).sort((a, b) => a.localeCompare(b))
 	const hasModels = modelIds.length > 0
 	const selectedModelInList = selectedModel.modelId in models
+
+	// The committed selection and the model catalog both hydrate asynchronously
+	// after mount, so the lazy useState init above can capture a placeholder
+	// value. Re-sync when the committed model changes or its in-list status
+	// flips. Depend on the derived values rather than `models` itself, whose
+	// identity can change every render while the catalog is loading.
+	useEffect(() => {
+		setCustomModelId(selectedModelInList ? "" : selectedModel.modelId)
+	}, [selectedModel.modelId, selectedModelInList])
 	const showManualEntry =
 		allowsCustomIds && (isManualEntryVisible || !hasModels || isLoading || Boolean(error) || !selectedModelInList)
 


### PR DESCRIPTION
### Related Issue

Issue: N/A. Found while manually testing the SDK migration branch (`dpc/sdk-migration-simpler-login`).

### Description

While testing the migrated extension, selecting the DeepSeek provider in the API provider settings showed a dropdown that was visibly a different UI element from the dropdowns on other providers (raw native HTML, no VS Code theming).

Root cause: the SDK migration replaced ~15 dedicated provider settings components (`DeepSeekProvider.tsx`, `GeminiProvider.tsx`, `MistralProvider.tsx`, etc.) with a shared catalog-backed `GenericProviderSettings` component, and the model picker inside that path (`ModelPickerWithManualEntry.tsx`) was rendering bare `<select>`, `<input>`, and `<button>` elements instead of the `@vscode/webview-ui-toolkit` components every other provider uses. So this wasn't DeepSeek-specific at all; it affected every provider routed through the generic path (deepseek, gemini, mistral, groq, fireworks, together, minimax, nebius, sambanova, cerebras, doubao, huawei-cloud-maas, wandb, nousResearch, baseten, vercel-ai-gateway, huggingface).

Two changes:

1. `ModelPickerWithManualEntry.tsx` now renders `VSCodeDropdown`/`VSCodeOption` for the model list and `VSCodeTextField`/`VSCodeButton` for the custom model ID entry. It reuses `DropdownContainer` from `common/ModelSelector.tsx` and the same `key`-based re-init workaround for the toolkit's dynamic-options bug (microsoft/vscode-webview-ui-toolkit#433, see the OG note in `ModelSelector.tsx`): without re-keying, `VSCodeDropdown` ignores the `value` prop when options render after async catalog hydration and silently falls back to the first option. The custom-ID flow kept its explicit commit-on-button behavior (the old version used a `<form>` submit with `form.elements.namedItem`, which does not work reliably with shadow-DOM web components) and gained Enter-to-commit. The custom ID input is now controlled state instead of an uncontrolled `defaultValue` input.

2. `GenericProviderSettings.tsx` now renders `ReasoningEffortSelector` when the selected model's catalog info has `supportsReasoning: true` (e.g. `deepseek-reasoner`), persisting the choice through the provider config `reasoning` patch (`write({ reasoning: { enabled, effort } })`), exactly mirroring what `ClineModelPicker` does for reasoning-capable models. This closes the parity gap where providers with dedicated components (Anthropic, Bedrock, Vertex, OpenAI Native, Cline) show a thinking/reasoning control but generic-path providers showed nothing. It is keyed off the catalog capability flag, not provider ID string matching, so any generic provider with reasoning-capable models picks it up automatically.

### Test Procedure

- `npx vitest run` on the two affected test files: 14/14 pass, including a new test asserting the reasoning effort selector renders for a `supportsReasoning` model and not for a non-reasoning model.
- Test gotcha worth knowing: the toolkit web components have no value setters in jsdom, so `fireEvent.change` throws "The given element does not have a value setter" against the real components. Both test files now mock `@vscode/webview-ui-toolkit/react` to render native elements, following the existing convention in `ActionButtons.test.tsx`. `GenericProviderSettings.test.tsx` uses a partial mock (`importOriginal` + override of just `VSCodeDropdown`/`VSCodeOption`) so the existing API key masking tests keep exercising the real `VSCodeTextField`.
- `tsc --noEmit` in `webview-ui`: clean.
- `biome check` on the four changed files: clean (formatter applied).
- Pre-existing, unrelated: 16 failures in `src/hooks/` tests (`useProviderConfig`, `useProviderModels`, `useNormalizedApiConfiguration`) fail identically on the clean branch head in my environment, likely from stale generated proto output rather than this change.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

The dropdown UI in the generic path looked like placeholder scaffolding from the squashed migration commit, so there may have been a plan to restyle it later; this PR just brings it in line with the rest of the settings UI now. If a follow-up later replaces toolkit components with the shadcn `Select` across settings, both call sites are isolated in `ModelPickerWithManualEntry.tsx`.
