### PR TITLE
fix(cli): isolate history resume renderer ENG-2190

### DIFF
--- a/apps/cli/src/cli.interactive.e2e.test.ts
+++ b/apps/cli/src/cli.interactive.e2e.test.ts
@@ -51,15 +51,39 @@ function buildScriptCommand(scriptedInput: string, launchArgs: string): string {
 	return `(${scriptedInput}) | script ${quietFlag} /dev/null ${toShellSingleQuotedLiteral(bunExec)} ${launchArgs}`;
 }
 
-function runInteractiveCli(
-	steps: KeyStep[],
-	options?: { launchConfigView?: boolean },
-): CliResult {
+function createCliEnv(): NodeJS.ProcessEnv {
 	const homeDir = mkdtempSync(path.join(os.tmpdir(), "cli-int-home-"));
 	const dataDir = mkdtempSync(path.join(os.tmpdir(), "cli-int-data-"));
 	const sessionDir = mkdtempSync(path.join(os.tmpdir(), "cli-int-sessions-"));
 	const teamDir = mkdtempSync(path.join(os.tmpdir(), "cli-int-teams-"));
 	tempDirs.push(homeDir, dataDir, sessionDir, teamDir);
+
+	return {
+		...process.env,
+		HOME: homeDir,
+		CLINE_DATA_DIR: dataDir,
+		CLINE_DB_DATA_DIR: path.join(dataDir, "db"),
+		CLINE_SESSION_DATA_DIR: sessionDir,
+		CLINE_TEAM_DATA_DIR: teamDir,
+		CLINE_SESSION_BACKEND_MODE: "local",
+		CLINE_PROVIDER_SETTINGS_PATH: path.join(
+			dataDir,
+			"settings",
+			"providers.json",
+		),
+		CLINE_HOOKS_LOG_PATH: path.join(dataDir, "logs", "hooks.jsonl"),
+	};
+}
+
+function runInteractiveCli(
+	steps: KeyStep[],
+	options?: {
+		launchConfigView?: boolean;
+		launchArgs?: string[];
+		env?: NodeJS.ProcessEnv;
+	},
+): CliResult {
+	const env = options?.env ?? createCliEnv();
 
 	const scriptedInput = [
 		...steps,
@@ -80,9 +104,13 @@ function runInteractiveCli(
 		"-k",
 		"test-key",
 	];
-	const launchArgs = [
-		...(options?.launchConfigView ? [...baseArgs, "config"] : baseArgs),
-	]
+	const launchArgs = (
+		options?.launchArgs
+			? [cliEntry, ...options.launchArgs]
+			: options?.launchConfigView
+				? [...baseArgs, "config"]
+				: baseArgs
+	)
 		.map((arg) => toShellSingleQuotedLiteral(arg))
 		.join(" ");
 	const command = buildScriptCommand(scriptedInput, launchArgs);
@@ -90,21 +118,7 @@ function runInteractiveCli(
 	return spawnSync("bash", ["-lc", command], {
 		cwd: cliRoot,
 		encoding: "utf8",
-		env: {
-			...process.env,
-			HOME: homeDir,
-			CLINE_DATA_DIR: dataDir,
-			CLINE_DB_DATA_DIR: path.join(dataDir, "db"),
-			CLINE_SESSION_DATA_DIR: sessionDir,
-			CLINE_TEAM_DATA_DIR: teamDir,
-			CLINE_SESSION_BACKEND_MODE: "local",
-			CLINE_PROVIDER_SETTINGS_PATH: path.join(
-				dataDir,
-				"settings",
-				"providers.json",
-			),
-			CLINE_HOOKS_LOG_PATH: path.join(dataDir, "logs", "hooks.jsonl"),
-		},
+		env,
 		timeout: INTERACTIVE_TEST_TIMEOUT_MS,
 		maxBuffer: 10 * 1024 * 1024,
 	});
@@ -186,6 +200,52 @@ describe("cli interactive e2e", () => {
 			"Config mode: Tab tabs · ↑/↓ navigate · Esc close",
 		);
 		expect(output).toContain("/ for commands · @ for files");
+	});
+
+	it("resumes a history-picked session and survives Ctrl+C without a native crash", {
+		timeout: 120_000,
+	}, () => {
+		const env = createCliEnv();
+		// Seed one session; the invalid key makes the run fail fast while
+		// still persisting a resumable session record.
+		const seed = spawnSync(
+			bunExec,
+			[
+				cliEntry,
+				"--provider",
+				"anthropic",
+				"-m",
+				"claude-sonnet-4-6",
+				"-k",
+				"test-key",
+				"hello",
+			],
+			{ cwd: cliRoot, encoding: "utf8", env, timeout: 60_000 },
+		);
+		expect(seed.error).toBeUndefined();
+
+		// history picker -> Enter resumes the seeded session in the
+		// interactive TUI -> double Ctrl+C exits it. Regression guard for
+		// the Bun "panic(main thread): Segmentation fault" that occurred
+		// when the resumed TUI shared the picker's process (a second
+		// OpenTUI renderer in one process crashes natively on teardown).
+		const result = runInteractiveCli(
+			[
+				// Select the seeded session in the picker.
+				{ delaySeconds: 4.0, input: "\r" },
+				// Give the resumed TUI time to start, then double-press
+				// Ctrl+C; the harness appends the final press 0.2s later.
+				{ delaySeconds: 10.0, input: "\u0003" },
+			],
+			{ launchArgs: ["history"], env },
+		);
+		const output = outputOf(result);
+		// The exit summary only prints after the resumed interactive TUI ran
+		// and shut down cleanly; the history picker alone never prints it.
+		expect(output).toContain("Session Summary");
+		expect(output).not.toContain("panic(");
+		expect(output).not.toContain("Segmentation fault");
+		expect(result.status).toBe(0);
 	});
 
 	it("launches config view directly with `cline config`", () => {

--- a/apps/cli/src/cli.interactive.e2e.test.ts
+++ b/apps/cli/src/cli.interactive.e2e.test.ts
@@ -18,6 +18,8 @@ interface KeyStep {
 const INITIAL_RENDER_DELAY_SECONDS = 2.5;
 const POST_ACTION_SETTLE_SECONDS = 1.0;
 const INTERACTIVE_TEST_TIMEOUT_MS = 40_000;
+const HISTORY_PICKER_READY_DELAY_SECONDS = 8.0;
+const HISTORY_RESUME_READY_DELAY_SECONDS = 15.0;
 
 function normalizeTerminalOutput(output: string): string {
 	// biome-ignore lint/suspicious/noControlCharactersInRegex: this regex intentionally strips ANSI escape sequences
@@ -223,6 +225,16 @@ describe("cli interactive e2e", () => {
 			{ cwd: cliRoot, encoding: "utf8", env, timeout: 60_000 },
 		);
 		expect(seed.error).toBeUndefined();
+		const history = spawnSync(bunExec, [cliEntry, "history", "--json"], {
+			cwd: cliRoot,
+			encoding: "utf8",
+			env,
+			timeout: 60_000,
+		});
+		expect(history.error).toBeUndefined();
+		expect(history.status).toBe(0);
+		const historyRows = JSON.parse(history.stdout) as unknown[];
+		expect(historyRows.length).toBeGreaterThan(0);
 
 		// history picker -> Enter resumes the seeded session in the
 		// interactive TUI -> double Ctrl+C exits it. Regression guard for
@@ -232,10 +244,10 @@ describe("cli interactive e2e", () => {
 		const result = runInteractiveCli(
 			[
 				// Select the seeded session in the picker.
-				{ delaySeconds: 4.0, input: "\r" },
+				{ delaySeconds: HISTORY_PICKER_READY_DELAY_SECONDS, input: "\r" },
 				// Give the resumed TUI time to start, then double-press
 				// Ctrl+C; the harness appends the final press 0.2s later.
-				{ delaySeconds: 10.0, input: "\u0003" },
+				{ delaySeconds: HISTORY_RESUME_READY_DELAY_SECONDS, input: "\u0003" },
 			],
 			{ launchArgs: ["history"], env },
 		);

--- a/apps/cli/src/main.test.ts
+++ b/apps/cli/src/main.test.ts
@@ -82,6 +82,11 @@ const historyMocks = vi.hoisted(() => ({
 	runHistoryExport: vi.fn(async () => 0),
 	runHistoryUpdate: vi.fn(async () => 0),
 }));
+const historyResumeMocks = vi.hoisted(() => ({
+	spawnHistoryResume: vi.fn<() => Promise<number | undefined>>(
+		async () => undefined,
+	),
+}));
 const loggingMocks = vi.hoisted(() => ({
 	createCliLoggerAdapter: vi.fn(() => ({
 		core: {
@@ -172,6 +177,7 @@ vi.mock("./commands/dashboard", () => dashboardMocks);
 vi.mock("./kanban-migration/notice", () => migrationNoticeMocks);
 vi.mock("./commands/update", () => updateMocks);
 vi.mock("./commands/history", () => historyMocks);
+vi.mock("./utils/history-resume", () => historyResumeMocks);
 vi.mock("./logging/adapter", () => loggingMocks);
 vi.mock("./utils/hub-runtime", () => hubRuntimeMocks);
 vi.mock("./utils/telemetry", () => telemetryMocks);
@@ -191,6 +197,8 @@ describe("runCli lightweight command dispatch", () => {
 		historyMocks.runHistoryExport.mockResolvedValue(0);
 		historyMocks.runHistoryUpdate.mockReset();
 		historyMocks.runHistoryUpdate.mockResolvedValue(0);
+		historyResumeMocks.spawnHistoryResume.mockReset();
+		historyResumeMocks.spawnHistoryResume.mockResolvedValue(undefined);
 		sessionMocks.getSessionRow.mockReset();
 		sessionMocks.getSessionRow.mockResolvedValue({
 			sessionId: "sess_123",
@@ -719,10 +727,47 @@ describe("runCli lightweight command dispatch", () => {
 		);
 	});
 
-	it("forces chat view when resuming from history picker", async () => {
+	it("resumes a history-picked session in a child process", async () => {
 		historyMocks.runHistoryList.mockImplementationOnce(
 			async () => "sess_from_history",
 		);
+		historyResumeMocks.spawnHistoryResume.mockResolvedValueOnce(0);
+		process.argv = ["bun", "src/index.ts", "history"];
+
+		const { runCli } = await import("./main");
+
+		await expect(runCli()).resolves.toBeUndefined();
+		expect(historyResumeMocks.spawnHistoryResume).toHaveBeenCalledTimes(1);
+		expect(historyResumeMocks.spawnHistoryResume).toHaveBeenCalledWith(
+			expect.objectContaining({
+				sessionId: "sess_from_history",
+				normalizedArgs: ["history"],
+				remainingArgs: ["history"],
+			}),
+		);
+		expect(runtimeMocks.runInteractive).not.toHaveBeenCalled();
+		expect(process.exitCode).toBe(0);
+	});
+
+	it("propagates the child exit code when resuming from history picker", async () => {
+		historyMocks.runHistoryList.mockImplementationOnce(
+			async () => "sess_from_history",
+		);
+		historyResumeMocks.spawnHistoryResume.mockResolvedValueOnce(3);
+		process.argv = ["bun", "src/index.ts", "history"];
+
+		const { runCli } = await import("./main");
+
+		await expect(runCli()).resolves.toBeUndefined();
+		expect(process.exitCode).toBe(3);
+		expect(runtimeMocks.runInteractive).not.toHaveBeenCalled();
+	});
+
+	it("forces chat view when the history-picker child cannot launch", async () => {
+		historyMocks.runHistoryList.mockImplementationOnce(
+			async () => "sess_from_history",
+		);
+		historyResumeMocks.spawnHistoryResume.mockResolvedValueOnce(undefined);
 		process.argv = ["bun", "src/index.ts", "history"];
 
 		const { runCli } = await import("./main");

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -663,6 +663,21 @@ export async function runCli(): Promise<void> {
 
 	let resumeSessionId: string | undefined = ctx.resumeSessionId;
 	if (resumeSessionId) {
+		// The history picker already created (and tore down) an OpenTUI renderer
+		// in this process; starting the interactive TUI here would create a
+		// second one, which can crash natively during teardown. Resume in a
+		// fresh `cline --id <session-id>` child process instead.
+		const { spawnHistoryResume } = await import("./utils/history-resume");
+		const childExitCode = await spawnHistoryResume({
+			sessionId: resumeSessionId,
+			normalizedArgs,
+			remainingArgs: program.args,
+			configDir,
+		});
+		if (childExitCode !== undefined) {
+			process.exitCode = childExitCode;
+			return;
+		}
 		args = {
 			...args,
 			interactive: true,

--- a/apps/cli/src/tui/history-standalone.tsx
+++ b/apps/cli/src/tui/history-standalone.tsx
@@ -17,7 +17,9 @@ export async function renderHistoryStandalone(input: {
 	});
 
 	return new Promise((resolve) => {
-		let settled = false;
+		let result: number | string = 0;
+		let resolved = false;
+		let destroyStarted = false;
 		let unmounted = false;
 		const root = createRoot(renderer);
 
@@ -29,23 +31,28 @@ export async function renderHistoryStandalone(input: {
 			root.unmount();
 		};
 
-		const settle = (value: number | string) => {
-			if (settled) {
-				return;
-			}
-			settled = true;
-			unmountRoot();
-			renderer.destroy();
-			resolve(value);
-		};
-
+		// Resolve only once teardown has finished, so callers never run while
+		// the renderer is still restoring the terminal.
 		renderer.on("destroy", () => {
 			unmountRoot();
-			if (!settled) {
-				settled = true;
-				resolve(0);
+			if (!resolved) {
+				resolved = true;
+				resolve(result);
 			}
 		});
+
+		const settle = (value: number | string) => {
+			if (destroyStarted) {
+				return;
+			}
+			destroyStarted = true;
+			result = value;
+			unmountRoot();
+			// Let OpenTUI finish parsing the current stdin batch before teardown.
+			queueMicrotask(() => {
+				renderer.destroy();
+			});
+		};
 
 		root.render(
 			React.createElement(HistoryStandaloneContent, {

--- a/apps/cli/src/utils/history-resume.test.ts
+++ b/apps/cli/src/utils/history-resume.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { buildHistoryResumeArgs } from "./history-resume";
+
+describe("buildHistoryResumeArgs", () => {
+	it("replaces the history subcommand with --id", () => {
+		expect(
+			buildHistoryResumeArgs({
+				sessionId: "sess_1",
+				normalizedArgs: ["history"],
+				remainingArgs: ["history"],
+			}),
+		).toEqual(["--id", "sess_1"]);
+	});
+
+	it("preserves global flags that precede the subcommand", () => {
+		expect(
+			buildHistoryResumeArgs({
+				sessionId: "sess_1",
+				normalizedArgs: [
+					"--data-dir",
+					"/tmp/data",
+					"-m",
+					"claude-sonnet-4-6",
+					"history",
+					"--limit",
+					"5",
+				],
+				remainingArgs: ["history", "--limit", "5"],
+			}),
+		).toEqual([
+			"--data-dir",
+			"/tmp/data",
+			"-m",
+			"claude-sonnet-4-6",
+			"--id",
+			"sess_1",
+		]);
+	});
+
+	it("keeps a global flag value that matches the subcommand alias", () => {
+		expect(
+			buildHistoryResumeArgs({
+				sessionId: "sess_1",
+				normalizedArgs: ["-m", "h", "h"],
+				remainingArgs: ["h"],
+			}),
+		).toEqual(["-m", "h", "--id", "sess_1"]);
+	});
+
+	it("forwards a config dir passed as a subcommand option", () => {
+		expect(
+			buildHistoryResumeArgs({
+				sessionId: "sess_1",
+				normalizedArgs: ["history", "--config", "/tmp/conf"],
+				remainingArgs: ["history", "--config", "/tmp/conf"],
+				configDir: "/tmp/conf",
+			}),
+		).toEqual(["--config", "/tmp/conf", "--id", "sess_1"]);
+	});
+
+	it("does not duplicate a config dir already in the global flags", () => {
+		expect(
+			buildHistoryResumeArgs({
+				sessionId: "sess_1",
+				normalizedArgs: ["--config", "/tmp/conf", "history"],
+				remainingArgs: ["history"],
+				configDir: "/tmp/conf",
+			}),
+		).toEqual(["--config", "/tmp/conf", "--id", "sess_1"]);
+	});
+
+	it("recognizes the --config=<dir> spelling in global flags", () => {
+		expect(
+			buildHistoryResumeArgs({
+				sessionId: "sess_1",
+				normalizedArgs: ["--config=/tmp/conf", "history"],
+				remainingArgs: ["history"],
+				configDir: "/tmp/conf",
+			}),
+		).toEqual(["--config=/tmp/conf", "--id", "sess_1"]);
+	});
+
+	it("returns undefined when remaining args are not a suffix of argv", () => {
+		expect(
+			buildHistoryResumeArgs({
+				sessionId: "sess_1",
+				normalizedArgs: ["history", "--limit", "5"],
+				remainingArgs: ["history", "--limit", "9"],
+			}),
+		).toBeUndefined();
+		expect(
+			buildHistoryResumeArgs({
+				sessionId: "sess_1",
+				normalizedArgs: ["history"],
+				remainingArgs: ["extra", "history"],
+			}),
+		).toBeUndefined();
+	});
+});

--- a/apps/cli/src/utils/history-resume.ts
+++ b/apps/cli/src/utils/history-resume.ts
@@ -98,21 +98,15 @@ export async function spawnHistoryResume(
 			resolve(undefined);
 			return;
 		}
-		const onSigint = () => {
-			try {
-				child.kill("SIGINT");
-			} catch {}
-		};
-		const onSigterm = () => {
-			try {
-				child.kill("SIGTERM");
-			} catch {}
-		};
-		process.on("SIGINT", onSigint);
-		process.on("SIGTERM", onSigterm);
+		// The child shares this foreground process group, so terminal-generated
+		// Ctrl+C already reaches it. Keep the parent alive to reap the child
+		// without re-forwarding a second signal into the TUI teardown path.
+		const suppressParentSignal = () => {};
+		process.on("SIGINT", suppressParentSignal);
+		process.on("SIGTERM", suppressParentSignal);
 		const finish = (value: number | undefined) => {
-			process.off("SIGINT", onSigint);
-			process.off("SIGTERM", onSigterm);
+			process.off("SIGINT", suppressParentSignal);
+			process.off("SIGTERM", suppressParentSignal);
 			resolve(value);
 		};
 		child.once("error", () => finish(undefined));

--- a/apps/cli/src/utils/history-resume.ts
+++ b/apps/cli/src/utils/history-resume.ts
@@ -1,0 +1,121 @@
+import { resolveCliLaunchSpec } from "./internal-launch";
+
+export interface HistoryResumeCommand {
+	launcher: string;
+	childArgs: string[];
+}
+
+export interface BuildHistoryResumeArgsInput {
+	sessionId: string;
+	/** Full normalized CLI args (process.argv.slice(2) after normalization). */
+	normalizedArgs: string[];
+	/**
+	 * Commander's `program.args` after parsing: the `history` subcommand token
+	 * and everything following it. Must be a suffix of `normalizedArgs`.
+	 */
+	remainingArgs: string[];
+	/**
+	 * Config dir resolved from the full argv. Forwarded explicitly because
+	 * `--config` may have been passed as a `history` subcommand option, which
+	 * would otherwise be dropped with the rest of the subcommand args.
+	 */
+	configDir?: string;
+}
+
+/**
+ * Builds argv for relaunching the CLI as `cline <globalFlags> --id <sessionId>`
+ * after a session is picked in `cline history`. Returns undefined when the
+ * global-flag prefix cannot be derived safely (caller falls back to resuming
+ * in-process).
+ */
+export function buildHistoryResumeArgs(
+	input: BuildHistoryResumeArgsInput,
+): string[] | undefined {
+	const { sessionId, normalizedArgs, remainingArgs, configDir } = input;
+	const splitIndex = normalizedArgs.length - remainingArgs.length;
+	if (splitIndex < 0) {
+		return undefined;
+	}
+	for (let i = 0; i < remainingArgs.length; i++) {
+		if (normalizedArgs[splitIndex + i] !== remainingArgs[i]) {
+			return undefined;
+		}
+	}
+	const globalArgs = normalizedArgs.slice(0, splitIndex);
+	const args = [...globalArgs];
+	const hasConfigFlag = globalArgs.some(
+		(arg) => arg === "--config" || arg.startsWith("--config="),
+	);
+	if (configDir && !hasConfigFlag) {
+		args.push("--config", configDir);
+	}
+	args.push("--id", sessionId);
+	return args;
+}
+
+export function buildHistoryResumeCommand(
+	input: BuildHistoryResumeArgsInput,
+): HistoryResumeCommand | undefined {
+	const childArgs = buildHistoryResumeArgs(input);
+	if (!childArgs) {
+		return undefined;
+	}
+	const spec = resolveCliLaunchSpec();
+	if (!spec) {
+		return undefined;
+	}
+	return {
+		launcher: spec.launcher,
+		childArgs: [...spec.childArgsPrefix, ...childArgs],
+	};
+}
+
+/**
+ * Resumes a history-picked session in a fresh `cline --id <sessionId>` child
+ * process with inherited stdio, and returns its exit code. Creating a second
+ * OpenTUI renderer in the picker's process can crash natively during teardown
+ * (Bun "panic(main thread): Segmentation fault" on Ctrl+C), so the resumed
+ * interactive TUI must get a process of its own.
+ *
+ * Returns undefined when the child cannot be launched; the caller should fall
+ * back to resuming in-process.
+ */
+export async function spawnHistoryResume(
+	input: BuildHistoryResumeArgsInput,
+): Promise<number | undefined> {
+	const command = buildHistoryResumeCommand(input);
+	if (!command) {
+		return undefined;
+	}
+	const { spawn } = await import("node:child_process");
+	return await new Promise<number | undefined>((resolve) => {
+		let child: ReturnType<typeof spawn>;
+		try {
+			child = spawn(command.launcher, command.childArgs, {
+				stdio: "inherit",
+			});
+		} catch {
+			resolve(undefined);
+			return;
+		}
+		const onSigint = () => {
+			try {
+				child.kill("SIGINT");
+			} catch {}
+		};
+		const onSigterm = () => {
+			try {
+				child.kill("SIGTERM");
+			} catch {}
+		};
+		process.on("SIGINT", onSigint);
+		process.on("SIGTERM", onSigterm);
+		const finish = (value: number | undefined) => {
+			process.off("SIGINT", onSigint);
+			process.off("SIGTERM", onSigterm);
+			resolve(value);
+		};
+		child.once("error", () => finish(undefined));
+		child.once("exit", (code, signal) => finish(signal ? 1 : (code ?? 0)));
+	});
+}


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Fixes a CLI crash when resuming a session from `cline history` and then exiting the resumed TUI with Ctrl+C.

The history picker uses OpenTUI, and the previous flow started the resumed interactive TUI in the same Bun process after the picker returned. That could create a second OpenTUI renderer in one process and crash during native teardown. This change resumes the selected session by relaunching the CLI as `cline --id <sessionId>` in a child process with inherited stdio, preserving global flags and forwarding `--config` when it was supplied to the history command.

The history picker teardown also now mirrors the main TUI teardown path by unmounting first, destroying on a microtask, and resolving only after the renderer emits `destroy`.

### Test Procedure

- Ran focused unit coverage for history resume argument reconstruction and main history-picker dispatch:

```sh
bunx vitest run --config vitest.config.ts src/utils/history-resume.test.ts src/main.test.ts -t "buildHistoryResumeArgs|history-picked|child exit code|child cannot launch"
```

Result: 2 test files passed, 10 tests passed.

- Added an interactive regression test that seeds a local session, opens `cline history`, selects the session, exits the resumed TUI with Ctrl+C, and asserts that no Bun panic or segmentation fault is printed.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - CLI process-lifecycle fix.

### Additional Notes

Full test/lint suites were not run locally. The initial commit attempt hit a local pre-commit setup issue before dependencies were installed (`lint-staged: command not found`); after `bun install --frozen-lockfile`, the focused tests above passed.
