### PR TITLE
docs(vscode): remove marketplace README language links

### DIFF
--- a/apps/vscode/README.marketplace.md
+++ b/apps/vscode/README.marketplace.md
@@ -1,7 +1,3 @@
-<div align="center"><sub>
-English | <a href="https://github.com/cline/cline/blob/main/locales/es/README.md" target="_blank">Español</a> | <a href="https://github.com/cline/cline/blob/main/locales/de/README.md" target="_blank">Deutsch</a> | <a href="https://github.com/cline/cline/blob/main/locales/ja/README.md" target="_blank">日本語</a> | <a href="https://github.com/cline/cline/blob/main/locales/zh-cn/README.md" target="_blank">简体中文</a> | <a href="https://github.com/cline/cline/blob/main/locales/zh-tw/README.md" target="_blank">繁體中文</a> | <a href="https://github.com/cline/cline/blob/main/locales/ko/README.md" target="_blank">한국어</a>
-</sub></div>
-
 # Cline
 <div align="center">
 <table>


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This removes the language-switcher row from the top of the VS Code marketplace README.

The requested links were not present in `apps/vscode/README.md`; they were at the top of `apps/vscode/README.marketplace.md`, which is the README used for the VS Code marketplace content. The change removes only that leading translation-link block and leaves the rest of the marketplace README unchanged.

While preparing the PR, the task worktree started from a detached commit whose tree differed from `origin/main` in unrelated files. To keep this PR scoped, I rebuilt the final PR branch from `origin/main` and cherry-picked only the README commit. The resulting diff against `main` is a single documentation file with four deleted lines.

### Test Procedure

Reviewed the git diff to confirm the only final change is the removal of the language-link block from `apps/vscode/README.marketplace.md`.

No automated tests were run because this is a documentation-only change that does not affect runtime code, build output, or test behavior.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. This is a README markdown-only change.

### Additional Notes

The final head branch is based on `origin/main` and contains one commit: `docs(vscode): remove marketplace readme language links`.
