### PR TITLE
fix(vscode): remove unused ClineStorageMessage import blocking publish

### DIFF
--- a/apps/vscode/src/core/api/transform/openai-format.ts
+++ b/apps/vscode/src/core/api/transform/openai-format.ts
@@ -6,7 +6,6 @@ import {
 	ClineAssistantThinkingBlock,
 	ClineAssistantToolUseBlock,
 	ClineImageContentBlock,
-	ClineStorageMessage,
 	ClineTextContentBlock,
 	ClineUserToolResultContentBlock,
 	getImageDataUrl,


### PR DESCRIPTION
### Related Issue

**Issue:** N/A (CI/lint fix, unblocks the 3.89.2 publish)

### Description

The `@anthropic-ai/sdk` 0.50.1 upgrade (#11454) widened `convertToOpenAiMessages` to accept `Anthropic.Messages.MessageParam[]`. That removed the only code reference to `ClineStorageMessage` in `openai-format.ts`, leaving it imported but used only in doc comments.

`tsc --noEmit` does not error on unused imports in this config, so it passed locally and in the SDK PR. But the publish workflow's quality checks run `biome lint`, which flags `lint/correctness/noUnusedImports`. That error blocked the `3.89.2` stable publish run. This removes the unused import.

### Test Procedure

- `npx biome lint --config-path ./biome.jsonc --no-errors-on-unmatched --files-ignore-unknown=true --diagnostic-level=error src/core/api/transform/openai-format.ts` passes.
- `npx tsc --noEmit` clean.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
