### PR TITLE
feat(vscode): allow cancelling queued prompts

### DIFF
--- a/apps/vscode/proto/cline/task.proto
+++ b/apps/vscode/proto/cline/task.proto
@@ -12,6 +12,8 @@ option java_package = "bot.cline.proto";
 service TaskService {
   // Cancels the currently running task
   rpc cancelTask(EmptyRequest) returns (Empty);
+  // Cancels a queued prompt by ID
+  rpc cancelQueuedPrompt(StringRequest) returns (Empty);
   // Cancels the currently running background command
   rpc cancelBackgroundCommand(EmptyRequest) returns (Empty);
   // Clears the current task

--- a/apps/vscode/src/core/controller/task/cancelQueuedPrompt.ts
+++ b/apps/vscode/src/core/controller/task/cancelQueuedPrompt.ts
@@ -1,0 +1,20 @@
+import { Empty, type StringRequest } from "@shared/proto/cline/common"
+import { Logger } from "@/shared/services/Logger"
+import { Controller } from ".."
+
+/**
+ * Cancels a queued prompt for the active SDK session.
+ *
+ * @param controller The controller instance
+ * @param request The request containing the queued prompt ID
+ * @returns Empty response
+ */
+export async function cancelQueuedPrompt(controller: Controller, request: StringRequest): Promise<Empty> {
+	try {
+		await controller.cancelQueuedPrompt(request.value)
+		return Empty.create()
+	} catch (error) {
+		Logger.error("Error in cancelQueuedPrompt handler:", error)
+		throw error
+	}
+}

--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -997,6 +997,29 @@ export class Controller {
 		stubWarn("cancelBackgroundCommand")
 	}
 
+	async cancelQueuedPrompt(promptId: string): Promise<void> {
+		const trimmedPromptId = promptId.trim()
+		if (!trimmedPromptId) {
+			Logger.warn("[SdkController] cancelQueuedPrompt: Missing prompt id")
+			return
+		}
+
+		const activeSession = this.sessions.getActiveSession()
+		if (!activeSession) {
+			Logger.warn("[SdkController] cancelQueuedPrompt: No active session")
+			return
+		}
+
+		const result = await activeSession.sdkHost.pendingPrompts("delete", {
+			sessionId: activeSession.sessionId,
+			promptId: trimmedPromptId,
+		})
+		if (!result.removed) {
+			Logger.warn(`[SdkController] cancelQueuedPrompt: Prompt not found: ${trimmedPromptId}`)
+		}
+		await this.postStateToWebview()
+	}
+
 	/**
 	 * Manually compact (condense) the active task's conversation. Triggered by
 	 * the compact button and the `/compact` (alias `/smol`) slash command.

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/QueuedPrompts.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/QueuedPrompts.test.tsx
@@ -1,0 +1,59 @@
+import type { QueuedPrompt } from "@shared/ExtensionMessage"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { QueuedPrompts } from "./QueuedPrompts"
+
+const cancelQueuedPromptMock = vi.hoisted(() => vi.fn())
+
+vi.mock("@/services/grpc-client", () => ({
+	TaskServiceClient: {
+		cancelQueuedPrompt: (request: unknown) => cancelQueuedPromptMock(request),
+	},
+}))
+
+vi.mock("@shared/proto/cline/common", () => ({
+	StringRequest: {
+		create: (request: unknown) => request,
+	},
+}))
+
+const queuedPrompts: QueuedPrompt[] = [
+	{
+		id: "prompt-1",
+		prompt: "First queued message",
+		delivery: "queue",
+		attachmentCount: 0,
+	},
+	{
+		id: "prompt-2",
+		prompt: "Second queued message",
+		delivery: "steer",
+		attachmentCount: 1,
+	},
+]
+
+describe("QueuedPrompts", () => {
+	beforeEach(() => {
+		cancelQueuedPromptMock.mockReset()
+		cancelQueuedPromptMock.mockResolvedValue({})
+	})
+
+	it("cancels a queued prompt from the row action", async () => {
+		render(<QueuedPrompts items={queuedPrompts} />)
+
+		const cancelButtons = screen.getAllByRole("button", { name: "Cancel queued message" })
+		fireEvent.click(cancelButtons[0])
+
+		expect(cancelQueuedPromptMock).toHaveBeenCalledTimes(1)
+		expect(cancelQueuedPromptMock).toHaveBeenCalledWith({ value: "prompt-1" })
+		expect(cancelButtons[0]).toBeDisabled()
+
+		await waitFor(() => expect(cancelButtons[0]).not.toBeDisabled())
+	})
+
+	it("does not render an empty queue", () => {
+		const { container } = render(<QueuedPrompts items={[]} />)
+
+		expect(container).toBeEmptyDOMElement()
+	})
+})

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/QueuedPrompts.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/QueuedPrompts.tsx
@@ -1,4 +1,7 @@
 import type { QueuedPrompt } from "@shared/ExtensionMessage"
+import { StringRequest } from "@shared/proto/cline/common"
+import { useState } from "react"
+import { TaskServiceClient } from "@/services/grpc-client"
 
 function truncatePrompt(prompt: string): string {
 	const trimmed = prompt.trim()
@@ -29,8 +32,25 @@ interface QueuedPromptsProps {
 }
 
 export function QueuedPrompts({ items = [] }: QueuedPromptsProps) {
+	const [cancellingIds, setCancellingIds] = useState<Set<string>>(() => new Set())
+
 	if (items.length === 0) {
 		return null
+	}
+
+	const cancelQueuedPrompt = (promptId: string) => {
+		setCancellingIds((current) => new Set(current).add(promptId))
+		TaskServiceClient.cancelQueuedPrompt(StringRequest.create({ value: promptId }))
+			.catch((error) => {
+				console.error("Failed to cancel queued prompt:", error)
+			})
+			.finally(() => {
+				setCancellingIds((current) => {
+					const next = new Set(current)
+					next.delete(promptId)
+					return next
+				})
+			})
 	}
 
 	return (
@@ -43,6 +63,7 @@ export function QueuedPrompts({ items = [] }: QueuedPromptsProps) {
 				{items.map((item) => {
 					const attachments = attachmentLabel(item.attachmentCount)
 					const isSteer = item.delivery === "steer"
+					const isCancelling = cancellingIds.has(item.id)
 					return (
 						<div
 							className="flex items-start gap-2 rounded-[3px] bg-input-background/40 px-2 py-1.5 text-xs leading-snug"
@@ -59,6 +80,15 @@ export function QueuedPrompts({ items = [] }: QueuedPromptsProps) {
 									{attachments}
 								</span>
 							)}
+							<button
+								aria-label="Cancel queued message"
+								className="mt-[-2px] flex size-5 shrink-0 items-center justify-center rounded-[3px] text-description hover:bg-toolbar-hover-background hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
+								disabled={isCancelling}
+								onClick={() => cancelQueuedPrompt(item.id)}
+								title="Cancel queued message"
+								type="button">
+								<span aria-hidden="true" className="codicon codicon-close text-[12px]" />
+							</button>
 						</div>
 					)
 				})}


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This PR adds a cancel affordance for queued prompts in the VS Code chat footer. Users can already submit follow-up messages while a turn is streaming, and those messages appear in the queued prompts panel, but there was no way to remove a queued item after submission. That made accidental queued follow-ups sticky until the active turn drained them.

The approach is intentionally small and uses the existing SDK pending prompt queue instead of introducing a parallel webview-only queue. The `TaskService` proto now exposes `cancelQueuedPrompt(StringRequest)`, the VS Code controller resolves the active SDK session, and `SdkController.cancelQueuedPrompt()` calls `pendingPrompts("delete", { sessionId, promptId })`. The SDK already emits pending prompt updates after deletion, and the controller also posts state back to the webview so the row disappears promptly.

On the webview side, each queued prompt row now has a right-aligned codicon close button with an accessible `Cancel queued message` label. The button tracks a local in-flight disabled state so repeated clicks do not issue duplicate cancel requests. The row stays otherwise unchanged: queued and steering badges still render as before, and the existing pending prompt state snapshot remains the source of truth.

One non-obvious detail: the CLI TUI currently supports editing queued prompts and promoting them to `steer`, but it does not expose a visible delete/cancel action. This PR is therefore not attempting strict CLI UI parity. It uses the shared SDK delete capability that already exists for pending prompts, which applies by prompt id.

### Test Procedure

Ran the proto generator so the ignored local generated service/client files included the new RPC:

```bash
bun run protos
```

Ran the focused webview test for the new queue row behavior:

```bash
cd apps/vscode/webview-ui
bun run test -- src/components/chat/chat-view/components/layout/QueuedPrompts.test.tsx
```

Ran TypeScript checks for both the extension and webview packages:

```bash
cd apps/vscode
bunx tsc --noEmit
cd apps/vscode/webview-ui
bunx tsc --noEmit
```

Ran proto lint:

```bash
cd apps/vscode
bun run lint:proto
```

I also rebased the branch onto the refreshed `origin/main` before creating the PR so the final PR diff contains only the queued prompt cancel change.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not included. The UI change is a small row-level close icon in the existing queued prompts panel.

### Additional Notes

Generated proto/client outputs are intentionally not committed because this repository ignores `apps/vscode/src/generated/`, `apps/vscode/src/shared/proto/`, and `apps/vscode/webview-ui/src/services/grpc-client.ts`. The source proto change plus `bun run protos` regenerates the needed local files.
