### PR TITLE
fix(doc): `OpenAI Codex` to `ChatGPT Subscription`

### DIFF
--- a/docs/provider-config/openai.mdx
+++ b/docs/provider-config/openai.mdx
@@ -39,7 +39,7 @@ Cline supports accessing models directly through the official OpenAI API.
 ## OpenAI Codex (OAuth)
 
 1. Open Cline settings.
-2. Select **OpenAI Codex** from **API Provider**.
+2. Select **ChatGPT subscription** from **API Provider**.
 3. Click **Sign in with OpenAI** and complete browser OAuth.
 4. Return to Cline and choose a model.
 

--- a/docs/provider-config/openai.mdx
+++ b/docs/provider-config/openai.mdx
@@ -39,7 +39,7 @@ Cline supports accessing models directly through the official OpenAI API.
 ## OpenAI Codex (OAuth)
 
 1. Open Cline settings.
-2. Select **ChatGPT subscription** from **API Provider**.
+2. Select **ChatGPT Subscription** from **API Provider**.
 3. Click **Sign in with OpenAI** and complete browser OAuth.
 4. Return to Cline and choose a model.
 


### PR DESCRIPTION
ref. https://docs.cline.bot/provider-config/openai?#openai-codex-oauth
via https://github.com/cline/cline/commit/6cff60b53b8df8d893ec346583a192f775caf401#diff-730697ddc650c47d2df4e081aa1426a0e0193efffb63a9ca2670125b0bc66483
https://github.com/cline/cline/blob/ee59f81706981e0a64c8b32f8f0415c9d39561fa/apps/vscode/src/shared/providers/providers.json#L11-L14