### PR TITLE
fix(hub): validate dashboard websocket host and origin

### DIFF
--- a/apps/cline-hub/src/options.ts
+++ b/apps/cline-hub/src/options.ts
@@ -1,3 +1,5 @@
+import { isIP } from "node:net";
+
 export interface ClineHubServerOptions {
 	host: string;
 	port: number;
@@ -47,6 +49,9 @@ function normalizePublicUrl(
 			`PUBLIC_URL must use http: or https:, got ${parsed.protocol}`,
 		);
 	}
+	if (shouldAddDashboardPortToPublicUrl(parsed, port)) {
+		parsed.port = String(port);
+	}
 	parsed.hash = "";
 	return parsed.toString().replace(/\/$/, "");
 }
@@ -85,12 +90,26 @@ export function resolveClineHubServerOptions(
 	};
 }
 
+function isDefaultProtocolPort(url: URL, port: number): boolean {
+	return (
+		(url.protocol === "http:" && port === 80) ||
+		(url.protocol === "https:" && port === 443)
+	);
+}
+
+function shouldAddDashboardPortToPublicUrl(url: URL, port: number): boolean {
+	if (url.port || isDefaultProtocolPort(url, port)) return false;
+	const hostname = url.hostname.replace(/^\[|\]$/g, "");
+	return hostname === "localhost" || isIP(hostname) !== 0;
+}
+
 export function buildInviteUrl(
 	publicUrl: string,
 	roomSecret: string | undefined,
 ): string {
-	if (!roomSecret) return publicUrl;
 	const url = new URL(publicUrl);
-	url.searchParams.set("roomSecret", roomSecret);
+	if (roomSecret) {
+		url.searchParams.set("roomSecret", roomSecret);
+	}
 	return url.toString();
 }

--- a/apps/cline-hub/src/server.ts
+++ b/apps/cline-hub/src/server.ts
@@ -4,6 +4,7 @@ import {
 	handleToolApprovalResponse,
 	rejectOrphanedApprovals,
 } from "./server/approvals";
