### PR TITLE
Add open subscription page option to the ClinePass options

### DIFF
--- a/apps/cli/src/tui/components/dialogs/provider-picker.tsx
+++ b/apps/cli/src/tui/components/dialogs/provider-picker.tsx
@@ -354,19 +354,13 @@ export function ClinePassSubscriptionContent(
 	const [status, setStatus] = useState("Opening browser...");
 
 	useEffect(() => {
-		try {
-			void open(subscriptionUrl, { wait: false })
-				.then(() => {
-					setStatus("Opened subscription page in your browser.");
-				})
-				.catch(() => {
-					setStatus(
-						"Could not open browser automatically. Open the URL below.",
-					);
-				});
-		} catch {
-			setStatus("Could not open browser automatically. Open the URL below.");
-		}
+		void open(subscriptionUrl, { wait: false })
+			.then(() => {
+				setStatus("Opened subscription page in your browser.");
+			})
+			.catch(() => {
+				setStatus("Could not open browser automatically. Open the URL below.");
+			});
 	}, [subscriptionUrl]);
 
 	useDialogKeyboard((key) => {
@@ -393,7 +387,7 @@ export function ClinePassSubscriptionContent(
 			</text>
 
 			<text fg="gray">
-				<em>Enter to go back, Esc to cancel</em>
+				<em>Enter or Esc to go back</em>
 			</text>
 		</box>
 	);

--- a/apps/cli/src/tui/components/dialogs/provider-picker.tsx
+++ b/apps/cli/src/tui/components/dialogs/provider-picker.tsx
@@ -248,18 +248,44 @@ export function ProviderPickerContent(
 	);
 }
 
-export type ExistingProviderAction = "use_existing" | "reconfigure";
+export type ExistingProviderAction =
+	| "use_existing"
+	| "reconfigure"
+	| "open_subscription";
+
+export interface ExistingProviderOption {
+	value: ExistingProviderAction;
+	label: string;
+	onSelect?: () => Promise<void> | void;
+}
+
+const CLINE_PASS_SUBSCRIPTION_PATH = "/dashboard/subscription";
+const DEFAULT_APP_BASE_URL = "https://app.cline.bot";
+
+export function buildClinePassSubscriptionPageUrl(
+	appBaseUrl: string | undefined,
+): string {
+	return new URL(
+		CLINE_PASS_SUBSCRIPTION_PATH,
+		appBaseUrl || DEFAULT_APP_BASE_URL,
+	).toString();
+}
 
 export function UseExistingOrReconfigureContent(
-	props: ChoiceContext<ExistingProviderAction> & {
+	props: ChoiceContext<ExistingProviderOption> & {
 		providerName: string;
+		extraOptions?: ExistingProviderOption[];
 	},
 ) {
-	const { resolve, dismiss, dialogId, providerName } = props;
-	const options: { value: ExistingProviderAction; label: string }[] = [
-		{ value: "use_existing", label: "Use existing configuration" },
-		{ value: "reconfigure", label: "Configure again" },
-	];
+	const { resolve, dismiss, dialogId, providerName, extraOptions } = props;
+	const options: ExistingProviderOption[] = useMemo(
+		() => [
+			{ value: "use_existing", label: "Use existing configuration" },
+			{ value: "reconfigure", label: "Configure again" },
+			...(extraOptions ?? []),
+		],
+		[extraOptions],
+	);
 	const [selected, setSelected] = useState(0);
 
 	useDialogKeyboard((key) => {
@@ -269,7 +295,7 @@ export function UseExistingOrReconfigureContent(
 		}
 		if (key.name === "return" || key.name === "enter") {
 			const opt = options[selected];
-			if (opt) resolve(opt.value);
+			if (opt) resolve(opt);
 			return;
 		}
 		if (key.name === "up" || (key.ctrl && key.name === "p")) {
@@ -310,6 +336,65 @@ export function UseExistingOrReconfigureContent(
 			</box>
 
 			<text fg="gray">↑/↓ navigate, Enter to select, Esc to go back</text>
+		</box>
+	);
+}
+
+export function ClinePassSubscriptionContent(
+	props: ChoiceContext<boolean> & {
+		providerName: string;
+	},
+) {
+	const { resolve, dismiss, dialogId, providerName } = props;
+	const subscriptionUrl = useMemo(
+		() =>
+			buildClinePassSubscriptionPageUrl(getClineEnvironmentConfig().appBaseUrl),
+		[],
+	);
+	const [status, setStatus] = useState("Opening browser...");
+
+	useEffect(() => {
+		try {
+			void open(subscriptionUrl, { wait: false })
+				.then(() => {
+					setStatus("Opened subscription page in your browser.");
+				})
+				.catch(() => {
+					setStatus(
+						"Could not open browser automatically. Open the URL below.",
+					);
+				});
+		} catch {
+			setStatus("Could not open browser automatically. Open the URL below.");
+		}
+	}, [subscriptionUrl]);
+
+	useDialogKeyboard((key) => {
+		if (key.name === "escape") {
+			dismiss();
+			return;
+		}
+		if (key.name === "return" || key.name === "enter") {
+			resolve(true);
+		}
+	}, dialogId);
+
+	return (
+		<box flexDirection="column" paddingX={1} gap={1}>
+			<text fg="cyan">
+				<strong>{providerName}</strong>
+			</text>
+
+			<text>{status}</text>
+
+			<text fg="gray">Subscription page:</text>
+			<text fg="cyan" selectable>
+				<a href={subscriptionUrl}>{subscriptionUrl}</a>
+			</text>
+
+			<text fg="gray">
+				<em>Enter to go back, Esc to cancel</em>
+			</text>
 		</box>
 	);
 }

--- a/apps/cli/src/tui/hooks/use-model-selector.tsx
+++ b/apps/cli/src/tui/hooks/use-model-selector.tsx
@@ -18,8 +18,9 @@ import {
 import type { Config } from "../../utils/types";
 import { withLoadingDialog } from "../components/dialogs/loading-dialog";
 import {
+	ClinePassSubscriptionContent,
 	CodexCliStatusContent,
-	type ExistingProviderAction,
+	type ExistingProviderOption,
 	OAuthLoginContent,
 	ProviderConfigInputContent,
 	ProviderPickerContent,
@@ -78,6 +79,36 @@ function usesModelIdInput(providerId: string): boolean {
 	return providerId === "openai-compatible";
 }
 
+function providerToExistingProviderOptions(input: {
+	providerId: string;
+	providerName: string;
+	dialog: DialogActions;
+	termHeight: number;
+}): ExistingProviderOption[] {
+	if (input.providerId !== "cline-pass") {
+		return [];
+	}
+
+	return [
+		{
+			value: "open_subscription",
+			label: "Open ClinePass subscription page",
+			onSelect: async () => {
+				await input.dialog.choice<boolean>({
+					style: { maxHeight: input.termHeight - 2 },
+					closeOnEscape: false,
+					content: (ctx: ChoiceContext<boolean>) => (
+						<ClinePassSubscriptionContent
+							{...ctx}
+							providerName={input.providerName}
+						/>
+					),
+				});
+			},
+		},
+	];
+}
+
 async function runProviderChange(
 	dialog: DialogActions,
 	config: Config,
@@ -102,14 +133,33 @@ async function runProviderChange(
 
 	let needsAuth = true;
 	if (isProviderConfigured(newProviderId, existingSettings)) {
-		const action = await dialog.choice<ExistingProviderAction>({
-			style: { maxHeight: termHeight - 2 },
-			content: (ctx: ChoiceContext<ExistingProviderAction>) => (
-				<UseExistingOrReconfigureContent {...ctx} providerName={displayName} />
-			),
+		let option: ExistingProviderOption | undefined;
+		const extraOptions = providerToExistingProviderOptions({
+			providerId: newProviderId,
+			providerName: displayName,
+			dialog,
+			termHeight,
 		});
-		if (!action) return false;
-		needsAuth = action === "reconfigure";
+		while (true) {
+			option = await dialog.choice<ExistingProviderOption>({
+				style: { maxHeight: termHeight - 2 },
+				content: (ctx: ChoiceContext<ExistingProviderOption>) => (
+					<UseExistingOrReconfigureContent
+						{...ctx}
+						providerName={displayName}
+						extraOptions={extraOptions}
+					/>
+				),
+			});
+			if (!option) return false;
+			if (option.onSelect) {
+				await option.onSelect();
+				option = undefined;
+				continue;
+			}
+			break;
+		}
+		needsAuth = option.value === "reconfigure";
 	}
 
 	if (needsAuth) {


### PR DESCRIPTION
### Description

We want to add a way of opening the subscription page through the provider options

### Test Procedure

Tested locally
<img width="429" height="139" alt="image" src="https://github.com/user-attachments/assets/efc36803-c2ff-4329-b611-cad1165662c9" />
<img width="429" height="139" alt="image" src="https://github.com/user-attachments/assets/9d49bb7e-1afc-475f-9635-1b2f2967fe49" />


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)