### PR TITLE
ENG-2184 Add generic provider-request capture for SDK CLI

### DIFF
--- a/sdk/packages/agents/src/agent-runtime.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.test.ts
@@ -960,6 +960,47 @@ describe("AgentRuntime", () => {
 		expect(model.requests).toHaveLength(1);
 	});
 
+	it("merges beforeModel options metadata into the model request", async () => {
+		const model = new ScriptedModel([
+			(request) => {
+				expect(request.options?.metadata).toMatchObject({
+					sessionId: "session-1",
+					runId: "run-1",
+					iteration: 1,
+				});
+				return [
+					{ type: "text-delta", text: "done" },
+					{ type: "finish", reason: "stop" },
+				];
+			},
+		]);
+		const runtime = new AgentRuntime({
+			model,
+			modelOptions: { metadata: { existing: true } },
+			hooks: {
+				beforeModel: () => ({
+					options: {
+						metadata: {
+							sessionId: "session-1",
+							runId: "run-1",
+							iteration: 1,
+						},
+					},
+				}),
+			},
+		});
+
+		await runtime.run("capture metadata");
+
+		expect(model.requests).toHaveLength(1);
+		expect(model.requests[0]?.options?.metadata).toMatchObject({
+			existing: true,
+			sessionId: "session-1",
+			runId: "run-1",
+			iteration: 1,
+		});
+	});
+
 	it("preserves the existing system prompt when prepareTurn returns only messages", async () => {
 		const compactedMessage: AgentMessage = {
 			id: "msg_compacted",

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -23,7 +23,11 @@ import type {
 	ToolApprovalResult,
 	ToolPolicy,
 } from "@cline/shared";
-import { captureSdkError, estimateTokens } from "@cline/shared";
+import {
+	captureSdkError,
+	estimateTokens,
+	mergeModelOptions,
+} from "@cline/shared";
 import { nanoid } from "nanoid";
 
 // Local `createUID` helper. The clinee source imports this from
@@ -778,7 +782,7 @@ export class AgentRuntime {
 			if (result?.options) {
 				request = {
 					...request,
-					options: { ...(request.options ?? {}), ...result.options },
+					options: mergeModelOptions(request.options, result.options),
 				};
 			}
 		}

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
@@ -524,6 +524,85 @@ describe("SessionRuntime message preparation", () => {
 		expect(textParts).toEqual(["original", "builder-added"]);
 	});
 
+	it("merges beforeModel metadata through final message preparation", async () => {
+		const extension: AgentExtension = {
+			name: "metadata-ext",
+			manifest: { capabilities: ["hooks"] },
+			hooks: {
+				beforeModel: () => ({
+					options: {
+						metadata: {
+							runId: "run-plugin",
+							iteration: 2,
+						},
+					},
+				}),
+			},
+		};
+		const { deps, configs } = makeRecordingRuntimeFactory();
+		const session = new SessionRuntime(
+			makeAgentConfig({
+				extensions: [extension],
+				hooks: {
+					beforeModel: () => ({
+						options: {
+							metadata: {
+								sessionId: "session-config",
+								conversationId: "conversation-config",
+							},
+						},
+					}),
+				},
+			}),
+			deps,
+		);
+
+		await (
+			session as unknown as {
+				ensureExtensionsInitialized(): Promise<void>;
+			}
+		).ensureExtensionsInitialized();
+		const hooks = (
+			session as unknown as {
+				createRuntimeHooks(): AgentRuntimeConfig["hooks"];
+			}
+		).createRuntimeHooks();
+		const beforeModel = hooks?.beforeModel;
+		expect(beforeModel).toBeDefined();
+
+		const result = await beforeModel?.({
+			snapshot: makeSnapshot(),
+			request: {
+				systemPrompt: "system",
+				messages: [
+					{
+						id: "m1",
+						role: "user",
+						content: [
+							{
+								type: "text",
+								text: "<user_input>original</user_input>",
+							},
+						],
+						createdAt: 1,
+					},
+				],
+				tools: [],
+			},
+		});
+
+		expect(result?.options?.metadata).toMatchObject({
+			sessionId: "session-config",
+			conversationId: "conversation-config",
+			runId: "run-plugin",
+			iteration: 2,
+		});
+		expect(result?.messages?.[0]?.content).toEqual([
+			{ type: "text", text: "original" },
+		]);
+		expect(configs).toHaveLength(0);
+	});
+
 	it("adapts prepareTurn with API-safe messages for runtime compaction", async () => {
 		const prepareTurn = vi.fn(() => ({
 			messages: [

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
@@ -44,6 +44,7 @@ import {
 	type Message,
 	type MessageWithMetadata,
 	type ModelInfo,
+	mergeModelOptions,
 	type ToolCallRecord,
 } from "@cline/shared";
 import {
@@ -136,17 +137,14 @@ function mergeRuntimeHooks(
 				aggregate = {
 					...aggregate,
 					...result,
-					options: {
-						...(aggregate?.options ?? {}),
-						...(result.options ?? {}),
-					},
+					options: mergeModelOptions(aggregate?.options, result.options),
 				};
 				request = {
 					...request,
 					...(result.messages ? { messages: result.messages } : {}),
 					...(result.tools ? { tools: result.tools } : {}),
 					...(result.options
-						? { options: { ...(request.options ?? {}), ...result.options } }
+						? { options: mergeModelOptions(request.options, result.options) }
 						: {}),
 				};
 			}

--- a/sdk/packages/llms/src/providers/README.md
+++ b/sdk/packages/llms/src/providers/README.md
@@ -47,7 +47,8 @@ issue is in Cline's final provider formatting/build step. If it is already in
 | --- | --- | --- | --- |
 | `CLINE_CAPTURE_PROVIDER_REQUEST` | `off`, `summary`, `full` | `off` | Enables provider request capture. |
 | `CLINE_CAPTURE_WIRE` | `true`, `false` | `false` | Wraps provider `fetch` to capture literal request bodies. |
-| `CLINE_CAPTURE_DIR` | filesystem path | unset | Explicit output directory for NDJSON capture files. |
+| `CLINE_CAPTURE_DIR` | filesystem path | unset | Explicit output directory for capture files. |
+| `CLINE_CAPTURE_CLEANUP` | `on`, `off` | `on` | Prunes old capture files. Set `off` to keep local files. |
 | `CLINE_CAPTURE_MAX_PREVIEW_BYTES` | positive integer | `65536` | Full-mode payload preview byte cap. |
 | `CLINE_DATA_DIR` | filesystem path | unset | Fallback base directory. Captures write to `CLINE_DATA_DIR/provider-request-captures`. |
 
@@ -57,22 +58,34 @@ accident.
 
 ## Output
 
-Capture writes newline-delimited JSON files:
+Capture writes one JSON file per captured stage:
 
 ```text
-${CLINE_CAPTURE_DIR}/YYYY-MM-DD.provider-request.ndjson
+${CLINE_CAPTURE_DIR}/<captureId>.<captureStage>.<attempt>.provider-request.json
 ```
 
 or, when only `CLINE_DATA_DIR` is set:
 
 ```text
-${CLINE_DATA_DIR}/provider-request-captures/YYYY-MM-DD.provider-request.ndjson
+${CLINE_DATA_DIR}/provider-request-captures/<captureId>.<captureStage>.<attempt>.provider-request.json
 ```
+
+Files are written atomically through a temporary file and same-directory rename,
+so consumers should ignore `*.tmp`. `captureId` comes from
+`GatewayStreamRequest.metadata.captureId` when present; otherwise the SDK derives
+a stable ID from request correlation metadata. `attempt` increments when the same
+stage is captured more than once for a request, such as provider retries.
+
+When `CLINE_CAPTURE_CLEANUP` is on, the SDK opportunistically prunes capture
+files older than 24 hours. Consumers may also delete files after processing them.
+Set `CLINE_CAPTURE_CLEANUP=off` when you need to keep local capture files for
+manual inspection.
 
 Each record includes:
 
 - `timestamp`
 - `captureStage`: `ai_sdk_prompt` or `wire_request`
+- `attempt`
 - `mode`: `summary` or `full`
 - `correlation`: copied from `GatewayStreamRequest.metadata`, plus provider and model IDs
 - `summary`: byte counts, estimated tokens, hashes, role counts, largest messages, reasoning/tool-result counts
@@ -100,6 +113,8 @@ export CLINE_DATA_DIR="$(mktemp -d)"
 export CLINE_CAPTURE_PROVIDER_REQUEST=full
 export CLINE_CAPTURE_WIRE=true
 export CLINE_CAPTURE_MAX_PREVIEW_BYTES=1000000
+# Optional: keep files after consumers process them.
+# export CLINE_CAPTURE_CLEANUP=off
 ```
 
 ## Correlation
@@ -109,7 +124,7 @@ record. A plugin can stamp this metadata from a `beforeModel` hook:
 
 ```text
 beforeModel hook
-  returns options.metadata = { sessionId, runId, conversationId, iteration }
+  returns options.metadata = { captureId, sessionId, runId, conversationId, iteration }
         |
         v
 agents/core hook composition deep-merges metadata
@@ -118,7 +133,7 @@ agents/core hook composition deep-merges metadata
 GatewayStreamRequest.metadata
         |
         v
-provider-request-capture.ts writes NDJSON records keyed by the same values
+provider-request-capture.ts writes per-stage files keyed by captureId
 ```
 
 The Weave tracing plugin uses this path to join local provider captures onto the

--- a/sdk/packages/llms/src/providers/README.md
+++ b/sdk/packages/llms/src/providers/README.md
@@ -1,0 +1,132 @@
+# Provider Request Capture
+
+This directory contains the SDK provider gateway and AI SDK provider adapter.
+`provider-request-capture.ts` adds an opt-in local capture path for debugging
+the exact prompt/request sent to a model provider.
+
+The capture layer is provider-agnostic. It does not import Weave, W&B, OTel, or
+plugin code. A plugin or external tool can correlate records by stamping
+`request.options.metadata` before the request reaches `sdk/packages/llms`.
+
+## Why This Exists
+
+Plugin hooks can observe Cline's conversation state, but they run before Core's
+final provider-message preparation. That final pass can repair missing tool
+results, truncate tool outputs, rewrite stale file content, apply prompt-cache
+provider options, and format messages for the provider.
+
+For token investigations, compare these layers:
+
+```text
+Plugin-visible messages
+  captureStage = pre_build_for_api
+        |
+        v
+Core MessageBuilder.buildForApi(...)
+        |
+        v
+AI SDK prompt passed to streamText(...)
+  captureStage = ai_sdk_prompt
+        |
+        v
+Provider client fetch(...)
+  captureStage = wire_request, only when CLINE_CAPTURE_WIRE=true
+        |
+        v
+Provider receives request
+```
+
+If token growth appears only in `wire_request`, the issue is provider
+serialization. If it appears in `ai_sdk_prompt` but not `pre_build_for_api`, the
+issue is in Cline's final provider formatting/build step. If it is already in
+`pre_build_for_api`, the issue is upstream of the final build step.
+
+## Environment Variables
+
+| Variable | Values | Default | Purpose |
+| --- | --- | --- | --- |
+| `CLINE_CAPTURE_PROVIDER_REQUEST` | `off`, `summary`, `full` | `off` | Enables provider request capture. |
+| `CLINE_CAPTURE_WIRE` | `true`, `false` | `false` | Wraps provider `fetch` to capture literal request bodies. |
+| `CLINE_CAPTURE_DIR` | filesystem path | unset | Explicit output directory for NDJSON capture files. |
+| `CLINE_CAPTURE_MAX_PREVIEW_BYTES` | positive integer | `65536` | Full-mode payload preview byte cap. |
+| `CLINE_DATA_DIR` | filesystem path | unset | Fallback base directory. Captures write to `CLINE_DATA_DIR/provider-request-captures`. |
+
+If neither `CLINE_CAPTURE_DIR` nor `CLINE_DATA_DIR` is set, capture no-ops. This
+prevents prompt content from being written into a repository working tree by
+accident.
+
+## Output
+
+Capture writes newline-delimited JSON files:
+
+```text
+${CLINE_CAPTURE_DIR}/YYYY-MM-DD.provider-request.ndjson
+```
+
+or, when only `CLINE_DATA_DIR` is set:
+
+```text
+${CLINE_DATA_DIR}/provider-request-captures/YYYY-MM-DD.provider-request.ndjson
+```
+
+Each record includes:
+
+- `timestamp`
+- `captureStage`: `ai_sdk_prompt` or `wire_request`
+- `mode`: `summary` or `full`
+- `correlation`: copied from `GatewayStreamRequest.metadata`, plus provider and model IDs
+- `summary`: byte counts, estimated tokens, hashes, role counts, largest messages, reasoning/tool-result counts
+- `payload`: only in `full` mode, truncated to `CLINE_CAPTURE_MAX_PREVIEW_BYTES`
+
+Wire capture intentionally records URL, method, and body only. It does not record
+headers, so authorization values are not written to capture files.
+
+## Example
+
+```bash
+export CLINE_DATA_DIR="$(mktemp -d)"
+export CLINE_CAPTURE_PROVIDER_REQUEST=summary
+export CLINE_CAPTURE_WIRE=true
+
+cline --provider openrouter --model openai/gpt-4o-mini "Say hello"
+
+ls "$CLINE_DATA_DIR/provider-request-captures"
+```
+
+For an internal investigation where full request bodies are expected:
+
+```bash
+export CLINE_DATA_DIR="$(mktemp -d)"
+export CLINE_CAPTURE_PROVIDER_REQUEST=full
+export CLINE_CAPTURE_WIRE=true
+export CLINE_CAPTURE_MAX_PREVIEW_BYTES=1000000
+```
+
+## Correlation
+
+The capture module reads `GatewayStreamRequest.metadata` and copies it into each
+record. A plugin can stamp this metadata from a `beforeModel` hook:
+
+```text
+beforeModel hook
+  returns options.metadata = { sessionId, runId, conversationId, iteration }
+        |
+        v
+agents/core hook composition deep-merges metadata
+        |
+        v
+GatewayStreamRequest.metadata
+        |
+        v
+provider-request-capture.ts writes NDJSON records keyed by the same values
+```
+
+The Weave tracing plugin uses this path to join local provider captures onto the
+matching model span, but the SDK capture files are useful without Weave too.
+
+## Coverage
+
+This capture path is currently wired into the AI SDK provider adapter in
+`ai-sdk.ts`. Providers that bypass `createAiSdkProvider(...)` will not emit
+`ai_sdk_prompt` or `wire_request` records until they get equivalent
+instrumentation.

--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -20,6 +20,10 @@ import { z } from "zod";
 import { extractErrorMessage } from "./format";
 import { isAnthropicCompatibleModel, resolveModelFamily } from "./model-facts";
 import {
+	recordProviderRequestCapture,
+	wrapFetchForProviderRequestCapture,
+} from "./provider-request-capture";
+import {
 	applyPromptCacheToLastTextPart,
 	shouldApplyPromptCache,
 } from "./routing/anthropic-compatible";
@@ -884,7 +888,14 @@ function createAiSdkProvider(kind: ProviderModuleKind): GatewayProviderFactory {
 				current: undefined,
 			};
 			try {
-				const provider = await createProviderModule(kind, config, context);
+				const provider = await createProviderModule(
+					kind,
+					{
+						...config,
+						fetch: wrapFetchForProviderRequestCapture(config.fetch, request),
+					},
+					context,
+				);
 				const langfuse = await ensureGatewayLangfuseTelemetry(
 					config.providerId,
 				);
@@ -895,11 +906,29 @@ function createAiSdkProvider(kind: ProviderModuleKind): GatewayProviderFactory {
 				const useSystemOption =
 					typeof systemPrompt === "string" && systemPrompt.trim().length > 0;
 				const messagesSystemPrompt = useSystemOption ? undefined : systemPrompt;
+				const messages = shouldApplyPromptCache(request, context)
+					? buildCachedAiSdkMessages(request, context, messagesSystemPrompt)
+					: toAiSdkMessages(request.messages, messagesSystemPrompt);
+				const providerOptions = composeAiSdkProviderOptions(
+					request,
+					context,
+					kind,
+				) as never;
+				recordProviderRequestCapture({
+					stage: "ai_sdk_prompt",
+					request,
+					payload: {
+						messages,
+						...(useSystemOption ? { system: systemPrompt } : {}),
+						tools,
+						providerOptions,
+						maxOutputTokens: request.maxTokens,
+						temperature: request.temperature,
+					},
+				});
 				stream = streamText({
 					model: provider.model(context.model.id) as never,
-					messages: (shouldApplyPromptCache(request, context)
-						? buildCachedAiSdkMessages(request, context, messagesSystemPrompt)
-						: toAiSdkMessages(request.messages, messagesSystemPrompt)) as never,
+					messages: messages as never,
 					...(useSystemOption ? { system: systemPrompt } : {}),
 					tools: tools as never,
 					temperature: request.temperature,
@@ -910,11 +939,7 @@ function createAiSdkProvider(kind: ProviderModuleKind): GatewayProviderFactory {
 					experimental_telemetry: {
 						isEnabled: langfuse,
 					},
-					providerOptions: composeAiSdkProviderOptions(
-						request,
-						context,
-						kind,
-					) as never,
+					providerOptions,
 					onError: ({ error: streamError }) => {
 						const msg = extractErrorMessage(streamError);
 						capturedError.current = msg;

--- a/sdk/packages/llms/src/providers/gateway.test.ts
+++ b/sdk/packages/llms/src/providers/gateway.test.ts
@@ -1,4 +1,10 @@
-import { mkdtempSync, readdirSync, readFileSync } from "node:fs";
+import {
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	utimesSync,
+	writeFileSync,
+} from "node:fs";
 import { access } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -115,16 +121,18 @@ const originalCaptureDir = process.env.CLINE_CAPTURE_DIR;
 const originalCaptureDataDir = process.env.CLINE_DATA_DIR;
 const originalCaptureMaxPreviewBytes =
 	process.env.CLINE_CAPTURE_MAX_PREVIEW_BYTES;
+const originalCaptureCleanup = process.env.CLINE_CAPTURE_CLEANUP;
 
 function readCaptureRecords(dir: string): Array<Record<string, unknown>> {
 	return readdirSync(dir)
-		.filter((file) => file.endsWith(".provider-request.ndjson"))
-		.flatMap((file) =>
-			readFileSync(join(dir, file), "utf8")
-				.trim()
-				.split("\n")
-				.filter(Boolean)
-				.map((line) => JSON.parse(line) as Record<string, unknown>),
+		.filter((file) => file.endsWith(".provider-request.json"))
+		.sort()
+		.map(
+			(file) =>
+				JSON.parse(readFileSync(join(dir, file), "utf8")) as Record<
+					string,
+					unknown
+				>,
 		);
 }
 
@@ -189,6 +197,11 @@ describe("sdk-gateway", () => {
 		} else {
 			process.env.CLINE_CAPTURE_MAX_PREVIEW_BYTES =
 				originalCaptureMaxPreviewBytes;
+		}
+		if (originalCaptureCleanup === undefined) {
+			delete process.env.CLINE_CAPTURE_CLEANUP;
+		} else {
+			process.env.CLINE_CAPTURE_CLEANUP = originalCaptureCleanup;
 		}
 	});
 
@@ -3652,6 +3665,7 @@ describe("sdk-gateway", () => {
 				modelId: "anthropic/claude-test",
 				messages: baseMessages,
 				metadata: {
+					captureId: "cap-session-1-run-1-2",
 					sessionId: "session-1",
 					runId: "run-1",
 					conversationId: "conv-1",
@@ -3662,10 +3676,15 @@ describe("sdk-gateway", () => {
 
 		const records = readCaptureRecords(captureDir);
 		expect(records).toHaveLength(1);
+		expect(readdirSync(captureDir)).toContain(
+			"cap-session-1-run-1-2.ai_sdk_prompt.1.provider-request.json",
+		);
 		expect(records[0]).toMatchObject({
 			captureStage: "ai_sdk_prompt",
+			attempt: 1,
 			mode: "summary",
 			correlation: {
+				captureId: "cap-session-1-run-1-2",
 				sessionId: "session-1",
 				runId: "run-1",
 				conversationId: "conv-1",
@@ -3688,6 +3707,36 @@ describe("sdk-gateway", () => {
 			},
 		});
 		expect(records[0]).not.toHaveProperty("payload");
+	});
+
+	it("falls back to a stable per-request capture filename without captureId", async () => {
+		const captureDir = mkdtempSync(join(tmpdir(), "llms-capture-fallback-"));
+		process.env.CLINE_CAPTURE_PROVIDER_REQUEST = "summary";
+		process.env.CLINE_CAPTURE_DIR = captureDir;
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([{ type: "finish", finishReason: "stop" }]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [{ providerId: "openrouter", apiKey: "test-key" }],
+		});
+
+		await collect(
+			await gateway.stream({
+				providerId: "openrouter",
+				modelId: "anthropic/claude-test",
+				messages: baseMessages,
+				metadata: { runId: "run-fallback", iteration: 4 },
+			}),
+		);
+
+		const files = readdirSync(captureDir).filter((file) =>
+			file.endsWith(".provider-request.json"),
+		);
+		expect(files).toHaveLength(1);
+		expect(files[0]).toMatch(
+			/^cap_run-fallback_4_[a-f0-9]{16}\.ai_sdk_prompt\.1\.provider-request\.json$/,
+		);
 	});
 
 	it("honors the full capture preview byte cap override", async () => {
@@ -3860,5 +3909,109 @@ describe("sdk-gateway", () => {
 				},
 			},
 		});
+	});
+
+	it("increments capture attempts instead of overwriting repeated wire requests", async () => {
+		const captureDir = mkdtempSync(join(tmpdir(), "llms-wire-attempts-"));
+		process.env.CLINE_CAPTURE_PROVIDER_REQUEST = "summary";
+		process.env.CLINE_CAPTURE_WIRE = "true";
+		process.env.CLINE_CAPTURE_DIR = captureDir;
+		const customFetch = vi.fn(
+			async () => new Response("ok"),
+		) as unknown as typeof fetch;
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([{ type: "finish", finishReason: "stop" }]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [
+				{ providerId: "openrouter", apiKey: "test-key", fetch: customFetch },
+			],
+		});
+
+		await collect(
+			await gateway.stream({
+				providerId: "openrouter",
+				modelId: "anthropic/claude-test",
+				messages: baseMessages,
+				metadata: { captureId: "cap-repeat", runId: "run-repeat" },
+			}),
+		);
+
+		const config = openaiCompatibleFactorySpy.mock.calls[0]?.[0] as {
+			fetch?: typeof fetch;
+		};
+		await config.fetch?.("https://example.test/v1/chat/completions", {
+			method: "POST",
+			body: JSON.stringify({ messages: [{ role: "user", content: "first" }] }),
+		});
+		await config.fetch?.("https://example.test/v1/chat/completions", {
+			method: "POST",
+			body: JSON.stringify({ messages: [{ role: "user", content: "second" }] }),
+		});
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		expect(
+			readdirSync(captureDir)
+				.filter((file) => file.endsWith(".provider-request.json"))
+				.sort(),
+		).toEqual([
+			"cap-repeat.ai_sdk_prompt.1.provider-request.json",
+			"cap-repeat.wire_request.1.provider-request.json",
+			"cap-repeat.wire_request.2.provider-request.json",
+		]);
+		const records = readCaptureRecords(captureDir);
+		expect(records.map((record) => record.attempt)).toEqual([1, 1, 2]);
+	});
+
+	it("prunes old capture files unless cleanup is disabled", async () => {
+		const captureDir = mkdtempSync(join(tmpdir(), "llms-capture-cleanup-"));
+		const oldFile = join(
+			captureDir,
+			"old.ai_sdk_prompt.1.provider-request.json",
+		);
+		writeFileSync(oldFile, "{}\n", { mode: 0o600 });
+		const oldDate = new Date(Date.now() - 48 * 60 * 60 * 1000);
+		utimesSync(oldFile, oldDate, oldDate);
+		process.env.CLINE_CAPTURE_PROVIDER_REQUEST = "summary";
+		process.env.CLINE_CAPTURE_DIR = captureDir;
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([{ type: "finish", finishReason: "stop" }]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [{ providerId: "openrouter", apiKey: "test-key" }],
+		});
+		await collect(
+			await gateway.stream({
+				providerId: "openrouter",
+				modelId: "anthropic/claude-test",
+				messages: baseMessages,
+				metadata: { captureId: "cap-cleanup-on" },
+			}),
+		);
+
+		expect(readdirSync(captureDir)).not.toContain(
+			"old.ai_sdk_prompt.1.provider-request.json",
+		);
+
+		const keepDir = mkdtempSync(join(tmpdir(), "llms-capture-keep-"));
+		const keepFile = join(keepDir, "old.ai_sdk_prompt.1.provider-request.json");
+		writeFileSync(keepFile, "{}\n", { mode: 0o600 });
+		utimesSync(keepFile, oldDate, oldDate);
+		process.env.CLINE_CAPTURE_DIR = keepDir;
+		process.env.CLINE_CAPTURE_CLEANUP = "off";
+		await collect(
+			await gateway.stream({
+				providerId: "openrouter",
+				modelId: "anthropic/claude-test",
+				messages: baseMessages,
+				metadata: { captureId: "cap-cleanup-off" },
+			}),
+		);
+
+		expect(readdirSync(keepDir)).toContain(
+			"old.ai_sdk_prompt.1.provider-request.json",
+		);
 	});
 });

--- a/sdk/packages/llms/src/providers/gateway.test.ts
+++ b/sdk/packages/llms/src/providers/gateway.test.ts
@@ -1,3 +1,7 @@
+import { mkdtempSync, readdirSync, readFileSync } from "node:fs";
+import { access } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { AgentMessage, AgentModelEvent } from "@cline/shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { normalizeModelsDevProviderModels } from "../catalog/catalog-live";
@@ -104,6 +108,25 @@ const baseMessages: AgentMessage[] = [
 	},
 ];
 const originalOpenRouterApiKey = process.env.OPENROUTER_API_KEY;
+const originalCaptureProviderRequest =
+	process.env.CLINE_CAPTURE_PROVIDER_REQUEST;
+const originalCaptureWire = process.env.CLINE_CAPTURE_WIRE;
+const originalCaptureDir = process.env.CLINE_CAPTURE_DIR;
+const originalCaptureDataDir = process.env.CLINE_DATA_DIR;
+const originalCaptureMaxPreviewBytes =
+	process.env.CLINE_CAPTURE_MAX_PREVIEW_BYTES;
+
+function readCaptureRecords(dir: string): Array<Record<string, unknown>> {
+	return readdirSync(dir)
+		.filter((file) => file.endsWith(".provider-request.ndjson"))
+		.flatMap((file) =>
+			readFileSync(join(dir, file), "utf8")
+				.trim()
+				.split("\n")
+				.filter(Boolean)
+				.map((line) => JSON.parse(line) as Record<string, unknown>),
+		);
+}
 
 describe("sdk-gateway", () => {
 	beforeEach(() => {
@@ -139,6 +162,33 @@ describe("sdk-gateway", () => {
 			delete process.env.OPENROUTER_API_KEY;
 		} else {
 			process.env.OPENROUTER_API_KEY = originalOpenRouterApiKey;
+		}
+		if (originalCaptureProviderRequest === undefined) {
+			delete process.env.CLINE_CAPTURE_PROVIDER_REQUEST;
+		} else {
+			process.env.CLINE_CAPTURE_PROVIDER_REQUEST =
+				originalCaptureProviderRequest;
+		}
+		if (originalCaptureWire === undefined) {
+			delete process.env.CLINE_CAPTURE_WIRE;
+		} else {
+			process.env.CLINE_CAPTURE_WIRE = originalCaptureWire;
+		}
+		if (originalCaptureDir === undefined) {
+			delete process.env.CLINE_CAPTURE_DIR;
+		} else {
+			process.env.CLINE_CAPTURE_DIR = originalCaptureDir;
+		}
+		if (originalCaptureDataDir === undefined) {
+			delete process.env.CLINE_DATA_DIR;
+		} else {
+			process.env.CLINE_DATA_DIR = originalCaptureDataDir;
+		}
+		if (originalCaptureMaxPreviewBytes === undefined) {
+			delete process.env.CLINE_CAPTURE_MAX_PREVIEW_BYTES;
+		} else {
+			process.env.CLINE_CAPTURE_MAX_PREVIEW_BYTES =
+				originalCaptureMaxPreviewBytes;
 		}
 	});
 
@@ -3571,5 +3621,244 @@ describe("sdk-gateway", () => {
 		);
 
 		expect(createProvider).toHaveBeenCalledOnce();
+	});
+
+	it("writes AI SDK prompt captures with request metadata correlation", async () => {
+		const captureDir = mkdtempSync(join(tmpdir(), "llms-capture-"));
+		process.env.CLINE_CAPTURE_PROVIDER_REQUEST = "summary";
+		process.env.CLINE_CAPTURE_DIR = captureDir;
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([
+				{
+					type: "finish",
+					finishReason: "stop",
+					usage: { inputTokens: 1, outputTokens: 1 },
+				},
+			]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [
+				{
+					providerId: "openrouter",
+					apiKey: "test-key",
+				},
+			],
+		});
+
+		await collect(
+			await gateway.stream({
+				providerId: "openrouter",
+				modelId: "anthropic/claude-test",
+				messages: baseMessages,
+				metadata: {
+					sessionId: "session-1",
+					runId: "run-1",
+					conversationId: "conv-1",
+					iteration: 2,
+				},
+			}),
+		);
+
+		const records = readCaptureRecords(captureDir);
+		expect(records).toHaveLength(1);
+		expect(records[0]).toMatchObject({
+			captureStage: "ai_sdk_prompt",
+			mode: "summary",
+			correlation: {
+				sessionId: "session-1",
+				runId: "run-1",
+				conversationId: "conv-1",
+				iteration: 2,
+				providerId: "openrouter",
+				modelId: "anthropic/claude-test",
+			},
+		});
+		expect(records[0]?.summary).toMatchObject({
+			messages: {
+				messageCount: 1,
+				roleCounts: { user: 1 },
+				messages: [
+					expect.objectContaining({
+						index: 0,
+						role: "user",
+						sha256: expect.any(String),
+					}),
+				],
+			},
+		});
+		expect(records[0]).not.toHaveProperty("payload");
+	});
+
+	it("honors the full capture preview byte cap override", async () => {
+		const captureDir = mkdtempSync(join(tmpdir(), "llms-full-capture-"));
+		process.env.CLINE_CAPTURE_PROVIDER_REQUEST = "full";
+		process.env.CLINE_CAPTURE_DIR = captureDir;
+		process.env.CLINE_CAPTURE_MAX_PREVIEW_BYTES = "24";
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([{ type: "finish", finishReason: "stop" }]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [
+				{
+					providerId: "openrouter",
+					apiKey: "test-key",
+				},
+			],
+		});
+
+		await collect(
+			await gateway.stream({
+				providerId: "openrouter",
+				modelId: "anthropic/claude-test",
+				messages: [
+					{
+						id: "user_full",
+						role: "user",
+						content: [{ type: "text", text: "Hello ".repeat(50) }],
+						createdAt: Date.now(),
+					},
+				],
+			}),
+		);
+
+		const payload = readCaptureRecords(captureDir)[0]?.payload as
+			| { preview?: string; truncated?: boolean }
+			| undefined;
+		expect(payload).toMatchObject({ truncated: true });
+		expect(
+			Buffer.byteLength(payload?.preview ?? "", "utf8"),
+		).toBeLessThanOrEqual(24);
+	});
+
+	it("does not write provider request captures without an explicit capture or data dir", async () => {
+		const cwd = process.cwd();
+		const tempCwd = mkdtempSync(join(tmpdir(), "llms-capture-cwd-"));
+		process.env.CLINE_CAPTURE_PROVIDER_REQUEST = "summary";
+		delete process.env.CLINE_CAPTURE_DIR;
+		delete process.env.CLINE_DATA_DIR;
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([{ type: "finish", finishReason: "stop" }]),
+		});
+
+		try {
+			process.chdir(tempCwd);
+			const gateway = createGateway({
+				providerConfigs: [
+					{
+						providerId: "openrouter",
+						apiKey: "test-key",
+					},
+				],
+			});
+
+			await collect(
+				await gateway.stream({
+					providerId: "openrouter",
+					modelId: "anthropic/claude-test",
+					messages: baseMessages,
+				}),
+			);
+
+			await expect(
+				access(join(tempCwd, ".cline", "provider-request-captures")),
+			).rejects.toThrow();
+		} finally {
+			process.chdir(cwd);
+		}
+	});
+
+	it("does not wrap provider fetch when wire capture is disabled", async () => {
+		const customFetch = vi.fn() as unknown as typeof fetch;
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([{ type: "finish", finishReason: "stop" }]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [
+				{ providerId: "openrouter", apiKey: "test-key", fetch: customFetch },
+			],
+		});
+
+		await collect(
+			await gateway.stream({
+				providerId: "openrouter",
+				modelId: "anthropic/claude-test",
+				messages: baseMessages,
+			}),
+		);
+
+		const config = openaiCompatibleFactorySpy.mock.calls[0]?.[0] as {
+			fetch?: typeof fetch;
+		};
+		expect(config.fetch).toBe(customFetch);
+	});
+
+	it("wraps provider fetch for wire capture while delegating to the configured fetch", async () => {
+		const captureDir = mkdtempSync(join(tmpdir(), "llms-wire-capture-"));
+		process.env.CLINE_CAPTURE_PROVIDER_REQUEST = "summary";
+		process.env.CLINE_CAPTURE_WIRE = "true";
+		process.env.CLINE_CAPTURE_DIR = captureDir;
+		const customFetch = vi.fn(
+			async () => new Response("ok"),
+		) as unknown as typeof fetch;
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([{ type: "finish", finishReason: "stop" }]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [
+				{ providerId: "openrouter", apiKey: "test-key", fetch: customFetch },
+			],
+		});
+
+		await collect(
+			await gateway.stream({
+				providerId: "openrouter",
+				modelId: "anthropic/claude-test",
+				messages: baseMessages,
+				metadata: { runId: "run-wire", iteration: 3 },
+			}),
+		);
+
+		const config = openaiCompatibleFactorySpy.mock.calls[0]?.[0] as {
+			fetch?: typeof fetch;
+		};
+		expect(config.fetch).not.toBe(customFetch);
+		await config.fetch?.("https://example.test/v1/chat/completions", {
+			method: "POST",
+			body: JSON.stringify({ messages: [{ role: "user", content: "hi" }] }),
+		});
+
+		expect(customFetch).toHaveBeenCalledOnce();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		const records = readCaptureRecords(captureDir);
+		expect(records.map((record) => record.captureStage)).toEqual([
+			"ai_sdk_prompt",
+			"wire_request",
+		]);
+		expect(records[1]).toMatchObject({
+			captureStage: "wire_request",
+			correlation: {
+				runId: "run-wire",
+				iteration: 3,
+				providerId: "openrouter",
+				modelId: "anthropic/claude-test",
+			},
+			summary: {
+				messages: {
+					messageCount: 1,
+					roleCounts: { user: 1 },
+					messages: [
+						expect.objectContaining({
+							index: 0,
+							role: "user",
+							sha256: expect.any(String),
+						}),
+					],
+				},
+			},
+		});
 	});
 });

--- a/sdk/packages/llms/src/providers/provider-request-capture.ts
+++ b/sdk/packages/llms/src/providers/provider-request-capture.ts
@@ -1,5 +1,13 @@
 import { createHash } from "node:crypto";
-import { appendFileSync, mkdirSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	renameSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
 import { join, resolve } from "node:path";
 import type { GatewayStreamRequest } from "@cline/shared";
 import { estimateTokens } from "@cline/shared";
@@ -8,6 +16,11 @@ type CaptureMode = "off" | "summary" | "full";
 type CaptureStage = "ai_sdk_prompt" | "wire_request";
 
 const DEFAULT_MAX_PREVIEW_BYTES = 64 * 1024;
+const CAPTURE_FILE_EXTENSION = ".provider-request.json";
+const CAPTURE_TMP_EXTENSION = ".tmp";
+const CLEANUP_TTL_MS = 24 * 60 * 60 * 1000;
+const cleanupDirs = new Set<string>();
+const attemptCounters = new Map<string, number>();
 
 function readCaptureMode(): CaptureMode {
 	const raw = process.env.CLINE_CAPTURE_PROVIDER_REQUEST?.trim().toLowerCase();
@@ -26,6 +39,10 @@ function readMaxPreviewBytes(): number {
 	return Number.isFinite(parsed) && parsed > 0
 		? Math.floor(parsed)
 		: DEFAULT_MAX_PREVIEW_BYTES;
+}
+
+function isCleanupEnabled(): boolean {
+	return process.env.CLINE_CAPTURE_CLEANUP?.trim().toLowerCase() !== "off";
 }
 
 function resolveCaptureDir(): string | undefined {
@@ -199,17 +216,84 @@ function captureCorrelation(
 	};
 }
 
+function safeFilePart(value: unknown): string | undefined {
+	if (typeof value !== "string" && typeof value !== "number") return undefined;
+	const raw = String(value).trim();
+	if (!raw) return undefined;
+	const safe = raw.replace(/[^a-zA-Z0-9_-]+/g, "_").replace(/^_+|_+$/g, "");
+	return safe || undefined;
+}
+
+function captureIdForCorrelation(correlation: Record<string, unknown>): string {
+	const explicit = safeFilePart(correlation.captureId);
+	if (explicit) return explicit;
+	const hash = hashString(safeStringify(correlation)).slice(0, 16);
+	const runId = safeFilePart(correlation.runId);
+	const iteration = safeFilePart(correlation.iteration);
+	return ["cap", runId, iteration, hash].filter(Boolean).join("_");
+}
+
+function nextAttempt(captureId: string, stage: CaptureStage): number {
+	const key = `${captureId}:${stage}`;
+	const next = (attemptCounters.get(key) ?? 0) + 1;
+	attemptCounters.set(key, next);
+	return next;
+}
+
+function cleanupOldCaptures(dir: string): void {
+	if (!isCleanupEnabled() || cleanupDirs.has(dir)) return;
+	cleanupDirs.add(dir);
+	try {
+		const cutoff = Date.now() - CLEANUP_TTL_MS;
+		for (const file of readdirSync(dir)) {
+			if (
+				!file.endsWith(CAPTURE_FILE_EXTENSION) &&
+				!(
+					file.includes(CAPTURE_FILE_EXTENSION) &&
+					file.endsWith(CAPTURE_TMP_EXTENSION)
+				)
+			) {
+				continue;
+			}
+			const path = join(dir, file);
+			const stat = statSync(path);
+			if (stat.mtimeMs < cutoff) {
+				rmSync(path, { force: true });
+			}
+		}
+	} catch {
+		// Capture cleanup must never affect model execution.
+	}
+}
+
 function writeCapture(record: Record<string, unknown>): void {
 	try {
 		const dir = resolveCaptureDir();
 		if (!dir) return;
 		mkdirSync(dir, { recursive: true });
-		const day = new Date().toISOString().slice(0, 10);
-		appendFileSync(
-			join(dir, `${day}.provider-request.ndjson`),
-			`${safeStringify(record)}\n`,
-			"utf8",
+		cleanupOldCaptures(dir);
+		const correlation =
+			record.correlation && typeof record.correlation === "object"
+				? (record.correlation as Record<string, unknown>)
+				: {};
+		const captureId = captureIdForCorrelation(correlation);
+		const stage =
+			record.captureStage === "ai_sdk_prompt" ||
+			record.captureStage === "wire_request"
+				? record.captureStage
+				: "ai_sdk_prompt";
+		const attempt = nextAttempt(captureId, stage);
+		const finalPath = join(
+			dir,
+			`${captureId}.${stage}.${attempt}${CAPTURE_FILE_EXTENSION}`,
 		);
+		const tmpPath = `${finalPath}.${process.pid}.${Date.now()}${CAPTURE_TMP_EXTENSION}`;
+		writeFileSync(tmpPath, `${safeStringify({ ...record, attempt })}\n`, {
+			encoding: "utf8",
+			mode: 0o600,
+		});
+		renameSync(tmpPath, finalPath);
+		if (existsSync(tmpPath)) rmSync(tmpPath, { force: true });
 	} catch {
 		// Provider-request capture must never affect model execution.
 	}

--- a/sdk/packages/llms/src/providers/provider-request-capture.ts
+++ b/sdk/packages/llms/src/providers/provider-request-capture.ts
@@ -1,0 +1,323 @@
+import { createHash } from "node:crypto";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+import type { GatewayStreamRequest } from "@cline/shared";
+import { estimateTokens } from "@cline/shared";
+
+type CaptureMode = "off" | "summary" | "full";
+type CaptureStage = "ai_sdk_prompt" | "wire_request";
+
+const DEFAULT_MAX_PREVIEW_BYTES = 64 * 1024;
+
+function readCaptureMode(): CaptureMode {
+	const raw = process.env.CLINE_CAPTURE_PROVIDER_REQUEST?.trim().toLowerCase();
+	if (raw === "summary" || raw === "full") {
+		return raw;
+	}
+	return "off";
+}
+
+function isWireCaptureEnabled(): boolean {
+	return process.env.CLINE_CAPTURE_WIRE?.trim().toLowerCase() === "true";
+}
+
+function readMaxPreviewBytes(): number {
+	const parsed = Number(process.env.CLINE_CAPTURE_MAX_PREVIEW_BYTES);
+	return Number.isFinite(parsed) && parsed > 0
+		? Math.floor(parsed)
+		: DEFAULT_MAX_PREVIEW_BYTES;
+}
+
+function resolveCaptureDir(): string | undefined {
+	const explicit = process.env.CLINE_CAPTURE_DIR?.trim();
+	if (explicit) {
+		return resolve(explicit);
+	}
+	const dataDir = process.env.CLINE_DATA_DIR?.trim();
+	if (dataDir) {
+		return resolve(dataDir, "provider-request-captures");
+	}
+	return undefined;
+}
+
+function safeStringify(value: unknown): string {
+	const seen = new WeakSet<object>();
+	try {
+		return (
+			JSON.stringify(value, (_key, nestedValue: unknown) => {
+				if (typeof nestedValue === "bigint") {
+					return nestedValue.toString();
+				}
+				if (typeof nestedValue !== "object" || nestedValue === null) {
+					return nestedValue;
+				}
+				if (seen.has(nestedValue)) {
+					return "[Circular]";
+				}
+				seen.add(nestedValue);
+				return nestedValue;
+			}) ?? ""
+		);
+	} catch {
+		return String(value ?? "");
+	}
+}
+
+function hashString(value: string): string {
+	return createHash("sha256").update(value).digest("hex");
+}
+
+function byteLength(value: string): number {
+	return Buffer.byteLength(value, "utf8");
+}
+
+function previewValue(
+	value: unknown,
+	maxBytes = DEFAULT_MAX_PREVIEW_BYTES,
+): unknown {
+	const serialized = safeStringify(value);
+	if (byteLength(serialized) <= maxBytes) {
+		return value;
+	}
+	const previewBuffer = Buffer.from(serialized, "utf8").subarray(0, maxBytes);
+	let preview = previewBuffer.toString("utf8");
+	while (byteLength(preview) > maxBytes) {
+		preview = preview.slice(0, -1);
+	}
+	return {
+		truncated: true,
+		bytes: byteLength(serialized),
+		sha256: hashString(serialized),
+		preview,
+	};
+}
+
+function summarizeContent(value: unknown): {
+	bytes: number;
+	estimatedTokens: number;
+	sha256: string;
+	kind: string;
+} {
+	const serialized = typeof value === "string" ? value : safeStringify(value);
+	return {
+		bytes: byteLength(serialized),
+		estimatedTokens: estimateTokens(byteLength(serialized)),
+		sha256: hashString(serialized),
+		kind: Array.isArray(value) ? "array" : typeof value,
+	};
+}
+
+function summarizeMessages(messages: unknown): Record<string, unknown> {
+	if (!Array.isArray(messages)) {
+		return summarizeContent(messages);
+	}
+
+	const roleCounts: Record<string, number> = {};
+	let reasoningBlockCount = 0;
+	let toolResultCount = 0;
+	const messageSummaries = messages.map((message, index) => {
+		const record =
+			message && typeof message === "object"
+				? (message as Record<string, unknown>)
+				: {};
+		const role = typeof record.role === "string" ? record.role : "unknown";
+		roleCounts[role] = (roleCounts[role] ?? 0) + 1;
+		const content = record.content;
+		const contentArray = Array.isArray(content) ? content : [content];
+		for (const part of contentArray) {
+			if (!part || typeof part !== "object") continue;
+			const type = (part as Record<string, unknown>).type;
+			if (type === "reasoning") reasoningBlockCount += 1;
+			if (type === "tool-result" || role === "tool") toolResultCount += 1;
+		}
+		const contentSummary = summarizeContent(content);
+		return {
+			index,
+			role,
+			contentParts: contentArray.length,
+			contentBytes: contentSummary.bytes,
+			estimatedTokens: contentSummary.estimatedTokens,
+			sha256: contentSummary.sha256,
+		};
+	});
+
+	const largestMessages = [...messageSummaries]
+		.sort((a, b) => b.contentBytes - a.contentBytes)
+		.slice(0, 5)
+		.map((message) => ({ ...message }));
+	const serialized = safeStringify(messages);
+	return {
+		messageCount: messages.length,
+		roleCounts,
+		totalBytes: byteLength(serialized),
+		estimatedTokens: estimateTokens(byteLength(serialized)),
+		sha256: hashString(serialized),
+		reasoningBlockCount,
+		toolResultCount,
+		largestMessages,
+		messages: messageSummaries,
+	};
+}
+
+function parseJsonString(value: unknown): unknown {
+	if (typeof value !== "string") return undefined;
+	const trimmed = value.trim();
+	if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) return undefined;
+	try {
+		return JSON.parse(trimmed);
+	} catch {
+		return undefined;
+	}
+}
+
+function extractProviderMessages(
+	payloadRecord: Record<string, unknown>,
+): unknown {
+	if ("messages" in payloadRecord) return payloadRecord.messages;
+	const body = payloadRecord.body;
+	const parsedBody = parseJsonString(body);
+	if (parsedBody && typeof parsedBody === "object") {
+		const bodyRecord = parsedBody as Record<string, unknown>;
+		if ("messages" in bodyRecord) return bodyRecord.messages;
+		if ("prompt" in bodyRecord) return bodyRecord.prompt;
+		if ("contents" in bodyRecord) return bodyRecord.contents;
+	}
+	return undefined;
+}
+
+function captureCorrelation(
+	request: GatewayStreamRequest,
+): Record<string, unknown> {
+	const metadata =
+		request.metadata && typeof request.metadata === "object"
+			? request.metadata
+			: {};
+	return {
+		...metadata,
+		providerId: request.providerId,
+		modelId: request.modelId,
+	};
+}
+
+function writeCapture(record: Record<string, unknown>): void {
+	try {
+		const dir = resolveCaptureDir();
+		if (!dir) return;
+		mkdirSync(dir, { recursive: true });
+		const day = new Date().toISOString().slice(0, 10);
+		appendFileSync(
+			join(dir, `${day}.provider-request.ndjson`),
+			`${safeStringify(record)}\n`,
+			"utf8",
+		);
+	} catch {
+		// Provider-request capture must never affect model execution.
+	}
+}
+
+export function recordProviderRequestCapture(input: {
+	stage: CaptureStage;
+	request: GatewayStreamRequest;
+	payload: unknown;
+}): void {
+	try {
+		const mode = readCaptureMode();
+		if (mode === "off") return;
+		const payloadRecord =
+			input.payload && typeof input.payload === "object"
+				? (input.payload as Record<string, unknown>)
+				: { value: input.payload };
+		const messages = extractProviderMessages(payloadRecord);
+		const serializedPayload = safeStringify(input.payload);
+		writeCapture({
+			timestamp: new Date().toISOString(),
+			captureStage: input.stage,
+			mode,
+			correlation: captureCorrelation(input.request),
+			summary: {
+				payloadBytes: byteLength(serializedPayload),
+				estimatedTokens: estimateTokens(byteLength(serializedPayload)),
+				sha256: hashString(serializedPayload),
+				messages: summarizeMessages(messages),
+			},
+			...(mode === "full"
+				? { payload: previewValue(input.payload, readMaxPreviewBytes()) }
+				: {}),
+		});
+	} catch {
+		// Provider-request capture must never affect model execution.
+	}
+}
+
+async function readRequestBody(
+	input: Parameters<typeof fetch>[0],
+	init: Parameters<typeof fetch>[1],
+): Promise<unknown> {
+	const body = init?.body;
+	if (body !== undefined && body !== null) {
+		if (typeof body === "string") return body;
+		if (body instanceof URLSearchParams) return body.toString();
+		if (body instanceof ArrayBuffer) return Buffer.from(body).toString("utf8");
+		if (ArrayBuffer.isView(body)) {
+			return Buffer.from(
+				body.buffer,
+				body.byteOffset,
+				body.byteLength,
+			).toString("utf8");
+		}
+		return { type: body.constructor?.name ?? typeof body };
+	}
+	if (input instanceof Request) {
+		try {
+			return await input.clone().text();
+		} catch {
+			return { type: "Request", bodyReadable: false };
+		}
+	}
+	return undefined;
+}
+
+export function wrapFetchForProviderRequestCapture(
+	baseFetch: typeof fetch | undefined,
+	request: GatewayStreamRequest,
+): typeof fetch | undefined {
+	if (!isWireCaptureEnabled()) {
+		return baseFetch;
+	}
+	const delegate = baseFetch ?? globalThis.fetch;
+	if (!delegate) {
+		return baseFetch;
+	}
+	const captureFetch = (async (input, init) => {
+		void readRequestBody(input, init)
+			.then((body) => {
+				recordProviderRequestCapture({
+					stage: "wire_request",
+					request,
+					payload: {
+						url: input instanceof Request ? input.url : String(input),
+						method:
+							init?.method ??
+							(input instanceof Request ? input.method : undefined) ??
+							"GET",
+						body,
+					},
+				});
+			})
+			.catch(() => {
+				// Provider-request capture must never affect model execution.
+			});
+		return delegate(input, init);
+	}) as typeof fetch;
+	const delegateWithPreconnect = delegate as typeof fetch & {
+		preconnect?: (...args: unknown[]) => unknown;
+	};
+	if (typeof delegateWithPreconnect.preconnect === "function") {
+		(
+			captureFetch as typeof fetch & {
+				preconnect?: (...args: unknown[]) => unknown;
+			}
+		).preconnect = delegateWithPreconnect.preconnect.bind(delegate);
+	}
+	return captureFetch;
+}

--- a/sdk/packages/shared/src/index.browser.ts
+++ b/sdk/packages/shared/src/index.browser.ts
@@ -122,6 +122,7 @@ export {
 	type ThinkingConfig,
 	ThinkingConfigSchema,
 } from "./llms/model-info";
+export { mergeModelOptions } from "./llms/model-options";
 export {
 	DEFAULT_REASONING_EFFORT,
 	REASONING_EFFORT_RATIOS,

--- a/sdk/packages/shared/src/index.ts
+++ b/sdk/packages/shared/src/index.ts
@@ -136,6 +136,7 @@ export {
 	type ThinkingConfig,
 	ThinkingConfigSchema,
 } from "./llms/model-info";
+export { mergeModelOptions } from "./llms/model-options";
 export {
 	DEFAULT_REASONING_EFFORT,
 	REASONING_EFFORT_RATIOS,

--- a/sdk/packages/shared/src/llms/model-options.ts
+++ b/sdk/packages/shared/src/llms/model-options.ts
@@ -1,0 +1,25 @@
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function mergeModelOptions(
+	base: Record<string, unknown> | undefined,
+	next: Record<string, unknown>,
+): Record<string, unknown>;
+export function mergeModelOptions(
+	base: Record<string, unknown> | undefined,
+	next: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined;
+export function mergeModelOptions(
+	base: Record<string, unknown> | undefined,
+	next: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+	if (!base && !next) return undefined;
+	const baseMetadata = base?.metadata;
+	const nextMetadata = next?.metadata;
+	const merged = { ...(base ?? {}), ...(next ?? {}) };
+	if (isRecord(baseMetadata) && isRecord(nextMetadata)) {
+		merged.metadata = { ...baseMetadata, ...nextMetadata };
+	}
+	return merged;
+}


### PR DESCRIPTION
### Related Issue

**Issue:** ENG-2184

### Description

Adds generic provider-request capture infrastructure for SDK CLI provider investigations, with the Weave tracing plugin as the first concrete consumer.

#### Why this is necessary

The existing plugin hooks can observe Cline's conversation state, but they cannot observe the final provider-bound request. In the current turn pipeline, plugin hooks run before Core's final provider-message preparation. That final preparation is exactly where token-relevant transformations can happen: tool-result repair/truncation, stale file-content rewrite, prompt-cache/provider options, provider formatting, and wire serialization.

For the token investigation, we need to compare three different views of the same turn:

- `pre_build_for_api`: what a plugin can see before Core's final `MessageBuilder.buildForApi(...)` pass.
- `ai_sdk_prompt`: the final AI SDK prompt passed to `streamText(...)` after Cline-side provider formatting.
- `wire_request`: the literal HTTP request body sent by the provider client, when wire capture is explicitly enabled.

That comparison tells us whether token growth happens before Core finalization, inside Core/provider formatting, or at the provider wire serialization layer.

#### Turn timing

```text
User turn starts
     |
     v
Cline runtime snapshot / transcript state
     |
     v
Plugin beforeModel hooks
     |     - plugin can stamp request.options.metadata
     |     - plugin can summarize request.messages
     |     - NOT final provider request yet
     |
     v
Plugin registerMessageBuilder hooks
     |     captureStage = pre_build_for_api
     |     records the messages entering Core's final buildForApi pass
     |
     v
Core MessageBuilder.buildForApi(...)
     |     - repairs missing tool results
     |     - truncates oversized tool results
     |     - rewrites outdated file content
     |     - applies total text budget truncation
     |     - applies provider/cache shaping inputs
     |
     v
sdk/packages/llms createAiSdkProvider(...)
     |
     v
AI SDK prompt object assembled
     |     captureStage = ai_sdk_prompt
     |     records the exact messages/providerOptions given to streamText(...)
     |
     v
streamText(...)
     |
     v
Provider client fetch
     |     captureStage = wire_request, only when CLINE_CAPTURE_WIRE=true
     |     records URL/method/body summary, no headers
     |
     v
Provider receives request
```

#### Data flow and correlation

```text
Weave/plugin side                               SDK/llms side
----------------                               -------------

beforeModel hook
  stamps options.metadata
  { sessionId, runId, conversationId,
    agentId, iteration }
        |
        v
agents/core metadata merge
  deep-merges options.metadata
  instead of clobbering it
        |
        v
GatewayStreamRequest.metadata ---------------> recordProviderRequestCapture(...)
                                                writes local NDJSON records
                                                keyed by the same metadata
        |
        v
plugin can later join local records
onto the matching model span
```

#### What this PR changes

This PR intentionally keeps the SDK side provider-agnostic:

- Adds neutral env-gated capture controls: `CLINE_CAPTURE_PROVIDER_REQUEST=off|summary|full`, `CLINE_CAPTURE_WIRE=true|false`, `CLINE_CAPTURE_DIR`, and `CLINE_CAPTURE_MAX_PREVIEW_BYTES`.
- Writes local NDJSON summaries with correlation metadata, byte counts, token estimates, role counts, largest-message summaries, reasoning/tool-result counts, and per-message hashes.
- Captures the final AI SDK prompt immediately before `streamText`.
- Optionally wraps the configured provider fetch to capture literal request bodies while preserving `config.fetch` and `preconnect`.
- Does not capture headers, so authorization values are not written to capture files.
- Avoids writing capture files unless `CLINE_CAPTURE_DIR` or `CLINE_DATA_DIR` is set, so full capture cannot silently land in a repo working tree.
- Makes the full-mode payload preview cap configurable via `CLINE_CAPTURE_MAX_PREVIEW_BYTES` for deliberate internal investigations that need larger payloads.
- Documents usage close to the code in `sdk/packages/llms/src/providers/README.md`.
- Deep-merges `options.metadata` in agents/core hook composition so plugin/config metadata composes instead of clobbering.

The first consumer is `cline/weave-tracing-plugin`, which stamps correlation metadata in `beforeModel` and joins these local capture summaries onto Weave model spans. The SDK layer does not import Weave, W&B, OTel, or plugin code.

Coverage caveat for v1: capture is wired into the AI SDK provider path in `sdk/packages/llms/src/providers/ai-sdk.ts`. Providers that bypass that path will not emit `ai_sdk_prompt` or `wire_request` capture records until they get equivalent instrumentation.

### Test Procedure

Validated locally with:

- `bun -F @cline/llms test -- src/providers/gateway.test.ts` (`72 passed`)
- `bun -F @cline/agents test -- src/agent-runtime.test.ts`
- `vitest run --config vitest.config.ts src/runtime/orchestration/session-runtime-orchestrator.test.ts` from `sdk/packages/core` (`46 passed`)
- `bun run types`
- `bun biome check --diagnostic-level=error sdk/packages/agents/src/agent-runtime.ts sdk/packages/agents/src/agent-runtime.test.ts sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts sdk/packages/llms/src/providers/ai-sdk.ts sdk/packages/llms/src/providers/gateway.test.ts sdk/packages/llms/src/providers/provider-request-capture.ts`
- `git diff --check`

Also smoke-tested with the local Weave plugin and a temp `CLINE_DATA_DIR`; the downstream plugin verified correlated `pre_build_for_api`, `ai_sdk_prompt`, and `wire_request` summaries in Weave.

CI should be treated as authoritative for the full repo because an earlier local orchestrator run hit a stale Vite transform-cache flake that disappeared after cache refresh and did not reproduce after clearing package `.vite` caches.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. Backend/provider instrumentation only.

### Additional Notes

This PR is intentionally generic. Weave-specific export, `wandb.*` attributes, OTel spans, and content capture live in the companion `cline/weave-tracing-plugin` work.