### PR TITLE
fix: hide workflows tab from customize menu

### DIFF
--- a/apps/vscode/webview-ui/src/components/cline-rules/ClineRulesToggleModal.tsx
+++ b/apps/vscode/webview-ui/src/components/cline-rules/ClineRulesToggleModal.tsx
@@ -9,7 +9,6 @@ import {
 	ToggleCursorRuleRequest,
 	ToggleSkillRequest,
 	ToggleWindsurfRuleRequest,
-	ToggleWorkflowRequest,
 } from "@shared/proto/cline/file"
 import { VSCodeButton, VSCodeLink } from "@vscode/webview-ui-toolkit/react"
 import React, { useEffect, useRef, useState } from "react"
@@ -33,8 +32,6 @@ const ClineRulesToggleModal: React.FC = () => {
 		localCursorRulesToggles = {},
 		localWindsurfRulesToggles = {},
 		localAgentsRulesToggles = {},
-		localWorkflowToggles = {},
-		globalWorkflowToggles = {},
 		hooksEnabled,
 		setGlobalClineRulesToggles,
 		setLocalClineRulesToggles,
@@ -61,7 +58,7 @@ const ClineRulesToggleModal: React.FC = () => {
 	const { width: viewportWidth, height: viewportHeight } = useWindowSize()
 	const [arrowPosition, setArrowPosition] = useState(0)
 	const [menuPosition, setMenuPosition] = useState(0)
-	const [currentView, setCurrentView] = useState<"rules" | "workflows" | "hooks" | "skills">("rules")
+	const [currentView, setCurrentView] = useState<"rules" | "hooks" | "skills">("rules")
 
 	// Auto-switch to rules tab if hooks become disabled while viewing hooks tab
 	useEffect(() => {
@@ -208,20 +205,10 @@ const ClineRulesToggleModal: React.FC = () => {
 		.map(([path, enabled]): [string, boolean] => [path, enabled as boolean])
 		.sort(([a], [b]) => a.localeCompare(b))
 
-	const localWorkflows = Object.entries(localWorkflowToggles || {})
-		.map(([path, enabled]): [string, boolean] => [path, enabled as boolean])
-		.sort(([a], [b]) => a.localeCompare(b))
-
-	const globalWorkflows = Object.entries(globalWorkflowToggles || {})
-		.map(([path, enabled]): [string, boolean] => [path, enabled as boolean])
-		.sort(([a], [b]) => a.localeCompare(b))
-
 	const remoteConfigSettings = useRemoteConfigSettings(isVisible)
 	const remoteRules = remoteConfigSettings.filter((s) => s.type === "rule")
-	const remoteWorkflows = remoteConfigSettings.filter((s) => s.type === "workflow")
 	const remoteSkills = remoteConfigSettings.filter((s) => s.type === "skill")
 	const hasRemoteRules = remoteRules.length > 0
-	const hasRemoteWorkflows = remoteWorkflows.length > 0
 	const hasRemoteSkills = remoteSkills.length > 0
 
 	// Handle toggle rule using gRPC
@@ -320,28 +307,6 @@ const ClineRulesToggleModal: React.FC = () => {
 			})
 	}
 
-	const toggleWorkflow = (isGlobal: boolean, workflowPath: string, enabled: boolean) => {
-		FileServiceClient.toggleWorkflow(
-			ToggleWorkflowRequest.create({
-				workflowPath,
-				enabled,
-				scope: isGlobal ? RuleScope.GLOBAL : RuleScope.LOCAL,
-			}),
-		)
-			.then((response) => {
-				if (response.toggles) {
-					if (isGlobal) {
-						setGlobalWorkflowToggles(response.toggles)
-					} else {
-						setLocalWorkflowToggles(response.toggles)
-					}
-				}
-			})
-			.catch((err: Error) => {
-				console.error("Failed to toggle workflow:", err)
-			})
-	}
-
 	// Handle toggle for skills
 	const toggleSkill = (isGlobal: boolean, skillPath: string, enabled: boolean) => {
 		FileServiceClient.toggleSkill(
@@ -393,11 +358,11 @@ const ClineRulesToggleModal: React.FC = () => {
 		<div className="inline-flex min-w-0 max-w-full items-center" ref={modalRef}>
 			<div className="inline-flex w-full items-center" ref={buttonRef}>
 				<Tooltip>
-					{!isVisible && <TooltipContent>Manage Cline Rules & Workflows</TooltipContent>}
+					{!isVisible && <TooltipContent>Customize</TooltipContent>}
 					<TooltipTrigger>
 						<VSCodeButton
 							appearance="icon"
-							aria-label={isVisible ? "Hide Cline Rules & Workflows" : "Show Cline Rules & Workflows"}
+							aria-label={isVisible ? "Hide Customize" : "Show Customize"}
 							className="p-0 m-0 flex items-center"
 							onClick={() => setIsVisible(!isVisible)}>
 							<i className="codicon codicon-law" style={{ fontSize: "12.5px" }} />
@@ -428,9 +393,6 @@ const ClineRulesToggleModal: React.FC = () => {
 								<TabButton isActive={currentView === "rules"} onClick={() => setCurrentView("rules")}>
 									Rules
 								</TabButton>
-								<TabButton isActive={currentView === "workflows"} onClick={() => setCurrentView("workflows")}>
-									Workflows
-								</TabButton>
 								{hooksEnabled && (
 									<TabButton isActive={currentView === "hooks"} onClick={() => setCurrentView("hooks")}>
 										Hooks
@@ -443,17 +405,13 @@ const ClineRulesToggleModal: React.FC = () => {
 						</div>
 
 						{/* Remote config banner */}
-						{(currentView === "rules" && hasRemoteRules) ||
-						(currentView === "workflows" && hasRemoteWorkflows) ||
-						(currentView === "skills" && hasRemoteSkills) ? (
+						{(currentView === "rules" && hasRemoteRules) || (currentView === "skills" && hasRemoteSkills) ? (
 							<div className="flex items-center gap-2 px-3 py-3 mb-4 bg-vscode-textBlockQuote-background border-l-[3px] border-vscode-textLink-foreground">
 								<i className="codicon codicon-lock text-sm" />
 								<span className="text-base">
 									{currentView === "rules"
 										? "Your organization manages some rules"
-										: currentView === "workflows"
-											? "Your organization manages some workflows"
-											: "Your organization manages some skills"}
+										: "Your organization manages some skills"}
 								</span>
 							</div>
 						) : null}
@@ -468,17 +426,6 @@ const ClineRulesToggleModal: React.FC = () => {
 										className="text-xs"
 										href="https://docs.cline.bot/features/cline-rules"
 										style={{ display: "inline", fontSize: "inherit" }}>
-										Docs
-									</VSCodeLink>
-								</p>
-							) : currentView === "workflows" ? (
-								<p>
-									Workflows allow you to define a series of steps to guide Cline through a repetitive set of
-									tasks, such as deploying a service or submitting a PR. To invoke a workflow, type{" "}
-									<span className="text-foreground font-bold">/workflow-name</span> in the chat.{" "}
-									<VSCodeLink
-										className="text-xs inline"
-										href="https://docs.cline.bot/features/slash-commands/workflows">
 										Docs
 									</VSCodeLink>
 								</p>
@@ -580,62 +527,6 @@ const ClineRulesToggleModal: React.FC = () => {
 										showNewRule={true}
 										showNoRules={false}
 										toggleRule={toggleAgentsRule}
-									/>
-								</div>
-							</>
-						) : currentView === "workflows" ? (
-							<>
-								{/* Remote Workflows Section */}
-								{hasRemoteWorkflows && (
-									<div className="mb-3">
-										<div className="text-sm font-normal mb-2">Enterprise Workflows</div>
-										<div className="flex flex-col gap-0">
-											{remoteWorkflows.map((workflow) => {
-												const enabled = workflow.locked || workflow.enabled
-												return (
-													<RuleRow
-														alwaysEnabled={workflow.locked}
-														enabled={enabled}
-														isGlobal={false}
-														isRemote={true}
-														key={workflow.name}
-														rulePath={workflow.name}
-														ruleType="workflow"
-														toggleRule={workflow.toggle}
-													/>
-												)
-											})}
-										</div>
-									</div>
-								)}
-
-								{/* Global Workflows Section */}
-								<div className="mb-3">
-									<div className="text-sm font-normal mb-2">Global Workflows</div>
-
-									{/* File-based Global Workflows */}
-									<RulesToggleList
-										isGlobal={true}
-										listGap="small"
-										rules={globalWorkflows}
-										ruleType={"workflow"}
-										showNewRule={true}
-										showNoRules={false}
-										toggleRule={(rulePath, enabled) => toggleWorkflow(true, rulePath, enabled)}
-									/>
-								</div>
-
-								{/* Local Workflows Section */}
-								<div className="-mb-2.5">
-									<div className="text-sm font-normal mb-2">Workspace Workflows</div>
-									<RulesToggleList
-										isGlobal={false}
-										listGap="small"
-										rules={localWorkflows}
-										ruleType={"workflow"}
-										showNewRule={true}
-										showNoRules={false}
-										toggleRule={(rulePath, enabled) => toggleWorkflow(false, rulePath, enabled)}
 									/>
 								</div>
 							</>


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This PR removes the Workflows tab from the chat-field customization menu and renames the hover label for that button to `Customize`.

The goal is to keep the UI focused on the currently preferred customization surfaces without removing legacy workflow runtime support. Existing workflow files and slash command execution are not touched here; this only removes the workflow management tab from the small customization popover shown from the chat input controls.

Technical approach:

- Removed `workflows` from the local `currentView` union in `ClineRulesToggleModal`.
- Removed the Workflows tab and its related description/content branch from that modal.
- Removed now-unused workflow list derivation and toggle handler code from that component.
- Changed the button tooltip and ARIA label from “Cline Rules & Workflows” wording to “Customize”.

I intentionally left the underlying workflow refresh state handling alone because this PR is only about hiding the tab from this UI surface, not removing workflow compatibility for existing users.

### Test Procedure

Ran targeted webview checks:

```bash
bunx tsc --noEmit
bunx biome lint --config-path ./biome.jsonc --no-errors-on-unmatched --files-ignore-unknown=true --diagnostic-level=error webview-ui/src/components/cline-rules/ClineRulesToggleModal.tsx
```

Verified the branch diff against `origin/main` contains only `apps/vscode/webview-ui/src/components/cline-rules/ClineRulesToggleModal.tsx`.

Potential impact reviewed:

- The customize menu still exposes Rules, Hooks when enabled, and Skills.
- The Workflows tab is no longer reachable from the popover.
- Runtime workflow support was not changed.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not included. This is a small copy/navigation change in the chat-field customization popover.

### Additional Notes

The first pushed branch, `saoudrizwan/hide-workflows-tab`, was based on the detached worktree's prior commit stack and contained unrelated changes relative to `main`. I created this clean branch from `origin/main` and cherry-picked only the intended commit so this PR stays scoped to the modal UI change.
