### PR TITLE
fix(vscode): flush state after model selection

### DIFF
--- a/apps/vscode/src/common.ts
+++ b/apps/vscode/src/common.ts
@@ -155,28 +155,30 @@ async function checkWorktreeAutoOpen(stateManager: StateManager): Promise<void> 
  */
 export async function tearDown(): Promise<void> {
 	try {
-		await StateManager.get().flushPendingState()
-	} catch (error) {
-		Logger.error("[Cline] Failed to flush pending state during teardown:", error)
+		AgentConfigLoader.getInstance()?.dispose()
+		PostHogClientProvider.getInstance().dispose()
+		telemetryService.dispose()
+		ErrorService.get().dispose()
+		featureFlagsService.dispose()
+		// Dispose all webview instances
+		await WebviewProvider.disposeAllInstances()
+		syncWorker().dispose()
+		clearOnboardingModelsCache()
+
+		// Kill any running hook processes to prevent zombies
+		await HookProcessRegistry.terminateAll()
+		// Clean up hook discovery cache
+		HookDiscoveryCache.getInstance().dispose()
+		// Stop periodic temp file cleanup
+		ClineTempManager.stopPeriodicCleanup()
+
+		// Clean up test mode
+		cleanupTestMode()
+	} finally {
+		try {
+			await StateManager.get().flushPendingState()
+		} catch (error) {
+			Logger.error("[Cline] Failed to flush pending state during teardown:", error)
+		}
 	}
-
-	AgentConfigLoader.getInstance()?.dispose()
-	PostHogClientProvider.getInstance().dispose()
-	telemetryService.dispose()
-	ErrorService.get().dispose()
-	featureFlagsService.dispose()
-	// Dispose all webview instances
-	await WebviewProvider.disposeAllInstances()
-	syncWorker().dispose()
-	clearOnboardingModelsCache()
-
-	// Kill any running hook processes to prevent zombies
-	await HookProcessRegistry.terminateAll()
-	// Clean up hook discovery cache
-	HookDiscoveryCache.getInstance().dispose()
-	// Stop periodic temp file cleanup
-	ClineTempManager.stopPeriodicCleanup()
-
-	// Clean up test mode
-	cleanupTestMode()
 }

