### PR TITLE
fix(vscode): wait before terminal cwd setup

### DIFF
--- a/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalManager.ts
+++ b/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalManager.ts
@@ -218,19 +218,17 @@ export class VscodeTerminalManager implements ITerminalManager {
 			})
 		})
 
-		const startCommand = async () => {
-			await this.showTerminalBeforeInput(vscodeTerminalInfo.terminal)
-
+		this.showTerminalBeforeInput(vscodeTerminalInfo.terminal).then(() => {
 			// if shell integration is already active, run the command immediately
 			if (vscodeTerminalInfo.terminal.shellIntegration) {
 				process.waitForShellIntegration = false
-				await process.run(vscodeTerminalInfo.terminal, command)
+				process.run(vscodeTerminalInfo.terminal, command)
 			} else {
 				// docs recommend waiting 3s for shell integration to activate
 				Logger.log(
 					`[TerminalManager Test] Waiting for shell integration for terminal ${vscodeTerminalInfo.id} with timeout ${this.shellIntegrationTimeout}ms`,
 				)
-				await pWaitFor(() => vscodeTerminalInfo.terminal.shellIntegration !== undefined, {
+				pWaitFor(() => vscodeTerminalInfo.terminal.shellIntegration !== undefined, {
 					timeout: this.shellIntegrationTimeout,
 				})
 					.then(() => {
@@ -243,20 +241,15 @@ export class VscodeTerminalManager implements ITerminalManager {
 							`[TerminalManager Test] Shell integration timed out or failed for terminal ${vscodeTerminalInfo.id}: ${err.message}`,
 						)
 					})
-
-				Logger.log(`[TerminalManager Test] Proceeding with command execution for terminal ${vscodeTerminalInfo.id}.`)
-				const existingProcess = this.processes.get(vscodeTerminalInfo.id)
-				if (existingProcess && existingProcess.waitForShellIntegration) {
-					existingProcess.waitForShellIntegration = false
-					await existingProcess.run(vscodeTerminalInfo.terminal, command)
-				}
+					.finally(() => {
+						Logger.log(`[TerminalManager Test] Proceeding with command execution for terminal ${vscodeTerminalInfo.id}.`)
+						const existingProcess = this.processes.get(vscodeTerminalInfo.id)
+						if (existingProcess && existingProcess.waitForShellIntegration) {
+							existingProcess.waitForShellIntegration = false
+							existingProcess.run(vscodeTerminalInfo.terminal, command)
+						}
+					})
 			}
-		}
-		startCommand().catch((error) => {
-			Logger.error(
-				`[TerminalManager] Failed to start command on terminal ${vscodeTerminalInfo.id}: ${(error as Error)?.message ?? String(error)}`,
-			)
-			process.emit("error", error instanceof Error ? error : new Error(String(error)))
 		})
 
 		return mergePromise(process, promise)

--- a/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalManager.ts
+++ b/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalManager.ts
@@ -1,5 +1,4 @@
 import { arePathsEqual } from "@utils/path"
-import { setTimeout as setTimeoutPromise } from "node:timers/promises"
 import { getShell, getShellForProfile } from "@utils/shell"
 import pWaitFor from "p-wait-for"
 import * as vscode from "vscode"
@@ -105,7 +104,6 @@ export class VscodeTerminalManager implements ITerminalManager {
 	private terminalReuseEnabled = true
 	private terminalOutputLineLimit = 500
 	private defaultTerminalProfile = "default"
-	private terminalShowDelayMs = 2000
 
 	/**
 	 * Resolve a terminal's stored shellPath to an effective path.
@@ -174,14 +172,6 @@ export class VscodeTerminalManager implements ITerminalManager {
 		return arePathsEqual(currentCwd, targetCwd)
 	}
 
-	private async showTerminalBeforeInput(terminal: vscode.Terminal, forceDelay = false): Promise<void> {
-		const wasActive = vscode.window.activeTerminal === terminal
-		terminal.show()
-		if (forceDelay || !wasActive) {
-			await setTimeoutPromise(this.terminalShowDelayMs)
-		}
-	}
-
 	runCommand(terminalInfo: ITerminalInfo, command: string): ITerminalProcessResultPromise {
 		// Cast to VSCode-specific TerminalInfo for internal use
 		// Using unknown as intermediate cast due to structural differences between ITerminal and vscode.Terminal
@@ -218,39 +208,37 @@ export class VscodeTerminalManager implements ITerminalManager {
 			})
 		})
 
-		this.showTerminalBeforeInput(vscodeTerminalInfo.terminal).then(() => {
-			// if shell integration is already active, run the command immediately
-			if (vscodeTerminalInfo.terminal.shellIntegration) {
-				process.waitForShellIntegration = false
-				process.run(vscodeTerminalInfo.terminal, command)
-			} else {
-				// docs recommend waiting 3s for shell integration to activate
-				Logger.log(
-					`[TerminalManager Test] Waiting for shell integration for terminal ${vscodeTerminalInfo.id} with timeout ${this.shellIntegrationTimeout}ms`,
-				)
-				pWaitFor(() => vscodeTerminalInfo.terminal.shellIntegration !== undefined, {
-					timeout: this.shellIntegrationTimeout,
+		// if shell integration is already active, run the command immediately
+		if (vscodeTerminalInfo.terminal.shellIntegration) {
+			process.waitForShellIntegration = false
+			process.run(vscodeTerminalInfo.terminal, command)
+		} else {
+			// docs recommend waiting 3s for shell integration to activate
+			Logger.log(
+				`[TerminalManager Test] Waiting for shell integration for terminal ${vscodeTerminalInfo.id} with timeout ${this.shellIntegrationTimeout}ms`,
+			)
+			pWaitFor(() => vscodeTerminalInfo.terminal.shellIntegration !== undefined, {
+				timeout: this.shellIntegrationTimeout,
+			})
+				.then(() => {
+					Logger.log(
+						`[TerminalManager Test] Shell integration activated for terminal ${vscodeTerminalInfo.id} within timeout.`,
+					)
 				})
-					.then(() => {
-						Logger.log(
-							`[TerminalManager Test] Shell integration activated for terminal ${vscodeTerminalInfo.id} within timeout.`,
-						)
-					})
-					.catch((err) => {
-						Logger.warn(
-							`[TerminalManager Test] Shell integration timed out or failed for terminal ${vscodeTerminalInfo.id}: ${err.message}`,
-						)
-					})
-					.finally(() => {
-						Logger.log(`[TerminalManager Test] Proceeding with command execution for terminal ${vscodeTerminalInfo.id}.`)
-						const existingProcess = this.processes.get(vscodeTerminalInfo.id)
-						if (existingProcess && existingProcess.waitForShellIntegration) {
-							existingProcess.waitForShellIntegration = false
-							existingProcess.run(vscodeTerminalInfo.terminal, command)
-						}
-					})
-			}
-		})
+				.catch((err) => {
+					Logger.warn(
+						`[TerminalManager Test] Shell integration timed out or failed for terminal ${vscodeTerminalInfo.id}: ${err.message}`,
+					)
+				})
+				.finally(() => {
+					Logger.log(`[TerminalManager Test] Proceeding with command execution for terminal ${vscodeTerminalInfo.id}.`)
+					const existingProcess = this.processes.get(vscodeTerminalInfo.id)
+					if (existingProcess && existingProcess.waitForShellIntegration) {
+						existingProcess.waitForShellIntegration = false
+						existingProcess.run(vscodeTerminalInfo.terminal, command)
+					}
+				})
+		}
 
 		return mergePromise(process, promise)
 	}
@@ -307,7 +295,8 @@ export class VscodeTerminalManager implements ITerminalManager {
 				// through VscodeTerminalProcess, since fast zero-output commands like `cd`
 				// can get stuck waiting on shell integration and prevent the real command
 				// from ever being sent.
-				await this.showTerminalBeforeInput(availableTerminal.terminal, true)
+				availableTerminal.terminal.show()
+				await new Promise((resolve) => setTimeout(resolve, 2000))
 				availableTerminal.terminal.sendText(`cd "${cwd}"`, true)
 
 				// Either resolve immediately if CWD already updated or wait for event/timeout

--- a/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalManager.ts
+++ b/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalManager.ts
@@ -1,4 +1,5 @@
 import { arePathsEqual } from "@utils/path"
+import { setTimeout as setTimeoutPromise } from "node:timers/promises"
 import { getShell, getShellForProfile } from "@utils/shell"
 import pWaitFor from "p-wait-for"
 import * as vscode from "vscode"
@@ -104,6 +105,7 @@ export class VscodeTerminalManager implements ITerminalManager {
 	private terminalReuseEnabled = true
 	private terminalOutputLineLimit = 500
 	private defaultTerminalProfile = "default"
+	private terminalShowDelayMs = 2000
 
 	/**
 	 * Resolve a terminal's stored shellPath to an effective path.
@@ -172,6 +174,14 @@ export class VscodeTerminalManager implements ITerminalManager {
 		return arePathsEqual(currentCwd, targetCwd)
 	}
 
+	private async showTerminalBeforeInput(terminal: vscode.Terminal, forceDelay = false): Promise<void> {
+		const wasActive = vscode.window.activeTerminal === terminal
+		terminal.show()
+		if (forceDelay || !wasActive) {
+			await setTimeoutPromise(this.terminalShowDelayMs)
+		}
+	}
+
 	runCommand(terminalInfo: ITerminalInfo, command: string): ITerminalProcessResultPromise {
 		// Cast to VSCode-specific TerminalInfo for internal use
 		// Using unknown as intermediate cast due to structural differences between ITerminal and vscode.Terminal
@@ -208,37 +218,46 @@ export class VscodeTerminalManager implements ITerminalManager {
 			})
 		})
 
-		// if shell integration is already active, run the command immediately
-		if (vscodeTerminalInfo.terminal.shellIntegration) {
-			process.waitForShellIntegration = false
-			process.run(vscodeTerminalInfo.terminal, command)
-		} else {
-			// docs recommend waiting 3s for shell integration to activate
-			Logger.log(
-				`[TerminalManager Test] Waiting for shell integration for terminal ${vscodeTerminalInfo.id} with timeout ${this.shellIntegrationTimeout}ms`,
-			)
-			pWaitFor(() => vscodeTerminalInfo.terminal.shellIntegration !== undefined, {
-				timeout: this.shellIntegrationTimeout,
-			})
-				.then(() => {
-					Logger.log(
-						`[TerminalManager Test] Shell integration activated for terminal ${vscodeTerminalInfo.id} within timeout.`,
-					)
+		const startCommand = async () => {
+			await this.showTerminalBeforeInput(vscodeTerminalInfo.terminal)
+
+			// if shell integration is already active, run the command immediately
+			if (vscodeTerminalInfo.terminal.shellIntegration) {
+				process.waitForShellIntegration = false
+				await process.run(vscodeTerminalInfo.terminal, command)
+			} else {
+				// docs recommend waiting 3s for shell integration to activate
+				Logger.log(
+					`[TerminalManager Test] Waiting for shell integration for terminal ${vscodeTerminalInfo.id} with timeout ${this.shellIntegrationTimeout}ms`,
+				)
+				await pWaitFor(() => vscodeTerminalInfo.terminal.shellIntegration !== undefined, {
+					timeout: this.shellIntegrationTimeout,
 				})
-				.catch((err) => {
-					Logger.warn(
-						`[TerminalManager Test] Shell integration timed out or failed for terminal ${vscodeTerminalInfo.id}: ${err.message}`,
-					)
-				})
-				.finally(() => {
-					Logger.log(`[TerminalManager Test] Proceeding with command execution for terminal ${vscodeTerminalInfo.id}.`)
-					const existingProcess = this.processes.get(vscodeTerminalInfo.id)
-					if (existingProcess && existingProcess.waitForShellIntegration) {
-						existingProcess.waitForShellIntegration = false
-						existingProcess.run(vscodeTerminalInfo.terminal, command)
-					}
-				})
+					.then(() => {
+						Logger.log(
+							`[TerminalManager Test] Shell integration activated for terminal ${vscodeTerminalInfo.id} within timeout.`,
+						)
+					})
+					.catch((err) => {
+						Logger.warn(
+							`[TerminalManager Test] Shell integration timed out or failed for terminal ${vscodeTerminalInfo.id}: ${err.message}`,
+						)
+					})
+
+				Logger.log(`[TerminalManager Test] Proceeding with command execution for terminal ${vscodeTerminalInfo.id}.`)
+				const existingProcess = this.processes.get(vscodeTerminalInfo.id)
+				if (existingProcess && existingProcess.waitForShellIntegration) {
+					existingProcess.waitForShellIntegration = false
+					await existingProcess.run(vscodeTerminalInfo.terminal, command)
+				}
+			}
 		}
+		startCommand().catch((error) => {
+			Logger.error(
+				`[TerminalManager] Failed to start command on terminal ${vscodeTerminalInfo.id}: ${(error as Error)?.message ?? String(error)}`,
+			)
+			process.emit("error", error instanceof Error ? error : new Error(String(error)))
+		})
 
 		return mergePromise(process, promise)
 	}
@@ -291,15 +310,12 @@ export class VscodeTerminalManager implements ITerminalManager {
 					availableTerminal.cwdResolved = { resolve, reject }
 				})
 
-				// Navigate back to the desired directory
-				// Cast to ITerminalInfo for interface compatibility
-				const cdProcess = this.runCommand(availableTerminal as unknown as ITerminalInfo, `cd "${cwd}"`)
-
-				// Wait for the cd command to complete before proceeding
-				await cdProcess
-
-				// Add a small delay to ensure terminal is ready after cd
-				await new Promise((resolve) => setTimeout(resolve, 100))
+				// Navigate back to the desired directory as terminal setup. Do not run this
+				// through VscodeTerminalProcess, since fast zero-output commands like `cd`
+				// can get stuck waiting on shell integration and prevent the real command
+				// from ever being sent.
+				await this.showTerminalBeforeInput(availableTerminal.terminal, true)
+				availableTerminal.terminal.sendText(`cd "${cwd}"`, true)
 
 				// Either resolve immediately if CWD already updated or wait for event/timeout
 				if (this.isCwdMatchingExpected(availableTerminal)) {

--- a/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalManager.ts
+++ b/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalManager.ts
@@ -291,13 +291,20 @@ export class VscodeTerminalManager implements ITerminalManager {
 					availableTerminal.cwdResolved = { resolve, reject }
 				})
 
-				// Navigate back to the desired directory as terminal setup. Do not run this
-				// through VscodeTerminalProcess, since fast zero-output commands like `cd`
-				// can get stuck waiting on shell integration and prevent the real command
-				// from ever being sent.
+				// Open the terminal before the cwd setup command so VS Code has time
+				// to initialize the terminal surface and shell integration.
 				availableTerminal.terminal.show()
 				await new Promise((resolve) => setTimeout(resolve, 2000))
-				availableTerminal.terminal.sendText(`cd "${cwd}"`, true)
+
+				// Navigate back to the desired directory
+				// Cast to ITerminalInfo for interface compatibility
+				const cdProcess = this.runCommand(availableTerminal as unknown as ITerminalInfo, `cd "${cwd}"`)
+
+				// Wait for the cd command to complete before proceeding
+				await cdProcess
+
+				// Add a small delay to ensure terminal is ready after cd
+				await new Promise((resolve) => setTimeout(resolve, 100))
 
 				// Either resolve immediately if CWD already updated or wait for event/timeout
 				if (this.isCwdMatchingExpected(availableTerminal)) {


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This PR fixes a VS Code foreground terminal reuse issue where Cline could appear to run the setup `cd "<cwd>"` command and then never send the actual requested command.

The problematic path is the reused-terminal cwd setup in `VscodeTerminalManager.getOrCreateTerminal()`. When an existing terminal is available but in the wrong cwd, Cline runs `cd "<cwd>"` through the existing `runCommand()` path before returning the terminal to the caller. The foreground command caller shows the terminal after `getOrCreateTerminal()` returns, so this setup `cd` could be sent while the VS Code terminal surface/shell integration was not yet ready.

The final fix is intentionally small: before running the existing setup `cd` command, Cline now shows the terminal and waits briefly so VS Code has time to initialize the terminal surface and shell integration. The existing `runCommand(cd ...)` behavior and the existing post-`cd` readiness delay are preserved.

Debugging context: earlier experiments changed more of the terminal command startup path, but the final net diff was reduced to only this cwd setup readiness delay. The PR branch contains cleanup commits from that narrowing process, but the final diff against `main` is only five added lines in `VscodeTerminalManager.ts`.

### Test Procedure

Validated locally in the main workspace:

```bash
bunx tsc --noEmit --project apps/vscode/tsconfig.json
sleep 1 && git diff --check
```

Manual verification performed by reproducing the VS Code foreground terminal reuse case: when the terminal needed a cwd change, opening the terminal and waiting before the setup `cd` allowed the command sequence to proceed instead of getting stuck after `cd`.

Suggested reviewer/manual check:

1. Enable foreground VS Code terminal execution.
2. Reuse an existing Cline terminal whose cwd differs from the requested command cwd.
3. Ask Cline to run a fast command, for example `cat package.json`.
4. Confirm the terminal opens, `cd "<cwd>"` runs, and the requested command is sent afterward.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. This is terminal command lifecycle behavior without a persistent UI surface change.

### Additional Notes

This PR intentionally excludes unrelated working-tree changes from the original workspace. The PR branch was managed in a separate clean worktree, and the final diff against `main` is limited to `apps/vscode/src/hosts/vscode/terminal/VscodeTerminalManager.ts`.
