### PR TITLE
Use auto Core backend for VS Code SDK host

### DIFF
--- a/apps/vscode/src/sdk/vscode-session-host.ts
+++ b/apps/vscode/src/sdk/vscode-session-host.ts
@@ -89,7 +89,7 @@ export class VscodeSessionHost implements SdkSessionHost {
 		}
 
 		const inner = await ClineCore.create({
-			backendMode: "local",
+			backendMode: "auto",
 			capabilities: {
 				requestToolApproval: options.requestToolApproval as
 					| ((request: ToolApprovalRequest) => Promise<ToolApprovalResult>)


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Switches the VS Code SDK-backed session host from a forced in-process Core runtime to Core's automatic backend selection:

```ts
backendMode: "auto"
```

This lets `ClineCore.create(...)` opportunistically attach to a compatible local Cline Core hub when one is discovered, while retaining Core's fallback to the local runtime if no compatible hub is available or the hub connection fails.

Implications for reviewers/testers:

- VS Code sessions may now run through `HubRuntimeHost` instead of always using `LocalRuntimeHost`.
- Core will best-effort prewarm a detached local hub for `auto`/`hub` modes when no explicit endpoint is provided.
- Timing can matter: the shared VS Code session host may fall back to local if no hub is ready yet, while later-created hosts could attach to a prewarmed/discovered hub.
- VS Code-specific capabilities such as tool approvals, question prompts, MCP-backed extra tools, and terminal integration should flow through hub client contributions when hub mode is selected, but this path is more complex than the previous forced-local execution path and should be smoke-tested carefully.

### Test Procedure

Manual testing planned in VS Code after opening this PR:

- Start a new SDK-backed task with no compatible hub available and confirm it falls back to local runtime successfully.
- Start with a compatible Cline Core hub available and confirm the session attaches/runs through hub mode.
- Verify streamed messages, task completion/cancel, tool approvals, MCP tools, and terminal command execution still work.
- Watch for timing-dependent behavior between the shared session host and temporary/history hosts.

Automated tests were not run for this one-line backend-selection change.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — no UI changes.

### Additional Notes

This is intentionally a small change to enable manual validation of Core hub auto-selection from the VS Code SDK adapter. If the timing-dependent local-vs-hub behavior is undesirable, a follow-up may need to make backend selection explicit/configurable for VS Code.