### PR TITLE
Fix GLM editor conflict tool calls

### DIFF
--- a/sdk/packages/core/src/extensions/tools/definitions.test.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.test.ts
@@ -1287,6 +1287,36 @@ describe("zod schema conversion", () => {
 		expect(schema.required).toEqual(["skill"]);
 		expect(schema.properties).toHaveProperty("args");
 	});
+
+	it("exposes editor old_text as optional string, not nullable", () => {
+		const tools = createDefaultTools({
+			executors: {
+				editor: async () => "ok",
+			},
+			enableReadFiles: false,
+			enableSearch: false,
+			enableBash: false,
+			enableWebFetch: false,
+			enableEditor: true,
+			enableApplyPatch: false,
+			enableAskQuestion: false,
+			enableSkills: false,
+		});
+		const editor = tools.find((tool) => tool.name === "editor");
+		expect(editor).toBeDefined();
+		if (!editor) {
+			throw new Error("Expected editor tool.");
+		}
+		const schema = editor.inputSchema as {
+			required?: string[];
+			properties?: Record<string, unknown>;
+		};
+		expect(schema.required).toEqual(["path", "new_text"]);
+		expect(schema.properties?.old_text).toMatchObject({
+			type: "string",
+		});
+		expect(schema.properties?.old_text).not.toHaveProperty("anyOf");
+	});
 });
 
 describe("default editor tool", () => {

--- a/sdk/packages/core/src/extensions/tools/schemas.ts
+++ b/sdk/packages/core/src/extensions/tools/schemas.ts
@@ -194,7 +194,6 @@ export const EditFileInputSchema = z
 			.describe("The absolute file path for the action to be performed on"),
 		old_text: z
 			.string()
-			.nullable()
 			.optional()
 			.describe(
 				`Exact text to replace (must match exactly once). Omit this when creating a missing file or inserting via insert_line. Keep this at or below ${INPUT_ARG_CHAR_LIMIT} characters when possible; larger payloads should be split across multiple tool calls to avoid timeouts.`,


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Fixes malformed GLM 5.2 `editor` tool calls for git conflict resolution in the SDK/CLI path.

Investigation summary:

- The failure reproduced with OpenRouter `z-ai/glm-5.2` when Cline advertised the `editor` tool with `old_text` as a nullable schema field.
- The malformed bytes were present in raw OpenRouter streaming SSE chunks before Cline runtime parsing. Example bad shape: `"old_text": <<<<<<< HEAD ...`
- This rejected the runtime/harness corruption hypothesis for the observed malformed final input.
- Non-streaming OpenRouter calls were clean across repeated runs, so the issue was specific to streaming tool-call generation.
- Streaming with forced `editor` tool choice was clean, and streaming with `old_text` represented as an optional string was clean.

The fix keeps `old_text` optional but removes `nullable()`, so create/insert flows can still omit it while GLM no longer sees a `string | null` schema for conflict-block replacement.

### Test Procedure

TDD proof:

- Added a regression test first asserting the exported `editor.old_text` JSON schema is an optional string and does not contain `anyOf`.
- Confirmed it failed before the fix because the schema exposed `anyOf: [{ type: "string" }, { type: "null" }]`.
- Removed `nullable()` from `EditFileInputSchema.old_text`.
- Confirmed the regression test passes.

Live provider investigation:

- Raw OpenRouter streaming with full yolo tools before fix: 13/20 clean, 7/20 malformed.
- Bad raw SSE chunks already contained malformed unquoted conflict markers.
- Raw OpenRouter non-streaming with same setup: 60/60 clean.
- Forced `editor` tool choice: 15/15 clean.
- Optional-string `old_text` schema: 20/20 clean.
- Actual SDK tool builder after this fix: 20/20 clean.
- Full CLI conflict repro after this fix: 3/3 completed and wrote `resolved value`.

Local verification:

- `bunx vitest run --config vitest.config.ts sdk/packages/core/src/extensions/tools/definitions.test.ts sdk/packages/core/src/extensions/tools/executors/editor.test.ts`
- `bun -F @cline/core typecheck`
- `bun -F @cline/agents typecheck`
- `bun -F @cline/agents test`
- `bun -F @cline/core test`

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

This intentionally does not change runtime tool-call assembly. The repeated live-provider tests showed the malformed payload already existed in the provider stream, while changing the exported tool schema removed the failure mode.
