### PR TITLE
fix(vscode): force temperature 1 for kimi-k2 models on moonshot.ai endpoints (#10544)

### DIFF
--- a/apps/vscode/src/core/api/providers/__tests__/openai-kimi-temperature.test.ts
+++ b/apps/vscode/src/core/api/providers/__tests__/openai-kimi-temperature.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, describe, it } from "mocha"
+import sinon from "sinon"
+import "should"
+import type { ClineStorageMessage } from "@shared/messages/content"
+import { OpenAiHandler } from "../openai"
+
+interface OpenAiRequestPayload {
+	model: string
+	temperature?: number
+	max_tokens: number | undefined
+	messages: any[]
+	stream: boolean
+}
+
+describe("OpenAiHandler kimi-k2 temperature", () => {
+	afterEach(() => {
+		sinon.restore()
+	})
+
+	const createAsyncIterable = (data: unknown[] = []): AsyncIterable<unknown> => ({
+		[Symbol.asyncIterator]: async function* () {
+			yield* data
+		},
+	})
+
+	it("should override temperature to 1 for kimi-k2 on moonshot.ai endpoint", async () => {
+		const handler = new OpenAiHandler({
+			openAiApiKey: "test-api-key",
+			openAiBaseUrl: "https://api.moonshot.ai/v1",
+			openAiModelId: "kimi-k2",
+		})
+
+		const createStub = sinon.stub().resolves(createAsyncIterable([]))
+		sinon.stub(handler as unknown as { ensureClient: () => unknown }, "ensureClient").returns({
+			chat: {
+				completions: {
+					create: createStub,
+				},
+			},
+		})
+
+		const messages: ClineStorageMessage[] = [{ role: "user", content: "hi" }]
+		for await (const _chunk of handler.createMessage("system", messages)) {
+			// Consume stream to trigger request execution.
+		}
+
+		const payload = createStub.firstCall.args[0] as OpenAiRequestPayload
+		payload.temperature!.should.equal(1)
+	})
+
+	it("should override temperature to 1 for kimi-k2 even with explicit user config", async () => {
+		const handler = new OpenAiHandler({
+			openAiApiKey: "test-api-key",
+			openAiBaseUrl: "https://api.moonshot.ai/v1",
+			openAiModelId: "kimi-k2",
+			openAiModelInfo: {
+				temperature: 0.5,
+				maxTokens: 4096,
+			} as any,
+		})
+
+		const createStub = sinon.stub().resolves(createAsyncIterable([]))
+		sinon.stub(handler as unknown as { ensureClient: () => unknown }, "ensureClient").returns({
+			chat: {
+				completions: {
+					create: createStub,
+				},
+			},
+		})
+
+		const messages: ClineStorageMessage[] = [{ role: "user", content: "hi" }]
+		for await (const _chunk of handler.createMessage("system", messages)) {
+			// Consume stream to trigger request execution.
+		}
+
+		const payload = createStub.firstCall.args[0] as OpenAiRequestPayload
+		payload.temperature!.should.equal(1)
+	})
+
+	it("should not override temperature for kimi-k2 on non-moonshot endpoints", async () => {
+		const handler = new OpenAiHandler({
+			openAiApiKey: "test-api-key",
+			openAiBaseUrl: "https://api.openai.com/v1",
+			openAiModelId: "kimi-k2",
+			openAiModelInfo: {
+				temperature: 0.7,
+				maxTokens: 4096,
+			} as any,
+		})
+
+		const createStub = sinon.stub().resolves(createAsyncIterable([]))
+		sinon.stub(handler as unknown as { ensureClient: () => unknown }, "ensureClient").returns({
+			chat: {
+				completions: {
+					create: createStub,
+				},
+			},
+		})
+
+		const messages: ClineStorageMessage[] = [{ role: "user", content: "hi" }]
+		for await (const _chunk of handler.createMessage("system", messages)) {
+			// Consume stream to trigger request execution.
+		}
+
+		const payload = createStub.firstCall.args[0] as OpenAiRequestPayload
+		payload.temperature!.should.equal(0.7)
+	})
+
+	it("should not override temperature for non-kimi models on moonshot.ai endpoint", async () => {
+		const handler = new OpenAiHandler({
+			openAiApiKey: "test-api-key",
+			openAiBaseUrl: "https://api.moonshot.ai/v1",
+			openAiModelId: "gpt-4",
+			openAiModelInfo: {
+				temperature: 0.7,
+				maxTokens: 4096,
+			} as any,
+		})
+
+		const createStub = sinon.stub().resolves(createAsyncIterable([]))
+		sinon.stub(handler as unknown as { ensureClient: () => unknown }, "ensureClient").returns({
+			chat: {
+				completions: {
+					create: createStub,
+				},
+			},
+		})
+
+		const messages: ClineStorageMessage[] = [{ role: "user", content: "hi" }]
+		for await (const _chunk of handler.createMessage("system", messages)) {
+			// Consume stream to trigger request execution.
+		}
+
+		const payload = createStub.firstCall.args[0] as OpenAiRequestPayload
+		payload.temperature!.should.equal(0.7)
+	})
+})

