### PR TITLE
fix(cli): reject accidental prompt fallback for bad args

### DIFF
--- a/apps/cli/src/commands/program.ts
+++ b/apps/cli/src/commands/program.ts
@@ -116,7 +116,6 @@ export function createProgram(): Command {
 			writeOut: () => {}, // suppress by default; main.ts re-enables for routing
 			writeErr: () => {},
 		})
-		.allowUnknownOption()
 		.allowExcessArguments()
 		.enablePositionalOptions()
 		.argument(

--- a/apps/cli/src/main.test.ts
+++ b/apps/cli/src/main.test.ts
@@ -411,6 +411,61 @@ describe("runCli lightweight command dispatch", () => {
 		expect(mockState.runInteractiveImports).toBe(0);
 	});
 
+	it("rejects multiple bare positional prompt tokens", async () => {
+		const consoleError = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => undefined);
+		forcePromptModeInput();
+		process.argv = ["bun", "src/index.ts", "hello", "world"];
+
+		const { runCli } = await import("./main");
+
+		await expect(runCli()).resolves.toBeUndefined();
+		expect(process.exitCode).toBe(1);
+		expect(consoleError).toHaveBeenCalledWith(
+			expect.stringContaining(
+				"Unknown command or extra arguments: hello world",
+			),
+		);
+		expect(runtimeMocks.runAgent).not.toHaveBeenCalled();
+		expect(mockState.runAgentImports).toBe(0);
+		expect(mockState.runInteractiveImports).toBe(0);
+	});
+
+	it("runs quoted positional prompt text", async () => {
+		forcePromptModeInput();
+		process.argv = ["bun", "src/index.ts", "hello world"];
+
+		const { runCli } = await import("./main");
+
+		await expect(runCli()).resolves.toBeUndefined();
+		expect(runtimeMocks.runAgent).toHaveBeenCalledTimes(1);
+		expect(runtimeMocks.runAgent).toHaveBeenCalledWith(
+			"hello world",
+			expect.any(Object),
+			expect.anything(),
+		);
+	});
+
+	it("rejects unknown root flags before loading runtime modules", async () => {
+		const consoleError = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => undefined);
+		forcePromptModeInput();
+		process.argv = ["bun", "src/index.ts", "--made-up-flag"];
+
+		const { runCli } = await import("./main");
+
+		await expect(runCli()).resolves.toBeUndefined();
+		expect(process.exitCode).toBe(1);
+		expect(consoleError).toHaveBeenCalledWith(
+			expect.stringContaining("unknown option '--made-up-flag'"),
+		);
+		expect(runtimeMocks.runAgent).not.toHaveBeenCalled();
+		expect(mockState.runAgentImports).toBe(0);
+		expect(mockState.runInteractiveImports).toBe(0);
+	});
+
 	it("creates a worktree and runs prompt sessions from it", async () => {
 		forcePromptModeInput();
 		process.argv = ["bun", "src/index.ts", "--worktree", "hello"];
@@ -932,7 +987,7 @@ describe("runCli lightweight command dispatch", () => {
 		runtimeMocks.runAgent.mockClear();
 
 		forcePromptModeInput();
-		process.argv = ["bun", "src/index.ts", "/team", "find", "the", "bug"];
+		process.argv = ["bun", "src/index.ts", "/team find the bug"];
 
 		const { runCli } = await import("./main");
 

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -139,7 +139,7 @@ export async function runCli(): Promise<void> {
 	// Re-enable built-in help/version output for the routing program
 	program.configureOutput({
 		writeOut: (str: string) => process.stdout.write(str),
-		writeErr: (str: string) => process.stderr.write(str),
+		writeErr: () => {},
 	});
 	// Default action handles non-subcommand args (e.g. prompt text)
 	program.action(() => {});
@@ -659,6 +659,7 @@ export async function runCli(): Promise<void> {
 		if (err instanceof CommanderError) {
 			if (err.exitCode !== 0) {
 				writeErr(err.message);
+				process.exitCode = err.exitCode;
 				return;
 			}
 			return;
@@ -709,6 +710,13 @@ export async function runCli(): Promise<void> {
 
 	// Default flow: no subcommand matched, or fall-through from config/history.
 	let args = commanderToParsedArgs(program);
+	if (program.args.length > 1) {
+		writeErr(
+			`Unknown command or extra arguments: ${program.args.join(" ")}\nPrompt text with spaces must be quoted as a single argument, for example: cline "fix the tests". Use "cline --help" to see available commands and flags.`,
+		);
+		process.exitCode = 1;
+		return;
+	}
 
 	let resumeSessionId: string | undefined = ctx.resumeSessionId;
 	if (resumeSessionId) {


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This fixes a CLI argument parsing footgun where mistyped root commands or flags could be treated as prompt text and then run non-interactively. For example, a user intending to pass a command with flags could accidentally type multiple bare words, and the CLI would concatenate them into a prompt instead of failing fast.

The change keeps the existing quoted prompt flow intact: `cline "fix the tests"` still runs as a one-shot prompt because the shell passes the quoted string as a single positional argument. It now rejects multiple bare positional root tokens before loading the runtime, with an error that tells the user to quote prompt text containing spaces. Unknown root flags are also rejected by Commander instead of being accepted as positional prompt text.

The implementation is intentionally narrow:

- Remove root-level `allowUnknownOption()` so unknown flags fail during routing.
- Add a lightweight guard before runtime bootstrap that rejects more than one root positional token.
- Preserve one-token positional prompts and the existing interactive/runtime paths.

### Test Procedure

Ran the focused CLI unit test suite:

```sh
cd apps/cli && bun run vitest run --config vitest.config.ts src/main.test.ts
```

Result: `62 passed`.

The added tests cover:

- Rejecting multiple bare positional prompt tokens like `cline hello world`.
- Continuing to accept quoted prompt text as a single positional argument.
- Rejecting unknown root flags before loading runtime modules.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. CLI argument parsing change only.

### Additional Notes

The pre-commit hook also ran `bun run types` and Biome on the staged CLI files during commit creation.
