### PR TITLE
fix(core): hide synthetic empty assistant content

### DIFF
--- a/sdk/packages/core/src/runtime/config/agent-message-codec.test.ts
+++ b/sdk/packages/core/src/runtime/config/agent-message-codec.test.ts
@@ -2,8 +2,9 @@ import { EMPTY_CONTENT_TEXT } from "@cline/shared";
 import { describe, expect, it } from "vitest";
 import {
 	agentMessageToMessageWithMetadata,
-	messageToAgentMessages,
 	messagesToAgentMessages,
+	messageToAgentMessages,
+	SYNTHETIC_EMPTY_CONTENT_METADATA_KEY,
 } from "./agent-message-codec";
 
 describe("agent message codec", () => {
@@ -21,7 +22,7 @@ describe("agent message codec", () => {
 				role: "assistant",
 				content: [{ type: "text", text: EMPTY_CONTENT_TEXT }],
 				createdAt: 1,
-				metadata: undefined,
+				metadata: { [SYNTHETIC_EMPTY_CONTENT_METADATA_KEY]: true },
 				modelInfo: undefined,
 				metrics: undefined,
 			},
@@ -39,7 +40,7 @@ describe("agent message codec", () => {
 				role: "user",
 				content: [{ type: "text", text: EMPTY_CONTENT_TEXT }],
 				createdAt: 1,
-				metadata: undefined,
+				metadata: { [SYNTHETIC_EMPTY_CONTENT_METADATA_KEY]: true },
 				modelInfo: undefined,
 				metrics: undefined,
 			},
@@ -57,7 +58,7 @@ describe("agent message codec", () => {
 				role: "assistant",
 				content: [{ type: "text", text: EMPTY_CONTENT_TEXT }],
 				createdAt: 1,
-				metadata: undefined,
+				metadata: { [SYNTHETIC_EMPTY_CONTENT_METADATA_KEY]: true },
 				modelInfo: undefined,
 				metrics: undefined,
 			},

--- a/sdk/packages/core/src/runtime/config/agent-message-codec.ts
+++ b/sdk/packages/core/src/runtime/config/agent-message-codec.ts
@@ -15,6 +15,8 @@ import type {
 } from "@cline/shared";
 import { EMPTY_CONTENT_TEXT } from "@cline/shared";
 
+export const SYNTHETIC_EMPTY_CONTENT_METADATA_KEY = "syntheticEmptyContent";
+
 export function messageToAgentMessages(
 	message: MessageWithMetadata,
 ): AgentMessage[] {
@@ -51,7 +53,10 @@ export function messageToAgentMessages(
 			role: message.role,
 			content: [{ type: "text", text: EMPTY_CONTENT_TEXT }],
 			createdAt: message.ts ?? Date.now(),
-			metadata: message.metadata,
+			metadata: {
+				...message.metadata,
+				[SYNTHETIC_EMPTY_CONTENT_METADATA_KEY]: true,
+			},
 			modelInfo: message.modelInfo,
 			metrics: metricsToAgentMetrics(message.metrics),
 		});

--- a/sdk/packages/core/src/runtime/orchestration/runtime-event-adapter.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-event-adapter.test.ts
@@ -21,7 +21,9 @@ import type {
 	AgentToolCallPart,
 	AgentUsage,
 } from "@cline/shared";
+import { EMPTY_CONTENT_TEXT } from "@cline/shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SYNTHETIC_EMPTY_CONTENT_METADATA_KEY } from "../config/agent-message-codec";
 import {
 	RuntimeEventAdapter,
 	toLegacyAgentEvent,
@@ -287,6 +289,37 @@ describe("RuntimeEventAdapter — assistant-message → content_end", () => {
 		});
 		expect(out).toEqual([
 			{ type: "content_end", contentType: "text", text: "hi there" },
+		]);
+	});
+
+	it("suppresses synthetic empty-content placeholder text", () => {
+		const out = adapter.translate({
+			type: "assistant-message",
+			snapshot: makeSnapshot(),
+			iteration: 1,
+			message: makeMessage(
+				{
+					metadata: { [SYNTHETIC_EMPTY_CONTENT_METADATA_KEY]: true },
+				},
+				[{ type: "text", text: EMPTY_CONTENT_TEXT }],
+			),
+			finishReason: "stop",
+		});
+
+		expect(out).toEqual([]);
+	});
+
+	it("keeps literal empty-content text when it is not synthetic", () => {
+		const out = adapter.translate({
+			type: "assistant-message",
+			snapshot: makeSnapshot(),
+			iteration: 1,
+			message: makeMessage({}, [{ type: "text", text: EMPTY_CONTENT_TEXT }]),
+			finishReason: "stop",
+		});
+
+		expect(out).toEqual([
+			{ type: "content_end", contentType: "text", text: EMPTY_CONTENT_TEXT },
 		]);
 	});
 

--- a/sdk/packages/core/src/runtime/orchestration/runtime-event-adapter.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-event-adapter.ts
@@ -61,6 +61,8 @@ import type {
 	AgentUsage,
 	LegacyAgentUsage,
 } from "@cline/shared";
+import { EMPTY_CONTENT_TEXT } from "@cline/shared";
+import { SYNTHETIC_EMPTY_CONTENT_METADATA_KEY } from "../config/agent-message-codec";
 
 // =============================================================================
 // Helpers
@@ -104,6 +106,16 @@ function textFromMessage(message: AgentMessage | undefined): string {
 		return "";
 	}
 	return extractTextPart(message) ?? "";
+}
+
+function isSyntheticEmptyContentMessage(
+	message: AgentMessage,
+	text: string,
+): boolean {
+	return (
+		message.metadata?.[SYNTHETIC_EMPTY_CONTENT_METADATA_KEY] === true &&
+		text === EMPTY_CONTENT_TEXT
+	);
 }
 
 function statusToLegacyFinishReason(
@@ -266,7 +278,7 @@ export class RuntimeEventAdapter {
 	private translateAssistantMessage(message: AgentMessage): AgentEvent[] {
 		const out: AgentEvent[] = [];
 		const text = extractTextPart(message);
-		if (text !== undefined) {
+		if (text !== undefined && !isSyntheticEmptyContentMessage(message, text)) {
 			out.push({ type: "content_end", contentType: "text", text });
 		}
 		const reasoning = extractReasoningPart(message);


### PR DESCRIPTION
## Summary
- mark empty persisted-message placeholders as synthetic metadata
- suppress synthetic `ERROR: EMPTY CONTENT` placeholders from legacy assistant content events
- keep literal model text `ERROR: EMPTY CONTENT` visible when it is not synthetic

## Test plan
- `bun run build:sdk`
- `bun -F @cline/core test:unit -- src/runtime/config/agent-message-codec.test.ts src/runtime/orchestration/runtime-event-adapter.test.ts`
- `bun -F @cline/core typecheck`
- repro script: empty persisted assistant message now translates to no legacy content event
