### PR TITLE
fix(cli): hide costs for Cline free models

### DIFF
--- a/apps/cli/src/runtime/run-agent.test.ts
+++ b/apps/cli/src/runtime/run-agent.test.ts
@@ -27,6 +27,16 @@ const outputMocks = vi.hoisted(() => ({
 	c: { dim: "", reset: "" },
 }));
 
+const sessionEventsMocks = vi.hoisted(() => ({
+	listener: undefined as ((event: unknown) => void) | undefined,
+	subscribeToAgentEvents: vi.fn(
+		(_: unknown, listener: (event: unknown) => void) => {
+			sessionEventsMocks.listener = listener;
+			return () => {};
+		},
+	),
+}));
+
 const CLINE_PASS_SUBSCRIPTION_URL =
 	"https://app.cline.bot/dashboard/subscription/";
 const CLINE_PASS_SUBSCRIPTION_MESSAGE = `No access to ClinePass subscription models yet. Subscribe to ClinePass, the low cost open weights model coding plan: ${CLINE_PASS_SUBSCRIPTION_URL}`;
@@ -88,7 +98,7 @@ vi.mock("./prompt", () => ({
 }));
 
 vi.mock("./session-events", () => ({
-	subscribeToAgentEvents: vi.fn(() => () => {}),
+	subscribeToAgentEvents: sessionEventsMocks.subscribeToAgentEvents,
 }));
 
 describe("runAgent", () => {
@@ -112,6 +122,9 @@ describe("runAgent", () => {
 		outputMocks.writeln.mockReset();
 		outputMocks.emitJsonLine.mockReset();
 		outputMocks.setActiveCliSession.mockReset();
+		sessionEventsMocks.listener = undefined;
+		sessionEventsMocks.subscribeToAgentEvents.mockClear();
+		vi.unstubAllGlobals();
 	});
 
 	afterEach(() => {
@@ -936,6 +949,123 @@ describe("runAgent", () => {
 
 		expect(outputMocks.writeln).not.toHaveBeenCalledWith(
 			expect.stringContaining("est. cost"),
+		);
+	});
+
+	it("zeros Cline free model costs in JSON results and agent events", async () => {
+		const startedAt = new Date("2026-03-22T00:00:00.000Z");
+		const endedAt = new Date("2026-03-22T00:00:01.000Z");
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => {
+				return new Response(
+					JSON.stringify({
+						free: [{ id: "deepseek/deepseek-v4-flash" }],
+					}),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				);
+			}),
+		);
+		sessionManagerMocks.start.mockResolvedValue({
+			sessionId: "session-1",
+			manifestPath: "/tmp/manifest.json",
+			messagesPath: "/tmp/messages.json",
+			manifest: {
+				session_id: "session-1",
+			},
+			result: {
+				text: "completed text",
+				usage: {
+					inputTokens: 1,
+					outputTokens: 1,
+					cacheReadTokens: 0,
+					cacheWriteTokens: 0,
+					totalCost: 0.25,
+				},
+				messages: [],
+				toolCalls: [],
+				iterations: 1,
+				finishReason: "completed",
+				model: {
+					id: "deepseek/deepseek-v4-flash",
+					provider: "cline",
+					info: {},
+				},
+				startedAt,
+				endedAt,
+				durationMs: 1000,
+			},
+		});
+		sessionManagerMocks.getAccumulatedUsage.mockResolvedValue({
+			usage: {
+				inputTokens: 1,
+				outputTokens: 1,
+				cacheReadTokens: 0,
+				cacheWriteTokens: 0,
+				totalCost: 0.25,
+			},
+			aggregateUsage: {
+				inputTokens: 1,
+				outputTokens: 1,
+				cacheReadTokens: 0,
+				cacheWriteTokens: 0,
+				totalCost: 0.25,
+			},
+		});
+
+		const { runAgent } = await import("./run-agent");
+		const { handleEvent } = await import("../utils/events");
+
+		await expect(
+			runAgent("test prompt", {
+				baseUrl: "https://cline.test/api/v1",
+				cwd: process.cwd(),
+				enableAgentTeams: false,
+				enableSpawnAgent: false,
+				enableTools: [],
+				execution: {
+					maxConsecutiveMistakes: 3,
+				},
+				logger: undefined,
+				mode: "yolo",
+				modelId: "deepseek/deepseek-v4-flash",
+				outputMode: "json",
+				providerId: "cline",
+				systemPrompt: "system",
+				thinking: false,
+				toolPolicies: { "*": { autoApprove: true } },
+				verbose: false,
+				workspaceRoot: process.cwd(),
+			} as never),
+		).resolves.toBeUndefined();
+
+		const runResult = outputMocks.emitJsonLine.mock.calls.find(
+			([, payload]) =>
+				(payload as { type?: string } | undefined)?.type === "run_result",
+		)?.[1] as
+			| {
+					usage?: { totalCost?: number };
+					aggregateUsage?: { totalCost?: number };
+			  }
+			| undefined;
+		expect(runResult?.usage?.totalCost).toBe(0);
+		expect(runResult?.aggregateUsage?.totalCost).toBe(0);
+
+		sessionEventsMocks.listener?.({
+			type: "usage",
+			inputTokens: 1,
+			outputTokens: 1,
+			cost: 0.25,
+			totalCost: 0.25,
+		});
+
+		expect(handleEvent).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				type: "usage",
+				cost: 0,
+				totalCost: 0,
+			}),
+			expect.any(Object),
 		);
 	});
 });

