### PR TITLE
fix(webview): respect supportsImages model configuration on paste and drop

### DIFF
--- a/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -224,6 +224,11 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			navigateToSettingsModelPicker,
 			mcpServers,
 		} = useExtensionState()
+
+		const { selectedModelInfo } = useMemo(() => {
+			return normalizeApiConfiguration(apiConfiguration, mode)
+		}, [apiConfiguration, mode])
+
 		const [isTextAreaFocused, setIsTextAreaFocused] = useState(false)
 		const [isDraggingOver, setIsDraggingOver] = useState(false)
 		const [gitCommits, setGitCommits] = useState<GitCommit[]>([])
@@ -254,6 +259,8 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 		const unsupportedFileTimerRef = useRef<NodeJS.Timeout | null>(null)
 		const [showDimensionError, setShowDimensionError] = useState(false)
 		const dimensionErrorTimerRef = useRef<NodeJS.Timeout | null>(null)
+		const [showImageUnsupportedError, setShowImageUnsupportedError] = useState(false)
+		const imageUnsupportedTimerRef = useRef<NodeJS.Timeout | null>(null)
 
 		const [fileSearchResults, setFileSearchResults] = useState<SearchResult[]>([])
 		const [searchLoading, setSearchLoading] = useState(false)
@@ -876,52 +883,59 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					const [type, subtype] = item.type.split("/")
 					return type === "image" && acceptedTypes.includes(subtype)
 				})
-				if (!shouldDisableFilesAndImages && imageItems.length > 0) {
-					e.preventDefault()
-					const imagePromises = imageItems.map((item) => {
-						return new Promise<string | null>((resolve) => {
-							const blob = item.getAsFile()
-							if (!blob) {
-								resolve(null)
-								return
-							}
-							const reader = new FileReader()
-							reader.onloadend = async () => {
-								if (reader.error) {
-									console.error("Error reading file:", reader.error)
+				if (imageItems.length > 0) {
+					if (!selectedModelInfo.supportsImages) {
+						e.preventDefault()
+						showImageUnsupportedErrorMessage()
+						return
+					}
+					if (!shouldDisableFilesAndImages) {
+						e.preventDefault()
+						const imagePromises = imageItems.map((item) => {
+							return new Promise<string | null>((resolve) => {
+								const blob = item.getAsFile()
+								if (!blob) {
 									resolve(null)
-								} else {
-									const result = reader.result
-									if (typeof result === "string") {
-										try {
-											await getImageDimensions(result)
-											resolve(result)
-										} catch (error) {
-											console.warn((error as Error).message)
-											showDimensionErrorMessage()
+									return
+								}
+								const reader = new FileReader()
+								reader.onloadend = async () => {
+									if (reader.error) {
+										console.error("Error reading file:", reader.error)
+										resolve(null)
+									} else {
+										const result = reader.result
+										if (typeof result === "string") {
+											try {
+												await getImageDimensions(result)
+												resolve(result)
+											} catch (error) {
+												console.warn((error as Error).message)
+												showDimensionErrorMessage()
+												resolve(null)
+											}
+										} else {
 											resolve(null)
 										}
-									} else {
-										resolve(null)
 									}
 								}
-							}
-							reader.readAsDataURL(blob)
+								reader.readAsDataURL(blob)
+							})
 						})
-					})
-					const imageDataArray = await Promise.all(imagePromises)
-					const dataUrls = imageDataArray.filter((dataUrl): dataUrl is string => dataUrl !== null)
-					//.map((dataUrl) => dataUrl.split(",")[1]) // strip the mime type prefix, sharp doesn't need it
-					if (dataUrls.length > 0) {
-						const filesAndImagesLength = selectedImages.length + selectedFiles.length
-						const availableSlots = MAX_IMAGES_AND_FILES_PER_MESSAGE - filesAndImagesLength
+						const imageDataArray = await Promise.all(imagePromises)
+						const dataUrls = imageDataArray.filter((dataUrl): dataUrl is string => dataUrl !== null)
+						//.map((dataUrl) => dataUrl.split(",")[1]) // strip the mime type prefix, sharp doesn't need it
+						if (dataUrls.length > 0) {
+							const filesAndImagesLength = selectedImages.length + selectedFiles.length
+							const availableSlots = MAX_IMAGES_AND_FILES_PER_MESSAGE - filesAndImagesLength
 
-						if (availableSlots > 0) {
-							const imagesToAdd = Math.min(dataUrls.length, availableSlots)
-							setSelectedImages((prevImages) => [...prevImages, ...dataUrls.slice(0, imagesToAdd)])
+							if (availableSlots > 0) {
+								const imagesToAdd = Math.min(dataUrls.length, availableSlots)
+								setSelectedImages((prevImages) => [...prevImages, ...dataUrls.slice(0, imagesToAdd)])
+							}
+						} else {
+							console.warn("No valid images were processed")
 						}
-					} else {
-						console.warn("No valid images were processed")
 					}
 				}
 			},
@@ -934,6 +948,8 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				setInputValue,
 				inputValue,
 				showDimensionErrorMessage,
+				selectedModelInfo.supportsImages,
+				showImageUnsupportedErrorMessage,
 			],
 		)
 
@@ -1146,6 +1162,28 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			}, 3000)
 		}
 
+		// Function to show error message for unsupported images when the model doesn't support images
+		const showImageUnsupportedErrorMessage = useCallback(() => {
+			setShowImageUnsupportedError(true)
+
+			if (imageUnsupportedTimerRef.current) {
+				clearTimeout(imageUnsupportedTimerRef.current)
+			}
+
+			imageUnsupportedTimerRef.current = setTimeout(() => {
+				setShowImageUnsupportedError(false)
+				imageUnsupportedTimerRef.current = null
+			}, 3000)
+		}, [])
+
+		useEffect(() => {
+			return () => {
+				if (imageUnsupportedTimerRef.current) {
+					clearTimeout(imageUnsupportedTimerRef.current)
+				}
+			}
+		}, [])
+
 		const handleDragEnter = (e: React.DragEvent) => {
 			e.preventDefault()
 			setIsDraggingOver(true)
@@ -1284,6 +1322,11 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				return type === "image" && acceptedTypes.includes(subtype)
 			})
 
+			if (imageFiles.length > 0 && !selectedModelInfo.supportsImages) {
+				showImageUnsupportedErrorMessage()
+				return
+			}
+
 			if (shouldDisableFilesAndImages || imageFiles.length === 0) {
 				return
 			}
@@ -1380,6 +1423,11 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 							<span className="text-error font-bold text-xs">Files other than images are currently disabled</span>
 						</div>
 					)}
