### PR TITLE
fix(sdk): stop full command echo duplication in provider-facing run_commands tool results

### DIFF
--- a/sdk/packages/core/src/extensions/tools/definitions.test.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.test.ts
@@ -11,7 +11,7 @@ import {
 	createSkillsTool,
 	createWindowsShellTool,
 } from "./definitions";
-import { TimeoutError } from "./helpers";
+import { RUN_COMMAND_QUERY_PREVIEW_LIMIT, TimeoutError } from "./helpers";
 import { INPUT_ARG_CHAR_LIMIT } from "./schemas";
 import type { SkillsExecutorWithMetadata } from "./types";
 
@@ -592,6 +592,108 @@ describe("default run_commands tool", () => {
 				iteration: 1,
 			}),
 		);
+	});
+
+	it("keeps short command echoes unchanged in tool results", async () => {
+		const execute = vi.fn(
+			async (command: string | { command: string }) =>
+				`ran:${typeof command === "string" ? command : command.command}`,
+		);
+		const tool = createBashTool(execute);
+
+		const result = await tool.execute(
+			{ commands: ["git status --short"] },
+			{
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 1,
+			},
+		);
+
+		expect(result).toEqual([
+			{
+				query: "git status --short",
+				result: "ran:git status --short",
+				success: true,
+			},
+		]);
+	});
+
+	it("truncates long command echoes in tool results without affecting execution", async () => {
+		const execute = vi.fn(
+			async (command: string | { command: string }) =>
+				`ran:${typeof command === "string" ? command.length : command.command.length}`,
+		);
+		const tool = createBashTool(execute);
+		const largeSource = "x".repeat(14000);
+		const command = `cat > /app/eval.scm << 'EOF'\n${largeSource}\nEOF`;
+
+		const result = (await tool.execute(
+			{ commands: [command] },
+			{
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 1,
+			},
+		)) as Array<{ query: string; result: string; success: boolean }>;
+
+		// The executor still receives the full command
+		expect(execute).toHaveBeenCalledWith(
+			command,
+			process.cwd(),
+			expect.anything(),
+		);
+		expect(result[0].success).toBe(true);
+		expect(result[0].result).toBe(`ran:${command.length}`);
+		// The provider-facing echo is bounded and self-describing
+		expect(result[0].query.length).toBeLessThan(
+			RUN_COMMAND_QUERY_PREVIEW_LIMIT + 100,
+		);
+		expect(result[0].query).toContain("cat > /app/eval.scm << 'EOF'");
+		expect(result[0].query).toContain("command truncated");
+		expect(result[0].query).toContain("full command is in the tool call input");
+	});
+
+	it("truncates long command echoes on the error path too", async () => {
+		const execute = vi.fn(async () => {
+			throw new Error("boom");
+		});
+		const tool = createBashTool(execute);
+		const command = `cat > /app/big.txt << 'EOF'\n${"y".repeat(10000)}\nEOF`;
+
+		const result = (await tool.execute(
+			{ commands: [command] },
+			{
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 1,
+			},
+		)) as Array<{ query: string; success: boolean; error?: string }>;
+
+		expect(result[0].success).toBe(false);
+		expect(result[0].error).toContain("boom");
+		expect(result[0].query.length).toBeLessThan(
+			RUN_COMMAND_QUERY_PREVIEW_LIMIT + 100,
+		);
+		expect(result[0].query).toContain("command truncated");
+	});
+
+	it("truncates long command echoes for the structured windows shell tool", async () => {
+		const execute = vi.fn(async () => "ok");
+		const tool = createWindowsShellTool(execute);
+		const command = `powershell -Command "${"z".repeat(9000)}"`;
+
+		const result = (await tool.execute({ commands: [command] } as never, {
+			agentId: "agent-1",
+			conversationId: "conv-1",
+			iteration: 1,
+		})) as Array<{ query: string; success: boolean }>;
+
+		expect(result[0].success).toBe(true);
+		expect(result[0].query.length).toBeLessThan(
+			RUN_COMMAND_QUERY_PREVIEW_LIMIT + 100,
+		);
+		expect(result[0].query).toContain("command truncated");
 	});
 
 	it("emits timeout telemetry without leaking raw command data", async () => {

--- a/sdk/packages/core/src/extensions/tools/definitions.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.ts
@@ -16,7 +16,7 @@ import { getToolContextTelemetry } from "../../services/telemetry/tool-context";
 import {
 	formatError,
 	formatReadFileQuery,
-	formatRunCommandQuery,
+	formatRunCommandQueryPreview,
 	getEditorSizeError,
 	getReadFileRangeError,
 	normalizeRunCommandsInput,
@@ -310,6 +310,7 @@ export function createBashTool(
 			return Promise.all(
 				commands.map(async (command: string): Promise<ToolOperationResult> => {
 					const startedAt = Date.now();
+					const query = formatRunCommandQueryPreview(command);
 					try {
 						const output = await withTimeout(
 							executor(command, cwd, context),
@@ -317,7 +318,7 @@ export function createBashTool(
 							`Command timed out after ${timeoutMs}ms`,
 						);
 						return {
-							query: command,
+							query,
 							result: output,
 							success: true,
 						};
@@ -332,7 +333,7 @@ export function createBashTool(
 						}
 						const msg = formatError(error);
 						return {
-							query: command,
+							query,
 							result: "",
 							error: `Command failed: ${msg}`,
 							success: false,
@@ -376,6 +377,7 @@ export function createWindowsShellTool(
 			return Promise.all(
 				commands.map(async (command): Promise<ToolOperationResult> => {
 					const startedAt = Date.now();
+					const query = formatRunCommandQueryPreview(command);
 					try {
 						const output = await withTimeout(
 							executor(command, cwd, context),
@@ -383,7 +385,7 @@ export function createWindowsShellTool(
 							`Command timed out after ${timeoutMs}ms`,
 						);
 						return {
-							query: formatRunCommandQuery(command),
+							query,
 							result: output,
 							success: true,
 						};
@@ -398,7 +400,7 @@ export function createWindowsShellTool(
 						}
 						const msg = formatError(error);
 						return {
-							query: formatRunCommandQuery(command),
+							query,
 							result: "",
 							error: `Command failed: ${msg}`,
 							success: false,

--- a/sdk/packages/core/src/extensions/tools/helpers.ts
+++ b/sdk/packages/core/src/extensions/tools/helpers.ts
@@ -124,3 +124,27 @@ export function formatRunCommandQuery(
 	);
 	return `${command.command} ${renderedArgs.join(" ")}`;
 }
+
+/**
+ * Max characters of the executed command echoed back in the tool result's
+ * `query` field. The full command already exists in the assistant tool-call
+ * input, so repeating it in the result only duplicates tokens in the
+ * provider request (expensive for large heredoc/file-generation commands).
+ */
+export const RUN_COMMAND_QUERY_PREVIEW_LIMIT = 200;
+
+/**
+ * Bound the command echo placed in a provider-facing tool result.
+ * Short commands pass through unchanged; long commands keep a short
+ * prefix plus a truncation note so the result is still identifiable.
+ */
+export function formatRunCommandQueryPreview(
+	command: string | StructuredCommandInput,
+): string {
+	const rendered = formatRunCommandQuery(command);
+	if (rendered.length <= RUN_COMMAND_QUERY_PREVIEW_LIMIT) {
+		return rendered;
+	}
+	const truncatedChars = rendered.length - RUN_COMMAND_QUERY_PREVIEW_LIMIT;
+	return `${rendered.slice(0, RUN_COMMAND_QUERY_PREVIEW_LIMIT)} ... [command truncated: ${truncatedChars} more chars; full command is in the tool call input]`;
+}


### PR DESCRIPTION
## Problem

The `run_commands` tool puts the full executed command into the tool result's `query` field. The same command is already present verbatim in the assistant tool-call input, so for large generated-file commands (e.g. `cat > file << 'EOF' ...` heredocs) the entire source text was duplicated into the conversation and resent in every subsequent provider request — expensive over repeated turns and cached context.

```jsonc
// assistant tool call
{"commands":["cat > /app/eval.scm << 'EOF'\n...large source...\nEOF"]}
// tool result repeated it all over again
{"query":"cat > /app/eval.scm << 'EOF'\n...large source...\nEOF","result":"","success":true}
```

## Fix

`sdk/packages/core/src/extensions/tools/`:

- New `formatRunCommandQueryPreview()` in `helpers.ts` bounds the command echo to 200 chars plus a self-describing truncation note:
  `cat > /app/eval.scm << 'EOF' ... [command truncated: 10790 more chars; full command is in the tool call input]`
- `createBashTool` and `createWindowsShellTool` use it on both success and error paths.
- Short commands (≤200 chars, i.e. the vast majority) pass through completely unchanged.
- Command execution is untouched — the executor still receives the full command; only the provider-facing echo is bounded.

Display is unaffected: UIs render the command from the tool *call* input (which still carries the full command); the only consumer that parses result `query` strings is the read-file locator logic in `message-builder.ts`, which applies to `read_files` results only.

## A/B test with real inference

Ran the same agent task (Anthropic `claude-haiku-4-5`, SDK `Agent` + `createBashTool` with a real shell executor) against the pre-patch tool (factory built from git HEAD) and the patched tool. Task: generate a ~10 KB Scheme-evaluator file via a single `cat << 'EOF'` heredoc, then `wc -c` it — mirroring the `schemelike-metacircular-eval` echo-dominated workload. Provider-facing request messages captured per turn via a `beforeModel` hook into `*.messages.json`; usage from the provider's reported token counts.

| metric | before (run1 / run2) | after (run1 / run2) |
|---|---|---|
| heredoc tool-call input chars | 10,487 / 11,066 | 11,065 / 10,872 |
| max tool-result `query` chars | **10,415 / 10,991** | **282 / 282** |
| serialized request chars after heredoc turn | 23,379 / 24,582 | 13,839 / 13,516 |
| total prompt tokens for the task | 16,381 / 17,138 | 10,325 / 10,157 |
| task outcome | completed, correct byte count | completed, correct byte count |

- Max tool-result `query` chars dropped ~10,400–11,000 → 282 (bounded regardless of command size).
- ~40% fewer total prompt tokens on this 3-turn task; the gap compounds with longer tasks since the duplicated text rides along in every later request.
- Functionally equivalent behavior: in all runs the agent created the file with one heredoc, ran `wc -c`, and reported the real byte count; truncated echoes confirmed in captured messages, short commands (`wc -c ...`) unchanged.

## Tests

- 4 new unit tests in `definitions.test.ts`: short echoes unchanged, long echoes truncated (success + error paths, both tool variants), executor still receives the full command.
- Existing tool-result shape tests unchanged and passing: `src/extensions/tools/` suite 13 files / 127 passed.
- Full `@cline/core` unit suite: same 5 pre-existing failures (hub client/server, legacy migration, local runtime host) with and without this patch — verified by stash/re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
