### PR TITLE
fix(cli): clarify plugin MCP OAuth failure handling

### DIFF
--- a/apps/cli/src/commands/plugin.ts
+++ b/apps/cli/src/commands/plugin.ts
@@ -1207,12 +1207,10 @@ function serializePluginInstallResult(
 	};
 }
 
-function isInteractivePluginInstall(
-	options: PluginInstallOptions & { json?: boolean },
-): boolean {
+function isInteractivePluginInstall(options: PluginInstallOptions): boolean {
 	return (
 		options.mcpOAuth?.interactive ??
-		(options.json !== true && process.stdin.isTTY && process.stdout.isTTY)
+		(process.stdin.isTTY && process.stdout.isTTY)
 	);
 }
 
@@ -1268,14 +1266,16 @@ async function authorizeMcpOAuthCandidate(
 	const { authorizeMcpServerOAuthWithBrowser } = await import(
 		"../wizards/mcp/oauth"
 	);
-	await authorizeMcpServerOAuthWithBrowser(candidate.name);
+	await authorizeMcpServerOAuthWithBrowser(candidate.name, {
+		throwOnError: true,
+	});
 }
 
 async function runPluginMcpOAuthFollowup(
 	candidates: PluginMcpOAuthCandidate[],
-	options: PluginInstallOptions & { json?: boolean },
+	options: PluginInstallOptions,
 ): Promise<void> {
-	if (candidates.length === 0 || options.json === true) {
+	if (candidates.length === 0) {
 		return;
 	}
 
@@ -1303,7 +1303,7 @@ async function runPluginMcpOAuthFollowup(
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			options.io?.writeErr(
-				`Warning: failed to authorize MCP server ${candidate.name}: ${message}`,
+				`Warning: failed to authorize MCP server ${candidate.name}: ${message}. Run "cline mcp" and choose "Authorize OAuth" to retry.`,
 			);
 		}
 	}

--- a/apps/cli/src/wizards/mcp/oauth.ts
+++ b/apps/cli/src/wizards/mcp/oauth.ts
@@ -17,6 +17,7 @@ function toErrorMessage(error: unknown): string {
 
 export async function authorizeMcpServerOAuthWithBrowser(
 	name: string,
+	options: { throwOnError?: boolean } = {},
 ): Promise<void> {
 	p.log.info("Opening browser for MCP OAuth authorization");
 	try {
@@ -33,6 +34,9 @@ export async function authorizeMcpServerOAuthWithBrowser(
 		});
 		p.log.success(result.message);
 	} catch (error) {
+		if (options.throwOnError === true) {
+			throw error instanceof Error ? error : new Error(toErrorMessage(error));
+		}
 		p.log.error(`OAuth authorization failed: ${toErrorMessage(error)}`);
 		p.log.warn(
 			`Server "${name}" is still saved. Choose "Authorize OAuth" to retry.`,


### PR DESCRIPTION
### Related Issue

**Issue:** #11575

### Description

This is a small follow-up to #11575, addressing the Greptile review comments that landed after the plugin MCP OAuth install flow was merged.

The original implementation already skipped the OAuth follow-up before calling into the follow-up helper when `--json` was used. That left a redundant `options.json === true` guard inside `runPluginMcpOAuthFollowup`, which could not be reached from the production call path. This PR removes that dead guard and simplifies the helper signature so it only deals with plugin install options relevant to the follow-up.

The review also pointed out that the default browser OAuth helper swallowed authorization errors internally for the MCP wizard. That was correct for the MCP wizard's existing behavior, but it meant the plugin install follow-up's outer warning path was only exercised by injected test doubles and not by the production default authorizer. This PR adds an optional `throwOnError` mode to the shared browser helper. The MCP wizard keeps the default log-and-continue behavior, while plugin install opts into thrown errors so it can report the non-blocking retry guidance through its own command output path.

### Test Procedure

I tested the focused CLI plugin path and formatting/type safety locally:

```sh
bun -F @cline/cli test:unit -- src/commands/plugin.test.ts
bun -F @cline/cli typecheck
bun biome check --diagnostic-level=error apps/cli/src/commands/plugin.ts apps/cli/src/commands/plugin.test.ts apps/cli/src/wizards/mcp/index.ts apps/cli/src/wizards/mcp/oauth.ts
```

These checks cover the plugin install OAuth candidate flow added in #11575, including the non-blocking OAuth failure case. The behavior that could regress here is the MCP wizard's authorization handling, so the helper defaults remain unchanged unless callers explicitly pass `throwOnError: true`.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable. This is a CLI behavior cleanup with unit coverage and no persistent UI surface.

### Additional Notes

This PR intentionally preserves the MCP wizard's existing behavior. Only plugin install passes `throwOnError: true`, because plugin install owns the non-blocking warning and retry guidance for its OAuth follow-up.
