### PR TITLE
vscode(ENG-2203): Migrate legacy MCP files, formats to shared settings file.

### DIFF
--- a/apps/vscode/src/core/storage/__tests__/syncRemoteMcpServers.test.ts
+++ b/apps/vscode/src/core/storage/__tests__/syncRemoteMcpServers.test.ts
@@ -1,20 +1,9 @@
-import { afterEach, beforeEach, describe, it, mock } from "bun:test"
+import { afterEach, beforeEach, describe, it } from "bun:test"
 import "should"
-import * as actualDiskModule from "@core/storage/disk"
 import fs from "fs/promises"
 import os from "os"
 import path from "path"
 import sinon from "sinon"
-
-// bun loads real ESM, so sinon cannot stub the `@core/storage/disk` namespace
-// export ("ES Modules cannot be stubbed"). Inject a module-level sinon stub for
-// `getMcpSettingsFilePath` via mock.module so the full sinon stub API keeps
-// working. Register both the alias form and the relative form the SUT uses.
-const getMcpSettingsFilePathStub: sinon.SinonStub = sinon.stub()
-const diskMock = () => ({ ...actualDiskModule, getMcpSettingsFilePath: getMcpSettingsFilePathStub })
-mock.module("@core/storage/disk", diskMock)
-mock.module("@/core/storage/disk", diskMock)
-mock.module("../../disk", diskMock)
 
 import { syncRemoteMcpServersToSettings } from "../remote-config/syncRemoteMcpServers"
 
