### PR TITLE
fix: prevent API key field clearing on settings load

### DIFF
--- a/apps/vscode/webview-ui/src/components/settings/common/ApiKeyField.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/common/ApiKeyField.tsx
@@ -29,6 +29,7 @@ export const ApiKeyField = ({
 }: ApiKeyFieldProps) => {
 	const [localValue, setLocalValue] = useState(initialValue)
 	const isFocusedRef = useRef(false)
+	const hasPendingUserEditRef = useRef(false)
 	const prevInitialValueRef = useRef(initialValue)
 
 	useEffect(() => {
@@ -48,6 +49,11 @@ export const ApiKeyField = ({
 
 	useDebounceEffect(
 		() => {
+			if (!hasPendingUserEditRef.current) {
+				return
+			}
+
+			hasPendingUserEditRef.current = false
 			onChange(localValue)
 		},
 		100,
@@ -63,7 +69,10 @@ export const ApiKeyField = ({
 				onFocus={() => {
 					isFocusedRef.current = true
 				}}
-				onInput={(e: any) => setLocalValue(e.target.value)}
+				onInput={(e) => {
+					hasPendingUserEditRef.current = true
+					setLocalValue((e.target as HTMLInputElement | null)?.value ?? "")
+				}}
 				placeholder={placeholder}
 				required={true}
 				style={{ width: "100%" }}

--- a/apps/vscode/webview-ui/src/components/settings/common/ApiKeyField.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/common/ApiKeyField.tsx
@@ -43,6 +43,7 @@ export const ApiKeyField = ({
 		// Do not replace their in-progress input with the new mask, or subsequent saves only
 		// persist the suffix typed after that rerender.
 		if (!isFocusedRef.current) {
+			hasPendingUserEditRef.current = false
 			setLocalValue(initialValue)
 		}
 	}, [initialValue])

--- a/apps/vscode/webview-ui/src/components/settings/providers/GenericProviderSettings.test.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/GenericProviderSettings.test.tsx
@@ -248,6 +248,53 @@ describe("GenericProviderSettings", () => {
 		expect(write).not.toHaveBeenCalled()
 	})
 
+	it("does not write a mask if config hydrates after a blurred edit", async () => {
+		const write = vi.fn(async () => undefined)
+		vi.mocked(useProviderModels).mockReturnValue({
+			models: {},
+			defaultModelId: "",
+			isLoading: false,
+			isStale: false,
+			error: undefined,
+			refresh: vi.fn(),
+			fingerprint: "fingerprint",
+		})
+		vi.mocked(useProviderConfig).mockReturnValue({ config: undefined, write, commitSelection: vi.fn() })
+
+		const { rerender } = render(
+			<GenericProviderSettings
+				allowsCustomIds={false}
+				currentMode="act"
+				providerId="deepseek"
+				providerName="DeepSeek"
+				showModelOptions={false}
+			/>,
+		)
+
+		const apiKeyInput = screen.getByPlaceholderText("Enter API Key...")
+		fireEvent.input(apiKeyInput, { target: { value: "partial-key" } })
+		fireEvent.blur(apiKeyInput)
+
+		vi.mocked(useProviderConfig).mockReturnValue({
+			config: providerConfig({ apiKeyLength: 8 }),
+			write,
+			commitSelection: vi.fn(),
+		})
+		rerender(
+			<GenericProviderSettings
+				allowsCustomIds={false}
+				currentMode="act"
+				providerId="deepseek"
+				providerName="DeepSeek"
+				showModelOptions={false}
+			/>,
+		)
+
+		await new Promise((resolve) => setTimeout(resolve, 150))
+		expect(write).not.toHaveBeenCalledWith({ apiKey: "••••••••" })
+		expect(write).not.toHaveBeenCalled()
+	})
+
 	it("still allows users to clear a saved API key", async () => {
 		const write = vi.fn(async () => undefined)
 		vi.mocked(useProviderModels).mockReturnValue({

--- a/apps/vscode/webview-ui/src/components/settings/providers/GenericProviderSettings.test.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/GenericProviderSettings.test.tsx
@@ -1,3 +1,4 @@
+import type { ProviderConfigResponse } from "@shared/proto/cline/models"
 import { ApiFormat } from "@shared/proto/cline/models"
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import type { ChangeEventHandler, ReactNode } from "react"
@@ -5,6 +6,8 @@ import { describe, expect, it, vi } from "vitest"
 import { useProviderConfig } from "@/hooks/useProviderConfig"
 import { useProviderModels } from "@/hooks/useProviderModels"
 import { GenericProviderSettings } from "./GenericProviderSettings"
+
+const providerConfig = (config: Partial<ProviderConfigResponse>): ProviderConfigResponse => config as ProviderConfigResponse
 
 vi.mock("@/hooks/useProviderModels", () => ({
 	useProviderModels: vi.fn(),
@@ -147,7 +150,11 @@ describe("GenericProviderSettings", () => {
 			refresh: vi.fn(),
 			fingerprint: "fingerprint",
 		})
-		vi.mocked(useProviderConfig).mockReturnValue({ config: { apiKeyLength: 12 } as any, write, commitSelection: vi.fn() })
+		vi.mocked(useProviderConfig).mockReturnValue({
+			config: providerConfig({ apiKeyLength: 12 }),
+			write,
+			commitSelection: vi.fn(),
+		})
 
 		render(
 			<GenericProviderSettings
@@ -168,6 +175,111 @@ describe("GenericProviderSettings", () => {
 		await waitFor(() => expect(write).toHaveBeenCalledWith({ apiKey: "new-secret" }))
 	})
 
+	it("does not clear API keys while provider config is loading", async () => {
+		const write = vi.fn(async () => undefined)
+		vi.mocked(useProviderModels).mockReturnValue({
+			models: {},
+			defaultModelId: "",
+			isLoading: false,
+			isStale: false,
+			error: undefined,
+			refresh: vi.fn(),
+			fingerprint: "fingerprint",
+		})
+		vi.mocked(useProviderConfig).mockReturnValue({ config: undefined, write, commitSelection: vi.fn() })
+
+		render(
+			<GenericProviderSettings
+				allowsCustomIds={false}
+				currentMode="act"
+				providerId="deepseek"
+				providerName="DeepSeek"
+				showModelOptions={false}
+			/>,
+		)
+
+		await new Promise((resolve) => setTimeout(resolve, 150))
+		expect(write).not.toHaveBeenCalled()
+	})
+
+	it("does not save when provider config hydrates a saved API key", async () => {
+		const write = vi.fn(async () => undefined)
+		vi.mocked(useProviderModels).mockReturnValue({
+			models: {},
+			defaultModelId: "",
+			isLoading: false,
+			isStale: false,
+			error: undefined,
+			refresh: vi.fn(),
+			fingerprint: "fingerprint",
+		})
+		vi.mocked(useProviderConfig).mockReturnValue({ config: undefined, write, commitSelection: vi.fn() })
+
+		const { rerender } = render(
+			<GenericProviderSettings
+				allowsCustomIds={false}
+				currentMode="act"
+				providerId="deepseek"
+				providerName="DeepSeek"
+				showModelOptions={false}
+			/>,
+		)
+
+		await new Promise((resolve) => setTimeout(resolve, 150))
+		expect(write).not.toHaveBeenCalled()
+
+		vi.mocked(useProviderConfig).mockReturnValue({
+			config: providerConfig({ apiKeyLength: 8 }),
+			write,
+			commitSelection: vi.fn(),
+		})
+		rerender(
+			<GenericProviderSettings
+				allowsCustomIds={false}
+				currentMode="act"
+				providerId="deepseek"
+				providerName="DeepSeek"
+				showModelOptions={false}
+			/>,
+		)
+
+		expect(screen.getByDisplayValue("••••••••")).toBeInTheDocument()
+		await new Promise((resolve) => setTimeout(resolve, 150))
+		expect(write).not.toHaveBeenCalled()
+	})
+
+	it("still allows users to clear a saved API key", async () => {
+		const write = vi.fn(async () => undefined)
+		vi.mocked(useProviderModels).mockReturnValue({
+			models: {},
+			defaultModelId: "",
+			isLoading: false,
+			isStale: false,
+			error: undefined,
+			refresh: vi.fn(),
+			fingerprint: "fingerprint",
+		})
+		vi.mocked(useProviderConfig).mockReturnValue({
+			config: providerConfig({ apiKeyLength: 8 }),
+			write,
+			commitSelection: vi.fn(),
+		})
+
+		render(
+			<GenericProviderSettings
+				allowsCustomIds={false}
+				currentMode="act"
+				providerId="deepseek"
+				providerName="DeepSeek"
+				showModelOptions={false}
+			/>,
+		)
+
+		fireEvent.input(screen.getByDisplayValue("••••••••"), { target: { value: "" } })
+
+		await waitFor(() => expect(write).toHaveBeenCalledWith({ apiKey: "" }))
+	})
+
 	it("does not persist mask characters when editing a saved API key", async () => {
 		const write = vi.fn(async () => undefined)
 		vi.mocked(useProviderModels).mockReturnValue({
@@ -179,7 +291,11 @@ describe("GenericProviderSettings", () => {
 			refresh: vi.fn(),
 			fingerprint: "fingerprint",
 		})
-		vi.mocked(useProviderConfig).mockReturnValue({ config: { apiKeyLength: 7 } as any, write, commitSelection: vi.fn() })
+		vi.mocked(useProviderConfig).mockReturnValue({
+			config: providerConfig({ apiKeyLength: 7 }),
+			write,
+			commitSelection: vi.fn(),
+		})
 
 		render(
 			<GenericProviderSettings
@@ -208,7 +324,11 @@ describe("GenericProviderSettings", () => {
 			refresh: vi.fn(),
 			fingerprint: "fingerprint",
 		})
-		vi.mocked(useProviderConfig).mockReturnValue({ config: { apiKeyLength: 0 } as any, write, commitSelection: vi.fn() })
+		vi.mocked(useProviderConfig).mockReturnValue({
+			config: providerConfig({ apiKeyLength: 0 }),
+			write,
+			commitSelection: vi.fn(),
+		})
 
 		const { rerender } = render(
 			<GenericProviderSettings
@@ -226,7 +346,11 @@ describe("GenericProviderSettings", () => {
 
 		await waitFor(() => expect(write).toHaveBeenCalledWith({ apiKey: "max" }))
 
-		vi.mocked(useProviderConfig).mockReturnValue({ config: { apiKeyLength: 3 } as any, write, commitSelection: vi.fn() })
+		vi.mocked(useProviderConfig).mockReturnValue({
+			config: providerConfig({ apiKeyLength: 3 }),
+			write,
+			commitSelection: vi.fn(),
+		})
 		rerender(
 			<GenericProviderSettings
 				allowsCustomIds={false}
@@ -264,7 +388,7 @@ describe("GenericProviderSettings", () => {
 			fingerprint: "fingerprint",
 		})
 		vi.mocked(useProviderConfig).mockReturnValue({
-			config: { baseUrl: "https://custom.example", apiKeyLength: 0 } as any,
+			config: providerConfig({ baseUrl: "https://custom.example", apiKeyLength: 0 }),
 			write,
 			commitSelection: vi.fn(),
 		})


### PR DESCRIPTION
This PR fixes a Settings race that could clear saved API keys for SDK-backed provider settings, observed with DeepSeek after the SDK migration.

The problematic path was in the shared API key field used by generic provider settings:

```tsx
useDebounceEffect(() => {
  onChange(localValue)
}, 100, [localValue])
```

That effect fired on mount, not just after user edits. For DeepSeek, `GenericProviderSettings` starts with `config: undefined` while `useProviderConfig("deepseek")` asynchronously reads the provider config. During that loading window the API key field mounts with an empty initial value. If the 100ms debounce fires before the provider config hydrates, the field calls `write({ apiKey: "" })`, which is interpreted as clearing the saved key.

The reason this showed up as intermittent is timing: if the config read wins the race, the input hydrates to the saved-key mask before the debounce writes. If the debounce wins, it writes an empty key.

The fix is to make `ApiKeyField` distinguish user edits from mount/prop hydration. The field now tracks whether the current local value came from an actual `onInput` event before running the debounced save. Programmatic updates from `initialValue` still update the visible field, but they no longer persist as user changes.

This keeps the intended behavior intact:

- opening Settings does not write an empty key while provider config is loading
- hydrating a saved key mask does not trigger a save
- typing a new key still saves after the debounce
- editing a masked key still strips mask characters before save
- intentionally clearing the field still writes `apiKey: ""`

