### PR TITLE
fix: auto-discover OS trust anchors in the CLI wrapper

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -346,8 +346,23 @@ Desktop-integrated approval mode is also supported via env wiring (`CLINE_TOOL_A
 - `CLINE_LOG_LEVEL` - Runtime log level (`trace|debug|info|warn|error|fatal|silent`, default `info`)
 - `CLINE_LOG_PATH` - Runtime log file path (default `<CLINE_DATA_DIR>/logs/cline.log`)
 - `CLINE_LOG_NAME` - Logger name embedded in runtime log records
+- `CLINE_DEBUG` - Set to `1`/`true` to print wrapper diagnostics (e.g. the CA bundle summary)
 
 `--key` takes precedence over environment variables.
+
+## Certificate trust
+
+The CLI automatically trusts your operating system's certificate store, so it
+works behind corporate TLS-inspecting proxies and with self-signed/internal
+endpoints without any setup. On launch the `cline` wrapper harvests the OS trust
+anchors and writes them to `~/.cline/cli-node-extra-ca-certs.pem`, then points
+the runtime's `NODE_EXTRA_CA_CERTS` at that bundle. The file is regenerated when
+it changes and is safe to delete (it is rebuilt on the next run).
+
+If you set `NODE_EXTRA_CA_CERTS` yourself, your certificates are **merged** into
+that bundle alongside the system store rather than replacing it. Run with
+`CLINE_DEBUG=1` to see how many OS and user CAs were loaded and where the bundle
+was written.
 
 ## Contributing
 

--- a/apps/cli/bin/ca-certs.cjs
+++ b/apps/cli/bin/ca-certs.cjs
@@ -145,6 +145,36 @@ function readFileIfExists(fs, filePath) {
 	}
 }
 
+function resolveClineDir(env, os, path) {
+	return env.CLINE_DIR?.trim() || path.join(os.homedir(), ".cline");
+}
+
+/**
+ * True when the api-unavailable warning should print. Stamped per Node version
+ * in the cline dir so the nudge shows once rather than on every command; a
+ * version change (upgrade that still falls short, or downgrade) re-arms it.
+ * When the stamp cannot be read or written, warn — bookkeeping failures must
+ * never suppress a real diagnostic.
+ */
+function shouldWarnApiUnavailable(env, deps = {}) {
+	const fs = deps.fs || require("node:fs");
+	const os = deps.os || require("node:os");
+	const path = deps.path || require("node:path");
+	const version = deps.nodeVersion || process.versions.node;
+	const dir = resolveClineDir(env, os, path);
+	const stamp = path.join(dir, `.ca-api-warned-${version}`);
+	try {
+		if (fs.existsSync(stamp)) {
+			return false;
+		}
+		fs.mkdirSync(dir, { recursive: true });
+		fs.writeFileSync(stamp, "", { mode: 0o600 });
+		return true;
+	} catch {
+		return true;
+	}
+}
+
 /** Atomically writes [content] to [target]; returns true on success. */
 function writeBundle(fs, dir, target, content) {
 	const tmp = `${target}.${process.pid}.${Date.now()}.tmp`;
@@ -208,7 +238,7 @@ function configureNodeExtraCaCerts(env, deps = {}) {
 		};
 	}
 
-	const managedDir = env.CLINE_DIR?.trim() || path.join(os.homedir(), ".cline");
+	const managedDir = resolveClineDir(env, os, path);
 	const managedPath = path.join(managedDir, "cli-node-extra-ca-certs.pem");
 	const userValue = (env.NODE_EXTRA_CA_CERTS || "").trim() || null;
 	const userPems = readUserCerts(fs, path, userValue, managedPath);
@@ -247,4 +277,5 @@ module.exports = {
 	buildBundle,
 	countCerts,
 	configureNodeExtraCaCerts,
+	shouldWarnApiUnavailable,
 };

--- a/apps/cli/bin/ca-certs.cjs
+++ b/apps/cli/bin/ca-certs.cjs
@@ -1,27 +1,20 @@
-// Auto-discovery of OS trust anchors for the Cline CLI (CLINE-2353).
+// Auto-discovery of OS trust anchors for the Cline CLI.
 //
-// The 3.x CLI ships as a Bun-compiled binary. Bun does not read the OS trust
-// store unless NODE_USE_SYSTEM_CA is set, and even then its Windows enumeration
-// covers only the `Root` store, not `CA`/Intermediate — so corporate MITM roots
-// are not trusted out of the box and inference fails with "unable to get local
-// issuer certificate". The pre-3.0 (Node) CLI did not have app-level CA handling
-// either, so this restores zero-config trust the way JetBrains already does it:
-// harvest the OS-trusted certificates and hand them to the child via
-// NODE_EXTRA_CA_CERTS, which both Bun and Node honor reliably.
+// Bun does not read the OS trust store, so the 3.x CLI cannot see corporate
+// MITM / self-signed CAs out of the box. This runs in the Node `bin/cline`
+// wrapper (not Bun), reads the full OS store via tls.getCACertificates("system")
+// (Node >= 22, no --use-system-ca flag), and hands the certs to the Bun child
+// via NODE_EXTRA_CA_CERTS, which both runtimes honor. Mirrors the JetBrains
+// plugin's configureCertificates(), sourcing from the OS instead of the IDE.
 //
-// This runs in the Node `bin/cline` wrapper (not Bun), so tls.getCACertificates
-// can read the full OS store — including Windows `Root` AND `CA` — without any
-// flag, before the Bun child's TLS context initializes.
-//
-// Kept as dependency-free CommonJS with injectable modules so the logic is unit
-// testable and ships verbatim in the published wrapper package.
+// Dependency-free CommonJS with injectable modules so it is unit-testable and
+// ships verbatim in the published wrapper package.
 
 const PEM_MARKER = "-----BEGIN CERTIFICATE-----";
 
 /**
  * Returns OS-trusted certificates as PEM strings, or [] when unavailable.
- * tls.getCACertificates("system") requires Node >= 22 and reads the OS store
- * directly (no --use-system-ca flag needed).
+ * tls.getCACertificates("system") requires Node >= 22.
  */
 function harvestSystemCerts(tlsModule) {
 	try {
@@ -61,28 +54,97 @@ function readUserBundle(fsModule, userPath) {
 }
 
 /**
- * Concatenates the user's PEM (if any) and the system certificates into one
+ * Reads the user's NODE_EXTRA_CA_CERTS value into PEM strings. Node treats the
+ * value as a single file, but some users set an OS-path-delimited list; the
+ * whole value is tried as one file first, then split.
+ * The managed bundle is excluded so reading it back never re-appends its certs.
+ */
+function readUserCerts(fsModule, pathModule, value, managedPath) {
+	if (!value) {
+		return [];
+	}
+	const fs = fsModule || require("node:fs");
+	const path = pathModule || require("node:path");
+	const candidates = [];
+	const whole = readUserBundle(fs, value);
+	if (whole) {
+		candidates.push({ filePath: value, pem: whole });
+	} else if (value.includes(path.delimiter)) {
+		for (const segment of value.split(path.delimiter)) {
+			const trimmed = segment.trim();
+			if (!trimmed) {
+				continue;
+			}
+			const pem = readUserBundle(fs, trimmed);
+			if (pem) {
+				candidates.push({ filePath: trimmed, pem });
+			}
+		}
+	}
+	const pems = [];
+	for (const candidate of candidates) {
+		const isManaged =
+			managedPath &&
+			path.resolve(candidate.filePath) === path.resolve(managedPath);
+		if (!isManaged) {
+			pems.push(candidate.pem);
+		}
+	}
+	return pems;
+}
+
+/**
+ * Concatenates the user PEMs (if any) and the system certificates into one
  * bundle. A separating newline is inserted between parts so adjacent END/BEGIN
  * markers cannot fuse into one invalid line.
  */
-function buildBundle({ systemCerts, userPem }) {
-	const parts = [];
-	if (userPem) {
-		parts.push(userPem);
-	}
-	for (const cert of systemCerts) {
-		parts.push(cert);
-	}
+function buildBundle({ systemCerts, userPems }) {
+	const parts = [...(userPems ?? []), ...systemCerts];
 	return parts
 		.map((part) => (part.endsWith("\n") ? part : `${part}\n`))
 		.join("");
 }
 
+function readFileIfExists(fs, filePath) {
+	try {
+		return fs.readFileSync(filePath, "utf8");
+	} catch {
+		return null;
+	}
+}
+
+/** Atomically writes [content] to [target]; returns true on success. */
+function writeBundle(fs, dir, target, content) {
+	try {
+		fs.mkdirSync(dir, { recursive: true });
+		const tmp = `${target}.${process.pid}.${Date.now()}.tmp`;
+		// Owner read/write: the bundle holds public CA material, not secrets,
+		// but there is no reason to make it world-writable.
+		fs.writeFileSync(tmp, content, { mode: 0o600 });
+		try {
+			fs.renameSync(tmp, target);
+		} catch {
+			// Windows can reject rename over a file a concurrent child holds open.
+			try {
+				fs.rmSync(target, { force: true });
+				fs.renameSync(tmp, target);
+			} catch {
+				fs.rmSync(tmp, { force: true });
+				return false;
+			}
+		}
+		return true;
+	} catch {
+		return false;
+	}
+}
+
 /**
  * Harvests OS trust anchors, merges them with any user NODE_EXTRA_CA_CERTS, and
  * points env.NODE_EXTRA_CA_CERTS at a single managed PEM bundle. Mutates `env`
- * in place and returns the managed path, or null when nothing was changed (no
- * system certs available — the user's existing setting is left untouched).
+ * in place. Returns an outcome the caller can log; `action` is one of
+ * "unchanged" | "written" | "write-failed-reused" | "write-failed" |
+ * "no-system-certs".
  */
 function configureNodeExtraCaCerts(env, deps = {}) {
 	const fs = deps.fs || require("node:fs");
@@ -91,39 +153,51 @@ function configureNodeExtraCaCerts(env, deps = {}) {
 
 	const systemCerts = harvestSystemCerts(deps.tls);
 	if (systemCerts.length === 0) {
-		// Nothing to add: do not clobber a user-provided NODE_EXTRA_CA_CERTS,
-		// and let the runtime fall back to its bundled CAs otherwise.
-		return null;
+		// Nothing to add: leave any user-provided NODE_EXTRA_CA_CERTS untouched
+		// and let the runtime fall back to its bundled CAs.
+		return {
+			action: "no-system-certs",
+			path: null,
+			systemCertCount: 0,
+			userCertCount: 0,
+		};
 	}
 
-	const userPath = (env.NODE_EXTRA_CA_CERTS || "").trim() || null;
 	const managedDir = env.CLINE_DIR?.trim() || path.join(os.homedir(), ".cline");
 	const managedPath = path.join(managedDir, "cli-node-extra-ca-certs.pem");
+	const userValue = (env.NODE_EXTRA_CA_CERTS || "").trim() || null;
+	const userPems = readUserCerts(fs, path, userValue, managedPath);
+	const bundle = buildBundle({ systemCerts, userPems });
+	const base = {
+		path: managedPath,
+		systemCertCount: systemCerts.length,
+		userCertCount: userPems.length,
+	};
 
-	// Guard against the user pointing NODE_EXTRA_CA_CERTS at our own managed
-	// file, which would otherwise re-append the system certs every launch.
-	const userIsManaged =
-		userPath && path.resolve(userPath) === path.resolve(managedPath);
-	const userPem = userIsManaged ? null : readUserBundle(fs, userPath);
-
-	const bundle = buildBundle({ systemCerts, userPem });
-	try {
-		fs.mkdirSync(managedDir, { recursive: true });
-		const tmp = `${managedPath}.${process.pid}.tmp`;
-		// Owner read/write: the bundle holds public CA material, not secrets,
-		// but there is no reason to make it world-writable.
-		fs.writeFileSync(tmp, bundle, { mode: 0o600 });
-		fs.renameSync(tmp, managedPath);
+	// Skip the rewrite when the bundle is already current. Avoids per-launch I/O
+	// and the concurrent-rename race in the steady state.
+	if (readFileIfExists(fs, managedPath) === bundle) {
 		env.NODE_EXTRA_CA_CERTS = managedPath;
-		return managedPath;
-	} catch {
-		return null;
+		return { ...base, action: "unchanged" };
 	}
+
+	if (writeBundle(fs, managedDir, managedPath, bundle)) {
+		env.NODE_EXTRA_CA_CERTS = managedPath;
+		return { ...base, action: "written" };
+	}
+
+	// Write failed: fall back to a previously-written bundle if one exists.
+	if (readFileIfExists(fs, managedPath)) {
+		env.NODE_EXTRA_CA_CERTS = managedPath;
+		return { ...base, action: "write-failed-reused" };
+	}
+	return { ...base, path: null, action: "write-failed" };
 }
 
 module.exports = {
 	harvestSystemCerts,
 	readUserBundle,
+	readUserCerts,
 	buildBundle,
 	configureNodeExtraCaCerts,
 };

--- a/apps/cli/bin/ca-certs.cjs
+++ b/apps/cli/bin/ca-certs.cjs
@@ -11,6 +11,27 @@
 // ships verbatim in the published wrapper package.
 
 const PEM_MARKER = "-----BEGIN CERTIFICATE-----";
+const CERT_BLOCK =
+	/-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----/g;
+
+/**
+ * Returns only the complete certificate blocks from PEM text, or null when
+ * there are none. User files may also hold private keys (combined cert+key
+ * PEMs) or other sections, which must never be copied into the managed
+ * bundle. Files that contain nothing but certificates pass through verbatim
+ * so unchanged bundles keep hash-skipping the rewrite.
+ */
+function sanitizePem(text) {
+	const blocks = text.match(CERT_BLOCK) ?? [];
+	if (blocks.length === 0) {
+		return null;
+	}
+	const rest = text.replace(CERT_BLOCK, "");
+	if (/^\s*$/.test(rest)) {
+		return text;
+	}
+	return `${blocks.join("\n")}\n`;
+}
 
 /**
  * Returns OS-trusted certificates as PEM strings, or [] when unavailable.
@@ -34,7 +55,10 @@ function harvestSystemCerts(tlsModule) {
 	}
 }
 
-/** Returns the file's PEM text, or null when missing, unreadable, or not PEM. */
+/**
+ * Returns the file's certificate blocks as PEM text, or null when missing,
+ * unreadable, or holding no complete certificate block.
+ */
 function readUserBundle(fsModule, userPath) {
 	if (!userPath) {
 		return null;
@@ -45,9 +69,8 @@ function readUserBundle(fsModule, userPath) {
 		if (!stat || !stat.isFile()) {
 			return null;
 		}
-		const text = fs.readFileSync(userPath, "utf8");
 		// Binary DER would not have loaded in the runtime either; require PEM.
-		return text.includes(PEM_MARKER) ? text : null;
+		return sanitizePem(fs.readFileSync(userPath, "utf8"));
 	} catch {
 		return null;
 	}
@@ -218,6 +241,7 @@ function configureNodeExtraCaCerts(env, deps = {}) {
 
 module.exports = {
 	harvestSystemCerts,
+	sanitizePem,
 	readUserBundle,
 	readUserCerts,
 	buildBundle,

--- a/apps/cli/bin/ca-certs.cjs
+++ b/apps/cli/bin/ca-certs.cjs
@@ -105,6 +105,15 @@ function buildBundle({ systemCerts, userPems }) {
 		.join("");
 }
 
+/** Counts individual PEM certificates across the given bundle strings. */
+function countCerts(pems) {
+	let count = 0;
+	for (const pem of pems) {
+		count += pem.split(PEM_MARKER).length - 1;
+	}
+	return count;
+}
+
 function readFileIfExists(fs, filePath) {
 	try {
 		return fs.readFileSync(filePath, "utf8");
@@ -115,9 +124,9 @@ function readFileIfExists(fs, filePath) {
 
 /** Atomically writes [content] to [target]; returns true on success. */
 function writeBundle(fs, dir, target, content) {
+	const tmp = `${target}.${process.pid}.${Date.now()}.tmp`;
 	try {
 		fs.mkdirSync(dir, { recursive: true });
-		const tmp = `${target}.${process.pid}.${Date.now()}.tmp`;
 		// Owner read/write: the bundle holds public CA material, not secrets,
 		// but there is no reason to make it world-writable.
 		fs.writeFileSync(tmp, content, { mode: 0o600 });
@@ -125,16 +134,17 @@ function writeBundle(fs, dir, target, content) {
 			fs.renameSync(tmp, target);
 		} catch {
 			// Windows can reject rename over a file a concurrent child holds open.
-			try {
-				fs.rmSync(target, { force: true });
-				fs.renameSync(tmp, target);
-			} catch {
-				fs.rmSync(tmp, { force: true });
-				return false;
-			}
+			fs.rmSync(target, { force: true });
+			fs.renameSync(tmp, target);
 		}
 		return true;
 	} catch {
+		// Never leave a partial temp file behind (e.g. ENOSPC mid-write).
+		try {
+			fs.rmSync(tmp, { force: true });
+		} catch {
+			// Ignore: best-effort cleanup.
+		}
 		return false;
 	}
 }
@@ -171,7 +181,7 @@ function configureNodeExtraCaCerts(env, deps = {}) {
 	const base = {
 		path: managedPath,
 		systemCertCount: systemCerts.length,
-		userCertCount: userPems.length,
+		userCertCount: countCerts(userPems),
 	};
 
 	// Skip the rewrite when the bundle is already current. Avoids per-launch I/O
@@ -199,5 +209,6 @@ module.exports = {
 	readUserBundle,
 	readUserCerts,
 	buildBundle,
+	countCerts,
 	configureNodeExtraCaCerts,
 };

--- a/apps/cli/bin/ca-certs.cjs
+++ b/apps/cli/bin/ca-certs.cjs
@@ -154,14 +154,26 @@ function writeBundle(fs, dir, target, content) {
  * points env.NODE_EXTRA_CA_CERTS at a single managed PEM bundle. Mutates `env`
  * in place. Returns an outcome the caller can log; `action` is one of
  * "unchanged" | "written" | "write-failed-reused" | "write-failed" |
- * "no-system-certs".
+ * "no-system-certs" | "api-unavailable".
  */
 function configureNodeExtraCaCerts(env, deps = {}) {
 	const fs = deps.fs || require("node:fs");
 	const os = deps.os || require("node:os");
 	const path = deps.path || require("node:path");
+	const tls = deps.tls || require("node:tls");
 
-	const systemCerts = harvestSystemCerts(deps.tls);
+	// tls.getCACertificates("system") needs Node >= 22.15; on older Nodes the
+	// harvest cannot run at all, which the caller should surface to the user.
+	if (typeof tls.getCACertificates !== "function") {
+		return {
+			action: "api-unavailable",
+			path: null,
+			systemCertCount: 0,
+			userCertCount: 0,
+		};
+	}
+
+	const systemCerts = harvestSystemCerts(tls);
 	if (systemCerts.length === 0) {
 		// Nothing to add: leave any user-provided NODE_EXTRA_CA_CERTS untouched
 		// and let the runtime fall back to its bundled CAs.

--- a/apps/cli/bin/ca-certs.cjs
+++ b/apps/cli/bin/ca-certs.cjs
@@ -1,0 +1,129 @@
+// Auto-discovery of OS trust anchors for the Cline CLI (CLINE-2353).
+//
+// The 3.x CLI ships as a Bun-compiled binary. Bun does not read the OS trust
+// store unless NODE_USE_SYSTEM_CA is set, and even then its Windows enumeration
+// covers only the `Root` store, not `CA`/Intermediate — so corporate MITM roots
+// are not trusted out of the box and inference fails with "unable to get local
+// issuer certificate". The pre-3.0 (Node) CLI did not have app-level CA handling
+// either, so this restores zero-config trust the way JetBrains already does it:
+// harvest the OS-trusted certificates and hand them to the child via
+// NODE_EXTRA_CA_CERTS, which both Bun and Node honor reliably.
+//
+// This runs in the Node `bin/cline` wrapper (not Bun), so tls.getCACertificates
+// can read the full OS store — including Windows `Root` AND `CA` — without any
+// flag, before the Bun child's TLS context initializes.
+//
+// Kept as dependency-free CommonJS with injectable modules so the logic is unit
+// testable and ships verbatim in the published wrapper package.
+
+const PEM_MARKER = "-----BEGIN CERTIFICATE-----";
+
+/**
+ * Returns OS-trusted certificates as PEM strings, or [] when unavailable.
+ * tls.getCACertificates("system") requires Node >= 22 and reads the OS store
+ * directly (no --use-system-ca flag needed).
+ */
+function harvestSystemCerts(tlsModule) {
+	try {
+		const tls = tlsModule || require("node:tls");
+		if (typeof tls.getCACertificates !== "function") {
+			return [];
+		}
+		const certs = tls.getCACertificates("system");
+		if (!Array.isArray(certs)) {
+			return [];
+		}
+		return certs.filter(
+			(cert) => typeof cert === "string" && cert.includes(PEM_MARKER),
+		);
+	} catch {
+		return [];
+	}
+}
+
+/** Returns the file's PEM text, or null when missing, unreadable, or not PEM. */
+function readUserBundle(fsModule, userPath) {
+	if (!userPath) {
+		return null;
+	}
+	try {
+		const fs = fsModule || require("node:fs");
+		const stat = fs.statSync(userPath, { throwIfNoEntry: false });
+		if (!stat || !stat.isFile()) {
+			return null;
+		}
+		const text = fs.readFileSync(userPath, "utf8");
+		// Binary DER would not have loaded in the runtime either; require PEM.
+		return text.includes(PEM_MARKER) ? text : null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Concatenates the user's PEM (if any) and the system certificates into one
+ * bundle. A separating newline is inserted between parts so adjacent END/BEGIN
+ * markers cannot fuse into one invalid line.
+ */
+function buildBundle({ systemCerts, userPem }) {
+	const parts = [];
+	if (userPem) {
+		parts.push(userPem);
+	}
+	for (const cert of systemCerts) {
+		parts.push(cert);
+	}
+	return parts
+		.map((part) => (part.endsWith("\n") ? part : `${part}\n`))
+		.join("");
+}
+
+/**
+ * Harvests OS trust anchors, merges them with any user NODE_EXTRA_CA_CERTS, and
+ * points env.NODE_EXTRA_CA_CERTS at a single managed PEM bundle. Mutates `env`
+ * in place and returns the managed path, or null when nothing was changed (no
+ * system certs available — the user's existing setting is left untouched).
+ */
+function configureNodeExtraCaCerts(env, deps = {}) {
+	const fs = deps.fs || require("node:fs");
+	const os = deps.os || require("node:os");
+	const path = deps.path || require("node:path");
+
+	const systemCerts = harvestSystemCerts(deps.tls);
+	if (systemCerts.length === 0) {
+		// Nothing to add: do not clobber a user-provided NODE_EXTRA_CA_CERTS,
+		// and let the runtime fall back to its bundled CAs otherwise.
+		return null;
+	}
+
+	const userPath = (env.NODE_EXTRA_CA_CERTS || "").trim() || null;
+	const managedDir = env.CLINE_DIR?.trim() || path.join(os.homedir(), ".cline");
+	const managedPath = path.join(managedDir, "cli-node-extra-ca-certs.pem");
+
+	// Guard against the user pointing NODE_EXTRA_CA_CERTS at our own managed
+	// file, which would otherwise re-append the system certs every launch.
+	const userIsManaged =
+		userPath && path.resolve(userPath) === path.resolve(managedPath);
+	const userPem = userIsManaged ? null : readUserBundle(fs, userPath);
+
+	const bundle = buildBundle({ systemCerts, userPem });
+	try {
+		fs.mkdirSync(managedDir, { recursive: true });
+		const tmp = `${managedPath}.${process.pid}.tmp`;
+		// Owner read/write: the bundle holds public CA material, not secrets,
+		// but there is no reason to make it world-writable.
+		fs.writeFileSync(tmp, bundle, { mode: 0o600 });
+		fs.renameSync(tmp, managedPath);
+		env.NODE_EXTRA_CA_CERTS = managedPath;
+		return managedPath;
+	} catch {
+		return null;
+	}
+}
+
+module.exports = {
+	harvestSystemCerts,
+	readUserBundle,
+	buildBundle,
+	configureNodeExtraCaCerts,
+};

--- a/apps/cli/bin/cline
+++ b/apps/cli/bin/cline
@@ -23,6 +23,16 @@ const childEnv = {
 	CLINE_WRAPPER_PATH: scriptPath,
 };
 
+// Auto-discover OS trust anchors and pass them to the Bun child via
+// NODE_EXTRA_CA_CERTS. The Bun runtime does not read the OS store on its own,
+// so corporate/self-signed CAs would otherwise fail (CLINE-2353). This wrapper
+// runs on Node, which can read the full store here.
+try {
+	require("./ca-certs.cjs").configureNodeExtraCaCerts(childEnv);
+} catch {
+	// Best effort: fall back to the runtime's default trust on any failure.
+}
+
 function run(target) {
 	const result = childProcess.spawnSync(target, process.argv.slice(2), {
 		stdio: "inherit",

--- a/apps/cli/bin/cline
+++ b/apps/cli/bin/cline
@@ -25,10 +25,27 @@ const childEnv = {
 
 // Auto-discover OS trust anchors and pass them to the Bun child via
 // NODE_EXTRA_CA_CERTS. The Bun runtime does not read the OS store on its own,
-// so corporate/self-signed CAs would otherwise fail (CLINE-2353). This wrapper
-// runs on Node, which can read the full store here.
+// so corporate/self-signed CAs would otherwise fail. This wrapper runs on
+// Node, which can read the full store here.
 try {
-	require("./ca-certs.cjs").configureNodeExtraCaCerts(childEnv);
+	const outcome = require("./ca-certs.cjs").configureNodeExtraCaCerts(childEnv);
+	const debug =
+		process.env.CLINE_DEBUG === "1" || process.env.CLINE_DEBUG === "true";
+	if (debug && outcome) {
+		if (outcome.action === "no-system-certs") {
+			console.warn(
+				"[cline] No OS trust anchors found; relying on the runtime's bundled CAs.",
+			);
+		} else if (outcome.action === "write-failed") {
+			console.warn(
+				"[cline] Could not write the managed CA bundle; relying on the runtime's bundled CAs.",
+			);
+		} else {
+			console.warn(
+				`[cline] Trust: ${outcome.systemCertCount} OS + ${outcome.userCertCount} user CAs (${outcome.action}) -> ${outcome.path}`,
+			);
+		}
+	}
 } catch {
 	// Best effort: fall back to the runtime's default trust on any failure.
 }

--- a/apps/cli/bin/cline
+++ b/apps/cli/bin/cline
@@ -31,6 +31,18 @@ try {
 	const outcome = require("./ca-certs.cjs").configureNodeExtraCaCerts(childEnv);
 	const debug =
 		process.env.CLINE_DEBUG === "1" || process.env.CLINE_DEBUG === "true";
+	// Not debug-gated: on old Nodes the harvest silently doing nothing is
+	// indistinguishable from a broken corporate proxy, so tell the user once.
+	if (
+		outcome &&
+		outcome.action === "api-unavailable" &&
+		!childEnv.NODE_EXTRA_CA_CERTS
+	) {
+		console.warn(
+			`[cline] Node ${process.versions.node} cannot read the OS trust store (needs >= 22.15); ` +
+				"corporate or self-signed CAs may fail TLS. Upgrade Node or set NODE_EXTRA_CA_CERTS.",
+		);
+	}
 	if (debug && outcome) {
 		if (outcome.action === "no-system-certs") {
 			console.warn(

--- a/apps/cli/bin/cline
+++ b/apps/cli/bin/cline
@@ -28,15 +28,18 @@ const childEnv = {
 // so corporate/self-signed CAs would otherwise fail. This wrapper runs on
 // Node, which can read the full store here.
 try {
-	const outcome = require("./ca-certs.cjs").configureNodeExtraCaCerts(childEnv);
+	const caCerts = require("./ca-certs.cjs");
+	const outcome = caCerts.configureNodeExtraCaCerts(childEnv);
 	const debug =
 		process.env.CLINE_DEBUG === "1" || process.env.CLINE_DEBUG === "true";
 	// Not debug-gated: on old Nodes the harvest silently doing nothing is
-	// indistinguishable from a broken corporate proxy, so tell the user once.
+	// indistinguishable from a broken corporate proxy. Stamped per Node
+	// version so the nudge shows once, not on every command.
 	if (
 		outcome &&
 		outcome.action === "api-unavailable" &&
-		!childEnv.NODE_EXTRA_CA_CERTS
+		!childEnv.NODE_EXTRA_CA_CERTS &&
+		caCerts.shouldWarnApiUnavailable(childEnv)
 	) {
 		console.warn(
 			`[cline] Node ${process.versions.node} cannot read the OS trust store (needs >= 22.15); ` +

--- a/apps/cli/src/bin/ca-certs.test.ts
+++ b/apps/cli/src/bin/ca-certs.test.ts
@@ -222,6 +222,17 @@ describe("ca-certs", () => {
 			expect(env.NODE_EXTRA_CA_CERTS).toBe("/user/corp.pem");
 		});
 
+		it("reports api-unavailable on Nodes without getCACertificates", () => {
+			const env: Record<string, string> = {
+				CLINE_DIR: dir,
+				NODE_EXTRA_CA_CERTS: "/user/corp.pem",
+			};
+			const out = caCerts.configureNodeExtraCaCerts(env, { tls: {} });
+			expect(out.action).toBe("api-unavailable");
+			expect(out.path).toBeNull();
+			expect(env.NODE_EXTRA_CA_CERTS).toBe("/user/corp.pem");
+		});
+
 		it("reports write-failed when the bundle cannot be written", () => {
 			const realFs = require("node:fs");
 			const failingFs = {

--- a/apps/cli/src/bin/ca-certs.test.ts
+++ b/apps/cli/src/bin/ca-certs.test.ts
@@ -28,6 +28,10 @@ const caCerts = require("../../bin/ca-certs.cjs") as {
 		systemCertCount: number;
 		userCertCount: number;
 	};
+	shouldWarnApiUnavailable: (
+		env: Record<string, string>,
+		deps?: { fs?: unknown; nodeVersion?: string },
+	) => boolean;
 };
 
 const fs = require("node:fs");
@@ -318,6 +322,46 @@ describe("ca-certs", () => {
 			expect(caCerts.countCerts([twoInOne])).toBe(2);
 			expect(caCerts.countCerts([certUser, certSystem])).toBe(2);
 			expect(caCerts.countCerts([])).toBe(0);
+		});
+	});
+
+	describe("shouldWarnApiUnavailable", () => {
+		it("warns once per Node version, then stays quiet", () => {
+			const env = { CLINE_DIR: dir };
+			const deps = { nodeVersion: "22.1.0" };
+			expect(caCerts.shouldWarnApiUnavailable(env, deps)).toBe(true);
+			expect(caCerts.shouldWarnApiUnavailable(env, deps)).toBe(false);
+		});
+
+		it("re-arms when the Node version changes", () => {
+			const env = { CLINE_DIR: dir };
+			expect(
+				caCerts.shouldWarnApiUnavailable(env, { nodeVersion: "22.1.0" }),
+			).toBe(true);
+			expect(
+				caCerts.shouldWarnApiUnavailable(env, { nodeVersion: "22.14.0" }),
+			).toBe(true);
+			expect(
+				caCerts.shouldWarnApiUnavailable(env, { nodeVersion: "22.1.0" }),
+			).toBe(false);
+		});
+
+		it("still warns when the stamp cannot be written", () => {
+			const realFs = require("node:fs");
+			const failingFs = {
+				...realFs,
+				mkdirSync: () => {
+					throw new Error("EACCES");
+				},
+				writeFileSync: () => {
+					throw new Error("EACCES");
+				},
+			};
+			const env = { CLINE_DIR: dir };
+			const deps = { fs: failingFs, nodeVersion: "22.1.0" };
+			// Bookkeeping failure must never suppress the diagnostic.
+			expect(caCerts.shouldWarnApiUnavailable(env, deps)).toBe(true);
+			expect(caCerts.shouldWarnApiUnavailable(env, deps)).toBe(true);
 		});
 	});
 });

--- a/apps/cli/src/bin/ca-certs.test.ts
+++ b/apps/cli/src/bin/ca-certs.test.ts
@@ -1,0 +1,163 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// The helper ships as CommonJS in the published wrapper package, so it is
+// loaded via require rather than an ESM import.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const caCerts = require("../../bin/ca-certs.cjs") as {
+	harvestSystemCerts: (tls?: unknown) => string[];
+	readUserBundle: (fs: unknown, p: string | null) => string | null;
+	buildBundle: (input: {
+		systemCerts: string[];
+		userPem: string | null;
+	}) => string;
+	configureNodeExtraCaCerts: (
+		env: Record<string, string>,
+		deps?: { tls?: unknown },
+	) => string | null;
+};
+
+const certSystem =
+	"-----BEGIN CERTIFICATE-----\nSYSTEM\n-----END CERTIFICATE-----\n";
+const certUser = "-----BEGIN CERTIFICATE-----\nUSER\n-----END CERTIFICATE-----";
+
+function fakeTls(certs: unknown) {
+	return { getCACertificates: () => certs };
+}
+
+describe("ca-certs", () => {
+	let dir: string;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "cline-ca-"));
+	});
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	describe("harvestSystemCerts", () => {
+		it("returns only PEM strings from the system store", () => {
+			const result = caCerts.harvestSystemCerts(
+				fakeTls([certSystem, "not-a-cert", 42]),
+			);
+			expect(result).toEqual([certSystem]);
+		});
+
+		it("returns [] when getCACertificates is unavailable", () => {
+			expect(caCerts.harvestSystemCerts({})).toEqual([]);
+		});
+
+		it("returns [] when getCACertificates throws", () => {
+			expect(
+				caCerts.harvestSystemCerts({
+					getCACertificates: () => {
+						throw new Error("nope");
+					},
+				}),
+			).toEqual([]);
+		});
+	});
+
+	describe("readUserBundle", () => {
+		const fs = require("node:fs");
+
+		it("returns PEM contents for a PEM file", () => {
+			const p = join(dir, "user.pem");
+			writeFileSync(p, certUser);
+			expect(caCerts.readUserBundle(fs, p)).toBe(certUser);
+		});
+
+		it("returns null for a non-PEM (DER) file", () => {
+			const p = join(dir, "user.der");
+			writeFileSync(p, Buffer.from([0x30, 0x82, 0x01, 0x02]));
+			expect(caCerts.readUserBundle(fs, p)).toBeNull();
+		});
+
+		it("returns null for a missing file and for null path", () => {
+			expect(caCerts.readUserBundle(fs, join(dir, "nope.pem"))).toBeNull();
+			expect(caCerts.readUserBundle(fs, null)).toBeNull();
+		});
+	});
+
+	describe("buildBundle", () => {
+		it("merges user PEM before system certs", () => {
+			const merged = caCerts.buildBundle({
+				systemCerts: [certSystem],
+				userPem: certUser,
+			});
+			expect(merged).toBe(`${certUser}\n${certSystem}`);
+		});
+
+		it("inserts a separating newline so END/BEGIN markers do not fuse", () => {
+			const merged = caCerts.buildBundle({
+				systemCerts: [certSystem],
+				userPem: certUser,
+			});
+			expect(merged).not.toContain(
+				"-----END CERTIFICATE----------BEGIN CERTIFICATE-----",
+			);
+		});
+
+		it("handles no user PEM", () => {
+			expect(
+				caCerts.buildBundle({ systemCerts: [certSystem], userPem: null }),
+			).toBe(certSystem);
+		});
+	});
+
+	describe("configureNodeExtraCaCerts", () => {
+		it("writes a managed bundle and points the env var at it", () => {
+			const env: Record<string, string> = { CLINE_DIR: dir };
+			const out = caCerts.configureNodeExtraCaCerts(env, {
+				tls: fakeTls([certSystem]),
+			});
+			expect(out).toBe(join(dir, "cli-node-extra-ca-certs.pem"));
+			expect(env.NODE_EXTRA_CA_CERTS).toBe(out);
+			expect(readFileSync(out as string, "utf8")).toContain("SYSTEM");
+		});
+
+		it("merges a user-supplied NODE_EXTRA_CA_CERTS with system certs", () => {
+			const userPath = join(dir, "corp.pem");
+			writeFileSync(userPath, certUser);
+			const env: Record<string, string> = {
+				CLINE_DIR: dir,
+				NODE_EXTRA_CA_CERTS: userPath,
+			};
+			caCerts.configureNodeExtraCaCerts(env, { tls: fakeTls([certSystem]) });
+			const written = readFileSync(env.NODE_EXTRA_CA_CERTS, "utf8");
+			expect(written).toContain("USER");
+			expect(written).toContain("SYSTEM");
+		});
+
+		it("does not re-append when the user already points at the managed bundle", () => {
+			const env: Record<string, string> = { CLINE_DIR: dir };
+			const first = caCerts.configureNodeExtraCaCerts(env, {
+				tls: fakeTls([certSystem]),
+			}) as string;
+			// Second launch with NODE_EXTRA_CA_CERTS set to our own managed file.
+			const env2: Record<string, string> = {
+				CLINE_DIR: dir,
+				NODE_EXTRA_CA_CERTS: first,
+			};
+			caCerts.configureNodeExtraCaCerts(env2, { tls: fakeTls([certSystem]) });
+			const written = readFileSync(env2.NODE_EXTRA_CA_CERTS, "utf8");
+			// Exactly one SYSTEM block, not duplicated.
+			expect(written.match(/SYSTEM/g)?.length).toBe(1);
+		});
+
+		it("leaves the env untouched when no system certs are available", () => {
+			const env: Record<string, string> = {
+				CLINE_DIR: dir,
+				NODE_EXTRA_CA_CERTS: "/user/corp.pem",
+			};
+			const out = caCerts.configureNodeExtraCaCerts(env, {
+				tls: fakeTls([]),
+			});
+			expect(out).toBeNull();
+			expect(env.NODE_EXTRA_CA_CERTS).toBe("/user/corp.pem");
+		});
+	});
+});

--- a/apps/cli/src/bin/ca-certs.test.ts
+++ b/apps/cli/src/bin/ca-certs.test.ts
@@ -18,6 +18,7 @@ const caCerts = require("../../bin/ca-certs.cjs") as {
 		systemCerts: string[];
 		userPems?: string[];
 	}) => string;
+	countCerts: (pems: string[]) => number;
 	configureNodeExtraCaCerts: (
 		env: Record<string, string>,
 		deps?: { tls?: unknown; fs?: unknown },
@@ -240,6 +241,45 @@ describe("ca-certs", () => {
 			expect(out.action).toBe("write-failed");
 			expect(out.path).toBeNull();
 			expect(env.NODE_EXTRA_CA_CERTS).toBeUndefined();
+		});
+
+		it("reuses a stale bundle when the rewrite fails", () => {
+			// First run writes the bundle normally.
+			const env: Record<string, string> = { CLINE_DIR: dir };
+			const managedPath = caCerts.configureNodeExtraCaCerts(env, {
+				tls: fakeTls([certSystem]),
+			}).path as string;
+
+			// Second run: writes fail, but the stale bundle is still readable.
+			const realFs = require("node:fs");
+			const failingFs = {
+				...realFs,
+				mkdirSync: () => {
+					throw new Error("EACCES");
+				},
+				writeFileSync: () => {
+					throw new Error("EACCES");
+				},
+			};
+			const env2: Record<string, string> = { CLINE_DIR: dir };
+			const out = caCerts.configureNodeExtraCaCerts(env2, {
+				// A different system cert forces a rewrite attempt (not "unchanged").
+				tls: fakeTls([certUser]),
+				fs: failingFs,
+			});
+
+			expect(out.action).toBe("write-failed-reused");
+			expect(env2.NODE_EXTRA_CA_CERTS).toBe(managedPath);
+		});
+	});
+
+	describe("countCerts", () => {
+		it("counts individual certificates, not files", () => {
+			// One file holding two certs must report 2, not 1.
+			const twoInOne = `${certUser}\n${certSystem}`;
+			expect(caCerts.countCerts([twoInOne])).toBe(2);
+			expect(caCerts.countCerts([certUser, certSystem])).toBe(2);
+			expect(caCerts.countCerts([])).toBe(0);
 		});
 	});
 });

--- a/apps/cli/src/bin/ca-certs.test.ts
+++ b/apps/cli/src/bin/ca-certs.test.ts
@@ -91,6 +91,33 @@ describe("ca-certs", () => {
 			expect(caCerts.readUserBundle(fs, join(dir, "nope.pem"))).toBeNull();
 			expect(caCerts.readUserBundle(fs, null)).toBeNull();
 		});
+
+		it("strips non-certificate sections such as private keys", () => {
+			// Combined cert+key files (nginx/haproxy style) are common; the key
+			// must never reach the managed bundle.
+			const p = join(dir, "combined.pem");
+			writeFileSync(
+				p,
+				`${certUser}\n-----BEGIN PRIVATE KEY-----\nSECRET\n-----END PRIVATE KEY-----\n`,
+			);
+			const out = caCerts.readUserBundle(fs, p);
+			expect(out).toContain("USER");
+			expect(out).not.toContain("PRIVATE KEY");
+			expect(out).not.toContain("SECRET");
+		});
+
+		it("keeps certificates-only files verbatim", () => {
+			// Byte-identical passthrough keeps the unchanged-skip hash stable.
+			const p = join(dir, "clean.pem");
+			writeFileSync(p, `${certUser}\n${certSystem}`);
+			expect(caCerts.readUserBundle(fs, p)).toBe(`${certUser}\n${certSystem}`);
+		});
+
+		it("returns null for a BEGIN marker without a complete block", () => {
+			const p = join(dir, "truncated.pem");
+			writeFileSync(p, "-----BEGIN CERTIFICATE-----\ntruncated");
+			expect(caCerts.readUserBundle(fs, p)).toBeNull();
+		});
 	});
 
 	describe("readUserCerts", () => {

--- a/apps/cli/src/bin/ca-certs.test.ts
+++ b/apps/cli/src/bin/ca-certs.test.ts
@@ -1,23 +1,36 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 // The helper ships as CommonJS in the published wrapper package, so it is
 // loaded via require rather than an ESM import.
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const caCerts = require("../../bin/ca-certs.cjs") as {
 	harvestSystemCerts: (tls?: unknown) => string[];
 	readUserBundle: (fs: unknown, p: string | null) => string | null;
+	readUserCerts: (
+		fs: unknown,
+		path: unknown,
+		value: string | null,
+		managedPath: string | null,
+	) => string[];
 	buildBundle: (input: {
 		systemCerts: string[];
-		userPem: string | null;
+		userPems?: string[];
 	}) => string;
 	configureNodeExtraCaCerts: (
 		env: Record<string, string>,
-		deps?: { tls?: unknown },
-	) => string | null;
+		deps?: { tls?: unknown; fs?: unknown },
+	) => {
+		action: string;
+		path: string | null;
+		systemCertCount: number;
+		userCertCount: number;
+	};
 };
+
+const fs = require("node:fs");
+const path = require("node:path");
 
 const certSystem =
 	"-----BEGIN CERTIFICATE-----\nSYSTEM\n-----END CERTIFICATE-----\n";
@@ -40,10 +53,9 @@ describe("ca-certs", () => {
 
 	describe("harvestSystemCerts", () => {
 		it("returns only PEM strings from the system store", () => {
-			const result = caCerts.harvestSystemCerts(
-				fakeTls([certSystem, "not-a-cert", 42]),
-			);
-			expect(result).toEqual([certSystem]);
+			expect(
+				caCerts.harvestSystemCerts(fakeTls([certSystem, "not-a-cert", 42])),
+			).toEqual([certSystem]);
 		});
 
 		it("returns [] when getCACertificates is unavailable", () => {
@@ -62,8 +74,6 @@ describe("ca-certs", () => {
 	});
 
 	describe("readUserBundle", () => {
-		const fs = require("node:fs");
-
 		it("returns PEM contents for a PEM file", () => {
 			const p = join(dir, "user.pem");
 			writeFileSync(p, certUser);
@@ -82,29 +92,67 @@ describe("ca-certs", () => {
 		});
 	});
 
+	describe("readUserCerts", () => {
+		it("reads a single PEM file path", () => {
+			const p = join(dir, "corp.pem");
+			writeFileSync(p, certUser);
+			expect(caCerts.readUserCerts(fs, path, p, null)).toEqual([certUser]);
+		});
+
+		it("splits a legacy OS-path-delimited value and reads each PEM", () => {
+			// Legacy footgun: NODE_EXTRA_CA_CERTS="a.pem;b.pem".
+			const a = join(dir, "a.pem");
+			const b = join(dir, "b.pem");
+			writeFileSync(a, certUser);
+			writeFileSync(b, certSystem);
+			expect(
+				caCerts.readUserCerts(fs, path, [a, b].join(delimiter), null),
+			).toEqual([certUser, certSystem]);
+		});
+
+		it("skips missing segments in a delimited value", () => {
+			const a = join(dir, "a.pem");
+			writeFileSync(a, certUser);
+			const value = [a, join(dir, "missing.pem")].join(delimiter);
+			expect(caCerts.readUserCerts(fs, path, value, null)).toEqual([certUser]);
+		});
+
+		it("excludes the managed bundle from user certs", () => {
+			const managed = join(dir, "cli-node-extra-ca-certs.pem");
+			writeFileSync(managed, certUser);
+			expect(caCerts.readUserCerts(fs, path, managed, managed)).toEqual([]);
+		});
+
+		it("returns [] for empty value", () => {
+			expect(caCerts.readUserCerts(fs, path, null, null)).toEqual([]);
+		});
+	});
+
 	describe("buildBundle", () => {
-		it("merges user PEM before system certs", () => {
-			const merged = caCerts.buildBundle({
-				systemCerts: [certSystem],
-				userPem: certUser,
-			});
-			expect(merged).toBe(`${certUser}\n${certSystem}`);
+		it("merges user PEMs before system certs", () => {
+			expect(
+				caCerts.buildBundle({
+					systemCerts: [certSystem],
+					userPems: [certUser],
+				}),
+			).toBe(`${certUser}\n${certSystem}`);
 		});
 
 		it("inserts a separating newline so END/BEGIN markers do not fuse", () => {
+			// certUser has no trailing newline, so this proves the boundary fix.
 			const merged = caCerts.buildBundle({
 				systemCerts: [certSystem],
-				userPem: certUser,
+				userPems: [certUser],
 			});
 			expect(merged).not.toContain(
 				"-----END CERTIFICATE----------BEGIN CERTIFICATE-----",
 			);
 		});
 
-		it("handles no user PEM", () => {
-			expect(
-				caCerts.buildBundle({ systemCerts: [certSystem], userPem: null }),
-			).toBe(certSystem);
+		it("handles no user PEMs", () => {
+			expect(caCerts.buildBundle({ systemCerts: [certSystem] })).toBe(
+				certSystem,
+			);
 		});
 	});
 
@@ -114,9 +162,10 @@ describe("ca-certs", () => {
 			const out = caCerts.configureNodeExtraCaCerts(env, {
 				tls: fakeTls([certSystem]),
 			});
-			expect(out).toBe(join(dir, "cli-node-extra-ca-certs.pem"));
-			expect(env.NODE_EXTRA_CA_CERTS).toBe(out);
-			expect(readFileSync(out as string, "utf8")).toContain("SYSTEM");
+			expect(out.action).toBe("written");
+			expect(out.path).toBe(join(dir, "cli-node-extra-ca-certs.pem"));
+			expect(env.NODE_EXTRA_CA_CERTS).toBe(out.path);
+			expect(readFileSync(out.path as string, "utf8")).toContain("SYSTEM");
 		});
 
 		it("merges a user-supplied NODE_EXTRA_CA_CERTS with system certs", () => {
@@ -126,38 +175,71 @@ describe("ca-certs", () => {
 				CLINE_DIR: dir,
 				NODE_EXTRA_CA_CERTS: userPath,
 			};
-			caCerts.configureNodeExtraCaCerts(env, { tls: fakeTls([certSystem]) });
+			const out = caCerts.configureNodeExtraCaCerts(env, {
+				tls: fakeTls([certSystem]),
+			});
+			expect(out.userCertCount).toBe(1);
 			const written = readFileSync(env.NODE_EXTRA_CA_CERTS, "utf8");
 			expect(written).toContain("USER");
 			expect(written).toContain("SYSTEM");
+		});
+
+		it("reports unchanged and skips rewrite on the second run", () => {
+			const env: Record<string, string> = { CLINE_DIR: dir };
+			expect(
+				caCerts.configureNodeExtraCaCerts(env, { tls: fakeTls([certSystem]) })
+					.action,
+			).toBe("written");
+			expect(
+				caCerts.configureNodeExtraCaCerts(env, { tls: fakeTls([certSystem]) })
+					.action,
+			).toBe("unchanged");
 		});
 
 		it("does not re-append when the user already points at the managed bundle", () => {
 			const env: Record<string, string> = { CLINE_DIR: dir };
 			const first = caCerts.configureNodeExtraCaCerts(env, {
 				tls: fakeTls([certSystem]),
-			}) as string;
-			// Second launch with NODE_EXTRA_CA_CERTS set to our own managed file.
+			}).path as string;
 			const env2: Record<string, string> = {
 				CLINE_DIR: dir,
 				NODE_EXTRA_CA_CERTS: first,
 			};
 			caCerts.configureNodeExtraCaCerts(env2, { tls: fakeTls([certSystem]) });
 			const written = readFileSync(env2.NODE_EXTRA_CA_CERTS, "utf8");
-			// Exactly one SYSTEM block, not duplicated.
 			expect(written.match(/SYSTEM/g)?.length).toBe(1);
 		});
 
-		it("leaves the env untouched when no system certs are available", () => {
+		it("no-ops when no system certs are available", () => {
 			const env: Record<string, string> = {
 				CLINE_DIR: dir,
 				NODE_EXTRA_CA_CERTS: "/user/corp.pem",
 			};
-			const out = caCerts.configureNodeExtraCaCerts(env, {
-				tls: fakeTls([]),
-			});
-			expect(out).toBeNull();
+			const out = caCerts.configureNodeExtraCaCerts(env, { tls: fakeTls([]) });
+			expect(out.action).toBe("no-system-certs");
+			expect(out.path).toBeNull();
 			expect(env.NODE_EXTRA_CA_CERTS).toBe("/user/corp.pem");
+		});
+
+		it("reports write-failed when the bundle cannot be written", () => {
+			const realFs = require("node:fs");
+			const failingFs = {
+				...realFs,
+				mkdirSync: () => {
+					throw new Error("EACCES");
+				},
+				writeFileSync: () => {
+					throw new Error("EACCES");
+				},
+			};
+			const env: Record<string, string> = { CLINE_DIR: dir };
+			const out = caCerts.configureNodeExtraCaCerts(env, {
+				tls: fakeTls([certSystem]),
+				fs: failingFs,
+			});
+			expect(out.action).toBe("write-failed");
+			expect(out.path).toBeNull();
+			expect(env.NODE_EXTRA_CA_CERTS).toBeUndefined();
 		});
 	});
 });

--- a/apps/vscode/src/shared/net.ts
+++ b/apps/vscode/src/shared/net.ts
@@ -61,8 +61,10 @@
  * JetBrains exports trusted certificates from the OS and writes them to a
  * temporary file, then configures node TLS by setting NODE_EXTRA_CA_CERTS.
  *
- * CLI users should set the NODE_EXTRA_CA_CERTS environment variable if
- * necessary, because node does not automatically use the OS' trusted certs.
+ * The CLI's npm wrapper (bin/cline) does the same automatically: it harvests
+ * the OS trust store and points the child's NODE_EXTRA_CA_CERTS at a managed
+ * bundle, because the Bun runtime does not read the OS store on its own. A
+ * user-set NODE_EXTRA_CA_CERTS is merged in rather than replaced.
  *
  * ## Limitations in JetBrains & CLI
  *


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

#### Auto-discover OS trust anchors in the CLI (corporate-CA / self-signed TLS)

##### Problem
On corporate networks with a TLS-inspecting proxy (or any self-signed/internal endpoint), the 3.x CLI fails inference with `unable to get local issuer certificate`. The pre-3.0 CLI ran on Node and users could lean on the OS trust store; the 3.x CLI ships as a Bun-compiled binary, and **Bun does not read the OS trust store**. Even `NODE_USE_SYSTEM_CA=1` is insufficient on Windows — Bun's enumeration covers only the `Root` store, not `CA`/Intermediate, where corporate GPO-pushed roots commonly land. The only workaround was to set `NODE_EXTRA_CA_CERTS` by hand. Reporter's ask: have it just work.
##### Fix
The npm `bin/cline` wrapper runs on the user's **Node**, not Bun, so it can read the full OS store before the Bun child starts. On launch it now:
1. Harvests OS trust anchors via `tls.getCACertificates("system")` (Node ≥ 22) — this reads **both** the Windows `Root` and `CA` stores, exactly the gap Bun has.
2. Merges them with any user-set `NODE_EXTRA_CA_CERTS` into a managed bundle (`~/.cline/cli-node-extra-ca-certs.pem`).
3. Points the child's `NODE_EXTRA_CA_CERTS` at that bundle — which both Bun and Node honor reliably.
This mirrors what the JetBrains plugin and VS Code already do (harvest OS trust → feed Node), sourcing from the OS store instead of an IDE trust manager. It is a CLI-only change; the SDK fetch-threading change is a separate, already-merged piece (Bun's global fetch is already proxy-aware, and the CLI's missing piece was trust material, not the fetch).
##### Behavior notes
- **Fail-safe:** any harvest/write error is swallowed and the launch proceeds on the runtime's default trust. When no OS certs are found, a user-set `NODE_EXTRA_CA_CERTS` is left untouched.
- **Merge, not replace:** if you already set `NODE_EXTRA_CA_CERTS`, your certs are merged *alongside* the system store rather than replacing it. This matches JetBrains' existing `CertificateBundleMerger` behavior. ⚠️ Reviewer call: this means a user who pinned a deliberately minimal CA set now also trusts the full OS store. Consistent across surfaces, but flagging it explicitly.
- **Legacy values:** a delimiter-joined `NODE_EXTRA_CA_CERTS="a.pem;b.pem"` (which Node never split) is now handled — tried as one file first, then split and each PEM merged — instead of being silently dropped.
- **Cheap:** the bundle is only rewritten when its contents change; steady-state launches do no extra write.
- **Diagnostics:** `CLINE_DEBUG=1` prints a one-line summary (OS + user cert counts, managed path) or a warning when nothing was harvested / the write failed.
##### Verification
- **Windows, real repro of the failing case:** test root installed only in `LocalMachine\CA` (Intermediate), 0 in `Root` — the exact layout where Bun's `NODE_USE_SYSTEM_CA` fails. Result: raw Bun → `UNABLE_TO_VERIFY_LEAF_SIGNATURE`; current wrapper → harvested `121 OS + 0 user CAs (written)`, child fetch `200 OK`. Exercised via `CLINE_BIN_PATH` against a Bun-compiled probe (the wrapper's real pre-exec path).
- 20 unit tests (`ca-certs.test.ts`) covering harvest filtering, single/delimited/missing-segment/managed-exclusion user-cert reads, newline-separated merge, unchanged-skip, and the write-failure outcome.
- biome clean, `tsc --noEmit` clean.
- Packaging confirmed: `publish-npm.ts` copies `bin/` wholesale and the wrapper package has no `files` allowlist, so `ca-certs.cjs` ships next to `bin/cline`.
##### Docs
- Updated the stale CLI guidance in `apps/vscode/src/shared/net.ts` (it told CLI users to set `NODE_EXTRA_CA_CERTS` manually).
- Added a "Certificate trust" section + `CLINE_DEBUG` to the CLI README, documenting auto-trust, the managed `~/.cline` bundle (safe to delete), and the merge-not-replace override.

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
