### PR TITLE
fix(llms): includes session id for OpenRouter caching

### DIFF
--- a/sdk/packages/agents/src/agent-runtime.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.test.ts
@@ -1068,6 +1068,66 @@ describe("AgentRuntime", () => {
 		});
 	});
 
+	it("stamps runtime identity metadata onto model requests", async () => {
+		const model = new ScriptedModel([
+			(request) => {
+				const metadata = request.options?.metadata as
+					| Record<string, unknown>
+					| undefined;
+				expect(metadata).toMatchObject({
+					sessionId: "session-runtime",
+					agentId: "agent-runtime",
+					conversationId: "conversation-runtime",
+					iteration: 1,
+				});
+				expect(typeof metadata?.runId).toBe("string");
+				return [
+					{ type: "text-delta", text: "done" },
+					{ type: "finish", reason: "stop" },
+				];
+			},
+		]);
+		const runtime = new AgentRuntime({
+			sessionId: "session-runtime",
+			agentId: "agent-runtime",
+			conversationId: "conversation-runtime",
+			model,
+		});
+
+		await runtime.run("capture metadata");
+
+		expect(model.requests).toHaveLength(1);
+	});
+
+	it("does not synthesize session or conversation ids in model request metadata", async () => {
+		const model = new ScriptedModel([
+			(request) => {
+				const metadata = request.options?.metadata as
+					| Record<string, unknown>
+					| undefined;
+				expect(metadata).not.toHaveProperty("sessionId");
+				expect(metadata).not.toHaveProperty("conversationId");
+				expect(metadata).toMatchObject({
+					agentId: "agent-runtime",
+					iteration: 1,
+				});
+				expect(typeof metadata?.runId).toBe("string");
+				return [
+					{ type: "text-delta", text: "done" },
+					{ type: "finish", reason: "stop" },
+				];
+			},
+		]);
+		const runtime = new AgentRuntime({
+			agentId: "agent-runtime",
+			model,
+		});
+
+		await runtime.run("capture metadata");
+
+		expect(model.requests).toHaveLength(1);
+	});
+
 	it("preserves the existing system prompt when prepareTurn returns only messages", async () => {
 		const compactedMessage: AgentMessage = {
 			id: "msg_compacted",

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -27,6 +27,8 @@ import {
 	captureSdkError,
 	estimateTokens,
 	mergeModelOptions,
+	omitUndefinedValues,
+	trimNonEmpty,
 } from "@cline/shared";
 import { nanoid } from "nanoid";
 
@@ -747,6 +749,13 @@ export class AgentRuntime {
 		finishReason: AgentModelFinishReason;
 	}> {
 		const usageBeforeModel = cloneUsage(this.state.usage);
+		const modelRequestMetadata = omitUndefinedValues({
+			sessionId: trimNonEmpty(this.config.sessionId),
+			agentId: this.state.agentId,
+			conversationId: trimNonEmpty(this.config.conversationId),
+			runId: this.state.runId,
+			iteration: this.state.iteration,
+		});
 		let request: AgentModelRequest = {
 			systemPrompt: this.config.systemPrompt,
 			messages: cloneMessages(this.state.messages),
@@ -756,7 +765,9 @@ export class AgentRuntime {
 				inputSchema: tool.inputSchema,
 			})),
 			signal: this.abortController?.signal,
-			options: this.config.modelOptions,
+			options: mergeModelOptions(this.config.modelOptions, {
+				metadata: modelRequestMetadata,
+			}),
 		};
 
 		if (this.state.iteration > 1) {

--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -108,31 +108,45 @@ function resolveStickySession(
 	};
 }
 
+type FetchBodyText =
+	| { source: "init-body"; text: string }
+	| { request: Request; source: "request"; text: string };
+
 async function bodyTextFromFetchInput(
 	input: Parameters<typeof fetch>[0],
 	init: Parameters<typeof fetch>[1],
-): Promise<string | undefined> {
+): Promise<FetchBodyText | undefined> {
 	const body = init?.body;
+	if (body === null) {
+		return undefined;
+	}
 	if (typeof body === "string") {
-		return body;
+		return { source: "init-body", text: body };
 	}
 	if (body instanceof URLSearchParams) {
-		return body.toString();
+		return { source: "init-body", text: body.toString() };
 	}
 	if (body instanceof ArrayBuffer) {
-		return Buffer.from(body).toString("utf8");
+		return { source: "init-body", text: Buffer.from(body).toString("utf8") };
 	}
 	if (ArrayBuffer.isView(body)) {
-		return Buffer.from(body.buffer, body.byteOffset, body.byteLength).toString(
-			"utf8",
-		);
+		return {
+			source: "init-body",
+			text: Buffer.from(body.buffer, body.byteOffset, body.byteLength).toString(
+				"utf8",
+			),
+		};
 	}
-	if (body !== undefined && body !== null) {
+	if (body !== undefined) {
 		return undefined;
 	}
 	if (input instanceof Request) {
 		try {
-			return await input.clone().text();
+			return {
+				request: input,
+				source: "request",
+				text: await input.clone().text(),
+			};
 		} catch {
 			return undefined;
 		}
@@ -145,13 +159,13 @@ async function injectJsonBodyStickySession(
 	init: Parameters<typeof fetch>[1],
 	stickySession: { field: string; value: string },
 ): Promise<Parameters<typeof fetch>> {
-	const text = await bodyTextFromFetchInput(input, init);
-	if (!text?.trim().startsWith("{")) {
+	const bodyText = await bodyTextFromFetchInput(input, init);
+	if (!bodyText?.text.trim().startsWith("{")) {
 		return [input, init];
 	}
 	let parsed: unknown;
 	try {
-		parsed = JSON.parse(text);
+		parsed = JSON.parse(bodyText.text);
 	} catch {
 		return [input, init];
 	}
@@ -164,13 +178,10 @@ async function injectJsonBodyStickySession(
 		body[stickySession.field] = stickySession.value;
 	}
 	const nextBody = JSON.stringify(body);
-	if (init?.body !== undefined && init.body !== null) {
+	if (bodyText.source === "init-body") {
 		return [input, { ...init, body: nextBody }];
 	}
-	if (input instanceof Request) {
-		return [new Request(input, { body: nextBody }), init];
-	}
-	return [input, { ...init, body: nextBody }];
+	return [new Request(bodyText.request, { body: nextBody }), init];
 }
 
 function injectHeaderStickySession(
@@ -178,7 +189,9 @@ function injectHeaderStickySession(
 	init: Parameters<typeof fetch>[1],
 	stickySession: { field: string; value: string },
 ): Parameters<typeof fetch> {
-	const headers = new Headers(input instanceof Request ? input.headers : undefined);
+	const headers = new Headers(
+		input instanceof Request ? input.headers : undefined,
+	);
 	new Headers(init?.headers).forEach((value, key) => {
 		headers.set(key, value);
 	});

--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -75,6 +75,152 @@ function buildCachedAiSdkMessages(
 	return aiMessages;
 }
 
+function resolveStickySession(
+	request: GatewayStreamRequest,
+	context: GatewayProviderContext,
+):
+	| {
+			transport: "json-body" | "header";
+			field: string;
+			value: string;
+	  }
+	| undefined {
+	const stickySession = context.provider.metadata?.stickySession;
+	if (!stickySession) {
+		return undefined;
+	}
+	const metadata = request.metadata;
+	const value =
+		metadata && typeof metadata === "object"
+			? metadata[stickySession.metadataKey]
+			: undefined;
+	if (typeof value !== "string") {
+		return undefined;
+	}
+	const trimmed = value.trim();
+	if (!trimmed) {
+		return undefined;
+	}
+	return {
+		transport: stickySession.transport,
+		field: stickySession.field,
+		value: trimmed,
+	};
+}
+
+async function bodyTextFromFetchInput(
+	input: Parameters<typeof fetch>[0],
+	init: Parameters<typeof fetch>[1],
+): Promise<string | undefined> {
+	const body = init?.body;
+	if (typeof body === "string") {
+		return body;
+	}
+	if (body instanceof URLSearchParams) {
+		return body.toString();
+	}
+	if (body instanceof ArrayBuffer) {
+		return Buffer.from(body).toString("utf8");
+	}
+	if (ArrayBuffer.isView(body)) {
+		return Buffer.from(body.buffer, body.byteOffset, body.byteLength).toString(
+			"utf8",
+		);
+	}
+	if (body !== undefined && body !== null) {
+		return undefined;
+	}
+	if (input instanceof Request) {
+		try {
+			return await input.clone().text();
+		} catch {
+			return undefined;
+		}
+	}
+	return undefined;
+}
+
+async function injectJsonBodyStickySession(
+	input: Parameters<typeof fetch>[0],
+	init: Parameters<typeof fetch>[1],
+	stickySession: { field: string; value: string },
+): Promise<Parameters<typeof fetch>> {
+	const text = await bodyTextFromFetchInput(input, init);
+	if (!text?.trim().startsWith("{")) {
+		return [input, init];
+	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(text);
+	} catch {
+		return [input, init];
+	}
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+		return [input, init];
+	}
+	const body = parsed as Record<string, unknown>;
+	const existingValue = body[stickySession.field];
+	if (typeof existingValue !== "string" || !existingValue.trim()) {
+		body[stickySession.field] = stickySession.value;
+	}
+	const nextBody = JSON.stringify(body);
+	if (init?.body !== undefined && init.body !== null) {
+		return [input, { ...init, body: nextBody }];
+	}
+	if (input instanceof Request) {
+		return [new Request(input, { body: nextBody }), init];
+	}
+	return [input, { ...init, body: nextBody }];
+}
+
+function injectHeaderStickySession(
+	input: Parameters<typeof fetch>[0],
+	init: Parameters<typeof fetch>[1],
+	stickySession: { field: string; value: string },
+): Parameters<typeof fetch> {
+	const headers = new Headers(input instanceof Request ? input.headers : undefined);
+	new Headers(init?.headers).forEach((value, key) => {
+		headers.set(key, value);
+	});
+	if (!headers.get(stickySession.field)?.trim()) {
+		headers.set(stickySession.field, stickySession.value);
+	}
+	return [input, { ...init, headers }];
+}
+
+function wrapFetchForStickySession(
+	baseFetch: typeof fetch | undefined,
+	request: GatewayStreamRequest,
+	context: GatewayProviderContext,
+): typeof fetch | undefined {
+	const stickySession = resolveStickySession(request, context);
+	if (!stickySession) {
+		return baseFetch;
+	}
+	const delegate = baseFetch ?? globalThis.fetch;
+	if (!delegate) {
+		return baseFetch;
+	}
+	const sessionFetch = (async (input, init) => {
+		const [nextInput, nextInit] =
+			stickySession.transport === "json-body"
+				? await injectJsonBodyStickySession(input, init, stickySession)
+				: injectHeaderStickySession(input, init, stickySession);
+		return delegate(nextInput, nextInit);
+	}) as typeof fetch;
+	const delegateWithPreconnect = delegate as typeof fetch & {
+		preconnect?: (...args: unknown[]) => unknown;
+	};
+	if (typeof delegateWithPreconnect.preconnect === "function") {
+		(
+			sessionFetch as typeof fetch & {
+				preconnect?: (...args: unknown[]) => unknown;
+			}
+		).preconnect = delegateWithPreconnect.preconnect.bind(delegate);
+	}
+	return sessionFetch;
+}
+
 async function ensureGatewayLangfuseTelemetry(
 	providerId: string,
 ): Promise<boolean> {
@@ -892,7 +1038,11 @@ function createAiSdkProvider(kind: ProviderModuleKind): GatewayProviderFactory {
 					kind,
 					{
 						...config,
-						fetch: wrapFetchForProviderRequestCapture(config.fetch, request),
+						fetch: wrapFetchForStickySession(
+							wrapFetchForProviderRequestCapture(config.fetch, request),
+							request,
+							context,
+						),
 					},
 					context,
 				);

--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -43,6 +43,13 @@ export const DEFAULT_EXTERNAL_OCA_BASE_URL =
 const CLINE_DEFAULT_MODEL_ID = "anthropic/claude-sonnet-4.6";
 const CLINE_PASS_PROVIDER_ID = "cline-pass";
 const OPENAI_CODEX_DEFAULT_MODEL_ID = "gpt-5.4";
+const OPENROUTER_STICKY_SESSION_METADATA: GatewayProviderMetadata = {
+	stickySession: {
+		transport: "json-body",
+		field: "session_id",
+		metadataKey: "sessionId",
+	},
+};
 
 export type ProviderFamily =
 	| "openai"
@@ -889,7 +896,10 @@ const OPENAI_COMPATIBLE_SPECS: BuiltinSpec[] = [
 		modelsProviderId: "openrouter",
 		docsUrl: "https://openrouter.ai/models",
 		defaults: { baseUrl: "https://openrouter.ai/api/v1" },
-		metadata: ANTHROPIC_AND_QWEN_CACHE_ROUTING_METADATA,
+		metadata: {
+			...ANTHROPIC_AND_QWEN_CACHE_ROUTING_METADATA,
+			...OPENROUTER_STICKY_SESSION_METADATA,
+		},
 	},
 	{
 		id: "ollama",

--- a/sdk/packages/llms/src/providers/gateway.test.ts
+++ b/sdk/packages/llms/src/providers/gateway.test.ts
@@ -38,6 +38,19 @@ const codexExecSpy = vi.fn((modelId: string) => ({
 	family: "openai-codex",
 }));
 
+function createFetchMock() {
+	const fetchMock = vi.fn(
+		async (
+			_input: Parameters<typeof fetch>[0],
+			_init?: Parameters<typeof fetch>[1],
+		) => new Response("ok"),
+	);
+	return {
+		fetchMock,
+		fetch: fetchMock as unknown as typeof fetch,
+	};
+}
+
 vi.mock("ai", () => ({
 	jsonSchema: (schema: unknown, options: unknown) => ({
 		jsonSchema: schema,
@@ -3851,10 +3864,8 @@ describe("sdk-gateway", () => {
 	});
 
 	it("adds OpenRouter session_id to JSON wire requests from request metadata", async () => {
-		const customFetchMock = vi.fn(
-			async () => new Response("ok"),
-		);
-		const customFetch = customFetchMock as unknown as typeof fetch;
+		const { fetchMock: customFetchMock, fetch: customFetch } =
+			createFetchMock();
 		streamTextSpy.mockReturnValue({
 			fullStream: makeStreamParts([{ type: "finish", finishReason: "stop" }]),
 		});
@@ -3894,8 +3905,8 @@ describe("sdk-gateway", () => {
 	});
 
 	it("adds configured JSON-body sticky session fields for providers that opt in", async () => {
-		const customFetchMock = vi.fn(async () => new Response("ok"));
-		const customFetch = customFetchMock as unknown as typeof fetch;
+		const { fetchMock: customFetchMock, fetch: customFetch } =
+			createFetchMock();
 		streamTextSpy.mockReturnValue({
 			fullStream: makeStreamParts([{ type: "finish", finishReason: "stop" }]),
 		});
@@ -3943,8 +3954,8 @@ describe("sdk-gateway", () => {
 	});
 
 	it("adds configured header sticky session fields for providers that opt in", async () => {
-		const customFetchMock = vi.fn(async () => new Response("ok"));
-		const customFetch = customFetchMock as unknown as typeof fetch;
+		const { fetchMock: customFetchMock, fetch: customFetch } =
+			createFetchMock();
 		streamTextSpy.mockReturnValue({
 			fullStream: makeStreamParts([{ type: "finish", finishReason: "stop" }]),
 		});
@@ -3993,8 +4004,8 @@ describe("sdk-gateway", () => {
 	});
 
 	it("preserves explicit configured header sticky session values", async () => {
-		const customFetchMock = vi.fn(async () => new Response("ok"));
-		const customFetch = customFetchMock as unknown as typeof fetch;
+		const { fetchMock: customFetchMock, fetch: customFetch } =
+			createFetchMock();
 		streamTextSpy.mockReturnValue({
 			fullStream: makeStreamParts([{ type: "finish", finishReason: "stop" }]),
 		});
@@ -4041,10 +4052,8 @@ describe("sdk-gateway", () => {
 	});
 
 	it("preserves explicit OpenRouter session_id in JSON wire requests", async () => {
-		const customFetchMock = vi.fn(
-			async () => new Response("ok"),
-		);
-		const customFetch = customFetchMock as unknown as typeof fetch;
+		const { fetchMock: customFetchMock, fetch: customFetch } =
+			createFetchMock();
 		streamTextSpy.mockReturnValue({
 			fullStream: makeStreamParts([{ type: "finish", finishReason: "stop" }]),
 		});
@@ -4081,11 +4090,49 @@ describe("sdk-gateway", () => {
 		});
 	});
 
-	it("does not fall back to conversationId for OpenRouter session_id", async () => {
-		const customFetchMock = vi.fn(
-			async () => new Response("ok"),
+	it("does not inspect a Request body when init explicitly sets a null body", async () => {
+		const { fetchMock: customFetchMock, fetch: customFetch } =
+			createFetchMock();
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([{ type: "finish", finishReason: "stop" }]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [
+				{ providerId: "openrouter", apiKey: "test-key", fetch: customFetch },
+			],
+		});
+
+		await collect(
+			await gateway.stream({
+				providerId: "openrouter",
+				modelId: "anthropic/claude-test",
+				messages: baseMessages,
+				metadata: { sessionId: "session-openrouter" },
+			}),
 		);
-		const customFetch = customFetchMock as unknown as typeof fetch;
+
+		const config = openaiCompatibleFactorySpy.mock.calls[0]?.[0] as {
+			fetch?: typeof fetch;
+		};
+		const request = new Request(
+			"https://openrouter.ai/api/v1/chat/completions",
+			{
+				method: "POST",
+				body: JSON.stringify({ messages: [{ role: "user", content: "hi" }] }),
+			},
+		);
+		await config.fetch?.(request, { body: null });
+
+		expect(customFetch).toHaveBeenCalledOnce();
+		expect(customFetchMock.mock.calls[0]?.[0]).toBe(request);
+		const init = customFetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+		expect(init?.body).toBeNull();
+	});
+
+	it("does not fall back to conversationId for OpenRouter session_id", async () => {
+		const { fetchMock: customFetchMock, fetch: customFetch } =
+			createFetchMock();
 		streamTextSpy.mockReturnValue({
 			fullStream: makeStreamParts([{ type: "finish", finishReason: "stop" }]),
 		});

--- a/sdk/packages/llms/src/providers/gateway.test.ts
+++ b/sdk/packages/llms/src/providers/gateway.test.ts
@@ -3904,6 +3904,60 @@ describe("sdk-gateway", () => {
 		});
 	});
 
+	it("preserves default model metadata when request metadata is present", async () => {
+		const { fetchMock: customFetchMock, fetch: customFetch } =
+			createFetchMock();
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([{ type: "finish", finishReason: "stop" }]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [
+				{ providerId: "openrouter", apiKey: "test-key", fetch: customFetch },
+			],
+		});
+		const model = gateway.createAgentModel(
+			{
+				providerId: "openrouter",
+				modelId: "anthropic/claude-test",
+			},
+			{
+				metadata: {
+					sessionId: "default-session",
+					traceId: "default-trace",
+				},
+			},
+		);
+
+		await collect(
+			await model.stream({
+				messages: baseMessages,
+				tools: [],
+				options: {
+					metadata: {
+						runId: "request-run",
+						traceId: "request-trace",
+					},
+				},
+			}),
+		);
+
+		const config = openaiCompatibleFactorySpy.mock.calls[0]?.[0] as {
+			fetch?: typeof fetch;
+		};
+		expect(config.fetch).not.toBe(customFetch);
+		await config.fetch?.("https://openrouter.ai/api/v1/chat/completions", {
+			method: "POST",
+			body: JSON.stringify({ messages: [{ role: "user", content: "hi" }] }),
+		});
+
+		expect(customFetch).toHaveBeenCalledOnce();
+		const init = customFetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+		expect(JSON.parse(String(init?.body))).toMatchObject({
+			session_id: "default-session",
+		});
+	});
+
 	it("adds configured JSON-body sticky session fields for providers that opt in", async () => {
 		const { fetchMock: customFetchMock, fetch: customFetch } =
 			createFetchMock();

--- a/sdk/packages/llms/src/providers/gateway.test.ts
+++ b/sdk/packages/llms/src/providers/gateway.test.ts
@@ -424,6 +424,11 @@ describe("sdk-gateway", () => {
 		const openrouter = gateway
 			.listProviders()
 			.find((provider) => provider.id === "openrouter");
+		expect(openrouter?.metadata?.stickySession).toEqual({
+			transport: "json-body",
+			field: "session_id",
+			metadataKey: "sessionId",
+		});
 		const promptCacheRoutes =
 			openrouter?.metadata?.routing?.promptCache?.routes ?? [];
 
@@ -3836,6 +3841,267 @@ describe("sdk-gateway", () => {
 				providerId: "openrouter",
 				modelId: "anthropic/claude-test",
 				messages: baseMessages,
+			}),
+		);
+
+		const config = openaiCompatibleFactorySpy.mock.calls[0]?.[0] as {
+			fetch?: typeof fetch;
+		};
+		expect(config.fetch).toBe(customFetch);
+	});
+
+	it("adds OpenRouter session_id to JSON wire requests from request metadata", async () => {
+		const customFetchMock = vi.fn(
+			async () => new Response("ok"),
+		);
+		const customFetch = customFetchMock as unknown as typeof fetch;
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([{ type: "finish", finishReason: "stop" }]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [
+				{ providerId: "openrouter", apiKey: "test-key", fetch: customFetch },
+			],
+		});
+
+		await collect(
+			await gateway.stream({
+				providerId: "openrouter",
+				modelId: "anthropic/claude-test",
+				messages: baseMessages,
+				metadata: {
+					sessionId: "session-openrouter",
+					conversationId: "conversation-openrouter",
+				},
+			}),
+		);
+
+		const config = openaiCompatibleFactorySpy.mock.calls[0]?.[0] as {
+			fetch?: typeof fetch;
+		};
+		expect(config.fetch).not.toBe(customFetch);
+		await config.fetch?.("https://openrouter.ai/api/v1/chat/completions", {
+			method: "POST",
+			body: JSON.stringify({ messages: [{ role: "user", content: "hi" }] }),
+		});
+
+		expect(customFetch).toHaveBeenCalledOnce();
+		const init = customFetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+		expect(JSON.parse(String(init?.body))).toMatchObject({
+			session_id: "session-openrouter",
+		});
+	});
+
+	it("adds configured JSON-body sticky session fields for providers that opt in", async () => {
+		const customFetchMock = vi.fn(async () => new Response("ok"));
+		const customFetch = customFetchMock as unknown as typeof fetch;
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([{ type: "finish", finishReason: "stop" }]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [
+				{
+					providerId: "openai-compatible",
+					apiKey: "test-key",
+					fetch: customFetch,
+					metadata: {
+						stickySession: {
+							transport: "json-body",
+							field: "sticky_session",
+							metadataKey: "sessionId",
+						},
+					},
+				},
+			],
+		});
+
+		await collect(
+			await gateway.stream({
+				providerId: "openai-compatible",
+				modelId: "custom/model",
+				messages: baseMessages,
+				metadata: { sessionId: "session-longer-than-eight" },
+			}),
+		);
+
+		const config = openaiCompatibleFactorySpy.mock.calls[0]?.[0] as {
+			fetch?: typeof fetch;
+		};
+		expect(config.fetch).not.toBe(customFetch);
+		await config.fetch?.("https://example.test/v1/chat/completions", {
+			method: "POST",
+			body: JSON.stringify({ messages: [{ role: "user", content: "hi" }] }),
+		});
+
+		expect(customFetch).toHaveBeenCalledOnce();
+		const init = customFetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+		expect(JSON.parse(String(init?.body))).toMatchObject({
+			sticky_session: "session-longer-than-eight",
+		});
+	});
+
+	it("adds configured header sticky session fields for providers that opt in", async () => {
+		const customFetchMock = vi.fn(async () => new Response("ok"));
+		const customFetch = customFetchMock as unknown as typeof fetch;
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([{ type: "finish", finishReason: "stop" }]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [
+				{
+					providerId: "openai-compatible",
+					apiKey: "test-key",
+					fetch: customFetch,
+					metadata: {
+						stickySession: {
+							transport: "header",
+							field: "x-session-id",
+							metadataKey: "sessionId",
+						},
+					},
+				},
+			],
+		});
+
+		await collect(
+			await gateway.stream({
+				providerId: "openai-compatible",
+				modelId: "custom/model",
+				messages: baseMessages,
+				metadata: { sessionId: "session-header" },
+			}),
+		);
+
+		const config = openaiCompatibleFactorySpy.mock.calls[0]?.[0] as {
+			fetch?: typeof fetch;
+		};
+		expect(config.fetch).not.toBe(customFetch);
+		await config.fetch?.("https://example.test/v1/chat/completions", {
+			method: "POST",
+			headers: { "x-existing": "kept" },
+			body: JSON.stringify({ messages: [{ role: "user", content: "hi" }] }),
+		});
+
+		expect(customFetch).toHaveBeenCalledOnce();
+		const init = customFetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+		const headers = new Headers(init?.headers);
+		expect(headers.get("x-session-id")).toBe("session-header");
+		expect(headers.get("x-existing")).toBe("kept");
+	});
+
+	it("preserves explicit configured header sticky session values", async () => {
+		const customFetchMock = vi.fn(async () => new Response("ok"));
+		const customFetch = customFetchMock as unknown as typeof fetch;
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([{ type: "finish", finishReason: "stop" }]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [
+				{
+					providerId: "openai-compatible",
+					apiKey: "test-key",
+					fetch: customFetch,
+					metadata: {
+						stickySession: {
+							transport: "header",
+							field: "x-session-id",
+							metadataKey: "sessionId",
+						},
+					},
+				},
+			],
+		});
+
+		await collect(
+			await gateway.stream({
+				providerId: "openai-compatible",
+				modelId: "custom/model",
+				messages: baseMessages,
+				metadata: { sessionId: "session-header" },
+			}),
+		);
+
+		const config = openaiCompatibleFactorySpy.mock.calls[0]?.[0] as {
+			fetch?: typeof fetch;
+		};
+		await config.fetch?.("https://example.test/v1/chat/completions", {
+			method: "POST",
+			headers: { "x-session-id": "explicit-header-session" },
+			body: JSON.stringify({ messages: [{ role: "user", content: "hi" }] }),
+		});
+
+		const init = customFetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+		expect(new Headers(init?.headers).get("x-session-id")).toBe(
+			"explicit-header-session",
+		);
+	});
+
+	it("preserves explicit OpenRouter session_id in JSON wire requests", async () => {
+		const customFetchMock = vi.fn(
+			async () => new Response("ok"),
+		);
+		const customFetch = customFetchMock as unknown as typeof fetch;
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([{ type: "finish", finishReason: "stop" }]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [
+				{ providerId: "openrouter", apiKey: "test-key", fetch: customFetch },
+			],
+		});
+
+		await collect(
+			await gateway.stream({
+				providerId: "openrouter",
+				modelId: "anthropic/claude-test",
+				messages: baseMessages,
+				metadata: { sessionId: "session-openrouter" },
+			}),
+		);
+
+		const config = openaiCompatibleFactorySpy.mock.calls[0]?.[0] as {
+			fetch?: typeof fetch;
+		};
+		await config.fetch?.("https://openrouter.ai/api/v1/chat/completions", {
+			method: "POST",
+			body: JSON.stringify({
+				session_id: "explicit-session",
+				messages: [{ role: "user", content: "hi" }],
+			}),
+		});
+
+		const init = customFetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+		expect(JSON.parse(String(init?.body))).toMatchObject({
+			session_id: "explicit-session",
+		});
+	});
+
+	it("does not fall back to conversationId for OpenRouter session_id", async () => {
+		const customFetchMock = vi.fn(
+			async () => new Response("ok"),
+		);
+		const customFetch = customFetchMock as unknown as typeof fetch;
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([{ type: "finish", finishReason: "stop" }]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [
+				{ providerId: "openrouter", apiKey: "test-key", fetch: customFetch },
+			],
+		});
+
+		await collect(
+			await gateway.stream({
+				providerId: "openrouter",
+				modelId: "anthropic/claude-test",
+				messages: baseMessages,
+				metadata: { conversationId: "conversation-openrouter" },
 			}),
 		);
 

--- a/sdk/packages/llms/src/providers/gateway.ts
+++ b/sdk/packages/llms/src/providers/gateway.ts
@@ -21,6 +21,19 @@ export type * from "@cline/shared";
 
 const GATEWAY_OUTPUT_RESERVE_TOKENS = 1_024;
 
+function mergeRequestMetadata(
+	defaults: Record<string, unknown> | undefined,
+	request: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+	if (!defaults && !request) {
+		return undefined;
+	}
+	return {
+		...(defaults ?? {}),
+		...(request ?? {}),
+	};
+}
+
 export interface Gateway {
 	registerProvider(registration: GatewayProviderRegistration): this;
 	configureProvider(
@@ -92,9 +105,10 @@ class GatewayModelAdapter implements AgentModel {
 			maxTokens:
 				(request.options?.maxTokens as number | undefined) ??
 				this.defaults?.maxTokens,
-			metadata:
-				(request.options?.metadata as Record<string, unknown> | undefined) ??
+			metadata: mergeRequestMetadata(
 				this.defaults?.metadata,
+				request.options?.metadata as Record<string, unknown> | undefined,
+			),
 			reasoning:
 				requestedReasoning ?? legacyReasoning ?? this.defaults?.reasoning,
 			signal: request.signal ?? this.defaults?.signal,

--- a/sdk/packages/shared/src/index.browser.ts
+++ b/sdk/packages/shared/src/index.browser.ts
@@ -193,10 +193,12 @@ export {
 	safeJsonParse,
 	safeJsonStringify,
 } from "./parse/json";
+export { omitUndefinedValues, type OmitUndefinedValues } from "./parse/object";
 export { getDefaultShell, getShellArgs } from "./parse/shell";
 export {
 	maskSecret,
 	sanitizeFileName,
+	trimNonEmpty,
 	truncateSplit,
 	truncateStr,
 } from "./parse/string";

--- a/sdk/packages/shared/src/index.ts
+++ b/sdk/packages/shared/src/index.ts
@@ -207,10 +207,12 @@ export {
 	safeJsonParse,
 	safeJsonStringify,
 } from "./parse/json";
+export { omitUndefinedValues, type OmitUndefinedValues } from "./parse/object";
 export { getDefaultShell, getShellArgs } from "./parse/shell";
 export {
 	maskSecret,
 	sanitizeFileName,
+	trimNonEmpty,
 	truncateSplit,
 	truncateStr,
 } from "./parse/string";

--- a/sdk/packages/shared/src/llms/gateway.ts
+++ b/sdk/packages/shared/src/llms/gateway.ts
@@ -62,14 +62,29 @@ export interface GatewayProviderRouting {
 	};
 }
 
+export type GatewayStickySessionTransport = "json-body" | "header";
+
+export interface GatewayStickySessionMetadata {
+	/**
+	 * Where the provider expects the sticky-session identifier on the wire.
+	 * `field` is a JSON body property for `json-body`, and an HTTP header name
+	 * for `header`.
+	 */
+	transport: GatewayStickySessionTransport;
+	field: string;
+	metadataKey: string;
+}
+
 export interface GatewayProviderMetadata {
 	promptCacheStrategy?: GatewayPromptCacheStrategy;
 	usageCostDisplay?: GatewayUsageCostDisplay;
 	routing?: GatewayProviderRouting;
+	stickySession?: GatewayStickySessionMetadata;
 	configFields?: readonly ProviderConfigField[];
 	[key: string]:
 		| JsonValue
 		| GatewayProviderRouting
+		| GatewayStickySessionMetadata
 		| readonly ProviderConfigField[]
 		| undefined;
 }

--- a/sdk/packages/shared/src/parse/object.test.ts
+++ b/sdk/packages/shared/src/parse/object.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { omitUndefinedValues } from "./object";
+
+describe("omitUndefinedValues", () => {
+	it("removes undefined properties and preserves other falsy values", () => {
+		expect(
+			omitUndefinedValues({
+				sessionId: "session-id",
+				conversationId: undefined,
+				count: 0,
+				enabled: false,
+				empty: "",
+				nullable: null,
+			}),
+		).toEqual({
+			sessionId: "session-id",
+			count: 0,
+			enabled: false,
+			empty: "",
+			nullable: null,
+		});
+	});
+});

--- a/sdk/packages/shared/src/parse/object.ts
+++ b/sdk/packages/shared/src/parse/object.ts
@@ -1,0 +1,24 @@
+type KeysWithUndefinedValues<T extends Record<string, unknown>> = {
+	[K in keyof T]: undefined extends T[K] ? K : never;
+}[keyof T];
+
+type KeysWithoutUndefinedValues<T extends Record<string, unknown>> = Exclude<
+	keyof T,
+	KeysWithUndefinedValues<T>
+>;
+
+export type OmitUndefinedValues<T extends Record<string, unknown>> = Pick<
+	T,
+	KeysWithoutUndefinedValues<T>
+> &
+	Partial<{
+		[K in KeysWithUndefinedValues<T>]: Exclude<T[K], undefined>;
+	}>;
+
+export function omitUndefinedValues<T extends Record<string, unknown>>(
+	value: T,
+): OmitUndefinedValues<T> {
+	return Object.fromEntries(
+		Object.entries(value).filter(([, entry]) => entry !== undefined),
+	) as OmitUndefinedValues<T>;
+}

--- a/sdk/packages/shared/src/parse/string.test.ts
+++ b/sdk/packages/shared/src/parse/string.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { trimNonEmpty } from "./string";
+
+describe("trimNonEmpty", () => {
+	it("returns trimmed strings and omits empty values", () => {
+		expect(trimNonEmpty("  session-id  ")).toBe("session-id");
+		expect(trimNonEmpty("   ")).toBeUndefined();
+		expect(trimNonEmpty("")).toBeUndefined();
+		expect(trimNonEmpty(undefined)).toBeUndefined();
+		expect(trimNonEmpty(null)).toBeUndefined();
+	});
+});

--- a/sdk/packages/shared/src/parse/string.ts
+++ b/sdk/packages/shared/src/parse/string.ts
@@ -2,6 +2,13 @@ export function sanitizeFileName(value: string): string {
 	return value.toLowerCase().replace(/[^\w.-]+/g, "_");
 }
 
+export function trimNonEmpty(
+	value: string | null | undefined,
+): string | undefined {
+	const trimmed = value?.trim();
+	return trimmed ? trimmed : undefined;
+}
+
 export function truncateStr(str: string, maxLen: number): string {
 	if (str.length <= maxLen) return str;
 	return `${str.slice(0, maxLen - 1)}…`;


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

OpenRouter prompt caching was getting weaker cache hit rates because requests did not include a stable session_id as suggested by their docs at https://openrouter.ai/docs/guides/best-practices/prompt-caching#anthropic-claude.

Without that identifier, OpenRouter can route consecutive turns away from the same upstream cache context even when cache_control is present, causing more fresh input billing.

Propagate explicit runtime sessionId metadata from agents into model requests without synthesizing fallback session or conversation ids. Add provider metadata for sticky sessions so OpenRouter maps metadata.sessionId to the JSON body session_id field, while keeping the mechanism extensible for header-based providers.

Apply sticky-session metadata in the AI SDK provider fetch wrapper, preserving explicit wire values when callers already set them. Move trimNonEmpty and omitUndefinedValues into @cline/shared for reuse, and cover the JSON-body, header, and no-fallback paths with tests.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

`bun run build`

`CLINE_SESSION_BACKEND_MODE=local bun run cli --provider openrouter`


After: cost = $0.022356

<img width="869" height="736" alt="image" src="https://github.com/user-attachments/assets/3f04a043-6880-451c-96bf-512164936a34" />


Before: cost = $0.078183

<img width="876" height="737" alt="image" src="https://github.com/user-attachments/assets/cf9b11c0-ee85-4451-8649-26f2117dc609" />


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
