### PR TITLE
fix(vscode): revert OpenAI-compatible metadata limit plumbing

### DIFF
--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -411,6 +411,33 @@ describe("buildSessionConfig", () => {
 		expect(config.providerConfig).not.toHaveProperty("apiKey")
 	})
 
+	it("passes OpenAI Compatible max output tokens as an explicit request limit", async () => {
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "openai",
+			actModeOpenAiModelId: "custom-reasoner",
+			openAiApiKey: "openai-compatible-key",
+			openAiBaseUrl: "https://openai-compatible.example/v1",
+			actModeOpenAiModelInfo: {
+				name: "Custom Reasoner",
+				contextWindow: 16_000,
+				maxTokens: 4_096,
+				supportsImages: false,
+				supportsPromptCache: false,
+				inputPrice: 0,
+				outputPrice: 0,
+			},
+		} as any)
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+
+		expect(config.providerId).toBe("openai-compatible")
+		expect(config.modelId).toBe("custom-reasoner")
+		expect(config.knownModels).toBeUndefined()
+		expect((config.providerConfig as any).knownModels).toBeUndefined()
+		expect((config.providerConfig as any).maxOutputTokens).toBeUndefined()
+		expect((config as any).maxTokensPerTurn).toBe(4_096)
+	})
+
 	it("builds structured SAP AI Core config from legacy ApiConfiguration fields", async () => {
 		mocks.stateManager.getApiConfiguration.mockReturnValue({
 			actModeApiProvider: "sapaicore",

--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -411,44 +411,6 @@ describe("buildSessionConfig", () => {
 		expect(config.providerConfig).not.toHaveProperty("apiKey")
 	})
 
-	it("passes OpenAI Compatible custom model metadata through as SDK knownModels", async () => {
-		mocks.stateManager.getApiConfiguration.mockReturnValue({
-			actModeApiProvider: "openai",
-			actModeOpenAiModelId: "custom-reasoner",
-			openAiApiKey: "openai-compatible-key",
-			openAiBaseUrl: "https://openai-compatible.example/v1",
-			actModeOpenAiModelInfo: {
-				name: "Custom Reasoner",
-				contextWindow: 16_000,
-				maxTokens: 4_096,
-				supportsImages: false,
-				supportsPromptCache: false,
-				supportsReasoning: true,
-				inputPrice: 0,
-				outputPrice: 0,
-			},
-		} as any)
-
-		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
-
-		expect(config.providerId).toBe("openai-compatible")
-		expect(config.modelId).toBe("custom-reasoner")
-		expect(config.knownModels?.["custom-reasoner"]).toMatchObject({
-			id: "custom-reasoner",
-			name: "Custom Reasoner",
-			contextWindow: 16_000,
-			maxInputTokens: 16_000,
-			maxTokens: 4_096,
-			capabilities: ["streaming", "tools"],
-		})
-		expect((config.providerConfig as any).knownModels?.["custom-reasoner"]).toMatchObject({
-			contextWindow: 16_000,
-			maxInputTokens: 16_000,
-			maxTokens: 4_096,
-		})
-		expect((config.providerConfig as any).maxOutputTokens).toBe(4_096)
-	})
-
 	it("builds structured SAP AI Core config from legacy ApiConfiguration fields", async () => {
 		mocks.stateManager.getApiConfiguration.mockReturnValue({
 			actModeApiProvider: "sapaicore",

--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -182,6 +182,12 @@ function resolveProviderReasoningConfig(providerId: string): SessionReasoningCon
 	}
 }
 
+function resolveOpenAiCompatibleMaxTokens(config: ApiConfiguration | undefined, mode: Mode): number | undefined {
+	const modelInfo = mode === "plan" ? config?.planModeOpenAiModelInfo : config?.actModeOpenAiModelInfo
+	const maxTokens = modelInfo?.maxTokens
+	return typeof maxTokens === "number" && Number.isFinite(maxTokens) && maxTokens > 0 ? maxTokens : undefined
+}
+
 // ---------------------------------------------------------------------------
 // Provider → API key field mapping
 // ---------------------------------------------------------------------------
@@ -580,6 +586,7 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 		apiKey = resolveApiKey(providerId, apiConfig)
 	}
 	apiKey = apiKey ?? ""
+	const maxTokensPerTurn = providerId === "openai" ? resolveOpenAiCompatibleMaxTokens(apiConfig, mode) : undefined
 	const reasoningConfig = resolveProviderReasoningConfig(providerId)
 
 	// Build the system prompt using the shared prompt builder. Core still
@@ -673,6 +680,7 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 		disableMcpSettingsTools: true,
 		mode: mode === "plan" ? "plan" : "act",
 		...reasoningConfig,
+		...(maxTokensPerTurn !== undefined ? { maxTokensPerTurn } : {}),
 		maxIterations: undefined,
 		logger: sdkLogger,
 		extensionContext: {

--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -16,9 +16,9 @@ import {
 	resolveProviderApiKeyFromSettings,
 	type StartSessionResult,
 } from "@cline/core"
-import { getGeneratedModelsForProvider, MODEL_COLLECTIONS_BY_PROVIDER_ID, type ModelInfo as SdkModelInfo } from "@cline/llms"
+import { getGeneratedModelsForProvider, MODEL_COLLECTIONS_BY_PROVIDER_ID } from "@cline/llms"
 import { buildClineSystemPrompt } from "@cline/shared"
-import type { ApiConfiguration, ModelInfo as LegacyModelInfo } from "@shared/api"
+import type { ApiConfiguration } from "@shared/api"
 import type { HistoryItem } from "@shared/HistoryItem"
 import { DEFAULT_LANGUAGE_SETTINGS, getLanguageKey, type LanguageDisplay } from "@shared/Languages"
 import { Logger } from "@shared/services/Logger"
@@ -179,54 +179,6 @@ function resolveProviderReasoningConfig(providerId: string): SessionReasoningCon
 	} catch (error) {
 		Logger.warn("[SessionFactory] Provider reasoning resolution failed:", error)
 		return {}
-	}
-}
-
-function positiveNumber(value: unknown): number | undefined {
-	return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined
-}
-
-function getOpenAiCompatibleModelInfo(config: ApiConfiguration, mode: Mode): LegacyModelInfo | undefined {
-	return mode === "plan" ? config.planModeOpenAiModelInfo : config.actModeOpenAiModelInfo
-}
-
-const OPENAI_COMPATIBLE_DEFAULT_CAPABILITIES: NonNullable<SdkModelInfo["capabilities"]> = ["streaming", "tools"]
-
-function buildOpenAiCompatibleCapabilities(modelInfo: LegacyModelInfo): NonNullable<SdkModelInfo["capabilities"]> {
-	const capabilities: NonNullable<SdkModelInfo["capabilities"]> = [...OPENAI_COMPATIBLE_DEFAULT_CAPABILITIES]
-	if (modelInfo.supportsImages !== false) {
-		capabilities.push("images")
-	}
-	return capabilities
-}
-
-// VS Code stores OpenAI-compatible custom model metadata in legacy
-// ApiConfiguration fields. The SDK runtime enforces context/output limits from
-// knownModels, so bridge the selected model into the SDK shape during session
-// creation.
-function buildOpenAiCompatibleKnownModels(
-	modelId: string | undefined,
-	modelInfo: LegacyModelInfo | undefined,
-): Record<string, SdkModelInfo> | undefined {
-	const trimmedModelId = modelId?.trim()
-	if (!trimmedModelId || !modelInfo) {
-		return undefined
-	}
-
-	const contextWindow = positiveNumber(modelInfo.contextWindow)
-	const maxTokens = positiveNumber(modelInfo.maxTokens)
-
-	return {
-		[trimmedModelId]: {
-			id: trimmedModelId,
-			name: modelInfo.name ?? trimmedModelId,
-			description: modelInfo.description,
-			contextWindow,
-			maxInputTokens: contextWindow,
-			maxTokens,
-			capabilities: buildOpenAiCompatibleCapabilities(modelInfo),
-			temperature: modelInfo.temperature,
-		},
 	}
 }
 
@@ -546,7 +498,6 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 	let modelId: string | undefined
 	let apiKey: string | undefined
 	let baseUrl: string | undefined
-	let knownModels: CoreSessionConfig["knownModels"] | undefined
 	let apiConfig: ApiConfiguration | undefined
 	// Cloud-provider structured options. The core runtime reads these from
 	// CoreSessionConfig.providerConfig; without them the SDK gateway never receives
@@ -569,9 +520,6 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 
 			// Resolve model ID
 			modelId = resolveModelId(providerId, mode, apiConfig)
-			if (providerId === "openai") {
-				knownModels = buildOpenAiCompatibleKnownModels(modelId, getOpenAiCompatibleModelInfo(apiConfig, mode))
-			}
 
 			// Resolve base URL
 			baseUrl = resolveBaseUrl(providerId, apiConfig)
@@ -699,10 +647,6 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 		modelId,
 		...(apiKey ? { apiKey } : {}),
 		...(baseUrl !== undefined ? { baseUrl } : {}),
-		...(knownModels ? { knownModels } : {}),
-		...(modelId && positiveNumber(knownModels?.[modelId]?.maxTokens)
-			? { maxOutputTokens: positiveNumber(knownModels?.[modelId]?.maxTokens) }
-			: {}),
 		fetch,
 	}
 
@@ -711,7 +655,6 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 		modelId,
 		apiKey,
 		baseUrl,
-		knownModels,
 		providerConfig,
 		cwd,
 		workspaceRoot,

--- a/sdk/packages/core/src/extensions/tools/team/delegated-agent.ts
+++ b/sdk/packages/core/src/extensions/tools/team/delegated-agent.ts
@@ -27,6 +27,7 @@ export type DelegatedAgentConnectionConfig = Pick<
 	| "providerConfig"
 	| "knownModels"
 	| "thinking"
+	| "maxTokensPerTurn"
 >;
 
 export interface DelegatedAgentRuntimeConfig
@@ -87,6 +88,7 @@ export function createDelegatedAgentConfigProvider(
 			providerConfig: runtimeConfig.providerConfig,
 			knownModels: runtimeConfig.knownModels,
 			thinking: runtimeConfig.thinking,
+			maxTokensPerTurn: runtimeConfig.maxTokensPerTurn,
 		}),
 		updateConnectionDefaults: (overrides) => {
 			runtimeConfig = {

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -468,6 +468,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 			thinking: configWithProvider.thinking,
 			reasoningEffort:
 				configWithProvider.reasoningEffort ?? providerConfig.reasoningEffort,
+			maxTokensPerTurn: configWithProvider.maxTokensPerTurn,
 			systemPrompt: configWithProvider.systemPrompt,
 			maxIterations: configWithProvider.maxIterations,
 			execution: configWithProvider.execution,

--- a/sdk/packages/core/src/runtime/orchestration/runtime-builder.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-builder.ts
@@ -485,6 +485,7 @@ export class DefaultRuntimeBuilder implements RuntimeBuilder {
 			providerConfig: config.providerConfig,
 			knownModels: config.knownModels,
 			thinking: config.thinking,
+			maxTokensPerTurn: config.maxTokensPerTurn,
 			maxIterations: config.maxIterations,
 			hooks,
 			extensions: runtimeExtensions,

--- a/sdk/packages/core/src/services/llms/handler-factory.test.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.test.ts
@@ -200,6 +200,31 @@ describe("createAgentModelFromConfig", () => {
 		});
 	});
 
+	it("uses explicit per-turn max tokens for gateway request limits", async () => {
+		const { createAgentModelFromConfig } = await import("./handler-factory");
+
+		createAgentModelFromConfig(
+			{
+				providerId: "openai-compatible",
+				modelId: "custom-model",
+				apiKey: "key",
+				systemPrompt: "",
+				tools: [],
+				maxTokensPerTurn: 4_096,
+				providerConfig: {
+					providerId: "openai-compatible",
+					modelId: "custom-model",
+				},
+			},
+			undefined,
+		);
+
+		expect(gatewayMock.createAgentModel).toHaveBeenLastCalledWith(
+			{ providerId: "openai-compatible", modelId: "custom-model" },
+			{ maxTokens: 4_096 },
+		);
+	});
+
 	it("forwards Bedrock AWS settings as gateway provider options", async () => {
 		const { createAgentModelFromConfig } = await import("./handler-factory");
 

--- a/sdk/packages/core/src/services/llms/handler-factory.test.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.test.ts
@@ -125,31 +125,6 @@ describe("createAgentModelFromConfig", () => {
 		);
 	});
 
-	it("uses providerConfig maxOutputTokens when no direct per-turn override is set", async () => {
-		const { createAgentModelFromConfig } = await import("./handler-factory");
-
-		createAgentModelFromConfig(
-			{
-				providerId: "openai-compatible",
-				modelId: "custom-model",
-				apiKey: "key",
-				systemPrompt: "",
-				tools: [],
-				providerConfig: {
-					providerId: "openai-compatible",
-					modelId: "custom-model",
-					maxOutputTokens: 4_096,
-				},
-			},
-			undefined,
-		);
-
-		expect(gatewayMock.createAgentModel).toHaveBeenLastCalledWith(
-			{ providerId: "openai-compatible", modelId: "custom-model" },
-			{ maxTokens: 4_096 },
-		);
-	});
-
 	it("preserves model capabilities and metadata when configuring gateway models", async () => {
 		const { createAgentModelFromConfig } = await import("./handler-factory");
 

--- a/sdk/packages/core/src/services/llms/handler-factory.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.ts
@@ -163,7 +163,7 @@ export function createAgentModelFromConfig(
 		baseUrl: config.baseUrl ?? baseProviderConfig?.baseUrl,
 		headers: config.headers ?? baseProviderConfig?.headers,
 		knownModels: resolveKnownModelsFromConfig(config),
-		maxOutputTokens: config.maxTokensPerTurn ?? baseProviderConfig?.maxOutputTokens,
+		maxOutputTokens: config.maxTokensPerTurn,
 		reasoningEffort: config.reasoningEffort,
 		thinkingBudgetTokens: config.thinkingBudgetTokens,
 		thinking: config.thinking,

--- a/sdk/packages/core/src/types/config.ts
+++ b/sdk/packages/core/src/types/config.ts
@@ -37,6 +37,10 @@ export interface CoreModelConfig {
 	 * Explicit reasoning effort override for capable models.
 	 */
 	reasoningEffort?: ProviderConfig["reasoningEffort"];
+	/**
+	 * Maximum output tokens per API call.
+	 */
+	maxTokensPerTurn?: number;
 }
 
 export interface CoreRuntimeFeatures {

--- a/sdk/packages/llms/src/providers/compat.test.ts
+++ b/sdk/packages/llms/src/providers/compat.test.ts
@@ -394,6 +394,36 @@ describe("createGatewayApiHandler.createMessage", () => {
 		expect(call).not.toHaveProperty("maxOutputTokens");
 	});
 
+	it("sends configured OpenAI-compatible maxOutputTokens to the provider request", async () => {
+		streamTextSpy.mockReturnValue({
+			fullStream: (async function* () {
+				yield { type: "finish", finishReason: "stop" };
+			})(),
+			usage: Promise.resolve({ inputTokens: 1, outputTokens: 1 }),
+		});
+
+		const handler = createGatewayApiHandler({
+			providerId: "openai-compatible",
+			clientType: "openai-compatible",
+			modelId: "custom-model",
+			apiKey: "test-key",
+			baseUrl: "https://example.com/v1",
+			maxOutputTokens: 4_096,
+		});
+
+		for await (const _chunk of handler.createMessage("", [
+			{ role: "user", content: "Hello" },
+		])) {
+			// Drain the stream so the provider request is executed.
+		}
+
+		expect(streamTextSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				maxOutputTokens: 4_096,
+			}),
+		);
+	});
+
 	it("caps configured maxOutputTokens with the catalog model output limit", async () => {
 		streamTextSpy.mockReturnValue({
 			fullStream: (async function* () {


### PR DESCRIPTION
This PR rolls back the request-level max-output-token behavior introduced in #11710 after the follow-up cleanup in #11772 clarified the persistence boundary for model metadata.

The short version:

- #11710 tried to make VS Code OpenAI-compatible custom context/output limits affect SDK runtime behavior by bridging `actModeOpenAiModelInfo` / `planModeOpenAiModelInfo` into SDK `knownModels` during session creation.
- That same path also copied the selected model's `maxTokens` into `providerConfig.maxOutputTokens`.
- #11772 then fixed the adjacent persistence problem: `providers.json` should store provider runtime settings and the selected model id, but should not store model metadata like `contextWindow` or `maxTokens`.
- Given that cleanup, the #11710 bridge is now too broad and risky. It makes model metadata behave like an explicit request option, which can cause providers such as ChatGPT Provider / OAuth-backed OpenAI-compatible paths to receive `maxOutputTokens` when they should not.

The key distinction for reviewers:

```ts
knownModels[modelId].maxTokens
```

is model catalog metadata. It can describe a model's output limit and can be used as a cap when an explicit request max exists. It should not, by itself, force every request to include a max-output-token parameter.

```ts
providerConfig.maxOutputTokens
```

is request behavior. Once this is populated and passed through `createAgentModelFromConfig`, the gateway sends it as the active max token setting for the request. That is the part this PR removes.

Concretely, this PR:

- Removes the VS Code session-factory bridge that manufactured OpenAI-compatible `knownModels` from legacy `actModeOpenAiModelInfo` / `planModeOpenAiModelInfo`.
- Stops adding `maxOutputTokens` to `providerConfig` from those model-info fields.
- Reverts core handler-factory behavior so `providerConfig.maxOutputTokens` is no longer used as a fallback when `maxTokensPerTurn` is absent.
- Removes the tests that asserted that now-undesired behavior.

This is intentionally a damage-control PR, not the final fix for the OpenAI-compatible "Max Output Tokens" setting. A follow-up should wire that UI setting through an explicit request-level path for OpenAI-compatible only, now that we understand the separation:

- `models.json` / `knownModels`: model metadata and catalog limits
- explicit request config: whether to actually send a max token parameter on a request

That follow-up should be narrow and should avoid reintroducing provider-wide or persisted metadata as request behavior for unrelated providers.

### Additional Notes

The important reviewer question is not whether model metadata can still exist in `models.json` or SDK `knownModels`; it can. The question is whether that metadata should automatically become a request max-output-token parameter. This PR restores the safer behavior: catalog metadata stays metadata, and request-level max token behavior must be explicit.


---

### Follow-up PR

Follow-up PR: #11776

This rollback PR intentionally removes the OpenAI-compatible model metadata bridge from the SDK session path. The follow-up restores the actually desired behavior without reintroducing provider/model metadata storage:

- VS Code reads the legacy OpenAI-compatible Max Output Tokens value from `actModeOpenAiModelInfo.maxTokens` / `planModeOpenAiModelInfo.maxTokens`.
- That value is passed through core as an explicit `maxTokensPerTurn` request limit.
- Core gives the gateway `{ maxTokens }` for the agent model.
- The llms provider layer sends it to the AI SDK request as `maxOutputTokens`.

So #11775 removes the incorrect metadata-derived limit plumbing, while #11776 adds the narrower request-level fix that makes the OpenAI-compatible Max Output Tokens setting actually affect outbound requests. The follow-up includes a request-capture smoke test proving the outgoing OpenAI-compatible provider call contains `maxOutputTokens: 4096`, without using a live provider key.