--- a/apps/vscode/src/common.ts
+++ b/apps/vscode/src/common.ts
@@ -154,6 +154,12 @@ async function checkWorktreeAutoOpen(stateManager: StateManager): Promise<void> 
  * Performs cleanup when Cline is deactivated that is common to all platforms.
  */
 export async function tearDown(): Promise<void> {
+	try {
+		await StateManager.get().flushPendingState()
+	} catch (error) {
+		Logger.error("[Cline] Failed to flush pending state during teardown:", error)
+	}
+
 	AgentConfigLoader.getInstance()?.dispose()
 	PostHogClientProvider.getInstance().dispose()
 	telemetryService.dispose()

--- a/apps/vscode/src/core/controller/models/__tests__/providerCatalogHandlers.test.ts
+++ b/apps/vscode/src/core/controller/models/__tests__/providerCatalogHandlers.test.ts
@@ -275,6 +275,7 @@ describe("provider model catalog handlers", () => {
 		})
 
 		expect(handleApiConfigurationChanged).toHaveBeenCalledWith({}, { actModeApiProvider: "deepseek" })
+		expect(stateManager.flushPendingState).toHaveBeenCalledTimes(1)
 	})
 
 	it("commitModelSelection rejects invalid mode", async () => {

--- a/apps/vscode/src/core/controller/models/__tests__/providerCatalogHandlers.test.ts
+++ b/apps/vscode/src/core/controller/models/__tests__/providerCatalogHandlers.test.ts
@@ -8,6 +8,7 @@ import type { ProviderCatalogController } from "../providerCatalogShared"
 
 type TestStateManager = {
 	setGlobalStateBatch: ReturnType<typeof vi.fn>
+	flushPendingState?: ReturnType<typeof vi.fn<() => Promise<void>>>
 	getApiConfiguration?: ReturnType<typeof vi.fn<() => ApiConfiguration | undefined>>
 }
 
@@ -213,7 +214,10 @@ describe("provider model catalog handlers", () => {
 		const { commitModelSelection } = await import("../commitModelSelection")
 		const providerId = parseProviderId("deepseek")
 		const store = makeStore({ providerId })
-		const stateManager: TestStateManager = { setGlobalStateBatch: vi.fn() }
+		const stateManager: TestStateManager = {
+			setGlobalStateBatch: vi.fn(),
+			flushPendingState: vi.fn(async () => undefined),
+		}
 		const controller = makeController(store, makeCatalog(), stateManager)
 
 		await commitModelSelection(controller, {
@@ -242,6 +246,7 @@ describe("provider model catalog handlers", () => {
 			actModeApiProvider: "deepseek",
 			actModeApiModelId: "deepseek-v4-flash",
 		})
+		expect(stateManager.flushPendingState).toHaveBeenCalledTimes(1)
 	})
 
 	it("commitModelSelection reports provider changes when config is initialized", async () => {
@@ -250,6 +255,7 @@ describe("provider model catalog handlers", () => {
 		const store = makeStore({ providerId })
 		const stateManager: TestStateManager = {
 			setGlobalStateBatch: vi.fn(),
+			flushPendingState: vi.fn(async () => undefined),
 			getApiConfiguration: vi
 				.fn<() => ApiConfiguration | undefined>()
 				.mockReturnValueOnce(undefined)

--- a/apps/vscode/src/core/controller/models/commitModelSelection.ts
+++ b/apps/vscode/src/core/controller/models/commitModelSelection.ts
@@ -27,6 +27,7 @@ export async function commitModelSelection(
 			[`${mode}ModeApiProvider`]: providerId,
 			[getProviderModelIdKey(toLegacyApiProvider(providerId.toString()), mode)]: selection.modelId,
 		})
+		await controller.stateManager.flushPendingState?.()
 		const nextApiConfiguration = controller.stateManager.getApiConfiguration?.()
 		if (nextApiConfiguration) {
 			controller.handleApiConfigurationChanged?.(previousApiConfiguration ?? {}, nextApiConfiguration)

--- a/apps/vscode/src/core/controller/models/providerCatalogShared.ts
+++ b/apps/vscode/src/core/controller/models/providerCatalogShared.ts
@@ -34,6 +34,7 @@ export interface ProviderCatalogController {
 export interface ProviderCatalogStateController extends ProviderCatalogController {
 	stateManager: {
 		setGlobalStateBatch(updates: Partial<GlobalStateAndSettings>): void
+		flushPendingState?(): Promise<void>
 		getApiConfiguration?(): ApiConfiguration
 	}
 	handleApiConfigurationChanged?(previous: ApiConfiguration, next: ApiConfiguration): void

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -700,10 +700,12 @@ async function getBinaryLocation(name: string): Promise<string> {
 // This method is called when your extension is deactivated
 export async function deactivate() {
 	// Dispose Non-VSCode-specific services
-	tearDown()
-
-	// VSCode-specific services
-	disposeVscodeCommentReviewController()
+	try {
+		await tearDown()
+	} finally {
+		// VSCode-specific services
+		disposeVscodeCommentReviewController()
+	}
 }
 
 // TODO: Find a solution for automatically removing DEV related content from production builds.

--- a/apps/vscode/src/standalone/cline-core.ts
+++ b/apps/vscode/src/standalone/cline-core.ts
@@ -263,7 +263,7 @@ async function shutdownGracefully(lockManager?: SqliteLockManager) {
 		// Step 3: Tear down services
 		log("Tearing down services...")
 		try {
-			tearDown()
+			await tearDown()
 			log("Services torn down successfully")
 		} catch (error) {
 			log(`Warning: Failed to tear down services: ${error}`)


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

**Issue:** #XXXX

### Description

This fixes a settings durability bug where model selection can be lost if the extension host exits shortly after a user changes models.

The bug showed up while debugging an F5 extension launch that kept returning the Cline provider model to a stale Kimi selection even after selecting Sonnet. The local storage state had split:

```text
~/.cline/data/globalState.json
  actModeClineModelId: moonshotai/kimi-k2.7-code
  planModeClineModelId: moonshotai/kimi-k2.7-code

~/.cline/data/settings/providers.json
  providers.cline.settings.model: anthropic/claude-sonnet-4.6
```

That split matters because the VS Code extension still reads Cline provider selections from `StateManager` / `globalState.json` when the provider-specific model id and model info fields are present. The SDK provider settings file had the newer Sonnet value, but the extension-side read path and SDK session config both resolved the active Cline model from `StateManager`.

The immediate cause is a durability mismatch:

- `ProviderSettingsManager.saveProviderSettings()` writes `providers.json` synchronously.
- `StateManager.setGlobalStateBatch()` updates the in-memory cache immediately but persists `globalState.json` through a 500ms debounce.
- Model selection writes to both stores.
- The VS Code `deactivate()` hook called `tearDown()` without awaiting it.
- `tearDown()` did not flush pending `StateManager` writes.

That means a fast debug stop/re-F5, extension host crash, or quick VS Code reload after a model change can persist the SDK provider setting while losing the debounced legacy/global state update. On the next launch, the stale `globalState.json` value wins.

This PR makes the narrow reliability fix:

- Flush pending `StateManager` writes during common teardown.
- Await teardown from the VS Code `deactivate()` hook, while still disposing VS Code-specific services in a `finally`.
- Await teardown from standalone graceful shutdown.
- Flush pending state immediately after `commitModelSelection()` writes the mode-specific provider/model fields.

I intentionally did not redesign the two-store model selection flow here. The deeper cleanup should still happen separately: model selection should eventually have one canonical source of truth, with startup reconciliation for legacy state. This PR is the low-risk production fix for the data-loss window.

### Test Procedure

Verified locally:

```bash
cd apps/vscode
bun run test:vitest src/core/controller/models/__tests__/providerCatalogHandlers.test.ts
bun run check-types
bun run lint
```

Results:

- Focused Vitest suite passed: 1 file, 8 tests.
- Type checking passed for the VS Code extension and webview.
- Lint passed, including proto lint.

One note from verification: running the focused Vitest command in parallel with `check-types` can race because `check-types` regenerates proto outputs before type checking. The focused test passes when run after proto generation completes.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. This is a storage durability fix with no UI changes.

### Additional Notes

This should reduce both the F5/debug repro and the production edge cases where users change model selection and then quickly reload, quit, or crash the extension host before the debounced `globalState.json` write fires.

The remaining design smell is still the duplicated model selection state across `globalState.json` and `providers.json`. This PR does not try to solve that broader migration question.

I did not run the full `bun test` suite; I ran the focused handler test, `bun run check-types`, and `bun run lint`.
