### PR TITLE
fix(mcp): require per-tool approval when Auto-approve toggle is OFF (#10499)

### DIFF
--- a/apps/vscode/src/core/task/tools/handlers/UseMcpToolHandler.ts
+++ b/apps/vscode/src/core/task/tools/handlers/UseMcpToolHandler.ts
@@ -18,6 +18,37 @@ export class UseMcpToolHandler implements IFullyManagedTool {
 		return `[${block.name} for '${block.params.server_name}']`
 	}
 
+	/**
+	 * Decide whether a specific MCP tool call should be auto-approved.
+	 *
+	 * The global "Use MCP servers" auto-approve action (autoApprovalSettings.actions.useMcp)
+	 * only *enables* per-tool auto-approval — it must not approve a tool on its own. A tool is
+	 * auto-approved only when its individual Auto-approve toggle is ON. This matches the webview,
+	 * which renders the per-tool checkbox only while the global MCP action is enabled.
+	 *
+	 * YOLO mode and "auto-approve all" are master overrides that bypass the per-tool gate, so a
+	 * truthy (non-tuple) result from shouldAutoApproveTool is honored directly.
+	 */
+	private isMcpToolAutoApproved(config: TaskConfig, serverName: string | undefined, toolName: string | undefined): boolean {
+		// Master overrides (YOLO / auto-approve all) make shouldAutoApproveTool return a plain
+		// boolean; the per-action useMcp path returns its value too, so distinguish them via the
+		// dedicated toggles rather than the conflated return value.
+		if (config.yoloModeToggled || config.services.stateManager.getGlobalSettingsKey("autoApproveAllToggled")) {
+			return true
+		}
+
+		const useMcpEnabled = config.callbacks.shouldAutoApproveTool(this.name) === true
+		if (!useMcpEnabled) {
+			return false
+		}
+
+		const isToolAutoApproved = config.services.mcpHub.connections
+			?.find((conn) => conn.server.name === serverName)
+			?.server.tools?.find((tool) => tool.name === toolName)?.autoApprove
+
+		return isToolAutoApproved === true
+	}
+
 	async handlePartialBlock(block: ToolUse, uiHelpers: StronglyTypedUIHelpers): Promise<void> {
 		const server_name = block.params.server_name
 		const tool_name = block.params.tool_name
@@ -32,7 +63,7 @@ export class UseMcpToolHandler implements IFullyManagedTool {
 
 		// Check if tool should be auto-approved using MCP-specific logic
 		const config = uiHelpers.getConfig()
-		const shouldAutoApprove = config.callbacks.shouldAutoApproveTool(block.name)
+		const shouldAutoApprove = this.isMcpToolAutoApproved(config, server_name, tool_name)
 
 		if (shouldAutoApprove) {
 			await uiHelpers.removeLastPartialMessageIfExistsWithType("ask", "use_mcp_server")
@@ -86,11 +117,7 @@ export class UseMcpToolHandler implements IFullyManagedTool {
 			arguments: mcp_arguments,
 		} satisfies ClineAskUseMcpServer)
 
-		const isToolAutoApproved = config.services.mcpHub.connections
-			?.find((conn: any) => conn.server.name === server_name)
-			?.server.tools?.find((tool: any) => tool.name === tool_name)?.autoApprove
-
-		if (config.callbacks.shouldAutoApproveTool(block.name) || isToolAutoApproved) {
+		if (this.isMcpToolAutoApproved(config, server_name, tool_name)) {
 			// Auto-approval flow
 			await config.callbacks.removeLastPartialMessageIfExistsWithType("ask", "use_mcp_server")
 			await config.callbacks.say("use_mcp_server", completeMessage, undefined, undefined, false)

--- a/apps/vscode/src/core/task/tools/handlers/__tests__/UseMcpToolHandler.autoApprove.test.ts
+++ b/apps/vscode/src/core/task/tools/handlers/__tests__/UseMcpToolHandler.autoApprove.test.ts
@@ -1,0 +1,203 @@
+import { strict as assert } from "node:assert"
+import { ClineDefaultTool } from "@shared/tools"
+import { afterEach, describe, it } from "mocha"
+import sinon from "sinon"
+import type { TaskConfig } from "../../types/TaskConfig"
+import { createUIHelpers } from "../../types/UIHelpers"
+import { UseMcpToolHandler } from "../UseMcpToolHandler"
+
+const SERVER_NAME = "ado"
+const TOOL_NAME = "repo_create_pull_request_thread"
+
+function createConfig(options?: {
+	useMcp?: boolean
+	toolAutoApprove?: boolean
+	yoloModeToggled?: boolean
+	autoApproveAllToggled?: boolean
+	askResponse?: "yesButtonClicked" | "noButtonClicked"
+}) {
+	const useMcp = options?.useMcp ?? false
+	const toolAutoApprove = options?.toolAutoApprove ?? false
+
+	const callTool = sinon.stub().resolves({ isError: false, content: [{ type: "text", text: "ok" }] })
+
+	const callbacks = {
+		say: sinon.stub().resolves(undefined),
+		ask: sinon.stub().resolves({ response: options?.askResponse ?? "yesButtonClicked" }),
+		removeLastPartialMessageIfExistsWithType: sinon.stub().resolves(),
+		// shouldAutoApproveTool for MCP_USE returns the global useMcp action value
+		shouldAutoApproveTool: sinon.stub().returns(useMcp),
+	}
+
+	const config = {
+		ulid: "ulid-1",
+		yoloModeToggled: options?.yoloModeToggled ?? false,
+		isSubagentExecution: false,
+		taskState: { consecutiveMistakeCount: 0, didRejectTool: false, userMessageContent: [] },
+		api: {
+			getModel: () => ({ id: "anthropic/claude", info: { supportsImages: false } }),
+		},
+		autoApprovalSettings: {
+			enableNotifications: false,
+			actions: { useMcp },
+		},
+		services: {
+			stateManager: {
+				getGlobalSettingsKey: (key: string) => {
+					if (key === "autoApproveAllToggled") {
+						return options?.autoApproveAllToggled ?? false
+					}
+					if (key === "mode") {
+						return "act"
+					}
+					if (key === "hooksEnabled") {
+						return false
+					}
+					return undefined
+				},
+				getApiConfiguration: () => ({
+					planModeApiProvider: "anthropic",
+					actModeApiProvider: "anthropic",
+				}),
+			},
+			mcpHub: {
+				connections: [
+					{
+						server: {
+							name: SERVER_NAME,
+							tools: [{ name: TOOL_NAME, autoApprove: toolAutoApprove }],
+						},
+					},
+				],
+				callTool,
+				getPendingNotifications: sinon.stub().returns([]),
+			},
+		},
+		callbacks,
+	} as unknown as TaskConfig
+
+	return { config, callbacks, callTool }
+}
+
+function partialBlock() {
+	return {
+		type: "tool_use" as const,
+		name: ClineDefaultTool.MCP_USE,
+		params: {
+			server_name: SERVER_NAME,
+			tool_name: TOOL_NAME,
+			arguments: "{}",
+		},
+		partial: true,
+	}
+}
+
+describe("UseMcpToolHandler auto-approval gating", () => {
+	afterEach(() => {
+		sinon.restore()
+	})
+
+	it("requires manual approval when global useMcp is ON but the tool toggle is OFF", async () => {
+		// Regression test for #10499: the per-tool Auto-approve OFF toggle must be honored.
+		const { config, callbacks } = createConfig({ useMcp: true, toolAutoApprove: false })
+		const handler = new UseMcpToolHandler()
+
+		await handler.handlePartialBlock(partialBlock(), createUIHelpers(config))
+
+		sinon.assert.calledOnce(callbacks.ask)
+		sinon.assert.calledWithExactly(callbacks.removeLastPartialMessageIfExistsWithType, "say", "use_mcp_server")
+	})
+
+	it("auto-approves when global useMcp is ON and the tool toggle is ON", async () => {
+		const { config, callbacks } = createConfig({ useMcp: true, toolAutoApprove: true })
+		const handler = new UseMcpToolHandler()
+
+		await handler.handlePartialBlock(partialBlock(), createUIHelpers(config))
+
+		sinon.assert.calledOnce(callbacks.say)
+		sinon.assert.notCalled(callbacks.ask)
+		sinon.assert.calledWithExactly(callbacks.removeLastPartialMessageIfExistsWithType, "ask", "use_mcp_server")
+	})
+
+	it("requires manual approval when global useMcp is OFF even if the tool toggle is ON", async () => {
+		const { config, callbacks } = createConfig({ useMcp: false, toolAutoApprove: true })
+		const handler = new UseMcpToolHandler()
+
+		await handler.handlePartialBlock(partialBlock(), createUIHelpers(config))
+
+		sinon.assert.calledOnce(callbacks.ask)
+		sinon.assert.notCalled(callbacks.say)
+	})
+
+	it("auto-approves when YOLO mode is ON regardless of the tool toggle", async () => {
+		const { config, callbacks } = createConfig({ useMcp: false, toolAutoApprove: false, yoloModeToggled: true })
+		const handler = new UseMcpToolHandler()
+
+		await handler.handlePartialBlock(partialBlock(), createUIHelpers(config))
+
+		sinon.assert.calledOnce(callbacks.say)
+		sinon.assert.notCalled(callbacks.ask)
+	})
+
+	it("auto-approves when auto-approve-all is ON regardless of the tool toggle", async () => {
+		const { config, callbacks } = createConfig({ useMcp: false, toolAutoApprove: false, autoApproveAllToggled: true })
+		const handler = new UseMcpToolHandler()
+
+		await handler.handlePartialBlock(partialBlock(), createUIHelpers(config))
+
+		sinon.assert.calledOnce(callbacks.say)
+		sinon.assert.notCalled(callbacks.ask)
+	})
+})
+
+function completeBlock() {
+	return {
+		type: "tool_use" as const,
+		name: ClineDefaultTool.MCP_USE,
+		params: {
+			server_name: SERVER_NAME,
+			tool_name: TOOL_NAME,
+			arguments: "{}",
+		},
+		partial: false,
+	}
+}
+
+// execute() is the actual enforcement gate (handlePartialBlock only drives UI state).
+// These cover the two highest-risk paths directly so a future refactor that splits the
+// two functions' logic cannot silently regress the gate.
+describe("UseMcpToolHandler execute() enforcement", () => {
+	afterEach(() => {
+		sinon.restore()
+	})
+
+	it("does NOT execute the tool when global useMcp is ON, the tool toggle is OFF, and the user rejects", async () => {
+		// Regression test for #10499 at the enforcement boundary.
+		const { config, callbacks, callTool } = createConfig({
+			useMcp: true,
+			toolAutoApprove: false,
+			askResponse: "noButtonClicked",
+		})
+		const handler = new UseMcpToolHandler()
+
+		const result = await handler.execute(config, completeBlock())
+
+		sinon.assert.calledOnce(callbacks.ask)
+		sinon.assert.notCalled(callTool)
+		assert.match(String(result), /denied/i)
+	})
+
+	it("executes the tool without asking when YOLO mode is ON", async () => {
+		const { config, callbacks, callTool } = createConfig({
+			useMcp: false,
+			toolAutoApprove: false,
+			yoloModeToggled: true,
+		})
+		const handler = new UseMcpToolHandler()
+
+		await handler.execute(config, completeBlock())
+
+		sinon.assert.notCalled(callbacks.ask)
+		sinon.assert.calledOnce(callTool)
+	})
+})


### PR DESCRIPTION
## Description

Fixes #10499.

MCP tool calls were auto-executing whenever the global **Use MCP servers** auto-approve action was ON, ignoring the per-tool **Auto-approve** toggle. A tool with its per-tool toggle OFF would still run with no approval prompt — including write-capable tools (e.g. posting PR comments, modifying work items), defeating the purpose of the control.

### Root cause

In `UseMcpToolHandler`, the auto-approval gate was:

```ts
if (config.callbacks.shouldAutoApproveTool(block.name) || isToolAutoApproved) { ... }
```

`shouldAutoApproveTool(MCP_USE)` returns the **global** `autoApprovalSettings.actions.useMcp` flag. Because the global flag alone returned `true`, it short-circuited the gate and the per-tool `autoApprove` flag became a no-op.

This contradicts the webview, which only renders the per-tool Auto-approve checkbox **while the global MCP action is enabled** (`McpToolRow.tsx`). The intended model is: the global action *enables* per-tool auto-approval; the per-tool toggle decides *which* tools auto-run.

### Fix

Introduce a shared `isMcpToolAutoApproved(config, serverName, toolName)` helper that returns `true` only when:

- YOLO mode is ON, **or**
- "auto-approve all" is ON, **or**
- the global `useMcp` action is ON **AND** the specific tool's per-tool `autoApprove` is ON.

It is used by **both** the partial-block (UI state) and execute (enforcement) paths so they cannot diverge — the previous divergence was part of the bug. YOLO and "auto-approve all" remain master overrides. The check fails closed on every missing-connection / missing-tool / undefined-toggle edge.

## How to test

1. Add an MCP server (e.g. an Azure DevOps `ado` server) with a write-capable tool.
2. Enable the global **Use MCP servers** auto-approve action.
3. Leave the per-tool **Auto-approve** toggle **OFF** for the write tool.
4. Give Cline a task that calls that tool.
5. **Before:** the tool executed immediately with no prompt. **After:** Cline pauses and shows the approve/reject dialog.
6. Toggle the per-tool Auto-approve **ON** → the tool auto-runs as expected.

## Automated tests

Added `UseMcpToolHandler.autoApprove.test.ts` covering the full matrix at both the UI-state and enforcement boundaries:

- global ON + tool OFF → manual approval (regression test for #10499)
- global ON + tool ON → auto-approved
- global OFF + tool ON → manual approval
- YOLO ON → auto-approved
- auto-approve-all ON → auto-approved
- `execute()`: global ON + tool OFF + user rejects → tool is **not** called, returns denied
- `execute()`: YOLO ON → tool called without asking

`tsc --noEmit`, biome lint/format, and the new tests all pass.

## Breaking changes

None. Behavior only changes for the previously-broken case (per-tool toggle OFF now correctly requires approval), which restores the documented/intended UX.