### PR TITLE
fix(onboarding): gate ClinePass on reliable extension-side flag

### DIFF
--- a/apps/vscode/src/core/controller/state/getStateToPostToWebview.ts
+++ b/apps/vscode/src/core/controller/state/getStateToPostToWebview.ts
@@ -171,6 +171,7 @@ export async function getStateToPostToWebview(controller: {
 			user: stateManager.getGlobalSettingsKey("worktreesEnabled"),
 			featureFlag: featureFlagsService.getWorktreesEnabled(),
 		},
+		clinePassEnabled: featureFlagsService.getClinePassEnabled(),
 		hooksEnabled: getHooksEnabledSafe(stateManager.getGlobalSettingsKey("hooksEnabled")),
 		lastDismissedInfoBannerVersion,
 		lastDismissedModelBannerVersion,

--- a/apps/vscode/src/services/feature-flags/FeatureFlagsService.ts
+++ b/apps/vscode/src/services/feature-flags/FeatureFlagsService.ts
@@ -122,6 +122,10 @@ export class FeatureFlagsService {
 		return this.getBooleanFlagEnabled(FeatureFlag.WORKTREES)
 	}
 
+	public getClinePassEnabled(): boolean {
+		return this.getBooleanFlagEnabled(FeatureFlag.CLINE_PASS)
+	}
+
 	public getOnboardingOverrides() {
 		const payload = this.cache.get(FeatureFlag.ONBOARDING_MODELS)
 		// Check if payload is object

--- a/apps/vscode/src/shared/ExtensionMessage.ts
+++ b/apps/vscode/src/shared/ExtensionMessage.ts
@@ -102,6 +102,7 @@ export interface ExtensionState {
 	subagentsEnabled?: boolean
 	clineWebToolsEnabled?: ClineFeatureSetting
 	worktreesEnabled?: ClineFeatureSetting
+	clinePassEnabled?: boolean
 	customPrompt?: string
 	favoritedModelIds: string[]
 	// NEW: Add workspace information

--- a/apps/vscode/webview-ui/src/components/onboarding/OnboardingView.tsx
+++ b/apps/vscode/webview-ui/src/components/onboarding/OnboardingView.tsx
@@ -335,7 +335,7 @@ const OnboardingStepContent = ({
 
 const OnboardingViewContent = ({ onboardingModels }: { onboardingModels: OnboardingModelGroup }) => {
 	const { handleFieldsChange } = useApiConfigurationHandlers()
-	const { openRouterModels, hideSettings, hideAccount, setShowWelcome } = useExtensionState()
+	const { openRouterModels, hideSettings, hideAccount, setShowWelcome, clinePassEnabled } = useExtensionState()
 	const { models: clineModels } = useProviderModels("cline")
 	const { commitSelection } = useProviderConfig("cline")
 	const loginAttemptIdRef = useRef(0)
@@ -350,8 +350,8 @@ const OnboardingViewContent = ({ onboardingModels }: { onboardingModels: Onboard
 	const [searchTerm, setSearchTerm] = useState("")
 
 	const models = useMemo(() => getClineUIOnboardingGroups(onboardingModels), [onboardingModels])
-	const hasClinePassModels = models.clinePass.length > 0
-	const userTypeSelections = useMemo(() => getUserTypeSelections(hasClinePassModels), [hasClinePassModels])
+	const showClinePass = Boolean(clinePassEnabled) && models.clinePass.length > 0
+	const userTypeSelections = useMemo(() => getUserTypeSelections(showClinePass), [showClinePass])
 	// ClinePass model IDs (e.g. "cline-pass/glm-5.1") aren't keyed in openRouterModels,
 	// so resolve their info via the slug-based lookup used by ClinePassProvider.
 	const openRouterModelsByName = useMemo(() => buildModelInfoNameMap(openRouterModels), [openRouterModels])

--- a/apps/vscode/webview-ui/src/components/onboarding/OnboardingView.tsx
+++ b/apps/vscode/webview-ui/src/components/onboarding/OnboardingView.tsx
@@ -7,20 +7,20 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Item, ItemContent, ItemDescription, ItemHeader, ItemMedia, ItemTitle } from "@/components/ui/item"
-import { CLINE_PASS_FEATURE_FLAG } from "@/constants/featureFlags"
 import { useExtensionState } from "@/context/ExtensionStateContext"
-import { useHasFeatureFlag } from "@/hooks/useFeatureFlag"
 import { useProviderConfig } from "@/hooks/useProviderConfig"
 import { useProviderModels } from "@/hooks/useProviderModels"
 import { cn } from "@/lib/utils"
 import { AccountServiceClient, StateServiceClient } from "@/services/grpc-client"
-import { setPendingClinePassSubscribe } from "./clinePassSubscribe"
 import ApiConfigurationSection from "../settings/sections/ApiConfigurationSection"
 import { useApiConfigurationHandlers } from "../settings/utils/useApiConfigurationHandlers"
 import WelcomeView from "../welcome/WelcomeView"
+import { setPendingClinePassSubscribe } from "./clinePassSubscribe"
 import {
+	CLINEPASS_GROUP,
 	getCapabilities,
 	getClineUIOnboardingGroups,
+	getOnboardingGroupDisplayName,
 	getPriceRange,
 	getSpeedLabel,
 	type OnboardingModelsByGroup,
@@ -161,14 +161,23 @@ const ModelSelection = ({
 	return (
 		<div className="flex flex-col w-full items-center px-2">
 			<div className="flex w-full max-w-lg flex-col gap-6 my-4">
-				{modelGroups.map((group) => (
-					<div className="flex flex-col gap-3" key={group.group}>
-						<h4 className="text-sm font-bold text-foreground/70 uppercase mb-2">{group.group}</h4>
-						{group.models.map((model) => (
-							<ModelItem id={model.id} isSelected={selectedModelId === model.id} key={model.id} model={model} />
-						))}
-					</div>
-				))}
+				{modelGroups.map((group) => {
+					const isClinePassGroup = group.group === CLINEPASS_GROUP
+					return (
+						<div className="flex flex-col gap-3" key={group.group}>
+							<h4
+								className={cn(
+									"text-sm font-bold text-foreground/70 mb-2",
+									isClinePassGroup ? "normal-case" : "uppercase",
+								)}>
+								{getOnboardingGroupDisplayName(group.group)}
+							</h4>
+							{group.models.map((model) => (
+								<ModelItem id={model.id} isSelected={selectedModelId === model.id} key={model.id} model={model} />
+							))}
+						</div>
+					)
+				})}
 			</div>
 
 			{/* SEARCH MODEL — hidden for ClinePass, whose selection is constrained to the curated list. */}
@@ -327,8 +336,6 @@ const OnboardingStepContent = ({
 const OnboardingViewContent = ({ onboardingModels }: { onboardingModels: OnboardingModelGroup }) => {
 	const { handleFieldsChange } = useApiConfigurationHandlers()
 	const { openRouterModels, hideSettings, hideAccount, setShowWelcome } = useExtensionState()
-	const isClinePassEnabled = useHasFeatureFlag(CLINE_PASS_FEATURE_FLAG)
-	const userTypeSelections = useMemo(() => getUserTypeSelections(isClinePassEnabled), [isClinePassEnabled])
 	const { models: clineModels } = useProviderModels("cline")
 	const { commitSelection } = useProviderConfig("cline")
 	const loginAttemptIdRef = useRef(0)
@@ -343,6 +350,8 @@ const OnboardingViewContent = ({ onboardingModels }: { onboardingModels: Onboard
 	const [searchTerm, setSearchTerm] = useState("")
 
 	const models = useMemo(() => getClineUIOnboardingGroups(onboardingModels), [onboardingModels])
+	const hasClinePassModels = models.clinePass.length > 0
+	const userTypeSelections = useMemo(() => getUserTypeSelections(hasClinePassModels), [hasClinePassModels])
 	// ClinePass model IDs (e.g. "cline-pass/glm-5.1") aren't keyed in openRouterModels,
 	// so resolve their info via the slug-based lookup used by ClinePassProvider.
 	const openRouterModelsByName = useMemo(() => buildModelInfoNameMap(openRouterModels), [openRouterModels])

--- a/apps/vscode/webview-ui/src/components/onboarding/__tests__/data-models.test.ts
+++ b/apps/vscode/webview-ui/src/components/onboarding/__tests__/data-models.test.ts
@@ -1,6 +1,11 @@
 import type { OnboardingModel, OnboardingModelGroup } from "@shared/proto/cline/state"
 import { describe, expect, it } from "vitest"
-import { CLINEPASS_GROUP, getClineUIOnboardingGroups, getRecommendedModelsData } from "../data-models"
+import {
+	CLINEPASS_GROUP,
+	getClineUIOnboardingGroups,
+	getOnboardingGroupDisplayName,
+	getRecommendedModelsData,
+} from "../data-models"
 
 function model(id: string, group: string): OnboardingModel {
 	return {
@@ -49,44 +54,38 @@ describe("getClineUIOnboardingGroups", () => {
 })
 
 describe("getRecommendedModelsData", () => {
-	it("ignores ClinePass-only responses when the ClinePass feature flag is disabled", () => {
-		const result = getRecommendedModelsData(
-			{
-				recommended: [],
-				free: [],
-				clinePass: [{ id: "cline-pass/glm-5.1", name: "GLM 5.1", description: "", tags: [] }],
-			},
-			false,
-		)
-
-		expect(result).toBeUndefined()
-	})
-
-	it("includes ClinePass models when the ClinePass feature flag is enabled", () => {
-		const result = getRecommendedModelsData(
-			{
-				recommended: [],
-				free: [],
-				clinePass: [{ id: "cline-pass/glm-5.1", name: "GLM 5.1", description: "", tags: [] }],
-			},
-			true,
-		)
+	it("includes ClinePass-only responses without depending on feature-flag timing", () => {
+		const result = getRecommendedModelsData({
+			recommended: [],
+			free: [],
+			clinePass: [{ id: "cline-pass/glm-5.1", name: "GLM 5.1", description: "", tags: [] }],
+		})
 
 		expect(result?.clinePass.map((model) => model.id)).toEqual(["cline-pass/glm-5.1"])
 	})
 
-	it("keeps classic recommended/free responses when the ClinePass feature flag is disabled", () => {
-		const result = getRecommendedModelsData(
-			{
-				recommended: [{ id: "anthropic/claude", name: "Claude", description: "", tags: [] }],
-				free: [{ id: "free-model", name: "Free", description: "", tags: [] }],
-				clinePass: [{ id: "cline-pass/glm-5.1", name: "GLM 5.1", description: "", tags: [] }],
-			},
-			false,
-		)
+	it("keeps classic recommended/free responses and ClinePass responses", () => {
+		const result = getRecommendedModelsData({
+			recommended: [{ id: "anthropic/claude", name: "Claude", description: "", tags: [] }],
+			free: [{ id: "free-model", name: "Free", description: "", tags: [] }],
+			clinePass: [{ id: "cline-pass/glm-5.1", name: "GLM 5.1", description: "", tags: [] }],
+		})
 
 		expect(result?.recommended.map((model) => model.id)).toEqual(["anthropic/claude"])
 		expect(result?.free.map((model) => model.id)).toEqual(["free-model"])
-		expect(result?.clinePass).toEqual([])
+		expect(result?.clinePass.map((model) => model.id)).toEqual(["cline-pass/glm-5.1"])
+	})
+
+	it("returns undefined when every recommended bucket is empty", () => {
+		const result = getRecommendedModelsData({ recommended: [], free: [], clinePass: [] })
+
+		expect(result).toBeUndefined()
+	})
+})
+
+describe("onboarding display labels", () => {
+	it("renders the canonical ClinePass group as a user-facing product name", () => {
+		expect(getOnboardingGroupDisplayName(CLINEPASS_GROUP)).toBe("ClinePass")
+		expect(getOnboardingGroupDisplayName("frontier")).toBe("frontier")
 	})
 })

--- a/apps/vscode/webview-ui/src/components/onboarding/__tests__/data-steps.test.ts
+++ b/apps/vscode/webview-ui/src/components/onboarding/__tests__/data-steps.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, it } from "vitest"
 import { getUserTypeSelections, NEW_USER_TYPE } from "../data-steps"
 
 describe("getUserTypeSelections", () => {
-	it("omits the ClinePass option when the flag is disabled", () => {
+	it("omits the ClinePass option when no ClinePass models are available", () => {
 		const selections = getUserTypeSelections(false)
 		expect(selections.map((s) => s.type)).toEqual([NEW_USER_TYPE.FREE, NEW_USER_TYPE.POWER, NEW_USER_TYPE.BYOK])
 		expect(selections.some((s) => s.type === NEW_USER_TYPE.CLINE_PASS)).toBe(false)
 	})
 
-	it("inserts ClinePass right after the free option when the flag is enabled", () => {
+	it("inserts ClinePass right after the free option when ClinePass models are available", () => {
 		const selections = getUserTypeSelections(true)
 		// Free stays first (and remains the default selection); ClinePass is the
 		// recommended-but-optional second choice.

--- a/apps/vscode/webview-ui/src/components/onboarding/data-models.ts
+++ b/apps/vscode/webview-ui/src/components/onboarding/data-models.ts
@@ -15,13 +15,10 @@ type RecommendedModelsResponseLike = {
 	clinePass?: ClineRecommendedModel[]
 }
 
-export function getRecommendedModelsData(
-	response: RecommendedModelsResponseLike,
-	isClinePassEnabled: boolean,
-): RecommendedModelsData | undefined {
+export function getRecommendedModelsData(response: RecommendedModelsResponseLike): RecommendedModelsData | undefined {
 	const recommended = response.recommended ?? []
 	const free = response.free ?? []
-	const clinePass = isClinePassEnabled ? (response.clinePass ?? []) : []
+	const clinePass = response.clinePass ?? []
 
 	if (recommended.length === 0 && free.length === 0 && clinePass.length === 0) {
 		return undefined
@@ -61,6 +58,13 @@ export function getClineUIOnboardingGroups(groupedModels: OnboardingModelGroup):
 			...(openSourceModels.length > 0 ? [{ group: "open source", models: openSourceModels }] : []),
 		],
 	}
+}
+
+export function getOnboardingGroupDisplayName(group: string): string {
+	if (group === CLINEPASS_GROUP) {
+		return "ClinePass"
+	}
+	return group
 }
 
 export function getPriceRange(modelInfo: OpenRouterModelInfo): string {

--- a/apps/vscode/webview-ui/src/components/onboarding/data-steps.ts
+++ b/apps/vscode/webview-ui/src/components/onboarding/data-steps.ts
@@ -67,15 +67,9 @@ const BASE_USER_TYPE_SELECTIONS: UserTypeSelection[] = [
 	{ title: "Bring my own API key", description: "Use Cline with your provider of choice", type: NEW_USER_TYPE.BYOK },
 ]
 
-/**
- * Returns the onboarding user-type options. The free option leads the list and is
- * the default selection; ClinePass is inserted as a recommended-but-optional
- * choice (labeled "Recommended") right after it, only when the `ext-cline-pass`
- * feature flag is enabled. When the flag is off, the classic Free / Frontier /
- * BYOK options are shown unchanged.
- */
-export function getUserTypeSelections(isClinePassEnabled: boolean): UserTypeSelection[] {
-	if (!isClinePassEnabled) {
+/** Free leads (and is the default); ClinePass is inserted second when its models are available. */
+export function getUserTypeSelections(hasClinePassModels: boolean): UserTypeSelection[] {
+	if (!hasClinePassModels) {
 		return BASE_USER_TYPE_SELECTIONS
 	}
 	const [free, ...rest] = BASE_USER_TYPE_SELECTIONS

--- a/apps/vscode/webview-ui/src/components/onboarding/useOnboardingModels.ts
+++ b/apps/vscode/webview-ui/src/components/onboarding/useOnboardingModels.ts
@@ -4,9 +4,7 @@ import { EmptyRequest } from "@shared/proto/cline/common"
 import type { ClineRecommendedModel } from "@shared/proto/cline/models"
 import type { OnboardingModel, OnboardingModelGroup } from "@shared/proto/cline/state"
 import { useEffect, useMemo, useState } from "react"
-import { CLINE_PASS_FEATURE_FLAG } from "@/constants/featureFlags"
 import { useExtensionState } from "@/context/ExtensionStateContext"
-import { useHasFeatureFlag } from "@/hooks/useFeatureFlag"
 import { useProviderModels } from "@/hooks/useProviderModels"
 import { ModelsServiceClient } from "@/services/grpc-client"
 import { CLINEPASS_GROUP, getRecommendedModelsData, type RecommendedModelsData } from "./data-models"
@@ -53,7 +51,6 @@ type FetchState = { status: "loading" } | { status: "success"; data: Recommended
 export function useOnboardingModels(): UseOnboardingModelsResult {
 	const { openRouterModels } = useExtensionState()
 	const { models: clineModels } = useProviderModels("cline")
-	const isClinePassEnabled = useHasFeatureFlag(CLINE_PASS_FEATURE_FLAG)
 	const [fetchState, setFetchState] = useState<FetchState>({ status: "loading" })
 
 	useEffect(() => {
@@ -63,7 +60,7 @@ export function useOnboardingModels(): UseOnboardingModelsResult {
 			try {
 				const response = await ModelsServiceClient.refreshClineRecommendedModelsRpc(EmptyRequest.create({}))
 				if (!cancelled) {
-					const data = getRecommendedModelsData(response, isClinePassEnabled)
+					const data = getRecommendedModelsData(response)
 					if (!data) {
 						setFetchState({ status: "empty" })
 					} else {
@@ -82,7 +79,7 @@ export function useOnboardingModels(): UseOnboardingModelsResult {
 		return () => {
 			cancelled = true
 		}
-	}, [isClinePassEnabled])
+	}, [])
 
 	// Merge openRouter and cline models into a single catalog for lookups
 	const modelCatalog = useMemo<Record<string, ModelInfo>>(() => {

--- a/apps/vscode/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/apps/vscode/webview-ui/src/context/ExtensionStateContext.tsx
@@ -280,6 +280,7 @@ export const ExtensionStateContextProvider: React.FC<{
 		subagentsEnabled: false,
 		clineWebToolsEnabled: { user: true, featureFlag: false },
 		worktreesEnabled: { user: true, featureFlag: false },
+		clinePassEnabled: false,
 		favoritedModelIds: [],
 		lastDismissedInfoBannerVersion: 0,
 		lastDismissedModelBannerVersion: 0,


### PR DESCRIPTION
## Summary

ClinePass wasn't showing in onboarding for eligible users (and the model list could appear empty) because onboarding read the `ext-cline-pass` flag through the **webview `posthog-js`** client. During onboarding that path is unreliable in Nightly: PostHog remote-config scripts from `data.cline.bot` are blocked by the webview CSP, and the flag is evaluated before auth/identify resolves — so the flag read false even for users it's enabled for.

`ext-cline-pass` is rolled out to internal cohorts only (QA Team / Cline team / ClinePass Beta), **not GA**, so the flag must be honored — it can't just be removed.

## Fix

Read the flag from the **extension-side** `featureFlagsService` (the same server-evaluated source Settings and the provider catalog already use, which resolves correctly once logged in), and plumb it into webview state like `worktreesEnabled` / `clineWebToolsEnabled` already are.

Onboarding now shows ClinePass **iff the flag is enabled AND the payload contains ClinePass models**, so the option and the model list are always in sync — no second, racy webview PostHog read.

- `FeatureFlagsService.getClinePassEnabled()`
- `getStateToPostToWebview`: `clinePassEnabled`
- `ExtensionState` type + webview default
- `OnboardingView` gates the ClinePass option on `state.clinePassEnabled`
- Group header renders `ClinePass` (not the raw `cline-pass` id); model ids/names unchanged

## Result

- Eligible users (flag on) → ClinePass shows reliably in onboarding.
- Everyone else (flag off) → ClinePass stays hidden.
- No Nightly empty-list race.

## Test plan

```bash
cd apps/vscode/webview-ui
npm run test -- src/components/onboarding/__tests__/   # 9 passed
npm run build                                          # tsc -b + vite build pass
```
