### PR TITLE
Add compaction sidecar feature gate

### DIFF
--- a/apps/cli/src/runtime/interactive/session-runtime.test.ts
+++ b/apps/cli/src/runtime/interactive/session-runtime.test.ts
@@ -217,7 +217,7 @@ async function makeRuntime(
 				onTeamEvent: vi.fn(),
 				onPendingPrompts: vi.fn(),
 				onPendingPromptSubmitted: vi.fn(),
-				isCompactionSidecarEnabled: () => true,
+				getCompactionSidecarEnabled: () => true,
 			});
 }
 
@@ -295,7 +295,7 @@ describe("createInteractiveSessionRuntime", () => {
 				onTeamEvent: vi.fn(),
 				onPendingPrompts: vi.fn(),
 				onPendingPromptSubmitted: vi.fn(),
-				isCompactionSidecarEnabled: () => true,
+				getCompactionSidecarEnabled: () => true,
 			});
 
 		await runtime.ensureReady();
@@ -380,7 +380,7 @@ describe("createInteractiveSessionRuntime", () => {
 			onTeamEvent: vi.fn(),
 			onPendingPrompts: vi.fn(),
 			onPendingPromptSubmitted: vi.fn(),
-			isCompactionSidecarEnabled: () => false,
+			getCompactionSidecarEnabled: () => false,
 		});
 
 		await runtime.ensureReady();
@@ -442,7 +442,7 @@ describe("createInteractiveSessionRuntime", () => {
 				onTeamEvent: vi.fn(),
 				onPendingPrompts: vi.fn(),
 				onPendingPromptSubmitted: vi.fn(),
-				isCompactionSidecarEnabled: () => true,
+				getCompactionSidecarEnabled: () => true,
 			});
 
 		await runtime.ensureReady();
@@ -540,7 +540,7 @@ describe("createInteractiveSessionRuntime", () => {
 				onTeamEvent: vi.fn(),
 				onPendingPrompts: vi.fn(),
 				onPendingPromptSubmitted: vi.fn(),
-				isCompactionSidecarEnabled: () => true,
+				getCompactionSidecarEnabled: () => true,
 			});
 
 		await runtime.ensureReady();

