### PR TITLE
fix(vscode): never load bundled undici in VSCode builds to fix Anthropic connection errors

### DIFF
--- a/apps/vscode/src/core/api/providers/openai-codex.ts
+++ b/apps/vscode/src/core/api/providers/openai-codex.ts
@@ -1,21 +1,21 @@
-import { ModelInfo, OpenAiCodexModelId, openAiCodexDefaultModelId, openAiCodexModels } from "@shared/api"
+import { type ModelInfo, type OpenAiCodexModelId, openAiCodexDefaultModelId, openAiCodexModels } from "@shared/api"
 import { normalizeOpenaiReasoningEffort } from "@shared/storage/types"
 import OpenAI from "openai"
 import type { ChatCompletionTool } from "openai/resources/chat/completions"
 import * as os from "os"
-import { MessageEvent as UndiciMessageEvent, WebSocket as UndiciWebSocket } from "undici"
+import type { MessageEvent as UndiciMessageEvent } from "undici"
 import { v7 as uuidv7 } from "uuid"
 import { openAiCodexOAuthManager } from "@/integrations/openai-codex/oauth"
 import { buildExternalBasicHeaders } from "@/services/EnvUtils"
 import { featureFlagsService } from "@/services/feature-flags"
-import { ClineStorageMessage } from "@/shared/messages/content"
-import { fetch } from "@/shared/net"
+import type { ClineStorageMessage } from "@/shared/messages/content"
+import { type ClineWebSocket, createWebSocket, fetch } from "@/shared/net"
 import { ApiFormat } from "@/shared/proto/cline/models"
 import { FeatureFlag } from "@/shared/services/feature-flags/feature-flags"
 import { Logger } from "@/shared/services/Logger"
-import { ApiHandler, CommonApiHandlerOptions } from "../"
+import type { ApiHandler, CommonApiHandlerOptions } from "../"
 import { convertToOpenAIResponsesInput } from "../transform/openai-response-format"
