### PR TITLE
Clarify malformed execute_command XML errors

### DIFF
--- a/apps/vscode/src/core/task/tools/handlers/ExecuteCommandToolHandler.ts
+++ b/apps/vscode/src/core/task/tools/handlers/ExecuteCommandToolHandler.ts
@@ -55,6 +55,36 @@ export function resolveCommandTimeoutSeconds(
 	return isLikelyLongRunningCommand(command) ? LONG_RUNNING_COMMAND_TIMEOUT_SECONDS : DEFAULT_COMMAND_TIMEOUT_SECONDS
 }
 
+const NON_COMMAND_CLOSE_BEFORE_REQUIRES_APPROVAL_PATTERN =
+	/<\/(?!command\b)[A-Za-z_][\w:.-]*>\s*<requires_approval\b/i
+
+export function getMalformedExecuteCommandXmlCloseTag(command: string): string | undefined {
+	const match = command.match(NON_COMMAND_CLOSE_BEFORE_REQUIRES_APPROVAL_PATTERN)
+	return match?.[0].match(/<\/[A-Za-z_][\w:.-]*>/)?.[0]
+}
+
+export function isMalformedExecuteCommandXml(command: string): boolean {
+	return /<requires_approval\b/i.test(command) || /<\/execute_command>/i.test(command)
+}
+
+export function createMalformedExecuteCommandXmlError(command: string): string {
+	const closeTag = getMalformedExecuteCommandXmlCloseTag(command)
+	const closeTagHint = closeTag
+		? ` It looks like the command parameter was closed with '${closeTag}' instead of '</command>'.`
+		: ""
+
+	return (
+		`Malformed XML in execute_command.${closeTagHint}\n\n` +
+		`Each execute_command parameter must use matching XML tags.\n` +
+		`Close <command> with </command>, and keep other parameter tags outside the command text.\n\n` +
+		`Correct format:\n` +
+		`<execute_command>\n` +
+		`<command>npm test</command>\n` +
+		`<requires_approval>false</requires_approval>\n` +
+		`</execute_command>`
+	)
+}
+
 export class ExecuteCommandToolHandler implements IFullyManagedTool {
 	readonly name = ClineDefaultTool.BASH
 
@@ -108,6 +138,10 @@ export class ExecuteCommandToolHandler implements IFullyManagedTool {
 
 		if (!requiresApprovalRaw) {
 			config.taskState.consecutiveMistakeCount++
+			if (isMalformedExecuteCommandXml(command)) {
+				await config.callbacks.say("error", "Cline tried to use malformed XML for execute_command. Retrying...")
+				return formatResponse.toolError(createMalformedExecuteCommandXmlError(command))
+			}
 			return await config.callbacks.sayAndCreateMissingParamError(this.name, "requires_approval")
 		}
 

--- a/apps/vscode/src/core/task/tools/handlers/__tests__/ExecuteCommandToolHandler.timeout.test.ts
+++ b/apps/vscode/src/core/task/tools/handlers/__tests__/ExecuteCommandToolHandler.timeout.test.ts
@@ -54,6 +54,17 @@ describe("ExecuteCommandToolHandler malformed XML detection", () => {
 		assert.equal(getMalformedExecuteCommandXmlCloseTag(command), undefined)
 	})
 
+	it("detects a swallowed execute_command close tag without a close-tag hint", () => {
+		const command = "npm test\n</execute_command>"
+
+		assert.equal(isMalformedExecuteCommandXml(command), true)
+		assert.equal(getMalformedExecuteCommandXmlCloseTag(command), undefined)
+
+		const message = createMalformedExecuteCommandXmlError(command)
+		assert.match(message, /Malformed XML in execute_command/)
+		assert.doesNotMatch(message, /instead of '<\/command>'/)
+	})
+
 	it("tells the model to fix malformed execute_command XML", () => {
 		const message = createMalformedExecuteCommandXmlError(
 			"npm test</unexpected>\n<requires_approval>false</requires_approval>",

--- a/apps/vscode/src/core/task/tools/handlers/__tests__/ExecuteCommandToolHandler.timeout.test.ts
+++ b/apps/vscode/src/core/task/tools/handlers/__tests__/ExecuteCommandToolHandler.timeout.test.ts
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict"
 import { describe, it } from "mocha"
-import { isLikelyLongRunningCommand, resolveCommandTimeoutSeconds } from "../ExecuteCommandToolHandler"
+import {
+	createMalformedExecuteCommandXmlError,
+	getMalformedExecuteCommandXmlCloseTag,
+	isLikelyLongRunningCommand,
+	isMalformedExecuteCommandXml,
+	resolveCommandTimeoutSeconds,
+} from "../ExecuteCommandToolHandler"
 
 describe("ExecuteCommandToolHandler timeout policy", () => {
 	it("returns undefined when managed timeout is disabled", () => {
@@ -27,5 +33,35 @@ describe("ExecuteCommandToolHandler timeout policy", () => {
 		assert.equal(isLikelyLongRunningCommand("cargo build --release"), true)
 		assert.equal(isLikelyLongRunningCommand("docker build ."), true)
 		assert.equal(isLikelyLongRunningCommand("pytest -q"), true)
+	})
+})
+
+describe("ExecuteCommandToolHandler malformed XML detection", () => {
+	it("detects execute_command XML swallowed into the command parameter", () => {
+		const command =
+			"npm test</unexpected>\n" +
+			"<requires_approval>false</requires_approval>\n" +
+			"</execute_command>"
+
+		assert.equal(isMalformedExecuteCommandXml(command), true)
+		assert.equal(getMalformedExecuteCommandXmlCloseTag(command), "</unexpected>")
+	})
+
+	it("does not flag normal command text", () => {
+		const command = "npm test -- --reporter spec"
+
+		assert.equal(isMalformedExecuteCommandXml(command), false)
+		assert.equal(getMalformedExecuteCommandXmlCloseTag(command), undefined)
+	})
+
+	it("tells the model to fix malformed execute_command XML", () => {
+		const message = createMalformedExecuteCommandXmlError(
+			"npm test</unexpected>\n<requires_approval>false</requires_approval>",
+		)
+
+		assert.match(message, /Malformed XML in execute_command/)
+		assert.match(message, /<\/unexpected>/)
+		assert.match(message, /<\/command>/)
+		assert.match(message, /<requires_approval>false<\/requires_approval>/)
 	})
 })


### PR DESCRIPTION
### Related Issue

N/A - small defensive tool-error fix.

### Description

Context: This was discovered when using QWEN 3.6 27B Q8 - it produce some malformed XML which wasn't handled gracefully by Cline.

When malformed XML causes `execute_command` parameter tags to be parsed as part of the command text, Cline can report a misleading missing-parameter error.

This PR adds a narrow `execute_command` validation check for that malformed XML shape and returns a model-facing error that identifies the issue and shows the correct format. Normal missing-parameter handling is unchanged.

### Test Procedure

Verified the branch is minimal against `origin/main`:

```text
git diff --stat origin/main..HEAD
```

Result:

```text
apps/vscode/src/core/task/tools/handlers/ExecuteCommandToolHandler.ts
apps/vscode/src/core/task/tools/handlers/__tests__/ExecuteCommandToolHandler.timeout.test.ts
```

Also verified:

```text
git diff --check
```

No whitespace errors.

Targeted Mocha tests were not run locally because `node`, `npm`, `pnpm`, and `bun` are not available on PATH in this shell.

### Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Refactor Changes
-   [ ] Cosmetic Changes
-   [ ] Documentation update
-   [ ] Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - tool error-message change only.

### Additional Notes

Checked for existing defensive handling before adding this. `parseAssistantMessageV2` preserves this malformed XML as parsed parameter text, `ToolValidator` only reports generic missing parameters, and the malformed XML handling in `o1-format.ts` is for a separate transform path.
