### PR TITLE
test(vscode): exercise full SDK structured edit flow in file-edit e2e

### DIFF
--- a/apps/vscode/src/test/e2e/diff.test.ts
+++ b/apps/vscode/src/test/e2e/diff.test.ts
@@ -3,13 +3,12 @@ import * as path from "node:path"
 import { expect } from "@playwright/test"
 import { E2E_WORKSPACE_TYPES, e2e } from "./utils/helpers"
 
-// NOTE ON BEHAVIORAL DIFFERENCE FROM THE CLASSIC EXTENSION:
-// Under the SDK runtime, file edits are performed by the SDK's `editor` tool
-// executor, which writes the file directly (Node fs) after the user approves
-// the tool call — it does NOT stream the edit through DiffViewProvider, so no
-// "test.ts: Original ↔ Cline's Changes" diff tab opens. This test asserts the
-// SDK edit flow instead: approval ask row → Save → file modified on disk →
-// turn-ending completion text.
+// File edits are performed by the SDK's `editor` tool executor, which writes
+// the file directly (Node fs) after the user approves the tool call — it does
+// not stream the edit through DiffViewProvider, so no diff editor tab (e.g.
+// "test.ts: Original ↔ Cline's Changes") opens. This test therefore asserts
+// the approval flow rather than a diff editor: approval ask row → Save →
+// file modified on disk → turn-ending completion text.
 e2e.describe("Diff Editor", () => {
 	E2E_WORKSPACE_TYPES.forEach(({ title, workspaceType }) => {
 		e2e.extend({

--- a/apps/vscode/src/test/e2e/diff.test.ts
+++ b/apps/vscode/src/test/e2e/diff.test.ts
@@ -20,9 +20,11 @@ e2e.describe("Diff Editor", () => {
 			// multi-root workspaces (fixtures/workspace). The fixture file is
 			// checked into git, so restore it after the (real) edit.
 			const editedFilePath = path.join(workspaceDir, "test.ts")
-			const originalFileContent = readFileSync(editedFilePath, "utf-8")
+			let originalFileContent: string | undefined
 
 			try {
+				originalFileContent = readFileSync(editedFilePath, "utf-8")
+
 				await helper.signin(sidebar)
 
 				const inputbox = sidebar.getByTestId("chat-input")
@@ -68,7 +70,11 @@ e2e.describe("Diff Editor", () => {
 				// The edit was actually applied to the file on disk.
 				expect(readFileSync(editedFilePath, "utf-8")).toContain('export const name = "cline"')
 			} finally {
-				writeFileSync(editedFilePath, originalFileContent, "utf-8")
+				// Skip the restore when the initial read failed — there is
+				// nothing to restore and the read error is the real failure.
+				if (originalFileContent !== undefined) {
+					writeFileSync(editedFilePath, originalFileContent, "utf-8")
+				}
 			}
 		})
 	})

--- a/apps/vscode/src/test/e2e/diff.test.ts
+++ b/apps/vscode/src/test/e2e/diff.test.ts
@@ -1,46 +1,75 @@
+import { readFileSync, writeFileSync } from "node:fs"
+import * as path from "node:path"
 import { expect } from "@playwright/test"
 import { E2E_WORKSPACE_TYPES, e2e } from "./utils/helpers"
 
+// NOTE ON BEHAVIORAL DIFFERENCE FROM THE CLASSIC EXTENSION:
+// Under the SDK runtime, file edits are performed by the SDK's `editor` tool
+// executor, which writes the file directly (Node fs) after the user approves
+// the tool call — it does NOT stream the edit through DiffViewProvider, so no
+// "test.ts: Original ↔ Cline's Changes" diff tab opens. This test asserts the
+// SDK edit flow instead: approval ask row → Save → file modified on disk →
+// turn-ending completion text.
 e2e.describe("Diff Editor", () => {
 	E2E_WORKSPACE_TYPES.forEach(({ title, workspaceType }) => {
 		e2e.extend({
 			workspaceType,
-		})(title, async ({ helper, sidebar }) => {
-			await helper.signin(sidebar)
+		})(title, async ({ helper, sidebar, workspaceDir }) => {
+			// The mock editor tool call targets "test.ts" relative to the session
+			// cwd, which is the first workspace folder in both single-root and
+			// multi-root workspaces (fixtures/workspace). The fixture file is
+			// checked into git, so restore it after the (real) edit.
+			const editedFilePath = path.join(workspaceDir, "test.ts")
+			const originalFileContent = readFileSync(editedFilePath, "utf-8")
 
-			const inputbox = sidebar.getByTestId("chat-input")
-			await expect(inputbox).toBeVisible()
+			try {
+				await helper.signin(sidebar)
 
-			await inputbox.fill("[diff.test.ts] Hello, Cline!")
-			await expect(inputbox).toHaveValue("[diff.test.ts] Hello, Cline!")
-			await sidebar.getByTestId("send-button").click()
-			await expect(inputbox).toHaveValue("")
+				const inputbox = sidebar.getByTestId("chat-input")
+				await expect(inputbox).toBeVisible()
 
-			// Wait for the (mock) agent turn to finish before navigating away —
-			// the task is persisted to SDK session history when the turn completes,
-			// and the mock server delays this response by 500ms.
-			await expect(sidebar.getByText("mock Cline API response")).toBeVisible()
+				await inputbox.fill("[diff.test.ts] Hello, Cline!")
+				await expect(inputbox).toHaveValue("[diff.test.ts] Hello, Cline!")
+				await sidebar.getByTestId("send-button").click()
+				await expect(inputbox).toHaveValue("")
 
-			// Back to home page with history. The turn ends in "awaiting_followup"
-			// (the mock response has no attempt_completion), so the footer shows no
-			// "Start New Task" button — use the header "New Task" button instead,
-			// same as chat.test.ts.
-			await sidebar.getByRole("button", { name: "New Task", exact: true }).first().click()
-			await expect(sidebar.getByText("Recent")).toBeVisible()
-			await expect(sidebar.getByText("Hello, Cline!")).toBeVisible() // History with the previous sent message
+				// Wait for the (mock) agent turn to finish before navigating away —
+				// the task is persisted to SDK session history when the turn completes,
+				// and the mock server delays this response by 500ms.
+				await expect(sidebar.getByText("mock Cline API response")).toBeVisible()
 
-			// Submit a file edit request
-			await sidebar.getByTestId("chat-input").click()
-			await sidebar.getByTestId("chat-input").fill("edit_request")
-			await sidebar.getByTestId("send-button").click({ delay: 50 })
+				// Back to home page with history. The turn ends in "awaiting_followup"
+				// (the mock response has no attempt_completion), so the footer shows no
+				// "Start New Task" button — use the header "New Task" button instead,
+				// same as chat.test.ts.
+				await sidebar.getByRole("button", { name: "New Task", exact: true }).first().click()
+				await expect(sidebar.getByText("Recent")).toBeVisible()
+				await expect(sidebar.getByText("Hello, Cline!")).toBeVisible() // History with the previous sent message
 
-			// Wait for the sidebar to load the file edit request
-			await sidebar.waitForSelector('span:has-text("Cline wants to edit this file:")')
+				// Submit a file edit request. The mock server responds with a
+				// structured `editor` tool call (path: test.ts, old/new text).
+				await sidebar.getByTestId("chat-input").click()
+				await sidebar.getByTestId("chat-input").fill("edit_request")
+				await sidebar.getByTestId("send-button").click({ delay: 50 })
 
-			// The SDK-backed path renders a pending edit approval before the user saves it.
-			await expect(sidebar.getByText(/\/test\.ts/)).toBeVisible()
-			await expect(sidebar.getByRole("button", { name: "Save" })).toBeVisible()
-			await expect(sidebar.getByRole("button", { name: "Reject" })).toBeVisible()
+				// The edit tool requires approval (edit tools are never auto-approved
+				// by default) — the ask row appears with the file path and diff.
+				await sidebar.waitForSelector('span:has-text("Cline wants to edit this file:")')
+				await expect(sidebar.getByText("test.ts").first()).toBeVisible()
+				await expect(sidebar.getByRole("button", { name: "Reject" })).toBeVisible()
+
+				// Approve the edit ("Save" is the primary button for file-edit asks).
+				await sidebar.getByRole("button", { name: "Save", exact: true }).click({ delay: 50 })
+
+				// The SDK executes the editor tool and sends the tool result back to
+				// the (mock) model, which replies with turn-ending completion text.
+				await expect(sidebar.getByText("I successfully replaced")).toBeVisible({ timeout: 30_000 })
+
+				// The edit was actually applied to the file on disk.
+				expect(readFileSync(editedFilePath, "utf-8")).toContain('export const name = "cline"')
+			} finally {
+				writeFileSync(editedFilePath, originalFileContent, "utf-8")
+			}
 		})
 	})
 })

--- a/apps/vscode/src/test/e2e/file-edit.test.ts
+++ b/apps/vscode/src/test/e2e/file-edit.test.ts
@@ -6,10 +6,10 @@ import { E2E_WORKSPACE_TYPES, e2e } from "./utils/helpers"
 // File edits are performed by the SDK's `editor` tool executor, which writes
 // the file directly (Node fs) after the user approves the tool call — it does
 // not stream the edit through DiffViewProvider, so no diff editor tab (e.g.
-// "test.ts: Original ↔ Cline's Changes") opens. This test therefore asserts
-// the approval flow rather than a diff editor: approval ask row → Save →
-// file modified on disk → turn-ending completion text.
-e2e.describe("Diff Editor", () => {
+// "test.ts: Original ↔ Cline's Changes") opens. This test asserts the
+// approval flow: approval ask row → Save → file modified on disk →
+// turn-ending completion text.
+e2e.describe("File Edit Approval", () => {
 	E2E_WORKSPACE_TYPES.forEach(({ title, workspaceType }) => {
 		e2e.extend({
 			workspaceType,
@@ -26,31 +26,11 @@ e2e.describe("Diff Editor", () => {
 
 				await helper.signin(sidebar)
 
-				const inputbox = sidebar.getByTestId("chat-input")
-				await expect(inputbox).toBeVisible()
-
-				await inputbox.fill("[diff.test.ts] Hello, Cline!")
-				await expect(inputbox).toHaveValue("[diff.test.ts] Hello, Cline!")
-				await sidebar.getByTestId("send-button").click()
-				await expect(inputbox).toHaveValue("")
-
-				// Wait for the (mock) agent turn to finish before navigating away —
-				// the task is persisted to SDK session history when the turn completes,
-				// and the mock server delays this response by 500ms.
-				await expect(sidebar.getByText("mock Cline API response")).toBeVisible()
-
-				// Back to home page with history. The turn ends in "awaiting_followup"
-				// (the mock response has no attempt_completion), so the footer shows no
-				// "Start New Task" button — use the header "New Task" button instead,
-				// same as chat.test.ts.
-				await sidebar.getByRole("button", { name: "New Task", exact: true }).first().click()
-				await expect(sidebar.getByText("Recent")).toBeVisible()
-				await expect(sidebar.getByText("Hello, Cline!")).toBeVisible() // History with the previous sent message
-
 				// Submit a file edit request. The mock server responds with a
 				// structured `editor` tool call (path: test.ts, old/new text).
-				await sidebar.getByTestId("chat-input").click()
-				await sidebar.getByTestId("chat-input").fill("edit_request")
+				const inputbox = sidebar.getByTestId("chat-input")
+				await expect(inputbox).toBeVisible()
+				await inputbox.fill("edit_request")
 				await sidebar.getByTestId("send-button").click({ delay: 50 })
 
 				// The edit tool requires approval (edit tools are never auto-approved

--- a/apps/vscode/src/test/e2e/fixtures/server/api.ts
+++ b/apps/vscode/src/test/e2e/fixtures/server/api.ts
@@ -29,58 +29,42 @@ export const E2E_REGISTERED_MOCK_ENDPOINTS = {
 	},
 }
 
-const replace_in_file = `I successfully replaced "john" with "cline" in the test.ts file. The change has been completed and the file now contains:
+/**
+ * Structured `editor` tool call streamed in response to the `edit_request` prompt.
+ *
+ * The SDK runtime only executes structured (OpenAI-format) tool calls — unlike
+ * the classic extension, it does not parse XML-style tool syntax (e.g.
+ * `<replace_in_file>`) out of assistant text. The mock server streams this as
+ * `choices[].delta.tool_calls[]` deltas followed by `finish_reason: "tool_calls"`.
+ *
+ * The `path` is workspace-relative; the SDK editor executor resolves relative
+ * paths against the session cwd, which is the first workspace folder in both
+ * the single-root and multi-root e2e workspaces (`fixtures/workspace`).
+ */
+export const E2E_MOCK_EDITOR_TOOL_CALL = {
+	id: "call_e2e_edit_1",
+	name: "editor",
+	arguments: {
+		path: "test.ts",
+		old_text: 'export const name = "john"',
+		new_text: 'export const name = "cline"',
+	},
+}
+
+const edit_request_complete = `I successfully replaced "john" with "cline" in the test.ts file. The change has been completed and the file now contains:
 
 \`\`\`typescript
 export const name = "cline"
 \`\`\`
 
-The TypeScript errors shown in the output are unrelated to this change - they appear to be existing issues in the broader codebase related to missing type definitions and dependencies. The specific task of updating the name in test.ts has been completed successfully.
-
-<attempt_completion>
-<result>
-I have successfully replaced the name "john" with "cline" in the test.ts file. The file now exports:
-
-\`\`\`typescript
-export const name = "cline"
-\`\`\`
-
-The change has been applied and saved to the file.
-</result>
-</attempt_completion>`
-
-const edit_request = `<thinking>
-The user wants me to replace the name "john" with "cline" in the test.ts file. I can see the file content provided:
-
-\`\`\`typescript
-export const name = "john"
-\`\`\`
-
-I need to change "john" to "cline". This is a simple targeted edit, so I should use the replace_in_file tool rather than write_to_file since I'm only changing one small part of the file.
-
-I need to:
-1. Use replace_in_file to change "john" to "cline" in the test.ts file
-2. The SEARCH block should match the exact content: \`export const name = "john"\`
-3. The REPLACE block should be: \`export const name = "cline"\`
-</thinking>
-
-I'll replace "john" with "cline" in the test.ts file.
-
-<replace_in_file>
-<path>test.ts</path>
-<diff>
-------- SEARCH
-export const name = "john"
-=======
-export const name = "cline"
-+++++++ REPLACE
-</diff>
-</replace_in_file>`
+The change has been applied and saved to the file.`
 
 export const E2E_MOCK_API_RESPONSES = {
 	DEFAULT: "Hello! I'm a mock Cline API response.",
-	REPLACE_REQUEST: replace_in_file,
-	EDIT_REQUEST: edit_request,
+	/** Assistant text streamed before the structured editor tool call. */
+	EDIT_REQUEST_LEAD_IN: `I'll replace "john" with "cline" in the test.ts file.`,
+	/** Turn-ending text streamed after the SDK reports the editor tool result. */
+	EDIT_REQUEST_COMPLETE: edit_request_complete,
 }
 
 export const E2E_MOCK_CLINE_RECOMMENDED_MODELS = {

--- a/apps/vscode/src/test/e2e/fixtures/server/api.ts
+++ b/apps/vscode/src/test/e2e/fixtures/server/api.ts
@@ -30,12 +30,11 @@ export const E2E_REGISTERED_MOCK_ENDPOINTS = {
 }
 
 /**
- * Structured `editor` tool call streamed in response to the `edit_request` prompt.
- *
- * The SDK runtime only executes structured (OpenAI-format) tool calls — unlike
- * the classic extension, it does not parse XML-style tool syntax (e.g.
- * `<replace_in_file>`) out of assistant text. The mock server streams this as
- * `choices[].delta.tool_calls[]` deltas followed by `finish_reason: "tool_calls"`.
+ * Structured `editor` tool call streamed in response to the `edit_request`
+ * prompt. The mock server streams it as OpenAI-format
+ * `choices[].delta.tool_calls[]` deltas followed by
+ * `finish_reason: "tool_calls"`, which is the only tool-call syntax the SDK
+ * runtime executes.
  *
  * The `path` is workspace-relative; the SDK editor executor resolves relative
  * paths against the session cwd, which is the first workspace folder in both

--- a/apps/vscode/src/test/e2e/fixtures/server/index.ts
+++ b/apps/vscode/src/test/e2e/fixtures/server/index.ts
@@ -6,6 +6,7 @@ import {
 	E2E_MOCK_API_RESPONSES,
 	E2E_MOCK_CLINE_MODELS,
 	E2E_MOCK_CLINE_RECOMMENDED_MODELS,
+	E2E_MOCK_EDITOR_TOOL_CALL,
 	E2E_REGISTERED_MOCK_ENDPOINTS,
 } from "./api"
 import { ClineDataMock } from "./data"
@@ -472,18 +473,31 @@ export class ClineApiServerMock {
 
 						const body = await readBody()
 						const parsed = JSON.parse(body)
-						const { _messages, model = "claude-3-5-sonnet-20241022", stream = true } = parsed
+						const { messages, model = "claude-3-5-sonnet-20241022", stream = true } = parsed
+
+						// The SDK runtime executes structured tool calls and then sends a
+						// follow-up /chat/completions request containing the tool result as
+						// a `role: "tool"` message. Detect that follow-up first — the
+						// original "edit_request" user prompt is still present in the
+						// conversation history of the follow-up request, so order matters.
+						const hasToolResult =
+							Array.isArray(messages) && messages.some((m: { role?: string }) => m?.role === "tool")
+
 						let responseText = E2E_MOCK_API_RESPONSES.DEFAULT
-						const isEditRequest = body.includes("edit_request")
+						let includeEditorToolCall = false
 						log("Chat completion mock selection:", {
-							isEditRequest,
-							isReplaceResult: body.includes("[replace_in_file for 'test.ts'] Result:"),
+							isEditRequest: body.includes("edit_request"),
+							hasToolResult,
 						})
-						if (body.includes("[replace_in_file for 'test.ts'] Result:")) {
-							responseText = E2E_MOCK_API_RESPONSES.REPLACE_REQUEST
-						}
-						if (isEditRequest) {
-							responseText = E2E_MOCK_API_RESPONSES.EDIT_REQUEST
+						if (hasToolResult) {
+							responseText = E2E_MOCK_API_RESPONSES.EDIT_REQUEST_COMPLETE
+						} else if (body.includes("edit_request")) {
+							// Stream a structured `editor` tool call (OpenAI tool_calls
+							// deltas) after the lead-in text. The classic XML-in-prose
+							// replace_in_file response no longer works: the SDK does not
+							// parse tool syntax out of assistant text.
+							responseText = E2E_MOCK_API_RESPONSES.EDIT_REQUEST_LEAD_IN
+							includeEditorToolCall = true
 						}
 						if (body.includes("[diff.test.ts] Hello, Cline!")) {
 							// The playwright test in diff.test.ts needs the "API Request..." text
@@ -503,67 +517,43 @@ export class ClineApiServerMock {
 
 							const randomUUID = uuidv4()
 
-							if (isEditRequest) {
-								const toolCallId = `call_${randomUUID}`
-								const toolCallChunk = {
-									id: generationId,
-									object: "chat.completion.chunk",
-									created: Math.floor(Date.now() / 1000),
-									model,
-									choices: [
-										{
-											index: 0,
-											delta: {
-												tool_calls: [
-													{
-														index: 0,
-														id: toolCallId,
-														type: "function",
-														function: {
-															name: "editor",
-															arguments: JSON.stringify({
-																path: "test.ts",
-																old_text: 'export const name = "john"',
-																new_text: 'export const name = "cline"',
-															}),
-														},
-													},
-												],
-											},
-											finish_reason: null,
-										},
-									],
-								}
-								const finalChunk = {
-									id: generationId,
-									object: "chat.completion.chunk",
-									created: Math.floor(Date.now() / 1000),
-									model,
-									choices: [
-										{
-											index: 0,
-											delta: {},
-											finish_reason: "tool_calls",
-										},
-									],
-									usage: {
-										prompt_tokens: 140,
-										completion_tokens: responseText.length,
-										total_tokens: 140 + responseText.length,
-										cost: (140 + responseText.length) * 0.00015,
-									},
-								}
-								res.write(`data: ${JSON.stringify(toolCallChunk)}\n\n`)
-								res.write(`data: ${JSON.stringify(finalChunk)}\n\n`)
-								res.write("data: [DONE]\n\n")
-								res.end()
-								return
-							}
-
 							responseText += `\n\nGenerated UUID: ${randomUUID}`
 
 							const chunks = responseText.split(" ")
 							let chunkIndex = 0
+
+							// OpenAI-format streamed tool call deltas, matching what the
+							// AI SDK's openai-compatible client expects: the first delta
+							// for a tool_calls index must carry `id` + `function.name`;
+							// `function.arguments` accumulates as string fragments. Split
+							// the arguments JSON to exercise fragment reassembly.
+							const argumentsJson = JSON.stringify(E2E_MOCK_EDITOR_TOOL_CALL.arguments)
+							const argsSplitAt = Math.floor(argumentsJson.length / 2)
+							const toolCallDeltas = includeEditorToolCall
+								? [
+										[
+											{
+												index: 0,
+												id: E2E_MOCK_EDITOR_TOOL_CALL.id,
+												type: "function",
+												function: { name: E2E_MOCK_EDITOR_TOOL_CALL.name, arguments: "" },
+											},
+										],
+										[
+											{
+												index: 0,
+												function: { arguments: argumentsJson.slice(0, argsSplitAt) },
+											},
+										],
+										[
+											{
+												index: 0,
+												function: { arguments: argumentsJson.slice(argsSplitAt) },
+											},
+										],
+									]
+								: []
+							let toolCallDeltaIndex = 0
 
 							const sendChunk = () => {
 								if (chunkIndex < chunks.length) {
@@ -585,6 +575,25 @@ export class ClineApiServerMock {
 									res.write(`data: ${JSON.stringify(chunk)}\n\n`)
 									chunkIndex++
 									setTimeout(sendChunk, 10)
+								} else if (toolCallDeltaIndex < toolCallDeltas.length) {
+									const chunk = {
+										id: generationId,
+										object: "chat.completion.chunk",
+										created: Math.floor(Date.now() / 1000),
+										model,
+										choices: [
+											{
+												index: 0,
+												delta: {
+													tool_calls: toolCallDeltas[toolCallDeltaIndex],
+												},
+												finish_reason: null,
+											},
+										],
+									}
+									res.write(`data: ${JSON.stringify(chunk)}\n\n`)
+									toolCallDeltaIndex++
+									setTimeout(sendChunk, 10)
 								} else {
 									const finalChunk = {
 										id: generationId,
@@ -595,7 +604,7 @@ export class ClineApiServerMock {
 											{
 												index: 0,
 												delta: {},
-												finish_reason: "stop",
+												finish_reason: includeEditorToolCall ? "tool_calls" : "stop",
 											},
 										],
 										usage: {

--- a/apps/vscode/src/test/e2e/fixtures/server/index.ts
+++ b/apps/vscode/src/test/e2e/fixtures/server/index.ts
@@ -496,10 +496,9 @@ export class ClineApiServerMock {
 						if (hasToolResult) {
 							responseText = E2E_MOCK_API_RESPONSES.EDIT_REQUEST_COMPLETE
 						} else if (body.includes("edit_request")) {
-							// Stream a structured `editor` tool call (OpenAI tool_calls
-							// deltas) after the lead-in text. The classic XML-in-prose
-							// replace_in_file response no longer works: the SDK does not
-							// parse tool syntax out of assistant text.
+							// Stream lead-in text followed by a structured `editor` tool
+							// call (OpenAI tool_calls deltas) — the only tool-call syntax
+							// the SDK runtime executes.
 							responseText = E2E_MOCK_API_RESPONSES.EDIT_REQUEST_LEAD_IN
 							includeEditorToolCall = true
 						}

--- a/apps/vscode/src/test/e2e/fixtures/server/index.ts
+++ b/apps/vscode/src/test/e2e/fixtures/server/index.ts
@@ -480,8 +480,12 @@ export class ClineApiServerMock {
 						// a `role: "tool"` message. Detect that follow-up first — the
 						// original "edit_request" user prompt is still present in the
 						// conversation history of the follow-up request, so order matters.
+						// Scoped to edit_request conversations so tool results from other
+						// (future) scenarios don't mis-route to EDIT_REQUEST_COMPLETE.
 						const hasToolResult =
-							Array.isArray(messages) && messages.some((m: { role?: string }) => m?.role === "tool")
+							body.includes("edit_request") &&
+							Array.isArray(messages) &&
+							messages.some((m: { role?: string }) => m?.role === "tool")
 
 						let responseText = E2E_MOCK_API_RESPONSES.DEFAULT
 						let includeEditorToolCall = false

--- a/apps/vscode/src/test/e2e/fixtures/server/index.ts
+++ b/apps/vscode/src/test/e2e/fixtures/server/index.ts
@@ -502,13 +502,6 @@ export class ClineApiServerMock {
 							responseText = E2E_MOCK_API_RESPONSES.EDIT_REQUEST_LEAD_IN
 							includeEditorToolCall = true
 						}
-						if (body.includes("[diff.test.ts] Hello, Cline!")) {
-							// The playwright test in diff.test.ts needs the "API Request..." text
-							// to be on the screen long enough to detect it.  This worked at 100ms
-							// too, but setting to 500ms to cover slower CI boxes.
-							await new Promise((resolve) => setTimeout(resolve, 500))
-						}
-
 						const generationId = `gen_${++controller.generationCounter}_${Date.now()}`
 
 						if (stream) {


### PR DESCRIPTION
### Description

`diff.test.ts` was the last failing e2e suite on the SDK-migration branch. The classic extension parsed XML-style tool calls (`<replace_in_file>…`) out of assistant prose; the SDK runtime only executes structured (OpenAI-format) `tool_calls`. #11441 already converted the mock server's `edit_request` response to a structured `editor` tool call and relaxed the test to assert the approval row renders. This PR builds on that and exercises the **full edit flow end-to-end**:

**Mock server (`fixtures/server/`)**
- Removed the dead XML-era `EDIT_REQUEST` / `REPLACE_REQUEST` responses and the classic-era follow-up matcher (`"[replace_in_file for 'test.ts'] Result:"`), which can never match SDK traffic.
- The structured `editor` tool call is now streamed as multiple `choices[].delta.tool_calls[]` deltas with the arguments JSON split across fragments (first delta carries `index`+`id`+`function.name`; later deltas append `function.arguments`), exercising the AI SDK's fragment-reassembly path, followed by `finish_reason: "tool_calls"`. A lead-in text delta precedes the tool call.
- After the user approves and the SDK executes the tool, it POSTs a follow-up `/chat/completions` containing the tool result as a `role: "tool"` message. The mock now detects that (shape-based, not string matching) and replies with turn-ending completion text.

**Test (`diff.test.ts`)**
- Now covers the full flow: approval ask row ("Cline wants to edit this file:") → Save/Reject buttons → click **Save** → editor tool writes the file → completion text renders → the edit is verified **on disk** → the git-tracked fixture (`fixtures/workspace/test.ts`) is restored in `finally`.
- Renamed the test to be about editing, since there's no diff view streaming any more: the SDK `editor` executor writes via Node fs and does not route through `DiffViewProvider`, so the old `test.ts: Original ↔ Cline's Changes` diff-tab assertion is unreachable (verified: `VscodeSessionHost` does not override the editor executor and nothing in `apps/vscode/src/sdk/` touches `DiffViewProvider`).
- De-duped some parts of the test covered elsewhere.
- Relative-path resolution verified for both workspace types: the SDK session cwd is the first workspace folder, which is `fixtures/workspace` in both the single-root and multi-root e2e workspaces.

### Test Procedure

- `npx playwright test` (Windows, locally built `dist/e2e.vsix` from this branch): **7/7 passed** — auth, chat, editor ×2, diff ×2.
- `chat.test.ts` regression check: the default mock reply path (`DEFAULT`) is untouched and the structured tool call only triggers for the `edit_request` prompt; chat test passes.
- Verified the fixture file `fixtures/workspace/test.ts` is back to `export const name = "john"` after the runs (the test performs a *real* edit and restores it).
- `tsc --noEmit` and `biome format`/`lint` clean on the touched files.
- Streamed `tool_calls` wire format checked against `@ai-sdk/openai-compatible`'s chunk schema/parser (first delta must carry `id` + `function.name`; arguments accumulate as string fragments).

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

- Test-only changes; no extension or webview runtime code is touched.