### PR TITLE
Show cost has been covered by the users subscription

### DIFF
--- a/apps/cli/src/tui/components/status-bar.test.ts
+++ b/apps/cli/src/tui/components/status-bar.test.ts
@@ -67,6 +67,6 @@ describe("formatStatusBarUsageText", () => {
 				totalCost: 0.123,
 				providerId: "cline-pass",
 			}),
-		).toBe("(12,345 tokens) $0.00 (included in your subscription)");
+		).toBe("(12,345 tokens) $0.00 (included with your subscription)");
 	});
 });

--- a/apps/cli/src/tui/components/status-bar.test.ts
+++ b/apps/cli/src/tui/components/status-bar.test.ts
@@ -55,18 +55,18 @@ describe("formatStatusBarUsageText", () => {
 			formatStatusBarUsageText({
 				totalTokens: 12_345,
 				totalCost: 0.123,
-				showCost: true,
+				providerId: "cline",
 			}),
 		).toBe("(12,345 tokens) $0.12");
 	});
 
-	it("omits cost when usage cost is hidden", () => {
+	it("displays subscription message when the provider is a subscription provider", () => {
 		expect(
 			formatStatusBarUsageText({
 				totalTokens: 12_345,
 				totalCost: 0.123,
-				showCost: false,
+				providerId: "cline-pass",
 			}),
-		).toBe("(12,345 tokens)");
+		).toBe("(12,345 tokens) $0.00 (included in your subscription)");
 	});
 });

