### PR TITLE
fix(core): migrate legacy reasoning effort

### DIFF
--- a/sdk/packages/core/src/services/storage/provider-settings-legacy-migration.test.ts
+++ b/sdk/packages/core/src/services/storage/provider-settings-legacy-migration.test.ts
@@ -71,6 +71,43 @@ describe("migrateLegacyProviderSettings", () => {
 		expect(manager.read().providers.anthropic?.tokenSource).toBe("migration");
 	});
 
+	it("migrates legacy OCA-specific reasoning effort into provider settings", () => {
+		const tempDir = mkdtempSync(
+			path.join(os.tmpdir(), "core-legacy-provider-"),
+		);
+		tempDirs.push(tempDir);
+		const providersPath = path.join(tempDir, "provider-settings.json");
+		const manager = new ProviderSettingsManager({ filePath: providersPath });
+
+		writeFileSync(
+			path.join(tempDir, "globalState.json"),
+			JSON.stringify(
+				{
+					mode: "plan",
+					planModeApiProvider: "oca",
+					actModeReasoningEffort: "low",
+					planModeOcaReasoningEffort: "high",
+					actModeOcaReasoningEffort: "medium",
+				},
+				null,
+				2,
+			),
+		);
+		writeFileSync(
+			path.join(tempDir, "secrets.json"),
+			JSON.stringify({ ocaApiKey: "legacy-oca-key" }, null, 2),
+		);
+
+		migrateLegacyProviderSettings({
+			providerSettingsManager: manager,
+			dataDir: tempDir,
+		});
+
+		expect(manager.getProviderSettings("oca")?.reasoning).toEqual({
+			effort: "medium",
+		});
+	});
+
 	it("migrates missing providers without overwriting existing providers", () => {
 		const tempDir = mkdtempSync(
 			path.join(os.tmpdir(), "core-legacy-provider-"),

--- a/sdk/packages/core/src/services/storage/provider-settings-legacy-migration.ts
+++ b/sdk/packages/core/src/services/storage/provider-settings-legacy-migration.ts
@@ -24,6 +24,8 @@ interface LegacyGlobalState {
 	actModeApiModelId?: string;
 	planModeReasoningEffort?: string;
 	actModeReasoningEffort?: string;
+	planModeOcaReasoningEffort?: string;
+	actModeOcaReasoningEffort?: string;
 	planModeThinkingBudgetTokens?: number;
 	actModeThinkingBudgetTokens?: number;
 	geminiPlanModeThinkingLevel?: string;
@@ -337,25 +339,30 @@ function resolveReasoning(
 	providerId: string,
 	mode: LegacyMode,
 ): ProviderSettings["reasoning"] | undefined {
-	const effortCandidate =
-		mode === "plan"
-			? legacy.planModeReasoningEffort
-			: legacy.actModeReasoningEffort;
-	const geminiLevel =
-		mode === "plan"
-			? legacy.geminiPlanModeThinkingLevel
-			: legacy.geminiActModeThinkingLevel;
 	const budgetTokens =
 		mode === "plan"
 			? legacy.planModeThinkingBudgetTokens
 			: legacy.actModeThinkingBudgetTokens;
-	const rawEffort =
-		(providerId === "gemini" ? geminiLevel : undefined) ?? effortCandidate;
+	// ProviderSettings has one reasoning effort; legacy state had mode-specific
+	// fields, with OCA/Gemini using provider-specific variants.
+	const rawEffort = [
+		...(providerId === "oca"
+			? [legacy.actModeOcaReasoningEffort, legacy.planModeOcaReasoningEffort]
+			: []),
+		...(providerId === "gemini"
+			? [legacy.geminiActModeThinkingLevel, legacy.geminiPlanModeThinkingLevel]
+			: []),
+		legacy.actModeReasoningEffort,
+		legacy.planModeReasoningEffort,
+	]
+		.map(trimNonEmpty)
+		.find(Boolean);
 	const effort =
 		rawEffort === "none" ||
 		rawEffort === "low" ||
 		rawEffort === "medium" ||
-		rawEffort === "high"
+		rawEffort === "high" ||
+		rawEffort === "xhigh"
 			? rawEffort
 			: undefined;
 	const normalizedBudget =


### PR DESCRIPTION
### Related Issue

**Issue:** N/A - small SDK migration bug fix.

### Description

Legacy VS Code configuration stored reasoning effort in mode-specific fields such as `actModeReasoningEffort` and `planModeReasoningEffort`. OCA also stored the same concept in provider-specific legacy fields: `actModeOcaReasoningEffort` and `planModeOcaReasoningEffort`.

The SDK provider settings schema has one provider-level `reasoning` object, so this PR converts the legacy fields during provider-settings migration instead of adding a runtime bridge in session construction.

`resolveReasoning` now builds an ordered list of legacy effort candidates:

```ts
const rawEffort = [
  ...(providerId === "oca" ? [legacy.actModeOcaReasoningEffort, legacy.planModeOcaReasoningEffort] : []),
  ...(providerId === "gemini" ? [legacy.geminiActModeThinkingLevel, legacy.geminiPlanModeThinkingLevel] : []),
  legacy.actModeReasoningEffort,
  legacy.planModeReasoningEffort,
]
  .map(trimNonEmpty)
  .find(Boolean)
```

That collapses legacy mode-specific reasoning into the provider-level SDK shape by preferring Act over Plan. OCA-specific values are checked before generic values so upgraded OCA users keep the value selected by the old OCA model picker.

After the base branch was rebased, this PR branch was rebuilt on top of the new `dpc/sdk-migration-simpler-login` head and force-pushed so the diff contains only this migration fix.

### Test Procedure

Ran the focused SDK migration tests:

```sh
bun run --cwd sdk/packages/core test:unit src/services/storage/provider-settings-legacy-migration.test.ts
```

Ran SDK core typecheck:

```sh
bun run --cwd sdk/packages/core typecheck
```

Ran whitespace validation:

```sh
git diff --check
```

The migration tests cover:

- existing generic legacy reasoning migration behavior in the baseline provider migration test
- OCA-specific legacy reasoning effort migrating into `ProviderSettings.reasoning`
- OCA-specific effort taking priority over generic effort, with Act preferred over Plan when both OCA legacy mode fields exist

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed contributor guidelines

### Screenshots

N/A - migration-only SDK storage change.

### Additional Notes

This does not preserve separate Plan/Act reasoning effort values after migration. That is intentional for the minimal provider-level migration path: legacy values are collapsed to the new `ProviderSettings.reasoning` shape, with Act preferred over Plan.
