### PR TITLE
feat(cli): add hub marketplace

### DIFF
--- a/apps/cli/src/commands/skill.test.ts
+++ b/apps/cli/src/commands/skill.test.ts
@@ -10,7 +10,7 @@ describe("buildSkillsArgs", () => {
 		expect(buildSkillsArgs(["install", "owner/repo"])).toEqual([
 			"-y",
 			"skills@latest",
-			"install",
+			"add",
 			"owner/repo",
 			"--agent",
 			"cline",
@@ -18,6 +18,17 @@ describe("buildSkillsArgs", () => {
 		expect(buildSkillsArgs(["add", "owner/repo"])).toContain("cline");
 		expect(buildSkillsArgs(["i", "owner/repo"])).toContain("cline");
 		expect(buildSkillsArgs(["update", "owner/repo"])).toContain("cline");
+	});
+
+	it("aliases uninstall to the skills remove subcommand", () => {
+		expect(buildSkillsArgs(["uninstall", "my-skill"])).toEqual([
+			"-y",
+			"skills@latest",
+			"remove",
+			"my-skill",
+			"--agent",
+			"cline",
+		]);
 	});
 
 	it("does not inject when the user already targeted an agent", () => {
@@ -32,10 +43,37 @@ describe("buildSkillsArgs", () => {
 		).not.toContain("cline");
 	});
 
+	it("aliases install and uninstall when agent options come before the subcommand", () => {
+		expect(
+			buildSkillsArgs(["--agent", "cursor", "install", "owner/repo"]),
+		).toEqual([
+			"-y",
+			"skills@latest",
+			"--agent",
+			"cursor",
+			"add",
+			"owner/repo",
+		]);
+		expect(
+			buildSkillsArgs(["--agent=cursor", "uninstall", "my-skill"]),
+		).toEqual(["-y", "skills@latest", "--agent=cursor", "remove", "my-skill"]);
+	});
+
 	it("does not scope non-install subcommands to cline", () => {
 		expect(buildSkillsArgs(["use", "owner/repo"])).not.toContain("--agent");
-		expect(buildSkillsArgs(["remove"])).not.toContain("--agent");
 		expect(buildSkillsArgs(["list"])).not.toContain("--agent");
+	});
+
+	it("scopes remove-style subcommands to cline", () => {
+		expect(buildSkillsArgs(["remove"])).toEqual([
+			"-y",
+			"skills@latest",
+			"remove",
+			"--agent",
+			"cline",
+		]);
+		expect(buildSkillsArgs(["rm", "my-skill"])).toContain("cline");
+		expect(buildSkillsArgs(["r", "my-skill"])).toContain("cline");
 	});
 
 	it("ignores leading flags when detecting the subcommand", () => {

--- a/apps/cli/src/commands/skill.ts
+++ b/apps/cli/src/commands/skill.ts
@@ -16,7 +16,21 @@ const SKILLS_PACKAGE = "skills@latest";
 // own agent. `use` is intentionally excluded: without --agent it prints the
 // generated prompt to stdout, whereas adding --agent would launch that agent
 // interactively instead — not what someone scoping to Cline would expect.
-const CLINE_SCOPED_SUBCOMMANDS = new Set(["add", "install", "i", "update"]);
+const CLINE_SCOPED_SUBCOMMANDS = new Set([
+	"add",
+	"install",
+	"i",
+	"update",
+	"remove",
+	"rm",
+	"r",
+	"uninstall",
+]);
+
+const SKILLS_SUBCOMMAND_ALIASES = new Map([
+	["install", "add"],
+	["uninstall", "remove"],
+]);
 
 function hasAgentFlag(args: readonly string[]): boolean {
 	return args.some(
@@ -24,8 +38,36 @@ function hasAgentFlag(args: readonly string[]): boolean {
 	);
 }
 
+function optionConsumesNextValue(arg: string): boolean {
+	return arg === "-a" || arg === "--agent";
+}
+
+function findSubcommandIndex(args: readonly string[]): number {
+	for (let index = 0; index < args.length; index++) {
+		const arg = args[index];
+		if (arg.startsWith("-")) {
+			if (optionConsumesNextValue(arg)) {
+				index++;
+			}
+			continue;
+		}
+		return index;
+	}
+	return -1;
+}
+
 function findSubcommand(args: readonly string[]): string | undefined {
-	return args.find((arg) => !arg.startsWith("-"));
+	const index = findSubcommandIndex(args);
+	return index >= 0 ? args[index] : undefined;
+}
+
+function normalizeSkillsSubcommandAliases(args: string[]): void {
+	const index = findSubcommandIndex(args);
+	if (index < 0) return;
+	const alias = SKILLS_SUBCOMMAND_ALIASES.get(args[index]);
+	if (alias) {
+		args[index] = alias;
+	}
 }
 
 /**
@@ -35,6 +77,7 @@ function findSubcommand(args: readonly string[]): string | undefined {
 export function buildSkillsArgs(userArgs: readonly string[]): string[] {
 	const args = [...userArgs];
 	const subcommand = findSubcommand(args);
+	normalizeSkillsSubcommandAliases(args);
 	if (
 		subcommand &&
 		CLINE_SCOPED_SUBCOMMANDS.has(subcommand) &&

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -324,10 +324,12 @@ export async function runCli(): Promise<void> {
 		.addHelpText(
 			"after",
 			"\nForwards to the open skills CLI via npx. Examples:\n" +
-				"  cline skill install <owner/repo>   Install a skill into Cline\n" +
+				"  cline skill add <owner/repo>       Add a skill into Cline\n" +
+				"  cline skill install <owner/repo>   Alias for add\n" +
 				"  cline skill list                   List installed skills\n" +
 				"  cline skill remove                 Remove installed skills\n" +
-				"\ninstall/add default to '--agent cline' unless you pass your own --agent.\n" +
+				"  cline skill uninstall              Alias for remove\n" +
+				"\nadd/install and remove/uninstall default to '--agent cline' unless you pass your own --agent.\n" +
 				"Run 'npx skills --help' for the full command reference.",
 		)
 		.action(async () => {

--- a/apps/cline-hub/package.json
+++ b/apps/cline-hub/package.json
@@ -12,6 +12,7 @@
 		"dev": "bun run src/dev.ts",
 		"start": "bun run src/server.ts",
 		"smoke:options": "bun run src/validate-options.ts",
+		"test": "bunx vitest run --config vitest.config.ts",
 		"typecheck": "bun tsc -p tsconfig.json --noEmit"
 	},
 	"dependencies": {

--- a/apps/cline-hub/src/server.ts
+++ b/apps/cline-hub/src/server.ts
@@ -22,6 +22,7 @@ import {
 	syncHubClientsAndSessions,
 	syncHubHealth,
 } from "./server/hub";
+import { fetchMarketplaceCatalog } from "./server/marketplace";
 import {
 	loadModels,
 	runProviderOAuthLogin,
@@ -98,6 +99,21 @@ export async function startClineHubDashboardServer(): Promise<ClineHubDashboardS
 			}
 			if (url.pathname === "/config.json") {
 				return createJsonResponse(browserConfig);
+			}
+			if (url.pathname === "/api/marketplace/catalog") {
+				try {
+					return createJsonResponse(await fetchMarketplaceCatalog());
+				} catch (error) {
+					return createJsonResponse(
+						{
+							error:
+								error instanceof Error
+									? error.message
+									: "Failed to fetch marketplace catalog",
+						},
+						502,
+					);
+				}
 			}
 			return assets.serve(url.pathname);
 		},

--- a/apps/cline-hub/src/server/desktop-commands.ts
+++ b/apps/cline-hub/src/server/desktop-commands.ts
@@ -28,6 +28,10 @@ import {
 } from "./connectors";
 import { providerSettingsManager, workspaceRoot } from "./deps";
 import {
+	installMarketplaceEntryForDesktopCommand,
+	listMarketplaceInstalledEntries,
+} from "./marketplace";
+import {
 	deleteMcpServer,
 	ensureMcpSettingsFile,
 	readMcpServersResponse,
@@ -212,6 +216,17 @@ export async function handleDesktopCommand(
 	}
 	if (command === "list_user_instruction_configs") {
 		return await listUserInstructionConfigs(workspaceRoot);
+	}
+	if (command === "list_marketplace_installed_entries") {
+		return listMarketplaceInstalledEntries(
+			args,
+			await listUserInstructionConfigs(workspaceRoot),
+		);
+	}
+	if (command === "install_marketplace_entry") {
+		const result = await installMarketplaceEntryForDesktopCommand(args);
+		broadcastHubState(ctx);
+		return result;
 	}
 	if (command === "toggle_disabled_plugin_tool") {
 		const toolName = String(args?.name ?? "").trim();

--- a/apps/cline-hub/src/server/desktop-commands.ts
+++ b/apps/cline-hub/src/server/desktop-commands.ts
@@ -30,6 +30,7 @@ import { providerSettingsManager, workspaceRoot } from "./deps";
 import {
 	installMarketplaceEntryForDesktopCommand,
 	listMarketplaceInstalledEntries,
+	uninstallMarketplaceEntryForDesktopCommand,
 } from "./marketplace";
 import {
 	deleteMcpServer,
@@ -225,6 +226,11 @@ export async function handleDesktopCommand(
 	}
 	if (command === "install_marketplace_entry") {
 		const result = await installMarketplaceEntryForDesktopCommand(args);
+		broadcastHubState(ctx);
+		return result;
+	}
+	if (command === "uninstall_marketplace_entry") {
+		const result = await uninstallMarketplaceEntryForDesktopCommand(args);
 		broadcastHubState(ctx);
 		return result;
 	}

--- a/apps/cline-hub/src/server/http.test.ts
+++ b/apps/cline-hub/src/server/http.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { isWebviewRoute } from "./http";
+
+describe("isWebviewRoute", () => {
+	it.each([
+		"/marketplace",
+		"/marketplace/mcp",
+		"/marketplace/skills",
+		"/marketplace/plugins",
+	])("matches marketplace SPA route %s", (pathname) => {
+		expect(isWebviewRoute(pathname)).toBe(true);
+	});
+});

--- a/apps/cline-hub/src/server/http.test.ts
+++ b/apps/cline-hub/src/server/http.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isWebviewRoute } from "./http";
+import { isWebviewRoute, normalizeWebviewIndexHtml } from "./http";
 
 describe("isWebviewRoute", () => {
 	it.each([
@@ -9,5 +9,21 @@ describe("isWebviewRoute", () => {
 		"/marketplace/plugins",
 	])("matches marketplace SPA route %s", (pathname) => {
 		expect(isWebviewRoute(pathname)).toBe(true);
+	});
+
+	it("does not treat nested marketplace asset requests as SPA routes", () => {
+		expect(isWebviewRoute("/marketplace/assets/index.js")).toBe(false);
+	});
+});
+
+describe("normalizeWebviewIndexHtml", () => {
+	it("rewrites relative built asset URLs so deep links can refresh", () => {
+		expect(
+			normalizeWebviewIndexHtml(
+				'<script type="module" src="./assets/index.js"></script><link href="./assets/index.css">',
+			),
+		).toBe(
+			'<script type="module" src="/assets/index.js"></script><link href="/assets/index.css">',
+		);
 	});
 });

--- a/apps/cline-hub/src/server/http.ts
+++ b/apps/cline-hub/src/server/http.ts
@@ -44,12 +44,13 @@ function contentTypeFor(path: string): string {
 	}
 }
 
-function isWebviewRoute(pathname: string): boolean {
+export function isWebviewRoute(pathname: string): boolean {
 	return (
 		pathname === "/" ||
 		pathname === "/index.html" ||
 		pathname === "/chat" ||
 		pathname === "/marketplace" ||
+		pathname.startsWith("/marketplace/") ||
 		pathname === "/settings" ||
 		pathname.startsWith("/settings/")
 	);

--- a/apps/cline-hub/src/server/http.ts
+++ b/apps/cline-hub/src/server/http.ts
@@ -50,10 +50,16 @@ export function isWebviewRoute(pathname: string): boolean {
 		pathname === "/index.html" ||
 		pathname === "/chat" ||
 		pathname === "/marketplace" ||
-		pathname.startsWith("/marketplace/") ||
+		pathname === "/marketplace/mcp" ||
+		pathname === "/marketplace/skills" ||
+		pathname === "/marketplace/plugins" ||
 		pathname === "/settings" ||
 		pathname.startsWith("/settings/")
 	);
+}
+
+export function normalizeWebviewIndexHtml(html: string): string {
+	return html.replaceAll('src="./', 'src="/').replaceAll('href="./', 'href="/');
 }
 
 function renderDevIndexHtml(devServerUrl: string): string {
@@ -107,7 +113,7 @@ export class WebviewAssets {
 	private async serveIndex(): Promise<Response> {
 		const indexFile = Bun.file(join(this.webviewDistDir, "index.html"));
 		if (await indexFile.exists()) {
-			return new Response(indexFile, {
+			return new Response(normalizeWebviewIndexHtml(await indexFile.text()), {
 				headers: {
 					"content-type": "text/html; charset=utf-8",
 					...NO_STORE_HEADERS,

--- a/apps/cline-hub/src/server/http.ts
+++ b/apps/cline-hub/src/server/http.ts
@@ -15,6 +15,14 @@ export function createTextResponse(text: string, status = 200): Response {
 	});
 }
 
+const NO_STORE_HEADERS = {
+	"cache-control": "no-store, no-cache, must-revalidate, proxy-revalidate",
+	pragma: "no-cache",
+	expires: "0",
+};
+
+const IMMUTABLE_ASSET_CACHE = "public, max-age=31536000, immutable";
+
 function contentTypeFor(path: string): string {
 	switch (extname(path)) {
 		case ".html":
@@ -41,6 +49,7 @@ function isWebviewRoute(pathname: string): boolean {
 		pathname === "/" ||
 		pathname === "/index.html" ||
 		pathname === "/chat" ||
+		pathname === "/marketplace" ||
 		pathname === "/settings" ||
 		pathname.startsWith("/settings/")
 	);
@@ -74,6 +83,14 @@ function renderDevIndexHtml(devServerUrl: string): string {
 export class WebviewAssets {
 	constructor(private readonly webviewDistDir: string) {}
 
+	private async resolveCurrentMainAssetPath(): Promise<string | undefined> {
+		const indexFile = Bun.file(join(this.webviewDistDir, "index.html"));
+		if (!(await indexFile.exists())) return undefined;
+		const html = await indexFile.text();
+		const match = html.match(/src="\.\/(assets\/index-[^"]+\.js)"/);
+		return match?.[1] ? join(this.webviewDistDir, match[1]) : undefined;
+	}
+
 	private resolveStaticPath(pathname: string): string | undefined {
 		const decoded = decodeURIComponent(pathname);
 		const requested = decoded === "/" ? "/index.html" : decoded;
@@ -90,7 +107,10 @@ export class WebviewAssets {
 		const indexFile = Bun.file(join(this.webviewDistDir, "index.html"));
 		if (await indexFile.exists()) {
 			return new Response(indexFile, {
-				headers: { "content-type": "text/html; charset=utf-8" },
+				headers: {
+					"content-type": "text/html; charset=utf-8",
+					...NO_STORE_HEADERS,
+				},
 			});
 		}
 		return createTextResponse(
@@ -103,7 +123,10 @@ export class WebviewAssets {
 		const devServerUrl = process.env.VITE_DEV_SERVER_URL?.trim();
 		if (devServerUrl && isWebviewRoute(pathname)) {
 			return new Response(renderDevIndexHtml(devServerUrl), {
-				headers: { "content-type": "text/html; charset=utf-8" },
+				headers: {
+					"content-type": "text/html; charset=utf-8",
+					...NO_STORE_HEADERS,
+				},
 			});
 		}
 		if (isWebviewRoute(pathname)) {
@@ -112,12 +135,37 @@ export class WebviewAssets {
 
 		const filePath = this.resolveStaticPath(pathname);
 		if (!filePath) return createTextResponse("not found", 404);
-		const file = Bun.file(filePath);
+		let responsePath = filePath;
+		let file = Bun.file(responsePath);
+		if (
+			!(await file.exists()) &&
+			/^\/assets\/index-[A-Za-z0-9_-]+\.js$/.test(pathname)
+		) {
+			const currentMainAssetPath = await this.resolveCurrentMainAssetPath();
+			if (currentMainAssetPath) {
+				responsePath = currentMainAssetPath;
+				file = Bun.file(responsePath);
+			}
+		}
 		if (!(await file.exists())) {
 			return createTextResponse("not found", 404);
 		}
+		const isHashedAsset = /^\/assets\/.+-[A-Za-z0-9_-]+\.[A-Za-z0-9]+$/.test(
+			pathname,
+		);
 		return new Response(file, {
-			headers: { "content-type": contentTypeFor(filePath) },
+			headers: {
+				"content-type": contentTypeFor(responsePath),
+				"cache-control": isHashedAsset
+					? IMMUTABLE_ASSET_CACHE
+					: NO_STORE_HEADERS["cache-control"],
+				...(isHashedAsset
+					? {}
+					: {
+							pragma: NO_STORE_HEADERS.pragma,
+							expires: NO_STORE_HEADERS.expires,
+						}),
+			},
 		});
 	}
 }

--- a/apps/cline-hub/src/server/marketplace.test.ts
+++ b/apps/cline-hub/src/server/marketplace.test.ts
@@ -675,6 +675,31 @@ describe("marketplace installer", () => {
 		).toEqual({ installedKeys: ["plugin:goal"] });
 	});
 
+	it("does not report plugin inventory substring matches as installed", () => {
+		expect(
+			listMarketplaceInstalledEntries(
+				{
+					entries: [
+						{
+							id: "goal",
+							type: "plugin",
+							name: "Goal",
+							install: { args: ["goal"] },
+						},
+					],
+				},
+				{
+					plugins: [
+						{
+							name: "goal-helper",
+							path: "/workspace/.cline/plugins/goal-helper/index.ts",
+						},
+					],
+				},
+			),
+		).toEqual({ installedKeys: [] });
+	});
+
 	it("skips invalid marketplace entries during installed-status checks", () => {
 		const clineDir = mkdtempSync(join(tmpdir(), "cline-marketplace-test-"));
 		process.env.CLINE_DIR = clineDir;

--- a/apps/cline-hub/src/server/marketplace.test.ts
+++ b/apps/cline-hub/src/server/marketplace.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -9,12 +9,15 @@ import {
 	installMarketplaceEntry,
 	installMarketplaceEntryForDesktopCommand,
 	listMarketplaceInstalledEntries,
+	uninstallMarketplaceEntry,
+	uninstallMarketplaceEntryForDesktopCommand,
 } from "./marketplace";
 
 describe("marketplace installer", () => {
 	const originalWrapperPath = process.env.CLINE_WRAPPER_PATH;
 	const originalClineDir = process.env.CLINE_DIR;
 	const originalHome = process.env.HOME;
+	const originalMcpSettingsPath = process.env.CLINE_MCP_SETTINGS_PATH;
 
 	afterEach(() => {
 		if (originalWrapperPath === undefined) {
@@ -31,6 +34,11 @@ describe("marketplace installer", () => {
 			delete process.env.HOME;
 		} else {
 			process.env.HOME = originalHome;
+		}
+		if (originalMcpSettingsPath === undefined) {
+			delete process.env.CLINE_MCP_SETTINGS_PATH;
+		} else {
+			process.env.CLINE_MCP_SETTINGS_PATH = originalMcpSettingsPath;
 		}
 		vi.restoreAllMocks();
 	});
@@ -230,6 +238,49 @@ describe("marketplace installer", () => {
 		});
 	});
 
+	it("removes Cline global marketplace skills without prompts", async () => {
+		const homeDir = mkdtempSync(join(tmpdir(), "cline-marketplace-home-"));
+		process.env.HOME = homeDir;
+		const skillDir = join(homeDir, ".agents", "skills", "cline-sdk");
+		mkdirSync(skillDir, { recursive: true });
+		writeFileSync(join(skillDir, "SKILL.md"), "---\nname: cline-sdk\n---\n");
+		const spawnCommand = vi.fn(async () => {
+			rmSync(skillDir, { recursive: true, force: true });
+			return {
+				exitCode: 0,
+				stdout: "removed",
+				stderr: "",
+			};
+		});
+
+		await expect(
+			uninstallMarketplaceEntry(
+				{
+					entry: {
+						id: "cline-sdk",
+						type: "skill",
+						name: "Cline SDK",
+						install: { args: ["cline/sdk-skill"] },
+					},
+				},
+				{ spawnCommand },
+			),
+		).resolves.toMatchObject({
+			status: "uninstalled",
+			message: "Uninstalled Cline SDK.",
+		});
+		expect(spawnCommand).toHaveBeenCalledWith("npx", [
+			"-y",
+			"skills@latest",
+			"remove",
+			"cline-sdk",
+			"-g",
+			"-a",
+			"cline",
+			"-y",
+		]);
+	});
+
 	it("does not report project-local skills as marketplace-installed globals", () => {
 		const homeDir = mkdtempSync(join(tmpdir(), "cline-marketplace-home-"));
 		process.env.HOME = homeDir;
@@ -406,6 +457,44 @@ describe("marketplace installer", () => {
 		]);
 	});
 
+	it("runs official plugin uninstalls through the current Cline CLI", async () => {
+		process.env.CLINE_WRAPPER_PATH = "/usr/local/bin/cline";
+		const spawnCommand = vi.fn(async () => ({
+			exitCode: 0,
+			stdout: JSON.stringify({
+				name: "goal",
+				installPath: "/tmp/plugin",
+				removedPaths: ["/tmp/plugin"],
+				entryPaths: [],
+			}),
+			stderr: "",
+		}));
+
+		await expect(
+			uninstallMarketplaceEntry(
+				{
+					entry: {
+						id: "goal",
+						type: "plugin",
+						name: "Goal",
+						install: { args: ["goal"] },
+					},
+				},
+				{ spawnCommand },
+			),
+		).resolves.toMatchObject({
+			status: "uninstalled",
+			message: "Uninstalled Goal.",
+		});
+
+		expect(spawnCommand).toHaveBeenCalledWith("/usr/local/bin/cline", [
+			"plugin",
+			"uninstall",
+			"goal",
+			"--json",
+		]);
+	});
+
 	it("resolves desktop installs from the server catalog instead of browser-sent args", async () => {
 		process.env.CLINE_WRAPPER_PATH = "/usr/local/bin/cline";
 		const spawnCommand = vi.fn(async () => ({
@@ -444,6 +533,116 @@ describe("marketplace installer", () => {
 			"marketplace-test-plugin",
 			"--json",
 		]);
+	});
+
+	it("resolves desktop uninstalls from the server catalog instead of browser-sent args", async () => {
+		process.env.CLINE_WRAPPER_PATH = "/usr/local/bin/cline";
+		const spawnCommand = vi.fn(async () => ({
+			exitCode: 0,
+			stdout: JSON.stringify({
+				name: "goal",
+				installPath: "/tmp/plugin",
+				removedPaths: ["/tmp/plugin"],
+				entryPaths: [],
+			}),
+			stderr: "",
+		}));
+
+		await uninstallMarketplaceEntryForDesktopCommand(
+			{
+				entry: {
+					id: "goal",
+					type: "plugin",
+					name: "Tampered",
+					install: { args: ["malicious-source"] },
+				},
+			},
+			{
+				spawnCommand,
+				loadCatalog: async () => ({
+					entries: [
+						{
+							id: "goal",
+							type: "plugin",
+							name: "Goal",
+							install: { args: ["goal"] },
+						},
+					],
+				}),
+			},
+		);
+
+		expect(spawnCommand).toHaveBeenCalledWith("/usr/local/bin/cline", [
+			"plugin",
+			"uninstall",
+			"goal",
+			"--json",
+		]);
+	});
+
+	it("uninstalls MCP marketplace entries from Cline MCP settings", async () => {
+		const settingsPath = join(
+			mkdtempSync(join(tmpdir(), "cline-marketplace-mcp-")),
+			"cline_mcp_settings.json",
+		);
+		process.env.CLINE_MCP_SETTINGS_PATH = settingsPath;
+		writeFileSync(
+			settingsPath,
+			JSON.stringify(
+				{
+					mcpServers: {
+						context7: {
+							transport: {
+								type: "streamableHttp",
+								url: "https://mcp.context7.com/mcp",
+							},
+						},
+					},
+				},
+				null,
+				2,
+			),
+		);
+
+		await expect(
+			uninstallMarketplaceEntry({
+				entry: {
+					id: "context7",
+					type: "mcp",
+					name: "Context7",
+					install: {
+						args: [
+							"context7",
+							"--transport",
+							"http",
+							"https://mcp.context7.com/mcp",
+						],
+					},
+				},
+			}),
+		).resolves.toMatchObject({
+			status: "uninstalled",
+			message: "Uninstalled Context7.",
+		});
+		expect(
+			listMarketplaceInstalledEntries({
+				entries: [
+					{
+						id: "context7",
+						type: "mcp",
+						name: "Context7",
+						install: {
+							args: [
+								"context7",
+								"--transport",
+								"http",
+								"https://mcp.context7.com/mcp",
+							],
+						},
+					},
+				],
+			}),
+		).toEqual({ installedKeys: [] });
 	});
 
 	it("reports official plugin marketplace entries installed from Cline home", () => {

--- a/apps/cline-hub/src/server/marketplace.test.ts
+++ b/apps/cline-hub/src/server/marketplace.test.ts
@@ -1,0 +1,524 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	buildMarketplaceMcpInput,
+	fetchMarketplaceCatalog,
+	installMarketplaceEntry,
+	installMarketplaceEntryForDesktopCommand,
+	listMarketplaceInstalledEntries,
+} from "./marketplace";
+
+describe("marketplace installer", () => {
+	const originalWrapperPath = process.env.CLINE_WRAPPER_PATH;
+	const originalClineDir = process.env.CLINE_DIR;
+	const originalHome = process.env.HOME;
+
+	afterEach(() => {
+		if (originalWrapperPath === undefined) {
+			delete process.env.CLINE_WRAPPER_PATH;
+		} else {
+			process.env.CLINE_WRAPPER_PATH = originalWrapperPath;
+		}
+		if (originalClineDir === undefined) {
+			delete process.env.CLINE_DIR;
+		} else {
+			process.env.CLINE_DIR = originalClineDir;
+		}
+		if (originalHome === undefined) {
+			delete process.env.HOME;
+		} else {
+			process.env.HOME = originalHome;
+		}
+		vi.restoreAllMocks();
+	});
+
+	it("maps remote MCP catalog args to the hub MCP upsert shape", () => {
+		expect(
+			buildMarketplaceMcpInput([
+				"context7",
+				"--transport",
+				"http",
+				"https://mcp.context7.com/mcp",
+			]),
+		).toEqual({
+			name: "context7",
+			transportType: "streamableHttp",
+			url: "https://mcp.context7.com/mcp",
+			disabled: false,
+		});
+	});
+
+	it("maps stdio MCP catalog args to command and args", () => {
+		expect(
+			buildMarketplaceMcpInput(["filesystem", "npx", "-y", "server", "/tmp"]),
+		).toEqual({
+			name: "filesystem",
+			transportType: "stdio",
+			command: "npx",
+			args: ["-y", "server", "/tmp"],
+			disabled: false,
+		});
+	});
+
+	it("preserves server flags after stdio MCP command args begin", () => {
+		expect(
+			buildMarketplaceMcpInput([
+				"search",
+				"npx",
+				"-y",
+				"server",
+				"--transport",
+				"stdio",
+			]),
+		).toEqual({
+			name: "search",
+			transportType: "stdio",
+			command: "npx",
+			args: ["-y", "server", "--transport", "stdio"],
+			disabled: false,
+		});
+	});
+
+	it("runs skills globally for Cline without prompts", async () => {
+		const homeDir = mkdtempSync(join(tmpdir(), "cline-marketplace-home-"));
+		process.env.HOME = homeDir;
+		const spawnCommand = vi.fn(async () => {
+			mkdirSync(join(homeDir, ".agents", "skills", "web-design-guidelines"), {
+				recursive: true,
+			});
+			writeFileSync(
+				join(homeDir, ".agents", "skills", "web-design-guidelines", "SKILL.md"),
+				"---\nname: web-design-guidelines\n---\n",
+			);
+			return {
+				exitCode: 0,
+				stdout: "installed",
+				stderr: "",
+			};
+		});
+
+		await installMarketplaceEntry(
+			{
+				entry: {
+					id: "web-design-guidelines",
+					type: "skill",
+					name: "Web Design Guidelines",
+					install: {
+						args: [
+							"vercel-labs/agent-skills",
+							"--skill",
+							"web-design-guidelines",
+						],
+					},
+				},
+			},
+			{ spawnCommand },
+		);
+
+		expect(spawnCommand).toHaveBeenCalledWith("npx", [
+			"-y",
+			"skills@latest",
+			"add",
+			"vercel-labs/agent-skills",
+			"--skill",
+			"web-design-guidelines",
+			"-g",
+			"-a",
+			"cline",
+			"-y",
+		]);
+	});
+
+	it("skips skill install commands when the global skill already exists", async () => {
+		const homeDir = mkdtempSync(join(tmpdir(), "cline-marketplace-home-"));
+		process.env.HOME = homeDir;
+		mkdirSync(join(homeDir, ".agents", "skills", "cline-sdk"), {
+			recursive: true,
+		});
+		writeFileSync(
+			join(homeDir, ".agents", "skills", "cline-sdk", "SKILL.md"),
+			"---\nname: cline-sdk\n---\n",
+		);
+		const spawnCommand = vi.fn(async () => ({
+			exitCode: 0,
+			stdout: "",
+			stderr: "",
+		}));
+
+		await expect(
+			installMarketplaceEntry(
+				{
+					entry: {
+						id: "cline-sdk",
+						type: "skill",
+						name: "Cline SDK",
+						install: { args: ["cline/sdk-skill"] },
+					},
+				},
+				{ spawnCommand },
+			),
+		).resolves.toMatchObject({
+			status: "installed",
+			message: "Cline SDK is already installed.",
+		});
+		expect(spawnCommand).not.toHaveBeenCalled();
+	});
+
+	it("reports Cline global skills as marketplace-installed", () => {
+		const clineDir = mkdtempSync(join(tmpdir(), "cline-marketplace-cline-"));
+		process.env.CLINE_DIR = clineDir;
+		mkdirSync(join(clineDir, "skills", "cline-sdk"), {
+			recursive: true,
+		});
+		writeFileSync(
+			join(clineDir, "skills", "cline-sdk", "SKILL.md"),
+			"---\nname: cline-sdk\n---\n",
+		);
+
+		expect(
+			listMarketplaceInstalledEntries({
+				entries: [
+					{
+						id: "cline-sdk",
+						type: "skill",
+						name: "Cline SDK",
+						install: { args: ["cline/sdk-skill"] },
+					},
+				],
+			}),
+		).toEqual({ installedKeys: ["skill:cline-sdk"] });
+	});
+
+	it("accepts skill installs that create Cline global skills", async () => {
+		const homeDir = mkdtempSync(join(tmpdir(), "cline-marketplace-home-"));
+		const clineDir = join(homeDir, ".cline");
+		process.env.HOME = homeDir;
+		process.env.CLINE_DIR = clineDir;
+		const spawnCommand = vi.fn(async () => {
+			mkdirSync(join(clineDir, "skills", "cline-sdk"), {
+				recursive: true,
+			});
+			writeFileSync(
+				join(clineDir, "skills", "cline-sdk", "SKILL.md"),
+				"---\nname: cline-sdk\n---\n",
+			);
+			return {
+				exitCode: 0,
+				stdout: "installed",
+				stderr: "",
+			};
+		});
+
+		await expect(
+			installMarketplaceEntry(
+				{
+					entry: {
+						id: "cline-sdk",
+						type: "skill",
+						name: "Cline SDK",
+						install: { args: ["cline/sdk-skill"] },
+					},
+				},
+				{ spawnCommand },
+			),
+		).resolves.toMatchObject({
+			status: "installed",
+			message: "Installed Cline SDK globally for Cline.",
+		});
+	});
+
+	it("does not report project-local skills as marketplace-installed globals", () => {
+		const homeDir = mkdtempSync(join(tmpdir(), "cline-marketplace-home-"));
+		process.env.HOME = homeDir;
+
+		expect(
+			listMarketplaceInstalledEntries(
+				{
+					entries: [
+						{
+							id: "cline-sdk",
+							type: "skill",
+							name: "Cline SDK",
+							install: { args: ["cline/sdk-skill"] },
+						},
+					],
+				},
+				{
+					skills: [
+						{
+							id: "cline-sdk",
+							name: "cline-sdk",
+							path: "/workspace/project/.agents/skills/cline-sdk/SKILL.md",
+						},
+					],
+				},
+			),
+		).toEqual({ installedKeys: [] });
+	});
+
+	it("rejects skill installs that exit zero but report failure", async () => {
+		const homeDir = mkdtempSync(join(tmpdir(), "cline-marketplace-home-"));
+		process.env.HOME = homeDir;
+		const spawnCommand = vi.fn(async () => ({
+			exitCode: 0,
+			stdout: "Failed to install 1",
+			stderr: "",
+		}));
+
+		await expect(
+			installMarketplaceEntry(
+				{
+					entry: {
+						id: "cline-sdk",
+						type: "skill",
+						name: "Cline SDK",
+						install: { args: ["cline/sdk-skill"] },
+					},
+				},
+				{ spawnCommand },
+			),
+		).rejects.toThrow("Skill install failed");
+	});
+
+	it("redacts common secret formats from failed install output", async () => {
+		const homeDir = mkdtempSync(join(tmpdir(), "cline-marketplace-home-"));
+		process.env.HOME = homeDir;
+		const spawnCommand = vi.fn(async () => ({
+			exitCode: 1,
+			stdout: "Authorization: Bearer stdout-token\napi key stdout-key",
+			stderr: "TOKEN=stderr-token\npassword is stderr-password",
+		}));
+
+		let message = "";
+		try {
+			await installMarketplaceEntry(
+				{
+					entry: {
+						id: "cline-sdk",
+						type: "skill",
+						name: "Cline SDK",
+						install: { args: ["cline/sdk-skill"] },
+					},
+				},
+				{ spawnCommand },
+			);
+		} catch (error) {
+			message = error instanceof Error ? error.message : String(error);
+		}
+
+		expect(message).toContain("Authorization: [redacted]");
+		expect(message).toContain("api key [redacted]");
+		expect(message).toContain("TOKEN=[redacted]");
+		expect(message).toContain("password is [redacted]");
+		expect(message).not.toContain("stdout-token");
+		expect(message).not.toContain("stdout-key");
+		expect(message).not.toContain("stderr-token");
+		expect(message).not.toContain("stderr-password");
+	});
+
+	it("rejects skill installs before spawning when the global skill directory is not writable", async () => {
+		const homeDir = mkdtempSync(join(tmpdir(), "cline-marketplace-home-"));
+		process.env.HOME = homeDir;
+		mkdirSync(join(homeDir, ".agents"), { recursive: true });
+		writeFileSync(join(homeDir, ".agents", "skills"), "");
+		const spawnCommand = vi.fn(async () => ({
+			exitCode: 0,
+			stdout: "",
+			stderr: "",
+		}));
+
+		await expect(
+			installMarketplaceEntry(
+				{
+					entry: {
+						id: "cline-sdk",
+						type: "skill",
+						name: "Cline SDK",
+						install: { args: ["cline/sdk-skill"] },
+					},
+				},
+				{ spawnCommand },
+			),
+		).rejects.toThrow(
+			"Cannot install skill globally because ~/.agents/skills is not writable",
+		);
+		expect(spawnCommand).not.toHaveBeenCalled();
+	});
+
+	it("rejects skill installs that do not create a global skill", async () => {
+		const homeDir = mkdtempSync(join(tmpdir(), "cline-marketplace-home-"));
+		process.env.HOME = homeDir;
+		const spawnCommand = vi.fn(async () => ({
+			exitCode: 0,
+			stdout: "Installation complete",
+			stderr: "",
+		}));
+
+		await expect(
+			installMarketplaceEntry(
+				{
+					entry: {
+						id: "cline-sdk",
+						type: "skill",
+						name: "Cline SDK",
+						install: { args: ["cline/sdk-skill"] },
+					},
+				},
+				{ spawnCommand },
+			),
+		).rejects.toThrow("was not found in Cline's global skills directories");
+	});
+
+	it("runs official plugin installs through the current Cline CLI", async () => {
+		process.env.CLINE_WRAPPER_PATH = "/usr/local/bin/cline";
+		const spawnCommand = vi.fn(async () => ({
+			exitCode: 0,
+			stdout: JSON.stringify({ installPath: "/tmp/plugin" }),
+			stderr: "",
+		}));
+
+		await installMarketplaceEntry(
+			{
+				entry: {
+					id: "marketplace-test-plugin",
+					type: "plugin",
+					name: "Marketplace Test Plugin",
+					install: { args: ["marketplace-test-plugin"] },
+				},
+			},
+			{ spawnCommand },
+		);
+
+		expect(spawnCommand).toHaveBeenCalledWith("/usr/local/bin/cline", [
+			"plugin",
+			"install",
+			"marketplace-test-plugin",
+			"--json",
+		]);
+	});
+
+	it("resolves desktop installs from the server catalog instead of browser-sent args", async () => {
+		process.env.CLINE_WRAPPER_PATH = "/usr/local/bin/cline";
+		const spawnCommand = vi.fn(async () => ({
+			exitCode: 0,
+			stdout: JSON.stringify({ installPath: "/tmp/plugin" }),
+			stderr: "",
+		}));
+
+		await installMarketplaceEntryForDesktopCommand(
+			{
+				entry: {
+					id: "marketplace-test-plugin",
+					type: "plugin",
+					name: "Tampered",
+					install: { args: ["malicious-source"] },
+				},
+			},
+			{
+				spawnCommand,
+				loadCatalog: async () => ({
+					entries: [
+						{
+							id: "marketplace-test-plugin",
+							type: "plugin",
+							name: "Marketplace Test Plugin",
+							install: { args: ["marketplace-test-plugin"] },
+						},
+					],
+				}),
+			},
+		);
+
+		expect(spawnCommand).toHaveBeenCalledWith("/usr/local/bin/cline", [
+			"plugin",
+			"install",
+			"marketplace-test-plugin",
+			"--json",
+		]);
+	});
+
+	it("reports official plugin marketplace entries installed from Cline home", () => {
+		const clineDir = mkdtempSync(join(tmpdir(), "cline-marketplace-test-"));
+		process.env.CLINE_DIR = clineDir;
+		const sourceKey =
+			"official:https://github.com/cline/plugins.git#plugins/goal";
+		const hash = createHash("sha256")
+			.update(sourceKey)
+			.digest("hex")
+			.slice(0, 12);
+		mkdirSync(
+			join(clineDir, "plugins", "_installed", "official", `goal-${hash}`),
+			{
+				recursive: true,
+			},
+		);
+
+		expect(
+			listMarketplaceInstalledEntries({
+				entries: [
+					{
+						id: "goal",
+						type: "plugin",
+						name: "Goal",
+						install: { args: ["goal"] },
+					},
+				],
+			}),
+		).toEqual({ installedKeys: ["plugin:goal"] });
+	});
+
+	it("rejects invalid marketplace entries before spawning commands", async () => {
+		const spawnCommand = vi.fn(async () => ({
+			exitCode: 0,
+			stdout: "",
+			stderr: "",
+		}));
+
+		await expect(
+			installMarketplaceEntry(
+				{
+					entry: {
+						id: "bad",
+						type: "skill",
+						install: { args: [] },
+					},
+				},
+				{ spawnCommand },
+			),
+		).rejects.toThrow("marketplace install args are required");
+		expect(spawnCommand).not.toHaveBeenCalled();
+	});
+
+	it("fetches the marketplace catalog through the server helper", async () => {
+		const fetchImpl = vi.fn(async () => {
+			return new Response(JSON.stringify({ version: 1, entries: [] }), {
+				headers: { "content-type": "application/json" },
+			});
+		});
+
+		await expect(fetchMarketplaceCatalog(fetchImpl)).resolves.toEqual({
+			version: 1,
+			entries: [],
+		});
+		expect(fetchImpl).toHaveBeenCalledWith(
+			"https://cline.github.io/marketplace/catalog.json",
+			{ headers: { Accept: "application/json" } },
+		);
+	});
+
+	it("surfaces marketplace catalog upstream failures", async () => {
+		const fetchImpl = vi.fn(async () => {
+			return new Response("nope", {
+				status: 503,
+				statusText: "Service Unavailable",
+			});
+		});
+
+		await expect(fetchMarketplaceCatalog(fetchImpl)).rejects.toThrow(
+			"Failed to fetch marketplace catalog: 503 Service Unavailable",
+		);
+	});
+});

--- a/apps/cline-hub/src/server/marketplace.test.ts
+++ b/apps/cline-hub/src/server/marketplace.test.ts
@@ -288,8 +288,10 @@ describe("marketplace installer", () => {
 		process.env.HOME = homeDir;
 		const spawnCommand = vi.fn(async () => ({
 			exitCode: 1,
-			stdout: "Authorization: Bearer stdout-token\napi key stdout-key",
-			stderr: "TOKEN=stderr-token\npassword is stderr-password",
+			stdout:
+				"Authorization: Bearer stdout-token\napi key stdout-key\nOPENAI_API_KEY=compound-key",
+			stderr:
+				"TOKEN=stderr-token\npassword is stderr-password\nANTHROPIC_SECRET_KEY=anthropic-secret",
 		}));
 
 		let message = "";
@@ -311,12 +313,16 @@ describe("marketplace installer", () => {
 
 		expect(message).toContain("Authorization: [redacted]");
 		expect(message).toContain("api key [redacted]");
+		expect(message).toContain("OPENAI_API_KEY=[redacted]");
 		expect(message).toContain("TOKEN=[redacted]");
 		expect(message).toContain("password is [redacted]");
+		expect(message).toContain("ANTHROPIC_SECRET_KEY=[redacted]");
 		expect(message).not.toContain("stdout-token");
 		expect(message).not.toContain("stdout-key");
+		expect(message).not.toContain("compound-key");
 		expect(message).not.toContain("stderr-token");
 		expect(message).not.toContain("stderr-password");
+		expect(message).not.toContain("anthropic-secret");
 	});
 
 	it("rejects skill installs before spawning when the global skill directory is not writable", async () => {
@@ -459,6 +465,49 @@ describe("marketplace installer", () => {
 		expect(
 			listMarketplaceInstalledEntries({
 				entries: [
+					{
+						id: "goal",
+						type: "plugin",
+						name: "Goal",
+						install: { args: ["goal"] },
+					},
+				],
+			}),
+		).toEqual({ installedKeys: ["plugin:goal"] });
+	});
+
+	it("skips invalid marketplace entries during installed-status checks", () => {
+		const clineDir = mkdtempSync(join(tmpdir(), "cline-marketplace-test-"));
+		process.env.CLINE_DIR = clineDir;
+		const sourceKey =
+			"official:https://github.com/cline/plugins.git#plugins/goal";
+		const hash = createHash("sha256")
+			.update(sourceKey)
+			.digest("hex")
+			.slice(0, 12);
+		mkdirSync(
+			join(clineDir, "plugins", "_installed", "official", `goal-${hash}`),
+			{
+				recursive: true,
+			},
+		);
+
+		expect(
+			listMarketplaceInstalledEntries({
+				entries: [
+					{
+						id: "broken-mcp",
+						type: "mcp",
+						name: "Broken MCP",
+						install: {
+							args: [
+								"broken-mcp",
+								"--transport",
+								"ws",
+								"https://example.com/mcp",
+							],
+						},
+					},
 					{
 						id: "goal",
 						type: "plugin",

--- a/apps/cline-hub/src/server/marketplace.ts
+++ b/apps/cline-hub/src/server/marketplace.ts
@@ -35,7 +35,6 @@ type MarketplaceInstallResult = {
 	message: string;
 	details?: JsonRecord;
 	output?: string;
-	warnings?: string[];
 };
 
 type MarketplaceInstallStatusResult = {
@@ -67,14 +66,6 @@ const MARKETPLACE_CATALOG_URL =
 	"https://cline.github.io/marketplace/catalog.json";
 const SECRET_PATTERN =
 	/(api[_ -]?key|access[_ -]?token|refresh[_ -]?token|auth(?:orization)?[_ -]?token|token|secret|password|authorization|credential)/i;
-const DEBUG_MARKETPLACE =
-	process.env.CLINE_HUB_DEBUG === "1" ||
-	process.env.CLINE_HUB_DEBUG?.toLowerCase() === "true";
-
-function logMarketplace(message: string, details?: Record<string, unknown>) {
-	if (!DEBUG_MARKETPLACE) return;
-	console.info("[marketplace]", message, details ?? {});
-}
 
 export async function fetchMarketplaceCatalog(
 	fetchImpl: CatalogFetch = fetch,
@@ -236,11 +227,6 @@ const defaultSpawnCommand: SpawnCommand = async (command, args, options = {}) =>
 	new Promise<SpawnResult>((resolve, reject) => {
 		let settled = false;
 		let timedOut = false;
-		const startedAt = Date.now();
-		logMarketplace("spawn-start", {
-			command,
-			args: args.map((arg) => (SECRET_PATTERN.test(arg) ? "[redacted]" : arg)),
-		});
 		const child = spawn(command, args, {
 			...options,
 			env: options.env ?? process.env,
@@ -277,11 +263,6 @@ const defaultSpawnCommand: SpawnCommand = async (command, args, options = {}) =>
 		child.once("error", (error) => {
 			clearTimeout(timeout);
 			clearTimeout(forceKillTimeout);
-			logMarketplace("spawn-error", {
-				command,
-				elapsedMs: Date.now() - startedAt,
-				error: error.message,
-			});
 			reject(error);
 		});
 		child.once("close", (code, signal) => {
@@ -293,15 +274,6 @@ const defaultSpawnCommand: SpawnCommand = async (command, args, options = {}) =>
 				stdout,
 				stderr,
 			};
-			logMarketplace("spawn-close", {
-				command,
-				exitCode: result.exitCode,
-				signal,
-				timedOut,
-				elapsedMs: Date.now() - startedAt,
-				stdoutChars: stdout.length,
-				stderrChars: stderr.length,
-			});
 			resolve(result);
 		});
 	});
@@ -443,14 +415,7 @@ function isOfficialPluginInstalled(entry: MarketplaceInstallInput): boolean {
 	const [source] = entry.install.args ?? [];
 	if (!source) return false;
 	const installPath = getOfficialPluginInstallPath(source);
-	const installed = Boolean(installPath && existsSync(installPath));
-	logMarketplace("plugin-installed-check", {
-		id: entry.id,
-		source,
-		installPath,
-		installed,
-	});
-	return installed;
+	return Boolean(installPath && existsSync(installPath));
 }
 
 function normalizeMatchValue(value: string | undefined): string {
@@ -515,14 +480,7 @@ function isGlobalSkillInstalled(entry: MarketplaceInstallInput): boolean {
 	if (entry.type !== "skill") return false;
 	const candidates = getSkillInstallCandidates(entry);
 	const checkedPaths = candidates.flatMap(getGlobalSkillPaths);
-	const installed = checkedPaths.some((path) => existsSync(path));
-	logMarketplace("skill-installed-check", {
-		id: entry.id,
-		candidates,
-		checkedPaths,
-		installed,
-	});
-	return installed;
+	return checkedPaths.some((path) => existsSync(path));
 }
 
 function hasMatchingInventoryItem(
@@ -595,10 +553,6 @@ async function installSkill(
 	spawnCommand: SpawnCommand,
 ): Promise<MarketplaceInstallResult> {
 	if (isGlobalSkillInstalled(entry)) {
-		logMarketplace("skill-install-skip-installed", {
-			id: entry.id,
-			name: entry.name,
-		});
 		return {
 			id: entry.id,
 			type: entry.type,
@@ -606,10 +560,6 @@ async function installSkill(
 			message: `${entry.name ?? entry.id} is already installed.`,
 		};
 	}
-	logMarketplace("skill-install-start", {
-		id: entry.id,
-		name: entry.name,
-	});
 	ensureGlobalSkillsDirWritable();
 	const result = await spawnCommand("npx", [
 		"-y",
@@ -655,11 +605,6 @@ async function installPlugin(
 		);
 	}
 	if (isOfficialPluginInstalled(entry)) {
-		logMarketplace("plugin-install-skip-installed", {
-			id: entry.id,
-			name: entry.name,
-			source: installArgs[0],
-		});
 		return {
 			id: entry.id,
 			type: entry.type,
@@ -668,13 +613,6 @@ async function installPlugin(
 		};
 	}
 	const { command, argsPrefix } = resolveClineInvocation();
-	logMarketplace("plugin-install-start", {
-		id: entry.id,
-		name: entry.name,
-		source: installArgs[0],
-		command,
-		argsPrefix,
-	});
 	const result = await spawnCommand(command, [
 		...argsPrefix,
 		"plugin",
@@ -710,11 +648,6 @@ export async function installMarketplaceEntry(
 	options: { spawnCommand?: SpawnCommand } = {},
 ): Promise<MarketplaceInstallResult> {
 	const entry = readInstallInput(args);
-	logMarketplace("install-entry", {
-		id: entry.id,
-		type: entry.type,
-		name: entry.name,
-	});
 	const spawnCommand = options.spawnCommand ?? defaultSpawnCommand;
 	if (entry.type === "mcp") {
 		const input = buildMarketplaceMcpInput(entry.install.args ?? []);
@@ -768,16 +701,6 @@ export function listMarketplaceInstalledEntries(
 	const installedKeys = entries
 		.filter((entry) => isMarketplaceEntryInstalled(entry, inventory))
 		.map(marketplaceEntryKey);
-	logMarketplace("list-installed", {
-		entryCount: entries.length,
-		installedKeys,
-		inventorySkillCount: Array.isArray(inventory?.skills)
-			? inventory.skills.length
-			: undefined,
-		inventoryPluginCount: Array.isArray(inventory?.plugins)
-			? inventory.plugins.length
-			: undefined,
-	});
 	return { installedKeys };
 }
 

--- a/apps/cline-hub/src/server/marketplace.ts
+++ b/apps/cline-hub/src/server/marketplace.ts
@@ -515,11 +515,7 @@ function hasMatchingInventoryItem(
 		]
 			.map(normalizeMatchValue)
 			.filter(Boolean);
-		return values.some((value) =>
-			[...candidates].some(
-				(candidate) => value === candidate || value.includes(candidate),
-			),
-		);
+		return values.some((value) => candidates.has(value));
 	});
 }
 

--- a/apps/cline-hub/src/server/marketplace.ts
+++ b/apps/cline-hub/src/server/marketplace.ts
@@ -4,7 +4,11 @@ import { existsSync, mkdirSync, unlinkSync, writeFileSync } from "node:fs";
 import { homedir, platform } from "node:os";
 import { join } from "node:path";
 import { resolveClineDir } from "@cline/shared/storage";
-import { readMcpServersResponse, upsertMcpServer } from "./mcp";
+import {
+	deleteMcpServer,
+	readMcpServersResponse,
+	upsertMcpServer,
+} from "./mcp";
 import type { JsonRecord } from "./types";
 
 type MarketplacePrimitiveType = "mcp" | "skill" | "plugin";
@@ -31,7 +35,7 @@ type MarketplaceInstallInput = {
 type MarketplaceInstallResult = {
 	id: string;
 	type: MarketplacePrimitiveType;
-	status: "installed";
+	status: "installed" | "uninstalled";
 	message: string;
 	details?: JsonRecord;
 	output?: string;
@@ -477,10 +481,17 @@ function ensureGlobalSkillsDirWritable(): void {
 }
 
 function isGlobalSkillInstalled(entry: MarketplaceInstallInput): boolean {
-	if (entry.type !== "skill") return false;
+	return findInstalledGlobalSkillName(entry) !== undefined;
+}
+
+function findInstalledGlobalSkillName(
+	entry: MarketplaceInstallInput,
+): string | undefined {
+	if (entry.type !== "skill") return undefined;
 	const candidates = getSkillInstallCandidates(entry);
-	const checkedPaths = candidates.flatMap(getGlobalSkillPaths);
-	return checkedPaths.some((path) => existsSync(path));
+	return candidates.find((candidate) =>
+		getGlobalSkillPaths(candidate).some((path) => existsSync(path)),
+	);
 }
 
 function hasMatchingInventoryItem(
@@ -599,6 +610,50 @@ async function installSkill(
 	};
 }
 
+async function uninstallSkill(
+	entry: MarketplaceInstallInput,
+	spawnCommand: SpawnCommand,
+): Promise<MarketplaceInstallResult> {
+	const installedName = findInstalledGlobalSkillName(entry);
+	if (!installedName) {
+		return {
+			id: entry.id,
+			type: entry.type,
+			status: "uninstalled",
+			message: `${entry.name ?? entry.id} is not installed.`,
+		};
+	}
+	const result = await spawnCommand("npx", [
+		"-y",
+		"skills@latest",
+		"remove",
+		installedName,
+		"-g",
+		"-a",
+		"cline",
+		"-y",
+	]);
+	if (result.exitCode !== 0) {
+		const output = commandOutput(result);
+		throw new Error(
+			`Skill uninstall failed with exit code ${result.exitCode}${output ? `:\n${output}` : ""}`,
+		);
+	}
+	const output = commandOutput(result);
+	if (isGlobalSkillInstalled(entry)) {
+		throw new Error(
+			`Skill uninstall completed, but ${entry.name ?? entry.id} is still present in Cline's global skills directories.`,
+		);
+	}
+	return {
+		id: entry.id,
+		type: entry.type,
+		status: "uninstalled",
+		message: `Uninstalled ${entry.name ?? entry.id}.`,
+		output,
+	};
+}
+
 async function installPlugin(
 	entry: MarketplaceInstallInput,
 	spawnCommand: SpawnCommand,
@@ -649,6 +704,47 @@ async function installPlugin(
 	};
 }
 
+async function uninstallPlugin(
+	entry: MarketplaceInstallInput,
+	spawnCommand: SpawnCommand,
+): Promise<MarketplaceInstallResult> {
+	const installArgs = entry.install.args ?? [];
+	const target = installArgs[0]?.trim() || entry.id;
+	if (!target) {
+		throw new Error("Plugin marketplace uninstalls require a plugin name.");
+	}
+	const { command, argsPrefix } = resolveClineInvocation();
+	const result = await spawnCommand(command, [
+		...argsPrefix,
+		"plugin",
+		"uninstall",
+		target,
+		"--json",
+	]);
+	if (result.exitCode !== 0) {
+		const output = commandOutput(result);
+		throw new Error(
+			`Plugin uninstall failed with exit code ${result.exitCode}${output ? `:\n${output}` : ""}`,
+		);
+	}
+	let details: JsonRecord | undefined;
+	try {
+		details = result.stdout.trim()
+			? (JSON.parse(result.stdout.trim()) as JsonRecord)
+			: undefined;
+	} catch {
+		details = undefined;
+	}
+	return {
+		id: entry.id,
+		type: entry.type,
+		status: "uninstalled",
+		message: `Uninstalled ${entry.name ?? entry.id}.`,
+		details,
+		output: commandOutput(result),
+	};
+}
+
 export async function installMarketplaceEntry(
 	args?: Record<string, unknown>,
 	options: { spawnCommand?: SpawnCommand } = {},
@@ -671,6 +767,32 @@ export async function installMarketplaceEntry(
 	}
 	if (entry.type === "plugin") {
 		return installPlugin(entry, spawnCommand);
+	}
+	throw new Error(`Unsupported marketplace entry type: ${entry.type}`);
+}
+
+export async function uninstallMarketplaceEntry(
+	args?: Record<string, unknown>,
+	options: { spawnCommand?: SpawnCommand } = {},
+): Promise<MarketplaceInstallResult> {
+	const entry = readInstallInput(args);
+	const spawnCommand = options.spawnCommand ?? defaultSpawnCommand;
+	if (entry.type === "mcp") {
+		const input = buildMarketplaceMcpInput(entry.install.args ?? []);
+		const response = deleteMcpServer(String(input.name ?? ""));
+		return {
+			id: entry.id,
+			type: entry.type,
+			status: "uninstalled",
+			message: `Uninstalled ${entry.name ?? input.name ?? entry.id}.`,
+			details: { mcp: response },
+		};
+	}
+	if (entry.type === "skill") {
+		return uninstallSkill(entry, spawnCommand);
+	}
+	if (entry.type === "plugin") {
+		return uninstallPlugin(entry, spawnCommand);
 	}
 	throw new Error(`Unsupported marketplace entry type: ${entry.type}`);
 }
@@ -699,6 +821,30 @@ export async function installMarketplaceEntryFromCatalog(
 	);
 }
 
+export async function uninstallMarketplaceEntryFromCatalog(
+	args?: Record<string, unknown>,
+	options: {
+		spawnCommand?: SpawnCommand;
+		loadCatalog?: CatalogLoader;
+	} = {},
+): Promise<MarketplaceInstallResult> {
+	const requested = readInstallRequest(args);
+	const catalog = await (options.loadCatalog ?? fetchMarketplaceCatalog)();
+	const entry = readCatalogEntries(catalog).find(
+		(candidate) =>
+			candidate.id === requested.id && candidate.type === requested.type,
+	);
+	if (!entry) {
+		throw new Error(
+			`Marketplace entry ${requested.type}:${requested.id} was not found in the catalog.`,
+		);
+	}
+	return uninstallMarketplaceEntry(
+		{ entry },
+		{ spawnCommand: options.spawnCommand },
+	);
+}
+
 export function listMarketplaceInstalledEntries(
 	args?: Record<string, unknown>,
 	inventory?: JsonRecord,
@@ -718,4 +864,14 @@ export async function installMarketplaceEntryForDesktopCommand(
 	} = {},
 ): Promise<MarketplaceInstallResult> {
 	return installMarketplaceEntryFromCatalog(args, options);
+}
+
+export async function uninstallMarketplaceEntryForDesktopCommand(
+	args?: Record<string, unknown>,
+	options: {
+		spawnCommand?: SpawnCommand;
+		loadCatalog?: CatalogLoader;
+	} = {},
+): Promise<MarketplaceInstallResult> {
+	return uninstallMarketplaceEntryFromCatalog(args, options);
 }

--- a/apps/cline-hub/src/server/marketplace.ts
+++ b/apps/cline-hub/src/server/marketplace.ts
@@ -211,12 +211,12 @@ function redactOutput(value: string): string {
 		if (!SECRET_PATTERN.test(line)) return line;
 		return line
 			.replace(
-				/(\b(?:api[_ -]?key|token|secret|password|authorization|credential)\b\s*[:=]\s*)(.+)$/gi,
+				/((?:^|[^\w])(?:[a-z0-9_]*?(?:api[_ -]?key|access[_ -]?token|refresh[_ -]?token|auth(?:orization)?[_ -]?token|token|secret|password|authorization|credential)[a-z0-9_]*)\s*[:=]\s*)(.+)$/gi,
 				"$1[redacted]",
 			)
 			.replace(/\b(Bearer)\s+\S+/gi, "$1 [redacted]")
 			.replace(
-				/(\b(?:api\s+key|access\s+token|refresh\s+token|auth(?:orization)?\s+token|secret|password|credential)\s+(?:is\s+)?)(\S+)/gi,
+				/((?:^|[^\w])(?:api\s+key|access\s+token|refresh\s+token|auth(?:orization)?\s+token|secret|password|credential)\s+(?:is\s+)?)(\S+)/gi,
 				"$1[redacted]",
 			);
 	});
@@ -528,17 +528,21 @@ function isMarketplaceEntryInstalled(
 	entry: MarketplaceInstallInput,
 	inventory?: JsonRecord,
 ): boolean {
-	if (entry.type === "mcp") return isMcpEntryInstalled(entry);
-	if (entry.type === "plugin") {
-		return (
-			isOfficialPluginInstalled(entry) ||
-			hasMatchingInventoryItem(inventory?.plugins, entry)
-		);
+	try {
+		if (entry.type === "mcp") return isMcpEntryInstalled(entry);
+		if (entry.type === "plugin") {
+			return (
+				isOfficialPluginInstalled(entry) ||
+				hasMatchingInventoryItem(inventory?.plugins, entry)
+			);
+		}
+		if (entry.type === "skill") {
+			return isGlobalSkillInstalled(entry);
+		}
+		return false;
+	} catch {
+		return false;
 	}
-	if (entry.type === "skill") {
-		return isGlobalSkillInstalled(entry);
-	}
-	return false;
 }
 
 function commandOutput(result: SpawnResult): string | undefined {
@@ -572,8 +576,9 @@ async function installSkill(
 		"-y",
 	]);
 	if (result.exitCode !== 0) {
+		const output = commandOutput(result);
 		throw new Error(
-			`Skill install failed with exit code ${result.exitCode}${commandOutput(result) ? `:\n${commandOutput(result)}` : ""}`,
+			`Skill install failed with exit code ${result.exitCode}${output ? `:\n${output}` : ""}`,
 		);
 	}
 	const output = commandOutput(result);
@@ -621,8 +626,9 @@ async function installPlugin(
 		"--json",
 	]);
 	if (result.exitCode !== 0) {
+		const output = commandOutput(result);
 		throw new Error(
-			`Plugin install failed with exit code ${result.exitCode}${commandOutput(result) ? `:\n${commandOutput(result)}` : ""}`,
+			`Plugin install failed with exit code ${result.exitCode}${output ? `:\n${output}` : ""}`,
 		);
 	}
 	let details: JsonRecord | undefined;

--- a/apps/cline-hub/src/server/marketplace.ts
+++ b/apps/cline-hub/src/server/marketplace.ts
@@ -1,0 +1,792 @@
+import { type SpawnOptions, spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { homedir, platform } from "node:os";
+import { join } from "node:path";
+import { resolveClineDir } from "@cline/shared/storage";
+import { readMcpServersResponse, upsertMcpServer } from "./mcp";
+import type { JsonRecord } from "./types";
+
+type MarketplacePrimitiveType = "mcp" | "skill" | "plugin";
+
+type MarketplaceEnvVar = {
+	name: string;
+	required?: boolean;
+	description?: string;
+	url?: string;
+};
+
+type MarketplaceInstallInput = {
+	id: string;
+	type: MarketplacePrimitiveType;
+	name?: string;
+	install: {
+		args?: string[];
+		env?: MarketplaceEnvVar[];
+		command?: string;
+		notes?: string;
+	};
+};
+
+type MarketplaceInstallResult = {
+	id: string;
+	type: MarketplacePrimitiveType;
+	status: "installed";
+	message: string;
+	details?: JsonRecord;
+	output?: string;
+	warnings?: string[];
+};
+
+type MarketplaceInstallStatusResult = {
+	installedKeys: string[];
+};
+
+type SpawnResult = {
+	exitCode: number;
+	stdout: string;
+	stderr: string;
+};
+
+type SpawnCommand = (
+	command: string,
+	args: string[],
+	options?: SpawnOptions,
+) => Promise<SpawnResult>;
+type CatalogFetch = (
+	input: string | URL | Request,
+	init?: RequestInit,
+) => Promise<Response>;
+type CatalogLoader = () => Promise<unknown>;
+
+const MAX_OUTPUT_CHARS = 12_000;
+const INSTALL_COMMAND_TIMEOUT_MS = 120_000;
+const OFFICIAL_PLUGINS_REPO = "https://github.com/cline/plugins.git";
+const MARKETPLACE_CATALOG_URL =
+	process.env.CLINE_MARKETPLACE_CATALOG_URL?.trim() ||
+	"https://cline.github.io/marketplace/catalog.json";
+const SECRET_PATTERN =
+	/(api[_ -]?key|access[_ -]?token|refresh[_ -]?token|auth(?:orization)?[_ -]?token|token|secret|password|authorization|credential)/i;
+const DEBUG_MARKETPLACE =
+	process.env.CLINE_HUB_DEBUG === "1" ||
+	process.env.CLINE_HUB_DEBUG?.toLowerCase() === "true";
+
+function logMarketplace(message: string, details?: Record<string, unknown>) {
+	if (!DEBUG_MARKETPLACE) return;
+	console.info("[marketplace]", message, details ?? {});
+}
+
+export async function fetchMarketplaceCatalog(
+	fetchImpl: CatalogFetch = fetch,
+): Promise<unknown> {
+	const response = await fetchImpl(MARKETPLACE_CATALOG_URL, {
+		headers: { Accept: "application/json" },
+	});
+	if (!response.ok) {
+		throw new Error(
+			`Failed to fetch marketplace catalog: ${response.status} ${response.statusText}`.trim(),
+		);
+	}
+	return response.json();
+}
+
+function isPrimitiveType(value: unknown): value is MarketplacePrimitiveType {
+	return value === "mcp" || value === "skill" || value === "plugin";
+}
+
+function toStringArray(value: unknown): string[] {
+	return Array.isArray(value)
+		? value.filter((item): item is string => typeof item === "string")
+		: [];
+}
+
+function readInstallInput(
+	args?: Record<string, unknown>,
+): MarketplaceInstallInput {
+	const entry = readInstallRecord(args);
+	const install =
+		entry.install && typeof entry.install === "object"
+			? (entry.install as Record<string, unknown>)
+			: {};
+	const installArgs = toStringArray(install.args);
+	if (installArgs.length === 0) {
+		throw new Error("marketplace install args are required");
+	}
+	const env = Array.isArray(install.env)
+		? install.env
+				.map((item): MarketplaceEnvVar | null => {
+					if (!item || typeof item !== "object") return null;
+					const candidate = item as Record<string, unknown>;
+					if (typeof candidate.name !== "string") return null;
+					const parsed: MarketplaceEnvVar = {
+						name: candidate.name,
+					};
+					if (typeof candidate.required === "boolean") {
+						parsed.required = candidate.required;
+					}
+					if (typeof candidate.description === "string") {
+						parsed.description = candidate.description;
+					}
+					if (typeof candidate.url === "string") {
+						parsed.url = candidate.url;
+					}
+					return parsed;
+				})
+				.filter((item): item is MarketplaceEnvVar => item !== null)
+		: undefined;
+	return {
+		id: entry.id.trim(),
+		type: entry.type,
+		name: typeof entry.name === "string" ? entry.name : undefined,
+		install: {
+			args: installArgs,
+			command:
+				typeof install.command === "string" ? install.command : undefined,
+			env,
+			notes: typeof install.notes === "string" ? install.notes : undefined,
+		},
+	};
+}
+
+function readInstallRecord(
+	args?: Record<string, unknown>,
+): Record<string, unknown> & { id: string; type: MarketplacePrimitiveType } {
+	const entry =
+		args?.entry && typeof args.entry === "object"
+			? (args.entry as Record<string, unknown>)
+			: (args ?? {});
+	if (typeof entry.id !== "string" || entry.id.trim().length === 0) {
+		throw new Error("marketplace entry id is required");
+	}
+	if (!isPrimitiveType(entry.type)) {
+		throw new Error("marketplace entry type must be mcp, skill, or plugin");
+	}
+	return entry as Record<string, unknown> & {
+		id: string;
+		type: MarketplacePrimitiveType;
+	};
+}
+
+function readInstallRequest(args?: Record<string, unknown>) {
+	const entry = readInstallRecord(args);
+	return {
+		id: entry.id.trim(),
+		type: entry.type,
+	};
+}
+
+function readInstallInputList(
+	args?: Record<string, unknown>,
+): MarketplaceInstallInput[] {
+	const rawEntries = Array.isArray(args?.entries) ? args.entries : [];
+	return rawEntries
+		.map((entry) => {
+			try {
+				return readInstallInput({ entry });
+			} catch {
+				return null;
+			}
+		})
+		.filter((entry): entry is MarketplaceInstallInput => entry !== null);
+}
+
+function readCatalogEntries(catalog: unknown): MarketplaceInstallInput[] {
+	const catalogEntries =
+		catalog && typeof catalog === "object"
+			? (catalog as Record<string, unknown>).entries
+			: undefined;
+	if (!Array.isArray(catalogEntries)) {
+		throw new Error("marketplace catalog entries are required");
+	}
+	return catalogEntries
+		.map((entry) => {
+			try {
+				return readInstallInput({ entry });
+			} catch {
+				return null;
+			}
+		})
+		.filter((entry): entry is MarketplaceInstallInput => entry !== null);
+}
+
+function marketplaceEntryKey(
+	entry: Pick<MarketplaceInstallInput, "id" | "type">,
+) {
+	return `${entry.type}:${entry.id}`;
+}
+
+function redactOutput(value: string): string {
+	const lines = value.split(/\r?\n/).map((line) => {
+		if (!SECRET_PATTERN.test(line)) return line;
+		return line
+			.replace(
+				/(\b(?:api[_ -]?key|token|secret|password|authorization|credential)\b\s*[:=]\s*)(.+)$/gi,
+				"$1[redacted]",
+			)
+			.replace(/\b(Bearer)\s+\S+/gi, "$1 [redacted]")
+			.replace(
+				/(\b(?:api\s+key|access\s+token|refresh\s+token|auth(?:orization)?\s+token|secret|password|credential)\s+(?:is\s+)?)(\S+)/gi,
+				"$1[redacted]",
+			);
+	});
+	return lines.join("\n").slice(-MAX_OUTPUT_CHARS);
+}
+
+const defaultSpawnCommand: SpawnCommand = async (command, args, options = {}) =>
+	new Promise<SpawnResult>((resolve, reject) => {
+		let settled = false;
+		let timedOut = false;
+		const startedAt = Date.now();
+		logMarketplace("spawn-start", {
+			command,
+			args: args.map((arg) => (SECRET_PATTERN.test(arg) ? "[redacted]" : arg)),
+		});
+		const child = spawn(command, args, {
+			...options,
+			env: options.env ?? process.env,
+			shell: options.shell ?? platform() === "win32",
+			stdio: options.stdio ?? ["ignore", "pipe", "pipe"],
+			windowsHide: true,
+		});
+		let stdout = "";
+		let stderr = "";
+		const forceKillTimeout = setTimeout(() => {
+			if (!settled) {
+				child.kill("SIGKILL");
+			}
+		}, INSTALL_COMMAND_TIMEOUT_MS + 5_000);
+		const timeout = setTimeout(() => {
+			timedOut = true;
+			stderr += `\nTimed out after ${INSTALL_COMMAND_TIMEOUT_MS / 1000}s.`;
+			child.kill("SIGTERM");
+		}, INSTALL_COMMAND_TIMEOUT_MS);
+		forceKillTimeout.unref?.();
+		timeout.unref?.();
+		child.stdout?.on("data", (chunk) => {
+			stdout += String(chunk);
+			if (stdout.length > MAX_OUTPUT_CHARS * 2) {
+				stdout = stdout.slice(-MAX_OUTPUT_CHARS);
+			}
+		});
+		child.stderr?.on("data", (chunk) => {
+			stderr += String(chunk);
+			if (stderr.length > MAX_OUTPUT_CHARS * 2) {
+				stderr = stderr.slice(-MAX_OUTPUT_CHARS);
+			}
+		});
+		child.once("error", (error) => {
+			clearTimeout(timeout);
+			clearTimeout(forceKillTimeout);
+			logMarketplace("spawn-error", {
+				command,
+				elapsedMs: Date.now() - startedAt,
+				error: error.message,
+			});
+			reject(error);
+		});
+		child.once("close", (code, signal) => {
+			settled = true;
+			clearTimeout(timeout);
+			clearTimeout(forceKillTimeout);
+			const result = {
+				exitCode: timedOut ? 124 : (code ?? (signal === "SIGINT" ? 130 : 1)),
+				stdout,
+				stderr,
+			};
+			logMarketplace("spawn-close", {
+				command,
+				exitCode: result.exitCode,
+				signal,
+				timedOut,
+				elapsedMs: Date.now() - startedAt,
+				stdoutChars: stdout.length,
+				stderrChars: stderr.length,
+			});
+			resolve(result);
+		});
+	});
+
+function normalizeTransport(value: string | undefined): string {
+	const normalized = (value ?? "stdio").trim();
+	if (normalized === "http" || normalized === "streamable-http") {
+		return "streamableHttp";
+	}
+	if (
+		normalized === "stdio" ||
+		normalized === "sse" ||
+		normalized === "streamableHttp"
+	) {
+		return normalized;
+	}
+	throw new Error(
+		`Unsupported MCP transport "${normalized}". Expected stdio, sse, http, streamable-http, or streamableHttp.`,
+	);
+}
+
+function assertUrl(value: string): void {
+	let parsed: URL;
+	try {
+		parsed = new URL(value);
+	} catch {
+		throw new Error(`Invalid MCP server URL: ${value}`);
+	}
+	if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+		throw new Error(`Invalid MCP server URL: ${value}`);
+	}
+}
+
+export function buildMarketplaceMcpInput(args: string[]): JsonRecord {
+	const [rawName, ...rest] = args;
+	const name = rawName?.trim();
+	if (!name) {
+		throw new Error("MCP marketplace install requires a server name");
+	}
+	let transportType = "stdio";
+	const targetArgs: string[] = [];
+	let parsingMarketplaceOptions = true;
+	for (let index = 0; index < rest.length; index++) {
+		const arg = rest[index];
+		if (parsingMarketplaceOptions && arg === "--") {
+			targetArgs.push(...rest.slice(index + 1));
+			break;
+		}
+		if (parsingMarketplaceOptions && (arg === "--transport" || arg === "-t")) {
+			const next = rest[index + 1]?.trim();
+			if (!next) throw new Error("--transport requires a value");
+			transportType = normalizeTransport(next);
+			index++;
+			continue;
+		}
+		parsingMarketplaceOptions = false;
+		targetArgs.push(arg);
+	}
+	transportType = normalizeTransport(transportType);
+	if (transportType === "stdio") {
+		const [command, ...commandArgs] = targetArgs;
+		if (!command?.trim()) {
+			throw new Error("Stdio MCP install requires a command");
+		}
+		return {
+			name,
+			transportType,
+			command,
+			args: commandArgs.length > 0 ? commandArgs : undefined,
+			disabled: false,
+		};
+	}
+	if (targetArgs.length !== 1) {
+		throw new Error("Remote MCP install requires exactly one URL");
+	}
+	const url = targetArgs[0]?.trim() ?? "";
+	assertUrl(url);
+	return {
+		name,
+		transportType,
+		url,
+		disabled: false,
+	};
+}
+
+function resolveClineInvocation(): { command: string; argsPrefix: string[] } {
+	const wrapperPath = process.env.CLINE_WRAPPER_PATH?.trim();
+	if (wrapperPath) {
+		return { command: wrapperPath, argsPrefix: [] };
+	}
+	const entry = process.argv[1]?.trim();
+	if (entry && /(?:^|[/\\])apps[/\\]cli[/\\]src[/\\]index\.ts$/.test(entry)) {
+		return { command: process.execPath, argsPrefix: [entry] };
+	}
+	return { command: "cline", argsPrefix: [] };
+}
+
+function hashSource(source: string): string {
+	return createHash("sha256").update(source).digest("hex").slice(0, 12);
+}
+
+function sanitizeSegment(value: string): string {
+	const sanitized = value
+		.replace(/^@/, "")
+		.replace(/[^a-zA-Z0-9._-]+/g, "-")
+		.replace(/^-+|-+$/g, "")
+		.slice(0, 80);
+	return sanitized || "plugin";
+}
+
+function sanitizeSkillSegment(value: string): string {
+	const sanitized = value
+		.toLowerCase()
+		.replace(/[^a-z0-9._]+/g, "-")
+		.replace(/^[.-]+|[.-]+$/g, "")
+		.slice(0, 255);
+	return sanitized || "skill";
+}
+
+function isOfficialPluginSlug(source: string): boolean {
+	return /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(source.trim());
+}
+
+function getOfficialPluginInstallPath(source: string): string | undefined {
+	const slug = source.trim();
+	if (!isOfficialPluginSlug(slug)) return undefined;
+	const sourceKey = `official:${OFFICIAL_PLUGINS_REPO}#plugins/${slug}`;
+	return join(
+		resolveClineDir(),
+		"plugins",
+		"_installed",
+		"official",
+		`${sanitizeSegment(slug)}-${hashSource(sourceKey)}`,
+	);
+}
+
+function isOfficialPluginInstalled(entry: MarketplaceInstallInput): boolean {
+	if (entry.type !== "plugin") return false;
+	const [source] = entry.install.args ?? [];
+	if (!source) return false;
+	const installPath = getOfficialPluginInstallPath(source);
+	const installed = Boolean(installPath && existsSync(installPath));
+	logMarketplace("plugin-installed-check", {
+		id: entry.id,
+		source,
+		installPath,
+		installed,
+	});
+	return installed;
+}
+
+function normalizeMatchValue(value: string | undefined): string {
+	return (value ?? "")
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "");
+}
+
+function getSkillInstallCandidates(entry: MarketplaceInstallInput): string[] {
+	const candidates = new Set<string>();
+	const addCandidate = (value: string | undefined) => {
+		const normalized = sanitizeSkillSegment(value ?? "");
+		if (normalized && normalized !== "skill") {
+			candidates.add(normalized);
+		}
+	};
+	addCandidate(entry.id);
+	addCandidate(entry.name);
+	const installArgs = entry.install.args ?? [];
+	for (let index = 0; index < installArgs.length; index++) {
+		const arg = installArgs[index];
+		if ((arg === "--skill" || arg === "-s") && installArgs[index + 1]) {
+			addCandidate(installArgs[index + 1]);
+			index++;
+			continue;
+		}
+		const skillFilter = arg.split("@").at(1);
+		if (skillFilter) {
+			addCandidate(skillFilter);
+		}
+	}
+	return [...candidates];
+}
+
+function getGlobalSkillPaths(skillName: string): string[] {
+	return [
+		join(resolveClineDir(), "skills", skillName, "SKILL.md"),
+		join(homedir(), ".agents", "skills", skillName, "SKILL.md"),
+	].filter((path, index, paths) => paths.indexOf(path) === index);
+}
+
+function ensureGlobalSkillsDirWritable(): void {
+	const skillsDir = join(homedir(), ".agents", "skills");
+	try {
+		mkdirSync(skillsDir, { recursive: true });
+		const probePath = join(
+			skillsDir,
+			`.cline-marketplace-write-test-${process.pid}-${Date.now()}`,
+		);
+		writeFileSync(probePath, "", { flag: "wx" });
+		unlinkSync(probePath);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		throw new Error(
+			`Cannot install skill globally because ~/.agents/skills is not writable: ${message}`,
+		);
+	}
+}
+
+function isGlobalSkillInstalled(entry: MarketplaceInstallInput): boolean {
+	if (entry.type !== "skill") return false;
+	const candidates = getSkillInstallCandidates(entry);
+	const checkedPaths = candidates.flatMap(getGlobalSkillPaths);
+	const installed = checkedPaths.some((path) => existsSync(path));
+	logMarketplace("skill-installed-check", {
+		id: entry.id,
+		candidates,
+		checkedPaths,
+		installed,
+	});
+	return installed;
+}
+
+function hasMatchingInventoryItem(
+	items: unknown,
+	entry: MarketplaceInstallInput,
+): boolean {
+	if (!Array.isArray(items)) return false;
+	const candidates = new Set([
+		normalizeMatchValue(entry.id),
+		normalizeMatchValue(entry.name),
+		...(entry.install.args ?? []).map(normalizeMatchValue),
+	]);
+	candidates.delete("");
+	return items.some((item) => {
+		if (!item || typeof item !== "object") return false;
+		const record = item as JsonRecord;
+		const values = [
+			typeof record.name === "string" ? record.name : undefined,
+			typeof record.id === "string" ? record.id : undefined,
+			typeof record.path === "string" ? record.path : undefined,
+		]
+			.map(normalizeMatchValue)
+			.filter(Boolean);
+		return values.some((value) =>
+			[...candidates].some(
+				(candidate) => value === candidate || value.includes(candidate),
+			),
+		);
+	});
+}
+
+function isMcpEntryInstalled(entry: MarketplaceInstallInput): boolean {
+	if (entry.type !== "mcp") return false;
+	const input = buildMarketplaceMcpInput(entry.install.args ?? []);
+	const response = readMcpServersResponse();
+	const servers = Array.isArray(response.servers) ? response.servers : [];
+	return servers.some((server) => {
+		if (!server || typeof server !== "object") return false;
+		const record = server as JsonRecord;
+		return record.name === input.name;
+	});
+}
+
+function isMarketplaceEntryInstalled(
+	entry: MarketplaceInstallInput,
+	inventory?: JsonRecord,
+): boolean {
+	if (entry.type === "mcp") return isMcpEntryInstalled(entry);
+	if (entry.type === "plugin") {
+		return (
+			isOfficialPluginInstalled(entry) ||
+			hasMatchingInventoryItem(inventory?.plugins, entry)
+		);
+	}
+	if (entry.type === "skill") {
+		return isGlobalSkillInstalled(entry);
+	}
+	return false;
+}
+
+function commandOutput(result: SpawnResult): string | undefined {
+	const output = redactOutput(
+		[result.stdout, result.stderr].filter(Boolean).join("\n"),
+	);
+	return output.trim().length > 0 ? output.trim() : undefined;
+}
+
+async function installSkill(
+	entry: MarketplaceInstallInput,
+	spawnCommand: SpawnCommand,
+): Promise<MarketplaceInstallResult> {
+	if (isGlobalSkillInstalled(entry)) {
+		logMarketplace("skill-install-skip-installed", {
+			id: entry.id,
+			name: entry.name,
+		});
+		return {
+			id: entry.id,
+			type: entry.type,
+			status: "installed",
+			message: `${entry.name ?? entry.id} is already installed.`,
+		};
+	}
+	logMarketplace("skill-install-start", {
+		id: entry.id,
+		name: entry.name,
+	});
+	ensureGlobalSkillsDirWritable();
+	const result = await spawnCommand("npx", [
+		"-y",
+		"skills@latest",
+		"add",
+		...(entry.install.args ?? []),
+		"-g",
+		"-a",
+		"cline",
+		"-y",
+	]);
+	if (result.exitCode !== 0) {
+		throw new Error(
+			`Skill install failed with exit code ${result.exitCode}${commandOutput(result) ? `:\n${commandOutput(result)}` : ""}`,
+		);
+	}
+	const output = commandOutput(result);
+	if (/\bFailed to install\b/i.test(output ?? "")) {
+		throw new Error(`Skill install failed${output ? `:\n${output}` : ""}`);
+	}
+	if (!isGlobalSkillInstalled(entry)) {
+		throw new Error(
+			`Skill install completed, but ${entry.name ?? entry.id} was not found in Cline's global skills directories.`,
+		);
+	}
+	return {
+		id: entry.id,
+		type: entry.type,
+		status: "installed",
+		message: `Installed ${entry.name ?? entry.id} globally for Cline.`,
+		output,
+	};
+}
+
+async function installPlugin(
+	entry: MarketplaceInstallInput,
+	spawnCommand: SpawnCommand,
+): Promise<MarketplaceInstallResult> {
+	const installArgs = entry.install.args ?? [];
+	if (installArgs.length !== 1) {
+		throw new Error(
+			"Plugin marketplace installs currently support exactly one source argument.",
+		);
+	}
+	if (isOfficialPluginInstalled(entry)) {
+		logMarketplace("plugin-install-skip-installed", {
+			id: entry.id,
+			name: entry.name,
+			source: installArgs[0],
+		});
+		return {
+			id: entry.id,
+			type: entry.type,
+			status: "installed",
+			message: `${entry.name ?? entry.id} is already installed.`,
+		};
+	}
+	const { command, argsPrefix } = resolveClineInvocation();
+	logMarketplace("plugin-install-start", {
+		id: entry.id,
+		name: entry.name,
+		source: installArgs[0],
+		command,
+		argsPrefix,
+	});
+	const result = await spawnCommand(command, [
+		...argsPrefix,
+		"plugin",
+		"install",
+		installArgs[0] ?? "",
+		"--json",
+	]);
+	if (result.exitCode !== 0) {
+		throw new Error(
+			`Plugin install failed with exit code ${result.exitCode}${commandOutput(result) ? `:\n${commandOutput(result)}` : ""}`,
+		);
+	}
+	let details: JsonRecord | undefined;
+	try {
+		details = result.stdout.trim()
+			? (JSON.parse(result.stdout.trim()) as JsonRecord)
+			: undefined;
+	} catch {
+		details = undefined;
+	}
+	return {
+		id: entry.id,
+		type: entry.type,
+		status: "installed",
+		message: `Installed ${entry.name ?? entry.id}.`,
+		details,
+		output: commandOutput(result),
+	};
+}
+
+export async function installMarketplaceEntry(
+	args?: Record<string, unknown>,
+	options: { spawnCommand?: SpawnCommand } = {},
+): Promise<MarketplaceInstallResult> {
+	const entry = readInstallInput(args);
+	logMarketplace("install-entry", {
+		id: entry.id,
+		type: entry.type,
+		name: entry.name,
+	});
+	const spawnCommand = options.spawnCommand ?? defaultSpawnCommand;
+	if (entry.type === "mcp") {
+		const input = buildMarketplaceMcpInput(entry.install.args ?? []);
+		const response = upsertMcpServer(input);
+		return {
+			id: entry.id,
+			type: entry.type,
+			status: "installed",
+			message: `Installed ${entry.name ?? input.name ?? entry.id}.`,
+			details: { mcp: response },
+		};
+	}
+	if (entry.type === "skill") {
+		return installSkill(entry, spawnCommand);
+	}
+	if (entry.type === "plugin") {
+		return installPlugin(entry, spawnCommand);
+	}
+	throw new Error(`Unsupported marketplace entry type: ${entry.type}`);
+}
+
+export async function installMarketplaceEntryFromCatalog(
+	args?: Record<string, unknown>,
+	options: {
+		spawnCommand?: SpawnCommand;
+		loadCatalog?: CatalogLoader;
+	} = {},
+): Promise<MarketplaceInstallResult> {
+	const requested = readInstallRequest(args);
+	const catalog = await (options.loadCatalog ?? fetchMarketplaceCatalog)();
+	const entry = readCatalogEntries(catalog).find(
+		(candidate) =>
+			candidate.id === requested.id && candidate.type === requested.type,
+	);
+	if (!entry) {
+		throw new Error(
+			`Marketplace entry ${requested.type}:${requested.id} was not found in the catalog.`,
+		);
+	}
+	return installMarketplaceEntry(
+		{ entry },
+		{ spawnCommand: options.spawnCommand },
+	);
+}
+
+export function listMarketplaceInstalledEntries(
+	args?: Record<string, unknown>,
+	inventory?: JsonRecord,
+): MarketplaceInstallStatusResult {
+	const entries = readInstallInputList(args);
+	const installedKeys = entries
+		.filter((entry) => isMarketplaceEntryInstalled(entry, inventory))
+		.map(marketplaceEntryKey);
+	logMarketplace("list-installed", {
+		entryCount: entries.length,
+		installedKeys,
+		inventorySkillCount: Array.isArray(inventory?.skills)
+			? inventory.skills.length
+			: undefined,
+		inventoryPluginCount: Array.isArray(inventory?.plugins)
+			? inventory.plugins.length
+			: undefined,
+	});
+	return { installedKeys };
+}
+
+export async function installMarketplaceEntryForDesktopCommand(
+	args?: Record<string, unknown>,
+	options: {
+		spawnCommand?: SpawnCommand;
+		loadCatalog?: CatalogLoader;
+	} = {},
+): Promise<MarketplaceInstallResult> {
+	return installMarketplaceEntryFromCatalog(args, options);
+}

--- a/apps/cline-hub/src/webview/src/App.tsx
+++ b/apps/cline-hub/src/webview/src/App.tsx
@@ -155,14 +155,37 @@ function readCurrentChatSessionId(): string | undefined {
 }
 
 function chatPath(sessionId?: string): string {
-	if (!sessionId) return VIEW_PATHS.chat;
-	const params = new URLSearchParams({ [CHAT_SESSION_QUERY_PARAM]: sessionId });
-	return `${VIEW_PATHS.chat}?${params.toString()}`;
+	const params = persistentRouteSearchParams();
+	if (sessionId) {
+		params.set(CHAT_SESSION_QUERY_PARAM, sessionId);
+	} else {
+		params.delete(CHAT_SESSION_QUERY_PARAM);
+	}
+	const query = params.toString();
+	return query ? `${VIEW_PATHS.chat}?${query}` : VIEW_PATHS.chat;
 }
 
 function readCurrentSettingsSection(): SettingsSection {
 	if (typeof window === "undefined") return "General";
 	return settingsSectionFromPath(window.location.pathname);
+}
+
+function persistentRouteSearchParams(): URLSearchParams {
+	if (typeof window === "undefined") return new URLSearchParams();
+	const params = new URLSearchParams(window.location.search);
+	params.delete(CHAT_SESSION_QUERY_PARAM);
+	return params;
+}
+
+function routePath(pathname: string): string {
+	const params = persistentRouteSearchParams();
+	const query = params.toString();
+	return query ? `${pathname}?${query}` : pathname;
+}
+
+function currentPathWithSearch(): string {
+	if (typeof window === "undefined") return "/";
+	return `${window.location.pathname}${window.location.search}`;
 }
 
 function formatRelativeTime(timestamp?: number): string {
@@ -938,8 +961,8 @@ function App() {
 		if (nextView !== "chat") {
 			setSelectedSessionId(undefined);
 		}
-		const nextPath = VIEW_PATHS[nextView];
-		if (window.location.pathname !== nextPath) {
+		const nextPath = routePath(VIEW_PATHS[nextView]);
+		if (currentPathWithSearch() !== nextPath) {
 			window.history.pushState(null, "", nextPath);
 		}
 		setView(nextView);
@@ -947,8 +970,8 @@ function App() {
 
 	const navigateSettingsSection = useCallback((section: SettingsSection) => {
 		setSettingsSection(section);
-		const nextPath = SETTINGS_SECTION_PATHS[section];
-		if (window.location.pathname !== nextPath) {
+		const nextPath = routePath(SETTINGS_SECTION_PATHS[section]);
+		if (currentPathWithSearch() !== nextPath) {
 			window.history.pushState(null, "", nextPath);
 		}
 	}, []);
@@ -956,7 +979,7 @@ function App() {
 	const openSession = useCallback((sessionId: string) => {
 		setSelectedSessionId(sessionId);
 		const nextPath = chatPath(sessionId);
-		if (`${window.location.pathname}${window.location.search}` !== nextPath) {
+		if (currentPathWithSearch() !== nextPath) {
 			window.history.pushState(null, "", nextPath);
 		}
 		setView("chat");
@@ -965,7 +988,7 @@ function App() {
 	const updateChatSessionRoute = useCallback((sessionId?: string) => {
 		setSelectedSessionId(sessionId);
 		const nextPath = chatPath(sessionId);
-		if (`${window.location.pathname}${window.location.search}` !== nextPath) {
+		if (currentPathWithSearch() !== nextPath) {
 			window.history.replaceState(null, "", nextPath);
 		}
 	}, []);

--- a/apps/cline-hub/src/webview/src/App.tsx
+++ b/apps/cline-hub/src/webview/src/App.tsx
@@ -7,6 +7,7 @@ import {
 	HomeIcon,
 	LinkIcon,
 	MessageSquareIcon,
+	PackageIcon,
 	PencilIcon,
 	RotateCcwIcon,
 	RssIcon,
@@ -46,18 +47,20 @@ import type {
 	WebviewSessionSummary,
 } from "../../webview-protocol";
 import Chat from "./Chat";
+import { MarketplaceView } from "./components/views/marketplace-view";
 import {
 	type SettingsSection,
 	SettingsView,
 } from "./components/views/settings/settings-view";
 import { getVsCodeApi, postToHost } from "./vscode";
 
-type View = "home" | "chat" | "settings";
+type View = "home" | "chat" | "marketplace" | "settings";
 type Theme = "dark" | "light";
 
 const VIEW_PATHS: Record<View, string> = {
 	home: "/",
 	chat: "/chat",
+	marketplace: "/marketplace",
 	settings: "/settings",
 };
 
@@ -105,6 +108,7 @@ function writeTheme(theme: Theme): void {
 
 function viewFromPath(pathname: string): View {
 	if (pathname === VIEW_PATHS.chat) return "chat";
+	if (pathname === VIEW_PATHS.marketplace) return "marketplace";
 	if (
 		pathname === VIEW_PATHS.settings ||
 		pathname.startsWith(`${VIEW_PATHS.settings}/`)
@@ -286,6 +290,16 @@ function Shell({
 						variant={view === "chat" ? "default" : "ghost"}
 					>
 						<MessageSquareIcon className="size-4" />
+					</Button>
+					<Button
+						onClick={() => onNavigate("marketplace")}
+						size="sm"
+						title="Marketplace"
+						type="button"
+						variant={view === "marketplace" ? "default" : "ghost"}
+					>
+						<PackageIcon className="size-4" />
+						<span className="sr-only">Marketplace</span>
 					</Button>
 					<Button
 						onClick={() => onNavigate("settings")}
@@ -919,6 +933,9 @@ function App() {
 		if (nextView === "settings") {
 			setSettingsSection("General");
 		}
+		if (nextView !== "chat") {
+			setSelectedSessionId(undefined);
+		}
 		const nextPath = VIEW_PATHS[nextView];
 		if (window.location.pathname !== nextPath) {
 			window.history.pushState(null, "", nextPath);
@@ -991,6 +1008,9 @@ function App() {
 					theme={theme}
 				/>
 			);
+		}
+		if (view === "marketplace") {
+			return <MarketplaceView />;
 		}
 		return (
 			<HomeView

--- a/apps/cline-hub/src/webview/src/App.tsx
+++ b/apps/cline-hub/src/webview/src/App.tsx
@@ -7,12 +7,14 @@ import {
 	HomeIcon,
 	LinkIcon,
 	MessageSquareIcon,
-	PackageIcon,
 	PencilIcon,
+	PlugIcon,
 	RotateCcwIcon,
 	RssIcon,
+	ServerIcon,
 	SettingsIcon,
 	Trash2Icon,
+	WrenchIcon,
 } from "lucide-react";
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -52,15 +54,18 @@ import {
 	type SettingsSection,
 	SettingsView,
 } from "./components/views/settings/settings-view";
+import type { MarketplacePrimitiveType } from "./lib/marketplace";
 import { getVsCodeApi, postToHost } from "./vscode";
 
-type View = "home" | "chat" | "marketplace" | "settings";
+type View = "home" | "chat" | "mcp" | "skills" | "plugins" | "settings";
 type Theme = "dark" | "light";
 
 const VIEW_PATHS: Record<View, string> = {
 	home: "/",
 	chat: "/chat",
-	marketplace: "/marketplace",
+	mcp: "/marketplace/mcp",
+	skills: "/marketplace/skills",
+	plugins: "/marketplace/plugins",
 	settings: "/settings",
 };
 
@@ -75,6 +80,12 @@ const SETTINGS_SECTION_PATHS: Record<SettingsSection, string> = {
 	Schedules: "/settings/schedules",
 	Account: "/settings/account",
 };
+
+const MARKETPLACE_VIEW_PRIMITIVES = {
+	mcp: "mcp",
+	skills: "skill",
+	plugins: "plugin",
+} satisfies Partial<Record<View, MarketplacePrimitiveType>>;
 
 const EMPTY_HUB_STATE: WebviewHubState = {
 	type: "hub_state",
@@ -108,7 +119,9 @@ function writeTheme(theme: Theme): void {
 
 function viewFromPath(pathname: string): View {
 	if (pathname === VIEW_PATHS.chat) return "chat";
-	if (pathname === VIEW_PATHS.marketplace) return "marketplace";
+	if (pathname === "/marketplace" || pathname === VIEW_PATHS.mcp) return "mcp";
+	if (pathname === VIEW_PATHS.skills) return "skills";
+	if (pathname === VIEW_PATHS.plugins) return "plugins";
 	if (
 		pathname === VIEW_PATHS.settings ||
 		pathname.startsWith(`${VIEW_PATHS.settings}/`)
@@ -257,62 +270,51 @@ function Shell({
 	theme: Theme;
 	view: View;
 }) {
+	const navItems = [
+		{ view: "home", label: "Home", icon: HomeIcon },
+		{ view: "chat", label: "Chat", icon: MessageSquareIcon },
+		{ view: "mcp", label: "MCP", icon: ServerIcon },
+		{ view: "skills", label: "Skills", icon: WrenchIcon },
+		{ view: "plugins", label: "Plugins", icon: PlugIcon },
+		{ view: "settings", label: "Settings", icon: SettingsIcon },
+	] satisfies Array<{
+		view: View;
+		label: string;
+		icon: typeof HomeIcon;
+	}>;
+
 	return (
-		<div className="grid h-screen min-h-screen grid-rows-[auto_minmax(0,1fr)] bg-background text-foreground">
-			<header className="flex items-center justify-between gap-4 border-b bg-[color-mix(in_oklch,var(--background)_94%,var(--card))] px-4 py-2.5 max-[720px]:flex-col max-[720px]:items-stretch">
-				<div className="min-w-0">
-					<h1 className="min-w-0">
-						<button
-							className="block truncate rounded-sm text-base font-semibold outline-none transition-colors hover:text-primary focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background pointer-cursor"
-							onClick={() => onNavigate("home")}
-							type="button"
-						>
-							Cline Hub
-						</button>
-					</h1>
-				</div>
+		<div className="grid h-screen min-h-screen grid-cols-[13.5rem_minmax(0,1fr)] bg-background text-foreground max-[720px]:grid-cols-1 max-[720px]:grid-rows-[auto_minmax(0,1fr)]">
+			<aside className="flex min-h-0 flex-col border-r bg-[color-mix(in_oklch,var(--background)_94%,var(--card))] p-3 max-[720px]:border-b max-[720px]:border-r-0">
+				<button
+					className="mb-4 flex min-w-0 items-center rounded-md px-2 py-1.5 text-left text-base font-semibold outline-none transition-colors hover:text-primary focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background max-[720px]:mb-2"
+					onClick={() => onNavigate("home")}
+					type="button"
+				>
+					<span className="truncate">Cline Hub</span>
+				</button>
 				<nav
-					className="flex items-center gap-1.5 max-[720px]:justify-start"
+					className="grid gap-1 max-[720px]:grid-flow-col max-[720px]:auto-cols-max max-[720px]:overflow-x-auto"
 					aria-label="Hub views"
 				>
-					<Button
-						onClick={() => onNavigate("home")}
-						size="sm"
-						type="button"
-						variant={view === "home" ? "default" : "ghost"}
-					>
-						<HomeIcon className="size-4" />
-					</Button>
-					<Button
-						onClick={() => onNavigate("chat")}
-						size="sm"
-						type="button"
-						variant={view === "chat" ? "default" : "ghost"}
-					>
-						<MessageSquareIcon className="size-4" />
-					</Button>
-					<Button
-						onClick={() => onNavigate("marketplace")}
-						size="sm"
-						title="Marketplace"
-						type="button"
-						variant={view === "marketplace" ? "default" : "ghost"}
-					>
-						<PackageIcon className="size-4" />
-						<span className="sr-only">Marketplace</span>
-					</Button>
-					<Button
-						onClick={() => onNavigate("settings")}
-						size="icon-sm"
-						title="Settings"
-						type="button"
-						variant={view === "settings" ? "default" : "ghost"}
-					>
-						<SettingsIcon className="size-4" />
-						<span className="sr-only">Settings</span>
-					</Button>
+					{navItems.map((item) => {
+						const Icon = item.icon;
+						return (
+							<Button
+								className="justify-start"
+								key={item.view}
+								onClick={() => onNavigate(item.view)}
+								size="sm"
+								type="button"
+								variant={view === item.view ? "default" : "ghost"}
+							>
+								<Icon className="size-4" />
+								<span>{item.label}</span>
+							</Button>
+						);
+					})}
 				</nav>
-			</header>
+			</aside>
 			<main className="min-h-0 overflow-hidden [&>.h-screen]:h-full">
 				{children}
 			</main>
@@ -1009,8 +1011,13 @@ function App() {
 				/>
 			);
 		}
-		if (view === "marketplace") {
-			return <MarketplaceView />;
+		if (view === "mcp" || view === "skills" || view === "plugins") {
+			return (
+				<MarketplaceView
+					key={view}
+					primitive={MARKETPLACE_VIEW_PRIMITIVES[view]}
+				/>
+			);
 		}
 		return (
 			<HomeView

--- a/apps/cline-hub/src/webview/src/components/views/marketplace-view.tsx
+++ b/apps/cline-hub/src/webview/src/components/views/marketplace-view.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import {
 	CheckCircle2,
 	Copy,

--- a/apps/cline-hub/src/webview/src/components/views/marketplace-view.tsx
+++ b/apps/cline-hub/src/webview/src/components/views/marketplace-view.tsx
@@ -118,33 +118,6 @@ function TypeBadge({ type }: { type: MarketplacePrimitiveType }) {
 	);
 }
 
-function EntryIcon({ entry }: { entry: MarketplaceEntry }) {
-	const initials = entry.name
-		.split(/\s+/)
-		.map((part) => part[0])
-		.join("")
-		.slice(0, 2)
-		.toUpperCase();
-	return (
-		<div className="flex size-11 shrink-0 items-center justify-center overflow-hidden rounded-lg border bg-background">
-			{/* Marketplace icons are currently often placeholders, so keep them hidden for now.
-			{entry.icon ? (
-				<img
-					alt=""
-					className="max-h-8 max-w-8 object-contain"
-					referrerPolicy="no-referrer"
-					src={entry.icon}
-				/>
-			) : (
-			*/}
-			<span className="text-xs font-semibold text-muted-foreground">
-				{initials}
-			</span>
-			{/* )} */}
-		</div>
-	);
-}
-
 function entryKey(entry: Pick<MarketplaceEntry, "id" | "type">): string {
 	return `${entry.type}:${entry.id}`;
 }
@@ -359,29 +332,26 @@ function MarketplaceEntryCard({
 			role="button"
 			tabIndex={0}
 		>
-			<div className="flex items-start gap-3">
-				<EntryIcon entry={entry} />
-				<div className="min-w-0 flex-1">
-					<div className="flex min-w-0 items-start justify-between gap-2">
-						<h2 className="min-w-0 truncate text-sm font-semibold text-foreground">
-							{entry.name}
-							{entry.featured ? (
-								<Sparkles className="ml-1.5 inline size-3.5 shrink-0 text-primary" />
-							) : null}
-						</h2>
-						<TypeBadge type={entry.type} />
-					</div>
-					<div className="mt-1 flex flex-wrap gap-1.5">
-						{entry.tags.slice(0, 5).map((tag) => (
-							<Badge
-								key={tag}
-								variant="outline"
-								className="max-w-full text-muted-foreground"
-							>
-								<span className="truncate">{tagLabels.get(tag) ?? tag}</span>
-							</Badge>
-						))}
-					</div>
+			<div className="min-w-0">
+				<div className="flex min-w-0 items-start justify-between gap-2">
+					<h2 className="min-w-0 truncate text-sm font-semibold text-foreground">
+						{entry.name}
+						{entry.featured ? (
+							<Sparkles className="ml-1.5 inline size-3.5 shrink-0 text-primary" />
+						) : null}
+					</h2>
+					<TypeBadge type={entry.type} />
+				</div>
+				<div className="mt-1 flex flex-wrap gap-1.5">
+					{entry.tags.slice(0, 5).map((tag) => (
+						<Badge
+							key={tag}
+							variant="outline"
+							className="max-w-full text-muted-foreground"
+						>
+							<span className="truncate">{tagLabels.get(tag) ?? tag}</span>
+						</Badge>
+					))}
 				</div>
 			</div>
 

--- a/apps/cline-hub/src/webview/src/components/views/marketplace-view.tsx
+++ b/apps/cline-hub/src/webview/src/components/views/marketplace-view.tsx
@@ -5,7 +5,6 @@ import {
 	Plug,
 	Search,
 	Server,
-	Sparkles,
 	Trash2,
 	Wrench,
 } from "lucide-react";
@@ -336,9 +335,6 @@ function MarketplaceEntryCard({
 				<div className="flex min-w-0 items-start justify-between gap-2">
 					<h2 className="min-w-0 truncate text-sm font-semibold text-foreground">
 						{entry.name}
-						{entry.featured ? (
-							<Sparkles className="ml-1.5 inline size-3.5 shrink-0 text-primary" />
-						) : null}
 					</h2>
 					<TypeBadge type={entry.type} />
 				</div>

--- a/apps/cline-hub/src/webview/src/components/views/marketplace-view.tsx
+++ b/apps/cline-hub/src/webview/src/components/views/marketplace-view.tsx
@@ -10,7 +10,13 @@ import {
 	Trash2,
 	Wrench,
 } from "lucide-react";
-import { type CSSProperties, useEffect, useMemo, useState } from "react";
+import {
+	type CSSProperties,
+	type MouseEvent,
+	useEffect,
+	useMemo,
+	useState,
+} from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -266,16 +272,28 @@ function MarketplaceCard({
 	entry,
 	installed,
 	installedStatusReady,
+	uninstalling,
 	onInstall,
+	onUninstall,
 	tagLabels,
 }: {
 	entry: MarketplaceEntry;
 	installed: boolean;
 	installedStatusReady: boolean;
+	uninstalling: boolean;
 	onInstall: (entry: MarketplaceEntry) => void;
+	onUninstall: (entry: MarketplaceEntry) => void;
 	tagLabels: Map<string, string>;
 }) {
 	const openInstallDialog = () => onInstall(entry);
+	const handleActionClick = (event: MouseEvent<HTMLButtonElement>) => {
+		event.stopPropagation();
+		if (installed) {
+			onUninstall(entry);
+			return;
+		}
+		openInstallDialog();
+	};
 	return (
 		// biome-ignore lint/a11y/useSemanticElements: The card contains a nested action button, so the wrapper cannot be a native button.
 		<div
@@ -327,16 +345,20 @@ function MarketplaceCard({
 			<div className="mt-auto pt-4">
 				<Button
 					className="w-full"
-					disabled={!installedStatusReady}
-					onClick={openInstallDialog}
+					disabled={!installedStatusReady || uninstalling}
+					onClick={handleActionClick}
 					type="button"
 					variant={installed ? "destructive" : "default"}
 				>
-					{installedStatusReady ? null : <Spinner />}
-					{installedStatusReady && installed ? (
+					{!installedStatusReady || uninstalling ? <Spinner /> : null}
+					{installedStatusReady && installed && !uninstalling ? (
 						<Trash2 className="size-4" />
 					) : null}
-					{installedStatusReady ? installLabel(installed) : "Checking..."}
+					{uninstalling
+						? "Uninstalling..."
+						: installedStatusReady
+							? installLabel(installed)
+							: "Checking..."}
 				</Button>
 			</div>
 		</div>
@@ -598,6 +620,9 @@ export function MarketplaceView() {
 	const [installedEntryKeys, setInstalledEntryKeys] = useState<Set<string>>(
 		() => new Set(),
 	);
+	const [uninstallingEntryKeys, setUninstallingEntryKeys] = useState<
+		Set<string>
+	>(() => new Set());
 	const [installedStatusState, setInstalledStatusState] =
 		useState<InstalledStatusState>("loading");
 
@@ -677,6 +702,41 @@ export function MarketplaceView() {
 		setQuery("");
 		setPrimitive("all");
 		setSelectedTag(null);
+	};
+
+	const markEntryInstalled = (entry: MarketplaceEntry) => {
+		setInstalledEntryKeys((current) => new Set(current).add(entryKey(entry)));
+	};
+
+	const markEntryUninstalled = (entry: MarketplaceEntry) => {
+		setInstalledEntryKeys((current) => {
+			const next = new Set(current);
+			next.delete(entryKey(entry));
+			return next;
+		});
+	};
+
+	const uninstallEntryFromCard = async (entry: MarketplaceEntry) => {
+		const key = entryKey(entry);
+		if (uninstallingEntryKeys.has(key)) return;
+		setErrorMessage(null);
+		setUninstallingEntryKeys((current) => new Set(current).add(key));
+		try {
+			await desktopClient.invoke<MarketplaceInstallResult>(
+				"uninstall_marketplace_entry",
+				{ entry },
+				{ timeoutMs: INSTALL_TIMEOUT_MS },
+			);
+			markEntryUninstalled(entry);
+		} catch (error) {
+			setErrorMessage(error instanceof Error ? error.message : String(error));
+		} finally {
+			setUninstallingEntryKeys((current) => {
+				const next = new Set(current);
+				next.delete(key);
+				return next;
+			});
+		}
 	};
 
 	const activeFilters =
@@ -863,7 +923,9 @@ export function MarketplaceView() {
 												installedStatusReady={installedStatusReady}
 												key={key}
 												onInstall={setSelectedEntry}
+												onUninstall={uninstallEntryFromCard}
 												tagLabels={tagLabels}
+												uninstalling={uninstallingEntryKeys.has(key)}
 											/>
 										);
 									})}
@@ -900,18 +962,8 @@ export function MarketplaceView() {
 				installedStatusReady={installedStatusReady}
 				key={selectedEntry ? entryKey(selectedEntry) : "empty"}
 				onClose={() => setSelectedEntry(null)}
-				onInstalled={(entry) =>
-					setInstalledEntryKeys((current) =>
-						new Set(current).add(entryKey(entry)),
-					)
-				}
-				onUninstalled={(entry) =>
-					setInstalledEntryKeys((current) => {
-						const next = new Set(current);
-						next.delete(entryKey(entry));
-						return next;
-					})
-				}
+				onInstalled={markEntryInstalled}
+				onUninstalled={markEntryUninstalled}
 				open={selectedEntry !== null}
 			/>
 		</ScrollArea>

--- a/apps/cline-hub/src/webview/src/components/views/marketplace-view.tsx
+++ b/apps/cline-hub/src/webview/src/components/views/marketplace-view.tsx
@@ -388,7 +388,7 @@ function MarketplaceEntryCard({
 			</div>
 
 			<p className="line-clamp-2 text-xs leading-5 text-muted-foreground">
-				{entry.tagline}
+				{entry.description}
 			</p>
 
 			<div className="flex flex-wrap items-center justify-between gap-3">

--- a/apps/cline-hub/src/webview/src/components/views/marketplace-view.tsx
+++ b/apps/cline-hub/src/webview/src/components/views/marketplace-view.tsx
@@ -365,6 +365,17 @@ function InstallDialog({
 		entry?.install.env?.filter((env) => env.required !== false) ?? [];
 	const optionalEnv =
 		entry?.install.env?.filter((env) => env.required === false) ?? [];
+	const currentInstalled =
+		state.status === "installed"
+			? true
+			: state.status === "uninstalled"
+				? false
+				: installed;
+	const busy = state.status === "installing" || state.status === "uninstalling";
+	const statusMessage =
+		state.status === "installed" || state.status === "uninstalled"
+			? state.message
+			: undefined;
 
 	useEffect(() => {
 		if (open) {
@@ -378,13 +389,7 @@ function InstallDialog({
 	};
 
 	const install = async () => {
-		if (
-			!entry ||
-			state.status === "installing" ||
-			state.status === "uninstalling"
-		) {
-			return;
-		}
+		if (!entry || busy) return;
 		setState({ status: "installing" });
 		try {
 			const result = await desktopClient.invoke<MarketplaceInstallResult>(
@@ -407,13 +412,7 @@ function InstallDialog({
 	};
 
 	const uninstall = async () => {
-		if (
-			!entry ||
-			state.status === "installing" ||
-			state.status === "uninstalling"
-		) {
-			return;
-		}
+		if (!entry || busy) return;
 		setState({ status: "uninstalling" });
 		try {
 			const result = await desktopClient.invoke<MarketplaceInstallResult>(
@@ -523,7 +522,7 @@ function InstallDialog({
 					</div>
 				) : null}
 
-				{installed && state.status !== "installed" ? (
+				{currentInstalled && state.status !== "installed" ? (
 					<div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-3 text-sm text-emerald-700 dark:text-emerald-300">
 						This entry is already installed.
 					</div>
@@ -531,16 +530,6 @@ function InstallDialog({
 				{!installedStatusReady ? (
 					<div className="rounded-lg border bg-muted/30 p-3 text-sm text-muted-foreground">
 						Checking whether this entry is already installed...
-					</div>
-				) : null}
-				{state.status === "installed" ? (
-					<div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-3 text-sm text-emerald-700 dark:text-emerald-300">
-						{state.message}
-					</div>
-				) : null}
-				{state.status === "uninstalled" ? (
-					<div className="rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
-						{state.message}
 					</div>
 				) : null}
 				{state.status === "failed" ? (
@@ -559,10 +548,11 @@ function InstallDialog({
 				) : null}
 
 				<DialogFooter>
+					<p className="min-h-9 min-w-0 flex-1 content-center text-left text-sm text-muted-foreground">
+						{statusMessage}
+					</p>
 					<Button
-						disabled={
-							state.status === "installing" || state.status === "uninstalling"
-						}
+						disabled={busy}
 						onClick={onClose}
 						type="button"
 						variant="outline"
@@ -570,35 +560,25 @@ function InstallDialog({
 						Close
 					</Button>
 					<Button
-						disabled={
-							!installedStatusReady ||
-							state.status === "installing" ||
-							state.status === "uninstalling" ||
-							state.status === "installed" ||
-							state.status === "uninstalled"
-						}
-						onClick={installed ? uninstall : install}
+						disabled={!installedStatusReady || busy}
+						onClick={currentInstalled ? uninstall : install}
 						type="button"
-						variant={installed ? "destructive" : "default"}
+						variant={currentInstalled ? "destructive" : "default"}
 					>
 						{state.status === "installing" ? <Spinner /> : null}
 						{state.status === "uninstalling" ? <Spinner /> : null}
-						{installed || state.status === "installed" ? (
-							<Trash2 className="size-4" />
-						) : null}
+						{currentInstalled ? <Trash2 className="size-4" /> : null}
 						{!installedStatusReady
 							? "Checking..."
-							: state.status === "uninstalled"
-								? "Uninstalled"
-								: installed
-									? state.status === "uninstalling"
-										? "Uninstalling..."
-										: "Uninstall"
-									: state.status === "installing"
-										? "Installing..."
-										: state.status === "installed"
-											? "Installed"
-											: installLabel(false)}
+							: currentInstalled
+								? state.status === "uninstalling"
+									? "Uninstalling..."
+									: "Uninstall"
+								: state.status === "installing"
+									? "Installing..."
+									: state.status === "installed"
+										? "Installed"
+										: installLabel(false)}
 					</Button>
 				</DialogFooter>
 			</DialogContent>

--- a/apps/cline-hub/src/webview/src/components/views/marketplace-view.tsx
+++ b/apps/cline-hub/src/webview/src/components/views/marketplace-view.tsx
@@ -544,7 +544,7 @@ function InstallDialog({
 					</div>
 				) : null}
 
-				{currentInstalled && state.status !== "installed" ? (
+				{currentInstalled && state.status === "idle" ? (
 					<div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-3 text-sm text-emerald-700 dark:text-emerald-300">
 						This entry is already installed.
 					</div>

--- a/apps/cline-hub/src/webview/src/components/views/marketplace-view.tsx
+++ b/apps/cline-hub/src/webview/src/components/views/marketplace-view.tsx
@@ -42,7 +42,6 @@ type InstallState =
 			status: "installed";
 			message: string;
 			output?: string;
-			warnings?: string[];
 	  }
 	| { status: "failed"; message: string };
 
@@ -50,7 +49,6 @@ type MarketplaceInstallResult = {
 	status: "installed";
 	message: string;
 	output?: string;
-	warnings?: string[];
 };
 
 type MarketplaceInstallStatusResult = {
@@ -385,7 +383,6 @@ function InstallDialog({
 				status: "installed",
 				message: result.message,
 				output: result.output,
-				warnings: result.warnings,
 			});
 			onInstalled(entry);
 		} catch (error) {

--- a/apps/cline-hub/src/webview/src/components/views/marketplace-view.tsx
+++ b/apps/cline-hub/src/webview/src/components/views/marketplace-view.tsx
@@ -203,10 +203,6 @@ function EntryDetails({
 			onKeyDown={(event) => event.stopPropagation()}
 			role="presentation"
 		>
-			<p className="text-sm leading-6 text-muted-foreground">
-				{entry.description}
-			</p>
-
 			{requiredEnv.length > 0 || optionalEnv.length > 0 ? (
 				<div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3">
 					<p className="text-sm font-medium text-amber-800 dark:text-amber-200">

--- a/apps/cline-hub/src/webview/src/components/views/marketplace-view.tsx
+++ b/apps/cline-hub/src/webview/src/components/views/marketplace-view.tsx
@@ -7,6 +7,7 @@ import {
 	Search,
 	Server,
 	Sparkles,
+	Trash2,
 	Wrench,
 } from "lucide-react";
 import { type CSSProperties, useEffect, useMemo, useState } from "react";
@@ -36,15 +37,21 @@ type PrimitiveFilter = "installed" | "all" | MarketplacePrimitiveType;
 type InstallState =
 	| { status: "idle" }
 	| { status: "installing" }
+	| { status: "uninstalling" }
 	| {
 			status: "installed";
+			message: string;
+			output?: string;
+	  }
+	| {
+			status: "uninstalled";
 			message: string;
 			output?: string;
 	  }
 	| { status: "failed"; message: string };
 
 type MarketplaceInstallResult = {
-	status: "installed";
+	status: "installed" | "uninstalled";
 	message: string;
 	output?: string;
 };
@@ -247,7 +254,7 @@ function TagButton({
 }
 
 function installLabel(installed: boolean): string {
-	if (installed) return "Installed";
+	if (installed) return "Uninstall";
 	return "Install";
 }
 
@@ -323,11 +330,11 @@ function MarketplaceCard({
 					disabled={!installedStatusReady}
 					onClick={openInstallDialog}
 					type="button"
-					variant={installed ? "secondary" : "default"}
+					variant={installed ? "destructive" : "default"}
 				>
 					{installedStatusReady ? null : <Spinner />}
 					{installedStatusReady && installed ? (
-						<CheckCircle2 className="size-4" />
+						<Trash2 className="size-4" />
 					) : null}
 					{installedStatusReady ? installLabel(installed) : "Checking..."}
 				</Button>
@@ -342,6 +349,7 @@ function InstallDialog({
 	installedStatusReady,
 	onClose,
 	onInstalled,
+	onUninstalled,
 	open,
 }: {
 	entry: MarketplaceEntry | null;
@@ -349,6 +357,7 @@ function InstallDialog({
 	installedStatusReady: boolean;
 	onClose: () => void;
 	onInstalled: (entry: MarketplaceEntry) => void;
+	onUninstalled: (entry: MarketplaceEntry) => void;
 	open: boolean;
 }) {
 	const [state, setState] = useState<InstallState>({ status: "idle" });
@@ -369,7 +378,13 @@ function InstallDialog({
 	};
 
 	const install = async () => {
-		if (!entry || state.status === "installing") return;
+		if (
+			!entry ||
+			state.status === "installing" ||
+			state.status === "uninstalling"
+		) {
+			return;
+		}
 		setState({ status: "installing" });
 		try {
 			const result = await desktopClient.invoke<MarketplaceInstallResult>(
@@ -383,6 +398,35 @@ function InstallDialog({
 				output: result.output,
 			});
 			onInstalled(entry);
+		} catch (error) {
+			setState({
+				status: "failed",
+				message: error instanceof Error ? error.message : String(error),
+			});
+		}
+	};
+
+	const uninstall = async () => {
+		if (
+			!entry ||
+			state.status === "installing" ||
+			state.status === "uninstalling"
+		) {
+			return;
+		}
+		setState({ status: "uninstalling" });
+		try {
+			const result = await desktopClient.invoke<MarketplaceInstallResult>(
+				"uninstall_marketplace_entry",
+				{ entry },
+				{ timeoutMs: INSTALL_TIMEOUT_MS },
+			);
+			setState({
+				status: "uninstalled",
+				message: result.message,
+				output: result.output,
+			});
+			onUninstalled(entry);
 		} catch (error) {
 			setState({
 				status: "failed",
@@ -494,12 +538,18 @@ function InstallDialog({
 						{state.message}
 					</div>
 				) : null}
+				{state.status === "uninstalled" ? (
+					<div className="rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+						{state.message}
+					</div>
+				) : null}
 				{state.status === "failed" ? (
 					<div className="max-h-44 overflow-auto rounded-lg border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
 						{state.message}
 					</div>
 				) : null}
-				{state.status === "installed" && state.output ? (
+				{(state.status === "installed" || state.status === "uninstalled") &&
+				state.output ? (
 					<pre
 						className="max-h-44 overflow-auto rounded-lg border bg-muted/30 p-3 font-mono text-xs text-muted-foreground"
 						style={CODE_FONT_STYLE}
@@ -510,7 +560,9 @@ function InstallDialog({
 
 				<DialogFooter>
 					<Button
-						disabled={state.status === "installing"}
+						disabled={
+							state.status === "installing" || state.status === "uninstalling"
+						}
 						onClick={onClose}
 						type="button"
 						variant="outline"
@@ -520,26 +572,33 @@ function InstallDialog({
 					<Button
 						disabled={
 							!installedStatusReady ||
-							installed ||
 							state.status === "installing" ||
-							state.status === "installed"
+							state.status === "uninstalling" ||
+							state.status === "installed" ||
+							state.status === "uninstalled"
 						}
-						onClick={install}
+						onClick={installed ? uninstall : install}
 						type="button"
+						variant={installed ? "destructive" : "default"}
 					>
 						{state.status === "installing" ? <Spinner /> : null}
+						{state.status === "uninstalling" ? <Spinner /> : null}
 						{installed || state.status === "installed" ? (
-							<CheckCircle2 className="size-4" />
+							<Trash2 className="size-4" />
 						) : null}
 						{!installedStatusReady
 							? "Checking..."
-							: installed
-								? "Installed"
-								: state.status === "installing"
-									? "Installing..."
-									: state.status === "installed"
-										? "Installed"
-										: installLabel(false)}
+							: state.status === "uninstalled"
+								? "Uninstalled"
+								: installed
+									? state.status === "uninstalling"
+										? "Uninstalling..."
+										: "Uninstall"
+									: state.status === "installing"
+										? "Installing..."
+										: state.status === "installed"
+											? "Installed"
+											: installLabel(false)}
 					</Button>
 				</DialogFooter>
 			</DialogContent>
@@ -865,6 +924,13 @@ export function MarketplaceView() {
 					setInstalledEntryKeys((current) =>
 						new Set(current).add(entryKey(entry)),
 					)
+				}
+				onUninstalled={(entry) =>
+					setInstalledEntryKeys((current) => {
+						const next = new Set(current);
+						next.delete(entryKey(entry));
+						return next;
+					})
 				}
 				open={selectedEntry !== null}
 			/>

--- a/apps/cline-hub/src/webview/src/components/views/marketplace-view.tsx
+++ b/apps/cline-hub/src/webview/src/components/views/marketplace-view.tsx
@@ -127,6 +127,7 @@ function EntryIcon({ entry }: { entry: MarketplaceEntry }) {
 		.toUpperCase();
 	return (
 		<div className="flex size-11 shrink-0 items-center justify-center overflow-hidden rounded-lg border bg-background">
+			{/* Marketplace icons are currently often placeholders, so keep them hidden for now.
 			{entry.icon ? (
 				<img
 					alt=""
@@ -135,10 +136,11 @@ function EntryIcon({ entry }: { entry: MarketplaceEntry }) {
 					src={entry.icon}
 				/>
 			) : (
-				<span className="text-xs font-semibold text-muted-foreground">
-					{initials}
-				</span>
-			)}
+			*/}
+			<span className="text-xs font-semibold text-muted-foreground">
+				{initials}
+			</span>
+			{/* )} */}
 		</div>
 	);
 }

--- a/apps/cline-hub/src/webview/src/components/views/marketplace-view.tsx
+++ b/apps/cline-hub/src/webview/src/components/views/marketplace-view.tsx
@@ -1,0 +1,878 @@
+"use client";
+
+import {
+	CheckCircle2,
+	Copy,
+	ExternalLink,
+	Package,
+	Plug,
+	Search,
+	Server,
+	Sparkles,
+	Wrench,
+} from "lucide-react";
+import { type CSSProperties, useEffect, useMemo, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Spinner } from "@/components/ui/spinner";
+import { desktopClient } from "@/lib/desktop-client";
+import {
+	fetchMarketplaceCatalog,
+	type MarketplaceCatalog,
+	type MarketplaceEntry,
+	type MarketplacePrimitiveType,
+	type MarketplaceTag,
+} from "@/lib/marketplace";
+
+type PrimitiveFilter = "installed" | "all" | MarketplacePrimitiveType;
+type InstallState =
+	| { status: "idle" }
+	| { status: "installing" }
+	| {
+			status: "installed";
+			message: string;
+			output?: string;
+			warnings?: string[];
+	  }
+	| { status: "failed"; message: string };
+
+type MarketplaceInstallResult = {
+	status: "installed";
+	message: string;
+	output?: string;
+	warnings?: string[];
+};
+
+type MarketplaceInstallStatusResult = {
+	installedKeys: string[];
+};
+
+type InstalledStatusState = "loading" | "ready";
+
+const INSTALL_TIMEOUT_MS = 300_000;
+const CODE_FONT_STYLE: CSSProperties = {
+	fontFamily:
+		'ui-monospace, "SFMono-Regular", Menlo, Consolas, "Liberation Mono", monospace',
+};
+
+const primitiveLabels: Record<PrimitiveFilter, string> = {
+	installed: "Installed",
+	all: "All",
+	mcp: "MCP",
+	skill: "Skills",
+	plugin: "Plugins",
+};
+
+const primitiveBadgeLabels: Record<MarketplacePrimitiveType, string> = {
+	mcp: "MCP Server",
+	skill: "Skill",
+	plugin: "Plugin",
+};
+
+const primitiveIcons = {
+	installed: CheckCircle2,
+	all: Package,
+	mcp: Server,
+	skill: Wrench,
+	plugin: Plug,
+} satisfies Record<PrimitiveFilter, typeof Package>;
+
+function getPrimitiveCount(
+	catalog: MarketplaceCatalog,
+	primitive: PrimitiveFilter,
+	installedCount: number,
+): number {
+	if (primitive === "installed") return installedCount;
+	if (primitive === "all") return catalog.counts.total;
+	if (primitive === "mcp") return catalog.counts.mcps;
+	if (primitive === "skill") return catalog.counts.skills;
+	return catalog.counts.plugins;
+}
+
+function TypeBadge({ type }: { type: MarketplacePrimitiveType }) {
+	const tone = {
+		mcp: "border-purple-400/40 bg-purple-500/10 text-purple-700 dark:text-purple-300",
+		skill:
+			"border-emerald-400/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+		plugin: "border-sky-400/40 bg-sky-500/10 text-sky-700 dark:text-sky-300",
+	}[type];
+	return (
+		<Badge variant="outline" className={tone}>
+			{primitiveBadgeLabels[type]}
+		</Badge>
+	);
+}
+
+function MarketplaceIcon() {
+	return (
+		<svg
+			aria-hidden="true"
+			className="size-9 shrink-0 text-primary"
+			fill="none"
+			viewBox="0 0 48 48"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<rect
+				height="20"
+				rx="4"
+				stroke="currentColor"
+				strokeLinejoin="round"
+				strokeWidth="2.5"
+				width="28"
+				x="10"
+				y="18"
+			/>
+			<path
+				d="M14 26h10v12H14V26Z"
+				stroke="currentColor"
+				strokeLinejoin="round"
+				strokeWidth="2.5"
+			/>
+			<path
+				d="M28 27h6M28 33h6"
+				stroke="currentColor"
+				strokeLinecap="round"
+				strokeWidth="2.5"
+			/>
+			<path
+				d="M9 10h30l3 9H6l3-9Z"
+				stroke="currentColor"
+				strokeLinejoin="round"
+				strokeWidth="2.5"
+			/>
+			<path
+				d="M15 10l-1.5 9M24 10v9M33 10l1.5 9"
+				stroke="currentColor"
+				strokeLinecap="round"
+				strokeWidth="2.5"
+			/>
+			<path
+				d="M6 19h36v2c0 1.7-1.3 3-3 3s-3-1.3-3-3c0 1.7-1.3 3-3 3s-3-1.3-3-3c0 1.7-1.3 3-3 3s-3-1.3-3-3c0 1.7-1.3 3-3 3s-3-1.3-3-3c0 1.7-1.3 3-3 3s-3-1.3-3-3c0 1.7-1.3 3-3 3s-3-1.3-3-3v-2Z"
+				stroke="currentColor"
+				strokeLinejoin="round"
+				strokeWidth="2.5"
+			/>
+		</svg>
+	);
+}
+
+function EntryIcon({ entry }: { entry: MarketplaceEntry }) {
+	const initials = entry.name
+		.split(/\s+/)
+		.map((part) => part[0])
+		.join("")
+		.slice(0, 2)
+		.toUpperCase();
+	return (
+		<div className="flex size-11 shrink-0 items-center justify-center overflow-hidden rounded-lg border bg-background">
+			{entry.icon ? (
+				<img
+					alt=""
+					className="max-h-8 max-w-8 object-contain"
+					referrerPolicy="no-referrer"
+					src={entry.icon}
+				/>
+			) : (
+				<span className="text-xs font-semibold text-muted-foreground">
+					{initials}
+				</span>
+			)}
+		</div>
+	);
+}
+
+function PrimitiveButton({
+	active,
+	catalog,
+	installedCount,
+	onClick,
+	primitive,
+}: {
+	active: boolean;
+	catalog: MarketplaceCatalog;
+	installedCount: number;
+	onClick: () => void;
+	primitive: PrimitiveFilter;
+}) {
+	const Icon = primitiveIcons[primitive];
+	return (
+		<Button
+			aria-pressed={active}
+			className="w-full justify-between"
+			onClick={onClick}
+			type="button"
+			variant={active ? "default" : "ghost"}
+		>
+			<span className="flex min-w-0 items-center gap-2">
+				<Icon className="size-4" />
+				<span className="truncate">{primitiveLabels[primitive]}</span>
+			</span>
+			<span className="rounded bg-background/30 px-1.5 py-0.5 text-xs">
+				{getPrimitiveCount(catalog, primitive, installedCount)}
+			</span>
+		</Button>
+	);
+}
+
+function TagButton({
+	active,
+	onClick,
+	tag,
+}: {
+	active: boolean;
+	onClick: () => void;
+	tag: MarketplaceTag;
+}) {
+	return (
+		<Button
+			aria-pressed={active}
+			className="w-full justify-between"
+			onClick={onClick}
+			size="sm"
+			type="button"
+			variant={active ? "default" : "ghost"}
+		>
+			<span className="truncate">{tag.label}</span>
+			<span className="rounded bg-background/30 px-1.5 py-0.5 text-xs">
+				{tag.count}
+			</span>
+		</Button>
+	);
+}
+
+function installLabel(installed: boolean): string {
+	if (installed) return "Installed";
+	return "Install";
+}
+
+function entryKey(entry: Pick<MarketplaceEntry, "id" | "type">): string {
+	return `${entry.type}:${entry.id}`;
+}
+
+function MarketplaceCard({
+	entry,
+	installed,
+	installedStatusReady,
+	onInstall,
+	tagLabels,
+}: {
+	entry: MarketplaceEntry;
+	installed: boolean;
+	installedStatusReady: boolean;
+	onInstall: (entry: MarketplaceEntry) => void;
+	tagLabels: Map<string, string>;
+}) {
+	const openInstallDialog = () => onInstall(entry);
+	return (
+		// biome-ignore lint/a11y/useSemanticElements: The card contains a nested action button, so the wrapper cannot be a native button.
+		<div
+			aria-label={`View ${entry.name} installation details`}
+			className="flex min-h-64 cursor-pointer flex-col rounded-lg border bg-card p-4 transition-colors hover:bg-accent/20 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none"
+			onClick={openInstallDialog}
+			onKeyDown={(event) => {
+				if (event.key === "Enter" || event.key === " ") {
+					event.preventDefault();
+					openInstallDialog();
+				}
+			}}
+			role="button"
+			tabIndex={0}
+		>
+			<div className="flex items-start gap-3">
+				<EntryIcon entry={entry} />
+				<div className="min-w-0 flex-1">
+					<div className="flex min-w-0 items-start justify-between gap-2">
+						<h2 className="min-w-0 truncate text-sm font-semibold text-foreground">
+							{entry.name}
+							{entry.featured ? (
+								<Sparkles className="ml-1.5 inline size-3.5 shrink-0 text-primary" />
+							) : null}
+						</h2>
+						<TypeBadge type={entry.type} />
+					</div>
+					<div className="mt-1 flex flex-wrap gap-1.5">
+						{entry.tags.slice(0, 4).map((tag) => (
+							<Badge
+								key={tag}
+								variant="outline"
+								className="max-w-full text-muted-foreground"
+							>
+								<span className="truncate">{tagLabels.get(tag) ?? tag}</span>
+							</Badge>
+						))}
+					</div>
+				</div>
+			</div>
+			<p className="mt-3 line-clamp-3 text-xs leading-5 text-muted-foreground">
+				{entry.tagline}
+			</p>
+			{entry.install.env && entry.install.env.length > 0 ? (
+				<p className="mt-3 text-xs text-amber-700 dark:text-amber-300">
+					Requires setup after install
+				</p>
+			) : null}
+			<div className="mt-auto pt-4">
+				<Button
+					className="w-full"
+					disabled={!installedStatusReady}
+					onClick={openInstallDialog}
+					type="button"
+					variant={installed ? "secondary" : "default"}
+				>
+					{installedStatusReady ? null : <Spinner />}
+					{installedStatusReady && installed ? (
+						<CheckCircle2 className="size-4" />
+					) : null}
+					{installedStatusReady ? installLabel(installed) : "Checking..."}
+				</Button>
+			</div>
+		</div>
+	);
+}
+
+function InstallDialog({
+	entry,
+	installed,
+	installedStatusReady,
+	onClose,
+	onInstalled,
+	open,
+}: {
+	entry: MarketplaceEntry | null;
+	installed: boolean;
+	installedStatusReady: boolean;
+	onClose: () => void;
+	onInstalled: (entry: MarketplaceEntry) => void;
+	open: boolean;
+}) {
+	const [state, setState] = useState<InstallState>({ status: "idle" });
+	const requiredEnv =
+		entry?.install.env?.filter((env) => env.required !== false) ?? [];
+	const optionalEnv =
+		entry?.install.env?.filter((env) => env.required === false) ?? [];
+
+	useEffect(() => {
+		if (open) {
+			setState({ status: "idle" });
+		}
+	}, [open]);
+
+	const copyCommand = async () => {
+		if (!entry) return;
+		await navigator.clipboard?.writeText(entry.install.command);
+	};
+
+	const install = async () => {
+		if (!entry || state.status === "installing") return;
+		setState({ status: "installing" });
+		try {
+			const result = await desktopClient.invoke<MarketplaceInstallResult>(
+				"install_marketplace_entry",
+				{ entry },
+				{ timeoutMs: INSTALL_TIMEOUT_MS },
+			);
+			setState({
+				status: "installed",
+				message: result.message,
+				output: result.output,
+				warnings: result.warnings,
+			});
+			onInstalled(entry);
+		} catch (error) {
+			setState({
+				status: "failed",
+				message: error instanceof Error ? error.message : String(error),
+			});
+		}
+	};
+
+	if (!entry) return null;
+	return (
+		<Dialog open={open} onOpenChange={(nextOpen) => !nextOpen && onClose()}>
+			<DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
+				<DialogHeader>
+					<div className="flex items-start gap-3">
+						<EntryIcon entry={entry} />
+						<div className="min-w-0">
+							<DialogTitle>{entry.name}</DialogTitle>
+							<DialogDescription className="mt-1">
+								{entry.tagline}
+							</DialogDescription>
+							<div className="mt-2 flex flex-wrap gap-1.5">
+								<TypeBadge type={entry.type} />
+							</div>
+						</div>
+					</div>
+				</DialogHeader>
+
+				<p className="text-sm leading-6 text-muted-foreground">
+					{entry.description}
+				</p>
+
+				<div className="rounded-lg border bg-muted/30 p-3">
+					<div className="mb-2 flex items-center justify-between gap-3">
+						<p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+							Equivalent Command
+						</p>
+						<Button
+							onClick={copyCommand}
+							size="sm"
+							type="button"
+							variant="ghost"
+						>
+							<Copy className="size-3.5" />
+							Copy
+						</Button>
+					</div>
+					<code className="block overflow-x-auto whitespace-nowrap font-mono text-xs text-muted-foreground">
+						<span style={CODE_FONT_STYLE}>{entry.install.command}</span>
+					</code>
+				</div>
+
+				{requiredEnv.length > 0 || optionalEnv.length > 0 ? (
+					<div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3">
+						<p className="text-sm font-medium text-amber-800 dark:text-amber-200">
+							Environment setup needed
+						</p>
+						<p className="mt-1 text-xs leading-5 text-amber-800/80 dark:text-amber-100/80">
+							This dashboard does not store secrets in v1. Add these values to
+							your Cline/plugin environment after install.
+						</p>
+						<div className="mt-3 grid gap-2">
+							{[...requiredEnv, ...optionalEnv].map((env) => (
+								<div
+									key={env.name}
+									className="rounded-md border border-amber-500/20 bg-background/60 p-2"
+								>
+									<div className="flex items-center justify-between gap-2">
+										<code className="font-mono text-xs font-semibold">
+											<span style={CODE_FONT_STYLE}>{env.name}</span>
+										</code>
+										<Badge variant="outline">
+											{env.required === false ? "Optional" : "Required"}
+										</Badge>
+									</div>
+									{env.description ? (
+										<p className="mt-1 text-xs text-muted-foreground">
+											{env.description}
+										</p>
+									) : null}
+									{env.url ? (
+										<a
+											className="mt-1 inline-flex items-center gap-1 text-xs text-primary hover:underline"
+											href={env.url}
+											rel="noreferrer"
+											target="_blank"
+										>
+											Get value
+											<ExternalLink className="size-3" />
+										</a>
+									) : null}
+								</div>
+							))}
+						</div>
+					</div>
+				) : null}
+
+				{installed && state.status !== "installed" ? (
+					<div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-3 text-sm text-emerald-700 dark:text-emerald-300">
+						This entry is already installed.
+					</div>
+				) : null}
+				{!installedStatusReady ? (
+					<div className="rounded-lg border bg-muted/30 p-3 text-sm text-muted-foreground">
+						Checking whether this entry is already installed...
+					</div>
+				) : null}
+				{state.status === "installed" ? (
+					<div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-3 text-sm text-emerald-700 dark:text-emerald-300">
+						{state.message}
+					</div>
+				) : null}
+				{state.status === "failed" ? (
+					<div className="max-h-44 overflow-auto rounded-lg border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+						{state.message}
+					</div>
+				) : null}
+				{state.status === "installed" && state.output ? (
+					<pre
+						className="max-h-44 overflow-auto rounded-lg border bg-muted/30 p-3 font-mono text-xs text-muted-foreground"
+						style={CODE_FONT_STYLE}
+					>
+						{state.output}
+					</pre>
+				) : null}
+
+				<DialogFooter>
+					<Button
+						disabled={state.status === "installing"}
+						onClick={onClose}
+						type="button"
+						variant="outline"
+					>
+						Close
+					</Button>
+					<Button
+						disabled={
+							!installedStatusReady ||
+							installed ||
+							state.status === "installing" ||
+							state.status === "installed"
+						}
+						onClick={install}
+						type="button"
+					>
+						{state.status === "installing" ? <Spinner /> : null}
+						{installed || state.status === "installed" ? (
+							<CheckCircle2 className="size-4" />
+						) : null}
+						{!installedStatusReady
+							? "Checking..."
+							: installed
+								? "Installed"
+								: state.status === "installing"
+									? "Installing..."
+									: state.status === "installed"
+										? "Installed"
+										: installLabel(false)}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}
+
+export function MarketplaceView() {
+	const [catalog, setCatalog] = useState<MarketplaceCatalog | null>(null);
+	const [errorMessage, setErrorMessage] = useState<string | null>(null);
+	const [query, setQuery] = useState("");
+	const [primitive, setPrimitive] = useState<PrimitiveFilter>("all");
+	const [selectedTag, setSelectedTag] = useState<string | null>(null);
+	const [selectedEntry, setSelectedEntry] = useState<MarketplaceEntry | null>(
+		null,
+	);
+	const [installedEntryKeys, setInstalledEntryKeys] = useState<Set<string>>(
+		() => new Set(),
+	);
+	const [installedStatusState, setInstalledStatusState] =
+		useState<InstalledStatusState>("loading");
+
+	useEffect(() => {
+		let cancelled = false;
+		void (async () => {
+			try {
+				if (!cancelled) {
+					setInstalledStatusState("loading");
+				}
+				const nextCatalog = await fetchMarketplaceCatalog();
+				if (!cancelled) {
+					setCatalog(nextCatalog);
+					setErrorMessage(null);
+				}
+				try {
+					const response =
+						await desktopClient.invoke<MarketplaceInstallStatusResult>(
+							"list_marketplace_installed_entries",
+							{ entries: nextCatalog.entries },
+						);
+					if (!cancelled) {
+						setInstalledEntryKeys(new Set(response.installedKeys));
+						setInstalledStatusState("ready");
+					}
+				} catch (error) {
+					if (!cancelled) {
+						setInstalledStatusState("ready");
+					}
+				}
+			} catch (error) {
+				if (!cancelled) {
+					setErrorMessage(
+						error instanceof Error ? error.message : String(error),
+					);
+					setInstalledStatusState("ready");
+				}
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	const tagLabels = useMemo(
+		() => new Map(catalog?.tags.map((tag) => [tag.id, tag.label]) ?? []),
+		[catalog?.tags],
+	);
+
+	const filteredEntries = useMemo(() => {
+		if (!catalog) return [];
+		const normalizedQuery = query.trim().toLowerCase();
+		return catalog.entries.filter((entry) => {
+			const key = entryKey(entry);
+			const matchesPrimitive =
+				primitive === "all" ||
+				(primitive === "installed" && installedEntryKeys.has(key)) ||
+				entry.type === primitive;
+			const matchesTag = !selectedTag || entry.tags.includes(selectedTag);
+			const searchableText = [
+				entry.name,
+				entry.tagline,
+				entry.description,
+				entry.type,
+				...entry.tags.map((tag) => tagLabels.get(tag) ?? tag),
+			]
+				.join(" ")
+				.toLowerCase();
+			const matchesQuery =
+				normalizedQuery.length === 0 ||
+				searchableText.includes(normalizedQuery);
+			return matchesPrimitive && matchesTag && matchesQuery;
+		});
+	}, [catalog, installedEntryKeys, primitive, query, selectedTag, tagLabels]);
+
+	const clearFilters = () => {
+		setQuery("");
+		setPrimitive("all");
+		setSelectedTag(null);
+	};
+
+	const activeFilters =
+		query.trim().length > 0 || primitive !== "all" || selectedTag !== null;
+	const installedStatusReady = installedStatusState === "ready";
+	const selectedEntryInstalled = selectedEntry
+		? installedEntryKeys.has(entryKey(selectedEntry))
+		: false;
+
+	return (
+		<ScrollArea className="h-full">
+			<div className="mx-auto max-w-7xl px-6 py-6 max-[720px]:px-3">
+				<div className="mb-6 flex flex-col gap-4 border-b pb-5 lg:flex-row lg:items-end lg:justify-between">
+					<div>
+						<h1 className="flex items-center gap-3 text-2xl font-semibold tracking-normal text-foreground">
+							<MarketplaceIcon />
+							<span>Marketplace</span>
+						</h1>
+						<p className="mt-1 max-w-2xl text-sm text-muted-foreground">
+							Browse Cline primitives and install them directly into this CLI
+							environment.
+						</p>
+					</div>
+					{catalog?.generatedAt ? (
+						<p className="text-xs text-muted-foreground">
+							Updated{" "}
+							{new Intl.DateTimeFormat(undefined, {
+								month: "short",
+								day: "numeric",
+								year: "numeric",
+							}).format(new Date(catalog.generatedAt))}
+						</p>
+					) : null}
+				</div>
+
+				{!catalog && !errorMessage ? (
+					<div className="flex min-h-80 items-center justify-center rounded-lg border bg-card text-sm text-muted-foreground">
+						<Spinner className="mr-2" />
+						Loading marketplace...
+					</div>
+				) : (
+					<div className="grid gap-5 lg:grid-cols-[16rem_minmax(0,1fr)]">
+						<aside className="min-w-0 lg:sticky lg:top-4 lg:self-start">
+							<div className="rounded-lg border bg-card p-3">
+								<PrimitiveButton
+									active={primitive === "installed"}
+									catalog={
+										catalog ?? {
+											version: 1,
+											counts: {
+												total: 0,
+												mcps: 0,
+												skills: 0,
+												plugins: 0,
+											},
+											tags: [],
+											entries: [],
+										}
+									}
+									installedCount={installedEntryKeys.size}
+									onClick={() => setPrimitive("installed")}
+									primitive="installed"
+								/>
+							</div>
+
+							<div className="mt-3 rounded-lg border bg-card p-3">
+								<p className="mb-2 text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+									Primitive
+								</p>
+								<div className="grid gap-1">
+									{(["all", "mcp", "skill", "plugin"] as PrimitiveFilter[]).map(
+										(item) => (
+											<PrimitiveButton
+												active={primitive === item}
+												catalog={
+													catalog ?? {
+														version: 1,
+														counts: {
+															total: 0,
+															mcps: 0,
+															skills: 0,
+															plugins: 0,
+														},
+														tags: [],
+														entries: [],
+													}
+												}
+												installedCount={installedEntryKeys.size}
+												key={item}
+												onClick={() => setPrimitive(item)}
+												primitive={item}
+											/>
+										),
+									)}
+								</div>
+							</div>
+
+							<div className="mt-3 rounded-lg border bg-card p-3">
+								<div className="mb-2 flex items-center justify-between gap-2">
+									<p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+										Tags
+									</p>
+									{selectedTag ? (
+										<Button
+											onClick={() => setSelectedTag(null)}
+											size="xs"
+											type="button"
+											variant="ghost"
+										>
+											Clear
+										</Button>
+									) : null}
+								</div>
+								<div className="grid max-h-80 gap-1 overflow-y-auto">
+									{catalog?.tags
+										.filter((tag) => tag.count > 0)
+										.map((tag) => (
+											<TagButton
+												active={selectedTag === tag.id}
+												key={tag.id}
+												onClick={() =>
+													setSelectedTag((current) =>
+														current === tag.id ? null : tag.id,
+													)
+												}
+												tag={tag}
+											/>
+										))}
+									{catalog?.tags.every((tag) => tag.count === 0) ? (
+										<p className="px-2 py-3 text-xs text-muted-foreground">
+											No tags available.
+										</p>
+									) : null}
+								</div>
+							</div>
+						</aside>
+
+						<section className="min-w-0">
+							<div className="mb-4 flex flex-col gap-3 md:flex-row md:items-center">
+								<div className="relative block flex-1">
+									<Search className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+									<Input
+										aria-label="Search marketplace"
+										className="h-10 pl-8"
+										onChange={(event) => setQuery(event.target.value)}
+										placeholder="Search marketplace"
+										value={query}
+									/>
+								</div>
+								<div className="flex min-h-8 items-center gap-2 text-sm text-muted-foreground">
+									<span className="font-medium text-foreground">
+										{filteredEntries.length}
+									</span>
+									<span>
+										{filteredEntries.length === 1 ? "result" : "results"}
+									</span>
+									{activeFilters ? (
+										<Button
+											onClick={clearFilters}
+											size="sm"
+											type="button"
+											variant="ghost"
+										>
+											Clear filters
+										</Button>
+									) : null}
+								</div>
+							</div>
+
+							{errorMessage ? (
+								<div className="rounded-lg border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive">
+									{errorMessage}
+								</div>
+							) : null}
+
+							{catalog && filteredEntries.length > 0 ? (
+								<div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
+									{filteredEntries.map((entry) => {
+										const key = entryKey(entry);
+										return (
+											<MarketplaceCard
+												entry={entry}
+												installed={installedEntryKeys.has(key)}
+												installedStatusReady={installedStatusReady}
+												key={key}
+												onInstall={setSelectedEntry}
+												tagLabels={tagLabels}
+											/>
+										);
+									})}
+								</div>
+							) : null}
+
+							{catalog && filteredEntries.length === 0 ? (
+								<div className="flex min-h-80 flex-col items-center justify-center rounded-lg border border-dashed bg-card p-6 text-center">
+									<p className="text-base font-medium text-foreground">
+										No entries found
+									</p>
+									<p className="mt-1 text-sm text-muted-foreground">
+										Try changing your search or filters.
+									</p>
+									{activeFilters ? (
+										<Button
+											className="mt-4"
+											onClick={clearFilters}
+											type="button"
+											variant="outline"
+										>
+											Clear filters
+										</Button>
+									) : null}
+								</div>
+							) : null}
+						</section>
+					</div>
+				)}
+			</div>
+			<InstallDialog
+				entry={selectedEntry}
+				installed={selectedEntryInstalled}
+				installedStatusReady={installedStatusReady}
+				key={selectedEntry ? entryKey(selectedEntry) : "empty"}
+				onClose={() => setSelectedEntry(null)}
+				onInstalled={(entry) =>
+					setInstalledEntryKeys((current) =>
+						new Set(current).add(entryKey(entry)),
+					)
+				}
+				open={selectedEntry !== null}
+			/>
+		</ScrollArea>
+	);
+}

--- a/apps/cline-hub/src/webview/src/components/views/marketplace-view.tsx
+++ b/apps/cline-hub/src/webview/src/components/views/marketplace-view.tsx
@@ -2,7 +2,6 @@ import {
 	CheckCircle2,
 	Copy,
 	ExternalLink,
-	Package,
 	Plug,
 	Search,
 	Server,
@@ -19,14 +18,6 @@ import {
 } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-	Dialog,
-	DialogContent,
-	DialogDescription,
-	DialogFooter,
-	DialogHeader,
-	DialogTitle,
-} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Spinner } from "@/components/ui/spinner";
@@ -39,8 +30,7 @@ import {
 	type MarketplaceTag,
 } from "@/lib/marketplace";
 
-type PrimitiveFilter = "installed" | "all" | MarketplacePrimitiveType;
-type InstallState =
+type EntryActionState =
 	| { status: "idle" }
 	| { status: "installing" }
 	| { status: "uninstalling" }
@@ -74,39 +64,45 @@ const CODE_FONT_STYLE: CSSProperties = {
 		'ui-monospace, "SFMono-Regular", Menlo, Consolas, "Liberation Mono", monospace',
 };
 
-const primitiveLabels: Record<PrimitiveFilter, string> = {
-	installed: "Installed",
-	all: "All",
-	mcp: "MCP",
-	skill: "Skills",
-	plugin: "Plugins",
-};
+const primitivePageDetails = {
+	mcp: {
+		title: "MCP Servers",
+		description:
+			"Install Model Context Protocol servers into this CLI environment.",
+		emptyInstalled: "No MCP servers installed from this catalog.",
+		emptyCatalog: "No MCP servers match the current filters.",
+		icon: Server,
+	},
+	skill: {
+		title: "Skills",
+		description: "Install skills globally for Cline.",
+		emptyInstalled: "No skills installed from this catalog.",
+		emptyCatalog: "No skills match the current filters.",
+		icon: Wrench,
+	},
+	plugin: {
+		title: "Plugins",
+		description: "Install plugins into this CLI environment.",
+		emptyInstalled: "No plugins installed from this catalog.",
+		emptyCatalog: "No plugins match the current filters.",
+		icon: Plug,
+	},
+} satisfies Record<
+	MarketplacePrimitiveType,
+	{
+		title: string;
+		description: string;
+		emptyInstalled: string;
+		emptyCatalog: string;
+		icon: typeof Server;
+	}
+>;
 
 const primitiveBadgeLabels: Record<MarketplacePrimitiveType, string> = {
 	mcp: "MCP Server",
 	skill: "Skill",
 	plugin: "Plugin",
 };
-
-const primitiveIcons = {
-	installed: CheckCircle2,
-	all: Package,
-	mcp: Server,
-	skill: Wrench,
-	plugin: Plug,
-} satisfies Record<PrimitiveFilter, typeof Package>;
-
-function getPrimitiveCount(
-	catalog: MarketplaceCatalog,
-	primitive: PrimitiveFilter,
-	installedCount: number,
-): number {
-	if (primitive === "installed") return installedCount;
-	if (primitive === "all") return catalog.counts.total;
-	if (primitive === "mcp") return catalog.counts.mcps;
-	if (primitive === "skill") return catalog.counts.skills;
-	return catalog.counts.plugins;
-}
 
 function TypeBadge({ type }: { type: MarketplacePrimitiveType }) {
 	const tone = {
@@ -116,62 +112,9 @@ function TypeBadge({ type }: { type: MarketplacePrimitiveType }) {
 		plugin: "border-sky-400/40 bg-sky-500/10 text-sky-700 dark:text-sky-300",
 	}[type];
 	return (
-		<Badge variant="outline" className={tone}>
-			{primitiveBadgeLabels[type]}
+		<Badge variant="outline" className={`${tone} max-w-32`}>
+			<span className="truncate">{primitiveBadgeLabels[type]}</span>
 		</Badge>
-	);
-}
-
-function MarketplaceIcon() {
-	return (
-		<svg
-			aria-hidden="true"
-			className="size-9 shrink-0 text-primary"
-			fill="none"
-			viewBox="0 0 48 48"
-			xmlns="http://www.w3.org/2000/svg"
-		>
-			<rect
-				height="20"
-				rx="4"
-				stroke="currentColor"
-				strokeLinejoin="round"
-				strokeWidth="2.5"
-				width="28"
-				x="10"
-				y="18"
-			/>
-			<path
-				d="M14 26h10v12H14V26Z"
-				stroke="currentColor"
-				strokeLinejoin="round"
-				strokeWidth="2.5"
-			/>
-			<path
-				d="M28 27h6M28 33h6"
-				stroke="currentColor"
-				strokeLinecap="round"
-				strokeWidth="2.5"
-			/>
-			<path
-				d="M9 10h30l3 9H6l3-9Z"
-				stroke="currentColor"
-				strokeLinejoin="round"
-				strokeWidth="2.5"
-			/>
-			<path
-				d="M15 10l-1.5 9M24 10v9M33 10l1.5 9"
-				stroke="currentColor"
-				strokeLinecap="round"
-				strokeWidth="2.5"
-			/>
-			<path
-				d="M6 19h36v2c0 1.7-1.3 3-3 3s-3-1.3-3-3c0 1.7-1.3 3-3 3s-3-1.3-3-3c0 1.7-1.3 3-3 3s-3-1.3-3-3c0 1.7-1.3 3-3 3s-3-1.3-3-3c0 1.7-1.3 3-3 3s-3-1.3-3-3c0 1.7-1.3 3-3 3s-3-1.3-3-3v-2Z"
-				stroke="currentColor"
-				strokeLinejoin="round"
-				strokeWidth="2.5"
-			/>
-		</svg>
 	);
 }
 
@@ -200,110 +143,219 @@ function EntryIcon({ entry }: { entry: MarketplaceEntry }) {
 	);
 }
 
-function PrimitiveButton({
-	active,
-	catalog,
-	installedCount,
-	onClick,
-	primitive,
-}: {
-	active: boolean;
-	catalog: MarketplaceCatalog;
-	installedCount: number;
-	onClick: () => void;
-	primitive: PrimitiveFilter;
-}) {
-	const Icon = primitiveIcons[primitive];
-	return (
-		<Button
-			aria-pressed={active}
-			className="w-full justify-between"
-			onClick={onClick}
-			type="button"
-			variant={active ? "default" : "ghost"}
-		>
-			<span className="flex min-w-0 items-center gap-2">
-				<Icon className="size-4" />
-				<span className="truncate">{primitiveLabels[primitive]}</span>
-			</span>
-			<span className="rounded bg-background/30 px-1.5 py-0.5 text-xs">
-				{getPrimitiveCount(catalog, primitive, installedCount)}
-			</span>
-		</Button>
-	);
-}
-
-function TagButton({
-	active,
-	onClick,
-	tag,
-}: {
-	active: boolean;
-	onClick: () => void;
-	tag: MarketplaceTag;
-}) {
-	return (
-		<Button
-			aria-pressed={active}
-			className="w-full justify-between"
-			onClick={onClick}
-			size="sm"
-			type="button"
-			variant={active ? "default" : "ghost"}
-		>
-			<span className="truncate">{tag.label}</span>
-			<span className="rounded bg-background/30 px-1.5 py-0.5 text-xs">
-				{tag.count}
-			</span>
-		</Button>
-	);
-}
-
-function installLabel(installed: boolean): string {
-	if (installed) return "Uninstall";
-	return "Install";
-}
-
 function entryKey(entry: Pick<MarketplaceEntry, "id" | "type">): string {
 	return `${entry.type}:${entry.id}`;
 }
 
-function MarketplaceCard({
+function entrySearchText(
+	entry: MarketplaceEntry,
+	tagLabels: Map<string, string>,
+): string {
+	return [
+		entry.name,
+		entry.tagline,
+		entry.description,
+		entry.type,
+		...entry.tags.map((tag) => tagLabels.get(tag) ?? tag),
+	]
+		.join(" ")
+		.toLowerCase();
+}
+
+function actionMessage(
+	state: EntryActionState | undefined,
+): string | undefined {
+	if (state?.status === "installed" || state?.status === "uninstalled") {
+		return state.message;
+	}
+	return undefined;
+}
+
+function actionOutput(state: EntryActionState | undefined): string | undefined {
+	if (state?.status === "installed" || state?.status === "uninstalled") {
+		return state.output;
+	}
+	return undefined;
+}
+
+function EntryDetails({
+	actionState,
 	entry,
+}: {
+	actionState: EntryActionState | undefined;
+	entry: MarketplaceEntry;
+}) {
+	const requiredEnv =
+		entry.install.env?.filter((env) => env.required !== false) ?? [];
+	const optionalEnv =
+		entry.install.env?.filter((env) => env.required === false) ?? [];
+	const statusMessage = actionMessage(actionState);
+	const output = actionOutput(actionState);
+
+	const copyCommand = async () => {
+		await navigator.clipboard?.writeText(entry.install.command);
+	};
+
+	return (
+		<div
+			className="grid gap-3 border-t pt-3"
+			onClick={(event) => event.stopPropagation()}
+			onKeyDown={(event) => event.stopPropagation()}
+			role="presentation"
+		>
+			<p className="text-sm leading-6 text-muted-foreground">
+				{entry.description}
+			</p>
+
+			{requiredEnv.length > 0 || optionalEnv.length > 0 ? (
+				<div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3">
+					<p className="text-sm font-medium text-amber-800 dark:text-amber-200">
+						Environment setup needed
+					</p>
+					<p className="mt-1 text-xs leading-5 text-amber-800/80 dark:text-amber-100/80">
+						Add these values to your Cline/plugin environment after install.
+					</p>
+					<div className="mt-3 grid gap-2">
+						{[...requiredEnv, ...optionalEnv].map((env) => (
+							<div
+								key={env.name}
+								className="rounded-md border border-amber-500/20 bg-background/60 p-2"
+							>
+								<div className="flex items-center justify-between gap-2">
+									<code className="font-mono text-xs font-semibold">
+										<span style={CODE_FONT_STYLE}>{env.name}</span>
+									</code>
+									<Badge variant="outline">
+										{env.required === false ? "Optional" : "Required"}
+									</Badge>
+								</div>
+								{env.description ? (
+									<p className="mt-1 text-xs text-muted-foreground">
+										{env.description}
+									</p>
+								) : null}
+								{env.url ? (
+									<a
+										className="mt-1 inline-flex items-center gap-1 text-xs text-primary hover:underline"
+										href={env.url}
+										rel="noreferrer"
+										target="_blank"
+									>
+										Get value
+										<ExternalLink className="size-3" />
+									</a>
+								) : null}
+							</div>
+						))}
+					</div>
+				</div>
+			) : null}
+
+			{entry.install.notes ? (
+				<p className="rounded-lg border bg-muted/30 p-3 text-xs leading-5 text-muted-foreground">
+					{entry.install.notes}
+				</p>
+			) : null}
+
+			<details className="rounded-lg border bg-muted/30 p-3">
+				<summary className="cursor-pointer text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+					Manual CLI command
+				</summary>
+				<div className="mt-3 grid gap-2">
+					<p className="text-xs leading-5 text-muted-foreground">
+						Use this only if you prefer installing from a terminal.
+					</p>
+					<div className="flex items-start gap-2">
+						<code className="min-w-0 flex-1 overflow-x-auto whitespace-nowrap rounded-md border bg-background p-2 font-mono text-xs text-muted-foreground">
+							<span style={CODE_FONT_STYLE}>{entry.install.command}</span>
+						</code>
+						<Button
+							onClick={copyCommand}
+							size="sm"
+							type="button"
+							variant="ghost"
+						>
+							<Copy className="size-3.5" />
+							Copy
+						</Button>
+					</div>
+				</div>
+			</details>
+
+			{statusMessage ? (
+				<p className="text-sm text-muted-foreground">{statusMessage}</p>
+			) : null}
+			{actionState?.status === "failed" ? (
+				<div className="max-h-44 overflow-auto rounded-lg border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+					{actionState.message}
+				</div>
+			) : null}
+			{output ? (
+				<pre
+					className="max-h-44 overflow-auto rounded-lg border bg-muted/30 p-3 font-mono text-xs text-muted-foreground"
+					style={CODE_FONT_STYLE}
+				>
+					{output}
+				</pre>
+			) : null}
+		</div>
+	);
+}
+
+function MarketplaceEntryCard({
+	actionState,
+	entry,
+	expanded,
 	installed,
 	installedStatusReady,
-	uninstalling,
 	onInstall,
+	onToggleExpanded,
 	onUninstall,
 	tagLabels,
 }: {
+	actionState: EntryActionState | undefined;
 	entry: MarketplaceEntry;
+	expanded: boolean;
 	installed: boolean;
 	installedStatusReady: boolean;
-	uninstalling: boolean;
 	onInstall: (entry: MarketplaceEntry) => void;
+	onToggleExpanded: (entry: MarketplaceEntry) => void;
 	onUninstall: (entry: MarketplaceEntry) => void;
 	tagLabels: Map<string, string>;
 }) {
-	const openInstallDialog = () => onInstall(entry);
+	const busy =
+		actionState?.status === "installing" ||
+		actionState?.status === "uninstalling";
+	const setupNeeded = Boolean(entry.install.env?.length);
 	const handleActionClick = (event: MouseEvent<HTMLButtonElement>) => {
 		event.stopPropagation();
 		if (installed) {
 			onUninstall(entry);
 			return;
 		}
-		openInstallDialog();
+		onInstall(entry);
 	};
+	const actionLabel = !installedStatusReady
+		? "Checking..."
+		: actionState?.status === "installing"
+			? "Installing..."
+			: actionState?.status === "uninstalling"
+				? "Uninstalling..."
+				: installed
+					? "Uninstall"
+					: "Install";
+
 	return (
 		// biome-ignore lint/a11y/useSemanticElements: The card contains a nested action button, so the wrapper cannot be a native button.
 		<div
-			aria-label={`View ${entry.name} installation details`}
-			className="flex min-h-64 cursor-pointer flex-col rounded-lg border bg-card p-4 transition-colors hover:bg-accent/20 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none"
-			onClick={openInstallDialog}
+			aria-expanded={expanded}
+			aria-label={`${expanded ? "Collapse" : "Expand"} ${entry.name}`}
+			className="grid cursor-pointer gap-3 rounded-lg border bg-card p-4 text-left transition-colors hover:bg-accent/20 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none"
+			onClick={() => onToggleExpanded(entry)}
 			onKeyDown={(event) => {
 				if (event.key === "Enter" || event.key === " ") {
 					event.preventDefault();
-					openInstallDialog();
+					onToggleExpanded(entry);
 				}
 			}}
 			role="button"
@@ -322,7 +374,7 @@ function MarketplaceCard({
 						<TypeBadge type={entry.type} />
 					</div>
 					<div className="mt-1 flex flex-wrap gap-1.5">
-						{entry.tags.slice(0, 4).map((tag) => (
+						{entry.tags.slice(0, 5).map((tag) => (
 							<Badge
 								key={tag}
 								variant="outline"
@@ -334,295 +386,146 @@ function MarketplaceCard({
 					</div>
 				</div>
 			</div>
-			<p className="mt-3 line-clamp-3 text-xs leading-5 text-muted-foreground">
+
+			<p className="line-clamp-2 text-xs leading-5 text-muted-foreground">
 				{entry.tagline}
 			</p>
-			{entry.install.env && entry.install.env.length > 0 ? (
-				<p className="mt-3 text-xs text-amber-700 dark:text-amber-300">
-					Requires setup after install
-				</p>
-			) : null}
-			<div className="mt-auto pt-4">
+
+			<div className="flex flex-wrap items-center justify-between gap-3">
+				<div className="min-h-5 text-xs text-muted-foreground">
+					{installed ? (
+						<span className="inline-flex items-center gap-1 text-emerald-700 dark:text-emerald-300">
+							<CheckCircle2 className="size-3.5" />
+							Installed
+						</span>
+					) : setupNeeded ? (
+						<span className="text-amber-700 dark:text-amber-300">
+							Requires setup after install
+						</span>
+					) : null}
+				</div>
 				<Button
-					className="w-full"
-					disabled={!installedStatusReady || uninstalling}
+					disabled={!installedStatusReady || busy}
 					onClick={handleActionClick}
 					type="button"
 					variant={installed ? "destructive" : "default"}
 				>
-					{!installedStatusReady || uninstalling ? <Spinner /> : null}
-					{installedStatusReady && installed && !uninstalling ? (
-						<Trash2 className="size-4" />
-					) : null}
-					{uninstalling
-						? "Uninstalling..."
-						: installedStatusReady
-							? installLabel(installed)
-							: "Checking..."}
+					{busy || !installedStatusReady ? <Spinner /> : null}
+					{installed && !busy ? <Trash2 className="size-4" /> : null}
+					{actionLabel}
 				</Button>
 			</div>
+
+			{expanded ? (
+				<EntryDetails actionState={actionState} entry={entry} />
+			) : null}
 		</div>
 	);
 }
 
-function InstallDialog({
-	entry,
-	installed,
-	installedStatusReady,
-	onClose,
-	onInstalled,
-	onUninstalled,
-	open,
+function TagButton({
+	active,
+	count,
+	onClick,
+	tag,
 }: {
-	entry: MarketplaceEntry | null;
-	installed: boolean;
-	installedStatusReady: boolean;
-	onClose: () => void;
-	onInstalled: (entry: MarketplaceEntry) => void;
-	onUninstalled: (entry: MarketplaceEntry) => void;
-	open: boolean;
+	active: boolean;
+	count: number;
+	onClick: () => void;
+	tag: MarketplaceTag;
 }) {
-	const [state, setState] = useState<InstallState>({ status: "idle" });
-	const requiredEnv =
-		entry?.install.env?.filter((env) => env.required !== false) ?? [];
-	const optionalEnv =
-		entry?.install.env?.filter((env) => env.required === false) ?? [];
-	const currentInstalled =
-		state.status === "installed"
-			? true
-			: state.status === "uninstalled"
-				? false
-				: installed;
-	const busy = state.status === "installing" || state.status === "uninstalling";
-	const statusMessage =
-		state.status === "installed" || state.status === "uninstalled"
-			? state.message
-			: undefined;
-
-	useEffect(() => {
-		if (open) {
-			setState({ status: "idle" });
-		}
-	}, [open]);
-
-	const copyCommand = async () => {
-		if (!entry) return;
-		await navigator.clipboard?.writeText(entry.install.command);
-	};
-
-	const install = async () => {
-		if (!entry || busy) return;
-		setState({ status: "installing" });
-		try {
-			const result = await desktopClient.invoke<MarketplaceInstallResult>(
-				"install_marketplace_entry",
-				{ entry },
-				{ timeoutMs: INSTALL_TIMEOUT_MS },
-			);
-			setState({
-				status: "installed",
-				message: result.message,
-				output: result.output,
-			});
-			onInstalled(entry);
-		} catch (error) {
-			setState({
-				status: "failed",
-				message: error instanceof Error ? error.message : String(error),
-			});
-		}
-	};
-
-	const uninstall = async () => {
-		if (!entry || busy) return;
-		setState({ status: "uninstalling" });
-		try {
-			const result = await desktopClient.invoke<MarketplaceInstallResult>(
-				"uninstall_marketplace_entry",
-				{ entry },
-				{ timeoutMs: INSTALL_TIMEOUT_MS },
-			);
-			setState({
-				status: "uninstalled",
-				message: result.message,
-				output: result.output,
-			});
-			onUninstalled(entry);
-		} catch (error) {
-			setState({
-				status: "failed",
-				message: error instanceof Error ? error.message : String(error),
-			});
-		}
-	};
-
-	if (!entry) return null;
 	return (
-		<Dialog open={open} onOpenChange={(nextOpen) => !nextOpen && onClose()}>
-			<DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
-				<DialogHeader>
-					<div className="flex items-start gap-3">
-						<EntryIcon entry={entry} />
-						<div className="min-w-0">
-							<DialogTitle>{entry.name}</DialogTitle>
-							<DialogDescription className="mt-1">
-								{entry.tagline}
-							</DialogDescription>
-							<div className="mt-2 flex flex-wrap gap-1.5">
-								<TypeBadge type={entry.type} />
-							</div>
-						</div>
-					</div>
-				</DialogHeader>
-
-				<p className="text-sm leading-6 text-muted-foreground">
-					{entry.description}
-				</p>
-
-				<div className="rounded-lg border bg-muted/30 p-3">
-					<div className="mb-2 flex items-center justify-between gap-3">
-						<p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-							Equivalent Command
-						</p>
-						<Button
-							onClick={copyCommand}
-							size="sm"
-							type="button"
-							variant="ghost"
-						>
-							<Copy className="size-3.5" />
-							Copy
-						</Button>
-					</div>
-					<code className="block overflow-x-auto whitespace-nowrap font-mono text-xs text-muted-foreground">
-						<span style={CODE_FONT_STYLE}>{entry.install.command}</span>
-					</code>
-				</div>
-
-				{requiredEnv.length > 0 || optionalEnv.length > 0 ? (
-					<div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3">
-						<p className="text-sm font-medium text-amber-800 dark:text-amber-200">
-							Environment setup needed
-						</p>
-						<p className="mt-1 text-xs leading-5 text-amber-800/80 dark:text-amber-100/80">
-							This dashboard does not store secrets in v1. Add these values to
-							your Cline/plugin environment after install.
-						</p>
-						<div className="mt-3 grid gap-2">
-							{[...requiredEnv, ...optionalEnv].map((env) => (
-								<div
-									key={env.name}
-									className="rounded-md border border-amber-500/20 bg-background/60 p-2"
-								>
-									<div className="flex items-center justify-between gap-2">
-										<code className="font-mono text-xs font-semibold">
-											<span style={CODE_FONT_STYLE}>{env.name}</span>
-										</code>
-										<Badge variant="outline">
-											{env.required === false ? "Optional" : "Required"}
-										</Badge>
-									</div>
-									{env.description ? (
-										<p className="mt-1 text-xs text-muted-foreground">
-											{env.description}
-										</p>
-									) : null}
-									{env.url ? (
-										<a
-											className="mt-1 inline-flex items-center gap-1 text-xs text-primary hover:underline"
-											href={env.url}
-											rel="noreferrer"
-											target="_blank"
-										>
-											Get value
-											<ExternalLink className="size-3" />
-										</a>
-									) : null}
-								</div>
-							))}
-						</div>
-					</div>
-				) : null}
-
-				{currentInstalled && state.status === "idle" ? (
-					<div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-3 text-sm text-emerald-700 dark:text-emerald-300">
-						This entry is already installed.
-					</div>
-				) : null}
-				{!installedStatusReady ? (
-					<div className="rounded-lg border bg-muted/30 p-3 text-sm text-muted-foreground">
-						Checking whether this entry is already installed...
-					</div>
-				) : null}
-				{state.status === "failed" ? (
-					<div className="max-h-44 overflow-auto rounded-lg border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
-						{state.message}
-					</div>
-				) : null}
-				{(state.status === "installed" || state.status === "uninstalled") &&
-				state.output ? (
-					<pre
-						className="max-h-44 overflow-auto rounded-lg border bg-muted/30 p-3 font-mono text-xs text-muted-foreground"
-						style={CODE_FONT_STYLE}
-					>
-						{state.output}
-					</pre>
-				) : null}
-
-				<DialogFooter>
-					<p className="min-h-9 min-w-0 flex-1 content-center text-left text-sm text-muted-foreground">
-						{statusMessage}
-					</p>
-					<Button
-						disabled={busy}
-						onClick={onClose}
-						type="button"
-						variant="outline"
-					>
-						Close
-					</Button>
-					<Button
-						disabled={!installedStatusReady || busy}
-						onClick={currentInstalled ? uninstall : install}
-						type="button"
-						variant={currentInstalled ? "destructive" : "default"}
-					>
-						{state.status === "installing" ? <Spinner /> : null}
-						{state.status === "uninstalling" ? <Spinner /> : null}
-						{currentInstalled ? <Trash2 className="size-4" /> : null}
-						{!installedStatusReady
-							? "Checking..."
-							: currentInstalled
-								? state.status === "uninstalling"
-									? "Uninstalling..."
-									: "Uninstall"
-								: state.status === "installing"
-									? "Installing..."
-									: state.status === "installed"
-										? "Installed"
-										: installLabel(false)}
-					</Button>
-				</DialogFooter>
-			</DialogContent>
-		</Dialog>
+		<Button
+			aria-pressed={active}
+			onClick={onClick}
+			size="sm"
+			type="button"
+			variant={active ? "default" : "outline"}
+		>
+			<span className="truncate">{tag.label}</span>
+			<span className="rounded bg-background/30 px-1.5 py-0.5 text-xs">
+				{count}
+			</span>
+		</Button>
 	);
 }
 
-export function MarketplaceView() {
+function MarketplaceSection({
+	actionStates,
+	emptyMessage,
+	entries,
+	expandedEntryKey,
+	installedEntryKeys,
+	installedStatusReady,
+	onInstall,
+	onToggleExpanded,
+	onUninstall,
+	tagLabels,
+	title,
+}: {
+	actionStates: Map<string, EntryActionState>;
+	emptyMessage: string;
+	entries: MarketplaceEntry[];
+	expandedEntryKey: string | null;
+	installedEntryKeys: Set<string>;
+	installedStatusReady: boolean;
+	onInstall: (entry: MarketplaceEntry) => void;
+	onToggleExpanded: (entry: MarketplaceEntry) => void;
+	onUninstall: (entry: MarketplaceEntry) => void;
+	tagLabels: Map<string, string>;
+	title: string;
+}) {
+	return (
+		<section className="grid gap-3">
+			<div className="flex items-center justify-between gap-3">
+				<h2 className="text-base font-semibold text-foreground">{title}</h2>
+				<span className="text-sm text-muted-foreground">{entries.length}</span>
+			</div>
+			{entries.length > 0 ? (
+				<div className="grid gap-3">
+					{entries.map((entry) => {
+						const key = entryKey(entry);
+						return (
+							<MarketplaceEntryCard
+								actionState={actionStates.get(key)}
+								entry={entry}
+								expanded={expandedEntryKey === key}
+								installed={installedEntryKeys.has(key)}
+								installedStatusReady={installedStatusReady}
+								key={key}
+								onInstall={onInstall}
+								onToggleExpanded={onToggleExpanded}
+								onUninstall={onUninstall}
+								tagLabels={tagLabels}
+							/>
+						);
+					})}
+				</div>
+			) : (
+				<div className="rounded-lg border border-dashed bg-card p-6 text-center text-sm text-muted-foreground">
+					{emptyMessage}
+				</div>
+			)}
+		</section>
+	);
+}
+
+export function MarketplaceView({
+	primitive,
+}: {
+	primitive: MarketplacePrimitiveType;
+}) {
 	const [catalog, setCatalog] = useState<MarketplaceCatalog | null>(null);
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);
 	const [query, setQuery] = useState("");
-	const [primitive, setPrimitive] = useState<PrimitiveFilter>("all");
 	const [selectedTag, setSelectedTag] = useState<string | null>(null);
-	const [selectedEntry, setSelectedEntry] = useState<MarketplaceEntry | null>(
-		null,
-	);
+	const [expandedEntryKey, setExpandedEntryKey] = useState<string | null>(null);
 	const [installedEntryKeys, setInstalledEntryKeys] = useState<Set<string>>(
 		() => new Set(),
 	);
-	const [uninstallingEntryKeys, setUninstallingEntryKeys] = useState<
-		Set<string>
-	>(() => new Set());
+	const [actionStates, setActionStates] = useState<
+		Map<string, EntryActionState>
+	>(() => new Map());
 	const [installedStatusState, setInstalledStatusState] =
 		useState<InstalledStatusState>("loading");
 
@@ -648,7 +551,7 @@ export function MarketplaceView() {
 						setInstalledEntryKeys(new Set(response.installedKeys));
 						setInstalledStatusState("ready");
 					}
-				} catch (error) {
+				} catch {
 					if (!cancelled) {
 						setInstalledStatusState("ready");
 					}
@@ -667,41 +570,76 @@ export function MarketplaceView() {
 		};
 	}, []);
 
+	const pageDetails = primitivePageDetails[primitive];
+	const PageIcon = pageDetails.icon;
 	const tagLabels = useMemo(
 		() => new Map(catalog?.tags.map((tag) => [tag.id, tag.label]) ?? []),
 		[catalog?.tags],
 	);
 
+	const primitiveEntries = useMemo(
+		() => catalog?.entries.filter((entry) => entry.type === primitive) ?? [],
+		[catalog?.entries, primitive],
+	);
+
+	const tagCounts = useMemo(() => {
+		const counts = new Map<string, number>();
+		for (const entry of primitiveEntries) {
+			for (const tag of entry.tags) {
+				counts.set(tag, (counts.get(tag) ?? 0) + 1);
+			}
+		}
+		return counts;
+	}, [primitiveEntries]);
+
+	const primitiveTags = useMemo(
+		() =>
+			(catalog?.tags ?? []).filter((tag) => (tagCounts.get(tag.id) ?? 0) > 0),
+		[catalog?.tags, tagCounts],
+	);
+
 	const filteredEntries = useMemo(() => {
-		if (!catalog) return [];
 		const normalizedQuery = query.trim().toLowerCase();
-		return catalog.entries.filter((entry) => {
-			const key = entryKey(entry);
-			const matchesPrimitive =
-				primitive === "all" ||
-				(primitive === "installed" && installedEntryKeys.has(key)) ||
-				entry.type === primitive;
+		return primitiveEntries.filter((entry) => {
 			const matchesTag = !selectedTag || entry.tags.includes(selectedTag);
-			const searchableText = [
-				entry.name,
-				entry.tagline,
-				entry.description,
-				entry.type,
-				...entry.tags.map((tag) => tagLabels.get(tag) ?? tag),
-			]
-				.join(" ")
-				.toLowerCase();
 			const matchesQuery =
 				normalizedQuery.length === 0 ||
-				searchableText.includes(normalizedQuery);
-			return matchesPrimitive && matchesTag && matchesQuery;
+				entrySearchText(entry, tagLabels).includes(normalizedQuery);
+			return matchesTag && matchesQuery;
 		});
-	}, [catalog, installedEntryKeys, primitive, query, selectedTag, tagLabels]);
+	}, [primitiveEntries, query, selectedTag, tagLabels]);
+
+	const installedEntries = useMemo(
+		() =>
+			filteredEntries.filter((entry) =>
+				installedEntryKeys.has(entryKey(entry)),
+			),
+		[filteredEntries, installedEntryKeys],
+	);
+
+	const catalogEntries = useMemo(
+		() =>
+			filteredEntries.filter(
+				(entry) => !installedEntryKeys.has(entryKey(entry)),
+			),
+		[filteredEntries, installedEntryKeys],
+	);
+
+	const activeFilters = query.trim().length > 0 || selectedTag !== null;
+	const installedStatusReady = installedStatusState === "ready";
 
 	const clearFilters = () => {
 		setQuery("");
-		setPrimitive("all");
 		setSelectedTag(null);
+	};
+
+	const setEntryState = (entry: MarketplaceEntry, state: EntryActionState) => {
+		const key = entryKey(entry);
+		setActionStates((current) => {
+			const next = new Map(current);
+			next.set(key, state);
+			return next;
+		});
 	};
 
 	const markEntryInstalled = (entry: MarketplaceEntry) => {
@@ -716,48 +654,84 @@ export function MarketplaceView() {
 		});
 	};
 
-	const uninstallEntryFromCard = async (entry: MarketplaceEntry) => {
+	const toggleExpanded = (entry: MarketplaceEntry) => {
 		const key = entryKey(entry);
-		if (uninstallingEntryKeys.has(key)) return;
-		setErrorMessage(null);
-		setUninstallingEntryKeys((current) => new Set(current).add(key));
+		setExpandedEntryKey((current) => (current === key ? null : key));
+	};
+
+	const installEntry = async (entry: MarketplaceEntry) => {
+		const key = entryKey(entry);
+		const currentState = actionStates.get(key);
+		if (
+			currentState?.status === "installing" ||
+			currentState?.status === "uninstalling"
+		) {
+			return;
+		}
+		setExpandedEntryKey(key);
+		setEntryState(entry, { status: "installing" });
 		try {
-			await desktopClient.invoke<MarketplaceInstallResult>(
-				"uninstall_marketplace_entry",
+			const result = await desktopClient.invoke<MarketplaceInstallResult>(
+				"install_marketplace_entry",
 				{ entry },
 				{ timeoutMs: INSTALL_TIMEOUT_MS },
 			);
-			markEntryUninstalled(entry);
+			setEntryState(entry, {
+				status: "installed",
+				message: result.message,
+				output: result.output,
+			});
+			markEntryInstalled(entry);
 		} catch (error) {
-			setErrorMessage(error instanceof Error ? error.message : String(error));
-		} finally {
-			setUninstallingEntryKeys((current) => {
-				const next = new Set(current);
-				next.delete(key);
-				return next;
+			setEntryState(entry, {
+				status: "failed",
+				message: error instanceof Error ? error.message : String(error),
 			});
 		}
 	};
 
-	const activeFilters =
-		query.trim().length > 0 || primitive !== "all" || selectedTag !== null;
-	const installedStatusReady = installedStatusState === "ready";
-	const selectedEntryInstalled = selectedEntry
-		? installedEntryKeys.has(entryKey(selectedEntry))
-		: false;
+	const uninstallEntry = async (entry: MarketplaceEntry) => {
+		const key = entryKey(entry);
+		const currentState = actionStates.get(key);
+		if (
+			currentState?.status === "installing" ||
+			currentState?.status === "uninstalling"
+		) {
+			return;
+		}
+		setExpandedEntryKey(key);
+		setEntryState(entry, { status: "uninstalling" });
+		try {
+			const result = await desktopClient.invoke<MarketplaceInstallResult>(
+				"uninstall_marketplace_entry",
+				{ entry },
+				{ timeoutMs: INSTALL_TIMEOUT_MS },
+			);
+			setEntryState(entry, {
+				status: "uninstalled",
+				message: result.message,
+				output: result.output,
+			});
+			markEntryUninstalled(entry);
+		} catch (error) {
+			setEntryState(entry, {
+				status: "failed",
+				message: error instanceof Error ? error.message : String(error),
+			});
+		}
+	};
 
 	return (
 		<ScrollArea className="h-full">
-			<div className="mx-auto max-w-7xl px-6 py-6 max-[720px]:px-3">
+			<div className="mx-auto max-w-6xl px-6 py-6 max-[720px]:px-3">
 				<div className="mb-6 flex flex-col gap-4 border-b pb-5 lg:flex-row lg:items-end lg:justify-between">
 					<div>
 						<h1 className="flex items-center gap-3 text-2xl font-semibold tracking-normal text-foreground">
-							<MarketplaceIcon />
-							<span>Marketplace</span>
+							<PageIcon className="size-8 text-primary" />
+							<span>{pageDetails.title}</span>
 						</h1>
 						<p className="mt-1 max-w-2xl text-sm text-muted-foreground">
-							Browse Cline primitives and install them directly into this CLI
-							environment.
+							{pageDetails.description}
 						</p>
 					</div>
 					{catalog?.generatedAt ? (
@@ -777,112 +751,32 @@ export function MarketplaceView() {
 						<Spinner className="mr-2" />
 						Loading marketplace...
 					</div>
-				) : (
-					<div className="grid gap-5 lg:grid-cols-[16rem_minmax(0,1fr)]">
-						<aside className="min-w-0 lg:sticky lg:top-4 lg:self-start">
-							<div className="rounded-lg border bg-card p-3">
-								<PrimitiveButton
-									active={primitive === "installed"}
-									catalog={
-										catalog ?? {
-											version: 1,
-											counts: {
-												total: 0,
-												mcps: 0,
-												skills: 0,
-												plugins: 0,
-											},
-											tags: [],
-											entries: [],
-										}
-									}
-									installedCount={installedEntryKeys.size}
-									onClick={() => setPrimitive("installed")}
-									primitive="installed"
-								/>
-							</div>
+				) : null}
 
-							<div className="mt-3 rounded-lg border bg-card p-3">
-								<p className="mb-2 text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-									Primitive
-								</p>
-								<div className="grid gap-1">
-									{(["all", "mcp", "skill", "plugin"] as PrimitiveFilter[]).map(
-										(item) => (
-											<PrimitiveButton
-												active={primitive === item}
-												catalog={
-													catalog ?? {
-														version: 1,
-														counts: {
-															total: 0,
-															mcps: 0,
-															skills: 0,
-															plugins: 0,
-														},
-														tags: [],
-														entries: [],
-													}
-												}
-												installedCount={installedEntryKeys.size}
-												key={item}
-												onClick={() => setPrimitive(item)}
-												primitive={item}
-											/>
-										),
-									)}
-								</div>
-							</div>
+				{catalog && !installedStatusReady ? (
+					<div className="flex min-h-80 items-center justify-center rounded-lg border bg-card text-sm text-muted-foreground">
+						<Spinner className="mr-2" />
+						Checking installed status...
+					</div>
+				) : null}
 
-							<div className="mt-3 rounded-lg border bg-card p-3">
-								<div className="mb-2 flex items-center justify-between gap-2">
-									<p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-										Tags
-									</p>
-									{selectedTag ? (
-										<Button
-											onClick={() => setSelectedTag(null)}
-											size="xs"
-											type="button"
-											variant="ghost"
-										>
-											Clear
-										</Button>
-									) : null}
-								</div>
-								<div className="grid max-h-80 gap-1 overflow-y-auto">
-									{catalog?.tags
-										.filter((tag) => tag.count > 0)
-										.map((tag) => (
-											<TagButton
-												active={selectedTag === tag.id}
-												key={tag.id}
-												onClick={() =>
-													setSelectedTag((current) =>
-														current === tag.id ? null : tag.id,
-													)
-												}
-												tag={tag}
-											/>
-										))}
-									{catalog?.tags.every((tag) => tag.count === 0) ? (
-										<p className="px-2 py-3 text-xs text-muted-foreground">
-											No tags available.
-										</p>
-									) : null}
-								</div>
-							</div>
-						</aside>
+				{errorMessage ? (
+					<div className="rounded-lg border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive">
+						{errorMessage}
+					</div>
+				) : null}
 
-						<section className="min-w-0">
-							<div className="mb-4 flex flex-col gap-3 md:flex-row md:items-center">
+				{catalog && installedStatusReady ? (
+					<div className="grid gap-6">
+						<div className="grid gap-3">
+							<div className="flex flex-col gap-3 md:flex-row md:items-center">
 								<div className="relative block flex-1">
 									<Search className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
 									<Input
-										aria-label="Search marketplace"
+										aria-label={`Search ${pageDetails.title}`}
 										className="h-10 pl-8"
 										onChange={(event) => setQuery(event.target.value)}
-										placeholder="Search marketplace"
+										placeholder={`Search ${pageDetails.title.toLowerCase()}`}
 										value={query}
 									/>
 								</div>
@@ -906,66 +800,55 @@ export function MarketplaceView() {
 								</div>
 							</div>
 
-							{errorMessage ? (
-								<div className="rounded-lg border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive">
-									{errorMessage}
+							{primitiveTags.length > 0 ? (
+								<div className="flex gap-2 overflow-x-auto pb-1">
+									{primitiveTags.map((tag) => (
+										<TagButton
+											active={selectedTag === tag.id}
+											count={tagCounts.get(tag.id) ?? 0}
+											key={tag.id}
+											onClick={() =>
+												setSelectedTag((current) =>
+													current === tag.id ? null : tag.id,
+												)
+											}
+											tag={tag}
+										/>
+									))}
 								</div>
 							) : null}
+						</div>
 
-							{catalog && filteredEntries.length > 0 ? (
-								<div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
-									{filteredEntries.map((entry) => {
-										const key = entryKey(entry);
-										return (
-											<MarketplaceCard
-												entry={entry}
-												installed={installedEntryKeys.has(key)}
-												installedStatusReady={installedStatusReady}
-												key={key}
-												onInstall={setSelectedEntry}
-												onUninstall={uninstallEntryFromCard}
-												tagLabels={tagLabels}
-												uninstalling={uninstallingEntryKeys.has(key)}
-											/>
-										);
-									})}
-								</div>
-							) : null}
+						<MarketplaceSection
+							actionStates={actionStates}
+							emptyMessage={pageDetails.emptyInstalled}
+							entries={installedEntries}
+							expandedEntryKey={expandedEntryKey}
+							installedEntryKeys={installedEntryKeys}
+							installedStatusReady={installedStatusReady}
+							onInstall={installEntry}
+							onToggleExpanded={toggleExpanded}
+							onUninstall={uninstallEntry}
+							tagLabels={tagLabels}
+							title="Installed"
+						/>
 
-							{catalog && filteredEntries.length === 0 ? (
-								<div className="flex min-h-80 flex-col items-center justify-center rounded-lg border border-dashed bg-card p-6 text-center">
-									<p className="text-base font-medium text-foreground">
-										No entries found
-									</p>
-									<p className="mt-1 text-sm text-muted-foreground">
-										Try changing your search or filters.
-									</p>
-									{activeFilters ? (
-										<Button
-											className="mt-4"
-											onClick={clearFilters}
-											type="button"
-											variant="outline"
-										>
-											Clear filters
-										</Button>
-									) : null}
-								</div>
-							) : null}
-						</section>
+						<MarketplaceSection
+							actionStates={actionStates}
+							emptyMessage={pageDetails.emptyCatalog}
+							entries={catalogEntries}
+							expandedEntryKey={expandedEntryKey}
+							installedEntryKeys={installedEntryKeys}
+							installedStatusReady={installedStatusReady}
+							onInstall={installEntry}
+							onToggleExpanded={toggleExpanded}
+							onUninstall={uninstallEntry}
+							tagLabels={tagLabels}
+							title="Catalog"
+						/>
 					</div>
-				)}
+				) : null}
 			</div>
-			<InstallDialog
-				entry={selectedEntry}
-				installed={selectedEntryInstalled}
-				installedStatusReady={installedStatusReady}
-				key={selectedEntry ? entryKey(selectedEntry) : "empty"}
-				onClose={() => setSelectedEntry(null)}
-				onInstalled={markEntryInstalled}
-				onUninstalled={markEntryUninstalled}
-				open={selectedEntry !== null}
-			/>
 		</ScrollArea>
 	);
 }

--- a/apps/cline-hub/src/webview/src/index.css
+++ b/apps/cline-hub/src/webview/src/index.css
@@ -43,7 +43,9 @@
 
 @theme inline {
 	--font-sans: "Geist Variable", sans-serif;
-	--font-mono: "Geist Mono", "Geist Mono Fallback";
+	--font-mono:
+		ui-monospace, "SFMono-Regular", Menlo, Consolas, "Liberation Mono",
+		monospace;
 	--color-background: var(--background);
 	--color-foreground: var(--foreground);
 	--color-card: var(--card);

--- a/apps/cline-hub/src/webview/src/lib/desktop-client.test.ts
+++ b/apps/cline-hub/src/webview/src/lib/desktop-client.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+import type { WebviewInboundMessage } from "../../../webview-protocol";
+import { HubDesktopClient, isBrowserTransportFailure } from "./desktop-client";
+
+function createClient() {
+	const postToHost = vi.fn<(message: WebviewInboundMessage) => void>();
+	const client = new HubDesktopClient({ postToHost, listen: false });
+	return { client, postToHost };
+}
+
+function lastDesktopCommand(postToHost: ReturnType<typeof vi.fn>) {
+	const message = postToHost.mock.lastCall?.[0] as
+		| Extract<WebviewInboundMessage, { type: "desktopCommand" }>
+		| undefined;
+	if (message?.type !== "desktopCommand") {
+		throw new Error("Expected a desktop command to be posted");
+	}
+	return message;
+}
+
+describe("HubDesktopClient", () => {
+	it("does not reject pending desktop commands for unrelated hub errors", async () => {
+		const { client, postToHost } = createClient();
+		const pending = client.invoke<{ installedKeys: string[] }>(
+			"list_marketplace_installed_entries",
+		);
+		const command = lastDesktopCommand(postToHost);
+
+		client.handleMessage({
+			data: { type: "error", text: "Failed to restore previous session." },
+		});
+		client.handleMessage({
+			data: {
+				type: "desktopCommandResult",
+				id: command.id,
+				ok: true,
+				result: { installedKeys: ["plugin:goal"] },
+			},
+		});
+
+		await expect(pending).resolves.toEqual({ installedKeys: ["plugin:goal"] });
+	});
+
+	it("rejects pending desktop commands for browser transport failures", async () => {
+		const { client } = createClient();
+		const pending = client.invoke("list_marketplace_installed_entries");
+
+		client.handleMessage({
+			data: { type: "status", text: "Disconnected from the Cline Hub server." },
+		});
+
+		await expect(pending).rejects.toThrow(
+			"Disconnected from the Cline Hub server.",
+		);
+	});
+
+	it("only treats exact browser lifecycle messages as transport failures", () => {
+		expect(
+			isBrowserTransportFailure({
+				type: "error",
+				text: "Failed to connect to the Cline Hub server.",
+			}),
+		).toBe(true);
+		expect(
+			isBrowserTransportFailure({
+				type: "error",
+				text: "Failed to restore previous session.",
+			}),
+		).toBe(false);
+	});
+});

--- a/apps/cline-hub/src/webview/src/lib/desktop-client.ts
+++ b/apps/cline-hub/src/webview/src/lib/desktop-client.ts
@@ -3,28 +3,62 @@
 import type { WebviewOutboundMessage } from "../../../webview-protocol";
 import { postToHost } from "../vscode";
 
+type PostToHost = typeof postToHost;
+
 type PendingRequest = {
+	command: string;
 	resolve: (value: unknown) => void;
 	reject: (error: Error) => void;
 	timeoutId: ReturnType<typeof setTimeout>;
 };
 
 const REQUEST_TIMEOUT_MS = 120_000;
+const BROWSER_TRANSPORT_FAILURE_MESSAGES = new Set([
+	"Disconnected from the Cline Hub server.",
+	"Failed to connect to the Cline Hub server.",
+	"Received an invalid message from the Cline Hub server.",
+]);
 
-class HubDesktopClient {
+export function isBrowserTransportFailure(
+	message: WebviewOutboundMessage,
+): boolean {
+	if (message.type !== "status" && message.type !== "error") {
+		return false;
+	}
+	return BROWSER_TRANSPORT_FAILURE_MESSAGES.has(message.text);
+}
+
+export class HubDesktopClient {
 	private requestCounter = 0;
 	private readonly pending = new Map<string, PendingRequest>();
+	private readonly postToHost: PostToHost;
 
-	constructor() {
-		if (typeof window !== "undefined") {
+	constructor(options: { postToHost?: PostToHost; listen?: boolean } = {}) {
+		this.postToHost = options.postToHost ?? postToHost;
+		if ((options.listen ?? true) && typeof window !== "undefined") {
 			window.addEventListener("message", (event) => {
 				this.handleMessage(event as MessageEvent<WebviewOutboundMessage>);
 			});
 		}
 	}
 
-	private handleMessage(event: MessageEvent<WebviewOutboundMessage>) {
+	handleMessage(event: Pick<MessageEvent<WebviewOutboundMessage>, "data">) {
 		const message = event.data;
+		if (
+			message &&
+			typeof message === "object" &&
+			(message.type === "status" || message.type === "error")
+		) {
+			if (isBrowserTransportFailure(message) && this.pending.size > 0) {
+				const error = new Error(message.text);
+				for (const pending of this.pending.values()) {
+					clearTimeout(pending.timeoutId);
+					pending.reject(error);
+				}
+				this.pending.clear();
+			}
+			return;
+		}
 		if (
 			!message ||
 			typeof message !== "object" ||
@@ -46,19 +80,24 @@ class HubDesktopClient {
 		pending.reject(new Error(message.error));
 	}
 
-	async invoke<T>(command: string, args?: Record<string, unknown>): Promise<T> {
+	async invoke<T>(
+		command: string,
+		args?: Record<string, unknown>,
+		options?: { timeoutMs?: number },
+	): Promise<T> {
 		const id = `desktop_${Date.now()}_${this.requestCounter++}`;
 		return await new Promise<T>((resolve, reject) => {
 			const timeoutId = setTimeout(() => {
 				this.pending.delete(id);
 				reject(new Error(`Timed out waiting for desktop command: ${command}`));
-			}, REQUEST_TIMEOUT_MS);
+			}, options?.timeoutMs ?? REQUEST_TIMEOUT_MS);
 			this.pending.set(id, {
+				command,
 				resolve: (value) => resolve(value as T),
 				reject,
 				timeoutId,
 			});
-			postToHost({ type: "desktopCommand", id, command, args });
+			this.postToHost({ type: "desktopCommand", id, command, args });
 		});
 	}
 }

--- a/apps/cline-hub/src/webview/src/lib/marketplace.ts
+++ b/apps/cline-hub/src/webview/src/lib/marketplace.ts
@@ -19,10 +19,7 @@ export type MarketplaceEntry = {
 	name: string;
 	tagline: string;
 	description: string;
-	icon?: string;
 	tags: string[];
-	verified?: boolean;
-	featured?: boolean;
 	install: {
 		args: string[];
 		env?: MarketplaceEnvVar[];
@@ -98,19 +95,6 @@ function parseEnv(value: unknown): MarketplaceEnvVar[] | undefined {
 	return env.length > 0 ? env : undefined;
 }
 
-function resolveCatalogAssetUrl(
-	value: string | undefined,
-	baseUrl: string | undefined,
-): string | undefined {
-	if (!value) return undefined;
-	if (!baseUrl) return value;
-	try {
-		return new URL(value, baseUrl).toString();
-	} catch {
-		return value;
-	}
-}
-
 export async function fetchMarketplaceCatalog(): Promise<MarketplaceCatalog> {
 	const response = await fetch(MARKETPLACE_CATALOG_URL, {
 		headers: { Accept: "application/json" },
@@ -170,19 +154,7 @@ export async function fetchMarketplaceCatalog(): Promise<MarketplaceCatalog> {
 						name: candidate.name,
 						tagline: candidate.tagline,
 						description: candidate.description,
-						icon: resolveCatalogAssetUrl(
-							typeof candidate.icon === "string" ? candidate.icon : undefined,
-							baseUrl,
-						),
 						tags: toStringArray(candidate.tags),
-						verified:
-							typeof candidate.verified === "boolean"
-								? candidate.verified
-								: undefined,
-						featured:
-							typeof candidate.featured === "boolean"
-								? candidate.featured
-								: undefined,
 						install: {
 							args: toStringArray(install.args),
 							command: install.command,

--- a/apps/cline-hub/src/webview/src/lib/marketplace.ts
+++ b/apps/cline-hub/src/webview/src/lib/marketplace.ts
@@ -1,0 +1,217 @@
+export type MarketplacePrimitiveType = "mcp" | "skill" | "plugin";
+
+export type MarketplaceTag = {
+	id: string;
+	label: string;
+	count: number;
+};
+
+export type MarketplaceEnvVar = {
+	name: string;
+	required?: boolean;
+	description?: string;
+	url?: string;
+};
+
+export type MarketplaceEntry = {
+	id: string;
+	type: MarketplacePrimitiveType;
+	name: string;
+	tagline: string;
+	description: string;
+	icon?: string;
+	tags: string[];
+	verified?: boolean;
+	featured?: boolean;
+	install: {
+		args: string[];
+		env?: MarketplaceEnvVar[];
+		notes?: string;
+		command: string;
+	};
+};
+
+export type MarketplaceCatalog = {
+	version: number;
+	generatedAt?: string;
+	baseUrl?: string;
+	counts: {
+		total: number;
+		plugins: number;
+		skills: number;
+		mcps: number;
+	};
+	tags: MarketplaceTag[];
+	entries: MarketplaceEntry[];
+};
+
+const MARKETPLACE_CATALOG_URL = "/api/marketplace/catalog";
+
+const EMPTY_CATALOG: MarketplaceCatalog = {
+	version: 1,
+	counts: {
+		total: 0,
+		plugins: 0,
+		skills: 0,
+		mcps: 0,
+	},
+	tags: [],
+	entries: [],
+};
+
+function isPrimitiveType(value: unknown): value is MarketplacePrimitiveType {
+	return value === "mcp" || value === "skill" || value === "plugin";
+}
+
+function toStringArray(value: unknown): string[] {
+	return Array.isArray(value)
+		? value.filter((item): item is string => typeof item === "string")
+		: [];
+}
+
+function parseCount(value: unknown): number {
+	return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function parseEnv(value: unknown): MarketplaceEnvVar[] | undefined {
+	if (!Array.isArray(value)) return undefined;
+	const env = value
+		.map((item): MarketplaceEnvVar | null => {
+			if (!item || typeof item !== "object") return null;
+			const candidate = item as Record<string, unknown>;
+			if (typeof candidate.name !== "string") return null;
+			const parsed: MarketplaceEnvVar = {
+				name: candidate.name,
+			};
+			if (typeof candidate.required === "boolean") {
+				parsed.required = candidate.required;
+			}
+			if (typeof candidate.description === "string") {
+				parsed.description = candidate.description;
+			}
+			if (typeof candidate.url === "string") {
+				parsed.url = candidate.url;
+			}
+			return parsed;
+		})
+		.filter((item): item is MarketplaceEnvVar => item !== null);
+	return env.length > 0 ? env : undefined;
+}
+
+function resolveCatalogAssetUrl(
+	value: string | undefined,
+	baseUrl: string | undefined,
+): string | undefined {
+	if (!value) return undefined;
+	if (!baseUrl) return value;
+	try {
+		return new URL(value, baseUrl).toString();
+	} catch {
+		return value;
+	}
+}
+
+export async function fetchMarketplaceCatalog(): Promise<MarketplaceCatalog> {
+	const response = await fetch(MARKETPLACE_CATALOG_URL, {
+		headers: { Accept: "application/json" },
+	});
+	if (!response.ok) {
+		throw new Error(`Failed to fetch marketplace catalog: ${response.status}`);
+	}
+	const data = await response.json();
+	const baseUrl = typeof data?.baseUrl === "string" ? data.baseUrl : undefined;
+	const rawCounts =
+		typeof data?.counts === "object" && data.counts !== null ? data.counts : {};
+
+	const tags: MarketplaceTag[] = Array.isArray(data?.tags)
+		? data.tags
+				.map((tag: unknown) => {
+					if (!tag || typeof tag !== "object") return null;
+					const candidate = tag as Record<string, unknown>;
+					if (
+						typeof candidate.id !== "string" ||
+						typeof candidate.label !== "string"
+					) {
+						return null;
+					}
+					return {
+						id: candidate.id,
+						label: candidate.label,
+						count: parseCount(candidate.count),
+					};
+				})
+				.filter(
+					(tag: MarketplaceTag | null): tag is MarketplaceTag => tag !== null,
+				)
+		: [];
+
+	const entries: MarketplaceEntry[] = Array.isArray(data?.entries)
+		? data.entries
+				.map((entry: unknown) => {
+					if (!entry || typeof entry !== "object") return null;
+					const candidate = entry as Record<string, unknown>;
+					const install =
+						typeof candidate.install === "object" && candidate.install !== null
+							? (candidate.install as Record<string, unknown>)
+							: {};
+					if (
+						typeof candidate.id !== "string" ||
+						!isPrimitiveType(candidate.type) ||
+						typeof candidate.name !== "string" ||
+						typeof candidate.tagline !== "string" ||
+						typeof candidate.description !== "string" ||
+						typeof install.command !== "string"
+					) {
+						return null;
+					}
+					return {
+						id: candidate.id,
+						type: candidate.type,
+						name: candidate.name,
+						tagline: candidate.tagline,
+						description: candidate.description,
+						icon: resolveCatalogAssetUrl(
+							typeof candidate.icon === "string" ? candidate.icon : undefined,
+							baseUrl,
+						),
+						tags: toStringArray(candidate.tags),
+						verified:
+							typeof candidate.verified === "boolean"
+								? candidate.verified
+								: undefined,
+						featured:
+							typeof candidate.featured === "boolean"
+								? candidate.featured
+								: undefined,
+						install: {
+							args: toStringArray(install.args),
+							command: install.command,
+							env: parseEnv(install.env),
+							notes:
+								typeof install.notes === "string" ? install.notes : undefined,
+						},
+					};
+				})
+				.filter(
+					(entry: MarketplaceEntry | null): entry is MarketplaceEntry =>
+						entry !== null && entry.install.args.length > 0,
+				)
+		: [];
+
+	return {
+		version: parseCount(data?.version) || EMPTY_CATALOG.version,
+		generatedAt:
+			typeof data?.generatedAt === "string" ? data.generatedAt : undefined,
+		baseUrl,
+		counts: {
+			total: parseCount(rawCounts.total) || entries.length,
+			plugins: parseCount(rawCounts.plugins),
+			skills: parseCount(rawCounts.skills),
+			mcps: parseCount(rawCounts.mcps),
+		},
+		tags,
+		entries,
+	};
+}
+
+export { EMPTY_CATALOG, MARKETPLACE_CATALOG_URL };

--- a/apps/cline-hub/src/webview/src/vscode.ts
+++ b/apps/cline-hub/src/webview/src/vscode.ts
@@ -42,9 +42,8 @@ function createBrowserSocket(): WebSocket {
 		params.set("roomSecret", roomSecret);
 	}
 	const query = params.toString();
-	browserSocket = new WebSocket(
-		`${protocol}//${window.location.host}/browser${query ? `?${query}` : ""}`,
-	);
+	const socketUrl = `${protocol}//${window.location.host}/browser${query ? `?${query}` : ""}`;
+	browserSocket = new WebSocket(socketUrl);
 	browserSocket.addEventListener("open", () => {
 		for (const message of pendingMessages.splice(0)) {
 			browserSocket?.send(JSON.stringify(message));
@@ -52,10 +51,10 @@ function createBrowserSocket(): WebSocket {
 	});
 	browserSocket.addEventListener("message", (event) => {
 		try {
-			dispatchHostMessage(
-				JSON.parse(String(event.data)) as WebviewOutboundMessage,
-			);
+			const message = JSON.parse(String(event.data)) as WebviewOutboundMessage;
+			dispatchHostMessage(message);
 		} catch {
+			pendingMessages.splice(0);
 			dispatchHostMessage({
 				type: "error",
 				text: "Received an invalid message from the Cline Hub server.",
@@ -63,12 +62,14 @@ function createBrowserSocket(): WebSocket {
 		}
 	});
 	browserSocket.addEventListener("close", () => {
+		pendingMessages.splice(0);
 		dispatchHostMessage({
 			type: "status",
 			text: "Disconnected from the Cline Hub server.",
 		});
 	});
 	browserSocket.addEventListener("error", () => {
+		pendingMessages.splice(0);
 		dispatchHostMessage({
 			type: "error",
 			text: "Failed to connect to the Cline Hub server.",

--- a/apps/cline-hub/src/webview/src/vscode.ts
+++ b/apps/cline-hub/src/webview/src/vscode.ts
@@ -19,7 +19,6 @@ let cachedApi: VsCodeApi | undefined;
 let browserSocket: WebSocket | undefined;
 const pendingMessages: WebviewInboundMessage[] = [];
 const stateKey = "cline-hub-webview-state";
-const roomSecretStateKey = "cline-hub-room-secret";
 
 function dispatchHostMessage(message: WebviewOutboundMessage): void {
 	window.dispatchEvent(new MessageEvent("message", { data: message }));
@@ -29,19 +28,7 @@ function readBrowserRoomSecret(): string | undefined {
 	const roomSecret = new URLSearchParams(window.location.search)
 		.get("roomSecret")
 		?.trim();
-	if (roomSecret) {
-		try {
-			window.localStorage.setItem(roomSecretStateKey, roomSecret);
-		} catch {
-			// Room secret persistence is best-effort.
-		}
-		return roomSecret;
-	}
-	try {
-		return window.localStorage.getItem(roomSecretStateKey)?.trim() || undefined;
-	} catch {
-		return undefined;
-	}
+	return roomSecret || undefined;
 }
 
 function createBrowserSocket(): WebSocket {

--- a/apps/cline-hub/src/webview/src/vscode.ts
+++ b/apps/cline-hub/src/webview/src/vscode.ts
@@ -19,9 +19,29 @@ let cachedApi: VsCodeApi | undefined;
 let browserSocket: WebSocket | undefined;
 const pendingMessages: WebviewInboundMessage[] = [];
 const stateKey = "cline-hub-webview-state";
+const roomSecretStateKey = "cline-hub-room-secret";
 
 function dispatchHostMessage(message: WebviewOutboundMessage): void {
 	window.dispatchEvent(new MessageEvent("message", { data: message }));
+}
+
+function readBrowserRoomSecret(): string | undefined {
+	const roomSecret = new URLSearchParams(window.location.search)
+		.get("roomSecret")
+		?.trim();
+	if (roomSecret) {
+		try {
+			window.localStorage.setItem(roomSecretStateKey, roomSecret);
+		} catch {
+			// Room secret persistence is best-effort.
+		}
+		return roomSecret;
+	}
+	try {
+		return window.localStorage.getItem(roomSecretStateKey)?.trim() || undefined;
+	} catch {
+		return undefined;
+	}
 }
 
 function createBrowserSocket(): WebSocket {
@@ -35,9 +55,7 @@ function createBrowserSocket(): WebSocket {
 
 	const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
 	const params = new URLSearchParams();
-	const roomSecret = new URLSearchParams(window.location.search)
-		.get("roomSecret")
-		?.trim();
+	const roomSecret = readBrowserRoomSecret();
 	if (roomSecret) {
 		params.set("roomSecret", roomSecret);
 	}

--- a/apps/cline-hub/vitest.config.ts
+++ b/apps/cline-hub/vitest.config.ts
@@ -1,0 +1,33 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+const rootDir = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+	root: rootDir,
+	resolve: {
+		alias: [
+			{
+				find: /^@cline\/core$/,
+				replacement: resolve(rootDir, "../../sdk/packages/core/src/index.ts"),
+			},
+			{
+				find: /^@cline\/core\/(.+)$/,
+				replacement: resolve(rootDir, "../../sdk/packages/core/src/$1"),
+			},
+			{
+				find: /^@cline\/shared$/,
+				replacement: resolve(rootDir, "../../sdk/packages/shared/src/index.ts"),
+			},
+			{
+				find: /^@cline\/shared\/(.+)$/,
+				replacement: resolve(rootDir, "../../sdk/packages/shared/src/$1"),
+			},
+		],
+	},
+	test: {
+		environment: "node",
+		include: ["src/**/*.test.ts"],
+	},
+});

--- a/package.json
+++ b/package.json
@@ -1,68 +1,68 @@
 {
-	"name": "@cline/packages",
-	"private": true,
-	"workspaces": [
-		"sdk/packages/*",
-		"apps/*",
-		"!apps/vscode",
-		"apps/cline-hub/src/webview",
-		"apps/examples/*",
-		"apps/examples/vscode/src/webview",
-		"sdk/examples",
-		"sdk/examples/plugins/*"
-	],
-	"scripts": {
-		"prepare": "husky",
-		"build": "bun run clean && bun install && bun run build:sdk && bun -F @cline/cli build",
-		"build:sdk": "bun --production -F './sdk/packages/*' build",
-		"build:apps": "bun -F './apps/**' --production build",
-		"build:models": "bun -F @cline/llms generate:models && bun format --write",
-		"dev": "bun --conditions=development run build:sdk && bun run cli && bun run cli hub stop",
-		"cli": "bun --conditions=development --cwd apps/cli dev",
-		"code": "bun --conditions=development -F @cline/code dev",
-		"clean": "bun run sdk/scripts/clean.ts",
-		"types": "bun --parallel -F '*' typecheck",
-		"test": "bun --parallel -F './sdk/packages/**' -F @cline/cli -F @cline/cline-hub test",
-		"test:unit": "bash -lc 'set -euo pipefail; bun -F @cline/agents test & p1=$!; bun -F @cline/llms test & p2=$!; bun -F @cline/core test:unit & p3=$!; bun -F @cline/cli test:unit & p4=$!; bun -F @cline/cline-hub test & p5=$!; wait $p1; wait $p2; wait $p3; wait $p4; wait $p5'",
-		"test:e2e": "bun -F @cline/core test:e2e && bun -F @cline/cli test:e2e",
-		"test:e2e:interactive": "bun -F @cline/cli test:e2e:interactive",
-		"verify:routines": "zsh -lc 'cd sdk/packages/core && bunx vitest run src/cron/schedule-service.test.ts --config vitest.config.ts'",
-		"verify:workos-device-auth": "bun sdk/scripts/verify-workos-device-auth.ts",
-		"biome": "bunx --bun @biomejs/biome",
-		"format": "bun biome format sdk/ apps/cli/ apps/cline-hub/ apps/examples/",
-		"lint": "bun biome lint sdk/ apps/cli/ apps/cline-hub/ apps/examples/",
-		"fix": "bun biome check --write --unsafe --diagnostic-level=error sdk/ apps/cli/ apps/cline-hub/ apps/examples/",
-		"check": "bun biome check --diagnostic-level=error sdk/ apps/cli/ apps/cline-hub/ apps/examples/ && bun run build:sdk && bun run -F @cline/cli build && bun -F @cline/cline-hub build:webview && bun --parallel -F './sdk/packages/**' -F @cline/cli -F @cline/cline-hub typecheck && bun sdk/scripts/check-publish.ts",
-		"version": "bun run types && bun sdk/scripts/version.ts",
-		"release": "bun sdk/scripts/release.ts"
-	},
-	"lint-staged": {
-		"sdk/**": [
-			"sh -c 'bun run types'",
-			"bun biome check --no-errors-on-unmatched --files-ignore-unknown=true"
-		],
-		"apps/{cli,cline-hub,examples}/**": [
-			"sh -c 'bun run types'",
-			"bun biome check --no-errors-on-unmatched --files-ignore-unknown=true"
-		]
-	},
-	"module": "index.ts",
-	"type": "module",
-	"engines": {
-		"bun": "1.3.13",
-		"node": ">=22"
-	},
-	"devDependencies": {
-		"@biomejs/biome": "2.4.5",
-		"@types/bun": "^1.3.13",
-		"@types/node": "^25.3.5",
-		"husky": "^9.1.7",
-		"lint-staged": "^16.3.2",
-		"vitest": "^4.0.18"
-	},
-	"peerDependencies": {
-		"nanoid": "^5.1.7",
-		"typescript": "^5.9.3"
-	},
-	"packageManager": "bun@1.3.13"
+    "name": "@cline/packages",
+    "private": true,
+    "workspaces": [
+        "sdk/packages/*",
+        "apps/*",
+        "!apps/vscode",
+        "apps/cline-hub/src/webview",
+        "apps/examples/*",
+        "apps/examples/vscode/src/webview",
+        "sdk/examples",
+        "sdk/examples/plugins/*"
+    ],
+    "scripts": {
+        "prepare": "husky",
+        "build": "bun run clean && bun install && bun run build:sdk && bun -F @cline/cli build",
+        "build:sdk": "bun --production -F './sdk/packages/*' build",
+        "build:apps": "bun -F './apps/**' --production build",
+        "build:models": "bun -F @cline/llms generate:models && bun format --write",
+        "dev": "bun --conditions=development run build:sdk && bun run cli && bun run cli hub stop",
+        "cli": "bun --conditions=development --cwd apps/cli dev",
+        "code": "bun --conditions=development -F @cline/code dev",
+        "clean": "bun run sdk/scripts/clean.ts",
+        "types": "bun --parallel -F '*' typecheck",
+        "test": "bun --parallel -F './sdk/packages/**' -F @cline/cli -F @cline/cline-hub test",
+        "test:unit": "bash -lc 'set -euo pipefail; bun -F @cline/agents test & p1=$!; bun -F @cline/llms test & p2=$!; bun -F @cline/core test:unit & p3=$!; bun -F @cline/cli test:unit & p4=$!; bun -F @cline/cline-hub test & p5=$!; wait $p1; wait $p2; wait $p3; wait $p4; wait $p5'",
+        "test:e2e": "bun -F @cline/core test:e2e && bun -F @cline/cli test:e2e",
+        "test:e2e:interactive": "bun -F @cline/cli test:e2e:interactive",
+        "verify:routines": "zsh -lc 'cd sdk/packages/core && bunx vitest run src/cron/schedule-service.test.ts --config vitest.config.ts'",
+        "verify:workos-device-auth": "bun sdk/scripts/verify-workos-device-auth.ts",
+        "biome": "bunx --bun @biomejs/biome",
+        "format": "bun biome format sdk/ apps/cli/ apps/cline-hub/ apps/examples/",
+        "lint": "bun biome lint sdk/ apps/cli/ apps/cline-hub/ apps/examples/",
+        "fix": "bun biome check --write --unsafe --diagnostic-level=error sdk/ apps/cli/ apps/cline-hub/ apps/examples/",
+        "check": "bun biome check --diagnostic-level=error sdk/ apps/cli/ apps/cline-hub/ apps/examples/ && bun run build:sdk && bun run -F @cline/cli build && bun -F @cline/cline-hub build:webview && bun --parallel -F './sdk/packages/**' -F @cline/cli -F @cline/cline-hub typecheck && bun sdk/scripts/check-publish.ts",
+        "version": "bun run types && bun sdk/scripts/version.ts",
+        "release": "bun sdk/scripts/release.ts"
+    },
+    "lint-staged": {
+        "sdk/**": [
+            "sh -c 'bun run types'",
+            "bun biome check --no-errors-on-unmatched --files-ignore-unknown=true"
+        ],
+        "apps/{cli,cline-hub,examples}/**": [
+            "sh -c 'bun run types'",
+            "bun biome check --no-errors-on-unmatched --files-ignore-unknown=true"
+        ]
+    },
+    "module": "index.ts",
+    "type": "module",
+    "engines": {
+        "bun": "1.3.13",
+        "node": ">=22"
+    },
+    "devDependencies": {
+        "@biomejs/biome": "2.4.5",
+        "@types/bun": "^1.3.13",
+        "@types/node": "^25.3.5",
+        "husky": "^9.1.7",
+        "lint-staged": "^16.3.2",
+        "vitest": "^4.0.18"
+    },
+    "peerDependencies": {
+        "nanoid": "^5.1.7",
+        "typescript": "^5.9.3"
+    },
+    "packageManager": "bun@1.3.13"
 }

--- a/package.json
+++ b/package.json
@@ -1,68 +1,68 @@
 {
-    "name": "@cline/packages",
-    "private": true,
-    "workspaces": [
-        "sdk/packages/*",
-        "apps/*",
-        "!apps/vscode",
-        "apps/cline-hub/src/webview",
-        "apps/examples/*",
-        "apps/examples/vscode/src/webview",
-        "sdk/examples",
-        "sdk/examples/plugins/*"
-    ],
-    "scripts": {
-        "prepare": "husky",
-        "build": "bun run clean && bun install && bun run build:sdk && bun -F @cline/cli build",
-        "build:sdk": "bun --production -F './sdk/packages/*' build",
-        "build:apps": "bun -F './apps/**' --production build",
-        "build:models": "bun -F @cline/llms generate:models && bun format --write",
-        "dev": "bun --conditions=development run build:sdk && bun run cli && bun run cli hub stop",
-        "cli": "bun --conditions=development --cwd apps/cli dev",
-        "code": "bun --conditions=development -F @cline/code dev",
-        "clean": "bun run sdk/scripts/clean.ts",
-        "types": "bun --parallel -F '*' typecheck",
-        "test": "bun --parallel -F './sdk/packages/**' -F @cline/cli test",
-        "test:unit": "bash -lc 'set -euo pipefail; bun -F @cline/agents test & p1=$!; bun -F @cline/llms test & p2=$!; bun -F @cline/core test:unit & p3=$!; bun -F @cline/cli test:unit & p4=$!; wait $p1; wait $p2; wait $p3; wait $p4'",
-        "test:e2e": "bun -F @cline/core test:e2e && bun -F @cline/cli test:e2e",
-        "test:e2e:interactive": "bun -F @cline/cli test:e2e:interactive",
-        "verify:routines": "zsh -lc 'cd sdk/packages/core && bunx vitest run src/cron/schedule-service.test.ts --config vitest.config.ts'",
-        "verify:workos-device-auth": "bun sdk/scripts/verify-workos-device-auth.ts",
-        "biome": "bunx --bun @biomejs/biome",
-        "format": "bun biome format sdk/ apps/cli/ apps/cline-hub/ apps/examples/",
-        "lint": "bun biome lint sdk/ apps/cli/ apps/cline-hub/ apps/examples/",
-        "fix": "bun biome check --write --unsafe --diagnostic-level=error sdk/ apps/cli/ apps/cline-hub/ apps/examples/",
-        "check": "bun biome check --diagnostic-level=error sdk/ apps/cli/ apps/cline-hub/ apps/examples/ && bun run build:sdk && bun run -F @cline/cli build && bun --parallel -F './sdk/packages/**' -F @cline/cli typecheck && bun sdk/scripts/check-publish.ts",
-        "version": "bun run types && bun sdk/scripts/version.ts",
-        "release": "bun sdk/scripts/release.ts"
-    },
-    "lint-staged": {
-        "sdk/**": [
-            "sh -c 'bun run types'",
-            "bun biome check --no-errors-on-unmatched --files-ignore-unknown=true"
-        ],
-        "apps/{cli,cline-hub,examples}/**": [
-            "sh -c 'bun run types'",
-            "bun biome check --no-errors-on-unmatched --files-ignore-unknown=true"
-        ]
-    },
-    "module": "index.ts",
-    "type": "module",
-    "engines": {
-        "bun": "1.3.13",
-        "node": ">=22"
-    },
-    "devDependencies": {
-        "@biomejs/biome": "2.4.5",
-        "@types/bun": "^1.3.13",
-        "@types/node": "^25.3.5",
-        "husky": "^9.1.7",
-        "lint-staged": "^16.3.2",
-        "vitest": "^4.0.18"
-    },
-    "peerDependencies": {
-        "nanoid": "^5.1.7",
-        "typescript": "^5.9.3"
-    },
-    "packageManager": "bun@1.3.13"
+	"name": "@cline/packages",
+	"private": true,
+	"workspaces": [
+		"sdk/packages/*",
+		"apps/*",
+		"!apps/vscode",
+		"apps/cline-hub/src/webview",
+		"apps/examples/*",
+		"apps/examples/vscode/src/webview",
+		"sdk/examples",
+		"sdk/examples/plugins/*"
+	],
+	"scripts": {
+		"prepare": "husky",
+		"build": "bun run clean && bun install && bun run build:sdk && bun -F @cline/cli build",
+		"build:sdk": "bun --production -F './sdk/packages/*' build",
+		"build:apps": "bun -F './apps/**' --production build",
+		"build:models": "bun -F @cline/llms generate:models && bun format --write",
+		"dev": "bun --conditions=development run build:sdk && bun run cli && bun run cli hub stop",
+		"cli": "bun --conditions=development --cwd apps/cli dev",
+		"code": "bun --conditions=development -F @cline/code dev",
+		"clean": "bun run sdk/scripts/clean.ts",
+		"types": "bun --parallel -F '*' typecheck",
+		"test": "bun --parallel -F './sdk/packages/**' -F @cline/cli -F @cline/cline-hub test",
+		"test:unit": "bash -lc 'set -euo pipefail; bun -F @cline/agents test & p1=$!; bun -F @cline/llms test & p2=$!; bun -F @cline/core test:unit & p3=$!; bun -F @cline/cli test:unit & p4=$!; bun -F @cline/cline-hub test & p5=$!; wait $p1; wait $p2; wait $p3; wait $p4; wait $p5'",
+		"test:e2e": "bun -F @cline/core test:e2e && bun -F @cline/cli test:e2e",
+		"test:e2e:interactive": "bun -F @cline/cli test:e2e:interactive",
+		"verify:routines": "zsh -lc 'cd sdk/packages/core && bunx vitest run src/cron/schedule-service.test.ts --config vitest.config.ts'",
+		"verify:workos-device-auth": "bun sdk/scripts/verify-workos-device-auth.ts",
+		"biome": "bunx --bun @biomejs/biome",
+		"format": "bun biome format sdk/ apps/cli/ apps/cline-hub/ apps/examples/",
+		"lint": "bun biome lint sdk/ apps/cli/ apps/cline-hub/ apps/examples/",
+		"fix": "bun biome check --write --unsafe --diagnostic-level=error sdk/ apps/cli/ apps/cline-hub/ apps/examples/",
+		"check": "bun biome check --diagnostic-level=error sdk/ apps/cli/ apps/cline-hub/ apps/examples/ && bun run build:sdk && bun run -F @cline/cli build && bun -F @cline/cline-hub build:webview && bun --parallel -F './sdk/packages/**' -F @cline/cli -F @cline/cline-hub typecheck && bun sdk/scripts/check-publish.ts",
+		"version": "bun run types && bun sdk/scripts/version.ts",
+		"release": "bun sdk/scripts/release.ts"
+	},
+	"lint-staged": {
+		"sdk/**": [
+			"sh -c 'bun run types'",
+			"bun biome check --no-errors-on-unmatched --files-ignore-unknown=true"
+		],
+		"apps/{cli,cline-hub,examples}/**": [
+			"sh -c 'bun run types'",
+			"bun biome check --no-errors-on-unmatched --files-ignore-unknown=true"
+		]
+	},
+	"module": "index.ts",
+	"type": "module",
+	"engines": {
+		"bun": "1.3.13",
+		"node": ">=22"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.4.5",
+		"@types/bun": "^1.3.13",
+		"@types/node": "^25.3.5",
+		"husky": "^9.1.7",
+		"lint-staged": "^16.3.2",
+		"vitest": "^4.0.18"
+	},
+	"peerDependencies": {
+		"nanoid": "^5.1.7",
+		"typescript": "^5.9.3"
+	},
+	"packageManager": "bun@1.3.13"
 }


### PR DESCRIPTION
This PR adds a Marketplace page to the CLI Hub dashboard so users can browse, install, and uninstall Cline primitives from the shared marketplace catalog directly from the browser UI.

<img width="1275" height="793" alt="Google Chrome 2026-06-17 14 44 31" src="https://github.com/user-attachments/assets/ee8cf854-fb2f-4b8f-9aea-a8064aaa6d9b" />

<img width="711" height="605" alt="image" src="https://github.com/user-attachments/assets/bf7be499-0255-4755-abaa-501bc0ea04e6" />

- Adds the Marketplace route/view to the Cline Hub dashboard navigation.
- Adds a marketplace catalog proxy at `/api/marketplace/catalog` so the browser fetches the catalog through the local hub server.
- Adds desktop commands for marketplace installed-status lookup, installation, and uninstallation.
- Adds install support for:
  - MCP entries by writing/upserting MCP server config.
  - Plugin entries by invoking the current Cline CLI plugin install command with JSON output.
  - Skill entries by invoking `npx skills@latest add` globally for Cline with `-y`.
- Adds uninstall support for:
  - MCP entries by deleting the parsed marketplace MCP server name from MCP settings.
  - Plugin entries by invoking the current Cline CLI plugin uninstall command with JSON output.
  - Skill entries by invoking `npx skills@latest remove` globally for Cline with `-y`.
- Adds installed detection for:
  - MCP entries by matching configured MCP server names.
  - Official plugins by matching the deterministic installed plugin path, with inventory fallback.
  - Skills by checking Cline/global skill directories and ignoring project-local skills for marketplace global-installed status.
- Installed cards now show a destructive `Uninstall` action while still opening the details/setup dialog for entries that need post-install configuration.
- Adds command output redaction before returning install/uninstall stdout/stderr to the UI.
- Adds focused unit tests for installer/uninstaller behavior, installed detection, catalog-backed install/uninstall resolution, redaction, CLI skill aliasing, MCP arg parsing, and desktop command result handling.

Some deliberately deferred scope:

- The dashboard does not collect or persist environment secrets.
- The dashboard does not expose the full skills wizard for project-level or multi-agent installs.
- Catalog entries are re-fetched server-side at install/uninstall time for safety, so if the catalog changes between page load and click, the action follows the current server catalog or fails clearly if the entry is gone.

Risk-focused cases covered by tests:

- Already-installed skills/plugins return installed instead of hanging in `Installing...`.
- Desktop command pending requests are not rejected by unrelated hub `error` messages.
- Browser socket lifecycle failures still reject pending desktop commands.
- Install output redacts common secret formats such as bearer tokens, `TOKEN=...`, `api key ...`, and passwords.
- MCP stdio command args preserve server-owned flags after command args begin, so a real server `--transport` flag is not accidentally consumed as a marketplace option.
- Desktop marketplace installs and uninstalls resolve from the server catalog rather than trusting browser-supplied install args.
- Marketplace uninstall removes the expected primitive target for MCP servers, plugins, and global Cline skills.
