### PR TITLE
feat(cli): wire up agent profile tools, skills, provider, and model for the main agent

### DIFF
--- a/apps/cli/src/main.test.ts
+++ b/apps/cli/src/main.test.ts
@@ -6,6 +6,10 @@ interface MockConfiguredAgentConfig {
 	name: string;
 	description: string;
 	systemPrompt: string;
+	tools?: string[];
+	skills?: string[];
+	providerId?: string;
+	modelId?: string;
 	path?: string;
 }
 
@@ -41,6 +45,7 @@ const authMocks = vi.hoisted(() => ({
 	ensureOAuthProviderApiKey: vi.fn(),
 	getPersistedProviderApiKey: vi.fn(() => undefined),
 	isOAuthProvider: vi.fn(() => false),
+	isProviderConfigured: vi.fn(() => true),
 	normalizeProviderId: vi.fn((providerId?: string) => providerId ?? "cline"),
 	parseAuthCommandArgs: vi.fn(),
 	runAuthCommand: vi.fn(),
@@ -93,7 +98,7 @@ const updateMocks = vi.hoisted(() => ({
 	getPreferredKanbanInstaller: vi.fn(() => undefined),
 }));
 const runtimeMocks = vi.hoisted(() => ({
-	runAgent: vi.fn(async () => {
+	runAgent: vi.fn(async (..._args: unknown[]) => {
 		mockState.runAgentCalls += 1;
 	}),
 	runInteractive: vi.fn(),
@@ -164,8 +169,14 @@ vi.mock("./runtime/run-interactive", () => {
 });
 vi.mock("./utils/session", () => sessionMocks);
 vi.mock("./session/session", () => sessionMocks);
-vi.mock("@cline/core", () => {
+vi.mock("@cline/core", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@cline/core")>();
 	return {
+		// Pure helpers backing the profile tools restriction; the real
+		// implementations keep the disable-list derivation honest.
+		getCoreBuiltinToolCatalog: actual.getCoreBuiltinToolCatalog,
+		resolveConfiguredAgentAllowedToolNames:
+			actual.resolveConfiguredAgentAllowedToolNames,
 		resolveProviderConfig: llmMocks.resolveProviderConfig,
 		loadConfiguredAgentConfigs: agentConfigMocks.loadConfiguredAgentConfigs,
 		createTeamName: vi.fn(() => "team-test"),
@@ -251,6 +262,8 @@ describe("runCli lightweight command dispatch", () => {
 		authMocks.getPersistedProviderApiKey.mockReturnValue(undefined);
 		authMocks.isOAuthProvider.mockReset();
 		authMocks.isOAuthProvider.mockReturnValue(false);
+		authMocks.isProviderConfigured.mockReset();
+		authMocks.isProviderConfigured.mockReturnValue(true);
 		authMocks.normalizeProviderId.mockReset();
 		authMocks.normalizeProviderId.mockImplementation(
 			(providerId?: string) => providerId ?? "cline",
@@ -1009,6 +1022,131 @@ describe("runCli lightweight command dispatch", () => {
 		expect(process.exitCode).toBe(1);
 		expect(runtimeMocks.runAgent).not.toHaveBeenCalled();
 		expect(runtimeMocks.runInteractive).not.toHaveBeenCalled();
+	});
+
+	it("applies a profile's provider, model, tools, and skills to prompt runs", async () => {
+		agentConfigMocks.loadConfiguredAgentConfigs.mockReturnValue({
+			configs: [
+				{
+					name: "Reviewer",
+					description: "Reviews code",
+					systemPrompt: "You are a reviewer.",
+					tools: ["read_files", "search_codebase"],
+					skills: ["review-pr"],
+					providerId: "openai",
+					modelId: "openai/gpt-test",
+					path: "/repo/.cline/agents/reviewer.yaml",
+				},
+			],
+			errors: [],
+		});
+		providerSettingsMocks.saveProviderSettings.mockClear();
+		forcePromptModeInput();
+		process.argv = ["bun", "src/index.ts", "--agent", "reviewer", "hello"];
+
+		const { runCli } = await import("./main");
+
+		await expect(runCli()).resolves.toBeUndefined();
+		expect(runtimeMocks.runAgent).toHaveBeenCalledWith(
+			"hello",
+			expect.objectContaining({
+				providerId: "openai",
+				modelId: "openai/gpt-test",
+				skills: ["review-pr"],
+				disabledToolNames: expect.arrayContaining([
+					"run_commands",
+					"editor",
+					"fetch_web_content",
+					"spawn_agent",
+				]),
+			}),
+			expect.anything(),
+		);
+		const runConfig = runtimeMocks.runAgent.mock.calls.at(-1)?.[1] as {
+			disabledToolNames?: string[];
+		};
+		expect(runConfig.disabledToolNames).not.toContain("read_files");
+		expect(runConfig.disabledToolNames).not.toContain("search_codebase");
+		// Skills tool stays available because the profile lists skills.
+		expect(runConfig.disabledToolNames).not.toContain("skills");
+		// A profile-driven provider is never persisted as the user's selection.
+		expect(providerSettingsMocks.saveProviderSettings).not.toHaveBeenCalled();
+	});
+
+	it("lets explicit --provider and --model beat the profile's provider and model", async () => {
+		agentConfigMocks.loadConfiguredAgentConfigs.mockReturnValue({
+			configs: [
+				{
+					name: "Reviewer",
+					description: "Reviews code",
+					systemPrompt: "You are a reviewer.",
+					providerId: "openai",
+					modelId: "openai/gpt-test",
+					path: "/repo/.cline/agents/reviewer.yaml",
+				},
+			],
+			errors: [],
+		});
+		forcePromptModeInput();
+		process.argv = [
+			"bun",
+			"src/index.ts",
+			"--agent",
+			"reviewer",
+			"--provider",
+			"anthropic",
+			"--model",
+			"anthropic/claude-sonnet-4.6",
+			"hello",
+		];
+
+		const { runCli } = await import("./main");
+
+		await expect(runCli()).resolves.toBeUndefined();
+		expect(runtimeMocks.runAgent).toHaveBeenCalledWith(
+			"hello",
+			expect.objectContaining({
+				providerId: "anthropic",
+				modelId: "anthropic/claude-sonnet-4.6",
+			}),
+			expect.anything(),
+		);
+	});
+
+	it("keeps the user's provider when the profile's provider is not configured", async () => {
+		agentConfigMocks.loadConfiguredAgentConfigs.mockReturnValue({
+			configs: [
+				{
+					name: "Reviewer",
+					description: "Reviews code",
+					systemPrompt: "You are a reviewer.",
+					providerId: "groq",
+					modelId: "groq/some-model",
+					path: "/repo/.cline/agents/reviewer.yaml",
+				},
+			],
+			errors: [],
+		});
+		authMocks.isProviderConfigured.mockReturnValue(false);
+		forcePromptModeInput();
+		process.argv = ["bun", "src/index.ts", "--agent", "reviewer", "hello"];
+
+		const { runCli } = await import("./main");
+
+		await expect(runCli()).resolves.toBeUndefined();
+		expect(runtimeMocks.runAgent).toHaveBeenCalledWith(
+			"hello",
+			expect.objectContaining({
+				providerId: "cline",
+				agentProfile: expect.objectContaining({ name: "Reviewer" }),
+			}),
+			expect.anything(),
+		);
+		const runConfig = runtimeMocks.runAgent.mock.calls.at(-1)?.[1] as {
+			modelId: string;
+		};
+		// The profile's model belongs to its unconfigured provider; ignore it.
+		expect(runConfig.modelId).not.toBe("groq/some-model");
 	});
 
 	it("rejects --agent in yolo mode before loading profiles", async () => {

--- a/apps/cli/src/main.test.ts
+++ b/apps/cli/src/main.test.ts
@@ -44,6 +44,7 @@ const mockState = vi.hoisted(() => ({
 const authMocks = vi.hoisted(() => ({
 	ensureOAuthProviderApiKey: vi.fn(),
 	getPersistedProviderApiKey: vi.fn(() => undefined),
+	hasEnvProviderApiKey: vi.fn(() => false),
 	isOAuthProvider: vi.fn(() => false),
 	isProviderConfigured: vi.fn(() => true),
 	normalizeProviderId: vi.fn((providerId?: string) => providerId ?? "cline"),
@@ -264,6 +265,8 @@ describe("runCli lightweight command dispatch", () => {
 		authMocks.isOAuthProvider.mockReturnValue(false);
 		authMocks.isProviderConfigured.mockReset();
 		authMocks.isProviderConfigured.mockReturnValue(true);
+		authMocks.hasEnvProviderApiKey.mockReset();
+		authMocks.hasEnvProviderApiKey.mockReturnValue(false);
 		authMocks.normalizeProviderId.mockReset();
 		authMocks.normalizeProviderId.mockImplementation(
 			(providerId?: string) => providerId ?? "cline",

--- a/apps/cli/src/main.test.ts
+++ b/apps/cli/src/main.test.ts
@@ -1152,6 +1152,50 @@ describe("runCli lightweight command dispatch", () => {
 		expect(runConfig.modelId).not.toBe("groq/some-model");
 	});
 
+	it("treats an explicit --key as credentials for the profile's provider and persists nothing", async () => {
+		agentConfigMocks.loadConfiguredAgentConfigs.mockReturnValue({
+			configs: [
+				{
+					name: "Reviewer",
+					description: "Reviews code",
+					systemPrompt: "You are a reviewer.",
+					providerId: "groq",
+					modelId: "groq/some-model",
+					path: "/repo/.cline/agents/reviewer.yaml",
+				},
+			],
+			errors: [],
+		});
+		// The provider has no stored credentials; only the --key flag supplies one.
+		authMocks.isProviderConfigured.mockReturnValue(false);
+		providerSettingsMocks.saveProviderSettings.mockClear();
+		forcePromptModeInput();
+		process.argv = [
+			"bun",
+			"src/index.ts",
+			"--agent",
+			"reviewer",
+			"--key",
+			"groq-key",
+			"hello",
+		];
+
+		const { runCli } = await import("./main");
+
+		await expect(runCli()).resolves.toBeUndefined();
+		expect(runtimeMocks.runAgent).toHaveBeenCalledWith(
+			"hello",
+			expect.objectContaining({
+				providerId: "groq",
+				modelId: "groq/some-model",
+				apiKey: "groq-key",
+			}),
+			expect.anything(),
+		);
+		// The --key must not leak into another provider's persisted settings.
+		expect(providerSettingsMocks.saveProviderSettings).not.toHaveBeenCalled();
+	});
+
 	it("rejects --agent in yolo mode before loading profiles", async () => {
 		forcePromptModeInput();
 		process.argv = [

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -972,10 +972,14 @@ export async function runCli(): Promise<void> {
 		);
 		let selectedProviderSettings =
 			providerSettingsManager.getProviderSettings(provider);
-		// Env-declared API keys count as credentials: request paths resolve
-		// them at runtime even when no settings are persisted.
+		// Env-declared API keys count as credentials (request paths resolve
+		// them at runtime even when no settings are persisted), and so does an
+		// explicit --key: with a key in hand the profile's provider is usable,
+		// and skipping the fail-soft keeps that key from being persisted into
+		// the fallback provider's settings below.
 		if (
 			providerFromProfile &&
+			!args.key?.trim() &&
 			!isProviderConfigured(provider, selectedProviderSettings) &&
 			!hasEnvProviderApiKey(provider)
 		) {

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -15,6 +15,7 @@ import {
 	getPreferredKanbanInstaller,
 } from "./commands/update";
 import { resolveAgentProfileDisabledPluginPaths } from "./runtime/agent-profile-plugins";
+import { resolveAgentProfileDisabledToolNames } from "./runtime/agent-profile-tools";
 import { CLI_DEFAULT_CHECKPOINT_CONFIG } from "./runtime/defaults";
 import {
 	buildCliCompactionConfig,
@@ -36,6 +37,7 @@ import {
 	ensureOAuthProviderApiKey,
 	getPersistedProviderApiKey,
 	isOAuthProvider,
+	isProviderConfigured,
 	normalizeProviderId,
 } from "./utils/provider-auth";
 import { rewriteTeamPrompt, TEAM_COMMAND_USAGE } from "./utils/team-command";
@@ -902,22 +904,104 @@ export async function runCli(): Promise<void> {
 	};
 	registerDisposable(stopUserInstructionService);
 	try {
+		const isYoloMode = args.mode === "yolo";
+		const isZenMode = args.mode === "zen";
+
+		// Resolved before the provider so the profile's providerId/modelId can
+		// participate in provider selection below.
+		let activeAgentProfile: ActiveAgentProfile | undefined;
+		const requestedAgentName = args.agent?.trim();
+		if (requestedAgentName) {
+			if (isYoloMode) {
+				writeErr("--agent is not supported in yolo mode");
+				process.exitCode = 1;
+				return;
+			}
+			if (args.systemPrompt) {
+				// Don't store an unused profile: it would resurface on plan/act toggles.
+				writeln(
+					`${c.dim}[warn] --system overrides --agent; ignoring agent profile "${requestedAgentName}"${c.reset}`,
+				);
+			} else {
+				const { loadConfiguredAgentConfigs } = await import("@cline/core");
+				const { configs, errors } = loadConfiguredAgentConfigs({
+					workspaceRoot,
+				});
+				const profile = configs.find(
+					(candidate) =>
+						candidate.name.trim().toLowerCase() ===
+						requestedAgentName.toLowerCase(),
+				);
+				if (!profile) {
+					const availableNames = configs.map((candidate) => candidate.name);
+					writeErr(
+						availableNames.length > 0
+							? `agent profile "${requestedAgentName}" not found (available: ${availableNames.join(", ")})`
+							: `agent profile "${requestedAgentName}" not found (no agent profiles in .cline/agents)`,
+					);
+					for (const error of errors) {
+						writeErr(`failed to load ${error.path}: ${error.error.message}`);
+					}
+					process.exitCode = 1;
+					return;
+				}
+				activeAgentProfile = {
+					name: profile.name,
+					systemPrompt: profile.systemPrompt,
+					plugins: profile.plugins?.map((plugin) => plugin.name),
+					tools: profile.tools,
+					skills: profile.skills,
+					providerId: profile.providerId,
+					modelId: profile.modelId,
+				};
+			}
+		}
+
 		const lastUsedProviderSettings =
 			providerSettingsManager.getLastUsedProviderSettings();
-		const provider = normalizeProviderId(
-			args.provider?.trim() || lastUsedProviderSettings?.provider || "cline",
+		// Provider precedence: explicit --provider, then the profile's
+		// providerId, then the persisted last-used selection.
+		let providerFromProfile =
+			!args.provider?.trim() && !!activeAgentProfile?.providerId;
+		let provider = normalizeProviderId(
+			args.provider?.trim() ||
+				activeAgentProfile?.providerId ||
+				lastUsedProviderSettings?.provider ||
+				"cline",
 		);
 		let selectedProviderSettings =
 			providerSettingsManager.getProviderSettings(provider);
+		if (
+			providerFromProfile &&
+			!isProviderConfigured(provider, selectedProviderSettings)
+		) {
+			// Fail soft: keep the user's provider, the persona still applies.
+			const fallbackProvider = normalizeProviderId(
+				lastUsedProviderSettings?.provider || "cline",
+			);
+			writeln(
+				`${c.dim}[warn] agent profile "${activeAgentProfile?.name}" requests provider "${provider}" which is not configured; keeping ${fallbackProvider}${c.reset}`,
+			);
+			provider = fallbackProvider;
+			selectedProviderSettings =
+				providerSettingsManager.getProviderSettings(provider);
+			providerFromProfile = false;
+		}
+		// The profile's modelId only applies on the profile's intended provider
+		// (or the user's provider when the profile does not pin one).
+		const profileProviderApplied =
+			!activeAgentProfile?.providerId ||
+			provider === normalizeProviderId(activeAgentProfile.providerId);
+		const profileModelId = profileProviderApplied
+			? activeAgentProfile?.modelId
+			: undefined;
+		const modelFromProfile = !args.model && !!profileModelId;
 		const persistedApiKey = getPersistedProviderApiKey(
 			provider,
 			selectedProviderSettings,
 		);
 		const providedApiKey = args.key?.trim() || undefined;
 		let apiKey = providedApiKey || persistedApiKey || undefined;
-
-		const isYoloMode = args.mode === "yolo";
-		const isZenMode = args.mode === "zen";
 
 		// In headless mode (yolo / json / piped stdin without --tui),
 		// don't attempt browser-based OAuth. Authentication may still resolve at
@@ -970,6 +1054,14 @@ export async function runCli(): Promise<void> {
 			);
 		}
 		const knownModelIds = knownModels ? Object.keys(knownModels) : [];
+		// Model precedence: explicit --model, then the profile's modelId, then
+		// the provider's persisted selection.
+		const modelId =
+			args.model ??
+			profileModelId ??
+			selectedProviderSettings?.model ??
+			knownModelIds[0] ??
+			"anthropic/claude-sonnet-4.6";
 		const persistedReasoning = selectedProviderSettings?.reasoning;
 		const persistedReasoningEffort = persistedReasoning?.effort;
 		const reasoningEffortFromSettings =
@@ -994,57 +1086,9 @@ export async function runCli(): Promise<void> {
 			cwd,
 		});
 
-		let activeAgentProfile: ActiveAgentProfile | undefined;
-		const requestedAgentName = args.agent?.trim();
-		if (requestedAgentName) {
-			if (isYoloMode) {
-				writeErr("--agent is not supported in yolo mode");
-				process.exitCode = 1;
-				return;
-			}
-			if (args.systemPrompt) {
-				// Don't store an unused profile: it would resurface on plan/act toggles.
-				writeln(
-					`${c.dim}[warn] --system overrides --agent; ignoring agent profile "${requestedAgentName}"${c.reset}`,
-				);
-			} else {
-				const { loadConfiguredAgentConfigs } = await import("@cline/core");
-				const { configs, errors } = loadConfiguredAgentConfigs({
-					workspaceRoot,
-				});
-				const profile = configs.find(
-					(candidate) =>
-						candidate.name.trim().toLowerCase() ===
-						requestedAgentName.toLowerCase(),
-				);
-				if (!profile) {
-					const availableNames = configs.map((candidate) => candidate.name);
-					writeErr(
-						availableNames.length > 0
-							? `agent profile "${requestedAgentName}" not found (available: ${availableNames.join(", ")})`
-							: `agent profile "${requestedAgentName}" not found (no agent profiles in .cline/agents)`,
-					);
-					for (const error of errors) {
-						writeErr(`failed to load ${error.path}: ${error.error.message}`);
-					}
-					process.exitCode = 1;
-					return;
-				}
-				activeAgentProfile = {
-					name: profile.name,
-					systemPrompt: profile.systemPrompt,
-					plugins: profile.plugins?.map((plugin) => plugin.name),
-				};
-			}
-		}
-
 		const config: Config = {
 			providerId: provider,
-			modelId:
-				args.model ??
-				selectedProviderSettings?.model ??
-				knownModelIds[0] ??
-				"anthropic/claude-sonnet-4.6",
+			modelId,
 			apiKey: apiKey ?? "",
 			knownModels,
 			systemPrompt: await resolveSystemPrompt({
@@ -1080,6 +1124,15 @@ export async function runCli(): Promise<void> {
 				activeAgentProfile,
 				workspaceRoot,
 			),
+			disabledToolNames: resolveAgentProfileDisabledToolNames(
+				activeAgentProfile,
+				{
+					mode: args.mode ?? "act",
+					providerId: provider,
+					modelId,
+				},
+			),
+			skills: activeAgentProfile?.skills,
 			enableSpawnAgent: !isYoloMode,
 			enableAgentTeams: !isYoloMode,
 			enableTools: true,
@@ -1109,12 +1162,18 @@ export async function runCli(): Promise<void> {
 					: apiKey && !isOAuthProvider(provider)
 						? { apiKey }
 						: {};
-			providerSettingsManager.saveProviderSettings({
-				...(selectedProviderSettings ?? {}),
-				provider,
-				model: config.modelId,
-				...persistApiKey,
-			});
+			// A profile-driven provider/model is session-only: never write it into
+			// the user's persisted provider selection.
+			if (!providerFromProfile) {
+				providerSettingsManager.saveProviderSettings({
+					...(selectedProviderSettings ?? {}),
+					provider,
+					model: modelFromProfile
+						? selectedProviderSettings?.model
+						: config.modelId,
+					...persistApiKey,
+				});
+			}
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			writeln(

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -36,6 +36,7 @@ import {
 import {
 	ensureOAuthProviderApiKey,
 	getPersistedProviderApiKey,
+	hasEnvProviderApiKey,
 	isOAuthProvider,
 	isProviderConfigured,
 	normalizeProviderId,
@@ -971,9 +972,12 @@ export async function runCli(): Promise<void> {
 		);
 		let selectedProviderSettings =
 			providerSettingsManager.getProviderSettings(provider);
+		// Env-declared API keys count as credentials: request paths resolve
+		// them at runtime even when no settings are persisted.
 		if (
 			providerFromProfile &&
-			!isProviderConfigured(provider, selectedProviderSettings)
+			!isProviderConfigured(provider, selectedProviderSettings) &&
+			!hasEnvProviderApiKey(provider)
 		) {
 			// Fail soft: keep the user's provider, the persona still applies.
 			const fallbackProvider = normalizeProviderId(

--- a/apps/cli/src/runtime/agent-profile-model.test.ts
+++ b/apps/cli/src/runtime/agent-profile-model.test.ts
@@ -206,6 +206,31 @@ describe("applyAgentProfileModelSelection", () => {
 		expect(config.modelId).toBe(firstKnownModelId);
 	});
 
+	it("falls back to the provider's catalog default model when nothing else is available", async () => {
+		const root = await mkdtemp(join(tmpdir(), "cli-profile-model-"));
+		tempRoots.push(root);
+		const home = join(root, "home");
+		await mkdir(home, { recursive: true });
+		process.env.HOME = home;
+		setHomeDir(home);
+		process.env.CLINE_GLOBAL_SETTINGS_PATH = join(home, "global-settings.json");
+		// No persisted model, and the live config carries no known models.
+		new ProviderSettingsManager().saveProviderSettings({
+			provider: "anthropic",
+			apiKey: "anthropic-key",
+		});
+		const config = makeConfig({ knownModels: undefined });
+
+		const pinned = { modelId: "anthropic/claude-haiku-4.5" };
+		await applyAgentProfileModelSelection(config, pinned);
+		await applyAgentProfileModelSelection(config, undefined, {
+			previousProfile: pinned,
+		});
+
+		// Anthropic's catalog default, not the profile's pinned model.
+		expect(config.modelId).toBe("claude-sonnet-4-6");
+	});
+
 	it("accepts a profile provider configured only through its environment variable", async () => {
 		await setUpProviderSettings();
 		const previousEnv = process.env.OPENROUTER_API_KEY;

--- a/apps/cli/src/runtime/agent-profile-model.test.ts
+++ b/apps/cli/src/runtime/agent-profile-model.test.ts
@@ -177,6 +177,59 @@ describe("applyAgentProfileModelSelection", () => {
 		expect(config.modelId).toBe("anthropic/claude-sonnet-4.6");
 	});
 
+	it("does not leak a model-only profile's model past the revert when no model is persisted", async () => {
+		const root = await mkdtemp(join(tmpdir(), "cli-profile-model-"));
+		tempRoots.push(root);
+		const home = join(root, "home");
+		await mkdir(home, { recursive: true });
+		process.env.HOME = home;
+		setHomeDir(home);
+		process.env.CLINE_GLOBAL_SETTINGS_PATH = join(home, "global-settings.json");
+		// The user's provider settings carry no model selection.
+		new ProviderSettingsManager().saveProviderSettings({
+			provider: "anthropic",
+			apiKey: "anthropic-key",
+		});
+		const { Llms } = await import("@cline/core");
+		const knownModels = await Llms.getModelsForProvider("anthropic");
+		const firstKnownModelId = Object.keys(knownModels)[0];
+		const config = makeConfig({ knownModels, modelId: firstKnownModelId });
+
+		const pinned = { modelId: "anthropic/claude-haiku-4.5" };
+		await applyAgentProfileModelSelection(config, pinned);
+		expect(config.modelId).toBe("anthropic/claude-haiku-4.5");
+
+		await applyAgentProfileModelSelection(config, undefined, {
+			previousProfile: pinned,
+		});
+
+		expect(config.modelId).toBe(firstKnownModelId);
+	});
+
+	it("accepts a profile provider configured only through its environment variable", async () => {
+		await setUpProviderSettings();
+		const previousEnv = process.env.OPENROUTER_API_KEY;
+		process.env.OPENROUTER_API_KEY = "env-key";
+		try {
+			const config = makeConfig();
+
+			const result = await applyAgentProfileModelSelection(config, {
+				providerId: "openrouter",
+				modelId: "anthropic/claude-sonnet-4.6",
+			});
+
+			expect(result.warning).toBeUndefined();
+			expect(config.providerId).toBe("openrouter");
+			expect(config.modelId).toBe("anthropic/claude-sonnet-4.6");
+		} finally {
+			if (previousEnv === undefined) {
+				delete process.env.OPENROUTER_API_KEY;
+			} else {
+				process.env.OPENROUTER_API_KEY = previousEnv;
+			}
+		}
+	});
+
 	it("never writes the profile's selection into persisted provider settings", async () => {
 		await setUpProviderSettings();
 		const config = makeConfig();

--- a/apps/cli/src/runtime/agent-profile-model.test.ts
+++ b/apps/cli/src/runtime/agent-profile-model.test.ts
@@ -1,0 +1,194 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setHomeDir } from "@cline/shared/storage";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@cline/core", async (importOriginal) => {
+	const original = await importOriginal<typeof import("@cline/core")>();
+	return {
+		...original,
+		resolveProviderConfig: vi.fn(async () => ({
+			knownModels: {
+				"mock/model-a": { name: "Mock Model A" },
+				"mock/model-b": { name: "Mock Model B" },
+			},
+		})),
+	};
+});
+
+import { ProviderSettingsManager, resolveProviderConfig } from "@cline/core";
+import type { Config } from "../utils/types";
+import { applyAgentProfileModelSelection } from "./agent-profile-model";
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+	return {
+		providerId: "anthropic",
+		modelId: "anthropic/claude-sonnet-4.6",
+		apiKey: "anthropic-key",
+		systemPrompt: "test",
+		cwd: process.cwd(),
+		verbose: false,
+		sandbox: false,
+		thinking: false,
+		outputMode: "text",
+		mode: "act",
+		defaultToolAutoApprove: false,
+		toolPolicies: {},
+		enableTools: true,
+		enableSpawnAgent: false,
+		enableAgentTeams: false,
+		...overrides,
+	};
+}
+
+describe("applyAgentProfileModelSelection", () => {
+	const envSnapshot = {
+		HOME: process.env.HOME,
+		CLINE_GLOBAL_SETTINGS_PATH: process.env.CLINE_GLOBAL_SETTINGS_PATH,
+	};
+	const tempRoots: string[] = [];
+
+	afterEach(async () => {
+		process.env.HOME = envSnapshot.HOME;
+		process.env.CLINE_GLOBAL_SETTINGS_PATH =
+			envSnapshot.CLINE_GLOBAL_SETTINGS_PATH;
+		setHomeDir(envSnapshot.HOME ?? "~");
+		vi.clearAllMocks();
+		for (const root of tempRoots.splice(0)) {
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+
+	async function setUpProviderSettings(): Promise<void> {
+		const root = await mkdtemp(join(tmpdir(), "cli-profile-model-"));
+		tempRoots.push(root);
+		const home = join(root, "home");
+		await mkdir(home, { recursive: true });
+		process.env.HOME = home;
+		setHomeDir(home);
+		process.env.CLINE_GLOBAL_SETTINGS_PATH = join(home, "global-settings.json");
+
+		const manager = new ProviderSettingsManager();
+		manager.saveProviderSettings(
+			{
+				provider: "openai",
+				model: "openai/gpt-test",
+				apiKey: "openai-key",
+				reasoning: { enabled: true, effort: "high" },
+			},
+			{ setLastUsed: false },
+		);
+		// Saved last: anthropic is the user's persisted selection.
+		manager.saveProviderSettings({
+			provider: "anthropic",
+			model: "anthropic/claude-sonnet-4.6",
+			apiKey: "anthropic-key",
+		});
+	}
+
+	it("applies the profile's provider and model with its stored credentials", async () => {
+		await setUpProviderSettings();
+		const config = makeConfig();
+
+		const result = await applyAgentProfileModelSelection(config, {
+			providerId: "openai",
+			modelId: "openai/gpt-custom",
+		});
+
+		expect(result.warning).toBeUndefined();
+		expect(config.providerId).toBe("openai");
+		expect(config.modelId).toBe("openai/gpt-custom");
+		expect(config.apiKey).toBe("openai-key");
+		expect(config.knownModels).toMatchObject({ "mock/model-a": {} });
+		expect(config.thinking).toBe(true);
+		expect(config.reasoningEffort).toBe("high");
+	});
+
+	it("falls back to the profile provider's persisted model when the profile only pins a provider", async () => {
+		await setUpProviderSettings();
+		const config = makeConfig();
+
+		await applyAgentProfileModelSelection(config, { providerId: "openai" });
+
+		expect(config.providerId).toBe("openai");
+		expect(config.modelId).toBe("openai/gpt-test");
+	});
+
+	it("applies a model-only profile on the user's provider without provider resolution", async () => {
+		await setUpProviderSettings();
+		const config = makeConfig();
+
+		await applyAgentProfileModelSelection(config, {
+			modelId: "anthropic/claude-haiku-4.5",
+		});
+
+		expect(config.providerId).toBe("anthropic");
+		expect(config.modelId).toBe("anthropic/claude-haiku-4.5");
+		expect(config.apiKey).toBe("anthropic-key");
+		expect(resolveProviderConfig).not.toHaveBeenCalled();
+	});
+
+	it("warns and keeps the current selection when the profile provider is not configured", async () => {
+		await setUpProviderSettings();
+		const config = makeConfig();
+
+		const result = await applyAgentProfileModelSelection(config, {
+			providerId: "groq",
+			modelId: "groq/some-model",
+		});
+
+		expect(result.warning).toContain('"groq"');
+		expect(config.providerId).toBe("anthropic");
+		expect(config.modelId).toBe("anthropic/claude-sonnet-4.6");
+		expect(config.apiKey).toBe("anthropic-key");
+	});
+
+	it("restores the user's persisted selection when reverting to the default agent", async () => {
+		await setUpProviderSettings();
+		const config = makeConfig();
+
+		await applyAgentProfileModelSelection(config, {
+			providerId: "openai",
+			modelId: "openai/gpt-custom",
+		});
+		const result = await applyAgentProfileModelSelection(config, undefined);
+
+		expect(result.warning).toBeUndefined();
+		expect(config.providerId).toBe("anthropic");
+		expect(config.modelId).toBe("anthropic/claude-sonnet-4.6");
+		expect(config.apiKey).toBe("anthropic-key");
+		expect(config.thinking).toBe(false);
+		expect(config.reasoningEffort).toBeUndefined();
+	});
+
+	it("restores the persisted selection when switching to a profile without provider or model fields", async () => {
+		await setUpProviderSettings();
+		const config = makeConfig();
+
+		await applyAgentProfileModelSelection(config, {
+			providerId: "openai",
+			modelId: "openai/gpt-custom",
+		});
+		await applyAgentProfileModelSelection(config, {});
+
+		expect(config.providerId).toBe("anthropic");
+		expect(config.modelId).toBe("anthropic/claude-sonnet-4.6");
+	});
+
+	it("never writes the profile's selection into persisted provider settings", async () => {
+		await setUpProviderSettings();
+		const config = makeConfig();
+
+		await applyAgentProfileModelSelection(config, {
+			providerId: "openai",
+			modelId: "openai/gpt-custom",
+		});
+
+		const manager = new ProviderSettingsManager();
+		expect(manager.getLastUsedProviderSettings()?.provider).toBe("anthropic");
+		expect(manager.getProviderSettings("openai")?.model).toBe(
+			"openai/gpt-test",
+		);
+	});
+});

--- a/apps/cli/src/runtime/agent-profile-model.test.ts
+++ b/apps/cli/src/runtime/agent-profile-model.test.ts
@@ -72,7 +72,7 @@ describe("applyAgentProfileModelSelection", () => {
 		const manager = new ProviderSettingsManager();
 		manager.saveProviderSettings(
 			{
-				provider: "openai",
+				provider: "openai-compatible",
 				model: "openai/gpt-test",
 				apiKey: "openai-key",
 				reasoning: { enabled: true, effort: "high" },
@@ -92,12 +92,12 @@ describe("applyAgentProfileModelSelection", () => {
 		const config = makeConfig();
 
 		const result = await applyAgentProfileModelSelection(config, {
-			providerId: "openai",
+			providerId: "openai-compatible",
 			modelId: "openai/gpt-custom",
 		});
 
 		expect(result.warning).toBeUndefined();
-		expect(config.providerId).toBe("openai");
+		expect(config.providerId).toBe("openai-compatible");
 		expect(config.modelId).toBe("openai/gpt-custom");
 		expect(config.apiKey).toBe("openai-key");
 		expect(config.knownModels).toMatchObject({ "mock/model-a": {} });
@@ -105,13 +105,14 @@ describe("applyAgentProfileModelSelection", () => {
 		expect(config.reasoningEffort).toBe("high");
 	});
 
-	it("falls back to the profile provider's persisted model when the profile only pins a provider", async () => {
+	it("normalizes provider aliases and falls back to that provider's persisted model", async () => {
 		await setUpProviderSettings();
 		const config = makeConfig();
 
+		// "openai" is a frontmatter alias for "openai-compatible".
 		await applyAgentProfileModelSelection(config, { providerId: "openai" });
 
-		expect(config.providerId).toBe("openai");
+		expect(config.providerId).toBe("openai-compatible");
 		expect(config.modelId).toBe("openai/gpt-test");
 	});
 
@@ -149,7 +150,7 @@ describe("applyAgentProfileModelSelection", () => {
 		const config = makeConfig();
 
 		await applyAgentProfileModelSelection(config, {
-			providerId: "openai",
+			providerId: "openai-compatible",
 			modelId: "openai/gpt-custom",
 		});
 		const result = await applyAgentProfileModelSelection(config, undefined);
@@ -167,7 +168,7 @@ describe("applyAgentProfileModelSelection", () => {
 		const config = makeConfig();
 
 		await applyAgentProfileModelSelection(config, {
-			providerId: "openai",
+			providerId: "openai-compatible",
 			modelId: "openai/gpt-custom",
 		});
 		await applyAgentProfileModelSelection(config, {});
@@ -181,13 +182,13 @@ describe("applyAgentProfileModelSelection", () => {
 		const config = makeConfig();
 
 		await applyAgentProfileModelSelection(config, {
-			providerId: "openai",
+			providerId: "openai-compatible",
 			modelId: "openai/gpt-custom",
 		});
 
 		const manager = new ProviderSettingsManager();
 		expect(manager.getLastUsedProviderSettings()?.provider).toBe("anthropic");
-		expect(manager.getProviderSettings("openai")?.model).toBe(
+		expect(manager.getProviderSettings("openai-compatible")?.model).toBe(
 			"openai/gpt-test",
 		);
 	});

--- a/apps/cli/src/runtime/agent-profile-model.ts
+++ b/apps/cli/src/runtime/agent-profile-model.ts
@@ -1,0 +1,88 @@
+import { ProviderSettingsManager, resolveProviderConfig } from "@cline/core";
+import {
+	getPersistedProviderApiKey,
+	isProviderConfigured,
+} from "../utils/provider-auth";
+import type { ActiveAgentProfile, Config } from "../utils/types";
+
+export interface AgentProfileModelSelectionResult {
+	warning?: string;
+}
+
+/**
+ * Applies a profile's providerId/modelId to the live session config, layered
+ * on top of the user's persisted provider selection. Called once at profile
+ * selection time (not on every restart) so a later explicit /model change by
+ * the user wins for the rest of the session. Reverting to the default agent
+ * (or switching to a profile without provider/model fields) restores the
+ * user's persisted selection, which profile switches never write to.
+ */
+export async function applyAgentProfileModelSelection(
+	config: Config,
+	profile: Pick<ActiveAgentProfile, "providerId" | "modelId"> | undefined,
+): Promise<AgentProfileModelSelectionResult> {
+	const manager = new ProviderSettingsManager();
+	const userSettings = manager.getLastUsedProviderSettings();
+	const baselineProvider = userSettings?.provider ?? config.providerId;
+	const targetProvider = profile?.providerId ?? baselineProvider;
+	const targetSettings =
+		targetProvider === userSettings?.provider
+			? userSettings
+			: manager.getProviderSettings(targetProvider);
+
+	// Fail soft when the profile names a provider the user has no credentials
+	// for: keep the current provider and model, the persona still applies.
+	if (
+		profile?.providerId &&
+		targetProvider !== config.providerId &&
+		!isProviderConfigured(targetProvider, targetSettings)
+	) {
+		return {
+			warning: `Agent profile requests provider "${targetProvider}" which is not configured; keeping ${config.providerId}. Use /model to configure it.`,
+		};
+	}
+
+	const previousModelId = config.modelId;
+	const providerChanged = targetProvider !== config.providerId;
+	if (providerChanged) {
+		config.providerId = targetProvider;
+		config.apiKey =
+			getPersistedProviderApiKey(targetProvider, targetSettings) ?? "";
+		const resolved = await resolveProviderConfig(
+			targetProvider,
+			{
+				loadLatestOnInit: true,
+				loadPrivateOnAuth: true,
+				failOnError: false,
+			},
+			manager.getProviderConfig(targetProvider, { includeKnownModels: false }),
+		).catch(() => undefined);
+		config.knownModels = resolved?.knownModels;
+	}
+
+	const knownModelIds = config.knownModels
+		? Object.keys(config.knownModels)
+		: [];
+	config.modelId =
+		profile?.modelId ??
+		targetSettings?.model ??
+		(providerChanged ? (knownModelIds[0] ?? config.modelId) : config.modelId);
+
+	if (providerChanged || config.modelId !== previousModelId) {
+		// Reasoning preferences belong to the user's persisted settings for the
+		// target provider, same as session startup.
+		const persistedReasoning = targetSettings?.reasoning;
+		const effort =
+			persistedReasoning?.enabled === false
+				? "none"
+				: persistedReasoning?.effort && persistedReasoning.effort !== "none"
+					? persistedReasoning.effort
+					: persistedReasoning?.enabled === true
+						? "medium"
+						: "none";
+		config.thinking = effort !== "none";
+		config.reasoningEffort = effort === "none" ? undefined : effort;
+	}
+
+	return {};
+}

--- a/apps/cli/src/runtime/agent-profile-model.ts
+++ b/apps/cli/src/runtime/agent-profile-model.ts
@@ -1,4 +1,8 @@
-import { ProviderSettingsManager, resolveProviderConfig } from "@cline/core";
+import {
+	Llms,
+	ProviderSettingsManager,
+	resolveProviderConfig,
+} from "@cline/core";
 import {
 	getPersistedProviderApiKey,
 	hasEnvProviderApiKey,
@@ -84,7 +88,10 @@ export async function applyAgentProfileModelSelection(
 		profile?.modelId ??
 		targetSettings?.model ??
 		(providerChanged || currentModelIsProfileDriven
-			? (knownModelIds[0] ?? config.modelId)
+			? (knownModelIds[0] ??
+				Llms.getProviderCollectionSync(targetProvider)?.provider
+					.defaultModelId ??
+				config.modelId)
 			: config.modelId);
 
 	if (providerChanged || config.modelId !== previousModelId) {

--- a/apps/cli/src/runtime/agent-profile-model.ts
+++ b/apps/cli/src/runtime/agent-profile-model.ts
@@ -2,6 +2,7 @@ import { ProviderSettingsManager, resolveProviderConfig } from "@cline/core";
 import {
 	getPersistedProviderApiKey,
 	isProviderConfigured,
+	normalizeProviderId,
 } from "../utils/provider-auth";
 import type { ActiveAgentProfile, Config } from "../utils/types";
 
@@ -24,7 +25,10 @@ export async function applyAgentProfileModelSelection(
 	const manager = new ProviderSettingsManager();
 	const userSettings = manager.getLastUsedProviderSettings();
 	const baselineProvider = userSettings?.provider ?? config.providerId;
-	const targetProvider = profile?.providerId ?? baselineProvider;
+	// Normalize frontmatter aliases the same way --agent startup does.
+	const targetProvider = profile?.providerId
+		? normalizeProviderId(profile.providerId)
+		: baselineProvider;
 	const targetSettings =
 		targetProvider === userSettings?.provider
 			? userSettings

--- a/apps/cli/src/runtime/agent-profile-model.ts
+++ b/apps/cli/src/runtime/agent-profile-model.ts
@@ -1,6 +1,7 @@
 import { ProviderSettingsManager, resolveProviderConfig } from "@cline/core";
 import {
 	getPersistedProviderApiKey,
+	hasEnvProviderApiKey,
 	isProviderConfigured,
 	normalizeProviderId,
 } from "../utils/provider-auth";
@@ -21,6 +22,10 @@ export interface AgentProfileModelSelectionResult {
 export async function applyAgentProfileModelSelection(
 	config: Config,
 	profile: Pick<ActiveAgentProfile, "providerId" | "modelId"> | undefined,
+	options: {
+		/** The profile active before this switch, for revert bookkeeping. */
+		previousProfile?: Pick<ActiveAgentProfile, "providerId" | "modelId">;
+	} = {},
 ): Promise<AgentProfileModelSelectionResult> {
 	const manager = new ProviderSettingsManager();
 	const userSettings = manager.getLastUsedProviderSettings();
@@ -36,10 +41,12 @@ export async function applyAgentProfileModelSelection(
 
 	// Fail soft when the profile names a provider the user has no credentials
 	// for: keep the current provider and model, the persona still applies.
+	// Env-declared API keys count, since request paths resolve them at runtime.
 	if (
 		profile?.providerId &&
 		targetProvider !== config.providerId &&
-		!isProviderConfigured(targetProvider, targetSettings)
+		!isProviderConfigured(targetProvider, targetSettings) &&
+		!hasEnvProviderApiKey(targetProvider)
 	) {
 		return {
 			warning: `Agent profile requests provider "${targetProvider}" which is not configured; keeping ${config.providerId}. Use /model to configure it.`,
@@ -67,10 +74,18 @@ export async function applyAgentProfileModelSelection(
 	const knownModelIds = config.knownModels
 		? Object.keys(config.knownModels)
 		: [];
+	// The current modelId is only a valid fallback when it is the user's own:
+	// if the outgoing profile pinned a model and the persisted settings carry
+	// none, falling back to it would leak the profile's model past the revert.
+	const currentModelIsProfileDriven =
+		options.previousProfile?.modelId !== undefined &&
+		config.modelId === options.previousProfile.modelId;
 	config.modelId =
 		profile?.modelId ??
 		targetSettings?.model ??
-		(providerChanged ? (knownModelIds[0] ?? config.modelId) : config.modelId);
+		(providerChanged || currentModelIsProfileDriven
+			? (knownModelIds[0] ?? config.modelId)
+			: config.modelId);
 
 	if (providerChanged || config.modelId !== previousModelId) {
 		// Reasoning preferences belong to the user's persisted settings for the

--- a/apps/cli/src/runtime/agent-profile-tools.test.ts
+++ b/apps/cli/src/runtime/agent-profile-tools.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { resolveAgentProfileDisabledToolNames } from "./agent-profile-tools";
+
+describe("resolveAgentProfileDisabledToolNames", () => {
+	it("returns undefined without a profile", () => {
+		expect(resolveAgentProfileDisabledToolNames(undefined)).toBeUndefined();
+	});
+
+	it("returns undefined when the profile has no tools restriction", () => {
+		expect(
+			resolveAgentProfileDisabledToolNames({ skills: ["review-pr"] }),
+		).toBeUndefined();
+	});
+
+	it("disables catalog tools outside the allowlist, resolving legacy aliases", () => {
+		const disabled = resolveAgentProfileDisabledToolNames({
+			tools: ["Read_File", "search_codebase"],
+		});
+		expect(disabled).toBeDefined();
+		expect(disabled).toContain("run_commands");
+		expect(disabled).toContain("fetch_web_content");
+		expect(disabled).toContain("editor");
+		expect(disabled).toContain("skills");
+		expect(disabled).toContain("spawn_agent");
+		expect(disabled).not.toContain("read_files");
+		expect(disabled).not.toContain("search_codebase");
+	});
+
+	it("never disables harness tools outside the catalog", () => {
+		const disabled = resolveAgentProfileDisabledToolNames({ tools: [] });
+		expect(disabled).toBeDefined();
+		expect(disabled).not.toContain("submit_and_exit");
+		expect(disabled).not.toContain("attempt_completion");
+	});
+
+	it("implicitly allows the skills tool when the profile lists skills", () => {
+		const disabled = resolveAgentProfileDisabledToolNames({
+			tools: ["read_files"],
+			skills: ["review-pr"],
+		});
+		expect(disabled).toBeDefined();
+		expect(disabled).not.toContain("skills");
+	});
+
+	it("keeps both routed editor tool names enabled when the editor is allowed", () => {
+		for (const modelId of ["anthropic/claude-sonnet-4.6", "openai/gpt-5.2"]) {
+			const disabled = resolveAgentProfileDisabledToolNames(
+				{ tools: ["editor"] },
+				{ providerId: modelId.split("/")[0], modelId, mode: "act" },
+			);
+			expect(disabled).toBeDefined();
+			expect(disabled).not.toContain("editor");
+			expect(disabled).not.toContain("apply_patch");
+		}
+	});
+});

--- a/apps/cli/src/runtime/agent-profile-tools.test.ts
+++ b/apps/cli/src/runtime/agent-profile-tools.test.ts
@@ -53,4 +53,16 @@ describe("resolveAgentProfileDisabledToolNames", () => {
 			expect(disabled).not.toContain("apply_patch");
 		}
 	});
+
+	it("accepts runtime tool names like apply_patch for routed catalog entries", () => {
+		for (const modelId of ["anthropic/claude-sonnet-4.6", "openai/gpt-5.2"]) {
+			const disabled = resolveAgentProfileDisabledToolNames(
+				{ tools: ["apply_patch", "read_files"] },
+				{ providerId: modelId.split("/")[0], modelId, mode: "act" },
+			);
+			expect(disabled).toBeDefined();
+			expect(disabled).not.toContain("apply_patch");
+			expect(disabled).toContain("run_commands");
+		}
+	});
 });

--- a/apps/cli/src/runtime/agent-profile-tools.ts
+++ b/apps/cli/src/runtime/agent-profile-tools.ts
@@ -29,7 +29,14 @@ export function resolveAgentProfileDisabledToolNames(
 	}
 	const disabled = new Set<string>();
 	for (const entry of getCoreBuiltinToolCatalog(availabilityContext)) {
-		if (allowed.has(entry.id)) {
+		// An entry is allowed by its catalog id or by any of its runtime tool
+		// names, so `tools: apply_patch` keeps the editor entry on models that
+		// route editing through apply_patch, matching the subagent filter which
+		// matches on runtime tool names.
+		const entryAllowed =
+			allowed.has(entry.id) ||
+			entry.headlessToolNames.some((name) => allowed.has(name));
+		if (entryAllowed) {
 			continue;
 		}
 		disabled.add(entry.id);

--- a/apps/cli/src/runtime/agent-profile-tools.ts
+++ b/apps/cli/src/runtime/agent-profile-tools.ts
@@ -1,0 +1,41 @@
+import {
+	type BuiltinToolAvailabilityContext,
+	getCoreBuiltinToolCatalog,
+	resolveConfiguredAgentAllowedToolNames,
+} from "@cline/core";
+import type { ActiveAgentProfile } from "../utils/types";
+
+/**
+ * Computes the session-scoped tool disable list for an agent profile's tools
+ * allowlist: every builtin tool catalog entry whose id is not in the profile's
+ * resolved allowlist (legacy aliases resolved, `skills` implied by a skills
+ * field). Returns undefined when the profile has no tools field (no
+ * restriction). Only catalog tools are ever disabled; harness tools outside
+ * the catalog (like submit_and_exit), plugin tools, MCP tools, and
+ * `subagent_*` tools are unaffected. Recomputed on every session (re)start
+ * with the active provider/model/mode so routed tool names (editor vs
+ * apply_patch) match the runtime's toolset.
+ */
+export function resolveAgentProfileDisabledToolNames(
+	profile: Pick<ActiveAgentProfile, "tools" | "skills"> | undefined,
+	availabilityContext?: BuiltinToolAvailabilityContext,
+): string[] | undefined {
+	if (!profile) {
+		return undefined;
+	}
+	const allowed = resolveConfiguredAgentAllowedToolNames(profile);
+	if (allowed === undefined) {
+		return undefined;
+	}
+	const disabled = new Set<string>();
+	for (const entry of getCoreBuiltinToolCatalog(availabilityContext)) {
+		if (allowed.has(entry.id)) {
+			continue;
+		}
+		disabled.add(entry.id);
+		for (const name of entry.headlessToolNames) {
+			disabled.add(name);
+		}
+	}
+	return [...disabled];
+}

--- a/apps/cli/src/runtime/interactive/session-config.test.ts
+++ b/apps/cli/src/runtime/interactive/session-config.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import type { Config } from "../../utils/types";
+import { buildInteractiveSessionConfig } from "./session-config";
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+	return {
+		providerId: "anthropic",
+		modelId: "anthropic/claude-sonnet-4.6",
+		apiKey: "key",
+		systemPrompt: "test",
+		cwd: process.cwd(),
+		verbose: false,
+		sandbox: false,
+		thinking: false,
+		outputMode: "text",
+		mode: "act",
+		defaultToolAutoApprove: false,
+		toolPolicies: {},
+		enableTools: true,
+		enableSpawnAgent: false,
+		enableAgentTeams: false,
+		...overrides,
+	};
+}
+
+function buildConfig(config: Config): Config {
+	return buildInteractiveSessionConfig({
+		config,
+		chatCommandState: {
+			enableTools: true,
+			autoApproveTools: false,
+			cwd: config.cwd,
+			workspaceRoot: config.workspaceRoot ?? config.cwd,
+		},
+		runtimeHooks: {},
+		onTeamEvent: () => {},
+		resolveMistakeLimitDecision: undefined,
+	});
+}
+
+describe("buildInteractiveSessionConfig agent profile restrictions", () => {
+	it("derives tool and skill restrictions from the active profile", () => {
+		const built = buildConfig(
+			makeConfig({
+				agentProfile: {
+					name: "reviewer",
+					systemPrompt: "You are a reviewer.",
+					tools: ["read_files"],
+					skills: ["review-pr"],
+				},
+			}),
+		);
+
+		expect(built.skills).toEqual(["review-pr"]);
+		expect(built.disabledToolNames).toContain("run_commands");
+		expect(built.disabledToolNames).not.toContain("read_files");
+		// Implied by the profile's skills field.
+		expect(built.disabledToolNames).not.toContain("skills");
+	});
+
+	it("clears the restrictions when no profile is active", () => {
+		const built = buildConfig(
+			makeConfig({
+				agentProfile: undefined,
+				// Stale values from a previous profile must not survive a rebuild.
+				disabledToolNames: ["run_commands"],
+				skills: ["review-pr"],
+			}),
+		);
+
+		expect(built.disabledToolNames).toBeUndefined();
+		expect(built.skills).toBeUndefined();
+	});
+
+	it("leaves tools unrestricted for a profile without a tools field", () => {
+		const built = buildConfig(
+			makeConfig({
+				agentProfile: {
+					name: "reviewer",
+					systemPrompt: "You are a reviewer.",
+				},
+			}),
+		);
+
+		expect(built.disabledToolNames).toBeUndefined();
+		expect(built.skills).toBeUndefined();
+	});
+});

--- a/apps/cli/src/runtime/interactive/session-config.ts
+++ b/apps/cli/src/runtime/interactive/session-config.ts
@@ -38,7 +38,9 @@ export function buildInteractiveSessionConfig(input: {
 		// Same lifecycle for the profile's tools and skills restrictions. The
 		// availability context tracks the live provider/model/mode so routed
 		// tool names (editor vs apply_patch) stay accurate across /model and
-		// plan/act switches.
+		// plan/act switches. The skills allowlist scopes the agent's skills
+		// tool only: a user explicitly typing a /skill slash command is an
+		// explicit user action that wins over the profile, like /model.
 		disabledToolNames: resolveAgentProfileDisabledToolNames(
 			input.config.agentProfile,
 			{

--- a/apps/cli/src/runtime/interactive/session-config.ts
+++ b/apps/cli/src/runtime/interactive/session-config.ts
@@ -2,6 +2,7 @@ import type { TeamEvent } from "@cline/core";
 import type { ChatCommandState } from "../../utils/chat-commands";
 import type { Config } from "../../utils/types";
 import { resolveAgentProfileDisabledPluginPaths } from "../agent-profile-plugins";
+import { resolveAgentProfileDisabledToolNames } from "../agent-profile-tools";
 import {
 	CLI_DEFAULT_CHECKPOINT_CONFIG,
 	CLI_DEFAULT_LOOP_DETECTION,
@@ -34,5 +35,18 @@ export function buildInteractiveSessionConfig(input: {
 			input.config.agentProfile,
 			input.chatCommandState.workspaceRoot,
 		),
+		// Same lifecycle for the profile's tools and skills restrictions. The
+		// availability context tracks the live provider/model/mode so routed
+		// tool names (editor vs apply_patch) stay accurate across /model and
+		// plan/act switches.
+		disabledToolNames: resolveAgentProfileDisabledToolNames(
+			input.config.agentProfile,
+			{
+				mode: input.config.mode,
+				providerId: input.config.providerId,
+				modelId: input.config.modelId,
+			},
+		),
+		skills: input.config.agentProfile?.skills,
 	};
 }

--- a/apps/cli/src/runtime/interactive/session-runtime.ts
+++ b/apps/cli/src/runtime/interactive/session-runtime.ts
@@ -23,6 +23,10 @@ import { setActiveCliSession } from "../../utils/output";
 import { loadInteractiveResumeMessages } from "../../utils/resume";
 import type { ActiveAgentProfile, Config } from "../../utils/types";
 import { markAbortInProgress } from "../active-runtime";
+import {
+	type AgentProfileModelSelectionResult,
+	applyAgentProfileModelSelection,
+} from "../agent-profile-model";
 import type {
 	PendingPromptSnapshot,
 	PendingPromptSubmittedEvent,
@@ -361,8 +365,15 @@ export function createInteractiveSessionRuntime(input: {
 
 	const applyAgentProfile = async (
 		profile: ActiveAgentProfile | undefined,
-	): Promise<void> => {
+	): Promise<AgentProfileModelSelectionResult> => {
 		input.config.agentProfile = profile;
+		// Apply the profile's provider/model, or restore the user's persisted
+		// selection when the profile does not pin one, before the restart
+		// rebuilds the session config from the mutated values.
+		const modelResult = await applyAgentProfileModelSelection(
+			input.config,
+			profile,
+		);
 		// Re-apply the current mode so the system prompt picks up the persona.
 		await applyInteractiveModeConfig({
 			config: input.config,
@@ -370,6 +381,7 @@ export function createInteractiveSessionRuntime(input: {
 			switchToActModeTool: input.switchToActModeTool,
 		});
 		await restartWithCurrentMessages();
+		return modelResult;
 	};
 
 	const sendCurrentTurn = async (

--- a/apps/cli/src/runtime/interactive/session-runtime.ts
+++ b/apps/cli/src/runtime/interactive/session-runtime.ts
@@ -366,6 +366,7 @@ export function createInteractiveSessionRuntime(input: {
 	const applyAgentProfile = async (
 		profile: ActiveAgentProfile | undefined,
 	): Promise<AgentProfileModelSelectionResult> => {
+		const previousProfile = input.config.agentProfile;
 		input.config.agentProfile = profile;
 		// Apply the profile's provider/model, or restore the user's persisted
 		// selection when the profile does not pin one, before the restart
@@ -373,6 +374,7 @@ export function createInteractiveSessionRuntime(input: {
 		const modelResult = await applyAgentProfileModelSelection(
 			input.config,
 			profile,
+			{ previousProfile },
 		);
 		// Re-apply the current mode so the system prompt picks up the persona.
 		await applyInteractiveModeConfig({

--- a/apps/cli/src/runtime/run-interactive.ts
+++ b/apps/cli/src/runtime/run-interactive.ts
@@ -644,8 +644,11 @@ export async function runInteractive(
 		},
 		onAgentProfileChange: async (profile) => {
 			await sessionRuntime.ensureReady();
-			await sessionRuntime.applyAgentProfile(profile ?? undefined);
+			const result = await sessionRuntime.applyAgentProfile(
+				profile ?? undefined,
+			);
 			await resetPluginChatCommandHost();
+			return result;
 		},
 		onNewSession: async () => {
 			await sessionRuntime.resetForNewSession();

--- a/apps/cli/src/tui/components/dialogs/agent-selector.tsx
+++ b/apps/cli/src/tui/components/dialogs/agent-selector.tsx
@@ -16,6 +16,10 @@ export interface AgentProfileOption {
 	description?: string;
 	systemPrompt: string;
 	plugins?: string[];
+	tools?: string[];
+	skills?: string[];
+	providerId?: string;
+	modelId?: string;
 	source: "workspace" | "global";
 }
 

--- a/apps/cli/src/tui/components/dialogs/agent-selector.tsx
+++ b/apps/cli/src/tui/components/dialogs/agent-selector.tsx
@@ -40,25 +40,32 @@ export function AgentSelectorContent(
 
 	const items: SearchableItem[] = useMemo(() => {
 		const normalizedCurrent = currentAgentName?.trim().toLowerCase() ?? null;
-		const defaultItem: SearchableItem = {
-			key: DEFAULT_AGENT_ACTION,
-			label: "Cline (default)",
-			detail: "Standard Cline agent",
-			section: "Agents",
-			rightLabel: normalizedCurrent === null ? "(current)" : undefined,
-		};
-		const profileItems = agents.map((agent) => ({
+		const toItem = (agent: AgentProfileOption): SearchableItem => ({
 			key: agent.name.toLowerCase(),
 			label: agent.name,
 			detail: agent.description,
-			section:
-				agent.source === "workspace" ? "Workspace agents" : "Global agents",
+			section: agent.source === "workspace" ? "Workspace" : "Global",
 			rightLabel:
 				normalizedCurrent === agent.name.trim().toLowerCase()
 					? "(current)"
 					: undefined,
-		}));
-		return [defaultItem, ...profileItems];
+		});
+		// The default Cline agent lives at the top of the "Global" section; it is
+		// the revert-to-stock choice, not a peer profile.
+		const defaultItem: SearchableItem = {
+			key: DEFAULT_AGENT_ACTION,
+			label: "Cline (default)",
+			detail: "Standard Cline agent",
+			section: "Global",
+			rightLabel: normalizedCurrent === null ? "(current)" : undefined,
+		};
+		const globalItems = agents
+			.filter((agent) => agent.source === "global")
+			.map(toItem);
+		const workspaceItems = agents
+			.filter((agent) => agent.source === "workspace")
+			.map(toItem);
+		return [defaultItem, ...globalItems, ...workspaceItems];
 	}, [agents, currentAgentName]);
 
 	const list = useSearchableList(items);

--- a/apps/cli/src/tui/hooks/use-agent-selector.tsx
+++ b/apps/cli/src/tui/hooks/use-agent-selector.tsx
@@ -26,6 +26,10 @@ function loadAgentProfileEntries(config: Config): {
 			description: profile.description,
 			systemPrompt: profile.systemPrompt,
 			plugins: profile.plugins?.map((plugin) => plugin.name),
+			tools: profile.tools,
+			skills: profile.skills,
+			providerId: profile.providerId,
+			modelId: profile.modelId,
 			source:
 				workspaceRoot && profile.path?.startsWith(`${workspaceRoot}${sep}`)
 					? ("workspace" as const)
@@ -98,14 +102,24 @@ export function useAgentSelector(opts: {
 			return;
 		}
 		if (profile.name !== currentAgentName) {
-			await withLoadingDialog(dialog, "Applying agent...", async () => {
-				await onAgentProfileChange({
-					name: profile.name,
-					systemPrompt: profile.systemPrompt,
-					plugins: profile.plugins,
-				});
-			});
+			const result = await withLoadingDialog(
+				dialog,
+				"Applying agent...",
+				async () =>
+					await onAgentProfileChange({
+						name: profile.name,
+						systemPrompt: profile.systemPrompt,
+						plugins: profile.plugins,
+						tools: profile.tools,
+						skills: profile.skills,
+						providerId: profile.providerId,
+						modelId: profile.modelId,
+					}),
+			);
 			session.setActiveAgentName(profile.name);
+			if (result && result.warning) {
+				session.appendEntry({ kind: "status", text: result.warning });
+			}
 		}
 		refocusTextarea();
 	}, [

--- a/apps/cli/src/tui/root.tsx
+++ b/apps/cli/src/tui/root.tsx
@@ -197,8 +197,9 @@ function App(props: TuiProps) {
 		config: props.config,
 		termHeight,
 		onAgentProfileChange: async (profile) => {
-			await props.onAgentProfileChange(profile);
+			const result = await props.onAgentProfileChange(profile);
 			setPluginCommandsRefreshKey((key) => key + 1);
+			return result;
 		},
 		refocusTextarea: () => refocusTextareaRef.current(),
 	});

--- a/apps/cli/src/tui/types.ts
+++ b/apps/cli/src/tui/types.ts
@@ -174,7 +174,9 @@ export interface TuiProps {
 	onCompactionModeChange: (mode: CliCompactionMode) => Promise<void>;
 	onModelChange: () => Promise<void>;
 	onModeChange: (mode: AgentMode) => Promise<void>;
-	onAgentProfileChange: (profile: ActiveAgentProfile | null) => Promise<void>;
+	onAgentProfileChange: (
+		profile: ActiveAgentProfile | null,
+	) => Promise<{ warning?: string } | void>;
 	onNewSession: () => Promise<void>;
 	onSessionRestart: () => Promise<void>;
 	onAccountChange: () => Promise<void>;

--- a/apps/cli/src/utils/provider-auth.ts
+++ b/apps/cli/src/utils/provider-auth.ts
@@ -23,6 +23,17 @@ export function normalizeAuthProviderId(providerId: string): string {
 
 export { isOAuthProvider };
 
+/**
+ * Returns true when the provider declares API key environment variables and
+ * one of them is set. Runtime request paths resolve these env keys even when
+ * no settings are persisted, so they count as usable credentials (e.g. for
+ * agent profiles that pin a provider the user only configured via env).
+ */
+export function hasEnvProviderApiKey(providerId: string): boolean {
+	const envKeys = Llms.getProviderCollectionSync(providerId)?.provider.env;
+	return (envKeys ?? []).some((key) => !!process.env[key]?.trim());
+}
+
 export function toProviderApiKey(
 	providerId: string,
 	credentials: Pick<OAuthCredentials, "access">,

--- a/apps/cli/src/utils/types.ts
+++ b/apps/cli/src/utils/types.ts
@@ -30,6 +30,22 @@ export interface ActiveAgentProfile {
 	 * empty), only these plugins plus always-enabled ones load this session.
 	 */
 	plugins?: string[];
+	/**
+	 * Builtin tool allowlist from the profile's tools frontmatter. When present
+	 * (even empty), builtin tools outside the list are disabled this session.
+	 */
+	tools?: string[];
+	/**
+	 * Skill allowlist from the profile's skills frontmatter. When present, only
+	 * these skills are surfaced by the skills tool this session.
+	 */
+	skills?: string[];
+	/**
+	 * Provider/model from the profile's frontmatter, applied once at selection
+	 * time. A later explicit /model change wins for the rest of the session.
+	 */
+	providerId?: string;
+	modelId?: string;
 }
 
 export interface Config extends Omit<CoreSessionConfig, "apiKey" | "mode"> {

--- a/sdk/packages/core/src/extensions/tools/team/configured-agent-config.test.ts
+++ b/sdk/packages/core/src/extensions/tools/team/configured-agent-config.test.ts
@@ -129,9 +129,9 @@ describe("resolveConfiguredAgentAllowedToolNames", () => {
 	it("resolves legacy aliases and normalizes casing", () => {
 		expect(
 			resolveConfiguredAgentAllowedToolNames({
-				tools: ["Execute_Command", "read_file", "editor"],
+				tools: ["Execute_Command", "read_file"],
 			}),
-		).toEqual(new Set(["run_commands", "read_files", "editor"]));
+		).toEqual(new Set(["run_commands", "read_files"]));
 	});
 
 	it("implicitly allows the skills tool when skills are configured", () => {
@@ -147,5 +147,14 @@ describe("resolveConfiguredAgentAllowedToolNames", () => {
 		expect(resolveConfiguredAgentAllowedToolNames({ tools: [] })).toEqual(
 			new Set(),
 		);
+	});
+
+	it("allows both editing tool names when either routed name is listed", () => {
+		expect(
+			resolveConfiguredAgentAllowedToolNames({ tools: ["editor"] }),
+		).toEqual(new Set(["editor", "apply_patch"]));
+		expect(
+			resolveConfiguredAgentAllowedToolNames({ tools: ["apply_patch"] }),
+		).toEqual(new Set(["editor", "apply_patch"]));
 	});
 });

--- a/sdk/packages/core/src/extensions/tools/team/configured-agent-config.test.ts
+++ b/sdk/packages/core/src/extensions/tools/team/configured-agent-config.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { parseConfiguredAgentConfig } from "./configured-agent-config";
+import {
+	parseConfiguredAgentConfig,
+	resolveConfiguredAgentAllowedToolNames,
+} from "./configured-agent-config";
 
 describe("configured agent config parser", () => {
 	it("parses YAML frontmatter and system prompt body", () => {
@@ -113,5 +116,36 @@ ${yaml}
 ---
 You are a code reviewer.`),
 		).toThrow("Missing closing YAML frontmatter delimiter");
+	});
+});
+
+describe("resolveConfiguredAgentAllowedToolNames", () => {
+	it("returns undefined when the config does not restrict tools", () => {
+		expect(
+			resolveConfiguredAgentAllowedToolNames({ skills: ["review-pr"] }),
+		).toBeUndefined();
+	});
+
+	it("resolves legacy aliases and normalizes casing", () => {
+		expect(
+			resolveConfiguredAgentAllowedToolNames({
+				tools: ["Execute_Command", "read_file", "editor"],
+			}),
+		).toEqual(new Set(["run_commands", "read_files", "editor"]));
+	});
+
+	it("implicitly allows the skills tool when skills are configured", () => {
+		expect(
+			resolveConfiguredAgentAllowedToolNames({
+				tools: ["read_files"],
+				skills: ["review-pr"],
+			}),
+		).toEqual(new Set(["read_files", "skills"]));
+	});
+
+	it("treats an empty tools list as allowing nothing extra", () => {
+		expect(resolveConfiguredAgentAllowedToolNames({ tools: [] })).toEqual(
+			new Set(),
+		);
 	});
 });

--- a/sdk/packages/core/src/extensions/tools/team/configured-agent-config.ts
+++ b/sdk/packages/core/src/extensions/tools/team/configured-agent-config.ts
@@ -69,6 +69,12 @@ export function resolveConfiguredAgentAllowedToolNames(
 	if (config.skills !== undefined) {
 		allowed.add("skills");
 	}
+	// Editing is one capability that model routing surfaces under two tool
+	// names; allowing either keeps the profile working on every model.
+	if (allowed.has("editor") || allowed.has("apply_patch")) {
+		allowed.add("editor");
+		allowed.add("apply_patch");
+	}
 	return allowed;
 }
 

--- a/sdk/packages/core/src/extensions/tools/team/configured-agent-config.ts
+++ b/sdk/packages/core/src/extensions/tools/team/configured-agent-config.ts
@@ -32,6 +32,46 @@ export interface ConfiguredAgentPluginRef {
 	install?: string;
 }
 
+// Legacy/alternate tool names accepted in agent config `tools` lists, mapped
+// to the builtin tool names they resolve to.
+const CONFIGURED_AGENT_TOOL_NAME_ALIASES: Record<string, string> = {
+	apply_diff: "editor",
+	attempt_completion: "submit_and_exit",
+	bash: "run_commands",
+	execute_command: "run_commands",
+	list_code_definition_names: "search_codebase",
+	list_files: "run_commands",
+	read_file: "read_files",
+	replace_in_file: "editor",
+	search_files: "search_codebase",
+	use_skill: "skills",
+	write_to_file: "editor",
+};
+
+export function resolveConfiguredAgentToolName(toolName: string): string {
+	const normalized = toolName.trim().toLowerCase();
+	return CONFIGURED_AGENT_TOOL_NAME_ALIASES[normalized] ?? normalized;
+}
+
+/**
+ * Resolves an agent config's `tools` allowlist to builtin tool names,
+ * applying alias resolution and the implicit rule that listing `skills`
+ * in the frontmatter also allows the `skills` tool. Returns undefined when
+ * the config does not restrict tools.
+ */
+export function resolveConfiguredAgentAllowedToolNames(
+	config: Pick<ConfiguredAgentConfig, "tools" | "skills">,
+): Set<string> | undefined {
+	if (config.tools === undefined) {
+		return undefined;
+	}
+	const allowed = new Set(config.tools.map(resolveConfiguredAgentToolName));
+	if (config.skills !== undefined) {
+		allowed.add("skills");
+	}
+	return allowed;
+}
+
 export interface ConfiguredAgentConfig {
 	name: string;
 	description: string;

--- a/sdk/packages/core/src/extensions/tools/team/index.ts
+++ b/sdk/packages/core/src/extensions/tools/team/index.ts
@@ -5,6 +5,8 @@ export {
 	type ConfiguredAgentReadError,
 	loadConfiguredAgentConfigs,
 	parseConfiguredAgentConfig,
+	resolveConfiguredAgentAllowedToolNames,
+	resolveConfiguredAgentToolName,
 } from "./configured-agent-config";
 export {
 	buildConfiguredAgentToolDescriptors,

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -321,6 +321,8 @@ export {
 	type DelegatedAgentRuntimeConfig,
 	loadConfiguredAgentConfigs,
 	parseConfiguredAgentConfig,
+	resolveConfiguredAgentAllowedToolNames,
+	resolveConfiguredAgentToolName,
 	reviveTeamStateDates,
 	type SpawnTeammateOptions,
 	type SubAgentEndContext,

--- a/sdk/packages/core/src/runtime/orchestration/runtime-builder.configured-agent-execution.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-builder.configured-agent-execution.test.ts
@@ -258,6 +258,60 @@ Write a concise commit message.`,
 		await runtime.shutdown("test");
 	});
 
+	it("does not apply session-disabled tools to configured subagent toolsets", async () => {
+		const { DefaultRuntimeBuilder } = await import("./runtime-builder");
+		const tempHome = mkdtempSync(join(tmpdir(), "cline-agent-home-"));
+		const workspaceRoot = mkdtempSync(join(tmpdir(), "cline-agent-session-"));
+		tempDirs.push(tempHome, workspaceRoot);
+		process.env.HOME = tempHome;
+		setHomeDir(tempHome);
+		const agentsDir = join(workspaceRoot, ".cline", "agents");
+		mkdirSync(agentsDir, { recursive: true });
+		writeFileSync(
+			join(agentsDir, "reviewer.yml"),
+			`---
+name: reviewer
+description: Reviews code
+tools: run_commands, read_files
+---
+You are a reviewer.`,
+			"utf8",
+		);
+
+		const runtime = await new DefaultRuntimeBuilder().build({
+			config: makeBaseConfig({
+				cwd: workspaceRoot,
+				workspaceRoot,
+				disabledToolNames: ["run_commands"],
+			}),
+			configExtensions: [],
+		});
+
+		const mainToolNames = runtime.tools.map((tool) => tool.name);
+		expect(mainToolNames).not.toContain("run_commands");
+		expect(mainToolNames).toContain("subagent_reviewer");
+
+		const reviewer = runtime.tools.find(
+			(tool) => tool.name === "subagent_reviewer",
+		);
+		if (!reviewer) {
+			throw new Error("Expected configured reviewer tool.");
+		}
+		await reviewer.execute(
+			{ prompt: "review this change" },
+			{ agentId: "parent-agent", iteration: 1 },
+		);
+
+		const delegatedConfig = agentConstructorSpy.mock.calls.at(-1)?.[0] as
+			| AgentConfig
+			| undefined;
+		expect(delegatedConfig?.tools.map((tool) => tool.name)).toContain(
+			"run_commands",
+		);
+
+		await runtime.shutdown("test");
+	});
+
 	it("does not require custom user instruction services to implement createSkillsExecutor", async () => {
 		const { DefaultRuntimeBuilder } = await import("./runtime-builder");
 		const workspaceRoot = mkdtempSync(join(tmpdir(), "cline-agent-compat-"));

--- a/sdk/packages/core/src/runtime/orchestration/runtime-builder.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-builder.test.ts
@@ -383,6 +383,41 @@ Use the review guidance.`,
 		expect(names).toContain("read_files");
 	});
 
+	it("omits session-disabled tools from the advertised runtime tool list", async () => {
+		const runtime = await new DefaultRuntimeBuilder().build({
+			config: makeBaseConfig({
+				disabledToolNames: ["search_codebase"],
+			}),
+		});
+
+		const names = runtime.tools.map((tool) => tool.name);
+		expect(names).not.toContain("search_codebase");
+		expect(names).toContain("read_files");
+	});
+
+	it("unions session-disabled tools with globally disabled tools", async () => {
+		const tempRoot = mkdtempSync(join(tmpdir(), "runtime-builder-session-"));
+		tempDirs.push(tempRoot);
+		const settingsPath = join(tempRoot, "global-settings.json");
+		process.env.CLINE_GLOBAL_SETTINGS_PATH = settingsPath;
+		writeFileSync(
+			settingsPath,
+			JSON.stringify({ disabledTools: ["search_codebase"] }, null, 2),
+			"utf8",
+		);
+
+		const runtime = await new DefaultRuntimeBuilder().build({
+			config: makeBaseConfig({
+				disabledToolNames: ["read_files"],
+			}),
+		});
+
+		const names = runtime.tools.map((tool) => tool.name);
+		expect(names).not.toContain("search_codebase");
+		expect(names).not.toContain("read_files");
+		expect(names).toContain("run_commands");
+	});
+
 	it("adds spawn tool when enabled", async () => {
 		const runtime = await new DefaultRuntimeBuilder().build({
 			config: makeBaseConfig({

--- a/sdk/packages/core/src/runtime/orchestration/runtime-builder.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-builder.ts
@@ -32,7 +32,10 @@ import {
 	type TeamEvent,
 } from "../../extensions/tools/team";
 import type { ConfiguredAgentConfig } from "../../extensions/tools/team/configured-agent-config";
-import { loadConfiguredAgentConfigs } from "../../extensions/tools/team/configured-agent-config";
+import {
+	loadConfiguredAgentConfigs,
+	resolveConfiguredAgentAllowedToolNames,
+} from "../../extensions/tools/team/configured-agent-config";
 import { createConfiguredAgentTools } from "../../extensions/tools/team/configured-agent-tool";
 import {
 	filterDisabledTools,
@@ -79,42 +82,25 @@ function filterToolsByPolicies(
 function filterAvailableTools(
 	tools: AgentTool[],
 	toolPolicies: CoreSessionConfig["toolPolicies"],
+	sessionDisabledToolNames?: ReadonlyArray<string>,
 ): AgentTool[] {
-	return filterDisabledTools(filterToolsByPolicies(tools, toolPolicies));
-}
-
-const CONFIGURED_AGENT_TOOL_NAME_ALIASES: Record<string, string> = {
-	apply_diff: "editor",
-	attempt_completion: "submit_and_exit",
-	bash: "run_commands",
-	execute_command: "run_commands",
-	list_code_definition_names: "search_codebase",
-	list_files: "run_commands",
-	read_file: "read_files",
-	replace_in_file: "editor",
-	search_files: "search_codebase",
-	use_skill: "skills",
-	write_to_file: "editor",
-};
-
-function resolveConfiguredAgentToolName(toolName: string): string {
-	const normalized = toolName.trim().toLowerCase();
-	return CONFIGURED_AGENT_TOOL_NAME_ALIASES[normalized] ?? normalized;
+	const filtered = filterDisabledTools(
+		filterToolsByPolicies(tools, toolPolicies),
+	);
+	if (!sessionDisabledToolNames?.length) {
+		return filtered;
+	}
+	const sessionDisabled = new Set(sessionDisabledToolNames);
+	return filtered.filter((tool) => !sessionDisabled.has(tool.name));
 }
 
 function filterToolsForConfiguredAgent(
 	tools: AgentTool[],
 	agent: ConfiguredAgentConfig,
 ): AgentTool[] {
-	if (agent.tools === undefined) {
+	const allowedToolNames = resolveConfiguredAgentAllowedToolNames(agent);
+	if (allowedToolNames === undefined) {
 		return tools;
-	}
-
-	const allowedToolNames = new Set(
-		agent.tools.map(resolveConfiguredAgentToolName),
-	);
-	if (agent.skills !== undefined) {
-		allowedToolNames.add("skills");
 	}
 	return tools.filter((tool) => allowedToolNames.has(tool.name));
 }
@@ -132,6 +118,7 @@ function createBuiltinToolsList(
 	toolPolicies: CoreSessionConfig["toolPolicies"],
 	skillsExecutor?: SkillsExecutorWithMetadata,
 	executorOverrides?: Partial<ToolExecutors>,
+	sessionDisabledToolNames?: ReadonlyArray<string>,
 ): AgentTool[] {
 	const preset = ToolPresets[resolveToolPresetName({ mode })];
 	const toolRoutingConfig = resolveToolRoutingConfig(
@@ -157,6 +144,7 @@ function createBuiltinToolsList(
 			},
 		}),
 		toolPolicies,
+		sessionDisabledToolNames,
 	);
 }
 
@@ -168,6 +156,7 @@ function isSkillsToolEnabledForSession(input: {
 	toolRoutingRules?: ToolRoutingRule[];
 	toolPolicies?: CoreSessionConfig["toolPolicies"];
 	toolExecutors?: Partial<ToolExecutors>;
+	disabledToolNames?: ReadonlyArray<string>;
 }): boolean {
 	return createBuiltinToolsList(
 		input.cwd,
@@ -178,6 +167,7 @@ function isSkillsToolEnabledForSession(input: {
 		input.toolPolicies,
 		SKILLS_PROBE_EXECUTOR,
 		input.toolExecutors,
+		input.disabledToolNames,
 	).some((tool) => tool.name === "skills");
 }
 
@@ -421,6 +411,7 @@ export class DefaultRuntimeBuilder implements RuntimeBuilder {
 				toolRoutingRules: config.toolRoutingRules,
 				toolPolicies: effectiveToolPolicies,
 				toolExecutors,
+				disabledToolNames: config.disabledToolNames,
 			});
 
 		const userInstructionPlugin =
@@ -448,6 +439,7 @@ export class DefaultRuntimeBuilder implements RuntimeBuilder {
 					effectiveToolPolicies,
 					undefined,
 					toolExecutors,
+					config.disabledToolNames,
 				),
 			);
 			if (!normalized.disableMcpSettingsTools) {
@@ -653,7 +645,11 @@ export class DefaultRuntimeBuilder implements RuntimeBuilder {
 			ensureTeamRuntime();
 		}
 
-		const finalTools = filterAvailableTools(tools, effectiveToolPolicies);
+		const finalTools = filterAvailableTools(
+			tools,
+			effectiveToolPolicies,
+			config.disabledToolNames,
+		);
 		const requiresCompletionTool = finalTools.some(
 			(tool) =>
 				tool.name === "submit_and_exit" &&

--- a/sdk/packages/core/src/types/config.ts
+++ b/sdk/packages/core/src/types/config.ts
@@ -206,6 +206,14 @@ export interface CoreSessionConfig
 	 * plugin set for one session without touching persisted user settings.
 	 */
 	disabledPluginPaths?: string[];
+	/**
+	 * Session-scoped tool disable list (builtin tool names), applied on top of
+	 * the globally disabled tools. Used by agent profiles to restrict the main
+	 * agent's builtin toolset for one session without touching persisted user
+	 * settings. Does not affect subagent or teammate toolsets, which are
+	 * governed by their own configs.
+	 */
+	disabledToolNames?: string[];
 	extensions?: AgentConfig["extensions"];
 	execution?: AgentConfig["execution"];
 	compaction?: CoreCompactionConfig;


### PR DESCRIPTION
### Related Issue

Third PR in the agent profiles stack, on top of #11448 (plugins, itself on top of #11435). Retarget to `main` as the stack merges.

### Description

Agent profiles parse `tools`, `skills`, `providerId`, `modelId`, and `maxIterations` frontmatter, but until now those fields only took effect when the profile ran as a `subagent_<name>` spawn. Selecting a profile for the main agent (via `/agents` or `--agent`) applied only the persona (phase 1) and `plugins` (phase 2). This PR closes that gap: a profile selected for the main agent now gets its tool allowlist, skill allowlist, and provider/model too.

#### tools: a session-scoped builtin disable list

There was no session-scoped tool restriction, so the SDK gains `CoreSessionConfig.disabledToolNames`, modeled exactly on phase 2's `disabledPluginPaths`: applied on top of the globally disabled tools, plain data so it survives hub daemon serialization for free, and never touching persisted settings. It is threaded into three spots in `runtime-builder.ts`: the main agent's builtin tool list, the final advertised tool list (so `spawn_agent` and team tools can be restricted), and the skills-tool registration probe (the skills tool registers through an extension, which bypasses the final list). Subagent and teammate toolsets deliberately do not receive it; those are governed by their own configs, so a `reviewer` profile restricted to read-only tools can still spawn a `subagent_implementer` that edits files.

The CLI derives the disable list as: every builtin catalog entry (the same set shown in `/settings` tools) whose id is not in the profile's resolved allowlist. The resolution logic (legacy alias mapping like `read_file` -> `read_files`, plus the implicit rule that a `skills:` field allows the `skills` tool) was extracted from the subagent filter into an exported `resolveConfiguredAgentAllowedToolNames`, so main-agent and subagent semantics cannot drift. Two scope decisions worth calling out:

- Only catalog tools are ever disabled. Harness tools outside the catalog (`submit_and_exit`), plugin tools (governed by the `plugins` field), MCP tools, and `subagent_*` tools are unaffected. This keeps a restrictive profile from breaking run completion.
- The derivation runs inside `buildInteractiveSessionConfig` with the live provider/model/mode as the catalog availability context, because the editor entry's runtime tool name is routing-dependent (`editor` vs `apply_patch`). It is recomputed on every session restart, so `/model` and plan/act switches keep the names accurate. Review also caught that a profile saying `tools: apply_patch` (a runtime name, not a catalog id) must keep the editor entry; entries are now matched by catalog id or any of their runtime tool names, same as the subagent filter.

#### skills: the seam already existed

`CoreSessionConfig.skills` was already a consumed allowlist (`allowedSkillNames` in the runtime builder), so the CLI just sets it from the profile. One deliberate scope decision: the allowlist restricts the agent's autonomous `skills` tool only. A user explicitly typing a `/skill-name` slash command still works, on the same philosophy as `/model` below: explicit user actions win over the profile.

#### providerId/modelId: applied once, user override wins

This is the part with real design weight. Tools/skills/plugins are derived config, recomputed from `config.agentProfile` on every restart. Provider/model is NOT: it is applied once, at profile selection time (`applyAgentProfileModelSelection`, called from `applyAgentProfile`). That single decision is what produces the agreed UX:

- Switching to a profile that pins `anthropic` / Sonnet moves the session there (silently, status bar updates).
- The user can then `/model` to Gemini and keep using the profile; nothing re-applies the profile's model on later restarts, plan/act toggles, or compactions, because the restart path never touches provider/model.
- Reverting to the default agent (or switching to a profile without these fields) restores the user's own selection by reading it back from `providerSettingsManager`. This needs no snapshot state: profile switches never write to the settings store, so the persisted value is always the user's own last explicit choice. `/model` mid-profile persists (it already did), so reverting after that lands on the model the user picked, which is the right answer.

Edge cases handled along the way, mostly found through adversarial review rounds:

- Missing credentials fail soft: a profile naming a provider the user has not configured keeps the current provider and model (the persona still applies) and surfaces a warning in the transcript. Providers configured only through their declared env var (e.g. `OPENROUTER_API_KEY`) count as configured, since request paths resolve env keys at runtime; `isProviderConfigured` alone would have wrongly rejected them.
- Frontmatter aliases are normalized (`providerId: openai` -> `openai-compatible`) in the interactive path, matching what `--agent` startup already did. Without this, a profile worked from the flag but not from the dialog.
- Model revert leak: with a model-only profile active and persisted settings that carry no model, reverting fell back to the "current" model, which was the profile's. `applyAgentProfile` now passes the outgoing profile so the revert can detect that case and fall back to the provider's known models instead.
- The warning result was silently swallowed by the `onAgentProfileChange` wrapper in `root.tsx` (it incremented the plugin-commands refresh key but did not return the result). Found by review; the warning now reaches the chat transcript.
- Reasoning settings follow the target provider's persisted preferences when the provider or model changes, same mapping as session startup.

#### --agent parity

The non-interactive flag follows the same rules, which required moving profile resolution above provider resolution in `main.ts`. Precedence is explicit `--provider`/`--model` > profile > persisted last-used. Two guards matter:

- The profile's `modelId` only applies when the session actually runs on the profile's intended provider (it is ignored if `--provider` forces a different one, or if the profile's provider fails the credential check), since a model id is meaningless on the wrong provider.
- The startup `saveProviderSettings` call is skipped when the provider came from the profile, and writes the user's existing model (not the profile's) when only the model came from the profile. Without this, `cline --agent reviewer` would have silently rewritten the user's persisted provider selection.

#### Deliberate non-goals

- `maxIterations` is NOT applied to the main agent. It exists as runaway protection for delegated subagents; an interactive session dying mid-task at an arbitrary iteration cap would be surprising. It still applies to subagent spawns.
- Subagents still do not get the `plugins` field (the reverse gap): subagents run in-process with the parent session's extensions, and per-spawn plugin loading is a separate, harder problem. Documented in the registry README.
- Profile selection remains session-only (phase 1 decision): resuming a session from a fresh CLI process without `--agent` starts as the default agent. Re-select via `/agents` or pass `--agent` with `--resume`.

### Test Procedure

- New SDK tests: session disable list filters the advertised runtime tools, unions with globally disabled tools, and does not leak into configured subagent toolsets (asserted via the delegated agent constructor spy); unit tests for `resolveConfiguredAgentAllowedToolNames` (aliases, implicit skills, empty list).
- New CLI tests: disable-list derivation (aliases, harness tools never disabled, routed editor names in both directions, `apply_patch` as an allowlist entry); `buildInteractiveSessionConfig` derives and, critically, clears restrictions when reverting; `applyAgentProfileModelSelection` against a real temp-home `ProviderSettingsManager` (apply, alias normalization, model-only profiles, fail-soft warning, env-only credentials, revert restore, the model revert leak, and never writing the settings store); `main.ts` `--agent` precedence, fail-soft fallback, and the persist guard.
- Full gates: `bun -F @cline/shared test`, `bun -F @cline/core test:unit`, `bun -F @cline/cli test:unit`, parallel typechecks, `bun biome check`, `bun run check` all green (the only failures are the known sandbox-environment `distribution-package.test.ts` and two bootstrap-test timeouts that pass in isolation and only appear when running both suites concurrently).
- Four codex review rounds until clean; rounds 1 to 3 produced the warning propagation, alias normalization, `apply_patch` allowlist, model revert leak, and env-credential fixes above. The final round found nothing of substance beyond the documented session-only resume behavior.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

The cline/agents registry README gets a matching update (separate repo) replacing the "apply when the profile is spawned as a subagent" line with per-field documentation of the new main-agent behavior.
