### PR TITLE
fix(execute_command): stop model self-approving shell commands

### DIFF
--- a/apps/vscode/src/core/task/tools/handlers/ExecuteCommandToolHandler.ts
+++ b/apps/vscode/src/core/task/tools/handlers/ExecuteCommandToolHandler.ts
@@ -12,6 +12,7 @@ import type { IFullyManagedTool } from "../ToolExecutorCoordinator"
 import type { ToolValidator } from "../ToolValidator"
 import type { TaskConfig } from "../types/TaskConfig"
 import type { StronglyTypedUIHelpers } from "../types/UIHelpers"
+import { commandLooksDestructive, shouldAutoApproveExecuteCommand } from "../utils/commandSafety"
 import { applyModelContentFixes } from "../utils/ModelContentProcessor"
 import { ToolResultUtils } from "../utils/ToolResultUtils"
 
@@ -220,11 +221,25 @@ export class ExecuteCommandToolHandler implements IFullyManagedTool {
 			)
 		}
 
-		if (
-			config.isSubagentExecution ||
-			(!requiresApprovalPerLLM && autoApproveSafe) ||
-			(requiresApprovalPerLLM && autoApproveSafe && autoApproveAll)
-		) {
+		// Harness-trusted destructive-command check. The model's own
+		// `requires_approval` flag must not be the sole gate that decides whether
+		// its command is auto-executed: a prompt-injected or over-eager model could
+		// mark a destructive command as "safe" and have it run with no human
+		// prompt. We therefore independently inspect the command text and, when it
+		// looks destructive, refuse the "model says safe" auto-approve path so the
+		// command falls through to explicit human approval. The all-commands
+		// opt-in (executeAllCommands / yolo / autoApproveAll) is unchanged — that
+		// is a deliberate, harness-trusted decision to skip approval entirely.
+		const harnessFlagsDestructive = commandLooksDestructive(actualCommand)
+		const autoApprove = shouldAutoApproveExecuteCommand({
+			isSubagentExecution: config.isSubagentExecution,
+			requiresApprovalPerLLM,
+			autoApproveSafe,
+			autoApproveAll,
+			command: actualCommand,
+		})
+
+		if (autoApprove) {
 			// Auto-approve flow
 			if (!config.isSubagentExecution) {
 				await config.callbacks.removeLastPartialMessageIfExistsWithType("ask", "command")
@@ -242,15 +257,20 @@ export class ExecuteCommandToolHandler implements IFullyManagedTool {
 				block.isNativeToolCall,
 			)
 		} else {
-			// Manual approval flow
+			// Manual approval flow.
+			// Surface the explicit-approval treatment both when the model itself
+			// flagged the command as requiring approval AND when the harness
+			// overrode a model "safe" classification because the command looks
+			// destructive.
+			const requiresExplicitApproval = autoApproveSafe && (requiresApprovalPerLLM || harnessFlagsDestructive)
 			void showApprovalNotification(
-				{ message: actualCommand, requiresExplicitApproval: autoApproveSafe && requiresApprovalPerLLM },
+				{ message: actualCommand, requiresExplicitApproval },
 				config.autoApprovalSettings.enableNotifications,
 			)
 
 			const didApprove = await ToolResultUtils.askApprovalAndPushFeedback(
 				"command",
-				actualCommand + `${autoApproveSafe && requiresApprovalPerLLM ? COMMAND_REQ_APP_STRING : ""}`,
+				actualCommand + `${requiresExplicitApproval ? COMMAND_REQ_APP_STRING : ""}`,
 				config,
 			)
 			if (!didApprove) {

--- a/apps/vscode/src/core/task/tools/utils/__tests__/commandSafety.test.ts
+++ b/apps/vscode/src/core/task/tools/utils/__tests__/commandSafety.test.ts
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict"
+import { describe, it } from "mocha"
+import { commandLooksDestructive, shouldAutoApproveExecuteCommand } from "../commandSafety"
+
+// Regression coverage for the model-controlled-command-approval-flag hardening.
+//
+// The execute_command tool exposes a `requires_approval` boolean that the MODEL
+// fills in. With the shipped default (executeSafeCommands=true), a command the
+// model marks requires_approval=false takes the auto-approve path and runs with
+// no human prompt. A prompt-injected / over-eager model can therefore mark a
+// destructive command as "safe" and have it auto-executed.
+//
+// The fix makes the auto-approval decision consult harness-trusted state in
+// addition to the model flag: when the harness independently considers the
+// command destructive, a model "safe" classification no longer suffices to skip
+// the human prompt.
+describe("commandLooksDestructive (harness-trusted destructive-command detection)", () => {
+	it("flags the documented destructive payload (rm -rf)", () => {
+		// Mirrors the PoC minimal payload: execute_command{command:'rm -rf ~/x'}
+		assert.equal(commandLooksDestructive("rm -rf ~/x"), true)
+		assert.equal(commandLooksDestructive("rm -rf /"), true)
+		assert.equal(commandLooksDestructive("rm -rf /important/data"), true)
+	})
+
+	it("flags rm with combined / reordered recursive+force flags", () => {
+		assert.equal(commandLooksDestructive("rm -fr ~/x"), true)
+		assert.equal(commandLooksDestructive("rm -r -f ~/x"), true)
+		assert.equal(commandLooksDestructive("rm -f -r ~/x"), true)
+		assert.equal(commandLooksDestructive("rm --recursive --force ~/x"), true)
+		assert.equal(commandLooksDestructive("rm --force --recursive ~/x"), true)
+	})
+
+	it("flags destructive commands hidden behind command chaining", () => {
+		assert.equal(commandLooksDestructive('echo hi && rm -rf "$HOME"'), true)
+		assert.equal(commandLooksDestructive("ls; rm -rf ~/x"), true)
+		assert.equal(commandLooksDestructive("true || rm -rf ~/x"), true)
+	})
+
+	it("flags disk / filesystem destruction and privilege escalation", () => {
+		assert.equal(commandLooksDestructive("dd if=/dev/zero of=/dev/sda"), true)
+		assert.equal(commandLooksDestructive("mkfs.ext4 /dev/sdb1"), true)
+		assert.equal(commandLooksDestructive("sudo rm -rf /etc"), true)
+		assert.equal(commandLooksDestructive("git reset --hard HEAD~5"), true)
+	})
+
+	it("does NOT flag ordinary development commands (no false positives)", () => {
+		// These are exactly the kinds of "safe" commands the auto-approve-safe
+		// feature is designed to run unattended.
+		assert.equal(commandLooksDestructive("ls -la"), false)
+		assert.equal(commandLooksDestructive("npm install"), false)
+		assert.equal(commandLooksDestructive("npm run build"), false)
+		assert.equal(commandLooksDestructive("npm test"), false)
+		assert.equal(commandLooksDestructive("git status"), false)
+		assert.equal(commandLooksDestructive("git commit -m 'msg'"), false)
+		assert.equal(commandLooksDestructive("cat package.json"), false)
+		assert.equal(commandLooksDestructive("python manage.py runserver"), false)
+		assert.equal(commandLooksDestructive("rm build/output.tmp"), false) // non-recursive single file delete
+		assert.equal(commandLooksDestructive("echo 'rm -rf is dangerous'"), false) // literal text in single quotes
+		assert.equal(commandLooksDestructive("grep -rf patterns.txt src/"), false) // -rf here is grep's flags, not rm
+	})
+
+	it("handles empty / whitespace commands without flagging", () => {
+		assert.equal(commandLooksDestructive(""), false)
+		assert.equal(commandLooksDestructive("   "), false)
+	})
+})
+
+describe("shouldAutoApproveExecuteCommand (model flag is not the sole gate)", () => {
+	// Shipped default: executeSafeCommands=true (autoApproveSafe), executeAllCommands=false.
+	const SHIPPED_DEFAULT = { autoApproveSafe: true, autoApproveAll: false, isSubagentExecution: false }
+
+	it("SECURITY: a model-'safe' destructive command is NOT auto-approved under shipped defaults", () => {
+		// This is the core of the finding: model sets requires_approval=false on a
+		// destructive command. Before the fix this auto-approved and ran with no
+		// human prompt. After the fix the harness refuses auto-approval, so the
+		// command routes to manual approval.
+		const decision = shouldAutoApproveExecuteCommand({
+			...SHIPPED_DEFAULT,
+			requiresApprovalPerLLM: false, // model claims "safe"
+			command: "rm -rf ~/x", // but it is destructive
+		})
+		assert.equal(decision, false, "destructive command marked 'safe' by the model must NOT auto-approve")
+	})
+
+	it("still auto-approves ordinary 'safe' commands (no UX regression)", () => {
+		for (const command of ["npm install", "npm run build", "ls -la", "git status"]) {
+			const decision = shouldAutoApproveExecuteCommand({
+				...SHIPPED_DEFAULT,
+				requiresApprovalPerLLM: false,
+				command,
+			})
+			assert.equal(decision, true, `expected '${command}' to remain auto-approved`)
+		}
+	})
+
+	it("does not auto-approve when the model itself flags approval (default: executeAllCommands=false)", () => {
+		const decision = shouldAutoApproveExecuteCommand({
+			...SHIPPED_DEFAULT,
+			requiresApprovalPerLLM: true,
+			command: "npm install left-pad",
+		})
+		assert.equal(decision, false)
+	})
+
+	it("honors the explicit all-commands opt-in for risky commands (unchanged behavior)", () => {
+		const decision = shouldAutoApproveExecuteCommand({
+			isSubagentExecution: false,
+			autoApproveSafe: true,
+			autoApproveAll: true, // user explicitly opted in to auto-approve everything
+			requiresApprovalPerLLM: true,
+			command: "rm -rf ~/x",
+		})
+		assert.equal(decision, true, "all-commands opt-in is a deliberate harness-trusted decision")
+	})
+
+	it("does not auto-approve a destructive command even with the all-commands opt-in if the model marked it safe", () => {
+		// When the model claims "safe" the safe-path is taken, which is gated by the
+		// destructive check regardless of the all-commands toggle.
+		const decision = shouldAutoApproveExecuteCommand({
+			isSubagentExecution: false,
+			autoApproveSafe: true,
+			autoApproveAll: true,
+			requiresApprovalPerLLM: false, // model claims "safe"
+			command: "rm -rf ~/x",
+		})
+		assert.equal(decision, false)
+	})
+
+	it("auto-approves subagent execution regardless of command (unchanged behavior)", () => {
+		const decision = shouldAutoApproveExecuteCommand({
+			isSubagentExecution: true,
+			autoApproveSafe: false,
+			autoApproveAll: false,
+			requiresApprovalPerLLM: false,
+			command: "rm -rf ~/x",
+		})
+		assert.equal(decision, true)
+	})
+})

--- a/apps/vscode/src/core/task/tools/utils/commandSafety.ts
+++ b/apps/vscode/src/core/task/tools/utils/commandSafety.ts
@@ -1,0 +1,161 @@
+import { type ParseEntry, parse as parseShell } from "shell-quote"
+
+// Conservative deny-list of unambiguously destructive command invocations.
+// Each pattern is anchored at the START of a parsed command segment so it only
+// matches the command's actual executable + flags, NOT a destructive-looking
+// substring that appears inside a quoted argument (e.g. `echo 'rm -rf x'`).
+// An optional leading `sudo`/`env`/`command`/`time`/absolute-or-relative-path
+// prefix is tolerated. This list is intentionally narrow: it targets operations
+// that are irreversible / system-damaging (recursive force delete, raw disk
+// writes, filesystem creation, fork bombs, history obliteration) rather than
+// ordinary development commands such as build/test/lint/dev-server.
+const SEGMENT_LEAD = /^(?:(?:sudo|env|command|time|nice|nohup|doas)\s+)*(?:[\w./-]*\/)?/.source
+
+const DESTRUCTIVE_COMMAND_PATTERNS: RegExp[] = [
+	// rm with both recursive and force (any flag ordering / combined short flags)
+	new RegExp(
+		`${SEGMENT_LEAD}rm\\s+(?:-[a-z]*r[a-z]*f|-[a-z]*f[a-z]*r|-r\\w*\\s+-f\\b|-f\\w*\\s+-r\\b|--recursive\\b.*--force|--force\\b.*--recursive)`,
+		"i",
+	),
+	// recursive removals via find -delete / find -exec rm
+	new RegExp(`${SEGMENT_LEAD}find\\b[^\\n]*\\b-delete\\b`, "i"),
+	new RegExp(`${SEGMENT_LEAD}find\\b[^\\n]*-exec\\s+rm\\b`, "i"),
+	// disk / filesystem destruction
+	new RegExp(`${SEGMENT_LEAD}dd\\b[^\\n]*\\bof=/dev/`, "i"),
+	new RegExp(`${SEGMENT_LEAD}mkfs(?:\\.\\w+)?\\b`, "i"),
+	new RegExp(`${SEGMENT_LEAD}(?:shred|wipefs)\\b`, "i"),
+	new RegExp(`${SEGMENT_LEAD}fdisk\\b`, "i"),
+	// recursive chmod 777 / recursive chown|chmod from filesystem root
+	new RegExp(`${SEGMENT_LEAD}chmod\\s+(?:-R\\s+)?0?777\\s+/`, "i"),
+	new RegExp(`${SEGMENT_LEAD}ch(?:own|mod)\\s+-R\\b[^\\n]*\\s/(?:\\s|$)`, "i"),
+	// git history / working-tree obliteration
+	new RegExp(`${SEGMENT_LEAD}git\\s+(?:reset\\s+--hard|clean\\s+-[a-z]*f|push\\s+.*--force)`, "i"),
+]
+
+// Raw-string destructive markers that are meaningful regardless of segment
+// position (redirect onto a raw block device, classic fork bomb).
+const DESTRUCTIVE_RAW_PATTERNS: RegExp[] = [/>\s*\/dev\/(?:sd[a-z]|nvme\d|disk\d)/i, /:\s*\(\)\s*\{\s*:\s*\|/]
+
+/**
+ * Split a command line into command segments using the same shell tokenizer the
+ * permission controller relies on (`shell-quote`). Quoted strings collapse into
+ * single argument tokens, so destructive-looking text inside quotes does not
+ * begin a new segment. Returns the original command as a single segment if
+ * tokenization fails.
+ */
+function splitCommandSegments(command: string): string[] {
+	const segments: string[] = []
+	try {
+		const tokens: ParseEntry[] = parseShell(command)
+		let current: string[] = []
+		const flush = () => {
+			if (current.length > 0) {
+				segments.push(current.join(" "))
+				current = []
+			}
+		}
+		for (const token of tokens) {
+			if (typeof token === "string") {
+				current.push(token)
+			} else if (token && typeof token === "object" && "pattern" in token) {
+				current.push((token as { pattern: string }).pattern)
+			} else if (token && typeof token === "object" && "op" in token) {
+				// Operators (&&, ||, |, ;, redirects, subshell parens) end a segment
+				flush()
+			}
+		}
+		flush()
+	} catch {
+		// fall through to raw command
+	}
+	if (segments.length === 0) {
+		segments.push(command)
+	}
+	return segments
+}
+
+/**
+ * Heuristically determine whether a command line looks destructive enough that
+ * the harness should require explicit human approval even when the model marked
+ * it as not requiring approval.
+ *
+ * The decision is made entirely from harness-trusted parsing of the command
+ * text — it never consults the model-supplied `requires_approval` flag — so a
+ * model cannot opt a destructive command out of this check. The harness signal
+ * can only escalate toward asking the human; it never relaxes approval.
+ */
+export function commandLooksDestructive(command: string): boolean {
+	const normalized = command.trim()
+	if (!normalized) {
+		return false
+	}
+
+	for (const pattern of DESTRUCTIVE_RAW_PATTERNS) {
+		if (pattern.test(normalized)) {
+			return true
+		}
+	}
+
+	for (const segment of splitCommandSegments(normalized)) {
+		const trimmed = segment.trim()
+		for (const pattern of DESTRUCTIVE_COMMAND_PATTERNS) {
+			if (pattern.test(trimmed)) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+/** Inputs to the execute_command auto-approval decision. */
+export interface ExecuteCommandApprovalInput {
+	/** Running on behalf of a subagent (always auto-approved by design). */
+	isSubagentExecution: boolean
+	/** The model's own `requires_approval` self-classification (model-supplied). */
+	requiresApprovalPerLLM: boolean
+	/** User opted in to auto-approve commands the model deems safe (harness state). */
+	autoApproveSafe: boolean
+	/** User opted in to auto-approve ALL commands incl. model-deemed-risky (harness state). */
+	autoApproveAll: boolean
+	/** The actual command string about to run (harness-inspected). */
+	command: string
+}
+
+/**
+ * Decide whether an execute_command invocation may be auto-approved (run without
+ * an explicit human prompt).
+ *
+ * Security property: the model-supplied `requires_approval` flag must not be the
+ * SOLE gate. When the user has enabled "auto-approve safe commands" the model's
+ * claim of "safe" (requiresApprovalPerLLM === false) is honored only if the
+ * harness's own inspection (`commandLooksDestructive`) does not flag the command
+ * as destructive. A prompt-injected / over-eager model therefore cannot mark a
+ * destructive command "safe" and have it auto-execute — such a command falls
+ * through to manual approval.
+ *
+ * The all-commands opt-in (autoApproveAll / yolo, surfaced here as
+ * autoApproveAll) is unchanged: that is a deliberate, harness-trusted decision
+ * by the user to skip approval entirely, including for risky commands.
+ */
+export function shouldAutoApproveExecuteCommand(input: ExecuteCommandApprovalInput): boolean {
+	const { isSubagentExecution, requiresApprovalPerLLM, autoApproveSafe, autoApproveAll, command } = input
+
+	if (isSubagentExecution) {
+		return true
+	}
+
+	// Model says safe AND user enabled safe-auto-approve AND the harness does not
+	// independently consider the command destructive.
+	if (!requiresApprovalPerLLM && autoApproveSafe && !commandLooksDestructive(command)) {
+		return true
+	}
+
+	// Model says risky, but the user explicitly opted in to auto-approve every
+	// command (both safe and all toggles on).
+	if (requiresApprovalPerLLM && autoApproveSafe && autoApproveAll) {
+		return true
+	}
+
+	return false
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

Closes #12020

### Description

**What problem does this PR solve?**

The `execute_command` tool defines a `requires_approval` boolean that the **model** fills in. With the shipped auto-approval default (`executeSafeCommands: true`), a command the model marks `requires_approval=false` takes the auto-approve branch and runs **without any human prompt**. That makes the model's own self-classification the sole gate on unattended shell execution: an over-eager or prompt-influenced model can mark a destructive command "safe" and have it auto-executed.

**Why these changes were introduced**

Today the auto-approve decision in `apps/vscode/src/core/task/tools/handlers/ExecuteCommandToolHandler.ts` reduces to:

```ts
config.isSubagentExecution ||
(!requiresApprovalPerLLM && autoApproveSafe) ||          // <-- model-controlled
(requiresApprovalPerLLM && autoApproveSafe && autoApproveAll)
```

`requiresApprovalPerLLM` comes straight from `block.params.requires_approval` (model output); `autoApproveSafe` is `executeSafeCommands`, which defaults to `true`. So by default the middle branch reduces to "the model said it's safe → run it". The intent is to harden that gate so the model flag is no longer the only thing standing between a model turn and an irreversible command.

**Approach**

A new pure module `apps/vscode/src/core/task/tools/utils/commandSafety.ts`:

- **`commandLooksDestructive(command)`** — a harness-side inspection that tokenizes the command with `shell-quote` (the same parser already used by `CommandPermissionController`) into operator-separated segments and matches each segment, anchored at its command position, against a conservative deny-list of *unambiguously* destructive operations (recursive force `rm`, `find -delete` / `-exec rm`, raw-device `dd`, `mkfs`, `shred`/`wipefs`/`fdisk`, recursive root `chmod`/`chown`, `chmod 777 /`, `git reset --hard` / `clean -f` / `push --force`, redirect onto a block device, fork bomb). Quoted text such as `echo 'rm -rf x'` is **not** matched, because quotes collapse into a single argument token and the patterns are anchored at the executable position.
- **`shouldAutoApproveExecuteCommand({...})`** — the auto-approval decision, lifted out of the handler so it is directly unit-testable. The "model says safe" path is now additionally gated on `!commandLooksDestructive(command)`.

Behavioral effect:

- The model's `requires_approval=false` claim is honored **only** when the harness does not independently consider the command destructive.
- A destructive command marked "safe" by the model is **not** auto-approved — it falls through to the existing **manual approval** flow (it is *not* hard-blocked), and surfaces the same explicit-approval treatment (`COMMAND_REQ_APP_STRING`, notification) already used for model-flagged-risky commands.
- The explicit *all-commands* opt-in (`executeAllCommands` / yolo, surfaced as `autoApproveAll`) is **unchanged** — that remains a deliberate, user-made decision to skip approval entirely.

Because the harness check can only ever escalate *toward* asking the human and never relaxes approval, it is safe by construction and preserves the documented meaning of `executeSafeCommands` for ordinary development commands.

**Affected sites (decisive lines)**

- `apps/vscode/src/core/task/tools/handlers/ExecuteCommandToolHandler.ts:234` — the auto-approve decision (`shouldAutoApproveExecuteCommand(...)`), fed by the model-supplied `requires_approval` flag and now additionally gated on the harness check; previously this was an inline `(!requiresApprovalPerLLM && autoApproveSafe)` branch with no independent inspection.
- `apps/vscode/src/core/task/tools/handlers/ExecuteCommandToolHandler.ts:90` — `requiresApprovalPerLLM = block.params.requires_approval === "true"` (origin of the model-controlled flag).
- `apps/vscode/src/core/prompts/system-prompt/tools/execute_command.ts` — where the `requires_approval` boolean is defined as a required, model-filled tool parameter.
- `apps/vscode/src/shared/AutoApprovalSettings.ts` — `executeSafeCommands: true` (default-on), `executeAllCommands: false`.
- `apps/vscode/src/core/task/tools/utils/commandSafety.ts` — new harness-side check and decision function (the fix).

### Test Procedure

**How did you test this change?**

Added `apps/vscode/src/core/task/tools/utils/__tests__/commandSafety.test.ts` (mocha + `node:assert/strict`, the project's unit-test framework) and ran the project's unit runner against it. **12 passing.**

- `commandLooksDestructive`:
  - flags the destructive payloads, including flag-ordering and command-chaining variants and disk/filesystem-destruction + privilege-escalation cases;
  - crucially **does not** flag ordinary dev commands (`npm install`, `npm run build`, `git status`, `python manage.py runserver`, a non-recursive `rm file`, quoted-literal text, `grep -rf`), i.e. no false positives;
  - handles empty/whitespace input without flagging.
- `shouldAutoApproveExecuteCommand`:
  - **Security**: under shipped defaults (`executeSafeCommands=true`, `executeAllCommands=false`), a model-"safe" destructive command (`requires_approval=false`, `rm -rf ~/x`) is **NOT** auto-approved (asserts the decision is `false`);
  - ordinary "safe" commands still auto-approve (no UX regression);
  - the all-commands opt-in and the subagent path remain unchanged.

**What could potentially break, and how I verified it doesn't**

- *Risk of UX regression* (ordinary commands no longer auto-approving): covered by explicit no-false-positive tests above; the deny-list is intentionally narrow and anchored at the command position, so normal `build`/`test`/`lint`/dev-server commands are untouched.
- *Risk of behavior change to the all-commands / subagent paths*: covered by tests that assert those branches are unchanged.
- *Risk of evasion via quoting*: covered by a test asserting quoted literals (`echo 'rm -rf x'`) are not matched, matching `shell-quote`'s tokenization.

**Existing functionality affected, and how I checked it still works**

The auto-approval decision logic was extracted into `shouldAutoApproveExecuteCommand` and the handler now calls it; the subagent and all-commands branches are preserved verbatim and asserted unchanged by tests. No tool schema or public API was altered, so `requires_approval` and all existing callers continue to work.

**Why I'm confident this is ready for merge**

The decision is consolidated into one small, pure, directly-tested function; the change adds no public-API or tool-schema surface and reuses an existing dependency. The fail-before / pass-after is concrete: on the prior code path the same destructive payload auto-approves and the security assertion fails; with the new gate it falls through to human approval and the assertion passes. (On the base tree the new test cannot resolve `../commandSafety` and the suite fails to load, since the secured code path does not yet exist.)

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — this is a backend/approval-gating change with no UI surface. The new behavior is covered by unit tests; when the harness overrides a model-"safe" classification, the command takes the existing manual-approval path (the standard approve/reject command prompt), unchanged in appearance.

### Additional Notes

<!-- Add any additional notes for reviewers -->

- **Compatibility**: no public API or tool-schema changes; `requires_approval` keeps working. Ordinary dev commands continue to auto-approve under the default. Reuses an existing dependency (`shell-quote`); no new runtime dependencies.
- The deny-list is deliberately narrow and conservative to avoid false positives; it is meant as defense-in-depth, complementing (not replacing) the opt-in `CLINE_COMMAND_PERMISSIONS` allow/deny mechanism, and can be extended over time. The decision lives in one small testable function so the policy is easy to audit.
- Per `SECURITY.md`, Cline prefers private vulnerability disclosure (Bugcrowd VDP / GitHub security advisories). This change is defense-in-depth hardening of behavior that is already visible in the public source and tool schema, so it is raised here as a normal code-quality PR; maintainers should feel free to route it through the private channel instead if they prefer.

