### PR TITLE
fix(vscode): reuse idle SDK sessions for follow-ups

### DIFF
--- a/apps/vscode/src/sdk/sdk-followup-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-followup-coordinator.test.ts
@@ -66,6 +66,27 @@ describe("SdkFollowupCoordinator", () => {
 		)
 	})
 
+	it("reuses an idle active session for a displayed task instead of resuming from disk", async () => {
+		const activeSession = makeActiveSession()
+		const task = makeTask("session-123")
+		const { coordinator, options } = makeCoordinator({ activeSession, task })
+
+		await coordinator.askResponse("keep going")
+
+		expect(options.waitForPendingModeRebuild).toHaveBeenCalledOnce()
+		expect(options.sessions.startNewSession).not.toHaveBeenCalled()
+		expect(options.createTempSessionHost).not.toHaveBeenCalled()
+		expect(options.loadInitialMessages).not.toHaveBeenCalled()
+		expect(options.sessions.fireAndForgetSend).toHaveBeenCalledWith(
+			activeSession.sdkHost,
+			"session-123",
+			"resolved: keep going",
+			undefined,
+			undefined,
+			undefined,
+		)
+	})
+
 	it("queues a follow-up when the active session is already running", async () => {
 		const activeSession = makeActiveSession({ isRunning: true })
 		const { coordinator, options } = makeCoordinator({ activeSession })

--- a/apps/vscode/src/sdk/sdk-followup-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-followup-coordinator.ts
@@ -71,7 +71,7 @@ export class SdkFollowupCoordinator {
 			await this.options.waitForPendingModeRebuild()
 			activeSession = this.options.sessions.getActiveSession()
 		}
-		if (!activeSession?.isRunning && task) {
+		if (!activeSession && task) {
 			Logger.log(`[SdkController] askResponse: No active session but task exists (${task.taskId}), resuming...`)
 			await this.tryResumeSessionFromTask(task.taskId, prompt, images, files)
 			return

--- a/apps/vscode/src/sdk/sdk-session-lifecycle.test.ts
+++ b/apps/vscode/src/sdk/sdk-session-lifecycle.test.ts
@@ -164,7 +164,7 @@ describe("SdkSessionLifecycle", () => {
 		expect(lifecycle.getActiveSession()?.isRunning).toBe(true)
 	})
 
-	it("marks the active session idle and reports non-abort send errors", async () => {
+	it("clears the active session and reports non-abort send errors", async () => {
 		const onSendError = vi.fn()
 		const error = new Error("boom")
 		const sdkHost = makeSdkHost({ send: vi.fn().mockRejectedValue(error) })
@@ -177,7 +177,7 @@ describe("SdkSessionLifecycle", () => {
 		lifecycle.fireAndForgetSend(sdkHost as any, "session-123", "hello")
 		await vi.waitFor(() => expect(onSendError).toHaveBeenCalledWith(error, "session-123"))
 
-		expect(lifecycle.getActiveSession()?.isRunning).toBe(false)
+		expect(lifecycle.getActiveSession()).toBeUndefined()
 	})
 
 	it("skips completion bookkeeping when the session was replaced before the send settled", async () => {

--- a/apps/vscode/src/sdk/sdk-session-lifecycle.ts
+++ b/apps/vscode/src/sdk/sdk-session-lifecycle.ts
@@ -353,7 +353,9 @@ export class SdkSessionLifecycle {
 					return
 				}
 				Logger.error("[SdkController] Agent turn failed:", error)
-				this.setRunning(false)
+				// Thrown turn failures shut down the runtime session, so this
+				// reference is no longer reusable for follow-up sends.
+				this.clearActiveSessionReference()
 				await this.options.onSendError(error, sessionId)
 			})
 	}

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.test.tsx
@@ -148,6 +148,108 @@ describe("useMessageHandlers — send routing", () => {
 		)
 	})
 
+	it("clears follow-up UI state before askResponse resolves", async () => {
+		mockTurnState = { phase: "completed", seq: 7 }
+		let resolveAskResponse: () => void = () => {}
+		askResponse.mockImplementationOnce(
+			() =>
+				new Promise<void>((resolve) => {
+					resolveAskResponse = resolve
+				}),
+		)
+		const setInputValue = vi.fn()
+		const setActiveQuote = vi.fn()
+		const setSendingDisabled = vi.fn()
+		const setSelectedImages = vi.fn()
+		const setSelectedFiles = vi.fn()
+		const setEnableButtons = vi.fn()
+		const chatState = makeChatState(completedConversation, {
+			activeQuote: "selected context",
+			sendingDisabled: false,
+			enableButtons: true,
+			setInputValue,
+			setActiveQuote,
+			setSendingDisabled,
+			setSelectedImages,
+			setSelectedFiles,
+			setEnableButtons,
+		})
+		const { result } = renderHook(() => useMessageHandlers(completedConversation, chatState))
+
+		let sendPromise: Promise<void>
+		await act(async () => {
+			sendPromise = result.current.handleSendMessage("another question", ["image.png"], ["a.ts"])
+			await Promise.resolve()
+		})
+
+		expect(askResponse).toHaveBeenCalledTimes(1)
+		expect(setInputValue).toHaveBeenCalledWith("")
+		expect(setActiveQuote).toHaveBeenCalledWith(null)
+		expect(setSendingDisabled).toHaveBeenCalledWith(true)
+		expect(setSelectedImages).toHaveBeenCalledWith([])
+		expect(setSelectedFiles).toHaveBeenCalledWith([])
+		expect(setEnableButtons).toHaveBeenCalledWith(false)
+
+		await act(async () => {
+			resolveAskResponse()
+			await sendPromise
+		})
+	})
+
+	it("restores pending follow-up UI state when askResponse fails", async () => {
+		mockTurnState = { phase: "completed", seq: 7 }
+		const error = new Error("transport down")
+		const setInputValue = vi.fn()
+		const setActiveQuote = vi.fn()
+		const setSendingDisabled = vi.fn()
+		const setSelectedImages = vi.fn()
+		const setSelectedFiles = vi.fn()
+		const setEnableButtons = vi.fn()
+		const chatState = makeChatState(completedConversation, {
+			activeQuote: "selected context",
+			sendingDisabled: false,
+			enableButtons: true,
+			setInputValue,
+			setActiveQuote,
+			setSendingDisabled,
+			setSelectedImages,
+			setSelectedFiles,
+			setEnableButtons,
+		})
+		const { result } = renderHook(() => useMessageHandlers(completedConversation, chatState))
+		askResponse.mockRejectedValueOnce(error)
+
+		let caught: unknown
+		await act(async () => {
+			try {
+				await result.current.handleSendMessage("another question", ["image.png"], ["a.ts"])
+			} catch (err) {
+				caught = err
+			}
+		})
+
+		expect(caught).toBe(error)
+		expect(askResponse).toHaveBeenCalledWith(
+			expect.objectContaining({
+				text: expect.stringContaining("selected context"),
+				images: ["image.png"],
+				files: ["a.ts"],
+			}),
+		)
+		expect(setInputValue).toHaveBeenNthCalledWith(1, "")
+		expect(setInputValue).toHaveBeenLastCalledWith("another question")
+		expect(setActiveQuote).toHaveBeenNthCalledWith(1, null)
+		expect(setActiveQuote).toHaveBeenLastCalledWith("selected context")
+		expect(setSendingDisabled).toHaveBeenNthCalledWith(1, true)
+		expect(setSendingDisabled).toHaveBeenLastCalledWith(false)
+		expect(setSelectedImages).toHaveBeenNthCalledWith(1, [])
+		expect(setSelectedImages).toHaveBeenLastCalledWith(["image.png"])
+		expect(setSelectedFiles).toHaveBeenNthCalledWith(1, [])
+		expect(setSelectedFiles).toHaveBeenLastCalledWith(["a.ts"])
+		expect(setEnableButtons).toHaveBeenNthCalledWith(1, false)
+		expect(setEnableButtons).toHaveBeenLastCalledWith(true)
+	})
+
 	it("phase awaiting_followup also routes a follow-up to askResponse", async () => {
 		mockTurnState = { phase: "awaiting_followup", seq: 3 }
 		const { result } = renderHook(() => useMessageHandlers(completedConversation, makeChatState(completedConversation)))

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.ts
@@ -79,6 +79,16 @@ export function useMessageHandlers(messages: ClineMessage[], chatState: ChatStat
 					setSelectedFiles(files)
 					setEnableButtons(enableButtons)
 				}
+				const sendAskResponseOptimistically = async (request: ReturnType<typeof AskResponseRequest.create>) => {
+					clearSentMessageState()
+					try {
+						await TaskServiceClient.askResponse(request)
+					} catch (error) {
+						restorePendingMessageState()
+						throw error
+					}
+					messageSent = true
+				}
 
 				if (messages.length === 0) {
 					const request = NewTaskRequest.create({
@@ -98,7 +108,7 @@ export function useMessageHandlers(messages: ClineMessage[], chatState: ChatStat
 					// For resume_task and resume_completed_task, use yesButtonClicked to match Resume button behavior
 					// This ensures Enter key and Resume button work identically
 					if (clineAsk === "resume_task" || clineAsk === "resume_completed_task") {
-						await TaskServiceClient.askResponse(
+						await sendAskResponseOptimistically(
 							AskResponseRequest.create({
 								responseType: "yesButtonClicked",
 								text: messageToSend,
@@ -106,7 +116,6 @@ export function useMessageHandlers(messages: ClineMessage[], chatState: ChatStat
 								files,
 							}),
 						)
-						messageSent = true
 					} else {
 						// All other ask types use messageResponse
 						switch (clineAsk) {
@@ -124,7 +133,7 @@ export function useMessageHandlers(messages: ClineMessage[], chatState: ChatStat
 							case "new_task":
 							case "condense":
 							case "report_bug":
-								await TaskServiceClient.askResponse(
+								await sendAskResponseOptimistically(
 									AskResponseRequest.create({
 										responseType: "messageResponse",
 										text: messageToSend,
@@ -132,7 +141,6 @@ export function useMessageHandlers(messages: ClineMessage[], chatState: ChatStat
 										files,
 									}),
 								)
-								messageSent = true
 								break
 						}
 					}
@@ -158,7 +166,7 @@ export function useMessageHandlers(messages: ClineMessage[], chatState: ChatStat
 
 					if (turnAllowsFollowup || isTaskRunning) {
 						// Continue the conversation / interrupt with feedback.
-						await TaskServiceClient.askResponse(
+						await sendAskResponseOptimistically(
 							AskResponseRequest.create({
 								responseType: "messageResponse",
 								text: messageToSend,
@@ -166,7 +174,6 @@ export function useMessageHandlers(messages: ClineMessage[], chatState: ChatStat
 								files,
 							}),
 						)
-						messageSent = true
 					}
 				}
 


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This fixes the visible delay when sending a follow-up message in an existing VS Code extension chat after the agent has finished a turn.

There were two separate issues contributing to the “I hit send and it sits there for a second” feeling.

First, the SDK follow-up path treated an idle-but-live session as if it were gone. `SdkFollowupCoordinator.askResponse()` was using `!activeSession?.isRunning` as the signal that it needed to resume the task from history:

```ts
// old behavior
if (!activeSession?.isRunning && task) {
    await this.tryResumeSessionFromTask(task.taskId, prompt, images, files)
    return
}
```

`isRunning === false` does not mean the SDK session is gone. For normal interactive turn completion, the core runtime keeps the session alive and marks it idle, so the next `send()` can reuse the same in-memory session. The old guard forced the extension to rebuild from persisted history anyway: create a temp host, load initial messages, start a replacement session, then send the follow-up. That extra resume path is unnecessary for normal post-completion follow-ups.

This PR changes the resume decision to only run when `activeSession` is actually absent. Idle-but-live sessions now go through the immediate follow-up path and call `fireAndForgetSend()` on the current SDK host.

There was one important edge case to keep intact: thrown turn failures. In the core runtime, a thrown failure calls `failSession()` and shuts down/removes the runtime session. The VS Code lifecycle could still hold a stale `activeSession` reference after that failure path. This PR clears that reference in the non-abort send error branch so the new invariant is:

```ts
activeSession is set => the runtime session should be alive and reusable
```

That preserves the resume-from-history path for genuinely dead sessions, while avoiding it for normal idle sessions and cancelled/aborted interactive turns that remain reusable.

Second, the webview composer still waited for `TaskServiceClient.askResponse(...)` to resolve before clearing the input for follow-up sends. New tasks had already been made optimistic, but follow-ups still did this:

```ts
await TaskServiceClient.askResponse(...)
clearSentMessageState()
```

`askResponse` can still wait on extension-side work such as context mention resolution before the unary RPC returns. Even when the backend echo is emitted early, the composer can look stuck because the text is not cleared until the await completes.

This PR now clears follow-up composer state before awaiting `askResponse`, matching the new-task behavior, and restores the original text/images/files if the RPC rejects. This covers normal follow-ups, resume-task sends, and ask-response message sends through the composer.

### Test Procedure

Focused SDK tests run from `apps/vscode`:

```bash
bunx vitest run src/sdk/sdk-followup-coordinator.test.ts src/sdk/sdk-session-lifecycle.test.ts --config vitest.config.ts
```

Result: 2 files passed, 31 tests passed.

Focused webview hook test run from `apps/vscode/webview-ui`:

```bash
bunx vitest run src/components/chat/chat-view/hooks/useMessageHandlers.test.tsx
```

Result: 1 file passed, 10 tests passed.

Changed-file Biome check run from `apps/vscode`:

```bash
bunx @biomejs/biome check --config-path ./biome.jsonc --no-errors-on-unmatched --files-ignore-unknown=true src/sdk/sdk-followup-coordinator.ts src/sdk/sdk-session-lifecycle.ts src/sdk/sdk-followup-coordinator.test.ts src/sdk/sdk-session-lifecycle.test.ts webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.ts webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.test.tsx
```

Result: exited successfully. Biome reported existing info-level findings in `useMessageHandlers.ts` (`any` casts and an exhaustive-deps suggestion), but no errors and no fixes were applied.

Whitespace check from repo root:

```bash
git diff --check
```

Result: passed.

I also previously ran a broader SDK-adapter Vitest sweep:

```bash
bunx vitest run src/sdk --config vitest.config.ts
```

That run passed 46 suites / 596 tests, then failed on `src/sdk/sdk-tool-policies.test.ts` because that file imports `bun:test`, which Vitest cannot resolve in this invocation. That failure is unrelated to this PR's changed files; the targeted suites for the changed files pass.

The regression tests added here cover:

- an idle active session with a displayed task reuses the current SDK host instead of resuming from disk
- thrown send failures clear the stale active session reference so future sends can resume correctly
- follow-up composer state clears before `askResponse` resolves
- failed follow-up RPCs restore the pending composer state

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. This is SDK session lifecycle and chat composer behavior with no visual styling changes.

### Additional Notes

The mode-rebuild race protection remains in place. `askResponse()` still waits for a pending mode rebuild before deciding whether to resume or send; the only changed decision is that an idle active session is no longer treated as absent.
