### PR TITLE
Open ClinePass subscribe page

### DIFF
--- a/apps/vscode/webview-ui/src/components/onboarding/clinePassSubscribe.ts
+++ b/apps/vscode/webview-ui/src/components/onboarding/clinePassSubscribe.ts
@@ -3,7 +3,8 @@ import { UiServiceClient } from "@/services/grpc-client"
 
 // ClinePass subscription signup page in the dashboard (requires auth).
 const CLINE_PASS_SUBSCRIBE_PATH = "/onboarding/individual-plan"
-const DEFAULT_APP_BASE_URL = "https://app.cline.bot"
+const CLINE_PASS_USAGE_PATH = "/dashboard/subscription"
+export const DEFAULT_APP_BASE_URL = "https://app.cline.bot"
 
 // Module-level so the pending intent survives OnboardingView unmounting: handleAuthCallback
 // completes the welcome view (unmounting onboarding) before it pushes the auth-status update
@@ -26,3 +27,6 @@ export function openClinePassSubscriptionIfPending(appBaseUrl: string | undefine
 	)
 }
 
+export function buildClinePassSubscriptionPageUrl(appBaseUrl: string | undefined): string {
+	return new URL(CLINE_PASS_USAGE_PATH, appBaseUrl || DEFAULT_APP_BASE_URL).toString()
+}

--- a/apps/vscode/webview-ui/src/components/settings/ClineAccountInfoCard.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/ClineAccountInfoCard.tsx
@@ -1,10 +1,12 @@
+import { StringRequest } from "@shared/proto/cline/common"
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
 import { useEffect, useState } from "react"
 import { ClineAuthStatus } from "@/components/account/ClineAuthStatus"
 import { useClineAuth, useClineSignIn } from "@/context/ClineAuthContext"
 import { useExtensionState } from "@/context/ExtensionStateContext"
+import { UiServiceClient } from "@/services/grpc-client"
 
-export const ClineAccountInfoCard = () => {
+export const ClineAccountInfoCard = ({ usageLink }: { usageLink?: string }) => {
 	const { clineUser } = useClineAuth()
 	const { navigateToAccount } = useExtensionState()
 	const { isLoginLoading, authStatusMessage, handleSignIn } = useClineSignIn()
@@ -24,7 +26,13 @@ export const ClineAccountInfoCard = () => {
 	}, [didStartLogin, navigateToAccount, user])
 
 	const handleShowAccount = () => {
-		navigateToAccount()
+		if (!usageLink) {
+			return navigateToAccount()
+		}
+
+		UiServiceClient.openUrl(StringRequest.create({ value: usageLink })).catch((err) => {
+			console.error("Failed to open usage link:", err)
+		})
 	}
 
 	return (

--- a/apps/vscode/webview-ui/src/components/settings/providers/ClinePassProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/ClinePassProvider.tsx
@@ -1,6 +1,8 @@
 import type { ModelInfo } from "@shared/api"
 import { openAiModelInfoSafeDefaults } from "@shared/api"
 import { Mode } from "@shared/storage/types"
+import { buildClinePassSubscriptionPageUrl } from "@/components/onboarding/clinePassSubscribe"
+import { useClineAuth } from "@/context/ClineAuthContext"
 import { useProviderConfig } from "@/hooks/useProviderConfig"
 import { useProviderModelSelection } from "@/hooks/useProviderModelSelection"
 import { useProviderModels } from "@/hooks/useProviderModels"
@@ -44,6 +46,7 @@ export const ClinePassProvider = ({ showModelOptions, isPopup, currentMode }: Cl
 		commitSelection,
 		customModelInfo: clinePassFallbackModelInfo,
 	})
+	const { clineUser } = useClineAuth()
 
 	const handleModelSelect = (selection: ModelPickerSelection) => {
 		void commitModelSelection(selection).catch((err) => console.error("Failed to commit ClinePass model selection:", err))
@@ -52,7 +55,7 @@ export const ClinePassProvider = ({ showModelOptions, isPopup, currentMode }: Cl
 	return (
 		<div>
 			<div style={{ marginBottom: 14, marginTop: 4 }}>
-				<ClineAccountInfoCard />
+				<ClineAccountInfoCard usageLink={buildClinePassSubscriptionPageUrl(clineUser?.appBaseUrl)} />
 			</div>
 
 			{showModelOptions && (


### PR DESCRIPTION
### Description

When using the account info card in ClinePass, we should redirect to the dashboard usage page (the subscription one) instead of going to the account tab.

### Test Procedure

Tested locally.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)