### PR TITLE
fix(sdk): compact core tool output before transcript

### DIFF
--- a/sdk/packages/core/src/extensions/tools/definitions.test.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.test.ts
@@ -1,9 +1,17 @@
-import type { ITelemetryService } from "@cline/shared";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type {
+	ITelemetryService,
+	Message,
+	ToolResultContent,
+} from "@cline/shared";
 import { describe, expect, it, vi } from "vitest";
 import {
 	CLINE_INTERNAL_TELEMETRY_METADATA_KEY,
 	getToolContextTelemetry,
 } from "../../services/telemetry/tool-context";
+import { MessageBuilder } from "../../session/services/message-builder";
 import {
 	createBashTool,
 	createDefaultTools,
@@ -13,7 +21,7 @@ import {
 } from "./definitions";
 import { RUN_COMMAND_QUERY_PREVIEW_LIMIT, TimeoutError } from "./helpers";
 import { INPUT_ARG_CHAR_LIMIT } from "./schemas";
-import type { SkillsExecutorWithMetadata } from "./types";
+import type { SkillsExecutorWithMetadata, ToolOperationResult } from "./types";
 
 function createMockSkillsExecutor(
 	fn: (...args: unknown[]) => Promise<string> = async () => "ok",
@@ -22,6 +30,36 @@ function createMockSkillsExecutor(
 	const executor = fn as SkillsExecutorWithMetadata;
 	executor.configuredSkills = configuredSkills;
 	return executor;
+}
+
+function messagesForToolResult(
+	name: string,
+	operations: ToolOperationResult[],
+): Message[] {
+	return [
+		{
+			role: "assistant",
+			content: [
+				{
+					type: "tool_use",
+					id: "call_1",
+					name,
+					input: { commands: ["cat big.log"] },
+				},
+			],
+		},
+		{
+			role: "user",
+			content: [
+				{
+					type: "tool_result",
+					tool_use_id: "call_1",
+					name,
+					content: operations as unknown as ToolResultContent["content"],
+				},
+			],
+		},
+	];
 }
 
 describe("default skills tool", () => {
@@ -696,6 +734,124 @@ describe("default run_commands tool", () => {
 		expect(result[0].query).toContain("command truncated");
 	});
 
+	it("caps huge command output, artifacts the full output, and keeps transcript/API payloads compact", async () => {
+		const artifactDir = mkdtempSync(join(tmpdir(), "core-tool-output-"));
+		try {
+			const hugeOutput = [
+				"COMMAND_HEAD",
+				"x".repeat(20_000),
+				"MIDDLE_SENTINEL_SHOULD_NOT_BE_INLINE",
+				"y".repeat(20_000),
+				"COMMAND_TAIL",
+			].join("\n");
+			const execute = vi.fn(async () => hugeOutput);
+			const tool = createBashTool(execute, {
+				runCommandOutputMaxChars: 700,
+				toolOutputArtifactDirectory: artifactDir,
+			});
+
+			const result = (await tool.execute(
+				{ commands: ["cat big.log"] },
+				{
+					sessionId: "session-1",
+					agentId: "agent-1",
+					conversationId: "conv-1",
+					iteration: 1,
+					toolCallId: "tool-call-1",
+				},
+			)) as ToolOperationResult[];
+			const operation = result[0];
+			if (!operation) {
+				throw new Error("expected operation result");
+			}
+
+			expect(operation.success).toBe(true);
+			expect(operation.truncated).toBe(true);
+			expect(operation.omittedChars).toBeGreaterThan(35_000);
+			expect(operation.omittedBytes).toBeGreaterThan(35_000);
+			expect(operation.fullOutputPath).toContain(artifactDir);
+			expect(String(operation.result).length).toBeLessThan(900);
+			expect(operation.result).toContain("COMMAND_HEAD");
+			expect(operation.result).toContain("COMMAND_TAIL");
+			expect(operation.result).toContain("omitted");
+			expect(operation.result).toContain("full output saved");
+			expect(operation.result).not.toContain(
+				"MIDDLE_SENTINEL_SHOULD_NOT_BE_INLINE",
+			);
+			if (!operation.fullOutputPath) {
+				throw new Error("expected full output artifact path");
+			}
+			expect(existsSync(operation.fullOutputPath)).toBe(true);
+			expect(readFileSync(operation.fullOutputPath, "utf8")).toBe(hugeOutput);
+
+			const persistedTranscript = JSON.stringify(
+				messagesForToolResult("run_commands", result),
+			);
+			expect(persistedTranscript.length).toBeLessThan(2_500);
+			expect(persistedTranscript).not.toContain(
+				"MIDDLE_SENTINEL_SHOULD_NOT_BE_INLINE",
+			);
+
+			const providerMessages = new MessageBuilder().buildForApi(
+				messagesForToolResult("run_commands", result),
+			);
+			const providerPayload = JSON.stringify(providerMessages);
+			expect(providerPayload.length).toBeLessThan(2_500);
+			expect(providerPayload).not.toContain(
+				"MIDDLE_SENTINEL_SHOULD_NOT_BE_INLINE",
+			);
+		} finally {
+			rmSync(artifactDir, { recursive: true, force: true });
+		}
+	});
+
+	it("normalizes CR-heavy command progress logs and keeps the useful tail", async () => {
+		const artifactDir = mkdtempSync(join(tmpdir(), "core-tool-cr-output-"));
+		try {
+			const progressOutput = `${Array.from(
+				{ length: 1_000 },
+				(_, index) => `Downloading ${index}/999`,
+			).join("\r")}\ncomplete\n`;
+			const execute = vi.fn(async () => progressOutput);
+			const tool = createBashTool(execute, {
+				runCommandOutputMaxChars: 400,
+				toolOutputArtifactDirectory: artifactDir,
+			});
+
+			const result = (await tool.execute(
+				{ commands: ["download-model"] },
+				{
+					sessionId: "session-1",
+					agentId: "agent-1",
+					conversationId: "conv-1",
+					iteration: 1,
+					toolCallId: "tool-call-1",
+				},
+			)) as ToolOperationResult[];
+			const operation = result[0];
+			if (!operation) {
+				throw new Error("expected operation result");
+			}
+
+			expect(operation.success).toBe(true);
+			expect(operation.truncated).toBe(true);
+			expect(operation.normalizedCarriageReturns).toBe(true);
+			expect(operation.fullOutputPath).toContain(artifactDir);
+			expect(String(operation.result).length).toBeLessThan(500);
+			expect(operation.result).toContain("Downloading 999/999");
+			expect(operation.result).toContain("complete");
+			expect(operation.result).not.toContain("Downloading 0/999");
+			if (!operation.fullOutputPath) {
+				throw new Error("expected full output artifact path");
+			}
+			expect(readFileSync(operation.fullOutputPath, "utf8")).toBe(
+				progressOutput,
+			);
+		} finally {
+			rmSync(artifactDir, { recursive: true, force: true });
+		}
+	});
+
 	it("emits timeout telemetry without leaking raw command data", async () => {
 		const execute = vi.fn(
 			async (): Promise<string> =>
@@ -1008,6 +1164,97 @@ describe("default read_files tool", () => {
 			{ path: "/tmp/c.ts" },
 			expect.objectContaining({ iteration: 2 }),
 		);
+	});
+
+	it("caps huge unranged file reads before they enter transcript/provider payloads", async () => {
+		const hugeFile = [
+			"FILE_HEAD",
+			"a".repeat(20_000),
+			"FILE_MIDDLE_SENTINEL_SHOULD_NOT_BE_INLINE",
+			"b".repeat(20_000),
+			"FILE_TAIL",
+		].join("\n");
+		const execute = vi.fn(async () => hugeFile);
+		const tool = createReadFilesTool(execute, {
+			readFileOutputMaxChars: 700,
+		});
+
+		const result = (await tool.execute(
+			{ files: [{ path: "/tmp/huge.txt" }] },
+			{
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 1,
+			},
+		)) as ToolOperationResult[];
+		const operation = result[0];
+		if (!operation) {
+			throw new Error("expected operation result");
+		}
+
+		expect(operation.success).toBe(true);
+		expect(operation.truncated).toBe(true);
+		expect(operation.omittedChars).toBeGreaterThan(35_000);
+		expect(operation.fullOutputPath).toBeUndefined();
+		expect(String(operation.result).length).toBeLessThan(900);
+		expect(operation.result).toContain("FILE_HEAD");
+		expect(operation.result).toContain("FILE_TAIL");
+		expect(operation.result).toContain("start_line/end_line");
+		expect(operation.result).not.toContain(
+			"FILE_MIDDLE_SENTINEL_SHOULD_NOT_BE_INLINE",
+		);
+
+		const persistedTranscript = JSON.stringify(
+			messagesForToolResult("read_files", result),
+		);
+		expect(persistedTranscript.length).toBeLessThan(2_000);
+		expect(persistedTranscript).not.toContain(
+			"FILE_MIDDLE_SENTINEL_SHOULD_NOT_BE_INLINE",
+		);
+
+		const providerMessages = new MessageBuilder().buildForApi(
+			messagesForToolResult("read_files", result),
+		);
+		const providerPayload = JSON.stringify(providerMessages);
+		expect(providerPayload.length).toBeLessThan(2_000);
+		expect(providerPayload).not.toContain(
+			"FILE_MIDDLE_SENTINEL_SHOULD_NOT_BE_INLINE",
+		);
+	});
+
+	it("does not cap explicitly ranged file reads", async () => {
+		const rangedContent = [
+			"RANGED_HEAD",
+			"r".repeat(2_000),
+			"RANGED_TAIL",
+		].join("\n");
+		const execute = vi.fn(async () => rangedContent);
+		const tool = createReadFilesTool(execute, {
+			readFileOutputMaxChars: 100,
+		});
+
+		const result = (await tool.execute(
+			{
+				files: [
+					{
+						path: "/tmp/ranged.txt",
+						start_line: 10,
+						end_line: 20,
+					},
+				],
+			},
+			{
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 1,
+			},
+		)) as ToolOperationResult[];
+
+		expect(result[0]).toEqual({
+			query: "/tmp/ranged.txt:10-20",
+			result: rangedContent,
+			success: true,
+		});
 	});
 
 	it("rejects invalid union inputs before calling the executor", async () => {

--- a/sdk/packages/core/src/extensions/tools/definitions.test.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.test.ts
@@ -805,6 +805,83 @@ describe("default run_commands tool", () => {
 		}
 	});
 
+	it("applies an aggregate output budget across batched command results", async () => {
+		const execute = vi.fn(async (command: unknown) => {
+			const renderedCommand = String(command);
+			const index = Number(renderedCommand.match(/\d+$/u)?.[0] ?? 0);
+			const sentinel =
+				index >= 2
+					? `AGGREGATE_COMMAND_${index}_SHOULD_NOT_BE_INLINE`
+					: `command-${index}-kept`;
+			return [
+				`command-${index}-head`,
+				"x".repeat(1_800),
+				sentinel,
+				"y".repeat(1_800),
+				`command-${index}-tail`,
+			].join("\n");
+		});
+		const tool = createBashTool(execute, {
+			runCommandOutputMaxChars: 10_000,
+			runCommandAggregateOutputMaxChars: 7_000,
+		});
+		const commands = Array.from(
+			{ length: 8 },
+			(_, index) => `curl endpoint-${index}`,
+		);
+
+		const result = (await tool.execute(
+			{ commands },
+			{
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 1,
+			},
+		)) as ToolOperationResult[];
+
+		expect(result).toHaveLength(8);
+		expect(result[0]?.aggregateOmitted).toBeUndefined();
+		expect(result[7]?.query).toBe("curl endpoint-7");
+		expect(result[7]?.aggregateOmitted).toBe(true);
+		expect(result[7]?.omittedChars).toBeGreaterThan(3_000);
+		expect(String(result[7]?.result)).toContain("aggregate output budget");
+		expect(String(result[7]?.result)).not.toContain(
+			"AGGREGATE_COMMAND_7_SHOULD_NOT_BE_INLINE",
+		);
+
+		const inlineOutputChars = result.reduce(
+			(total, operation) =>
+				total +
+				String(operation.result ?? "").length +
+				(operation.error?.length ?? 0),
+			0,
+		);
+		expect(inlineOutputChars).toBeLessThan(7_000);
+
+		const serializedResult = JSON.stringify(result);
+		expect(serializedResult).not.toContain(
+			"AGGREGATE_COMMAND_7_SHOULD_NOT_BE_INLINE",
+		);
+		expect(serializedResult.length).toBeLessThan(9_000);
+
+		const persistedTranscript = JSON.stringify(
+			messagesForToolResult("run_commands", result),
+		);
+		expect(persistedTranscript.length).toBeLessThan(10_000);
+		expect(persistedTranscript).not.toContain(
+			"AGGREGATE_COMMAND_7_SHOULD_NOT_BE_INLINE",
+		);
+
+		const providerMessages = new MessageBuilder().buildForApi(
+			messagesForToolResult("run_commands", result),
+		);
+		const providerPayload = JSON.stringify(providerMessages);
+		expect(providerPayload.length).toBeLessThan(10_000);
+		expect(providerPayload).not.toContain(
+			"AGGREGATE_COMMAND_7_SHOULD_NOT_BE_INLINE",
+		);
+	});
+
 	it("normalizes CR-heavy command progress logs and keeps the useful tail", async () => {
 		const artifactDir = mkdtempSync(join(tmpdir(), "core-tool-cr-output-"));
 		try {
@@ -1219,6 +1296,84 @@ describe("default read_files tool", () => {
 		expect(providerPayload.length).toBeLessThan(2_000);
 		expect(providerPayload).not.toContain(
 			"FILE_MIDDLE_SENTINEL_SHOULD_NOT_BE_INLINE",
+		);
+	});
+
+	it("applies an aggregate output budget across batched ranged file reads", async () => {
+		const execute = vi.fn(async (request) => {
+			const index = Number(request.path.match(/(\d+)\.gcode$/u)?.[1] ?? 0);
+			const sentinel =
+				index >= 2
+					? `AGGREGATE_FILE_${index}_SHOULD_NOT_BE_INLINE`
+					: `file-${index}-kept`;
+			return [
+				`range-${index}-head`,
+				"r".repeat(1_800),
+				sentinel,
+				"s".repeat(1_800),
+				`range-${index}-tail`,
+			].join("\n");
+		});
+		const tool = createReadFilesTool(execute, {
+			readFileOutputMaxChars: 100,
+			readFilesAggregateOutputMaxChars: 7_000,
+		});
+		const files = Array.from({ length: 11 }, (_, index) => ({
+			path: `/tmp/text-${index}.gcode`,
+			start_line: index * 100 + 1,
+			end_line: (index + 1) * 100,
+		}));
+
+		const result = (await tool.execute(
+			{ files },
+			{
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 1,
+			},
+		)) as ToolOperationResult[];
+
+		expect(result).toHaveLength(11);
+		expect(result[0]?.aggregateOmitted).toBeUndefined();
+		expect(String(result[0]?.result)).toContain("range-0-head");
+		expect(result[10]?.query).toBe("/tmp/text-10.gcode:1001-1100");
+		expect(result[10]?.aggregateOmitted).toBe(true);
+		expect(result[10]?.omittedChars).toBeGreaterThan(3_000);
+		expect(String(result[10]?.result)).toContain("aggregate output budget");
+		expect(String(result[10]?.result)).not.toContain(
+			"AGGREGATE_FILE_10_SHOULD_NOT_BE_INLINE",
+		);
+
+		const inlineOutputChars = result.reduce(
+			(total, operation) =>
+				total +
+				String(operation.result ?? "").length +
+				(operation.error?.length ?? 0),
+			0,
+		);
+		expect(inlineOutputChars).toBeLessThan(7_000);
+
+		const serializedResult = JSON.stringify(result);
+		expect(serializedResult).not.toContain(
+			"AGGREGATE_FILE_10_SHOULD_NOT_BE_INLINE",
+		);
+		expect(serializedResult.length).toBeLessThan(10_000);
+
+		const persistedTranscript = JSON.stringify(
+			messagesForToolResult("read_files", result),
+		);
+		expect(persistedTranscript.length).toBeLessThan(11_000);
+		expect(persistedTranscript).not.toContain(
+			"AGGREGATE_FILE_10_SHOULD_NOT_BE_INLINE",
+		);
+
+		const providerMessages = new MessageBuilder().buildForApi(
+			messagesForToolResult("read_files", result),
+		);
+		const providerPayload = JSON.stringify(providerMessages);
+		expect(providerPayload.length).toBeLessThan(11_000);
+		expect(providerPayload).not.toContain(
+			"AGGREGATE_FILE_10_SHOULD_NOT_BE_INLINE",
 		);
 	});
 

--- a/sdk/packages/core/src/extensions/tools/definitions.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.ts
@@ -14,6 +14,10 @@ import {
 import { captureRunCommandsTimeout } from "../../services/telemetry/core-events";
 import { getToolContextTelemetry } from "../../services/telemetry/tool-context";
 import {
+	budgetReadFileOutput,
+	budgetRunCommandOutput,
+	DEFAULT_READ_FILE_OUTPUT_MAX_CHARS,
+	DEFAULT_RUN_COMMAND_OUTPUT_MAX_CHARS,
 	formatError,
 	formatReadFileQuery,
 	formatRunCommandQueryPreview,
@@ -115,9 +119,14 @@ function captureRunCommandsTimeoutFromContext(
  */
 export function createReadFilesTool(
 	executor: FileReadExecutor,
-	config: Pick<DefaultToolsConfig, "fileReadTimeoutMs"> = {},
+	config: Pick<
+		DefaultToolsConfig,
+		"fileReadTimeoutMs" | "readFileOutputMaxChars"
+	> = {},
 ): AgentTool<ReadFilesInput, ToolOperationResult[]> {
 	const timeoutMs = config.fileReadTimeoutMs ?? 10000;
+	const outputMaxChars =
+		config.readFileOutputMaxChars ?? DEFAULT_READ_FILE_OUTPUT_MAX_CHARS;
 
 	return createTool<ReadFilesInput, ToolOperationResult[]>({
 		name: "read_files",
@@ -179,6 +188,20 @@ export function createReadFilesTool(
 							timeoutMs,
 							`File read timed out after ${timeoutMs}ms`,
 						);
+						if (typeof content === "string") {
+							const budgeted = budgetReadFileOutput({
+								output: content,
+								maxChars: outputMaxChars,
+								isExplicitRange:
+									request.start_line != null || request.end_line != null,
+							});
+							return {
+								query: formatReadFileQuery(request),
+								result: budgeted.text,
+								success: true,
+								...budgeted.metadata,
+							};
+						}
 						return {
 							query: formatReadFileQuery(request),
 							result: content,
@@ -270,9 +293,17 @@ export function createSearchTool(
  */
 export function createBashTool(
 	executor: BashExecutor,
-	config: Pick<DefaultToolsConfig, "cwd" | "bashTimeoutMs"> = {},
+	config: Pick<
+		DefaultToolsConfig,
+		| "cwd"
+		| "bashTimeoutMs"
+		| "runCommandOutputMaxChars"
+		| "toolOutputArtifactDirectory"
+	> = {},
 ): AgentTool<RunCommandsInput, ToolOperationResult[]> {
 	const timeoutMs = config.bashTimeoutMs ?? 30000;
+	const outputMaxChars =
+		config.runCommandOutputMaxChars ?? DEFAULT_RUN_COMMAND_OUTPUT_MAX_CHARS;
 	const timeoutSource =
 		config.bashTimeoutMs === undefined
 			? "default_setting"
@@ -317,10 +348,19 @@ export function createBashTool(
 							timeoutMs,
 							`Command timed out after ${timeoutMs}ms`,
 						);
+						const budgeted = await budgetRunCommandOutput({
+							output,
+							maxChars: outputMaxChars,
+							cwd,
+							artifactDirectory: config.toolOutputArtifactDirectory,
+							sessionId: context.sessionId,
+							toolCallId: context.toolCallId,
+						});
 						return {
 							query,
-							result: output,
+							result: budgeted.text,
 							success: true,
+							...budgeted.metadata,
 						};
 					} catch (error) {
 						if (error instanceof TimeoutError) {
@@ -332,11 +372,20 @@ export function createBashTool(
 							});
 						}
 						const msg = formatError(error);
+						const budgeted = await budgetRunCommandOutput({
+							output: msg,
+							maxChars: outputMaxChars,
+							cwd,
+							artifactDirectory: config.toolOutputArtifactDirectory,
+							sessionId: context.sessionId,
+							toolCallId: context.toolCallId,
+						});
 						return {
 							query,
 							result: "",
-							error: `Command failed: ${msg}`,
+							error: `Command failed: ${budgeted.text}`,
 							success: false,
+							...budgeted.metadata,
 						};
 					}
 				}),
@@ -352,9 +401,17 @@ export function createBashTool(
  */
 export function createWindowsShellTool(
 	executor: BashExecutor,
-	config: Pick<DefaultToolsConfig, "cwd" | "bashTimeoutMs"> = {},
+	config: Pick<
+		DefaultToolsConfig,
+		| "cwd"
+		| "bashTimeoutMs"
+		| "runCommandOutputMaxChars"
+		| "toolOutputArtifactDirectory"
+	> = {},
 ): AgentTool<StructuredCommandInput, ToolOperationResult[]> {
 	const timeoutMs = config.bashTimeoutMs ?? 30000;
+	const outputMaxChars =
+		config.runCommandOutputMaxChars ?? DEFAULT_RUN_COMMAND_OUTPUT_MAX_CHARS;
 	const timeoutSource =
 		config.bashTimeoutMs === undefined
 			? "default_setting"
@@ -384,10 +441,19 @@ export function createWindowsShellTool(
 							timeoutMs,
 							`Command timed out after ${timeoutMs}ms`,
 						);
+						const budgeted = await budgetRunCommandOutput({
+							output,
+							maxChars: outputMaxChars,
+							cwd,
+							artifactDirectory: config.toolOutputArtifactDirectory,
+							sessionId: context.sessionId,
+							toolCallId: context.toolCallId,
+						});
 						return {
 							query,
-							result: output,
+							result: budgeted.text,
 							success: true,
+							...budgeted.metadata,
 						};
 					} catch (error) {
 						if (error instanceof TimeoutError) {
@@ -399,11 +465,20 @@ export function createWindowsShellTool(
 							});
 						}
 						const msg = formatError(error);
+						const budgeted = await budgetRunCommandOutput({
+							output: msg,
+							maxChars: outputMaxChars,
+							cwd,
+							artifactDirectory: config.toolOutputArtifactDirectory,
+							sessionId: context.sessionId,
+							toolCallId: context.toolCallId,
+						});
 						return {
 							query,
 							result: "",
-							error: `Command failed: ${msg}`,
+							error: `Command failed: ${budgeted.text}`,
 							success: false,
+							...budgeted.metadata,
 						};
 					}
 				}),

--- a/sdk/packages/core/src/extensions/tools/definitions.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.ts
@@ -14,11 +14,15 @@ import {
 import { captureRunCommandsTimeout } from "../../services/telemetry/core-events";
 import { getToolContextTelemetry } from "../../services/telemetry/tool-context";
 import {
+	applyAggregateToolResultBudget,
 	budgetReadFileOutput,
 	budgetRunCommandOutput,
 	DEFAULT_READ_FILE_OUTPUT_MAX_CHARS,
+	DEFAULT_READ_FILES_AGGREGATE_OUTPUT_MAX_CHARS,
+	DEFAULT_RUN_COMMAND_AGGREGATE_OUTPUT_MAX_CHARS,
 	DEFAULT_RUN_COMMAND_OUTPUT_MAX_CHARS,
 	formatError,
+	formatOmittedCount,
 	formatReadFileQuery,
 	formatRunCommandQueryPreview,
 	getEditorSizeError,
@@ -108,6 +112,53 @@ function captureRunCommandsTimeoutFromContext(
 	});
 }
 
+function createReadFilesAggregatePlaceholder(context: {
+	entry: ToolOperationResult;
+	omittedChars: number;
+	omittedBytes: number;
+}): ToolOperationResult {
+	const placeholder = `[omitted ${formatOmittedCount(
+		context.omittedChars,
+		context.omittedBytes,
+	)} from read_files entry: aggregate output budget exhausted. Read this path/range in a separate call or use a narrower range.]`;
+
+	return {
+		...context.entry,
+		result: context.entry.error ? "" : placeholder,
+		...(context.entry.error ? { error: placeholder } : {}),
+		success: context.entry.success,
+		truncated: true,
+		aggregateOmitted: true,
+		omittedChars: (context.entry.omittedChars ?? 0) + context.omittedChars,
+		omittedBytes: (context.entry.omittedBytes ?? 0) + context.omittedBytes,
+	};
+}
+
+function createRunCommandsAggregatePlaceholder(context: {
+	entry: ToolOperationResult;
+	omittedChars: number;
+	omittedBytes: number;
+}): ToolOperationResult {
+	const inspectHint = context.entry.fullOutputPath
+		? ` Full output saved to ${context.entry.fullOutputPath}.`
+		: " Run this command separately to inspect full output.";
+	const placeholder = `[omitted ${formatOmittedCount(
+		context.omittedChars,
+		context.omittedBytes,
+	)} from run_commands entry: aggregate output budget exhausted.${inspectHint}]`;
+
+	return {
+		...context.entry,
+		result: context.entry.error ? "" : placeholder,
+		...(context.entry.error ? { error: placeholder } : {}),
+		success: context.entry.success,
+		truncated: true,
+		aggregateOmitted: true,
+		omittedChars: (context.entry.omittedChars ?? 0) + context.omittedChars,
+		omittedBytes: (context.entry.omittedBytes ?? 0) + context.omittedBytes,
+	};
+}
+
 // =============================================================================
 // AgentTool Factory Functions
 // =============================================================================
@@ -121,12 +172,17 @@ export function createReadFilesTool(
 	executor: FileReadExecutor,
 	config: Pick<
 		DefaultToolsConfig,
-		"fileReadTimeoutMs" | "readFileOutputMaxChars"
+		| "fileReadTimeoutMs"
+		| "readFileOutputMaxChars"
+		| "readFilesAggregateOutputMaxChars"
 	> = {},
 ): AgentTool<ReadFilesInput, ToolOperationResult[]> {
 	const timeoutMs = config.fileReadTimeoutMs ?? 10000;
 	const outputMaxChars =
 		config.readFileOutputMaxChars ?? DEFAULT_READ_FILE_OUTPUT_MAX_CHARS;
+	const aggregateOutputMaxChars =
+		config.readFilesAggregateOutputMaxChars ??
+		DEFAULT_READ_FILES_AGGREGATE_OUTPUT_MAX_CHARS;
 
 	return createTool<ReadFilesInput, ToolOperationResult[]>({
 		name: "read_files",
@@ -170,7 +226,7 @@ export function createReadFilesTool(
 				requests = [validate];
 			}
 
-			return Promise.all(
+			const results = await Promise.all(
 				requests.map(async (request): Promise<ToolOperationResult> => {
 					const rangeError = getReadFileRangeError(request);
 					if (rangeError) {
@@ -218,6 +274,10 @@ export function createReadFilesTool(
 					}
 				}),
 			);
+			return applyAggregateToolResultBudget(results, {
+				maxChars: aggregateOutputMaxChars,
+				createPlaceholder: createReadFilesAggregatePlaceholder,
+			});
 		},
 	});
 }
@@ -298,12 +358,16 @@ export function createBashTool(
 		| "cwd"
 		| "bashTimeoutMs"
 		| "runCommandOutputMaxChars"
+		| "runCommandAggregateOutputMaxChars"
 		| "toolOutputArtifactDirectory"
 	> = {},
 ): AgentTool<RunCommandsInput, ToolOperationResult[]> {
 	const timeoutMs = config.bashTimeoutMs ?? 30000;
 	const outputMaxChars =
 		config.runCommandOutputMaxChars ?? DEFAULT_RUN_COMMAND_OUTPUT_MAX_CHARS;
+	const aggregateOutputMaxChars =
+		config.runCommandAggregateOutputMaxChars ??
+		DEFAULT_RUN_COMMAND_AGGREGATE_OUTPUT_MAX_CHARS;
 	const timeoutSource =
 		config.bashTimeoutMs === undefined
 			? "default_setting"
@@ -338,7 +402,7 @@ export function createBashTool(
 				commands = [validate.cmd];
 			}
 
-			return Promise.all(
+			const results = await Promise.all(
 				commands.map(async (command: string): Promise<ToolOperationResult> => {
 					const startedAt = Date.now();
 					const query = formatRunCommandQueryPreview(command);
@@ -390,6 +454,10 @@ export function createBashTool(
 					}
 				}),
 			);
+			return applyAggregateToolResultBudget(results, {
+				maxChars: aggregateOutputMaxChars,
+				createPlaceholder: createRunCommandsAggregatePlaceholder,
+			});
 		},
 	});
 }
@@ -406,12 +474,16 @@ export function createWindowsShellTool(
 		| "cwd"
 		| "bashTimeoutMs"
 		| "runCommandOutputMaxChars"
+		| "runCommandAggregateOutputMaxChars"
 		| "toolOutputArtifactDirectory"
 	> = {},
 ): AgentTool<StructuredCommandInput, ToolOperationResult[]> {
 	const timeoutMs = config.bashTimeoutMs ?? 30000;
 	const outputMaxChars =
 		config.runCommandOutputMaxChars ?? DEFAULT_RUN_COMMAND_OUTPUT_MAX_CHARS;
+	const aggregateOutputMaxChars =
+		config.runCommandAggregateOutputMaxChars ??
+		DEFAULT_RUN_COMMAND_AGGREGATE_OUTPUT_MAX_CHARS;
 	const timeoutSource =
 		config.bashTimeoutMs === undefined
 			? "default_setting"
@@ -431,7 +503,7 @@ export function createWindowsShellTool(
 		execute: async (input, context) => {
 			const commands = normalizeRunCommandsInput(input);
 
-			return Promise.all(
+			const results = await Promise.all(
 				commands.map(async (command): Promise<ToolOperationResult> => {
 					const startedAt = Date.now();
 					const query = formatRunCommandQueryPreview(command);
@@ -483,6 +555,10 @@ export function createWindowsShellTool(
 					}
 				}),
 			);
+			return applyAggregateToolResultBudget(results, {
+				maxChars: aggregateOutputMaxChars,
+				createPlaceholder: createRunCommandsAggregatePlaceholder,
+			});
 		},
 	});
 }

--- a/sdk/packages/core/src/extensions/tools/helpers.ts
+++ b/sdk/packages/core/src/extensions/tools/helpers.ts
@@ -1,3 +1,7 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import { validateWithZod } from "@cline/shared";
 import {
 	type EditFileInput,
@@ -147,4 +151,320 @@ export function formatRunCommandQueryPreview(
 	}
 	const truncatedChars = rendered.length - RUN_COMMAND_QUERY_PREVIEW_LIMIT;
 	return `${rendered.slice(0, RUN_COMMAND_QUERY_PREVIEW_LIMIT)} ... [command truncated: ${truncatedChars} more chars; full command is in the tool call input]`;
+}
+
+export const DEFAULT_RUN_COMMAND_OUTPUT_MAX_CHARS = 20_000;
+export const DEFAULT_READ_FILE_OUTPUT_MAX_CHARS = 40_000;
+
+interface TextBudgetMetadata {
+	truncated?: true;
+	omittedChars?: number;
+	omittedBytes?: number;
+	fullOutputPath?: string;
+	normalizedCarriageReturns?: true;
+}
+
+export interface BudgetedText {
+	text: string;
+	metadata: TextBudgetMetadata;
+}
+
+interface PreviewOptions {
+	source: string;
+	original: string;
+	maxChars: number;
+	preserve: "head-tail" | "tail";
+	marker: (omittedChars: number, omittedBytes: number) => string;
+}
+
+function byteLength(value: string): number {
+	return Buffer.byteLength(value, "utf8");
+}
+
+function formatOmittedCount(chars: number, bytes: number): string {
+	if (chars === bytes) {
+		return `${chars} chars`;
+	}
+	return `${chars} chars / ${bytes} bytes`;
+}
+
+function computeVisibleText(
+	source: string,
+	budget: number,
+	preserve: PreviewOptions["preserve"],
+): string {
+	if (budget <= 0) {
+		return "";
+	}
+	if (source.length <= budget) {
+		return source;
+	}
+	if (preserve === "tail") {
+		return source.slice(source.length - budget);
+	}
+
+	const headChars = Math.ceil(budget * 0.4);
+	const tailChars = Math.max(0, budget - headChars);
+	return `${source.slice(0, headChars)}${source.slice(
+		source.length - tailChars,
+	)}`;
+}
+
+function buildPreview(options: PreviewOptions): {
+	text: string;
+	omittedChars: number;
+	omittedBytes: number;
+} {
+	let marker = options.marker(0, 0);
+	let visible = "";
+	let omittedChars = 0;
+	let omittedBytes = 0;
+
+	for (let i = 0; i < 4; i++) {
+		const budget = Math.max(0, options.maxChars - marker.length);
+		visible = computeVisibleText(options.source, budget, options.preserve);
+		omittedChars = Math.max(0, options.original.length - visible.length);
+		omittedBytes = Math.max(
+			0,
+			byteLength(options.original) - byteLength(visible),
+		);
+		marker = options.marker(omittedChars, omittedBytes);
+	}
+
+	const text =
+		options.preserve === "tail"
+			? `${marker}${visible}`
+			: `${visible.slice(
+					0,
+					Math.ceil(visible.length * 0.4),
+				)}${marker}${visible.slice(Math.ceil(visible.length * 0.4))}`;
+
+	return {
+		text,
+		omittedChars,
+		omittedBytes,
+	};
+}
+
+interface NormalizedCarriageReturnOutput {
+	text: string;
+	changed: boolean;
+	carriageReturnCount: number;
+}
+
+function normalizeCarriageReturnOutput(
+	output: string,
+): NormalizedCarriageReturnOutput {
+	if (!output.includes("\r")) {
+		return { text: output, changed: false, carriageReturnCount: 0 };
+	}
+
+	const lines: string[] = [];
+	let current = "";
+	let carriageReturnCount = 0;
+	let endedWithLineBreak = false;
+
+	for (let i = 0; i < output.length; i++) {
+		const char = output[i];
+		endedWithLineBreak = false;
+
+		if (char === "\r") {
+			carriageReturnCount += 1;
+			if (output[i + 1] === "\n") {
+				lines.push(current);
+				current = "";
+				i += 1;
+				endedWithLineBreak = true;
+			} else {
+				current = "";
+			}
+			continue;
+		}
+
+		if (char === "\n") {
+			lines.push(current);
+			current = "";
+			endedWithLineBreak = true;
+			continue;
+		}
+
+		current += char;
+	}
+
+	if (current.length > 0 || !endedWithLineBreak) {
+		lines.push(current);
+	}
+
+	const text = `${lines.join("\n")}${endedWithLineBreak ? "\n" : ""}`;
+	return {
+		text,
+		changed: text !== output,
+		carriageReturnCount,
+	};
+}
+
+function isCarriageReturnProgressOutput(
+	normalized: NormalizedCarriageReturnOutput,
+	original: string,
+): boolean {
+	if (normalized.carriageReturnCount >= 20) {
+		return true;
+	}
+	return (
+		normalized.carriageReturnCount >= 5 &&
+		original.length - normalized.text.length > 1_000
+	);
+}
+
+function sanitizeArtifactSegment(
+	value: string | undefined,
+): string | undefined {
+	const normalized = value?.trim();
+	if (!normalized) {
+		return undefined;
+	}
+	const safe = normalized.replace(/[^a-zA-Z0-9._-]+/g, "_").slice(0, 64);
+	return safe || undefined;
+}
+
+async function writeCommandOutputArtifact(options: {
+	output: string;
+	cwd: string;
+	artifactDirectory?: string;
+	sessionId?: string;
+	toolCallId?: string;
+}): Promise<string | undefined> {
+	const sessionSegment = sanitizeArtifactSegment(options.sessionId);
+	const toolCallSegment = sanitizeArtifactSegment(options.toolCallId);
+	const filename = [
+		"run_commands",
+		sessionSegment,
+		toolCallSegment,
+		Date.now().toString(36),
+		randomUUID(),
+	]
+		.filter((segment): segment is string => Boolean(segment))
+		.join("-");
+	const candidateDirs = [
+		options.artifactDirectory
+			? resolve(options.artifactDirectory)
+			: resolve(options.cwd, ".cline", "tmp", "tool-outputs"),
+		join(tmpdir(), "cline-tool-outputs"),
+	];
+
+	for (const dir of candidateDirs) {
+		try {
+			await mkdir(dir, { recursive: true });
+			const outputPath = join(dir, `${filename}.txt`);
+			await writeFile(outputPath, options.output, "utf8");
+			return outputPath;
+		} catch {
+			// Try the next artifact directory.
+		}
+	}
+
+	return undefined;
+}
+
+function commandOmittedMarker(
+	path: string | undefined,
+	omittedChars: number,
+	omittedBytes: number,
+): string {
+	const artifactText = path
+		? `; full output saved to ${path}`
+		: "; full output artifact unavailable";
+	return `\n\n[... omitted ${formatOmittedCount(
+		omittedChars,
+		omittedBytes,
+	)} from command output${artifactText} ...]\n\n`;
+}
+
+function readFileOmittedMarker(
+	omittedChars: number,
+	omittedBytes: number,
+): string {
+	return `\n\n[... omitted ${formatOmittedCount(
+		omittedChars,
+		omittedBytes,
+	)} from file output; use start_line/end_line to inspect omitted content ...]\n\n`;
+}
+
+export async function budgetRunCommandOutput(options: {
+	output: string;
+	maxChars: number;
+	cwd: string;
+	artifactDirectory?: string;
+	sessionId?: string;
+	toolCallId?: string;
+}): Promise<BudgetedText> {
+	const normalized = normalizeCarriageReturnOutput(options.output);
+	const needsCompaction =
+		options.output.length > options.maxChars ||
+		normalized.text.length > options.maxChars ||
+		normalized.changed;
+
+	if (!needsCompaction) {
+		return { text: options.output, metadata: {} };
+	}
+
+	const fullOutputPath =
+		options.output.length > options.maxChars
+			? await writeCommandOutputArtifact({
+					output: options.output,
+					cwd: options.cwd,
+					artifactDirectory: options.artifactDirectory,
+					sessionId: options.sessionId,
+					toolCallId: options.toolCallId,
+				})
+			: undefined;
+	const preserve = isCarriageReturnProgressOutput(normalized, options.output)
+		? "tail"
+		: "head-tail";
+	const preview = buildPreview({
+		source: normalized.text,
+		original: options.output,
+		maxChars: options.maxChars,
+		preserve,
+		marker: (omittedChars, omittedBytes) =>
+			commandOmittedMarker(fullOutputPath, omittedChars, omittedBytes),
+	});
+
+	return {
+		text: preview.text,
+		metadata: {
+			truncated: true,
+			omittedChars: preview.omittedChars,
+			omittedBytes: preview.omittedBytes,
+			...(fullOutputPath ? { fullOutputPath } : {}),
+			...(normalized.changed ? { normalizedCarriageReturns: true } : {}),
+		},
+	};
+}
+
+export function budgetReadFileOutput(options: {
+	output: string;
+	maxChars: number;
+	isExplicitRange: boolean;
+}): BudgetedText {
+	if (options.isExplicitRange || options.output.length <= options.maxChars) {
+		return { text: options.output, metadata: {} };
+	}
+
+	const preview = buildPreview({
+		source: options.output,
+		original: options.output,
+		maxChars: options.maxChars,
+		preserve: "head-tail",
+		marker: readFileOmittedMarker,
+	});
+
+	return {
+		text: preview.text,
+		metadata: {
+			truncated: true,
+			omittedChars: preview.omittedChars,
+			omittedBytes: preview.omittedBytes,
+		},
+	};
 }

--- a/sdk/packages/core/src/extensions/tools/helpers.ts
+++ b/sdk/packages/core/src/extensions/tools/helpers.ts
@@ -10,6 +10,7 @@ import {
 	type StructuredCommandInput,
 	StructuredCommandsInputUnionSchema,
 } from "./schemas";
+import type { ToolOperationResult } from "./types";
 
 /**
  * Format an error into a string message
@@ -155,6 +156,8 @@ export function formatRunCommandQueryPreview(
 
 export const DEFAULT_RUN_COMMAND_OUTPUT_MAX_CHARS = 20_000;
 export const DEFAULT_READ_FILE_OUTPUT_MAX_CHARS = 40_000;
+export const DEFAULT_RUN_COMMAND_AGGREGATE_OUTPUT_MAX_CHARS = 40_000;
+export const DEFAULT_READ_FILES_AGGREGATE_OUTPUT_MAX_CHARS = 80_000;
 
 interface TextBudgetMetadata {
 	truncated?: true;
@@ -181,11 +184,132 @@ function byteLength(value: string): number {
 	return Buffer.byteLength(value, "utf8");
 }
 
-function formatOmittedCount(chars: number, bytes: number): string {
+export function formatOmittedCount(chars: number, bytes: number): string {
 	if (chars === bytes) {
 		return `${chars} chars`;
 	}
 	return `${chars} chars / ${bytes} bytes`;
+}
+
+interface OutputSize {
+	chars: number;
+	bytes: number;
+}
+
+function addOutputSize(left: OutputSize, right: OutputSize): OutputSize {
+	return {
+		chars: left.chars + right.chars,
+		bytes: left.bytes + right.bytes,
+	};
+}
+
+function measureInlineOutput(value: unknown): OutputSize {
+	if (typeof value === "string") {
+		return {
+			chars: value.length,
+			bytes: byteLength(value),
+		};
+	}
+
+	if (Array.isArray(value)) {
+		return value.reduce<OutputSize>(
+			(size, item) => addOutputSize(size, measureInlineOutput(item)),
+			{ chars: 0, bytes: 0 },
+		);
+	}
+
+	if (value && typeof value === "object") {
+		return Object.values(value).reduce<OutputSize>(
+			(size, item) => addOutputSize(size, measureInlineOutput(item)),
+			{ chars: 0, bytes: 0 },
+		);
+	}
+
+	return { chars: 0, bytes: 0 };
+}
+
+function measureToolOperationOutput(entry: ToolOperationResult): OutputSize {
+	return addOutputSize(measureInlineOutput(entry.result), {
+		chars: entry.error?.length ?? 0,
+		bytes: entry.error ? byteLength(entry.error) : 0,
+	});
+}
+
+function fitToolOperationOutput(
+	entry: ToolOperationResult,
+	maxChars: number,
+): ToolOperationResult {
+	if (maxChars <= 0) {
+		return {
+			...entry,
+			result: "",
+			...(entry.error ? { error: "" } : {}),
+		};
+	}
+
+	if (entry.error) {
+		return {
+			...entry,
+			result: "",
+			error: entry.error.slice(0, maxChars),
+		};
+	}
+
+	if (typeof entry.result === "string") {
+		return {
+			...entry,
+			result: entry.result.slice(0, maxChars),
+		};
+	}
+
+	return {
+		...entry,
+		result: "",
+	};
+}
+
+interface AggregateBudgetContext {
+	entry: ToolOperationResult;
+	index: number;
+	omittedChars: number;
+	omittedBytes: number;
+}
+
+export function applyAggregateToolResultBudget(
+	entries: ToolOperationResult[],
+	options: {
+		maxChars: number;
+		createPlaceholder: (context: AggregateBudgetContext) => ToolOperationResult;
+	},
+): ToolOperationResult[] {
+	const maxChars = Math.max(0, options.maxChars);
+	let remainingChars = maxChars;
+	let exhausted = false;
+
+	return entries.map((entry, index) => {
+		const outputSize = measureToolOperationOutput(entry);
+		if (!exhausted && outputSize.chars <= remainingChars) {
+			remainingChars -= outputSize.chars;
+			return entry;
+		}
+
+		exhausted = true;
+		const placeholder = options.createPlaceholder({
+			entry,
+			index,
+			omittedChars: outputSize.chars,
+			omittedBytes: outputSize.bytes,
+		});
+		const placeholderSize = measureToolOperationOutput(placeholder);
+		if (placeholderSize.chars > remainingChars) {
+			const fitted = fitToolOperationOutput(placeholder, remainingChars);
+			remainingChars = 0;
+			return fitted;
+		}
+
+		remainingChars = Math.max(0, remainingChars - placeholderSize.chars);
+		return placeholder;
+	});
 }
 
 function computeVisibleText(

--- a/sdk/packages/core/src/extensions/tools/types.ts
+++ b/sdk/packages/core/src/extensions/tools/types.ts
@@ -44,6 +44,8 @@ export interface ToolOperationResult {
 	fullOutputPath?: string;
 	/** Whether carriage-return progress updates were collapsed in the preview */
 	normalizedCarriageReturns?: boolean;
+	/** Whether this entry's inline output was omitted by a tool-call aggregate budget */
+	aggregateOmitted?: boolean;
 }
 
 export type FileReadResultContent = string | Array<TextContent | ImageContent>;
@@ -320,6 +322,12 @@ export interface DefaultToolsConfig {
 	readFileOutputMaxChars?: number;
 
 	/**
+	 * Maximum aggregate inline output characters across one read_files call
+	 * @default 80000
+	 */
+	readFilesAggregateOutputMaxChars?: number;
+
+	/**
 	 * Timeout for bash command execution in milliseconds
 	 * @default 30000
 	 */
@@ -330,6 +338,12 @@ export interface DefaultToolsConfig {
 	 * @default 20000
 	 */
 	runCommandOutputMaxChars?: number;
+
+	/**
+	 * Maximum aggregate inline output characters across one run_commands call
+	 * @default 40000
+	 */
+	runCommandAggregateOutputMaxChars?: number;
 
 	/**
 	 * Directory for full run_commands output artifacts

--- a/sdk/packages/core/src/extensions/tools/types.ts
+++ b/sdk/packages/core/src/extensions/tools/types.ts
@@ -34,6 +34,16 @@ export interface ToolOperationResult {
 	success: boolean;
 	/** Duration in MS */
 	duration?: number;
+	/** Whether result/error text was compacted before entering the transcript */
+	truncated?: boolean;
+	/** Characters omitted from the original tool output */
+	omittedChars?: number;
+	/** UTF-8 bytes omitted from the original tool output */
+	omittedBytes?: number;
+	/** Path containing the full output when a large command output was artifacted */
+	fullOutputPath?: string;
+	/** Whether carriage-return progress updates were collapsed in the preview */
+	normalizedCarriageReturns?: boolean;
 }
 
 export type FileReadResultContent = string | Array<TextContent | ImageContent>;
@@ -304,10 +314,28 @@ export interface DefaultToolsConfig {
 	fileReadTimeoutMs?: number;
 
 	/**
+	 * Maximum characters of unranged read_files text to return inline
+	 * @default 40000
+	 */
+	readFileOutputMaxChars?: number;
+
+	/**
 	 * Timeout for bash command execution in milliseconds
 	 * @default 30000
 	 */
 	bashTimeoutMs?: number;
+
+	/**
+	 * Maximum characters of run_commands output to return inline
+	 * @default 20000
+	 */
+	runCommandOutputMaxChars?: number;
+
+	/**
+	 * Directory for full run_commands output artifacts
+	 * @default <cwd>/.cline/tmp/tool-outputs
+	 */
+	toolOutputArtifactDirectory?: string;
 
 	/**
 	 * Timeout for web fetch operations in milliseconds


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Adds execution-time output budgets for SDK core default tools so large command and file outputs do not enter the transcript inline.

- `run_commands` now returns a compact preview with head/tail preservation, omitted character/byte counts, and a path to the full output artifact for oversized output.
- `run_commands` also normalizes carriage-return-heavy progress logs and keeps the useful tail.
- `read_files` now previews oversized unranged text reads while preserving explicit ranged reads.
- `read_files` and `run_commands` now enforce aggregate per-tool-call inline output budgets across batched structured results; later entries preserve command/path metadata and become aggregate-omitted placeholders once the budget is exhausted.
- Tool result metadata now records truncation state, omitted counts, artifact paths, CR normalization, and aggregate omission state.

### Test Procedure

- `bunx vitest run src/extensions/tools/definitions.test.ts --config vitest.config.ts`
- `bunx vitest run src/extensions/tools/definitions.test.ts src/session/services/message-builder.test.ts --config vitest.config.ts`
- `bun tsc -p tsconfig.dev.json --noEmit`
- `bun biome check sdk/packages/core/src/extensions/tools/definitions.ts sdk/packages/core/src/extensions/tools/helpers.ts sdk/packages/core/src/extensions/tools/types.ts sdk/packages/core/src/extensions/tools/definitions.test.ts`
- Pre-commit `bun run types` and staged-file Biome check
- Live Anthropic SDK inference using `/Users/ara2/Desktop/cline/.env`: confirmed a model-triggered `run_commands` call returned a 1,200-character preview, omitted 79,124 chars, kept serialized runtime messages compact, and saved the full output artifact.

Also ran `bun -F @cline/core test:unit`; it has unrelated failures in hub/protocol and provider migration tests outside this change set, while the focused suites above pass.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality not to work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - SDK/tooling change only.

### Additional Notes

This complements provider-request truncation by preventing oversized tool payloads from entering persisted/runtime transcript messages in the first place, including when many individually acceptable nested results are batched into one tool call.
