### PR TITLE
fix(vscode): disable subagents

### DIFF
--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -648,7 +648,6 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 	}
 
 	const stateManager = StateManager.get()
-	const globalSubagentsEnabled = stateManager.getGlobalSettingsKey("subagentsEnabled") ?? false
 	const globalUseAutoCondense = stateManager.getGlobalSettingsKey("useAutoCondense") ?? false
 	const enableCheckpoints = stateManager.getGlobalSettingsKey("enableCheckpointsSetting") ?? true
 	const useAutoCondense = input.taskSettings?.useAutoCondense ?? globalUseAutoCondense
@@ -688,7 +687,7 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 		checkpoint: {
 			enabled: enableCheckpoints,
 		},
-		enableSpawnAgent: input.taskSettings?.subagentsEnabled ?? globalSubagentsEnabled,
+		enableSpawnAgent: false,
 		enableAgentTeams: false,
 		...(useAutoCondense
 			? {

--- a/apps/vscode/webview-ui/src/components/settings/sections/FeatureSettingsSection.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/sections/FeatureSettingsSection.tsx
@@ -31,13 +31,6 @@ interface FeatureToggle {
 
 const agentFeatures: FeatureToggle[] = [
 	{
-		id: "subagents",
-		label: "Subagents",
-		description: "Let Cline run focused subagents in parallel to explore the codebase for you.",
-		stateKey: "subagentsEnabled",
-		settingKey: "subagentsEnabled",
-	},
-	{
 		id: "auto-compact",
 		label: "Auto Compact",
 		description: "Automatically compress conversation history.",


### PR DESCRIPTION
### Related Issue

**Issue:** N/A

### Description

This PR temporarily disables SDK subagents in the VS Code extension while the implementation is reviewed.

The VS Code extension was still exposing a Subagents setting in the Features section and passing the saved/task `subagentsEnabled` value into SDK session creation. That meant a user-facing toggle could enable `enableSpawnAgent` for VS Code SDK sessions even though the current behavior around subagent tool access and approval handling needs more scrutiny.

The change keeps this intentionally narrow:

- The Settings > Features UI no longer renders the Subagents toggle.
- VS Code SDK sessions always pass `enableSpawnAgent: false`.
- Existing persisted settings/state plumbing is left in place for compatibility and to avoid a broader migration or cleanup in this hotfix.

This makes the current VS Code behavior conservative without changing the CLI implementation or removing shared SDK concepts.

### Test Procedure

- Ran `bunx tsc --noEmit --project tsconfig.json` from `apps/vscode`.
- Ran `bunx tsc --noEmit` from `apps/vscode/webview-ui`.
- Ran `git diff --check`.

These checks verify that the extension backend and webview TypeScript still type-check and that the focused diff has no whitespace errors. The behavioral surface is limited to session config construction and the settings feature list.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not included. The UI change removes the Subagents toggle from Settings > Features.

### Additional Notes

I did not run the full `bun test` suite or full `bun run format && bun run lint` commands for this small hotfix. Focused TypeScript checks for both touched VS Code packages and `git diff --check` passed locally.
