### PR TITLE
fix(vscode): avoid false shell integration warnings in WSL terminals

### DIFF
--- a/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalProcess.test.ts
+++ b/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalProcess.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, beforeEach, describe, it } from "mocha"
-import { setVscodeHostProviderMock } from "@/test/host-provider-test-utils"
 import "should"
 import * as sinon from "sinon"
 import * as vscode from "vscode"
 import { VscodeTerminalProcess } from "./VscodeTerminalProcess"
 import { TerminalRegistry } from "./VscodeTerminalRegistry"
+import * as terminalOutputModule from "./get-latest-output"
 
 declare module "vscode" {
 	// https://github.com/microsoft/vscode/blob/f0417069c62e20f3667506f4b7e53ca0004b4e3e/src/vscode-dts/vscode.d.ts#L7442
@@ -37,7 +37,6 @@ describe("TerminalProcess (Integration Tests)", () => {
 
 	beforeEach(() => {
 		sandbox = sinon.createSandbox({ useFakeTimers: true })
-		setVscodeHostProviderMock()
 		process = new VscodeTerminalProcess()
 	})
 
@@ -194,16 +193,13 @@ describe("TerminalProcess (Integration Tests)", () => {
 	})
 
 	// Test that specifically checks for no shell integration
-	it("should handle terminals without shell integration", async () => {
-		// Create a real terminal without explicitly providing shell integration
-		const terminal = vscode.window.createTerminal({ name: "Test Terminal" })
-		createdTerminals.push(terminal)
+	it("should emit no_shell_integration when fallback output is empty", async () => {
+		const terminal = {
+			sendText: sandbox.stub(),
+			shellIntegration: undefined,
+		} as unknown as vscode.Terminal
 
-		// Stub the shellIntegration getter to return undefined for this test
-		sandbox.stub(terminal, "shellIntegration").get(() => undefined)
-
-		// Stub the sendText method to verify it's called
-		const sendTextStub = sandbox.stub(terminal, "sendText")
+		sandbox.stub(terminalOutputModule, "getLatestTerminalOutput").resolves("")
 
 		// Spy on the emit function to verify events
 		const emitSpy = sandbox.spy(process, "emit")
@@ -218,12 +214,38 @@ describe("TerminalProcess (Integration Tests)", () => {
 		await runPromise
 
 		// Check that the correct methods were called and events emitted
-		sendTextStub.calledWith("test-command", true).should.be.true()
+		;(terminal.sendText as sinon.SinonStub).calledWith("test-command", true).should.be.true()
 		;(emitSpy as sinon.SinonSpy).calledWith("completed").should.be.true()
 		;(emitSpy as sinon.SinonSpy).calledWith("continue").should.be.true()
-
-		// This event should be emitted for terminals without shell integration
 		;(emitSpy as sinon.SinonSpy).calledWith("no_shell_integration").should.be.true()
+	})
+
+	it("should suppress no_shell_integration when fallback output is captured", async () => {
+		const terminal = {
+			sendText: sandbox.stub(),
+			shellIntegration: undefined,
+		} as unknown as vscode.Terminal
+
+		sandbox.stub(terminalOutputModule, "getLatestTerminalOutput").resolves("command output\nmore output")
+
+		// Spy on the emit function to verify events
+		const emitSpy = sandbox.spy(process, "emit")
+
+		const runPromise = process.run(terminal, "test-command")
+
+		await sandbox.clock.tickAsync(3000)
+		await runPromise
+
+		;(terminal.sendText as sinon.SinonStub).calledWith("test-command", true).should.be.true()
+		;(emitSpy as sinon.SinonSpy).calledWith("completed").should.be.true()
+		;(emitSpy as sinon.SinonSpy).calledWith("continue").should.be.true()
+		;(emitSpy as sinon.SinonSpy).calledWith("no_shell_integration").should.be.false()
+		;(emitSpy as sinon.SinonSpy)
+			.calledWithMatch(
+				"line",
+				sinon.match((value: unknown) => typeof value === "string" && value.includes("Here's the current terminal's content")),
+			)
+			.should.be.true()
 	})
 
 	// The following tests require shell integration and controlled terminal output

--- a/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalProcess.test.ts
+++ b/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalProcess.test.ts
@@ -2,9 +2,10 @@ import { afterEach, beforeEach, describe, it } from "mocha"
 import "should"
 import * as sinon from "sinon"
 import * as vscode from "vscode"
+import { setVscodeHostProviderMock } from "@/test/host-provider-test-utils"
+import * as terminalOutputModule from "./get-latest-output"
 import { VscodeTerminalProcess } from "./VscodeTerminalProcess"
 import { TerminalRegistry } from "./VscodeTerminalRegistry"
-import * as terminalOutputModule from "./get-latest-output"
 
 declare module "vscode" {
 	// https://github.com/microsoft/vscode/blob/f0417069c62e20f3667506f4b7e53ca0004b4e3e/src/vscode-dts/vscode.d.ts#L7442
@@ -37,6 +38,7 @@ describe("TerminalProcess (Integration Tests)", () => {
 
 	beforeEach(() => {
 		sandbox = sinon.createSandbox({ useFakeTimers: true })
+		setVscodeHostProviderMock()
 		process = new VscodeTerminalProcess()
 	})
 
@@ -243,7 +245,9 @@ describe("TerminalProcess (Integration Tests)", () => {
 		;(emitSpy as sinon.SinonSpy)
 			.calledWithMatch(
 				"line",
-				sinon.match((value: unknown) => typeof value === "string" && value.includes("Here's the current terminal's content")),
+				sinon.match(
+					(value: unknown) => typeof value === "string" && value.includes("Here's the current terminal's content"),
+				),
 			)
 			.should.be.true()
 	})

--- a/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalProcess.ts
+++ b/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalProcess.ts
@@ -27,7 +27,7 @@ import { Logger } from "@/shared/services/Logger"
  * - 'completed': Emitted when the process completes
  * - 'continue': Emitted when continue() is called
  * - 'error': Emitted on process errors
- * - 'no_shell_integration': Emitted when shell integration is not available
+ * - 'no_shell_integration': Emitted when shell integration is not available and fallback output could not be captured
  */
 export class VscodeTerminalProcess extends EventEmitter<TerminalProcessEvents> implements ITerminalProcess {
 	waitForShellIntegration = true
@@ -44,7 +44,7 @@ export class VscodeTerminalProcess extends EventEmitter<TerminalProcessEvents> i
 		this.exitCode = undefined
 		this.signal = null
 
-		// When command does not produce any output, we can assume the shell integration API failed and as a fallback return the current terminal contents
+		// When shell integration does not produce usable output, fall back to the current terminal contents
 		const returnCurrentTerminalContents = async () => {
 			try {
 				const terminalSnapshot = await getLatestTerminalOutput()
@@ -52,8 +52,10 @@ export class VscodeTerminalProcess extends EventEmitter<TerminalProcessEvents> i
 					const fallbackMessage = `The command's output could not be captured due to some technical issue, however it has been executed successfully. Here's the current terminal's content to help you get the command's output:\n\n${terminalSnapshot}`
 					this.emit("line", fallbackMessage)
 				}
+				return terminalSnapshot
 			} catch (error) {
 				Logger.error("Error capturing terminal output:", error)
+				return ""
 			}
 		}
 
@@ -214,9 +216,8 @@ export class VscodeTerminalProcess extends EventEmitter<TerminalProcessEvents> i
 			if (!this.fullOutput.trim()) {
 				// No output captured via shell integration, trying fallback
 				telemetryService.captureTerminalOutputFailure(TerminalOutputFailureReason.TIMEOUT, "vscode")
-				await returnCurrentTerminalContents()
+				const terminalSnapshot = await returnCurrentTerminalContents()
 				// Check if fallback worked
-				const terminalSnapshot = await getLatestTerminalOutput()
 				if (terminalSnapshot && terminalSnapshot.trim()) {
 					telemetryService.captureTerminalExecution(true, "vscode", "clipboard")
 				} else {
@@ -245,9 +246,8 @@ export class VscodeTerminalProcess extends EventEmitter<TerminalProcessEvents> i
 			await new Promise((resolve) => setTimeout(resolve, 3000))
 
 			// For terminals without shell integration, also try to capture terminal content
-			await returnCurrentTerminalContents()
+			const terminalSnapshot = await returnCurrentTerminalContents()
 			// Check if clipboard fallback worked
-			const terminalSnapshot = await getLatestTerminalOutput()
 			if (terminalSnapshot && terminalSnapshot.trim()) {
 				telemetryService.captureTerminalExecution(true, "vscode", "clipboard")
 			} else {
@@ -257,7 +257,9 @@ export class VscodeTerminalProcess extends EventEmitter<TerminalProcessEvents> i
 			// So we'll just emit the continue event after a delay
 			this.emit("completed", this.getCompletionDetails())
 			this.emit("continue")
-			this.emit("no_shell_integration")
+			if (!(terminalSnapshot && terminalSnapshot.trim())) {
+				this.emit("no_shell_integration")
+			}
 			// setTimeout(() => {
 			// 	Logger.log(`Emitting continue after delay for terminal`)
 			// 	// can't emit completed since we don't if the command actually completed, it could still be running server


### PR DESCRIPTION
### Description

WSL terminals can successfully return fallback output even when VS Code shell integration never activates, but Cline was still surfacing that path as `no_shell_integration`.

**Root cause:** `VscodeTerminalProcess` emitted `no_shell_integration` after the fallback terminal snapshot path, even when that fallback captured usable output, and `VscodeTerminalManager` treated that event as a terminal failure signal.

**Fix:** reuse the captured fallback snapshot and only emit `no_shell_integration` when shell integration is unavailable and the fallback snapshot is empty. Successful fallback capture still emits the user-facing terminal snapshot message, but no longer marks the run as a shell-integration failure.

When fallback output is empty, terminal reuse safety remains unchanged.

### Test Procedure

- `npm run format:fix` in `apps/vscode` — no additional formatting changes required for the touched files.
- Focused regression harness for `apps/vscode/src/hosts/vscode/terminal/VscodeTerminalProcess.test.ts` — 2/2 passing. Covers: empty fallback snapshots still emitting `no_shell_integration`, non-empty fallback snapshots suppressing it.
- What could break: terminal reuse and failure handling for true no-shell-integration failures. Verified by keeping the failure event for empty fallback captures and by leaving the manager listener contract unchanged.

### Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] ♻️ Refactor
- [ ] 💅 Cosmetic
- [ ] 📝 Documentation
- [ ] 🔧 Workflow

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore
- [ ] Tests are passing and code is formatted and linted
- [x] I have reviewed contributor guidelines

### Additional Notes

Fallback terminal output capture already exists in the codebase from #4605. This change narrows the remaining false-positive warning path rather than changing how fallback capture itself works.

## Upstream

Closes #11022.
Reported by @AkbarTheGreat.
