### PR TITLE
fix(core): avoid implicit max output token caps

### DIFF
--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -446,7 +446,7 @@ describe("buildSessionConfig", () => {
 			maxInputTokens: 16_000,
 			maxTokens: 4_096,
 		})
-		expect((config.providerConfig as any).maxOutputTokens).toBe(4_096)
+		expect(config.providerConfig).not.toHaveProperty("maxOutputTokens")
 	})
 
 	it("builds structured SAP AI Core config from legacy ApiConfiguration fields", async () => {

--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -700,9 +700,6 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 		...(apiKey ? { apiKey } : {}),
 		...(baseUrl !== undefined ? { baseUrl } : {}),
 		...(knownModels ? { knownModels } : {}),
-		...(modelId && positiveNumber(knownModels?.[modelId]?.maxTokens)
-			? { maxOutputTokens: positiveNumber(knownModels?.[modelId]?.maxTokens) }
-			: {}),
 		fetch,
 	}
 

--- a/sdk/packages/core/src/services/llms/handler-factory.test.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.test.ts
@@ -125,7 +125,33 @@ describe("createAgentModelFromConfig", () => {
 		);
 	});
 
-	it("uses providerConfig maxOutputTokens when no direct per-turn override is set", async () => {
+	it("uses maxTokensPerTurn as the request max token cap", async () => {
+		const { createAgentModelFromConfig } = await import("./handler-factory");
+
+		createAgentModelFromConfig(
+			{
+				providerId: "openai-compatible",
+				modelId: "custom-model",
+				apiKey: "key",
+				systemPrompt: "",
+				tools: [],
+				maxTokensPerTurn: 4_096,
+				providerConfig: {
+					providerId: "openai-compatible",
+					modelId: "custom-model",
+					maxOutputTokens: 8_192,
+				},
+			},
+			undefined,
+		);
+
+		expect(gatewayMock.createAgentModel).toHaveBeenLastCalledWith(
+			{ providerId: "openai-compatible", modelId: "custom-model" },
+			{ maxTokens: 4_096 },
+		);
+	});
+
+	it("does not use providerConfig maxOutputTokens as a request cap", async () => {
 		const { createAgentModelFromConfig } = await import("./handler-factory");
 
 		createAgentModelFromConfig(
@@ -146,7 +172,7 @@ describe("createAgentModelFromConfig", () => {
 
 		expect(gatewayMock.createAgentModel).toHaveBeenLastCalledWith(
 			{ providerId: "openai-compatible", modelId: "custom-model" },
-			{ maxTokens: 4_096 },
+			undefined,
 		);
 	});
 

--- a/sdk/packages/core/src/services/llms/handler-factory.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.ts
@@ -163,7 +163,7 @@ export function createAgentModelFromConfig(
 		baseUrl: config.baseUrl ?? baseProviderConfig?.baseUrl,
 		headers: config.headers ?? baseProviderConfig?.headers,
 		knownModels: resolveKnownModelsFromConfig(config),
-		maxOutputTokens: config.maxTokensPerTurn ?? baseProviderConfig?.maxOutputTokens,
+		maxOutputTokens: config.maxTokensPerTurn,
 		reasoningEffort: config.reasoningEffort,
 		thinkingBudgetTokens: config.thinkingBudgetTokens,
 		thinking: config.thinking,
@@ -216,6 +216,8 @@ export function createAgentModelFromConfig(
 			providerId: normalizedProviderConfig.providerId,
 			modelId: normalizedProviderConfig.modelId,
 		},
-		{ maxTokens: normalizedProviderConfig.maxOutputTokens },
+		normalizedProviderConfig.maxOutputTokens === undefined
+			? undefined
+			: { maxTokens: normalizedProviderConfig.maxOutputTokens },
 	);
 }


### PR DESCRIPTION
### Related Issue

**Issue:** ENG-2218

### Description

This fixes a ChatGPT Subscription / `openai-codex` regression where requests could fail with:

```text
Unsupported parameter: max_output_tokens
```

The regression came from treating `providerConfig.maxOutputTokens` as a request-time output cap in `createAgentModelFromConfig`:

```ts
maxOutputTokens: config.maxTokensPerTurn ?? baseProviderConfig?.maxOutputTokens
```

That looked reasonable for OpenAI-compatible configuration at first glance, but it conflated two different concepts:

- `config.maxTokensPerTurn` is an explicit per-turn request cap. If this is set, it is expected to flow into the model invocation as `{ maxTokens }`.
- `providerConfig.maxOutputTokens` is provider/model metadata. In particular, VS Code was copying OpenAI-compatible `knownModels[modelId].maxTokens` into this field, which made model capability metadata look like an explicit request cap.

For ChatGPT OAuth / Codex, that distinction matters because the AI SDK maps the request cap to the OpenAI Responses API parameter `max_output_tokens`. The ChatGPT Subscription backend rejects that parameter, so carrying provider metadata into request options made otherwise valid `openai-codex` calls fail.

The fix keeps the source of truth simple:

```ts
maxOutputTokens: config.maxTokensPerTurn
```

Then `createAgentModel` receives request options only when an explicit per-turn cap exists:

```ts
normalizedProviderConfig.maxOutputTokens === undefined
  ? undefined
  : { maxTokens: normalizedProviderConfig.maxOutputTokens }
```

This also removes the VS Code-side copy from OpenAI-compatible model metadata into `providerConfig.maxOutputTokens`. The metadata itself is still preserved in `knownModels[modelId].maxTokens`, so OpenAI-compatible custom model information is not lost. What changes is only that model metadata no longer silently becomes a request parameter.

The key behavior after this PR:

- OpenAI-compatible custom model metadata still carries `maxTokens` through `knownModels`.
- Explicit `maxTokensPerTurn` still becomes the request cap passed to the SDK.
- Provider/model metadata no longer implicitly produces `max_output_tokens` for providers that never asked for a request cap.

I considered filtering `max_output_tokens` inside the OpenAI vendor headers/request path, but that would be more indirect and would only hide the symptom for one transport. The root issue is higher up: we should not convert provider metadata into a request cap globally. Keeping the request cap sourced only from `maxTokensPerTurn` makes the behavior easier to reason about and avoids provider-specific allow/deny lists for this regression.

### Test Procedure

Targeted tests were run around both sides of the regression:

```bash
bun vitest run --config vitest.config.ts src/services/llms/handler-factory.test.ts
```

from `sdk/packages/core`, covering:

- `maxTokensPerTurn` is still passed to `createAgentModel` as `{ maxTokens }`.
- `providerConfig.maxOutputTokens` is not treated as a request cap when `maxTokensPerTurn` is absent.
- existing model capability/metadata preservation behavior still passes.

```bash
bun vitest run --config vitest.config.ts src/sdk/cline-session-factory.test.ts -t "OpenAI Compatible custom model metadata"
```

from `apps/vscode`, covering:

- OpenAI-compatible custom model `knownModels[modelId].maxTokens` metadata is still present.
- VS Code no longer duplicates that metadata into `providerConfig.maxOutputTokens`.

Additional verification:

```bash
bun biome check --diagnostic-level=error sdk/packages/core/src/services/llms/handler-factory.ts sdk/packages/core/src/services/llms/handler-factory.test.ts
bunx --bun @biomejs/biome check --diagnostic-level=error src/sdk/cline-session-factory.ts src/sdk/cline-session-factory.test.ts
bun tsc -p tsconfig.dev.json --noEmit
```

I also smoke-tested the OpenAI-compatible path with OpenRouter earlier in the debugging session: model metadata included `maxOutputTokens`, no explicit request cap was provided, and the request succeeded. A live `openai-codex` OAuth smoke test was attempted but blocked by local Docker OAuth callback plumbing rather than by this code path; the regression itself is covered by the unit tests asserting we no longer pass request max tokens unless `maxTokensPerTurn` is explicitly set.

The main compatibility risk is callers that were unintentionally relying on `providerConfig.maxOutputTokens` to cap generation. This PR intentionally routes request caps through `maxTokensPerTurn` only; `providerConfig.maxOutputTokens` remains metadata, not invocation policy.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. This is a provider/runtime configuration fix with no UI changes.

### Additional Notes

This deliberately does not add a provider-specific blocklist for `openai-codex`. The regression came from the generic config normalization layer, so the fix keeps the distinction there: explicit request cap from `maxTokensPerTurn`, model/provider output budget metadata in `knownModels` / `providerConfig`.

A user can still force a request cap by setting `maxTokensPerTurn`. If a provider does not support request-time max token controls, that is a separate provider-capability question. This PR fixes the accidental path where a provider that never exposed such a setting received one because metadata was promoted into invocation options.
