### PR TITLE
fix(cli): implement ACP loadSession to prevent -32601 on Zed restart (#11404)

### DIFF
--- a/apps/cli/src/acp/acpAgent.ts
+++ b/apps/cli/src/acp/acpAgent.ts
@@ -7,6 +7,8 @@ import type {
 	ContentBlock,
 	InitializeRequest,
 	InitializeResponse,
+	LoadSessionRequest,
+	LoadSessionResponse,
 	NewSessionRequest,
 	NewSessionResponse,
 	PromptRequest,
@@ -176,6 +178,84 @@ export class AcpAgent implements Agent {
 				await buildProviderConfigOption(providerId),
 				buildModelConfigOption(defaultModelId, providerModels),
 				buildModeConfigOption(defaultMode),
+			],
+		};
+	}
+
+	async loadSession(params: LoadSessionRequest): Promise<LoadSessionResponse> {
+		// Require authentication, same gate as newSession.
+		if (!this.authResult && !process.env.CLINE_API_KEY) {
+			this.authResult = this.tryRestoreAuth();
+
+			if (!this.authResult) {
+				throw RequestError.authRequired(
+					undefined,
+					"Call authenticate before loading a session",
+				);
+			}
+		}
+
+		// Tear down any existing session under this id to avoid leaking
+		// the old sessionManager and event subscription.
+		const existing = this.sessions.get(params.sessionId);
+		if (existing) {
+			await this.teardownSessionManager(existing);
+			if (existing.unsubscribe) {
+				existing.unsubscribe();
+			}
+		}
+
+		// The CLI does not persist session history across process restarts.
+		// We create a new session under the requested sessionId so the client
+		// can continue sending prompts without receiving a hard -32601 error.
+		// TODO: restore conversation history when a session store is available
+		const providerId =
+			process.env.CLINE_PROVIDER ?? this.authResult?.providerId ?? "cline";
+		const defaultModelId =
+			process.env.CLINE_MODEL ?? "anthropic/claude-sonnet-4.6";
+
+		this.sessions.set(params.sessionId, {
+			id: params.sessionId,
+			cwd: params.cwd,
+			mcpServers: params.mcpServers,
+			currentMode: "act",
+			currentProviderId: providerId,
+			currentModelId: defaultModelId,
+		});
+
+		const providerModels = await Llms.getModelsForProvider(providerId);
+
+		return {
+			modes: {
+				availableModes: [
+					{
+						id: "plan",
+						name: "Plan",
+						description:
+							"Explore the codebase and plan changes without modifying files",
+					},
+					{
+						id: "act",
+						name: "Act",
+						description: "Make changes to the codebase",
+					},
+				],
+				currentModeId: "act",
+			},
+			models: {
+				availableModels: Object.entries(providerModels).map(
+					([modelId, info]) => ({
+						modelId,
+						name: info.name ?? modelId,
+						description: info.description,
+					}),
+				),
+				currentModelId: defaultModelId,
+			},
+			configOptions: [
+				await buildProviderConfigOption(providerId),
+				buildModelConfigOption(defaultModelId, providerModels),
+				buildModeConfigOption("act"),
 			],
 		};
 	}

