### PR TITLE
Tighten provider tool result limits

### DIFF
--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
@@ -51,7 +51,10 @@ import {
 	resolveKnownModelsFromConfig,
 } from "../../services/llms/handler-factory";
 import { CLINE_INTERNAL_TELEMETRY_METADATA_KEY } from "../../services/telemetry/tool-context";
-import { MessageBuilder } from "../../session/services/message-builder";
+import {
+	getMessageBuilderOptionsFromEnv,
+	MessageBuilder,
+} from "../../session/services/message-builder";
 import { ConversationStore } from "../../session/stores/conversation-store";
 import {
 	agentMessagesToMessages,
@@ -345,7 +348,7 @@ export class SessionRuntime {
 			deps.createAgentRuntimeImpl ?? createAgentRuntime;
 
 		this.conversation = new ConversationStore(config.initialMessages);
-		this.messageBuilder = new MessageBuilder();
+		this.messageBuilder = new MessageBuilder(getMessageBuilderOptionsFromEnv());
 		this.contributionRegistry = createContributionRegistry<
 			AgentExtension,
 			AgentTool,

--- a/sdk/packages/core/src/session/services/message-builder.test.ts
+++ b/sdk/packages/core/src/session/services/message-builder.test.ts
@@ -6,7 +6,12 @@ import {
 } from "@cline/shared";
 import { describe, expect, it } from "vitest";
 import { messagesToAgentMessages } from "../../runtime/config/agent-message-codec";
-import { MessageBuilder } from "./message-builder";
+import {
+	DEFAULT_MAX_TOOL_RESULT_CHARS,
+	DEFAULT_MAX_TOTAL_TEXT_BYTES,
+	getMessageBuilderOptionsFromEnv,
+	MessageBuilder,
+} from "./message-builder";
 
 describe("MessageBuilder", () => {
 	it("inserts an error tool result before a follow-up prompt when a prior tool call is missing a result", () => {
@@ -199,6 +204,107 @@ describe("MessageBuilder", () => {
 		}
 		expect(block.content.length).toBeLessThanOrEqual(100);
 		expect(block.content).toContain("...[truncated");
+	});
+
+	it("uses aggressive provider-facing defaults", () => {
+		expect(DEFAULT_MAX_TOOL_RESULT_CHARS).toBe(8_000);
+		expect(DEFAULT_MAX_TOTAL_TEXT_BYTES).toBe(1_000_000);
+	});
+
+	it("accepts named limit options for targeted provider payload tests", () => {
+		const builder = new MessageBuilder({
+			maxToolResultChars: 120,
+			targetToolNames: new Set(["run_commands"]),
+			maxTotalTextBytes: 10_000,
+		});
+		const messages: Message[] = [
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "tool_use",
+						id: "tool_1",
+						name: "run_commands",
+						input: { commands: ["cat big.log"] },
+					},
+				],
+			},
+			{
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "tool_1",
+						name: "run_commands",
+						content: "a".repeat(500),
+					},
+				],
+			},
+		];
+
+		const result = builder.buildForApi(messages);
+		const block = Array.isArray(result[1].content)
+			? result[1].content[0]
+			: undefined;
+
+		expect(block?.type).toBe("tool_result");
+		if (block?.type !== "tool_result") {
+			throw new Error("expected tool_result");
+		}
+		expect(typeof block.content).toBe("string");
+		if (typeof block.content !== "string") {
+			throw new Error("expected string content");
+		}
+		expect(block.content.length).toBeLessThanOrEqual(120);
+		expect(block.content).toContain("...[truncated");
+	});
+
+	it("parses message-builder limit environment overrides", () => {
+		const builder = new MessageBuilder(
+			getMessageBuilderOptionsFromEnv({
+				CLINE_MESSAGE_BUILDER_MAX_TOOL_RESULT_CHARS: "96",
+				CLINE_MESSAGE_BUILDER_MAX_TOTAL_TEXT_BYTES: "5000",
+			}),
+		);
+		const messages: Message[] = [
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "tool_use",
+						id: "tool_1",
+						name: "search_codebase",
+						input: { queries: ["needle"] },
+					},
+				],
+			},
+			{
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "tool_1",
+						name: "search_codebase",
+						content: "b".repeat(500),
+					},
+				],
+			},
+		];
+
+		const result = builder.buildForApi(messages);
+		const block = Array.isArray(result[1].content)
+			? result[1].content[0]
+			: undefined;
+
+		expect(block?.type).toBe("tool_result");
+		if (block?.type !== "tool_result") {
+			throw new Error("expected tool_result");
+		}
+		expect(typeof block.content).toBe("string");
+		if (typeof block.content !== "string") {
+			throw new Error("expected string content");
+		}
+		expect(block.content.length).toBeLessThanOrEqual(96);
 	});
 
 	it("applies an aggregate text budget across targeted tool results", () => {
@@ -462,6 +568,105 @@ describe("MessageBuilder with structured ToolOperationResult content", () => {
 		}
 		return 0;
 	}
+
+	function serializeForAiSdk(messages: Message[]): string {
+		const agentMessages = messagesToAgentMessages(messages);
+		const aiSdkMessages = formatMessagesForAiSdk(
+			undefined,
+			agentMessages.map(({ role, content }) => ({
+				role,
+				content,
+			})) as unknown as AiSdkFormatterMessage[],
+		);
+		return JSON.stringify(aiSdkMessages);
+	}
+
+	function firstToolOperationResult(
+		result: Message[],
+	): ToolOperationResultLike {
+		const block = Array.isArray(result[1]?.content)
+			? result[1].content[0]
+			: undefined;
+		expect(block?.type).toBe("tool_result");
+		if (block?.type !== "tool_result" || typeof block.content === "string") {
+			throw new Error("expected structured tool_result");
+		}
+		const operation = block.content[0] as unknown;
+		expect(operation).toBeTruthy();
+		return operation as ToolOperationResultLike;
+	}
+
+	it("reduces a real-shaped multi-MB run_commands result to the default cap", () => {
+		const builder = new MessageBuilder();
+		const messages: Message[] = [
+			toolUseMessage("call_1", "run_commands", {
+				commands: ["python emit_multi_mb_output.py"],
+			}),
+			structuredToolResultMessage("call_1", "run_commands", [
+				{
+					query: "python emit_multi_mb_output.py",
+					result: hugeText(2_500_000),
+					success: true,
+					duration: 4321,
+				},
+			]),
+		];
+
+		const rawSerializedLength = JSON.stringify(messages).length;
+		const result = builder.buildForApi(messages);
+		const operation = firstToolOperationResult(result);
+		const output = operation.result;
+
+		expect(rawSerializedLength).toBeGreaterThan(2_400_000);
+		expect(typeof output).toBe("string");
+		if (typeof output !== "string") {
+			throw new Error("expected string result");
+		}
+		expect(output.length).toBeLessThanOrEqual(DEFAULT_MAX_TOOL_RESULT_CHARS);
+		expect(output).toContain("...[truncated");
+		expect(output).not.toContain(MIDDLE_SENTINEL);
+		expect(output).toContain(HEAD_MARKER);
+		expect(output).toContain(TAIL_MARKER);
+		expect(sumStringBytes(operation)).toBeLessThan(
+			DEFAULT_MAX_TOOL_RESULT_CHARS + 512,
+		);
+	});
+
+	it("materially shrinks provider-formatted payloads compared with previous defaults", () => {
+		const messages: Message[] = [];
+		for (let i = 0; i < 20; i++) {
+			messages.push(
+				toolUseMessage(`call_${i}`, "run_commands", {
+					commands: [`python noisy_task_${i}.py`],
+				}),
+				structuredToolResultMessage(`call_${i}`, "run_commands", [
+					{
+						query: `python noisy_task_${i}.py`,
+						result: hugeText(300_000),
+						success: true,
+						duration: 1000 + i,
+					},
+				]),
+			);
+		}
+		const previousDefaults = new MessageBuilder({
+			maxToolResultChars: 50_000,
+			maxTotalTextBytes: 6_000_000,
+		});
+		const currentDefaults = new MessageBuilder();
+
+		const previousPayload = serializeForAiSdk(
+			previousDefaults.buildForApi(messages),
+		);
+		const currentPayload = serializeForAiSdk(
+			currentDefaults.buildForApi(messages),
+		);
+
+		expect(previousPayload.length).toBeGreaterThan(900_000);
+		expect(currentPayload.length).toBeLessThan(previousPayload.length * 0.25);
+		expect(currentPayload.length).toBeLessThan(250_000);
+		expect(currentPayload).not.toContain(MIDDLE_SENTINEL);
+	});
 
 	it("truncates a huge nested `result` string in run_commands structured output", () => {
 		const builder = new MessageBuilder();

--- a/sdk/packages/core/src/session/services/message-builder.ts
+++ b/sdk/packages/core/src/session/services/message-builder.ts
@@ -17,9 +17,13 @@ import {
 	type ToolResultContent,
 } from "@cline/shared";
 
-const DEFAULT_MAX_TOOL_RESULT_CHARS = 50_000;
-const DEFAULT_MAX_TOTAL_TEXT_BYTES = 6_000_000;
-const MIN_TOTAL_BUDGET_TOOL_RESULT_BYTES = 8_000;
+export const DEFAULT_MAX_TOOL_RESULT_CHARS = 8_000;
+export const DEFAULT_MAX_TOTAL_TEXT_BYTES = 1_000_000;
+const MIN_TOTAL_BUDGET_TOOL_RESULT_BYTES = 2_000;
+export const MESSAGE_BUILDER_LIMIT_ENV = {
+	maxToolResultChars: "CLINE_MESSAGE_BUILDER_MAX_TOOL_RESULT_CHARS",
+	maxTotalTextBytes: "CLINE_MESSAGE_BUILDER_MAX_TOTAL_TEXT_BYTES",
+} as const;
 const TARGET_TOOL_NAMES = new Set([
 	"read",
 	"read_files",
@@ -50,6 +54,25 @@ interface TruncationCandidate {
 	set(value: string): void;
 }
 
+export interface MessageBuilderOptions {
+	maxToolResultChars?: number;
+	targetToolNames?: ReadonlySet<string>;
+	maxTotalTextBytes?: number;
+}
+
+export function getMessageBuilderOptionsFromEnv(
+	env: Record<string, string | undefined> = process.env,
+): MessageBuilderOptions {
+	return {
+		maxToolResultChars: parsePositiveIntegerEnv(
+			env[MESSAGE_BUILDER_LIMIT_ENV.maxToolResultChars],
+		),
+		maxTotalTextBytes: parseNonNegativeIntegerEnv(
+			env[MESSAGE_BUILDER_LIMIT_ENV.maxTotalTextBytes],
+		),
+	};
+}
+
 /**
  * Builds an API-safe message copy without mutating original conversation history.
  */
@@ -67,12 +90,39 @@ export class MessageBuilder {
 		string
 	>();
 	private readResultLocatorCache = new WeakMap<object, ReadLocator[]>();
+	private readonly maxToolResultChars: number;
+	private readonly targetToolNames: ReadonlySet<string>;
+	private readonly maxTotalTextBytes: number;
 
 	constructor(
-		private readonly maxToolResultChars = DEFAULT_MAX_TOOL_RESULT_CHARS,
-		private readonly targetToolNames = TARGET_TOOL_NAMES,
-		private readonly maxTotalTextBytes = DEFAULT_MAX_TOTAL_TEXT_BYTES,
-	) {}
+		optionsOrMaxToolResultChars: MessageBuilderOptions | number = {},
+		targetToolNames: ReadonlySet<string> = TARGET_TOOL_NAMES,
+		maxTotalTextBytes = DEFAULT_MAX_TOTAL_TEXT_BYTES,
+	) {
+		if (typeof optionsOrMaxToolResultChars === "number") {
+			this.maxToolResultChars = normalizePositiveLimit(
+				optionsOrMaxToolResultChars,
+				DEFAULT_MAX_TOOL_RESULT_CHARS,
+			);
+			this.targetToolNames = targetToolNames;
+			this.maxTotalTextBytes = normalizeNonNegativeLimit(
+				maxTotalTextBytes,
+				DEFAULT_MAX_TOTAL_TEXT_BYTES,
+			);
+			return;
+		}
+
+		this.maxToolResultChars = normalizePositiveLimit(
+			optionsOrMaxToolResultChars.maxToolResultChars,
+			DEFAULT_MAX_TOOL_RESULT_CHARS,
+		);
+		this.targetToolNames =
+			optionsOrMaxToolResultChars.targetToolNames ?? TARGET_TOOL_NAMES;
+		this.maxTotalTextBytes = normalizeNonNegativeLimit(
+			optionsOrMaxToolResultChars.maxTotalTextBytes,
+			DEFAULT_MAX_TOTAL_TEXT_BYTES,
+		);
+	}
 
 	buildForApi(messages: Message[]): Message[] {
 		this.reindex(messages);
@@ -961,6 +1011,44 @@ export class MessageBuilder {
 
 function utf8ByteLength(text: string): number {
 	return Buffer.byteLength(text, "utf8");
+}
+
+function parsePositiveIntegerEnv(
+	value: string | undefined,
+): number | undefined {
+	if (value === undefined) {
+		return undefined;
+	}
+	const parsed = Number.parseInt(value, 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function parseNonNegativeIntegerEnv(
+	value: string | undefined,
+): number | undefined {
+	if (value === undefined) {
+		return undefined;
+	}
+	const parsed = Number.parseInt(value, 10);
+	return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+function normalizePositiveLimit(
+	value: number | undefined,
+	fallback: number,
+): number {
+	return typeof value === "number" && Number.isFinite(value) && value > 0
+		? Math.floor(value)
+		: fallback;
+}
+
+function normalizeNonNegativeLimit(
+	value: number | undefined,
+	fallback: number,
+): number {
+	return typeof value === "number" && Number.isFinite(value) && value >= 0
+		? Math.floor(value)
+		: fallback;
 }
 
 function truncateMiddleByChars(


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Tightens Cline's provider-facing `MessageBuilder` truncation limits for tool-output-heavy sessions:

- lowers the default nested tool-result string cap from 50,000 chars to 8,000 chars
- lowers the default aggregate provider text budget from 6,000,000 bytes to 1,000,000 bytes
- adds named `MessageBuilderOptions` and env overrides for A/B testing:
  - `CLINE_MESSAGE_BUILDER_MAX_TOOL_RESULT_CHARS`
  - `CLINE_MESSAGE_BUILDER_MAX_TOTAL_TEXT_BYTES`
- wires the session runtime to read those env overrides when constructing the provider-facing `MessageBuilder`
- keeps existing head/tail truncation markers and recursive structured `ToolOperationResult[]` truncation behavior

This targets provider-bound context bloat from large structured tool results emitted by tools such as `run_commands`, `read_files`, `search_codebase`, and `fetch_web_content`.

### Test Procedure

- `bun -F @cline/core test:unit -- src/session/services/message-builder.test.ts`
- `bun -F @cline/core typecheck`
- `bun biome check sdk/packages/core/src/session/services/message-builder.ts sdk/packages/core/src/session/services/message-builder.test.ts sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts`
- Real A/B inference using `/Users/ara2/Desktop/cline/.env`, Anthropic `claude-sonnet-4-6`, old Desktop checkout vs changed worktree, with a 300k-char `run_commands` output:
  - old defaults: 21,395 aggregate input tokens, 5,524 cache read, 9,269 cache write, 248 output, $0.059942
  - new defaults: 10,891 aggregate input tokens, 5,524 cache read, 4,017 cache write, 246 output, $0.024461
  - second provider turn input dropped from 9,196 to 3,944 tokens
  - aggregate input dropped 49.1%; aggregate cost dropped 59.2%

Also ran `bun -F @cline/core test:unit`; it still has unrelated existing failures in hub/provider-settings/local-runtime suites, outside this change.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

No UI changes. The new env overrides are intentionally process-local so provider payload limits can be A/B tested without changing persisted settings.