+					{showImageUnsupportedError && (
+						<div className="absolute inset-2.5 bg-[rgba(var(--vscode-errorForeground-rgb),0.1)] border-2 border-error rounded-xs flex items-center justify-center z-10 pointer-events-none">
+							<span className="text-error font-bold text-xs">Selected model does not support images</span>
+						</div>
+					)}
 					{showSlashCommandsMenu && (
 						<div ref={slashCommandsMenuContainerRef}>
 							<SlashCommandMenu
@@ -1462,7 +1510,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 						onPaste={handlePaste}
 						onScroll={() => updateHighlights()}
 						onSelect={updateCursorPosition}
-						placeholder={showUnsupportedFileError || showDimensionError ? "" : placeholderText}
+						placeholder={showUnsupportedFileError || showDimensionError || showImageUnsupportedError ? "" : placeholderText}
 						ref={(el) => {
 							if (typeof ref === "function") {
 								ref(el)
@@ -1501,12 +1549,12 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 							flex: 1,
 							zIndex: 1,
 							outline:
-								isDraggingOver && !showUnsupportedFileError // Only show drag outline if not showing error
+								isDraggingOver && !showUnsupportedFileError && !showImageUnsupportedError // Only show drag outline if not showing error
 									? "2px dashed var(--vscode-focusBorder)"
 									: isTextAreaFocused
 										? `1px solid ${mode === "plan" ? PLAN_MODE_COLOR : "var(--vscode-focusBorder)"}`
 										: "none",
-							outlineOffset: isDraggingOver && !showUnsupportedFileError ? "1px" : "0px", // Add offset for drag-over outline
+							outlineOffset: isDraggingOver && !showUnsupportedFileError && !showImageUnsupportedError ? "1px" : "0px", // Add offset for drag-over outline
 						}}
 						value={inputValue}
 					/>

--- a/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -848,6 +848,28 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			}, 3000)
 		}, [])
 
+		// Function to show error message for unsupported images when the model doesn't support images
+		const showImageUnsupportedErrorMessage = useCallback(() => {
+			setShowImageUnsupportedError(true)
+
+			if (imageUnsupportedTimerRef.current) {
+				clearTimeout(imageUnsupportedTimerRef.current)
+			}
+
+			imageUnsupportedTimerRef.current = setTimeout(() => {
+				setShowImageUnsupportedError(false)
+				imageUnsupportedTimerRef.current = null
+			}, 3000)
+		}, [])
+
+		useEffect(() => {
+			return () => {
+				if (imageUnsupportedTimerRef.current) {
+					clearTimeout(imageUnsupportedTimerRef.current)
+				}
+			}
+		}, [])
+
 		const handlePaste = useCallback(
 			async (e: React.ClipboardEvent) => {
 				const items = e.clipboardData.items
@@ -1161,28 +1183,6 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				unsupportedFileTimerRef.current = null
 			}, 3000)
 		}
