### PR TITLE
feat(cli): authorize plugin MCP OAuth during install

### DIFF
--- a/apps/cli/src/commands/plugin.test.ts
+++ b/apps/cli/src/commands/plugin.test.ts
@@ -17,6 +17,7 @@ import {
 } from "@cline/shared/storage";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+	collectPluginMcpOAuthCandidates,
 	installPlugin,
 	isOfficialPluginSlug,
 	parsePluginSource,
@@ -35,6 +36,7 @@ describe("plugin install command", () => {
 	let originalHome: string | undefined;
 	let originalClineDir: string | undefined;
 	let originalClineDataDir: string | undefined;
+	let originalMcpSettingsPath: string | undefined;
 
 	beforeEach(() => {
 		root = mkdtempSync(join(tmpdir(), "cli-plugin-install-"));
@@ -43,6 +45,7 @@ describe("plugin install command", () => {
 		originalHome = process.env.HOME;
 		originalClineDir = process.env.CLINE_DIR;
 		originalClineDataDir = process.env.CLINE_DATA_DIR;
+		originalMcpSettingsPath = process.env.CLINE_MCP_SETTINGS_PATH;
 		process.env.HOME = home;
 		process.env.CLINE_DIR = join(home, ".cline");
 		process.env.CLINE_DATA_DIR = join(home, ".cline", "data");
@@ -90,6 +93,11 @@ describe("plugin install command", () => {
 			delete process.env.CLINE_DATA_DIR;
 		} else {
 			process.env.CLINE_DATA_DIR = originalClineDataDir;
+		}
+		if (originalMcpSettingsPath === undefined) {
+			delete process.env.CLINE_MCP_SETTINGS_PATH;
+		} else {
+			process.env.CLINE_MCP_SETTINGS_PATH = originalMcpSettingsPath;
 		}
 		rmSync(root, { recursive: true, force: true });
 	});
@@ -676,6 +684,60 @@ describe("plugin install command", () => {
 			expect(code).toBe(0);
 			const parsed = JSON.parse(stdout.join("")) as { installPath: string };
 			expect(parsed.installPath).toContain(join(home, ".cline", "plugins"));
+			expect("mcpOAuthCandidates" in parsed).toBe(false);
+		} finally {
+			process.stdout.write = originalWrite;
+		}
+	});
+
+	it("does not run MCP OAuth follow-up for JSON plugin installs", async () => {
+		process.env.CLINE_MCP_SETTINGS_PATH = join(root, "mcp-settings.json");
+		const source = join(root, "json-oauth-mcp-plugin.js");
+		writeFileSync(
+			source,
+			`
+export default {
+  name: "json-oauth-mcp-plugin",
+  manifest: { capabilities: ["mcp"] },
+  setup(api) {
+    api.registerMcpServer({
+      name: "json-oauth-docs",
+      transport: { type: "streamableHttp", url: "https://example.com/mcp" },
+    })
+  },
+}
+`,
+			"utf8",
+		);
+		const stdout: string[] = [];
+		const originalWrite = process.stdout.write;
+		const authorize = vi.fn();
+		process.stdout.write = ((chunk: string | Uint8Array) => {
+			stdout.push(String(chunk));
+			return true;
+		}) as typeof process.stdout.write;
+		try {
+			const code = await runPluginInstallCommand({
+				source,
+				json: true,
+				io: {
+					writeln: () => {},
+					writeErr: () => {},
+				},
+				mcpOAuth: {
+					interactive: true,
+					selectCandidates: async (candidates) => candidates,
+					authorize,
+				},
+			});
+			expect(code).toBe(0);
+			expect(authorize).not.toHaveBeenCalled();
+			const parsed = JSON.parse(stdout.join("")) as {
+				installPath: string;
+				mcpOAuthCandidates?: unknown;
+			};
+			expect(parsed.installPath).toContain(join(home, ".cline", "plugins"));
+			expect(parsed.mcpOAuthCandidates).toBeUndefined();
 		} finally {
 			process.stdout.write = originalWrite;
 		}
@@ -729,6 +791,232 @@ export default {
 				process.env.CLINE_MCP_SETTINGS_PATH = originalSettingsPath;
 			}
 		}
+	});
+
+	it("detects plugin-owned remote MCP servers as OAuth candidates", async () => {
+		process.env.CLINE_MCP_SETTINGS_PATH = join(root, "mcp-settings.json");
+		const source = join(root, "oauth-mcp-plugin.js");
+		writeFileSync(
+			source,
+			`
+export default {
+  name: "oauth-mcp-plugin",
+  manifest: { capabilities: ["mcp"] },
+  setup(api) {
+    api.registerMcpServer({
+      name: "oauth-docs",
+      transport: { type: "streamableHttp", url: "https://example.com/mcp" },
+    })
+  },
+}
+`,
+			"utf8",
+		);
+
+		const result = await installPlugin({ source });
+
+		expect(result.mcpOAuthCandidates).toEqual([
+			expect.objectContaining({
+				name: "oauth-docs",
+				pluginName: "oauth-mcp-plugin",
+				transportType: "streamableHttp",
+			}),
+		]);
+	});
+
+	it("does not treat remote MCP servers with static headers as OAuth candidates", async () => {
+		process.env.CLINE_MCP_SETTINGS_PATH = join(root, "mcp-settings.json");
+		const source = join(root, "headers-mcp-plugin.js");
+		writeFileSync(
+			source,
+			`
+export default {
+  name: "headers-mcp-plugin",
+  manifest: { capabilities: ["mcp"] },
+  setup(api) {
+    api.registerMcpServer({
+      name: "headers-docs",
+      transport: {
+        type: "streamableHttp",
+        url: "https://example.com/mcp",
+        headers: { Authorization: "Bearer token" },
+      },
+    })
+  },
+}
+`,
+			"utf8",
+		);
+
+		const result = await installPlugin({ source });
+
+		expect(result.mcpOAuthCandidates).toEqual([]);
+	});
+
+	it("skips plugin MCP OAuth candidates that already have tokens", async () => {
+		const settingsPath = join(root, "mcp-settings.json");
+		process.env.CLINE_MCP_SETTINGS_PATH = settingsPath;
+		const source = join(root, "authorized-mcp-plugin.js");
+		writeFileSync(
+			source,
+			`
+export default {
+  name: "authorized-mcp-plugin",
+  manifest: { capabilities: ["mcp"] },
+  setup(api) {
+    api.registerMcpServer({
+      name: "authorized-docs",
+      transport: { type: "streamableHttp", url: "https://example.com/mcp" },
+    })
+  },
+}
+`,
+			"utf8",
+		);
+		const result = await installPlugin({ source });
+		const settings = JSON.parse(readFileSync(settingsPath, "utf8")) as {
+			mcpServers?: Record<string, { oauth?: unknown }>;
+		};
+		const server = settings.mcpServers?.["authorized-docs"];
+		if (!server) {
+			throw new Error("Expected authorized-docs MCP server to be written");
+		}
+		server.oauth = { tokens: { access_token: "oauth-token" } };
+		writeFileSync(settingsPath, JSON.stringify(settings, null, 2), "utf8");
+
+		expect(
+			collectPluginMcpOAuthCandidates({
+				pluginPaths: result.entryPaths,
+				settingsPath,
+			}),
+		).toEqual([]);
+	});
+
+	it("authorizes selected plugin MCP OAuth candidates during interactive installs", async () => {
+		process.env.CLINE_MCP_SETTINGS_PATH = join(root, "mcp-settings.json");
+		const source = join(root, "interactive-mcp-plugin.js");
+		writeFileSync(
+			source,
+			`
+export default {
+  name: "interactive-mcp-plugin",
+  manifest: { capabilities: ["mcp"] },
+  setup(api) {
+    api.registerMcpServer({
+      name: "interactive-docs",
+      transport: { type: "streamableHttp", url: "https://example.com/mcp" },
+    })
+  },
+}
+`,
+			"utf8",
+		);
+		const authorized: string[] = [];
+		const output: string[] = [];
+
+		const code = await runPluginInstallCommand({
+			source,
+			io: {
+				writeln: (text = "") => output.push(text),
+				writeErr: (text) => output.push(text),
+			},
+			mcpOAuth: {
+				interactive: true,
+				selectCandidates: async (candidates) => candidates,
+				authorize: async (candidate) => {
+					authorized.push(candidate.name);
+				},
+			},
+		});
+
+		expect(code).toBe(0);
+		expect(authorized).toEqual(["interactive-docs"]);
+		expect(output.join("\n")).toContain("Installed plugin from");
+	});
+
+	it("keeps plugin install successful when MCP OAuth authorization fails", async () => {
+		process.env.CLINE_MCP_SETTINGS_PATH = join(root, "mcp-settings.json");
+		const source = join(root, "failing-oauth-mcp-plugin.js");
+		writeFileSync(
+			source,
+			`
+export default {
+  name: "failing-oauth-mcp-plugin",
+  manifest: { capabilities: ["mcp"] },
+  setup(api) {
+    api.registerMcpServer({
+      name: "failing-docs",
+      transport: { type: "streamableHttp", url: "https://example.com/mcp" },
+    })
+  },
+}
+`,
+			"utf8",
+		);
+		const output: string[] = [];
+
+		const code = await runPluginInstallCommand({
+			source,
+			io: {
+				writeln: (text = "") => output.push(text),
+				writeErr: (text) => output.push(text),
+			},
+			mcpOAuth: {
+				interactive: true,
+				selectCandidates: async (candidates) => candidates,
+				authorize: async () => {
+					throw new Error("oauth unavailable");
+				},
+			},
+		});
+
+		expect(code).toBe(0);
+		expect(output.join("\n")).toContain(
+			"Warning: failed to authorize MCP server failing-docs: oauth unavailable",
+		);
+	});
+
+	it("prints guidance for plugin MCP OAuth candidates in non-interactive installs", async () => {
+		process.env.CLINE_MCP_SETTINGS_PATH = join(root, "mcp-settings.json");
+		const source = join(root, "non-interactive-mcp-plugin.js");
+		writeFileSync(
+			source,
+			`
+export default {
+  name: "non-interactive-mcp-plugin",
+  manifest: { capabilities: ["mcp"] },
+  setup(api) {
+    api.registerMcpServer({
+      name: "non-interactive-docs",
+      transport: { type: "streamableHttp", url: "https://example.com/mcp" },
+    })
+  },
+}
+`,
+			"utf8",
+		);
+		const output: string[] = [];
+		const authorize = vi.fn();
+
+		const code = await runPluginInstallCommand({
+			source,
+			io: {
+				writeln: (text = "") => output.push(text),
+				writeErr: (text) => output.push(text),
+			},
+			mcpOAuth: {
+				interactive: false,
+				authorize,
+			},
+		});
+
+		expect(code).toBe(0);
+		expect(authorize).not.toHaveBeenCalled();
+		expect(output.join("\n")).toContain(
+			"Plugin MCP servers may require OAuth authorization",
+		);
+		expect(output.join("\n")).toContain("non-interactive-docs");
+		expect(output.join("\n")).toContain('Run "cline mcp"');
 	});
 
 	it("prints JSON output for official plugin installs", async () => {

--- a/apps/cli/src/commands/plugin.ts
+++ b/apps/cli/src/commands/plugin.ts
@@ -22,8 +22,11 @@ import {
 	sep,
 } from "node:path";
 import {
+	type McpServerRegistration,
 	type PluginMcpSettingsSyncResult,
 	type PluginUninstallOptions,
+	resolveDefaultMcpSettingsPath,
+	resolveMcpServerRegistrations,
 	syncPluginMcpServersToSettings,
 	uninstallPlugin,
 } from "@cline/core";
@@ -41,6 +44,7 @@ export interface PluginInstallOptions {
 	npmCommand?: string;
 	officialPluginsRepo?: string;
 	io?: PluginInstallIo;
+	mcpOAuth?: PluginInstallMcpOAuthOptions;
 }
 
 export interface PluginInstallResult {
@@ -48,6 +52,23 @@ export interface PluginInstallResult {
 	installPath: string;
 	entryPaths: string[];
 	mcpSyncFailures: PluginMcpSettingsSyncResult["failures"];
+	mcpOAuthCandidates: PluginMcpOAuthCandidate[];
+}
+
+export interface PluginMcpOAuthCandidate {
+	name: string;
+	pluginName: string;
+	pluginPath: string;
+	transportType: "sse" | "streamableHttp";
+	lastError?: string;
+}
+
+export interface PluginInstallMcpOAuthOptions {
+	interactive?: boolean;
+	selectCandidates?: (
+		candidates: PluginMcpOAuthCandidate[],
+	) => Promise<PluginMcpOAuthCandidate[]>;
+	authorize?: (candidate: PluginMcpOAuthCandidate) => Promise<void>;
 }
 
 export interface PluginInstallIo {
@@ -1011,6 +1032,81 @@ function replaceInstallPath(
 	}
 }
 
+function hasStaticHeaders(registration: McpServerRegistration): boolean {
+	const transport = registration.transport;
+	if (transport.type === "stdio") {
+		return false;
+	}
+	return (
+		transport.headers !== undefined && Object.keys(transport.headers).length > 0
+	);
+}
+
+function hasOAuthAccessToken(registration: McpServerRegistration): boolean {
+	const accessToken = registration.oauth?.tokens?.access_token;
+	return typeof accessToken === "string" && accessToken.trim().length > 0;
+}
+
+function getPluginOwner(
+	registration: McpServerRegistration,
+): { pluginName: string; pluginPath: string } | undefined {
+	const metadata = registration.metadata;
+	if (
+		!metadata ||
+		metadata.source !== "plugin" ||
+		typeof metadata.pluginName !== "string" ||
+		typeof metadata.pluginPath !== "string"
+	) {
+		return undefined;
+	}
+	return {
+		pluginName: metadata.pluginName,
+		pluginPath: metadata.pluginPath,
+	};
+}
+
+export function collectPluginMcpOAuthCandidates(input: {
+	pluginPaths: readonly string[];
+	settingsPath?: string;
+}): PluginMcpOAuthCandidate[] {
+	const pluginPaths = new Set(input.pluginPaths.map((path) => resolve(path)));
+	if (pluginPaths.size === 0) {
+		return [];
+	}
+
+	let registrations: McpServerRegistration[];
+	try {
+		registrations = resolveMcpServerRegistrations({
+			filePath: input.settingsPath ?? resolveDefaultMcpSettingsPath(),
+		});
+	} catch {
+		return [];
+	}
+
+	const candidates: PluginMcpOAuthCandidate[] = [];
+	for (const registration of registrations) {
+		const owner = getPluginOwner(registration);
+		if (!owner || !pluginPaths.has(resolve(owner.pluginPath))) {
+			continue;
+		}
+		const transportType = registration.transport.type;
+		if (transportType === "stdio") {
+			continue;
+		}
+		if (hasStaticHeaders(registration) || hasOAuthAccessToken(registration)) {
+			continue;
+		}
+		candidates.push({
+			name: registration.name,
+			pluginName: owner.pluginName,
+			pluginPath: owner.pluginPath,
+			transportType,
+			lastError: registration.oauth?.lastError,
+		});
+	}
+	return candidates.sort((left, right) => left.name.localeCompare(right.name));
+}
+
 export async function installPlugin(
 	options: PluginInstallOptions,
 ): Promise<PluginInstallResult> {
@@ -1082,6 +1178,7 @@ export async function installPlugin(
 			installPath,
 			entryPaths: entryPaths.map((entry) => resolve(installPath, entry)),
 			mcpSyncFailures: [] as PluginMcpSettingsSyncResult["failures"],
+			mcpOAuthCandidates: [] as PluginMcpOAuthCandidate[],
 		};
 		const syncResult = await syncPluginMcpServersToSettings({
 			pluginPaths: result.entryPaths,
@@ -1089,10 +1186,126 @@ export async function installPlugin(
 			workspacePath: cwd,
 		});
 		result.mcpSyncFailures = syncResult.failures;
+		result.mcpOAuthCandidates = collectPluginMcpOAuthCandidates({
+			pluginPaths: result.entryPaths,
+		});
 		return result;
 	} catch (error) {
 		rmSync(stagingRoot, { recursive: true, force: true });
 		throw error;
+	}
+}
+
+function serializePluginInstallResult(
+	result: PluginInstallResult,
+): Omit<PluginInstallResult, "mcpOAuthCandidates"> {
+	return {
+		source: result.source,
+		installPath: result.installPath,
+		entryPaths: result.entryPaths,
+		mcpSyncFailures: result.mcpSyncFailures,
+	};
+}
+
+function isInteractivePluginInstall(
+	options: PluginInstallOptions & { json?: boolean },
+): boolean {
+	return (
+		options.mcpOAuth?.interactive ??
+		(options.json !== true && process.stdin.isTTY && process.stdout.isTTY)
+	);
+}
+
+async function selectMcpOAuthCandidatesWithClack(
+	candidates: PluginMcpOAuthCandidate[],
+): Promise<PluginMcpOAuthCandidate[]> {
+	const p = await import("@clack/prompts");
+	const action = await p.select({
+		message: "Authorize plugin MCP servers now?",
+		options: [
+			{
+				value: "all",
+				label: "Authorize all",
+				hint: "open browser authorization for each server",
+			},
+			{
+				value: "choose",
+				label: "Choose servers",
+				hint: "select which servers to authorize",
+			},
+			{
+				value: "skip",
+				label: "Skip",
+			},
+		],
+	});
+	if (p.isCancel(action) || action === "skip") {
+		return [];
+	}
+	if (action === "all") {
+		return candidates;
+	}
+
+	const selectedNames = await p.multiselect({
+		message: "Select MCP servers to authorize",
+		options: candidates.map((candidate) => ({
+			value: candidate.name,
+			label: candidate.name,
+			hint: `${candidate.transportType} [${candidate.pluginName}]`,
+		})),
+		required: false,
+	});
+	if (p.isCancel(selectedNames) || !Array.isArray(selectedNames)) {
+		return [];
+	}
+	const selected = new Set(selectedNames);
+	return candidates.filter((candidate) => selected.has(candidate.name));
+}
+
+async function authorizeMcpOAuthCandidate(
+	candidate: PluginMcpOAuthCandidate,
+): Promise<void> {
+	const { authorizeMcpServerOAuthWithBrowser } = await import(
+		"../wizards/mcp/oauth"
+	);
+	await authorizeMcpServerOAuthWithBrowser(candidate.name);
+}
+
+async function runPluginMcpOAuthFollowup(
+	candidates: PluginMcpOAuthCandidate[],
+	options: PluginInstallOptions & { json?: boolean },
+): Promise<void> {
+	if (candidates.length === 0 || options.json === true) {
+		return;
+	}
+
+	if (!isInteractivePluginInstall(options)) {
+		options.io?.writeln("Plugin MCP servers may require OAuth authorization:");
+		for (const candidate of candidates) {
+			options.io?.writeln(
+				`  ${candidate.name} (${candidate.transportType}, plugin: ${candidate.pluginName})`,
+			);
+		}
+		options.io?.writeln(
+			'Run "cline mcp" and choose "Authorize OAuth" to authorize them.',
+		);
+		return;
+	}
+
+	const selected =
+		options.mcpOAuth?.selectCandidates !== undefined
+			? await options.mcpOAuth.selectCandidates(candidates)
+			: await selectMcpOAuthCandidatesWithClack(candidates);
+	const authorize = options.mcpOAuth?.authorize ?? authorizeMcpOAuthCandidate;
+	for (const candidate of selected) {
+		try {
+			await authorize(candidate);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			options.io?.writeErr(
+				`Warning: failed to authorize MCP server ${candidate.name}: ${message}`,
+			);
+		}
 	}
 }
 
@@ -1102,7 +1315,9 @@ export async function runPluginInstallCommand(
 	try {
 		const result = await installPlugin(options);
 		if (options.json) {
-			process.stdout.write(JSON.stringify(result));
+			process.stdout.write(
+				JSON.stringify(serializePluginInstallResult(result)),
+			);
 			return 0;
 		}
 		options.io?.writeln(`Installed plugin from ${result.source}`);
@@ -1112,6 +1327,7 @@ export async function runPluginInstallCommand(
 				`Warning: failed to sync plugin MCP servers for ${failure.pluginName ?? failure.pluginPath}: ${failure.message}`,
 			);
 		}
+		await runPluginMcpOAuthFollowup(result.mcpOAuthCandidates, options);
 		return 0;
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);

--- a/apps/cli/src/wizards/mcp/index.ts
+++ b/apps/cli/src/wizards/mcp/index.ts
@@ -1,6 +1,5 @@
 import * as p from "@clack/prompts";
-import { authorizeMcpServerOAuth } from "@cline/core";
-import open from "open";
+import { authorizeMcpServerOAuthWithBrowser as authorizeOAuth } from "./oauth";
 import {
 	addServer,
 	clearServerOAuth,
@@ -15,16 +14,6 @@ import {
 
 function isCancel(value: unknown): value is symbol {
 	return p.isCancel(value);
-}
-
-function toErrorMessage(error: unknown): string {
-	if (error instanceof Error) {
-		const message = error.message.trim();
-		if (message.length > 0) {
-			return message;
-		}
-	}
-	return String(error);
 }
 
 function transportLabel(t: McpTransport): string {
@@ -220,29 +209,6 @@ async function collectUrlTransport(
 		transport: { type, url: (url as string).trim(), headers },
 		authMode,
 	};
-}
-
-async function authorizeOAuth(name: string): Promise<void> {
-	p.log.info("Opening browser for MCP OAuth authorization");
-	try {
-		const result = await authorizeMcpServerOAuth({
-			serverName: name,
-			filePath: getSettingsPath(),
-			openUrl: async (url) => {
-				p.log.message(`Authorization URL: ${url}`);
-				await open(url, { wait: false });
-			},
-			onServerListening: (info) => {
-				p.log.message(`Waiting for OAuth callback at ${info.callbackUrl}`);
-			},
-		});
-		p.log.success(result.message);
-	} catch (error) {
-		p.log.error(`OAuth authorization failed: ${toErrorMessage(error)}`);
-		p.log.warn(
-			`Server "${name}" is still saved. Choose "Authorize OAuth" to retry.`,
-		);
-	}
 }
 
 async function actionAdd(): Promise<void> {

--- a/apps/cli/src/wizards/mcp/oauth.ts
+++ b/apps/cli/src/wizards/mcp/oauth.ts
@@ -1,0 +1,41 @@
+import * as p from "@clack/prompts";
+import {
+	authorizeMcpServerOAuth,
+	resolveDefaultMcpSettingsPath,
+} from "@cline/core";
+import open from "open";
+
+function toErrorMessage(error: unknown): string {
+	if (error instanceof Error) {
+		const message = error.message.trim();
+		if (message.length > 0) {
+			return message;
+		}
+	}
+	return String(error);
+}
+
+export async function authorizeMcpServerOAuthWithBrowser(
+	name: string,
+): Promise<void> {
+	p.log.info("Opening browser for MCP OAuth authorization");
+	try {
+		const result = await authorizeMcpServerOAuth({
+			serverName: name,
+			filePath: resolveDefaultMcpSettingsPath(),
+			openUrl: async (url) => {
+				p.log.message(`Authorization URL: ${url}`);
+				await open(url, { wait: false });
+			},
+			onServerListening: (info) => {
+				p.log.message(`Waiting for OAuth callback at ${info.callbackUrl}`);
+			},
+		});
+		p.log.success(result.message);
+	} catch (error) {
+		p.log.error(`OAuth authorization failed: ${toErrorMessage(error)}`);
+		p.log.warn(
+			`Server "${name}" is still saved. Choose "Authorize OAuth" to retry.`,
+		);
+	}
+}


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This PR adds the missing OAuth follow-up for MCP servers installed through CLI plugins.

The previous MCP plugin support synced plugin-owned MCP server registrations into the user's MCP settings, but remote HTTP/SSE MCPs that require OAuth still needed the user to know to run the MCP wizard separately and authorize them. That made plugin install feel incomplete compared with manually adding MCP servers through the CLI MCP wizard, where OAuth is part of the setup flow.

The CLI now infers plugin MCP OAuth candidates after plugin install sync completes. A candidate is a plugin-owned `sse` or `streamableHttp` server that does not use static headers and does not already have an OAuth access token saved. In a real interactive terminal, `cline plugin install <source>` offers a Clack follow-up to authorize all candidates, choose specific servers, or skip. Authorization reuses the same browser/callback helper as the MCP wizard, so tokens are saved in the existing MCP settings OAuth state.

Scripted installs remain safe. `--json` keeps the previous machine-readable output shape and never prompts or opens a browser. Non-TTY text installs do not launch OAuth either; they print concise guidance listing the candidate server names and point users to `cline mcp` -> `Authorize OAuth`.

The implementation deliberately keeps this scoped to `apps/cli`. It does not add a new plugin API field or change SDK/core plugin MCP sync behavior. The MCP wizard's browser OAuth wrapper was extracted into a shared CLI helper so both the MCP wizard and plugin install follow-up use the same authorization path.

### Test Procedure

I tested the focused plugin install path and CLI type safety locally:

```sh
bun -F @cline/cli test:unit -- src/commands/plugin.test.ts
bun -F @cline/cli typecheck
bun biome check --diagnostic-level=error apps/cli/src/commands/plugin.ts apps/cli/src/commands/plugin.test.ts apps/cli/src/wizards/mcp/index.ts apps/cli/src/wizards/mcp/oauth.ts
```

The new unit coverage exercises the important branches:

- Remote plugin-owned `streamableHttp` MCPs without headers become OAuth candidates.
- Remote MCPs with static headers are excluded because auth is already represented by headers.
- Servers with existing OAuth access tokens are skipped so reinstall/update does not prompt again.
- Interactive plugin installs call the OAuth follow-up for selected candidates.
- OAuth authorization failure warns but does not make plugin installation fail.
- Non-TTY installs print guidance and do not run OAuth.
- `--json` installs stay valid JSON, do not run OAuth, and do not expose the internal candidate list in the command output.

The commit hook also ran the repo's staged type and Biome checks during commit.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not included. This is a CLI prompt flow and settings/OAuth behavior change covered by unit tests rather than a persistent UI surface.

### Additional Notes

A few non-obvious decisions are worth calling out for review:

- OAuth is inferred rather than declared by a new plugin API field. The current plugin MCP API only exposes transport plus optional headers; for this PR, a remote plugin-owned server with no static headers and no saved OAuth token is treated as likely needing interactive OAuth.
- The install itself is never blocked on OAuth. Failed or skipped authorization leaves the plugin and MCP settings in place, and users can retry through the existing `cline mcp` wizard.
- The JSON command output intentionally omits `mcpOAuthCandidates` even though `installPlugin()` returns that internal metadata for command handling. This avoids surprising automation that consumes `cline plugin install --json`.
