### PR TITLE
test(vscode): fix auth-service test mocks broken by feature-flag change

### DIFF
--- a/apps/vscode/src/sdk/auth-service.test.ts
+++ b/apps/vscode/src/sdk/auth-service.test.ts
@@ -476,7 +476,7 @@ describe("AuthService", () => {
 	describe("streaming subscriptions", () => {
 		it("subscribeToAuthStatusUpdate pushes initial state immediately", async () => {
 			const mockResponseStream = vi.fn()
-			const mockController = { postStateToWebview: vi.fn() }
+			const mockController = { postStateToWebview: vi.fn(), invalidateProviderListings: vi.fn() }
 
 			await authService.subscribeToAuthStatusUpdate(
 				// biome-ignore lint/suspicious/noExplicitAny: mock controller for testing
@@ -500,7 +500,7 @@ describe("AuthService", () => {
 			testAccess(authService)._authenticated = true
 
 			const mockResponseStream = vi.fn().mockResolvedValue(undefined)
-			const mockController = { postStateToWebview: vi.fn() }
+			const mockController = { postStateToWebview: vi.fn(), invalidateProviderListings: vi.fn() }
 
 			await authService.subscribeToAuthStatusUpdate(
 				// biome-ignore lint/suspicious/noExplicitAny: mock controller for testing
@@ -522,7 +522,7 @@ describe("AuthService", () => {
 
 		it("removes subscription on cleanup", async () => {
 			const mockResponseStream = vi.fn().mockResolvedValue(undefined)
-			const mockController = { postStateToWebview: vi.fn() }
+			const mockController = { postStateToWebview: vi.fn(), invalidateProviderListings: vi.fn() }
 
 			await authService.subscribeToAuthStatusUpdate(
 				// biome-ignore lint/suspicious/noExplicitAny: mock controller for testing


### PR DESCRIPTION
### Related Issue

N/A — fixes a test failure introduced by #11720 that is blocking the nightly publish.

### Description

The nightly publish (`ext-vscode-publish-nightly`) is failing in the `vscode test` job on two tests in `src/sdk/auth-service.test.ts > AuthService > streaming subscriptions`:

```
× polls feature flags with the authenticated user before posting state
    AssertionError: expected "vi.fn()" to be called at least once
× removes subscription on cleanup
    AssertionError: expected +0 to be 1
```

**Root cause:** #11720 ("Fix Feature Flag resolution on startup") added a `controller.invalidateProviderListings()` call to `AuthService.sendAuthStatusUpdate()`:

```js
await featureFlagsService.poll(userId)
for (const controller of uniqueControllers) {
    controller.invalidateProviderListings()   // <-- new
}
await Promise.all(Array.from(uniqueControllers).map((c) => c.postStateToWebview()))
```

…but the test's mock controllers were only `{ postStateToWebview: vi.fn() }`. The new call throws `TypeError: controller.invalidateProviderListings is not a function` on the mock, which:

- happens *after* the feature-flag poll but *before* `postStateToWebview`, so `postStateToWebview` is never called → "polls feature flags…" assertion fails; and
- propagates into `subscribeToAuthStatusUpdate`'s `catch`, which deletes the handler → the handler set is empty → "removes subscription on cleanup" sees size 0 instead of 1.

`invalidateProviderListings` is a real method (`SdkController.ts:509`, `model-catalog/contracts.ts:391`), so the mocks were simply out of date. Fix adds `invalidateProviderListings: vi.fn()` to the three mock controllers in that describe block.

### Test Procedure

- `npx vitest run src/sdk/auth-service.test.ts` → **27/27 passed** (was 2 failing).
- Change is test-only; no production code touched.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore
-   [x] Tests are passing (`bun test`) and code is formatted and linted

### Additional Notes

Targeting `dpc/sdk-migration-simpler-login` since that's the branch nightlies publish from during the SDK migration.
