### PR TITLE
Add VS Code SDK compaction strategy setting

### DIFF
--- a/apps/vscode/proto/cline/state.proto
+++ b/apps/vscode/proto/cline/state.proto
@@ -234,8 +234,8 @@ message Settings {
   optional string act_mode_nous_research_model_id = 121;
   optional string act_mode_vercel_ai_gateway_model_id = 122;
   optional OpenRouterModelInfo act_mode_vercel_ai_gateway_model_info = 123;
-  optional ApiProvider plan_mode_api_provider = 124;
-  optional ApiProvider act_mode_api_provider = 125;
+  optional string plan_mode_api_provider = 124;
+  optional string act_mode_api_provider = 125;
   optional string hicap_model_id = 126;
   optional string lm_studio_model_id = 127;
   optional AutoApprovalSettings auto_approval_settings = 128;

--- a/apps/vscode/proto/cline/state.proto
+++ b/apps/vscode/proto/cline/state.proto
@@ -284,6 +284,7 @@ message Settings {
   optional string act_mode_cline_model_id = 180;
   optional OpenRouterModelInfo act_mode_cline_model_info = 181;
   optional bool show_feature_tips = 182;
+  optional string compaction_strategy = 183;
 }
 
 message State {
@@ -425,6 +426,7 @@ message UpdateSettingsRequest {
   optional bool opt_out_of_remote_config = 39;
   optional bool worktrees_enabled = 40;
   optional bool show_feature_tips = 42;
+  optional string compaction_strategy = 44;
 }
 
 message UpdateTerminalConnectionTimeoutRequest {

--- a/apps/vscode/proto/cline/state.proto
+++ b/apps/vscode/proto/cline/state.proto
@@ -112,9 +112,6 @@ message Secrets {
 // in src/shared/storage/state-keys.ts and use the scripts/generate-state-proto.mjs
 // script to regenerate this list.
 message Settings {
-  reserved 144, 154, 176;
-  reserved "cline_web_tools_enabled", "enable_parallel_tool_calling", "double_check_completion_enabled";
-
   optional string lite_llm_base_url = 1;
   optional bool lite_llm_use_prompt_cache = 2;
   optional string anthropic_base_url = 4;
@@ -237,8 +234,8 @@ message Settings {
   optional string act_mode_nous_research_model_id = 121;
   optional string act_mode_vercel_ai_gateway_model_id = 122;
   optional OpenRouterModelInfo act_mode_vercel_ai_gateway_model_info = 123;
-  optional string plan_mode_api_provider = 124;
-  optional string act_mode_api_provider = 125;
+  optional ApiProvider plan_mode_api_provider = 124;
+  optional ApiProvider act_mode_api_provider = 125;
   optional string hicap_model_id = 126;
   optional string lm_studio_model_id = 127;
   optional AutoApprovalSettings auto_approval_settings = 128;
@@ -284,7 +281,10 @@ message Settings {
   optional string act_mode_cline_model_id = 180;
   optional OpenRouterModelInfo act_mode_cline_model_info = 181;
   optional bool show_feature_tips = 182;
-  optional string compaction_strategy = 183;
+  optional string plan_mode_cline_pass_model_id = 183;
+  optional OpenRouterModelInfo plan_mode_cline_pass_model_info = 184;
+  optional string act_mode_cline_pass_model_id = 185;
+  optional OpenRouterModelInfo act_mode_cline_pass_model_info = 186;
 }
 
 message State {

--- a/apps/vscode/proto/cline/state.proto
+++ b/apps/vscode/proto/cline/state.proto
@@ -112,6 +112,9 @@ message Secrets {
 // in src/shared/storage/state-keys.ts and use the scripts/generate-state-proto.mjs
 // script to regenerate this list.
 message Settings {
+  reserved 144, 154, 176;
+  reserved "cline_web_tools_enabled", "enable_parallel_tool_calling", "double_check_completion_enabled";
+
   optional string lite_llm_base_url = 1;
   optional bool lite_llm_use_prompt_cache = 2;
   optional string anthropic_base_url = 4;

--- a/apps/vscode/scripts/generate-state-proto.mjs
+++ b/apps/vscode/scripts/generate-state-proto.mjs
@@ -85,7 +85,7 @@ function inferProtoType(typeText, fieldName) {
 		["FocusChainSettings", "FocusChainSettings"],
 		["OpenaiReasoningEffort", "OpenaiReasoningEffort"],
 		["PlanActMode", "PlanActMode"],
-		["ApiProvider", "ApiProvider"],
+		["ApiProvider", "string"],
 		["LanguageModelChatSelector", "LanguageModelChatSelector"], // Must come before "Mode" check
 	]
 

--- a/apps/vscode/src/core/controller/state/getStateToPostToWebview.ts
+++ b/apps/vscode/src/core/controller/state/getStateToPostToWebview.ts
@@ -4,6 +4,7 @@
 // This allows the SdkController to reuse the classic state-building logic
 // without inheriting the entire classic Controller implementation.
 
+import { readCompactionStrategyGlobally } from "@cline/core"
 import { getHooksEnabledSafe } from "@core/hooks/hooks-utils"
 import type { ExtensionState, Platform } from "@shared/ExtensionMessage"
 import { ClineEnv } from "@/config"
@@ -40,7 +41,7 @@ export async function getStateToPostToWebview(controller: {
 	const mode = stateManager.getGlobalSettingsKey("mode")
 	const yoloModeToggled = stateManager.getGlobalSettingsKey("yoloModeToggled")
 	const useAutoCondense = stateManager.getGlobalSettingsKey("useAutoCondense")
-	const compactionStrategy = stateManager.getGlobalSettingsKey("compactionStrategy")
+	const compactionStrategy = readCompactionStrategyGlobally()
 	const subagentsEnabled = stateManager.getGlobalSettingsKey("subagentsEnabled")
 	const userInfo = stateManager.getGlobalStateKey("userInfo")
 	const mcpMarketplaceEnabled = stateManager.getGlobalStateKey("mcpMarketplaceEnabled")

--- a/apps/vscode/src/core/controller/state/getStateToPostToWebview.ts
+++ b/apps/vscode/src/core/controller/state/getStateToPostToWebview.ts
@@ -40,6 +40,7 @@ export async function getStateToPostToWebview(controller: {
 	const mode = stateManager.getGlobalSettingsKey("mode")
 	const yoloModeToggled = stateManager.getGlobalSettingsKey("yoloModeToggled")
 	const useAutoCondense = stateManager.getGlobalSettingsKey("useAutoCondense")
+	const compactionStrategy = stateManager.getGlobalSettingsKey("compactionStrategy")
 	const subagentsEnabled = stateManager.getGlobalSettingsKey("subagentsEnabled")
 	const userInfo = stateManager.getGlobalStateKey("userInfo")
 	const mcpMarketplaceEnabled = stateManager.getGlobalStateKey("mcpMarketplaceEnabled")
@@ -118,6 +119,7 @@ export async function getStateToPostToWebview(controller: {
 		mode,
 		yoloModeToggled,
 		useAutoCondense,
+		compactionStrategy,
 		subagentsEnabled,
 		userInfo,
 		mcpMarketplaceEnabled,

--- a/apps/vscode/src/core/controller/state/updateSettings.ts
+++ b/apps/vscode/src/core/controller/state/updateSettings.ts
@@ -8,6 +8,7 @@ import { fetchRemoteConfig } from "@/core/storage/remote-config/fetch"
 import { clearRemoteConfig } from "@/core/storage/remote-config/utils"
 import { McpDisplayMode } from "@/shared/McpDisplayMode"
 import { Logger } from "@/shared/services/Logger"
+import type { CompactionStrategySetting } from "@/shared/storage/state-keys"
 import { telemetryService } from "../../../services/telemetry"
 import { BrowserSettings as SharedBrowserSettings } from "../../../shared/BrowserSettings"
 import { Controller } from ".."
@@ -177,6 +178,14 @@ export async function updateSettings(controller: Controller, request: UpdateSett
 				)
 			}
 			controller.stateManager.setGlobalState("useAutoCondense", request.useAutoCondense)
+		}
+
+		if (request.compactionStrategy !== undefined) {
+			const strategy = request.compactionStrategy
+			if (strategy !== "basic" && strategy !== "agentic") {
+				throw new Error(`Invalid compaction strategy value: ${strategy}`)
+			}
+			controller.stateManager.setGlobalState("compactionStrategy", strategy satisfies CompactionStrategySetting)
 		}
 
 		// Update custom prompt choice

--- a/apps/vscode/src/core/controller/state/updateSettings.ts
+++ b/apps/vscode/src/core/controller/state/updateSettings.ts
@@ -1,3 +1,4 @@
+import { setCompactionStrategyGlobally } from "@cline/core"
 import { Empty } from "@shared/proto/cline/common"
 import { PlanActMode, McpDisplayMode as ProtoMcpDisplayMode, UpdateSettingsRequest } from "@shared/proto/cline/state"
 import { convertProtoToApiProvider } from "@shared/proto-conversions/models/api-configuration-conversion"
@@ -8,7 +9,6 @@ import { fetchRemoteConfig } from "@/core/storage/remote-config/fetch"
 import { clearRemoteConfig } from "@/core/storage/remote-config/utils"
 import { McpDisplayMode } from "@/shared/McpDisplayMode"
 import { Logger } from "@/shared/services/Logger"
-import type { CompactionStrategySetting } from "@/shared/storage/state-keys"
 import { telemetryService } from "../../../services/telemetry"
 import { BrowserSettings as SharedBrowserSettings } from "../../../shared/BrowserSettings"
 import { Controller } from ".."
@@ -185,7 +185,7 @@ export async function updateSettings(controller: Controller, request: UpdateSett
 			if (strategy !== "basic" && strategy !== "agentic") {
 				throw new Error(`Invalid compaction strategy value: ${strategy}`)
 			}
-			controller.stateManager.setGlobalState("compactionStrategy", strategy satisfies CompactionStrategySetting)
+			setCompactionStrategyGlobally(strategy)
 		}
 
 		// Update custom prompt choice

--- a/apps/vscode/src/core/controller/state/updateSettingsCli.ts
+++ b/apps/vscode/src/core/controller/state/updateSettingsCli.ts
@@ -1,7 +1,7 @@
 import { Empty } from "@shared/proto/cline/common"
 import { PlanActMode, UpdateSettingsRequestCli } from "@shared/proto/cline/state"
 import { convertProtoToApiProvider } from "@shared/proto-conversions/models/api-configuration-conversion"
-import { Settings } from "@shared/storage/state-keys"
+import type { CompactionStrategySetting, Settings } from "@shared/storage/state-keys"
 import { TelemetrySetting } from "@shared/TelemetrySetting"
 import { ClineEnv } from "@/config"
 import { Logger } from "@/shared/services/Logger"
@@ -44,6 +44,7 @@ export async function updateSettingsCli(controller: Controller, request: UpdateS
 			telemetrySetting,
 			yoloModeToggled,
 			useAutoCondense,
+			compactionStrategy,
 			worktreesEnabled,
 			subagentsEnabled,
 			browserSettings,
@@ -139,6 +140,13 @@ export async function updateSettingsCli(controller: Controller, request: UpdateS
 				)
 			}
 			controller.stateManager.setGlobalState("useAutoCondense", useAutoCondense)
+		}
+
+		if (compactionStrategy !== undefined) {
+			if (compactionStrategy !== "basic" && compactionStrategy !== "agentic") {
+				throw new Error(`Invalid compaction strategy value: ${compactionStrategy}`)
+			}
+			controller.stateManager.setGlobalState("compactionStrategy", compactionStrategy satisfies CompactionStrategySetting)
 		}
 
 		// Update worktrees setting

--- a/apps/vscode/src/core/controller/state/updateSettingsCli.ts
+++ b/apps/vscode/src/core/controller/state/updateSettingsCli.ts
@@ -1,7 +1,7 @@
 import { Empty } from "@shared/proto/cline/common"
 import { PlanActMode, UpdateSettingsRequestCli } from "@shared/proto/cline/state"
 import { convertProtoToApiProvider } from "@shared/proto-conversions/models/api-configuration-conversion"
-import type { CompactionStrategySetting, Settings } from "@shared/storage/state-keys"
+import type { Settings } from "@shared/storage/state-keys"
 import { TelemetrySetting } from "@shared/TelemetrySetting"
 import { ClineEnv } from "@/config"
 import { Logger } from "@/shared/services/Logger"
@@ -44,7 +44,6 @@ export async function updateSettingsCli(controller: Controller, request: UpdateS
 			telemetrySetting,
 			yoloModeToggled,
 			useAutoCondense,
-			compactionStrategy,
 			worktreesEnabled,
 			subagentsEnabled,
 			browserSettings,
@@ -140,13 +139,6 @@ export async function updateSettingsCli(controller: Controller, request: UpdateS
 				)
 			}
 			controller.stateManager.setGlobalState("useAutoCondense", useAutoCondense)
-		}
-
-		if (compactionStrategy !== undefined) {
-			if (compactionStrategy !== "basic" && compactionStrategy !== "agentic") {
-				throw new Error(`Invalid compaction strategy value: ${compactionStrategy}`)
-			}
-			controller.stateManager.setGlobalState("compactionStrategy", compactionStrategy satisfies CompactionStrategySetting)
 		}
 
 		// Update worktrees setting

--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -71,9 +71,11 @@ vi.mock("@shared/services/Logger", () => ({
 // ---------------------------------------------------------------------------
 
 let tempDir: string
+const previousGlobalSettingsPath = process.env.CLINE_GLOBAL_SETTINGS_PATH
 
 beforeEach(() => {
 	tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "cline-session-factory-"))
+	process.env.CLINE_GLOBAL_SETTINGS_PATH = path.join(tempDir, "global-settings.json")
 	vi.clearAllMocks()
 	mocks.stateManager.getApiConfiguration.mockReturnValue({
 		actModeApiProvider: "anthropic",
@@ -91,6 +93,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+	process.env.CLINE_GLOBAL_SETTINGS_PATH = previousGlobalSettingsPath
 	fs.rmSync(tempDir, { recursive: true, force: true })
 })
 
@@ -652,12 +655,10 @@ describe("buildSessionConfig", () => {
 	})
 
 	it("uses the configured SDK compaction strategy when auto condense is enabled", async () => {
+		writeJson(process.env.CLINE_GLOBAL_SETTINGS_PATH!, { compactionStrategy: "agentic" })
 		mocks.stateManager.getGlobalSettingsKey.mockImplementation((key: string) => {
 			if (key === "useAutoCondense") {
 				return true
-			}
-			if (key === "compactionStrategy") {
-				return "agentic" as never
 			}
 			if (key === "subagentsEnabled") {
 				return false
@@ -674,12 +675,10 @@ describe("buildSessionConfig", () => {
 	})
 
 	it("falls back to basic SDK compaction for an invalid stored strategy", async () => {
+		writeJson(process.env.CLINE_GLOBAL_SETTINGS_PATH!, { compactionStrategy: "invalid" })
 		mocks.stateManager.getGlobalSettingsKey.mockImplementation((key: string) => {
 			if (key === "useAutoCondense") {
 				return true
-			}
-			if (key === "compactionStrategy") {
-				return "invalid" as never
 			}
 			if (key === "subagentsEnabled") {
 				return false

--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -651,6 +651,50 @@ describe("buildSessionConfig", () => {
 		})
 	})
 
+	it("uses the configured SDK compaction strategy when auto condense is enabled", async () => {
+		mocks.stateManager.getGlobalSettingsKey.mockImplementation((key: string) => {
+			if (key === "useAutoCondense") {
+				return true
+			}
+			if (key === "compactionStrategy") {
+				return "agentic" as never
+			}
+			if (key === "subagentsEnabled") {
+				return false
+			}
+			return undefined
+		})
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+
+		expect(config.compaction).toEqual({
+			enabled: true,
+			strategy: "agentic",
+		})
+	})
+
+	it("falls back to basic SDK compaction for an invalid stored strategy", async () => {
+		mocks.stateManager.getGlobalSettingsKey.mockImplementation((key: string) => {
+			if (key === "useAutoCondense") {
+				return true
+			}
+			if (key === "compactionStrategy") {
+				return "invalid" as never
+			}
+			if (key === "subagentsEnabled") {
+				return false
+			}
+			return undefined
+		})
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+
+		expect(config.compaction).toEqual({
+			enabled: true,
+			strategy: "basic",
+		})
+	})
+
 	it("does not enable SDK compaction when global useAutoCondense is false", async () => {
 		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
 

--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -22,7 +22,7 @@ import type { ApiConfiguration } from "@shared/api"
 import type { HistoryItem } from "@shared/HistoryItem"
 import { DEFAULT_LANGUAGE_SETTINGS, getLanguageKey, type LanguageDisplay } from "@shared/Languages"
 import { Logger } from "@shared/services/Logger"
-import type { Settings } from "@shared/storage/state-keys"
+import type { CompactionStrategySetting, Settings } from "@shared/storage/state-keys"
 import type { Mode } from "@shared/storage/types"
 import { stringifyVsCodeLmModelSelector } from "@shared/vsCodeSelectorUtils"
 import { StateManager } from "@/core/storage/StateManager"
@@ -206,6 +206,10 @@ function resolveOpenAiCompatibleMaxTokens(config: ApiConfiguration | undefined, 
 	const modelInfo = mode === "plan" ? config?.planModeOpenAiModelInfo : config?.actModeOpenAiModelInfo
 	const maxTokens = modelInfo?.maxTokens
 	return typeof maxTokens === "number" && Number.isFinite(maxTokens) && maxTokens > 0 ? maxTokens : undefined
+}
+
+function resolveCompactionStrategy(value: unknown): CompactionStrategySetting {
+	return value === "agentic" ? "agentic" : "basic"
 }
 
 // ---------------------------------------------------------------------------
@@ -655,6 +659,7 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 
 	const stateManager = StateManager.get()
 	const globalUseAutoCondense = stateManager.getGlobalSettingsKey("useAutoCondense") ?? false
+	const compactionStrategy = resolveCompactionStrategy(stateManager.getGlobalSettingsKey("compactionStrategy"))
 	const enableCheckpoints = stateManager.getGlobalSettingsKey("enableCheckpointsSetting") ?? true
 	const useAutoCondense = input.taskSettings?.useAutoCondense ?? globalUseAutoCondense
 
@@ -699,7 +704,7 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 			? {
 					compaction: {
 						enabled: true,
-						strategy: "basic",
+						strategy: compactionStrategy,
 					},
 				}
 			: {}),

--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -13,6 +13,7 @@ import {
 	type CoreSessionConfig,
 	getProviderAuthHandler,
 	type ProviderSettings,
+	readCompactionStrategyGlobally,
 	resolveProviderApiKeyFromSettings,
 	type StartSessionResult,
 } from "@cline/core"
@@ -22,7 +23,7 @@ import type { ApiConfiguration } from "@shared/api"
 import type { HistoryItem } from "@shared/HistoryItem"
 import { DEFAULT_LANGUAGE_SETTINGS, getLanguageKey, type LanguageDisplay } from "@shared/Languages"
 import { Logger } from "@shared/services/Logger"
-import type { CompactionStrategySetting, Settings } from "@shared/storage/state-keys"
+import type { Settings } from "@shared/storage/state-keys"
 import type { Mode } from "@shared/storage/types"
 import { stringifyVsCodeLmModelSelector } from "@shared/vsCodeSelectorUtils"
 import { StateManager } from "@/core/storage/StateManager"
@@ -206,10 +207,6 @@ function resolveOpenAiCompatibleMaxTokens(config: ApiConfiguration | undefined, 
 	const modelInfo = mode === "plan" ? config?.planModeOpenAiModelInfo : config?.actModeOpenAiModelInfo
 	const maxTokens = modelInfo?.maxTokens
 	return typeof maxTokens === "number" && Number.isFinite(maxTokens) && maxTokens > 0 ? maxTokens : undefined
-}
-
-function resolveCompactionStrategy(value: unknown): CompactionStrategySetting {
-	return value === "agentic" ? "agentic" : "basic"
 }
 
 // ---------------------------------------------------------------------------
@@ -659,7 +656,7 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 
 	const stateManager = StateManager.get()
 	const globalUseAutoCondense = stateManager.getGlobalSettingsKey("useAutoCondense") ?? false
-	const compactionStrategy = resolveCompactionStrategy(stateManager.getGlobalSettingsKey("compactionStrategy"))
+	const compactionStrategy = readCompactionStrategyGlobally()
 	const enableCheckpoints = stateManager.getGlobalSettingsKey("enableCheckpointsSetting") ?? true
 	const useAutoCondense = input.taskSettings?.useAutoCondense ?? globalUseAutoCondense
 

--- a/apps/vscode/src/shared/ExtensionMessage.ts
+++ b/apps/vscode/src/shared/ExtensionMessage.ts
@@ -1,7 +1,6 @@
 // type that represents json data that is sent from extension to webview, called ExtensionMessage and has 'type' enum which can be 'plusButtonClicked' or 'settingsButtonClicked' or 'hello'
 
 import { WorkspaceRoot } from "@shared/multi-root/types"
-import type { CompactionStrategySetting } from "@shared/storage/state-keys"
 import { RemoteConfigFields } from "@shared/storage/state-keys"
 import type { Environment } from "../config"
 import { AutoApprovalSettings } from "./AutoApprovalSettings"
@@ -110,7 +109,7 @@ export interface ExtensionState {
 	mcpResponsesCollapsed?: boolean
 	yoloModeToggled?: boolean
 	useAutoCondense?: boolean
-	compactionStrategy?: CompactionStrategySetting
+	compactionStrategy?: string
 	subagentsEnabled?: boolean
 	worktreesEnabled?: ClineFeatureSetting
 	customPrompt?: string

--- a/apps/vscode/src/shared/ExtensionMessage.ts
+++ b/apps/vscode/src/shared/ExtensionMessage.ts
@@ -1,6 +1,7 @@
 // type that represents json data that is sent from extension to webview, called ExtensionMessage and has 'type' enum which can be 'plusButtonClicked' or 'settingsButtonClicked' or 'hello'
 
 import { WorkspaceRoot } from "@shared/multi-root/types"
+import type { CompactionStrategySetting } from "@shared/storage/state-keys"
 import { RemoteConfigFields } from "@shared/storage/state-keys"
 import type { Environment } from "../config"
 import { AutoApprovalSettings } from "./AutoApprovalSettings"
@@ -109,6 +110,7 @@ export interface ExtensionState {
 	mcpResponsesCollapsed?: boolean
 	yoloModeToggled?: boolean
 	useAutoCondense?: boolean
+	compactionStrategy?: CompactionStrategySetting
 	subagentsEnabled?: boolean
 	worktreesEnabled?: ClineFeatureSetting
 	customPrompt?: string

--- a/apps/vscode/src/shared/storage/state-keys.ts
+++ b/apps/vscode/src/shared/storage/state-keys.ts
@@ -48,7 +48,6 @@ type FieldDefinition<T> = {
 type FieldDefinitions = Record<string, FieldDefinition<any>>
 
 export type ConfiguredAPIKeys = Partial<Record<ApiProvider, boolean>>
-export type CompactionStrategySetting = "basic" | "agentic"
 const REMOTE_CONFIG_EXTRA_FIELDS = {
 	remoteConfiguredProviders: { default: [] as ApiProvider[] },
 	allowedMCPServers: { default: [] as Array<{ id: string }> },
@@ -265,7 +264,6 @@ const USER_SETTINGS_FIELDS = {
 	yoloModeToggled: { default: false as boolean },
 	autoApproveAllToggled: { default: false as boolean },
 	useAutoCondense: { default: false as boolean },
-	compactionStrategy: { default: "basic" as CompactionStrategySetting },
 	subagentsEnabled: { default: false as boolean },
 	worktreesEnabled: { default: false as boolean },
 	preferredLanguage: { default: "English" as string },

--- a/apps/vscode/src/shared/storage/state-keys.ts
+++ b/apps/vscode/src/shared/storage/state-keys.ts
@@ -48,6 +48,7 @@ type FieldDefinition<T> = {
 type FieldDefinitions = Record<string, FieldDefinition<any>>
 
 export type ConfiguredAPIKeys = Partial<Record<ApiProvider, boolean>>
+export type CompactionStrategySetting = "basic" | "agentic"
 const REMOTE_CONFIG_EXTRA_FIELDS = {
 	remoteConfiguredProviders: { default: [] as ApiProvider[] },
 	allowedMCPServers: { default: [] as Array<{ id: string }> },
@@ -264,6 +265,7 @@ const USER_SETTINGS_FIELDS = {
 	yoloModeToggled: { default: false as boolean },
 	autoApproveAllToggled: { default: false as boolean },
 	useAutoCondense: { default: false as boolean },
+	compactionStrategy: { default: "basic" as CompactionStrategySetting },
 	subagentsEnabled: { default: false as boolean },
 	worktreesEnabled: { default: false as boolean },
 	preferredLanguage: { default: "English" as string },

--- a/apps/vscode/src/test/cline-core-vitest-stub.ts
+++ b/apps/vscode/src/test/cline-core-vitest-stub.ts
@@ -1,3 +1,4 @@
+import { readFileSync, writeFileSync } from "node:fs"
 import { getGeneratedModelsForProvider, MODEL_COLLECTIONS_BY_PROVIDER_ID } from "@cline/llms"
 
 export interface OAuthCredentials {
@@ -11,6 +12,23 @@ export interface StartSessionResult {
 }
 
 export const MAX_COMMAND_OUTPUT_CHARS = 200_000
+
+export type GlobalCompactionStrategy = "basic" | "agentic"
+
+export function readCompactionStrategyGlobally(): GlobalCompactionStrategy {
+	try {
+		const settings = JSON.parse(readFileSync(process.env.CLINE_GLOBAL_SETTINGS_PATH ?? "", "utf8"))
+		return settings.compactionStrategy === "agentic" ? "agentic" : "basic"
+	} catch {
+		return "basic"
+	}
+}
+
+export function setCompactionStrategyGlobally(compactionStrategy: GlobalCompactionStrategy): void {
+	if (process.env.CLINE_GLOBAL_SETTINGS_PATH) {
+		writeFileSync(process.env.CLINE_GLOBAL_SETTINGS_PATH, JSON.stringify({ compactionStrategy }))
+	}
+}
 
 export function truncateCommandOutput(output: string): string {
 	return output

--- a/apps/vscode/src/test/cline-core-vitest-stub.ts
+++ b/apps/vscode/src/test/cline-core-vitest-stub.ts
@@ -25,8 +25,13 @@ export function readCompactionStrategyGlobally(): GlobalCompactionStrategy {
 }
 
 export function setCompactionStrategyGlobally(compactionStrategy: GlobalCompactionStrategy): void {
-	if (process.env.CLINE_GLOBAL_SETTINGS_PATH) {
-		writeFileSync(process.env.CLINE_GLOBAL_SETTINGS_PATH, JSON.stringify({ compactionStrategy }))
+	const filePath = process.env.CLINE_GLOBAL_SETTINGS_PATH
+	if (filePath) {
+		let settings = {}
+		try {
+			settings = JSON.parse(readFileSync(filePath, "utf8"))
+		} catch {}
+		writeFileSync(filePath, JSON.stringify({ ...settings, compactionStrategy }))
 	}
 }
 

--- a/apps/vscode/webview-ui/src/components/settings/sections/FeatureSettingsSection.spec.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/sections/FeatureSettingsSection.spec.tsx
@@ -1,23 +1,27 @@
 import { fireEvent, render, screen } from "@testing-library/react"
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import FeatureSettingsSection from "./FeatureSettingsSection"
 
 const mockUpdateSetting = vi.fn()
-
-vi.mock("@/context/ExtensionStateContext", () => ({
-	useExtensionState: vi.fn(() => ({
+const mockExtensionState = vi.hoisted(() => ({
+	value: {
 		enableCheckpointsSetting: true,
 		hooksEnabled: false,
 		showFeatureTips: false,
 		mcpDisplayMode: "rich",
 		yoloModeToggled: false,
 		useAutoCondense: false,
+		compactionStrategy: "basic",
 		subagentsEnabled: false,
 		worktreesEnabled: { user: true, featureFlag: true },
 		focusChainSettings: { enabled: false, remindClineInterval: 6 },
 		remoteConfigSettings: {},
 		backgroundEditEnabled: false,
-	})),
+	},
+}))
+
+vi.mock("@/context/ExtensionStateContext", () => ({
+	useExtensionState: vi.fn(() => mockExtensionState.value),
 }))
 
 vi.mock("../utils/settingsHandlers", () => ({
@@ -25,6 +29,15 @@ vi.mock("../utils/settingsHandlers", () => ({
 }))
 
 describe("FeatureSettingsSection", () => {
+	beforeEach(() => {
+		mockUpdateSetting.mockClear()
+		mockExtensionState.value = {
+			...mockExtensionState.value,
+			useAutoCondense: false,
+			compactionStrategy: "basic",
+		}
+	})
+
 	it("renders Hooks feature toggle", () => {
 		const { container } = render(<FeatureSettingsSection renderSectionHeader={() => null} />)
 
@@ -47,6 +60,22 @@ describe("FeatureSettingsSection", () => {
 
 		expect(editorSection?.querySelector('[id="Feature Tips"]')).toBeTruthy()
 		expect(agentSection?.querySelector('[id="Feature Tips"]')).toBeNull()
+	})
+
+	it("renders the Auto Compact Strategy setting in the Agent section", () => {
+		const { container } = render(<FeatureSettingsSection renderSectionHeader={() => null} />)
+
+		expect(screen.getByText("Auto Compact Strategy")).toBeTruthy()
+
+		const agentSection = container.querySelector("#agent-features")
+		expect(agentSection?.textContent).toContain("Basic")
+	})
+
+	it("disables Auto Compact Strategy when Auto Compact is off", () => {
+		const { container } = render(<FeatureSettingsSection renderSectionHeader={() => null} />)
+
+		const strategySelect = container.querySelector("#agent-features button[role='combobox']")
+		expect(strategySelect).toHaveAttribute("disabled")
 	})
 
 	it("calls updateSetting with hooksEnabled when toggled", () => {

--- a/apps/vscode/webview-ui/src/components/settings/sections/FeatureSettingsSection.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/sections/FeatureSettingsSection.tsx
@@ -204,7 +204,7 @@ const FeatureSettingsSection = ({ renderSectionHeader }: FeatureSettingsSectionP
 							))}
 							<div className="space-y-2 py-3">
 								<Label className="text-sm font-medium text-foreground">Auto Compact Strategy</Label>
-								<p className="text-xs text-muted-foreground">Controls how SDK auto compaction rewrites context.</p>
+								<p className="text-xs text-muted-foreground">Controls how auto compaction rewrites context.</p>
 								<Select
 									disabled={!useAutoCondense}
 									onValueChange={(value) => updateSetting("compactionStrategy", value)}

--- a/apps/vscode/webview-ui/src/components/settings/sections/FeatureSettingsSection.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/sections/FeatureSettingsSection.tsx
@@ -154,6 +154,7 @@ const FeatureSettingsSection = ({ renderSectionHeader }: FeatureSettingsSectionP
 		mcpDisplayMode,
 		yoloModeToggled,
 		useAutoCondense,
+		compactionStrategy,
 		subagentsEnabled,
 		worktreesEnabled,
 		remoteConfigSettings,
@@ -201,6 +202,22 @@ const FeatureSettingsSection = ({ renderSectionHeader }: FeatureSettingsSectionP
 									onChange={(checked) => updateSetting(feature.settingKey, checked)}
 								/>
 							))}
+							<div className="space-y-2 py-3">
+								<Label className="text-sm font-medium text-foreground">Auto Compact Strategy</Label>
+								<p className="text-xs text-muted-foreground">Controls how SDK auto compaction rewrites context.</p>
+								<Select
+									disabled={!useAutoCondense}
+									onValueChange={(value) => updateSetting("compactionStrategy", value)}
+									value={compactionStrategy ?? "basic"}>
+									<SelectTrigger className="w-full">
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										<SelectItem value="basic">Basic</SelectItem>
+										<SelectItem value="agentic">Agentic</SelectItem>
+									</SelectContent>
+								</Select>
+							</div>
 						</div>
 					</div>
 

--- a/apps/vscode/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/apps/vscode/webview-ui/src/context/ExtensionStateContext.tsx
@@ -301,6 +301,7 @@ export const ExtensionStateContextProvider: React.FC<{
 		yoloModeToggled: false,
 		customPrompt: undefined,
 		useAutoCondense: false,
+		compactionStrategy: "basic",
 		subagentsEnabled: false,
 		worktreesEnabled: { user: true, featureFlag: false },
 		favoritedModelIds: [],

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -481,16 +481,19 @@ export {
 	isPluginDisabledGlobally,
 	isTelemetryOptedOutGlobally,
 	isToolDisabledGlobally,
+	readCompactionStrategyGlobally,
 	readGlobalSettings,
 	resolveDisabledPluginPaths,
 	resolveDisabledToolNames,
 	setAutoUpdateEnabledGlobally,
+	setCompactionStrategyGlobally,
 	setDisabledPlugin,
 	setDisabledTools,
 	setTelemetryOptOutGlobally,
 	toggleDisabledTool,
 	writeGlobalSettings,
 } from "./services/global-settings";
+export type { GlobalCompactionStrategy } from "./services/global-settings";
 export type {
 	McpInstallOptions,
 	McpInstallResult,

--- a/sdk/packages/core/src/services/global-settings.test.ts
+++ b/sdk/packages/core/src/services/global-settings.test.ts
@@ -5,8 +5,10 @@ import type { ITelemetryService } from "@cline/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	GlobalSettingsSchema,
+	readCompactionStrategyGlobally,
 	readGlobalSettings,
 	setAutoUpdateEnabledGlobally,
+	setCompactionStrategyGlobally,
 	setDisabledPlugin,
 	setDisabledTools,
 	setTelemetryOptOutGlobally,
@@ -44,11 +46,13 @@ describe("global-settings", () => {
 		});
 		expect(
 			GlobalSettingsSchema.parse({
+				compactionStrategy: "agentic",
 				disabledTools: ["read_files"],
 				extra: true,
 			}),
 		).toEqual({
 			autoUpdateEnabled: true,
+			compactionStrategy: "agentic",
 			disabledTools: ["read_files"],
 			telemetryOptOut: false,
 		});
@@ -194,6 +198,20 @@ describe("global-settings", () => {
 				disabledTools: ["editor"],
 				telemetryOptOut: true,
 			});
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+
+	it("reads and writes the compaction strategy globally", async () => {
+		const root = await mkdtemp(join(tmpdir(), "core-global-settings-"));
+		try {
+			const settingsPath = join(root, "global-settings.json");
+			process.env.CLINE_GLOBAL_SETTINGS_PATH = settingsPath;
+
+			expect(readCompactionStrategyGlobally()).toBe("basic");
+			setCompactionStrategyGlobally("agentic");
+			expect(readCompactionStrategyGlobally()).toBe("agentic");
 		} finally {
 			await rm(root, { recursive: true, force: true });
 		}

--- a/sdk/packages/core/src/services/global-settings.ts
+++ b/sdk/packages/core/src/services/global-settings.ts
@@ -29,10 +29,15 @@ const GlobalSettingsStringListSchema = z
 		return normalized.length > 0 ? normalized : undefined;
 	});
 
+const GlobalCompactionStrategySchema = z.enum(["basic", "agentic"]).catch("basic");
+
+export type GlobalCompactionStrategy = z.infer<typeof GlobalCompactionStrategySchema>;
+
 export const GlobalSettingsSchema = z
 	.object({
 		telemetryOptOut: z.boolean().default(false).catch(false),
 		autoUpdateEnabled: z.boolean().default(true).catch(true),
+		compactionStrategy: GlobalCompactionStrategySchema.optional(),
 		disabledTools: GlobalSettingsStringListSchema.optional(),
 		disabledPlugins: GlobalSettingsStringListSchema.optional(),
 	})
@@ -41,12 +46,16 @@ export const GlobalSettingsSchema = z
 		const normalized: {
 			telemetryOptOut: boolean;
 			autoUpdateEnabled: boolean;
+			compactionStrategy?: GlobalCompactionStrategy;
 			disabledTools?: string[];
 			disabledPlugins?: string[];
 		} = {
 			autoUpdateEnabled: settings.autoUpdateEnabled,
 			telemetryOptOut: settings.telemetryOptOut,
 		};
+		if (settings.compactionStrategy) {
+			normalized.compactionStrategy = settings.compactionStrategy;
+		}
 		if (settings.disabledTools?.length) {
 			normalized.disabledTools = settings.disabledTools;
 		}
@@ -178,6 +187,16 @@ export function setAutoUpdateEnabledGlobally(
 		},
 		options,
 	);
+}
+
+export function readCompactionStrategyGlobally(): GlobalCompactionStrategy {
+	return readGlobalSettings().compactionStrategy ?? "basic";
+}
+
+export function setCompactionStrategyGlobally(
+	compactionStrategy: GlobalCompactionStrategy,
+): void {
+	writeGlobalSettings({ ...readGlobalSettings(), compactionStrategy });
 }
 
 export function resolveDisabledToolNames(

--- a/sdk/packages/core/src/types.ts
+++ b/sdk/packages/core/src/types.ts
@@ -128,16 +128,19 @@ export {
 	isPluginDisabledGlobally,
 	isTelemetryOptedOutGlobally,
 	isToolDisabledGlobally,
+	readCompactionStrategyGlobally,
 	readGlobalSettings,
 	resolveDisabledPluginPaths,
 	resolveDisabledToolNames,
 	setAutoUpdateEnabledGlobally,
+	setCompactionStrategyGlobally,
 	setDisabledPlugin,
 	setDisabledTools,
 	setTelemetryOptOutGlobally,
 	toggleDisabledTool,
 	writeGlobalSettings,
 } from "./services/global-settings";
+export type { GlobalCompactionStrategy } from "./services/global-settings";
 export type {
 	ListPluginToolsResult,
 	PluginToolSummary,


### PR DESCRIPTION
## Summary
- add a persisted VS Code SDK compaction strategy setting
- keep Auto Compact as the existing on/off switch, defaulting strategy to basic
- pass basic/agentic into SDK session compaction config when auto compact is enabled

## Verification
- `bun -F @cline/core build`
- `bun -F claude-dev check-types`
- `bun -F claude-dev lint`
- `bun test src/sdk/cline-session-factory.test.ts` from `apps/vscode`
- `bun run test src/components/settings/sections/FeatureSettingsSection.spec.tsx` from `apps/vscode/webview-ui`
