### PR TITLE
fix(vscode): persist task state before PreToolUse hook abort (#9937)

### DIFF
--- a/apps/vscode/src/core/task/tools/utils/ToolHookUtils.ts
+++ b/apps/vscode/src/core/task/tools/utils/ToolHookUtils.ts
@@ -92,6 +92,15 @@ export class ToolHookUtils {
 
 		// Handle cancellation from hook
 		if (preToolResult.cancel === true) {
+			// Signal that the stream has finished aborting so Controller.cancelTask's
+			// pWaitFor resolves on the correct condition rather than racing on isStreaming.
+			config.taskState.didFinishAbortingStream = true
+			// Persist conversation state before handing off to Controller — same pattern
+			// as Task.handleHookCancellation used by TaskStart/TaskResume/UserPromptSubmit.
+			await config.messageState.saveClineMessagesAndUpdateHistory()
+			await config.messageState.overwriteApiConversationHistory(
+				config.messageState.getApiConversationHistory(),
+			)
 			// Clear the active hook execution state BEFORE calling cancelTask
 			// This prevents abortTask from trying to "cancel" an already-completed hook
 			await config.callbacks.clearActiveHookExecution()


### PR DESCRIPTION
### Description

When a PreToolUse hook returns `{"cancel":true}`, the task enters an unresponsive "Resume task" state where user input is ignored until a full VS Code window reload. The root cause is that `ToolHookUtils.runPreToolUseIfEnabled` calls `cancelTask()` without first setting `didFinishAbortingStream` or persisting the message history, causing the Controller's cancellation handoff to race against the streaming state.

**Root cause:** `ToolHookUtils.runPreToolUseIfEnabled` (apps/vscode/src/core/task/tools/utils/ToolHookUtils.ts:94–101) detects `preToolResult.cancel === true` and calls `await config.callbacks.cancelTask()`. At the time of that call `taskState.didFinishAbortingStream` is `false` and `taskState.isStreaming` may also be `false` (the hook ran synchronously between API chunks). `Controller.cancelTask()` calls `task.abortTask()` and then waits with a `pWaitFor` that resolves immediately on the first polling tick — without actually waiting for the hook's own cleanup to complete — because `isStreaming` is already false and `didFinishAbortingStream` has never been set.

Additionally, other hook cancellation paths (TaskStart, TaskResume, UserPromptSubmit via `Task.handleHookCancellation`) persist conversation state to disk before calling `cancelTask()`. PreToolUse was missing these calls, so when `Controller.cancelTask()` creates a new Task instance via `initTask(historyItem)`, the conversation state wasn't available, leaving the new task out of sync with the UI.

**Fix:** Before calling `cancelTask()` in `ToolHookUtils.runPreToolUseIfEnabled`, set `taskState.didFinishAbortingStream = true` and persist both `clineMessages` and `apiConversationHistory` to disk — matching the pattern already used by `Task.handleHookCancellation`. This ensures `Controller.cancelTask`'s `pWaitFor` waits for the correct signal rather than racing on `isStreaming`, and history is on disk for `initTask` to find.

**Scope:** When hooks return `cancel:false` or no output, functions exactly as before. PostToolUse, TaskStart, TaskResume, and UserPromptSubmit hook cancellation paths are unaffected. Issue #11098 (task auto-restart after clicking Abort during hook execution) is also resolved: the `config.taskState.abort` guard at line 105 already prevents a second `cancelTask()` call, so once state is saved the task cleans up without restarting.

### Test Procedure

Unit tests covering the changed code:
- `src/core/task/tools/utils/__tests__/ToolHookUtils.test.ts` (2/2 passing): validates hook execution and fire-and-forget pattern
- `src/core/task/__tests__/Task.ask.test.ts` (5/5 passing): ensures resume asks remain pending during abort and resolve when user responds — critical path for Resume button functionality
- `src/core/hooks/__tests__/taskcancel.test.ts` (27/27 passing): covers TaskCancel hook invocation with correct metadata and fire-and-forget behavior

**Total: 1466 passing, 4 pending — no failures**

The tests verify that hook cancellation is detected correctly, that resume asks don't prematurely wake during cancellation, and that message state handling works across the task lifecycle.

Manual reproduction (required in VS Code debug instance):
1. Create a PreToolUse hook script that outputs `{"cancel":true}`.
2. Start a task that invokes a tool (e.g., "list files in .").
3. Observe: "Resume task" button appears. Click it and confirm the task resumes without requiring a VS Code reload (previously required reload).
4. Repeat with Abort button click during hook execution: verify task stops cleanly without auto-restart.

What could break: any code path relying on `cancelTask()` running before history is written. No such code exists — `Controller.cancelTask` already handles missing history by calling `clearTask()` as a fallback. The added disk writes are idempotent.

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Cosmetic
- [ ] Documentation

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix, or chore
- [x] Tests are passing and code is formatted and linted
- [x] I have reviewed contributor guidelines

### Screenshots

N/A — backend state-machine fix. The observable difference is that the "Resume task" button becomes functional after a PreToolUse hook cancellation, eliminating the need for a window reload.

### Additional Notes

The pattern of `didFinishAbortingStream = true` + disk saves before `cancelTask()` is already established in `Task.handleHookCancellation` (apps/vscode/src/core/task/index.ts:976–989), used by TaskStart, TaskResume, and UserPromptSubmit hook cancellation paths. This PR brings PreToolUse into that same pattern. The existing comment in ToolHookUtils says "Abort the entire task (consistent with PostToolUse and other hook cancellations)" — the disk-write step was simply missing.

## Upstream

Closes #9937.
Reported by @tryvin.
