### PR TITLE
fix(cli): resolve Cline model display names by just model name

### DIFF
--- a/apps/cli/src/tui/components/model-selector/cline-model-picker.tsx
+++ b/apps/cli/src/tui/components/model-selector/cline-model-picker.tsx
@@ -9,7 +9,10 @@ import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
 import "opentui-spinner/react";
 import { palette } from "../../palette";
-import { resolveModelDisplayName } from "./model-display-name";
+import {
+	type KnownModels,
+	resolveModelDisplayName,
+} from "./model-display-name";
 
 export interface ClineModelPickerItem {
 	kind: "model";
@@ -70,7 +73,7 @@ export function ClineModelPicker(props: {
 	entries: ClineModelPickerEntry[];
 	selected: number;
 	loading?: boolean;
-	knownModels?: Record<string, unknown>;
+	knownModels?: KnownModels;
 	currentModelId?: string;
 }) {
 	const { entries, selected, loading, knownModels, currentModelId } = props;

--- a/apps/cli/src/tui/components/model-selector/cline-model-picker.tsx
+++ b/apps/cli/src/tui/components/model-selector/cline-model-picker.tsx
@@ -9,6 +9,7 @@ import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
 import "opentui-spinner/react";
 import { palette } from "../../palette";
+import { resolveModelDisplayName } from "./model-display-name";
 
 export interface ClineModelPickerItem {
 	kind: "model";
@@ -28,23 +29,6 @@ function tagColor(tag: string): string {
 	if (tag === "FREE") return palette.success;
 	if (tag === "BEST") return "magenta";
 	return "cyan";
-}
-
-function resolveDisplayName(
-	modelId: string,
-	knownModels?: Record<string, unknown>,
-): string {
-	if (knownModels) {
-		const candidates = [modelId, modelId.split("/").pop()];
-		for (const key of candidates) {
-			if (!key) continue;
-			const hit = knownModels[key] as { name?: string } | undefined;
-			if (hit?.name) return hit.name;
-		}
-	}
-	return modelId.includes("/")
-		? (modelId.split("/").pop() ?? modelId)
-		: modelId;
 }
 
 export function useClineRecommendedModels() {
@@ -126,7 +110,11 @@ export function ClineModelPicker(props: {
 			}
 
 			const tags = entry.model.tags;
-			const name = resolveDisplayName(entry.model.id, knownModels);
+			const name = resolveModelDisplayName(
+				entry.model.id,
+				knownModels,
+				entry.model.name,
+			);
 			const isCurrent = currentModelId === entry.model.id;
 			rows.push(
 				<box

--- a/apps/cli/src/tui/components/model-selector/cline-model-selector.tsx
+++ b/apps/cli/src/tui/components/model-selector/cline-model-selector.tsx
@@ -4,7 +4,10 @@ import { useDialogKeyboard } from "@opentui-ui/dialog/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { palette } from "../../palette";
 import type { ClineModelPickerEntry } from "./cline-model-picker";
-import { resolveModelDisplayName } from "./model-display-name";
+import {
+	type KnownModels,
+	resolveModelDisplayName,
+} from "./model-display-name";
 import { CHANGE_PROVIDER_ACTION } from "./model-selector";
 import { ProviderRow } from "./provider-row";
 
@@ -25,7 +28,7 @@ export function ClineModelSelectorContent(
 	props: ChoiceContext<string> & {
 		currentModel: string;
 		currentProviderName: string;
-		knownModels?: Record<string, unknown>;
+		knownModels?: KnownModels;
 		entries: ClineModelPickerEntry[];
 	},
 ) {
@@ -206,7 +209,7 @@ export function ClineModelSelectorDialogContent(
 	props: ChoiceContext<string> & {
 		currentModel: string;
 		currentProviderName: string;
-		knownModels?: Record<string, unknown>;
+		knownModels?: KnownModels;
 		loadEntries: () => Promise<ClineModelPickerEntry[]>;
 	},
 ) {

--- a/apps/cli/src/tui/components/model-selector/cline-model-selector.tsx
+++ b/apps/cli/src/tui/components/model-selector/cline-model-selector.tsx
@@ -4,6 +4,7 @@ import { useDialogKeyboard } from "@opentui-ui/dialog/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { palette } from "../../palette";
 import type { ClineModelPickerEntry } from "./cline-model-picker";
+import { resolveModelDisplayName } from "./model-display-name";
 import { CHANGE_PROVIDER_ACTION } from "./model-selector";
 import { ProviderRow } from "./provider-row";
 
@@ -18,23 +19,6 @@ function tagColor(tag: string): string {
 	if (tag === "FREE") return palette.success;
 	if (tag === "BEST") return "magenta";
 	return "cyan";
-}
-
-function resolveDisplayName(
-	modelId: string,
-	knownModels?: Record<string, unknown>,
-): string {
-	if (knownModels) {
-		const candidates = [modelId, modelId.split("/").pop()];
-		for (const key of candidates) {
-			if (!key) continue;
-			const hit = knownModels[key] as { name?: string } | undefined;
-			if (hit?.name) return hit.name;
-		}
-	}
-	return modelId.includes("/")
-		? (modelId.split("/").pop() ?? modelId)
-		: modelId;
 }
 
 export function ClineModelSelectorContent(
@@ -85,7 +69,11 @@ export function ClineModelSelectorContent(
 				rows.push({
 					key: entry.model.id,
 					kind: "model",
-					label: resolveDisplayName(entry.model.id, knownModels),
+					label: resolveModelDisplayName(
+						entry.model.id,
+						knownModels,
+						entry.model.name,
+					),
 					tags: entry.model.tags,
 					isCurrent: currentModel === entry.model.id,
 					entryIndex: i,

--- a/apps/cli/src/tui/components/model-selector/model-display-name.test.ts
+++ b/apps/cli/src/tui/components/model-selector/model-display-name.test.ts
@@ -2,6 +2,14 @@ import { describe, expect, it } from "vitest";
 import { resolveModelDisplayName } from "./model-display-name";
 
 describe("resolveModelDisplayName", () => {
+	it("resolves display names by exact model id", () => {
+		expect(
+			resolveModelDisplayName("claude-sonnet", {
+				"claude-sonnet": { name: "Claude Sonnet" },
+			}),
+		).toBe("Claude Sonnet");
+	});
+
 	it("resolves display names by model slug when provider prefixes differ", () => {
 		expect(
 			resolveModelDisplayName("zai/glm-5.2", {
@@ -17,5 +25,15 @@ describe("resolveModelDisplayName", () => {
 				"zai/glm-5.2": { id: "zai/glm-5.2", name: "Vercel GLM" },
 			}),
 		).toBe("Vercel GLM");
+	});
+
+	it("uses the fallback name when no catalog entry matches", () => {
+		expect(resolveModelDisplayName("zai/glm-5.2", {}, "GLM 5.2")).toBe(
+			"GLM 5.2",
+		);
+	});
+
+	it("falls back to the model slug without known models", () => {
+		expect(resolveModelDisplayName("zai/glm-5.2")).toBe("glm-5.2");
 	});
 });

--- a/apps/cli/src/tui/components/model-selector/model-display-name.test.ts
+++ b/apps/cli/src/tui/components/model-selector/model-display-name.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { resolveModelDisplayName } from "./model-display-name";
+
+describe("resolveModelDisplayName", () => {
+	it("resolves display names by model slug when provider prefixes differ", () => {
+		expect(
+			resolveModelDisplayName("zai/glm-5.2", {
+				"z-ai/glm-5.2": { id: "z-ai/glm-5.2", name: "GLM-5.2" },
+			}),
+		).toBe("GLM-5.2");
+	});
+
+	it("prefers exact model id matches over slug matches", () => {
+		expect(
+			resolveModelDisplayName("zai/glm-5.2", {
+				"z-ai/glm-5.2": { id: "z-ai/glm-5.2", name: "OpenRouter GLM" },
+				"zai/glm-5.2": { id: "zai/glm-5.2", name: "Vercel GLM" },
+			}),
+		).toBe("Vercel GLM");
+	});
+});

--- a/apps/cli/src/tui/components/model-selector/model-display-name.ts
+++ b/apps/cli/src/tui/components/model-selector/model-display-name.ts
@@ -15,7 +15,7 @@ export function resolveKnownModelInfo(
 	if (!knownModels) return undefined;
 
 	const exactMatch = knownModels[modelId];
-	if (exactMatch) return exactMatch;
+	if (exactMatch !== undefined) return exactMatch;
 
 	const modelSlug = modelId.split("/").pop();
 	return Object.entries(knownModels).find(([key, model]) => {

--- a/apps/cli/src/tui/components/model-selector/model-display-name.ts
+++ b/apps/cli/src/tui/components/model-selector/model-display-name.ts
@@ -1,0 +1,32 @@
+export function resolveKnownModelInfo(
+	modelId: string,
+	knownModels?: Record<string, unknown>,
+): { name?: string } | undefined {
+	if (!knownModels) return undefined;
+
+	const exactMatch = knownModels[modelId] as { name?: string } | undefined;
+	if (exactMatch) return exactMatch;
+
+	const modelSlug = modelId.split("/").pop();
+	return Object.entries(knownModels).find(([key, model]) => {
+		const knownModel = model as { id?: string } | undefined;
+		return (
+			key.split("/").pop() === modelSlug ||
+			knownModel?.id?.split("/").pop() === modelSlug
+		);
+	})?.[1] as { name?: string } | undefined;
+}
+
+export function resolveModelDisplayName(
+	modelId: string,
+	knownModels?: Record<string, unknown>,
+	fallbackName?: string,
+): string {
+	const modelInfo = resolveKnownModelInfo(modelId, knownModels);
+	if (modelInfo?.name) return modelInfo.name;
+
+	if (fallbackName) return fallbackName;
+	return modelId.includes("/")
+		? (modelId.split("/").pop() ?? modelId)
+		: modelId;
+}

--- a/apps/cli/src/tui/components/model-selector/model-display-name.ts
+++ b/apps/cli/src/tui/components/model-selector/model-display-name.ts
@@ -1,25 +1,34 @@
+export interface KnownModelInfo {
+	id?: string;
+	name?: string;
+	capabilities?: string[];
+	maxInputTokens?: number;
+	contextWindow?: number;
+}
+
+export type KnownModels = Record<string, KnownModelInfo>;
+
 export function resolveKnownModelInfo(
 	modelId: string,
-	knownModels?: Record<string, unknown>,
-): { name?: string } | undefined {
+	knownModels?: KnownModels,
+): KnownModelInfo | undefined {
 	if (!knownModels) return undefined;
 
-	const exactMatch = knownModels[modelId] as { name?: string } | undefined;
+	const exactMatch = knownModels[modelId];
 	if (exactMatch) return exactMatch;
 
 	const modelSlug = modelId.split("/").pop();
 	return Object.entries(knownModels).find(([key, model]) => {
-		const knownModel = model as { id?: string } | undefined;
 		return (
 			key.split("/").pop() === modelSlug ||
-			knownModel?.id?.split("/").pop() === modelSlug
+			model.id?.split("/").pop() === modelSlug
 		);
-	})?.[1] as { name?: string } | undefined;
+	})?.[1];
 }
 
 export function resolveModelDisplayName(
 	modelId: string,
-	knownModels?: Record<string, unknown>,
+	knownModels?: KnownModels,
 	fallbackName?: string,
 ): string {
 	const modelInfo = resolveKnownModelInfo(modelId, knownModels);

--- a/apps/cli/src/tui/components/status-bar.test.ts
+++ b/apps/cli/src/tui/components/status-bar.test.ts
@@ -3,6 +3,8 @@ import {
 	createContextBar,
 	formatStatusBarUsageText,
 	resolveContextBarFilledForeground,
+	resolveModelDisplayName,
+	resolveModelMaxInputTokens,
 } from "./status-bar";
 
 vi.mock("@opentui/react", () => ({
@@ -68,5 +70,33 @@ describe("formatStatusBarUsageText", () => {
 				showCost: false,
 			}),
 		).toBe("(12,345)");
+	});
+});
+
+describe("model display helpers", () => {
+	it("resolves status-bar model names by model slug when provider prefixes differ", () => {
+		expect(
+			resolveModelDisplayName({
+				modelId: "zai/glm-5.2",
+				knownModels: {
+					"z-ai/glm-5.2": { id: "z-ai/glm-5.2", name: "GLM-5.2" },
+				},
+			}),
+		).toBe("GLM-5.2");
+	});
+
+	it("resolves max input tokens by model slug when provider prefixes differ", () => {
+		expect(
+			resolveModelMaxInputTokens({
+				modelId: "zai/glm-5.2",
+				knownModels: {
+					"z-ai/glm-5.2": {
+						id: "z-ai/glm-5.2",
+						name: "GLM-5.2",
+						maxInputTokens: 262_144,
+					},
+				},
+			}),
+		).toBe(262_144);
 	});
 });

--- a/apps/cli/src/tui/components/status-bar.tsx
+++ b/apps/cli/src/tui/components/status-bar.tsx
@@ -11,6 +11,10 @@ import {
 	getSuccessColor,
 } from "../palette";
 import { HOME_VIEW_MAX_WIDTH } from "../types";
+import {
+	resolveModelDisplayName as resolveKnownModelDisplayName,
+	resolveKnownModelInfo,
+} from "./model-selector/model-display-name";
 
 export function createContextBar(
 	used: number,
@@ -56,31 +60,13 @@ export function formatStatusBarUsageText(input: {
 	return `${tokens} ${formatCost(input.totalCost)}`;
 }
 
-// knownModels keys are bare IDs ("claude-sonnet-4-6") but config.modelId
-// may include a provider prefix ("anthropic/claude-sonnet-4-6"), so we
-// try the full ID first, then strip the prefix and retry.
-function lookupModelInfo(
-	modelId: string,
-	knownModels?: Record<string, unknown>,
-): { name?: string } | undefined {
-	if (!knownModels) return undefined;
-	const candidates = [modelId, modelId.split("/").pop()];
-	for (const key of candidates) {
-		if (!key) continue;
-		const hit = knownModels[key] as { name?: string } | undefined;
-		if (hit) return hit;
-	}
-	return undefined;
-}
-
 export function resolveModelDisplayName(config: {
 	modelId: string;
 	knownModels?: Record<string, unknown>;
 	thinking?: boolean;
 	reasoningEffort?: string;
 }): string {
-	const info = lookupModelInfo(config.modelId, config.knownModels);
-	const name = info?.name ?? config.modelId.split("/").pop() ?? config.modelId;
+	const name = resolveKnownModelDisplayName(config.modelId, config.knownModels);
 	if (config.thinking && config.reasoningEffort) {
 		return `${name} (${config.reasoningEffort})`;
 	}
@@ -91,7 +77,8 @@ export function resolveModelMaxInputTokens(config: {
 	modelId: string;
 	knownModels?: Record<string, unknown>;
 }): number | undefined {
-	const info = (lookupModelInfo(config.modelId, config.knownModels) ?? {}) as {
+	const info = (resolveKnownModelInfo(config.modelId, config.knownModels) ??
+		{}) as {
 		maxInputTokens?: number;
 		contextWindow?: number;
 	};

--- a/apps/cli/src/tui/components/status-bar.tsx
+++ b/apps/cli/src/tui/components/status-bar.tsx
@@ -12,6 +12,7 @@ import {
 } from "../palette";
 import { HOME_VIEW_MAX_WIDTH } from "../types";
 import {
+	type KnownModels,
 	resolveModelDisplayName as resolveKnownModelDisplayName,
 	resolveKnownModelInfo,
 } from "./model-selector/model-display-name";
@@ -62,7 +63,7 @@ export function formatStatusBarUsageText(input: {
 
 export function resolveModelDisplayName(config: {
 	modelId: string;
-	knownModels?: Record<string, unknown>;
+	knownModels?: KnownModels;
 	thinking?: boolean;
 	reasoningEffort?: string;
 }): string {
@@ -75,13 +76,9 @@ export function resolveModelDisplayName(config: {
 
 export function resolveModelMaxInputTokens(config: {
 	modelId: string;
-	knownModels?: Record<string, unknown>;
+	knownModels?: KnownModels;
 }): number | undefined {
-	const info = (resolveKnownModelInfo(config.modelId, config.knownModels) ??
-		{}) as {
-		maxInputTokens?: number;
-		contextWindow?: number;
-	};
+	const info = resolveKnownModelInfo(config.modelId, config.knownModels) ?? {};
 	if (typeof info.maxInputTokens === "number" && info.maxInputTokens > 0) {
 		return info.maxInputTokens;
 	}

--- a/apps/cli/src/tui/hooks/use-model-selector.tsx
+++ b/apps/cli/src/tui/hooks/use-model-selector.tsx
@@ -299,7 +299,7 @@ export function useModelSelector(opts: {
 								{...ctx}
 								currentModel={config.modelId}
 								currentProviderName={providerDisplayName}
-								knownModels={config.knownModels as Record<string, unknown>}
+								knownModels={config.knownModels}
 								loadEntries={async () =>
 									buildClineModelEntries(await fetchClineRecommendedModels())
 								}

--- a/apps/cli/src/tui/views/onboarding/controller.ts
+++ b/apps/cli/src/tui/views/onboarding/controller.ts
@@ -25,6 +25,7 @@ import {
 	type ClineModelPickerEntry,
 	useClineRecommendedModels,
 } from "../../components/model-selector/cline-model-picker";
+import type { KnownModels } from "../../components/model-selector/model-display-name";
 import {
 	type SearchableItem,
 	useSearchableList,
@@ -194,7 +195,7 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 		Set<string>
 	>(new Set());
 	const [clineKnownModels, setClineKnownModels] = useState<
-		Record<string, unknown> | undefined
+		KnownModels | undefined
 	>(undefined);
 
 	useEffect(() => {

--- a/apps/cli/src/tui/views/onboarding/screens.tsx
+++ b/apps/cli/src/tui/views/onboarding/screens.tsx
@@ -8,6 +8,7 @@ import {
 	ClineModelPicker,
 	type ClineModelPickerEntry,
 } from "../../components/model-selector/cline-model-picker";
+import type { KnownModels } from "../../components/model-selector/model-display-name";
 import {
 	type SearchableItem,
 	SearchableList,
@@ -433,7 +434,7 @@ export function OnboardingProviderPickerScreen(props: {
 
 export function OnboardingClineModelScreen(props: {
 	clineEntries: ClineModelPickerEntry[];
-	clineKnownModels: Record<string, unknown> | undefined;
+	clineKnownModels: KnownModels | undefined;
 	clineModelSelected: number;
 	compact: boolean;
 	contentWidth: number;


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This fixes Cline CLI model display names when the selected model id uses one provider prefix but the catalog metadata uses another prefix for the same underlying model.

The concrete case is `zai/glm-5.2` from the Cline recommended models endpoint while the OpenRouter-backed model metadata uses `z-ai/glm-5.2`. Previously the recommended picker and the selected model label under the chat field could fall back to a raw or less readable model id because lookup only tried the exact id and a bare slug key.

The change extracts model display-name lookup into a shared helper used by both Cline recommended model renderers and the status bar. The helper keeps the existing exact-id behavior first, then compares model slugs across known model keys and known model `id` values. This keeps routing unchanged while letting display-only UI reuse the pretty catalog name for equivalent model slugs.

### Test Procedure

- Ran focused unit tests for the new shared display-name helper and status bar behavior:
  ```sh
  bunx vitest run src/tui/components/model-selector/model-display-name.test.ts src/tui/components/status-bar.test.ts --config vitest.config.ts
  ```
- Ran the CLI typecheck:
  ```sh
  bun -F @cline/cli typecheck
  ```
- Ran Biome on the touched files during local verification.
- The commit hook also ran `bun run types` and Biome for the staged CLI files before committing.

Potential risk is limited to CLI display labels and status-bar model metadata lookup. The helper prefers exact id matches before slug matches, so existing exact catalog entries continue to win.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not included. This is a terminal display-label fix and is covered by focused unit tests.

### Additional Notes

The helper intentionally does not rewrite model ids. It only resolves display names and known-model metadata by exact id first, then by the trailing model slug.
