### PR TITLE
fix(vscode): align Anthropic Vertex SDK with runtime SDK

### DIFF
--- a/apps/vscode/package-lock.json
+++ b/apps/vscode/package-lock.json
@@ -9,8 +9,8 @@
 			"version": "3.89.2",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@anthropic-ai/sdk": "^0.50.1",
-				"@anthropic-ai/vertex-sdk": "^0.6.4",
+				"@anthropic-ai/sdk": "^0.50.4",
+				"@anthropic-ai/vertex-sdk": "^0.11.5",
 				"@aws-sdk/client-bedrock-runtime": "^3.922.0",
 				"@aws-sdk/credential-providers": "^3.922.0",
 				"@azure/identity": "^4.13.0",
@@ -156,9 +156,9 @@
 			}
 		},
 		"node_modules/@anthropic-ai/sdk": {
-			"version": "0.50.1",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.50.1.tgz",
-			"integrity": "sha512-e54b/ccQE6Ds31Qku/7RLWhPHmJh2/WVKDYX0bjNZbWEu6XG5KuVHmq1qbKWwsomsZlinv3YMHg1wHFpLZPMwg==",
+			"version": "0.50.4",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.50.4.tgz",
+			"integrity": "sha512-zZOWyIuznx2uqiRcCNuidkAsLC8IBHgS9lTwSVEB29sUCwEcqL95MWpWP1nccHSKfiZga+hbZaI0btR2zjuMmw==",
 			"license": "MIT",
 			"bin": {
 				"anthropic-ai-sdk": "bin/cli"
@@ -168,12 +168,12 @@
 			}
 		},
 		"node_modules/@anthropic-ai/vertex-sdk": {
-			"version": "0.6.4",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/vertex-sdk/-/vertex-sdk-0.6.4.tgz",
-			"integrity": "sha512-rMBlO2jF53TfMRmsQMm1bPO2JRUh4jYddjq/OJLj8DSAkfbCrNWhc0yhDed6oLYJg5s+VpDbvlPzMggqHhTfMw==",
+			"version": "0.11.5",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/vertex-sdk/-/vertex-sdk-0.11.5.tgz",
+			"integrity": "sha512-V7sB5nY80unEQu8lSQaEzh1WhYwpIdpC3iXNRHUskghkuQDhS6dQu2ASZBgA5MNuJ1Yv5PhY61NM15dLaQhPQw==",
 			"license": "MIT",
 			"dependencies": {
-				"@anthropic-ai/sdk": ">=0.35 <1",
+				"@anthropic-ai/sdk": ">=0.50.3 <1",
 				"google-auth-library": "^9.4.2"
 			}
 		},

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -486,8 +486,8 @@
 		"typescript": "^5.4.5"
 	},
 	"dependencies": {
-		"@anthropic-ai/sdk": "^0.50.1",
-		"@anthropic-ai/vertex-sdk": "^0.6.4",
+		"@anthropic-ai/sdk": "^0.50.4",
+		"@anthropic-ai/vertex-sdk": "^0.11.5",
 		"@aws-sdk/client-bedrock-runtime": "^3.922.0",
 		"@aws-sdk/credential-providers": "^3.922.0",
 		"@azure/identity": "^4.13.0",


### PR DESCRIPTION
### Related Issue

Issue: #XXXX

Follow-up to #11454, which upgraded `@anthropic-ai/sdk` to fix the Anthropic provider on VS Code 1.123 and Node 24.

### Description

#11454 fixed the Anthropic SDK runtime issue by moving the VS Code extension from `@anthropic-ai/sdk@0.40.1` to `0.50.1`, but the release package build exposed a second dependency compatibility issue in the Vertex integration.

The extension still depended on `@anthropic-ai/vertex-sdk@0.6.4`. That package declares a very broad dependency range, `@anthropic-ai/sdk >=0.35 <1`, but its bundled client imports the bare subpath `@anthropic-ai/sdk/core`. The `0.50.x` Anthropic SDK package does not export that bare subpath. It exports specific subpaths such as `@anthropic-ai/sdk/client` and `@anthropic-ai/sdk/core/*`.

That means typecheck and lint can pass, but the production extension bundle fails during esbuild with:

```text
Could not resolve "@anthropic-ai/sdk/core"
node_modules/@anthropic-ai/vertex-sdk/client.mjs:1:22
```

This PR bumps the paired Anthropic packages so the Vertex SDK matches the runtime SDK line:

- `@anthropic-ai/sdk`: `^0.50.1` to `^0.50.4`
- `@anthropic-ai/vertex-sdk`: `^0.6.4` to `^0.11.5`

`@anthropic-ai/vertex-sdk@0.11.5` depends on `@anthropic-ai/sdk >=0.50.3 <1` and imports `@anthropic-ai/sdk/client`, which is exported by the SDK. This keeps the Node 24 native fetch fix from #11454 while restoring the production bundle path for Vertex users.

### Test Procedure

I verified the exact failure before this change by running:

```bash
npm run package
```

Before this PR, that command passed typecheck, webview build, and lint, then failed during the production esbuild step because `@anthropic-ai/vertex-sdk@0.6.4` imported `@anthropic-ai/sdk/core`.

After this PR, I ran:

```bash
npm install
npm run package
npm ls @anthropic-ai/sdk @anthropic-ai/vertex-sdk --prefix apps/vscode
```

`npm run package` now passes end to end, including the esbuild step that previously failed.

The resolved dependency tree is:

```text
@anthropic-ai/sdk@0.50.4
@anthropic-ai/vertex-sdk@0.11.5
└── @anthropic-ai/sdk@0.50.4 deduped
```

I also checked the installed SDK package metadata. `@anthropic-ai/sdk@0.50.4` still has no runtime dependencies and requires Node `>= 20`, so it preserves the native fetch runtime fix needed for VS Code 1.123 and Node 24.

Potentially affected functionality:

- Anthropic provider: should retain the Node 24 fix from #11454.
- Vertex Claude provider: production bundling now succeeds with a Vertex SDK version that is compatible with the `0.50.x` Anthropic SDK export map.
- Other providers: unchanged, since this only touches package versions and the lockfile.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable. This is a dependency compatibility fix for the VS Code extension build.

### Additional Notes

I did not run the full `npm test` suite. The release-relevant command for this regression is `npm run package`, because the bug was in the production bundle step, and that now passes.
