### PR TITLE
fix: wire up SAP provider 

### DIFF
--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -449,6 +449,86 @@ describe("buildSessionConfig", () => {
 		expect((config.providerConfig as any).maxOutputTokens).toBe(4_096)
 	})
 
+	it("builds structured SAP AI Core config from legacy ApiConfiguration fields", async () => {
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "sapaicore",
+			actModeApiModelId: "anthropic--claude-4.6-sonnet",
+			sapAiCoreClientId: "sap-client",
+			sapAiCoreClientSecret: "sap-secret",
+			sapAiCoreBaseUrl: " https://api.ai.example.aws.ml.hana.ondemand.com ",
+			sapAiCoreTokenUrl: " https://example.authentication.sap.hana.ondemand.com ",
+			sapAiResourceGroup: " default ",
+			sapAiCoreUseOrchestrationMode: false,
+			actModeSapAiCoreDeploymentId: " deployment-id ",
+		} as any)
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+
+		expect(config.providerId).toBe("sapaicore")
+		expect(config.modelId).toBe("anthropic--claude-4.6-sonnet")
+		expect(config.apiKey).toBe("")
+		expect(config.baseUrl).toBe("https://api.ai.example.aws.ml.hana.ondemand.com")
+		expect(config.providerConfig).toMatchObject({
+			providerId: "sapaicore",
+			modelId: "anthropic--claude-4.6-sonnet",
+			baseUrl: "https://api.ai.example.aws.ml.hana.ondemand.com",
+			sap: {
+				clientId: "sap-client",
+				clientSecret: "sap-secret",
+				tokenUrl: "https://example.authentication.sap.hana.ondemand.com",
+				resourceGroup: "default",
+				deploymentId: "deployment-id",
+				useOrchestrationMode: false,
+			},
+		})
+		expect(config.providerConfig).not.toHaveProperty("apiKey")
+	})
+
+	it("falls back to legacy SAP-specific model fields when the generic model field is absent", async () => {
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "sapaicore",
+			actModeSapAiCoreModelId: "anthropic--claude-3.5-sonnet",
+		} as any)
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+
+		expect(config.providerId).toBe("sapaicore")
+		expect(config.modelId).toBe("anthropic--claude-3.5-sonnet")
+	})
+
+	it("preserves an explicitly cleared SAP base URL so stored settings cannot fill it back in", async () => {
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "sapaicore",
+			actModeApiModelId: "anthropic--claude-4.6-sonnet",
+			sapAiCoreBaseUrl: "   ",
+		} as any)
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+
+		expect(config.baseUrl).toBe("")
+		expect(config.providerConfig).toMatchObject({
+			providerId: "sapaicore",
+			baseUrl: "",
+		})
+		expect(config.providerConfig).not.toHaveProperty("sap")
+	})
+
+	it("does not emit partial SAP overrides when SAP strings are absent", async () => {
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "sapaicore",
+			actModeApiModelId: "anthropic--claude-4.6-sonnet",
+			sapAiCoreUseOrchestrationMode: false,
+		} as any)
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+
+		expect(config.providerConfig).toMatchObject({
+			providerId: "sapaicore",
+		})
+		expect(config.providerConfig).not.toHaveProperty("baseUrl")
+		expect(config.providerConfig).not.toHaveProperty("sap")
+	})
+
 	it("uses ClinePass model storage and omits empty nested apiKey so SDK OAuth can fill it", async () => {
 		mocks.stateManager.getApiConfiguration.mockReturnValue({
 			actModeApiProvider: "cline-pass",

--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -36,6 +36,7 @@ import { buildAgentHooks } from "./hooks-adapter"
 import { readTaskHistory, resolveDataDir } from "./legacy-state-reader"
 import { toSdkProviderId } from "./model-catalog/sdk-provider-id"
 import { getProviderSettingsManager } from "./provider-migration"
+import { buildSapProviderConfig, type SapProviderConfig } from "./sap-config"
 import type { SdkSessionHost } from "./session-host"
 
 // ---------------------------------------------------------------------------
@@ -274,7 +275,6 @@ const PROVIDER_API_KEY_MAP: Record<string, keyof ApiConfiguration> = {
 	aihubmix: "aihubmixApiKey",
 	nousResearch: "nousResearchApiKey",
 	"vercel-ai-gateway": "vercelAiGatewayApiKey",
-	sapaicore: "sapAiCoreClientId", // SAP uses client ID + secret
 	claude_code: "apiKey", // Claude Code uses anthropic key
 	wandb: "wandbApiKey",
 	"qwen-code": "qwenApiKey",
@@ -312,7 +312,6 @@ const PROVIDER_MODEL_ID_MAP: Record<string, { plan: keyof ApiConfiguration; act:
 	hicap: { plan: "planModeHicapModelId", act: "actModeHicapModelId" },
 	nousResearch: { plan: "planModeNousResearchModelId", act: "actModeNousResearchModelId" },
 	"vercel-ai-gateway": { plan: "planModeVercelAiGatewayModelId", act: "actModeVercelAiGatewayModelId" },
-	sapaicore: { plan: "planModeSapAiCoreModelId", act: "actModeSapAiCoreModelId" },
 }
 
 // ---------------------------------------------------------------------------
@@ -414,6 +413,16 @@ export function resolveModelId(providerId: string, mode: Mode, config: ApiConfig
 		return selector ? stringifyVsCodeLmModelSelector(selector) || undefined : undefined
 	}
 
+	if (providerId === "sapaicore") {
+		const genericField = mode === "plan" ? "planModeApiModelId" : "actModeApiModelId"
+		const legacyField = mode === "plan" ? "planModeSapAiCoreModelId" : "actModeSapAiCoreModelId"
+		return (
+			(config[genericField] as string | undefined)?.trim() ||
+			(config[legacyField] as string | undefined)?.trim() ||
+			undefined
+		)
+	}
+
 	// Check provider-specific mode model ID fields.
 	// If the provider has a dedicated field, do not fall back to generic
 	// *ModeApiModelId. Those generic slots may contain a stale model from a
@@ -499,6 +508,7 @@ export function resolveBaseUrl(providerId: string, config: ApiConfiguration): st
 		oca: "ocaBaseUrl",
 		aihubmix: "aihubmixBaseUrl",
 		dify: "difyBaseUrl",
+		sapaicore: "sapAiCoreBaseUrl",
 	}
 
 	const field = baseUrlMap[providerId]
@@ -544,6 +554,7 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 	// region/project/auth fields for inference calls.
 	let bedrockProviderConfig: BedrockProviderConfig | undefined
 	let vertexProviderConfig: Pick<ProviderSettings, "gcp" | "region"> | undefined
+	let sapProviderConfig: SapProviderConfig | undefined
 
 	try {
 		const stateManager = StateManager.get()
@@ -575,6 +586,11 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 
 			if (providerId === "vertex") {
 				vertexProviderConfig = resolveVertexProviderConfig(apiConfig)
+			}
+
+			if (providerId === "sapaicore") {
+				sapProviderConfig = buildSapProviderConfig(apiConfig, mode)
+				baseUrl = sapProviderConfig.baseUrl
 			}
 
 			Logger.log(
@@ -673,9 +689,9 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 	// Always pass a providerConfig so the proxy/CA-aware fetch reaches the SDK
 	// gateway; without it the agent loop uses bare global fetch and corporate
 	// proxy/self-signed CA setups fail on JetBrains and CLI. Cloud providers
-	// additionally need structured options (region/project/auth), which core
+	// additionally need structured options (region/project/auth/SAP OAuth), which core
 	// reads from providerConfig in createAgentModelFromConfig.
-	const cloudProviderConfig = bedrockProviderConfig ?? vertexProviderConfig
+	const cloudProviderConfig = bedrockProviderConfig ?? vertexProviderConfig ?? sapProviderConfig
 	// Spread the cloud config first so the explicit fields below — notably the
 	// proxy/CA-aware fetch — can never be clobbered if those types gain matching keys.
 	const providerConfig = {
@@ -683,7 +699,7 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 		providerId: sdkProviderId,
 		modelId,
 		...(apiKey ? { apiKey } : {}),
-		baseUrl,
+		...(baseUrl !== undefined ? { baseUrl } : {}),
 		...(knownModels ? { knownModels } : {}),
 		...(modelId && positiveNumber(knownModels?.[modelId]?.maxTokens)
 			? { maxOutputTokens: positiveNumber(knownModels?.[modelId]?.maxTokens) }

--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -508,7 +508,6 @@ export function resolveBaseUrl(providerId: string, config: ApiConfiguration): st
 		oca: "ocaBaseUrl",
 		aihubmix: "aihubmixBaseUrl",
 		dify: "difyBaseUrl",
-		sapaicore: "sapAiCoreBaseUrl",
 	}
 
 	const field = baseUrlMap[providerId]

--- a/apps/vscode/src/sdk/sap-config.ts
+++ b/apps/vscode/src/sdk/sap-config.ts
@@ -1,0 +1,47 @@
+// Maps the extension's legacy SAP AI Core ApiConfiguration onto the SDK's
+// structured SAP provider options (baseUrl + sap block).
+//
+// buildSessionConfig() uses this to hand the SDK runtime the same structured
+// SAP fields that the legacy UI stores in ApiConfiguration.
+
+import type { ProviderSettings } from "@cline/core"
+import type { ApiConfiguration } from "@shared/api"
+import type { Mode } from "@shared/storage/types"
+
+export type SapProviderConfig = Pick<ProviderSettings, "baseUrl" | "sap">
+
+function trimString(value: unknown): string | undefined {
+	if (typeof value !== "string") {
+		return undefined
+	}
+
+	return value.trim()
+}
+
+export function buildSapProviderConfig(config: ApiConfiguration, mode: Mode): SapProviderConfig {
+	const sap: NonNullable<SapProviderConfig["sap"]> = {}
+	const baseUrl = trimString(config.sapAiCoreBaseUrl)
+	const deploymentId = trimString(mode === "plan" ? config.planModeSapAiCoreDeploymentId : config.actModeSapAiCoreDeploymentId)
+	const sapFields = {
+		clientId: trimString(config.sapAiCoreClientId),
+		clientSecret: trimString(config.sapAiCoreClientSecret),
+		tokenUrl: trimString(config.sapAiCoreTokenUrl),
+		resourceGroup: trimString(config.sapAiResourceGroup),
+		deploymentId,
+	}
+
+	for (const [key, value] of Object.entries(sapFields)) {
+		if (value !== undefined) {
+			sap[key as keyof typeof sapFields] = value
+		}
+	}
+
+	if (Object.keys(sap).length > 0 && config.sapAiCoreUseOrchestrationMode !== undefined) {
+		sap.useOrchestrationMode = config.sapAiCoreUseOrchestrationMode
+	}
+
+	return {
+		...(baseUrl !== undefined ? { baseUrl } : {}),
+		...(Object.keys(sap).length > 0 ? { sap } : {}),
+	}
+}


### PR DESCRIPTION
This fixes SAP AI Core wiring in the VS Code SDK session bridge.

SAP AI Core already has SDK/runtime support for its structured configuration, but the VS Code session builder was still treating it like a mostly flat legacy provider. That meant task sessions could omit the SAP `baseUrl`, fail to pass the structured `sap` options into the SDK runtime, and accidentally treat the SAP client ID as a generic `apiKey`.

The change keeps the fix scoped to the session-config bridge:

- Adds a small SAP mapper that translates legacy `ApiConfiguration` fields into the SDK shape: `baseUrl` plus `sap.{clientId, clientSecret, tokenUrl, resourceGroup, deploymentId, useOrchestrationMode}`.
- Wires SAP into `buildSessionConfig()` alongside the existing Bedrock/Vertex cloud-provider config path.
- Stops mapping SAP's client ID as a generic API key.
- Resolves SAP model IDs from the generic mode model field first, with the legacy SAP-specific model field as fallback.
- Avoids emitting partial SAP/baseUrl overrides when SAP legacy string fields are absent, so migrated `providers.json` settings are not clobbered by undefined session values.

Per-mode SAP deployment behavior remains as-is; this only ensures the selected mode's legacy deployment field is forwarded when present.