--- a/apps/vscode/src/core/api/providers/openai.ts
+++ b/apps/vscode/src/core/api/providers/openai.ts
@@ -137,6 +137,7 @@ export class OpenAiHandler implements ApiHandler {
 			reasoningEffort = requestedEffort === "none" ? undefined : (requestedEffort as ChatCompletionReasoningEffort)
 		}
 
+		// TODO(#10985): replace with supportsTemperature field
 		if (isKimiK2OnMoonshot) {
 			temperature = 1
 		}

--- a/apps/vscode/src/core/api/providers/openai.ts
+++ b/apps/vscode/src/core/api/providers/openai.ts
@@ -97,6 +97,10 @@ export class OpenAiHandler implements ApiHandler {
 	async *createMessage(systemPrompt: string, messages: ClineStorageMessage[], tools?: ChatCompletionTool[]): ApiStream {
 		const client = this.ensureClient()
 		const modelId = this.options.openAiModelId ?? ""
+		const baseUrl = this.options.openAiBaseUrl?.toLowerCase() ?? ""
+		const isKimiK2OnMoonshot =
+			baseUrl.includes("moonshot.ai") &&
+			modelId.toLowerCase().startsWith("kimi-k2")
 		const isDeepseekReasoner = modelId.includes("deepseek-reasoner")
 		const isR1FormatRequired = this.options.openAiModelInfo?.isR1FormatRequired ?? false
 		const isReasoningModelFamily =
@@ -131,6 +135,10 @@ export class OpenAiHandler implements ApiHandler {
 			temperature = undefined // does not support temperature
 			const requestedEffort = normalizeOpenaiReasoningEffort(this.options.reasoningEffort)
 			reasoningEffort = requestedEffort === "none" ? undefined : (requestedEffort as ChatCompletionReasoningEffort)
+		}
+
+		if (isKimiK2OnMoonshot) {
+			temperature = 1
 		}
 
 		const stream = await client.chat.completions.create({


### PR DESCRIPTION
## Related Issue

Fixes #10544

## Description

Using Cline's OpenAI-compatible provider with `baseUrl: https://api.moonshot.ai/v1` and model `kimi-k2.6` fails immediately with `400 invalid temperature: only 1 is allowed for this model`. Moonshot's kimi-k2 family accepts only `temperature: 1`; any other value, including the default `0` sent by `OpenAiHandler`, is rejected.

**Root cause:** `OpenAiHandler.createMessage` assigns `temperature = openAiModelInfoSaneDefaults.temperature` (which is `0`) when the user has not set a custom temperature. The `temperature === 0 → undefined` conversion only applies when `openAiModelInfo?.temperature` is explicitly set; when it is `undefined` the `else` branch bypasses that logic and sends `0` directly.

**Fix:** After the existing temperature-assignment block, detect the combination of a `moonshot.ai` base URL and a `kimi-k2` model ID, and override `temperature` to `1`. This is the same targeted-override pattern already used for `isReasoningModelFamily` (`temperature = undefined`).

The dedicated `MoonshotHandler` already reads temperature from model metadata (`moonshotModels["kimi-k2.6"].temperature === 1.0`); users of the first-class Moonshot provider are unaffected. This fix covers only the OpenAI-compatible path.

## Test Procedure

- [x] Unit tests: kimi-k2 on moonshot.ai gets temperature 1, other endpoints unaffected
- [x] TypeScript compilation: no errors
- [x] gitleaks pre-commit hook passed
- [x] Cross-provider adversarial review passed (GPT-5.5)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore
- [x] Tests are passing and code is formatted and linted
- [x] I have reviewed contributor guidelines

## Additional Notes

Issue #10985 proposes adding a `supportsTemperature` field to `ModelInfo` to replace all hardcoded model-ID checks including this one. A TODO comment in the added code points to that issue so it can be cleaned up as part of that refactor.