### PR TITLE
fix(sdk): send Cline client type headers

### DIFF
--- a/apps/vscode/src/common.ts
+++ b/apps/vscode/src/common.ts
@@ -49,6 +49,7 @@ export async function initialize(storageContext: StorageContext): Promise<Webvie
 			type: ShowMessageType.ERROR,
 			message: "Failed to initialize storage. Please check logs for details or try restarting the client.",
 		})
+		throw error
 	}
 
 	// Register host-only SDK provider handlers (e.g. VS Code Language Model API),

--- a/apps/vscode/src/core/storage/remote-config/fetch.ts
+++ b/apps/vscode/src/core/storage/remote-config/fetch.ts
@@ -55,7 +55,7 @@ async function makeAuthenticatedRequest<T>(endpoint: string, organizationId: str
 		headers: {
 			Authorization: `Bearer ${authToken}`,
 			"Content-Type": "application/json",
-			...(await buildBasicClineHeaders()),
+			...buildBasicClineHeaders(),
 		},
 		...getAxiosSettings(),
 	}

--- a/apps/vscode/src/core/storage/remote-config/sdk-control-plane.ts
+++ b/apps/vscode/src/core/storage/remote-config/sdk-control-plane.ts
@@ -63,7 +63,7 @@ async function makeAuthenticatedRequest<T>(endpoint: string, organizationId: str
 		headers: {
 			Authorization: `Bearer ${authToken}`,
 			"Content-Type": "application/json",
-			...(await buildBasicClineHeaders()),
+			...buildBasicClineHeaders(),
 		},
 		...getAxiosSettings(),
 	}

--- a/apps/vscode/src/hosts/vscode/commit-message-generator.ts
+++ b/apps/vscode/src/hosts/vscode/commit-message-generator.ts
@@ -215,7 +215,7 @@ async function performCommitMsgGeneration(controller: Controller, gitDiff: strin
 		// transform that doesn't need extended thinking; disabling reasoning also
 		// avoids sending both reasoning.effort and reasoning.max_tokens, which
 		// some providers (e.g. OpenRouter) reject.
-		const apiHandler = buildApiHandler(apiConfiguration, currentMode, { disableReasoning: true })
+		const apiHandler = await buildApiHandler(apiConfiguration, currentMode, { disableReasoning: true })
 
 		// Create a system prompt
 		const systemPrompt = PROMPT.system

--- a/apps/vscode/src/registry.ts
+++ b/apps/vscode/src/registry.ts
@@ -95,5 +95,10 @@ export const HostRegistryInfo = {
 		const ide = host.clineType || "unknown"
 		hostInfo = { hostVersion, extensionVersion, platform, os, ide, distinctId }
 	},
-	get: () => hostInfo,
+	get: () => {
+		if (!hostInfo) {
+			throw new Error("HostRegistryInfo has not been initialized. Call initialize() before using host metadata.")
+		}
+		return hostInfo
+	},
 }

