### PR TITLE
fix: tolerate non-string tool input deltas

### DIFF
--- a/sdk/packages/agents/src/agent-runtime.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.test.ts
@@ -163,6 +163,17 @@ describe("AgentRuntime", () => {
 
 		expect(result.status).toBe("completed");
 		expect(result.outputText).toBe("done");
+		const toolMessage = result.messages.find(
+			(message) => message.role === "tool",
+		);
+		expect(toolMessage?.content).toEqual([
+			expect.objectContaining({
+				type: "tool-result",
+				toolCallId: "call_1",
+				toolName: "echo",
+				output: { echoed: "hi" },
+			}),
+		]);
 	});
 
 	it("injects a pending user message after tool results and before the next model request", async () => {

--- a/sdk/packages/agents/src/agent-runtime.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.test.ts
@@ -135,6 +135,36 @@ describe("AgentRuntime", () => {
 		expect(result.outputText).toBe("done");
 	});
 
+	it("ignores non-string tool input text deltas when structured input is provided", async () => {
+		const model = new ScriptedModel([
+			() => [
+				{
+					type: "tool-call-delta",
+					toolCallId: "call_1",
+					toolName: "echo",
+					inputText: '{"text"',
+				},
+				{
+					type: "tool-call-delta",
+					toolCallId: "call_1",
+					input: { text: "hi" },
+					inputText: { text: "hi" },
+				} as AgentModelEvent,
+				{ type: "finish", reason: "tool-calls" },
+			],
+			() => [
+				{ type: "text-delta", text: "done" },
+				{ type: "finish", reason: "stop" },
+			],
+		]);
+		const runtime = new AgentRuntime({ model, tools: [createEchoTool()] });
+
+		const result = await runtime.run("Start");
+
+		expect(result.status).toBe("completed");
+		expect(result.outputText).toBe("done");
+	});
+
 	it("injects a pending user message after tool results and before the next model request", async () => {
 		const consumePendingUserMessage = vi.fn(() => "steer now");
 		const model = new ScriptedModel([

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -1604,7 +1604,10 @@ function parseToolArguments(
 	};
 }
 
-function mergeToolInputText(current: string, incoming: string): string {
+function mergeToolInputText(current: string, incoming: unknown): string {
+	if (typeof incoming !== "string") {
+		return current;
+	}
 	if (!current) {
 		return incoming;
 	}


### PR DESCRIPTION
Summary\n- Ignore non-string tool input text deltas before merging partial tool-call text.\n- Add a regression test covering a structured tool input arriving alongside a non-string inputText delta.\n\nTests\n- git diff --check\n\nNotes\n- I could not run the package vitest locally because this checkout requires bun and no bun/vitest binary is available in this shell.\n\nRefs #11879