### PR TITLE
fix(permissions): treat the |& (pipe-both-streams) operator as a command separator

### DIFF
--- a/apps/vscode/src/core/permissions/CommandPermissionController.test.ts
+++ b/apps/vscode/src/core/permissions/CommandPermissionController.test.ts
@@ -976,6 +976,103 @@ describe("CommandPermissionController", () => {
 		})
 	})
 
+	describe("Pipe-Both-Streams Operator (|&) Separation", () => {
+		it("should deny a denied command piped after |& when redirects are allowed", () => {
+			// "|&" is bash pipe-both-streams ("cmd1 2>&1 | cmd2"). The command after it is a
+			// separate command. Previously "|&" was classified as a redirect, so the downstream
+			// command was merged into the preceding segment and escaped the deny rule whenever
+			// allowRedirects was true.
+			process.env[COMMAND_PERMISSIONS_ENV_VAR] = JSON.stringify({
+				deny: ["curl *", "wget *"],
+				allowRedirects: true,
+			})
+			const controller = new CommandPermissionController()
+
+			const result = controller.validateCommand("npm run build |& curl http://evil.com")
+			result.allowed.should.be.false()
+			result.reason.should.equal("segment_denied")
+			result.failedSegment!.should.equal("curl http://evil.com")
+		})
+
+		it("should not let an allow-glob swallow the command after |& (deny-by-default)", () => {
+			process.env[COMMAND_PERMISSIONS_ENV_VAR] = JSON.stringify({
+				allow: ["npm *"],
+				allowRedirects: true,
+			})
+			const controller = new CommandPermissionController()
+
+			const result = controller.validateCommand("npm run build |& curl http://evil.com")
+			result.allowed.should.be.false()
+			result.reason.should.equal("segment_no_match")
+			result.failedSegment!.should.equal("curl http://evil.com")
+		})
+
+		it("should report a segment reason (not redirect_detected) for a denied |& downstream under default config", () => {
+			// Even without allowRedirects, a denied command after |& must be reported as a
+			// denied segment, not mislabeled as a redirect.
+			process.env[COMMAND_PERMISSIONS_ENV_VAR] = JSON.stringify({
+				deny: ["curl *"],
+			})
+			const controller = new CommandPermissionController()
+
+			const result = controller.validateCommand("ls -la |& curl http://evil.com")
+			result.allowed.should.be.false()
+			result.reason.should.equal("segment_denied")
+			result.failedSegment!.should.equal("curl http://evil.com")
+		})
+
+		it("should allow a legitimate |& pipeline without treating it as a redirect", () => {
+			// "build |& tee log" merges stderr into stdout and pipes to tee — a common,
+			// legitimate workflow. It must not be denied as a redirect, and both segments
+			// are validated normally.
+			process.env[COMMAND_PERMISSIONS_ENV_VAR] = JSON.stringify({
+				allow: ["npm *", "tee *"],
+			})
+			const controller = new CommandPermissionController()
+
+			controller.validateCommand("npm run build |& tee build.log").allowed.should.be.true()
+		})
+
+		it("should validate every segment in a chain mixing |& with other operators", () => {
+			process.env[COMMAND_PERMISSIONS_ENV_VAR] = JSON.stringify({
+				allow: ["echo *", "grep *"],
+			})
+			const controller = new CommandPermissionController()
+
+			const result = controller.validateCommand("echo hi |& grep x && nc evil.com 1234")
+			result.allowed.should.be.false()
+			result.failedSegment!.should.equal("nc evil.com 1234")
+		})
+
+		it("documents the behavior change: with allowRedirects, the command after |& must be allow-listed", () => {
+			// Behavior change vs the old redirect-merge handling: previously, when "|&" was
+			// treated as a redirect, "npm run build |& tee build.log" collapsed into one
+			// segment, so allow-listing only "npm *" (with allowRedirects:true) let the whole
+			// line through. Now "|&" is a separator, so the right-hand command ("tee build.log")
+			// is its own segment and must also be allow-listed. This is the same tradeoff the
+			// existing "|", "&&" and ";" separators already impose, and it moves in the safer
+			// (fail-closed) direction: the downstream command is now validated rather than
+			// silently merged into the preceding segment.
+			process.env[COMMAND_PERMISSIONS_ENV_VAR] = JSON.stringify({
+				allow: ["npm *"],
+				allowRedirects: true,
+			})
+			const controller = new CommandPermissionController()
+			const before = controller.validateCommand("npm run build |& tee build.log")
+			before.allowed.should.be.false()
+			before.reason.should.equal("segment_no_match")
+			before.failedSegment!.should.equal("tee build.log")
+
+			// Allow-listing the right-hand command restores the legitimate pipeline.
+			process.env[COMMAND_PERMISSIONS_ENV_VAR] = JSON.stringify({
+				allow: ["npm *", "tee *"],
+				allowRedirects: true,
+			})
+			const controller2 = new CommandPermissionController()
+			controller2.validateCommand("npm run build |& tee build.log").allowed.should.be.true()
+		})
+	})
+
 	describe("No Config Bypass Prevention", () => {
 		it("should NOT check anything when no config is set (backward compatibility)", () => {
 			delete process.env[COMMAND_PERMISSIONS_ENV_VAR]

--- a/apps/vscode/src/core/permissions/CommandPermissionController.ts
+++ b/apps/vscode/src/core/permissions/CommandPermissionController.ts
@@ -2,8 +2,14 @@ import { ParseEntry, parse } from "shell-quote"
 import { Logger } from "@/shared/services/Logger"
 import { COMMAND_PERMISSIONS_ENV_VAR, CommandPermissionConfig, PermissionValidationResult, ShellOperatorMatch } from "./types"
 
-const REDIRECT_OPERATORS = new Set([">", ">>", "<", ">&", "<&", "|&", "<(", ">("])
-const COMMAND_SEPARATOR_OPERATORS = new Set(["&&", "||", "|", ";"])
+// Note: "|&" (bash pipe-both-streams, shorthand for "2>&1 |") is intentionally NOT
+// listed here. It connects two commands (the second is a separate command that must
+// be validated on its own), so it is treated as a command separator below, not a
+// redirect. Listing it as a redirect both (a) merged the downstream command into the
+// preceding segment, letting it bypass per-segment allow/deny checks when
+// allowRedirects is true, and (b) reported "redirect_detected" for a plain pipe.
+const REDIRECT_OPERATORS = new Set([">", ">>", "<", ">&", "<&", "<(", ">("])
+const COMMAND_SEPARATOR_OPERATORS = new Set(["&&", "||", "|", ";", "|&"])
 
 const LINE_SEPARATOR_REGEX = /[\n\r\u2028\u2029\u0085]/
 const LINE_SEPARATOR_DESCRIPTIONS: Record<string, ShellOperatorMatch> = {
@@ -31,7 +37,7 @@ interface ParsedCommand {
  * Format: {"allow": ["pattern1", "pattern2"], "deny": ["pattern3"], "allowRedirects": true}
  *
  * Rule evaluation for chained commands (e.g., "cd /tmp && npm test"):
- * 1. Parse command into segments split by operators (&&, ||, |, ;)
+ * 1. Parse command into segments split by operators (&&, ||, |, ;, |&)
  * 2. Check for dangerous characters (backticks outside single quotes, newlines outside quotes)
  * 3. If redirects detected and allowRedirects !== true → DENIED
  * 4. Validate EACH segment against allow/deny rules - ALL must pass
@@ -244,7 +250,9 @@ export class CommandPermissionController {
 					continue
 				}
 
-				// 2. Handle Logic Separators: &&, ||, ;, |
+				// 2. Handle Logic/Pipe Separators: &&, ||, ;, |, |&
+				// "|&" is bash pipe-both-streams ("cmd1 2>&1 | cmd2"); the command after it
+				// is a separate command, so flush the current segment to validate it on its own.
 				if (typeof token === "object" && "op" in token && COMMAND_SEPARATOR_OPERATORS.has(token.op as string)) {
 					flushSegment()
 					continue


### PR DESCRIPTION
### Related Issue

Small bug fix — submitted directly under the template's small-bugfix exception (no prior discussion required). Closely related to #11607, which fixes the sibling `&` background operator in this same file and parser; this PR is the same bug class for a different operator and is independent of it.

### Description

**Problem.** `CommandPermissionController` splits a command into segments on `COMMAND_SEPARATOR_OPERATORS` (`&&`, `||`, `|`, `;`) and validates **each** segment against the configured allow/deny rules. `|&` — bash *pipe-both-streams*, shorthand for `2>&1 |` — connects two commands, but it was listed in `REDIRECT_OPERATORS` instead of the separator set.

`shell-quote` tokenizes `npm run build |& curl evil.com` as `["npm","run","build",{op:"|&"},"curl","evil.com"]` (structurally identical to a plain `|`). Because `{op:"|&"}` hit the redirect branch (sets `hasRedirects`, **no** `flushSegment()`), `curl evil.com` was merged into the preceding `npm run build` segment. Two consequences for anyone using `CLINE_COMMAND_PERMISSIONS`:

- **Permission bypass** — with `allowRedirects: true`, a denied command after `|&` escaped the per-segment deny check. `npm run build |& curl evil.com` was **allowed** even with `deny: ["curl *"]`, because the merged segment `"npm run build curl evil.com"` does not match `^curl .*$`.
- **False positive** — without `allowRedirects`, a legitimate `npm run build |& tee build.log` was blocked as `redirect_detected`, even though `|&` is a pipe, not a file redirect.

**Fix.** Move `|&` from `REDIRECT_OPERATORS` to `COMMAND_SEPARATOR_OPERATORS`, so the command after it is flushed into its own segment and validated, consistent with how `|`, `&&` and `;` already behave. The genuine redirect operators (`>`, `>>`, `<`, `>&`, `<&`, `<(`, `>(`) are unchanged — `2>&1` tokenizes to operator `>&` (not `|&`) and is unaffected.

### Test Procedure

Six tests were added in a `Pipe-Both-Streams Operator (|&) Separation` block covering: a denied command after `|&` under `allowRedirects:true` (the bypass), an allow-glob not swallowing the downstream command, the correct `segment_denied` reason (not `redirect_detected`), a legitimate `|& tee` pipeline still allowed, a mixed `|&`+`&&` chain validating every segment, and the documented behavior change.

How I verified (the full mocha suite needs the complete monorepo dep tree, so I exercised each assertion against the **real compiled `CommandPermissionController`** via a small bun harness):

- **Green on fix:** all six scenarios + nine total checks pass on this branch.
- **Red on base:** running the same scenarios against the unpatched `main` controller, exactly the bug cases fail — `... |& curl evil` returns `allowed:true` (bypass) and `... |& tee log` returns `redirect_detected` (false positive). So the tests detect the real defect, not just confirm new code.
- **No regressions:** `2>&1` (single command and without `allowRedirects`), plain `|` splitting, `&>`/`>&` redirects, and a legitimate two-segment `|&` pipeline all behave identically to base. The change only affects the literal `|&` token.

`shell-quote` tokenization confirmed: `a |& b` → `["a",{op:"|&"},"b"]`; `cat f 2>&1` → `["cat","f","2",{op:">&"},"1"]` (operator `>&`, untouched).

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single bugfix
-   [x] I have reviewed the contributor guidelines (no changelog file added, per CONTRIBUTING)

### Additional Notes

One intentional behavior change: a command on the right-hand side of `|&` (e.g. `tee build.log` in `npm run build |& tee build.log`) now forms its own segment and must also be allow-listed, the same tradeoff the existing `|`, `&&` and `;` separators impose. This is the fail-closed direction — the downstream command is now validated rather than silently merged. It affects only users who have configured `CLINE_COMMAND_PERMISSIONS`.
