### PR TITLE
fix(sdk): guide repeated run_commands polling loops

### DIFF
--- a/sdk/packages/core/src/extensions/tools/definitions.test.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.test.ts
@@ -864,6 +864,80 @@ describe("default run_commands tool", () => {
 		expect(result[0]?.result).toContain("Skipped exact repeated command");
 	});
 
+	it("adds guidance after repeated similar polling commands", async () => {
+		const execute = vi.fn(
+			async (command: string | { command: string }) =>
+				`ran:${typeof command === "string" ? command : command.command}`,
+		);
+		const tool = createShellTool(execute);
+		const context = {
+			sessionId: "session-repeated-polling",
+			agentId: "agent-1",
+			conversationId: "conv-1",
+			iteration: 1,
+		};
+
+		await tool.execute({ commands: ["tail -5 /tmp/build.log"] }, context);
+		await tool.execute(
+			{ commands: ["tail -10 /tmp/build.log"] },
+			{ ...context, iteration: 2 },
+		);
+		const result = await tool.execute(
+			{ commands: ["tail -30 /tmp/build.log"] },
+			{ ...context, iteration: 3 },
+		);
+
+		expect(execute).toHaveBeenCalledTimes(3);
+		expect(result).toEqual([
+			expect.objectContaining({
+				query: "tail -30 /tmp/build.log",
+				success: true,
+			}),
+		]);
+		expect(result[0]?.result).toContain("ran:tail -30 /tmp/build.log");
+		expect(result[0]?.result).toContain("Do not keep polling in short loops");
+	});
+
+	it("resets polling guidance after a successful file edit", async () => {
+		const executeBash = vi.fn(
+			async (command: string | { command: string }) =>
+				`ran:${typeof command === "string" ? command : command.command}`,
+		);
+		const executeEdit = vi.fn(async () => "patched");
+		const bashTool = createShellTool(executeBash);
+		const editorTool = createEditorTool(executeEdit);
+		const context = {
+			sessionId: "session-polling-reset-after-edit",
+			agentId: "agent-1",
+			conversationId: "conv-1",
+			iteration: 1,
+		};
+
+		await bashTool.execute({ commands: ["tail -5 /tmp/build.log"] }, context);
+		await bashTool.execute(
+			{ commands: ["tail -10 /tmp/build.log"] },
+			{ ...context, iteration: 2 },
+		);
+		await editorTool.execute(
+			{
+				path: "/tmp/example.ts",
+				old_text: "before",
+				new_text: "after",
+			},
+			{ ...context, iteration: 3 },
+		);
+		const result = await bashTool.execute(
+			{ commands: ["tail -30 /tmp/build.log"] },
+			{ ...context, iteration: 4 },
+		);
+
+		expect(executeBash).toHaveBeenCalledTimes(3);
+		expect(result[0]?.result).toContain("ran:tail -30 /tmp/build.log");
+		expect(result[0]?.result).not.toContain(
+			"Do not keep polling in short loops",
+		);
+	});
+
 	it("coalesces split heredoc command arrays before execution", async () => {
 		const execute = vi.fn(
 			async (command: string | { command: string }) =>
@@ -1324,10 +1398,10 @@ describe("default run_commands tool", () => {
 		const result = await tool.execute(
 			{ commands: ["echo secret-token", "pwd"] },
 			{
-				sessionId: "session-1",
+				sessionId: "session-2",
 				agentId: "agent-1",
 				conversationId: "conv-1",
-				runId: "run-1",
+				runId: "run-2",
 				iteration: 1,
 				toolCallId: "tool-call-1",
 				metadata: {
@@ -1350,13 +1424,13 @@ describe("default run_commands tool", () => {
 				effective_timeout_ms: 5,
 				timeout_source: "configured_setting",
 				command_count: 2,
-				ulid: "session-1",
+				ulid: "session-2",
 				mode: "act",
 				source: "sdk-test",
-				session_id: "session-1",
+				session_id: "session-2",
 				agent_id: "agent-1",
 				conversation_id: "conv-1",
-				run_id: "run-1",
+				run_id: "run-2",
 				iteration: 1,
 				tool_call_id: "tool-call-1",
 			});

--- a/sdk/packages/core/src/extensions/tools/definitions.test.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.test.ts
@@ -6,6 +6,7 @@ import {
 } from "../../services/telemetry/tool-context";
 import {
 	createDefaultTools,
+	createEditorTool,
 	createReadFilesTool,
 	createSearchTool,
 	createShellTool,
@@ -697,6 +698,170 @@ describe("default run_commands tool", () => {
 				success: false,
 			},
 		]);
+	});
+
+	it("skips exact repeated commands in the same session", async () => {
+		const execute = vi.fn(
+			async (command: string | { command: string }) =>
+				`ran:${typeof command === "string" ? command : command.command}`,
+		);
+		const tool = createShellTool(execute);
+		const context = {
+			sessionId: "session-repeated-command",
+			agentId: "agent-1",
+			conversationId: "conv-1",
+			iteration: 1,
+		};
+
+		await tool.execute({ commands: ["python3 --version"] }, context);
+		const result = await tool.execute(
+			{ commands: ["python3 --version"] },
+			{ ...context, iteration: 2 },
+		);
+
+		expect(result).toEqual([
+			expect.objectContaining({
+				query: "python3 --version",
+				success: true,
+			}),
+		]);
+		expect(execute).toHaveBeenCalledTimes(1);
+		expect(result[0]?.result).toContain("Skipped exact repeated command");
+		expect(result[0]?.result).not.toContain("ran:python3 --version");
+	});
+
+	it("allows an exact command rerun after a successful file edit", async () => {
+		const executeBash = vi.fn(
+			async (command: string | { command: string }) =>
+				`ran:${typeof command === "string" ? command : command.command}`,
+		);
+		const executeEdit = vi.fn(async () => "patched");
+		const bashTool = createShellTool(executeBash);
+		const editorTool = createEditorTool(executeEdit);
+		const context = {
+			sessionId: "session-repeat-after-edit",
+			agentId: "agent-1",
+			conversationId: "conv-1",
+			iteration: 1,
+		};
+
+		await bashTool.execute({ commands: ["npm test"] }, context);
+		await editorTool.execute(
+			{
+				path: "/tmp/example.ts",
+				old_text: "before",
+				new_text: "after",
+			},
+			{ ...context, iteration: 2 },
+		);
+		const result = await bashTool.execute(
+			{ commands: ["npm test"] },
+			{ ...context, iteration: 3 },
+		);
+
+		expect(executeBash).toHaveBeenCalledTimes(2);
+		expect(result).toEqual([
+			expect.objectContaining({
+				query: "npm test",
+				result: expect.stringContaining("ran:npm test"),
+				success: true,
+			}),
+		]);
+	});
+
+	it("allows an exact command rerun after a successful shell mutation", async () => {
+		const execute = vi.fn(
+			async (command: string | { command: string }) =>
+				`ran:${typeof command === "string" ? command : command.command}`,
+		);
+		const tool = createShellTool(execute);
+		const context = {
+			sessionId: "session-repeat-after-shell-mutation",
+			agentId: "agent-1",
+			conversationId: "conv-1",
+			iteration: 1,
+		};
+
+		await tool.execute({ commands: ["npm test"] }, context);
+		await tool.execute(
+			{ commands: ["sed -i 's/before/after/' src/example.ts"] },
+			{ ...context, iteration: 2 },
+		);
+		const result = await tool.execute(
+			{ commands: ["npm test"] },
+			{ ...context, iteration: 3 },
+		);
+
+		expect(execute).toHaveBeenCalledTimes(3);
+		expect(result).toEqual([
+			expect.objectContaining({
+				query: "npm test",
+				result: expect.stringContaining("ran:npm test"),
+				success: true,
+			}),
+		]);
+	});
+
+	it("does not treat stderr fd duplication as a workspace mutation", async () => {
+		const execute = vi.fn(
+			async (command: string | { command: string }) =>
+				`ran:${typeof command === "string" ? command : command.command}`,
+		);
+		const tool = createShellTool(execute);
+		const context = {
+			sessionId: "session-stderr-redirection-is-not-mutation",
+			agentId: "agent-1",
+			conversationId: "conv-1",
+			iteration: 1,
+		};
+
+		await tool.execute({ commands: ["pmars -b warrior.red 2>&1"] }, context);
+		await tool.execute(
+			{ commands: ["other-check 2>&1"] },
+			{ ...context, iteration: 2 },
+		);
+		const result = await tool.execute(
+			{ commands: ["pmars -b warrior.red 2>&1"] },
+			{ ...context, iteration: 3 },
+		);
+
+		expect(execute).toHaveBeenCalledTimes(2);
+		expect(result).toEqual([
+			expect.objectContaining({
+				query: "pmars -b warrior.red 2>&1",
+				success: true,
+			}),
+		]);
+		expect(result[0]?.result).toContain("Skipped exact repeated command");
+	});
+
+	it("skips an exact repeated shell mutation command", async () => {
+		const execute = vi.fn(
+			async (command: string | { command: string }) =>
+				`ran:${typeof command === "string" ? command : command.command}`,
+		);
+		const tool = createShellTool(execute);
+		const context = {
+			sessionId: "session-repeated-shell-mutation",
+			agentId: "agent-1",
+			conversationId: "conv-1",
+			iteration: 1,
+		};
+
+		await tool.execute({ commands: ["rm -f /app/povray-2.2.tgz"] }, context);
+		const result = await tool.execute(
+			{ commands: ["rm -f /app/povray-2.2.tgz"] },
+			{ ...context, iteration: 2 },
+		);
+
+		expect(execute).toHaveBeenCalledTimes(1);
+		expect(result).toEqual([
+			expect.objectContaining({
+				query: "rm -f /app/povray-2.2.tgz",
+				success: true,
+			}),
+		]);
+		expect(result[0]?.result).toContain("Skipped exact repeated command");
 	});
 
 	it("coalesces split heredoc command arrays before execution", async () => {

--- a/sdk/packages/core/src/extensions/tools/definitions.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.ts
@@ -23,6 +23,7 @@ import {
 import {
 	formatError,
 	formatReadFileQuery,
+	formatRunCommandQuery,
 	formatRunCommandQueryPreview,
 	getEditorSizeError,
 	getReadFileRangeError,
@@ -172,6 +173,142 @@ function coalesceAdjacentStringHeredocs(
 	return coalesced;
 }
 
+const MAX_TOOL_HISTORY_SCOPES = 200;
+const workspaceMutationRevisionByScope = new Map<string, number>();
+const previousRunCommandResultsByScope = new Map<
+	string,
+	Map<
+		string,
+		{
+			count: number;
+			revision: number;
+			query: string;
+			success: boolean;
+			error?: string;
+		}
+	>
+>();
+
+type PreviousRunCommandResult = {
+	count: number;
+	revision: number;
+	query: string;
+	success: boolean;
+	error?: string;
+};
+
+function getToolHistoryScopeKey(context: AgentToolContext): string | undefined {
+	if (context.runId) {
+		return `run:${context.runId}`;
+	}
+	if (context.sessionId) {
+		return `session:${context.sessionId}`;
+	}
+	return undefined;
+}
+
+function getScopeMutationRevision(scope: string | undefined): number {
+	if (!scope) {
+		return 0;
+	}
+	return workspaceMutationRevisionByScope.get(scope) ?? 0;
+}
+
+function bumpScopeMutationRevisionForScope(scope: string | undefined): void {
+	if (!scope) {
+		return;
+	}
+	workspaceMutationRevisionByScope.set(
+		scope,
+		getScopeMutationRevision(scope) + 1,
+	);
+}
+
+function bumpScopeMutationRevision(context: AgentToolContext): void {
+	bumpScopeMutationRevisionForScope(getToolHistoryScopeKey(context));
+}
+
+function getScopedCommandResultMap(
+	scope: string | undefined,
+): Map<string, PreviousRunCommandResult> | undefined {
+	if (!scope) {
+		return undefined;
+	}
+	if (
+		!previousRunCommandResultsByScope.has(scope) &&
+		previousRunCommandResultsByScope.size >= MAX_TOOL_HISTORY_SCOPES
+	) {
+		const oldestScope = previousRunCommandResultsByScope.keys().next().value;
+		if (oldestScope) {
+			previousRunCommandResultsByScope.delete(oldestScope);
+			workspaceMutationRevisionByScope.delete(oldestScope);
+		}
+	}
+	let commands = previousRunCommandResultsByScope.get(scope);
+	if (!commands) {
+		commands = new Map();
+		previousRunCommandResultsByScope.set(scope, commands);
+	}
+	return commands;
+}
+
+function getRepeatedCommandSkip(
+	scope: string | undefined,
+	commandKey: string,
+): ToolOperationResult | undefined {
+	const commandResults = getScopedCommandResultMap(scope);
+	const previous = commandResults?.get(commandKey);
+	if (!previous || previous.revision !== getScopeMutationRevision(scope)) {
+		return undefined;
+	}
+	previous.count += 1;
+	const skippedResult: ToolOperationResult = {
+		query: previous.query,
+		result:
+			`Tool guidance: Skipped exact repeated command (already run ${previous.count} times since the last file edit). ` +
+			"Reuse the previous result already in the conversation, edit files before rerunning tests, or run a different targeted command.",
+		success: previous.success,
+	};
+	if (!previous.success && previous.error) {
+		skippedResult.error = previous.error;
+	}
+	return skippedResult;
+}
+
+function rememberCommandResult(
+	scope: string | undefined,
+	commandKey: string,
+	result: ToolOperationResult,
+): void {
+	const commandResults = getScopedCommandResultMap(scope);
+	if (!commandResults) {
+		return;
+	}
+	commandResults.set(commandKey, {
+		count: 1,
+		revision: getScopeMutationRevision(scope),
+		query: result.query,
+		success: result.success,
+		error: result.error,
+	});
+}
+
+function commandLikelyMutatesWorkspace(command: string): boolean {
+	return (
+		/(?:^|[;&|({]\s*)(?:rm|mv|cp|mkdir|touch|chmod|chown|ln|install)\b/.test(
+			command,
+		) ||
+		/(?:^|[;&|({]\s*)(?:git\s+(?:apply|checkout|switch|restore|clean|reset))\b/.test(
+			command,
+		) ||
+		/(?:^|[;&|({]\s*)(?:sed\s+-i|perl\s+-pi)\b/.test(command) ||
+		/(?:^|[;&|({]\s*)(?:(?:npm|pnpm|yarn|bun)\s+install)\b/.test(command) ||
+		/(?:^|[;&|({]\s*)(?:tar\s+[\s\S]*\b-x|unzip)\b/.test(command) ||
+		/(?:^|[;&|({]\s*)(?:curl[\s\S]*\s-o\s|wget[\s\S]*\s-O\s)/.test(command) ||
+		/(?:^|[\s;|&({])(?:\d*)>>?\s*(?!&\d\b|\/dev\/null\b)\S/.test(command)
+	);
+}
+
 async function executeShellCommands(
 	commands: Array<string | StructuredCommandInput>,
 	options: {
@@ -183,22 +320,33 @@ async function executeShellCommands(
 	},
 ): Promise<ToolOperationResult[]> {
 	const { executor, cwd, context, timeoutMs, timeoutSource } = options;
+	const scope = getToolHistoryScopeKey(context);
 
 	return Promise.all(
 		commands.map(async (command): Promise<ToolOperationResult> => {
 			const startedAt = Date.now();
+			const commandKey = formatRunCommandQuery(command);
 			const query = formatRunCommandQueryPreview(command);
+			const skippedRepeat = getRepeatedCommandSkip(scope, commandKey);
+			if (skippedRepeat) {
+				return skippedRepeat;
+			}
 			try {
 				const output = await withTimeout(
 					executor(command, cwd, context),
 					timeoutMs,
 					`Command timed out after ${timeoutMs}ms`,
 				);
-				return {
+				const result = {
 					query,
 					result: output,
 					success: true,
 				};
+				if (commandLikelyMutatesWorkspace(commandKey)) {
+					bumpScopeMutationRevisionForScope(scope);
+				}
+				rememberCommandResult(scope, commandKey, result);
+				return result;
 			} catch (error) {
 				if (error instanceof TimeoutError) {
 					captureRunCommandsTimeoutFromContext(context, {
@@ -209,20 +357,24 @@ async function executeShellCommands(
 					});
 				}
 				if (error instanceof CommandExitError) {
-					return {
+					const result = {
 						query,
 						result: error.output,
 						error: error.message,
 						success: false,
 					};
+					rememberCommandResult(scope, commandKey, result);
+					return result;
 				}
 				const msg = formatError(error);
-				return {
+				const result = {
 					query,
 					result: "",
 					error: `Command failed: ${msg}`,
 					success: false,
 				};
+				rememberCommandResult(scope, commandKey, result);
+				return result;
 			}
 		}),
 	);
@@ -561,6 +713,7 @@ export function createApplyPatchTool(
 					`apply_patch timed out after ${timeoutMs}ms`,
 				);
 
+				bumpScopeMutationRevision(context);
 				return {
 					query: "apply_patch",
 					result,
@@ -624,6 +777,7 @@ export function createEditorTool(
 					`Editor operation timed out after ${timeoutMs}ms`,
 				);
 
+				bumpScopeMutationRevision(context);
 				return {
 					query: `${operation}:${validatedInput.path}`,
 					result,

--- a/sdk/packages/core/src/extensions/tools/definitions.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.ts
@@ -174,6 +174,7 @@ function coalesceAdjacentStringHeredocs(
 }
 
 const MAX_TOOL_HISTORY_SCOPES = 200;
+const POLLING_GUIDANCE_THRESHOLD = 3;
 const workspaceMutationRevisionByScope = new Map<string, number>();
 const previousRunCommandResultsByScope = new Map<
 	string,
@@ -185,6 +186,17 @@ const previousRunCommandResultsByScope = new Map<
 			query: string;
 			success: boolean;
 			error?: string;
+		}
+	>
+>();
+const pollingCommandCountsByScope = new Map<
+	string,
+	Map<
+		string,
+		{
+			count: number;
+			revision: number;
+			label: string;
 		}
 	>
 >();
@@ -241,6 +253,7 @@ function getScopedCommandResultMap(
 		const oldestScope = previousRunCommandResultsByScope.keys().next().value;
 		if (oldestScope) {
 			previousRunCommandResultsByScope.delete(oldestScope);
+			pollingCommandCountsByScope.delete(oldestScope);
 			workspaceMutationRevisionByScope.delete(oldestScope);
 		}
 	}
@@ -248,6 +261,20 @@ function getScopedCommandResultMap(
 	if (!commands) {
 		commands = new Map();
 		previousRunCommandResultsByScope.set(scope, commands);
+	}
+	return commands;
+}
+
+function getScopedPollingCommandMap(
+	scope: string | undefined,
+): Map<string, { count: number; revision: number; label: string }> | undefined {
+	if (!scope) {
+		return undefined;
+	}
+	let commands = pollingCommandCountsByScope.get(scope);
+	if (!commands) {
+		commands = new Map();
+		pollingCommandCountsByScope.set(scope, commands);
 	}
 	return commands;
 }
@@ -291,6 +318,114 @@ function rememberCommandResult(
 		success: result.success,
 		error: result.error,
 	});
+}
+
+function appendToolGuidance(message: string, guidance: string): string {
+	if (!message) {
+		return `Tool guidance: ${guidance}`;
+	}
+	return `${message}\n\nTool guidance: ${guidance}`;
+}
+
+function normalizePollingCommand(command: string): string {
+	return command
+		.replace(/^\s*(?:sleep\s+\d+(?:\.\d+)?\s*(?:&&|;)\s*)+/g, "")
+		.replace(/\b(tail|head)\s+-(?:[nc]\s*)?\d+\b/g, "$1 -n <n>")
+		.replace(/\bps\s+-p\s+\d+\b/g, "ps -p <pid>")
+		.replace(/\bgrep\s+\d{2,}\b/g, "grep <id>")
+		.replace(/\b\d{4,}\b/g, "<n>")
+		.replace(/\s+/g, " ")
+		.trim();
+}
+
+function getPollingCommandInfo(
+	command: string,
+): { key: string; label: string } | undefined {
+	const normalized = normalizePollingCommand(command);
+	const lower = normalized.toLowerCase();
+
+	const tailOrHeadMatch = lower.match(
+		/\b(?:tail|head)\s+(?:-n\s+<n>\s+)?([/~.$\w][^\s|;&]*)/,
+	);
+	if (tailOrHeadMatch?.[1]) {
+		return {
+			key: `log-read:${tailOrHeadMatch[1]}`,
+			label: `log reads of ${tailOrHeadMatch[1]}`,
+		};
+	}
+
+	const wcMatch = lower.match(/\bwc\s+-l\s+([/~.$\w-][^\s|;&]*)/);
+	if (wcMatch?.[1]) {
+		return {
+			key: `line-count:${wcMatch[1]}`,
+			label: `line counts of ${wcMatch[1]}`,
+		};
+	}
+
+	const statMatch = lower.match(
+		/\bstat\s+-c\s+['"]?%s['"]?\s+([/~.$\w-][^\s|;&]*)/,
+	);
+	if (statMatch?.[1]) {
+		return {
+			key: `size-check:${statMatch[1]}`,
+			label: `size checks of ${statMatch[1]}`,
+		};
+	}
+
+	const findCountMatch = lower.match(
+		/\bfind\s+([/~.$\w-][^\s|;&]*).*?\|\s*wc\s+-l/,
+	);
+	if (findCountMatch?.[1]) {
+		return {
+			key: `file-count:${findCountMatch[1]}`,
+			label: `file counts under ${findCountMatch[1]}`,
+		};
+	}
+
+	if (/\b(?:ps|pgrep)\b/.test(lower)) {
+		return {
+			key: `process-check:${normalized}`,
+			label: "process status checks",
+		};
+	}
+
+	if (/^sleep\s+\d+(?:\.\d+)?$/.test(lower)) {
+		return {
+			key: "sleep-only",
+			label: "sleep-only waits",
+		};
+	}
+
+	return undefined;
+}
+
+function getPollingGuidanceAfterCommand(
+	scope: string | undefined,
+	command: string,
+): string | undefined {
+	const pollingInfo = getPollingCommandInfo(command);
+	if (!pollingInfo) {
+		return undefined;
+	}
+	const pollingCommands = getScopedPollingCommandMap(scope);
+	if (!pollingCommands) {
+		return undefined;
+	}
+	const revision = getScopeMutationRevision(scope);
+	const previous = pollingCommands.get(pollingInfo.key);
+	const count = previous?.revision === revision ? previous.count + 1 : 1;
+	pollingCommands.set(pollingInfo.key, {
+		count,
+		revision,
+		label: pollingInfo.label,
+	});
+	if (count < POLLING_GUIDANCE_THRESHOLD) {
+		return undefined;
+	}
+	return (
+		`You have repeated ${pollingInfo.label} ${count} times without a file edit. ` +
+		"Do not keep polling in short loops; use one longer wait/read if needed, inspect the saved log/output directly, or proceed/submit if there is enough evidence."
+	);
 }
 
 function commandLikelyMutatesWorkspace(command: string): boolean {
@@ -337,9 +472,15 @@ async function executeShellCommands(
 					timeoutMs,
 					`Command timed out after ${timeoutMs}ms`,
 				);
+				const pollingGuidance =
+					typeof command === "string"
+						? getPollingGuidanceAfterCommand(scope, commandKey)
+						: undefined;
 				const result = {
 					query,
-					result: output,
+					result: pollingGuidance
+						? appendToolGuidance(output, pollingGuidance)
+						: output,
 					success: true,
 				};
 				if (commandLikelyMutatesWorkspace(commandKey)) {
@@ -357,9 +498,15 @@ async function executeShellCommands(
 					});
 				}
 				if (error instanceof CommandExitError) {
+					const pollingGuidance =
+						typeof command === "string"
+							? getPollingGuidanceAfterCommand(scope, commandKey)
+							: undefined;
 					const result = {
 						query,
-						result: error.output,
+						result: pollingGuidance
+							? appendToolGuidance(error.output, pollingGuidance)
+							: error.output,
 						error: error.message,
 						success: false,
 					};


### PR DESCRIPTION
## Summary

Rebased onto `main` after closing #11519.

Adds a non-blocking guidance guardrail for repeated status/progress polling in `run_commands`:

- detects repeated log/progress reads such as `tail -5`, `tail -30`, `wc -l`, `stat -c %s`, `find ... | wc -l`, `ps`, `pgrep`, and sleep-only waits
- normalizes common variants so `tail -5 /tmp/build.log` and `tail -30 /tmp/build.log` count as the same polling loop
- after the third similar poll in the same run/session mutation revision, appends guidance to the tool result
- always executes the command; it does not skip execution or replay stale output
- resets after successful `editor`, `apply_patch`, or likely-mutating shell commands

This keeps the useful part of the repeated-command work without the unsafe hard exact-repeat skip from #11519.

## Validation

- `bun install --frozen-lockfile`
- `cd sdk/packages/core && bun -F @cline/shared build && bunx vitest run --config vitest.config.ts src/extensions/tools/definitions.test.ts`
- `cd sdk && bun -F @cline/core typecheck`
- `bun biome check --files-ignore-unknown=true sdk/packages/core/src/extensions/tools/definitions.ts sdk/packages/core/src/extensions/tools/definitions.test.ts`
