### PR TITLE
feat(deepseek): support reasoning effort (incl. xhigh) for thinking models

### DIFF
--- a/apps/vscode/src/core/api/index.ts
+++ b/apps/vscode/src/core/api/index.ts
@@ -204,6 +204,7 @@ function createHandlerForProvider(
 				onRetryAttempt: options.onRetryAttempt,
 				deepSeekApiKey: options.deepSeekApiKey,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
+				reasoningEffort: mode === "plan" ? options.planModeReasoningEffort : options.actModeReasoningEffort,
 			})
 		case "requesty":
 			return new RequestyHandler({

--- a/apps/vscode/src/core/api/providers/deepseek.ts
+++ b/apps/vscode/src/core/api/providers/deepseek.ts
@@ -1,7 +1,10 @@
 import { DeepSeekModelId, deepSeekDefaultModelId, deepSeekModels, ModelInfo } from "@shared/api"
 import { calculateApiCostOpenAI } from "@utils/cost"
 import OpenAI from "openai"
-import type { ChatCompletionTool as OpenAITool } from "openai/resources/chat/completions"
+import type {
+	ChatCompletionReasoningEffort,
+	ChatCompletionTool as OpenAITool,
+} from "openai/resources/chat/completions"
 import { buildExternalBasicHeaders } from "@/services/EnvUtils"
 import { ClineStorageMessage } from "@/shared/messages/content"
 import { fetch } from "@/shared/net"
@@ -15,6 +18,7 @@ import { getOpenAIToolParams, ToolCallProcessor } from "../transform/tool-call-p
 interface DeepSeekHandlerOptions extends CommonApiHandlerOptions {
 	deepSeekApiKey?: string
 	apiModelId?: string
+	reasoningEffort?: string
 }
 
 export class DeepSeekHandler implements ApiHandler {
@@ -98,6 +102,10 @@ export class DeepSeekHandler implements ApiHandler {
 			stream_options: { include_usage: true },
 			// Only set temperature for non-thinking models
 			...(isDeepSeekThinkingModel ? {} : { temperature: 0 }),
+			// DeepSeek thinking models accept reasoning effort (low/medium map to high, xhigh maps to max)
+			...(isDeepSeekThinkingModel && this.options.reasoningEffort
+				? { reasoning_effort: this.options.reasoningEffort as ChatCompletionReasoningEffort }
+				: {}),
 			...getOpenAIToolParams(tools),
 		})
 

--- a/apps/vscode/src/core/api/providers/deepseek.ts
+++ b/apps/vscode/src/core/api/providers/deepseek.ts
@@ -102,8 +102,9 @@ export class DeepSeekHandler implements ApiHandler {
 			stream_options: { include_usage: true },
 			// Only set temperature for non-thinking models
 			...(isDeepSeekThinkingModel ? {} : { temperature: 0 }),
-			// DeepSeek thinking models accept reasoning effort (low/medium map to high, xhigh maps to max)
-			...(isDeepSeekThinkingModel && this.options.reasoningEffort
+			// DeepSeek thinking models accept reasoning effort (low/medium map to high, xhigh maps to max).
+			// "none" isn't a valid DeepSeek value, so omit it and let the API use its default.
+			...(isDeepSeekThinkingModel && this.options.reasoningEffort && this.options.reasoningEffort !== "none"
 				? { reasoning_effort: this.options.reasoningEffort as ChatCompletionReasoningEffort }
 				: {}),
 			...getOpenAIToolParams(tools),

--- a/apps/vscode/src/shared/utils/reasoning-support.ts
+++ b/apps/vscode/src/shared/utils/reasoning-support.ts
@@ -42,8 +42,6 @@ export function supportsReasoningEffortForModel(modelId?: string): boolean {
 		id.startsWith("openai/o") ||
 		id.includes("/o") ||
 		id.startsWith("o") ||
-		id.includes("grok") ||
-		id.includes("deepseek-v4") ||
-		id.includes("deepseek-reasoner")
+		id.includes("grok")
 	)
 }

--- a/apps/vscode/src/shared/utils/reasoning-support.ts
+++ b/apps/vscode/src/shared/utils/reasoning-support.ts
@@ -42,6 +42,8 @@ export function supportsReasoningEffortForModel(modelId?: string): boolean {
 		id.startsWith("openai/o") ||
 		id.includes("/o") ||
 		id.startsWith("o") ||
-		id.includes("grok")
+		id.includes("grok") ||
+		id.includes("deepseek-v4") ||
+		id.includes("deepseek-reasoner")
 	)
 }

--- a/apps/vscode/webview-ui/src/components/settings/providers/DeepSeekProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/DeepSeekProvider.tsx
@@ -4,7 +4,8 @@ import { useExtensionState } from "@/context/ExtensionStateContext"
 import { ApiKeyField } from "../common/ApiKeyField"
 import { ModelInfoView } from "../common/ModelInfoView"
 import { ModelSelector } from "../common/ModelSelector"
-import { normalizeApiConfiguration } from "../utils/providerUtils"
+import ReasoningEffortSelector from "../ReasoningEffortSelector"
+import { normalizeApiConfiguration, supportsReasoningEffortForModelId } from "../utils/providerUtils"
 import { useApiConfigurationHandlers } from "../utils/useApiConfigurationHandlers"
 
 /**
@@ -25,6 +26,7 @@ export const DeepSeekProvider = ({ showModelOptions, isPopup, currentMode }: Dee
 
 	// Get the normalized configuration
 	const { selectedModelId, selectedModelInfo } = normalizeApiConfiguration(apiConfiguration, currentMode)
+	const showReasoningEffort = supportsReasoningEffortForModelId(selectedModelId)
 
 	return (
 		<div>
@@ -49,6 +51,8 @@ export const DeepSeekProvider = ({ showModelOptions, isPopup, currentMode }: Dee
 						}
 						selectedModelId={selectedModelId}
 					/>
+
+					{showReasoningEffort && <ReasoningEffortSelector currentMode={currentMode} />}
 
 					<ModelInfoView isPopup={isPopup} modelInfo={selectedModelInfo} selectedModelId={selectedModelId} />
 				</>

--- a/apps/vscode/webview-ui/src/components/settings/providers/DeepSeekProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/DeepSeekProvider.tsx
@@ -5,8 +5,14 @@ import { ApiKeyField } from "../common/ApiKeyField"
 import { ModelInfoView } from "../common/ModelInfoView"
 import { ModelSelector } from "../common/ModelSelector"
 import ReasoningEffortSelector from "../ReasoningEffortSelector"
-import { normalizeApiConfiguration, supportsReasoningEffortForModelId } from "../utils/providerUtils"
+import { normalizeApiConfiguration } from "../utils/providerUtils"
 import { useApiConfigurationHandlers } from "../utils/useApiConfigurationHandlers"
+
+const DEEPSEEK_REASONING_EFFORT_MODELS = new Set([
+	"deepseek-v4-flash",
+	"deepseek-v4-pro",
+	"deepseek-reasoner",
+])
 
 /**
  * Props for the DeepSeekProvider component
@@ -26,7 +32,7 @@ export const DeepSeekProvider = ({ showModelOptions, isPopup, currentMode }: Dee
 
 	// Get the normalized configuration
 	const { selectedModelId, selectedModelInfo } = normalizeApiConfiguration(apiConfiguration, currentMode)
-	const showReasoningEffort = supportsReasoningEffortForModelId(selectedModelId)
+	const showReasoningEffort = DEEPSEEK_REASONING_EFFORT_MODELS.has(selectedModelId)
 
 	return (
 		<div>


### PR DESCRIPTION
### Related Issue

DeepSeek reasoning effort wasn't being sent on the legacy (pre-migration) extension, so users couldn't control thinking depth — and there was no way to select "extra high" (xhigh).

### Description

Wires reasoning effort through to the DeepSeek provider on the legacy extension. Previously the native DeepSeek handler sent no `reasoning_effort` at all and the DeepSeek settings had no effort selector.

- `DeepSeekHandler` now accepts `reasoningEffort` and sends `reasoning_effort` for thinking models (`deepseek-v4-flash`, `deepseek-v4-pro`, `deepseek-reasoner`).
- `api/index.ts` plumbs the plan/act effort into the handler (same pattern as every other provider).
- `supportsReasoningEffortForModel` now matches DeepSeek thinking models so the selector renders.
- `DeepSeekProvider` settings UI renders the existing `ReasoningEffortSelector`.

`xhigh` is already part of the shared `OPENAI_REASONING_EFFORT_OPTIONS`, so it shows in the dropdown automatically. Per DeepSeek's API, `xhigh` maps to `max` and low/medium map to `high` server-side, so passing the selected value straight through is correct.

### Type of Change

-   [x] ✨ New feature (non-breaking change which adds functionality)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore
