### PR TITLE
fix(core): cap MCP tool names at 64 chars for OpenAI-compatible providers

### DIFF
--- a/sdk/packages/core/src/extensions/mcp/name-transform.test.ts
+++ b/sdk/packages/core/src/extensions/mcp/name-transform.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { defaultMcpToolNameTransform } from "./name-transform";
+
+const MAX_LENGTH = 64;
+const VALID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+describe("defaultMcpToolNameTransform", () => {
+	it("passes through short, valid names unchanged", () => {
+		expect(
+			defaultMcpToolNameTransform({ serverName: "mock", toolName: "echo" }),
+		).toBe("mock__echo");
+	});
+
+	it("sanitizes invalid characters", () => {
+		const result = defaultMcpToolNameTransform({
+			serverName: "my.server",
+			toolName: "tool/name",
+		});
+		expect(result).toMatch(VALID_PATTERN);
+		expect(result).not.toContain(".");
+		expect(result).not.toContain("/");
+	});
+
+	it("truncates valid names longer than 64 characters", () => {
+		const toolName = "a".repeat(100);
+		const result = defaultMcpToolNameTransform({
+			serverName: "server",
+			toolName,
+		});
+		expect(result.length).toBeLessThanOrEqual(MAX_LENGTH);
+		expect(result).toMatch(VALID_PATTERN);
+	});
+
+	it("keeps names that are exactly at the limit unchanged", () => {
+		const toolName = "a".repeat(MAX_LENGTH - "server__".length);
+		const rawName = `server__${toolName}`;
+		expect(rawName.length).toBe(MAX_LENGTH);
+		expect(
+			defaultMcpToolNameTransform({ serverName: "server", toolName }),
+		).toBe(rawName);
+	});
+
+	it("produces distinct names for distinct long inputs via the hash suffix", () => {
+		const a = defaultMcpToolNameTransform({
+			serverName: "server",
+			toolName: `${"x".repeat(80)}_a`,
+		});
+		const b = defaultMcpToolNameTransform({
+			serverName: "server",
+			toolName: `${"x".repeat(80)}_b`,
+		});
+		expect(a).not.toBe(b);
+		expect(a.length).toBeLessThanOrEqual(MAX_LENGTH);
+		expect(b.length).toBeLessThanOrEqual(MAX_LENGTH);
+	});
+});

--- a/sdk/packages/core/src/extensions/mcp/name-transform.ts
+++ b/sdk/packages/core/src/extensions/mcp/name-transform.ts
@@ -1,7 +1,9 @@
 import { createHash } from "node:crypto";
 import type { McpToolNameTransform } from "./types";
 
-const MAX_MCP_TOOL_NAME_LENGTH = 128;
+// 64 is OpenAI's function-name limit; Anthropic allows 128. Cap at the lower
+// bound so OpenAI-compatible providers don't reject long MCP tool names.
+const MAX_MCP_TOOL_NAME_LENGTH = 64;
 const INVALID_MCP_TOOL_NAME_CHARACTERS = /[^a-zA-Z0-9_-]+/g;
 const HASH_LENGTH = 8;
 const HASH_SEPARATOR_LENGTH = 1;


### PR DESCRIPTION
### Related Issue

**Issue:** #11877

### Description

Long MCP tool names were causing API errors on OpenAI-compatible providers.

When MCP tools are converted into native tool/function definitions, the tool name flows straight to the provider API. OpenAI-compatible APIs reject any function name longer than **64 characters** (the name must match `^[a-zA-Z0-9_-]+$`, max length 64). Some MCP servers expose tools with very long names, so any name in the 65–128 char range would be sent verbatim and rejected by the provider.

We already handle this correctly in `sdk/packages/core/src/extensions/mcp/name-transform.ts` — MCP tool names are prefixed with the server name (`server__tool`), sanitized of invalid characters, and, when too long, truncated and given an 8-char SHA-1 suffix to keep them unique. The original tool name is preserved in the `execute` closure so the actual MCP call still uses the real name. The bug was purely the cap value:

```ts
const MAX_MCP_TOOL_NAME_LENGTH = 128;
```

```ts
if (sanitizedName === rawName && rawName.length <= MAX_MCP_TOOL_NAME_LENGTH) {
    return rawName; // <- a 65–128 char valid name passed through untouched
}
```

128 is the Anthropic ceiling, not OpenAI's. So a valid-character name between 65 and 128 chars skipped the truncation path and was sent as-is, then rejected by OpenAI-compatible providers.

**Fix:** lower the cap to `64`, the safe lowest common denominator across providers (it satisfies both OpenAI's 64 and Anthropic's 128). The existing hash-truncate path handles everything beyond that, so no other changes are needed. This matches what other agent codebases do — both the `pi` and OpenCode/codex implementations cap at 64 for the same reason.

This means affected users do **not** need to change anything about their MCP server — Cline now truncates the name to a provider-safe length automatically.

### Test Procedure

Added `name-transform.test.ts` covering:
- short valid names pass through unchanged
- invalid characters are sanitized
- names longer than 64 chars are truncated to ≤ 64 and still match the valid pattern
- a name exactly at the 64-char limit is preserved
- distinct long inputs produce distinct outputs (hash suffix collision-avoidance)

Existing `runtime-builder.test.ts` cases (which assert on `mock__echo`) continue to pass since they use short names. Full run: 36 tests passing across both files.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
