### PR TITLE
fix(vscode): show pending state before queued prompt appears

### DIFF
--- a/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1451,7 +1451,6 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					<DynamicTextArea
 						autoFocus={true}
 						data-testid="chat-input"
-						disabled={sendingDisabled}
 						maxRows={10}
 						minRows={3}
 						onBlur={handleBlur}
@@ -1510,8 +1509,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 							// Instead of using boxShadow, we use a div with a border to better replicate the behavior when the textarea is focused
 							// boxShadow: "0px 0px 0px 1px var(--vscode-input-border)",
 							padding: "9px 28px 9px 9px",
-							cursor: sendingDisabled ? "not-allowed" : "text",
-							opacity: sendingDisabled ? 0.65 : 1,
+							cursor: "text",
 							flex: 1,
 							zIndex: 1,
 							outline:

--- a/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1451,6 +1451,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					<DynamicTextArea
 						autoFocus={true}
 						data-testid="chat-input"
+						disabled={sendingDisabled}
 						maxRows={10}
 						minRows={3}
 						onBlur={handleBlur}
@@ -1509,7 +1510,8 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 							// Instead of using boxShadow, we use a div with a border to better replicate the behavior when the textarea is focused
 							// boxShadow: "0px 0px 0px 1px var(--vscode-input-border)",
 							padding: "9px 28px 9px 9px",
-							cursor: "text",
+							cursor: sendingDisabled ? "not-allowed" : "text",
+							opacity: sendingDisabled ? 0.65 : 1,
 							flex: 1,
 							zIndex: 1,
 							outline:

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.test.tsx
@@ -148,6 +148,108 @@ describe("useMessageHandlers — send routing", () => {
 		)
 	})
 
