### PR TITLE
fix(vscode): keep command output pinned to bottom

### DIFF
--- a/apps/vscode/webview-ui/src/components/chat/ChatRow.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatRow.tsx
@@ -71,6 +71,7 @@ interface ChatRowProps {
 	lastModifiedMessage?: ClineMessage
 	isLast: boolean
 	onHeightChange: (isTaller: boolean) => void
+	onLastRowContentChange: () => void
 	inputValue?: string
 	sendMessageFromChatRow?: (text: string, images: string[], files: string[]) => void
 	onSetQuote: (text: string) => void
@@ -88,7 +89,9 @@ export interface QuoteButtonState {
 	selectedText: string
 }
 
-interface ChatRowContentProps extends Omit<ChatRowProps, "onHeightChange"> {}
+interface ChatRowContentProps extends Omit<ChatRowProps, "onHeightChange" | "onLastRowContentChange"> {
+	onLastRowContentChange?: () => void
+}
 
 export const ProgressIndicator = () => <LoaderCircleIcon className="size-2 mr-2 animate-spin" />
 const InvisibleSpacer = () => <div aria-hidden className="h-px" />
@@ -139,6 +142,7 @@ export const ChatRowContent = memo(
 		sendMessageFromChatRow,
 		onSetQuote,
 		onCancelCommand,
+		onLastRowContentChange,
 		mode,
 		isRequestInProgress,
 		reasoningContent,
@@ -742,6 +746,7 @@ export const ChatRowContent = memo(
 					isCommandPending={isCommandPending}
 					isOutputFullyExpanded={isOutputFullyExpanded}
 					message={message}
+					onOutputChange={isLast ? onLastRowContentChange : undefined}
 					onCancelCommand={onCancelCommand}
 					setIsOutputFullyExpanded={setIsOutputFullyExpanded}
 					title={title}

--- a/apps/vscode/webview-ui/src/components/chat/CommandOutputRow.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/CommandOutputRow.test.tsx
@@ -1,0 +1,78 @@
+import { render, waitFor } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { CommandOutputContent } from "./CommandOutputRow"
+
+vi.mock("../common/CodeBlock", () => ({
+	default: ({ source }: { source: string }) => <pre>{source}</pre>,
+}))
+
+describe("CommandOutputContent", () => {
+	it("notifies when visible output changes", async () => {
+		const onOutputChange = vi.fn()
+		const { rerender } = render(
+			<CommandOutputContent
+				isContainerExpanded={true}
+				isOutputFullyExpanded={false}
+				onOutputChange={onOutputChange}
+				onToggle={vi.fn()}
+				output="first line"
+			/>,
+		)
+
+		await waitFor(() => expect(onOutputChange).toHaveBeenCalledTimes(1))
+
+		rerender(
+			<CommandOutputContent
+				isContainerExpanded={true}
+				isOutputFullyExpanded={false}
+				onOutputChange={onOutputChange}
+				onToggle={vi.fn()}
+				output={"first line\nsecond line"}
+			/>,
+		)
+
+		await waitFor(() => expect(onOutputChange).toHaveBeenCalledTimes(2))
+	})
+
+	it("notifies when visible output expansion changes", async () => {
+		const onOutputChange = vi.fn()
+		const { rerender } = render(
+			<CommandOutputContent
+				isContainerExpanded={true}
+				isOutputFullyExpanded={false}
+				onOutputChange={onOutputChange}
+				onToggle={vi.fn()}
+				output={"1\n2\n3\n4\n5\n6"}
+			/>,
+		)
+
+		await waitFor(() => expect(onOutputChange).toHaveBeenCalledTimes(1))
+
+		rerender(
+			<CommandOutputContent
+				isContainerExpanded={true}
+				isOutputFullyExpanded={true}
+				onOutputChange={onOutputChange}
+				onToggle={vi.fn()}
+				output={"1\n2\n3\n4\n5\n6"}
+			/>,
+		)
+
+		await waitFor(() => expect(onOutputChange).toHaveBeenCalledTimes(2))
+	})
+
+	it("does not notify while the container is collapsed", async () => {
+		const onOutputChange = vi.fn()
+		render(
+			<CommandOutputContent
+				isContainerExpanded={false}
+				isOutputFullyExpanded={false}
+				onOutputChange={onOutputChange}
+				onToggle={vi.fn()}
+				output="hidden"
+			/>,
+		)
+
+		await waitFor(() => expect(onOutputChange).not.toHaveBeenCalled())
+	})
+})

--- a/apps/vscode/webview-ui/src/components/chat/CommandOutputRow.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/CommandOutputRow.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from "@testing-library/react"
+import { act, render, waitFor } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 import { CommandOutputContent } from "./CommandOutputRow"
 
@@ -73,6 +73,7 @@ describe("CommandOutputContent", () => {
 			/>,
 		)
 
-		await waitFor(() => expect(onOutputChange).not.toHaveBeenCalled())
+		await act(async () => {})
+		expect(onOutputChange).not.toHaveBeenCalled()
 	})
 })

