### PR TITLE
Fix VS Code Codex OAuth credential resolution

### DIFF
--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -333,6 +333,48 @@ describe("buildSessionConfig", () => {
 		expect(mocks.providerSettingsManager.getProviderSettings).not.toHaveBeenCalled()
 	})
 
+	it("resolves OpenAI Codex through the shared OAuth provider registry", async () => {
+		mocks.providerSettingsManager.getProviderSettings.mockReturnValue({
+			provider: "openai-codex",
+			auth: {
+				accessToken: "codex-oauth-token",
+				refreshToken: "codex-refresh-token",
+			},
+		} as any)
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "openai-codex",
+			actModeApiModelId: "gpt-5.4",
+			openAiNativeApiKey: "openai-api-key-should-not-be-used",
+		} as any)
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+
+		expect(config.providerId).toBe("openai-codex")
+		expect(config.modelId).toBe("gpt-5.4")
+		expect(config.apiKey).toBe("codex-oauth-token")
+		expect(config.providerConfig).toMatchObject({
+			providerId: "openai-codex",
+			modelId: "gpt-5.4",
+			apiKey: "codex-oauth-token",
+		})
+	})
+
+	it("does not treat OpenAI Codex as OpenAI Native API-key auth", async () => {
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "openai-codex",
+			actModeApiModelId: "gpt-5.4",
+			openAiNativeApiKey: "openai-api-key-should-not-be-used",
+		} as any)
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+
+		expect(config.providerId).toBe("openai-codex")
+		expect(config.modelId).toBe("gpt-5.4")
+		expect(config.apiKey).toBe("")
+		expect(config.providerConfig).toMatchObject({ providerId: "openai-codex", modelId: "gpt-5.4" })
+		expect(config.providerConfig).not.toHaveProperty("apiKey")
+	})
+
 	it("uses ClinePass model storage and omits empty nested apiKey so SDK OAuth can fill it", async () => {
 		mocks.stateManager.getApiConfiguration.mockReturnValue({
 			actModeApiProvider: "cline-pass",

--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -192,7 +192,6 @@ const PROVIDER_API_KEY_MAP: Record<string, keyof ApiConfiguration> = {
 	openrouter: "openRouterApiKey",
 	openai: "openAiApiKey",
 	"openai-native": "openAiNativeApiKey",
-	"openai-codex": "openAiNativeApiKey", // Codex uses the same key
 	bedrock: "awsBedrockApiKey",
 	vertex: "geminiApiKey",
 	gemini: "geminiApiKey",


### PR DESCRIPTION
### Description

OpenAI Codex in the VS Code SDK session factory was being treated like OpenAI Native API-key auth by mapping `openai-codex` to `openAiNativeApiKey`. That meant a signed-in ChatGPT subscription user could still hit the OpenAI SDK error:

> OpenAI API key is missing. Pass it using the 'apiKey' parameter or the OPENAI_API_KEY environment variable.

Codex should not require an OpenAI API key. It is an OAuth-backed provider, and the extension already persists Codex OAuth credentials in provider settings. This PR removes the incorrect Codex -> OpenAI Native API key mapping so Codex follows the shared OAuth provider registry path, matching how the CLI resolves OAuth-backed providers.

The added tests cover both sides of the fix:

- Codex resolves a token through the shared OAuth/provider settings path when OAuth credentials are present.
- Codex does not fall back to `openAiNativeApiKey` when OAuth credentials are absent.

### Test Procedure

- `bun -F claude-dev test:vitest src/sdk/cline-session-factory.test.ts`
- `bun -F claude-dev check-types`

This specifically verifies the VS Code session config builder no longer passes OpenAI Native API key state into Codex, while preserving the existing shared OAuth resolution behavior.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — no UI changes.

### Additional Notes

Base branch: `dpc/sdk-migration-simpler-login`.