+import { isAuthorizedBrowserToDesktopRequest } from "./server/browser-auth";
 import {
 	browserConfig,
 	host,
@@ -59,11 +60,6 @@ export async function startClineHubDashboardServer(): Promise<ClineHubDashboardS
 	const syncClientsAndSessions = () => syncHubClientsAndSessions(ctx);
 	let stopped = false;
 
-	function isAuthorizedBrowserRequest(url: URL): boolean {
-		if (!roomSecret) return true;
-		return url.searchParams.get("roomSecret") === roomSecret;
-	}
-
 	await attachHub(ctx);
 	const healthInterval = setInterval(() => {
 		void (async () => {
@@ -77,6 +73,16 @@ export async function startClineHubDashboardServer(): Promise<ClineHubDashboardS
 		hostname: host,
 		async fetch(req, server) {
 			const url = new URL(req.url);
+			if (
+				!isAuthorizedBrowserToDesktopRequest(req, url, {
+					bindHost: host,
+					port,
+					publicUrl,
+					roomSecret,
+				})
+			) {
+				return createJsonResponse({ error: "unauthorized_browser" }, 403);
+			}
 			if (url.pathname === "/version") {
 				return createJsonResponse({ coreVersion: CORE_BUILD_VERSION });
 			}
@@ -85,9 +91,6 @@ export async function startClineHubDashboardServer(): Promise<ClineHubDashboardS
 				return createJsonResponse(hubStatusPayload(ctx));
 			}
 			if (url.pathname === "/browser") {
-				if (!isAuthorizedBrowserRequest(url)) {
-					return createJsonResponse({ error: "invalid_room_secret" }, 401);
-				}
 				const displayName = `Browser ${Math.random().toString(36).slice(2, 6)}`;
 				const data = {
 					socket: undefined as never,

--- a/apps/cline-hub/src/server.ts
+++ b/apps/cline-hub/src/server.ts
@@ -15,7 +15,11 @@ import {
 	webviewDistDir,
 } from "./server/deps";
 import { handleDesktopCommand } from "./server/desktop-commands";
-import { createJsonResponse, WebviewAssets } from "./server/http";
+import {
+	createJsonResponse,
+	isWebviewRoute,
+	WebviewAssets,
+} from "./server/http";
 import {
 	attachHub,
 	detachHub,
@@ -54,6 +58,27 @@ export interface ClineHubDashboardServer {
 	stop: () => Promise<void>;
 }
 
+const PUBLIC_BROWSER_PATHS = new Set([
+	"/version",
+	"/health",
+	"/config.json",
+	"/api/marketplace/catalog",
+	"/icon.png",
+	"/icon.svg",
+	"/icon.ico",
+	"/32x32.png",
+	"/cline-logo-filled.svg",
+	"/favicon.svg",
+]);
+
+function isPublicStaticAssetPath(pathname: string): boolean {
+	return pathname.startsWith("/assets/") || PUBLIC_BROWSER_PATHS.has(pathname);
+}
+
+function isPublicBrowserRoute(_req: Request, url: URL): boolean {
+	return isWebviewRoute(url.pathname) || isPublicStaticAssetPath(url.pathname);
+}
+
 export async function startClineHubDashboardServer(): Promise<ClineHubDashboardServer> {
 	const ctx = new HubContext();
 	const assets = new WebviewAssets(webviewDistDir);
@@ -74,12 +99,17 @@ export async function startClineHubDashboardServer(): Promise<ClineHubDashboardS
 		async fetch(req, server) {
 			const url = new URL(req.url);
 			if (
-				!isAuthorizedBrowserToDesktopRequest(req, url, {
-					bindHost: host,
-					port,
-					publicUrl,
-					roomSecret,
-				})
+				!isAuthorizedBrowserToDesktopRequest(
+					req,
+					url,
+					{
+						bindHost: host,
+						port,
+						publicUrl,
+						roomSecret,
+					},
+					isPublicBrowserRoute,
+				)
 			) {
 				return createJsonResponse({ error: "unauthorized_browser" }, 403);
 			}

--- a/apps/cline-hub/src/server/browser-auth.test.ts
+++ b/apps/cline-hub/src/server/browser-auth.test.ts
@@ -55,6 +55,28 @@ describe("allowedBrowserOrigins", () => {
 		]);
 	});
 
+	it("omits default protocol ports for local alias origins", () => {
+		expect(
+			[
+				...allowedBrowserOrigins({
+					bindHost: "127.0.0.1",
+					port: 80,
+					publicUrl: "http://localhost",
+				}),
+			].sort(),
+		).toEqual(["http://127.0.0.1", "http://[::1]", "http://localhost"]);
+
+		expect(
+			[
+				...allowedBrowserOrigins({
+					bindHost: "127.0.0.1",
+					port: 443,
+					publicUrl: "https://localhost",
+				}),
+			].sort(),
+		).toEqual(["https://127.0.0.1", "https://[::1]", "https://localhost"]);
+	});
+
 	it("allows the configured public URL origin and explicit bind origin for non-local binds", () => {
 		expect(
 			[
@@ -76,6 +98,28 @@ describe("allowedBrowserHosts", () => {
 			"[::1]:8787",
 			"localhost:8787",
 		]);
+	});
+
+	it("omits default protocol ports for local alias hosts", () => {
+		expect(
+			[
+				...allowedBrowserHosts({
+					bindHost: "127.0.0.1",
+					port: 80,
+					publicUrl: "http://localhost",
+				}),
+			].sort(),
+		).toEqual(["127.0.0.1", "[::1]", "localhost"]);
+
+		expect(
+			[
+				...allowedBrowserHosts({
+					bindHost: "127.0.0.1",
+					port: 443,
+					publicUrl: "https://localhost",
+				}),
+			].sort(),
+		).toEqual(["127.0.0.1", "[::1]", "localhost"]);
 	});
 
 	it("allows the configured public URL host and explicit bind host for non-local binds", () => {

--- a/apps/cline-hub/src/server/browser-auth.test.ts
+++ b/apps/cline-hub/src/server/browser-auth.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from "vitest";
+import {
+	allowedBrowserHosts,
+	allowedBrowserOrigins,
+	isAuthorizedBrowserRequest,
+	isAuthorizedBrowserToDesktopRequest,
+	requiresBrowserRequestAuth,
+} from "./browser-auth";
+
+const defaultOptions = {
+	bindHost: "127.0.0.1",
+	port: 8787,
+	publicUrl: "http://127.0.0.1:8787",
+};
+
+function browserRequest(
+	origin?: string,
+	init?: Omit<RequestInit, "headers"> & {
+		headers?: Record<string, string>;
+	},
+): Request {
+	return new Request("http://127.0.0.1:8787/browser", {
+		...init,
+		headers: {
+			host: "127.0.0.1:8787",
+			...(origin === undefined ? {} : { origin }),
+			...(init?.headers ?? {}),
+		},
+	});
+}
+
+describe("allowedBrowserOrigins", () => {
+	it("allows the configured public URL origin and local aliases for local binds", () => {
+		expect([...allowedBrowserOrigins(defaultOptions)].sort()).toEqual([
+			"http://127.0.0.1:8787",
+			"http://[::1]:8787",
+			"http://localhost:8787",
+		]);
+	});
+
+	it("only allows the configured public URL origin for non-local binds", () => {
+		expect([
+			...allowedBrowserOrigins({
+				bindHost: "0.0.0.0",
+				port: 8787,
+				publicUrl: "https://example.ngrok-free.app",
+				roomSecret: "secret",
+			}),
+		]).toEqual(["https://example.ngrok-free.app"]);
+	});
+});
+
+describe("allowedBrowserHosts", () => {
+	it("allows the configured public URL host and local aliases for local binds", () => {
+		expect([...allowedBrowserHosts(defaultOptions)].sort()).toEqual([
+			"127.0.0.1:8787",
+			"[::1]:8787",
+			"localhost:8787",
+		]);
+	});
+
+	it("only allows the configured public URL host for non-local binds", () => {
+		expect([
+			...allowedBrowserHosts({
+				bindHost: "0.0.0.0",
+				port: 8787,
+				publicUrl: "https://example.ngrok-free.app",
+				roomSecret: "secret",
+			}),
+		]).toEqual(["example.ngrok-free.app"]);
+	});
+});
+
+describe("requiresBrowserRequestAuth", () => {
+	it("does not require browser auth for safe public GET routes", () => {
+		expect(
+			requiresBrowserRequestAuth(
+				new Request("http://127.0.0.1:8787/health"),
+				new URL("http://127.0.0.1:8787/health"),
+			),
+		).toBe(false);
+	});
+
+	it("requires browser auth for privileged paths even when they use GET", () => {
+		expect(
+			requiresBrowserRequestAuth(
+				new Request("http://127.0.0.1:8787/browser"),
+				new URL("http://127.0.0.1:8787/browser"),
+			),
+		).toBe(true);
+	});
+
+	it("requires browser auth for every WebSocket upgrade path", () => {
+		expect(
+			requiresBrowserRequestAuth(
+				new Request("http://127.0.0.1:8787/future-socket", {
+					headers: { upgrade: "websocket" },
+				}),
+				new URL("http://127.0.0.1:8787/future-socket"),
+			),
+		).toBe(true);
+	});
+
+	it("requires browser auth for every unsafe HTTP method", () => {
+		expect(
+			requiresBrowserRequestAuth(
+				new Request("http://127.0.0.1:8787/future-api", { method: "POST" }),
+				new URL("http://127.0.0.1:8787/future-api"),
+			),
+		).toBe(true);
+	});
+});
+
+describe("isAuthorizedBrowserRequest", () => {
+	it.each([
+		"http://127.0.0.1:8787",
+		"http://localhost:8787",
+		"http://[::1]:8787",
+	])("accepts local dashboard origin %s without a room secret", (origin) => {
+		expect(
+			isAuthorizedBrowserRequest(
+				browserRequest(origin),
+				new URL("http://127.0.0.1:8787/browser"),
+				defaultOptions,
+			),
+		).toBe(true);
+	});
+
+	it.each([
+		undefined,
+		"",
+		"null",
+		"not a url",
+		"http://evil.attacker.example.com",
+		"http://127.0.0.1:9999",
+		"https://127.0.0.1:8787",
+	])("rejects untrusted origin %s", (origin) => {
+		expect(
+			isAuthorizedBrowserRequest(
+				browserRequest(origin),
+				new URL("http://127.0.0.1:8787/browser"),
+				defaultOptions,
+			),
+		).toBe(false);
+	});
+
+	it.each([
+		undefined,
+		"",
+		"evil.attacker.example.com",
+		"127.0.0.1:9999",
+		"localhost:9999",
+	])("rejects untrusted host %s", (host) => {
+		expect(
+			isAuthorizedBrowserRequest(
+				browserRequest("http://127.0.0.1:8787", {
+					headers: host === undefined ? { host: "" } : { host },
+				}),
+				new URL("http://127.0.0.1:8787/browser"),
+				defaultOptions,
+			),
+		).toBe(false);
+	});
+
+	it("requires trusted origin, trusted host, and room secret when a room secret is configured", () => {
+		const options = { ...defaultOptions, roomSecret: "invite-123" };
+
+		expect(
+			isAuthorizedBrowserRequest(
+				browserRequest("http://127.0.0.1:8787"),
+				new URL("http://127.0.0.1:8787/browser?roomSecret=invite-123"),
+				options,
+			),
+		).toBe(true);
+		expect(
+			isAuthorizedBrowserRequest(
+				browserRequest("http://127.0.0.1:8787"),
+				new URL("http://127.0.0.1:8787/browser"),
+				options,
+			),
+		).toBe(false);
+		expect(
+			isAuthorizedBrowserRequest(
+				browserRequest("http://evil.attacker.example.com"),
+				new URL("http://127.0.0.1:8787/browser?roomSecret=invite-123"),
+				options,
+			),
+		).toBe(false);
+		expect(
+			isAuthorizedBrowserRequest(
+				browserRequest("http://127.0.0.1:8787", {
+					headers: { host: "evil.attacker.example.com" },
+				}),
+				new URL("http://127.0.0.1:8787/browser?roomSecret=invite-123"),
+				options,
+			),
+		).toBe(false);
+	});
+});
+
+describe("isAuthorizedBrowserToDesktopRequest", () => {
+	it("allows safe public GET routes without an origin", () => {
+		expect(
+			isAuthorizedBrowserToDesktopRequest(
+				new Request("http://127.0.0.1:8787/health"),
+				new URL("http://127.0.0.1:8787/health"),
+				defaultOptions,
+			),
+		).toBe(true);
+	});
+
+	it("rejects future WebSocket paths from untrusted origins by default", () => {
+		expect(
+			isAuthorizedBrowserToDesktopRequest(
+				new Request("http://127.0.0.1:8787/future-socket", {
+					headers: {
+						origin: "http://evil.attacker.example.com",
+						upgrade: "websocket",
+					},
+				}),
+				new URL("http://127.0.0.1:8787/future-socket"),
+				defaultOptions,
+			),
+		).toBe(false);
+	});
+
+	it("rejects future unsafe HTTP routes from untrusted origins by default", () => {
+		expect(
+			isAuthorizedBrowserToDesktopRequest(
+				new Request("http://127.0.0.1:8787/future-api", {
+					method: "POST",
+					headers: { origin: "http://evil.attacker.example.com" },
+				}),
+				new URL("http://127.0.0.1:8787/future-api"),
+				defaultOptions,
+			),
+		).toBe(false);
+	});
+
+	it("allows future unsafe HTTP routes from trusted origins", () => {
+		expect(
+			isAuthorizedBrowserToDesktopRequest(
+				new Request("http://127.0.0.1:8787/future-api", {
+					method: "POST",
+					headers: {
+						host: "127.0.0.1:8787",
+						origin: "http://127.0.0.1:8787",
+					},
+				}),
+				new URL("http://127.0.0.1:8787/future-api"),
+				defaultOptions,
+			),
+		).toBe(true);
+	});
+});

--- a/apps/cline-hub/src/server/browser-auth.test.ts
+++ b/apps/cline-hub/src/server/browser-auth.test.ts
@@ -53,15 +53,17 @@ describe("allowedBrowserOrigins", () => {
 		]);
 	});
 
-	it("only allows the configured public URL origin for non-local binds", () => {
-		expect([
-			...allowedBrowserOrigins({
-				bindHost: "0.0.0.0",
-				port: 8787,
-				publicUrl: "https://example.ngrok-free.app",
-				roomSecret: "secret",
-			}),
-		]).toEqual(["https://example.ngrok-free.app"]);
+	it("allows the configured public URL origin and explicit bind origin for non-local binds", () => {
+		expect(
+			[
+				...allowedBrowserOrigins({
+					bindHost: "0.0.0.0",
+					port: 8787,
+					publicUrl: "https://example.ngrok-free.app",
+					roomSecret: "secret",
+				}),
+			].sort(),
+		).toEqual(["https://0.0.0.0:8787", "https://example.ngrok-free.app"]);
 	});
 });
 
@@ -74,15 +76,17 @@ describe("allowedBrowserHosts", () => {
 		]);
 	});
 
-	it("only allows the configured public URL host for non-local binds", () => {
-		expect([
-			...allowedBrowserHosts({
-				bindHost: "0.0.0.0",
-				port: 8787,
-				publicUrl: "https://example.ngrok-free.app",
-				roomSecret: "secret",
-			}),
-		]).toEqual(["example.ngrok-free.app"]);
+	it("allows the configured public URL host and explicit bind host for non-local binds", () => {
+		expect(
+			[
+				...allowedBrowserHosts({
+					bindHost: "0.0.0.0",
+					port: 8787,
+					publicUrl: "https://example.ngrok-free.app",
+					roomSecret: "secret",
+				}),
+			].sort(),
+		).toEqual(["0.0.0.0:8787", "example.ngrok-free.app"]);
 	});
 });
 
@@ -175,6 +179,23 @@ describe("isAuthorizedBrowserRequest", () => {
 				defaultOptions,
 			),
 		).toBe(false);
+	});
+
+	it("allows explicit wildcard bind host and origin when a room secret is configured", () => {
+		expect(
+			isAuthorizedBrowserRequest(
+				browserRequest("http://0.0.0.0:8787", {
+					headers: { host: "0.0.0.0:8787" },
+				}),
+				new URL("http://0.0.0.0:8787/browser?roomSecret=invite-123"),
+				{
+					bindHost: "0.0.0.0",
+					port: 8787,
+					publicUrl: "http://127.0.0.1:8787",
+					roomSecret: "invite-123",
+				},
+			),
+		).toBe(true);
 	});
 
 	it("requires trusted origin, trusted host, and room secret when a room secret is configured", () => {

--- a/apps/cline-hub/src/server/browser-auth.test.ts
+++ b/apps/cline-hub/src/server/browser-auth.test.ts
@@ -38,6 +38,21 @@ describe("allowedBrowserOrigins", () => {
 		]);
 	});
 
+	it("uses the configured public URL scheme for local aliases", () => {
+		expect(
+			[
+				...allowedBrowserOrigins({
+					...defaultOptions,
+					publicUrl: "https://127.0.0.1:8787",
+				}),
+			].sort(),
+		).toEqual([
+			"https://127.0.0.1:8787",
+			"https://[::1]:8787",
+			"https://localhost:8787",
+		]);
+	});
+
 	it("only allows the configured public URL origin for non-local binds", () => {
 		expect([
 			...allowedBrowserOrigins({
@@ -214,6 +229,7 @@ describe("isAuthorizedBrowserToDesktopRequest", () => {
 			isAuthorizedBrowserToDesktopRequest(
 				new Request("http://127.0.0.1:8787/future-socket", {
 					headers: {
+						host: "127.0.0.1:8787",
 						origin: "http://evil.attacker.example.com",
 						upgrade: "websocket",
 					},
@@ -229,7 +245,10 @@ describe("isAuthorizedBrowserToDesktopRequest", () => {
 			isAuthorizedBrowserToDesktopRequest(
 				new Request("http://127.0.0.1:8787/future-api", {
 					method: "POST",
-					headers: { origin: "http://evil.attacker.example.com" },
+					headers: {
+						host: "127.0.0.1:8787",
+						origin: "http://evil.attacker.example.com",
+					},
 				}),
 				new URL("http://127.0.0.1:8787/future-api"),
 				defaultOptions,

--- a/apps/cline-hub/src/server/browser-auth.test.ts
+++ b/apps/cline-hub/src/server/browser-auth.test.ts
@@ -13,6 +13,8 @@ const defaultOptions = {
 	publicUrl: "http://127.0.0.1:8787",
 };
 
+const publicRoute = (_req: Request, url: URL) => url.pathname === "/public";
+
 function browserRequest(
 	origin?: string,
 	init?: Omit<RequestInit, "headers"> & {
@@ -91,13 +93,24 @@ describe("allowedBrowserHosts", () => {
 });
 
 describe("requiresBrowserRequestAuth", () => {
-	it("does not require browser auth for safe public GET routes", () => {
+	it("does not require browser auth for public GET routes", () => {
 		expect(
 			requiresBrowserRequestAuth(
-				new Request("http://127.0.0.1:8787/health"),
-				new URL("http://127.0.0.1:8787/health"),
+				new Request("http://127.0.0.1:8787/public"),
+				new URL("http://127.0.0.1:8787/public"),
+				publicRoute,
 			),
 		).toBe(false);
+	});
+
+	it("requires browser auth for unknown paths even when they use GET", () => {
+		expect(
+			requiresBrowserRequestAuth(
+				new Request("http://127.0.0.1:8787/future-api"),
+				new URL("http://127.0.0.1:8787/future-api"),
+				publicRoute,
+			),
+		).toBe(true);
 	});
 
 	it("requires browser auth for privileged paths even when they use GET", () => {
@@ -105,6 +118,7 @@ describe("requiresBrowserRequestAuth", () => {
 			requiresBrowserRequestAuth(
 				new Request("http://127.0.0.1:8787/browser"),
 				new URL("http://127.0.0.1:8787/browser"),
+				publicRoute,
 			),
 		).toBe(true);
 	});
@@ -116,6 +130,7 @@ describe("requiresBrowserRequestAuth", () => {
 					headers: { upgrade: "websocket" },
 				}),
 				new URL("http://127.0.0.1:8787/future-socket"),
+				publicRoute,
 			),
 		).toBe(true);
 	});
@@ -125,6 +140,7 @@ describe("requiresBrowserRequestAuth", () => {
 			requiresBrowserRequestAuth(
 				new Request("http://127.0.0.1:8787/future-api", { method: "POST" }),
 				new URL("http://127.0.0.1:8787/future-api"),
+				publicRoute,
 			),
 		).toBe(true);
 	});
@@ -238,9 +254,10 @@ describe("isAuthorizedBrowserToDesktopRequest", () => {
 	it("allows safe public GET routes without an origin", () => {
 		expect(
 			isAuthorizedBrowserToDesktopRequest(
-				new Request("http://127.0.0.1:8787/health"),
-				new URL("http://127.0.0.1:8787/health"),
+				new Request("http://127.0.0.1:8787/public"),
+				new URL("http://127.0.0.1:8787/public"),
 				defaultOptions,
+				publicRoute,
 			),
 		).toBe(true);
 	});
@@ -257,6 +274,7 @@ describe("isAuthorizedBrowserToDesktopRequest", () => {
 				}),
 				new URL("http://127.0.0.1:8787/future-socket"),
 				defaultOptions,
+				publicRoute,
 			),
 		).toBe(false);
 	});
@@ -273,6 +291,7 @@ describe("isAuthorizedBrowserToDesktopRequest", () => {
 				}),
 				new URL("http://127.0.0.1:8787/future-api"),
 				defaultOptions,
+				publicRoute,
 			),
 		).toBe(false);
 	});
@@ -289,6 +308,7 @@ describe("isAuthorizedBrowserToDesktopRequest", () => {
 				}),
 				new URL("http://127.0.0.1:8787/future-api"),
 				defaultOptions,
+				publicRoute,
 			),
 		).toBe(true);
 	});

--- a/apps/cline-hub/src/server/browser-auth.ts
+++ b/apps/cline-hub/src/server/browser-auth.ts
@@ -9,10 +9,7 @@ export interface BrowserRequestAuthOptions {
 
 const SAFE_HTTP_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
 
-// Browser-to-desktop routes must be origin-gated by default. This catches future
-// WebSocket endpoints and unsafe HTTP APIs automatically; add any privileged
-// safe-method paths here so they cannot bypass Origin/room-secret checks.
-const PRIVILEGED_BROWSER_PATHS = new Set(["/browser"]);
+export type PublicBrowserRoutePredicate = (req: Request, url: URL) => boolean;
 
 function isWebSocketUpgrade(req: Request): boolean {
 	return req.headers.get("upgrade")?.toLowerCase() === "websocket";
@@ -78,12 +75,14 @@ export function allowedBrowserHosts({
 	return hosts;
 }
 
-export function requiresBrowserRequestAuth(req: Request, url: URL): boolean {
-	return (
-		isWebSocketUpgrade(req) ||
-		!SAFE_HTTP_METHODS.has(req.method.toUpperCase()) ||
-		PRIVILEGED_BROWSER_PATHS.has(url.pathname)
-	);
+export function requiresBrowserRequestAuth(
+	req: Request,
+	url: URL,
+	isPublicBrowserRoute: PublicBrowserRoutePredicate,
+): boolean {
+	if (isWebSocketUpgrade(req)) return true;
+	if (!SAFE_HTTP_METHODS.has(req.method.toUpperCase())) return true;
+	return !isPublicBrowserRoute(req, url);
 }
 
 export function isAuthorizedBrowserRequest(
@@ -105,9 +104,10 @@ export function isAuthorizedBrowserToDesktopRequest(
 	req: Request,
 	url: URL,
 	options: BrowserRequestAuthOptions,
+	isPublicBrowserRoute: PublicBrowserRoutePredicate,
 ): boolean {
 	return (
-		!requiresBrowserRequestAuth(req, url) ||
+		!requiresBrowserRequestAuth(req, url, isPublicBrowserRoute) ||
 		isAuthorizedBrowserRequest(req, url, options)
 	);
 }

--- a/apps/cline-hub/src/server/browser-auth.ts
+++ b/apps/cline-hub/src/server/browser-auth.ts
@@ -1,0 +1,102 @@
+import { isNonLocalBindHost } from "../options";
+
+export interface BrowserRequestAuthOptions {
+	bindHost: string;
+	port: number;
+	publicUrl: string;
+	roomSecret?: string;
+}
+
+const SAFE_HTTP_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+
+// Browser-to-desktop routes must be origin-gated by default. This catches future
+// WebSocket endpoints and unsafe HTTP APIs automatically; add any privileged
+// safe-method paths here so they cannot bypass Origin/room-secret checks.
+const PRIVILEGED_BROWSER_PATHS = new Set(["/browser"]);
+
+function isWebSocketUpgrade(req: Request): boolean {
+	return req.headers.get("upgrade")?.toLowerCase() === "websocket";
+}
+
+function parseOrigin(value: string | null): string | undefined {
+	const origin = parseHeader(value);
+	try {
+		return new URL(origin ?? "").origin;
+	} catch {
+		return undefined;
+	}
+}
+
+function parseHeader(value: string | null): string | undefined {
+	const host = value?.trim().toLowerCase();
+	return host || undefined;
+}
+
+export function allowedBrowserOrigins({
+	bindHost,
+	port,
+	publicUrl,
+}: BrowserRequestAuthOptions): Set<string> {
+	const origins = new Set<string>();
+	origins.add(new URL(publicUrl).origin);
+
+	if (!isNonLocalBindHost(bindHost)) {
+		for (const hostname of ["127.0.0.1", "localhost", "[::1]"]) {
+			origins.add(`http://${hostname}:${port}`);
+		}
+	}
+
+	return origins;
+}
+
+export function allowedBrowserHosts({
+	bindHost,
+	port,
+	publicUrl,
+}: BrowserRequestAuthOptions): Set<string> {
+	const hosts = new Set<string>();
+	const publicHost = new URL(publicUrl).host.toLowerCase();
+	hosts.add(publicHost);
+
+	if (!isNonLocalBindHost(bindHost)) {
+		for (const hostname of ["127.0.0.1", "localhost", "[::1]"]) {
+			hosts.add(`${hostname}:${port}`);
+		}
+	}
+
+	return hosts;
+}
+
+export function requiresBrowserRequestAuth(req: Request, url: URL): boolean {
+	return (
+		isWebSocketUpgrade(req) ||
+		!SAFE_HTTP_METHODS.has(req.method.toUpperCase()) ||
+		PRIVILEGED_BROWSER_PATHS.has(url.pathname)
+	);
+}
+
+export function isAuthorizedBrowserRequest(
+	req: Request,
+	url: URL,
+	options: BrowserRequestAuthOptions,
+): boolean {
+	const host = parseHeader(req.headers.get("host"));
+	if (!host || !allowedBrowserHosts(options).has(host)) return false;
+
+	const origin = parseOrigin(req.headers.get("origin"));
+	if (!origin || !allowedBrowserOrigins(options).has(origin)) return false;
+
+	if (!options.roomSecret) return true;
+	return url.searchParams.get("roomSecret") === options.roomSecret;
+}
+
+export function isAuthorizedBrowserToDesktopRequest(
+	req: Request,
+	url: URL,
+	options: BrowserRequestAuthOptions,
+): boolean {
+	return (
+		!requiresBrowserRequestAuth(req, url) ||
+		isAuthorizedBrowserRequest(req, url, options)
+	);
+}

--- a/apps/cline-hub/src/server/browser-auth.ts
+++ b/apps/cline-hub/src/server/browser-auth.ts
@@ -37,12 +37,13 @@ export function allowedBrowserOrigins({
 	port,
 	publicUrl,
 }: BrowserRequestAuthOptions): Set<string> {
+	const publicUrlParts = new URL(publicUrl);
 	const origins = new Set<string>();
-	origins.add(new URL(publicUrl).origin);
+	origins.add(publicUrlParts.origin);
 
 	if (!isNonLocalBindHost(bindHost)) {
 		for (const hostname of ["127.0.0.1", "localhost", "[::1]"]) {
-			origins.add(`http://${hostname}:${port}`);
+			origins.add(`${publicUrlParts.protocol}//${hostname}:${port}`);
 		}
 	}
 

--- a/apps/cline-hub/src/server/browser-auth.ts
+++ b/apps/cline-hub/src/server/browser-auth.ts
@@ -33,6 +33,28 @@ function formatHostForOrigin(host: string): string {
 	return host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
 }
 
+function isDefaultProtocolPort(protocol: string, port: number): boolean {
+	return (
+		(protocol === "http:" && port === 80) ||
+		(protocol === "https:" && port === 443)
+	);
+}
+
+function originForHost(protocol: string, host: string, port: number): string {
+	return new URL(`${protocol}//${formatHostForOrigin(host)}:${port}`).origin;
+}
+
+function hostHeaderForHost(
+	protocol: string,
+	host: string,
+	port: number,
+): string {
+	const formattedHost = formatHostForOrigin(host).toLowerCase();
+	return isDefaultProtocolPort(protocol, port)
+		? formattedHost
+		: `${formattedHost}:${port}`;
+}
+
 export function allowedBrowserOrigins({
 	bindHost,
 	port,
@@ -42,13 +64,11 @@ export function allowedBrowserOrigins({
 	const origins = new Set<string>();
 	origins.add(publicUrlParts.origin);
 
-	origins.add(
-		`${publicUrlParts.protocol}//${formatHostForOrigin(bindHost)}:${port}`,
-	);
+	origins.add(originForHost(publicUrlParts.protocol, bindHost, port));
 
 	if (!isNonLocalBindHost(bindHost)) {
 		for (const hostname of ["127.0.0.1", "localhost", "[::1]"]) {
-			origins.add(`${publicUrlParts.protocol}//${hostname}:${port}`);
+			origins.add(originForHost(publicUrlParts.protocol, hostname, port));
 		}
 	}
 
@@ -60,15 +80,16 @@ export function allowedBrowserHosts({
 	port,
 	publicUrl,
 }: BrowserRequestAuthOptions): Set<string> {
+	const publicUrlParts = new URL(publicUrl);
 	const hosts = new Set<string>();
-	const publicHost = new URL(publicUrl).host.toLowerCase();
+	const publicHost = publicUrlParts.host.toLowerCase();
 	hosts.add(publicHost);
 
-	hosts.add(`${formatHostForOrigin(bindHost)}:${port}`);
+	hosts.add(hostHeaderForHost(publicUrlParts.protocol, bindHost, port));
 
 	if (!isNonLocalBindHost(bindHost)) {
 		for (const hostname of ["127.0.0.1", "localhost", "[::1]"]) {
-			hosts.add(`${hostname}:${port}`);
+			hosts.add(hostHeaderForHost(publicUrlParts.protocol, hostname, port));
 		}
 	}
 

--- a/apps/cline-hub/src/server/browser-auth.ts
+++ b/apps/cline-hub/src/server/browser-auth.ts
@@ -32,6 +32,10 @@ function parseHeader(value: string | null): string | undefined {
 	return host || undefined;
 }
 
+function formatHostForOrigin(host: string): string {
+	return host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
+}
+
 export function allowedBrowserOrigins({
 	bindHost,
 	port,
@@ -40,6 +44,10 @@ export function allowedBrowserOrigins({
 	const publicUrlParts = new URL(publicUrl);
 	const origins = new Set<string>();
 	origins.add(publicUrlParts.origin);
+
+	origins.add(
+		`${publicUrlParts.protocol}//${formatHostForOrigin(bindHost)}:${port}`,
+	);
 
 	if (!isNonLocalBindHost(bindHost)) {
 		for (const hostname of ["127.0.0.1", "localhost", "[::1]"]) {
@@ -58,6 +66,8 @@ export function allowedBrowserHosts({
 	const hosts = new Set<string>();
 	const publicHost = new URL(publicUrl).host.toLowerCase();
 	hosts.add(publicHost);
+
+	hosts.add(`${formatHostForOrigin(bindHost)}:${port}`);
 
 	if (!isNonLocalBindHost(bindHost)) {
 		for (const hostname of ["127.0.0.1", "localhost", "[::1]"]) {

--- a/apps/cline-hub/src/validate-options.ts
+++ b/apps/cline-hub/src/validate-options.ts
@@ -41,6 +41,23 @@ expectEqual(
 	"invite URL",
 );
 
+const tailscale = resolveClineHubServerOptions({
+	HOST: "0.0.0.0",
+	CLINE_HUB_DASHBOARD_PORT: "8787",
+	PUBLIC_URL: "http://100.82.5.118",
+	ROOM_SECRET: "invite-123",
+});
+expectEqual(
+	tailscale.publicUrl,
+	"http://100.82.5.118:8787",
+	"direct IP public URL gets dashboard port",
+);
+expectEqual(
+	buildInviteUrl(tailscale.publicUrl, tailscale.roomSecret),
+	"http://100.82.5.118:8787/?roomSecret=invite-123",
+	"invite URL for direct IP public URL",
+);
+
 expectThrows(
 	() => resolveClineHubServerOptions({ HOST: "0.0.0.0" }),
 	"non-local bind without ROOM_SECRET",


### PR DESCRIPTION
### Related Issue

**Issue:** [SEC-95](https://linear.app/cline-bot/issue/SEC-95)

### Description

This fixes the Cline Hub dashboard `/browser` WebSocket CSWSH issue reported in SEC-95 by requiring privileged browser-to-desktop requests to come from the expected dashboard host and origin before the server accepts the WebSocket upgrade.

The new shared browser auth helper:

- gates `/browser`, all WebSocket upgrades, and unsafe HTTP methods through the same browser-to-desktop authorization path
- validates the `Origin` header against the configured dashboard origin
- validates the `Host` header against the configured dashboard host/local aliases
- still requires `roomSecret` when `ROOM_SECRET` is configured
- keeps safe public GET routes like `/health`, `/version`, `/config.json`, and static assets accessible without an origin requirement

#### Compatibility implications

This intentionally stops several previously accepted access patterns:

- arbitrary websites can no longer connect to `ws://127.0.0.1:8787/browser`
- WebSocket clients without an `Origin` header are rejected for `/browser`
- requests with a trusted room secret but an untrusted `Origin` or `Host` are rejected
- dashboard access through unlisted aliases such as `http://127.0.0.1:9000`, `http://0.0.0.0:8787`, `http://192.168.x.x:8787`, or custom local hostnames will not be allowed to drive the privileged socket unless they match the configured policy
- public/tunnel setups must load the dashboard from `PUBLIC_URL`; direct access through a different local/LAN origin will not be allowed to use `/browser`

Normal local dashboard use through `http://127.0.0.1:8787`, `http://localhost:8787`, or `http://[::1]:8787` continues to work.

#### Relationship to the Kanban fix

This follows the same general hardening pattern used in Kanban's WebSocket service fix: enforce known `Host`/`Origin` policy before accepting privileged WebSocket upgrades.

References:

- Kanban PR: https://github.com/cline/kanban/pull/421
- Dev-origin follow-up: https://github.com/cline/kanban/pull/432

Similarities:

- validates known hosts before accepting privileged browser-to-desktop traffic
- validates origins before privileged WebSocket upgrade handling
- rejects wrong host, wrong origin, wrong port, and wrong scheme cases
- adds unit coverage for the policy matrix

Differences:

- Cline Hub keeps a stricter policy for `/browser`: missing `Origin` is rejected, whereas the Kanban middleware allows requests with no `Origin` and rejects only explicit foreign origins
- Cline Hub does not add CORS preflight support because the dashboard is expected to be same-origin with the Hub server
- Cline Hub uses Bun's `fetch`/`server.upgrade(...)` flow, so rejected upgrades return a normal `403` response instead of writing directly to a raw Node socket
- Cline Hub continues to enforce `ROOM_SECRET` for configured remote/public use in addition to host/origin checks

### Test Procedure

Ran the Cline Hub test suite and typecheck:

```bash
bun -F @cline/cline-hub test
bun -F @cline/cline-hub typecheck
```

Results:

- `5` test files passed
- `81` tests passed
- typecheck passed

Manual verification approach:

1. Start Cline Hub locally with no `ROOM_SECRET`.
2. From a separate attacker origin such as `http://127.0.0.1:9000`, attempt `new WebSocket("ws://127.0.0.1:8787/browser")`.
3. Verify the fixed server rejects the connection.
4. Open the real dashboard at `http://127.0.0.1:8787` and verify it still connects normally.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — backend security fix for WebSocket upgrade authorization.

### Additional Notes

Security-sensitive compatibility note: custom `/browser` WebSocket clients must now send a trusted `Origin` header and use an allowed `Host`; if `ROOM_SECRET` is configured, they must also include the matching `roomSecret` query parameter.
