### PR TITLE
Fix image paste/drop support check

### DIFF
--- a/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -21,6 +21,7 @@ import { usePlatform } from "@/context/PlatformContext"
 import { useNormalizedApiConfiguration } from "@/hooks/useNormalizedApiConfiguration"
 import { cn } from "@/lib/utils"
 import { FileServiceClient, StateServiceClient } from "@/services/grpc-client"
+import { shouldProcessImageAttachments } from "./chat-view/utils/imageAttachments"
 import {
 	ContextMenuOptionType,
 	getContextMenuOptionIndex,
@@ -253,13 +254,16 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 		const _shiftHoldTimerRef = useRef<NodeJS.Timeout | null>(null)
 		const [showUnsupportedFileError, setShowUnsupportedFileError] = useState(false)
 		const unsupportedFileTimerRef = useRef<NodeJS.Timeout | null>(null)
+		const [showUnsupportedImageError, setShowUnsupportedImageError] = useState(false)
+		const unsupportedImageTimerRef = useRef<NodeJS.Timeout | null>(null)
 		const [showDimensionError, setShowDimensionError] = useState(false)
 		const dimensionErrorTimerRef = useRef<NodeJS.Timeout | null>(null)
 
 		const [fileSearchResults, setFileSearchResults] = useState<SearchResult[]>([])
 		const [searchLoading, setSearchLoading] = useState(false)
 		const [, metaKeyChar] = useMetaKeyDetection(platform)
-		const { selectedProvider, selectedModelId } = useNormalizedApiConfiguration(mode)
+		const { selectedProvider, selectedModelId, selectedModelInfo } = useNormalizedApiConfiguration(mode)
+		const selectedModelSupportsImages = selectedModelInfo.supportsImages ?? false
 
 		// Fetch git commits when Git is selected or when typing a hash
 		useEffect(() => {
@@ -843,6 +847,17 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			}, 3000)
 		}, [])
 
+		const showUnsupportedImageErrorMessage = useCallback(() => {
+			setShowUnsupportedImageError(true)
+			if (unsupportedImageTimerRef.current) {
+				clearTimeout(unsupportedImageTimerRef.current)
+			}
+			unsupportedImageTimerRef.current = setTimeout(() => {
+				setShowUnsupportedImageError(false)
+				unsupportedImageTimerRef.current = null
+			}, 3000)
+		}, [])
+
 		const handlePaste = useCallback(
 			async (e: React.ClipboardEvent) => {
 				const items = e.clipboardData.items
@@ -878,7 +893,18 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					const [type, subtype] = item.type.split("/")
 					return type === "image" && acceptedTypes.includes(subtype)
 				})
-				if (!shouldDisableFilesAndImages && imageItems.length > 0) {
+				if (imageItems.length > 0 && !selectedModelSupportsImages) {
+					e.preventDefault()
+					showUnsupportedImageErrorMessage()
+					return
+				}
+				if (
+					shouldProcessImageAttachments({
+						supportsImages: selectedModelSupportsImages,
+						shouldDisableFilesAndImages,
+						imageCount: imageItems.length,
+					})
+				) {
 					e.preventDefault()
 					const imagePromises = imageItems.map((item) => {
 						return new Promise<string | null>((resolve) => {
@@ -936,6 +962,8 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				setInputValue,
 				inputValue,
 				showDimensionErrorMessage,
+				showUnsupportedImageErrorMessage,
+				selectedModelSupportsImages,
 			],
 		)
 
@@ -1145,7 +1173,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				default:
 					return `${selectedProvider}:${selectedModelId}`
 			}
-		}, [apiConfiguration, mode, selectedProvider, selectedModelId])
+		}, [apiConfiguration, mode, selectedModelId, selectedProvider])
 
 		// Function to show error message for unsupported files for drag and drop
 		const showUnsupportedFileErrorMessage = () => {
@@ -1182,6 +1210,11 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 
 				if (hasNonImageFile) {
 					showUnsupportedFileErrorMessage()
+				}
+
+				const hasImageFile = items.some((item) => item.kind === "file" && item.type.split("/")[0] === "image")
+				if (hasImageFile && !selectedModelSupportsImages) {
+					showUnsupportedImageErrorMessage()
 				}
 			}
 		}
