### PR TITLE
fix(vscode): reset button processing state after file approval to fix sequential multi-file edit (#9790)

### DIFF
--- a/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/ActionButtons.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/ActionButtons.test.tsx
@@ -1,6 +1,6 @@
 import type { ClineMessage } from "@shared/ExtensionMessage"
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import type { MessageHandlers } from "../../types/chatTypes"
 import { ActionButtons } from "./ActionButtons"
 

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/ActionButtons.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/ActionButtons.test.tsx
@@ -1,0 +1,347 @@
+import type { ClineMessage } from "@shared/ExtensionMessage"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import type { MessageHandlers } from "../../types/chatTypes"
+import { ActionButtons } from "./ActionButtons"
+
+describe("ActionButtons", () => {
+	const mockMessageHandlers: MessageHandlers = {
+		executeButtonAction: vi.fn(),
+		updateChatHistory: vi.fn(),
+		streamMessage: vi.fn(),
+	} as any
+
+	const mockChatState = {
+		inputValue: "test input",
+		selectedImages: [],
+		selectedFiles: [],
+		setSendingDisabled: vi.fn(),
+		setInputValue: vi.fn(),
+		setSelectedImages: vi.fn(),
+		setSelectedFiles: vi.fn(),
+	}
+
+	const mockScrollBehavior = {
+		scrollToBottomSmooth: vi.fn(),
+		disableAutoScrollRef: { current: false },
+		showScrollToBottom: false,
+		virtuosoRef: { current: null },
+	}
+
+	const mockTask: ClineMessage = {
+		ts: Date.now(),
+		type: "ask",
+		ask: "tool",
+		text: JSON.stringify({ tool: "newFileCreated" }),
+	}
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it("renders save and reject buttons for file creation", () => {
+		render(
+			<ActionButtons
+				chatState={mockChatState as any}
+				messageHandlers={mockMessageHandlers}
+				messages={[mockTask]}
+				mode="act"
+				scrollBehavior={mockScrollBehavior as any}
+				task={mockTask}
+			/>,
+		)
+
+		expect(screen.getByText("Save")).toBeInTheDocument()
+		expect(screen.getByText("Reject")).toBeInTheDocument()
+	})
+
+	it("disables buttons while processing action", async () => {
+		mockMessageHandlers.executeButtonAction.mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					setTimeout(resolve, 100)
+				}),
+		)
+
+		render(
+			<ActionButtons
+				chatState={mockChatState as any}
+				messageHandlers={mockMessageHandlers}
+				messages={[mockTask]}
+				mode="act"
+				scrollBehavior={mockScrollBehavior as any}
+				task={mockTask}
+			/>,
+		)
+
+		const buttons = screen.getAllByText(/Save|Reject/)
+		const saveButton = buttons[0] as unknown as HTMLElement
+		const parentButton = saveButton.closest("vscode-button") as any
+		expect(parentButton.disabled).not.toBe(true)
+
+		fireEvent.click(saveButton)
+
+		// Buttons should be disabled immediately after click
+		expect(parentButton.disabled).toBe(true)
+
+		// Wait for promise to resolve
+		await waitFor(() => {
+			expect(mockMessageHandlers.executeButtonAction).toHaveBeenCalled()
+		})
+	})
+
+	it("re-enables buttons after successful action completion", async () => {
+		mockMessageHandlers.executeButtonAction.mockResolvedValue(undefined)
+
+		const { rerender } = render(
+			<ActionButtons
+				chatState={mockChatState as any}
+				messageHandlers={mockMessageHandlers}
+				messages={[mockTask]}
+				mode="act"
+				scrollBehavior={mockScrollBehavior as any}
+				task={mockTask}
+			/>,
+		)
+
+		const buttons = screen.getAllByText(/Save|Reject/)
+		const saveButton = buttons[0] as unknown as HTMLElement
+		fireEvent.click(saveButton)
+
+		// Wait for the promise chain to complete
+		await waitFor(
+			() => {
+				expect(mockMessageHandlers.executeButtonAction).toHaveBeenCalled()
+			},
+			{ timeout: 500 },
+		)
+
+		// Rerender to pick up state change (buttons should be re-enabled)
+		rerender(
+			<ActionButtons
+				chatState={mockChatState as any}
+				messageHandlers={mockMessageHandlers}
+				messages={[mockTask]}
+				mode="act"
+				scrollBehavior={mockScrollBehavior as any}
+				task={mockTask}
+			/>,
+		)
+
+		// Since isProcessing is set to false after .then(), buttons should be enabled
+		// We verify this by checking that another click doesn't fire multiple actions
+		fireEvent.click(saveButton)
+		expect(mockMessageHandlers.executeButtonAction).toHaveBeenCalledTimes(2)
+	})
+
+	it("re-enables buttons after error in action", async () => {
+		mockMessageHandlers.executeButtonAction.mockRejectedValue(new Error("Test error"))
+
+		const { rerender } = render(
+			<ActionButtons
+				chatState={mockChatState as any}
+				messageHandlers={mockMessageHandlers}
+				messages={[mockTask]}
+				mode="act"
+				scrollBehavior={mockScrollBehavior as any}
+				task={mockTask}
+			/>,
+		)
+
+		const buttons = screen.getAllByText(/Save|Reject/)
+		const saveButton = buttons[0] as unknown as HTMLElement
+		fireEvent.click(saveButton)
+
+		// Wait for the promise chain to complete
+		await waitFor(
+			() => {
+				expect(mockMessageHandlers.executeButtonAction).toHaveBeenCalled()
+			},
+			{ timeout: 500 },
+		)
+
+		// Rerender to pick up state change
+		rerender(
+			<ActionButtons
+				chatState={mockChatState as any}
+				messageHandlers={mockMessageHandlers}
+				messages={[mockTask]}
+				mode="act"
+				scrollBehavior={mockScrollBehavior as any}
+				task={mockTask}
+			/>,
+		)
+
+		// Button should be enabled again after error, allowing another click
+		fireEvent.click(saveButton)
+		expect(mockMessageHandlers.executeButtonAction).toHaveBeenCalledTimes(2)
+	})
+
+	it("allows sequential file approvals without getting stuck", async () => {
+		mockMessageHandlers.executeButtonAction.mockResolvedValue(undefined)
+
+		const { rerender } = render(
+			<ActionButtons
+				chatState={mockChatState as any}
+				messageHandlers={mockMessageHandlers}
+				messages={[mockTask]}
+				mode="act"
+				scrollBehavior={mockScrollBehavior as any}
+				task={mockTask}
+			/>,
+		)
+
+		const buttons = screen.getAllByText(/Save|Reject/)
+		const saveButton = buttons[0] as unknown as HTMLElement
+
+		// First approval
+		fireEvent.click(saveButton)
+		await waitFor(() => {
+			expect(mockMessageHandlers.executeButtonAction).toHaveBeenCalledTimes(1)
+		})
+
+		// Rerender (simulating message update from backend)
+		const secondTask: ClineMessage = {
+			ts: Date.now() + 1000,
+			type: "ask",
+			ask: "tool",
+			text: JSON.stringify({ tool: "editedExistingFile" }),
+		}
+
+		rerender(
+			<ActionButtons
+				chatState={mockChatState as any}
+				messageHandlers={mockMessageHandlers}
+				messages={[mockTask, secondTask]}
+				mode="act"
+				scrollBehavior={mockScrollBehavior as any}
+				task={secondTask}
+			/>,
+		)
+
+		// Second approval should be possible without buttons being stuck
+		fireEvent.click(saveButton)
+		await waitFor(() => {
+			expect(mockMessageHandlers.executeButtonAction).toHaveBeenCalledTimes(2)
+		})
+	})
+
+	it("prevents rapid sequential clicks on the same action", async () => {
+		mockMessageHandlers.executeButtonAction.mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					setTimeout(resolve, 50)
+				}),
+		)
+
+		render(
+			<ActionButtons
+				chatState={mockChatState as any}
+				messageHandlers={mockMessageHandlers}
+				messages={[mockTask]}
+				mode="act"
+				scrollBehavior={mockScrollBehavior as any}
+				task={mockTask}
+			/>,
+		)
+
+		const buttons = screen.getAllByText(/Save|Reject/)
+		const saveButton = buttons[0] as unknown as HTMLElement
+
+		// Rapid clicks while processing
+		fireEvent.click(saveButton)
+		fireEvent.click(saveButton)
+		fireEvent.click(saveButton)
+
+		// Should only execute once, not three times
+		await waitFor(() => {
+			expect(mockMessageHandlers.executeButtonAction).toHaveBeenCalledTimes(1)
+		})
+	})
+
+	it("calls executeButtonAction with correct parameters", async () => {
+		mockMessageHandlers.executeButtonAction.mockResolvedValue(undefined)
+
+		render(
+			<ActionButtons
+				chatState={{
+					...mockChatState,
+					inputValue: "save this",
+					selectedImages: ["img1", "img2"],
+					selectedFiles: ["file1", "file2"],
+				} as any}
+				messageHandlers={mockMessageHandlers}
+				messages={[mockTask]}
+				mode="act"
+				scrollBehavior={mockScrollBehavior as any}
+				task={mockTask}
+			/>,
+		)
+
+		const buttons = screen.getAllByText(/Save|Reject/)
+		const saveButton = buttons[0] as unknown as HTMLElement
+		fireEvent.click(saveButton)
+
+		await waitFor(() => {
+			expect(mockMessageHandlers.executeButtonAction).toHaveBeenCalledWith(
+				"approve",
+				"save this",
+				["img1", "img2"],
+				["file1", "file2"],
+			)
+		})
+	})
+
+	it("does not render action buttons when task is null", () => {
+		render(
+			<ActionButtons
+				chatState={mockChatState as any}
+				messageHandlers={mockMessageHandlers}
+				messages={[]}
+				mode="act"
+				scrollBehavior={mockScrollBehavior as any}
+				task={undefined}
+			/>,
+		)
+
+		expect(screen.queryByRole("button", { name: /Save/i })).not.toBeInTheDocument()
+		expect(screen.queryByRole("button", { name: /Reject/i })).not.toBeInTheDocument()
+	})
+
+	it("calls setSendingDisabled when button config changes", async () => {
+		const { rerender } = render(
+			<ActionButtons
+				chatState={mockChatState as any}
+				messageHandlers={mockMessageHandlers}
+				messages={[mockTask]}
+				mode="act"
+				scrollBehavior={mockScrollBehavior as any}
+				task={mockTask}
+			/>,
+		)
+
+		expect(mockChatState.setSendingDisabled).toHaveBeenCalled()
+
+		// Change the task to trigger buttonConfig change
+		const newTask: ClineMessage = {
+			ts: Date.now() + 1000,
+			type: "ask",
+			ask: "command",
+			text: "",
+		}
+
+		rerender(
+			<ActionButtons
+				chatState={mockChatState as any}
+				messageHandlers={mockMessageHandlers}
+				messages={[mockTask, newTask]}
+				mode="act"
+				scrollBehavior={mockScrollBehavior as any}
+				task={newTask}
+			/>,
+		)
+
+		// setSendingDisabled should have been called again
+		expect(mockChatState.setSendingDisabled).toHaveBeenCalledTimes(2)
+	})
+})

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/ActionButtons.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/ActionButtons.test.tsx
@@ -1,5 +1,5 @@
 import type { ClineMessage } from "@shared/ExtensionMessage"
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import type { MessageHandlers } from "../../types/chatTypes"
 import { ActionButtons } from "./ActionButtons"
