### PR TITLE
fix(vscode): surface plugin bundled skills

### DIFF
--- a/apps/vscode/src/core/controller/file/refreshSkills.ts
+++ b/apps/vscode/src/core/controller/file/refreshSkills.ts
@@ -1,65 +1,16 @@
+import { type CoreSettingsItem, createCoreSettingsService } from "@cline/core"
 import { parseRemoteSkillEntries } from "@core/context/instructions/user-instructions/skills"
 import { RefreshedSkills, SkillInfo } from "@shared/proto/cline/file"
-import fs from "fs/promises"
-import path from "path"
-import { parseYamlFrontmatter } from "@/core/context/instructions/user-instructions/frontmatter"
-import { getSkillsDirectoriesForScan } from "@/core/storage/disk"
 import { HostProvider } from "@/hosts/host-provider"
-import { Logger } from "@/shared/services/Logger"
-import { fileExistsAtPath, isDirectory } from "@/utils/fs"
 import { Controller } from ".."
 
-/**
- * Scan a directory for skill subdirectories containing SKILL.md files.
- */
-async function scanSkillsDirectory(dirPath: string): Promise<SkillInfo[]> {
-	const skills: SkillInfo[] = []
-
-	if (!(await fileExistsAtPath(dirPath)) || !(await isDirectory(dirPath))) {
-		return skills
-	}
-
-	try {
-		const entries = await fs.readdir(dirPath)
-
-		for (const entryName of entries) {
-			const entryPath = path.join(dirPath, entryName)
-			const stats = await fs.stat(entryPath).catch(() => null)
-			if (!stats?.isDirectory()) continue
-
-			const skillMdPath = path.join(entryPath, "SKILL.md")
-			if (!(await fileExistsAtPath(skillMdPath))) continue
-
-			try {
-				const fileContent = await fs.readFile(skillMdPath, "utf-8")
-				const result = parseYamlFrontmatter(fileContent)
-				if (result.parseError) {
-					Logger.warn("Failed to parse YAML frontmatter:", result.parseError)
-				}
-				const frontmatter = result.data
-
-				// Validate required fields
-				if (!frontmatter.name || typeof frontmatter.name !== "string") continue
-				if (!frontmatter.description || typeof frontmatter.description !== "string") continue
-				if (frontmatter.name !== entryName) continue
-
-				skills.push(
-					SkillInfo.create({
-						name: entryName,
-						description: frontmatter.description,
-						path: skillMdPath,
-						enabled: true, // Will be updated with toggle state
-					}),
-				)
-			} catch {
-				// Skip invalid skills
-			}
-		}
-	} catch {
-		// Directory read error, skip
-	}
-
-	return skills
+function coreSkillToSkillInfo(skill: CoreSettingsItem): SkillInfo {
+	return SkillInfo.create({
+		name: skill.name,
+		description: skill.description ?? "",
+		path: skill.path,
+		enabled: skill.enabled !== false,
+	})
 }
 
 /**
@@ -70,33 +21,15 @@ export async function refreshSkills(controller: Controller): Promise<RefreshedSk
 	const workspacePaths = await HostProvider.workspace.getWorkspacePaths({})
 	const primaryWorkspace = workspacePaths.paths[0]
 
-	const globalSkills: SkillInfo[] = []
-	const localSkills: SkillInfo[] = []
-
-	if (primaryWorkspace) {
-		const scanDirs = getSkillsDirectoriesForScan(primaryWorkspace)
-		for (const dir of scanDirs) {
-			const skills = await scanSkillsDirectory(dir.path)
-			if (dir.source === "global") {
-				globalSkills.push(...skills)
-			} else {
-				localSkills.push(...skills)
-			}
-		}
-	} else {
-		const scanDirs = getSkillsDirectoriesForScan("")
-		for (const dir of scanDirs) {
-			if (dir.source !== "global") continue
-			const skills = await scanSkillsDirectory(dir.path)
-			globalSkills.push(...skills)
-		}
-	}
-
-	// Get global toggles and apply them
-	const globalToggles = controller.stateManager.getGlobalSettingsKey("globalSkillsToggles") || {}
-	for (const skill of globalSkills) {
-		skill.enabled = globalToggles[skill.path] !== false
-	}
+	const settingsSnapshot = await createCoreSettingsService().list({
+		workspaceRoot: primaryWorkspace,
+	})
+	const globalSkills = settingsSnapshot.skills
+		.filter((skill) => skill.source === "global" || skill.source === "global-plugin")
+		.map(coreSkillToSkillInfo)
+	const localSkills = settingsSnapshot.skills
+		.filter((skill) => skill.source === "workspace" || skill.source === "workspace-plugin")
+		.map(coreSkillToSkillInfo)
 
 	// Add remote skills from remote config.
 	// Precedence: remote (enterprise) > disk-global (user) > project (workspace).
@@ -118,12 +51,6 @@ export async function refreshSkills(controller: Controller): Promise<RefreshedSk
 				alwaysEnabled: entry.alwaysEnabled,
 			}),
 		)
-	}
-
-	// Get local toggles and apply them
-	const localToggles = controller.stateManager.getWorkspaceStateKey("localSkillsToggles") || {}
-	for (const skill of localSkills) {
-		skill.enabled = localToggles[skill.path] !== false
 	}
 
 	return RefreshedSkills.create({

--- a/apps/vscode/src/core/controller/marketplace/installMarketplaceEntry.ts
+++ b/apps/vscode/src/core/controller/marketplace/installMarketplaceEntry.ts
@@ -3,11 +3,15 @@ import type { Controller } from "../index"
 import { installMarketplaceEntryFromCatalog } from "./marketplace-helpers"
 
 export async function installMarketplaceEntry(
-	_controller: Controller,
+	controller: Controller,
 	request: MarketplaceEntryRequest,
 ): Promise<MarketplaceInstallResult> {
 	if (!request.entry) {
 		throw new Error("Marketplace entry is required.")
 	}
-	return installMarketplaceEntryFromCatalog(request.entry)
+	const result = await installMarketplaceEntryFromCatalog(request.entry)
+	if (request.entry.type === "skill" || request.entry.type === "plugin") {
+		await controller.invalidateUserInstructionService()
+	}
+	return result
 }

--- a/apps/vscode/src/core/controller/marketplace/marketplace-helpers.ts
+++ b/apps/vscode/src/core/controller/marketplace/marketplace-helpers.ts
@@ -543,6 +543,7 @@ export async function toggleLocalMarketplaceInstalledEntry(
 	}
 	if (entry.type === "plugin") {
 		await togglePluginLocalEntry(controller, entry, enabled)
+		await controller.invalidateUserInstructionService()
 		return listLocalMarketplaceInstalledEntries(controller)
 	}
 	throw new Error(`Marketplace toggle is not supported for ${entry.type}.`)

--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -9,8 +9,8 @@ import * as path from "node:path"
 import {
 	createUserInstructionConfigService,
 	getProviderAuthStorageId,
-	resolveDefaultMcpSettingsPath,
 	type PreparedRemoteConfigCoreIntegration,
+	resolveDefaultMcpSettingsPath,
 	type SessionHistoryRecord,
 	setTelemetryOptOutGlobally,
 	type UserInstructionConfigService,
@@ -610,6 +610,15 @@ export class Controller {
 		}
 	}
 
+	async invalidateUserInstructionService(): Promise<void> {
+		const userInstructionServicePromise = this.userInstructionService
+		this.userInstructionService = undefined
+		this.userInstructionServiceRoot = undefined
+		if (userInstructionServicePromise) {
+			await userInstructionServicePromise.then((service) => service.stop()).catch(() => {})
+		}
+	}
+
 	async dispose(): Promise<void> {
 		this.providerConfigStoreSubscription.dispose()
 		// Clear the remote config timer to prevent stale fetches
@@ -619,11 +628,7 @@ export class Controller {
 		}
 		await this.setRemoteConfigCoreIntegration(undefined)
 		this.isDisposed = true
-		const userInstructionServicePromise = this.userInstructionService
-		this.userInstructionService = undefined
-		if (userInstructionServicePromise) {
-			await userInstructionServicePromise.then((service) => service.stop()).catch(() => {})
-		}
+		await this.invalidateUserInstructionService()
 		this.messages.cancelPendingSave()
 		// Clear MCP tool list change callback before disposing McpHub
 		this.mcpHub?.clearToolListChangeCallback()
@@ -666,7 +671,11 @@ export class Controller {
 		this.userInstructionService = (async () => {
 			const service = createUserInstructionConfigService({
 				workflows: { workspacePath: workspaceRoot },
-				skills: { workspacePath: workspaceRoot },
+				skills: {
+					workspacePath: workspaceRoot,
+					includePluginSkills: true,
+					cwd: workspaceRoot,
+				},
 				rules: { workspacePath: workspaceRoot },
 			})
 			// start() runs the initial scan; await so the snapshot is populated

--- a/sdk/packages/core/src/settings/settings-service.test.ts
+++ b/sdk/packages/core/src/settings/settings-service.test.ts
@@ -13,9 +13,17 @@ describe("CoreSettingsService", () => {
 	};
 
 	afterEach(async () => {
-		process.env.CLINE_GLOBAL_SETTINGS_PATH =
-			envSnapshot.CLINE_GLOBAL_SETTINGS_PATH;
-		process.env.CLINE_MCP_SETTINGS_PATH = envSnapshot.CLINE_MCP_SETTINGS_PATH;
+		if (envSnapshot.CLINE_GLOBAL_SETTINGS_PATH === undefined) {
+			delete process.env.CLINE_GLOBAL_SETTINGS_PATH;
+		} else {
+			process.env.CLINE_GLOBAL_SETTINGS_PATH =
+				envSnapshot.CLINE_GLOBAL_SETTINGS_PATH;
+		}
+		if (envSnapshot.CLINE_MCP_SETTINGS_PATH === undefined) {
+			delete process.env.CLINE_MCP_SETTINGS_PATH;
+		} else {
+			process.env.CLINE_MCP_SETTINGS_PATH = envSnapshot.CLINE_MCP_SETTINGS_PATH;
+		}
 		await Promise.all(
 			tempRoots.map((dir) => rm(dir, { recursive: true, force: true })),
 		);

--- a/sdk/packages/core/src/settings/settings-service.test.ts
+++ b/sdk/packages/core/src/settings/settings-service.test.ts
@@ -105,6 +105,112 @@ Use this skill.`,
 		);
 	});
 
+	it("lists bundled plugin skills with plugin ownership metadata", async () => {
+		const tempRoot = await mkdtemp(
+			join(tmpdir(), "core-settings-plugin-skills-"),
+		);
+		tempRoots.push(tempRoot);
+		const installRoot = join(
+			tempRoot,
+			".cline",
+			"plugins",
+			"_installed",
+			"local",
+			"test-plugin-skill-owner",
+		);
+		const packageRoot = join(installRoot, "package");
+		const pluginPath = join(packageRoot, "index.ts");
+		const skillDir = join(packageRoot, "skills", "test-plugin-skill-owner");
+		await mkdir(skillDir, { recursive: true });
+		await writeFile(
+			join(installRoot, "package.json"),
+			JSON.stringify({
+				name: "test-plugin-skill-owner",
+				cline: {
+					plugins: [{ paths: ["./package/index.ts"] }],
+				},
+			}),
+		);
+		await writeFile(pluginPath, "export default {};");
+		await writeFile(
+			join(skillDir, "SKILL.md"),
+			`---
+name: test-plugin-skill-owner
+description: Browser agent
+---
+Use the browser.`,
+		);
+
+		const snapshot = await new CoreSettingsService().list({ cwd: tempRoot });
+
+		expect(snapshot.skills).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					id: "test-plugin-skill-owner",
+					name: "test-plugin-skill-owner",
+					source: "workspace-plugin",
+					pluginName: "test-plugin-skill-owner",
+					pluginPath,
+					enabled: true,
+				}),
+			]),
+		);
+	});
+
+	it("does not list skills from disabled plugins", async () => {
+		const tempRoot = await mkdtemp(
+			join(tmpdir(), "core-settings-plugin-skills-"),
+		);
+		tempRoots.push(tempRoot);
+		const settingsPath = join(tempRoot, "global-settings.json");
+		process.env.CLINE_GLOBAL_SETTINGS_PATH = settingsPath;
+		const installRoot = join(
+			tempRoot,
+			".cline",
+			"plugins",
+			"_installed",
+			"local",
+			"test-plugin-skill-disabled",
+		);
+		const packageRoot = join(installRoot, "package");
+		const pluginPath = join(packageRoot, "index.ts");
+		const skillDir = join(packageRoot, "skills", "test-plugin-skill-disabled");
+		await mkdir(skillDir, { recursive: true });
+		await writeFile(
+			join(installRoot, "package.json"),
+			JSON.stringify({
+				name: "test-plugin-skill-disabled",
+				cline: {
+					plugins: [{ paths: ["./package/index.ts"] }],
+				},
+			}),
+		);
+		await writeFile(pluginPath, "export default {};");
+		await writeFile(
+			join(skillDir, "SKILL.md"),
+			`---
+name: test-plugin-skill-disabled
+description: Browser agent
+---
+Use the browser.`,
+		);
+		await writeFile(
+			settingsPath,
+			JSON.stringify({ disabledPlugins: [pluginPath] }),
+		);
+
+		const snapshot = await new CoreSettingsService().list({ cwd: tempRoot });
+
+		expect(snapshot.skills).not.toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					id: "test-plugin-skill-disabled",
+					pluginPath,
+				}),
+			]),
+		);
+	});
+
 	it("lists and toggles MCP server disabled state", async () => {
 		const tempRoot = await mkdtemp(join(tmpdir(), "core-settings-"));
 		tempRoots.push(tempRoot);

--- a/sdk/packages/core/src/settings/settings-service.ts
+++ b/sdk/packages/core/src/settings/settings-service.ts
@@ -1,5 +1,13 @@
-import { existsSync } from "node:fs";
-import { basename, isAbsolute, relative } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+import {
+	basename,
+	dirname,
+	extname,
+	isAbsolute,
+	join,
+	relative,
+	resolve,
+} from "node:path";
 import {
 	createUserInstructionConfigService,
 	type RuleConfig,
@@ -14,6 +22,10 @@ import {
 	resolveMcpServerRegistrations,
 	setMcpServerDisabled,
 } from "../extensions/mcp";
+import {
+	resolveAgentPluginPaths,
+	resolvePluginSkillDirectoriesFromPaths,
+} from "../extensions/plugin/plugin-config-loader";
 import {
 	setToolDisabledGlobally,
 	toggleDisabledTool,
@@ -38,6 +50,97 @@ function detectSource(
 	return !relativePath.startsWith("..") && !isAbsolute(relativePath)
 		? "workspace"
 		: "global";
+}
+
+function detectPluginSource(
+	filePath: string,
+	workspaceRoot: string,
+): "global-plugin" | "workspace-plugin" {
+	return detectSource(filePath, workspaceRoot) === "workspace"
+		? "workspace-plugin"
+		: "global-plugin";
+}
+
+function isPathWithin(parentPath: string, childPath: string): boolean {
+	const relativePath = relative(resolve(parentPath), resolve(childPath));
+	return (
+		relativePath === "" ||
+		(!relativePath.startsWith("..") && !isAbsolute(relativePath))
+	);
+}
+
+function readPackageName(packageJsonPath: string): string | undefined {
+	try {
+		const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+			name?: unknown;
+		};
+		return typeof packageJson.name === "string" && packageJson.name.trim()
+			? packageJson.name.trim()
+			: undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function getPluginDisplayName(filePath: string): string {
+	let current = dirname(filePath);
+	while (true) {
+		const packageJsonPath = join(current, "package.json");
+		if (existsSync(packageJsonPath)) {
+			const packageName = readPackageName(packageJsonPath);
+			if (packageName) {
+				return packageName;
+			}
+			break;
+		}
+		const parent = dirname(current);
+		if (parent === current) {
+			break;
+		}
+		current = parent;
+	}
+	return basename(filePath, extname(filePath));
+}
+
+type PluginSkillOwner = {
+	directory: string;
+	pluginName: string;
+	pluginPath: string;
+	source: "global-plugin" | "workspace-plugin";
+};
+
+function buildPluginSkillOwners(input: {
+	workspaceRoot: string;
+	cwd?: string;
+}): PluginSkillOwner[] {
+	const owners: PluginSkillOwner[] = [];
+	for (const pluginPath of resolveAgentPluginPaths({
+		workspacePath: input.workspaceRoot || undefined,
+		cwd: input.cwd,
+	})) {
+		for (const directory of resolvePluginSkillDirectoriesFromPaths([
+			pluginPath,
+		])) {
+			owners.push({
+				directory,
+				pluginName: getPluginDisplayName(pluginPath),
+				pluginPath,
+				source: input.workspaceRoot
+					? detectPluginSource(pluginPath, input.workspaceRoot)
+					: "global-plugin",
+			});
+		}
+	}
+	return owners.sort(
+		(left, right) => right.directory.length - left.directory.length,
+	);
+}
+
+function findPluginSkillOwner(
+	filePath: string,
+	owners: readonly PluginSkillOwner[],
+): PluginSkillOwner | undefined {
+	return owners.find((owner) => isPathWithin(owner.directory, filePath));
 }
 
 function toSorted<T extends CoreSettingsItem>(items: T[]): T[] {
@@ -73,18 +176,15 @@ async function withUserInstructionService<T>(
 		return await run(input.userInstructionService);
 	}
 	const workspaceRoot = resolveWorkspaceRoot(input);
-	if (!workspaceRoot) {
-		return await run(undefined);
-	}
-	const cwd = input.cwd?.trim() || workspaceRoot;
+	const cwd = input.cwd?.trim() || workspaceRoot || process.cwd();
 	const service = createUserInstructionConfigService({
 		skills: {
-			workspacePath: workspaceRoot,
+			workspacePath: workspaceRoot || undefined,
 			includePluginSkills: true,
 			cwd,
 		},
-		rules: { workspacePath: workspaceRoot },
-		workflows: { workspacePath: workspaceRoot },
+		rules: { workspacePath: workspaceRoot || undefined },
+		workflows: { workspacePath: workspaceRoot || undefined },
 	});
 	try {
 		await service.start();
@@ -124,6 +224,10 @@ export class CoreSettingsService {
 	async list(input: CoreSettingsListInput = {}): Promise<CoreSettingsSnapshot> {
 		return await withUserInstructionService(input, async (service) => {
 			const workspaceRoot = resolveWorkspaceRoot(input);
+			const pluginSkillOwners = buildPluginSkillOwners({
+				workspaceRoot,
+				cwd: input.cwd,
+			});
 			const workflows: CoreSettingsItem[] = [];
 			const rules: CoreSettingsItem[] = [];
 			const skills: CoreSettingsItem[] = [];
@@ -159,14 +263,22 @@ export class CoreSettingsService {
 				}
 				for (const record of service.listRecords<SkillConfig>("skill")) {
 					const skill = record.item;
+					const pluginOwner = findPluginSkillOwner(
+						record.filePath,
+						pluginSkillOwners,
+					);
 					skills.push({
 						id: record.id,
 						name: skill.name,
 						path: record.filePath,
 						enabled: skill.disabled !== true,
 						kind: "skill",
-						source: detectSource(record.filePath, workspaceRoot),
+						source:
+							pluginOwner?.source ??
+							detectSource(record.filePath, workspaceRoot),
 						description: skill.description,
+						pluginName: pluginOwner?.pluginName,
+						pluginPath: pluginOwner?.pluginPath,
 						toggleable: true,
 					});
 				}

--- a/sdk/packages/core/src/settings/settings-service.ts
+++ b/sdk/packages/core/src/settings/settings-service.ts
@@ -168,6 +168,13 @@ function resolveWorkspaceRoot(input: CoreSettingsListInput): string {
 	return input.workspaceRoot?.trim() || input.cwd?.trim() || "";
 }
 
+function resolveCwd(
+	input: CoreSettingsListInput,
+	workspaceRoot: string,
+): string {
+	return input.cwd?.trim() || workspaceRoot || process.cwd();
+}
+
 async function withUserInstructionService<T>(
 	input: CoreSettingsListInput,
 	run: (service?: UserInstructionConfigService) => Promise<T>,
@@ -176,7 +183,7 @@ async function withUserInstructionService<T>(
 		return await run(input.userInstructionService);
 	}
 	const workspaceRoot = resolveWorkspaceRoot(input);
-	const cwd = input.cwd?.trim() || workspaceRoot || process.cwd();
+	const cwd = resolveCwd(input, workspaceRoot);
 	const service = createUserInstructionConfigService({
 		skills: {
 			workspacePath: workspaceRoot || undefined,
@@ -226,7 +233,7 @@ export class CoreSettingsService {
 			const workspaceRoot = resolveWorkspaceRoot(input);
 			const pluginSkillOwners = buildPluginSkillOwners({
 				workspaceRoot,
-				cwd: input.cwd,
+				cwd: resolveCwd(input, workspaceRoot),
 			});
 			const workflows: CoreSettingsItem[] = [];
 			const rules: CoreSettingsItem[] = [];

--- a/sdk/packages/core/src/settings/types.ts
+++ b/sdk/packages/core/src/settings/types.ts
@@ -31,6 +31,8 @@ export interface CoreSettingsItem {
 	enabled?: boolean;
 	description?: string;
 	toggleable?: boolean;
+	pluginName?: string;
+	pluginPath?: string;
 }
 
 export interface CoreSettingsSnapshot {


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This fixes VS Code plugin-bundled skills not being visible or usable after installing a plugin such as `agent-browser` from the marketplace.

Before this change, the VS Code skills popup used its own local filesystem scanner for skill folders. That scanner only knew about normal user/workspace skill directories, so plugin-packaged skills could be installed on disk and still not appear in the skills UI. Separately, the VS Code runtime user-instruction watcher was not explicitly configured to include plugin skill directories, so even if a skill existed in an installed plugin, slash-command expansion could still miss it.

The approach here is to keep plugin skill discovery owned by core/SDK code instead of adding another VS Code-only plugin scanner:

- `CoreSettingsService.list()` now creates its user-instruction service with plugin skill discovery enabled, then maps skill records back to owning plugin paths using the existing plugin config loader helpers.
- Core settings items now carry optional `pluginName` / `pluginPath` metadata so clients can distinguish plugin-owned skills from normal user/workspace skills.
- VS Code `refreshSkills` now asks `createCoreSettingsService().list({ workspaceRoot })` for skills rather than scanning directories and parsing `SKILL.md` locally.
- VS Code's runtime user-instruction service now includes plugin skills, matching the behavior already used by CLI runtime startup.
- Marketplace plugin/skill install and plugin enable/disable invalidate the cached VS Code user-instruction service so newly available plugin skills are not hidden by a stale watcher.

A few things were intentionally left alone after reviewing the CLI settings implementation:

- The generic user-instruction config loader default was not changed. Plugin skills remain opt-in for callers that need them.
- CLI, hub dashboard, connector adapters, and old storage helpers were not changed in this PR.
- The CLI settings dialog already has its own plugin-aware settings loader. Long term, CLI could move onto `CoreSettingsService`, but doing that here would broaden the change beyond the VS Code bug.

### Test Procedure

Ran targeted checks for the affected core and VS Code paths:

- `bunx vitest run src/settings/settings-service.test.ts --config vitest.config.ts` from `sdk/packages/core`
- `bun -F @cline/core typecheck`
- `bun -F claude-dev check-types`
- Targeted Biome checks for the changed core and VS Code files

I also traced the relevant paths manually:

- VS Code skills popup: webview calls `FileServiceClient.refreshSkills`, controller calls `createCoreSettingsService().list`, returned skills are split into global/workspace groups.
- VS Code runtime slash expansion: `SdkController.ensureUserInstructionService` creates a user-instruction service with `includePluginSkills: true`, so plugin-bundled skills can resolve as runtime commands.
- Marketplace install/toggle: plugin/skill installs and plugin enable/disable clear the cached user-instruction service before future resolution.
- CLI comparison: CLI runtime already enables plugin skills, and CLI settings already maps plugin-owned skills using `resolvePluginSkillDirectoriesFromPaths`; this PR mirrors that behavior through core settings for VS Code rather than duplicating the old VS Code scanner.

Potentially affected behavior: legacy VS Code skills toggle state. The UI now trusts the core/frontmatter `disabled` state instead of overlaying the old `globalSkillsToggles` / `localSkillsToggles` maps during refresh. This should be correct because `toggleSkill` already persists the enabled state into `SKILL.md` frontmatter, which is what the SDK runtime uses.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not included. This is a settings/discovery fix; the UI uses the existing skills popup rows.

### Additional Notes

The branch was rebased onto `origin/main` before PR creation so the PR diff contains only the intended seven files.
