### PR TITLE
feat(providers): add PleumRouter built-in (OpenAI-compatible gateway)

### DIFF
--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -605,6 +605,17 @@ const OPENAI_COMPATIBLE_SPECS: BuiltinSpec[] = [
 		defaults: { baseUrl: "https://api.groq.com/openai/v1" },
 	},
 	{
+		id: "pleumrouter",
+		name: "PleumRouter",
+		description: "Korea-region OpenAI-compatible multi-provider LLM gateway",
+		family: "openai-compatible",
+		capabilities: ["tools", "reasoning"],
+		defaultModelId: "claude-sonnet-4-6",
+		apiKeyEnv: ["PLEUMROUTER_API_KEY"],
+		defaults: { baseUrl: "https://router.pleum.ai/v1" },
+		docsUrl: "https://router.pleum.ai/docs",
+	},
+	{
 		id: "poolside",
 		name: "Poolside",
 		description: "OpenAI-compatible code intelligence models",

--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -610,7 +610,7 @@ const OPENAI_COMPATIBLE_SPECS: BuiltinSpec[] = [
 		description: "Korea-region OpenAI-compatible multi-provider LLM gateway",
 		family: "openai-compatible",
 		capabilities: ["tools", "reasoning"],
-		defaultModelId: "claude-sonnet-4-6",
+		defaultModelId: "deepseek-v4-pro",
 		apiKeyEnv: ["PLEUMROUTER_API_KEY"],
 		defaults: { baseUrl: "https://router.pleum.ai/v1" },
 		docsUrl: "https://router.pleum.ai/docs",


### PR DESCRIPTION
### Related Issue

**Issue:** _none_ — this is a minimal, additive provider entry that mirrors the existing built-in OpenAI-compatible gateways (Together, Fireworks, Groq). Happy to open a Feature Requests discussion first if maintainers prefer the full process for a new provider; flagging here so you can redirect me.

### Description

Adds **PleumRouter** (https://router.pleum.ai) as a built-in provider. PleumRouter is a Korea-region, OpenAI-compatible multi-provider LLM gateway (one key → many providers; OpenAI `/v1/chat/completions` + a public `/v1/models`). It slots into `OPENAI_COMPATIBLE_SPECS` in `sdk/packages/llms/src/providers/builtins.ts` exactly like the existing Together / Fireworks / Groq gateway built-ins — `family: "openai-compatible"`, `baseUrl: https://router.pleum.ai/v1`, `apiKeyEnv: ["PLEUMROUTER_API_KEY"]`. Model list is fetched live from the public `/v1/models`, same as the other openai-compatible gateways (no generated catalog entry needed).

### Test Procedure

- The change is a single declarative `BuiltinSpec` entry, structurally identical to the adjacent `together` / `fireworks` / `groq` specs.
- `builtins.test.ts` asserts only per-provider behavior (cline, huggingface, Z.AI, MiniMax, ChatGPT catalog) — there is no global snapshot/count over the spec list, so this addition does not affect existing tests.
- Manual: set `PLEUMROUTER_API_KEY`, select PleumRouter, confirm models populate from `/v1/models` and a chat + tool call round-trips.
- Note: I did not run the full monorepo suite locally (large workspace); relying on CI for `npm test` / lint / format.

### Type of Change

-   [x] ✨ New feature (non-breaking change which adds functionality)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature (one provider spec entry)
-   [ ] Tests are passing locally — not run locally (heavy monorepo); CI covers `npm test` / `npm run format && npm run lint`
-   [x] I have reviewed the contributor guidelines

### Screenshots

N/A — backend provider registration (no UI change beyond the picker listing a new entry).

### Additional Notes

Mirrors the merged Together/Fireworks/Groq gateway entries. Happy to adjust `defaultModelId`, description, or `capabilities`, or to open a Feature Requests discussion if that's your preferred path for new providers.
