### PR TITLE
Identfy accounts for feature flag resolution

### DIFF
--- a/apps/vscode/src/sdk/auth-service.test.ts
+++ b/apps/vscode/src/sdk/auth-service.test.ts
@@ -17,6 +17,7 @@ import { AuthService, type ClineAuthInfo, LogoutReason } from "./auth-service"
 // ---------------------------------------------------------------------------
 
 const mockFeatureFlagsPoll = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
+const mockIdentifyAccount = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
 
 // Mock StateManager
 const mockSecrets = new Map<string, string>()
@@ -83,6 +84,12 @@ vi.mock("@/services/EnvUtils", () => ({
 vi.mock("@/services/feature-flags", () => ({
 	featureFlagsService: {
 		poll: mockFeatureFlagsPoll,
+	},
+}))
+
+vi.mock("@/services/telemetry", () => ({
+	telemetryService: {
+		identifyAccount: mockIdentifyAccount,
 	},
 }))
 
@@ -511,6 +518,8 @@ describe("AuthService", () => {
 			)
 
 			expect(mockFeatureFlagsPoll).toHaveBeenCalledWith("user-123")
+			expect(mockIdentifyAccount).toHaveBeenCalledWith(authInfo.userInfo)
+			expect(mockIdentifyAccount.mock.invocationCallOrder[0]).toBeLessThan(mockFeatureFlagsPoll.mock.invocationCallOrder[0])
 			expect(mockController.postStateToWebview).toHaveBeenCalled()
 		})
 
@@ -518,6 +527,7 @@ describe("AuthService", () => {
 			await authService.sendAuthStatusUpdate()
 
 			expect(mockFeatureFlagsPoll).toHaveBeenCalledWith(null)
+			expect(mockIdentifyAccount).not.toHaveBeenCalled()
 		})
 
 		it("removes subscription on cleanup", async () => {

--- a/apps/vscode/src/sdk/auth-service.ts
+++ b/apps/vscode/src/sdk/auth-service.ts
@@ -29,7 +29,7 @@ import { openAiCodexOAuthManager } from "@/integrations/openai-codex/oauth"
 import { BannerService } from "@/services/banner/BannerService"
 import { buildBasicClineHeaders } from "@/services/EnvUtils"
 import { featureFlagsService } from "@/services/feature-flags"
-import { setDistinctId } from "@/services/logging/distinctId"
+import { telemetryService } from "@/services/telemetry"
 import { CLINE_API_ENDPOINT } from "@/shared/cline/api"
 import { fetch, getAxiosSettings } from "@/shared/net"
 import { Logger } from "@/shared/services/Logger"
@@ -945,7 +945,7 @@ export class AuthService {
 	 * Send an authStatusUpdate event to all active subscribers.
 	 */
 	async sendAuthStatusUpdate(): Promise<void> {
-		const authInfo: AuthState = this.getInfo()
+		const authState: AuthState = this.getInfo()
 		const uniqueControllers = new Set<Controller>()
 
 		const streamSends = Array.from(this._activeAuthStatusUpdateHandlers).map(async (responseStream) => {
@@ -954,7 +954,7 @@ export class AuthService {
 				uniqueControllers.add(controller)
 			}
 			try {
-				await responseStream(authInfo, false)
+				await responseStream(authState, false)
 			} catch (error) {
 				Logger.error("[SdkAuthService] Error sending authStatusUpdate event:", error)
 				this._activeAuthStatusUpdateHandlers.delete(responseStream)
@@ -966,10 +966,11 @@ export class AuthService {
 
 		// Poll feature flags immediately for the current auth context so cache-only
 		// consumers (for example BannerService) see the latest remote config.
-		const userId = this._clineAuthInfo?.userInfo?.id || null
-		if (userId) {
-			setDistinctId(userId)
+		const authInfo = this._clineAuthInfo
+		if (authInfo?.userInfo) {
+			await telemetryService.identifyAccount(authInfo.userInfo)
 		}
+		const userId = authInfo?.userInfo?.id || null
 		await featureFlagsService.poll(userId)
 		for (const controller of uniqueControllers) {
 			controller.invalidateProviderListings()

--- a/apps/vscode/webview-ui/src/CustomPostHogProvider.tsx
+++ b/apps/vscode/webview-ui/src/CustomPostHogProvider.tsx
@@ -59,12 +59,11 @@ export function CustomPostHogProvider({ children }: { children: ReactNode }) {
 			email: userInfo?.email,
 			name: userInfo?.displayName,
 		}
+		posthog.identify(distinctId, args)
+
 		if (isTelemetryEnabled && !optedIn) {
 			posthog.opt_in_capturing()
-			posthog.identify(distinctId, args)
 		} else if (!isTelemetryEnabled && !optedOut) {
-			// For feature flags to work, we need to identify the user even when telemetry is disabled
-			posthog.identify(distinctId, args)
 			// Then opt out of capturing other events
 			posthog.opt_out_capturing()
 		}


### PR DESCRIPTION
We need to call identify for feature flags to work properly. setDistinctId doesn't quite do it.