### PR TITLE
fix(cli): suppress flickering console windows on Windows

### DIFF
--- a/apps/cli/src/commands/kanban.ts
+++ b/apps/cli/src/commands/kanban.ts
@@ -166,6 +166,8 @@ export function buildKanbanSpawnOptions(
 	return {
 		stdio: "inherit",
 		detached: shouldDetachKanbanProcess(platform),
+		// Prevent a console window from flashing on Windows.
+		windowsHide: true,
 		...(platform === "win32" ? { shell: true } : {}),
 		...options,
 	};
@@ -178,6 +180,8 @@ function buildKanbanInstallSpawnOptions(
 	return {
 		detached: false,
 		stdio: "inherit",
+		// Prevent a console window from flashing on Windows.
+		windowsHide: true,
 		...(platform === "win32" ? { shell: true } : {}),
 		...options,
 	};
@@ -203,6 +207,8 @@ export function getInstalledKanbanVersion(): string | null {
 		const result = spawnSync(getKanbanCommand(), ["--version"], {
 			encoding: "utf8",
 			shell: process.platform === "win32",
+			// Prevent a console window from flashing on Windows.
+			windowsHide: true,
 		});
 		if (result.status !== 0) {
 			return null;

--- a/apps/cli/src/commands/kanban.ts
+++ b/apps/cli/src/commands/kanban.ts
@@ -166,10 +166,10 @@ export function buildKanbanSpawnOptions(
 	return {
 		stdio: "inherit",
 		detached: shouldDetachKanbanProcess(platform),
-		// Prevent a console window from flashing on Windows.
-		windowsHide: true,
 		...(platform === "win32" ? { shell: true } : {}),
 		...options,
+		// Prevent a console window from flashing on Windows.
+		windowsHide: true,
 	};
 }
 

--- a/apps/cli/src/commands/plugin.ts
+++ b/apps/cli/src/commands/plugin.ts
@@ -506,6 +506,8 @@ async function runCommand(
 			cwd: options.cwd,
 			stdio: ["ignore", "ignore", "pipe"],
 			env: process.env,
+			// Prevent a console window from flashing on Windows.
+			windowsHide: true,
 		});
 		let stderr = "";
 		child.stderr.on("data", (chunk) => {

--- a/apps/cli/src/commands/update.ts
+++ b/apps/cli/src/commands/update.ts
@@ -362,6 +362,9 @@ export function autoUpdateOnStartup(): void {
 				env: autoUpdateCommand.env
 					? { ...process.env, ...autoUpdateCommand.env }
 					: process.env,
+				// Prevent a console window from flashing on Windows; detached
+				// processes otherwise allocate a new visible console.
+				windowsHide: true,
 			});
 			const exitCode = await waitForProcessExit(child);
 			if (exitCode === 0) {

--- a/apps/cli/src/connectors/common.ts
+++ b/apps/cli/src/connectors/common.ts
@@ -194,6 +194,9 @@ export function spawnDetachedConnector(
 				...withResolvedClineBuildEnv(process.env),
 				[childEnvKey]: "1",
 			},
+			// Prevent a console window from appearing on Windows; detached
+			// processes otherwise allocate a new visible console.
+			windowsHide: true,
 		});
 		logSpawnedProcess({
 			component: options?.component ?? "connectors",

--- a/apps/cli/src/tui/utils/clipboard.test.ts
+++ b/apps/cli/src/tui/utils/clipboard.test.ts
@@ -107,12 +107,13 @@ describe("copyTextToSystemClipboard", () => {
 
 		expect(spawnMock).toHaveBeenNthCalledWith(1, "wl-copy", [], {
 			stdio: ["pipe", "ignore", "ignore"],
+			windowsHide: true,
 		});
 		expect(spawnMock).toHaveBeenNthCalledWith(
 			2,
 			"xclip",
 			["-selection", "clipboard"],
-			{ stdio: ["pipe", "ignore", "ignore"] },
+			{ stdio: ["pipe", "ignore", "ignore"], windowsHide: true },
 		);
 		expect(failed.getInput()).toBe("selected text");
 		expect(succeeded.getInput()).toBe("selected text");
@@ -134,6 +135,7 @@ describe("copyTextToSystemClipboard", () => {
 		expect(spawnMock).toHaveBeenCalledTimes(1);
 		expect(spawnMock).toHaveBeenCalledWith("wl-copy", [], {
 			stdio: ["pipe", "ignore", "ignore"],
+			windowsHide: true,
 		});
 		expect(wlcopy.getInput()).toBe("plain linux");
 	});

--- a/apps/cli/src/tui/utils/clipboard.ts
+++ b/apps/cli/src/tui/utils/clipboard.ts
@@ -142,6 +142,8 @@ function runClipboardCommand(
 		const child = spawn(command.command, command.args, {
 			stdio: ["pipe", "ignore", "ignore"],
 			...(command.env ? { env: command.env } : {}),
+			// Prevent a console window from flashing on Windows.
+			windowsHide: true,
 		});
 		let settled = false;
 

--- a/apps/cli/src/tui/utils/image-paste.ts
+++ b/apps/cli/src/tui/utils/image-paste.ts
@@ -115,6 +115,8 @@ async function runCommand(
 	return await new Promise((resolve) => {
 		const child = spawn(command, args, {
 			stdio: ["ignore", "pipe", "ignore"],
+			// Prevent a console window from flashing on Windows.
+			windowsHide: true,
 		});
 		const chunks: Buffer[] = [];
 		let total = 0;

--- a/apps/cli/src/utils/repo-status.ts
+++ b/apps/cli/src/utils/repo-status.ts
@@ -18,9 +18,12 @@ export async function readRepoStatus(cwd: string): Promise<RepoStatus> {
 	const [branchResult, diffResult] = await Promise.allSettled([
 		execFileAsync("git", ["-C", cwd, "rev-parse", "--abbrev-ref", "HEAD"], {
 			encoding: "utf8",
+			// Prevent a console window from flashing on Windows.
+			windowsHide: true,
 		}),
 		execFileAsync("git", ["-C", cwd, "diff", "--shortstat"], {
 			encoding: "utf8",
+			windowsHide: true,
 		}),
 	]);
 

--- a/apps/cline-hub/src/server/connectors.ts
+++ b/apps/cline-hub/src/server/connectors.ts
@@ -68,6 +68,8 @@ async function runCliConnectCommand(args: string[]): Promise<{
 				CLINE_BUILD_ENV: process.env.CLINE_BUILD_ENV ?? "development",
 			},
 			stdio: ["ignore", "pipe", "pipe"],
+			// Prevent a console window from flashing on Windows.
+			windowsHide: true,
 		},
 	);
 	let stdout = "";

--- a/apps/cline-hub/src/server/utils.ts
+++ b/apps/cline-hub/src/server/utils.ts
@@ -134,6 +134,12 @@ export function openExternalUrl(url: string): void {
 	const command =
 		platform === "darwin" ? "open" : platform === "win32" ? "cmd" : "xdg-open";
 	const args = platform === "win32" ? ["/c", "start", "", url] : [url];
-	const child = spawn(command, args, { stdio: "ignore", detached: true });
+	const child = spawn(command, args, {
+		stdio: "ignore",
+		detached: true,
+		// Prevent a console window from flashing on Windows; the launched
+		// browser/app still opens normally.
+		windowsHide: true,
+	});
 	child.unref();
 }

--- a/sdk/examples/plugins/background-terminal.ts
+++ b/sdk/examples/plugins/background-terminal.ts
@@ -193,6 +193,8 @@ function startCommand(
 		detached: true,
 		stdio: ["ignore", "pipe", "pipe"],
 		env: process.env,
+		// Prevent a console window from flashing on Windows.
+		windowsHide: true,
 	});
 
 	const record: JobRecord = {

--- a/sdk/examples/plugins/gitignore-read-files-guard.ts
+++ b/sdk/examples/plugins/gitignore-read-files-guard.ts
@@ -192,7 +192,11 @@ async function checkIgnoredByWorkspaceGitignore(
 		const child = spawn(
 			"git",
 			["check-ignore", "--stdin", "-z", "-v", "-n", "--no-index"],
-			{ cwd: workspaceRoot, stdio: ["pipe", "pipe", "pipe"] },
+			{
+				cwd: workspaceRoot,
+				stdio: ["pipe", "pipe", "pipe"],
+				windowsHide: true,
+			},
 		);
 
 		const stdout: Buffer[] = [];

--- a/sdk/packages/core/src/extensions/tools/executors/bash.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/bash.ts
@@ -69,6 +69,10 @@ function spawnAndCollect(
 			env: { ...process.env, ...config.env },
 			stdio: ["pipe", "pipe", "pipe"],
 			detached: !isWindows,
+			// Prevent a console window from flashing on Windows when the
+			// parent process has no console (or a different console).
+			// No-op on non-Windows platforms.
+			windowsHide: true,
 		});
 		const childPid = child.pid;
 

--- a/sdk/packages/core/src/extensions/tools/executors/search.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/search.ts
@@ -129,6 +129,8 @@ function checkRipgrepAvailable(): Promise<boolean> {
 	return new Promise((resolve) => {
 		const child = spawn("rg", ["--version"], {
 			stdio: ["ignore", "pipe", "pipe"],
+			// Prevent a console window from flashing on Windows.
+			windowsHide: true,
 		});
 
 		child.on("close", (code) => {
@@ -168,6 +170,8 @@ function searchWithRipgrep(
 			{
 				cwd,
 				stdio: ["ignore", "pipe", "pipe"],
+				// Prevent a console window from flashing on Windows.
+				windowsHide: true,
 			},
 		);
 

--- a/sdk/packages/core/src/hooks/hook-file-hooks.ts
+++ b/sdk/packages/core/src/hooks/hook-file-hooks.ts
@@ -335,6 +335,9 @@ async function runHookCommandOnce(
 			? ["pipe", "ignore", "ignore"]
 			: ["pipe", "pipe", "pipe"],
 		detached: options.detached,
+		// Prevent a console window from flashing on Windows (especially when
+		// detached, which would otherwise allocate a new console).
+		windowsHide: true,
 	});
 	const spawned = new Promise<void>((resolve) => {
 		child.once("spawn", () => resolve());

--- a/sdk/packages/core/src/hooks/subprocess-runner.ts
+++ b/sdk/packages/core/src/hooks/subprocess-runner.ts
@@ -125,6 +125,9 @@ export async function runSubprocessEvent(
 		env: withResolvedClineBuildEnv(options.env),
 		stdio: detached ? ["pipe", "ignore", "ignore"] : ["pipe", "pipe", "pipe"],
 		detached,
+		// Prevent a console window from flashing on Windows (especially when
+		// detached, which would otherwise allocate a new console).
+		windowsHide: true,
 	});
 	const spawned = new Promise<void>((resolve) => {
 		child.once("spawn", () => {

--- a/sdk/packages/core/src/hub/daemon/index.ts
+++ b/sdk/packages/core/src/hub/daemon/index.ts
@@ -171,6 +171,9 @@ export function spawnDetachedHubServer(
 			stdio: logFile ? ["ignore", logFile.fd, logFile.fd] : "ignore",
 			env: command.env,
 			cwd: command.cwd,
+			// Prevent a console window from appearing on Windows; detached
+			// processes otherwise allocate a new visible console.
+			windowsHide: true,
 		});
 		child.unref();
 	} finally {

--- a/sdk/packages/core/src/runtime/tools/subprocess-sandbox.ts
+++ b/sdk/packages/core/src/runtime/tools/subprocess-sandbox.ts
@@ -170,6 +170,8 @@ export class SubprocessSandbox {
 			{
 				stdio: ["ignore", "ignore", "pipe", "ipc"],
 				env: withResolvedClineBuildEnv(process.env),
+				// Prevent a console window from flashing on Windows.
+				windowsHide: true,
 			},
 		);
 		this.process = child;

--- a/sdk/packages/core/src/services/workspace/file-indexer.ts
+++ b/sdk/packages/core/src/services/workspace/file-indexer.ts
@@ -85,6 +85,8 @@ async function listFilesWithRg(cwd: string): Promise<Set<string>> {
 		const child = spawn("rg", ["--files", "--hidden", "-g", "!.git"], {
 			cwd,
 			stdio: ["ignore", "pipe", "pipe"],
+			// Prevent a console window from flashing on Windows.
+			windowsHide: true,
 		});
 
 		let stdout = "";


### PR DESCRIPTION
### Description

On Windows, the CLI constantly spawns short-lived visible console windows that flicker and obscure the CLI window and other applications.

**Root cause:** `child_process.spawn`/`spawnSync`/`execFile` default to `windowsHide: false`. When console-subsystem executables (`powershell.exe`, `rg.exe`, `git.exe`, `node.exe`, package managers) are spawned, Windows will allocate a new visible console window for the child when `detached: true` is used. Frequent triggers in the CLI included:

- **`run_commands` tool** — spawns `powershell` per command (the biggest offender)
- **TUI status bar** — `repo-status.ts` repeatedly polls `git rev-parse` / `git diff`, so just sitting in the TUI inside a git repo flickered
- **`search_codebase` / workspace file indexing** — spawns `rg`
- **Clipboard copy/paste helpers** — spawn `powershell.exe`
- **Hooks and plugins** — spawn `node`/`bun` subprocesses (sandbox, hook runner, detached event emitters)
- **Detached background processes** — hub daemon, connectors, auto-update (guaranteed new console window due to `detached: true`)

**Fix:** Set `windowsHide: true` (Win32 `CREATE_NO_WINDOW`; a no-op on macOS/Linux) on all remaining child-process call sites in the SDK core, CLI, Cline Hub, and example plugins. This matches the pattern already established in the codebase (MCP stdio client, `checkpoint-hooks.ts`, `StandaloneTerminalProcess.ts`, `codex-cli.ts`, `worktree.ts`).

### Test Plan

- **Unit tests** for all touched areas pass on Windows: `bash.test.ts` (9/9), `definitions.test.ts` (37/37), `file-indexer.test.ts` (5/5), `subprocess-sandbox.test.ts` (6/6), `hub/daemon/index.test.ts` (8/8), `clipboard.test.ts` (16/16), `image-paste.test.ts` (5/5), `update.test.ts` (6/6), `kanban.test.ts` option-builder tests.
- **Updated** two strict-equality spawn assertions in `clipboard.test.ts` to expect the new `windowsHide: true` option.
- **Pre-existing Windows failures are unrelated** unfortunately these are failing for me on Windows with a clean checkout: `hook-file-hooks.test.ts` (2 bash-on-Windows failures), `kanban.test.ts` (2 npm-not-on-PATH failures), and `plugin.test.ts` (5 `spawn EFTYPE` failures) all fail identically with or without this change.

Manual test:

```
bun install
bun build:sdk
cd <some interesting other git repo>
$env:CLINE_BUILD_ENV = "development"
bun --conditions=development path\to\cline\apps\cli\src\index.ts
```

...get the model to use run_commands, etc. and verify that the flashing console windows are gone.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — backend/process-spawning change. The visible symptom (flickering console windows on Windows) is gone after this change; reproduce by running the CLI TUI in a git repo on Windows and watching for flashing windows during `run_commands` or status-bar polling.

### Additional Notes

`windowsHide: true` already appears in several places in the repo for exactly this reason — this PR completes the coverage for the remaining spawn sites (19 files). Call sites are in: `sdk/packages/core` (bash/search executors, file indexer, hook runners, subprocess sandbox, hub daemon), `apps/cli` (connectors, update, plugin, kanban, clipboard, image-paste, repo-status), `apps/cline-hub`, and `sdk/examples/plugins`.
