### PR TITLE
fix(vscode): avoid MCP settings lock deadlock

### DIFF
--- a/apps/vscode/src/services/mcp/__tests__/settingsLock.test.ts
+++ b/apps/vscode/src/services/mcp/__tests__/settingsLock.test.ts
@@ -1,0 +1,41 @@
+import { existsSync } from "node:fs"
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { updateMcpSettingsFile } from "../settingsLock"
+
+describe("updateMcpSettingsFile", () => {
+	let tempDir: string
+	let settingsPath: string
+
+	beforeEach(async () => {
+		tempDir = path.join(os.tmpdir(), `mcp-settings-lock-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+		await fs.mkdir(tempDir, { recursive: true })
+		settingsPath = path.join(tempDir, "cline_mcp_settings.json")
+		await fs.writeFile(settingsPath, JSON.stringify({ mcpServers: {} }, null, 2))
+	})
+
+	afterEach(async () => {
+		await fs.rm(tempDir, { recursive: true, force: true })
+	})
+
+	it("does not yield while holding the settings lock", async () => {
+		let mutatorRan = false
+
+		const update = updateMcpSettingsFile(settingsPath, (settings) => {
+			mutatorRan = true
+			settings.mcpServers = {
+				alpha: {
+					type: "stdio",
+					command: "node",
+				},
+			}
+			return "updated"
+		})
+
+		expect(mutatorRan).toBe(true)
+		expect(existsSync(`${settingsPath}.lock`)).toBe(false)
+		await expect(update).resolves.toBe("updated")
+	})
+})

--- a/apps/vscode/src/services/mcp/settingsLock.ts
+++ b/apps/vscode/src/services/mcp/settingsLock.ts
@@ -1,7 +1,17 @@
 import { setTimeout as delay } from "node:timers/promises"
 import { randomUUID } from "node:crypto"
-import * as fs from "fs/promises"
-import * as path from "path"
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	renameSync,
+	rmdirSync,
+	rmSync,
+	statSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs"
+import * as path from "node:path"
 import { Logger } from "@/shared/services/Logger"
 
 const SETTINGS_LOCK_STALE_MS = 10_000
@@ -47,14 +57,18 @@ interface AcquiredSettingsLock {
 	ownerFile: string
 }
 
-async function atomicWriteSettingsFile(settingsPath: string, contents: string): Promise<void> {
+function atomicWriteSettingsFile(settingsPath: string, contents: string): void {
 	const tempPath = `${settingsPath}.tmp.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}`
-	await fs.mkdir(path.dirname(settingsPath), { recursive: true })
+	mkdirSync(path.dirname(settingsPath), { recursive: true })
 	try {
-		await fs.writeFile(tempPath, contents, { encoding: "utf-8", flag: "wx" })
-		await fs.rename(tempPath, settingsPath)
+		writeFileSync(tempPath, contents, { encoding: "utf-8", flag: "wx" })
+		renameSync(tempPath, settingsPath)
 	} catch (error) {
-		await fs.unlink(tempPath).catch(() => {})
+		try {
+			unlinkSync(tempPath)
+		} catch {
+			// Best-effort cleanup of the temp file.
+		}
 		throw error
 	}
 }
@@ -70,32 +84,30 @@ async function atomicWriteSettingsFile(settingsPath: string, contents: string): 
  * operations and avoids inode- or handle-based deletion, so it works with
  * Node's portable fs APIs on Windows and POSIX.
  */
-async function tryAcquireSettingsLock(lockDir: string, token: string): Promise<AcquiredSettingsLock | undefined> {
-	await fs.mkdir(path.dirname(lockDir), { recursive: true })
+function tryAcquireSettingsLock(lockDir: string, token: string): AcquiredSettingsLock | undefined {
+	mkdirSync(path.dirname(lockDir), { recursive: true })
 	const stagingDir = `${lockDir}.tmp.${token}`
-	await fs.rm(stagingDir, { recursive: true, force: true })
-	await fs.mkdir(stagingDir, { recursive: true })
+	rmSync(stagingDir, { recursive: true, force: true })
+	mkdirSync(stagingDir, { recursive: true })
 	const ownerFileName = `owner.${token}`
 	const stagingOwnerFile = path.join(stagingDir, ownerFileName)
-	await fs.writeFile(stagingOwnerFile, token, { encoding: "utf8", flag: "wx" })
+	writeFileSync(stagingOwnerFile, token, { encoding: "utf8", flag: "wx" })
 	try {
-		await fs.rename(stagingDir, lockDir)
+		renameSync(stagingDir, lockDir)
 		return { lockDir, ownerFile: path.join(lockDir, ownerFileName) }
 	} catch (error) {
-		await fs.rm(stagingDir, { recursive: true, force: true })
-		try {
-			await fs.access(lockDir)
+		rmSync(stagingDir, { recursive: true, force: true })
+		if (existsSync(lockDir)) {
 			return undefined
-		} catch {
-			throw error
 		}
+		throw error
 	}
 }
 
-async function reclaimStaleLock(lockDir: string): Promise<void> {
+function reclaimStaleLock(lockDir: string): void {
 	let ageMs: number
 	try {
-		ageMs = Date.now() - (await fs.stat(lockDir)).mtimeMs
+		ageMs = Date.now() - statSync(lockDir).mtimeMs
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException).code === "ENOENT") {
 			return
@@ -108,28 +120,32 @@ async function reclaimStaleLock(lockDir: string): Promise<void> {
 	Logger.warn(`[mcp-settings] Stale lock directory at ${lockDir} (age ${ageMs}ms); reclaiming.`)
 	const staleDir = `${lockDir}.stale.${makeLockToken()}`
 	try {
-		await fs.rename(lockDir, staleDir)
+		renameSync(lockDir, staleDir)
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException).code === "ENOENT") {
 			return
 		}
 		throw error
 	}
-	await fs.rm(staleDir, { recursive: true, force: true })
+	rmSync(staleDir, { recursive: true, force: true })
 }
 
-async function releaseSettingsLock(lock: AcquiredSettingsLock): Promise<void> {
-	await fs.unlink(lock.ownerFile).catch((error) => {
+function releaseSettingsLock(lock: AcquiredSettingsLock): void {
+	try {
+		unlinkSync(lock.ownerFile)
+	} catch (error) {
 		if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
 			throw error
 		}
-	})
-	await fs.rmdir(lock.lockDir).catch((error) => {
+	}
+	try {
+		rmdirSync(lock.lockDir)
+	} catch (error) {
 		const code = (error as NodeJS.ErrnoException).code
 		if (code !== "ENOENT" && code !== "ENOTEMPTY" && code !== "EEXIST") {
 			throw error
 		}
-	})
+	}
 }
 
 function checkAbort(signal: AbortSignal | undefined, lockDir: string): void {
@@ -138,8 +154,8 @@ function checkAbort(signal: AbortSignal | undefined, lockDir: string): void {
 	}
 }
 
-async function readSettingsObject(settingsPath: string): Promise<Record<string, unknown>> {
-	const content = await fs.readFile(settingsPath, "utf-8")
+function readSettingsObject(settingsPath: string): Record<string, unknown> {
+	const content = readFileSync(settingsPath, "utf-8")
 	const settings = JSON.parse(content) as Record<string, unknown>
 	if (!settings.mcpServers || typeof settings.mcpServers !== "object" || Array.isArray(settings.mcpServers)) {
 		settings.mcpServers = {}
@@ -171,6 +187,12 @@ function runPureSettingsMutator<T>(settings: Record<string, unknown>, mutator: M
  * Locked MCP settings read-update-write. The mutator is synchronous and may be
  * called more than once to validate purity/determinism. Do not perform slow work
  * or side effects inside it; compute values before calling and close over them.
+ *
+ * Waiting for another process to release the lock is async, but once this
+ * process owns the lock, the critical section uses synchronous filesystem calls.
+ * @cline/core OAuth writes use a synchronous lock in the same extension host;
+ * yielding here while holding the lock would let that sync waiter block the
+ * event loop before this holder can resume and release it.
  */
 export async function updateMcpSettingsFile<T>(
 	settingsPath: string,
@@ -180,18 +202,18 @@ export async function updateMcpSettingsFile<T>(
 	const lockDir = settingsLockDir(settingsPath)
 	const token = makeLockToken()
 	let lock: AcquiredSettingsLock | undefined
-	while (!(lock = await tryAcquireSettingsLock(lockDir, token))) {
+	while (!(lock = tryAcquireSettingsLock(lockDir, token))) {
 		checkAbort(options.abortSignal, lockDir)
-		await reclaimStaleLock(lockDir)
+		reclaimStaleLock(lockDir)
 		await delay(SETTINGS_LOCK_POLL_MS)
 	}
 	try {
 		checkAbort(options.abortSignal, lockDir)
-		const settings = await readSettingsObject(settingsPath)
+		const settings = readSettingsObject(settingsPath)
 		const result = runPureSettingsMutator(settings, mutator)
-		await atomicWriteSettingsFile(settingsPath, `${JSON.stringify(settings, null, 2)}\n`)
+		atomicWriteSettingsFile(settingsPath, `${JSON.stringify(settings, null, 2)}\n`)
 		return result
 	} finally {
-		await releaseSettingsLock(lock)
+		releaseSettingsLock(lock)
 	}
 }

--- a/apps/vscode/vitest.config.ts
+++ b/apps/vscode/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
 			"src/shared/vsCodeSelectorUtils.test.ts",
 			"src/core/storage/__tests__/**/*.test.ts",
 			"src/core/storage/remote-config/**/*.test.ts",
+			"src/services/mcp/__tests__/settingsLock.test.ts",
 			"src/shared/model-catalog/provider-helpers.test.ts",
 			"src/core/controller/models/__tests__/providerCatalogHandlers.test.ts",
 			"src/core/controller/models/__tests__/providerSwitchNormalization.test.ts",


### PR DESCRIPTION
### Related Issue

**Issue:** #11529

### Description

This is a small follow-up to #11529. The PR now serializes MCP settings read-modify-writes with a cross-process lock, but the VS Code-side helper and the SDK-side OAuth helper were using two different waiting modes for the same lock inside the extension host:

- `apps/vscode/src/services/mcp/settingsLock.ts` held the lock across awaited filesystem operations.
- `@cline/core` OAuth writes use a synchronous lock and wait with `Atomics.wait`.

That combination can deadlock within one extension process: if a sync OAuth write starts while the async VS Code helper owns the lock but is awaiting filesystem I/O, the sync waiter blocks the event loop before the async holder can resume and release. After the stale timeout, the sync path can reclaim the still-live lock and write, and the async holder can later resume and write from its older snapshot.

The fix keeps lock contention polling async while no lock is held, but once VS Code owns the lock it performs the read/mutate/write/release critical section synchronously. That preserves the existing async public API while removing the event-loop yield that made the mixed async/sync lock unsafe.

A regression test asserts that `updateMcpSettingsFile()` does not yield while it owns an uncontended lock and that the lock directory is released before the returned promise is observed asynchronously.

### Test Procedure

Ran focused checks locally:

```bash
# Whitespace
git diff --check origin/dpc/sdk-migration-simpler-login...HEAD

# SDK lock/OAuth coverage
cd sdk/packages/core
npx vitest run src/extensions/mcp/config-loader.test.ts src/auth/server.test.ts src/extensions/mcp/oauth.test.ts

# VS Code focused coverage
cd apps/vscode
npx vitest run --config vitest.config.ts src/services/mcp/__tests__/settingsLock.test.ts src/sdk/sdk-mcp-coordinator.test.ts
```

All focused checks passed.

I also tried the full `apps/vscode` Vitest config, but this sandbox cannot run it because multiple local dependencies are unavailable in the workspace (`@cline/llms`, `@bufbuild/protobuf/wire`, `mocha`, `chai`, `should`, `node-machine-id`, etc.). The failure occurs broadly during module resolution and is not specific to this patch.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. No UI changes.

### Additional Notes

This is intended to be merged into `mcp-oauth` before #11529 lands, not into the long-lived base branch directly.
