### PR TITLE
fix: gate OpenRouter/Vercel AI Gateway prompt-cache markers by supportsPromptCache

### DIFF
--- a/apps/vscode/src/core/api/transform/__tests__/openrouter-stream.test.ts
+++ b/apps/vscode/src/core/api/transform/__tests__/openrouter-stream.test.ts
@@ -23,11 +23,11 @@ describe("createOpenRouterStream", () => {
 		}
 	}
 
-	const createModelInfo = (maxTokens: number): ModelInfo => ({
+	const createModelInfo = (maxTokens: number, supportsPromptCache = false): ModelInfo => ({
 		maxTokens,
 		contextWindow: 1_048_576,
 		supportsImages: true,
-		supportsPromptCache: false,
+		supportsPromptCache,
 	})
 
 	it("caps Gemini Flash OpenRouter requests to 8192 max_tokens", async () => {
@@ -91,6 +91,31 @@ describe("createOpenRouterStream", () => {
 			payload.messages[0].content[0].cache_control.should.deepEqual({ type: "ephemeral" })
 			payload.messages[1].content[0].cache_control.should.deepEqual({ type: "ephemeral" })
 		}
+	})
+
+	it("adds cache_control blocks when the model reports supportsPromptCache, regardless of id", async () => {
+		const { client, create } = createClient()
+
+		await createOpenRouterStream(client as any, "system prompt", [{ role: "user", content: "hello" }] as any, {
+			id: "deepseek/deepseek-chat",
+			info: createModelInfo(65_536, true),
+		})
+
+		const payload = create.firstCall.args[0] as any
+		payload.messages[0].content[0].cache_control.should.deepEqual({ type: "ephemeral" })
+		payload.messages[1].content[0].cache_control.should.deepEqual({ type: "ephemeral" })
+	})
+
+	it("does not add cache_control blocks for models without prompt cache support", async () => {
+		const { client, create } = createClient()
+
+		await createOpenRouterStream(client as any, "system prompt", [{ role: "user", content: "hello" }] as any, {
+			id: "google/gemini-2.5-pro",
+			info: createModelInfo(65_536, false),
+		})
+
+		const payload = create.firstCall.args[0] as any
+		payload.messages[0].content.should.be.a.String()
 	})
 
 	it("uses adaptive reasoning with verbosity for Claude Opus adaptive models", async () => {

--- a/apps/vscode/src/core/api/transform/__tests__/vercel-ai-gateway-stream.test.ts
+++ b/apps/vscode/src/core/api/transform/__tests__/vercel-ai-gateway-stream.test.ts
@@ -56,6 +56,19 @@ describe("createVercelAIGatewayStream", () => {
 		payload.messages[1].content[0].cache_control.should.deepEqual({ type: "ephemeral" })
 	})
 
+	it("adds cache_control blocks for Anthropic models even when the flag is unset", async () => {
+		// Guards against registry pricing data being missing or stale for an Anthropic model.
+		const { client, create } = createClient()
+
+		await createVercelAIGatewayStream(client as any, "system prompt", [{ role: "user", content: "hello" }] as any, {
+			id: "anthropic/claude-sonnet-4.5",
+			info: createModelInfo(false),
+		})
+
+		const payload = create.firstCall.args[0] as any
+		payload.messages[0].content[0].cache_control.should.deepEqual({ type: "ephemeral" })
+	})
+
 	it("adds cache_control blocks for MiniMax models even without the flag", async () => {
 		const { client, create } = createClient()
 

--- a/apps/vscode/src/core/api/transform/__tests__/vercel-ai-gateway-stream.test.ts
+++ b/apps/vscode/src/core/api/transform/__tests__/vercel-ai-gateway-stream.test.ts
@@ -1,0 +1,82 @@
+import { describe, it } from "mocha"
+import "should"
+import type { ModelInfo } from "@shared/api"
+import sinon from "sinon"
+import { createVercelAIGatewayStream } from "../vercel-ai-gateway-stream"
+
+describe("createVercelAIGatewayStream", () => {
+	const createAsyncIterable = () => ({
+		async *[Symbol.asyncIterator]() {},
+	})
+
+	const createClient = () => {
+		const create = sinon.stub().resolves(createAsyncIterable())
+		return {
+			client: {
+				chat: {
+					completions: {
+						create,
+					},
+				},
+			},
+			create,
+		}
+	}
+
+	const createModelInfo = (supportsPromptCache: boolean): ModelInfo => ({
+		maxTokens: 8_192,
+		contextWindow: 200_000,
+		supportsImages: true,
+		supportsPromptCache,
+	})
+
+	it("adds cache_control blocks when the model reports supportsPromptCache", async () => {
+		const { client, create } = createClient()
+
+		await createVercelAIGatewayStream(client as any, "system prompt", [{ role: "user", content: "hello" }] as any, {
+			id: "anthropic/claude-sonnet-4.5",
+			info: createModelInfo(true),
+		})
+
+		const payload = create.firstCall.args[0] as any
+		payload.messages[0].content[0].cache_control.should.deepEqual({ type: "ephemeral" })
+		payload.messages[1].content[0].cache_control.should.deepEqual({ type: "ephemeral" })
+	})
+
+	it("adds cache_control blocks for non-anthropic cache-capable models", async () => {
+		const { client, create } = createClient()
+
+		await createVercelAIGatewayStream(client as any, "system prompt", [{ role: "user", content: "hello" }] as any, {
+			id: "zai/glm-4.6",
+			info: createModelInfo(true),
+		})
+
+		const payload = create.firstCall.args[0] as any
+		payload.messages[0].content[0].cache_control.should.deepEqual({ type: "ephemeral" })
+		payload.messages[1].content[0].cache_control.should.deepEqual({ type: "ephemeral" })
+	})
+
+	it("adds cache_control blocks for MiniMax models even without the flag", async () => {
+		const { client, create } = createClient()
+
+		await createVercelAIGatewayStream(client as any, "system prompt", [{ role: "user", content: "hello" }] as any, {
+			id: "minimax/minimax-m2",
+			info: createModelInfo(false),
+		})
+
+		const payload = create.firstCall.args[0] as any
+		payload.messages[0].content[0].cache_control.should.deepEqual({ type: "ephemeral" })
+	})
+
+	it("does not add cache_control blocks for models without prompt cache support", async () => {
+		const { client, create } = createClient()
+
+		await createVercelAIGatewayStream(client as any, "system prompt", [{ role: "user", content: "hello" }] as any, {
+			id: "openai/gpt-4o",
+			info: createModelInfo(false),
+		})
+
+		const payload = create.firstCall.args[0] as any
+		payload.messages[0].content.should.be.a.String()
+	})
+})

--- a/apps/vscode/src/core/api/transform/openrouter-stream.ts
+++ b/apps/vscode/src/core/api/transform/openrouter-stream.ts
@@ -35,9 +35,16 @@ const openRouterExplicitCacheControlModelIds = new Set([
 	"qwen/qwen3-coder-flash",
 ])
 
-function needsExplicitCacheControl(modelId: string): boolean {
+function needsExplicitCacheControl(model: { id: string; info: ModelInfo }): boolean {
+	// Honor the capability flag the model registry computes (refreshOpenRouterModels.ts),
+	// so newly cache-capable models don't silently miss caching just because they're absent
+	// from the hardcoded id list below. The id checks remain as a fallback for envelope-honoring
+	// families (Anthropic/MiniMax shapes) and ids that aren't flagged in the registry yet.
 	return (
-		modelId.startsWith("anthropic/") || modelId.startsWith("minimax/") || openRouterExplicitCacheControlModelIds.has(modelId)
+		model.info.supportsPromptCache ||
+		model.id.startsWith("anthropic/") ||
+		model.id.startsWith("minimax/") ||
+		openRouterExplicitCacheControlModelIds.has(model.id)
 	)
 }
 
@@ -77,7 +84,7 @@ export async function createOpenRouterStream(
 	// prompt caching: https://openrouter.ai/docs/prompt-caching
 	// Some OpenRouter models require cache_control blocks instead of automatic provider caching.
 	// Other providers (OpenAI, Google) handle caching automatically without cache_control blocks.
-	const needsCacheControl = needsExplicitCacheControl(model.id)
+	const needsCacheControl = needsExplicitCacheControl(model)
 
 	if (needsCacheControl) {
 		openAiMessages[0] = {

--- a/apps/vscode/src/core/api/transform/vercel-ai-gateway-stream.ts
+++ b/apps/vscode/src/core/api/transform/vercel-ai-gateway-stream.ts
@@ -50,12 +50,15 @@ export async function createVercelAIGatewayStream(
 	// Sanitize messages for Gemini models (removes tool_calls without reasoning_details)
 	openAiMessages = sanitizeGeminiMessages(openAiMessages, model.id)
 
-	// Prompt caching for supported models
-	// This handles cache_control for Claude and MiniMax models
-	const isAnthropicModel = model.id.startsWith("anthropic/")
+	// Prompt caching for supported models.
+	// Gate on the capability flag the model registry computes from pricing
+	// (refreshVercelAiGatewayModels.ts sets supportsPromptCache when the Gateway
+	// reports cache read/write pricing), so any cache-capable model gets cache_control
+	// rather than only ids that start with "anthropic/". Keep the MiniMax id check as a
+	// fallback for envelope-honoring shapes that may not be flagged by pricing.
 	const isMinimaxModel = model.id.startsWith("minimax/")
 
-	if (isAnthropicModel || isMinimaxModel) {
+	if (model.info.supportsPromptCache || isMinimaxModel) {
 		openAiMessages[0] = {
 			role: "system",
 			content: [

--- a/apps/vscode/src/core/api/transform/vercel-ai-gateway-stream.ts
+++ b/apps/vscode/src/core/api/transform/vercel-ai-gateway-stream.ts
@@ -54,11 +54,13 @@ export async function createVercelAIGatewayStream(
 	// Gate on the capability flag the model registry computes from pricing
 	// (refreshVercelAiGatewayModels.ts sets supportsPromptCache when the Gateway
 	// reports cache read/write pricing), so any cache-capable model gets cache_control
-	// rather than only ids that start with "anthropic/". Keep the MiniMax id check as a
-	// fallback for envelope-honoring shapes that may not be flagged by pricing.
+	// rather than only ids that start with "anthropic/". Keep the Anthropic/MiniMax id
+	// checks as a fallback for envelope-honoring families whose pricing data may be
+	// missing or stale in the registry (e.g. a new Anthropic model before pricing lands).
+	const isAnthropicModel = model.id.startsWith("anthropic/")
 	const isMinimaxModel = model.id.startsWith("minimax/")
 
-	if (model.info.supportsPromptCache || isMinimaxModel) {
+	if (model.info.supportsPromptCache || isAnthropicModel || isMinimaxModel) {
 		openAiMessages[0] = {
 			role: "system",
 			content: [


### PR DESCRIPTION
### Related Issue

No existing issue — submitting directly as a small bug fix per the contributing guidelines.

### Description

Two OpenRouter/Gateway streaming transforms decide whether to attach `cache_control` markers using hardcoded model-id matching instead of the `supportsPromptCache` capability flag the model registries already compute. As a result, models that the registry knows are cache-capable silently skip prompt caching, so every request pays full input price with no cache reads.

**1. OpenRouter — `apps/vscode/src/core/api/transform/openrouter-stream.ts:38`**

`needsExplicitCacheControl()` gated on `model.id.startsWith("anthropic/") || model.id.startsWith("minimax/") || openRouterExplicitCacheControlModelIds.has(model.id)`, ignoring `model.info.supportsPromptCache`. The registry in `refreshOpenRouterModels.ts` sets `supportsPromptCache: true` for a much broader set (e.g. `deepseek/deepseek-chat`, `x-ai/grok-3-beta`, the Claude `:beta` variants), so those models were never sent `cache_control` even though they support it.

**2. Vercel AI Gateway — `apps/vscode/src/core/api/transform/vercel-ai-gateway-stream.ts:55`**

Caching was gated on `model.id.startsWith("anthropic/")`, while `refreshVercelAiGatewayModels.ts:142` computes the capability dynamically from pricing:

```ts
supportsPromptCache: !!(rawModel.pricing?.input_cache_read && rawModel.pricing?.input_cache_write)
```

Any non-Anthropic model the Gateway prices with cache read/write therefore gets `supportsPromptCache: true` from the registry but never receives `cache_control` from the transform.

**Fix**

Gate the `cache_control` envelope on `model.info.supportsPromptCache` (the same flag the registries set), and keep the existing id checks as a fallback for envelope-honoring families (Anthropic/MiniMax shapes) so behavior for models not yet flagged in the registry is unchanged. The diff is intentionally minimal.

### Test Procedure

Extended `apps/vscode/src/core/api/transform/__tests__/openrouter-stream.test.ts` and added `apps/vscode/src/core/api/transform/__tests__/vercel-ai-gateway-stream.test.ts`:

- a cache-capable non-Anthropic id (`deepseek/deepseek-chat`, `zai/glm-4.6`) with `supportsPromptCache: true` now emits `cache_control` on the system block and the last user message;
- a model with `supportsPromptCache: false` (`google/gemini-2.5-pro`, `openai/gpt-4o`) does not;
- the existing MiniMax/Qwen/Anthropic paths still behave as before.

Verified locally on Node 22:

- `mocha` (targeted unit tests): 12 passing, no regressions in the existing cases
- `tsc --noEmit` (check-types): clean
- `biome lint` on the touched files: clean

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing and code is formatted and linted
-   [x] I have reviewed contributor guidelines

### Additional Notes

The same bug exists verbatim in downstream forks of this codebase; sourcing the gate from the capability flag the registries already maintain fixes it everywhere the registry is the source of truth, without a second id list to keep in sync.