@@ -36,8 +36,12 @@ describe("ActionButtons", () => {
 	}
 
 	beforeEach(() => {
-		vi.clearAllMocks()
+		vi.resetAllMocks()
 	})
+
+	const getSaveButton = () => screen.getByText("Save") as unknown as HTMLElement
+
+	const getSaveHost = () => getSaveButton().closest("vscode-button") as any
 
 	it("renders save and reject buttons for file creation", () => {
 		render(
@@ -74,9 +78,8 @@ describe("ActionButtons", () => {
 			/>,
 		)
 
-		const buttons = screen.getAllByText(/Save|Reject/)
-		const saveButton = buttons[0] as unknown as HTMLElement
-		const parentButton = saveButton.closest("vscode-button") as any
+		const saveButton = getSaveButton()
+		const parentButton = getSaveHost()
 		expect(parentButton.disabled).not.toBe(true)
 
 		fireEvent.click(saveButton)
@@ -104,9 +107,11 @@ describe("ActionButtons", () => {
 			/>,
 		)
 
-		const buttons = screen.getAllByText(/Save|Reject/)
-		const saveButton = buttons[0] as unknown as HTMLElement
-		fireEvent.click(saveButton)
+		await act(async () => {
+			fireEvent.click(getSaveButton())
+			await Promise.resolve()
+			await Promise.resolve()
+		})
 
 		// Wait for the promise chain to complete
 		await waitFor(
@@ -128,14 +133,28 @@ describe("ActionButtons", () => {
 			/>,
 		)
 
-		// Since isProcessing is set to false after .then(), buttons should be enabled
-		// We verify this by checking that another click doesn't fire multiple actions
-		fireEvent.click(saveButton)
+		await waitFor(() => {
+			expect(getSaveHost().disabled).not.toBe(true)
+		})
+
+		await act(async () => {
+			fireEvent.click(getSaveButton())
+			await Promise.resolve()
+			await Promise.resolve()
+		})
 		expect(mockMessageHandlers.executeButtonAction).toHaveBeenCalledTimes(2)
 	})
 
 	it("re-enables buttons after error in action", async () => {
-		mockMessageHandlers.executeButtonAction.mockRejectedValue(new Error("Test error"))
+		let rejectAction: ((reason?: unknown) => void) | undefined
+		mockMessageHandlers.executeButtonAction
+			.mockImplementationOnce(
+				() =>
+					new Promise((_, reject) => {
+						rejectAction = reject
+					}),
+			)
+			.mockResolvedValue(undefined)
 
 		const { rerender } = render(
 			<ActionButtons
@@ -148,17 +167,13 @@ describe("ActionButtons", () => {
 			/>,
 		)
 
-		const buttons = screen.getAllByText(/Save|Reject/)
-		const saveButton = buttons[0] as unknown as HTMLElement
-		fireEvent.click(saveButton)
-
-		// Wait for the promise chain to complete
-		await waitFor(
-			() => {
-				expect(mockMessageHandlers.executeButtonAction).toHaveBeenCalled()
-			},
-			{ timeout: 500 },
-		)
+		await act(async () => {
+			fireEvent.click(getSaveButton())
+			expect(rejectAction).toBeDefined()
+			rejectAction?.(new Error("Test error"))
+			await Promise.resolve()
+			await Promise.resolve()
+		})
 
 		// Rerender to pick up state change
 		rerender(
@@ -172,8 +187,15 @@ describe("ActionButtons", () => {
 			/>,
 		)
 
-		// Button should be enabled again after error, allowing another click
-		fireEvent.click(saveButton)
+		await waitFor(() => {
+			expect(getSaveHost().disabled).not.toBe(true)
+		})
+
+		await act(async () => {
+			fireEvent.click(getSaveButton())
+			await Promise.resolve()
+			await Promise.resolve()
+		})
 		expect(mockMessageHandlers.executeButtonAction).toHaveBeenCalledTimes(2)
 	})
 
@@ -191,11 +213,8 @@ describe("ActionButtons", () => {
 			/>,
 		)
 
-		const buttons = screen.getAllByText(/Save|Reject/)
-		const saveButton = buttons[0] as unknown as HTMLElement
-
 		// First approval
-		fireEvent.click(saveButton)
+		fireEvent.click(getSaveButton())
 		await waitFor(() => {
 			expect(mockMessageHandlers.executeButtonAction).toHaveBeenCalledTimes(1)
 		})
@@ -220,7 +239,11 @@ describe("ActionButtons", () => {
 		)
 
 		// Second approval should be possible without buttons being stuck
-		fireEvent.click(saveButton)
+		await waitFor(() => {
+			expect(getSaveHost().disabled).not.toBe(true)
+		})
+
+		fireEvent.click(getSaveButton())
 		await waitFor(() => {
 			expect(mockMessageHandlers.executeButtonAction).toHaveBeenCalledTimes(2)
 		})
@@ -245,8 +268,7 @@ describe("ActionButtons", () => {
 			/>,
 		)
 
-		const buttons = screen.getAllByText(/Save|Reject/)
-		const saveButton = buttons[0] as unknown as HTMLElement
+		const saveButton = getSaveButton()
 
 		// Rapid clicks while processing
 		fireEvent.click(saveButton)

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/ActionButtons.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/ActionButtons.tsx
@@ -69,10 +69,8 @@ export const ActionButtons: React.FC<ActionButtonsProps> = ({
 			}
 			setIsProcessing(true)
 
-			void messageHandlers.executeButtonAction(action, text, images, files).then(() => {
-				setIsProcessing(false)
-			}).catch(() => {
-				// Reset processing state on errors to avoid getting stuck.
+			void messageHandlers.executeButtonAction(action, text, images, files).finally(() => {
+				// Reset processing state after action completes (success or error)
 				setIsProcessing(false)
 			})
 		},

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/ActionButtons.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/ActionButtons.tsx
@@ -69,7 +69,9 @@ export const ActionButtons: React.FC<ActionButtonsProps> = ({
 			}
 			setIsProcessing(true)
 
-			void messageHandlers.executeButtonAction(action, text, images, files).catch(() => {
+			void messageHandlers.executeButtonAction(action, text, images, files).then(() => {
+				setIsProcessing(false)
+			}).catch(() => {
 				// Reset processing state on errors to avoid getting stuck.
 				setIsProcessing(false)
 			})

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/ActionButtons.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/ActionButtons.tsx
@@ -69,10 +69,13 @@ export const ActionButtons: React.FC<ActionButtonsProps> = ({
 			}
 			setIsProcessing(true)
 
-			void messageHandlers.executeButtonAction(action, text, images, files).finally(() => {
-				// Reset processing state after action completes (success or error)
-				setIsProcessing(false)
-			})
+			void messageHandlers
+				.executeButtonAction(action, text, images, files)
+				.finally(() => {
+					// Reset processing state after action completes (success or error)
+					setIsProcessing(false)
+				})
+				.catch(() => undefined)
 		},
 		[messageHandlers, isProcessing],
 	)


### PR DESCRIPTION
## Related Issue

Fixes #9790

## Description

During multi-file edits in manual-approval mode, Save/Reject buttons stay disabled after clicking Save for the first file. The buttons only recover when a new message arrives from the backend, but if the checkpoint commit between files takes any time (logs show 87-113ms), the buttons appear permanently stuck until the window is reloaded.

**Root cause:** `isProcessing` in `ActionButtons.tsx` (local `useState`) is set to `true` on button click and reset only inside a `useEffect` that fires when `buttonConfig` changes. Between the user clicking Save and the backend delivering the next file's `ask("tool", ...)` message, `lastMessage` does not change (checkpoint commits are backend-only and do not push a new UI message), so the `useEffect` never fires and `isProcessing` stays `true`.

**Fix:** Reset `isProcessing` to `false` immediately after `executeButtonAction` settles with `.finally(() => setIsProcessing(false))`, rather than relying solely on a subsequent message from the backend. The rejected promise chain is consumed after the reset so failed actions re-enable the buttons without surfacing unhandled promise rejections in the webview or Vitest.

When a new backend message arrives (as in the normal streaming flow), behavior stays the same; the `useEffect` also resets `isProcessing`, and the double reset is harmless.

## Test Procedure

- [x] Local focused webview test: `cd apps/vscode/webview-ui && npm run test -- ActionButtons.test.tsx` (9/9)
- [x] GitHub CI on current head `c48f24bb3`: `ext-vscode-test` green, including Linux and Windows VS Code tests, Quality Checks, aggregate `test`, and `qlty`
- [x] GitHub CI on current head `c48f24bb3`: `ext-vscode-test-e2e` green on Ubuntu, macOS, and Windows
- [x] Greptile Review and Socket checks green
- [ ] Full local `npm run test:coverage`: not used for final verification because this worktree lacked generated proto/gRPC outputs before the `apps/vscode` CI build step; the GitHub workflow ran that generated build path and passed

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore
- [x] Tests are passing and code is formatted and linted
- [x] I have reviewed contributor guidelines

## Screenshots

N/A, no visual layout change.

## Additional Notes

The `.clinerules` workaround suggested in the issue comments ("edit files one-by-one and wait for me to save before you proceed") avoids triggering the bug by preventing the model from queuing multiple file edits. This fix removes the need for that workaround.