@@ -29,20 +18,11 @@ describe("syncRemoteMcpServersToSettings", () => {
 		await fs.mkdir(tempDir, { recursive: true })
 		settingsPath = path.join(tempDir, "cline_mcp_settings.json")
 
-		getMcpSettingsFilePathStub.reset()
-		getMcpSettingsFilePathStub.callsFake(async () => {
-			try {
-				await fs.access(settingsPath)
-			} catch {
-				await fs.writeFile(settingsPath, JSON.stringify({ mcpServers: {} }, null, 2))
-			}
-			return settingsPath
-		})
+		await fs.writeFile(settingsPath, JSON.stringify({ mcpServers: {} }, null, 2))
 	})
 
 	afterEach(async () => {
 		sandbox.restore()
-		getMcpSettingsFilePathStub.reset()
 		try {
 			await fs.rm(tempDir, { recursive: true, force: true })
 		} catch {
@@ -61,7 +41,7 @@ describe("syncRemoteMcpServersToSettings", () => {
 
 	describe("adding remote servers", () => {
 		it("should add a new remote server with remoteConfigured marker", async () => {
-			await syncRemoteMcpServersToSettings([{ name: "test-server", url: "https://example.com/mcp" }], tempDir)
+			await syncRemoteMcpServersToSettings([{ name: "test-server", url: "https://example.com/mcp" }], settingsPath)
 
 			const result = await readSettings()
 			result.mcpServers["test-server"].should.have.property("url", "https://example.com/mcp")
@@ -80,9 +60,32 @@ describe("syncRemoteMcpServersToSettings", () => {
 				},
 			})
 
-			await syncRemoteMcpServersToSettings([{ name: "test-server", url: "https://example.com/mcp" }], tempDir)
+			await syncRemoteMcpServersToSettings([{ name: "test-server", url: "https://example.com/mcp" }], settingsPath)
 
 			const result = await readSettings()
+			result.mcpServers["test-server"].disabled.should.equal(true)
+			result.mcpServers["test-server"].autoApprove.should.deepEqual(["some-tool"])
+			result.mcpServers["test-server"].remoteConfigured.should.equal(true)
+		})
+
+		it("should preserve nested transport remote server settings when matching remote config", async () => {
+			await writeSettings({
+				"test-server": {
+					transport: { type: "streamableHttp", url: "https://example.com/mcp" },
+					disabled: true,
+					autoApprove: ["some-tool"],
+					remoteConfigured: true,
+				},
+			})
+
+			await syncRemoteMcpServersToSettings([{ name: "test-server", url: "https://example.com/mcp" }], settingsPath)
+
+			const result = await readSettings()
+			result.mcpServers["test-server"].transport.should.deepEqual({
+				type: "streamableHttp",
+				url: "https://example.com/mcp",
+			})
+			result.mcpServers["test-server"].url.should.equal("https://example.com/mcp")
 			result.mcpServers["test-server"].disabled.should.equal(true)
 			result.mcpServers["test-server"].autoApprove.should.deepEqual(["some-tool"])
 			result.mcpServers["test-server"].remoteConfigured.should.equal(true)
@@ -96,7 +99,7 @@ describe("syncRemoteMcpServersToSettings", () => {
 					{ name: "server-a", url: "https://a.example.com" },
 					{ name: "server-b", url: "https://b.example.com" },
 				],
-				tempDir,
+				settingsPath,
 			)
 
 			const result = await readSettings()
@@ -114,7 +117,7 @@ describe("syncRemoteMcpServersToSettings", () => {
 				},
 			})
 
-			await syncRemoteMcpServersToSettings([{ name: "remote-server", url: "https://example.com" }], tempDir)
+			await syncRemoteMcpServersToSettings([{ name: "remote-server", url: "https://example.com" }], settingsPath)
 
 			const result = await readSettings()
 			result.mcpServers.should.have.property("local-server")
@@ -133,10 +136,29 @@ describe("syncRemoteMcpServersToSettings", () => {
 				},
 			})
 
-			await syncRemoteMcpServersToSettings([], tempDir)
+			await syncRemoteMcpServersToSettings([], settingsPath)
 
 			const result = await readSettings()
 			result.mcpServers.should.not.have.property("old-server")
+		})
+
+		it("should not remove nested transport remote server when URL still matches remote config", async () => {
+			await writeSettings({
+				"keep-server": {
+					transport: { type: "streamableHttp", url: "https://keep.example.com" },
+					remoteConfigured: true,
+					disabled: true,
+					autoApprove: ["tool-a"],
+				},
+			})
+
+			await syncRemoteMcpServersToSettings([{ name: "keep-server", url: "https://keep.example.com" }], settingsPath)
+
+			const result = await readSettings()
+			result.mcpServers.should.have.property("keep-server")
+			result.mcpServers["keep-server"].transport.url.should.equal("https://keep.example.com")
+			result.mcpServers["keep-server"].disabled.should.equal(true)
+			result.mcpServers["keep-server"].autoApprove.should.deepEqual(["tool-a"])
 		})
 
 		it("should NOT remove a server without remoteConfigured marker", async () => {
@@ -147,7 +169,7 @@ describe("syncRemoteMcpServersToSettings", () => {
 				},
 			})
 
-			await syncRemoteMcpServersToSettings([], tempDir)
+			await syncRemoteMcpServersToSettings([], settingsPath)
 
 			const result = await readSettings()
 			result.mcpServers.should.have.property("user-server")
@@ -167,7 +189,7 @@ describe("syncRemoteMcpServersToSettings", () => {
 				},
 			})
 
-			await syncRemoteMcpServersToSettings([{ name: "keep-server", url: "https://keep.example.com" }], tempDir)
+			await syncRemoteMcpServersToSettings([{ name: "keep-server", url: "https://keep.example.com" }], settingsPath)
 
 			const result = await readSettings()
 			result.mcpServers.should.have.property("keep-server")
@@ -181,7 +203,7 @@ describe("syncRemoteMcpServersToSettings", () => {
 				"local-server": { command: "node", type: "stdio" },
 			})
 
-			await syncRemoteMcpServersToSettings([], tempDir)
+			await syncRemoteMcpServersToSettings([], settingsPath)
 
 			const result = await readSettings()
 			result.mcpServers.should.not.have.property("server-a")
@@ -200,7 +222,7 @@ describe("syncRemoteMcpServersToSettings", () => {
 				},
 			})
 
-			await syncRemoteMcpServersToSettings([{ name: "legacy-server", url: "https://legacy.example.com" }], tempDir)
+			await syncRemoteMcpServersToSettings([{ name: "legacy-server", url: "https://legacy.example.com" }], settingsPath)
 
 			const result = await readSettings()
 			result.mcpServers["legacy-server"].remoteConfigured.should.equal(true)
@@ -211,7 +233,7 @@ describe("syncRemoteMcpServersToSettings", () => {
 		it("should handle empty settings file with no mcpServers key", async () => {
 			await fs.writeFile(settingsPath, JSON.stringify({}, null, 2))
 
-			await syncRemoteMcpServersToSettings([{ name: "new-server", url: "https://new.example.com" }], tempDir)
+			await syncRemoteMcpServersToSettings([{ name: "new-server", url: "https://new.example.com" }], settingsPath)
 
 			const result = await readSettings()
 			result.mcpServers["new-server"].url.should.equal("https://new.example.com")
@@ -227,7 +249,7 @@ describe("syncRemoteMcpServersToSettings", () => {
 				},
 			})
 
-			await syncRemoteMcpServersToSettings([{ name: "my-server", url: "https://new-url.example.com" }], tempDir)
+			await syncRemoteMcpServersToSettings([{ name: "my-server", url: "https://new-url.example.com" }], settingsPath)
 
 			const result = await readSettings()
 			result.mcpServers["my-server"].url.should.equal("https://new-url.example.com")
@@ -241,7 +263,7 @@ describe("syncRemoteMcpServersToSettings", () => {
 				recordSettingsFingerprint: sandbox.stub(),
 			}
 
-			await syncRemoteMcpServersToSettings([{ name: "test", url: "https://test.com" }], tempDir, mockMcpHub as any)
+			await syncRemoteMcpServersToSettings([{ name: "test", url: "https://test.com" }], settingsPath, mockMcpHub as any)
 
 			mockMcpHub.recordSettingsFingerprint.calledOnce.should.be.true()
 			const result = await readSettings()

--- a/apps/vscode/src/core/storage/disk.ts
+++ b/apps/vscode/src/core/storage/disk.ts
@@ -1,6 +1,5 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import { TaskMetadata } from "@core/context/context-tracking/ContextTrackerTypes"
-import { execa } from "@packages/execa"
 import { RemoteConfig } from "@shared/remote-config/schema"
 import { GlobalState, Settings } from "@shared/storage/state-keys"
 import { fileExistsAtPath, isDirectory } from "@utils/fs"
@@ -9,7 +8,10 @@ import os from "os"
 import * as path from "path"
 import { HostProvider } from "@/hosts/host-provider"
 import { Logger } from "@/shared/services/Logger"
+import { getDocumentsPath } from "./documents-path"
 import { StateManager } from "./StateManager"
+
+export { getDocumentsPath } from "./documents-path"
 
 export { getSkillsDirectoriesForScan, type SkillsScanDirectory } from "./skill-directories"
 
@@ -37,42 +39,6 @@ export const GlobalFileNames = {
 	agentsRulesFile: "AGENTS.md",
 	taskMetadata: "task_metadata.json",
 	remoteConfig: (orgId: string) => `remote_config_${orgId}.json`,
-}
-
-export async function getDocumentsPath(): Promise<string> {
-	if (process.platform === "win32") {
-		try {
-			const { stdout: docsPath } = await execa("powershell", [
-				"-NoProfile", // Ignore user's PowerShell profile(s)
-				"-Command",
-				"[System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::MyDocuments)",
-			])
-			const trimmedPath = docsPath.trim()
-			if (trimmedPath) {
-				return trimmedPath
-			}
-		} catch (_err) {
-			Logger.error("Failed to retrieve Windows Documents path. Falling back to homedir/Documents.")
-		}
-	} else if (process.platform === "linux") {
-		try {
-			// First check if xdg-user-dir exists
-			await execa("which", ["xdg-user-dir"])
-
-			// If it exists, try to get XDG documents path
-			const { stdout } = await execa("xdg-user-dir", ["DOCUMENTS"])
-			const trimmedPath = stdout.trim()
-			if (trimmedPath) {
-				return trimmedPath
-			}
-		} catch {
-			// Log error but continue to fallback
-			Logger.error("Failed to retrieve XDG Documents path. Falling back to homedir/Documents.")
-		}
-	}
-
-	// Default fallback for all platforms
-	return path.join(os.homedir(), "Documents")
 }
 
 /**

--- a/apps/vscode/src/core/storage/documents-path.ts
+++ b/apps/vscode/src/core/storage/documents-path.ts
@@ -1,0 +1,40 @@
+import { execa } from "@packages/execa"
+import os from "os"
+import * as path from "path"
+import { Logger } from "@/shared/services/Logger"
+
+export async function getDocumentsPath(): Promise<string> {
+	if (process.platform === "win32") {
+		try {
+			const { stdout: docsPath } = await execa("powershell", [
+				"-NoProfile", // Ignore user's PowerShell profile(s)
+				"-Command",
+				"[System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::MyDocuments)",
+			])
+			const trimmedPath = docsPath.trim()
+			if (trimmedPath) {
+				return trimmedPath
+			}
+		} catch (_err) {
+			Logger.error("Failed to retrieve Windows Documents path. Falling back to homedir/Documents.")
+		}
+	} else if (process.platform === "linux") {
+		try {
+			// First check if xdg-user-dir exists
+			await execa("which", ["xdg-user-dir"])
+
+			// If it exists, try to get XDG documents path
+			const { stdout } = await execa("xdg-user-dir", ["DOCUMENTS"])
+			const trimmedPath = stdout.trim()
+			if (trimmedPath) {
+				return trimmedPath
+			}
+		} catch {
+			// Log error but continue to fallback
+			Logger.error("Failed to retrieve XDG Documents path. Falling back to homedir/Documents.")
+		}
+	}
+
+	// Default fallback for all platforms
+	return path.join(os.homedir(), "Documents")
+}

--- a/apps/vscode/src/core/storage/remote-config/syncRemoteMcpServers.ts
+++ b/apps/vscode/src/core/storage/remote-config/syncRemoteMcpServers.ts
@@ -1,8 +1,22 @@
-import { getMcpSettingsFilePath } from "@core/storage/disk"
 import { RemoteMCPServer } from "@shared/remote-config/schema"
-import type { McpHub } from "@/services/mcp/McpHub"
 import { updateMcpSettingsFile } from "@/services/mcp/settingsLock"
 import { Logger } from "@/shared/services/Logger"
+
+type McpSettingsFingerprintRecorder = {
+	recordSettingsFingerprint(servers: Record<string, unknown>): void
+}
+
+function getConfiguredServerUrl(server: Record<string, unknown>): string | undefined {
+	if (typeof server.url === "string") {
+		return server.url
+	}
+	const transport = server.transport
+	if (transport && typeof transport === "object" && !Array.isArray(transport)) {
+		const url = (transport as Record<string, unknown>).url
+		return typeof url === "string" ? url : undefined
+	}
+	return undefined
+}
 
 /**
  * Synchronizes remote MCP servers from remote config to the local MCP settings file
@@ -18,18 +32,15 @@ import { Logger } from "@/shared/services/Logger"
  * - Preventing duplicates when re-adding servers
  *
  * @param remoteMCPServers Array of remote MCP servers from remote config
- * @param settingsDirectoryPath Path to the settings directory
+ * @param settingsPath Path to the MCP settings file
  * @param mcpHub Optional McpHub instance to set flag preventing watcher triggers
  */
 export async function syncRemoteMcpServersToSettings(
 	remoteMCPServers: RemoteMCPServer[],
-	settingsDirectoryPath: string,
-	mcpHub?: McpHub,
+	settingsPath: string,
+	mcpHub?: McpSettingsFingerprintRecorder,
 ): Promise<void> {
 	try {
-		// Get or create the MCP settings file
-		const settingsPath = await getMcpSettingsFilePath(settingsDirectoryPath)
-
 		// Hold the cross-process lock across the whole read-modify-write so a
 		// concurrent writer (CLI, another window, an OAuth handshake) cannot drop
 		// this sync's changes from a stale snapshot. Only writers need the lock;
@@ -44,8 +55,9 @@ export async function syncRemoteMcpServersToSettings(
 			for (const [serverName, serverConfig] of Object.entries(servers)) {
 				const server = serverConfig as Record<string, unknown>
 				if (server.remoteConfigured === true) {
+					const configuredUrl = getConfiguredServerUrl(server)
 					const stillInRemoteConfig = remoteMCPServers.some(
-						(remoteServer) => remoteServer.name === serverName && remoteServer.url === server.url,
+						(remoteServer) => remoteServer.name === serverName && remoteServer.url === configuredUrl,
 					)
 					if (!stillInRemoteConfig) {
 						delete servers[serverName]
@@ -57,9 +69,15 @@ export async function syncRemoteMcpServersToSettings(
 			for (const server of remoteMCPServers) {
 				// Check if server with same name and URL already exists to skip duplicates
 				const existingServer = servers[server.name]
-				if (existingServer && existingServer.url === server.url) {
+				if (existingServer && getConfiguredServerUrl(existingServer) === server.url) {
 					if (!existingServer.remoteConfigured) {
 						existingServer.remoteConfigured = true
+					}
+					// Keep the historical top-level URL field for remote-configured
+					// servers so older sync/UI code can identify the managed server
+					// without needing to understand nested SDK transport shape.
+					if (!existingServer.url) {
+						existingServer.url = server.url
 					}
 					continue
 				}

--- a/apps/vscode/src/core/storage/remote-config/utils.ts
+++ b/apps/vscode/src/core/storage/remote-config/utils.ts
@@ -1,5 +1,4 @@
 import { synchronizeRemoteRuleToggles } from "@core/context/instructions/user-instructions/rule-helpers"
-import path from "node:path"
 import { parseRemoteSkillEntries } from "@core/context/instructions/user-instructions/skills"
 import type { RemoteConfig, S3AccessKeySettings } from "@shared/remote-config/schema"
 import { ConfiguredAPIKeys, GlobalStateAndSettings, RemoteConfigFields } from "@shared/storage/state-keys"
@@ -374,8 +373,7 @@ export async function applyRemoteConfig(
 	try {
 		const serversToSync = remoteConfig.remoteMCPServers ?? []
 		const settingsPath = await mcpHub.getMcpSettingsFilePath()
-		const settingsDirectoryPath = path.dirname(settingsPath)
-		await syncRemoteMcpServersToSettings(serversToSync, settingsDirectoryPath, mcpHub)
+		await syncRemoteMcpServersToSettings(serversToSync, settingsPath, mcpHub)
 		stateManager.setRemoteConfigField("previousRemoteMCPServers", serversToSync)
 	} catch (error) {
 		Logger.error("[RemoteConfig] Failed to sync remote MCP servers to settings:", error)

--- a/apps/vscode/src/core/storage/remote-config/utils.ts
+++ b/apps/vscode/src/core/storage/remote-config/utils.ts
@@ -1,4 +1,5 @@
 import { synchronizeRemoteRuleToggles } from "@core/context/instructions/user-instructions/rule-helpers"
+import path from "node:path"
 import { parseRemoteSkillEntries } from "@core/context/instructions/user-instructions/skills"
 import type { RemoteConfig, S3AccessKeySettings } from "@shared/remote-config/schema"
 import { ConfiguredAPIKeys, GlobalStateAndSettings, RemoteConfigFields } from "@shared/storage/state-keys"
@@ -14,7 +15,6 @@ import { isOpenTelemetryConfigValid, remoteConfigToOtelConfig } from "@/shared/s
 import { Logger } from "@/shared/services/Logger"
 import { syncWorker } from "@/shared/services/worker/sync"
 import { BlobStoreSettings } from "@/shared/storage"
-import { ensureSettingsDirectoryExists } from "../disk"
 import { StateManager } from "../StateManager"
 import { syncRemoteMcpServersToSettings } from "./syncRemoteMcpServers"
 
@@ -373,8 +373,9 @@ export async function applyRemoteConfig(
 	// - No dependency on in-memory state that would be lost across restarts
 	try {
 		const serversToSync = remoteConfig.remoteMCPServers ?? []
-		const settingsPath = await ensureSettingsDirectoryExists()
-		await syncRemoteMcpServersToSettings(serversToSync, settingsPath, mcpHub)
+		const settingsPath = await mcpHub.getMcpSettingsFilePath()
+		const settingsDirectoryPath = path.dirname(settingsPath)
+		await syncRemoteMcpServersToSettings(serversToSync, settingsDirectoryPath, mcpHub)
 		stateManager.setRemoteConfigField("previousRemoteMCPServers", serversToSync)
 	} catch (error) {
 		Logger.error("[RemoteConfig] Failed to sync remote MCP servers to settings:", error)

--- a/apps/vscode/src/hosts/vscode/__tests__/vscode-to-file-migration.test.ts
+++ b/apps/vscode/src/hosts/vscode/__tests__/vscode-to-file-migration.test.ts
@@ -77,11 +77,14 @@ describe("vscode-to-file-migration", () => {
 	let sandbox: sinon.SinonSandbox
 	let tempDir: string
 	let storageContext: StorageContext
+	let originalMcpSettingsPath: string | undefined
 
 	beforeEach(() => {
 		sandbox = sinon.createSandbox()
+		originalMcpSettingsPath = process.env.CLINE_MCP_SETTINGS_PATH
 		tempDir = path.join(os.tmpdir(), `migration-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
 		fs.mkdirSync(tempDir, { recursive: true })
+		process.env.CLINE_MCP_SETTINGS_PATH = path.join(tempDir, "runtime-mcp-settings", "cline_mcp_settings.json")
 
 		storageContext = createStorageContext({
 			clineDir: tempDir,
@@ -91,6 +94,11 @@ describe("vscode-to-file-migration", () => {
 
 	afterEach(() => {
 		sandbox.restore()
+		if (originalMcpSettingsPath === undefined) {
+			delete process.env.CLINE_MCP_SETTINGS_PATH
+		} else {
+			process.env.CLINE_MCP_SETTINGS_PATH = originalMcpSettingsPath
+		}
 		try {
 			fs.rmSync(tempDir, { recursive: true, force: true })
 		} catch {
@@ -289,19 +297,42 @@ describe("vscode-to-file-migration", () => {
 	})
 
 	describe("legacy MCP settings migration", () => {
-		function readSharedMcpSettings() {
-			return JSON.parse(fs.readFileSync(path.join(storageContext.dataDir, "settings", "cline_mcp_settings.json"), "utf8"))
+		function sharedMcpSettingsPath() {
+			return process.env.CLINE_MCP_SETTINGS_PATH!
 		}
+
+		function readSharedMcpSettings() {
+			return JSON.parse(fs.readFileSync(sharedMcpSettingsPath(), "utf8"))
+		}
+
+		it("writes to the runtime MCP settings resolver path rather than storage.dataDir", async () => {
+			const mockCtx = createMockVSCodeContext()
+			const extensionStorage = path.join(tempDir, "vscode-global-storage")
+			mockCtx.globalStorageUri.fsPath = extensionStorage
+			fs.mkdirSync(path.join(extensionStorage, "settings"), { recursive: true })
+			fs.writeFileSync(
+				path.join(extensionStorage, "settings", "cline_mcp_settings.json"),
+				JSON.stringify({ mcpServers: { overrideTarget: { command: "node" } } }),
+			)
+
+			const result = await exportVSCodeStorageToSharedFiles(mockCtx as any, storageContext, {
+				documentsDir: path.join(tempDir, "Documents"),
+			})
+
+			result.mcpServersAdded.should.equal(1)
+			fs.existsSync(sharedMcpSettingsPath()).should.be.true()
+			fs.existsSync(path.join(storageContext.dataDir, "settings", "cline_mcp_settings.json")).should.be.false()
+			readSharedMcpSettings().mcpServers.overrideTarget.should.deepEqual({
+				transport: { type: "stdio", command: "node" },
+			})
+		})
 
 		it("skips a legacy source that resolves to the shared MCP settings file", async () => {
 			const mockCtx = createMockVSCodeContext()
-			mockCtx.globalStorageUri.fsPath = storageContext.dataDir
-			const sharedSettingsDir = path.join(storageContext.dataDir, "settings")
+			const sharedSettingsDir = path.dirname(sharedMcpSettingsPath())
 			fs.mkdirSync(sharedSettingsDir, { recursive: true })
-			fs.writeFileSync(
-				path.join(sharedSettingsDir, "cline_mcp_settings.json"),
-				JSON.stringify({ mcpServers: { alreadyShared: { command: "node" } } }),
-			)
+			mockCtx.globalStorageUri.fsPath = path.dirname(sharedSettingsDir)
+			fs.writeFileSync(sharedMcpSettingsPath(), JSON.stringify({ mcpServers: { alreadyShared: { command: "node" } } }))
 
 			const result = await exportVSCodeStorageToSharedFiles(mockCtx as any, storageContext, {
 				documentsDir: path.join(tempDir, "Documents"),
@@ -324,7 +355,7 @@ describe("vscode-to-file-migration", () => {
 				JSON.stringify({ mcpServers: { lockedServer: { command: "node" } } }),
 			)
 
-			const sharedSettingsPath = path.join(storageContext.dataDir, "settings", "cline_mcp_settings.json")
+			const sharedSettingsPath = sharedMcpSettingsPath()
 			const lockDir = `${sharedSettingsPath}.lock`
 			fs.mkdirSync(lockDir, { recursive: true })
 			fs.writeFileSync(path.join(lockDir, "owner.test"), "test")
@@ -370,10 +401,10 @@ describe("vscode-to-file-migration", () => {
 				}),
 			)
 
-			const sharedSettingsDir = path.join(storageContext.dataDir, "settings")
+			const sharedSettingsDir = path.dirname(sharedMcpSettingsPath())
 			fs.mkdirSync(sharedSettingsDir, { recursive: true })
 			fs.writeFileSync(
-				path.join(sharedSettingsDir, "cline_mcp_settings.json"),
+				sharedMcpSettingsPath(),
 				JSON.stringify({
 					mcpServers: {
 						existing: {
@@ -401,6 +432,39 @@ describe("vscode-to-file-migration", () => {
 			settings.mcpServers.docsServer.should.deepEqual({
 				transport: { type: "sse", url: "https://example.com/sse" },
 				autoApprove: ["search"],
+			})
+		})
+
+		it("preserves top-level URL for migrated remote-configured URL servers", async () => {
+			const mockCtx = createMockVSCodeContext()
+			const extensionStorage = path.join(tempDir, "vscode-global-storage")
+			mockCtx.globalStorageUri.fsPath = extensionStorage
+			fs.mkdirSync(path.join(extensionStorage, "settings"), { recursive: true })
+			fs.writeFileSync(
+				path.join(extensionStorage, "settings", "cline_mcp_settings.json"),
+				JSON.stringify({
+					mcpServers: {
+						managed: {
+							url: "https://managed.example.com/mcp",
+							type: "streamableHttp",
+							remoteConfigured: true,
+							disabled: true,
+							autoApprove: ["tool-a"],
+						},
+					},
+				}),
+			)
+
+			await exportVSCodeStorageToSharedFiles(mockCtx as any, storageContext, {
+				documentsDir: path.join(tempDir, "Documents"),
+			})
+
+			readSharedMcpSettings().mcpServers.managed.should.deepEqual({
+				transport: { type: "streamableHttp", url: "https://managed.example.com/mcp" },
+				disabled: true,
+				autoApprove: ["tool-a"],
+				remoteConfigured: true,
+				url: "https://managed.example.com/mcp",
 			})
 		})
 
@@ -477,7 +541,7 @@ describe("vscode-to-file-migration", () => {
 			await exportVSCodeStorageToSharedFiles(mockCtx as any, storageContext, {
 				documentsDir: path.join(tempDir, "Documents"),
 			} as any)
-			const settingsPath = path.join(storageContext.dataDir, "settings", "cline_mcp_settings.json")
+			const settingsPath = sharedMcpSettingsPath()
 			fs.writeFileSync(settingsPath, JSON.stringify({ mcpServers: {} }))
 
 			const second = await exportVSCodeStorageToSharedFiles(mockCtx as any, storageContext, {

--- a/apps/vscode/src/hosts/vscode/__tests__/vscode-to-file-migration.test.ts
+++ b/apps/vscode/src/hosts/vscode/__tests__/vscode-to-file-migration.test.ts
@@ -135,9 +135,7 @@ describe("vscode-to-file-migration", () => {
 				JSON.stringify({ mcpServers: { fromV1: { command: "node" } } }),
 			)
 
-			const result = await exportVSCodeStorageToSharedFiles(mockCtx as any, storageContext, {
-				documentsDir: path.join(tempDir, "Documents"),
-			})
+			const result = await exportVSCodeStorageToSharedFiles(mockCtx as any, storageContext)
 
 			result.migrated.should.be.true()
 			result.globalStateCount.should.equal(0)
@@ -315,9 +313,7 @@ describe("vscode-to-file-migration", () => {
 				JSON.stringify({ mcpServers: { overrideTarget: { command: "node" } } }),
 			)
 
-			const result = await exportVSCodeStorageToSharedFiles(mockCtx as any, storageContext, {
-				documentsDir: path.join(tempDir, "Documents"),
-			})
+			const result = await exportVSCodeStorageToSharedFiles(mockCtx as any, storageContext)
 
 			result.mcpServersAdded.should.equal(1)
 			fs.existsSync(sharedMcpSettingsPath()).should.be.true()
@@ -334,9 +330,7 @@ describe("vscode-to-file-migration", () => {
 			mockCtx.globalStorageUri.fsPath = path.dirname(sharedSettingsDir)
 			fs.writeFileSync(sharedMcpSettingsPath(), JSON.stringify({ mcpServers: { alreadyShared: { command: "node" } } }))
 
-			const result = await exportVSCodeStorageToSharedFiles(mockCtx as any, storageContext, {
-				documentsDir: path.join(tempDir, "Documents"),
-			})
+			const result = await exportVSCodeStorageToSharedFiles(mockCtx as any, storageContext)
 
 			result.mcpServersAdded.should.equal(0)
 			const tombstone = storageContext.globalState.get("__vscodeLegacyMcpSettingsMigration") as any
@@ -362,9 +356,7 @@ describe("vscode-to-file-migration", () => {
 			const freshMtime = new Date()
 			fs.utimesSync(lockDir, freshMtime, freshMtime)
 
-			const migration = exportVSCodeStorageToSharedFiles(mockCtx as any, storageContext, {
-				documentsDir: path.join(tempDir, "Documents"),
-			})
+			const migration = exportVSCodeStorageToSharedFiles(mockCtx as any, storageContext)
 			await new Promise((resolve) => setTimeout(resolve, 75))
 			;(fs.existsSync(sharedSettingsPath) === false).should.be.true()
 			fs.rmSync(lockDir, { recursive: true, force: true })
@@ -375,7 +367,7 @@ describe("vscode-to-file-migration", () => {
 			settings.mcpServers.lockedServer.should.deepEqual({ transport: { type: "stdio", command: "node" } })
 		})
 
-		it("merges missing legacy MCP servers from VSCode globalStorage and Documents without overwriting shared settings", async () => {
+		it("merges missing legacy MCP servers from VSCode globalStorage without overwriting shared settings", async () => {
 			const mockCtx = createMockVSCodeContext()
 			const extensionStorage = path.join(tempDir, "vscode-global-storage")
 			mockCtx.globalStorageUri.fsPath = extensionStorage
@@ -391,15 +383,6 @@ describe("vscode-to-file-migration", () => {
 				}),
 			)
 
-			fs.mkdirSync(path.join(tempDir, "Documents", "Cline", "MCP"), { recursive: true })
-			fs.writeFileSync(
-				path.join(tempDir, "Documents", "Cline", "MCP", "cline_mcp_settings.json"),
-				JSON.stringify({
-					mcpServers: {
-						docsServer: { url: "https://example.com/sse", autoApprove: ["search"] },
-					},
-				}),
-			)
 
 			const sharedSettingsDir = path.dirname(sharedMcpSettingsPath())
 			fs.mkdirSync(sharedSettingsDir, { recursive: true })
@@ -415,11 +398,9 @@ describe("vscode-to-file-migration", () => {
 				}),
 			)
 
-			const result = await exportVSCodeStorageToSharedFiles(mockCtx as any, storageContext, {
-				documentsDir: path.join(tempDir, "Documents"),
-			} as any)
+			const result = await exportVSCodeStorageToSharedFiles(mockCtx as any, storageContext)
 
-			result.mcpServersAdded.should.equal(2)
+			result.mcpServersAdded.should.equal(1)
 			result.mcpServersSkippedExisting.should.equal(1)
 			const settings = readSharedMcpSettings()
 			settings.mcpServers.existing.should.deepEqual({
@@ -428,10 +409,6 @@ describe("vscode-to-file-migration", () => {
 			})
 			settings.mcpServers.stdioLegacy.should.deepEqual({
 				transport: { type: "stdio", command: "node", args: ["server.js"], env: { API_KEY: "abc" } },
-			})
-			settings.mcpServers.docsServer.should.deepEqual({
-				transport: { type: "sse", url: "https://example.com/sse" },
-				autoApprove: ["search"],
 			})
 		})
 
@@ -455,9 +432,7 @@ describe("vscode-to-file-migration", () => {
 				}),
 			)
 
-			await exportVSCodeStorageToSharedFiles(mockCtx as any, storageContext, {
-				documentsDir: path.join(tempDir, "Documents"),
-			})
+			await exportVSCodeStorageToSharedFiles(mockCtx as any, storageContext)
 
 			readSharedMcpSettings().mcpServers.managed.should.deepEqual({
 				transport: { type: "streamableHttp", url: "https://managed.example.com/mcp" },
@@ -504,9 +479,7 @@ describe("vscode-to-file-migration", () => {
 				}),
 			)
 
-			const result = await exportVSCodeStorageToSharedFiles(mockCtx as any, storageContext, {
-				documentsDir: path.join(tempDir, "Documents"),
-			} as any)
+			const result = await exportVSCodeStorageToSharedFiles(mockCtx as any, storageContext)
 
 			result.mcpServersAdded.should.equal(1)
 			const settings = readSharedMcpSettings()
@@ -538,15 +511,11 @@ describe("vscode-to-file-migration", () => {
 				JSON.stringify({ mcpServers: { oneShot: { command: "node" } } }),
 			)
 
-			await exportVSCodeStorageToSharedFiles(mockCtx as any, storageContext, {
-				documentsDir: path.join(tempDir, "Documents"),
-			} as any)
+			await exportVSCodeStorageToSharedFiles(mockCtx as any, storageContext)
 			const settingsPath = sharedMcpSettingsPath()
 			fs.writeFileSync(settingsPath, JSON.stringify({ mcpServers: {} }))
 
-			const second = await exportVSCodeStorageToSharedFiles(mockCtx as any, storageContext, {
-				documentsDir: path.join(tempDir, "Documents"),
-			} as any)
+			const second = await exportVSCodeStorageToSharedFiles(mockCtx as any, storageContext)
 
 			second.mcpServersAdded.should.equal(0)
 			const settings = readSharedMcpSettings()

--- a/apps/vscode/src/hosts/vscode/__tests__/vscode-to-file-migration.test.ts
+++ b/apps/vscode/src/hosts/vscode/__tests__/vscode-to-file-migration.test.ts
@@ -6,6 +6,7 @@ import fs from "fs"
 import os from "os"
 import path from "path"
 import sinon from "sinon"
+import { getServerAuthHash } from "@/utils/mcpAuth"
 import { exportVSCodeStorageToSharedFiles } from "../vscode-to-file-migration"
 
 /**
@@ -62,6 +63,9 @@ function createMockVSCodeContext() {
 			},
 			setKeysForSync() {},
 		},
+		globalStorageUri: {
+			fsPath: "",
+		},
 		// Expose internal stores for test setup
 		_globalStateStore: globalStateStore,
 		_secretsStore: secretsStore,
@@ -105,14 +109,43 @@ describe("vscode-to-file-migration", () => {
 			result.globalStateCount.should.be.greaterThan(0)
 			storageContext.globalState.get("mode")!.should.equal("act")
 			// Both sentinels should be written
-			storageContext.globalState.get("__vscodeMigrationVersion")!.should.equal(1)
-			storageContext.workspaceState.get("__vscodeMigrationVersion")!.should.equal(1)
+			storageContext.globalState.get("__vscodeMigrationVersion")!.should.equal(2)
+			storageContext.workspaceState.get("__vscodeMigrationVersion")!.should.equal(2)
+		})
+
+		it("should run only MCP settings migration when v1 storage export sentinels are already present", async () => {
+			storageContext.globalState.update("__vscodeMigrationVersion", 1)
+			storageContext.workspaceState.set("__vscodeMigrationVersion", 1)
+			const mockCtx = createMockVSCodeContext()
+			mockCtx._globalStateStore.set("mode", "plan")
+			mockCtx._workspaceStateStore.set("localClineRulesToggles", { "rule-1": true })
+			const extensionStorage = path.join(tempDir, "vscode-global-storage")
+			mockCtx.globalStorageUri.fsPath = extensionStorage
+			fs.mkdirSync(path.join(extensionStorage, "settings"), { recursive: true })
+			fs.writeFileSync(
+				path.join(extensionStorage, "settings", "cline_mcp_settings.json"),
+				JSON.stringify({ mcpServers: { fromV1: { command: "node" } } }),
+			)
+
+			const result = await exportVSCodeStorageToSharedFiles(mockCtx as any, storageContext, {
+				documentsDir: path.join(tempDir, "Documents"),
+			})
+
+			result.migrated.should.be.true()
+			result.globalStateCount.should.equal(0)
+			result.secretsCount.should.equal(0)
+			result.workspaceStateCount.should.equal(0)
+			result.mcpServersAdded.should.equal(1)
+			;(storageContext.globalState.get("mode") === undefined).should.be.true()
+			;(storageContext.workspaceState.get("localClineRulesToggles") === undefined).should.be.true()
+			storageContext.globalState.get("__vscodeMigrationVersion")!.should.equal(2)
+			storageContext.workspaceState.get("__vscodeMigrationVersion")!.should.equal(2)
 		})
 
 		it("should skip everything when both sentinels are current version", async () => {
 			// Pre-set BOTH sentinels
-			storageContext.globalState.update("__vscodeMigrationVersion", 1)
-			storageContext.workspaceState.set("__vscodeMigrationVersion", 1)
+			storageContext.globalState.update("__vscodeMigrationVersion", 2)
+			storageContext.workspaceState.set("__vscodeMigrationVersion", 2)
 
 			const mockCtx = createMockVSCodeContext()
 			mockCtx._globalStateStore.set("mode", "plan")
@@ -123,6 +156,7 @@ describe("vscode-to-file-migration", () => {
 			result.migrated.should.be.false()
 			result.globalStateCount.should.equal(0)
 			result.workspaceStateCount.should.equal(0)
+			result.mcpServersAdded.should.equal(0)
 			// Should NOT have the VSCode values — migration was skipped
 			const modeVal = storageContext.globalState.get("mode")
 			;(modeVal === undefined).should.be.true()
@@ -138,6 +172,9 @@ describe("vscode-to-file-migration", () => {
 			const result = await exportVSCodeStorageToSharedFiles(mockCtx as any, storageContext)
 
 			result.migrated.should.be.false()
+			result.globalStateCount.should.equal(0)
+			result.workspaceStateCount.should.equal(0)
+			result.mcpServersAdded.should.equal(0)
 		})
 
 		it("should re-run migration if sentinels are lower version", async () => {
@@ -173,7 +210,7 @@ describe("vscode-to-file-migration", () => {
 			const stored = storageContext.workspaceState.get("localClineRulesToggles") as any
 			stored.should.deepEqual({ "rule-1": true })
 			// Workspace sentinel should now be set
-			storageContext.workspaceState.get("__vscodeMigrationVersion")!.should.equal(1)
+			storageContext.workspaceState.get("__vscodeMigrationVersion")!.should.equal(2)
 		})
 
 		it("should migrate globals when workspace already migrated", async () => {
@@ -194,7 +231,7 @@ describe("vscode-to-file-migration", () => {
 			// Workspace state should NOT have been migrated
 			result.workspaceStateCount.should.equal(0)
 			// Global sentinel should now be set
-			storageContext.globalState.get("__vscodeMigrationVersion")!.should.equal(1)
+			storageContext.globalState.get("__vscodeMigrationVersion")!.should.equal(2)
 		})
 	})
 
@@ -248,6 +285,212 @@ describe("vscode-to-file-migration", () => {
 			// taskHistory should NOT be in the file store
 			const val = storageContext.globalState.get("taskHistory")
 			;(val === undefined).should.be.true()
+		})
+	})
+
+	describe("legacy MCP settings migration", () => {
+		function readSharedMcpSettings() {
+			return JSON.parse(fs.readFileSync(path.join(storageContext.dataDir, "settings", "cline_mcp_settings.json"), "utf8"))
+		}
+
+		it("skips a legacy source that resolves to the shared MCP settings file", async () => {
+			const mockCtx = createMockVSCodeContext()
+			mockCtx.globalStorageUri.fsPath = storageContext.dataDir
+			const sharedSettingsDir = path.join(storageContext.dataDir, "settings")
+			fs.mkdirSync(sharedSettingsDir, { recursive: true })
+			fs.writeFileSync(
+				path.join(sharedSettingsDir, "cline_mcp_settings.json"),
+				JSON.stringify({ mcpServers: { alreadyShared: { command: "node" } } }),
+			)
+
+			const result = await exportVSCodeStorageToSharedFiles(mockCtx as any, storageContext, {
+				documentsDir: path.join(tempDir, "Documents"),
+			})
+
+			result.mcpServersAdded.should.equal(0)
+			const tombstone = storageContext.globalState.get("__vscodeLegacyMcpSettingsMigration") as any
+			;(tombstone?.sources?.vscodeGlobalStorage === undefined).should.be.true()
+			const settings = readSharedMcpSettings()
+			settings.mcpServers.alreadyShared.should.deepEqual({ command: "node" })
+		})
+
+		it("uses the MCP settings lock when writing migrated servers", async () => {
+			const mockCtx = createMockVSCodeContext()
+			const extensionStorage = path.join(tempDir, "vscode-global-storage")
+			mockCtx.globalStorageUri.fsPath = extensionStorage
+			fs.mkdirSync(path.join(extensionStorage, "settings"), { recursive: true })
+			fs.writeFileSync(
+				path.join(extensionStorage, "settings", "cline_mcp_settings.json"),
+				JSON.stringify({ mcpServers: { lockedServer: { command: "node" } } }),
+			)
+
+			const sharedSettingsPath = path.join(storageContext.dataDir, "settings", "cline_mcp_settings.json")
+			const lockDir = `${sharedSettingsPath}.lock`
+			fs.mkdirSync(lockDir, { recursive: true })
+			fs.writeFileSync(path.join(lockDir, "owner.test"), "test")
+			const freshMtime = new Date()
+			fs.utimesSync(lockDir, freshMtime, freshMtime)
+
+			const migration = exportVSCodeStorageToSharedFiles(mockCtx as any, storageContext, {
+				documentsDir: path.join(tempDir, "Documents"),
+			})
+			await new Promise((resolve) => setTimeout(resolve, 75))
+			;(fs.existsSync(sharedSettingsPath) === false).should.be.true()
+			fs.rmSync(lockDir, { recursive: true, force: true })
+
+			const result = await migration
+			result.mcpServersAdded.should.equal(1)
+			const settings = readSharedMcpSettings()
+			settings.mcpServers.lockedServer.should.deepEqual({ transport: { type: "stdio", command: "node" } })
+		})
+
+		it("merges missing legacy MCP servers from VSCode globalStorage and Documents without overwriting shared settings", async () => {
+			const mockCtx = createMockVSCodeContext()
+			const extensionStorage = path.join(tempDir, "vscode-global-storage")
+			mockCtx.globalStorageUri.fsPath = extensionStorage
+
+			fs.mkdirSync(path.join(extensionStorage, "settings"), { recursive: true })
+			fs.writeFileSync(
+				path.join(extensionStorage, "settings", "cline_mcp_settings.json"),
+				JSON.stringify({
+					mcpServers: {
+						existing: { command: "legacy-existing", args: ["old"] },
+						stdioLegacy: { command: "node", args: ["server.js"], env: { API_KEY: "abc" } },
+					},
+				}),
+			)
+
+			fs.mkdirSync(path.join(tempDir, "Documents", "Cline", "MCP"), { recursive: true })
+			fs.writeFileSync(
+				path.join(tempDir, "Documents", "Cline", "MCP", "cline_mcp_settings.json"),
+				JSON.stringify({
+					mcpServers: {
+						docsServer: { url: "https://example.com/sse", autoApprove: ["search"] },
+					},
+				}),
+			)
+
+			const sharedSettingsDir = path.join(storageContext.dataDir, "settings")
+			fs.mkdirSync(sharedSettingsDir, { recursive: true })
+			fs.writeFileSync(
+				path.join(sharedSettingsDir, "cline_mcp_settings.json"),
+				JSON.stringify({
+					mcpServers: {
+						existing: {
+							transport: { type: "stdio", command: "shared-existing" },
+							disabled: true,
+						},
+					},
+				}),
+			)
+
+			const result = await exportVSCodeStorageToSharedFiles(mockCtx as any, storageContext, {
+				documentsDir: path.join(tempDir, "Documents"),
+			} as any)
+
+			result.mcpServersAdded.should.equal(2)
+			result.mcpServersSkippedExisting.should.equal(1)
+			const settings = readSharedMcpSettings()
+			settings.mcpServers.existing.should.deepEqual({
+				transport: { type: "stdio", command: "shared-existing" },
+				disabled: true,
+			})
+			settings.mcpServers.stdioLegacy.should.deepEqual({
+				transport: { type: "stdio", command: "node", args: ["server.js"], env: { API_KEY: "abc" } },
+			})
+			settings.mcpServers.docsServer.should.deepEqual({
+				transport: { type: "sse", url: "https://example.com/sse" },
+				autoApprove: ["search"],
+			})
+		})
+
+		it("upgrades legacy transportType and OAuth secret format into SDK MCP settings format", async () => {
+			const mockCtx = createMockVSCodeContext()
+			const extensionStorage = path.join(tempDir, "vscode-global-storage")
+			mockCtx.globalStorageUri.fsPath = extensionStorage
+			const serverUrl = "https://linear.example.com/mcp"
+			const serverHash = getServerAuthHash("linear", serverUrl)
+
+			mockCtx._secretsStore.set(
+				"mcpOAuthSecrets",
+				JSON.stringify({
+					[serverHash]: {
+						tokens: { access_token: "old-token", refresh_token: "refresh" },
+						tokens_saved_at: 123456,
+						client_info: { client_id: "client-id" },
+						code_verifier: "verifier",
+						redirect_url_at_registration: "http://127.0.0.1:1456/mcp/oauth/callback",
+					},
+				}),
+			)
+
+			fs.mkdirSync(path.join(extensionStorage, "settings"), { recursive: true })
+			fs.writeFileSync(
+				path.join(extensionStorage, "settings", "cline_mcp_settings.json"),
+				JSON.stringify({
+					mcpServers: {
+						linear: {
+							transportType: "http",
+							url: serverUrl,
+							headers: { Authorization: "Bearer static" },
+							disabled: false,
+							timeout: 30,
+						},
+					},
+				}),
+			)
+
+			const result = await exportVSCodeStorageToSharedFiles(mockCtx as any, storageContext, {
+				documentsDir: path.join(tempDir, "Documents"),
+			} as any)
+
+			result.mcpServersAdded.should.equal(1)
+			const settings = readSharedMcpSettings()
+			settings.mcpServers.linear.should.deepEqual({
+				transport: {
+					type: "streamableHttp",
+					url: serverUrl,
+					headers: { Authorization: "Bearer static" },
+				},
+				disabled: false,
+				timeout: 30,
+				oauth: {
+					clientInformation: { client_id: "client-id" },
+					tokens: { access_token: "old-token", refresh_token: "refresh" },
+					codeVerifier: "verifier",
+					redirectUrl: "http://127.0.0.1:1456/mcp/oauth/callback",
+					lastAuthenticatedAt: 123456,
+				},
+			})
+		})
+
+		it("writes source tombstones and does not re-import a deleted migrated server", async () => {
+			const mockCtx = createMockVSCodeContext()
+			const extensionStorage = path.join(tempDir, "vscode-global-storage")
+			mockCtx.globalStorageUri.fsPath = extensionStorage
+			fs.mkdirSync(path.join(extensionStorage, "settings"), { recursive: true })
+			fs.writeFileSync(
+				path.join(extensionStorage, "settings", "cline_mcp_settings.json"),
+				JSON.stringify({ mcpServers: { oneShot: { command: "node" } } }),
+			)
+
+			await exportVSCodeStorageToSharedFiles(mockCtx as any, storageContext, {
+				documentsDir: path.join(tempDir, "Documents"),
+			} as any)
+			const settingsPath = path.join(storageContext.dataDir, "settings", "cline_mcp_settings.json")
+			fs.writeFileSync(settingsPath, JSON.stringify({ mcpServers: {} }))
+
+			const second = await exportVSCodeStorageToSharedFiles(mockCtx as any, storageContext, {
+				documentsDir: path.join(tempDir, "Documents"),
+			} as any)
+
+			second.mcpServersAdded.should.equal(0)
+			const settings = readSharedMcpSettings()
+			;(settings.mcpServers.oneShot === undefined).should.be.true()
+			const tombstone = storageContext.globalState.get("__vscodeLegacyMcpSettingsMigration") as any
+			tombstone.sources.vscodeGlobalStorage.path.should.equal(
+				path.join(extensionStorage, "settings", "cline_mcp_settings.json"),
+			)
 		})
 	})
 

--- a/apps/vscode/src/hosts/vscode/__tests__/vscode-to-file-migration.test.ts
+++ b/apps/vscode/src/hosts/vscode/__tests__/vscode-to-file-migration.test.ts
@@ -383,7 +383,6 @@ describe("vscode-to-file-migration", () => {
 				}),
 			)
 
-
 			const sharedSettingsDir = path.dirname(sharedMcpSettingsPath())
 			fs.mkdirSync(sharedSettingsDir, { recursive: true })
 			fs.writeFileSync(

--- a/apps/vscode/src/hosts/vscode/mcp-settings-legacy-migration.ts
+++ b/apps/vscode/src/hosts/vscode/mcp-settings-legacy-migration.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs"
 import os from "node:os"
 import path from "node:path"
+import { getDocumentsPath } from "@/core/storage/documents-path"
 import type * as vscode from "vscode"
 import { updateMcpSettingsFile } from "@/services/mcp/settingsLock"
 import type { StorageContext } from "@/shared/storage/storage-context"
@@ -184,6 +185,12 @@ export function normalizeLegacyMcpServer(
 	if (typeof source.remoteConfigured === "boolean") {
 		normalized.remoteConfigured = source.remoteConfigured
 	}
+	// Remote-config sync historically keys URL-based remote servers by a top-level
+	// `url`. Keep that compatibility field on migrated remote-configured servers
+	// so the next sync does not delete/recreate them and lose user state.
+	if (source.remoteConfigured === true && typeof transport.url === "string") {
+		normalized.url = transport.url
+	}
 
 	const inlineOAuth = normalizeOauthState(source.oauth)
 	const serverUrl = getUrlForAuthHash(normalized)
@@ -232,11 +239,7 @@ async function readLegacyOAuthSecrets(
 	return { ...vscodeSecrets, ...fileBackedSecrets }
 }
 
-function defaultDocumentsDir(): string {
-	return path.join(os.homedir(), "Documents")
-}
-
-export function getLegacyMcpSettingsSources(options: LegacyMcpSourceOptions = {}): LegacyMcpSource[] {
+export async function getLegacyMcpSettingsSources(options: LegacyMcpSourceOptions = {}): Promise<LegacyMcpSource[]> {
 	const sources: LegacyMcpSource[] = []
 	if (options.extensionStorageDir) {
 		sources.push({
@@ -244,7 +247,7 @@ export function getLegacyMcpSettingsSources(options: LegacyMcpSourceOptions = {}
 			path: path.join(options.extensionStorageDir, "settings", MCP_SETTINGS_FILE_NAME),
 		})
 	}
-	const documentsDir = options.documentsDir ?? defaultDocumentsDir()
+	const documentsDir = options.documentsDir ?? (await getDocumentsPath())
 	sources.push({
 		id: "documentsClineMcp",
 		path: path.join(documentsDir, "Cline", "MCP", MCP_SETTINGS_FILE_NAME),
@@ -253,7 +256,16 @@ export function getLegacyMcpSettingsSources(options: LegacyMcpSourceOptions = {}
 }
 
 export function getSharedMcpSettingsPath(storage: StorageContext): string {
-	return path.join(storage.dataDir, "settings", MCP_SETTINGS_FILE_NAME)
+	const explicitPath = process.env.CLINE_MCP_SETTINGS_PATH?.trim()
+	if (explicitPath) {
+		return explicitPath
+	}
+	const explicitDataDir = process.env.CLINE_DATA_DIR?.trim()
+	if (explicitDataDir) {
+		return path.join(explicitDataDir, "settings", MCP_SETTINGS_FILE_NAME)
+	}
+	const clineDir = process.env.CLINE_DIR?.trim() || path.join(os.homedir(), ".cline")
+	return path.join(clineDir, "data", "settings", MCP_SETTINGS_FILE_NAME)
 }
 
 function readMigrationState(storage: StorageContext): JsonRecord {
@@ -309,7 +321,7 @@ export async function migrateLegacyMcpSettings(
 	const legacyOAuthSecrets = await readLegacyOAuthSecrets(vscodeContext, storage)
 	const preparedSources: PreparedLegacyMcpSource[] = []
 
-	for (const source of getLegacyMcpSettingsSources({
+	for (const source of await getLegacyMcpSettingsSources({
 		extensionStorageDir: options.extensionStorageDir ?? vscodeContext.globalStorageUri?.fsPath,
 		documentsDir: options.documentsDir,
 	})) {

--- a/apps/vscode/src/hosts/vscode/mcp-settings-legacy-migration.ts
+++ b/apps/vscode/src/hosts/vscode/mcp-settings-legacy-migration.ts
@@ -34,11 +34,6 @@ interface PreparedLegacyMcpSource {
 	skippedInvalid: number
 }
 
-export interface LegacyMcpSourceOptions {
-	extensionStorageDir?: string
-	documentsDir?: string
-}
-
 function isRecord(value: unknown): value is JsonRecord {
 	return typeof value === "object" && value !== null && !Array.isArray(value)
 }
@@ -239,15 +234,16 @@ async function readLegacyOAuthSecrets(
 	return { ...vscodeSecrets, ...fileBackedSecrets }
 }
 
-export async function getLegacyMcpSettingsSources(options: LegacyMcpSourceOptions = {}): Promise<LegacyMcpSource[]> {
+export async function getLegacyMcpSettingsSources(vscodeContext: vscode.ExtensionContext): Promise<LegacyMcpSource[]> {
 	const sources: LegacyMcpSource[] = []
-	if (options.extensionStorageDir) {
+	const extensionStorageDir = vscodeContext.globalStorageUri?.fsPath
+	if (extensionStorageDir) {
 		sources.push({
 			id: "vscodeGlobalStorage",
-			path: path.join(options.extensionStorageDir, "settings", MCP_SETTINGS_FILE_NAME),
+			path: path.join(extensionStorageDir, "settings", MCP_SETTINGS_FILE_NAME),
 		})
 	}
-	const documentsDir = options.documentsDir ?? (await getDocumentsPath())
+	const documentsDir = await getDocumentsPath()
 	sources.push({
 		id: "documentsClineMcp",
 		path: path.join(documentsDir, "Cline", "MCP", MCP_SETTINGS_FILE_NAME),
@@ -304,7 +300,6 @@ function prepareLegacySource(
 export async function migrateLegacyMcpSettings(
 	vscodeContext: vscode.ExtensionContext,
 	storage: StorageContext,
-	options: LegacyMcpSourceOptions = {},
 ): Promise<LegacyMcpSettingsMigrationResult> {
 	const result: LegacyMcpSettingsMigrationResult = {
 		migrated: false,
@@ -321,10 +316,7 @@ export async function migrateLegacyMcpSettings(
 	const legacyOAuthSecrets = await readLegacyOAuthSecrets(vscodeContext, storage)
 	const preparedSources: PreparedLegacyMcpSource[] = []
 
-	for (const source of await getLegacyMcpSettingsSources({
-		extensionStorageDir: options.extensionStorageDir ?? vscodeContext.globalStorageUri?.fsPath,
-		documentsDir: options.documentsDir,
-	})) {
+	for (const source of await getLegacyMcpSettingsSources(vscodeContext)) {
 		result.sourcesChecked++
 		if (migratedSources[source.id] || arePathsEqual(source.path, sharedSettingsPath)) {
 			continue

--- a/apps/vscode/src/hosts/vscode/mcp-settings-legacy-migration.ts
+++ b/apps/vscode/src/hosts/vscode/mcp-settings-legacy-migration.ts
@@ -1,0 +1,374 @@
+import { existsSync, readFileSync } from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import type * as vscode from "vscode"
+import { updateMcpSettingsFile } from "@/services/mcp/settingsLock"
+import type { StorageContext } from "@/shared/storage/storage-context"
+import { Logger } from "@/shared/services/Logger"
+import { getServerAuthHash } from "@/utils/mcpAuth"
+import { arePathsEqual } from "@/utils/path"
+
+const MCP_SETTINGS_FILE_NAME = "cline_mcp_settings.json"
+const MCP_SETTINGS_MIGRATION_KEY = "__vscodeLegacyMcpSettingsMigration"
+
+type JsonRecord = Record<string, unknown>
+
+export interface LegacyMcpSettingsMigrationResult {
+	migrated: boolean
+	sourcesChecked: number
+	sourcesMigrated: number
+	serversAdded: number
+	serversSkippedExisting: number
+	serversSkippedInvalid: number
+}
+
+interface LegacyMcpSource {
+	id: string
+	path: string
+}
+
+interface PreparedLegacyMcpSource {
+	source: LegacyMcpSource
+	servers: Record<string, JsonRecord>
+	skippedInvalid: number
+}
+
+export interface LegacyMcpSourceOptions {
+	extensionStorageDir?: string
+	documentsDir?: string
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+	return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function readJsonRecord(filePath: string): JsonRecord | undefined {
+	try {
+		if (!existsSync(filePath)) {
+			return undefined
+		}
+		const parsed = JSON.parse(readFileSync(filePath, "utf8")) as unknown
+		return isRecord(parsed) ? parsed : undefined
+	} catch (error) {
+		Logger.warn(`[Migration] Failed to read legacy MCP settings from ${filePath}:`, error)
+		return undefined
+	}
+}
+
+function getServers(settings: JsonRecord | undefined): JsonRecord {
+	const servers = settings?.mcpServers
+	return isRecord(servers) ? servers : {}
+}
+
+function mapLegacyTransportType(value: unknown): "stdio" | "sse" | "streamableHttp" | undefined {
+	if (value === "stdio" || value === "sse" || value === "streamableHttp") {
+		return value
+	}
+	if (value === "http") {
+		return "streamableHttp"
+	}
+	return undefined
+}
+
+function normalizeStringArray(value: unknown): string[] | undefined {
+	if (!Array.isArray(value)) {
+		return undefined
+	}
+	const strings = value.filter((item): item is string => typeof item === "string")
+	return strings.length === value.length ? strings : undefined
+}
+
+function normalizeStringRecord(value: unknown): Record<string, string> | undefined {
+	if (!isRecord(value)) {
+		return undefined
+	}
+	const entries = Object.entries(value)
+	if (!entries.every(([, entryValue]) => typeof entryValue === "string")) {
+		return undefined
+	}
+	return Object.fromEntries(entries) as Record<string, string>
+}
+
+function compactRecord(record: JsonRecord): JsonRecord {
+	return Object.fromEntries(Object.entries(record).filter(([, value]) => value !== undefined))
+}
+
+function normalizeOauthState(value: unknown): JsonRecord | undefined {
+	if (!isRecord(value)) {
+		return undefined
+	}
+	const normalized = compactRecord({
+		clientInformation: isRecord(value.clientInformation) ? value.clientInformation : undefined,
+		tokens: isRecord(value.tokens) ? value.tokens : undefined,
+		codeVerifier: typeof value.codeVerifier === "string" ? value.codeVerifier : undefined,
+		discoveryState: isRecord(value.discoveryState) ? value.discoveryState : undefined,
+		redirectUrl: typeof value.redirectUrl === "string" ? value.redirectUrl : undefined,
+		lastError: typeof value.lastError === "string" ? value.lastError : undefined,
+		lastAuthenticatedAt: typeof value.lastAuthenticatedAt === "number" ? value.lastAuthenticatedAt : undefined,
+	})
+	return Object.keys(normalized).length > 0 ? normalized : undefined
+}
+
+function normalizeLegacyOAuthSecret(value: unknown): JsonRecord | undefined {
+	if (!isRecord(value)) {
+		return undefined
+	}
+	const normalized = compactRecord({
+		clientInformation: isRecord(value.client_info) ? value.client_info : undefined,
+		tokens: isRecord(value.tokens) ? value.tokens : undefined,
+		codeVerifier: typeof value.code_verifier === "string" ? value.code_verifier : undefined,
+		redirectUrl: typeof value.redirect_url_at_registration === "string" ? value.redirect_url_at_registration : undefined,
+		lastAuthenticatedAt: typeof value.tokens_saved_at === "number" ? value.tokens_saved_at : undefined,
+	})
+	return Object.keys(normalized).length > 0 ? normalized : undefined
+}
+
+function getUrlForAuthHash(registration: JsonRecord): string | undefined {
+	const transport = isRecord(registration.transport) ? registration.transport : registration
+	return typeof transport.url === "string" ? transport.url : undefined
+}
+
+export function normalizeLegacyMcpServer(
+	value: unknown,
+	legacyOAuthSecrets: JsonRecord | undefined,
+	serverName: string,
+): JsonRecord | undefined {
+	if (!isRecord(value)) {
+		return undefined
+	}
+
+	const source = isRecord(value.transport) ? { ...value.transport, ...value } : { ...value }
+	delete source.transport
+
+	const explicitType = mapLegacyTransportType(source.type)
+	const transportType = mapLegacyTransportType(source.transportType)
+	const resolvedType = explicitType ?? transportType ?? (typeof source.command === "string" ? "stdio" : undefined)
+
+	let transport: JsonRecord | undefined
+	if (resolvedType === "stdio" && typeof source.command === "string" && source.command.trim()) {
+		transport = compactRecord({
+			type: "stdio",
+			command: source.command,
+			args: normalizeStringArray(source.args),
+			cwd: typeof source.cwd === "string" && source.cwd.trim() ? source.cwd : undefined,
+			env: normalizeStringRecord(source.env),
+		})
+	} else {
+		const urlType = resolvedType ?? "sse"
+		if ((urlType === "sse" || urlType === "streamableHttp") && typeof source.url === "string") {
+			transport = compactRecord({
+				type: urlType,
+				url: source.url,
+				headers: normalizeStringRecord(source.headers),
+			})
+		}
+	}
+
+	if (!transport) {
+		return undefined
+	}
+
+	const normalized: JsonRecord = compactRecord({
+		transport,
+		disabled: typeof source.disabled === "boolean" ? source.disabled : undefined,
+		metadata: isRecord(source.metadata) ? source.metadata : undefined,
+	})
+
+	const autoApprove = normalizeStringArray(source.autoApprove)
+	if (autoApprove) {
+		normalized.autoApprove = autoApprove
+	}
+	if (typeof source.timeout === "number") {
+		normalized.timeout = source.timeout
+	}
+	if (typeof source.remoteConfigured === "boolean") {
+		normalized.remoteConfigured = source.remoteConfigured
+	}
+
+	const inlineOAuth = normalizeOauthState(source.oauth)
+	const serverUrl = getUrlForAuthHash(normalized)
+	const legacyOAuth =
+		serverUrl && legacyOAuthSecrets
+			? normalizeLegacyOAuthSecret(legacyOAuthSecrets[getServerAuthHash(serverName, serverUrl)])
+			: undefined
+	const oauth = inlineOAuth ?? legacyOAuth
+	if (oauth) {
+		normalized.oauth = oauth
+	}
+
+	return normalized
+}
+
+function parseLegacyOAuthSecrets(raw: string | undefined): JsonRecord | undefined {
+	if (!raw) {
+		return undefined
+	}
+	try {
+		const parsed = JSON.parse(raw) as unknown
+		return isRecord(parsed) ? parsed : undefined
+	} catch (error) {
+		Logger.warn("[Migration] Failed to parse legacy MCP OAuth secrets:", error)
+		return undefined
+	}
+}
+
+async function readLegacyOAuthSecrets(
+	vscodeContext: vscode.ExtensionContext,
+	storage: StorageContext,
+): Promise<JsonRecord | undefined> {
+	let vscodeSecrets: JsonRecord | undefined
+	try {
+		vscodeSecrets = parseLegacyOAuthSecrets(await vscodeContext.secrets.get("mcpOAuthSecrets"))
+	} catch (error) {
+		Logger.warn("[Migration] Failed to read legacy MCP OAuth secrets from VSCode storage:", error)
+	}
+	const fileBackedSecrets = parseLegacyOAuthSecrets(storage.secrets.get("mcpOAuthSecrets"))
+	if (!vscodeSecrets) {
+		return fileBackedSecrets
+	}
+	if (!fileBackedSecrets) {
+		return vscodeSecrets
+	}
+	return { ...vscodeSecrets, ...fileBackedSecrets }
+}
+
+function defaultDocumentsDir(): string {
+	return path.join(os.homedir(), "Documents")
+}
+
+export function getLegacyMcpSettingsSources(options: LegacyMcpSourceOptions = {}): LegacyMcpSource[] {
+	const sources: LegacyMcpSource[] = []
+	if (options.extensionStorageDir) {
+		sources.push({
+			id: "vscodeGlobalStorage",
+			path: path.join(options.extensionStorageDir, "settings", MCP_SETTINGS_FILE_NAME),
+		})
+	}
+	const documentsDir = options.documentsDir ?? defaultDocumentsDir()
+	sources.push({
+		id: "documentsClineMcp",
+		path: path.join(documentsDir, "Cline", "MCP", MCP_SETTINGS_FILE_NAME),
+	})
+	return sources
+}
+
+export function getSharedMcpSettingsPath(storage: StorageContext): string {
+	return path.join(storage.dataDir, "settings", MCP_SETTINGS_FILE_NAME)
+}
+
+function readMigrationState(storage: StorageContext): JsonRecord {
+	const value = storage.globalState.get(MCP_SETTINGS_MIGRATION_KEY)
+	return isRecord(value) ? value : {}
+}
+
+function writeMigrationState(storage: StorageContext, state: JsonRecord): void {
+	storage.globalState.update(MCP_SETTINGS_MIGRATION_KEY, state)
+}
+
+function prepareLegacySource(
+	source: LegacyMcpSource,
+	legacyOAuthSecrets: JsonRecord | undefined,
+): PreparedLegacyMcpSource | undefined {
+	if (!existsSync(source.path)) {
+		return undefined
+	}
+	const legacySettings = readJsonRecord(source.path)
+	if (!legacySettings) {
+		return undefined
+	}
+	const servers: Record<string, JsonRecord> = {}
+	let skippedInvalid = 0
+	for (const [serverName, serverValue] of Object.entries(getServers(legacySettings))) {
+		const normalized = normalizeLegacyMcpServer(serverValue, legacyOAuthSecrets, serverName)
+		if (!normalized) {
+			skippedInvalid++
+			continue
+		}
+		servers[serverName] = normalized
+	}
+	return { source, servers, skippedInvalid }
+}
+
+export async function migrateLegacyMcpSettings(
+	vscodeContext: vscode.ExtensionContext,
+	storage: StorageContext,
+	options: LegacyMcpSourceOptions = {},
+): Promise<LegacyMcpSettingsMigrationResult> {
+	const result: LegacyMcpSettingsMigrationResult = {
+		migrated: false,
+		sourcesChecked: 0,
+		sourcesMigrated: 0,
+		serversAdded: 0,
+		serversSkippedExisting: 0,
+		serversSkippedInvalid: 0,
+	}
+
+	const migrationState = readMigrationState(storage)
+	const migratedSources = isRecord(migrationState.sources) ? migrationState.sources : {}
+	const sharedSettingsPath = getSharedMcpSettingsPath(storage)
+	const legacyOAuthSecrets = await readLegacyOAuthSecrets(vscodeContext, storage)
+	const preparedSources: PreparedLegacyMcpSource[] = []
+
+	for (const source of getLegacyMcpSettingsSources({
+		extensionStorageDir: options.extensionStorageDir ?? vscodeContext.globalStorageUri?.fsPath,
+		documentsDir: options.documentsDir,
+	})) {
+		result.sourcesChecked++
+		if (migratedSources[source.id] || arePathsEqual(source.path, sharedSettingsPath)) {
+			continue
+		}
+		const prepared = prepareLegacySource(source, legacyOAuthSecrets)
+		if (!prepared) {
+			continue
+		}
+		preparedSources.push(prepared)
+		result.serversSkippedInvalid += prepared.skippedInvalid
+	}
+
+	if (preparedSources.length > 0) {
+		const mergeResult = await updateMcpSettingsFile(sharedSettingsPath, (settings) => {
+			const existingServersValue = settings.mcpServers
+			const servers = isRecord(existingServersValue) ? { ...existingServersValue } : {}
+			let serversAdded = 0
+			let serversSkippedExisting = 0
+			let sourcesMigrated = 0
+
+			for (const prepared of preparedSources) {
+				let sourceAdded = 0
+				for (const [serverName, serverConfig] of Object.entries(prepared.servers)) {
+					if (Object.hasOwn(servers, serverName)) {
+						serversSkippedExisting++
+						continue
+					}
+					servers[serverName] = serverConfig
+					serversAdded++
+					sourceAdded++
+				}
+				if (sourceAdded > 0) {
+					sourcesMigrated++
+				}
+			}
+
+			settings.mcpServers = servers
+			return { serversAdded, serversSkippedExisting, sourcesMigrated }
+		})
+
+		result.serversAdded += mergeResult.serversAdded
+		result.serversSkippedExisting += mergeResult.serversSkippedExisting
+		result.sourcesMigrated += mergeResult.sourcesMigrated
+
+		for (const prepared of preparedSources) {
+			migratedSources[prepared.source.id] = {
+				path: prepared.source.path,
+				migratedAt: Date.now(),
+			}
+		}
+		result.migrated = true
+	}
+
+	if (result.migrated) {
+		writeMigrationState(storage, { sources: migratedSources })
+	}
+
+	return result
+}

--- a/apps/vscode/src/hosts/vscode/vscode-to-file-migration.ts
+++ b/apps/vscode/src/hosts/vscode/vscode-to-file-migration.ts
@@ -36,9 +36,16 @@ import type * as vscode from "vscode"
 import { Logger } from "@/shared/services/Logger"
 import { GlobalStateAndSettingKeys, LocalStateKeys, SecretKeys } from "@/shared/storage/state-keys"
 import type { StorageContext } from "@/shared/storage/storage-context"
+import { migrateLegacyMcpSettings, type LegacyMcpSourceOptions } from "./mcp-settings-legacy-migration"
+
+/** Version 1 exported VSCode memento/secrets/workspace state to file-backed stores. */
+const FILE_BACKED_STORAGE_EXPORT_VERSION = 1
+
+/** Version 2 imports legacy MCP settings files into the shared SDK/CLI settings path. */
+const MCP_SETTINGS_MIGRATION_VERSION = 2
 
 /** Bump this when adding new migration steps. */
-const CURRENT_MIGRATION_VERSION = 1
+const CURRENT_MIGRATION_VERSION = MCP_SETTINGS_MIGRATION_VERSION
 
 /** Sentinel key written to both globalState and workspaceState to track migration independently. */
 const MIGRATION_VERSION_KEY = "__vscodeMigrationVersion"
@@ -59,6 +66,8 @@ export interface MigrationResult {
 	secretsCount: number
 	workspaceStateCount: number
 	skippedExisting: number
+	mcpServersAdded: number
+	mcpServersSkippedExisting: number
 }
 
 /**
@@ -78,6 +87,7 @@ export interface MigrationResult {
 export async function exportVSCodeStorageToSharedFiles(
 	vscodeContext: vscode.ExtensionContext,
 	storage: StorageContext,
+	legacyMcpOptions: LegacyMcpSourceOptions = {},
 ): Promise<MigrationResult> {
 	const result: MigrationResult = {
 		migrated: false,
@@ -85,16 +95,19 @@ export async function exportVSCodeStorageToSharedFiles(
 		secretsCount: 0,
 		workspaceStateCount: 0,
 		skippedExisting: 0,
+		mcpServersAdded: 0,
+		mcpServersSkippedExisting: 0,
 	}
 
 	// Check sentinels independently
 	const globalVersion = storage.globalState.get<number>(MIGRATION_VERSION_KEY)
 	const workspaceVersion = storage.workspaceState.get<number>(MIGRATION_VERSION_KEY)
 
-	const needGlobalMigration = globalVersion === undefined || globalVersion < CURRENT_MIGRATION_VERSION
-	const needWorkspaceMigration = workspaceVersion === undefined || workspaceVersion < CURRENT_MIGRATION_VERSION
+	const needGlobalMigration = globalVersion === undefined || globalVersion < FILE_BACKED_STORAGE_EXPORT_VERSION
+	const needWorkspaceMigration = workspaceVersion === undefined || workspaceVersion < FILE_BACKED_STORAGE_EXPORT_VERSION
+	const needMcpSettingsMigration = globalVersion === undefined || globalVersion < MCP_SETTINGS_MIGRATION_VERSION
 
-	if (!needGlobalMigration && !needWorkspaceMigration) {
+	if (!needGlobalMigration && !needWorkspaceMigration && !needMcpSettingsMigration) {
 		Logger.info(
 			`[Migration] File-backed stores already current (global: v${globalVersion}, workspace: v${workspaceVersion}), skipping.`,
 		)
@@ -106,6 +119,13 @@ export async function exportVSCodeStorageToSharedFiles(
 	)
 
 	try {
+		// ─── 0. Migrate legacy MCP settings files (if needed) ───────────
+		if (needMcpSettingsMigration) {
+			const mcpMigration = await migrateLegacyMcpSettings(vscodeContext, storage, legacyMcpOptions)
+			result.mcpServersAdded = mcpMigration.serversAdded
+			result.mcpServersSkippedExisting = mcpMigration.serversSkippedExisting
+		}
+
 		// ─── 1. Migrate global state + secrets (if needed) ─────────────
 		if (needGlobalMigration) {
 			// Batch global state keys
@@ -130,7 +150,8 @@ export async function exportVSCodeStorageToSharedFiles(
 				result.globalStateCount++
 			}
 
-			// Add sentinel to batch
+			// Add sentinel to batch. This advances straight to CURRENT because the
+			// v2 MCP migration already ran above when needed.
 			globalStateBatch[MIGRATION_VERSION_KEY] = CURRENT_MIGRATION_VERSION
 
 			// Write all global state in one operation
@@ -182,19 +203,34 @@ export async function exportVSCodeStorageToSharedFiles(
 				result.workspaceStateCount++
 			}
 
-			// Add sentinel to batch
+			// Add sentinel to batch. This advances straight to CURRENT because any
+			// global v2-only migrations already ran above when needed.
 			workspaceStateBatch[MIGRATION_VERSION_KEY] = CURRENT_MIGRATION_VERSION
 
 			// Write all workspace state in one operation
 			storage.workspaceState.setBatch(workspaceStateBatch)
 		}
 
-		result.migrated = true
+
+		// If the original v1 export was already complete, still advance sentinels
+		// for this workspace after the v2 MCP migration attempt so future startups
+		// don't re-run it. New workspaces still have no workspace sentinel and will
+		// get their v1 workspace-state export when first opened.
+		if (!needGlobalMigration && needMcpSettingsMigration) {
+			storage.globalState.update(MIGRATION_VERSION_KEY, CURRENT_MIGRATION_VERSION)
+		}
+		if (!needWorkspaceMigration && needMcpSettingsMigration) {
+			storage.workspaceState.set(MIGRATION_VERSION_KEY, CURRENT_MIGRATION_VERSION)
+		}
+
+		result.migrated =
+			needGlobalMigration || needWorkspaceMigration || needMcpSettingsMigration || result.mcpServersAdded > 0
 
 		Logger.info(
 			`[Migration] Complete: ${result.globalStateCount} global state keys, ` +
 				`${result.secretsCount} secrets, ${result.workspaceStateCount} workspace state keys migrated. ` +
-				`${result.skippedExisting} keys skipped (already in file store).`,
+				`${result.skippedExisting} keys skipped (already in file store). ` +
+				`Legacy MCP migration added ${result.mcpServersAdded} server(s), skipped ${result.mcpServersSkippedExisting} existing server(s).`,
 		)
 	} catch (error) {
 		Logger.error("[Migration] Fatal error during VSCode → file-backed migration:", error)

--- a/apps/vscode/src/hosts/vscode/vscode-to-file-migration.ts
+++ b/apps/vscode/src/hosts/vscode/vscode-to-file-migration.ts
@@ -211,7 +211,6 @@ export async function exportVSCodeStorageToSharedFiles(
 			storage.workspaceState.setBatch(workspaceStateBatch)
 		}
 
-
 		// If the original v1 export was already complete, still advance sentinels
 		// for this workspace after the v2 MCP migration attempt so future startups
 		// don't re-run it. New workspaces still have no workspace sentinel and will
@@ -223,8 +222,7 @@ export async function exportVSCodeStorageToSharedFiles(
 			storage.workspaceState.set(MIGRATION_VERSION_KEY, CURRENT_MIGRATION_VERSION)
 		}
 
-		result.migrated =
-			needGlobalMigration || needWorkspaceMigration || needMcpSettingsMigration || result.mcpServersAdded > 0
+		result.migrated = needGlobalMigration || needWorkspaceMigration || needMcpSettingsMigration || result.mcpServersAdded > 0
 
 		Logger.info(
 			`[Migration] Complete: ${result.globalStateCount} global state keys, ` +

--- a/apps/vscode/src/hosts/vscode/vscode-to-file-migration.ts
+++ b/apps/vscode/src/hosts/vscode/vscode-to-file-migration.ts
@@ -36,7 +36,7 @@ import type * as vscode from "vscode"
 import { Logger } from "@/shared/services/Logger"
 import { GlobalStateAndSettingKeys, LocalStateKeys, SecretKeys } from "@/shared/storage/state-keys"
 import type { StorageContext } from "@/shared/storage/storage-context"
-import { migrateLegacyMcpSettings, type LegacyMcpSourceOptions } from "./mcp-settings-legacy-migration"
+import { migrateLegacyMcpSettings } from "./mcp-settings-legacy-migration"
 
 /** Version 1 exported VSCode memento/secrets/workspace state to file-backed stores. */
 const FILE_BACKED_STORAGE_EXPORT_VERSION = 1
@@ -87,7 +87,6 @@ export interface MigrationResult {
 export async function exportVSCodeStorageToSharedFiles(
 	vscodeContext: vscode.ExtensionContext,
 	storage: StorageContext,
-	legacyMcpOptions: LegacyMcpSourceOptions = {},
 ): Promise<MigrationResult> {
 	const result: MigrationResult = {
 		migrated: false,
@@ -121,7 +120,7 @@ export async function exportVSCodeStorageToSharedFiles(
 	try {
 		// ─── 0. Migrate legacy MCP settings files (if needed) ───────────
 		if (needMcpSettingsMigration) {
-			const mcpMigration = await migrateLegacyMcpSettings(vscodeContext, storage, legacyMcpOptions)
+			const mcpMigration = await migrateLegacyMcpSettings(vscodeContext, storage)
 			result.mcpServersAdded = mcpMigration.serversAdded
 			result.mcpServersSkippedExisting = mcpMigration.serversSkippedExisting
 		}

--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -5,11 +5,11 @@
 // cancelTask, …) to the Cline SDK (@cline/core) and bridges SDK events to
 // the webview's gRPC streams.
 import * as fs from "node:fs/promises"
-import * as os from "node:os"
 import * as path from "node:path"
 import {
 	createUserInstructionConfigService,
 	getProviderAuthStorageId,
+	resolveDefaultMcpSettingsPath,
 	type PreparedRemoteConfigCoreIntegration,
 	type SessionHistoryRecord,
 	setTelemetryOptOutGlobally,
@@ -232,8 +232,7 @@ export class Controller {
 		this.mcpHub = new McpHub(
 			() => ensureMcpServersDirectoryExists(),
 			async () => {
-				const clineDir = process.env.CLINE_DIR || path.join(os.homedir(), ".cline")
-				const settingsDir = path.join(clineDir, "data", "settings")
+				const settingsDir = path.dirname(resolveDefaultMcpSettingsPath())
 				await fs.mkdir(settingsDir, { recursive: true })
 				return settingsDir
 			},


### PR DESCRIPTION
### Related Issue

**Issue:** ENG-2203

### Description

VSCode Cline historically wrote MCP settings into the extension
storage location, or ~/Documents/Cline/MCP. (Note, various overrides
were possible with environment variables, and for JetBrains, the
"extension storage location" was contrived to *be* the ~/.cline/data
shared storage location.)

The formats are also different, for example, VSCode Cline historically
stored OAuth secrets in VSCode secret storage; CLI's new settings file
includes auth information inline.

This creates a migration step to pull MCP servers from the old storage
locations, join the auth information from VSCode secrets, and add them
to the CLI's new storage location.

We do this once only on startup; and we only update servers which are
not in the new storage location already.

### Test Procedure

Added tests:

```
bun test \
  apps/vscode/src/hosts/vscode/__tests__/vscode-to-file-migration.test.ts
```

Manual test:

1. Ensure you're using the "classic" (3.x) series of the Cline
   extension (not 4.x, not Cline (Nigthly).

2. Set up an MCP server which is not in your CLI MCP servers.

If you need a handy MCP server, you can:

```
cd apps/vscode
bun run dev:mcp-oauth-test-server -- --verbose
```

3. Start VSCode. (The migration happens silently at this point.)

4. Switch to the 4.x extension.

5. Observe that your MCP server list now includes the one you added in
   step 2.

Note, if you want to re-run the migration test, open ~/.cline/data/globalState.json and change these keys:

- `"__vscodeLegacyMcpSettingsMigration": 2,` &rarr; `1,` (or delete it)
- `"__vscodeLegacyMcpSettingsMigration": { ...` &larr; delete this key

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="494" height="708" alt="Screenshot 2026-06-25 at 17 44 50" src="https://github.com/user-attachments/assets/8d5a8cac-1b8a-48e4-b59d-0c5873e877d2" />

Post-migration: oauth-test is migrated from classic settings