+	it("shows pending composer state before a follow-up askResponse resolves", async () => {
+		mockTurnState = { phase: "completed", seq: 7 }
+		let resolveAskResponse: () => void = () => {}
+		askResponse.mockImplementationOnce(
+			() =>
+				new Promise<void>((resolve) => {
+					resolveAskResponse = resolve
+				}),
+		)
+		const setInputValue = vi.fn()
+		const setActiveQuote = vi.fn()
+		const setSendingDisabled = vi.fn()
+		const setSelectedImages = vi.fn()
+		const setSelectedFiles = vi.fn()
+		const setEnableButtons = vi.fn()
+		const chatState = makeChatState(completedConversation, {
+			activeQuote: "selected context",
+			sendingDisabled: false,
+			enableButtons: true,
+			setInputValue,
+			setActiveQuote,
+			setSendingDisabled,
+			setSelectedImages,
+			setSelectedFiles,
+			setEnableButtons,
+		})
+		const { result } = renderHook(() => useMessageHandlers(completedConversation, chatState))
+
+		let sendPromise: Promise<void> = Promise.resolve()
+		await act(async () => {
+			sendPromise = result.current.handleSendMessage("another question", ["image.png"], ["a.ts"])
+			await Promise.resolve()
+		})
+
+		expect(askResponse).toHaveBeenCalledWith(
+			expect.objectContaining({
+				responseType: "messageResponse",
+				text: expect.stringContaining("another question"),
+				images: ["image.png"],
+				files: ["a.ts"],
+			}),
+		)
+		expect(setInputValue).toHaveBeenCalledWith("")
+		expect(setActiveQuote).toHaveBeenCalledWith(null)
+		expect(setSendingDisabled).toHaveBeenCalledWith(true)
+		expect(setSelectedImages).toHaveBeenCalledWith([])
+		expect(setSelectedFiles).toHaveBeenCalledWith([])
+		expect(setEnableButtons).toHaveBeenCalledWith(false)
+
+		await act(async () => {
+			resolveAskResponse()
+			await sendPromise
+		})
+	})
+
+	it("restores pending follow-up UI state when askResponse fails", async () => {
+		mockTurnState = { phase: "completed", seq: 7 }
+		const error = new Error("transport down")
+		const setInputValue = vi.fn()
+		const setActiveQuote = vi.fn()
+		const setSendingDisabled = vi.fn()
+		const setSelectedImages = vi.fn()
+		const setSelectedFiles = vi.fn()
+		const setEnableButtons = vi.fn()
+		const chatState = makeChatState(completedConversation, {
+			activeQuote: "selected context",
+			sendingDisabled: false,
+			enableButtons: true,
+			setInputValue,
+			setActiveQuote,
+			setSendingDisabled,
+			setSelectedImages,
+			setSelectedFiles,
+			setEnableButtons,
+		})
+		const { result } = renderHook(() => useMessageHandlers(completedConversation, chatState))
+		askResponse.mockRejectedValueOnce(error)
+
+		let caught: unknown
+		await act(async () => {
+			try {
+				await result.current.handleSendMessage("another question", ["image.png"], ["a.ts"])
+			} catch (err) {
+				caught = err
+			}
+		})
+
+		expect(caught).toBe(error)
+		expect(setInputValue).toHaveBeenNthCalledWith(1, "")
+		expect(setInputValue).toHaveBeenLastCalledWith("another question")
+		expect(setActiveQuote).toHaveBeenNthCalledWith(1, null)
+		expect(setActiveQuote).toHaveBeenLastCalledWith("selected context")
+		expect(setSendingDisabled).toHaveBeenNthCalledWith(1, true)
+		expect(setSendingDisabled).toHaveBeenLastCalledWith(false)
+		expect(setSelectedImages).toHaveBeenNthCalledWith(1, [])
+		expect(setSelectedImages).toHaveBeenLastCalledWith(["image.png"])
+		expect(setSelectedFiles).toHaveBeenNthCalledWith(1, [])
+		expect(setSelectedFiles).toHaveBeenLastCalledWith(["a.ts"])
+		expect(setEnableButtons).toHaveBeenNthCalledWith(1, false)
+		expect(setEnableButtons).toHaveBeenLastCalledWith(true)
+	})
+
 	it("phase awaiting_followup also routes a follow-up to askResponse", async () => {
 		mockTurnState = { phase: "awaiting_followup", seq: 3 }
 		const { result } = renderHook(() => useMessageHandlers(completedConversation, makeChatState(completedConversation)))

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.ts
@@ -79,6 +79,15 @@ export function useMessageHandlers(messages: ClineMessage[], chatState: ChatStat
 					setSelectedFiles(files)
 					setEnableButtons(enableButtons)
 				}
+				const sendAskResponseWithPendingState = async (request: ReturnType<typeof AskResponseRequest.create>) => {
+					clearSentMessageState()
+					try {
+						await TaskServiceClient.askResponse(request)
+					} catch (error) {
+						restorePendingMessageState()
+						throw error
+					}
+				}
 
 				if (messages.length === 0) {
 					const request = NewTaskRequest.create({
@@ -98,7 +107,7 @@ export function useMessageHandlers(messages: ClineMessage[], chatState: ChatStat
 					// For resume_task and resume_completed_task, use yesButtonClicked to match Resume button behavior
 					// This ensures Enter key and Resume button work identically
 					if (clineAsk === "resume_task" || clineAsk === "resume_completed_task") {
-						await TaskServiceClient.askResponse(
+						await sendAskResponseWithPendingState(
 							AskResponseRequest.create({
 								responseType: "yesButtonClicked",
 								text: messageToSend,
@@ -124,7 +133,7 @@ export function useMessageHandlers(messages: ClineMessage[], chatState: ChatStat
 							case "new_task":
 							case "condense":
 							case "report_bug":
-								await TaskServiceClient.askResponse(
+								await sendAskResponseWithPendingState(
 									AskResponseRequest.create({
 										responseType: "messageResponse",
 										text: messageToSend,
@@ -158,7 +167,7 @@ export function useMessageHandlers(messages: ClineMessage[], chatState: ChatStat
 
 					if (turnAllowsFollowup || isTaskRunning) {
 						// Continue the conversation / interrupt with feedback.
-						await TaskServiceClient.askResponse(
+						await sendAskResponseWithPendingState(
 							AskResponseRequest.create({
 								responseType: "messageResponse",
 								text: messageToSend,


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This PR is a small UX improvement for the short window after the user submits a chat response but before the extension has accepted and reflected that response back to the webview.

This has been rebased on top of #11835, which added queued-prompt UI for prompts that have already been accepted by the SDK pending-prompt queue while a turn is streaming. This PR deliberately plays a narrower role:

- #11835 shows prompts after the extension/SDK has accepted them into the running-turn queue.
- This PR covers the pre-acceptance gap while `TaskServiceClient.askResponse` itself is still pending.

That gap still matters for cancelled/resumed sessions and other slow `askResponse` paths. Before this change, the user could hit Enter and the composer would continue to look unchanged while the webview waited for the `askResponse` RPC to resolve. That made the UI feel like Enter had been ignored or the chat had frozen.

This PR does not add fake transcript rows, does not touch SDK/session resume behavior, and does not interfere with queued prompts. It only moves the existing pending composer cleanup earlier for `askResponse` sends:

- clear the input, selected files/images, and quote immediately after a valid follow-up/ask response is routed
- set the existing sending/button disabled state before awaiting `askResponse`
- restore the previous composer state if the RPC fails

One deliberate adjustment after #11835: this PR no longer disables the actual textarea element. `sendingDisabled` is broader than "this RPC is pending" and can coexist with the new queued-prompt behavior, so disabling the textarea from that flag would be too heavy. The queue UI remains free to represent accepted queued messages, and this patch simply prevents the immediate send action from looking frozen before that state arrives.

### Test Procedure

Focused regression test:

```bash
cd apps/vscode/webview-ui
bunx vitest run src/components/chat/chat-view/hooks/useMessageHandlers.test.tsx
```

Result after rebasing on #11835: 1 test file passed, 10 tests passed.

Whitespace check:

```bash
sleep 1 && git diff --check
```

Result: passed.

Biome touched-file check:

```bash
cd apps/vscode
bunx @biomejs/biome check --config-path ./biome.jsonc --no-errors-on-unmatched --files-ignore-unknown=true webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.ts webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.test.tsx
```

Result: exited successfully. It prints existing info-level diagnostics in `useMessageHandlers.ts`, but no blocking errors.

Earlier, the webview production build was attempted and was blocked by an unrelated TypeScript error outside this PR:

```text
src/components/common/CheckmarkControl.tsx(106,35): error TS2339: Property 'checkpointDiff' does not exist on type 'typeof CheckpointsServiceClient'.
```

The new tests cover the important behavior for this PR:

- completed-turn follow-ups still route through `askResponse`, not `newTask`
- pending composer state is applied before `askResponse` resolves
- failed `askResponse` restores the previous input, quote, files/images, sending-disabled state, and button state
- existing new-task failure restoration behavior remains covered

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. This is a small send-state timing change. The intended behavior is that after a follow-up send, the composer clears and the existing pending state applies immediately while the response is being accepted. If the prompt is accepted into the running-turn queue, #11835's queued-prompt UI can then represent it.

### Additional Notes

This is deliberately a baby step. It does not make resumed sessions faster and does not duplicate the new queued-prompt UI. It only closes the pre-queue/pre-state-update gap where the send could look ignored.
