### PR TITLE
Fix search approval webview crash

### DIFF
--- a/apps/vscode/webview-ui/src/components/chat/SearchResultsDisplay.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/SearchResultsDisplay.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import SearchResultsDisplay from "./SearchResultsDisplay"
+
+describe("SearchResultsDisplay", () => {
+	it("does not crash when approval asks have no result content yet", () => {
+		const { container } = render(
+			<SearchResultsDisplay content={undefined} isExpanded={false} onToggleExpand={vi.fn()} path={undefined} />,
+		)
+
+		expect(container).toBeEmptyDOMElement()
+	})
+
+	it("renders search result content when present", () => {
+		render(<SearchResultsDisplay content="README.md: hello" isExpanded={false} onToggleExpand={vi.fn()} path="." />)
+
+		expect(screen.getByRole("button", { name: "Expand code block" })).toBeInTheDocument()
+	})
+
+	it("does not render undefined when multi-workspace results have no path", () => {
+		render(
+			<SearchResultsDisplay
+				content={`Found 1 result across 1 workspace.\n## Workspace: app\nREADME.md: hello`}
+				isExpanded={false}
+				onToggleExpand={vi.fn()}
+				path={undefined}
+			/>,
+		)
+
+		expect(screen.queryByText("undefined")).not.toBeInTheDocument()
+	})
+})

--- a/apps/vscode/webview-ui/src/components/chat/SearchResultsDisplay.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/SearchResultsDisplay.tsx
@@ -3,10 +3,10 @@ import React, { useMemo } from "react"
 import CodeAccordian from "../common/CodeAccordian"
 
 interface SearchResultsDisplayProps {
-	content: string
+	content?: string
 	isExpanded: boolean
 	onToggleExpand: () => void
-	path: string
+	path?: string
 	filePattern?: string
 }
 
@@ -17,9 +17,12 @@ const SearchResultsDisplay: React.FC<SearchResultsDisplayProps> = ({
 	path,
 	filePattern,
 }) => {
+	const safeContent = content ?? ""
+	const safePath = path ?? ""
+
 	const parsedData = useMemo(() => {
 		// Check if this is a multi-workspace result
-		const multiWorkspaceMatch = content.match(/^Found \d+ results? across \d+ workspaces?\./m)
+		const multiWorkspaceMatch = safeContent.match(/^Found \d+ results? across \d+ workspaces?\./m)
 
 		if (!multiWorkspaceMatch) {
 			// Single workspace result - return as is
@@ -27,7 +30,7 @@ const SearchResultsDisplay: React.FC<SearchResultsDisplayProps> = ({
 		}
 
 		// Parse multi-workspace results
-		const lines = content.split("\n")
+		const lines = safeContent.split("\n")
 		const sections: Array<{ workspace: string; content: string }> = []
 		let currentWorkspace: string | null = null
 		let currentContent: string[] = []
@@ -63,17 +66,21 @@ const SearchResultsDisplay: React.FC<SearchResultsDisplayProps> = ({
 		}
 
 		return { isMultiWorkspace: true, sections, summaryLine: lines[0] }
-	}, [content])
+	}, [safeContent])
+
+	if (!safeContent) {
+		return null
+	}
 
 	// For single workspace, use the standard CodeAccordian
 	if (!parsedData.isMultiWorkspace) {
 		return (
 			<CodeAccordian
-				code={content}
+				code={safeContent}
 				isExpanded={isExpanded}
 				language="plaintext"
 				onToggleExpand={onToggleExpand}
-				path={path + (filePattern ? `/(${filePattern})` : "")}
+				path={safePath + (filePattern ? `/(${filePattern})` : "")}
 			/>
 		)
 	}
@@ -119,9 +126,9 @@ const SearchResultsDisplay: React.FC<SearchResultsDisplayProps> = ({
 						textOverflow: "ellipsis",
 						marginRight: "8px",
 					}}>
-					{path + (filePattern ? `/(${filePattern})` : "")}
+					{safePath + (filePattern ? `/(${filePattern})` : "")}
 				</span>
-				<div style={{ flexGrow: 1 }}></div>
+				<div style={{ flexGrow: 1 }} />
 				{isExpanded ? (
 					<ChevronDownIcon size={16} style={{ margin: "1px 0" }} />
 				) : (
@@ -162,7 +169,8 @@ const SearchResultsDisplay: React.FC<SearchResultsDisplayProps> = ({
 									style={{
 										fontSize: "14px",
 										color: "var(--vscode-symbolIcon-folderForeground)",
-									}}></span>
+									}}
+								/>
 								<span
 									style={{
 										fontWeight: "500",


### PR DESCRIPTION
### Related Issue

**Issue:** ENG-2205 (https://linear.app/cline-bot/issue/ENG-2205/extension-crash-likely-tool-call-approvals)

### Description

Fixes a webview crash that happened when rendering a `searchFiles`/`search_codebase` tool approval row before search results were available.

The search results component assumed `content` was always present and called `content.match(...)`. Approval asks can render before result content exists, so the webview threw `Cannot read properties of undefined (reading 'match')` and crashed before the approval UI could complete rendering.

This change makes `SearchResultsDisplay` tolerate missing `content` and `path`, and renders nothing for missing content instead of crashing. It also adds coverage for the missing-content approval state.

### Test Procedure

- Manually reproduced and verified the extension no longer crashes when a prompt triggers a search tool approval.
- Ran targeted webview test:
  - `cd apps/vscode/webview-ui && bun run test -- src/components/chat/SearchResultsDisplay.test.tsx`
- Ran webview typecheck:
  - `cd apps/vscode/webview-ui && bunx tsc -b --pretty false`

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — crash fix for approval-row rendering.

### Additional Notes

The GitHub Copilot 404s seen in the console during reproduction appear unrelated; the fatal error was the webview `content.match(...)` exception.
