### PR TITLE
Forcefully send users to their personal dashboard when going to subscribe

### DIFF
--- a/apps/cli/src/runtime/run-agent.test.ts
+++ b/apps/cli/src/runtime/run-agent.test.ts
@@ -38,7 +38,7 @@ const sessionEventsMocks = vi.hoisted(() => ({
 }));
 
 const CLINE_PASS_SUBSCRIPTION_URL =
-	"https://app.cline.bot/dashboard/subscription/";
+	"https://app.cline.bot/dashboard/subscription?personal=true";
 const CLINE_PASS_SUBSCRIPTION_MESSAGE = `No access to ClinePass subscription models yet. Subscribe to ClinePass, the low cost open weights model coding plan: ${CLINE_PASS_SUBSCRIPTION_URL}`;
 
 vi.mock("@cline/core", () => ({

--- a/apps/cli/src/utils/cline-pass-errors.test.ts
+++ b/apps/cli/src/utils/cline-pass-errors.test.ts
@@ -20,7 +20,7 @@ describe("cline-pass-errors", () => {
 
 	it("formats the ClinePass subscription URL", () => {
 		expect(getClinePassSubscriptionUrl()).toBe(
-			"https://app.cline.bot/dashboard/subscription/",
+			"https://app.cline.bot/dashboard/subscription?personal=true",
 		);
 	});
 });

--- a/apps/vscode/webview-ui/src/components/chat/EntitlementError.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/EntitlementError.test.tsx
@@ -48,14 +48,14 @@ describe("EntitlementError", () => {
 	it("builds the subscribe link from the authenticated user's app base URL", () => {
 		mockAuth.clineUser = { appBaseUrl: "https://staging-app.cline.bot" }
 		const { unmount } = render(<EntitlementError />)
-		expect(getSubscribeHref()).toBe("https://staging-app.cline.bot/dashboard/subscription")
+		expect(getSubscribeHref()).toBe("https://staging-app.cline.bot/dashboard/subscription?personal=true")
 		unmount()
 
 		mockAuth.clineUser = {
 			appBaseUrl: "https://proxy.enterprise.com/cline/app",
 		}
 		render(<EntitlementError />)
-		expect(getSubscribeHref()).toBe("https://proxy.enterprise.com/cline/app/dashboard/subscription")
+		expect(getSubscribeHref()).toBe("https://proxy.enterprise.com/cline/app/dashboard/subscription?personal=true")
 	})
 
 	it("sends a yesButtonClicked askResponse when Retry Request is clicked", () => {

--- a/apps/vscode/webview-ui/src/components/chat/EntitlementError.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/EntitlementError.tsx
@@ -20,7 +20,9 @@ function buildSubscribeUrl(appBaseUrl?: string): string | undefined {
 	}
 	try {
 		const base = appBaseUrl.endsWith("/") ? appBaseUrl : `${appBaseUrl}/`
-		return new URL(CLINE_PASS_SUBSCRIBE_PATH, base).toString()
+		const url = new URL(CLINE_PASS_SUBSCRIBE_PATH, base)
+		url.searchParams.set("personal", "true")
+		return url.toString()
 	} catch {
 		// Malformed appBaseUrl: omit the link rather than crashing the error card.
 		return undefined

--- a/sdk/packages/llms/src/providers/errors.ts
+++ b/sdk/packages/llms/src/providers/errors.ts
@@ -5,7 +5,7 @@ export const CLINE_NOT_SUBSCRIBED_RESPONSE_MESSAGE =
 
 export function getClinePassSubscriptionUrl(): string {
 	return `${new URL(
-		"/dashboard/subscription",
+		"/dashboard/subscription?personal=true",
 		getClineEnvironmentConfig().appBaseUrl,
 	).toString()}/`;
 }

--- a/sdk/packages/llms/src/providers/errors.ts
+++ b/sdk/packages/llms/src/providers/errors.ts
@@ -7,7 +7,7 @@ export function getClinePassSubscriptionUrl(): string {
 	return `${new URL(
 		"/dashboard/subscription?personal=true",
 		getClineEnvironmentConfig().appBaseUrl,
-	).toString()}/`;
+	).toString()}`;
 }
 
 export function getClineNotSubscribedMessage(): string {


### PR DESCRIPTION
We need users to land in their personal page, even if they're on an org dashboard.