### PR TITLE
fix(sdk): default-on tool result truncation, tightened limits + budget accounting in MessageBuilder

### DIFF
--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -673,7 +673,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 					await this.failSession(active);
 				} catch (cleanupError) {
 					// Never let cleanup failures mask the error that actually
-					// killed the turn — that one is what callers must see.
+					// killed the turn; that one is what callers must see.
 					active.config.logger?.error?.("Session failure cleanup threw", {
 						sessionId: active.sessionId,
 						error: cleanupError,

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -669,7 +669,16 @@ export class LocalRuntimeHost implements RuntimeHost {
 						modelId: active.config.modelId,
 					},
 				});
-				await this.failSession(active);
+				try {
+					await this.failSession(active);
+				} catch (cleanupError) {
+					// Never let cleanup failures mask the error that actually
+					// killed the turn — that one is what callers must see.
+					active.config.logger?.error?.("Session failure cleanup threw", {
+						sessionId: active.sessionId,
+						error: cleanupError,
+					});
+				}
 				throw error;
 			}
 		}

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
@@ -3,15 +3,15 @@
  *
  * Owns all cross-turn state for one logical agent session:
  *
- *   - `ConversationStore`      - message transcript + session-started gate
- *   - `MistakeTracker`         - per-session consecutive-mistake counter
- *   - `LoopDetectionTracker`   - per-session repeated-tool-call detector
- *   - `MessageBuilder`         - provider-message assembly cache
- *   - `AgentRuntimeHooks`      - runtime-native hooks from config/extensions
- *   - `RuntimeEventAdapter`    - per-run stateful `AgentRuntimeEvent`
+ *   - `ConversationStore`      — message transcript + session-started gate
+ *   - `MistakeTracker`         — per-session consecutive-mistake counter
+ *   - `LoopDetectionTracker`   — per-session repeated-tool-call detector
+ *   - `MessageBuilder`         — provider-message assembly cache
+ *   - `AgentRuntimeHooks`      — runtime-native hooks from config/extensions
+ *   - `RuntimeEventAdapter`    — per-run stateful `AgentRuntimeEvent`
  *                                → legacy `AgentEvent` translator
- *   - listener registry        - host subscribers see legacy `AgentEvent`s
- *   - pending tool set, abort  - per-run lifecycle housekeeping
+ *   - listener registry        — host subscribers see legacy `AgentEvent`s
+ *   - pending tool set, abort  — per-run lifecycle housekeeping
  *
  * A fresh `AgentRuntime` is instantiated per run via
  * `createAgentRuntime(createAgentRuntimeConfig({...}))`. All
