### PR TITLE
fix(sdk): return captured stdout on failing run_commands

### DIFF
--- a/sdk/packages/core/src/extensions/tools/definitions.test.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.test.ts
@@ -11,6 +11,7 @@ import {
 	createSkillsTool,
 	createWindowsShellTool,
 } from "./definitions";
+import { CommandExitError } from "./executors/bash";
 import { RUN_COMMAND_QUERY_PREVIEW_LIMIT, TimeoutError } from "./helpers";
 import { INPUT_ARG_CHAR_LIMIT } from "./schemas";
 import type { SkillsExecutorWithMetadata } from "./types";
@@ -615,6 +616,34 @@ describe("default run_commands tool", () => {
 				query: "git status --short",
 				result: "ran:git status --short",
 				success: true,
+			},
+		]);
+	});
+
+	it("returns captured output for non-zero command exits", async () => {
+		const execute = vi.fn(async () => {
+			throw new CommandExitError(
+				1,
+				"[Command exited with code 1]\nfailed assertion details",
+			);
+		});
+		const tool = createBashTool(execute);
+
+		const result = await tool.execute(
+			{ commands: ["bun test"] },
+			{
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 1,
+			},
+		);
+
+		expect(result).toEqual([
+			{
+				query: "bun test",
+				result: "[Command exited with code 1]\nfailed assertion details",
+				error: "Command exited with code 1",
+				success: false,
 			},
 		]);
 	});

--- a/sdk/packages/core/src/extensions/tools/definitions.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.ts
@@ -13,6 +13,7 @@ import {
 } from "@cline/shared";
 import { captureRunCommandsTimeout } from "../../services/telemetry/core-events";
 import { getToolContextTelemetry } from "../../services/telemetry/tool-context";
+import { CommandExitError } from "./executors/bash";
 import {
 	MAX_COMMAND_OUTPUT_CHARS,
 	MAX_READ_LINES,
@@ -338,6 +339,14 @@ export function createBashTool(
 								durationMs: Date.now() - startedAt,
 							});
 						}
+						if (error instanceof CommandExitError) {
+							return {
+								query,
+								result: error.output,
+								error: error.message,
+								success: false,
+							};
+						}
 						const msg = formatError(error);
 						return {
 							query,
@@ -405,6 +414,14 @@ export function createWindowsShellTool(
 								commandCount: commands.length,
 								durationMs: Date.now() - startedAt,
 							});
