### PR TITLE
fix(vscode): sync auto-approve task settings

### DIFF
--- a/apps/vscode/src/core/controller/state/updateAutoApprovalSettings.test.ts
+++ b/apps/vscode/src/core/controller/state/updateAutoApprovalSettings.test.ts
@@ -1,0 +1,107 @@
+import { DEFAULT_AUTO_APPROVAL_SETTINGS } from "@shared/AutoApprovalSettings"
+import { AutoApprovalSettingsRequest } from "@shared/proto/cline/state"
+import { describe, expect, it, vi } from "vitest"
+import type { Controller } from ".."
+import { updateAutoApprovalSettings } from "./updateAutoApprovalSettings"
+
+function makeController(currentSettings = DEFAULT_AUTO_APPROVAL_SETTINGS, taskId?: string) {
+	const controller = {
+		task: taskId ? { taskId } : undefined,
+		getStateToPostToWebview: vi.fn(async () => ({
+			autoApprovalSettings: currentSettings,
+		})),
+		postStateToWebview: vi.fn(async () => undefined),
+		stateManager: {
+			setGlobalState: vi.fn(),
+			setTaskSettings: vi.fn(),
+		},
+	}
+
+	return controller as unknown as Controller & {
+		getStateToPostToWebview: ReturnType<typeof vi.fn>
+		postStateToWebview: ReturnType<typeof vi.fn>
+		stateManager: {
+			setGlobalState: ReturnType<typeof vi.fn>
+			setTaskSettings: ReturnType<typeof vi.fn>
+		}
+	}
+}
+
+describe("updateAutoApprovalSettings", () => {
+	it("updates the active task override when auto-approval settings change", async () => {
+		const currentSettings = {
+			...DEFAULT_AUTO_APPROVAL_SETTINGS,
+			version: 1,
+			actions: {
+				...DEFAULT_AUTO_APPROVAL_SETTINGS.actions,
+				editFiles: false,
+			},
+		}
+		const controller = makeController(currentSettings, "task-1")
+
+		await updateAutoApprovalSettings(
+			controller,
+			AutoApprovalSettingsRequest.create({
+				version: 2,
+				actions: {
+					editFiles: true,
+				},
+			}),
+		)
+
+		const expectedSettings = {
+			...currentSettings,
+			version: 2,
+			actions: {
+				...currentSettings.actions,
+				editFiles: true,
+			},
+		}
+
+		expect(controller.stateManager.setGlobalState).toHaveBeenCalledWith("autoApprovalSettings", expectedSettings)
+		expect(controller.stateManager.setTaskSettings).toHaveBeenCalledWith("task-1", "autoApprovalSettings", expectedSettings)
+		expect(controller.postStateToWebview).toHaveBeenCalledOnce()
+	})
+
+	it("does not create a task override when no task is active", async () => {
+		const controller = makeController(DEFAULT_AUTO_APPROVAL_SETTINGS)
+
+		await updateAutoApprovalSettings(
+			controller,
+			AutoApprovalSettingsRequest.create({
+				version: DEFAULT_AUTO_APPROVAL_SETTINGS.version + 1,
+				actions: {
+					readFiles: false,
+				},
+			}),
+		)
+
+		expect(controller.stateManager.setGlobalState).toHaveBeenCalledOnce()
+		expect(controller.stateManager.setTaskSettings).not.toHaveBeenCalled()
+		expect(controller.postStateToWebview).toHaveBeenCalledOnce()
+	})
+
+	it("ignores stale auto-approval settings versions", async () => {
+		const controller = makeController(
+			{
+				...DEFAULT_AUTO_APPROVAL_SETTINGS,
+				version: 3,
+			},
+			"task-1",
+		)
+
+		await updateAutoApprovalSettings(
+			controller,
+			AutoApprovalSettingsRequest.create({
+				version: 3,
+				actions: {
+					readFiles: false,
+				},
+			}),
+		)
+
+		expect(controller.stateManager.setGlobalState).not.toHaveBeenCalled()
+		expect(controller.stateManager.setTaskSettings).not.toHaveBeenCalled()
+		expect(controller.postStateToWebview).not.toHaveBeenCalled()
+	})
+})

