### PR TITLE
Fix Cline login retry state after auth error

### DIFF
--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -825,6 +825,7 @@ export class Controller {
 		)
 		const serializedError = clineError.serialize()
 
+		const failedAskTs = ts + 2
 		const messages: ClineMessage[] = [
 			{
 				ts,
@@ -843,13 +844,15 @@ export class Controller {
 				partial: false,
 			},
 			{
-				ts: ts + 2,
+				ts: failedAskTs,
 				type: "ask",
 				ask: "api_req_failed",
 				text: serializedError,
 				partial: false,
 			},
 		]
+
+		this.turnStateTracker.set("error", failedAskTs)
 
 		this.messages.appendAndEmit(messages, {
 			type: "status",
@@ -894,6 +897,7 @@ export class Controller {
 			message: rawErrorMessage,
 		})
 
+		const failedAskTs = ts + 1
 		const messages: ClineMessage[] = [
 			{
 				ts,
@@ -905,13 +909,15 @@ export class Controller {
 				partial: false,
 			},
 			{
-				ts: ts + 1,
+				ts: failedAskTs,
 				type: "ask",
 				ask: "api_req_failed",
 				text: serializedError,
 				partial: false,
 			},
 		]
+
+		this.turnStateTracker.set("error", failedAskTs)
 
 		this.messages.appendAndEmit(messages, {
 			type: "status",


### PR DESCRIPTION
### Description

This fixes a frozen-chat state that could happen when using the Cline provider while signed out.

When a user sent a message while unauthenticated, the SDK path emitted the expected synthetic `api_req_failed` auth error so the webview could show the **Sign in to Cline** button. After the user signed in, the error row correctly switched to telling the user to click Retry, but the footer did not show the Retry button because the authoritative SDK `turnState` was still not anchored to the synthetic failed ask.

The webview prioritizes `turnState` over message-tail inference for footer button state. This meant the visible message stream said “retryable auth error,” while the footer state still behaved as if there were no retryable ask, leaving users stuck until they exited the chat.

This PR anchors the SDK `turnState` to the synthetic `ask: "api_req_failed"` message when emitting Cline auth and balance errors, so the footer reliably renders the Retry action after sign-in.

### Test Procedure

Manually tested locally:

- Selected the Cline provider while signed out.
- Sent a chat message and verified the auth error row showed the **Sign in to Cline** button.
- Completed sign-in locally.
- Verified the chat no longer remained frozen and the retryable error state exposed the expected footer recovery action.

Potentially affected behavior is limited to SDK-generated Cline auth/balance error recovery states. The change only updates the authoritative `turnState` anchor to match the already-emitted `api_req_failed` message sequence.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — no visual UI changes beyond restoring the existing Retry footer action in this error state.

### Additional Notes

There is an unrelated local modification to `apps/vscode/src/sdk/vscode-session-host.ts` in the working tree; it is not committed and is not included in this PR.
