### PR TITLE
fix(vscode): upgrade @anthropic-ai/sdk to 0.50.1 for Node 24 compatibility

### DIFF
--- a/apps/vscode/package-lock.json
+++ b/apps/vscode/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "3.89.1",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@anthropic-ai/sdk": "^0.40.1",
+				"@anthropic-ai/sdk": "^0.50.1",
 				"@anthropic-ai/vertex-sdk": "^0.6.4",
 				"@aws-sdk/client-bedrock-runtime": "^3.922.0",
 				"@aws-sdk/credential-providers": "^3.922.0",
@@ -156,34 +156,16 @@
 			}
 		},
 		"node_modules/@anthropic-ai/sdk": {
-			"version": "0.40.1",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.40.1.tgz",
-			"integrity": "sha512-DJMWm8lTEM9Lk/MSFL+V+ugF7jKOn0M2Ujvb5fN8r2nY14aHbGPZ1k6sgjL+tpJ3VuOGJNG+4R83jEpOuYPv8w==",
+			"version": "0.50.1",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.50.1.tgz",
+			"integrity": "sha512-e54b/ccQE6Ds31Qku/7RLWhPHmJh2/WVKDYX0bjNZbWEu6XG5KuVHmq1qbKWwsomsZlinv3YMHg1wHFpLZPMwg==",
 			"license": "MIT",
-			"dependencies": {
-				"@types/node": "^18.11.18",
-				"@types/node-fetch": "^2.6.4",
-				"abort-controller": "^3.0.0",
-				"agentkeepalive": "^4.2.1",
-				"form-data-encoder": "1.7.2",
-				"formdata-node": "^4.3.2",
-				"node-fetch": "^2.6.7"
+			"bin": {
+				"anthropic-ai-sdk": "bin/cli"
+			},
+			"engines": {
+				"node": ">= 20"
 			}
-		},
-		"node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
-			"version": "18.19.130",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-			"integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-			"license": "MIT",
-			"dependencies": {
-				"undici-types": "~5.26.4"
-			}
-		},
-		"node_modules/@anthropic-ai/sdk/node_modules/undici-types": {
-			"version": "5.26.5",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-			"license": "MIT"
 		},
 		"node_modules/@anthropic-ai/vertex-sdk": {
 			"version": "0.6.4",

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -486,7 +486,7 @@
 		"typescript": "^5.4.5"
 	},
 	"dependencies": {
-		"@anthropic-ai/sdk": "^0.40.1",
+		"@anthropic-ai/sdk": "^0.50.1",
 		"@anthropic-ai/vertex-sdk": "^0.6.4",
 		"@aws-sdk/client-bedrock-runtime": "^3.922.0",
 		"@aws-sdk/credential-providers": "^3.922.0",

--- a/apps/vscode/src/core/api/transform/anthropic-format.ts
+++ b/apps/vscode/src/core/api/transform/anthropic-format.ts
@@ -12,7 +12,7 @@ import { ClineStorageMessage, convertClineStorageToAnthropicMessage } from "@/sh
  * @returns Array of Anthropic-compatible messages with cache control applied
  */
 export function sanitizeAnthropicMessages(
-	clineMessages: Array<ClineStorageMessage | Anthropic.MessageParam>,
+	clineMessages: ClineStorageMessage[],
 	supportCache: boolean,
 ): Array<Anthropic.MessageParam> {
 	// The latest message will be the new user message, one before will be the assistant message from a previous request,

--- a/apps/vscode/src/core/api/transform/gemini-format.ts
+++ b/apps/vscode/src/core/api/transform/gemini-format.ts
@@ -60,7 +60,7 @@ export function convertAnthropicContentToGemini(content: string | ClineStorageMe
 		.filter((part): part is Part => part !== undefined) // Filter out unsupported blocks
 }
 
-export function convertAnthropicMessageToGemini(message: Anthropic.Messages.MessageParam): Content {
+export function convertAnthropicMessageToGemini(message: ClineStorageMessage): Content {
 	return {
 		role: message.role === "assistant" ? "model" : "user",
 		parts: convertAnthropicContentToGemini(message.content),
@@ -113,6 +113,7 @@ export function convertGeminiResponseToAnthropic(response: GenerateContentRespon
 			output_tokens: response.usageMetadata?.candidatesTokenCount ?? 0,
 			cache_creation_input_tokens: null,
 			cache_read_input_tokens: null,
+			server_tool_use: null,
 		},
 	}
 }

--- a/apps/vscode/src/core/api/transform/o1-format.ts
+++ b/apps/vscode/src/core/api/transform/o1-format.ts
@@ -400,6 +400,7 @@ export function convertO1ResponseToAnthropicMessage(
 			output_tokens: completion.usage?.completion_tokens || 0,
 			cache_creation_input_tokens: null,
 			cache_read_input_tokens: null,
+			server_tool_use: null,
 		},
 	}
 

--- a/apps/vscode/src/core/api/transform/openai-format.ts
+++ b/apps/vscode/src/core/api/transform/openai-format.ts
@@ -66,7 +66,7 @@ function transformToolCallIdForNativeApi(toolId: string, provider?: ApiProvider)
  * @returns Array of OpenAI.Chat.ChatCompletionMessageParam objects
  */
 export function convertToOpenAiMessages(
-	anthropicMessages: Omit<ClineStorageMessage, "modelInfo">[],
+	anthropicMessages: Anthropic.Messages.MessageParam[],
 	provider?: ApiProvider,
 ): OpenAI.Chat.ChatCompletionMessageParam[] {
 	const openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = []
@@ -422,6 +422,7 @@ export function convertToAnthropicMessage(completion: OpenAI.Chat.Completions.Ch
 			output_tokens: completion.usage?.completion_tokens || 0,
 			cache_creation_input_tokens: null,
 			cache_read_input_tokens: null,
+			server_tool_use: null,
 		},
 	}
 	try {

--- a/apps/vscode/src/core/api/transform/vscode-lm-format.ts
+++ b/apps/vscode/src/core/api/transform/vscode-lm-format.ts
@@ -199,6 +199,7 @@ export function convertToAnthropicMessage(vsCodeLmMessage: vscode.LanguageModelC
 			output_tokens: 0,
 			cache_creation_input_tokens: null,
 			cache_read_input_tokens: null,
+			server_tool_use: null,
 		},
 	}
 }

--- a/apps/vscode/src/core/hooks/precompact-executor.ts
+++ b/apps/vscode/src/core/hooks/precompact-executor.ts
@@ -192,11 +192,13 @@ export async function executePreCompactHookWithCleanup(params: PreCompactHookPar
 	let contextRawPath: string | undefined
 
 	try {
-		// Get current active context (respects previous compactions)
+		// Get current active context (respects previous compactions).
+		// getTruncatedMessages types its output as Anthropic.MessageParam[], but it slices the Cline-stored
+		// conversation history (ClineStorageMessage[]) passed in, so narrow it back here.
 		const currentContext = params.contextManager.getTruncatedMessages(
 			params.apiConversationHistory,
 			params.conversationHistoryDeletedRange,
-		)
+		) as ClineStorageMessage[]
 
 		// Write context files for hook access
 		const contextFiles = await writePreCompactContextFiles(params.taskId, currentContext)

--- a/apps/vscode/src/core/storage/disk.ts
+++ b/apps/vscode/src/core/storage/disk.ts
@@ -13,6 +13,7 @@ import { HostProvider } from "@/hosts/host-provider"
 import { ExtensionRegistryInfo } from "@/registry"
 import { telemetryService } from "@/services/telemetry"
 import { McpMarketplaceCatalog } from "@/shared/mcp"
+import { ClineStorageMessage } from "@/shared/messages/content"
 import { Logger } from "@/shared/services/Logger"
 import { syncWorker } from "@/shared/services/worker/sync"
 import { reconstructTaskHistory } from "../commands/reconstructTaskHistory"
@@ -233,7 +234,7 @@ export async function getMcpSettingsFilePath(settingsDirectoryPath: string): Pro
 	return mcpSettingsFilePath
 }
 
-export async function getSavedApiConversationHistory(taskId: string): Promise<Anthropic.MessageParam[]> {
+export async function getSavedApiConversationHistory(taskId: string): Promise<ClineStorageMessage[]> {
 	const filePath = path.join(await ensureTaskDirectoryExists(taskId), GlobalFileNames.apiConversationHistory)
 	const fileExists = await fileExistsAtPath(filePath)
 	if (fileExists) {

--- a/apps/vscode/src/core/task/index.ts
+++ b/apps/vscode/src/core/task/index.ts
@@ -2018,7 +2018,10 @@ export class Task {
 		}
 
 		// Response API requires native tool calls to be enabled
-		const stream = this.api.createMessage(systemPrompt, contextManagementMetadata.truncatedConversationHistory, tools)
+		// ContextManager types its truncated output as Anthropic.MessageParam[], but the history it slices is the
+		// Cline-stored conversation history (ClineStorageMessage[]), so narrow it back for the provider boundary.
+		const truncatedConversationHistory = contextManagementMetadata.truncatedConversationHistory as ClineStorageMessage[]
+		const stream = this.api.createMessage(systemPrompt, truncatedConversationHistory, tools)
 
 		const iterator = stream[Symbol.asyncIterator]()
 


### PR DESCRIPTION
### Related Issue

Follow-up to the 3.89.1 hotfix (#11036 release). No tracked issue; reported directly by users after updating VS Code.

### Description

After updating to VS Code 1.123+, the Anthropic provider stopped working for users (other providers were fine). This is the real fix; 3.89.1 shipped an insufficient one.

**Root cause.** VS Code 1.123.0 bumped its bundled runtime from Node 22 to Node 24 (Electron 39 to 42). The Anthropic provider used `@anthropic-ai/sdk` `^0.40.1`, and every SDK release `<=0.41.x` ships a legacy runtime built on `node-fetch@^2.6.7` plus an internal `_shims` layer. That runtime does not work under Node 24, so the Anthropic provider broke specifically on the updated editor while providers on other clients kept working. Nightly already worked because it tracks the latest SDK.

**Why 3.89.1 (0.40.1) didn't fix it.** The earlier hotfix bumped the version number but not the runtime architecture: 0.40.1 is structurally identical to 0.37 (still `node-fetch` + `_shims`). It changed nothing about the failure mode. That's on me, I bisected by assumption instead of inspecting the SDK internals.

**The actual fix.** `0.50.1` is the first SDK release rewritten on top of the platform's native `fetch`. It has zero runtime dependencies (no `node-fetch`, no `_shims`), which removes the Node 24 incompatibility entirely. Verified against the installed package: `dependencies: {}`, no `_shims/` directory, and `node-fetch` appears in the lockfile only for unrelated packages.

**Why 0.50.1 specifically (not latest).** To minimize blast radius. Latest at pin time (0.100.1) carries substantially more type churn (`cache_creation`, `inference_geo`, `output_tokens_details`, `ToolUseBlock.caller`, reshaped `OutputConfig`, a wider content-block union, etc.) for ~23 type errors to resolve. 0.50.1 is the first version that fixes the runtime, and only needs the minimal type changes below.

### Type changes (and why each is safe)

The jump from 0.40.1 to 0.50.1 produced exactly two categories of type breakage:

1. **`Usage` gained a required `server_tool_use` field.** Four transforms fabricate `Usage` objects from non-Anthropic responses (gemini, o1, openai, vscode-lm). Each now sets `server_tool_use: null`, matching how the adjacent `cache_*` fields are already handled.

2. **`ContentBlockParam` widened**, so `Anthropic.MessageParam` is no longer structurally assignable to `ClineStorageMessage` (Cline's internal message type, which narrows `content`). Before 0.50.1 this assignment was implicit. Handled with the most localized fix at each of the 5 sites rather than widening shared signatures:
   - `sanitizeAnthropicMessages` and `convertAnthropicMessageToGemini`: narrowed their params to `ClineStorageMessage` / `ClineStorageMessage[]`. Every caller already passes Cline history, so this is strictly more accurate.
   - `getSavedApiConversationHistory`: typed its return as `ClineStorageMessage[]` (the Cline-stored history it actually reads back). All three consumers take a subtype and are read-only, so nothing downstream breaks.
   - `ContextManager` types its truncated output as `Anthropic.MessageParam[]`, but it slices the Cline history passed in. At the two boundaries that hand that output to a provider/hook (`Task.createMessage` call, precompact hook), narrowed it back to `ClineStorageMessage[]` with an explanatory comment. The ContextManager chain itself is left as `MessageParam[]` internally to avoid a cascading refactor in a hotfix.

`convertToOpenAiMessages` was also widened to `Anthropic.Messages.MessageParam[]` (its body already tolerates the wider type) to fix the openrouter/vercel callers.

### Test Procedure

- `npx tsc --noEmit` is fully clean (0 errors).
- Verified the installed `0.50.1` has no `node-fetch` dependency and no `_shims` layer (the source of the Node 24 break).
- Type narrowing changes are compile-time only; runtime behavior of the transforms is unchanged (the `server_tool_use: null` additions mirror existing `cache_*: null` handling).

### Follow-up

3.89.1 was already published with the insufficient 0.40.1 bump, so a fast-follow patch release (3.89.2) off this change is needed to actually get the fix to users.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
