### PR TITLE
test(vscode): raise vitest testTimeout to fix import-cost flakes

### DIFF
--- a/apps/vscode/vitest.config.ts
+++ b/apps/vscode/vitest.config.ts
@@ -20,6 +20,13 @@ export default defineConfig({
 			"src/core/controller/models/__tests__/refreshClineRecommendedModels.test.ts",
 		],
 		environment: "node",
+		// Several suites lazily `await import()` their subject inside the first test
+		// (needed so vi.mock factories apply first). That import pulls in heavy
+		// workspace packages (@cline/core/@cline/llms/@cline/shared), and on loaded
+		// CI runners the first test in a file can blow past the 5s default and flake
+		// (seen in catalog.test.ts and resolveModelInfo.test.ts). Raise the per-test
+		// timeout so import cost attributed to the first test doesn't cause flakes.
+		testTimeout: 20000,
 		// Some matched files are intentionally-empty placeholders that point to
 		// where the real suite lives (e.g. sdk-control-plane.test.ts), so an
 		// empty file should not fail the run.


### PR DESCRIPTION
### Related Issue

N/A — fixes a flaky-test class that has been intermittently failing the nightly publish.

### Description

Several vitest suites in `apps/vscode` lazily `await import()` their subject **inside the first test** (this is deliberate — it lets `vi.mock(...)` factories apply before the real module loads). That dynamic import pulls in heavy workspace packages (`@cline/core`, `@cline/llms`, `@cline/shared`), so the **first test in a file** ends up paying the entire module-graph import cost *inside its own 5s test timeout*. On loaded CI runners this intermittently exceeds 5000ms and fails the `vscode test` job, which skips the nightly publish.

This has now bitten two files:
- `src/sdk/model-catalog/catalog.test.ts` (#11711, previously patched with a `beforeAll` warm-up)
- `src/core/controller/models/__tests__/resolveModelInfo.test.ts` (just observed)

Rather than keep adding per-file `beforeAll` warm-ups, this raises the global vitest `testTimeout` to 20s. The actual test bodies run in milliseconds; the only thing approaching 5s is one-time import cost. A 20s ceiling absorbs that on slow/loaded runners while still catching genuinely hung tests.

### Test Procedure

- `npx vitest run` (full apps/vscode vitest suite) → **600/600 passed** with the new timeout. Before the change, the full-suite run intermittently failed with `resolveModelInfo.test.ts ... Test timed out in 5000ms`; in isolation that same test passes in ~4s (warm import), confirming the failure is import-cost attribution, not test logic.
- Config-only change; no test or product code modified.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore
-   [x] Tests are passing (`bun test`) and code is formatted and linted

### Additional Notes

Targeting `dpc/sdk-migration-simpler-login` since that's the branch nightlies publish from during the SDK migration. The existing `beforeAll` warm-up in catalog.test.ts is now redundant but harmless; leaving it in place.
