### PR TITLE
fix: refresh provider model metadata from catalog

### DIFF
--- a/apps/vscode/webview-ui/src/components/settings/providers/ZAiProvider.test.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/ZAiProvider.test.tsx
@@ -1,0 +1,116 @@
+import { toProtobufModelInfo } from "@shared/proto-conversions/models/typeConversion"
+import { render, screen } from "@testing-library/react"
+import type { ChangeEventHandler, ReactNode } from "react"
+import { describe, expect, it, vi } from "vitest"
+import { useExtensionState } from "@/context/ExtensionStateContext"
+import { useProviderConfig } from "@/hooks/useProviderConfig"
+import { useProviderModels } from "@/hooks/useProviderModels"
+import { useStaticProviderSelection } from "@/hooks/useStaticProviderSelection"
+import { ZAiProvider } from "./ZAiProvider"
+
+vi.mock("@/context/ExtensionStateContext", () => ({
+	useExtensionState: vi.fn(),
+}))
+
+vi.mock("@/hooks/useProviderConfig", () => ({
+	useProviderConfig: vi.fn(),
+}))
+
+vi.mock("@/hooks/useProviderModels", () => ({
+	useProviderModels: vi.fn(),
+}))
+
+vi.mock("@/hooks/useStaticProviderSelection", () => ({
+	useStaticProviderSelection: vi.fn(),
+}))
+
+vi.mock("../utils/useApiConfigurationHandlers", () => ({
+	useApiConfigurationHandlers: () => ({
+		handleModeFieldChange: vi.fn(),
+	}),
+}))
+
+vi.mock("@vscode/webview-ui-toolkit/react", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@vscode/webview-ui-toolkit/react")>()
+	return {
+		...actual,
+		VSCodeDropdown: ({
+			children,
+			id,
+			onChange,
+			value,
+			"aria-label": ariaLabel,
+		}: {
+			children?: ReactNode
+			id?: string
+			onChange?: ChangeEventHandler<HTMLSelectElement>
+			value?: string
+			"aria-label"?: string
+		}) => (
+			<select aria-label={ariaLabel} id={id} onChange={onChange} value={value}>
+				{children}
+			</select>
+		),
+		VSCodeOption: ({ children, value }: { children?: ReactNode; value?: string }) => (
+			<option value={value}>{children}</option>
+		),
+	}
+})
+
+describe("ZAiProvider", () => {
+	it("uses live catalog reasoning support when the saved model snapshot is stale", () => {
+		const liveModelInfo = {
+			name: "GLM 5.2",
+			supportsPromptCache: true,
+			contextWindow: 1_048_576,
+			supportsReasoning: true,
+		}
+
+		vi.mocked(useExtensionState).mockReturnValue({
+			apiConfiguration: {
+				apiProvider: "zai",
+				actModeApiModelId: "glm-5.2",
+				zaiApiKey: "test-key",
+			},
+		} as ReturnType<typeof useExtensionState>)
+		vi.mocked(useProviderModels).mockReturnValue({
+			models: {},
+			defaultModelId: "",
+			isLoading: false,
+			isStale: false,
+			error: undefined,
+			refresh: vi.fn(),
+			fingerprint: "fingerprint",
+		})
+		vi.mocked(useStaticProviderSelection).mockReturnValue({
+			models: {
+				"glm-5.2": liveModelInfo,
+			},
+			defaultModelId: "glm-5.2",
+			selectedModelId: "glm-5.2",
+			selectedModelInfo: {
+				name: "GLM 5.2",
+				supportsPromptCache: true,
+			},
+			hideUsageCost: false,
+		})
+		vi.mocked(useProviderConfig).mockReturnValue({
+			config: {
+				actSelection: {
+					providerId: "zai",
+					modelId: "glm-5.2",
+					modelInfo: toProtobufModelInfo({
+						name: "GLM 5.2",
+						supportsPromptCache: true,
+					}),
+				},
+			},
+			write: vi.fn(async () => undefined),
+			commitSelection: vi.fn(),
+		})
+
+		render(<ZAiProvider currentMode="act" showModelOptions={true} />)
+
+		expect(screen.getByText("Reasoning Effort")).toBeInTheDocument()
+	})
+})

--- a/apps/vscode/webview-ui/src/components/settings/providers/ZAiProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/ZAiProvider.tsx
@@ -8,6 +8,7 @@ import { useStaticProviderSelection } from "@/hooks/useStaticProviderSelection"
 import { ApiKeyField } from "../common/ApiKeyField"
 import { ModelInfoView } from "../common/ModelInfoView"
 import { DropdownContainer, ModelSelector } from "../common/ModelSelector"
+import ReasoningEffortSelector from "../ReasoningEffortSelector"
 import { useProviderApiKeyField } from "../utils/useProviderApiKeyField"
 
 const PROVIDER_ID = "zai"
