### PR TITLE
Fix ClinePass onboarding model grouping

### DIFF
--- a/apps/vscode/webview-ui/src/components/onboarding/__tests__/data-models.test.ts
+++ b/apps/vscode/webview-ui/src/components/onboarding/__tests__/data-models.test.ts
@@ -1,6 +1,6 @@
 import type { OnboardingModel, OnboardingModelGroup } from "@shared/proto/cline/state"
 import { describe, expect, it } from "vitest"
-import { getClineUIOnboardingGroups, getRecommendedModelsData } from "../data-models"
+import { CLINEPASS_GROUP, getClineUIOnboardingGroups, getRecommendedModelsData } from "../data-models"
 
 function model(id: string, group: string): OnboardingModel {
 	return {
@@ -22,7 +22,7 @@ describe("getClineUIOnboardingGroups", () => {
 	it("buckets ClinePass models into the clinePass group", () => {
 		const result = getClineUIOnboardingGroups(
 			groupOf([
-				model("cline-pass/glm-5.1", "clinepass"),
+				model("cline-pass/glm-5.1", CLINEPASS_GROUP),
 				model("free-model", "free"),
 				model("anthropic/claude", "frontier"),
 				model("z-ai/glm", "open source"),
@@ -30,10 +30,16 @@ describe("getClineUIOnboardingGroups", () => {
 		)
 
 		expect(result.clinePass).toHaveLength(1)
-		expect(result.clinePass[0].group).toBe("clinepass")
+		expect(result.clinePass[0].group).toBe(CLINEPASS_GROUP)
 		expect(result.clinePass[0].models.map((m) => m.id)).toEqual(["cline-pass/glm-5.1"])
 		expect(result.free[0].models.map((m) => m.id)).toEqual(["free-model"])
 		expect(result.power.flatMap((g) => g.models.map((m) => m.id))).toEqual(["anthropic/claude", "z-ai/glm"])
+	})
+
+	it("does not bucket cline-pass ids without a ClinePass group label", () => {
+		const result = getClineUIOnboardingGroups(groupOf([model("cline-pass/glm-5.2", "frontier")]))
+
+		expect(result.clinePass).toEqual([])
 	})
 
 	it("returns an empty clinePass group when no ClinePass models are present", () => {

--- a/apps/vscode/webview-ui/src/components/onboarding/data-models.ts
+++ b/apps/vscode/webview-ui/src/components/onboarding/data-models.ts
@@ -1,6 +1,8 @@
 import type { ClineRecommendedModel, OpenRouterModelInfo } from "@shared/proto/cline/models"
 import type { OnboardingModel, OnboardingModelGroup } from "@shared/proto/cline/state"
 
+export const CLINEPASS_GROUP = "cline-pass"
+
 export interface RecommendedModelsData {
 	recommended: ClineRecommendedModel[]
 	free: ClineRecommendedModel[]
@@ -39,16 +41,20 @@ interface ModelGroup {
 	models: OnboardingModel[]
 }
 
+function isClinePassOnboardingModel(model: OnboardingModel): boolean {
+	return model.group === CLINEPASS_GROUP
+}
+
 export function getClineUIOnboardingGroups(groupedModels: OnboardingModelGroup): OnboardingModelsByGroup {
 	const { models } = groupedModels
 
-	const clinePassModels = models.filter((m) => m.group === "clinepass")
+	const clinePassModels = models.filter(isClinePassOnboardingModel)
 	const freeModels = models.filter((m) => m.group === "free")
 	const frontierModels = models.filter((m) => m.group === "frontier")
 	const openSourceModels = models.filter((m) => m.group === "open source")
 
 	return {
-		clinePass: clinePassModels.length > 0 ? [{ group: "clinepass", models: clinePassModels }] : [],
+		clinePass: clinePassModels.length > 0 ? [{ group: CLINEPASS_GROUP, models: clinePassModels }] : [],
 		free: freeModels.length > 0 ? [{ group: "free", models: freeModels }] : [],
 		power: [
 			...(frontierModels.length > 0 ? [{ group: "frontier", models: frontierModels }] : []),

--- a/apps/vscode/webview-ui/src/components/onboarding/useOnboardingModels.ts
+++ b/apps/vscode/webview-ui/src/components/onboarding/useOnboardingModels.ts
@@ -8,7 +8,7 @@ import { CLINE_PASS_FEATURE_FLAG } from "@/constants/featureFlags"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { useHasFeatureFlag } from "@/hooks/useFeatureFlag"
 import { ModelsServiceClient } from "@/services/grpc-client"
-import { getRecommendedModelsData, type RecommendedModelsData } from "./data-models"
+import { CLINEPASS_GROUP, getRecommendedModelsData, type RecommendedModelsData } from "./data-models"
 
 export type OnboardingModelsStatus = "loading" | "success" | "empty"
 
@@ -107,7 +107,7 @@ export function useOnboardingModels(): UseOnboardingModelsResult {
 		const clinePassCatalog = Object.fromEntries(
 			data.clinePass.map((rec) => [rec.id, resolveClinePassModelInfo(rec.id, openRouterModelsByName)]),
 		)
-		const clinePassModels = data.clinePass.map((rec) => toOnboardingModel(rec, "clinepass", "", clinePassCatalog))
+		const clinePassModels = data.clinePass.map((rec) => toOnboardingModel(rec, CLINEPASS_GROUP, "", clinePassCatalog))
 
 		return { status: "success", models: { models: [...clinePassModels, ...freeModels, ...frontierModels] } }
 	}, [fetchState, modelCatalog, openRouterModelsByName])


### PR DESCRIPTION
## Summary

Fix ClinePass model grouping in onboarding by standardizing the ClinePass onboarding group value to the canonical `cline-pass` string.

Previously, onboarding-created ClinePass models were assigned to `clinepass`, while the expected provider/model namespace is `cline-pass`. This could cause the “Select a ClinePass model” step to miss returned ClinePass models and show the empty state.

## Changes

- Add `CLINEPASS_GROUP = "cline-pass"` as the shared onboarding group constant.
- Use `CLINEPASS_GROUP` when creating ClinePass onboarding models.
- Group ClinePass onboarding models by `CLINEPASS_GROUP`.
- Update onboarding model grouping tests for the canonical `cline-pass` value.
- Keep grouping based on explicit group labels, not model ID prefixes.

## Test Plan

- Ran focused onboarding model grouping tests:

  ```bash
  cd /Users/johnchoi1/main/cline/apps/vscode/webview-ui
  npm run test -- src/components/onboarding/__tests__/data-models.test.ts
  ```

  Result:

  ```txt
  ✓ src/components/onboarding/__tests__/data-models.test.ts (6 tests)
  ```

- Rebuilt webview:

  ```bash
  cd /Users/johnchoi1/main/cline/apps/vscode
  npm run build:webview
  ```

- Rebuilt extension bundle:

  ```bash
  IS_DEV=true node esbuild.mjs
  ```

- Verified locally against staging with ClinePass feature flag forced on for local testing only. ClinePass provider/model list loads and includes staging-returned `cline-pass/...` models.
