### PR TITLE
fix(llms): preserve fetch error cause details

### DIFF
--- a/sdk/packages/llms/src/providers/format.test.ts
+++ b/sdk/packages/llms/src/providers/format.test.ts
@@ -34,6 +34,17 @@ describe("extractErrorMessage", () => {
 		);
 	});
 
+	it("preserves native transport error wrappers and cause metadata", () => {
+		const socketError = Object.assign(new Error("other side closed"), {
+			name: "SocketError",
+			code: "UND_ERR_SOCKET",
+		});
+
+		expect(
+			extractErrorMessage(new TypeError("fetch failed", { cause: socketError })),
+		).toBe("fetch failed: SocketError: other side closed (UND_ERR_SOCKET)");
+	});
+
 	it("prefers nested stream error details over generic wrapper messages", () => {
 		expect(
 			extractErrorMessage({

--- a/sdk/packages/llms/src/providers/format.ts
+++ b/sdk/packages/llms/src/providers/format.ts
@@ -13,6 +13,29 @@ export function extractErrorMessage(error: unknown): string {
 		if (typeof value !== "object") {
 			return undefined;
 		}
+		if (value instanceof Error) {
+			const causeMessage = extractStructuredMessage(
+				(value as { cause?: unknown }).cause,
+			);
+			const message = value.message.trim();
+			if (causeMessage && message && causeMessage !== message) {
+				const cause = (value as { cause?: unknown }).cause;
+				const causeName =
+					cause instanceof Error && cause.name && cause.name !== "Error"
+						? `${cause.name}: `
+						: "";
+				const causeCode =
+					cause && typeof cause === "object" && "code" in cause
+						? (cause as { code?: unknown }).code
+						: undefined;
+				const codeSuffix =
+					typeof causeCode === "string" && causeCode.trim()
+						? ` (${causeCode})`
+						: "";
+				return `${message}: ${causeName}${causeMessage}${codeSuffix}`;
+			}
+			return causeMessage ?? (message || undefined);
+		}
 		const payload = value as {
 			error?: { message?: string } | string;
 			errors?: unknown;


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This PR fixes a low-level provider error formatting issue that made VS Code extension users see only `other side closed` when a model stream failed because the remote socket closed.

The error path is:

```text
Node/Undici fetch
  -> TypeError: fetch failed
  -> cause: SocketError: other side closed, code: UND_ERR_SOCKET
  -> AI SDK stream error
  -> @cline/llms extractErrorMessage()
  -> Agent error shown in the VS Code chat
```

`extractErrorMessage()` already walks structured provider errors and causes, which is useful for provider response bodies, but for native `Error` objects it was too aggressive: it preferred the nested cause and discarded the top-level transport wrapper. For fetch failures, that turns a diagnosable error shape into the opaque message `other side closed`.

The change handles native `Error` objects explicitly before the generic object payload path. When an error has a distinct cause, the formatter now keeps the top-level message and appends the cause name/message/code. For the reported failure class, that changes the surfaced message from:

```text
other side closed
```

into:

```text
fetch failed: SocketError: other side closed (UND_ERR_SOCKET)
```

This is not string matching on the symptom. It preserves structured native error/cause metadata so similar transport failures remain more actionable too.

### Test Procedure

Reproduced the underlying runtime shape locally by making Node `fetch()` send a request to a socket server that closes the connection after receiving data. Node emitted:

```text
TypeError: fetch failed
cause.name: SocketError
cause.message: other side closed
cause.code: UND_ERR_SOCKET
```

Added a focused regression test for `extractErrorMessage()` using that native error shape.

Ran:

```text
bunx vitest run src/providers/format.test.ts --config vitest.config.ts
bun run typecheck
```

Both passed after rebasing this branch onto current `origin/main`.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable. This is provider error formatting with no UI layout change.

### Additional Notes

I did not run the full repository `bun test`, formatter, or lint suite. The focused formatter test and `@cline/llms` typecheck passed.
