### PR TITLE
chore: Unbreak Linux TUI tests/createRequire conflict.

### DIFF
--- a/apps/cli/bun.mts
+++ b/apps/cli/bun.mts
@@ -3,6 +3,7 @@ import {
 	cpSync,
 	existsSync,
 	mkdirSync,
+	readFileSync,
 	readdirSync,
 	statSync,
 } from "node:fs";
@@ -21,6 +22,17 @@ const hubWebviewSourcePath = join(repoRoot, "apps/cline-hub/src/webview");
 const hubWebviewDistPath = join(repoRoot, "apps/cline-hub/dist/webview");
 const hubWebviewIndexPath = join(hubWebviewDistPath, "index.html");
 const cliHubWebviewDistPath = join(rootDir, "dist/cline-hub/webview");
+const SAP_PROVIDER_DIST_PATTERN =
+	/[\\/]@jerome-benoit[\\/]sap-ai-provider[\\/]dist[\\/].+\.js$/;
+
+function renameSapCreateRequireAlias(contents: string): string {
+	return contents
+		.replace(
+			/createRequire\s+as\s+__createRequire/g,
+			"createRequire as __clineSapCreateRequire",
+		)
+		.replace(/\b__createRequire\(/g, "__clineSapCreateRequire(");
+}
 
 function newestFileMtimeMs(dir: string): number {
 	let newest = 0;
@@ -121,13 +133,28 @@ const result = await Bun.build({
 	},
 	env: "OTEL_*",
 	banner:
-		'import { createRequire as __createRequire } from "node:module"; const require = __createRequire(import.meta.url);',
+		'import { createRequire as __clineCliCreateRequire } from "node:module"; const require = __clineCliCreateRequire(import.meta.url);',
+	plugins: [
+		{
+			name: "rename-sap-create-require-alias",
+			setup(build) {
+				build.onLoad({ filter: SAP_PROVIDER_DIST_PATTERN }, async (args) => ({
+					contents: renameSapCreateRequireAlias(readFileSync(args.path, "utf8")),
+					loader: "js",
+				}));
+			},
+		},
+	],
 });
 
 if (result.logs.length > 0) {
 	for (const log of result.logs) {
 		console.warn(log);
 	}
+}
+
+if (!result.success) {
+	process.exit(1);
 }
 
 const coreBootstrapPath = join(


### PR DESCRIPTION
### Description

sdk-test is failing in CI on Ubuntu with `SyntaxError: Cannot declare
an imported binding name twice: '__createRequire'.`

Example jobs:
- https://github.com/cline/cline/actions/runs/28141308493/job/83339292497?pr=10651
- https://github.com/cline/cline/actions/runs/28139071478/job/83332429436

This is a three-way collision between the CLI bundle, SAP AI package
(used by @cline/llms), and bun's generated binding with the same
name. When we concatenate these, each has a `__createRequire` binding.

Fixes the naming collision by renaming the CLI's import and using bun
to rename SAP AI's binding.

### Test Procedure

```
bun -F @cline/cli test:e2e:cli:tui
```

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