@@ -208,7 +208,7 @@ function mergeRuntimeHooks(
 
 /**
  * Listener invoked for every legacy `AgentEvent` produced by the
- * session runtime. Use `subscribeEvents(listener)` - it returns an
+ * session runtime. Use `subscribeEvents(listener)` — it returns an
  * `unsubscribe` function.
  */
 export type SessionEventListener = (event: AgentEvent) => void;
@@ -253,7 +253,7 @@ export class SessionRuntime {
 	private readonly agentId: string;
 	private readonly parentAgentId?: string;
 	private readonly logger?: BasicLogger;
-	// Reserved for §3.4.4 telemetry parity (not yet consumed - §3.4.4
+	// Reserved for §3.4.4 telemetry parity (not yet consumed — §3.4.4
 	// listed as explicitly deferred until telemetry wiring is added).
 	// Typed as `readonly` to preserve the field slot for future use
 	// without re-touching the constructor.
@@ -263,7 +263,7 @@ export class SessionRuntime {
 	private readonly loopTracker: LoopDetectionTracker;
 	/**
 	 * True when `execution.loopDetection === false` at construction
-	 * time. Loop inspection is skipped entirely - the tracker still
+	 * time. Loop inspection is skipped entirely — the tracker still
 	 * exists for API compatibility but is never fed.
 	 */
 	private readonly loopDetectionDisabled: boolean;
@@ -302,7 +302,7 @@ export class SessionRuntime {
 	private activeRunPromise: Promise<AgentResult> | null = null;
 	/** Per-run `Agent → AgentEvent` adapter; `reset()` each run. */
 	private readonly eventAdapter = new RuntimeEventAdapter();
-	/** Session-shutdown gate - rejects late runs. */
+	/** Session-shutdown gate — rejects late runs. */
 	private shutdownCalled = false;
 	/** Running tally of tool-call records for `AgentResult.toolCalls`. */
 	private currentRunToolCalls: ToolCallRecord[] = [];
@@ -493,7 +493,7 @@ export class SessionRuntime {
 	// -------------------------------------------------------------------
 
 	/**
-	 * Subscribe to legacy `AgentEvent`s. The session runtime
+	 * Subscribe to **legacy** `AgentEvent`s. The session runtime
 	 * translates the new `AgentRuntimeEvent` stream via
 	 * `RuntimeEventAdapter` before fanout, so consumers see the
 	 * pre-swap shape.
@@ -692,7 +692,7 @@ export class SessionRuntime {
 
 		// Append the user turn (if any) to the conversation store. This
 		// must happen BEFORE we snapshot `initialMessages` below so the
-		// runtime sees the user message as part of its seed - we then
+		// runtime sees the user message as part of its seed — we then
 		// pass an empty input to `runtime.run()` so the runtime does not
 		// append the message a second time (AgentRuntime.execute treats
 		// a falsy input as "no additional messages", per
@@ -716,7 +716,7 @@ export class SessionRuntime {
 		);
 		// Merge extension-contributed tools with the config-declared
 		// tools for this turn. Extensions register tools via
-		// `api.registerTool` during `setup()` - parity with legacy
+		// `api.registerTool` during `setup()` — parity with legacy
 		// `Agent.ensureExtensionsInitialized` at pre-Step-9 `agent.ts:1140-1146`
 		// which merged `this.contributionRegistry.getRegisteredTools()`
 		// into `this.config.tools`. Dedupe by name so a config tool
@@ -1067,7 +1067,7 @@ export class SessionRuntime {
 						}`,
 					});
 				} else if (succeeded > 0) {
-					// Productive turn - reset the tracker so transient
+					// Productive turn — reset the tracker so transient
 					// failures don't accumulate across unrelated turns.
 					this.mistakeTracker.reset();
 				}
@@ -1183,7 +1183,7 @@ export class SessionRuntime {
 	/**
 	 * Enqueue a mistake-record onto the serial tracker work chain. The
 	 * runtime event stream is synchronous but `MistakeTracker.record`
-	 * is async - chaining onto a shared promise preserves ordering
+	 * is async — chaining onto a shared promise preserves ordering
 	 * (legacy parity) and lets `executeRun` await draining before
 	 * returning the `AgentResult`.
 	 *

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
@@ -51,7 +51,10 @@ import {
 	resolveKnownModelsFromConfig,
 } from "../../services/llms/handler-factory";
 import { CLINE_INTERNAL_TELEMETRY_METADATA_KEY } from "../../services/telemetry/tool-context";
-import { MessageBuilder } from "../../session/services/message-builder";
+import {
+	getMessageBuilderOptionsFromEnv,
+	MessageBuilder,
+} from "../../session/services/message-builder";
 import { ConversationStore } from "../../session/stores/conversation-store";
 import {
 	agentMessagesToMessages,
@@ -345,7 +348,7 @@ export class SessionRuntime {
 			deps.createAgentRuntimeImpl ?? createAgentRuntime;
 
 		this.conversation = new ConversationStore(config.initialMessages);
-		this.messageBuilder = new MessageBuilder();
+		this.messageBuilder = new MessageBuilder(getMessageBuilderOptionsFromEnv());
 		this.contributionRegistry = createContributionRegistry<
 			AgentExtension,
 			AgentTool,

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
@@ -3,15 +3,15 @@
  *
  * Owns all cross-turn state for one logical agent session:
  *
- *   - `ConversationStore`      — message transcript + session-started gate
- *   - `MistakeTracker`         — per-session consecutive-mistake counter
- *   - `LoopDetectionTracker`   — per-session repeated-tool-call detector
- *   - `MessageBuilder`         — provider-message assembly cache
- *   - `AgentRuntimeHooks`      — runtime-native hooks from config/extensions
- *   - `RuntimeEventAdapter`    — per-run stateful `AgentRuntimeEvent`
+ *   - `ConversationStore`      - message transcript + session-started gate
+ *   - `MistakeTracker`         - per-session consecutive-mistake counter
+ *   - `LoopDetectionTracker`   - per-session repeated-tool-call detector
+ *   - `MessageBuilder`         - provider-message assembly cache
+ *   - `AgentRuntimeHooks`      - runtime-native hooks from config/extensions
+ *   - `RuntimeEventAdapter`    - per-run stateful `AgentRuntimeEvent`
  *                                → legacy `AgentEvent` translator
- *   - listener registry        — host subscribers see legacy `AgentEvent`s
- *   - pending tool set, abort  — per-run lifecycle housekeeping
+ *   - listener registry        - host subscribers see legacy `AgentEvent`s
+ *   - pending tool set, abort  - per-run lifecycle housekeeping
  *
  * A fresh `AgentRuntime` is instantiated per run via
  * `createAgentRuntime(createAgentRuntimeConfig({...}))`. All
@@ -208,7 +208,7 @@ function mergeRuntimeHooks(
 
 /**
  * Listener invoked for every legacy `AgentEvent` produced by the
- * session runtime. Use `subscribeEvents(listener)` — it returns an
+ * session runtime. Use `subscribeEvents(listener)` - it returns an
  * `unsubscribe` function.
  */
 export type SessionEventListener = (event: AgentEvent) => void;
@@ -253,7 +253,7 @@ export class SessionRuntime {
 	private readonly agentId: string;
 	private readonly parentAgentId?: string;
 	private readonly logger?: BasicLogger;
-	// Reserved for §3.4.4 telemetry parity (not yet consumed — §3.4.4
+	// Reserved for §3.4.4 telemetry parity (not yet consumed - §3.4.4
 	// listed as explicitly deferred until telemetry wiring is added).
 	// Typed as `readonly` to preserve the field slot for future use
 	// without re-touching the constructor.
@@ -263,7 +263,7 @@ export class SessionRuntime {
 	private readonly loopTracker: LoopDetectionTracker;
 	/**
 	 * True when `execution.loopDetection === false` at construction
-	 * time. Loop inspection is skipped entirely — the tracker still
+	 * time. Loop inspection is skipped entirely - the tracker still
 	 * exists for API compatibility but is never fed.
 	 */
 	private readonly loopDetectionDisabled: boolean;
@@ -302,7 +302,7 @@ export class SessionRuntime {
 	private activeRunPromise: Promise<AgentResult> | null = null;
 	/** Per-run `Agent → AgentEvent` adapter; `reset()` each run. */
 	private readonly eventAdapter = new RuntimeEventAdapter();
-	/** Session-shutdown gate — rejects late runs. */
+	/** Session-shutdown gate - rejects late runs. */
 	private shutdownCalled = false;
 	/** Running tally of tool-call records for `AgentResult.toolCalls`. */
 	private currentRunToolCalls: ToolCallRecord[] = [];
@@ -493,7 +493,7 @@ export class SessionRuntime {
 	// -------------------------------------------------------------------
 
 	/**
-	 * Subscribe to **legacy** `AgentEvent`s. The session runtime
+	 * Subscribe to legacy `AgentEvent`s. The session runtime
 	 * translates the new `AgentRuntimeEvent` stream via
 	 * `RuntimeEventAdapter` before fanout, so consumers see the
 	 * pre-swap shape.
@@ -692,7 +692,7 @@ export class SessionRuntime {
 
 		// Append the user turn (if any) to the conversation store. This
 		// must happen BEFORE we snapshot `initialMessages` below so the
-		// runtime sees the user message as part of its seed — we then
+		// runtime sees the user message as part of its seed - we then
 		// pass an empty input to `runtime.run()` so the runtime does not
 		// append the message a second time (AgentRuntime.execute treats
 		// a falsy input as "no additional messages", per
@@ -716,7 +716,7 @@ export class SessionRuntime {
 		);
 		// Merge extension-contributed tools with the config-declared
 		// tools for this turn. Extensions register tools via
-		// `api.registerTool` during `setup()` — parity with legacy
+		// `api.registerTool` during `setup()` - parity with legacy
 		// `Agent.ensureExtensionsInitialized` at pre-Step-9 `agent.ts:1140-1146`
 		// which merged `this.contributionRegistry.getRegisteredTools()`
 		// into `this.config.tools`. Dedupe by name so a config tool
@@ -1067,7 +1067,7 @@ export class SessionRuntime {
 						}`,
 					});
 				} else if (succeeded > 0) {
-					// Productive turn — reset the tracker so transient
+					// Productive turn - reset the tracker so transient
 					// failures don't accumulate across unrelated turns.
 					this.mistakeTracker.reset();
 				}
@@ -1183,7 +1183,7 @@ export class SessionRuntime {
 	/**
 	 * Enqueue a mistake-record onto the serial tracker work chain. The
 	 * runtime event stream is synchronous but `MistakeTracker.record`
-	 * is async — chaining onto a shared promise preserves ordering
+	 * is async - chaining onto a shared promise preserves ordering
 	 * (legacy parity) and lets `executeRun` await draining before
 	 * returning the `AgentResult`.
 	 *

--- a/sdk/packages/core/src/session/services/message-builder.test.ts
+++ b/sdk/packages/core/src/session/services/message-builder.test.ts
@@ -6,7 +6,13 @@ import {
 } from "@cline/shared";
 import { describe, expect, it } from "vitest";
 import { messagesToAgentMessages } from "../../runtime/config/agent-message-codec";
-import { MessageBuilder } from "./message-builder";
+import {
+	DEFAULT_MAX_FILE_CONTENT_CHARS,
+	DEFAULT_MAX_TOOL_RESULT_CHARS,
+	DEFAULT_MAX_TOTAL_TEXT_BYTES,
+	getMessageBuilderOptionsFromEnv,
+	MessageBuilder,
+} from "./message-builder";
 
 describe("MessageBuilder", () => {
 	it("inserts an error tool result before a follow-up prompt when a prior tool call is missing a result", () => {
@@ -163,7 +169,7 @@ describe("MessageBuilder", () => {
 	});
 
 	it("truncates search_codebase tool results before provider requests", () => {
-		const builder = new MessageBuilder(100);
+		const builder = new MessageBuilder({ maxToolResultChars: 100 });
 		const messages: Message[] = [
 			{
 				role: "assistant",
@@ -201,8 +207,126 @@ describe("MessageBuilder", () => {
 		expect(block.content).toContain("...[truncated");
 	});
 
+	it("uses an aggressive per-result cap and a loose aggregate budget", () => {
+		expect(DEFAULT_MAX_TOOL_RESULT_CHARS).toBe(8_000);
+		expect(DEFAULT_MAX_FILE_CONTENT_CHARS).toBe(50_000);
+		// The aggregate budget stays loose on purpose: budget truncation
+		// rewrites mid-transcript bytes and breaks provider prefix caching, so
+		// it must stay a rare overflow valve while the per-result cap (which
+		// is deterministic per content) does the routine work.
+		expect(DEFAULT_MAX_TOTAL_TEXT_BYTES).toBe(6_000_000);
+	});
+
+	it("accepts named limit options for targeted provider payload tests", () => {
+		const builder = new MessageBuilder({
+			maxToolResultChars: 120,
+			maxTotalTextBytes: 10_000,
+		});
+		const messages: Message[] = [
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "tool_use",
+						id: "tool_1",
+						name: "run_commands",
+						input: { commands: ["cat big.log"] },
+					},
+				],
+			},
+			{
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "tool_1",
+						name: "run_commands",
+						content: "a".repeat(500),
+					},
+				],
+			},
+		];
+
+		const result = builder.buildForApi(messages);
+		const block = Array.isArray(result[1].content)
+			? result[1].content[0]
+			: undefined;
+
+		expect(block?.type).toBe("tool_result");
+		if (block?.type !== "tool_result") {
+			throw new Error("expected tool_result");
+		}
+		expect(typeof block.content).toBe("string");
+		if (typeof block.content !== "string") {
+			throw new Error("expected string content");
+		}
+		expect(block.content.length).toBeLessThanOrEqual(120);
+		expect(block.content).toContain("...[truncated");
+	});
+
+	it("parses message-builder limit environment overrides", () => {
+		const builder = new MessageBuilder(
+			getMessageBuilderOptionsFromEnv({
+				CLINE_MESSAGE_BUILDER_MAX_TOOL_RESULT_CHARS: "96",
+				CLINE_MESSAGE_BUILDER_MAX_TOTAL_TEXT_BYTES: "5000",
+			}),
+		);
+		const messages: Message[] = [
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "tool_use",
+						id: "tool_1",
+						name: "search_codebase",
+						input: { queries: ["needle"] },
+					},
+				],
+			},
+			{
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "tool_1",
+						name: "search_codebase",
+						content: "b".repeat(500),
+					},
+				],
+			},
+		];
+
+		const result = builder.buildForApi(messages);
+		const block = Array.isArray(result[1].content)
+			? result[1].content[0]
+			: undefined;
+
+		expect(block?.type).toBe("tool_result");
+		if (block?.type !== "tool_result") {
+			throw new Error("expected tool_result");
+		}
+		expect(typeof block.content).toBe("string");
+		if (typeof block.content !== "string") {
+			throw new Error("expected string content");
+		}
+		expect(block.content.length).toBeLessThanOrEqual(96);
+		expect(block.content).toContain("...[truncated");
+	});
+
+	it("ignores zero env overrides instead of disabling the limits", () => {
+		const options = getMessageBuilderOptionsFromEnv({
+			CLINE_MESSAGE_BUILDER_MAX_TOOL_RESULT_CHARS: "0",
+			CLINE_MESSAGE_BUILDER_MAX_TOTAL_TEXT_BYTES: "0",
+		});
+		expect(options.maxToolResultChars).toBeUndefined();
+		expect(options.maxTotalTextBytes).toBeUndefined();
+	});
+
 	it("applies an aggregate text budget across targeted tool results", () => {
-		const builder = new MessageBuilder(50_000, 20_000);
+		const builder = new MessageBuilder({
+			maxToolResultChars: 50_000,
+			maxTotalTextBytes: 20_000,
+		});
 		const messages: Message[] = [
 			{
 				role: "assistant",
@@ -266,7 +390,10 @@ describe("MessageBuilder", () => {
 	});
 
 	it("applies the aggregate budget using UTF-8 byte size", () => {
-		const builder = new MessageBuilder(50_000, 12_000);
+		const builder = new MessageBuilder({
+			maxToolResultChars: 50_000,
+			maxTotalTextBytes: 12_000,
+		});
 		const messages: Message[] = [
 			{
 				role: "assistant",
@@ -312,7 +439,10 @@ describe("MessageBuilder", () => {
 	});
 
 	it("does not mutate original nested tool result content when applying aggregate budget", () => {
-		const builder = new MessageBuilder(50_000, 10_000);
+		const builder = new MessageBuilder({
+			maxToolResultChars: 50_000,
+			maxTotalTextBytes: 10_000,
+		});
 		const originalText = "a".repeat(15_000);
 		const messages: Message[] = [
 			{
@@ -455,6 +585,105 @@ describe("MessageBuilder with structured ToolOperationResult content", () => {
 		return 0;
 	}
 
+	function serializeForAiSdk(messages: Message[]): string {
+		const agentMessages = messagesToAgentMessages(messages);
+		const aiSdkMessages = formatMessagesForAiSdk(
+			undefined,
+			agentMessages.map(({ role, content }) => ({
+				role,
+				content,
+			})) as unknown as AiSdkFormatterMessage[],
+		);
+		return JSON.stringify(aiSdkMessages);
+	}
+
+	function firstToolOperationResult(
+		result: Message[],
+	): ToolOperationResultLike {
+		const block = Array.isArray(result[1]?.content)
+			? result[1].content[0]
+			: undefined;
+		expect(block?.type).toBe("tool_result");
+		if (block?.type !== "tool_result" || typeof block.content === "string") {
+			throw new Error("expected structured tool_result");
+		}
+		const operation = block.content[0] as unknown;
+		expect(operation).toBeTruthy();
+		return operation as ToolOperationResultLike;
+	}
+
+	it("reduces a real-shaped multi-MB run_commands result to the default cap", () => {
+		const builder = new MessageBuilder();
+		const messages: Message[] = [
+			toolUseMessage("call_1", "run_commands", {
+				commands: ["python emit_multi_mb_output.py"],
+			}),
+			structuredToolResultMessage("call_1", "run_commands", [
+				{
+					query: "python emit_multi_mb_output.py",
+					result: hugeText(2_500_000),
+					success: true,
+					duration: 4321,
+				},
+			]),
+		];
+
+		const rawSerializedLength = JSON.stringify(messages).length;
+		const result = builder.buildForApi(messages);
+		const operation = firstToolOperationResult(result);
+		const output = operation.result;
+
+		expect(rawSerializedLength).toBeGreaterThan(2_400_000);
+		expect(typeof output).toBe("string");
+		if (typeof output !== "string") {
+			throw new Error("expected string result");
+		}
+		expect(output.length).toBeLessThanOrEqual(DEFAULT_MAX_TOOL_RESULT_CHARS);
+		expect(output).toContain("...[truncated");
+		expect(output).not.toContain(MIDDLE_SENTINEL);
+		expect(output).toContain(HEAD_MARKER);
+		expect(output).toContain(TAIL_MARKER);
+		expect(sumStringBytes(operation)).toBeLessThan(
+			DEFAULT_MAX_TOOL_RESULT_CHARS + 512,
+		);
+	});
+
+	it("materially shrinks provider-formatted payloads compared with previous defaults", () => {
+		const messages: Message[] = [];
+		for (let i = 0; i < 20; i++) {
+			messages.push(
+				toolUseMessage(`call_${i}`, "run_commands", {
+					commands: [`python noisy_task_${i}.py`],
+				}),
+				structuredToolResultMessage(`call_${i}`, "run_commands", [
+					{
+						query: `python noisy_task_${i}.py`,
+						result: hugeText(300_000),
+						success: true,
+						duration: 1000 + i,
+					},
+				]),
+			);
+		}
+		const previousDefaults = new MessageBuilder({
+			maxToolResultChars: 50_000,
+			maxTotalTextBytes: 6_000_000,
+		});
+		const currentDefaults = new MessageBuilder();
+
+		const previousPayload = serializeForAiSdk(
+			previousDefaults.buildForApi(messages),
+		);
+		const currentPayload = serializeForAiSdk(
+			currentDefaults.buildForApi(messages),
+		);
+
+		expect(previousPayload.length).toBeGreaterThan(900_000);
+		expect(currentPayload.length).toBeLessThan(previousPayload.length * 0.25);
+		expect(currentPayload.length).toBeLessThan(250_000);
+		expect(currentPayload).not.toContain(MIDDLE_SENTINEL);
+	});
+
 	it("truncates a huge nested `result` string in run_commands structured output", () => {
 		const builder = new MessageBuilder();
 		const messages: Message[] = [
@@ -535,16 +764,15 @@ describe("MessageBuilder with structured ToolOperationResult content", () => {
 
 	it("omits an oversized read_files image result without corrupting base64", () => {
 		const oversizedImage = imageData(96);
-		const builder = new MessageBuilder(
-			50_000,
-			new Set(["read_files"]),
-			1_000_000,
-			{
+		const builder = new MessageBuilder({
+			maxToolResultChars: 50_000,
+			maxTotalTextBytes: 1_000_000,
+			mediaBudget: {
 				maxImageEncodedBytes: 48,
 				maxImageDecodedBytes: 48,
 				maxTotalMediaBytes: 512,
 			},
-		);
+		});
 		const messages: Message[] = [
 			toolUseMessage("call_1", "read_files", {
 				files: [{ path: "/tmp/large.png" }],
@@ -592,18 +820,17 @@ describe("MessageBuilder with structured ToolOperationResult content", () => {
 		]);
 	});
 
-	it("omits oversized custom structured image results even when text truncation is not targeted", () => {
+	it("omits oversized custom structured image results regardless of tool name", () => {
 		const oversizedImage = imageData(96);
-		const builder = new MessageBuilder(
-			50_000,
-			new Set(["read_files"]),
-			1_000_000,
-			{
+		const builder = new MessageBuilder({
+			maxToolResultChars: 50_000,
+			maxTotalTextBytes: 1_000_000,
+			mediaBudget: {
 				maxImageEncodedBytes: 48,
 				maxImageDecodedBytes: 48,
 				maxTotalMediaBytes: 512,
 			},
-		);
+		});
 		const messages: Message[] = [
 			toolUseMessage("call_1", "custom_mcp_tool", {
 				path: "/tmp/large.png",
@@ -633,16 +860,15 @@ describe("MessageBuilder with structured ToolOperationResult content", () => {
 
 	it("omits malformed image-shaped objects instead of counting them as free text", () => {
 		const hiddenPayload = imageData(4096);
-		const builder = new MessageBuilder(
-			50_000,
-			new Set(["read_files"]),
-			1_000_000,
-			{
+		const builder = new MessageBuilder({
+			maxToolResultChars: 50_000,
+			maxTotalTextBytes: 1_000_000,
+			mediaBudget: {
 				maxImageEncodedBytes: 128,
 				maxImageDecodedBytes: 128,
 				maxTotalMediaBytes: 128,
 			},
-		);
+		});
 		const messages: Message[] = [
 			toolUseMessage("call_1", "custom_mcp_tool", {
 				path: "/tmp/malformed.png",
@@ -671,16 +897,15 @@ describe("MessageBuilder with structured ToolOperationResult content", () => {
 
 	it("keeps valid small read_files images as native provider media", () => {
 		const smallImage = imageData(16);
-		const builder = new MessageBuilder(
-			50_000,
-			new Set(["read_files"]),
-			1_000_000,
-			{
+		const builder = new MessageBuilder({
+			maxToolResultChars: 50_000,
+			maxTotalTextBytes: 1_000_000,
+			mediaBudget: {
 				maxImageEncodedBytes: 128,
 				maxImageDecodedBytes: 128,
 				maxTotalMediaBytes: 128,
 			},
-		);
+		});
 		const messages: Message[] = [
 			toolUseMessage("call_1", "read_files", {
 				files: [{ path: "/tmp/small.png" }],
@@ -722,16 +947,15 @@ describe("MessageBuilder with structured ToolOperationResult content", () => {
 	it("applies the total media budget across otherwise valid images", () => {
 		const firstImage = imageData(16);
 		const secondImage = imageData(16, 2);
-		const builder = new MessageBuilder(
-			50_000,
-			new Set(["read_files"]),
-			1_000_000,
-			{
+		const builder = new MessageBuilder({
+			maxToolResultChars: 50_000,
+			maxTotalTextBytes: 1_000_000,
+			mediaBudget: {
 				maxImageEncodedBytes: 128,
 				maxImageDecodedBytes: 128,
 				maxTotalMediaBytes: Buffer.byteLength(firstImage, "utf8"),
 			},
-		);
+		});
 		const messages: Message[] = [
 			toolUseMessage("call_1", "read_files", {
 				files: [{ path: "/tmp/a.png" }, { path: "/tmp/b.png" }],
@@ -801,7 +1025,10 @@ describe("MessageBuilder with structured ToolOperationResult content", () => {
 	});
 
 	it("applies the aggregate text budget to nested structured strings", () => {
-		const builder = new MessageBuilder(50_000, 100_000);
+		const builder = new MessageBuilder({
+			maxToolResultChars: 50_000,
+			maxTotalTextBytes: 100_000,
+		});
 		// Five results of ~40k chars each: every nested string is below the
 		// per-result limit, but the aggregate (~200k) exceeds the budget.
 		const messages: Message[] = [];
@@ -838,7 +1065,10 @@ describe("MessageBuilder with structured ToolOperationResult content", () => {
 	});
 
 	it("does not mutate the original structured tool results", () => {
-		const builder = new MessageBuilder(10_000, 20_000);
+		const builder = new MessageBuilder({
+			maxToolResultChars: 10_000,
+			maxTotalTextBytes: 20_000,
+		});
 		const messages: Message[] = [
 			toolUseMessage("call_1", "run_commands", { commands: ["cat a.log"] }),
 			structuredToolResultMessage("call_1", "run_commands", [
@@ -904,7 +1134,7 @@ describe("MessageBuilder with structured ToolOperationResult content", () => {
  */
 describe("MessageBuilder default-on truncation", () => {
 	it("truncates huge results from MCP/custom tools that were never on the old allowlist", () => {
-		const builder = new MessageBuilder(100);
+		const builder = new MessageBuilder({ maxToolResultChars: 100 });
 		const messages: Message[] = [
 			{
 				role: "assistant",
@@ -942,7 +1172,10 @@ describe("MessageBuilder default-on truncation", () => {
 	});
 
 	it("collects non-builtin tool results as aggregate budget candidates", () => {
-		const builder = new MessageBuilder(50_000, 20_000);
+		const builder = new MessageBuilder({
+			maxToolResultChars: 50_000,
+			maxTotalTextBytes: 20_000,
+		});
 		const messages: Message[] = [
 			{
 				role: "assistant",
@@ -984,7 +1217,10 @@ describe("MessageBuilder default-on truncation", () => {
 	});
 
 	it("counts tool_use input strings toward the aggregate budget", () => {
-		const builder = new MessageBuilder(50_000, 20_000);
+		const builder = new MessageBuilder({
+			maxToolResultChars: 50_000,
+			maxTotalTextBytes: 20_000,
+		});
 		const hugeInput = "f".repeat(15_000);
 		const messages: Message[] = [
 			{
@@ -1025,7 +1261,8 @@ describe("MessageBuilder default-on truncation", () => {
 		}
 		expect(resultBlock.content).toContain("provider request budget");
 
-		// The model-generated arguments themselves must never be rewritten.
+		// Tool results absorb the overflow first, so the model-generated
+		// arguments stay byte-identical whenever results alone can cover it.
 		const useBlock = Array.isArray(result[0].content)
 			? result[0].content[0]
 			: undefined;
@@ -1033,6 +1270,66 @@ describe("MessageBuilder default-on truncation", () => {
 			throw new Error("expected tool_use");
 		}
 		expect(useBlock.input).toEqual({ commands: [hugeInput] });
+	});
+
+	it("truncates oversized tool_use inputs as a last resort when results cannot absorb the overflow", () => {
+		const builder = new MessageBuilder({
+			maxToolResultChars: 50_000,
+			maxTotalTextBytes: 20_000,
+		});
+		const hugeInput = "f".repeat(40_000);
+		const messages: Message[] = [
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "tool_use",
+						id: "tool_1",
+						name: "run_commands",
+						input: { commands: [hugeInput] },
+					},
+				],
+			},
+			{
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "tool_1",
+						name: "run_commands",
+						content: "g".repeat(10_000),
+					},
+				],
+			},
+		];
+
+		const result = builder.buildForApi(messages);
+
+		// The result shrinks to the floor first, but that alone cannot bring
+		// 50k total under the 20k budget, so the input is truncated too.
+		const useBlock = Array.isArray(result[0].content)
+			? result[0].content[0]
+			: undefined;
+		if (useBlock?.type !== "tool_use") {
+			throw new Error("expected tool_use");
+		}
+		const builtInput = (useBlock.input as { commands: string[] }).commands[0];
+		expect(builtInput).toContain("provider request budget");
+		expect(Buffer.byteLength(builtInput, "utf8")).toBeLessThan(40_000);
+
+		const totalBytes = JSON.stringify(result).length;
+		expect(totalBytes).toBeLessThan(25_000);
+
+		// Original history must stay untouched.
+		const originalUse = Array.isArray(messages[0].content)
+			? messages[0].content[0]
+			: undefined;
+		if (originalUse?.type !== "tool_use") {
+			throw new Error("expected tool_use");
+		}
+		expect((originalUse.input as { commands: string[] }).commands[0]).toBe(
+			hugeInput,
+		);
 	});
 
 	it("rewrites outdated reads on orphaned tool results via the name fallback", () => {
@@ -1095,7 +1392,7 @@ describe("MessageBuilder default-on truncation", () => {
 	});
 
 	it("preserves non-image binary carrier blocks nested in structured results", () => {
-		const builder = new MessageBuilder(100);
+		const builder = new MessageBuilder({ maxToolResultChars: 100 });
 		const pdfData = "p".repeat(5_000);
 		const messages: Message[] = [
 			{
@@ -1149,5 +1446,89 @@ describe("MessageBuilder default-on truncation", () => {
 		const text = entry.result.find((item) => item.type === "text");
 		expect(doc?.data).toBe(pdfData);
 		expect(text?.text).toContain("...[truncated");
+	});
+
+	it("truncates textual {type, data} payloads that are not known binary blocks", () => {
+		const builder = new MessageBuilder({ maxToolResultChars: 100 });
+		const messages: Message[] = [
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "tool_use",
+						id: "tool_1",
+						name: "dump_server_logs",
+						input: {},
+					},
+				],
+			},
+			{
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "tool_1",
+						name: "dump_server_logs",
+						content: [
+							{
+								query: "logs",
+								result: [{ type: "log", data: "x".repeat(5_000) }],
+								success: true,
+							},
+						] as unknown as ToolResultContent["content"],
+					},
+				],
+			},
+		];
+
+		const result = builder.buildForApi(messages);
+		const block = Array.isArray(result[1].content)
+			? result[1].content[0]
+			: undefined;
+		if (block?.type !== "tool_result" || !Array.isArray(block.content)) {
+			throw new Error("expected tool_result with array content");
+		}
+		const entry = block.content[0] as unknown as {
+			result: Array<{ type: string; data: string }>;
+		};
+		const log = entry.result.find((item) => item.type === "log");
+		if (!log) {
+			throw new Error("expected log entry");
+		}
+		expect(log.data.length).toBeLessThanOrEqual(100);
+		expect(log.data).toContain("...[truncated");
+	});
+
+	it("caps user file attachments separately from tool results", () => {
+		const builder = new MessageBuilder();
+		const underFileCap = "a".repeat(20_000);
+		const overFileCap = "b".repeat(60_000);
+		const messages: Message[] = [
+			{
+				role: "user",
+				content: [
+					{ type: "file", path: "/tmp/notes.md", content: underFileCap },
+					{ type: "file", path: "/tmp/dump.log", content: overFileCap },
+					{ type: "text", text: "summarize these" },
+				],
+			},
+		];
+
+		const result = builder.buildForApi(messages);
+		const content = result[0].content;
+		if (!Array.isArray(content)) {
+			throw new Error("expected array content");
+		}
+		const [small, large] = content;
+		if (small?.type !== "file" || large?.type !== "file") {
+			throw new Error("expected file blocks");
+		}
+		// 20k would be mutilated under the 8k tool-result cap; attachments get
+		// the dedicated file cap instead.
+		expect(small.content).toBe(underFileCap);
+		expect(large.content.length).toBeLessThanOrEqual(
+			DEFAULT_MAX_FILE_CONTENT_CHARS,
+		);
+		expect(large.content).toContain("...[truncated");
 	});
 });

--- a/sdk/packages/core/src/session/services/message-builder.test.ts
+++ b/sdk/packages/core/src/session/services/message-builder.test.ts
@@ -202,11 +202,7 @@ describe("MessageBuilder", () => {
 	});
 
 	it("applies an aggregate text budget across targeted tool results", () => {
-		const builder = new MessageBuilder(
-			50_000,
-			new Set(["search_codebase"]),
-			20_000,
-		);
+		const builder = new MessageBuilder(50_000, 20_000);
 		const messages: Message[] = [
 			{
 				role: "assistant",
@@ -270,11 +266,7 @@ describe("MessageBuilder", () => {
 	});
 
 	it("applies the aggregate budget using UTF-8 byte size", () => {
-		const builder = new MessageBuilder(
-			50_000,
-			new Set(["search_codebase"]),
-			12_000,
-		);
+		const builder = new MessageBuilder(50_000, 12_000);
 		const messages: Message[] = [
 			{
 				role: "assistant",
@@ -320,11 +312,7 @@ describe("MessageBuilder", () => {
 	});
 
 	it("does not mutate original nested tool result content when applying aggregate budget", () => {
-		const builder = new MessageBuilder(
-			50_000,
-			new Set(["search_codebase"]),
-			10_000,
-		);
+		const builder = new MessageBuilder(50_000, 10_000);
 		const originalText = "a".repeat(15_000);
 		const messages: Message[] = [
 			{
@@ -813,11 +801,7 @@ describe("MessageBuilder with structured ToolOperationResult content", () => {
 	});
 
 	it("applies the aggregate text budget to nested structured strings", () => {
-		const builder = new MessageBuilder(
-			50_000,
-			new Set(["run_commands", "read_files"]),
-			100_000,
-		);
+		const builder = new MessageBuilder(50_000, 100_000);
 		// Five results of ~40k chars each: every nested string is below the
 		// per-result limit, but the aggregate (~200k) exceeds the budget.
 		const messages: Message[] = [];
@@ -854,11 +838,7 @@ describe("MessageBuilder with structured ToolOperationResult content", () => {
 	});
 
 	it("does not mutate the original structured tool results", () => {
-		const builder = new MessageBuilder(
-			10_000,
-			new Set(["run_commands"]),
-			20_000,
-		);
+		const builder = new MessageBuilder(10_000, 20_000);
 		const messages: Message[] = [
 			toolUseMessage("call_1", "run_commands", { commands: ["cat a.log"] }),
 			structuredToolResultMessage("call_1", "run_commands", [
@@ -915,5 +895,259 @@ describe("MessageBuilder with structured ToolOperationResult content", () => {
 		expect(serialized).not.toContain(MIDDLE_SENTINEL);
 		expect(serialized).toContain(HEAD_MARKER);
 		expect(serialized).toContain(TAIL_MARKER);
+	});
+});
+
+/**
+ * Coverage for default-on truncation (no tool allowlist), tool_use input
+ * budget accounting, tool_result.name fallback, and binary block protection.
+ */
+describe("MessageBuilder default-on truncation", () => {
+	it("truncates huge results from MCP/custom tools that were never on the old allowlist", () => {
+		const builder = new MessageBuilder(100);
+		const messages: Message[] = [
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "tool_use",
+						id: "tool_1",
+						name: "mcp__github__get_pull_request_diff",
+						input: { pull_number: 42 },
+					},
+				],
+			},
+			{
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "tool_1",
+						name: "mcp__github__get_pull_request_diff",
+						content: "d".repeat(5_000),
+					},
+				],
+			},
+		];
+
+		const result = builder.buildForApi(messages);
+		const block = Array.isArray(result[1].content)
+			? result[1].content[0]
+			: undefined;
+		if (block?.type !== "tool_result" || typeof block.content !== "string") {
+			throw new Error("expected tool_result with string content");
+		}
+		expect(block.content.length).toBeLessThanOrEqual(100);
+		expect(block.content).toContain("...[truncated");
+	});
+
+	it("collects non-builtin tool results as aggregate budget candidates", () => {
+		const builder = new MessageBuilder(50_000, 20_000);
+		const messages: Message[] = [
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "tool_use",
+						id: "tool_1",
+						name: "my_custom_dump_tool",
+						input: {},
+					},
+				],
+			},
+			{
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "tool_1",
+						name: "my_custom_dump_tool",
+						content: [{ type: "text", text: "e".repeat(30_000) }],
+					},
+				],
+			},
+		];
+
+		const result = builder.buildForApi(messages);
+		const block = Array.isArray(result[1].content)
+			? result[1].content[0]
+			: undefined;
+		if (block?.type !== "tool_result" || !Array.isArray(block.content)) {
+			throw new Error("expected tool_result with array content");
+		}
+		const entry = block.content[0];
+		if (entry.type !== "text") {
+			throw new Error("expected text entry");
+		}
+		expect(Buffer.byteLength(entry.text, "utf8")).toBeLessThanOrEqual(20_000);
+		expect(entry.text).toContain("provider request budget");
+	});
+
+	it("counts tool_use input strings toward the aggregate budget", () => {
+		const builder = new MessageBuilder(50_000, 20_000);
+		const hugeInput = "f".repeat(15_000);
+		const messages: Message[] = [
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "tool_use",
+						id: "tool_1",
+						name: "run_commands",
+						input: { commands: [hugeInput] },
+					},
+				],
+			},
+			{
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "tool_1",
+						name: "run_commands",
+						content: "g".repeat(10_000),
+					},
+				],
+			},
+		];
+
+		const result = builder.buildForApi(messages);
+		// Result alone (10k) is under the 20k budget; only counting the 15k
+		// tool_use input pushes the total over and forces budget truncation.
+		const resultBlock = Array.isArray(result[1].content)
+			? result[1].content[0]
+			: undefined;
+		if (
+			resultBlock?.type !== "tool_result" ||
+			typeof resultBlock.content !== "string"
+		) {
+			throw new Error("expected tool_result with string content");
+		}
+		expect(resultBlock.content).toContain("provider request budget");
+
+		// The model-generated arguments themselves must never be rewritten.
+		const useBlock = Array.isArray(result[0].content)
+			? result[0].content[0]
+			: undefined;
+		if (useBlock?.type !== "tool_use") {
+			throw new Error("expected tool_use");
+		}
+		expect(useBlock.input).toEqual({ commands: [hugeInput] });
+	});
+
+	it("rewrites outdated reads on orphaned tool results via the name fallback", () => {
+		const builder = new MessageBuilder();
+		const oldRead = JSON.stringify([
+			{ path: "/tmp/a.txt", result: "OLD CONTENT" },
+		]);
+		const messages: Message[] = [
+			{
+				role: "user",
+				// Orphaned result: its tool_use was dropped (e.g. compaction), so
+				// only the name field identifies it as a read tool.
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "tool_orphan",
+						name: "read_files",
+						content: oldRead,
+					},
+				],
+			},
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "tool_use",
+						id: "tool_2",
+						name: "read_files",
+						input: { file_paths: ["/tmp/a.txt"] },
+					},
+				],
+			},
+			{
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "tool_2",
+						name: "read_files",
+						content: JSON.stringify([
+							{ path: "/tmp/a.txt", result: "NEW CONTENT" },
+						]),
+					},
+				],
+			},
+		];
+
+		const result = builder.buildForApi(messages);
+		const orphan = Array.isArray(result[0].content)
+			? result[0].content[0]
+			: undefined;
+		if (orphan?.type !== "tool_result") {
+			throw new Error("expected tool_result");
+		}
+		expect(JSON.stringify(orphan.content)).toContain(
+			"[outdated - see the latest file content]",
+		);
+		expect(JSON.stringify(orphan.content)).not.toContain("OLD CONTENT");
+		expect(JSON.stringify(result[2].content)).toContain("NEW CONTENT");
+	});
+
+	it("preserves non-image binary carrier blocks nested in structured results", () => {
+		const builder = new MessageBuilder(100);
+		const pdfData = "p".repeat(5_000);
+		const messages: Message[] = [
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "tool_use",
+						id: "tool_1",
+						name: "fetch_web_content",
+						input: { url: "https://example.com/report.pdf" },
+					},
+				],
+			},
+			{
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "tool_1",
+						name: "fetch_web_content",
+						content: [
+							{
+								query: "https://example.com/report.pdf",
+								result: [
+									{
+										type: "document",
+										data: pdfData,
+										mediaType: "application/pdf",
+									},
+									{ type: "text", text: "h".repeat(5_000) },
+								],
+								success: true,
+							},
+						] as unknown as ToolResultContent["content"],
+					},
+				],
+			},
+		];
+
+		const result = builder.buildForApi(messages);
+		const block = Array.isArray(result[1].content)
+			? result[1].content[0]
+			: undefined;
+		if (block?.type !== "tool_result" || !Array.isArray(block.content)) {
+			throw new Error("expected tool_result with array content");
+		}
+		const entry = block.content[0] as unknown as {
+			result: Array<{ type: string; data?: string; text?: string }>;
+		};
+		const doc = entry.result.find((item) => item.type === "document");
+		const text = entry.result.find((item) => item.type === "text");
+		expect(doc?.data).toBe(pdfData);
+		expect(text?.text).toContain("...[truncated");
 	});
 });

--- a/sdk/packages/core/src/session/services/message-builder.test.ts
+++ b/sdk/packages/core/src/session/services/message-builder.test.ts
@@ -1391,8 +1391,11 @@ describe("MessageBuilder default-on truncation", () => {
 		expect(JSON.stringify(result[2].content)).toContain("NEW CONTENT");
 	});
 
-	it("preserves non-image binary carrier blocks nested in structured results", () => {
-		const builder = new MessageBuilder({ maxToolResultChars: 100 });
+	it("truncates unsupported document data blocks nested in structured results", () => {
+		const builder = new MessageBuilder({
+			maxToolResultChars: 100,
+			maxTotalTextBytes: 1_000,
+		});
 		const pdfData = "p".repeat(5_000);
 		const messages: Message[] = [
 			{
@@ -1444,8 +1447,94 @@ describe("MessageBuilder default-on truncation", () => {
 		};
 		const doc = entry.result.find((item) => item.type === "document");
 		const text = entry.result.find((item) => item.type === "text");
-		expect(doc?.data).toBe(pdfData);
+		expect(doc?.data).not.toBe(pdfData);
+		expect(doc?.data?.length).toBeLessThanOrEqual(100);
+		expect(doc?.data).toContain("...[truncated");
 		expect(text?.text).toContain("...[truncated");
+
+		const formattedPayload = JSON.stringify(
+			formatMessagesForAiSdk(
+				undefined,
+				messagesToAgentMessages(result).map(({ role, content }) => ({
+					role,
+					content,
+				})) as unknown as AiSdkFormatterMessage[],
+			),
+		);
+		expect(formattedPayload).not.toContain(pdfData);
+		expect(formattedPayload.length).toBeLessThan(1_000);
+	});
+
+	it("preserves nested image data that the formatter hoists natively", () => {
+		const builder = new MessageBuilder({ maxToolResultChars: 100 });
+		const imageData = "i".repeat(5_000);
+		const messages: Message[] = [
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "tool_use",
+						id: "tool_1",
+						name: "read_files",
+						input: { file_paths: ["/tmp/image.png"] },
+					},
+				],
+			},
+			{
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "tool_1",
+						name: "read_files",
+						content: [
+							{
+								query: "/tmp/image.png",
+								result: [
+									{ type: "text", text: "Successfully read image" },
+									{
+										type: "image",
+										data: imageData,
+										mediaType: "image/png",
+									},
+									{ type: "text", text: "h".repeat(5_000) },
+								],
+								success: true,
+							},
+						] as unknown as ToolResultContent["content"],
+					},
+				],
+			},
+		];
+
+		const result = builder.buildForApi(messages);
+		const block = Array.isArray(result[1].content)
+			? result[1].content[0]
+			: undefined;
+		if (block?.type !== "tool_result" || !Array.isArray(block.content)) {
+			throw new Error("expected tool_result with array content");
+		}
+		const entry = block.content[0] as unknown as {
+			result: Array<{ type: string; data?: string; text?: string }>;
+		};
+		const image = entry.result.find((item) => item.type === "image");
+		const longText = entry.result.find(
+			(item) => item.type === "text" && item.text?.startsWith("h"),
+		);
+		expect(image?.data).toBe(imageData);
+		expect(longText?.text).toContain("...[truncated");
+
+		const formattedPayload = JSON.stringify(
+			formatMessagesForAiSdk(
+				undefined,
+				messagesToAgentMessages(result).map(({ role, content }) => ({
+					role,
+					content,
+				})) as unknown as AiSdkFormatterMessage[],
+			),
+		);
+		expect(formattedPayload).toContain('"type":"image-data"');
+		expect(formattedPayload).toContain(imageData);
 	});
 
 	it("truncates textual {type, data} payloads that are not known binary blocks", () => {

--- a/sdk/packages/core/src/session/services/message-builder.ts
+++ b/sdk/packages/core/src/session/services/message-builder.ts
@@ -1,8 +1,8 @@
 /**
  * API-safe message builder for provider payloads.
  *
- * @see PLAN.md §3.1 - moved from `packages/agents/src/context/message-builder.ts`.
- * @see PLAN.md §3.2.3 - public surface of `MessageBuilder`.
+ * @see PLAN.md §3.1 — moved from `packages/agents/src/context/message-builder.ts`.
+ * @see PLAN.md §3.2.3 — public surface of `MessageBuilder`.
  *
  * Walks the conversation to produce provider-ready messages, handling
  * tool-result truncation and outdated-file-content rewrite for compaction.
@@ -1279,7 +1279,7 @@ function cloneContentBlockForMutation(block: ContentBlock): ContentBlock {
 
 /**
  * True for tool_result content entries that are not the typed text/image/file
- * blocks - i.e. structured tool outputs such as `ToolOperationResult[]`
+ * blocks — i.e. structured tool outputs such as `ToolOperationResult[]`
  * entries that the runtime stores directly in the content array.
  */
 function isStructuredToolResultEntry(entry: unknown): boolean {

--- a/sdk/packages/core/src/session/services/message-builder.ts
+++ b/sdk/packages/core/src/session/services/message-builder.ts
@@ -28,15 +28,6 @@ import {
 const DEFAULT_MAX_TOOL_RESULT_CHARS = 50_000;
 const DEFAULT_MAX_TOTAL_TEXT_BYTES = 6_000_000;
 const MIN_TOTAL_BUDGET_TOOL_RESULT_BYTES = 8_000;
-const TARGET_TOOL_NAMES = new Set([
-	"read",
-	"read_files",
-	"search",
-	"search_codebase",
-	"bash",
-	"run_commands",
-	"fetch_web_content",
-]);
 const READ_TOOL_NAMES = new Set(["read", "read_files"]);
 const OUTDATED_FILE_CONTENT = "[outdated - see the latest file content]";
 const MISSING_TOOL_RESULT_TEXT =
@@ -78,7 +69,6 @@ export class MessageBuilder {
 
 	constructor(
 		private readonly maxToolResultChars = DEFAULT_MAX_TOOL_RESULT_CHARS,
-		private readonly targetToolNames = TARGET_TOOL_NAMES,
 		private readonly maxTotalTextBytes = DEFAULT_MAX_TOTAL_TEXT_BYTES,
 		private readonly mediaBudget: MediaBudgetOptions = {},
 	) {}
@@ -141,7 +131,7 @@ export class MessageBuilder {
 			return block;
 		}
 
-		const toolName = this.toolNameByIdCache.get(block.tool_use_id);
+		const toolName = this.resolveToolName(block);
 		let nextContent = block.content;
 
 		if (this.isReadTool(toolName) && block.is_error !== true) {
@@ -156,9 +146,10 @@ export class MessageBuilder {
 			}
 		}
 
-		if (this.shouldTruncateTool(toolName)) {
-			nextContent = this.truncateToolResultContent(nextContent);
-		}
+		// Truncation is default-on for every tool result: MCP and custom SDK
+		// tools produce payloads just as large as the built-in ones, and any
+		// allowlist gate silently exempts them.
+		nextContent = this.truncateToolResultContent(nextContent);
 
 		return nextContent === block.content
 			? block
@@ -197,7 +188,7 @@ export class MessageBuilder {
 						}
 					}
 				} else if (block.type === "tool_result") {
-					const toolName = this.toolNameByIdCache.get(block.tool_use_id);
+					const toolName = this.resolveToolName(block);
 					if (!this.isReadTool(toolName) || block.is_error === true) {
 						continue;
 					}
@@ -761,8 +752,19 @@ export class MessageBuilder {
 		return !!toolName && READ_TOOL_NAMES.has(toolName);
 	}
 
-	private shouldTruncateTool(toolName: string | undefined): boolean {
-		return !!toolName && this.targetToolNames.has(toolName);
+	/**
+	 * Tool results can outlive their paired tool_use block (compacted or
+	 * imported histories), so fall back to the name carried on the result
+	 * itself when the id lookup misses.
+	 */
+	private resolveToolName(block: ToolResultContent): string | undefined {
+		const cached = this.toolNameByIdCache.get(block.tool_use_id);
+		if (cached !== undefined) {
+			return cached;
+		}
+		return typeof block.name === "string" && block.name.length > 0
+			? block.name.toLowerCase()
+			: undefined;
 	}
 
 	private truncateToolResultContent(
@@ -809,7 +811,7 @@ export class MessageBuilder {
 			return changed ? next : value;
 		}
 		if (value !== null && typeof value === "object") {
-			if (isImageContentLike(value)) {
+			if (isBinaryContentLike(value)) {
 				return value;
 			}
 			let changed = false;
@@ -896,6 +898,12 @@ export class MessageBuilder {
 					total += utf8ByteLength(block.thinking);
 				} else if (block.type === "file") {
 					total += utf8ByteLength(block.content);
+				} else if (block.type === "tool_use") {
+					// Model-generated tool arguments ship on the wire too. They are
+					// never truncated (providers can validate or replay them), but
+					// counting them makes the budget shrink reducible content harder
+					// instead of silently overshooting the request size.
+					total += countNestedStringBytes(block.input);
 				} else if (block.type === "tool_result") {
 					if (typeof block.content === "string") {
 						total += utf8ByteLength(block.content);
@@ -926,10 +934,6 @@ export class MessageBuilder {
 			}
 			for (const block of message.content) {
 				if (block.type !== "tool_result") {
-					continue;
-				}
-				const toolName = this.toolNameByIdCache.get(block.tool_use_id);
-				if (!this.shouldTruncateTool(toolName)) {
 					continue;
 				}
 				if (typeof block.content === "string") {
@@ -1217,6 +1221,10 @@ function isImageContentWithData(value: unknown): value is ImageContent {
 	);
 }
 
+function isBinaryContentLike(value: unknown): boolean {
+	return isImageContentWithData(value);
+}
+
 function countNestedStringBytes(value: unknown): number {
 	if (typeof value === "string") {
 		return utf8ByteLength(value);
@@ -1229,7 +1237,7 @@ function countNestedStringBytes(value: unknown): number {
 		return total;
 	}
 	if (value !== null && typeof value === "object") {
-		if (isImageContentWithData(value)) {
+		if (isBinaryContentLike(value)) {
 			return 0;
 		}
 		let total = 0;
@@ -1262,7 +1270,7 @@ function collectNestedStringCandidates(
 		return;
 	}
 	if (container !== null && typeof container === "object") {
-		if (isImageContentWithData(container)) {
+		if (isBinaryContentLike(container)) {
 			return;
 		}
 		const record = container as Record<string, unknown>;

--- a/sdk/packages/core/src/session/services/message-builder.ts
+++ b/sdk/packages/core/src/session/services/message-builder.ts
@@ -25,9 +25,18 @@ import {
 	validateAndReserveImageMedia,
 } from "@cline/shared";
 
-const DEFAULT_MAX_TOOL_RESULT_CHARS = 50_000;
-const DEFAULT_MAX_TOTAL_TEXT_BYTES = 6_000_000;
-const MIN_TOTAL_BUDGET_TOOL_RESULT_BYTES = 8_000;
+export const DEFAULT_MAX_TOOL_RESULT_CHARS = 8_000;
+export const DEFAULT_MAX_FILE_CONTENT_CHARS = 50_000;
+// The aggregate budget intentionally stays far above what the per-result cap
+// usually produces: budget truncation rewrites bytes mid-transcript, which
+// invalidates provider prefix caches from the first rewritten block onward,
+// so it must remain a rare overflow valve rather than the steady state.
+export const DEFAULT_MAX_TOTAL_TEXT_BYTES = 6_000_000;
+const MIN_TOTAL_BUDGET_TOOL_RESULT_BYTES = 2_000;
+export const MESSAGE_BUILDER_LIMIT_ENV = {
+	maxToolResultChars: "CLINE_MESSAGE_BUILDER_MAX_TOOL_RESULT_CHARS",
+	maxTotalTextBytes: "CLINE_MESSAGE_BUILDER_MAX_TOTAL_TEXT_BYTES",
+} as const;
 const READ_TOOL_NAMES = new Set(["read", "read_files"]);
 const OUTDATED_FILE_CONTENT = "[outdated - see the latest file content]";
 const MISSING_TOOL_RESULT_TEXT =
@@ -49,6 +58,28 @@ interface TruncationCandidate {
 	set(value: string): void;
 }
 
+export interface MessageBuilderOptions {
+	maxToolResultChars?: number;
+	maxFileContentChars?: number;
+	maxTotalTextBytes?: number;
+	mediaBudget?: MediaBudgetOptions;
+}
+
+export function getMessageBuilderOptionsFromEnv(
+	env: Record<string, string | undefined> = process.env,
+): MessageBuilderOptions {
+	// Zero and negative values are rejected (falling back to the defaults), so
+	// an env override can tune the limits but never silently disable them.
+	return {
+		maxToolResultChars: parsePositiveIntegerEnv(
+			env[MESSAGE_BUILDER_LIMIT_ENV.maxToolResultChars],
+		),
+		maxTotalTextBytes: parsePositiveIntegerEnv(
+			env[MESSAGE_BUILDER_LIMIT_ENV.maxTotalTextBytes],
+		),
+	};
+}
+
 /**
  * Builds an API-safe message copy without mutating original conversation history.
  */
@@ -66,12 +97,26 @@ export class MessageBuilder {
 		string
 	>();
 	private readResultLocatorCache = new WeakMap<object, ReadLocator[]>();
+	private readonly maxToolResultChars: number;
+	private readonly maxFileContentChars: number;
+	private readonly maxTotalTextBytes: number;
+	private readonly mediaBudget: MediaBudgetOptions;
 
-	constructor(
-		private readonly maxToolResultChars = DEFAULT_MAX_TOOL_RESULT_CHARS,
-		private readonly maxTotalTextBytes = DEFAULT_MAX_TOTAL_TEXT_BYTES,
-		private readonly mediaBudget: MediaBudgetOptions = {},
-	) {}
+	constructor(options: MessageBuilderOptions = {}) {
+		this.maxToolResultChars = normalizePositiveLimit(
+			options.maxToolResultChars,
+			DEFAULT_MAX_TOOL_RESULT_CHARS,
+		);
+		this.maxFileContentChars = normalizePositiveLimit(
+			options.maxFileContentChars,
+			DEFAULT_MAX_FILE_CONTENT_CHARS,
+		);
+		this.maxTotalTextBytes = normalizePositiveLimit(
+			options.maxTotalTextBytes,
+			DEFAULT_MAX_TOTAL_TEXT_BYTES,
+		);
+		this.mediaBudget = options.mediaBudget ?? {};
+	}
 
 	buildForApi(messages: Message[]): Message[] {
 		this.reindex(messages);
@@ -121,7 +166,14 @@ export class MessageBuilder {
 		}
 
 		if (block.type === "file") {
-			const truncated = this.truncateMiddle(block.content);
+			// Top-level file blocks are user attachments, not tool output; they
+			// get their own (looser) cap so the aggressive tool-result limit
+			// does not mutilate content the user explicitly supplied.
+			const truncated = truncateMiddleByChars(
+				block.content,
+				this.maxFileContentChars,
+				TRUNCATE_MARKER_DEFAULT,
+			);
 			return truncated === block.content
 				? block
 				: { ...block, content: truncated };
@@ -837,10 +889,6 @@ export class MessageBuilder {
 	}
 
 	private truncateToTotalTextBudget(messages: Message[]): Message[] {
-		if (this.maxTotalTextBytes <= 0) {
-			return messages;
-		}
-
 		let totalBytes = this.countMessageTextBytes(messages);
 		if (totalBytes <= this.maxTotalTextBytes) {
 			return messages;
@@ -899,10 +947,10 @@ export class MessageBuilder {
 				} else if (block.type === "file") {
 					total += utf8ByteLength(block.content);
 				} else if (block.type === "tool_use") {
-					// Model-generated tool arguments ship on the wire too. They are
-					// never truncated (providers can validate or replay them), but
-					// counting them makes the budget shrink reducible content harder
-					// instead of silently overshooting the request size.
+					// Model-generated tool arguments ship on the wire too. Counting
+					// them keeps the budget honest; if tool results alone cannot
+					// absorb the overflow, oversized argument strings are truncated
+					// as a last resort (see collectTruncationCandidates).
 					total += countNestedStringBytes(block.input);
 				} else if (block.type === "tool_result") {
 					if (typeof block.content === "string") {
@@ -927,17 +975,22 @@ export class MessageBuilder {
 	private collectTruncationCandidates(
 		messages: Message[],
 	): TruncationCandidate[] {
-		const candidates: TruncationCandidate[] = [];
+		const resultCandidates: TruncationCandidate[] = [];
+		const inputCandidates: TruncationCandidate[] = [];
 		for (const message of messages) {
 			if (!Array.isArray(message.content)) {
 				continue;
 			}
 			for (const block of message.content) {
+				if (block.type === "tool_use") {
+					collectNestedStringCandidates(block.input, inputCandidates);
+					continue;
+				}
 				if (block.type !== "tool_result") {
 					continue;
 				}
 				if (typeof block.content === "string") {
-					candidates.push({
+					resultCandidates.push({
 						byteLength: utf8ByteLength(block.content),
 						get: () => block.content as string,
 						set: (value) => {
@@ -948,7 +1001,7 @@ export class MessageBuilder {
 				}
 				for (const entry of block.content) {
 					if (entry.type === "text") {
-						candidates.push({
+						resultCandidates.push({
 							byteLength: utf8ByteLength(entry.text),
 							get: () => entry.text,
 							set: (value) => {
@@ -956,7 +1009,7 @@ export class MessageBuilder {
 							},
 						});
 					} else if (entry.type === "file") {
-						candidates.push({
+						resultCandidates.push({
 							byteLength: utf8ByteLength(entry.content),
 							get: () => entry.content,
 							set: (value) => {
@@ -964,12 +1017,18 @@ export class MessageBuilder {
 							},
 						});
 					} else if (isStructuredToolResultEntry(entry)) {
-						collectNestedStringCandidates(entry, candidates);
+						collectNestedStringCandidates(entry, resultCandidates);
 					}
 				}
 			}
 		}
-		return candidates.sort((l, r) => r.byteLength - l.byteLength);
+		// Tool results truncate first; model-generated tool_use arguments are a
+		// last resort because some providers revalidate or replay them. Both
+		// being candidates keeps the budget reclaimable no matter which side
+		// carries the overflow.
+		resultCandidates.sort((l, r) => r.byteLength - l.byteLength);
+		inputCandidates.sort((l, r) => r.byteLength - l.byteLength);
+		return [...resultCandidates, ...inputCandidates];
 	}
 
 	private applyMediaBudget(messages: Message[]): Message[] {
@@ -1124,6 +1183,25 @@ function utf8ByteLength(text: string): number {
 	return Buffer.byteLength(text, "utf8");
 }
 
+function parsePositiveIntegerEnv(
+	value: string | undefined,
+): number | undefined {
+	if (value === undefined) {
+		return undefined;
+	}
+	const parsed = Number.parseInt(value, 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function normalizePositiveLimit(
+	value: number | undefined,
+	fallback: number,
+): number {
+	return typeof value === "number" && Number.isFinite(value) && value > 0
+		? Math.floor(value)
+		: fallback;
+}
+
 function truncateMiddleByChars(
 	text: string,
 	maxChars: number,
@@ -1174,6 +1252,15 @@ function truncateMiddleToBytes(
 }
 
 function cloneContentBlockForMutation(block: ContentBlock): ContentBlock {
+	if (block.type === "tool_use") {
+		// Inputs are budget-truncation candidates of last resort, so they need
+		// the same deep-clone treatment as structured results: a shallow copy
+		// would leak truncation mutations back into conversation history.
+		return {
+			...block,
+			input: deepCloneJsonLike(block.input) as typeof block.input,
+		};
+	}
 	if (block.type !== "tool_result" || typeof block.content === "string") {
 		return { ...block };
 	}

--- a/sdk/packages/core/src/session/services/message-builder.ts
+++ b/sdk/packages/core/src/session/services/message-builder.ts
@@ -1,8 +1,8 @@
 /**
  * API-safe message builder for provider payloads.
  *
- * @see PLAN.md §3.1 — moved from `packages/agents/src/context/message-builder.ts`.
- * @see PLAN.md §3.2.3 — public surface of `MessageBuilder`.
+ * @see PLAN.md §3.1 - moved from `packages/agents/src/context/message-builder.ts`.
+ * @see PLAN.md §3.2.3 - public surface of `MessageBuilder`.
  *
  * Walks the conversation to produce provider-ready messages, handling
  * tool-result truncation and outdated-file-content rewrite for compaction.
@@ -1279,7 +1279,7 @@ function cloneContentBlockForMutation(block: ContentBlock): ContentBlock {
 
 /**
  * True for tool_result content entries that are not the typed text/image/file
- * blocks — i.e. structured tool outputs such as `ToolOperationResult[]`
+ * blocks - i.e. structured tool outputs such as `ToolOperationResult[]`
  * entries that the runtime stores directly in the content array.
  */
 function isStructuredToolResultEntry(entry: unknown): boolean {


### PR DESCRIPTION
## Problem

Follow-ups to #11465 (and @robinnewhouse's review finding there). This PR now also absorbs #11474 (closed in favor of this one) so the truncation architecture and the limits that ride on it are reviewed as one unit. Gaps addressed:

1. **The truncation gate was an opt-in allowlist.** Only seven built-in tool names were truncated. MCP tools, custom `createTool()` tools, `editor`, `apply_patch`, etc. bypassed both the per-result cap and budget-candidate collection — worse, their bytes *were* counted toward the budget while being unreducible, so one huge MCP result could make the budget loop uselessly shrink other tools' results and still fail.
2. **`tool_use.input` was invisible to the budget.** Model-generated tool arguments (the other half of the huge-`query` asymmetry measured in #11465) were neither truncated nor counted.
3. **Tool-name resolution required the paired `tool_use` block.** Orphaned tool results (compacted/imported histories) skipped read-outdated rewriting because `toolNameByIdCache` was the only lookup, even though `tool_result.name` exists since #10975.
4. **The 50k per-result cap was too loose** for tool-output-heavy sessions (from #11474).

## Fix

`MessageBuilder` now:
- truncates **every** tool result (per-result cap + aggregate budget candidates) — no allowlist; the `targetToolNames` constructor param is gone
- takes a named `MessageBuilderOptions` object with env overrides for A/B testing (`CLINE_MESSAGE_BUILDER_MAX_TOOL_RESULT_CHARS`, `CLINE_MESSAGE_BUILDER_MAX_TOTAL_TEXT_BYTES`); the session runtime reads these when constructing the provider-facing builder
- defaults the per-result cap to **8,000 chars** (was 50,000)
- counts `tool_use.input` strings toward the aggregate budget **and** truncates them as a last resort when tool results alone cannot absorb the overflow (review finding by @robinnewhouse and greptile — the budget is now always reclaimable, never one-sided)
- falls back to `tool_result.name` when the paired `tool_use` is missing
- protects known binary carrier blocks (`image`/`document`/`audio`/`video` with string `data`) from truncation — restricted to a known-type set per codex/greptile review so textual `{type: "log", data}` payloads can no longer dodge every cap
- caps top-level `file` blocks (user attachments) at a dedicated 50k instead of the aggressive tool-result cap (codex review on #11474)

### Combined-effect note (please sign off explicitly)

The two halves multiply: #11475's default-on truncation widens *which* content is capped (everything, including MCP/custom tools), and #11474's tightening lowers *how hard* (8k per result). Together every tool result in a provider request is capped at 8k chars by default.

**The aggregate budget intentionally stays at 6MB** (not lowered to 1MB as #11474 originally proposed). Rationale, per @johnwschoi's review: budget truncation rewrites bytes mid-transcript, which invalidates provider prefix caches from the first rewritten block onward on *every subsequent request*. The per-result cap is deterministic per content block (same input → same truncated bytes on every build), so it is prefix-cache-safe and does the routine work; the aggregate budget stays a rare overflow valve. A/B testing tighter budgets is what the env override is for.

Drive-by in `local-runtime-host.ts`: a `failSession()` cleanup throw no longer masks the original turn error (it swallowed every real startup failure with `SessionRuntime.shutdown called while a run is in progress`).

## Regression tests

28 tests total in `message-builder.test.ts`; new since #11465:
1. MCP-named tool huge result → per-result truncated
2. custom tool result → collected as budget candidate, byte-bounded
3. huge `tool_use.input` forces budget truncation of results first; input stays byte-identical when results can absorb the overflow
4. huge `tool_use.input` that results *cannot* absorb → input truncated as last resort, original history untouched
5. orphaned read result rewritten as outdated via the name fallback
6. `{type:"document", data}` nested in structured results survives intact while its text sibling truncates
7. `{type:"log", data}` (textual payload masquerading as a binary shape) → truncated
8. user file attachments: 20k attachment survives intact under the dedicated 50k cap; 60k attachment truncates at 50k
9. `=0` env overrides are ignored instead of disabling limits
10. env overrides assert the truncation marker, not just the length

## Real-inference A/B

**Default-on truncation (custom tool, off the old allowlist):** a custom `dump_server_logs` tool returns ~280k chars; the answer lives in the final line. Same task on `origin/main` vs this branch, per-request provider-reported input tokens:

| model | request | main | patched | reduction |
|---|---|---|---|---|
| minimax/minimax-m2.7 | after tool result | 116,341 | 18,868 | **83.8%** |
| minimax/minimax-m2.7 | follow-up turn | 116,354 | 18,880 | 83.8% |
| deepseek/deepseek-v4-flash | after tool result | 120,451 | 19,636 | **83.7%** |
| deepseek/deepseek-v4-flash | follow-up turn | 120,537 | 19,732 | 83.6% |

Session cost: $0.0679 → $0.0115 (minimax), $0.0314 → $0.0052 (deepseek). All four runs answered the tail-of-log question correctly — middle truncation preserved the information the model needed.

**Tightened per-result cap (from #11474's A/B):** Anthropic `claude-sonnet-4-6`, 300k-char `run_commands` output, old defaults vs new:
- aggregate input tokens 21,395 → 10,891 (-49.1%), aggregate cost $0.0599 → $0.0245 (-59.2%)
- second provider turn input dropped from 9,196 to 3,944 tokens

## Verification

- `vitest run src/session/services/message-builder.test.ts` — 28/28 pass
- full core unit suite — only the pre-existing hub/migration/auth-retry failures, byte-identical set on pristine `origin/main`
- `tsc -p tsconfig.dev.json --noEmit` clean, biome clean, pre-commit workspace typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
