### PR TITLE
docs: fix CLI MCP config path

### DIFF
--- a/docs/mcp/mcp-overview.mdx
+++ b/docs/mcp/mcp-overview.mdx
@@ -31,7 +31,7 @@ Use Cline's MCP Marketplace for one-click install when available.
 
 Edit your MCP config file and add either:
 
-- **CLI:** `~/.cline/mcp.json`
+- **CLI:** `~/.cline/data/settings/cline_mcp_settings.json`
 - **IDE extensions:**
   1. In the Cline panel, click the **MCP Servers** icon (stacked server icon in the top toolbar).
   2. Open the **Configure** tab.


### PR DESCRIPTION
## Summary
- Update the MCP manual config docs to point CLI users at the actual settings path.
- Align the docs with `resolveMcpSettingsPath()` and the existing config directory documentation.

Fixes #11671

## Tests
- `git diff --check`