### PR TITLE
fix(vscode): cap tool result text in task history

### DIFF
--- a/apps/vscode/src/core/task/tools/utils/ToolResultUtils.ts
+++ b/apps/vscode/src/core/task/tools/utils/ToolResultUtils.ts
@@ -7,6 +7,23 @@ import { Logger } from "@/shared/services/Logger"
 import type { ToolExecutorCoordinator } from "../ToolExecutorCoordinator"
 import { TaskConfig } from "../types/TaskConfig"
 
+export const MAX_TOOL_RESULT_TEXT_CHARS = 8_000
+const TOOL_RESULT_TRUNCATION_REASON = "tool result truncated"
+
+function truncateMiddle(text: string, maxChars: number, makeMarker: (removed: number) => string): string {
+	if (text.length <= maxChars) {
+		return text
+	}
+
+	const tentativeMarker = makeMarker(text.length - maxChars)
+	const tentativeKeep = Math.max(0, Math.floor((maxChars - tentativeMarker.length) / 2))
+	const removed = Math.max(0, text.length - tentativeKeep * 2)
+	const marker = makeMarker(removed)
+	const keep = Math.max(0, Math.floor((maxChars - marker.length) / 2))
+
+	return `${text.slice(0, keep)}${marker}${keep > 0 ? text.slice(-keep) : ""}`
+}
+
 /**
  * Utility functions for handling tool results and feedback
  */
