### PR TITLE
Add Atomic Chat to "Works With Every Model" table

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Cline is not locked to a single AI provider. Use whichever model fits your workf
 | AWS Bedrock | Claude, Llama, and more |
 | Azure / GCP Vertex | All hosted models |
 | Cerebras / Groq | Fast inference models |
-| Ollama / LM Studio | Run local models on your machine |
+| Ollama / LM Studio / Atomic Chat | Run local models on your machine |
 | Any OpenAI-compatible API | Self-hosted or third-party endpoints |
 
 ## Extend With Plugins or MCP Servers


### PR DESCRIPTION
### Related Issue

**Issue:** N/A — minor documentation wording update (eligible for direct submission per PR template).

### Description

Updates the **Works With Every Model** table in `README.md` to list **Atomic Chat** alongside **Ollama** and **LM Studio** as a supported way to run local models.

[Atomic Chat](https://atomic.chat) is a desktop app for running local LLMs with an OpenAI-compatible API. Cline already documents Atomic Chat in the local models guide (`docs/running-models-locally/overview.mdx`) and provider config (`docs/provider-config/atomic-chat.mdx`) via #11453; this change aligns the main README provider table with that support.

### Test Procedure

- Opened `README.md` and confirmed the table row now reads `Ollama / LM Studio / Atomic Chat`.
- Verified markdown table formatting is unchanged (single-line edit, no broken pipes).
- No runtime or build impact — documentation-only change.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`) — N/A for README-only edit
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — one-word addition to an existing README table row.

### Additional Notes

Related implementation PR: #11453 (Atomic Chat as a first-class local provider). This PR is intentionally scoped to the README table only for a quick, reviewable docs fix.

Made with [Cursor](https://cursor.com)