### PR TITLE
fix(vscode): disable command auto-approval by default

### DIFF
--- a/apps/vscode/src/sdk/sdk-tool-policies.test.ts
+++ b/apps/vscode/src/sdk/sdk-tool-policies.test.ts
@@ -3,6 +3,10 @@ import { describe, expect, it } from "vitest"
 import { isToolAutoApproved } from "./sdk-tool-policies"
 
 describe("isToolAutoApproved", () => {
+	it("does not auto-approve command tools by default", () => {
+		expect(isToolAutoApproved("run_commands", DEFAULT_AUTO_APPROVAL_SETTINGS)).toBe(false)
+	})
+
 	it("uses executeSafeCommands as the single command approval flag", () => {
 		const settings = {
 			...DEFAULT_AUTO_APPROVAL_SETTINGS,

--- a/apps/vscode/src/shared/AutoApprovalSettings.ts
+++ b/apps/vscode/src/shared/AutoApprovalSettings.ts
@@ -35,7 +35,7 @@ export const DEFAULT_AUTO_APPROVAL_SETTINGS: AutoApprovalSettings = {
 		readFilesExternally: true,
 		editFiles: true,
 		editFilesExternally: true,
-		executeSafeCommands: true,
+		executeSafeCommands: false,
 		executeAllCommands: true,
 		useBrowser: true,
 		useMcp: true,


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This PR changes the VS Code auto-approve menu defaults so command execution is not auto-approved for a fresh/default settings object.

The behavior was coming from `DEFAULT_AUTO_APPROVAL_SETTINGS.actions.executeSafeCommands`, which was set to `true`. The auto-approve menu uses the `executeSafeCommands` action id for the "Execute commands" item, and the SDK tool policy path also uses `executeSafeCommands` as the single current command approval flag for `run_commands` / `execute_command` tools.

The implementation is intentionally narrow:

- Set `executeSafeCommands` to `false` in the shared default settings.
- Leave the legacy `executeAllCommands` compatibility field unchanged, because current command approval logic ignores that field and the existing test explicitly documents `executeSafeCommands` as the active flag.
- Add a focused SDK policy test proving command tools are not auto-approved by the default settings.

Debugging notes: I traced the auto-approve menu from `ACTION_METADATA` through `useAutoApproveActions` to the shared default settings, then checked the SDK policy guard to confirm which field actually controls command auto-approval at runtime. While preparing the PR from the detached worktree, the initial detached base had drift relative to `origin/main`, so I rebased the new task branch onto `origin/main` before opening this PR. After the rebase, the PR diff is limited to the default change and the focused regression test.

### Test Procedure

Ran the focused VS Code Vitest spec that covers the SDK command approval behavior:

```bash
cd apps/vscode && bun run test:vitest -- src/sdk/sdk-tool-policies.test.ts
```

Result: 1 test file passed, 2 tests passed.

I also verified the final branch diff against `origin/main` only includes the intended auto-approval default change and the focused test. Existing stored user settings should continue to use their stored values; this change affects the default settings object used for fresh/default state.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. This is a default settings and policy test change; there is no visual UI change to capture.

### Additional Notes

Full `bun test`, `bun run format`, and `bun run lint` were not run. The focused Vitest coverage for the affected policy path passed.
