### PR TITLE
fix(llms): default Ollama qwen3 thinking off for tool-use reliability

### DIFF
--- a/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
@@ -59,9 +59,15 @@ function isMiniMaxM3(input: ProviderOptionMatchInput): boolean {
 function isOllamaReasoningDefaultOnDisable(
 	input: ProviderOptionMatchInput,
 ): boolean {
+	// Ollama models whose reasoning defaults on (e.g. qwen3) keep "thinking"
+	// enabled unless we explicitly opt out. For Cline's agent/tool-use flows this
+	// produces slow, thinking-bloated turns and less reliable tool calls, so we
+	// treat thinking as off by default: disable it whenever the request has not
+	// explicitly opted into reasoning (`enabled === true`). Users can still turn
+	// thinking back on via the explicit reasoning toggle.
 	return (
 		input.request.providerId === "ollama" &&
-		input.request.reasoning?.enabled === false &&
+		input.request.reasoning?.enabled !== true &&
 		modelReasoningDefaultsOn({
 			request: input.request,
 			context: input.context,

--- a/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
@@ -55,9 +55,15 @@ function isMiniMaxM3(input: ProviderOptionMatchInput): boolean {
 function isOllamaReasoningDefaultOnDisable(
 	input: ProviderOptionMatchInput,
 ): boolean {
+	// Ollama models whose reasoning defaults on (e.g. qwen3) keep "thinking"
+	// enabled unless we explicitly opt out. For Cline's agent/tool-use flows this
+	// produces slow, thinking-bloated turns and less reliable tool calls, so we
+	// treat thinking as off by default: disable it whenever the request has not
+	// explicitly opted into reasoning (`enabled === true`). Users can still turn
+	// thinking back on via the explicit reasoning toggle.
 	return (
 		input.request.providerId === "ollama" &&
-		input.request.reasoning?.enabled === false &&
+		input.request.reasoning?.enabled !== true &&
 		modelReasoningDefaultsOn({
 			request: input.request,
 			context: input.context,

--- a/sdk/packages/llms/src/providers/routing/provider-options.test.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-options.test.ts
@@ -1613,23 +1613,65 @@ describe("composeAiSdkProviderOptions: family/provider thinking patches", () => 
 			],
 		},
 		{
-			name: "ollama qwen3 fallback with unset reasoning -> no disable patch",
+			// Thinking is off by default for reasoning-defaults-on Ollama models:
+			// when the request has not explicitly opted into reasoning, we still
+			// emit reasoningEffort=none so qwen3 does not "think" on every turn.
+			name: "ollama qwen3 fallback with unset reasoning -> reasoningEffort none",
 			request: {
 				providerId: "ollama",
 				modelId: "qwen3-coder:30b",
 			},
 			expect: [
-				{ bucket: "ollama", lacks: ["reasoningEffort", "reasoning"] },
-				{ bucket: "openaiCompatible", lacks: ["reasoningEffort", "reasoning"] },
+				{
+					bucket: "ollama",
+					has: {
+						reasoningEffort: "none",
+						reasoning: { effort: "none" },
+					},
+				},
+				{
+					bucket: "openaiCompatible",
+					has: {
+						reasoningEffort: "none",
+						reasoning: { effort: "none" },
+					},
+				},
 			],
 		},
 		{
-			name: "ollama metadata reasoningDefaultOn with unset reasoning -> no disable patch",
+			// Metadata-driven reasoning-defaults-on models behave the same way:
+			// unset reasoning is treated as "thinking off".
+			name: "ollama metadata reasoningDefaultOn with unset reasoning -> reasoningEffort none",
 			request: {
 				providerId: "ollama",
 				modelId: "local-known-reasoner:latest",
 			},
 			context: { modelMetadata: { reasoningDefaultOn: true } },
+			expect: [
+				{
+					bucket: "ollama",
+					has: {
+						reasoningEffort: "none",
+						reasoning: { effort: "none" },
+					},
+				},
+				{
+					bucket: "openaiCompatible",
+					has: {
+						reasoningEffort: "none",
+						reasoning: { effort: "none" },
+					},
+				},
+			],
+		},
+		{
+			// Non-reasoning-defaults-on Ollama models are unaffected: unset
+			// reasoning must not inject a disable patch.
+			name: "ollama non-reasoner with unset reasoning -> no disable patch",
+			request: {
+				providerId: "ollama",
+				modelId: "llama3.1:8b",
+			},
 			expect: [
 				{ bucket: "ollama", lacks: ["reasoningEffort", "reasoning"] },
 				{ bucket: "openaiCompatible", lacks: ["reasoningEffort", "reasoning"] },

--- a/sdk/packages/llms/src/providers/routing/provider-options.test.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-options.test.ts
@@ -1815,23 +1815,65 @@ describe("composeAiSdkProviderOptions: family/provider thinking patches", () => 
 			],
 		},
 		{
-			name: "ollama qwen3 fallback with unset reasoning -> no disable patch",
+			// Thinking is off by default for reasoning-defaults-on Ollama models:
+			// when the request has not explicitly opted into reasoning, we still
+			// emit reasoningEffort=none so qwen3 does not "think" on every turn.
+			name: "ollama qwen3 fallback with unset reasoning -> reasoningEffort none",
 			request: {
 				providerId: "ollama",
 				modelId: "qwen3-coder:30b",
 			},
 			expect: [
-				{ bucket: "ollama", lacks: ["reasoningEffort", "reasoning"] },
-				{ bucket: "openaiCompatible", lacks: ["reasoningEffort", "reasoning"] },
+				{
+					bucket: "ollama",
+					has: {
+						reasoningEffort: "none",
+						reasoning: { effort: "none" },
+					},
+				},
+				{
+					bucket: "openaiCompatible",
+					has: {
+						reasoningEffort: "none",
+						reasoning: { effort: "none" },
+					},
+				},
 			],
 		},
 		{
-			name: "ollama metadata reasoningDefaultOn with unset reasoning -> no disable patch",
+			// Metadata-driven reasoning-defaults-on models behave the same way:
+			// unset reasoning is treated as "thinking off".
+			name: "ollama metadata reasoningDefaultOn with unset reasoning -> reasoningEffort none",
 			request: {
 				providerId: "ollama",
 				modelId: "local-known-reasoner:latest",
 			},
 			context: { modelMetadata: { reasoningDefaultOn: true } },
+			expect: [
+				{
+					bucket: "ollama",
+					has: {
+						reasoningEffort: "none",
+						reasoning: { effort: "none" },
+					},
+				},
+				{
+					bucket: "openaiCompatible",
+					has: {
+						reasoningEffort: "none",
+						reasoning: { effort: "none" },
+					},
+				},
+			],
+		},
+		{
+			// Non-reasoning-defaults-on Ollama models are unaffected: unset
+			// reasoning must not inject a disable patch.
+			name: "ollama non-reasoner with unset reasoning -> no disable patch",
+			request: {
+				providerId: "ollama",
+				modelId: "llama3.1:8b",
+			},
 			expect: [
 				{ bucket: "ollama", lacks: ["reasoningEffort", "reasoning"] },
 				{ bucket: "openaiCompatible", lacks: ["reasoningEffort", "reasoning"] },


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX
<!-- No tracking issue; small, self-contained provider-routing fix. -->

### Description

Local Ollama models whose reasoning "defaults on" (notably the `qwen3` family, and any model with `reasoningDefaultOn` metadata) kept **thinking enabled by default**. In Cline's agent/tool-use flows this produces slow, thinking-bloated turns and noticeably less reliable tool calls — users on recent builds reported qwen behaving worse than it did in the older native-Ollama handler (v3.89.2).

The routing rule that disables thinking (`isOllamaReasoningDefaultOnDisable` in `provider-option-rules.ts`) only fired when reasoning was **explicitly** turned off (`reasoning.enabled === false`). The local-Ollama UX never sets that, so the disable patch effectively never applied and qwen kept thinking on every turn.

This PR treats thinking as **off by default** for reasoning-defaults-on Ollama models: the rule now applies whenever the request has not explicitly opted into reasoning (`reasoning.enabled !== true`), emitting `reasoningEffort: "none"`. Explicitly enabling reasoning (`enabled: true`) still preserves thinking, and non-reasoning-defaults-on Ollama models are unaffected.

This is the first of a series of Ollama tool-calling improvements; it is intentionally scoped to the reasoning-default change only.

### Test Procedure

- Updated and extended the routing unit tests in `provider-options.test.ts`:
  - qwen3 / metadata `reasoningDefaultOn` with **unset** reasoning now expects the `reasoningEffort: "none"` disable patch (previously asserted "no patch").
  - Added a non-reasoner control case (`llama3.1:8b`, unset reasoning) that must **not** receive a disable patch.
  - Explicit `enabled: true` (no disable) and explicit `enabled: false` (disable) cases continue to pass.
  - Removed a stale duplicate case that asserted the old behavior.
- `bunx vitest run src/providers/routing/provider-options.test.ts` → **96/96 pass**.
- `bun run typecheck` (dev tsconfig) in `sdk/packages/llms` → clean.
- Confirmed the 2 pre-existing `gateway.test.ts` failures exist on clean `main` and are unrelated to this change (verified by stashing this change and re-running).

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — backend provider-routing change. Net effect: reasoning-defaults-on Ollama models (e.g. qwen3) send `reasoningEffort: "none"` unless reasoning is explicitly enabled.

### Additional Notes

The behavior is implemented purely in the rule table / model-facts layer (no hardcoded provider string-matching in plumbing): detection continues to flow through `modelReasoningDefaultsOn` (`reasoningDefaultOn` metadata or the documented `isOllamaQwen3ModelIdFallback`). Follow-up work on Ollama native tool-calling will be submitted as separate PRs.
