### PR TITLE
Add the FeatureFlagService to the SDK [NOOP]

### DIFF
--- a/sdk/packages/core/src/ClineCore.test.ts
+++ b/sdk/packages/core/src/ClineCore.test.ts
@@ -18,6 +18,7 @@ vi.mock("./runtime/host/host", () => ({
 
 import type { AgentResult } from "@cline/shared";
 import { ClineCore } from "./ClineCore";
+import { NoOpFeatureFlagsProvider } from "./services/feature-flags";
 
 function createStartInput(): ClineCoreStartInput {
 	return {
@@ -329,6 +330,58 @@ describe("ClineCore", () => {
 			expect.objectContaining({ event: "session.started" }),
 		);
 		expect(coreTelemetry.capture).not.toHaveBeenCalled();
+	});
+
+	it("wraps an injected feature flags provider", async () => {
+		const host = {
+			runtimeAddress: undefined,
+			startSession: vi.fn(),
+			runTurn: vi.fn(),
+			getAccumulatedUsage: vi.fn(),
+			abort: vi.fn(),
+			stopSession: vi.fn(),
+			dispose: vi.fn(),
+			getSession: vi.fn(async () => undefined),
+			listSessions: vi.fn(),
+			deleteSession: vi.fn(),
+			readSessionMessages: vi.fn(),
+			subscribe: vi.fn(() => () => {}),
+			updateSessionModel: vi.fn(),
+		};
+		createRuntimeHostMock.mockResolvedValue(host);
+		const provider = new NoOpFeatureFlagsProvider();
+
+		const core = await ClineCore.create({ featureFlags: provider });
+
+		expect(core.featureFlags.getProvider()).toBe(provider);
+		await core.dispose();
+	});
+
+	it("uses a no-op feature flags provider by default", async () => {
+		const host = {
+			runtimeAddress: undefined,
+			startSession: vi.fn(),
+			runTurn: vi.fn(),
+			getAccumulatedUsage: vi.fn(),
+			abort: vi.fn(),
+			stopSession: vi.fn(),
+			dispose: vi.fn(),
+			getSession: vi.fn(async () => undefined),
+			listSessions: vi.fn(),
+			deleteSession: vi.fn(),
+			readSessionMessages: vi.fn(),
+			subscribe: vi.fn(() => () => {}),
+			updateSessionModel: vi.fn(),
+		};
+		createRuntimeHostMock.mockResolvedValue(host);
+
+		const core = await ClineCore.create();
+
+		expect(core.featureFlags.getProvider()).toBeInstanceOf(
+			NoOpFeatureFlagsProvider,
+		);
+		await core.dispose();
+		expect(host.dispose).toHaveBeenCalledTimes(1);
 	});
 
 	it("hydrates list rows through the core API", async () => {

--- a/sdk/packages/core/src/ClineCore.ts
+++ b/sdk/packages/core/src/ClineCore.ts
@@ -395,8 +395,6 @@ export class ClineCore {
 		try {
 			await this.automationService?.dispose();
 			await this.host.dispose(...args);
-			await this.featureFlags.dispose().catch(this.logger?.error);
-			await this.telemetry?.dispose().catch(this.logger?.error);
 		} finally {
 			this.unsubscribeBootstrapCleanup();
 			const sessionIds = [...this.activeSessionBootstraps.keys()];

--- a/sdk/packages/core/src/ClineCore.ts
+++ b/sdk/packages/core/src/ClineCore.ts
@@ -42,6 +42,11 @@ import type {
 	StartSessionInput,
 	StartSessionResult,
 } from "./runtime/host/runtime-host";
+import {
+	FeatureFlagsService,
+	NoOpFeatureFlagsProvider,
+} from "./services/feature-flags";
+import { resolveCoreDistinctId } from "./services/telemetry/distinct-id";
 import type { CoreSessionEvent } from "./types/events";
 import type { SessionHistoryRecord } from "./types/sessions";
 
@@ -86,6 +91,7 @@ export class ClineCore {
 	readonly runtimeAddress: string | undefined;
 	readonly automation: ClineCoreAutomationApi;
 	readonly settings: ClineCoreSettingsApi;
+	readonly featureFlags: FeatureFlagsService;
 	readonly pendingPrompts: PendingPromptsServiceApi;
 	private readonly host: RuntimeHost;
 	private readonly prepare: ClineCoreOptions["prepare"] | undefined;
@@ -109,6 +115,7 @@ export class ClineCore {
 		logger: BasicLogger | undefined,
 		telemetry: ITelemetryService | undefined,
 		distinctId: string | undefined,
+		featureFlags: FeatureFlagsService,
 		automationOptions:
 			| (ClineCoreAutomationOptions & { logger?: BasicLogger })
 			| undefined,
@@ -121,6 +128,7 @@ export class ClineCore {
 		this.logger = logger;
 		this.telemetry = telemetry;
 		this.distinctId = distinctId;
+		this.featureFlags = featureFlags;
 		this.settings = createClineCoreSettingsApi(host);
 		this.pendingPrompts = createClineCorePendingPromptsApi(host);
 		this.automation = new ClineCoreAutomationController(() => {
@@ -187,9 +195,20 @@ export class ClineCore {
 	 * ```
 	 */
 	static async create(options: ClineCoreOptions = {}): Promise<ClineCore> {
+		const distinctId = resolveCoreDistinctId(options.distinctId);
 		const capabilities = normalizeRuntimeCapabilities(options.capabilities);
-		const host = await createRuntimeHost({ ...options, capabilities });
+		const normalizedOptions = { ...options, capabilities, distinctId };
+		const host = await createRuntimeHost(normalizedOptions);
 		const automationOptions = normalizeAutomationOptions(options.automation);
+		const featureFlags = new FeatureFlagsService({
+			provider: options.featureFlags ?? new NoOpFeatureFlagsProvider(),
+			telemetry: options.telemetry,
+			logger: options.logger,
+			context: {
+				distinctId,
+				clientName: options.clientName,
+			},
+		});
 		const core = new ClineCore(
 			host,
 			options.clientName,
@@ -198,7 +217,8 @@ export class ClineCore {
 			capabilities,
 			options.logger,
 			options.telemetry,
-			options.distinctId,
+			distinctId,
+			featureFlags,
 			automationOptions
 				? { ...automationOptions, logger: options.logger }
 				: undefined,

--- a/sdk/packages/core/src/ClineCore.ts
+++ b/sdk/packages/core/src/ClineCore.ts
@@ -396,6 +396,11 @@ export class ClineCore {
 			await this.automationService?.dispose();
 			await this.host.dispose(...args);
 		} finally {
+			await this.featureFlags.dispose().catch((error) => {
+				this.logger?.error?.("Error disposing feature flags provider", {
+					error,
+				});
+			});
 			this.unsubscribeBootstrapCleanup();
 			const sessionIds = [...this.activeSessionBootstraps.keys()];
 			await Promise.allSettled(

--- a/sdk/packages/core/src/ClineCore.ts
+++ b/sdk/packages/core/src/ClineCore.ts
@@ -395,6 +395,7 @@ export class ClineCore {
 		try {
 			await this.automationService?.dispose();
 			await this.host.dispose(...args);
+			await this.telemetry?.dispose().catch(this.logger?.error);
 		} finally {
 			this.unsubscribeBootstrapCleanup();
 			const sessionIds = [...this.activeSessionBootstraps.keys()];

--- a/sdk/packages/core/src/ClineCore.ts
+++ b/sdk/packages/core/src/ClineCore.ts
@@ -395,6 +395,7 @@ export class ClineCore {
 		try {
 			await this.automationService?.dispose();
 			await this.host.dispose(...args);
+			await this.featureFlags.dispose().catch(this.logger?.error);
 			await this.telemetry?.dispose().catch(this.logger?.error);
 		} finally {
 			this.unsubscribeBootstrapCleanup();

--- a/sdk/packages/core/src/cline-core/types.ts
+++ b/sdk/packages/core/src/cline-core/types.ts
@@ -3,6 +3,7 @@ import type {
 	AgentConfig,
 	AutomationEventEnvelope,
 	BasicLogger,
+	IFeatureFlagsProvider,
 	ITelemetryService,
 } from "@cline/shared";
 import type { CronEventSuppression } from "../cron/events/cron-event-ingress";
@@ -205,6 +206,12 @@ export interface ClineCoreOptions {
 	 * If omitted, telemetry is a no-op.
 	 */
 	telemetry?: ITelemetryService;
+	/**
+	 * Feature flags provider for this ClineCore instance. Core wraps the provider
+	 * in a cached FeatureFlagsService and exposes it as `cline.featureFlags`.
+	 * If omitted, Core uses a no-op provider with default flag values.
+	 */
+	featureFlags?: IFeatureFlagsProvider;
 	/**
 	 * Optional structured logger for core-side operational diagnostics such as
 	 * runtime-host selection and fallback decisions.

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -32,9 +32,15 @@ export type {
 	ClineAccountActionRequest,
 	ConnectorHookEvent,
 	ContentBlock,
+	FeatureFlag,
+	FeatureFlagPayload,
+	FeatureFlagsAndPayloads,
+	FeatureFlagsContext,
+	FeatureFlagsSettings,
 	FileContent,
 	GetProviderModelsActionRequest,
 	HookSessionContext,
+	IFeatureFlagsProvider,
 	ImageContent,
 	ITelemetryService,
 	ListProvidersActionRequest,
@@ -81,6 +87,8 @@ export {
 	createContributionRegistry,
 	createTool,
 	emptyWorkspaceManifest,
+	FEATURE_FLAGS,
+	FeatureFlagDefaultValue,
 	formatDisplayUserInput,
 	noopBasicLogger,
 	normalizeSdkError,
@@ -434,6 +442,11 @@ export {
 	type DesktopToolApprovalOptions,
 	requestDesktopToolApproval,
 } from "./runtime/tools/tool-approval";
+export {
+	FeatureFlagsService,
+	type FeatureFlagsServiceOptions,
+	NoOpFeatureFlagsProvider,
+} from "./services/feature-flags";
 export type { GlobalSettings } from "./services/global-settings";
 export {
 	filterDisabledPluginPaths,

--- a/sdk/packages/core/src/services/feature-flags/FeatureFlagsService.test.ts
+++ b/sdk/packages/core/src/services/feature-flags/FeatureFlagsService.test.ts
@@ -17,8 +17,8 @@ function createProvider(
 				[TEST_PAYLOAD_FLAG]: 1234,
 			},
 		})),
-		isEnabled: vi.fn(() => true),
-		getSettings: vi.fn(() => ({ enabled: true, timeout: 1000 })),
+		enabled: true,
+		getSettings: vi.fn(() => ({ enabled: true, timeoutMs: 1000 })),
 		dispose: vi.fn(async () => {}),
 		...overrides,
 	};
@@ -66,7 +66,21 @@ describe("FeatureFlagsService", () => {
 		const service = new FeatureFlagsService({ provider });
 
 		await service.poll("user-1");
+		expect(provider.getAllFlagsAndPayloads).toHaveBeenCalledTimes(1);
+
 		await service.poll("user-1");
+
+		expect(provider.getAllFlagsAndPayloads).toHaveBeenCalledTimes(1);
+	});
+
+	it("polls only once if two calls are made simultaneously with the same user context", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-06-10T10:00:00Z"));
+
+		const provider = createProvider();
+		const service = new FeatureFlagsService({ provider });
+
+		await Promise.all([service.poll("user-1"), service.poll("user-1")]);
 
 		expect(provider.getAllFlagsAndPayloads).toHaveBeenCalledTimes(1);
 	});

--- a/sdk/packages/core/src/services/feature-flags/FeatureFlagsService.test.ts
+++ b/sdk/packages/core/src/services/feature-flags/FeatureFlagsService.test.ts
@@ -1,0 +1,101 @@
+import type { IFeatureFlagsProvider } from "@cline/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FeatureFlagsService } from "./FeatureFlagsService";
+
+const TEST_BOOLEAN_FLAG = "test_boolean_flag";
+const TEST_PAYLOAD_FLAG = "test_payload_flag";
+
+function createProvider(
+	overrides: Partial<IFeatureFlagsProvider> = {},
+): IFeatureFlagsProvider {
+	return {
+		getAllFlagsAndPayloads: vi.fn(async () => ({
+			featureFlags: {
+				[TEST_BOOLEAN_FLAG]: true,
+			},
+			featureFlagPayloads: {
+				[TEST_PAYLOAD_FLAG]: 1234,
+			},
+		})),
+		isEnabled: vi.fn(() => true),
+		getSettings: vi.fn(() => ({ enabled: true, timeout: 1000 })),
+		dispose: vi.fn(async () => {}),
+		...overrides,
+	};
+}
+
+describe("FeatureFlagsService", () => {
+	beforeEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("polls provider values into the cache", async () => {
+		const provider = createProvider();
+		const telemetry = { capture: vi.fn() };
+		const service = new FeatureFlagsService({
+			provider,
+			telemetry: telemetry as never,
+			context: { distinctId: "machine-1", clientName: "unit-test" },
+		});
+
+		await service.poll("user-1");
+
+		expect(provider.getAllFlagsAndPayloads).toHaveBeenCalledWith({
+			flagKeys: undefined,
+			context: {
+				distinctId: "machine-1",
+				clientName: "unit-test",
+				userId: "user-1",
+			},
+		});
+		expect(service.getBooleanFlagEnabled(TEST_BOOLEAN_FLAG)).toBe(true);
+		expect(service.getFlagPayload(TEST_PAYLOAD_FLAG)).toBe(1234);
+		expect(telemetry.capture).toHaveBeenCalledWith({
+			event: "$feature_flag_called",
+			properties: {
+				$feature_flag: TEST_BOOLEAN_FLAG,
+				$feature_flag_response: true,
+			},
+		});
+	});
+
+	it("skips polling while the cache is fresh and user context is unchanged", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-06-10T10:00:00Z"));
+		const provider = createProvider();
+		const service = new FeatureFlagsService({ provider });
+
+		await service.poll("user-1");
+		await service.poll("user-1");
+
+		expect(provider.getAllFlagsAndPayloads).toHaveBeenCalledTimes(1);
+	});
+
+	it("re-polls when the user context changes within the cache ttl", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-06-10T10:00:00Z"));
+		const provider = createProvider();
+		const service = new FeatureFlagsService({ provider });
+
+		await service.poll("user-1");
+		await service.poll("user-2");
+
+		expect(provider.getAllFlagsAndPayloads).toHaveBeenCalledTimes(2);
+	});
+
+	it("returns false or undefined before polling", () => {
+		const service = new FeatureFlagsService({ provider: createProvider() });
+
+		expect(service.getBooleanFlagEnabled(TEST_BOOLEAN_FLAG)).toBe(false);
+		expect(service.getFlagPayload(TEST_PAYLOAD_FLAG)).toBeUndefined();
+	});
+
+	it("disposes the provider", async () => {
+		const provider = createProvider();
+		const service = new FeatureFlagsService({ provider });
+
+		await service.dispose();
+
+		expect(provider.dispose).toHaveBeenCalledTimes(1);
+	});
+});

--- a/sdk/packages/core/src/services/feature-flags/FeatureFlagsService.ts
+++ b/sdk/packages/core/src/services/feature-flags/FeatureFlagsService.ts
@@ -1,0 +1,157 @@
+import type {
+	BasicLogger,
+	FeatureFlagPayload,
+	FeatureFlagsAndPayloads,
+	FeatureFlagsContext,
+	IFeatureFlagsProvider,
+	ITelemetryService,
+} from "@cline/shared";
+import {
+	FEATURE_FLAGS,
+	type FeatureFlag,
+	FeatureFlagDefaultValue,
+} from "@cline/shared";
+
+const DEFAULT_CACHE_TTL_MS = 60 * 60 * 1000;
+
+type CacheInfo = {
+	updateTime: number;
+	userId: string | null;
+	flagsPayload?: FeatureFlagsAndPayloads;
+};
+
+export interface FeatureFlagsServiceOptions {
+	provider: IFeatureFlagsProvider;
+	telemetry?: ITelemetryService;
+	logger?: BasicLogger;
+	cacheTtlMs?: number;
+	context?: FeatureFlagsContext;
+}
+
+export class FeatureFlagsService {
+	private readonly provider: IFeatureFlagsProvider;
+	private readonly telemetry?: ITelemetryService;
+	private readonly logger?: BasicLogger;
+	private readonly cacheTtlMs: number;
+	private context: FeatureFlagsContext;
+	private cache: Map<FeatureFlag, FeatureFlagPayload | undefined> = new Map();
+	private cacheInfo: CacheInfo = { updateTime: 0, userId: null };
+
+	constructor(options: FeatureFlagsServiceOptions) {
+		this.provider = options.provider;
+		this.telemetry = options.telemetry;
+		this.logger = options.logger;
+		this.cacheTtlMs = options.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+		this.context = { ...(options.context ?? {}) };
+	}
+
+	setContext(context: FeatureFlagsContext): void {
+		this.context = { ...context };
+	}
+
+	async poll(
+		userId: string | null = this.context.userId ?? null,
+	): Promise<void> {
+		const timeNow = Date.now();
+		if (
+			timeNow - this.cacheInfo.updateTime < this.cacheTtlMs &&
+			this.cache.size
+		) {
+			if (this.cacheInfo.userId === userId) {
+				return;
+			}
+		}
+
+		const previousCacheInfo = this.cacheInfo;
+		this.cacheInfo = { updateTime: timeNow, userId: userId || null };
+
+		try {
+			const values = await this.provider.getAllFlagsAndPayloads({
+				flagKeys: FEATURE_FLAGS.length > 0 ? FEATURE_FLAGS : undefined,
+				context: { ...this.context, userId },
+			});
+			this.cacheInfo.flagsPayload = values;
+
+			for (const flag of this.getReturnedFlagKeys(values)) {
+				const payload = this.getFeatureFlag(flag);
+				this.cache.set(flag, payload ?? false);
+			}
+		} catch (error) {
+			this.cacheInfo = previousCacheInfo.updateTime
+				? previousCacheInfo
+				: { updateTime: 0, userId: null };
+			this.logger?.error?.("Error polling SDK feature flags", { error });
+			throw error;
+		}
+	}
+
+	private getReturnedFlagKeys(
+		values: FeatureFlagsAndPayloads | undefined,
+	): FeatureFlag[] {
+		return [
+			...new Set([
+				...Object.keys(values?.featureFlags ?? {}),
+				...Object.keys(values?.featureFlagPayloads ?? {}),
+			]),
+		];
+	}
+
+	private getFeatureFlag(
+		flagName: FeatureFlag,
+	): FeatureFlagPayload | undefined {
+		try {
+			const payload =
+				this.cacheInfo.flagsPayload?.featureFlagPayloads?.[flagName];
+			const flagValue = this.cacheInfo.flagsPayload?.featureFlags?.[flagName];
+			const value =
+				payload ?? flagValue ?? FeatureFlagDefaultValue[flagName] ?? undefined;
+
+			if (!this.cache.has(flagName) || this.cache.get(flagName) !== value) {
+				this.telemetry?.capture({
+					event: "$feature_flag_called",
+					properties: {
+						$feature_flag: flagName,
+						$feature_flag_response: flagValue,
+					},
+				});
+			}
+
+			return value;
+		} catch (error) {
+			this.logger?.error?.(`Error checking SDK feature flag ${flagName}`, {
+				error,
+			});
+			return FeatureFlagDefaultValue[flagName] ?? false;
+		}
+	}
+
+	getBooleanFlagEnabled(flagName: FeatureFlag): boolean {
+		return this.cache.get(flagName) === true;
+	}
+
+	getFlagPayload(flagName: FeatureFlag): FeatureFlagPayload | undefined {
+		return this.cache.get(flagName) ?? FeatureFlagDefaultValue[flagName];
+	}
+
+	getProvider(): IFeatureFlagsProvider {
+		return this.provider;
+	}
+
+	isEnabled(): boolean {
+		return this.provider.isEnabled();
+	}
+
+	getSettings() {
+		return this.provider.getSettings();
+	}
+
+	test(flagName: FeatureFlag, value: boolean): void {
+		if (process.env.NODE_ENV === "test" || process.env.IS_TEST === "true") {
+			this.cache.set(flagName, value);
+		}
+	}
+
+	async dispose(): Promise<void> {
+		await this.provider.dispose();
+	}
+}

--- a/sdk/packages/core/src/services/feature-flags/FeatureFlagsService.ts
+++ b/sdk/packages/core/src/services/feature-flags/FeatureFlagsService.ts
@@ -135,8 +135,8 @@ export class FeatureFlagsService {
 		return this.provider;
 	}
 
-	isEnabled(): boolean {
-		return this.provider.isEnabled();
+	get enabled(): boolean {
+		return this.provider.enabled;
 	}
 
 	getSettings() {

--- a/sdk/packages/core/src/services/feature-flags/FeatureFlagsService.ts
+++ b/sdk/packages/core/src/services/feature-flags/FeatureFlagsService.ts
@@ -68,6 +68,12 @@ export class FeatureFlagsService {
 				flagKeys: FEATURE_FLAGS.length > 0 ? FEATURE_FLAGS : undefined,
 				context: { ...this.context, userId },
 			});
+
+			if (this.cacheInfo.userId !== userId) {
+				// A new poll has started with a different userId, so we should not update the cache with the results of this poll
+				return;
+			}
+
 			this.cacheInfo.flagsPayload = values;
 
 			for (const flag of this.getReturnedFlagKeys(values)) {
@@ -75,6 +81,11 @@ export class FeatureFlagsService {
 				this.cache.set(flag, payload ?? false);
 			}
 		} catch (error) {
+			if (this.cacheInfo.userId !== userId) {
+				// A new poll has started with a different userId, so we should not update the cache with the results of this poll
+				return;
+			}
+
 			this.cacheInfo = previousCacheInfo.updateTime
 				? previousCacheInfo
 				: { updateTime: 0, userId: null };

--- a/sdk/packages/core/src/services/feature-flags/FeatureFlagsService.ts
+++ b/sdk/packages/core/src/services/feature-flags/FeatureFlagsService.ts
@@ -11,6 +11,7 @@ import {
 	type FeatureFlag,
 	FeatureFlagDefaultValue,
 } from "@cline/shared";
+import { CORE_TELEMETRY_EVENTS } from "../..";
 
 const DEFAULT_CACHE_TTL_MS = 60 * 60 * 1000;
 
@@ -53,10 +54,7 @@ export class FeatureFlagsService {
 		userId: string | null = this.context.userId ?? null,
 	): Promise<void> {
 		const timeNow = Date.now();
-		if (
-			timeNow - this.cacheInfo.updateTime < this.cacheTtlMs &&
-			this.cache.size
-		) {
+		if (timeNow - this.cacheInfo.updateTime < this.cacheTtlMs) {
 			if (this.cacheInfo.userId === userId) {
 				return;
 			}
@@ -108,7 +106,7 @@ export class FeatureFlagsService {
 
 			if (!this.cache.has(flagName) || this.cache.get(flagName) !== value) {
 				this.telemetry?.capture({
-					event: "$feature_flag_called",
+					event: CORE_TELEMETRY_EVENTS.FEATURE_FLAGS.FLAG_CALLED,
 					properties: {
 						$feature_flag: flagName,
 						$feature_flag_response: flagValue,

--- a/sdk/packages/core/src/services/feature-flags/FeatureFlagsService.ts
+++ b/sdk/packages/core/src/services/feature-flags/FeatureFlagsService.ts
@@ -75,11 +75,12 @@ export class FeatureFlagsService {
 			}
 
 			this.cacheInfo.flagsPayload = values;
-
+			const nextCache = new Map<FeatureFlag, FeatureFlagPayload | undefined>();
 			for (const flag of this.getReturnedFlagKeys(values)) {
 				const payload = this.getFeatureFlag(flag);
-				this.cache.set(flag, payload ?? false);
+				nextCache.set(flag, payload ?? false);
 			}
+			this.cache = nextCache;
 		} catch (error) {
 			if (this.cacheInfo.userId !== userId) {
 				// A new poll has started with a different userId, so we should not update the cache with the results of this poll

--- a/sdk/packages/core/src/services/feature-flags/index.ts
+++ b/sdk/packages/core/src/services/feature-flags/index.ts
@@ -1,0 +1,5 @@
+export {
+	FeatureFlagsService,
+	type FeatureFlagsServiceOptions,
+} from "./FeatureFlagsService";
+export { NoOpFeatureFlagsProvider } from "./providers";

--- a/sdk/packages/core/src/services/feature-flags/providers.ts
+++ b/sdk/packages/core/src/services/feature-flags/providers.ts
@@ -9,12 +9,10 @@ export class NoOpFeatureFlagsProvider implements IFeatureFlagsProvider {
 		return {};
 	}
 
-	isEnabled(): boolean {
-		return false;
-	}
+	enabled = false;
 
 	getSettings(): FeatureFlagsSettings {
-		return { enabled: false, timeout: 1000 };
+		return { enabled: false, timeoutMs: 1000 };
 	}
 
 	async dispose(): Promise<void> {}

--- a/sdk/packages/core/src/services/feature-flags/providers.ts
+++ b/sdk/packages/core/src/services/feature-flags/providers.ts
@@ -1,0 +1,21 @@
+import type {
+	FeatureFlagsAndPayloads,
+	FeatureFlagsSettings,
+	IFeatureFlagsProvider,
+} from "@cline/shared";
+
+export class NoOpFeatureFlagsProvider implements IFeatureFlagsProvider {
+	async getAllFlagsAndPayloads(): Promise<FeatureFlagsAndPayloads> {
+		return {};
+	}
+
+	isEnabled(): boolean {
+		return false;
+	}
+
+	getSettings(): FeatureFlagsSettings {
+		return { enabled: false, timeout: 1000 };
+	}
+
+	async dispose(): Promise<void> {}
+}

--- a/sdk/packages/core/src/services/telemetry/core-events.ts
+++ b/sdk/packages/core/src/services/telemetry/core-events.ts
@@ -74,6 +74,9 @@ export const CORE_TELEMETRY_EVENTS = {
 		ERROR: SDK_ERROR_TELEMETRY_EVENT,
 		TOOL_TIMEOUT: "sdk.tool_timeout",
 	},
+	FEATURE_FLAGS: {
+		FLAG_CALLED: "$feature_flag_called",
+	},
 } as const;
 
 export interface RunCommandsTimeoutTelemetryProperties {

--- a/sdk/packages/core/src/types.ts
+++ b/sdk/packages/core/src/types.ts
@@ -1,8 +1,18 @@
 export type {
 	AgentRunResult,
 	AgentRunStatus,
+	FeatureFlag,
+	FeatureFlagPayload,
+	FeatureFlagsAndPayloads,
+	FeatureFlagsContext,
+	FeatureFlagsSettings,
+	IFeatureFlagsProvider,
 	WorkspaceInfo,
 	WorkspaceManifest,
+} from "@cline/shared";
+export {
+	FEATURE_FLAGS,
+	FeatureFlagDefaultValue,
 } from "@cline/shared";
 export { ClineCore } from "./ClineCore";
 export type {
@@ -103,6 +113,11 @@ export type {
 	SubprocessSandboxOptions,
 } from "./runtime/tools/subprocess-sandbox";
 export { SubprocessSandbox } from "./runtime/tools/subprocess-sandbox";
+export {
+	FeatureFlagsService,
+	type FeatureFlagsServiceOptions,
+	NoOpFeatureFlagsProvider,
+} from "./services/feature-flags";
 export type { GlobalSettings } from "./services/global-settings";
 export {
 	filterDisabledPluginPaths,

--- a/sdk/packages/shared/src/feature-flags.ts
+++ b/sdk/packages/shared/src/feature-flags.ts
@@ -1,0 +1,50 @@
+export type FeatureFlag = string;
+
+export type FeatureFlagJsonValue =
+	| string
+	| number
+	| boolean
+	| null
+	| { [key: string]: FeatureFlagJsonValue }
+	| FeatureFlagJsonValue[];
+
+export type FeatureFlagPayload = FeatureFlagJsonValue;
+
+export type FeatureFlagsAndPayloads = {
+	featureFlags?: Record<string, FeatureFlagPayload>;
+	featureFlagPayloads?: Record<string, FeatureFlagPayload>;
+};
+
+export interface FeatureFlagsContext {
+	/** Stable SDK/client/user identifier used by providers that evaluate per identity. */
+	distinctId?: string;
+	/** Authenticated Cline account/user ID, when available. */
+	userId?: string | null;
+	/** Optional SDK consumer name, e.g. `my-production-app`. */
+	clientName?: string;
+}
+
+export interface FeatureFlagsSettings {
+	/** Whether the provider is enabled. */
+	enabled: boolean;
+	/** Optional timeout for feature flag requests. */
+	timeout?: number;
+}
+
+export interface IFeatureFlagsProvider {
+	getAllFlagsAndPayloads(options: {
+		flagKeys?: readonly string[];
+		context?: FeatureFlagsContext;
+	}): Promise<FeatureFlagsAndPayloads | undefined>;
+	isEnabled(): boolean;
+	getSettings(): FeatureFlagsSettings;
+	dispose(): Promise<void>;
+}
+
+export const FeatureFlagDefaultValue: Partial<
+	Record<FeatureFlag, FeatureFlagPayload | undefined>
+> = {};
+
+export const FEATURE_FLAGS: readonly FeatureFlag[] = Object.keys(
+	FeatureFlagDefaultValue,
+);

--- a/sdk/packages/shared/src/feature-flags.ts
+++ b/sdk/packages/shared/src/feature-flags.ts
@@ -24,11 +24,22 @@ export interface FeatureFlagsContext {
 	clientName?: string;
 }
 
+type AssertTrue<T extends true> = T;
+type Primitive = string | number | boolean | bigint | symbol | null | undefined;
+type HasNonPrimitiveFieldNames<T> = {
+	[K in keyof T]-?: Exclude<T[K], Primitive> extends never ? never : K;
+}[keyof T];
+type HasOnlyPrimitiveFields<T> =
+	HasNonPrimitiveFieldNames<T> extends never ? true : false;
+export type FeatureFlagsContextPrimitiveValued = AssertTrue<
+	HasOnlyPrimitiveFields<FeatureFlagsContext>
+>;
+
 export interface FeatureFlagsSettings {
 	/** Whether the provider is enabled. */
 	enabled: boolean;
-	/** Optional timeout for feature flag requests. */
-	timeout?: number;
+	/** Optional timeout in ms for feature flag requests. */
+	timeoutMs?: number;
 }
 
 export interface IFeatureFlagsProvider {
@@ -36,7 +47,7 @@ export interface IFeatureFlagsProvider {
 		flagKeys?: readonly string[];
 		context?: FeatureFlagsContext;
 	}): Promise<FeatureFlagsAndPayloads | undefined>;
-	isEnabled(): boolean;
+	readonly enabled: boolean;
 	getSettings(): FeatureFlagsSettings;
 	dispose(): Promise<void>;
 }

--- a/sdk/packages/shared/src/index.browser.ts
+++ b/sdk/packages/shared/src/index.browser.ts
@@ -48,6 +48,16 @@ export {
 	normalizePluginManifest,
 } from "./extensions/contribution-registry";
 export { PLUGIN_FILE_EXTENSIONS } from "./extensions/plugin";
+export {
+	FEATURE_FLAGS,
+	type FeatureFlag,
+	FeatureFlagDefaultValue,
+	type FeatureFlagPayload,
+	type FeatureFlagsAndPayloads,
+	type FeatureFlagsContext,
+	type FeatureFlagsSettings,
+	type IFeatureFlagsProvider,
+} from "./feature-flags";
 export type { HookControl } from "./hooks/contracts";
 export type {
 	AgentAbortHookPayload,

--- a/sdk/packages/shared/src/index.ts
+++ b/sdk/packages/shared/src/index.ts
@@ -62,6 +62,16 @@ export {
 	normalizePluginManifest,
 } from "./extensions/contribution-registry";
 export { PLUGIN_FILE_EXTENSIONS } from "./extensions/plugin";
+export {
+	FEATURE_FLAGS,
+	type FeatureFlag,
+	FeatureFlagDefaultValue,
+	type FeatureFlagPayload,
+	type FeatureFlagsAndPayloads,
+	type FeatureFlagsContext,
+	type FeatureFlagsSettings,
+	type IFeatureFlagsProvider,
+} from "./feature-flags";
 export type { HookControl } from "./hooks/contracts";
 export type {
 	AgentAbortHookPayload,


### PR DESCRIPTION
### Description

This PR introduces the concept of feature flags to the SDK. We will need it to enable/disable things later on.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)