### PR TITLE
feat(cli): add prefilled MCP install wizard command

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -163,6 +163,30 @@ cline auth --provider anthropic --apikey sk-... --modelid claude-sonnet-4-6
 cline auth --provider openai-native --apikey sk-... --modelid gpt-5 --baseurl https://api.example.com/v1
 ```
 
+### MCP servers
+
+Manage MCP servers with the interactive wizard:
+
+```sh
+cline mcp
+cline config mcp
+```
+
+Open the add-server wizard with the name, transport, and command or URL already filled in with `cline mcp install` (`cline mcp add` also works). Stdio servers use everything after `--` as the command and arguments:
+
+```sh
+cline mcp install fs -- npx -y @modelcontextprotocol/server-filesystem /tmp
+```
+
+Remote HTTP and SSE servers take a name, transport, and URL. The wizard still asks for auth details before saving:
+
+```sh
+cline mcp install ctx7 --transport http https://mcp.context7.com/mcp
+cline mcp install events --transport sse https://example.com/sse
+```
+
+Because this command opens the wizard, it requires a TTY.
+
 ### Connectors
 
 Bridge a chat surface into RPC-backed Cline sessions. Each conversation thread maps to a session with full context. Supported platforms: Telegram, Slack, Google Chat, WhatsApp, and Linear.

--- a/apps/cli/src/cli.e2e.test.ts
+++ b/apps/cli/src/cli.e2e.test.ts
@@ -746,6 +746,27 @@ Break work into clear steps.`,
 		).toBe(true);
 	});
 
+	it("routes mcp install and requires a TTY for the prefilled wizard", () => {
+		const result = runCli(
+			[
+				"mcp",
+				"install",
+				"fs",
+				"--",
+				"npx",
+				"-y",
+				"@modelcontextprotocol/server-filesystem",
+				"/tmp",
+			],
+			{ env: createIsolatedEnv() },
+		);
+
+		expect(result.status).toBe(1);
+		expect(asText(result.stderr)).toContain(
+			"cline mcp install opens the MCP wizard and requires a TTY.",
+		);
+	});
+
 	it("lists available tools", () => {
 		const homeDir = mkdtempSync(path.join(os.tmpdir(), "cli-e2e-home-"));
 		const dataDir = mkdtempSync(path.join(os.tmpdir(), "cli-e2e-data-"));

--- a/apps/cli/src/commands/mcp.test.ts
+++ b/apps/cli/src/commands/mcp.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildMcpInstallDefaults, runMcpInstallCommand } from "./mcp";
+
+describe("mcp install command", () => {
+	it("builds stdio wizard defaults from command args", () => {
+		expect(
+			buildMcpInstallDefaults({
+				name: "fs",
+				targetArgs: [
+					"npx",
+					"-y",
+					"@modelcontextprotocol/server-filesystem",
+					"/tmp/my dir",
+				],
+			}),
+		).toEqual({
+			name: "fs",
+			type: "stdio",
+			command: 'npx -y @modelcontextprotocol/server-filesystem "/tmp/my dir"',
+		});
+	});
+
+	it("builds remote wizard defaults and normalizes http transport", () => {
+		expect(
+			buildMcpInstallDefaults({
+				name: "ctx7",
+				transport: "http",
+				targetArgs: ["https://mcp.context7.com/mcp"],
+			}),
+		).toEqual({
+			name: "ctx7",
+			type: "streamableHttp",
+			url: "https://mcp.context7.com/mcp",
+		});
+	});
+
+	it("normalizes streamable-http transport", () => {
+		expect(
+			buildMcpInstallDefaults({
+				name: "docs",
+				transport: "streamable-http",
+				targetArgs: ["https://example.com/mcp"],
+			}),
+		).toEqual({
+			name: "docs",
+			type: "streamableHttp",
+			url: "https://example.com/mcp",
+		});
+	});
+
+	it("builds SSE wizard defaults", () => {
+		expect(
+			buildMcpInstallDefaults({
+				name: "events",
+				transport: "sse",
+				targetArgs: ["https://example.com/sse"],
+			}),
+		).toEqual({
+			name: "events",
+			type: "sse",
+			url: "https://example.com/sse",
+		});
+	});
+
+	it("rejects missing stdio command and invalid remote URL", () => {
+		expect(() =>
+			buildMcpInstallDefaults({
+				name: "fs",
+			}),
+		).toThrow(/requires a command/);
+
+		expect(() =>
+			buildMcpInstallDefaults({
+				name: "bad",
+				transport: "http",
+				targetArgs: ["not-a-url"],
+			}),
+		).toThrow(/Invalid MCP server URL/);
+	});
+
+	it("opens the add wizard with prefilled defaults", async () => {
+		const runWizard = vi.fn(async () => 0);
+
+		const code = await runMcpInstallCommand({
+			name: "ctx7",
+			transport: "http",
+			targetArgs: ["https://mcp.context7.com/mcp"],
+			isTty: true,
+			runWizard,
+			io: { writeErr: vi.fn() },
+		});
+
+		expect(code).toBe(0);
+		expect(runWizard).toHaveBeenCalledWith({
+			name: "ctx7",
+			type: "streamableHttp",
+			url: "https://mcp.context7.com/mcp",
+		});
+	});
+
+	it("requires a TTY because it opens the wizard", async () => {
+		const writeErr = vi.fn();
+		const runWizard = vi.fn(async () => 0);
+
+		const code = await runMcpInstallCommand({
+			name: "ctx7",
+			transport: "http",
+			targetArgs: ["https://mcp.context7.com/mcp"],
+			isTty: false,
+			runWizard,
+			io: { writeErr },
+		});
+
+		expect(code).toBe(1);
+		expect(runWizard).not.toHaveBeenCalled();
+		expect(writeErr).toHaveBeenCalledWith(
+			"cline mcp install opens the MCP wizard and requires a TTY.",
+		);
+	});
+});

--- a/apps/cli/src/commands/mcp.test.ts
+++ b/apps/cli/src/commands/mcp.test.ts
@@ -78,6 +78,16 @@ describe("mcp install command", () => {
 		).toThrow(/Invalid MCP server URL/);
 	});
 
