### PR TITLE
fix(sdk): resolve Cline Z.ai model metadata aliases

### DIFF
--- a/sdk/packages/core/src/services/llms/provider-defaults.test.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.test.ts
@@ -58,6 +58,18 @@ describe("resolveProviderConfig", () => {
 		);
 	});
 
+	it("prefers Vercel-style Z.ai ids in Cline known models", async () => {
+		const resolved = await resolveProviderConfig("cline");
+
+		expect(resolved?.knownModels?.["zai/glm-5.2"]).toMatchObject({
+			id: "zai/glm-5.2",
+			name: "GLM 5.2",
+			contextWindow: 1_000_000,
+			maxInputTokens: 1_000_000,
+		});
+		expect(resolved?.knownModels?.["z-ai/glm-5.2"]).toBeUndefined();
+	});
+
 	it("uses the live OpenAI catalog for ChatGPT subscription models", async () => {
 		vi.stubGlobal(
 			"fetch",

--- a/sdk/packages/core/src/services/llms/provider-defaults.test.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.test.ts
@@ -70,6 +70,33 @@ describe("resolveProviderConfig", () => {
 		expect(resolved?.knownModels?.["z-ai/glm-5.2"]).toBeUndefined();
 	});
 
+	it("preserves explicit Cline known model overrides for alias ids", async () => {
+		const resolved = await resolveProviderConfig("cline", undefined, {
+			providerId: "cline",
+			modelId: "z-ai/glm-5.2",
+			knownModels: {
+				"z-ai/glm-5.2": {
+					id: "z-ai/glm-5.2",
+					name: "Custom GLM 5.2",
+					contextWindow: 123_456,
+					maxInputTokens: 123_456,
+				},
+			},
+		});
+
+		expect(resolved?.knownModels?.["z-ai/glm-5.2"]).toMatchObject({
+			id: "z-ai/glm-5.2",
+			name: "Custom GLM 5.2",
+			contextWindow: 123_456,
+			maxInputTokens: 123_456,
+		});
+		expect(resolved?.knownModels?.["zai/glm-5.2"]).toMatchObject({
+			id: "zai/glm-5.2",
+			contextWindow: 1_000_000,
+			maxInputTokens: 1_000_000,
+		});
+	});
+
 	it("uses the live OpenAI catalog for ChatGPT subscription models", async () => {
 		vi.stubGlobal(
 			"fetch",

--- a/sdk/packages/core/src/services/llms/provider-defaults.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.ts
@@ -179,7 +179,7 @@ async function mergeKnownModels(
 			...userKnownModels,
 		});
 	}
-	return Llms.sortModelsByReleaseDate({
+	const knownModels = Llms.sortModelsByReleaseDate({
 		...generated,
 		...defaultKnownModels,
 		...liveModels,
@@ -187,6 +187,17 @@ async function mergeKnownModels(
 		...publicModels,
 		...userKnownModels,
 	});
+
+	if (providerId === "cline") {
+		// Cline recommendations can use Vercel-style ids while the broader
+		// catalog includes OpenRouter aliases for the same models.
+		return Llms.preferCanonicalModelIds(
+			knownModels,
+			Llms.VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES,
+		);
+	}
+
+	return knownModels;
 }
 
 function resolveCatalogModels(

--- a/sdk/packages/core/src/services/llms/provider-defaults.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.ts
@@ -179,25 +179,30 @@ async function mergeKnownModels(
 			...userKnownModels,
 		});
 	}
-	const knownModels = Llms.sortModelsByReleaseDate({
+	const knownModelsWithoutUserOverrides = Llms.sortModelsByReleaseDate({
 		...generated,
 		...defaultKnownModels,
 		...liveModels,
 		...privateModels,
 		...publicModels,
-		...userKnownModels,
 	});
 
 	if (providerId === "cline") {
 		// Cline recommendations can use Vercel-style ids while the broader
 		// catalog includes OpenRouter aliases for the same models.
-		return Llms.preferCanonicalModelIds(
-			knownModels,
-			Llms.VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES,
-		);
+		return Llms.sortModelsByReleaseDate({
+			...Llms.preferCanonicalModelIds(
+				knownModelsWithoutUserOverrides,
+				Llms.VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES,
+			),
+			...userKnownModels,
+		});
 	}
 
-	return knownModels;
+	return Llms.sortModelsByReleaseDate({
+		...knownModelsWithoutUserOverrides,
+		...userKnownModels,
+	});
 }
 
 function resolveCatalogModels(

--- a/sdk/packages/core/src/services/providers/local-provider-service.test.ts
+++ b/sdk/packages/core/src/services/providers/local-provider-service.test.ts
@@ -1193,7 +1193,7 @@ describe("listLocalProviders", () => {
 		).toBe(false);
 	});
 
-	it("uses the same built-in model list for cline as openrouter", async () => {
+	it("uses Cline-specific Z.ai aliases in the built-in model list", async () => {
 		manager.saveProviderSettings(
 			{
 				provider: "cline",
@@ -1209,9 +1209,17 @@ describe("listLocalProviders", () => {
 		const openrouter = providers.find(
 			(provider) => provider.id === "openrouter",
 		);
+		const clineModelIds = new Set(
+			cline?.modelList?.map((model) => model.id) ?? [],
+		);
+		const openrouterModelIds = new Set(
+			openrouter?.modelList?.map((model) => model.id) ?? [],
+		);
 
 		expect(cline?.modelList?.length).toBeGreaterThan(0);
-		expect(cline?.modelList).toEqual(openrouter?.modelList);
+		expect(clineModelIds).toContain("zai/glm-5.2");
+		expect(clineModelIds).not.toContain("z-ai/glm-5.2");
+		expect(openrouterModelIds).toContain("z-ai/glm-5.2");
 	});
 
 	it("does not eagerly fetch LiteLLM private models while listing providers", async () => {

--- a/sdk/packages/llms/src/catalog/model-id-aliases.test.ts
+++ b/sdk/packages/llms/src/catalog/model-id-aliases.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+	isCanonicalModelIdForAliasRules,
+	preferCanonicalModelIds,
+	VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES,
+} from "./model-id-aliases";
+
+describe("model id aliases", () => {
+	it("recognizes canonical model ids for configured alias rules", () => {
+		expect(
+			isCanonicalModelIdForAliasRules(
+				"zai/glm-5.2",
+				VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES,
+			),
+		).toBe(true);
+		expect(
+			isCanonicalModelIdForAliasRules(
+				"z-ai/glm-5.2",
+				VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES,
+			),
+		).toBe(false);
+	});
+
+	it("removes an alias only when its canonical model id exists", () => {
+		const models = preferCanonicalModelIds(
+			{
+				"zai/glm-5.2": { source: "vercel" },
+				"z-ai/glm-5.2": { source: "openrouter" },
+				"z-ai/openrouter-only": { source: "openrouter" },
+			},
+			VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES,
+		);
+
+		expect(models).toEqual({
+			"zai/glm-5.2": { source: "vercel" },
+			"z-ai/openrouter-only": { source: "openrouter" },
+		});
+	});
+});

--- a/sdk/packages/llms/src/catalog/model-id-aliases.ts
+++ b/sdk/packages/llms/src/catalog/model-id-aliases.ts
@@ -1,0 +1,34 @@
+export interface ModelIdAliasRule {
+	canonicalPrefix: string;
+	aliasPrefix: string;
+}
+
+// Some upstream catalogs expose the same routed model under different provider
+// namespaces. Prefer the namespace our runtime can receive so exact model-info
+// lookups keep the right context window and token limits.
+export const VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES = [
+	{ canonicalPrefix: "zai/", aliasPrefix: "z-ai/" },
+] as const satisfies readonly ModelIdAliasRule[];
+
+export function isCanonicalModelIdForAliasRules(
+	modelId: string,
+	rules: readonly ModelIdAliasRule[],
+): boolean {
+	return rules.some((rule) => modelId.startsWith(rule.canonicalPrefix));
+}
+
+export function preferCanonicalModelIds<T>(
+	models: Record<string, T>,
+	rules: readonly ModelIdAliasRule[],
+): Record<string, T> {
+	return Object.fromEntries(
+		Object.entries(models).filter(([modelId]) => {
+			for (const rule of rules) {
+				if (!modelId.startsWith(rule.aliasPrefix)) continue;
+				const canonicalModelId = `${rule.canonicalPrefix}${modelId.slice(rule.aliasPrefix.length)}`;
+				if (canonicalModelId in models) return false;
+			}
+			return true;
+		}),
+	);
+}

--- a/sdk/packages/llms/src/index.browser.ts
+++ b/sdk/packages/llms/src/index.browser.ts
@@ -1,5 +1,6 @@
 export type {
 	ModelCollection,
+	ModelIdAliasRule,
 	ModelInfo,
 	ModelInfo as CatalogModelInfo,
 	ProviderCapability as CatalogProviderCapability,
@@ -15,11 +16,14 @@ export {
 	getProviderCollectionSync,
 	getProviderIds,
 	hasProvider,
+	isCanonicalModelIdForAliasRules,
 	MODEL_COLLECTIONS_BY_PROVIDER_ID,
+	preferCanonicalModelIds,
 	registerModel,
 	registerProvider,
 	resetRegistry,
 	unregisterProvider,
+	VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES,
 } from "./models";
 export {
 	type ProviderUsageCostDisplay,

--- a/sdk/packages/llms/src/index.ts
+++ b/sdk/packages/llms/src/index.ts
@@ -1,5 +1,6 @@
 export type {
 	ModelCollection,
+	ModelIdAliasRule,
 	ModelInfo,
 	ModelInfo as CatalogModelInfo,
 	ProviderCapability as CatalogProviderCapability,
@@ -19,12 +20,15 @@ export {
 	getProviderCollectionSync,
 	getProviderIds,
 	hasProvider,
+	isCanonicalModelIdForAliasRules,
 	MODEL_COLLECTIONS_BY_PROVIDER_ID,
+	preferCanonicalModelIds,
 	registerModel,
 	registerProvider,
 	resetRegistry,
 	sortModelsByReleaseDate,
 	unregisterProvider,
+	VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES,
 } from "./models";
 export type {
 	ApiHandler,

--- a/sdk/packages/llms/src/models.ts
+++ b/sdk/packages/llms/src/models.ts
@@ -6,6 +6,12 @@ export {
 	fetchModelsDevProviderModels,
 	sortModelsByReleaseDate,
 } from "./catalog/catalog-live";
+export type { ModelIdAliasRule } from "./catalog/model-id-aliases";
+export {
+	isCanonicalModelIdForAliasRules,
+	preferCanonicalModelIds,
+	VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES,
+} from "./catalog/model-id-aliases";
 export type {
 	ModelCollection,
 	ModelInfo,

--- a/sdk/packages/llms/src/providers/builtins.test.ts
+++ b/sdk/packages/llms/src/providers/builtins.test.ts
@@ -50,6 +50,23 @@ describe("cline builtin spec defaults.baseUrl", () => {
 	});
 });
 
+describe("cline builtin models", () => {
+	it("prefers Vercel-style Z.ai model ids over equivalent OpenRouter ids", async () => {
+		const models = await getModelsForProvider("cline");
+
+		expect(models["zai/glm-5.2"]).toMatchObject({
+			id: "zai/glm-5.2",
+			name: "GLM 5.2",
+			contextWindow: 1_000_000,
+			maxInputTokens: 1_000_000,
+		});
+		expect(models["zai/glm-5.1"]).toMatchObject({
+			id: "zai/glm-5.1",
+		});
+		expect(models["z-ai/glm-5.2"]).toBeUndefined();
+	});
+});
+
 describe("cline-pass builtin spec", () => {
 	it("registers a distinct Cline-compatible provider with a custom model list", async () => {
 		const models = await getModelsForProvider("cline-pass");

--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -10,6 +10,11 @@ import {
 	type ProviderConfigField,
 } from "@cline/shared";
 import { getGeneratedModelsForProvider } from "../catalog/catalog.generated-access";
+import {
+	isCanonicalModelIdForAliasRules,
+	preferCanonicalModelIds,
+	VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES,
+} from "../catalog/model-id-aliases";
 import type {
 	ModelCollection,
 	ModelInfo,
@@ -325,6 +330,27 @@ function buildOpenAICodexModels(): Record<string, ModelInfo> {
 	return filterOpenAICodexModels(generatedModels("openai-native"));
 }
 
+function buildClineModels(): Record<string, ModelInfo> {
+	// Cline is OpenRouter-backed generally, but its recommended-model endpoint
+	// can return Vercel-style ids. Include those exact ids so runtime metadata
+	// resolves without adding duplicate OpenRouter aliases to the picker.
+	const vercelAliasModels = Object.fromEntries(
+		Object.entries(generatedModels("vercel-ai-gateway")).filter(([modelId]) =>
+			isCanonicalModelIdForAliasRules(
+				modelId,
+				VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES,
+			),
+		),
+	);
+	return preferCanonicalModelIds(
+		{
+			...generatedModels("openrouter"),
+			...vercelAliasModels,
+		},
+		VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES,
+	);
+}
+
 function fallbackModelInfo(id: string, spec?: BuiltinSpec): ModelInfo {
 	const info: ModelInfo = {
 		id,
@@ -482,7 +508,7 @@ const cline = createClineLikeSpec({
 	id: "cline",
 	name: "Cline",
 	popular: 1,
-	modelsProviderId: "openrouter",
+	modelsFactory: buildClineModels,
 	defaultModelId: CLINE_DEFAULT_MODEL_ID,
 });
 


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Cline can receive recommended model ids using Vercel AI Gateway's Z.ai namespace, for example `zai/glm-5.2`, while the broader OpenRouter-backed model catalog exposes the same models under OpenRouter's namespace, for example `z-ai/glm-5.2`.

The previous CLI-side display-name fix tried to paper over this by resolving names against the model basename. That helped labels in some places, but it did not solve the actual SDK/runtime model-info lookup problem: when Cline selected `zai/glm-5.2`, exact lookups in `knownModels` could miss and fall back to default metadata, including an incorrect context window.

This PR moves the fix to the SDK catalog layer:

- Adds a small shared model-id alias helper in `@cline/llms` for provider namespace discrepancies.
- Defines the current Vercel/OpenRouter Z.ai alias rule once: canonical `zai/` ids, OpenRouter alias `z-ai/` ids.
- Builds the Cline builtin model catalog from OpenRouter models plus only the Vercel-style canonical alias ids that Cline can receive.
- Removes equivalent OpenRouter aliases when the canonical Vercel-style id exists, so `/settings > models` does not show duplicate `GLM 5.2` rows.
- Applies the same alias cleanup in core provider-default resolution after all generated/live/private/public/user model sources are merged.

The important behavioral result is that Cline keeps an exact `knownModels["zai/glm-5.2"]` entry with the Vercel catalog metadata, including the correct `1_000_000` token context/input limits, while avoiding a duplicate `z-ai/glm-5.2` row for the same routed model.

This is intentionally not basename matching. Basename matching can conflate provider-specific metadata across unrelated providers. The alias table keeps the behavior explicit and makes future namespace discrepancies easy to add in one place.

### Test Procedure

Ran focused formatting, tests, build, and typechecks on a branch based on latest `origin/main`, which already contains the revert of the previous CLI display-name workaround.

Commands run:

```bash
bun biome check --write sdk/packages/llms/src/catalog/model-id-aliases.ts sdk/packages/llms/src/catalog/model-id-aliases.test.ts sdk/packages/llms/src/models.ts sdk/packages/llms/src/index.ts sdk/packages/llms/src/index.browser.ts sdk/packages/llms/src/providers/builtins.ts sdk/packages/llms/src/providers/builtins.test.ts sdk/packages/core/src/services/llms/provider-defaults.ts sdk/packages/core/src/services/llms/provider-defaults.test.ts
bunx vitest run src/catalog/model-id-aliases.test.ts src/providers/builtins.test.ts --config vitest.config.ts
bun -F @cline/llms build
bun -F @cline/llms typecheck
bunx vitest run src/services/llms/provider-defaults.test.ts --config vitest.config.ts
bun -F @cline/core typecheck
```

Verified coverage includes:

- The generic alias helper keeps canonical ids and removes an alias only when the canonical id exists.
- `getModelsForProvider("cline")` includes `zai/glm-5.2` and `zai/glm-5.1`.
- The Cline model catalog no longer includes the equivalent `z-ai/glm-5.2` duplicate when `zai/glm-5.2` is present.
- `resolveProviderConfig("cline")` exposes `knownModels["zai/glm-5.2"]` with the expected Vercel metadata and does not expose the duplicate `z-ai/glm-5.2` entry.
- `@cline/llms` builds successfully before the core test, so core imports fresh package output.

Potentially affected behavior:

- Cline provider model browsing now prefers the Vercel-style `zai/*` id for overlapping Z.ai models instead of showing both `zai/*` and `z-ai/*` duplicates.
- Non-Cline providers are unchanged. The core cleanup is gated to `providerId === "cline"`.
- OpenRouter-only `z-ai/*` entries remain intact because aliases are removed only when the canonical `zai/*` id exists.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. This is SDK/runtime model catalog behavior and does not introduce new UI.

### Additional Notes

This branch is based on latest `origin/main`, where `Revert "fix(cli): resolve Cline model display names by just model name (#11668)" (#11684)` is already present. The only commit in this PR is the SDK catalog fix.
