### PR TITLE
Fix bun createRequire on cli build

### DIFF
--- a/apps/cli/bun.mts
+++ b/apps/cli/bun.mts
@@ -121,7 +121,7 @@ const result = await Bun.build({
 	},
 	env: "OTEL_*",
 	banner:
-		'import { createRequire as __createRequire } from "node:module"; const require = __createRequire(import.meta.url);',
+		'import { createRequire as __clineCreateRequire } from "node:module"; const require = __clineCreateRequire(import.meta.url);',
 });
 
 if (result.logs.length > 0) {


### PR DESCRIPTION
Tests are failing because the sapAiModule uses the same __createRequire name