--- a/apps/cli/src/runtime/interactive/session-runtime.test.ts
+++ b/apps/cli/src/runtime/interactive/session-runtime.test.ts
@@ -213,11 +213,12 @@ async function makeRuntime(
 		askQuestionRef: { current: null },
 		resolveMistakeLimitDecision: undefined,
 		switchToActModeTool: makeSwitchToActModeTool(),
-		onAgentEvent: vi.fn(),
-		onTeamEvent: vi.fn(),
-		onPendingPrompts: vi.fn(),
-		onPendingPromptSubmitted: vi.fn(),
-	});
+				onAgentEvent: vi.fn(),
+				onTeamEvent: vi.fn(),
+				onPendingPrompts: vi.fn(),
+				onPendingPromptSubmitted: vi.fn(),
+				isCompactionSidecarEnabled: () => true,
+			});
 }
 
 describe("createInteractiveSessionRuntime", () => {
@@ -281,20 +282,21 @@ describe("createInteractiveSessionRuntime", () => {
 			compactionState,
 		});
 		const { createInteractiveSessionRuntime } = await importRuntime();
-		const runtime = createInteractiveSessionRuntime({
-			config: createConfig(),
-			providerSettingsManager: createProviderSettingsManager(),
-			chatCommandState: createChatCommandState(),
-			requestToolApproval: vi.fn(),
+			const runtime = createInteractiveSessionRuntime({
+				config: createConfig(),
+				providerSettingsManager: createProviderSettingsManager(),
+				chatCommandState: createChatCommandState(),
+				requestToolApproval: vi.fn(),
 			resolveToolPolicy: () => ({ autoApprove: true }),
-			askQuestionRef: { current: null },
-			resolveMistakeLimitDecision: undefined,
-			switchToActModeTool: {} as never,
-			onAgentEvent: vi.fn(),
-			onTeamEvent: vi.fn(),
-			onPendingPrompts: vi.fn(),
-			onPendingPromptSubmitted: vi.fn(),
-		});
+				askQuestionRef: { current: null },
+				resolveMistakeLimitDecision: undefined,
+				switchToActModeTool: {} as never,
+				onAgentEvent: vi.fn(),
+				onTeamEvent: vi.fn(),
+				onPendingPrompts: vi.fn(),
+				onPendingPromptSubmitted: vi.fn(),
+				isCompactionSidecarEnabled: () => true,
+			});
 
 		await runtime.ensureReady();
 		const result = await runtime.compactCurrentSession();
@@ -327,7 +329,7 @@ describe("createInteractiveSessionRuntime", () => {
 		expect(runtime.getActiveSessionId()).toBe(sessionId);
 	});
 
-	it("manual compact skips sidecar writes when the sidecar flag is off", async () => {
+	it("manual compact runs compaction but reports not compacted when the sidecar flag is off", async () => {
 		const sessionId = "sess-active-sidecar-off";
 		const messages = [
 			{ id: "u1", role: "user" as const, content: "hello" },
@@ -365,11 +367,11 @@ describe("createInteractiveSessionRuntime", () => {
 			compactionState,
 		});
 		const { createInteractiveSessionRuntime } = await importRuntime();
-		const runtime = createInteractiveSessionRuntime({
-			config: createConfig(),
-			providerSettingsManager: createProviderSettingsManager(),
-			chatCommandState: createChatCommandState(),
-			requestToolApproval: vi.fn(),
+			const runtime = createInteractiveSessionRuntime({
+				config: createConfig(),
+				providerSettingsManager: createProviderSettingsManager(),
+				chatCommandState: createChatCommandState(),
+				requestToolApproval: vi.fn(),
 			resolveToolPolicy: () => ({ autoApprove: true }),
 			askQuestionRef: { current: null },
 			resolveMistakeLimitDecision: undefined,
@@ -389,6 +391,12 @@ describe("createInteractiveSessionRuntime", () => {
 			messagesAfter: messages.length,
 			compacted: false,
 		});
+		expect(compactInteractiveMessagesMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				sessionId,
+				messages,
+			}),
+		);
 		expect(manager.updateSessionCompactionState).not.toHaveBeenCalled();
 		expect(runtime.getActiveSessionId()).toBe(sessionId);
 	});
@@ -430,11 +438,12 @@ describe("createInteractiveSessionRuntime", () => {
 			askQuestionRef: { current: null },
 			resolveMistakeLimitDecision: undefined,
 			switchToActModeTool: {} as never,
-			onAgentEvent: vi.fn(),
-			onTeamEvent: vi.fn(),
-			onPendingPrompts: vi.fn(),
-			onPendingPromptSubmitted: vi.fn(),
-		});
+				onAgentEvent: vi.fn(),
+				onTeamEvent: vi.fn(),
+				onPendingPrompts: vi.fn(),
+				onPendingPromptSubmitted: vi.fn(),
+				isCompactionSidecarEnabled: () => true,
+			});
 
 		await runtime.ensureReady();
 
@@ -527,11 +536,12 @@ describe("createInteractiveSessionRuntime", () => {
 			askQuestionRef: { current: null },
 			resolveMistakeLimitDecision: undefined,
 			switchToActModeTool: {} as never,
-			onAgentEvent: vi.fn(),
-			onTeamEvent: vi.fn(),
-			onPendingPrompts: vi.fn(),
-			onPendingPromptSubmitted: vi.fn(),
-		});
+				onAgentEvent: vi.fn(),
+				onTeamEvent: vi.fn(),
+				onPendingPrompts: vi.fn(),
+				onPendingPromptSubmitted: vi.fn(),
+				isCompactionSidecarEnabled: () => true,
+			});
 
 		await runtime.ensureReady();
 		await runtime.applyMode("plan");

--- a/apps/cli/src/runtime/interactive/session-runtime.test.ts
+++ b/apps/cli/src/runtime/interactive/session-runtime.test.ts
@@ -327,6 +327,73 @@ describe("createInteractiveSessionRuntime", () => {
 		expect(runtime.getActiveSessionId()).toBe(sessionId);
 	});
 
+	it("manual compact skips sidecar writes when the sidecar flag is off", async () => {
+		const sessionId = "sess-active-sidecar-off";
+		const messages = [
+			{ id: "u1", role: "user" as const, content: "hello" },
+			{ id: "a1", role: "assistant" as const, content: "world" },
+		];
+		const compactionState = createSessionCompactionState({
+			sourceMessages: messages,
+			compactedMessages: [
+				{ id: "summary", role: "user" as const, content: "summary" },
+			],
+			updatedAt: "2026-01-01T00:00:00.000Z",
+		});
+		const manager = {
+			start: vi.fn().mockResolvedValue({
+				sessionId,
+				manifest: createManifest(sessionId),
+				manifestPath: "/tmp/session.json",
+				messagesPath: "/tmp/session.messages.json",
+			}),
+			readMessages: vi.fn().mockResolvedValue(messages),
+			updateSessionCompactionState: vi.fn(),
+			stop: vi.fn().mockResolvedValue(undefined),
+			dispose: vi.fn().mockResolvedValue(undefined),
+			ingestHookEvent: vi.fn().mockResolvedValue(undefined),
+			get: vi.fn(),
+			list: vi.fn(),
+			delete: vi.fn(),
+			send: vi.fn(),
+			getAccumulatedUsage: vi.fn(),
+		};
+		createCliCoreMock.mockResolvedValue(manager);
+		compactInteractiveMessagesMock.mockResolvedValue({
+			compacted: true,
+			canonicalMessages: messages,
+			compactionState,
+		});
+		const { createInteractiveSessionRuntime } = await importRuntime();
+		const runtime = createInteractiveSessionRuntime({
+			config: createConfig(),
+			providerSettingsManager: createProviderSettingsManager(),
+			chatCommandState: createChatCommandState(),
+			requestToolApproval: vi.fn(),
+			resolveToolPolicy: () => ({ autoApprove: true }),
+			askQuestionRef: { current: null },
+			resolveMistakeLimitDecision: undefined,
+			switchToActModeTool: {} as never,
+			onAgentEvent: vi.fn(),
+			onTeamEvent: vi.fn(),
+			onPendingPrompts: vi.fn(),
+			onPendingPromptSubmitted: vi.fn(),
+			isCompactionSidecarEnabled: () => false,
+		});
+
+		await runtime.ensureReady();
+		const result = await runtime.compactCurrentSession();
+
+		expect(result).toEqual({
+			messagesBefore: messages.length,
+			messagesAfter: messages.length,
+			workingContextMessagesAfter: compactionState.messages.length,
+			compacted: true,
+		});
+		expect(manager.updateSessionCompactionState).not.toHaveBeenCalled();
+		expect(runtime.getActiveSessionId()).toBe(sessionId);
+	});
+
 	it("rejects manual compact while the active session is running", async () => {
 		const sessionId = "sess-running";
 		const messages = [{ role: "user" as const, content: "hello" }];

--- a/apps/cli/src/runtime/interactive/session-runtime.test.ts
+++ b/apps/cli/src/runtime/interactive/session-runtime.test.ts
@@ -387,8 +387,7 @@ describe("createInteractiveSessionRuntime", () => {
 		expect(result).toEqual({
 			messagesBefore: messages.length,
 			messagesAfter: messages.length,
-			workingContextMessagesAfter: compactionState.messages.length,
-			compacted: true,
+			compacted: false,
 		});
 		expect(manager.updateSessionCompactionState).not.toHaveBeenCalled();
 		expect(runtime.getActiveSessionId()).toBe(sessionId);

--- a/apps/cli/src/runtime/interactive/session-runtime.ts
+++ b/apps/cli/src/runtime/interactive/session-runtime.ts
@@ -3,6 +3,7 @@ import {
 	type AgentHooks,
 	type CheckpointEntry,
 	createSessionCompactionState,
+	createSessionCompactionSidecarEnabledResolver,
 	isSessionNotFoundError,
 	type PendingPromptMutationResult,
 	type ProviderSettingsManager,
@@ -103,8 +104,12 @@ export function createInteractiveSessionRuntime(input: {
 	onTeamEvent: (event: TeamEvent) => void;
 	onPendingPrompts: (event: PendingPromptSnapshot) => void;
 	onPendingPromptSubmitted: (event: PendingPromptSubmittedEvent) => void;
+	isCompactionSidecarEnabled?: () => boolean;
 }) {
 	let sessionManager: CliCore | undefined;
+	const isCompactionSidecarEnabled =
+		input.isCompactionSidecarEnabled ??
+		createSessionCompactionSidecarEnabledResolver();
 	let runtimeHooks: RuntimeHooks | undefined;
 	let unsubscribeAgent = () => {};
 	let unsubscribePendingPrompts = () => {};
@@ -219,7 +224,9 @@ export function createInteractiveSessionRuntime(input: {
 			toolPolicies: input.config.toolPolicies,
 			interactive: true,
 			initialMessages: initial,
-			...(initialCompactionState ? { initialCompactionState } : {}),
+			...(isCompactionSidecarEnabled() && initialCompactionState
+				? { initialCompactionState }
+				: {}),
 			...(sessionMetadata ? { sessionMetadata } : {}),
 			localRuntime: {
 				onTeamRestored: () => {},
@@ -318,6 +325,9 @@ export function createInteractiveSessionRuntime(input: {
 	const readCompactionState = async (
 		sessionId: string,
 	): Promise<SessionCompactionState | undefined> => {
+		if (!isCompactionSidecarEnabled()) {
+			return undefined;
+		}
 		const manager = sessionManager;
 		if (!manager) {
 			return undefined;
@@ -688,6 +698,14 @@ export function createInteractiveSessionRuntime(input: {
 				messagesBefore,
 				messagesAfter: messagesBefore,
 				compacted: false,
+			};
+		}
+		if (!isCompactionSidecarEnabled()) {
+			return {
+				messagesBefore,
+				messagesAfter: result.canonicalMessages.length,
+				workingContextMessagesAfter: result.compactionState.messages.length,
+				compacted: true,
 			};
 		}
 		const updated = await manager.updateSessionCompactionState(

--- a/apps/cli/src/runtime/interactive/session-runtime.ts
+++ b/apps/cli/src/runtime/interactive/session-runtime.ts
@@ -3,6 +3,7 @@ import {
 	type AgentHooks,
 	type CheckpointEntry,
 	createSessionCompactionState,
+	createSessionCompactionSidecarAccess,
 	createSessionCompactionSidecarEnabledResolver,
 	isSessionNotFoundError,
 	type PendingPromptMutationResult,
@@ -110,6 +111,9 @@ export function createInteractiveSessionRuntime(input: {
 	const isCompactionSidecarEnabled =
 		input.isCompactionSidecarEnabled ??
 		createSessionCompactionSidecarEnabledResolver();
+	const compactionSidecar = createSessionCompactionSidecarAccess(
+		isCompactionSidecarEnabled,
+	);
 	let runtimeHooks: RuntimeHooks | undefined;
 	let unsubscribeAgent = () => {};
 	let unsubscribePendingPrompts = () => {};
@@ -218,14 +222,17 @@ export function createInteractiveSessionRuntime(input: {
 	): Promise<void> => {
 		const generation = sessionStartGeneration;
 		const manager = await ensureSessionManager();
+		const sidecarInitialCompactionState = compactionSidecar.initialState(
+			initialCompactionState,
+		);
 		const started = await manager.start({
 			source: SessionSource.CLI,
 			config: buildSessionConfig(),
 			toolPolicies: input.config.toolPolicies,
 			interactive: true,
 			initialMessages: initial,
-			...(isCompactionSidecarEnabled() && initialCompactionState
-				? { initialCompactionState }
+			...(sidecarInitialCompactionState
+				? { initialCompactionState: sidecarInitialCompactionState }
 				: {}),
 			...(sessionMetadata ? { sessionMetadata } : {}),
 			localRuntime: {
@@ -325,15 +332,14 @@ export function createInteractiveSessionRuntime(input: {
 	const readCompactionState = async (
 		sessionId: string,
 	): Promise<SessionCompactionState | undefined> => {
-		if (!isCompactionSidecarEnabled()) {
-			return undefined;
-		}
 		const manager = sessionManager;
 		if (!manager) {
 			return undefined;
 		}
 		try {
-			return await manager.readSessionCompactionState(sessionId);
+			return await compactionSidecar.read(() =>
+				manager.readSessionCompactionState(sessionId),
+			);
 		} catch (error) {
 			input.config.logger?.log?.("Failed to read session compaction state", {
 				sessionId,
@@ -700,25 +706,20 @@ export function createInteractiveSessionRuntime(input: {
 				compacted: false,
 			};
 		}
-		if (!isCompactionSidecarEnabled()) {
-			return {
-				messagesBefore,
-				messagesAfter: result.canonicalMessages.length,
-				workingContextMessagesAfter: result.compactionState.messages.length,
-				compacted: true,
-			};
-		}
-		const updated = await manager.updateSessionCompactionState(
-			sourceSessionId,
-			result.compactionState,
+		const compactionState = result.compactionState;
+		const updated = await compactionSidecar.update(() =>
+			manager.updateSessionCompactionState(
+				sourceSessionId,
+				compactionState,
+			),
 		);
-		if (!updated.updated) {
+		if (!updated.updated && !updated.disabled) {
 			throw new Error("Compaction could not be saved. Try again.");
 		}
 		return {
 			messagesBefore,
 			messagesAfter: result.canonicalMessages.length,
-			workingContextMessagesAfter: result.compactionState?.messages.length,
+			workingContextMessagesAfter: compactionState.messages.length,
 			compacted: true,
 		};
 	};

--- a/apps/cli/src/runtime/interactive/session-runtime.ts
+++ b/apps/cli/src/runtime/interactive/session-runtime.ts
@@ -710,7 +710,14 @@ export function createInteractiveSessionRuntime(input: {
 		const updated = await compactionSidecar.update(() =>
 			manager.updateSessionCompactionState(sourceSessionId, compactionState),
 		);
-		if (!updated.updated && !updated.disabled) {
+		if (updated.disabled) {
+			return {
+				messagesBefore,
+				messagesAfter: messagesBefore,
+				compacted: false,
+			};
+		}
+		if (!updated.updated) {
 			throw new Error("Compaction could not be saved. Try again.");
 		}
 		return {

--- a/apps/cli/src/runtime/interactive/session-runtime.ts
+++ b/apps/cli/src/runtime/interactive/session-runtime.ts
@@ -105,14 +105,14 @@ export function createInteractiveSessionRuntime(input: {
 	onTeamEvent: (event: TeamEvent) => void;
 	onPendingPrompts: (event: PendingPromptSnapshot) => void;
 	onPendingPromptSubmitted: (event: PendingPromptSubmittedEvent) => void;
-	isCompactionSidecarEnabled?: () => boolean;
+	getCompactionSidecarEnabled?: () => boolean;
 }) {
 	let sessionManager: CliCore | undefined;
-	const isCompactionSidecarEnabled =
-		input.isCompactionSidecarEnabled ??
+	const getCompactionSidecarEnabled =
+		input.getCompactionSidecarEnabled ??
 		createSessionCompactionSidecarEnabledResolver();
 	const compactionSidecar = createSessionCompactionSidecarAccess(
-		isCompactionSidecarEnabled,
+		getCompactionSidecarEnabled,
 	);
 	let runtimeHooks: RuntimeHooks | undefined;
 	let unsubscribeAgent = () => {};

--- a/apps/cli/src/runtime/interactive/session-runtime.ts
+++ b/apps/cli/src/runtime/interactive/session-runtime.ts
@@ -708,10 +708,7 @@ export function createInteractiveSessionRuntime(input: {
 		}
 		const compactionState = result.compactionState;
 		const updated = await compactionSidecar.update(() =>
-			manager.updateSessionCompactionState(
-				sourceSessionId,
-				compactionState,
-			),
+			manager.updateSessionCompactionState(sourceSessionId, compactionState),
 		);
 		if (!updated.updated && !updated.disabled) {
 			throw new Error("Compaction could not be saved. Try again.");

--- a/apps/cli/src/runtime/interactive/session-runtime.ts
+++ b/apps/cli/src/runtime/interactive/session-runtime.ts
@@ -707,16 +707,17 @@ export function createInteractiveSessionRuntime(input: {
 			};
 		}
 		const compactionState = result.compactionState;
-		const updated = await compactionSidecar.update(() =>
-			manager.updateSessionCompactionState(sourceSessionId, compactionState),
-		);
-		if (updated.disabled) {
+		if (!compactionSidecar.enabled) {
 			return {
 				messagesBefore,
 				messagesAfter: messagesBefore,
 				compacted: false,
 			};
 		}
+		const updated = await manager.updateSessionCompactionState(
+			sourceSessionId,
+			compactionState,
+		);
 		if (!updated.updated) {
 			throw new Error("Compaction could not be saved. Try again.");
 		}

--- a/apps/cli/src/runtime/run-interactive.ts
+++ b/apps/cli/src/runtime/run-interactive.ts
@@ -211,7 +211,7 @@ export async function runInteractive(
 		onPendingPromptSubmitted: (event) => {
 			uiEvents.emit("pending-prompt-submitted", event);
 		},
-		isCompactionSidecarEnabled:
+		getCompactionSidecarEnabled:
 			createSessionCompactionSidecarEnabledResolver(getCliFeatureFlagsService()),
 	});
 	let modeChangePromise: Promise<void> | undefined;

--- a/apps/cli/src/runtime/run-interactive.ts
+++ b/apps/cli/src/runtime/run-interactive.ts
@@ -1,5 +1,6 @@
 import {
 	getCurrentContextSize,
+	createSessionCompactionSidecarEnabledResolver,
 	type ProviderSettings,
 	ProviderSettingsManager,
 	type UserInstructionConfigService,
@@ -26,6 +27,7 @@ import { disableOpenTuiGraphicsProbe } from "../tui/opentui-env";
 import type { QueuedPromptItem } from "../tui/types";
 import { type ChatCommandState, chatCommandHost } from "../utils/chat-commands";
 import { applyCliCompactionMode } from "../utils/compaction-mode";
+import { getCliFeatureFlagsService } from "../utils/feature-flags";
 import {
 	shouldZeroClineFreeModelCost,
 	zeroCliAgentEventCost,
@@ -209,6 +211,8 @@ export async function runInteractive(
 		onPendingPromptSubmitted: (event) => {
 			uiEvents.emit("pending-prompt-submitted", event);
 		},
+		isCompactionSidecarEnabled:
+			createSessionCompactionSidecarEnabledResolver(getCliFeatureFlagsService()),
 	});
 	let modeChangePromise: Promise<void> | undefined;
 	let modeChangeTarget: "plan" | "act" | undefined;

--- a/sdk/packages/core/src/ClineCore.ts
+++ b/sdk/packages/core/src/ClineCore.ts
@@ -50,6 +50,7 @@ import {
 	NoOpFeatureFlagsProvider,
 } from "./services/feature-flags";
 import { resolveCoreDistinctId } from "./services/telemetry/distinct-id";
+import { createSessionCompactionSidecarEnabledResolver } from "./session/models/session-compaction";
 import type { CoreSessionEvent } from "./types/events";
 import type { SessionHistoryRecord } from "./types/sessions";
 
@@ -202,9 +203,6 @@ export class ClineCore {
 	static async create(options: ClineCoreOptions = {}): Promise<ClineCore> {
 		const distinctId = resolveCoreDistinctId(options.distinctId);
 		const capabilities = normalizeRuntimeCapabilities(options.capabilities);
-		const normalizedOptions = { ...options, capabilities, distinctId };
-		const host = await createRuntimeHost(normalizedOptions);
-		const automationOptions = normalizeAutomationOptions(options.automation);
 		const featureFlags =
 			options.featureFlags ||
 			new FeatureFlagsService({
@@ -216,6 +214,16 @@ export class ClineCore {
 					clientName: options.clientName,
 				},
 			});
+		const normalizedOptions = {
+			...options,
+			capabilities,
+			distinctId,
+			isCompactionSidecarEnabled:
+				options.isCompactionSidecarEnabled ??
+				createSessionCompactionSidecarEnabledResolver(featureFlags),
+		};
+		const host = await createRuntimeHost(normalizedOptions);
+		const automationOptions = normalizeAutomationOptions(options.automation);
 		const core = new ClineCore(
 			host,
 			options.clientName,

--- a/sdk/packages/core/src/ClineCore.ts
+++ b/sdk/packages/core/src/ClineCore.ts
@@ -218,8 +218,8 @@ export class ClineCore {
 			...options,
 			capabilities,
 			distinctId,
-			isCompactionSidecarEnabled:
-				options.isCompactionSidecarEnabled ??
+			getCompactionSidecarEnabled:
+				options.getCompactionSidecarEnabled ??
 				createSessionCompactionSidecarEnabledResolver(featureFlags),
 		};
 		const host = await createRuntimeHost(normalizedOptions);

--- a/sdk/packages/core/src/cline-core/types.ts
+++ b/sdk/packages/core/src/cline-core/types.ts
@@ -222,6 +222,7 @@ export interface ClineCoreOptions {
 	featureFlags?: FeatureFlagsService;
 	/**
 	 * Gets whether persisted compaction sidecar reads and writes are enabled.
+	 * See createSessionCompactionSidecarAccess.
 	 * @internal
 	 */
 	isCompactionSidecarEnabled?: () => boolean;

--- a/sdk/packages/core/src/cline-core/types.ts
+++ b/sdk/packages/core/src/cline-core/types.ts
@@ -221,6 +221,11 @@ export interface ClineCoreOptions {
 	 */
 	featureFlags?: FeatureFlagsService;
 	/**
+	 * Overrides the compaction sidecar rollout decision.
+	 * @internal
+	 */
+	isCompactionSidecarEnabled?: () => boolean;
+	/**
 	 * Optional structured logger for core-side operational diagnostics such as
 	 * runtime-host selection and fallback decisions.
 	 */

--- a/sdk/packages/core/src/cline-core/types.ts
+++ b/sdk/packages/core/src/cline-core/types.ts
@@ -225,7 +225,7 @@ export interface ClineCoreOptions {
 	 * See createSessionCompactionSidecarAccess.
 	 * @internal
 	 */
-	isCompactionSidecarEnabled?: () => boolean;
+	getCompactionSidecarEnabled?: () => boolean;
 	/**
 	 * Optional structured logger for core-side operational diagnostics such as
 	 * runtime-host selection and fallback decisions.

--- a/sdk/packages/core/src/cline-core/types.ts
+++ b/sdk/packages/core/src/cline-core/types.ts
@@ -126,8 +126,10 @@ export interface ClineCoreAutomationApi {
 
 export type ClineCoreListHistoryOptions = SessionHistoryListOptions;
 
-export interface ClineCoreStartInput
-	extends Omit<StartSessionInput, "config" | "localRuntime"> {
+export interface ClineCoreStartInput extends Omit<
+  StartSessionInput,
+  "config" | "localRuntime"
+> {
 	config: CoreSessionConfig;
 	localRuntime?: LocalRuntimeStartOptions;
 }
@@ -221,7 +223,7 @@ export interface ClineCoreOptions {
 	 */
 	featureFlags?: FeatureFlagsService;
 	/**
-	 * Overrides the compaction sidecar rollout decision.
+   * Gets whether persisted compaction sidecar reads and writes are enabled.
 	 * @internal
 	 */
 	isCompactionSidecarEnabled?: () => boolean;

--- a/sdk/packages/core/src/cline-core/types.ts
+++ b/sdk/packages/core/src/cline-core/types.ts
@@ -126,10 +126,8 @@ export interface ClineCoreAutomationApi {
 
 export type ClineCoreListHistoryOptions = SessionHistoryListOptions;
 
-export interface ClineCoreStartInput extends Omit<
-  StartSessionInput,
-  "config" | "localRuntime"
-> {
+export interface ClineCoreStartInput
+	extends Omit<StartSessionInput, "config" | "localRuntime"> {
 	config: CoreSessionConfig;
 	localRuntime?: LocalRuntimeStartOptions;
 }
@@ -223,7 +221,7 @@ export interface ClineCoreOptions {
 	 */
 	featureFlags?: FeatureFlagsService;
 	/**
-   * Gets whether persisted compaction sidecar reads and writes are enabled.
+	 * Gets whether persisted compaction sidecar reads and writes are enabled.
 	 * @internal
 	 */
 	isCompactionSidecarEnabled?: () => boolean;

--- a/sdk/packages/core/src/hub/server/boundary.test.ts
+++ b/sdk/packages/core/src/hub/server/boundary.test.ts
@@ -687,7 +687,7 @@ describe("HubServerTransport boundaries", () => {
 		});
 		const transport = createTransport({
 			sessionHost: { startSession },
-			isCompactionSidecarEnabled: () => false,
+			getCompactionSidecarEnabled: () => false,
 		});
 		const initialCompactionState = createSessionCompactionState({
 			sourceMessages: [{ role: "user", content: "source" }],
@@ -891,7 +891,7 @@ describe("HubServerTransport boundaries", () => {
 	it("authorizes compaction sidecar access from server session state, not mutable metadata", async () => {
 		const readSessionCompactionState = vi.fn();
 		const transport = createTransport({
-			isCompactionSidecarEnabled: () => true,
+			getCompactionSidecarEnabled: () => true,
 			sessionHost: {
 				getSession: vi.fn().mockResolvedValue({
 					sessionId: "session-1",
@@ -938,7 +938,7 @@ describe("HubServerTransport boundaries", () => {
 					readSessionCompactionState,
 					updateSessionCompactionState,
 				},
-				isCompactionSidecarEnabled: () => true,
+				getCompactionSidecarEnabled: () => true,
 			});
 		const ctx = getContext(transport);
 		expect(ctx.sessionState.has("session-1")).toBe(false);
@@ -996,7 +996,7 @@ describe("HubServerTransport boundaries", () => {
 		const readSessionCompactionState = vi.fn().mockResolvedValue(state);
 			const transport = createTransport({
 				sessionHost: { readSessionCompactionState },
-				isCompactionSidecarEnabled: () => true,
+				getCompactionSidecarEnabled: () => true,
 			});
 		const ctx = getContext(transport);
 		ensureSessionParticipant(ctx, "session-1", "viewer-client", "participant");
@@ -1033,7 +1033,7 @@ describe("HubServerTransport boundaries", () => {
 		const readSessionCompactionState = vi.fn();
 			const transport = createTransport({
 				sessionHost: { readSessionCompactionState },
-				isCompactionSidecarEnabled: () => true,
+				getCompactionSidecarEnabled: () => true,
 			});
 		const ctx = getContext(transport);
 		ensureSessionState(ctx, "session-1", "owner-client", "creator");
@@ -1074,7 +1074,7 @@ describe("HubServerTransport boundaries", () => {
 		const readSessionCompactionState = vi.fn();
 			const transport = createTransport({
 				sessionHost: { readSessionCompactionState },
-				isCompactionSidecarEnabled: () => true,
+				getCompactionSidecarEnabled: () => true,
 			});
 		const ctx = getContext(transport);
 		ensureSessionState(ctx, "session-1", "owner-client", "creator");
@@ -1118,7 +1118,7 @@ describe("HubServerTransport boundaries", () => {
 		});
 		const readSessionCompactionState = vi.fn().mockResolvedValue(state);
 		const transport = createTransport({
-			isCompactionSidecarEnabled: () => true,
+			getCompactionSidecarEnabled: () => true,
 			sessionHost: { readSessionCompactionState },
 		});
 		const ctx = getContext(transport);
@@ -1143,7 +1143,7 @@ describe("HubServerTransport boundaries", () => {
 		const readSessionCompactionState = vi.fn();
 		const transport = createTransport({
 			sessionHost: { readSessionCompactionState },
-			isCompactionSidecarEnabled: () => false,
+			getCompactionSidecarEnabled: () => false,
 		});
 		const ctx = getContext(transport);
 		ensureSessionState(ctx, "session-1", "owner-client", "creator");
@@ -1167,7 +1167,7 @@ describe("HubServerTransport boundaries", () => {
 		const updateSessionCompactionState = vi.fn();
 			const transport = createTransport({
 				sessionHost: { updateSessionCompactionState },
-				isCompactionSidecarEnabled: () => true,
+				getCompactionSidecarEnabled: () => true,
 			});
 		const ctx = getContext(transport);
 		ensureSessionState(ctx, "session-1", "owner-client", "creator");
@@ -1197,7 +1197,7 @@ describe("HubServerTransport boundaries", () => {
 		const updateSessionCompactionState = vi.fn();
 		const transport = createTransport({
 			sessionHost: { updateSessionCompactionState },
-			isCompactionSidecarEnabled: () => false,
+			getCompactionSidecarEnabled: () => false,
 		});
 		const ctx = getContext(transport);
 		ensureSessionState(ctx, "session-1", "owner-client", "creator");
@@ -1229,7 +1229,7 @@ describe("HubServerTransport boundaries", () => {
 			.mockResolvedValue({ updated: true });
 			const transport = createTransport({
 				sessionHost: { updateSessionCompactionState },
-				isCompactionSidecarEnabled: () => true,
+				getCompactionSidecarEnabled: () => true,
 			});
 		const ctx = getContext(transport);
 		const events: HubEventEnvelope[] = [];

--- a/sdk/packages/core/src/hub/server/boundary.test.ts
+++ b/sdk/packages/core/src/hub/server/boundary.test.ts
@@ -891,6 +891,7 @@ describe("HubServerTransport boundaries", () => {
 	it("authorizes compaction sidecar access from server session state, not mutable metadata", async () => {
 		const readSessionCompactionState = vi.fn();
 		const transport = createTransport({
+			isCompactionSidecarEnabled: () => true,
 			sessionHost: {
 				getSession: vi.fn().mockResolvedValue({
 					sessionId: "session-1",
@@ -932,12 +933,13 @@ describe("HubServerTransport boundaries", () => {
 		const updateSessionCompactionState = vi
 			.fn()
 			.mockResolvedValue({ updated: true });
-		const transport = createTransport({
-			sessionHost: {
-				readSessionCompactionState,
-				updateSessionCompactionState,
-			},
-		});
+			const transport = createTransport({
+				sessionHost: {
+					readSessionCompactionState,
+					updateSessionCompactionState,
+				},
+				isCompactionSidecarEnabled: () => true,
+			});
 		const ctx = getContext(transport);
 		expect(ctx.sessionState.has("session-1")).toBe(false);
 
@@ -992,9 +994,10 @@ describe("HubServerTransport boundaries", () => {
 			conversationId: "session-1",
 		});
 		const readSessionCompactionState = vi.fn().mockResolvedValue(state);
-		const transport = createTransport({
-			sessionHost: { readSessionCompactionState },
-		});
+			const transport = createTransport({
+				sessionHost: { readSessionCompactionState },
+				isCompactionSidecarEnabled: () => true,
+			});
 		const ctx = getContext(transport);
 		ensureSessionParticipant(ctx, "session-1", "viewer-client", "participant");
 
@@ -1028,9 +1031,10 @@ describe("HubServerTransport boundaries", () => {
 
 	it("clears compaction sidecar ownership when the owner detaches", async () => {
 		const readSessionCompactionState = vi.fn();
-		const transport = createTransport({
-			sessionHost: { readSessionCompactionState },
-		});
+			const transport = createTransport({
+				sessionHost: { readSessionCompactionState },
+				isCompactionSidecarEnabled: () => true,
+			});
 		const ctx = getContext(transport);
 		ensureSessionState(ctx, "session-1", "owner-client", "creator");
 		ensureSessionParticipant(ctx, "session-1", "viewer-client", "participant");
@@ -1068,9 +1072,10 @@ describe("HubServerTransport boundaries", () => {
 
 	it("clears compaction sidecar ownership when the owner unregisters", async () => {
 		const readSessionCompactionState = vi.fn();
-		const transport = createTransport({
-			sessionHost: { readSessionCompactionState },
-		});
+			const transport = createTransport({
+				sessionHost: { readSessionCompactionState },
+				isCompactionSidecarEnabled: () => true,
+			});
 		const ctx = getContext(transport);
 		ensureSessionState(ctx, "session-1", "owner-client", "creator");
 		ensureSessionParticipant(ctx, "session-1", "viewer-client", "participant");
@@ -1113,6 +1118,7 @@ describe("HubServerTransport boundaries", () => {
 		});
 		const readSessionCompactionState = vi.fn().mockResolvedValue(state);
 		const transport = createTransport({
+			isCompactionSidecarEnabled: () => true,
 			sessionHost: { readSessionCompactionState },
 		});
 		const ctx = getContext(transport);
@@ -1159,9 +1165,10 @@ describe("HubServerTransport boundaries", () => {
 
 	it("rejects invalid compaction sidecar updates before calling the session host", async () => {
 		const updateSessionCompactionState = vi.fn();
-		const transport = createTransport({
-			sessionHost: { updateSessionCompactionState },
-		});
+			const transport = createTransport({
+				sessionHost: { updateSessionCompactionState },
+				isCompactionSidecarEnabled: () => true,
+			});
 		const ctx = getContext(transport);
 		ensureSessionState(ctx, "session-1", "owner-client", "creator");
 
@@ -1220,9 +1227,10 @@ describe("HubServerTransport boundaries", () => {
 		const updateSessionCompactionState = vi
 			.fn()
 			.mockResolvedValue({ updated: true });
-		const transport = createTransport({
-			sessionHost: { updateSessionCompactionState },
-		});
+			const transport = createTransport({
+				sessionHost: { updateSessionCompactionState },
+				isCompactionSidecarEnabled: () => true,
+			});
 		const ctx = getContext(transport);
 		const events: HubEventEnvelope[] = [];
 		ensureSessionState(ctx, "session-1", "owner-client", "creator");

--- a/sdk/packages/core/src/hub/server/boundary.test.ts
+++ b/sdk/packages/core/src/hub/server/boundary.test.ts
@@ -654,73 +654,73 @@ describe("HubServerTransport boundaries", () => {
 			},
 		});
 
-			await expect(answerPromise).resolves.toBe("Use hub");
-		});
+		await expect(answerPromise).resolves.toBe("Use hub");
+	});
 
-		it("ignores initial compaction sidecar state when the sidecar flag is off", async () => {
-			let capturedStartInput: StartSessionInput | undefined;
-			const startSession = vi.fn(async (input: StartSessionInput) => {
-				capturedStartInput = input;
-				const sessionId = input.config.sessionId?.trim() || "session-1";
-				return {
-					sessionId,
-					manifest: {
-						version: 1,
-						session_id: sessionId,
-						source: "cli",
-						pid: 1,
-						started_at: new Date(0).toISOString(),
-						status: "running",
-						interactive: true,
-						provider: "cline",
-						model: "test-model",
-						cwd: "/tmp/project",
-						workspace_root: "/tmp/project",
-						enable_tools: true,
-						enable_spawn: true,
-						enable_teams: false,
-					},
-					manifestPath: "",
-					messagesPath: "",
-					result: undefined,
-				};
-			});
-			const transport = createTransport({
-				sessionHost: { startSession },
-				isCompactionSidecarEnabled: () => false,
-			});
-			const initialCompactionState = createSessionCompactionState({
-				sourceMessages: [{ role: "user", content: "source" }],
-				compactedMessages: [{ role: "user", content: "summary" }],
-				conversationId: "session-1",
-			});
-
-			const reply = await transport.handleCommand({
-				version: "v1",
-				requestId: "req-create-sidecar-off",
-				command: "session.create",
-				clientId: "client-1",
-				payload: {
-					workspaceRoot: "/tmp/project",
+	it("ignores initial compaction sidecar state when the sidecar flag is off", async () => {
+		let capturedStartInput: StartSessionInput | undefined;
+		const startSession = vi.fn(async (input: StartSessionInput) => {
+			capturedStartInput = input;
+			const sessionId = input.config.sessionId?.trim() || "session-1";
+			return {
+				sessionId,
+				manifest: {
+					version: 1,
+					session_id: sessionId,
+					source: "cli",
+					pid: 1,
+					started_at: new Date(0).toISOString(),
+					status: "running",
+					interactive: true,
+					provider: "cline",
+					model: "test-model",
 					cwd: "/tmp/project",
-					sessionConfig: {
-						sessionId: "session-1",
-						providerId: "cline",
-						modelId: "test-model",
-						cwd: "/tmp/project",
-						workspaceRoot: "/tmp/project",
-						systemPrompt: "system",
-					},
-					initialCompactionState,
+					workspace_root: "/tmp/project",
+					enable_tools: true,
+					enable_spawn: true,
+					enable_teams: false,
 				},
-			});
-
-			expect(reply.ok).toBe(true);
-			expect(capturedStartInput?.initialCompactionState).toBeUndefined();
+				manifestPath: "",
+				messagesPath: "",
+				result: undefined,
+			};
+		});
+		const transport = createTransport({
+			sessionHost: { startSession },
+			isCompactionSidecarEnabled: () => false,
+		});
+		const initialCompactionState = createSessionCompactionState({
+			sourceMessages: [{ role: "user", content: "source" }],
+			compactedMessages: [{ role: "user", content: "summary" }],
+			conversationId: "session-1",
 		});
 
-		it("does not transfer capability ownership to attached clients", async () => {
-			let createdSessionId = "";
+		const reply = await transport.handleCommand({
+			version: "v1",
+			requestId: "req-create-sidecar-off",
+			command: "session.create",
+			clientId: "client-1",
+			payload: {
+				workspaceRoot: "/tmp/project",
+				cwd: "/tmp/project",
+				sessionConfig: {
+					sessionId: "session-1",
+					providerId: "cline",
+					modelId: "test-model",
+					cwd: "/tmp/project",
+					workspaceRoot: "/tmp/project",
+					systemPrompt: "system",
+				},
+				initialCompactionState,
+			},
+		});
+
+		expect(reply.ok).toBe(true);
+		expect(capturedStartInput?.initialCompactionState).toBeUndefined();
+	});
+
+	it("does not transfer capability ownership to attached clients", async () => {
+		let createdSessionId = "";
 		const startSession = vi.fn(async (input: StartSessionInput) => {
 			createdSessionId = input.config.sessionId?.trim() || "missing-session";
 			return {

--- a/sdk/packages/core/src/hub/server/boundary.test.ts
+++ b/sdk/packages/core/src/hub/server/boundary.test.ts
@@ -654,11 +654,73 @@ describe("HubServerTransport boundaries", () => {
 			},
 		});
 
-		await expect(answerPromise).resolves.toBe("Use hub");
-	});
+			await expect(answerPromise).resolves.toBe("Use hub");
+		});
 
-	it("does not transfer capability ownership to attached clients", async () => {
-		let createdSessionId = "";
+		it("ignores initial compaction sidecar state when the sidecar flag is off", async () => {
+			let capturedStartInput: StartSessionInput | undefined;
+			const startSession = vi.fn(async (input: StartSessionInput) => {
+				capturedStartInput = input;
+				const sessionId = input.config.sessionId?.trim() || "session-1";
+				return {
+					sessionId,
+					manifest: {
+						version: 1,
+						session_id: sessionId,
+						source: "cli",
+						pid: 1,
+						started_at: new Date(0).toISOString(),
+						status: "running",
+						interactive: true,
+						provider: "cline",
+						model: "test-model",
+						cwd: "/tmp/project",
+						workspace_root: "/tmp/project",
+						enable_tools: true,
+						enable_spawn: true,
+						enable_teams: false,
+					},
+					manifestPath: "",
+					messagesPath: "",
+					result: undefined,
+				};
+			});
+			const transport = createTransport({
+				sessionHost: { startSession },
+				isCompactionSidecarEnabled: () => false,
+			});
+			const initialCompactionState = createSessionCompactionState({
+				sourceMessages: [{ role: "user", content: "source" }],
+				compactedMessages: [{ role: "user", content: "summary" }],
+				conversationId: "session-1",
+			});
+
+			const reply = await transport.handleCommand({
+				version: "v1",
+				requestId: "req-create-sidecar-off",
+				command: "session.create",
+				clientId: "client-1",
+				payload: {
+					workspaceRoot: "/tmp/project",
+					cwd: "/tmp/project",
+					sessionConfig: {
+						sessionId: "session-1",
+						providerId: "cline",
+						modelId: "test-model",
+						cwd: "/tmp/project",
+						workspaceRoot: "/tmp/project",
+						systemPrompt: "system",
+					},
+					initialCompactionState,
+				},
+			});
+
+			expect(reply.ok).toBe(true);
+			expect(capturedStartInput?.initialCompactionState).toBeUndefined();
+		});
+
+		it("does not transfer capability ownership to attached clients", async () => {
+			let createdSessionId = "";
 		const startSession = vi.fn(async (input: StartSessionInput) => {
 			createdSessionId = input.config.sessionId?.trim() || "missing-session";
 			return {
@@ -1071,6 +1133,30 @@ describe("HubServerTransport boundaries", () => {
 		expect(readSessionCompactionState).toHaveBeenCalledWith("session-1");
 	});
 
+	it("does not read compaction sidecar state when the sidecar flag is off", async () => {
+		const readSessionCompactionState = vi.fn();
+		const transport = createTransport({
+			sessionHost: { readSessionCompactionState },
+			isCompactionSidecarEnabled: () => false,
+		});
+		const ctx = getContext(transport);
+		ensureSessionState(ctx, "session-1", "owner-client", "creator");
+
+		const reply = await transport.handleCommand({
+			version: "v1",
+			requestId: "req-compact-get-off",
+			command: "session.compaction.get",
+			clientId: "owner-client",
+			sessionId: "session-1",
+		});
+
+		expect(reply).toMatchObject({
+			ok: true,
+			payload: { sessionId: "session-1", disabled: true },
+		});
+		expect(readSessionCompactionState).not.toHaveBeenCalled();
+	});
+
 	it("rejects invalid compaction sidecar updates before calling the session host", async () => {
 		const updateSessionCompactionState = vi.fn();
 		const transport = createTransport({
@@ -1091,6 +1177,36 @@ describe("HubServerTransport boundaries", () => {
 		expect(reply).toMatchObject({
 			ok: false,
 			error: { code: "invalid_compaction_state" },
+		});
+		expect(updateSessionCompactionState).not.toHaveBeenCalled();
+	});
+
+	it("does not update compaction sidecar state when the sidecar flag is off", async () => {
+		const state = createSessionCompactionState({
+			sourceMessages: [{ role: "user", content: "source" }],
+			compactedMessages: [{ role: "user", content: "summary" }],
+			conversationId: "session-1",
+		});
+		const updateSessionCompactionState = vi.fn();
+		const transport = createTransport({
+			sessionHost: { updateSessionCompactionState },
+			isCompactionSidecarEnabled: () => false,
+		});
+		const ctx = getContext(transport);
+		ensureSessionState(ctx, "session-1", "owner-client", "creator");
+
+		const reply = await transport.handleCommand({
+			version: "v1",
+			requestId: "req-compact-update-off",
+			command: "session.compaction.update",
+			clientId: "owner-client",
+			sessionId: "session-1",
+			payload: { state },
+		});
+
+		expect(reply).toMatchObject({
+			ok: true,
+			payload: { sessionId: "session-1", updated: false, disabled: true },
 		});
 		expect(updateSessionCompactionState).not.toHaveBeenCalled();
 	});

--- a/sdk/packages/core/src/hub/server/handlers/connector-handlers.test.ts
+++ b/sdk/packages/core/src/hub/server/handlers/connector-handlers.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { HubCommandEnvelope } from "@cline/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createSessionCompactionSidecarAccess } from "../../../session/models/session-compaction";
 import { __test__, handleConnectorCommand } from "./connector-handlers";
 import type { HubTransportContext } from "./context";
 
@@ -34,7 +35,7 @@ describe("connector hub handlers", () => {
 			pendingCapabilityRequests: new Map(),
 			suppressNextTerminalEventBySession: new Map(),
 			telemetry: telemetry as never,
-			isCompactionSidecarEnabled: () => true,
+      compactionSidecar: createSessionCompactionSidecarAccess(() => true),
 			sessionHost: {} as never,
 			publish: vi.fn(),
 			buildEvent: vi.fn() as never,

--- a/sdk/packages/core/src/hub/server/handlers/connector-handlers.test.ts
+++ b/sdk/packages/core/src/hub/server/handlers/connector-handlers.test.ts
@@ -34,6 +34,7 @@ describe("connector hub handlers", () => {
 			pendingCapabilityRequests: new Map(),
 			suppressNextTerminalEventBySession: new Map(),
 			telemetry: telemetry as never,
+			isCompactionSidecarEnabled: () => true,
 			sessionHost: {} as never,
 			publish: vi.fn(),
 			buildEvent: vi.fn() as never,

--- a/sdk/packages/core/src/hub/server/handlers/context.ts
+++ b/sdk/packages/core/src/hub/server/handlers/context.ts
@@ -14,6 +14,7 @@ import type {
 	RuntimeHost,
 	SessionUsageRuntimeService,
 } from "../../../runtime/host/runtime-host";
+import type { SessionCompactionSidecarAccess } from "../../../session/models/session-compaction";
 import {
 	type CoreSessionSnapshot,
 	createCoreSessionSnapshot,
@@ -51,7 +52,7 @@ export interface HubTransportContext {
 	readonly pendingCapabilityRequests: Map<string, PendingCapabilityRequest>;
 	readonly suppressNextTerminalEventBySession: Map<string, string>;
 	readonly telemetry?: ITelemetryService;
-	readonly isCompactionSidecarEnabled: () => boolean;
+  readonly compactionSidecar: SessionCompactionSidecarAccess;
 	readonly sessionHost: RuntimeHost &
 		Partial<PendingPromptsRuntimeService & SessionUsageRuntimeService>;
 	publish(event: HubEventEnvelope): void;

--- a/sdk/packages/core/src/hub/server/handlers/context.ts
+++ b/sdk/packages/core/src/hub/server/handlers/context.ts
@@ -51,6 +51,7 @@ export interface HubTransportContext {
 	readonly pendingCapabilityRequests: Map<string, PendingCapabilityRequest>;
 	readonly suppressNextTerminalEventBySession: Map<string, string>;
 	readonly telemetry?: ITelemetryService;
+	readonly isCompactionSidecarEnabled: () => boolean;
 	readonly sessionHost: RuntimeHost &
 		Partial<PendingPromptsRuntimeService & SessionUsageRuntimeService>;
 	publish(event: HubEventEnvelope): void;

--- a/sdk/packages/core/src/hub/server/handlers/context.ts
+++ b/sdk/packages/core/src/hub/server/handlers/context.ts
@@ -52,7 +52,7 @@ export interface HubTransportContext {
 	readonly pendingCapabilityRequests: Map<string, PendingCapabilityRequest>;
 	readonly suppressNextTerminalEventBySession: Map<string, string>;
 	readonly telemetry?: ITelemetryService;
-  readonly compactionSidecar: SessionCompactionSidecarAccess;
+	readonly compactionSidecar: SessionCompactionSidecarAccess;
 	readonly sessionHost: RuntimeHost &
 		Partial<PendingPromptsRuntimeService & SessionUsageRuntimeService>;
 	publish(event: HubEventEnvelope): void;

--- a/sdk/packages/core/src/hub/server/handlers/run-handlers.test.ts
+++ b/sdk/packages/core/src/hub/server/handlers/run-handlers.test.ts
@@ -14,6 +14,7 @@ function createContext(
 		pendingApprovals: new Map(),
 		pendingCapabilityRequests: new Map(),
 		suppressNextTerminalEventBySession: new Map(),
+		isCompactionSidecarEnabled: () => true,
 		sessionHost: {
 			startSession: vi.fn(),
 			runTurn: vi.fn(),

--- a/sdk/packages/core/src/hub/server/handlers/run-handlers.test.ts
+++ b/sdk/packages/core/src/hub/server/handlers/run-handlers.test.ts
@@ -1,6 +1,7 @@
 import type { HubEventEnvelope } from "@cline/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeHost } from "../../../runtime/host/runtime-host";
+import { createSessionCompactionSidecarAccess } from "../../../session/models/session-compaction";
 import { buildHubEvent, type HubTransportContext } from "./context";
 import { handleRunAbort, handleSessionInput } from "./run-handlers";
 
@@ -14,7 +15,7 @@ function createContext(
 		pendingApprovals: new Map(),
 		pendingCapabilityRequests: new Map(),
 		suppressNextTerminalEventBySession: new Map(),
-		isCompactionSidecarEnabled: () => true,
+    compactionSidecar: createSessionCompactionSidecarAccess(() => true),
 		sessionHost: {
 			startSession: vi.fn(),
 			runTurn: vi.fn(),

--- a/sdk/packages/core/src/hub/server/handlers/session-handlers.ts
+++ b/sdk/packages/core/src/hub/server/handlers/session-handlers.ts
@@ -111,9 +111,9 @@ export async function handleSessionCreate(
 		payload.runtimeOptions && typeof payload.runtimeOptions === "object"
 			? (payload.runtimeOptions as Record<string, unknown>)
 			: {};
-	const initialCompactionState = parseSessionCompactionState(
-		payload.initialCompactionState,
-	);
+	const initialCompactionState = ctx.isCompactionSidecarEnabled()
+		? parseSessionCompactionState(payload.initialCompactionState)
+		: undefined;
 	if (typeof sessionConfig?.mode === "string") {
 		metadata.mode = sessionConfig.mode;
 	} else if (typeof runtimeOptions.mode === "string") {
@@ -387,9 +387,9 @@ export async function handleSessionRestore(
 			payload.runtimeOptions && typeof payload.runtimeOptions === "object"
 				? (payload.runtimeOptions as Record<string, unknown>)
 				: {};
-		const initialCompactionState = parseSessionCompactionState(
-			payload.initialCompactionState,
-		);
+		const initialCompactionState = ctx.isCompactionSidecarEnabled()
+			? parseSessionCompactionState(payload.initialCompactionState)
+			: undefined;
 		const metadata =
 			payload.metadata && typeof payload.metadata === "object"
 				? JSON.parse(JSON.stringify(payload.metadata))
@@ -757,6 +757,9 @@ export async function handleSessionCompactionGet(
 			`Unknown session: ${sessionId}`,
 		);
 	}
+	if (!ctx.isCompactionSidecarEnabled()) {
+		return okReply(envelope, { sessionId, state: undefined, disabled: true });
+	}
 	const clientId = envelope.clientId?.trim() || "hub-client";
 	const unauthorized = authorizeSessionCompactionAccess({
 		sessionId,
@@ -840,6 +843,9 @@ export async function handleSessionCompactionUpdate(
 			"session_not_found",
 			`Unknown session: ${sessionId}`,
 		);
+	}
+	if (!ctx.isCompactionSidecarEnabled()) {
+		return okReply(envelope, { sessionId, updated: false, disabled: true });
 	}
 	const unauthorized = authorizeSessionCompactionAccess({
 		sessionId,

--- a/sdk/packages/core/src/hub/server/handlers/session-handlers.ts
+++ b/sdk/packages/core/src/hub/server/handlers/session-handlers.ts
@@ -111,9 +111,9 @@ export async function handleSessionCreate(
 		payload.runtimeOptions && typeof payload.runtimeOptions === "object"
 			? (payload.runtimeOptions as Record<string, unknown>)
 			: {};
-	const initialCompactionState = ctx.isCompactionSidecarEnabled()
-		? parseSessionCompactionState(payload.initialCompactionState)
-		: undefined;
+	const initialCompactionState = ctx.compactionSidecar.initialState(
+		parseSessionCompactionState(payload.initialCompactionState),
+	);
 	if (typeof sessionConfig?.mode === "string") {
 		metadata.mode = sessionConfig.mode;
 	} else if (typeof runtimeOptions.mode === "string") {
@@ -387,9 +387,9 @@ export async function handleSessionRestore(
 			payload.runtimeOptions && typeof payload.runtimeOptions === "object"
 				? (payload.runtimeOptions as Record<string, unknown>)
 				: {};
-		const initialCompactionState = ctx.isCompactionSidecarEnabled()
-			? parseSessionCompactionState(payload.initialCompactionState)
-			: undefined;
+		const initialCompactionState = ctx.compactionSidecar.initialState(
+			parseSessionCompactionState(payload.initialCompactionState),
+		);
 		const metadata =
 			payload.metadata && typeof payload.metadata === "object"
 				? JSON.parse(JSON.stringify(payload.metadata))
@@ -757,7 +757,7 @@ export async function handleSessionCompactionGet(
 			`Unknown session: ${sessionId}`,
 		);
 	}
-	if (!ctx.isCompactionSidecarEnabled()) {
+	if (!ctx.compactionSidecar.enabled) {
 		return okReply(envelope, { sessionId, state: undefined, disabled: true });
 	}
 	const clientId = envelope.clientId?.trim() || "hub-client";
@@ -770,7 +770,9 @@ export async function handleSessionCompactionGet(
 	if (unauthorized) {
 		return unauthorized;
 	}
-	const state = await ctx.sessionHost.readSessionCompactionState(sessionId);
+	const state = await ctx.compactionSidecar.read(() =>
+		ctx.sessionHost.readSessionCompactionState(sessionId),
+	);
 	return okReply(envelope, { sessionId, state });
 }
 
@@ -844,7 +846,7 @@ export async function handleSessionCompactionUpdate(
 			`Unknown session: ${sessionId}`,
 		);
 	}
-	if (!ctx.isCompactionSidecarEnabled()) {
+	if (!ctx.compactionSidecar.enabled) {
 		return okReply(envelope, { sessionId, updated: false, disabled: true });
 	}
 	const unauthorized = authorizeSessionCompactionAccess({
@@ -868,9 +870,8 @@ export async function handleSessionCompactionUpdate(
 			"session.compaction.update requires a valid compaction state",
 		);
 	}
-	const updated = await ctx.sessionHost.updateSessionCompactionState(
-		sessionId,
-		state,
+	const updated = await ctx.compactionSidecar.update(() =>
+		ctx.sessionHost.updateSessionCompactionState(sessionId, state),
 	);
 	const [updatedSession, snapshot] = updated.updated
 		? await Promise.all([

--- a/sdk/packages/core/src/hub/server/hub-server-options.ts
+++ b/sdk/packages/core/src/hub/server/hub-server-options.ts
@@ -43,7 +43,7 @@ export interface HubWebSocketServerOptions {
 	 * Ignored when `sessionHost` is supplied.
 	 */
 	telemetry?: ITelemetryService;
-	isCompactionSidecarEnabled?: () => boolean;
+	getCompactionSidecarEnabled?: () => boolean;
 }
 
 export interface HubWebSocketServer {

--- a/sdk/packages/core/src/hub/server/hub-server-options.ts
+++ b/sdk/packages/core/src/hub/server/hub-server-options.ts
@@ -43,6 +43,7 @@ export interface HubWebSocketServerOptions {
 	 * Ignored when `sessionHost` is supplied.
 	 */
 	telemetry?: ITelemetryService;
+	isCompactionSidecarEnabled?: () => boolean;
 }
 
 export interface HubWebSocketServer {

--- a/sdk/packages/core/src/hub/server/hub-server-transport.ts
+++ b/sdk/packages/core/src/hub/server/hub-server-transport.ts
@@ -15,6 +15,7 @@ import type {
 	RuntimeHost,
 } from "../../runtime/host/runtime-host";
 import { SqliteSessionStore } from "../../services/storage/sqlite-session-store";
+import { createSessionCompactionSidecarEnabledResolver } from "../../session/models/session-compaction";
 import { CoreSessionService } from "../../session/services/session-service";
 import {
 	type CoreSettingsListInput,
@@ -183,12 +184,16 @@ export class HubServerTransport implements NativeHubTransport {
 	private readonly ctx: HubTransportContext;
 
 	constructor(readonly options: HubWebSocketServerOptions) {
+		const isCompactionSidecarEnabled =
+			options.isCompactionSidecarEnabled ??
+			createSessionCompactionSidecarEnabledResolver();
 		this.sessionHost =
 			options.sessionHost ??
 			new LocalRuntimeHost({
 				sessionService: new CoreSessionService(new SqliteSessionStore()),
 				fetch: options.fetch,
 				telemetry: options.telemetry,
+				isCompactionSidecarEnabled,
 			});
 		this.ctx = {
 			clients: this.clients,
@@ -198,6 +203,7 @@ export class HubServerTransport implements NativeHubTransport {
 			suppressNextTerminalEventBySession:
 				this.suppressNextTerminalEventBySession,
 			telemetry: options.telemetry,
+			isCompactionSidecarEnabled,
 			sessionHost: this.sessionHost,
 			publish: (event) => this.publish(event),
 			buildEvent: buildHubEvent,

--- a/sdk/packages/core/src/hub/server/hub-server-transport.ts
+++ b/sdk/packages/core/src/hub/server/hub-server-transport.ts
@@ -15,7 +15,10 @@ import type {
 	RuntimeHost,
 } from "../../runtime/host/runtime-host";
 import { SqliteSessionStore } from "../../services/storage/sqlite-session-store";
-import { createSessionCompactionSidecarEnabledResolver } from "../../session/models/session-compaction";
+import {
+  createSessionCompactionSidecarAccess,
+  createSessionCompactionSidecarEnabledResolver,
+} from "../../session/models/session-compaction";
 import { CoreSessionService } from "../../session/services/session-service";
 import {
 	type CoreSettingsListInput,
@@ -187,6 +190,9 @@ export class HubServerTransport implements NativeHubTransport {
 		const isCompactionSidecarEnabled =
 			options.isCompactionSidecarEnabled ??
 			createSessionCompactionSidecarEnabledResolver();
+    const compactionSidecar = createSessionCompactionSidecarAccess(
+      isCompactionSidecarEnabled,
+    );
 		this.sessionHost =
 			options.sessionHost ??
 			new LocalRuntimeHost({
@@ -203,7 +209,7 @@ export class HubServerTransport implements NativeHubTransport {
 			suppressNextTerminalEventBySession:
 				this.suppressNextTerminalEventBySession,
 			telemetry: options.telemetry,
-			isCompactionSidecarEnabled,
+      compactionSidecar,
 			sessionHost: this.sessionHost,
 			publish: (event) => this.publish(event),
 			buildEvent: buildHubEvent,

--- a/sdk/packages/core/src/hub/server/hub-server-transport.ts
+++ b/sdk/packages/core/src/hub/server/hub-server-transport.ts
@@ -16,8 +16,8 @@ import type {
 } from "../../runtime/host/runtime-host";
 import { SqliteSessionStore } from "../../services/storage/sqlite-session-store";
 import {
-  createSessionCompactionSidecarAccess,
-  createSessionCompactionSidecarEnabledResolver,
+	createSessionCompactionSidecarAccess,
+	createSessionCompactionSidecarEnabledResolver,
 } from "../../session/models/session-compaction";
 import { CoreSessionService } from "../../session/services/session-service";
 import {
@@ -190,9 +190,9 @@ export class HubServerTransport implements NativeHubTransport {
 		const isCompactionSidecarEnabled =
 			options.isCompactionSidecarEnabled ??
 			createSessionCompactionSidecarEnabledResolver();
-    const compactionSidecar = createSessionCompactionSidecarAccess(
-      isCompactionSidecarEnabled,
-    );
+		const compactionSidecar = createSessionCompactionSidecarAccess(
+			isCompactionSidecarEnabled,
+		);
 		this.sessionHost =
 			options.sessionHost ??
 			new LocalRuntimeHost({
@@ -209,7 +209,7 @@ export class HubServerTransport implements NativeHubTransport {
 			suppressNextTerminalEventBySession:
 				this.suppressNextTerminalEventBySession,
 			telemetry: options.telemetry,
-      compactionSidecar,
+			compactionSidecar,
 			sessionHost: this.sessionHost,
 			publish: (event) => this.publish(event),
 			buildEvent: buildHubEvent,

--- a/sdk/packages/core/src/hub/server/hub-server-transport.ts
+++ b/sdk/packages/core/src/hub/server/hub-server-transport.ts
@@ -187,11 +187,11 @@ export class HubServerTransport implements NativeHubTransport {
 	private readonly ctx: HubTransportContext;
 
 	constructor(readonly options: HubWebSocketServerOptions) {
-		const isCompactionSidecarEnabled =
-			options.isCompactionSidecarEnabled ??
+		const getCompactionSidecarEnabled =
+			options.getCompactionSidecarEnabled ??
 			createSessionCompactionSidecarEnabledResolver();
 		const compactionSidecar = createSessionCompactionSidecarAccess(
-			isCompactionSidecarEnabled,
+			getCompactionSidecarEnabled,
 		);
 		this.sessionHost =
 			options.sessionHost ??
@@ -199,7 +199,7 @@ export class HubServerTransport implements NativeHubTransport {
 				sessionService: new CoreSessionService(new SqliteSessionStore()),
 				fetch: options.fetch,
 				telemetry: options.telemetry,
-				isCompactionSidecarEnabled,
+				getCompactionSidecarEnabled,
 			});
 		this.ctx = {
 			clients: this.clients,

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -44,7 +44,6 @@ export type {
 	ClineAccountActionRequest,
 	ConnectorHookEvent,
 	ContentBlock,
-	FeatureFlag,
 	FeatureFlagPayload,
 	FeatureFlagsAndPayloads,
 	FeatureFlagsContext,
@@ -100,6 +99,7 @@ export {
 	createTool,
 	emptyWorkspaceManifest,
 	FEATURE_FLAGS,
+	FeatureFlag,
 	FeatureFlagDefaultValue,
 	formatDisplayUserInput,
 	noopBasicLogger,
@@ -883,6 +883,7 @@ export {
 	type TelemetryServiceOptions,
 } from "./services/telemetry/TelemetryService";
 export {
+	createSessionCompactionSidecarEnabledResolver,
 	createSessionCompactionState,
 	parseSessionCompactionState,
 	projectSessionCompactionState,

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -734,10 +734,7 @@ export type {
 	CoreSettingsToggleInput,
 	CoreSettingsType,
 } from "./settings";
-export {
-	CoreSettingsService,
-	createCoreSettingsService,
-} from "./settings";
+export { CoreSettingsService, createCoreSettingsService } from "./settings";
 export type {
 	ChatMessage,
 	ChatSessionConfig,
@@ -883,10 +880,13 @@ export {
 	type TelemetryServiceOptions,
 } from "./services/telemetry/TelemetryService";
 export {
+  createSessionCompactionSidecarAccess,
 	createSessionCompactionSidecarEnabledResolver,
 	createSessionCompactionState,
 	parseSessionCompactionState,
 	projectSessionCompactionState,
+  type SessionCompactionSidecarAccess,
+  type SessionCompactionSidecarUpdateResult,
 	type SessionCompactionState,
 } from "./session/models/session-compaction";
 // Compatibility barrel (legacy imports).

--- a/sdk/packages/core/src/runtime/host/host.ts
+++ b/sdk/packages/core/src/runtime/host/host.ts
@@ -109,7 +109,7 @@ function createLocalRuntimeHost(
 		toolPolicies: options.toolPolicies,
 		distinctId,
 		fetch: options.fetch,
-		isCompactionSidecarEnabled: options.isCompactionSidecarEnabled,
+		getCompactionSidecarEnabled: options.getCompactionSidecarEnabled,
 	});
 }
 

--- a/sdk/packages/core/src/runtime/host/host.ts
+++ b/sdk/packages/core/src/runtime/host/host.ts
@@ -109,6 +109,7 @@ function createLocalRuntimeHost(
 		toolPolicies: options.toolPolicies,
 		distinctId,
 		fetch: options.fetch,
+		isCompactionSidecarEnabled: options.isCompactionSidecarEnabled,
 	});
 }
 

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
@@ -4246,9 +4246,10 @@ describe("LocalRuntimeHost", () => {
 					tools: [],
 					shutdown: vi.fn(),
 				}),
-			},
-			createAgent: createAgent as never,
-		});
+				},
+				createAgent: createAgent as never,
+				isCompactionSidecarEnabled: () => true,
+			});
 
 		await manager.startSession(
 			normalizeStartInput({
@@ -4313,6 +4314,7 @@ describe("LocalRuntimeHost", () => {
 				}),
 			},
 			createAgent: createAgent as never,
+			isCompactionSidecarEnabled: () => true,
 		});
 
 		await manager.startSession(
@@ -4386,6 +4388,7 @@ describe("LocalRuntimeHost", () => {
 				}),
 			},
 			createAgent: createAgent as never,
+			isCompactionSidecarEnabled: () => true,
 		});
 
 		await manager.startSession(
@@ -4543,6 +4546,7 @@ describe("LocalRuntimeHost", () => {
 				}),
 			},
 			createAgent: createAgent as never,
+			isCompactionSidecarEnabled: () => true,
 		});
 
 		await manager.startSession(

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
@@ -4413,6 +4413,86 @@ describe("LocalRuntimeHost", () => {
 		);
 	});
 
+	it("keeps compaction active but ignores sidecar state when the sidecar flag is off", async () => {
+		const sessionId = "sess-compaction-sidecar-off";
+		const manifest = createManifest(sessionId);
+		const initialMessages: MessageWithMetadata[] = [
+			{ role: "user", content: "canonical source" },
+		];
+		const initialCompactionState = createSessionCompactionState({
+			sourceMessages: initialMessages,
+			compactedMessages: [{ role: "user", content: "summary" }],
+			conversationId: sessionId,
+			updatedAt: "2026-01-01T00:00:00.000Z",
+		});
+		const sessionService = {
+			ensureSessionsDir: vi.fn().mockReturnValue("/tmp/sessions"),
+			createRootSessionWithArtifacts: vi.fn().mockResolvedValue({
+				manifestPath: "/tmp/manifest-compaction-sidecar-off.json",
+				messagesPath: "/tmp/messages-compaction-sidecar-off.json",
+				manifest,
+			}),
+			persistSessionMessages: vi.fn(),
+			persistSessionCompactionState: vi.fn(),
+			updateSessionStatus: vi.fn().mockResolvedValue({ updated: true }),
+			writeSessionManifest: vi.fn(),
+			listSessions: vi.fn().mockResolvedValue([]),
+			deleteSession: vi.fn().mockResolvedValue({ deleted: true }),
+		};
+		const createAgent = vi.fn().mockReturnValue({
+			run: vi.fn().mockResolvedValue(createResult()),
+			continue: vi.fn(),
+			abort: vi.fn(),
+			subscribeEvents: vi.fn().mockReturnValue(() => {}),
+			canStartRun: vi.fn().mockReturnValue(true),
+			getAgentId: vi.fn().mockReturnValue("agent-root-1"),
+			getConversationId: vi.fn().mockReturnValue(sessionId),
+			restore: vi.fn(),
+			shutdown: vi.fn().mockResolvedValue(undefined),
+			getMessages: vi.fn().mockReturnValue(initialMessages),
+			messages: initialMessages,
+		});
+		const manager = new RuntimeHostUnderTest({
+			distinctId,
+			sessionService: sessionService as never,
+			runtimeBuilder: {
+				build: vi.fn().mockReturnValue({
+					tools: [],
+					shutdown: vi.fn(),
+				}),
+			},
+			createAgent: createAgent as never,
+			isCompactionSidecarEnabled: () => false,
+		});
+
+		await manager.startSession(
+			normalizeStartInput({
+				config: createConfig({
+					sessionId,
+					compaction: {
+						enabled: true,
+						strategy: "basic",
+						compact: vi.fn(),
+					},
+				}),
+				initialMessages,
+				initialCompactionState,
+				interactive: true,
+			}),
+		);
+
+		expect(createAgent.mock.calls[0]?.[0]?.prepareTurn).toEqual(
+			expect.any(Function),
+		);
+		expect(sessionService.persistSessionCompactionState).not.toHaveBeenCalled();
+		await expect(
+			manager.readSessionCompactionState(sessionId),
+		).resolves.toBeUndefined();
+		await expect(
+			manager.updateSessionCompactionState(sessionId, initialCompactionState),
+		).resolves.toEqual({ updated: false });
+	});
+
 	it("does not project compaction state when compaction is disabled", async () => {
 		const sessionId = "sess-compaction-disabled";
 		const manifest = createManifest(sessionId);

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
@@ -4248,7 +4248,7 @@ describe("LocalRuntimeHost", () => {
 				}),
 				},
 				createAgent: createAgent as never,
-				isCompactionSidecarEnabled: () => true,
+				getCompactionSidecarEnabled: () => true,
 			});
 
 		await manager.startSession(
@@ -4314,7 +4314,7 @@ describe("LocalRuntimeHost", () => {
 				}),
 			},
 			createAgent: createAgent as never,
-			isCompactionSidecarEnabled: () => true,
+			getCompactionSidecarEnabled: () => true,
 		});
 
 		await manager.startSession(
@@ -4388,7 +4388,7 @@ describe("LocalRuntimeHost", () => {
 				}),
 			},
 			createAgent: createAgent as never,
-			isCompactionSidecarEnabled: () => true,
+			getCompactionSidecarEnabled: () => true,
 		});
 
 		await manager.startSession(
@@ -4428,6 +4428,9 @@ describe("LocalRuntimeHost", () => {
 			conversationId: sessionId,
 			updatedAt: "2026-01-01T00:00:00.000Z",
 		});
+		const compact = vi.fn().mockResolvedValue({
+			messages: [{ role: "user", content: "compact summary" }],
+		});
 		const sessionService = {
 			ensureSessionsDir: vi.fn().mockReturnValue("/tmp/sessions"),
 			createRootSessionWithArtifacts: vi.fn().mockResolvedValue({
@@ -4465,7 +4468,7 @@ describe("LocalRuntimeHost", () => {
 				}),
 			},
 			createAgent: createAgent as never,
-			isCompactionSidecarEnabled: () => false,
+			getCompactionSidecarEnabled: () => false,
 		});
 
 		await manager.startSession(
@@ -4475,7 +4478,8 @@ describe("LocalRuntimeHost", () => {
 					compaction: {
 						enabled: true,
 						strategy: "basic",
-						compact: vi.fn(),
+						compact,
+						maxInputTokens: 10,
 					},
 				}),
 				initialMessages,
@@ -4484,9 +4488,26 @@ describe("LocalRuntimeHost", () => {
 			}),
 		);
 
-		expect(createAgent.mock.calls[0]?.[0]?.prepareTurn).toEqual(
-			expect.any(Function),
-		);
+		const prepareTurn = createAgent.mock.calls[0]?.[0]?.prepareTurn;
+		expect(prepareTurn).toEqual(expect.any(Function));
+		await prepareTurn?.({
+			agentId: "agent-1",
+			conversationId: sessionId,
+			parentAgentId: null,
+			iteration: 1,
+			abortSignal: new AbortController().signal,
+			systemPrompt: "",
+			tools: [],
+			messages: initialMessages,
+			apiMessages: initialMessages,
+			model: {
+				id: "mock-model",
+				provider: "mock-provider",
+				info: { id: "mock-model", maxInputTokens: 10 },
+			},
+		});
+
+		expect(compact).toHaveBeenCalled();
 		expect(sessionService.persistSessionCompactionState).not.toHaveBeenCalled();
 		await expect(
 			manager.readSessionCompactionState(sessionId),
@@ -4546,7 +4567,7 @@ describe("LocalRuntimeHost", () => {
 				}),
 			},
 			createAgent: createAgent as never,
-			isCompactionSidecarEnabled: () => true,
+			getCompactionSidecarEnabled: () => true,
 		});
 
 		await manager.startSession(

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -51,8 +51,10 @@ import {
 } from "../../services/usage";
 import { enrichPromptWithMentions } from "../../services/workspace";
 import {
+	createSessionCompactionSidecarAccess,
 	createSessionCompactionSidecarEnabledResolver,
 	projectSessionCompactionState,
+	type SessionCompactionSidecarAccess,
 	type SessionCompactionState,
 } from "../../session/models/session-compaction";
 import {
@@ -224,7 +226,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 	private readonly oauthTokenManager: RuntimeOAuthTokenManager;
 	private readonly defaultTelemetry?: ITelemetryService;
 	private readonly defaultFetch?: typeof fetch;
-	private readonly isCompactionSidecarEnabled: () => boolean;
+	private readonly compactionSidecar: SessionCompactionSidecarAccess;
 	private readonly events = new RuntimeHostEventBus();
 	private readonly sessions = new Map<string, ActiveSession>();
 	private readonly usageBySession = new Map<string, SessionAccumulatedUsage>();
@@ -261,9 +263,10 @@ export class LocalRuntimeHost implements RuntimeHost {
 		this.defaultTelemetry = options.telemetry;
 		this.defaultTelemetry?.setDistinctId(distinctId);
 		this.defaultFetch = options.fetch;
-		this.isCompactionSidecarEnabled =
+		this.compactionSidecar = createSessionCompactionSidecarAccess(
 			options.isCompactionSidecarEnabled ??
-			createSessionCompactionSidecarEnabledResolver();
+				createSessionCompactionSidecarEnabledResolver(),
+		);
 
 		this.pendingPromptsController = new PendingPromptsController({
 			getSession: (sid) => this.sessions.get(sid),
@@ -381,18 +384,18 @@ export class LocalRuntimeHost implements RuntimeHost {
 			);
 			if (existingManifest) {
 				manifest = existingManifest;
-					resumedArtifacts = {
-						manifestPath,
-						messagesPath: existingManifest.messages_path || messagesPath,
-						compactionPath: existingManifest.compaction_path,
-						manifest: existingManifest,
-					};
-					resumedCompactionState = this.isCompactionSidecarEnabled()
-						? await this.invokeOptionalValue<SessionCompactionState>(
-								"readSessionCompactionState",
-								sessionId,
-							)
-						: undefined;
+				resumedArtifacts = {
+					manifestPath,
+					messagesPath: existingManifest.messages_path || messagesPath,
+					compactionPath: existingManifest.compaction_path,
+					manifest: existingManifest,
+				};
+				resumedCompactionState = await this.compactionSidecar.read(() =>
+					this.invokeOptionalValue<SessionCompactionState>(
+						"readSessionCompactionState",
+						sessionId,
+					),
+				);
 			}
 		}
 		const initialAggregateUsage = await this.seedAggregateUsageFromArtifacts({
@@ -492,64 +495,70 @@ export class LocalRuntimeHost implements RuntimeHost {
 		const explicitInitialCompactionState = startInput.initialCompactionState;
 		let activeSessionRef: ActiveSession | undefined;
 		const compact = createContextCompactionPrepareTurn(configWithProvider);
-		const sidecarEnabled = this.isCompactionSidecarEnabled();
 		const rawInitialCompactionState =
 			explicitInitialCompactionState ?? resumedCompactionState;
-		const initialCompactionState =
-			sidecarEnabled && compact && rawInitialCompactionState
+		const initialCompactionState = this.compactionSidecar.initialState(
+			compact && rawInitialCompactionState
 				? {
 						...rawInitialCompactionState,
 						conversation_id:
 							rawInitialCompactionState.conversation_id?.trim() || sessionId,
 					}
-				: undefined;
+				: undefined,
+		);
 		const prepareTurn = compact
 			? createCompactionStateAwarePrepareTurn({
 					compact,
 					getState: () =>
-						sidecarEnabled ? activeSessionRef?.compactionState : undefined,
+						this.compactionSidecar.initialState(
+							activeSessionRef?.compactionState,
+						),
 					saveState: async (state) => {
-						if (!sidecarEnabled) return;
-						const activeSession = activeSessionRef;
-						if (!activeSession) return;
-						const stateForSession = {
-							...state,
-							conversation_id: activeSession.sessionId,
-						};
-						try {
-							const result = await this.persistActiveSessionCompactionState(
-								activeSession,
-								stateForSession,
-							);
-							if (!result.updated) {
-								configWithProvider.logger?.debug?.(
-									"Skipped stale session compaction state",
-									{
-										sessionId: activeSession.sessionId,
-										sourceMessageCount: stateForSession.source_message_count,
-									},
+						await this.compactionSidecar.update(async () => {
+							const activeSession = activeSessionRef;
+							if (!activeSession) return { updated: false };
+							const stateForSession = {
+								...state,
+								conversation_id: activeSession.sessionId,
+							};
+							try {
+								const result = await this.persistActiveSessionCompactionState(
+									activeSession,
+									stateForSession,
 								);
+								if (!result.updated) {
+									configWithProvider.logger?.debug?.(
+										"Skipped stale session compaction state",
+										{
+											sessionId: activeSession.sessionId,
+											sourceMessageCount:
+												stateForSession.source_message_count,
+										},
+									);
+								}
+								return result;
+							} catch (error) {
+								configWithProvider.logger?.error?.(
+									"Failed to persist session compaction state",
+									{ sessionId: activeSession.sessionId, error },
+								);
+								captureSdkError(configWithProvider.telemetry, {
+									component: "core",
+									operation: "session.persist_compaction_state",
+									severity: "warn",
+									handled: true,
+									error,
+									context: {
+										sessionId: activeSession.sessionId,
+										providerId: configWithProvider.providerId,
+										modelId: configWithProvider.modelId,
+									},
+								});
+								return { updated: false };
 							}
-						} catch (error) {
-							configWithProvider.logger?.error?.(
-								"Failed to persist session compaction state",
-								{ sessionId: activeSession.sessionId, error },
-							);
-							captureSdkError(configWithProvider.telemetry, {
-								component: "core",
-								operation: "session.persist_compaction_state",
-								severity: "warn",
-								handled: true,
-								error,
-								context: {
-									sessionId: activeSession.sessionId,
-									providerId: configWithProvider.providerId,
-									modelId: configWithProvider.modelId,
-								},
-							});
-						}
+						});
 					},
-					})
+				})
 				: undefined;
 
 		const agentConfig = {
@@ -1057,66 +1066,65 @@ export class LocalRuntimeHost implements RuntimeHost {
 		sessionId: string,
 		state: SessionCompactionState,
 	): Promise<{ updated: boolean }> {
-		if (!this.isCompactionSidecarEnabled()) {
-			return { updated: false };
-		}
-		const target = sessionId.trim();
-		if (!target) return { updated: false };
-		const activeSession = this.sessions.get(target);
-		const sessionRecord = activeSession
-			? undefined
-			: await this.getSession(target);
-		const existing = activeSession ?? sessionRecord;
-		if (!existing) return { updated: false };
-		if (
-			!(await this.canPersistCompactionState(
+		const result = await this.compactionSidecar.update(async () => {
+			const target = sessionId.trim();
+			if (!target) return { updated: false };
+			const activeSession = this.sessions.get(target);
+			const sessionRecord = activeSession
+				? undefined
+				: await this.getSession(target);
+			const existing = activeSession ?? sessionRecord;
+			if (!existing) return { updated: false };
+			if (
+				!(await this.canPersistCompactionState(
+					target,
+					state,
+					activeSession,
+					sessionRecord,
+				))
+			) {
+				return { updated: false };
+			}
+			if (activeSession) {
+				return await this.persistActiveSessionCompactionState(
+					activeSession,
+					state,
+				);
+			}
+			const current = await this.invokeOptionalValue<SessionCompactionState>(
+				"readSessionCompactionState",
 				target,
-				state,
-				activeSession,
-				sessionRecord,
-			))
-		) {
-			return { updated: false };
-		}
-		if (activeSession) {
-			return await this.persistActiveSessionCompactionState(
-				activeSession,
-				state,
 			);
-		}
-		const current = await this.invokeOptionalValue<SessionCompactionState>(
-			"readSessionCompactionState",
-			target,
-		);
-		if (isIncomingCompactionStateStale(state, current)) {
-			return { updated: false };
-		}
-		await this.invoke<void>("persistSessionCompactionState", target, state);
-		return { updated: true };
+			if (isIncomingCompactionStateStale(state, current)) {
+				return { updated: false };
+			}
+			await this.invoke<void>("persistSessionCompactionState", target, state);
+			return { updated: true };
+		});
+		return { updated: result.updated };
 	}
 
 	async readSessionCompactionState(
 		sessionId: string,
 	): Promise<SessionCompactionState | undefined> {
-		if (!this.isCompactionSidecarEnabled()) {
-			return undefined;
-		}
-		const target = sessionId.trim();
-		if (!target) return undefined;
-		const activeSession = this.sessions.get(target);
-		if (activeSession) {
-			for (;;) {
-				const pendingWrite = activeSession.compactionStateWriteQueue;
-				if (!pendingWrite) {
-					return activeSession.compactionState;
+		return await this.compactionSidecar.read(async () => {
+			const target = sessionId.trim();
+			if (!target) return undefined;
+			const activeSession = this.sessions.get(target);
+			if (activeSession) {
+				for (;;) {
+					const pendingWrite = activeSession.compactionStateWriteQueue;
+					if (!pendingWrite) {
+						return activeSession.compactionState;
+					}
+					await pendingWrite.catch(() => undefined);
 				}
-				await pendingWrite.catch(() => undefined);
 			}
-		}
-		return await this.invokeOptionalValue<SessionCompactionState>(
-			"readSessionCompactionState",
-			target,
-		);
+			return await this.invokeOptionalValue<SessionCompactionState>(
+				"readSessionCompactionState",
+				target,
+			);
+		});
 	}
 
 	private isCompactionStateForSession(

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -204,7 +204,7 @@ export interface LocalRuntimeHostOptions {
 	providerSettingsManager?: ProviderSettingsManager;
 	oauthTokenManager?: RuntimeOAuthTokenManager;
 	telemetry?: ITelemetryService;
-	isCompactionSidecarEnabled?: () => boolean;
+	getCompactionSidecarEnabled?: () => boolean;
 	/**
 	 * Default custom `fetch` implementation threaded into every
 	 * `ProviderConfig.fetch` built during local session bootstrap. Used by
@@ -264,7 +264,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 		this.defaultTelemetry?.setDistinctId(distinctId);
 		this.defaultFetch = options.fetch;
 		this.compactionSidecar = createSessionCompactionSidecarAccess(
-			options.isCompactionSidecarEnabled ??
+			options.getCompactionSidecarEnabled ??
 				createSessionCompactionSidecarEnabledResolver(),
 		);
 

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -259,7 +259,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 			new RuntimeOAuthTokenManager({
 				providerSettingsManager: this.providerSettingsManager,
 				telemetry: options.telemetry,
-		});
+			});
 		this.defaultTelemetry = options.telemetry;
 		this.defaultTelemetry?.setDistinctId(distinctId);
 		this.defaultFetch = options.fetch;
@@ -531,8 +531,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 										"Skipped stale session compaction state",
 										{
 											sessionId: activeSession.sessionId,
-											sourceMessageCount:
-												stateForSession.source_message_count,
+											sourceMessageCount: stateForSession.source_message_count,
 										},
 									);
 								}
@@ -559,7 +558,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 						});
 					},
 				})
-				: undefined;
+			: undefined;
 
 		const agentConfig = {
 			sessionId,

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -51,6 +51,7 @@ import {
 } from "../../services/usage";
 import { enrichPromptWithMentions } from "../../services/workspace";
 import {
+	createSessionCompactionSidecarEnabledResolver,
 	projectSessionCompactionState,
 	type SessionCompactionState,
 } from "../../session/models/session-compaction";
@@ -201,6 +202,7 @@ export interface LocalRuntimeHostOptions {
 	providerSettingsManager?: ProviderSettingsManager;
 	oauthTokenManager?: RuntimeOAuthTokenManager;
 	telemetry?: ITelemetryService;
+	isCompactionSidecarEnabled?: () => boolean;
 	/**
 	 * Default custom `fetch` implementation threaded into every
 	 * `ProviderConfig.fetch` built during local session bootstrap. Used by
@@ -222,6 +224,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 	private readonly oauthTokenManager: RuntimeOAuthTokenManager;
 	private readonly defaultTelemetry?: ITelemetryService;
 	private readonly defaultFetch?: typeof fetch;
+	private readonly isCompactionSidecarEnabled: () => boolean;
 	private readonly events = new RuntimeHostEventBus();
 	private readonly sessions = new Map<string, ActiveSession>();
 	private readonly usageBySession = new Map<string, SessionAccumulatedUsage>();
@@ -254,10 +257,13 @@ export class LocalRuntimeHost implements RuntimeHost {
 			new RuntimeOAuthTokenManager({
 				providerSettingsManager: this.providerSettingsManager,
 				telemetry: options.telemetry,
-			});
+		});
 		this.defaultTelemetry = options.telemetry;
 		this.defaultTelemetry?.setDistinctId(distinctId);
 		this.defaultFetch = options.fetch;
+		this.isCompactionSidecarEnabled =
+			options.isCompactionSidecarEnabled ??
+			createSessionCompactionSidecarEnabledResolver();
 
 		this.pendingPromptsController = new PendingPromptsController({
 			getSession: (sid) => this.sessions.get(sid),
@@ -375,17 +381,18 @@ export class LocalRuntimeHost implements RuntimeHost {
 			);
 			if (existingManifest) {
 				manifest = existingManifest;
-				resumedArtifacts = {
-					manifestPath,
-					messagesPath: existingManifest.messages_path || messagesPath,
-					compactionPath: existingManifest.compaction_path,
-					manifest: existingManifest,
-				};
-				resumedCompactionState =
-					await this.invokeOptionalValue<SessionCompactionState>(
-						"readSessionCompactionState",
-						sessionId,
-					);
+					resumedArtifacts = {
+						manifestPath,
+						messagesPath: existingManifest.messages_path || messagesPath,
+						compactionPath: existingManifest.compaction_path,
+						manifest: existingManifest,
+					};
+					resumedCompactionState = this.isCompactionSidecarEnabled()
+						? await this.invokeOptionalValue<SessionCompactionState>(
+								"readSessionCompactionState",
+								sessionId,
+							)
+						: undefined;
 			}
 		}
 		const initialAggregateUsage = await this.seedAggregateUsageFromArtifacts({
@@ -485,10 +492,11 @@ export class LocalRuntimeHost implements RuntimeHost {
 		const explicitInitialCompactionState = startInput.initialCompactionState;
 		let activeSessionRef: ActiveSession | undefined;
 		const compact = createContextCompactionPrepareTurn(configWithProvider);
+		const sidecarEnabled = this.isCompactionSidecarEnabled();
 		const rawInitialCompactionState =
 			explicitInitialCompactionState ?? resumedCompactionState;
 		const initialCompactionState =
-			compact && rawInitialCompactionState
+			sidecarEnabled && compact && rawInitialCompactionState
 				? {
 						...rawInitialCompactionState,
 						conversation_id:
@@ -498,8 +506,10 @@ export class LocalRuntimeHost implements RuntimeHost {
 		const prepareTurn = compact
 			? createCompactionStateAwarePrepareTurn({
 					compact,
-					getState: () => activeSessionRef?.compactionState,
+					getState: () =>
+						sidecarEnabled ? activeSessionRef?.compactionState : undefined,
 					saveState: async (state) => {
+						if (!sidecarEnabled) return;
 						const activeSession = activeSessionRef;
 						if (!activeSession) return;
 						const stateForSession = {
@@ -1047,6 +1057,9 @@ export class LocalRuntimeHost implements RuntimeHost {
 		sessionId: string,
 		state: SessionCompactionState,
 	): Promise<{ updated: boolean }> {
+		if (!this.isCompactionSidecarEnabled()) {
+			return { updated: false };
+		}
 		const target = sessionId.trim();
 		if (!target) return { updated: false };
 		const activeSession = this.sessions.get(target);
@@ -1085,6 +1098,9 @@ export class LocalRuntimeHost implements RuntimeHost {
 	async readSessionCompactionState(
 		sessionId: string,
 	): Promise<SessionCompactionState | undefined> {
+		if (!this.isCompactionSidecarEnabled()) {
+			return undefined;
+		}
 		const target = sessionId.trim();
 		if (!target) return undefined;
 		const activeSession = this.sessions.get(target);

--- a/sdk/packages/core/src/session/models/session-compaction.test.ts
+++ b/sdk/packages/core/src/session/models/session-compaction.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+	createSessionCompactionSidecarEnabledResolver,
 	createSessionCompactionState,
 	parseSessionCompactionState,
 	projectSessionCompactionState,
@@ -21,6 +22,25 @@ describe("session compaction state", () => {
 				updatedAt: "2026-01-01T00:00:00.000Z",
 			}),
 		).toThrow("Message role cannot contain ':'");
+	});
+
+	it("enables sidecar use only when the feature flag is explicitly true", () => {
+		expect(
+			createSessionCompactionSidecarEnabledResolver({
+				getBooleanFlagEnabled: () => false,
+			})(),
+		).toBe(false);
+		expect(
+			createSessionCompactionSidecarEnabledResolver({
+				getBooleanFlagEnabled: () => true,
+			})(),
+		).toBe(true);
+		expect(
+			createSessionCompactionSidecarEnabledResolver({
+				getBooleanFlagEnabled: () => undefined,
+			})(),
+		).toBe(false);
+		expect(createSessionCompactionSidecarEnabledResolver()()).toBe(false);
 	});
 
 	it("rejects projection when the canonical prefix was edited before the boundary", () => {

--- a/sdk/packages/core/src/session/models/session-compaction.test.ts
+++ b/sdk/packages/core/src/session/models/session-compaction.test.ts
@@ -35,11 +35,6 @@ describe("session compaction state", () => {
 				getBooleanFlagEnabled: () => true,
 			})(),
 		).toBe(true);
-		expect(
-			createSessionCompactionSidecarEnabledResolver({
-				getBooleanFlagEnabled: () => undefined,
-			})(),
-		).toBe(false);
 		expect(createSessionCompactionSidecarEnabledResolver()()).toBe(false);
 	});
 

--- a/sdk/packages/core/src/session/models/session-compaction.ts
+++ b/sdk/packages/core/src/session/models/session-compaction.ts
@@ -65,49 +65,21 @@ export interface SessionCompactionSidecarAccess {
 	): Promise<SessionCompactionSidecarUpdateResult>;
 }
 
-type SessionCompactionSidecarRole = SessionCompactionSidecarAccess;
-
-class EnabledSessionCompactionSidecar implements SessionCompactionSidecarRole {
-	readonly enabled = true;
-
-	initialState(
-		state: SessionCompactionState | undefined,
-	): SessionCompactionState | undefined {
-		return state;
-	}
-
-	async read<T>(read: () => Promise<T | undefined>): Promise<T | undefined> {
-		return await read();
-	}
-
-	async update(
-		update: () => Promise<{ updated: boolean }>,
-	): Promise<SessionCompactionSidecarUpdateResult> {
-		return await update();
-	}
-}
-
-class DisabledSessionCompactionSidecar implements SessionCompactionSidecarRole {
-	readonly enabled = false;
-
-	initialState(): undefined {
-		return undefined;
-	}
-
-	async read(): Promise<undefined> {
-		return undefined;
-	}
-
-	async update(): Promise<SessionCompactionSidecarUpdateResult> {
-		return { updated: false, disabled: true };
-	}
-}
-
 export function createSessionCompactionSidecarAccess(
 	isEnabled: () => boolean = createSessionCompactionSidecarEnabledResolver(),
 ): SessionCompactionSidecarAccess {
-	const enabled = new EnabledSessionCompactionSidecar();
-	const disabled = new DisabledSessionCompactionSidecar();
+	const enabled: SessionCompactionSidecarAccess = {
+		enabled: true,
+		initialState: (state) => state,
+		read: (read) => read(),
+		update: (update) => update(),
+	};
+	const disabled: SessionCompactionSidecarAccess = {
+		enabled: false,
+		initialState: () => undefined,
+		read: async () => undefined,
+		update: async () => ({ updated: false, disabled: true }),
+	};
 	const current = () => (isEnabled() ? enabled : disabled);
 	return {
 		get enabled() {

--- a/sdk/packages/core/src/session/models/session-compaction.ts
+++ b/sdk/packages/core/src/session/models/session-compaction.ts
@@ -49,6 +49,76 @@ export function createSessionCompactionSidecarEnabledResolver(
 		featureFlags?.getFlagPayload(FeatureFlag.COMPACTION_SIDECAR) !== false;
 }
 
+export type SessionCompactionSidecarUpdateResult = {
+	updated: boolean;
+	disabled?: true;
+};
+
+export interface SessionCompactionSidecarAccess {
+	readonly enabled: boolean;
+	initialState(
+		state: SessionCompactionState | undefined,
+	): SessionCompactionState | undefined;
+	read<T>(read: () => Promise<T | undefined>): Promise<T | undefined>;
+	update(
+		update: () => Promise<{ updated: boolean }>,
+	): Promise<SessionCompactionSidecarUpdateResult>;
+}
+
+type SessionCompactionSidecarRole = SessionCompactionSidecarAccess;
+
+class EnabledSessionCompactionSidecar implements SessionCompactionSidecarRole {
+	readonly enabled = true;
+
+	initialState(
+		state: SessionCompactionState | undefined,
+	): SessionCompactionState | undefined {
+		return state;
+	}
+
+	async read<T>(read: () => Promise<T | undefined>): Promise<T | undefined> {
+		return await read();
+	}
+
+	async update(
+		update: () => Promise<{ updated: boolean }>,
+	): Promise<SessionCompactionSidecarUpdateResult> {
+		return await update();
+	}
+}
+
+class DisabledSessionCompactionSidecar implements SessionCompactionSidecarRole {
+	readonly enabled = false;
+
+	initialState(): undefined {
+		return undefined;
+	}
+
+	async read(): Promise<undefined> {
+		return undefined;
+	}
+
+	async update(): Promise<SessionCompactionSidecarUpdateResult> {
+		return { updated: false, disabled: true };
+	}
+}
+
+export function createSessionCompactionSidecarAccess(
+	isEnabled: () => boolean = createSessionCompactionSidecarEnabledResolver(),
+): SessionCompactionSidecarAccess {
+	const enabled = new EnabledSessionCompactionSidecar();
+	const disabled = new DisabledSessionCompactionSidecar();
+	const current = () => (isEnabled() ? enabled : disabled);
+	return {
+		get enabled() {
+			return current().enabled;
+		},
+		initialState: (state) => current().initialState(state),
+		read: (read) => current().read(read),
+		update: (update) => current().update(update),
+	};
+}
+
 function cloneMessages(
 	messages: readonly MessageWithMetadata[],
 ): MessageWithMetadata[] {

--- a/sdk/packages/core/src/session/models/session-compaction.ts
+++ b/sdk/packages/core/src/session/models/session-compaction.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import {
+	FeatureFlag,
 	formatDisplayUserInput,
 	type MessageWithMetadata,
 } from "@cline/shared";
@@ -36,6 +37,17 @@ export const SessionCompactionStateSchema = z.object({
 export type SessionCompactionState = z.infer<
 	typeof SessionCompactionStateSchema
 >;
+
+type CompactionSidecarFeatureFlags = {
+	getFlagPayload(flagName: string): unknown;
+};
+
+export function createSessionCompactionSidecarEnabledResolver(
+	featureFlags?: CompactionSidecarFeatureFlags,
+): () => boolean {
+	return () =>
+		featureFlags?.getFlagPayload(FeatureFlag.COMPACTION_SIDECAR) !== false;
+}
 
 function cloneMessages(
 	messages: readonly MessageWithMetadata[],

--- a/sdk/packages/core/src/session/models/session-compaction.ts
+++ b/sdk/packages/core/src/session/models/session-compaction.ts
@@ -39,14 +39,15 @@ export type SessionCompactionState = z.infer<
 >;
 
 type CompactionSidecarFeatureFlags = {
-	getFlagPayload(flagName: string): unknown;
+	getBooleanFlagEnabled(flagName: string): boolean;
 };
 
 export function createSessionCompactionSidecarEnabledResolver(
 	featureFlags?: CompactionSidecarFeatureFlags,
 ): () => boolean {
 	return () =>
-		featureFlags?.getFlagPayload(FeatureFlag.COMPACTION_SIDECAR) !== false;
+		featureFlags?.getBooleanFlagEnabled(FeatureFlag.COMPACTION_SIDECAR) ??
+		false;
 }
 
 export type SessionCompactionSidecarUpdateResult = {

--- a/sdk/packages/shared/src/feature-flags.ts
+++ b/sdk/packages/shared/src/feature-flags.ts
@@ -64,7 +64,7 @@ export const FeatureFlagDefaultValue: Partial<
 	Record<FeatureFlag, FeatureFlagPayload | undefined>
 > = {
 	[FeatureFlag.CLINE_PASS]: false,
-	[FeatureFlag.COMPACTION_SIDECAR]: true,
+	[FeatureFlag.COMPACTION_SIDECAR]: false,
 };
 
 export const FEATURE_FLAGS: readonly FeatureFlag[] = Object.values(FeatureFlag);

--- a/sdk/packages/shared/src/feature-flags.ts
+++ b/sdk/packages/shared/src/feature-flags.ts
@@ -1,6 +1,8 @@
 export const FeatureFlag = {
 	/** Enables ClinePass provider/model list exposure in supported clients. */
 	CLINE_PASS: "ext-cline-pass",
+	/** Enables persisted compaction sidecar projection state. */
+	COMPACTION_SIDECAR: "sdk-compaction-sidecar",
 } as const;
 
 export type KnownFeatureFlag = (typeof FeatureFlag)[keyof typeof FeatureFlag];
@@ -62,6 +64,7 @@ export const FeatureFlagDefaultValue: Partial<
 	Record<FeatureFlag, FeatureFlagPayload | undefined>
 > = {
 	[FeatureFlag.CLINE_PASS]: false,
+	[FeatureFlag.COMPACTION_SIDECAR]: true,
 };
 
 export const FEATURE_FLAGS: readonly FeatureFlag[] = Object.values(FeatureFlag);

--- a/sdk/packages/shared/src/index.browser.ts
+++ b/sdk/packages/shared/src/index.browser.ts
@@ -77,7 +77,7 @@ export {
 export { PLUGIN_FILE_EXTENSIONS } from "./extensions/plugin";
 export {
 	FEATURE_FLAGS,
-	type FeatureFlag,
+	FeatureFlag,
 	FeatureFlagDefaultValue,
 	type FeatureFlagPayload,
 	type FeatureFlagsAndPayloads,

--- a/sdk/packages/shared/src/index.ts
+++ b/sdk/packages/shared/src/index.ts
@@ -91,7 +91,7 @@ export {
 export { PLUGIN_FILE_EXTENSIONS } from "./extensions/plugin";
 export {
 	FEATURE_FLAGS,
-	type FeatureFlag,
+	FeatureFlag,
 	FeatureFlagDefaultValue,
 	type FeatureFlagPayload,
 	type FeatureFlagsAndPayloads,


### PR DESCRIPTION
Adds a default-off PostHog feature gate for compaction sidecar activation.

PostHog flag:

```text
key: sdk-compaction-sidecar
type: boolean
default behavior: disabled unless the boolean flag is true
current rollout: controlled in PostHog
```

When disabled, normal compaction still runs, but sidecar state is ignored and not persisted:

```text
compaction: still active
sidecar reads: disabled
sidecar writes: disabled
hub get/update: disabled/no-op
hub create/restore initialCompactionState: ignored
manual /compact: computes compaction but reports not compacted if state is discarded
existing sidecar files: left on disk and ignored
```

Rollout / rollback path:

```text
Enable: PostHog -> Feature flags -> sdk-compaction-sidecar -> turn on rollout
Rollback: set rollout to 0% or disable the flag
```

This keeps the sidecar schema and plumbing in place while making persisted compaction state opt-in until we are ready to roll it out.
