### PR TITLE
Fix legacy task history disappearing after resume

### DIFF
--- a/apps/vscode/src/sdk/sdk-followup-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-followup-coordinator.test.ts
@@ -170,6 +170,10 @@ describe("SdkFollowupCoordinator", () => {
 			config: expect.objectContaining({ sessionId: "task-1" }),
 			interactive: true,
 			initialMessages: [{ role: "user", content: "hello" }],
+			sessionMetadata: expect.objectContaining({
+				title: "Original task",
+				modelId: "model",
+			}),
 		})
 		expect(options.taskHistory.updateTaskHistoryItem).toHaveBeenCalledWith(
 			expect.objectContaining({ id: "task-1", modelId: "model" }),

--- a/apps/vscode/src/sdk/sdk-followup-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-followup-coordinator.ts
@@ -8,7 +8,7 @@ import type { SdkInteractionCoordinator } from "./sdk-interaction-coordinator"
 import type { SdkMessageCoordinator } from "./sdk-message-coordinator"
 import type { SdkSessionConfigBuilder } from "./sdk-session-config-builder"
 import type { SdkSessionLifecycle } from "./sdk-session-lifecycle"
-import type { SdkTaskHistory } from "./sdk-task-history"
+import { historyItemToSessionMetadata, type SdkTaskHistory } from "./sdk-task-history"
 import type { SdkSessionHost } from "./session-host"
 import type { TaskProxy } from "./task-proxy"
 import type { VscodeSessionHost } from "./vscode-session-host"
@@ -152,6 +152,7 @@ export class SdkFollowupCoordinator {
 			config,
 			interactive: true,
 			...(initialMessages ? { initialMessages: initialMessages as InitialMessages } : {}),
+			...(historyItem ? { sessionMetadata: historyItemToSessionMetadata(historyItem, config.modelId) } : {}),
 		})
 
 		const task = this.options.getTask()

--- a/apps/vscode/src/sdk/sdk-task-history.ts
+++ b/apps/vscode/src/sdk/sdk-task-history.ts
@@ -71,6 +71,20 @@ function historyItemHasTokenUsage(item: HistoryItem): boolean {
 	return (item.tokensIn ?? 0) > 0 || (item.tokensOut ?? 0) > 0 || (item.cacheReads ?? 0) > 0 || (item.cacheWrites ?? 0) > 0
 }
 
+export function historyItemToSessionMetadata(item: HistoryItem, fallbackModelId?: string): Record<string, unknown> {
+	return {
+		title: item.task,
+		isFavorited: item.isFavorited ?? false,
+		size: item.size ?? 0,
+		totalCost: item.totalCost ?? 0,
+		tokensIn: item.tokensIn ?? 0,
+		tokensOut: item.tokensOut ?? 0,
+		cacheWrites: item.cacheWrites ?? 0,
+		cacheReads: item.cacheReads ?? 0,
+		modelId: item.modelId ?? fallbackModelId ?? "",
+	}
+}
+
 function historyItemToSessionHistoryRecord(item: HistoryItem): SessionHistoryRecord {
 	const startedAt = new Date(item.ts || Date.now()).toISOString()
 	const displayTask = formatDisplayUserInput(item.task)
@@ -93,15 +107,7 @@ function historyItemToSessionHistoryRecord(item: HistoryItem): SessionHistoryRec
 		isSubagent: false,
 		prompt: displayTask,
 		metadata: {
-			title: displayTask,
-			isFavorited: item.isFavorited ?? false,
-			size: item.size ?? 0,
-			totalCost: item.totalCost ?? 0,
-			tokensIn: item.tokensIn ?? 0,
-			tokensOut: item.tokensOut ?? 0,
-			cacheWrites: item.cacheWrites ?? 0,
-			cacheReads: item.cacheReads ?? 0,
-			modelId: item.modelId ?? "",
+			...historyItemToSessionMetadata({ ...item, task: displayTask }),
 			legacyTask: true,
 		},
 		updatedAt: startedAt,
@@ -556,15 +562,7 @@ export class SdkTaskHistory {
 					interactive: true,
 					initialMessages,
 					sessionMetadata: {
-						title: historyItem.task,
-						isFavorited: historyItem.isFavorited ?? false,
-						size: historyItem.size ?? 0,
-						totalCost: historyItem.totalCost ?? 0,
-						tokensIn: historyItem.tokensIn ?? 0,
-						tokensOut: historyItem.tokensOut ?? 0,
-						cacheWrites: historyItem.cacheWrites ?? 0,
-						cacheReads: historyItem.cacheReads ?? 0,
-						modelId: historyItem.modelId ?? "",
+						...historyItemToSessionMetadata(historyItem),
 						migratedFromLegacyTask: true,
 					},
 				})
