### PR TITLE
Persist VS Code manual compaction sidecar

### DIFF
--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -1136,8 +1136,8 @@ export class Controller {
 	 * Manually compact (condense) the active task's conversation. Triggered by
 	 * the compact button and the `/compact` (alias `/smol`) slash command.
 	 * Mirrors the CLI's `/compact` local command: runs an SDK manual compaction
-	 * and restarts the session with the compacted transcript so the model's
-	 * working context is actually reduced.
+	 * and persists the compaction sidecar so the model's working context is
+	 * reduced on the next turn and later resumes.
 	 */
 	async compactTask(): Promise<void> {
 		await this.compaction.compactTask()

--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -511,10 +511,7 @@ export class Controller {
 			sessions: this.sessions,
 			messages: this.messages,
 			sessionConfigBuilder: this.sessionConfigBuilder,
-			getTask: () => this.task,
 			getWorkspaceRoot: () => this.getWorkspaceRoot(),
-			buildStartSessionInput,
-			resetMessageTranslator: () => this.resetMessageTranslatorAndFence(),
 			postStateToWebview: () => this.postStateToWebview(),
 		})
 		this.sessionEvents = new SdkSessionEventCoordinator({

--- a/apps/vscode/src/sdk/sdk-compaction-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-compaction-coordinator.test.ts
@@ -3,6 +3,16 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import type { StateManager } from "@/core/storage/StateManager"
 import { SdkCompactionCoordinator, type SdkCompactionCoordinatorOptions } from "./sdk-compaction-coordinator"
 
+const createContextCompactionPrepareTurn = vi.fn()
+const createSessionCompactionState = vi.fn((input: { compactedMessages: unknown[] }) => ({
+	version: 1,
+	messages: input.compactedMessages,
+}))
+vi.mock("@cline/core", () => ({
+	createContextCompactionPrepareTurn: (...args: unknown[]) => createContextCompactionPrepareTurn(...args),
+	createSessionCompactionState: (input: { compactedMessages: unknown[] }) => createSessionCompactionState(input),
+}))
+
 vi.mock("@/shared/services/Logger", () => ({
 	Logger: {
 		debug: vi.fn(),
@@ -10,11 +20,6 @@ vi.mock("@/shared/services/Logger", () => ({
 		log: vi.fn(),
 		warn: vi.fn(),
 	},
-}))
-
-const compactSessionMessages = vi.fn()
-vi.mock("./sdk-compaction", () => ({
-	compactSessionMessages: (...args: unknown[]) => compactSessionMessages(...args),
 }))
 
 describe("SdkCompactionCoordinator", () => {
@@ -28,7 +33,7 @@ describe("SdkCompactionCoordinator", () => {
 		await coordinator.compactTask()
 
 		expect(options.sessions.replaceActiveSession).not.toHaveBeenCalled()
-		expect(compactSessionMessages).not.toHaveBeenCalled()
+		expect(createContextCompactionPrepareTurn).not.toHaveBeenCalled()
 		expect(options.messages.appendAndEmit).toHaveBeenCalledWith(
 			[expect.objectContaining({ say: "info", text: "There is no active task to compact." })],
 			expect.anything(),
@@ -41,7 +46,7 @@ describe("SdkCompactionCoordinator", () => {
 
 		await coordinator.compactTask()
 
-		expect(compactSessionMessages).not.toHaveBeenCalled()
+		expect(createContextCompactionPrepareTurn).not.toHaveBeenCalled()
 		expect(options.sessions.replaceActiveSession).not.toHaveBeenCalled()
 		expect(options.messages.appendAndEmit).toHaveBeenCalledWith(
 			[expect.objectContaining({ say: "info", text: expect.stringContaining("Cannot compact while a response") })],
@@ -56,7 +61,7 @@ describe("SdkCompactionCoordinator", () => {
 
 		await coordinator.compactTask()
 
-		expect(compactSessionMessages).not.toHaveBeenCalled()
+		expect(createContextCompactionPrepareTurn).not.toHaveBeenCalled()
 		expect(options.sessions.replaceActiveSession).not.toHaveBeenCalled()
 		expect(options.messages.appendAndEmit).toHaveBeenCalledWith(
 			[expect.objectContaining({ say: "info", text: "No messages to compact." })],
@@ -67,14 +72,11 @@ describe("SdkCompactionCoordinator", () => {
 	it("reports when the strategy declines to compact", async () => {
 		const activeSession = makeActiveSession()
 		const { coordinator, options } = makeCoordinator({ activeSession })
-		compactSessionMessages.mockResolvedValueOnce({
-			compacted: false,
-			messages: [{ role: "user", content: "a" }],
-		})
+		createContextCompactionPrepareTurn.mockReturnValueOnce(vi.fn().mockResolvedValue(undefined))
 
 		await coordinator.compactTask()
 
-		expect(compactSessionMessages).toHaveBeenCalledOnce()
+		expect(createContextCompactionPrepareTurn).toHaveBeenCalledOnce()
 		expect(options.sessions.replaceActiveSession).not.toHaveBeenCalled()
 		expect(options.messages.appendAndEmit).toHaveBeenCalledWith(
 			[expect.objectContaining({ say: "info", text: "No compaction needed." })],
@@ -91,11 +93,9 @@ describe("SdkCompactionCoordinator", () => {
 		])
 		const task = makeTask("old-session")
 		const { coordinator, options } = makeCoordinator({ activeSession, task })
-		compactSessionMessages.mockResolvedValueOnce({
-			compacted: true,
-			messages: [{ role: "user", content: "summary" }],
-			compactionState: { version: 1, messages: [{ role: "user", content: "summary" }] },
-		})
+		createContextCompactionPrepareTurn.mockReturnValueOnce(
+			vi.fn().mockResolvedValue({ messages: [{ role: "user", content: "summary" }] }),
+		)
 
 		await coordinator.compactTask()
 
@@ -136,11 +136,9 @@ describe("SdkCompactionCoordinator", () => {
 		const activeSession = makeActiveSession()
 		activeSession.sdkHost.updateSessionCompactionState.mockResolvedValueOnce({ updated: false })
 		const { coordinator, options } = makeCoordinator({ activeSession })
-		compactSessionMessages.mockResolvedValueOnce({
-			compacted: true,
-			messages: [{ role: "user", content: "summary" }],
-			compactionState: { version: 1, messages: [{ role: "user", content: "summary" }] },
-		})
+		createContextCompactionPrepareTurn.mockReturnValueOnce(
+			vi.fn().mockResolvedValue({ messages: [{ role: "user", content: "summary" }] }),
+		)
 
 		await coordinator.compactTask()
 
@@ -154,7 +152,7 @@ describe("SdkCompactionCoordinator", () => {
 	it("reports a failure when compaction throws", async () => {
 		const activeSession = makeActiveSession()
 		const { coordinator, options } = makeCoordinator({ activeSession })
-		compactSessionMessages.mockRejectedValueOnce(new Error("boom"))
+		createContextCompactionPrepareTurn.mockReturnValueOnce(vi.fn().mockRejectedValue(new Error("boom")))
 
 		await coordinator.compactTask()
 

--- a/apps/vscode/src/sdk/sdk-compaction-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-compaction-coordinator.test.ts
@@ -69,6 +69,21 @@ describe("SdkCompactionCoordinator", () => {
 		)
 	})
 
+	it("reports unsupported runtime without running compaction", async () => {
+		const activeSession = makeActiveSession()
+		;(activeSession.sdkHost as Partial<typeof activeSession.sdkHost>).updateSessionCompactionState = undefined
+		const { coordinator, options } = makeCoordinator({ activeSession })
+
+		await coordinator.compactTask()
+
+		expect(activeSession.sdkHost.readMessages).not.toHaveBeenCalled()
+		expect(mockCreateContextCompactionPrepareTurn).not.toHaveBeenCalled()
+		expect(options.messages.appendAndEmit).toHaveBeenCalledWith(
+			[expect.objectContaining({ say: "info", text: expect.stringContaining("not supported") })],
+			expect.anything(),
+		)
+	})
+
 	it("reports when the strategy declines to compact", async () => {
 		const activeSession = makeActiveSession()
 		const { coordinator, options } = makeCoordinator({ activeSession })
@@ -107,6 +122,22 @@ describe("SdkCompactionCoordinator", () => {
 			[expect.objectContaining({ say: "info", text: "Compacted 3 messages to 1." })],
 			expect.anything(),
 		)
+	})
+
+	it("does not append compaction status to a different active session", async () => {
+		const activeSession = makeActiveSession()
+		const { coordinator, options } = makeCoordinator({ activeSession })
+		options.sessions.getActiveSession
+			.mockReturnValueOnce(activeSession)
+			.mockReturnValueOnce(makeActiveSession({ sessionId: "other-session" }))
+		mockCreateContextCompactionPrepareTurn.mockReturnValueOnce(
+			vi.fn().mockResolvedValue({ messages: [{ role: "user", content: "summary" }] }),
+		)
+
+		await coordinator.compactTask()
+
+		expect(activeSession.sdkHost.updateSessionCompactionState).toHaveBeenCalled()
+		expect(options.messages.appendAndEmit).not.toHaveBeenCalled()
 	})
 
 	it("does not restart or report success when sidecar persistence fails", async () => {
@@ -196,9 +227,9 @@ function makeCoordinator(input: Partial<MakeCoordinatorInput> = {}) {
 	}
 }
 
-function makeActiveSession(input: { isRunning?: boolean } = {}) {
+function makeActiveSession(input: { isRunning?: boolean; sessionId?: string } = {}) {
 	return {
-		sessionId: "old-session",
+		sessionId: input.sessionId ?? "old-session",
 		sdkHost: {
 			readMessages: vi.fn().mockResolvedValue([{ role: "user", content: "1" }]),
 			updateSessionCompactionState: vi.fn().mockResolvedValue({ updated: true }),

--- a/apps/vscode/src/sdk/sdk-compaction-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-compaction-coordinator.test.ts
@@ -94,10 +94,15 @@ describe("SdkCompactionCoordinator", () => {
 		compactSessionMessages.mockResolvedValueOnce({
 			compacted: true,
 			messages: [{ role: "user", content: "summary" }],
+			compactionState: { version: 1, messages: [{ role: "user", content: "summary" }] },
 		})
 
 		await coordinator.compactTask()
 
+		expect(activeSession.sdkHost.updateSessionCompactionState).toHaveBeenCalledWith("old-session", {
+			version: 1,
+			messages: [{ role: "user", content: "summary" }],
+		})
 		expect(options.buildStartSessionInput).toHaveBeenCalledWith(expect.objectContaining({ sessionId: "old-session" }), {
 			cwd: "/workspace",
 			mode: "act",
@@ -106,15 +111,42 @@ describe("SdkCompactionCoordinator", () => {
 			startInput: expect.objectContaining({
 				config: expect.objectContaining({ sessionId: "old-session" }),
 				interactive: true,
+				initialCompactionState: {
+					version: 1,
+					messages: [{ role: "user", content: "summary" }],
+				},
 				prompt: undefined,
 			}),
-			initialMessages: [{ role: "user", content: "summary" }],
+			initialMessages: [
+				{ role: "user", content: "1" },
+				{ role: "assistant", content: "2" },
+				{ role: "user", content: "3" },
+			],
 			disposeReason: "compactTask",
 		})
 		expect(task.taskId).toBe("new-session")
 		expect(options.resetMessageTranslator).toHaveBeenCalledOnce()
 		expect(options.messages.appendAndEmit).toHaveBeenCalledWith(
 			[expect.objectContaining({ say: "info", text: "Compacted 3 messages to 1." })],
+			expect.anything(),
+		)
+	})
+
+	it("does not restart or report success when sidecar persistence fails", async () => {
+		const activeSession = makeActiveSession()
+		activeSession.sdkHost.updateSessionCompactionState.mockResolvedValueOnce({ updated: false })
+		const { coordinator, options } = makeCoordinator({ activeSession })
+		compactSessionMessages.mockResolvedValueOnce({
+			compacted: true,
+			messages: [{ role: "user", content: "summary" }],
+			compactionState: { version: 1, messages: [{ role: "user", content: "summary" }] },
+		})
+
+		await coordinator.compactTask()
+
+		expect(options.sessions.replaceActiveSession).not.toHaveBeenCalled()
+		expect(options.messages.appendAndEmit).toHaveBeenCalledWith(
+			[expect.objectContaining({ say: "info", text: "Compaction failed: Compaction sidecar could not be persisted." })],
 			expect.anything(),
 		)
 	})
@@ -204,6 +236,7 @@ function makeActiveSession(input: { isRunning?: boolean } = {}) {
 		sessionId: "old-session",
 		sdkHost: {
 			readMessages: vi.fn().mockResolvedValue([{ role: "user", content: "1" }]),
+			updateSessionCompactionState: vi.fn().mockResolvedValue({ updated: true }),
 			send: vi.fn(),
 			abort: vi.fn().mockResolvedValue(undefined),
 			stop: vi.fn().mockResolvedValue(undefined),

--- a/apps/vscode/src/sdk/sdk-compaction-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-compaction-coordinator.test.ts
@@ -1,5 +1,4 @@
 import { createContextCompactionPrepareTurn } from "@cline/core"
-import type { ClineMessage } from "@shared/ExtensionMessage"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import type { StateManager } from "@/core/storage/StateManager"
 import { SdkCompactionCoordinator, type SdkCompactionCoordinatorOptions } from "./sdk-compaction-coordinator"
@@ -85,15 +84,14 @@ describe("SdkCompactionCoordinator", () => {
 		)
 	})
 
-	it("compacts and restarts the session, preserving the session id", async () => {
+	it("compacts and persists the sidecar without rebuilding the session", async () => {
 		const activeSession = makeActiveSession()
 		activeSession.sdkHost.readMessages.mockResolvedValueOnce([
 			{ role: "user", content: "1" },
 			{ role: "assistant", content: "2" },
 			{ role: "user", content: "3" },
 		])
-		const task = makeTask("old-session")
-		const { coordinator, options } = makeCoordinator({ activeSession, task })
+		const { coordinator, options } = makeCoordinator({ activeSession })
 		mockCreateContextCompactionPrepareTurn.mockReturnValueOnce(
 			vi.fn().mockResolvedValue({ messages: [{ role: "user", content: "summary" }] }),
 		)
@@ -104,29 +102,7 @@ describe("SdkCompactionCoordinator", () => {
 			version: 1,
 			messages: [{ role: "user", content: "summary" }],
 		})
-		expect(options.buildStartSessionInput).toHaveBeenCalledWith(expect.objectContaining({ sessionId: "old-session" }), {
-			cwd: "/workspace",
-			mode: "act",
-		})
-		expect(options.sessions.replaceActiveSession).toHaveBeenCalledWith({
-			startInput: expect.objectContaining({
-				config: expect.objectContaining({ sessionId: "old-session" }),
-				interactive: true,
-				initialCompactionState: {
-					version: 1,
-					messages: [{ role: "user", content: "summary" }],
-				},
-				prompt: undefined,
-			}),
-			initialMessages: [
-				{ role: "user", content: "1" },
-				{ role: "assistant", content: "2" },
-				{ role: "user", content: "3" },
-			],
-			disposeReason: "compactTask",
-		})
-		expect(task.taskId).toBe("new-session")
-		expect(options.resetMessageTranslator).toHaveBeenCalledOnce()
+		expect(options.sessions.replaceActiveSession).not.toHaveBeenCalled()
 		expect(options.messages.appendAndEmit).toHaveBeenCalledWith(
 			[expect.objectContaining({ say: "info", text: "Compacted 3 messages to 1." })],
 			expect.anything(),
@@ -145,7 +121,7 @@ describe("SdkCompactionCoordinator", () => {
 
 		expect(options.sessions.replaceActiveSession).not.toHaveBeenCalled()
 		expect(options.messages.appendAndEmit).toHaveBeenCalledWith(
-			[expect.objectContaining({ say: "info", text: "Compaction failed: Compaction sidecar could not be persisted." })],
+			[expect.objectContaining({ say: "info", text: "Couldn't compact the conversation. Please try again." })],
 			expect.anything(),
 		)
 	})
@@ -159,7 +135,7 @@ describe("SdkCompactionCoordinator", () => {
 
 		expect(options.sessions.replaceActiveSession).not.toHaveBeenCalled()
 		expect(options.messages.appendAndEmit).toHaveBeenCalledWith(
-			[expect.objectContaining({ say: "info", text: "Compaction failed: boom" })],
+			[expect.objectContaining({ say: "info", text: "Couldn't compact the conversation. Please try again." })],
 			expect.anything(),
 		)
 	})
@@ -167,7 +143,6 @@ describe("SdkCompactionCoordinator", () => {
 
 interface MakeCoordinatorInput {
 	activeSession: ReturnType<typeof makeActiveSession> | undefined
-	task: ReturnType<typeof makeTask>
 }
 
 function makeCoordinator(input: Partial<MakeCoordinatorInput> = {}) {
@@ -199,14 +174,7 @@ function makeCoordinator(input: Partial<MakeCoordinatorInput> = {}) {
 		sessionConfigBuilder: {
 			build: vi.fn().mockResolvedValue(config),
 		},
-		getTask: vi.fn(() => input.task),
 		getWorkspaceRoot: vi.fn().mockResolvedValue("/workspace"),
-		buildStartSessionInput: vi.fn((startConfig) => ({
-			config: startConfig,
-			prompt: undefined,
-			interactive: true,
-		})),
-		resetMessageTranslator: vi.fn(),
 		postStateToWebview: vi.fn().mockResolvedValue(undefined),
 	} as unknown as SdkCompactionCoordinatorOptions & {
 		sessions: SdkCompactionCoordinatorOptions["sessions"] & {
@@ -219,8 +187,6 @@ function makeCoordinator(input: Partial<MakeCoordinatorInput> = {}) {
 		sessionConfigBuilder: SdkCompactionCoordinatorOptions["sessionConfigBuilder"] & {
 			build: ReturnType<typeof vi.fn>
 		}
-		buildStartSessionInput: ReturnType<typeof vi.fn>
-		resetMessageTranslator: ReturnType<typeof vi.fn>
 		postStateToWebview: ReturnType<typeof vi.fn>
 	}
 
@@ -244,17 +210,5 @@ function makeActiveSession(input: { isRunning?: boolean } = {}) {
 		unsubscribe: vi.fn(),
 		startResult: { sessionId: "old-session" },
 		isRunning: input.isRunning ?? false,
-	}
-}
-
-function makeTask(taskId: string, messages: Array<Partial<ClineMessage>> = []) {
-	return {
-		taskId,
-		messageStateHandler: {
-			getClineMessages: vi.fn(() => messages as ClineMessage[]),
-		},
-	} as unknown as {
-		taskId: string
-		messageStateHandler: { getClineMessages: () => ClineMessage[] }
 	}
 }

--- a/apps/vscode/src/sdk/sdk-compaction-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-compaction-coordinator.test.ts
@@ -1,17 +1,18 @@
+import { createContextCompactionPrepareTurn } from "@cline/core"
 import type { ClineMessage } from "@shared/ExtensionMessage"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import type { StateManager } from "@/core/storage/StateManager"
 import { SdkCompactionCoordinator, type SdkCompactionCoordinatorOptions } from "./sdk-compaction-coordinator"
 
-const createContextCompactionPrepareTurn = vi.fn()
-const createSessionCompactionState = vi.fn((input: { compactedMessages: unknown[] }) => ({
-	version: 1,
-	messages: input.compactedMessages,
-}))
 vi.mock("@cline/core", () => ({
-	createContextCompactionPrepareTurn,
-	createSessionCompactionState,
+	createContextCompactionPrepareTurn: vi.fn(),
+	createSessionCompactionState: vi.fn((input: { compactedMessages: unknown[] }) => ({
+		version: 1,
+		messages: input.compactedMessages,
+	})),
 }))
+
+const mockCreateContextCompactionPrepareTurn = createContextCompactionPrepareTurn as unknown as ReturnType<typeof vi.fn>
 
 vi.mock("@/shared/services/Logger", () => ({
 	Logger: {
@@ -33,7 +34,7 @@ describe("SdkCompactionCoordinator", () => {
 		await coordinator.compactTask()
 
 		expect(options.sessions.replaceActiveSession).not.toHaveBeenCalled()
-		expect(createContextCompactionPrepareTurn).not.toHaveBeenCalled()
+		expect(mockCreateContextCompactionPrepareTurn).not.toHaveBeenCalled()
 		expect(options.messages.appendAndEmit).toHaveBeenCalledWith(
 			[expect.objectContaining({ say: "info", text: "There is no active task to compact." })],
 			expect.anything(),
@@ -46,7 +47,7 @@ describe("SdkCompactionCoordinator", () => {
 
 		await coordinator.compactTask()
 
-		expect(createContextCompactionPrepareTurn).not.toHaveBeenCalled()
+		expect(mockCreateContextCompactionPrepareTurn).not.toHaveBeenCalled()
 		expect(options.sessions.replaceActiveSession).not.toHaveBeenCalled()
 		expect(options.messages.appendAndEmit).toHaveBeenCalledWith(
 			[expect.objectContaining({ say: "info", text: expect.stringContaining("Cannot compact while a response") })],
@@ -61,7 +62,7 @@ describe("SdkCompactionCoordinator", () => {
 
 		await coordinator.compactTask()
 
-		expect(createContextCompactionPrepareTurn).not.toHaveBeenCalled()
+		expect(mockCreateContextCompactionPrepareTurn).not.toHaveBeenCalled()
 		expect(options.sessions.replaceActiveSession).not.toHaveBeenCalled()
 		expect(options.messages.appendAndEmit).toHaveBeenCalledWith(
 			[expect.objectContaining({ say: "info", text: "No messages to compact." })],
@@ -72,11 +73,11 @@ describe("SdkCompactionCoordinator", () => {
 	it("reports when the strategy declines to compact", async () => {
 		const activeSession = makeActiveSession()
 		const { coordinator, options } = makeCoordinator({ activeSession })
-		createContextCompactionPrepareTurn.mockReturnValueOnce(vi.fn().mockResolvedValue(undefined))
+		mockCreateContextCompactionPrepareTurn.mockReturnValueOnce(vi.fn().mockResolvedValue(undefined))
 
 		await coordinator.compactTask()
 
-		expect(createContextCompactionPrepareTurn).toHaveBeenCalledOnce()
+		expect(mockCreateContextCompactionPrepareTurn).toHaveBeenCalledOnce()
 		expect(options.sessions.replaceActiveSession).not.toHaveBeenCalled()
 		expect(options.messages.appendAndEmit).toHaveBeenCalledWith(
 			[expect.objectContaining({ say: "info", text: "No compaction needed." })],
@@ -93,7 +94,7 @@ describe("SdkCompactionCoordinator", () => {
 		])
 		const task = makeTask("old-session")
 		const { coordinator, options } = makeCoordinator({ activeSession, task })
-		createContextCompactionPrepareTurn.mockReturnValueOnce(
+		mockCreateContextCompactionPrepareTurn.mockReturnValueOnce(
 			vi.fn().mockResolvedValue({ messages: [{ role: "user", content: "summary" }] }),
 		)
 
@@ -136,7 +137,7 @@ describe("SdkCompactionCoordinator", () => {
 		const activeSession = makeActiveSession()
 		activeSession.sdkHost.updateSessionCompactionState.mockResolvedValueOnce({ updated: false })
 		const { coordinator, options } = makeCoordinator({ activeSession })
-		createContextCompactionPrepareTurn.mockReturnValueOnce(
+		mockCreateContextCompactionPrepareTurn.mockReturnValueOnce(
 			vi.fn().mockResolvedValue({ messages: [{ role: "user", content: "summary" }] }),
 		)
 
@@ -152,7 +153,7 @@ describe("SdkCompactionCoordinator", () => {
 	it("reports a failure when compaction throws", async () => {
 		const activeSession = makeActiveSession()
 		const { coordinator, options } = makeCoordinator({ activeSession })
-		createContextCompactionPrepareTurn.mockReturnValueOnce(vi.fn().mockRejectedValue(new Error("boom")))
+		mockCreateContextCompactionPrepareTurn.mockReturnValueOnce(vi.fn().mockRejectedValue(new Error("boom")))
 
 		await coordinator.compactTask()
 

--- a/apps/vscode/src/sdk/sdk-compaction-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-compaction-coordinator.test.ts
@@ -9,8 +9,8 @@ const createSessionCompactionState = vi.fn((input: { compactedMessages: unknown[
 	messages: input.compactedMessages,
 }))
 vi.mock("@cline/core", () => ({
-	createContextCompactionPrepareTurn: (...args: unknown[]) => createContextCompactionPrepareTurn(...args),
-	createSessionCompactionState: (input: { compactedMessages: unknown[] }) => createSessionCompactionState(input),
+	createContextCompactionPrepareTurn,
+	createSessionCompactionState,
 }))
 
 vi.mock("@/shared/services/Logger", () => ({

--- a/apps/vscode/src/sdk/sdk-compaction-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-compaction-coordinator.ts
@@ -6,9 +6,8 @@
 //
 //   1. Read the active session's transcript.
 //   2. Run a manual SDK compaction over it (sdk-compaction.ts).
-//   3. Restart the session with the compacted messages as initialMessages, so
-//      the model's working context is actually reduced (reusing the mode-rebuild
-//      replaceActiveSession path, which lazily persists on the next turn).
+//   3. Persist the SDK compaction sidecar and restart the session with that
+//      same state so resumes keep using the compacted working context.
 //
 // Before this, the VSCode button sent the literal text "/compact" to the model,
 // which the SDK does not treat as a runtime command, so the model improvised a
@@ -120,15 +119,29 @@ export class SdkCompactionCoordinator {
 			return
 		}
 
-		// Restart the session with the compacted transcript. Reusing the
+		if (!result.compactionState) {
+			throw new Error("Compaction did not return durable state.")
+		}
+		if (!sdkHost.updateSessionCompactionState) {
+			throw new Error("Compaction sidecar persistence is unavailable.")
+		}
+		const persisted = await sdkHost.updateSessionCompactionState(sessionId, result.compactionState)
+		if (!persisted.updated) {
+			throw new Error("Compaction sidecar could not be persisted.")
+		}
+
+		// Restart with canonical messages plus the sidecar state. Reusing the
 		// sessionId keeps the task identity (history item, task header) stable;
 		// replaceActiveSession waits for the old session's stop before starting
 		// the replacement (same sequencing as a mode rebuild).
 		config.sessionId = sessionId
-		const startInput = this.options.buildStartSessionInput(config, { cwd, mode })
+		const startInput = {
+			...this.options.buildStartSessionInput(config, { cwd, mode }),
+			initialCompactionState: result.compactionState,
+		}
 		const rebuildResult = await this.options.sessions.replaceActiveSession({
 			startInput,
-			initialMessages: result.messages as InitialMessages,
+			initialMessages: messages as InitialMessages,
 			disposeReason: "compactTask",
 		})
 		if (!rebuildResult) {

--- a/apps/vscode/src/sdk/sdk-compaction-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-compaction-coordinator.ts
@@ -6,8 +6,8 @@
 //
 //   1. Read the active session's transcript.
 //   2. Run a manual SDK compaction over it (sdk-compaction.ts).
-//   3. Persist the SDK compaction sidecar and restart the session with that
-//      same state so resumes keep using the compacted working context.
+//   3. Persist the SDK compaction sidecar so the next turn and resumes keep
+//      using the compacted working context.
 //
 // Before this, the VSCode button sent the literal text "/compact" to the model,
 // which the SDK does not treat as a runtime command, so the model improvised a
@@ -23,22 +23,15 @@ import type { SdkMessageCoordinator } from "./sdk-message-coordinator"
 import type { SdkSessionConfigBuilder } from "./sdk-session-config-builder"
 import type { SdkSessionLifecycle } from "./sdk-session-lifecycle"
 import type { SdkSessionHost } from "./session-host"
-import type { TaskProxy } from "./task-proxy"
-import type { VscodeSessionHost } from "./vscode-session-host"
 
-type StartInput = Parameters<VscodeSessionHost["start"]>[0]
-type InitialMessages = StartInput["initialMessages"]
-type SessionConfig = Awaited<ReturnType<SdkSessionConfigBuilder["build"]>>
+const COMPACTION_FAILURE_MESSAGE = "Couldn't compact the conversation. Please try again."
 
 export interface SdkCompactionCoordinatorOptions {
 	stateManager: StateManager
 	sessions: SdkSessionLifecycle
 	messages: SdkMessageCoordinator
 	sessionConfigBuilder: SdkSessionConfigBuilder
-	getTask: () => TaskProxy | undefined
 	getWorkspaceRoot: () => Promise<string>
-	buildStartSessionInput: (config: SessionConfig, input: { cwd: string; mode: Mode }) => StartInput
-	resetMessageTranslator: () => void
 	postStateToWebview: () => Promise<void>
 }
 
@@ -79,7 +72,7 @@ export class SdkCompactionCoordinator {
 			await this.runCompaction(activeSession.sdkHost, activeSession.sessionId)
 		} catch (error) {
 			Logger.error("[SdkController] compactTask failed:", error)
-			this.emitInfo(`Compaction failed: ${error instanceof Error ? error.message : String(error)}`)
+			this.emitInfo(COMPACTION_FAILURE_MESSAGE)
 			await this.options.postStateToWebview()
 		} finally {
 			this.compactInFlight = false
@@ -130,42 +123,10 @@ export class SdkCompactionCoordinator {
 			throw new Error("Compaction sidecar could not be persisted.")
 		}
 
-		// Restart with canonical messages plus the sidecar state. Reusing the
-		// sessionId keeps the task identity (history item, task header) stable;
-		// replaceActiveSession waits for the old session's stop before starting
-		// the replacement (same sequencing as a mode rebuild).
-		config.sessionId = sessionId
-		const startInput = {
-			...this.options.buildStartSessionInput(config, { cwd, mode }),
-			initialCompactionState: result.compactionState,
-		}
-		const rebuildResult = await this.options.sessions.replaceActiveSession({
-			startInput,
-			initialMessages: messages as InitialMessages,
-			disposeReason: "compactTask",
-		})
-		if (!rebuildResult) {
-			this.emitInfo("Compaction could not be applied because the session was replaced.")
-			await this.options.postStateToWebview()
-			return
-		}
-
-		const { startResult } = rebuildResult
-		const task = this.options.getTask()
-		if (task && task.taskId !== startResult.sessionId) {
-			task.taskId = startResult.sessionId
-		}
-
-		// Fence the conversation boundary so any straggler events from the old
-		// session carry an older epoch and are dropped by the webview.
-		this.options.resetMessageTranslator()
-
 		this.emitInfo(this.formatCompactionStatus(messagesBefore, result.messages.length))
 		await this.options.postStateToWebview()
 
-		Logger.log(
-			`[SdkController] Compacted session ${sessionId}: ${messagesBefore} -> ${result.messages.length} messages (new session ${startResult.sessionId})`,
-		)
+		Logger.log(`[SdkController] Compacted session ${sessionId}: ${messagesBefore} -> ${result.messages.length} messages`)
 	}
 
 	private getCurrentMode(): Mode {

--- a/apps/vscode/src/sdk/sdk-compaction-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-compaction-coordinator.ts
@@ -25,6 +25,7 @@ import type { SdkSessionLifecycle } from "./sdk-session-lifecycle"
 import type { SdkSessionHost } from "./session-host"
 
 const COMPACTION_FAILURE_MESSAGE = "Couldn't compact the conversation. Please try again."
+const COMPACTION_UNSUPPORTED_MESSAGE = "Compaction is not supported by this runtime yet. Please update Cline and try again."
 
 export interface SdkCompactionCoordinatorOptions {
 	stateManager: StateManager
@@ -62,7 +63,10 @@ export class SdkCompactionCoordinator {
 		// A turn is still running; compacting mid-turn would race the live agent
 		// loop's own message persistence. Ask the user to wait until it finishes.
 		if (activeSession.isRunning) {
-			this.emitInfo("Cannot compact while a response is in progress. Try again once the current turn finishes.")
+			this.emitInfo(
+				"Cannot compact while a response is in progress. Try again once the current turn finishes.",
+				activeSession.sessionId,
+			)
 			await this.options.postStateToWebview()
 			return
 		}
@@ -72,7 +76,7 @@ export class SdkCompactionCoordinator {
 			await this.runCompaction(activeSession.sdkHost, activeSession.sessionId)
 		} catch (error) {
 			Logger.error("[SdkController] compactTask failed:", error)
-			this.emitInfo(COMPACTION_FAILURE_MESSAGE)
+			this.emitInfo(COMPACTION_FAILURE_MESSAGE, activeSession.sessionId)
 			await this.options.postStateToWebview()
 		} finally {
 			this.compactInFlight = false
@@ -80,10 +84,15 @@ export class SdkCompactionCoordinator {
 	}
 
 	private async runCompaction(sdkHost: SdkSessionHost, sessionId: string): Promise<void> {
+		if (!sdkHost.updateSessionCompactionState) {
+			this.emitInfo(COMPACTION_UNSUPPORTED_MESSAGE, sessionId)
+			await this.options.postStateToWebview()
+			return
+		}
 		const messages = (await sdkHost.readMessages(sessionId)) as SdkMessage[]
 		const messagesBefore = messages.length
 		if (messagesBefore === 0) {
-			this.emitInfo("No messages to compact.")
+			this.emitInfo("No messages to compact.", sessionId)
 			await this.options.postStateToWebview()
 			return
 		}
@@ -107,7 +116,7 @@ export class SdkCompactionCoordinator {
 		})
 
 		if (!result.compacted) {
-			this.emitInfo("No compaction needed.")
+			this.emitInfo("No compaction needed.", sessionId)
 			await this.options.postStateToWebview()
 			return
 		}
@@ -115,15 +124,12 @@ export class SdkCompactionCoordinator {
 		if (!result.compactionState) {
 			throw new Error("Compaction did not return durable state.")
 		}
-		if (!sdkHost.updateSessionCompactionState) {
-			throw new Error("Compaction sidecar persistence is unavailable.")
-		}
 		const persisted = await sdkHost.updateSessionCompactionState(sessionId, result.compactionState)
 		if (!persisted.updated) {
 			throw new Error("Compaction sidecar could not be persisted.")
 		}
 
-		this.emitInfo(this.formatCompactionStatus(messagesBefore, result.messages.length))
+		this.emitInfo(this.formatCompactionStatus(messagesBefore, result.messages.length), sessionId)
 		await this.options.postStateToWebview()
 
 		Logger.log(`[SdkController] Compacted session ${sessionId}: ${messagesBefore} -> ${result.messages.length} messages`)
@@ -142,8 +148,13 @@ export class SdkCompactionCoordinator {
 		return `Compacted ${messagesBefore} messages to ${messagesAfter}.`
 	}
 
-	private emitInfo(text: string): void {
-		const sessionId = this.options.sessions.getActiveSession()?.sessionId ?? ""
+	private emitInfo(text: string, sessionId?: string): void {
+		const activeSessionId = this.options.sessions.getActiveSession()?.sessionId
+		if (sessionId && activeSessionId !== sessionId) {
+			Logger.warn(`[SdkController] compactTask: skipped info for inactive session ${sessionId}`)
+			return
+		}
+		const targetSessionId = sessionId ?? activeSessionId ?? ""
 		const infoMessage: ClineMessage = {
 			ts: Date.now(),
 			type: "say",
@@ -153,7 +164,7 @@ export class SdkCompactionCoordinator {
 		}
 		this.options.messages.appendAndEmit([infoMessage], {
 			type: "status",
-			payload: { sessionId, status: "running" },
+			payload: { sessionId: targetSessionId, status: "running" },
 		})
 	}
 }

--- a/apps/vscode/src/sdk/sdk-compaction.test.ts
+++ b/apps/vscode/src/sdk/sdk-compaction.test.ts
@@ -40,7 +40,9 @@ describe("compactSessionMessages", () => {
 	})
 
 	it("builds a manual-mode prepareTurn and force-enables compaction", async () => {
-		const compact = vi.fn().mockResolvedValue({ messages: [{ role: "user", content: "summary" }] })
+		const compact = vi
+			.fn()
+			.mockResolvedValue({ messages: [{ role: "user", content: "summary" }], systemPrompt: "rewritten system" })
 		createContextCompactionPrepareTurn.mockReturnValueOnce(compact)
 
 		const messages = [
@@ -64,7 +66,7 @@ describe("compactSessionMessages", () => {
 			sourceMessages: messages,
 			compactedMessages: [{ role: "user", content: "summary" }],
 			conversationId: "s1",
-			systemPrompt: undefined,
+			systemPrompt: "rewritten system",
 		})
 		expect(result).toEqual({
 			compacted: true,

--- a/apps/vscode/src/sdk/sdk-compaction.test.ts
+++ b/apps/vscode/src/sdk/sdk-compaction.test.ts
@@ -1,14 +1,17 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
-import { compactSessionMessages } from "./sdk-compaction"
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 
 const createContextCompactionPrepareTurn = vi.fn()
+const createSessionCompactionState = vi.fn((input: unknown) => ({ version: 1, input }))
 vi.mock("@cline/core", () => ({
 	createContextCompactionPrepareTurn: (...args: unknown[]) => createContextCompactionPrepareTurn(...args),
+	createSessionCompactionState: (input: unknown) => createSessionCompactionState(input),
 }))
 
 vi.mock("@/shared/services/Logger", () => ({
 	Logger: { debug: vi.fn(), error: vi.fn(), log: vi.fn(), warn: vi.fn() },
 }))
+
+let compactSessionMessages: typeof import("./sdk-compaction").compactSessionMessages
 
 const baseConfig = {
 	providerConfig: { providerId: "anthropic", modelId: "claude" },
@@ -21,6 +24,10 @@ const baseConfig = {
 } as unknown as Parameters<typeof compactSessionMessages>[0]["config"]
 
 describe("compactSessionMessages", () => {
+	beforeAll(async () => {
+		;({ compactSessionMessages } = await import("./sdk-compaction"))
+	})
+
 	beforeEach(() => {
 		vi.clearAllMocks()
 	})
@@ -53,7 +60,17 @@ describe("compactSessionMessages", () => {
 			{ mode: "manual" },
 		)
 		expect(compact).toHaveBeenCalledOnce()
-		expect(result).toEqual({ compacted: true, messages: [{ role: "user", content: "summary" }] })
+		expect(createSessionCompactionState).toHaveBeenCalledWith({
+			sourceMessages: messages,
+			compactedMessages: [{ role: "user", content: "summary" }],
+			conversationId: "s1",
+			systemPrompt: undefined,
+		})
+		expect(result).toEqual({
+			compacted: true,
+			messages: [{ role: "user", content: "summary" }],
+			compactionState: { version: 1, input: expect.anything() },
+		})
 	})
 
 	it("returns compacted=false when prepareTurn is unavailable", async () => {

--- a/apps/vscode/src/sdk/sdk-compaction.ts
+++ b/apps/vscode/src/sdk/sdk-compaction.ts
@@ -7,15 +7,14 @@
 // transcript, returning the compacted working-context sidecar state.
 //
 // The VSCode coordinator persists that sidecar and restarts with canonical
-// messages intact. Keeping the actual compaction effect in the SDK (rather than
-// asking the model to "summarize the conversation") is what makes the compact
-// button real instead of improvised.
+// messages intact, so the persisted transcript remains unchanged while the
+// restarted session receives compacted working context.
 
 import {
 	type CoreSessionConfig,
-	type SessionCompactionState,
 	createContextCompactionPrepareTurn,
 	createSessionCompactionState,
+	type SessionCompactionState,
 } from "@cline/core"
 import type { Message as SdkMessage, ModelInfo as SdkModelInfo } from "@cline/llms"
 import { Logger } from "@/shared/services/Logger"

--- a/apps/vscode/src/sdk/sdk-compaction.ts
+++ b/apps/vscode/src/sdk/sdk-compaction.ts
@@ -4,14 +4,19 @@
 // apps/cli/src/runtime/interactive/compaction.ts (`compactInteractiveMessages`):
 // it builds a manual-mode compaction `prepareTurn` via the SDK's
 // `createContextCompactionPrepareTurn` and runs it against the current session
-// transcript, returning the compacted messages.
+// transcript, returning the compacted working-context sidecar state.
 //
-// The CLI then restarts the session with the compacted messages; the VSCode
-// adapter does the same in SdkCompactionCoordinator. Keeping the actual
-// compaction effect in the SDK (rather than asking the model to "summarize the
-// conversation") is what makes the compact button real instead of improvised.
+// The VSCode coordinator persists that sidecar and restarts with canonical
+// messages intact. Keeping the actual compaction effect in the SDK (rather than
+// asking the model to "summarize the conversation") is what makes the compact
+// button real instead of improvised.
 
-import { type CoreSessionConfig, createContextCompactionPrepareTurn } from "@cline/core"
+import {
+	type CoreSessionConfig,
+	type SessionCompactionState,
+	createContextCompactionPrepareTurn,
+	createSessionCompactionState,
+} from "@cline/core"
 import type { Message as SdkMessage, ModelInfo as SdkModelInfo } from "@cline/llms"
 import { Logger } from "@/shared/services/Logger"
 
@@ -35,6 +40,7 @@ export interface CompactSessionMessagesInput {
 export interface CompactSessionMessagesResult {
 	compacted: boolean
 	messages: SdkMessage[]
+	compactionState?: SessionCompactionState
 }
 
 /**
@@ -103,5 +109,14 @@ export async function compactSessionMessages(input: CompactSessionMessagesInput)
 	if (!result) {
 		return { compacted: false, messages: input.messages }
 	}
-	return { compacted: true, messages: result.messages }
+	return {
+		compacted: true,
+		messages: result.messages,
+		compactionState: createSessionCompactionState({
+			sourceMessages: input.messages,
+			compactedMessages: result.messages,
+			conversationId: input.sessionId,
+			systemPrompt: result.systemPrompt,
+		}),
+	}
 }

--- a/apps/vscode/src/sdk/sdk-compaction.ts
+++ b/apps/vscode/src/sdk/sdk-compaction.ts
@@ -6,9 +6,9 @@
 // `createContextCompactionPrepareTurn` and runs it against the current session
 // transcript, returning the compacted working-context sidecar state.
 //
-// The VSCode coordinator persists that sidecar and restarts with canonical
-// messages intact, so the persisted transcript remains unchanged while the
-// restarted session receives compacted working context.
+// The VSCode coordinator persists that sidecar without replacing the canonical
+// transcript, so the active session and later resumes use compacted working
+// context while saved messages remain intact.
 
 import {
 	type CoreSessionConfig,

--- a/apps/vscode/src/sdk/session-host.ts
+++ b/apps/vscode/src/sdk/session-host.ts
@@ -11,6 +11,7 @@ import type {
 	RestoreResult,
 	SendSessionInput,
 	SessionAccumulatedUsage,
+	SessionCompactionState,
 	SessionHistoryRecord,
 	SessionPendingPrompt,
 	SessionRecord,
@@ -33,6 +34,7 @@ export interface SdkSessionHost {
 	listHistory(options?: ClineCoreListHistoryOptions): Promise<SessionHistoryRecord[]>
 	delete(sessionId: string): Promise<boolean>
 	readMessages(sessionId: string): Promise<SdkInitialMessages>
+	updateSessionCompactionState?(sessionId: string, state: SessionCompactionState): Promise<{ updated: boolean }>
 	restore(input: RestoreInput): Promise<RestoreResult>
 	update(
 		sessionId: string,

--- a/apps/vscode/src/sdk/vscode-session-host.ts
+++ b/apps/vscode/src/sdk/vscode-session-host.ts
@@ -20,6 +20,7 @@ import {
 	type RestoreResult,
 	type SendSessionInput,
 	type SessionAccumulatedUsage,
+	type SessionCompactionState,
 	type SessionHistoryRecord,
 	type SessionPendingPrompt,
 	type SessionRecord,
@@ -197,6 +198,10 @@ export class VscodeSessionHost implements SdkSessionHost {
 
 	async readMessages(sessionId: string) {
 		return this.inner.readMessages(sessionId)
+	}
+
+	async updateSessionCompactionState(sessionId: string, state: SessionCompactionState): Promise<{ updated: boolean }> {
+		return this.inner.updateSessionCompactionState(sessionId, state)
 	}
 
 	async restore(input: RestoreInput): Promise<RestoreResult> {

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
@@ -4594,6 +4594,105 @@ describe("LocalRuntimeHost", () => {
 		expect(createAgent.mock.calls[0]?.[0]?.prepareTurn).toBeUndefined();
 	});
 
+	it("persists active manual compaction state against the persisted transcript", async () => {
+		const sessionId = "sess-compaction-active-persisted";
+		const tempCwd = mkdtempSync(join(tmpdir(), "compaction-active-"));
+		try {
+			const messagesPath = join(tempCwd, "messages.json");
+			const persistedMessages = [
+				{ role: "user", content: "hi" },
+				{
+					role: "assistant",
+					content: "hello",
+					modelInfo: { maxTokens: 1 },
+				},
+			] as MessageWithMetadata[];
+			const liveMessages = [
+				{ role: "user", content: "hi" },
+				{ role: "assistant", content: "hello" },
+			] as MessageWithMetadata[];
+			writeFileSync(messagesPath, JSON.stringify(persistedMessages), "utf8");
+			const manifest = {
+				...createManifest(sessionId),
+				messages_path: messagesPath,
+			};
+			const incoming = createSessionCompactionState({
+				sourceMessages: persistedMessages,
+				compactedMessages: [{ role: "user", content: "summary" }],
+				conversationId: sessionId,
+				updatedAt: "2026-01-01T00:00:00Z",
+			});
+			const sessionService = {
+				ensureSessionsDir: vi.fn().mockReturnValue("/tmp/sessions"),
+				createRootSessionWithArtifacts: vi.fn().mockResolvedValue({
+					manifestPath: "/tmp/manifest-compaction-active.json",
+					messagesPath,
+					manifest,
+				}),
+				persistSessionMessages: vi.fn(),
+				persistSessionCompactionState: vi.fn(),
+				updateSessionStatus: vi.fn().mockResolvedValue({ updated: true }),
+				writeSessionManifest: vi.fn(),
+				listSessions: vi.fn().mockResolvedValue([
+					{
+						sessionId,
+						provider: "mock-provider",
+						model: "mock-model",
+						cwd: "/tmp/project",
+						workspaceRoot: "/tmp/project",
+						createdAt: "2026-01-01T00:00:00.000Z",
+						updatedAt: "2026-01-01T00:00:00.000Z",
+						status: "completed",
+						messagesPath,
+					},
+				]),
+				deleteSession: vi.fn().mockResolvedValue({ deleted: true }),
+			};
+			const createAgent = vi.fn().mockReturnValue({
+				run: vi.fn().mockResolvedValue(createResult()),
+				continue: vi.fn(),
+				abort: vi.fn(),
+				subscribeEvents: vi.fn().mockReturnValue(() => {}),
+				canStartRun: vi.fn().mockReturnValue(true),
+				getAgentId: vi.fn().mockReturnValue("agent-root-1"),
+				getConversationId: vi.fn().mockReturnValue(sessionId),
+				restore: vi.fn(),
+				shutdown: vi.fn().mockResolvedValue(undefined),
+				getMessages: vi.fn().mockReturnValue(liveMessages),
+				messages: liveMessages,
+			});
+			const manager = new RuntimeHostUnderTest({
+				distinctId,
+				sessionService: sessionService as never,
+				runtimeBuilder: {
+					build: vi.fn().mockReturnValue({
+						tools: [],
+						shutdown: vi.fn(),
+					}),
+				},
+				createAgent: createAgent as never,
+			});
+
+			await manager.startSession(
+				normalizeStartInput({
+					config: createConfig({ sessionId }),
+					initialMessages: liveMessages,
+					interactive: true,
+				}),
+			);
+
+			await expect(
+				manager.updateSessionCompactionState(sessionId, incoming),
+			).resolves.toEqual({ updated: true });
+			expect(sessionService.persistSessionCompactionState).toHaveBeenCalledWith(
+				sessionId,
+				incoming,
+			);
+		} finally {
+			rmSync(tempCwd, { recursive: true, force: true });
+		}
+	});
+
 	it("orders equal-length compaction updates by parsed timestamp", async () => {
 		const sessionId = "inactive-session";
 		const tempCwd = mkdtempSync(join(tmpdir(), "compaction-stale-"));

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
@@ -4675,7 +4675,14 @@ describe("LocalRuntimeHost", () => {
 
 			await manager.startSession(
 				normalizeStartInput({
-					config: createConfig({ sessionId }),
+					config: createConfig({
+						sessionId,
+						compaction: {
+							enabled: true,
+							strategy: "basic",
+							compact: vi.fn().mockResolvedValue(undefined),
+						},
+					}),
 					initialMessages: liveMessages,
 					interactive: true,
 				}),
@@ -4688,6 +4695,39 @@ describe("LocalRuntimeHost", () => {
 				sessionId,
 				incoming,
 			);
+			expect(createAgent.mock.results[0]?.value.restore).toHaveBeenCalledWith(
+				persistedMessages,
+			);
+			const prepareTurn = createAgent.mock.calls[0]?.[0]?.prepareTurn;
+			await expect(
+				prepareTurn?.({
+					agentId: "agent-root-1",
+					conversationId: sessionId,
+					parentAgentId: null,
+					iteration: 1,
+					abortSignal: new AbortController().signal,
+					systemPrompt: "",
+					tools: [],
+					messages: [
+						...persistedMessages,
+						{ role: "user", content: "next" },
+					] as MessageWithMetadata[],
+					apiMessages: [
+						...persistedMessages,
+						{ role: "user", content: "next" },
+					] as MessageWithMetadata[],
+					model: {
+						id: "mock-model",
+						provider: "mock-provider",
+						info: { id: "mock-model", maxInputTokens: 100_000 },
+					},
+				}),
+			).resolves.toEqual({
+				messages: [
+					{ role: "user", content: "summary" },
+					{ role: "user", content: "next" },
+				],
+			});
 		} finally {
 			rmSync(tempCwd, { recursive: true, force: true });
 		}

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -1060,11 +1060,26 @@ export class LocalRuntimeHost implements RuntimeHost {
 		if (!existing) return { updated: false };
 		if (activeSession) {
 			const persistedMessages = await this.readSessionMessages(target);
-			const validationMessages =
-				persistedMessages.length >= state.source_message_count ||
-				state.source_message_count === 0
-					? persistedMessages
-					: undefined;
+			const hasPersistedSource =
+				state.source_message_count > 0 &&
+				persistedMessages.length >= state.source_message_count;
+			const validationMessages = hasPersistedSource
+				? persistedMessages
+				: undefined;
+			if (hasPersistedSource) {
+				if (
+					!(await this.canPersistCompactionState(
+						target,
+						state,
+						activeSession,
+						undefined,
+						persistedMessages,
+					))
+				) {
+					return { updated: false };
+				}
+				activeSession.agent.restore(persistedMessages);
+			}
 			return await this.persistActiveSessionCompactionState(
 				activeSession,
 				state,

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -1058,21 +1058,28 @@ export class LocalRuntimeHost implements RuntimeHost {
 			: await this.getSession(target);
 		const existing = activeSession ?? sessionRecord;
 		if (!existing) return { updated: false };
+		if (activeSession) {
+			const persistedMessages = await this.readSessionMessages(target);
+			const validationMessages =
+				persistedMessages.length >= state.source_message_count ||
+				state.source_message_count === 0
+					? persistedMessages
+					: undefined;
+			return await this.persistActiveSessionCompactionState(
+				activeSession,
+				state,
+				validationMessages,
+			);
+		}
 		if (
 			!(await this.canPersistCompactionState(
 				target,
 				state,
-				activeSession,
+				undefined,
 				sessionRecord,
 			))
 		) {
 			return { updated: false };
-		}
-		if (activeSession) {
-			return await this.persistActiveSessionCompactionState(
-				activeSession,
-				state,
-			);
 		}
 		const current = await this.invokeOptionalValue<SessionCompactionState>(
 			"readSessionCompactionState",
@@ -1132,6 +1139,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 		state: SessionCompactionState,
 		activeSession?: ActiveSession,
 		sessionRecord?: SessionRecord,
+		sourceMessages?: readonly LlmsProviders.Message[],
 	): Promise<boolean> {
 		if (!state.conversation_id?.trim()) {
 			return false;
@@ -1146,18 +1154,28 @@ export class LocalRuntimeHost implements RuntimeHost {
 		) {
 			return false;
 		}
-		const sourceMessages =
+		const messagesForProjection =
+			sourceMessages ??
 			activeSession?.agent.getMessages() ??
 			(await this.readSessionMessages(sessionId));
-		return projectSessionCompactionState(state, sourceMessages) !== undefined;
+		return (
+			projectSessionCompactionState(state, messagesForProjection) !== undefined
+		);
 	}
 
 	private async persistActiveSessionCompactionState(
 		session: ActiveSession,
 		state: SessionCompactionState,
+		sourceMessages?: readonly LlmsProviders.Message[],
 	): Promise<{ updated: boolean }> {
 		if (
-			!(await this.canPersistCompactionState(session.sessionId, state, session))
+			!(await this.canPersistCompactionState(
+				session.sessionId,
+				state,
+				session,
+				undefined,
+				sourceMessages,
+			))
 		) {
 			return { updated: false };
 		}


### PR DESCRIPTION
## Summary
- make VS Code manual compaction return a durable `SessionCompactionState`
- persist that sidecar before reporting compaction success
- restart the active session with canonical messages intact plus `initialCompactionState`
- fail visibly if sidecar persistence is unavailable or rejected

## Why
Manual compaction could display a compacted state, then a later follow-up/resume could reload the full canonical transcript and compact again. The sidecar is the durable compacted working context; canonical history remains unchanged.

```text
canonical transcript on disk
[M1][M2][M3]...[Mn]
        |
        | manual compact
        v
sidecar working context
[S summary][tail]
        |
        | next turn / resume
        v
provider request uses sidecar projection, not the full old transcript
```

## Verification
- `bun test apps/vscode/src/sdk/sdk-compaction.test.ts`
- `bun test apps/vscode/src/sdk/sdk-compaction-coordinator.test.ts`
- `bun -F claude-dev check-types`
- `bun -F claude-dev lint`
- `bun -F @cline/shared build`
- `bun -F @cline/core typecheck`
- `bun -F @cline/llms build`
- `git diff --check`
