### PR TITLE
fix: improve ask option selection UI

### DIFF
--- a/apps/vscode/webview-ui/src/components/chat/OptionsButtons.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/OptionsButtons.test.tsx
@@ -37,4 +37,25 @@ describe("OptionsButtons", () => {
 
 		expect(askResponseMock).toHaveBeenCalledTimes(1)
 	})
+
+	it("re-enables options after askResponse rejects", async () => {
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+		askResponseMock.mockRejectedValue(new Error("failed"))
+
+		render(<OptionsButtons isActive options={["Use this", "Use that"]} />)
+
+		const selectedButton = screen.getByRole("button", { name: "Use this" })
+		const otherButton = screen.getByRole("button", { name: "Use that" })
+
+		fireEvent.click(selectedButton)
+
+		expect(askResponseMock).toHaveBeenCalledTimes(1)
+		await waitFor(() => {
+			expect(selectedButton).not.toBeDisabled()
+			expect(otherButton).not.toBeDisabled()
+			expect(getComputedStyle(otherButton).cursor).toBe("pointer")
+		})
+
+		consoleError.mockRestore()
+	})
 })

--- a/apps/vscode/webview-ui/src/components/chat/OptionsButtons.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/OptionsButtons.test.tsx
@@ -1,0 +1,40 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { OptionsButtons } from "./OptionsButtons"
+
+const askResponseMock = vi.hoisted(() => vi.fn())
+
+vi.mock("@/services/grpc-client", () => ({
+	TaskServiceClient: {
+		askResponse: askResponseMock,
+	},
+}))
+
+describe("OptionsButtons", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it("removes hover affordance from the other options immediately after a selection", async () => {
+		askResponseMock.mockReturnValue(new Promise(() => undefined))
+
+		render(<OptionsButtons isActive options={["Use this", "Use that"]} />)
+
+		const selectedButton = screen.getByRole("button", { name: "Use this" })
+		const otherButton = screen.getByRole("button", { name: "Use that" })
+
+		expect(getComputedStyle(otherButton).cursor).toBe("pointer")
+
+		fireEvent.click(selectedButton)
+
+		expect(askResponseMock).toHaveBeenCalledTimes(1)
+		await waitFor(() => {
+			expect(getComputedStyle(selectedButton).cursor).toBe("default")
+			expect(getComputedStyle(otherButton).cursor).toBe("default")
+		})
+
+		fireEvent.click(otherButton)
+
+		expect(askResponseMock).toHaveBeenCalledTimes(1)
+	})
+})

--- a/apps/vscode/webview-ui/src/components/chat/OptionsButtons.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/OptionsButtons.tsx
@@ -1,20 +1,21 @@
 import { AskResponseRequest } from "@shared/proto/cline/task"
+import { useState } from "react"
 import styled from "styled-components"
 import { CODE_BLOCK_BG_COLOR } from "@/components/common/CodeBlock"
 import { TaskServiceClient } from "@/services/grpc-client"
 
-const OptionButton = styled.button<{ isSelected?: boolean; isNotSelectable?: boolean }>`
+const OptionButton = styled.button<{ $isSelected?: boolean; $isNotSelectable?: boolean }>`
 	padding: 8px 12px;
-	background: ${(props) => (props.isSelected ? "var(--vscode-focusBorder)" : CODE_BLOCK_BG_COLOR)};
-	color: ${(props) => (props.isSelected ? "white" : "var(--vscode-input-foreground)")};
+	background: ${(props) => (props.$isSelected ? "var(--vscode-focusBorder)" : CODE_BLOCK_BG_COLOR)};
+	color: ${(props) => (props.$isSelected ? "white" : "var(--vscode-input-foreground)")};
 	border: 1px solid var(--vscode-editorGroup-border);
 	border-radius: 2px;
