### PR TITLE
fix(ci): harden ext-vscode stable release workflow

### DIFF
--- a/.github/workflows/ext-vscode-publish-stable.yml
+++ b/.github/workflows/ext-vscode-publish-stable.yml
@@ -27,6 +27,10 @@ permissions:
     checks: write
     pull-requests: write
 
+concurrency:
+    group: ext-vscode-publish-stable-${{ github.event.inputs.tag }}
+    cancel-in-progress: false
+
 jobs:
     test:
         uses: ./.github/workflows/ext-vscode-test.yml
@@ -102,7 +106,13 @@ jobs:
                       echo "Error: tag '$TAG' does not exist in the repository"
                       exit 1
                     fi
-                    echo "Using existing tag '$TAG'."
+                    TAG_SHA=$(git rev-list -n 1 "$TAG_REF^{commit}")
+                    if [[ "$TAG_SHA" != "$TESTED_SHA" ]]; then
+                      echo "Error: existing tag '$TAG' points to $TAG_SHA, but this workflow tested $TESTED_SHA"
+                      echo "Dispatch from the tag ref, or from the exact main commit the tag points to."
+                      exit 1
+                    fi
+                    echo "Using existing tag '$TAG' at tested SHA $TESTED_SHA."
                   fi
 
                   git checkout --detach "$TAG_REF^{commit}"
@@ -170,6 +180,33 @@ jobs:
                   fi
                   echo "Tag and package version match: $TAG"
 
+            - name: Verify Changelog Entry
+              working-directory: ${{ github.workspace }}
+              run: |
+                  EXPECTED_HEADING="## [${{ steps.get_version.outputs.version }}]"
+                  FIRST_HEADING=$(grep -m 1 '^## \[' CHANGELOG.md || true)
+                  if [[ "$FIRST_HEADING" != "$EXPECTED_HEADING" ]]; then
+                    echo "Error: CHANGELOG.md must start with '$EXPECTED_HEADING' before publishing."
+                    echo "Current first release heading: ${FIRST_HEADING:-<none>}"
+                    exit 1
+                  fi
+                  echo "Found changelog entry for ${{ steps.get_version.outputs.version }}"
+
+            - name: Verify Marketplace Tokens
+              env:
+                  VSCE_PAT: ${{ secrets.VSCE_PAT }}
+                  OVSX_PAT: ${{ secrets.OVSX_PAT }}
+              run: |
+                  if [[ -z "$VSCE_PAT" ]]; then
+                    echo "Error: VSCE_PAT is required to publish the stable VS Code extension."
+                    exit 1
+                  fi
+                  if [[ -z "$OVSX_PAT" ]]; then
+                    echo "Error: OVSX_PAT is required to publish the stable Open VSX extension."
+                    exit 1
+                  fi
+                  echo "Marketplace publish tokens are configured."
+
             - name: Package and Publish Extension
               env:
                   VSCE_PAT: ${{ secrets.VSCE_PAT }}
@@ -215,15 +252,24 @@ jobs:
               working-directory: ${{ github.workspace }}
               run: |
                   CURRENT_TAG="${{ steps.resolve_tag.outputs.tag }}"
-                  PREV_TAG=$(git describe --tags --abbrev=0 "$CURRENT_TAG^" 2>/dev/null || echo "")
+                  PREV_TAG=$(
+                    git tag --merged "$CURRENT_TAG^" --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname \
+                      | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.]+)?$' \
+                      | head -n 1 || true
+                  )
                   echo "prev_tag=$PREV_TAG" >> $GITHUB_OUTPUT
 
             - name: Get Changelog Entry
               id: changelog
               working-directory: ${{ github.workspace }}
               run: |
