### PR TITLE
test(vscode): warm catalog import to fix flaky 5s timeout in nightly

### DIFF
--- a/apps/vscode/src/sdk/model-catalog/catalog.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/catalog.test.ts
@@ -1,5 +1,5 @@
 import type { ModelInfo } from "@shared/api"
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 import type {
 	EffectiveProviderConfig,
 	Fingerprint,
@@ -33,6 +33,15 @@ type TestReader = ProviderConfigReader & {
 	setConfig(next: EffectiveProviderConfig): void
 	emit(event: ProviderConfigChange): void
 }
+
+// Warm the catalog module graph once before any test runs. catalog.ts statically
+// pulls in @cline/core, @cline/llms and @cline/shared, so the first test to call
+// `await import("./catalog")` otherwise pays the entire (>5s on CI) import cost
+// inside its own 5s test timeout and flakily fails. Importing here moves that cost
+// outside any per-test clock (hooks get a generous timeout of their own).
+beforeAll(async () => {
+	await import("./catalog")
+}, 60_000)
 
 beforeEach(() => {
 	mocks.resolveProviderConfig.mockReset()


### PR DESCRIPTION
### Related Issue

N/A — flaky-test fix surfaced while investigating repeated nightly publish failures.

### Description

Nightly publishes (`ext-vscode-publish-nightly`) have been failing intermittently in the `vscode test` job on a single test:

```
FAIL src/sdk/model-catalog/catalog.test.ts > ProviderCatalog Phase 3.1 cache
  > returns cache hit only when provider and fingerprint both match
Error: Test timed out in 5000ms.
```

The failure is **not** a logic bug — that test is pure in-memory cache logic driven by a fake clock and does no real I/O. The cost is the lazy module import at the top of every test:

```ts
const { _testing } = await import("./catalog")
```

`catalog.ts` statically pulls in `@cline/core`, `@cline/llms`, and `@cline/shared` (and the `vi.mock("@cline/core")` factory `await importOriginal()`s the real package on top). The **first** test in the file pays that entire import cost *inside its own 5s test timeout*. On CI the import phase is heavy (observed >30s cumulative for the suite), so whichever test runs first occasionally tips over 5000ms and fails the whole job — which in turn skips the marketplace publish. Re-running usually "fixes" it, which is the classic flaky-timeout signature (seen at 5047ms and 5008ms across runs).

The fix warms the module graph once in `beforeAll` (with a generous 60s hook timeout, separate from the per-test clock), so by the time any test calls `await import("./catalog")` it's already resolved and instant.

### Test Procedure

- Reproduced the discrepancy locally: the test passes in isolation but the import cost is what's being measured.
- After the change, `npx vitest run src/sdk/model-catalog/catalog.test.ts` → **28/28 passed**, with the import phase dropping to ~95ms (was multiple seconds, attributed to test #1).
- No production code changed — this only moves *when* the test imports the module, not what it tests.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore
-   [x] Tests are passing (`bun test`) and code is formatted and linted

### Additional Notes

Targeting `dpc/sdk-migration-simpler-login` because that's the branch nightlies currently publish from during the SDK migration. Once merged, re-running the nightly should clear the test phase and actually publish.