@@ -1302,7 +1335,18 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				return type === "image" && acceptedTypes.includes(subtype)
 			})
 
-			if (shouldDisableFilesAndImages || imageFiles.length === 0) {
+			if (imageFiles.length > 0 && !selectedModelSupportsImages) {
+				showUnsupportedImageErrorMessage()
+				return
+			}
+
+			if (
+				!shouldProcessImageAttachments({
+					supportsImages: selectedModelSupportsImages,
+					shouldDisableFilesAndImages,
+					imageCount: imageFiles.length,
+				})
+			) {
 				return
 			}
 
@@ -1398,6 +1442,11 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 							<span className="text-error font-bold text-xs">Files other than images are currently disabled</span>
 						</div>
 					)}
+					{showUnsupportedImageError && (
+						<div className="absolute inset-2.5 bg-[rgba(var(--vscode-errorForeground-rgb),0.1)] border-2 border-error rounded-xs flex items-center justify-center z-10 pointer-events-none">
+							<span className="text-error font-bold text-xs">The current model doesn't support images</span>
+						</div>
+					)}
 					{showSlashCommandsMenu && (
 						<div ref={slashCommandsMenuContainerRef}>
 							<SlashCommandMenu
@@ -1480,7 +1529,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 						onPaste={handlePaste}
 						onScroll={() => updateHighlights()}
 						onSelect={updateCursorPosition}
-						placeholder={showUnsupportedFileError || showDimensionError ? "" : placeholderText}
+						placeholder={showUnsupportedFileError || showUnsupportedImageError || showDimensionError ? "" : placeholderText}
 						ref={(el) => {
 							if (typeof ref === "function") {
 								ref(el)

--- a/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -21,7 +21,7 @@ import { usePlatform } from "@/context/PlatformContext"
 import { useNormalizedApiConfiguration } from "@/hooks/useNormalizedApiConfiguration"
 import { cn } from "@/lib/utils"
 import { FileServiceClient, StateServiceClient } from "@/services/grpc-client"
-import { shouldProcessImageAttachments } from "./chat-view/utils/imageAttachments"
+import { isAcceptedImageType, shouldProcessImageAttachments } from "./chat-view/utils/imageAttachments"
 import {
 	ContextMenuOptionType,
 	getContextMenuOptionIndex,
@@ -1212,7 +1212,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					showUnsupportedFileErrorMessage()
 				}
 
-				const hasImageFile = items.some((item) => item.kind === "file" && item.type.split("/")[0] === "image")
+				const hasImageFile = items.some((item) => item.kind === "file" && isAcceptedImageType(item.type))
 				if (hasImageFile && !selectedModelSupportsImages) {
 					showUnsupportedImageErrorMessage()
 				}
@@ -1329,11 +1329,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			// --- 3. Image Drop Handling ---
 			// Only proceed if it wasn't a VSCode resource or plain text drop
 			const files = Array.from(e.dataTransfer.files)
-			const acceptedTypes = ["png", "jpeg", "webp"]
-			const imageFiles = files.filter((file) => {
-				const [type, subtype] = file.type.split("/")
-				return type === "image" && acceptedTypes.includes(subtype)
-			})
+			const imageFiles = files.filter((file) => isAcceptedImageType(file.type))
 
 			if (imageFiles.length > 0 && !selectedModelSupportsImages) {
 				showUnsupportedImageErrorMessage()

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/utils/imageAttachments.test.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/utils/imageAttachments.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest"
+import { shouldProcessImageAttachments } from "./imageAttachments"
+
+describe("shouldProcessImageAttachments", () => {
+	it("rejects images when the selected model does not support images", () => {
+		expect(
+			shouldProcessImageAttachments({
+				supportsImages: false,
+				shouldDisableFilesAndImages: false,
+				imageCount: 1,
+			}),
+		).toBe(false)
+	})
+
+	it("accepts images when the selected model supports images and attachment slots remain", () => {
+		expect(
+			shouldProcessImageAttachments({
+				supportsImages: true,
+				shouldDisableFilesAndImages: false,
+				imageCount: 1,
+			}),
+		).toBe(true)
+	})
+
+	it("rejects image handling when there are no images or attachment slots are full", () => {
+		expect(
+			shouldProcessImageAttachments({
+				supportsImages: true,
+				shouldDisableFilesAndImages: false,
+				imageCount: 0,
+			}),
+		).toBe(false)
+		expect(
+			shouldProcessImageAttachments({
+				supportsImages: true,
+				shouldDisableFilesAndImages: true,
+				imageCount: 1,
+			}),
+		).toBe(false)
+	})
+})

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/utils/imageAttachments.test.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/utils/imageAttachments.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { shouldProcessImageAttachments } from "./imageAttachments"
+import { isAcceptedImageType, shouldProcessImageAttachments } from "./imageAttachments"
 
 describe("shouldProcessImageAttachments", () => {
 	it("rejects images when the selected model does not support images", () => {
@@ -37,5 +37,19 @@ describe("shouldProcessImageAttachments", () => {
 				imageCount: 1,
 			}),
 		).toBe(false)
+	})
+})
+
+describe("isAcceptedImageType", () => {
+	it("accepts image MIME types supported by the attachment pipeline", () => {
+		expect(isAcceptedImageType("image/png")).toBe(true)
+		expect(isAcceptedImageType("image/jpeg")).toBe(true)
+		expect(isAcceptedImageType("image/webp")).toBe(true)
+	})
+
+	it("rejects unsupported image MIME types and non-image files", () => {
+		expect(isAcceptedImageType("image/gif")).toBe(false)
+		expect(isAcceptedImageType("text/plain")).toBe(false)
+		expect(isAcceptedImageType("")).toBe(false)
 	})
 })

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/utils/imageAttachments.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/utils/imageAttachments.ts
@@ -11,3 +11,10 @@ export const shouldProcessImageAttachments = ({
 }: ImageAttachmentGateArgs) => {
 	return supportsImages && !shouldDisableFilesAndImages && imageCount > 0
 }
+
+const ACCEPTED_IMAGE_SUBTYPES = new Set(["png", "jpeg", "webp"])
+
+export const isAcceptedImageType = (mimeType: string) => {
+	const [type, subtype] = mimeType.split("/")
+	return type === "image" && ACCEPTED_IMAGE_SUBTYPES.has(subtype)
+}

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/utils/imageAttachments.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/utils/imageAttachments.ts
@@ -1,0 +1,13 @@
+export interface ImageAttachmentGateArgs {
+	supportsImages: boolean
+	shouldDisableFilesAndImages: boolean
+	imageCount: number
+}
+
+export const shouldProcessImageAttachments = ({
+	supportsImages,
+	shouldDisableFilesAndImages,
+	imageCount,
+}: ImageAttachmentGateArgs) => {
+	return supportsImages && !shouldDisableFilesAndImages && imageCount > 0
+}


### PR DESCRIPTION
## Summary
- Prevent pasted or dropped image files from being attached when the selected model does not support images.
- Reuse the normalized model image-support capability for paste/drop attachment gating.
- Show transient input feedback instead of allowing the request to fail later, and add focused unit coverage.

Fixes #8635

## Tests
- `npm test -- imageAttachments.test.ts`

## Notes
- A full fresh-clone build is currently blocked by missing generated proto/grpc artifacts, but the targeted image attachment tests pass and no touched-file type errors remain.