### PR TITLE
fix(cli): apply auto-approve toggles immediately

### DIFF
--- a/apps/cli/src/runtime/interactive/approvals.test.ts
+++ b/apps/cli/src/runtime/interactive/approvals.test.ts
@@ -61,6 +61,20 @@ describe("createInteractiveApprovalController", () => {
 		).resolves.toEqual({ approved: false, reason: "no" });
 	});
 
+	it("approves stale required-approval requests after auto-approve is enabled", async () => {
+		const controller = createInteractiveApprovalController(makeConfig(false));
+		controller.tuiToolApprover.current = async () => ({
+			approved: false,
+			reason: "stale prompt",
+		});
+
+		controller.setInteractiveAutoApprove(true);
+
+		await expect(
+			controller.requestToolApproval(makeRequest({ autoApprove: false })),
+		).resolves.toEqual({ approved: true });
+	});
+
 	it("denies approval-required requests when no TUI approver is available", async () => {
 		const controller = createInteractiveApprovalController(makeConfig(false));
 
@@ -77,6 +91,7 @@ describe("createInteractiveApprovalController", () => {
 
 		expect(controller.autoApproveAllRef.current).toBe(true);
 		expect(config.defaultToolAutoApprove).toBe(false);
-		expect(config.toolPolicies["*"]?.autoApprove).toBe(false);
+		expect(config.toolPolicies["*"]?.autoApprove).toBe(true);
+		expect(controller.resolveToolPolicy("run_commands").autoApprove).toBe(true);
 	});
 });