@@ -585,17 +583,15 @@ export class SdkTaskHistory {
 			const existing = await host.get(sessionId)
 			const metadata: Record<string, unknown> = {
 				...(existing?.metadata ?? {}),
-				title: item.task,
-				isFavorited: item.isFavorited ?? false,
-				totalCost: item.totalCost ?? 0,
-				tokensIn: item.tokensIn ?? 0,
-				tokensOut: item.tokensOut ?? 0,
-				cacheWrites: item.cacheWrites ?? 0,
-				cacheReads: item.cacheReads ?? 0,
-				modelId: item.modelId ?? existing?.model ?? "",
+				...historyItemToSessionMetadata(item, existing?.model),
 			}
-			if (item.size !== undefined) {
-				metadata.size = item.size
+			if (item.size === undefined) {
+				const existingSize = existing?.metadata?.size
+				if (existingSize !== undefined) {
+					metadata.size = existingSize
+				} else {
+					delete metadata.size
+				}
 			}
 			await host.update(sessionId, {
 				prompt: item.task,

--- a/apps/vscode/src/sdk/sdk-task-start-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-task-start-coordinator.test.ts
@@ -124,6 +124,10 @@ describe("SdkTaskStartCoordinator", () => {
 			config: expect.objectContaining({ providerId: "anthropic", modelId: "model" }),
 			interactive: true,
 			initialMessages: [{ role: "user", content: "hello" }],
+			sessionMetadata: expect.objectContaining({
+				title: "old task",
+				modelId: "model",
+			}),
 		})
 		expect(state.task?.taskId).toBe("session-123")
 		expect(options.postStateToWebview).toHaveBeenCalledOnce()

--- a/apps/vscode/src/sdk/sdk-task-start-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-task-start-coordinator.ts
@@ -8,7 +8,7 @@ import { Logger } from "@/shared/services/Logger"
 import type { SdkMessageCoordinator } from "./sdk-message-coordinator"
 import type { SdkSessionConfigBuilder } from "./sdk-session-config-builder"
 import type { SdkSessionLifecycle } from "./sdk-session-lifecycle"
-import type { SdkTaskHistory } from "./sdk-task-history"
+import { historyItemToSessionMetadata, type SdkTaskHistory } from "./sdk-task-history"
 import type { SdkSessionHost } from "./session-host"
 import { createTaskProxy, type TaskProxy } from "./task-proxy"
 import type { VscodeSessionHost } from "./vscode-session-host"
@@ -148,6 +148,7 @@ export class SdkTaskStartCoordinator {
 				config,
 				interactive: true,
 				...(initialMessages ? { initialMessages: initialMessages as InitialMessages } : {}),
+				sessionMetadata: historyItemToSessionMetadata(historyItem, config.modelId),
 			})
 
 			this.createAndSetTask(startResult.sessionId)


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

Linear: ENG-2200

### Description

Fixes a VS Code task history regression when resuming an old pre-SDK/pre-migration task after upgrading to 4.0.0.

When a legacy task was opened, it could be migrated into SDK session storage with its history metadata. But when the user clicked Continue, the resumed active SDK session was started with preserved messages but without the legacy task metadata (notably the title). Task history prefers the active SDK session record over the legacy fallback, and `getTaskHistory()` filters out entries without a timestamp and task title, so the task appeared to disappear after returning to New Task/history.

This PR centralizes HistoryItem-to-session-metadata conversion and passes preserved metadata into resumed/reinitialized sessions so the history record remains visible while active and after persistence.

### Test Procedure

- Ran targeted VS Code SDK tests:
  - `cd apps/vscode && npx vitest run --config vitest.config.ts src/sdk/sdk-followup-coordinator.test.ts src/sdk/sdk-task-start-coordinator.test.ts src/sdk/sdk-task-history.test.ts`
- Manually tested in VS Code that resuming an old migrated task no longer makes the history entry disappear.
- Verified the history entry also appears in the CLI.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — no UI changes.

### Additional Notes

This specifically preserves title/favorite/token/cost/model metadata across the resume path so history filtering keeps the active resumed session visible.
