### PR TITLE
fix(agents): lazy-load llms gateway for browser builds

### DIFF
--- a/sdk/packages/agents/src/agent-runtime.browser-build.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.browser-build.test.ts
@@ -1,0 +1,155 @@
+import { execFile } from "node:child_process";
+import {
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const repositoryRoot = resolve(packageRoot, "../../..");
+const llmsRoot = resolve(packageRoot, "../llms");
+const sharedRoot = resolve(packageRoot, "../shared");
+const require = createRequire(import.meta.url);
+
+function linkSourcePackage(
+	tempDir: string,
+	scope: string,
+	name: string,
+	root: string,
+	exports: Record<string, unknown>,
+): void {
+	const packageDir = join(tempDir, "node_modules", scope, name);
+	mkdirSync(packageDir, { recursive: true });
+	writeFileSync(
+		join(packageDir, "package.json"),
+		JSON.stringify(
+			{
+				name: `${scope}/${name}`,
+				type: "module",
+				exports,
+			},
+			null,
+			2,
+		),
+	);
+	symlinkSync(join(root, "src"), join(packageDir, "src"), "dir");
+}
+
+function linkInstalledPackage(tempDir: string, packageName: string): void {
+	const parts = packageName.split("/");
+	const packageDir = join(tempDir, "node_modules", ...parts);
+	mkdirSync(dirname(packageDir), { recursive: true });
+	let packageJsonPath: string;
+	try {
+		packageJsonPath = require.resolve(`${packageName}/package.json`, {
+			paths: [packageRoot],
+		});
+	} catch {
+		const bunStore = join(repositoryRoot, "node_modules", ".bun");
+		const storePrefix = `${packageName.replace("/", "+")}@`;
+		const storeEntry = readdirSync(bunStore).find((entry) =>
+			entry.startsWith(storePrefix),
+		);
+		if (!storeEntry) {
+			throw new Error(
+				`Unable to resolve package fixture dependency ${packageName}`,
+			);
+		}
+		packageJsonPath = join(
+			bunStore,
+			storeEntry,
+			"node_modules",
+			packageName,
+			"package.json",
+		);
+	}
+	symlinkSync(dirname(packageJsonPath), packageDir, "dir");
+}
+
+describe("AgentRuntime browser bundle", () => {
+	it("bundles the browser-safe Agent entry without resolving the llms gateway", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "cline-agents-browser-"));
+		try {
+			writeFileSync(
+				join(tempDir, "package.json"),
+				JSON.stringify({ type: "module" }, null, 2),
+			);
+			writeFileSync(
+				join(tempDir, "entry.ts"),
+				[
+					'import { Agent } from "@cline/agents";',
+					"console.log(typeof Agent);",
+				].join("\n"),
+			);
+
+			linkSourcePackage(tempDir, "@cline", "agents", packageRoot, {
+				".": {
+					browser: "./src/index.ts",
+					import: "./src/index.ts",
+				},
+			});
+			linkSourcePackage(tempDir, "@cline", "llms", llmsRoot, {
+				".": {
+					browser: "./src/index.browser.ts",
+					import: "./src/index.ts",
+				},
+			});
+			linkSourcePackage(tempDir, "@cline", "shared", sharedRoot, {
+				".": {
+					browser: "./src/index.ts",
+					import: "./src/index.ts",
+				},
+			});
+			linkInstalledPackage(tempDir, "nanoid");
+			linkInstalledPackage(tempDir, "zod");
+
+			const outfile = join(tempDir, "out.js");
+			await execFileAsync(
+				"bun",
+				[
+					"build",
+					join(tempDir, "entry.ts"),
+					"--target",
+					"browser",
+					"--conditions",
+					"browser",
+					"--packages",
+					"bundle",
+					"--external",
+					"@cline/shared",
+					"--external",
+					"nanoid",
+					"--external",
+					"zod",
+					"--outfile",
+					outfile,
+				],
+				{ cwd: tempDir },
+			);
+
+			const output = readFileSync(outfile, "utf8");
+			expect(output).not.toContain("@aws-sdk/credential-providers");
+			expect(output).not.toContain("@opentelemetry/sdk-trace-node");
+			expect(output).not.toContain("vendors/bedrock");
+
+			const { stdout } = await execFileAsync("bun", ["run", outfile], {
+				cwd: tempDir,
+			});
+			expect(stdout.trim()).toBe("function");
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/sdk/packages/agents/src/agent-runtime.provider-form.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.provider-form.test.ts
@@ -9,17 +9,16 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AgentRuntime, AgentRuntimeAbortError } from "./agent-runtime";
 import { Agent, createAgent } from "./index";
 
-const { createAgentModel, createGateway } = vi.hoisted(() => {
+const { createAgentModel, createGateway, llmsModule } = vi.hoisted(() => {
 	const createAgentModel = vi.fn();
 	const createGateway = vi.fn(() => ({
 		createAgentModel,
 	}));
-	return { createAgentModel, createGateway };
+	const llmsModule = { createGateway };
+	return { createAgentModel, createGateway, llmsModule };
 });
 
-vi.mock("@cline/llms", () => ({
-	createGateway,
-}));
+vi.mock("@cline/llms", () => llmsModule);
 
 class ScriptedModel implements AgentModel {
 	constructor(
@@ -53,10 +52,16 @@ describe("AgentRuntime (provider-form config + Agent alias)", () => {
 	beforeEach(() => {
 		createGateway.mockClear();
 		createAgentModel.mockReset();
+		llmsModule.createGateway = createGateway;
 	});
 
-	it("constructs the runtime via the llms gateway in ESM-safe code", () => {
-		const model = new ScriptedModel([]);
+	it("constructs the runtime synchronously and resolves the llms gateway on first run", async () => {
+		const model = new ScriptedModel([
+			() => [
+				{ type: "text-delta", text: "hello" },
+				{ type: "finish", reason: "stop" },
+			],
+		]);
 		createAgentModel.mockReturnValue(model);
 
 		const agent = new Agent({
@@ -66,6 +71,12 @@ describe("AgentRuntime (provider-form config + Agent alias)", () => {
 		});
 
 		expect(agent).toBeInstanceOf(Agent);
+		expect(createGateway).not.toHaveBeenCalled();
+
+		await expect(agent.run("hi")).resolves.toMatchObject({
+			status: "completed",
+			outputText: "hello",
+		});
 		expect(createGateway).toHaveBeenCalledWith({
 			providerConfigs: [
 				{
@@ -76,6 +87,7 @@ describe("AgentRuntime (provider-form config + Agent alias)", () => {
 					options: undefined,
 				},
 			],
+			telemetry: undefined,
 		});
 		expect(createAgentModel).toHaveBeenCalledWith({
 			providerId: "openai",
@@ -83,11 +95,16 @@ describe("AgentRuntime (provider-form config + Agent alias)", () => {
 		});
 	});
 
-	it("passes provider options through to the llms gateway", () => {
-		const model = new ScriptedModel([]);
+	it("passes provider options through to the llms gateway on first run", async () => {
+		const model = new ScriptedModel([
+			() => [
+				{ type: "text-delta", text: "configured" },
+				{ type: "finish", reason: "stop" },
+			],
+		]);
 		createAgentModel.mockReturnValue(model);
 
-		new Agent({
+		const agent = new Agent({
 			providerId: "openai-compatible",
 			modelId: "gpt-4.1",
 			apiKey: "test-key",
@@ -95,6 +112,11 @@ describe("AgentRuntime (provider-form config + Agent alias)", () => {
 			options: { apiVersion: "2025-01-01-preview" },
 		});
 
+		expect(createGateway).not.toHaveBeenCalled();
+		await expect(agent.run("hi")).resolves.toMatchObject({
+			status: "completed",
+			outputText: "configured",
+		});
 		expect(createGateway).toHaveBeenCalledWith({
 			providerConfigs: [
 				{
@@ -106,14 +128,73 @@ describe("AgentRuntime (provider-form config + Agent alias)", () => {
 					options: { apiVersion: "2025-01-01-preview" },
 				},
 			],
+			telemetry: undefined,
 		});
+	});
+
+	it("reports a clear error when the browser llms entry lacks createGateway", async () => {
+		llmsModule.createGateway = undefined as unknown as typeof createGateway;
+		const agent = new Agent({
+			providerId: "openai-compatible",
+			modelId: "gpt-4.1",
+			apiKey: "test-key",
+		});
+
+		const result = await agent.run("hi");
+
+		expect(result.status).toBe("failed");
+		expect(result.error?.message).toBe(
+			"@cline/agents browser builds require a prebuilt AgentModel. Provider-id construction uses @cline/llms and is Node-only.",
+		);
+	});
+
+	it("retries initialization after restore() clears a failed init attempt", async () => {
+		llmsModule.createGateway = undefined as unknown as typeof createGateway;
+		const agent = new Agent({
+			providerId: "openai-compatible",
+			modelId: "gpt-4.1",
+			apiKey: "test-key",
+		});
+
+		await expect(agent.run("hi")).resolves.toMatchObject({
+			status: "failed",
+		});
+
+		llmsModule.createGateway = createGateway;
+		createAgentModel.mockReturnValue(
+			new ScriptedModel([
+				() => [
+					{ type: "text-delta", text: "recovered" },
+					{ type: "finish", reason: "stop" },
+				],
+			]),
+		);
+		agent.restore([
+			{
+				id: "msg_1",
+				role: "user",
+				content: [{ type: "text", text: "restored" }],
+				createdAt: 1,
+			},
+		]);
+
+		await expect(agent.run("hi again")).resolves.toMatchObject({
+			status: "completed",
+			outputText: "recovered",
+		});
+		expect(createGateway).toHaveBeenCalledTimes(1);
 	});
 
 	it("forwards abort() to the active AgentRuntime", async () => {
 		let abortReason: unknown;
+		let resolveStreamStarted!: () => void;
+		const streamStarted = new Promise<void>((resolve) => {
+			resolveStreamStarted = resolve;
+		});
 		const model = new ScriptedModel([
 			async function* (request) {
 				yield { type: "text-delta", text: "partial" };
+				resolveStreamStarted();
 				await new Promise<void>((resolve) => {
 					request.signal?.addEventListener(
 						"abort",
@@ -135,12 +216,7 @@ describe("AgentRuntime (provider-form config + Agent alias)", () => {
 		});
 
 		const runPromise = agent.run("cancel me");
-		for (let i = 0; i < 20; i += 1) {
-			if (agent.snapshot().status === "running") {
-				break;
-			}
-			await new Promise((resolve) => setTimeout(resolve, 0));
-		}
+		await streamStarted;
 		agent.abort("user cancelled");
 
 		await expect(runPromise).resolves.toMatchObject({

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -1,4 +1,4 @@
-import { createGateway, type GatewayProviderSettings } from "@cline/llms";
+import type { GatewayProviderSettings } from "@cline/llms";
 import type {
 	AgentAfterToolResult,
 	AgentBeforeModelResult,
@@ -78,26 +78,47 @@ export type AgentRuntimeConfig =
 	| AgentRuntimeConfigWithModel
 	| AgentRuntimeConfigWithProvider;
 
+type UnresolvedRuntimeConfig = Omit<BaseAgentRuntimeConfig, "model"> & {
+	model?: AgentModel;
+	providerId?: string;
+	modelId?: string;
+};
+
+type RuntimeConfig = Omit<BaseAgentRuntimeConfig, "model" | "toolExecution"> & {
+	toolExecution: NonNullable<BaseAgentRuntimeConfig["toolExecution"]>;
+	model?: AgentModel;
+	providerId?: string;
+	modelId?: string;
+};
+
+interface PendingProviderConfig {
+	providerId: string;
+	modelId: string;
+	apiKey?: string;
+	baseUrl?: string;
+	headers?: Record<string, string>;
+	options?: GatewayProviderSettings["options"];
+}
+
 function hasPrebuiltModel(
 	config: AgentRuntimeConfig,
 ): config is AgentRuntimeConfigWithModel {
 	return (config as AgentRuntimeConfigWithModel).model !== undefined;
 }
 
-function resolveRuntimeConfig(
-	config: AgentRuntimeConfig,
-): BaseAgentRuntimeConfig {
+function resolveRuntimeConfig(config: AgentRuntimeConfig): {
+	config: UnresolvedRuntimeConfig;
+	provider?: PendingProviderConfig;
+} {
 	if (hasPrebuiltModel(config)) {
-		return config;
+		return { config };
 	}
 	const { providerId, modelId, apiKey, baseUrl, headers, options, ...rest } =
 		config;
-	const gateway = createGateway({
-		providerConfigs: [{ providerId, apiKey, baseUrl, headers, options }],
-		telemetry: rest.telemetry,
-	});
-	const model = gateway.createAgentModel({ providerId, modelId });
-	return { ...rest, model };
+	return {
+		config: { ...rest, providerId, modelId },
+		provider: { providerId, modelId, apiKey, baseUrl, headers, options },
+	};
 }
 
 function resolveToolPolicy(
@@ -357,13 +378,8 @@ function normalizeInput(input: AgentRunInput): AgentMessage[] {
 	return cloneMessages([input as AgentMessage]);
 }
 
-export class AgentRuntime {
-	private config: Required<Pick<BaseAgentRuntimeConfig, "toolExecution">> &
-		BaseAgentRuntimeConfig;
-	private readonly listeners = new Set<AgentEventListener>();
-	// biome-ignore lint/suspicious/noExplicitAny: tool input/output types vary per tool
-	private readonly tools = new Map<string, AgentTool<any, any>>();
-	private hooks: HookBag = {
+function createHookBag(): HookBag {
+	return {
 		beforeRun: [],
 		afterRun: [],
 		beforeModel: [],
@@ -372,6 +388,15 @@ export class AgentRuntime {
 		afterTool: [],
 		onEvent: [],
 	};
+}
+
+export class AgentRuntime {
+	private config: RuntimeConfig;
+	private pendingProvider?: PendingProviderConfig;
+	private readonly listeners = new Set<AgentEventListener>();
+	// biome-ignore lint/suspicious/noExplicitAny: tool input/output types vary per tool
+	private readonly tools = new Map<string, AgentTool<any, any>>();
+	private hooks: HookBag = createHookBag();
 	private readonly state = {
 		agentId: "",
 		agentRole: undefined as string | undefined,
@@ -385,18 +410,20 @@ export class AgentRuntime {
 		lastError: undefined as string | undefined,
 	};
 	private initialization?: Promise<void>;
+	private initialized = false;
 	private abortController?: AbortController;
 
 	constructor(config: AgentRuntimeConfig) {
 		const resolved = resolveRuntimeConfig(config);
+		this.pendingProvider = resolved.provider;
 		this.config = {
-			...resolved,
-			toolExecution: resolved.toolExecution ?? "sequential",
+			...resolved.config,
+			toolExecution: resolved.config.toolExecution ?? "sequential",
 		};
-		this.state.agentId = resolved.agentId ?? createUID("agent");
-		this.state.agentRole = resolved.agentRole;
-		this.state.parentAgentId = resolved.parentAgentId;
-		this.state.messages = cloneMessages(resolved.initialMessages ?? []);
+		this.state.agentId = resolved.config.agentId ?? createUID("agent");
+		this.state.agentRole = resolved.config.agentRole;
+		this.state.parentAgentId = resolved.config.parentAgentId;
+		this.state.messages = cloneMessages(resolved.config.initialMessages ?? []);
 	}
 
 	async run(input: AgentRunInput): Promise<AgentRunResult> {
@@ -436,9 +463,16 @@ export class AgentRuntime {
 	 */
 	restore(messages: readonly AgentMessage[]): void {
 		this.abort("Agent state restored");
+		if (!this.initialized) {
+			this.initialization = undefined;
+			this.tools.clear();
+			this.hooks = createHookBag();
+		}
 		// Reset state that is not carried across restores. Keep `listeners`,
-		// tools, hooks, plugins, model, and agent identity so external event
-		// subscribers continue to receive events after restore().
+		// plugins, model, and agent identity so external event subscribers continue
+		// to receive events after restore(). Once initialized, tools and hooks are
+		// also preserved; before that, discard any partial init state so a retry
+		// starts from the configured hooks/tools instead of a cached rejection.
 		this.state.runId = undefined;
 		this.state.status = "idle";
 		this.state.iteration = 0;
@@ -474,6 +508,7 @@ export class AgentRuntime {
 	}
 
 	private async initialize(): Promise<void> {
+		await this.ensureModel();
 		this.registerHooks(this.config.hooks);
 		for (const tool of this.config.tools ?? []) {
 			this.tools.set(tool.name, tool);
@@ -489,6 +524,31 @@ export class AgentRuntime {
 			}
 			this.registerHooks(setup?.hooks);
 		}
+		this.initialized = true;
+	}
+
+	private async ensureModel(): Promise<void> {
+		if (this.config.model) {
+			return;
+		}
+		const provider = this.pendingProvider;
+		if (!provider) {
+			throw new Error("Agent runtime requires a model");
+		}
+		const llms = await import("@cline/llms");
+		const createGateway = llms.createGateway;
+		if (typeof createGateway !== "function") {
+			throw new Error(
+				"@cline/agents browser builds require a prebuilt AgentModel. Provider-id construction uses @cline/llms and is Node-only.",
+			);
+		}
+		const { providerId, modelId, apiKey, baseUrl, headers, options } = provider;
+		const gateway = createGateway({
+			providerConfigs: [{ providerId, apiKey, baseUrl, headers, options }],
+			telemetry: this.config.telemetry,
+		});
+		this.config.model = gateway.createAgentModel({ providerId, modelId });
+		this.pendingProvider = undefined;
 	}
 
 	private registerHooks(hooks: Partial<AgentRuntimeHooks> | undefined): void {
@@ -543,7 +603,6 @@ export class AgentRuntime {
 	}
 
 	private async execute(input?: AgentRunInput): Promise<AgentRunResult> {
-		await this.ensureInitialized();
 		if (this.state.status === "running") {
 			throw new Error("Agent runtime is already running");
 		}
@@ -557,6 +616,7 @@ export class AgentRuntime {
 		this.state.usage = cloneUsage(DEFAULT_USAGE);
 
 		try {
+			await this.ensureInitialized();
 			await this.callBeforeRunHooks();
 			await this.emit({ type: "run-started", snapshot: this.snapshot() });
 
@@ -797,7 +857,11 @@ export class AgentRuntime {
 			...summarizeModelRequest(request),
 		});
 
-		const stream = await this.config.model.stream(request);
+		const model = this.config.model;
+		if (!model) {
+			throw new Error("Agent runtime requires a model");
+		}
+		const stream = await model.stream(request);
 		const content: AgentMessagePart[] = [];
 		const toolAssemblies = new Map<string, PendingToolAssembly>();
 		const invalidToolCalls: InvalidToolCall[] = [];


### PR DESCRIPTION
### Related Issue

**Issue:** Fixes #11415

### Description

`@cline/agents` imported `createGateway` from `@cline/llms` at module load time. Browser builds resolve `@cline/llms` through its browser export, which intentionally does not export `createGateway`, so Vite/Rollup-style builds failed before consumers could use the browser-safe prebuilt-model path.

This PR removes the runtime `@cline/llms` import from the agents module graph. Provider-form configs now stash the provider settings in the constructor and lazily resolve `createGateway` during the existing async initialization path on first run. If the browser `@cline/llms` entry is selected and has no `createGateway`, the runtime returns a clear failed-run error asking browser consumers to provide a prebuilt `AgentModel`.

The public constructor shape remains unchanged for Node consumers: `new Agent({ providerId, modelId, ... })` still works, but provider validation/construction now happens on first run instead of during construction.

This also addresses review follow-ups by clearing partial failed initialization state on `restore()` and by executing the emitted browser bundle in the regression test, not only checking its contents.

### Test Procedure

- `bun -F @cline/agents test`
- `bun -F @cline/agents typecheck`
- `bun -F @cline/agents build`
- `bun biome check --diagnostic-level=error sdk/packages/agents/src/agent-runtime.ts sdk/packages/agents/src/agent-runtime.provider-form.test.ts sdk/packages/agents/src/agent-runtime.browser-build.test.ts`

The new browser build regression test exercises the browser conditional export path, verifies the bundle does not include known Node-only provider dependencies such as AWS credential providers or Node OTEL tracing, and executes the emitted bundle to confirm `Agent` is importable.

Note: the pre-commit hook's repo-wide `bun run types` failed outside this change in `@cline/cline-hub` with `"@cline/llms" has no exported member named 'hasRegisteredHandler'`. The focused `@cline/agents` typecheck passed both directly and inside that hook before the unrelated workspace failure stopped the hook.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — SDK/runtime packaging fix only.

### Additional Notes

Behavioral notes for reviewers:

- Provider-form `Agent` construction now resolves the gateway during first run/init instead of in the constructor.
- Failed initialization is reported through the same failed `AgentRunResult` channel as other runtime failures.
- Browser-side default OpenAI-compatible construction remains a separate product/API decision; this PR unblocks browser imports and preserves the prebuilt `AgentModel` browser path.