@@ -69,7 +86,9 @@ export class ToolResultUtils {
 		if (id === "cline" || !id) {
 			return {
 				type: "text",
-				text: typeof content === "string" ? content : JSON.stringify(content, null, 2),
+				text: ToolResultUtils.truncateToolResultText(
+					typeof content === "string" ? content : JSON.stringify(content, null, 2),
+				),
 			}
 		}
 
@@ -80,8 +99,14 @@ export class ToolResultUtils {
 			type: "tool_result",
 			tool_use_id: id,
 			call_id: call_id,
-			content: typeof content === "string" ? content : content,
+			content: typeof content === "string" ? ToolResultUtils.truncateToolResultText(content) : content,
 		}
+	}
+
+	private static truncateToolResultText(text: string): string {
+		return truncateMiddle(text, MAX_TOOL_RESULT_TEXT_CHARS, (removed) => {
+			return `\n... (${TOOL_RESULT_TRUNCATION_REASON}, ${removed} chars omitted) ...\n`
+		})
 	}
 
 	/**

--- a/apps/vscode/src/core/task/tools/utils/ToolResultUtils.ts
+++ b/apps/vscode/src/core/task/tools/utils/ToolResultUtils.ts
@@ -4,25 +4,12 @@ import { ToolResponse } from "@core/task"
 import { processFilesIntoText } from "@/integrations/misc/extract-text"
 import { ClineAsk } from "@/shared/ExtensionMessage"
 import { Logger } from "@/shared/services/Logger"
+import { truncateMiddle } from "@utils/string"
 import type { ToolExecutorCoordinator } from "../ToolExecutorCoordinator"
 import { TaskConfig } from "../types/TaskConfig"
 
 export const MAX_TOOL_RESULT_TEXT_CHARS = 8_000
 const TOOL_RESULT_TRUNCATION_REASON = "tool result truncated"
-
-function truncateMiddle(text: string, maxChars: number, makeMarker: (removed: number) => string): string {
-	if (text.length <= maxChars) {
-		return text
-	}
-
-	const tentativeMarker = makeMarker(text.length - maxChars)
-	const tentativeKeep = Math.max(0, Math.floor((maxChars - tentativeMarker.length) / 2))
-	const removed = Math.max(0, text.length - tentativeKeep * 2)
-	const marker = makeMarker(removed)
-	const keep = Math.max(0, Math.floor((maxChars - marker.length) / 2))
-
-	return `${text.slice(0, keep)}${marker}${keep > 0 ? text.slice(-keep) : ""}`
-}
 
 /**
  * Utility functions for handling tool results and feedback

--- a/apps/vscode/src/core/task/tools/utils/ToolResultUtils.ts
+++ b/apps/vscode/src/core/task/tools/utils/ToolResultUtils.ts
@@ -4,12 +4,13 @@ import { ToolResponse } from "@core/task"
 import { processFilesIntoText } from "@/integrations/misc/extract-text"
 import { ClineAsk } from "@/shared/ExtensionMessage"
 import { Logger } from "@/shared/services/Logger"
-import { truncateMiddle } from "@utils/string"
+import { getMiddleTruncationParts, truncateMiddle } from "@utils/string"
 import type { ToolExecutorCoordinator } from "../ToolExecutorCoordinator"
 import { TaskConfig } from "../types/TaskConfig"
 
 export const MAX_TOOL_RESULT_TEXT_CHARS = 8_000
 const TOOL_RESULT_TRUNCATION_REASON = "tool result truncated"
+type ToolResponseBlocks = Exclude<ToolResponse, string>
 
 /**
  * Utility functions for handling tool results and feedback
@@ -60,7 +61,7 @@ export class ToolResultUtils {
 			// If using backward-compatible "cline" ID and content is an array, spread it directly
 			// instead of wrapping it (which would cause JSON.stringify in createToolResultBlock)
 			if ((toolUseId === "cline" || !toolUseId) && Array.isArray(content)) {
-				userMessageContent.push(...content)
+				userMessageContent.push(...ToolResultUtils.truncateToolResponseBlocks(content))
 			} else {
 				userMessageContent.push(ToolResultUtils.createToolResultBlock(content, toolUseId, block.call_id))
 			}
@@ -71,11 +72,13 @@ export class ToolResultUtils {
 		// If id is "cline", we treat it as a plain text result for backward compatibility
 		// as we cannot find any existing tool call that matches this id.
 		if (id === "cline" || !id) {
+			const text =
+				typeof content === "string"
+					? content
+					: JSON.stringify(ToolResultUtils.truncateToolResponseContent(content), null, 2)
 			return {
 				type: "text",
-				text: ToolResultUtils.truncateToolResultText(
-					typeof content === "string" ? content : JSON.stringify(content, null, 2),
-				),
+				text: ToolResultUtils.truncateToolResultText(text),
 			}
 		}
 
@@ -86,14 +89,84 @@ export class ToolResultUtils {
 			type: "tool_result",
 			tool_use_id: id,
 			call_id: call_id,
-			content: typeof content === "string" ? ToolResultUtils.truncateToolResultText(content) : content,
+			content: ToolResultUtils.truncateToolResponseContent(content),
 		}
 	}
 
+	private static truncateToolResponseContent(content: ToolResponse): ToolResponse {
+		return typeof content === "string"
+			? ToolResultUtils.truncateToolResultText(content)
+			: ToolResultUtils.truncateToolResponseBlocks(content)
+	}
+
+	private static truncateToolResponseBlocks(content: ToolResponseBlocks): ToolResponseBlocks {
+		const textLength = content.reduce((total, block) => {
+			return block.type === "text" ? total + block.text.length : total
+		}, 0)
+		const truncation = getMiddleTruncationParts(
+			textLength,
+			MAX_TOOL_RESULT_TEXT_CHARS,
+			ToolResultUtils.createToolResultTruncationMarker,
+		)
+		if (!truncation) {
+			return content
+		}
+
+		const prefixText = ToolResultUtils.takeTextFromStart(content, truncation.prefixChars)
+		const suffixText = ToolResultUtils.takeTextFromEnd(content, truncation.suffixChars)
+		const nonTextBlocks = content.filter((block) => block.type !== "text")
+		const truncatedBlocks: ToolResponseBlocks = []
+		if (prefixText) {
+			truncatedBlocks.push({ type: "text", text: prefixText })
+		}
+		if (truncation.marker) {
+			truncatedBlocks.push({ type: "text", text: truncation.marker })
+		}
+		truncatedBlocks.push(...nonTextBlocks)
+		if (suffixText) {
+			truncatedBlocks.push({ type: "text", text: suffixText })
+		}
+		return truncatedBlocks
+	}
+
+	private static takeTextFromStart(content: ToolResponseBlocks, chars: number): string {
+		let remaining = chars
+		let text = ""
+		for (const block of content) {
+			if (remaining <= 0) {
+				break
+			}
+			if (block.type !== "text") {
+				continue
+			}
+			const chunk = block.text.slice(0, remaining)
+			text += chunk
+			remaining -= chunk.length
+		}
+		return text
+	}
+
+	private static takeTextFromEnd(content: ToolResponseBlocks, chars: number): string {
+		let remaining = chars
+		let text = ""
+		for (let i = content.length - 1; i >= 0 && remaining > 0; i--) {
+			const block = content[i]
+			if (block.type !== "text") {
+				continue
+			}
+			const chunk = block.text.slice(Math.max(0, block.text.length - remaining))
+			text = `${chunk}${text}`
+			remaining -= chunk.length
+		}
+		return text
+	}
+
 	private static truncateToolResultText(text: string): string {
-		return truncateMiddle(text, MAX_TOOL_RESULT_TEXT_CHARS, (removed) => {
-			return `\n... (${TOOL_RESULT_TRUNCATION_REASON}, ${removed} chars omitted) ...\n`
-		})
+		return truncateMiddle(text, MAX_TOOL_RESULT_TEXT_CHARS, ToolResultUtils.createToolResultTruncationMarker)
+	}
+
+	private static createToolResultTruncationMarker(removed: number): string {
+		return `\n... (${TOOL_RESULT_TRUNCATION_REASON}, ${removed} chars omitted) ...\n`
 	}
 
 	/**

--- a/apps/vscode/src/core/task/tools/utils/__tests__/ToolResultUtils.test.ts
+++ b/apps/vscode/src/core/task/tools/utils/__tests__/ToolResultUtils.test.ts
@@ -1,0 +1,67 @@
+import { expect } from "chai"
+import type { ToolUse } from "@core/assistant-message"
+import { MAX_TOOL_RESULT_TEXT_CHARS, ToolResultUtils } from "../ToolResultUtils"
+
+describe("ToolResultUtils", () => {
+	const block: ToolUse = {
+		type: "tool_use",
+		name: "list_code_definition_names",
+		params: { path: "src" },
+		partial: false,
+		call_id: "tool-call-1",
+	}
+
+	it("caps fallback text tool results before adding them to task history", () => {
+		const userMessageContent: any[] = []
+		const oversizedResult = `${"a".repeat(MAX_TOOL_RESULT_TEXT_CHARS)}${"b".repeat(10_000)}`
+
+		ToolResultUtils.pushToolResult(
+			oversizedResult,
+			block,
+			userMessageContent,
+			() => "[list_code_definition_names for 'src']",
+		)
+
+		expect(userMessageContent).to.have.length(1)
+		expect(userMessageContent[0].type).to.equal("text")
+		expect(userMessageContent[0].text.length).to.equal(MAX_TOOL_RESULT_TEXT_CHARS)
+		expect(userMessageContent[0].text).to.contain("tool result truncated")
+		expect(userMessageContent[0].text).to.contain("[list_code_definition_names for 'src'] Result:")
+		expect(userMessageContent[0].text.endsWith("b".repeat(20))).to.equal(true)
+	})
+
+	it("caps matched native tool_result string content", () => {
+		const userMessageContent: any[] = []
+		const oversizedResult = `${"x".repeat(MAX_TOOL_RESULT_TEXT_CHARS)}${"y".repeat(10_000)}`
+		const toolUseIdMap = new Map([["tool-call-1", "provider-tool-use-1"]])
+
+		ToolResultUtils.pushToolResult(
+			oversizedResult,
+			block,
+			userMessageContent,
+			() => "[replace_in_file for 'src/main.cpp']",
+			undefined,
+			toolUseIdMap,
+		)
+
+		expect(userMessageContent).to.have.length(1)
+		expect(userMessageContent[0].type).to.equal("tool_result")
+		expect(userMessageContent[0].tool_use_id).to.equal("provider-tool-use-1")
+		expect(userMessageContent[0].content.length).to.equal(MAX_TOOL_RESULT_TEXT_CHARS)
+		expect(userMessageContent[0].content).to.contain("tool result truncated")
+		expect(userMessageContent[0].content.endsWith("y".repeat(20))).to.equal(true)
+	})
+
+	it("does not alter small string results", () => {
+		const userMessageContent: any[] = []
+
+		ToolResultUtils.pushToolResult("small result", block, userMessageContent, () => "[test tool]")
+
+		expect(userMessageContent).to.deep.equal([
+			{
+				type: "text",
+				text: "[test tool] Result:\nsmall result",
+			},
+		])
+	})
+})

--- a/apps/vscode/src/core/task/tools/utils/__tests__/ToolResultUtils.test.ts
+++ b/apps/vscode/src/core/task/tools/utils/__tests__/ToolResultUtils.test.ts
@@ -52,6 +52,43 @@ describe("ToolResultUtils", () => {
 		expect(userMessageContent[0].content.endsWith("y".repeat(20))).to.equal(true)
 	})
 
+	it("caps aggregate text in matched native tool_result array content", () => {
+		const userMessageContent: any[] = []
+		const toolUseIdMap = new Map([["tool-call-1", "provider-tool-use-1"]])
+		const imageBlock = {
+			type: "image",
+			source: {
+				type: "base64",
+				media_type: "image/png",
+				data: "abc123",
+			},
+		} as const
+
+		ToolResultUtils.pushToolResult(
+			[
+				{ type: "text", text: "a".repeat(MAX_TOOL_RESULT_TEXT_CHARS) },
+				imageBlock,
+				{ type: "text", text: "b".repeat(10_000) },
+			],
+			block,
+			userMessageContent,
+			() => "[browser_action result]",
+			undefined,
+			toolUseIdMap,
+		)
+
+		const resultContent = userMessageContent[0].content
+		const textBlocks = resultContent.filter((item: any) => item.type === "text")
+		const totalTextLength = textBlocks.reduce((total: number, item: any) => total + item.text.length, 0)
+
+		expect(userMessageContent).to.have.length(1)
+		expect(userMessageContent[0].type).to.equal("tool_result")
+		expect(totalTextLength).to.equal(MAX_TOOL_RESULT_TEXT_CHARS)
+		expect(textBlocks.map((item: any) => item.text).join("")).to.contain("tool result truncated")
+		expect(resultContent).to.deep.include(imageBlock)
+		expect(textBlocks[textBlocks.length - 1].text.endsWith("b".repeat(20))).to.equal(true)
+	})
+
 	it("does not alter small string results", () => {
 		const userMessageContent: any[] = []
 

--- a/apps/vscode/src/utils/string.test.ts
+++ b/apps/vscode/src/utils/string.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "mocha"
 import "should"
-import { fixModelHtmlEscaping, removeInvalidChars } from "./string"
+import { fixModelHtmlEscaping, removeInvalidChars, truncateMiddle } from "./string"
 
 describe("fixModelHtmlEscaping", () => {
 	it("should convert &gt; to >", () => {
@@ -53,5 +53,24 @@ describe("removeInvalidChars", () => {
 
 	it("should return unchanged string when no replacement characters are present", () => {
 		removeInvalidChars("normal string").should.equal("normal string")
+	})
+})
+
+describe("truncateMiddle", () => {
+	it("should return unchanged string when it is under the limit", () => {
+		truncateMiddle("short", 10, (removed) => `[omitted ${removed}]`).should.equal("short")
+	})
+
+	it("should preserve the start and end with a generated marker", () => {
+		const result = truncateMiddle(
+			`${"a".repeat(50)}${"b".repeat(50)}`,
+			40,
+			(removed) => `[omitted ${removed}]`,
+		)
+
+		result.length.should.equal(40)
+		result.should.startWith("a".repeat(14))
+		result.should.containEql("[omitted 72]")
+		result.should.endWith("b".repeat(14))
 	})
 })

--- a/apps/vscode/src/utils/string.test.ts
+++ b/apps/vscode/src/utils/string.test.ts
@@ -73,4 +73,20 @@ describe("truncateMiddle", () => {
 		result.should.containEql("[omitted 72]")
 		result.should.endWith("b".repeat(14))
 	})
+
+	it("should report the exact omitted count when marker length changes", () => {
+		const originalLength = 18_000
+		const result = truncateMiddle("a".repeat(9_000) + "b".repeat(9_000), 8_001, (removed) => {
+			return `[omitted ${removed}]`
+		})
+		const match = result.match(/\[omitted (\d+)\]/)
+
+		result.length.should.be.belowOrEqual(8_001)
+		if (!match) {
+			throw new Error("expected omission marker")
+		}
+		const marker = match[0]
+		const omitted = Number(match[1])
+		omitted.should.equal(originalLength - (result.length - marker.length))
+	})
 })

--- a/apps/vscode/src/utils/string.ts
+++ b/apps/vscode/src/utils/string.ts
@@ -20,3 +20,21 @@ export function fixModelHtmlEscaping(text: string): string {
 export function removeInvalidChars(text: string): string {
 	return text.replace(/\uFFFD/g, "")
 }
+
+/**
+ * Truncates the middle of a string, preserving an equal prefix and suffix.
+ * The marker is generated after calculating how many characters are omitted.
+ */
+export function truncateMiddle(text: string, maxChars: number, makeMarker: (removed: number) => string): string {
+	if (text.length <= maxChars) {
+		return text
+	}
+
+	const tentativeMarker = makeMarker(text.length - maxChars)
+	const tentativeKeep = Math.max(0, Math.floor((maxChars - tentativeMarker.length) / 2))
+	const removed = Math.max(0, text.length - tentativeKeep * 2)
+	const marker = makeMarker(removed)
+	const keep = Math.max(0, Math.floor((maxChars - marker.length) / 2))
+
+	return `${text.slice(0, keep)}${marker}${keep > 0 ? text.slice(-keep) : ""}`
+}

