### PR TITLE
fix(agents): populate messageModelInfo for the standalone provider/model constructor

### DIFF
--- a/sdk/packages/agents/src/agent-runtime.provider-form.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.provider-form.test.ts
@@ -234,4 +234,56 @@ describe("AgentRuntime (provider-form config + Agent alias)", () => {
 		await agent.run("again");
 		expect(received).toHaveLength(countAfterRun);
 	});
+
+	it("derives messageModelInfo from providerId/modelId so assistant messages carry model tags", async () => {
+		const model = new ScriptedModel([
+			() => [
+				{ type: "text-delta", text: "hi" },
+				{ type: "finish", reason: "stop" },
+			],
+		]);
+		createAgentModel.mockReturnValue(model);
+
+		const agent = new Agent({
+			providerId: "anthropic",
+			modelId: "claude-sonnet-4-6",
+		});
+
+		const result = await agent.run("hello");
+
+		const assistant = result.messages.find((m) => m.role === "assistant");
+		expect(assistant?.modelInfo).toEqual({
+			id: "claude-sonnet-4-6",
+			provider: "anthropic",
+		});
+	});
+
+	it("prefers an explicit messageModelInfo over the derived provider/model", async () => {
+		const model = new ScriptedModel([
+			() => [
+				{ type: "text-delta", text: "hi" },
+				{ type: "finish", reason: "stop" },
+			],
+		]);
+		createAgentModel.mockReturnValue(model);
+
+		const agent = new Agent({
+			providerId: "anthropic",
+			modelId: "claude-sonnet-4-6",
+			messageModelInfo: {
+				id: "explicit-model",
+				provider: "explicit-provider",
+				family: "explicit-family",
+			},
+		});
+
+		const result = await agent.run("hello");
+
+		const assistant = result.messages.find((m) => m.role === "assistant");
+		expect(assistant?.modelInfo).toEqual({
+			id: "explicit-model",
+			provider: "explicit-provider",
+			family: "explicit-family",
+		});
+	});
 });

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -105,7 +105,14 @@ function resolveRuntimeConfig(
 		telemetry: rest.telemetry,
 	});
 	const model = gateway.createAgentModel({ providerId, modelId });
-	return { ...rest, model };
+	// The prebuilt-model path preserves a caller-provided messageModelInfo;
+	// mirror that here so the provider/model constructor also tags assistant
+	// messages with modelInfo. An explicit caller-provided value still wins.
+	const messageModelInfo = rest.messageModelInfo ?? {
+		id: modelId,
+		provider: providerId,
+	};
+	return { ...rest, model, messageModelInfo };
 }
 
 function resolveToolPolicy(


### PR DESCRIPTION
## Summary

The standalone `AgentRuntime({ providerId, modelId, ... })` / `new Agent({ providerId, modelId })` constructor builds its model inside `resolveRuntimeConfig` and returns `{ ...rest, model }` **without deriving `messageModelInfo`**.

The prebuilt-model path (`{ model }`) preserves a caller-provided `messageModelInfo`, so this is an inconsistency between the two construction modes: standalone SDK callers that supply `providerId`/`modelId` end up with no `messageModelInfo`. As a result, anything that reads `this.config.messageModelInfo` in that path is missing the model label — most visibly, persisted assistant-message `modelInfo` is `undefined`, and the reasoning-token telemetry is emitted without provider/model fields.

This is a small, pre-existing correctness gap. It only affects direct SDK users of the standalone provider/model constructor (e.g. the `apps/examples/*` agents); sessions that go through `@cline/core` are unaffected because they already populate `messageModelInfo` via `buildMessageModelInfo`.

## Fix

In `resolveRuntimeConfig`, derive `messageModelInfo` from the provider/model the runtime builds itself:

```ts
const messageModelInfo = rest.messageModelInfo ?? { id: modelId, provider: providerId };
return { ...rest, model, messageModelInfo };
```

- `family` is omitted (optional in the type, and not reliably available in this path).
- An explicit caller-provided `messageModelInfo` still wins.

This makes the two construction modes consistent: assistant messages produced by the standalone constructor now carry `modelInfo`, matching the prebuilt-model and core paths.

## Tests

`sdk/packages/agents/src/agent-runtime.provider-form.test.ts`:
- derives `messageModelInfo` from `providerId`/`modelId` so assistant messages carry model tags
- prefers an explicit `messageModelInfo` over the derived provider/model

## Verification

- `bun -F @cline/agents typecheck` — pass
- `bun -F @cline/agents test` — pass (provider-form suite +2)
- `bun run build:sdk` — pass

## Scope

Intentionally minimal and self-contained. Independent of any other in-flight work.
