### PR TITLE
fix: thread proxy/CA-aware fetch into the SDK inference path

### DIFF
--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -21,6 +21,7 @@ import { stringifyVsCodeLmModelSelector } from "@shared/vsCodeSelectorUtils"
 import { StateManager } from "@/core/storage/StateManager"
 import { ExtensionRegistryInfo } from "@/registry"
 import { getDistinctId } from "@/services/logging/distinctId"
+import { fetch } from "@/shared/net"
 import { type BedrockProviderConfig, buildBedrockProviderConfig } from "./bedrock-config"
 import { buildAgentHooks } from "./hooks-adapter"
 import { readTaskHistory, resolveDataDir } from "./legacy-state-reader"
@@ -589,20 +590,22 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 	// extension's "openai"). Convert before handing the id to core.
 	const sdkProviderId = toSdkProviderId(providerId)
 
-	// Cloud providers require structured options (region/project/auth). Core reads
-	// these from providerConfig in createAgentModelFromConfig, but only when its
-	// providerId/modelId match the session, so build a minimal ProviderConfig.
+	// Always pass a providerConfig so the proxy/CA-aware fetch reaches the SDK
+	// gateway; without it the agent loop uses bare global fetch and corporate
+	// proxy/self-signed CA setups fail on JetBrains and CLI. Cloud providers
+	// additionally need structured options (region/project/auth), which core
+	// reads from providerConfig in createAgentModelFromConfig.
 	const cloudProviderConfig = bedrockProviderConfig ?? vertexProviderConfig
-	const providerConfig =
-		cloudProviderConfig !== undefined
-			? {
-					providerId: sdkProviderId,
-					modelId,
-					apiKey,
-					baseUrl,
-					...cloudProviderConfig,
-				}
-			: undefined
+	// Spread the cloud config first so the explicit fields below — notably the
+	// proxy/CA-aware fetch — can never be clobbered if those types gain matching keys.
+	const providerConfig = {
+		...(cloudProviderConfig ?? {}),
+		providerId: sdkProviderId,
+		modelId,
+		apiKey,
+		baseUrl,
+		fetch,
+	}
 
 	const config: CoreSessionConfig = {
 		providerId: sdkProviderId,

--- a/apps/vscode/src/standalone/cline-core.ts
+++ b/apps/vscode/src/standalone/cline-core.ts
@@ -1,3 +1,9 @@
+// Side-effect import: in the standalone (JetBrains/CLI) build (IS_STANDALONE==="true"),
+// loading @/shared/net installs the undici EnvHttpProxyAgent as the global dispatcher
+// so all HTTP/inference honors proxy/CA configuration. It must run before any network
+// I/O, so KEEP IT FIRST: do not add an import above this line that performs network
+// work at module-eval time, or proxy support silently breaks on JetBrains/CLI.
+import "@/shared/net"
 import { ExternalCommentReviewController } from "@hosts/external/ExternalCommentReviewController"
 import { ExternalDiffViewProvider } from "@hosts/external/ExternalDiffviewProvider"
 import { ExternalWebviewProvider } from "@hosts/external/ExternalWebviewProvider"

--- a/sdk/packages/core/src/services/llms/handler-factory.test.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.test.ts
@@ -92,6 +92,39 @@ describe("createAgentModelFromConfig", () => {
 		);
 	});
 