--- a/apps/cli/src/runtime/interactive/approvals.ts
+++ b/apps/cli/src/runtime/interactive/approvals.ts
@@ -3,6 +3,7 @@ import type { Config } from "../../utils/types";
 import {
 	applyInteractiveAutoApproveOverride,
 	cloneToolPolicies,
+	resolveInteractiveAutoApprovePolicy,
 } from "../tool-policies";
 
 export interface InteractiveRuntimeRefs {
@@ -38,10 +39,10 @@ export function createInteractiveApprovalController(config: Config) {
 	const requestToolApproval = async (
 		request: ToolApprovalRequest,
 	): Promise<ToolApprovalResult> => {
-		if (request.policy?.autoApprove === true) {
+		if (autoApproveAllRef.current) {
 			return { approved: true };
 		}
-		if (autoApproveAllRef.current && request.policy?.autoApprove !== false) {
+		if (request.policy?.autoApprove === true) {
 			return { approved: true };
 		}
 		if (refs.tuiToolApprover.current) {
@@ -54,6 +55,12 @@ export function createInteractiveApprovalController(config: Config) {
 		autoApproveAllRef,
 		setInteractiveAutoApprove,
 		requestToolApproval,
+		resolveToolPolicy: (toolName: string) =>
+			resolveInteractiveAutoApprovePolicy({
+				toolName,
+				baselinePolicies: baselineToolPolicies,
+				enabled: autoApproveAllRef.current,
+			}),
 		...refs,
 	};
 }

--- a/apps/cli/src/runtime/interactive/session-runtime.test.ts
+++ b/apps/cli/src/runtime/interactive/session-runtime.test.ts
@@ -152,7 +152,10 @@ function deferred<T>() {
 
 function makeRuntime(
 	manager: ReturnType<typeof makeManager>,
-	options: { resumeSessionId?: string } = {},
+	options: {
+		resumeSessionId?: string;
+		resolveToolPolicy?: (toolName: string) => Config["toolPolicies"][string];
+	} = {},
 ) {
 	mockCreateCliCore.mockResolvedValue(manager);
 	const config = makeConfig();
@@ -164,6 +167,8 @@ function makeRuntime(
 		requestToolApproval: async (
 			_request: ToolApprovalRequest,
 		): Promise<ToolApprovalResult> => ({ approved: true }),
+		resolveToolPolicy:
+			options.resolveToolPolicy ?? (() => ({ autoApprove: true })),
 		askQuestionRef: { current: null },
 		resolveMistakeLimitDecision: undefined,
 		switchToActModeTool: makeSwitchToActModeTool(),
@@ -203,6 +208,68 @@ describe("createInteractiveSessionRuntime", () => {
 
 		expect(manager.start).toHaveBeenCalledTimes(2);
 		expect(runtime.getActiveSessionId()).toBe("session-2");
+	});
+
+	it("adds a live interactive approval policy hook to started sessions", async () => {
+		const manager = makeManager();
+		const upstreamBeforeTool = vi.fn(async () => ({
+			input: { text: "updated" },
+		}));
+		mockCreateRuntimeHooks.mockReturnValueOnce({
+			hooks: {
+				beforeTool: upstreamBeforeTool,
+			},
+			shutdown: vi.fn(async () => {}),
+		});
+		const runtime = makeRuntime(manager, {
+			resolveToolPolicy: (toolName) => ({
+				autoApprove: toolName === "echo",
+			}),
+		});
+
+		await runtime.ensureReady();
+
+		const startInput = manager.start.mock.calls[0]?.[0] as
+			| { config?: Config }
+			| undefined;
+		const beforeTool = startInput?.config?.hooks?.beforeTool;
+		expect(beforeTool).toBeTypeOf("function");
+
+		const result = await beforeTool?.({
+			snapshot: {
+				agentId: "agent-1",
+				conversationId: "conversation-1",
+				status: "running",
+				iteration: 1,
+				messages: [],
+				pendingToolCalls: [],
+				usage: {
+					inputTokens: 0,
+					outputTokens: 0,
+					cacheReadTokens: 0,
+					cacheWriteTokens: 0,
+				},
+			},
+			tool: {
+				name: "echo",
+				description: "",
+				inputSchema: {},
+				execute: async () => "ok",
+			},
+			toolCall: {
+				type: "tool-call",
+				toolCallId: "call-1",
+				toolName: "echo",
+				input: { text: "original" },
+			},
+			input: { text: "original" },
+		});
+
+		expect(upstreamBeforeTool).toHaveBeenCalledOnce();
+		expect(result).toEqual({
+			input: { text: "updated" },
+			policy: { autoApprove: true },
+		});
 	});
 
 	it("starts fresh after resetting an initially resumed session", async () => {

--- a/apps/cli/src/runtime/interactive/session-runtime.ts
+++ b/apps/cli/src/runtime/interactive/session-runtime.ts
@@ -1,5 +1,6 @@
 import {
 	type AgentEvent,
+	type AgentHooks,
 	type CheckpointEntry,
 	isSessionNotFoundError,
 	type PendingPromptMutationResult,
@@ -48,6 +49,32 @@ type CurrentTurnResult = Awaited<ReturnType<CliCore["send"]>>;
 type AskQuestionRef = {
 	current: ((question: string, options: string[]) => Promise<string>) | null;
 };
+type ToolPolicyResolver = (
+	toolName: string,
+) => NonNullable<Config["toolPolicies"]>[string];
+
+function withInteractiveApprovalPolicyHook(
+	hooks: AgentHooks | undefined,
+	resolveToolPolicy: ToolPolicyResolver,
+): AgentHooks {
+	return {
+		...hooks,
+		beforeTool: async (ctx) => {
+			const result = await hooks?.beforeTool?.(ctx);
+			if (result?.stop || result?.skip) {
+				return result;
+			}
+			const policy = resolveToolPolicy(ctx.toolCall.toolName);
+			return {
+				...result,
+				policy: {
+					...result?.policy,
+					autoApprove: policy.autoApprove,
+				},
+			};
+		},
+	};
+}
 
 export function createInteractiveSessionRuntime(input: {
 	config: Config;
@@ -58,6 +85,7 @@ export function createInteractiveSessionRuntime(input: {
 	requestToolApproval: (
 		request: ToolApprovalRequest,
 	) => Promise<ToolApprovalResult>;
+	resolveToolPolicy: ToolPolicyResolver;
 	askQuestionRef: AskQuestionRef;
 	resolveMistakeLimitDecision: Config["onConsecutiveMistakeLimitReached"];
 	switchToActModeTool: NonNullable<Config["extraTools"]>[number];
@@ -152,10 +180,14 @@ export function createInteractiveSessionRuntime(input: {
 		if (!runtimeHooks) {
 			throw new Error("interactive runtime hooks are unavailable");
 		}
+		const hooks = withInteractiveApprovalPolicyHook(
+			runtimeHooks.hooks,
+			input.resolveToolPolicy,
+		);
 		return buildInteractiveSessionConfig({
 			config: input.config,
 			chatCommandState: input.chatCommandState,
-			runtimeHooks,
+			runtimeHooks: { hooks },
 			onTeamEvent: input.onTeamEvent,
 			resolveMistakeLimitDecision: input.resolveMistakeLimitDecision,
 		});

--- a/apps/cli/src/runtime/run-interactive.ts
+++ b/apps/cli/src/runtime/run-interactive.ts
@@ -121,6 +121,7 @@ export async function runInteractive(
 		autoApproveAllRef,
 		setInteractiveAutoApprove,
 		requestToolApproval,
+		resolveToolPolicy,
 		tuiToolApprover,
 		tuiAskQuestion,
 	} = createInteractiveApprovalController(config);
@@ -160,6 +161,7 @@ export async function runInteractive(
 		resumeSessionId,
 		chatCommandState,
 		requestToolApproval,
+		resolveToolPolicy,
 		askQuestionRef: tuiAskQuestion,
 		resolveMistakeLimitDecision,
 		switchToActModeTool,

--- a/apps/cli/src/runtime/tool-policies.test.ts
+++ b/apps/cli/src/runtime/tool-policies.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
 	applyInteractiveAutoApproveOverride,
 	cloneToolPolicies,
+	resolveInteractiveAutoApprovePolicy,
 } from "./tool-policies";
 
 describe("tool policy helpers", () => {
@@ -53,9 +54,9 @@ describe("tool policy helpers", () => {
 		});
 	});
 
-	it("restores the baseline policies when toggled back on", () => {
+	it("forces all baseline policies to auto-approve when toggled back on", () => {
 		const baseline = {
-			"*": { autoApprove: true },
+			"*": { autoApprove: false },
 			run_commands: { autoApprove: true, enabled: true },
 			editor: { autoApprove: false, enabled: true },
 		};
@@ -72,6 +73,40 @@ describe("tool policy helpers", () => {
 			enabled: true,
 		});
 
-		expect(target).toEqual(baseline);
+		expect(target).toEqual({
+			"*": { autoApprove: true },
+			run_commands: { autoApprove: true, enabled: true },
+			editor: { autoApprove: true, enabled: true },
+		});
+	});
+
+	it("resolves live per-tool policies from the interactive auto-approve state", () => {
+		const baseline = {
+			"*": { autoApprove: false },
+			read_files: { enabled: true },
+			editor: { autoApprove: false, enabled: true },
+		};
+
+		expect(
+			resolveInteractiveAutoApprovePolicy({
+				toolName: "editor",
+				baselinePolicies: baseline,
+				enabled: true,
+			}),
+		).toEqual({ autoApprove: true, enabled: true });
+		expect(
+			resolveInteractiveAutoApprovePolicy({
+				toolName: "run_commands",
+				baselinePolicies: baseline,
+				enabled: false,
+			}),
+		).toEqual({ autoApprove: false });
+		expect(
+			resolveInteractiveAutoApprovePolicy({
+				toolName: "read_files",
+				baselinePolicies: baseline,
+				enabled: false,
+			}),
+		).toEqual({ autoApprove: true, enabled: true });
 	});
 });

--- a/apps/cli/src/runtime/tool-policies.ts
+++ b/apps/cli/src/runtime/tool-policies.ts
@@ -27,21 +27,51 @@ export function cloneToolPolicies(
 	);
 }
 
+export function resolveInteractiveAutoApprovePolicy(input: {
+	toolName: string;
+	baselinePolicies: Record<string, ToolPolicy>;
+	enabled: boolean;
+}): ToolPolicy {
+	const toolPolicy = input.baselinePolicies[input.toolName] ?? {};
+	const baselinePolicy = {
+		...(input.baselinePolicies["*"] ?? {}),
+		...toolPolicy,
+	};
+	return {
+		...baselinePolicy,
+		autoApprove: input.enabled
+			? true
+			: SAFE_AUTO_APPROVE_TOOLS.has(input.toolName)
+				? (toolPolicy.autoApprove ?? true)
+				: false,
+	};
+}
+
 export function applyInteractiveAutoApproveOverride(input: {
 	targetPolicies: Record<string, ToolPolicy>;
 	baselinePolicies: Record<string, ToolPolicy>;
 	enabled: boolean;
 }): void {
 	const nextPolicies: Record<string, ToolPolicy> = input.enabled
-		? cloneToolPolicies(input.baselinePolicies)
+		? Object.fromEntries(
+				Object.entries(input.baselinePolicies).map(([name, policy]) => [
+					name,
+					{
+						...policy,
+						autoApprove: true,
+					},
+				]),
+			)
 		: Object.fromEntries(
 				Object.entries(input.baselinePolicies).map(([name, policy]) => [
 					name,
 					{
 						...policy,
-						autoApprove: SAFE_AUTO_APPROVE_TOOLS.has(name)
-							? (policy.autoApprove ?? true)
-							: false,
+						autoApprove: resolveInteractiveAutoApprovePolicy({
+							toolName: name,
+							baselinePolicies: input.baselinePolicies,
+							enabled: false,
+						}).autoApprove,
 					},
 				]),
 			);
@@ -53,9 +83,7 @@ export function applyInteractiveAutoApproveOverride(input: {
 	}
 
 	const globalPolicy = clonePolicy(nextPolicies["*"]);
-	globalPolicy.autoApprove = input.enabled
-		? (input.baselinePolicies["*"]?.autoApprove ?? true)
-		: false;
+	globalPolicy.autoApprove = input.enabled;
 	nextPolicies["*"] = globalPolicy;
 
 	for (const key of Object.keys(input.targetPolicies)) {

--- a/apps/cli/src/tui/contexts/session-context.tsx
+++ b/apps/cli/src/tui/contexts/session-context.tsx
@@ -106,9 +106,9 @@ export function SessionProvider(props: {
 	const [uiMode, setUiMode] = useState<AgentMode>(
 		config.mode === "plan" ? "plan" : "act",
 	);
-	const [autoApproveAll, _setAutoApproveAll] = useState(
-		config.toolPolicies["*"]?.autoApprove !== false,
-	);
+	const initialAutoApproveAll = config.toolPolicies["*"]?.autoApprove !== false;
+	const autoApproveAllRef = useRef(initialAutoApproveAll);
+	const [autoApproveAll, _setAutoApproveAll] = useState(initialAutoApproveAll);
 	const [compactionMode, _setCompactionMode] = useState<CliCompactionMode>(() =>
 		getCliCompactionMode(config),
 	);
@@ -192,11 +192,10 @@ export function SessionProvider(props: {
 	}, []);
 
 	const toggleAutoApprove = useCallback(() => {
-		_setAutoApproveAll((prev) => {
-			const next = !prev;
-			onAutoApproveChange(next);
-			return next;
-		});
+		const next = !autoApproveAllRef.current;
+		autoApproveAllRef.current = next;
+		onAutoApproveChange(next);
+		_setAutoApproveAll(next);
 	}, [onAutoApproveChange]);
 
 	const setCompactionMode = useCallback(

--- a/sdk/packages/agents/src/agent-runtime.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.test.ts
@@ -600,6 +600,73 @@ describe("AgentRuntime", () => {
 		});
 	});
 
+	it("applies beforeTool approval policy overrides before executing tools", async () => {
+		const executeTool = vi.fn(async () => ({ echoed: "hi" }));
+		const requestToolApproval = vi.fn(async () => ({
+			approved: false,
+			reason: "live policy denied",
+		}));
+		const model = new ScriptedModel([
+			() => [
+				{
+					type: "tool-call-delta",
+					toolCallId: "call_live_policy",
+					toolName: "echo",
+					inputText: '{"text":"hi"}',
+				},
+				{ type: "finish", reason: "tool-calls" },
+			],
+			(request) => {
+				const toolMessage = request.messages.at(-1) as AgentMessage;
+				expect(toolMessage.role).toBe("tool");
+				expect(toolMessage.content[0]).toMatchObject({
+					type: "tool-result",
+					isError: true,
+					output: { error: "live policy denied" },
+				});
+				return [
+					{ type: "text-delta", text: "live policy handled" },
+					{ type: "finish", reason: "stop" },
+				];
+			},
+		]);
+		const runtime = new AgentRuntime({
+			sessionId: "session_test",
+			agentId: "agent_test",
+			conversationId: "conversation_test",
+			model,
+			tools: [
+				{
+					name: "echo",
+					description: "Echo input text",
+					inputSchema: { type: "object" },
+					execute: executeTool,
+				},
+			],
+			toolPolicies: { "*": { autoApprove: true } },
+			hooks: {
+				beforeTool: () => ({ policy: { autoApprove: false } }),
+			},
+			requestToolApproval,
+		});
+
+		const result = await runtime.run("Start");
+
+		expect(result.status).toBe("completed");
+		expect(result.outputText).toBe("live policy handled");
+		expect(executeTool).not.toHaveBeenCalled();
+		expect(requestToolApproval).toHaveBeenCalledWith({
+			sessionId: "session_test",
+			agentId: "agent_test",
+			conversationId: "conversation_test",
+			iteration: 1,
+			toolCallId: "call_live_policy",
+			toolName: "echo",
+			input: { text: "hi" },
+			policy: { autoApprove: false },
+		});
+	});
+
 	it("stores tool calls but skips execution when metadata disables external execution", async () => {
 		const executeTool = vi.fn(async () => ({ echoed: "hi" }));
 		const model = new ScriptedModel([

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -1133,6 +1133,7 @@ export class AgentRuntime {
 			skipReason = `Tool execution is disabled for provider ${providerId}`;
 		}
 
+		let policyOverride: ToolPolicy | undefined;
 		if (tool && !skipReason) {
 			for (const hook of this.hooks.beforeTool) {
 				const result = (await hook({
@@ -1144,6 +1145,12 @@ export class AgentRuntime {
 				if (result?.input !== undefined) {
 					input = result.input;
 				}
+				if (result?.policy) {
+					policyOverride = {
+						...policyOverride,
+						...result.policy,
+					};
+				}
 				this.applyStopControl(result);
 				if (result?.skip) {
 					skipReason =
@@ -1154,10 +1161,10 @@ export class AgentRuntime {
 		}
 
 		if (tool && !skipReason) {
-			const policy = resolveToolPolicy(
-				toolCall.toolName,
-				this.config.toolPolicies,
-			);
+			const policy = {
+				...resolveToolPolicy(toolCall.toolName, this.config.toolPolicies),
+				...policyOverride,
+			};
 			if (policy.enabled === false) {
 				skipReason = `Tool "${toolCall.toolName}" is disabled by policy`;
 			} else if (policy.autoApprove === false) {

--- a/sdk/packages/shared/src/agent.ts
+++ b/sdk/packages/shared/src/agent.ts
@@ -300,6 +300,7 @@ export interface AgentBeforeToolResult {
 	stop?: boolean;
 	reason?: string;
 	input?: unknown;
+	policy?: ToolPolicy;
 }
 
 export interface AgentAfterToolContext {


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This fixes a CLI interactive approval-state lag where switching auto-approve all from disabled to enabled, or enabled to disabled, could leave the next tool call using the previous setting.

The root cause was that interactive sessions started with a tool-policy snapshot. The TUI toggle updated the live CLI ref and scheduled a session policy refresh, but active agent runs could still prepare the next tool call with the old `toolPolicies` before the restart/refresh caught up. There was also a small UI timing issue: the TUI toggle used a queued React state updater, so the runtime callback was coupled to React's async state update path instead of an immediate mutable value.

The approach in this PR is to make the current interactive auto-approve toggle authoritative at tool-prep time:

- The CLI approval controller now resolves live per-tool approval policy from the current toggle state.
- Interactive sessions install a `beforeTool` hook that applies the current auto-approve policy to each tool call, including hub-backed sessions where the original policies are serialized at session start.
- The agent runtime now supports `beforeTool` hooks returning a narrow policy override, merged after the session's configured tool policy and before deciding whether to request approval.
- Stale required-approval requests are also approved immediately if auto-approve is currently enabled, so an already-in-flight approval path does not show a prompt after the user turns auto-approve on.
- The TUI session context updates the runtime-facing auto-approve ref synchronously before updating React state.

The main tradeoff was whether to force a session restart on every toggle and wait for it before allowing the next tool call. That would be more disruptive during active runs and still would not help already-started hub sessions cleanly. A live `beforeTool` policy override keeps the change scoped to the interactive runtime and preserves existing safe-tool behavior when auto-approve all is disabled.

### Test Procedure

Ran focused tests for the changed CLI approval paths:

```bash
cd apps/cli
bunx vitest run --config vitest.config.ts src/runtime/tool-policies.test.ts src/runtime/interactive/approvals.test.ts src/runtime/interactive/session-runtime.test.ts
```

Ran the agent runtime regression test suite covering the new hook policy override:

```bash
cd sdk/packages/agents
bunx vitest run --config vitest.config.ts src/agent-runtime.test.ts
```

Ran typechecks for the touched packages and the core package that proxies hooks through hub sessions:

```bash
cd apps/cli && bun run typecheck
cd sdk/packages/agents && bun run typecheck
cd sdk/packages/shared && bun run typecheck
cd sdk/packages/core && bun run typecheck
```

Ran Biome on the touched files:

```bash
bun biome check --write apps/cli/src/runtime/tool-policies.ts apps/cli/src/runtime/tool-policies.test.ts apps/cli/src/runtime/interactive/approvals.ts apps/cli/src/runtime/interactive/approvals.test.ts apps/cli/src/runtime/interactive/session-runtime.ts apps/cli/src/runtime/interactive/session-runtime.test.ts apps/cli/src/runtime/run-interactive.ts apps/cli/src/tui/contexts/session-context.tsx sdk/packages/agents/src/agent-runtime.ts sdk/packages/agents/src/agent-runtime.test.ts sdk/packages/shared/src/agent.ts
```

I also checked the branch diff against `origin/main` after rebasing to verify the PR contains only the intended approval-toggle changes.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable. This is a CLI runtime behavior fix with no visual UI changes.

### Additional Notes

While preparing the PR, the task worktree was on a detached commit behind current `origin/main`. I rebased the single fix commit onto `origin/main` before creating the PR so the branch diff is limited to this bug fix.
