### PR TITLE
fix(vscode): refresh MCP hub after marketplace MCP installs

### DIFF
--- a/apps/vscode/src/core/controller/marketplace/__tests__/installMarketplaceEntry.test.ts
+++ b/apps/vscode/src/core/controller/marketplace/__tests__/installMarketplaceEntry.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, it, mock } from "bun:test"
+import * as assert from "assert"
+import sinon from "sinon"
+import type { Controller } from "../../index"
+
+const installMarketplaceEntryFromCatalogStub: sinon.SinonStub = sinon.stub()
+const marketplaceHelpersMock = () => ({
+	installMarketplaceEntryFromCatalog: installMarketplaceEntryFromCatalogStub,
+})
+
+mock.module("../marketplace-helpers", marketplaceHelpersMock)
+mock.module("./marketplace-helpers", marketplaceHelpersMock)
+
+describe("installMarketplaceEntry", () => {
+	afterEach(() => {
+		installMarketplaceEntryFromCatalogStub.reset()
+	})
+
+	it("reconciles the MCP hub after installing an MCP marketplace entry", async () => {
+		const { installMarketplaceEntry } = await import("../installMarketplaceEntry")
+		const reconcileMcpServersFromSettingsRPC = sinon.stub().resolves([])
+		const invalidateUserInstructionService = sinon.stub().resolves()
+		const controller = {
+			mcpHub: { reconcileMcpServersFromSettingsRPC },
+			invalidateUserInstructionService,
+		} as unknown as Controller
+		installMarketplaceEntryFromCatalogStub.resolves({
+			id: "chrome-devtools",
+			type: "mcp",
+			status: "installed",
+		})
+
+		await installMarketplaceEntry(controller, {
+			entry: {
+				id: "chrome-devtools",
+				type: "mcp",
+				name: "Chrome DevTools",
+				install: {
+					args: ["chrome-devtools", "--", "npx", "chrome-devtools-mcp@1.2.0"],
+					env: [],
+				},
+				tags: [],
+				tagObjects: [],
+			},
+		})
+
+		assert.equal(installMarketplaceEntryFromCatalogStub.callCount, 1)
+		assert.equal(reconcileMcpServersFromSettingsRPC.callCount, 1)
+		assert.equal(invalidateUserInstructionService.callCount, 0)
+	})
+})

--- a/apps/vscode/src/core/controller/marketplace/installMarketplaceEntry.ts
+++ b/apps/vscode/src/core/controller/marketplace/installMarketplaceEntry.ts
@@ -10,6 +10,9 @@ export async function installMarketplaceEntry(
 		throw new Error("Marketplace entry is required.")
 	}
 	const result = await installMarketplaceEntryFromCatalog(request.entry)
+	if (request.entry.type === "mcp") {
+		await controller.mcpHub?.reconcileMcpServersFromSettingsRPC()
+	}
 	if (request.entry.type === "skill" || request.entry.type === "plugin") {
 		await controller.invalidateUserInstructionService()
 	}

--- a/apps/vscode/src/services/mcp/McpHub.ts
+++ b/apps/vscode/src/services/mcp/McpHub.ts
@@ -1267,6 +1267,15 @@ export class McpHub {
 		await this.notifyWebviewOfServerChanges()
 	}
 
+	async reconcileMcpServersFromSettingsRPC(): Promise<McpServer[]> {
+		const settings = await this.readPostWriteMcpSettings()
+		await this.updateServerConnectionsRPC(settings.mcpServers as Record<string, McpServerConfig>)
+		await this.notifyWebviewOfServerChanges()
+
+		const serverOrder = Object.keys(settings.mcpServers || {})
+		return this.getSortedMcpServers(serverOrder)
+	}
+
 	async getLatestMcpServersRPC(): Promise<McpServer[]> {
 		const settings = await this.readAndValidateMcpSettingsFile()
 		if (!settings) {


### PR DESCRIPTION
This fixes a race in the VS Code Customize > MCP marketplace install flow.

Clicking an MCP entry in the marketplace already writes the server to `cline_mcp_settings.json` immediately through the shared marketplace/core install helper. The installed MCP UI, however, is not rendered directly from that settings file. It is driven by the extension's live `mcpHub` state and the MCP servers subscription. Before this change, the marketplace install RPC returned after the file write without forcing `mcpHub` to reload that new settings state.

That meant the UI depended on the MCP settings file watcher eventually observing the write and reconciling connections. Fast or OAuth-gated remote servers could appear quickly because their connection path emitted updates, while slower stdio installs like Chrome DevTools could sit in the settings file but not show in the installed MCP UI until the watcher caught up or the user closed/reopened Customize later.

The fix adds an explicit `reconcileMcpServersFromSettingsRPC()` method on `McpHub` that:

```ts
const settings = await this.readPostWriteMcpSettings()
await this.updateServerConnectionsRPC(settings.mcpServers as Record<string, McpServerConfig>)
await this.notifyWebviewOfServerChanges()
```

The marketplace install handler now calls that method immediately after successful MCP installs. This makes marketplace MCP installs behave like the Add Remote Server flow: write settings, reconcile hub state, publish an MCP server update to the webview.

I also added a focused controller regression test that verifies MCP marketplace installs trigger the hub reconcile path and do not invalidate user instructions, which remains limited to skill/plugin installs.
