### PR TITLE
fix(vscode): restore Anthropic provider on Node 24 by bumping @anthropic-ai/sdk

### DIFF
--- a/apps/vscode/package-lock.json
+++ b/apps/vscode/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "3.89.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@anthropic-ai/sdk": "^0.37.0",
+				"@anthropic-ai/sdk": "^0.40.1",
 				"@anthropic-ai/vertex-sdk": "^0.6.4",
 				"@aws-sdk/client-bedrock-runtime": "^3.922.0",
 				"@aws-sdk/credential-providers": "^3.922.0",
@@ -156,9 +156,9 @@
 			}
 		},
 		"node_modules/@anthropic-ai/sdk": {
-			"version": "0.37.0",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.37.0.tgz",
-			"integrity": "sha512-tHjX2YbkUBwEgg0JZU3EFSSAQPoK4qQR/NFYa8Vtzd5UAyXzZksCw2In69Rml4R/TyHPBfRYaLK35XiOe33pjw==",
+			"version": "0.40.1",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.40.1.tgz",
+			"integrity": "sha512-DJMWm8lTEM9Lk/MSFL+V+ugF7jKOn0M2Ujvb5fN8r2nY14aHbGPZ1k6sgjL+tpJ3VuOGJNG+4R83jEpOuYPv8w==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "^18.11.18",

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -486,7 +486,7 @@
 		"typescript": "^5.4.5"
 	},
 	"dependencies": {
-		"@anthropic-ai/sdk": "^0.37.0",
+		"@anthropic-ai/sdk": "^0.40.1",
 		"@anthropic-ai/vertex-sdk": "^0.6.4",
 		"@aws-sdk/client-bedrock-runtime": "^3.922.0",
 		"@aws-sdk/credential-providers": "^3.922.0",

--- a/apps/vscode/src/core/api/providers/sapaicore.ts
+++ b/apps/vscode/src/core/api/providers/sapaicore.ts
@@ -11,7 +11,7 @@ import axios from "axios"
 import JSON5 from "json5"
 import OpenAI from "openai"
 import { buildExternalBasicHeaders } from "@/services/EnvUtils"
-import { ClineStorageMessage } from "@/shared/messages/content"
+import { ClineStorageMessage, getBase64ImageSource } from "@/shared/messages/content"
 import { getAxiosSettings } from "@/shared/net"
 import { Logger } from "@/shared/services/Logger"
 import { ApiHandler, CommonApiHandlerOptions } from "../"
@@ -302,10 +302,11 @@ namespace Gemini {
 				if (block.type === "text") {
 					parts.push({ text: block.text })
 				} else if (block.type === "image") {
+					const { mediaType, data } = getBase64ImageSource(block.source)
 					parts.push({
 						inlineData: {
-							mimeType: block.source.media_type,
-							data: block.source.data,
+							mimeType: mediaType,
+							data,
 						},
 					})
 				}

--- a/apps/vscode/src/core/api/transform/mistral-format.ts
+++ b/apps/vscode/src/core/api/transform/mistral-format.ts
@@ -3,6 +3,7 @@ import { AssistantMessage } from "@mistralai/mistralai/models/components/assista
 import { SystemMessage } from "@mistralai/mistralai/models/components/systemmessage"
 import { ToolMessage } from "@mistralai/mistralai/models/components/toolmessage"
 import { UserMessage } from "@mistralai/mistralai/models/components/usermessage"
+import { getImageDataUrl } from "@/shared/messages/content"
 
 export type MistralMessage =
 	| (SystemMessage & { role: "system" })
@@ -33,7 +34,7 @@ export function convertToMistralMessages(anthropicMessages: Anthropic.Messages.M
 								return {
 									type: "image_url",
 									imageUrl: {
-										url: `data:${part.source.media_type};base64,${part.source.data}`,
+										url: getImageDataUrl(part.source),
 									},
 								}
 							}

--- a/apps/vscode/src/core/api/transform/ollama-format.ts
+++ b/apps/vscode/src/core/api/transform/ollama-format.ts
@@ -5,6 +5,7 @@ import {
 	ClineStorageMessage,
 	ClineTextContentBlock,
 	ClineUserToolResultContentBlock,
+	getImageDataUrl,
 } from "@/shared/messages/content"
 
 export function convertToOllamaMessages(anthropicMessages: Omit<ClineStorageMessage, "modelInfo">[]): Message[] {
@@ -46,7 +47,7 @@ export function convertToOllamaMessages(anthropicMessages: Omit<ClineStorageMess
 							toolMessage.content
 								?.map((part) => {
 									if (part.type === "image") {
-										toolResultImages.push(`data:${part.source.media_type};base64,${part.source.data}`)
+										toolResultImages.push(getImageDataUrl(part.source))
 										return "(see following user message for image)"
 									}
 									return part.text
@@ -67,7 +68,7 @@ export function convertToOllamaMessages(anthropicMessages: Omit<ClineStorageMess
 						content: nonToolMessages
 							.map((part) => {
 								if (part.type === "image") {
-									return `data:${part.source.media_type};base64,${part.source.data}`
+									return getImageDataUrl(part.source)
 								}
 								return part.text
 							})

--- a/apps/vscode/src/core/api/transform/openai-format.ts
+++ b/apps/vscode/src/core/api/transform/openai-format.ts
@@ -9,6 +9,7 @@ import {
 	ClineStorageMessage,
 	ClineTextContentBlock,
 	ClineUserToolResultContentBlock,
+	getImageDataUrl,
 } from "@/shared/messages/content"
 import { Logger } from "@/shared/services/Logger"
 
@@ -144,7 +145,7 @@ export function convertToOpenAiMessages(
 						role: "user",
 						content: toolResultImages.map((part) => ({
 							type: "image_url",
-							image_url: { url: `data:${part.source.media_type};base64,${part.source.data}` },
+							image_url: { url: getImageDataUrl(part.source) },
 						})),
 					})
 				}
@@ -158,7 +159,7 @@ export function convertToOpenAiMessages(
 								return {
 									type: "image_url",
 									image_url: {
-										url: `data:${part.source.media_type};base64,${part.source.data}`,
+										url: getImageDataUrl(part.source),
 									},
 								}
 							}

--- a/apps/vscode/src/core/api/transform/openai-response-format.ts
+++ b/apps/vscode/src/core/api/transform/openai-response-format.ts
@@ -1,5 +1,5 @@
 import { ResponseInput, ResponseInputMessageContentList, ResponseReasoningItem } from "openai/resources/responses/responses"
-import { ClineStorageMessage } from "@/shared/messages/content"
+import { ClineStorageMessage, getBase64ImageSource, getImageDataUrl } from "@/shared/messages/content"
 
 /**
  * Converts an array of ClineStorageMessage objects (extension of Anthropic format) to a ResponseInput array to use with OpenAI's Responses API.
@@ -177,7 +177,7 @@ export function convertToOpenAIResponsesInput(
 						const imageItem: any = {
 							type: "message",
 							role: "assistant",
-							content: [{ type: "output_text", text: `[image:${part.source.media_type}]` }],
+							content: [{ type: "output_text", text: `[image:${getBase64ImageSource(part.source).mediaType}]` }],
 						}
 						// Set message-level id if available (though images typically don't have call_id)
 						if (part.call_id) {
@@ -218,7 +218,7 @@ export function convertToOpenAIResponsesInput(
 						messageContent.push({
 							type: "input_image",
 							detail: "auto",
-							image_url: `data:${part.source.media_type};base64,${part.source.data}`,
+							image_url: getImageDataUrl(part.source),
 						})
 						break
 					case "tool_result": {

--- a/apps/vscode/src/core/api/transform/r1-format.ts
+++ b/apps/vscode/src/core/api/transform/r1-format.ts
@@ -1,6 +1,6 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import OpenAI from "openai"
-import { ClineAssistantThinkingBlock, ClineStorageMessage } from "@/shared/messages/content"
+import { ClineAssistantThinkingBlock, ClineStorageMessage, getImageDataUrl } from "@/shared/messages/content"
 
 /**
  * DeepSeek Reasoner message format with reasoning_content support.
@@ -87,7 +87,7 @@ export function convertToR1Format(messages: Anthropic.Messages.MessageParam[]): 
 					hasImages = true
 					imageParts.push({
 						type: "image_url",
-						image_url: { url: `data:${part.source.media_type};base64,${part.source.data}` },
+						image_url: { url: getImageDataUrl(part.source) },
 					})
 				}
 			})

--- a/apps/vscode/src/core/api/transform/vscode-lm-format.ts
+++ b/apps/vscode/src/core/api/transform/vscode-lm-format.ts
@@ -74,7 +74,7 @@ export function convertToVsCodeLmMessages(
 								: (toolMessage.content?.map((part) => {
 										if (part.type === "image") {
 											return new vscode.LanguageModelTextPart(
-												`[Image (${part.source?.type || "Unknown source-type"}): ${part.source?.media_type || "unknown media-type"} not supported by VSCode LM API]`,
+												`[Image (${part.source?.type || "Unknown source-type"}): ${(part.source?.type === "base64" && part.source.media_type) || "unknown media-type"} not supported by VSCode LM API]`,
 											)
 										}
 										return new vscode.LanguageModelTextPart(part.text)
@@ -87,7 +87,7 @@ export function convertToVsCodeLmMessages(
 					...nonToolMessages.map((part) => {
 						if (part.type === "image") {
 							return new vscode.LanguageModelTextPart(
-								`[Image (${part.source?.type || "Unknown source-type"}): ${part.source?.media_type || "unknown media-type"} not supported by VSCode LM API]`,
+								`[Image (${part.source?.type || "Unknown source-type"}): ${(part.source?.type === "base64" && part.source.media_type) || "unknown media-type"} not supported by VSCode LM API]`,
 							)
 						}
 						return new vscode.LanguageModelTextPart(part.text)

--- a/apps/vscode/src/integrations/claude-code/message-filter.ts
+++ b/apps/vscode/src/integrations/claude-code/message-filter.ts
@@ -16,7 +16,7 @@ export function filterMessagesForClaudeCode(messages: Anthropic.Messages.Message
 			if (block.type === "image") {
 				// Replace image blocks with text placeholders
 				const sourceType = block.source?.type || "unknown"
-				const mediaType = block.source?.media_type || "unknown"
+				const mediaType = (block.source?.type === "base64" && block.source.media_type) || "unknown"
 				return {
 					type: "text" as const,
 					text: `[Image (${sourceType}): ${mediaType} not supported by Claude Code]`,

--- a/apps/vscode/src/shared/messages/content.ts
+++ b/apps/vscode/src/shared/messages/content.ts
@@ -132,6 +132,27 @@ export function convertClineStorageToAnthropicMessage(
 }
 
 /**
+ * Cline stores images as base64, so an image block's source is always a base64 source.
+ * The Anthropic SDK types the source as a Base64ImageSource | URLImageSource union, so this
+ * narrows to the base64 variant for the transform layer. URL sources are not produced by Cline,
+ * so they degrade to empty values rather than throwing.
+ */
+export function getBase64ImageSource(source: Anthropic.ImageBlockParam["source"]): { mediaType: string; data: string } {
+	if (source.type === "base64") {
+		return { mediaType: source.media_type, data: source.data }
+	}
+	return { mediaType: "", data: "" }
+}
+
+/**
+ * Builds a base64 data URL from an image block's source. See getBase64ImageSource.
+ */
+export function getImageDataUrl(source: Anthropic.ImageBlockParam["source"]): string {
+	const { mediaType, data } = getBase64ImageSource(source)
+	return `data:${mediaType};base64,${data}`
+}
+
+/**
  * Clean a content block by removing Cline-specific fields and returning only Anthropic-compatible fields
  */
 export function cleanContentBlock(block: ClineContent): Anthropic.ContentBlock {


### PR DESCRIPTION
### Related Issue

Reports that the Anthropic provider stopped working after users updated VS Code, while other providers (OpenAI, Gemini, etc.) kept working.

### Description

**Problem.** After updating VS Code, users on the Anthropic provider hit failures, but only Anthropic, not the other providers. It wasn't reproducible on older VS Code builds, which was the key clue.

**Root cause.** VS Code `1.123.0` (released Jun 5) bumped its bundled runtime:

| | Electron | Node |
|---|---|---|
| 1.122.x | 39.8.8 | 22.22.1 |
| 1.123.0 / 1.124.0 | 42.2.0 | 24.15.0 |

That is a major Node bump, 22 to 24, which ships a new V8 and a much newer undici (the engine behind `globalThis.fetch`).

**Why only Anthropic.** In VS Code mode, `src/shared/net.ts` hands VS Code's own `globalThis.fetch` to every provider SDK. So the runtime changed for all of them at once. The difference is SDK age:

- `@anthropic-ai/sdk` was pinned at `^0.37.0`, which predates the SDK's native-fetch rewrite and still relies on legacy `_shims` runtime detection. That layer is what breaks when fetch/streams semantics shift under it on a new Node major.
- `openai` (`^6.x`) and `@google/genai` (`^1.30`) are modern and cope fine.

The runtime changed for everyone; only the ancient Anthropic SDK couldn't handle it. That asymmetry is the whole bug.

This is **not** related to the recent Fable 5 / Opus 4.8 model work. Those changes were additive and gated, and the default Anthropic model (`claude-sonnet-4-5`) was unchanged.

**Fix.** Bump `@anthropic-ai/sdk` to `^0.40.1`, the first release with the native-fetch rewrite that restores Node 24 compatibility.

**Why 0.40.1 and not latest (0.100+).** Both contain the same runtime fix. But jumping to latest roughly doubles the type-churn surface and pulls in semantic changes (mid-conversation `system` role on `MessageParam`, reshaped `OutputConfig`) that ripple through every provider's transform code. For an urgent fix unbreaking users, `0.40.1` is the minimal-risk change. A deliberate bump to latest can follow as its own PR.

**The one type change the bump requires.** `ImageBlockParam.source` widened from a base64-only type to `Base64ImageSource | URLImageSource`. Because Cline uses the Anthropic SDK types as its internal message format for *all* providers (`ClineImageContentBlock extends Anthropic.ImageBlockParam`), every transform that reads `.media_type`/`.data` off an image needed to narrow the union. Rather than scatter inline guards, this adds one helper in `shared/messages/content.ts`:

```ts
getBase64ImageSource(source)  // narrows to base64, returns { mediaType, data }
getImageDataUrl(source)       // builds the data: URL
```

and routes the call sites through it. Cline only ever produces base64 image sources, so **behavior is unchanged**; the helper emits the exact same `data:<mediaType>;base64,<data>` string the inline code produced. URL sources (which Cline never creates) degrade to empty values instead of throwing.

### Test Procedure

- `tsc --noEmit` is clean for all SDK-touched files. (Remaining type errors in a fresh checkout are pre-existing codegen files that require `protoc` to regenerate, unrelated to this change.)
- Behavior is provably identical for the image path: the helper returns the same data URL the previous inline expressions built, for base64 sources, which is the only kind Cline produces.

**Still needs verifying in CI / a full env:**
- Full `test:unit` and `compile` (this change was prepared in an environment without `protoc`).
- Confirmation from an affected user that the failure is a runtime/stream `TypeError` rather than an API `400`. A `TypeError` confirms the diagnosis; a `400` would point elsewhere. The crash could not be reproduced locally on a Node 22 host.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

- [x] Changes are limited to a single bugfix
- [ ] Tests are passing (`npm test`) and code is formatted and linted (needs CI / a full env with `protoc`)
- [x] I have reviewed contributor guidelines

### Additional Notes

The image-source narrowing touches OpenAI/Ollama/Mistral/R1 transforms even though this is an Anthropic SDK bump. That is expected: those files convert Cline's internal message format (which is built on Anthropic SDK types) into each provider's wire format, so a change to the shared Anthropic image type ripples to all of them. The diff is one helper plus one-line call-site swaps with no behavior change.