### PR TITLE
test(vscode): fix toMatchObject failure in proto conversion integration test

### DIFF
--- a/apps/vscode/src/shared/proto-conversions/models/api-configuration-conversion.test.ts
+++ b/apps/vscode/src/shared/proto-conversions/models/api-configuration-conversion.test.ts
@@ -12,10 +12,12 @@ describe("api configuration provider conversion", () => {
 				planModeApiProvider: provider,
 			})
 
-			expect(convertProtoToApiConfiguration(proto)).toMatchObject({
-				actModeApiProvider: provider,
-				planModeApiProvider: provider,
-			})
+			// Assert field-by-field instead of toMatchObject: this file is also picked up by
+			// the mocha integration runner (.vscode-test.mjs globs src/shared/**/*.test.js),
+			// where vitest's jest-compat matchers like toMatchObject are not available.
+			const result = convertProtoToApiConfiguration(proto)
+			expect(result.actModeApiProvider).toBe(provider)
+			expect(result.planModeApiProvider).toBe(provider)
 		}
 	})
 })


### PR DESCRIPTION
### Related Issue

N/A — fixes a test failure introduced by #11703 that is blocking the nightly publish.

### Description

The nightly publish (`ext-vscode-publish-nightly`) has been failing in the `vscode test` job. After the catalog flaky-timeout fix landed, the vitest (53/53) and bun unit (931/0) phases pass, but the **mocha integration phase** fails:

```
1 failing
   TypeError: (0 , vitest_1.expect)(...).toMatchObject is not a function
   at Context.<anonymous> (out/src/shared/proto-conversions/models/api-configuration-conversion.test.js:13:109)
```

`api-configuration-conversion.test.ts` (added in #11703) is a vitest test, but it lives under `src/shared/proto-conversions/models/`, which is matched by **both** test runners:

- `vitest.config.ts` includes `src/shared/proto-conversions/models/**/*.test.ts`
- `.vscode-test.mjs` (the mocha/vscode-test integration runner) globs `src/{...,shared,...}/**/*.test.js`

It passes under vitest but throws under mocha, because `toMatchObject` is a jest-compat matcher that only exists inside vitest's runtime — it is not available when vitest's `expect` is imported into the plain Node/mocha runtime. Other vitest-style tests under these paths survive the dual-run only because they happen to use universally-available matchers (`toBe`, `toEqual`).

The fix replaces the single partial-match `toMatchObject` assertion with two field-level `toBe` assertions, which behave identically under both runners. (`toEqual` would not work here — the round-tripped object contains many more fields than the two being checked, so a partial match is what's intended.)

### Test Procedure

- `npx vitest run src/shared/proto-conversions/models/api-configuration-conversion.test.ts` → **1/1 passed**.
- `bun run compile-tests` succeeds; verified the emitted `out/.../api-configuration-conversion.test.js` now uses `.toBe(...)` and no longer references `toMatchObject`. `toBe` is the same matcher used across the other 211 passing integration tests, so it resolves correctly in the mocha runtime.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore
-   [x] Tests are passing (`bun test`) and code is formatted and linted

### Additional Notes

Targeting `dpc/sdk-migration-simpler-login` since that's the branch nightlies publish from during the SDK migration. Once merged, re-running the nightly should get past the integration phase and publish.
