### PR TITLE
Fix auto-approved command row UI

### DIFF
--- a/apps/vscode/webview-ui/src/components/chat/ChatRow.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatRow.tsx
@@ -230,7 +230,7 @@ export const ChatRowContent = memo(
 			isCommandMessage &&
 			!isCommandCompleted &&
 			!isCommandPending &&
-			(commandHasOutput || message.partial === true || (isLast && backgroundCommandRunning))
+			(commandHasOutput || message.partial === true || (isLast && backgroundCommandRunning === true))
 		const commandTitle = isCommandCompleted
 			? "Cline executed this command:"
 			: isCommandPending

--- a/apps/vscode/webview-ui/src/components/chat/ChatRow.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatRow.tsx
@@ -148,7 +148,14 @@ export const ChatRowContent = memo(
 		reasoningContent,
 		responseStarted,
 	}: ChatRowContentProps) => {
-		const { backgroundEditEnabled, mcpServers, vscodeTerminalExecutionMode, clineMessages, showFeatureTips } =
+		const {
+			backgroundCommandRunning,
+			backgroundEditEnabled,
+			mcpServers,
+			vscodeTerminalExecutionMode,
+			clineMessages,
+			showFeatureTips,
+		} =
 			useExtensionState()
 		const [quoteButtonState, setQuoteButtonState] = useState<QuoteButtonState>({
 			visible: false,
@@ -210,11 +217,27 @@ export const ChatRowContent = memo(
 		const isCommandMessage = type === "command"
 		// Check if command has output to determine if it's actually executing
 		const commandHasOutput = message.text?.includes(COMMAND_OUTPUT_STRING) ?? false
-		// A command is executing if it has output but hasn't completed yet
-		const isCommandExecuting = isCommandMessage && !message.commandCompleted && commandHasOutput
-		// A command is pending if it hasn't started (no output) and hasn't completed
-		const isCommandPending = isCommandMessage && isLast && !message.commandCompleted && !commandHasOutput
 		const isCommandCompleted = isCommandMessage && message.commandCompleted === true
+		const isCommandPending =
+			isCommandMessage &&
+			!isCommandCompleted &&
+			message.type === "ask" &&
+			isLast &&
+			!commandHasOutput &&
+			!backgroundCommandRunning &&
+			!message.partial
+		const isCommandExecuting =
+			isCommandMessage &&
+			!isCommandCompleted &&
+			!isCommandPending &&
+			(commandHasOutput || message.partial === true || (isLast && backgroundCommandRunning))
+		const commandTitle = isCommandCompleted
+			? "Cline executed this command:"
+			: isCommandPending
+				? "Cline wants to execute this command:"
+				: isCommandExecuting
+					? "Cline is executing this command:"
+					: "Cline did not execute this command:"
 
 		const isMcpServerResponding = isLast && lastModifiedMessage?.say === "mcp_server_request_started"
 
@@ -308,7 +331,7 @@ export const ChatRowContent = memo(
 				case "command":
 					return [
 						<TerminalIcon className="text-foreground size-2" />,
-						<span className="font-bold text-foreground">Cline wants to execute this command:</span>,
+						<span className="font-bold text-foreground">{commandTitle}</span>,
 					]
 				case "use_mcp_server":
 					const mcpServerUse = JSON.parse(message.text || "{}") as ClineAskUseMcpServer
@@ -344,8 +367,7 @@ export const ChatRowContent = memo(
 			type,
 			cost,
 			apiRequestFailedMessage,
-			isCommandExecuting,
-			isCommandPending,
+			commandTitle,
 			apiReqCancelReason,
 			isMcpServerResponding,
 			message.text,

--- a/apps/vscode/webview-ui/src/components/chat/CommandOutputRow.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/CommandOutputRow.test.tsx
@@ -1,6 +1,6 @@
-import { act, render, waitFor } from "@testing-library/react"
+import { act, render, screen, waitFor } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
-import { CommandOutputContent } from "./CommandOutputRow"
+import { CommandOutputContent, CommandOutputRow } from "./CommandOutputRow"
 
 vi.mock("../common/CodeBlock", () => ({
 	default: ({ source }: { source: string }) => <pre>{source}</pre>,
@@ -75,5 +75,22 @@ describe("CommandOutputContent", () => {
 
 		await act(async () => {})
 		expect(onOutputChange).not.toHaveBeenCalled()
+	})
+})
+
+describe("CommandOutputRow", () => {
+	it("shows a spinner while a command is running", () => {
+		render(
+			<CommandOutputRow
+				isCommandExecuting={true}
+				isOutputFullyExpanded={false}
+				message={{ ts: 1, type: "say", say: "command", text: "sleep 10" }}
+				setIsOutputFullyExpanded={vi.fn()}
+				title={<span>Cline is executing this command:</span>}
+			/>,
+		)
+
+		expect(screen.getByLabelText("Command running")).toBeInTheDocument()
+		expect(screen.getByText("Running")).toBeInTheDocument()
 	})
 })

--- a/apps/vscode/webview-ui/src/components/chat/CommandOutputRow.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/CommandOutputRow.tsx
@@ -1,6 +1,7 @@
 import { COMMAND_OUTPUT_STRING, COMMAND_REQ_APP_STRING } from "@shared/combineCommandSequences"
 import { ClineMessage } from "@shared/ExtensionMessage"
 import { StringRequest } from "@shared/proto/cline/common"
+import { LoaderCircleIcon } from "lucide-react"
 import { memo, useEffect, useRef } from "react"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
@@ -194,15 +195,19 @@ export const CommandOutputRow = memo(
 					{command && (
 						<div className="bg-code flex items-center justify-between px-2 py-2.5 border-b border-editor-group-border rounded-sm rounded-b-none overflow-hidden">
 							<div className="flex items-center gap-2 flex-1 m-w-0">
-								<div
-									className={cn("bg-description rounded-full w-2 h-2 shrink-0", {
-										"bg-success animate-pulse": isCommandExecuting,
-										"bg-editor-warning-foreground": isCommandPending,
-									})}
-								/>
+								{isCommandExecuting ? (
+									<LoaderCircleIcon aria-label="Command running" className="size-3 shrink-0 animate-spin text-success" />
+								) : (
+									<div
+										className={cn("bg-description rounded-full w-2 h-2 shrink-0", {
+											"bg-editor-warning-foreground": isCommandPending,
+											"bg-success": isCommandCompleted,
+										})}
+									/>
+								)}
 								<span
 									className={cn("text-description font-medium text-base shrink-0", {
-										"text-success": isCommandExecuting,
+										"text-success": isCommandExecuting || isCommandCompleted,
 										"text-editor-warning-foreground": isCommandPending,
 									})}>
 									{getCommandStatusText(isCommandExecuting, isCommandPending, isCommandCompleted)}


### PR DESCRIPTION
### Related Issue

**Issue:** CLINE-2298

### Description

Fixes the command row UI for auto-approved command execution.

When command execution is auto-approved, the row no longer reads as though Cline is still asking for permission. Running rows now say that Cline is executing the command, completed rows say the command was executed, and the running status uses a real spinner instead of a pulsing dot.

### Test Procedure

Ran the focused command row test:

`node node_modules/vitest/vitest.mjs run src/components/chat/CommandOutputRow.test.tsx`

Also ran:

`git diff --check`

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not included.

### Additional Notes

Full webview typecheck was not run successfully in this checkout because existing generated/shared API mismatches and a missing workspace dependency (`@cline/llms`) fail before this change.
