### PR TITLE
fix(tools): parse JSON-encoded command arrays in shell tools

### DIFF
--- a/sdk/packages/core/src/extensions/tools/definitions.test.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.test.ts
@@ -603,6 +603,43 @@ describe("default run_commands tool", () => {
 		);
 	});
 
+	it("accepts nested JSON-encoded commands payloads", async () => {
+		const execute = vi.fn(async (command: string | { command: string }) =>
+			typeof command === "string" ? `ran:${command}` : `ran:${command.command}`,
+		);
+		const tool = createBashTool(execute);
+
+		const result = await tool.execute(
+			{
+				commands: JSON.stringify({
+					commands: JSON.stringify(["git status --short"]),
+				}),
+			} as never,
+			{
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 1,
+			},
+		);
+
+		expect(result).toEqual([
+			{
+				query: "git status --short",
+				result: "ran:git status --short",
+				success: true,
+			},
+		]);
+		expect(execute).toHaveBeenCalledWith(
+			"git status --short",
+			process.cwd(),
+			expect.objectContaining({
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 1,
+			}),
+		);
+	});
+
 	it("accepts common single-command aliases", async () => {
 		const execute = vi.fn(
 			async (command: string | { command: string }) =>

--- a/sdk/packages/core/src/extensions/tools/definitions.test.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.test.ts
@@ -535,6 +535,74 @@ describe("default run_commands tool", () => {
 		);
 	});
 
+	it("accepts object input with commands as a JSON-encoded string array", async () => {
+		const execute = vi.fn(async (command: string | { command: string }) =>
+			typeof command === "string" ? `ran:${command}` : `ran:${command.command}`,
+		);
+		const tool = createBashTool(execute);
+		const command = "cd /repo && bunx tsc --noEmit --pretty 2>&1 | head -40";
+
+		const result = await tool.execute(
+			{ commands: JSON.stringify([command]) } as never,
+			{
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 1,
+			},
+		);
+
+		expect(result).toEqual([
+			{
+				query: command,
+				result: `ran:${command}`,
+				success: true,
+			},
+		]);
+		expect(execute).toHaveBeenCalledTimes(1);
+		expect(execute).toHaveBeenCalledWith(
+			command,
+			process.cwd(),
+			expect.objectContaining({
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 1,
+			}),
+		);
+	});
+
+	it("accepts JSON-encoded command arrays in the Windows shell tool", async () => {
+		const execute = vi.fn(async (command: string | { command: string }) =>
+			typeof command === "string" ? `ran:${command}` : `ran:${command.command}`,
+		);
+		const tool = createWindowsShellTool(execute);
+
+		const result = await tool.execute(
+			{ commands: JSON.stringify(["git status --short"]) } as never,
+			{
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 1,
+			},
+		);
+
+		expect(result).toEqual([
+			{
+				query: "git status --short",
+				result: "ran:git status --short",
+				success: true,
+			},
+		]);
+		expect(execute).toHaveBeenCalledWith(
+			"git status --short",
+			process.cwd(),
+			expect.objectContaining({
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 1,
+			}),
+		);
+	});
+
 	it("accepts common single-command aliases", async () => {
 		const execute = vi.fn(
 			async (command: string | { command: string }) =>

--- a/sdk/packages/core/src/extensions/tools/definitions.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.ts
@@ -46,7 +46,6 @@ import {
 	ReadFilesInputUnionSchema,
 	type RunCommandsInput,
 	RunCommandsInputSchema,
-	RunCommandsInputUnionSchema,
 	type SearchCodebaseInput,
 	SearchCodebaseInputSchema,
 	SearchCodebaseUnionInputSchema,
@@ -118,10 +117,17 @@ function getHeredocDelimiter(command: string): string | undefined {
 	return match?.[1] ?? match?.[2] ?? match?.[3];
 }
 
-function coalesceSplitHeredocCommands(commands: string[]): string[] {
-	const coalesced: string[] = [];
+function coalesceSplitHeredocCommands(
+	commands: Array<string | StructuredCommandInput>,
+): Array<string | StructuredCommandInput> {
+	const coalesced: Array<string | StructuredCommandInput> = [];
 	for (let index = 0; index < commands.length; index += 1) {
 		const command = commands[index];
+		if (typeof command !== "string") {
+			coalesced.push(command);
+			continue;
+		}
+
 		const delimiter = getHeredocDelimiter(command);
 		if (!delimiter) {
 			coalesced.push(command);
@@ -130,7 +136,9 @@ function coalesceSplitHeredocCommands(commands: string[]): string[] {
 
 		const endIndex = commands.findIndex(
 			(nextCommand, nextIndex) =>
-				nextIndex > index && nextCommand.trim() === delimiter,
+				nextIndex > index &&
+				typeof nextCommand === "string" &&
+				nextCommand.trim() === delimiter,
 		);
 		if (endIndex === -1) {
 			coalesced.push(command);
@@ -141,7 +149,9 @@ function coalesceSplitHeredocCommands(commands: string[]): string[] {
 		while (index < endIndex) {
 			index += 1;
 			const nextCommand = commands[index];
-			parts.push(nextCommand);
+			if (typeof nextCommand === "string") {
+				parts.push(nextCommand);
+			}
 		}
 		coalesced.push(parts.join("\n"));
 	}
@@ -336,25 +346,12 @@ export function createBashTool(
 		retryable: false, // Shell commands often have side effects
 		maxRetries: 0,
 		execute: async (input, context) => {
-			const validate = validateWithZod(RunCommandsInputUnionSchema, input);
-			let commands: string[];
-			if (typeof validate === "string") {
-				commands = [validate];
-			} else if (Array.isArray(validate)) {
-				commands = validate;
-			} else if ("commands" in validate) {
-				commands = Array.isArray(validate.commands)
-					? validate.commands
-					: [validate.commands];
-			} else if ("command" in validate) {
-				commands = [validate.command];
-			} else {
-				commands = [validate.cmd];
-			}
-			commands = coalesceSplitHeredocCommands(commands);
+			const commands = coalesceSplitHeredocCommands(
+				normalizeRunCommandsInput(input),
+			);
 
 			return Promise.all(
-				commands.map(async (command: string): Promise<ToolOperationResult> => {
+				commands.map(async (command): Promise<ToolOperationResult> => {
 					const startedAt = Date.now();
 					const query = formatRunCommandQueryPreview(command);
 					try {

--- a/sdk/packages/core/src/extensions/tools/definitions.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.ts
@@ -26,6 +26,7 @@ import {
 	formatRunCommandQueryPreview,
 	getEditorSizeError,
 	getReadFileRangeError,
+	normalizeJsonLikeRunCommandsInput,
 	normalizeRunCommandsInput,
 	TimeoutError,
 	withTimeout,
@@ -46,6 +47,7 @@ import {
 	ReadFilesInputUnionSchema,
 	type RunCommandsInput,
 	RunCommandsInputSchema,
+	RunCommandsInputUnionSchema,
 	type SearchCodebaseInput,
 	SearchCodebaseInputSchema,
 	SearchCodebaseUnionInputSchema,
@@ -117,6 +119,10 @@ function getHeredocDelimiter(command: string): string | undefined {
 	return match?.[1] ?? match?.[2] ?? match?.[3];
 }
 
+function coalesceSplitHeredocCommands(commands: string[]): string[];
+function coalesceSplitHeredocCommands(
+	commands: Array<string | StructuredCommandInput>,
+): Array<string | StructuredCommandInput>;
 function coalesceSplitHeredocCommands(
 	commands: Array<string | StructuredCommandInput>,
 ): Array<string | StructuredCommandInput> {
@@ -346,12 +352,28 @@ export function createBashTool(
 		retryable: false, // Shell commands often have side effects
 		maxRetries: 0,
 		execute: async (input, context) => {
-			const commands = coalesceSplitHeredocCommands(
-				normalizeRunCommandsInput(input),
+			const validate = validateWithZod(
+				RunCommandsInputUnionSchema,
+				normalizeJsonLikeRunCommandsInput(input),
 			);
+			let commands: string[];
+			if (typeof validate === "string") {
+				commands = [validate];
+			} else if (Array.isArray(validate)) {
+				commands = validate;
+			} else if ("commands" in validate) {
+				commands = Array.isArray(validate.commands)
+					? validate.commands
+					: [validate.commands];
+			} else if ("command" in validate) {
+				commands = [validate.command];
+			} else {
+				commands = [validate.cmd];
+			}
+			commands = coalesceSplitHeredocCommands(commands);
 
 			return Promise.all(
-				commands.map(async (command): Promise<ToolOperationResult> => {
+				commands.map(async (command: string): Promise<ToolOperationResult> => {
 					const startedAt = Date.now();
 					const query = formatRunCommandQueryPreview(command);
 					try {

--- a/sdk/packages/core/src/extensions/tools/helpers.ts
+++ b/sdk/packages/core/src/extensions/tools/helpers.ts
@@ -77,10 +77,48 @@ export function getReadFileRangeError(request: ReadFileRequest): string | null {
 	return `start_line must be less than or equal to end_line (received start_line: ${start_line}, end_line: ${end_line})`;
 }
 
+function parseJsonLikeString(input: unknown): unknown {
+	if (typeof input !== "string") {
+		return input;
+	}
+
+	const trimmed = input.trim();
+	if (!trimmed.startsWith("[") && !trimmed.startsWith("{")) {
+		return input;
+	}
+
+	try {
+		return JSON.parse(trimmed) as unknown;
+	} catch {
+		return input;
+	}
+}
+
+function isRecord(input: unknown): input is Record<string, unknown> {
+	return typeof input === "object" && input != null && !Array.isArray(input);
+}
+
+function normalizeJsonLikeRunCommandsInput(input: unknown): unknown {
+	const parsed = parseJsonLikeString(input);
+	if (!isRecord(parsed) || !("commands" in parsed)) {
+		return parsed;
+	}
+
+	const commands = parseJsonLikeString(parsed.commands);
+	if (isRecord(commands) && "commands" in commands) {
+		return { ...parsed, commands: parseJsonLikeString(commands.commands) };
+	}
+
+	return { ...parsed, commands };
+}
+
 export function normalizeRunCommandsInput(
 	input: unknown,
 ): Array<string | StructuredCommandInput> {
-	const validate = validateWithZod(StructuredCommandsInputUnionSchema, input);
+	const validate = validateWithZod(
+		StructuredCommandsInputUnionSchema,
+		normalizeJsonLikeRunCommandsInput(input),
+	);
 
 	if (typeof validate === "string") {
 		return [validate];

--- a/sdk/packages/core/src/extensions/tools/helpers.ts
+++ b/sdk/packages/core/src/extensions/tools/helpers.ts
@@ -98,7 +98,7 @@ function isRecord(input: unknown): input is Record<string, unknown> {
 	return typeof input === "object" && input != null && !Array.isArray(input);
 }
 
-function normalizeJsonLikeRunCommandsInput(input: unknown): unknown {
+export function normalizeJsonLikeRunCommandsInput(input: unknown): unknown {
 	const parsed = parseJsonLikeString(input);
 	if (!isRecord(parsed) || !("commands" in parsed)) {
 		return parsed;

--- a/sdk/packages/core/src/extensions/tools/schemas.ts
+++ b/sdk/packages/core/src/extensions/tools/schemas.ts
@@ -155,15 +155,11 @@ export const StructuredCommandsInputSchema = z.object({
  * Union schema for run_commands tool input. More flexible.
  */
 export const StructuredCommandsInputUnionSchema = z.union([
-	RunCommandsInputSchema,
 	StructuredCommandsInputSchema,
 	z.object({ commands: StructuredCommandEntrySchema }),
 	z.array(StructuredCommandInputSchema),
 	StructuredCommandInputSchema,
-	z.object({ command: CommandInputSchema }),
-	z.object({ cmd: CommandInputSchema }),
-	z.array(z.string()),
-	z.string(),
+	RunCommandsInputUnionSchema,
 ]);
 
 /**


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Handle cases where the `commands` field is passed as a JSON-encoded string array instead of a native array. Refactor input handling in `createBashTool` and `createWindowsShellTool` to support both string and structured command inputs, and update `coalesceSplitHeredocCommands` to skip non-string entries. Removes the `RunCommandsInputUnionSchema` in favor of direct validation.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

Handles models that returns commands in array that's encoded as string

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
