### PR TITLE
fix(vscode): keep model metadata out of provider settings

### DIFF
--- a/apps/vscode/src/sdk/model-catalog/store.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/store.test.ts
@@ -232,9 +232,9 @@ describe("createProviderConfigStore", () => {
 		expect(mocks.getSavedProviderSettings("openrouter")).toMatchObject({
 			provider: "openrouter",
 			model: "provider/model-b",
-			contextWindow: 64_000,
-			maxTokens: 4_096,
 		})
+		expect(mocks.getSavedProviderSettings("openrouter")).not.toHaveProperty("contextWindow")
+		expect(mocks.getSavedProviderSettings("openrouter")).not.toHaveProperty("maxTokens")
 	})
 
 	it("updates providers.json model with setLastUsed false when planActSeparateModelsSetting=false", async () => {
@@ -268,9 +268,9 @@ describe("createProviderConfigStore", () => {
 		expect(mocks.getSavedProviderSettings("claude-code")).toMatchObject({
 			provider: "claude-code",
 			model: "haiku",
-			contextWindow: 128_000,
-			maxTokens: 8_192,
 		})
+		expect(mocks.getSavedProviderSettings("claude-code")).not.toHaveProperty("contextWindow")
+		expect(mocks.getSavedProviderSettings("claude-code")).not.toHaveProperty("maxTokens")
 		expect(mocks.getSaveProviderSettingsMock()).toHaveBeenCalledWith(expect.objectContaining({ model: "haiku" }), {
 			setLastUsed: false,
 		})

--- a/apps/vscode/src/sdk/model-catalog/store.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/store.test.ts
@@ -240,7 +240,9 @@ describe("createProviderConfigStore", () => {
 	it("updates providers.json model with setLastUsed false when planActSeparateModelsSetting=false", async () => {
 		const { createProviderConfigStore } = await import("./store")
 		mocks.setApiConfiguration({ planActSeparateModelsSetting: false })
-		mocks.setProviderSettings({ openrouter: { provider: "openrouter", apiKey: "existing-key" } })
+		mocks.setProviderSettings({
+			openrouter: { provider: "openrouter", apiKey: "existing-key", contextWindow: 64_000, maxTokens: 4_096 },
+		})
 		const store = createProviderConfigStore()
 		const providerId = parseProviderId("openrouter")
 		const selection = { providerId, modelId: "provider/model-a", modelInfo: modelInfoA }
@@ -252,6 +254,8 @@ describe("createProviderConfigStore", () => {
 			apiKey: "existing-key",
 			model: "provider/model-a",
 		})
+		expect(mocks.getSavedProviderSettings("openrouter")).not.toHaveProperty("contextWindow")
+		expect(mocks.getSavedProviderSettings("openrouter")).not.toHaveProperty("maxTokens")
 		expect(mocks.getSaveProviderSettingsMock()).toHaveBeenCalledWith(expect.objectContaining({ model: "provider/model-a" }), {
 			setLastUsed: false,
 		})

--- a/apps/vscode/src/sdk/model-catalog/store.ts
+++ b/apps/vscode/src/sdk/model-catalog/store.ts
@@ -400,14 +400,6 @@ function writeSelectionToState(providerId: ProviderId, mode: Mode, selection: Mo
 function writeSelectionToProviderSettings(providerId: ProviderId, selection: ModelSelection): void {
 	const next: ProviderSettingsRecord = { ...getProviderSettings(providerId), model: selection.modelId }
 
-	if (selection.modelInfo.contextWindow !== undefined && selection.modelInfo.contextWindow > 0) {
-		next.contextWindow = selection.modelInfo.contextWindow
-	}
-
-	if (selection.modelInfo.maxTokens !== undefined && selection.modelInfo.maxTokens > 0) {
-		next.maxTokens = selection.modelInfo.maxTokens
-	}
-
 	saveProviderSettings(providerId, next)
 }
 

--- a/apps/vscode/src/sdk/model-catalog/store.ts
+++ b/apps/vscode/src/sdk/model-catalog/store.ts
@@ -399,6 +399,7 @@ function writeSelectionToState(providerId: ProviderId, mode: Mode, selection: Mo
 
 function writeSelectionToProviderSettings(providerId: ProviderId, selection: ModelSelection): void {
 	const next: ProviderSettingsRecord = { ...getProviderSettings(providerId), model: selection.modelId }
+	// Prune model metadata that earlier builds may have written to providers.json.
 	delete next.contextWindow
 	delete next.maxTokens
 

--- a/apps/vscode/src/sdk/model-catalog/store.ts
+++ b/apps/vscode/src/sdk/model-catalog/store.ts
@@ -399,6 +399,8 @@ function writeSelectionToState(providerId: ProviderId, mode: Mode, selection: Mo
 
 function writeSelectionToProviderSettings(providerId: ProviderId, selection: ModelSelection): void {
 	const next: ProviderSettingsRecord = { ...getProviderSettings(providerId), model: selection.modelId }
+	delete next.contextWindow
+	delete next.maxTokens
 
 	saveProviderSettings(providerId, next)
 }


### PR DESCRIPTION
When the extension committed a model selection for SDK-backed providers, `writeSelectionToProviderSettings` wrote the selected `model` to `providers.json`, which is expected. It also copied model metadata from the selected `ModelInfo` into the same provider settings record:

```ts
next.contextWindow = selection.modelInfo.contextWindow
next.maxTokens = selection.modelInfo.maxTokens
```

That meant signing into providers such as ChatGPT Provider, or changing models in app flows that call `commitSelection`, could mutate `providers.json` with model metadata like context window and max output tokens. That is the wrong persistence layer. `providers.json` should keep provider runtime settings such as auth, base URL, and the selected model id; model metadata should stay in the model catalog / model-info settings path rather than being mirrored into provider settings.

The fix is intentionally small: `writeSelectionToProviderSettings` now continues to save only the latest selected `model` while preserving any existing provider settings. It no longer writes `contextWindow` or `maxTokens` into the provider settings record. The tests now assert that committing OpenRouter and Claude Code selections updates the provider model id without adding model metadata fields.

One important review point: this should not break the OpenAI-compatible "Max Output Tokens" UI setting. That UI setting already has a separate persistence/runtime path:

- `OpenAICompatible.tsx` updates `openAiModelInfo.maxTokens` through `handleOpenAiModelInfoChange`.
- `handleOpenAiModelInfoChange` writes the value via `handleModeFieldChange` to the mode-specific API configuration fields, `planModeOpenAiModelInfo` / `actModeOpenAiModelInfo`.
- `cline-session-factory.ts` later reads that mode-specific OpenAI-compatible model info with `getOpenAiCompatibleModelInfo(...)`, builds SDK `knownModels` with `buildOpenAiCompatibleKnownModels(...)`, and sets the SDK provider config's `maxOutputTokens` from `knownModels[modelId].maxTokens`.

So removing the accidental `providers.json` mirror does not remove the SDK's access to UI-set OpenAI-compatible max output tokens. It just stops duplicating that value into the wrong file.
