### PR TITLE
fix(core): preserve compaction target headroom

### DIFF
--- a/sdk/packages/core/src/extensions/context/compaction.test.ts
+++ b/sdk/packages/core/src/extensions/context/compaction.test.ts
@@ -1358,6 +1358,48 @@ describe("createContextCompactionPrepareTurn", () => {
 		expect(result).toBeUndefined();
 	});
 
+	it("ignores a derived input budget that would collapse the trigger threshold", async () => {
+		const compact = vi.fn((_context: CoreCompactionContext) => ({
+			messages: [
+				{ role: "user" as const, content: "Compacted by tiny input budget" },
+			],
+		}));
+		const prepareTurn = createContextCompactionPrepareTurn({
+			providerId: "openai-codex",
+			modelId: "large-output-model",
+			providerConfig: {
+				providerId: "openai-codex",
+				modelId: "large-output-model",
+			} as LlmsProviders.ProviderConfig,
+			compaction: { enabled: true, compact },
+			logger: undefined,
+		});
+
+		const result = await prepareTurn?.({
+			agentId: "agent-1",
+			conversationId: "conv-1",
+			parentAgentId: null,
+			iteration: 1,
+			abortSignal: new AbortController().signal,
+			systemPrompt: "You are helpful.",
+			tools: [],
+			messages: [{ role: "user", content: "small prompt" }],
+			apiMessages: [{ role: "user", content: "small prompt" }],
+			model: {
+				id: "large-output-model",
+				provider: "openai-codex",
+				info: {
+					id: "large-output-model",
+					contextWindow: 200_000,
+					maxTokens: 190_000,
+				},
+			},
+		});
+
+		expect(compact).not.toHaveBeenCalled();
+		expect(result).toBeUndefined();
+	});
+
 	it("triggers compaction from provider-sized tool result payloads", async () => {
 		const compact = vi.fn((_context: CoreCompactionContext) => ({
 			messages: [
@@ -1519,7 +1561,9 @@ describe("createContextCompactionPrepareTurn", () => {
 		expect(compact).toHaveBeenCalledTimes(1);
 		const context = compact.mock.calls[0]?.[0];
 		expect(context?.maxInputTokens).toBe(100);
-		expect(context?.triggerTokens).toBeLessThan(95);
+		expect(context?.triggerTokens).toBe(95);
+		expect(context?.targetTokens).toBeLessThan(95);
+		expect(context?.thresholdRatio).toBe(0.95);
 		expect(result?.messages).toEqual([
 			{ role: "user", content: "Compacted manually" },
 		]);
@@ -2032,6 +2076,7 @@ describe("createContextCompactionPrepareTurn", () => {
 			{ role: "user", content: "current request" },
 		];
 		const triggerTokens = 150;
+
 		const firstResult = await prepareTurn?.({
 			agentId: "agent-1",
 			conversationId: "conv-1",

--- a/sdk/packages/core/src/extensions/context/compaction.ts
+++ b/sdk/packages/core/src/extensions/context/compaction.ts
@@ -100,7 +100,10 @@ function resolveMaxInputTokens(input: {
 			isPositiveFiniteNumber(input.modelMaxTokens) &&
 			input.modelMaxTokens < input.contextWindow
 		) {
-			candidates.push(input.contextWindow - input.modelMaxTokens);
+			const derivedInputTokens = input.contextWindow - input.modelMaxTokens;
+			if (derivedInputTokens > DEFAULT_RESERVE_TOKENS) {
+				candidates.push(derivedInputTokens);
+			}
 		}
 	}
 	return candidates.length > 0
@@ -164,7 +167,7 @@ const BUILTIN_COMPACTION_STRATEGIES = {
 					? Math.min(
 							compaction?.preserveRecentTokens ??
 								DEFAULT_PRESERVE_RECENT_TOKENS,
-							context.triggerTokens,
+							context.targetTokens ?? context.triggerTokens,
 						)
 					: (compaction?.preserveRecentTokens ??
 						DEFAULT_PRESERVE_RECENT_TOKENS),
@@ -216,10 +219,9 @@ function resolveTriggerState(input: {
 
 function resolveManualTargetState(input: {
 	inputTokens: number;
-	maxInputTokens: number;
 	autoTriggerTokens: number;
 	manualTargetRatio: number | undefined;
-}): { triggerTokens: number; thresholdRatio: number } {
+}): { targetTokens: number } {
 	const ratio =
 		typeof input.manualTargetRatio === "number" &&
 		Number.isFinite(input.manualTargetRatio)
@@ -235,9 +237,7 @@ function resolveManualTargetState(input: {
 		),
 	);
 	return {
-		triggerTokens: targetTokens,
-		thresholdRatio:
-			input.maxInputTokens > 0 ? targetTokens / input.maxInputTokens : 0,
+		targetTokens,
 	};
 }
 
@@ -351,37 +351,32 @@ export function createContextCompactionPrepareTurn(
 		if (mode === "auto" && !triggerState.shouldCompact) {
 			return undefined;
 		}
-			const targetState =
-				mode === "manual"
-					? resolveManualTargetState({
-							inputTokens,
-							maxInputTokens,
+		const targetTokens =
+			mode === "manual"
+				? resolveManualTargetState({
+						inputTokens,
 						autoTriggerTokens: triggerState.triggerTokens,
 						manualTargetRatio: options.manualTargetRatio,
-					})
-					: triggerState;
-			const targetTokens =
-				mode === "auto"
-					? resolveBasicTargetTokens({
-							maxInputTokens,
-							modelMaxTokens: context.model.info?.maxTokens,
-							triggerTokens: targetState.triggerTokens,
-						})
-					: undefined;
+					}).targetTokens
+				: resolveBasicTargetTokens({
+						maxInputTokens,
+						modelMaxTokens: context.model.info?.maxTokens,
+						triggerTokens: triggerState.triggerTokens,
+					});
 
-			const compactionContext = {
-				agentId: context.agentId,
-				conversationId: context.conversationId,
+		const compactionContext = {
+			agentId: context.agentId,
+			conversationId: context.conversationId,
 			parentAgentId: context.parentAgentId,
 			iteration: context.iteration,
 			messages: context.messages,
-				model: context.model,
-				maxInputTokens,
-				triggerTokens: targetState.triggerTokens,
-				targetTokens,
-				thresholdRatio: targetState.thresholdRatio,
-				utilizationRatio: maxInputTokens > 0 ? inputTokens / maxInputTokens : 0,
-			};
+			model: context.model,
+			maxInputTokens,
+			triggerTokens: triggerState.triggerTokens,
+			targetTokens,
+			thresholdRatio: triggerState.thresholdRatio,
+			utilizationRatio: maxInputTokens > 0 ? inputTokens / maxInputTokens : 0,
+		};
 
 		const statusReason =
 			mode === "manual" ? "manual_compaction" : "auto_compaction";
@@ -391,7 +386,8 @@ export function createContextCompactionPrepareTurn(
 				kind: statusReason,
 				reason: statusReason,
 				iteration: context.iteration,
-				triggerTokens: targetState.triggerTokens,
+				triggerTokens: triggerState.triggerTokens,
+				targetTokens,
 				maxInputTokens,
 			},
 		);
@@ -439,7 +435,8 @@ export function createContextCompactionPrepareTurn(
 				tokensSaved: inputTokens - afterTokens,
 				utilizationBefore: `${((inputTokens / maxInputTokens) * 100).toFixed(1)}%`,
 				utilizationAfter: `${((afterTokens / maxInputTokens) * 100).toFixed(1)}%`,
-				thresholdTrigger: `${(targetState.thresholdRatio * 100).toFixed(1)}%`,
+				thresholdTrigger: `${(triggerState.thresholdRatio * 100).toFixed(1)}%`,
+				targetTrigger: `${((targetTokens / maxInputTokens) * 100).toFixed(1)}%`,
 				messagesBefore: beforeMessageCount,
 				messagesAfter: result.messages.length,
 				messagesRemoved: beforeMessageCount - result.messages.length,
@@ -454,9 +451,9 @@ export function createContextCompactionPrepareTurn(
 				tokensBefore: inputTokens,
 				tokensAfter: afterTokens,
 				tokensSaved: inputTokens - afterTokens,
-				triggerTokens: targetState.triggerTokens,
+				triggerTokens: triggerState.triggerTokens,
 				maxInputTokens,
-				thresholdRatio: targetState.thresholdRatio,
+				thresholdRatio: triggerState.thresholdRatio,
 				durationMs,
 				// Matches the field name used by other TASK telemetry helpers
 				// (e.g. captureTaskCompleted, captureToolUsage).
@@ -471,9 +468,9 @@ export function createContextCompactionPrepareTurn(
 				mode,
 				reason: "no_result",
 				tokensBefore: inputTokens,
-				triggerTokens: targetState.triggerTokens,
+				triggerTokens: triggerState.triggerTokens,
 				maxInputTokens,
-				thresholdRatio: targetState.thresholdRatio,
+				thresholdRatio: triggerState.thresholdRatio,
 				durationMs,
 				provider: config.providerId,
 				modelId: config.modelId,


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

Follow-up to #11894 and a retargeted subset of the compaction headroom work from #11897.

#11894 landed the important production fix for basic compaction: automatic compaction now has a lower `targetTokens` budget instead of compacting right back to the threshold. That addresses the immediate problem where users can repeatedly compact as soon as they hit the context threshold.

This PR keeps that behavior but cleans up the remaining trigger/target semantics after #11894:

- `triggerTokens` now consistently remains the threshold that decides whether compaction should run.
- `targetTokens` is passed separately as the post-compaction landing budget.
- status notices include both `triggerTokens` and `targetTokens`.
- telemetry continues reporting the actual trigger threshold rather than the target budget.
- manual compaction now preserves the auto trigger while separately setting a manual target.
- manual agentic compaction clamps `preserveRecentTokens` against `targetTokens` when available.

This also fixes the Greptile edge case from #11894. `resolveMaxInputTokens()` can derive an input budget from `contextWindow - modelMaxTokens`; if that derived value is smaller than the default reserve, the later trigger calculation can collapse to zero and make compaction fire on every non-empty conversation. This PR only considers the derived input budget when it is large enough to leave a usable trigger threshold.

Finally, this removes the `console.info` diagnostics that were left in the compaction loop regression test from #11894.

This is intentionally not a direct merge of #11897. That PR is stacked on `robin/compaction-retry-telemetry` and brings a much larger session/runtime/budget-projection stack when compared against current `main`. This branch ports only the headroom semantics that still apply cleanly after #11894.

### Test Procedure

- `bun biome check sdk/packages/core/src/extensions/context/compaction.ts sdk/packages/core/src/extensions/context/compaction.test.ts`
- `bun --production -F './sdk/packages/*' build`
- `bun -F @cline/core test:unit src/extensions/context/compaction.test.ts`

Also ran:

- `bun -F @cline/core typecheck`

That still fails on the existing unrelated `session-runtime-orchestrator.test.ts` error:

```text
src/runtime/orchestration/session-runtime-orchestrator.test.ts(1499,52): error TS2339: Property 'type' does not exist on type 'string | ContentBlock'.
```

That same failure was present before this branch and is unrelated to the two compaction files touched here.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

The diff includes some indentation cleanup from running Biome over the two touched compaction files. The behavioral changes are limited to preserving trigger/target semantics, adding the derived-budget guard, and removing test diagnostics.