+	it("forwards a host-provided fetch into the gateway (top-level and per-provider)", async () => {
+		const { createAgentModelFromConfig } = await import("./handler-factory");
+		const hostFetch = vi.fn() as unknown as typeof fetch;
+
+		createAgentModelFromConfig(
+			{
+				providerId: "openai-compatible",
+				modelId: "mock-model",
+				apiKey: "key",
+				systemPrompt: "",
+				tools: [],
+				providerConfig: {
+					providerId: "openai-compatible",
+					modelId: "mock-model",
+					fetch: hostFetch,
+				},
+			},
+			undefined,
+		);
+
+		expect(gatewayMock.createGateway).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				fetch: hostFetch,
+				providerConfigs: [
+					expect.objectContaining({
+						providerId: "openai-compatible",
+						fetch: hostFetch,
+					}),
+				],
+			}),
+		);
+	});
+
 	it("preserves model capabilities and metadata when configuring gateway models", async () => {
 		const { createAgentModelFromConfig } = await import("./handler-factory");
 

--- a/sdk/packages/core/src/services/llms/handler-factory.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.ts
@@ -184,12 +184,18 @@ export function createAgentModelFromConfig(
 	}
 
 	return createGateway({
+		// Forward the host-provided fetch so inference honors proxy/CA config on
+		// JetBrains and CLI, where the global fetch is not proxy-aware. Without
+		// this the agent loop falls back to bare global fetch and corporate
+		// proxy/self-signed CA setups fail.
+		fetch: normalizedProviderConfig.fetch,
 		providerConfigs: [
 			{
 				providerId: normalizedProviderConfig.providerId,
 				apiKey: normalizedProviderConfig.apiKey,
 				baseUrl: normalizedProviderConfig.baseUrl,
 				headers: normalizedProviderConfig.headers,
+				fetch: normalizedProviderConfig.fetch,
 				options: buildGatewayProviderOptions(normalizedProviderConfig),
 				models: normalizedProviderConfig.knownModels
 					? Object.entries(normalizedProviderConfig.knownModels).map(


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

#### What

Make the SDK inference path honor proxy and custom-CA configuration on the
standalone hosts (JetBrains, CLI), and make the standalone proxy dispatcher
install deterministic.

Two commits:

1. **Thread the proxy/CA-aware `fetch` into the SDK inference path.**
   - App (`cline-session-factory.ts`): always build `CoreSessionConfig.providerConfig`
     and carry the proxy/CA-aware `fetch` from `@/shared/net`, not just for cloud
     providers (Bedrock/Vertex).
   - SDK (`handler-factory.ts`): forward `providerConfig.fetch` into `createGateway`
     as both the top-level fallback fetch and the per-provider fetch, so the
     gateway's provider clients actually use it.
   - Adds a unit test asserting the host fetch reaches `createGateway` at both
     levels.
2. **Deterministically install the proxy dispatcher in the standalone core.**
   - `cline-core.ts` now imports `@/shared/net` for its side effect (installing the
     undici `EnvHttpProxyAgent` global dispatcher in the standalone build), first,
     so the install is guaranteed rather than incidental on the import graph.

#### Why

The SDK agent loop never received the host's proxy/CA-aware `fetch`, so inference
through a corporate proxy or to a self-signed / private-CA endpoint failed with
`unable to get local issuer certificate`. In VS Code this `fetch` is the global
fetch (proxy handled by VS Code), so behavior there is unchanged; in the
standalone (JetBrains) build it is undici with `EnvHttpProxyAgent`. Passing
`undefined` is a no-op (the registry resolves
`config?.fetch ?? defaults?.fetch ?? fallbackFetch`), so other SDK consumers are
unaffected.

#### Scope -- what this PR fixes vs. does not

**Fixes:**
- VS Code and JetBrains: the main agent loop now routes inference through the
  proxy/CA-aware fetch.
- JetBrains standalone core: the proxy dispatcher is installed deterministically
  at startup.
- Any SDK host that supplies a `fetch` benefits from the gateway-forwarding
  change.

**Does NOT fix (yet):**
- **The original report is the CLI, and this PR does not resolve it.** The CLI
  builds its session config through a separate path (`apps/cli`) and runs on Bun,
  whose native `fetch` already reads `HTTPS_PROXY` and `NODE_EXTRA_CA_CERTS` -- so
  the missing-fetch problem this PR fixes does not exist there. The CLI failure on
  Windows has a different, still-open root cause (Node->Bun runtime change at the
  3.0 rewrite; suspected difference in how Bun-on-Windows reads the Windows system
  trust store / `NODE_USE_SYSTEM_CA`). A **Windows + Bun investigation is in
  progress**, and the CLI fix will land as a **follow-up**.

#### Related

- JetBrains-plugin companion PR (fixes `NODE_EXTRA_CA_CERTS` handling on the Kotlin
  side): https://github.com/cline/intellij-plugin/pull/983
- Tracking issue: cline/cline#11175

#### Testing

- `handler-factory` unit test passes (host fetch forwarded top-level + per
  provider).
- `tsc --noEmit` on `apps/vscode` clean for the changed files (pre-existing
  proto-gen errors in `providerCatalogShared.ts` are unrelated and resolve after
  `npm run protos`).
- Reproduced the trust failure + fix end-to-end on macOS against a private-CA
  HTTPS OpenAI-compatible endpoint through the exact `@ai-sdk/openai-compatible`
  client the SDK uses.

#### Notes

- VS Code behavior is unchanged (its `fetch` is the global fetch).
- No new dependencies; no public API changes.


<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
