### PR TITLE
Fix ModelAutocomplete selection

### DIFF
--- a/apps/vscode/webview-ui/src/components/settings/common/ModelAutocomplete.test.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/common/ModelAutocomplete.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import type { FocusEventHandler, FormEventHandler, KeyboardEventHandler, ReactNode } from "react"
+import { describe, expect, it, vi } from "vitest"
+import { ModelAutocomplete } from "./ModelAutocomplete"
+
+vi.mock("@vscode/webview-ui-toolkit/react", () => ({
+	VSCodeTextField: ({
+		children,
+		id,
+		onBlur,
+		onFocus,
+		onInput,
+		onKeyDown,
+		placeholder,
+		role,
+		value,
+	}: {
+		children?: ReactNode
+		id?: string
+		onBlur?: FocusEventHandler<HTMLInputElement>
+		onFocus?: FocusEventHandler<HTMLInputElement>
+		onInput?: FormEventHandler<HTMLInputElement>
+		onKeyDown?: KeyboardEventHandler<HTMLInputElement>
+		placeholder?: string
+		role?: string
+		value?: string
+	}) => (
+		<div>
+			<label htmlFor={id}>{children}</label>
+			<input
+				id={id}
+				onBlur={onBlur}
+				onChange={onInput}
+				onFocus={onFocus}
+				onKeyDown={onKeyDown}
+				placeholder={placeholder}
+				role={role}
+				value={value}
+			/>
+		</div>
+	),
+}))
+
+const models = {
+	"gpt-4o": { name: "GPT-4o", supportsPromptCache: false, contextWindow: 128_000 },
+	"gpt-4o-mini": { name: "GPT-4o Mini", supportsPromptCache: false, contextWindow: 128_000 },
+}
+
+describe("ModelAutocomplete", () => {
+	it("commits a clicked dropdown model only once when the input blur handler also runs", async () => {
+		const onChange = vi.fn()
+		render(<ModelAutocomplete models={models} onChange={onChange} selectedModelId="gpt-4o" />)
+
+		const input = screen.getByRole("combobox")
+		fireEvent.focus(input)
+
+		const option = screen.getAllByRole("option").find((element) => element.textContent === "gpt-4o-mini")
+		if (!option) {
+			throw new Error("Expected gpt-4o-mini option to be rendered")
+		}
+
+		fireEvent.mouseDown(option)
+		fireEvent.blur(input)
+		fireEvent.click(option)
+
+		await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1))
+		expect(onChange).toHaveBeenCalledWith("gpt-4o-mini", models["gpt-4o-mini"])
+	})
+
+	it("still commits a typed custom model id on blur", async () => {
+		const onChange = vi.fn()
+		render(<ModelAutocomplete models={models} onChange={onChange} selectedModelId="gpt-4o" />)
+
+		const input = screen.getByRole("combobox")
+		fireEvent.focus(input)
+		fireEvent.change(input, { target: { value: "custom-model" } })
+		fireEvent.blur(input)
+
+		await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1))
+		expect(onChange).toHaveBeenCalledWith("custom-model", undefined)
+	})
+})

--- a/apps/vscode/webview-ui/src/components/settings/common/ModelAutocomplete.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/common/ModelAutocomplete.tsx
@@ -214,14 +214,13 @@ export const ModelAutocomplete = ({
 							style={{ zIndex: zIndex - 1 }}>
 							{modelSearchResults.map((item, index) => (
 								<DropdownItem
+									$isSelected={index === selectedIndex}
 									aria-selected={index === selectedIndex}
 									id={`${listboxId}-option-${index}`}
-									isSelected={index === selectedIndex}
 									key={item.id}
 									onClick={() => {
 										handleModelChange(item.id)
 										setIsDropdownVisible(false)
-										isSelectingRef.current = false
 									}}
 									onMouseDown={() => {
 										isSelectingRef.current = true
@@ -258,13 +257,13 @@ const DropdownList = styled.div`
 	border-bottom-right-radius: 3px;
 `
 
-const DropdownItem = styled.div<{ isSelected: boolean }>`
+const DropdownItem = styled.div<{ $isSelected: boolean }>`
 	padding: 5px 10px;
 	cursor: pointer;
 	word-break: break-all;
 	white-space: normal;
 
-	background-color: ${({ isSelected }) => (isSelected ? "var(--vscode-list-activeSelectionBackground)" : "inherit")};
+	background-color: ${({ $isSelected }) => ($isSelected ? "var(--vscode-list-activeSelectionBackground)" : "inherit")};
 
 	&:hover {
 		background-color: var(--vscode-list-activeSelectionBackground);


### PR DESCRIPTION
LiteLLM model selection is broken because the autocomplete model selector right now deals to 2 calls, one with model id and one without. This PR prevents the second call.