### PR TITLE
feat(cli): allow plugin commands to submit prompts

### DIFF
--- a/apps/cli/src/runtime/interactive/chat-command-runner.test.ts
+++ b/apps/cli/src/runtime/interactive/chat-command-runner.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
 	type ChatCommandState,
+	createChatCommandHost,
 	chatCommandHost,
 } from "../../utils/chat-commands";
 import type { Config } from "../../utils/types";
@@ -161,5 +162,38 @@ describe("runInteractiveChatCommand", () => {
 		});
 		expect(state.autoApproveTools).toBe(true);
 		expect(setInteractiveAutoApprove).toHaveBeenCalledWith(true);
+	});
+
+	it("returns plugin command submit prompts as model input", async () => {
+		const config = makeConfig();
+		const runtime = makeRuntime();
+		const onCommandOutput = vi.fn();
+		const host = createChatCommandHost().register("command", {
+			names: ["/goal"],
+			run: async ({ args }, context) => {
+				await context.reply(`Goal guard set: ${args.join(" ")}`);
+				await context.submitPrompt?.(args.join(" "));
+			},
+		});
+
+		const result = await runInteractiveChatCommand({
+			prompt: "/goal fix tests",
+			enabled: true,
+			config,
+			host,
+			chatCommandState: makeState(config),
+			autoApproveAllRef: { current: false },
+			setInteractiveAutoApprove: () => {},
+			sessionRuntime: runtime,
+			stop: () => {},
+			onCommandOutput,
+		});
+
+		expect(result).toEqual({
+			handled: false,
+			input: "fix tests",
+			commandOutput: "Goal guard set: fix tests",
+		});
+		expect(onCommandOutput).toHaveBeenCalledWith("Goal guard set: fix tests");
 	});
 });

--- a/apps/cli/src/runtime/interactive/chat-command-runner.ts
+++ b/apps/cli/src/runtime/interactive/chat-command-runner.ts
@@ -26,7 +26,7 @@ export type InteractiveChatCommandRuntime = Pick<
 
 export type InteractiveChatCommandResult =
 	| { handled: true; turnResult: InteractiveTurnResult }
