### PR TITLE
fix: prevent 'ERROR: EMPTY CONTENT' message when error occurs

### DIFF
--- a/sdk/packages/agents/src/agent-runtime.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.test.ts
@@ -68,6 +68,41 @@ describe("AgentRuntime", () => {
 		expect(model.requests).toHaveLength(1);
 	});
 
+	it("does not persist an empty assistant message when the model stream fails", async () => {
+		const model = new ScriptedModel([
+			() => [{ type: "finish", reason: "error", error: "upstream failed" }],
+		]);
+		const addedMessages: AgentMessage[] = [];
+		const runtime = new AgentRuntime({ model });
+		runtime.subscribe((event) => {
+			if (event.type === "message-added") {
+				addedMessages.push(event.message);
+			}
+		});
+
+		const result = await runtime.run("Hi");
+
+		expect(result.status).toBe("failed");
+		expect(result.error?.message).toBe("upstream failed");
+		expect(result.messages).toHaveLength(1);
+		expect(result.messages[0]?.role).toBe("user");
+		expect(addedMessages.map((message) => message.role)).toEqual(["user"]);
+	});
+
+	it("does not complete or persist history when the model returns no content", async () => {
+		const model = new ScriptedModel([
+			() => [{ type: "finish", reason: "stop" }],
+		]);
+		const runtime = new AgentRuntime({ model });
+
+		const result = await runtime.run("Hi");
+
+		expect(result.status).toBe("failed");
+		expect(result.error?.message).toBe("Model returned empty response");
+		expect(result.messages).toHaveLength(1);
+		expect(result.messages[0]?.role).toBe("user");
+	});
+
 	it("executes a tool call and continues the loop", async () => {
 		const model = new ScriptedModel([
 			() => [

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -597,10 +597,6 @@ export class AgentRuntime {
 				if (finishReason === "aborted") {
 					throw this.normalizeAbortError();
 				}
-				const toolCalls = message.content.filter(
-					(part: AgentMessagePart): part is AgentToolCallPart =>
-						part.type === "tool-call",
-				);
 				if (message.content.length === 0) {
 					throw new Error(
 						finishReason === "error"
@@ -608,6 +604,10 @@ export class AgentRuntime {
 							: "Model returned empty response",
 					);
 				}
+				const toolCalls = message.content.filter(
+					(part: AgentMessagePart): part is AgentToolCallPart =>
+						part.type === "tool-call",
+				);
 
 				finalAssistantMessage = message;
 				this.state.messages.push(message);

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -594,6 +594,21 @@ export class AgentRuntime {
 				});
 
 				const { message, finishReason } = await this.generateAssistantMessage();
+				if (finishReason === "aborted") {
+					throw this.normalizeAbortError();
+				}
+				const toolCalls = message.content.filter(
+					(part: AgentMessagePart): part is AgentToolCallPart =>
+						part.type === "tool-call",
+				);
+				if (message.content.length === 0) {
+					throw new Error(
+						finishReason === "error"
+							? (this.state.lastError ?? "Model stream failed")
+							: "Model returned empty response",
+					);
+				}
+
 				finalAssistantMessage = message;
 				this.state.messages.push(message);
 				await this.emit({
@@ -609,14 +624,6 @@ export class AgentRuntime {
 					finishReason,
 				});
 
-				if (finishReason === "aborted") {
-					throw this.normalizeAbortError();
-				}
-
-				const toolCalls = message.content.filter(
-					(part: AgentMessagePart): part is AgentToolCallPart =>
-						part.type === "tool-call",
-				);
 				if (finishReason === "error" && toolCalls.length === 0) {
 					throw new Error(this.state.lastError ?? "Model stream failed");
 				}

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
@@ -14,17 +14,23 @@
  *  - `canStartRun` / `shutdown` guards enforce the lifecycle rules.
  */
 
-import type { AgentRuntime, AgentRuntimeConfig } from "@cline/agents";
-import type {
-	AgentConfig,
-	AgentEvent,
-	AgentExtension,
-	AgentExtensionContext,
-	AgentMessage,
-	AgentRunResult,
-	AgentRuntimeEvent,
-	AgentTool,
-	AgentToolContext,
+import {
+	type AgentRuntime,
+	type AgentRuntimeConfig,
+	createAgentRuntime,
+} from "@cline/agents";
+import {
+	type AgentConfig,
+	type AgentEvent,
+	type AgentExtension,
+	type AgentExtensionContext,
+	type AgentMessage,
+	type AgentModel,
+	type AgentRunResult,
+	type AgentRuntimeEvent,
+	type AgentTool,
+	type AgentToolContext,
+	EMPTY_CONTENT_TEXT,
 } from "@cline/shared";
 import { describe, expect, it, vi } from "vitest";
 import { CLINE_INTERNAL_TELEMETRY_METADATA_KEY } from "../../services/telemetry/tool-context";
@@ -1226,6 +1232,69 @@ describe("SessionRuntime.addTools / updateConnection / clearHistory / restore", 
 		expect(messages).toHaveLength(2);
 		expect(messages[0].role).toBe("user");
 		expect(messages[1].role).toBe("assistant");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// real AgentRuntime smoke
+// ---------------------------------------------------------------------------
+
+describe("SessionRuntime real AgentRuntime smoke", () => {
+	it("does not replay ERROR: EMPTY CONTENT after an empty upstream failure", async () => {
+		const modelRequests: AgentMessage[][] = [];
+		const scriptedModel: AgentModel = {
+			async stream(request) {
+				modelRequests.push(request.messages.map((message) => ({ ...message })));
+				const turn = modelRequests.length;
+
+				return (async function* () {
+					if (turn === 1) {
+						yield {
+							type: "finish" as const,
+							reason: "error" as const,
+							error: "upstream failed",
+						};
+						return;
+					}
+					yield { type: "text-delta" as const, text: "second ok" };
+					yield { type: "finish" as const, reason: "stop" as const };
+				})();
+			},
+		};
+		const session = new SessionRuntime(
+			makeAgentConfig({
+				providerId: "cline",
+				modelId: "openai/gpt-5.5",
+				apiKey: "test-key",
+			}),
+			{
+				createAgentRuntimeImpl: (config) =>
+					createAgentRuntime({ ...config, model: scriptedModel }),
+			},
+		);
+
+		const first = await session.run("first");
+		expect(first.finishReason).toBe("error");
+		expect(first.text).toBe("upstream failed");
+		expect(session.getMessages().map((message) => message.role)).toEqual([
+			"user",
+		]);
+
+		const second = await session.continue("second");
+		expect(second.finishReason).toBe("completed");
+		expect(second.text).toBe("second ok");
+		expect(modelRequests).toHaveLength(2);
+		expect(
+			modelRequests[1]?.some((message) =>
+				message.content.some(
+					(part) => part.type === "text" && part.text === EMPTY_CONTENT_TEXT,
+				),
+			),
+		).toBe(false);
+		expect(modelRequests[1]?.map((message) => message.role)).toEqual([
+			"user",
+			"user",
+		]);
 	});
 });
 


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This fixes a CLI/runtime history poisoning bug where an empty assistant turn could be persisted and later replayed to the model as the literal sentinel text `ERROR: EMPTY CONTENT`.

The sentinel itself is produced intentionally by the AI SDK formatter when it receives malformed blank message history. The problem here was earlier in the runtime: if a provider/model stream finished without emitting any assistant text, reasoning, or tool call, `AgentRuntime` still created and persisted an assistant message with `content: []`. On the next turn, that invalid assistant history entry flowed through the formatter, got rewritten to `ERROR: EMPTY CONTENT`, and could then show up in the model context/user-visible output.

This is especially visible with `apps/cli` using the Cline provider and `openai/gpt-5.5`, where users reported the issue happening intermittently. The behavior is intermittent because the bad empty message is created on one turn, then only becomes visible when a later request replays history.

The fix is intentionally narrow: `AgentRuntime` now rejects truly empty assistant turns before they are emitted or persisted. If the stream finished with `finish:error`, the runtime fails with the upstream provider error. If it finished nominally but produced no content at all, it fails with `Model returned empty response`. Tool-call-only turns remain valid, because tool calls are meaningful assistant content in this runtime contract. Partial content from an errored stream is also still preserved as before.

Debugging notes:

- The visible string came from `sdk/packages/shared/src/llms/ai-sdk-format.ts`, not directly from OpenAI/Cline upstream.
- The formatter is still useful as a defensive sanitizer for already-malformed/legacy blank history.
- The actual new-history bug was in `sdk/packages/agents/src/agent-runtime.ts`, where the assistant message was pushed and emitted before the error/no-content condition was handled.
- A core-level smoke test initially failed until `@cline/agents` was rebuilt, because `@cline/core` resolves `@cline/agents` through package `dist` in this workspace. After rebuilding, the smoke validated the patched runtime path.

### Test Procedure

I tested this at three levels:

1. Focused agent runtime regression tests:
   - `bun -F @cline/agents test -- src/agent-runtime.test.ts`
   - Covers `finish:error` with no content and `finish:stop` with no content.
   - Verifies the failed run keeps only the user message and does not emit/persist an empty assistant message.

2. Session/core smoke test:
   - `bun -F @cline/agents build`
   - `bun -F @cline/core test:unit -- src/runtime/orchestration/session-runtime-orchestrator.test.ts`
   - The new smoke test runs `SessionRuntime` with the real `AgentRuntime`, simulates `providerId: "cline"` and `modelId: "openai/gpt-5.5"`, makes the first turn fail with an empty upstream response, then continues the same session.
   - It asserts the second model request does not contain `ERROR: EMPTY CONTENT`, which directly exercises the reported replay failure mode.

3. Existing formatter and quality checks:
   - `bun -F @cline/shared test:unit -- src/llms/ai-sdk-format.test.ts`
   - `bun -F @cline/agents typecheck`
   - `bun -F @cline/core typecheck`
   - `bun biome check --diagnostic-level=error sdk/packages/agents/src/agent-runtime.ts sdk/packages/agents/src/agent-runtime.test.ts sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts`

Potentially affected behavior: any provider that returns an entirely empty assistant turn will now surface a failed model turn instead of silently adding an empty assistant message to history. That is intentional because the old behavior produced invalid replay state. Normal text, reasoning, and tool-call turns are unchanged.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. This is a runtime/history handling fix with no UI changes.

### Additional Notes

There is no linked issue number in the current context, so the template placeholder remains as `#XXXX`.
