### PR TITLE
fix(sdk): keep SAP model filtering client-side

### DIFF
--- a/sdk/packages/core/src/services/llms/provider-defaults.test.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.test.ts
@@ -106,13 +106,15 @@ describe("resolveProviderConfig", () => {
 		});
 
 		expect(fetchMock).toHaveBeenCalledTimes(2);
-		expect(resolved?.knownModels?.["cline-pass/live-pass-model"]).toMatchObject({
-			id: "cline-pass/live-pass-model",
-			name: "Live Pass Model",
-			contextWindow: 256_000,
-			maxInputTokens: 200_000,
-			maxTokens: 32_000,
-		});
+		expect(resolved?.knownModels?.["cline-pass/live-pass-model"]).toMatchObject(
+			{
+				id: "cline-pass/live-pass-model",
+				name: "Live Pass Model",
+				contextWindow: 256_000,
+				maxInputTokens: 200_000,
+				maxTokens: 32_000,
+			},
+		);
 		expect(resolved?.knownModels?.["cline-pass/mimo-v2.5-pro"]).toBeUndefined();
 	});
 
@@ -152,9 +154,9 @@ describe("resolveProviderConfig", () => {
 		});
 
 		expect(fetchMock).toHaveBeenCalledTimes(2);
-		expect(
-			resolved?.knownModels?.["cline-pass/mimo-v2.5-pro"]?.name,
-		).toBe("MiMo-V2.5-Pro");
+		expect(resolved?.knownModels?.["cline-pass/mimo-v2.5-pro"]?.name).toBe(
+			"MiMo-V2.5-Pro",
+		);
 		expect(
 			resolved?.knownModels?.["vendor/live-openrouter-model"],
 		).toBeUndefined();
@@ -519,44 +521,5 @@ describe("resolveProviderConfig", () => {
 			}),
 		);
 		expect(resolved?.knownModels?.["gpt-5.4-nano"]).toBeUndefined();
-	});
-
-	it("filters SAP AI Core models in foundation-models mode", async () => {
-		const resolved = await resolveProviderConfig("sapaicore", undefined, {
-			providerId: "sapaicore",
-			modelId: "anthropic--claude-3.5-sonnet",
-			sap: { useOrchestrationMode: false },
-			knownModels: {
-				"gpt-4-base": { id: "gpt-4-base", name: "GPT-4 Base" },
-				"gpt-4-instruct": { id: "gpt-4-instruct", name: "GPT-4 Instruct" },
-				"gpt-4-realtime": { id: "gpt-4-realtime", name: "GPT-4 Realtime" },
-			},
-		});
-
-		expect(Object.keys(resolved?.knownModels ?? {})).toEqual(
-			expect.arrayContaining(["gpt-5.4", "gpt-5.5"]),
-		);
-		expect(resolved?.modelId).not.toBe("anthropic--claude-3.5-sonnet");
-		expect(resolved?.knownModels?.[resolved?.modelId ?? ""]).toBeDefined();
-		expect(
-			resolved?.knownModels?.["anthropic--claude-3.5-sonnet"],
-		).toBeUndefined();
-		expect(resolved?.knownModels?.["gpt-4-base"]).toBeUndefined();
-		expect(resolved?.knownModels?.["gpt-4-instruct"]).toBeUndefined();
-		expect(resolved?.knownModels?.["gpt-4-realtime"]).toBeUndefined();
-		expect(resolved?.knownModels?.["gpt-5.3-codex"]).toBeUndefined();
-	});
-
-	it("keeps the full SAP AI Core catalog in orchestration mode", async () => {
-		const resolved = await resolveProviderConfig("sapaicore", undefined, {
-			providerId: "sapaicore",
-			modelId: "anthropic--claude-3.5-sonnet",
-			sap: { useOrchestrationMode: true },
-		});
-
-		expect(
-			resolved?.knownModels?.["anthropic--claude-3.5-sonnet"],
-		).toBeDefined();
-		expect(resolved?.knownModels?.["gpt-5.4"]).toBeDefined();
 	});
 });

--- a/sdk/packages/core/src/services/llms/provider-defaults.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.ts
@@ -215,50 +215,6 @@ async function mergeKnownModels(
 	});
 }
 
