### PR TITLE
fix(cli): pass persisted provider endpoint config

### DIFF
--- a/apps/cli/src/main.test.ts
+++ b/apps/cli/src/main.test.ts
@@ -801,6 +801,50 @@ describe("runCli lightweight command dispatch", () => {
 		);
 	});
 
+	it("passes persisted provider endpoint config into prompt runtime", async () => {
+		const ollamaSettings = {
+			provider: "ollama",
+			baseUrl: "http://127.0.0.1:11434/v1",
+			model: "qwen3.6",
+		};
+		const ollamaProviderConfig = {
+			providerId: "ollama",
+			modelId: "qwen3.6",
+			baseUrl: "http://127.0.0.1:11434/v1",
+		};
+		providerSettingsMocks.getLastUsedProviderSettings.mockReturnValue(
+			ollamaSettings,
+		);
+		providerSettingsMocks.getProviderSettings.mockReturnValue(ollamaSettings);
+		providerSettingsMocks.getProviderConfig.mockReturnValue(
+			ollamaProviderConfig,
+		);
+		authMocks.normalizeProviderId.mockImplementation(
+			(providerId?: string) => providerId ?? "ollama",
+		);
+		forcePromptModeInput();
+		process.argv = ["bun", "src/index.ts", "hello"];
+
+		const { runCli } = await import("./main");
+
+		await expect(runCli()).resolves.toBeUndefined();
+		expect(llmMocks.resolveProviderConfig).toHaveBeenCalledWith(
+			"ollama",
+			undefined,
+			ollamaProviderConfig,
+		);
+		expect(runtimeMocks.runAgent).toHaveBeenCalledWith(
+			"hello",
+			expect.objectContaining({
+				providerId: "ollama",
+				modelId: "qwen3.6",
+				baseUrl: "http://127.0.0.1:11434/v1",
+				providerConfig: ollamaProviderConfig,
+			}),
+			expect.anything(),
+		);
+	});
+
 	it("runs kanban before loading runtime modules", async () => {
 		process.argv = ["bun", "src/index.ts", "kanban"];
 

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -877,8 +877,9 @@ export async function runCli(): Promise<void> {
 		}
 
 		let knownModels: Config["knownModels"];
+		let persistedProviderConfig: Config["providerConfig"];
 		try {
-			const persistedProviderConfig = providerSettingsManager.getProviderConfig(
+			persistedProviderConfig = providerSettingsManager.getProviderConfig(
 				provider,
 				{
 					includeKnownModels: false,
@@ -936,6 +937,11 @@ export async function runCli(): Promise<void> {
 				knownModelIds[0] ??
 				"anthropic/claude-sonnet-4.6",
 			apiKey: apiKey ?? "",
+			baseUrl:
+				persistedProviderConfig?.baseUrl ?? selectedProviderSettings?.baseUrl,
+			headers:
+				persistedProviderConfig?.headers ?? selectedProviderSettings?.headers,
+			providerConfig: persistedProviderConfig,
 			knownModels,
 			systemPrompt: await resolveSystemPrompt({
 				cwd,


### PR DESCRIPTION
### Related Issue

Issue: #XXXX

### Description

This fixes the new CLI path for external launchers that configure Cline by writing provider settings before starting the `cline` binary. Ollama's launcher uses that integration style: `ollama launch cline` writes `~/.cline/data/settings/providers.json` with `lastUsedProvider` set to `ollama`, stores the selected model, and stores the Ollama OpenAI-compatible endpoint such as `http://127.0.0.1:11434/v1`.

The new CLI already read the persisted provider and model correctly, but it only used the provider config while resolving the model catalog. When building the actual runtime config, it passed `providerId`, `modelId`, and `apiKey`, but not the persisted `baseUrl`, `headers`, or full `providerConfig`. That meant a launch could appear to select Ollama and the requested model, while the agent runtime did not receive the endpoint configuration it needed to talk to the local Ollama server.

The fix keeps the persisted provider config in scope after catalog resolution and carries it into the session config. The runtime already supports these fields through `CoreModelConfig`, and the handler factory already uses them when constructing the gateway provider config. This change wires the existing data through rather than introducing a new launch mechanism or special case for Ollama.

I added a regression test with an Ollama-shaped persisted config for `qwen3.6` and `http://127.0.0.1:11434/v1`. The test verifies that the persisted provider config is passed into `resolveProviderConfig` and that the final prompt runtime config includes both `baseUrl` and `providerConfig`.

### Test Procedure

I tested the focused CLI path and the touched files:

```bash
bun biome check apps/cli/src/main.ts apps/cli/src/main.test.ts
bun -F @cline/cli test src/main.test.ts
bun -F @cline/cli typecheck
```

The regression test covers the failure mode from `ollama launch cline --model qwen3.6`: persisted provider selection is used for provider/model resolution, and the persisted endpoint is now available to the runtime.

Potentially affected behavior is provider selection for the CLI startup path. Existing non-local providers should continue to work because the added fields come from the same persisted provider config the CLI already reads for catalog resolution. Providers without a custom endpoint simply pass `undefined` for these fields.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

No UI changes.

### Additional Notes

The original `/workspace/cline` checkout was in a pre-existing cherry-pick state, so I created the PR branch in a clean temporary worktree at `/tmp/cline-ollama-cli-pr` to avoid mutating that state.
