### PR TITLE
Add a prompt to change to ClinePass when out of credits

### DIFF
--- a/apps/cli/src/tui/components/chat-entry.tsx
+++ b/apps/cli/src/tui/components/chat-entry.tsx
@@ -9,6 +9,7 @@ import {
 	isClineOrgIndividualInferenceSubscriptionErrorMessage,
 	isClinePassSubscriptionError,
 } from "../../utils/cline-pass-errors";
+import { getCliFeatureFlagsService } from "../../utils/feature-flags";
 import {
 	CLINE_CREDITS_DASHBOARD_URL,
 	isClineAccountCreditsErrorMessage,
@@ -273,7 +274,14 @@ function ToolCallView(props: {
 	);
 }
 
+const CLINE_PASS_ENABLED_OUT_OF_CREDITS_MESSAGE =
+	"You have run out of Cline credits. Add credits in the dashboard or purchase and switch to ClinePass to continue.";
+const OUT_OF_CREDITS_MESSAGE =
+	"You have run out of Cline credits. Add credits in the dashboard to continue.";
+
 function ClineCreditsErrorView(props: { defaultFg?: string }) {
+	const isClinePassEnabled =
+		getCliFeatureFlagsService().getBooleanFlagEnabled("ext-cline-pass");
 	return (
 		<box flexDirection="row">
 			<text fg="red" content="* " />
@@ -288,7 +296,11 @@ function ClineCreditsErrorView(props: { defaultFg?: string }) {
 				<text
 					fg={props.defaultFg}
 					selectable
-					content="You have run out of Cline credits. Add credits in the dashboard to continue."
+					content={
+						isClinePassEnabled
+							? CLINE_PASS_ENABLED_OUT_OF_CREDITS_MESSAGE
+							: OUT_OF_CREDITS_MESSAGE
+					}
 				/>
 				<box flexDirection="row">
 					<text fg="gray">Dashboard: </text>


### PR DESCRIPTION
### Description

We want to prompt users to use ClinePass when they run out of credits. We don't want to add more information on the error message so as to keep the screen clean.

### Test Procedure

<img width="842" height="142" alt="image" src="https://github.com/user-attachments/assets/63189cc5-9272-4992-b083-3c5f8a12515f" />

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)