### PR TITLE
fix(sdk): coalesce split heredoc run_commands

### DIFF
--- a/sdk/packages/core/src/extensions/tools/definitions.test.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.test.ts
@@ -741,6 +741,97 @@ describe("default run_commands tool", () => {
 		]);
 	});
 
+	it("coalesces split heredocs while preserving surrounding command order", async () => {
+		const execute = vi.fn(
+			async (command: string | { command: string }) =>
+				`ran:${typeof command === "string" ? command : command.command}`,
+		);
+		const tool = createBashTool(execute);
+
+		const result = await tool.execute(
+			{
+				commands: [
+					"pwd",
+					"python3 << 'PYEOF'",
+					"print('ok')",
+					"PYEOF",
+					"ls /app",
+				],
+			},
+			{
+				sessionId: "session-surrounding-heredoc",
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 1,
+			},
+		);
+
+		const expectedCommand = "python3 << 'PYEOF'\nprint('ok')\nPYEOF";
+		expect(execute).toHaveBeenCalledTimes(3);
+		expect(execute).toHaveBeenNthCalledWith(
+			1,
+			"pwd",
+			process.cwd(),
+			expect.objectContaining({ sessionId: "session-surrounding-heredoc" }),
+		);
+		expect(execute).toHaveBeenNthCalledWith(
+			2,
+			expectedCommand,
+			process.cwd(),
+			expect.objectContaining({ sessionId: "session-surrounding-heredoc" }),
+		);
+		expect(execute).toHaveBeenNthCalledWith(
+			3,
+			"ls /app",
+			process.cwd(),
+			expect.objectContaining({ sessionId: "session-surrounding-heredoc" }),
+		);
+		expect(result).toEqual([
+			expect.objectContaining({ query: "pwd", result: "ran:pwd" }),
+			expect.objectContaining({
+				query: expectedCommand,
+				result: `ran:${expectedCommand}`,
+			}),
+			expect.objectContaining({ query: "ls /app", result: "ran:ls /app" }),
+		]);
+	});
+
+	it("coalesces split tab-stripping heredocs", async () => {
+		const execute = vi.fn(
+			async (command: string | { command: string }) =>
+				`ran:${typeof command === "string" ? command : command.command}`,
+		);
+		const tool = createBashTool(execute);
+
+		const result = await tool.execute(
+			{
+				commands: ["cat <<- EOF", "\tindented body", "EOF"],
+			},
+			{
+				sessionId: "session-tab-stripping-heredoc",
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 1,
+			},
+		);
+
+		const expectedCommand = "cat <<- EOF\n\tindented body\nEOF";
+		expect(execute).toHaveBeenCalledTimes(1);
+		expect(execute).toHaveBeenCalledWith(
+			expectedCommand,
+			process.cwd(),
+			expect.objectContaining({
+				sessionId: "session-tab-stripping-heredoc",
+			}),
+		);
+		expect(result).toEqual([
+			expect.objectContaining({
+				query: expectedCommand,
+				result: `ran:${expectedCommand}`,
+			}),
+		]);
+	});
+
 	it("does not coalesce independent command arrays", async () => {
 		const execute = vi.fn(
 			async (command: string | { command: string }) =>

--- a/sdk/packages/core/src/extensions/tools/definitions.test.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.test.ts
@@ -765,6 +765,89 @@ describe("default run_commands tool", () => {
 		]);
 	});
 
+	it("coalesces consecutive split heredoc command arrays independently", async () => {
+		const execute = vi.fn(
+			async (command: string | { command: string }) =>
+				`ran:${typeof command === "string" ? command : command.command}`,
+		);
+		const tool = createBashTool(execute);
+
+		const result = await tool.execute(
+			{
+				commands: [
+					"cat << 'FOO'",
+					"foo body",
+					"FOO",
+					"cat << 'BAR'",
+					"bar body",
+					"BAR",
+				],
+			},
+			{
+				sessionId: "session-consecutive-heredocs",
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 1,
+			},
+		);
+
+		const expectedFirstCommand = "cat << 'FOO'\nfoo body\nFOO";
+		const expectedSecondCommand = "cat << 'BAR'\nbar body\nBAR";
+		expect(execute).toHaveBeenCalledTimes(2);
+		expect(execute).toHaveBeenNthCalledWith(
+			1,
+			expectedFirstCommand,
+			process.cwd(),
+			expect.objectContaining({ sessionId: "session-consecutive-heredocs" }),
+		);
+		expect(execute).toHaveBeenNthCalledWith(
+			2,
+			expectedSecondCommand,
+			process.cwd(),
+			expect.objectContaining({ sessionId: "session-consecutive-heredocs" }),
+		);
+		expect(result).toEqual([
+			expect.objectContaining({
+				query: "cat << 'FOO'\nfoo body\nFOO",
+				result: `ran:${expectedFirstCommand}`,
+			}),
+			expect.objectContaining({
+				query: "cat << 'BAR'\nbar body\nBAR",
+				result: `ran:${expectedSecondCommand}`,
+			}),
+		]);
+	});
+
+	it("does not treat here-strings as split heredocs", async () => {
+		const execute = vi.fn(
+			async (command: string | { command: string }) =>
+				`ran:${typeof command === "string" ? command : command.command}`,
+		);
+		const tool = createBashTool(execute);
+
+		const result = await tool.execute(
+			{ commands: ['wc -c <<< "hello"', "hello"] },
+			{
+				sessionId: "session-here-string",
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 1,
+			},
+		);
+
+		expect(execute).toHaveBeenCalledTimes(2);
+		expect(result).toEqual([
+			expect.objectContaining({
+				query: 'wc -c <<< "hello"',
+				result: 'ran:wc -c <<< "hello"',
+			}),
+			expect.objectContaining({
+				query: "hello",
+				result: "ran:hello",
+			}),
+		]);
+	});
+
 	it("does not coalesce unterminated heredoc command arrays", async () => {
 		const execute = vi.fn(
 			async (command: string | { command: string }) =>

--- a/sdk/packages/core/src/extensions/tools/definitions.test.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.test.ts
@@ -700,6 +700,101 @@ describe("default run_commands tool", () => {
 		]);
 	});
 
+	it("coalesces split heredoc command arrays before execution", async () => {
+		const execute = vi.fn(
+			async (command: string | { command: string }) =>
+				`ran:${typeof command === "string" ? command : command.command}`,
+		);
+		const tool = createBashTool(execute);
+
+		const result = await tool.execute(
+			{
+				commands: [
+					"cd /app && python3 << 'PYEOF'",
+					"import csv",
+					"print('ok')",
+					"PYEOF",
+				],
+			},
+			{
+				sessionId: "session-split-heredoc",
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 1,
+			},
+		);
+
+		const expectedCommand =
+			"cd /app && python3 << 'PYEOF'\nimport csv\nprint('ok')\nPYEOF";
+		expect(execute).toHaveBeenCalledTimes(1);
+		expect(execute).toHaveBeenCalledWith(
+			expectedCommand,
+			process.cwd(),
+			expect.objectContaining({ sessionId: "session-split-heredoc" }),
+		);
+		expect(result).toEqual([
+			expect.objectContaining({
+				query: expect.stringContaining("cd /app && python3"),
+				result: `ran:${expectedCommand}`,
+				success: true,
+			}),
+		]);
+	});
+
+	it("does not coalesce independent command arrays", async () => {
+		const execute = vi.fn(
+			async (command: string | { command: string }) =>
+				`ran:${typeof command === "string" ? command : command.command}`,
+		);
+		const tool = createBashTool(execute);
+
+		const result = await tool.execute(
+			{ commands: ["pwd", "ls /app"] },
+			{
+				sessionId: "session-independent-commands",
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 1,
+			},
+		);
+
+		expect(execute).toHaveBeenCalledTimes(2);
+		expect(result).toEqual([
+			expect.objectContaining({ query: "pwd", result: "ran:pwd" }),
+			expect.objectContaining({ query: "ls /app", result: "ran:ls /app" }),
+		]);
+	});
+
+	it("does not coalesce unterminated heredoc command arrays", async () => {
+		const execute = vi.fn(
+			async (command: string | { command: string }) =>
+				`ran:${typeof command === "string" ? command : command.command}`,
+		);
+		const tool = createBashTool(execute);
+
+		const result = await tool.execute(
+			{ commands: ["python3 << 'PYEOF'", "print('ok')"] },
+			{
+				sessionId: "session-unterminated-heredoc",
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 1,
+			},
+		);
+
+		expect(execute).toHaveBeenCalledTimes(2);
+		expect(result).toEqual([
+			expect.objectContaining({
+				query: "python3 << 'PYEOF'",
+				result: "ran:python3 << 'PYEOF'",
+			}),
+			expect.objectContaining({
+				query: "print('ok')",
+				result: "ran:print('ok')",
+			}),
+		]);
+	});
+
 	it("truncates long command echoes in tool results without affecting execution", async () => {
 		const execute = vi.fn(
 			async (command: string | { command: string }) =>

--- a/sdk/packages/core/src/extensions/tools/definitions.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.ts
@@ -112,7 +112,7 @@ function captureRunCommandsTimeoutFromContext(
 
 function getHeredocDelimiter(command: string): string | undefined {
 	const match = command.match(
-		/<<-?\s*(?:"([^"]+)"|'([^']+)'|([A-Za-z0-9_./-]+))/,
+		/(?<![<])<<-?\s*(?:"([^"]+)"|'([^']+)'|([A-Za-z0-9_./-]+))/,
 	);
 	return match?.[1] ?? match?.[2] ?? match?.[3];
 }

--- a/sdk/packages/core/src/extensions/tools/definitions.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.ts
@@ -110,6 +110,43 @@ function captureRunCommandsTimeoutFromContext(
 	});
 }
 
+function getHeredocDelimiter(command: string): string | undefined {
+	const match = command.match(
+		/<<-?\s*(?:"([^"]+)"|'([^']+)'|([A-Za-z0-9_./-]+))/,
+	);
+	return match?.[1] ?? match?.[2] ?? match?.[3];
+}
+
+function coalesceSplitHeredocCommands(commands: string[]): string[] {
+	const coalesced: string[] = [];
+	for (let index = 0; index < commands.length; index += 1) {
+		const command = commands[index];
+		const delimiter = getHeredocDelimiter(command);
+		if (!delimiter) {
+			coalesced.push(command);
+			continue;
+		}
+
+		const endIndex = commands.findIndex(
+			(nextCommand, nextIndex) =>
+				nextIndex > index && nextCommand.trim() === delimiter,
+		);
+		if (endIndex === -1) {
+			coalesced.push(command);
+			continue;
+		}
+
+		const parts = [command];
+		while (index < endIndex) {
+			index += 1;
+			const nextCommand = commands[index];
+			parts.push(nextCommand);
+		}
+		coalesced.push(parts.join("\n"));
+	}
+	return coalesced;
+}
+
 // =============================================================================
 // AgentTool Factory Functions
 // =============================================================================
@@ -289,7 +326,7 @@ export function createBashTool(
 		description:
 			"Run shell commands from the root of the workspace. " +
 			"Use for listing files, checking git status, running builds, executing tests, etc. " +
-			"Commands should be properly shell-escaped and targeted to avoid error or timeout. Include multiple commands when they are independent and safe to run concurrently. " +
+			"Commands should be properly shell-escaped and targeted to avoid error or timeout. Include multiple commands only when they are independent complete shell commands and safe to run concurrently; multiline scripts and heredocs must be a single command string. " +
 			`Output beyond ~${Math.round(MAX_COMMAND_OUTPUT_CHARS / 1000)}k characters is middle-truncated (start and end preserved); pipe through grep/head/tail when you need specific sections of large output. ` +
 			"For long-running commands, run them in background and redirect output to a tmp file that you can read from later.",
 		inputSchema: zodToJsonSchema(RunCommandsInputSchema),
@@ -312,6 +349,7 @@ export function createBashTool(
 			} else {
 				commands = [validate.cmd];
 			}
+			commands = coalesceSplitHeredocCommands(commands);
 
 			return Promise.all(
 				commands.map(async (command: string): Promise<ToolOperationResult> => {


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Fixes a `run_commands` tool-input failure mode found in Harbor token-efficiency traces.

`run_commands.commands[]` is intended to contain independent complete shell commands that can run concurrently. In at least one trace, the model emitted a heredoc script split across array entries:

```json
[
  "cd /app && python3 << 'PYEOF'",
  "import csv",
  "print('ok')",
  "PYEOF"
]
```

Before this PR, Cline executed those entries as separate parallel shell commands, so lines such as `import csv` and `PYEOF` ran as standalone commands. In the sampled Harbor task `protein-assembly`, 7 intended heredoc scripts expanded into 402 command-array entries; coalescing those obvious split heredocs would reduce that to 7 actual shell executions.

This PR keeps the fix narrow:

- clarifies the tool description that `commands[]` entries must be independent complete commands, and multiline scripts/heredocs belong in one string
- detects unambiguous split heredocs with a matching delimiter later in the same `commands[]` array
- joins only that heredoc span into one newline-delimited shell command before execution
- leaves normal independent command arrays untouched
- leaves unterminated heredoc-looking arrays untouched rather than guessing

### Test Procedure

Validated locally in a clean worktree from `origin/main`:

- `cd sdk/packages/core && bunx vitest run --config vitest.config.ts src/extensions/tools/definitions.test.ts` — 47 passed
- `cd sdk && bun -F @cline/core typecheck` — passed
- `bun biome check --files-ignore-unknown=true sdk/packages/core/src/extensions/tools/definitions.ts sdk/packages/core/src/extensions/tools/definitions.test.ts` — passed

Regression tests cover:

- split heredoc command arrays are coalesced into one executor call
- ordinary independent command arrays still execute as separate commands
- unterminated heredoc-looking arrays are not coalesced

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A backend tool-runtime change.

### Additional Notes

This intentionally does not attempt to parse shell generally. It only repairs the high-signal malformed-input case where a heredoc opener and matching delimiter are separate entries in the same `commands[]` array.