--- a/apps/vscode/src/utils/string.ts
+++ b/apps/vscode/src/utils/string.ts
@@ -26,15 +26,47 @@ export function removeInvalidChars(text: string): string {
  * The marker is generated after calculating how many characters are omitted.
  */
 export function truncateMiddle(text: string, maxChars: number, makeMarker: (removed: number) => string): string {
-	if (text.length <= maxChars) {
+	const truncation = getMiddleTruncationParts(text.length, maxChars, makeMarker)
+	if (!truncation) {
 		return text
 	}
 
-	const tentativeMarker = makeMarker(text.length - maxChars)
-	const tentativeKeep = Math.max(0, Math.floor((maxChars - tentativeMarker.length) / 2))
-	const removed = Math.max(0, text.length - tentativeKeep * 2)
-	const marker = makeMarker(removed)
-	const keep = Math.max(0, Math.floor((maxChars - marker.length) / 2))
+	const { prefixChars, suffixChars, marker } = truncation
+	return `${text.slice(0, prefixChars)}${marker}${suffixChars > 0 ? text.slice(-suffixChars) : ""}`
+}
 
-	return `${text.slice(0, keep)}${marker}${keep > 0 ? text.slice(-keep) : ""}`
+export interface MiddleTruncationParts {
+	prefixChars: number
+	suffixChars: number
+	marker: string
+}
+
+export function getMiddleTruncationParts(
+	textLength: number,
+	maxChars: number,
+	makeMarker: (removed: number) => string,
+): MiddleTruncationParts | undefined {
+	if (textLength <= maxChars) {
+		return undefined
+	}
+
+	if (maxChars <= 0) {
+		return { prefixChars: 0, suffixChars: 0, marker: "" }
+	}
+
+	let keep = Math.max(0, Math.floor(maxChars / 2))
+
+	while (true) {
+		const removed = Math.max(0, textLength - keep * 2)
+		const marker = makeMarker(removed)
+		if (marker.length > maxChars) {
+			return { prefixChars: 0, suffixChars: 0, marker: marker.slice(0, maxChars) }
+		}
+
+		const nextKeep = Math.max(0, Math.floor((maxChars - marker.length) / 2))
+		if (nextKeep === keep) {
+			return { prefixChars: keep, suffixChars: keep, marker }
+		}
+		keep = nextKeep
+	}
 }


### PR DESCRIPTION
## Summary
- add a reusable VS Code 	runcateMiddle string helper in @utils/string
- cap oversized VS Code string tool results before they are appended to task history
- preserve the start and end of the result with a middle truncation marker
- cover the string helper, fallback text results, and matched native 	ool_result string content with regression tests

## Why
The SDK provider message builder already applies an 8,000 character default cap to provider-bound tool results, but the VS Code task path can still persist very large string results before that provider safety pass. Local reproduction showed list_code_definition_names and large edit results bloating task history enough to trigger context overflow during resume/continuation.

## Existing helper check
The nearby VS Code helpers were not a fit: 	runcateContent in shared/content-limits is file/MCP-specific and prefix-only, while the SDK compaction/message-builder truncators are package-local and tied to provider/compaction policy. This PR puts the generic middle truncation primitive in the existing VS Code string utility module and keeps the tool-result cap policy in ToolResultUtils.

## Test Procedure
- git diff --check

Not run locally: this shell does not have 
ode, 
pm, un, pnpm, or yarn on PATH.