### PR TITLE
fix(prompt): add an overeager scope-discipline rule to the system prompt

### DIFF
--- a/sdk/packages/shared/src/prompt/system.ts
+++ b/sdk/packages/shared/src/prompt/system.ts
@@ -14,6 +14,7 @@ Environment you are running in:
 
 Remember:
 - Always adhere to existing code conventions and patterns.
+- Guard against overeager actions: pay careful attention to the scope of the user's request. Do what they ask, but no more. Do not improve, comment, fix, or modify unrelated parts of the code in any way.
 - Use only libraries and frameworks that are confirmed to be in use in the current codebase.
 - Provide complete and functional code without omissions or placeholders.
 - Be explicit about any assumptions or limitations in your solution.


### PR DESCRIPTION
Adds a general overeager scope-discipline rule to the system prompt, in the spirit of the `overeager_prompt` line aider ships: the agent stays within the scope of the request -- does what's asked and no more, and does not modify unrelated parts of the code.

Prompt-only change; one line added to `sdk/packages/shared/src/prompt/system.ts`. No new behavior beyond the scope guidance.