### PR TITLE
fix: bundle SAP AI Core provider auth

### DIFF
--- a/sdk/packages/core/src/services/llms/handler-factory.test.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.test.ts
@@ -370,21 +370,7 @@ describe("createAgentModelFromConfig", () => {
 			};
 		};
 
-		expect(model.config?.destination).toMatchObject({
-			service: {
-				credentials: {
-					clientid: "sap-client",
-					clientsecret: "sap-secret",
-					serviceurls: {
-						AI_API_URL: "https://api.ai.example.aws.ml.hana.ondemand.com",
-					},
-					url: "https://auth.example",
-				},
-				label: "aicore",
-				name: "sapaicore",
-				tags: ["aicore"],
-			},
-		});
+		expect(model.config?.destination).toBeUndefined();
 		expect(model.config?.deploymentConfig).toMatchObject({
 			deploymentId: "deployment-id",
 		});

--- a/sdk/packages/llms/src/providers/vendors/community.test.ts
+++ b/sdk/packages/llms/src/providers/vendors/community.test.ts
@@ -12,7 +12,7 @@ describe("createSapAiCoreProviderModule", () => {
 		}
 	});
 
-	it("passes SAP credentials as a provider destination without mutating process env", async () => {
+	it("uses SAP service-key credentials without mutating process env", async () => {
 		process.env.AICORE_SERVICE_KEY = "existing-service-key";
 
 		const provider = await createSapAiCoreProviderModule({
@@ -27,25 +27,19 @@ describe("createSapAiCoreProviderModule", () => {
 		});
 
 		const model = provider.model("anthropic--claude-4.6-sonnet") as {
-			config?: { destination?: Record<string, unknown> };
+			config?: {
+				destination?: Record<string, unknown>;
+				deploymentConfig?: Record<string, unknown>;
+				providerApi?: string;
+			};
 		};
 
 		expect(process.env.AICORE_SERVICE_KEY).toBe("existing-service-key");
-		expect(model.config?.destination).toMatchObject({
-			service: {
-				credentials: {
-					clientid: "sap-client",
-					clientsecret: "sap-secret",
-					serviceurls: {
-						AI_API_URL: "https://api.ai.example.aws.ml.hana.ondemand.com",
-					},
-					url: "https://auth.example",
-				},
-				label: "aicore",
-				name: "sapaicore",
-				tags: ["aicore"],
-			},
+		expect(model.config?.destination).toBeUndefined();
+		expect(model.config?.deploymentConfig).toMatchObject({
+			deploymentId: "deployment-id",
 		});
+		expect(model.config?.providerApi).toBe("orchestration");
 	});
 
 	it("uses resource group deployment resolution for orchestration mode", async () => {

--- a/sdk/packages/llms/src/providers/vendors/community.test.ts
+++ b/sdk/packages/llms/src/providers/vendors/community.test.ts
@@ -3,6 +3,14 @@ import { createSapAiCoreProviderModule } from "./community";
 
 const originalServiceKey = process.env.AICORE_SERVICE_KEY;
 
+function deferred() {
+	let resolve!: () => void;
+	const promise = new Promise<void>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}
+
 describe("createSapAiCoreProviderModule", () => {
 	afterEach(() => {
 		if (originalServiceKey === undefined) {
@@ -40,6 +48,112 @@ describe("createSapAiCoreProviderModule", () => {
 			deploymentId: "deployment-id",
 		});
 		expect(model.config?.providerApi).toBe("orchestration");
+	});
+
+	it("sets SAP service-key credentials while model methods run", async () => {
+		process.env.AICORE_SERVICE_KEY = "existing-service-key";
+
+		const provider = await createSapAiCoreProviderModule({
+			providerId: "sapaicore",
+			baseUrl: "https://api.ai.example.aws.ml.hana.ondemand.com/",
+			options: {
+				clientId: "sap-client",
+				clientSecret: "sap-secret",
+				tokenUrl: "https://auth.example/oauth/token",
+			},
+		});
+
+		const model = provider.model("anthropic--claude-4.6-sonnet") as {
+			doGenerate: () => Promise<string>;
+		};
+		let observedServiceKey: string | undefined;
+		model.doGenerate = async () => {
+			observedServiceKey = process.env.AICORE_SERVICE_KEY;
+			return "ok";
+		};
+
+		await expect(model.doGenerate()).resolves.toBe("ok");
+		expect(JSON.parse(observedServiceKey ?? "{}")).toMatchObject({
+			clientid: "sap-client",
+			clientsecret: "sap-secret",
+			serviceurls: {
+				AI_API_URL: "https://api.ai.example.aws.ml.hana.ondemand.com",
+			},
+			url: "https://auth.example",
+		});
+		expect(process.env.AICORE_SERVICE_KEY).toBe("existing-service-key");
+	});
+
+	it("serializes concurrent SAP service-key model calls", async () => {
+		process.env.AICORE_SERVICE_KEY = "existing-service-key";
+
+		const firstProvider = await createSapAiCoreProviderModule({
+			providerId: "sapaicore",
+			baseUrl: "https://first.ai.example.aws.ml.hana.ondemand.com",
+			options: {
+				clientId: "first-client",
+				clientSecret: "first-secret",
+				tokenUrl: "https://first-auth.example",
+			},
+		});
+		const secondProvider = await createSapAiCoreProviderModule({
+			providerId: "sapaicore",
+			baseUrl: "https://second.ai.example.aws.ml.hana.ondemand.com",
+			options: {
+				clientId: "second-client",
+				clientSecret: "second-secret",
+				tokenUrl: "https://second-auth.example",
+			},
+		});
+
+		const firstModel = firstProvider.model("anthropic--claude-4.6-sonnet") as {
+			doGenerate: () => Promise<string>;
+		};
+		const secondModel = secondProvider.model("anthropic--claude-4.6-sonnet") as {
+			doGenerate: () => Promise<string>;
+		};
+		const firstStarted = deferred();
+		const releaseFirst = deferred();
+		let firstServiceKey: string | undefined;
+		let firstServiceKeyBeforeReturn: string | undefined;
+		let secondServiceKey: string | undefined;
+		let secondStarted = false;
+
+		firstModel.doGenerate = async () => {
+			firstServiceKey = process.env.AICORE_SERVICE_KEY;
+			firstStarted.resolve();
+			await releaseFirst.promise;
+			firstServiceKeyBeforeReturn = process.env.AICORE_SERVICE_KEY;
+			return "first";
+		};
+		secondModel.doGenerate = async () => {
+			secondStarted = true;
+			secondServiceKey = process.env.AICORE_SERVICE_KEY;
+			return "second";
+		};
+
+		const firstResult = firstModel.doGenerate();
+		await firstStarted.promise;
+		const secondResult = secondModel.doGenerate();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(secondStarted).toBe(false);
+		expect(JSON.parse(firstServiceKey ?? "{}")).toMatchObject({
+			clientid: "first-client",
+		});
+
+		releaseFirst.resolve();
+		await expect(firstResult).resolves.toBe("first");
+		await expect(secondResult).resolves.toBe("second");
+
+		expect(JSON.parse(firstServiceKeyBeforeReturn ?? "{}")).toMatchObject({
+			clientid: "first-client",
+		});
+		expect(JSON.parse(secondServiceKey ?? "{}")).toMatchObject({
+			clientid: "second-client",
+		});
+		expect(process.env.AICORE_SERVICE_KEY).toBe("existing-service-key");
 	});
 
 	it("uses resource group deployment resolution for orchestration mode", async () => {

--- a/sdk/packages/llms/src/providers/vendors/community.ts
+++ b/sdk/packages/llms/src/providers/vendors/community.ts
@@ -11,6 +11,12 @@ import { resolveApiKey } from "../http";
 import type { ProviderFactoryResult } from "./types";
 
 type SapModel = Record<PropertyKey, unknown>;
+const SAP_SERVICE_KEY_METHODS = new Set<PropertyKey>([
+	"doGenerate",
+	"doStream",
+	"doEmbed",
+]);
+let sapServiceKeyQueue: Promise<void> = Promise.resolve();
 
 function readOptions(
 	config: GatewayResolvedProviderConfig,
@@ -177,26 +183,35 @@ function resolveSapApi(options: Record<string, unknown>) {
 	return "orchestration";
 }
 
-function withSapServiceKey<T>(serviceKey: string | undefined, fn: () => T): T {
+async function withSapServiceKey<T>(
+	serviceKey: string | undefined,
+	fn: () => T,
+): Promise<Awaited<T>> {
 	if (!serviceKey) {
-		return fn();
+		return await fn();
 	}
+
+	const previousQueue = sapServiceKeyQueue.catch(() => {});
+	let releaseQueue!: () => void;
+	sapServiceKeyQueue = new Promise<void>((resolve) => {
+		releaseQueue = resolve;
+	});
+
+	await previousQueue;
 	const previous = process.env.AICORE_SERVICE_KEY;
 	process.env.AICORE_SERVICE_KEY = serviceKey;
 	try {
-		const result = fn();
-		const maybePromise = result as unknown as { finally?: unknown };
-		if (result && typeof maybePromise.finally === "function") {
-			return (maybePromise as Promise<unknown>).finally(() => {
-				restoreSapServiceKey(previous);
-			}) as T;
-		}
-		restoreSapServiceKey(previous);
-		return result;
+		return await fn();
 	} catch (error) {
-		restoreSapServiceKey(previous);
 		throw error;
+	} finally {
+		restoreSapServiceKey(previous);
+		releaseQueue();
 	}
+}
+
+function shouldWrapSapServiceKeyMethod(property: PropertyKey): boolean {
+	return SAP_SERVICE_KEY_METHODS.has(property);
 }
 
 function restoreSapServiceKey(previous: string | undefined): void {
@@ -217,7 +232,10 @@ function wrapSapModelWithServiceKey(
 	return new Proxy(model as SapModel, {
 		get(target, property, receiver) {
 			const value = Reflect.get(target, property, receiver);
-			if (typeof value !== "function") {
+			if (
+				typeof value !== "function" ||
+				!shouldWrapSapServiceKeyMethod(property)
+			) {
 				return value;
 			}
 			return (...args: unknown[]) =>

--- a/sdk/packages/llms/src/providers/vendors/community.ts
+++ b/sdk/packages/llms/src/providers/vendors/community.ts
@@ -1,14 +1,16 @@
 import type { GatewayResolvedProviderConfig } from "@cline/shared";
-import type { SAPAIProviderSettings } from "@jerome-benoit/sap-ai-provider";
+// Keep this import static so the VS Code extension bundle includes the SAP
+// provider. Hiding it behind a computed dynamic import leaves the published
+// extension trying to load @jerome-benoit/sap-ai-provider from node_modules at
+// runtime, but VSIX packaging uses the bundled extension output.
+import { createSAPAIProvider } from "@jerome-benoit/sap-ai-provider";
 import { createClaudeCode } from "ai-sdk-provider-claude-code";
 import { createCodexExec } from "ai-sdk-provider-codex-cli";
 import { createDifyProvider } from "dify-ai-provider";
 import { resolveApiKey } from "../http";
 import type { ProviderFactoryResult } from "./types";
 
-type SapAiProviderModule = typeof import("@jerome-benoit/sap-ai-provider");
-type SapDestination = NonNullable<SAPAIProviderSettings["destination"]>;
-const SAP_AI_PROVIDER_PACKAGE = "@jerome-benoit/sap-ai-provider";
+type SapModel = Record<PropertyKey, unknown>;
 
 function readOptions(
 	config: GatewayResolvedProviderConfig,
@@ -129,10 +131,10 @@ function hasExplicitSapConnectionConfig(
 	);
 }
 
-function buildSapDestination(
+function buildSapServiceKey(
 	config: GatewayResolvedProviderConfig,
 	options: Record<string, unknown>,
-): SapDestination | undefined {
+): string | undefined {
 	const clientId = readStringOption(options, "clientId");
 	const clientSecret =
 		readStringOption(options, "clientSecret") ?? config.apiKey?.trim();
@@ -154,25 +156,14 @@ function buildSapDestination(
 			)}.`,
 		);
 	}
-	// SAP Cloud SDK accepts service-binding fetch options at runtime
-	// (`isDestinationFetchOptions()` checks for `service`), but its exported
-	// XOR type makes the `service` branch unrepresentable by also requiring
-	// `destinationName`. Keep the cast at this dependency boundary.
-	return {
-		service: {
-			credentials: {
-				clientid: clientId,
-				clientsecret: clientSecret,
-				serviceurls: {
-					AI_API_URL: baseUrl.replace(/\/+$/, ""),
-				},
-				url: normalizeSapTokenBaseUrl(tokenUrl),
-			},
-			label: "aicore",
-			name: config.providerId,
-			tags: ["aicore"],
+	return JSON.stringify({
+		clientid: clientId,
+		clientsecret: clientSecret,
+		serviceurls: {
+			AI_API_URL: baseUrl.replace(/\/+$/, ""),
 		},
-	} as unknown as SapDestination;
+		url: normalizeSapTokenBaseUrl(tokenUrl),
+	});
 }
 
 function resolveSapApi(options: Record<string, unknown>) {
@@ -186,18 +177,61 @@ function resolveSapApi(options: Record<string, unknown>) {
 	return "orchestration";
 }
 
-async function importSapAiProvider(): Promise<SapAiProviderModule> {
-	const specifier: string = SAP_AI_PROVIDER_PACKAGE;
-	return import(specifier) as Promise<SapAiProviderModule>;
+function withSapServiceKey<T>(serviceKey: string | undefined, fn: () => T): T {
+	if (!serviceKey) {
+		return fn();
+	}
+	const previous = process.env.AICORE_SERVICE_KEY;
+	process.env.AICORE_SERVICE_KEY = serviceKey;
+	try {
+		const result = fn();
+		const maybePromise = result as unknown as { finally?: unknown };
+		if (result && typeof maybePromise.finally === "function") {
+			return (maybePromise as Promise<unknown>).finally(() => {
+				restoreSapServiceKey(previous);
+			}) as T;
+		}
+		restoreSapServiceKey(previous);
+		return result;
+	} catch (error) {
+		restoreSapServiceKey(previous);
+		throw error;
+	}
+}
+
+function restoreSapServiceKey(previous: string | undefined): void {
+	if (previous === undefined) {
+		delete process.env.AICORE_SERVICE_KEY;
+		return;
+	}
+	process.env.AICORE_SERVICE_KEY = previous;
+}
+
+function wrapSapModelWithServiceKey(
+	model: unknown,
+	serviceKey: string | undefined,
+): unknown {
+	if (!serviceKey || !model || typeof model !== "object") {
+		return model;
+	}
+	return new Proxy(model as SapModel, {
+		get(target, property, receiver) {
+			const value = Reflect.get(target, property, receiver);
+			if (typeof value !== "function") {
+				return value;
+			}
+			return (...args: unknown[]) =>
+				withSapServiceKey(serviceKey, () => value.apply(target, args));
+		},
+	});
 }
 
 export async function createSapAiCoreProviderModule(
 	config: GatewayResolvedProviderConfig,
 ): Promise<ProviderFactoryResult> {
 	const options = readOptions(config);
-	const destination = buildSapDestination(config, options);
+	const serviceKey = buildSapServiceKey(config, options);
 
-	const { createSAPAIProvider } = await importSapAiProvider();
 	const deploymentId = readStringOption(options, "deploymentId");
 	const provider = createSAPAIProvider({
 		name: config.providerId,
@@ -205,7 +239,6 @@ export async function createSapAiCoreProviderModule(
 			? { deploymentId }
 			: { resourceGroup: readStringOption(options, "resourceGroup") }),
 		api: resolveSapApi(options),
-		...(destination ? { destination } : {}),
 		...(typeof options.defaultSettings === "object" &&
 		options.defaultSettings !== null &&
 		!Array.isArray(options.defaultSettings)
@@ -213,6 +246,6 @@ export async function createSapAiCoreProviderModule(
 			: {}),
 	});
 	return {
-		model: (modelId) => provider(modelId),
+		model: (modelId) => wrapSapModelWithServiceKey(provider(modelId), serviceKey),
 	};
 }


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This fixes the SAP AI Core provider path after the SDK migration for the VS Code extension and shared SDK runtime.

There were two separate issues in the current integration:

1. The SAP provider package was hidden behind a computed dynamic import:

```ts
const specifier: string = SAP_AI_PROVIDER_PACKAGE
return import(specifier)
```

That pattern prevents the VS Code extension bundle from statically including `@jerome-benoit/sap-ai-provider`. The published VSIX is built around the bundled extension output, so at runtime it can end up trying to resolve the SAP provider from `node_modules`, which is not available in the packaged extension. This PR switches SAP to a static import and leaves a comment documenting why it must stay that way.

2. Cline stores SAP AI Core credentials as split fields from the legacy provider UI: client id, client secret, token URL, and AI Core base URL. The SAP Vercel AI SDK community provider and underlying SAP SDK expect normal authentication to come from `AICORE_SERVICE_KEY` or `VCAP_SERVICES`; its `destination` option is for custom SAP Cloud SDK destination configuration.

The previous integration tried to pass the split Cline fields as `destination.service`. In smoke testing that sent SAP SDK down the destination-resolution path and failed looking for a destination service binding. This PR instead converts the split Cline fields into the documented service-key JSON shape:

```json
{
  "clientid": "...",
  "clientsecret": "...",
  "url": "...",
  "serviceurls": {
    "AI_API_URL": "..."
  }
}
```

The service key is scoped around SAP model method calls and the previous `AICORE_SERVICE_KEY` value is restored afterward. That lets the SAP provider/SAP SDK own the auth, deployment resolution, token request, and inference request behavior while avoiding a permanent process-wide env mutation.

A few things are intentionally not included here:

- No direct SAP SDK package additions.
- No SAP SDK dependency version overrides.
- No SAP-specific request implementation in Cline.
- No foundation-model UI filtering or AbortError behavior changes.

Those may be separate product or compatibility discussions, but they are not needed for the provider bundle/auth failure.

### Test Procedure

Focused automated checks run on a branch based on latest `origin/main`:

```bash
bunx vitest run src/providers/vendors/community.test.ts
bunx vitest run src/services/llms/handler-factory.test.ts
bun -F @cline/llms typecheck
bun -F @cline/llms build
(cd apps/vscode && bun esbuild.mjs --production)
```

I also scanned the built VS Code extension bundle to verify the packaging failure mode directly:

```text
createSAPAIProvider: present
import(vkl): -1
destination.service: -1
```

That confirms the SAP provider code is now included in `apps/vscode/dist/extension.js`, the old computed dynamic import path is gone, and the old `destination.service` auth path is no longer emitted.

Local SAP stub smoke testing during the debugging pass verified that Cline-style split settings produce the expected SAP flow through the provider stack: OAuth token request, deployment lookup, and orchestration completion request with bearer auth and resource group headers.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. No UI changes.

### Additional Notes

The implementation mirrors the way the SAP provider and SAP SDK expect to receive service-key auth. opencode has similar SAP-specific glue that feeds `AICORE_SERVICE_KEY` before invoking the SAP AI SDK provider; the difference here is that Cline still stores SAP credentials as split legacy fields, so the SDK adapter builds the service-key JSON from those fields.
