### PR TITLE
fix(vscode): clarify partial-line replace_in_file match failures

### DIFF
--- a/apps/vscode/src/core/assistant-message/diff.test.ts
+++ b/apps/vscode/src/core/assistant-message/diff.test.ts
@@ -22,6 +22,20 @@ async function expectPartialLineMismatch(diff: string, original: string): Promis
 	}
 }
 
+async function expectGenericSearchMismatch(diff: string, original: string): Promise<void> {
+	for (const run of [cnfc, cnfc2]) {
+		try {
+			await run(diff, original, true)
+			expect.fail("Expected an error to be thrown")
+		} catch (err) {
+			expect(err).to.be.an("error")
+			const message = err instanceof Error ? err.message : String(err)
+			expect(message).to.include("does not match anything in the file")
+			expect(message).to.not.include("only matches part of a longer line")
+		}
+	}
+}
+
 describe("constructNewFileContent", () => {
 	const testCases = [
 		{
@@ -287,6 +301,36 @@ replaced
 		].join("\n")
 
 		await expectPartialLineMismatch(diff, original)
+	})
+
+	it("should report partial-line SEARCH mismatch for matches before the current scan index", async () => {
+		const original = [
+			"// Build tree spheres with CONTINUOUS time + live audio (no jerk)",
+			"middle line",
+			"exact target line",
+		].join("\n")
+
+		const diff = [
+			"------- SEARCH",
+			"exact target line",
+			"=======",
+			"exact replacement",
+			"+++++++ REPLACE",
+			"------- SEARCH",
+			"// Build tree spheres",
+			"=======",
+			"partial replacement",
+			"+++++++ REPLACE",
+		].join("\n")
+
+		await expectPartialLineMismatch(diff, original)
+	})
+
+	it("should keep very short substring matches on the generic no-match path", async () => {
+		const original = "const index = value"
+		const diff = ["------- SEARCH", "i", "=======", "replacement", "+++++++ REPLACE"].join("\n")
+
+		await expectGenericSearchMismatch(diff, original)
 	})
 
 	it("should handle missing final REPLACE marker when isFinal is true", async () => {

--- a/apps/vscode/src/core/assistant-message/diff.test.ts
+++ b/apps/vscode/src/core/assistant-message/diff.test.ts
@@ -7,6 +7,21 @@ async function cnfc2(diffContent: string, originalContent: string, isFinal: bool
 	return result.newContent
 }
 
+async function expectPartialLineMismatch(diff: string, original: string): Promise<void> {
+	for (const run of [cnfc, cnfc2]) {
+		try {
+			await run(diff, original, true)
+			expect.fail("Expected an error to be thrown")
+		} catch (err) {
+			expect(err).to.be.an("error")
+			const message = err instanceof Error ? err.message : String(err)
+			expect(message).to.include("only matches part of a longer line")
+			expect(message).to.include("exact line or span match")
+			expect(message).to.not.include("does not match anything in the file")
+		}
+	}
+}
+
 describe("constructNewFileContent", () => {
 	const testCases = [
 		{
@@ -250,6 +265,28 @@ replaced
 		} catch (err) {
 			expect(err).to.be.an("error")
 		}
+	})
+
+	it("should report partial-line SEARCH mismatch", async () => {
+		const original = [
+			"                g_audioFeatures[0].dominantFreq = live.dominantFreq;",
+			"            }",
+			"",
+			"            // Build tree spheres with CONTINUOUS time + live audio (no jerk)",
+		].join("\n")
+
+		const diff = [
+			"------- SEARCH",
+			"                g_audioFeatures[0].dominantFreq = live.dominantFreq;",
+			"            }",
+			"",
+			"            // Build tree spheres",
+			"=======",
+			"replaced",
+			"+++++++ REPLACE",
+		].join("\n")
+
+		await expectPartialLineMismatch(diff, original)
 	})
 
 	it("should handle missing final REPLACE marker when isFinal is true", async () => {

--- a/apps/vscode/src/core/assistant-message/diff.ts
+++ b/apps/vscode/src/core/assistant-message/diff.ts
@@ -133,7 +133,7 @@ function hasPartialLineMismatch(originalContent: string, searchContent: string, 
 				continue
 			}
 
-			if (searchTrimmed && originalTrimmed.includes(searchTrimmed)) {
+			if (searchTrimmed.length > 2 && originalTrimmed.includes(searchTrimmed)) {
 				sawPartialLineMatch = true
 				continue
 			}
@@ -152,7 +152,10 @@ function hasPartialLineMismatch(originalContent: string, searchContent: string, 
 
 function getSearchMismatchError(originalContent: string, searchContent: string, startIndex: number): Error {
 	const trimmedSearchContent = searchContent.trimEnd()
-	if (hasPartialLineMismatch(originalContent, searchContent, startIndex)) {
+	const hasMeaningfulPartialLineMismatch =
+		hasPartialLineMismatch(originalContent, searchContent, startIndex) ||
+		(startIndex > 0 && hasPartialLineMismatch(originalContent, searchContent, 0))
+	if (hasMeaningfulPartialLineMismatch) {
 		return new Error(
 			`The SEARCH block:\n${trimmedSearchContent}\n...only matches part of a longer line in the file. SEARCH/REPLACE blocks require an exact line or span match, including line boundaries.`,
 		)

--- a/apps/vscode/src/core/assistant-message/diff.ts
+++ b/apps/vscode/src/core/assistant-message/diff.ts
@@ -102,6 +102,65 @@ function lineTrimmedFallbackMatch(originalContent: string, searchContent: string
 	return false
 }
 
+function hasPartialLineMismatch(originalContent: string, searchContent: string, startIndex: number): boolean {
+	const originalLines = originalContent.split("\n")
+	const searchLines = searchContent.split("\n")
+
+	if (searchLines[searchLines.length - 1] === "") {
+		searchLines.pop()
+	}
+
+	if (searchLines.length === 0) {
+		return false
+	}
+
+	let startLineNum = 0
+	let currentIndex = 0
+	while (currentIndex < startIndex && startLineNum < originalLines.length) {
+		currentIndex += originalLines[startLineNum].length + 1
+		startLineNum++
+	}
+
+	for (let i = startLineNum; i <= originalLines.length - searchLines.length; i++) {
+		let sawPartialLineMatch = false
+		let matches = true
+
+		for (let j = 0; j < searchLines.length; j++) {
+			const originalTrimmed = originalLines[i + j].trim()
+			const searchTrimmed = searchLines[j].trim()
+
+			if (originalTrimmed === searchTrimmed) {
+				continue
+			}
+
+			if (searchTrimmed && originalTrimmed.includes(searchTrimmed)) {
+				sawPartialLineMatch = true
+				continue
+			}
+
+			matches = false
+			break
+		}
+
+		if (matches && sawPartialLineMatch) {
+			return true
+		}
+	}
+
+	return false
+}
+
+function getSearchMismatchError(originalContent: string, searchContent: string, startIndex: number): Error {
+	const trimmedSearchContent = searchContent.trimEnd()
+	if (hasPartialLineMismatch(originalContent, searchContent, startIndex)) {
+		return new Error(
+			`The SEARCH block:\n${trimmedSearchContent}\n...only matches part of a longer line in the file. SEARCH/REPLACE blocks require an exact line or span match, including line boundaries.`,
+		)
+	}
+
+	return new Error(`The SEARCH block:\n${trimmedSearchContent}\n...does not match anything in the file.`)
+}
+
 /**
  * Attempts to match blocks of code by using the first and last lines as anchors.
  * This is a third-tier fallback strategy that helps match blocks where we can identify
@@ -371,9 +430,7 @@ async function constructNewFileContentV1(
 									pendingOutOfOrderReplacement = true
 								}
 							} else {
-								throw new Error(
-									`The SEARCH block:\n${currentSearchContent.trimEnd()}\n...does not match anything in the file.`,
-								)
+								throw getSearchMismatchError(originalContent, currentSearchContent, lastProcessedIndex)
 							}
 						}
 					}
@@ -703,9 +760,7 @@ class NewFileContentConstructor {
 					if (blockMatch) {
 						;[this.searchMatchIndex, this.searchEndIndex] = blockMatch
 					} else {
-						throw new Error(
-							`The SEARCH block:\n${this.currentSearchContent.trimEnd()}\n...does not match anything in the file.`,
-						)
+						throw getSearchMismatchError(this.originalContent, this.currentSearchContent, this.lastProcessedIndex)
 					}
 				}
 			}

--- a/apps/vscode/src/core/task/tools/handlers/WriteToFileToolHandler.ts
+++ b/apps/vscode/src/core/task/tools/handlers/WriteToFileToolHandler.ts
@@ -523,10 +523,11 @@ export class WriteToFileToolHandler implements IFullyManagedTool {
 				const { providerId, modelId } = getModelInfo(config)
 
 				// Extract error type from error message if possible
-				const errorType =
-					error instanceof Error && error.message.includes("does not match anything")
-						? "search_not_found"
-						: "other_diff_error"
+				const isSearchMismatchError =
+					error instanceof Error &&
+					(error.message.includes("does not match anything") ||
+						error.message.includes("only matches part of a longer line"))
+				const errorType = isSearchMismatchError ? "search_not_found" : "other_diff_error"
 
 				// Add telemetry for diff edit failure
 				const isNativeToolCall = block.isNativeToolCall === true


### PR DESCRIPTION
### Description
`replace_in_file` currently collapses a partial-line mismatch into the generic "does not match anything in the file" error. That makes it look like the SEARCH text is missing even when it is visible as part of a longer line.

Changes:
- Add a narrow partial-line diagnostic helper in `apps/vscode/src/core/assistant-message/diff.ts`.
- Reuse the same diagnostic in both matcher implementations so V1 and V2 report the clearer exact-span mismatch, including duplicate earlier matches that fall before the current scan index.
- Guard the helper against very short substring coincidences so single-character SEARCH lines stay on the generic no-match path.
- Keep `WriteToFileToolHandler` telemetry bucketing aligned with the new partial-line error text so these failures still count as `search_not_found`.
- Add regression tests for the issue's minimal example, earlier duplicate partial-line matches, and very short substring false positives.

### Test Procedure
1. Run `cd D:\Repos\cline-pr-replace-in-file-partial-line-match\apps\vscode; npm run format:fix` to normalize the touched matcher files before validation.
2. Run `cd D:\Repos\cline-pr-replace-in-file-partial-line-match\apps\vscode; npx cross-env TS_NODE_PROJECT=./tsconfig.unit-test.json mocha --no-config src/core/assistant-message/diff.test.ts --require ts-node/register --require source-map-support/register --require ./src/test/requires.ts --extension ts --grep "partial-line|very short substring" --exit` to verify the issue repro, the earlier-duplicate diagnostic case, and the short-token false-positive guard in both matcher paths.
3. Run `cd D:\Repos\cline-pr-replace-in-file-partial-line-match\apps\vscode; npx cross-env TS_NODE_PROJECT=./tsconfig.unit-test.json mocha --no-config src/core/assistant-message/diff.test.ts --require ts-node/register --require source-map-support/register --require ./src/test/requires.ts --extension ts --exit` to confirm the existing diff matcher cases still pass after the tighter diagnostic helper and throw-site changes.
4. Run `cd D:\Repos\cline-pr-replace-in-file-partial-line-match\apps\vscode; npx cross-env TS_NODE_PROJECT=./tsconfig.unit-test.json mocha --no-config src/core/task/tools/handlers/__tests__/WriteToFileToolHandler.consecutiveMistakeCount.test.ts --require ts-node/register --require source-map-support/register --require ./src/test/requires.ts --extension ts --exit` to verify the touched handler path still behaves correctly around diff-error handling after the telemetry classification update.

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

### Pre-flight Checklist
- [x] I have read the contributing guidelines relevant to this change.
- [x] I have tested the scoped change in the worktree.
- [x] I have kept the change limited to the requested files and behavior.

### Screenshots
N/A - backend matcher and telemetry classification change only.

### Additional Notes
The fix preserves exact-span replacement behavior. It only changes the failure message for meaningful partial-line SEARCH mismatches, keeps the existing diff-failure telemetry classification aligned with that clearer wording, and leaves very short incidental substring matches on the generic no-match path.

## Upstream

Closes #11439.
Reported by @martindye.