--- a/apps/vscode/src/core/controller/state/updateAutoApprovalSettings.ts
+++ b/apps/vscode/src/core/controller/state/updateAutoApprovalSettings.ts
@@ -29,6 +29,9 @@ export async function updateAutoApprovalSettings(controller: Controller, request
 		}
 
 		controller.stateManager.setGlobalState("autoApprovalSettings", settings)
+		if (controller.task?.taskId) {
+			controller.stateManager.setTaskSettings(controller.task.taskId, "autoApprovalSettings", settings)
+		}
 
 		await controller.postStateToWebview()
 	}

--- a/apps/vscode/vitest.config.ts
+++ b/apps/vscode/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
 			"src/shared/vsCodeSelectorUtils.test.ts",
 			"src/shared/proto-conversions/models/**/*.test.ts",
 			"src/core/storage/remote-config/**/*.test.ts",
+			"src/core/controller/state/**/*.test.ts",
 			"src/core/controller/slash/**/*.test.ts",
 			"src/services/mcp/__tests__/settingsLock.test.ts",
 			"src/shared/model-catalog/provider-helpers.test.ts",


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

This fixes an auto-approve regression reported after the SDK migration where users could toggle auto-approve off and back on, but tool approvals would still appear during the active extension task.

The SDK approval path reads auto-approval through `StateManager.getGlobalSettingsKey("autoApprovalSettings")`. That accessor intentionally resolves the effective setting with this precedence:

```ts
remote config > session override > task settings > global settings
```

The auto-approve menu update handler only wrote the merged settings back to global state. That meant an active task with a task-scoped `autoApprovalSettings` override could continue to shadow the newly saved global setting. From the user perspective, the UI showed that auto-approve had been toggled, but the SDK approval callback could still evaluate the stale task copy and ask for approvals.

The fix keeps the existing version guard and merge behavior, then mirrors the same merged `autoApprovalSettings` into the active task settings when a task is running. That makes the setting immediately effective for the same precedence chain the SDK uses, without changing behavior for idle/no-task settings updates.

I also added regression coverage for:

- active task updates writing both global and task-scoped auto-approval settings
- no-task updates only writing global settings
- stale/equal versions still being ignored

The new state-controller test file is added to the VS Code Vitest include list so it runs with the existing selected Vitest suite.

### Test Procedure

Ran the focused regression tests:

```sh
bun --cwd apps/vscode vitest run --config vitest.config.ts src/core/controller/state/updateAutoApprovalSettings.test.ts src/sdk/sdk-tool-policies.test.ts
```

Ran the selected VS Code Vitest suite after adding the new include glob:

```sh
bun --cwd apps/vscode vitest run --config vitest.config.ts
```

Result: 60 test files passed, 660 tests passed.

Checked formatting/linting for the touched files:

```sh
bun --cwd apps/vscode biome check --config-path ./biome.jsonc src/core/controller/state/updateAutoApprovalSettings.ts src/core/controller/state/updateAutoApprovalSettings.test.ts vitest.config.ts --no-errors-on-unmatched --files-ignore-unknown=true
```

Ran TypeScript no-emit from `apps/vscode`:

```sh
bunx tsc --noEmit --project tsconfig.json --pretty false
```

I did not run the full `bun test` or full repo lint/format suite; this PR is scoped to a narrow VS Code settings handler regression and the selected VS Code Vitest suite plus TypeScript check passed.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

No UI changes.

### Additional Notes

The SDK policy layer already forces Cline-governed tools through the approval callback, and that callback evaluates the latest effective settings. The missing piece was keeping the active task override in sync with the global auto-approve setting update.
