### PR TITLE
chore: update Biome VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,11 +22,24 @@
 	},
 	// Enable Lint and format using Biome
 	"biome.enabled": true,
+	"biome.requireConfiguration": true,
+	"prettier.enable": false,
 	"editor.defaultFormatter": "biomejs.biome",
+	"[javascript]": {
+		"editor.defaultFormatter": "biomejs.biome"
+	},
+	"[javascriptreact]": {
+		"editor.defaultFormatter": "biomejs.biome"
+	},
+	"[typescript]": {
+		"editor.defaultFormatter": "biomejs.biome"
+	},
+	"[typescriptreact]": {
+		"editor.defaultFormatter": "biomejs.biome"
+	},
 	"editor.codeActionsOnSave": {
 		"source.fixAll.biome": "explicit",
 		"source.removeUnused.biome": "always",
-		"source.removeUnusedImports": "always",
 		"source.organizeImports.biome": "always"
 	},
 	// Disable auto-forwarding ports to prevent Simple Browser from opening the Vite dev server


### PR DESCRIPTION
### Description

Update VS Code workspace settings so Biome is the required formatter/linter configuration and Prettier is disabled for this workspace.

This stops VSCode adding spurious semicolons everywhere on save.

### Test Procedure

Not run; settings-only change.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

(...not really *workflow* but closest category 🤷 )

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)