-	| { handled: false; input: string };
+	| { handled: false; input: string; commandOutput?: string };
 
 function commandTurnResult(commandOutput?: string): InteractiveTurnResult {
 	return {
@@ -46,6 +46,7 @@ export async function runInteractiveChatCommand(input: {
 	setInteractiveAutoApprove: (enabled: boolean) => void;
 	sessionRuntime: InteractiveChatCommandRuntime;
 	stop: () => void;
+	onCommandOutput?: (text: string) => void;
 }): Promise<InteractiveChatCommandResult> {
 	let prompt = input.prompt;
 	const rewrittenTeamPrompt = rewriteTeamPrompt(prompt);
@@ -64,6 +65,7 @@ export async function runInteractiveChatCommand(input: {
 	}
 
 	let commandOutput: string | undefined;
+	let submitPrompt: string | undefined;
 	const handled = await maybeHandleChatCommand(prompt, {
 		enabled: input.enabled,
 		host: input.host,
@@ -80,6 +82,13 @@ export async function runInteractiveChatCommand(input: {
 		},
 		reply: async (text) => {
 			commandOutput = text;
+			input.onCommandOutput?.(text);
+		},
+		submitPrompt: async (text) => {
+			const trimmed = text.trim();
+			if (trimmed) {
+				submitPrompt = trimmed;
+			}
 		},
 		reset: async () => {
 			await input.sessionRuntime.resetForNewSession();
@@ -98,6 +107,13 @@ export async function runInteractiveChatCommand(input: {
 		fork: input.sessionRuntime.forkCurrentSession,
 	});
 	if (handled) {
+		if (submitPrompt) {
+			return {
+				handled: false,
+				input: submitPrompt,
+				...(commandOutput ? { commandOutput } : {}),
+			};
+		}
 		return {
 			handled: true,
 			turnResult: commandTurnResult(commandOutput),

--- a/apps/cli/src/runtime/run-interactive.ts
+++ b/apps/cli/src/runtime/run-interactive.ts
@@ -427,7 +427,13 @@ export async function runInteractive(
 				uiEvents.off("pending-prompt-submitted", onPendingPromptSubmitted);
 			};
 		},
-		onSubmit: async (input, mode, delivery, attachments) => {
+		onSubmit: async (
+			input,
+			mode,
+			delivery,
+			attachments,
+			onCommandOutput,
+		) => {
 			try {
 				await sessionRuntime.ensureReady();
 				await waitForSubmittedMode(mode);
@@ -446,6 +452,7 @@ export async function runInteractive(
 					setInteractiveAutoApprove,
 					sessionRuntime,
 					stop: () => tuiApp?.destroy(),
+					onCommandOutput,
 				});
 				if (chatCommandResult.handled) {
 					return chatCommandResult.turnResult;
@@ -465,12 +472,14 @@ export async function runInteractive(
 						setInteractiveAutoApprove,
 						sessionRuntime,
 						stop: () => tuiApp?.destroy(),
+						onCommandOutput,
 					});
 					if (chatCommandResult.handled) {
 						return chatCommandResult.turnResult;
 					}
 				}
 				input = chatCommandResult.input;
+				const commandOutput = chatCommandResult.commandOutput;
 				const {
 					prompt: userInput,
 					userImages,
@@ -507,6 +516,7 @@ export async function runInteractive(
 						iterations: 0,
 						finishReason: "queued",
 						queued: delivery === "queue" || delivery === "steer",
+						commandOutput,
 					};
 				}
 				if (result.finishReason !== "completed") {
@@ -532,6 +542,7 @@ export async function runInteractive(
 					currentContextSize: getCurrentContextSize(result.messages),
 					iterations: result.iterations,
 					finishReason: result.finishReason,
+					commandOutput,
 				};
 			} catch (error) {
 				if (isAbortInProgress()) {

--- a/apps/cli/src/runtime/run-interactive.ts
+++ b/apps/cli/src/runtime/run-interactive.ts
@@ -434,6 +434,7 @@ export async function runInteractive(
 			attachments,
 			onCommandOutput,
 		) => {
+			let commandOutput: string | undefined;
 			try {
 				await sessionRuntime.ensureReady();
 				await waitForSubmittedMode(mode);
@@ -479,7 +480,7 @@ export async function runInteractive(
 					}
 				}
 				input = chatCommandResult.input;
-				const commandOutput = chatCommandResult.commandOutput;
+				commandOutput = chatCommandResult.commandOutput;
 				const {
 					prompt: userInput,
 					userImages,
@@ -529,6 +530,7 @@ export async function runInteractive(
 							currentContextSize: getCurrentContextSize(result.messages),
 							iterations: result.iterations,
 							finishReason: "aborted",
+							commandOutput,
 						};
 					}
 					const errorText = result.text.trim();
@@ -550,6 +552,7 @@ export async function runInteractive(
 						usage: { inputTokens: 0, outputTokens: 0 },
 						iterations: 0,
 						finishReason: "aborted",
+						commandOutput,
 					};
 				}
 				logCliError(config.logger, "Interactive turn failed", {

--- a/apps/cli/src/tui/hooks/use-prompt-input-controller.ts
+++ b/apps/cli/src/tui/hooks/use-prompt-input-controller.ts
@@ -327,6 +327,14 @@ export function usePromptInputController(input: {
 			}
 
 			const startedAt = performance.now();
+			let commandOutputAppended = false;
+			const appendCommandOutput = (text: string) => {
+				commandOutputAppended = true;
+				session.appendEntry({
+					kind: "status",
+					text,
+				});
+			};
 			try {
 				const result = await onSubmit(
 					promptForSubmit,
@@ -335,8 +343,9 @@ export function usePromptInputController(input: {
 					activeUserImages.length > 0
 						? { userImages: activeUserImages }
 						: undefined,
+					appendCommandOutput,
 				);
-				if (result.commandOutput) {
+				if (result.commandOutput && !commandOutputAppended) {
 					session.appendEntry({
 						kind: "status",
 						text: result.commandOutput,

--- a/apps/cli/src/tui/root.tsx
+++ b/apps/cli/src/tui/root.tsx
@@ -252,14 +252,13 @@ function App(props: TuiProps) {
 		const shouldRestartSession = session.hasSubmitted;
 		session.clearEntries();
 		session.setHasSubmitted(false);
+		setAppView("home");
 		if (!shouldRestartSession) {
-			setAppView("home");
 			refocusTextareaRef.current();
 			return;
 		}
 		try {
 			await props.onNewSession();
-			setAppView("home");
 		} catch (error) {
 			setAppView("chat");
 			session.appendEntry({

--- a/apps/cli/src/tui/root.tsx
+++ b/apps/cli/src/tui/root.tsx
@@ -252,13 +252,14 @@ function App(props: TuiProps) {
 		const shouldRestartSession = session.hasSubmitted;
 		session.clearEntries();
 		session.setHasSubmitted(false);
-		setAppView("home");
 		if (!shouldRestartSession) {
+			setAppView("home");
 			refocusTextareaRef.current();
 			return;
 		}
 		try {
 			await props.onNewSession();
+			setAppView("home");
 		} catch (error) {
 			setAppView("chat");
 			session.appendEntry({

--- a/apps/cli/src/tui/types.ts
+++ b/apps/cli/src/tui/types.ts
@@ -152,6 +152,7 @@ export interface TuiProps {
 		mode: AgentMode,
 		delivery?: "queue" | "steer",
 		attachments?: UserInputAttachments,
+		onCommandOutput?: (text: string) => void,
 	) => Promise<InteractiveTurnResult>;
 	onUpdatePendingPrompt: (input: {
 		promptId: string;

--- a/apps/cli/src/utils/chat-commands.ts
+++ b/apps/cli/src/utils/chat-commands.ts
@@ -28,6 +28,7 @@ export type ChatCommandContext = {
 	getState: () => Promise<ChatCommandState> | ChatCommandState;
 	setState: (next: ChatCommandState) => Promise<void> | void;
 	reply: (text: string) => Promise<void> | void;
+	submitPrompt?: (prompt: string) => Promise<void> | void;
 	reset?: () => Promise<void> | void;
 	abort?: () => Promise<void> | void;
 	stop?: () => Promise<void> | void;

--- a/apps/cli/src/utils/plugin-chat-commands.test.ts
+++ b/apps/cli/src/utils/plugin-chat-commands.test.ts
@@ -65,4 +65,55 @@ describe("plugin chat commands", () => {
 		expect(reply).toHaveBeenCalledWith("echo:hello plugin");
 		await shutdown?.();
 	});
+
+	it("bridges plugin command submit prompts onto the chat command context", async () => {
+		const tempRoot = await mkdtemp(join(tmpdir(), "cli-plugin-commands-"));
+		tempRoots.push(tempRoot);
+		const pluginsDir = join(tempRoot, ".cline", "plugins");
+		await mkdir(pluginsDir, { recursive: true });
+		await writeFile(
+			join(pluginsDir, "submit.js"),
+			[
+				"export default {",
+				"  name: 'submit-plugin',",
+				"  manifest: { capabilities: ['commands'] },",
+				"  setup(api) {",
+				"    api.registerCommand({",
+				"      name: 'goal',",
+				"      description: 'Set a goal and submit it',",
+				"      handler: async (input) => ({",
+				"        reply: 'goal:' + input,",
+				"        submitPrompt: input",
+				"      })",
+				"    });",
+				"  },",
+				"};",
+			].join("\n"),
+		);
+
+		const { host, shutdown } = await createWorkspaceChatCommandHost({
+			cwd: tempRoot,
+			workspaceRoot: tempRoot,
+		});
+		const reply = vi.fn(async () => undefined);
+		const submitPrompt = vi.fn(async () => undefined);
+
+		const handled = await host.handle("/goal fix tests", {
+			enabled: true,
+			getState: async () => ({
+				enableTools: false,
+				autoApproveTools: false,
+				cwd: tempRoot,
+				workspaceRoot: tempRoot,
+			}),
+			setState: async () => undefined,
+			reply,
+			submitPrompt,
+		});
+
+		expect(handled).toBe(true);
+		expect(reply).toHaveBeenCalledWith("goal:fix tests");
+		expect(submitPrompt).toHaveBeenCalledWith("fix tests");
+		await shutdown?.();
+	});
 });

--- a/apps/cli/src/utils/plugin-chat-commands.ts
+++ b/apps/cli/src/utils/plugin-chat-commands.ts
@@ -67,14 +67,13 @@ function normalizeCommandResult(
 	if (!result || typeof result !== "object") {
 		return {};
 	}
-	const record = result as Record<string, unknown>;
 	const reply =
-		typeof record.reply === "string" && record.reply.trim()
-			? record.reply.trim()
+		typeof result.reply === "string" && result.reply.trim()
+			? result.reply.trim()
 			: undefined;
 	const submitPrompt =
-		typeof record.submitPrompt === "string" && record.submitPrompt.trim()
-			? record.submitPrompt.trim()
+		typeof result.submitPrompt === "string" && result.submitPrompt.trim()
+			? result.submitPrompt.trim()
 			: undefined;
 	return {
 		...(reply ? { reply } : {}),

--- a/apps/cli/src/utils/plugin-chat-commands.ts
+++ b/apps/cli/src/utils/plugin-chat-commands.ts
@@ -1,5 +1,6 @@
 import {
 	type AgentExtensionCommand,
+	type AgentExtensionCommandResult,
 	type BasicLogger,
 	createContributionRegistry,
 	resolveAndLoadAgentPlugins,
@@ -45,10 +46,39 @@ function createPluginCommandDefinition(
 		names: [normalizedName.toLowerCase()],
 		run: async ({ args }, context) => {
 			const result = await command.handler?.(args.join(" "));
-			if (typeof result === "string" && result.trim()) {
-				await context.reply(result);
+			const { reply, submitPrompt } = normalizeCommandResult(result);
+			if (reply) {
+				await context.reply(reply);
+			}
+			if (submitPrompt) {
+				await context.submitPrompt?.(submitPrompt);
 			}
 		},
+	};
+}
+
+function normalizeCommandResult(
+	result: AgentExtensionCommandResult | undefined,
+): { reply?: string; submitPrompt?: string } {
+	if (typeof result === "string") {
+		const reply = result.trim();
+		return reply ? { reply } : {};
+	}
+	if (!result || typeof result !== "object") {
+		return {};
+	}
+	const record = result as Record<string, unknown>;
+	const reply =
+		typeof record.reply === "string" && record.reply.trim()
+			? record.reply.trim()
+			: undefined;
+	const submitPrompt =
+		typeof record.submitPrompt === "string" && record.submitPrompt.trim()
+			? record.submitPrompt.trim()
+			: undefined;
+	return {
+		...(reply ? { reply } : {}),
+		...(submitPrompt ? { submitPrompt } : {}),
 	};
 }
 

--- a/sdk/packages/core/src/extensions/plugin/plugin-sandbox-bootstrap.ts
+++ b/sdk/packages/core/src/extensions/plugin/plugin-sandbox-bootstrap.ts
@@ -37,8 +37,15 @@ interface PluginTool {
 interface PluginCommand {
 	name: string;
 	description?: string;
-	handler?: (input: string) => Promise<string>;
+	handler?: (input: string) => Promise<PluginCommandResult> | PluginCommandResult;
 }
+
+type PluginCommandResult =
+	| string
+	| {
+			reply?: string;
+			submitPrompt?: string;
+	  };
 
 interface PluginRule {
 	id: string;
@@ -706,7 +713,7 @@ async function executeCommand(args: {
 	pluginId: string;
 	contributionId: string;
 	input: string;
-}): Promise<string> {
+}): Promise<PluginCommandResult> {
 	const state = getPlugin(args.pluginId);
 	const handler = state.handlers.commands.get(args.contributionId);
 	if (typeof handler !== "function") {

--- a/sdk/packages/core/src/extensions/plugin/plugin-sandbox-bootstrap.ts
+++ b/sdk/packages/core/src/extensions/plugin/plugin-sandbox-bootstrap.ts
@@ -40,6 +40,8 @@ interface PluginCommand {
 	handler?: (input: string) => Promise<PluginCommandResult> | PluginCommandResult;
 }
 
+// Keep this local mirror in sync with AgentExtensionCommandResult from @cline/shared.
+// The sandbox bootstrap runs in an isolated process and avoids host package imports.
 type PluginCommandResult =
 	| string
 	| {

--- a/sdk/packages/core/src/extensions/plugin/plugin-sandbox.ts
+++ b/sdk/packages/core/src/extensions/plugin/plugin-sandbox.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type {
 	AgentConfig,
+	AgentExtensionCommandResult,
 	AgentExtensionAutomationEventType,
 	AgentExtensionRule,
 	AgentRuntimeHooks,
@@ -434,7 +435,7 @@ function registerCommands(
 			description: cd.description,
 			handler: async (input: string) => {
 				try {
-					return await sandbox.call<string>(
+					return await sandbox.call<AgentExtensionCommandResult>(
 						"executeCommand",
 						{
 							pluginId: descriptor.pluginId,
@@ -448,7 +449,7 @@ function registerCommands(
 						throw error;
 					}
 					await reinitialize();
-					return await sandbox.call<string>(
+					return await sandbox.call<AgentExtensionCommandResult>(
 						"executeCommand",
 						{
 							pluginId: descriptor.pluginId,

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -12,6 +12,7 @@ export type {
 	AgentEvent,
 	AgentExtension as AgentPlugin, // Public-facing alias for extensions
 	AgentExtensionCommand,
+	AgentExtensionCommandResult,
 	AgentExtensionCommand as AgentPluginCommand,
 	AgentHooks,
 	AgentMode,

--- a/sdk/packages/shared/src/extensions/contribution-registry.ts
+++ b/sdk/packages/shared/src/extensions/contribution-registry.ts
@@ -8,8 +8,17 @@ import type { ClientContext, UserContext } from "./context";
 export interface AgentExtensionCommand {
 	name: string;
 	description?: string;
-	handler?: (input: string) => Promise<string> | string;
+	handler?: (
+		input: string,
+	) => Promise<AgentExtensionCommandResult> | AgentExtensionCommandResult;
 }
+
+export type AgentExtensionCommandResult =
+	| string
+	| {
+			reply?: string;
+			submitPrompt?: string;
+	  };
 
 export interface AgentExtensionRule {
 	id: string;

--- a/sdk/packages/shared/src/index.browser.ts
+++ b/sdk/packages/shared/src/index.browser.ts
@@ -31,6 +31,7 @@ export type {
 	AgentExtensionAutomationEventType,
 	AgentExtensionCapability,
 	AgentExtensionCommand,
+	AgentExtensionCommandResult,
 	AgentExtensionHooks,
 	AgentExtensionMessageBuilder,
 	AgentExtensionProvider,

--- a/sdk/packages/shared/src/index.ts
+++ b/sdk/packages/shared/src/index.ts
@@ -45,6 +45,7 @@ export type {
 	AgentExtensionAutomationEventType,
 	AgentExtensionCapability,
 	AgentExtensionCommand,
+	AgentExtensionCommandResult,
 	AgentExtensionHooks,
 	AgentExtensionMessageBuilder,
 	AgentExtensionProvider,


### PR DESCRIPTION
### Related Issue

Issue: #XXXX

### Description

This PR extends plugin slash commands so they can do more than return a display-only string. A command handler may now return either the existing string reply or an object with `reply` and `submitPrompt`. The CLI interactive path uses that to show the command reply and immediately submit the requested prompt as the next model turn.

The motivating workflow is a goal plugin. `/goal fix tests` should set plugin state, render a status row such as `Goal set: fix tests`, and then start `fix tests` without requiring the user to send a second message. The old command contract could show text but could not hand a prompt back to the chat runner.

Technical approach:

- Added `AgentExtensionCommandResult` in shared extension contracts and re-exported it from shared, browser shared, and core.
- Updated the plugin sandbox bootstrap and host-side sandbox adapter so sandboxed plugins can return either strings or `{ reply, submitPrompt }` objects.
- Updated CLI plugin command bridging to normalize command results while preserving existing string-returning commands.
- Added `submitPrompt` to `ChatCommandContext` and taught the interactive chat command runner to convert a handled command with `submitPrompt` into model input.
- Threaded an immediate `onCommandOutput` callback through the TUI submit path so command replies render before the submitted model turn streams.
- Kept returned `commandOutput` as a fallback for non-TUI paths and to avoid losing status text in queued, completed, or aborted result paths.

The main compatibility decision is that old string command handlers continue to behave exactly as before. The object shape is additive. Connectors that do not provide `submitPrompt` still show `reply` and ignore prompt submission.

### Test Procedure

Ran the following on a clean branch based on `origin/main`:

```bash
bun run build:sdk
bun -F @cline/cli typecheck
bun -F @cline/cli test:unit -- src/utils/plugin-chat-commands.test.ts src/runtime/interactive/chat-command-runner.test.ts src/tui/hooks/use-local-command-actions.test.ts
git diff --check
```

Also manually installed a locally built CLI binary while testing and verified the plugin command path with a no-model smoke test:

- `/goal smoke reinstall` loaded exactly one plugin command.
- The command reply was rendered as `Goal set: smoke reinstall`.
- The submitted prompt captured by the chat command context was `smoke reinstall`.
- `/goal off` cleared the smoke state.

Potential breakage considered:

- String-returning plugin commands still normalize to `reply` only.
- Missing or malformed command result objects normalize to no-op command output.
- Sandboxed plugin commands now serialize the wider object result, matching the in-process command result type.
- TUI command output is guarded so immediate display does not duplicate the returned `commandOutput` row.
- Aborted turns preserve `commandOutput` for consumers that did not render the immediate callback.

### Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Refactor Changes
-   [ ] Cosmetic Changes
-   [ ] Documentation update
-   [ ] Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. This is a CLI/plugin command behavior change. The relevant visible behavior is covered in the manual smoke notes above.

### Additional Notes

No linked issue. Full `npm test`, `npm run format`, and `npm run lint` were not run. Focused typecheck, SDK build, and unit tests listed above passed.
