### PR TITLE
chore(release): bump VS Code extension to 3.89.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.89.2]
+
+### Fixed
+
+- Complete the fix for the Anthropic provider on VS Code 1.123 and later by upgrading the bundled Anthropic SDK to a release compatible with the Node 24 runtime.
+
 ## [3.89.1]
 
 ### Fixed

--- a/apps/vscode/package-lock.json
+++ b/apps/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "claude-dev",
-	"version": "3.89.1",
+	"version": "3.89.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "claude-dev",
-			"version": "3.89.1",
+			"version": "3.89.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.50.1",

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -2,7 +2,7 @@
 	"name": "claude-dev",
 	"displayName": "Cline",
 	"description": "Autonomous coding agent right in your IDE, capable of creating/editing files, running commands, using the browser, and more with your permission every step of the way.",
-	"version": "3.89.1",
+	"version": "3.89.2",
 	"icon": "assets/icons/icon.png",
 	"engines": {
 		"vscode": "^1.84.0"


### PR DESCRIPTION
### Related Issue

**Issue:** N/A (patch release)

### Description

Bumps the VS Code extension version to `3.89.2` and updates `CHANGELOG.md`.

This is a fast-follow to `3.89.1`. That release upgraded `@anthropic-ai/sdk` to `0.40.1`, which turned out to be architecturally identical to the prior version (still built on `node-fetch` + `_shims`) and did not actually fix the Anthropic provider breaking under the Node 24 runtime in VS Code 1.123+. `3.89.2` ships the real fix: `@anthropic-ai/sdk` `0.50.1`, the first native-fetch SDK release (zero runtime dependencies), merged in #11454.

### Test Procedure

- Verified `apps/vscode/package.json` and `apps/vscode/package-lock.json` report `3.89.2`.
- Ran `git diff --check`.

### Type of Change

-   [x] 📚 Documentation update

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] I have reviewed contributor guidelines

### Screenshots

N/A

### Additional Notes

Release-only changelog and version bump. The underlying SDK fix landed separately in #11454.
