### PR TITLE
fix(core): accept structured option objects in ask_question

### DIFF
--- a/sdk/packages/core/src/extensions/tools/definitions.test.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.test.ts
@@ -5,6 +5,7 @@ import {
 	getToolContextTelemetry,
 } from "../../services/telemetry/tool-context";
 import {
+	createAskQuestionTool,
 	createBashTool,
 	createDefaultTools,
 	createReadFilesTool,
@@ -193,6 +194,55 @@ describe("default ask_question tool", () => {
 				iteration: 1,
 			}),
 		);
+	});
+
+	it("normalizes structured option objects to display strings", async () => {
+		const execute = vi.fn(async () => "asked");
+		const tool = createAskQuestionTool(execute);
+
+		const result = await tool.execute(
+			{
+				question: "Which approach should I take?",
+				options: [
+					{ key: "a", label: "Use the SDK", description: "Recommended" },
+					{ value: "Write custom code" },
+					"Plain string option",
+				],
+			} as never,
+			{
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 1,
+			},
+		);
+
+		expect(result).toBe("asked");
+		expect(execute).toHaveBeenCalledWith(
+			"Which approach should I take?",
+			["Use the SDK", "Write custom code", "Plain string option"],
+			expect.objectContaining({ iteration: 1 }),
+		);
+	});
+
+	it("rejects option objects without any label-like field", async () => {
+		const execute = vi.fn(async () => "should not run");
+		const tool = createAskQuestionTool(execute);
+
+		await expect(
+			tool.execute(
+				{
+					question: "Which approach should I take?",
+					options: [{ description: "no label" }, "Option 2"],
+				} as never,
+				{
+					agentId: "agent-1",
+					conversationId: "conv-1",
+					iteration: 1,
+				},
+			),
+		).rejects.toThrow();
+
+		expect(execute).not.toHaveBeenCalled();
 	});
 
 	it("waits for ask_question answers without timing out", async () => {

--- a/sdk/packages/core/src/extensions/tools/definitions.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.ts
@@ -35,10 +35,12 @@ import {
 	ApplyPatchInputUnionSchema,
 	type AskQuestionInput,
 	AskQuestionInputSchema,
+	AskQuestionInputUnionSchema,
 	type EditFileInput,
 	EditFileInputSchema,
 	type FetchWebContentInput,
 	FetchWebContentInputSchema,
+	normalizeAskQuestionOptions,
 	type ReadFileRequest,
 	type ReadFilesInput,
 	ReadFilesInputSchema,
@@ -717,8 +719,12 @@ export function createAskQuestionTool(
 		retryable: false,
 		maxRetries: 0,
 		execute: async (input, context) => {
-			const validatedInput = validateWithZod(AskQuestionInputSchema, input);
-			return executor(validatedInput.question, validatedInput.options, context);
+			const validatedInput = validateWithZod(
+				AskQuestionInputUnionSchema,
+				input,
+			);
+			const options = normalizeAskQuestionOptions(validatedInput.options);
+			return executor(validatedInput.question, options, context);
 		},
 	};
 }

--- a/sdk/packages/core/src/extensions/tools/schemas.ts
+++ b/sdk/packages/core/src/extensions/tools/schemas.ts
@@ -268,6 +268,76 @@ export const AskQuestionInputSchema = z.object({
 		),
 });
 
+/**
+ * Schema for a single ask_question option supplied as an object.
+ *
+ * Some models emit structured option entries such as
+ * `{ key, label, description }` instead of plain strings. Accept the common
+ * key variants and normalize them to a display string at execution time.
+ */
+export const AskQuestionOptionObjectSchema = z
+	.object({
+		label: z.string().min(1).optional(),
+		value: z.string().min(1).optional(),
+		title: z.string().min(1).optional(),
+		name: z.string().min(1).optional(),
+		key: z.string().min(1).optional(),
+		description: z.string().optional(),
+	})
+	.refine(
+		(option) =>
+			Boolean(
+				option.label ??
+					option.value ??
+					option.title ??
+					option.name ??
+					option.key,
+			),
+		{
+			message:
+				"Option object must include a non-empty label, value, title, name, or key",
+		},
+	);
+
+/**
+ * Union schema for ask_question tool input. Accepts options as plain strings or
+ * as structured objects, mirroring the read_files union-schema flexibility.
+ */
+export const AskQuestionInputUnionSchema = z.object({
+	question: z
+		.string()
+		.min(1)
+		.describe(
+			'The single question to ask the user. E.g. "How can I help you?"',
+		),
+	options: z
+		.array(z.union([z.string().min(1), AskQuestionOptionObjectSchema]))
+		.min(2)
+		.max(5)
+		.describe(
+			"Array of 2-5 user-selectable answer options for the single question",
+		),
+});
+
+/**
+ * Normalize ask_question options to display strings, collapsing any structured
+ * option objects down to their most descriptive label.
+ */
+export function normalizeAskQuestionOptions(
+	options: z.infer<typeof AskQuestionInputUnionSchema>["options"],
+): string[] {
+	return options.map((option) =>
+		typeof option === "string"
+			? option
+			: (option.label ??
+				option.value ??
+				option.title ??
+				option.name ??
+				option.key ??
+				""),
+	);
+}
+
 export const SubmitInputSchema = z.object({
 	summary: z
 		.string()


### PR DESCRIPTION
Fixes #11337

`createAskQuestionTool` validated input with `AskQuestionInputSchema`, whose `options` is `z.array(z.string())`. Some models (e.g. MiniMax M3) emit structured option entries like `{key, label, description}[]`, which fail Zod validation (`expected string, received object`) — and per the issue this cascades into a Hub disconnect/crash.

This mirrors the maintainers' already-merged `read_files` union-schema fix (#11225):
- Add `AskQuestionInputUnionSchema` (options accept a non-empty string **or** an option object) plus `normalizeAskQuestionOptions`, which collapses each object to `label ?? value ?? title ?? name ?? key`.
- `execute()` now validates with the union schema and normalizes before calling the executor, so the executor contract stays `string[]`.
- The advertised JSON input schema (`zodToJsonSchema(AskQuestionInputSchema)`) is unchanged, so models still see `string[]` as the contract.

### How I verified
- `cd sdk/packages/core && bunx vitest run src/extensions/tools/definitions.test.ts` → 46 pass (2 new: normalizes mixed object/string options; rejects an object with no label-like field).
- Negative control: reverting `execute()` to the strict schema makes the new test fail with the exact issue error (`expected string, received object → at options[0]`).
- `cd sdk && bun run build` → exit 0; `biome check` clean on the changed files.