-	cursor: ${(props) => (props.isNotSelectable ? "default" : "pointer")};
+	cursor: ${(props) => (props.$isNotSelectable ? "default" : "pointer")};
 	text-align: left;
 	font-size: 12px;
 
 	${(props) =>
-		!props.isNotSelectable &&
+		!props.$isNotSelectable &&
 		`
 		&:hover {
 			background: var(--vscode-focusBorder);
@@ -34,11 +35,22 @@ export const OptionsButtons = ({
 	isActive?: boolean
 	inputValue?: string
 }) => {
-	if (!options?.length) {
+	const optionItems = options ?? []
+	const optionsKey = optionItems.join("\u0000")
+	const optimisticSelectionKey = `${selected ?? ""}\u0001${optionsKey}`
+	const [optimisticSelection, setOptimisticSelection] = useState<{ key: string; option: string }>()
+
+	if (!optionItems.length) {
 		return null
 	}
 
-	const hasSelected = selected !== undefined && options.includes(selected)
+	const selectedOption =
+		selected !== undefined && optionItems.includes(selected)
+			? selected
+			: optimisticSelection?.key === optimisticSelectionKey
+				? optimisticSelection.option
+				: undefined
+	const hasSelected = selectedOption !== undefined && optionItems.includes(selectedOption)
 
 	return (
 		<div
@@ -50,17 +62,18 @@ export const OptionsButtons = ({
 			{/* <div style={{ color: "var(--vscode-descriptionForeground)", fontSize: "11px", textTransform: "uppercase" }}>
 				SELECT ONE:
 			</div> */}
-			{options.map((option, index) => (
+			{optionItems.map((option, index) => (
 				<OptionButton
+					$isNotSelectable={hasSelected || !isActive}
+					$isSelected={option === selectedOption}
 					className="options-button"
 					id={`options-button-${index}`}
-					isNotSelectable={hasSelected || !isActive}
-					isSelected={option === selected}
-					key={index}
+					key={option}
 					onClick={async () => {
 						if (hasSelected || !isActive) {
 							return
 						}
+						setOptimisticSelection({ key: optimisticSelectionKey, option })
 						try {
 							await TaskServiceClient.askResponse(
 								AskResponseRequest.create({
@@ -70,6 +83,7 @@ export const OptionsButtons = ({
 								}),
 							)
 						} catch (error) {
+							setOptimisticSelection(undefined)
 							console.error("Error sending option response:", error)
 						}
 					}}>

--- a/apps/vscode/webview-ui/src/components/chat/OptionsButtons.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/OptionsButtons.tsx
@@ -67,6 +67,7 @@ export const OptionsButtons = ({
 					$isNotSelectable={hasSelected || !isActive}
 					$isSelected={option === selectedOption}
 					className="options-button"
+					disabled={hasSelected || !isActive}
 					id={`options-button-${index}`}
 					key={option}
 					onClick={async () => {

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/utils/messageUtils.test.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/utils/messageUtils.test.ts
@@ -1,6 +1,6 @@
 import type { ClineMessage } from "@shared/ExtensionMessage"
 import { describe, expect, it } from "vitest"
-import { groupLowStakesTools, isToolGroup } from "./messageUtils"
+import { filterVisibleMessages, groupLowStakesTools, isToolGroup } from "./messageUtils"
 
 const createTextMessage = (ts: number, text: string): ClineMessage => ({
 	type: "say",
@@ -21,6 +21,69 @@ const createReasoningMessage = (ts: number, text: string): ClineMessage => ({
 	say: "reasoning",
 	text,
 	ts,
+})
+
+const createUserFeedbackMessage = (ts: number, text: string): ClineMessage => ({
+	type: "say",
+	say: "user_feedback",
+	text,
+	ts,
+})
+
+const createAskMessage = (
+	ts: number,
+	ask: "followup" | "plan_mode_respond",
+	options: string[],
+	selected?: string,
+): ClineMessage => ({
+	type: "ask",
+	ask,
+	text: JSON.stringify(
+		ask === "followup" ? { question: "Pick one", options, selected } : { response: "Pick one", options, selected },
+	),
+	ts,
+})
+
+describe("filterVisibleMessages", () => {
+	it("hides exact user feedback echoes for selected follow-up options", () => {
+		const askMessage = createAskMessage(1, "followup", ["Use this", "Use that"], "Use this")
+		const visible = filterVisibleMessages([askMessage, createUserFeedbackMessage(2, "Use this")])
+
+		expect(visible).toEqual([askMessage])
+	})
+
+	it("hides exact option echoes when selected has not been persisted on the ask row yet", () => {
+		const askMessage = createAskMessage(1, "followup", ["Use this", "Use that"])
+		const visible = filterVisibleMessages([askMessage, createUserFeedbackMessage(2, "Use this")])
+
+		expect(visible).toEqual([askMessage])
+	})
+
+	it("hides exact user feedback echoes for plan-mode response options", () => {
+		const askMessage = createAskMessage(1, "plan_mode_respond", ["Plan it", "Do it"], "Plan it")
+		const visible = filterVisibleMessages([askMessage, createUserFeedbackMessage(2, "Plan it")])
+
+		expect(visible).toEqual([askMessage])
+	})
+
+	it("keeps custom user feedback that extends a selected option", () => {
+		const askMessage = createAskMessage(1, "followup", ["Use this", "Use that"], "Use this")
+		const userMessage = createUserFeedbackMessage(2, "Use this: include tests")
+		const visible = filterVisibleMessages([askMessage, userMessage])
+
+		expect(visible).toEqual([askMessage, userMessage])
+	})
+
+	it("keeps exact option feedback when it includes attachments", () => {
+		const askMessage = createAskMessage(1, "followup", ["Use this", "Use that"], "Use this")
+		const userMessage: ClineMessage = {
+			...createUserFeedbackMessage(2, "Use this"),
+			images: ["data:image/png;base64,abc"],
+		}
+		const visible = filterVisibleMessages([askMessage, userMessage])
+
+		expect(visible).toEqual([askMessage, userMessage])
+	})
 })
 
 describe("groupLowStakesTools", () => {

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/utils/messageUtils.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/utils/messageUtils.ts
@@ -2,7 +2,13 @@
  * Utility functions for message filtering, grouping, and manipulation
  */
 
-import type { ClineMessage, ClineSayBrowserAction, ClineSayTool } from "@shared/ExtensionMessage"
+import type {
+	ClineAskQuestion,
+	ClineMessage,
+	ClinePlanModeResponse,
+	ClineSayBrowserAction,
+	ClineSayTool,
+} from "@shared/ExtensionMessage"
 import { FileIcon, FolderOpenDotIcon, FolderOpenIcon, SearchIcon, ShapesIcon, WrenchIcon } from "lucide-react"
 
 /**
@@ -35,7 +41,36 @@ export function isLowStakesTool(message: ClineMessage): boolean {
  * Check if a message group is a tool group (array with _isToolGroup marker)
  */
 export function isToolGroup(item: ClineMessage | ClineMessage[]): item is ClineMessage[] & { _isToolGroup: true } {
-	return Array.isArray(item) && (item as any)._isToolGroup === true
+	return Array.isArray(item) && (item as ClineMessage[] & { _isToolGroup?: boolean })._isToolGroup === true
+}
+
+function isDuplicateAskOptionEcho(message: ClineMessage, previousMessage: ClineMessage | undefined): boolean {
+	if (
+		message.type !== "say" ||
+		message.say !== "user_feedback" ||
+		(message.images?.length ?? 0) > 0 ||
+		(message.files?.length ?? 0) > 0 ||
+		previousMessage?.type !== "ask" ||
+		(previousMessage.ask !== "followup" && previousMessage.ask !== "plan_mode_respond")
+	) {
+		return false
+	}
+
+	const responseText = message.text ?? ""
+	if (!responseText) {
+		return false
+	}
+
+	try {
+		const parsed = JSON.parse(previousMessage.text || "{}") as ClineAskQuestion | ClinePlanModeResponse
+		if (!parsed.options?.includes(responseText)) {
+			return false
+		}
+
+		return parsed.selected === undefined || parsed.selected === responseText
+	} catch {
+		return false
+	}
 }
 
 /**
@@ -43,6 +78,10 @@ export function isToolGroup(item: ClineMessage | ClineMessage[]): item is ClineM
  */
 export function filterVisibleMessages(messages: ClineMessage[]): ClineMessage[] {
 	return messages.filter((message, index, arr) => {
+		if (isDuplicateAskOptionEcho(message, arr[index - 1])) {
+			return false
+		}
+
 		switch (message.ask) {
 			case "completion_result":
 				// don't show a chat row for a completion_result ask without text. This specific type of message only occurs if cline wants to execute a command as part of its completion result, in which case we interject the completion_result tool with the execute_command tool.
@@ -105,7 +144,7 @@ export function filterVisibleMessages(messages: ClineMessage[]): ClineMessage[] 
  */
 function isBrowserSessionMessage(message: ClineMessage): boolean {
 	if (message.type === "ask") {
-		return ["browser_action_launch"].includes(message.ask!)
+		return message.ask === "browser_action_launch"
 	}
 	if (message.type === "say") {
 		return [
@@ -117,7 +156,7 @@ function isBrowserSessionMessage(message: ClineMessage): boolean {
 			"checkpoint_created",
 			"reasoning",
 			"error_retry",
-		].includes(message.say!)
+		].includes(message.say ?? "")
 	}
 	return false
 }
@@ -501,8 +540,12 @@ export function groupLowStakesTools(groupedMessages: (ClineMessage | ClineMessag
 	const pendingTools: ClineMessage[] = []
 
 	const flushPending = () => {
-		pendingApiReq.forEach((m) => result.push(m))
-		pendingReasoning.forEach((m) => result.push(m))
+		pendingApiReq.forEach((m) => {
+			result.push(m)
+		})
+		pendingReasoning.forEach((m) => {
+			result.push(m)
+		})
 		pendingApiReq = []
 		pendingReasoning = []
 	}


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This PR fixes a small but confusing UI issue in the VS Code webview Ask Question / plan response option buttons.

When Cline asks a follow-up question with suggested answer options, selecting an option immediately sends that option as the user's response. Before this change, the other option buttons could still look hoverable/clickable during the async response round trip, which made the UI feel like the user could still change their answer after it had already been sent.

The option buttons now lock immediately on click using a scoped optimistic selection state. The clicked option is shown as selected, all options become non-hoverable and natively disabled, and the server-provided `selected` value still wins once it arrives. If sending the option fails, the optimistic state is cleared so the user can retry.

This also removes the duplicate-looking user bubble for exact option selections. The selected option is already visible on the ask row, so rendering a separate `user_feedback` row with the same exact option text makes the chat look redundant. The filter is intentionally narrow: it hides only an exact option echo immediately after a follow-up or plan response ask row. Custom responses like `Use this: include tests`, or messages with images/files, remain visible.

### Test Procedure

Ran focused webview tests for the affected components/utilities:

```sh
cd apps/vscode/webview-ui
bun run test src/components/chat/OptionsButtons.test.tsx src/components/chat/chat-view/utils/messageUtils.test.ts
```

This covers:

- immediate option locking and hover removal after click
- native disabled state preventing duplicate submissions
- error recovery when `askResponse` rejects
- hiding exact duplicate option echoes after follow-up and plan-mode asks
- keeping custom option responses and attachment-bearing user messages visible

Ran Biome on the touched files:

```sh
cd apps/vscode
bunx biome check webview-ui/src/components/chat/OptionsButtons.tsx webview-ui/src/components/chat/OptionsButtons.test.tsx webview-ui/src/components/chat/chat-view/utils/messageUtils.ts webview-ui/src/components/chat/chat-view/utils/messageUtils.test.ts
```

Also attempted the webview TypeScript build:

```sh
cd apps/vscode/webview-ui
bunx tsc -b
```

That currently fails on an unrelated branch/base issue:

```text
src/components/common/CheckmarkControl.tsx(106,35): error TS2339: Property 'checkpointDiff' does not exist on type 'typeof CheckpointsServiceClient'.
```

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

No screenshot attached. This is a small interaction/rendering-state fix covered by focused component and message-filter tests.

### Additional Notes

The chat still sends the selected option as the user response. This PR only fixes the visual interaction state and hides the redundant exact echo in the rendered message list.