--- a/apps/cli/src/tui/components/status-bar.tsx
+++ b/apps/cli/src/tui/components/status-bar.tsx
@@ -51,7 +51,7 @@ function formatCost(cost: number): string {
 
 function formatCostText(providerId: string, totalCost: number): string {
 	if (shouldShowCliUsageCoveredBySubscription(providerId)) {
-		return "$0.00 (included in your subscription)";
+		return "$0.00 (included with your subscription)";
 	}
 
 	if (!shouldShowCliUsageCost(providerId)) {

--- a/apps/cli/src/tui/components/status-bar.tsx
+++ b/apps/cli/src/tui/components/status-bar.tsx
@@ -1,6 +1,9 @@
 import type { AgentMode } from "@cline/core";
 import { useTerminalDimensions } from "@opentui/react";
-import { shouldShowCliUsageCost } from "../../utils/usage-cost-display";
+import {
+	shouldShowCliUsageCost,
+	shouldShowCliUsageCoveredBySubscription,
+} from "../../utils/usage-cost-display";
 import {
 	useTerminalBackground,
 	useTerminalTheme,
@@ -46,14 +49,31 @@ function formatCost(cost: number): string {
 	return `$${cost.toFixed(2)}`;
 }
 
+function formatCostText(providerId: string, totalCost: number): string {
+	if (shouldShowCliUsageCoveredBySubscription(providerId)) {
+		return "$0.00 (included with your subscription)";
+	}
+
+	if (!shouldShowCliUsageCost(providerId)) {
+		return "";
+	}
+
+	return formatCost(totalCost);
+}
+
 export function formatStatusBarUsageText(input: {
 	totalTokens: number;
 	totalCost: number;
-	showCost: boolean;
+	providerId: string;
 }): string {
 	const tokens = `(${input.totalTokens.toLocaleString()} tokens)`;
-	if (!input.showCost) return tokens;
-	return `${tokens} ${formatCost(input.totalCost)}`;
+	const costText = formatCostText(input.providerId, input.totalCost);
+
+	if (!costText) {
+		return tokens;
+	}
+
+	return `${tokens} ${costText}`;
 }
 
 // knownModels keys are bare IDs ("claude-sonnet-4-6") but config.modelId
@@ -152,7 +172,6 @@ export function StatusBar(props: StatusBarProps) {
 	const bar = hasMaxInputTokens
 		? createContextBar(totalTokens, maxInputTokens)
 		: undefined;
-	const showUsageCost = shouldShowCliUsageCost(props.providerId);
 
 	// Available content width after accounting for padding.
 	// Home view: parent box is capped at 60 wide, status bar adds paddingX=1 (-2).
@@ -169,7 +188,7 @@ export function StatusBar(props: StatusBarProps) {
 	const usageText = formatStatusBarUsageText({
 		totalTokens,
 		totalCost,
-		showCost: showUsageCost,
+		providerId: props.providerId,
 	});
 	const contextText = bar
 		? ` ${bar.filled}${bar.empty} ${usageText}`

--- a/apps/cli/src/tui/components/status-bar.tsx
+++ b/apps/cli/src/tui/components/status-bar.tsx
@@ -51,7 +51,7 @@ function formatCost(cost: number): string {
 
 function formatCostText(providerId: string, totalCost: number): string {
 	if (shouldShowCliUsageCoveredBySubscription(providerId)) {
-		return "$0.00 (included with your subscription)";
+		return "$0.00 (included in your subscription)";
 	}
 
 	if (!shouldShowCliUsageCost(providerId)) {

--- a/apps/cli/src/utils/usage-cost-display.ts
+++ b/apps/cli/src/utils/usage-cost-display.ts
@@ -3,3 +3,9 @@ import { Llms } from "@cline/core";
 export function shouldShowCliUsageCost(providerId: string): boolean {
 	return Llms.shouldShowProviderUsageCost(providerId);
 }
+
+export function shouldShowCliUsageCoveredBySubscription(
+	providerId: string,
+): boolean {
+	return Llms.resolveProviderUsageCostDisplay(providerId) === "subscription";
+}

--- a/sdk/packages/llms/src/providers/billing.test.ts
+++ b/sdk/packages/llms/src/providers/billing.test.ts
@@ -7,8 +7,12 @@ import { getProviderCollectionSync } from "./model-registry";
 
 describe("provider usage cost display", () => {
 	it("hides usage cost for subscription-backed Codex providers", () => {
-		expect(resolveProviderUsageCostDisplay("openai-codex")).toBe("hide");
-		expect(resolveProviderUsageCostDisplay("openai-codex-cli")).toBe("hide");
+		expect(resolveProviderUsageCostDisplay("openai-codex")).toBe(
+			"subscription",
+		);
+		expect(resolveProviderUsageCostDisplay("openai-codex-cli")).toBe(
+			"subscription",
+		);
 		expect(shouldShowProviderUsageCost("openai-codex")).toBe(false);
 		expect(shouldShowProviderUsageCost("openai-codex-cli")).toBe(false);
 	});
@@ -23,6 +27,6 @@ describe("provider usage cost display", () => {
 	it("stores the display policy on provider metadata", () => {
 		expect(
 			getProviderCollectionSync("openai-codex")?.provider.metadata,
-		).toMatchObject({ usageCostDisplay: "hide" });
+		).toMatchObject({ usageCostDisplay: "subscription" });
 	});
 });

--- a/sdk/packages/llms/src/providers/billing.ts
+++ b/sdk/packages/llms/src/providers/billing.ts
@@ -1,12 +1,29 @@
+import {
+	type GatewayUsageCostDisplay,
+	USAGE_COST_DISPLAYS,
+} from "@cline/shared";
 import { normalizeProviderId } from "./ids";
 import { getProviderCollectionSync } from "./model-registry";
 
-export type ProviderUsageCostDisplay = "show" | "hide";
+export type ProviderUsageCostDisplay = GatewayUsageCostDisplay;
+
+const isValidMetadataUsage = (
+	usageCostDisplay: unknown,
+): usageCostDisplay is ProviderUsageCostDisplay => {
+	return (
+		!!usageCostDisplay &&
+		typeof usageCostDisplay === "string" &&
+		USAGE_COST_DISPLAYS.includes(usageCostDisplay as ProviderUsageCostDisplay)
+	);
+};
 
 function resolveMetadataUsageCostDisplay(
 	metadata: Record<string, unknown> | undefined,
 ): ProviderUsageCostDisplay {
-	return metadata?.usageCostDisplay === "hide" ? "hide" : "show";
+	if (isValidMetadataUsage(metadata?.usageCostDisplay)) {
+		return metadata.usageCostDisplay;
+	}
+	return "show";
 }
 
 export function resolveProviderUsageCostDisplay(

--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -560,7 +560,7 @@ const clinePass = createClineLikeSpec({
 	description: "Cline API endpoint with ClinePass models",
 	modelsProviderId: CLINE_PASS_PROVIDER_ID,
 	defaultModelId: firstGeneratedModelId(CLINE_PASS_PROVIDER_ID),
-	metadata: { usageCostDisplay: "hide" },
+	metadata: { usageCostDisplay: "subscription" },
 	defaults: {
 		options: {
 			onResponseError: async (response: Response) => {
@@ -972,7 +972,7 @@ export const BUILTIN_SPECS: BuiltinSpec[] = [
 		modelsFactory: buildOpenAICodexModels,
 		defaults: { baseUrl: "https://chatgpt.com/backend-api/codex" },
 		configFields: [],
-		metadata: { usageCostDisplay: "hide" },
+		metadata: { usageCostDisplay: "subscription" },
 	},
 	{
 		id: "openai-codex-cli",
@@ -984,7 +984,7 @@ export const BUILTIN_SPECS: BuiltinSpec[] = [
 		modelsProviderId: "openai",
 		defaults: { baseUrl: "https://chatgpt.com/backend-api/codex" },
 		configFields: [],
-		metadata: { usageCostDisplay: "hide" },
+		metadata: { usageCostDisplay: "subscription" },
 	},
 	{
 		id: "anthropic",

--- a/sdk/packages/shared/src/index.browser.ts
+++ b/sdk/packages/shared/src/index.browser.ts
@@ -128,7 +128,7 @@ export {
 	sanitizeSurrogates,
 	toAiSdkToolResultOutput,
 } from "./llms/ai-sdk-format";
-export type * from "./llms/gateway";
+export * from "./llms/gateway";
 export {
 	createMediaBudgetState,
 	DEFAULT_MAX_IMAGE_BASE64_BYTES,

--- a/sdk/packages/shared/src/index.ts
+++ b/sdk/packages/shared/src/index.ts
@@ -142,7 +142,7 @@ export {
 	sanitizeSurrogates,
 	toAiSdkToolResultOutput,
 } from "./llms/ai-sdk-format";
-export type * from "./llms/gateway";
+export * from "./llms/gateway";
 export {
 	createMediaBudgetState,
 	DEFAULT_MAX_IMAGE_BASE64_BYTES,

--- a/sdk/packages/shared/src/llms/gateway.ts
+++ b/sdk/packages/shared/src/llms/gateway.ts
@@ -33,7 +33,8 @@ export type GatewayModelCapability =
 	| "structured-output";
 
 export type GatewayPromptCacheStrategy = "anthropic-automatic";
-export type GatewayUsageCostDisplay = "show" | "hide";
+export const USAGE_COST_DISPLAYS = ["show", "hide", "subscription"] as const;
+export type GatewayUsageCostDisplay = (typeof USAGE_COST_DISPLAYS)[number];
 export type GatewayPromptCacheFormat = "anthropic-cache-control";
 export type GatewayReasoningFormat =
 	| "anthropic-thinking"


### PR DESCRIPTION
### Description

We want to show the users that the cost of their request is covered by their subscription. This is only meant for the interactive status bar. `"subscription"` still doesn't display cost on existing path flows, so we don't need to worry about other display places (such as the summary or whatnot).

### Test Procedure

Tested locally
<img width="565" height="58" alt="image" src="https://github.com/user-attachments/assets/3aa7511c-f770-40b8-9bc8-3fceff4e68f6" />


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)