### PR TITLE
docs: include streamable HTTP MCP type

### DIFF
--- a/docs/mcp/mcp-overview.mdx
+++ b/docs/mcp/mcp-overview.mdx
@@ -95,6 +95,7 @@ When adding a server, the CLI prompts for server name, transport type, command/a
 {
   "mcpServers": {
     "remote-server": {
+      "type": "streamableHttp",
       "url": "https://example.com/mcp",
       "headers": {
         "Authorization": "Bearer your-token"


### PR DESCRIPTION
Summary
- Add `"type": "streamableHttp"` to the remote MCP JSON example.
- Align the copy-paste config with the docs recommendation for Streamable HTTP instead of falling back to legacy SSE.

Tests
- git diff --check

Fixes #11670