-function isSapAiCoreFoundationModels(
-	config: ProviderConfig | undefined,
-): boolean {
-	return (
-		config?.providerId === "sapaicore" &&
-		config.sap?.useOrchestrationMode === false
-	);
-}
-
-function isSapAiCoreFoundationChatModel(modelId: string): boolean {
-	const normalizedModelId = modelId.trim().toLowerCase();
-	const unsupportedModelKinds = ["base", "codex", "instruct", "realtime"];
-	return (
-		/^gpt-?\d/.test(normalizedModelId) &&
-		!unsupportedModelKinds.some((kind) => normalizedModelId.includes(kind))
-	);
-}
-
-function filterResolvedKnownModels(
-	providerId: string,
-	knownModels: Record<string, ModelInfo>,
-	config: ProviderConfig | undefined,
-): Record<string, ModelInfo> {
-	if (providerId !== "sapaicore" || !isSapAiCoreFoundationModels(config)) {
-		return knownModels;
-	}
-
-	return Object.fromEntries(
-		Object.entries(knownModels).filter(([modelId]) =>
-			isSapAiCoreFoundationChatModel(modelId),
-		),
-	);
-}
-
-function chooseResolvedModelId(
-	defaultModelId: string,
-	knownModels: Record<string, ModelInfo>,
-): string {
-	if (knownModels[defaultModelId]) {
-		return defaultModelId;
-	}
-	return Object.keys(knownModels)[0] ?? defaultModelId;
-}
-
 function resolveCatalogModels(
 	providerId: string,
 	modelsByProviderId: Record<string, Record<string, ModelInfo>>,
@@ -964,7 +920,7 @@ export async function resolveProviderConfig(
 					publicConfig,
 				).catch(() => ({}))
 			: {};
-		const mergedModels = await mergeKnownModels(
+		const knownModels = await mergeKnownModels(
 			providerId,
 			defaults.knownModels,
 			liveModels,
@@ -972,15 +928,9 @@ export async function resolveProviderConfig(
 			publicModels,
 			config?.knownModels,
 		);
-		const knownModels = filterResolvedKnownModels(
-			providerId,
-			mergedModels,
-			config,
-		);
 
 		return {
 			...defaults,
-			modelId: chooseResolvedModelId(defaults.modelId, knownModels),
 			knownModels,
 		};
 	} catch (error) {


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

Follow-up to #11833.

### Description

This PR removes the SAP AI Core foundation-mode model filtering that #11833 added inside the SDK provider defaults resolver.

After another pass over the abstraction boundary, that SDK-side filtering is too broad. `resolveProviderConfig()` is used outside the VS Code SAP settings UI, including SDK consumers and `apps/cli`, so filtering SAP `knownModels` there makes a product/UI assumption globally: that `sap.useOrchestrationMode === false` should hide all non-GPT models from every caller. That behavior is based on current Cline UI needs and SAP model-id heuristics, not provider-owned catalog metadata.

The mode-specific visibility should stay where the mode toggle and deployment context live today: the VS Code SAP AI Core picker. #11833 already keeps that client-side behavior in `SapAiCoreModelPicker`, so foundation-model mode still filters the VS Code picker to GPT chat-compatible entries while orchestration mode keeps the full SAP catalog visible.

This follow-up keeps the SDK provider defaults more provider-agnostic again:

- removes `isSapAiCoreFoundationModels`, `isSapAiCoreFoundationChatModel`, `filterResolvedKnownModels`, and `chooseResolvedModelId` from `provider-defaults.ts`;
- restores `resolveProviderConfig()` to return the merged SAP catalog without mode-specific filtering;
- removes the SDK tests that asserted SAP foundation-mode filtering inside provider defaults.

The SAP runtime/provider fixes from #11833 remain intact, including the static SAP provider import for VSIX bundling, SAP Cloud SDK 4.6.0 overrides, session/runtime SAP config mapping, and VS Code picker filtering.

### Test Procedure

Targeted checks run locally:

```bash
cd sdk/packages/core && bunx vitest run src/services/llms/provider-defaults.test.ts
cd apps/vscode/webview-ui && bunx vitest run src/components/settings/__tests__/SapAiCoreModelPicker.spec.tsx
cd sdk/packages/core && bunx biome check src/services/llms/provider-defaults.ts src/services/llms/provider-defaults.test.ts
```

Results:

- SDK provider defaults tests: 15 passed.
- SAP picker tests: 28 passed.
- Biome check passed.

The SAP picker test still logs the existing React warning about the `zIndex` prop on `DropdownContainer`; this PR does not introduce or change that warning.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Targeted tests are passing; full `bun test` / `bun run format && bun run lint` were not run because this is a narrow follow-up.
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

No screenshots. This removes SDK-side model filtering and preserves the existing tested VS Code picker behavior.

### Additional Notes

This keeps SAP model visibility policy client-side for now. If we later get reliable SAP/provider-owned metadata that identifies which models are valid for foundation-model mode, we can revisit centralizing that in a shared provider helper rather than hardcoding model-id heuristics in generic SDK defaults.
