### PR TITLE
feat(vscode): add Fireworks GLM 5.2 and Kimi K2.6 Fast, fix DeepSeek V4 Flash cache-read price

### DIFF
--- a/apps/vscode/src/shared/api.ts
+++ b/apps/vscode/src/shared/api.ts
@@ -5143,6 +5143,18 @@ export const fireworksModels = {
 		description:
 			"Kimi K2.6 Turbo router for high-performance agentic workloads with vision and text reasoning.",
 	},
+	"accounts/fireworks/routers/kimi-k2p6-fast": {
+		maxTokens: 262000,
+		contextWindow: 262000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 2,
+		outputPrice: 8,
+		cacheWritesPrice: 0,
+		cacheReadsPrice: 0.3,
+		description:
+			"Kimi K2.6 Fast router for high-performance agentic workloads with vision and text reasoning.",
+	},
 	"accounts/fireworks/routers/kimi-k2p7-code-fast": {
 		maxTokens: 262000,
 		contextWindow: 262000,
@@ -5163,7 +5175,7 @@ export const fireworksModels = {
 		inputPrice: 0.14,
 		outputPrice: 0.28,
 		cacheWritesPrice: 0,
-		cacheReadsPrice: 0.03,
+		cacheReadsPrice: 0.028,
 		description:
 			"DeepSeek V4 Flash is a fast, cost-efficient reasoning model with a 1M context window and strong tool-use capabilities.",
 	},
@@ -5178,6 +5190,17 @@ export const fireworksModels = {
 		cacheReadsPrice: 0.145,
 		description:
 			"DeepSeek V4 Pro is a flagship reasoning model with a 1M context window, advanced structured output, and agentic performance.",
+	},
+	"accounts/fireworks/models/glm-5p2": {
+		maxTokens: 131072,
+		contextWindow: 1048576,
+		supportsImages: false,
+		supportsPromptCache: true,
+		inputPrice: 1.4,
+		outputPrice: 4.4,
+		cacheWritesPrice: 0,
+		cacheReadsPrice: 0.26,
+		description: "GLM 5.2 is a next-generation general-purpose model optimized for coding, reasoning, and agentic workflows with a 1M context window.",
 	},
 	"accounts/fireworks/models/glm-5p1": {
 		maxTokens: 131072,


### PR DESCRIPTION
### Related Issue

**Issue:** #11640 

### Description

The Fireworks AI provider model registry in Cline's VS Code extension is out of date compared to the current active models and pricing available on the Fireworks platform. This PR updates the hardcoded registry to add a new model, standardize a router naming convention, and correct a cache-read price.

- **Added model:**
- `accounts/fireworks/models/glm-5p2`: new general-purpose model with a 1,048,576-token context window.
- **Added router:**
- `accounts/fireworks/routers/kimi-k2p6-fast`: standardizes the Kimi K2.6 router on the `-fast` naming convention used for `/routers`. The existing `kimi-k2p6-turbo` entry is retained for now to avoid breaking user workflows, but the turbo variant is expected to be removed in a future releases when the fast variant is the only one serving.
- **Price correction:**
- `accounts/fireworks/models/deepseek-v4-flash` cache-read price corrected from 0.03 to 0.028.
- **Changes made:**
- `apps/vscode/src/shared/api.ts`

Per project scope, this change is intentionally limited to the VS Code extension's hardcoded registry. The default model remains `accounts/fireworks/models/kimi-k2p6`, so no changes to `sdk/packages/llms/src/providers/builtins.ts` or `APIOptions.spec.tsx` are needed.

The same change has already been pushed and merged in the models.dev repository, so the Cline SDK will be able to fetch the updated models list automatically, too.

Pricing sourced from https://docs.fireworks.ai/serverless/pricing.

### Test Procedure

- **Verification approach:** The changes are confined to the `fireworksModels` object in `apps/vscode/src/shared/api.ts`, which is the single source of truth for the Fireworks UI model list. The `FireworksProvider` React component, `providerUtils.ts`, and `fireworks.ts` API handler all consume this object dynamically by reference, so no cascading changes were needed.
- **What could break:** Nothing. No models are removed in this PR, so no fallback behavior is triggered. The `kimi-k2p6-turbo` entry is retained alongside the new `kimi-k2p6-fast` entry, so existing user selections remain valid. The cache-read price correction only affects cost reporting accuracy.
- **Why this is ready:** The blast radius is minimal and only affects 1 file. The Fireworks serverless pricing documentation was used to verify all pricing and metadata.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

**GLM 5.2 and Kimi K2.6 Fast are missing:**
<img width="574" height="589" alt="Cline_Before_2" src="https://github.com/user-attachments/assets/a3b7d21a-59a8-4b9f-be65-4de2921ce74e" />

**GLM 5.2 and Kimi K2.6 Fast are present:**
<img width="574" height="581" alt="Cline_After_1" src="https://github.com/user-attachments/assets/4aaf2f94-ba48-4c42-b111-9650cae37f08" />