### PR TITLE
fix(vscode): route hasHook through discovery cache to prevent task-start hang with hooks enabled (#11117)

### DIFF
--- a/apps/vscode/src/core/hooks/__tests__/hook-factory.test.ts
+++ b/apps/vscode/src/core/hooks/__tests__/hook-factory.test.ts
@@ -5,6 +5,7 @@ import path from "path"
 import sinon from "sinon"
 import { setDistinctId } from "@/services/logging/distinctId"
 import { HookFactory } from "../hook-factory"
+import { HookDiscoveryCache } from "../HookDiscoveryCache"
 import { createHookTestEnv, HookTestEnv, stubHookDirs, withPlatform, writeHookScriptForPlatform } from "./test-utils"
 
 describe("Hook System", () => {
@@ -682,6 +683,66 @@ console.log(JSON.stringify({
 			})
 
 			result.contextModification?.should.equal("Global observed: true")
+		})
+	})
+
+	describe("Cache Usage", () => {
+		it("should use HookDiscoveryCache in hasHook()", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "PreToolUse")
+			const hookScript = `#!/usr/bin/env node
+console.log(JSON.stringify({ cancel: false }))`
+			await writeHookScript(hookPath, hookScript)
+
+			// Spy on HookDiscoveryCache.getInstance().get
+			const cacheGetSpy = sinon.spy(HookDiscoveryCache.getInstance(), "get")
+
+			try {
+				const factory = new HookFactory()
+				const result = await factory.hasHook("PreToolUse")
+
+				// Should return true since hook exists
+				result.should.be.true()
+
+				// Verify cache.get() was called
+				sinon.assert.calledOnce(cacheGetSpy)
+				cacheGetSpy.firstCall.args[0].should.equal("PreToolUse")
+			} finally {
+				cacheGetSpy.restore()
+			}
+		})
+
+		it("should return false from hasHook() when no hooks exist", async () => {
+			const factory = new HookFactory()
+			const result = await factory.hasHook("PreToolUse")
+
+			// Should return false since no hook exists
+			result.should.be.false()
+		})
+
+		it("should cache hasHook() result on subsequent calls", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "PreToolUse")
+			const hookScript = `#!/usr/bin/env node
+console.log(JSON.stringify({ cancel: false }))`
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+
+			// First call (cache miss, triggers scan)
+			const result1 = await factory.hasHook("PreToolUse")
+			result1.should.be.true()
+
+			// Get cache stats after first call
+			const cache = HookDiscoveryCache.getInstance()
+			const statsAfterFirst = cache.getStats()
+			statsAfterFirst.cacheSize.should.equal(1)
+
+			// Second call (cache hit, no scan)
+			const result2 = await factory.hasHook("PreToolUse")
+			result2.should.be.true()
+
+			// Cache size should remain 1 (same entry)
+			const statsAfterSecond = cache.getStats()
+			statsAfterSecond.cacheSize.should.equal(1)
 		})
 	})
 })

--- a/apps/vscode/src/core/hooks/hook-factory.ts
+++ b/apps/vscode/src/core/hooks/hook-factory.ts
@@ -738,7 +738,8 @@ export class HookFactory {
 	 * @returns true if at least one hook script exists, false otherwise
 	 */
 	async hasHook<Name extends HookName>(hookName: Name): Promise<boolean> {
-		const scripts = await HookFactory.findHookScripts(hookName)
+		const { HookDiscoveryCache } = await import("./HookDiscoveryCache")
+		const scripts = await HookDiscoveryCache.getInstance().get(hookName)
 		return scripts.length > 0
 	}
 


### PR DESCRIPTION
## Related Issue

Fixes #11117

## Description

With the Hooks toggle enabled in Cline Settings, starting any new task hangs indefinitely in the thinking/loading state and never progresses. No hook scripts need to be present; the toggle being ON is sufficient to reproduce.

**Root cause:** `HookFactory.hasHook` calls `findHookScripts` directly, bypassing `HookDiscoveryCache`. Every `executeHook` call triggers two independent `getAllHooksDirs()` filesystem scans: one inside `hasHook` and a second inside `getHookInfo` (which goes through the cache). `getAllHooksDirs` calls `ensureHooksDirectoryExists()` → `getDocumentsPath()`. On platforms where `getDocumentsPath` spawns a subprocess (Linux: `xdg-user-dir`), concurrent calls from `hasHook` and `getHookInfo` on the same hook can contend on the filesystem or process spawning, causing a hang.

**Fix:** Route `hasHook` through `HookDiscoveryCache.getInstance().get(hookName)` — the same path already used by `getHookInfo`. The cache's `scanningPromises` guard deduplicates concurrent scans for the same hook name, and results are reused on subsequent calls in the same task.

When hooks are disabled or no hook scripts exist: functions exactly as before. The cache returns `[]` and `hasHook` returns `false` within one scan cycle.

## Test Procedure

- [x] Unit tests: cache usage by hasHook, return values, cache hit/miss behavior
- [x] TypeScript compilation: no errors
- [x] gitleaks pre-commit hook passed
- [x] Cross-provider adversarial review passed (GPT-5.5)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore
- [x] Tests are passing and code is formatted and linted
- [x] I have reviewed contributor guidelines

## Additional Notes

`getHookInfo` at line 726 already uses `HookDiscoveryCache.getInstance().get(hookName)`. The `hasHook` method was the only callsite still using the uncached `findHookScripts` path. Making them consistent also eliminates a redundant filesystem scan per hook execution.