### PR TITLE
fix: wrap customize tabs on narrow screens

### DIFF
--- a/apps/vscode/webview-ui/src/components/marketplace/MarketplaceView.tsx
+++ b/apps/vscode/webview-ui/src/components/marketplace/MarketplaceView.tsx
@@ -584,8 +584,8 @@ const MarketplaceStyles = () => (
 				width: auto;
 				flex: 0 0 auto;
 				display: flex;
-				overflow-x: auto;
-				overflow-y: hidden;
+				flex-wrap: wrap;
+				overflow: visible;
 				border-right: 0;
 				border-bottom: 1px solid var(--vscode-panel-border);
 				padding: 0 4px;
@@ -593,7 +593,8 @@ const MarketplaceStyles = () => (
 
 			.marketplace-tab {
 				width: auto;
-				flex: 0 0 auto;
+				flex: 1 1 96px;
+				min-width: 96px;
 				border-left: 0;
 				border-bottom: 2px solid transparent;
 				padding: 0 10px;


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This fixes the Customize view tab strip in the VS Code extension when the webview panel is narrow. The Skills, MCP, and Plugins tabs already switch from the left-side vertical navigation to a top navigation at widths below 520px, but that top navigation previously stayed as a single non-wrapping row with horizontal overflow. At narrow widths, the tab strip could crowd the content and make the UI look broken.

The change keeps the existing breakpoint and visual treatment, but changes the mobile tab list to wrap instead of scrolling horizontally. Each tab now has a stable 96px minimum/flex basis, so the three tabs can split across two or three rows when the panel is too narrow, while still filling available row width when there is enough space.

The implementation is intentionally scoped to the Customize marketplace view CSS in `MarketplaceView.tsx`. It does not change the shared tab primitives, other settings screens, or any marketplace data/loading behavior.

Debugging notes:

- The affected screen is rendered by `apps/vscode/webview-ui/src/components/marketplace/MarketplaceView.tsx` under the `Customize` header.
- The existing mobile media query was already responsible for converting the tab list to a horizontal top nav.
- The layout issue came from `overflow-x: auto` plus `flex: 0 0 auto` on tabs, which preserves a single row even when the VS Code panel gets too narrow.
- Replacing that with wrapping and a small tab minimum width preserves the current UI but lets the browser naturally break the tabs into additional rows.

### Test Procedure

Ran the webview production build:

```bash
bun -F webview-ui build
```

The build completed successfully, including TypeScript project build and Vite bundling for the VS Code webview.

Also ran:

```bash
bun -F webview-ui lint
```

That command completed successfully, though it reported that zero changed files were checked. Because this is a CSS-only change inside an existing TSX style block, the production webview build is the useful validation that the edited file still parses and bundles.

Manual verification focus for reviewers:

- Open the VS Code extension Customize view.
- Narrow the webview/sidebar below the existing 520px breakpoint.
- Confirm Skills, MCP, and Plugins wrap onto additional rows instead of squeezing or forcing horizontal tab overflow.
- Confirm the selected tab underline still appears correctly after wrapping.
- Confirm wider layouts still keep the existing left-side vertical tab navigation.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not captured in this sandbox. The visual change is limited to the narrow-width Customize tab strip: the expected behavior is that Skills, MCP, and Plugins wrap onto additional rows below the existing 520px breakpoint.

### Additional Notes

The PR intentionally leaves the existing breakpoint, colors, selected state, spacing, and desktop side-nav layout unchanged. The only behavioral layout change is allowing the mobile tab list to wrap.