-import { ApiStream, ApiStreamUsageChunk } from "../transform/stream"
+import type { ApiStream, ApiStreamUsageChunk } from "../transform/stream"
 
 /**
  * OpenAI Codex base URL for API requests
@@ -42,7 +42,7 @@ interface OpenAiCodexHandlerOptions extends CommonApiHandlerOptions {
 export class OpenAiCodexHandler implements ApiHandler {
 	private options: OpenAiCodexHandlerOptions
 	private client?: OpenAI
-	private responsesWs: UndiciWebSocket | undefined
+	private responsesWs: ClineWebSocket | undefined
 	private websocketRequestInFlight = false
 	// Session ID for the Codex API (persists for the lifetime of the handler)
 	private readonly sessionId: string
@@ -313,19 +313,17 @@ export class OpenAiCodexHandler implements ApiHandler {
 		return false
 	}
 
-	private async ensureResponsesWebsocket(accessToken: string, codexHeaders: Record<string, string>): Promise<UndiciWebSocket> {
-		if (this.responsesWs && this.responsesWs.readyState === UndiciWebSocket.OPEN) {
+	private async ensureResponsesWebsocket(accessToken: string, codexHeaders: Record<string, string>): Promise<ClineWebSocket> {
+		if (this.responsesWs && this.responsesWs.readyState === this.responsesWs.OPEN) {
 			return this.responsesWs
 		}
 
 		this.closeResponsesWebsocket()
 
-		const ws = new UndiciWebSocket(CODEX_RESPONSES_WEBSOCKET_URL, {
-			headers: {
-				Authorization: `Bearer ${accessToken}`,
-				"OpenAI-Beta": "responses_websockets=2026-02-06",
-				...codexHeaders,
-			},
+		const ws = createWebSocket(CODEX_RESPONSES_WEBSOCKET_URL, {
+			Authorization: `Bearer ${accessToken}`,
+			"OpenAI-Beta": "responses_websockets=2026-02-06",
+			...codexHeaders,
 		})
 
 		await new Promise<void>((resolve, reject) => {

--- a/apps/vscode/src/core/api/providers/openai-native.ts
+++ b/apps/vscode/src/core/api/providers/openai-native.ts
@@ -1,32 +1,32 @@
 import {
-	ModelInfo,
-	OpenAiCompatibleModelInfo,
-	OpenAiNativeModelId,
+	type ModelInfo,
+	type OpenAiCompatibleModelInfo,
+	type OpenAiNativeModelId,
 	openAiNativeDefaultModelId,
 	openAiNativeModels,
 } from "@shared/api"
 import { normalizeOpenaiReasoningEffort } from "@shared/storage/types"
 import { calculateApiCostOpenAI } from "@utils/cost"
-import OpenAI from "openai"
+import type OpenAI from "openai"
 import type {
 	ChatCompletionFunctionTool,
 	ChatCompletionReasoningEffort,
 	ChatCompletionTool,
 } from "openai/resources/chat/completions"
-import { MessageEvent as UndiciMessageEvent, WebSocket as UndiciWebSocket } from "undici"
+import type { MessageEvent as UndiciMessageEvent } from "undici"
 import { buildExternalBasicHeaders } from "@/services/EnvUtils"
 import { featureFlagsService } from "@/services/feature-flags"
-import { ClineStorageMessage } from "@/shared/messages/content"
-import { createOpenAIClient } from "@/shared/net"
+import type { ClineStorageMessage } from "@/shared/messages/content"
+import { type ClineWebSocket, createOpenAIClient, createWebSocket } from "@/shared/net"
 import { ApiFormat } from "@/shared/proto/cline/models"
 import { FeatureFlag } from "@/shared/services/feature-flags/feature-flags"
 import { Logger } from "@/shared/services/Logger"
 import { isGPT5ModelFamily } from "@/utils/model-utils"
-import { ApiHandler, CommonApiHandlerOptions } from "../"
+import type { ApiHandler, CommonApiHandlerOptions } from "../"
 import { withRetry } from "../retry"
 import { convertToOpenAiMessages } from "../transform/openai-format"
 import { convertToOpenAIResponsesInput } from "../transform/openai-response-format"
-import { ApiStream } from "../transform/stream"
+import type { ApiStream } from "../transform/stream"
 import { getOpenAIToolParams, ToolCallProcessor } from "../transform/tool-call-processor"
 
 interface OpenAiNativeHandlerOptions extends CommonApiHandlerOptions {
@@ -40,8 +40,8 @@ interface OpenAiNativeHandlerOptions extends CommonApiHandlerOptions {
 export class OpenAiNativeHandler implements ApiHandler {
 	private options: OpenAiNativeHandlerOptions
 	private client: OpenAI | undefined
-	private responsesWs: UndiciWebSocket | undefined
-	private responsesWsReadyPromise: Promise<UndiciWebSocket> | undefined
+	private responsesWs: ClineWebSocket | undefined
+	private responsesWsReadyPromise: Promise<ClineWebSocket> | undefined
 	private websocketRequestInFlight = false
 	private abortController?: AbortController
 
@@ -269,7 +269,9 @@ export class OpenAiNativeHandler implements ApiHandler {
 	): ApiStream {
 		const client = this.ensureClient()
 		Logger.debug(`OpenAI Responses Input (HTTP): ${JSON.stringify(params.input)}`)
-		const stream = await client.responses.create(params, { signal: this.abortController?.signal })
+		const stream = await client.responses.create(params, {
+			signal: this.abortController?.signal,
+		})
 		yield* this.processResponsesEvents(stream, modelInfo)
 	}
 
@@ -307,8 +309,8 @@ export class OpenAiNativeHandler implements ApiHandler {
 		return false
 	}
 
-	private async ensureResponsesWebsocket(): Promise<UndiciWebSocket> {
-		if (this.responsesWs && this.responsesWs.readyState === UndiciWebSocket.OPEN) {
+	private async ensureResponsesWebsocket(): Promise<ClineWebSocket> {
+		if (this.responsesWs && this.responsesWs.readyState === this.responsesWs.OPEN) {
 			return this.responsesWs
 		}
 
@@ -322,16 +324,14 @@ export class OpenAiNativeHandler implements ApiHandler {
 			throw new Error("OpenAI API key is required")
 		}
 
-		const ws = new UndiciWebSocket("wss://api.openai.com/v1/responses", {
-			headers: {
-				Authorization: `Bearer ${this.options.openAiNativeApiKey}`,
-				"OpenAI-Beta": "responses_websockets=2026-02-06",
-				...buildExternalBasicHeaders(),
-			},
+		const ws = createWebSocket("wss://api.openai.com/v1/responses", {
+			Authorization: `Bearer ${this.options.openAiNativeApiKey}`,
+			"OpenAI-Beta": "responses_websockets=2026-02-06",
+			...buildExternalBasicHeaders(),
 		})
 
 		this.responsesWs = ws
-		const readyPromise = new Promise<UndiciWebSocket>((resolve, reject) => {
+		const readyPromise = new Promise<ClineWebSocket>((resolve, reject) => {
 			const cleanup = () => {
 				ws.removeEventListener("open", handleOpen)
 				ws.removeEventListener("error", handleError)
@@ -509,7 +509,11 @@ export class OpenAiNativeHandler implements ApiHandler {
 			if (chunk.type === "response.output_item.added") {
 				const item = chunk.item
 				if (item.type === "function_call" && item.id) {
-					functionCallByItemId.set(item.id, { call_id: item.call_id, name: item.name, id: item.id })
+					functionCallByItemId.set(item.id, {
+						call_id: item.call_id,
+						name: item.name,
+						id: item.id,
+					})
 					yield {
 						type: "tool_calls",
 						id: item.id,
@@ -536,7 +540,11 @@ export class OpenAiNativeHandler implements ApiHandler {
 				const item = chunk.item
 				if (item.type === "function_call") {
 					if (item.id) {
-						functionCallByItemId.set(item.id, { call_id: item.call_id, name: item.name, id: item.id })
+						functionCallByItemId.set(item.id, {
+							call_id: item.call_id,
+							name: item.name,
+							id: item.id,
+						})
 					}
 					yield {
 						type: "tool_calls",

--- a/apps/vscode/src/shared/net.ts
+++ b/apps/vscode/src/shared/net.ts
@@ -93,9 +93,28 @@
  * ```
  */
 
