### PR TITLE
fix(clinepass): render the entitlement card for not-subscribed errors

### DIFF
--- a/apps/vscode/src/services/error/ClineError.ts
+++ b/apps/vscode/src/services/error/ClineError.ts
@@ -155,26 +155,18 @@ export class ClineError extends Error {
 			return ClineErrorType.SpendLimit
 		}
 
-		// ClinePass entitlement errors are user-actionable and should not fall through to generic 403 auth.
-		// The organization-account variant gets separate copy because subscribing is not the right action.
 		const isEntitlementCode = code === "ENTITLEMENT_ERROR" || details?.code === "ENTITLEMENT_ERROR"
 		const entitlementText = `${message ?? ""} ${details?.message ?? ""}`.toLowerCase()
-		// Org variant. The raw backend phrase ("...individual model inference subscriptions") stays gated
-		// on the code to avoid false positives, but the user-facing message ("...ClinePass subscriptions")
-		// is specific enough to match on text alone — needed because the SDK rethrow strips the code.
-		if (
+		const isOrgClinePassRestriction =
 			(isEntitlementCode && entitlementText.includes(ORG_CLINE_PASS_RESTRICTION_MESSAGE)) ||
 			entitlementText.includes(ORG_CLINE_PASS_RESTRICTION_USER_MESSAGE)
-		) {
+		if (isOrgClinePassRestriction) {
 			return ClineErrorType.OrgClinePassRestriction
 		}
-		// Personal ClinePass "not subscribed" errors. The SDK rethrows these as a plain Error and
-		// drops the backend ENTITLEMENT_ERROR code, so match on the user-facing message too (not just
-		// isEntitlementCode) to keep rendering the actionable "Get ClinePass" subscription card.
-		if (
+		const isClinePassNotSubscribed =
 			(isEntitlementCode && entitlementText.includes("not subscribed to required model plan")) ||
 			entitlementText.includes("no access to clinepass subscription models")
-		) {
+		if (isClinePassNotSubscribed) {
 			return ClineErrorType.Entitlement
 		}
 

--- a/apps/vscode/src/services/error/ClineError.ts
+++ b/apps/vscode/src/services/error/ClineError.ts
@@ -159,14 +159,22 @@ export class ClineError extends Error {
 		// The organization-account variant gets separate copy because subscribing is not the right action.
 		const isEntitlementCode = code === "ENTITLEMENT_ERROR" || details?.code === "ENTITLEMENT_ERROR"
 		const entitlementText = `${message ?? ""} ${details?.message ?? ""}`.toLowerCase()
+		// Org variant. The raw backend phrase ("...individual model inference subscriptions") stays gated
+		// on the code to avoid false positives, but the user-facing message ("...ClinePass subscriptions")
+		// is specific enough to match on text alone — needed because the SDK rethrow strips the code.
 		if (
-			isEntitlementCode &&
-			(entitlementText.includes(ORG_CLINE_PASS_RESTRICTION_MESSAGE) ||
-				entitlementText.includes(ORG_CLINE_PASS_RESTRICTION_USER_MESSAGE))
+			(isEntitlementCode && entitlementText.includes(ORG_CLINE_PASS_RESTRICTION_MESSAGE)) ||
+			entitlementText.includes(ORG_CLINE_PASS_RESTRICTION_USER_MESSAGE)
 		) {
 			return ClineErrorType.OrgClinePassRestriction
 		}
-		if (isEntitlementCode && entitlementText.includes("not subscribed to required model plan")) {
+		// Personal ClinePass "not subscribed" errors. The SDK rethrows these as a plain Error and
+		// drops the backend ENTITLEMENT_ERROR code, so match on the user-facing message too (not just
+		// isEntitlementCode) to keep rendering the actionable "Get ClinePass" subscription card.
+		if (
+			(isEntitlementCode && entitlementText.includes("not subscribed to required model plan")) ||
+			entitlementText.includes("no access to clinepass subscription models")
+		) {
 			return ClineErrorType.Entitlement
 		}
 

--- a/apps/vscode/src/services/error/__tests__/ClineError.test.ts
+++ b/apps/vscode/src/services/error/__tests__/ClineError.test.ts
@@ -67,6 +67,25 @@ describe("ClineError", () => {
 			;(result !== ClineErrorType.Entitlement).should.be.true()
 		})
 
+		it("should classify the org ClinePass user message as OrgClinePassRestriction even when the code is stripped", () => {
+			// SDK rethrows the org error as a plain Error; only the user-facing message survives.
+			const err = new ClineError({
+				message:
+					"Organization accounts cannot use ClinePass subscriptions. Go to /account -> change account to switch to your personal account for ClinePass",
+			})
+			ClineError.getErrorType(err)!.should.equal(ClineErrorType.OrgClinePassRestriction)
+		})
+
+		it("should return Entitlement for the personal ClinePass not-subscribed message even when the code is stripped", () => {
+			// The SDK rethrows ClineNotSubscribedError as a plain Error (no ENTITLEMENT_ERROR code),
+			// surfacing only the user-facing promo message. The card must still render.
+			const err = new ClineError({
+				message:
+					"No access to ClinePass subscription models yet. Subscribe to ClinePass, the low cost open weights model coding plan: https://app.cline.bot/promo?code=CLI-100&personal=true",
+			})
+			ClineError.getErrorType(err)!.should.equal(ClineErrorType.Entitlement)
+		})
+
 		it("should not classify organization restriction text without ENTITLEMENT_ERROR as OrgClinePassRestriction", () => {
 			const err = new ClineError({
 				message: "Network error: organization accounts cannot use individual model inference subscriptions",

--- a/apps/vscode/webview-ui/src/components/chat/EntitlementError.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/EntitlementError.tsx
@@ -29,10 +29,43 @@ function buildSubscribeUrl(appBaseUrl?: string): string | undefined {
 	}
 }
 
+// The backend promo message embeds the canonical subscribe URL (with the discount code, e.g.
+// /promo?code=CLI-100). Prefer it, but only trust an http(s) URL on the same host as appBaseUrl.
+function extractSubscribeUrlFromMessage(message?: string, appBaseUrl?: string): string | undefined {
+	if (!message) {
+		return undefined
+	}
+	const match = message.match(/https?:\/\/\S+/)
+	if (!match) {
+		return undefined
+	}
+	try {
+		const candidate = new URL(match[0].replace(/[).,]+$/, ""))
+		if (candidate.protocol !== "https:" && candidate.protocol !== "http:") {
+			return undefined
+		}
+		if (appBaseUrl) {
+			const expectedHost = new URL(appBaseUrl).host
+			if (candidate.host !== expectedHost) {
+				return undefined
+			}
+		}
+		return candidate.toString()
+	} catch {
+		return undefined
+	}
+}
+
 const EntitlementError: React.FC<EntitlementErrorProps> = ({ message }) => {
 	const { clineUser } = useClineAuth()
-	const subscribeUrl = buildSubscribeUrl(clineUser?.appBaseUrl)
-	const backendDetail = message && message !== HEADLINE ? message : undefined
+	// Prefer the promo URL embedded in the backend message (carries the discount code); otherwise
+	// fall back to the constructed subscription URL.
+	const subscribeUrl =
+		extractSubscribeUrlFromMessage(message, clineUser?.appBaseUrl) ?? buildSubscribeUrl(clineUser?.appBaseUrl)
+	// Suppress the default "No access to ClinePass..." promo message: it duplicates this card's copy
+	// and the Get ClinePass button. Only surface a backend detail when it adds something new.
+	const isDefaultPromoMessage = message?.toLowerCase().includes("no access to clinepass subscription models")
+	const backendDetail = message && message !== HEADLINE && !isDefaultPromoMessage ? message : undefined
 
 	return (
 		<div className="p-2 border-none rounded-md mb-2 bg-(--vscode-textBlockQuote-background)">

--- a/apps/vscode/webview-ui/src/components/chat/EntitlementError.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/EntitlementError.tsx
@@ -29,10 +29,8 @@ function buildSubscribeUrl(appBaseUrl?: string): string | undefined {
 	}
 }
 
-// The backend promo message embeds the canonical subscribe URL (with the discount code, e.g.
-// /promo?code=CLI-100). Prefer it, but only trust an http(s) URL on the same host as appBaseUrl.
 function extractSubscribeUrlFromMessage(message?: string, appBaseUrl?: string): string | undefined {
-	if (!message) {
+	if (!message || !appBaseUrl) {
 		return undefined
 	}
 	const match = message.match(/https?:\/\/\S+/)
@@ -44,11 +42,9 @@ function extractSubscribeUrlFromMessage(message?: string, appBaseUrl?: string): 
 		if (candidate.protocol !== "https:" && candidate.protocol !== "http:") {
 			return undefined
 		}
-		if (appBaseUrl) {
-			const expectedHost = new URL(appBaseUrl).host
-			if (candidate.host !== expectedHost) {
-				return undefined
-			}
+		const expectedHost = new URL(appBaseUrl).host
+		if (candidate.host !== expectedHost) {
+			return undefined
 		}
 		return candidate.toString()
 	} catch {
@@ -58,12 +54,8 @@ function extractSubscribeUrlFromMessage(message?: string, appBaseUrl?: string): 
 
 const EntitlementError: React.FC<EntitlementErrorProps> = ({ message }) => {
 	const { clineUser } = useClineAuth()
-	// Prefer the promo URL embedded in the backend message (carries the discount code); otherwise
-	// fall back to the constructed subscription URL.
 	const subscribeUrl =
 		extractSubscribeUrlFromMessage(message, clineUser?.appBaseUrl) ?? buildSubscribeUrl(clineUser?.appBaseUrl)
-	// Suppress the default "No access to ClinePass..." promo message: it duplicates this card's copy
-	// and the Get ClinePass button. Only surface a backend detail when it adds something new.
 	const isDefaultPromoMessage = message?.toLowerCase().includes("no access to clinepass subscription models")
 	const backendDetail = message && message !== HEADLINE && !isDefaultPromoMessage ? message : undefined
 


### PR DESCRIPTION
## Summary

ClinePass 403 "not subscribed" errors stopped rendering the actionable subscription card and instead showed raw error text.

**Root cause:** the SDK's `handleClineResponseError` rethrows these 403s as a plain `Error` (`ClineNotSubscribedError` / `ClineOrgIndividualInferenceSubscriptionError`), which **drops the backend `ENTITLEMENT_ERROR` code** and surfaces only the user-facing message. The webview classifier (`ClineError.getErrorType`) required that code, so both the **personal** and **org** variants fell through to the generic error renderer.

<img width="347" height="887" alt="Screenshot 2026-06-24 at 6 19 19 PM" src="https://github.com/user-attachments/assets/8c5f862e-e92f-4b84-98f6-37e0e76891ee" />


## Changes

**`ClineError.ts` — classify by user-facing message when the code is stripped**
- Personal: `"no access to clinepass subscription models"` → `ClineErrorType.Entitlement`
- Org: `"organization accounts cannot use clinepass subscriptions"` → `ClineErrorType.OrgClinePassRestriction`
- The raw backend phrases (`"...required model plan"`, `"...individual model inference subscriptions"`) stay gated on `ENTITLEMENT_ERROR` to avoid false positives.

**`EntitlementError.tsx` — cleaner, correctly-linked card**
- Suppress the default "No access to ClinePass..." promo message as a `backendDetail` line (it duplicated the card copy + button).
- "Get ClinePass" now uses the promo URL embedded in the backend message (carries the discount code, e.g. `/promo?code=CLI-100&personal=true`), **validated to the same host as `appBaseUrl`**, falling back to the constructed `dashboard/subscription` URL.

**Tests** — added cases for the code-stripped personal and org messages.

## Result

- Personal (no subscription) → renders the **"This model requires a ClinePass subscription"** card with a **Get ClinePass** button that opens the promo/discount link.
- Org → renders the org-restriction card.
- No redundant promo paragraph.

## Test plan

```bash
cd apps/vscode
bun test src/services/error/__tests__/ClineError.test.ts   # 9 pass
```
Manually verified with a production-config VSIX: personal no-subscription account + a `cline-pass/*` model → card renders, button → promo URL.

## Notes

- Webview-only + error-classifier change; does not touch the SDK rethrow path (kept minimal/surgical).
- Org **card classification** is fixed here; the org card's "switch account" action itself was not modified.
