### PR TITLE
fix(core): limit persisted max token adaptation

### DIFF
--- a/sdk/packages/core/src/services/llms/provider-settings.test.ts
+++ b/sdk/packages/core/src/services/llms/provider-settings.test.ts
@@ -36,4 +36,38 @@ describe("provider settings", () => {
 			}),
 		);
 	});
+
+	it("only adapts persisted maxTokens for providers with user-editable output token settings", () => {
+		expect(
+			toProviderConfig({
+				provider: "openai-compatible",
+				model: "custom-model",
+				maxTokens: 4096,
+			}).maxOutputTokens,
+		).toBe(4096);
+
+		expect(
+			toProviderConfig({
+				provider: "ollama",
+				model: "llama3",
+				maxTokens: 4096,
+			}).maxOutputTokens,
+		).toBe(4096);
+
+		expect(
+			toProviderConfig({
+				provider: "openai-codex",
+				model: "gpt-5.4",
+				maxTokens: 4096,
+			}).maxOutputTokens,
+		).toBeUndefined();
+
+		expect(
+			toProviderConfig({
+				provider: "anthropic",
+				model: "claude-sonnet-4-6-20251111",
+				maxTokens: 4096,
+			}).maxOutputTokens,
+		).toBeUndefined();
+	});
 });

--- a/sdk/packages/core/src/services/llms/provider-settings.ts
+++ b/sdk/packages/core/src/services/llms/provider-settings.ts
@@ -196,6 +196,15 @@ function shouldRouteThroughOpenAIResponses(
 	);
 }
 
+// Legacy VS Code/provider settings could persist catalog model max tokens here.
+// Only adapt it as a request cap for providers where users can edit that value.
+function shouldAdaptMaxTokensSetting(providerId: string): boolean {
+	return (
+		providerId === BUILT_IN_PROVIDER.OPENAI_COMPATIBLE ||
+		providerId === BUILT_IN_PROVIDER.OLLAMA
+	);
+}
+
 export function toProviderConfig(
 	settings: ProviderSettings,
 	options: ToProviderConfigOptions = {},
@@ -255,7 +264,9 @@ export function toProviderConfig(
 		baseUrl: resolvedBaseUrl,
 		headers: settings.headers,
 		timeoutMs: settings.timeout,
-		maxOutputTokens: settings.maxTokens,
+		maxOutputTokens: shouldAdaptMaxTokensSetting(normalizedProviderId)
+			? settings.maxTokens
+			: undefined,
 		maxInputTokens: settings.contextWindow,
 		thinking: settings.reasoning?.enabled,
 		reasoningEffort,


### PR DESCRIPTION
### Related Issue

**Issue:** ENG-2218

### Description

This fixes the ChatGPT Subscription / `openai-codex` regression where requests can fail with:

```text
Unsupported parameter: max_output_tokens
```

The root issue is that persisted provider settings can contain `maxTokens` even when the user did not explicitly configure a request-time output cap for that provider. Some legacy VS Code/model-selection paths write catalog model metadata into provider settings:

```ts
settings.maxTokens
```

During provider-settings adaptation, that value was always converted into SDK provider config:

```ts
maxOutputTokens: settings.maxTokens
```

Later, core treats `providerConfig.maxOutputTokens` as a request cap and passes it into the gateway model invocation. For providers like ChatGPT Subscription / Codex, that ultimately becomes the OpenAI Responses API parameter `max_output_tokens`, which the backend rejects.

This PR narrows the providers.json -> SDK adaptation step so persisted `settings.maxTokens` is only adapted into `ProviderConfig.maxOutputTokens` for providers where this value is user-editable request-cap configuration:

```ts
openai-compatible
ollama
```

For all other providers, the persisted value is ignored during SDK adaptation. The value is not deleted from disk in this PR; it simply stops becoming request policy for providers that never exposed that setting as something users intentionally configured.

I checked the VS Code settings surfaces while making this change. The explicit “Max Output Tokens” UI appears in OpenAI-compatible settings. Ollama is kept in the allowlist per the intended local-provider safe set; its visible setting path is primarily context-window related, but we are intentionally not broadening this change beyond the requested OpenAI-compatible/Ollama allowlist.

Why this shape instead of the previous adapter-boundary PR:

- The earlier approach suppressed `maxOutputTokens` at the AI SDK adapter for Codex providers only.
- That prevented the hard Codex failure, but left the broader persisted-config issue intact: stale/model-derived `settings.maxTokens` could still be treated as request policy for other providers.
- This PR fixes the source of the accidental request cap when adapting provider settings into SDK config.
- It preserves the OpenAI-compatible path that needs user-configured max output tokens to keep flowing.

### Test Procedure

Ran the focused provider settings tests:

```bash
bun vitest run --config vitest.config.ts src/services/llms/provider-settings.test.ts
```

Result: 3 tests passed.

The new test verifies:

- `openai-compatible` persisted `maxTokens` becomes SDK `maxOutputTokens`.
- `ollama` persisted `maxTokens` becomes SDK `maxOutputTokens`.
- `openai-codex` persisted `maxTokens` is ignored during SDK adaptation.
- `anthropic` persisted `maxTokens` is ignored during SDK adaptation.

Ran Biome on the touched files:

```bash
bun biome check --diagnostic-level=error sdk/packages/core/src/services/llms/provider-settings.ts sdk/packages/core/src/services/llms/provider-settings.test.ts
```

Result: passed.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. This is a provider settings adaptation fix with no UI changes.

### Additional Notes

The branch was pushed with `GIT_LFS_SKIP_PUSH=1` because an earlier push on the prior branch hung in the repository Git LFS pre-push hook; this branch only changes TypeScript files.