--- a/apps/cli/src/acp/index.test.ts
+++ b/apps/cli/src/acp/index.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("runAcpMode", () => {
 	afterEach(() => {
@@ -32,5 +32,156 @@ describe("runAcpMode", () => {
 		expect(stderrWrite).not.toHaveBeenCalledWith(
 			expect.stringContaining("error:"),
 		);
+	});
+});
+
+describe("AcpAgent.loadSession", () => {
+	let savedApiKey: string | undefined;
+
+	beforeEach(() => {
+		savedApiKey = process.env.CLINE_API_KEY;
+		process.env.CLINE_API_KEY = "test-key";
+	});
+
+	afterEach(() => {
+		if (savedApiKey === undefined) {
+			delete process.env.CLINE_API_KEY;
+		} else {
+			process.env.CLINE_API_KEY = savedApiKey;
+		}
+		vi.doUnmock("@agentclientprotocol/sdk");
+		vi.doUnmock("@cline/core");
+		vi.doUnmock("./acpAgent");
+		vi.restoreAllMocks();
+	});
+
+	it("returns a LoadSessionResponse with modes, models, and configOptions", async () => {
+		vi.doMock("@agentclientprotocol/sdk", () => ({
+			PROTOCOL_VERSION: "0.1.0",
+			RequestError: { methodNotFound: () => new Error("Method not found") },
+			AgentSideConnection: class {
+				closed = Promise.resolve();
+			},
+		}));
+
+		vi.doMock("@cline/core", () => ({
+			Llms: {
+				getModelsForProvider: vi.fn().mockResolvedValue({
+					"anthropic/claude-sonnet-4.6": { name: "Claude Sonnet 4.6" },
+				}),
+				getProvider: vi.fn().mockResolvedValue({ name: "Cline" }),
+			},
+			ProviderSettingsManager: class {
+				getProviderSettings() {
+					return {};
+				}
+			},
+			SessionSource: { CLI: "cli" },
+		}));
+
+		const { AcpAgent } = await import("./acpAgent");
+
+		const mockConn = {
+			on: vi.fn(),
+			send: vi.fn(),
+			closed: Promise.resolve(),
+		} as any;
+		const agent = new AcpAgent(mockConn);
+
+		const response = await agent.loadSession({
+			sessionId: "test-id",
+			cwd: "/workspace",
+			mcpServers: [],
+		});
+
+		expect(response).toHaveProperty("modes");
+		expect(response).toHaveProperty("models");
+		expect(response).toHaveProperty("configOptions");
+		expect(response.modes?.currentModeId).toBe("act");
+		expect(response.models?.currentModelId).toBe("anthropic/claude-sonnet-4.6");
+	});
+
+	it("registers the session under the provided sessionId for subsequent prompts", async () => {
+		vi.doMock("@agentclientprotocol/sdk", () => ({
+			PROTOCOL_VERSION: "0.1.0",
+			RequestError: { methodNotFound: () => new Error("Method not found") },
+			AgentSideConnection: class {
+				closed = Promise.resolve();
+			},
+		}));
+
+		vi.doMock("@cline/core", () => ({
+			Llms: {
+				getModelsForProvider: vi.fn().mockResolvedValue({
+					"anthropic/claude-sonnet-4.6": { name: "Claude Sonnet 4.6" },
+				}),
+				getProvider: vi.fn().mockResolvedValue({ name: "Cline" }),
+			},
+			ProviderSettingsManager: class {
+				getProviderSettings() {
+					return {};
+				}
+			},
+			SessionSource: { CLI: "cli" },
+		}));
+
+		const { AcpAgent } = await import("./acpAgent");
+
+		const mockConn = {
+			on: vi.fn(),
+			send: vi.fn(),
+			closed: Promise.resolve(),
+		} as any;
+		const agent = new AcpAgent(mockConn);
+
+		await agent.loadSession({
+			sessionId: "test-id",
+			cwd: "/workspace",
+			mcpServers: [],
+		});
+
+		// Access the private sessions map via reflection to verify the session was registered
+		const sessions = (agent as any).sessions;
+		expect(sessions.has("test-id")).toBe(true);
+
+		const session = sessions.get("test-id");
+		expect(session.id).toBe("test-id");
+		expect(session.cwd).toBe("/workspace");
+	});
+
+	it("initialize advertises loadSession: true", async () => {
+		vi.doMock("@agentclientprotocol/sdk", () => ({
+			PROTOCOL_VERSION: "0.1.0",
+			RequestError: { methodNotFound: () => new Error("Method not found") },
+			AgentSideConnection: class {
+				closed = Promise.resolve();
+			},
+		}));
+
+		vi.doMock("@cline/core", () => ({
+			Llms: {
+				getModelsForProvider: vi.fn().mockResolvedValue({}),
+				getProvider: vi.fn().mockResolvedValue({}),
+			},
+			ProviderSettingsManager: class {
+				getProviderSettings() {
+					return {};
+				}
+			},
+			SessionSource: { CLI: "cli" },
+		}));
+
+		const { AcpAgent } = await import("./acpAgent");
+
+		const mockConn = {
+			on: vi.fn(),
+			send: vi.fn(),
+			closed: Promise.resolve(),
+		} as any;
+		const agent = new AcpAgent(mockConn);
+
+		const response = await agent.initialize({} as any);
+
+		expect(response.agentCapabilities?.loadSession).toBe(true);
 	});
 });


### PR DESCRIPTION
# PR: fix(cli): implement ACP loadSession to prevent -32601 on Zed restart

## Description

When a Zed user restarts their editor after using Cline in ACP (Agent Client Protocol) mode, Zed sends a `session/load` request using the sessionId from the previous conversation. The server responds with `-32601 "Method not found"` even though the `initialize` response advertised `agentCapabilities.loadSession: true`. This breaks the user workflow—the session is lost and the user must start over.

Root cause: `AcpAgent.initialize()` advertises `loadSession: true`, but the `AcpAgent` class does not implement a `loadSession` method. The SDK's `AgentSideConnection` dispatcher checks for the presence of `loadSession` on the agent instance and throws "method not found" if it's missing.

The fix implements `loadSession` as a new-session fallback: the method preserves the `cwd`, `mcpServers`, and `sessionId` from the request and creates a fresh `SessionState` (conversation history is lost, but the agent is ready to continue). This prevents the hard error and allows Zed to proceed with subsequent prompts.

**Changes:**
- Extended the import list in `apps/cli/src/acp/acpAgent.ts` to include `LoadSessionRequest` and `LoadSessionResponse` from `@agentclientprotocol/sdk`.
- Added the `loadSession` async method to the `AcpAgent` class (between `newSession` and `prompt`).
 - Resolves `providerId` and `defaultModelId` using the same env-then-auth fallback as `newSession`.
 - Calls `this.sessions.set()` to register the session under the provided sessionId.
 - Returns a `LoadSessionResponse` with `modes`, `models`, and `configOptions` populated identically to `newSession`.
 - Includes a TODO comment for restoring conversation history when a persistence layer is available.
- Added three unit tests in `apps/cli/src/acp/index.test.ts`:
 - Verifies that `loadSession` returns a valid `LoadSessionResponse` shape with all required properties.
 - Verifies that the session is registered in the internal `sessions` Map under the provided sessionId.
 - Verifies that `initialize()` continues to advertise `loadSession: true`.

## Test Procedure

**Unit tests (targeted):**
```
bun -F @cline/cli test src/acp/index.test.ts
```
Result: **4 passed (4)** — all tests in the test file pass, including the original "writes the startup diagnostic" test and the three new `loadSession` tests.

**Typecheck:**
```
bun -F @cline/cli typecheck
```
Result: **No errors** — TypeScript compilation succeeds with no errors.

**What could break and how it was verified:**
- **Breaking the `initialize` contract:** The new `loadSession` method is added alongside `newSession` without modifying existing behavior. The `initialize` test confirms the capability flag is still advertised.
- **Session routing to subsequent prompts:** The `loadSession` test verifies that the session is registered under the correct ID, so the existing `prompt` and `cancel` methods (which look up sessions by ID) continue to work.
- **Model and mode availability:** The method reuses the same model and mode resolution logic as `newSession`, ensuring consistency. Tests verify the response includes the correct default model and mode.
- **SDK dispatcher compatibility:** By implementing `loadSession` as a proper method on the `AcpAgent` instance, the SDK's dispatcher no longer throws `-32601`; it can now dispatch incoming `session/load` requests to this handler.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore / documentation update

## Pre-flight Checklist

- [x] My code follows the code style of this project
- [x] I have tested the changes locally
- [ ] I have not created any changeset files or CHANGELOG entries (maintainers handle these)

## Screenshots

N/A — backend change, no UI involved. The fix ensures that when Zed sends a `session/load` RPC, the CLI agent responds with a valid `LoadSessionResponse` instead of a method-not-found error.

## Additional Notes

The CLI does not currently persist session history between process invocations; `sessionManager.readMessages()` only works on a live `ClineCore` instance. The correct minimal fix is therefore to treat `loadSession` as a new-session fallback: preserve the context (cwd, mcpServers, sessionId) but discard the conversation history. The TODO comment marks where true cross-restart persistence can be added later.

This mirrors the design pattern used in `teardownSessionManager()` and `ensureSessionManager()`, which already support conversation continuity within a single process via `pendingInitialMessages`.

## Upstream

Closes #11404.
Reported by @TAYUN.
