### PR TITLE
fix(vscode): honor OpenAI-compatible model settings

### DIFF
--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -375,6 +375,48 @@ describe("buildSessionConfig", () => {
 		expect(config.providerConfig).not.toHaveProperty("apiKey")
 	})
 
+	it("passes OpenAI Compatible custom model metadata through as SDK knownModels", async () => {
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "openai",
+			actModeOpenAiModelId: "custom-reasoner",
+			openAiApiKey: "openai-compatible-key",
+			openAiBaseUrl: "https://openai-compatible.example/v1",
+			actModeOpenAiModelInfo: {
+				name: "Custom Reasoner",
+				contextWindow: 16_000,
+				maxTokens: 4_096,
+				family: "deepseek",
+				metadata: { reasoningDefaultOn: true },
+				supportsImages: false,
+				supportsPromptCache: false,
+				supportsReasoning: true,
+				inputPrice: 0,
+				outputPrice: 0,
+			},
+		} as any)
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+
+		expect(config.providerId).toBe("openai-compatible")
+		expect(config.modelId).toBe("custom-reasoner")
+		expect(config.knownModels?.["custom-reasoner"]).toMatchObject({
+			id: "custom-reasoner",
+			name: "Custom Reasoner",
+			contextWindow: 16_000,
+			maxInputTokens: 16_000,
+			maxTokens: 4_096,
+			capabilities: expect.arrayContaining(["streaming", "tools", "reasoning"]),
+			family: "deepseek",
+			metadata: { reasoningDefaultOn: true },
+		})
+		expect((config.providerConfig as any).knownModels?.["custom-reasoner"]).toMatchObject({
+			contextWindow: 16_000,
+			maxInputTokens: 16_000,
+			maxTokens: 4_096,
+		})
+		expect((config.providerConfig as any).maxOutputTokens).toBe(4_096)
+	})
+
 	it("uses ClinePass model storage and omits empty nested apiKey so SDK OAuth can fill it", async () => {
 		mocks.stateManager.getApiConfiguration.mockReturnValue({
 			actModeApiProvider: "cline-pass",

--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -385,8 +385,6 @@ describe("buildSessionConfig", () => {
 				name: "Custom Reasoner",
 				contextWindow: 16_000,
 				maxTokens: 4_096,
-				family: "deepseek",
-				metadata: { reasoningDefaultOn: true },
 				supportsImages: false,
 				supportsPromptCache: false,
 				supportsReasoning: true,
@@ -405,9 +403,7 @@ describe("buildSessionConfig", () => {
 			contextWindow: 16_000,
 			maxInputTokens: 16_000,
 			maxTokens: 4_096,
-			capabilities: expect.arrayContaining(["streaming", "tools", "reasoning"]),
-			family: "deepseek",
-			metadata: { reasoningDefaultOn: true },
+			capabilities: ["streaming", "tools", "images"],
 		})
 		expect((config.providerConfig as any).knownModels?.["custom-reasoner"]).toMatchObject({
 			contextWindow: 16_000,

--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -403,7 +403,7 @@ describe("buildSessionConfig", () => {
 			contextWindow: 16_000,
 			maxInputTokens: 16_000,
 			maxTokens: 4_096,
-			capabilities: ["streaming", "tools", "images"],
+			capabilities: ["streaming", "tools"],
 		})
 		expect((config.providerConfig as any).knownModels?.["custom-reasoner"]).toMatchObject({
 			contextWindow: 16_000,

--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -187,6 +187,12 @@ function getOpenAiCompatibleModelInfo(config: ApiConfiguration, mode: Mode): Leg
 	return mode === "plan" ? config.planModeOpenAiModelInfo : config.actModeOpenAiModelInfo
 }
 
+const OPENAI_COMPATIBLE_DEFAULT_CAPABILITIES: NonNullable<SdkModelInfo["capabilities"]> = [
+	"streaming",
+	"tools",
+	"images",
+]
+
 // VS Code stores OpenAI-compatible custom model metadata in legacy
 // ApiConfiguration fields. The SDK runtime enforces context/output limits from
 // knownModels, so bridge the selected model into the SDK shape during session
@@ -200,37 +206,6 @@ function buildOpenAiCompatibleKnownModels(
 		return undefined
 	}
 
-	const modelInfoExtras = modelInfo as LegacyModelInfo & {
-		family?: string
-		metadata?: SdkModelInfo["metadata"]
-		supportsReasoningEffort?: boolean
-		supportsStreaming?: boolean
-		supportsTools?: boolean
-	}
-	const capabilities: NonNullable<SdkModelInfo["capabilities"]> = []
-	const supportsStreaming = modelInfoExtras.supportsStreaming
-	const supportsTools = modelInfoExtras.supportsTools
-	const supportsReasoningEffort = modelInfoExtras.supportsReasoningEffort
-
-	if (supportsStreaming !== false) {
-		capabilities.push("streaming")
-	}
-	if (supportsTools !== false) {
-		capabilities.push("tools")
-	}
-	if (modelInfo.supportsImages) {
-		capabilities.push("images")
-	}
-	if (modelInfo.supportsPromptCache) {
-		capabilities.push("prompt-cache")
-	}
-	if (modelInfo.supportsReasoning || supportsReasoningEffort) {
-		capabilities.push("reasoning")
-	}
-	if (supportsReasoningEffort) {
-		capabilities.push("reasoning-effort")
-	}
-
 	const contextWindow = positiveNumber(modelInfo.contextWindow)
 	const maxTokens = positiveNumber(modelInfo.maxTokens)
 
@@ -242,16 +217,8 @@ function buildOpenAiCompatibleKnownModels(
 			contextWindow,
 			maxInputTokens: contextWindow,
 			maxTokens,
-			capabilities: capabilities.length > 0 ? capabilities : undefined,
-			family: modelInfoExtras.family,
-			metadata: modelInfoExtras.metadata,
+			capabilities: OPENAI_COMPATIBLE_DEFAULT_CAPABILITIES,
 			temperature: modelInfo.temperature,
-			pricing: {
-				input: modelInfo.inputPrice,
-				output: modelInfo.outputPrice,
-				cacheWrite: modelInfo.cacheWritesPrice,
-				cacheRead: modelInfo.cacheReadsPrice,
-			},
 		},
 	}
 }

--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -190,8 +190,15 @@ function getOpenAiCompatibleModelInfo(config: ApiConfiguration, mode: Mode): Leg
 const OPENAI_COMPATIBLE_DEFAULT_CAPABILITIES: NonNullable<SdkModelInfo["capabilities"]> = [
 	"streaming",
 	"tools",
-	"images",
 ]
+
+function buildOpenAiCompatibleCapabilities(modelInfo: LegacyModelInfo): NonNullable<SdkModelInfo["capabilities"]> {
+	const capabilities: NonNullable<SdkModelInfo["capabilities"]> = [...OPENAI_COMPATIBLE_DEFAULT_CAPABILITIES]
+	if (modelInfo.supportsImages !== false) {
+		capabilities.push("images")
+	}
+	return capabilities
+}
 
 // VS Code stores OpenAI-compatible custom model metadata in legacy
 // ApiConfiguration fields. The SDK runtime enforces context/output limits from
@@ -217,7 +224,7 @@ function buildOpenAiCompatibleKnownModels(
 			contextWindow,
 			maxInputTokens: contextWindow,
 			maxTokens,
-			capabilities: OPENAI_COMPATIBLE_DEFAULT_CAPABILITIES,
+			capabilities: buildOpenAiCompatibleCapabilities(modelInfo),
 			temperature: modelInfo.temperature,
 		},
 	}

--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -16,9 +16,9 @@ import {
 	resolveProviderApiKeyFromSettings,
 	type StartSessionResult,
 } from "@cline/core"
-import { getGeneratedModelsForProvider, MODEL_COLLECTIONS_BY_PROVIDER_ID } from "@cline/llms"
+import { getGeneratedModelsForProvider, type ModelInfo as SdkModelInfo, MODEL_COLLECTIONS_BY_PROVIDER_ID } from "@cline/llms"
 import { buildClineSystemPrompt } from "@cline/shared"
-import type { ApiConfiguration } from "@shared/api"
+import type { ApiConfiguration, ModelInfo as LegacyModelInfo } from "@shared/api"
 import type { HistoryItem } from "@shared/HistoryItem"
 import { DEFAULT_LANGUAGE_SETTINGS, getLanguageKey, type LanguageDisplay } from "@shared/Languages"
 import { Logger } from "@shared/services/Logger"
@@ -176,6 +176,83 @@ function resolveProviderReasoningConfig(providerId: string): SessionReasoningCon
 	} catch (error) {
 		Logger.warn("[SessionFactory] Provider reasoning resolution failed:", error)
 		return {}
+	}
+}
+
+function positiveNumber(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined
+}
+
+function getOpenAiCompatibleModelInfo(config: ApiConfiguration, mode: Mode): LegacyModelInfo | undefined {
+	return mode === "plan" ? config.planModeOpenAiModelInfo : config.actModeOpenAiModelInfo
+}
+
+// VS Code stores OpenAI-compatible custom model metadata in legacy
+// ApiConfiguration fields. The SDK runtime enforces context/output limits from
+// knownModels, so bridge the selected model into the SDK shape during session
+// creation.
+function buildOpenAiCompatibleKnownModels(
+	modelId: string | undefined,
+	modelInfo: LegacyModelInfo | undefined,
+): Record<string, SdkModelInfo> | undefined {
+	const trimmedModelId = modelId?.trim()
+	if (!trimmedModelId || !modelInfo) {
+		return undefined
+	}
+
+	const modelInfoExtras = modelInfo as LegacyModelInfo & {
+		family?: string
+		metadata?: SdkModelInfo["metadata"]
+		supportsReasoningEffort?: boolean
+		supportsStreaming?: boolean
+		supportsTools?: boolean
+	}
+	const capabilities: NonNullable<SdkModelInfo["capabilities"]> = []
+	const supportsStreaming = modelInfoExtras.supportsStreaming
+	const supportsTools = modelInfoExtras.supportsTools
+	const supportsReasoningEffort = modelInfoExtras.supportsReasoningEffort
+
+	if (supportsStreaming !== false) {
+		capabilities.push("streaming")
+	}
+	if (supportsTools !== false) {
+		capabilities.push("tools")
+	}
+	if (modelInfo.supportsImages) {
+		capabilities.push("images")
+	}
+	if (modelInfo.supportsPromptCache) {
+		capabilities.push("prompt-cache")
+	}
+	if (modelInfo.supportsReasoning || supportsReasoningEffort) {
+		capabilities.push("reasoning")
+	}
+	if (supportsReasoningEffort) {
+		capabilities.push("reasoning-effort")
+	}
+
+	const contextWindow = positiveNumber(modelInfo.contextWindow)
+	const maxTokens = positiveNumber(modelInfo.maxTokens)
+
+	return {
+		[trimmedModelId]: {
+			id: trimmedModelId,
+			name: modelInfo.name ?? trimmedModelId,
+			description: modelInfo.description,
+			contextWindow,
+			maxInputTokens: contextWindow,
+			maxTokens,
+			capabilities: capabilities.length > 0 ? capabilities : undefined,
+			family: modelInfoExtras.family,
+			metadata: modelInfoExtras.metadata,
+			temperature: modelInfo.temperature,
+			pricing: {
+				input: modelInfo.inputPrice,
+				output: modelInfo.outputPrice,
+				cacheWrite: modelInfo.cacheWritesPrice,
+				cacheRead: modelInfo.cacheReadsPrice,
+			},
+		},
 	}
 }
 
@@ -473,6 +550,7 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 	let modelId: string | undefined
 	let apiKey: string | undefined
 	let baseUrl: string | undefined
+	let knownModels: CoreSessionConfig["knownModels"] | undefined
 	let apiConfig: ApiConfiguration | undefined
 	// Cloud-provider structured options. The core runtime reads these from
 	// CoreSessionConfig.providerConfig; without them the SDK gateway never receives
@@ -494,6 +572,9 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 
 			// Resolve model ID
 			modelId = resolveModelId(providerId, mode, apiConfig)
+			if (providerId === "openai") {
+				knownModels = buildOpenAiCompatibleKnownModels(modelId, getOpenAiCompatibleModelInfo(apiConfig, mode))
+			}
 
 			// Resolve base URL
 			baseUrl = resolveBaseUrl(providerId, apiConfig)
@@ -614,6 +695,10 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 		modelId,
 		...(apiKey ? { apiKey } : {}),
 		baseUrl,
+		...(knownModels ? { knownModels } : {}),
+		...(modelId && positiveNumber(knownModels?.[modelId]?.maxTokens)
+			? { maxOutputTokens: positiveNumber(knownModels?.[modelId]?.maxTokens) }
+			: {}),
 		fetch,
 	}
 
@@ -622,6 +707,7 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 		modelId,
 		apiKey,
 		baseUrl,
+		knownModels,
 		providerConfig,
 		cwd,
 		workspaceRoot,

--- a/apps/vscode/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
@@ -16,7 +16,7 @@ import { DebouncedTextField } from "../common/DebouncedTextField"
 import { ModelInfoView } from "../common/ModelInfoView"
 import ReasoningEffortSelector from "../ReasoningEffortSelector"
 import { parsePrice } from "../utils/pricingUtils"
-import { getModeSpecificFields, supportsReasoningEffortForModelId } from "../utils/providerUtils"
+import { getModeSpecificFields } from "../utils/providerUtils"
 import { useApiConfigurationHandlers } from "../utils/useApiConfigurationHandlers"
 import { useProviderApiKeyField } from "../utils/useProviderApiKeyField"
 
@@ -60,7 +60,6 @@ export const OpenAICompatibleProvider = ({ showModelOptions, isPopup, currentMod
 
 	// Get the normalized configuration
 	const { selectedModelId, selectedModelInfo } = useDynamicProviderSelection("openai", apiConfiguration, currentMode)
-	const showReasoningEffort = supportsReasoningEffortForModelId(selectedModelId, true)
 
 	// Get mode-specific fields
 	const { openAiModelInfo } = getModeSpecificFields(apiConfiguration, currentMode)
@@ -541,7 +540,18 @@ export const OpenAICompatibleProvider = ({ showModelOptions, isPopup, currentMod
 
 			{showModelOptions && (
 				<>
-					{showReasoningEffort && <ReasoningEffortSelector currentMode={currentMode} />}
+					<ReasoningEffortSelector
+						currentMode={currentMode}
+						defaultEffort="none"
+						onEffortChange={(effort) => {
+							void write({
+								reasoning: {
+									enabled: effort !== "none",
+									effort: effort !== "none" ? effort : undefined,
+								},
+							}).catch((err) => console.error("Failed to update OpenAI Compatible reasoning effort:", err))
+						}}
+					/>
 					<ModelInfoView isPopup={isPopup} modelInfo={selectedModelInfo} selectedModelId={selectedModelId} />
 				</>
 			)}

--- a/sdk/packages/core/src/services/llms/handler-factory.test.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.test.ts
@@ -125,6 +125,31 @@ describe("createAgentModelFromConfig", () => {
 		);
 	});
 
+	it("uses providerConfig maxOutputTokens when no direct per-turn override is set", async () => {
+		const { createAgentModelFromConfig } = await import("./handler-factory");
+
+		createAgentModelFromConfig(
+			{
+				providerId: "openai-compatible",
+				modelId: "custom-model",
+				apiKey: "key",
+				systemPrompt: "",
+				tools: [],
+				providerConfig: {
+					providerId: "openai-compatible",
+					modelId: "custom-model",
+					maxOutputTokens: 4_096,
+				},
+			},
+			undefined,
+		);
+
+		expect(gatewayMock.createAgentModel).toHaveBeenLastCalledWith(
+			{ providerId: "openai-compatible", modelId: "custom-model" },
+			{ maxTokens: 4_096 },
+		);
+	});
+
 	it("preserves model capabilities and metadata when configuring gateway models", async () => {
 		const { createAgentModelFromConfig } = await import("./handler-factory");
 

--- a/sdk/packages/core/src/services/llms/handler-factory.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.ts
@@ -159,7 +159,7 @@ export function createAgentModelFromConfig(
 		baseUrl: config.baseUrl ?? baseProviderConfig?.baseUrl,
 		headers: config.headers ?? baseProviderConfig?.headers,
 		knownModels: resolveKnownModelsFromConfig(config),
-		maxOutputTokens: config.maxTokensPerTurn,
+		maxOutputTokens: config.maxTokensPerTurn ?? baseProviderConfig?.maxOutputTokens,
 		reasoningEffort: config.reasoningEffort,
 		thinkingBudgetTokens: config.thinkingBudgetTokens,
 		thinking: config.thinking,


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This fixes two OpenAI-compatible issues in the VS Code SDK path.

First, OpenAI-compatible settings now always expose the reasoning effort selector when model options are shown. This provider is intentionally bring-your-own-model/base-URL, so gating the selector on incomplete model metadata made it impossible for testers to disable reasoning or choose a reasoning level for compatible endpoints that support those controls. The selector defaults to `none` for OpenAI-compatible and persists changes into provider reasoning settings, which is the store the SDK session factory reads when building runtime config.

Second, VS Code's OpenAI-compatible custom model limits are now bridged into the SDK `knownModels` shape during session creation. VS Code stores custom model data such as `contextWindow` and `maxTokens` in legacy `actModeOpenAiModelInfo` / `planModeOpenAiModelInfo` fields, while the SDK runtime and context compaction look at `knownModels[modelId].maxInputTokens` / `contextWindow`. Without this bridge, the UI could save a custom context window but the SDK runtime would behave as if it did not know that limit.

The bridge is intentionally narrow and CLI-aligned: it carries the selected custom model id/name, context window, max output tokens, temperature, and baseline OpenAI-compatible capabilities. Capabilities are not user-editable through this PR; the bridge defaults to `streaming` + `tools`, and includes `images` only when the existing VS Code OpenAI-compatible `supportsImages` model setting is not explicitly false. It does not add pricing, model-family metadata, or arbitrary request-body JSON injection.

The core handler factory now also preserves `providerConfig.maxOutputTokens` when there is no direct per-turn override. This keeps the selected custom model's output limit from being dropped before the gateway model is created.

### Test Procedure

- Ran `bun -F claude-dev test:vitest src/sdk/cline-session-factory.test.ts` from `apps/vscode`.
- Ran `bun -F @cline/core test:unit src/services/llms/handler-factory.test.ts` from the repository root.
- Ran `bun -F claude-dev check-types` from the repository root.

The added VS Code session-factory test verifies that an OpenAI-compatible custom model's context window, max output tokens, and capabilities are passed through as SDK `knownModels` and provider config while respecting `supportsImages: false`. The added core handler-factory test verifies that `providerConfig.maxOutputTokens` reaches gateway model defaults when no per-turn override is set.

Potential risk is limited to the VS Code OpenAI-compatible SDK path and the shared handler-factory max-output defaulting behavior. Existing direct `maxTokensPerTurn` overrides still take precedence.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. The visible UI change is that the existing OpenAI-compatible reasoning selector is always rendered in model options.

### Additional Notes

This PR intentionally does not implement a generic arbitrary request-body JSON editor. It supports the reported reasoning controls through the existing typed SDK reasoning/provider-options path, and supports custom context/output limits through SDK model metadata propagation.
