### PR TITLE
fix: send raw base64 images to Ollama

### DIFF
--- a/apps/vscode/src/core/api/transform/ollama-format.test.ts
+++ b/apps/vscode/src/core/api/transform/ollama-format.test.ts
@@ -1,0 +1,70 @@
+import { describe, it } from "mocha"
+import "should"
+import type { ClineStorageMessage } from "@/shared/messages/content"
+import { convertToOllamaMessages } from "./ollama-format"
+
+describe("convertToOllamaMessages", () => {
+	it("sends user images as raw base64 image payloads", () => {
+		const messages: Omit<ClineStorageMessage, "modelInfo">[] = [
+			{
+				role: "user",
+				content: [
+					{ type: "text", text: "Describe this image" },
+					{
+						type: "image",
+						source: {
+							type: "base64",
+							media_type: "image/png",
+							data: "aGVsbG8=",
+						},
+					},
+				],
+			},
+		]
+
+		const result = convertToOllamaMessages(messages)
+
+		result.should.deepEqual([
+			{
+				role: "user",
+				content: "Describe this image",
+				images: ["aGVsbG8="],
+			},
+		])
+	})
+
+	it("sends tool result images as raw base64 image payloads", () => {
+		const messages: Omit<ClineStorageMessage, "modelInfo">[] = [
+			{
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "tool-1",
+						content: [
+							{ type: "text", text: "Screenshot captured" },
+							{
+								type: "image",
+								source: {
+									type: "base64",
+									media_type: "image/jpeg",
+									data: "cmF3LWpwZw==",
+								},
+							},
+						],
+					},
+				],
+			},
+		]
+
+		const result = convertToOllamaMessages(messages)
+
+		result.should.deepEqual([
+			{
+				role: "user",
+				content: "Screenshot captured\n(see following user message for image)",
+				images: ["cmF3LWpwZw=="],
+			},
+		])
+	})
+})

--- a/apps/vscode/src/core/api/transform/ollama-format.ts
+++ b/apps/vscode/src/core/api/transform/ollama-format.ts
@@ -12,6 +12,18 @@ function getOllamaImageData(source: ClineImageContentBlock["source"]): string {
 	return getBase64ImageSource(source).data;
 }
 
+function isImageContentBlock(
+	part: ClineTextContentBlock | ClineImageContentBlock,
+): part is ClineImageContentBlock {
+	return part.type === "image";
+}
+
+function isTextContentBlock(
+	part: ClineTextContentBlock | ClineImageContentBlock,
+): part is ClineTextContentBlock {
+	return part.type === "text";
+}
+
 export function convertToOllamaMessages(
 	anthropicMessages: Omit<ClineStorageMessage, "modelInfo">[],
 ): Message[] {
@@ -71,10 +83,10 @@ export function convertToOllamaMessages(
 				// Process non-tool messages
 				if (nonToolMessages.length > 0) {
 					const images = nonToolMessages
-						.filter((part) => part.type === "image")
+						.filter(isImageContentBlock)
 						.map((part) => getOllamaImageData(part.source));
 					const content = nonToolMessages
-						.filter((part) => part.type === "text")
+						.filter(isTextContentBlock)
 						.map((part) => part.text)
 						.join("\n");
 

--- a/apps/vscode/src/core/api/transform/ollama-format.ts
+++ b/apps/vscode/src/core/api/transform/ollama-format.ts
@@ -5,8 +5,12 @@ import {
 	type ClineStorageMessage,
 	type ClineTextContentBlock,
 	type ClineUserToolResultContentBlock,
-	getImageDataUrl,
+	getBase64ImageSource,
 } from "@/shared/messages/content";
+
+function getOllamaImageData(source: ClineImageContentBlock["source"]): string {
+	return getBase64ImageSource(source).data;
+}
 
 export function convertToOllamaMessages(
 	anthropicMessages: Omit<ClineStorageMessage, "modelInfo">[],
@@ -38,8 +42,8 @@ export function convertToOllamaMessages(
 					);
 
 				// Process tool result messages FIRST since they must follow the tool use messages
-				const toolResultImages: string[] = [];
 				toolMessages.forEach((toolMessage) => {
+					const toolResultImages: string[] = [];
 					// The Anthropic SDK allows tool results to be a string or an array of text and image blocks, enabling rich and structured content. In contrast, the Ollama SDK only supports tool results as a single string, so we map the Anthropic tool result parts into one concatenated string to maintain compatibility.
 					let content: string;
 
@@ -50,7 +54,7 @@ export function convertToOllamaMessages(
 							toolMessage.content
 								?.map((part) => {
 									if (part.type === "image") {
-										toolResultImages.push(getImageDataUrl(part.source));
+										toolResultImages.push(getOllamaImageData(part.source));
 										return "(see following user message for image)";
 									}
 									return part.text;
@@ -66,16 +70,18 @@ export function convertToOllamaMessages(
 
 				// Process non-tool messages
 				if (nonToolMessages.length > 0) {
+					const images = nonToolMessages
+						.filter((part) => part.type === "image")
+						.map((part) => getOllamaImageData(part.source));
+					const content = nonToolMessages
+						.filter((part) => part.type === "text")
+						.map((part) => part.text)
+						.join("\n");
+
 					ollamaMessages.push({
 						role: "user",
-						content: nonToolMessages
-							.map((part) => {
-								if (part.type === "image") {
-									return getImageDataUrl(part.source);
-								}
-								return part.text;
-							})
-							.join("\n"),
+						content,
+						images: images.length > 0 ? images : undefined,
 					});
 				}
 			} else if (anthropicMessage.role === "assistant") {


### PR DESCRIPTION
Summary
- Send user image blocks through Ollama `images` instead of embedding data URLs into message content.
- Strip the `data:image/...;base64,` wrapper by using the stored raw base64 image source.
- Apply the same raw-base64 handling to image tool results and add transform coverage.

Tests
- `git diff --check HEAD~1..HEAD`

Notes
- Targeted unit tests could not be run locally. A fresh root `bun install` succeeded, but `apps/vscode` is excluded from the root workspace; `npm install` inside `apps/vscode` failed while compiling `better-sqlite3` under local Node v26 (`PropertyCallbackInfo` API errors). The package warnings indicate this dependency supports Node <26.