### PR TITLE
fix(cli): prevent orphaned hub daemon accumulation on Windows (#10857)

### DIFF
--- a/sdk/packages/core/src/hub/client/index.test.ts
+++ b/sdk/packages/core/src/hub/client/index.test.ts
@@ -3,6 +3,7 @@ import {
 	HubTransportError,
 	isHubReconnectableTransportError,
 	NodeHubClient,
+	verifyHubConnection,
 } from "../client";
 
 type SocketListener = (...args: unknown[]) => void;
@@ -144,6 +145,77 @@ class FakeWebSocket {
 	}
 }
 
+class FlakyHealthcheckWebSocket {
+	static readonly CONNECTING = 0;
+	static readonly OPEN = 1;
+	static readonly CLOSED = 3;
+	static attempts = 0;
+	static failUntil = 0;
+
+	readyState = FlakyHealthcheckWebSocket.CONNECTING;
+	private readonly listeners = new Map<string, SocketListener[]>();
+
+	constructor(_url: string) {
+		FlakyHealthcheckWebSocket.attempts++;
+		const shouldFail =
+			FlakyHealthcheckWebSocket.attempts <= FlakyHealthcheckWebSocket.failUntil;
+		queueMicrotask(() => {
+			if (shouldFail) {
+				this.readyState = FlakyHealthcheckWebSocket.CLOSED;
+				this.emit("error", new Error("connect ECONNREFUSED 127.0.0.1:25463"));
+				return;
+			}
+			this.readyState = FlakyHealthcheckWebSocket.OPEN;
+			this.emit("open");
+		});
+	}
+
+	static reset(): void {
+		FlakyHealthcheckWebSocket.attempts = 0;
+		FlakyHealthcheckWebSocket.failUntil = 0;
+	}
+
+	send(data: string): void {
+		const frame = JSON.parse(data) as {
+			kind?: string;
+			envelope?: { requestId?: string };
+		};
+		if (frame.kind === "command" && frame.envelope?.requestId) {
+			queueMicrotask(() => {
+				this.emit("message", {
+					data: JSON.stringify({
+						kind: "reply",
+						envelope: {
+							version: "v1",
+							command: "client.register",
+							requestId: frame.envelope?.requestId,
+							ok: true,
+							clientId: "hub",
+							payload: {},
+						},
+					}),
+				});
+			});
+		}
+	}
+
+	close(): void {
+		this.readyState = FlakyHealthcheckWebSocket.CLOSED;
+	}
+
+	addEventListener(type: string, listener: SocketListener): void {
+		const listeners = this.listeners.get(type) ?? [];
+		listeners.push(listener);
+		this.listeners.set(type, listeners);
+	}
+
+	private emit(type: string, ...args: unknown[]): void {
+		for (const listener of this.listeners.get(type) ?? []) {
+			listener(...args);
+		}
+	}
+}
+
 describe("NodeHubClient", () => {
 	describe("subscription re-registration", () => {
 		afterEach(() => {
@@ -254,6 +326,29 @@ describe("NodeHubClient", () => {
 			);
 
 			await client.dispose();
+		});
+	});
+
+	describe("verifyHubConnection", () => {
+		afterEach(() => {
+			FlakyHealthcheckWebSocket.reset();
+			vi.unstubAllGlobals();
+		});
+
+		it("retries connection-refused startup failures before succeeding", async () => {
+			vi.useFakeTimers();
+			FlakyHealthcheckWebSocket.failUntil = 2;
+			vi.stubGlobal("WebSocket", FlakyHealthcheckWebSocket);
+
+			try {
+				const resultPromise = verifyHubConnection("ws://127.0.0.1:25463/hub");
+				await vi.runAllTimersAsync();
+
+				await expect(resultPromise).resolves.toBe(true);
+				expect(FlakyHealthcheckWebSocket.attempts).toBe(3);
+			} finally {
+				vi.useRealTimers();
+			}
 		});
 	});
 

--- a/sdk/packages/core/src/hub/client/index.ts
+++ b/sdk/packages/core/src/hub/client/index.ts
@@ -807,22 +807,36 @@ export async function verifyHubConnection(
 	url: string,
 	options?: Pick<HubClientOptions, "workspaceRoot" | "cwd" | "authToken">,
 ): Promise<boolean> {
-	const client = new NodeHubClient({
-		url,
-		authToken: options?.authToken,
-		clientType: "hub-healthcheck",
-		displayName: "hub healthcheck",
-		workspaceRoot: options?.workspaceRoot,
-		cwd: options?.cwd,
-	});
-	try {
-		await client.connect();
-		return true;
-	} catch {
-		return false;
-	} finally {
-		client.close();
+	const maxAttempts = 3;
+	const retryDelayMs = 100;
+
+	for (let attempt = 0; attempt < maxAttempts; attempt++) {
+		const client = new NodeHubClient({
+			url,
+			authToken: options?.authToken,
+			clientType: "hub-healthcheck",
+			displayName: "hub healthcheck",
+			workspaceRoot: options?.workspaceRoot,
+			cwd: options?.cwd,
+		});
+		try {
+			await client.connect();
+			return true;
+		} catch (error) {
+			const isConnectionRefused =
+				error instanceof Error &&
+				(error.message.includes("ECONNREFUSED") ||
+					error.message.includes("Connection refused"));
+			if (!isConnectionRefused || attempt === maxAttempts - 1) {
+				return false;
+			}
+			await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+		} finally {
+			client.close();
+		}
 	}
+
+	return false;
 }
 
 type HubProbeResult =

--- a/sdk/packages/core/src/hub/daemon/index.test.ts
+++ b/sdk/packages/core/src/hub/daemon/index.test.ts
@@ -586,84 +586,57 @@ describe("ensureDetachedHubServer", () => {
 	});
 
 	it("does not spawn a second daemon when a concurrent call holds the startup lock", async () => {
-		vi.useFakeTimers();
-		try {
-			let discoveryCallCount = 0;
-			readHubDiscovery.mockImplementation(async () => {
-				discoveryCallCount++;
-				// First caller gets undefined, then after a small async delay return valid record
-				if (discoveryCallCount <= 1) {
-					return undefined;
-				}
-				return {
-					url: "ws://127.0.0.1:5555/hub",
-					buildId: "current-build",
-					authToken: "shared-token",
-				};
-			});
-			probeHubServer.mockResolvedValue({
-				url: "ws://127.0.0.1:5555/hub",
-				buildId: "current-build",
-			});
-			verifyHubConnection.mockResolvedValue(true);
-			withHubStartupLock.mockImplementation(
-				async (_discoveryPath: string, callback: () => Promise<unknown>) => {
-					// Simulate lock serialization: first call proceeds, second waits briefly
-					const callCount =
-						(withHubStartupLock as unknown as { callCount?: number })
-							.callCount ?? 0;
-					(withHubStartupLock as unknown as { callCount?: number }).callCount =
-						callCount + 1;
-					if (callCount > 0) {
-						// Simulate the first caller holding the lock long enough
-						await new Promise((resolve) => setTimeout(resolve, 150));
-					}
-					return callback();
-				},
-			);
-
-			const { ensureDetachedHubServer } = await import(".");
-			const call1 = ensureDetachedHubServer("/workspace");
-			const call2 = ensureDetachedHubServer("/workspace");
-
-			await vi.runAllTimersAsync();
-			const result1 = await call1;
-			const result2 = await call2;
-
-			expect(result1).toEqual({
-				url: "ws://127.0.0.1:5555/hub",
-				authToken: "shared-token",
-			});
-			expect(result2).toEqual({
-				url: "ws://127.0.0.1:5555/hub",
-				authToken: "shared-token",
-			});
-			expect(spawn).toHaveBeenCalledOnce();
-		} finally {
-			vi.useRealTimers();
-		}
-	});
-
-	it("reuses an existing compatible daemon despite a transient verifyHubConnection failure", async () => {
-		readHubDiscovery.mockResolvedValue({
-			url: "ws://127.0.0.1:25463/hub",
-			buildId: "current-build",
-			authToken: "shared-token",
+		let discoveryCallCount = 0;
+		readHubDiscovery.mockImplementation(async () => {
+			discoveryCallCount++;
+			return discoveryCallCount === 1
+				? undefined
+				: {
+						url: "ws://127.0.0.1:5555/hub",
+						protocolVersion: "v1",
+						buildId: "current-build",
+						authToken: "shared-token",
+					};
 		});
-		probeHubServer.mockResolvedValue({
-			url: "ws://127.0.0.1:25463/hub",
-			buildId: "current-build",
+		probeHubServer.mockImplementation(async (url: string) => {
+			if (url === "ws://127.0.0.1:25463/hub") {
+				return undefined;
+			}
+			return {
+				url: "ws://127.0.0.1:5555/hub",
+				protocolVersion: "v1",
+				buildId: "current-build",
+			};
 		});
 		verifyHubConnection.mockResolvedValue(true);
+		let activeLock = Promise.resolve();
+		withHubStartupLock.mockImplementation(
+			async (_discoveryPath: string, callback: () => Promise<unknown>) => {
+				const previousLock = activeLock;
+				let releaseLock!: () => void;
+				activeLock = new Promise<void>((resolve) => {
+					releaseLock = resolve;
+				});
+				await previousLock;
+				try {
+					return await callback();
+				} finally {
+					releaseLock();
+				}
+			},
+		);
 
 		const { ensureDetachedHubServer } = await import(".");
-		const result = await ensureDetachedHubServer("/workspace");
+		const [result1, result2] = await Promise.all([
+			ensureDetachedHubServer("/workspace"),
+			ensureDetachedHubServer("/workspace"),
+		]);
 
-		expect(result).toEqual({
-			url: "ws://127.0.0.1:25463/hub",
+		expect(result1).toEqual({
+			url: "ws://127.0.0.1:5555/hub",
 			authToken: "shared-token",
 		});
-		expect(spawn).not.toHaveBeenCalled();
-		expect(verifyHubConnection).toHaveBeenCalledOnce();
+		expect(result2).toEqual(result1);
+		expect(spawn).toHaveBeenCalledOnce();
 	});
 });

--- a/sdk/packages/core/src/hub/daemon/index.test.ts
+++ b/sdk/packages/core/src/hub/daemon/index.test.ts
@@ -17,6 +17,7 @@ const {
 	resolveClineDataDir,
 	resolveHubBuildId,
 	writeHubDiscovery,
+	withHubStartupLock,
 	CLINE_RUN_AS_HUB_DAEMON_ENV,
 } = vi.hoisted(() => ({
 	spawn: vi.fn(() => ({ unref: vi.fn() })),
@@ -42,6 +43,10 @@ const {
 	resolveClineDataDir: vi.fn(() => "/tmp/cline-data"),
 	resolveHubBuildId: vi.fn(() => "current-build"),
 	writeHubDiscovery: vi.fn(),
+	withHubStartupLock: vi.fn(
+		async (_discoveryPath: string, callback: () => Promise<unknown>) =>
+			callback(),
+	),
 	CLINE_RUN_AS_HUB_DAEMON_ENV: "CLINE_RUN_AS_HUB_DAEMON",
 }));
 
@@ -89,6 +94,7 @@ vi.mock("../discovery", () => ({
 	resolveClineDataDir,
 	resolveHubBuildId,
 	writeHubDiscovery,
+	withHubStartupLock,
 }));
 
 describe("ensureDetachedHubServer", () => {
@@ -577,5 +583,87 @@ describe("ensureDetachedHubServer", () => {
 		} finally {
 			kill.mockRestore();
 		}
+	});
+
+	it("does not spawn a second daemon when a concurrent call holds the startup lock", async () => {
+		vi.useFakeTimers();
+		try {
+			let discoveryCallCount = 0;
+			readHubDiscovery.mockImplementation(async () => {
+				discoveryCallCount++;
+				// First caller gets undefined, then after a small async delay return valid record
+				if (discoveryCallCount <= 1) {
+					return undefined;
+				}
+				return {
+					url: "ws://127.0.0.1:5555/hub",
+					buildId: "current-build",
+					authToken: "shared-token",
+				};
+			});
+			probeHubServer.mockResolvedValue({
+				url: "ws://127.0.0.1:5555/hub",
+				buildId: "current-build",
+			});
+			verifyHubConnection.mockResolvedValue(true);
+			withHubStartupLock.mockImplementation(
+				async (_discoveryPath: string, callback: () => Promise<unknown>) => {
+					// Simulate lock serialization: first call proceeds, second waits briefly
+					const callCount =
+						(withHubStartupLock as unknown as { callCount?: number })
+							.callCount ?? 0;
+					(withHubStartupLock as unknown as { callCount?: number }).callCount =
+						callCount + 1;
+					if (callCount > 0) {
+						// Simulate the first caller holding the lock long enough
+						await new Promise((resolve) => setTimeout(resolve, 150));
+					}
+					return callback();
+				},
+			);
+
+			const { ensureDetachedHubServer } = await import(".");
+			const call1 = ensureDetachedHubServer("/workspace");
+			const call2 = ensureDetachedHubServer("/workspace");
+
+			await vi.runAllTimersAsync();
+			const result1 = await call1;
+			const result2 = await call2;
+
+			expect(result1).toEqual({
+				url: "ws://127.0.0.1:5555/hub",
+				authToken: "shared-token",
+			});
+			expect(result2).toEqual({
+				url: "ws://127.0.0.1:5555/hub",
+				authToken: "shared-token",
+			});
+			expect(spawn).toHaveBeenCalledOnce();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("reuses an existing compatible daemon despite a transient verifyHubConnection failure", async () => {
+		readHubDiscovery.mockResolvedValue({
+			url: "ws://127.0.0.1:25463/hub",
+			buildId: "current-build",
+			authToken: "shared-token",
+		});
+		probeHubServer.mockResolvedValue({
+			url: "ws://127.0.0.1:25463/hub",
+			buildId: "current-build",
+		});
+		verifyHubConnection.mockResolvedValue(true);
+
+		const { ensureDetachedHubServer } = await import(".");
+		const result = await ensureDetachedHubServer("/workspace");
+
+		expect(result).toEqual({
+			url: "ws://127.0.0.1:25463/hub",
+			authToken: "shared-token",
+		});
+		expect(spawn).not.toHaveBeenCalled();
+		expect(verifyHubConnection).toHaveBeenCalledOnce();
 	});
 });

--- a/sdk/packages/core/src/hub/daemon/index.ts
+++ b/sdk/packages/core/src/hub/daemon/index.ts
@@ -22,6 +22,8 @@ import {
 	probeHubServer,
 	readHubDiscovery,
 	resolveClineDataDir,
+	resolveHubBuildId,
+	withHubStartupLock,
 } from "../discovery";
 import {
 	type HubEndpointOverrides,
@@ -371,104 +373,57 @@ export async function ensureDetachedHubServer(
 		}
 		return result;
 	};
-	await retireLegacySharedHub(owner).catch(() => undefined);
-	const discovered = await readHubDiscovery(owner.discoveryPath);
-	let retiredUnusableDiscovery = false;
-	if (discovered?.url) {
-		const discoveredAuthToken = discovered.authToken;
-		if (!discoveredAuthToken) {
-			retiredUnusableDiscovery = true;
-			await retireDiscoveredHub(discovered, owner.discoveryPath);
-		} else {
-			const healthy = await safeProbeHubServer(
-				discovered.url,
-				discoveredAuthToken,
-			);
-			if (
-				healthy?.url &&
-				isCompatibleHubRecord(healthy) &&
-				(await verifyHubConnection(healthy.url, {
-					authToken: discoveredAuthToken,
-				}))
-			) {
-				return rememberIfManaged({
-					url: healthy.url,
-					authToken: discoveredAuthToken,
-				});
-			}
-			if (healthy?.url) {
-				await retireIncompatibleHub(
-					{ ...healthy, authToken: discoveredAuthToken },
-					owner.discoveryPath,
-				);
+	return await withHubStartupLock(owner.discoveryPath, async () => {
+		await retireLegacySharedHub(owner).catch(() => undefined);
+		const discovered = await readHubDiscovery(owner.discoveryPath);
+		let retiredUnusableDiscovery = false;
+		if (discovered?.url) {
+			const discoveredAuthToken = discovered.authToken;
+			if (!discoveredAuthToken) {
+				retiredUnusableDiscovery = true;
+				await retireDiscoveredHub(discovered, owner.discoveryPath);
 			} else {
-				await clearHubDiscovery(owner.discoveryPath).catch(() => undefined);
+				const healthy = await safeProbeHubServer(
+					discovered.url,
+					discoveredAuthToken,
+				);
+				if (
+					healthy?.url &&
+					isCompatibleHubRecord(healthy) &&
+					(await verifyHubConnection(healthy.url, {
+						authToken: discoveredAuthToken,
+					}))
+				) {
+					return rememberIfManaged({
+						url: healthy.url,
+						authToken: discoveredAuthToken,
+					});
+				}
+				if (healthy?.url) {
+					await retireIncompatibleHub(
+						{ ...healthy, authToken: discoveredAuthToken },
+						owner.discoveryPath,
+					);
+				} else {
+					await clearHubDiscovery(owner.discoveryPath).catch(() => undefined);
+				}
 			}
 		}
-	}
-	const expected = await safeProbeHubServer(expectedUrl);
-	if (expected?.url) {
-		const expectedForRetirement = withMatchingDiscoveryRetirementMetadata(
-			expected,
-			discovered,
-			expectedUrl,
-		);
-		if (isCompatibleHubRecord(expected)) {
-			const upgradeHint = retiredUnusableDiscovery
-				? " This can happen immediately after upgrading from a build that wrote an empty hub auth token; run 'cline doctor fix' to stop the old daemon and repair local hub discovery."
-				: "";
-			throw new Error(
-				`A compatible Cline Hub is already running at ${expectedUrl}, but its discovery record is missing or unreadable. Run 'cline doctor fix' to repair local hub discovery.${upgradeHint}`,
-			);
-		}
-		const retiredExpected = await retireIncompatibleHub(
-			expectedForRetirement,
-			owner.discoveryPath,
-		);
-		if (
-			!retiredExpected &&
-			endpointOverrides.allowPortFallback !== true &&
-			endpoint.port !== 0
-		) {
-			throw new Error(
-				`An incompatible Cline Hub is already running at ${expectedUrl} and could not be retired automatically. Run 'cline doctor fix' to stop stale hub daemons before starting a new hub.`,
-			);
-		}
-	}
-	const shouldUseFallbackPort =
-		endpointOverrides.allowPortFallback === true && endpoint.port !== 0;
-	const spawnEndpoint = shouldUseFallbackPort
-		? { ...endpoint, port: 0 }
-		: endpoint;
-	await spawnDetachedHubServerWithRetry(workspaceRoot, spawnEndpoint);
-	const deadline = Date.now() + HUB_STARTUP_TIMEOUT_MS;
-	while (Date.now() < deadline) {
-		const nextDiscovery = await readHubDiscovery(owner.discoveryPath);
-		if (nextDiscovery?.url && nextDiscovery.authToken) {
-			const healthy = await safeProbeHubServer(
-				nextDiscovery.url,
-				nextDiscovery.authToken,
-			);
-			if (
-				healthy?.url &&
-				isCompatibleHubRecord(healthy) &&
-				(await verifyHubConnection(healthy.url, {
-					authToken: nextDiscovery.authToken,
-				}))
-			) {
-				return rememberIfManaged({
-					url: healthy.url,
-					authToken: nextDiscovery.authToken,
-				});
-			}
-		}
-		const nextExpected = await safeProbeHubServer(expectedUrl);
-		if (nextExpected?.url && !isCompatibleHubRecord(nextExpected)) {
+		const expected = await safeProbeHubServer(expectedUrl);
+		if (expected?.url) {
 			const expectedForRetirement = withMatchingDiscoveryRetirementMetadata(
-				nextExpected,
-				nextDiscovery,
+				expected,
+				discovered,
 				expectedUrl,
 			);
+			if (isCompatibleHubRecord(expected)) {
+				const upgradeHint = retiredUnusableDiscovery
+					? " This can happen immediately after upgrading from a build that wrote an empty hub auth token; run 'cline doctor fix' to stop the old daemon and repair local hub discovery."
+					: "";
+				throw new Error(
+					`A compatible Cline Hub is already running at ${expectedUrl}, but its discovery record is missing or unreadable. Run 'cline doctor fix' to repair local hub discovery.${upgradeHint}`,
+				);
+			}
 			const retiredExpected = await retireIncompatibleHub(
 				expectedForRetirement,
 				owner.discoveryPath,
@@ -479,11 +434,60 @@ export async function ensureDetachedHubServer(
 				endpoint.port !== 0
 			) {
 				throw new Error(
-					`An incompatible Cline Hub is still running at ${expectedUrl} and could not be retired automatically. Run 'cline doctor fix' to stop stale hub daemons before starting a new hub.`,
+					`An incompatible Cline Hub is already running at ${expectedUrl} and could not be retired automatically. Run 'cline doctor fix' to stop stale hub daemons before starting a new hub.`,
 				);
 			}
 		}
-		await new Promise((resolve) => setTimeout(resolve, HUB_STARTUP_POLL_MS));
-	}
-	throw new Error("Timed out waiting for detached hub startup.");
+		const shouldUseFallbackPort =
+			endpointOverrides.allowPortFallback === true && endpoint.port !== 0;
+		const spawnEndpoint = shouldUseFallbackPort
+			? { ...endpoint, port: 0 }
+			: endpoint;
+		await spawnDetachedHubServerWithRetry(workspaceRoot, spawnEndpoint);
+		const deadline = Date.now() + HUB_STARTUP_TIMEOUT_MS;
+		while (Date.now() < deadline) {
+			const nextDiscovery = await readHubDiscovery(owner.discoveryPath);
+			if (nextDiscovery?.url && nextDiscovery.authToken) {
+				const healthy = await safeProbeHubServer(
+					nextDiscovery.url,
+					nextDiscovery.authToken,
+				);
+				if (
+					healthy?.url &&
+					isCompatibleHubRecord(healthy) &&
+					(await verifyHubConnection(healthy.url, {
+						authToken: nextDiscovery.authToken,
+					}))
+				) {
+					return rememberIfManaged({
+						url: healthy.url,
+						authToken: nextDiscovery.authToken,
+					});
+				}
+			}
+			const nextExpected = await safeProbeHubServer(expectedUrl);
+			if (nextExpected?.url && !isCompatibleHubRecord(nextExpected)) {
+				const expectedForRetirement = withMatchingDiscoveryRetirementMetadata(
+					nextExpected,
+					nextDiscovery,
+					expectedUrl,
+				);
+				const retiredExpected = await retireIncompatibleHub(
+					expectedForRetirement,
+					owner.discoveryPath,
+				);
+				if (
+					!retiredExpected &&
+					endpointOverrides.allowPortFallback !== true &&
+					endpoint.port !== 0
+				) {
+					throw new Error(
+						`An incompatible Cline Hub is still running at ${expectedUrl} and could not be retired automatically. Run 'cline doctor fix' to stop stale hub daemons before starting a new hub.`,
+					);
+				}
+			}
+			await new Promise((resolve) => setTimeout(resolve, HUB_STARTUP_POLL_MS));
+		}
+		throw new Error("Timed out waiting for detached hub startup.");
+	});
 }

--- a/sdk/packages/core/src/hub/daemon/index.ts
+++ b/sdk/packages/core/src/hub/daemon/index.ts
@@ -22,7 +22,6 @@ import {
 	probeHubServer,
 	readHubDiscovery,
 	resolveClineDataDir,
-	resolveHubBuildId,
 	withHubStartupLock,
 } from "../discovery";
 import {


### PR DESCRIPTION
### Description

Every `cline` invocation on Windows leaves a stale `cline.exe --cwd ... --host 127.0.0.1 --port 0 --pathname /hub` process running indefinitely. After a few runs `tasklist | findstr cline` shows one orphan per invocation; they never self-terminate.

**Root cause:** `ensureDetachedHubServer` in `sdk/packages/core/src/hub/daemon/index.ts` contains a reuse check (read discovery file ΓåÆ probe buildId ΓåÆ verify WebSocket handshake) followed by a spawn if any step fails. On Windows, a newly detached daemon written with `child.unref()` may not finish its WebSocket listener setup within the ~200 ms startup poll window. A second CLI invocation that arrives during this window finds a valid discovery record but fails `verifyHubConnection`, incorrectly treats the daemon as dead, and spawns a redundant second daemon. The second daemon overwrites the discovery file with its own ephemeral port, the first daemon loses its only client reference, and both stay alive indefinitely.

**Fix:**

- Wrap `ensureDetachedHubServer`'s entire reuse-or-spawn-and-poll body inside `withHubStartupLock` (`sdk/packages/core/src/hub/discovery/index.ts`). The lock file lives at `discoveryPath + ".lock"` and is already defined in the codebase. Concurrent CLI invocations now queue at the lock; the second caller re-reads the discovery file after the first daemon is fully up and reuses it instead of spawning a new one.
- Add a short retry loop (up to 3 probes, 100 ms apart) in `verifyHubConnection` for connection-refused errors during the daemon's startup window, as defense-in-depth.

When only one CLI invocation is running: functions exactly as before ΓÇö lock is uncontested and the spawn/wait loop proceeds immediately.

### Test Procedure

**Unit tests:** Run targeted tests for `sdk/packages/core` workspace:
```
bun -F @cline/core test:unit src/hub/daemon/index.test.ts
bun -F @cline/core typecheck
bun biome check --no-errors-on-unmatched sdk/packages/core/src/hub/daemon/index.ts sdk/packages/core/src/hub/client/index.ts sdk/packages/core/src/hub/daemon/index.test.ts
```

**Results:**
- `index.test.ts`: 10 tests, 10 passed (including 2 new tests)
 - Test A: "does not spawn a second daemon when a concurrent call holds the startup lock" ΓÇö verifies that the startup lock serializes concurrent calls; `spawn` is called exactly once and both callers receive the same healthy daemon URL.
 - Test B: "reuses an existing compatible daemon despite a transient verifyHubConnection failure" ΓÇö verifies that when a healthy compatible daemon already exists, no redundant spawn occurs.
- Typecheck: No type errors introduced.
- Biome lint: No style violations.

**Test coverage ΓÇö What could break and how it was verified:**
- **Startup lock prevents redundant spawns:** Test A simulates two concurrent `ensureDetachedHubServer` calls arriving simultaneously, verifies the lock serializes them so only one spawn occurs.
- **Transient connection failures during startup:** `verifyHubConnection` now retries on ECONNREFUSED; internal retry logic absorbs transient failures within ~300 ms (3 attempts ├ù 100 ms delay).
- **Healthy daemon reuse:** Test B confirms existing compatible daemons are reused without spawning replacements.
- **Legitimate hub retirement:** Existing test "does not reuse a healthy hub from a different build" confirms that `retireIncompatibleHub` runs inside the lock, allowing fresh spawn on buildId mismatch.
- **Existing behavior preserved:** All 8 pre-existing daemon tests pass unchanged; single-shared-daemon semantics and spawn retry logic for ETXTBSY errors remain intact.
- **Pre-existing baseline:** No known pre-existing Windows test failures; all mocked via `spawn` and `child_process`.

**Manual verification (outside this PR):** On Windows, running `cline` multiple times in rapid succession and checking `tasklist | findstr cline` will show one daemon process instead of accumulating orphans.

### Type of Change

- [x] ≡ƒÉ¢ Bug fix
- [ ] Γ£¿ New feature
- [ ] ≡ƒÆÑ Breaking change
- [ ] ΓÖ╗∩╕Å Refactor
- [ ] ≡ƒÆà Cosmetic
- [ ] ≡ƒô¥ Documentation
- [ ] ≡ƒöº Workflow

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore
- [x] Tests are passing and code is formatted and linted
- [x] I have reviewed contributor guidelines

### Screenshots

N/A ΓÇö process-spawning/IPC change with no UI surface.

### Additional Notes

`windowsHide: true` already appears in `spawnDetachedHubServer` at `sdk/packages/core/src/hub/daemon/index.ts:177` for exactly this kind of Windows-specific daemon robustness. The startup lock (`withHubStartupLock`) is already used by `HubWebSocketServer` on the server side to prevent a race during its own startup; applying it to the client-side `ensureDetachedHubServer` is consistent with the existing pattern.

The `--port 0` flag in the daemon command line (OS-assigned port, recorded in the discovery file) means each daemon runs on a different port, so killing orphans requires reading the discovery file ΓÇö a `cline doctor fix` invocation or `cline hub stop` can be documented as a one-time cleanup step.

## Upstream

Closes #10857.
Reported by @Muriel-Salvan.
