### PR TITLE
fix(llms): omit max output tokens for ChatGPT OAuth

### DIFF
--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -948,13 +948,15 @@ function createAiSdkProvider(kind: ProviderModuleKind): GatewayProviderFactory {
 						temperature: request.temperature,
 					},
 				});
+				const supportsRequestMaxOutputTokens =
+					request.providerId !== "openai-codex";
 				stream = streamText({
 					model: provider.model(context.model.id) as never,
 					messages: messages as never,
 					...(useSystemOption ? { system: systemPrompt } : {}),
 					tools: tools as never,
 					temperature: request.temperature,
-					...(request.maxTokens !== undefined
+					...(supportsRequestMaxOutputTokens && request.maxTokens !== undefined
 						? { maxOutputTokens: request.maxTokens }
 						: {}),
 					abortSignal: request.signal,

--- a/sdk/packages/llms/src/providers/gateway.test.ts
+++ b/sdk/packages/llms/src/providers/gateway.test.ts
@@ -2231,6 +2231,65 @@ describe("sdk-gateway", () => {
 		expect(call).not.toHaveProperty("maxOutputTokens");
 	});
 
+	it("does not send maxOutputTokens to ChatGPT OAuth even when the request has max tokens", async () => {
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([
+				{ type: "finish", usage: { inputTokens: 1, outputTokens: 1 } },
+			]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [{ providerId: "openai-codex" }],
+		});
+
+		await collect(
+			await gateway.stream({
+				providerId: "openai-codex",
+				modelId: "gpt-5.4",
+				messages: baseMessages,
+				maxTokens: 4096,
+			}),
+		);
+
+		const call = streamTextSpy.mock.calls.at(-1)?.[0] as
+			| { maxOutputTokens?: unknown }
+			| undefined;
+		expect(call).not.toHaveProperty("maxOutputTokens");
+	});
+
+	it("still sends maxOutputTokens for OpenAI-compatible requests with max tokens", async () => {
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([
+				{ type: "finish", usage: { inputTokens: 1, outputTokens: 1 } },
+			]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [
+				{
+					providerId: "openai-compatible",
+					apiKey: "openai-compatible-key",
+					baseUrl: "https://openai-compatible.example/v1",
+				},
+			],
+		});
+
+		await collect(
+			await gateway.stream({
+				providerId: "openai-compatible",
+				modelId: "custom-model",
+				messages: baseMessages,
+				maxTokens: 4096,
+			}),
+		);
+
+		expect(streamTextSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				maxOutputTokens: 4096,
+			}),
+		);
+	});
+
 	it("passes Codex instructions through provider options and removes the system message from messages", async () => {
 		streamTextSpy.mockReturnValue({
 			fullStream: makeStreamParts([


### PR DESCRIPTION
### Related Issue

**Issue:** ENG-2218

### Description

This fixes the ChatGPT Subscription / `openai-codex` regression where requests can fail with:

```text
Unsupported parameter: max_output_tokens
```

The previous implementation allowed a request max token cap to flow into the generic AI SDK `streamText(...)` call as:

```ts
maxOutputTokens: request.maxTokens
```

For OpenAI-compatible providers, that is valid and is the behavior we want to preserve: configured request caps should continue to produce an outbound max-token parameter.

The problem is that ChatGPT Subscription / Codex is different. The `openai-codex` provider uses the OpenAI Responses API path, and that backend rejects the `max_output_tokens` parameter. So the safest fix is not to remove max-token plumbing globally, and not to reinterpret provider/model metadata in core. Instead, this PR suppresses the unsupported AI SDK `maxOutputTokens` option only when the gateway request is for `openai-codex`.

The important behavior after this PR:

```ts
request.providerId === "openai-codex"
```

means the AI SDK adapter omits:

```ts
maxOutputTokens: request.maxTokens
```

For other AI SDK-backed providers, including OpenAI-compatible providers, the existing behavior remains unchanged.

This replaces the earlier closed approach in #11765. That approach fixed ChatGPT OAuth by narrowing the core request-cap source, but Max verified with Proxyman that OpenAI-compatible requests on that branch no longer sent `max_tokens`. That was a sign the fix was at the wrong layer. This PR keeps the previous OpenAI-compatible fix intact and applies the provider-specific behavior at the outbound adapter boundary where the provider capability actually differs.

Why this shape:

- `openai-codex` is the provider that rejects `max_output_tokens`.
- OpenAI-compatible providers can still need request max-token caps.
- The gateway request may legitimately contain `maxTokens`; the adapter should decide whether the target provider supports forwarding it to the underlying API.
- This avoids provider-specific changes in VS Code session config or core handler normalization.

### Test Procedure

Ran the focused regression coverage:

```bash
bun vitest run src/providers/gateway.test.ts -t "maxOutputTokens"
```

This covers:

- `openai-codex` does not send AI SDK `maxOutputTokens` when the request omits max tokens.
- `openai-codex` still does not send AI SDK `maxOutputTokens` even when the gateway request has `maxTokens`.
- OpenAI-compatible requests with `maxTokens` still send AI SDK `maxOutputTokens`.

Ran the full gateway provider test file:

```bash
bun vitest run src/providers/gateway.test.ts
```

Result: 80 tests passed.

Ran Biome on the touched files:

```bash
bun biome check --diagnostic-level=error sdk/packages/llms/src/providers/ai-sdk.ts sdk/packages/llms/src/providers/gateway.test.ts
```

Result: passed.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. This is a provider adapter/runtime request fix with no UI changes.

### Additional Notes

I intentionally left the generic max-token plumbing intact for non-Codex providers. The regression is provider-specific: ChatGPT OAuth rejects the Responses API `max_output_tokens` parameter, while OpenAI-compatible providers may still rely on the request cap being forwarded.

The first push attempt hung in the repository's Git LFS pre-push hook while running `git lfs pre-push`; this branch only changes TypeScript files, so the branch was pushed with `GIT_LFS_SKIP_PUSH=1`.
