### PR TITLE
fix(vscode): handle Escape while editing user messages

### DIFF
--- a/apps/vscode/webview-ui/src/components/chat/UserMessage.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/UserMessage.tsx
@@ -28,6 +28,23 @@ const UserMessage: React.FC<UserMessageProps> = ({ text, images, files, messageT
 		setIsEditing(true)
 	}
 
+	const cancelEditing = () => {
+		if (savingMode) {
+			return
+		}
+		setIsEditing(false)
+	}
+
+	const handleEditingKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+		if (event.key !== "Escape") {
+			return
+		}
+
+		event.preventDefault()
+		event.stopPropagation()
+		cancelEditing()
+	}
+
 	const handleSave = async (restoreWorkspace: boolean) => {
 		if (!messageTs || savingMode) {
 			return
@@ -95,7 +112,7 @@ const UserMessage: React.FC<UserMessageProps> = ({ text, images, files, messageT
 				</Tooltip>
 			)}
 			{isEditing ? (
-				<div className="flex flex-col gap-2">
+				<div className="flex flex-col gap-2" onKeyDown={handleEditingKeyDown}>
 					<textarea
 						className="w-full box-border rounded-xs border border-vscode-input-border bg-vscode-input-background text-vscode-input-foreground p-2 text-sm resize-vertical"
 						disabled={!!savingMode}
@@ -108,7 +125,7 @@ const UserMessage: React.FC<UserMessageProps> = ({ text, images, files, messageT
 						<button
 							className="shrink-0 whitespace-nowrap px-1 py-1 rounded-xs border-0 bg-transparent text-badge-foreground/80 hover:text-badge-foreground cursor-pointer text-xs"
 							disabled={!!savingMode}
-							onClick={() => setIsEditing(false)}
+							onClick={cancelEditing}
 							type="button">
 							Cancel
 						</button>

--- a/apps/vscode/webview-ui/src/components/chat/__tests__/UserMessage.ime.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/__tests__/UserMessage.ime.test.tsx
@@ -5,7 +5,7 @@
  * even if you confirm the IME conversion (Enter) in message re-edit mode.
  */
 
-import { fireEvent, render } from "@testing-library/react"
+import { fireEvent, render, screen } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 
 vi.mock("@/context/ExtensionStateContext", () => ({
@@ -39,5 +39,27 @@ describe("UserMessage – IME composition handling", () => {
 		fireEvent.compositionEnd(editable)
 
 		expect(sendMessageFromChatRow).not.toHaveBeenCalled()
+	})
+
+	it("cancels inline editing on Escape without bubbling to global task shortcuts", () => {
+		const onWindowKeyDown = vi.fn()
+		window.addEventListener("keydown", onWindowKeyDown)
+
+		try {
+			render(<UserMessage images={[]} messageTs={Date.now()} text="Original prompt" />)
+
+			fireEvent.click(screen.getByText("Original prompt"))
+
+			const textbox = screen.getByRole("textbox")
+			fireEvent.change(textbox, { target: { value: "Edited prompt" } })
+
+			fireEvent.keyDown(textbox, { key: "Escape" })
+
+			expect(screen.queryByRole("textbox")).not.toBeInTheDocument()
+			expect(screen.getByText("Original prompt")).toBeInTheDocument()
+			expect(onWindowKeyDown).not.toHaveBeenCalled()
+		} finally {
+			window.removeEventListener("keydown", onWindowKeyDown)
+		}
 	})
 })


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This fixes an annoying keyboard handling bug in the VS Code webview chat: when a user is editing a previous user message inline, pressing Escape should leave that inline edit field exactly like clicking the local Cancel button. Before this change, the Escape key bubbled past the inline edit UI to the global action button shortcut, which could cancel the active task instead.

The change keeps the behavior scoped to `UserMessage`:

- adds a shared `cancelEditing` helper used by both the Cancel button and Escape handling
- handles Escape on the inline edit container
- calls `preventDefault()` and `stopPropagation()` so the key event does not reach the window-level task cancel handler
- preserves the existing disabled behavior while a regenerate/save action is in progress

I also added a regression test around the exact failure mode. The test enters inline edit mode, modifies the textarea, presses Escape, verifies the edit UI closes and the original message remains visible, and verifies a window-level keydown listener was not called.

### Test Procedure

Ran the focused webview test file:

```bash
bun run test src/components/chat/__tests__/UserMessage.ime.test.tsx
```

Result:

```text
✓ src/components/chat/__tests__/UserMessage.ime.test.tsx (2 tests)
```

I also formatted the touched files with the VS Code app Biome config:

```bash
bunx --bun @biomejs/biome format --write webview-ui/src/components/chat/UserMessage.tsx webview-ui/src/components/chat/__tests__/UserMessage.ime.test.tsx
```

I did not run the full webview test suite or full lint/typecheck because this is a narrow keyboard handling change with focused coverage.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not included. This is a keyboard behavior fix for the existing inline edit UI and does not change the visual presentation.

### Additional Notes

The relevant global task-cancel shortcut lives outside the user-message edit component, so the important part of this fix is stopping the Escape event at the inline edit boundary. That preserves Escape as a task-level shortcut elsewhere while making it behave like Cancel when focus is inside the edited user message.