+	it("rejects remote URL schemes other than http and https", () => {
+		expect(() =>
+			buildMcpInstallDefaults({
+				name: "bad",
+				transport: "http",
+				targetArgs: ["file:///etc/passwd"],
+			}),
+		).toThrow(/only http and https are supported/);
+	});
+
 	it("opens the add wizard with prefilled defaults", async () => {
 		const runWizard = vi.fn(async () => 0);
 
@@ -113,6 +123,21 @@ describe("mcp install command", () => {
 
 		expect(code).toBe(1);
 		expect(runWizard).not.toHaveBeenCalled();
+		expect(writeErr).toHaveBeenCalledWith(
+			"cline mcp install opens the MCP wizard and requires a TTY.",
+		);
+	});
+
+	it("checks for TTY before validating install arguments", async () => {
+		const writeErr = vi.fn();
+
+		const code = await runMcpInstallCommand({
+			name: "fs",
+			isTty: false,
+			io: { writeErr },
+		});
+
+		expect(code).toBe(1);
 		expect(writeErr).toHaveBeenCalledWith(
 			"cline mcp install opens the MCP wizard and requires a TTY.",
 		);

--- a/apps/cli/src/commands/mcp.ts
+++ b/apps/cli/src/commands/mcp.ts
@@ -1,0 +1,115 @@
+import type { McpAddDefaults } from "../wizards/mcp";
+
+export interface McpCommandIo {
+	writeErr: (text: string) => void;
+}
+
+export interface McpInstallOptions {
+	name: string;
+	targetArgs?: string[];
+	transport?: string;
+	io?: McpCommandIo;
+	isTty?: boolean;
+	runWizard?: (defaults: McpAddDefaults) => Promise<number>;
+}
+
+function normalizeTransportType(
+	value: string | undefined,
+): McpAddDefaults["type"] {
+	const normalized = (value ?? "stdio").trim();
+	if (normalized === "http" || normalized === "streamable-http") {
+		return "streamableHttp";
+	}
+	if (
+		normalized === "stdio" ||
+		normalized === "sse" ||
+		normalized === "streamableHttp"
+	) {
+		return normalized;
+	}
+	throw new Error(
+		`Unsupported MCP transport "${normalized}". Expected stdio, sse, http, streamable-http, or streamableHttp.`,
+	);
+}
+
+function assertValidUrl(url: string): void {
+	try {
+		new URL(url);
+	} catch {
+		throw new Error(`Invalid MCP server URL: ${url}`);
+	}
+}
+
+function quoteCommandArg(arg: string): string {
+	if (/^[^\s"'\\]+$/.test(arg)) {
+		return arg;
+	}
+	return `"${arg.replace(/(["\\])/g, "\\$1")}"`;
+}
+
+export function buildMcpInstallDefaults(options: {
+	name: string;
+	targetArgs?: string[];
+	transport?: string;
+}): McpAddDefaults {
+	const name = options.name.trim();
+	if (!name) {
+		throw new Error("MCP server name is required");
+	}
+	const type = normalizeTransportType(options.transport);
+	const targetArgs = options.targetArgs ?? [];
+	if (type === "stdio") {
+		if (targetArgs.length === 0) {
+			throw new Error(
+				"Stdio MCP install requires a command after the server name, for example: cline mcp install fs -- npx -y @modelcontextprotocol/server-filesystem /tmp",
+			);
+		}
+		return {
+			name,
+			type,
+			command: targetArgs.map(quoteCommandArg).join(" "),
+		};
+	}
+
+	if (targetArgs.length !== 1) {
+		throw new Error(
+			"Remote MCP install requires exactly one URL argument after the server name.",
+		);
+	}
+	const url = targetArgs[0]?.trim() ?? "";
+	assertValidUrl(url);
+	return {
+		name,
+		type,
+		url,
+	};
+}
+
+async function runPrefilledWizard(defaults: McpAddDefaults): Promise<number> {
+	const { runMcpWizard } = await import("../wizards/mcp");
+	return runMcpWizard({
+		initialAction: "add",
+		addDefaults: defaults,
+		exitAfterInitialAction: true,
+	});
+}
+
+export async function runMcpInstallCommand(
+	options: McpInstallOptions,
+): Promise<number> {
+	try {
+		const defaults = buildMcpInstallDefaults(options);
+		const isTty =
+			options.isTty ?? (process.stdin.isTTY && process.stdout.isTTY);
+		if (!isTty) {
+			throw new Error(
+				"cline mcp install opens the MCP wizard and requires a TTY.",
+			);
+		}
+		return await (options.runWizard ?? runPrefilledWizard)(defaults);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		options.io?.writeErr(message);
+		return 1;
+	}
+}

--- a/apps/cli/src/commands/mcp.ts
+++ b/apps/cli/src/commands/mcp.ts
@@ -33,10 +33,16 @@ function normalizeTransportType(
 }
 
 function assertValidUrl(url: string): void {
+	let parsed: URL;
 	try {
-		new URL(url);
+		parsed = new URL(url);
 	} catch {
 		throw new Error(`Invalid MCP server URL: ${url}`);
+	}
+	if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+		throw new Error(
+			`Invalid MCP server URL: ${url} (only http and https are supported)`,
+		);
 	}
 }
 
@@ -98,7 +104,6 @@ export async function runMcpInstallCommand(
 	options: McpInstallOptions,
 ): Promise<number> {
 	try {
-		const defaults = buildMcpInstallDefaults(options);
 		const isTty =
 			options.isTty ?? (process.stdin.isTTY && process.stdout.isTTY);
 		if (!isTty) {
@@ -106,6 +111,7 @@ export async function runMcpInstallCommand(
 				"cline mcp install opens the MCP wizard and requires a TTY.",
 			);
 		}
+		const defaults = buildMcpInstallDefaults(options);
 		return await (options.runWizard ?? runPrefilledWizard)(defaults);
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -356,7 +356,7 @@ export async function runCli(): Promise<void> {
 			}
 		});
 
-	program
+	const mcpCmd = program
 		.command("mcp")
 		.description("Manage MCP servers")
 		.action(async () => {
@@ -367,6 +367,31 @@ export async function runCli(): Promise<void> {
 					"MCP wizard requires a TTY. Use cline config mcp to list servers.",
 				);
 			}
+		});
+	const mcpInstallCmd = mcpCmd
+		.command("install")
+		.alias("add")
+		.description("Open the MCP add wizard with server fields prefilled")
+		.argument("<name>", "MCP server name")
+		.argument(
+			"[targetArgs...]",
+			"URL for remote transports, or command and args after -- for stdio",
+		)
+		.option(
+			"--transport <transport>",
+			"stdio, sse, http, streamable-http, or streamableHttp (default: stdio)",
+		)
+		.action(async (name: string, targetArgs: string[]) => {
+			const opts = mcpInstallCmd.opts<{
+				transport?: string;
+			}>();
+			const { runMcpInstallCommand } = await import("./commands/mcp");
+			ctx.exitCode = await runMcpInstallCommand({
+				name,
+				targetArgs,
+				transport: opts.transport,
+				io,
+			});
 		});
 
 	const createDoctorRuntimeCommand = async () => {

--- a/apps/cli/src/wizards/mcp/index.ts
+++ b/apps/cli/src/wizards/mcp/index.ts
@@ -436,14 +436,16 @@ export async function runMcpWizard(
 	p.intro("MCP Servers");
 
 	if (options.initialAction === "add") {
+		let initialActionExitCode = 0;
 		try {
 			await actionAdd(options.addDefaults);
 		} catch (err) {
+			initialActionExitCode = 1;
 			p.log.error(err instanceof Error ? err.message : String(err));
 		}
 		if (options.exitAfterInitialAction === true) {
 			p.outro("Done");
-			return 0;
+			return initialActionExitCode;
 		}
 	}
 

--- a/apps/cli/src/wizards/mcp/index.ts
+++ b/apps/cli/src/wizards/mcp/index.ts
@@ -51,6 +51,19 @@ interface UrlServerConfig {
 	authMode: RemoteAuthMode;
 }
 
+export interface McpAddDefaults {
+	name?: string;
+	type?: McpTransport["type"];
+	command?: string;
+	url?: string;
+}
+
+export interface RunMcpWizardOptions {
+	initialAction?: "add";
+	addDefaults?: McpAddDefaults;
+	exitAfterInitialAction?: boolean;
+}
+
 export function parseStdioCommand(input: string): string[] {
 	const tokens: string[] = [];
 	let current = "";
@@ -96,12 +109,15 @@ export function parseStdioCommand(input: string): string[] {
 	return tokens;
 }
 
-async function collectStdioTransport(): Promise<McpTransport | null> {
+async function collectStdioTransport(
+	defaultCommand?: string,
+): Promise<McpTransport | null> {
 	p.log.info("Quoted arguments and escaped spaces are supported");
 
 	const command = await p.text({
 		message: "Command to run",
 		placeholder: "npx -y @modelcontextprotocol/server-filesystem",
+		initialValue: defaultCommand,
 		validate: (v) => {
 			if (!v?.trim()) return "Command is required";
 			return undefined;
@@ -141,10 +157,12 @@ async function collectStdioTransport(): Promise<McpTransport | null> {
 
 async function collectUrlTransport(
 	type: "sse" | "streamableHttp",
+	defaultUrl?: string,
 ): Promise<UrlServerConfig | null> {
 	const url = await p.text({
 		message: "Server URL",
 		placeholder: "https://example.com/mcp",
+		initialValue: defaultUrl,
 		validate: (v) => {
 			if (!v?.trim()) return "URL is required";
 			try {
@@ -211,10 +229,11 @@ async function collectUrlTransport(
 	};
 }
 
-async function actionAdd(): Promise<void> {
+async function actionAdd(defaults?: McpAddDefaults): Promise<void> {
 	const name = await p.text({
 		message: "Server name",
 		placeholder: "my-mcp-server",
+		initialValue: defaults?.name,
 		validate: (v) => {
 			if (!v?.trim()) return "Name is required";
 			const existing = loadServers();
@@ -228,6 +247,7 @@ async function actionAdd(): Promise<void> {
 
 	const type = await p.select({
 		message: "Server type",
+		initialValue: defaults?.type,
 		options: [
 			{
 				value: "stdio",
@@ -251,9 +271,12 @@ async function actionAdd(): Promise<void> {
 	let transport: McpTransport | null;
 	let authMode: RemoteAuthMode = "none";
 	if (type === "stdio") {
-		transport = await collectStdioTransport();
+		transport = await collectStdioTransport(defaults?.command);
 	} else {
-		const config = await collectUrlTransport(type as "sse" | "streamableHttp");
+		const config = await collectUrlTransport(
+			type as "sse" | "streamableHttp",
+			defaults?.url,
+		);
 		transport = config?.transport ?? null;
 		authMode = config?.authMode ?? "none";
 	}
@@ -407,8 +430,22 @@ async function actionAuthorizeOAuth(): Promise<void> {
 	await authorizeOAuth(name);
 }
 
-export async function runMcpWizard(): Promise<number> {
+export async function runMcpWizard(
+	options: RunMcpWizardOptions = {},
+): Promise<number> {
 	p.intro("MCP Servers");
+
+	if (options.initialAction === "add") {
+		try {
+			await actionAdd(options.addDefaults);
+		} catch (err) {
+			p.log.error(err instanceof Error ? err.message : String(err));
+		}
+		if (options.exitAfterInitialAction === true) {
+			p.outro("Done");
+			return 0;
+		}
+	}
 
 	let keepGoing = true;
 	while (keepGoing) {


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This adds a lightweight `cline mcp install` path for the CLI. The intent is not to introduce a second non-interactive MCP settings writer. Instead, the command gives users and docs/marketplace surfaces a one-line command shape that opens the existing MCP add wizard with the obvious fields already filled in.

The supported command shapes are intentionally narrow:

```sh
cline mcp install fs -- npx -y @modelcontextprotocol/server-filesystem /tmp
cline mcp install ctx7 --transport http https://mcp.context7.com/mcp
cline mcp install events --transport sse https://example.com/sse
```

The command parses the server name, transport, and command-or-URL, normalizes `http` and `streamable-http` to the existing `streamableHttp` wizard transport, then launches the MCP wizard directly into the add flow. The wizard still owns the actual save behavior, duplicate-name validation, environment variable entry, static header entry, auth mode selection, OAuth handoff, and settings writes.

This keeps the CLI surface pragmatic and avoids copying wizard behavior into a separate command implementation. It also means the command requires a TTY by design; in non-TTY contexts it exits with a clear error explaining that it opens the wizard.

Implementation notes:

- `apps/cli/src/commands/mcp.ts` only builds wizard defaults and invokes `runMcpWizard`.
- `apps/cli/src/wizards/mcp/index.ts` now accepts optional add-flow defaults and can exit after the seeded add action.
- Existing `cline mcp` behavior is unchanged when no subcommand is provided.
- `cline mcp add` is an alias for `cline mcp install`.

### Test Procedure

Focused verification completed:

```sh
bun biome lint --diagnostic-level=error apps/cli
bun run typecheck
bunx vitest run --config vitest.config.ts src/commands/mcp.test.ts src/wizards/mcp/settings.test.ts
bunx vitest run --config vitest.e2e.config.ts src/cli.e2e.test.ts --testNamePattern "routes mcp install"
```

I also manually smoke-tested the CLI route in a non-TTY shell:

```sh
bun apps/cli/src/index.ts mcp install fs -- npx -y @modelcontextprotocol/server-filesystem /tmp
```

That verified Commander routes the command correctly and returns the intended TTY-required error instead of falling through to the normal MCP wizard or agent startup.

Earlier broad suite checks surfaced failures outside this MCP change path:

- `bun run test:unit` failed in `src/commands/distribution-package.test.ts` because the direct source package packing guard expected a non-zero status but got `0`.
- `bun run test:e2e` failed existing expectations around help text option rendering, hub/history error statuses, Documents/Cline skills discovery, and tool status label text.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable. This is a CLI command/wizard-entry change.

### Additional Notes

The command intentionally does not support `--header`, `--env`, `--force`, or JSON config input. Those were considered, but they duplicate wizard behavior and make the CLI surface feel heavier than the current need. The pragmatic behavior is to prefill the wizard and let the existing wizard continue to collect the remaining details.
