### PR TITLE
feat(sdk): cap tool output ingestion for bash and file reads

### DIFF
--- a/sdk/packages/core/src/extensions/tools/definitions.test.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.test.ts
@@ -1169,13 +1169,13 @@ describe("zod schema conversion", () => {
 					end_line: {
 						anyOf: [{ type: "integer" }, { type: "null" }],
 						description:
-							"Optional one-based ending line number to read through; use null or omit for the end of the file",
+							"Optional one-based ending line number to read through; use null or omit to read to the end of the file or the read cap, whichever comes first",
 					},
 				},
 				required: ["path"],
 			},
 			description:
-				"Array of file read requests. Omit start_line/end_line or set them to null to return the full file content boundaries; provide integers to return only that inclusive one-based line range. Prefer this tool over running terminal command to get file content for better performance and reliability.",
+				"Array of file read requests. Omit start_line/end_line or set them to null to read from the start; provide integers to return only that inclusive one-based line range. Reads are capped, so page through long files with start_line/end_line. Prefer this tool over running terminal command to get file content for better performance and reliability.",
 		});
 		expect(inputSchema.required).toEqual(["files"]);
 	});

--- a/sdk/packages/core/src/extensions/tools/definitions.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.ts
@@ -14,6 +14,11 @@ import {
 import { captureRunCommandsTimeout } from "../../services/telemetry/core-events";
 import { getToolContextTelemetry } from "../../services/telemetry/tool-context";
 import {
+	MAX_COMMAND_OUTPUT_CHARS,
+	MAX_READ_LINES,
+	MAX_READ_OUTPUT_CHARS,
+} from "./executors/output-limits";
+import {
 	formatError,
 	formatReadFileQuery,
 	formatRunCommandQueryPreview,
@@ -122,7 +127,8 @@ export function createReadFilesTool(
 	return createTool<ReadFilesInput, ToolOperationResult[]>({
 		name: "read_files",
 		description:
-			"Read the full content of text or image files at the provided absolute paths, or return only an inclusive one-based line range when start_line/end_line are provided. " +
+			"Read the content of text or image files at the provided absolute paths, or return only an inclusive one-based line range when start_line/end_line are provided. " +
+			`Each read returns at most ${MAX_READ_LINES} lines / ~${Math.round(MAX_READ_OUTPUT_CHARS / 1024)}k characters; longer files report their total line count, page through them with start_line/end_line. ` +
 			"Binary files that are not image and large files are not supported. " +
 			"Returns file contents or error messages for each path. ",
 		inputSchema: zodToJsonSchema(ReadFilesInputSchema),
@@ -285,6 +291,7 @@ export function createBashTool(
 			"Run shell commands from the root of the workspace. " +
 			"Use for listing files, checking git status, running builds, executing tests, etc. " +
 			"Commands should be properly shell-escaped and targeted to avoid error or timeout. " +
+			`Output beyond ~${Math.round(MAX_COMMAND_OUTPUT_CHARS / 1000)}k characters is middle-truncated (start and end preserved); pipe through grep/head/tail when you need specific sections of large output. ` +
 			"For long-running commands, run them in background and redirect output to a tmp file that you can read from later.",
 		inputSchema: zodToJsonSchema(RunCommandsInputSchema),
 		timeoutMs: timeoutMs * 2,
@@ -366,6 +373,7 @@ export function createWindowsShellTool(
 		description:
 			"Run shell commands from the root of the workspacein Windows environment. " +
 			"Use for listing files, checking git status, running builds, executing tests, etc. " +
+			`Output beyond ~${Math.round(MAX_COMMAND_OUTPUT_CHARS / 1000)}k characters is middle-truncated (start and end preserved); filter output when you need specific sections. ` +
 			"Prefer structured { command, args } entries for portability; plain string commands should be properly shell-escaped.",
 		inputSchema: zodToJsonSchema(StructuredCommandsInputSchema),
 		timeoutMs: timeoutMs * 2,

--- a/sdk/packages/core/src/extensions/tools/executors/bash.test.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/bash.test.ts
@@ -61,17 +61,87 @@ describe("createBashExecutor", () => {
 		);
 	});
 
-	it("truncates output exceeding maxOutputBytes", async () => {
-		const bash = createBashExecutor({ maxOutputBytes: 10 });
+	it("middle-truncates output exceeding maxOutputBytes, keeping head and tail", async () => {
+		const bash = createBashExecutor({ maxOutputBytes: 20 });
 		const output = await bash(
 			{
 				command: process.execPath,
-				args: ["-e", "process.stdout.write('a'.repeat(100))"],
+				args: ["-e", "process.stdout.write('HEAD' + 'x'.repeat(100) + 'TAIL')"],
 			},
 			process.cwd(),
 			ctx,
 		);
-		expect(output).toContain("[Output truncated:");
+		expect(output).toContain("HEAD");
+		expect(output).toContain("TAIL");
+		expect(output).toContain("[... output truncated: 108 chars total");
+		expect(output.length).toBeLessThan(300);
+	});
+
+	it("keeps default-capped output under the MessageBuilder per-result backstop", async () => {
+		// MessageBuilder re-truncates tool-result strings over 50_000 chars
+		// (session/services/message-builder.ts), which would replace the
+		// executor's truncation notice with a generic marker. The default
+		// cap plus notice must stay below that.
+		const bash = createBashExecutor();
+		const output = await bash(
+			{
+				command: process.execPath,
+				args: ["-e", "process.stdout.write('x'.repeat(60_000))"],
+			},
+			process.cwd(),
+			ctx,
+		);
+		expect(output.length).toBeLessThanOrEqual(50_000);
+		expect(output).toContain("output truncated: 60000 chars total");
+	});
+
+	it("does not truncate output within maxOutputBytes", async () => {
+		const bash = createBashExecutor({ maxOutputBytes: 1000 });
+		const payload = "b".repeat(500);
+		const output = await bash(
+			{
+				command: process.execPath,
+				args: ["-e", `process.stdout.write('${payload}')`],
+			},
+			process.cwd(),
+			ctx,
+		);
+		expect(output).toBe(payload);
+	});
+
+	it("marks truncation in the error when a failing command floods stderr", async () => {
+		const bash = createBashExecutor({ maxOutputBytes: 20 });
+		await expect(
+			bash(
+				{
+					command: process.execPath,
+					args: [
+						"-e",
+						"process.stderr.write('ERR' + 'x'.repeat(100) + 'TAIL'); process.exit(1)",
+					],
+				},
+				process.cwd(),
+				ctx,
+			),
+		).rejects.toThrow("output truncated");
+	});
+
+	it("keeps the tail of streamed output written in many chunks", async () => {
+		const bash = createBashExecutor({ maxOutputBytes: 40 });
+		const output = await bash(
+			{
+				command: process.execPath,
+				args: [
+					"-e",
+					"for (let i = 0; i < 50; i++) process.stdout.write('line' + i + '\\n'); process.stdout.write('FINAL')",
+				],
+			},
+			process.cwd(),
+			ctx,
+		);
+		expect(output).toContain("line0");
+		expect(output).toContain("FINAL");
+		expect(output).toContain("output truncated");
 	});
 
 	it("rejects when abort signal fires", async () => {

--- a/sdk/packages/core/src/extensions/tools/executors/bash.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/bash.ts
@@ -5,6 +5,7 @@
  */
 
 import { spawn } from "node:child_process";
+import { StringDecoder } from "node:string_decoder";
 import {
 	type AgentToolContext,
 	getDefaultShell,
@@ -12,6 +13,7 @@ import {
 } from "@cline/shared";
 import { TimeoutError } from "../helpers";
 import type { BashExecutor } from "../types";
+import { MAX_COMMAND_OUTPUT_CHARS } from "./output-limits";
 
 /**
  * Options for the bash executor
@@ -30,8 +32,11 @@ export interface BashExecutorOptions {
 	timeoutMs?: number;
 
 	/**
-	 * Maximum output size in bytes
-	 * @default 1_000_000 (1MB)
+	 * Maximum output size, measured in characters (approximately bytes for
+	 * ASCII-dominant output). Output beyond this is middle-truncated: the
+	 * head and tail are preserved and the middle is elided, since build and
+	 * test failures usually live at the end of the output.
+	 * @default 51_200 (~50KB)
 	 */
 	maxOutputBytes?: number;
 
@@ -52,6 +57,57 @@ interface SpawnConfig {
 	args: string[];
 	cwd: string;
 	env: Record<string, string>;
+}
+
+/**
+ * Collects stream output with bounded memory: the first half of the budget
+ * is kept verbatim, the rest rolls so the latest output always survives.
+ */
+function createRollingCollector(maxChars: number) {
+	const headLimit = Math.ceil(maxChars / 2);
+	const tailLimit = Math.max(1, maxChars - headLimit);
+	// StringDecoder keeps multibyte UTF-8 sequences split across stream
+	// chunks intact instead of corrupting them at chunk boundaries.
+	const decoder = new StringDecoder("utf8");
+	let head = "";
+	let tail = "";
+	let totalChars = 0;
+
+	return {
+		append(data: Buffer): void {
+			const text = decoder.write(data);
+			totalChars += text.length;
+			const headRoom = headLimit - head.length;
+			if (headRoom > 0) {
+				head += text.slice(0, headRoom);
+				tail = (tail + text.slice(headRoom)).slice(-tailLimit);
+				return;
+			}
+			tail = (tail + text).slice(-tailLimit);
+		},
+		snapshot() {
+			return {
+				text: head + tail,
+				totalChars,
+				dropped: totalChars > head.length + tail.length,
+			};
+		},
+	};
+}
+
+function truncateMiddle(
+	text: string,
+	maxChars: number,
+	totalChars: number,
+): string {
+	const headLimit = Math.ceil(maxChars / 2);
+	const tailLimit = Math.max(1, maxChars - headLimit);
+	return (
+		`${text.slice(0, headLimit)}\n` +
+		`[... output truncated: ${totalChars} chars total. ` +
+		"Refine the command (grep, head, tail) to view the elided middle ...]\n" +
+		text.slice(-tailLimit)
+	);
 }
 
 function spawnAndCollect(
@@ -76,9 +132,8 @@ function spawnAndCollect(
 		});
 		const childPid = child.pid;
 
-		let stdout = "";
-		let stderr = "";
-		let outputSize = 0;
+		const stdout = createRollingCollector(maxOutputBytes);
+		const stderr = createRollingCollector(maxOutputBytes);
 		let killed = false;
 		let settled = false;
 
@@ -132,30 +187,36 @@ function spawnAndCollect(
 		};
 
 		child.stdout?.on("data", (data: Buffer) => {
-			outputSize += data.length;
-			if (outputSize <= maxOutputBytes) stdout += data.toString();
+			stdout.append(data);
 		});
 
 		child.stderr?.on("data", (data: Buffer) => {
-			outputSize += data.length;
-			if (outputSize <= maxOutputBytes) stderr += data.toString();
+			stderr.append(data);
 		});
 
 		child.on("close", (code) => {
 			cleanup();
 			if (killed) return;
 
+			const out = stdout.snapshot();
+			const err = stderr.snapshot();
 			let output = combineOutput
-				? stdout + (stderr ? `\n[stderr]\n${stderr}` : "")
-				: stdout;
-
-			if (outputSize > maxOutputBytes) {
-				output += `\n\n[Output truncated: ${outputSize} bytes total, showing first ${maxOutputBytes} bytes]`;
+				? out.text + (err.text ? `\n[stderr]\n${err.text}` : "")
+				: out.text;
+			const dropped = out.dropped || (combineOutput && err.dropped);
+			if (dropped || output.length > maxOutputBytes) {
+				const totalChars = combineOutput
+					? out.totalChars + err.totalChars
+					: out.totalChars;
+				output = truncateMiddle(output, maxOutputBytes, totalChars);
 			}
 
 			if (code !== 0) {
+				const stderrText = err.dropped
+					? truncateMiddle(err.text, maxOutputBytes, err.totalChars)
+					: err.text;
 				settle(() =>
-					reject(new Error(stderr || `Command exited with code ${code}`)),
+					reject(new Error(stderrText || `Command exited with code ${code}`)),
 				);
 			} else {
 				settle(() => resolve(output));
@@ -190,7 +251,7 @@ export function createBashExecutor(
 	const {
 		shell = getDefaultShell(process.platform),
 		timeoutMs = 30000,
-		maxOutputBytes = 1_000_000,
+		maxOutputBytes = MAX_COMMAND_OUTPUT_CHARS,
 		env = {},
 		combineOutput = true,
 	} = options;

--- a/sdk/packages/core/src/extensions/tools/executors/file-read.test.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/file-read.test.ts
@@ -6,45 +6,79 @@ import { createFileReadExecutor } from "./file-read";
 
 describe("createFileReadExecutor", () => {
 	it("reads a file from an absolute path", async () => {
-		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "agents-file-read-"));
-		const filePath = path.join(dir, "example.txt");
-		await fs.writeFile(filePath, "hello absolute path", "utf-8");
-
-		try {
-			const readFile = createFileReadExecutor();
-			const result = await readFile(
-				{ path: filePath },
-				{
-					agentId: "agent-1",
-					conversationId: "conv-1",
-					iteration: 1,
-				},
-			);
-			expect(result).toBe("1 | hello absolute path");
-		} finally {
-			await fs.rm(dir, { recursive: true, force: true });
-		}
+		const result = await readTempFile("hello absolute path");
+		expect(result).toBe("1 | hello absolute path");
 	});
 
 	it("returns only the requested inclusive line range", async () => {
-		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "agents-file-read-"));
-		const filePath = path.join(dir, "example.txt");
-		await fs.writeFile(filePath, "alpha\nbeta\ngamma\ndelta", "utf-8");
+		const result = await readTempFile("alpha\nbeta\ngamma\ndelta", {
+			start_line: 2,
+			end_line: 3,
+		});
+		expect(result).toBe("2 | beta\n3 | gamma");
+	});
 
+	async function readTempFile(
+		content: string,
+		range?: { start_line?: number; end_line?: number },
+	): Promise<string> {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "agents-file-read-"));
 		try {
+			const filePath = path.join(dir, "example.txt");
+			await fs.writeFile(filePath, content, "utf-8");
 			const readFile = createFileReadExecutor();
-			const result = await readFile(
-				{ path: filePath, start_line: 2, end_line: 3 },
-				{
-					agentId: "agent-1",
-					conversationId: "conv-1",
-					iteration: 1,
-				},
-			);
-			expect(result).toBe("2 | beta\n3 | gamma");
+			return (await readFile(
+				{ path: filePath, ...range },
+				{ agentId: "agent-1", conversationId: "conv-1", iteration: 1 },
+			)) as string;
 		} finally {
 			await fs.rm(dir, { recursive: true, force: true });
 		}
+	}
+
+	const numberedLines = (count: number) =>
+		Array.from({ length: count }, (_, i) => `line ${i + 1}`).join("\n");
+
+	it("windows whole-file reads to the line cap and reports how to paginate", async () => {
+		const result = await readTempFile(numberedLines(2500));
+
+		expect(result).toContain("1 | line 1");
+		expect(result).toContain("2000 | line 2000");
+		expect(result).not.toContain("line 2001");
+		expect(result).toContain(
+			"[Showing lines 1-2000 of 2500. Use start_line/end_line to read other sections.]",
+		);
+	});
+
+	it("honors explicit ranges beyond the default window start", async () => {
+		const result = await readTempFile(numberedLines(2500), {
+			start_line: 2400,
+			end_line: 2402,
+		});
+
+		expect(result).toBe("2400 | line 2400\n2401 | line 2401\n2402 | line 2402");
+	});
+
+	it("truncates very long lines", async () => {
+		const result = await readTempFile(`short\n${"y".repeat(5000)}\nend`);
+
+		expect(result).toContain("short");
+		expect(result).toContain("[line truncated]");
+		expect(result).toContain("end");
+		expect(result.length).toBeLessThan(2500);
+	});
+
+	it("caps the returned window by characters for dense files", async () => {
+		// 1500 lines of 100 chars each is ~150k chars, well over the ~50k cap
+		// while staying under the 2000-line cap.
+		const result = await readTempFile(
+			Array.from({ length: 1500 }, () => "z".repeat(100)).join("\n"),
+		);
+
+		// Stays under MessageBuilder's 50_000 per-string backstop so the
+		// pagination notice survives provider-request truncation.
+		expect(result.length).toBeLessThanOrEqual(50_000);
+		expect(result).toContain("of 1500. Use start_line/end_line");
 	});
 
 	it("returns image blocks for image files when the model supports images", async () => {

--- a/sdk/packages/core/src/extensions/tools/executors/file-read.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/file-read.ts
@@ -10,6 +10,11 @@ import type { AgentToolContext } from "@cline/shared";
 import { resolveExistingFilePath } from "@cline/shared/storage";
 import type { ReadFileRequest } from "../schemas";
 import type { FileReadExecutor } from "../types";
+import {
+	MAX_LINE_CHARS,
+	MAX_READ_LINES,
+	MAX_READ_OUTPUT_CHARS,
+} from "./output-limits";
 
 const IMAGE_MEDIA_TYPES = new Map<string, string>([
 	[".gif", "image/gif"],
@@ -122,19 +127,39 @@ export function createFileReadExecutor(
 			end_line ?? allLines.length,
 			allLines.length,
 		);
-		const lines = allLines.slice(rangeStart, rangeEndExclusive);
+		const maxLineNumWidth = String(allLines.length).length;
 
-		// Optionally add line numbers - one-based indexing for better readability
-		if (includeLineNumbers) {
-			const maxLineNumWidth = String(allLines.length).length;
-			return lines
-				.map(
-					(line, i) =>
-						`${String(rangeStart + i + 1).padStart(maxLineNumWidth, " ")} | ${line}`,
-				)
-				.join("\n");
+		// Window the read: whole-file and oversized-range reads stop at the
+		// line and character caps so a single read cannot flood the
+		// conversation. The model pages through the rest with
+		// start_line/end_line. Line numbers are one-based for readability.
+		const lines: string[] = [];
+		let chars = 0;
+		let lineIndex = rangeStart;
+		while (lineIndex < rangeEndExclusive && lines.length < MAX_READ_LINES) {
+			let line = allLines[lineIndex];
+			if (line.length > MAX_LINE_CHARS) {
+				line = `${line.slice(0, MAX_LINE_CHARS)} [line truncated]`;
+			}
+			if (includeLineNumbers) {
+				line = `${String(lineIndex + 1).padStart(maxLineNumWidth, " ")} | ${line}`;
+			}
+			if (chars + line.length + 1 > MAX_READ_OUTPUT_CHARS && lines.length > 0) {
+				break;
+			}
+			lines.push(line);
+			chars += line.length + 1;
+			lineIndex += 1;
 		}
 
-		return lines.join("\n");
+		const body = lines.join("\n");
+		if (lineIndex >= rangeEndExclusive) {
+			return body;
+		}
+		return (
+			`${body}\n\n` +
+			`[Showing lines ${rangeStart + 1}-${lineIndex} of ${allLines.length}. ` +
+			"Use start_line/end_line to read other sections.]"
+		);
 	};
 }

--- a/sdk/packages/core/src/extensions/tools/executors/output-limits.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/output-limits.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared caps for how much tool output may enter the conversation. Every
+ * character returned by an executor is re-sent to the model on each
+ * subsequent request, so oversized outputs cost quadratically over the
+ * remaining run. Limits are measured in characters (UTF-16 code units),
+ * which tracks token cost more closely than bytes and is what JS strings
+ * measure exactly. Executors enforce these caps; tool descriptions
+ * reference them so the model pages or narrows instead of retrying.
+ *
+ * The character caps sit below MessageBuilder's 50_000 per-string backstop
+ * (session/services/message-builder.ts) so capped content plus the
+ * truncation notice passes through provider requests intact instead of
+ * being re-truncated into a generic marker.
+ */
+
+/** Max characters of command output kept; beyond this the middle is elided. */
+export const MAX_COMMAND_OUTPUT_CHARS = 48_000;
+
+/** Max lines returned per file read when the range is larger or absent. */
+export const MAX_READ_LINES = 2_000;
+
+/** Max characters kept per line in file reads (defangs minified files). */
+export const MAX_LINE_CHARS = 2_000;
+
+/** Max characters returned per file read window. */
+export const MAX_READ_OUTPUT_CHARS = 48_000;

--- a/sdk/packages/core/src/extensions/tools/runtime.ts
+++ b/sdk/packages/core/src/extensions/tools/runtime.ts
@@ -30,7 +30,7 @@ const BASE_TOOL_CATALOG: readonly RuntimeToolCatalogEntry[] = [
 	{
 		id: "read_files",
 		description:
-			"Read the full content of text or image files at the provided absolute paths, or return only an inclusive one-based line range when start_line/end_line are provided.",
+			"Read the content of text or image files at the provided absolute paths, or return only an inclusive one-based line range when start_line/end_line are provided. Long files are windowed; page with start_line/end_line.",
 		headlessToolNames: ["read_files"],
 	},
 	{

--- a/sdk/packages/core/src/extensions/tools/schemas.ts
+++ b/sdk/packages/core/src/extensions/tools/schemas.ts
@@ -34,7 +34,7 @@ export const ReadFileLineRangeSchema = z
 			.nullable()
 			.optional()
 			.describe(
-				"Optional one-based ending line number to read through; use null or omit for the end of the file",
+				"Optional one-based ending line number to read through; use null or omit to read to the end of the file or the read cap, whichever comes first",
 			),
 	})
 	.describe("Optional inclusive one-based file line range");
@@ -56,7 +56,7 @@ export const ReadFilesInputSchema = z.object({
 	files: z
 		.array(ReadFileRequestSchema)
 		.describe(
-			"Array of file read requests. Omit start_line/end_line or set them to null to return the full file content boundaries; provide integers to return only that inclusive one-based line range. Prefer this tool over running terminal command to get file content for better performance and reliability.",
+			"Array of file read requests. Omit start_line/end_line or set them to null to read from the start; provide integers to return only that inclusive one-based line range. Reads are capped, so page through long files with start_line/end_line. Prefer this tool over running terminal command to get file content for better performance and reliability.",
 		),
 });
 


### PR DESCRIPTION

- `run_commands`: the combined stdout/stderr cap drops from 1MB to 48,000 chars. Truncation switches from keep-first-N-bytes to head+tail sampling (start and end preserved, middle elided with a notice), since build/test failures live at the end of output. The notice reports the original size so the model knows to narrow with grep/head/tail. Failing-command stderr carries the notice too. Streams decode through `StringDecoder` so multibyte UTF-8 sequences split across chunks stay intact.
- `read_files`: whole-file and oversized-range reads are windowed to 2,000 lines / 48,000 chars, with a per-line cap of 2,000 chars to defang minified files. The truncation notice reports the total line count and tells the model to paginate with `start_line`/`end_line`. In-window ranged reads are byte-for-byte unchanged. The 10MB stat guard stays.
- Shared constants live in a new `executors/output-limits.ts` so the executors and the tool descriptions reference the same numbers, and remain overridable through the existing executor options. The caps are deliberately sized below MessageBuilder's 50,000 per-string backstop so capped content plus the truncation notice passes through provider requests intact instead of being re-truncated into a generic marker; regression tests assert the relationship.
- Tool descriptions for both tools now document the windowing and how to paginate or filter, so the model has a deliberate recovery path instead of silently losing the middle of a large output.

Why both layers are worth having:

- The executor caps bound what enters session history at all: session JSON files, memory, UI rendering, and summarizer inputs stay small, instead of storing megabyte blobs that only get trimmed at request-build time.
- The pagination affordances are model-facing. MessageBuilder's marker says content was truncated, but gives no path to recover it. The read_files notice plus updated descriptions teach the model to fetch exactly the range it needs, which is the part of opencode's design that protects task success rather than just cost.
- MessageBuilder remains the universal backstop for anything the executor caps do not cover (MCP/plugin tools, future tools).

Deliberately out of scope: opencode also persists full oversized outputs to disk and lets the model re-read them in pages (`tool-output-store`). That is deferred until evals show the model struggling without it; with #11465, the full content still exists in stored history.