-                  # Get content between first ## [ and second ## [
-                  CONTENT=$(awk '/^## \[/{if(found) exit; found=1; next} found{print}' CHANGELOG.md)
+                  # Get content between the matching version heading and the next release heading.
+                  CONTENT=$(awk -v version="${{ steps.get_version.outputs.version }}" '
+                    $0 == "## [" version "]" { found=1; next }
+                    found && /^## \[/ { exit }
+                    found { print }
+                    END { if (!found) exit 1 }
+                  ' CHANGELOG.md)
                   echo "content<<EOF" >> $GITHUB_OUTPUT
                   echo "$CONTENT" >> $GITHUB_OUTPUT
                   echo "EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/ext-vscode-publish-stable.yml
+++ b/.github/workflows/ext-vscode-publish-stable.yml
@@ -207,6 +207,33 @@ jobs:
                   fi
                   echo "Marketplace publish tokens are configured."
 
+            - name: Get Previous Tag
+              id: prev_tag
+              working-directory: ${{ github.workspace }}
+              run: |
+                  CURRENT_TAG="${{ steps.resolve_tag.outputs.tag }}"
+                  PREV_TAG=$(
+                    git tag --merged "$CURRENT_TAG^" --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname \
+                      | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.]+)?$' \
+                      | head -n 1 || true
+                  )
+                  echo "prev_tag=$PREV_TAG" >> $GITHUB_OUTPUT
+
+            - name: Get Changelog Entry
+              id: changelog
+              working-directory: ${{ github.workspace }}
+              run: |
+                  # Get content between the matching version heading and the next release heading.
+                  CONTENT=$(awk -v version="${{ steps.get_version.outputs.version }}" '
+                    $0 == "## [" version "]" { found=1; next }
+                    found && /^## \[/ { exit }
+                    found { print }
+                    END { if (!found) exit 1 }
+                  ' CHANGELOG.md)
+                  echo "content<<EOF" >> $GITHUB_OUTPUT
+                  echo "$CONTENT" >> $GITHUB_OUTPUT
+                  echo "EOF" >> $GITHUB_OUTPUT
+
             - name: Package and Publish Extension
               env:
                   VSCE_PAT: ${{ secrets.VSCE_PAT }}
@@ -246,33 +273,6 @@ jobs:
                     bun run publish:marketplace
                     echo "Successfully published release version ${{ steps.get_version.outputs.version }} to VS Code Marketplace and Open VSX Registry"
                   fi
-
-            - name: Get Previous Tag
-              id: prev_tag
-              working-directory: ${{ github.workspace }}
-              run: |
-                  CURRENT_TAG="${{ steps.resolve_tag.outputs.tag }}"
-                  PREV_TAG=$(
-                    git tag --merged "$CURRENT_TAG^" --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname \
-                      | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.]+)?$' \
-                      | head -n 1 || true
-                  )
-                  echo "prev_tag=$PREV_TAG" >> $GITHUB_OUTPUT
-
-            - name: Get Changelog Entry
-              id: changelog
-              working-directory: ${{ github.workspace }}
-              run: |
-                  # Get content between the matching version heading and the next release heading.
-                  CONTENT=$(awk -v version="${{ steps.get_version.outputs.version }}" '
-                    $0 == "## [" version "]" { found=1; next }
-                    found && /^## \[/ { exit }
-                    found { print }
-                    END { if (!found) exit 1 }
-                  ' CHANGELOG.md)
-                  echo "content<<EOF" >> $GITHUB_OUTPUT
-                  echo "$CONTENT" >> $GITHUB_OUTPUT
-                  echo "EOF" >> $GITHUB_OUTPUT
 
             - name: Create GitHub Release
               uses: softprops/action-gh-release@v1


### PR DESCRIPTION
### Related Issue

N/A — release-infra hardening ahead of the first public stable release on the new SDK-based extension (4.0.0, post #11777 migration).

### Description

While reviewing whether the `ext-vscode-publish-stable` workflow was safe to run for the first public 4.0.0 release after the npm→bun migration (#11632), a few release-only code paths — ones the nightly workflow never exercises — turned out to be unsafe or to produce wrong release notes. This PR hardens them. The bun migration of the workflow itself is correct (it mirrors the proven nightly steps exactly); these fixes are about the stable-specific steps that have not actually run since the migration.

**1. Previous-tag resolution picked up nightly tags.**
The nightly workflow now pushes a `nightly-main-*` annotated tag on *every* main commit. The old `git describe --tags --abbrev=0 "$TAG^"` therefore resolves the "previous tag" to a nightly tag, so the release notes' **Full Changelog** compare link would read `compare/nightly-main-…...v4.0.0` instead of `compare/v3.89.2...v4.0.0`. Confirmed locally:

```
git describe --tags --abbrev=0 HEAD                    → nightly-main-20260626181505-690f80523f24
git tag --merged HEAD --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+...' | head -1 → v3.89.2 ✅
```

Now resolves to the latest `vX.Y.Z` ancestor.

**2. Changelog notes were extracted positionally, not by version.**
The old step grabbed the content between the first two `## [` headings regardless of which version it was. With `package.json` at `4.0.0` but `CHANGELOG.md` still topped by `## [3.89.2]`, the GitHub Release body **and** the Slack announcement would have shipped 3.89.2's notes under a 4.0.0 release — silently, no failure. Now the changelog is extracted by exact `## [<version>]` heading and the step fails if that heading is absent.

**3. No pre-publish gates.**
Added two fail-fast checks that run *before* packaging/publishing:
- **Verify Changelog Entry** — `CHANGELOG.md` must lead with `## [<version>]`, so you can't accidentally publish with stale/missing notes.
- **Verify Marketplace Tokens** — `VSCE_PAT`/`OVSX_PAT` must be present, so a missing secret fails immediately instead of halfway through the publish.

**4. Existing-tag mode could publish untested code.**
When `auto_create_tag_from_main=false`, the workflow used an existing tag without checking it pointed at the commit CI actually tested. Now it requires the existing tag to point at the tested SHA, guaranteeing the published artifact matches what passed CI.

**5. No concurrency guard.**
Added a `concurrency` group keyed on the tag (mirroring nightly) so two dispatches of the same release can't race.

### Test Procedure

Workflow-only change; validated the logic locally against the live repo state:
- YAML parses cleanly (`js-yaml`).
- New previous-tag query returns `v3.89.2` (not a nightly tag) from current `main`.
- New changelog `awk` returns the correct section for an existing version and exits non-zero for a missing one (e.g. `4.0.0`, which is intentionally still absent).
- The Verify Changelog Entry gate correctly blocks until a `## [4.0.0]` entry is added.

The install/build half of this workflow is already proven by the nightly publish (runs daily on bun); these changes touch only the tag/changelog/gate/release steps.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing and code is formatted and linted
-   [x] I have reviewed contributor guidelines

### Additional Notes

Still required before publishing 4.0.0 (out of scope for this PR, handled separately): add a `## [4.0.0]` section to the top of `CHANGELOG.md`. With this PR merged, the workflow will now *enforce* that rather than silently shipping the wrong notes.