@@ -128,6 +129,20 @@ export const ZAiProvider = ({ showModelOptions, isPopup, currentMode }: ZAiProvi
 						onChange={(event: Event) => handleModelChange(getEventValue(event))}
 						selectedModelId={selectedModelId}
 					/>
+
+					{selectedModelInfo.supportsReasoning === true && (
+						<ReasoningEffortSelector
+							currentMode={currentMode}
+							onEffortChange={(effort) => {
+								void write({
+									reasoning: {
+										enabled: effort !== "none",
+										effort: effort !== "none" ? effort : undefined,
+									},
+								}).catch((err) => console.error("Failed to update Z AI reasoning effort:", err))
+							}}
+						/>
+					)}
 
 					<ModelInfoView
 						hideUsageCost={hideUsageCost}

--- a/apps/vscode/webview-ui/src/hooks/useProviderModelSelection.ts
+++ b/apps/vscode/webview-ui/src/hooks/useProviderModelSelection.ts
@@ -30,11 +30,15 @@ export function useProviderModelSelection(
 	const committedSelection = currentMode === "plan" ? config?.planSelection : config?.actSelection
 	const fallbackModelId = defaultModelId || Object.keys(models)[0] || ""
 	const selectedModelId = committedSelection?.modelId ?? fallbackModelId
-	const selectedModelInfo = committedSelection?.modelInfo
-		? fromProtobufModelInfo(committedSelection.modelInfo)
-		: (models[selectedModelId] ??
-			(selectedModelId && customModelInfo ? customModelInfo(selectedModelId) : undefined) ??
-			fallbackModelInfo)
+	const persistedModelInfo = committedSelection?.modelInfo ? fromProtobufModelInfo(committedSelection.modelInfo) : undefined
+	const liveModelInfo = models[selectedModelId]
+	const selectedModelInfo =
+		persistedModelInfo || liveModelInfo
+			? {
+					...persistedModelInfo,
+					...liveModelInfo,
+				}
+			: ((selectedModelId && customModelInfo ? customModelInfo(selectedModelId) : undefined) ?? fallbackModelInfo)
 
 	const selectedModel: ProviderModelSelection = {
 		providerId,


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Provider model info can become stale after a user saves a model selection. The committed protobuf `modelInfo` is a snapshot from selection time, while the SDK model catalog can later add or update capability flags and metadata for the same model ID. Before this PR, providers using `useProviderModelSelection` treated the committed snapshot as authoritative whenever it existed, so the settings UI could miss newer catalog data such as `supportsReasoning`, `thinkingConfig`, context window updates, or other model metadata.

This PR changes that behavior for providers that use `useProviderModelSelection`: when the selected model still exists in the live catalog, we now resolve model info by using the persisted snapshot as the base and overlaying the latest catalog-retrieved model data. In other words, committed model info remains the fallback/history of what the user selected, but current catalog data wins for fields the catalog knows about. That matches the same model-metadata principle used in the Cline picker fix: saved model info should not permanently freeze capability flags when we have fresher catalog data for the exact selected model.

The practical impact is broader than ZAI. Any provider wired through this shared hook can now reflect refreshed catalog metadata in its settings UI instead of being stuck on the saved snapshot. This is intentional: `modelInfo` in provider selection storage is not meant to be the long-term source of truth for mutable catalog capabilities when the selected model is still present in the catalog. If the model is not present in the live catalog, the hook still falls back to the persisted/custom/fallback info path so manual or unavailable model IDs keep working.

This PR also adds the visible ZAI-specific piece: the regular ZAI provider (`providerId: "zai"`) now renders the existing `ReasoningEffortSelector` when the resolved selected model supports reasoning. ZAI has catalog models with reasoning support, and once the shared selection hook sees fresh `supportsReasoning` data, the provider needs to expose the same reasoning-effort control pattern used by other reasoning-capable providers. Effort changes are persisted into the provider config `reasoning` field, matching the generic catalog-backed provider behavior and the runtime session factory path that normalizes provider-level reasoning settings.

Non-obvious details and scope:

- This is not only a ZAI metadata fix; the shared hook behavior affects all providers that call `useProviderModelSelection`.
- The ZAI UI addition is scoped to the regular `zai` provider component, not the `zai-coding-plan` provider component.
- `zai-coding-plan` uses the generic provider settings path, so it benefits from the shared metadata-refresh behavior without using `ZAiProvider.tsx`.
- We only overlay live catalog data when `models[selectedModelId]` exists, so custom/manual model IDs continue to rely on the previous fallback behavior.

### Test Procedure

Ran the focused provider tests:

```bash
bun -F webview-ui test src/components/settings/providers/ZAiProvider.test.tsx src/components/settings/providers/GenericProviderSettings.test.tsx
```

Ran Biome on the touched webview files from the VS Code package boundary:

```bash
bunx --bun @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true webview-ui/src/components/settings/providers/ZAiProvider.tsx webview-ui/src/components/settings/providers/ZAiProvider.test.tsx webview-ui/src/hooks/useProviderModelSelection.ts
```

Ran the webview build:

```bash
bun -F webview-ui build
```

The regression test renders ZAI with a committed stale model snapshot that lacks `supportsReasoning`, plus a live catalog entry for the same selected model with `supportsReasoning: true`, and verifies that the Reasoning Effort control appears. The existing generic provider settings tests were rerun because the shared hook behavior also affects catalog-backed providers beyond ZAI.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. This restores an existing reasoning-effort settings control for reasoning-capable ZAI models and updates provider metadata resolution behavior.

### Additional Notes

While preparing the PR, the task worktree was on a detached HEAD that was behind the current GitHub `main`. I rebased the single commit onto `origin/main` before updating the pushed branch so the PR diff contains only the intended provider metadata and ZAI settings changes.
