### PR TITLE
fix(sdk): backport Z.ai model aliases to nightly

### DIFF
--- a/sdk/packages/core/src/services/llms/provider-defaults.test.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.test.ts
@@ -58,6 +58,45 @@ describe("resolveProviderConfig", () => {
 		);
 	});
 
+	it("prefers Vercel-style Z.ai ids in Cline known models", async () => {
+		const resolved = await resolveProviderConfig("cline");
+
+		expect(resolved?.knownModels?.["zai/glm-5.2"]).toMatchObject({
+			id: "zai/glm-5.2",
+			name: "GLM 5.2",
+			contextWindow: 1_000_000,
+			maxInputTokens: 1_000_000,
+		});
+		expect(resolved?.knownModels?.["z-ai/glm-5.2"]).toBeUndefined();
+	});
+
+	it("preserves explicit Cline known model overrides for alias ids", async () => {
+		const resolved = await resolveProviderConfig("cline", undefined, {
+			providerId: "cline",
+			modelId: "z-ai/glm-5.2",
+			knownModels: {
+				"z-ai/glm-5.2": {
+					id: "z-ai/glm-5.2",
+					name: "Custom GLM 5.2",
+					contextWindow: 123_456,
+					maxInputTokens: 123_456,
+				},
+			},
+		});
+
+		expect(resolved?.knownModels?.["z-ai/glm-5.2"]).toMatchObject({
+			id: "z-ai/glm-5.2",
+			name: "Custom GLM 5.2",
+			contextWindow: 123_456,
+			maxInputTokens: 123_456,
+		});
+		expect(resolved?.knownModels?.["zai/glm-5.2"]).toMatchObject({
+			id: "zai/glm-5.2",
+			contextWindow: 1_000_000,
+			maxInputTokens: 1_000_000,
+		});
+	});
+
 	it("uses the live OpenAI catalog for ChatGPT subscription models", async () => {
 		vi.stubGlobal(
 			"fetch",

--- a/sdk/packages/core/src/services/llms/provider-defaults.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.ts
@@ -179,12 +179,28 @@ async function mergeKnownModels(
 			...userKnownModels,
 		});
 	}
-	return Llms.sortModelsByReleaseDate({
+	const knownModelsWithoutUserOverrides = Llms.sortModelsByReleaseDate({
 		...generated,
 		...defaultKnownModels,
 		...liveModels,
 		...privateModels,
 		...publicModels,
+	});
+
+	if (providerId === "cline") {
+		// Cline recommendations can use Vercel-style ids while the broader
+		// catalog includes OpenRouter aliases for the same models.
+		return Llms.sortModelsByReleaseDate({
+			...Llms.preferCanonicalModelIds(
+				knownModelsWithoutUserOverrides,
+				Llms.VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES,
+			),
+			...userKnownModels,
+		});
+	}
+
+	return Llms.sortModelsByReleaseDate({
+		...knownModelsWithoutUserOverrides,
 		...userKnownModels,
 	});
 }

--- a/sdk/packages/core/src/services/providers/local-provider-service.test.ts
+++ b/sdk/packages/core/src/services/providers/local-provider-service.test.ts
@@ -1193,7 +1193,7 @@ describe("listLocalProviders", () => {
 		).toBe(false);
 	});
 
-	it("uses the same built-in model list for cline as openrouter", async () => {
+	it("uses Cline-specific Z.ai aliases in the built-in model list", async () => {
 		manager.saveProviderSettings(
 			{
 				provider: "cline",
@@ -1209,9 +1209,17 @@ describe("listLocalProviders", () => {
 		const openrouter = providers.find(
 			(provider) => provider.id === "openrouter",
 		);
+		const clineModelIds = new Set(
+			cline?.modelList?.map((model) => model.id) ?? [],
+		);
+		const openrouterModelIds = new Set(
+			openrouter?.modelList?.map((model) => model.id) ?? [],
+		);
 
 		expect(cline?.modelList?.length).toBeGreaterThan(0);
-		expect(cline?.modelList).toEqual(openrouter?.modelList);
+		expect(clineModelIds).toContain("zai/glm-5.2");
+		expect(clineModelIds).not.toContain("z-ai/glm-5.2");
+		expect(openrouterModelIds).toContain("z-ai/glm-5.2");
 	});
 
 	it("does not eagerly fetch LiteLLM private models while listing providers", async () => {

--- a/sdk/packages/llms/src/catalog/model-id-aliases.test.ts
+++ b/sdk/packages/llms/src/catalog/model-id-aliases.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+	isCanonicalModelIdForAliasRules,
+	preferCanonicalModelIds,
+	VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES,
+} from "./model-id-aliases";
+
+describe("model id aliases", () => {
+	it("recognizes canonical model ids for configured alias rules", () => {
+		expect(
+			isCanonicalModelIdForAliasRules(
+				"zai/glm-5.2",
+				VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES,
+			),
+		).toBe(true);
+		expect(
+			isCanonicalModelIdForAliasRules(
+				"z-ai/glm-5.2",
+				VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES,
+			),
+		).toBe(false);
+	});
+
+	it("removes an alias only when its canonical model id exists", () => {
+		const models = preferCanonicalModelIds(
+			{
+				"zai/glm-5.2": { source: "vercel" },
+				"z-ai/glm-5.2": { source: "openrouter" },
+				"z-ai/openrouter-only": { source: "openrouter" },
+			},
+			VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES,
+		);
+
+		expect(models).toEqual({
+			"zai/glm-5.2": { source: "vercel" },
+			"z-ai/openrouter-only": { source: "openrouter" },
+		});
+	});
+});

--- a/sdk/packages/llms/src/catalog/model-id-aliases.ts
+++ b/sdk/packages/llms/src/catalog/model-id-aliases.ts
@@ -1,0 +1,34 @@
+export interface ModelIdAliasRule {
+	canonicalPrefix: string;
+	aliasPrefix: string;
+}
+
+// Some upstream catalogs expose the same routed model under different provider
+// namespaces. Prefer the namespace our runtime can receive so exact model-info
+// lookups keep the right context window and token limits.
+export const VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES = [
+	{ canonicalPrefix: "zai/", aliasPrefix: "z-ai/" },
+] as const satisfies readonly ModelIdAliasRule[];
+
+export function isCanonicalModelIdForAliasRules(
+	modelId: string,
+	rules: readonly ModelIdAliasRule[],
+): boolean {
+	return rules.some((rule) => modelId.startsWith(rule.canonicalPrefix));
+}
+
+export function preferCanonicalModelIds<T>(
+	models: Record<string, T>,
+	rules: readonly ModelIdAliasRule[],
+): Record<string, T> {
+	return Object.fromEntries(
+		Object.entries(models).filter(([modelId]) => {
+			for (const rule of rules) {
+				if (!modelId.startsWith(rule.aliasPrefix)) continue;
+				const canonicalModelId = `${rule.canonicalPrefix}${modelId.slice(rule.aliasPrefix.length)}`;
+				if (canonicalModelId in models) return false;
+			}
+			return true;
+		}),
+	);
+}

--- a/sdk/packages/llms/src/index.browser.ts
+++ b/sdk/packages/llms/src/index.browser.ts
@@ -1,5 +1,6 @@
 export type {
 	ModelCollection,
+	ModelIdAliasRule,
 	ModelInfo,
 	ModelInfo as CatalogModelInfo,
 	ProviderCapability as CatalogProviderCapability,
@@ -15,11 +16,14 @@ export {
 	getProviderCollectionSync,
 	getProviderIds,
 	hasProvider,
+	isCanonicalModelIdForAliasRules,
 	MODEL_COLLECTIONS_BY_PROVIDER_ID,
+	preferCanonicalModelIds,
 	registerModel,
 	registerProvider,
 	resetRegistry,
 	unregisterProvider,
+	VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES,
 } from "./models";
 export {
 	type ProviderUsageCostDisplay,

--- a/sdk/packages/llms/src/index.ts
+++ b/sdk/packages/llms/src/index.ts
@@ -1,5 +1,6 @@
 export type {
 	ModelCollection,
+	ModelIdAliasRule,
 	ModelInfo,
 	ModelInfo as CatalogModelInfo,
 	ProviderCapability as CatalogProviderCapability,
@@ -19,12 +20,15 @@ export {
 	getProviderCollectionSync,
 	getProviderIds,
 	hasProvider,
+	isCanonicalModelIdForAliasRules,
 	MODEL_COLLECTIONS_BY_PROVIDER_ID,
+	preferCanonicalModelIds,
 	registerModel,
 	registerProvider,
 	resetRegistry,
 	sortModelsByReleaseDate,
 	unregisterProvider,
+	VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES,
 } from "./models";
 export type {
 	ApiHandler,

--- a/sdk/packages/llms/src/models.ts
+++ b/sdk/packages/llms/src/models.ts
@@ -6,6 +6,12 @@ export {
 	fetchModelsDevProviderModels,
 	sortModelsByReleaseDate,
 } from "./catalog/catalog-live";
+export type { ModelIdAliasRule } from "./catalog/model-id-aliases";
+export {
+	isCanonicalModelIdForAliasRules,
+	preferCanonicalModelIds,
+	VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES,
+} from "./catalog/model-id-aliases";
 export type {
 	ModelCollection,
 	ModelInfo,

--- a/sdk/packages/llms/src/providers/builtins.test.ts
+++ b/sdk/packages/llms/src/providers/builtins.test.ts
@@ -50,6 +50,23 @@ describe("cline builtin spec defaults.baseUrl", () => {
 	});
 });
 
+describe("cline builtin models", () => {
+	it("prefers Vercel-style Z.ai model ids over equivalent OpenRouter ids", async () => {
+		const models = await getModelsForProvider("cline");
+
+		expect(models["zai/glm-5.2"]).toMatchObject({
+			id: "zai/glm-5.2",
+			name: "GLM 5.2",
+			contextWindow: 1_000_000,
+			maxInputTokens: 1_000_000,
+		});
+		expect(models["zai/glm-5.1"]).toMatchObject({
+			id: "zai/glm-5.1",
+		});
+		expect(models["z-ai/glm-5.2"]).toBeUndefined();
+	});
+});
+
 describe("cline-pass builtin spec", () => {
 	it("registers a distinct Cline-compatible provider with a custom model list", async () => {
 		const models = await getModelsForProvider("cline-pass");

--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -10,6 +10,11 @@ import {
 	type ProviderConfigField,
 } from "@cline/shared";
 import { getGeneratedModelsForProvider } from "../catalog/catalog.generated-access";
+import {
+	isCanonicalModelIdForAliasRules,
+	preferCanonicalModelIds,
+	VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES,
+} from "../catalog/model-id-aliases";
 import type {
 	ModelCollection,
 	ModelInfo,
@@ -325,6 +330,27 @@ function buildOpenAICodexModels(): Record<string, ModelInfo> {
 	return filterOpenAICodexModels(generatedModels("openai-native"));
 }
 
+function buildClineModels(): Record<string, ModelInfo> {
+	// Cline is OpenRouter-backed generally, but its recommended-model endpoint
+	// can return Vercel-style ids. Include those exact ids so runtime metadata
+	// resolves without adding duplicate OpenRouter aliases to the picker.
+	const vercelAliasModels = Object.fromEntries(
+		Object.entries(generatedModels("vercel-ai-gateway")).filter(([modelId]) =>
+			isCanonicalModelIdForAliasRules(
+				modelId,
+				VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES,
+			),
+		),
+	);
+	return preferCanonicalModelIds(
+		{
+			...generatedModels("openrouter"),
+			...vercelAliasModels,
+		},
+		VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES,
+	);
+}
+
 function fallbackModelInfo(id: string, spec?: BuiltinSpec): ModelInfo {
 	const info: ModelInfo = {
 		id,
@@ -482,7 +508,7 @@ const cline = createClineLikeSpec({
 	id: "cline",
 	name: "Cline",
 	popular: 1,
-	modelsProviderId: "openrouter",
+	modelsFactory: buildClineModels,
 	defaultModelId: CLINE_DEFAULT_MODEL_ID,
 });
 


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This backports the already-merged SDK catalog fix from #11685 onto `dpc/sdk-migration-simpler-login`, which is the branch used to build the nightly VS Code extension.

The bug is that Cline can receive recommended model ids using Vercel AI Gateway's Z.ai namespace, for example `zai/glm-5.2`, while the broader OpenRouter-backed model catalog exposes overlapping Z.ai models under OpenRouter's namespace, for example `z-ai/glm-5.2`. Without an explicit alias rule, exact model metadata lookup can miss for the Cline provider and fall back to generic/default metadata. The visible risk is wrong model metadata in the nightly extension, including context/input-token limits for Z.ai GLM models.

The original fix is intentionally in the SDK catalog layer rather than in CLI or UI display code. It adds an explicit alias table for the current Vercel/OpenRouter namespace discrepancy, keeps `zai/` as the canonical Cline-provider id, and removes duplicate OpenRouter-style aliases only when the canonical Vercel-style id exists. This keeps exact `knownModels["zai/glm-5.2"]` lookup working while avoiding duplicate GLM rows in provider model listings.

This PR is a straight backport/cherry-pick of #11685 onto the nightly extension branch. It does not change the release workflow or package versions. The intent is simply to make the next nightly extension build include the same SDK alias behavior that is already fixed on `main`.

Non-obvious gotchas checked while preparing this PR:

- `dpc/sdk-migration-simpler-login` already contains the later exposed-provider auth/routing fix from #11721, so this PR does not need to carry those changes.
- The local detached checkout already had #11685 through a newer local branch tip, but `origin/dpc/sdk-migration-simpler-login` did not, so the PR had to branch from the remote nightly base.
- This is not basename matching. Basename matching can conflate unrelated provider metadata; the alias table is explicit and only applies to configured namespace rules.

### Test Procedure

Ran the focused tests and checks that cover the backported behavior:

```bash
bunx vitest run src/catalog/model-id-aliases.test.ts src/providers/builtins.test.ts --config vitest.config.ts
bun -F @cline/llms build
bunx vitest run src/services/llms/provider-defaults.test.ts --config vitest.config.ts
bun -F @cline/llms typecheck
bun -F @cline/core typecheck
git diff --check origin/dpc/sdk-migration-simpler-login...HEAD
```

Results:

- `@cline/llms` alias and builtins tests passed: 2 files, 10 tests.
- `@cline/llms` build passed.
- `@cline/core` provider-defaults test passed: 1 file, 11 tests.
- `@cline/llms` typecheck passed.
- `@cline/core` typecheck passed.
- `git diff --check` passed.

The most relevant coverage verifies that the Cline model catalog includes canonical `zai/glm-5.2` and avoids the duplicate `z-ai/glm-5.2` alias when the canonical id exists, and that provider-default resolution preserves the same canonical metadata after model sources are merged.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that causes existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. This is SDK/runtime model catalog behavior and does not introduce UI changes.

### Additional Notes

After this lands on `dpc/sdk-migration-simpler-login`, a nightly extension release from that branch should include the Z.ai GLM metadata alias fix without requiring a separate extension-side patch.
