### PR TITLE
fix: hook status stuck in Running for NoOp hooks (#9337)

### DIFF
--- a/apps/vscode/src/core/hooks/hook-executor.ts
+++ b/apps/vscode/src/core/hooks/hook-executor.ts
@@ -159,6 +159,17 @@ export async function executeHook<Name extends keyof Hooks>(options: HookExecuti
 
 		// NoOp hooks return proto defaults; preserve the minimal legacy return shape.
 		if (result.cancel === false && result.contextModification === "" && result.errorMessage === "") {
+			// Update hook status to completed even for NoOp hooks
+			if (hookMessageTs !== undefined) {
+				await updateHookMessage(messageStateHandler, hookMessageTs, {
+					hookName,
+					...(options.toolName && { toolName: options.toolName }),
+					status: "completed",
+					exitCode: 0,
+					hasJsonResponse: false,
+					scriptPaths: hookInfo.scriptPaths,
+				})
+			}
 			return { wasCancelled: false }
 		}
 

--- a/apps/vscode/src/core/hooks/hook-executor.ts
+++ b/apps/vscode/src/core/hooks/hook-executor.ts
@@ -159,6 +159,11 @@ export async function executeHook<Name extends keyof Hooks>(options: HookExecuti
 
 		// NoOp hooks return proto defaults; preserve the minimal legacy return shape.
 		if (result.cancel === false && result.contextModification === "" && result.errorMessage === "") {
+			// Clear active hook execution after successful completion (only if cancellable)
+			if (isCancellable && clearActiveHookExecution) {
+				await clearActiveHookExecution()
+			}
+
 			// Update hook status to completed even for NoOp hooks
 			if (hookMessageTs !== undefined) {
 				await updateHookMessage(messageStateHandler, hookMessageTs, {

--- a/apps/vscode/src/test/hook-executor.test.ts
+++ b/apps/vscode/src/test/hook-executor.test.ts
@@ -684,5 +684,59 @@ setTimeout(() => {
 			result.wasCancelled.should.equal(false)
 			// contextModification and errorMessage may be undefined
 		})
+
+		it("should update hook status to completed for NoOp hooks", async function () {
+			this.timeout(5000)
+
+			await createHookScript("TaskStart", {
+				cancel: false,
+			})
+
+			const messages: ClineMessage[] = []
+			const mockHandler = {
+				...testHandler,
+				getClineMessages: () => messages,
+				updateClineMessage: async (index: number, updates: Partial<ClineMessage>) => {
+					if (messages[index]) {
+						Object.assign(messages[index], updates)
+					}
+				},
+			} as any
+
+			await executeHook({
+				hookName: "TaskStart",
+				hookInput: {
+					taskStart: {
+						taskMetadata: {
+							taskId: "test-task",
+							ulid: "test-ulid",
+							initialTask: "test task",
+						},
+					},
+				},
+				isCancellable: true,
+				say: async (type: any) => {
+					const msg: ClineMessage = {
+						ts: Date.now(),
+						type: "say",
+						say: type,
+						text: "",
+					}
+					messages.push(msg)
+					return msg.ts
+				},
+				messageStateHandler: mockHandler,
+				taskId: "test-task",
+				hooksEnabled: true,
+			})
+
+			// Verify hook message was updated to completed
+			const hookMessage = messages.find((m) => m.say === "hook_status")
+			should.exist(hookMessage)
+			if (hookMessage) {
+				const metadata = JSON.parse(hookMessage.text || "{}")
+				metadata.status.should.equal("completed")
+			}
+		})
 	})
 })


### PR DESCRIPTION
Bug #9337 — Custom Hook stays in Running state unless contextModification has whitespace
### Related Issue

**Issue:** #9337

### Description

Custom hooks (e.g., `UserPromptSubmit`) that return `{"cancel": false}` without a `contextModification` field stay in the "Running" state indefinitely in the UI. The hook completes execution successfully but the status is never updated to "Completed", leaving the UI permanently showing a spinning hook indicator.

**Root Cause:** In `hook-executor.ts`, when a hook returns NoOp (proto defaults: `cancel=false`, `contextModification=""`, `errorMessage=""`), the early return on line 161 skips the status update block at line 187-197. The hook message remains in its initial "running" state forever.

**Fix:** Added the hook status update to "completed" before the NoOp early return, matching the same pattern used for non-NoOp hooks at line 187-197.

**Changes:**
- `hook-executor.ts`: Added `updateHookMessage()` call with `status: "completed"` in the NoOp early return path
- `__tests__/hook-executor.test.ts`: Added test verifying NoOp hooks update status to "completed"

### Test Procedure

1. Created test that executes a NoOp hook (`{"cancel": false}`) and verifies the hook_status message is updated to "completed"
2. Verified existing tests still pass (empty context modification, undefined optional fields)
3. Code review confirmed the fix is correct: the NoOp path now mirrors the non-NoOp path for status updates

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

The existing test on line 625-656 ("should handle empty context modification") was already aware of this issue — note the comment: *"If the hook script returned an empty string, this may be treated as 'no modification' and omitted depending on executor normalization."* The new test explicitly validates the fix.