### PR TITLE
fix: show history empty state for empty search results

### DIFF
--- a/apps/vscode/webview-ui/src/components/history/HistoryView.tsx
+++ b/apps/vscode/webview-ui/src/components/history/HistoryView.tsx
@@ -373,6 +373,17 @@ const HistoryView = ({ onDone }: HistoryViewProps) => {
 		[taskHistorySearchResults],
 	)
 
+	const hasHistoryResults = groupedTasks.length > 0
+	const historyEmptyMessage = searchQuery
+		? "No history matches your search."
+		: showFavoritesOnly && showCurrentWorkspaceOnly
+			? "No favorite history in this workspace."
+			: showFavoritesOnly
+				? "No favorite history available."
+				: showCurrentWorkspaceOnly
+					? "No history in this workspace."
+					: "No history available."
+
 	return (
 		<div className="fixed overflow-hidden inset-0 flex flex-col w-full">
 			{/* HEADER */}
@@ -476,38 +487,44 @@ const HistoryView = ({ onDone }: HistoryViewProps) => {
 
 			{/* HISTORY ITEMS */}
 			<div className="flex-grow overflow-y-auto m-0 w-full py-2">
-				<GroupedVirtuoso
-					className="flex-grow overflow-y-scroll"
-					components={{
-						Footer: () =>
-							hasMoreTasks ? (
-								<div className="px-4 py-3 text-center text-xs text-description">
-									{isLoadingHistory ? "Loading..." : ""}
-								</div>
-							) : null,
-					}}
-					endReached={loadMoreTaskHistory}
-					groupContent={(index) => (
-						<div className="px-4 py-2 text-xs font-bold uppercase tracking-wide sticky top-0 z-10 text-description bg-sidebar-background border-b-border-panel">
-							{groupLabels[index]}
-						</div>
-					)}
-					groupCounts={groupCounts}
-					itemContent={(index) => {
-						const item = groupedTasks[index]
-						return (
-							<HistoryViewItem
-								handleDeleteHistoryItem={handleDeleteHistoryItem}
-								handleHistorySelect={handleHistorySelect}
-								index={index}
-								item={item}
-								pendingFavoriteToggles={pendingFavoriteToggles}
-								selectedItems={selectedItems}
-								toggleFavorite={toggleFavorite}
-							/>
-						)
-					}}
-				/>
+				{hasHistoryResults ? (
+					<GroupedVirtuoso
+						className="flex-grow overflow-y-scroll"
+						components={{
+							Footer: () =>
+								hasMoreTasks ? (
+									<div className="px-4 py-3 text-center text-xs text-description">
+										{isLoadingHistory ? "Loading..." : ""}
+									</div>
+								) : null,
+						}}
+						endReached={loadMoreTaskHistory}
+						groupContent={(index) => (
+							<div className="px-4 py-2 text-xs font-bold uppercase tracking-wide sticky top-0 z-10 text-description bg-sidebar-background border-b-border-panel">
+								{groupLabels[index]}
+							</div>
+						)}
+						groupCounts={groupCounts}
+						itemContent={(index) => {
+							const item = groupedTasks[index]
+							return (
+								<HistoryViewItem
+									handleDeleteHistoryItem={handleDeleteHistoryItem}
+									handleHistorySelect={handleHistorySelect}
+									index={index}
+									item={item}
+									pendingFavoriteToggles={pendingFavoriteToggles}
+									selectedItems={selectedItems}
+									toggleFavorite={toggleFavorite}
+								/>
+							)
+						}}
+					/>
+				) : (
+					<div className="flex h-full items-center justify-center px-4 text-center text-sm text-description">
+						{historyEmptyMessage}
+					</div>
+				)}
 			</div>
 
 			{/* FOOTER */}


### PR DESCRIPTION
Summary
- Render the existing history empty state when search filters produce no grouped tasks.
- Avoid mounting the virtualized grouped list with zero groups.

Tests
- `git diff --check`
- `npm --prefix apps/vscode/webview-ui test -- HistoryView --runInBand` blocked locally: `vitest` is not installed in this worktree.
- `npm --prefix apps/vscode/webview-ui run build` blocked locally: `tsc` is not installed in this worktree.

Notes
- Fixes #9425.