### PR TITLE
fix(vscode): prevent streaming abort from discarding in-progress file edits (#10927)

### DIFF
--- a/apps/vscode/src/core/prompts/responses.ts
+++ b/apps/vscode/src/core/prompts/responses.ts
@@ -242,7 +242,7 @@ Otherwise, if you have not completed the task and do not need additional informa
 				: `This task was interrupted ${agoText}. It may or may not be complete, so please reassess the task context. Be aware that the project state may have changed since then. The current working directory is now '${cwd.toPosix()}'. If the task has not been completed, retry the last step before interruption and proceed with completing the task.\n\nNote: If you previously attempted a tool use that the user did not provide a result for, you should assume the tool use was not successful and assess whether you should retry. If the last tool was a browser_action, the browser has been closed and you must launch a new browser if needed.`
 		}${
 			wasRecent && !hasPendingFileContextWarnings
-				? "\n\nIMPORTANT: If the last tool use was a replace_in_file or write_to_file that was interrupted, the file was reverted back to its original state before the interrupted edit, and you do NOT need to re-read the file as you already have its up-to-date contents."
+				? "\n\nIMPORTANT: If the last tool use was a replace_in_file or write_to_file that was interrupted, and the edit was in progress, the file has been reverted back to its original state before the interrupted edit, and you do NOT need to re-read the file as you already have its up-to-date contents."
 				: ""
 		}`
 

--- a/apps/vscode/src/core/task/index.ts
+++ b/apps/vscode/src/core/task/index.ts
@@ -1798,7 +1798,7 @@ export class Task {
 		return true;
 	}
 
-	async abortTask() {
+	async abortTask(skipDiffRevert = false) {
 		try {
 			// PHASE 1: Check if TaskCancel should run BEFORE any cleanup
 			// We must capture this state now because subsequent cleanup will
@@ -1933,7 +1933,9 @@ export class Task {
 			this.fileContextTracker.dispose();
 			// need to await for when we want to make sure directories/files are reverted before
 			// re-starting the task from a checkpoint
-			await this.diffViewProvider.revertChanges();
+			if (!skipDiffRevert) {
+				await this.diffViewProvider.revertChanges();
+			}
 			// Clear the notification callback when task is aborted
 			this.mcpHub.clearNotificationCallback();
 			if (this.FocusChainManager) {
@@ -3619,7 +3621,7 @@ export class Task {
 					}
 
 					// needs to happen after the say, otherwise the say would fail
-					this.abortTask(); // if the stream failed, there's various states the task could be in (i.e. could have streamed some tools the user may have executed), so we just resort to replicating a cancel task
+					this.abortTask(true); // if the stream failed, there's various states the task could be in (i.e. could have streamed some tools the user may have executed), so we just resort to replicating a cancel task
 
 					await abortStream("streaming_failed", errorMessage);
 					await this.reinitExistingTaskFromId(this.taskId);

--- a/apps/vscode/src/integrations/editor/DiffViewProvider.ts
+++ b/apps/vscode/src/integrations/editor/DiffViewProvider.ts
@@ -17,6 +17,7 @@ export abstract class DiffViewProvider {
 	editType?: "create" | "modify" | "delete"
 	isEditing = false
 	originalContent: string | undefined
+	protected capturedOriginalForAbort: string | undefined
 	private createdDirs: string[] = []
 	protected documentWasOpen = false
 	private preDiagnostics: FileDiagnostics[] = []
@@ -45,8 +46,10 @@ export abstract class DiffViewProvider {
 			const fileBuffer = await fs.readFile(this.absolutePath)
 			this.fileEncoding = await detectEncoding(fileBuffer)
 			this.originalContent = iconv.decode(fileBuffer, this.fileEncoding)
+			this.capturedOriginalForAbort = this.originalContent
 		} else {
 			this.originalContent = ""
+			this.capturedOriginalForAbort = ""
 			this.fileEncoding = "utf8"
 		}
 		// for new files, create any necessary directories and keep track of new directories to delete if the user denies the operation
@@ -430,12 +433,19 @@ export abstract class DiffViewProvider {
 			// revert document
 			// Apply the edit and save, since contents shouldn't have changed this won't show in local history unless of
 			// course the user made changes and saved during the edit.
-			const contents = (await this.getDocumentText()) || ""
-			const lineCount = (contents.match(/\n/g) || []).length + 1
-			await this.replaceText(this.originalContent ?? "", { startLine: 0, endLine: lineCount }, undefined)
+			const contents = await this.getDocumentText()
+			if (contents === undefined && this.isEditing && this.absolutePath && this.capturedOriginalForAbort !== undefined) {
+				// Editor is closed but we have a captured original; write directly to disk
+				await fs.writeFile(this.absolutePath, iconv.encode(this.capturedOriginalForAbort, this.fileEncoding))
+				Logger.log(`File ${this.absolutePath} has been reverted to its original content (from captured state).`)
+			} else if (contents !== undefined) {
+				// Editor is open; use normal path
+				const lineCount = (contents.match(/\n/g) || []).length + 1
+				await this.replaceText(this.originalContent ?? "", { startLine: 0, endLine: lineCount }, undefined)
 
-			await this.saveDocument()
-			Logger.log(`File ${this.absolutePath} has been reverted to its original content.`)
+				await this.saveDocument()
+				Logger.log(`File ${this.absolutePath} has been reverted to its original content.`)
+			}
 			if (this.documentWasOpen) {
 				openFile(this.absolutePath, true)
 			}
@@ -495,6 +505,7 @@ export abstract class DiffViewProvider {
 		this.preDiagnostics = []
 
 		this.originalContent = undefined
+		this.capturedOriginalForAbort = undefined
 		this.fileEncoding = "utf8"
 		this.documentWasOpen = false
 

--- a/apps/vscode/src/integrations/editor/__tests__/DiffViewProvider.test.ts
+++ b/apps/vscode/src/integrations/editor/__tests__/DiffViewProvider.test.ts
@@ -1,5 +1,8 @@
 import * as assert from "assert"
+import * as fs from "fs/promises"
 import { describe, it } from "mocha"
+import * as os from "os"
+import * as path from "path"
 import { DiffViewProvider } from "../DiffViewProvider"
 
 class TestBoundaryDiffViewProvider extends DiffViewProvider {
@@ -515,5 +518,123 @@ describe("DiffViewProvider Newline Preservation", () => {
 
 		const result = await provider.getDocumentText()
 		assert.strictEqual(result, "Hello World")
+	})
+})
+
+describe("DiffViewProvider abort-path revert guarantees", () => {
+	class AbortTestDiffViewProvider extends DiffViewProvider {
+		public documentText = ""
+		public replaceTextCalls = 0
+		public saveDocCalls = 0
+		public closeViewsCalls = 0
+		public getDocumentTextReturnsUndefined = false
+
+		async openDiffEditor(): Promise<void> {}
+		async scrollEditorToLine(_line: number): Promise<void> {}
+		async scrollAnimation(_startLine: number, _endLine: number): Promise<void> {}
+		async truncateDocument(_lineNumber: number): Promise<void> {}
+
+		async getDocumentLineCount(): Promise<number> {
+			return this.documentText.split("\n").length
+		}
+
+		async getDocumentText(): Promise<string | undefined> {
+			if (this.getDocumentTextReturnsUndefined) {
+				return undefined
+			}
+			return this.documentText
+		}
+
+		async saveDocument(): Promise<Boolean> {
+			this.saveDocCalls++
+			return true
+		}
+
+		async closeAllDiffViews(): Promise<void> {
+			this.closeViewsCalls++
+		}
+
+		async resetDiffView(): Promise<void> {}
+
+		async replaceText(
+			content: string,
+			_rangeToReplace: { startLine: number; endLine: number },
+			_currentLine: number | undefined,
+		): Promise<void> {
+			this.replaceTextCalls++
+			this.documentText = content
+		}
+
+		public getAbsolutePath(): string | undefined {
+			return this.absolutePath
+		}
+
+		public setup(initialContent: string, absolutePath = "/test/file.txt") {
+			this.isEditing = true
+			this.editType = "modify"
+			this.documentText = initialContent
+			this.originalContent = initialContent
+			this.capturedOriginalForAbort = initialContent
+			this.absolutePath = absolutePath
+			this.fileEncoding = "utf8"
+			this.replaceTextCalls = 0
+			this.saveDocCalls = 0
+			this.closeViewsCalls = 0
+			this.getDocumentTextReturnsUndefined = false
+		}
+	}
+
+	it("revertChanges() restores original content when the editor text is unavailable", async () => {
+		const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "cline-test-"))
+		const tmpFile = path.join(tmpDir, "revert-target.txt")
+
+		try {
+			await fs.writeFile(tmpFile, "should be overwritten")
+
+			const provider = new AbortTestDiffViewProvider()
+			provider.setup("original content", tmpFile)
+			provider.getDocumentTextReturnsUndefined = true
+
+			await provider.revertChanges()
+
+			assert.strictEqual(await fs.readFile(tmpFile, "utf8"), "original content")
+			assert.strictEqual(provider.isEditing, false)
+			assert.strictEqual(provider.getAbsolutePath(), undefined)
+			assert.strictEqual(provider.replaceTextCalls, 0)
+			assert.strictEqual(provider.saveDocCalls, 0)
+			assert.strictEqual(provider.closeViewsCalls, 1)
+		} finally {
+			await fs.rm(tmpDir, { recursive: true, force: true })
+		}
+	})
+
+	it("revertChanges() before open() does not throw", async () => {
+		const provider = new AbortTestDiffViewProvider()
+
+		await provider.revertChanges()
+
+		assert.strictEqual(provider.isEditing, false)
+		assert.strictEqual(provider.getAbsolutePath(), undefined)
+	})
+
+	it("double revertChanges() is idempotent", async () => {
+		const provider = new AbortTestDiffViewProvider()
+		provider.setup("original content")
+
+		await provider.revertChanges()
+		assert.strictEqual(provider.isEditing, false)
+		assert.strictEqual(provider.replaceTextCalls, 1)
+		assert.strictEqual(provider.saveDocCalls, 1)
+		assert.strictEqual(provider.closeViewsCalls, 1)
+
+		provider.replaceTextCalls = 0
+		provider.saveDocCalls = 0
+		provider.closeViewsCalls = 0
+
+		await provider.revertChanges()
+
+		assert.strictEqual(provider.replaceTextCalls, 0)
+		assert.strictEqual(provider.saveDocCalls, 0)
+		assert.strictEqual(provider.closeViewsCalls, 0)
 	})
 })


### PR DESCRIPTION
## Description

When a streaming `replace_in_file` or `write_to_file` operation is interrupted by an API error mid-stream, the system message claims the file has been reverted, but the file can remain partially modified on disk. This causes the model's in-context copy of the file to diverge from disk, leading to subsequent SEARCH block failures with "does not match anything in the file."

**Root cause:** Two independent abort paths (`abortTask` and `abortStream`) both attempt to revert the diff view but are not coordinated. A race condition allows `abortTask`'s cleanup to clear the `isEditing` flag before `abortStream` checks it, causing the revert to be skipped. Additionally, if the diff editor has already closed, `revertChanges()` has no way to restore the original file content from disk.

**Fix:**

1. **DiffViewProvider.ts**: Add `capturedOriginalForAbort` field to capture the original content at the start of `open()`. Modify `revertChanges()` to fall back to writing captured content directly to disk via `fs.writeFile()` if the editor is closed (`getDocumentText()` returns undefined).

2. **task/index.ts**: Add optional `skipDiffRevert` parameter to `abortTask()`. In the streaming error path (line 3057), pass `skipDiffRevert = true` so that `abortStream`'s revert is the authoritative one, eliminating the race.

3. **responses.ts**: Update the system prompt to conditionally state file revert: change "the file was reverted back to its original state" to "if the edit was in progress, it has been reverted to its original state."

4. **DiffViewProvider.test.ts**: Add three unit tests to verify abort-path revert guarantees.

## Test Procedure

- [x] Three new tests validate: closed editor path, pre-open safety, double-revert idempotency
- [x] gitleaks pre-commit hook passed
- [x] Cross-provider adversarial review passed (GPT-5.5)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Upstream

Closes #10927.
Reported by @eksej6041.
