### PR TITLE
fix(vscode): Fix run_commands single quotes bug

### DIFF
--- a/apps/vscode/src/sdk/vscode-run-commands-tool.test.ts
+++ b/apps/vscode/src/sdk/vscode-run-commands-tool.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest"
+import { formatCommandForTerminal } from "./vscode-run-commands-tool"
+
+describe("formatCommandForTerminal", () => {
+	it.each([
+		{
+			name: "raw shell command",
+			input: "which git",
+			expected: "which git",
+		},
+		{
+			name: "raw shell command with pipes and quotes",
+			input: "git status --short | sed -n '1,20p'",
+			expected: "git status --short | sed -n '1,20p'",
+		},
+		{
+			name: "structured command with omitted args",
+			input: { command: "which git" },
+			expected: "which git",
+		},
+		{
+			name: "structured shell command with omitted args and metacharacters",
+			input: { command: "git status --short | head -20" },
+			expected: "git status --short | head -20",
+		},
+		{
+			name: "structured executable with explicit empty args",
+			input: { command: "/tmp/path with spaces/tool", args: [] },
+			expected: "'/tmp/path with spaces/tool'",
+		},
+		{
+			name: "structured executable with simple args",
+			input: { command: "which", args: ["git"] },
+			expected: "which git",
+		},
+		{
+			name: "structured executable with spaced args",
+			input: { command: "echo", args: ["hello world", "again"] },
+			expected: "echo 'hello world' again",
+		},
+		{
+			name: "structured executable with apostrophe args",
+			input: { command: "printf", args: ["it's ok"] },
+			expected: "printf 'it'\\''s ok'",
+		},
+		{
+			name: "structured executable with empty arg",
+			input: { command: "printf", args: [""] },
+			expected: "printf ''",
+		},
+		{
+			name: "structured executable with shell metacharacters in args",
+			input: { command: "echo", args: ["$HOME", "a&b", "semi;colon", "paren(value)"] },
+			expected: "echo '$HOME' 'a&b' 'semi;colon' 'paren(value)'",
+		},
+		{
+			name: "structured executable with quoted args",
+			input: { command: "node", args: ["-e", 'console.log("hi")'] },
+			expected: "node -e 'console.log(\"hi\")'",
+		},
+	])("$name", ({ input, expected }) => {
+		expect(formatCommandForTerminal(input)).toBe(expected)
+	})
+
+	it("quotes multiple structured args that need shell escaping", () => {
+		expect(formatCommandForTerminal({ command: "echo", args: ["hello world", "it's ok"] })).toBe(
+			"echo 'hello world' 'it'\\''s ok'",
+		)
+	})
+})

--- a/apps/vscode/src/sdk/vscode-run-commands-tool.ts
+++ b/apps/vscode/src/sdk/vscode-run-commands-tool.ts
@@ -53,9 +53,12 @@ function quoteShellArg(arg: string): string {
 	return `'${arg.replace(/'/g, `'\\''`)}'`
 }
 
-function formatCommandForTerminal(command: ShellCommand): string {
+export function formatCommandForTerminal(command: ShellCommand): string {
 	if (typeof command === "string") {
 		return command
+	}
+	if (!("args" in command)) {
+		return command.command
 	}
 	return [command.command, ...(command.args ?? [])].map(quoteShellArg).join(" ")
 }

--- a/apps/vscode/src/test/cline-core-vitest-stub.ts
+++ b/apps/vscode/src/test/cline-core-vitest-stub.ts
@@ -10,6 +10,23 @@ export interface StartSessionResult {
 	sessionId: string
 }
 
+export const MAX_COMMAND_OUTPUT_CHARS = 200_000
+
+export function truncateCommandOutput(output: string): string {
+	return output
+}
+
+export function createShellExecutor() {
+	return async () => ""
+}
+
+export function createShellTool(execute: unknown) {
+	return {
+		name: "run_commands",
+		execute,
+	}
+}
+
 export interface SessionHistoryRecord {
 	id: string
 	metadata?: Record<string, unknown>


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This fixes a VS Code foreground terminal command-formatting bug where Cline could show a command correctly in chat, but run a differently quoted command in the integrated terminal.

The concrete failure mode was with SDK `run_commands` input shaped like:

```json
{ "command": "which git" }
```

The chat display path renders that as `which git`, because the SDK message translator treats `command` as display text when no args are present. The VS Code foreground terminal execution path used a separate formatter, `formatCommandForTerminal`, which treated every structured command object as argv-style data and shell-quoted each part. Because `which git` contains a space, the terminal command became:

```sh
'which git'
```

That asks the shell to execute a single binary literally named `which git`, which explains why a user could see `which git` in the Cline chat row but see quoted text in the integrated terminal.

The fix is intentionally narrow. If a structured command object omits the `args` field, VS Code now treats `command` as the complete shell command string and passes it through unchanged. If `args` exists, including an explicit empty `args: []`, the existing shell-argument quoting path is preserved. That keeps proper structured argv usage working as before, while tolerating the ambiguous provider/model output shape that triggered this bug.

I also added a focused formatter test matrix covering the likely regression surfaces: raw shell strings, shell metacharacters, omitted args, explicit empty args, split argv, spaces, apostrophes, empty args, shell metacharacters inside args, and quoted JavaScript snippets.

A small Vitest `@cline/core` stub update was needed so the new SDK test can import `vscode-run-commands-tool.ts` under the existing VS Code Vitest alias setup.

### Test Procedure

Ran the focused formatter test:

```sh
bunx vitest run --config vitest.config.ts src/sdk/vscode-run-commands-tool.test.ts
```

Result: 1 test file passed, 12 tests passed.

Ran the broader VS Code SDK Vitest slice:

```sh
bunx vitest run --config vitest.config.ts src/sdk
```

Result: 48 test files passed, 612 tests passed.

Ran Biome on the touched files:

```sh
bunx biome check --config-path ./biome.jsonc src/sdk/vscode-run-commands-tool.ts src/sdk/vscode-run-commands-tool.test.ts src/test/cline-core-vitest-stub.ts --no-errors-on-unmatched --files-ignore-unknown=true
```

Result: checked 3 files, no fixes applied.

The main behavior that could regress is structured command formatting for VS Code foreground terminal mode. The tests specifically verify that raw command strings remain unchanged, omitted `args` now pass through as full shell commands, and explicit `args` objects still use shell escaping.

I did not run the full `bun test` or full extension compile/lint suite for this small scoped change.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. This is a terminal command formatting fix with automated coverage.

### Additional Notes

This likely appeared provider-specific because different providers can emit different valid `run_commands` input shapes. A provider/model that emits `{ "command": "which git" }` hits this compatibility path; one that emits a raw string `"which git"` or structured argv `{ "command": "which", "args": ["git"] }` does not.
