### PR TITLE
fix(vscode): rename user message reset actions

### DIFF
--- a/apps/vscode/webview-ui/src/components/chat/UserMessage.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/UserMessage.tsx
@@ -131,9 +131,7 @@ const UserMessage: React.FC<UserMessageProps> = ({ text, images, files, messageT
 						</button>
 						<div className="flex items-center gap-1.5">
 							<Tooltip>
-								<TooltipContent side="top">
-									Regenerate from this edited message without changing files.
-								</TooltipContent>
+								<TooltipContent side="top">Rewind conversation, keep current code edits</TooltipContent>
 								<TooltipTrigger asChild>
 									<span className="inline-flex shrink-0">
 										<button
@@ -141,16 +139,14 @@ const UserMessage: React.FC<UserMessageProps> = ({ text, images, files, messageT
 											disabled={!!savingMode}
 											onClick={() => handleSave(false)}
 											type="button">
-											{savingMode === "chat" ? "Running..." : "Regenerate"}
+											{savingMode === "chat" ? "Running..." : "Reset Chat"}
 										</button>
 									</span>
 								</TooltipTrigger>
 							</Tooltip>
 							{canRestoreWorkspace && (
 								<Tooltip>
-									<TooltipContent side="top">
-										Restore workspace files to this checkpoint, then regenerate.
-									</TooltipContent>
+									<TooltipContent side="top">Rewind conversation, reset code edits</TooltipContent>
 									<TooltipTrigger asChild>
 										<span className="inline-flex shrink-0">
 											<button
@@ -158,7 +154,7 @@ const UserMessage: React.FC<UserMessageProps> = ({ text, images, files, messageT
 												disabled={!!savingMode}
 												onClick={() => handleSave(true)}
 												type="button">
-												{savingMode === "workspace" ? "Restoring..." : "Restore + Run"}
+												{savingMode === "workspace" ? "Restoring..." : "Reset Code"}
 											</button>
 										</span>
 									</TooltipTrigger>

--- a/apps/vscode/webview-ui/src/components/chat/__tests__/UserMessage.ime.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/__tests__/UserMessage.ime.test.tsx
@@ -5,8 +5,9 @@
  * even if you confirm the IME conversion (Enter) in message re-edit mode.
  */
 
-import { fireEvent, render, screen } from "@testing-library/react"
-import { describe, expect, it, vi } from "vitest"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
 vi.mock("@/context/ExtensionStateContext", () => ({
 	__esModule: true,
@@ -16,9 +17,29 @@ vi.mock("@/context/ExtensionStateContext", () => ({
 	}),
 }))
 
+vi.mock("@/services/grpc-client", () => ({
+	TaskServiceClient: {
+		editMessageAndRegenerate: vi.fn(),
+	},
+}))
+
+import { TaskServiceClient } from "@/services/grpc-client"
 import UserMessage from "../UserMessage"
 
 describe("UserMessage – IME composition handling", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		vi.stubGlobal(
+			"ResizeObserver",
+			class ResizeObserver {
+				observe() {}
+				unobserve() {}
+				disconnect() {}
+			},
+		)
+		vi.mocked(TaskServiceClient.editMessageAndRegenerate).mockResolvedValue({})
+	})
+
 	it("does NOT send when IME composition Enter is pressed while editing", () => {
 		const sendMessageFromChatRow = vi.fn()
 
@@ -61,5 +82,40 @@ describe("UserMessage – IME composition handling", () => {
 		} finally {
 			window.removeEventListener("keydown", onWindowKeyDown)
 		}
+	})
+
+	it("labels reset actions and preserves their restore behavior", async () => {
+		const user = userEvent.setup()
+		render(<UserMessage files={["src/app.ts"]} images={["image.png"]} messageTs={123} text="Update this" />)
+
+		await user.click(screen.getByText("Update this"))
+
+		expect(screen.getByRole("button", { name: "Reset Chat" })).toBeInTheDocument()
+		expect(screen.getByRole("button", { name: "Reset Code" })).toBeInTheDocument()
+
+		await user.click(screen.getByRole("button", { name: "Reset Chat" }))
+		await waitFor(() => expect(TaskServiceClient.editMessageAndRegenerate).toHaveBeenCalledTimes(1))
+		expect(TaskServiceClient.editMessageAndRegenerate).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				messageTs: 123,
+				text: "Update this",
+				images: ["image.png"],
+				files: ["src/app.ts"],
+				restoreWorkspace: false,
+			}),
+		)
+
+		await user.click(screen.getByText("Update this"))
+		await user.click(screen.getByRole("button", { name: "Reset Code" }))
+		await waitFor(() => expect(TaskServiceClient.editMessageAndRegenerate).toHaveBeenCalledTimes(2))
+		expect(TaskServiceClient.editMessageAndRegenerate).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				messageTs: 123,
+				text: "Update this",
+				images: ["image.png"],
+				files: ["src/app.ts"],
+				restoreWorkspace: true,
+			}),
+		)
 	})
 })


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This PR updates the copy for the two actions shown when editing a previous user message in the VS Code webview transcript.

The previous labels, `Regenerate` and `Restore + Run`, described the implementation but did not clearly distinguish the two reset behaviors. The new labels make the outcome explicit:

- `Reset Chat` rewinds the conversation from the edited message while keeping current code edits in place.
- `Reset Code` rewinds the conversation and restores code edits from the corresponding checkpoint.

Technically this keeps the existing behavior unchanged. The first button still calls `editMessageAndRegenerate` with `restoreWorkspace: false`, and the second still calls it with `restoreWorkspace: true`. Only the visible button labels and tooltip copy changed.

While preparing the PR, I found this worktree was based on a commit that was not current `main`, so I rebased the single copy-change commit onto the freshly fetched `origin/main`. That keeps the PR diff limited to `UserMessage.tsx` and its focused test.

### Test Procedure

Ran the focused webview component test:

```sh
bunx vitest run src/components/chat/__tests__/UserMessage.ime.test.tsx
```

Result: 3 tests passed.

Ran Biome on the touched files:

```sh
bunx biome check --config-path ../biome.jsonc src/components/chat/UserMessage.tsx src/components/chat/__tests__/UserMessage.ime.test.tsx --diagnostic-level=error
```

Result: checked 2 files with no fixes applied.

The added regression test verifies that both new labels render and that the behavior flags remain correct: `Reset Chat` sends `restoreWorkspace: false`, and `Reset Code` sends `restoreWorkspace: true`.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. This is a small copy-only change to existing inline edit action buttons.

### Additional Notes

Full repository test, format, and lint commands were not run. The focused Vitest file and targeted Biome check for the touched files passed locally.
