### PR TITLE
fix(llms): route Chutes reasoning controls by model family

### DIFF
--- a/sdk/packages/llms/src/providers/builtins.test.ts
+++ b/sdk/packages/llms/src/providers/builtins.test.ts
@@ -251,4 +251,9 @@ describe("built-in provider metadata", () => {
 			},
 		});
 	});
+
+	it("keeps Chutes unrouted families on standard reasoning fallbacks", async () => {
+		const provider = await getProvider("chutes");
+		expect(provider.metadata?.routing?.reasoning).toBeUndefined();
+	});
 });

--- a/sdk/packages/llms/src/providers/builtins.test.ts
+++ b/sdk/packages/llms/src/providers/builtins.test.ts
@@ -456,6 +456,11 @@ describe("built-in provider metadata", () => {
 			},
 		});
 	});
+
+	it("keeps Chutes unrouted families on standard reasoning fallbacks", async () => {
+		const provider = await getProvider("chutes");
+		expect(provider.metadata?.routing?.reasoning).toBeUndefined();
+	});
 });
 
 describe("regional API line base URLs", () => {

--- a/sdk/packages/llms/src/providers/gateway.test.ts
+++ b/sdk/packages/llms/src/providers/gateway.test.ts
@@ -3470,6 +3470,157 @@ describe("sdk-gateway", () => {
 		);
 	});
 
+	it("passes Chutes Kimi K2.6 TEE reasoning controls through provider options", async () => {
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([
+				{ type: "finish", usage: { inputTokens: 1, outputTokens: 1 } },
+			]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [{ providerId: "chutes", apiKey: "chutes-key" }],
+		});
+
+		await collect(
+			await gateway.stream({
+				providerId: "chutes",
+				modelId: "moonshotai/Kimi-K2.6-TEE",
+				messages: baseMessages,
+				reasoning: { enabled: true, effort: "high" },
+			}),
+		);
+		await collect(
+			await gateway.stream({
+				providerId: "chutes",
+				modelId: "moonshotai/Kimi-K2.6-TEE",
+				messages: baseMessages,
+				reasoning: { enabled: false, effort: "high" },
+			}),
+		);
+		await collect(
+			await gateway.stream({
+				providerId: "chutes",
+				modelId: "moonshotai/Kimi-K2.6-TEE",
+				messages: baseMessages,
+			}),
+		);
+
+		expect(streamTextSpy).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining({
+				providerOptions: expect.objectContaining({
+					chutes: expect.objectContaining({
+						chat_template_kwargs: {
+							thinking: true,
+							preserve_thinking: true,
+						},
+					}),
+				}),
+			}),
+		);
+		expect(streamTextSpy).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining({
+				providerOptions: expect.objectContaining({
+					chutes: expect.objectContaining({
+						chat_template_kwargs: { thinking: false },
+					}),
+				}),
+			}),
+		);
+
+		const defaultProviderOptions = (
+			streamTextSpy.mock.calls[2]?.[0] as {
+				providerOptions?: Record<string, Record<string, unknown>>;
+			}
+		).providerOptions;
+		for (const bucket of ["chutes", "openaiCompatible"] as const) {
+			expect(defaultProviderOptions?.[bucket]).not.toHaveProperty(
+				"chat_template_kwargs",
+			);
+		}
+
+		for (const call of streamTextSpy.mock.calls) {
+			const providerOptions = (
+				call[0] as {
+					providerOptions?: Record<string, Record<string, unknown>>;
+				}
+			).providerOptions;
+			for (const bucket of ["chutes", "openaiCompatible"] as const) {
+				expect(providerOptions?.[bucket]).not.toHaveProperty("thinking");
+				expect(providerOptions?.[bucket]).not.toHaveProperty("reasoningEffort");
+				expect(providerOptions?.[bucket]).not.toHaveProperty("effort");
+			}
+		}
+	});
+
+	it("routes Chutes Kimi and Qwen reasoning controls by model family", async () => {
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([
+				{ type: "finish", usage: { inputTokens: 1, outputTokens: 1 } },
+			]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [{ providerId: "chutes", apiKey: "chutes-key" }],
+		});
+
+		await collect(
+			await gateway.stream({
+				providerId: "chutes",
+				modelId: "moonshotai/Kimi-K2.5-TEE",
+				messages: baseMessages,
+				reasoning: { enabled: false },
+			}),
+		);
+		await collect(
+			await gateway.stream({
+				providerId: "chutes",
+				modelId: "Qwen/Qwen3-32B-TEE",
+				messages: baseMessages,
+				reasoning: { enabled: true },
+			}),
+		);
+		await collect(
+			await gateway.stream({
+				providerId: "chutes",
+				modelId: "Qwen/Qwen3-235B-A22B-Thinking-2507-TEE",
+				messages: baseMessages,
+				reasoning: { enabled: false },
+			}),
+		);
+
+		expect(streamTextSpy).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining({
+				providerOptions: expect.objectContaining({
+					chutes: expect.objectContaining({
+						chat_template_kwargs: { thinking: false },
+					}),
+				}),
+			}),
+		);
+		expect(streamTextSpy).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining({
+				providerOptions: expect.objectContaining({
+					chutes: expect.objectContaining({
+						chat_template_kwargs: { enable_thinking: true },
+					}),
+				}),
+			}),
+		);
+
+		const thinkingOnlyProviderOptions = (
+			streamTextSpy.mock.calls[2]?.[0] as {
+				providerOptions?: Record<string, Record<string, unknown>>;
+			}
+		).providerOptions;
+		expect(thinkingOnlyProviderOptions?.chutes).not.toHaveProperty(
+			"chat_template_kwargs",
+		);
+	});
+
 	it("does not apply generic thinking to non-GLM native Z.AI custom models", async () => {
 		streamTextSpy.mockReturnValue({
 			fullStream: makeStreamParts([

--- a/sdk/packages/llms/src/providers/gateway.test.ts
+++ b/sdk/packages/llms/src/providers/gateway.test.ts
@@ -5869,6 +5869,157 @@ describe("sdk-gateway", () => {
 		);
 	});
 
+	it("passes Chutes Kimi K2.6 TEE reasoning controls through provider options", async () => {
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([
+				{ type: "finish", usage: { inputTokens: 1, outputTokens: 1 } },
+			]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [{ providerId: "chutes", apiKey: "chutes-key" }],
+		});
+
+		await collect(
+			await gateway.stream({
+				providerId: "chutes",
+				modelId: "moonshotai/Kimi-K2.6-TEE",
+				messages: baseMessages,
+				reasoning: { enabled: true, effort: "high" },
+			}),
+		);
+		await collect(
+			await gateway.stream({
+				providerId: "chutes",
+				modelId: "moonshotai/Kimi-K2.6-TEE",
+				messages: baseMessages,
+				reasoning: { enabled: false, effort: "high" },
+			}),
+		);
+		await collect(
+			await gateway.stream({
+				providerId: "chutes",
+				modelId: "moonshotai/Kimi-K2.6-TEE",
+				messages: baseMessages,
+			}),
+		);
+
+		expect(streamTextSpy).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining({
+				providerOptions: expect.objectContaining({
+					chutes: expect.objectContaining({
+						chat_template_kwargs: {
+							thinking: true,
+							preserve_thinking: true,
+						},
+					}),
+				}),
+			}),
+		);
+		expect(streamTextSpy).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining({
+				providerOptions: expect.objectContaining({
+					chutes: expect.objectContaining({
+						chat_template_kwargs: { thinking: false },
+					}),
+				}),
+			}),
+		);
+
+		const defaultProviderOptions = (
+			streamTextSpy.mock.calls[2]?.[0] as {
+				providerOptions?: Record<string, Record<string, unknown>>;
+			}
+		).providerOptions;
+		for (const bucket of ["chutes", "openaiCompatible"] as const) {
+			expect(defaultProviderOptions?.[bucket]).not.toHaveProperty(
+				"chat_template_kwargs",
+			);
+		}
+
+		for (const call of streamTextSpy.mock.calls) {
+			const providerOptions = (
+				call[0] as {
+					providerOptions?: Record<string, Record<string, unknown>>;
+				}
+			).providerOptions;
+			for (const bucket of ["chutes", "openaiCompatible"] as const) {
+				expect(providerOptions?.[bucket]).not.toHaveProperty("thinking");
+				expect(providerOptions?.[bucket]).not.toHaveProperty("reasoningEffort");
+				expect(providerOptions?.[bucket]).not.toHaveProperty("effort");
+			}
+		}
+	});
+
+	it("routes Chutes Kimi and Qwen reasoning controls by model family", async () => {
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([
+				{ type: "finish", usage: { inputTokens: 1, outputTokens: 1 } },
+			]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [{ providerId: "chutes", apiKey: "chutes-key" }],
+		});
+
+		await collect(
+			await gateway.stream({
+				providerId: "chutes",
+				modelId: "moonshotai/Kimi-K2.5-TEE",
+				messages: baseMessages,
+				reasoning: { enabled: false },
+			}),
+		);
+		await collect(
+			await gateway.stream({
+				providerId: "chutes",
+				modelId: "Qwen/Qwen3-32B-TEE",
+				messages: baseMessages,
+				reasoning: { enabled: true },
+			}),
+		);
+		await collect(
+			await gateway.stream({
+				providerId: "chutes",
+				modelId: "Qwen/Qwen3-235B-A22B-Thinking-2507-TEE",
+				messages: baseMessages,
+				reasoning: { enabled: false },
+			}),
+		);
+
+		expect(streamTextSpy).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining({
+				providerOptions: expect.objectContaining({
+					chutes: expect.objectContaining({
+						chat_template_kwargs: { thinking: false },
+					}),
+				}),
+			}),
+		);
+		expect(streamTextSpy).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining({
+				providerOptions: expect.objectContaining({
+					chutes: expect.objectContaining({
+						chat_template_kwargs: { enable_thinking: true },
+					}),
+				}),
+			}),
+		);
+
+		const thinkingOnlyProviderOptions = (
+			streamTextSpy.mock.calls[2]?.[0] as {
+				providerOptions?: Record<string, Record<string, unknown>>;
+			}
+		).providerOptions;
+		expect(thinkingOnlyProviderOptions?.chutes).not.toHaveProperty(
+			"chat_template_kwargs",
+		);
+	});
+
 	it("does not apply generic thinking to non-GLM native Z.AI custom models", async () => {
 		streamTextSpy.mockReturnValue({
 			fullStream: makeStreamParts([

--- a/sdk/packages/llms/src/providers/gateway.test.ts
+++ b/sdk/packages/llms/src/providers/gateway.test.ts
@@ -5953,7 +5953,7 @@ describe("sdk-gateway", () => {
 		}
 	});
 
-	it("routes Chutes Kimi and Qwen reasoning controls by model family", async () => {
+	it("routes Chutes reasoning controls by model family", async () => {
 		streamTextSpy.mockReturnValue({
 			fullStream: makeStreamParts([
 				{ type: "finish", usage: { inputTokens: 1, outputTokens: 1 } },
@@ -5964,42 +5964,47 @@ describe("sdk-gateway", () => {
 			providerConfigs: [{ providerId: "chutes", apiKey: "chutes-key" }],
 		});
 
-		await collect(
-			await gateway.stream({
-				providerId: "chutes",
-				modelId: "moonshotai/Kimi-K2.5-TEE",
-				messages: baseMessages,
-				reasoning: { enabled: false },
-			}),
-		);
-		await collect(
-			await gateway.stream({
-				providerId: "chutes",
+		// One model per wire shape, not one per family: Chutes retires older
+		// checkpoints as newer ones land, so this covers both shapes with
+		// current models and leaves per-family mapping to the unit tests,
+		// which build their own context and do not track the catalog.
+		const cases = [
+			{ modelId: "moonshotai/Kimi-K2.6-TEE", kwargs: { thinking: false } },
+			{ modelId: "zai-org/GLM-5.2-TEE", kwargs: { thinking: false } },
+			{
+				modelId: "google/gemma-4-31B-turbo-TEE",
+				kwargs: { enable_thinking: false },
+			},
+			{
 				modelId: "Qwen/Qwen3-32B-TEE",
-				messages: baseMessages,
-				reasoning: { enabled: true },
-			}),
-		);
-		expect(streamTextSpy).toHaveBeenNthCalledWith(
-			1,
-			expect.objectContaining({
-				providerOptions: expect.objectContaining({
-					chutes: expect.objectContaining({
-						chat_template_kwargs: { thinking: false },
+				kwargs: { enable_thinking: true },
+				enabled: true,
+			},
+		];
+
+		for (const testCase of cases) {
+			await collect(
+				await gateway.stream({
+					providerId: "chutes",
+					modelId: testCase.modelId,
+					messages: baseMessages,
+					reasoning: { enabled: testCase.enabled ?? false },
+				}),
+			);
+		}
+
+		cases.forEach((testCase, index) => {
+			expect(streamTextSpy).toHaveBeenNthCalledWith(
+				index + 1,
+				expect.objectContaining({
+					providerOptions: expect.objectContaining({
+						chutes: expect.objectContaining({
+							chat_template_kwargs: testCase.kwargs,
+						}),
 					}),
 				}),
-			}),
-		);
-		expect(streamTextSpy).toHaveBeenNthCalledWith(
-			2,
-			expect.objectContaining({
-				providerOptions: expect.objectContaining({
-					chutes: expect.objectContaining({
-						chat_template_kwargs: { enable_thinking: true },
-					}),
-				}),
-			}),
-		);
+			);
+		});
 	});
 
 	it("does not apply generic thinking to non-GLM native Z.AI custom models", async () => {

--- a/sdk/packages/llms/src/providers/gateway.test.ts
+++ b/sdk/packages/llms/src/providers/gateway.test.ts
@@ -5980,15 +5980,6 @@ describe("sdk-gateway", () => {
 				reasoning: { enabled: true },
 			}),
 		);
-		await collect(
-			await gateway.stream({
-				providerId: "chutes",
-				modelId: "Qwen/Qwen3-235B-A22B-Thinking-2507-TEE",
-				messages: baseMessages,
-				reasoning: { enabled: false },
-			}),
-		);
-
 		expect(streamTextSpy).toHaveBeenNthCalledWith(
 			1,
 			expect.objectContaining({
@@ -6008,15 +5999,6 @@ describe("sdk-gateway", () => {
 					}),
 				}),
 			}),
-		);
-
-		const thinkingOnlyProviderOptions = (
-			streamTextSpy.mock.calls[2]?.[0] as {
-				providerOptions?: Record<string, Record<string, unknown>>;
-			}
-		).providerOptions;
-		expect(thinkingOnlyProviderOptions?.chutes).not.toHaveProperty(
-			"chat_template_kwargs",
 		);
 	});
 

--- a/sdk/packages/llms/src/providers/routing/chutes-thinking.ts
+++ b/sdk/packages/llms/src/providers/routing/chutes-thinking.ts
@@ -1,0 +1,73 @@
+import type {
+	GatewayProviderContext,
+	GatewayStreamRequest,
+} from "@cline/shared";
+import {
+	isQwenModel,
+	normalizeRoutingValue,
+	resolveModelFamily,
+} from "../model-facts";
+import { buildProviderAndAliasPatch, type ProviderOptionsPatch } from "./utils";
+
+export function usesChutesChatTemplateReasoning(
+	request: Pick<GatewayStreamRequest, "providerId" | "modelId">,
+	context: GatewayProviderContext,
+): boolean {
+	// Chutes hosts heterogeneous families. Provider routing metadata would claim
+	// its single reasoning format and disable Cline's fallbacks for other families.
+	if (
+		request.providerId !== "chutes" ||
+		!context.model.capabilities?.includes("reasoning")
+	) {
+		return false;
+	}
+
+	const family = resolveModelFamily(context);
+	return (
+		normalizeRoutingValue(family) === "kimi-k2" ||
+		isQwenModel({ modelId: request.modelId, family })
+	);
+}
+
+function isThinkingOnlyQwen(
+	request: Pick<GatewayStreamRequest, "modelId">,
+	context: GatewayProviderContext,
+): boolean {
+	const descriptor = [request.modelId, context.model.id, context.model.name]
+		.map((value) => normalizeRoutingValue(value))
+		.filter(Boolean)
+		.join(" ");
+	return /(^|[^a-z0-9])thinking([^a-z0-9]|$)/.test(descriptor);
+}
+
+export function buildChutesThinkingProviderOptionsPatch(
+	request: GatewayStreamRequest,
+	context: GatewayProviderContext,
+	providerOptionsKey: string,
+): ProviderOptionsPatch | undefined {
+	const enabled = request.reasoning?.enabled;
+	if (enabled === undefined) {
+		return undefined;
+	}
+
+	const family = resolveModelFamily(context);
+	let chatTemplateKwargs: Record<string, boolean> | undefined;
+	if (normalizeRoutingValue(family) === "kimi-k2") {
+		chatTemplateKwargs = enabled
+			? { thinking: true, preserve_thinking: true }
+			: { thinking: false };
+	} else if (
+		isQwenModel({ modelId: request.modelId, family }) &&
+		!isThinkingOnlyQwen(request, context)
+	) {
+		chatTemplateKwargs = { enable_thinking: enabled };
+	}
+
+	return chatTemplateKwargs
+		? buildProviderAndAliasPatch({
+				providerId: request.providerId,
+				providerOptionsKey,
+				bucketOptions: { chat_template_kwargs: chatTemplateKwargs },
+			})
+		: undefined;
+}

--- a/sdk/packages/llms/src/providers/routing/chutes-thinking.ts
+++ b/sdk/packages/llms/src/providers/routing/chutes-thinking.ts
@@ -9,6 +9,55 @@ import {
 } from "../model-facts";
 import { buildProviderAndAliasPatch, type ProviderOptionsPatch } from "./utils";
 
+/**
+ * Which `chat_template_kwargs` field carries the thinking switch for each
+ * family Chutes serves. models.dev states *whether* a model has a toggle;
+ * this table states *how* that toggle is spelled on the wire, which the
+ * catalog does not describe.
+ *
+ * Every entry is taken from the model's published chat template and confirmed
+ * against the live endpoint, where `reasoning_content` is present with the
+ * switch on and absent with it off.
+ */
+const CHUTES_THINKING_FIELD: ReadonlyMap<
+	string,
+	"thinking" | "enable_thinking"
+> = new Map([
+	["kimi-k2", "thinking"],
+	["kimi-k3", "thinking"],
+	["glm", "thinking"],
+	["deepseek", "thinking"],
+	["deepseek-flash", "thinking"],
+	["gemma", "enable_thinking"],
+]);
+
+/**
+ * Kimi K2's template takes a second flag that keeps earlier reasoning in
+ * context. No other family Chutes serves declares it — K3's template does not
+ * either — so everything else is sent only the switch its own template
+ * declares, rather than a field it would silently drop.
+ */
+const CHUTES_PRESERVE_THINKING_FAMILIES: ReadonlySet<string> = new Set([
+	"kimi-k2",
+]);
+
+function resolveChutesThinkingField(
+	request: Pick<GatewayStreamRequest, "modelId">,
+	context: GatewayProviderContext,
+): { field: "thinking" | "enable_thinking"; family: string } | undefined {
+	const family = resolveModelFamily(context);
+	const normalized = normalizeRoutingValue(family) ?? "";
+	const mapped = CHUTES_THINKING_FIELD.get(normalized);
+	if (mapped) {
+		return { field: mapped, family: normalized };
+	}
+	// Qwen checkpoints are recognized by model id as well as by family, since
+	// Chutes serves several that predate a family entry.
+	return isQwenModel({ modelId: request.modelId, family })
+		? { field: "enable_thinking", family: normalized }
+		: undefined;
+}
+
 export function usesChutesChatTemplateReasoning(
 	request: Pick<GatewayStreamRequest, "providerId" | "modelId">,
 	context: GatewayProviderContext,
@@ -22,11 +71,7 @@ export function usesChutesChatTemplateReasoning(
 		return false;
 	}
 
-	const family = resolveModelFamily(context);
-	return (
-		normalizeRoutingValue(family) === "kimi-k2" ||
-		isQwenModel({ modelId: request.modelId, family })
-	);
+	return resolveChutesThinkingField(request, context) !== undefined;
 }
 
 /**
@@ -45,21 +90,26 @@ export function buildChutesThinkingProviderOptionsPatch(
 		return undefined;
 	}
 
-	const family = resolveModelFamily(context);
-	let chatTemplateKwargs: Record<string, boolean> | undefined;
-	if (normalizeRoutingValue(family) === "kimi-k2") {
-		chatTemplateKwargs = enabled
-			? { thinking: true, preserve_thinking: true }
-			: { thinking: false };
-	} else if (isQwenModel({ modelId: request.modelId, family })) {
-		chatTemplateKwargs = { enable_thinking: enabled };
+	const resolved = resolveChutesThinkingField(request, context);
+	if (!resolved) {
+		return undefined;
 	}
 
-	return chatTemplateKwargs
-		? buildProviderAndAliasPatch({
-				providerId: request.providerId,
-				providerOptionsKey,
-				bucketOptions: { chat_template_kwargs: chatTemplateKwargs },
-			})
-		: undefined;
+	let chatTemplateKwargs: Record<string, boolean>;
+	if (resolved.field === "enable_thinking") {
+		chatTemplateKwargs = { enable_thinking: enabled };
+	} else if (
+		enabled &&
+		CHUTES_PRESERVE_THINKING_FAMILIES.has(resolved.family)
+	) {
+		chatTemplateKwargs = { thinking: true, preserve_thinking: true };
+	} else {
+		chatTemplateKwargs = { thinking: enabled };
+	}
+
+	return buildProviderAndAliasPatch({
+		providerId: request.providerId,
+		providerOptionsKey,
+		bucketOptions: { chat_template_kwargs: chatTemplateKwargs },
+	});
 }

--- a/sdk/packages/llms/src/providers/routing/chutes-thinking.ts
+++ b/sdk/packages/llms/src/providers/routing/chutes-thinking.ts
@@ -29,15 +29,20 @@ export function usesChutesChatTemplateReasoning(
 	);
 }
 
+/**
+ * Chutes Qwen-family models whose thinking mode cannot be disabled at the
+ * wire level. Membership is explicit and auditable: new thinking-only models
+ * must be added deliberately, not inferred from display names.
+ */
+const CHUTES_THINKING_ONLY_QWEN_IDS: ReadonlySet<string> = new Set([
+	"qwen/qwen3-235b-a22b-thinking-2507-tee",
+]);
+
 function isThinkingOnlyQwen(
 	request: Pick<GatewayStreamRequest, "modelId">,
-	context: GatewayProviderContext,
 ): boolean {
-	const descriptor = [request.modelId, context.model.id, context.model.name]
-		.map((value) => normalizeRoutingValue(value))
-		.filter(Boolean)
-		.join(" ");
-	return /(^|[^a-z0-9])thinking([^a-z0-9]|$)/.test(descriptor);
+	const modelId = normalizeRoutingValue(request.modelId);
+	return modelId ? CHUTES_THINKING_ONLY_QWEN_IDS.has(modelId) : false;
 }
 
 export function buildChutesThinkingProviderOptionsPatch(
@@ -58,7 +63,7 @@ export function buildChutesThinkingProviderOptionsPatch(
 			: { thinking: false };
 	} else if (
 		isQwenModel({ modelId: request.modelId, family }) &&
-		!isThinkingOnlyQwen(request, context)
+		!isThinkingOnlyQwen(request)
 	) {
 		chatTemplateKwargs = { enable_thinking: enabled };
 	}

--- a/sdk/packages/llms/src/providers/routing/chutes-thinking.ts
+++ b/sdk/packages/llms/src/providers/routing/chutes-thinking.ts
@@ -30,21 +30,11 @@ export function usesChutesChatTemplateReasoning(
 }
 
 /**
- * Chutes Qwen-family models whose thinking mode cannot be disabled at the
- * wire level. Membership is explicit and auditable: new thinking-only models
- * must be added deliberately, not inferred from display names.
+ * Mandatory-thinking models never reach this builder with a toggle intent:
+ * `normalizeReasoningRequest` drops `reasoning` when the model advertises no
+ * off control, so `enabled` is already undefined here. The distinction stays an
+ * authoritative catalog fact instead of a list maintained in routing code.
  */
-const CHUTES_THINKING_ONLY_QWEN_IDS: ReadonlySet<string> = new Set([
-	"qwen/qwen3-235b-a22b-thinking-2507-tee",
-]);
-
-function isThinkingOnlyQwen(
-	request: Pick<GatewayStreamRequest, "modelId">,
-): boolean {
-	const modelId = normalizeRoutingValue(request.modelId);
-	return modelId ? CHUTES_THINKING_ONLY_QWEN_IDS.has(modelId) : false;
-}
-
 export function buildChutesThinkingProviderOptionsPatch(
 	request: GatewayStreamRequest,
 	context: GatewayProviderContext,
@@ -61,10 +51,7 @@ export function buildChutesThinkingProviderOptionsPatch(
 		chatTemplateKwargs = enabled
 			? { thinking: true, preserve_thinking: true }
 			: { thinking: false };
-	} else if (
-		isQwenModel({ modelId: request.modelId, family }) &&
-		!isThinkingOnlyQwen(request)
-	) {
+	} else if (isQwenModel({ modelId: request.modelId, family })) {
 		chatTemplateKwargs = { enable_thinking: enabled };
 	}
 

--- a/sdk/packages/llms/src/providers/routing/portable-reasoning.ts
+++ b/sdk/packages/llms/src/providers/routing/portable-reasoning.ts
@@ -19,6 +19,11 @@ const PORTABLE_REASONING_PROVIDERS = new Set([
 ]);
 
 const NON_PORTABLE_REASONING_PROVIDERS = new Set([
+	// Chutes serves open-weights models on vLLM, where the thinking switch is a
+	// `chat_template_kwargs` field read by each model's chat template. The
+	// portable option has no way to express that, and claiming it here would
+	// strip the request's reasoning intent before the Chutes rule can encode it.
+	"chutes",
 	"claude-code",
 	"dify",
 	"mistral",

--- a/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
@@ -13,6 +13,10 @@ import {
 	supportsGeminiThinking,
 } from "../model-facts";
 import { buildGatewayReasoningOptions } from "./anthropic-compatible";
+import {
+	buildChutesThinkingProviderOptionsPatch,
+	usesChutesChatTemplateReasoning,
+} from "./chutes-thinking";
 import { buildOpenAINativeProviderOptions } from "./generic-compatible";
 import {
 	buildNativeGlmThinkingProviderOptionsPatch,
@@ -287,6 +291,22 @@ const openRouterReasoningRule: ProviderOptionRule = {
 		),
 };
 
+const chutesChatTemplateReasoningRule: ProviderOptionRule = {
+	id: "provider.chutes.chat-template-reasoning",
+	phase: "provider-reasoning",
+	description:
+		"Chutes Kimi and hybrid Qwen families use chat_template_kwargs thinking controls.",
+	applies: (input) =>
+		usesChutesChatTemplateReasoning(input.request, input.context),
+	suppresses: { genericThinking: true, genericEffort: true },
+	build: (input) =>
+		buildChutesThinkingProviderOptionsPatch(
+			input.request,
+			input.context,
+			input.providerOptionsKey,
+		),
+};
+
 const clineMiniMaxM3GatewayReasoningRule: ProviderOptionRule = {
 	id: "provider.cline.minimax-m3.gateway-reasoning",
 	phase: "provider-reasoning",
@@ -496,6 +516,7 @@ export const PROVIDER_OPTION_RULES: ReadonlyArray<ProviderOptionRule> = [
 	genericProviderFanoutRule,
 	clineGatewayReasoningRule,
 	openRouterReasoningRule,
+	chutesChatTemplateReasoningRule,
 	clineMiniMaxM3GatewayReasoningRule,
 	vercelMiniMaxM3GatewayReasoningRule,
 	geminiThinkingRule,

--- a/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
@@ -10,6 +10,10 @@ import {
 	providerReasoningRouteMatches,
 } from "../model-facts";
 import { buildGatewayReasoningOptions } from "./anthropic-compatible";
+import {
+	buildChutesThinkingProviderOptionsPatch,
+	usesChutesChatTemplateReasoning,
+} from "./chutes-thinking";
 import { buildOpenAINativeProviderOptions } from "./generic-compatible";
 import {
 	buildNativeGlmThinkingProviderOptionsPatch,
@@ -220,6 +224,22 @@ const openRouterReasoningRule: ProviderOptionRule = {
 		buildReasoningPatchForProvider(
 			input,
 			buildOpenRouterReasoningOptions(input.request, input.context),
+		),
+};
+
+const chutesChatTemplateReasoningRule: ProviderOptionRule = {
+	id: "provider.chutes.chat-template-reasoning",
+	phase: "provider-reasoning",
+	description:
+		"Chutes Kimi and hybrid Qwen families use chat_template_kwargs thinking controls.",
+	applies: (input) =>
+		usesChutesChatTemplateReasoning(input.request, input.context),
+	suppresses: { genericThinking: true, genericEffort: true },
+	build: (input) =>
+		buildChutesThinkingProviderOptionsPatch(
+			input.request,
+			input.context,
+			input.providerOptionsKey,
 		),
 };
 
@@ -516,6 +536,7 @@ export const PROVIDER_OPTION_RULES: ReadonlyArray<ProviderOptionRule> = [
 	genericProviderFanoutRule,
 	clineGatewayReasoningRule,
 	openRouterReasoningRule,
+	chutesChatTemplateReasoningRule,
 	clineMiniMaxM3GatewayReasoningRule,
 	vercelReasoningRule,
 	directMoonshotReasoningRule,

--- a/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
@@ -234,7 +234,7 @@ const chutesChatTemplateReasoningRule: ProviderOptionRule = {
 		"Chutes Kimi and hybrid Qwen families use chat_template_kwargs thinking controls.",
 	applies: (input) =>
 		usesChutesChatTemplateReasoning(input.request, input.context),
-	suppresses: { genericThinking: true, genericEffort: true },
+	suppresses: { genericThinking: true },
 	build: (input) =>
 		buildChutesThinkingProviderOptionsPatch(
 			input.request,

--- a/sdk/packages/llms/src/providers/routing/provider-options.test.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-options.test.ts
@@ -875,6 +875,277 @@ describe("composeAiSdkProviderOptions: family/provider thinking patches", () => 
 				{ bucket: "openaiCompatible", lacks: ["thinking", "reasoning"] },
 			],
 		},
+		{
+			name: "Chutes Kimi K2.6 TEE reasoning.enabled=true -> explicit thinking chat template",
+			request: {
+				providerId: "chutes",
+				modelId: "moonshotai/Kimi-K2.6-TEE",
+				reasoning: { enabled: true, effort: "high" },
+			},
+			context: {
+				family: "kimi-k2",
+				capabilities: ["text", "reasoning"],
+			},
+			expect: [
+				{
+					bucket: "chutes",
+					has: {
+						chat_template_kwargs: {
+							thinking: true,
+							preserve_thinking: true,
+						},
+					},
+					lacks: ["thinking", "reasoningEffort", "effort"],
+				},
+				{
+					bucket: "openaiCompatible",
+					lacks: [
+						"chat_template_kwargs",
+						"thinking",
+						"reasoningEffort",
+						"effort",
+					],
+				},
+			],
+		},
+		{
+			name: "Chutes Kimi K2.6 TEE reasoning.enabled=false -> instant chat template",
+			request: {
+				providerId: "chutes",
+				modelId: "moonshotai/kimi-k2.6-tee",
+				reasoning: { enabled: false, effort: "high" },
+			},
+			context: {
+				family: "kimi-k2",
+				capabilities: ["text", "reasoning"],
+			},
+			expect: [
+				{
+					bucket: "chutes",
+					has: { chat_template_kwargs: { thinking: false } },
+					lacks: ["thinking", "reasoningEffort", "effort"],
+				},
+				{
+					bucket: "openaiCompatible",
+					lacks: [
+						"chat_template_kwargs",
+						"thinking",
+						"reasoningEffort",
+						"effort",
+					],
+				},
+			],
+		},
+		{
+			name: "Chutes Kimi K2.6 TEE unset reasoning -> no chat template patch",
+			request: {
+				providerId: "chutes",
+				modelId: "moonshotai/Kimi-K2.6-TEE",
+			},
+			context: {
+				family: "kimi-k2",
+				capabilities: ["text", "reasoning"],
+			},
+			expect: [
+				{
+					bucket: "chutes",
+					lacks: [
+						"chat_template_kwargs",
+						"thinking",
+						"reasoningEffort",
+						"effort",
+					],
+				},
+				{
+					bucket: "openaiCompatible",
+					lacks: [
+						"chat_template_kwargs",
+						"thinking",
+						"reasoningEffort",
+						"effort",
+					],
+				},
+			],
+		},
+		{
+			name: "Chutes future Kimi K2 family reasoning.enabled=false -> instant chat template",
+			request: {
+				providerId: "chutes",
+				modelId: "moonshotai/Kimi-K2.7-TEE",
+				reasoning: { enabled: false, effort: "high" },
+			},
+			context: {
+				family: "kimi-k2",
+				capabilities: ["text", "reasoning"],
+			},
+			expect: [
+				{
+					bucket: "chutes",
+					has: { chat_template_kwargs: { thinking: false } },
+					lacks: ["thinking", "reasoningEffort", "effort"],
+				},
+				{
+					bucket: "openaiCompatible",
+					lacks: [
+						"chat_template_kwargs",
+						"thinking",
+						"reasoningEffort",
+						"effort",
+					],
+				},
+			],
+		},
+		{
+			name: "Chutes hybrid Qwen family reasoning.enabled=true -> enabled chat template",
+			request: {
+				providerId: "chutes",
+				modelId: "Qwen/Qwen4-Example-TEE",
+				reasoning: { enabled: true, effort: "high" },
+			},
+			context: {
+				family: "qwen",
+				capabilities: ["text", "reasoning"],
+			},
+			expect: [
+				{
+					bucket: "chutes",
+					has: { chat_template_kwargs: { enable_thinking: true } },
+					lacks: ["thinking", "reasoningEffort", "effort"],
+				},
+				{
+					bucket: "openaiCompatible",
+					lacks: [
+						"chat_template_kwargs",
+						"thinking",
+						"reasoningEffort",
+						"effort",
+					],
+				},
+			],
+		},
+		{
+			name: "Chutes hybrid Qwen family reasoning.enabled=false -> disabled chat template",
+			request: {
+				providerId: "chutes",
+				modelId: "Qwen/Qwen4-Example-TEE",
+				reasoning: { enabled: false, effort: "high" },
+			},
+			context: {
+				family: "qwen",
+				capabilities: ["text", "reasoning"],
+			},
+			expect: [
+				{
+					bucket: "chutes",
+					has: { chat_template_kwargs: { enable_thinking: false } },
+					lacks: ["thinking", "reasoningEffort", "effort"],
+				},
+				{
+					bucket: "openaiCompatible",
+					lacks: [
+						"chat_template_kwargs",
+						"thinking",
+						"reasoningEffort",
+						"effort",
+					],
+				},
+			],
+		},
+		{
+			name: "Chutes thinking-only Qwen family ignores explicit disable",
+			request: {
+				providerId: "chutes",
+				modelId: "Qwen/Qwen4-Example-Thinking-TEE",
+				reasoning: { enabled: false, effort: "high" },
+			},
+			context: {
+				family: "qwen",
+				capabilities: ["text", "reasoning"],
+			},
+			expect: [
+				{
+					bucket: "chutes",
+					lacks: [
+						"chat_template_kwargs",
+						"thinking",
+						"reasoningEffort",
+						"effort",
+					],
+				},
+				{
+					bucket: "openaiCompatible",
+					lacks: [
+						"chat_template_kwargs",
+						"thinking",
+						"reasoningEffort",
+						"effort",
+					],
+				},
+			],
+		},
+		{
+			name: "Chutes unknown reasoning family keeps standard compatible reasoning",
+			request: {
+				providerId: "chutes",
+				modelId: "future/reasoner-1",
+				reasoning: { enabled: true, effort: "high" },
+			},
+			context: {
+				family: "future-reasoner",
+				capabilities: ["text", "reasoning"],
+			},
+			expect: [
+				{
+					bucket: "chutes",
+					has: {
+						thinking: { type: "adaptive" },
+						reasoningEffort: "high",
+					},
+					lacks: ["chat_template_kwargs"],
+				},
+			],
+		},
+		{
+			name: "Chutes Claude family keeps standard Anthropic-compatible reasoning",
+			request: {
+				providerId: "chutes",
+				modelId: "anthropic/claude-future",
+				reasoning: { enabled: true, effort: "high" },
+			},
+			context: {
+				family: "claude-sonnet",
+				capabilities: ["text", "reasoning"],
+			},
+			expect: [
+				{
+					bucket: "chutes",
+					has: { reasoning: { enabled: true, max_tokens: 1024 } },
+					lacks: ["chat_template_kwargs", "thinking", "reasoningEffort"],
+				},
+			],
+		},
+		{
+			name: "Chutes Kimi family without reasoning capability keeps standard options",
+			request: {
+				providerId: "chutes",
+				modelId: "moonshotai/Kimi-K2.7-TEE",
+				reasoning: { enabled: true, effort: "high" },
+			},
+			context: {
+				family: "kimi-k2",
+				capabilities: ["text"],
+			},
+			expect: [
+				{
+					bucket: "chutes",
+					has: {
+						thinking: { type: "adaptive" },
+						reasoningEffort: "high",
+					},
+					lacks: ["chat_template_kwargs"],
+				},
+			],
+		},
 		// Kimi K2.6 family: explicit enabled/disabled and unset defaults to enabled
 		{
 			name: "cline Kimi K2.6 family reasoning.enabled=false -> thinking.type=disabled",

--- a/sdk/packages/llms/src/providers/routing/provider-options.test.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-options.test.ts
@@ -1226,6 +1226,110 @@ describe("composeAiSdkProviderOptions: family/provider thinking patches", () => 
 				},
 			],
 		},
+		// One case per remaining family Chutes serves. The wire field each one
+		// takes is declared by its own published chat template: `thinking` for
+		// Kimi, GLM and DeepSeek, `enable_thinking` for Qwen and Gemma. Only
+		// Kimi K2 declares `preserve_thinking`, so only it receives that flag.
+		{
+			name: "Chutes Kimi K3 -> thinking without preserve_thinking",
+			request: {
+				providerId: "chutes",
+				modelId: "moonshotai/Kimi-K3-TEE",
+				reasoning: { enabled: true },
+			},
+			context: {
+				family: "kimi-k3",
+				capabilities: ["text", "reasoning"],
+				reasoningOptions: [{ type: "toggle" }],
+			},
+			expect: [
+				{
+					bucket: "chutes",
+					has: { chat_template_kwargs: { thinking: true } },
+					lacks: ["reasoningEffort", "effort"],
+				},
+			],
+		},
+		{
+			name: "Chutes GLM -> thinking chat template kwarg",
+			request: {
+				providerId: "chutes",
+				modelId: "zai-org/GLM-5.2-TEE",
+				reasoning: { enabled: false },
+			},
+			context: {
+				family: "glm",
+				capabilities: ["text", "reasoning"],
+				reasoningOptions: [{ type: "toggle" }],
+			},
+			expect: [
+				{
+					bucket: "chutes",
+					has: { chat_template_kwargs: { thinking: false } },
+					lacks: ["reasoningEffort", "effort"],
+				},
+			],
+		},
+		{
+			name: "Chutes DeepSeek -> thinking chat template kwarg",
+			request: {
+				providerId: "chutes",
+				modelId: "deepseek-ai/DeepSeek-V3.2-TEE",
+				reasoning: { enabled: true },
+			},
+			context: {
+				family: "deepseek",
+				capabilities: ["text", "reasoning"],
+				reasoningOptions: [{ type: "toggle" }],
+			},
+			expect: [
+				{
+					bucket: "chutes",
+					has: { chat_template_kwargs: { thinking: true } },
+					lacks: ["reasoningEffort", "effort"],
+				},
+			],
+		},
+		{
+			name: "Chutes DeepSeek Flash -> thinking chat template kwarg",
+			request: {
+				providerId: "chutes",
+				modelId: "deepseek-ai/DeepSeek-V4-Flash-0731-TEE",
+				reasoning: { enabled: false },
+			},
+			context: {
+				family: "deepseek-flash",
+				capabilities: ["text", "reasoning"],
+				reasoningOptions: [{ type: "toggle" }],
+			},
+			expect: [
+				{
+					bucket: "chutes",
+					has: { chat_template_kwargs: { thinking: false } },
+					lacks: ["reasoningEffort", "effort"],
+				},
+			],
+		},
+		{
+			name: "Chutes Gemma -> enable_thinking chat template kwarg",
+			request: {
+				providerId: "chutes",
+				modelId: "google/gemma-4-31B-turbo-TEE",
+				reasoning: { enabled: true },
+			},
+			context: {
+				family: "gemma",
+				capabilities: ["text", "reasoning"],
+				reasoningOptions: [{ type: "toggle" }],
+			},
+			expect: [
+				{
+					bucket: "chutes",
+					has: { chat_template_kwargs: { enable_thinking: true } },
+					lacks: ["reasoningEffort", "effort"],
+				},
+			],
+		},
 		{
 			name: "Chutes Kimi K2.6 TEE unset reasoning -> no chat template patch",
 			request: {

--- a/sdk/packages/llms/src/providers/routing/provider-options.test.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-options.test.ts
@@ -1111,6 +1111,277 @@ describe("composeAiSdkProviderOptions: family/provider thinking patches", () => 
 				{ bucket: "openaiCompatible", lacks: ["thinking", "reasoning"] },
 			],
 		},
+		{
+			name: "Chutes Kimi K2.6 TEE reasoning.enabled=true -> explicit thinking chat template",
+			request: {
+				providerId: "chutes",
+				modelId: "moonshotai/Kimi-K2.6-TEE",
+				reasoning: { enabled: true, effort: "high" },
+			},
+			context: {
+				family: "kimi-k2",
+				capabilities: ["text", "reasoning"],
+			},
+			expect: [
+				{
+					bucket: "chutes",
+					has: {
+						chat_template_kwargs: {
+							thinking: true,
+							preserve_thinking: true,
+						},
+					},
+					lacks: ["thinking", "reasoningEffort", "effort"],
+				},
+				{
+					bucket: "openaiCompatible",
+					lacks: [
+						"chat_template_kwargs",
+						"thinking",
+						"reasoningEffort",
+						"effort",
+					],
+				},
+			],
+		},
+		{
+			name: "Chutes Kimi K2.6 TEE reasoning.enabled=false -> instant chat template",
+			request: {
+				providerId: "chutes",
+				modelId: "moonshotai/kimi-k2.6-tee",
+				reasoning: { enabled: false, effort: "high" },
+			},
+			context: {
+				family: "kimi-k2",
+				capabilities: ["text", "reasoning"],
+			},
+			expect: [
+				{
+					bucket: "chutes",
+					has: { chat_template_kwargs: { thinking: false } },
+					lacks: ["thinking", "reasoningEffort", "effort"],
+				},
+				{
+					bucket: "openaiCompatible",
+					lacks: [
+						"chat_template_kwargs",
+						"thinking",
+						"reasoningEffort",
+						"effort",
+					],
+				},
+			],
+		},
+		{
+			name: "Chutes Kimi K2.6 TEE unset reasoning -> no chat template patch",
+			request: {
+				providerId: "chutes",
+				modelId: "moonshotai/Kimi-K2.6-TEE",
+			},
+			context: {
+				family: "kimi-k2",
+				capabilities: ["text", "reasoning"],
+			},
+			expect: [
+				{
+					bucket: "chutes",
+					lacks: [
+						"chat_template_kwargs",
+						"thinking",
+						"reasoningEffort",
+						"effort",
+					],
+				},
+				{
+					bucket: "openaiCompatible",
+					lacks: [
+						"chat_template_kwargs",
+						"thinking",
+						"reasoningEffort",
+						"effort",
+					],
+				},
+			],
+		},
+		{
+			name: "Chutes future Kimi K2 family reasoning.enabled=false -> instant chat template",
+			request: {
+				providerId: "chutes",
+				modelId: "moonshotai/Kimi-K2.7-TEE",
+				reasoning: { enabled: false, effort: "high" },
+			},
+			context: {
+				family: "kimi-k2",
+				capabilities: ["text", "reasoning"],
+			},
+			expect: [
+				{
+					bucket: "chutes",
+					has: { chat_template_kwargs: { thinking: false } },
+					lacks: ["thinking", "reasoningEffort", "effort"],
+				},
+				{
+					bucket: "openaiCompatible",
+					lacks: [
+						"chat_template_kwargs",
+						"thinking",
+						"reasoningEffort",
+						"effort",
+					],
+				},
+			],
+		},
+		{
+			name: "Chutes hybrid Qwen family reasoning.enabled=true -> enabled chat template",
+			request: {
+				providerId: "chutes",
+				modelId: "Qwen/Qwen4-Example-TEE",
+				reasoning: { enabled: true, effort: "high" },
+			},
+			context: {
+				family: "qwen",
+				capabilities: ["text", "reasoning"],
+			},
+			expect: [
+				{
+					bucket: "chutes",
+					has: { chat_template_kwargs: { enable_thinking: true } },
+					lacks: ["thinking", "reasoningEffort", "effort"],
+				},
+				{
+					bucket: "openaiCompatible",
+					lacks: [
+						"chat_template_kwargs",
+						"thinking",
+						"reasoningEffort",
+						"effort",
+					],
+				},
+			],
+		},
+		{
+			name: "Chutes hybrid Qwen family reasoning.enabled=false -> disabled chat template",
+			request: {
+				providerId: "chutes",
+				modelId: "Qwen/Qwen4-Example-TEE",
+				reasoning: { enabled: false, effort: "high" },
+			},
+			context: {
+				family: "qwen",
+				capabilities: ["text", "reasoning"],
+			},
+			expect: [
+				{
+					bucket: "chutes",
+					has: { chat_template_kwargs: { enable_thinking: false } },
+					lacks: ["thinking", "reasoningEffort", "effort"],
+				},
+				{
+					bucket: "openaiCompatible",
+					lacks: [
+						"chat_template_kwargs",
+						"thinking",
+						"reasoningEffort",
+						"effort",
+					],
+				},
+			],
+		},
+		{
+			name: "Chutes thinking-only Qwen family ignores explicit disable",
+			request: {
+				providerId: "chutes",
+				modelId: "Qwen/Qwen4-Example-Thinking-TEE",
+				reasoning: { enabled: false, effort: "high" },
+			},
+			context: {
+				family: "qwen",
+				capabilities: ["text", "reasoning"],
+			},
+			expect: [
+				{
+					bucket: "chutes",
+					lacks: [
+						"chat_template_kwargs",
+						"thinking",
+						"reasoningEffort",
+						"effort",
+					],
+				},
+				{
+					bucket: "openaiCompatible",
+					lacks: [
+						"chat_template_kwargs",
+						"thinking",
+						"reasoningEffort",
+						"effort",
+					],
+				},
+			],
+		},
+		{
+			name: "Chutes unknown reasoning family keeps standard compatible reasoning",
+			request: {
+				providerId: "chutes",
+				modelId: "future/reasoner-1",
+				reasoning: { enabled: true, effort: "high" },
+			},
+			context: {
+				family: "future-reasoner",
+				capabilities: ["text", "reasoning"],
+			},
+			expect: [
+				{
+					bucket: "chutes",
+					has: {
+						thinking: { type: "adaptive" },
+						reasoningEffort: "high",
+					},
+					lacks: ["chat_template_kwargs"],
+				},
+			],
+		},
+		{
+			name: "Chutes Claude family keeps standard Anthropic-compatible reasoning",
+			request: {
+				providerId: "chutes",
+				modelId: "anthropic/claude-future",
+				reasoning: { enabled: true, effort: "high" },
+			},
+			context: {
+				family: "claude-sonnet",
+				capabilities: ["text", "reasoning"],
+			},
+			expect: [
+				{
+					bucket: "chutes",
+					has: { reasoning: { enabled: true, max_tokens: 1024 } },
+					lacks: ["chat_template_kwargs", "thinking", "reasoningEffort"],
+				},
+			],
+		},
+		{
+			name: "Chutes Kimi family without reasoning capability keeps standard options",
+			request: {
+				providerId: "chutes",
+				modelId: "moonshotai/Kimi-K2.7-TEE",
+				reasoning: { enabled: true, effort: "high" },
+			},
+			context: {
+				family: "kimi-k2",
+				capabilities: ["text"],
+			},
+			expect: [
+				{
+					bucket: "chutes",
+					has: {
+						thinking: { type: "adaptive" },
+						reasoningEffort: "high",
+					},
+					lacks: ["chat_template_kwargs"],
+				},
+			],
+		},
 		// Kimi K2.6 family: explicit enabled/disabled and unset defaults to enabled
 		{
 			name: "cline Kimi K2.6 family reasoning.enabled=false -> thinking.type=disabled",

--- a/sdk/packages/llms/src/providers/routing/provider-options.test.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-options.test.ts
@@ -1536,7 +1536,10 @@ describe("composeAiSdkProviderOptions: family/provider thinking patches", () => 
 			],
 		},
 		{
-			name: "Chutes unknown reasoning family keeps standard compatible reasoning",
+			// Chutes reads its thinking switch from chat_template_kwargs only, so a
+			// family this rule does not encode emits no reasoning control at all
+			// rather than a generic field the endpoint ignores.
+			name: "Chutes unknown reasoning family emits no reasoning control",
 			request: {
 				providerId: "chutes",
 				modelId: "future/reasoner-1",
@@ -1549,13 +1552,12 @@ describe("composeAiSdkProviderOptions: family/provider thinking patches", () => 
 			expect: [
 				{
 					bucket: "chutes",
-					has: { reasoningEffort: "high" },
-					lacks: ["chat_template_kwargs", "thinking"],
+					lacks: ["chat_template_kwargs", "thinking", "reasoningEffort"],
 				},
 			],
 		},
 		{
-			name: "Chutes Claude family keeps standard Anthropic-compatible reasoning",
+			name: "Chutes Claude family keeps Anthropic-compatible thinking",
 			request: {
 				providerId: "chutes",
 				modelId: "anthropic/claude-future",
@@ -1568,13 +1570,13 @@ describe("composeAiSdkProviderOptions: family/provider thinking patches", () => 
 			expect: [
 				{
 					bucket: "chutes",
-					has: { reasoning: { enabled: true, max_tokens: 1024 } },
-					lacks: ["chat_template_kwargs", "thinking", "reasoningEffort"],
+					has: { thinking: { type: "adaptive" } },
+					lacks: ["chat_template_kwargs", "reasoningEffort"],
 				},
 			],
 		},
 		{
-			name: "Chutes Kimi family without reasoning capability keeps standard options",
+			name: "Chutes Kimi family without reasoning capability emits no controls",
 			request: {
 				providerId: "chutes",
 				modelId: "moonshotai/Kimi-K2.7-TEE",
@@ -1587,8 +1589,7 @@ describe("composeAiSdkProviderOptions: family/provider thinking patches", () => 
 			expect: [
 				{
 					bucket: "chutes",
-					has: { reasoningEffort: "high" },
-					lacks: ["chat_template_kwargs", "thinking"],
+					lacks: ["chat_template_kwargs", "thinking", "reasoningEffort"],
 				},
 			],
 		},

--- a/sdk/packages/llms/src/providers/routing/provider-options.test.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-options.test.ts
@@ -22,6 +22,7 @@ type RequestOverrides = Partial<GatewayStreamRequest> & {
 type ContextOverrides = {
 	providerId?: string;
 	modelId?: string;
+	modelName?: string;
 	family?: string;
 	contextWindow?: number;
 	maxOutputTokens?: number;
@@ -36,6 +37,7 @@ type ContextOverrides = {
 function makeContext(options?: ContextOverrides): GatewayProviderContext {
 	const providerId = options?.providerId ?? "test-provider";
 	const modelId = options?.modelId ?? "model-id";
+	const modelName = options?.modelName ?? modelId;
 	const normalizedFamily = options?.family?.toLowerCase() ?? "";
 	const normalizedModelId = modelId.toLowerCase();
 	const useAnthropicReasoningRoute =
@@ -91,7 +93,7 @@ function makeContext(options?: ContextOverrides): GatewayProviderContext {
 		},
 		model: {
 			id: modelId,
-			name: modelId,
+			name: modelName,
 			providerId,
 			maxOutputTokens: options?.maxOutputTokens,
 			contextWindow: options?.contextWindow,
@@ -1291,7 +1293,7 @@ describe("composeAiSdkProviderOptions: family/provider thinking patches", () => 
 			name: "Chutes thinking-only Qwen family ignores explicit disable",
 			request: {
 				providerId: "chutes",
-				modelId: "Qwen/Qwen4-Example-Thinking-TEE",
+				modelId: "Qwen/Qwen3-235B-A22B-Thinking-2507-TEE",
 				reasoning: { enabled: false, effort: "high" },
 			},
 			context: {
@@ -1316,6 +1318,59 @@ describe("composeAiSdkProviderOptions: family/provider thinking patches", () => 
 						"reasoningEffort",
 						"effort",
 					],
+				},
+			],
+		},
+		{
+			name: "Chutes thinking-only classification is stable across display name changes",
+			request: {
+				providerId: "chutes",
+				modelId: "Qwen/Qwen3-235B-A22B-Thinking-2507-TEE",
+				reasoning: { enabled: false, effort: "high" },
+			},
+			context: {
+				family: "qwen",
+				capabilities: ["text", "reasoning"],
+				modelName: "Qwen3 235B Super Fast Non-Thinking Edition",
+			},
+			expect: [
+				{
+					bucket: "chutes",
+					lacks: [
+						"chat_template_kwargs",
+						"thinking",
+						"reasoningEffort",
+						"effort",
+					],
+				},
+				{
+					bucket: "openaiCompatible",
+					lacks: [
+						"chat_template_kwargs",
+						"thinking",
+						"reasoningEffort",
+						"effort",
+					],
+				},
+			],
+		},
+		{
+			name: "Chutes Qwen model not in thinking-only set receives toggle regardless of display name",
+			request: {
+				providerId: "chutes",
+				modelId: "Qwen/Qwen4-New-Model-TEE",
+				reasoning: { enabled: false, effort: "high" },
+			},
+			context: {
+				family: "qwen",
+				capabilities: ["text", "reasoning"],
+				modelName: "Qwen4 Thinking Ultra",
+			},
+			expect: [
+				{
+					bucket: "chutes",
+					has: { chat_template_kwargs: { enable_thinking: false } },
+					lacks: ["thinking", "reasoningEffort", "effort"],
 				},
 			],
 		},

--- a/sdk/packages/llms/src/providers/routing/provider-options.test.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-options.test.ts
@@ -1175,6 +1175,58 @@ describe("composeAiSdkProviderOptions: family/provider thinking patches", () => 
 			],
 		},
 		{
+			// Guards the catalog dependency: a model that advertises no
+			// user-facing reasoning control emits no chat template kwargs, even
+			// though its family would otherwise route through this rule.
+			name: "Chutes Kimi advertising no reasoning control -> no chat template patch",
+			request: {
+				providerId: "chutes",
+				modelId: "moonshotai/Kimi-K2.6-TEE",
+				reasoning: { enabled: true, effort: "high" },
+			},
+			context: {
+				family: "kimi-k2",
+				capabilities: ["text", "reasoning"],
+				reasoningOptions: [],
+			},
+			expect: [
+				{
+					bucket: "chutes",
+					lacks: [
+						"chat_template_kwargs",
+						"thinking",
+						"reasoningEffort",
+						"effort",
+					],
+				},
+			],
+		},
+		{
+			name: "Chutes Kimi advertising a toggle -> chat template patch",
+			request: {
+				providerId: "chutes",
+				modelId: "moonshotai/Kimi-K2.6-TEE",
+				reasoning: { enabled: true, effort: "high" },
+			},
+			context: {
+				family: "kimi-k2",
+				capabilities: ["text", "reasoning"],
+				reasoningOptions: [{ type: "toggle" }],
+			},
+			expect: [
+				{
+					bucket: "chutes",
+					has: {
+						chat_template_kwargs: {
+							thinking: true,
+							preserve_thinking: true,
+						},
+					},
+					lacks: ["thinking", "reasoningEffort", "effort"],
+				},
+			],
+		},
+		{
 			name: "Chutes Kimi K2.6 TEE unset reasoning -> no chat template patch",
 			request: {
 				providerId: "chutes",
@@ -1290,7 +1342,7 @@ describe("composeAiSdkProviderOptions: family/provider thinking patches", () => 
 			],
 		},
 		{
-			name: "Chutes thinking-only Qwen family ignores explicit disable",
+			name: "Chutes mandatory-thinking Qwen advertises no control -> explicit disable is dropped",
 			request: {
 				providerId: "chutes",
 				modelId: "Qwen/Qwen3-235B-A22B-Thinking-2507-TEE",
@@ -1299,6 +1351,9 @@ describe("composeAiSdkProviderOptions: family/provider thinking patches", () => 
 			context: {
 				family: "qwen",
 				capabilities: ["text", "reasoning"],
+				// models.dev advertises `reasoning_options = []` for this model:
+				// reasoning with no user-facing control.
+				reasoningOptions: [],
 			},
 			expect: [
 				{
@@ -1322,7 +1377,7 @@ describe("composeAiSdkProviderOptions: family/provider thinking patches", () => 
 			],
 		},
 		{
-			name: "Chutes thinking-only classification is stable across display name changes",
+			name: "Chutes mandatory-thinking classification is stable across display name changes",
 			request: {
 				providerId: "chutes",
 				modelId: "Qwen/Qwen3-235B-A22B-Thinking-2507-TEE",
@@ -1331,6 +1386,7 @@ describe("composeAiSdkProviderOptions: family/provider thinking patches", () => 
 			context: {
 				family: "qwen",
 				capabilities: ["text", "reasoning"],
+				reasoningOptions: [],
 				modelName: "Qwen3 235B Super Fast Non-Thinking Edition",
 			},
 			expect: [
@@ -1355,7 +1411,7 @@ describe("composeAiSdkProviderOptions: family/provider thinking patches", () => 
 			],
 		},
 		{
-			name: "Chutes Qwen model not in thinking-only set receives toggle regardless of display name",
+			name: "Chutes Qwen advertising a toggle receives it regardless of display name",
 			request: {
 				providerId: "chutes",
 				modelId: "Qwen/Qwen4-New-Model-TEE",
@@ -1364,6 +1420,7 @@ describe("composeAiSdkProviderOptions: family/provider thinking patches", () => 
 			context: {
 				family: "qwen",
 				capabilities: ["text", "reasoning"],
+				reasoningOptions: [{ type: "toggle" }],
 				modelName: "Qwen4 Thinking Ultra",
 			},
 			expect: [
@@ -1388,11 +1445,8 @@ describe("composeAiSdkProviderOptions: family/provider thinking patches", () => 
 			expect: [
 				{
 					bucket: "chutes",
-					has: {
-						thinking: { type: "adaptive" },
-						reasoningEffort: "high",
-					},
-					lacks: ["chat_template_kwargs"],
+					has: { reasoningEffort: "high" },
+					lacks: ["chat_template_kwargs", "thinking"],
 				},
 			],
 		},
@@ -1429,11 +1483,8 @@ describe("composeAiSdkProviderOptions: family/provider thinking patches", () => 
 			expect: [
 				{
 					bucket: "chutes",
-					has: {
-						thinking: { type: "adaptive" },
-						reasoningEffort: "high",
-					},
-					lacks: ["chat_template_kwargs"],
+					has: { reasoningEffort: "high" },
+					lacks: ["chat_template_kwargs", "thinking"],
 				},
 			],
 		},


### PR DESCRIPTION
## Related

- Feature Request: [#12284](https://github.com/cline/cline/discussions/12284)
- VS Code recognition: [#12068](https://github.com/cline/cline/pull/12068)

## What

Adds per-family reasoning routing for the Chutes provider (`chutes`).

## Why

[#12204](https://github.com/cline/cline/pull/12204) now generates Chutes' base registration (base URL, API key env, model catalog, capabilities) from models.dev, so this PR no longer needs to add that by hand — it originally did, but that part is superseded and has been dropped.

What's left: Chutes hosts heterogeneous model families behind one OpenAI-compatible endpoint. Kimi K2 and Qwen models expect reasoning toggled through `chat_template_kwargs` rather than the generic `reasoning` shape, and there's no single provider-wide reasoning format that fits every family without suppressing fallbacks for the others.

## Changes

- Adds `routing/chutes-thinking.ts`, building the `chat_template_kwargs` patch per family:
  - Kimi K2 family: `thinking` (+ `preserve_thinking` when enabled)
  - Hybrid Qwen families: `enable_thinking`
  - Qwen thinking-only variants: no disable toggle sent
- Registers a `provider.chutes.chat-template-reasoning` provider-option rule that suppresses the generic `thinking` / `reasoningEffort` / `effort` fields for the matched families
- Keeps Chutes' generated `BuiltinSpec` free of provider-level reasoning metadata, since a single format would block fallback handling for unrelated families on the same host — covered by an explicit test

No registration changes: base URL, API key, model catalog, and capabilities for Chutes come from the generated provider spec.

## Verification

- Rebased onto current `main` (post-#12204); scope reduced to routing only
- Local `@cline/llms`: 433 passed, 4 skipped
- Typecheck clean; no new Biome findings (one pre-existing, unrelated warning in `gateway.test.ts` outside the changed region)

