### PR TITLE
fix(core): forward SAP provider options to gateway

### DIFF
--- a/sdk/packages/core/src/services/llms/handler-factory.test.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.test.ts
@@ -301,6 +301,87 @@ describe("createAgentModelFromConfig", () => {
 		);
 	});
 
+	it("forwards SAP AI Core settings as gateway provider options", async () => {
+		const { createAgentModelFromConfig } = await import("./handler-factory");
+
+		createAgentModelFromConfig(
+			{
+				providerId: "sapaicore",
+				modelId: "anthropic--claude-4.6-sonnet",
+				baseUrl: "https://api.ai.example.aws.ml.hana.ondemand.com",
+				systemPrompt: "",
+				tools: [],
+				providerConfig: {
+					providerId: "sapaicore",
+					modelId: "anthropic--claude-4.6-sonnet",
+					sap: {
+						clientId: "sap-client",
+						clientSecret: "sap-secret",
+						tokenUrl: "https://auth.example",
+						resourceGroup: "default",
+						deploymentId: "deployment-id",
+						useOrchestrationMode: false,
+					},
+				},
+			},
+			undefined,
+		);
+
+		expect(gatewayMock.createGateway).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				providerConfigs: [
+					expect.objectContaining({
+						providerId: "sapaicore",
+						baseUrl: "https://api.ai.example.aws.ml.hana.ondemand.com",
+						options: expect.objectContaining({
+							clientId: "sap-client",
+							clientSecret: "sap-secret",
+							tokenUrl: "https://auth.example",
+							resourceGroup: "default",
+							deploymentId: "deployment-id",
+							useOrchestrationMode: false,
+						}),
+					}),
+				],
+			}),
+		);
+
+		const gatewayConfig = (
+			gatewayMock.createGateway.mock.calls as unknown as Array<
+				[
+					{
+						providerConfigs: Array<Record<string, unknown>>;
+					},
+				]
+			>
+		).at(-1)?.[0];
+		const { createSapAiCoreProviderModule } = await import(
+			"../../../../llms/src/providers/vendors/community"
+		);
+		const provider = await createSapAiCoreProviderModule(
+			gatewayConfig?.providerConfigs[0] as never,
+		);
+		const model = provider.model("anthropic--claude-4.6-sonnet") as {
+			config?: {
+				destination?: Record<string, unknown>;
+				deploymentConfig?: Record<string, unknown>;
+				providerApi?: string;
+			};
+		};
+
+		expect(model.config?.destination).toMatchObject({
+			authentication: "OAuth2ClientCredentials",
+			clientId: "sap-client",
+			clientSecret: "sap-secret",
+			tokenServiceUrl: "https://auth.example/oauth/token",
+			url: "https://api.ai.example.aws.ml.hana.ondemand.com",
+		});
+		expect(model.config?.deploymentConfig).toMatchObject({
+			deploymentId: "deployment-id",
+		});
+		expect(model.config?.providerApi).toBe("foundation-models");
+	});
+
 	it("forwards Azure settings as OpenAI-compatible gateway provider options", async () => {
 		const { createAgentModelFromConfig } = await import("./handler-factory");
 

--- a/sdk/packages/core/src/services/llms/handler-factory.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.ts
@@ -74,6 +74,10 @@ function buildGatewayProviderOptions(
 		});
 	}
 
+	if (config.providerId === "sapaicore") {
+		Object.assign(options, config.sap);
+	}
+
 	return compactOptions(options);
 }
 


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

SAP AI Core still failed in the nightly after the VS Code session config mapper landed. The extension now builds `providerConfig.sap` correctly, but the core runtime was dropping that structured SAP block before it reached the SDK gateway. The SAP provider adapter reads `clientId`, `clientSecret`, `tokenUrl`, `resourceGroup`, `deploymentId`, and `useOrchestrationMode` from gateway provider `options`; without this handoff it throws:

```text
SAP AI Core provider is missing required configuration: sap.clientId, sap.tokenUrl, baseUrl.
```

This PR adds the missing final hop in `buildGatewayProviderOptions()` for `sapaicore` by forwarding `config.sap` into gateway options. The change mirrors the existing provider-specific option forwarding for Bedrock, Vertex, and Azure, and keeps the fix scoped to the runtime boundary that was still losing SAP configuration.

The regression test covers two layers:

1. `createAgentModelFromConfig()` now sends SAP fields through the mocked gateway provider config.
2. The captured gateway config is then fed into the real SAP provider adapter, proving those forwarded values become the SAP OAuth destination, deployment config, and foundation-models API selection.

I also ran a no-network negative smoke with fake SAP endpoints through `createAgentModelFromConfig(...).stream(...)`. With this fix, the failure moves past local configuration validation and becomes the expected fake-auth failure from the SAP SDK provider, not the previous missing-config error.

### Test Procedure

Ran focused regression and smoke coverage:

```bash
bunx vitest run src/services/llms/handler-factory.test.ts
# 11 passed

bunx vitest run src/sdk/cline-session-factory.test.ts --config vitest.config.ts
# 42 passed

bunx vitest run src/providers/vendors/community.test.ts
# 2 passed

bun -F @cline/core typecheck
# passed

git diff --check
# passed
```

Additional manual smoke, using fake SAP credentials/endpoints and no real SAP service access:

```text
createAgentModelFromConfig(...).stream(...) -> SAP provider initializes with the forwarded destination and fails later with an OAuth token fetch error.
```

That confirms the local missing-configuration error is no longer produced once `baseUrl` and `sap.*` settings are present.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. Runtime SDK provider-config forwarding fix; no UI changes.

### Additional Notes

This does not perform a live SAP AI Core request because we do not have valid SAP service credentials in this environment. The added regression test and manual negative smoke cover the local Cline handoff that was responsible for the reported missing configuration error.
