### PR TITLE
feat: add support for JSON-encoded string arrays for tools

### DIFF
--- a/sdk/packages/core/src/extensions/tools/definitions.test.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.test.ts
@@ -399,6 +399,47 @@ describe("default search_codebase tool", () => {
 			},
 		]);
 	});
+
+	it("accepts object input with queries as a JSON-encoded string array", async () => {
+		const execute = vi.fn(async (query: string) => `results:${query}`);
+		const tool = createSearchTool(execute);
+
+		const result = await tool.execute(
+			{
+				queries: JSON.stringify(["createSearchTool", "run_commands"]),
+			} as never,
+			{
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 1,
+			},
+		);
+
+		expect(result).toEqual([
+			{
+				query: "createSearchTool",
+				result: "results:createSearchTool",
+				success: true,
+			},
+			{
+				query: "run_commands",
+				result: "results:run_commands",
+				success: true,
+			},
+		]);
+		expect(execute).toHaveBeenNthCalledWith(
+			1,
+			"createSearchTool",
+			process.cwd(),
+			expect.objectContaining({ iteration: 1 }),
+		);
+		expect(execute).toHaveBeenNthCalledWith(
+			2,
+			"run_commands",
+			process.cwd(),
+			expect.objectContaining({ iteration: 1 }),
+		);
+	});
 });
 
 describe("default apply_patch tool", () => {
@@ -1462,6 +1503,45 @@ describe("default read_files tool", () => {
 			3,
 			{ path: "/tmp/c.ts" },
 			expect.objectContaining({ iteration: 2 }),
+		);
+	});
+
+	it("accepts object input with files as a JSON-encoded string array", async () => {
+		const execute = vi.fn(
+			async (request: { path: string }) => `content:${request.path}`,
+		);
+		const tool = createReadFilesTool(execute);
+
+		const result = await tool.execute(
+			{ files: JSON.stringify(["/tmp/a.ts", "/tmp/b.ts"]) } as never,
+			{
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 1,
+			},
+		);
+
+		expect(result).toEqual([
+			{
+				query: "/tmp/a.ts",
+				result: "content:/tmp/a.ts",
+				success: true,
+			},
+			{
+				query: "/tmp/b.ts",
+				result: "content:/tmp/b.ts",
+				success: true,
+			},
+		]);
+		expect(execute).toHaveBeenNthCalledWith(
+			1,
+			{ path: "/tmp/a.ts" },
+			expect.objectContaining({ iteration: 1 }),
+		);
+		expect(execute).toHaveBeenNthCalledWith(
+			2,
+			{ path: "/tmp/b.ts" },
+			expect.objectContaining({ iteration: 1 }),
 		);
 	});
 

--- a/sdk/packages/core/src/extensions/tools/definitions.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.ts
@@ -26,7 +26,9 @@ import {
 	formatRunCommandQueryPreview,
 	getEditorSizeError,
 	getReadFileRangeError,
+	normalizeJsonLikeReadFilesInput,
 	normalizeJsonLikeRunCommandsInput,
+	normalizeJsonLikeSearchCodebaseInput,
 	normalizeRunCommandsInput,
 	TimeoutError,
 	withTimeout,
@@ -192,7 +194,10 @@ export function createReadFilesTool(
 		retryable: true,
 		maxRetries: 1,
 		execute: async (input, context) => {
-			const validate = validateWithZod(ReadFilesInputUnionSchema, input);
+			const validate = validateWithZod(
+				ReadFilesInputUnionSchema,
+				normalizeJsonLikeReadFilesInput(input),
+			);
 			let requests: ReadFileRequest[];
 			if (typeof validate === "string") {
 				requests = [{ path: validate }];
@@ -286,7 +291,10 @@ export function createSearchTool(
 		maxRetries: 1,
 		execute: async (input, context) => {
 			// Validate input with Zod schema
-			const validate = validateWithZod(SearchCodebaseUnionInputSchema, input);
+			const validate = validateWithZod(
+				SearchCodebaseUnionInputSchema,
+				normalizeJsonLikeSearchCodebaseInput(input),
+			);
 			const queries = Array.isArray(validate)
 				? validate
 				: typeof validate === "object"

--- a/sdk/packages/core/src/extensions/tools/helpers.ts
+++ b/sdk/packages/core/src/extensions/tools/helpers.ts
@@ -98,18 +98,42 @@ function isRecord(input: unknown): input is Record<string, unknown> {
 	return typeof input === "object" && input != null && !Array.isArray(input);
 }
 
-export function normalizeJsonLikeRunCommandsInput(input: unknown): unknown {
+export function normalizeJsonLikeToolInput(
+	input: unknown,
+	keys: string[],
+): unknown {
 	const parsed = parseJsonLikeString(input);
-	if (!isRecord(parsed) || !("commands" in parsed)) {
+	if (!isRecord(parsed)) {
 		return parsed;
 	}
 
-	const commands = parseJsonLikeString(parsed.commands);
-	if (isRecord(commands) && "commands" in commands) {
-		return { ...parsed, commands: parseJsonLikeString(commands.commands) };
+	const normalized = { ...parsed };
+	for (const key of keys) {
+		if (!(key in normalized)) {
+			continue;
+		}
+
+		const value = parseJsonLikeString(normalized[key]);
+		if (isRecord(value) && key in value) {
+			normalized[key] = parseJsonLikeString(value[key]);
+		} else {
+			normalized[key] = value;
+		}
 	}
 
-	return { ...parsed, commands };
+	return normalized;
+}
+
+export function normalizeJsonLikeRunCommandsInput(input: unknown): unknown {
+	return normalizeJsonLikeToolInput(input, ["commands"]);
+}
+
+export function normalizeJsonLikeReadFilesInput(input: unknown): unknown {
+	return normalizeJsonLikeToolInput(input, ["files", "file_paths", "paths"]);
+}
+
+export function normalizeJsonLikeSearchCodebaseInput(input: unknown): unknown {
+	return normalizeJsonLikeToolInput(input, ["queries"]);
 }
 
 export function normalizeRunCommandsInput(


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

- Added normalizeJsonLikeSearchCodebaseInput and normalizeJsonLikeReadFilesInput helpers
- Updated createSearchTool and createReadFilesTool to accept queries/files as JSON-encoded string arrays
- Refactored normalizeJsonLikeRunCommandsInput into a generic normalizeJsonLikeToolInput utility
- Added test coverage for new input format acceptance

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
