### PR TITLE
fix(sdk): cap assistant text in provider messages

### DIFF
--- a/sdk/packages/core/src/session/services/message-builder.test.ts
+++ b/sdk/packages/core/src/session/services/message-builder.test.ts
@@ -496,6 +496,124 @@ describe("MessageBuilder", () => {
 			}),
 		]);
 	});
+
+	it("caps assistant text with repeated DSML tool-call fragments before provider requests", () => {
+		const builder = new MessageBuilder();
+		const dsmlFragment = [
+			"<\uFF5CDSML\uFF5Ctool_calls>",
+			'<\uFF5CDSML\uFF5Cinvoke name="read_file">',
+			`{"path":"/tmp/circuit-fibsqrt.ts","payload":"${"x".repeat(1_200)}"}`,
+			"</\uFF5CDSML\uFF5Cinvoke>",
+			"</\uFF5CDSML\uFF5Ctool_calls>",
+			"<tool_call>",
+			"</tool_call>",
+		].join("\n");
+		const assistantText = `I will inspect the circuit.\n${dsmlFragment.repeat(437)}\nDone.`;
+		const messages: Message[] = [
+			{
+				role: "assistant",
+				content: [{ type: "text", text: assistantText }],
+			},
+			{
+				role: "user",
+				content: [{ type: "text", text: "continue" }],
+			},
+		];
+
+		const result = builder.buildForApi(messages);
+		const block = Array.isArray(result[0].content)
+			? result[0].content[0]
+			: undefined;
+
+		expect(assistantText.length).toBeGreaterThan(500_000);
+		expect(block?.type).toBe("text");
+		if (block?.type !== "text") {
+			throw new Error("expected assistant text block");
+		}
+		expect(block.text.length).toBeLessThanOrEqual(12_000);
+		expect(block.text).toContain("assistant text truncated: omitted");
+		expect(block.text).toContain("repeated tool-call markup");
+		expect(block.text.match(/DSML/g)?.length ?? 0).toBeLessThan(40);
+		expect(messages[0].content).toEqual([
+			{ type: "text", text: assistantText },
+		]);
+	});
+
+	it("keeps repeated assistant tool-call markup out of provider-formatted AI SDK payloads", () => {
+		const builder = new MessageBuilder();
+		const dsmlFragment = [
+			"<\uFF5CDSML\uFF5Ctool_calls>",
+			'<\uFF5CDSML\uFF5Cinvoke name="run_command">',
+			`{"command":"${"printf x; ".repeat(150)}"}`,
+			"</\uFF5CDSML\uFF5Cinvoke>",
+			"</\uFF5CDSML\uFF5Ctool_calls>",
+		].join("\n");
+		const messages: Message[] = [
+			{
+				role: "assistant",
+				content: [{ type: "text", text: dsmlFragment.repeat(500) }],
+			},
+			{
+				role: "user",
+				content: [{ type: "text", text: "next request" }],
+			},
+		];
+
+		const built = builder.buildForApi(messages);
+		const agentMessages = messagesToAgentMessages(built);
+		const aiSdkMessages = formatMessagesForAiSdk(
+			undefined,
+			agentMessages.map(({ role, content }) => ({
+				role,
+				content,
+			})) as unknown as AiSdkFormatterMessage[],
+		);
+		const serialized = JSON.stringify(aiSdkMessages);
+
+		expect(JSON.stringify(messages).length).toBeGreaterThan(650_000);
+		expect(serialized.length).toBeLessThan(25_000);
+		expect(serialized).toContain("assistant text truncated: omitted");
+		expect(serialized.match(/DSML/g)?.length ?? 0).toBeLessThan(40);
+	});
+
+	it("caps oversized top-level assistant string content with an omitted-char marker", () => {
+		const builder = new MessageBuilder({ maxAssistantTextChars: 1_000 });
+		const assistantText = `Lead\n${"normal assistant answer ".repeat(200)}\nTail`;
+		const messages: Message[] = [
+			{
+				role: "assistant",
+				content: assistantText,
+			},
+		];
+
+		const result = builder.buildForApi(messages);
+
+		expect(typeof result[0].content).toBe("string");
+		expect(result[0].content.length).toBeLessThanOrEqual(1_000);
+		expect(result[0].content).toContain("assistant text truncated: omitted");
+		expect(messages[0].content).toBe(assistantText);
+	});
+
+	it("preserves normal long assistant answers below the assistant text cap", () => {
+		const builder = new MessageBuilder();
+		const answer = [
+			"Summary:",
+			"A".repeat(80_000),
+			"Implementation notes:",
+			"B".repeat(80_000),
+			"Final answer.",
+		].join("\n");
+		const messages: Message[] = [
+			{
+				role: "assistant",
+				content: [{ type: "text", text: answer }],
+			},
+		];
+
+		const result = builder.buildForApi(messages);
+
+		expect(result).toEqual(messages);
+	});
 });
 
 /**

--- a/sdk/packages/core/src/session/services/message-builder.ts
+++ b/sdk/packages/core/src/session/services/message-builder.ts
@@ -32,7 +32,11 @@ export const DEFAULT_MAX_FILE_CONTENT_CHARS = 50_000;
 // invalidates provider prefix caches from the first rewritten block onward,
 // so it must remain a rare overflow valve rather than the steady state.
 export const DEFAULT_MAX_TOTAL_TEXT_BYTES = 6_000_000;
+export const DEFAULT_MAX_ASSISTANT_TEXT_CHARS = 200_000;
+export const DEFAULT_MAX_ASSISTANT_TOOL_MARKUP_CHARS = 12_000;
 const MIN_TOTAL_BUDGET_TOOL_RESULT_BYTES = 2_000;
+const MIN_TOTAL_BUDGET_ASSISTANT_TEXT_BYTES = 40_000;
+const REPEATED_TOOL_CALL_MARKUP_THRESHOLD = 8;
 export const MESSAGE_BUILDER_LIMIT_ENV = {
 	maxToolResultChars: "CLINE_MESSAGE_BUILDER_MAX_TOOL_RESULT_CHARS",
 	maxTotalTextBytes: "CLINE_MESSAGE_BUILDER_MAX_TOTAL_TEXT_BYTES",
@@ -45,6 +49,12 @@ const TRUNCATE_MARKER_DEFAULT = (n: number) =>
 	`\n\n...[truncated ${n} chars]...\n\n`;
 const TRUNCATE_MARKER_BUDGET = (n: number) =>
 	`\n\n...[truncated ${n} chars to fit provider request budget]...\n\n`;
+const TRUNCATE_ASSISTANT_TEXT_MARKER = (n: number) =>
+	`\n\n...[assistant text truncated: omitted ${n} chars]...\n\n`;
+const TRUNCATE_ASSISTANT_TEXT_BUDGET_MARKER = (n: number) =>
+	`\n\n...[assistant text truncated: omitted ${n} chars to fit provider request budget]...\n\n`;
+const TRUNCATE_ASSISTANT_TOOL_MARKUP_MARKER = (n: number) =>
+	`\n\n...[assistant text truncated: omitted ${n} chars due to repeated tool-call markup]...\n\n`;
 
 interface ReadLocator {
 	path: string;
@@ -54,6 +64,8 @@ interface ReadLocator {
 
 interface TruncationCandidate {
 	byteLength: number;
+	minBytes: number;
+	makeMarker: (removed: number) => string;
 	get(): string;
 	set(value: string): void;
 }
@@ -63,6 +75,8 @@ export interface MessageBuilderOptions {
 	maxFileContentChars?: number;
 	maxTotalTextBytes?: number;
 	mediaBudget?: MediaBudgetOptions;
+	maxAssistantTextChars?: number;
+	maxAssistantToolMarkupChars?: number;
 }
 
 export function getMessageBuilderOptionsFromEnv(
@@ -101,6 +115,8 @@ export class MessageBuilder {
 	private readonly maxFileContentChars: number;
 	private readonly maxTotalTextBytes: number;
 	private readonly mediaBudget: MediaBudgetOptions;
+	private readonly maxAssistantTextChars: number;
+	private readonly maxAssistantToolMarkupChars: number;
 
 	constructor(options: MessageBuilderOptions = {}) {
 		this.maxToolResultChars = normalizePositiveLimit(
@@ -116,6 +132,14 @@ export class MessageBuilder {
 			DEFAULT_MAX_TOTAL_TEXT_BYTES,
 		);
 		this.mediaBudget = options.mediaBudget ?? {};
+		this.maxAssistantTextChars = normalizePositiveLimit(
+			options.maxAssistantTextChars,
+			DEFAULT_MAX_ASSISTANT_TEXT_CHARS,
+		);
+		this.maxAssistantToolMarkupChars = normalizePositiveLimit(
+			options.maxAssistantToolMarkupChars,
+			DEFAULT_MAX_ASSISTANT_TOOL_MARKUP_CHARS,
+		);
 	}
 
 	buildForApi(messages: Message[]): Message[] {
@@ -128,6 +152,15 @@ export class MessageBuilder {
 					const normalized = normalizeUserInput(message.content);
 					if (normalized !== message.content) {
 						return { ...message, content: normalized };
+					}
+				}
+				if (
+					message.role === "assistant" &&
+					typeof message.content === "string"
+				) {
+					const truncated = this.truncateAssistantText(message.content);
+					if (truncated !== message.content) {
+						return { ...message, content: truncated };
 					}
 				}
 				return message;
@@ -163,6 +196,15 @@ export class MessageBuilder {
 				return { ...block, text: normalized };
 			}
 			return block;
+		}
+
+		if (
+			role === "assistant" &&
+			block.type === "text" &&
+			typeof block.text === "string"
+		) {
+			const truncated = this.truncateAssistantText(block.text);
+			return truncated === block.text ? block : { ...block, text: truncated };
 		}
 
 		if (block.type === "file") {
@@ -888,6 +930,35 @@ export class MessageBuilder {
 		);
 	}
 
+	private truncateAssistantText(text: string): string {
+		if (this.hasRepeatedToolCallMarkup(text)) {
+			return truncateMiddleByChars(
+				text,
+				this.maxAssistantToolMarkupChars,
+				TRUNCATE_ASSISTANT_TOOL_MARKUP_MARKER,
+			);
+		}
+		return truncateMiddleByChars(
+			text,
+			this.maxAssistantTextChars,
+			TRUNCATE_ASSISTANT_TEXT_MARKER,
+		);
+	}
+
+	private hasRepeatedToolCallMarkup(text: string): boolean {
+		if (text.length <= this.maxAssistantToolMarkupChars) {
+			return false;
+		}
+		let count = 0;
+		for (const _match of text.matchAll(TOOL_CALL_MARKUP_PATTERN)) {
+			count += 1;
+			if (count >= REPEATED_TOOL_CALL_MARKUP_THRESHOLD) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	private truncateToTotalTextBudget(messages: Message[]): Message[] {
 		let totalBytes = this.countMessageTextBytes(messages);
 		if (totalBytes <= this.maxTotalTextBytes) {
@@ -896,7 +967,7 @@ export class MessageBuilder {
 
 		const next = messages.map((message) => {
 			if (!Array.isArray(message.content)) {
-				return message;
+				return { ...message };
 			}
 			return {
 				...message,
@@ -912,18 +983,15 @@ export class MessageBuilder {
 				break;
 			}
 			const currentBytes = candidate.byteLength;
-			if (currentBytes <= MIN_TOTAL_BUDGET_TOOL_RESULT_BYTES) {
+			if (currentBytes <= candidate.minBytes) {
 				continue;
 			}
 			const overflow = totalBytes - this.maxTotalTextBytes;
-			const targetBytes = Math.max(
-				MIN_TOTAL_BUDGET_TOOL_RESULT_BYTES,
-				currentBytes - overflow,
-			);
+			const targetBytes = Math.max(candidate.minBytes, currentBytes - overflow);
 			const truncated = truncateMiddleToBytes(
 				candidate.get(),
 				targetBytes,
-				TRUNCATE_MARKER_BUDGET,
+				candidate.makeMarker,
 			);
 			candidate.set(truncated);
 			totalBytes -= currentBytes - utf8ByteLength(truncated);
@@ -978,6 +1046,18 @@ export class MessageBuilder {
 		const resultCandidates: TruncationCandidate[] = [];
 		const inputCandidates: TruncationCandidate[] = [];
 		for (const message of messages) {
+			if (message.role === "assistant" && typeof message.content === "string") {
+				resultCandidates.push({
+					byteLength: utf8ByteLength(message.content),
+					minBytes: MIN_TOTAL_BUDGET_ASSISTANT_TEXT_BYTES,
+					makeMarker: TRUNCATE_ASSISTANT_TEXT_BUDGET_MARKER,
+					get: () => message.content as string,
+					set: (value) => {
+						message.content = value;
+					},
+				});
+				continue;
+			}
 			if (!Array.isArray(message.content)) {
 				continue;
 			}
@@ -986,12 +1066,26 @@ export class MessageBuilder {
 					collectNestedStringCandidates(block.input, inputCandidates);
 					continue;
 				}
+				if (message.role === "assistant" && block.type === "text") {
+					resultCandidates.push({
+						byteLength: utf8ByteLength(block.text),
+						minBytes: MIN_TOTAL_BUDGET_ASSISTANT_TEXT_BYTES,
+						makeMarker: TRUNCATE_ASSISTANT_TEXT_BUDGET_MARKER,
+						get: () => block.text,
+						set: (value) => {
+							block.text = value;
+						},
+					});
+					continue;
+				}
 				if (block.type !== "tool_result") {
 					continue;
 				}
 				if (typeof block.content === "string") {
 					resultCandidates.push({
 						byteLength: utf8ByteLength(block.content),
+						minBytes: MIN_TOTAL_BUDGET_TOOL_RESULT_BYTES,
+						makeMarker: TRUNCATE_MARKER_BUDGET,
 						get: () => block.content as string,
 						set: (value) => {
 							block.content = value;
@@ -1003,6 +1097,8 @@ export class MessageBuilder {
 					if (entry.type === "text") {
 						resultCandidates.push({
 							byteLength: utf8ByteLength(entry.text),
+							minBytes: MIN_TOTAL_BUDGET_TOOL_RESULT_BYTES,
+							makeMarker: TRUNCATE_MARKER_BUDGET,
 							get: () => entry.text,
 							set: (value) => {
 								entry.text = value;
@@ -1011,6 +1107,8 @@ export class MessageBuilder {
 					} else if (entry.type === "file") {
 						resultCandidates.push({
 							byteLength: utf8ByteLength(entry.content),
+							minBytes: MIN_TOTAL_BUDGET_TOOL_RESULT_BYTES,
+							makeMarker: TRUNCATE_MARKER_BUDGET,
 							get: () => entry.content,
 							set: (value) => {
 								entry.content = value;
@@ -1022,10 +1120,10 @@ export class MessageBuilder {
 				}
 			}
 		}
-		// Tool results truncate first; model-generated tool_use arguments are a
-		// last resort because some providers revalidate or replay them. Both
-		// being candidates keeps the budget reclaimable no matter which side
-		// carries the overflow.
+		// Tool results and assistant text truncate first; model-generated
+		// tool_use arguments are a last resort because some providers
+		// revalidate or replay them. All three being candidates keeps the
+		// budget reclaimable no matter which side carries the overflow.
 		resultCandidates.sort((l, r) => r.byteLength - l.byteLength);
 		inputCandidates.sort((l, r) => r.byteLength - l.byteLength);
 		return [...resultCandidates, ...inputCandidates];
@@ -1178,6 +1276,14 @@ export class MessageBuilder {
 		};
 	}
 }
+
+const DSML_BAR = String.raw`[\|\uFF5C]`;
+// Compiled once at module load; String.prototype.matchAll clones the regex
+// per call, so sharing the global-flagged instance is safe.
+const TOOL_CALL_MARKUP_PATTERN = new RegExp(
+	String.raw`<\s*(?:${DSML_BAR}\s*)?DSML\s*(?:${DSML_BAR}\s*)?(?:tool_calls|invoke)\b[^>]*>|<\s*/?\s*(?:tool_calls?|tool_call|function_calls?|function_call|invoke)\b[^>]*>`,
+	"gi",
+);
 
 function utf8ByteLength(text: string): number {
 	return Buffer.byteLength(text, "utf8");
@@ -1345,6 +1451,8 @@ function collectNestedStringCandidates(
 			if (typeof item === "string") {
 				candidates.push({
 					byteLength: utf8ByteLength(item),
+					minBytes: MIN_TOTAL_BUDGET_TOOL_RESULT_BYTES,
+					makeMarker: TRUNCATE_MARKER_BUDGET,
 					get: () => container[index] as string,
 					set: (value) => {
 						container[index] = value;
@@ -1366,6 +1474,8 @@ function collectNestedStringCandidates(
 			if (typeof item === "string") {
 				candidates.push({
 					byteLength: utf8ByteLength(item),
+					minBytes: MIN_TOTAL_BUDGET_TOOL_RESULT_BYTES,
+					makeMarker: TRUNCATE_MARKER_BUDGET,
 					get: () => record[key] as string,
 					set: (value) => {
 						record[key] = value;


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

Adds provider-facing safeguards for oversized assistant text in `MessageBuilder`. Some provider traces can persist malformed tool-call markup as assistant text rather than `tool_result` content, so the existing tool-result truncation path does not catch it.

This PR:

- caps provider-bound assistant text blocks with an omitted-character marker
- applies a more aggressive cap when repeated DSML/XML/tool-call-looking markup is detected
- includes assistant text in the aggregate provider text-budget truncation candidates
- preserves normal long assistant answers under the assistant-text cap

### Test Procedure

- `bun -F @cline/core test:unit -- src/session/services/message-builder.test.ts` passed: 18 tests
- `bun -F @cline/core typecheck` passed
- `bun tsc -p sdk/packages/core/tsconfig.dev.json --noEmit` passed
- `bun biome check --diagnostic-level=error sdk/packages/core/src/session/services/message-builder.ts sdk/packages/core/src/session/services/message-builder.test.ts` passed
- `git diff --check` passed
- Live DeepSeek Flash inference through OpenRouter passed after loading `/Users/ara2/Desktop/cline/.env`:
  - original bad history: 601,047 chars
  - built provider messages: 12,285 chars
  - provider request: 12,552 chars
  - captured HTTP body: 12,431 chars
  - truncation marker present in provider body
  - response preview: `OK`

I also ran `bun -F @cline/core test:unit`; it currently has unrelated failures in hub/protocol mocks, local runtime auth retry, and one provider-settings migration expectation outside the changed files.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

N/A - provider request-building safeguard only.

### Additional Notes

The repeated-markup detector covers DSML fragments like `<｜DSML｜tool_calls>`, `<｜DSML｜invoke ...>`, and generic `<tool_call>`-style XML tags.
