### PR TITLE
fix(webview): make PostHog feature flags reliable in the packaged webview

### DIFF
--- a/apps/vscode/src/core/webview/WebviewProvider.ts
+++ b/apps/vscode/src/core/webview/WebviewProvider.ts
@@ -110,7 +110,7 @@ export abstract class WebviewProvider {
 					font-src ${this.getCspSource()} data:; 
 					style-src ${this.getCspSource()} 'unsafe-inline'; 
 					img-src ${this.getCspSource()} https: data:; 
-					script-src 'nonce-${nonce}' 'unsafe-eval';">
+					script-src 'nonce-${nonce}' 'unsafe-eval' https://*.posthog.com https://*.cline.bot;">
 				<title>Cline</title>
 			</head>
 			<body>

--- a/apps/vscode/webview-ui/src/hooks/useFeatureFlag.ts
+++ b/apps/vscode/webview-ui/src/hooks/useFeatureFlag.ts
@@ -34,3 +34,49 @@ export const useHasFeatureFlag = (flagName: string): boolean => {
 
 	return flagEnabled
 }
+
+/**
+ * Tri-state feature flag status.
+ * - "enabled" / "disabled": PostHog has resolved the flag.
+ * - "loading": PostHog hasn't returned flags yet (e.g. mid auth/identify
+ *   handshake, or while remote config is still loading).
+ *
+ * The boolean {@link useHasFeatureFlag} collapses "loading" into `false`, which
+ * causes a false-negative when a feature is briefly treated as disabled before
+ * flags have actually resolved. Callers that must not flash a disabled/empty
+ * state before flags load should use this variant and treat "loading" distinctly
+ * from "disabled".
+ */
+export type FeatureFlagStatus = "enabled" | "disabled" | "loading"
+
+export const useFeatureFlagStatus = (flagName: string): FeatureFlagStatus => {
+	const { environment } = useExtensionState()
+	const isSelfHostedOrUnknown = !environment || environment === "selfHosted"
+	const [status, setStatus] = useState<FeatureFlagStatus>("loading")
+
+	useEffect(() => {
+		if (isSelfHostedOrUnknown) {
+			setStatus("disabled")
+			return
+		}
+
+		const readFlag = () => {
+			// posthog.isFeatureEnabled returns undefined until flags have loaded.
+			const value = posthog.isFeatureEnabled(flagName)
+			if (value === undefined) {
+				setStatus("loading")
+				return
+			}
+			setStatus(value ? "enabled" : "disabled")
+		}
+
+		readFlag()
+		return posthog.onFeatureFlags(readFlag)
+	}, [flagName, isSelfHostedOrUnknown])
+
+	if (isSelfHostedOrUnknown) {
+		return "disabled"
+	}
+
+	return status
+}


### PR DESCRIPTION
## Summary

Makes PostHog-backed feature flags reliable in the **packaged** webview (production / Nightly). This is the general follow-up to #11798, which removed onboarding's dependency on this path; other webview flags still ride it.

## Problems

**1. CSP blocked PostHog remote-config scripts.**
The production webview CSP allowed PostHog over `connect-src` (the `/decide` flag call) but `script-src` was only `'nonce-...' 'unsafe-eval'`. PostHog lazy-loads helper scripts (`config.js`, `array.js`, `surveys.js`, `exception-autocapture.js`) from `https://data.cline.bot` via injected `<script>` tags — all blocked, so flag resolution was unreliable (these are the `data.cline.bot` CSP violations seen in webview consoles).

**2. "Flags not loaded yet" was a false-negative.**
`useHasFeatureFlag` collapses PostHog's `undefined`-while-loading state into `false`, so a flag can briefly read as disabled during the auth/identify handshake.

## Changes

- `WebviewProvider.ts`: add `https://*.posthog.com https://*.cline.bot` to the production CSP `script-src`.
- `useFeatureFlag.ts`: add a tri-state `useFeatureFlagStatus` (`enabled | disabled | loading`) so callers that must not flash a disabled/empty state can treat `loading` distinctly from `disabled`. `useHasFeatureFlag` is unchanged for existing boolean callers.

## Test plan

- `npx tsc -b` (webview): passes.
- Manual: in the packaged webview, PostHog remote-config scripts from `data.cline.bot` no longer trigger CSP violations and flags resolve.