--- a/apps/cli/src/runtime/run-agent.ts
+++ b/apps/cli/src/runtime/run-agent.ts
@@ -18,6 +18,11 @@ import {
 } from "../utils/approval";
 import { formatCliErrorMessage } from "../utils/cline-pass-errors";
 import { handleEvent, handleTeamEvent } from "../utils/events";
+import {
+	shouldZeroClineFreeModelCost,
+	zeroCliAgentEventCost,
+	zeroCliUsageCost,
+} from "../utils/free-model-cost";
 import { createRuntimeHooks } from "../utils/hooks";
 import {
 	c,
@@ -184,8 +189,10 @@ export async function runAgent(
 	let reasoningChunkCount = 0;
 	let redactedReasoningChunkCount = 0;
 	const displayedErrorMessages = new Set<string>();
+	const shouldZeroCost = await shouldZeroClineFreeModelCost(config);
 
-	const onAgentEvent = (event: AgentEvent): void => {
+	const onAgentEvent = (rawEvent: AgentEvent): void => {
+		const event = zeroCliAgentEventCost(rawEvent, shouldZeroCost);
 		if (event.type === "content_start" && event.contentType === "reasoning") {
 			reasoningChunkCount += 1;
 			if (event.redacted) {
@@ -339,8 +346,14 @@ export async function runAgent(
 		const usageSummary = await sessionManager.getAccumulatedUsage(
 			started.sessionId,
 		);
-		const aggregateUsage = usageSummary?.aggregateUsage;
-		const usage = aggregateUsage ?? usageSummary?.usage ?? result.usage;
+		const aggregateUsage = zeroCliUsageCost(
+			usageSummary?.aggregateUsage,
+			shouldZeroCost,
+		);
+		const usage = zeroCliUsageCost(
+			aggregateUsage ?? usageSummary?.usage ?? result.usage,
+			shouldZeroCost,
+		);
 
 		if (config.outputMode === "json") {
 			emitJsonLine("stdout", {

--- a/apps/cli/src/runtime/run-interactive.ts
+++ b/apps/cli/src/runtime/run-interactive.ts
@@ -25,6 +25,11 @@ import type { QueuedPromptItem } from "../tui/types";
 import { type ChatCommandState, chatCommandHost } from "../utils/chat-commands";
 import { applyCliCompactionMode } from "../utils/compaction-mode";
 import {
+	shouldZeroClineFreeModelCost,
+	zeroCliAgentEventCost,
+	zeroCliUsageCost,
+} from "../utils/free-model-cost";
+import {
 	prepareTerminalForPostTuiOutput,
 	writeErr,
 	writeln,
@@ -153,6 +158,7 @@ export async function runInteractive(
 		askQuestionRef: tuiAskQuestion,
 	});
 	const providerSettingsManager = new ProviderSettingsManager();
+	let zeroCurrentTurnCost = false;
 
 	const sessionRuntime = createInteractiveSessionRuntime({
 		config,
@@ -166,7 +172,7 @@ export async function runInteractive(
 		resolveMistakeLimitDecision,
 		switchToActModeTool,
 		onAgentEvent: (event) => {
-			uiEvents.emit("agent", event);
+			uiEvents.emit("agent", zeroCliAgentEventCost(event, zeroCurrentTurnCost));
 		},
 		onTeamEvent: (event) => {
 			uiEvents.emit("team", event);
@@ -432,6 +438,7 @@ export async function runInteractive(
 		},
 		onSubmit: async (input, mode, delivery, attachments, onCommandOutput) => {
 			let commandOutput: string | undefined;
+			let zeroTurnCost = false;
 			try {
 				await sessionRuntime.ensureReady();
 				await waitForSubmittedMode(mode);
@@ -478,6 +485,8 @@ export async function runInteractive(
 				}
 				input = chatCommandResult.input;
 				commandOutput = chatCommandResult.commandOutput;
+				zeroTurnCost = await shouldZeroClineFreeModelCost(config);
+				zeroCurrentTurnCost = zeroTurnCost;
 				const {
 					prompt: userInput,
 					userImages,
@@ -519,8 +528,9 @@ export async function runInteractive(
 				}
 				if (result.finishReason !== "completed") {
 					if (result.finishReason === "aborted" || isAbortInProgress()) {
-						const usage = await sessionRuntime.getAccumulatedUsage(
-							result.usage,
+						const usage = zeroCliUsageCost(
+							await sessionRuntime.getAccumulatedUsage(result.usage),
+							zeroTurnCost,
 						);
 						return {
 							usage,
@@ -535,7 +545,10 @@ export async function runInteractive(
 						errorText || `Turn finished with ${result.finishReason}`,
 					);
 				}
-				const usage = await sessionRuntime.getAccumulatedUsage(result.usage);
+				const usage = zeroCliUsageCost(
+					await sessionRuntime.getAccumulatedUsage(result.usage),
+					zeroTurnCost,
+				);
 				return {
 					usage,
 					currentContextSize: getCurrentContextSize(result.messages),
@@ -559,6 +572,7 @@ export async function runInteractive(
 				});
 				throw error;
 			} finally {
+				zeroCurrentTurnCost = false;
 				if (!delivery) {
 					isRunning = false;
 					clearAbortInProgress();

--- a/apps/cli/src/utils/free-model-cost.test.ts
+++ b/apps/cli/src/utils/free-model-cost.test.ts
@@ -1,0 +1,109 @@
+import type { AgentEvent } from "@cline/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	clearClineFreeModelCostCache,
+	shouldZeroClineFreeModelCost,
+	zeroCliAgentEventCost,
+	zeroCliUsageCost,
+} from "./free-model-cost";
+
+afterEach(() => {
+	clearClineFreeModelCostCache();
+	vi.unstubAllGlobals();
+});
+
+describe("shouldZeroClineFreeModelCost", () => {
+	it("uses the Cline free model list", async () => {
+		const fetchMock = vi.fn(
+			async (_input: Parameters<typeof fetch>[0], _init?: RequestInit) => {
+				return new Response(
+					JSON.stringify({
+						free: [{ id: "deepseek/deepseek-v4-flash" }],
+					}),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				);
+			},
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			shouldZeroClineFreeModelCost({
+				providerId: "cline",
+				modelId: "deepseek/deepseek-v4-flash",
+				baseUrl: "https://cline.test/api/v1",
+			}),
+		).resolves.toBe(true);
+
+		expect(fetchMock.mock.calls[0]?.[0]).toBe(
+			"https://cline.test/api/v1/ai/cline/recommended-models",
+		);
+	});
+
+	it("does not zero non-Cline providers", async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			shouldZeroClineFreeModelCost({
+				providerId: "openrouter",
+				modelId: "deepseek/deepseek-v4-flash",
+				baseUrl: "https://cline.test/api/v1",
+			}),
+		).resolves.toBe(false);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+});
+
+describe("zeroCliUsageCost", () => {
+	it("zeros total cost while preserving token usage", () => {
+		expect(
+			zeroCliUsageCost(
+				{
+					inputTokens: 10,
+					outputTokens: 5,
+					totalCost: 0.001,
+				},
+				true,
+			),
+		).toEqual({
+			inputTokens: 10,
+			outputTokens: 5,
+			totalCost: 0,
+		});
+	});
+});
+
+describe("zeroCliAgentEventCost", () => {
+	it("zeros usage event cost fields", () => {
+		const event = {
+			type: "usage",
+			inputTokens: 10,
+			outputTokens: 5,
+			cost: 0.001,
+			totalCost: 0.001,
+		} as AgentEvent;
+
+		expect(zeroCliAgentEventCost(event, true)).toMatchObject({
+			cost: 0,
+			totalCost: 0,
+		});
+	});
+
+	it("zeros done event usage cost", () => {
+		const event = {
+			type: "done",
+			reason: "completed",
+			text: "ok",
+			iterations: 1,
+			usage: {
+				inputTokens: 10,
+				outputTokens: 5,
+				totalCost: 0.001,
+			},
+		} as AgentEvent;
+
+		expect(zeroCliAgentEventCost(event, true)).toMatchObject({
+			usage: { totalCost: 0 },
+		});
+	});
+});

--- a/apps/cli/src/utils/free-model-cost.test.ts
+++ b/apps/cli/src/utils/free-model-cost.test.ts
@@ -52,6 +52,59 @@ describe("shouldZeroClineFreeModelCost", () => {
 		).resolves.toBe(false);
 		expect(fetchMock).not.toHaveBeenCalled();
 	});
+
+	it("does not match a paid model by only the final path segment", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => {
+				return new Response(
+					JSON.stringify({
+						free: [{ id: "deepseek/deepseek-v4-flash" }],
+					}),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				);
+			}),
+		);
+
+		await expect(
+			shouldZeroClineFreeModelCost({
+				providerId: "cline",
+				modelId: "acme/deepseek-v4-flash",
+				baseUrl: "https://cline.test/api/v1",
+			}),
+		).resolves.toBe(false);
+	});
+
+	it("retries after a failed free model list fetch", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(new Response("unavailable", { status: 503 }))
+			.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						free: [{ id: "deepseek/deepseek-v4-flash" }],
+					}),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				),
+			);
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			shouldZeroClineFreeModelCost({
+				providerId: "cline",
+				modelId: "deepseek/deepseek-v4-flash",
+				baseUrl: "https://cline.test/api/v1",
+			}),
+		).resolves.toBe(false);
+		await expect(
+			shouldZeroClineFreeModelCost({
+				providerId: "cline",
+				modelId: "deepseek/deepseek-v4-flash",
+				baseUrl: "https://cline.test/api/v1",
+			}),
+		).resolves.toBe(true);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
 });
 
 describe("zeroCliUsageCost", () => {

--- a/apps/cli/src/utils/free-model-cost.ts
+++ b/apps/cli/src/utils/free-model-cost.ts
@@ -1,0 +1,119 @@
+import type { AgentEvent } from "@cline/core";
+import { getClineEnvironmentConfig } from "@cline/shared";
+import type { Config } from "./types";
+
+const CLINE_RECOMMENDED_MODELS_TIMEOUT_MS = 5_000;
+const freeModelIdsByBaseUrl = new Map<string, Promise<readonly string[]>>();
+
+function normalizeModelId(modelId: string | undefined): string {
+	return modelId?.trim().toLowerCase() ?? "";
+}
+
+function modelIdsMatch(selectedModelId: string, freeModelId: string): boolean {
+	const selected = normalizeModelId(selectedModelId);
+	const free = normalizeModelId(freeModelId);
+	if (!selected || !free) return false;
+	return (
+		selected === free || selected.split("/").pop() === free.split("/").pop()
+	);
+}
+
+function resolveClineRecommendedModelsUrl(baseUrl: string): string {
+	const normalizedBaseUrl = baseUrl.trim().replace(/\/+$/, "");
+	const apiBaseUrl = normalizedBaseUrl.endsWith("/api/v1")
+		? normalizedBaseUrl.slice(0, -"/api/v1".length)
+		: normalizedBaseUrl;
+	return `${apiBaseUrl}/api/v1/ai/cline/recommended-models`;
+}
+
+async function fetchClineFreeModelIds(
+	baseUrl: string,
+): Promise<readonly string[]> {
+	const controller = new AbortController();
+	const timeout = setTimeout(
+		() => controller.abort(),
+		CLINE_RECOMMENDED_MODELS_TIMEOUT_MS,
+	);
+	try {
+		const response = await fetch(resolveClineRecommendedModelsUrl(baseUrl), {
+			signal: controller.signal,
+		});
+		if (!response.ok) return [];
+		const json = (await response.json()) as { free?: unknown };
+		return Array.isArray(json.free)
+			? json.free
+					.map((model) =>
+						model && typeof model === "object"
+							? (model as Record<string, unknown>).id
+							: undefined,
+					)
+					.filter((id): id is string => typeof id === "string" && id.length > 0)
+			: [];
+	} catch {
+		return [];
+	} finally {
+		clearTimeout(timeout);
+	}
+}
+
+function getClineFreeModelIds(baseUrl: string): Promise<readonly string[]> {
+	const cacheKey = baseUrl.trim();
+	let cached = freeModelIdsByBaseUrl.get(cacheKey);
+	if (!cached) {
+		cached = fetchClineFreeModelIds(cacheKey);
+		freeModelIdsByBaseUrl.set(cacheKey, cached);
+	}
+	return cached;
+}
+
+export async function shouldZeroClineFreeModelCost(
+	config: Pick<Config, "providerId" | "modelId" | "baseUrl">,
+): Promise<boolean> {
+	if (config.providerId !== "cline") return false;
+	const modelId = normalizeModelId(config.modelId);
+	if (!modelId) return false;
+
+	const baseUrl =
+		config.baseUrl?.trim() || getClineEnvironmentConfig().apiBaseUrl;
+	const freeModelIds = await getClineFreeModelIds(baseUrl);
+	return freeModelIds.some((freeModelId) =>
+		modelIdsMatch(modelId, freeModelId),
+	);
+}
+
+export function zeroCliUsageCost<T extends { totalCost?: number } | undefined>(
+	usage: T,
+	shouldZeroCost: boolean,
+): T {
+	if (
+		!shouldZeroCost ||
+		!usage ||
+		typeof usage.totalCost !== "number" ||
+		usage.totalCost === 0
+	) {
+		return usage;
+	}
+	return { ...usage, totalCost: 0 } as T;
+}
+
+export function zeroCliAgentEventCost(
+	event: AgentEvent,
+	shouldZeroCost: boolean,
+): AgentEvent {
+	if (!shouldZeroCost) return event;
+	if (event.type === "done" && event.usage) {
+		return {
+			...event,
+			usage: zeroCliUsageCost(event.usage, true),
+		};
+	}
+	if (event.type !== "usage") return event;
+	const next = { ...event } as Record<string, unknown>;
+	if (typeof next.cost === "number") next.cost = 0;
+	if (typeof next.totalCost === "number") next.totalCost = 0;
+	return next as unknown as AgentEvent;
+}
+
+export function clearClineFreeModelCostCache(): void {
+	freeModelIdsByBaseUrl.clear();
+}

--- a/apps/cli/src/utils/free-model-cost.ts
+++ b/apps/cli/src/utils/free-model-cost.ts
@@ -3,7 +3,10 @@ import { getClineEnvironmentConfig } from "@cline/shared";
 import type { Config } from "./types";
 
 const CLINE_RECOMMENDED_MODELS_TIMEOUT_MS = 5_000;
-const freeModelIdsByBaseUrl = new Map<string, Promise<readonly string[]>>();
+const freeModelIdsByBaseUrl = new Map<
+	string,
+	Promise<readonly string[] | undefined>
+>();
 
 function normalizeModelId(modelId: string | undefined): string {
 	return modelId?.trim().toLowerCase() ?? "";
@@ -13,9 +16,7 @@ function modelIdsMatch(selectedModelId: string, freeModelId: string): boolean {
 	const selected = normalizeModelId(selectedModelId);
 	const free = normalizeModelId(freeModelId);
 	if (!selected || !free) return false;
-	return (
-		selected === free || selected.split("/").pop() === free.split("/").pop()
-	);
+	return selected === free;
 }
 
 function resolveClineRecommendedModelsUrl(baseUrl: string): string {
@@ -28,7 +29,7 @@ function resolveClineRecommendedModelsUrl(baseUrl: string): string {
 
 async function fetchClineFreeModelIds(
 	baseUrl: string,
-): Promise<readonly string[]> {
+): Promise<readonly string[] | undefined> {
 	const controller = new AbortController();
 	const timeout = setTimeout(
 		() => controller.abort(),
@@ -38,7 +39,7 @@ async function fetchClineFreeModelIds(
 		const response = await fetch(resolveClineRecommendedModelsUrl(baseUrl), {
 			signal: controller.signal,
 		});
-		if (!response.ok) return [];
+		if (!response.ok) return undefined;
 		const json = (await response.json()) as { free?: unknown };
 		return Array.isArray(json.free)
 			? json.free
@@ -50,7 +51,7 @@ async function fetchClineFreeModelIds(
 					.filter((id): id is string => typeof id === "string" && id.length > 0)
 			: [];
 	} catch {
-		return [];
+		return undefined;
 	} finally {
 		clearTimeout(timeout);
 	}
@@ -60,10 +61,13 @@ function getClineFreeModelIds(baseUrl: string): Promise<readonly string[]> {
 	const cacheKey = baseUrl.trim();
 	let cached = freeModelIdsByBaseUrl.get(cacheKey);
 	if (!cached) {
-		cached = fetchClineFreeModelIds(cacheKey);
+		cached = fetchClineFreeModelIds(cacheKey).then((ids) => {
+			if (!ids) freeModelIdsByBaseUrl.delete(cacheKey);
+			return ids;
+		});
 		freeModelIdsByBaseUrl.set(cacheKey, cached);
 	}
-	return cached;
+	return cached.then((ids) => ids ?? []);
 }
 
 export async function shouldZeroClineFreeModelCost(


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This fixes the CLI-side display of usage cost for Cline free models, specifically the case we reproduced with `deepseek/deepseek-v4-flash` reporting non-zero cost fields in runtime usage events/results even though the selected model is listed as free by the Cline API.

The change keeps the bandaid scoped to `apps/cli`:

- The CLI asks the Cline recommended-models endpoint for the current free model IDs when the selected provider is `cline`.
- The result is cached by base URL so repeated runs/turns do not repeatedly fetch the list.
- If the selected Cline model matches a free model ID, CLI usage payloads are normalized to `totalCost: 0` before they reach JSON output, final run stats, or interactive TUI event handling.
- Token usage is preserved. Only cost fields are zeroed.
- If the free-model lookup fails or times out, the CLI leaves the backend-provided cost untouched instead of guessing.

I intentionally avoided SDK/catalog/provider-default changes here because the issue is about what the CLI shows to users for Cline free models, and the cleaner long-term fix likely belongs in backend pricing semantics rather than broad client-side model metadata plumbing.

### Test Procedure

Ran targeted unit coverage for the helper and non-interactive runtime behavior:

```bash
bun -F @cline/cli test -- src/utils/free-model-cost.test.ts src/runtime/run-agent.test.ts
```

Result: 2 test files passed, 19 tests passed.

Ran CLI typecheck:

```bash
bun -F @cline/cli typecheck
```

Result: passed.

Ran Biome on the touched files:

```bash
bun biome check --diagnostic-level=error apps/cli/src/utils/free-model-cost.ts apps/cli/src/utils/free-model-cost.test.ts apps/cli/src/runtime/run-agent.ts apps/cli/src/runtime/run-agent.test.ts apps/cli/src/runtime/run-interactive.ts
```

Result: checked 5 files, no fixes applied.

Also smoke-tested the actual CLI behavior earlier with the Cline free model:

```bash
cd apps/cli
bun run dev -- --provider cline --model deepseek/deepseek-v4-flash --thinking none --yolo --json --timeout 90 "Reply exactly: OK" 2>&1 | tee /tmp/cline-free-model-zero-cost-smoke.log
```

The JSON usage event, done event, run result usage, and aggregate usage all reported zero cost while preserving token usage.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. This is CLI runtime usage/cost normalization behavior, covered by tests and the JSON smoke test above.

### Additional Notes

This is deliberately conservative. It only applies to the Cline provider and only when the current selected model appears in the Cline API free-model list. The failure mode is to preserve the existing backend-provided cost data if the free-model lookup cannot complete.
