### PR TITLE
Fix feature flag targeting for authenticated users

### DIFF
--- a/apps/vscode/src/sdk/auth-service.test.ts
+++ b/apps/vscode/src/sdk/auth-service.test.ts
@@ -17,6 +17,7 @@ import { AuthService, type ClineAuthInfo, LogoutReason } from "./auth-service"
 // ---------------------------------------------------------------------------
 
 const mockFeatureFlagsPoll = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
+const mockIdentifyAccount = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
 
 // Mock StateManager
 const mockSecrets = new Map<string, string>()
@@ -83,6 +84,13 @@ vi.mock("@/services/EnvUtils", () => ({
 vi.mock("@/services/feature-flags", () => ({
 	featureFlagsService: {
 		poll: mockFeatureFlagsPoll,
+	},
+}))
+
+// Mock telemetry
+vi.mock("@/services/telemetry", () => ({
+	telemetryService: {
+		identifyAccount: mockIdentifyAccount,
 	},
 }))
 
@@ -510,7 +518,9 @@ describe("AuthService", () => {
 				mockResponseStream as any,
 			)
 
+			expect(mockIdentifyAccount).toHaveBeenCalledWith(authInfo.userInfo)
 			expect(mockFeatureFlagsPoll).toHaveBeenCalledWith("user-123")
+			expect(mockIdentifyAccount.mock.invocationCallOrder[0]).toBeLessThan(mockFeatureFlagsPoll.mock.invocationCallOrder[0])
 			expect(mockController.postStateToWebview).toHaveBeenCalled()
 		})
 

--- a/apps/vscode/src/sdk/auth-service.ts
+++ b/apps/vscode/src/sdk/auth-service.ts
@@ -29,6 +29,7 @@ import { openAiCodexOAuthManager } from "@/integrations/openai-codex/oauth"
 import { BannerService } from "@/services/banner/BannerService"
 import { buildBasicClineHeaders } from "@/services/EnvUtils"
 import { featureFlagsService } from "@/services/feature-flags"
+import { telemetryService } from "@/services/telemetry"
 import { CLINE_API_ENDPOINT } from "@/shared/cline/api"
 import { fetch, getAxiosSettings } from "@/shared/net"
 import { Logger } from "@/shared/services/Logger"
@@ -963,9 +964,17 @@ export class AuthService {
 
 		await Promise.all(streamSends)
 
-		// Poll feature flags immediately for the current auth context so cache-only
-		// consumers (for example BannerService) see the latest remote config.
-		await featureFlagsService.poll(this._clineAuthInfo?.userInfo?.id || null)
+		// Identify authenticated users before polling feature flags so PostHog
+		// evaluates flags against the Cline account ID instead of the anonymous
+		// machine/install ID. Pass known person properties so flags can also target
+		// by email.
+		const userInfo = this._clineAuthInfo?.userInfo
+		if (userInfo?.id) {
+			await telemetryService.identifyAccount(userInfo)
+			await featureFlagsService.poll(userInfo.id)
+		} else {
+			await featureFlagsService.poll(null)
+		}
 
 		// Update state in webviews once per unique controller
 		await Promise.all(Array.from(uniqueControllers).map((c) => c.postStateToWebview()))


### PR DESCRIPTION
### Description

Updates feature flag polling on the SDK auth flow so authenticated users are identified before PostHog flag evaluation. The extension-side PostHog provider reads `getDistinctId()` when calling `getAllFlagsAndPayloads()`, so calling `telemetryService.identifyAccount(userInfo)` first is required to update that distinct id from the anonymous machine/install id to the signed-in Cline user id.

This lets extension-side feature flags target the authenticated Cline user id. The poll call continues to receive the user id for cache invalidation, and no name value is sent as a feature flag person property.

### Test Procedure

- Ran TypeScript type checking:
  - `cd apps/vscode && bunx tsc --noEmit --pretty false`
- Ran the auth service unit test covering feature flag polling:
  - `cd apps/vscode && bunx vitest run src/sdk/auth-service.test.ts --config vitest.config.ts`
- Ran Biome checks on changed files:
  - `cd apps/vscode && bunx biome check --config-path ./biome.jsonc src/sdk/auth-service.ts src/sdk/auth-service.test.ts src/services/feature-flags/FeatureFlagsService.ts src/services/feature-flags/FeatureFlagsProviderFactory.ts src/services/feature-flags/providers/IFeatureFlagsProvider.ts src/services/feature-flags/providers/PostHogFeatureFlagsProvider.ts src/services/telemetry/TelemetryService.ts src/services/telemetry/providers/posthog/PostHogTelemetryProvider.ts --no-errors-on-unmatched --files-ignore-unknown=true --diagnostic-level=error`

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — backend/service behavior only.

### Additional Notes

Base branch: `dpc/sdk-migration-simpler-login`.
