### PR TITLE
feat(sdk,cli): complete agent profiles support

### DIFF
--- a/apps/cli/src/commands/program.ts
+++ b/apps/cli/src/commands/program.ts
@@ -51,6 +51,10 @@ export function addRootOptions(cmd: Command): Command {
 				"-s, --system <system-prompt>",
 				"Override the default system prompt",
 			)
+			.option(
+				"--agent <name>",
+				"Use an agent profile from .cline/agents for this session",
+			)
 			.option("-z, --zen", "Start a session that runs in the background hub")
 			.option(
 				"--retries [value]",
@@ -225,6 +229,7 @@ export function commanderToParsedArgs(program: Command): ParsedArgs {
 	if (opts.cwd !== undefined) result.cwd = opts.cwd;
 	if (opts.teamName !== undefined) result.teamName = opts.teamName;
 	if (opts.system !== undefined) result.systemPrompt = opts.system;
+	if (opts.agent !== undefined) result.agent = opts.agent;
 	if (opts.model !== undefined) result.model = opts.model;
 	if (opts.provider !== undefined) result.provider = opts.provider;
 	if (opts.key !== undefined) result.key = opts.key;

--- a/apps/cli/src/main.test.ts
+++ b/apps/cli/src/main.test.ts
@@ -2,6 +2,23 @@ import { fstatSync } from "node:fs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CliMigrationNotice } from "./kanban-migration/notice";
 
+interface MockConfiguredAgentConfig {
+	name: string;
+	description: string;
+	systemPrompt: string;
+	path?: string;
+}
+
+interface MockConfiguredAgentReadError {
+	path: string;
+	error: Error;
+}
+
+interface MockConfiguredAgentLoadResult {
+	configs: MockConfiguredAgentConfig[];
+	errors: MockConfiguredAgentReadError[];
+}
+
 /** Real `fstatSync`: used when tests stub only stdin (fd 0); throwing for every fd breaks imports and session I/O. */
 const fsActual = vi.hoisted(() => ({
 	realFstatSync: null as null | typeof import("node:fs").fstatSync,
@@ -46,6 +63,14 @@ const sessionMocks = vi.hoisted(() => ({
 }));
 const llmMocks = vi.hoisted(() => ({
 	resolveProviderConfig: vi.fn(async (): Promise<unknown> => undefined),
+}));
+const agentConfigMocks = vi.hoisted(() => ({
+	loadConfiguredAgentConfigs: vi.fn<
+		(input: { workspaceRoot?: string }) => MockConfiguredAgentLoadResult
+	>(() => ({
+		configs: [],
+		errors: [],
+	})),
 }));
 const promptMocks = vi.hoisted(() => ({
 	resolveSystemPrompt: vi.fn(async () => "system prompt"),
@@ -142,6 +167,7 @@ vi.mock("./session/session", () => sessionMocks);
 vi.mock("@cline/core", () => {
 	return {
 		resolveProviderConfig: llmMocks.resolveProviderConfig,
+		loadConfiguredAgentConfigs: agentConfigMocks.loadConfiguredAgentConfigs,
 		createTeamName: vi.fn(() => "team-test"),
 		createUserInstructionConfigService: vi.fn(() => ({
 			start: vi.fn(async () => {}),
@@ -215,6 +241,11 @@ describe("runCli lightweight command dispatch", () => {
 		});
 		llmMocks.resolveProviderConfig.mockReset();
 		llmMocks.resolveProviderConfig.mockResolvedValue(undefined);
+		agentConfigMocks.loadConfiguredAgentConfigs.mockReset();
+		agentConfigMocks.loadConfiguredAgentConfigs.mockReturnValue({
+			configs: [],
+			errors: [],
+		});
 		authMocks.ensureOAuthProviderApiKey.mockReset();
 		authMocks.getPersistedProviderApiKey.mockReset();
 		authMocks.getPersistedProviderApiKey.mockReturnValue(undefined);
@@ -870,6 +901,133 @@ describe("runCli lightweight command dispatch", () => {
 		await expect(runCli()).resolves.toBeUndefined();
 		expect(runtimeMocks.runAgent).toHaveBeenCalledTimes(1);
 		expect(hubRuntimeMocks.ensureCliHubServer).not.toHaveBeenCalled();
+	});
+
+	it("applies an agent profile to prompt runs", async () => {
+		agentConfigMocks.loadConfiguredAgentConfigs.mockReturnValue({
+			configs: [
+				{
+					name: "Reviewer",
+					description: "Reviews code",
+					systemPrompt: "You are a reviewer.",
+					path: "/repo/.cline/agents/reviewer.yaml",
+				},
+			],
+			errors: [],
+		});
+		forcePromptModeInput();
+		process.argv = ["bun", "src/index.ts", "--agent", "reviewer", "hello"];
+
+		const { runCli } = await import("./main");
+
+		await expect(runCli()).resolves.toBeUndefined();
+		expect(agentConfigMocks.loadConfiguredAgentConfigs).toHaveBeenCalledWith({
+			workspaceRoot: "/workspace/cline",
+		});
+		expect(promptMocks.resolveSystemPrompt).toHaveBeenCalledWith(
+			expect.objectContaining({
+				agentPersona: "You are a reviewer.",
+			}),
+		);
+		expect(runtimeMocks.runAgent).toHaveBeenCalledWith(
+			"hello",
+			expect.objectContaining({
+				agentProfile: {
+					name: "Reviewer",
+					systemPrompt: "You are a reviewer.",
+				},
+				systemPrompt: "system prompt",
+			}),
+			expect.anything(),
+		);
+	});
+
+	it("lets --system override --agent without storing the profile", async () => {
+		agentConfigMocks.loadConfiguredAgentConfigs.mockReturnValue({
+			configs: [
+				{
+					name: "Reviewer",
+					description: "Reviews code",
+					systemPrompt: "You are a reviewer.",
+					path: "/repo/.cline/agents/reviewer.yaml",
+				},
+			],
+			errors: [],
+		});
+		forcePromptModeInput();
+		process.argv = [
+			"bun",
+			"src/index.ts",
+			"--agent",
+			"reviewer",
+			"--system",
+			"Custom system.",
+			"hello",
+		];
+
+		const { runCli } = await import("./main");
+
+		await expect(runCli()).resolves.toBeUndefined();
+		expect(agentConfigMocks.loadConfiguredAgentConfigs).not.toHaveBeenCalled();
+		expect(promptMocks.resolveSystemPrompt).toHaveBeenCalledWith(
+			expect.objectContaining({
+				explicitSystemPrompt: "Custom system.",
+			}),
+		);
+		expect(runtimeMocks.runAgent).toHaveBeenCalledWith(
+			"hello",
+			expect.objectContaining({
+				agentProfile: undefined,
+			}),
+			expect.anything(),
+		);
+	});
+
+	it("rejects missing agent profiles before starting the runtime", async () => {
+		agentConfigMocks.loadConfiguredAgentConfigs.mockReturnValue({
+			configs: [
+				{
+					name: "Planner",
+					description: "Plans work",
+					systemPrompt: "You are a planner.",
+					path: "/repo/.cline/agents/planner.yaml",
+				},
+			],
+			errors: [
+				{
+					path: "/repo/.cline/agents/broken.yaml",
+					error: new Error("Missing system prompt body"),
+				},
+			],
+		});
+		forcePromptModeInput();
+		process.argv = ["bun", "src/index.ts", "--agent", "reviewer", "hello"];
+
+		const { runCli } = await import("./main");
+
+		await expect(runCli()).resolves.toBeUndefined();
+		expect(process.exitCode).toBe(1);
+		expect(runtimeMocks.runAgent).not.toHaveBeenCalled();
+		expect(runtimeMocks.runInteractive).not.toHaveBeenCalled();
+	});
+
+	it("rejects --agent in yolo mode before loading profiles", async () => {
+		forcePromptModeInput();
+		process.argv = [
+			"bun",
+			"src/index.ts",
+			"--yolo",
+			"--agent",
+			"reviewer",
+			"hello",
+		];
+
+		const { runCli } = await import("./main");
+
+		await expect(runCli()).resolves.toBeUndefined();
+		expect(process.exitCode).toBe(1);
+		expect(agentConfigMocks.loadConfiguredAgentConfigs).not.toHaveBeenCalled();
+		expect(runtimeMocks.runAgent).not.toHaveBeenCalled();
 	});
 
 	it("rewrites /team prompts and enables teams in single-prompt mode", async () => {

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -936,37 +936,42 @@ export async function runCli(): Promise<void> {
 				process.exitCode = 1;
 				return;
 			}
-			const { loadConfiguredAgentConfigs } = await import("@cline/core");
-			const { configs, errors } = loadConfiguredAgentConfigs({ workspaceRoot });
-			const profile = configs.find(
-				(candidate) =>
-					candidate.name.trim().toLowerCase() ===
-					requestedAgentName.toLowerCase(),
-			);
-			if (!profile) {
-				const availableNames = configs.map((candidate) => candidate.name);
-				writeErr(
-					availableNames.length > 0
-						? `agent profile "${requestedAgentName}" not found (available: ${availableNames.join(", ")})`
-						: `agent profile "${requestedAgentName}" not found (no agent profiles in .cline/agents)`,
-				);
-				for (const error of errors) {
-					writeErr(`failed to load ${error.path}: ${error.error.message}`);
-				}
-				process.exitCode = 1;
-				return;
-			}
 			if (args.systemPrompt) {
+				// Don't keep a profile around that the explicit prompt overrides:
+				// it would resurface on plan/act toggles and mislead the status bar.
 				writeln(
-					`${c.dim}[warn] both --system and --agent provided; --system overrides the agent profile prompt${c.reset}`,
+					`${c.dim}[warn] --system overrides --agent; ignoring agent profile "${requestedAgentName}"${c.reset}`,
 				);
+			} else {
+				const { loadConfiguredAgentConfigs } = await import("@cline/core");
+				const { configs, errors } = loadConfiguredAgentConfigs({
+					workspaceRoot,
+				});
+				const profile = configs.find(
+					(candidate) =>
+						candidate.name.trim().toLowerCase() ===
+						requestedAgentName.toLowerCase(),
+				);
+				if (!profile) {
+					const availableNames = configs.map((candidate) => candidate.name);
+					writeErr(
+						availableNames.length > 0
+							? `agent profile "${requestedAgentName}" not found (available: ${availableNames.join(", ")})`
+							: `agent profile "${requestedAgentName}" not found (no agent profiles in .cline/agents)`,
+					);
+					for (const error of errors) {
+						writeErr(`failed to load ${error.path}: ${error.error.message}`);
+					}
+					process.exitCode = 1;
+					return;
+				}
+				activeAgentProfile = {
+					name: profile.name,
+					description: profile.description,
+					systemPrompt: profile.systemPrompt,
+					path: profile.path,
+				};
 			}
-			activeAgentProfile = {
-				name: profile.name,
-				description: profile.description,
-				systemPrompt: profile.systemPrompt,
-				path: profile.path,
-			};
 		}
 
 		const config: Config = {

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -937,8 +937,7 @@ export async function runCli(): Promise<void> {
 				return;
 			}
 			if (args.systemPrompt) {
-				// Don't keep a profile around that the explicit prompt overrides:
-				// it would resurface on plan/act toggles and mislead the status bar.
+				// Don't store an unused profile: it would resurface on plan/act toggles.
 				writeln(
 					`${c.dim}[warn] --system overrides --agent; ignoring agent profile "${requestedAgentName}"${c.reset}`,
 				);
@@ -967,9 +966,7 @@ export async function runCli(): Promise<void> {
 				}
 				activeAgentProfile = {
 					name: profile.name,
-					description: profile.description,
 					systemPrompt: profile.systemPrompt,
-					path: profile.path,
 				};
 			}
 		}

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -42,7 +42,7 @@ import {
 	captureCliExtensionActivated,
 	getCliTelemetryService,
 } from "./utils/telemetry";
-import type { Config } from "./utils/types";
+import type { ActiveAgentProfile, Config } from "./utils/types";
 import { runConnectWizard } from "./wizards/connect";
 import { runMcpWizard } from "./wizards/mcp";
 import { runScheduleWizard } from "./wizards/schedule";
@@ -928,6 +928,47 @@ export async function runCli(): Promise<void> {
 			cwd,
 		});
 
+		let activeAgentProfile: ActiveAgentProfile | undefined;
+		const requestedAgentName = args.agent?.trim();
+		if (requestedAgentName) {
+			if (isYoloMode) {
+				writeErr("--agent is not supported in yolo mode");
+				process.exitCode = 1;
+				return;
+			}
+			const { loadConfiguredAgentConfigs } = await import("@cline/core");
+			const { configs, errors } = loadConfiguredAgentConfigs({ workspaceRoot });
+			const profile = configs.find(
+				(candidate) =>
+					candidate.name.trim().toLowerCase() ===
+					requestedAgentName.toLowerCase(),
+			);
+			if (!profile) {
+				const availableNames = configs.map((candidate) => candidate.name);
+				writeErr(
+					availableNames.length > 0
+						? `agent profile "${requestedAgentName}" not found (available: ${availableNames.join(", ")})`
+						: `agent profile "${requestedAgentName}" not found (no agent profiles in .cline/agents)`,
+				);
+				for (const error of errors) {
+					writeErr(`failed to load ${error.path}: ${error.error.message}`);
+				}
+				process.exitCode = 1;
+				return;
+			}
+			if (args.systemPrompt) {
+				writeln(
+					`${c.dim}[warn] both --system and --agent provided; --system overrides the agent profile prompt${c.reset}`,
+				);
+			}
+			activeAgentProfile = {
+				name: profile.name,
+				description: profile.description,
+				systemPrompt: profile.systemPrompt,
+				path: profile.path,
+			};
+		}
+
 		const config: Config = {
 			providerId: provider,
 			modelId:
@@ -942,6 +983,7 @@ export async function runCli(): Promise<void> {
 				explicitSystemPrompt: args.systemPrompt,
 				providerId: provider,
 				mode: args.mode ?? "act",
+				agentPersona: activeAgentProfile?.systemPrompt,
 			}),
 			execution: {
 				maxConsecutiveMistakes: args.retries ?? 3,
@@ -964,6 +1006,7 @@ export async function runCli(): Promise<void> {
 			telemetry: getCliTelemetryService(loggerAdapter.core),
 			defaultToolAutoApprove,
 			toolPolicies,
+			agentProfile: activeAgentProfile,
 			enableSpawnAgent: !isYoloMode,
 			enableAgentTeams: !isYoloMode,
 			enableTools: true,

--- a/apps/cli/src/runtime/interactive/mode.test.ts
+++ b/apps/cli/src/runtime/interactive/mode.test.ts
@@ -83,7 +83,6 @@ describe("applyInteractiveModeConfig", () => {
 		const config = makeConfig();
 		config.agentProfile = {
 			name: "reviewer",
-			description: "Reviews code",
 			systemPrompt: "You are a reviewer.",
 		};
 

--- a/apps/cli/src/runtime/interactive/mode.test.ts
+++ b/apps/cli/src/runtime/interactive/mode.test.ts
@@ -78,4 +78,37 @@ describe("applyInteractiveModeConfig", () => {
 		expect(config.extraTools).toEqual([]);
 		expect(config.systemPrompt).toBe("system prompt for act");
 	});
+
+	it("threads the active agent profile persona across mode switches", async () => {
+		const config = makeConfig();
+		config.agentProfile = {
+			name: "reviewer",
+			description: "Reviews code",
+			systemPrompt: "You are a reviewer.",
+		};
+
+		await applyInteractiveModeConfig({
+			config,
+			mode: "plan",
+			switchToActModeTool,
+		});
+		expect(resolveSystemPrompt).toHaveBeenLastCalledWith({
+			cwd: config.cwd,
+			providerId: config.providerId,
+			mode: "plan",
+			agentPersona: "You are a reviewer.",
+		});
+
+		await applyInteractiveModeConfig({
+			config,
+			mode: "act",
+			switchToActModeTool,
+		});
+		expect(resolveSystemPrompt).toHaveBeenLastCalledWith({
+			cwd: config.cwd,
+			providerId: config.providerId,
+			mode: "act",
+			agentPersona: "You are a reviewer.",
+		});
+	});
 });

--- a/apps/cli/src/runtime/interactive/mode.ts
+++ b/apps/cli/src/runtime/interactive/mode.ts
@@ -43,5 +43,6 @@ export async function applyInteractiveModeConfig(input: {
 		cwd: input.config.cwd,
 		providerId: input.config.providerId,
 		mode: input.mode,
+		agentPersona: input.config.agentProfile?.systemPrompt,
 	});
 }

--- a/apps/cli/src/runtime/interactive/session-runtime.ts
+++ b/apps/cli/src/runtime/interactive/session-runtime.ts
@@ -363,8 +363,7 @@ export function createInteractiveSessionRuntime(input: {
 		profile: ActiveAgentProfile | undefined,
 	): Promise<void> => {
 		input.config.agentProfile = profile;
-		// Re-running the mode config keeps the system prompt and extraTools
-		// invariants consistent while threading the new persona.
+		// Re-apply the current mode so the system prompt picks up the persona.
 		await applyInteractiveModeConfig({
 			config: input.config,
 			mode: input.config.mode === "plan" ? "plan" : "act",

--- a/apps/cli/src/runtime/interactive/session-runtime.ts
+++ b/apps/cli/src/runtime/interactive/session-runtime.ts
@@ -21,7 +21,7 @@ import type {
 import { createRuntimeHooks } from "../../utils/hooks";
 import { setActiveCliSession } from "../../utils/output";
 import { loadInteractiveResumeMessages } from "../../utils/resume";
-import type { Config } from "../../utils/types";
+import type { ActiveAgentProfile, Config } from "../../utils/types";
 import { markAbortInProgress } from "../active-runtime";
 import type {
 	PendingPromptSnapshot,
@@ -359,6 +359,20 @@ export function createInteractiveSessionRuntime(input: {
 		await restartWithCurrentMessages();
 	};
 
+	const applyAgentProfile = async (
+		profile: ActiveAgentProfile | undefined,
+	): Promise<void> => {
+		input.config.agentProfile = profile;
+		// Re-running the mode config keeps the system prompt and extraTools
+		// invariants consistent while threading the new persona.
+		await applyInteractiveModeConfig({
+			config: input.config,
+			mode: input.config.mode === "plan" ? "plan" : "act",
+			switchToActModeTool: input.switchToActModeTool,
+		});
+		await restartWithCurrentMessages();
+	};
+
 	const sendCurrentTurn = async (
 		turnInput: CurrentTurnInput,
 	): Promise<CurrentTurnResult> => {
@@ -639,6 +653,7 @@ export function createInteractiveSessionRuntime(input: {
 		getCheckpointData,
 		restoreCheckpoint,
 		applyMode,
+		applyAgentProfile,
 		resetAbortRequest,
 		abortAll,
 		cleanup,

--- a/apps/cli/src/runtime/prompt.ts
+++ b/apps/cli/src/runtime/prompt.ts
@@ -28,6 +28,8 @@ export async function resolveSystemPrompt(input: {
 	providerId?: string;
 	rules?: string;
 	mode?: AgentMode;
+	/** Agent profile body that replaces the persona slot of the base prompt */
+	agentPersona?: string;
 }): Promise<string> {
 	const metadata = await buildWorkspaceMetadata(input.cwd);
 	let rules = mergeRulesForSystemPrompt(undefined, input.rules);
@@ -45,6 +47,7 @@ export async function resolveSystemPrompt(input: {
 		mode: input.mode,
 		providerId: input.providerId,
 		overridePrompt: input.explicitSystemPrompt,
+		personaPrompt: input.agentPersona,
 		platform:
 			(typeof process !== "undefined" && process?.platform) || "unknown",
 	});

--- a/apps/cli/src/runtime/run-interactive.ts
+++ b/apps/cli/src/runtime/run-interactive.ts
@@ -598,6 +598,10 @@ export async function runInteractive(
 			}
 			await applyModeChange(mode);
 		},
+		onAgentProfileChange: async (profile) => {
+			await sessionRuntime.ensureReady();
+			await sessionRuntime.applyAgentProfile(profile ?? undefined);
+		},
 		onNewSession: async () => {
 			await sessionRuntime.resetForNewSession();
 		},

--- a/apps/cli/src/tui/commands/slash-command-registry.test.ts
+++ b/apps/cli/src/tui/commands/slash-command-registry.test.ts
@@ -271,6 +271,35 @@ describe("slash command registry", () => {
 		).toContain("settings");
 	});
 
+	it("exposes agents as a local command with a hidden agent alias", () => {
+		const registry = buildSlashCommandRegistry({});
+		const commandNames = getVisibleSystemSlashCommands(registry).map(
+			(command) => command.name,
+		);
+
+		expect(resolveSlashCommand(registry, "agents")).toMatchObject({
+			source: "tui",
+			execution: "local",
+			description: "Switch agent profile",
+			visible: true,
+			selectable: true,
+		});
+		expect(resolveSlashCommand(registry, "agent")).toMatchObject({
+			source: "tui",
+			execution: "local",
+			visible: false,
+			selectable: false,
+		});
+		expect(commandNames).toContain("agents");
+		expect(commandNames).not.toContain("agent");
+		expect(commandNames.indexOf("agents")).toBeGreaterThan(
+			commandNames.indexOf("model"),
+		);
+		expect(commandNames.indexOf("agents")).toBeLessThan(
+			commandNames.indexOf("account"),
+		);
+	});
+
 	it("always exposes the account command", () => {
 		const registry = buildSlashCommandRegistry({});
 

--- a/apps/cli/src/tui/commands/slash-command-registry.ts
+++ b/apps/cli/src/tui/commands/slash-command-registry.ts
@@ -17,6 +17,8 @@ export type LocalSlashCommandName =
 	| "plugins"
 	| "account"
 	| "model"
+	| "agents"
+	| "agent"
 	| "compact"
 	| "skills"
 	| "fork"
@@ -61,6 +63,15 @@ const TUI_LOCAL_COMMANDS: Array<{
 	{
 		name: "model",
 		description: "Switch model or provider",
+	},
+	{
+		name: "agents",
+		description: "Switch agent profile",
+	},
+	{
+		name: "agent",
+		description: "Switch agent profile",
+		visible: false,
 	},
 	{
 		name: "account",
@@ -112,6 +123,7 @@ const TUI_LOCAL_COMMANDS: Array<{
 const SYSTEM_COMMAND_ORDER = [
 	"settings",
 	"model",
+	"agents",
 	"account",
 	"mcp",
 	"plugins",

--- a/apps/cli/src/tui/components/dialogs/agent-selector.tsx
+++ b/apps/cli/src/tui/components/dialogs/agent-selector.tsx
@@ -1,0 +1,110 @@
+import { basename } from "node:path";
+import type { ChoiceContext } from "@opentui-ui/dialog";
+import { useDialogKeyboard } from "@opentui-ui/dialog/react";
+import { useMemo } from "react";
+import {
+	type SearchableItem,
+	SearchableList,
+	useSearchableList,
+} from "../searchable-list";
+
+/** Sentinel resolved when the user picks the default Cline agent. */
+export const DEFAULT_AGENT_ACTION = "__default_agent__";
+
+export interface AgentProfileOption {
+	name: string;
+	description?: string;
+	/** Profile body used as the agent persona */
+	systemPrompt: string;
+	path?: string;
+	source: "workspace" | "global";
+}
+
+export interface AgentProfileLoadError {
+	path: string;
+	message: string;
+}
+
+export function AgentSelectorContent(
+	props: ChoiceContext<string> & {
+		currentAgentName: string | null;
+		agents: AgentProfileOption[];
+		loadErrors: AgentProfileLoadError[];
+	},
+) {
+	const { resolve, dismiss, dialogId, currentAgentName, agents, loadErrors } =
+		props;
+
+	const items: SearchableItem[] = useMemo(() => {
+		const normalizedCurrent = currentAgentName?.trim().toLowerCase() ?? null;
+		const defaultItem: SearchableItem = {
+			key: DEFAULT_AGENT_ACTION,
+			label: "Cline (default)",
+			detail: "Standard Cline agent",
+			section: "Agents",
+			rightLabel: normalizedCurrent === null ? "(current)" : undefined,
+		};
+		const profileItems = agents.map((agent) => ({
+			key: agent.name.toLowerCase(),
+			label: agent.name,
+			detail: agent.description,
+			section:
+				agent.source === "workspace" ? "Workspace agents" : "Global agents",
+			rightLabel:
+				normalizedCurrent === agent.name.trim().toLowerCase()
+					? "(current)"
+					: undefined,
+		}));
+		return [defaultItem, ...profileItems];
+	}, [agents, currentAgentName]);
+
+	const list = useSearchableList(items);
+
+	useDialogKeyboard((key) => {
+		if (key.name === "escape") {
+			dismiss();
+			return;
+		}
+		if (key.name === "return") {
+			const item = list.selectedItem;
+			if (item) resolve(item.key);
+			return;
+		}
+		if (key.name === "up") {
+			list.moveUp();
+			return;
+		}
+		if (key.name === "down") {
+			list.moveDown();
+		}
+	}, dialogId);
+
+	return (
+		<box flexDirection="column" gap={1}>
+			<text>Select Agent</text>
+
+			<SearchableList
+				items={list.filtered}
+				selected={list.safeSelected}
+				placeholder="Search agents..."
+				onSearchChange={list.setSearch}
+				onItemSelect={(item) => resolve(item.key)}
+				emptyText="No agents match"
+			/>
+
+			{loadErrors.length > 0 && (
+				<box flexDirection="column">
+					{loadErrors.map((error) => (
+						<text key={error.path} fg="red">
+							{basename(error.path)}: {error.message}
+						</text>
+					))}
+				</box>
+			)}
+
+			<text fg="gray">
+				Type to search, ↑/↓ navigate, Enter to select, Esc to go back
+			</text>
+		</box>
+	);
+}

--- a/apps/cli/src/tui/components/dialogs/agent-selector.tsx
+++ b/apps/cli/src/tui/components/dialogs/agent-selector.tsx
@@ -14,9 +14,7 @@ export const DEFAULT_AGENT_ACTION = "__default_agent__";
 export interface AgentProfileOption {
 	name: string;
 	description?: string;
-	/** Profile body used as the agent persona */
 	systemPrompt: string;
-	path?: string;
 	source: "workspace" | "global";
 }
 

--- a/apps/cli/src/tui/components/dialogs/command-palette-items.ts
+++ b/apps/cli/src/tui/components/dialogs/command-palette-items.ts
@@ -2,6 +2,7 @@ export type CommandPaletteAction =
 	| "settings"
 	| "change-model"
 	| "change-provider"
+	| "agents"
 	| "account"
 	| "mcp"
 	| "plugins"
@@ -56,6 +57,13 @@ const ACTION_ITEMS: Array<{
 		shortcut: "Opt+P",
 		description: "Switch provider and configure credentials",
 		keywords: ["provider", "api key", "account", "auth"],
+	},
+	{
+		action: "agents",
+		label: "Switch Agent",
+		shortcut: "Opt+T",
+		description: "Use an agent profile from .cline/agents",
+		keywords: ["agent", "agents", "profile", "persona", "subagent"],
 	},
 	{
 		action: "mcp",

--- a/apps/cli/src/tui/components/dialogs/help-dialog.tsx
+++ b/apps/cli/src/tui/components/dialogs/help-dialog.tsx
@@ -122,6 +122,12 @@ const HELP_ROWS: HelpRow[] = [
 	},
 	{
 		kind: "entry",
+		id: "c-agents",
+		key: "/agents",
+		desc: "Switch agent profile",
+	},
+	{
+		kind: "entry",
 		id: "c-settings",
 		key: "/settings",
 		desc: "Open interactive config browser",

--- a/apps/cli/src/tui/components/status-bar.test.ts
+++ b/apps/cli/src/tui/components/status-bar.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
 	createContextBar,
+	formatStatusBarAgentLabel,
 	formatStatusBarAgentName,
 	formatStatusBarUsageText,
 	resolveContextBarFilledForeground,
@@ -53,6 +54,7 @@ describe("createContextBar", () => {
 describe("formatStatusBarAgentName", () => {
 	it("keeps short names intact", () => {
 		expect(formatStatusBarAgentName("reviewer")).toBe("reviewer");
+		expect(formatStatusBarAgentName("  reviewer  ")).toBe("reviewer");
 	});
 
 	it("truncates long names with an ellipsis", () => {
@@ -62,6 +64,31 @@ describe("formatStatusBarAgentName", () => {
 		expect(formatStatusBarAgentName("documentation-specialist").length).toBe(
 			16,
 		);
+	});
+
+	it("handles very narrow limits without negative slicing", () => {
+		expect(formatStatusBarAgentName("reviewer", 3)).toBe("...");
+		expect(formatStatusBarAgentName("reviewer", 0)).toBe("");
+	});
+});
+
+describe("formatStatusBarAgentLabel", () => {
+	it("wraps the active agent name in brackets", () => {
+		expect(formatStatusBarAgentLabel("reviewer")).toBe("[reviewer]");
+	});
+
+	it("truncates inside the brackets to fit the label width", () => {
+		expect(formatStatusBarAgentLabel("documentation-specialist", 18)).toBe(
+			"[documentation...]",
+		);
+		expect(
+			formatStatusBarAgentLabel("documentation-specialist", 18)?.length,
+		).toBe(18);
+	});
+
+	it("hides blank or too-narrow labels", () => {
+		expect(formatStatusBarAgentLabel("   ")).toBeUndefined();
+		expect(formatStatusBarAgentLabel("reviewer", 4)).toBeUndefined();
 	});
 });
 

--- a/apps/cli/src/tui/components/status-bar.test.ts
+++ b/apps/cli/src/tui/components/status-bar.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
 	createContextBar,
+	formatStatusBarAgentName,
 	formatStatusBarUsageText,
 	resolveContextBarFilledForeground,
 } from "./status-bar";
@@ -46,6 +47,21 @@ describe("createContextBar", () => {
 	it("uses explicit white when terminal foreground would inherit gray", () => {
 		expect(resolveContextBarFilledForeground(undefined)).toBe("#ffffff");
 		expect(resolveContextBarFilledForeground("#1a1a1a")).toBe("#1a1a1a");
+	});
+});
+
+describe("formatStatusBarAgentName", () => {
+	it("keeps short names intact", () => {
+		expect(formatStatusBarAgentName("reviewer")).toBe("reviewer");
+	});
+
+	it("truncates long names with an ellipsis", () => {
+		expect(formatStatusBarAgentName("documentation-specialist")).toBe(
+			"documentation...",
+		);
+		expect(formatStatusBarAgentName("documentation-specialist").length).toBe(
+			16,
+		);
 	});
 });
 

--- a/apps/cli/src/tui/components/status-bar.test.ts
+++ b/apps/cli/src/tui/components/status-bar.test.ts
@@ -73,13 +73,14 @@ describe("formatStatusBarAgentName", () => {
 });
 
 describe("formatStatusBarAgentLabel", () => {
-	it("wraps the active agent name in brackets", () => {
-		expect(formatStatusBarAgentLabel("reviewer")).toBe("[reviewer]");
+	it("returns the trimmed active agent name", () => {
+		expect(formatStatusBarAgentLabel("reviewer")).toBe("reviewer");
+		expect(formatStatusBarAgentLabel("  reviewer  ")).toBe("reviewer");
 	});
 
-	it("truncates inside the brackets to fit the label width", () => {
+	it("truncates to fit the label width", () => {
 		expect(formatStatusBarAgentLabel("documentation-specialist", 18)).toBe(
-			"[documentation...]",
+			"documentation-s...",
 		);
 		expect(
 			formatStatusBarAgentLabel("documentation-specialist", 18)?.length,
@@ -88,7 +89,7 @@ describe("formatStatusBarAgentLabel", () => {
 
 	it("hides blank or too-narrow labels", () => {
 		expect(formatStatusBarAgentLabel("   ")).toBeUndefined();
-		expect(formatStatusBarAgentLabel("reviewer", 4)).toBeUndefined();
+		expect(formatStatusBarAgentLabel("reviewer", 0)).toBeUndefined();
 	});
 });
 

--- a/apps/cli/src/tui/components/status-bar.tsx
+++ b/apps/cli/src/tui/components/status-bar.tsx
@@ -117,8 +117,8 @@ export function formatStatusBarAgentLabel(
 	maxLen = 18,
 ): string | undefined {
 	const normalized = name.trim();
-	if (!normalized || maxLen < 5) return undefined;
-	return `[${formatStatusBarAgentName(normalized, maxLen - 2)}]`;
+	if (!normalized || maxLen <= 0) return undefined;
+	return formatStatusBarAgentName(normalized, maxLen);
 }
 
 export interface StatusBarProps {
@@ -191,7 +191,7 @@ export function StatusBar(props: StatusBarProps) {
 	const fullAgentLabel = agentName
 		? formatStatusBarAgentLabel(agentName)
 		: undefined;
-	const agentLabelWidth = fullAgentLabel ? fullAgentLabel.length + 1 : 0;
+	const agentLabelWidth = fullAgentLabel ? fullAgentLabel.length + 3 : 0;
 	const usageText = formatStatusBarUsageText({
 		totalTokens,
 		totalCost,
@@ -244,7 +244,7 @@ export function StatusBar(props: StatusBarProps) {
 			: pathPart;
 	const firstRowAgentMaxLen = Math.min(
 		18,
-		Math.max(0, avail - toggleWidth - 1),
+		Math.max(0, avail - toggleWidth - 3),
 	);
 	const agentLabel = agentName
 		? formatStatusBarAgentLabel(agentName, firstRowAgentMaxLen)
@@ -264,9 +264,12 @@ export function StatusBar(props: StatusBarProps) {
 					onMouseDown={onToggleMode}
 				>
 					{agentLabel && (
-						<box flexShrink={0} onMouseDown={onOpenAgent}>
-							<text fg={defaultFg}>{agentLabel}</text>
-						</box>
+						<>
+							<box flexShrink={0} onMouseDown={onOpenAgent}>
+								<text fg={defaultFg}>{agentLabel}</text>
+							</box>
+							<text fg="gray">|</text>
+						</>
 					)}
 					<text fg={uiMode === "plan" ? planAccent : "gray"}>
 						{uiMode === "plan" ? "●" : "○"} Plan

--- a/apps/cli/src/tui/components/status-bar.tsx
+++ b/apps/cli/src/tui/components/status-bar.tsx
@@ -104,6 +104,10 @@ export function resolveModelMaxInputTokens(config: {
 	return undefined;
 }
 
+export function formatStatusBarAgentName(name: string, maxLen = 16): string {
+	return name.length > maxLen ? `${name.slice(0, maxLen - 3)}...` : name;
+}
+
 export interface StatusBarProps {
 	providerId: string;
 	modelId: string;
@@ -120,6 +124,9 @@ export interface StatusBarProps {
 		deletions: number;
 	} | null;
 	onToggleMode?: () => void;
+	/** Name of the active agent profile; hidden when the default agent is active */
+	agentName?: string | null;
+	onOpenAgent?: () => void;
 	variant?: "home" | "chat";
 }
 
@@ -135,6 +142,8 @@ export function StatusBar(props: StatusBarProps) {
 		gitBranch,
 		gitDiffStats,
 		onToggleMode,
+		agentName,
+		onOpenAgent,
 	} = props;
 
 	const { width } = useTerminalDimensions();
@@ -162,10 +171,17 @@ export function StatusBar(props: StatusBarProps) {
 			? Math.min(width, HOME_VIEW_MAX_WIDTH) - 2
 			: width - 2;
 
-	// Row 1 layout: [model + context info] .... [Plan/Act toggle]
+	// Row 1 layout: [model + context info] .... [agent indicator] [Plan/Act toggle]
 	// When the full row doesn't fit, context info drops to its own row 2.
 	// Model ID truncates with "..." before wrapping; toggle stays right-aligned.
 	const toggleWidth = 20;
+	const truncatedAgentName = agentName
+		? formatStatusBarAgentName(agentName)
+		: undefined;
+	// "◆ name" plus the gap separating it from the Plan/Act toggle.
+	const agentLabelWidth = truncatedAgentName
+		? truncatedAgentName.length + 3
+		: 0;
 	const usageText = formatStatusBarUsageText({
 		totalTokens,
 		totalCost,
@@ -175,7 +191,8 @@ export function StatusBar(props: StatusBarProps) {
 		? ` ${bar.filled}${bar.empty} ${usageText}`
 		: ` ${usageText}`;
 	const firstRowFits =
-		modelId.length + contextText.length + toggleWidth + 1 <= avail;
+		modelId.length + contextText.length + toggleWidth + agentLabelWidth + 1 <=
+		avail;
 	const renderContextText = (withLeadingSpace: boolean) => (
 		<>
 			{withLeadingSpace && " "}
@@ -191,7 +208,11 @@ export function StatusBar(props: StatusBarProps) {
 
 	const modelMaxLen = Math.max(
 		10,
-		avail - toggleWidth - (firstRowFits ? contextText.length : 0) - 1,
+		avail -
+			toggleWidth -
+			agentLabelWidth -
+			(firstRowFits ? contextText.length : 0) -
+			1,
 	);
 	const truncatedModel =
 		modelId.length > modelMaxLen
@@ -217,19 +238,28 @@ export function StatusBar(props: StatusBarProps) {
 					{truncatedModel}
 					{firstRowFits && renderContextText(true)}
 				</text>
-				<box
-					flexDirection="row"
-					gap={1}
-					flexShrink={0}
-					onMouseDown={onToggleMode}
-				>
-					<text fg={uiMode === "plan" ? planAccent : "gray"}>
-						{uiMode === "plan" ? "●" : "○"} Plan
-					</text>
-					<text fg={uiMode === "act" ? actAccent : "gray"}>
-						{uiMode === "act" ? "●" : "○"} Act
-					</text>
-					<text fg="gray">(Tab)</text>
+				<box flexDirection="row" gap={1} flexShrink={0}>
+					{truncatedAgentName && (
+						<box flexShrink={0} onMouseDown={onOpenAgent}>
+							<text fg="cyan">
+								{"◆"} {truncatedAgentName}
+							</text>
+						</box>
+					)}
+					<box
+						flexDirection="row"
+						gap={1}
+						flexShrink={0}
+						onMouseDown={onToggleMode}
+					>
+						<text fg={uiMode === "plan" ? planAccent : "gray"}>
+							{uiMode === "plan" ? "●" : "○"} Plan
+						</text>
+						<text fg={uiMode === "act" ? actAccent : "gray"}>
+							{uiMode === "act" ? "●" : "○"} Act
+						</text>
+						<text fg="gray">(Tab)</text>
+					</box>
 				</box>
 			</box>
 

--- a/apps/cli/src/tui/components/status-bar.tsx
+++ b/apps/cli/src/tui/components/status-bar.tsx
@@ -124,7 +124,7 @@ export interface StatusBarProps {
 		deletions: number;
 	} | null;
 	onToggleMode?: () => void;
-	/** Name of the active agent profile; hidden when the default agent is active */
+	/** Active agent profile name; the indicator is hidden when unset */
 	agentName?: string | null;
 	onOpenAgent?: () => void;
 	variant?: "home" | "chat";

--- a/apps/cli/src/tui/components/status-bar.tsx
+++ b/apps/cli/src/tui/components/status-bar.tsx
@@ -105,7 +105,20 @@ export function resolveModelMaxInputTokens(config: {
 }
 
 export function formatStatusBarAgentName(name: string, maxLen = 16): string {
-	return name.length > maxLen ? `${name.slice(0, maxLen - 3)}...` : name;
+	const normalized = name.trim();
+	if (maxLen <= 0) return "";
+	if (normalized.length <= maxLen) return normalized;
+	if (maxLen <= 3) return ".".repeat(maxLen);
+	return `${normalized.slice(0, maxLen - 3)}...`;
+}
+
+export function formatStatusBarAgentLabel(
+	name: string,
+	maxLen = 18,
+): string | undefined {
+	const normalized = name.trim();
+	if (!normalized || maxLen < 5) return undefined;
+	return `[${formatStatusBarAgentName(normalized, maxLen - 2)}]`;
 }
 
 export interface StatusBarProps {
@@ -171,25 +184,23 @@ export function StatusBar(props: StatusBarProps) {
 			? Math.min(width, HOME_VIEW_MAX_WIDTH) - 2
 			: width - 2;
 
-	// Row 1 layout: [model + context info] .... [agent indicator] [Plan/Act toggle]
+	// Row 1 layout: [model + context info] .... [agent label] [Plan/Act toggle]
 	// When the full row doesn't fit, context info drops to its own row 2.
 	// Model ID truncates with "..." before wrapping; toggle stays right-aligned.
 	const toggleWidth = 20;
-	const truncatedAgentName = agentName
-		? formatStatusBarAgentName(agentName)
+	const fullAgentLabel = agentName
+		? formatStatusBarAgentLabel(agentName)
 		: undefined;
-	// "◆ name" plus the gap separating it from the Plan/Act toggle.
-	const agentLabelWidth = truncatedAgentName
-		? truncatedAgentName.length + 3
-		: 0;
+	const agentLabelWidth = fullAgentLabel ? fullAgentLabel.length + 1 : 0;
 	const usageText = formatStatusBarUsageText({
 		totalTokens,
 		totalCost,
 		showCost: showUsageCost,
 	});
-	const contextText = bar
-		? ` ${bar.filled}${bar.empty} ${usageText}`
-		: ` ${usageText}`;
+	const contextInlineText = bar
+		? `${bar.filled}${bar.empty} ${usageText}`
+		: usageText;
+	const contextText = ` ${contextInlineText}`;
 	const firstRowFits =
 		modelId.length + contextText.length + toggleWidth + agentLabelWidth + 1 <=
 		avail;
@@ -231,6 +242,14 @@ export function StatusBar(props: StatusBarProps) {
 		pathPart.length > pathMax
 			? `${pathPart.slice(0, pathMax - 3)}...`
 			: pathPart;
+	const firstRowAgentMaxLen = Math.min(
+		18,
+		Math.max(0, avail - toggleWidth - 1),
+	);
+	const agentLabel = agentName
+		? formatStatusBarAgentLabel(agentName, firstRowAgentMaxLen)
+		: undefined;
+
 	return (
 		<box flexDirection="column" paddingX={1}>
 			<box flexDirection="row" justifyContent="space-between">
@@ -238,28 +257,24 @@ export function StatusBar(props: StatusBarProps) {
 					{truncatedModel}
 					{firstRowFits && renderContextText(true)}
 				</text>
-				<box flexDirection="row" gap={1} flexShrink={0}>
-					{truncatedAgentName && (
+				<box
+					flexDirection="row"
+					gap={1}
+					flexShrink={0}
+					onMouseDown={onToggleMode}
+				>
+					{agentLabel && (
 						<box flexShrink={0} onMouseDown={onOpenAgent}>
-							<text fg="cyan">
-								{"◆"} {truncatedAgentName}
-							</text>
+							<text fg={defaultFg}>{agentLabel}</text>
 						</box>
 					)}
-					<box
-						flexDirection="row"
-						gap={1}
-						flexShrink={0}
-						onMouseDown={onToggleMode}
-					>
-						<text fg={uiMode === "plan" ? planAccent : "gray"}>
-							{uiMode === "plan" ? "●" : "○"} Plan
-						</text>
-						<text fg={uiMode === "act" ? actAccent : "gray"}>
-							{uiMode === "act" ? "●" : "○"} Act
-						</text>
-						<text fg="gray">(Tab)</text>
-					</box>
+					<text fg={uiMode === "plan" ? planAccent : "gray"}>
+						{uiMode === "plan" ? "●" : "○"} Plan
+					</text>
+					<text fg={uiMode === "act" ? actAccent : "gray"}>
+						{uiMode === "act" ? "●" : "○"} Act
+					</text>
+					<text fg="gray">(Tab)</text>
 				</box>
 			</box>
 

--- a/apps/cli/src/tui/contexts/session-context.tsx
+++ b/apps/cli/src/tui/contexts/session-context.tsx
@@ -21,6 +21,8 @@ interface SessionContextValue {
 	uiMode: AgentMode;
 	autoApproveAll: boolean;
 	compactionMode: CliCompactionMode;
+	/** Name of the active agent profile, or null for the default Cline agent */
+	activeAgentName: string | null;
 	lastTotalTokens: number;
 	lastTotalCost: number;
 	isExitRequested: boolean;
@@ -41,6 +43,7 @@ interface SessionContextValue {
 	setUiMode: (mode: AgentMode) => void;
 	toggleMode: () => void;
 	toggleAutoApprove: () => void;
+	setActiveAgentName: (name: string | null) => void;
 	setCompactionMode: (mode: CliCompactionMode) => void;
 	requestExit: () => void;
 	clearEntries: () => void;
@@ -111,6 +114,9 @@ export function SessionProvider(props: {
 	);
 	const [compactionMode, _setCompactionMode] = useState<CliCompactionMode>(() =>
 		getCliCompactionMode(config),
+	);
+	const [activeAgentName, setActiveAgentName] = useState<string | null>(
+		config.agentProfile?.name ?? null,
 	);
 	const [lastTotalTokens, setLastTotalTokens] = useState(
 		() => initialUsage?.totalTokens ?? 0,
@@ -250,6 +256,7 @@ export function SessionProvider(props: {
 		uiMode,
 		autoApproveAll,
 		compactionMode,
+		activeAgentName,
 		lastTotalTokens,
 		lastTotalCost,
 		isExitRequested,
@@ -268,6 +275,7 @@ export function SessionProvider(props: {
 		setUiMode,
 		toggleMode,
 		toggleAutoApprove,
+		setActiveAgentName,
 		setCompactionMode,
 		requestExit,
 		clearEntries,

--- a/apps/cli/src/tui/contexts/session-context.tsx
+++ b/apps/cli/src/tui/contexts/session-context.tsx
@@ -21,7 +21,6 @@ interface SessionContextValue {
 	uiMode: AgentMode;
 	autoApproveAll: boolean;
 	compactionMode: CliCompactionMode;
-	/** Name of the active agent profile, or null for the default Cline agent */
 	activeAgentName: string | null;
 	lastTotalTokens: number;
 	lastTotalCost: number;

--- a/apps/cli/src/tui/hooks/local-command-actions.ts
+++ b/apps/cli/src/tui/hooks/local-command-actions.ts
@@ -7,6 +7,7 @@ export interface LocalSlashCommandActionInput {
 	openConfig: (options?: OpenConfigOptions) => void;
 	openMcpManager: () => Promise<boolean>;
 	openModelSelector: () => void;
+	openAgentSelector: () => void;
 	openSkills: (invocation?: LocalSlashCommandInvocation) => void;
 	invocation?: LocalSlashCommandInvocation;
 	runCompact: () => void;
@@ -43,6 +44,10 @@ export function runLocalSlashCommandAction(
 	}
 	if (normalized === "model") {
 		input.openModelSelector();
+		return true;
+	}
+	if (normalized === "agents" || normalized === "agent") {
+		input.openAgentSelector();
 		return true;
 	}
 	if (normalized === "compact") {

--- a/apps/cli/src/tui/hooks/use-agent-selector.tsx
+++ b/apps/cli/src/tui/hooks/use-agent-selector.tsx
@@ -1,0 +1,111 @@
+import { loadConfiguredAgentConfigs } from "@cline/core";
+import type { ChoiceContext } from "@opentui-ui/dialog";
+import type { DialogActions } from "@opentui-ui/dialog/react";
+import { useCallback } from "react";
+import type { Config } from "../../utils/types";
+import {
+	type AgentProfileLoadError,
+	type AgentProfileOption,
+	AgentSelectorContent,
+	DEFAULT_AGENT_ACTION,
+} from "../components/dialogs/agent-selector";
+import { withLoadingDialog } from "../components/dialogs/loading-dialog";
+import { useSession } from "../contexts/session-context";
+import type { TuiProps } from "../types";
+
+function loadAgentProfileEntries(config: Config): {
+	agents: AgentProfileOption[];
+	loadErrors: AgentProfileLoadError[];
+} {
+	const workspaceRoot = config.workspaceRoot?.trim() || config.cwd;
+	const { configs, errors } = loadConfiguredAgentConfigs({ workspaceRoot });
+	return {
+		agents: configs.map((profile) => ({
+			name: profile.name,
+			description: profile.description,
+			systemPrompt: profile.systemPrompt,
+			path: profile.path,
+			source:
+				workspaceRoot && profile.path?.startsWith(workspaceRoot)
+					? ("workspace" as const)
+					: ("global" as const),
+		})),
+		loadErrors: errors.map((error) => ({
+			path: error.path,
+			message: error.error.message,
+		})),
+	};
+}
+
+export function useAgentSelector(opts: {
+	dialog: DialogActions;
+	config: Config;
+	termHeight: number;
+	onAgentProfileChange: TuiProps["onAgentProfileChange"];
+	refocusTextarea: () => void;
+}): () => Promise<void> {
+	const { dialog, config, termHeight, onAgentProfileChange, refocusTextarea } =
+		opts;
+	const session = useSession();
+
+	const openAgentSelector = useCallback(async () => {
+		const { agents, loadErrors } = loadAgentProfileEntries(config);
+		const currentAgentName = config.agentProfile?.name ?? null;
+
+		const selectedKey = await dialog.choice<string>({
+			style: { maxHeight: termHeight - 2 },
+			content: (ctx: ChoiceContext<string>) => (
+				<AgentSelectorContent
+					{...ctx}
+					currentAgentName={currentAgentName}
+					agents={agents}
+					loadErrors={loadErrors}
+				/>
+			),
+		});
+		if (!selectedKey) {
+			refocusTextarea();
+			return;
+		}
+
+		if (selectedKey === DEFAULT_AGENT_ACTION) {
+			if (config.agentProfile) {
+				await withLoadingDialog(dialog, "Applying agent...", async () => {
+					await onAgentProfileChange(null);
+				});
+				session.setActiveAgentName(null);
+			}
+			refocusTextarea();
+			return;
+		}
+
+		const profile = agents.find(
+			(agent) => agent.name.toLowerCase() === selectedKey,
+		);
+		if (!profile) {
+			refocusTextarea();
+			return;
+		}
+		if (profile.name !== currentAgentName) {
+			await withLoadingDialog(dialog, "Applying agent...", async () => {
+				await onAgentProfileChange({
+					name: profile.name,
+					description: profile.description,
+					systemPrompt: profile.systemPrompt,
+					path: profile.path,
+				});
+			});
+			session.setActiveAgentName(profile.name);
+		}
+		refocusTextarea();
+	}, [
+		dialog,
+		config,
+		termHeight,
+		onAgentProfileChange,
+		refocusTextarea,
+		session,
+	]);
+
+	return openAgentSelector;
+}

--- a/apps/cli/src/tui/hooks/use-agent-selector.tsx
+++ b/apps/cli/src/tui/hooks/use-agent-selector.tsx
@@ -1,3 +1,4 @@
+import { sep } from "node:path";
 import { loadConfiguredAgentConfigs } from "@cline/core";
 import type { ChoiceContext } from "@opentui-ui/dialog";
 import type { DialogActions } from "@opentui-ui/dialog/react";
@@ -25,7 +26,7 @@ function loadAgentProfileEntries(config: Config): {
 			description: profile.description,
 			systemPrompt: profile.systemPrompt,
 			source:
-				workspaceRoot && profile.path?.startsWith(workspaceRoot)
+				workspaceRoot && profile.path?.startsWith(`${workspaceRoot}${sep}`)
 					? ("workspace" as const)
 					: ("global" as const),
 		})),

--- a/apps/cli/src/tui/hooks/use-agent-selector.tsx
+++ b/apps/cli/src/tui/hooks/use-agent-selector.tsx
@@ -49,6 +49,16 @@ export function useAgentSelector(opts: {
 	const session = useSession();
 
 	const openAgentSelector = useCallback(async () => {
+		// Applying a profile restarts the session in place, so refuse while a
+		// turn is running instead of yanking the live stream out from under it.
+		if (session.isRunning) {
+			session.appendEntry({
+				kind: "status",
+				text: "Finish or abort the current task before switching agents.",
+			});
+			refocusTextarea();
+			return;
+		}
 		const { agents, loadErrors } = loadAgentProfileEntries(config);
 		const currentAgentName = config.agentProfile?.name ?? null;
 

--- a/apps/cli/src/tui/hooks/use-agent-selector.tsx
+++ b/apps/cli/src/tui/hooks/use-agent-selector.tsx
@@ -24,7 +24,6 @@ function loadAgentProfileEntries(config: Config): {
 			name: profile.name,
 			description: profile.description,
 			systemPrompt: profile.systemPrompt,
-			path: profile.path,
 			source:
 				workspaceRoot && profile.path?.startsWith(workspaceRoot)
 					? ("workspace" as const)
@@ -100,9 +99,7 @@ export function useAgentSelector(opts: {
 			await withLoadingDialog(dialog, "Applying agent...", async () => {
 				await onAgentProfileChange({
 					name: profile.name,
-					description: profile.description,
 					systemPrompt: profile.systemPrompt,
-					path: profile.path,
 				});
 			});
 			session.setActiveAgentName(profile.name);

--- a/apps/cli/src/tui/hooks/use-local-command-actions.test.ts
+++ b/apps/cli/src/tui/hooks/use-local-command-actions.test.ts
@@ -13,6 +13,7 @@ function makeActions(
 		openConfig: vi.fn(),
 		openMcpManager: vi.fn(async () => false),
 		openModelSelector: vi.fn(),
+		openAgentSelector: vi.fn(),
 		openSkills: vi.fn(),
 		runCompact: vi.fn(),
 		runFork: vi.fn(),
@@ -43,6 +44,21 @@ describe("runLocalSlashCommandAction", () => {
 
 		expect(handled).toBe(true);
 		expect(openSkills).toHaveBeenCalledWith(invocation);
+	});
+
+	it("opens the agent selector with agents and the agent alias", () => {
+		for (const name of ["agents", "agent"]) {
+			const openAgentSelector = vi.fn();
+			const actions = makeActions({ openAgentSelector });
+
+			const handled = runLocalSlashCommandAction({
+				name,
+				...actions,
+			});
+
+			expect(handled).toBe(true);
+			expect(openAgentSelector).toHaveBeenCalledOnce();
+		}
 	});
 
 	it("opens settings to the plugins tab with plugins", () => {

--- a/apps/cli/src/tui/hooks/use-local-command-actions.tsx
+++ b/apps/cli/src/tui/hooks/use-local-command-actions.tsx
@@ -23,6 +23,7 @@ export function useLocalCommandActions(input: {
 	openConfig: (options?: OpenConfigOptions) => void;
 	openMcpManager: () => Promise<boolean>;
 	openModelSelector: () => void;
+	openAgentSelector: () => void;
 	openSkills: (invocation?: LocalSlashCommandInvocation) => void;
 	refocusTextarea: () => void;
 	setAppView: (view: AppView) => void;
@@ -43,6 +44,7 @@ export function useLocalCommandActions(input: {
 		openConfig,
 		openMcpManager,
 		openModelSelector,
+		openAgentSelector,
 		openSkills,
 		refocusTextarea,
 		setAppView,
@@ -185,6 +187,7 @@ export function useLocalCommandActions(input: {
 				openConfig,
 				openMcpManager,
 				openModelSelector,
+				openAgentSelector,
 				openSkills,
 				runCompact,
 				runFork,
@@ -205,6 +208,7 @@ export function useLocalCommandActions(input: {
 			openHelp,
 			openHistory,
 			openModelSelector,
+			openAgentSelector,
 			openSkills,
 			runCompact,
 			runFork,

--- a/apps/cli/src/tui/interactive-config.ts
+++ b/apps/cli/src/tui/interactive-config.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import {
 	basename,
 	dirname,
@@ -14,11 +14,11 @@ import {
 	hasMcpSettingsFile,
 	listHookConfigFiles,
 	listPluginToolsWithDiagnostics,
+	loadConfiguredAgentConfigs,
 	type McpServerRegistration,
 	type PluginInitializationFailure,
 	type RuleConfig,
 	readGlobalSettings,
-	resolveAgentConfigSearchPaths,
 	resolveDefaultMcpSettingsPath,
 	resolveMcpServerRegistrations,
 	resolvePluginConfigSearchPaths,
@@ -175,58 +175,30 @@ function getMcpDescription(registration: McpServerRegistration): string {
 }
 
 function loadAgentConfigItems(workspaceRoot: string): InteractiveConfigItem[] {
-	const agentsById = new Map<string, InteractiveConfigItem>();
-	const directories = resolveAgentConfigSearchPaths(workspaceRoot).filter(
-		(directory) => existsSync(directory),
-	);
-
-	for (const directory of directories) {
-		try {
-			const entries = readdirSync(directory, { withFileTypes: true });
-			for (const entry of entries) {
-				if (!entry.isFile()) {
-					continue;
-				}
-				const extension = extname(entry.name).toLowerCase();
-				if (extension !== ".yml" && extension !== ".yaml") {
-					continue;
-				}
-				const filePath = join(directory, entry.name);
-				const raw = readFileSync(filePath, "utf8");
-				const frontmatterMatch = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-				const frontmatter = frontmatterMatch?.[1] ?? "";
-				const nameMatch = frontmatter.match(/^\s*name:\s*(.+?)\s*$/m);
-				const descriptionMatch = frontmatter.match(
-					/^\s*description:\s*(.+?)\s*$/m,
-				);
-				const parsedName = nameMatch?.[1]?.replace(/^["']|["']$/g, "").trim();
-				const parsedDescription = descriptionMatch?.[1]
-					?.replace(/^["']|["']$/g, "")
-					.trim();
-				const name =
-					parsedName && parsedName.length > 0
-						? parsedName
-						: basename(entry.name, extension);
-				const id = name.toLowerCase();
-				if (agentsById.has(id)) {
-					continue;
-				}
-				agentsById.set(id, {
-					id,
-					name,
-					path: filePath,
-					enabled: true,
-					kind: "agent",
-					source: detectSource(filePath, workspaceRoot),
-					description: parsedDescription,
-				});
-			}
-		} catch {
-			// Best effort: keep listing other agent config roots.
-		}
+	const { configs, errors } = loadConfiguredAgentConfigs({ workspaceRoot });
+	const items: InteractiveConfigItem[] = configs.map((config) => ({
+		id: config.name.toLowerCase(),
+		name: config.name,
+		path: config.path ?? "",
+		enabled: true,
+		kind: "agent" as const,
+		source: detectSource(config.path ?? "", workspaceRoot),
+		description: config.description,
+	}));
+	// Keep broken profile files visible so users can spot and fix them.
+	for (const error of errors) {
+		items.push({
+			id: error.path,
+			name: basename(error.path, extname(error.path)),
+			path: error.path,
+			enabled: false,
+			kind: "agent" as const,
+			source: detectSource(error.path, workspaceRoot),
+			description: error.error.message,
+			loadError: error.error.message,
+		});
 	}
-
-	return [...agentsById.values()];
+	return items;
 }
 
 function readPackageName(packageJsonPath: string): string | undefined {

--- a/apps/cli/src/tui/root.tsx
+++ b/apps/cli/src/tui/root.tsx
@@ -41,6 +41,7 @@ import { EventBridgeProvider } from "./contexts/event-bridge-context";
 import { SessionProvider, useSession } from "./contexts/session-context";
 import { useAccountDialog } from "./hooks/use-account-dialog";
 import { useAgentEventHandlers } from "./hooks/use-agent-events";
+import { useAgentSelector } from "./hooks/use-agent-selector";
 import { useAutocomplete } from "./hooks/use-autocomplete";
 import { useConfigPanel } from "./hooks/use-config-panel";
 import { useLocalCommandActions } from "./hooks/use-local-command-actions";
@@ -184,6 +185,14 @@ function App(props: TuiProps) {
 		config: props.config,
 		termHeight,
 		onModelChange: handleModelChange,
+		refocusTextarea: () => refocusTextareaRef.current(),
+	});
+
+	const openAgentSelector = useAgentSelector({
+		dialog,
+		config: props.config,
+		termHeight,
+		onAgentProfileChange: props.onAgentProfileChange,
 		refocusTextarea: () => refocusTextareaRef.current(),
 	});
 
@@ -639,6 +648,7 @@ function App(props: TuiProps) {
 		openConfig,
 		openMcpManager,
 		openModelSelector,
+		openAgentSelector,
 		openSkills,
 		refocusTextarea: () => refocusTextareaRef.current(),
 		setAppView,
@@ -886,6 +896,9 @@ function App(props: TuiProps) {
 			void saveQueuedPromptEdit(id, prompt);
 		},
 		onToggleMode: toggleMode,
+		onOpenAgentSelector: () => {
+			void openAgentSelector();
+		},
 		runtimeInteraction,
 		onResolveToolApproval: runtimeBridge.resolveToolApproval,
 		onResolveAskQuestion: runtimeBridge.resolveAskQuestion,

--- a/apps/cli/src/tui/types.ts
+++ b/apps/cli/src/tui/types.ts
@@ -15,7 +15,11 @@ import type {
 	PendingPromptSubmittedEvent,
 } from "../runtime/session-events";
 import type { RepoStatus } from "../utils/repo-status";
-import type { CliCompactionMode, Config } from "../utils/types";
+import type {
+	ActiveAgentProfile,
+	CliCompactionMode,
+	Config,
+} from "../utils/types";
 import type { ClineAccountSnapshot } from "./cline-account";
 import type {
 	InteractiveConfigData,
@@ -166,6 +170,7 @@ export interface TuiProps {
 	onCompactionModeChange: (mode: CliCompactionMode) => Promise<void>;
 	onModelChange: () => Promise<void>;
 	onModeChange: (mode: AgentMode) => Promise<void>;
+	onAgentProfileChange: (profile: ActiveAgentProfile | null) => Promise<void>;
 	onNewSession: () => Promise<void>;
 	onSessionRestart: () => Promise<void>;
 	onAccountChange: () => Promise<void>;

--- a/apps/cli/src/tui/views/chat-view.tsx
+++ b/apps/cli/src/tui/views/chat-view.tsx
@@ -56,6 +56,7 @@ export function ChatView(props: {
 	editingQueuedPrompt?: QueuedPromptItem;
 	onQueuedPromptEditConfirm: (id: string, prompt: string) => void;
 	onToggleMode: () => void;
+	onOpenAgentSelector: () => void;
 	runtimeInteraction?: RuntimeToolInteraction | null;
 	onResolveToolApproval: (id: number, approved: boolean) => void;
 	onResolveAskQuestion: (id: number, answer: string | null) => void;
@@ -157,6 +158,8 @@ export function ChatView(props: {
 					gitBranch={repoStatus.branch}
 					gitDiffStats={repoStatus.diffStats}
 					onToggleMode={props.onToggleMode}
+					agentName={session.activeAgentName}
+					onOpenAgent={props.onOpenAgentSelector}
 					variant="chat"
 				/>
 			</box>

--- a/apps/cli/src/tui/views/home-view.tsx
+++ b/apps/cli/src/tui/views/home-view.tsx
@@ -46,6 +46,7 @@ export function HomeView(props: {
 	textareaRef?: React.MutableRefObject<TextareaHandle | null>;
 	autocomplete?: AutocompleteDropdownProps;
 	onToggleMode: () => void;
+	onOpenAgentSelector: () => void;
 }) {
 	const {
 		config,
@@ -156,6 +157,8 @@ export function HomeView(props: {
 								gitBranch={repoStatus.branch}
 								gitDiffStats={repoStatus.diffStats}
 								onToggleMode={props.onToggleMode}
+								agentName={session.activeAgentName}
+								onOpenAgent={props.onOpenAgentSelector}
 								variant="home"
 							/>
 						</box>

--- a/apps/cli/src/utils/types.ts
+++ b/apps/cli/src/utils/types.ts
@@ -19,16 +19,12 @@ export type CliCompactionMode = "agentic" | "basic" | "off";
 
 /**
  * An agent profile from .cline/agents applied to the main Cline agent for
- * the current session. Session-only: never persisted to settings. Only the
- * name/description/body of a profile apply here; providerId/modelId/tools
- * remain subagent-spawn concerns.
+ * the current session. Session-only: never persisted to settings.
  */
 export interface ActiveAgentProfile {
 	name: string;
-	description?: string;
 	/** Profile body, captured at selection time (survives file deletion mid-session) */
 	systemPrompt: string;
-	path?: string;
 }
 
 export interface Config extends Omit<CoreSessionConfig, "apiKey" | "mode"> {

--- a/apps/cli/src/utils/types.ts
+++ b/apps/cli/src/utils/types.ts
@@ -17,6 +17,20 @@ export type CliReasoningEffort = NonNullable<
 >;
 export type CliCompactionMode = "agentic" | "basic" | "off";
 
+/**
+ * An agent profile from .cline/agents applied to the main Cline agent for
+ * the current session. Session-only: never persisted to settings. Only the
+ * name/description/body of a profile apply here; providerId/modelId/tools
+ * remain subagent-spawn concerns.
+ */
+export interface ActiveAgentProfile {
+	name: string;
+	description?: string;
+	/** Profile body, captured at selection time (survives file deletion mid-session) */
+	systemPrompt: string;
+	path?: string;
+}
+
 export interface Config extends Omit<CoreSessionConfig, "apiKey" | "mode"> {
 	apiKey: string;
 	knownModels?: Record<string, Llms.ModelInfo>;
@@ -30,6 +44,7 @@ export interface Config extends Omit<CoreSessionConfig, "apiKey" | "mode"> {
 	mode: CliAgentMode;
 	defaultToolAutoApprove: boolean;
 	toolPolicies: Record<string, ToolPolicy>;
+	agentProfile?: ActiveAgentProfile;
 }
 
 export interface ActiveCliSession {
@@ -96,4 +111,6 @@ export interface ParsedArgs {
 	teamName?: string;
 	defaultToolAutoApprove: boolean;
 	autoApproveOverride?: boolean;
+	/** Agent profile name from .cline/agents to apply to the main agent */
+	agent?: string;
 }

--- a/sdk/packages/core/src/extensions/tools/team/spawn-agent-tool.test.ts
+++ b/sdk/packages/core/src/extensions/tools/team/spawn-agent-tool.test.ts
@@ -323,7 +323,6 @@ describe("createSpawnAgentTool", () => {
 		const constructedConfig = agentConstructorSpy.mock.calls[0]?.[0] as {
 			systemPrompt: string;
 		};
-		// The spawn prompt fills the persona slot of the harness template.
 		expect(constructedConfig.systemPrompt.startsWith(inputSystemPrompt)).toBe(
 			true,
 		);

--- a/sdk/packages/core/src/extensions/tools/team/spawn-agent-tool.test.ts
+++ b/sdk/packages/core/src/extensions/tools/team/spawn-agent-tool.test.ts
@@ -320,11 +320,18 @@ describe("createSpawnAgentTool", () => {
 			},
 		);
 
-		expect(agentConstructorSpy).toHaveBeenCalledWith(
-			expect.objectContaining({
-				systemPrompt: inputSystemPrompt,
-			}),
+		const constructedConfig = agentConstructorSpy.mock.calls[0]?.[0] as {
+			systemPrompt: string;
+		};
+		// The spawn prompt fills the persona slot of the harness template.
+		expect(constructedConfig.systemPrompt.startsWith(inputSystemPrompt)).toBe(
+			true,
 		);
+		// The embedded workspace configuration is not injected a second time.
+		const markerCount = constructedConfig.systemPrompt.split(
+			"# Workspace Configuration",
+		).length;
+		expect(markerCount - 1).toBe(1);
 	});
 
 	it("resolves connection settings lazily at execution time", async () => {

--- a/sdk/packages/core/src/extensions/tools/team/subagent-prompts.test.ts
+++ b/sdk/packages/core/src/extensions/tools/team/subagent-prompts.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import type { DelegatedAgentRuntimeConfig } from "./delegated-agent";
+import {
+	buildSubAgentSystemPrompt,
+	buildTeammateSystemPrompt,
+} from "./subagent-prompts";
+
+const PROFILE_BODY = "You are a reviewer. Focus on correctness.";
+
+function makeConfig(
+	overrides: Partial<DelegatedAgentRuntimeConfig> = {},
+): DelegatedAgentRuntimeConfig {
+	return {
+		providerId: "cline",
+		modelId: "model",
+		cwd: "/repo",
+		apiKey: "key",
+		clineIdeName: "Terminal",
+		clinePlatform: "linux",
+		workspaceMetadata: '{"workspaces":{}}',
+		...overrides,
+	};
+}
+
+describe("buildSubAgentSystemPrompt", () => {
+	it("fills the persona slot and keeps the agent harness for cline", () => {
+		const prompt = buildSubAgentSystemPrompt(PROFILE_BODY, makeConfig());
+		expect(prompt.startsWith(PROFILE_BODY)).toBe(true);
+		expect(prompt).toContain("Environment you are running in:");
+		expect(prompt).toContain("4. Working Directory: /repo");
+		expect(prompt).toContain(
+			"IMPORTANT: Always includes tool calls in your response until the task is completed.",
+		);
+		expect(prompt).toContain("# Workspace Configuration");
+		expect(prompt).not.toContain("You are Cline, an AI coding agent.");
+	});
+
+	it("keeps the harness for non-cline providers without cline metadata", () => {
+		const prompt = buildSubAgentSystemPrompt(
+			PROFILE_BODY,
+			makeConfig({ providerId: "openai" }),
+		);
+		expect(prompt.startsWith(PROFILE_BODY)).toBe(true);
+		expect(prompt).toContain("Environment you are running in:");
+		expect(prompt).toContain(
+			"IMPORTANT: Always includes tool calls in your response until the task is completed.",
+		);
+		expect(prompt).not.toContain("# Workspace Configuration");
+	});
+});
+
+describe("buildTeammateSystemPrompt", () => {
+	it("injects the role prompt as rules under the default persona for cline", () => {
+		const prompt = buildTeammateSystemPrompt(PROFILE_BODY, makeConfig());
+		expect(prompt).toContain("You are Cline, an AI coding agent.");
+		expect(prompt).toContain(`# Team Teammate Role\n${PROFILE_BODY}`);
+	});
+
+	it("returns the raw prompt for non-cline providers", () => {
+		const prompt = buildTeammateSystemPrompt(
+			PROFILE_BODY,
+			makeConfig({ providerId: "openai" }),
+		);
+		expect(prompt).toBe(PROFILE_BODY);
+	});
+});

--- a/sdk/packages/core/src/extensions/tools/team/subagent-prompts.ts
+++ b/sdk/packages/core/src/extensions/tools/team/subagent-prompts.ts
@@ -26,15 +26,16 @@ export function buildSubAgentSystemPrompt(
 	config: DelegatedAgentRuntimeConfig,
 ): string {
 	const trimmedPrompt = prompt.trim();
-	if (config.providerId.toLowerCase() !== "cline") {
-		return trimmedPrompt;
-	}
-
+	// The spawn prompt fills the persona slot while the agent harness
+	// (environment block, tool-call loop contract, completion instructions)
+	// is preserved. The harness is provider-agnostic; Cline-specific
+	// workspace metadata stays gated on providerId inside
+	// buildClineSystemPrompt.
 	return buildClineSystemPrompt({
 		ide: config.clineIdeName || "Terminal",
 		workspaceRoot: config.cwd?.trim() || "/",
 		providerId: config.providerId,
-		overridePrompt: trimmedPrompt,
+		personaPrompt: trimmedPrompt,
 		metadata: config.workspaceMetadata,
 		platform: config.clinePlatform,
 	});

--- a/sdk/packages/core/src/extensions/tools/team/subagent-prompts.ts
+++ b/sdk/packages/core/src/extensions/tools/team/subagent-prompts.ts
@@ -26,11 +26,8 @@ export function buildSubAgentSystemPrompt(
 	config: DelegatedAgentRuntimeConfig,
 ): string {
 	const trimmedPrompt = prompt.trim();
-	// The spawn prompt fills the persona slot while the agent harness
-	// (environment block, tool-call loop contract, completion instructions)
-	// is preserved. The harness is provider-agnostic; Cline-specific
-	// workspace metadata stays gated on providerId inside
-	// buildClineSystemPrompt.
+	// The spawn prompt fills the persona slot; the provider-agnostic harness
+	// (env block, tool-call loop contract) is kept for every provider.
 	return buildClineSystemPrompt({
 		ide: config.clineIdeName || "Terminal",
 		workspaceRoot: config.cwd?.trim() || "/",

--- a/sdk/packages/core/src/runtime/config/agent-message-codec.test.ts
+++ b/sdk/packages/core/src/runtime/config/agent-message-codec.test.ts
@@ -2,8 +2,8 @@ import { EMPTY_CONTENT_TEXT } from "@cline/shared";
 import { describe, expect, it } from "vitest";
 import {
 	agentMessageToMessageWithMetadata,
-	messageToAgentMessages,
 	messagesToAgentMessages,
+	messageToAgentMessages,
 } from "./agent-message-codec";
 
 describe("agent message codec", () => {

--- a/sdk/packages/core/vitest.config.ts
+++ b/sdk/packages/core/vitest.config.ts
@@ -1,6 +1,22 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
+const rootDir = dirname(fileURLToPath(import.meta.url));
+
 export default defineConfig({
+	resolve: {
+		alias: [
+			{
+				find: /^@cline\/shared$/,
+				replacement: resolve(rootDir, "../shared/src/index.ts"),
+			},
+			{
+				find: /^@cline\/shared\/(.+)$/,
+				replacement: resolve(rootDir, "../shared/src/$1"),
+			},
+		],
+	},
 	test: {
 		environment: "node",
 		include: ["src/**/*.test.ts"],

--- a/sdk/packages/shared/src/index.browser.ts
+++ b/sdk/packages/shared/src/index.browser.ts
@@ -168,6 +168,12 @@ export {
 	parseUserCommandEnvelope,
 	xmlTagsRemoval,
 } from "./prompt/format";
+export type { ComposeClineSystemPromptInput } from "./prompt/system";
+export {
+	composeClineSystemPrompt,
+	DEFAULT_CLINE_PERSONA,
+	DEFAULT_CLINE_WORKING_GUIDELINES,
+} from "./prompt/system";
 export { REMOTE_URI_SCHEME } from "./remote-config/constants";
 export type {
 	AnthropicModel,

--- a/sdk/packages/shared/src/index.browser.ts
+++ b/sdk/packages/shared/src/index.browser.ts
@@ -168,12 +168,6 @@ export {
 	parseUserCommandEnvelope,
 	xmlTagsRemoval,
 } from "./prompt/format";
-export type { ComposeClineSystemPromptInput } from "./prompt/system";
-export {
-	composeClineSystemPrompt,
-	DEFAULT_CLINE_PERSONA,
-	DEFAULT_CLINE_WORKING_GUIDELINES,
-} from "./prompt/system";
 export { REMOTE_URI_SCHEME } from "./remote-config/constants";
 export type {
 	AnthropicModel,

--- a/sdk/packages/shared/src/index.ts
+++ b/sdk/packages/shared/src/index.ts
@@ -182,12 +182,6 @@ export {
 	parseUserCommandEnvelope,
 	xmlTagsRemoval,
 } from "./prompt/format";
-export type { ComposeClineSystemPromptInput } from "./prompt/system";
-export {
-	composeClineSystemPrompt,
-	DEFAULT_CLINE_PERSONA,
-	DEFAULT_CLINE_WORKING_GUIDELINES,
-} from "./prompt/system";
 export {
 	buildRemoteConfigSessionBlobUploadMetadata,
 	clearRemoteConfigSessionBlobUpload,

--- a/sdk/packages/shared/src/index.ts
+++ b/sdk/packages/shared/src/index.ts
@@ -182,6 +182,12 @@ export {
 	parseUserCommandEnvelope,
 	xmlTagsRemoval,
 } from "./prompt/format";
+export type { ComposeClineSystemPromptInput } from "./prompt/system";
+export {
+	composeClineSystemPrompt,
+	DEFAULT_CLINE_PERSONA,
+	DEFAULT_CLINE_WORKING_GUIDELINES,
+} from "./prompt/system";
 export {
 	buildRemoteConfigSessionBlobUploadMetadata,
 	clearRemoteConfigSessionBlobUpload,

--- a/sdk/packages/shared/src/prompt/cline.test.ts
+++ b/sdk/packages/shared/src/prompt/cline.test.ts
@@ -102,8 +102,6 @@ describe("buildClineSystemPrompt", () => {
 			personaPrompt: persona,
 			rules: "Real rules here.",
 		});
-		// The persona body is untouched while the harness placeholders still
-		// resolve to their real values.
 		expect(prompt.startsWith(persona)).toBe(true);
 		expect(prompt).toContain("1. Platform: linux");
 		expect(prompt).toContain("Real rules here.");

--- a/sdk/packages/shared/src/prompt/cline.test.ts
+++ b/sdk/packages/shared/src/prompt/cline.test.ts
@@ -92,4 +92,20 @@ describe("buildClineSystemPrompt", () => {
 		});
 		expect(prompt).toContain("Use $& and $' carefully.");
 	});
+
+	it("keeps template-like tokens inside the persona literal", () => {
+		const persona =
+			"You report {{PLATFORM_NAME}} and honor {{CLINE_RULES}} verbatim.";
+		const prompt = buildClineSystemPrompt({
+			workspaceRoot: "/repo",
+			platform: "linux",
+			personaPrompt: persona,
+			rules: "Real rules here.",
+		});
+		// The persona body is untouched while the harness placeholders still
+		// resolve to their real values.
+		expect(prompt.startsWith(persona)).toBe(true);
+		expect(prompt).toContain("1. Platform: linux");
+		expect(prompt).toContain("Real rules here.");
+	});
 });

--- a/sdk/packages/shared/src/prompt/cline.test.ts
+++ b/sdk/packages/shared/src/prompt/cline.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { buildClineSystemPrompt } from "./cline";
+import { DEFAULT_CLINE_PERSONA } from "./system";
+
+const PERSONA = "You are Reviewer, a meticulous code review agent.";
+
+describe("buildClineSystemPrompt", () => {
+	it("uses the default persona when no personaPrompt is provided", () => {
+		const prompt = buildClineSystemPrompt({
+			workspaceRoot: "/repo",
+			platform: "linux",
+		});
+		expect(prompt).toContain("You are Cline, an AI coding agent.");
+		expect(prompt).toContain("4. Working Directory: /repo");
+	});
+
+	it("applies personaPrompt while keeping the harness", () => {
+		const prompt = buildClineSystemPrompt({
+			workspaceRoot: "/repo",
+			platform: "linux",
+			ide: "Terminal",
+			personaPrompt: PERSONA,
+		});
+		expect(prompt.startsWith(PERSONA)).toBe(true);
+		expect(prompt).toContain("1. Platform: linux");
+		expect(prompt).toContain("4. Working Directory: /repo");
+		expect(prompt).toContain(
+			"IMPORTANT: Always includes tool calls in your response until the task is completed.",
+		);
+		expect(prompt).not.toContain(DEFAULT_CLINE_PERSONA);
+	});
+
+	it("appends workspace metadata for the cline provider with a persona", () => {
+		const prompt = buildClineSystemPrompt({
+			workspaceRoot: "/repo",
+			providerId: "cline",
+			personaPrompt: PERSONA,
+			metadata: '{"workspaces":{}}',
+		});
+		expect(prompt.startsWith(PERSONA)).toBe(true);
+		expect(prompt).toContain("# Workspace Configuration");
+	});
+
+	it("does not duplicate metadata when the persona already embeds it", () => {
+		const personaWithMetadata = `${PERSONA}\n\n# Workspace Configuration\n{"workspaces":{}}`;
+		const prompt = buildClineSystemPrompt({
+			workspaceRoot: "/repo",
+			providerId: "cline",
+			personaPrompt: personaWithMetadata,
+			metadata: '{"workspaces":{}}',
+		});
+		const markerCount = prompt.split("# Workspace Configuration").length - 1;
+		expect(markerCount).toBe(1);
+	});
+
+	it("omits workspace metadata for non-cline providers with a persona", () => {
+		const prompt = buildClineSystemPrompt({
+			workspaceRoot: "/repo",
+			providerId: "openai",
+			personaPrompt: PERSONA,
+			metadata: '{"workspaces":{}}',
+		});
+		expect(prompt.startsWith(PERSONA)).toBe(true);
+		expect(prompt).not.toContain("# Workspace Configuration");
+	});
+
+	it("lets overridePrompt win over personaPrompt", () => {
+		const prompt = buildClineSystemPrompt({
+			workspaceRoot: "/repo",
+			overridePrompt: "Full override.",
+			personaPrompt: PERSONA,
+		});
+		expect(prompt).toBe("Full override.");
+	});
+
+	it("ignores personaPrompt in yolo mode", () => {
+		const prompt = buildClineSystemPrompt({
+			workspaceRoot: "/repo",
+			mode: "yolo",
+			personaPrompt: PERSONA,
+		});
+		expect(prompt).toContain(
+			"You are Cline, a careful and helpful coding agent that works in the background.",
+		);
+		expect(prompt).not.toContain(PERSONA);
+	});
+
+	it("inserts rules containing replacement patterns literally", () => {
+		const prompt = buildClineSystemPrompt({
+			workspaceRoot: "/repo",
+			rules: "Use $& and $' carefully.",
+		});
+		expect(prompt).toContain("Use $& and $' carefully.");
+	});
+});

--- a/sdk/packages/shared/src/prompt/cline.ts
+++ b/sdk/packages/shared/src/prompt/cline.ts
@@ -1,6 +1,10 @@
 import type { WorkspaceContext } from "../extensions/context";
 import type { WorkspaceInfo } from "../session/workspace";
-import { composeClineSystemPrompt, YOLO_CLINE_SYSTEM_PROMPT } from "./system";
+import {
+	AGENT_PERSONA_SLOT,
+	composeClineSystemPrompt,
+	YOLO_CLINE_SYSTEM_PROMPT,
+} from "./system";
 
 const WORKSPACE_CONFIGURATION_MARKER = "# Workspace Configuration";
 
@@ -64,8 +68,9 @@ export interface ClineSystemPromptOptions
 	/** Per-request system prompt override */
 	overridePrompt?: string;
 	/**
-	 * Agent-profile persona: replaces only the persona slot of the default
-	 * system prompt while keeping the agent harness (environment block,
+	 * Agent-profile persona: replaces the coding-agent-specific prompting of
+	 * the default system prompt (the Cline persona and its working
+	 * guidelines) while keeping the agent harness (environment block,
 	 * tool-call loop contract, rules/metadata). Ignored when `overridePrompt`
 	 * is set or in yolo mode.
 	 */
@@ -103,14 +108,20 @@ export function buildClineSystemPrompt(
 		return trimmed;
 	}
 
+	const persona = mode === "yolo" ? undefined : personaPrompt?.trim();
+	// When a persona is provided, compose the harness with the persona slot
+	// left in place so the persona body is inserted after every other
+	// placeholder replacement; `{{...}}` sequences inside it stay literal.
 	const basePrompt =
 		mode === "yolo"
 			? YOLO_CLINE_SYSTEM_PROMPT
-			: composeClineSystemPrompt({ persona: personaPrompt });
+			: composeClineSystemPrompt(
+					persona ? { persona: AGENT_PERSONA_SLOT } : {},
+				);
 	// Skip metadata injection when the persona already embeds a workspace
 	// configuration block (e.g. spawn prompts composed by a parent agent).
 	const includeMetadata =
-		isCline && !personaPrompt?.includes(WORKSPACE_CONFIGURATION_MARKER);
+		isCline && !persona?.includes(WORKSPACE_CONFIGURATION_MARKER);
 
 	// Replacer functions (not replacement strings) so values containing
 	// `$&`-style patterns are inserted literally.
@@ -125,5 +136,6 @@ export function buildClineSystemPrompt(
 				: "",
 		)
 		.replace("{{CLINE_RULES}}", () => rules || "")
+		.replace(AGENT_PERSONA_SLOT, () => persona ?? "")
 		.trim();
 }

--- a/sdk/packages/shared/src/prompt/cline.ts
+++ b/sdk/packages/shared/src/prompt/cline.ts
@@ -60,10 +60,10 @@ export interface ClineSystemPromptOptions
 	extends Omit<WorkspaceContext, "rootPath"> {
 	/**
 	 * Workspace root path. Accepts either `rootPath` (from WorkspaceContext/WorkspaceInfo)
-	 * or `workspaceRoot` (legacy alias) — whichever is provided will be used.
+	 * or `workspaceRoot` (legacy alias) - whichever is provided will be used.
 	 */
 	rootPath?: string;
-	/** Alias for rootPath — kept for backwards compatibility with existing call sites */
+	/** Alias for rootPath - kept for backwards compatibility with existing call sites */
 	workspaceRoot?: string;
 	/** Per-request system prompt override */
 	overridePrompt?: string;
@@ -73,7 +73,7 @@ export interface ClineSystemPromptOptions
 	 * `overridePrompt` is set or in yolo mode.
 	 */
 	personaPrompt?: string;
-	/** Provider ID — used to gate Cline-specific metadata injection */
+	/** Provider ID - used to gate Cline-specific metadata injection */
 	providerId?: string;
 }
 

--- a/sdk/packages/shared/src/prompt/cline.ts
+++ b/sdk/packages/shared/src/prompt/cline.ts
@@ -1,9 +1,6 @@
 import type { WorkspaceContext } from "../extensions/context";
 import type { WorkspaceInfo } from "../session/workspace";
-import {
-	DEFAULT_CLINE_SYSTEM_PROMPT,
-	YOLO_CLINE_SYSTEM_PROMPT,
-} from "./system";
+import { composeClineSystemPrompt, YOLO_CLINE_SYSTEM_PROMPT } from "./system";
 
 const WORKSPACE_CONFIGURATION_MARKER = "# Workspace Configuration";
 
@@ -66,6 +63,13 @@ export interface ClineSystemPromptOptions
 	workspaceRoot?: string;
 	/** Per-request system prompt override */
 	overridePrompt?: string;
+	/**
+	 * Agent-profile persona: replaces only the persona slot of the default
+	 * system prompt while keeping the agent harness (environment block,
+	 * tool-call loop contract, rules/metadata). Ignored when `overridePrompt`
+	 * is set or in yolo mode.
+	 */
+	personaPrompt?: string;
 	/** Provider ID — used to gate Cline-specific metadata injection */
 	providerId?: string;
 }
@@ -81,6 +85,7 @@ export function buildClineSystemPrompt(
 		metadata,
 		rules,
 		overridePrompt,
+		personaPrompt,
 		providerId,
 	} = options;
 	const workspaceRoot = options.workspaceRoot ?? options.rootPath ?? "";
@@ -99,19 +104,26 @@ export function buildClineSystemPrompt(
 	}
 
 	const basePrompt =
-		mode === "yolo" ? YOLO_CLINE_SYSTEM_PROMPT : DEFAULT_CLINE_SYSTEM_PROMPT;
+		mode === "yolo"
+			? YOLO_CLINE_SYSTEM_PROMPT
+			: composeClineSystemPrompt({ persona: personaPrompt });
+	// Skip metadata injection when the persona already embeds a workspace
+	// configuration block (e.g. spawn prompts composed by a parent agent).
+	const includeMetadata =
+		isCline && !personaPrompt?.includes(WORKSPACE_CONFIGURATION_MARKER);
 
+	// Replacer functions (not replacement strings) so values containing
+	// `$&`-style patterns are inserted literally.
 	return basePrompt
-		.replace("{{PLATFORM_NAME}}", platform)
-		.replace("{{CWD}}", workspaceRoot)
-		.replace("{{CURRENT_DATE}}", new Date().toLocaleDateString())
-		.replace("{{IDE_NAME}}", ide)
-		.replace(
-			"{{CLINE_METADATA}}",
-			isCline
+		.replace("{{PLATFORM_NAME}}", () => platform)
+		.replace("{{CWD}}", () => workspaceRoot)
+		.replace("{{CURRENT_DATE}}", () => new Date().toLocaleDateString())
+		.replace("{{IDE_NAME}}", () => ide)
+		.replace("{{CLINE_METADATA}}", () =>
+			includeMetadata
 				? buildWorkspaceMetadata(workspaceRoot, workspaceName, metadata)
 				: "",
 		)
-		.replace("{{CLINE_RULES}}", rules || "")
+		.replace("{{CLINE_RULES}}", () => rules || "")
 		.trim();
 }

--- a/sdk/packages/shared/src/prompt/cline.ts
+++ b/sdk/packages/shared/src/prompt/cline.ts
@@ -68,11 +68,9 @@ export interface ClineSystemPromptOptions
 	/** Per-request system prompt override */
 	overridePrompt?: string;
 	/**
-	 * Agent-profile persona: replaces the coding-agent-specific prompting of
-	 * the default system prompt (the Cline persona and its working
-	 * guidelines) while keeping the agent harness (environment block,
-	 * tool-call loop contract, rules/metadata). Ignored when `overridePrompt`
-	 * is set or in yolo mode.
+	 * Agent-profile persona: replaces the default Cline persona and its
+	 * working guidelines while keeping the agent harness. Ignored when
+	 * `overridePrompt` is set or in yolo mode.
 	 */
 	personaPrompt?: string;
 	/** Provider ID — used to gate Cline-specific metadata injection */
@@ -109,9 +107,8 @@ export function buildClineSystemPrompt(
 	}
 
 	const persona = mode === "yolo" ? undefined : personaPrompt?.trim();
-	// When a persona is provided, compose the harness with the persona slot
-	// left in place so the persona body is inserted after every other
-	// placeholder replacement; `{{...}}` sequences inside it stay literal.
+	// Keep the persona slot in place and fill it last, so `{{...}}` sequences
+	// inside a persona body stay literal.
 	const basePrompt =
 		mode === "yolo"
 			? YOLO_CLINE_SYSTEM_PROMPT

--- a/sdk/packages/shared/src/prompt/cline.ts
+++ b/sdk/packages/shared/src/prompt/cline.ts
@@ -68,9 +68,9 @@ export interface ClineSystemPromptOptions
 	/** Per-request system prompt override */
 	overridePrompt?: string;
 	/**
-	 * Agent-profile persona: replaces the default Cline persona and its
-	 * working guidelines while keeping the agent harness. Ignored when
-	 * `overridePrompt` is set or in yolo mode.
+	 * Agent-profile persona: replaces the default Cline persona (the identity
+	 * intro) while keeping the agent harness, including the working guidelines.
+	 * Ignored when `overridePrompt` is set or in yolo mode.
 	 */
 	personaPrompt?: string;
 	/** Provider ID - used to gate Cline-specific metadata injection */

--- a/sdk/packages/shared/src/prompt/system.test.ts
+++ b/sdk/packages/shared/src/prompt/system.test.ts
@@ -76,7 +76,6 @@ describe("composeClineSystemPrompt", () => {
 		);
 		expect(prompt).toContain("{{CLINE_RULES}}");
 		expect(prompt).toContain("{{CLINE_METADATA}}");
-		// Default coding persona and working guidelines are fully replaced.
 		expect(prompt).not.toContain("You are Cline, an AI coding agent.");
 		expect(prompt).not.toContain(DEFAULT_CLINE_WORKING_GUIDELINES);
 		// The guidelines slot collapses cleanly: env block flows into the

--- a/sdk/packages/shared/src/prompt/system.test.ts
+++ b/sdk/packages/shared/src/prompt/system.test.ts
@@ -5,21 +5,6 @@ import {
 	DEFAULT_CLINE_SYSTEM_PROMPT,
 } from "./system";
 
-// The working guidelines are inlined into the harness template (always on,
-// never swapped), so they are no longer exported. Pin the block here to assert
-// it survives a persona swap. The no-guessing norm is the first bullet.
-const WORKING_GUIDELINES = `Remember:
-- If you need more information, use one of the available tools or ask for clarification instead of making assumptions or lies.
-- Always adhere to existing code conventions and patterns.
-- Use only libraries and frameworks that are confirmed to be in use in the current codebase.
-- Provide complete and functional code without omissions or placeholders.
-- Be explicit about any assumptions or limitations in your solution.
-- Always show your planning process before executing any task. This will help ensure that you have a clear understanding of the requirements and that your approach aligns with the user's needs.
-- Always use absolute paths when referring to files.
-- Always verify the files you have edited or created at the end of the task to ensure they are completed and working as expected.
-
-Begin by analyzing the user's input and gathering any necessary additional context. Then, present your plan at the start of your response along with tool calls before proceeding with the task. It's OK for this section to be quite long.`;
-
 // The canonical default system prompt. Pinned as a literal (including trailing
 // whitespace) so accidental drift is caught; update deliberately when the
 // default prompt is intentionally changed.
@@ -58,6 +43,13 @@ If user asked a simple question without any coding context, answer it directly w
 {{CLINE_RULES}}
 {{CLINE_METADATA}}`;
 
+// Everything after the persona is the always-on harness (env block, working
+// guidelines, tool-call contract, completion rules, rules/metadata). Derived
+// from the default so the harness text has a single source of truth.
+const HARNESS = EXPECTED_DEFAULT_CLINE_SYSTEM_PROMPT.slice(
+	DEFAULT_CLINE_PERSONA.length,
+);
+
 describe("composeClineSystemPrompt", () => {
 	it("composes the canonical default prompt", () => {
 		expect(DEFAULT_CLINE_SYSTEM_PROMPT).toBe(
@@ -69,6 +61,8 @@ describe("composeClineSystemPrompt", () => {
 		expect(composeClineSystemPrompt({})).toBe(
 			EXPECTED_DEFAULT_CLINE_SYSTEM_PROMPT,
 		);
+		// The exported persona is the real prefix; the rest is the harness.
+		expect(DEFAULT_CLINE_SYSTEM_PROMPT).toBe(DEFAULT_CLINE_PERSONA + HARNESS);
 	});
 
 	it("treats a blank persona as the default", () => {
@@ -77,48 +71,29 @@ describe("composeClineSystemPrompt", () => {
 		);
 	});
 
-	it("swaps the persona slot while keeping the harness", () => {
+	it("swaps the persona but keeps the harness verbatim", () => {
 		const persona =
 			"You are Reviewer, a meticulous code review agent. Focus on correctness.";
-		const prompt = composeClineSystemPrompt({ persona });
+		// Only the persona changes; the entire harness tail is byte-identical.
+		expect(composeClineSystemPrompt({ persona })).toBe(persona + HARNESS);
+	});
 
-		expect(prompt.startsWith(persona)).toBe(true);
-		expect(prompt).toContain("Environment you are running in:");
-		expect(prompt).toContain("4. Working Directory: {{CWD}}");
-		expect(prompt).toContain(
-			"IMPORTANT: Always includes tool calls in your response until the task is completed.",
-		);
-		expect(prompt).toContain("{{CLINE_RULES}}");
-		expect(prompt).toContain("{{CLINE_METADATA}}");
-		expect(prompt).not.toContain("You are Cline, an AI coding agent.");
-		// "Review each question carefully" is persona, so it goes with the swap.
-		expect(prompt).not.toContain("Review each question carefully");
-		// The working guidelines (including the no-guessing norm) are harness:
-		// retained in full even when a custom persona replaces the identity.
-		expect(prompt).toContain(WORKING_GUIDELINES);
-		expect(prompt).toContain(
-			`</env>\n\n${WORKING_GUIDELINES}\n\nREMEMBER, be helpful and proactive!`,
-		);
+	it("keeps the working guidelines, incl. the no-guessing norm, in the harness", () => {
+		const norm =
+			"If you need more information, use one of the available tools or ask for clarification instead of making assumptions or lies.";
+		// The norm and the rest of the working guidelines are harness, not
+		// persona, so a profile keeps them while the identity is swapped.
+		expect(HARNESS).toContain(norm);
+		expect(DEFAULT_CLINE_PERSONA).not.toContain(norm);
 	});
 
 	it("inserts persona content literally, including replacement patterns", () => {
 		const persona = "Echo the captured group $& and $' verbatim.";
-		const prompt = composeClineSystemPrompt({ persona });
-		expect(prompt.startsWith(persona)).toBe(true);
+		expect(composeClineSystemPrompt({ persona })).toBe(persona + HARNESS);
 	});
 
 	it("keeps template-like tokens inside the persona literal", () => {
 		const persona = "Mention {{AGENT_GUIDELINES}} and {{AGENT_PERSONA}} as-is.";
-		const prompt = composeClineSystemPrompt({ persona });
-		expect(prompt.startsWith(persona)).toBe(true);
-		// The harness — working guidelines included — follows the env block.
-		expect(prompt).toContain(
-			`</env>\n\n${WORKING_GUIDELINES}\n\nREMEMBER, be helpful and proactive!`,
-		);
-	});
-
-	it("keeps the exported default persona and guidelines in sync with the default prompt", () => {
-		expect(DEFAULT_CLINE_SYSTEM_PROMPT).toContain(DEFAULT_CLINE_PERSONA);
-		expect(DEFAULT_CLINE_SYSTEM_PROMPT).toContain(WORKING_GUIDELINES);
+		expect(composeClineSystemPrompt({ persona })).toBe(persona + HARNESS);
 	});
 });

--- a/sdk/packages/shared/src/prompt/system.test.ts
+++ b/sdk/packages/shared/src/prompt/system.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+	composeClineSystemPrompt,
+	DEFAULT_CLINE_PERSONA,
+	DEFAULT_CLINE_SYSTEM_PROMPT,
+	DEFAULT_CLINE_WORKING_GUIDELINES,
+} from "./system";
+
+// The exact default system prompt before the persona/harness split. The
+// refactor must keep the default output byte-identical, including trailing
+// whitespace, so this is pinned as a literal rather than recomposed.
+const PRE_SPLIT_DEFAULT_CLINE_SYSTEM_PROMPT = `You are Cline, an AI coding agent. Your primary goal is to assist users with various coding tasks by leveraging your knowledge and the tools at your disposal. Given the user's prompt, you should use the tools available to you to answer user's question.
+
+Always gather all the necessary context before starting to work on a task. For example, if you are generating a unit test or new code, make sure you understand the requirement, the naming conventions, frameworks and libraries used and aligned in the current codebase, and the environment and commands used to run and test the code etc. Always validate the new unit test at the end including running the code if possible for live feedback.
+Review each question carefully and answer it with detailed, accurate information.
+If you need more information, use one of the available tools or ask for clarification instead of making assumptions or lies.
+
+Environment you are running in:
+<env>
+1. Platform: {{PLATFORM_NAME}}
+2. Date: {{CURRENT_DATE}}
+3. IDE: {{IDE_NAME}}
+4. Working Directory: {{CWD}}
+</env>
+
+Remember:
+- Always adhere to existing code conventions and patterns.
+- Use only libraries and frameworks that are confirmed to be in use in the current codebase.
+- Provide complete and functional code without omissions or placeholders.
+- Be explicit about any assumptions or limitations in your solution.
+- Always show your planning process before executing any task. This will help ensure that you have a clear understanding of the requirements and that your approach aligns with the user's needs.
+- Always use absolute paths when referring to files.
+- Always verify the files you have edited or created at the end of the task to ensure they are completed and working as expected.
+
+Begin by analyzing the user's input and gathering any necessary additional context. Then, present your plan at the start of your response along with tool calls before proceeding with the task. It's OK for this section to be quite long.
+
+REMEMBER, be helpful and proactive! Don't ask for permission to do something when you can do it! Do not indicates you will be using a tool unless you are actually going to use it.
+
+IMPORTANT: Always includes tool calls in your response until the task is completed. Response without tool calls will considered as completed with final answer.
+
+When you have completed the task, please provide a summary of what you did and any relevant information that the user should know. This will help ensure that the user understands the changes made and can easily follow up if they have any questions or need further assistance. Do not indicate that you will perform an action without actually doing it. Always provide the final result in your response. Always validate your answer with checking the code and running it if possible. 
+
+If user asked a simple question without any coding context, answer it directly without using any tools.
+{{CLINE_RULES}}
+{{CLINE_METADATA}}`;
+
+describe("composeClineSystemPrompt", () => {
+	it("produces a byte-identical default prompt after the persona/harness split", () => {
+		expect(DEFAULT_CLINE_SYSTEM_PROMPT).toBe(
+			PRE_SPLIT_DEFAULT_CLINE_SYSTEM_PROMPT,
+		);
+		expect(composeClineSystemPrompt()).toBe(
+			PRE_SPLIT_DEFAULT_CLINE_SYSTEM_PROMPT,
+		);
+		expect(composeClineSystemPrompt({})).toBe(
+			PRE_SPLIT_DEFAULT_CLINE_SYSTEM_PROMPT,
+		);
+	});
+
+	it("treats a blank persona as the default", () => {
+		expect(composeClineSystemPrompt({ persona: "   " })).toBe(
+			PRE_SPLIT_DEFAULT_CLINE_SYSTEM_PROMPT,
+		);
+	});
+
+	it("swaps the persona slot while keeping the harness", () => {
+		const persona =
+			"You are Reviewer, a meticulous code review agent. Focus on correctness.";
+		const prompt = composeClineSystemPrompt({ persona });
+
+		expect(prompt.startsWith(persona)).toBe(true);
+		expect(prompt).toContain("Environment you are running in:");
+		expect(prompt).toContain("4. Working Directory: {{CWD}}");
+		expect(prompt).toContain(
+			"IMPORTANT: Always includes tool calls in your response until the task is completed.",
+		);
+		expect(prompt).toContain("{{CLINE_RULES}}");
+		expect(prompt).toContain("{{CLINE_METADATA}}");
+		// Default coding persona and working guidelines are fully replaced.
+		expect(prompt).not.toContain("You are Cline, an AI coding agent.");
+		expect(prompt).not.toContain(DEFAULT_CLINE_WORKING_GUIDELINES);
+		// The guidelines slot collapses cleanly: env block flows into the
+		// harness reminders with a single blank line.
+		expect(prompt).toContain("</env>\n\nREMEMBER, be helpful and proactive!");
+	});
+
+	it("inserts persona content literally, including replacement patterns", () => {
+		const persona = "Echo the captured group $& and $' verbatim.";
+		const prompt = composeClineSystemPrompt({ persona });
+		expect(prompt.startsWith(persona)).toBe(true);
+	});
+
+	it("keeps the exported default persona and guidelines in sync with the default prompt", () => {
+		expect(DEFAULT_CLINE_SYSTEM_PROMPT).toContain(DEFAULT_CLINE_PERSONA);
+		expect(DEFAULT_CLINE_SYSTEM_PROMPT).toContain(
+			DEFAULT_CLINE_WORKING_GUIDELINES,
+		);
+	});
+});

--- a/sdk/packages/shared/src/prompt/system.test.ts
+++ b/sdk/packages/shared/src/prompt/system.test.ts
@@ -38,7 +38,7 @@ REMEMBER, be helpful and proactive! Don't ask for permission to do something whe
 
 IMPORTANT: Always includes tool calls in your response until the task is completed. Response without tool calls will considered as completed with final answer.
 
-When you have completed the task, please provide a summary of what you did and any relevant information that the user should know. This will help ensure that the user understands the changes made and can easily follow up if they have any questions or need further assistance. Do not indicate that you will perform an action without actually doing it. Always provide the final result in your response. Always validate your answer with checking the code and running it if possible. 
+When you have completed the task, please provide a summary of what you did and any relevant information that the user should know. This will help ensure that the user understands the changes made and can easily follow up if they have any questions or need further assistance. Do not indicate that you will perform an action without actually doing it. Always provide the final result in your response. Always validate your answer with checking the code and running it if possible.${" "}
 
 If user asked a simple question without any coding context, answer it directly without using any tools.
 {{CLINE_RULES}}

--- a/sdk/packages/shared/src/prompt/system.test.ts
+++ b/sdk/packages/shared/src/prompt/system.test.ts
@@ -90,6 +90,14 @@ describe("composeClineSystemPrompt", () => {
 		expect(prompt.startsWith(persona)).toBe(true);
 	});
 
+	it("keeps template-like tokens inside the persona literal", () => {
+		const persona = "Mention {{AGENT_GUIDELINES}} and {{AGENT_PERSONA}} as-is.";
+		const prompt = composeClineSystemPrompt({ persona });
+		expect(prompt.startsWith(persona)).toBe(true);
+		// The harness guidelines slot still collapsed cleanly.
+		expect(prompt).toContain("</env>\n\nREMEMBER, be helpful and proactive!");
+	});
+
 	it("keeps the exported default persona and guidelines in sync with the default prompt", () => {
 		expect(DEFAULT_CLINE_SYSTEM_PROMPT).toContain(DEFAULT_CLINE_PERSONA);
 		expect(DEFAULT_CLINE_SYSTEM_PROMPT).toContain(

--- a/sdk/packages/shared/src/prompt/system.test.ts
+++ b/sdk/packages/shared/src/prompt/system.test.ts
@@ -3,17 +3,30 @@ import {
 	composeClineSystemPrompt,
 	DEFAULT_CLINE_PERSONA,
 	DEFAULT_CLINE_SYSTEM_PROMPT,
-	DEFAULT_CLINE_WORKING_GUIDELINES,
 } from "./system";
 
-// The exact default system prompt before the persona/harness split. The
-// refactor must keep the default output byte-identical, including trailing
-// whitespace, so this is pinned as a literal rather than recomposed.
-const PRE_SPLIT_DEFAULT_CLINE_SYSTEM_PROMPT = `You are Cline, an AI coding agent. Your primary goal is to assist users with various coding tasks by leveraging your knowledge and the tools at your disposal. Given the user's prompt, you should use the tools available to you to answer user's question.
+// The working guidelines are inlined into the harness template (always on,
+// never swapped), so they are no longer exported. Pin the block here to assert
+// it survives a persona swap. The no-guessing norm is the first bullet.
+const WORKING_GUIDELINES = `Remember:
+- If you need more information, use one of the available tools or ask for clarification instead of making assumptions or lies.
+- Always adhere to existing code conventions and patterns.
+- Use only libraries and frameworks that are confirmed to be in use in the current codebase.
+- Provide complete and functional code without omissions or placeholders.
+- Be explicit about any assumptions or limitations in your solution.
+- Always show your planning process before executing any task. This will help ensure that you have a clear understanding of the requirements and that your approach aligns with the user's needs.
+- Always use absolute paths when referring to files.
+- Always verify the files you have edited or created at the end of the task to ensure they are completed and working as expected.
+
+Begin by analyzing the user's input and gathering any necessary additional context. Then, present your plan at the start of your response along with tool calls before proceeding with the task. It's OK for this section to be quite long.`;
+
+// The canonical default system prompt. Pinned as a literal (including trailing
+// whitespace) so accidental drift is caught; update deliberately when the
+// default prompt is intentionally changed.
+const EXPECTED_DEFAULT_CLINE_SYSTEM_PROMPT = `You are Cline, an AI coding agent. Your primary goal is to assist users with various coding tasks by leveraging your knowledge and the tools at your disposal. Given the user's prompt, you should use the tools available to you to answer user's question.
 
 Always gather all the necessary context before starting to work on a task. For example, if you are generating a unit test or new code, make sure you understand the requirement, the naming conventions, frameworks and libraries used and aligned in the current codebase, and the environment and commands used to run and test the code etc. Always validate the new unit test at the end including running the code if possible for live feedback.
 Review each question carefully and answer it with detailed, accurate information.
-If you need more information, use one of the available tools or ask for clarification instead of making assumptions or lies.
 
 Environment you are running in:
 <env>
@@ -24,6 +37,7 @@ Environment you are running in:
 </env>
 
 Remember:
+- If you need more information, use one of the available tools or ask for clarification instead of making assumptions or lies.
 - Always adhere to existing code conventions and patterns.
 - Use only libraries and frameworks that are confirmed to be in use in the current codebase.
 - Provide complete and functional code without omissions or placeholders.
@@ -45,21 +59,21 @@ If user asked a simple question without any coding context, answer it directly w
 {{CLINE_METADATA}}`;
 
 describe("composeClineSystemPrompt", () => {
-	it("produces a byte-identical default prompt after the persona/harness split", () => {
+	it("composes the canonical default prompt", () => {
 		expect(DEFAULT_CLINE_SYSTEM_PROMPT).toBe(
-			PRE_SPLIT_DEFAULT_CLINE_SYSTEM_PROMPT,
+			EXPECTED_DEFAULT_CLINE_SYSTEM_PROMPT,
 		);
 		expect(composeClineSystemPrompt()).toBe(
-			PRE_SPLIT_DEFAULT_CLINE_SYSTEM_PROMPT,
+			EXPECTED_DEFAULT_CLINE_SYSTEM_PROMPT,
 		);
 		expect(composeClineSystemPrompt({})).toBe(
-			PRE_SPLIT_DEFAULT_CLINE_SYSTEM_PROMPT,
+			EXPECTED_DEFAULT_CLINE_SYSTEM_PROMPT,
 		);
 	});
 
 	it("treats a blank persona as the default", () => {
 		expect(composeClineSystemPrompt({ persona: "   " })).toBe(
-			PRE_SPLIT_DEFAULT_CLINE_SYSTEM_PROMPT,
+			EXPECTED_DEFAULT_CLINE_SYSTEM_PROMPT,
 		);
 	});
 
@@ -77,10 +91,14 @@ describe("composeClineSystemPrompt", () => {
 		expect(prompt).toContain("{{CLINE_RULES}}");
 		expect(prompt).toContain("{{CLINE_METADATA}}");
 		expect(prompt).not.toContain("You are Cline, an AI coding agent.");
-		expect(prompt).not.toContain(DEFAULT_CLINE_WORKING_GUIDELINES);
-		// The guidelines slot collapses cleanly: env block flows into the
-		// harness reminders with a single blank line.
-		expect(prompt).toContain("</env>\n\nREMEMBER, be helpful and proactive!");
+		// "Review each question carefully" is persona, so it goes with the swap.
+		expect(prompt).not.toContain("Review each question carefully");
+		// The working guidelines (including the no-guessing norm) are harness:
+		// retained in full even when a custom persona replaces the identity.
+		expect(prompt).toContain(WORKING_GUIDELINES);
+		expect(prompt).toContain(
+			`</env>\n\n${WORKING_GUIDELINES}\n\nREMEMBER, be helpful and proactive!`,
+		);
 	});
 
 	it("inserts persona content literally, including replacement patterns", () => {
@@ -93,14 +111,14 @@ describe("composeClineSystemPrompt", () => {
 		const persona = "Mention {{AGENT_GUIDELINES}} and {{AGENT_PERSONA}} as-is.";
 		const prompt = composeClineSystemPrompt({ persona });
 		expect(prompt.startsWith(persona)).toBe(true);
-		// The harness guidelines slot still collapsed cleanly.
-		expect(prompt).toContain("</env>\n\nREMEMBER, be helpful and proactive!");
+		// The harness — working guidelines included — follows the env block.
+		expect(prompt).toContain(
+			`</env>\n\n${WORKING_GUIDELINES}\n\nREMEMBER, be helpful and proactive!`,
+		);
 	});
 
 	it("keeps the exported default persona and guidelines in sync with the default prompt", () => {
 		expect(DEFAULT_CLINE_SYSTEM_PROMPT).toContain(DEFAULT_CLINE_PERSONA);
-		expect(DEFAULT_CLINE_SYSTEM_PROMPT).toContain(
-			DEFAULT_CLINE_WORKING_GUIDELINES,
-		);
+		expect(DEFAULT_CLINE_SYSTEM_PROMPT).toContain(WORKING_GUIDELINES);
 	});
 });

--- a/sdk/packages/shared/src/prompt/system.ts
+++ b/sdk/packages/shared/src/prompt/system.ts
@@ -41,12 +41,17 @@ If user asked a simple question without any coding context, answer it directly w
 {{CLINE_RULES}}
 {{CLINE_METADATA}}`;
 
+/** The persona placeholder of the harness template. */
+export const AGENT_PERSONA_SLOT = "{{AGENT_PERSONA}}";
+
 export interface ComposeClineSystemPromptInput {
 	/**
-	 * Replaces the persona slot (the coding-agent-specific prompting) while
-	 * keeping the agent harness (environment block, tool-call loop contract,
-	 * completion instructions, rules/metadata placeholders). Used to apply an
-	 * agent profile's system prompt body to the main agent or a subagent.
+	 * Replaces the coding-agent-specific prompting (the default Cline persona
+	 * AND its working guidelines) while keeping the agent harness (environment
+	 * block, tool-call loop contract, completion instructions, rules/metadata
+	 * placeholders). A custom persona is expected to bring its own working
+	 * guidance. Used to apply an agent profile's system prompt body to the
+	 * main agent or a subagent.
 	 */
 	persona?: string;
 }
@@ -55,14 +60,12 @@ export function composeClineSystemPrompt(
 	input: ComposeClineSystemPromptInput = {},
 ): string {
 	const persona = input.persona?.trim();
-	// Replacer functions (not replacement strings) so persona content
-	// containing `$&`-style patterns is inserted literally.
-	return CLINE_SYSTEM_PROMPT_TEMPLATE.replace(
-		"{{AGENT_PERSONA}}",
-		() => persona || DEFAULT_CLINE_PERSONA,
-	).replace("{{AGENT_GUIDELINES}}", () =>
+	// Guidelines are resolved before the persona is inserted, and replacer
+	// functions (not replacement strings) are used throughout, so persona
+	// content containing `{{...}}` or `$&`-style sequences stays literal.
+	return CLINE_SYSTEM_PROMPT_TEMPLATE.replace("{{AGENT_GUIDELINES}}", () =>
 		persona ? "" : `${DEFAULT_CLINE_WORKING_GUIDELINES}\n\n`,
-	);
+	).replace(AGENT_PERSONA_SLOT, () => persona || DEFAULT_CLINE_PERSONA);
 }
 
 export const DEFAULT_CLINE_SYSTEM_PROMPT = composeClineSystemPrompt();

--- a/sdk/packages/shared/src/prompt/system.ts
+++ b/sdk/packages/shared/src/prompt/system.ts
@@ -1,24 +1,14 @@
 export const DEFAULT_CLINE_PERSONA = `You are Cline, an AI coding agent. Your primary goal is to assist users with various coding tasks by leveraging your knowledge and the tools at your disposal. Given the user's prompt, you should use the tools available to you to answer user's question.
 
 Always gather all the necessary context before starting to work on a task. For example, if you are generating a unit test or new code, make sure you understand the requirement, the naming conventions, frameworks and libraries used and aligned in the current codebase, and the environment and commands used to run and test the code etc. Always validate the new unit test at the end including running the code if possible for live feedback.
-Review each question carefully and answer it with detailed, accurate information.
-If you need more information, use one of the available tools or ask for clarification instead of making assumptions or lies.`;
+Review each question carefully and answer it with detailed, accurate information.`;
 
-export const DEFAULT_CLINE_WORKING_GUIDELINES = `Remember:
-- Always adhere to existing code conventions and patterns.
-- Use only libraries and frameworks that are confirmed to be in use in the current codebase.
-- Provide complete and functional code without omissions or placeholders.
-- Be explicit about any assumptions or limitations in your solution.
-- Always show your planning process before executing any task. This will help ensure that you have a clear understanding of the requirements and that your approach aligns with the user's needs.
-- Always use absolute paths when referring to files.
-- Always verify the files you have edited or created at the end of the task to ensure they are completed and working as expected.
-
-Begin by analyzing the user's input and gathering any necessary additional context. Then, present your plan at the start of your response along with tool calls before proceeding with the task. It's OK for this section to be quite long.`;
-
-// The agent harness: env block, tool-call loop contract, completion
-// instructions, and rules/metadata placeholders. {{AGENT_PERSONA}} and
-// {{AGENT_GUIDELINES}} hold the coding-agent-specific prompting; an agent
-// profile body replaces both while the harness is preserved.
+// The agent harness: env block, working guidelines (including the no-guessing
+// norm: use tools or ask instead of fabricating), tool-call loop contract,
+// completion instructions, and rules/metadata placeholders. Only the
+// {{AGENT_PERSONA}} slot holds the coding-agent identity and workflow
+// prompting; an agent profile body replaces that slot while the rest of the
+// harness is always preserved.
 const CLINE_SYSTEM_PROMPT_TEMPLATE = `{{AGENT_PERSONA}}
 
 Environment you are running in:
@@ -29,7 +19,19 @@ Environment you are running in:
 4. Working Directory: {{CWD}}
 </env>
 
-{{AGENT_GUIDELINES}}REMEMBER, be helpful and proactive! Don't ask for permission to do something when you can do it! Do not indicates you will be using a tool unless you are actually going to use it.
+Remember:
+- If you need more information, use one of the available tools or ask for clarification instead of making assumptions or lies.
+- Always adhere to existing code conventions and patterns.
+- Use only libraries and frameworks that are confirmed to be in use in the current codebase.
+- Provide complete and functional code without omissions or placeholders.
+- Be explicit about any assumptions or limitations in your solution.
+- Always show your planning process before executing any task. This will help ensure that you have a clear understanding of the requirements and that your approach aligns with the user's needs.
+- Always use absolute paths when referring to files.
+- Always verify the files you have edited or created at the end of the task to ensure they are completed and working as expected.
+
+Begin by analyzing the user's input and gathering any necessary additional context. Then, present your plan at the start of your response along with tool calls before proceeding with the task. It's OK for this section to be quite long.
+
+REMEMBER, be helpful and proactive! Don't ask for permission to do something when you can do it! Do not indicates you will be using a tool unless you are actually going to use it.
 
 IMPORTANT: Always includes tool calls in your response until the task is completed. Response without tool calls will considered as completed with final answer.
 
@@ -44,9 +46,10 @@ export const AGENT_PERSONA_SLOT = "{{AGENT_PERSONA}}";
 
 export interface ComposeClineSystemPromptInput {
 	/**
-	 * Replaces the default Cline persona AND its working guidelines while
-	 * keeping the agent harness. A custom persona (e.g. an agent profile
-	 * body) is expected to bring its own working guidance.
+	 * Replaces the default Cline persona (the identity intro) while keeping the
+	 * agent harness. The working guidelines are part of the harness and are
+	 * always retained, even when a custom persona (e.g. an agent profile body)
+	 * is supplied.
 	 */
 	persona?: string;
 }
@@ -55,11 +58,12 @@ export function composeClineSystemPrompt(
 	input: ComposeClineSystemPromptInput = {},
 ): string {
 	const persona = input.persona?.trim();
-	// The persona is inserted last via a replacer function so `{{...}}` and
+	// The persona is inserted via a replacer function so `{{...}}` and
 	// `$&`-style sequences inside it stay literal.
-	return CLINE_SYSTEM_PROMPT_TEMPLATE.replace("{{AGENT_GUIDELINES}}", () =>
-		persona ? "" : `${DEFAULT_CLINE_WORKING_GUIDELINES}\n\n`,
-	).replace(AGENT_PERSONA_SLOT, () => persona || DEFAULT_CLINE_PERSONA);
+	return CLINE_SYSTEM_PROMPT_TEMPLATE.replace(
+		AGENT_PERSONA_SLOT,
+		() => persona || DEFAULT_CLINE_PERSONA,
+	);
 }
 
 export const DEFAULT_CLINE_SYSTEM_PROMPT = composeClineSystemPrompt();

--- a/sdk/packages/shared/src/prompt/system.ts
+++ b/sdk/packages/shared/src/prompt/system.ts
@@ -1,8 +1,27 @@
-export const DEFAULT_CLINE_SYSTEM_PROMPT = `You are Cline, an AI coding agent. Your primary goal is to assist users with various coding tasks by leveraging your knowledge and the tools at your disposal. Given the user's prompt, you should use the tools available to you to answer user's question.
+export const DEFAULT_CLINE_PERSONA = `You are Cline, an AI coding agent. Your primary goal is to assist users with various coding tasks by leveraging your knowledge and the tools at your disposal. Given the user's prompt, you should use the tools available to you to answer user's question.
 
 Always gather all the necessary context before starting to work on a task. For example, if you are generating a unit test or new code, make sure you understand the requirement, the naming conventions, frameworks and libraries used and aligned in the current codebase, and the environment and commands used to run and test the code etc. Always validate the new unit test at the end including running the code if possible for live feedback.
 Review each question carefully and answer it with detailed, accurate information.
-If you need more information, use one of the available tools or ask for clarification instead of making assumptions or lies.
+If you need more information, use one of the available tools or ask for clarification instead of making assumptions or lies.`;
+
+export const DEFAULT_CLINE_WORKING_GUIDELINES = `Remember:
+- Always adhere to existing code conventions and patterns.
+- Use only libraries and frameworks that are confirmed to be in use in the current codebase.
+- Provide complete and functional code without omissions or placeholders.
+- Be explicit about any assumptions or limitations in your solution.
+- Always show your planning process before executing any task. This will help ensure that you have a clear understanding of the requirements and that your approach aligns with the user's needs.
+- Always use absolute paths when referring to files.
+- Always verify the files you have edited or created at the end of the task to ensure they are completed and working as expected.
+
+Begin by analyzing the user's input and gathering any necessary additional context. Then, present your plan at the start of your response along with tool calls before proceeding with the task. It's OK for this section to be quite long.`;
+
+// The general agent harness prompting: environment block, tool-call loop
+// contract, completion instructions, and rules/metadata placeholders. The
+// {{AGENT_PERSONA}} slot holds the coding-agent-specific prompting and can be
+// swapped with an agent profile's system prompt body, while the harness is
+// preserved. {{AGENT_GUIDELINES}} holds the default working guidelines and
+// collapses to empty when a custom persona is active.
+const CLINE_SYSTEM_PROMPT_TEMPLATE = `{{AGENT_PERSONA}}
 
 Environment you are running in:
 <env>
@@ -12,18 +31,7 @@ Environment you are running in:
 4. Working Directory: {{CWD}}
 </env>
 
-Remember:
-- Always adhere to existing code conventions and patterns.
-- Use only libraries and frameworks that are confirmed to be in use in the current codebase.
-- Provide complete and functional code without omissions or placeholders.
-- Be explicit about any assumptions or limitations in your solution.
-- Always show your planning process before executing any task. This will help ensure that you have a clear understanding of the requirements and that your approach aligns with the user's needs.
-- Always use absolute paths when referring to files.
-- Always verify the files you have edited or created at the end of the task to ensure they are completed and working as expected.
-
-Begin by analyzing the user's input and gathering any necessary additional context. Then, present your plan at the start of your response along with tool calls before proceeding with the task. It's OK for this section to be quite long.
-
-REMEMBER, be helpful and proactive! Don't ask for permission to do something when you can do it! Do not indicates you will be using a tool unless you are actually going to use it.
+{{AGENT_GUIDELINES}}REMEMBER, be helpful and proactive! Don't ask for permission to do something when you can do it! Do not indicates you will be using a tool unless you are actually going to use it.
 
 IMPORTANT: Always includes tool calls in your response until the task is completed. Response without tool calls will considered as completed with final answer.
 
@@ -32,6 +40,32 @@ When you have completed the task, please provide a summary of what you did and a
 If user asked a simple question without any coding context, answer it directly without using any tools.
 {{CLINE_RULES}}
 {{CLINE_METADATA}}`;
+
+export interface ComposeClineSystemPromptInput {
+	/**
+	 * Replaces the persona slot (the coding-agent-specific prompting) while
+	 * keeping the agent harness (environment block, tool-call loop contract,
+	 * completion instructions, rules/metadata placeholders). Used to apply an
+	 * agent profile's system prompt body to the main agent or a subagent.
+	 */
+	persona?: string;
+}
+
+export function composeClineSystemPrompt(
+	input: ComposeClineSystemPromptInput = {},
+): string {
+	const persona = input.persona?.trim();
+	// Replacer functions (not replacement strings) so persona content
+	// containing `$&`-style patterns is inserted literally.
+	return CLINE_SYSTEM_PROMPT_TEMPLATE.replace(
+		"{{AGENT_PERSONA}}",
+		() => persona || DEFAULT_CLINE_PERSONA,
+	).replace("{{AGENT_GUIDELINES}}", () =>
+		persona ? "" : `${DEFAULT_CLINE_WORKING_GUIDELINES}\n\n`,
+	);
+}
+
+export const DEFAULT_CLINE_SYSTEM_PROMPT = composeClineSystemPrompt();
 
 export const YOLO_CLINE_SYSTEM_PROMPT = `You are Cline, a careful and helpful coding agent that works in the background.
 You are tasked to solve an issue reported by the user who you cannot communicate with directly.

--- a/sdk/packages/shared/src/prompt/system.ts
+++ b/sdk/packages/shared/src/prompt/system.ts
@@ -15,12 +15,10 @@ export const DEFAULT_CLINE_WORKING_GUIDELINES = `Remember:
 
 Begin by analyzing the user's input and gathering any necessary additional context. Then, present your plan at the start of your response along with tool calls before proceeding with the task. It's OK for this section to be quite long.`;
 
-// The general agent harness prompting: environment block, tool-call loop
-// contract, completion instructions, and rules/metadata placeholders. The
-// {{AGENT_PERSONA}} slot holds the coding-agent-specific prompting and can be
-// swapped with an agent profile's system prompt body, while the harness is
-// preserved. {{AGENT_GUIDELINES}} holds the default working guidelines and
-// collapses to empty when a custom persona is active.
+// The agent harness: env block, tool-call loop contract, completion
+// instructions, and rules/metadata placeholders. {{AGENT_PERSONA}} and
+// {{AGENT_GUIDELINES}} hold the coding-agent-specific prompting; an agent
+// profile body replaces both while the harness is preserved.
 const CLINE_SYSTEM_PROMPT_TEMPLATE = `{{AGENT_PERSONA}}
 
 Environment you are running in:
@@ -46,12 +44,9 @@ export const AGENT_PERSONA_SLOT = "{{AGENT_PERSONA}}";
 
 export interface ComposeClineSystemPromptInput {
 	/**
-	 * Replaces the coding-agent-specific prompting (the default Cline persona
-	 * AND its working guidelines) while keeping the agent harness (environment
-	 * block, tool-call loop contract, completion instructions, rules/metadata
-	 * placeholders). A custom persona is expected to bring its own working
-	 * guidance. Used to apply an agent profile's system prompt body to the
-	 * main agent or a subagent.
+	 * Replaces the default Cline persona AND its working guidelines while
+	 * keeping the agent harness. A custom persona (e.g. an agent profile
+	 * body) is expected to bring its own working guidance.
 	 */
 	persona?: string;
 }
@@ -60,9 +55,8 @@ export function composeClineSystemPrompt(
 	input: ComposeClineSystemPromptInput = {},
 ): string {
 	const persona = input.persona?.trim();
-	// Guidelines are resolved before the persona is inserted, and replacer
-	// functions (not replacement strings) are used throughout, so persona
-	// content containing `{{...}}` or `$&`-style sequences stays literal.
+	// The persona is inserted last via a replacer function so `{{...}}` and
+	// `$&`-style sequences inside it stay literal.
 	return CLINE_SYSTEM_PROMPT_TEMPLATE.replace("{{AGENT_GUIDELINES}}", () =>
 		persona ? "" : `${DEFAULT_CLINE_WORKING_GUIDELINES}\n\n`,
 	).replace(AGENT_PERSONA_SLOT, () => persona || DEFAULT_CLINE_PERSONA);


### PR DESCRIPTION
Agent profiles are YAML files in `.cline/agents/*.yml` (workspace) and `~/.cline/agents/` (global) with frontmatter (`name`, `description`) plus a body that serves as a system prompt. Before this PR they were in a half-wired state: the SDK parsed them and the runtime builder registered each as a `subagent_<name>` tool, and the CLI listed them read-only in `/settings`, but there was no way to use a profile for the main Cline agent, no UI to switch, and the prompts subagents actually received were poor (more below). This PR completes the feature end to end.

<img width="767" height="672" alt="Code 2026-06-11 01 27 07" src="https://github.com/user-attachments/assets/32345a8a-1133-47a6-ab31-c74a88f695e9" />

#### 1. Persona/harness split of the base system prompt (sdk/packages/shared)

The core design decision: rather than letting a profile body replace the entire system prompt, `DEFAULT_CLINE_SYSTEM_PROMPT` is now composed from two parts:

- a persona slot: the coding-agent-specific prompting ("You are Cline, an AI coding agent..." identity intro plus the "Remember:" working guidelines)
- the agent harness: the environment block (platform/date/IDE/cwd), the tool-call loop contract ("Always includes tool calls in your response until the task is completed"), completion instructions, and the `{{CLINE_RULES}}`/`{{CLINE_METADATA}}` placeholders

`composeClineSystemPrompt({ persona })` swaps just the persona while keeping the harness, and `buildClineSystemPrompt` gains a `personaPrompt` option. A custom persona replaces both the identity and the default working guidelines (a profile brings its own guidance); the harness always survives. `overridePrompt` (`-s` flag, cron runner, ACP/connectors) and the yolo template are untouched and still win over `personaPrompt`.

The riskiest part of this refactor is that the default prompt must not change at all, since every existing session depends on it. The original constant contains a trailing space on one line that is load-bearing for byte-identity, so there is a test that pins `DEFAULT_CLINE_SYSTEM_PROMPT` against the verbatim pre-refactor literal. If you touch `system.ts` and that test fails, you changed the default prompt.

Two non-obvious correctness details that came out of review:

- All template replacements use replacer functions (`.replace(token, () => value)`) instead of replacement strings, because profile bodies and user rules can contain `$&`/`$'` sequences that `String.replace` would otherwise interpret. The pre-existing replacements had this latent bug too and were converted.
- Insertion order matters. If a profile body contains a literal `{{CLINE_RULES}}` or `{{PLATFORM_NAME}}`, naively inserting the persona first would let the body hijack the harness replacement. `buildClineSystemPrompt` therefore composes the harness with the persona slot left in place, resolves every other placeholder, and inserts the persona body as the very last replacement, so `{{...}}` sequences inside profile bodies stay literal. Same ordering inside `composeClineSystemPrompt` (guidelines slot resolves before the persona).

#### 2. Subagent prompts adopt the persona slot (sdk/packages/core)

`buildSubAgentSystemPrompt` previously used `overridePrompt`, which fully replaced the system prompt for cline-provider subagents, and for non-cline providers it returned the raw profile body with nothing else. That means subagents spawned from profiles ran with no environment info and no tool-loop contract, which is likely a big part of why profile subagents underperformed.

Now the spawn prompt fills the persona slot for all providers: subagents keep the env block and loop contract. The non-cline early return was removed deliberately: the harness is provider-agnostic (SessionRuntime's iteration loop relies on those conventions regardless of provider) and the Cline-specific workspace metadata is already gated on `providerId` inside `buildClineSystemPrompt`. This covers both configured-agent subagents and ad-hoc `spawn_agent` calls since both funnel through `buildDelegatedAgentConfig`. Teammate prompts are intentionally unchanged (different wrapping design: role injected via rules under the default persona).

One subtlety: parent agents sometimes compose spawn prompts that already embed a `# Workspace Configuration` block. Metadata injection is skipped when the persona already contains the marker, so it never appears twice (there is an existing spawn-agent test guarding exactly this, which caught the issue during development).

#### 3. CLI: main-agent profile selection (apps/cli)

- `/agents` opens a dialog selector (searchable list, workspace/global sections, "(current)" marker), following the `ProviderPickerContent` + `useSearchableList` pattern. Hidden `/agent` alias, command palette entry (Opt+T), `/help` listing. Broken YAML files are listed in the selector footer with their parse error instead of being silently dropped.
- Selecting a profile captures `name`/`description`/`systemPrompt` onto `config.agentProfile`, re-resolves the system prompt with the body in the persona slot, and restarts the session in place keeping the transcript (`restartWithCurrentMessages`, same flow `/model` and compaction changes use). Selecting "Cline (default)" reverts.
- A `◆ profile-name` indicator renders in the status bar next to the Plan/Act toggle (only when a non-default profile is active), clickable to reopen the selector. Its width participates in the status bar fit math so the model name truncates correctly.
- Plan/act toggles preserve the active profile: `applyInteractiveModeConfig` threads `config.agentProfile?.systemPrompt` into `resolveSystemPrompt`, so the plan-mode instructions (which ride in via rules, orthogonal to the persona slot) compose naturally with a profile.
- Selection is session-only by design: nothing is persisted to settings. The profile body is captured at selection time, so deleting the file mid-session does not break the running session.
- `--agent <name>` flag for non-interactive runs. Case-insensitive name match; a miss errors with the list of available profiles plus any parse errors. Rejected in yolo mode (yolo has a structurally different prompt with no persona slot and `enableSpawnAgent` off).
- The duplicated regex frontmatter parser in `interactive-config.ts` was deleted; the `/settings` agents list now reuses the SDK's `loadConfiguredAgentConfigs`, and broken files remain visible there with their load error.

Scope note agreed up front: only `name`/`description`/body apply to the main agent. `providerId`/`modelId`/`tools`/`maxIterations` in profile frontmatter remain subagent-spawn concerns; a profile selected for the main agent is still independently available as a `subagent_*` tool.

On the "subagents don't work" suspicion that partly motivated this: the `subagent_<name>` tool registration was actually already live in CLI sessions (`enableSpawnAgent: !isYoloMode` flows into `DefaultRuntimeBuilder`, including hub-backed sessions since the daemon runs with cwd=workspaceRoot and resolves the same `.cline/agents`). The real gaps were prompt quality (fixed by the persona slot), error discoverability (parse failures only went to a debug logger; now surfaced in `/agents` and `/settings`), and the missing main-agent selection.

