### PR TITLE
Update the clinePass model list live

### DIFF
--- a/sdk/packages/core/src/services/llms/provider-defaults.test.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.test.ts
@@ -58,6 +58,63 @@ describe("resolveProviderConfig", () => {
 		);
 	});
 
+	it("uses live Cline recommended models for ClinePass", async () => {
+		const fetchMock = vi.fn(async (url: string) => {
+			if (url === "https://models.test/api.json") {
+				return new Response(
+					JSON.stringify({
+						openrouter: {
+							models: {
+								"vendor/live-pass-model": {
+									name: "Live Pass Model",
+									tool_call: true,
+									reasoning: true,
+									limit: { context: 256_000, input: 200_000, output: 32_000 },
+								},
+							},
+						},
+					}),
+					{
+						status: 200,
+						headers: { "content-type": "application/json" },
+					},
+				);
+			}
+
+			return new Response(
+				JSON.stringify({
+					clinePass: [
+						{
+							id: "cline-pass/live-pass-model",
+							name: "vendor/live-pass-model",
+						},
+					],
+				}),
+				{
+					status: 200,
+					headers: { "content-type": "application/json" },
+				},
+			);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const resolved = await resolveProviderConfig("cline-pass", {
+			loadLatestOnInit: true,
+			failOnError: false,
+			cacheTtlMs: 0,
+			url: "https://models.test/api.json",
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(resolved?.knownModels?.["cline-pass/live-pass-model"]).toMatchObject({
+			id: "cline-pass/live-pass-model",
+			name: "Live Pass Model",
+			contextWindow: 256_000,
+			maxInputTokens: 200_000,
+			maxTokens: 32_000,
+		});
+	});
+
 	it("prefers Vercel-style Z.ai ids in Cline known models", async () => {
 		const resolved = await resolveProviderConfig("cline");
 

--- a/sdk/packages/core/src/services/llms/provider-defaults.test.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.test.ts
@@ -58,7 +58,7 @@ describe("resolveProviderConfig", () => {
 		);
 	});
 
-	it("uses live Cline recommended models for ClinePass", async () => {
+	it("uses only live Cline recommended models for ClinePass when live models are found", async () => {
 		const fetchMock = vi.fn(async (url: string) => {
 			if (url === "https://models.test/api.json") {
 				return new Response(
@@ -113,6 +113,51 @@ describe("resolveProviderConfig", () => {
 			maxInputTokens: 200_000,
 			maxTokens: 32_000,
 		});
+		expect(resolved?.knownModels?.["cline-pass/mimo-v2.5-pro"]).toBeUndefined();
+	});
+
+	it("falls back to generated ClinePass models when no live ClinePass models are found", async () => {
+		const fetchMock = vi.fn(async (url: string) => {
+			if (url === "https://models.test/api.json") {
+				return new Response(
+					JSON.stringify({
+						openrouter: {
+							models: {
+								"vendor/live-openrouter-model": {
+									name: "Live OpenRouter Model",
+									tool_call: true,
+								},
+							},
+						},
+					}),
+					{
+						status: 200,
+						headers: { "content-type": "application/json" },
+					},
+				);
+			}
+
+			return new Response(JSON.stringify({ clinePass: [] }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const resolved = await resolveProviderConfig("cline-pass", {
+			loadLatestOnInit: true,
+			failOnError: false,
+			cacheTtlMs: 0,
+			url: "https://models.test/api.json",
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(
+			resolved?.knownModels?.["cline-pass/mimo-v2.5-pro"]?.name,
+		).toBe("MiMo-V2.5-Pro");
+		expect(
+			resolved?.knownModels?.["vendor/live-openrouter-model"],
+		).toBeUndefined();
 	});
 
 	it("prefers Vercel-style Z.ai ids in Cline known models", async () => {

--- a/sdk/packages/core/src/services/llms/provider-defaults.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.ts
@@ -183,6 +183,12 @@ async function mergeKnownModels(
 			...userKnownModels,
 		});
 	}
+	if (providerId === "cline-pass" && Object.keys(liveModels).length > 0) {
+		return Llms.sortModelsByReleaseDate({
+			...liveModels,
+			...userKnownModels,
+		});
+	}
 	const knownModelsWithoutUserOverrides = Llms.sortModelsByReleaseDate({
 		...generated,
 		...defaultKnownModels,

--- a/sdk/packages/core/src/services/llms/provider-defaults.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.ts
@@ -786,7 +786,7 @@ async function getPrivateProviderModels(
 async function fetchLiveModelsCatalog(
 	url: string,
 ): Promise<Record<string, Record<string, ModelInfo>>> {
-	return Llms.fetchModelsDevProviderModels(url, globalThis.fetch);
+	return Llms.fetchLiveProviderModels(url, globalThis.fetch);
 }
 
 export async function getLiveModelsCatalog(

--- a/sdk/packages/core/src/services/providers/local-provider-service.test.ts
+++ b/sdk/packages/core/src/services/providers/local-provider-service.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import * as LlmsModels from "@cline/llms";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearLiveModelsCatalogCache } from "../llms/provider-defaults";
 import { ProviderSettingsManager } from "../storage/provider-settings-manager";
 import {
 	parseModelsFile,
@@ -47,6 +48,7 @@ function makeTempManager(): {
 // ---------------------------------------------------------------------------
 
 afterEach(() => {
+	clearLiveModelsCatalogCache();
 	LlmsModels.resetRegistry();
 	vi.restoreAllMocks();
 	vi.unstubAllGlobals();
@@ -222,6 +224,98 @@ describe("addLocalProvider – model ID parsing via modelsSourceUrl", () => {
 
 		const { models } = await getLocalProviderModels("ollama-shaped-provider");
 		expect(models.map((m) => m.id).sort()).toEqual(["llama3.1", "qwen3:8b"]);
+	});
+
+	it("uses only live ClinePass models when live models are found", async () => {
+		const fetchMock = vi.fn(async (url: string) => {
+			if (url === "https://models.dev/api.json") {
+				return new Response(
+					JSON.stringify({
+						openrouter: {
+							models: {
+								"vendor/live-pass-model": {
+									name: "Live Pass Model",
+									tool_call: true,
+									reasoning: true,
+									limit: { context: 256_000, input: 200_000, output: 32_000 },
+								},
+							},
+						},
+					}),
+					{
+						status: 200,
+						headers: { "content-type": "application/json" },
+					},
+				);
+			}
+
+			return new Response(
+				JSON.stringify({
+					clinePass: [
+						{
+							id: "cline-pass/live-pass-model",
+							name: "vendor/live-pass-model",
+						},
+					],
+				}),
+				{
+					status: 200,
+					headers: { "content-type": "application/json" },
+				},
+			);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const { models } = await getLocalProviderModels("cline-pass");
+
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(models.map((model) => model.id)).toEqual([
+			"cline-pass/live-pass-model",
+		]);
+		expect(models[0]).toMatchObject({
+			id: "cline-pass/live-pass-model",
+			name: "Live Pass Model",
+			supportsReasoning: true,
+		});
+	});
+
+	it("falls back to generated ClinePass models when no live ClinePass models are found", async () => {
+		const fetchMock = vi.fn(async (url: string) => {
+			if (url === "https://models.dev/api.json") {
+				return new Response(
+					JSON.stringify({
+						openrouter: {
+							models: {
+								"vendor/live-openrouter-model": {
+									name: "Live OpenRouter Model",
+									tool_call: true,
+								},
+							},
+						},
+					}),
+					{
+						status: 200,
+						headers: { "content-type": "application/json" },
+					},
+				);
+			}
+
+			return new Response(JSON.stringify({ clinePass: [] }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const { models } = await getLocalProviderModels("cline-pass");
+
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(models.map((model) => model.id)).toContain(
+			"cline-pass/mimo-v2.5-pro",
+		);
+		expect(models.map((model) => model.id)).not.toContain(
+			"vendor/live-openrouter-model",
+		);
 	});
 
 	it("parses a { models: { id1: {}, id2: {} } } object-keyed payload", async () => {

--- a/sdk/packages/core/src/services/providers/local-provider-service.ts
+++ b/sdk/packages/core/src/services/providers/local-provider-service.ts
@@ -123,13 +123,15 @@ async function resolveProviderModelMap(
 	config?: ProviderConfig,
 ): Promise<Record<string, ModelInfo>> {
 	const registeredModels = await LlmsModels.getModelsForProvider(providerId);
-	if (!config) {
+	const isClinePass = providerId === CLINE_PASS_PROVIDER_ID;
+	if (!config && !isClinePass) {
 		return registeredModels;
 	}
 
 	const resolved = await resolveProviderConfig(
 		providerId,
 		{
+			loadLatestOnInit: isClinePass,
 			loadPrivateOnAuth: true,
 			failOnError: false,
 		},
@@ -137,6 +139,9 @@ async function resolveProviderModelMap(
 	);
 
 	if (providerId === "litellm" && resolved?.knownModels) {
+		return resolved.knownModels;
+	}
+	if (isClinePass && resolved?.knownModels) {
 		return resolved.knownModels;
 	}
 

--- a/sdk/packages/llms/scripts/generate-models.ts
+++ b/sdk/packages/llms/scripts/generate-models.ts
@@ -4,7 +4,10 @@ import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { ModelInfo } from "@cline/shared";
-import { fetchClineRecommendedProviderModels } from "../src/catalog/catalog-cline-recommended";
+import {
+	fetchClineRecommendedModelsPayload,
+	normalizeClineRecommendedProviderModels,
+} from "../src/catalog/catalog-cline-recommended";
 import { loadModelsDevProviderModels } from "./models/generate-models-dev";
 
 const OUTPUT_FILE = "src/catalog/catalog.generated.ts";
@@ -44,23 +47,29 @@ async function generate(): Promise<void> {
 	const providerModels: Record<string, Record<string, ModelInfo>> = {};
 	let loadError: Error | undefined;
 
-	try {
-		const modelsDev = await loadModelsDevProviderModels();
-		Object.assign(providerModels, modelsDev);
-	} catch (error) {
-		loadError =
-			error instanceof Error ? error : new Error(String(error ?? "unknown"));
-	}
+	const [modelsDevResult, clineRecommendedPayloadResult] = await Promise.all([
+		loadModelsDevProviderModels().catch((error) => {
+			loadError =
+				error instanceof Error ? error : new Error(String(error ?? "unknown"));
+			return {};
+		}),
+		fetchClineRecommendedModelsPayload(fetch).catch((error) => {
+			loadError =
+				error instanceof Error ? error : new Error(String(error ?? "unknown"));
+			return undefined;
+		}),
+	]);
 
-	try {
-		const clineRecommended = await fetchClineRecommendedProviderModels(
-			fetch,
-			providerModels.openrouter || {},
+	Object.assign(providerModels, modelsDevResult);
+
+	if (clineRecommendedPayloadResult) {
+		Object.assign(
+			providerModels,
+			normalizeClineRecommendedProviderModels(
+				clineRecommendedPayloadResult,
+				providerModels.openrouter || {},
+			),
 		);
-		Object.assign(providerModels, clineRecommended);
-	} catch (error) {
-		loadError =
-			error instanceof Error ? error : new Error(String(error ?? "unknown"));
 	}
 
 	if (Object.keys(providerModels).length === 0) {

--- a/sdk/packages/llms/scripts/generate-models.ts
+++ b/sdk/packages/llms/scripts/generate-models.ts
@@ -48,11 +48,7 @@ async function generate(): Promise<void> {
 	let loadError: Error | undefined;
 
 	const [modelsDevResult, clineRecommendedPayloadResult] = await Promise.all([
-		loadModelsDevProviderModels().catch((error) => {
-			loadError =
-				error instanceof Error ? error : new Error(String(error ?? "unknown"));
-			return {};
-		}),
+		loadModelsDevProviderModels(),
 		fetchClineRecommendedModelsPayload(fetch).catch((error) => {
 			loadError =
 				error instanceof Error ? error : new Error(String(error ?? "unknown"));

--- a/sdk/packages/llms/scripts/generate-models.ts
+++ b/sdk/packages/llms/scripts/generate-models.ts
@@ -48,7 +48,11 @@ async function generate(): Promise<void> {
 	let loadError: Error | undefined;
 
 	const [modelsDevResult, clineRecommendedPayloadResult] = await Promise.all([
-		loadModelsDevProviderModels(),
+		loadModelsDevProviderModels().catch((error) => {
+			loadError =
+				error instanceof Error ? error : new Error(String(error ?? "unknown"));
+			return {};
+		}),
 		fetchClineRecommendedModelsPayload(fetch).catch((error) => {
 			loadError =
 				error instanceof Error ? error : new Error(String(error ?? "unknown"));

--- a/sdk/packages/llms/src/catalog/catalog-cline-recommended.ts
+++ b/sdk/packages/llms/src/catalog/catalog-cline-recommended.ts
@@ -91,10 +91,9 @@ export function normalizeClineRecommendedProviderModels(
 	return { [CLINE_PASS_PROVIDER_ID]: models };
 }
 
-export async function fetchClineRecommendedProviderModels(
+export async function fetchClineRecommendedModelsPayload(
 	fetcher: typeof fetch = fetch,
-	openRouterModels: Record<string, ModelInfo>,
-): Promise<Record<string, Record<string, ModelInfo>>> {
+): Promise<ClineRecommendedModelsPayload> {
 	const url = `${getClineEnvironmentConfig().apiBaseUrl}/api/v1/ai/cline/recommended-models`;
 	const response = await fetcher(url);
 	if (!response.ok) {
@@ -103,6 +102,13 @@ export async function fetchClineRecommendedProviderModels(
 		);
 	}
 
-	const payload = (await response.json()) as ClineRecommendedModelsPayload;
+	return (await response.json()) as ClineRecommendedModelsPayload;
+}
+
+export async function fetchClineRecommendedProviderModels(
+	fetcher: typeof fetch = fetch,
+	openRouterModels: Record<string, ModelInfo>,
+): Promise<Record<string, Record<string, ModelInfo>>> {
+	const payload = await fetchClineRecommendedModelsPayload(fetcher);
 	return normalizeClineRecommendedProviderModels(payload, openRouterModels);
 }

--- a/sdk/packages/llms/src/catalog/catalog-live.test.ts
+++ b/sdk/packages/llms/src/catalog/catalog-live.test.ts
@@ -5,6 +5,7 @@ import {
 } from "./catalog.generated-access";
 import { normalizeClineRecommendedProviderModels } from "./catalog-cline-recommended";
 import {
+	fetchLiveProviderModels,
 	fetchModelsDevProviderModels,
 	type ModelsDevPayload,
 	normalizeModelsDevProviderModels,
@@ -355,6 +356,90 @@ describe("models-dev-catalog", () => {
 
 		expect(fetcher).toHaveBeenCalledWith("https://models.dev/api.json");
 		expect(result["openai-native"]).toHaveProperty("gpt-live");
+	});
+
+	it("fetches live models from models.dev and Cline recommended clinePass models", async () => {
+		const fetcher = vi.fn(async (url: string) => {
+			if (url === "https://models.dev/api.json") {
+				return {
+					ok: true,
+					json: async () =>
+						({
+							openrouter: {
+								models: {
+									"vendor/live-base-model": {
+										name: "Live Base Model",
+										tool_call: true,
+										reasoning: true,
+										limit: { context: 256_000, input: 200_000, output: 32_000 },
+										cost: { input: 1, output: 2 },
+									},
+								},
+							},
+						}) satisfies ModelsDevPayload,
+				};
+			}
+
+			return {
+				ok: true,
+				json: async () => ({
+					clinePass: [
+						{
+							id: "cline-pass/live-base-model",
+							name: "vendor/live-base-model",
+						},
+					],
+				}),
+			};
+		});
+
+		const result = await fetchLiveProviderModels(
+			"https://models.dev/api.json",
+			fetcher as unknown as typeof fetch,
+		);
+
+		expect(fetcher).toHaveBeenNthCalledWith(1, "https://models.dev/api.json");
+		expect(fetcher).toHaveBeenNthCalledWith(
+			2,
+			"https://api.cline.bot/api/v1/ai/cline/recommended-models",
+		);
+		expect(result.openrouter).toHaveProperty("vendor/live-base-model");
+		expect(result["cline-pass"]?.["cline-pass/live-base-model"]).toMatchObject({
+			id: "cline-pass/live-base-model",
+			name: "Live Base Model",
+			contextWindow: 256_000,
+			maxInputTokens: 200_000,
+			maxTokens: 32_000,
+			pricing: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 },
+		});
+	});
+
+	it("keeps models.dev live models when Cline recommended models fail", async () => {
+		const fetcher = vi.fn(async (url: string) => {
+			if (url === "https://models.dev/api.json") {
+				return {
+					ok: true,
+					json: async () =>
+						({
+							openai: {
+								models: {
+									"gpt-live": { name: "GPT Live", tool_call: true },
+								},
+							},
+						}) satisfies ModelsDevPayload,
+				};
+			}
+
+			return { ok: false, status: 503 };
+		});
+
+		const result = await fetchLiveProviderModels(
+			"https://models.dev/api.json",
+			fetcher as unknown as typeof fetch,
+		);
+
+		expect(result["openai-native"]?.["gpt-live"]?.name).toBe("GPT Live");
+		expect(result["cline-pass"]).toBeUndefined();
 	});
 
 	it("throws when models.dev request fails", async () => {

--- a/sdk/packages/llms/src/catalog/catalog-live.test.ts
+++ b/sdk/packages/llms/src/catalog/catalog-live.test.ts
@@ -398,9 +398,8 @@ describe("models-dev-catalog", () => {
 			fetcher as unknown as typeof fetch,
 		);
 
-		expect(fetcher).toHaveBeenNthCalledWith(1, "https://models.dev/api.json");
-		expect(fetcher).toHaveBeenNthCalledWith(
-			2,
+		expect(fetcher).toHaveBeenCalledWith("https://models.dev/api.json");
+		expect(fetcher).toHaveBeenCalledWith(
 			"https://api.cline.bot/api/v1/ai/cline/recommended-models",
 		);
 		expect(result.openrouter).toHaveProperty("vendor/live-base-model");
@@ -440,6 +439,41 @@ describe("models-dev-catalog", () => {
 
 		expect(result["openai-native"]?.["gpt-live"]?.name).toBe("GPT Live");
 		expect(result["cline-pass"]).toBeUndefined();
+	});
+
+	it("keeps Cline recommended clinePass models when models.dev fails", async () => {
+		const fetcher = vi.fn(async (url: string) => {
+			if (url === "https://models.dev/api.json") {
+				return { ok: false, status: 503 };
+			}
+
+			return {
+				ok: true,
+				json: async () => ({
+					clinePass: [
+						{
+							id: "cline-pass/live-default-model",
+							name: "Live Default Model",
+						},
+					],
+				}),
+			};
+		});
+
+		const result = await fetchLiveProviderModels(
+			"https://models.dev/api.json",
+			fetcher as unknown as typeof fetch,
+		);
+
+		expect(result["openai-native"]).toBeUndefined();
+		expect(result["cline-pass"]?.["cline-pass/live-default-model"]).toMatchObject({
+			id: "cline-pass/live-default-model",
+			name: "Live Default Model",
+			contextWindow: 128_000,
+			maxInputTokens: 128_000,
+			maxTokens: 8_192,
+			pricing: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		});
 	});
 
 	it("throws when models.dev request fails", async () => {

--- a/sdk/packages/llms/src/catalog/catalog-live.ts
+++ b/sdk/packages/llms/src/catalog/catalog-live.ts
@@ -1,4 +1,5 @@
 import { MODELS_DEV_PROVIDER_KEY_MAP } from "../providers/provider-keys";
+import { fetchClineRecommendedProviderModels } from "./catalog-cline-recommended";
 import type { ModelInfo } from "./types";
 
 export interface ModelsDevModel {
@@ -183,4 +184,28 @@ export async function fetchModelsDevProviderModels(
 
 	const payload = (await response.json()) as ModelsDevPayload;
 	return normalizeModelsDevProviderModels(payload);
+}
+
+export async function fetchLiveProviderModels(
+	modelsDevUrl: string,
+	fetcher: typeof fetch = fetch,
+): Promise<Record<string, Record<string, ModelInfo>>> {
+	const providerModels = await fetchModelsDevProviderModels(
+		modelsDevUrl,
+		fetcher,
+	);
+	let clineRecommended: Record<string, Record<string, ModelInfo>> = {};
+	try {
+		clineRecommended = await fetchClineRecommendedProviderModels(
+			fetcher,
+			providerModels.openrouter ?? {},
+		);
+	} catch {
+		clineRecommended = {};
+	}
+
+	return {
+		...providerModels,
+		...clineRecommended,
+	};
 }

--- a/sdk/packages/llms/src/catalog/catalog-live.ts
+++ b/sdk/packages/llms/src/catalog/catalog-live.ts
@@ -1,5 +1,8 @@
 import { MODELS_DEV_PROVIDER_KEY_MAP } from "../providers/provider-keys";
-import { fetchClineRecommendedProviderModels } from "./catalog-cline-recommended";
+import {
+	fetchClineRecommendedModelsPayload,
+	normalizeClineRecommendedProviderModels,
+} from "./catalog-cline-recommended";
 import type { ModelInfo } from "./types";
 
 export interface ModelsDevModel {
@@ -190,19 +193,19 @@ export async function fetchLiveProviderModels(
 	modelsDevUrl: string,
 	fetcher: typeof fetch = fetch,
 ): Promise<Record<string, Record<string, ModelInfo>>> {
-	const providerModels = await fetchModelsDevProviderModels(
-		modelsDevUrl,
-		fetcher,
-	);
-	let clineRecommended: Record<string, Record<string, ModelInfo>> = {};
-	try {
-		clineRecommended = await fetchClineRecommendedProviderModels(
-			fetcher,
-			providerModels.openrouter ?? {},
-		);
-	} catch {
-		clineRecommended = {};
-	}
+	const emptyProviderModels: Record<string, Record<string, ModelInfo>> = {};
+	const [providerModels, clineRecommendedPayload] = await Promise.all([
+		fetchModelsDevProviderModels(modelsDevUrl, fetcher).catch(
+			() => emptyProviderModels,
+		),
+		fetchClineRecommendedModelsPayload(fetcher).catch(() => undefined),
+	]);
+	const clineRecommended = clineRecommendedPayload
+		? normalizeClineRecommendedProviderModels(
+				clineRecommendedPayload,
+				providerModels.openrouter ?? {},
+			)
+		: {};
 
 	return {
 		...providerModels,

--- a/sdk/packages/llms/src/index.ts
+++ b/sdk/packages/llms/src/index.ts
@@ -9,6 +9,7 @@ export type {
 	ProviderProtocol,
 } from "./models";
 export {
+	fetchLiveProviderModels,
 	fetchModelsDevProviderModels,
 	filterOpenAICodexModels,
 	getAllProviders,

--- a/sdk/packages/llms/src/models.ts
+++ b/sdk/packages/llms/src/models.ts
@@ -3,6 +3,7 @@ export {
 	getGeneratedProviderModels,
 } from "./catalog/catalog.generated-access";
 export {
+	fetchLiveProviderModels,
 	fetchModelsDevProviderModels,
 	sortModelsByReleaseDate,
 } from "./catalog/catalog-live";


### PR DESCRIPTION
### Description

The clinePass model list isn't fetched from models.dev. We need to fetch it differently.

### Test Procedure

Tested locally that despite the generated model list not being updated, the selector is
<img width="241" height="224" alt="image" src="https://github.com/user-attachments/assets/aa3db7ef-3917-4443-ab5a-2a403fe59207" />


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)