### PR TITLE
fix: compile out debug OAuth hooks in production

### DIFF
--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -182,11 +182,14 @@ export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.window.registerUriHandler({ handleUri }))
 
 	// Debug-harness affordance: VSCode only delivers real vscode:// URIs to the
-	// registered handler above, which the harness can't synthesize. When running
-	// under browser-capture (debug harness) mode, expose the same handler on
-	// globalThis so the harness can deliver simulated OAuth callbacks via
-	// `ext.evaluate`. Gated on CLINE_CAPTURE_BROWSER so it never ships in prod.
-	if (process.env.CLINE_CAPTURE_BROWSER === "1" || process.env.CLINE_CAPTURE_BROWSER === "true") {
+	// registered handler above, which the harness can't synthesize. In development
+	// builds running under browser-capture (debug harness) mode, expose the same
+	// handler on globalThis so the harness can deliver simulated OAuth callbacks
+	// via `ext.evaluate`. Guard with IS_DEV so production builds compile this out.
+	if (
+		process.env.IS_DEV === "true" &&
+		(process.env.CLINE_CAPTURE_BROWSER === "1" || process.env.CLINE_CAPTURE_BROWSER === "true")
+	) {
 		;(globalThis as Record<string, unknown>).__clineHandleUri = (url: string) => SharedUriHandler.handleUri(url)
 	}
 

--- a/apps/vscode/src/utils/env.ts
+++ b/apps/vscode/src/utils/env.ts
@@ -38,16 +38,20 @@ export async function readTextFromClipboard(): Promise<string> {
  * Uses the host bridge RPC first (VS Code's openExternal which handles remote environments).
  * Falls back to the `open` npm package if the host doesn't implement the RPC (e.g., JetBrains).
  *
- * When CLINE_CAPTURE_BROWSER is set (debug harness mode), the URL is captured
- * to a file and/or posted to the debug harness instead of opening a real browser.
- * This enables automated OAuth flow testing.
+ * In development builds, when CLINE_CAPTURE_BROWSER is set (debug harness mode),
+ * the URL is captured to a file and/or posted to the debug harness instead of
+ * opening a real browser. This enables automated OAuth flow testing.
  *
  * @param url The URL to open
  * @returns Promise that resolves when the operation is complete
  */
 export async function openExternal(url: string): Promise<void> {
-	// Debug harness mode: capture URL instead of opening browser
-	if (process.env.CLINE_CAPTURE_BROWSER === "1" || process.env.CLINE_CAPTURE_BROWSER === "true") {
+	// Debug harness mode: capture URL instead of opening browser.
+	// Guard with IS_DEV so production builds compile this path out.
+	if (
+		process.env.IS_DEV === "true" &&
+		(process.env.CLINE_CAPTURE_BROWSER === "1" || process.env.CLINE_CAPTURE_BROWSER === "true")
+	) {
 		await captureBrowserUrl(url)
 		return
 	}

--- a/apps/vscode/webview-ui/src/config/platform.config.ts
+++ b/apps/vscode/webview-ui/src/config/platform.config.ts
@@ -54,8 +54,9 @@ declare global {
 // Initialize the vscode API if available
 const vsCodeApi = typeof acquireVsCodeApi === "function" ? acquireVsCodeApi() : null
 
-// Expose the VSCode API for debug harness access
-if (vsCodeApi && typeof window !== "undefined") {
+// Expose the VSCode API for debug harness access in development builds only.
+// Guard with IS_DEV so production webview builds compile this out.
+if (process.env.IS_DEV === "true" && vsCodeApi && typeof window !== "undefined") {
 	;(window as any).__clineVsCodeApi = vsCodeApi
 }
 


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Production VS Code extension bundles currently include debug harness OAuth/browser-capture affordances that are gated only by runtime environment variables. This PR adds an `IS_DEV` guard to those debug paths so production builds can compile them out:

- `CLINE_CAPTURE_BROWSER` browser URL capture in `openExternal`
- `globalThis.__clineHandleUri` debug URI delivery hook
- `window.__clineVsCodeApi` debug webview API exposure

### Test Procedure

- Ran `cd apps/vscode && bun esbuild.mjs --production`
- Verified the production extension bundle no longer contains `CLINE_CAPTURE_BROWSER`, `debug-captured-urls`, or `__clineHandleUri`
- Ran `cd apps/vscode/webview-ui && bun run build`
- Verified the production webview bundle no longer contains `__clineVsCodeApi`

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — no UI changes.

### Additional Notes

This intentionally preserves debug harness behavior for development builds while removing these hooks from production bundles.
