### PR TITLE
fix(llms): avoid disabled reasoning for StepFun flash

### DIFF
--- a/sdk/packages/llms/src/providers/routing/anthropic-compatible.ts
+++ b/sdk/packages/llms/src/providers/routing/anthropic-compatible.ts
@@ -583,10 +583,10 @@ export function buildGatewayReasoningOptions(
 			: request.reasoning?.budgetTokens;
 	const shouldSendDisabledReasoning =
 		request.reasoning?.enabled === false &&
-		// FIXME: temporary OpenRouter compatibility patch for Claude Fable.
-		// Remove once OpenRouter normalizes disabled reasoning like Vercel does,
-		// or replace with a systematic policy for models that reject it.
-		!request.modelId.toLowerCase().includes("claude-fable");
+		// FIXME: temporary compatibility patch for models that reject disabled
+		// reasoning. Remove once routed providers normalize disabled reasoning
+		// consistently, or replace with a systematic model policy.
+		!modelRejectsDisabledReasoning(request.modelId);
 	const reasoning: Record<string, unknown> = {
 		...(request.reasoning?.enabled === true
 			? { enabled: true }
@@ -605,4 +605,12 @@ export function buildGatewayReasoningOptions(
 	}
 
 	return Object.keys(reasoning).length > 0 ? reasoning : undefined;
+}
+
+function modelRejectsDisabledReasoning(modelId: string): boolean {
+	const normalized = modelId.toLowerCase();
+	return (
+		normalized.includes("claude-fable") ||
+		normalized === "stepfun/step-3.7-flash"
+	);
 }

--- a/sdk/packages/llms/src/providers/routing/anthropic-compatible.ts
+++ b/sdk/packages/llms/src/providers/routing/anthropic-compatible.ts
@@ -611,6 +611,6 @@ function modelRejectsDisabledReasoning(modelId: string): boolean {
 	const normalized = modelId.toLowerCase();
 	return (
 		normalized.includes("claude-fable") ||
-		normalized === "stepfun/step-3.7-flash"
+		normalized.includes("stepfun/step-3.7-flash")
 	);
 }

--- a/sdk/packages/llms/src/providers/routing/provider-options.test.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-options.test.ts
@@ -1133,6 +1133,20 @@ describe("composeAiSdkProviderOptions: family/provider thinking patches", () => 
 				},
 			],
 		},
+		{
+			name: "cline StepFun 3.7 Flash variants reasoning.enabled=false omit disabled reasoning",
+			request: {
+				providerId: "cline",
+				modelId: "stepfun/step-3.7-flash-v2",
+				reasoning: { enabled: false },
+			},
+			expect: [
+				{
+					bucket: "cline",
+					lacks: ["reasoning", "thinking"],
+				},
+			],
+		},
 		// OpenRouter owns the reasoning object regardless of Moonshot family.
 		{
 			name: "openrouter non-K2.6 Moonshot Kimi reasoning.enabled=false -> reasoning.exclude",

--- a/sdk/packages/llms/src/providers/routing/provider-options.test.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-options.test.ts
@@ -1115,6 +1115,24 @@ describe("composeAiSdkProviderOptions: family/provider thinking patches", () => 
 				},
 			],
 		},
+		{
+			name: "cline StepFun 3.7 Flash reasoning.enabled=false omits disabled reasoning",
+			request: {
+				providerId: "cline",
+				modelId: "stepfun/step-3.7-flash",
+				reasoning: { enabled: false },
+			},
+			expect: [
+				{
+					bucket: "cline",
+					lacks: ["reasoning", "thinking"],
+				},
+				{
+					bucket: "openaiCompatible",
+					lacks: ["reasoning", "thinking"],
+				},
+			],
+		},
 		// OpenRouter owns the reasoning object regardless of Moonshot family.
 		{
 			name: "openrouter non-K2.6 Moonshot Kimi reasoning.enabled=false -> reasoning.exclude",


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

`stepfun/step-3.7-flash` errors when routed requests explicitly disable reasoning. We already have a temporary provider-options workaround for models that reject disabled reasoning controls, originally added for Claude Fable. This PR adds StepFun 3.7 Flash to that same narrow path.

For StepFun 3.7 Flash model IDs, when the request has:

```ts
reasoning: { enabled: false }
```

Cline now omits disabled reasoning from the generated provider options instead of sending:

```ts
reasoning: { enabled: false }
```

The StepFun guard uses a substring match for `stepfun/step-3.7-flash`, mirroring the existing Claude Fable compatibility style. That keeps future StepFun 3.7 Flash variants, such as suffixed versions, on the same safe path instead of silently falling through to disabled reasoning.

This keeps the change scoped to the provider routing layer and avoids broad CLI defaults or catalog-wide behavior changes.

### Test Procedure

Added provider-options routing tests that verify disabled reasoning is omitted for:

- `stepfun/step-3.7-flash`
- a suffixed StepFun 3.7 Flash variant

Commands run:

```sh
bun -F @cline/llms test src/providers/routing/provider-options.test.ts
bun -F @cline/llms typecheck
```

Both passed.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. Provider routing behavior only.

### Additional Notes

This follows the existing temporary compatibility approach for models that reject disabled reasoning. It can be replaced later by a systematic model policy if more models need the same treatment.
