### PR TITLE
fix(vscode): show direct user messages immediately

### DIFF
--- a/apps/vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -2,6 +2,7 @@ import { combineApiRequests } from "@shared/combineApiRequests"
 import { combineCommandSequences } from "@shared/combineCommandSequences"
 import { combineErrorRetryMessages } from "@shared/combineErrorRetryMessages"
 import { combineHookSequences } from "@shared/combineHookSequences"
+import type { ClineMessage } from "@shared/ExtensionMessage"
 import { getApiMetrics, getLastApiReqTotalTokens } from "@shared/getApiMetrics"
 import { BooleanRequest, StringRequest } from "@shared/proto/cline/common"
 import { useCallback, useEffect, useMemo, useRef } from "react"
@@ -42,6 +43,25 @@ interface ChatViewProps {
 const MAX_IMAGES_AND_FILES_PER_MESSAGE = CHAT_CONSTANTS.MAX_IMAGES_AND_FILES_PER_MESSAGE
 const QUICK_WINS_HISTORY_THRESHOLD = 3
 
+const sameUserMessage = (left: ClineMessage, right: ClineMessage) => {
+	const leftImages = left.images ?? []
+	const rightImages = right.images ?? []
+	const leftFiles = left.files ?? []
+	const rightFiles = right.files ?? []
+
+	return (
+		left.type === "say" &&
+		left.say === "user_feedback" &&
+		right.type === "say" &&
+		right.say === "user_feedback" &&
+		left.text === right.text &&
+		leftImages.length === rightImages.length &&
+		leftImages.every((image, index) => image === rightImages[index]) &&
+		leftFiles.length === rightFiles.length &&
+		leftFiles.every((file, index) => file === rightFiles[index])
+	)
+}
+
 const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryView }: ChatViewProps) => {
 	const showNavbar = useShowNavbar()
 	const {
@@ -58,19 +78,6 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 	const isProdHostedApp = userInfo?.apiBaseUrl === "https://app.cline.bot"
 	const shouldShowQuickWins = isProdHostedApp && (!taskHistory || taskHistory.length < QUICK_WINS_HISTORY_THRESHOLD)
 
-	//const task = messages.length > 0 ? (messages[0].say === "task" ? messages[0] : undefined) : undefined) : undefined
-	const task = useMemo(() => messages.at(0), [messages]) // leaving this less safe version here since if the first message is not a task, then the extension is in a bad state and needs to be debugged (see Cline.abort)
-	const modifiedMessages = useMemo(() => {
-		const slicedMessages = messages.slice(1)
-		// Only combine hook sequences if hooks are enabled
-		const withHooks = hooksEnabled ? combineHookSequences(slicedMessages) : slicedMessages
-		return combineErrorRetryMessages(combineApiRequests(combineCommandSequences(withHooks)))
-	}, [messages, hooksEnabled])
-	// has to be after api_req_finished are all reduced into api_req_started messages
-	const apiMetrics = useMemo(() => getApiMetrics(modifiedMessages), [modifiedMessages])
-
-	const lastApiReqTotalTokens = useMemo(() => getLastApiReqTotalTokens(modifiedMessages) || undefined, [modifiedMessages])
-
 	// Use custom hooks for state management
 	const chatState = useChatState(messages)
 	const {
@@ -83,8 +90,36 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 		enableButtons,
 		expandedRows,
 		setExpandedRows,
+		pendingUserMessage,
+		setPendingUserMessage,
 		textAreaRef,
 	} = chatState
+
+	const displayMessages = useMemo(() => {
+		if (!pendingUserMessage || messages.some((message) => sameUserMessage(message, pendingUserMessage))) {
+			return messages
+		}
+		return [...messages, pendingUserMessage]
+	}, [messages, pendingUserMessage])
+
+	useEffect(() => {
+		if (pendingUserMessage && messages.some((message) => sameUserMessage(message, pendingUserMessage))) {
+			setPendingUserMessage(undefined)
+		}
+	}, [messages, pendingUserMessage, setPendingUserMessage])
+
+	//const task = messages.length > 0 ? (messages[0].say === "task" ? messages[0] : undefined) : undefined) : undefined
+	const task = useMemo(() => messages.at(0), [messages]) // leaving this less safe version here since if the first message is not a task, then the extension is in a bad state and needs to be debugged (see Cline.abort)
+	const modifiedMessages = useMemo(() => {
+		const slicedMessages = displayMessages.slice(1)
+		// Only combine hook sequences if hooks are enabled
+		const withHooks = hooksEnabled ? combineHookSequences(slicedMessages) : slicedMessages
+		return combineErrorRetryMessages(combineApiRequests(combineCommandSequences(withHooks)))
+	}, [displayMessages, hooksEnabled])
+	// has to be after api_req_finished are all reduced into api_req_started messages
+	const apiMetrics = useMemo(() => getApiMetrics(modifiedMessages), [modifiedMessages])
+
+	const lastApiReqTotalTokens = useMemo(() => getLastApiReqTotalTokens(modifiedMessages) || undefined, [modifiedMessages])
 	const lastAppliedCheckpointRestoreSessionId = useRef<string | undefined>(checkpointRestoreInput?.sessionId)
 
 	useEffect(() => {

--- a/apps/vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -96,14 +96,24 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 	} = chatState
 
 	const displayMessages = useMemo(() => {
-		if (!pendingUserMessage || messages.some((message) => sameUserMessage(message, pendingUserMessage))) {
+		if (
+			!pendingUserMessage ||
+			messages.some(
+				(message) => message.ts > pendingUserMessage.afterTs && sameUserMessage(message, pendingUserMessage.message),
+			)
+		) {
 			return messages
 		}
-		return [...messages, pendingUserMessage]
+		return [...messages, pendingUserMessage.message]
 	}, [messages, pendingUserMessage])
 
 	useEffect(() => {
-		if (pendingUserMessage && messages.some((message) => sameUserMessage(message, pendingUserMessage))) {
+		if (
+			pendingUserMessage &&
+			messages.some(
+				(message) => message.ts > pendingUserMessage.afterTs && sameUserMessage(message, pendingUserMessage.message),
+			)
+		) {
 			setPendingUserMessage(undefined)
 		}
 	}, [messages, pendingUserMessage, setPendingUserMessage])
@@ -349,7 +359,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 	}, [visibleMessages])
 
 	// Use scroll behavior hook
-	const scrollBehavior = useScrollBehavior(messages, visibleMessages, groupedMessages, expandedRows, setExpandedRows)
+	const scrollBehavior = useScrollBehavior(displayMessages, visibleMessages, groupedMessages, expandedRows, setExpandedRows)
 
 	const placeholderText = useMemo(() => {
 		const text = task ? "Type a message..." : "Type your task here..."

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useChatState.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useChatState.ts
@@ -20,6 +20,7 @@ export function useChatState(messages: ClineMessage[]): ChatState {
 	const [primaryButtonText, setPrimaryButtonText] = useState<string | undefined>("Approve")
 	const [secondaryButtonText, setSecondaryButtonText] = useState<string | undefined>("Reject")
 	const [expandedRows, setExpandedRows] = useState<Record<number, boolean>>({})
+	const [pendingUserMessage, setPendingUserMessage] = useState<ClineMessage | undefined>(undefined)
 
 	// Refs
 	const textAreaRef = useRef<HTMLTextAreaElement>(null)
@@ -75,6 +76,8 @@ export function useChatState(messages: ClineMessage[]): ChatState {
 		setSecondaryButtonText,
 		expandedRows,
 		setExpandedRows,
+		pendingUserMessage,
+		setPendingUserMessage,
 
 		// Refs
 		textAreaRef,

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useChatState.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useChatState.ts
@@ -1,6 +1,6 @@
 import { ClineMessage } from "@shared/ExtensionMessage"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { ChatState } from "../types/chatTypes"
+import { ChatState, PendingUserMessage } from "../types/chatTypes"
 
 /**
  * Custom hook for managing chat state
@@ -20,7 +20,7 @@ export function useChatState(messages: ClineMessage[]): ChatState {
 	const [primaryButtonText, setPrimaryButtonText] = useState<string | undefined>("Approve")
 	const [secondaryButtonText, setSecondaryButtonText] = useState<string | undefined>("Reject")
 	const [expandedRows, setExpandedRows] = useState<Record<number, boolean>>({})
-	const [pendingUserMessage, setPendingUserMessage] = useState<ClineMessage | undefined>(undefined)
+	const [pendingUserMessage, setPendingUserMessage] = useState<PendingUserMessage | undefined>(undefined)
 
 	// Refs
 	const textAreaRef = useRef<HTMLTextAreaElement>(null)

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.test.tsx
@@ -66,6 +66,8 @@ function makeChatState(messages: ClineMessage[], overrides: Partial<ChatState> =
 		setSecondaryButtonText: vi.fn(),
 		expandedRows: {},
 		setExpandedRows: vi.fn(),
+		pendingUserMessage: undefined,
+		setPendingUserMessage: vi.fn(),
 		textAreaRef: { current: null },
 		lastMessage: last,
 		secondLastMessage: messages.at(-2),
@@ -163,6 +165,7 @@ describe("useMessageHandlers — send routing", () => {
 		const setSelectedImages = vi.fn()
 		const setSelectedFiles = vi.fn()
 		const setEnableButtons = vi.fn()
+		const setPendingUserMessage = vi.fn()
 		const chatState = makeChatState(completedConversation, {
 			activeQuote: "selected context",
 			sendingDisabled: false,
@@ -173,6 +176,7 @@ describe("useMessageHandlers — send routing", () => {
 			setSelectedImages,
 			setSelectedFiles,
 			setEnableButtons,
+			setPendingUserMessage,
 		})
 		const { result } = renderHook(() => useMessageHandlers(completedConversation, chatState))
 
@@ -196,6 +200,16 @@ describe("useMessageHandlers — send routing", () => {
 		expect(setSelectedImages).toHaveBeenCalledWith([])
 		expect(setSelectedFiles).toHaveBeenCalledWith([])
 		expect(setEnableButtons).toHaveBeenCalledWith(false)
+		expect(setPendingUserMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: "say",
+				say: "user_feedback",
+				text: expect.stringContaining("another question"),
+				images: ["image.png"],
+				files: ["a.ts"],
+				partial: false,
+			}),
+		)
 
 		await act(async () => {
 			resolveAskResponse()
@@ -212,6 +226,7 @@ describe("useMessageHandlers — send routing", () => {
 		const setSelectedImages = vi.fn()
 		const setSelectedFiles = vi.fn()
 		const setEnableButtons = vi.fn()
+		const setPendingUserMessage = vi.fn()
 		const chatState = makeChatState(completedConversation, {
 			activeQuote: "selected context",
 			sendingDisabled: false,
@@ -222,6 +237,7 @@ describe("useMessageHandlers — send routing", () => {
 			setSelectedImages,
 			setSelectedFiles,
 			setEnableButtons,
+			setPendingUserMessage,
 		})
 		const { result } = renderHook(() => useMessageHandlers(completedConversation, chatState))
 		askResponse.mockRejectedValueOnce(error)
@@ -248,6 +264,34 @@ describe("useMessageHandlers — send routing", () => {
 		expect(setSelectedFiles).toHaveBeenLastCalledWith(["a.ts"])
 		expect(setEnableButtons).toHaveBeenNthCalledWith(1, false)
 		expect(setEnableButtons).toHaveBeenLastCalledWith(true)
+		expect(setPendingUserMessage).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining({
+				type: "say",
+				say: "user_feedback",
+				text: expect.stringContaining("another question"),
+			}),
+		)
+		expect(setPendingUserMessage).toHaveBeenLastCalledWith(undefined)
+	})
+
+	it("does not show a pending chat bubble for a streaming follow-up that will be queued", async () => {
+		mockTurnState = { phase: "streaming", seq: 9 }
+		const streamingConversation: ClineMessage[] = [
+			{ ts: 1, type: "say", say: "task", text: "task" },
+			{ ts: 2, type: "say", say: "text", text: "working", partial: true },
+		]
+		const setPendingUserMessage = vi.fn()
+		const { result } = renderHook(() =>
+			useMessageHandlers(streamingConversation, makeChatState(streamingConversation, { setPendingUserMessage })),
+		)
+
+		await act(async () => {
+			await result.current.handleSendMessage("steer this way", [], [])
+		})
+
+		expect(askResponse).toHaveBeenCalledTimes(1)
+		expect(setPendingUserMessage).not.toHaveBeenCalled()
 	})
 
 	it("phase awaiting_followup also routes a follow-up to askResponse", async () => {

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.test.tsx
@@ -202,12 +202,15 @@ describe("useMessageHandlers — send routing", () => {
 		expect(setEnableButtons).toHaveBeenCalledWith(false)
 		expect(setPendingUserMessage).toHaveBeenCalledWith(
 			expect.objectContaining({
-				type: "say",
-				say: "user_feedback",
-				text: expect.stringContaining("another question"),
-				images: ["image.png"],
-				files: ["a.ts"],
-				partial: false,
+				afterTs: 2,
+				message: expect.objectContaining({
+					type: "say",
+					say: "user_feedback",
+					text: expect.stringContaining("another question"),
+					images: ["image.png"],
+					files: ["a.ts"],
+					partial: false,
+				}),
 			}),
 		)
 
@@ -267,9 +270,12 @@ describe("useMessageHandlers — send routing", () => {
 		expect(setPendingUserMessage).toHaveBeenNthCalledWith(
 			1,
 			expect.objectContaining({
-				type: "say",
-				say: "user_feedback",
-				text: expect.stringContaining("another question"),
+				afterTs: 2,
+				message: expect.objectContaining({
+					type: "say",
+					say: "user_feedback",
+					text: expect.stringContaining("another question"),
+				}),
 			}),
 		)
 		expect(setPendingUserMessage).toHaveBeenLastCalledWith(undefined)

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.ts
@@ -86,14 +86,18 @@ export function useMessageHandlers(messages: ClineMessage[], chatState: ChatStat
 				) => {
 					clearSentMessageState()
 					if (options.showPendingMessage) {
+						const afterTs = Math.max(0, ...messages.map((message) => message.ts))
 						setPendingUserMessage({
-							ts: Date.now(),
-							type: "say",
-							say: "user_feedback",
-							text: request.text ?? "",
-							images: request.images,
-							files: request.files,
-							partial: false,
+							afterTs,
+							message: {
+								ts: Date.now(),
+								type: "say",
+								say: "user_feedback",
+								text: request.text ?? "",
+								images: request.images,
+								files: request.files,
+								partial: false,
+							},
 						})
 					}
 					try {
@@ -194,10 +198,7 @@ export function useMessageHandlers(messages: ClineMessage[], chatState: ChatStat
 								files,
 							}),
 							{
-								showPendingMessage:
-									turnState?.phase === "completed" ||
-									turnState?.phase === "awaiting_followup" ||
-									(!turnState && !isTaskRunning),
+								showPendingMessage: turnState?.phase === "completed" || turnState?.phase === "awaiting_followup",
 							},
 						)
 						messageSent = true

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.ts
@@ -23,6 +23,7 @@ export function useMessageHandlers(messages: ClineMessage[], chatState: ChatStat
 		setSendingDisabled,
 		enableButtons,
 		setEnableButtons,
+		setPendingUserMessage,
 		clineAsk,
 		lastMessage,
 	} = chatState
@@ -79,11 +80,28 @@ export function useMessageHandlers(messages: ClineMessage[], chatState: ChatStat
 					setSelectedFiles(files)
 					setEnableButtons(enableButtons)
 				}
-				const sendAskResponseWithPendingState = async (request: ReturnType<typeof AskResponseRequest.create>) => {
+				const sendAskResponseWithPendingState = async (
+					request: ReturnType<typeof AskResponseRequest.create>,
+					options: { showPendingMessage?: boolean } = {},
+				) => {
 					clearSentMessageState()
+					if (options.showPendingMessage) {
+						setPendingUserMessage({
+							ts: Date.now(),
+							type: "say",
+							say: "user_feedback",
+							text: request.text ?? "",
+							images: request.images,
+							files: request.files,
+							partial: false,
+						})
+					}
 					try {
 						await TaskServiceClient.askResponse(request)
 					} catch (error) {
+						if (options.showPendingMessage) {
+							setPendingUserMessage(undefined)
+						}
 						restorePendingMessageState()
 						throw error
 					}
@@ -140,6 +158,7 @@ export function useMessageHandlers(messages: ClineMessage[], chatState: ChatStat
 										images,
 										files,
 									}),
+									{ showPendingMessage: turnState?.phase !== "streaming" },
 								)
 								messageSent = true
 								break
@@ -174,6 +193,12 @@ export function useMessageHandlers(messages: ClineMessage[], chatState: ChatStat
 								images,
 								files,
 							}),
+							{
+								showPendingMessage:
+									turnState?.phase === "completed" ||
+									turnState?.phase === "awaiting_followup" ||
+									(!turnState && !isTaskRunning),
+							},
 						)
 						messageSent = true
 					}
@@ -203,6 +228,7 @@ export function useMessageHandlers(messages: ClineMessage[], chatState: ChatStat
 			setSelectedFiles,
 			enableButtons,
 			setEnableButtons,
+			setPendingUserMessage,
 			chatState,
 		],
 	)

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/types/chatTypes.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/types/chatTypes.ts
@@ -31,6 +31,8 @@ export interface ChatState {
 	setSecondaryButtonText: React.Dispatch<React.SetStateAction<string | undefined>>
 	expandedRows: Record<number, boolean>
 	setExpandedRows: React.Dispatch<React.SetStateAction<Record<number, boolean>>>
+	pendingUserMessage: ClineMessage | undefined
+	setPendingUserMessage: React.Dispatch<React.SetStateAction<ClineMessage | undefined>>
 
 	// Refs
 	textAreaRef: React.RefObject<HTMLTextAreaElement>

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/types/chatTypes.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/types/chatTypes.ts
@@ -6,6 +6,11 @@ import { ClineAsk, ClineMessage } from "@shared/ExtensionMessage"
 import { ListRange, VirtuosoHandle } from "react-virtuoso"
 import { ButtonActionType } from "../shared/buttonConfig"
 
+export interface PendingUserMessage {
+	message: ClineMessage
+	afterTs: number
+}
+
 /**
  * Chat state interface
  */
@@ -31,8 +36,8 @@ export interface ChatState {
 	setSecondaryButtonText: React.Dispatch<React.SetStateAction<string | undefined>>
 	expandedRows: Record<number, boolean>
 	setExpandedRows: React.Dispatch<React.SetStateAction<Record<number, boolean>>>
-	pendingUserMessage: ClineMessage | undefined
-	setPendingUserMessage: React.Dispatch<React.SetStateAction<ClineMessage | undefined>>
+	pendingUserMessage: PendingUserMessage | undefined
+	setPendingUserMessage: React.Dispatch<React.SetStateAction<PendingUserMessage | undefined>>
 
 	// Refs
 	textAreaRef: React.RefObject<HTMLTextAreaElement>


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This PR makes direct follow-up messages appear in the VS Code chat view immediately after the user sends them, instead of waiting for the extension/backend transcript echo to come back through state updates.

The problem was a small but noticeable delay in the active chat flow: the composer cleared right away, but the user message bubble did not appear until the backend sent the canonical `user_feedback` message back. That made the UI feel less responsive even in cases where the message was not being placed into the queued prompt UI.

The implementation keeps this intentionally UI-local. It adds a `pendingUserMessage` to the existing chat state and appends that message only to the rendered chat message list. It does not change the extension transcript reducer, protobuf messages, backend task handling, or persisted conversation state. When the real backend `user_feedback` echo arrives, `ChatView` detects the matching message and clears the pending one so the user does not see a duplicate. If the send RPC rejects, the existing restore path puts the text/images/files back into the composer and the pending bubble is removed.

A key decision was to keep queued/streaming follow-ups out of this local pending bubble path. When `turnState.phase === "streaming"`, those sends can be delivered as queued/steering prompts and should continue to use the existing queued prompt UI instead of pretending they are already part of the visible transcript. The instant bubble is therefore only used for direct visible `messageResponse` flows such as completed/awaiting-followup states and the legacy non-running fallback.

The debugging path here started with a heavier optimistic transcript approach, but that was more machinery than the behavior needs. This version keeps the backend as the source of truth and only makes the chat view render the message the user just submitted while the backend catches up.

### Test Procedure

Ran the focused webview TypeScript and unit checks after rebasing onto latest `origin/main`:

```bash
node_modules/.bin/tsc -b
node_modules/.bin/vitest run src/components/chat/chat-view/hooks/useMessageHandlers.test.tsx
../../node_modules/.bin/biome check webview-ui/src/components/chat/ChatView.tsx webview-ui/src/components/chat/chat-view/hooks/useChatState.ts webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.ts webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.test.tsx webview-ui/src/components/chat/chat-view/types/chatTypes.ts --no-errors-on-unmatched --diagnostic-level=error
git diff --check
```

The send-handler tests now cover:

- direct completed-turn follow-ups showing a pending user bubble immediately;
- failed `askResponse` clearing the pending bubble and restoring the composer state;
- streaming follow-ups not showing a pending chat bubble because those can go through the queue/steering path;
- existing new-task and `/compact` routing behavior remaining unchanged.

Potentially affected behavior is limited to the VS Code webview chat render path for active-task user sends. New task creation still waits for backend task initialization, and backend state remains authoritative once it arrives.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. This is a timing/responsiveness change in the existing chat UI: user messages now render immediately in direct-send cases while preserving the same final visual state once the backend echo arrives.

### Additional Notes

I did not run the full repo `bun test` / `bun run format && bun run lint` suite. I ran focused webview typecheck, targeted Vitest coverage for the changed send logic, targeted Biome error-level checks for the touched files, and `git diff --check`.
