### PR TITLE
docs: add Extending Cline Marketplace page

### DIFF
--- a/docs/cli/acp-editor-integrations.mdx
+++ b/docs/cli/acp-editor-integrations.mdx
@@ -210,7 +210,7 @@ If Cline can't access files or run commands:
     Understand how Cline's Skills work across all editors via ACP.
   </Card>
   
-  <Card title="Hooks" icon="link" href="/customization/hooks">
-    Learn how to enforce policies with Hooks in any editor.
+  <Card title="Plugins" icon="puzzle-piece" href="/customization/plugins">
+    Learn how to extend Cline with custom tools, hooks, and capabilities.
   </Card>
 </Columns>

--- a/docs/customization/hooks.mdx
+++ b/docs/customization/hooks.mdx
@@ -1,7 +1,0 @@
----
-title: "Hooks"
-sidebarTitle: "Hooks"
-description: "See details under SDK Hooks page."
----
-
-See details under [SDK Plugins](/sdk/plugins).

--- a/docs/customization/marketplace.mdx
+++ b/docs/customization/marketplace.mdx
@@ -1,0 +1,31 @@
+---
+title: "Marketplace"
+sidebarTitle: "Marketplace"
+description: "Discover curated MCP servers, skills, and plugins for extending Cline."
+---
+
+The Cline Marketplace is a curated catalog of extensions that help you add new capabilities to Cline quickly and safely.
+
+Marketplace listings can include:
+
+- **MCP servers** for connecting Cline to external tools, APIs, and data sources
+- **Skills** for reusable task-specific instructions and workflows
+- **Plugins** for custom tools, lifecycle hooks, slash commands, and other advanced capabilities
+
+## What the Marketplace is for
+
+Use the Marketplace when you want to discover extensions that are designed to work well with Cline without starting from a blank configuration.
+
+Each listing is intended to make it easier to understand what the extension does, when to use it, and how to install or configure it.
+
+## Community submissions
+
+Community submissions are welcome. If you have built an MCP server, skill, or plugin that could help other Cline users, submit it for review so it can be considered for inclusion in the curated catalog.
+
+Before submitting, make sure your extension is documented, easy to install, and clear about any required credentials, permissions, or external services.
+
+## Related docs
+
+- [MCP](/mcp/mcp-overview)
+- [Skills](/customization/skills)
+- [Plugins](/customization/plugins)

--- a/docs/customization/marketplace.mdx
+++ b/docs/customization/marketplace.mdx
@@ -18,6 +18,25 @@ Use the Marketplace when you want to discover extensions that are designed to wo
 
 Each listing is intended to make it easier to understand what the extension does, when to use it, and how to install or configure it.
 
+## Browse the Marketplace
+
+There are two ways to see what's available in the Cline Marketplace:
+
+### Option 1: Web
+
+Browse what's included in the Cline Marketplace on the web (TO-BE-UPDATED): [cline.bot/mcp-marketplace](https://cline.bot/mcp-marketplace).
+
+### Option 2: CLI
+
+Install the Cline CLI and configure directly from what's available in the Marketplace:
+
+```bash
+npm i -g cline
+cline dashboard
+```
+
+From the dashboard, navigate to the **MCP**, **Skills**, and **Plugins** sections accordingly.
+
 ## Community submissions
 
 Community submissions are welcome. If you have built an MCP server, skill, or plugin that could help other Cline users, submit it for review so it can be considered for inclusion in the curated catalog.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -136,13 +136,18 @@
 						"pages": [
 							"tools-reference/all-cline-tools",
 							"customization/cline-rules",
+							"cli/scheduling",
+							"customization/clineignore"
+						]
+					},
+					{
+						"group": "Extending Cline",
+						"pages": [
+							"mcp/mcp-overview",
 							"customization/skills",
 							"customization/plugins",
-							"mcp/mcp-overview",
-							"customization/hooks",
-							"cli/scheduling",
-							"cli/connectors",
-							"customization/clineignore"
+							"customization/marketplace",
+							"cli/connectors"
 						]
 					},
 					{
@@ -473,19 +478,19 @@
 		},
 		{
 			"source": "/features/hooks/real-world-examples",
-			"destination": "/customization/hooks"
+			"destination": "/sdk/plugins"
 		},
 		{
 			"source": "/features/hooks/index",
-			"destination": "/customization/hooks"
+			"destination": "/sdk/plugins"
 		},
 		{
 			"source": "/features/hooks/hook-reference",
-			"destination": "/customization/hooks"
+			"destination": "/sdk/plugins"
 		},
 		{
 			"source": "/features/hooks/samples",
-			"destination": "/customization/hooks"
+			"destination": "/sdk/plugins"
 		},
 		{
 			"source": "/features/plan-and-act",

--- a/docs/getting-started/config.mdx
+++ b/docs/getting-started/config.mdx
@@ -152,7 +152,6 @@ Rules:
 - [CLI Configuration](/cli/configuration)
 - [Rules](/customization/cline-rules)
 - [Skills](/customization/skills)
-- [Hooks](/customization/hooks)
 - [Plugins](/customization/plugins)
 - [.clineignore](/customization/clineignore)
 

--- a/docs/mcp/mcp-overview.mdx
+++ b/docs/mcp/mcp-overview.mdx
@@ -23,7 +23,7 @@ MCP (Model Context Protocol) lets Cline use external tools and data sources thro
 
 ### Option 1: Marketplace
 
-Use Cline's MCP Marketplace for one-click install when available.
+Use Cline's [Marketplace](/customization/marketplace) for one-click MCP server install when available.
 1. In the Cline panel, click the MCP Servers icon (stacked server icon in the top toolbar).
 2. Open the Marketplace tab.
 


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Adds an "Extending Cline" docs section to group extension-oriented pages together and introduces a new Marketplace page.

Changes include:

- Moves MCP, Skills, Plugins, and Connectors into the new Extending Cline section.
- Adds a Marketplace page describing Cline's curated catalog for MCP servers, skills, and plugins, including community submissions.
- Removes the standalone Hooks page and redirects old hook docs routes to SDK Plugins.
- Updates internal docs links that pointed at the removed Hooks page.

### Test Procedure

- Verified `docs.json` parses successfully with Node.
- Ran the Mintlify broken-link checker locally:

```bash
cd docs
npm run check -- --local
```

Result: `success no broken links found`

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - docs navigation/content update only.

### Additional Notes

No related issue; this is a small documentation/navigation update.
