### PR TITLE
fix(vscode): reject approvals from composer feedback

### DIFF
--- a/apps/vscode/src/sdk/sdk-followup-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-followup-coordinator.test.ts
@@ -21,7 +21,12 @@ describe("SdkFollowupCoordinator", () => {
 
 		await coordinator.askResponse("yes", undefined, undefined, "yesButtonClicked")
 
-		expect(options.interactions.resolvePendingToolApproval).toHaveBeenCalledWith("yes", "yesButtonClicked")
+		expect(options.interactions.resolvePendingToolApproval).toHaveBeenCalledWith(
+			"yes",
+			"yesButtonClicked",
+			undefined,
+			undefined,
+		)
 		expect(options.sessions.fireAndForgetSend).not.toHaveBeenCalled()
 	})
 
@@ -122,6 +127,8 @@ describe("SdkFollowupCoordinator", () => {
 		expect(options.interactions.resolvePendingToolApproval).toHaveBeenCalledWith(
 			"do the next thing after this",
 			"messageResponse",
+			undefined,
+			undefined,
 		)
 		expect(options.waitForPendingModeRebuild).not.toHaveBeenCalled()
 		expect(options.messages.appendAndEmit).not.toHaveBeenCalled()
@@ -204,7 +211,12 @@ describe("SdkFollowupCoordinator", () => {
 
 		await coordinator.askResponse("just give me an answer", undefined, undefined, "messageResponse")
 
-		expect(options.interactions.resolvePendingToolApproval).toHaveBeenCalledWith("just give me an answer", "messageResponse")
+		expect(options.interactions.resolvePendingToolApproval).toHaveBeenCalledWith(
+			"just give me an answer",
+			"messageResponse",
+			undefined,
+			undefined,
+		)
 		expect(options.messages.appendAndEmit).not.toHaveBeenCalled()
 		expect(options.sessions.fireAndForgetSend).toHaveBeenCalledWith(
 			activeSession.sdkHost,

--- a/apps/vscode/src/sdk/sdk-followup-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-followup-coordinator.ts
@@ -58,7 +58,7 @@ export class SdkFollowupCoordinator {
 			return
 		}
 
-		if (this.options.interactions.resolvePendingToolApproval(prompt, askResponse)) {
+		if (this.options.interactions.resolvePendingToolApproval(prompt, askResponse, images, files)) {
 			return
 		}
 

--- a/apps/vscode/src/sdk/sdk-interaction-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-interaction-coordinator.test.ts
@@ -103,8 +103,9 @@ describe("SdkInteractionCoordinator", () => {
 		const task = createTaskProxy("session-123", vi.fn(), vi.fn())
 		const recordApprovedToolMessage = vi.fn()
 		const recordDeniedToolApproval = vi.fn()
+		const messages = new SdkMessageCoordinator({ getTask: () => task })
 		const coordinator = new SdkInteractionCoordinator({
-			messages: new SdkMessageCoordinator({ getTask: () => task }),
+			messages,
 			getSessionId: () => "session-123",
 			postStateToWebview: vi.fn().mockResolvedValue(undefined),
 			recordApprovedToolMessage,
@@ -125,9 +126,17 @@ describe("SdkInteractionCoordinator", () => {
 		const clineMessages = task.messageStateHandler.getClineMessages()
 		expect(clineMessages[0]).toMatchObject({ type: "ask", ask: "command", text: "npm test" })
 
-		expect(coordinator.resolvePendingToolApproval("too risky", "noButtonClicked")).toBe(true)
+		expect(coordinator.resolvePendingToolApproval("too risky", "noButtonClicked", ["image.png"], ["a.ts"])).toBe(true)
 		expect(recordApprovedToolMessage).not.toHaveBeenCalled()
 		expect(recordDeniedToolApproval).toHaveBeenCalledWith("tool-call", "execute_command", "too risky")
+		expect(task.messageStateHandler.getClineMessages()[1]).toMatchObject({
+			type: "say",
+			say: "user_feedback",
+			text: "too risky",
+			images: ["image.png"],
+			files: ["a.ts"],
+			partial: false,
+		})
 		await expect(approvalPromise).resolves.toEqual({ approved: false, reason: "too risky" })
 	})
 
@@ -188,6 +197,7 @@ describe("SdkInteractionCoordinator", () => {
 			approved: false,
 			reason: DEFAULT_TOOL_APPROVAL_DENIAL_REASON,
 		})
+		expect(task.messageStateHandler.getClineMessages()).toHaveLength(1)
 		expect(recordDeniedToolApproval).toHaveBeenCalledWith(
 			"tool-call",
 			"fetch_web_content",

--- a/apps/vscode/src/sdk/sdk-interaction-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-interaction-coordinator.ts
@@ -127,7 +127,12 @@ export class SdkInteractionCoordinator {
 		})
 	}
 
-	resolvePendingToolApproval(prompt: string | undefined, responseType: ClineAskResponse | undefined): boolean {
+	resolvePendingToolApproval(
+		prompt: string | undefined,
+		responseType: ClineAskResponse | undefined,
+		images?: string[],
+		files?: string[],
+	): boolean {
 		if (!this.pendingToolApprovalResolve) {
 			return false
 		}
@@ -155,6 +160,21 @@ export class SdkInteractionCoordinator {
 		// On rejection the agent receives the denial and continues; the SDK drives the next phase.
 		this.options.setTurnPhase?.("streaming")
 		const denialReason = prompt || DEFAULT_TOOL_APPROVAL_DENIAL_REASON
+		if (!approved && (prompt?.trim() || images?.length || files?.length)) {
+			const userMessage: ClineMessage = {
+				ts: this.nextMessageTs(),
+				type: "say",
+				say: "user_feedback",
+				text: prompt ?? "",
+				images,
+				files,
+				partial: false,
+			}
+			this.options.messages.appendAndEmit([userMessage], {
+				type: "status",
+				payload: { sessionId: this.options.getSessionId(), status: "running" },
+			})
+		}
 		if (!approved && pendingMessage) {
 			this.options.recordDeniedToolApproval?.(pendingMessage.toolCallId, pendingMessage.toolName, denialReason)
 		}

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/InputSection.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/InputSection.test.tsx
@@ -75,6 +75,28 @@ describe("InputSection", () => {
 		expect(handleSendMessage).toHaveBeenCalledWith("queue this", [], [])
 	})
 
+	it("allows submit while approval is pending so typed feedback can reject the approval", () => {
+		mockTurnState.mockReturnValue({ phase: "awaiting_approval", seq: 1 })
+		const handleSendMessage = vi.fn().mockResolvedValue(undefined)
+
+		render(
+			<InputSection
+				chatState={makeChatState({ sendingDisabled: true })}
+				messageHandlers={{ handleSendMessage } as unknown as MessageHandlers}
+				placeholderText="Type a message"
+				scrollBehavior={makeScrollBehavior()}
+				selectFilesAndImages={vi.fn()}
+				shouldDisableFilesAndImages={false}
+			/>,
+		)
+
+		const composer = screen.getByLabelText("composer")
+		expect(composer).not.toBeDisabled()
+
+		fireEvent.keyDown(composer, { key: "Enter" })
+		expect(handleSendMessage).toHaveBeenCalledWith("queue this", [], [])
+	})
+
 	it("allows submit for legacy active-task state when turnState is unavailable", () => {
 		mockTurnState.mockReturnValue(undefined)
 		const handleSendMessage = vi.fn().mockResolvedValue(undefined)

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.test.tsx
@@ -300,6 +300,36 @@ describe("useMessageHandlers — send routing", () => {
 		expect(setPendingUserMessage).not.toHaveBeenCalled()
 	})
 
+	it("rejects a pending approval when the composer is submitted with typed feedback", async () => {
+		mockTurnState = { phase: "awaiting_approval", anchorTs: 2, seq: 9 }
+		const approvalConversation: ClineMessage[] = [
+			{ ts: 1, type: "say", say: "task", text: "task" },
+			{ ts: 2, type: "ask", ask: "tool", text: JSON.stringify({ tool: "newFileCreated", path: "notes.txt" }) },
+		]
+		const setPendingUserMessage = vi.fn()
+		const { result } = renderHook(() =>
+			useMessageHandlers(approvalConversation, makeChatState(approvalConversation, { setPendingUserMessage })),
+		)
+
+		await act(async () => {
+			await result.current.handleSendMessage("use a different filename", ["image.png"], ["notes.txt"])
+		})
+
+		expect(newTask).not.toHaveBeenCalled()
+		expect(condense).not.toHaveBeenCalled()
+		expect(askResponse).toHaveBeenCalledTimes(1)
+		expect(askResponse).toHaveBeenCalledWith(
+			expect.objectContaining({
+				responseType: "noButtonClicked",
+				text: "use a different filename",
+				images: ["image.png"],
+				files: ["notes.txt"],
+			}),
+		)
+		expect(askResponse).not.toHaveBeenCalledWith(expect.objectContaining({ responseType: "messageResponse" }))
+		expect(setPendingUserMessage).not.toHaveBeenCalled()
+	})
+
 	it("phase awaiting_followup also routes a follow-up to askResponse", async () => {
 		mockTurnState = { phase: "awaiting_followup", seq: 3 }
 		const { result } = renderHook(() => useMessageHandlers(completedConversation, makeChatState(completedConversation)))

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.ts
@@ -125,6 +125,16 @@ export function useMessageHandlers(messages: ClineMessage[], chatState: ChatStat
 						throw error
 					}
 					messageSent = true
+				} else if (turnState?.phase === "awaiting_approval") {
+					await sendAskResponseWithPendingState(
+						AskResponseRequest.create({
+							responseType: "noButtonClicked",
+							text: messageToSend,
+							images,
+							files,
+						}),
+					)
+					messageSent = true
 				} else if (clineAsk) {
 					// For resume_task and resume_completed_task, use yesButtonClicked to match Resume button behavior
 					// This ensures Enter key and Resume button work identically


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This PR fixes a VS Code chat approval-flow bug where typing into the composer while a tool/file approval was pending could submit the text through the generic chat-message path. That caused the message to be treated as a queued follow-up instead of resolving the approval, leaving it stuck in the queued prompts UI and sometimes visible at the bottom of the chat indefinitely.

The intended behavior is simpler: when Cline is waiting for a tool approval and the user submits composer text with Enter/send, that text should reject the pending approval and become the rejection reason. The typed text should still show as a normal user chat bubble, but it should not be added to the pending prompt queue.

Technical approach:

- The webview `handleSendMessage` path now checks `turnState.phase === "awaiting_approval"` before the generic `clineAsk`/`messageResponse` handling.
- In that phase, composer submit sends `AskResponseRequest` with `responseType: "noButtonClicked"`, preserving typed text plus images/files as the rejection payload.
- The SDK follow-up coordinator now passes images/files into `resolvePendingToolApproval`, so approval-denial handling has the full composer payload.
- The SDK interaction coordinator appends a real persisted `say: "user_feedback"` message for denials that include text or attachments. This is the single source of truth for the visible chat bubble.
- The webview intentionally does not create an optimistic pending bubble for this approval-rejection path, because the SDK now emits the real user-feedback row. This avoids duplicate chat bubbles.

A non-obvious gotcha here is that the lower-level SDK still supports `messageResponse` while an approval is pending; that behavior is used by other clients/queue APIs and was left intact. The fix is scoped to the VS Code composer so it no longer accidentally generates that wrong response shape during approval.

### Test Procedure

Verified the focused behavior in the main workspace where dependencies are installed:

```bash
cd apps/vscode/webview-ui && bunx vitest run src/components/chat/chat-view/hooks/useMessageHandlers.test.tsx src/components/chat/chat-view/components/layout/InputSection.test.tsx
cd apps/vscode && bunx vitest run --config vitest.config.ts src/sdk/sdk-interaction-coordinator.test.ts src/sdk/sdk-followup-coordinator.test.ts
cd apps/vscode && bunx tsc --noEmit --pretty false
cd apps/vscode/webview-ui && bunx tsc --noEmit --pretty false
```

The tests cover:

- Composer submit during `awaiting_approval` sends `noButtonClicked`, not `messageResponse`.
- Typed feedback and attachments are forwarded as the rejection payload.
- No webview-only optimistic bubble is created for this path, preventing duplicate user bubbles.
- The SDK persists one real `user_feedback` row for text/attachment-bearing denials.
- Generic reject-without-text still uses the default denial reason and does not add an extra user bubble.
- Existing streaming follow-up behavior still uses the queued message path.

I also created the PR branch from `origin/main` in a separate clean worktree so this PR does not include the unrelated marketplace branch commits or the unrelated dirty files currently present in the main working directory. Running tests directly inside that fresh worktree failed before exercising this patch because that worktree did not have the repo dependencies/protos installed; the same patch was verified successfully in the dependency-ready main workspace with the commands above.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. This is a chat behavior/routing fix covered by focused unit tests.

### Additional Notes

The branch was created as `saoudrizwan/fix-approval-enter-reject` from `origin/main` and contains one commit: `fix(vscode): reject approvals from composer feedback`.