-
-		// Function to show error message for unsupported images when the model doesn't support images
-		const showImageUnsupportedErrorMessage = useCallback(() => {
-			setShowImageUnsupportedError(true)
-
-			if (imageUnsupportedTimerRef.current) {
-				clearTimeout(imageUnsupportedTimerRef.current)
-			}
-
-			imageUnsupportedTimerRef.current = setTimeout(() => {
-				setShowImageUnsupportedError(false)
-				imageUnsupportedTimerRef.current = null
-			}, 3000)
-		}, [])
-
-		useEffect(() => {
-			return () => {
-				if (imageUnsupportedTimerRef.current) {
-					clearTimeout(imageUnsupportedTimerRef.current)
-				}
-			}
-		}, [])
 
 		const handleDragEnter = (e: React.DragEvent) => {
 			e.preventDefault()

--- a/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -80,6 +80,7 @@ interface ChatTextAreaProps {
 	onSend: () => void
 	onSelectFilesAndImages: () => void
 	shouldDisableFilesAndImages: boolean
+	supportsImages: boolean
 	onHeightChange?: (height: number) => void
 	onFocusChange?: (isFocused: boolean) => void
 }
@@ -207,6 +208,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			onSend,
 			onSelectFilesAndImages,
 			shouldDisableFilesAndImages,
+			supportsImages,
 			onHeightChange,
 			onFocusChange,
 		},
@@ -225,9 +227,6 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			mcpServers,
 		} = useExtensionState()
 
-		const { selectedModelInfo } = useMemo(() => {
-			return normalizeApiConfiguration(apiConfiguration, mode)
-		}, [apiConfiguration, mode])
 
 		const [isTextAreaFocused, setIsTextAreaFocused] = useState(false)
 		const [isDraggingOver, setIsDraggingOver] = useState(false)
@@ -906,7 +905,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					return type === "image" && acceptedTypes.includes(subtype)
 				})
 				if (imageItems.length > 0) {
-					if (!selectedModelInfo.supportsImages) {
+					if (!supportsImages) {
 						e.preventDefault()
 						showImageUnsupportedErrorMessage()
 						return
@@ -970,7 +969,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				setInputValue,
 				inputValue,
 				showDimensionErrorMessage,
-				selectedModelInfo.supportsImages,
+				supportsImages,
 				showImageUnsupportedErrorMessage,
 			],
 		)
@@ -1322,7 +1321,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				return type === "image" && acceptedTypes.includes(subtype)
 			})
 
-			if (imageFiles.length > 0 && !selectedModelInfo.supportsImages) {
+			if (imageFiles.length > 0 && !supportsImages) {
 				showImageUnsupportedErrorMessage()
 				return
 			}

--- a/apps/vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -390,7 +390,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 					scrollBehavior={scrollBehavior}
 					selectFilesAndImages={selectFilesAndImages}
 					shouldDisableFilesAndImages={shouldDisableFilesAndImages}
-					supportsImages={selectedModelInfo.supportsImages}
+					supportsImages={selectedModelInfo.supportsImages ?? false}
 				/>
 			</footer>
 		</ChatLayout>

--- a/apps/vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -390,6 +390,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 					scrollBehavior={scrollBehavior}
 					selectFilesAndImages={selectFilesAndImages}
 					shouldDisableFilesAndImages={shouldDisableFilesAndImages}
+					supportsImages={selectedModelInfo.supportsImages}
 				/>
 			</footer>
 		</ChatLayout>

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/InputSection.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/InputSection.tsx
@@ -10,6 +10,7 @@ interface InputSectionProps {
 	placeholderText: string
 	shouldDisableFilesAndImages: boolean
 	selectFilesAndImages: () => Promise<void>
+	supportsImages: boolean
 }
 
 /**
@@ -22,6 +23,7 @@ export const InputSection: React.FC<InputSectionProps> = ({
 	placeholderText,
 	shouldDisableFilesAndImages,
 	selectFilesAndImages,
+	supportsImages,
 }) => {
 	const {
 		activeQuote,
@@ -72,6 +74,7 @@ export const InputSection: React.FC<InputSectionProps> = ({
 				setSelectedFiles={setSelectedFiles}
 				setSelectedImages={setSelectedImages}
 				shouldDisableFilesAndImages={shouldDisableFilesAndImages}
+				supportsImages={supportsImages}
 			/>
 		</>
 	)


### PR DESCRIPTION
### Summary
When the "Supports images" configuration is disabled for a model, pasting or dragging and dropping an image into the chat text area is still accepted and sent to the model, causing failures with non-vision/multimodal models.

### Changes
- Checks if `supportsImages` capability is disabled on the active model configuration before processing pasted or dropped images.
- Displays a clean visual overlay warning to the user: "Selected model does not support images" for 3 seconds.
- Discards the unsupported image input.