### PR TITLE
docs(mcp): set type=streamableHttp in remote server example

### DIFF
--- a/docs/mcp/mcp-overview.mdx
+++ b/docs/mcp/mcp-overview.mdx
@@ -89,12 +89,13 @@ When adding a server, the CLI prompts for server name, transport type, command/a
 }
 ```
 
-### Remote server (HTTP/SSE)
+### Remote server (Streamable HTTP)
 
 ```json
 {
   "mcpServers": {
     "remote-server": {
+      "type": "streamableHttp",
       "url": "https://example.com/mcp",
       "headers": {
         "Authorization": "Bearer your-token"
@@ -105,6 +106,8 @@ When adding a server, the CLI prompts for server name, transport type, command/a
   }
 }
 ```
+
+The `type` field selects the transport. Omitting it defaults to the legacy `sse` transport for backward compatibility, so set `"type": "streamableHttp"` explicitly for the recommended transport. Use `"type": "sse"` only for legacy SSE servers.
 
 ## Transport types
 


### PR DESCRIPTION
﻿Fixes #11670

The remote-server JSON example in `docs/mcp/mcp-overview.mdx` omitted the `type` field. Because the config schema's `z.union` lists the SSE branch before `streamableHttp` (intentionally, for backward compat — see the load-bearing comment in `apps/vscode/src/services/mcp/schemas.ts`), an untyped remote entry silently resolves to the deprecated legacy SSE transport — the opposite of the docs' own "Streamable HTTP (recommended)" guidance.

This PR adds `"type": "streamableHttp"` to the example, renames the heading to match, and adds a sentence explaining that omitting `type` defaults to legacy SSE.

Docs-only change. No code or tests affected.
