### PR TITLE
fix(sdk): preserve failed run error messages

### DIFF
--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
@@ -1435,6 +1435,69 @@ describe("SessionRuntime real AgentRuntime smoke", () => {
 			"user",
 		]);
 	});
+
+	it("uses the error message instead of replaying prior assistant text after a tool-call stream failure", async () => {
+		const scriptedModel: AgentModel = {
+			async stream(request) {
+				const turn = request.messages.filter(
+					(message) => message.role === "assistant",
+				).length;
+
+				return (async function* () {
+					if (turn === 0) {
+						yield {
+							type: "text-delta" as const,
+							text: "I am going to make one more cleanup.",
+						};
+						yield {
+							type: "tool-call-delta" as const,
+							toolCallId: "call_cleanup",
+							toolName: "cleanup",
+							inputText: JSON.stringify({ ok: true }),
+						};
+						yield { type: "finish" as const, reason: "tool-calls" as const };
+						return;
+					}
+					yield {
+						type: "finish" as const,
+						reason: "error" as const,
+						error: "upstream failed after tool result",
+					};
+				})();
+			},
+		};
+		const session = new SessionRuntime(
+			makeAgentConfig({
+				providerId: "cline",
+				modelId: "openai/gpt-5.5",
+				apiKey: "test-key",
+				tools: [
+					{
+						name: "cleanup",
+						description: "cleanup",
+						inputSchema: { type: "object" },
+						execute: async () => ({ ok: true }),
+					},
+				],
+			}),
+			{
+				createAgentRuntimeImpl: (config) =>
+					createAgentRuntime({ ...config, model: scriptedModel }),
+			},
+		);
+
+		const result = await session.run("first");
+
+		expect(result.finishReason).toBe("error");
+		expect(result.text).toBe("upstream failed after tool result");
+		expect(result.text).not.toContain("one more cleanup");
+		expect(session.getMessages().map((message) => message.role)).toEqual([
+			"user",
+			"assistant",
+			"user",
+		]);
+		expect(session.getMessages().at(-1)?.content[0]?.type).toBe("tool_result");
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
@@ -1267,8 +1267,8 @@ export class SessionRuntime {
 			? "error"
 			: deriveFinishReason(runResult);
 		const text =
-			runResult?.outputText ||
 			(runResult?.status === "failed" ? runResult.error?.message : undefined) ||
+			runResult?.outputText ||
 			"";
 		const usage: LegacyAgentUsage = runResult
 			? {


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This fixes the CLI/TUI regression where a failed SDK run could surface the previous assistant response as the error text, producing messages like:

```text
Error: I'm going to make one more cleanup...
```

The user logs showed that the model had produced normal assistant text, emitted an `apply_patch` tool call, and persisted the tool result. The next model stream then failed before producing assistant content. After the recent SDK change that avoids persisting empty failed assistant messages, the failed run's `outputText` could resolve to the prior successful assistant message instead of the actual failure message.

The legacy `SessionRuntime` result adapter then preferred `runResult.outputText` before `runResult.error.message`. In the CLI interactive path, non-completed turns are thrown as `new Error(result.text)`, so the TUI rendered the previous model prose as a red error. Follow-up messages appeared to repeat the same response because each new failed run re-projected the same prior assistant text as the error.

This PR changes the failed-result text precedence so failed runs surface the underlying error message first, falling back to output text only when there is no structured error. It also adds a regression test for the exact shape we saw in the attached session: assistant text, tool call, successful tool result, then an empty failed follow-up model stream.

### Test Procedure

Ran the focused SDK orchestration test file:

```bash
bun test sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
```

Result: 50 passing tests, including the new regression case.

Ran Biome on the touched files:

```bash
bunx biome check sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
```

Result: passed with no fixes applied.

Also ran whitespace/conflict-marker validation:

```bash
git diff --check
```

Result: clean.

I did not run the full repo test/lint suite because this is a narrow SDK adapter change plus a focused regression test in the affected file.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. This is an SDK runtime result mapping fix covered by automated tests.

### Additional Notes

The underlying provider/model stream failure that triggered the original failed run was masked by this bug in the saved logs. After this fix, the CLI should display the real failed-run error instead of replaying prior assistant prose, which should make the remaining upstream/provider failure diagnosable if it recurs.

The logs also contained repeated `session.hook invalid_hook_payload` entries around `afterRun`. Those appear separate from this TUI error path because hook dispatch failures are swallowed, but they are worth investigating separately because they add noise during failure analysis.
