### PR TITLE
docs: fix outdated skills enable path

### DIFF
--- a/docs/customization/skills.mdx
+++ b/docs/customization/skills.mdx
@@ -9,7 +9,7 @@ Skills are modular instruction sets that extend Cline's capabilities for specifi
 Install multiple skills and Cline only loads what it needs. A deployment skill stays dormant until you ask about deploying. Unlike [rules](/customization/cline-rules) (which are always active), skills load on-demand so they don't consume context when you're working on something unrelated.
 
 <Note>
-Skills is an experimental feature. Enable it in **Settings → Features → Enable Skills**.
+Manage skills from the Skills menu: click the scale icon at the bottom of the Cline panel, to the left of the model selector, then switch to the **Skills** tab.
 </Note>
 
 ## How Skills Work


### PR DESCRIPTION
### Related Issue

**Issue:** #11740

### Description

The Skills documentation tells users to enable skills via **Settings → Features → Enable Skills**, but that toggle no longer exists. The Features settings section (`apps/vscode/webview-ui/src/components/settings/sections/FeatureSettingsSection.tsx`) has no Skills entry, and skills are loaded by default — there is nothing to "enable."

The same page already documents the real access path further down ("Click the scale icon at the bottom of the Cline panel… Switch to the Skills tab"), so the intro `<Note>` contradicted the body. This change updates the `<Note>` to point at the actual Skills menu, making the page self-consistent.

### Test Procedure

Documentation-only change (single line in `docs/customization/skills.mdx`).

- Verified the stale path "Settings → Features → Enable Skills" does not exist in the current UI: `FeatureSettingsSection.tsx` lists Subagents, Native Tool Call, etc. (experimental: Yolo Mode, Hooks, …) — no Skills toggle.
- Confirmed the corrected instruction matches the existing "Creating a Skill" steps in the same file (scale icon → Skills tab).
- Grepped `docs/` for other occurrences of the stale path — none remain.

### Type of Change

-   [x] 📚 Documentation update

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — text-only documentation change.

### Additional Notes

Per CONTRIBUTING.md, small documentation fixes may be submitted directly without a prior approved issue; this also resolves the linked issue #11740.
