### PR TITLE
fix(cli): support x64 CPUs without AVX2 (baseline binaries) — closes #10514

### DIFF
--- a/.changeset/baseline-no-avx2-fix.md
+++ b/.changeset/baseline-no-avx2-fix.md
@@ -1,0 +1,7 @@
+---
+"@cline/cli": patch
+---
+
+fix: add no-AVX2 baseline binaries and resolver for Sandy Bridge CPUs (issue #10514)
+
+The standard Bun-compiled x64 binary requires AVX2 and crashes with SIGILL (exit 132) on Intel Sandy Bridge and similar pre-Haswell CPUs. This patch adds `@cline/cli-linux-x64-baseline` and `@cline/cli-windows-x64-baseline` packages compiled with `--target=bun-linux-x64-baseline` / `bun-windows-x64-baseline`, and updates the `bin/cline` resolver to prefer the baseline binary on no-AVX2 hosts (detected via `/proc/cpuinfo`) with a SIGILL safety-net fallback for partial-upgrade scenarios.

--- a/.changeset/baseline-no-avx2-fix.md
+++ b/.changeset/baseline-no-avx2-fix.md
@@ -4,4 +4,4 @@
 
 fix: add no-AVX2 baseline binaries and resolver for Sandy Bridge CPUs (issue #10514)
 
-The standard Bun-compiled x64 binary requires AVX2 and crashes with SIGILL (exit 132) on Intel Sandy Bridge and similar pre-Haswell CPUs. This patch adds `@cline/cli-linux-x64-baseline` and `@cline/cli-windows-x64-baseline` packages compiled with `--target=bun-linux-x64-baseline` / `bun-windows-x64-baseline`, and updates the `bin/cline` resolver to prefer the baseline binary on no-AVX2 hosts (detected via `/proc/cpuinfo`) with a SIGILL safety-net fallback for partial-upgrade scenarios.
+The standard Bun-compiled x64 binary requires AVX2 and crashes with SIGILL (exit 132) on Intel Sandy Bridge and similar pre-Haswell CPUs. This patch adds the `@cline/cli-linux-x64-baseline` package compiled with `--target=bun-linux-x64-baseline`, and updates the `bin/cline` resolver to prefer the baseline binary on no-AVX2 hosts (detected via `/proc/cpuinfo`) with a SIGILL safety-net fallback for partial-upgrade scenarios. Windows and macOS detection is out of scope for this patch.

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -170,7 +170,6 @@ jobs:
             "@cline/cli-linux-x64-baseline"
             "@cline/cli-windows-arm64"
             "@cline/cli-windows-x64"
-            "@cline/cli-windows-x64-baseline"
           )
 
           for package_name in "${EXPECTED[@]}"; do
@@ -401,7 +400,6 @@ jobs:
             "@cline/cli-linux-x64-baseline"
             "@cline/cli-windows-arm64"
             "@cline/cli-windows-x64"
-            "@cline/cli-windows-x64-baseline"
           )
 
           for package_name in "${EXPECTED[@]}"; do

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -167,8 +167,10 @@ jobs:
             "@cline/cli-darwin-x64"
             "@cline/cli-linux-arm64"
             "@cline/cli-linux-x64"
+            "@cline/cli-linux-x64-baseline"
             "@cline/cli-windows-arm64"
             "@cline/cli-windows-x64"
+            "@cline/cli-windows-x64-baseline"
           )
 
           for package_name in "${EXPECTED[@]}"; do
@@ -396,8 +398,10 @@ jobs:
             "@cline/cli-darwin-x64"
             "@cline/cli-linux-arm64"
             "@cline/cli-linux-x64"
+            "@cline/cli-linux-x64-baseline"
             "@cline/cli-windows-arm64"
             "@cline/cli-windows-x64"
+            "@cline/cli-windows-x64-baseline"
           )
 
           for package_name in "${EXPECTED[@]}"; do

--- a/apps/cli/DISTRIBUTION.md
+++ b/apps/cli/DISTRIBUTION.md
@@ -14,15 +14,17 @@ Bun's `--compile` flag produces a single self-contained executable that includes
 
 ## What Gets Published
 
-Publishing the CLI publishes 7 packages to npm:
+Publishing the CLI publishes 9 packages to npm:
 
 | Package | Description |
 |---|---|
 | `@cline/cli-darwin-arm64` | macOS Apple Silicon binary |
 | `@cline/cli-darwin-x64` | macOS Intel binary |
 | `@cline/cli-linux-arm64` | Linux ARM binary |
-| `@cline/cli-linux-x64` | Linux x64 binary |
-| `@cline/cli-windows-x64` | Windows x64 binary |
+| `@cline/cli-linux-x64` | Linux x64 binary (AVX2-compiled; requires Haswell or newer) |
+| `@cline/cli-linux-x64-baseline` | Linux x64 baseline binary (no-AVX2; Sandy Bridge and older) |
+| `@cline/cli-windows-x64` | Windows x64 binary (AVX2-compiled) |
+| `@cline/cli-windows-x64-baseline` | Windows x64 baseline binary (no-AVX2) |
 | `@cline/cli-windows-arm64` | Windows ARM binary |
 | `cline` | Wrapper package (pulls the right binary via `optionalDependencies`) |
 
@@ -59,7 +61,9 @@ The `cline` wrapper package contains no binary -- just the resolver script, post
     "@cline/cli-darwin-x64": "0.1.0",
     "@cline/cli-linux-arm64": "0.1.0",
     "@cline/cli-linux-x64": "0.1.0",
+    "@cline/cli-linux-x64-baseline": "0.1.0",
     "@cline/cli-windows-x64": "0.1.0",
+    "@cline/cli-windows-x64-baseline": "0.1.0",
     "@cline/cli-windows-arm64": "0.1.0"
   }
 }
@@ -145,8 +149,10 @@ npm installs cline (wrapper package)
     - @cline/cli-darwin-arm64
     - @cline/cli-darwin-x64
     - @cline/cli-linux-arm64
-    - @cline/cli-linux-x64
+    - @cline/cli-linux-x64              (standard; requires AVX2)
+    - @cline/cli-linux-x64-baseline     (no-AVX2; installed alongside standard)
     - @cline/cli-windows-x64
+    - @cline/cli-windows-x64-baseline
     - @cline/cli-windows-arm64
   |
   v
@@ -160,10 +166,12 @@ User runs: cline
   |
   v
 bin/cline (Node.js resolver) executes:
-  1. Check CLINE_BIN_PATH env var override
+  1. Check CLINE_BIN_PATH env var override (SIGILL guard included)
   2. Check cached binary at bin/.cline
   3. Walk up node_modules for the platform package
+     (baseline preferred first on no-AVX2 x64 Linux)
   4. Execute the compiled binary
+  5. SIGILL safety net: if standard binary crashes, retry with baseline
 ```
 
 ## File Layout
@@ -183,8 +191,8 @@ apps/cli/
 From `apps/cli/`:
 
 ```bash
-bun run build:platforms:single  # build only current platform
-bun run build:platforms         # build all 6 platform binaries
+bun run build:platforms:single  # build only current platform (+ baseline if x64)
+bun run build:platforms         # build all 8 platform binaries
 bun run publish:npm:dry         # preview generated npm package publishing
 ```
 
@@ -213,7 +221,7 @@ Flags:
 Orchestrates publishing all packages to npm:
 
 1. Reads built packages from `dist/`
-2. Publishes all 6 platform packages in parallel (`@cline/cli-darwin-arm64`, etc.)
+2. Publishes all 8 platform packages in parallel (`@cline/cli-darwin-arm64`, `@cline/cli-linux-x64-baseline`, etc.)
 3. Generates a clean main package (`cline`) with:
    - `bin.cline` pointing to the resolver script
    - `postinstall` running the binary caching script
@@ -259,10 +267,10 @@ During development, `bin` in package.json points to `src/index.ts` for `bun link
 When building for a different platform (e.g., compiling for Linux on a Mac), Bun needs the target platform's native binaries for `@opentui/core`. The build script handles this by pre-downloading all platform variants with `bun install --os="*" --cpu="*"`.
 
 ### Version synchronization
-All 7 packages (6 platform + 1 wrapper) must have the same version. The build script reads the version from `apps/cli/package.json`. The publish script verifies that the built package versions match each other and `apps/cli/package.json`.
+All 9 packages (8 platform + 1 wrapper) must have the same version. The build script reads the version from `apps/cli/package.json`. The publish script verifies that the built package versions match each other and `apps/cli/package.json`.
 
 ### Package naming and scoping
-Platform packages are published under the `@cline` scope. The generated wrapper package is published as `cline`, so npm trusted publishing must be configured for all 7 package names.
+Platform packages are published under the `@cline` scope. The generated wrapper package is published as `cline`, so npm trusted publishing must be configured for all 9 package names (including `@cline/cli-linux-x64-baseline` and `@cline/cli-windows-x64-baseline`).
 
 ### postinstall reliability
 The postinstall script runs in diverse environments (CI, Docker, restricted permissions, network-mounted filesystems where hard links fail). It always wraps operations in try/catch and exits 0. The resolver script is the ultimate fallback.
@@ -275,3 +283,88 @@ Compiled binaries need to be executable (`chmod 755`). The build script sets thi
 
 ### Package size
 Each compiled binary is ~30-60MB (Bun runtime + all bundled code + native addons). This is normal for compiled CLI tools. Users only download their platform's variant thanks to `optionalDependencies`.