-import OpenAI, { ClientOptions as OpenAIClientOptions } from "openai"
-import { EnvHttpProxyAgent, setGlobalDispatcher, fetch as undiciFetch } from "undici"
+import OpenAI, { type ClientOptions as OpenAIClientOptions } from "openai"
+import type { WebSocket as UndiciWebSocket } from "undici"
 import { buildExternalBasicHeaders } from "@/services/EnvUtils"
+
+/**
+ * IMPORTANT: undici must only ever be loaded in standalone (JetBrains/CLI)
+ * builds, and only via the lazy `require` calls below--never via a top-level
+ * value import.
+ *
+ * Merely evaluating the undici module registers its Agent at the global
+ * symbol `Symbol.for("undici.globalDispatcher.1")`, which is shared with
+ * Node's built-in fetch. When the bundled undici version differs from the
+ * undici built into the Node runtime (e.g. VS Code's Electron), built-in
+ * fetch picks up the foreign Agent and requests can fail with errors like
+ * `UND_ERR_INVALID_ARG: invalid content-length header`. This broke the
+ * Anthropic provider on VS Code 1.124 / Electron 42 / Node 24.
+ * See https://github.com/cline/cline/issues/11407
+ */
+function requireUndici(): typeof import("undici") {
+	// eslint-disable-next-line @typescript-eslint/no-require-imports
+	return require("undici")
+}
 
 let mockFetch: typeof globalThis.fetch | undefined
 
@@ -117,7 +136,9 @@ export const fetch: typeof globalThis.fetch = (() => {
 	// to "true" or "false" (as strings) in the JetBrains/CLI build.
 	// We must use explicit string comparison because "false" is truthy in JS.
 	if (process.env.IS_STANDALONE === "true") {
-		// Configure undici with ProxyAgent
+		// Configure undici with ProxyAgent. undici is loaded lazily so that
+		// the VSCode build never evaluates it (see requireUndici above).
+		const { EnvHttpProxyAgent, setGlobalDispatcher, fetch: undiciFetch } = requireUndici()
 		const agent = new EnvHttpProxyAgent({})
 		setGlobalDispatcher(agent)
 		baseFetch = undiciFetch as any as typeof globalThis.fetch
@@ -199,4 +220,36 @@ export function createOpenAIClient(options: OpenAIClientOptions): OpenAI {
 		},
 		fetch, // Use configured fetch with proxy support
 	})
+}
+
+/**
+ * WebSocket type used by `createWebSocket`. Node 22+'s global WebSocket is
+ * undici's implementation, so undici's type describes both branches below.
+ */
+export type ClineWebSocket = UndiciWebSocket
+
+/**
+ * Creates a WebSocket that supports custom request headers (a non-standard
+ * extension provided by undici's WebSocket, which is also Node's built-in
+ * WebSocket since Node 22).
+ *
+ * - **VSCode**: uses `globalThis.WebSocket`, which VS Code's extension host
+ *   patches for proxy support. We must not use the bundled undici here (see
+ *   requireUndici above).
+ * - **JetBrains, CLI**: uses the bundled undici WebSocket so the connection
+ *   goes through the EnvHttpProxyAgent global dispatcher configured above.
+ */
+export function createWebSocket(url: string, headers: Record<string, string>): ClineWebSocket {
+	if (process.env.IS_STANDALONE === "true") {
+		const { WebSocket: StandaloneWebSocket } = requireUndici()
+		return new StandaloneWebSocket(url, { headers })
+	}
+	// Note: `headers` in the init object is non-standard, but supported by
+	// Node's (undici-based) global WebSocket implementation.
+	return new (
+		globalThis.WebSocket as unknown as new (
+			url: string,
+			init: { headers: Record<string, string> },
+		) => ClineWebSocket
+	)(url, { headers })
 }