--- a/apps/vscode/src/sdk/account-service.ts
+++ b/apps/vscode/src/sdk/account-service.ts
@@ -60,7 +60,7 @@ export class ClineAccountService {
 			headers: {
 				Authorization: `Bearer ${clineAccountAuthToken}`,
 				"Content-Type": "application/json",
-				...(await buildBasicClineHeaders()),
+				...buildBasicClineHeaders(),
 				...config.headers,
 			},
 			...getAxiosSettings(),

--- a/apps/vscode/src/sdk/auth-service.test.ts
+++ b/apps/vscode/src/sdk/auth-service.test.ts
@@ -77,7 +77,7 @@ vi.mock("@/shared/net", () => ({
 
 // Mock buildBasicClineHeaders
 vi.mock("@/services/EnvUtils", () => ({
-	buildBasicClineHeaders: async () => ({}),
+	buildBasicClineHeaders: () => ({}),
 }))
 
 // Mock feature flags

--- a/apps/vscode/src/sdk/auth-service.ts
+++ b/apps/vscode/src/sdk/auth-service.ts
@@ -255,7 +255,7 @@ export class AuthService {
 				headers: {
 					Authorization: `Bearer ${bearerToken}`,
 					"Content-Type": "application/json",
-					...(await buildBasicClineHeaders()),
+					...buildBasicClineHeaders(),
 				},
 				...getAxiosSettings(),
 			})
@@ -483,7 +483,7 @@ export class AuthService {
 					apiBaseUrl,
 					// Use WorkOS device auth so the browser confirmation code can be surfaced in the extension.
 					useWorkOSDeviceAuth: true,
-					headers: await buildBasicClineHeaders(),
+					headers: buildBasicClineHeaders(),
 					callbacks: createOAuthClientCallbacks({
 						onOutput: (message) => {
 							resolveAuthMessage(message)
@@ -544,7 +544,7 @@ export class AuthService {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
-				...(await buildBasicClineHeaders()),
+				...buildBasicClineHeaders(),
 			},
 			body: JSON.stringify({
 				code: "test-personal-token",
@@ -755,7 +755,7 @@ export class AuthService {
 				headers: {
 					Accept: "application/json",
 					"Content-Type": "application/json",
-					...(await buildBasicClineHeaders()),
+					...buildBasicClineHeaders(),
 				},
 				body: JSON.stringify({
 					grant_type: "authorization_code",

--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -24,12 +24,14 @@ const mocks = vi.hoisted(() => {
 	}
 
 	return {
-		buildClineExtraHeaders: vi.fn(async () => ({
-			"User-Agent": "Cline/test",
-			"X-CLIENT-TYPE": "VSCode Extension",
-			"X-CLIENT-VERSION": "1.2.3",
-			"X-CORE-VERSION": "1.2.3",
-			"X-IS-MULTIROOT": "false",
+		buildClientRuntimeContext: vi.fn(async () => ({
+			userAgent: "Cline/test",
+			clientName: "VSCode Extension",
+			clientVersion: "1.2.3",
+			platform: "Visual Studio Code",
+			platformVersion: "1.90.0",
+			coreVersion: "1.2.3",
+			isMultiRoot: false,
 		})),
 		getDistinctId: vi.fn(() => "test-distinct-id"),
 		getProviderSettingsManager: vi.fn(() => providerSettingsManager),
@@ -61,7 +63,7 @@ vi.mock("@/services/logging/distinctId", () => ({
 }))
 
 vi.mock("@/services/EnvUtils", () => ({
-	buildClineExtraHeaders: mocks.buildClineExtraHeaders,
+	buildClientRuntimeContext: mocks.buildClientRuntimeContext,
 }))
 
 vi.mock("@cline/llms", () => {
@@ -141,12 +143,14 @@ beforeEach(() => {
 	})
 	mocks.providerSettingsManager.getLastUsedProviderSettings.mockReturnValue(undefined)
 	mocks.providerSettingsManager.getProviderSettings.mockReturnValue(undefined)
-	mocks.buildClineExtraHeaders.mockResolvedValue({
-		"User-Agent": "Cline/test",
-		"X-CLIENT-TYPE": "VSCode Extension",
-		"X-CLIENT-VERSION": "1.2.3",
-		"X-CORE-VERSION": "1.2.3",
-		"X-IS-MULTIROOT": "false",
+	mocks.buildClientRuntimeContext.mockResolvedValue({
+		userAgent: "Cline/test",
+		clientName: "VSCode Extension",
+		clientVersion: "1.2.3",
+		platform: "Visual Studio Code",
+		platformVersion: "1.90.0",
+		coreVersion: "1.2.3",
+		isMultiRoot: false,
 	})
 })
 
@@ -254,7 +258,7 @@ describe("buildStartSessionInput", () => {
 		expect(result.prompt).toBeUndefined()
 	})
 
-	it("stamps Cline provider headers with the session id before start", () => {
+	it("does not rewrite provider headers before start", () => {
 		const headers = {
 			"HTTP-Referer": "https://cline.bot",
 			"X-Title": "Cline",
@@ -276,8 +280,8 @@ describe("buildStartSessionInput", () => {
 		const result = buildStartSessionInput(config, { cwd: "/tmp/workspace" })
 
 		expect(result.config).toBe(config)
-		expect(config.headers?.["X-Task-ID"]).toBe("session-123")
-		expect((config.providerConfig as any).headers["X-Task-ID"]).toBe("session-123")
+		expect(config.headers?.["X-Task-ID"]).toBe("")
+		expect((config.providerConfig as any).headers["X-Task-ID"]).toBe("")
 	})
 })
 
@@ -375,7 +379,7 @@ describe("buildSessionConfig", () => {
 		expect(config.apiKey).toBe("workos:test-access-token")
 	})
 
-	it("adds classic VS Code Cline provider headers to session config", async () => {
+	it("passes VS Code client request metadata without owning Cline provider headers", async () => {
 		mocks.stateManager.getApiConfiguration.mockReturnValue({
 			actModeApiProvider: "cline",
 			actModeClineModelId: "anthropic/claude-sonnet-4.6",
@@ -384,18 +388,29 @@ describe("buildSessionConfig", () => {
 
 		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
 
-		expect(mocks.buildClineExtraHeaders).toHaveBeenCalledTimes(1)
-		expect(config.headers).toEqual({
-			"HTTP-Referer": "https://cline.bot",
-			"User-Agent": "Cline/test",
-			"X-CLIENT-TYPE": "VSCode Extension",
-			"X-CLIENT-VERSION": "1.2.3",
-			"X-CORE-VERSION": "1.2.3",
-			"X-IS-MULTIROOT": "false",
-			"X-Task-ID": "",
-			"X-Title": "Cline",
+		expect(mocks.buildClientRuntimeContext).toHaveBeenCalledTimes(1)
+		expect(config.headers).toBeUndefined()
+		expect((config.providerConfig as any).headers).toBeUndefined()
+		expect(config.extensionContext).toMatchObject({
+			client: {
+				name: "cline-vscode",
+				version: "1.2.3",
+			},
+			workspace: {
+				cwd: "/tmp/workspace",
+				ide: "VS Code",
+				platform: process.platform,
+			},
+			requestMetadata: {
+				clientType: "VSCode Extension",
+				clientVersion: "1.2.3",
+				userAgent: "Cline/test",
+				platform: "Visual Studio Code",
+				platformVersion: "1.90.0",
+				coreVersion: "1.2.3",
+				isMultiRoot: false,
+			},
 		})
-		expect((config.providerConfig as any).headers).toEqual(config.headers)
 	})
 
 	it("resolves ClinePass from the shared Cline OAuth credentials", async () => {

--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -24,6 +24,13 @@ const mocks = vi.hoisted(() => {
 	}
 
 	return {
+		buildClineExtraHeaders: vi.fn(async () => ({
+			"User-Agent": "Cline/test",
+			"X-CLIENT-TYPE": "VSCode Extension",
+			"X-CLIENT-VERSION": "1.2.3",
+			"X-CORE-VERSION": "1.2.3",
+			"X-IS-MULTIROOT": "false",
+		})),
 		getDistinctId: vi.fn(() => "test-distinct-id"),
 		getProviderSettingsManager: vi.fn(() => providerSettingsManager),
 		providerSettingsManager,
@@ -52,6 +59,52 @@ vi.mock("@/core/storage/StateManager", () => ({
 vi.mock("@/services/logging/distinctId", () => ({
 	getDistinctId: mocks.getDistinctId,
 }))
+
+vi.mock("@/services/EnvUtils", () => ({
+	buildClineExtraHeaders: mocks.buildClineExtraHeaders,
+}))
+
+vi.mock("@cline/llms", () => {
+	const generatedModels = {
+		cline: {
+			"anthropic/claude-sonnet-4.6": { id: "anthropic/claude-sonnet-4.6" },
+		},
+		"cline-pass": {
+			"cline-pass/glm-5.1": { id: "cline-pass/glm-5.1" },
+		},
+		gemini: {
+			"gemini-3.5-flash": { id: "gemini-3.5-flash" },
+		},
+		"openai-compatible": {
+			"gpt-4o": { id: "gpt-4o" },
+		},
+	}
+	return {
+		getGeneratedModelsForProvider: (providerId: keyof typeof generatedModels) => generatedModels[providerId] ?? {},
+		MODEL_COLLECTIONS_BY_PROVIDER_ID: {
+			cline: {
+				provider: { name: "Cline", defaultModelId: "anthropic/claude-sonnet-4.6" },
+				models: {},
+			},
+			"cline-pass": {
+				provider: { name: "ClinePass", defaultModelId: "cline-pass/glm-5.1" },
+				models: {},
+			},
+			gemini: {
+				provider: { name: "Gemini", defaultModelId: "gemini-3.5-pro" },
+				models: {},
+			},
+			"openai-compatible": {
+				provider: { name: "OpenAI Compatible", defaultModelId: "gpt-4o", baseUrl: "https://api.openai.com/v1" },
+				models: {},
+			},
+			ollama: {
+				provider: { name: "Ollama", baseUrl: "http://localhost:11434/v1" },
+				models: {},
+			},
+		},
+	}
+})
 
 vi.mock("./provider-migration", () => ({
 	getProviderSettingsManager: mocks.getProviderSettingsManager,
@@ -88,6 +141,13 @@ beforeEach(() => {
 	})
 	mocks.providerSettingsManager.getLastUsedProviderSettings.mockReturnValue(undefined)
 	mocks.providerSettingsManager.getProviderSettings.mockReturnValue(undefined)
+	mocks.buildClineExtraHeaders.mockResolvedValue({
+		"User-Agent": "Cline/test",
+		"X-CLIENT-TYPE": "VSCode Extension",
+		"X-CLIENT-VERSION": "1.2.3",
+		"X-CORE-VERSION": "1.2.3",
+		"X-IS-MULTIROOT": "false",
+	})
 })
 
 afterEach(() => {
@@ -193,6 +253,32 @@ describe("buildStartSessionInput", () => {
 
 		expect(result.prompt).toBeUndefined()
 	})
+
+	it("stamps Cline provider headers with the session id before start", () => {
+		const headers = {
+			"HTTP-Referer": "https://cline.bot",
+			"X-Title": "Cline",
+			"X-Task-ID": "",
+			"X-CLIENT-TYPE": "VSCode Extension",
+		}
+		const config = makeBaseConfig({
+			providerId: "cline",
+			modelId: "anthropic/claude-sonnet-4.6",
+			sessionId: "session-123",
+			headers,
+			providerConfig: {
+				providerId: "cline",
+				modelId: "anthropic/claude-sonnet-4.6",
+				headers,
+			},
+		} as Partial<CoreSessionConfig>)
+
+		const result = buildStartSessionInput(config, { cwd: "/tmp/workspace" })
+
+		expect(result.config).toBe(config)
+		expect(config.headers?.["X-Task-ID"]).toBe("session-123")
+		expect((config.providerConfig as any).headers["X-Task-ID"]).toBe("session-123")
+	})
 })
 
 // ---------------------------------------------------------------------------
@@ -287,6 +373,29 @@ describe("buildSessionConfig", () => {
 
 		expect(config.providerId).toBe("cline")
 		expect(config.apiKey).toBe("workos:test-access-token")
+	})
+
+	it("adds classic VS Code Cline provider headers to session config", async () => {
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "cline",
+			actModeClineModelId: "anthropic/claude-sonnet-4.6",
+			clineApiKey: "workos:test-access-token",
+		} as any)
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+
+		expect(mocks.buildClineExtraHeaders).toHaveBeenCalledTimes(1)
+		expect(config.headers).toEqual({
+			"HTTP-Referer": "https://cline.bot",
+			"User-Agent": "Cline/test",
+			"X-CLIENT-TYPE": "VSCode Extension",
+			"X-CLIENT-VERSION": "1.2.3",
+			"X-CORE-VERSION": "1.2.3",
+			"X-IS-MULTIROOT": "false",
+			"X-Task-ID": "",
+			"X-Title": "Cline",
+		})
+		expect((config.providerConfig as any).headers).toEqual(config.headers)
 	})
 
 	it("resolves ClinePass from the shared Cline OAuth credentials", async () => {

--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -24,7 +24,7 @@ const mocks = vi.hoisted(() => {
 	}
 
 	return {
-		buildClientRuntimeContext: vi.fn(async () => ({
+		buildClineRequestMetadata: vi.fn(async () => ({
 			userAgent: "Cline/test",
 			clientName: "VSCode Extension",
 			clientVersion: "1.2.3",
@@ -63,7 +63,7 @@ vi.mock("@/services/logging/distinctId", () => ({
 }))
 
 vi.mock("@/services/EnvUtils", () => ({
-	buildClientRuntimeContext: mocks.buildClientRuntimeContext,
+	buildClineRequestMetadata: mocks.buildClineRequestMetadata,
 }))
 
 vi.mock("@cline/llms", () => {
@@ -143,7 +143,7 @@ beforeEach(() => {
 	})
 	mocks.providerSettingsManager.getLastUsedProviderSettings.mockReturnValue(undefined)
 	mocks.providerSettingsManager.getProviderSettings.mockReturnValue(undefined)
-	mocks.buildClientRuntimeContext.mockResolvedValue({
+	mocks.buildClineRequestMetadata.mockResolvedValue({
 		userAgent: "Cline/test",
 		clientName: "VSCode Extension",
 		clientVersion: "1.2.3",
@@ -388,7 +388,7 @@ describe("buildSessionConfig", () => {
 
 		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
 
-		expect(mocks.buildClientRuntimeContext).toHaveBeenCalledTimes(1)
+		expect(mocks.buildClineRequestMetadata).toHaveBeenCalledTimes(1)
 		expect(config.headers).toBeUndefined()
 		expect((config.providerConfig as any).headers).toBeUndefined()
 		expect(config.extensionContext).toMatchObject({

--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -27,6 +27,7 @@ import type { Mode } from "@shared/storage/types"
 import { stringifyVsCodeLmModelSelector } from "@shared/vsCodeSelectorUtils"
 import { StateManager } from "@/core/storage/StateManager"
 import { ExtensionRegistryInfo } from "@/registry"
+import { buildClineExtraHeaders } from "@/services/EnvUtils"
 import { getFeatureFlagsService } from "@/services/feature-flags"
 import { getDistinctId } from "@/services/logging/distinctId"
 import { fetch } from "@/shared/net"
@@ -61,6 +62,36 @@ You are in Plan mode. Your role is to explore, analyze, and plan -- not to execu
 - Do NOT implement anything -- focus on understanding and alignment first
 
 Once the user has reviewed your plan and explicitly approved it in a follow-up message, use the switch_to_act_mode tool to switch to act mode and begin implementation. Calling switch_to_act_mode immediately starts execution, so never call it in the same turn you present a plan and never treat the original task request as approval -- end your turn after presenting the plan and wait for the user's response.`
+
+function isSdkClineProvider(providerId: string): boolean {
+	return providerId === "cline" || providerId === "cline-pass"
+}
+
+async function buildClineProviderHeaders(taskId = ""): Promise<Record<string, string>> {
+	return {
+		"HTTP-Referer": "https://cline.bot",
+		"X-Title": "Cline",
+		"X-Task-ID": taskId,
+		...(await buildClineExtraHeaders()),
+	}
+}
+
+function updateClineProviderTaskHeader(config: CoreSessionConfig): void {
+	const taskId = config.sessionId?.trim()
+	if (!taskId) {
+		return
+	}
+
+	const headers = config.headers
+	if (headers?.["X-Task-ID"] !== undefined) {
+		headers["X-Task-ID"] = taskId
+	}
+
+	const providerHeaders = (config.providerConfig as { headers?: Record<string, string> } | undefined)?.headers
+	if (providerHeaders && providerHeaders !== headers && providerHeaders["X-Task-ID"] !== undefined) {
+		providerHeaders["X-Task-ID"] = taskId
+	}
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -669,6 +700,8 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 	// additionally need structured options (region/project/auth/SAP OAuth), which core
 	// reads from providerConfig in createAgentModelFromConfig.
 	const cloudProviderConfig = bedrockProviderConfig ?? vertexProviderConfig ?? sapProviderConfig
+	const clineTaskId = input.historyItem?.ulid || input.historyItem?.id || ""
+	const headers = isSdkClineProvider(sdkProviderId) ? await buildClineProviderHeaders(clineTaskId) : undefined
 	// Spread the cloud config first so the explicit fields below — notably the
 	// proxy/CA-aware fetch — can never be clobbered if those types gain matching keys.
 	const providerConfig = {
@@ -677,6 +710,7 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 		modelId,
 		...(apiKey ? { apiKey } : {}),
 		...(baseUrl !== undefined ? { baseUrl } : {}),
+		...(headers ? { headers } : {}),
 		fetch,
 	}
 
@@ -685,6 +719,7 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 		modelId,
 		apiKey,
 		baseUrl,
+		...(headers ? { headers } : {}),
 		providerConfig,
 		cwd,
 		workspaceRoot,
@@ -746,6 +781,8 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
  * agent turn completes.
  */
 export function buildStartSessionInput(config: CoreSessionConfig, input: SessionConfigInput): ClineCoreStartInput {
+	updateClineProviderTaskHeader(config)
+
 	return {
 		config,
 		// Do NOT pass prompt here — start() should return immediately.

--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -26,7 +26,7 @@ import type { Settings } from "@shared/storage/state-keys"
 import type { Mode } from "@shared/storage/types"
 import { stringifyVsCodeLmModelSelector } from "@shared/vsCodeSelectorUtils"
 import { StateManager } from "@/core/storage/StateManager"
-import { buildClientRuntimeContext } from "@/services/EnvUtils"
+import { buildClineRequestMetadata } from "@/services/EnvUtils"
 import { getFeatureFlagsService } from "@/services/feature-flags"
 import { getDistinctId } from "@/services/logging/distinctId"
 import { fetch } from "@/shared/net"
@@ -662,7 +662,7 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 	// own provider id spelling (e.g. "openai-compatible" rather than the
 	// extension's "openai"). Convert before handing the id to core.
 	const sdkProviderId = toSdkProviderId(providerId)
-	const clientRuntimeContext = await buildClientRuntimeContext()
+	const clineRequestMetadata = await buildClineRequestMetadata()
 
 	// Always pass a providerConfig so the proxy/CA-aware fetch reaches the SDK
 	// gateway; without it the agent loop uses bare global fetch and corporate
@@ -714,7 +714,7 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 			user: distinctId ? { distinctId } : undefined,
 			client: {
 				name: "cline-vscode",
-				version: clientRuntimeContext.clientVersion,
+				version: clineRequestMetadata.clientVersion,
 			},
 			workspace: {
 				rootPath: workspaceRoot,
@@ -725,13 +725,13 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 				mode: mode === "plan" ? "plan" : "act",
 			},
 			requestMetadata: {
-				clientType: clientRuntimeContext.clientName,
-				clientVersion: clientRuntimeContext.clientVersion,
-				userAgent: clientRuntimeContext.userAgent,
-				platform: clientRuntimeContext.platform,
-				platformVersion: clientRuntimeContext.platformVersion,
-				coreVersion: clientRuntimeContext.coreVersion,
-				isMultiRoot: clientRuntimeContext.isMultiRoot,
+				clientType: clineRequestMetadata.clientName,
+				clientVersion: clineRequestMetadata.clientVersion,
+				userAgent: clineRequestMetadata.userAgent,
+				platform: clineRequestMetadata.platform,
+				platformVersion: clineRequestMetadata.platformVersion,
+				coreVersion: clineRequestMetadata.coreVersion,
+				isMultiRoot: clineRequestMetadata.isMultiRoot,
 			},
 			logger: sdkLogger,
 		},

--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -26,8 +26,7 @@ import type { Settings } from "@shared/storage/state-keys"
 import type { Mode } from "@shared/storage/types"
 import { stringifyVsCodeLmModelSelector } from "@shared/vsCodeSelectorUtils"
 import { StateManager } from "@/core/storage/StateManager"
-import { ExtensionRegistryInfo } from "@/registry"
-import { buildClineExtraHeaders } from "@/services/EnvUtils"
+import { buildClientRuntimeContext } from "@/services/EnvUtils"
 import { getFeatureFlagsService } from "@/services/feature-flags"
 import { getDistinctId } from "@/services/logging/distinctId"
 import { fetch } from "@/shared/net"
@@ -62,36 +61,6 @@ You are in Plan mode. Your role is to explore, analyze, and plan -- not to execu
 - Do NOT implement anything -- focus on understanding and alignment first
 
 Once the user has reviewed your plan and explicitly approved it in a follow-up message, use the switch_to_act_mode tool to switch to act mode and begin implementation. Calling switch_to_act_mode immediately starts execution, so never call it in the same turn you present a plan and never treat the original task request as approval -- end your turn after presenting the plan and wait for the user's response.`
-
-function isSdkClineProvider(providerId: string): boolean {
-	return providerId === "cline" || providerId === "cline-pass"
-}
-
-async function buildClineProviderHeaders(taskId = ""): Promise<Record<string, string>> {
-	return {
-		"HTTP-Referer": "https://cline.bot",
-		"X-Title": "Cline",
-		"X-Task-ID": taskId,
-		...(await buildClineExtraHeaders()),
-	}
-}
-
-function updateClineProviderTaskHeader(config: CoreSessionConfig): void {
-	const taskId = config.sessionId?.trim()
-	if (!taskId) {
-		return
-	}
-
-	const headers = config.headers
-	if (headers?.["X-Task-ID"] !== undefined) {
-		headers["X-Task-ID"] = taskId
-	}
-
-	const providerHeaders = (config.providerConfig as { headers?: Record<string, string> } | undefined)?.headers
-	if (providerHeaders && providerHeaders !== headers && providerHeaders["X-Task-ID"] !== undefined) {
-		providerHeaders["X-Task-ID"] = taskId
-	}
-}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -693,6 +662,7 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 	// own provider id spelling (e.g. "openai-compatible" rather than the
 	// extension's "openai"). Convert before handing the id to core.
 	const sdkProviderId = toSdkProviderId(providerId)
+	const clientRuntimeContext = await buildClientRuntimeContext()
 
 	// Always pass a providerConfig so the proxy/CA-aware fetch reaches the SDK
 	// gateway; without it the agent loop uses bare global fetch and corporate
@@ -700,8 +670,6 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 	// additionally need structured options (region/project/auth/SAP OAuth), which core
 	// reads from providerConfig in createAgentModelFromConfig.
 	const cloudProviderConfig = bedrockProviderConfig ?? vertexProviderConfig ?? sapProviderConfig
-	const clineTaskId = input.historyItem?.ulid || input.historyItem?.id || ""
-	const headers = isSdkClineProvider(sdkProviderId) ? await buildClineProviderHeaders(clineTaskId) : undefined
 	// Spread the cloud config first so the explicit fields below — notably the
 	// proxy/CA-aware fetch — can never be clobbered if those types gain matching keys.
 	const providerConfig = {
@@ -710,7 +678,6 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 		modelId,
 		...(apiKey ? { apiKey } : {}),
 		...(baseUrl !== undefined ? { baseUrl } : {}),
-		...(headers ? { headers } : {}),
 		fetch,
 	}
 
@@ -719,7 +686,6 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 		modelId,
 		apiKey,
 		baseUrl,
-		...(headers ? { headers } : {}),
 		providerConfig,
 		cwd,
 		workspaceRoot,
@@ -748,7 +714,7 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 			user: distinctId ? { distinctId } : undefined,
 			client: {
 				name: "cline-vscode",
-				version: ExtensionRegistryInfo.version,
+				version: clientRuntimeContext.clientVersion,
 			},
 			workspace: {
 				rootPath: workspaceRoot,
@@ -757,6 +723,15 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 				ide: "VS Code",
 				platform: process.platform,
 				mode: mode === "plan" ? "plan" : "act",
+			},
+			requestMetadata: {
+				clientType: clientRuntimeContext.clientName,
+				clientVersion: clientRuntimeContext.clientVersion,
+				userAgent: clientRuntimeContext.userAgent,
+				platform: clientRuntimeContext.platform,
+				platformVersion: clientRuntimeContext.platformVersion,
+				coreVersion: clientRuntimeContext.coreVersion,
+				isMultiRoot: clientRuntimeContext.isMultiRoot,
 			},
 			logger: sdkLogger,
 		},
@@ -781,8 +756,6 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
  * agent turn completes.
  */
 export function buildStartSessionInput(config: CoreSessionConfig, input: SessionConfigInput): ClineCoreStartInput {
-	updateClineProviderTaskHeader(config)
-
 	return {
 		config,
 		// Do NOT pass prompt here — start() should return immediately.

--- a/apps/vscode/src/sdk/sdk-api-handler.test.ts
+++ b/apps/vscode/src/sdk/sdk-api-handler.test.ts
@@ -6,7 +6,7 @@ const mocks = vi.hoisted(() => {
 		getProviderSettings: vi.fn(),
 	}
 	return {
-		buildClientRuntimeContext: vi.fn(async () => ({
+		buildClineRequestMetadata: vi.fn(async () => ({
 			userAgent: "Cline/test",
 			clientName: "VSCode Extension",
 			clientVersion: "1.2.3",
@@ -28,7 +28,7 @@ const mocks = vi.hoisted(() => {
 })
 
 vi.mock("@/services/EnvUtils", () => ({
-	buildClientRuntimeContext: mocks.buildClientRuntimeContext,
+	buildClineRequestMetadata: mocks.buildClineRequestMetadata,
 }))
 
 vi.mock("@cline/llms", async () => {
@@ -122,7 +122,7 @@ describe("buildSdkProviderConfig", () => {
 			{ disableReasoning: true },
 		)
 
-		expect(mocks.buildClientRuntimeContext).toHaveBeenCalledTimes(1)
+		expect(mocks.buildClineRequestMetadata).toHaveBeenCalledTimes(1)
 		expect(mocks.createHandler).toHaveBeenCalledWith(
 			expect.objectContaining({
 				providerId: "cline",

--- a/apps/vscode/src/sdk/sdk-api-handler.test.ts
+++ b/apps/vscode/src/sdk/sdk-api-handler.test.ts
@@ -1,13 +1,41 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { buildSdkProviderConfig } from "./sdk-api-handler"
+import { buildApiHandler, buildSdkProviderConfig } from "./sdk-api-handler"
 
 const mocks = vi.hoisted(() => {
 	const providerSettingsManager = {
 		getProviderSettings: vi.fn(),
 	}
 	return {
+		buildClientRuntimeContext: vi.fn(async () => ({
+			userAgent: "Cline/test",
+			clientName: "VSCode Extension",
+			clientVersion: "1.2.3",
+			platform: "Visual Studio Code",
+			platformVersion: "1.90.0",
+			coreVersion: "1.2.3",
+			isMultiRoot: false,
+		})),
+		createHandler: vi.fn((config: { modelId?: string }) => ({
+			createMessage: vi.fn(),
+			getModel: vi.fn(() => ({
+				id: config.modelId ?? "",
+				info: {},
+			})),
+		})),
 		getProviderSettingsManager: vi.fn(() => providerSettingsManager),
 		providerSettingsManager,
+	}
+})
+
+vi.mock("@/services/EnvUtils", () => ({
+	buildClientRuntimeContext: mocks.buildClientRuntimeContext,
+}))
+
+vi.mock("@cline/llms", async () => {
+	const actual = await vi.importActual<typeof import("@cline/llms")>("@cline/llms")
+	return {
+		...actual,
+		createHandler: mocks.createHandler,
 	}
 })
 
@@ -81,5 +109,40 @@ describe("buildSdkProviderConfig", () => {
 			apiKey: "v0-key",
 		})
 		expect(mocks.providerSettingsManager.getProviderSettings).toHaveBeenCalledWith("v0")
+	})
+
+	it("threads VS Code request metadata into standalone Cline handlers", async () => {
+		const handler = await buildApiHandler(
+			{
+				actModeApiProvider: "cline",
+				actModeClineModelId: "anthropic/claude-sonnet-4.6",
+				clineApiKey: "test-key",
+			},
+			"act",
+			{ disableReasoning: true },
+		)
+
+		expect(mocks.buildClientRuntimeContext).toHaveBeenCalledTimes(1)
+		expect(mocks.createHandler).toHaveBeenCalledWith(
+			expect.objectContaining({
+				providerId: "cline",
+				extensionContext: expect.objectContaining({
+					client: {
+						name: "cline-vscode",
+						version: "1.2.3",
+					},
+					requestMetadata: {
+						clientType: "VSCode Extension",
+						clientVersion: "1.2.3",
+						userAgent: "Cline/test",
+						platform: "Visual Studio Code",
+						platformVersion: "1.90.0",
+						coreVersion: "1.2.3",
+						isMultiRoot: false,
+					},
+				}),
+			}),
+		)
+		expect((handler.getModel() as { providerId?: string }).providerId).toBe("cline")
 	})
 })

--- a/apps/vscode/src/sdk/sdk-api-handler.ts
+++ b/apps/vscode/src/sdk/sdk-api-handler.ts
@@ -10,7 +10,7 @@
 import { type ApiHandler, createHandler, type ProviderConfig } from "@cline/llms"
 import type { ApiConfiguration } from "@shared/api"
 import type { Mode } from "@shared/storage/types"
-import { buildClientRuntimeContext } from "@/services/EnvUtils"
+import { buildClineRequestMetadata } from "@/services/EnvUtils"
 import { fetch } from "@/shared/net"
 import { buildBedrockProviderConfig } from "./bedrock-config"
 import { resolveApiKey, resolveBaseUrl, resolveModelId, resolveVertexProviderConfig } from "./cline-session-factory"
@@ -29,21 +29,21 @@ export interface BuildApiHandlerOptions {
 }
 
 function buildStandaloneExtensionContext(
-	clientRuntimeContext: Awaited<ReturnType<typeof buildClientRuntimeContext>>,
+	clineRequestMetadata: Awaited<ReturnType<typeof buildClineRequestMetadata>>,
 ): ProviderConfig["extensionContext"] {
 	return {
 		client: {
 			name: "cline-vscode",
-			version: clientRuntimeContext.clientVersion,
+			version: clineRequestMetadata.clientVersion,
 		},
 		requestMetadata: {
-			clientType: clientRuntimeContext.clientName,
-			clientVersion: clientRuntimeContext.clientVersion,
-			userAgent: clientRuntimeContext.userAgent,
-			platform: clientRuntimeContext.platform,
-			platformVersion: clientRuntimeContext.platformVersion,
-			coreVersion: clientRuntimeContext.coreVersion,
-			isMultiRoot: clientRuntimeContext.isMultiRoot,
+			clientType: clineRequestMetadata.clientName,
+			clientVersion: clineRequestMetadata.clientVersion,
+			userAgent: clineRequestMetadata.userAgent,
+			platform: clineRequestMetadata.platform,
+			platformVersion: clineRequestMetadata.platformVersion,
+			coreVersion: clineRequestMetadata.coreVersion,
+			isMultiRoot: clineRequestMetadata.isMultiRoot,
 		},
 	}
 }
@@ -123,7 +123,7 @@ export async function buildApiHandler(
 	mode: Mode,
 	options?: BuildApiHandlerOptions,
 ): Promise<ApiHandler> {
-	const extensionContext = options?.extensionContext ?? buildStandaloneExtensionContext(await buildClientRuntimeContext())
+	const extensionContext = options?.extensionContext ?? buildStandaloneExtensionContext(await buildClineRequestMetadata())
 	const providerConfig = buildSdkProviderConfig(configuration, mode, {
 		...options,
 		extensionContext,

--- a/apps/vscode/src/sdk/sdk-api-handler.ts
+++ b/apps/vscode/src/sdk/sdk-api-handler.ts
@@ -10,6 +10,7 @@
 import { type ApiHandler, createHandler, type ProviderConfig } from "@cline/llms"
 import type { ApiConfiguration } from "@shared/api"
 import type { Mode } from "@shared/storage/types"
+import { buildClientRuntimeContext } from "@/services/EnvUtils"
 import { fetch } from "@/shared/net"
 import { buildBedrockProviderConfig } from "./bedrock-config"
 import { resolveApiKey, resolveBaseUrl, resolveModelId, resolveVertexProviderConfig } from "./cline-session-factory"
@@ -24,6 +25,27 @@ export interface BuildApiHandlerOptions {
 	 * OpenRouter don't receive a reasoning config at all.
 	 */
 	disableReasoning?: boolean
+	extensionContext?: ProviderConfig["extensionContext"]
+}
+
+function buildStandaloneExtensionContext(
+	clientRuntimeContext: Awaited<ReturnType<typeof buildClientRuntimeContext>>,
+): ProviderConfig["extensionContext"] {
+	return {
+		client: {
+			name: "cline-vscode",
+			version: clientRuntimeContext.clientVersion,
+		},
+		requestMetadata: {
+			clientType: clientRuntimeContext.clientName,
+			clientVersion: clientRuntimeContext.clientVersion,
+			userAgent: clientRuntimeContext.userAgent,
+			platform: clientRuntimeContext.platform,
+			platformVersion: clientRuntimeContext.platformVersion,
+			coreVersion: clientRuntimeContext.coreVersion,
+			isMultiRoot: clientRuntimeContext.isMultiRoot,
+		},
+	}
 }
 
 /**
@@ -70,6 +92,7 @@ export function buildSdkProviderConfig(
 		// Bedrock needs its region + structured AWS auth options forwarded to the
 		// SDK gateway. Without these, a pasted Bedrock API key / region is dropped.
 		...(providerId === "bedrock" ? buildBedrockProviderConfig(configuration, mode) : {}),
+		...(options?.extensionContext ? { extensionContext: options.extensionContext } : {}),
 	}
 
 	if (options?.disableReasoning) {
@@ -95,8 +118,16 @@ export function buildSdkProviderConfig(
  * returned handler implements the same `createMessage`/`getModel` surface, so
  * existing callers continue to work unchanged.
  */
-export function buildApiHandler(configuration: ApiConfiguration, mode: Mode, options?: BuildApiHandlerOptions): ApiHandler {
-	const providerConfig = buildSdkProviderConfig(configuration, mode, options)
+export async function buildApiHandler(
+	configuration: ApiConfiguration,
+	mode: Mode,
+	options?: BuildApiHandlerOptions,
+): Promise<ApiHandler> {
+	const extensionContext = options?.extensionContext ?? buildStandaloneExtensionContext(await buildClientRuntimeContext())
+	const providerConfig = buildSdkProviderConfig(configuration, mode, {
+		...options,
+		extensionContext,
+	})
 	const handler = createHandler(providerConfig)
 	const getModel = handler.getModel.bind(handler)
 

--- a/apps/vscode/src/sdk/sdk-remote-config-control-plane.test.ts
+++ b/apps/vscode/src/sdk/sdk-remote-config-control-plane.test.ts
@@ -41,7 +41,7 @@ vi.mock("@/core/storage/remote-config/utils", () => ({
 	isRemoteConfigEnabled,
 }))
 
-vi.mock("@/services/EnvUtils", () => ({ buildBasicClineHeaders: async () => ({}) }))
+vi.mock("@/services/EnvUtils", () => ({ buildBasicClineHeaders: () => ({}) }))
 vi.mock("@/shared/net", () => ({ getAxiosSettings: () => ({}) }))
 vi.mock("axios", () => ({ default: { request: vi.fn() } }))
 

--- a/apps/vscode/src/services/EnvUtils.ts
+++ b/apps/vscode/src/services/EnvUtils.ts
@@ -43,7 +43,7 @@ async function getHostRuntimeInfo(): Promise<HostRuntimeInfo> {
 			platform: host.platform || "unknown",
 			platformVersion: host.version || "unknown",
 			clientName: host.clineType || "unknown",
-			clientVersion: host.clineVersion || "unknown",
+			clientVersion: host.clineVersion || ExtensionRegistryInfo.version,
 		}
 	} catch (error) {
 		Logger.log("Failed to get IDE/platform info via HostBridge EnvService.getHostVersion", error)
@@ -51,7 +51,7 @@ async function getHostRuntimeInfo(): Promise<HostRuntimeInfo> {
 			platform: "unknown",
 			platformVersion: "unknown",
 			clientName: "unknown",
-			clientVersion: "unknown",
+			clientVersion: ExtensionRegistryInfo.version,
 		}
 	}
 }
@@ -84,13 +84,6 @@ export async function buildBasicClineHeaders(): Promise<Record<string, string>> 
 	headers[ClineHeaders.CLIENT_TYPE] = host.clientName
 	headers[ClineHeaders.CLIENT_VERSION] = host.clientVersion
 	headers[ClineHeaders.CORE_VERSION] = ExtensionRegistryInfo.version
-
-	return headers
-}
-
-export async function buildClineExtraHeaders(): Promise<Record<string, string>> {
-	const headers = await buildBasicClineHeaders()
-	headers[ClineHeaders.IS_MULTIROOT] = (await isMultiRootWorkspace()) ? "true" : "false"
 
 	return headers
 }

--- a/apps/vscode/src/services/EnvUtils.ts
+++ b/apps/vscode/src/services/EnvUtils.ts
@@ -13,27 +13,76 @@ const ClineHeaders = {
 	IS_MULTIROOT: "X-IS-MULTIROOT",
 } as const
 
+interface HostRuntimeInfo {
+	platform: string
+	platformVersion: string
+	clientName: string
+	clientVersion: string
+}
+
+export interface ClientRuntimeContext {
+	platform: string
+	platformVersion: string
+	clientName: string
+	clientVersion: string
+	userAgent: string
+	coreVersion: string
+	isMultiRoot: boolean
+}
+
 export function buildExternalBasicHeaders(): Record<string, string> {
 	return {
 		"User-Agent": `Cline/${ExtensionRegistryInfo.version}`,
 	}
 }
 
-export async function buildBasicClineHeaders(): Promise<Record<string, string>> {
-	const headers: Record<string, string> = buildExternalBasicHeaders()
+async function getHostRuntimeInfo(): Promise<HostRuntimeInfo> {
 	try {
 		const host = await HostProvider.env.getHostVersion(EmptyRequest.create({}))
-		headers[ClineHeaders.PLATFORM] = host.platform || "unknown"
-		headers[ClineHeaders.PLATFORM_VERSION] = host.version || "unknown"
-		headers[ClineHeaders.CLIENT_TYPE] = host.clineType || "unknown"
-		headers[ClineHeaders.CLIENT_VERSION] = host.clineVersion || "unknown"
+		return {
+			platform: host.platform || "unknown",
+			platformVersion: host.version || "unknown",
+			clientName: host.clineType || "unknown",
+			clientVersion: host.clineVersion || "unknown",
+		}
 	} catch (error) {
 		Logger.log("Failed to get IDE/platform info via HostBridge EnvService.getHostVersion", error)
-		headers[ClineHeaders.PLATFORM] = "unknown"
-		headers[ClineHeaders.PLATFORM_VERSION] = "unknown"
-		headers[ClineHeaders.CLIENT_TYPE] = "unknown"
-		headers[ClineHeaders.CLIENT_VERSION] = "unknown"
+		return {
+			platform: "unknown",
+			platformVersion: "unknown",
+			clientName: "unknown",
+			clientVersion: "unknown",
+		}
 	}
+}
+
+async function isMultiRootWorkspace(): Promise<boolean> {
+	try {
+		const { paths } = await HostProvider.workspace.getWorkspacePaths({})
+		return paths.length > 1
+	} catch (error) {
+		Logger.log("Failed to detect multi-root workspace", error)
+		return false
+	}
+}
+
+export async function buildClientRuntimeContext(): Promise<ClientRuntimeContext> {
+	const host = await getHostRuntimeInfo()
+	return {
+		...host,
+		userAgent: buildExternalBasicHeaders()["User-Agent"],
+		coreVersion: ExtensionRegistryInfo.version,
+		isMultiRoot: await isMultiRootWorkspace(),
+	}
+}
+
+export async function buildBasicClineHeaders(): Promise<Record<string, string>> {
+	const host = await getHostRuntimeInfo()
+	const headers: Record<string, string> = buildExternalBasicHeaders()
+	headers[ClineHeaders.PLATFORM] = host.platform
+	headers[ClineHeaders.PLATFORM_VERSION] = host.platformVersion
+	headers[ClineHeaders.CLIENT_TYPE] = host.clientName
+	headers[ClineHeaders.CLIENT_VERSION] = host.clientVersion
 	headers[ClineHeaders.CORE_VERSION] = ExtensionRegistryInfo.version
 
 	return headers
@@ -41,15 +90,7 @@ export async function buildBasicClineHeaders(): Promise<Record<string, string>> 
 
 export async function buildClineExtraHeaders(): Promise<Record<string, string>> {
 	const headers = await buildBasicClineHeaders()
-
-	try {
-		const { paths } = await HostProvider.workspace.getWorkspacePaths({})
-		const isMultiRoot = paths.length > 1
-		headers[ClineHeaders.IS_MULTIROOT] = isMultiRoot ? "true" : "false"
-	} catch (error) {
-		Logger.log("Failed to detect multi-root workspace", error)
-		headers[ClineHeaders.IS_MULTIROOT] = "false"
-	}
+	headers[ClineHeaders.IS_MULTIROOT] = (await isMultiRootWorkspace()) ? "true" : "false"
 
 	return headers
 }

--- a/apps/vscode/src/services/EnvUtils.ts
+++ b/apps/vscode/src/services/EnvUtils.ts
@@ -1,6 +1,5 @@
 import { HostProvider } from "@/hosts/host-provider"
-import { ExtensionRegistryInfo } from "@/registry"
-import { EmptyRequest } from "@/shared/proto/cline/common"
+import { ExtensionRegistryInfo, HostRegistryInfo } from "@/registry"
 import { Logger } from "@/shared/services/Logger"
 
 // Canonical header names for extra client/host context
@@ -36,23 +35,13 @@ export function buildExternalBasicHeaders(): Record<string, string> {
 	}
 }
 
-async function getHostRuntimeInfo(): Promise<HostRuntimeInfo> {
-	try {
-		const host = await HostProvider.env.getHostVersion(EmptyRequest.create({}))
-		return {
-			platform: host.platform || "unknown",
-			platformVersion: host.version || "unknown",
-			clientName: host.clineType || "unknown",
-			clientVersion: host.clineVersion || ExtensionRegistryInfo.version,
-		}
-	} catch (error) {
-		Logger.log("Failed to get IDE/platform info via HostBridge EnvService.getHostVersion", error)
-		return {
-			platform: "unknown",
-			platformVersion: "unknown",
-			clientName: "unknown",
-			clientVersion: ExtensionRegistryInfo.version,
-		}
+function getHostRuntimeInfo(): HostRuntimeInfo {
+	const host = HostRegistryInfo.get()
+	return {
+		platform: host.platform || "unknown",
+		platformVersion: host.hostVersion || "unknown",
+		clientName: host.ide || "unknown",
+		clientVersion: host.extensionVersion || ExtensionRegistryInfo.version,
 	}
 }
 
@@ -67,7 +56,7 @@ async function isMultiRootWorkspace(): Promise<boolean> {
 }
 
 export async function buildClientRuntimeContext(): Promise<ClientRuntimeContext> {
-	const host = await getHostRuntimeInfo()
+	const host = getHostRuntimeInfo()
 	return {
 		...host,
 		userAgent: buildExternalBasicHeaders()["User-Agent"],
@@ -76,8 +65,8 @@ export async function buildClientRuntimeContext(): Promise<ClientRuntimeContext>
 	}
 }
 
-export async function buildBasicClineHeaders(): Promise<Record<string, string>> {
-	const host = await getHostRuntimeInfo()
+export function buildBasicClineHeaders(): Record<string, string> {
+	const host = getHostRuntimeInfo()
 	const headers: Record<string, string> = buildExternalBasicHeaders()
 	headers[ClineHeaders.PLATFORM] = host.platform
 	headers[ClineHeaders.PLATFORM_VERSION] = host.platformVersion

--- a/apps/vscode/src/services/EnvUtils.ts
+++ b/apps/vscode/src/services/EnvUtils.ts
@@ -38,3 +38,18 @@ export async function buildBasicClineHeaders(): Promise<Record<string, string>> 
 
 	return headers
 }
+
+export async function buildClineExtraHeaders(): Promise<Record<string, string>> {
+	const headers = await buildBasicClineHeaders()
+
+	try {
+		const { paths } = await HostProvider.workspace.getWorkspacePaths({})
+		const isMultiRoot = paths.length > 1
+		headers[ClineHeaders.IS_MULTIROOT] = isMultiRoot ? "true" : "false"
+	} catch (error) {
+		Logger.log("Failed to detect multi-root workspace", error)
+		headers[ClineHeaders.IS_MULTIROOT] = "false"
+	}
+
+	return headers
+}

--- a/apps/vscode/src/services/EnvUtils.ts
+++ b/apps/vscode/src/services/EnvUtils.ts
@@ -12,20 +12,16 @@ const ClineHeaders = {
 	IS_MULTIROOT: "X-IS-MULTIROOT",
 } as const
 
-interface HostRuntimeInfo {
-	platform: string
-	platformVersion: string
-	clientName: string
-	clientVersion: string
-}
-
-export interface ClientRuntimeContext {
+export interface ClientIdentityContext {
 	platform: string
 	platformVersion: string
 	clientName: string
 	clientVersion: string
 	userAgent: string
 	coreVersion: string
+}
+
+export interface ClineRequestMetadataContext extends ClientIdentityContext {
 	isMultiRoot: boolean
 }
 
@@ -35,17 +31,19 @@ export function buildExternalBasicHeaders(): Record<string, string> {
 	}
 }
 
-function getHostRuntimeInfo(): HostRuntimeInfo {
+export function buildClientIdentityContext(): ClientIdentityContext {
 	const host = HostRegistryInfo.get()
 	return {
 		platform: host.platform || "unknown",
 		platformVersion: host.hostVersion || "unknown",
 		clientName: host.ide || "unknown",
 		clientVersion: host.extensionVersion || ExtensionRegistryInfo.version,
+		userAgent: buildExternalBasicHeaders()["User-Agent"],
+		coreVersion: ExtensionRegistryInfo.version,
 	}
 }
 
-async function isMultiRootWorkspace(): Promise<boolean> {
+export async function isMultiRootWorkspace(): Promise<boolean> {
 	try {
 		const { paths } = await HostProvider.workspace.getWorkspacePaths({})
 		return paths.length > 1
@@ -55,18 +53,15 @@ async function isMultiRootWorkspace(): Promise<boolean> {
 	}
 }
 
-export async function buildClientRuntimeContext(): Promise<ClientRuntimeContext> {
-	const host = getHostRuntimeInfo()
+export async function buildClineRequestMetadata(): Promise<ClineRequestMetadataContext> {
 	return {
-		...host,
-		userAgent: buildExternalBasicHeaders()["User-Agent"],
-		coreVersion: ExtensionRegistryInfo.version,
+		...buildClientIdentityContext(),
 		isMultiRoot: await isMultiRootWorkspace(),
 	}
 }
 
 export function buildBasicClineHeaders(): Record<string, string> {
-	const host = getHostRuntimeInfo()
+	const host = buildClientIdentityContext()
 	const headers: Record<string, string> = buildExternalBasicHeaders()
 	headers[ClineHeaders.PLATFORM] = host.platform
 	headers[ClineHeaders.PLATFORM_VERSION] = host.platformVersion

--- a/apps/vscode/src/services/account/ClineAccountService.ts
+++ b/apps/vscode/src/services/account/ClineAccountService.ts
@@ -69,7 +69,7 @@ export class ClineAccountService {
 			headers: {
 				Authorization: `Bearer ${clineAccountAuthToken}`,
 				"Content-Type": "application/json",
-				...(await buildBasicClineHeaders()),
+				...buildBasicClineHeaders(),
 				...config.headers,
 			},
 			...getAxiosSettings(),

--- a/apps/vscode/src/services/banner/BannerService.ts
+++ b/apps/vscode/src/services/banner/BannerService.ts
@@ -71,9 +71,6 @@ export class BannerService {
 			return BannerService.instance
 		}
 		const hostInfo = HostRegistryInfo.get()
-		if (!hostInfo) {
-			throw new Error("[BannerService] Ensure HostRegistryInfo is initialized before BannerService.")
-		}
 		BannerService.instance = new BannerService(controller, hostInfo)
 		return BannerService.instance
 	}
@@ -257,7 +254,7 @@ export class BannerService {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					...(await buildBasicClineHeaders()),
+					...buildBasicClineHeaders(),
 				},
 				body: JSON.stringify({
 					banner_id: bannerId,
@@ -299,7 +296,7 @@ export class BannerService {
 			const url = this.buildFetchUrl()
 			const headers: Record<string, string> = {
 				"Content-Type": "application/json",
-				...(await buildBasicClineHeaders()),
+				...buildBasicClineHeaders(),
 			}
 			const authToken = await AuthService.getInstance().getAuthToken()
 			if (authToken) {

--- a/sdk/packages/agents/src/agent-runtime.provider-form.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.provider-form.test.ts
@@ -109,7 +109,7 @@ describe("AgentRuntime (provider-form config + Agent alias)", () => {
 		});
 	});
 
-	it("adds default SDK headers for Cline provider requests", () => {
+	it("passes provider headers through to the llms gateway", () => {
 		const model = new ScriptedModel([]);
 		createAgentModel.mockReturnValue(model);
 
@@ -129,10 +129,6 @@ describe("AgentRuntime (provider-form config + Agent alias)", () => {
 					apiKey: "test-key",
 					baseUrl: undefined,
 					headers: {
-						"HTTP-Referer": "https://cline.bot",
-						"X-Title": "Cline",
-						"X-IS-MULTIROOT": "false",
-						"X-CLIENT-TYPE": "cline-sdk",
 						"x-custom": "kept",
 					},
 					options: undefined,

--- a/sdk/packages/agents/src/agent-runtime.provider-form.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.provider-form.test.ts
@@ -109,6 +109,38 @@ describe("AgentRuntime (provider-form config + Agent alias)", () => {
 		});
 	});
 
+	it("adds default SDK headers for Cline provider requests", () => {
+		const model = new ScriptedModel([]);
+		createAgentModel.mockReturnValue(model);
+
+		new Agent({
+			providerId: "cline",
+			modelId: "anthropic/claude-sonnet-4.6",
+			apiKey: "test-key",
+			headers: {
+				"x-custom": "kept",
+			},
+		});
+
+		expect(createGateway).toHaveBeenCalledWith({
+			providerConfigs: [
+				{
+					providerId: "cline",
+					apiKey: "test-key",
+					baseUrl: undefined,
+					headers: {
+						"HTTP-Referer": "https://cline.bot",
+						"X-Title": "Cline",
+						"X-IS-MULTIROOT": "false",
+						"X-CLIENT-TYPE": "cline-sdk",
+						"x-custom": "kept",
+					},
+					options: undefined,
+				},
+			],
+		});
+	});
+
 	it("forwards abort() to the active AgentRuntime", async () => {
 		let abortReason: unknown;
 		const model = new ScriptedModel([

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -24,6 +24,7 @@ import type {
 	ToolPolicy,
 } from "@cline/shared";
 import {
+	buildClineRequestHeaders,
 	captureAgentUnexpectedReasoningTokens,
 	captureSdkError,
 	estimateTokens,
@@ -101,7 +102,15 @@ function resolveRuntimeConfig(
 	const { providerId, modelId, apiKey, baseUrl, headers, options, ...rest } =
 		config;
 	const gateway = createGateway({
-		providerConfigs: [{ providerId, apiKey, baseUrl, headers, options }],
+		providerConfigs: [
+			{
+				providerId,
+				apiKey,
+				baseUrl,
+				headers: buildClineRequestHeaders({ providerId, headers }),
+				options,
+			},
+		],
 		telemetry: rest.telemetry,
 	});
 	const model = gateway.createAgentModel({ providerId, modelId });

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -24,7 +24,6 @@ import type {
 	ToolPolicy,
 } from "@cline/shared";
 import {
-	buildClineRequestHeaders,
 	captureAgentUnexpectedReasoningTokens,
 	captureSdkError,
 	estimateTokens,
@@ -107,7 +106,7 @@ function resolveRuntimeConfig(
 				providerId,
 				apiKey,
 				baseUrl,
-				headers: buildClineRequestHeaders({ providerId, headers }),
+				headers,
 				options,
 			},
 		],

--- a/sdk/packages/agents/vitest.config.ts
+++ b/sdk/packages/agents/vitest.config.ts
@@ -1,22 +1,6 @@
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
-const rootDir = dirname(fileURLToPath(import.meta.url));
-
 export default defineConfig({
-	resolve: {
-		alias: [
-			{
-				find: /^@cline\/shared\/(.+)$/,
-				replacement: resolve(rootDir, "../shared/src/$1"),
-			},
-			{
-				find: /^@cline\/shared$/,
-				replacement: resolve(rootDir, "../shared/src/index.ts"),
-			},
-		],
-	},
 	test: {
 		environment: "node",
 		include: ["src/**/*.test.ts"],

--- a/sdk/packages/agents/vitest.config.ts
+++ b/sdk/packages/agents/vitest.config.ts
@@ -1,6 +1,22 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
+const rootDir = dirname(fileURLToPath(import.meta.url));
+
 export default defineConfig({
+	resolve: {
+		alias: [
+			{
+				find: /^@cline\/shared\/(.+)$/,
+				replacement: resolve(rootDir, "../shared/src/$1"),
+			},
+			{
+				find: /^@cline\/shared$/,
+				replacement: resolve(rootDir, "../shared/src/index.ts"),
+			},
+		],
+	},
 	test: {
 		environment: "node",
 		include: ["src/**/*.test.ts"],

--- a/sdk/packages/core/src/services/llms/handler-factory.test.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.test.ts
@@ -145,14 +145,23 @@ describe("createAgentModelFromConfig", () => {
 				providerId: "cline",
 				modelId: "anthropic/claude-sonnet-4.6",
 				apiKey: "key",
-				sessionId: "sess-cli",
+				sessionId: "sess-vscode",
 				systemPrompt: "",
 				tools: [],
 				extensionContext: {
-					client: { name: "cline-cli", version: "1.2.3" },
+					client: { name: "cline-vscode", version: "1.2.3" },
 					workspace: {
 						rootPath: "/tmp/project",
 						platform: "darwin",
+					},
+					requestMetadata: {
+						clientType: "VSCode Extension",
+						clientVersion: "1.2.3",
+						userAgent: "Cline/1.2.3",
+						platform: "Visual Studio Code",
+						platformVersion: "1.90.0",
+						coreVersion: "1.2.3",
+						isMultiRoot: true,
 					},
 				},
 				providerConfig: {
@@ -170,11 +179,14 @@ describe("createAgentModelFromConfig", () => {
 		expect(gatewayConfig?.providerConfigs[0].headers).toMatchObject({
 			"HTTP-Referer": "https://cline.bot",
 			"X-Title": "Cline",
-			"X-IS-MULTIROOT": "false",
-			"X-CLIENT-TYPE": "cline-cli",
+			"User-Agent": "Cline/1.2.3",
+			"X-IS-MULTIROOT": "true",
+			"X-CLIENT-TYPE": "VSCode Extension",
 			"X-CLIENT-VERSION": "1.2.3",
-			"X-PLATFORM": "darwin",
-			"X-Task-ID": "sess-cli",
+			"X-PLATFORM": "Visual Studio Code",
+			"X-PLATFORM-VERSION": "1.90.0",
+			"X-CORE-VERSION": "1.2.3",
+			"X-Task-ID": "sess-vscode",
 			"x-provider": "kept",
 		});
 	});

--- a/sdk/packages/core/src/services/llms/handler-factory.test.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.test.ts
@@ -599,6 +599,9 @@ describe("createAgentModelFromConfig", () => {
 
 	it("uses a registered handler (adapter) instead of the gateway, building it lazily", async () => {
 		const { createAgentModelFromConfig } = await import("./handler-factory");
+		const extensionContext = {
+			client: { name: "cline-vscode", version: "1.2.3" },
+		} satisfies NonNullable<AgentConfig["extensionContext"]>;
 
 		// Pretend a host handler is registered for this provider.
 		gatewayMock.hasRegisteredHandler.mockReturnValue(true);
@@ -620,6 +623,7 @@ describe("createAgentModelFromConfig", () => {
 				apiKey: "",
 				systemPrompt: "",
 				tools: [],
+				extensionContext,
 			},
 			undefined,
 		);
@@ -638,5 +642,8 @@ describe("createAgentModelFromConfig", () => {
 			// drain
 		}
 		expect(gatewayMock.createHandlerAsync).toHaveBeenCalledTimes(1);
+		expect(gatewayMock.createHandlerAsync).toHaveBeenCalledWith(
+			expect.objectContaining({ extensionContext }),
+		);
 	});
 });

--- a/sdk/packages/core/src/services/llms/handler-factory.test.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.test.ts
@@ -21,6 +21,18 @@ vi.mock("@cline/llms", () => ({
 	normalizeProviderId: (id: string) => id,
 }));
 
+type GatewayConfigCall = {
+	providerConfigs: Array<{ headers?: Record<string, string> }>;
+};
+
+function getLastGatewayConfig(): GatewayConfigCall | undefined {
+	return (
+		gatewayMock.createGateway.mock.calls as unknown as Array<
+			[GatewayConfigCall]
+		>
+	).at(-1)?.[0];
+}
+
 describe("createAgentModelFromConfig", () => {
 	beforeEach(() => {
 		gatewayMock.createAgentModel.mockReset();
@@ -123,6 +135,124 @@ describe("createAgentModelFromConfig", () => {
 				],
 			}),
 		);
+	});
+
+	it("adds SDK client headers for Cline provider requests", async () => {
+		const { createAgentModelFromConfig } = await import("./handler-factory");
+
+		createAgentModelFromConfig(
+			{
+				providerId: "cline",
+				modelId: "anthropic/claude-sonnet-4.6",
+				apiKey: "key",
+				sessionId: "sess-cli",
+				systemPrompt: "",
+				tools: [],
+				extensionContext: {
+					client: { name: "cline-cli", version: "1.2.3" },
+					workspace: {
+						rootPath: "/tmp/project",
+						platform: "darwin",
+					},
+				},
+				providerConfig: {
+					providerId: "cline",
+					modelId: "anthropic/claude-sonnet-4.6",
+					headers: {
+						"x-provider": "kept",
+					},
+				},
+			},
+			undefined,
+		);
+
+		const gatewayConfig = getLastGatewayConfig();
+		expect(gatewayConfig?.providerConfigs[0].headers).toMatchObject({
+			"HTTP-Referer": "https://cline.bot",
+			"X-Title": "Cline",
+			"X-IS-MULTIROOT": "false",
+			"X-CLIENT-TYPE": "cline-cli",
+			"X-CLIENT-VERSION": "1.2.3",
+			"X-PLATFORM": "darwin",
+			"X-Task-ID": "sess-cli",
+			"x-provider": "kept",
+		});
+	});
+
+	it("lets explicit Cline headers override derived SDK client headers", async () => {
+		const { createAgentModelFromConfig } = await import("./handler-factory");
+
+		createAgentModelFromConfig(
+			{
+				providerId: "cline",
+				modelId: "anthropic/claude-sonnet-4.6",
+				apiKey: "key",
+				sessionId: "sess-vscode",
+				systemPrompt: "",
+				tools: [],
+				headers: {
+					"X-CLIENT-TYPE": "VSCode Extension",
+					"X-IS-MULTIROOT": "true",
+					"x-top": "wins",
+				},
+				extensionContext: {
+					client: { name: "cline-vscode", version: "1.2.3" },
+					workspace: {
+						rootPath: "/tmp/project",
+						platform: "darwin",
+					},
+				},
+				providerConfig: {
+					providerId: "cline",
+					modelId: "anthropic/claude-sonnet-4.6",
+					headers: {
+						"X-CLIENT-TYPE": "provider-client",
+						"x-provider": "kept",
+					},
+				},
+			},
+			undefined,
+		);
+
+		const gatewayConfig = getLastGatewayConfig();
+		expect(gatewayConfig?.providerConfigs[0].headers).toMatchObject({
+			"X-CLIENT-TYPE": "VSCode Extension",
+			"X-CLIENT-VERSION": "1.2.3",
+			"X-IS-MULTIROOT": "true",
+			"X-Task-ID": "sess-vscode",
+			"x-provider": "kept",
+			"x-top": "wins",
+		});
+	});
+
+	it("preserves existing header precedence for non-Cline providers", async () => {
+		const { createAgentModelFromConfig } = await import("./handler-factory");
+
+		createAgentModelFromConfig(
+			{
+				providerId: "openai-compatible",
+				modelId: "custom-model",
+				apiKey: "key",
+				systemPrompt: "",
+				tools: [],
+				headers: {
+					"x-top": "wins",
+				},
+				providerConfig: {
+					providerId: "openai-compatible",
+					modelId: "custom-model",
+					headers: {
+						"x-provider": "not-merged",
+					},
+				},
+			},
+			undefined,
+		);
+
+		const gatewayConfig = getLastGatewayConfig();
+		expect(gatewayConfig?.providerConfigs[0].headers).toEqual({
+			"x-top": "wins",
+		});
 	});
 
 	it("preserves model capabilities and metadata when configuring gateway models", async () => {

--- a/sdk/packages/core/src/services/llms/handler-factory.test.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.test.ts
@@ -191,7 +191,7 @@ describe("createAgentModelFromConfig", () => {
 		});
 	});
 
-	it("lets explicit Cline headers override derived SDK client headers", async () => {
+	it("keeps custom Cline headers while derived SDK client headers win", async () => {
 		const { createAgentModelFromConfig } = await import("./handler-factory");
 
 		createAgentModelFromConfig(
@@ -203,8 +203,8 @@ describe("createAgentModelFromConfig", () => {
 				systemPrompt: "",
 				tools: [],
 				headers: {
-					"X-CLIENT-TYPE": "VSCode Extension",
-					"X-IS-MULTIROOT": "true",
+					"X-CLIENT-TYPE": "",
+					"X-IS-MULTIROOT": "",
 					"x-top": "wins",
 				},
 				extensionContext: {
@@ -213,12 +213,18 @@ describe("createAgentModelFromConfig", () => {
 						rootPath: "/tmp/project",
 						platform: "darwin",
 					},
+					requestMetadata: {
+						clientType: "VSCode Extension",
+						clientVersion: "1.2.3",
+						isMultiRoot: true,
+					},
 				},
 				providerConfig: {
 					providerId: "cline",
 					modelId: "anthropic/claude-sonnet-4.6",
 					headers: {
 						"X-CLIENT-TYPE": "provider-client",
+						"X-CLIENT-VERSION": "stale-provider-version",
 						"x-provider": "kept",
 					},
 				},
@@ -235,6 +241,9 @@ describe("createAgentModelFromConfig", () => {
 			"x-provider": "kept",
 			"x-top": "wins",
 		});
+		expect(gatewayConfig?.providerConfigs[0].headers).not.toHaveProperty(
+			"X-PLATFORM",
+		);
 	});
 
 	it("preserves existing header precedence for non-Cline providers", async () => {

--- a/sdk/packages/core/src/services/llms/handler-factory.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.ts
@@ -127,19 +127,7 @@ function resolveHeadersFromConfig(
 	return buildClineRequestHeaders({
 		providerId,
 		headers,
-		clientName:
-			extensionContext?.requestMetadata?.clientType ??
-			extensionContext?.client?.name,
-		clientVersion:
-			extensionContext?.requestMetadata?.clientVersion ??
-			extensionContext?.client?.version,
-		userAgent: extensionContext?.requestMetadata?.userAgent,
-		platform:
-			extensionContext?.requestMetadata?.platform ??
-			extensionContext?.workspace?.platform,
-		platformVersion: extensionContext?.requestMetadata?.platformVersion,
-		coreVersion: extensionContext?.requestMetadata?.coreVersion,
-		isMultiRoot: extensionContext?.requestMetadata?.isMultiRoot,
+		extensionContext,
 		taskId: config.sessionId ?? baseProviderConfig?.taskId,
 	});
 }

--- a/sdk/packages/core/src/services/llms/handler-factory.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.ts
@@ -5,13 +5,15 @@ import {
 	MODEL_COLLECTIONS_BY_PROVIDER_ID,
 	normalizeProviderId,
 } from "@cline/llms";
-import type {
-	AgentConfig,
-	AgentModel,
-	BasicLogger,
-	GatewayModelDefinition,
-	ITelemetryService,
-	ModelInfo,
+import {
+	type AgentConfig,
+	type AgentModel,
+	type BasicLogger,
+	buildClineRequestHeaders,
+	type GatewayModelDefinition,
+	type ITelemetryService,
+	isClineProvider,
+	type ModelInfo,
 } from "@cline/shared";
 import { createAgentModelFromApiHandler } from "./apihandler-agent-model-adapter";
 import type { ProviderConfig } from "./provider-settings";
@@ -96,6 +98,42 @@ export function resolveKnownModelsFromConfig(
 	);
 }
 
+function mergeHeaders(
+	baseHeaders: Record<string, string> | undefined,
+	overrideHeaders: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+	if (!baseHeaders && !overrideHeaders) {
+		return undefined;
+	}
+	return {
+		...(baseHeaders ?? {}),
+		...(overrideHeaders ?? {}),
+	};
+}
+
+function resolveHeadersFromConfig(
+	config: AgentConfig,
+	baseProviderConfig: ProviderConfig | undefined,
+): Record<string, string> | undefined {
+	const providerId = normalizeProviderId(config.providerId);
+	if (!isClineProvider(providerId)) {
+		return config.headers ?? baseProviderConfig?.headers;
+	}
+
+	const extensionContext =
+		config.extensionContext ?? baseProviderConfig?.extensionContext;
+	const headers = mergeHeaders(baseProviderConfig?.headers, config.headers);
+
+	return buildClineRequestHeaders({
+		providerId,
+		headers,
+		clientName: extensionContext?.client?.name,
+		clientVersion: extensionContext?.client?.version,
+		platform: extensionContext?.workspace?.platform,
+		taskId: config.sessionId ?? baseProviderConfig?.taskId,
+	});
+}
+
 function toGatewayCapabilities(
 	capabilities: ModelInfo["capabilities"],
 ): GatewayModelDefinition["capabilities"] {
@@ -161,14 +199,15 @@ export function createAgentModelFromConfig(
 		modelId: config.modelId,
 		apiKey: config.apiKey ?? baseProviderConfig?.apiKey,
 		baseUrl: config.baseUrl ?? baseProviderConfig?.baseUrl,
-		headers: config.headers ?? baseProviderConfig?.headers,
+		headers: resolveHeadersFromConfig(config, baseProviderConfig),
 		knownModels: resolveKnownModelsFromConfig(config),
 		maxOutputTokens: config.maxTokensPerTurn,
 		reasoningEffort: config.reasoningEffort,
 		thinkingBudgetTokens: config.thinkingBudgetTokens,
 		thinking: config.thinking,
 		logger,
-		extensionContext: config.extensionContext,
+		extensionContext:
+			config.extensionContext ?? baseProviderConfig?.extensionContext,
 	};
 
 	// Host-registered custom handlers (e.g. VS Code LM, which needs the host's

--- a/sdk/packages/core/src/services/llms/handler-factory.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.ts
@@ -127,9 +127,19 @@ function resolveHeadersFromConfig(
 	return buildClineRequestHeaders({
 		providerId,
 		headers,
-		clientName: extensionContext?.client?.name,
-		clientVersion: extensionContext?.client?.version,
-		platform: extensionContext?.workspace?.platform,
+		clientName:
+			extensionContext?.requestMetadata?.clientType ??
+			extensionContext?.client?.name,
+		clientVersion:
+			extensionContext?.requestMetadata?.clientVersion ??
+			extensionContext?.client?.version,
+		userAgent: extensionContext?.requestMetadata?.userAgent,
+		platform:
+			extensionContext?.requestMetadata?.platform ??
+			extensionContext?.workspace?.platform,
+		platformVersion: extensionContext?.requestMetadata?.platformVersion,
+		coreVersion: extensionContext?.requestMetadata?.coreVersion,
+		isMultiRoot: extensionContext?.requestMetadata?.isMultiRoot,
 		taskId: config.sessionId ?? baseProviderConfig?.taskId,
 	});
 }

--- a/sdk/packages/core/src/services/llms/handler-factory.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.ts
@@ -10,6 +10,7 @@ import {
 	type AgentModel,
 	type BasicLogger,
 	buildClineRequestHeaders,
+	type ExtensionContext,
 	type GatewayModelDefinition,
 	type ITelemetryService,
 	isClineProvider,
@@ -114,14 +115,13 @@ function mergeHeaders(
 function resolveHeadersFromConfig(
 	config: AgentConfig,
 	baseProviderConfig: ProviderConfig | undefined,
+	extensionContext: ExtensionContext | undefined,
 ): Record<string, string> | undefined {
 	const providerId = normalizeProviderId(config.providerId);
 	if (!isClineProvider(providerId)) {
 		return config.headers ?? baseProviderConfig?.headers;
 	}
 
-	const extensionContext =
-		config.extensionContext ?? baseProviderConfig?.extensionContext;
 	const headers = mergeHeaders(baseProviderConfig?.headers, config.headers);
 
 	return buildClineRequestHeaders({
@@ -183,6 +183,13 @@ function toGatewayConfiguredModel(
 	};
 }
 
+function resolveExtensionContext(
+	config: AgentConfig,
+	baseProviderConfig: ProviderConfig | undefined,
+): ExtensionContext | undefined {
+	return config.extensionContext ?? baseProviderConfig?.extensionContext;
+}
+
 export function createAgentModelFromConfig(
 	config: AgentConfig,
 	logger: BasicLogger | undefined,
@@ -191,21 +198,24 @@ export function createAgentModelFromConfig(
 	const pc = config.providerConfig as ProviderConfig | undefined;
 	const baseProviderConfig =
 		pc?.providerId === config.providerId ? pc : undefined;
+	const extensionContext = resolveExtensionContext(config, baseProviderConfig);
 	const normalizedProviderConfig: ProviderConfig = {
 		...(baseProviderConfig ?? {}),
 		providerId: config.providerId,
 		modelId: config.modelId,
 		apiKey: config.apiKey ?? baseProviderConfig?.apiKey,
 		baseUrl: config.baseUrl ?? baseProviderConfig?.baseUrl,
-		headers: resolveHeadersFromConfig(config, baseProviderConfig),
+		headers: resolveHeadersFromConfig(
+			config,
+			baseProviderConfig,
+			extensionContext,
+		),
 		knownModels: resolveKnownModelsFromConfig(config),
 		maxOutputTokens: config.maxTokensPerTurn,
 		reasoningEffort: config.reasoningEffort,
 		thinkingBudgetTokens: config.thinkingBudgetTokens,
 		thinking: config.thinking,
 		logger,
-		extensionContext:
-			config.extensionContext ?? baseProviderConfig?.extensionContext,
 	};
 
 	// Host-registered custom handlers (e.g. VS Code LM, which needs the host's
@@ -220,7 +230,10 @@ export function createAgentModelFromConfig(
 		)
 	) {
 		return createAgentModelFromApiHandler(() =>
-			createHandlerAsync(normalizedProviderConfig),
+			createHandlerAsync({
+				...normalizedProviderConfig,
+				...(extensionContext ? { extensionContext } : {}),
+			}),
 		);
 	}
 
@@ -246,8 +259,7 @@ export function createAgentModelFromConfig(
 			},
 		],
 		logger,
-		telemetry:
-			telemetry ?? config.telemetry ?? config.extensionContext?.telemetry,
+		telemetry: telemetry ?? config.telemetry ?? extensionContext?.telemetry,
 	}).createAgentModel(
 		{
 			providerId: normalizedProviderConfig.providerId,

--- a/sdk/packages/core/src/services/local-runtime-bootstrap.test.ts
+++ b/sdk/packages/core/src/services/local-runtime-bootstrap.test.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { ExtensionContext } from "@cline/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ProviderSettings } from "../types/provider-settings";
 
@@ -392,6 +393,58 @@ describe("prepareLocalRuntimeBootstrap", () => {
 		});
 
 		expect(bootstrap.providerConfig.fetch).toBeUndefined();
+	});
+
+	it("preserves stored Cline headers when session config only supplies request metadata", async () => {
+		const { prepareLocalRuntimeBootstrap } = await import(
+			"./local-runtime-bootstrap"
+		);
+
+		const input = createStartInput();
+		const config = input.config as typeof input.config & {
+			extensionContext: ExtensionContext;
+		};
+		config.extensionContext = {
+			client: { name: "cline-vscode", version: "1.2.3" },
+			requestMetadata: {
+				clientType: "VSCode Extension",
+				clientVersion: "1.2.3",
+				platform: "Visual Studio Code",
+				platformVersion: "1.90.0",
+				coreVersion: "1.2.3",
+				isMultiRoot: false,
+			},
+		};
+
+		const bootstrap = await prepareLocalRuntimeBootstrap({
+			input,
+			sessionId: "sess-cline",
+			providerSettingsManager: createProviderSettingsManager({
+				provider: "cline",
+				model: "anthropic/claude-haiku-4.5",
+				headers: {
+					"x-stored": "stored",
+				},
+			}) as never,
+			defaultTelemetry: undefined,
+			defaultToolPolicies: undefined,
+			onPluginEvent: () => {},
+			onTeamEvent: () => {},
+			createSpawnTool,
+			readSessionMetadata: async () => undefined,
+			writeSessionMetadata: async () => {},
+		});
+
+		expect(bootstrap.config.headers).toBeUndefined();
+		expect(bootstrap.providerConfig.headers).toEqual({
+			"x-stored": "stored",
+		});
+		expect(
+			bootstrap.providerConfig.extensionContext?.requestMetadata,
+		).toMatchObject({
+			clientType: "VSCode Extension",
+			platform: "Visual Studio Code",
+		});
 	});
 
 	it("adds Codex backend headers for openai-codex from stored OAuth settings", async () => {

--- a/sdk/packages/core/src/services/local-runtime-bootstrap.test.ts
+++ b/sdk/packages/core/src/services/local-runtime-bootstrap.test.ts
@@ -439,9 +439,8 @@ describe("prepareLocalRuntimeBootstrap", () => {
 		expect(bootstrap.providerConfig.headers).toEqual({
 			"x-stored": "stored",
 		});
-		expect(
-			bootstrap.providerConfig.extensionContext?.requestMetadata,
-		).toMatchObject({
+		expect(bootstrap.providerConfig.extensionContext).toBeUndefined();
+		expect(bootstrap.config.extensionContext?.requestMetadata).toMatchObject({
 			clientType: "VSCode Extension",
 			platform: "Visual Studio Code",
 		});

--- a/sdk/packages/core/src/services/local-runtime-bootstrap.ts
+++ b/sdk/packages/core/src/services/local-runtime-bootstrap.ts
@@ -179,6 +179,51 @@ function deriveOpenAICodexAccountId(
 	return undefined;
 }
 
+function mergeExtensionContext(
+	base: ExtensionContext | undefined,
+	override: ExtensionContext | undefined,
+): ExtensionContext | undefined {
+	if (!base && !override) {
+		return undefined;
+	}
+	return {
+		...(base ?? {}),
+		...(override ?? {}),
+		user:
+			base?.user || override?.user
+				? { ...(base?.user ?? {}), ...(override?.user ?? {}) }
+				: undefined,
+		client:
+			base?.client || override?.client
+				? ({
+						...(base?.client ?? {}),
+						...(override?.client ?? {}),
+					} as ExtensionContext["client"])
+				: undefined,
+		workspace:
+			base?.workspace || override?.workspace
+				? ({
+						...(base?.workspace ?? {}),
+						...(override?.workspace ?? {}),
+					} as ExtensionContext["workspace"])
+				: undefined,
+		requestMetadata:
+			base?.requestMetadata || override?.requestMetadata
+				? {
+						...(base?.requestMetadata ?? {}),
+						...(override?.requestMetadata ?? {}),
+					}
+				: undefined,
+		session:
+			base?.session || override?.session
+				? { ...(base?.session ?? {}), ...(override?.session ?? {}) }
+				: undefined,
+		automation: override?.automation ?? base?.automation,
+		logger: override?.logger ?? base?.logger,
+		telemetry: override?.telemetry ?? base?.telemetry,
+	};
+}
+
 function buildProviderConfig(
 	config: CoreSessionConfig,
 	sessionId: string,
@@ -319,7 +364,10 @@ export async function prepareLocalRuntimeBootstrap(
 	// as workspaceMetadata; the structured object is kept as workspaceInfo.
 	const { workspaceInfo, workspaceMetadata, durationMs, vcsType, initError } =
 		await buildWorkspaceMetadataWithInfo(workspacePath);
-	const configuredExtensionContext = localConfig?.extensionContext;
+	const configuredExtensionContext = mergeExtensionContext(
+		(input.config as { extensionContext?: ExtensionContext }).extensionContext,
+		localConfig?.extensionContext,
+	);
 	const extensionContext: ExtensionContext = {
 		...(configuredExtensionContext ?? {}),
 		workspace: {

--- a/sdk/packages/core/src/services/local-runtime-bootstrap.ts
+++ b/sdk/packages/core/src/services/local-runtime-bootstrap.ts
@@ -270,9 +270,6 @@ function buildProviderConfig(
 	if (config.knownModels) {
 		providerConfig.knownModels = config.knownModels;
 	}
-	if (config.extensionContext) {
-		providerConfig.extensionContext = config.extensionContext;
-	}
 	// Thread a host-provided custom fetch through to the AI gateway providers.
 	// Precedence: explicit per-session config > stored provider settings > host default.
 	const sessionFetch = (config as { fetch?: typeof fetch }).fetch;

--- a/sdk/packages/core/vitest.config.ts
+++ b/sdk/packages/core/vitest.config.ts
@@ -1,22 +1,6 @@
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
-const rootDir = dirname(fileURLToPath(import.meta.url));
-
 export default defineConfig({
-	resolve: {
-		alias: [
-			{
-				find: /^@cline\/shared\/(.+)$/,
-				replacement: resolve(rootDir, "../shared/src/$1"),
-			},
-			{
-				find: /^@cline\/shared$/,
-				replacement: resolve(rootDir, "../shared/src/index.ts"),
-			},
-		],
-	},
 	test: {
 		environment: "node",
 		include: ["src/**/*.test.ts"],

--- a/sdk/packages/core/vitest.config.ts
+++ b/sdk/packages/core/vitest.config.ts
@@ -1,6 +1,22 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
+const rootDir = dirname(fileURLToPath(import.meta.url));
+
 export default defineConfig({
+	resolve: {
+		alias: [
+			{
+				find: /^@cline\/shared\/(.+)$/,
+				replacement: resolve(rootDir, "../shared/src/$1"),
+			},
+			{
+				find: /^@cline\/shared$/,
+				replacement: resolve(rootDir, "../shared/src/index.ts"),
+			},
+		],
+	},
 	test: {
 		environment: "node",
 		include: ["src/**/*.test.ts"],

--- a/sdk/packages/llms/src/providers/builtins.test.ts
+++ b/sdk/packages/llms/src/providers/builtins.test.ts
@@ -1,4 +1,8 @@
-import { CLINE_ENVIRONMENT_ENV, CLINE_ENVIRONMENTS } from "@cline/shared";
+import {
+	CLINE_ENVIRONMENT_ENV,
+	CLINE_ENVIRONMENTS,
+	DEFAULT_REQUEST_HEADERS,
+} from "@cline/shared";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { BUILTIN_SPECS } from "./builtins";
 import { getModelsForProvider, getProvider } from "./model-registry";
@@ -7,6 +11,14 @@ function findClineSpec() {
 	const spec = BUILTIN_SPECS.find((s) => s.id === "cline");
 	if (!spec) {
 		throw new Error("cline builtin spec not found");
+	}
+	return spec;
+}
+
+function findClinePassSpec() {
+	const spec = BUILTIN_SPECS.find((s) => s.id === "cline-pass");
+	if (!spec) {
+		throw new Error("cline-pass builtin spec not found");
 	}
 	return spec;
 }
@@ -46,6 +58,15 @@ describe("cline builtin spec defaults.baseUrl", () => {
 		delete process.env[CLINE_ENVIRONMENT_ENV];
 		expect(spec.defaults?.baseUrl).toBe(
 			`${CLINE_ENVIRONMENTS.production.apiBaseUrl}/api/v1`,
+		);
+	});
+});
+
+describe("cline builtin spec request headers", () => {
+	it("uses the shared default request headers for Cline-compatible providers", () => {
+		expect(findClineSpec().defaults?.headers).toEqual(DEFAULT_REQUEST_HEADERS);
+		expect(findClinePassSpec().defaults?.headers).toEqual(
+			DEFAULT_REQUEST_HEADERS,
 		);
 	});
 });

--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -1,4 +1,5 @@
 import {
+	DEFAULT_REQUEST_HEADERS,
 	type GatewayModelCapability,
 	type GatewayModelDefinition,
 	type GatewayProviderManifest,
@@ -492,6 +493,8 @@ function createClineLikeSpec(
 			>
 		>,
 ): BuiltinSpec {
+	const { headers, ...defaults } = input.defaults ?? {};
+
 	return {
 		id: input.id,
 		name: input.name,
@@ -507,7 +510,11 @@ function createClineLikeSpec(
 			get baseUrl(): string {
 				return `${getClineEnvironmentConfig().apiBaseUrl}/api/v1`;
 			},
-			...input.defaults,
+			headers: {
+				...DEFAULT_REQUEST_HEADERS,
+				...(headers ?? {}),
+			},
+			...defaults,
 		},
 		metadata: {
 			...ANTHROPIC_AND_QWEN_CACHE_ROUTING_METADATA,

--- a/sdk/packages/llms/src/providers/compat.test.ts
+++ b/sdk/packages/llms/src/providers/compat.test.ts
@@ -377,6 +377,13 @@ describe("createGatewayApiHandler.createMessage", () => {
 					rootPath: "/tmp/project",
 					platform: "darwin",
 				},
+				requestMetadata: {
+					userAgent: "Cline/2.3.4",
+					platform: "JetBrains",
+					platformVersion: "2026.1",
+					coreVersion: "2.3.4",
+					isMultiRoot: true,
+				},
 			},
 			headers: {
 				"x-custom": "kept",
@@ -395,10 +402,13 @@ describe("createGatewayApiHandler.createMessage", () => {
 		expect(factoryConfig?.headers).toMatchObject({
 			"HTTP-Referer": "https://cline.bot",
 			"X-Title": "Cline",
-			"X-IS-MULTIROOT": "false",
+			"User-Agent": "Cline/2.3.4",
+			"X-IS-MULTIROOT": "true",
 			"X-CLIENT-TYPE": "cline-jetbrains",
 			"X-CLIENT-VERSION": "2.3.4",
-			"X-PLATFORM": "darwin",
+			"X-PLATFORM": "JetBrains",
+			"X-PLATFORM-VERSION": "2026.1",
+			"X-CORE-VERSION": "2.3.4",
 			"X-Task-ID": "task-jetbrains",
 			"x-custom": "kept",
 		});

--- a/sdk/packages/llms/src/providers/compat.test.ts
+++ b/sdk/packages/llms/src/providers/compat.test.ts
@@ -357,6 +357,53 @@ describe("createGatewayApiHandler.createMessage", () => {
 		openaiCompatibleSpy.mockClear();
 	});
 
+	it("adds SDK client headers for Cline provider requests", async () => {
+		streamTextSpy.mockReturnValue({
+			fullStream: (async function* () {
+				yield { type: "finish", finishReason: "stop" };
+			})(),
+			usage: Promise.resolve({ inputTokens: 1, outputTokens: 1 }),
+		});
+
+		const handler = createGatewayApiHandler({
+			providerId: "cline",
+			clientType: "openai-compatible",
+			modelId: "anthropic/claude-sonnet-4.6",
+			apiKey: "test-key",
+			taskId: "task-jetbrains",
+			extensionContext: {
+				client: { name: "cline-jetbrains", version: "2.3.4" },
+				workspace: {
+					rootPath: "/tmp/project",
+					platform: "darwin",
+				},
+			},
+			headers: {
+				"x-custom": "kept",
+			},
+		});
+
+		for await (const _chunk of handler.createMessage("", [
+			{ role: "user", content: "Hello" },
+		])) {
+			// Drain the stream so the provider is constructed.
+		}
+
+		const factoryConfig = openaiCompatibleFactorySpy.mock.calls.at(-1)?.[0] as
+			| { headers?: Record<string, string> }
+			| undefined;
+		expect(factoryConfig?.headers).toMatchObject({
+			"HTTP-Referer": "https://cline.bot",
+			"X-Title": "Cline",
+			"X-IS-MULTIROOT": "false",
+			"X-CLIENT-TYPE": "cline-jetbrains",
+			"X-CLIENT-VERSION": "2.3.4",
+			"X-PLATFORM": "darwin",
+			"X-Task-ID": "task-jetbrains",
+			"x-custom": "kept",
+		});
+	});
+
 	it("does not convert catalog maxTokens into request maxOutputTokens", async () => {
 		streamTextSpy.mockReturnValue({
 			fullStream: (async function* () {

--- a/sdk/packages/llms/src/providers/compat.ts
+++ b/sdk/packages/llms/src/providers/compat.ts
@@ -453,9 +453,20 @@ function buildGatewayConfig(config: ProviderConfig) {
 		headers: buildClineRequestHeaders({
 			providerId,
 			headers: config.headers,
-			clientName: config.extensionContext?.client?.name,
-			clientVersion: config.extensionContext?.client?.version,
-			platform: config.extensionContext?.workspace?.platform,
+			clientName:
+				config.extensionContext?.requestMetadata?.clientType ??
+				config.extensionContext?.client?.name,
+			clientVersion:
+				config.extensionContext?.requestMetadata?.clientVersion ??
+				config.extensionContext?.client?.version,
+			userAgent: config.extensionContext?.requestMetadata?.userAgent,
+			platform:
+				config.extensionContext?.requestMetadata?.platform ??
+				config.extensionContext?.workspace?.platform,
+			platformVersion:
+				config.extensionContext?.requestMetadata?.platformVersion,
+			coreVersion: config.extensionContext?.requestMetadata?.coreVersion,
+			isMultiRoot: config.extensionContext?.requestMetadata?.isMultiRoot,
 			taskId: config.taskId,
 		}),
 		timeoutMs: config.timeoutMs,

--- a/sdk/packages/llms/src/providers/compat.ts
+++ b/sdk/packages/llms/src/providers/compat.ts
@@ -453,20 +453,7 @@ function buildGatewayConfig(config: ProviderConfig) {
 		headers: buildClineRequestHeaders({
 			providerId,
 			headers: config.headers,
-			clientName:
-				config.extensionContext?.requestMetadata?.clientType ??
-				config.extensionContext?.client?.name,
-			clientVersion:
-				config.extensionContext?.requestMetadata?.clientVersion ??
-				config.extensionContext?.client?.version,
-			userAgent: config.extensionContext?.requestMetadata?.userAgent,
-			platform:
-				config.extensionContext?.requestMetadata?.platform ??
-				config.extensionContext?.workspace?.platform,
-			platformVersion:
-				config.extensionContext?.requestMetadata?.platformVersion,
-			coreVersion: config.extensionContext?.requestMetadata?.coreVersion,
-			isMultiRoot: config.extensionContext?.requestMetadata?.isMultiRoot,
+			extensionContext: config.extensionContext,
 			taskId: config.taskId,
 		}),
 		timeoutMs: config.timeoutMs,

--- a/sdk/packages/llms/src/providers/compat.ts
+++ b/sdk/packages/llms/src/providers/compat.ts
@@ -1,9 +1,10 @@
-import type {
-	AgentModelEvent,
-	GatewayModelDefinition,
-	GatewayProviderFactory,
-	GatewayProviderRegistration,
-	GatewayStreamRequest,
+import {
+	type AgentModelEvent,
+	buildClineRequestHeaders,
+	type GatewayModelDefinition,
+	type GatewayProviderFactory,
+	type GatewayProviderRegistration,
+	type GatewayStreamRequest,
 } from "@cline/shared";
 import { nanoid } from "nanoid";
 import type {
@@ -449,7 +450,14 @@ function buildGatewayConfig(config: ProviderConfig) {
 		providerId,
 		apiKey: config.apiKey ?? config.accessToken,
 		baseUrl: config.baseUrl,
-		headers: config.headers,
+		headers: buildClineRequestHeaders({
+			providerId,
+			headers: config.headers,
+			clientName: config.extensionContext?.client?.name,
+			clientVersion: config.extensionContext?.client?.version,
+			platform: config.extensionContext?.workspace?.platform,
+			taskId: config.taskId,
+		}),
 		timeoutMs: config.timeoutMs,
 		fetch: config.fetch,
 		defaultModelId: config.modelId,

--- a/sdk/packages/shared/src/agents/types.ts
+++ b/sdk/packages/shared/src/agents/types.ts
@@ -815,7 +815,8 @@ export interface AgentConfig {
 	telemetry?: ITelemetryService;
 	/**
 	 * Ambient runtime context: user identity, client surface, workspace, logger,
-	 * and telemetry. Threaded through to ProviderConfig so handlers can access it.
+	 * telemetry, and host request metadata. Used by runtime extension setup and
+	 * forwarded to registered provider handlers that need host-local context.
 	 */
 	extensionContext?: ExtensionContext;
 

--- a/sdk/packages/shared/src/extensions/context.ts
+++ b/sdk/packages/shared/src/extensions/context.ts
@@ -30,6 +30,29 @@ export interface ClientContext {
 }
 
 /**
+ * Client/runtime metadata used when constructing provider request metadata.
+ *
+ * This is intentionally separate from WorkspaceContext so request headers can
+ * preserve legacy host metadata without changing prompt/workspace semantics.
+ */
+export interface RequestMetadataContext {
+	/** Legacy client type value for provider request headers. */
+	clientType?: string;
+	/** Client version value for provider request headers. */
+	clientVersion?: string;
+	/** HTTP User-Agent value for provider requests. */
+	userAgent?: string;
+	/** Host/application platform label, e.g. "Visual Studio Code". */
+	platform?: string;
+	/** Host/application version, e.g. the VS Code version. */
+	platformVersion?: string;
+	/** Cline core/runtime version. */
+	coreVersion?: string;
+	/** Whether the host is currently operating on multiple workspace roots. */
+	isMultiRoot?: boolean;
+}
+
+/**
  * Identity of the authenticated user.
  */
 export interface UserContext {
@@ -80,6 +103,7 @@ export interface ExtensionContext {
 	user?: UserContext;
 	client?: ClientContext;
 	workspace?: WorkspaceContext;
+	requestMetadata?: RequestMetadataContext;
 	/** Core session metadata forwarded into plugin setup context. */
 	session?: AgentExtensionSessionContext;
 	/**

--- a/sdk/packages/shared/src/index.browser.ts
+++ b/sdk/packages/shared/src/index.browser.ts
@@ -193,7 +193,12 @@ export {
 	resolveReasoningBudgetFromRatio,
 	resolveReasoningEffortRatio,
 } from "./llms/reasoning-effort";
-export { DEFAULT_REQUEST_HEADERS, serializeAbortReason } from "./llms/requests";
+export {
+	type BuildClineRequestHeadersInput,
+	buildClineRequestHeaders,
+	DEFAULT_REQUEST_HEADERS,
+	serializeAbortReason,
+} from "./llms/requests";
 export { CHARS_PER_TOKEN, estimateTokens } from "./llms/tokens";
 export type {
 	ToolApprovalRequest,

--- a/sdk/packages/shared/src/index.browser.ts
+++ b/sdk/packages/shared/src/index.browser.ts
@@ -41,6 +41,7 @@ export type {
 	ClientContext,
 	ClientName,
 	ExtensionContext,
+	RequestMetadataContext,
 	UserContext,
 	WorkspaceContext,
 } from "./extensions/context";

--- a/sdk/packages/shared/src/index.ts
+++ b/sdk/packages/shared/src/index.ts
@@ -207,7 +207,12 @@ export {
 	resolveReasoningBudgetFromRatio,
 	resolveReasoningEffortRatio,
 } from "./llms/reasoning-effort";
-export { DEFAULT_REQUEST_HEADERS, serializeAbortReason } from "./llms/requests";
+export {
+	type BuildClineRequestHeadersInput,
+	buildClineRequestHeaders,
+	DEFAULT_REQUEST_HEADERS,
+	serializeAbortReason,
+} from "./llms/requests";
 export { CHARS_PER_TOKEN, estimateTokens } from "./llms/tokens";
 export type {
 	ToolApprovalRequest,

--- a/sdk/packages/shared/src/index.ts
+++ b/sdk/packages/shared/src/index.ts
@@ -55,6 +55,7 @@ export type {
 	ClientContext,
 	ClientName,
 	ExtensionContext,
+	RequestMetadataContext,
 	UserContext,
 	WorkspaceContext,
 } from "./extensions/context";

--- a/sdk/packages/shared/src/llms/requests.ts
+++ b/sdk/packages/shared/src/llms/requests.ts
@@ -1,3 +1,4 @@
+import type { ExtensionContext } from "../extensions/context";
 import { isClineProvider } from "../providers/utils";
 
 export const DEFAULT_REQUEST_HEADERS: Record<string, string> = {
@@ -10,6 +11,7 @@ export const DEFAULT_REQUEST_HEADERS: Record<string, string> = {
 export interface BuildClineRequestHeadersInput {
 	providerId: string;
 	headers?: Record<string, string>;
+	extensionContext?: ExtensionContext;
 	clientName?: string;
 	clientVersion?: string;
 	userAgent?: string;
@@ -22,7 +24,19 @@ export interface BuildClineRequestHeadersInput {
 
 function cleanHeaderValue(value: string | undefined): string | undefined {
 	const trimmed = value?.trim();
-	return trimmed ? trimmed : undefined;
+	return trimmed && trimmed.toLowerCase() !== "unknown" ? trimmed : undefined;
+}
+
+function cleanHeaderOverrides(
+	headers: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+	if (!headers) {
+		return undefined;
+	}
+	const cleaned = Object.fromEntries(
+		Object.entries(headers).filter(([, value]) => cleanHeaderValue(value)),
+	);
+	return Object.keys(cleaned).length > 0 ? cleaned : undefined;
 }
 
 export function buildClineRequestHeaders(
@@ -32,27 +46,44 @@ export function buildClineRequestHeaders(
 		return input.headers;
 	}
 
-	const clientName = cleanHeaderValue(input.clientName);
-	const clientVersion = cleanHeaderValue(input.clientVersion);
-	const userAgent = cleanHeaderValue(input.userAgent);
-	const platform = cleanHeaderValue(input.platform);
-	const platformVersion = cleanHeaderValue(input.platformVersion);
-	const coreVersion = cleanHeaderValue(input.coreVersion);
+	const requestMetadata = input.extensionContext?.requestMetadata;
+	const clientName =
+		cleanHeaderValue(input.clientName) ??
+		cleanHeaderValue(requestMetadata?.clientType) ??
+		cleanHeaderValue(input.extensionContext?.client?.name);
+	const clientVersion =
+		cleanHeaderValue(input.clientVersion) ??
+		cleanHeaderValue(requestMetadata?.clientVersion) ??
+		cleanHeaderValue(input.extensionContext?.client?.version);
+	const userAgent =
+		cleanHeaderValue(input.userAgent) ??
+		cleanHeaderValue(requestMetadata?.userAgent);
+	const platform =
+		cleanHeaderValue(input.platform) ??
+		cleanHeaderValue(requestMetadata?.platform);
+	const platformVersion =
+		cleanHeaderValue(input.platformVersion) ??
+		cleanHeaderValue(requestMetadata?.platformVersion);
+	const coreVersion =
+		cleanHeaderValue(input.coreVersion) ??
+		cleanHeaderValue(requestMetadata?.coreVersion);
+	const isMultiRoot = input.isMultiRoot ?? requestMetadata?.isMultiRoot;
 	const taskId = cleanHeaderValue(input.taskId);
+	const headerOverrides = cleanHeaderOverrides(input.headers);
 
 	return {
 		...DEFAULT_REQUEST_HEADERS,
+		...(headerOverrides ?? {}),
 		...(userAgent ? { "User-Agent": userAgent } : {}),
 		...(clientName ? { "X-CLIENT-TYPE": clientName } : {}),
 		...(clientVersion ? { "X-CLIENT-VERSION": clientVersion } : {}),
 		...(platform ? { "X-PLATFORM": platform } : {}),
 		...(platformVersion ? { "X-PLATFORM-VERSION": platformVersion } : {}),
 		...(coreVersion ? { "X-CORE-VERSION": coreVersion } : {}),
-		...(input.isMultiRoot !== undefined
-			? { "X-IS-MULTIROOT": input.isMultiRoot ? "true" : "false" }
+		...(isMultiRoot !== undefined
+			? { "X-IS-MULTIROOT": isMultiRoot ? "true" : "false" }
 			: {}),
 		...(taskId ? { "X-Task-ID": taskId } : {}),
-		...(input.headers ?? {}),
 	};
 }
 

--- a/sdk/packages/shared/src/llms/requests.ts
+++ b/sdk/packages/shared/src/llms/requests.ts
@@ -12,7 +12,11 @@ export interface BuildClineRequestHeadersInput {
 	headers?: Record<string, string>;
 	clientName?: string;
 	clientVersion?: string;
+	userAgent?: string;
 	platform?: string;
+	platformVersion?: string;
+	coreVersion?: string;
+	isMultiRoot?: boolean;
 	taskId?: string;
 }
 
@@ -30,14 +34,23 @@ export function buildClineRequestHeaders(
 
 	const clientName = cleanHeaderValue(input.clientName);
 	const clientVersion = cleanHeaderValue(input.clientVersion);
+	const userAgent = cleanHeaderValue(input.userAgent);
 	const platform = cleanHeaderValue(input.platform);
+	const platformVersion = cleanHeaderValue(input.platformVersion);
+	const coreVersion = cleanHeaderValue(input.coreVersion);
 	const taskId = cleanHeaderValue(input.taskId);
 
 	return {
 		...DEFAULT_REQUEST_HEADERS,
+		...(userAgent ? { "User-Agent": userAgent } : {}),
 		...(clientName ? { "X-CLIENT-TYPE": clientName } : {}),
 		...(clientVersion ? { "X-CLIENT-VERSION": clientVersion } : {}),
 		...(platform ? { "X-PLATFORM": platform } : {}),
+		...(platformVersion ? { "X-PLATFORM-VERSION": platformVersion } : {}),
+		...(coreVersion ? { "X-CORE-VERSION": coreVersion } : {}),
+		...(input.isMultiRoot !== undefined
+			? { "X-IS-MULTIROOT": input.isMultiRoot ? "true" : "false" }
+			: {}),
 		...(taskId ? { "X-Task-ID": taskId } : {}),
 		...(input.headers ?? {}),
 	};

--- a/sdk/packages/shared/src/llms/requests.ts
+++ b/sdk/packages/shared/src/llms/requests.ts
@@ -1,9 +1,47 @@
+import { isClineProvider } from "../providers/utils";
+
 export const DEFAULT_REQUEST_HEADERS: Record<string, string> = {
 	"HTTP-Referer": "https://cline.bot",
 	"X-Title": "Cline",
 	"X-IS-MULTIROOT": "false",
 	"X-CLIENT-TYPE": "cline-sdk",
 };
+
+export interface BuildClineRequestHeadersInput {
+	providerId: string;
+	headers?: Record<string, string>;
+	clientName?: string;
+	clientVersion?: string;
+	platform?: string;
+	taskId?: string;
+}
+
+function cleanHeaderValue(value: string | undefined): string | undefined {
+	const trimmed = value?.trim();
+	return trimmed ? trimmed : undefined;
+}
+
+export function buildClineRequestHeaders(
+	input: BuildClineRequestHeadersInput,
+): Record<string, string> | undefined {
+	if (!isClineProvider(input.providerId)) {
+		return input.headers;
+	}
+
+	const clientName = cleanHeaderValue(input.clientName);
+	const clientVersion = cleanHeaderValue(input.clientVersion);
+	const platform = cleanHeaderValue(input.platform);
+	const taskId = cleanHeaderValue(input.taskId);
+
+	return {
+		...DEFAULT_REQUEST_HEADERS,
+		...(clientName ? { "X-CLIENT-TYPE": clientName } : {}),
+		...(clientVersion ? { "X-CLIENT-VERSION": clientVersion } : {}),
+		...(platform ? { "X-PLATFORM": platform } : {}),
+		...(taskId ? { "X-Task-ID": taskId } : {}),
+		...(input.headers ?? {}),
+	};
+}
 
 export function serializeAbortReason(reason: unknown): unknown {
 	return reason instanceof Error


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Restores Cline-provider request headers across the SDK-backed request paths so core-api can distinguish the client surface again.

The older SDK provider handler merged `DEFAULT_REQUEST_HEADERS` and overrode `X-CLIENT-TYPE` from `extensionContext.client.name`, which let CLI send `cline-cli`, SDK callers fall back to `cline-sdk`, and host integrations send their own client names. The AI SDK/gateway migration left the default header constant exported but stopped applying it in the provider request path.

This PR adds a shared Cline request-header builder and wires it into:

- Core's gateway factory used by ClineCore sessions, including CLI and JetBrains-style SDK hosts that set `extensionContext.client.name`.
- The lower-level `@cline/llms` compatibility handler for direct provider handler usage.
- The standalone Agent provider-form path, with the plain SDK fallback `X-CLIENT-TYPE: cline-sdk`.
- The VS Code session factory, which still supplies the classic extension headers so VS Code continues to send `X-CLIENT-TYPE: VSCode Extension`, plus the legacy host/platform/version/multiroot headers.

Explicit caller headers still win last, and non-Cline providers keep their previous `config.headers ?? providerConfig.headers` precedence.

### Test Procedure

- `bunx vitest run src/agent-runtime.provider-form.test.ts` from `sdk/packages/agents`
- `bunx vitest run src/services/llms/handler-factory.test.ts --config vitest.config.ts` from `sdk/packages/core`
- `bunx vitest run src/providers/compat.test.ts` from `sdk/packages/llms`
- `cd apps/vscode && bun run test:vitest -- src/sdk/cline-session-factory.test.ts`
- `bunx biome check --diagnostic-level=error ...` for touched SDK files
- `cd apps/vscode && bunx biome check --config-path ./biome.jsonc src/sdk/cline-session-factory.ts src/sdk/cline-session-factory.test.ts src/services/EnvUtils.ts --diagnostic-level=error --no-errors-on-unmatched --files-ignore-unknown=true --semicolons=as-needed`
- `bun -F @cline/shared typecheck`
- `bun -F @cline/llms typecheck`
- `bun -F @cline/agents typecheck`
- `bun -F @cline/core typecheck`
- `bun run build:sdk`
- `cd apps/vscode && bunx tsc --noEmit -p tsconfig.json`

`cd apps/vscode && bun run check-types` is blocked in this local worktree before TypeScript because proto generation cannot find `node_modules/.bun/grpc-tools@1.13.1/node_modules/grpc-tools/bin/protoc`; the direct TypeScript check above passes.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - no UI changes.

### Additional Notes

Core coverage now asserts CLI-style `X-CLIENT-TYPE: cline-cli`, explicit VS Code override behavior, and unchanged non-Cline header precedence. LLM handler coverage asserts JetBrains-style `X-CLIENT-TYPE: cline-jetbrains`. Agent coverage asserts the plain SDK fallback `X-CLIENT-TYPE: cline-sdk`.
