### PR TITLE
fix(mcp): preserve streamableHttp transportType

### DIFF
--- a/apps/vscode/src/services/mcp/__tests__/schemas.test.ts
+++ b/apps/vscode/src/services/mcp/__tests__/schemas.test.ts
@@ -183,6 +183,36 @@ describe("McpSettingsSchema", () => {
 			;(server as any).url.should.equal("https://mcp.example.com/mcp")
 		})
 
+		it("accepts legacy transportType streamableHttp in MCP settings", () => {
+			const input = {
+				mcpServers: {
+					strictServer: {
+						transportType: "streamableHttp",
+						url: "http://localhost:8000/mcp",
+					},
+				},
+			}
+
+			const result = McpSettingsSchema.safeParse(input)
+			result.success.should.be.true()
+
+			const server = result.data!.mcpServers["strictServer"]
+			server.type.should.equal("streamableHttp")
+			;((server as any).transportType === undefined).should.be.true()
+		})
+
+		it("accepts legacy transportType http for URL servers", () => {
+			const result = ServerConfigSchema.safeParse({
+				transportType: "http",
+				url: "http://localhost:8000/mcp",
+			})
+
+			result.success.should.be.true()
+			const server = result.data!
+			server.type.should.equal("streamableHttp")
+			;((server as any).transportType === undefined).should.be.true()
+		})
+
 		it("accepts a flat stdio server with no explicit type", () => {
 			const input = {
 				mcpServers: {
@@ -207,6 +237,15 @@ describe("McpSettingsSchema", () => {
 			result.success.should.be.true()
 			// Without a type field, the flat schema defaults to "sse"
 			result.data!.mcpServers["legacy"].type.should.equal("sse")
+		})
+
+		it("rejects unknown legacy transportType values for URL servers", () => {
+			const result = ServerConfigSchema.safeParse({
+				transportType: "websocket",
+				url: "http://localhost:8000/mcp",
+			})
+
+			result.success.should.be.false()
 		})
 
 		it("preserves oauth on flat-format servers (round-trip from write-back)", () => {

--- a/apps/vscode/src/services/mcp/schemas.ts
+++ b/apps/vscode/src/services/mcp/schemas.ts
@@ -116,7 +116,8 @@ const createServerTypeSchema = () => {
 		})
 			.transform((data) => {
 				// Support both type and transportType fields
-				const finalType = data.type || (data.transportType === "sse" ? "sse" : undefined) || "sse"
+				const finalType =
+					data.type || (data.transportType === "sse" ? "sse" : undefined) || (data.transportType ? undefined : "sse")
 				return {
 					...data,
 					type: finalType as "sse",
@@ -138,8 +139,10 @@ const createServerTypeSchema = () => {
 		})
 			.transform((data) => {
 				// Support both type and transportType fields
-				// Note: legacy transportType was "http" not "streamableHttp"
-				const finalType = data.type || (data.transportType === "http" ? "streamableHttp" : undefined) || "streamableHttp"
+				const finalType =
+					data.type ||
+					(data.transportType === "http" || data.transportType === "streamableHttp" ? "streamableHttp" : undefined) ||
+					(data.transportType ? undefined : "streamableHttp")
 				return {
 					...data,
 					type: finalType as "streamableHttp",


### PR DESCRIPTION
## Summary

Fixes #11693.

URL MCP server configs with `transportType: "streamableHttp"` were being parsed by the earlier SSE schema branch before the Streamable HTTP branch could normalize them. That made Cline select the SSE transport path and send an SSE GET instead of the Streamable HTTP initialize flow.

## Changes

This change keeps the existing SSE default for URL configs without an explicit transport type, but prevents non-SSE legacy `transportType` values from being accepted by the SSE branch. It also treats both `transportType: "http"` and `transportType: "streamableHttp"` as Streamable HTTP, while keeping unknown legacy values rejected.

The regression coverage exercises the full `McpSettingsSchema` path for `transportType: "streamableHttp"`, the existing `transportType: "http"` compatibility path, the untyped URL-to-SSE default, and unknown legacy transport rejection.

## Verification

```bash
npm run check-types
```
