### PR TITLE
fix: preserve multiline thinking content

### DIFF
--- a/apps/vscode/webview-ui/src/components/chat/ThinkingRow.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ThinkingRow.test.tsx
@@ -21,6 +21,19 @@ describe("ThinkingRow", () => {
 		expect(screen.getByText("Inspecting files...")).toBeInTheDocument()
 	})
 
+	it("preserves multiline reasoning content", () => {
+		render(
+			<ThinkingRow
+				isExpanded={true}
+				isVisible={true}
+				reasoningContent={"First step\nSecond step"}
+				showTitle={true}
+			/>,
+		)
+
+		expect(screen.getByText(/First step/)).toHaveClass("whitespace-pre-wrap")
+	})
+
 	it("calls onToggle when header is clicked", () => {
 		const onToggle = vi.fn()
 

--- a/apps/vscode/webview-ui/src/components/chat/ThinkingRow.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ThinkingRow.tsx
@@ -107,7 +107,7 @@ export const ThinkingRow = memo(
 								)}
 								onScroll={checkScrollable}
 								ref={scrollRef}>
-								<span className="pb-2 block text-sm">{reasoningContent}</span>
+								<span className="pb-2 block text-sm whitespace-pre-wrap break-words">{reasoningContent}</span>
 							</div>
 							{canScrollUp && (
 								<div className="absolute top-0 left-0 right-0 h-6 pointer-events-none bg-gradient-to-b from-background to-transparent" />


### PR DESCRIPTION
## What
- Preserve newlines in expanded thinking/reasoning content
- Add a regression test for multiline reasoning text

## Why
Expanded thinking blocks can contain line breaks from model output, but the inner span did not explicitly preserve them. Keeping `whitespace-pre-wrap` on the rendered text avoids collapsing multiline reasoning into a single line.

Fixes #7876

## Test
- `bun --cwd apps/vscode/webview-ui test -- ThinkingRow.test.tsx`
- `bun --cwd apps/vscode/webview-ui lint`