### PR TITLE
feat: add shared marketplace uninstall support

### DIFF
--- a/apps/cline-hub/src/server/marketplace.test.ts
+++ b/apps/cline-hub/src/server/marketplace.test.ts
@@ -51,6 +51,36 @@ describe("marketplace installer", () => {
 		vi.restoreAllMocks();
 	});
 
+	function createInstalledOfficialPlugin(
+		clineDir: string,
+		slug: string,
+	): string {
+		const sourceKey = `official:https://github.com/cline/plugins.git#plugins/${slug}`;
+		const hash = createHash("sha256")
+			.update(sourceKey)
+			.digest("hex")
+			.slice(0, 12);
+		const installPath = join(
+			clineDir,
+			"plugins",
+			"_installed",
+			"official",
+			`${slug}-${hash}`,
+		);
+		mkdirSync(join(installPath, "package"), { recursive: true });
+		writeFileSync(
+			join(installPath, "package.json"),
+			JSON.stringify({ name: slug }, null, 2),
+			"utf8",
+		);
+		writeFileSync(
+			join(installPath, "package", "index.ts"),
+			`export default { name: "${slug}", manifest: { capabilities: ["tools"] } };`,
+			"utf8",
+		);
+		return installPath;
+	}
+
 	it("maps remote MCP catalog args to MCP settings shape", () => {
 		expect(
 			buildMarketplaceMcpInput([
@@ -535,16 +565,13 @@ describe("marketplace installer", () => {
 		]);
 	});
 
-	it("runs official plugin uninstalls through the current Cline CLI", async () => {
-		process.env.CLINE_WRAPPER_PATH = "/usr/local/bin/cline";
+	it("uninstalls official marketplace plugins through the shared core service", async () => {
+		const clineDir = mkdtempSync(join(tmpdir(), "cline-marketplace-plugin-"));
+		process.env.CLINE_DIR = clineDir;
+		const installPath = createInstalledOfficialPlugin(clineDir, "goal");
 		const spawnCommand = vi.fn(async () => ({
 			exitCode: 0,
-			stdout: JSON.stringify({
-				name: "goal",
-				installPath: "/tmp/plugin",
-				removedPaths: ["/tmp/plugin"],
-				entryPaths: [],
-			}),
+			stdout: "",
 			stderr: "",
 		}));
 
@@ -565,12 +592,8 @@ describe("marketplace installer", () => {
 			message: "Uninstalled Goal.",
 		});
 
-		expect(spawnCommand).toHaveBeenCalledWith("/usr/local/bin/cline", [
-			"plugin",
-			"uninstall",
-			"goal",
-			"--json",
-		]);
+		expect(spawnCommand).not.toHaveBeenCalled();
+		expect(existsSync(installPath)).toBe(false);
 	});
 
 	it("resolves desktop installs from the server catalog instead of browser-sent args", async () => {
@@ -614,15 +637,12 @@ describe("marketplace installer", () => {
 	});
 
 	it("resolves desktop uninstalls from the server catalog instead of browser-sent args", async () => {
-		process.env.CLINE_WRAPPER_PATH = "/usr/local/bin/cline";
+		const clineDir = mkdtempSync(join(tmpdir(), "cline-marketplace-plugin-"));
+		process.env.CLINE_DIR = clineDir;
+		const installPath = createInstalledOfficialPlugin(clineDir, "goal");
 		const spawnCommand = vi.fn(async () => ({
 			exitCode: 0,
-			stdout: JSON.stringify({
-				name: "goal",
-				installPath: "/tmp/plugin",
-				removedPaths: ["/tmp/plugin"],
-				entryPaths: [],
-			}),
+			stdout: "",
 			stderr: "",
 		}));
 
@@ -650,12 +670,8 @@ describe("marketplace installer", () => {
 			},
 		);
 
-		expect(spawnCommand).toHaveBeenCalledWith("/usr/local/bin/cline", [
-			"plugin",
-			"uninstall",
-			"goal",
-			"--json",
-		]);
+		expect(spawnCommand).not.toHaveBeenCalled();
+		expect(existsSync(installPath)).toBe(false);
 	});
 
 	it("uninstalls MCP marketplace entries from Cline MCP settings", async () => {

--- a/apps/cline-hub/src/server/marketplace.ts
+++ b/apps/cline-hub/src/server/marketplace.ts
@@ -18,8 +18,11 @@ import {
 	resolve,
 } from "node:path";
 import {
+	type MarketplaceActionResult,
+	type MarketplaceEntryInput,
 	resolveSkillsConfigSearchPaths,
 	resolveWorkflowsConfigSearchPaths,
+	uninstallMarketplaceEntry as uninstallCoreMarketplaceEntry,
 	uninstallPlugin as uninstallLocalPlugin,
 } from "@cline/core";
 import { resolveClineDir } from "@cline/shared/storage";
@@ -792,50 +795,6 @@ async function installSkill(
 	};
 }
 
-async function uninstallSkill(
-	entry: MarketplaceInstallInput,
-	spawnCommand: SpawnCommand,
-): Promise<MarketplaceInstallResult> {
-	const installedName = findInstalledGlobalSkillName(entry);
-	if (!installedName) {
-		return {
-			id: entry.id,
-			type: entry.type,
-			status: "uninstalled",
-			message: `${entry.name ?? entry.id} is not installed.`,
-		};
-	}
-	const result = await spawnCommand("npx", [
-		"-y",
-		"skills@latest",
-		"remove",
-		installedName,
-		"-g",
-		"-a",
-		"cline",
-		"-y",
-	]);
-	if (result.exitCode !== 0) {
-		const output = commandOutput(result);
-		throw new Error(
-			`Skill uninstall failed with exit code ${result.exitCode}${output ? `:\n${output}` : ""}`,
-		);
-	}
-	const output = commandOutput(result);
-	if (isGlobalSkillInstalled(entry)) {
-		throw new Error(
-			`Skill uninstall completed, but ${entry.name ?? entry.id} is still present in Cline's global skills directories.`,
-		);
-	}
-	return {
-		id: entry.id,
-		type: entry.type,
-		status: "uninstalled",
-		message: `Uninstalled ${entry.name ?? entry.id}.`,
-		output,
-	};
-}
-
 async function installPlugin(
 	entry: MarketplaceInstallInput,
 	spawnCommand: SpawnCommand,
@@ -881,47 +840,6 @@ async function installPlugin(
 		type: entry.type,
 		status: "installed",
 		message: `Installed ${entry.name ?? entry.id}.`,
-		details,
-		output: commandOutput(result),
-	};
-}
-
-async function uninstallPlugin(
-	entry: MarketplaceInstallInput,
-	spawnCommand: SpawnCommand,
-): Promise<MarketplaceInstallResult> {
-	const installArgs = entry.install.args ?? [];
-	const target = installArgs[0]?.trim() || entry.id;
-	if (!target) {
-		throw new Error("Plugin marketplace uninstalls require a plugin name.");
-	}
-	const { command, argsPrefix } = resolveClineInvocation();
-	const result = await spawnCommand(command, [
-		...argsPrefix,
-		"plugin",
-		"uninstall",
-		target,
-		"--json",
-	]);
-	if (result.exitCode !== 0) {
-		const output = commandOutput(result);
-		throw new Error(
-			`Plugin uninstall failed with exit code ${result.exitCode}${output ? `:\n${output}` : ""}`,
-		);
-	}
-	let details: JsonRecord | undefined;
-	try {
-		details = result.stdout.trim()
-			? (JSON.parse(result.stdout.trim()) as JsonRecord)
-			: undefined;
-	} catch {
-		details = undefined;
-	}
-	return {
-		id: entry.id,
-		type: entry.type,
-		status: "uninstalled",
-		message: `Uninstalled ${entry.name ?? entry.id}.`,
 		details,
 		output: commandOutput(result),
 	};
@@ -983,24 +901,21 @@ export async function uninstallMarketplaceEntry(
 ): Promise<MarketplaceInstallResult> {
 	const entry = readInstallInput(args);
 	const spawnCommand = options.spawnCommand ?? defaultSpawnCommand;
-	if (entry.type === "mcp") {
-		const input = buildMarketplaceMcpInput(entry.install.args ?? []);
-		const response = deleteMcpServer(String(input.name ?? ""));
-		return {
-			id: entry.id,
-			type: entry.type,
-			status: "uninstalled",
-			message: `Uninstalled ${entry.name ?? input.name ?? entry.id}.`,
-			details: { mcp: response },
-		};
-	}
-	if (entry.type === "skill") {
-		return uninstallSkill(entry, spawnCommand);
-	}
-	if (entry.type === "plugin") {
-		return uninstallPlugin(entry, spawnCommand);
-	}
-	throw new Error(`Unsupported marketplace entry type: ${entry.type}`);
+	let mcpDetails: JsonRecord | undefined;
+	const result = await uninstallCoreMarketplaceEntry(
+		entry satisfies MarketplaceEntryInput,
+		{
+			deleteMcpServer: (name) => {
+				mcpDetails = deleteMcpServer(name);
+			},
+			spawnCommand: (command, commandArgs) =>
+				spawnCommand(command, commandArgs),
+		},
+	);
+	return {
+		...(result satisfies MarketplaceActionResult),
+		details: mcpDetails ? { mcp: mcpDetails } : undefined,
+	};
 }
 
 export async function installMarketplaceEntryFromCatalog(

--- a/apps/vscode/proto/cline/marketplace.proto
+++ b/apps/vscode/proto/cline/marketplace.proto
@@ -13,7 +13,9 @@ service MarketplaceService {
   rpc listMarketplaceLocalInstalledEntries(EmptyRequest) returns (MarketplaceLocalInstalledEntries);
   rpc listMarketplaceInstalledEntries(MarketplaceEntriesRequest) returns (MarketplaceInstalledEntries);
   rpc installMarketplaceEntry(MarketplaceEntryRequest) returns (MarketplaceInstallResult);
+  rpc uninstallMarketplaceEntry(MarketplaceEntryRequest) returns (MarketplaceInstallResult);
   rpc toggleMarketplaceLocalInstalledEntry(ToggleMarketplaceLocalInstalledEntryRequest) returns (MarketplaceLocalInstalledEntries);
+  rpc uninstallMarketplaceLocalInstalledEntry(MarketplaceLocalInstalledEntryRequest) returns (MarketplaceInstallResult);
 }
 
 message MarketplaceTag {
@@ -85,6 +87,10 @@ message MarketplaceLocalInstalledEntries {
 message ToggleMarketplaceLocalInstalledEntryRequest {
   MarketplaceLocalInstalledEntry entry = 1;
   bool enabled = 2;
+}
+
+message MarketplaceLocalInstalledEntryRequest {
+  MarketplaceLocalInstalledEntry entry = 1;
 }
 
 message MarketplaceEntryRequest {

--- a/apps/vscode/src/core/controller/marketplace/marketplace-helpers.ts
+++ b/apps/vscode/src/core/controller/marketplace/marketplace-helpers.ts
@@ -596,9 +596,10 @@ export async function uninstallLocalMarketplaceInstalledEntry(
 		})
 	}
 	if (entry.type === "skill") {
-		if (!entry.path || entry.path.startsWith("remote:")) {
+		if (entry.path?.startsWith("remote:")) {
 			throw new Error("Remote-managed skills cannot be uninstalled from Customize.")
 		}
+		if (!entry.path) throw new Error("Skill path is required for uninstall.")
 		await deleteSkillFile(
 			controller,
 			DeleteSkillRequest.create({
@@ -606,6 +607,7 @@ export async function uninstallLocalMarketplaceInstalledEntry(
 				isGlobal: entry.source === "global",
 			}),
 		)
+		await controller.invalidateUserInstructionService()
 		return MarketplaceInstallResult.create({
 			id: entry.id,
 			type: entry.type,

--- a/apps/vscode/src/core/controller/marketplace/marketplace-helpers.ts
+++ b/apps/vscode/src/core/controller/marketplace/marketplace-helpers.ts
@@ -8,16 +8,23 @@ import {
 	discoverPluginModulePaths,
 	installMcpServer,
 	installPlugin,
+	isMarketplaceSkillInstalled,
+	type MarketplaceActionResult,
+	type MarketplaceEntryInput,
+	type MarketplacePrimitiveType,
 	parseMcpInstallArgs,
 	readGlobalSettings,
 	resolvePluginConfigSearchPaths,
 	setDisabledPlugin,
 	syncPluginMcpServersToSettings,
+	uninstallMarketplaceEntry as uninstallCoreMarketplaceEntry,
+	uninstallPlugin,
 } from "@cline/core"
+import { deleteSkillFile } from "@core/controller/file/deleteSkillFile"
 import { refreshSkills } from "@core/controller/file/refreshSkills"
 import { toggleSkill } from "@core/controller/file/toggleSkill"
 import { resolveActiveModelIdFromApiConfiguration } from "@core/controller/models/taskApiModel"
-import { ToggleSkillRequest } from "@shared/proto/cline/file"
+import { DeleteSkillRequest, ToggleSkillRequest } from "@shared/proto/cline/file"
 import {
 	MarketplaceCatalog,
 	MarketplaceEntry,
@@ -25,6 +32,7 @@ import {
 	MarketplaceInstallResult,
 	MarketplaceLocalInstalledEntries,
 	MarketplaceLocalInstalledEntry,
+	MarketplaceLocalInstalledEntryRequest,
 	ToggleMarketplaceLocalInstalledEntryRequest,
 } from "@shared/proto/cline/marketplace"
 import { HostProvider } from "@/hosts/host-provider"
@@ -169,31 +177,9 @@ function isOfficialPluginInstalled(entry: MarketplaceEntry): boolean {
 	return existsSync(installPath)
 }
 
-function getSkillCandidates(entry: MarketplaceEntry): string[] {
-	const candidates = new Set([normalizeMatchValue(entry.id), normalizeMatchValue(entry.name)])
-	const args = getEntryArgs(entry)
-	for (let index = 0; index < args.length; index++) {
-		const arg = args[index]
-		if ((arg === "--skill" || arg === "-s") && args[index + 1]) {
-			candidates.add(normalizeMatchValue(args[index + 1]))
-			index++
-			continue
-		}
-		const skillFilter = arg.split("@").at(1)
-		if (skillFilter) candidates.add(normalizeMatchValue(skillFilter))
-	}
-	candidates.delete("")
-	return [...candidates]
-}
-
 function isSkillInstalled(entry: MarketplaceEntry): boolean {
 	if (entry.type !== "skill") return false
-	return getSkillCandidates(entry).some((candidate) =>
-		[
-			join(resolveClineHome(), "skills", candidate, "SKILL.md"),
-			join(homedir(), ".agents", "skills", candidate, "SKILL.md"),
-		].some((path) => existsSync(path)),
-	)
+	return isMarketplaceSkillInstalled(toCoreMarketplaceEntry(entry))
 }
 
 export function listInstalledMarketplaceEntries(
@@ -382,6 +368,44 @@ export async function installMarketplaceEntryFromCatalog(entry: MarketplaceEntry
 	return installSkillMarketplaceEntry(entry, args)
 }
 
+function toCoreMarketplaceEntry(entry: MarketplaceEntry): MarketplaceEntryInput {
+	if (entry.type !== "mcp" && entry.type !== "skill" && entry.type !== "plugin") {
+		throw new Error(`Unsupported marketplace entry type: ${entry.type}`)
+	}
+	return {
+		id: entry.id,
+		type: entry.type as MarketplacePrimitiveType,
+		name: entry.name,
+		install: {
+			args: getEntryArgs(entry),
+		},
+	}
+}
+
+function toProtoMarketplaceInstallResult(result: MarketplaceActionResult): MarketplaceInstallResult {
+	return MarketplaceInstallResult.create({
+		id: result.id,
+		type: result.type,
+		status: result.status,
+		message: result.message,
+		output: result.output,
+	})
+}
+
+export async function uninstallMarketplaceEntryFromCatalog(
+	controller: Controller,
+	entry: MarketplaceEntry,
+): Promise<MarketplaceInstallResult> {
+	const workspaceRoot = await getWorkspacePath()
+	const result = await uninstallCoreMarketplaceEntry(toCoreMarketplaceEntry(entry), {
+		deleteMcpServer: async (name) => {
+			await controller.mcpHub?.deleteServerRPC(name)
+		},
+		workspaceRoot,
+	})
+	return toProtoMarketplaceInstallResult(result)
+}
+
 function readPackageName(packageJsonPath: string): string | undefined {
 	try {
 		const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as { name?: unknown }
@@ -447,7 +471,6 @@ export async function listLocalMarketplaceInstalledEntries(controller: Controlle
 			type: "mcp",
 			name: server.name,
 			description: server.status,
-			path: server.config,
 			enabled: server.disabled !== true,
 		}),
 	)
@@ -530,6 +553,12 @@ export async function toggleLocalMarketplaceInstalledEntry(
 ): Promise<MarketplaceLocalInstalledEntries> {
 	const { entry, enabled } = request
 	if (!entry) throw new Error("Installed marketplace entry is required.")
+	if (entry.type === "mcp") {
+		const name = entry.name || entry.id
+		if (!name) throw new Error("MCP server name is required.")
+		await controller.mcpHub?.toggleServerDisabledRPC(name, !enabled)
+		return listLocalMarketplaceInstalledEntries(controller)
+	}
 	if (entry.type === "skill") {
 		await toggleSkill(
 			controller,
@@ -547,4 +576,58 @@ export async function toggleLocalMarketplaceInstalledEntry(
 		return listLocalMarketplaceInstalledEntries(controller)
 	}
 	throw new Error(`Marketplace toggle is not supported for ${entry.type}.`)
+}
+
+export async function uninstallLocalMarketplaceInstalledEntry(
+	controller: Controller,
+	request: MarketplaceLocalInstalledEntryRequest,
+): Promise<MarketplaceInstallResult> {
+	const { entry } = request
+	if (!entry) throw new Error("Installed marketplace entry is required.")
+	const name = entry.name || entry.id
+	if (entry.type === "mcp") {
+		if (!name) throw new Error("MCP server name is required.")
+		await controller.mcpHub?.deleteServerRPC(name)
+		return MarketplaceInstallResult.create({
+			id: entry.id,
+			type: entry.type,
+			status: "uninstalled",
+			message: `Uninstalled ${name}.`,
+		})
+	}
+	if (entry.type === "skill") {
+		if (!entry.path || entry.path.startsWith("remote:")) {
+			throw new Error("Remote-managed skills cannot be uninstalled from Customize.")
+		}
+		await deleteSkillFile(
+			controller,
+			DeleteSkillRequest.create({
+				skillPath: entry.path,
+				isGlobal: entry.source === "global",
+			}),
+		)
+		return MarketplaceInstallResult.create({
+			id: entry.id,
+			type: entry.type,
+			status: "uninstalled",
+			message: `Uninstalled ${name || entry.id}.`,
+		})
+	}
+	if (entry.type === "plugin") {
+		const workspaceRoot = await getWorkspacePath()
+		const result = await uninstallPlugin({
+			name: entry.path ? undefined : name,
+			path: entry.path,
+			workspaceRoot,
+		})
+		await controller.invalidateUserInstructionService()
+		return MarketplaceInstallResult.create({
+			id: entry.id,
+			type: entry.type,
+			status: "uninstalled",
+			message: `Uninstalled ${result.name}.`,
+			output: [`Path: ${result.installPath}`, ...result.removedPaths.map((path) => `Removed: ${path}`)].join("\n"),
+		})
+	}
+	throw new Error(`Marketplace uninstall is not supported for ${entry.type}.`)
 }

--- a/apps/vscode/src/core/controller/marketplace/uninstallMarketplaceEntry.ts
+++ b/apps/vscode/src/core/controller/marketplace/uninstallMarketplaceEntry.ts
@@ -1,0 +1,17 @@
+import { type MarketplaceEntryRequest, MarketplaceInstallResult } from "@shared/proto/cline/marketplace"
+import type { Controller } from "../index"
+import { uninstallMarketplaceEntryFromCatalog } from "./marketplace-helpers"
+
+export async function uninstallMarketplaceEntry(
+	controller: Controller,
+	request: MarketplaceEntryRequest,
+): Promise<MarketplaceInstallResult> {
+	if (!request.entry) {
+		throw new Error("Marketplace entry is required.")
+	}
+	const result = await uninstallMarketplaceEntryFromCatalog(controller, request.entry)
+	if (request.entry.type === "skill" || request.entry.type === "plugin") {
+		await controller.invalidateUserInstructionService()
+	}
+	return result
+}

--- a/apps/vscode/src/core/controller/marketplace/uninstallMarketplaceLocalInstalledEntry.ts
+++ b/apps/vscode/src/core/controller/marketplace/uninstallMarketplaceLocalInstalledEntry.ts
@@ -1,0 +1,10 @@
+import type { MarketplaceInstallResult, MarketplaceLocalInstalledEntryRequest } from "@shared/proto/cline/marketplace"
+import type { Controller } from "../index"
+import { uninstallLocalMarketplaceInstalledEntry } from "./marketplace-helpers"
+
+export async function uninstallMarketplaceLocalInstalledEntry(
+	controller: Controller,
+	request: MarketplaceLocalInstalledEntryRequest,
+): Promise<MarketplaceInstallResult> {
+	return uninstallLocalMarketplaceInstalledEntry(controller, request)
+}

--- a/apps/vscode/webview-ui/src/components/marketplace/MarketplaceView.tsx
+++ b/apps/vscode/webview-ui/src/components/marketplace/MarketplaceView.tsx
@@ -949,23 +949,16 @@ const InstalledMarketplaceRow = ({
 
 const CatalogEntryRow = ({
 	entry,
-	installed,
 	installing,
 	onInstall,
-	onUninstall,
-	uninstalling,
 }: {
 	entry: MarketplaceEntry
-	installed: boolean
 	installing: boolean
 	onInstall: (entry: MarketplaceEntry) => void
-	onUninstall: (entry: MarketplaceEntry) => void
-	uninstalling: boolean
 }) => {
 	const summary = setupSummary(entry)
-	const busy = installing || uninstalling
-	const canAct = installArgs(entry).length > 0 && !busy
-	const label = installed ? `Uninstall ${entry.name || entry.id}` : `Install ${entry.name || entry.id}`
+	const canInstall = installArgs(entry).length > 0 && !installing
+	const label = `Install ${entry.name || entry.id}`
 	return (
 		<div className="marketplace-row">
 			<div className="marketplace-row-main">
@@ -984,15 +977,13 @@ const CatalogEntryRow = ({
 			<div className="marketplace-action">
 				<button
 					aria-label={label}
-					className={`marketplace-icon-button${installed ? " marketplace-icon-button-danger" : ""}`}
-					disabled={!canAct}
-					onClick={() => (installed ? onUninstall(entry) : onInstall(entry))}
+					className="marketplace-icon-button"
+					disabled={!canInstall}
+					onClick={() => onInstall(entry)}
 					title={label}
 					type="button">
-					{busy ? (
+					{installing ? (
 						<LoaderCircleIcon aria-hidden className="marketplace-icon-spin" />
-					) : installed ? (
-						<Trash2Icon aria-hidden />
 					) : (
 						<DownloadIcon aria-hidden />
 					)}
@@ -1334,12 +1325,9 @@ const MarketplaceView = ({ initialType = "skill", onDone }: MarketplaceViewProps
 										{visibleCatalogEntries.map((entry) => (
 											<CatalogEntryRow
 												entry={entry}
-												installed={installedKeys.has(entryKey(entry))}
 												installing={installingId === entryKey(entry)}
 												key={entryKey(entry)}
 												onInstall={handleInstall}
-												onUninstall={handleUninstallMarketplace}
-												uninstalling={uninstallingId === entryKey(entry)}
 											/>
 										))}
 									</MarketplaceCatalogSection>

--- a/apps/vscode/webview-ui/src/components/marketplace/MarketplaceView.tsx
+++ b/apps/vscode/webview-ui/src/components/marketplace/MarketplaceView.tsx
@@ -180,34 +180,40 @@ const MarketplaceStyles = () => (
 		.marketplace-shell {
 			min-height: 0;
 			display: flex;
+			flex-direction: column;
 			flex: 1;
 		}
 
 		.marketplace-nav {
-			width: 148px;
-			flex: 0 0 148px;
-			overflow-y: auto;
-			border-right: 1px solid var(--vscode-panel-border);
+			flex: 0 0 auto;
+			display: flex;
+			align-items: center;
+			min-width: 0;
+			overflow-x: auto;
+			overflow-y: hidden;
+			border-bottom: 1px solid var(--vscode-panel-border);
 			background: var(--vscode-sideBar-background);
-			padding: 4px 0;
+			padding: 0 8px;
 		}
 
 		.marketplace-tab {
-			width: 100%;
+			width: auto;
+			flex: 0 1 auto;
+			min-width: fit-content;
 			height: 34px;
 			border: 0;
-			border-left: 2px solid transparent;
+			border-bottom: 2px solid transparent;
 			background: transparent;
 			color: var(--vscode-descriptionForeground);
 			font: inherit;
 			font-size: var(--vscode-font-size);
 			display: flex;
 			align-items: center;
+			justify-content: center;
 			gap: 8px;
-			padding: 0 10px;
-			text-align: left;
+			padding: 0 12px;
+			text-align: center;
 			cursor: pointer;
-			min-width: 0;
 		}
 
 		.marketplace-tab:hover {
@@ -218,7 +224,7 @@ const MarketplaceStyles = () => (
 		.marketplace-tab[aria-selected="true"] {
 			background: var(--vscode-list-activeSelectionBackground);
 			color: var(--vscode-list-activeSelectionForeground);
-			border-left-color: var(--vscode-list-activeSelectionForeground, var(--vscode-foreground));
+			border-bottom-color: var(--vscode-list-activeSelectionForeground, var(--vscode-foreground));
 		}
 
 		.marketplace-tab-label {
@@ -619,35 +625,15 @@ const MarketplaceStyles = () => (
 		}
 
 		@media (max-width: 520px) {
-			.marketplace-shell {
-				flex-direction: column;
-			}
-
 			.marketplace-nav {
-				width: auto;
-				flex: 0 0 auto;
-				display: flex;
-				flex-wrap: nowrap;
-				overflow: visible;
-				border-right: 0;
-				border-bottom: 1px solid var(--vscode-panel-border);
 				padding: 0 4px;
 			}
 
 			.marketplace-tab {
-				width: auto;
 				flex: 1 1 0;
 				min-width: 0;
-				justify-content: center;
-				border-left: 0;
-				border-bottom: 2px solid transparent;
 				gap: 5px;
 				padding: 0 6px;
-			}
-
-			.marketplace-tab[aria-selected="true"] {
-				border-bottom-color: var(--vscode-list-activeSelectionForeground, var(--vscode-foreground));
-				border-left-color: transparent;
 			}
 
 			.marketplace-inner {
@@ -963,7 +949,6 @@ const CatalogEntryRow = ({
 		<div className="marketplace-row">
 			<div className="marketplace-row-main">
 				<div className="marketplace-row-title">
-					{installed && <CheckIcon aria-hidden className="h-3.5 w-3.5" />}
 					<span className="marketplace-row-name">{entry.name || entry.id}</span>
 				</div>
 				{(entry.description || entry.tagline) && (

--- a/apps/vscode/webview-ui/src/components/marketplace/MarketplaceView.tsx
+++ b/apps/vscode/webview-ui/src/components/marketplace/MarketplaceView.tsx
@@ -4,6 +4,7 @@ import {
 	type MarketplaceEntry,
 	MarketplaceEntryRequest,
 	type MarketplaceLocalInstalledEntry,
+	MarketplaceLocalInstalledEntryRequest,
 	ToggleMarketplaceLocalInstalledEntryRequest,
 } from "@shared/proto/cline/marketplace"
 import { VSCodeButton, VSCodeLink, VSCodeProgressRing, VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
@@ -15,6 +16,7 @@ import {
 	PlugIcon,
 	PuzzleIcon,
 	SparklesIcon,
+	Trash2Icon,
 } from "lucide-react"
 import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react"
 import { Switch } from "@/components/ui/switch"
@@ -23,7 +25,8 @@ import { MarketplaceServiceClient, McpServiceClient } from "@/services/grpc-clie
 import { Tab, TabContent, TabList, TabTrigger } from "../common/Tab"
 import ViewHeader from "../common/ViewHeader"
 import AddRemoteServerForm from "../mcp/configuration/tabs/add-server/AddRemoteServerForm"
-import ServersToggleList from "../mcp/configuration/tabs/installed/ServersToggleList"
+import ServersToggleList, { type MarketplaceMcpMetadata } from "../mcp/configuration/tabs/installed/ServersToggleList"
+import { entryMatchesLocalEntry, localEntryKey } from "./marketplaceMatch"
 
 type PrimitiveType = "mcp" | "skill" | "plugin"
 type MarketplaceSectionType = "installed" | "marketplace"
@@ -324,7 +327,7 @@ const MarketplaceStyles = () => (
 
 		.marketplace-row {
 			display: grid;
-			grid-template-columns: minmax(0, 1fr) 26px;
+			grid-template-columns: minmax(0, 1fr) auto;
 			gap: 10px;
 			align-items: start;
 			min-height: 42px;
@@ -417,7 +420,9 @@ const MarketplaceStyles = () => (
 
 		.marketplace-action {
 			display: flex;
+			gap: 6px;
 			justify-content: flex-end;
+			align-items: center;
 		}
 
 		.marketplace-local-toggle {
@@ -454,6 +459,10 @@ const MarketplaceStyles = () => (
 		.marketplace-icon-button:disabled {
 			cursor: default;
 			opacity: 0.65;
+		}
+
+		.marketplace-icon-button-danger {
+			color: var(--vscode-errorForeground, var(--vscode-icon-foreground));
 		}
 
 		.marketplace-icon-button svg {
@@ -548,16 +557,14 @@ const MarketplaceStyles = () => (
 		}
 
 		.marketplace-mcp-panel {
-			border: 1px solid var(--vscode-panel-border);
-			background: var(--vscode-sideBar-background);
-			padding: 10px;
+			display: grid;
+			gap: 10px;
 		}
 
 		.marketplace-mcp-managed {
 			display: flex;
 			align-items: center;
 			gap: 8px;
-			margin-bottom: 10px;
 			padding: 8px 10px;
 			border-left: 3px solid var(--vscode-textLink-foreground);
 			background: var(--vscode-textBlockQuote-background);
@@ -620,7 +627,7 @@ const MarketplaceStyles = () => (
 				width: auto;
 				flex: 0 0 auto;
 				display: flex;
-				flex-wrap: wrap;
+				flex-wrap: nowrap;
 				overflow: visible;
 				border-right: 0;
 				border-bottom: 1px solid var(--vscode-panel-border);
@@ -629,11 +636,13 @@ const MarketplaceStyles = () => (
 
 			.marketplace-tab {
 				width: auto;
-				flex: 1 1 96px;
-				min-width: 96px;
+				flex: 1 1 0;
+				min-width: 0;
+				justify-content: center;
 				border-left: 0;
 				border-bottom: 2px solid transparent;
-				padding: 0 10px;
+				gap: 5px;
+				padding: 0 6px;
 			}
 
 			.marketplace-tab[aria-selected="true"] {
@@ -741,7 +750,15 @@ const TagFilters = ({
 	)
 }
 
-const McpManagementPanel = ({ showHeader = true }: { showHeader?: boolean }) => {
+const McpManagementPanel = ({
+	marketplaceMetadataByServerName,
+	showHeader = true,
+	showServerList = true,
+}: {
+	marketplaceMetadataByServerName?: Map<string, MarketplaceMcpMetadata>
+	showHeader?: boolean
+	showServerList?: boolean
+}) => {
 	const { mcpServers, navigateToSettings, remoteConfigSettings } = useExtensionState()
 	const [showAddRemote, setShowAddRemote] = useState(false)
 	const showRemoteServers = remoteConfigSettings?.blockPersonalRemoteMCPServers !== true
@@ -754,15 +771,25 @@ const McpManagementPanel = ({ showHeader = true }: { showHeader?: boolean }) => 
 					<h3 className="marketplace-section-title">Installed MCP Servers</h3>
 				</div>
 			)}
-			<div className="marketplace-mcp-panel">
-				{hasRemoteMCPServers && (
-					<div className="marketplace-mcp-managed">
-						<span className="codicon codicon-lock" />
-						<span>Your organization manages some MCP servers</span>
-					</div>
-				)}
-				<ServersToggleList hasTrashIcon={false} isExpandable={true} listGap="small" servers={mcpServers} />
-			</div>
+			{(showServerList || hasRemoteMCPServers) && (
+				<div className="marketplace-mcp-panel">
+					{hasRemoteMCPServers && (
+						<div className="marketplace-mcp-managed">
+							<span className="codicon codicon-lock" />
+							<span>Your organization manages some MCP servers</span>
+						</div>
+					)}
+					{showServerList && (
+						<ServersToggleList
+							hasTrashIcon={true}
+							isExpandable={true}
+							listGap="small"
+							marketplaceMetadataByServerName={marketplaceMetadataByServerName}
+							servers={mcpServers}
+						/>
+					)}
+				</div>
+			)}
 			<div className="marketplace-mcp-settings">
 				{showRemoteServers && !showAddRemote && (
 					<VSCodeButton appearance="primary" onClick={() => setShowAddRemote(true)}>
@@ -799,14 +826,19 @@ const McpManagementPanel = ({ showHeader = true }: { showHeader?: boolean }) => 
 
 const LocalInstalledRow = ({
 	entry,
+	onUninstall,
 	onToggle,
 	toggling,
+	uninstalling,
 }: {
 	entry: MarketplaceLocalInstalledEntry
+	onUninstall: (entry: MarketplaceLocalInstalledEntry) => void
 	onToggle: (entry: MarketplaceLocalInstalledEntry, enabled: boolean) => void
 	toggling: boolean
+	uninstalling: boolean
 }) => {
 	const origin = sourceLabel(entry)
+	const canUninstall = !(entry.type === "skill" && entry.path?.startsWith("remote:"))
 	return (
 		<div className="marketplace-row">
 			<div className="marketplace-row-main">
@@ -819,7 +851,7 @@ const LocalInstalledRow = ({
 					{entry.path && <span className="marketplace-path">{entry.path}</span>}
 				</div>
 			</div>
-			<div className="marketplace-local-toggle">
+			<div className="marketplace-action">
 				<Switch
 					aria-label={`${entry.enabled ? "Disable" : "Enable"} ${entry.name || entry.id}`}
 					checked={entry.enabled}
@@ -827,6 +859,89 @@ const LocalInstalledRow = ({
 					onClick={() => onToggle(entry, !entry.enabled)}
 					title={`${entry.enabled ? "Disable" : "Enable"} ${entry.name || entry.id}`}
 				/>
+				<button
+					aria-label={`Uninstall ${entry.name || entry.id}`}
+					className="marketplace-icon-button marketplace-icon-button-danger"
+					disabled={uninstalling || !canUninstall}
+					onClick={() => onUninstall(entry)}
+					title={
+						canUninstall ? `Uninstall ${entry.name || entry.id}` : "Remote-managed skills cannot be uninstalled here"
+					}
+					type="button">
+					{uninstalling ? (
+						<LoaderCircleIcon aria-hidden className="marketplace-icon-spin" />
+					) : (
+						<Trash2Icon aria-hidden />
+					)}
+				</button>
+			</div>
+		</div>
+	)
+}
+
+const InstalledMarketplaceRow = ({
+	entry,
+	matchedLocalEntries,
+	onToggle,
+	onUninstall,
+	togglingLocalId,
+	uninstalling,
+}: {
+	entry: MarketplaceEntry
+	matchedLocalEntries: MarketplaceLocalInstalledEntry[]
+	onToggle: (entry: MarketplaceLocalInstalledEntry, enabled: boolean) => void
+	onUninstall: (entry: MarketplaceEntry) => void
+	togglingLocalId: string | null
+	uninstalling: boolean
+}) => {
+	const primaryLocalEntry = matchedLocalEntries[0]
+	const label = `Uninstall ${entry.name || entry.id}`
+	return (
+		<div className="marketplace-row">
+			<div className="marketplace-row-main">
+				<div className="marketplace-row-title">
+					<CheckIcon aria-hidden className="h-3.5 w-3.5" />
+					<span className="marketplace-row-name">{entry.name || entry.id}</span>
+				</div>
+				{(entry.description || entry.tagline) && (
+					<div className="marketplace-row-description">{entry.description || entry.tagline}</div>
+				)}
+				<div className="marketplace-row-meta">
+					<span className="marketplace-pill">Marketplace</span>
+					{matchedLocalEntries.map((localEntry) => {
+						const origin = sourceLabel(localEntry)
+						return (
+							<span className="contents" key={localEntryKey(localEntry)}>
+								{origin && <span className="marketplace-pill">{origin}</span>}
+								{localEntry.path && <span className="marketplace-path">{localEntry.path}</span>}
+							</span>
+						)
+					})}
+				</div>
+			</div>
+			<div className="marketplace-action">
+				{primaryLocalEntry && (
+					<Switch
+						aria-label={`${primaryLocalEntry.enabled ? "Disable" : "Enable"} ${entry.name || entry.id}`}
+						checked={primaryLocalEntry.enabled}
+						disabled={togglingLocalId === localEntryKey(primaryLocalEntry)}
+						onClick={() => onToggle(primaryLocalEntry, !primaryLocalEntry.enabled)}
+						title={`${primaryLocalEntry.enabled ? "Disable" : "Enable"} ${entry.name || entry.id}`}
+					/>
+				)}
+				<button
+					aria-label={label}
+					className="marketplace-icon-button marketplace-icon-button-danger"
+					disabled={uninstalling}
+					onClick={() => onUninstall(entry)}
+					title={label}
+					type="button">
+					{uninstalling ? (
+						<LoaderCircleIcon aria-hidden className="marketplace-icon-spin" />
+					) : (
+						<Trash2Icon aria-hidden />
+					)}
+				</button>
 			</div>
 		</div>
 	)
@@ -837,15 +952,20 @@ const CatalogEntryRow = ({
 	installed,
 	installing,
 	onInstall,
+	onUninstall,
+	uninstalling,
 }: {
 	entry: MarketplaceEntry
 	installed: boolean
 	installing: boolean
 	onInstall: (entry: MarketplaceEntry) => void
+	onUninstall: (entry: MarketplaceEntry) => void
+	uninstalling: boolean
 }) => {
 	const summary = setupSummary(entry)
-	const canInstall = installArgs(entry).length > 0 && !installed && !installing
-	const label = installed ? `${entry.name || entry.id} is installed` : `Install ${entry.name || entry.id}`
+	const busy = installing || uninstalling
+	const canAct = installArgs(entry).length > 0 && !busy
+	const label = installed ? `Uninstall ${entry.name || entry.id}` : `Install ${entry.name || entry.id}`
 	return (
 		<div className="marketplace-row">
 			<div className="marketplace-row-main">
@@ -864,15 +984,15 @@ const CatalogEntryRow = ({
 			<div className="marketplace-action">
 				<button
 					aria-label={label}
-					className="marketplace-icon-button"
-					disabled={!canInstall}
-					onClick={() => onInstall(entry)}
+					className={`marketplace-icon-button${installed ? " marketplace-icon-button-danger" : ""}`}
+					disabled={!canAct}
+					onClick={() => (installed ? onUninstall(entry) : onInstall(entry))}
 					title={label}
 					type="button">
-					{installing ? (
+					{busy ? (
 						<LoaderCircleIcon aria-hidden className="marketplace-icon-spin" />
 					) : installed ? (
-						<CheckIcon aria-hidden />
+						<Trash2Icon aria-hidden />
 					) : (
 						<DownloadIcon aria-hidden />
 					)}
@@ -891,6 +1011,7 @@ const MarketplaceView = ({ initialType = "skill", onDone }: MarketplaceViewProps
 	const [installedKeys, setInstalledKeys] = useState<Set<string>>(new Set())
 	const [installingId, setInstallingId] = useState<string | null>(null)
 	const [togglingLocalId, setTogglingLocalId] = useState<string | null>(null)
+	const [uninstallingId, setUninstallingId] = useState<string | null>(null)
 	const [query, setQuery] = useState("")
 	const [selectedTag, setSelectedTag] = useState<string | null>(null)
 	const [loading, setLoading] = useState(true)
@@ -936,10 +1057,14 @@ const MarketplaceView = ({ initialType = "skill", onDone }: MarketplaceViewProps
 			(entry) => entry.type === activeType && (!normalizedQuery || searchTextForEntry(entry).includes(normalizedQuery)),
 		)
 	}, [catalogEntries, activeType, query])
+	const marketplaceCatalogEntries = useMemo(
+		() => searchedCatalogEntries.filter((entry) => !installedKeys.has(entryKey(entry))),
+		[searchedCatalogEntries, installedKeys],
+	)
 	const tagFilters = useMemo(() => {
 		const labelsById = new Map<string, string>()
 		const counts = new Map<string, number>()
-		for (const entry of searchedCatalogEntries) {
+		for (const entry of marketplaceCatalogEntries) {
 			for (const label of entryTagLabels(entry)) {
 				const id = tagId(label)
 				if (!id) continue
@@ -951,7 +1076,7 @@ const MarketplaceView = ({ initialType = "skill", onDone }: MarketplaceViewProps
 			counts,
 			tags: [...labelsById.entries()].map(([id, label]) => ({ id, label })).sort((a, b) => a.label.localeCompare(b.label)),
 		}
-	}, [searchedCatalogEntries])
+	}, [marketplaceCatalogEntries])
 	useEffect(() => {
 		if (selectedTag && !tagFilters.counts.has(selectedTag)) {
 			setSelectedTag(null)
@@ -960,14 +1085,59 @@ const MarketplaceView = ({ initialType = "skill", onDone }: MarketplaceViewProps
 	const visibleCatalogEntries = useMemo(
 		() =>
 			selectedTag
-				? searchedCatalogEntries.filter((entry) => entryTagLabels(entry).some((label) => tagId(label) === selectedTag))
-				: searchedCatalogEntries,
-		[searchedCatalogEntries, selectedTag],
+				? marketplaceCatalogEntries.filter((entry) => entryTagLabels(entry).some((label) => tagId(label) === selectedTag))
+				: marketplaceCatalogEntries,
+		[marketplaceCatalogEntries, selectedTag],
 	)
-	const visibleLocalEntries = useMemo(
+	const activeLocalEntries = useMemo(
 		() => localEntries.filter((entry) => entry.type === activeType),
 		[localEntries, activeType],
 	)
+	const activeCatalogEntries = useMemo(
+		() => catalogEntries.filter((entry) => entry.type === activeType),
+		[catalogEntries, activeType],
+	)
+	const installedCatalogEntries = useMemo(
+		() => activeCatalogEntries.filter((entry) => installedKeys.has(entryKey(entry))),
+		[activeCatalogEntries, installedKeys],
+	)
+	const matchedLocalEntriesByCatalogKey = useMemo(() => {
+		const matched = new Map<string, MarketplaceLocalInstalledEntry[]>()
+		for (const entry of installedCatalogEntries) {
+			const matches = activeLocalEntries.filter((localEntry) => entryMatchesLocalEntry(entry, localEntry))
+			if (matches.length > 0) matched.set(entryKey(entry), matches)
+		}
+		return matched
+	}, [activeLocalEntries, installedCatalogEntries])
+	const matchedLocalEntryKeys = useMemo(() => {
+		const keys = new Set<string>()
+		for (const entries of matchedLocalEntriesByCatalogKey.values()) {
+			for (const entry of entries) {
+				keys.add(localEntryKey(entry))
+			}
+		}
+		return keys
+	}, [matchedLocalEntriesByCatalogKey])
+	const localOnlyInstalledEntries = useMemo(
+		() => activeLocalEntries.filter((entry) => !matchedLocalEntryKeys.has(localEntryKey(entry))),
+		[activeLocalEntries, matchedLocalEntryKeys],
+	)
+	const marketplaceMcpMetadataByServerName = useMemo(() => {
+		const metadata = new Map<string, MarketplaceMcpMetadata>()
+		for (const entry of installedCatalogEntries) {
+			if (entry.type !== "mcp") continue
+			const matchedLocalEntries = matchedLocalEntriesByCatalogKey.get(entryKey(entry)) ?? []
+			for (const localEntry of matchedLocalEntries) {
+				const serverName = localEntry.name || localEntry.id
+				if (!serverName) continue
+				metadata.set(serverName, {
+					name: entry.name || entry.id,
+					description: entry.description || entry.tagline || undefined,
+				})
+			}
+		}
+		return metadata
+	}, [installedCatalogEntries, matchedLocalEntriesByCatalogKey])
 	const handleInstall = useCallback(
 		async (entry: MarketplaceEntry) => {
 			setInstallingId(entryKey(entry))
@@ -975,6 +1145,7 @@ const MarketplaceView = ({ initialType = "skill", onDone }: MarketplaceViewProps
 			try {
 				await MarketplaceServiceClient.installMarketplaceEntry(MarketplaceEntryRequest.create({ entry }))
 				await refresh()
+				setActiveSection("installed")
 			} catch (err) {
 				setError(err instanceof Error ? err.message : String(err))
 			} finally {
@@ -984,8 +1155,42 @@ const MarketplaceView = ({ initialType = "skill", onDone }: MarketplaceViewProps
 		[refresh],
 	)
 
+	const handleUninstallMarketplace = useCallback(
+		async (entry: MarketplaceEntry) => {
+			setUninstallingId(entryKey(entry))
+			setError(null)
+			try {
+				await MarketplaceServiceClient.uninstallMarketplaceEntry(MarketplaceEntryRequest.create({ entry }))
+				await refresh()
+			} catch (err) {
+				setError(err instanceof Error ? err.message : String(err))
+			} finally {
+				setUninstallingId(null)
+			}
+		},
+		[refresh],
+	)
+
+	const handleUninstallLocal = useCallback(
+		async (entry: MarketplaceLocalInstalledEntry) => {
+			setUninstallingId(localEntryKey(entry))
+			setError(null)
+			try {
+				await MarketplaceServiceClient.uninstallMarketplaceLocalInstalledEntry(
+					MarketplaceLocalInstalledEntryRequest.create({ entry }),
+				)
+				await refresh()
+			} catch (err) {
+				setError(err instanceof Error ? err.message : String(err))
+			} finally {
+				setUninstallingId(null)
+			}
+		},
+		[refresh],
+	)
+
 	const handleToggleLocal = useCallback(async (entry: MarketplaceLocalInstalledEntry, enabled: boolean) => {
-		const key = `${entry.type}:${entry.id}:${entry.path}`
+		const key = localEntryKey(entry)
 		setTogglingLocalId(key)
 		setError(null)
 		try {
@@ -1052,19 +1257,38 @@ const MarketplaceView = ({ initialType = "skill", onDone }: MarketplaceViewProps
 							<>
 								{activeSection === "installed" &&
 									(activeType === "mcp" ? (
-										<McpManagementPanel showHeader={false} />
+										<McpManagementPanel
+											marketplaceMetadataByServerName={marketplaceMcpMetadataByServerName}
+											showHeader={false}
+											showServerList={true}
+										/>
 									) : (
 										<Section
-											count={visibleLocalEntries.length}
+											count={installedCatalogEntries.length + localOnlyInstalledEntries.length}
 											empty={`No installed ${primitive.plural}.`}
 											showHeader={false}
 											title={`Installed ${primitive.title}`}>
-											{visibleLocalEntries.map((entry) => (
+											{installedCatalogEntries.map((entry) => (
+												<InstalledMarketplaceRow
+													entry={entry}
+													key={entryKey(entry)}
+													matchedLocalEntries={
+														matchedLocalEntriesByCatalogKey.get(entryKey(entry)) ?? []
+													}
+													onToggle={handleToggleLocal}
+													onUninstall={handleUninstallMarketplace}
+													togglingLocalId={togglingLocalId}
+													uninstalling={uninstallingId === entryKey(entry)}
+												/>
+											))}
+											{localOnlyInstalledEntries.map((entry) => (
 												<LocalInstalledRow
 													entry={entry}
-													key={`${entry.type}:${entry.id}:${entry.path}`}
+													key={localEntryKey(entry)}
 													onToggle={handleToggleLocal}
-													toggling={togglingLocalId === `${entry.type}:${entry.id}:${entry.path}`}
+													onUninstall={handleUninstallLocal}
+													toggling={togglingLocalId === localEntryKey(entry)}
+													uninstalling={uninstallingId === localEntryKey(entry)}
 												/>
 											))}
 										</Section>
@@ -1114,6 +1338,8 @@ const MarketplaceView = ({ initialType = "skill", onDone }: MarketplaceViewProps
 												installing={installingId === entryKey(entry)}
 												key={entryKey(entry)}
 												onInstall={handleInstall}
+												onUninstall={handleUninstallMarketplace}
+												uninstalling={uninstallingId === entryKey(entry)}
 											/>
 										))}
 									</MarketplaceCatalogSection>

--- a/apps/vscode/webview-ui/src/components/marketplace/marketplaceMatch.test.ts
+++ b/apps/vscode/webview-ui/src/components/marketplace/marketplaceMatch.test.ts
@@ -1,0 +1,53 @@
+import type { MarketplaceEntry, MarketplaceLocalInstalledEntry } from "@shared/proto/cline/marketplace"
+import { describe, expect, it } from "vitest"
+import { entryMatchesLocalEntry } from "./marketplaceMatch"
+
+function skillEntry(input: Partial<MarketplaceEntry>): MarketplaceEntry {
+	return {
+		id: input.id ?? "",
+		type: "skill",
+		name: input.name ?? "",
+		install: input.install ?? { args: [] },
+	} as MarketplaceEntry
+}
+
+function localSkill(input: Partial<MarketplaceLocalInstalledEntry>): MarketplaceLocalInstalledEntry {
+	return {
+		id: input.id ?? "",
+		type: "skill",
+		name: input.name ?? "",
+		path: input.path ?? "",
+		enabled: true,
+	} as MarketplaceLocalInstalledEntry
+}
+
+describe("marketplace installed row matching", () => {
+	it("does not match unrelated installed skills through shared path segments", () => {
+		const reviewTeam = skillEntry({
+			id: "review-team",
+			name: "Review Team",
+			install: { args: ["owner/repo", "--skill", "review-team"] },
+		})
+		const installed = [
+			localSkill({
+				id: "review-team",
+				name: "review-team",
+				path: "/home/tester/.agents/skills/review-team/SKILL.md",
+			}),
+			localSkill({
+				id: "sentry-cli",
+				name: "sentry-cli",
+				path: "/home/tester/.agents/skills/sentry-cli/SKILL.md",
+			}),
+			localSkill({
+				id: "cline-sdk",
+				name: "cline-sdk",
+				path: "/home/tester/.agents/skills/cline-sdk/SKILL.md",
+			}),
+		]
+
+		expect(installed.filter((localEntry) => entryMatchesLocalEntry(reviewTeam, localEntry)).map((entry) => entry.id)).toEqual(
+			["review-team"],
+		)
+	})
+})

--- a/apps/vscode/webview-ui/src/components/marketplace/marketplaceMatch.ts
+++ b/apps/vscode/webview-ui/src/components/marketplace/marketplaceMatch.ts
@@ -1,0 +1,105 @@
+import type { MarketplaceEntry, MarketplaceLocalInstalledEntry } from "@shared/proto/cline/marketplace"
+
+function installArgs(entry: MarketplaceEntry): string[] {
+	return entry.install?.args ?? []
+}
+
+export function localEntryKey(entry: MarketplaceLocalInstalledEntry): string {
+	return `${entry.type}:${entry.id}:${entry.path}`
+}
+
+function normalizeMatchValue(value: string | undefined): string {
+	return (value ?? "")
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "")
+}
+
+function pathBaseName(value: string | undefined): string | undefined {
+	const segments = (value ?? "").split(/[\\/]/).filter(Boolean)
+	const last = segments.at(-1)
+	if (!last) return undefined
+	if (last.toLowerCase() === "skill.md" && segments.length > 1) {
+		return segments.at(-2)
+	}
+	return last.replace(/\.[^.]+$/, "")
+}
+
+function sourceBaseName(value: string | undefined): string | undefined {
+	const withoutFragment = value?.split("#")[0]?.split("?")[0]
+	return pathBaseName(withoutFragment)
+}
+
+function stripPluginInstallSuffix(value: string | undefined): string | undefined {
+	return value?.replace(/-[0-9a-f]{12}$/i, "")
+}
+
+function addMatchValue(values: Set<string>, value: string | undefined): void {
+	const normalized = normalizeMatchValue(value)
+	if (normalized && normalized !== "skill") {
+		values.add(normalized)
+	}
+}
+
+function entrySkillMatchValues(entry: MarketplaceEntry): Set<string> {
+	const values = new Set<string>()
+	addMatchValue(values, entry.id)
+	addMatchValue(values, entry.name)
+	const args = installArgs(entry)
+	for (let index = 0; index < args.length; index++) {
+		const arg = args[index]
+		if ((arg === "--skill" || arg === "-s") && args[index + 1]) {
+			addMatchValue(values, args[index + 1])
+			index++
+			continue
+		}
+		const skillFilter = arg.split("@").at(1)
+		if (skillFilter) {
+			addMatchValue(values, skillFilter)
+			continue
+		}
+		if (arg.includes("/") || arg.includes("\\")) {
+			addMatchValue(values, sourceBaseName(arg))
+		}
+	}
+	return values
+}
+
+function entryMatchValues(entry: MarketplaceEntry): Set<string> {
+	if (entry.type === "skill") return entrySkillMatchValues(entry)
+
+	const values = new Set<string>()
+	addMatchValue(values, entry.id)
+	addMatchValue(values, entry.name)
+
+	const [source] = installArgs(entry)
+	if (entry.type === "plugin") {
+		addMatchValue(values, source)
+		addMatchValue(values, stripPluginInstallSuffix(sourceBaseName(source)))
+	} else if (entry.type === "mcp") {
+		addMatchValue(values, source)
+	}
+	return values
+}
+
+function localEntryMatchValues(entry: MarketplaceLocalInstalledEntry): Set<string> {
+	const values = new Set<string>()
+	addMatchValue(values, entry.id)
+	addMatchValue(values, entry.name)
+
+	if (entry.type === "skill") {
+		addMatchValue(values, pathBaseName(entry.path))
+	} else if (entry.type === "plugin") {
+		addMatchValue(values, stripPluginInstallSuffix(pathBaseName(entry.path)))
+	}
+	return values
+}
+
+export function entryMatchesLocalEntry(entry: MarketplaceEntry, localEntry: MarketplaceLocalInstalledEntry): boolean {
+	if (entry.type !== localEntry.type) return false
+	const marketplaceValues = entryMatchValues(entry)
+	for (const localValue of localEntryMatchValues(localEntry)) {
+		if (marketplaceValues.has(localValue)) return true
+	}
+	return false
+}

--- a/apps/vscode/webview-ui/src/components/mcp/configuration/tabs/installed/ServersToggleList.tsx
+++ b/apps/vscode/webview-ui/src/components/mcp/configuration/tabs/installed/ServersToggleList.tsx
@@ -1,16 +1,23 @@
 import { McpServer } from "@shared/mcp"
 import ServerRow from "./server-row/ServerRow"
 
+export type MarketplaceMcpMetadata = {
+	name: string
+	description?: string
+}
+
 const ServersToggleList = ({
 	servers,
 	isExpandable,
 	hasTrashIcon,
 	listGap = "medium",
+	marketplaceMetadataByServerName,
 }: {
 	servers: McpServer[]
 	isExpandable: boolean
 	hasTrashIcon: boolean
 	listGap?: "small" | "medium" | "large"
+	marketplaceMetadataByServerName?: Map<string, MarketplaceMcpMetadata>
 }) => {
 	const gapClasses = {
 		small: "gap-0",
@@ -23,7 +30,13 @@ const ServersToggleList = ({
 	return servers.length > 0 ? (
 		<div className={`flex flex-col ${gapClass}`}>
 			{servers.map((server) => (
-				<ServerRow hasTrashIcon={hasTrashIcon} isExpandable={isExpandable} key={server.name} server={server} />
+				<ServerRow
+					hasTrashIcon={hasTrashIcon}
+					isExpandable={isExpandable}
+					key={server.name}
+					marketplaceMetadata={marketplaceMetadataByServerName?.get(server.name)}
+					server={server}
+				/>
 			))}
 		</div>
 	) : (

--- a/apps/vscode/webview-ui/src/components/mcp/configuration/tabs/installed/server-row/ServerRow.tsx
+++ b/apps/vscode/webview-ui/src/components/mcp/configuration/tabs/installed/server-row/ServerRow.tsx
@@ -23,6 +23,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { cn } from "@/lib/utils"
 import { McpServiceClient } from "@/services/grpc-client"
+import type { MarketplaceMcpMetadata } from "../ServersToggleList"
 import McpPromptRow from "./McpPromptRow"
 import McpResourceRow from "./McpResourceRow"
 import McpToolRow from "./McpToolRow"
@@ -45,10 +46,12 @@ const ServerRow = ({
 	server,
 	isExpandable = true,
 	hasTrashIcon = true,
+	marketplaceMetadata,
 }: {
 	server: McpServer
 	isExpandable?: boolean
 	hasTrashIcon?: boolean
+	marketplaceMetadata?: MarketplaceMcpMetadata
 }) => {
 	const { autoApprovalSettings, setMcpServers, remoteConfigSettings } = useExtensionState()
 
@@ -217,7 +220,12 @@ const ServerRow = ({
 						})}
 					/>
 				)}
-				<span className="flex-1 overflow-hidden break-all whitespace-normal flex items-center">{server.name}</span>
+				<span className="flex-1 min-w-0 overflow-hidden break-words whitespace-normal">
+					<span className="block font-medium">{marketplaceMetadata?.name || server.name}</span>
+					{marketplaceMetadata?.description && (
+						<span className="block mt-0.5 text-xs text-description">{marketplaceMetadata.description}</span>
+					)}
+				</span>
 				{/* Collapsed view controls */}
 				{!server.error && (
 					<Button

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -500,6 +500,26 @@ export {
 	parseMcpInstallArgs,
 } from "./services/mcp-install";
 export type {
+	MarketplaceActionResult,
+	MarketplaceEntryInput,
+	MarketplacePrimitiveType,
+	MarketplaceSpawnCommand,
+	MarketplaceSpawnResult,
+	UninstallMarketplaceEntryOptions,
+} from "./services/marketplace";
+export {
+	findInstalledGlobalMarketplaceSkillName,
+	getGlobalMarketplaceSkillPaths,
+	getMarketplaceSkillCandidates,
+	isMarketplaceSkillInstalled,
+	marketplaceEntryKey,
+	resolveMarketplaceMcpServerName,
+	uninstallMarketplaceEntry,
+	uninstallMarketplaceMcpServerFromSettings,
+	uninstallMarketplacePlugin,
+	uninstallMarketplaceSkill,
+} from "./services/marketplace";
+export type {
 	ParsedPluginSource,
 	PluginInstallOptions,
 	PluginInstallResult,

--- a/sdk/packages/core/src/services/marketplace.test.ts
+++ b/sdk/packages/core/src/services/marketplace.test.ts
@@ -129,28 +129,34 @@ describe("marketplace service", () => {
 		expect(existsSync(skillDir)).toBe(false);
 	});
 
-	it("fails marketplace skill uninstall if the skill remains installed", async () => {
-		const skillDir = join(home, ".agents", "skills", "review-team");
-		await mkdir(skillDir, { recursive: true });
-		await writeFile(join(skillDir, "SKILL.md"), "# Review Team", "utf8");
+	it("cleans up remaining marketplace skill directories after skills CLI remove succeeds", async () => {
+		const clineSkillDir = join(
+			process.env.CLINE_DIR ?? "",
+			"skills",
+			"review-team",
+		);
+		await mkdir(clineSkillDir, { recursive: true });
+		await writeFile(join(clineSkillDir, "SKILL.md"), "# Review Team", "utf8");
 
-		await expect(
-			uninstallMarketplaceEntry(
-				{
-					id: "review-team",
-					type: "skill",
-					name: "Review Team",
-					install: { args: ["github.com/cline/skills@review-team"] },
-				},
-				{
-					spawnCommand: async () => ({
-						exitCode: 0,
-						stdout: "removed",
-						stderr: "",
-					}),
-				},
-			),
-		).rejects.toThrow(/still present/);
+		const result = await uninstallMarketplaceEntry(
+			{
+				id: "review-team",
+				type: "skill",
+				name: "Review Team",
+				install: { args: ["github.com/cline/skills@review-team"] },
+			},
+			{
+				spawnCommand: async () => ({
+					exitCode: 0,
+					stdout: "removed",
+					stderr: "",
+				}),
+			},
+		);
+
+		expect(result.status).toBe("uninstalled");
+		expect(result.output).toContain(`Removed: ${clineSkillDir}`);
+		expect(existsSync(clineSkillDir)).toBe(false);
 	});
 
 	it("uninstalls official marketplace plugins by marketplace slug", async () => {

--- a/sdk/packages/core/src/services/marketplace.test.ts
+++ b/sdk/packages/core/src/services/marketplace.test.ts
@@ -1,0 +1,193 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setClineDir, setHomeDir } from "@cline/shared/storage";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { uninstallMarketplaceEntry } from "./marketplace";
+
+describe("marketplace service", () => {
+	let root = "";
+	let home = "";
+	let originalHome: string | undefined;
+	let originalClineDir: string | undefined;
+
+	beforeEach(() => {
+		root = mkdtempSync(join(tmpdir(), "core-marketplace-"));
+		home = join(root, "home");
+		originalHome = process.env.HOME;
+		originalClineDir = process.env.CLINE_DIR;
+		process.env.HOME = home;
+		process.env.CLINE_DIR = join(home, ".cline");
+		setHomeDir(home);
+		setClineDir(process.env.CLINE_DIR);
+	});
+
+	afterEach(() => {
+		if (originalHome === undefined) {
+			delete process.env.HOME;
+		} else {
+			process.env.HOME = originalHome;
+		}
+		if (originalClineDir === undefined) {
+			delete process.env.CLINE_DIR;
+		} else {
+			process.env.CLINE_DIR = originalClineDir;
+		}
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	it("uninstalls marketplace MCP servers from settings by default", async () => {
+		const settingsPath = join(root, "cline_mcp_settings.json");
+		await writeFile(
+			settingsPath,
+			JSON.stringify(
+				{
+					mcpServers: {
+						context7: { transport: { type: "stdio", command: "node" } },
+						other: { transport: { type: "stdio", command: "node" } },
+					},
+				},
+				null,
+				2,
+			),
+			"utf8",
+		);
+
+		const result = await uninstallMarketplaceEntry(
+			{
+				id: "context7",
+				type: "mcp",
+				name: "Context7",
+				install: { args: ["context7", "node", "server.js"] },
+			},
+			{ mcpSettingsPath: settingsPath },
+		);
+
+		expect(result).toMatchObject({
+			id: "context7",
+			type: "mcp",
+			status: "uninstalled",
+			message: "Uninstalled Context7.",
+		});
+		const settings = JSON.parse(readFileSync(settingsPath, "utf8")) as {
+			mcpServers?: Record<string, unknown>;
+		};
+		expect(settings.mcpServers?.context7).toBeUndefined();
+		expect(settings.mcpServers?.other).toBeDefined();
+	});
+
+	it("uninstalls marketplace skills through skills CLI remove", async () => {
+		const skillDir = join(home, ".agents", "skills", "review-team");
+		await mkdir(skillDir, { recursive: true });
+		await writeFile(
+			join(skillDir, "SKILL.md"),
+			"---\nname: Review\n---\n",
+			"utf8",
+		);
+		const calls: Array<{ command: string; args: string[] }> = [];
+
+		const result = await uninstallMarketplaceEntry(
+			{
+				id: "review-team",
+				type: "skill",
+				name: "Review Team",
+				install: {
+					args: ["github.com/cline/skills@review-team"],
+				},
+			},
+			{
+				spawnCommand: async (command, args) => {
+					calls.push({ command, args });
+					rmSync(skillDir, { recursive: true, force: true });
+					return { exitCode: 0, stdout: "removed", stderr: "" };
+				},
+			},
+		);
+
+		expect(result).toMatchObject({
+			id: "review-team",
+			type: "skill",
+			status: "uninstalled",
+			message: "Uninstalled Review Team.",
+		});
+		expect(calls).toEqual([
+			{
+				command: "npx",
+				args: [
+					"-y",
+					"skills@latest",
+					"remove",
+					"review-team",
+					"-g",
+					"-a",
+					"cline",
+					"-y",
+				],
+			},
+		]);
+		expect(existsSync(skillDir)).toBe(false);
+	});
+
+	it("fails marketplace skill uninstall if the skill remains installed", async () => {
+		const skillDir = join(home, ".agents", "skills", "review-team");
+		await mkdir(skillDir, { recursive: true });
+		await writeFile(join(skillDir, "SKILL.md"), "# Review Team", "utf8");
+
+		await expect(
+			uninstallMarketplaceEntry(
+				{
+					id: "review-team",
+					type: "skill",
+					name: "Review Team",
+					install: { args: ["github.com/cline/skills@review-team"] },
+				},
+				{
+					spawnCommand: async () => ({
+						exitCode: 0,
+						stdout: "removed",
+						stderr: "",
+					}),
+				},
+			),
+		).rejects.toThrow(/still present/);
+	});
+
+	it("uninstalls official marketplace plugins by marketplace slug", async () => {
+		const installPath = join(
+			home,
+			".cline",
+			"plugins",
+			"_installed",
+			"official",
+			"goal-123456789abc",
+		);
+		const entryPath = join(installPath, "package", "index.ts");
+		await mkdir(join(installPath, "package"), { recursive: true });
+		await writeFile(
+			join(installPath, "package.json"),
+			JSON.stringify({ name: "goal" }, null, 2),
+			"utf8",
+		);
+		await writeFile(
+			entryPath,
+			"export default { name: 'goal', manifest: { capabilities: ['tools'] } };",
+			"utf8",
+		);
+
+		const result = await uninstallMarketplaceEntry({
+			id: "goal",
+			type: "plugin",
+			name: "Goal",
+			install: { args: ["goal"] },
+		});
+
+		expect(result).toMatchObject({
+			id: "goal",
+			type: "plugin",
+			status: "uninstalled",
+			message: "Uninstalled Goal.",
+		});
+		expect(existsSync(installPath)).toBe(false);
+	});
+});

--- a/sdk/packages/core/src/services/marketplace.test.ts
+++ b/sdk/packages/core/src/services/marketplace.test.ts
@@ -120,8 +120,6 @@ describe("marketplace service", () => {
 					"remove",
 					"review-team",
 					"-g",
-					"-a",
-					"cline",
 					"-y",
 				],
 			},

--- a/sdk/packages/core/src/services/marketplace.ts
+++ b/sdk/packages/core/src/services/marketplace.ts
@@ -65,12 +65,22 @@ function resolveHomeDir(): string {
 	);
 }
 
+function trimSkillSegmentEdges(value: string): string {
+	let start = 0;
+	let end = value.length;
+	while (start < end && (value[start] === "." || value[start] === "-")) {
+		start++;
+	}
+	while (end > start && (value[end - 1] === "." || value[end - 1] === "-")) {
+		end--;
+	}
+	return value.slice(start, end);
+}
+
 function sanitizeSkillSegment(value: string): string {
-	const sanitized = value
-		.toLowerCase()
-		.replace(/[^a-z0-9._]+/g, "-")
-		.replace(/^[.-]+|[.-]+$/g, "")
-		.slice(0, 255);
+	const sanitized = trimSkillSegmentEdges(
+		value.toLowerCase().replace(/[^a-z0-9._]+/g, "-"),
+	).slice(0, 255);
 	return sanitized || "skill";
 }
 

--- a/sdk/packages/core/src/services/marketplace.ts
+++ b/sdk/packages/core/src/services/marketplace.ts
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, rmSync } from "node:fs";
 import { homedir, platform } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { resolveClineDir, resolveMcpSettingsPath } from "@cline/shared/storage";
 import { updateMcpSettingsFileSync } from "../extensions/mcp";
 import { parseMcpInstallArgs } from "./mcp-install";
@@ -268,6 +268,22 @@ export function isMarketplaceSkillInstalled(
 	return findInstalledGlobalMarketplaceSkillName(entry) !== undefined;
 }
 
+function removeRemainingMarketplaceSkillPaths(
+	entry: MarketplaceEntryInput,
+): string[] {
+	const removedPaths: string[] = [];
+	if (entry.type !== "skill") return removedPaths;
+	for (const candidate of getMarketplaceSkillCandidates(entry)) {
+		for (const skillPath of getGlobalMarketplaceSkillPaths(candidate)) {
+			if (!existsSync(skillPath)) continue;
+			const skillDir = dirname(skillPath);
+			rmSync(skillDir, { recursive: true, force: true });
+			removedPaths.push(skillDir);
+		}
+	}
+	return removedPaths;
+}
+
 export async function uninstallMarketplaceSkill(
 	entry: MarketplaceEntryInput,
 	options: Pick<UninstallMarketplaceEntryOptions, "spawnCommand"> = {},
@@ -312,6 +328,7 @@ export async function uninstallMarketplaceSkill(
 			}`,
 		);
 	}
+	const removedPaths = removeRemainingMarketplaceSkillPaths(entry);
 	if (isMarketplaceSkillInstalled(entry)) {
 		throw new Error(
 			`Skill uninstall completed, but ${entry.name ?? entry.id} is still present in Cline's global skills directories.`,
@@ -322,7 +339,10 @@ export async function uninstallMarketplaceSkill(
 		type: "skill",
 		status: "uninstalled",
 		message: `Uninstalled ${entry.name ?? entry.id}.`,
-		output,
+		output:
+			[output, ...removedPaths.map((path) => `Removed: ${path}`)]
+				.filter(Boolean)
+				.join("\n") || undefined,
 	};
 }
 

--- a/sdk/packages/core/src/services/marketplace.ts
+++ b/sdk/packages/core/src/services/marketplace.ts
@@ -304,8 +304,6 @@ export async function uninstallMarketplaceSkill(
 		"remove",
 		installedName,
 		"-g",
-		"-a",
-		"cline",
 		"-y",
 	];
 	const displayCommand = formatCommand(command, commandArgs);

--- a/sdk/packages/core/src/services/marketplace.ts
+++ b/sdk/packages/core/src/services/marketplace.ts
@@ -1,0 +1,369 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir, platform } from "node:os";
+import { join } from "node:path";
+import { resolveClineDir, resolveMcpSettingsPath } from "@cline/shared/storage";
+import { updateMcpSettingsFileSync } from "../extensions/mcp";
+import { parseMcpInstallArgs } from "./mcp-install";
+import { uninstallPlugin } from "./plugin-uninstall";
+
+export type MarketplacePrimitiveType = "mcp" | "skill" | "plugin";
+
+export type MarketplaceEntryInput = {
+	id: string;
+	type: MarketplacePrimitiveType;
+	name?: string;
+	install?: {
+		args?: string[];
+	};
+};
+
+export type MarketplaceActionResult = {
+	id: string;
+	type: MarketplacePrimitiveType;
+	status: "installed" | "uninstalled";
+	message: string;
+	output?: string;
+};
+
+export type MarketplaceSpawnResult = {
+	exitCode: number;
+	stdout: string;
+	stderr: string;
+};
+
+export type MarketplaceSpawnCommand = (
+	command: string,
+	args: string[],
+) => Promise<MarketplaceSpawnResult>;
+
+export type UninstallMarketplaceEntryOptions = {
+	deleteMcpServer?: (name: string) => void | Promise<void>;
+	mcpSettingsPath?: string;
+	spawnCommand?: MarketplaceSpawnCommand;
+	workspaceRoot?: string;
+};
+
+const MARKETPLACE_COMMAND_TIMEOUT_MS = 120_000;
+const MAX_OUTPUT_CHARS = 12_000;
+const SECRET_PATTERN =
+	/(api[_ -]?key|access[_ -]?token|refresh[_ -]?token|auth(?:orization)?[_ -]?token|token|secret|password|authorization|credential)/i;
+const SECRET_KEY_VALUE_PATTERN =
+	/((?:^|[^\w])(?:[a-z0-9_]*?(?:api[_ -]?key|access[_ -]?token|refresh[_ -]?token|auth(?:orization)?[_ -]?token|token|secret|password|credential)[a-z0-9_]*)\s*[:=]\s*)(.+)$/gi;
+const SECRET_BEARER_VALUE_PATTERN =
+	/((?:^|[^\w])authorization\s*[:=]\s*)bearer\s+([^\s,"'}\]]+)/gi;
+const SECRET_AUTHORIZATION_VALUE_PATTERN =
+	/((?:^|[^\w])authorization\s*[:=])(?!\s*bearer\b)\s*(.+)$/gi;
+
+function getMarketplaceEntryArgs(entry: MarketplaceEntryInput): string[] {
+	return entry.install?.args ?? [];
+}
+
+function resolveHomeDir(): string {
+	return (
+		process.env.HOME?.trim() || process.env.USERPROFILE?.trim() || homedir()
+	);
+}
+
+function sanitizeSkillSegment(value: string): string {
+	const sanitized = value
+		.toLowerCase()
+		.replace(/[^a-z0-9._]+/g, "-")
+		.replace(/^[.-]+|[.-]+$/g, "")
+		.slice(0, 255);
+	return sanitized || "skill";
+}
+
+function redactOutput(value: string): string {
+	return value
+		.split(/\r?\n/)
+		.map((line) => {
+			if (!SECRET_PATTERN.test(line)) return line;
+			return line
+				.replace(SECRET_KEY_VALUE_PATTERN, "$1[redacted]")
+				.replace(SECRET_BEARER_VALUE_PATTERN, "$1Bearer [redacted]")
+				.replace(
+					/\b(Bearer)\s+(?!\[redacted\])([^\s,"'}\]]+)/gi,
+					"$1 [redacted]",
+				)
+				.replace(SECRET_AUTHORIZATION_VALUE_PATTERN, "$1 [redacted]")
+				.replace(
+					/((?:^|[^\w])(?:api\s+key|access\s+token|refresh\s+token|auth(?:orization)?\s+token|secret|password|credential)\s+(?:is\s+)?)(\S+)/gi,
+					"$1[redacted]",
+				);
+		})
+		.join("\n")
+		.slice(-MAX_OUTPUT_CHARS);
+}
+
+function commandOutput(result: MarketplaceSpawnResult): string | undefined {
+	const output = redactOutput(
+		[result.stdout, result.stderr].filter(Boolean).join("\n"),
+	).trim();
+	return output.length > 0 ? output : undefined;
+}
+
+function quoteCommandPart(value: string): string {
+	if (value === "") return '""';
+	if (/^[a-zA-Z0-9_./:=@%+,-]+$/.test(value)) return value;
+	return JSON.stringify(value);
+}
+
+function formatCommand(command: string, args: string[]): string {
+	return [command, ...args]
+		.map((part) => quoteCommandPart(redactOutput(part).trim()))
+		.join(" ");
+}
+
+const defaultMarketplaceSpawnCommand: MarketplaceSpawnCommand = async (
+	command,
+	args,
+) =>
+	new Promise<MarketplaceSpawnResult>((resolve, reject) => {
+		let settled = false;
+		let timedOut = false;
+		const child = spawn(command, args, {
+			env: process.env,
+			shell: platform() === "win32",
+			stdio: ["ignore", "pipe", "pipe"],
+			windowsHide: true,
+		});
+		let stdout = "";
+		let stderr = "";
+		const forceKillTimeout = setTimeout(() => {
+			if (!settled) child.kill("SIGKILL");
+		}, MARKETPLACE_COMMAND_TIMEOUT_MS + 5_000);
+		const timeout = setTimeout(() => {
+			timedOut = true;
+			stderr += `\nTimed out after ${MARKETPLACE_COMMAND_TIMEOUT_MS / 1000}s.`;
+			child.kill("SIGTERM");
+		}, MARKETPLACE_COMMAND_TIMEOUT_MS);
+		forceKillTimeout.unref?.();
+		timeout.unref?.();
+		child.stdout?.on("data", (chunk) => {
+			stdout += String(chunk);
+			if (stdout.length > MAX_OUTPUT_CHARS * 2) {
+				stdout = stdout.slice(-MAX_OUTPUT_CHARS);
+			}
+		});
+		child.stderr?.on("data", (chunk) => {
+			stderr += String(chunk);
+			if (stderr.length > MAX_OUTPUT_CHARS * 2) {
+				stderr = stderr.slice(-MAX_OUTPUT_CHARS);
+			}
+		});
+		child.once("error", (error) => {
+			clearTimeout(timeout);
+			clearTimeout(forceKillTimeout);
+			reject(error);
+		});
+		child.once("close", (code, signal) => {
+			settled = true;
+			clearTimeout(timeout);
+			clearTimeout(forceKillTimeout);
+			resolve({
+				exitCode: timedOut ? 124 : (code ?? (signal === "SIGINT" ? 130 : 1)),
+				stdout,
+				stderr,
+			});
+		});
+	});
+
+export function marketplaceEntryKey(
+	entry: Pick<MarketplaceEntryInput, "id" | "type">,
+): string {
+	return `${entry.type}:${entry.id}`;
+}
+
+export function resolveMarketplaceMcpServerName(
+	entry: MarketplaceEntryInput,
+): string {
+	const args = getMarketplaceEntryArgs(entry);
+	if (args.length === 0) {
+		throw new Error("Marketplace install args are required.");
+	}
+	return parseMcpInstallArgs(args).name;
+}
+
+export function uninstallMarketplaceMcpServerFromSettings(
+	entry: MarketplaceEntryInput,
+	options: Pick<UninstallMarketplaceEntryOptions, "mcpSettingsPath"> = {},
+): { name: string; deleted: boolean } {
+	const name = resolveMarketplaceMcpServerName(entry);
+	const settingsPath = options.mcpSettingsPath ?? resolveMcpSettingsPath();
+	const deleted = updateMcpSettingsFileSync(settingsPath, (settings) => {
+		const servers =
+			settings.mcpServers &&
+			typeof settings.mcpServers === "object" &&
+			!Array.isArray(settings.mcpServers)
+				? (settings.mcpServers as Record<string, unknown>)
+				: {};
+		const hadServer = Object.hasOwn(servers, name);
+		if (hadServer) {
+			delete servers[name];
+		}
+		settings.mcpServers = servers;
+		return hadServer;
+	});
+	return { name, deleted };
+}
+
+export function getMarketplaceSkillCandidates(
+	entry: MarketplaceEntryInput,
+): string[] {
+	const candidates = new Set<string>();
+	const addCandidate = (value: string | undefined) => {
+		const normalized = sanitizeSkillSegment(value ?? "");
+		if (normalized && normalized !== "skill") {
+			candidates.add(normalized);
+		}
+	};
+	addCandidate(entry.id);
+	addCandidate(entry.name);
+	const installArgs = getMarketplaceEntryArgs(entry);
+	for (let index = 0; index < installArgs.length; index++) {
+		const arg = installArgs[index];
+		if ((arg === "--skill" || arg === "-s") && installArgs[index + 1]) {
+			addCandidate(installArgs[index + 1]);
+			index++;
+			continue;
+		}
+		const skillFilter = arg.split("@").at(1);
+		if (skillFilter) {
+			addCandidate(skillFilter);
+		}
+	}
+	return [...candidates];
+}
+
+export function getGlobalMarketplaceSkillPaths(skillName: string): string[] {
+	return [
+		join(resolveClineDir(), "skills", skillName, "SKILL.md"),
+		join(resolveHomeDir(), ".agents", "skills", skillName, "SKILL.md"),
+	].filter((path, index, paths) => paths.indexOf(path) === index);
+}
+
+export function findInstalledGlobalMarketplaceSkillName(
+	entry: MarketplaceEntryInput,
+): string | undefined {
+	if (entry.type !== "skill") return undefined;
+	return getMarketplaceSkillCandidates(entry).find((candidate) =>
+		getGlobalMarketplaceSkillPaths(candidate).some((path) => existsSync(path)),
+	);
+}
+
+export function isMarketplaceSkillInstalled(
+	entry: MarketplaceEntryInput,
+): boolean {
+	return findInstalledGlobalMarketplaceSkillName(entry) !== undefined;
+}
+
+export async function uninstallMarketplaceSkill(
+	entry: MarketplaceEntryInput,
+	options: Pick<UninstallMarketplaceEntryOptions, "spawnCommand"> = {},
+): Promise<MarketplaceActionResult> {
+	const installedName = findInstalledGlobalMarketplaceSkillName(entry);
+	if (!installedName) {
+		return {
+			id: entry.id,
+			type: "skill",
+			status: "uninstalled",
+			message: `${entry.name ?? entry.id} is not installed.`,
+		};
+	}
+	const command = "npx";
+	const commandArgs = [
+		"-y",
+		"skills@latest",
+		"remove",
+		installedName,
+		"-g",
+		"-a",
+		"cline",
+		"-y",
+	];
+	const displayCommand = formatCommand(command, commandArgs);
+	const spawnCommand = options.spawnCommand ?? defaultMarketplaceSpawnCommand;
+	let result: MarketplaceSpawnResult;
+	try {
+		result = await spawnCommand(command, commandArgs);
+	} catch (error) {
+		throw new Error(
+			`Failed to start ${entry.name ?? entry.id} uninstall command:\n${displayCommand}\n${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
+	}
+	const output = commandOutput(result);
+	if (result.exitCode !== 0) {
+		throw new Error(
+			`${entry.name ?? entry.id} uninstall failed with exit code ${result.exitCode}.\nCommand:\n${displayCommand}${
+				output ? `\n\n${output}` : ""
+			}`,
+		);
+	}
+	if (isMarketplaceSkillInstalled(entry)) {
+		throw new Error(
+			`Skill uninstall completed, but ${entry.name ?? entry.id} is still present in Cline's global skills directories.`,
+		);
+	}
+	return {
+		id: entry.id,
+		type: "skill",
+		status: "uninstalled",
+		message: `Uninstalled ${entry.name ?? entry.id}.`,
+		output,
+	};
+}
+
+export async function uninstallMarketplacePlugin(
+	entry: MarketplaceEntryInput,
+	options: Pick<UninstallMarketplaceEntryOptions, "workspaceRoot"> = {},
+): Promise<MarketplaceActionResult> {
+	const [source] = getMarketplaceEntryArgs(entry);
+	const target = source?.trim() || entry.id;
+	if (!target) {
+		throw new Error("Plugin marketplace uninstalls require a plugin name.");
+	}
+	const result = await uninstallPlugin({
+		name: target,
+		workspaceRoot: options.workspaceRoot,
+	});
+	return {
+		id: entry.id,
+		type: "plugin",
+		status: "uninstalled",
+		message: `Uninstalled ${entry.name ?? result.name ?? entry.id}.`,
+		output: [
+			`Path: ${result.installPath}`,
+			...result.removedPaths.map((path) => `Removed: ${path}`),
+		].join("\n"),
+	};
+}
+
+export async function uninstallMarketplaceEntry(
+	entry: MarketplaceEntryInput,
+	options: UninstallMarketplaceEntryOptions = {},
+): Promise<MarketplaceActionResult> {
+	if (entry.type === "mcp") {
+		const name = resolveMarketplaceMcpServerName(entry);
+		if (options.deleteMcpServer) {
+			await options.deleteMcpServer(name);
+		} else {
+			uninstallMarketplaceMcpServerFromSettings(entry, options);
+		}
+		return {
+			id: entry.id,
+			type: entry.type,
+			status: "uninstalled",
+			message: `Uninstalled ${entry.name ?? name ?? entry.id}.`,
+		};
+	}
+	if (entry.type === "skill") {
+		return uninstallMarketplaceSkill(entry, options);
+	}
+	if (entry.type === "plugin") {
+		return uninstallMarketplacePlugin(entry, options);
+	}
+	throw new Error(`Unsupported marketplace entry type: ${entry.type}`);
+}


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This PR brings the VS Code Customize marketplace experience closer to the CLI hub dashboard and moves marketplace uninstall behavior into the shared core SDK so hub and VS Code do not have to maintain separate logic.

The main problems this solves:

- VS Code Customize could install marketplace MCPs, skills, and plugins, but did not expose uninstall/delete actions in the same way the CLI hub dashboard does.
- Hub already had marketplace uninstall behavior, but that logic lived in the hub server rather than the shared SDK layer where install logic had already been migrated.
- Installed marketplace rows in VS Code used local installed names/paths too directly, which could be confusing when marketplace naming differed from installed names.
- The installed skill matching was too broad during development: common path segments could make unrelated installed skills appear under the wrong marketplace row.
- MCP installed rows need to preserve the original MCP server UI, including auth/error/expanded tools/resources/prompts/settings controls, while still showing marketplace title and description.

Technical approach:

- Added `sdk/packages/core/src/services/marketplace.ts` with shared uninstall helpers for MCP, skill, and plugin marketplace entries.
- Exported the shared marketplace helpers from `@cline/core`.
- Updated `apps/cline-hub/src/server/marketplace.ts` to delegate marketplace uninstall to the shared core service while preserving hub-specific MCP delete details.
- Added VS Code marketplace RPCs for catalog uninstall and local installed uninstall:
  - `uninstallMarketplaceEntry`
  - `uninstallMarketplaceLocalInstalledEntry`
- Wired VS Code Customize rows to call those RPCs and refresh after actions.
- Updated installed Skills/Plugins rows to show marketplace name/description first, with matched local details underneath.
- Updated installed MCP handling to avoid duplicate rows: the original MCP `ServerRow` remains the single row, and receives optional marketplace metadata for display.
- Tightened marketplace/local matching into a small webview helper so installed rows do not match unrelated local skill paths.
- Changed the Marketplace tab to only show not-installed catalog entries, matching the hub dashboard split between Installed and Marketplace.
- After install completes in VS Code Customize, the view switches back to the Installed tab so users can see the installed item.
- Adjusted the Customize primitive tabs so Skills/MCP/Plugins stay on one line at narrower widths.

A few non-obvious decisions:

- I did not copy hub's broad local match helper into VS Code as-is. Hub passes rich local render callbacks and controls the local item shape, but VS Code was rendering proto rows more directly. The broader matching is what caused unrelated installed skill paths to show under marketplace rows, so VS Code now uses stricter type-specific matching.
- MCP installed rows are handled differently from Skills/Plugins. Skills and Plugins use marketplace-backed installed rows because their local rows are simpler. MCP uses the original server row because that UI already contains auth, error, restart, timeout, tools/resources/prompts, and remote-management behavior.
- Marketplace plugin uninstall now uses the shared local plugin uninstall service for official installed plugins rather than shelling back out through the current Cline CLI.
- Skill uninstall now preserves the old hub behavior of verifying that the skill is actually gone after `skills remove` exits successfully.

### Test Procedure

Validated the shared SDK marketplace uninstall service and related plugin/MCP helpers:

```bash
bun test sdk/packages/core/src/services/marketplace.test.ts sdk/packages/core/src/services/plugin-uninstall.test.ts sdk/packages/core/src/services/mcp-install.test.ts
```

Validated SDK types and build output used by VS Code:

```bash
cd sdk/packages/core
bun run typecheck
bun run build
```

Validated VS Code proto generation, extension typecheck, webview typecheck, linting, and the focused installed-row matching regression test:

```bash
cd apps/vscode
bun run check-types
bun run lint

cd webview-ui
bun test src/components/marketplace/marketplaceMatch.test.ts
```

Validated hub typecheck and linting against the shared core migration:

```bash
cd apps/cline-hub
bun run typecheck

cd /workspace/cline
bun biome lint sdk/ apps/cline-hub/ --diagnostic-level=error
```

Also ran:

```bash
git diff --check
```

Known local test environment caveat:

```bash
bun test apps/cline-hub/src/server/marketplace.test.ts
```

This currently fails before running assertions with:

```text
ENOENT reading "/workspace/cline/node_modules/.bun/@sap-ai-sdk+orchestration@2.11.0/node_modules/@sap-cloud-sdk/util"
```

That appears to be a local dependency/install issue in `node_modules`, not a failure caused by these marketplace changes. Hub typecheck and Biome lint pass, and the shared SDK tests cover the migrated uninstall behavior.

Risk areas I specifically checked:

- VS Code generated protobus service wiring includes both new uninstall RPC handlers.
- MCP Customize installed view keeps the original `ServerRow` UI rather than creating a second row for marketplace metadata.
- Remote-managed skills cannot be locally uninstalled from Customize.
- Installed marketplace skill matching no longer matches unrelated skills via shared path segments like `.agents`, `skills`, or `SKILL.md`.
- Marketplace tab does not duplicate entries already shown in Installed.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not included from this environment. The UI changes are scoped to the VS Code Customize marketplace screen:

- Skills/Plugins installed rows now show marketplace title/description with local details.
- MCP installed rows retain the original server card and are enriched with marketplace title/description when matched.
- Marketplace entries disappear from the Marketplace tab after install and appear under Installed.

### Additional Notes

This PR intentionally keeps marketplace uninstall behavior shared in `@cline/core` while letting each surface provide its own runtime integration points. Hub passes its MCP delete callback to preserve hub-specific details, and VS Code passes its controller MCP hub delete callback so the extension state updates through the existing path.