+						}
+						if (error instanceof CommandExitError) {
+							return {
+								query,
+								result: error.output,
+								error: error.message,
+								success: false,
+							};
 						}
 						const msg = formatError(error);
 						return {

--- a/sdk/packages/core/src/extensions/tools/executors/bash.test.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/bash.test.ts
@@ -47,6 +47,33 @@ describe("createBashExecutor", () => {
 		expect(error.output).toContain("failure details");
 	});
 
+	it("excludes stderr on non-zero exit when combineOutput is false", async () => {
+		const bash = createBashExecutor({ combineOutput: false });
+		let error: unknown;
+		try {
+			await bash(
+				{
+					command: process.execPath,
+					args: [
+						"-e",
+						"process.stdout.write('visible'); process.stderr.write('hidden'); process.exit(1)",
+					],
+				},
+				process.cwd(),
+				ctx,
+			);
+		} catch (caught) {
+			error = caught;
+		}
+
+		if (!(error instanceof CommandExitError)) {
+			throw new Error("Expected CommandExitError");
+		}
+		expect(error.output).toContain("visible");
+		expect(error.output).not.toContain("[stderr]");
+		expect(error.output).not.toContain("hidden");
+	});
+
 	it("includes stderr in combined output on success", async () => {
 		const bash = createBashExecutor({ combineOutput: true });
 		const output = await bash(

--- a/sdk/packages/core/src/extensions/tools/executors/bash.test.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/bash.test.ts
@@ -1,6 +1,6 @@
 import type { AgentToolContext } from "@cline/shared";
 import { describe, expect, it } from "vitest";
-import { createBashExecutor } from "./bash";
+import { CommandExitError, createBashExecutor } from "./bash";
 
 const ctx: AgentToolContext = {
 	agentId: "agent-1",
@@ -18,6 +18,33 @@ describe("createBashExecutor", () => {
 	it("rejects on non-zero exit code", async () => {
 		const bash = createBashExecutor();
 		await expect(bash("exit 1", process.cwd(), ctx)).rejects.toThrow();
+	});
+
+	it("includes stdout and exit code on non-zero exit", async () => {
+		const bash = createBashExecutor();
+		let error: unknown;
+		try {
+			await bash(
+				{
+					command: process.execPath,
+					args: [
+						"-e",
+						"process.stdout.write('failure details'); process.exit(1)",
+					],
+				},
+				process.cwd(),
+				ctx,
+			);
+		} catch (caught) {
+			error = caught;
+		}
+
+		if (!(error instanceof CommandExitError)) {
+			throw new Error("Expected CommandExitError");
+		}
+		expect(error.exitCode).toBe(1);
+		expect(error.output).toContain("[Command exited with code 1]");
+		expect(error.output).toContain("failure details");
 	});
 
 	it("includes stderr in combined output on success", async () => {
@@ -109,10 +136,11 @@ describe("createBashExecutor", () => {
 		expect(output).toBe(payload);
 	});
 
-	it("marks truncation in the error when a failing command floods stderr", async () => {
+	it("marks truncation in the captured output when a failing command floods stderr", async () => {
 		const bash = createBashExecutor({ maxOutputBytes: 20 });
-		await expect(
-			bash(
+		let error: unknown;
+		try {
+			await bash(
 				{
 					command: process.execPath,
 					args: [
@@ -122,8 +150,15 @@ describe("createBashExecutor", () => {
 				},
 				process.cwd(),
 				ctx,
-			),
-		).rejects.toThrow("output truncated");
+			);
+		} catch (caught) {
+			error = caught;
+		}
+
+		if (!(error instanceof CommandExitError)) {
+			throw new Error("Expected CommandExitError");
+		}
+		expect(error.output).toContain("output truncated");
 	});
 
 	it("keeps the tail of streamed output written in many chunks", async () => {

--- a/sdk/packages/core/src/extensions/tools/executors/bash.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/bash.ts
@@ -210,30 +210,21 @@ function spawnAndCollect(
 
 			const out = stdout.snapshot();
 			const err = stderr.snapshot();
-			let output = combineOutput
-				? out.text + (err.text ? `\n[stderr]\n${err.text}` : "")
-				: out.text;
-			const dropped = out.dropped || (combineOutput && err.dropped);
-			if (dropped || output.length > maxOutputBytes) {
-				const totalChars = combineOutput
-					? out.totalChars + err.totalChars
-					: out.totalChars;
-				output = truncateMiddle(output, maxOutputBytes, totalChars);
-			}
 
 			if (code !== 0) {
 				const exitCode = code ?? 1;
-				let failureOutput =
-					out.text + (err.text ? `\n[stderr]\n${err.text}` : "");
-				if (
-					out.dropped ||
-					err.dropped ||
-					failureOutput.length > maxOutputBytes
-				) {
+				let failureOutput = combineOutput
+					? out.text + (err.text ? `\n[stderr]\n${err.text}` : "")
+					: out.text;
+				const dropped = out.dropped || (combineOutput && err.dropped);
+				const totalChars = combineOutput
+					? out.totalChars + err.totalChars
+					: out.totalChars;
+				if (dropped || failureOutput.length > maxOutputBytes) {
 					failureOutput = truncateMiddle(
 						failureOutput,
 						maxOutputBytes,
-						out.totalChars + err.totalChars,
+						totalChars,
 					);
 				}
 				const result =
@@ -242,6 +233,16 @@ function spawnAndCollect(
 						: `[Command exited with code ${exitCode}]`;
 				settle(() => reject(new CommandExitError(exitCode, result)));
 			} else {
+				let output = combineOutput
+					? out.text + (err.text ? `\n[stderr]\n${err.text}` : "")
+					: out.text;
+				const dropped = out.dropped || (combineOutput && err.dropped);
+				if (dropped || output.length > maxOutputBytes) {
+					const totalChars = combineOutput
+						? out.totalChars + err.totalChars
+						: out.totalChars;
+					output = truncateMiddle(output, maxOutputBytes, totalChars);
+				}
 				settle(() => resolve(output));
 			}
 		});

--- a/sdk/packages/core/src/extensions/tools/executors/bash.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/bash.ts
@@ -15,6 +15,16 @@ import { TimeoutError } from "../helpers";
 import type { BashExecutor } from "../types";
 import { MAX_COMMAND_OUTPUT_CHARS } from "./output-limits";
 
+export class CommandExitError extends Error {
+	constructor(
+		readonly exitCode: number,
+		readonly output: string,
+	) {
+		super(`Command exited with code ${exitCode}`);
+		this.name = "CommandExitError";
+	}
+}
+
 /**
  * Options for the bash executor
  */
@@ -212,12 +222,25 @@ function spawnAndCollect(
 			}
 
 			if (code !== 0) {
-				const stderrText = err.dropped
-					? truncateMiddle(err.text, maxOutputBytes, err.totalChars)
-					: err.text;
-				settle(() =>
-					reject(new Error(stderrText || `Command exited with code ${code}`)),
-				);
+				const exitCode = code ?? 1;
+				let failureOutput =
+					out.text + (err.text ? `\n[stderr]\n${err.text}` : "");
+				if (
+					out.dropped ||
+					err.dropped ||
+					failureOutput.length > maxOutputBytes
+				) {
+					failureOutput = truncateMiddle(
+						failureOutput,
+						maxOutputBytes,
+						out.totalChars + err.totalChars,
+					);
+				}
+				const result =
+					failureOutput.length > 0
+						? `[Command exited with code ${exitCode}]\n${failureOutput}`
+						: `[Command exited with code ${exitCode}]`;
+				settle(() => reject(new CommandExitError(exitCode, result)));
 			} else {
 				settle(() => resolve(output));
 			}


### PR DESCRIPTION
### Related Issue

Issue: #XXXX

Benchmark harness follow-up from the CLI efficiency investigation.

### Description

This PR fixes the `run_commands` failure path so nonzero command exits preserve the captured command output.

Before this change, the bash executor rejected nonzero exits with stderr only. That loses important failure details because many test runners and build tools print assertion failures, compile diagnostics, and summaries to stdout. The outer `run_commands` wrapper then returned `success: false` with an empty `result`, so the model often had to rerun the command just to see the useful output.

The implementation adds a typed `CommandExitError` that carries the bounded, already-capped command output along with the exit code. The public `run_commands` tool keeps nonzero exits as `success: false`, but now places the captured output in `result` and the short exit-code message in `error`.

This keeps timeout and spawn failures as real executor errors while making ordinary command failures useful to the model on the first try.

### Test Procedure

Ran focused SDK core tests:

```sh
bunx vitest run --config vitest.config.ts src/extensions/tools/executors/bash.test.ts src/extensions/tools/definitions.test.ts
```

Ran formatting and lint checks for the touched files:

```sh
bun biome check --files-ignore-unknown=true sdk/packages/core/src/extensions/tools/executors/bash.ts sdk/packages/core/src/extensions/tools/executors/bash.test.ts sdk/packages/core/src/extensions/tools/definitions.ts sdk/packages/core/src/extensions/tools/definitions.test.ts
```

Ran the core typecheck:

```sh
bun -F @cline/core typecheck
```

The new tests cover both the executor-level typed error and the model-visible `run_commands` result shape.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable. This is SDK executor behavior.

### Additional Notes

This builds on the existing output cap work: the output carried by `CommandExitError` is the executor's bounded output, not an unbounded raw stream.