### PR DESCRIPTION
### Related Issue

**Issue:** #11407

### Description

On VS Code 1.122+ (Electron 42 / Node 24), the Anthropic provider fails every request with `{"message":"Connection error."}`.

**Root cause** (not an SDK version problem per se — bumping `@anthropic-ai/sdk` to 0.40.1 in #11449 did not resolve it):

1. `shared/net.ts` had a top-level `import { EnvHttpProxyAgent, ... } from "undici"`. Even in the VSCode build (where the standalone proxy branch is dead code), merely **evaluating** the undici module registers its `Agent` at the process-wide `Symbol.for("undici.globalDispatcher.1")`.
2. Node's built-in `fetch` shares that symbol. With our bundled undici (7.26.0) differing from the runtime's internal undici (7.24.4 in Electron 42), built-in fetch ends up driving a *foreign* Agent.
3. The Anthropic SDK ≤0.40.x manually sets a `content-length` header; the mismatched dispatcher rejects it with `UND_ERR_INVALID_ARG: invalid content-length header`, which the SDK surfaces as `APIConnectionError: Connection error.`

"Aligning" undici versions is not a robust fix — we'd be chasing the exact undici version inside every Electron/Node that each VS Code update ships. Instead, the VSCode build should never load bundled undici at all: VS Code already patches global `fetch` and `WebSocket` in the extension host for proxy support. Bundled undici is only needed on standalone (JetBrains/CLI) for env-var proxy support.

**Changes:**

- `shared/net.ts`: undici is now loaded lazily via `require()` strictly inside the `IS_STANDALONE === "true"` branch (esbuild statically rewrites the condition, so the VSCode bundle contains zero `require("undici")` sites — verified against the built bundle). Added a `createWebSocket(url, headers)` helper: global WebSocket on VSCode (proxy-patched by VS Code; supports the non-standard `{ headers }` init since Node 22), bundled undici WebSocket on standalone (routes through the `EnvHttpProxyAgent` global dispatcher). A prominent comment documents the dispatcher-symbol footgun.
- `openai-native.ts` / `openai-codex.ts`: undici value imports converted to type-only imports; Responses-API websockets created via `createWebSocket()`; `UndiciWebSocket.OPEN` statics replaced with instance constants.

### Test Procedure

Each link in the causal chain was reproduced and verified under VS Code 1.124.0's actual Electron binary (`ELECTRON_RUN_AS_NODE=1`, Electron 42.2.0 / Node 24.15.0), including a replication of VS Code's own `@vscode/proxy-agent` fetch patching:

- **Repro**: `new Anthropic({ apiKey, fetch })` + streaming `messages.create` with SDK 0.37.0/0.40.1 fails in ~1–17 ms with `APIConnectionError` ← `UND_ERR_INVALID_ARG: invalid content-length header` once bundled undici is imported; works without the import.
- **A/B/C test**: (A) top-level undici import + our fetch wrapper → fails; (B) same wrapper, no undici import → works; (C) no custom fetch → works.
- **VSCode bundle (after fix)**: loading `dist/extension.js` inside Electron 42 registers **no** global dispatcher symbol, and a fetch carrying an explicit `content-length` header (the previously-failing case) succeeds.
- **Standalone bundle (no regression)**: loading `dist-standalone/cline-core.js` still installs `EnvHttpProxyAgent` as the global dispatcher; a local CONNECT-proxy test confirmed env-var proxy routing works.
- **WebSocket parity**: verified against a local upgrade-logging server that the global WebSocket on both Node 22 and Electron 42/Node 24 delivers custom `Authorization`/`OpenAI-Beta` headers exactly like undici's WebSocket (it *is* undici's).
- `tsc --noEmit` ✅, biome lint ✅, unit suite: 1470 passing ✅.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A (backend/network change). Before/after evidence from the Electron 42 probe:

```
# before (with bundled undici imported at module scope)
[sdk 0.37.0] APIConnectionError: Connection error.
    cause: TypeError fetch failed
    cause: UND_ERR_INVALID_ARG invalid content-length header

# after (VSCode bundle, no undici evaluation)
dispatcher symbol after require(bundle): undefined
fetch with explicit content-length: status=401 (PASS — reaches the API)
```

### Additional Notes

Follow-ups worth tracking separately:

1. **JetBrains**: bump the bundled Node (currently 22.15.0) to ≥22.18/24.x and set `NODE_USE_ENV_PROXY=1` in `CoreProcessManager` — verified that native env-proxy support then routes through proxies with plain global fetch, which would let us delete bundled undici from standalone too.
2. The `@anthropic-ai/sdk` 0.37→0.93 modernization (groundwork in #11449) is still worthwhile independently, but is no longer required to fix this bug.
