### PR TITLE
Normalize JSON-like tool inputs by schema

### DIFF
--- a/sdk/packages/agents/src/agent-runtime.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.test.ts
@@ -816,6 +816,123 @@ describe("AgentRuntime", () => {
 		]);
 	});
 
+	it("normalizes JSON-encoded string fields when the tool schema expects arrays", async () => {
+		const executeTool = vi.fn(async (input: { commands: string[] }) => ({
+			joined: input.commands.join(" && "),
+		}));
+		const beforeTool = vi.fn();
+		const model = new ScriptedModel([
+			() => [
+				{
+					type: "tool-call-delta",
+					toolCallId: "call_commands",
+					toolName: "commands",
+					inputText: JSON.stringify({
+						commands: JSON.stringify(["git status", "bun test"]),
+					}),
+				},
+				{ type: "finish", reason: "tool-calls" },
+			],
+			(request) => {
+				const toolMessage = request.messages.at(-1) as AgentMessage;
+				expect(toolMessage.role).toBe("tool");
+				expect(toolMessage.content[0]).toMatchObject({
+					type: "tool-result",
+					toolName: "commands",
+					output: { joined: "git status && bun test" },
+				});
+				return [
+					{ type: "text-delta", text: "done" },
+					{ type: "finish", reason: "stop" },
+				];
+			},
+		]);
+		const runtime = new AgentRuntime({
+			model,
+			tools: [
+				{
+					name: "commands",
+					description: "Run commands",
+					inputSchema: {
+						type: "object",
+						properties: {
+							commands: {
+								type: "array",
+								items: { type: "string" },
+							},
+						},
+					},
+					execute: executeTool,
+				},
+			],
+			hooks: {
+				beforeTool,
+			},
+		});
+
+		const result = await runtime.run("Start");
+
+		expect(result.status).toBe("completed");
+		expect(executeTool).toHaveBeenCalledWith(
+			{ commands: ["git status", "bun test"] },
+			expect.anything(),
+		);
+		expect(beforeTool).toHaveBeenCalledWith(
+			expect.objectContaining({
+				input: { commands: ["git status", "bun test"] },
+				toolCall: expect.objectContaining({
+					input: { commands: ["git status", "bun test"] },
+				}),
+			}),
+		);
+	});
+
+	it("preserves JSON-looking strings when the tool schema expects strings", async () => {
+		const executeTool = vi.fn(async (input: { text: string }) => ({
+			echoed: input.text,
+		}));
+		const jsonText = JSON.stringify({ keep: "as text" });
+		const model = new ScriptedModel([
+			() => [
+				{
+					type: "tool-call-delta",
+					toolCallId: "call_text",
+					toolName: "echo_json",
+					inputText: JSON.stringify({ text: jsonText }),
+				},
+				{ type: "finish", reason: "tool-calls" },
+			],
+			() => [
+				{ type: "text-delta", text: "done" },
+				{ type: "finish", reason: "stop" },
+			],
+		]);
+		const runtime = new AgentRuntime({
+			model,
+			tools: [
+				{
+					name: "echo_json",
+					description: "Echo JSON-looking text",
+					inputSchema: {
+						type: "object",
+						properties: {
+							text: { type: "string" },
+						},
+					},
+					execute: executeTool,
+				},
+			],
+		});
+
+		const result = await runtime.run("Start");
+
+		expect(result.status).toBe("completed");
+		expect(executeTool).toHaveBeenCalledWith(
+			{ text: jsonText },
+			expect.anything(),
+		);
+	});
+
 	it("treats an unset maxIterations as unlimited", async () => {
 		const model = new ScriptedModel([
 			() => [

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -27,6 +27,7 @@ import {
 	captureSdkError,
 	estimateTokens,
 	mergeModelOptions,
+	normalizeJsonLikeStringsForSchema,
 	omitUndefinedValues,
 	trimNonEmpty,
 } from "@cline/shared";
@@ -1151,13 +1152,17 @@ export class AgentRuntime {
 			skipReason = `Tool execution is disabled for provider ${providerId}`;
 		}
 
+		if (tool && !skipReason) {
+			input = normalizeJsonLikeStringsForSchema(input, tool.inputSchema);
+		}
+
 		let policyOverride: ToolPolicy | undefined;
 		if (tool && !skipReason) {
 			for (const hook of this.hooks.beforeTool) {
 				const result = (await hook({
 					snapshot: this.snapshot(),
 					tool,
-					toolCall,
+					toolCall: { ...toolCall, input },
 					input,
 				})) as AgentBeforeToolResult | undefined;
 				if (result?.input !== undefined) {

--- a/sdk/packages/shared/src/index.browser.ts
+++ b/sdk/packages/shared/src/index.browser.ts
@@ -208,11 +208,12 @@ export {
 	noopBasicLogger,
 } from "./logging/logger";
 export {
+	normalizeJsonLikeStringsForSchema,
 	parseJsonStream,
 	safeJsonParse,
 	safeJsonStringify,
 } from "./parse/json";
-export { omitUndefinedValues, type OmitUndefinedValues } from "./parse/object";
+export { type OmitUndefinedValues, omitUndefinedValues } from "./parse/object";
 export { getDefaultShell, getShellArgs } from "./parse/shell";
 export {
 	maskSecret,

--- a/sdk/packages/shared/src/index.ts
+++ b/sdk/packages/shared/src/index.ts
@@ -222,11 +222,12 @@ export {
 	noopBasicLogger,
 } from "./logging/logger";
 export {
+	normalizeJsonLikeStringsForSchema,
 	parseJsonStream,
 	safeJsonParse,
 	safeJsonStringify,
 } from "./parse/json";
-export { omitUndefinedValues, type OmitUndefinedValues } from "./parse/object";
+export { type OmitUndefinedValues, omitUndefinedValues } from "./parse/object";
 export { getDefaultShell, getShellArgs } from "./parse/shell";
 export {
 	maskSecret,

--- a/sdk/packages/shared/src/parse/json.test.ts
+++ b/sdk/packages/shared/src/parse/json.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseJsonStream } from "./json";
+import { normalizeJsonLikeStringsForSchema, parseJsonStream } from "./json";
 
 describe("parseJsonStream", () => {
 	it("repairs a bare object value into a JSON string", () => {
@@ -9,6 +9,73 @@ describe("parseJsonStream", () => {
 		expect(parseJsonStream(input)).toEqual({
 			commands:
 				'find /Users/beatrix/dev/sdk -name "user-instruction-config-loader.ts" -o -name "rules.ts" | head -20',
+		});
+	});
+});
+
+describe("normalizeJsonLikeStringsForSchema", () => {
+	it("parses JSON strings when the schema expects arrays", () => {
+		expect(
+			normalizeJsonLikeStringsForSchema(
+				{ commands: JSON.stringify(["git status", "bun test"]) },
+				{
+					type: "object",
+					properties: {
+						commands: {
+							type: "array",
+							items: { type: "string" },
+						},
+					},
+				},
+			),
+		).toEqual({ commands: ["git status", "bun test"] });
+	});
+
+	it("preserves JSON-looking strings when the schema expects strings", () => {
+		const text = JSON.stringify({ keep: "as text" });
+
+		expect(
+			normalizeJsonLikeStringsForSchema(
+				{ text },
+				{
+					type: "object",
+					properties: {
+						text: { type: "string" },
+					},
+				},
+			),
+		).toEqual({ text });
+	});
+
+	it("normalizes nested array items using item schemas", () => {
+		expect(
+			normalizeJsonLikeStringsForSchema(
+				{
+					steps: [
+						{ args: JSON.stringify(["--version"]) },
+						{ args: JSON.stringify(["test"]) },
+					],
+				},
+				{
+					type: "object",
+					properties: {
+						steps: {
+							type: "array",
+							items: {
+								type: "object",
+								properties: {
+									args: {
+										type: "array",
+										items: { type: "string" },
+									},
+								},
+							},
+						},
+					},
+				},
+			),
+		).toEqual({
+			steps: [{ args: ["--version"] }, { args: ["test"] }],
 		});
 	});
 });

--- a/sdk/packages/shared/src/parse/json.ts
+++ b/sdk/packages/shared/src/parse/json.ts
@@ -84,3 +84,118 @@ export function safeJsonParse<T>(raw: string): T | undefined {
 		return undefined;
 	}
 }
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function schemaTypes(schema: Record<string, unknown>): string[] {
+	const type = schema.type;
+	if (typeof type === "string") {
+		return [type];
+	}
+	return Array.isArray(type)
+		? type.filter((item): item is string => typeof item === "string")
+		: [];
+}
+
+function schemaAcceptsKind(
+	schema: Record<string, unknown>,
+	kind: "array" | "object",
+): boolean {
+	const types = schemaTypes(schema);
+	if (types.includes(kind)) {
+		return true;
+	}
+
+	for (const key of ["anyOf", "oneOf", "allOf"] as const) {
+		const branches = schema[key];
+		if (
+			Array.isArray(branches) &&
+			branches.some(
+				(branch) => isRecord(branch) && schemaAcceptsKind(branch, kind),
+			)
+		) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+function parseJsonStringForSchema(
+	value: unknown,
+	schema: Record<string, unknown>,
+) {
+	if (typeof value !== "string") {
+		return value;
+	}
+
+	const trimmed = value.trim();
+	const expectsArray = schemaAcceptsKind(schema, "array");
+	const expectsObject = schemaAcceptsKind(schema, "object");
+	if (
+		(!expectsArray || !trimmed.startsWith("[")) &&
+		(!expectsObject || !trimmed.startsWith("{"))
+	) {
+		return value;
+	}
+
+	try {
+		const parsed = JSON.parse(trimmed) as unknown;
+		if (Array.isArray(parsed)) {
+			return expectsArray ? parsed : value;
+		}
+		if (isRecord(parsed)) {
+			return expectsObject ? parsed : value;
+		}
+		return value;
+	} catch {
+		return value;
+	}
+}
+
+export function normalizeJsonLikeStringsForSchema(
+	input: unknown,
+	schema: Record<string, unknown>,
+): unknown {
+	const value = parseJsonStringForSchema(input, schema);
+
+	if (Array.isArray(value)) {
+		const items = schema.items;
+		if (!isRecord(items)) {
+			return value;
+		}
+		let changed = false;
+		const normalized = value.map((item) => {
+			const next = normalizeJsonLikeStringsForSchema(item, items);
+			changed ||= next !== item;
+			return next;
+		});
+		return changed ? normalized : value;
+	}
+
+	if (!isRecord(value)) {
+		return value;
+	}
+
+	const properties = schema.properties;
+	if (!isRecord(properties)) {
+		return value;
+	}
+
+	let changed = false;
+	const normalized: Record<string, unknown> = { ...value };
+	for (const [key, propertySchema] of Object.entries(properties)) {
+		if (!(key in value) || !isRecord(propertySchema)) {
+			continue;
+		}
+		const next = normalizeJsonLikeStringsForSchema(value[key], propertySchema);
+		if (next !== value[key]) {
+			normalized[key] = next;
+			changed = true;
+		}
+	}
+
+	return changed ? normalized : value;
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

## Summary

- Add shared schema-guided normalization for JSON-like string values in tool inputs
- Apply normalization in `AgentRuntime` before `beforeTool` hooks, approval, and tool execution
- Cover array coercion, string preservation, nested item schemas, and runtime integration

## Why

Some model/tool-call providers can emit a field like:

```json
{ "commands": "[\"git status\"]" }
```

when the tool schema expects:

```json
{ "commands": ["git status"] }
```

Previously this had to be handled inside individual tools. This moves the repair to the runtime boundary and makes it schema-aware so all tools benefit without blindly parsing legitimate string fields.

Now, It only parses JSON-like string values when the matching schema position expects an array or object.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->


## Validation

- `bun -F @cline/shared build`
- `bun -F @cline/shared test:unit src/parse/json.test.ts`
- `bun -F @cline/agents test src/agent-runtime.test.ts`
- `bun -F @cline/shared typecheck`
- `bun -F @cline/agents typecheck`
- `bun biome check --no-errors-on-unmatched --files-ignore-unknown=true ...`

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

