### PR TITLE
Improve onboarding funnel metrics

### DIFF
--- a/apps/vscode/proto/cline/state.proto
+++ b/apps/vscode/proto/cline/state.proto
@@ -454,6 +454,11 @@ message OnboardingProgressRequest {
   optional string action = 2;
   optional bool completed = 3;
   optional string model_selected = 4;
+  optional string page = 5;
+  optional string page_variant = 6;
+  optional string user_type = 7;
+  optional int32 destination_step = 8;
+  optional string destination_page = 9;
 }
 
 message OnboardingModelGroup {

--- a/apps/vscode/src/core/controller/state/captureOnboardingProgress.ts
+++ b/apps/vscode/src/core/controller/state/captureOnboardingProgress.ts
@@ -14,8 +14,13 @@ export async function captureOnboardingProgress(_controller: Controller, request
 	try {
 		telemetryService.captureOnboardingProgress({
 			step: Number(request.step),
-			model: request.modelSelected,
 			action: request.action,
+			page: request.page,
+			pageVariant: request.pageVariant,
+			userType: request.userType,
+			selectedModelId: request.modelSelected,
+			destinationStep: request.destinationStep,
+			destinationPage: request.destinationPage,
 			completed: !!request.completed,
 		})
 		return Empty.create({})

--- a/apps/vscode/src/services/telemetry/TelemetryService.ts
+++ b/apps/vscode/src/services/telemetry/TelemetryService.ts
@@ -2136,7 +2136,17 @@ export class TelemetryService {
 		})
 	}
 
-	public captureOnboardingProgress(args: { step: number; action?: string; model?: string; completed?: boolean }) {
+	public captureOnboardingProgress(args: {
+		step: number
+		action?: string
+		page?: string
+		pageVariant?: string
+		userType?: string
+		selectedModelId?: string
+		destinationStep?: number
+		destinationPage?: string
+		completed?: boolean
+	}) {
 		this.capture({
 			event: TelemetryService.EVENTS.USER.ONBOARDING_PROGRESS,
 			properties: {

--- a/apps/vscode/webview-ui/src/components/onboarding/OnboardingView.tsx
+++ b/apps/vscode/webview-ui/src/components/onboarding/OnboardingView.tsx
@@ -25,6 +25,29 @@ import {
 import { NEW_USER_TYPE, STEP_CONFIG, USER_TYPE_SELECTIONS } from "./data-steps"
 import { useOnboardingModels } from "./useOnboardingModels"
 
+type OnboardingPage =
+	| "user_type"
+	| "free_model_selection"
+	| "power_model_selection"
+	| "byok_provider_config"
+	| "account_creation_wait"
+
+const getOnboardingPage = (step: number, userType: NEW_USER_TYPE): OnboardingPage => {
+	if (step === 0) {
+		return "user_type"
+	}
+	if (step === 2) {
+		return "account_creation_wait"
+	}
+	if (userType === NEW_USER_TYPE.POWER) {
+		return "power_model_selection"
+	}
+	if (userType === NEW_USER_TYPE.BYOK) {
+		return "byok_provider_config"
+	}
+	return "free_model_selection"
+}
+
 type ModelSelectionProps = {
 	userType: NEW_USER_TYPE.FREE | NEW_USER_TYPE.POWER
 	selectedModelId: string
@@ -274,6 +297,7 @@ const OnboardingViewContent = ({ onboardingModels }: { onboardingModels: Onboard
 	const { commitSelection } = useProviderConfig("cline")
 	const loginAttemptIdRef = useRef(0)
 	const loginLoadingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+	const pageViewTelemetryKeyRef = useRef<string | null>(null)
 
 	const [stepNumber, setStepNumber] = useState(0)
 	const [isActionLoading, setIsActionLoading] = useState(false)
@@ -286,6 +310,7 @@ const OnboardingViewContent = ({ onboardingModels }: { onboardingModels: Onboard
 	const onboardingModelById = useMemo(() => {
 		return new Map(onboardingModels.models.map((model) => [model.id, model]))
 	}, [onboardingModels])
+	const currentPage = useMemo(() => getOnboardingPage(stepNumber, userType), [stepNumber, userType])
 
 	useEffect(() => {
 		setSearchTerm("")
@@ -303,23 +328,47 @@ const OnboardingViewContent = ({ onboardingModels }: { onboardingModels: Onboard
 		}
 	}, [])
 
-	const onUserTypeClick = useCallback((userType: NEW_USER_TYPE) => {
-		setUserType(userType)
-		const action =
-			userType === NEW_USER_TYPE.POWER
-				? "power_user_selected"
-				: userType === NEW_USER_TYPE.FREE
-					? "free_user_selected"
-					: "byok_user_selected"
-		// User selection is available in step 0 only
-		StateServiceClient.captureOnboardingProgress({ step: 0, action })
+	useEffect(() => {
+		const telemetryKey = `${stepNumber}:${currentPage}`
+		if (pageViewTelemetryKeyRef.current === telemetryKey) {
+			return
+		}
+		pageViewTelemetryKeyRef.current = telemetryKey
+		StateServiceClient.captureOnboardingProgress({
+			step: stepNumber,
+			action: "page_viewed",
+			page: currentPage,
+			userType: currentPage === "user_type" ? undefined : userType,
+			modelSelected: selectedModelId || undefined,
+		})
+	}, [currentPage, selectedModelId, stepNumber, userType])
+
+	const onUserTypeClick = useCallback((selectedUserType: NEW_USER_TYPE) => {
+		setUserType(selectedUserType)
+		StateServiceClient.captureOnboardingProgress({
+			step: 0,
+			action: "option_selected",
+			page: "user_type",
+			userType: selectedUserType,
+		})
 	}, [])
 
-	const onModelClick = useCallback((modelSelected: string) => {
-		setSelectedModelId(modelSelected)
-		// User selection is available in step 1 only
-		StateServiceClient.captureOnboardingProgress({ step: 1, modelSelected, action: "model_selected" })
-	}, [])
+	const onModelClick = useCallback(
+		(modelSelected: string) => {
+			setSelectedModelId(modelSelected)
+			if (!modelSelected) {
+				return
+			}
+			StateServiceClient.captureOnboardingProgress({
+				step: stepNumber,
+				action: "model_selected",
+				page: currentPage,
+				userType,
+				modelSelected,
+			})
+		},
+		[currentPage, stepNumber, userType],
+	)
 
 	const finishOnboarding = useCallback(
 		async (updateModelId: boolean, step: number) => {
@@ -358,8 +407,14 @@ const OnboardingViewContent = ({ onboardingModels }: { onboardingModels: Onboard
 			setShowWelcome(false)
 			hideAccount()
 			hideSettings()
-			const action = "onboarding_completed"
-			StateServiceClient.captureOnboardingProgress({ step, modelSelected, action, completed: true })
+			StateServiceClient.captureOnboardingProgress({
+				step,
+				action: "completed",
+				page: getOnboardingPage(step, userType),
+				userType,
+				modelSelected,
+				completed: true,
+			})
 		},
 		[
 			hideAccount,
@@ -370,6 +425,7 @@ const OnboardingViewContent = ({ onboardingModels }: { onboardingModels: Onboard
 			onboardingModelById,
 			commitSelection,
 			setShowWelcome,
+			userType,
 		],
 	)
 
@@ -412,20 +468,34 @@ const OnboardingViewContent = ({ onboardingModels }: { onboardingModels: Onboard
 
 	const handleFooterAction = useCallback(
 		async (action: "signin" | "next" | "back" | "done" | "signup") => {
+			const captureNavigation = (telemetryAction: string, destinationStep?: number) => {
+				StateServiceClient.captureOnboardingProgress({
+					step: stepNumber,
+					action: telemetryAction,
+					page: currentPage,
+					userType,
+					modelSelected: selectedModelId || undefined,
+					destinationStep,
+					destinationPage: destinationStep === undefined ? undefined : getOnboardingPage(destinationStep, userType),
+				})
+			}
+
 			switch (action) {
 				case "signup":
+					captureNavigation("signup_clicked", stepNumber + 1)
 					setStepNumber(stepNumber + 1)
 					await loginAndFinishOnboarding(true, stepNumber + 1)
 					break
 				case "signin":
-					await loginAndFinishOnboarding(true, stepNumber + 1)
+					captureNavigation("signin_clicked")
+					await loginAndFinishOnboarding(true, stepNumber)
 					break
 				case "next":
-					StateServiceClient.captureOnboardingProgress({ step: stepNumber + 1 })
+					captureNavigation("continued", stepNumber + 1)
 					setStepNumber(stepNumber + 1)
 					break
 				case "back":
-					StateServiceClient.captureOnboardingProgress({ step: stepNumber - 1 })
+					captureNavigation("back_clicked", stepNumber - 1)
 					setStepNumber(stepNumber - 1)
 					break
 				case "done":
@@ -433,7 +503,7 @@ const OnboardingViewContent = ({ onboardingModels }: { onboardingModels: Onboard
 					break
 			}
 		},
-		[stepNumber, finishOnboarding, loginAndFinishOnboarding],
+		[stepNumber, currentPage, userType, selectedModelId, finishOnboarding, loginAndFinishOnboarding],
 	)
 
 	const stepDisplayInfo = useMemo(() => {
@@ -506,6 +576,18 @@ const OnboardingViewContent = ({ onboardingModels }: { onboardingModels: Onboard
 	)
 }
 
+const OnboardingWelcomeFallback = () => {
+	useEffect(() => {
+		StateServiceClient.captureOnboardingProgress({
+			step: 0,
+			action: "fallback_welcome_viewed",
+			page: "legacy_welcome_fallback",
+		})
+	}, [])
+
+	return <WelcomeView />
+}
+
 const OnboardingView = () => {
 	const { status, models } = useOnboardingModels()
 
@@ -518,7 +600,7 @@ const OnboardingView = () => {
 	}
 
 	if (status === "empty") {
-		return <WelcomeView />
+		return <OnboardingWelcomeFallback />
 	}
 
 	return <OnboardingViewContent onboardingModels={models} />

--- a/apps/vscode/webview-ui/src/components/onboarding/OnboardingView.tsx
+++ b/apps/vscode/webview-ui/src/components/onboarding/OnboardingView.tsx
@@ -31,6 +31,7 @@ type OnboardingPage =
 	| "power_model_selection"
 	| "byok_provider_config"
 	| "account_creation_wait"
+	| "legacy_welcome_fallback"
 
 const getOnboardingPage = (step: number, userType: NEW_USER_TYPE): OnboardingPage => {
 	if (step === 0) {
@@ -297,7 +298,7 @@ const OnboardingViewContent = ({ onboardingModels }: { onboardingModels: Onboard
 	const { commitSelection } = useProviderConfig("cline")
 	const loginAttemptIdRef = useRef(0)
 	const loginLoadingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-	const pageViewTelemetryKeyRef = useRef<string | null>(null)
+	const viewedPageTelemetryKeysRef = useRef<Set<string>>(new Set())
 
 	const [stepNumber, setStepNumber] = useState(0)
 	const [isActionLoading, setIsActionLoading] = useState(false)
@@ -330,10 +331,10 @@ const OnboardingViewContent = ({ onboardingModels }: { onboardingModels: Onboard
 
 	useEffect(() => {
 		const telemetryKey = `${stepNumber}:${currentPage}`
-		if (pageViewTelemetryKeyRef.current === telemetryKey) {
+		if (viewedPageTelemetryKeysRef.current.has(telemetryKey)) {
 			return
 		}
-		pageViewTelemetryKeyRef.current = telemetryKey
+		viewedPageTelemetryKeysRef.current.add(telemetryKey)
 		StateServiceClient.captureOnboardingProgress({
 			step: stepNumber,
 			action: "page_viewed",
@@ -578,10 +579,11 @@ const OnboardingViewContent = ({ onboardingModels }: { onboardingModels: Onboard
 
 const OnboardingWelcomeFallback = () => {
 	useEffect(() => {
+		const page: OnboardingPage = "legacy_welcome_fallback"
 		StateServiceClient.captureOnboardingProgress({
 			step: 0,
 			action: "fallback_welcome_viewed",
-			page: "legacy_welcome_fallback",
+			page,
 		})
 	}, [])
 


### PR DESCRIPTION
### Description

Adds structured onboarding funnel telemetry for the VS Code extension onboarding flow.

Video of the Events in sync with user actions:

https://github.com/user-attachments/assets/6d030c61-c462-4f0f-b8d4-8695f8a578aa


All funnel events continue to use the existing telemetry event name:

```ts
user.onboarding_progress
```

This PR expands the event payload so data can distinguish page impressions, navigation, selections, and completion. The telemetry now supports:

| Property | Description |
| --- | --- |
| `step` | Numeric onboarding step. |
| `action` | User action or lifecycle event. |
| `page` | Stable onboarding page ID. |
| `pageVariant` | Optional future experiment/variant field. |
| `userType` | Selected onboarding path: `free`, `power`, or `byok`. |
| `selectedModelId` | Selected model ID. |
| `destinationStep` | Step the user is navigating to. |
| `destinationPage` | Page the user is navigating to. |
| `completed` | Whether onboarding completed. |

Stable page IDs:

| Page ID | UI title |
| --- | --- |
| `user_type` | How will you use Cline? |
| `free_model_selection` | Select a free model |
| `power_model_selection` | Select your model |
| `byok_provider_config` | Configure your provider |
| `account_creation_wait` | Almost there! |
| `legacy_welcome_fallback` | Hi, I'm Cline fallback |

Logged actions:

| Action | Meaning |
| --- | --- |
| `page_viewed` | User saw an onboarding page. |
| `option_selected` | User selected Free, Frontier, or BYOK. |
| `continued` | User clicked Continue. |
| `back_clicked` | User clicked Back. |
| `model_selected` | User selected a specific model. This is not emitted while typing in model search. |
| `signup_clicked` | User clicked Create my Account. |
| `signin_clicked` | User clicked Login to Cline. |
| `completed` | User completed onboarding. |
| `fallback_welcome_viewed` | New onboarding could not load models, so the old welcome fallback was shown. |

This should let data answer:

- How many users saw each onboarding page.
- Where users drop off.
- Which onboarding path users select.
- Whether users continue from each page to the next page.
- Which models users select.
- How many users click signup/signin.
- How many users complete onboarding.
- How often the legacy welcome fallback appears.

### Test Procedure

- Ran VS Code extension type checking:

```bash
cd apps/vscode && npx tsc --noEmit && cd webview-ui && npx tsc --noEmit
```

- Ran full VS Code type check command earlier after proto generation:

```bash
cd apps/vscode && npm run check-types
```

- Verified that model search typing does not emit `model_selected` with an empty model ID; `model_selected` is only emitted after selecting an actual model.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality not to work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — telemetry-only change.

### Additional Notes

The telemetry event name remains `user.onboarding_progress`; this PR only adds structured properties and normalized `action`/`page` values for funnel analysis.
