### PR TITLE
fix(hub-ui): Use development mode conditionally for connector

### DIFF
--- a/apps/cline-hub/src/server/connectors.test.ts
+++ b/apps/cline-hub/src/server/connectors.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { __test__ } from "./connectors";
+
+describe("connector launch command", () => {
+	it("uses Bun conditions when launching the source CLI from Bun", () => {
+		expect(
+			__test__.buildCliConnectCommand(["telegram", "--bot-token", "token"], {
+				execPath: "/Users/test/.bun/bin/bun",
+				cliPath: "/repo/apps/cli/src/index.ts",
+				exists: () => true,
+			}),
+		).toEqual({
+			launcher: "/Users/test/.bun/bin/bun",
+			childArgs: [
+				"--conditions=development",
+				"/repo/apps/cli/src/index.ts",
+				"connect",
+				"telegram",
+				"--bot-token",
+				"token",
+			],
+		});
+	});
+
+	it("uses compiled CLI subcommands without Bun flags", () => {
+		expect(
+			__test__.buildCliConnectCommand(["telegram", "--bot-token", "token"], {
+				execPath: "/Applications/Cline/bin/cline",
+				cliPath: "/repo/apps/cli/src/index.ts",
+				exists: () => true,
+			}),
+		).toEqual({
+			launcher: "/Applications/Cline/bin/cline",
+			childArgs: ["connect", "telegram", "--bot-token", "token"],
+		});
+	});
+
+	it("strips terminal color codes from connector command failures", () => {
+		expect(
+			__test__.normalizeConnectorError(
+				"\u001B[31merror:\u001B[0m error: unknown option '--conditions=development'",
+				"connector start failed",
+			),
+		).toBe("unknown option '--conditions=development'");
+	});
+
+	it("turns Telegram unauthorized responses into a token validation message", () => {
+		expect(
+			__test__.normalizeConnectorError(
+				"\u001B[31merror:\u001B[0m Telegram getMe failed (401 Unauthorized): Unauthorized",
+				"connector start failed",
+			),
+		).toBe(
+			"Telegram rejected this bot token. Copy the token from @BotFather and try again.",
+		);
+	});
+});

--- a/apps/cline-hub/src/server/connectors.test.ts
+++ b/apps/cline-hub/src/server/connectors.test.ts
@@ -35,6 +35,46 @@ describe("connector launch command", () => {
 		});
 	});
 