--- a/apps/vscode/webview-ui/src/components/chat/CommandOutputRow.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/CommandOutputRow.tsx
@@ -14,11 +14,13 @@ export const CommandOutputContent = memo(
 		isOutputFullyExpanded,
 		onToggle,
 		isContainerExpanded,
+		onOutputChange,
 	}: {
 		output: string
 		isOutputFullyExpanded: boolean
 		onToggle: () => void
 		isContainerExpanded: boolean
+		onOutputChange?: () => void
 	}) => {
 		const outputLines = output.split("\n")
 		const lineCount = outputLines.length
@@ -39,6 +41,12 @@ export const CommandOutputContent = memo(
 				}, 50)
 			}
 		}, [output, isOutputFullyExpanded])
+
+		useEffect(() => {
+			if (isContainerExpanded) {
+				onOutputChange?.()
+			}
+		}, [output, isOutputFullyExpanded, isContainerExpanded, onOutputChange])
 
 		// Don't render anything if container is collapsed
 		if (!isContainerExpanded) {
@@ -118,6 +126,7 @@ export const CommandOutputRow = memo(
 		title,
 		isOutputFullyExpanded,
 		setIsOutputFullyExpanded,
+		onOutputChange,
 	}: {
 		message: ClineMessage
 		isCommandExecuting?: boolean
@@ -129,6 +138,7 @@ export const CommandOutputRow = memo(
 		title?: JSX.Element | null
 		isOutputFullyExpanded: boolean
 		setIsOutputFullyExpanded: (expanded: boolean) => void
+		onOutputChange?: () => void
 	}) => {
 		const splitMessage = (text: string) => {
 			const outputIndex = text.indexOf(COMMAND_OUTPUT_STRING)
@@ -230,6 +240,7 @@ export const CommandOutputRow = memo(
 							isContainerExpanded={true}
 							isOutputFullyExpanded={isOutputFullyExpanded}
 							onToggle={() => setIsOutputFullyExpanded(!isOutputFullyExpanded)}
+							onOutputChange={onOutputChange}
 							output={output}
 						/>
 					)}

--- a/apps/vscode/webview-ui/src/components/chat/HookMessage.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/HookMessage.tsx
@@ -42,7 +42,6 @@ interface HookMessageProps {
 		isOutputFullyExpanded: boolean
 		onToggle: () => void
 		isContainerExpanded: boolean
-		onOutputChange?: () => void
 	}>
 }
 

--- a/apps/vscode/webview-ui/src/components/chat/HookMessage.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/HookMessage.tsx
@@ -42,6 +42,7 @@ interface HookMessageProps {
 		isOutputFullyExpanded: boolean
 		onToggle: () => void
 		isContainerExpanded: boolean
+		onOutputChange?: () => void
 	}>
 }
 

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/MessagesArea.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/MessagesArea.tsx
@@ -49,6 +49,7 @@ export const MessagesArea: React.FC<MessagesAreaProps> = ({
 		scrollToMessage,
 		scrollToBottomSmooth,
 		scrollToBottomAuto,
+		handleLastRowContentChange,
 	} = scrollBehavior
 
 	// Find the index of the scrolled past user message for scrolling
@@ -247,6 +248,7 @@ export const MessagesArea: React.FC<MessagesAreaProps> = ({
 				expandedRows,
 				toggleRowExpansion,
 				handleRowHeightChange,
+				handleLastRowContentChange,
 				setActiveQuote,
 				inputValue,
 				messageHandlers,
@@ -258,6 +260,7 @@ export const MessagesArea: React.FC<MessagesAreaProps> = ({
 			expandedRows,
 			toggleRowExpansion,
 			handleRowHeightChange,
+			handleLastRowContentChange,
 			setActiveQuote,
 			inputValue,
 			messageHandlers,

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/components/messages/MessageRenderer.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/components/messages/MessageRenderer.tsx
@@ -17,6 +17,7 @@ interface MessageRendererProps {
 	expandedRows: Record<number, boolean>
 	onToggleExpand: (ts: number) => void
 	onHeightChange: (isTaller: boolean) => void
+	onLastRowContentChange: () => void
 	onSetQuote: (quote: string | null) => void
 	inputValue: string
 	messageHandlers: MessageHandlers
@@ -35,6 +36,7 @@ const MessageRenderer: React.FC<MessageRendererProps> = ({
 	expandedRows,
 	onToggleExpand,
 	onHeightChange,
+	onLastRowContentChange,
 	onSetQuote,
 	inputValue,
 	messageHandlers,
@@ -115,6 +117,7 @@ const MessageRenderer: React.FC<MessageRendererProps> = ({
 				mode={mode}
 				onCancelCommand={() => messageHandlers.executeButtonAction("cancel")}
 				onHeightChange={onHeightChange}
+				onLastRowContentChange={onLastRowContentChange}
 				onSetQuote={onSetQuote}
 				onToggleExpand={onToggleExpand}
 				reasoningContent={reasoningData.reasoning}
@@ -135,6 +138,7 @@ export const createMessageRenderer = (
 	expandedRows: Record<number, boolean>,
 	onToggleExpand: (ts: number) => void,
 	onHeightChange: (isTaller: boolean) => void,
+	onLastRowContentChange: () => void,
 	onSetQuote: (quote: string | null) => void,
 	inputValue: string,
 	messageHandlers: MessageHandlers,
@@ -151,6 +155,7 @@ export const createMessageRenderer = (
 			messageOrGroup={messageOrGroup}
 			modifiedMessages={modifiedMessages}
 			onHeightChange={onHeightChange}
+			onLastRowContentChange={onLastRowContentChange}
 			onSetQuote={onSetQuote}
 			onToggleExpand={onToggleExpand}
 		/>

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useScrollBehavior.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useScrollBehavior.ts
@@ -273,6 +273,24 @@ export function useScrollBehavior(
 		[scrollToBottomSmooth, scrollToBottomAuto],
 	)
 
+	const handleLastRowContentChange = useCallback(() => {
+		if (disableAutoScrollRef.current) {
+			return
+		}
+
+		scrollToBottomSmooth()
+		setTimeout(() => {
+			if (!disableAutoScrollRef.current) {
+				scrollToBottomAuto()
+			}
+		}, 0)
+		setTimeout(() => {
+			if (!disableAutoScrollRef.current) {
+				scrollToBottomAuto()
+			}
+		}, 50)
+	}, [scrollToBottomSmooth, scrollToBottomAuto])
+
 	useEffect(() => {
 		if (!disableAutoScrollRef.current) {
 			scrollToBottomSmooth()
@@ -316,6 +334,7 @@ export function useScrollBehavior(
 		scrollToMessage,
 		toggleRowExpansion,
 		handleRowHeightChange,
+		handleLastRowContentChange,
 		isAtBottom,
 		setIsAtBottom,
 		pendingScrollToMessage,

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useScrollBehavior.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useScrollBehavior.ts
@@ -30,6 +30,7 @@ export function useScrollBehavior(
 	const virtuosoRef = useRef<VirtuosoHandle>(null)
 	const scrollContainerRef = useRef<HTMLDivElement>(null)
 	const disableAutoScrollRef = useRef(false)
+	const lastRowContentScrollTimersRef = useRef<ReturnType<typeof setTimeout>[]>([])
 
 	// State
 	const [isAtBottom, setIsAtBottom] = useState(false)
@@ -273,23 +274,28 @@ export function useScrollBehavior(
 		[scrollToBottomSmooth, scrollToBottomAuto],
 	)
 
+	const clearLastRowContentScrollTimers = useCallback(() => {
+		lastRowContentScrollTimersRef.current.forEach((timer) => clearTimeout(timer))
+		lastRowContentScrollTimersRef.current = []
+	}, [])
+
 	const handleLastRowContentChange = useCallback(() => {
 		if (disableAutoScrollRef.current) {
 			return
 		}
 
+		clearLastRowContentScrollTimers()
 		scrollToBottomSmooth()
-		setTimeout(() => {
-			if (!disableAutoScrollRef.current) {
-				scrollToBottomAuto()
-			}
-		}, 0)
-		setTimeout(() => {
-			if (!disableAutoScrollRef.current) {
-				scrollToBottomAuto()
-			}
-		}, 50)
-	}, [scrollToBottomSmooth, scrollToBottomAuto])
+		lastRowContentScrollTimersRef.current = [0, 50].map((delay) =>
+			setTimeout(() => {
+				if (!disableAutoScrollRef.current) {
+					scrollToBottomAuto()
+				}
+			}, delay),
+		)
+	}, [clearLastRowContentScrollTimers, scrollToBottomSmooth, scrollToBottomAuto])
+
+	useEffect(() => clearLastRowContentScrollTimers, [clearLastRowContentScrollTimers])
 
 	useEffect(() => {
 		if (!disableAutoScrollRef.current) {

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/types/chatTypes.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/types/chatTypes.ts
@@ -73,6 +73,7 @@ export interface ScrollBehavior {
 	scrollToMessage: (messageIndex: number) => void
 	toggleRowExpansion: (ts: number) => void
 	handleRowHeightChange: (isTaller: boolean) => void
+	handleLastRowContentChange: () => void
 	isAtBottom: boolean
 	setIsAtBottom: React.Dispatch<React.SetStateAction<boolean>>
 	pendingScrollToMessage: number | null


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This fixes the VS Code webview Run Command output view drifting away from the bottom while command output is appended. The user-visible problem was that the command output itself could show new content, but the outer chat scroller did not reliably remain pinned to the footer/pinned action area, so users had to manually scroll back down.

The root cause is that command output updates are not always represented as a new rendered chat row. They often mutate the existing last command row: `combineCommandSequences` folds `command_output` messages back into the command message, and `CommandOutputContent` then updates inside that already-mounted row. The existing scroll behavior already handled new row count changes and generic row height changes, but command output has its own inner scroll container and delayed rendering/settling. That meant the outer Virtuoso scroller could decide it was already pinned before the command output layout finished changing.

The approach here is to make that relationship explicit:

- `useScrollBehavior` now exposes `handleLastRowContentChange`, using the same guarded bottom-scroll behavior as the existing auto-scroll paths.
- `MessagesArea` and `MessageRenderer` thread that handler down to chat rows.
- `ChatRow` only passes the handler to `CommandOutputRow` when the command row is the last visible row. This avoids yanking the user back to the bottom if they are reading or expanding older command output in history.
- `CommandOutputContent` calls the handler when visible output changes or when the command output expansion state changes.
- `HookMessage` has a small type update because it reuses `CommandOutputContent` as an injected component.

The main gotcha was preserving the existing manual-scroll behavior. The new handler still respects `disableAutoScrollRef`, so if the user has intentionally scrolled upward, command output updates should not force them back down.

### Test Procedure

Focused verification run:

```sh
bun -F webview-ui test -- CommandOutputRow.test.tsx
bun -F webview-ui build
```

The new `CommandOutputRow.test.tsx` covers the regression hook at the component boundary:

- visible command output changes notify the outer scroll layer
- output expansion changes notify the outer scroll layer
- collapsed output does not notify

The production webview build also passed, which verifies TypeScript and bundling across the affected chat components.

Potentially affected behavior is chat auto-scroll in the VS Code webview. The change is intentionally scoped to command output in the last visible row and reuses the existing scroll-disable guard, so historical command rows and user-controlled upward scrolling should keep their current behavior.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. This is a scroll-position behavior fix in the VS Code webview. The focused component test and webview build are included above; a reviewer can additionally validate manually by running a command that streams enough output to overflow the Run Command output area and confirming the chat remains pinned to the bottom while output arrives.

### Additional Notes

No related issue number was provided, so the template placeholder is left as `#XXXX`.

I did not run the full repository `bun test`, `bun run format`, or `bun run lint`; only the focused webview regression test and production webview build were run.