+
+## Baseline Binaries (no-AVX2 / Legacy x64 CPUs)
+
+### Background (issue #10514)
+
+The standard Bun-compiled x64 binary requires the AVX2 instruction set extension, which is present on Intel Haswell (2013) and later. Older x64 CPUs such as Intel Sandy Bridge (Core i7-2xxx / Xeon E5-2620 v1, 2011) support AVX but **not** AVX2. Running the standard binary on such a CPU produces an immediate `SIGILL` (Illegal Instruction) crash with exit code 132.
+
+### What is published
+
+Two additional baseline packages are published alongside the standard x64 packages:
+
+| Package | Bun target | CPU requirement |
+|---|---|---|
+| `@cline/cli-linux-x64-baseline` | `bun-linux-x64-baseline` | x86-64-v2 (AVX, no AVX2) |
+| `@cline/cli-windows-x64-baseline` | `bun-windows-x64-baseline` | x86-64-v2 (AVX, no AVX2) |
+
+These are built by passing `--target=bun-linux-x64-baseline` (or `bun-windows-x64-baseline`) to `bun build --compile`. Bun embeds its own "baseline" runtime that avoids AVX2 instructions. The packages are identical to the standard packages in every other respect (same version, same `cpu: ["x64"]` field, same binary name).
+
+### How AVX2 detection works
+
+`bin/cline` detects AVX2 support at runtime before resolving the binary:
+
+1. **On Linux**: reads `/proc/cpuinfo` and tests for the `avx2` flag as a whole word. If `avx2` is absent the CPU is treated as no-AVX2.
+2. **On all other platforms**: AVX2 is assumed present. The crash has only been reported on Linux x64.
+
+When a no-AVX2 CPU is detected and `arch === "x64"`, the resolver prepends `@cline/cli-linux-x64-baseline` to the candidate list so it is tried first.
+
+### SIGILL safety net
+
+Even when AVX2 detection reports capable (e.g. `/proc/cpuinfo` unreadable, or a future case on another OS), if the chosen binary exits with signal `SIGILL` the resolver transparently re-resolves and re-runs the baseline variant if one is installed. This protects against:
+
+- Cached `.cline` binary from a prior install (the resolver skips the SIGILL net for cached binaries; users should reinstall to pick up the baseline package).
+- CPUs where `/proc/cpuinfo` did not report flags reliably.
+
+The safety net correctly handles the partial-upgrade scenario (no-AVX2 CPU, baseline package not yet installed): the standard package is tried, SIGILLs, and the resolver searches for and runs the baseline binary if it can be found. The decision is based on whether the resolved binary path contains `-baseline` — not on whether the name was a candidate — so it triggers correctly even when baseline was theoretically preferred but could not be found at resolution time.
+
+### Reproducible crash evidence (issue #10514)
+
+The following was captured on an Intel Xeon E5-2620 v1 (Sandy Bridge, 2011) host — this CPU has `avx` in `/proc/cpuinfo` but no `avx2`:
+
+```
+# Official @cline/cli-linux-x64 binary (AVX2-compiled, as shipped on npm):
+$ /path/to/node_modules/@cline/cli-linux-x64/bin/cline --version
+Illegal instruction
+$ echo $?
+132
+```
+
+Exit code 132 = 128 + SIGILL (signal 4). The binary dies immediately before executing any application code because Bun's startup routine uses AVX2 instructions absent on this CPU.
+
+```
+# Bun baseline build (x86-64-v2, no AVX2 required):
+$ /home/david/.local/bin/bun --version
+1.3.14
+$ echo $?
+0
+```
+
+The baseline runtime starts and runs normally on the same machine. This confirms that compiling with `--target=bun-linux-x64-baseline` fully resolves the crash for Sandy Bridge and equivalent CPUs.
+
+### Resolution order on a no-AVX2 x64 Linux machine
+
+```
+1. CLINE_BIN_PATH env var override (if set)
+2. bin/.cline cached binary (if exists; no SIGILL net here — reinstall to fix)
+3. node_modules/@cline/cli-linux-x64-baseline/bin/cline  ← tried first
+4. node_modules/@cline/cli-linux-x64/bin/cline           ← fallback
+5. Error: "Could not find the Cline CLI binary for your platform"
+```
+
+### Building baseline packages locally
+
+```bash
+# Build all platforms including the two baseline variants:
+bun run build:platforms
+
+# Build only the current platform (baseline if on x64 Linux/Windows):
+bun run build:platforms:single
+```
+
+The build script in `script/build.ts` includes `{ os: "linux", arch: "x64", variant: "baseline" }` and `{ os: "win32", arch: "x64", variant: "baseline" }` in `allTargets`. The `variant` field appends `-baseline` to the Bun compile target, package name, and output directory.
+
+### Version synchronization
+
+Baseline packages share the same version number as all other platform packages. All 10 packages (8 standard + 2 baseline) are included in `expectedPlatformPackages` in `script/publish-npm.ts` and must be present in `dist/` before the publish script proceeds.

--- a/apps/cli/DISTRIBUTION.md
+++ b/apps/cli/DISTRIBUTION.md
@@ -14,7 +14,7 @@ Bun's `--compile` flag produces a single self-contained executable that includes
 
 ## What Gets Published
 
-Publishing the CLI publishes 9 packages to npm:
+Publishing the CLI publishes 8 packages to npm:
 
 | Package | Description |
 |---|---|
@@ -23,8 +23,7 @@ Publishing the CLI publishes 9 packages to npm:
 | `@cline/cli-linux-arm64` | Linux ARM binary |
 | `@cline/cli-linux-x64` | Linux x64 binary (AVX2-compiled; requires Haswell or newer) |
 | `@cline/cli-linux-x64-baseline` | Linux x64 baseline binary (no-AVX2; Sandy Bridge and older) |
-| `@cline/cli-windows-x64` | Windows x64 binary (AVX2-compiled) |
-| `@cline/cli-windows-x64-baseline` | Windows x64 baseline binary (no-AVX2) |
+| `@cline/cli-windows-x64` | Windows x64 binary |
 | `@cline/cli-windows-arm64` | Windows ARM binary |
 | `cline` | Wrapper package (pulls the right binary via `optionalDependencies`) |
 
@@ -63,7 +62,6 @@ The `cline` wrapper package contains no binary -- just the resolver script, post
     "@cline/cli-linux-x64": "0.1.0",
     "@cline/cli-linux-x64-baseline": "0.1.0",
     "@cline/cli-windows-x64": "0.1.0",
-    "@cline/cli-windows-x64-baseline": "0.1.0",
     "@cline/cli-windows-arm64": "0.1.0"
   }
 }
@@ -152,7 +150,6 @@ npm installs cline (wrapper package)
     - @cline/cli-linux-x64              (standard; requires AVX2)
     - @cline/cli-linux-x64-baseline     (no-AVX2; installed alongside standard)
     - @cline/cli-windows-x64
-    - @cline/cli-windows-x64-baseline
     - @cline/cli-windows-arm64
   |
   v
@@ -221,7 +218,7 @@ Flags:
 Orchestrates publishing all packages to npm:
 
 1. Reads built packages from `dist/`
-2. Publishes all 8 platform packages in parallel (`@cline/cli-darwin-arm64`, `@cline/cli-linux-x64-baseline`, etc.)
+2. Publishes all 7 platform packages in parallel (`@cline/cli-darwin-arm64`, `@cline/cli-linux-x64-baseline`, etc.)
 3. Generates a clean main package (`cline`) with:
    - `bin.cline` pointing to the resolver script
    - `postinstall` running the binary caching script
@@ -267,10 +264,10 @@ During development, `bin` in package.json points to `src/index.ts` for `bun link
 When building for a different platform (e.g., compiling for Linux on a Mac), Bun needs the target platform's native binaries for `@opentui/core`. The build script handles this by pre-downloading all platform variants with `bun install --os="*" --cpu="*"`.
 
 ### Version synchronization
-All 9 packages (8 platform + 1 wrapper) must have the same version. The build script reads the version from `apps/cli/package.json`. The publish script verifies that the built package versions match each other and `apps/cli/package.json`.
+All 8 packages (7 platform + 1 wrapper) must have the same version. The build script reads the version from `apps/cli/package.json`. The publish script verifies that the built package versions match each other and `apps/cli/package.json`.
 
 ### Package naming and scoping
-Platform packages are published under the `@cline` scope. The generated wrapper package is published as `cline`, so npm trusted publishing must be configured for all 9 package names (including `@cline/cli-linux-x64-baseline` and `@cline/cli-windows-x64-baseline`).
+Platform packages are published under the `@cline` scope. The generated wrapper package is published as `cline`, so npm trusted publishing must be configured for all 8 package names (including `@cline/cli-linux-x64-baseline`).
 
 ### postinstall reliability
 The postinstall script runs in diverse environments (CI, Docker, restricted permissions, network-mounted filesystems where hard links fail). It always wraps operations in try/catch and exits 0. The resolver script is the ultimate fallback.
@@ -292,14 +289,13 @@ The standard Bun-compiled x64 binary requires the AVX2 instruction set extension
 
 ### What is published
 
-Two additional baseline packages are published alongside the standard x64 packages:
+One additional baseline package is published alongside the standard x64 packages:
 
 | Package | Bun target | CPU requirement |
 |---|---|---|
 | `@cline/cli-linux-x64-baseline` | `bun-linux-x64-baseline` | x86-64-v2 (AVX, no AVX2) |
-| `@cline/cli-windows-x64-baseline` | `bun-windows-x64-baseline` | x86-64-v2 (AVX, no AVX2) |
 
-These are built by passing `--target=bun-linux-x64-baseline` (or `bun-windows-x64-baseline`) to `bun build --compile`. Bun embeds its own "baseline" runtime that avoids AVX2 instructions. The packages are identical to the standard packages in every other respect (same version, same `cpu: ["x64"]` field, same binary name).
+This is built by passing `--target=bun-linux-x64-baseline` to `bun build --compile`. Bun embeds its own "baseline" runtime that avoids AVX2 instructions. The package is identical to the standard package in every other respect (same version, same `cpu: ["x64"]` field, same binary name). Windows and macOS baseline detection is out of scope for this patch.
 
 ### How AVX2 detection works
 
@@ -359,12 +355,12 @@ The baseline runtime starts and runs normally on the same machine. This confirms
 # Build all platforms including the two baseline variants:
 bun run build:platforms
 
-# Build only the current platform (baseline if on x64 Linux/Windows):
+# Build only the current platform (baseline if on x64 Linux):
 bun run build:platforms:single
 ```
 
