### PR TITLE
Build the SDK sourcemaps

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -169,7 +169,8 @@
 			"isBackground": true,
 			"label": "npm: watch:esbuild",
 			"dependsOn": [
-				"npm: protos"
+				"npm: protos",
+				"build-sdk:debug"
 			],
 			"presentation": {
 				"group": "watch",
@@ -208,7 +209,8 @@
 			"isBackground": true,
 			"label": "npm: watch:esbuild:test",
 			"dependsOn": [
-				"npm: protos"
+				"npm: protos",
+				"build-sdk:debug"
 			],
 			"presentation": {
 				"group": "watch",
@@ -310,6 +312,24 @@
 			],
 			"options": {
 				"cwd": "${workspaceFolder}"
+			}
+		},
+		{
+			"label": "build-sdk:debug",
+			"type": "shell",
+			"command": "bun run build:sdk",
+			"problemMatcher": [
+				"$tsc"
+			],
+			"presentation": {
+				"group": "watch",
+				"reveal": "always"
+			},
+			"options": {
+				"cwd": "${workspaceFolder}",
+				"env": {
+					"CLINE_SOURCEMAPS": "1"
+				}
 			}
 		}
 	],

--- a/sdk/packages/agents/bun.mts
+++ b/sdk/packages/agents/bun.mts
@@ -5,13 +5,15 @@ export {};
 // the Agent facade loads dynamically. `@cline/shared` stays bundled.
 const external = ["@cline/llms", "nanoid"];
 const sourcemap = Bun.env.CLINE_SOURCEMAPS === "1" ? "linked" : "none";
+// minify: true keeps identifier mangling active even when sourcemaps are enabled.
+const minify = Bun.env.CLINE_SOURCEMAPS !== "1";
 
 const builds: Parameters<typeof Bun.build>[0][] = [
 	{
 		entrypoints: ["./src/index.ts"],
 		outdir: "./dist",
 		target: "node",
-		minify: true,
+		minify,
 		sourcemap,
 		packages: "bundle",
 		external,

--- a/sdk/packages/core/bun.mts
+++ b/sdk/packages/core/bun.mts
@@ -18,11 +18,13 @@ const external = Object.keys({
 });
 
 const sourcemap = Bun.env.CLINE_SOURCEMAPS === "1" ? "linked" : "none";
+// minify: true keeps identifier mangling active even when sourcemaps are enabled.
+const minify = Bun.env.CLINE_SOURCEMAPS !== "1";
 
 const buildConfig = {
 	target: "node",
 	format: "esm",
-	minify: true,
+	minify,
 	packages: "bundle",
 	sourcemap,
 	external,

--- a/sdk/packages/llms/bun.mts
+++ b/sdk/packages/llms/bun.mts
@@ -10,6 +10,8 @@ const packageJson = (await Bun.file(
 	new URL("./package.json", import.meta.url),
 ).json()) as PackageManifest;
 const sourcemap = Bun.env.CLINE_SOURCEMAPS === "1" ? "linked" : "none";
+// minify: true keeps identifier mangling active even when sourcemaps are enabled.
+const minify = Bun.env.CLINE_SOURCEMAPS !== "1";
 
 // Keep published third-party runtime packages external, but bundle internal workspace code.
 const external = Object.keys({
@@ -24,7 +26,7 @@ const builds: Parameters<typeof Bun.build>[0][] = [
 		target: "node",
 		external,
 		packages: "bundle",
-		minify: true,
+		minify,
 		sourcemap,
 	},
 	{
@@ -33,7 +35,7 @@ const builds: Parameters<typeof Bun.build>[0][] = [
 		target: "browser",
 		external,
 		packages: "bundle",
-		minify: true,
+		minify,
 		sourcemap,
 	},
 ];

--- a/sdk/packages/sdk/bun.mts
+++ b/sdk/packages/sdk/bun.mts
@@ -1,14 +1,16 @@
 export {};
 
 const sourcemap = Bun.env.CLINE_SOURCEMAPS === "1" ? "linked" : "none";
+// minify: true keeps identifier mangling active even when sourcemaps are enabled.
+const minify = Bun.env.CLINE_SOURCEMAPS !== "1";
 
 const result = await Bun.build({
 	entrypoints: ["./src/index.ts"],
 	outdir: "./dist",
 	target: "node",
 	format: "esm",
-	minify: true,
 	packages: "bundle",
+	minify,
 	sourcemap,
 	external: ["@cline/core"],
 });

--- a/sdk/packages/sdk/bun.mts
+++ b/sdk/packages/sdk/bun.mts
@@ -1,5 +1,7 @@
 export {};
 
+const sourcemap = Bun.env.CLINE_SOURCEMAPS === "1" ? "linked" : "none";
+
 const result = await Bun.build({
 	entrypoints: ["./src/index.ts"],
 	outdir: "./dist",
@@ -7,7 +9,7 @@ const result = await Bun.build({
 	format: "esm",
 	minify: true,
 	packages: "bundle",
-	sourcemap: "none",
+	sourcemap,
 	external: ["@cline/core"],
 });
 

--- a/sdk/packages/shared/bun.mts
+++ b/sdk/packages/shared/bun.mts
@@ -8,6 +8,8 @@ const buildMode: BuildMode =
 
 const shouldEmitTypes = buildMode === "package";
 const sourcemap = Bun.env.CLINE_SOURCEMAPS === "1" ? "linked" : "none";
+// minify: true keeps identifier mangling active even when sourcemaps are enabled.
+const minify = Bun.env.CLINE_SOURCEMAPS !== "1";
 
 const runBuild = async (
 	name: string,
@@ -40,7 +42,7 @@ await runBuild("node", {
 	],
 	outdir: "./dist",
 	target: "node",
-	minify: true,
+	minify,
 	sourcemap,
 });
 
@@ -48,7 +50,7 @@ await runBuild("browser", {
 	entrypoints: ["./src/index.browser.ts"],
 	outdir: "./dist",
 	target: "browser",
-	minify: true,
+	minify,
 	sourcemap,
 	packages: "bundle",
 	external: ["zod"],


### PR DESCRIPTION
Tested locally, and I can now add a breakpoint in the SDK while running the VS Code debug mode