### PR TITLE
Prevent injecting other models into the LiteLLM model list [CLINE-2530]

### DIFF
--- a/sdk/packages/core/src/services/llms/provider-defaults.test.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.test.ts
@@ -296,6 +296,17 @@ describe("resolveProviderConfig", () => {
 				capabilities: expect.arrayContaining(["images", "reasoning"]),
 			}),
 		);
+		expect(resolved?.knownModels?.["private-proxy-model"]).toEqual(
+			expect.objectContaining({
+				name: "private-proxy-model",
+				capabilities: expect.arrayContaining(["images", "reasoning"]),
+			}),
+		);
+		expect(Object.keys(resolved?.knownModels ?? {}).sort()).toEqual([
+			"openai/gpt-4o-mini",
+			"private-proxy-model",
+		]);
+		expect(resolved?.knownModels?.["gpt-5.4"]).toBeUndefined();
 	});
 
 	it("reports attempted path, auth header, status, and body for LiteLLM model fetch failures", async () => {

--- a/sdk/packages/core/src/services/llms/provider-defaults.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.ts
@@ -171,6 +171,16 @@ async function mergeKnownModels(
 			...userKnownModels,
 		});
 	}
+	// LiteLLM model access is configured by the user's proxy. When the proxy
+	// returns a private model list, treat it as the authoritative allowlist so
+	// the picker does not show bundled OpenAI-compatible catalog entries that the
+	// proxy may not actually expose.
+	if (providerId === "litellm" && Object.keys(privateModels).length > 0) {
+		return Llms.sortModelsByReleaseDate({
+			...privateModels,
+			...userKnownModels,
+		});
+	}
 	if (providerId === "openai-codex") {
 		return Llms.sortModelsByReleaseDate({
 			...defaultKnownModels,


### PR DESCRIPTION
Before
<img width="240" height="166" alt="image" src="https://github.com/user-attachments/assets/fdddf1f2-d5f1-40dc-9d2d-686e0cfb5c98" />


After
<img width="239" height="138" alt="image" src="https://github.com/user-attachments/assets/121563b7-1590-409c-aad0-bf2884b26fce" />

[CLINE-2530](https://linear.app/cline-bot/issue/CLINE-2530/litellm-model-list-includes-stale-cached-models)