### PR TITLE
fix(vscode): send OpenAI-compatible output token limit

### DIFF
--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -411,6 +411,33 @@ describe("buildSessionConfig", () => {
 		expect(config.providerConfig).not.toHaveProperty("apiKey")
 	})
 
+	it("passes OpenAI Compatible max output tokens as an explicit request limit", async () => {
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "openai",
+			actModeOpenAiModelId: "custom-reasoner",
+			openAiApiKey: "openai-compatible-key",
+			openAiBaseUrl: "https://openai-compatible.example/v1",
+			actModeOpenAiModelInfo: {
+				name: "Custom Reasoner",
+				contextWindow: 16_000,
+				maxTokens: 4_096,
+				supportsImages: false,
+				supportsPromptCache: false,
+				inputPrice: 0,
+				outputPrice: 0,
+			},
+		} as any)
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+
+		expect(config.providerId).toBe("openai-compatible")
+		expect(config.modelId).toBe("custom-reasoner")
+		expect(config.knownModels).toBeUndefined()
+		expect((config.providerConfig as any).knownModels).toBeUndefined()
+		expect((config.providerConfig as any).maxOutputTokens).toBeUndefined()
+		expect((config as any).maxTokensPerTurn).toBe(4_096)
+	})
+
 	it("builds structured SAP AI Core config from legacy ApiConfiguration fields", async () => {
 		mocks.stateManager.getApiConfiguration.mockReturnValue({
 			actModeApiProvider: "sapaicore",

--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -182,6 +182,12 @@ function resolveProviderReasoningConfig(providerId: string): SessionReasoningCon
 	}
 }
 
+function resolveOpenAiCompatibleMaxTokens(config: ApiConfiguration | undefined, mode: Mode): number | undefined {
+	const modelInfo = mode === "plan" ? config?.planModeOpenAiModelInfo : config?.actModeOpenAiModelInfo
+	const maxTokens = modelInfo?.maxTokens
+	return typeof maxTokens === "number" && Number.isFinite(maxTokens) && maxTokens > 0 ? maxTokens : undefined
+}
+
 // ---------------------------------------------------------------------------
 // Provider → API key field mapping
 // ---------------------------------------------------------------------------
@@ -580,6 +586,7 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 		apiKey = resolveApiKey(providerId, apiConfig)
 	}
 	apiKey = apiKey ?? ""
+	const maxTokensPerTurn = providerId === "openai" ? resolveOpenAiCompatibleMaxTokens(apiConfig, mode) : undefined
 	const reasoningConfig = resolveProviderReasoningConfig(providerId)
 
 	// Build the system prompt using the shared prompt builder. Core still
@@ -673,6 +680,7 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 		disableMcpSettingsTools: true,
 		mode: mode === "plan" ? "plan" : "act",
 		...reasoningConfig,
+		...(maxTokensPerTurn !== undefined ? { maxTokensPerTurn } : {}),
 		maxIterations: undefined,
 		logger: sdkLogger,
 		extensionContext: {

--- a/sdk/packages/core/src/extensions/tools/team/delegated-agent.ts
+++ b/sdk/packages/core/src/extensions/tools/team/delegated-agent.ts
@@ -27,6 +27,7 @@ export type DelegatedAgentConnectionConfig = Pick<
 	| "providerConfig"
 	| "knownModels"
 	| "thinking"
+	| "maxTokensPerTurn"
 >;
 
 export interface DelegatedAgentRuntimeConfig
@@ -87,6 +88,7 @@ export function createDelegatedAgentConfigProvider(
 			providerConfig: runtimeConfig.providerConfig,
 			knownModels: runtimeConfig.knownModels,
 			thinking: runtimeConfig.thinking,
+			maxTokensPerTurn: runtimeConfig.maxTokensPerTurn,
 		}),
 		updateConnectionDefaults: (overrides) => {
 			runtimeConfig = {

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -468,6 +468,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 			thinking: configWithProvider.thinking,
 			reasoningEffort:
 				configWithProvider.reasoningEffort ?? providerConfig.reasoningEffort,
+			maxTokensPerTurn: configWithProvider.maxTokensPerTurn,
 			systemPrompt: configWithProvider.systemPrompt,
 			maxIterations: configWithProvider.maxIterations,
 			execution: configWithProvider.execution,

--- a/sdk/packages/core/src/runtime/orchestration/runtime-builder.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-builder.ts
@@ -485,6 +485,7 @@ export class DefaultRuntimeBuilder implements RuntimeBuilder {
 			providerConfig: config.providerConfig,
 			knownModels: config.knownModels,
 			thinking: config.thinking,
+			maxTokensPerTurn: config.maxTokensPerTurn,
 			maxIterations: config.maxIterations,
 			hooks,
 			extensions: runtimeExtensions,

--- a/sdk/packages/core/src/services/llms/handler-factory.test.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.test.ts
@@ -200,6 +200,31 @@ describe("createAgentModelFromConfig", () => {
 		});
 	});
 
+	it("uses explicit per-turn max tokens for gateway request limits", async () => {
+		const { createAgentModelFromConfig } = await import("./handler-factory");
+
+		createAgentModelFromConfig(
+			{
+				providerId: "openai-compatible",
+				modelId: "custom-model",
+				apiKey: "key",
+				systemPrompt: "",
+				tools: [],
+				maxTokensPerTurn: 4_096,
+				providerConfig: {
+					providerId: "openai-compatible",
+					modelId: "custom-model",
+				},
+			},
+			undefined,
+		);
+
+		expect(gatewayMock.createAgentModel).toHaveBeenLastCalledWith(
+			{ providerId: "openai-compatible", modelId: "custom-model" },
+			{ maxTokens: 4_096 },
+		);
+	});
+
 	it("forwards Bedrock AWS settings as gateway provider options", async () => {
 		const { createAgentModelFromConfig } = await import("./handler-factory");
 

--- a/sdk/packages/core/src/types/config.ts
+++ b/sdk/packages/core/src/types/config.ts
@@ -37,6 +37,10 @@ export interface CoreModelConfig {
 	 * Explicit reasoning effort override for capable models.
 	 */
 	reasoningEffort?: ProviderConfig["reasoningEffort"];
+	/**
+	 * Maximum output tokens per API call.
+	 */
+	maxTokensPerTurn?: number;
 }
 
 export interface CoreRuntimeFeatures {

--- a/sdk/packages/llms/src/providers/compat.test.ts
+++ b/sdk/packages/llms/src/providers/compat.test.ts
@@ -394,6 +394,36 @@ describe("createGatewayApiHandler.createMessage", () => {
 		expect(call).not.toHaveProperty("maxOutputTokens");
 	});
 
+	it("sends configured OpenAI-compatible maxOutputTokens to the provider request", async () => {
+		streamTextSpy.mockReturnValue({
+			fullStream: (async function* () {
+				yield { type: "finish", finishReason: "stop" };
+			})(),
+			usage: Promise.resolve({ inputTokens: 1, outputTokens: 1 }),
+		});
+
+		const handler = createGatewayApiHandler({
+			providerId: "openai-compatible",
+			clientType: "openai-compatible",
+			modelId: "custom-model",
+			apiKey: "test-key",
+			baseUrl: "https://example.com/v1",
+			maxOutputTokens: 4_096,
+		});
+
+		for await (const _chunk of handler.createMessage("", [
+			{ role: "user", content: "Hello" },
+		])) {
+			// Drain the stream so the provider request is executed.
+		}
+
+		expect(streamTextSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				maxOutputTokens: 4_096,
+			}),
+		);
+	});
+
 	it("caps configured maxOutputTokens with the catalog model output limit", async () => {
 		streamTextSpy.mockReturnValue({
 			fullStream: (async function* () {


### PR DESCRIPTION
This is the follow-up to the rollback/damage-control PR for the OpenAI-compatible model metadata issue.

The earlier SDK migration work tried to bridge VS Code's OpenAI-compatible custom model metadata into the SDK's `knownModels` shape. That seemed reasonable at the time because the legacy VS Code settings store custom OpenAI-compatible model data like `contextWindow` and `maxTokens` in `actModeOpenAiModelInfo` / `planModeOpenAiModelInfo`, while parts of the SDK runtime look at model catalog metadata.

After #11772, the important distinction is clearer:

- Provider settings / provider config should not store or synthesize model metadata like `contextWindow` or catalog `maxTokens`.
- Catalog/model metadata can describe model capabilities and hard caps, but it should not automatically become a per-request output token limit.
- The OpenAI-compatible settings UI still has a user-editable Max Output Tokens field, and that value is intended to affect the actual request.

So this PR wires the OpenAI-compatible Max Output Tokens setting through as an explicit request limit instead of pretending it is provider/catalog metadata.

Concretely:

- VS Code reads `actModeOpenAiModelInfo.maxTokens` / `planModeOpenAiModelInfo.maxTokens` only for the legacy OpenAI-compatible provider selection.
- That value becomes `CoreSessionConfig.maxTokensPerTurn`.
- Core carries `maxTokensPerTurn` through local runtime and delegated-agent config.
- `createAgentModelFromConfig` already maps `maxTokensPerTurn` to the gateway's per-model request option as `{ maxTokens }`.
- The llms gateway/provider layer sends that explicit request limit to the AI SDK as `maxOutputTokens`.

The key behavior this preserves is that OpenAI-compatible users who set Max Output Tokens in the extension settings actually get that value sent with requests. The key behavior this avoids is reintroducing the provider metadata bridge that #11772 removed.

This PR intentionally does not:

- Put `contextWindow` or `maxTokens` into provider settings JSON.
- Populate `providerConfig.knownModels` from VS Code custom model settings.
- Treat catalog/model `maxTokens` as a request-level `maxOutputTokens` value.

