### PR TITLE
fix(llms): align SAP AI Core provider config

### DIFF
--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -484,6 +484,55 @@ describe("buildSessionConfig", () => {
 		expect(config.providerConfig).not.toHaveProperty("apiKey")
 	})
 
+	it("defaults SAP AI Core to orchestration mode and omits deployment id when mode is unset", async () => {
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "sapaicore",
+			actModeApiModelId: "anthropic--claude-4.6-sonnet",
+			sapAiCoreClientId: "sap-client",
+			sapAiCoreClientSecret: "sap-secret",
+			sapAiCoreBaseUrl: "https://api.ai.example.aws.ml.hana.ondemand.com",
+			sapAiCoreTokenUrl: "https://example.authentication.sap.hana.ondemand.com",
+			sapAiResourceGroup: "default",
+			actModeSapAiCoreDeploymentId: "foundation-deployment-id",
+		} as any)
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+
+		expect(config.providerConfig).toMatchObject({
+			providerId: "sapaicore",
+			sap: {
+				clientId: "sap-client",
+				clientSecret: "sap-secret",
+				tokenUrl: "https://example.authentication.sap.hana.ondemand.com",
+				resourceGroup: "default",
+				useOrchestrationMode: true,
+			},
+		})
+		expect((config.providerConfig as any).sap).not.toHaveProperty("deploymentId")
+	})
+
+	it("omits SAP AI Core deployment id when orchestration mode is enabled", async () => {
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "sapaicore",
+			actModeApiModelId: "anthropic--claude-4.6-sonnet",
+			sapAiCoreClientId: "sap-client",
+			sapAiCoreClientSecret: "sap-secret",
+			sapAiCoreBaseUrl: "https://api.ai.example.aws.ml.hana.ondemand.com",
+			sapAiCoreTokenUrl: "https://example.authentication.sap.hana.ondemand.com",
+			sapAiResourceGroup: "default",
+			sapAiCoreUseOrchestrationMode: true,
+			actModeSapAiCoreDeploymentId: "foundation-deployment-id",
+		} as any)
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+
+		expect((config.providerConfig as any).sap).toMatchObject({
+			resourceGroup: "default",
+			useOrchestrationMode: true,
+		})
+		expect((config.providerConfig as any).sap).not.toHaveProperty("deploymentId")
+	})
+
 	it("falls back to legacy SAP-specific model fields when the generic model field is absent", async () => {
 		mocks.stateManager.getApiConfiguration.mockReturnValue({
 			actModeApiProvider: "sapaicore",

--- a/apps/vscode/src/sdk/sap-config.ts
+++ b/apps/vscode/src/sdk/sap-config.ts
@@ -21,7 +21,10 @@ function trimString(value: unknown): string | undefined {
 export function buildSapProviderConfig(config: ApiConfiguration, mode: Mode): SapProviderConfig {
 	const sap: NonNullable<SapProviderConfig["sap"]> = {}
 	const baseUrl = trimString(config.sapAiCoreBaseUrl)
-	const deploymentId = trimString(mode === "plan" ? config.planModeSapAiCoreDeploymentId : config.actModeSapAiCoreDeploymentId)
+	const useOrchestrationMode = config.sapAiCoreUseOrchestrationMode ?? true
+	const deploymentId = useOrchestrationMode
+		? undefined
+		: trimString(mode === "plan" ? config.planModeSapAiCoreDeploymentId : config.actModeSapAiCoreDeploymentId)
 	const sapFields = {
 		clientId: trimString(config.sapAiCoreClientId),
 		clientSecret: trimString(config.sapAiCoreClientSecret),
@@ -36,8 +39,8 @@ export function buildSapProviderConfig(config: ApiConfiguration, mode: Mode): Sa
 		}
 	}
 
-	if (Object.keys(sap).length > 0 && config.sapAiCoreUseOrchestrationMode !== undefined) {
-		sap.useOrchestrationMode = config.sapAiCoreUseOrchestrationMode
+	if (Object.keys(sap).length > 0) {
+		sap.useOrchestrationMode = useOrchestrationMode
 	}
 
 	return {

--- a/apps/vscode/webview-ui/src/components/settings/providers/SapAiCoreProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/SapAiCoreProvider.tsx
@@ -43,6 +43,7 @@ export const SapAiCoreProvider = ({ showModelOptions, isPopup, currentMode }: Sa
 	const [hasCheckedOrchestration, setHasCheckedOrchestration] = useState<boolean>(false)
 	const [isLoadingModels, setIsLoadingModels] = useState(false)
 	const [modelError, setModelError] = useState<string | null>(null)
+	const useOrchestrationMode = apiConfiguration?.sapAiCoreUseOrchestrationMode ?? true
 
 	// Check if all required credentials are available
 	const hasRequiredCredentials =
@@ -109,10 +110,10 @@ export const SapAiCoreProvider = ({ showModelOptions, isPopup, currentMode }: Sa
 
 	// Handle automatic disabling of orchestration mode when not available
 	useEffect(() => {
-		if (hasCheckedOrchestration && !orchestrationAvailable && apiConfiguration?.sapAiCoreUseOrchestrationMode) {
+		if (hasCheckedOrchestration && !orchestrationAvailable && useOrchestrationMode) {
 			handleFieldChange("sapAiCoreUseOrchestrationMode", false)
 		}
-	}, [hasCheckedOrchestration, orchestrationAvailable, apiConfiguration?.sapAiCoreUseOrchestrationMode, handleFieldChange])
+	}, [hasCheckedOrchestration, orchestrationAvailable, useOrchestrationMode, handleFieldChange])
 
 	// Handle model selection
 	const handleModelChange = useCallback(
@@ -198,7 +199,7 @@ export const SapAiCoreProvider = ({ showModelOptions, isPopup, currentMode }: Sa
 					<div className="flex items-center gap-2">
 						<VSCodeCheckbox
 							aria-label="Orchestration Mode"
-							checked={apiConfiguration?.sapAiCoreUseOrchestrationMode}
+							checked={useOrchestrationMode}
 							onChange={(e) => handleOrchestrationChange((e.target as HTMLInputElement).checked)}
 						/>
 						<span className="font-medium">Orchestration Mode</span>
@@ -247,7 +248,7 @@ export const SapAiCoreProvider = ({ showModelOptions, isPopup, currentMode }: Sa
 										]
 									}
 									selectedModelId={selectedModelId || ""}
-									useOrchestrationMode={apiConfiguration?.sapAiCoreUseOrchestrationMode}
+									useOrchestrationMode={useOrchestrationMode}
 								/>
 							</>
 						) : (

--- a/sdk/packages/core/src/services/llms/handler-factory.test.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.test.ts
@@ -370,11 +370,19 @@ describe("createAgentModelFromConfig", () => {
 		};
 
 		expect(model.config?.destination).toMatchObject({
-			authentication: "OAuth2ClientCredentials",
-			clientId: "sap-client",
-			clientSecret: "sap-secret",
-			tokenServiceUrl: "https://auth.example/oauth/token",
-			url: "https://api.ai.example.aws.ml.hana.ondemand.com",
+			service: {
+				credentials: {
+					clientid: "sap-client",
+					clientsecret: "sap-secret",
+					serviceurls: {
+						AI_API_URL: "https://api.ai.example.aws.ml.hana.ondemand.com",
+					},
+					url: "https://auth.example",
+				},
+				label: "aicore",
+				name: "sapaicore",
+				tags: ["aicore"],
+			},
 		});
 		expect(model.config?.deploymentConfig).toMatchObject({
 			deploymentId: "deployment-id",

--- a/sdk/packages/core/src/services/storage/provider-settings-legacy-migration.test.ts
+++ b/sdk/packages/core/src/services/storage/provider-settings-legacy-migration.test.ts
@@ -538,11 +538,59 @@ describe("migrateLegacyProviderSettings", () => {
 				clientSecret: "sap-secret",
 				tokenUrl: "https://example.authentication.sap.hana.ondemand.com",
 				resourceGroup: "default",
-				deploymentId: "deployment-id",
 				useOrchestrationMode: true,
 			},
 		});
 		expect(manager.read().providers.sapaicore?.tokenSource).toBe("migration");
+	});
+
+	it("keeps SAP AI Core deployment id only for foundation-model mode", () => {
+		const tempDir = mkdtempSync(
+			path.join(os.tmpdir(), "core-legacy-provider-"),
+		);
+		tempDirs.push(tempDir);
+		const providersPath = path.join(tempDir, "settings", "providers.json");
+		const manager = new ProviderSettingsManager({ filePath: providersPath });
+
+		writeFileSync(
+			path.join(tempDir, "globalState.json"),
+			JSON.stringify(
+				{
+					mode: "act",
+					actModeApiProvider: "sapaicore",
+					actModeApiModelId: "gpt-4o",
+					sapAiCoreBaseUrl: "https://api.ai.example.aws.ml.hana.ondemand.com",
+					sapAiCoreTokenUrl:
+						"https://example.authentication.sap.hana.ondemand.com",
+					sapAiResourceGroup: "default",
+					sapAiCoreUseOrchestrationMode: false,
+					actModeSapAiCoreDeploymentId: "deployment-id",
+				},
+				null,
+				2,
+			),
+		);
+		writeFileSync(
+			path.join(tempDir, "secrets.json"),
+			JSON.stringify(
+				{
+					sapAiCoreClientId: "sap-client",
+					sapAiCoreClientSecret: "sap-secret",
+				},
+				null,
+				2,
+			),
+		);
+
+		migrateLegacyProviderSettings({
+			providerSettingsManager: manager,
+			dataDir: tempDir,
+		});
+
+		expect(manager.getProviderSettings("sapaicore")?.sap).toMatchObject({
+			deploymentId: "deployment-id",
+			useOrchestrationMode: false,
+		});
 	});
 
 	it("detects SAP AI Core legacy files even when provider mode is absent", () => {

--- a/sdk/packages/core/src/services/storage/provider-settings-legacy-migration.ts
+++ b/sdk/packages/core/src/services/storage/provider-settings-legacy-migration.ts
@@ -554,17 +554,21 @@ function buildLegacyProviderSettings(
 		};
 	}
 	if (providerId === "sapaicore") {
+		const useOrchestrationMode =
+			legacyGlobalState.sapAiCoreUseOrchestrationMode ?? true;
 		providerSpecific.sap = {
 			clientId: trimNonEmpty(legacySecrets.sapAiCoreClientId),
 			clientSecret: trimNonEmpty(legacySecrets.sapAiCoreClientSecret),
 			tokenUrl: trimNonEmpty(legacyGlobalState.sapAiCoreTokenUrl),
 			resourceGroup: trimNonEmpty(legacyGlobalState.sapAiResourceGroup),
-			deploymentId: trimNonEmpty(
-				mode === "plan"
-					? legacyGlobalState.planModeSapAiCoreDeploymentId
-					: legacyGlobalState.actModeSapAiCoreDeploymentId,
-			),
-			useOrchestrationMode: legacyGlobalState.sapAiCoreUseOrchestrationMode,
+			deploymentId: useOrchestrationMode
+				? undefined
+				: trimNonEmpty(
+						mode === "plan"
+							? legacyGlobalState.planModeSapAiCoreDeploymentId
+							: legacyGlobalState.actModeSapAiCoreDeploymentId,
+					),
+			useOrchestrationMode,
 		};
 	}
 	if (providerId === "oca") {

--- a/sdk/packages/llms/src/providers/vendors/community.test.ts
+++ b/sdk/packages/llms/src/providers/vendors/community.test.ts
@@ -40,6 +40,33 @@ describe("createSapAiCoreProviderModule", () => {
 		});
 	});
 
+	it("uses resource group deployment resolution for orchestration mode", async () => {
+		const provider = await createSapAiCoreProviderModule({
+			providerId: "sapaicore",
+			baseUrl: "https://api.ai.example.aws.ml.hana.ondemand.com",
+			options: {
+				clientId: "sap-client",
+				clientSecret: "sap-secret",
+				tokenUrl: "https://auth.example",
+				resourceGroup: "default",
+				useOrchestrationMode: true,
+			},
+		});
+
+		const model = provider.model("anthropic--claude-4.6-sonnet") as {
+			config?: {
+				deploymentConfig?: Record<string, unknown>;
+				providerApi?: string;
+			};
+		};
+
+		expect(model.config?.deploymentConfig).toMatchObject({
+			resourceGroup: "default",
+		});
+		expect(model.config?.deploymentConfig).not.toHaveProperty("deploymentId");
+		expect(model.config?.providerApi).toBe("orchestration");
+	});
+
 	it("fails fast for partial explicit SAP configuration", async () => {
 		await expect(
 			createSapAiCoreProviderModule({

--- a/sdk/packages/llms/src/providers/vendors/community.test.ts
+++ b/sdk/packages/llms/src/providers/vendors/community.test.ts
@@ -21,7 +21,7 @@ describe("createSapAiCoreProviderModule", () => {
 			options: {
 				clientId: "sap-client",
 				clientSecret: "sap-secret",
-				tokenUrl: "https://auth.example",
+				tokenUrl: "https://auth.example/oauth/token",
 				deploymentId: "deployment-id",
 			},
 		});
@@ -32,11 +32,19 @@ describe("createSapAiCoreProviderModule", () => {
 
 		expect(process.env.AICORE_SERVICE_KEY).toBe("existing-service-key");
 		expect(model.config?.destination).toMatchObject({
-			authentication: "OAuth2ClientCredentials",
-			clientId: "sap-client",
-			clientSecret: "sap-secret",
-			tokenServiceUrl: "https://auth.example/oauth/token",
-			url: "https://api.ai.example.aws.ml.hana.ondemand.com",
+			service: {
+				credentials: {
+					clientid: "sap-client",
+					clientsecret: "sap-secret",
+					serviceurls: {
+						AI_API_URL: "https://api.ai.example.aws.ml.hana.ondemand.com",
+					},
+					url: "https://auth.example",
+				},
+				label: "aicore",
+				name: "sapaicore",
+				tags: ["aicore"],
+			},
 		});
 	});
 

--- a/sdk/packages/llms/src/providers/vendors/community.ts
+++ b/sdk/packages/llms/src/providers/vendors/community.ts
@@ -111,9 +111,9 @@ function readStringOption(
 		: undefined;
 }
 
-function normalizeSapTokenServiceUrl(tokenUrl: string): string {
+function normalizeSapTokenBaseUrl(tokenUrl: string): string {
 	const trimmed = tokenUrl.replace(/\/+$/, "");
-	return /\/oauth\/token$/i.test(trimmed) ? trimmed : `${trimmed}/oauth/token`;
+	return trimmed.replace(/\/oauth\/token$/i, "");
 }
 
 function hasExplicitSapConnectionConfig(
@@ -154,14 +154,25 @@ function buildSapDestination(
 			)}.`,
 		);
 	}
+	// SAP Cloud SDK accepts service-binding fetch options at runtime
+	// (`isDestinationFetchOptions()` checks for `service`), but its exported
+	// XOR type makes the `service` branch unrepresentable by also requiring
+	// `destinationName`. Keep the cast at this dependency boundary.
 	return {
-		authentication: "OAuth2ClientCredentials" as const,
-		clientId,
-		clientSecret,
-		name: config.providerId,
-		tokenServiceUrl: normalizeSapTokenServiceUrl(tokenUrl),
-		url: baseUrl.replace(/\/+$/, ""),
-	} satisfies SapDestination;
+		service: {
+			credentials: {
+				clientid: clientId,
+				clientsecret: clientSecret,
+				serviceurls: {
+					AI_API_URL: baseUrl.replace(/\/+$/, ""),
+				},
+				url: normalizeSapTokenBaseUrl(tokenUrl),
+			},
+			label: "aicore",
+			name: config.providerId,
+			tags: ["aicore"],
+		},
+	} as unknown as SapDestination;
 }
 
 function resolveSapApi(options: Record<string, unknown>) {


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This PR fixes the SAP AI Core SDK migration path for VS Code users by keeping Cline's existing split-field credentials UI working with the SAP AI provider used by the SDK runtime.

The nightly failure reported by SAP users was:

```txt
SAP AI Core provider is missing required configuration: sap.clientId, sap.tokenUrl, baseUrl.
```

There were two related problems in the migrated path:

1. VS Code builds SAP-specific settings from the legacy UI, but the SDK runtime needs those values in the gateway provider options where `@cline/llms` can read them.
2. Cline stores SAP credentials as split fields (`clientId`, `clientSecret`, `tokenUrl`, `baseUrl`, resource group, deployment id), while the installed `@jerome-benoit/sap-ai-provider` is built on SAP's Cloud SDK auth flow. A plain local destination with split OAuth fields is not enough for SAP Cloud SDK request execution; it expects either an already-resolved destination with auth tokens or a service-binding/fetch-options shape that SAP's SDK can resolve itself.

The first part was already fixed by forwarding SAP settings into gateway provider options. This PR now also maps Cline's split fields into a SAP AI Core service-binding-shaped `destination.service` object:

```ts
{
  service: {
    label: "aicore",
    name: "sapaicore",
    tags: ["aicore"],
    credentials: {
      clientid,
      clientsecret,
      url: tokenUrlWithoutOauthTokenSuffix,
      serviceurls: { AI_API_URL: baseUrl },
    },
  },
}
```

That lets the SAP AI provider and SAP Cloud SDK handle OAuth and destination resolution themselves. Cline does not perform its own token request and does not mutate `AICORE_SERVICE_KEY`.

While validating David's proposed PR and the installed provider behavior, I also checked that `@jerome-benoit/sap-ai-provider` defaults to `api: "orchestration"`, and that `deploymentId` wins over `resourceGroup` when both are present. In Cline, the stored SAP deployment ID comes from the deployed-model picker and is meaningful for foundation-model mode. Passing that stale deployment ID while orchestration mode is on can route orchestration requests through the wrong deployment instead of letting SAP resolve the orchestration deployment from the resource group.

So this PR also makes the SAP mode mapping explicit:

```ts
useOrchestrationMode !== false -> api: "orchestration", deploymentConfig: { resourceGroup }
useOrchestrationMode === false -> api: "foundation-models", deploymentConfig: { deploymentId }
```

That keeps orchestration aligned with the SAP provider default and preserves foundation-model mode for users who explicitly disable orchestration.

I intentionally did not include the broader changes from the SAP developer PR:

- no new SAP provider dependency in `apps/vscode`
- no workspace-wide SAP Cloud SDK canary overrides
- no model picker filtering changes in this hotfix

Those changes are either unnecessary for this failure or should be reviewed separately with SAP-specific product confirmation.

### Test Procedure

Focused tests:

```bash
cd apps/vscode
bunx vitest run src/sdk/cline-session-factory.test.ts --config vitest.config.ts
```

- 44 tests passed
- verifies VS Code session config builds SAP `providerConfig.sap`
- verifies orchestration mode defaults to `true` when unset
- verifies orchestration mode omits a stale SAP deployment ID

```bash
cd sdk/packages/core
bunx vitest run src/services/llms/handler-factory.test.ts src/services/storage/provider-settings-legacy-migration.test.ts
```

- 32 tests passed
- verifies core forwards SAP settings into gateway provider options
- verifies legacy migration keeps deployment ID only for foundation-model mode
- verifies SAP settings become the expected service-binding-shaped destination at the LLM adapter boundary

```bash
cd sdk/packages/llms
bunx vitest run src/providers/vendors/community.test.ts
```

- 3 tests passed
- verifies Cline split credentials build SAP service-binding destination options without mutating `AICORE_SERVICE_KEY`
- verifies orchestration mode uses `deploymentConfig.resourceGroup`, not `deploymentId`
- verifies partial explicit SAP config fails fast with the expected missing field message

Type checks:

```bash
bun -F @cline/core typecheck
bun -F @cline/llms typecheck
```

Both passed.

I also ran a fake SAP AI Core smoke test through the real `createGateway()` + installed SAP provider path. The fake server returned a JWT-shaped OAuth token, deployments, and then a deliberate 418 at inference so the test could prove the request reached the intended SAP endpoint.

Observed behavior:

- orchestration mode called `POST /oauth/token`, `GET /v2/lm/deployments?scenarioId=orchestration&status=RUNNING`, then `POST /v2/inference/deployments/orchestration-deployment-id/v2/completion`
- foundation mode called `POST /oauth/token`, then `POST /v2/inference/deployments/foundation-deployment-id/chat/completions?api-version=2024-10-21`
- inference requests had authorization attached
- neither mode hit `SAP AI Core provider is missing required configuration`
- neither mode hit SAP Cloud SDK's `no auth tokens could be fetched` failure

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. This is provider configuration/runtime plumbing. The only UI change is aligning the SAP orchestration checkbox with the runtime default when the stored setting is unset.

### Additional Notes

The important design choice here is to let the SAP AI provider/SAP Cloud SDK perform auth, while preserving Cline's existing split-field settings UI. Cline only maps those fields into the service-binding shape the SAP SDK already understands.
