### PR TITLE
fix(vscode): limit persisted max token settings

### DIFF
--- a/apps/vscode/src/sdk/model-catalog/store.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/store.test.ts
@@ -233,8 +233,35 @@ describe("createProviderConfigStore", () => {
 			provider: "openrouter",
 			model: "provider/model-b",
 			contextWindow: 64_000,
-			maxTokens: 4_096,
 		})
+		expect(mocks.getSavedProviderSettings("openrouter")).not.toHaveProperty("maxTokens")
+	})
+
+	it("only persists maxTokens for providers with user-editable max output token settings", async () => {
+		const { createProviderConfigStore } = await import("./store")
+		mocks.setProviderSettings({ anthropic: { provider: "anthropic", maxTokens: 8_192 } })
+		const store = createProviderConfigStore()
+
+		store.commitSelection(parseProviderId("openai"), "act", {
+			providerId: parseProviderId("openai"),
+			modelId: "custom-model",
+			modelInfo: modelInfoA,
+		})
+		store.commitSelection(parseProviderId("ollama"), "act", {
+			providerId: parseProviderId("ollama"),
+			modelId: "llama3",
+			modelInfo: modelInfoB,
+		})
+
+		store.commitSelection(parseProviderId("anthropic"), "act", {
+			providerId: parseProviderId("anthropic"),
+			modelId: "claude-sonnet",
+			modelInfo: modelInfoA,
+		})
+
+		expect(mocks.getSavedProviderSettings("openai")).toMatchObject({ maxTokens: 8_192 })
+		expect(mocks.getSavedProviderSettings("ollama")).toMatchObject({ maxTokens: 4_096 })
+		expect(mocks.getSavedProviderSettings("anthropic")).not.toHaveProperty("maxTokens")
 	})
 
 	it("updates providers.json model with setLastUsed false when planActSeparateModelsSetting=false", async () => {
@@ -269,8 +296,8 @@ describe("createProviderConfigStore", () => {
 			provider: "claude-code",
 			model: "haiku",
 			contextWindow: 128_000,
-			maxTokens: 8_192,
 		})
+		expect(mocks.getSavedProviderSettings("claude-code")).not.toHaveProperty("maxTokens")
 		expect(mocks.getSaveProviderSettingsMock()).toHaveBeenCalledWith(expect.objectContaining({ model: "haiku" }), {
 			setLastUsed: false,
 		})

--- a/apps/vscode/src/sdk/model-catalog/store.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/store.test.ts
@@ -264,6 +264,27 @@ describe("createProviderConfigStore", () => {
 		expect(mocks.getSavedProviderSettings("anthropic")).not.toHaveProperty("maxTokens")
 	})
 
+	it("preserves existing maxTokens for allowed providers when selected model metadata omits it", async () => {
+		const { createProviderConfigStore } = await import("./store")
+		mocks.setProviderSettings({ openai: { provider: "openai", maxTokens: 1_234 } })
+		const store = createProviderConfigStore()
+
+		store.commitSelection(parseProviderId("openai"), "act", {
+			providerId: parseProviderId("openai"),
+			modelId: "custom-model",
+			modelInfo: {
+				name: "Custom Model",
+				contextWindow: 128_000,
+				supportsPromptCache: false,
+			},
+		})
+
+		expect(mocks.getSavedProviderSettings("openai")).toMatchObject({
+			model: "custom-model",
+			maxTokens: 1_234,
+		})
+	})
+
 	it("updates providers.json model with setLastUsed false when planActSeparateModelsSetting=false", async () => {
 		const { createProviderConfigStore } = await import("./store")
 		mocks.setApiConfiguration({ planActSeparateModelsSetting: false })

--- a/apps/vscode/src/sdk/model-catalog/store.ts
+++ b/apps/vscode/src/sdk/model-catalog/store.ts
@@ -412,8 +412,10 @@ function writeSelectionToProviderSettings(providerId: ProviderId, selection: Mod
 		next.contextWindow = selection.modelInfo.contextWindow
 	}
 
-	if (shouldPersistMaxTokens(providerId) && selection.modelInfo.maxTokens !== undefined && selection.modelInfo.maxTokens > 0) {
-		next.maxTokens = selection.modelInfo.maxTokens
+	if (shouldPersistMaxTokens(providerId)) {
+		if (selection.modelInfo.maxTokens !== undefined && selection.modelInfo.maxTokens > 0) {
+			next.maxTokens = selection.modelInfo.maxTokens
+		}
 	} else {
 		delete next.maxTokens
 	}

--- a/apps/vscode/src/sdk/model-catalog/store.ts
+++ b/apps/vscode/src/sdk/model-catalog/store.ts
@@ -127,6 +127,14 @@ function providerForStorage(providerId: ProviderId): ApiProvider | undefined {
 	return key as ApiProvider
 }
 
+// Legacy VS Code selection persistence can copy catalog model maxTokens into
+// providers.json. Only keep that value for providers with a user-editable max
+// output token setting; otherwise it becomes an accidental request cap in SDK.
+function shouldPersistMaxTokens(providerId: ProviderId): boolean {
+	const key = providerKey(providerId)
+	return key === "openai" || key === "ollama"
+}
+
 function memoryKey(providerId: ProviderId, mode: Mode): string {
 	return `${providerId}:${mode}`
 }
@@ -404,8 +412,10 @@ function writeSelectionToProviderSettings(providerId: ProviderId, selection: Mod
 		next.contextWindow = selection.modelInfo.contextWindow
 	}
 
-	if (selection.modelInfo.maxTokens !== undefined && selection.modelInfo.maxTokens > 0) {
+	if (shouldPersistMaxTokens(providerId) && selection.modelInfo.maxTokens !== undefined && selection.modelInfo.maxTokens > 0) {
 		next.maxTokens = selection.modelInfo.maxTokens
+	} else {
+		delete next.maxTokens
 	}
 
 	saveProviderSettings(providerId, next)


### PR DESCRIPTION
### Related Issue

**Issue:** ENG-2218

### Description

This fixes the ChatGPT Subscription / `openai-codex` regression where requests can fail with:

```text
Unsupported parameter: max_output_tokens
```

The issue is not that ChatGPT exposes a user-facing max output token setting. It does not. The problem is that VS Code's model-selection persistence can copy catalog model metadata into `providers.json`:

```ts
selection.modelInfo.maxTokens -> providers.json maxTokens
```

That field later gets adapted into SDK provider config as a request max-output cap. For providers that do not expose a user-editable max output token control, this turns catalog metadata into request policy by accident. For ChatGPT Subscription / Codex, that request policy eventually becomes `max_output_tokens`, which the backend rejects.

This PR keeps the fix at the VS Code legacy settings/model-selection adapter layer instead of SDK core. When VS Code writes a model selection into provider settings, it now only persists `maxTokens` for providers that are allowed to carry it as user-editable request configuration:

```ts
openai
ollama
```

For other providers, committing a model selection removes stale `maxTokens` from the provider settings object before saving. The model metadata still remains available through mode-specific model info / known model metadata, but it no longer becomes a request cap through `providers.json`.

I checked the VS Code settings surfaces while making this change. The explicit “Max Output Tokens” setting appears in OpenAI-compatible settings. Ollama has provider-specific local model token/context plumbing and is kept in the allowlist per the intended safe set. I did not find another equivalent visible max-output-token editor that writes through this generic `providers.json.maxTokens` path.

This supersedes the earlier SDK-core and AI-SDK-adapter approaches because the accidental value is introduced by VS Code selection persistence. Fixing it here avoids teaching SDK core or the generic adapter about VS Code migration policy.

### Test Procedure

Ran the focused VS Code model-catalog store tests:

```bash
bun vitest run --config vitest.config.ts src/sdk/model-catalog/store.test.ts
```

Result: 16 tests passed.

The new/updated coverage verifies:

- OpenRouter model selection still persists model/context metadata but no longer writes `maxTokens` to provider settings.
- Claude Code model selection no longer writes `maxTokens` to provider settings.
- OpenAI-compatible (`openai`) still persists `maxTokens`.
- Ollama still persists `maxTokens`.
- A stale `maxTokens` already present for Anthropic is removed when a selection is committed.

Ran Biome on the touched files:

```bash
bunx --bun @biomejs/biome check --diagnostic-level=error src/sdk/model-catalog/store.ts src/sdk/model-catalog/store.test.ts
```

Result: passed.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. This is a VS Code settings/model-selection persistence fix with no UI changes.

### Additional Notes

The branch was pushed with `GIT_LFS_SKIP_PUSH=1` because an earlier push on this repo hung in the Git LFS pre-push hook; this branch only changes TypeScript files.
