### PR TITLE
Fireworks AI: add Kimi K2.7 Code, Qwen 3.7 Plus, MiniMax M3; remove deprecated models

### DIFF
--- a/apps/vscode/src/shared/api.ts
+++ b/apps/vscode/src/shared/api.ts
@@ -5107,17 +5107,17 @@ export const mainlandZAiModels = {
 export type FireworksModelId = keyof typeof fireworksModels
 export const fireworksDefaultModelId: FireworksModelId = "accounts/fireworks/models/kimi-k2p6"
 export const fireworksModels = {
-	"accounts/fireworks/models/kimi-k2p5": {
-		maxTokens: 256000,
-		contextWindow: 256000,
+	"accounts/fireworks/models/kimi-k2p7-code": {
+		maxTokens: 262000,
+		contextWindow: 262000,
 		supportsImages: true,
 		supportsPromptCache: true,
-		inputPrice: 0.6,
-		outputPrice: 3,
+		inputPrice: 0.95,
+		outputPrice: 4,
 		cacheWritesPrice: 0,
-		cacheReadsPrice: 0.1,
+		cacheReadsPrice: 0.19,
 		description:
-			"Moonshot's flagship open agentic model. Kimi K2.5 unifies vision and text, thinking and non-thinking modes, and single-agent and multi-agent execution.",
+			"Moonshot's latest open coding model. Kimi K2.7 Code unifies vision and text, thinking and non-thinking modes, and single-agent and multi-agent execution.",
 	},
 	"accounts/fireworks/models/kimi-k2p6": {
 		maxTokens: 262000,
@@ -5142,6 +5142,18 @@ export const fireworksModels = {
 		cacheReadsPrice: 0.3,
 		description:
 			"Kimi K2.6 Turbo router for high-performance agentic workloads with vision and text reasoning.",
+	},
+	"accounts/fireworks/routers/kimi-k2p7-code-fast": {
+		maxTokens: 262000,
+		contextWindow: 262000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 1.9,
+		outputPrice: 8,
+		cacheWritesPrice: 0,
+		cacheReadsPrice: 0.38,
+		description:
+			"Kimi K2.7 Code Fast router for high-performance coding workloads with vision and text reasoning.",
 	},
 	"accounts/fireworks/models/deepseek-v4-flash": {
 		maxTokens: 384000,
@@ -5189,16 +5201,16 @@ export const fireworksModels = {
 		cacheReadsPrice: 0.52,
 		description: "GLM 5.1 Fast router for high-throughput coding, reasoning, and agentic workflows.",
 	},
-	"accounts/fireworks/models/minimax-m2p5": {
-		maxTokens: 196608,
-		contextWindow: 196608,
-		supportsImages: false,
+	"accounts/fireworks/models/minimax-m3": {
+		maxTokens: 512000,
+		contextWindow: 512000,
+		supportsImages: true,
 		supportsPromptCache: true,
 		inputPrice: 0.3,
 		outputPrice: 1.2,
 		cacheWritesPrice: 0,
-		cacheReadsPrice: 0.03,
-		description: "MiniMax M2.5 is built for state-of-the-art coding, agentic tool use.",
+		cacheReadsPrice: 0.06,
+		description: "MiniMax M3 is built for state-of-the-art coding, agentic tool use, and long-context multimodal tasks.",
 	},
 	"accounts/fireworks/models/minimax-m2p7": {
 		maxTokens: 196608,
@@ -5211,16 +5223,16 @@ export const fireworksModels = {
 		cacheReadsPrice: 0.06,
 		description: "MiniMax M2.7 is tuned for strong real-world performance across coding, agent-driven, and workflow-heavy tasks.",
 	},
-	"accounts/fireworks/models/qwen3p6-plus": {
-		maxTokens: 65536,
+	"accounts/fireworks/models/qwen3p7-plus": {
+		maxTokens: 262144,
 		contextWindow: 262144,
 		supportsImages: true,
 		supportsPromptCache: true,
-		inputPrice: 0.5,
-		outputPrice: 3,
+		inputPrice: 0.4,
+		outputPrice: 1.6,
 		cacheWritesPrice: 0,
-		cacheReadsPrice: 0.1,
-		description: "Qwen 3.6 Plus with strong multimodal reasoning, long context support, and function calling.",
+		cacheReadsPrice: 0.08,
+		description: "Qwen 3.7 Plus with strong multimodal reasoning, long context support, and function calling.",
 	},
 	"accounts/fireworks/models/gpt-oss-120b": {
 		maxTokens: 32768,


### PR DESCRIPTION
### Related Issue

**Issue:** #11553 

### Description

The Fireworks AI provider model registry in Cline's VS Code extension has become out of date compared to the current active models available on the Fireworks platform. This PR updates the hardcoded registry to match the latest lineup, ensuring users can select from the newest available models.

- **Added models:**
  - `accounts/fireworks/models/kimi-k2p7-code`
  - `accounts/fireworks/routers/kimi-k2p7-code-fast`
  - `accounts/fireworks/models/qwen3p7-plus`
  - `accounts/fireworks/models/minimax-m3`
- **Removed deprecated models:**
  - `accounts/fireworks/models/kimi-k2p5`
  - `accounts/fireworks/models/minimax-m2p5`
  - `accounts/fireworks/models/qwen3p6-plus`

- **Changes made:**
  - `apps/vscode/src/shared/api.ts`

Per project scope, this change is intentionally limited to the VS Code extension's hardcoded registry. The default model remains `accounts/fireworks/models/kimi-k2p6`, so no changes to `sdk/packages/llms/src/providers/builtins.ts` or `APIOptions.spec.tsx` are needed.

The same change has already been pushed and merged in the models.dev repository, so the Cline SDK will be able to fetch the updated models list automatically, too.

### Test Procedure

- **Verification approach:** The changes are confined to the `fireworksModels` object in `apps/vscode/src/shared/api.ts`, which is the single source of truth for the Fireworks UI model list. The `FireworksProvider` React component, `providerUtils.ts`, and `fireworks.ts` API handler all consume this object dynamically by reference, so no cascading changes were needed.
- **What could break:** The `fireworks.ts` handler uses `modelId in fireworksModels` for validation. If a user had previously selected a removed model (e.g., kimi-k2p5), the handler will gracefully fall back to the default `kimi-k2p6`. This is existing behavior, not new.
- **Why this is ready:** The blast radius is minimal and only affects 1 file. The Fireworks documentation and serverless models list were used to verify all pricing and metadata.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

All models highlighted in red are deprecated and will no longer be available over the Fireworks AI serverless api.
<img width="753" height="445" alt="Cline_Before" src="https://github.com/user-attachments/assets/95b5e9f8-6f93-41b9-be0a-36ce7e82067c" />

All models highlighted in green are available and active over the Fireworks AI serverless api to replace the deprecated models.
<img width="753" height="445" alt="Cline_After_1" src="https://github.com/user-attachments/assets/11d59177-5e8c-4265-906d-a04a6c22b424" />
<img width="753" height="445" alt="Cline_After_2" src="https://github.com/user-attachments/assets/2c82ca13-4f72-4d05-aae6-467aba3c1306" />
