### PR TITLE
Remove chat scroll action button

### DIFF
--- a/apps/vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -342,12 +342,6 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 					messageHandlers={messageHandlers}
 					messages={messages}
 					mode={mode}
-					scrollBehavior={{
-						scrollToBottomSmooth: scrollBehavior.scrollToBottomSmooth,
-						disableAutoScrollRef: scrollBehavior.disableAutoScrollRef,
-						showScrollToBottom: scrollBehavior.showScrollToBottom,
-						virtuosoRef: scrollBehavior.virtuosoRef,
-					}}
 					task={task}
 				/>
 				<InputSection

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/ActionButtons.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/ActionButtons.test.tsx
@@ -41,16 +41,32 @@ function makeChatState(): ChatState {
 	} as unknown as ChatState
 }
 
-function makeScrollBehavior() {
-	return {
-		scrollToBottomSmooth: vi.fn(),
-		disableAutoScrollRef: { current: false },
-		showScrollToBottom: false,
-		virtuosoRef: { current: null },
-	} as unknown as Parameters<typeof ActionButtons>[0]["scrollBehavior"]
-}
-
 describe("ActionButtons", () => {
+	it("does not render a scroll button when there are no action buttons", () => {
+		mockTurnState.mockReturnValue(undefined)
+		const task: ClineMessage = {
+			ts: 1,
+			type: "ask",
+			ask: "followup",
+			text: "Anything else?",
+			partial: false,
+		}
+
+		render(
+			<ActionButtons
+				chatState={makeChatState()}
+				messageHandlers={{ executeButtonAction: vi.fn() } as unknown as MessageHandlers}
+				messages={[task]}
+				mode="act"
+				task={task}
+			/>,
+		)
+
+		expect(screen.queryByRole("button")).not.toBeInTheDocument()
+		expect(screen.queryByLabelText("Scroll to bottom")).not.toBeInTheDocument()
+		expect(screen.queryByLabelText("Scroll to top")).not.toBeInTheDocument()
+	})
+
 	it("re-enables the buttons when a second identical approval ask arrives", async () => {
 		// Regression: the button configs are shared singletons, so two consecutive
 		// "create file" asks return the same object. Clicking the first latches a
@@ -68,7 +84,6 @@ describe("ActionButtons", () => {
 			chatState: makeChatState(),
 			messageHandlers,
 			mode: "act" as const,
-			scrollBehavior: makeScrollBehavior(),
 		}
 
 		const { rerender } = render(<ActionButtons {...props} messages={[task]} />)

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/ActionButtons.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/ActionButtons.tsx
@@ -3,7 +3,6 @@ import type { Mode } from "@shared/storage/types"
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
 import type React from "react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { VirtuosoHandle } from "react-virtuoso"
 import { useExtensionState } from "../../../../../context/ExtensionStateContext"
 import { ButtonActionType, getButtonConfigFromState } from "../../shared/buttonConfig"
 import type { ChatState, MessageHandlers } from "../../types/chatTypes"
@@ -14,25 +13,12 @@ interface ActionButtonsProps {
 	chatState: ChatState
 	messageHandlers: MessageHandlers
 	mode: Mode
-	scrollBehavior: {
-		scrollToBottomSmooth: () => void
-		disableAutoScrollRef: React.MutableRefObject<boolean>
-		showScrollToBottom: boolean
-		virtuosoRef: React.RefObject<VirtuosoHandle>
-	}
 }
 
 /**
- * Action buttons area including scroll-to-bottom and approve/reject buttons
+ * Action buttons area including approve/reject buttons
  */
-export const ActionButtons: React.FC<ActionButtonsProps> = ({
-	task,
-	messages,
-	chatState,
-	mode,
-	messageHandlers,
-	scrollBehavior,
-}) => {
+export const ActionButtons: React.FC<ActionButtonsProps> = ({ task, messages, chatState, mode, messageHandlers }) => {
 	const { inputValue, selectedImages, selectedFiles, setSendingDisabled } = chatState
 	const { turnState } = useExtensionState()
 
@@ -130,63 +116,13 @@ export const ActionButtons: React.FC<ActionButtonsProps> = ({
 		return null
 	}
 
-	const { showScrollToBottom, scrollToBottomSmooth, disableAutoScrollRef } = scrollBehavior
-
 	const { primaryText, secondaryText, primaryAction, secondaryAction, enableButtons } = buttonConfig
 	const hasButtons = primaryText || secondaryText
 	const isStreaming = task.partial === true
 	const canInteract = enableButtons && !isProcessing
 
-	// Early return for scroll button to avoid unnecessary computation.
-	// Action buttons must take priority over the scroll button; otherwise an
-	// approval ask can be visible while the footer only shows “scroll to bottom”.
 	if (!hasButtons) {
-		const handleScrollToBottom = () => {
-			scrollToBottomSmooth()
-			disableAutoScrollRef.current = false
-		}
-		// Show scroll to top button when there are no action buttons
-		const handleScrollToTop = () => {
-			scrollBehavior.virtuosoRef.current?.scrollTo({
-				top: 0,
-				behavior: "smooth",
-			})
-			disableAutoScrollRef.current = true
-			// Virtual rendering may not have all items rendered when at bottom,
-			// so scroll again after a delay to ensure we reach the true top
-			setTimeout(() => {
-				scrollBehavior.virtuosoRef.current?.scrollTo({
-					top: 0,
-					behavior: "smooth",
-				})
-			}, 300)
-		}
-
-		return (
-			<div className="flex px-3.5">
-				<VSCodeButton
-					appearance="icon"
-					aria-label={showScrollToBottom ? "Scroll to bottom" : "Scroll to top"}
-					className="text-lg text-(--vscode-primaryButton-foreground) bg-[color-mix(in_srgb,var(--vscode-toolbar-hoverBackground)_55%,transparent)] rounded-[3px] overflow-hidden cursor-pointer flex justify-center items-center flex-1 h-[25px] hover:bg-[color-mix(in_srgb,var(--vscode-toolbar-hoverBackground)_90%,transparent)] active:bg-[color-mix(in_srgb,var(--vscode-toolbar-hoverBackground)_70%,transparent)] border-0"
-					onClick={showScrollToBottom ? handleScrollToBottom : handleScrollToTop}
-					onKeyDown={(e) => {
-						if (e.key === "Enter" || e.key === " ") {
-							e.preventDefault()
-							if (showScrollToBottom) {
-								handleScrollToBottom()
-							} else {
-								handleScrollToTop()
-							}
-						}
-					}}>
-					{showScrollToBottom ? (
-						<span className="codicon codicon-chevron-down" />
-					) : (
-						<span className="codicon codicon-chevron-up" />
-					)}
-				</VSCodeButton>
-			</div>
-		)
+		return null
 	}
 
 	const opacity = canInteract || isStreaming ? 1 : 0.5

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/MessagesArea.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/MessagesArea.tsx
@@ -43,7 +43,6 @@ export const MessagesArea: React.FC<MessagesAreaProps> = ({
 		toggleRowExpansion,
 		handleRowHeightChange,
 		setIsAtBottom,
-		setShowScrollToBottom,
 		disableAutoScrollRef,
 		handleRangeChanged,
 		scrolledPastUserMessage,
@@ -295,7 +294,6 @@ export const MessagesArea: React.FC<MessagesAreaProps> = ({
 						if (isAtBottom) {
 							disableAutoScrollRef.current = false
 						}
-						setShowScrollToBottom(disableAutoScrollRef.current && !isAtBottom)
 					}}
 					atBottomThreshold={10} // trick to make sure virtuoso re-renders when task changes, and we use initialTopMostItemIndex to start at the bottom
 					className="scrollable grow overflow-y-scroll"

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useScrollBehavior.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useScrollBehavior.ts
@@ -19,8 +19,6 @@ export function useScrollBehavior(
 	expandedRows: Record<number, boolean>,
 	setExpandedRows: React.Dispatch<React.SetStateAction<Record<number, boolean>>>,
 ): ScrollBehavior & {
-	showScrollToBottom: boolean
-	setShowScrollToBottom: React.Dispatch<React.SetStateAction<boolean>>
 	isAtBottom: boolean
 	setIsAtBottom: React.Dispatch<React.SetStateAction<boolean>>
 	pendingScrollToMessage: number | null
@@ -34,7 +32,6 @@ export function useScrollBehavior(
 	const disableAutoScrollRef = useRef(false)
 
 	// State
-	const [showScrollToBottom, setShowScrollToBottom] = useState(false)
 	const [isAtBottom, setIsAtBottom] = useState(false)
 	const [pendingScrollToMessage, setPendingScrollToMessage] = useState<number | null>(null)
 	const [scrolledPastUserMessage, setScrolledPastUserMessage] = useState<ClineMessage | null>(null)
@@ -299,12 +296,6 @@ export function useScrollBehavior(
 		}
 	}, [pendingScrollToMessage, groupedMessages, scrollToMessage])
 
-	useEffect(() => {
-		if (!messages?.length) {
-			setShowScrollToBottom(false)
-		}
-	}, [messages.length])
-
 	const handleWheel = useCallback((event: Event) => {
 		const wheelEvent = event as WheelEvent
 		if (wheelEvent.deltaY && wheelEvent.deltaY < 0) {
@@ -325,8 +316,6 @@ export function useScrollBehavior(
 		scrollToMessage,
 		toggleRowExpansion,
 		handleRowHeightChange,
-		showScrollToBottom,
-		setShowScrollToBottom,
 		isAtBottom,
 		setIsAtBottom,
 		pendingScrollToMessage,

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/types/chatTypes.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/types/chatTypes.ts
@@ -47,7 +47,6 @@ export interface ChatState {
 	resetState: () => void
 
 	// Scroll-related state (will be moved to scroll hook)
-	showScrollToBottom?: boolean
 	isAtBottom?: boolean
 	pendingScrollToMessage?: number | null
 }
@@ -74,8 +73,6 @@ export interface ScrollBehavior {
 	scrollToMessage: (messageIndex: number) => void
 	toggleRowExpansion: (ts: number) => void
 	handleRowHeightChange: (isTaller: boolean) => void
-	showScrollToBottom: boolean
-	setShowScrollToBottom: React.Dispatch<React.SetStateAction<boolean>>
 	isAtBottom: boolean
 	setIsAtBottom: React.Dispatch<React.SetStateAction<boolean>>
 	pendingScrollToMessage: number | null


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Removes the chat footer scroll-to-top/bottom action button from `ActionButtons` and cleans up the now-unused scroll button props/state. When there are no approval/action buttons to show, `ActionButtons` now renders nothing instead of a scroll control.

### Test Procedure

- Manual verification: confirmed the no-action footer state no longer renders `Scroll to bottom` or `Scroll to top` controls, and verified there are no remaining runtime references to those labels/state in the chat UI source.
- Added/updated `ActionButtons` coverage for the no-action state.
- Ran `bun --cwd apps/vscode/webview-ui test -- ActionButtons.test.tsx`.
- Ran `cd apps/vscode/webview-ui && bun run build`.
- Ran `cd apps/vscode/webview-ui && bun run lint` (reports existing warnings/infos in unrelated changed files).

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality not to work as expected)
-   [x] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

No related issue.
