### PR TITLE
docs(changelog): note Vertex SDK companion bump in 3.89.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Complete the fix for the Anthropic provider on VS Code 1.123 and later by upgrading the bundled Anthropic SDK to a release compatible with the Node 24 runtime.
+- Update the Vertex AI provider to a compatible Anthropic Vertex SDK release so it works with the upgraded Anthropic SDK.
 
 ## [3.89.1]
 


### PR DESCRIPTION
### Related Issue

**Issue:** N/A (release changelog)

### Description

Adds a changelog line to the existing `3.89.2` entry covering the Anthropic Vertex SDK companion bump.

Context: the version on `main` is already `3.89.2`, but it was never published (latest release is `v3.89.1`, no `v3.89.2` tag). The Anthropic SDK upgrade to `0.50.x` required bumping `@anthropic-ai/vertex-sdk` to `0.11.x` (the companion release built against the native-fetch core layout), since the old `0.6.4` imported the removed `@anthropic-ai/sdk/core` subpath and broke the esbuild bundle. That vertex fix already merged. This just records it in the `3.89.2` changelog before we publish `v3.89.2`.

No version bump needed since `3.89.2` was never shipped.

### Test Procedure

- `npx tsc --noEmit` clean and `node esbuild.mjs` builds successfully on current `main`.

### Type of Change

-   [x] 📚 Documentation update
