### PR TITLE
fix(cli): require --retries value argument and allow --json session resume with --id

### DIFF
--- a/apps/cli/src/commands/program.ts
+++ b/apps/cli/src/commands/program.ts
@@ -53,7 +53,7 @@ export function addRootOptions(cmd: Command): Command {
 			)
 			.option("-z, --zen", "Start a session that runs in the background hub")
 			.option(
-				"--retries [value]",
+				"--retries <value>",
 				"Number of maximum consecutive mistakes (retries) before exiting (default: 6)",
 			)
 			.option(
@@ -207,7 +207,7 @@ export function commanderToParsedArgs(program: Command): ParsedArgs {
 
 	// Retries (max consecutive mistakes) validation
 	if (opts.retries !== undefined) {
-		const raw = opts.retries.trim();
+		const raw = typeof opts.retries === 'string' ? opts.retries.trim() : String(opts.retries);
 		const parsed = Number.parseInt(raw, 10);
 		if (raw && Number.isInteger(parsed) && parsed >= 1) {
 			result.retries = parsed;

--- a/apps/cli/src/commands/program.ts
+++ b/apps/cli/src/commands/program.ts
@@ -207,12 +207,15 @@ export function commanderToParsedArgs(program: Command): ParsedArgs {
 
 	// Retries (max consecutive mistakes) validation
 	if (opts.retries !== undefined) {
-		const raw = typeof opts.retries === 'string' ? opts.retries.trim() : String(opts.retries);
+		const raw =
+			typeof opts.retries === "string"
+				? opts.retries.trim()
+				: String(opts.retries);
 		const parsed = Number.parseInt(raw, 10);
 		if (raw && Number.isInteger(parsed) && parsed >= 1) {
 			result.retries = parsed;
-		} else if (raw) {
-			result.invalidRetries = raw;
+		} else {
+			result.invalidRetries = raw || "(empty)";
 		}
 	}
 

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -817,7 +817,11 @@ export async function runCli(): Promise<void> {
 		},
 	};
 
-	if (args.outputMode === "json" && (args.interactive || !args.prompt) && !args.id) {
+	if (
+		args.outputMode === "json" &&
+		(args.interactive || !args.prompt) &&
+		!args.id
+	) {
 		writeErr(
 			"JSON output mode requires a prompt argument or piped stdin (interactive mode is unsupported)",
 		);

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -798,9 +798,11 @@ export async function runCli(): Promise<void> {
 		return;
 	}
 	if (args.invalidRetries) {
-		writeln(
-			`${c.dim}[warn] ignoring invalid --retries value "${args.invalidRetries}" (expected integer >= 1)${c.reset}`,
+		writeErr(
+			`invalid retries "${args.invalidRetries}" (expected integer >= 1)`,
 		);
+		process.exitCode = 1;
+		return;
 	}
 	if (args.hooksDir?.trim()) {
 		process.env.CLINE_HOOKS_DIR = args.hooksDir.trim();
@@ -815,7 +817,7 @@ export async function runCli(): Promise<void> {
 		},
 	};
 
-	if (args.outputMode === "json" && (args.interactive || !args.prompt)) {
+	if (args.outputMode === "json" && (args.interactive || !args.prompt) && !args.id) {
 		writeErr(
 			"JSON output mode requires a prompt argument or piped stdin (interactive mode is unsupported)",
 		);

--- a/apps/cli/src/runtime/interactive/preflight.ts
+++ b/apps/cli/src/runtime/interactive/preflight.ts
@@ -1,8 +1,11 @@
 import { writeErr } from "../../utils/output";
 import type { Config } from "../../utils/types";
 
-export function assertInteractivePreflight(config: Config): void {
-	if (config.outputMode === "json") {
+export function assertInteractivePreflight(
+	config: Config,
+	{ allowJson = false } = {},
+): void {
+	if (!allowJson && config.outputMode === "json") {
 		writeErr("interactive mode is not supported with --json");
 		process.exit(1);
 	}

--- a/apps/cli/src/runtime/run-interactive.ts
+++ b/apps/cli/src/runtime/run-interactive.ts
@@ -65,7 +65,9 @@ export async function runInteractive(
 		onInitialNoticeShown?: (notice: CliMigrationNotice) => void | Promise<void>;
 	},
 ): Promise<void> {
-	assertInteractivePreflight(config);
+	assertInteractivePreflight(config, {
+		allowJson: !!resumeSessionId,
+	});
 
 	const initialRepoStatus = await readRepoStatus(config.cwd);
 	const workflowSlashCommands = listInteractiveSlashCommands(


### PR DESCRIPTION
### Related Issue

Fixes #10856
Fixes #10858

### Description

Two CLI argument handling bugs:

1. `cline --json --id <session_id> "prompt"` fails with "JSON output mode requires a prompt argument or piped stdin" because the prompt-required check doesn't account for session resumption via `--id`.

2. `cline --retries "do something"` crashes with `TypeError: opts.retries.trim is not a function` because `--retries` uses Commander.js optional brackets `[value]`, allowing it to be set to `true` (boolean) when no value follows.

**Root cause:** The `--retries` option declaration uses `[value]` (optional) instead of `<value>` (required), and the JSON mode prompt check runs unconditionally without considering `--id` session resume.

**Fix:** Change `--retries [value]` to `--retries <value>` for consistency with `--timeout <seconds>`, add a type guard before `.trim()`, skip the prompt-required check when `--id` is present, allow JSON mode through `assertInteractivePreflight` when resuming a session, and treat `--retries=` (empty value) as invalid instead of silently falling back to default.

When `--timeout 0` is provided, the CLI exits with code 1. When `--retries 0` is provided, it only warns. This PR aligns the behavior so `--retries 0` also exits with code 1.

### Test Procedure

- `bun --cwd apps/cli vitest run src/utils/helpers.test.ts src/main.test.ts` — 99 tests passing
- `bun -F @cline/cli typecheck` — clean
- `npx @biomejs/biome check --diagnostic-level=error apps/cli/src/commands/program.ts apps/cli/src/main.ts` — clean
- Manual: `cline --retries` now shows Commander's "missing required argument" error instead of crashing
- Manual: `cline --json --id <session_id>` proceeds to session resume without prompt error
- What could break: scripts using `--retries` without a value (unlikely, as the option is meaningless without a number)

### Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] ♻️ Refactor
- [ ] 💅 Cosmetic
- [ ] 📝 Documentation
- [ ] 🔧 Workflow

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore
- [x] Tests are passing and code is formatted and linted
- [x] I have reviewed contributor guidelines

### Screenshots

N/A — CLI argument parsing change, no UI impact.

### Additional Notes

The `--retries` declaration now matches `--timeout <seconds>` in using required argument syntax. The type guard is defense-in-depth for any future regression.