+	it("uses Bun conditions when launching the source CLI from Node", () => {
+		expect(
+			__test__.buildCliConnectCommand(["telegram", "--bot-token", "token"], {
+				execPath: "/usr/local/bin/node",
+				cliPath: "/repo/apps/cli/src/index.ts",
+				exists: () => true,
+			}),
+		).toEqual({
+			launcher: "bun",
+			childArgs: [
+				"--conditions=development",
+				"/repo/apps/cli/src/index.ts",
+				"connect",
+				"telegram",
+				"--bot-token",
+				"token",
+			],
+		});
+	});
+
+	it("detects Windows Node when launching the source CLI", () => {
+		expect(
+			__test__.buildCliConnectCommand(["telegram", "--bot-token", "token"], {
+				execPath: "node.exe",
+				cliPath: "C:\\repo\\apps\\cli\\src\\index.ts",
+				exists: () => true,
+			}),
+		).toEqual({
+			launcher: "bun",
+			childArgs: [
+				"--conditions=development",
+				"C:\\repo\\apps\\cli\\src\\index.ts",
+				"connect",
+				"telegram",
+				"--bot-token",
+				"token",
+			],
+		});
+	});
+
 	it("strips terminal color codes from connector command failures", () => {
 		expect(
 			__test__.normalizeConnectorError(

--- a/apps/cline-hub/src/server/connectors.ts
+++ b/apps/cline-hub/src/server/connectors.ts
@@ -64,7 +64,7 @@ function buildCliConnectCommand(
 	const exists = options.exists ?? existsSync;
 	const runtimeName = basename(execPath).toLowerCase();
 	const isBunRuntime = runtimeName.includes("bun");
-	const isNodeRuntime = runtimeName === "node";
+	const isNodeRuntime = runtimeName === "node" || runtimeName === "node.exe";
 	const useBunSourceEntrypoint =
 		(isBunRuntime || isNodeRuntime) && exists(cliPath);
 	const launcher = isBunRuntime

--- a/apps/cline-hub/src/server/connectors.ts
+++ b/apps/cline-hub/src/server/connectors.ts
@@ -1,5 +1,8 @@
 import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { basename } from "node:path";
 import process from "node:process";
+import { withResolvedClineBuildEnv } from "@cline/shared";
 import { listConnectorCatalog } from "../../../cli/src/connectors/catalog";
 import { listActiveConnectors } from "../../../cli/src/connectors/status";
 import {
@@ -12,6 +15,68 @@ import type {
 } from "../webview-protocol";
 import { cliIndexPath, workspaceRoot } from "./deps";
 import { asRecord, asString } from "./utils";
+
+type CliConnectCommand = {
+	launcher: string;
+	childArgs: string[];
+};
+
+const ANSI_ESCAPE_PATTERN = new RegExp(
+	[
+		"[\\u001B\\u009B][[\\]()#;?]*",
+		"(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\\u0007)",
+		"|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-nq-uy=><~]))",
+	].join(""),
+	"g",
+);
+
+function stripAnsi(value: string): string {
+	return value.replace(ANSI_ESCAPE_PATTERN, "");
+}
+
+function normalizeConnectorError(rawMessage: string, fallback: string): string {
+	const message =
+		stripAnsi(rawMessage)
+			.replace(/\r\n/g, "\n")
+			.trim()
+			.replace(/^(?:error:\s*)+/i, "")
+			.trim() || fallback;
+
+	if (
+		/^Telegram getMe failed \(401 Unauthorized\): Unauthorized$/i.test(message)
+	) {
+		return "Telegram rejected this bot token. Copy the token from @BotFather and try again.";
+	}
+
+	return message.slice(0, 2_000);
+}
+
+function buildCliConnectCommand(
+	args: string[],
+	options: {
+		execPath?: string;
+		cliPath?: string;
+		exists?: (path: string) => boolean;
+	} = {},
+): CliConnectCommand {
+	const execPath = options.execPath ?? process.execPath;
+	const cliPath = options.cliPath ?? cliIndexPath;
+	const exists = options.exists ?? existsSync;
+	const runtimeName = basename(execPath).toLowerCase();
+	const isBunRuntime = runtimeName.includes("bun");
+	const isNodeRuntime = runtimeName === "node";
+	const useBunSourceEntrypoint =
+		(isBunRuntime || isNodeRuntime) && exists(cliPath);
+	const launcher = isBunRuntime
+		? execPath
+		: useBunSourceEntrypoint
+			? "bun"
+			: execPath;
+	const childArgs = useBunSourceEntrypoint
+		? ["--conditions=development", cliPath, "connect", ...args]
+		: ["connect", ...args];
+	return { launcher, childArgs };
+}
 
 export function connectorChannelsPayload(): WebviewConnectorChannelsResponse {
 	const supported = new Set(
@@ -55,23 +120,14 @@ async function runCliConnectCommand(args: string[]): Promise<{
 	stdout: string;
 	stderr: string;
 }> {
-	const launcher = (process.versions as Record<string, string | undefined>).bun
-		? process.execPath
-		: "bun";
-	const child = spawn(
-		launcher,
-		["--conditions=development", cliIndexPath, "connect", ...args],
-		{
-			cwd: workspaceRoot,
-			env: {
-				...process.env,
-				CLINE_BUILD_ENV: process.env.CLINE_BUILD_ENV ?? "development",
-			},
-			stdio: ["ignore", "pipe", "pipe"],
-			// Prevent a console window from flashing on Windows.
-			windowsHide: true,
-		},
-	);
+	const { launcher, childArgs } = buildCliConnectCommand(args);
+	const child = spawn(launcher, childArgs, {
+		cwd: workspaceRoot,
+		env: withResolvedClineBuildEnv(process.env),
+		stdio: ["ignore", "pipe", "pipe"],
+		// Prevent a console window from flashing on Windows.
+		windowsHide: true,
+	});
 	let stdout = "";
 	let stderr = "";
 	child.stdout?.setEncoding("utf8");
@@ -157,9 +213,10 @@ export async function startConnectorChannel(
 	const result = await runCliConnectCommand(cliArgs);
 	if (result.code !== 0) {
 		throw new Error(
-			(result.stderr.trim() || result.stdout.trim() || "connector start failed")
-				.trim()
-				.slice(0, 2_000),
+			normalizeConnectorError(
+				result.stderr || result.stdout,
+				"connector start failed",
+			),
 		);
 	}
 	await waitForConnectorState(() =>
@@ -167,6 +224,11 @@ export async function startConnectorChannel(
 	);
 	return connectorChannelsPayload();
 }
+
+export const __test__ = {
+	buildCliConnectCommand,
+	normalizeConnectorError,
+};
 
 export async function stopConnectorChannel(
 	args?: Record<string, unknown>,
@@ -182,9 +244,10 @@ export async function stopConnectorChannel(
 	const result = await runCliConnectCommand([channel, "--stop"]);
 	if (result.code !== 0) {
 		throw new Error(
-			(result.stderr.trim() || result.stdout.trim() || "connector stop failed")
-				.trim()
-				.slice(0, 2_000),
+			normalizeConnectorError(
+				result.stderr || result.stdout,
+				"connector stop failed",
+			),
 		);
 	}
 	await waitForConnectorState(


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Refactor connector CLI launch logic to conditionally apply Bun-specific flags (`--conditions=development`) only when running under Bun or Node runtimes with access to the source entrypoint. When running from a compiled binary (e.g., packaged Cline app), use the execPath directly without Bun flags.

- Extract `buildCliConnectCommand` function to encapsulate launcher and args resolution logic based on runtime detection
- Use `withResolvedClineBuildEnv` for environment variable setup
- Export `__test__` object to enable unit testing of internal logic

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

added tests covering Bun source entrypoint and compiled binary cases

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
