### PR TITLE
fix(vscode): remove dead settings

### DIFF
--- a/apps/vscode/proto/cline/state.proto
+++ b/apps/vscode/proto/cline/state.proto
@@ -112,6 +112,9 @@ message Secrets {
 // in src/shared/storage/state-keys.ts and use the scripts/generate-state-proto.mjs
 // script to regenerate this list.
 message Settings {
+  reserved 144, 154, 176;
+  reserved "cline_web_tools_enabled", "enable_parallel_tool_calling", "double_check_completion_enabled";
+
   optional string lite_llm_base_url = 1;
   optional bool lite_llm_use_prompt_cache = 2;
   optional string anthropic_base_url = 4;
@@ -251,14 +254,12 @@ message Settings {
   optional int32 max_consecutive_mistakes = 139;
   optional bool yolo_mode_toggled = 142;
   optional bool use_auto_condense = 143;
-  optional bool cline_web_tools_enabled = 144;
   optional string preferred_language = 145;
   optional PlanActMode mode = 147;
   optional FocusChainSettings focus_chain_settings = 149;
   optional string custom_prompt = 150;
   optional bool hooks_enabled = 152;
   optional bool subagents_enabled = 153;
-  optional bool enable_parallel_tool_calling = 154;
   optional bool background_edit_enabled = 155;
   optional bool opt_out_of_remote_config = 157;
   optional bool open_telemetry_enabled = 158;
@@ -277,7 +278,6 @@ message Settings {
   optional int32 open_telemetry_log_max_queue_size = 171;
   optional bool worktrees_enabled = 172;
   optional bool auto_approve_all_toggled = 174;
-  optional bool double_check_completion_enabled = 176;
   map<string, string> open_ai_headers = 177;
   optional string plan_mode_cline_model_id = 178;
   optional OpenRouterModelInfo plan_mode_cline_model_info = 179;
@@ -387,9 +387,11 @@ message UpdateTaskSettingsRequest {
 message UpdateSettingsRequest {
   reserved 15; // was openai_reasoning_effort (moved to mode-scoped reasoning effort)
   reserved 23; // was dictation_settings (dictation removed)
+  reserved 32, 34, 35, 41;
   reserved 38; // was skills_enabled (removed - now always enabled)
   reserved 43; // was lazy_teammate_mode_enabled (removed)
   reserved 12; // was terminal_output_line_limit (removed; SDK command output limits are character-based)
+  reserved "native_tool_call_enabled", "cline_web_tools_enabled", "enable_parallel_tool_calling", "double_check_completion_enabled";
 
   Metadata metadata = 1;
   optional ModelsApiConfiguration api_configuration = 2;
@@ -417,15 +419,11 @@ message UpdateSettingsRequest {
   optional bool subagents_enabled = 29;
   optional int32 subagent_terminal_output_line_limit = 30;
   optional string cline_env = 31;
-  optional bool native_tool_call_enabled = 32;
   optional OnboardingModelGroup onboarding_models = 33;
-  optional bool cline_web_tools_enabled = 34;
-  optional bool enable_parallel_tool_calling = 35;
   optional bool background_edit_enabled = 36;
   optional string oca_reasoning_effort = 37;
   optional bool opt_out_of_remote_config = 39;
   optional bool worktrees_enabled = 40;
-  optional bool double_check_completion_enabled = 41;
   optional bool show_feature_tips = 42;
 }
 

--- a/apps/vscode/src/core/controller/state/getStateToPostToWebview.ts
+++ b/apps/vscode/src/core/controller/state/getStateToPostToWebview.ts
@@ -68,7 +68,6 @@ export async function getStateToPostToWebview(controller: {
 	const lastDismissedModelBannerVersion = stateManager.getGlobalStateKey("lastDismissedModelBannerVersion") || 0
 	const lastDismissedCliBannerVersion = stateManager.getGlobalStateKey("lastDismissedCliBannerVersion") || 0
 	const dismissedBanners = stateManager.getGlobalStateKey("dismissedBanners")
-	const doubleCheckCompletionEnabled = stateManager.getGlobalSettingsKey("doubleCheckCompletionEnabled")
 	const showFeatureTips = stateManager.getGlobalSettingsKey("showFeatureTips")
 
 	const localClineRulesToggles = stateManager.getWorkspaceStateKey("localClineRulesToggles")
@@ -162,10 +161,6 @@ export async function getStateToPostToWebview(controller: {
 			user: stateManager.getGlobalStateKey("multiRootEnabled"),
 			featureFlag: true,
 		},
-		clineWebToolsEnabled: {
-			user: stateManager.getGlobalSettingsKey("clineWebToolsEnabled"),
-			featureFlag: featureFlagsService.getWebtoolsEnabled(),
-		},
 		worktreesEnabled: {
 			user: stateManager.getGlobalSettingsKey("worktreesEnabled"),
 			featureFlag: featureFlagsService.getWorktreesEnabled(),
@@ -176,11 +171,8 @@ export async function getStateToPostToWebview(controller: {
 		remoteConfigSettings: stateManager.getRemoteConfigSettings?.(),
 		lastDismissedCliBannerVersion,
 		dismissedBanners,
-		nativeToolCallSetting: stateManager.getGlobalStateKey("nativeToolCallEnabled"),
-		enableParallelToolCalling: stateManager.getGlobalSettingsKey("enableParallelToolCalling"),
 		backgroundEditEnabled: stateManager.getGlobalSettingsKey("backgroundEditEnabled"),
 		optOutOfRemoteConfig: stateManager.getGlobalSettingsKey("optOutOfRemoteConfig"),
-		doubleCheckCompletionEnabled,
 		showFeatureTips,
 		banners,
 		welcomeBanners,

--- a/apps/vscode/src/core/controller/state/updateSettings.ts
+++ b/apps/vscode/src/core/controller/state/updateSettings.ts
@@ -150,14 +150,6 @@ export async function updateSettings(controller: Controller, request: UpdateSett
 			controller.stateManager.setGlobalState("yoloModeToggled", request.yoloModeToggled)
 		}
 
-		// Update cline web tools setting
-		if (request.clineWebToolsEnabled !== undefined) {
-			if (controller.task) {
-				telemetryService.captureClineWebToolsToggle(controller.task.ulid, request.clineWebToolsEnabled)
-			}
-			controller.stateManager.setGlobalState("clineWebToolsEnabled", request.clineWebToolsEnabled)
-		}
-
 		// Update worktrees setting
 		if (request.worktreesEnabled !== undefined) {
 			controller.stateManager.setGlobalState("worktreesEnabled", request.worktreesEnabled)
@@ -250,22 +242,6 @@ export async function updateSettings(controller: Controller, request: UpdateSett
 			controller.stateManager.setGlobalState("multiRootEnabled", !!request.multiRootEnabled)
 		}
 
-		if (request.nativeToolCallEnabled !== undefined) {
-			controller.stateManager.setGlobalState("nativeToolCallEnabled", !!request.nativeToolCallEnabled)
-			if (controller.task) {
-				telemetryService.captureFeatureToggle(
-					controller.task.ulid,
-					"native-tool-call",
-					request.nativeToolCallEnabled,
-					controller.task.api.getModel().id,
-				)
-			}
-		}
-
-		if (request.enableParallelToolCalling !== undefined) {
-			controller.stateManager.setGlobalState("enableParallelToolCalling", !!request.enableParallelToolCalling)
-		}
-
 		if (request.optOutOfRemoteConfig !== undefined) {
 			const hadOptedOut = controller.stateManager.getGlobalSettingsKey("optOutOfRemoteConfig")
 			const isOptingOut = !!request.optOutOfRemoteConfig
@@ -283,10 +259,6 @@ export async function updateSettings(controller: Controller, request: UpdateSett
 				// and we apply the actual config afterwards without blocking the settings update
 				fetchRemoteConfig(controller)
 			}
-		}
-
-		if (request.doubleCheckCompletionEnabled !== undefined) {
-			controller.stateManager.setGlobalState("doubleCheckCompletionEnabled", request.doubleCheckCompletionEnabled)
 		}
 
 		if (request.showFeatureTips !== undefined) {

--- a/apps/vscode/src/core/controller/state/updateSettingsCli.ts
+++ b/apps/vscode/src/core/controller/state/updateSettingsCli.ts
@@ -44,7 +44,6 @@ export async function updateSettingsCli(controller: Controller, request: UpdateS
 			telemetrySetting,
 			yoloModeToggled,
 			useAutoCondense,
-			clineWebToolsEnabled,
 			worktreesEnabled,
 			subagentsEnabled,
 			browserSettings,
@@ -140,14 +139,6 @@ export async function updateSettingsCli(controller: Controller, request: UpdateS
 				)
 			}
 			controller.stateManager.setGlobalState("useAutoCondense", useAutoCondense)
-		}
-
-		// Update Cline web tools setting (requires telemetry)
-		if (clineWebToolsEnabled !== undefined) {
-			if (controller.task) {
-				telemetryService.captureClineWebToolsToggle(controller.task.ulid, clineWebToolsEnabled)
-			}
-			controller.stateManager.setGlobalState("clineWebToolsEnabled", clineWebToolsEnabled)
 		}
 
 		// Update worktrees setting

--- a/apps/vscode/src/services/feature-flags/FeatureFlagsService.ts
+++ b/apps/vscode/src/services/feature-flags/FeatureFlagsService.ts
@@ -114,10 +114,6 @@ export class FeatureFlagsService {
 		return this.cache.get(flagName) ?? FeatureFlagDefaultValue[flagName]
 	}
 
-	public getWebtoolsEnabled(): boolean {
-		return this.getBooleanFlagEnabled(FeatureFlag.WEBTOOLS)
-	}
-
 	public getWorktreesEnabled(): boolean {
 		return this.getBooleanFlagEnabled(FeatureFlag.WORKTREES)
 	}

--- a/apps/vscode/src/services/telemetry/TelemetryService.ts
+++ b/apps/vscode/src/services/telemetry/TelemetryService.ts
@@ -309,8 +309,6 @@ export class TelemetryService {
 			AUTO_CONDENSE_TOGGLED: "task.auto_condense_toggled",
 			// Tracks when yolo mode setting is toggled on/off
 			YOLO_MODE_TOGGLED: "task.yolo_mode_toggled",
-			// Tracks when Cline web tools setting is toggled on/off
-			CLINE_WEB_TOOLS_TOGGLED: "task.cline_web_tools_toggled",
 			// Tracks task initialization timing
 			INITIALIZATION: "task.initialization",
 			// Terminal execution telemetry events
@@ -1625,21 +1623,6 @@ export class TelemetryService {
 	public captureYoloModeToggle(ulid: string, enabled: boolean) {
 		this.capture({
 			event: TelemetryService.EVENTS.TASK.YOLO_MODE_TOGGLED,
-			properties: {
-				ulid,
-				enabled,
-			},
-		})
-	}
-
-	/**
-	 * Records when Cline web tools are enabled/disabled by the user
-	 * @param ulid Unique identifier for the task
-	 * @param enabled Whether Cline web tools are enabled (true) or disabled (false)
-	 */
-	public captureClineWebToolsToggle(ulid: string, enabled: boolean) {
-		this.capture({
-			event: TelemetryService.EVENTS.TASK.CLINE_WEB_TOOLS_TOGGLED,
 			properties: {
 				ulid,
 				enabled,

--- a/apps/vscode/src/shared/ExtensionMessage.ts
+++ b/apps/vscode/src/shared/ExtensionMessage.ts
@@ -104,7 +104,6 @@ export interface ExtensionState {
 	yoloModeToggled?: boolean
 	useAutoCondense?: boolean
 	subagentsEnabled?: boolean
-	clineWebToolsEnabled?: ClineFeatureSetting
 	worktreesEnabled?: ClineFeatureSetting
 	customPrompt?: string
 	favoritedModelIds: string[]
@@ -121,11 +120,8 @@ export interface ExtensionState {
 	remoteConfigSettings?: Partial<RemoteConfigFields>
 	globalSkillsToggles?: Record<string, boolean>
 	localSkillsToggles?: Record<string, boolean>
-	nativeToolCallSetting?: boolean
-	enableParallelToolCalling?: boolean
 	backgroundEditEnabled?: boolean
 	optOutOfRemoteConfig?: boolean
-	doubleCheckCompletionEnabled?: boolean
 	showFeatureTips?: boolean
 	banners?: BannerCardData[]
 	welcomeBanners?: BannerCardData[]

--- a/apps/vscode/src/shared/services/feature-flags/feature-flags.ts
+++ b/apps/vscode/src/shared/services/feature-flags/feature-flags.ts
@@ -1,7 +1,6 @@
 import type { FeatureFlagPayload } from "@/services/feature-flags/providers/IFeatureFlagsProvider"
 
 export enum FeatureFlag {
-	WEBTOOLS = "webtools",
 	WORKTREES = "worktree-exp",
 	// Feature flag for showing the new onboarding flow or old welcome view.
 	ONBOARDING_MODELS = "onboarding_models",
@@ -24,7 +23,6 @@ export enum FeatureFlag {
 }
 
 export const FeatureFlagDefaultValue: Partial<Record<FeatureFlag, FeatureFlagPayload>> = {
-	[FeatureFlag.WEBTOOLS]: false,
 	[FeatureFlag.WORKTREES]: false,
 	[FeatureFlag.ONBOARDING_MODELS]: process.env.E2E_TEST === "true" ? { models: {} } : undefined,
 	[FeatureFlag.REMOTE_BANNERS]: process.env.E2E_TEST === "true" || process.env.IS_DEV === "true",

--- a/apps/vscode/src/shared/storage/state-keys.ts
+++ b/apps/vscode/src/shared/storage/state-keys.ts
@@ -86,7 +86,6 @@ const GLOBAL_STATE_FIELDS = {
 	lastDismissedInfoBannerVersion: { default: 0 as number },
 	lastDismissedModelBannerVersion: { default: 0 as number },
 	lastDismissedCliBannerVersion: { default: 0 as number },
-	nativeToolCallEnabled: { default: true as boolean },
 	remoteRulesToggles: { default: {} as ClineRulesToggles },
 	remoteWorkflowToggles: { default: {} as ClineRulesToggles },
 	remoteSkillsToggles: { default: {} as ClineRulesToggles },
@@ -141,7 +140,6 @@ const API_HANDLER_SETTINGS_FIELDS = {
 	ocaMode: { default: "internal" as string },
 	aihubmixBaseUrl: { default: undefined as string | undefined },
 	aihubmixAppCode: { default: undefined as string | undefined },
-	enableParallelToolCalling: { default: true as boolean },
 
 	// Plan mode configurations
 	planModeApiModelId: { default: undefined as string | undefined },
@@ -267,7 +265,6 @@ const USER_SETTINGS_FIELDS = {
 	autoApproveAllToggled: { default: false as boolean },
 	useAutoCondense: { default: false as boolean },
 	subagentsEnabled: { default: false as boolean },
-	clineWebToolsEnabled: { default: true as boolean },
 	worktreesEnabled: { default: false as boolean },
 	preferredLanguage: { default: "English" as string },
 	mode: { default: "act" as Mode },
@@ -275,7 +272,6 @@ const USER_SETTINGS_FIELDS = {
 	customPrompt: { default: undefined as "compact" | undefined },
 	backgroundEditEnabled: { default: false as boolean },
 	optOutOfRemoteConfig: { default: false as boolean },
-	doubleCheckCompletionEnabled: { default: false as boolean },
 	showFeatureTips: { default: true as boolean },
 
 	// OpenTelemetry configuration

--- a/apps/vscode/src/utils/__tests__/model-utils.test.ts
+++ b/apps/vscode/src/utils/__tests__/model-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "bun:test"
 import "should"
-import type { ApiHandlerModel, ApiProviderInfo } from "@core/api"
+import type { ApiHandlerModel } from "@core/api"
 import {
 	GEMINI_FLASH_MAX_OUTPUT_TOKENS,
 	isClaude4PlusModelFamily,
@@ -8,7 +8,6 @@ import {
 	isGLMModelFamily,
 	isGPT5ModelFamily,
 	isGptOssModelFamily,
-	isNativeToolCallingConfig,
 	isNextGenModelFamily,
 	isPoolsideModelFamily,
 	modelDoesntSupportWebp,
@@ -17,11 +16,6 @@ import {
 
 // Minimal helper — modelDoesntSupportWebp only reads apiHandlerModel.id
 const m = (id: string): ApiHandlerModel => ({ id, info: { supportsPromptCache: false } })
-const providerInfo = (providerId: string, modelId: string): ApiProviderInfo => ({
-	providerId,
-	model: m(modelId),
-	mode: "act",
-})
 
 describe("shouldSkipReasoningForModel", () => {
 	it("should return true for grok-4 models", () => {
@@ -137,10 +131,8 @@ describe("isPoolsideModelFamily", () => {
 		isPoolsideModelFamily("claude-sonnet-4").should.equal(false)
 	})
 
-	it("should qualify Laguna models for next-gen and native tool calling paths", () => {
+	it("should qualify Laguna models for next-gen paths", () => {
 		isNextGenModelFamily("poolside/laguna-m.1").should.equal(true)
-		isNativeToolCallingConfig(providerInfo("openai-compatible", "poolside/laguna-m.1"), true).should.equal(true)
-		isNativeToolCallingConfig(providerInfo("openai-compatible", "poolside/laguna-m.1"), false).should.equal(false)
 	})
 })
 

--- a/apps/vscode/src/utils/model-utils.ts
+++ b/apps/vscode/src/utils/model-utils.ts
@@ -1,31 +1,9 @@
 import { MODEL_COLLECTIONS_BY_PROVIDER_ID } from "@cline/llms"
-import { ApiHandlerModel, ApiProviderInfo } from "@core/api"
+import { ApiHandlerModel } from "@core/api"
 import type { AnthropicModelId } from "@/shared/api"
 
 const CLAUDE_VERSION_MATCH_REGEX = /[-_ ]([\d](?:\.[05])?)[-_ ]?/
 export const GEMINI_FLASH_MAX_OUTPUT_TOKENS = 8_192
-
-function isNextGenModelProvider(providerInfo: ApiProviderInfo): boolean {
-	const providerId = normalize(providerInfo.providerId)
-	return [
-		"cline",
-		"cline-pass",
-		"anthropic",
-		"bedrock",
-		"gemini",
-		"vertex",
-		"openrouter",
-		"openai",
-		"minimax",
-		"openai-native",
-		"openai-compatible",
-		"openai-codex",
-		"baseten",
-		"vercel-ai-gateway",
-		"deepseek",
-		"oca",
-	].some((id) => providerId === id)
-}
 
 export function modelDoesntSupportWebp(apiHandlerModel: ApiHandlerModel): boolean {
 	const modelId = apiHandlerModel.id.toLowerCase()
@@ -186,24 +164,6 @@ export function parsePrice(priceString: string | undefined): number {
 	}
 	// Convert from per-token to per-million-tokens (multiply by 1,000,000)
 	return parsed * 1_000_000
-}
-
-/**
- * Determines if the given provider and model combination will use native tool calling.
- * Helpful if we need to quickly check this for prompts or other logic.
- * @param providerInfo The provider and model information
- * @param enableNativeToolCalls Whether the native tool calls setting is enabled
- * @returns true if the model will use native tool calling, false otherwise
- */
-export function isNativeToolCallingConfig(providerInfo: ApiProviderInfo, enableNativeToolCalls: boolean): boolean {
-	if (!enableNativeToolCalls) {
-		return false
-	}
-	if (!isNextGenModelProvider(providerInfo)) {
-		return false
-	}
-	const modelId = providerInfo.model.id.toLowerCase()
-	return isNextGenModelFamily(modelId)
 }
 
 function normalize(text: string): string {

--- a/apps/vscode/webview-ui/src/components/settings/sections/FeatureSettingsSection.spec.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/sections/FeatureSettingsSection.spec.tsx
@@ -13,14 +13,10 @@ vi.mock("@/context/ExtensionStateContext", () => ({
 		yoloModeToggled: false,
 		useAutoCondense: false,
 		subagentsEnabled: false,
-		clineWebToolsEnabled: { user: true, featureFlag: true },
 		worktreesEnabled: { user: true, featureFlag: true },
 		focusChainSettings: { enabled: false, remindClineInterval: 6 },
 		remoteConfigSettings: {},
-		nativeToolCallSetting: false,
-		enableParallelToolCalling: false,
 		backgroundEditEnabled: false,
-		doubleCheckCompletionEnabled: false,
 	})),
 }))
 

--- a/apps/vscode/webview-ui/src/components/settings/sections/FeatureSettingsSection.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/sections/FeatureSettingsSection.tsx
@@ -38,20 +38,6 @@ const agentFeatures: FeatureToggle[] = [
 		settingKey: "subagentsEnabled",
 	},
 	{
-		id: "native-tool-call",
-		label: "Native Tool Call",
-		description: "Use native function calling when available",
-		stateKey: "nativeToolCallSetting",
-		settingKey: "nativeToolCallEnabled",
-	},
-	{
-		id: "parallel-tool-calling",
-		label: "Parallel Tool Calling",
-		description: "Execute multiple tool calls simultaneously",
-		stateKey: "enableParallelToolCalling",
-		settingKey: "enableParallelToolCalling",
-	},
-	{
 		id: "auto-compact",
 		label: "Auto Compact",
 		description: "Automatically compress conversation history.",
@@ -83,13 +69,6 @@ const editorFeatures: FeatureToggle[] = [
 		settingKey: "enableCheckpointsSetting",
 	},
 	{
-		id: "cline-web-tools",
-		label: "Cline Web Tools",
-		description: "Access web browsing and search capabilities",
-		stateKey: "clineWebToolsEnabled",
-		settingKey: "clineWebToolsEnabled",
-	},
-	{
 		id: "worktrees",
 		label: "Worktrees",
 		description: "Enables git worktree management for running parallel Cline tasks.",
@@ -106,14 +85,6 @@ const experimentalFeatures: FeatureToggle[] = [
 			"Execute tasks without user's confirmation. Auto-switches from Plan to Act mode and disables the ask question tool. Use with extreme caution.",
 		stateKey: "yoloModeToggled",
 		settingKey: "yoloModeToggled",
-	},
-	{
-		id: "double-check-completion",
-		label: "Double-Check Completion",
-		description:
-			"Rejects the first completion attempt and asks the model to re-verify its work against the original task requirements before accepting.",
-		stateKey: "doubleCheckCompletionEnabled",
-		settingKey: "doubleCheckCompletionEnabled",
 	},
 ]
 
@@ -191,13 +162,9 @@ const FeatureSettingsSection = ({ renderSectionHeader }: FeatureSettingsSectionP
 		yoloModeToggled,
 		useAutoCondense,
 		subagentsEnabled,
-		clineWebToolsEnabled,
 		worktreesEnabled,
 		remoteConfigSettings,
-		nativeToolCallSetting,
-		enableParallelToolCalling,
 		backgroundEditEnabled,
-		doubleCheckCompletionEnabled,
 		showFeatureTips,
 	} = useExtensionState()
 
@@ -208,20 +175,15 @@ const FeatureSettingsSection = ({ renderSectionHeader }: FeatureSettingsSectionP
 		showFeatureTips,
 		enableCheckpointsSetting,
 		hooksEnabled,
-		nativeToolCallSetting,
 		useAutoCondense,
 		subagentsEnabled,
-		clineWebToolsEnabled: clineWebToolsEnabled?.user,
 		worktreesEnabled: worktreesEnabled?.user,
-		enableParallelToolCalling,
 		backgroundEditEnabled,
-		doubleCheckCompletionEnabled,
 		yoloModeToggled: isYoloRemoteLocked ? remoteConfigSettings?.yoloModeToggled : yoloModeToggled,
 	}
 
 	// Visibility lookup for features with feature flags
 	const featureVisibility: Record<string, boolean | undefined> = {
-		clineWebToolsEnabled: clineWebToolsEnabled?.featureFlag,
 		worktreesEnabled: worktreesEnabled?.featureFlag,
 	}
 

--- a/apps/vscode/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/apps/vscode/webview-ui/src/context/ExtensionStateContext.tsx
@@ -301,7 +301,6 @@ export const ExtensionStateContextProvider: React.FC<{
 		customPrompt: undefined,
 		useAutoCondense: false,
 		subagentsEnabled: false,
-		clineWebToolsEnabled: { user: true, featureFlag: false },
 		worktreesEnabled: { user: true, featureFlag: false },
 		favoritedModelIds: [],
 		lastDismissedInfoBannerVersion: 0,
@@ -312,7 +311,6 @@ export const ExtensionStateContextProvider: React.FC<{
 		backgroundCommandTaskId: undefined,
 		lastDismissedCliBannerVersion: 0,
 		backgroundEditEnabled: false,
-		doubleCheckCompletionEnabled: false,
 		showFeatureTips: true,
 		globalSkillsToggles: {},
 		localSkillsToggles: {},
@@ -323,8 +321,6 @@ export const ExtensionStateContextProvider: React.FC<{
 		isMultiRootWorkspace: false,
 		multiRootSetting: { user: false, featureFlag: false },
 		hooksEnabled: false,
-		nativeToolCallSetting: false,
-		enableParallelToolCalling: false,
 	})
 	const [expandTaskHeader, setExpandTaskHeader] = useState(true)
 	const [didHydrateState, setDidHydrateState] = useState(false)


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This PR removes four VS Code Settings page toggles that survived the SDK refactor but no longer have real consumers in the active code path:

- Native Tool Call (`nativeToolCallEnabled`)
- Parallel Tool Calling (`enableParallelToolCalling`)
- Cline Web Tools (`clineWebToolsEnabled`)
- Double-Check Completion (`doubleCheckCompletionEnabled`)

Before deleting anything, I re-ran the requested audit grep against `apps/vscode/src`, `apps/vscode/webview-ui/src`, and `sdk/packages`, excluding generated proto, write paths, echo-back paths, state declarations, type declarations, settings UI, and tests. All four checks returned empty, so the remaining references were only the expected dead plumbing.

The removal is intentionally narrow. The Settings UI no longer renders the four toggles, the webview context no longer carries their default state, and the extension no longer accepts, stores, or echoes these settings. I also removed the Cline Web Tools-specific telemetry event/method because its only callers were the deleted setting handlers. The generic feature toggle telemetry remains because Hooks still uses it.

The proto schema now reserves the removed field numbers and names instead of reusing them. In this branch, the concrete fields existed in `Settings` for `cline_web_tools_enabled`, `enable_parallel_tool_calling`, and `double_check_completion_enabled`, and in `UpdateSettingsRequest` for all four removed settings. I ran `bun run protos` after editing the schema.

I also removed `isNativeToolCallingConfig` from `model-utils.ts`; after the settings removal, its only reference was its own test case. The Poolside model test still verifies the model family is considered next-gen, but no longer asserts the deleted native-tool-call helper.

Two settings were deliberately left alone per the task scope:

- Ollama Request Timeout (`requestTimeoutMs` / `request_timeout_ms`)
- Yolo Mode (`yoloModeToggled` / `yolo_mode_toggled`)

### Test Procedure

I verified the removal in several passes:

- Re-ran the mandatory consumer grep before deleting each setting; all four were empty.
- Re-ran the same consumer grep after deletion; all four remained empty.
- Searched for the removed camelCase keys across `apps/vscode/src`, `apps/vscode/webview-ui/src`, and `sdk/packages`; no references remain.
- Searched for the removed snake_case proto names in proto/generated locations; they now only appear as reserved names in `state.proto`.
- Confirmed `requestTimeoutMs` and `yoloModeToggled` still exist in the expected settings/proto/UI/controller paths.

Commands run:

```bash
bun run protos
bun test src/utils/__tests__/model-utils.test.ts
bunx vitest run src/components/settings/sections/FeatureSettingsSection.spec.tsx
bunx tsc --noEmit # from apps/vscode/webview-ui
bun run lint:proto
bunx biome check --config-path ./biome.jsonc src/core/controller/state/getStateToPostToWebview.ts src/core/controller/state/updateSettings.ts src/core/controller/state/updateSettingsCli.ts src/services/telemetry/TelemetryService.ts src/shared/ExtensionMessage.ts src/shared/storage/state-keys.ts src/utils/__tests__/model-utils.test.ts src/utils/model-utils.ts webview-ui/src/components/settings/sections/FeatureSettingsSection.spec.tsx webview-ui/src/components/settings/sections/FeatureSettingsSection.tsx webview-ui/src/context/ExtensionStateContext.tsx --no-errors-on-unmatched --files-ignore-unknown=true --diagnostic-level=error
```

Results:

- Targeted `model-utils` bun test passed: 32 tests.
- Targeted `FeatureSettingsSection` vitest passed: 4 tests.
- Webview TypeScript check passed.
- Proto lint passed.
- Biome check on changed source files passed.

I also ran full `bun run check-types` from `apps/vscode`. It re-ran proto generation successfully, then failed on unrelated existing test fixture type errors in `src/core/controller/models/__tests__/refreshClineRecommendedModels.test.ts` where three fixture objects are missing the required `clinePass` field. I left that unrelated issue untouched.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. This removes dead settings toggles from the Settings page and backing plumbing. No new UI surface was added.

### Additional Notes

The `Settings` proto message is partly generated from `state-keys.ts`; this PR keeps the required removed field numbers reserved in `state.proto` so future proto fields do not reuse them.