-The build script in `script/build.ts` includes `{ os: "linux", arch: "x64", variant: "baseline" }` and `{ os: "win32", arch: "x64", variant: "baseline" }` in `allTargets`. The `variant` field appends `-baseline` to the Bun compile target, package name, and output directory.
+The build script in `script/build.ts` includes `{ os: "linux", arch: "x64", variant: "baseline" }` in `allTargets`. The `variant` field appends `-baseline` to the Bun compile target, package name, and output directory.
 
 ### Version synchronization
 
-Baseline packages share the same version number as all other platform packages. All 8 platform packages (6 standard + 2 baseline) are included in `expectedPlatformPackages` in `script/publish-npm.ts` and must be present in `dist/` before the publish script proceeds.
+The baseline package shares the same version number as all other platform packages. All 7 platform packages (6 standard + 1 Linux baseline) are included in `expectedPlatformPackages` in `script/publish-npm.ts` and must be present in `dist/` before the publish script proceeds.

--- a/apps/cli/DISTRIBUTION.md
+++ b/apps/cli/DISTRIBUTION.md
@@ -367,4 +367,4 @@ The build script in `script/build.ts` includes `{ os: "linux", arch: "x64", vari
 
 ### Version synchronization
 
-Baseline packages share the same version number as all other platform packages. All 10 packages (8 standard + 2 baseline) are included in `expectedPlatformPackages` in `script/publish-npm.ts` and must be present in `dist/` before the publish script proceeds.
+Baseline packages share the same version number as all other platform packages. All 8 platform packages (6 standard + 2 baseline) are included in `expectedPlatformPackages` in `script/publish-npm.ts` and must be present in `dist/` before the publish script proceeds.

--- a/apps/cli/bin/cline
+++ b/apps/cli/bin/cline
@@ -16,10 +16,9 @@
 // whether the CPU supports AVX2 by reading /proc/cpuinfo. When AVX2 is absent
 // we prefer the "@cline/cli-linux-x64-baseline" package (compiled with
 // --target=bun-linux-x64-baseline) which targets the x86-64-v2 baseline.
-// On all other platforms we conservatively assume AVX2 is present.
-// A SIGILL safety net catches cases where the installed binary still crashes
-// (e.g. forced install, cached .cline binary) and transparently re-runs the
-// baseline variant.
+// AVX2 detection is Linux-only; other platforms always use the standard binary.
+// A SIGILL safety net on Linux catches edge cases (e.g. a cached binary from
+// before this fix was installed).
 
 const childProcess = require("child_process");
 const fs = require("fs");
@@ -37,14 +36,10 @@ const childEnv = {
 	CLINE_WRAPPER_PATH: scriptPath,
 };
 
-// Why: Centralise the host-platform AVX2 probe so callers don't need to know
-// the /proc path or handle read errors.
-// What: Reads /proc/cpuinfo on Linux and delegates to cpuHasAvx2(); returns
-// true unconditionally on non-Linux (no crash observed in practice there).
-// Test: On a no-AVX2 Linux host the call returns false; on macOS it returns true.
+// Reads /proc/cpuinfo on Linux to detect AVX2 support. Returns true on non-Linux platforms (detection is Linux-only).
 function hostCpuHasAvx2() {
 	if (os.platform() !== "linux") {
-		return true; // Only Linux /proc/cpuinfo is reliable; assume capable elsewhere.
+		return true; // AVX2 detection is Linux-only; always use the standard binary on other platforms.
 	}
 	try {
 		const cpuinfo = fs.readFileSync("/proc/cpuinfo", "utf8");
@@ -54,12 +49,7 @@ function hostCpuHasAvx2() {
 	}
 }
 
-// Why: Factor out the binary search loop so the SIGILL fallback path can call
-// it with a different names array without duplicating the directory-walk logic.
-// What: Walks parent directories from startDir looking for node_modules/<name>/bin/<binary>.
-// Returns the first matching path, or undefined if none found.
-// Test: Pass a single-element names array pointing to an existing fake binary
-//       path and verify the function returns that path.
+// Walks parent directories from startDir looking for node_modules/<name>/bin/<binary>. Returns first match or undefined.
 function findBinaryFromNames(startDir, nameList) {
 	let current = startDir;
 	for (;;) {
@@ -80,21 +70,12 @@ function findBinaryFromNames(startDir, nameList) {
 	}
 }
 
-// Why: Convenience wrapper that delegates to findBinaryFromNames using the
-// module-level `names` preference list. Avoids a duplicate directory-walk loop.
-// What: Same as findBinaryFromNames(startDir, names).
-// Test: Same as findBinaryFromNames — verifying findBinary returns the same
-//       result as calling findBinaryFromNames with the global names array.
+// Convenience wrapper: calls findBinaryFromNames with the module-level `names` preference list.
 function findBinary(startDir) {
 	return findBinaryFromNames(startDir, names);
 }
 
-// Why: Centralise process execution so SIGILL handling can be added in one
-// place without duplicating the spawnSync call.
-// What: Runs target with inherited stdio; handles errors, numeric exit codes,
-//       and signals. Optionally returns the raw result for SIGILL inspection.
-// Test: Mock childProcess.spawnSync to return { signal: "SIGILL" } and verify
-//       the return value propagates to the caller when returnResult is true.
+// Runs target with inherited stdio. If returnResult is true, returns the raw spawnSync result instead of exiting.
 function run(target, returnResult) {
 	const result = childProcess.spawnSync(target, process.argv.slice(2), {
 		stdio: "inherit",
@@ -244,7 +225,7 @@ if (!resolved) {
 // re-runs the standard binary.
 const result = run(resolved, /* returnResult= */ true);
 
-if (result.signal === "SIGILL" && arch === "x64") {
+if (result.signal === "SIGILL" && arch === "x64" && platform === "linux") {
 	// Check whether what we ran was already the baseline binary.
 	const resolvedIsBaseline = resolved.includes("-baseline");
 

--- a/apps/cli/bin/cline
+++ b/apps/cli/bin/cline
@@ -10,11 +10,25 @@
 // 1. CLINE_BIN_PATH env var override
 // 2. Cached binary at bin/.cline (created by postinstall)
 // 3. Walk up node_modules to find the platform-specific package
+//
+// AVX2 / no-AVX2 (Sandy Bridge and older Intel x64) handling (issue #10514):
+// The standard Bun-compiled x64 binary requires AVX2. On Linux we detect
+// whether the CPU supports AVX2 by reading /proc/cpuinfo. When AVX2 is absent
+// we prefer the "@cline/cli-linux-x64-baseline" package (compiled with
+// --target=bun-linux-x64-baseline) which targets the x86-64-v2 baseline.
+// On all other platforms we conservatively assume AVX2 is present.
+// A SIGILL safety net catches cases where the installed binary still crashes
+// (e.g. forced install, cached .cline binary) and transparently re-runs the
+// baseline variant.
 
 const childProcess = require("child_process");
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
+
+// Pure helpers live in a separate file so they can be unit-tested without
+// this script's top-level process.exit() calls running.
+const { cpuHasAvx2, buildNames } = require("./resolver-helpers.cjs");
 
 const scriptPath = fs.realpathSync(__filename);
 const scriptDir = path.dirname(scriptPath);
@@ -23,11 +37,72 @@ const childEnv = {
 	CLINE_WRAPPER_PATH: scriptPath,
 };
 
-function run(target) {
+// Why: Centralise the host-platform AVX2 probe so callers don't need to know
+// the /proc path or handle read errors.
+// What: Reads /proc/cpuinfo on Linux and delegates to cpuHasAvx2(); returns
+// true unconditionally on non-Linux (no crash observed in practice there).
+// Test: On a no-AVX2 Linux host the call returns false; on macOS it returns true.
+function hostCpuHasAvx2() {
+	if (os.platform() !== "linux") {
+		return true; // Only Linux /proc/cpuinfo is reliable; assume capable elsewhere.
+	}
+	try {
+		const cpuinfo = fs.readFileSync("/proc/cpuinfo", "utf8");
+		return cpuHasAvx2(cpuinfo);
+	} catch (_) {
+		return true; // If we can't read cpuinfo, assume capable.
+	}
+}
+
+// Why: Factor out the binary search loop so the SIGILL fallback path can call
+// it with a different names array without duplicating the directory-walk logic.
+// What: Walks parent directories from startDir looking for node_modules/<name>/bin/<binary>.
+// Returns the first matching path, or undefined if none found.
+// Test: Pass a single-element names array pointing to an existing fake binary
+//       path and verify the function returns that path.
+function findBinaryFromNames(startDir, nameList) {
+	let current = startDir;
+	for (;;) {
+		const modules = path.join(current, "node_modules");
+		if (fs.existsSync(modules)) {
+			for (const name of nameList) {
+				// Scoped package: @cline/cli-darwin-arm64 lives at
+				// node_modules/@cline/cli-darwin-arm64
+				const candidate = path.join(modules, name, "bin", binary);
+				if (fs.existsSync(candidate)) return candidate;
+			}
+		}
+		const parent = path.dirname(current);
+		if (parent === current) {
+			return undefined;
+		}
+		current = parent;
+	}
+}
+
+// Why: Convenience wrapper that delegates to findBinaryFromNames using the
+// module-level `names` preference list. Avoids a duplicate directory-walk loop.
+// What: Same as findBinaryFromNames(startDir, names).
+// Test: Same as findBinaryFromNames — verifying findBinary returns the same
+//       result as calling findBinaryFromNames with the global names array.
+function findBinary(startDir) {
+	return findBinaryFromNames(startDir, names);
+}
+
+// Why: Centralise process execution so SIGILL handling can be added in one
+// place without duplicating the spawnSync call.
+// What: Runs target with inherited stdio; handles errors, numeric exit codes,
+//       and signals. Optionally returns the raw result for SIGILL inspection.
+// Test: Mock childProcess.spawnSync to return { signal: "SIGILL" } and verify
+//       the return value propagates to the caller when returnResult is true.
+function run(target, returnResult) {
 	const result = childProcess.spawnSync(target, process.argv.slice(2), {
 		stdio: "inherit",
 		env: childEnv,
 	});
+	if (returnResult) {
+		return result;
+	}
 	if (result.error) {
 		console.error(result.error.message);
 		process.exit(1);
@@ -43,12 +118,40 @@ function run(target) {
 }
 
 // 1. Check env var override
+// If the binary pointed to by CLINE_BIN_PATH crashes with SIGILL, it means
+// the user has pointed at an AVX2 binary on a no-AVX2 CPU. Print a clear
+// message before exiting (see issue #10514).
 const envPath = process.env.CLINE_BIN_PATH;
 if (envPath) {
-	run(envPath);
+	const envResult = run(envPath, /* returnResult= */ true);
+	if (envResult.signal === "SIGILL") {
+		process.stderr.write(
+			"cline: CLINE_BIN_PATH binary requires AVX2 but this CPU lacks it. " +
+				"See https://github.com/cline/cline/issues/10514\n",
+		);
+		process.exit(132);
+	}
+	// Propagate normal exit.
+	if (envResult.error) {
+		console.error(envResult.error.message);
+		process.exit(1);
+	}
+	if (typeof envResult.status === "number") {
+		process.exit(envResult.status);
+	}
+	if (envResult.signal) {
+		process.kill(process.pid, envResult.signal);
+		process.exit(128);
+	}
+	process.exit(1);
 }
 
 // 2. Check cached binary
+// Note: the cached binary is written by postinstall and is always the standard
+// (non-baseline) binary. We intentionally do NOT apply SIGILL fallback here
+// because the postinstall script already picks the correct package; if the
+// cached binary SIGILLs the user should reinstall with a newer version that
+// includes the baseline package.
 const cached = path.join(scriptDir, ".cline");
 if (fs.existsSync(cached)) {
 	run(cached);
@@ -77,28 +180,12 @@ if (!arch) {
 const base = "@cline/cli-" + platform + "-" + arch;
 const binary = platform === "windows" ? "cline.exe" : "cline";
 
-// Build fallback chain of package names to try
-const names = [base];
-
-function findBinary(startDir) {
-	let current = startDir;
-	for (;;) {
-		const modules = path.join(current, "node_modules");
-		if (fs.existsSync(modules)) {
-			for (const name of names) {
-				// Scoped package: @cline/cli-darwin-arm64 lives at
-				// node_modules/@cline/cli-darwin-arm64
-				const candidate = path.join(modules, name, "bin", binary);
-				if (fs.existsSync(candidate)) return candidate;
-			}
-		}
-		const parent = path.dirname(current);
-		if (parent === current) {
-			return undefined;
-		}
-		current = parent;
-	}
-}
+// Build preference-ordered chain of package names to try.
+// On x64 Linux without AVX2 (e.g. Intel Sandy Bridge), prefer the baseline
+// package first so the binary works out of the box without needing a SIGILL
+// fallback. The standard package is kept at the end as a last resort for
+// cases where the baseline package was not installed (e.g. an older install).
+const names = buildNames(base, arch, hostCpuHasAvx2());
 
 const resolved = findBinary(scriptDir);
 if (!resolved) {
@@ -119,4 +206,59 @@ if (!resolved) {
 	process.exit(1);
 }
 
-run(resolved);
+// SIGILL safety net (issue #10514):
+// If the resolved binary crashes with SIGILL (Illegal Instruction, typically
+// because the standard x64 Bun runtime requires AVX2 but this CPU lacks it),
+// attempt a one-shot retry with the baseline variant IF:
+//   (a) the resolved path is NOT already the baseline binary, AND
+//   (b) a baseline binary actually exists on disk.
+//
+// This correctly handles the partial-upgrade scenario: no-AVX2 CPU where
+// the baseline package is NOT installed yet → standard package resolves →
+// SIGILLs → we attempt to find and run baseline. Checking `resolvedIsBaseline`
+// instead of whether baseline was in the `names` candidate list fixes the
+// prior bug where a no-AVX2 CPU with baseline as a CANDIDATE (but standard
+// resolving first because baseline dir was absent) would skip the fallback.
+//
+// Guarantee: the fallback runs the baseline binary at most once and never
+// re-runs the standard binary.
+const result = run(resolved, /* returnResult= */ true);
+
+if (result.signal === "SIGILL" && arch === "x64") {
+	// Check whether what we ran was already the baseline binary.
+	const resolvedIsBaseline = resolved.includes("-baseline");
+
+	if (!resolvedIsBaseline) {
+		// The standard binary crashed; look for the baseline variant now.
+		const baselinePackage = base + "-baseline";
+		const baselineBin = findBinaryFromNames(scriptDir, [baselinePackage]);
+		if (baselineBin) {
+			// Run the baseline binary once; this is a terminal call (no returnResult).
+			run(baselineBin);
+			// run() above exits; this line is unreachable.
+		}
+	}
+
+	// No baseline binary found (or we already ran baseline and it still SIGILLed).
+	process.stderr.write(
+		"cline: binary crashed with SIGILL (Illegal Instruction). " +
+			"This CPU may lack AVX2. " +
+			"See https://github.com/cline/cline/issues/10514\n",
+	);
+	process.kill(process.pid, "SIGILL");
+	process.exit(128);
+}
+
+// Handle all other outcomes from the result (normal exit or non-SIGILL signal).
+if (result.error) {
+	console.error(result.error.message);
+	process.exit(1);
+}
+if (typeof result.status === "number") {
+	process.exit(result.status);
+}
+if (result.signal) {
+	process.kill(process.pid, result.signal);
+	process.exit(128);
+}
+process.exit(1);

--- a/apps/cli/bin/cline
+++ b/apps/cli/bin/cline
@@ -147,14 +147,34 @@ if (envPath) {
 }
 
 // 2. Check cached binary
-// Note: the cached binary is written by postinstall and is always the standard
-// (non-baseline) binary. We intentionally do NOT apply SIGILL fallback here
-// because the postinstall script already picks the correct package; if the
-// cached binary SIGILLs the user should reinstall with a newer version that
-// includes the baseline package.
+// postinstall now writes the correct variant (baseline when AVX2 is absent) so
+// the cached binary should always be runnable. As defense-in-depth, however, if
+// the cached binary exits with SIGILL (e.g. a leftover cache from a pre-fix
+// install, or a manual binary replacement), we fall through to the step-3
+// node_modules walk rather than propagating the crash. The node_modules walk
+// already prefers the baseline package on no-AVX2 hosts, so a single fallthrough
+// is sufficient and safe — the binary SIGILLs at startup before doing any work.
 const cached = path.join(scriptDir, ".cline");
 if (fs.existsSync(cached)) {
-	run(cached);
+	const cachedResult = run(cached, /* returnResult= */ true);
+	if (cachedResult.signal === "SIGILL") {
+		// Cached binary is wrong variant; fall through to node_modules walk below.
+		// (no-op: execution continues past this block)
+	} else {
+		// Propagate normal exit or non-SIGILL signal.
+		if (cachedResult.error) {
+			console.error(cachedResult.error.message);
+			process.exit(1);
+		}
+		if (typeof cachedResult.status === "number") {
+			process.exit(cachedResult.status);
+		}
+		if (cachedResult.signal) {
+			process.kill(process.pid, cachedResult.signal);
+			process.exit(128);
+		}
+		process.exit(1);
+	}
 }
 
 // 3. Detect platform and architecture
@@ -233,13 +253,32 @@ if (result.signal === "SIGILL" && arch === "x64") {
 		const baselinePackage = base + "-baseline";
 		const baselineBin = findBinaryFromNames(scriptDir, [baselinePackage]);
 		if (baselineBin) {
-			// Run the baseline binary once; this is a terminal call (no returnResult).
-			run(baselineBin);
-			// run() above exits; this line is unreachable.
+			// Run the baseline binary and inspect the result so that if the
+			// baseline itself SIGILLs (CPU below x86-64-v2) we can print the
+			// helpful #10514 message rather than silently propagating the signal.
+			const baselineResult = run(baselineBin, /* returnResult= */ true);
+			if (baselineResult.signal === "SIGILL") {
+				// Fall through to the helpful message below.
+			} else {
+				// Propagate baseline's normal exit or non-SIGILL signal.
+				if (baselineResult.error) {
+					console.error(baselineResult.error.message);
+					process.exit(1);
+				}
+				if (typeof baselineResult.status === "number") {
+					process.exit(baselineResult.status);
+				}
+				if (baselineResult.signal) {
+					process.kill(process.pid, baselineResult.signal);
+					process.exit(128);
+				}
+				process.exit(1);
+			}
 		}
 	}
 
-	// No baseline binary found (or we already ran baseline and it still SIGILLed).
+	// No baseline binary found, or both standard and baseline SIGILLed
+	// (CPU below x86-64-v2), or we already ran baseline and it still SIGILLed.
 	process.stderr.write(
 		"cline: binary crashed with SIGILL (Illegal Instruction). " +
 			"This CPU may lack AVX2. " +

--- a/apps/cli/bin/resolver-helpers.cjs
+++ b/apps/cli/bin/resolver-helpers.cjs
@@ -2,33 +2,16 @@
 
 // Pure helper functions extracted from bin/cline so they can be unit-tested
 // without requiring the resolver to run its platform-detection side effects.
-//
-// Why: bin/cline is a self-contained CommonJS script that calls process.exit
-// at the top level, making it impossible to require() in tests without the
-// process terminating. Extracting stateless pure helpers into this file lets
-// unit tests exercise the logic directly.
-// What: Exports cpuHasAvx2(text), buildNames(base, arch, hasAvx2), and
-//       choosePackageName(platform, arch, hasAvx2).
-// Test: Import this file in vitest; call the exported functions directly.
+// bin/cline calls process.exit() at the top level, so it cannot be require()d
+// in tests; these stateless helpers can be exercised directly.
+// Exports: cpuHasAvx2(text), buildNames(base, arch, hasAvx2), choosePackageName(platform, arch, hasAvx2).
 
-/**
- * Why: Detect AVX2 from raw /proc/cpuinfo text.
- * What: Returns true if the text contains "avx2" as a whole word.
- * Test: Pass the Sandy Bridge flag line; assert false.
- *       Pass a Haswell flag line; assert true.
- *       Pass a line with "avx" but not "avx2"; assert false.
- */
+/** Returns true if the /proc/cpuinfo text contains "avx2" as a whole word. */
 function cpuHasAvx2(cpuinfoText) {
 	return /(^|\s)avx2(\s|$)/m.test(cpuinfoText);
 }
 
-/**
- * Why: Compute the ordered package name preference list for a given arch/CPU.
- * What: Returns ["<base>-baseline", "<base>"] when arch=="x64" and !hasAvx2,
- *       otherwise just ["<base>"].
- * Test: x64+no-avx2 → baseline first; x64+avx2 → standard only;
- *       arm64 → standard only regardless of hasAvx2.
- */
+/** Returns an ordered list of package names to try. On x64 Linux without AVX2, baseline comes first. */
 function buildNames(base, arch, hasAvx2) {
 	const result = [];
 	if (arch === "x64" && !hasAvx2) {
@@ -38,22 +21,7 @@ function buildNames(base, arch, hasAvx2) {
 	return result;
 }
 
-/**
- * Why: Factor the postinstall package-selection decision into a single pure
- *      function so both postinstall.mjs and the resolver share identical logic
- *      and the decision can be unit-tested without any filesystem side effects.
- * What: Returns the single npm package name that postinstall should resolve and
- *       cache. Returns the "-baseline" variant when arch === "x64" && !hasAvx2,
- *       regardless of platform; otherwise returns the standard package name.
- *       Returns null when the platform is not supported (e.g. win32 from Node
- *       perspective — postinstall skips Windows anyway, but callers must handle
- *       the null case).
- *       Note: callers on non-Linux platforms (darwin) always pass hasAvx2=true,
- *       so the darwin/x64-baseline branch is unreachable in production.
- * Test: choosePackageName("linux","x64",false) === "@cline/cli-linux-x64-baseline"
- *       choosePackageName("linux","x64",true)  === "@cline/cli-linux-x64"
- *       choosePackageName("darwin","arm64",false) === "@cline/cli-darwin-arm64"
- */
+/** Returns the single best package name for postinstall to cache. */
 function choosePackageName(platform, arch, hasAvx2) {
 	const platformMap = {
 		darwin: "darwin",

--- a/apps/cli/bin/resolver-helpers.cjs
+++ b/apps/cli/bin/resolver-helpers.cjs
@@ -1,0 +1,40 @@
+"use strict";
+
+// Pure helper functions extracted from bin/cline so they can be unit-tested
+// without requiring the resolver to run its platform-detection side effects.
+//
+// Why: bin/cline is a self-contained CommonJS script that calls process.exit
+// at the top level, making it impossible to require() in tests without the
+// process terminating. Extracting stateless pure helpers into this file lets
+// unit tests exercise the logic directly.
+// What: Exports cpuHasAvx2(text) and buildNames(base, arch, hasAvx2).
+// Test: Import this file in vitest; call the exported functions directly.
+
+/**
+ * Why: Detect AVX2 from raw /proc/cpuinfo text.
+ * What: Returns true if the text contains "avx2" as a whole word.
+ * Test: Pass the Sandy Bridge flag line; assert false.
+ *       Pass a Haswell flag line; assert true.
+ *       Pass a line with "avx" but not "avx2"; assert false.
+ */
+function cpuHasAvx2(cpuinfoText) {
+	return /(^|\s)avx2(\s|$)/m.test(cpuinfoText);
+}
+
+/**
+ * Why: Compute the ordered package name preference list for a given arch/CPU.
+ * What: Returns ["<base>-baseline", "<base>"] when arch=="x64" and !hasAvx2,
+ *       otherwise just ["<base>"].
+ * Test: x64+no-avx2 → baseline first; x64+avx2 → standard only;
+ *       arm64 → standard only regardless of hasAvx2.
+ */
+function buildNames(base, arch, hasAvx2) {
+	const result = [];
+	if (arch === "x64" && !hasAvx2) {
+		result.push(`${base}-baseline`);
+	}
+	result.push(base);
+	return result;
+}
+
+module.exports = { cpuHasAvx2, buildNames };

--- a/apps/cli/bin/resolver-helpers.cjs
+++ b/apps/cli/bin/resolver-helpers.cjs
@@ -7,7 +7,8 @@
 // at the top level, making it impossible to require() in tests without the
 // process terminating. Extracting stateless pure helpers into this file lets
 // unit tests exercise the logic directly.
-// What: Exports cpuHasAvx2(text) and buildNames(base, arch, hasAvx2).
+// What: Exports cpuHasAvx2(text), buildNames(base, arch, hasAvx2), and
+//       choosePackageName(platform, arch, hasAvx2).
 // Test: Import this file in vitest; call the exported functions directly.
 
 /**
@@ -37,4 +38,34 @@ function buildNames(base, arch, hasAvx2) {
 	return result;
 }
 
-module.exports = { cpuHasAvx2, buildNames };
+/**
+ * Why: Factor the postinstall package-selection decision into a single pure
+ *      function so both postinstall.mjs and the resolver share identical logic
+ *      and the decision can be unit-tested without any filesystem side effects.
+ * What: Returns the single npm package name that postinstall should resolve and
+ *       cache. On x64 Linux/Windows without AVX2 this is the "-baseline" variant;
+ *       on all other platform/arch combinations it is the standard package name.
+ *       Returns null when the platform is not supported (e.g. win32 from Node
+ *       perspective — postinstall skips Windows anyway, but callers must handle
+ *       the null case).
+ * Test: choosePackageName("linux","x64",false) === "@cline/cli-linux-x64-baseline"
+ *       choosePackageName("linux","x64",true)  === "@cline/cli-linux-x64"
+ *       choosePackageName("darwin","arm64",false) === "@cline/cli-darwin-arm64"
+ */
+function choosePackageName(platform, arch, hasAvx2) {
+	const platformMap = {
+		darwin: "darwin",
+		linux: "linux",
+	};
+	const mappedPlatform = platformMap[platform];
+	if (!mappedPlatform) {
+		return null;
+	}
+	const base = `@cline/cli-${mappedPlatform}-${arch}`;
+	if (arch === "x64" && !hasAvx2) {
+		return `${base}-baseline`;
+	}
+	return base;
+}
+
+module.exports = { cpuHasAvx2, buildNames, choosePackageName };

--- a/apps/cli/bin/resolver-helpers.cjs
+++ b/apps/cli/bin/resolver-helpers.cjs
@@ -43,11 +43,13 @@ function buildNames(base, arch, hasAvx2) {
  *      function so both postinstall.mjs and the resolver share identical logic
  *      and the decision can be unit-tested without any filesystem side effects.
  * What: Returns the single npm package name that postinstall should resolve and
- *       cache. On x64 Linux/Windows without AVX2 this is the "-baseline" variant;
- *       on all other platform/arch combinations it is the standard package name.
+ *       cache. Returns the "-baseline" variant when arch === "x64" && !hasAvx2,
+ *       regardless of platform; otherwise returns the standard package name.
  *       Returns null when the platform is not supported (e.g. win32 from Node
  *       perspective — postinstall skips Windows anyway, but callers must handle
  *       the null case).
+ *       Note: callers on non-Linux platforms (darwin) always pass hasAvx2=true,
+ *       so the darwin/x64-baseline branch is unreachable in production.
  * Test: choosePackageName("linux","x64",false) === "@cline/cli-linux-x64-baseline"
  *       choosePackageName("linux","x64",true)  === "@cline/cli-linux-x64"
  *       choosePackageName("darwin","arm64",false) === "@cline/cli-darwin-arm64"

--- a/apps/cli/script/build.ts
+++ b/apps/cli/script/build.ts
@@ -9,6 +9,7 @@ import {
 	realpathSync,
 	statSync,
 } from "node:fs";
+import { platform as osPlatform } from "node:os";
 import { join, relative, resolve } from "node:path";
 import { $ } from "bun";
 import {
@@ -45,6 +46,26 @@ function buildInlinedEnvDefines(): Record<string, string> {
 	return defines;
 }
 
+// Why: Detect AVX2 at build time so the smoke test can skip the standard x64
+// binary on no-AVX2 hosts (it would SIGILL and fail the build) and instead
+// run the baseline x64 binary when it is present.
+// What: Returns true when /proc/cpuinfo contains "avx2" as a whole word.
+// On non-Linux hosts (where /proc/cpuinfo doesn't exist) returns true.
+// Test: On a Sandy Bridge host (avx but no avx2), buildHostHasAvx2() returns false.
+function buildHostHasAvx2(): boolean {
+	if (osPlatform() !== "linux") {
+		return true;
+	}
+	try {
+		const cpuinfo = readFileSync("/proc/cpuinfo", "utf-8");
+		return /(^|\s)avx2(\s|$)/m.test(cpuinfo);
+	} catch {
+		return true;
+	}
+}
+
+const hostHasAvx2 = buildHostHasAvx2();
+
 const pkg = JSON.parse(readFileSync(join(cliDir, "package.json"), "utf-8"));
 const version: string = pkg.version;
 const repository: unknown = pkg.repository;
@@ -53,15 +74,22 @@ console.log(`Building @cline/cli v${version}`);
 
 const buildOptions = parseBuildOptions(process.argv.slice(2));
 
+// "baseline" variant: compiled with bun-linux-x64-baseline / bun-windows-x64-baseline.
+// These binaries use the x86-64-v2 instruction set (no AVX2) and are required on
+// older Intel CPUs such as Sandy Bridge (issue #10514). Only x64 Linux and Windows
+// are affected; macOS does not run on non-AVX2 x64 hardware in practice.
 const allTargets: {
 	os: string;
 	arch: "arm64" | "x64";
+	variant?: "baseline";
 }[] = [
 	{ os: "linux", arch: "arm64" },
 	{ os: "linux", arch: "x64" },
+	{ os: "linux", arch: "x64", variant: "baseline" },
 	{ os: "darwin", arch: "arm64" },
 	{ os: "darwin", arch: "x64" },
 	{ os: "win32", arch: "x64" },
+	{ os: "win32", arch: "x64", variant: "baseline" },
 	{ os: "win32", arch: "arm64" },
 ];
 
@@ -164,7 +192,9 @@ function getBunTarget(
 	item: (typeof allTargets)[number],
 ): Bun.Build.CompileTarget {
 	const targetOs = item.os === "win32" ? "windows" : item.os;
-	return `bun-${targetOs}-${item.arch}` as Bun.Build.CompileTarget;
+	// Append "-baseline" for baseline variants so Bun embeds the no-AVX2 runtime.
+	const suffix = item.variant === "baseline" ? "-baseline" : "";
+	return `bun-${targetOs}-${item.arch}${suffix}` as Bun.Build.CompileTarget;
 }
 
 async function buildCompiledBinary(input: {
@@ -225,8 +255,11 @@ async function buildCompiledBinary(input: {
 for (const item of targets) {
 	// npm treats "win32" specially in os field, but for package naming use "windows"
 	const displayOs = item.os === "win32" ? "windows" : item.os;
-	const name = `@cline/cli-${displayOs}-${item.arch}`;
-	const dirName = `cli-${displayOs}-${item.arch}`;
+	// Baseline variants get a "-baseline" suffix in both the package name and
+	// directory name so they can coexist alongside the standard packages.
+	const variantSuffix = item.variant === "baseline" ? "-baseline" : "";
+	const name = `@cline/cli-${displayOs}-${item.arch}${variantSuffix}`;
+	const dirName = `cli-${displayOs}-${item.arch}${variantSuffix}`;
 	const binaryName = item.os === "win32" ? "cline.exe" : "cline";
 	const bunTarget = getBunTarget(item);
 
@@ -238,21 +271,60 @@ for (const item of targets) {
 
 	await buildCompiledBinary({ bunTarget, dirName, outfile });
 
-	// Smoke test: only run on current platform
+	// Smoke test: only run on current platform.
+	// On x64 Linux without AVX2 (e.g. Sandy Bridge / Xeon E5-2620 v1), the
+	// standard x64 binary requires AVX2 and will SIGILL immediately — which
+	// would fail the build on a host that is working correctly. When AVX2 is
+	// absent we skip the standard x64 smoke test with a warning and instead
+	// run the baseline x64 binary (if it was just built) to prove the build
+	// produced a working artifact. On AVX2-capable hosts all smoke tests run
+	// normally.
 	if (item.os === process.platform && item.arch === process.arch) {
-		console.log(`  Smoke test: ${outfile} --version`);
-		try {
-			const output = await $`${outfile} --version`.text();
-			const actualVersion = output.trim();
-			if (actualVersion !== version) {
-				throw new Error(
-					`Expected --version to print ${version}, got ${actualVersion}`,
-				);
+		const isStandardX64 = item.arch === "x64" && item.variant !== "baseline";
+		const skipBecauseNoAvx2 =
+			isStandardX64 && process.platform === "linux" && !hostHasAvx2;
+
+		if (skipBecauseNoAvx2) {
+			console.warn(
+				`  WARNING: Skipping smoke test for ${name} — ` +
+					`build host lacks AVX2 (standard x64 binary would SIGILL). ` +
+					`The baseline x64 binary will be smoke-tested instead.`,
+			);
+		} else if (
+			item.arch === "x64" &&
+			item.variant === "baseline" &&
+			!hostHasAvx2
+		) {
+			// On a no-AVX2 host, run the baseline binary as the smoke test substitute.
+			console.log(`  Smoke test (baseline substitute): ${outfile} --version`);
+			try {
+				const output = await $`${outfile} --version`.text();
+				const actualVersion = output.trim();
+				if (actualVersion !== version) {
+					throw new Error(
+						`Expected --version to print ${version}, got ${actualVersion}`,
+					);
+				}
+				console.log(`  Passed (baseline): ${actualVersion}`);
+			} catch (e) {
+				console.error(`  Smoke test FAILED for ${name}:`, e);
+				process.exit(1);
 			}
-			console.log(`  Passed: ${actualVersion}`);
-		} catch (e) {
-			console.error(`  Smoke test FAILED for ${name}:`, e);
-			process.exit(1);
+		} else {
+			console.log(`  Smoke test: ${outfile} --version`);
+			try {
+				const output = await $`${outfile} --version`.text();
+				const actualVersion = output.trim();
+				if (actualVersion !== version) {
+					throw new Error(
+						`Expected --version to print ${version}, got ${actualVersion}`,
+					);
+				}
+				console.log(`  Passed: ${actualVersion}`);
+			} catch (e) {
+				console.error(`  Smoke test FAILED for ${name}:`, e);
+				process.exit(1);
+			}
 		}
 	}
 
@@ -277,14 +349,18 @@ for (const item of targets) {
 	}
 
 	// Generate platform package.json
+	const descriptionSuffix =
+		item.variant === "baseline" ? " (baseline / no-AVX2)" : "";
 	await Bun.write(
 		join(cliDir, `dist/${dirName}/package.json`),
 		`${JSON.stringify(
 			{
 				name,
 				version,
-				description: `Cline CLI binary for ${displayOs} ${item.arch}`,
+				description: `Cline CLI binary for ${displayOs} ${item.arch}${descriptionSuffix}`,
 				os: [item.os],
+				// cpu still lists the base architecture; the "-baseline" suffix in the
+				// package name is the signal to npm that this variant targets no-AVX2.
 				cpu: [item.arch],
 				...(repository ? { repository } : {}),
 				bin: {

--- a/apps/cli/script/build.ts
+++ b/apps/cli/script/build.ts
@@ -52,6 +52,13 @@ function buildInlinedEnvDefines(): Record<string, string> {
 // What: Returns true when /proc/cpuinfo contains "avx2" as a whole word.
 // On non-Linux hosts (where /proc/cpuinfo doesn't exist) returns true.
 // Test: On a Sandy Bridge host (avx but no avx2), buildHostHasAvx2() returns false.
+//
+// Note: The AVX2 regex below is intentionally duplicated from
+// bin/resolver-helpers.cjs. build.ts runs under Bun and could technically
+// require() the .cjs helper, but doing so would make the build script depend
+// on a runtime artifact that may not be present in all CI environments (e.g.
+// a fresh checkout before any install step). The duplication is two lines and
+// the risk of divergence is low; keeping build.ts self-contained is simpler.
 function buildHostHasAvx2(): boolean {
 	if (osPlatform() !== "linux") {
 		return true;

--- a/apps/cli/script/build.ts
+++ b/apps/cli/script/build.ts
@@ -46,12 +46,7 @@ function buildInlinedEnvDefines(): Record<string, string> {
 	return defines;
 }
 
-// Why: Detect AVX2 at build time so the smoke test can skip the standard x64
-// binary on no-AVX2 hosts (it would SIGILL and fail the build) and instead
-// run the baseline x64 binary when it is present.
-// What: Returns true when /proc/cpuinfo contains "avx2" as a whole word.
-// On non-Linux hosts (where /proc/cpuinfo doesn't exist) returns true.
-// Test: On a Sandy Bridge host (avx but no avx2), buildHostHasAvx2() returns false.
+// Reads /proc/cpuinfo on Linux to detect AVX2 support at build time. Returns true on non-Linux hosts.
 //
 // Note: The AVX2 regex below is intentionally duplicated from
 // bin/resolver-helpers.cjs. build.ts runs under Bun and could technically
@@ -81,10 +76,10 @@ console.log(`Building @cline/cli v${version}`);
 
 const buildOptions = parseBuildOptions(process.argv.slice(2));
 
-// "baseline" variant: compiled with bun-linux-x64-baseline / bun-windows-x64-baseline.
+// "baseline" variant: compiled with bun-linux-x64-baseline.
 // These binaries use the x86-64-v2 instruction set (no AVX2) and are required on
-// older Intel CPUs such as Sandy Bridge (issue #10514). Only x64 Linux and Windows
-// are affected; macOS does not run on non-AVX2 x64 hardware in practice.
+// older Intel CPUs such as Sandy Bridge (issue #10514). Baseline support is scoped
+// to x64 Linux; Windows and macOS detection is out of scope for this patch.
 const allTargets: {
 	os: string;
 	arch: "arm64" | "x64";
@@ -96,7 +91,6 @@ const allTargets: {
 	{ os: "darwin", arch: "arm64" },
 	{ os: "darwin", arch: "x64" },
 	{ os: "win32", arch: "x64" },
-	{ os: "win32", arch: "x64", variant: "baseline" },
 	{ os: "win32", arch: "arm64" },
 ];
 

--- a/apps/cli/script/postinstall.mjs
+++ b/apps/cli/script/postinstall.mjs
@@ -5,7 +5,7 @@
 // Creates a hard link (or copy fallback) from the platform-specific binary
 // to bin/.cline for fast startup on subsequent runs.
 //
-// On x64 Linux/Windows without AVX2 (e.g. Sandy Bridge / Xeon E5-2620 v1),
+// On x64 Linux without AVX2 (e.g. Sandy Bridge / Xeon E5-2620 v1),
 // the standard Bun-compiled binary requires AVX2 and will SIGILL immediately.
 // This script detects the CPU capability and caches the -baseline variant when
 // AVX2 is absent so the fast-path cached binary is always runnable.
@@ -28,11 +28,7 @@ const { cpuHasAvx2, choosePackageName } = require(
 	path.join(__dirname, "..", "bin", "resolver-helpers.cjs"),
 );
 
-// Why: Determine whether the host CPU supports AVX2 using the same probe as the
-//      runtime resolver, so postinstall and the resolver always agree on which
-//      package to use.
-// What: Reads /proc/cpuinfo on Linux; on non-Linux assumes AVX2 present.
-// Test: On a Sandy Bridge Linux host this returns false.
+// Reads /proc/cpuinfo on Linux to detect AVX2 support. Returns true on non-Linux platforms.
 function hostCpuHasAvx2() {
 	if (os.platform() !== "linux") {
 		return true; // /proc/cpuinfo is only reliable on Linux; assume capable elsewhere.

--- a/apps/cli/script/postinstall.mjs
+++ b/apps/cli/script/postinstall.mjs
@@ -5,6 +5,11 @@
 // Creates a hard link (or copy fallback) from the platform-specific binary
 // to bin/.cline for fast startup on subsequent runs.
 //
+// On x64 Linux/Windows without AVX2 (e.g. Sandy Bridge / Xeon E5-2620 v1),
+// the standard Bun-compiled binary requires AVX2 and will SIGILL immediately.
+// This script detects the CPU capability and caches the -baseline variant when
+// AVX2 is absent so the fast-path cached binary is always runnable.
+//
 // This script must use only Node.js APIs (no Bun) since it runs via
 // "node script/postinstall.mjs" in the npm lifecycle.
 
@@ -17,6 +22,29 @@ import { fileURLToPath } from "node:url";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
 
+// Reuse the pure helpers from bin/resolver-helpers.cjs so the package-selection
+// logic is shared and testable without duplicating the AVX2 detection regex.
+const { cpuHasAvx2, choosePackageName } = require(
+	path.join(__dirname, "..", "bin", "resolver-helpers.cjs"),
+);
+
+// Why: Determine whether the host CPU supports AVX2 using the same probe as the
+//      runtime resolver, so postinstall and the resolver always agree on which
+//      package to use.
+// What: Reads /proc/cpuinfo on Linux; on non-Linux assumes AVX2 present.
+// Test: On a Sandy Bridge Linux host this returns false.
+function hostCpuHasAvx2() {
+	if (os.platform() !== "linux") {
+		return true; // /proc/cpuinfo is only reliable on Linux; assume capable elsewhere.
+	}
+	try {
+		const cpuinfo = fs.readFileSync("/proc/cpuinfo", "utf8");
+		return cpuHasAvx2(cpuinfo);
+	} catch (_) {
+		return true; // If unreadable, conservatively assume capable.
+	}
+}
+
 function main() {
 	if (os.platform() === "win32") {
 		// On Windows, npm creates .cmd shims from the bin field.
@@ -25,13 +53,19 @@ function main() {
 		return;
 	}
 
-	const platformMap = {
-		darwin: "darwin",
-		linux: "linux",
-	};
-	const platform = platformMap[os.platform()] || os.platform();
 	const arch = os.arch();
-	const packageName = `@cline/cli-${platform}-${arch}`;
+	const hasAvx2 = hostCpuHasAvx2();
+
+	// choosePackageName picks the -baseline variant when arch=x64 and !hasAvx2.
+	// Returns null for unsupported platforms (e.g. win32 is already handled above).
+	const packageName = choosePackageName(os.platform(), arch, hasAvx2);
+	if (!packageName) {
+		console.log(
+			`Note: platform ${os.platform()} not supported, skipping binary cache`,
+		);
+		return;
+	}
+
 	const binaryName = "cline";
 
 	let binaryPath;
@@ -44,10 +78,14 @@ function main() {
 			throw new Error(`Binary not found at ${binaryPath}`);
 		}
 	} catch (_error) {
-		// Platform package not available. The resolver script will find
-		// it at runtime by walking node_modules. This is expected on
-		// platforms we don't ship binaries for.
-		console.log(`Note: ${packageName} not found, skipping binary cache`);
+		// Platform package not available. On a no-AVX2 host this means the baseline
+		// package is missing — do NOT fall back to caching the standard (AVX2) binary
+		// because that would SIGILL at runtime. Instead skip caching entirely so the
+		// runtime resolver's node_modules walk (which prefers baseline) handles it.
+		const reason = !hasAvx2 && arch === "x64" ? "baseline " : "";
+		console.log(
+			`Note: ${reason}${packageName} not found, skipping binary cache`,
+		);
 		return;
 	}
 

--- a/apps/cli/script/publish-npm.ts
+++ b/apps/cli/script/publish-npm.ts
@@ -40,7 +40,6 @@ const expectedPlatformPackages = [
 	"@cline/cli-linux-x64-baseline",
 	"@cline/cli-windows-arm64",
 	"@cline/cli-windows-x64",
-	"@cline/cli-windows-x64-baseline",
 ] as const;
 
 const hostSdkPackages = [

--- a/apps/cli/script/publish-npm.ts
+++ b/apps/cli/script/publish-npm.ts
@@ -37,8 +37,10 @@ const expectedPlatformPackages = [
 	"@cline/cli-darwin-x64",
 	"@cline/cli-linux-arm64",
 	"@cline/cli-linux-x64",
+	"@cline/cli-linux-x64-baseline",
 	"@cline/cli-windows-arm64",
 	"@cline/cli-windows-x64",
+	"@cline/cli-windows-x64-baseline",
 ] as const;
 
 const hostSdkPackages = [

--- a/apps/cli/src/resolver.test.ts
+++ b/apps/cli/src/resolver.test.ts
@@ -12,6 +12,10 @@
  *   (c) cpuHasAvx2 with an AVX2 cpuinfo line → true
  *   (d) cpuHasAvx2 without avx2 flag (Sandy Bridge) → false
  *   (e) cpuHasAvx2 must not match "avx" alone or "avx512" as "avx2"
+ *   (f) choosePackageName: x64+noAvx2 → baseline name
+ *   (g) choosePackageName: x64+avx2  → standard name
+ *   (h) choosePackageName: arm64     → standard regardless of hasAvx2
+ *   (i) choosePackageName: unsupported platform → null
  */
 
 import { createRequire } from "node:module";
@@ -26,8 +30,13 @@ const helpers = requireCjs(
 ) as {
 	cpuHasAvx2: (text: string) => boolean;
 	buildNames: (base: string, arch: string, hasAvx2: boolean) => string[];
+	choosePackageName: (
+		platform: string,
+		arch: string,
+		hasAvx2: boolean,
+	) => string | null;
 };
-const { cpuHasAvx2, buildNames } = helpers;
+const { cpuHasAvx2, buildNames, choosePackageName } = helpers;
 
 // ── Sample /proc/cpuinfo excerpts ─────────────────────────────────────────────
 
@@ -106,5 +115,60 @@ describe("buildNames", () => {
 			"@cline/cli-windows-x64-baseline",
 			"@cline/cli-windows-x64",
 		]);
+	});
+});
+
+// ── choosePackageName ─────────────────────────────────────────────────────────
+//
+// These tests verify the postinstall package-selection helper so we can assert
+// that a fresh install on a no-AVX2 x64 host caches the baseline package, never
+// the standard (AVX2-requiring) package.
+
+describe("choosePackageName", () => {
+	it("(f) linux x64 without AVX2 → baseline package name", () => {
+		expect(choosePackageName("linux", "x64", false)).toBe(
+			"@cline/cli-linux-x64-baseline",
+		);
+	});
+
+	it("(g) linux x64 with AVX2 → standard package name", () => {
+		expect(choosePackageName("linux", "x64", true)).toBe(
+			"@cline/cli-linux-x64",
+		);
+	});
+
+	it("(h) linux arm64 without AVX2 → standard package (baseline not applicable)", () => {
+		expect(choosePackageName("linux", "arm64", false)).toBe(
+			"@cline/cli-linux-arm64",
+		);
+	});
+
+	it("(h) linux arm64 with AVX2 → standard package", () => {
+		expect(choosePackageName("linux", "arm64", true)).toBe(
+			"@cline/cli-linux-arm64",
+		);
+	});
+
+	it("(h) darwin arm64 → standard package regardless of hasAvx2", () => {
+		expect(choosePackageName("darwin", "arm64", false)).toBe(
+			"@cline/cli-darwin-arm64",
+		);
+		expect(choosePackageName("darwin", "arm64", true)).toBe(
+			"@cline/cli-darwin-arm64",
+		);
+	});
+
+	it("darwin x64 with AVX2 → standard package", () => {
+		expect(choosePackageName("darwin", "x64", true)).toBe(
+			"@cline/cli-darwin-x64",
+		);
+	});
+
+	it("(i) win32 platform → null (Windows handled separately in postinstall)", () => {
+		expect(choosePackageName("win32", "x64", false)).toBeNull();
+	});
+
+	it("(i) unsupported platform → null", () => {
+		expect(choosePackageName("freebsd", "x64", false)).toBeNull();
 	});
 });

--- a/apps/cli/src/resolver.test.ts
+++ b/apps/cli/src/resolver.test.ts
@@ -164,6 +164,15 @@ describe("choosePackageName", () => {
 		);
 	});
 
+	it("darwin x64 without AVX2 → baseline package (unreachable in production: non-Linux callers always pass hasAvx2=true)", () => {
+		// This input is unreachable in production because the postinstall caller
+		// only reads /proc/cpuinfo on Linux; non-Linux platforms pass hasAvx2=true.
+		// The test documents the pure function's behavior for this logical branch.
+		expect(choosePackageName("darwin", "x64", false)).toBe(
+			"@cline/cli-darwin-x64-baseline",
+		);
+	});
+
 	it("(i) win32 platform → null (Windows handled separately in postinstall)", () => {
 		expect(choosePackageName("win32", "x64", false)).toBeNull();
 	});

--- a/apps/cli/src/resolver.test.ts
+++ b/apps/cli/src/resolver.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Unit tests for the pure helper functions from bin/resolver-helpers.cjs.
+ *
+ * Why: bin/cline is a plain Node CommonJS script whose top-level code calls
+ * process.exit() when no binary is found, making it impossible to require()
+ * in tests. The pure logic is extracted into bin/resolver-helpers.cjs so it
+ * can be tested in isolation without any platform side effects.
+ *
+ * Test coverage:
+ *   (a) buildNames for x64 without AVX2 = ["@cline/cli-linux-x64-baseline","@cline/cli-linux-x64"]
+ *   (b) buildNames for x64 with AVX2    = ["@cline/cli-linux-x64"]
+ *   (c) cpuHasAvx2 with an AVX2 cpuinfo line → true
+ *   (d) cpuHasAvx2 without avx2 flag (Sandy Bridge) → false
+ *   (e) cpuHasAvx2 must not match "avx" alone or "avx512" as "avx2"
+ */
+
+import { createRequire } from "node:module";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+// Import the CJS helper module directly. createRequire lets us load a .cjs
+// file from an ESM/vitest context without fighting the module system.
+const requireCjs = createRequire(import.meta.url);
+const helpers = requireCjs(
+	join(import.meta.dirname, "..", "bin", "resolver-helpers.cjs"),
+) as {
+	cpuHasAvx2: (text: string) => boolean;
+	buildNames: (base: string, arch: string, hasAvx2: boolean) => string[];
+};
+const { cpuHasAvx2, buildNames } = helpers;
+
+// ── Sample /proc/cpuinfo excerpts ─────────────────────────────────────────────
+
+const AVX2_CPUINFO = `
+processor	: 0
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss ht syscall nx rdtscp lm constant_tsc avx avx2 f16c rdrand lahf_lm
+`;
+
+// Intel Sandy Bridge / Xeon E5-2620 v1: has avx but NOT avx2
+const NO_AVX2_CPUINFO = `
+processor	: 0
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss ht syscall nx rdtscp lm constant_tsc avx pclmulqdq aes f16c rdrand lahf_lm
+`;
+
+// Tricky case: avx512 contains "avx" but not "avx2"
+const AVX512_NO_AVX2_CPUINFO = `
+processor	: 0
+flags		: fpu avx avx512f avx512dq
+`;
+
+// ── cpuHasAvx2 ────────────────────────────────────────────────────────────────
+
+describe("cpuHasAvx2", () => {
+	it("(c) returns true when cpuinfo contains the avx2 flag", () => {
+		expect(cpuHasAvx2(AVX2_CPUINFO)).toBe(true);
+	});
+
+	it("(d) returns false when cpuinfo lacks avx2 (Sandy Bridge / no-AVX2 CPU)", () => {
+		expect(cpuHasAvx2(NO_AVX2_CPUINFO)).toBe(false);
+	});
+
+	it("(e) does not mistake 'avx' alone for 'avx2'", () => {
+		// The flag line has "avx" but not "avx2" — must return false.
+		expect(cpuHasAvx2("flags\t: fpu avx pclmulqdq\n")).toBe(false);
+	});
+
+	it("(e) does not mistake 'avx512' for 'avx2'", () => {
+		expect(cpuHasAvx2(AVX512_NO_AVX2_CPUINFO)).toBe(false);
+	});
+
+	it("returns false for empty cpuinfo", () => {
+		expect(cpuHasAvx2("")).toBe(false);
+	});
+});
+
+// ── buildNames ────────────────────────────────────────────────────────────────
+
+describe("buildNames", () => {
+	it("(a) x64 without AVX2 → baseline first, then standard", () => {
+		expect(buildNames("@cline/cli-linux-x64", "x64", false)).toEqual([
+			"@cline/cli-linux-x64-baseline",
+			"@cline/cli-linux-x64",
+		]);
+	});
+
+	it("(b) x64 with AVX2 → standard only", () => {
+		expect(buildNames("@cline/cli-linux-x64", "x64", true)).toEqual([
+			"@cline/cli-linux-x64",
+		]);
+	});
+
+	it("arm64 without AVX2 → standard only (baseline not applicable)", () => {
+		expect(buildNames("@cline/cli-linux-arm64", "arm64", false)).toEqual([
+			"@cline/cli-linux-arm64",
+		]);
+	});
+
+	it("darwin x64 with AVX2 → standard only", () => {
+		expect(buildNames("@cline/cli-darwin-x64", "x64", true)).toEqual([
+			"@cline/cli-darwin-x64",
+		]);
+	});
+
+	it("windows x64 without AVX2 → baseline first, then standard", () => {
+		expect(buildNames("@cline/cli-windows-x64", "x64", false)).toEqual([
+			"@cline/cli-windows-x64-baseline",
+			"@cline/cli-windows-x64",
+		]);
+	});
+});

--- a/apps/cli/src/resolver.test.ts
+++ b/apps/cli/src/resolver.test.ts
@@ -109,13 +109,6 @@ describe("buildNames", () => {
 			"@cline/cli-darwin-x64",
 		]);
 	});
-
-	it("windows x64 without AVX2 → baseline first, then standard", () => {
-		expect(buildNames("@cline/cli-windows-x64", "x64", false)).toEqual([
-			"@cline/cli-windows-x64-baseline",
-			"@cline/cli-windows-x64",
-		]);
-	});
 });
 
 // ── choosePackageName ─────────────────────────────────────────────────────────


### PR DESCRIPTION
### Related Issue

**Issue:** #10514

### Description

Cline's CLI ships only AVX2-compiled Bun x64 binaries (`@cline/cli-linux-x64`). On x64 CPUs that predate the Haswell microarchitecture (Sandy Bridge, Ivy Bridge, early Xeon E5 series, and others), executing these binaries raises SIGILL (illegal instruction, exit 132) because the binary attempts instructions the CPU does not support.

This PR adds a baseline (no-AVX2) compile target for **Linux x64 only** (`@cline/cli-linux-x64-baseline`) and a resolver (`apps/cli/bin/resolver-helpers.cjs`) that detects whether the host CPU has AVX2 via `/proc/cpuinfo` at install/run time and prefers the `-baseline` package when it does not. A SIGILL safety net in `apps/cli/bin/cline` catches edge cases (e.g. a cached binary from before this fix was installed) and re-execs with the baseline variant.

**Scope:** AVX2 detection is Linux-only in this patch. Windows SIGILL detection does not work via Node's `spawnSync` (`EXCEPTION_ILLEGAL_INSTRUCTION` does not map to `signal: "SIGILL"`), and macOS does not run on pre-AVX2 x64 hardware in practice. Windows and macOS contributors can add detection later via `IsProcessorFeatureAvailable` / `sysctl` if desired.

See the linked issue for original reports.

### Test Procedure

**Environment:** Xeon E5-2620 v1 (Sandy Bridge, no AVX2 — flags in `/proc/cpuinfo` do not include `avx2`).

1. Built the CLI from this branch via `script/build.ts --single` targeting `linux-x64-baseline`.
2. Ran `cline --version` with the baseline binary: exits 0, prints `3.0.23`. `cline --help` exits 0.
3. Ran `cline --version` with the standard AVX2 binary (`@cline/cli-linux-x64` from npm): exits 132 (SIGILL) on the same host. Confirmed the contrast.
4. Verified resolver preference via strace: `resolver-helpers.cjs` `buildNames()` returns `["@cline/cli-linux-x64-baseline", "@cline/cli-linux-x64"]` when AVX2 is absent; the first resolvable entry wins.
5. **Resolver unit tests:** 18/18 pass (`vitest run src/resolver.test.ts`, exit 0).
6. **Biome format/lint:** 0 errors/warnings, exit 0.
7. **TypeScript typecheck:** `tsc --noEmit` in `apps/cli` — exit 0, no errors.
8. **Full test suite:** 686 tests run; 683 pass, 3 fail. The 3 failures are all in `src/commands/bin-wrapper.test.ts`, which is unrelated to this PR and fails identically on the base commit (pre-existing).

**Reviewer note on standard-vs-baseline contrast:** Reproducing the SIGILL crash requires both a no-AVX2 build host and the shipped npm AVX2 binary. The baseline binary produced by `script/build.ts --single` on the no-AVX2 host runs correctly. The crash was reproduced using the published `@cline/cli-linux-x64` npm binary on the same host.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist