### PR TITLE
Add shared APP_BASE_URL constant for the Cline web app URL

### DIFF
--- a/apps/vscode/webview-ui/src/components/account/AccountView.tsx
+++ b/apps/vscode/webview-ui/src/components/account/AccountView.tsx
@@ -7,6 +7,7 @@ import deepEqual from "fast-deep-equal"
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useInterval } from "react-use"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import { APP_BASE_URL } from "@/constants"
 import { type ClineUser, handleSignOut } from "@/context/ClineAuthContext"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { AccountServiceClient } from "@/services/grpc-client"
@@ -229,7 +230,7 @@ export const ClineAccountView = ({ clineUser, userOrganizations, activeOrganizat
 		fetchCreditBalance(dropdownValue)
 	}, 60000)
 
-	const clineUrl = appBaseUrl || "https://app.cline.bot"
+	const clineUrl = appBaseUrl || APP_BASE_URL
 
 	// Fetch balance on mount
 	useEffect(() => {

--- a/apps/vscode/webview-ui/src/components/chat/CreditLimitError.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/CreditLimitError.tsx
@@ -2,6 +2,7 @@ import { AskResponseRequest } from "@shared/proto/cline/task"
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
 import React, { useEffect, useMemo, useState } from "react"
 import VSCodeButtonLink from "@/components/common/VSCodeButtonLink"
+import { APP_BASE_URL } from "@/constants"
 import { useClineAuth } from "@/context/ClineAuthContext"
 import { AccountServiceClient, TaskServiceClient } from "@/services/grpc-client"
 
@@ -14,8 +15,8 @@ interface CreditLimitErrorProps {
 }
 
 const DEFAULT_BUY_CREDITS_URL = {
-	USER: "https://app.cline.bot/dashboard/account?tab=credits&redirect=true",
-	ORG: "https://app.cline.bot/dashboard/organization?tab=credits&redirect=true",
+	USER: `${APP_BASE_URL}/dashboard/account?tab=credits&redirect=true`,
+	ORG: `${APP_BASE_URL}/dashboard/organization?tab=credits&redirect=true`,
 }
 
 const CreditLimitError: React.FC<CreditLimitErrorProps> = ({

--- a/apps/vscode/webview-ui/src/components/settings/sections/RemoteConfigSection.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/sections/RemoteConfigSection.tsx
@@ -2,6 +2,7 @@ import { EmptyRequest } from "@shared/proto/index.cline"
 import { VSCodeButton, VSCodeLink } from "@vscode/webview-ui-toolkit/react"
 import { useEffect, useRef, useState } from "react"
 import { RemoteConfigToggle } from "@/components/account/RemoteConfigToggle"
+import { APP_BASE_URL } from "@/constants"
 import { useClineAuth } from "@/context/ClineAuthContext"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { StateServiceClient } from "@/services/grpc-client"
@@ -290,7 +291,7 @@ export function RemoteConfigSection({ renderSectionHeader }: RemoteConfigSection
 				<div className="flex flex-col justify-center gap-4">
 					<h3>
 						You haven't configured remote config yet. Do so through our{" "}
-						<VSCodeLink href="https://app.cline.bot/dashboard/organization?tab=settings">dashboard</VSCodeLink>.
+						<VSCodeLink href={`${APP_BASE_URL}/dashboard/organization?tab=settings`}>dashboard</VSCodeLink>.
 					</h3>
 
 					<RefreshButton />

--- a/apps/vscode/webview-ui/src/constants.ts
+++ b/apps/vscode/webview-ui/src/constants.ts
@@ -4,3 +4,5 @@ export const LINKS = {
 		LOCAL_MCP_SERVER_DOCS: "https://docs.cline.bot/mcp/configuring-mcp-servers#editing-mcp-settings-files",
 	},
 }
+
+export const APP_BASE_URL = "https://app.cline.bot"


### PR DESCRIPTION
Replaces the duplicated `https://app.cline.bot` literal across the webview with a single `APP_BASE_URL` constant in `webview-ui/src/constants.ts`.

## Changes
- Add `APP_BASE_URL` to `webview-ui/src/constants.ts`
- Use it in `AccountView`, `CreditLimitError`, and `RemoteConfigSection`

These components still prefer the environment-aware `clineUser.appBaseUrl` when available and fall back to `APP_BASE_URL` (production). `ChatView` is intentionally left as-is since it compares `userInfo.apiBaseUrl` (a distinct value).

## Validation
- webview `tsc --noEmit`: pass
- Biome check: pass
- 4 files changed, +9/-4