### PR TITLE
fix(sdk): bound accumulated provider history

### DIFF
--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -451,6 +451,30 @@ describe("buildSessionConfig", () => {
 		expect((config.providerConfig as any).knownModels).toBeUndefined()
 		expect((config.providerConfig as any).maxOutputTokens).toBeUndefined()
 		expect((config as any).maxTokensPerTurn).toBe(4_096)
+		expect(config.maxInputTokens).toBe(11_904)
+	})
+
+	it("passes the selected input limit for other dynamic providers", async () => {
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "openrouter",
+			actModeOpenRouterModelId: "vendor/large-context",
+			openRouterApiKey: "openrouter-key",
+			actModeOpenRouterModelInfo: {
+				name: "Large Context",
+				contextWindow: 1_000_000,
+				maxTokens: 32_000,
+				supportsImages: true,
+				supportsPromptCache: true,
+				inputPrice: 0,
+				outputPrice: 0,
+			},
+		} as any)
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+
+		expect(config.providerId).toBe("openrouter")
+		expect(config.modelId).toBe("vendor/large-context")
+		expect(config.maxInputTokens).toBe(968_000)
 	})
 
 	it("passes OCA reasoning effort from legacy mode settings to SDK sessions", async () => {

--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -34,7 +34,9 @@ import { FeatureFlag } from "@/shared/services/feature-flags/feature-flags"
 import { type BedrockProviderConfig, buildBedrockProviderConfig } from "./bedrock-config"
 import { buildAgentHooks } from "./hooks-adapter"
 import { readTaskHistory, resolveDataDir } from "./legacy-state-reader"
+import { parseProviderId } from "./model-catalog/provider-id"
 import { toSdkProviderId } from "./model-catalog/sdk-provider-id"
+import { createProviderConfigStore } from "./model-catalog/store"
 import { getProviderSettingsManager } from "./provider-migration"
 import { buildSapProviderConfig, type SapProviderConfig } from "./sap-config"
 import type { SdkSessionHost } from "./session-host"
@@ -200,10 +202,31 @@ function resolveOcaReasoningConfig(mode: Mode, apiConfig: ApiConfiguration | und
 	return isReasoningEffort(effort) ? { thinking: true, reasoningEffort: effort } : undefined
 }
 
+function positiveNumber(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined
+}
+
 function resolveOpenAiCompatibleMaxTokens(config: ApiConfiguration | undefined, mode: Mode): number | undefined {
 	const modelInfo = mode === "plan" ? config?.planModeOpenAiModelInfo : config?.actModeOpenAiModelInfo
-	const maxTokens = modelInfo?.maxTokens
-	return typeof maxTokens === "number" && Number.isFinite(maxTokens) && maxTokens > 0 ? maxTokens : undefined
+	return positiveNumber(modelInfo?.maxTokens)
+}
+
+function resolveSelectedModelMaxInputTokens(providerId: string, modelId: string, mode: Mode): number | undefined {
+	try {
+		const selection = createProviderConfigStore().readSelection(parseProviderId(providerId), mode)
+		if (!selection || selection.modelId !== modelId) {
+			return undefined
+		}
+		const contextWindow = positiveNumber(selection.modelInfo.contextWindow)
+		if (contextWindow === undefined) {
+			return undefined
+		}
+		const maxTokens = positiveNumber(selection.modelInfo.maxTokens)
+		return maxTokens !== undefined && maxTokens < contextWindow ? contextWindow - maxTokens : contextWindow
+	} catch (error) {
+		Logger.warn("[SessionFactory] Failed to resolve selected model input limit:", error)
+		return undefined
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -605,6 +628,7 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 	}
 	apiKey = apiKey ?? ""
 	const maxTokensPerTurn = providerId === "openai" ? resolveOpenAiCompatibleMaxTokens(apiConfig, mode) : undefined
+	const maxInputTokens = resolveSelectedModelMaxInputTokens(providerId, modelId, mode)
 	const reasoningConfig =
 		providerId === "oca"
 			? (resolveOcaReasoningConfig(mode, apiConfig) ?? resolveProviderReasoningConfig(providerId))
@@ -705,6 +729,7 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 		mode: mode === "plan" ? "plan" : "act",
 		...reasoningConfig,
 		...(maxTokensPerTurn !== undefined ? { maxTokensPerTurn } : {}),
+		...(maxInputTokens !== undefined ? { maxInputTokens } : {}),
 		maxIterations: undefined,
 		logger: sdkLogger,
 		extensionContext: {

--- a/sdk/packages/core/src/extensions/context/compaction-shared.ts
+++ b/sdk/packages/core/src/extensions/context/compaction-shared.ts
@@ -23,6 +23,51 @@ export const TOOL_RESULT_CHAR_LIMIT = 2_000;
 export const FILE_CONTENT_CHAR_LIMIT = 2_000;
 export const MIN_TRUNCATED_MESSAGE_TOKENS = 8;
 
+export interface MaxInputTokenLimits {
+	configMaxInputTokens?: number;
+	modelMaxInputTokens?: number;
+	contextWindow?: number;
+	modelMaxTokens?: number;
+}
+
+function isPositiveFiniteNumber(value: unknown): value is number {
+	return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+export function resolveMaxInputTokens(
+	input: MaxInputTokenLimits,
+): number | undefined {
+	const candidates: number[] = [];
+	if (isPositiveFiniteNumber(input.configMaxInputTokens)) {
+		candidates.push(input.configMaxInputTokens);
+	}
+	if (isPositiveFiniteNumber(input.modelMaxInputTokens)) {
+		candidates.push(input.modelMaxInputTokens);
+	}
+	if (isPositiveFiniteNumber(input.contextWindow)) {
+		candidates.push(input.contextWindow);
+		if (
+			isPositiveFiniteNumber(input.modelMaxTokens) &&
+			input.modelMaxTokens < input.contextWindow
+		) {
+			candidates.push(input.contextWindow - input.modelMaxTokens);
+		}
+	}
+	return candidates.length > 0 ? Math.min(...candidates) : undefined;
+}
+
+export function resolveDefaultContextTriggerTokens(
+	maxInputTokens: number,
+): number {
+	return Math.max(
+		0,
+		Math.min(
+			maxInputTokens - DEFAULT_RESERVE_TOKENS,
+			maxInputTokens * DEFAULT_THRESHOLD_RATIO,
+		),
+	);
+}
+
 export interface FileOperationSummary {
 	readFiles: string[];
 	modifiedFiles: string[];

--- a/sdk/packages/core/src/extensions/context/compaction.ts
+++ b/sdk/packages/core/src/extensions/context/compaction.ts
@@ -17,9 +17,9 @@ import {
 	createTokenEstimator,
 	DEFAULT_MAX_INPUT_TOKENS,
 	DEFAULT_PRESERVE_RECENT_TOKENS,
-	DEFAULT_RESERVE_TOKENS,
 	DEFAULT_TARGET_RATIO,
-	DEFAULT_THRESHOLD_RATIO,
+	resolveDefaultContextTriggerTokens,
+	resolveMaxInputTokens,
 } from "./compaction-shared";
 
 export interface ContextPipelinePrepareTurnInput {
@@ -75,37 +75,6 @@ function safeJsonSize(value: unknown): number {
 	} catch {
 		return String(value).length;
 	}
-}
-
-function isPositiveFiniteNumber(value: unknown): value is number {
-	return typeof value === "number" && Number.isFinite(value) && value > 0;
-}
-
-function resolveMaxInputTokens(input: {
-	configMaxInputTokens?: number;
-	modelMaxInputTokens?: number;
-	contextWindow?: number;
-	modelMaxTokens?: number;
-}): number {
-	const candidates: number[] = [];
-	if (isPositiveFiniteNumber(input.configMaxInputTokens)) {
-		candidates.push(input.configMaxInputTokens);
-	}
-	if (isPositiveFiniteNumber(input.modelMaxInputTokens)) {
-		candidates.push(input.modelMaxInputTokens);
-	}
-	if (isPositiveFiniteNumber(input.contextWindow)) {
-		candidates.push(input.contextWindow);
-		if (
-			isPositiveFiniteNumber(input.modelMaxTokens) &&
-			input.modelMaxTokens < input.contextWindow
-		) {
-			candidates.push(input.contextWindow - input.modelMaxTokens);
-		}
-	}
-	return candidates.length > 0
-		? Math.min(...candidates)
-		: DEFAULT_MAX_INPUT_TOKENS;
 }
 
 function summarizeToolResults(messages: CoreCompactionContext["messages"]): {
@@ -199,12 +168,8 @@ function resolveTriggerState(input: {
 		};
 	}
 
-	const triggerTokens = Math.max(
-		0,
-		Math.min(
-			input.maxInputTokens - DEFAULT_RESERVE_TOKENS,
-			input.maxInputTokens * DEFAULT_THRESHOLD_RATIO,
-		),
+	const triggerTokens = resolveDefaultContextTriggerTokens(
+		input.maxInputTokens,
 	);
 	return {
 		shouldCompact: input.inputTokens > triggerTokens,
@@ -316,12 +281,13 @@ export function createContextCompactionPrepareTurn(
 			(total: number, message) => total + estimateMessageTokens(message),
 			0,
 		);
-		const maxInputTokens = resolveMaxInputTokens({
-			configMaxInputTokens: userCompaction?.maxInputTokens,
-			modelMaxInputTokens: context.model.info?.maxInputTokens,
-			contextWindow: context.model.info?.contextWindow,
-			modelMaxTokens: context.model.info?.maxTokens,
-		});
+		const maxInputTokens =
+			resolveMaxInputTokens({
+				configMaxInputTokens: userCompaction?.maxInputTokens,
+				modelMaxInputTokens: context.model.info?.maxInputTokens,
+				contextWindow: context.model.info?.contextWindow,
+				modelMaxTokens: context.model.info?.maxTokens,
+			}) ?? DEFAULT_MAX_INPUT_TOKENS;
 
 		const triggerState = resolveTriggerState({
 			inputTokens,
@@ -351,37 +317,37 @@ export function createContextCompactionPrepareTurn(
 		if (mode === "auto" && !triggerState.shouldCompact) {
 			return undefined;
 		}
-			const targetState =
-				mode === "manual"
-					? resolveManualTargetState({
-							inputTokens,
-							maxInputTokens,
+		const targetState =
+			mode === "manual"
+				? resolveManualTargetState({
+						inputTokens,
+						maxInputTokens,
 						autoTriggerTokens: triggerState.triggerTokens,
 						manualTargetRatio: options.manualTargetRatio,
 					})
-					: triggerState;
-			const targetTokens =
-				mode === "auto"
-					? resolveBasicTargetTokens({
-							maxInputTokens,
-							modelMaxTokens: context.model.info?.maxTokens,
-							triggerTokens: targetState.triggerTokens,
-						})
-					: undefined;
+				: triggerState;
+		const targetTokens =
+			mode === "auto"
+				? resolveBasicTargetTokens({
+						maxInputTokens,
+						modelMaxTokens: context.model.info?.maxTokens,
+						triggerTokens: targetState.triggerTokens,
+					})
+				: undefined;
 
-			const compactionContext = {
-				agentId: context.agentId,
-				conversationId: context.conversationId,
+		const compactionContext = {
+			agentId: context.agentId,
+			conversationId: context.conversationId,
 			parentAgentId: context.parentAgentId,
 			iteration: context.iteration,
 			messages: context.messages,
-				model: context.model,
-				maxInputTokens,
-				triggerTokens: targetState.triggerTokens,
-				targetTokens,
-				thresholdRatio: targetState.thresholdRatio,
-				utilizationRatio: maxInputTokens > 0 ? inputTokens / maxInputTokens : 0,
-			};
+			model: context.model,
+			maxInputTokens,
+			triggerTokens: targetState.triggerTokens,
+			targetTokens,
+			thresholdRatio: targetState.thresholdRatio,
+			utilizationRatio: maxInputTokens > 0 ? inputTokens / maxInputTokens : 0,
+		};
 
 		const statusReason =
 			mode === "manual" ? "manual_compaction" : "auto_compaction";

--- a/sdk/packages/core/src/extensions/tools/team/delegated-agent.ts
+++ b/sdk/packages/core/src/extensions/tools/team/delegated-agent.ts
@@ -28,6 +28,7 @@ export type DelegatedAgentConnectionConfig = Pick<
 	| "knownModels"
 	| "thinking"
 	| "maxTokensPerTurn"
+	| "maxInputTokens"
 >;
 
 export interface DelegatedAgentRuntimeConfig
@@ -89,6 +90,7 @@ export function createDelegatedAgentConfigProvider(
 			knownModels: runtimeConfig.knownModels,
 			thinking: runtimeConfig.thinking,
 			maxTokensPerTurn: runtimeConfig.maxTokensPerTurn,
+			maxInputTokens: runtimeConfig.maxInputTokens,
 		}),
 		updateConnectionDefaults: (overrides) => {
 			runtimeConfig = {

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -469,6 +469,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 			reasoningEffort:
 				configWithProvider.reasoningEffort ?? providerConfig.reasoningEffort,
 			maxTokensPerTurn: configWithProvider.maxTokensPerTurn,
+			maxInputTokens: configWithProvider.maxInputTokens,
 			systemPrompt: configWithProvider.systemPrompt,
 			maxIterations: configWithProvider.maxIterations,
 			execution: configWithProvider.execution,

--- a/sdk/packages/core/src/runtime/orchestration/runtime-builder.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-builder.ts
@@ -486,6 +486,7 @@ export class DefaultRuntimeBuilder implements RuntimeBuilder {
 			knownModels: config.knownModels,
 			thinking: config.thinking,
 			maxTokensPerTurn: config.maxTokensPerTurn,
+			maxInputTokens: config.maxInputTokens,
 			maxIterations: config.maxIterations,
 			hooks,
 			extensions: runtimeExtensions,

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
@@ -496,6 +496,39 @@ describe("SessionRuntime.getExtensionRegistry", () => {
 });
 
 describe("SessionRuntime message preparation", () => {
+	it("passes the resolved model input limit to provider message budgeting", async () => {
+		const { deps, configs } = makeRecordingRuntimeFactory();
+		const session = new SessionRuntime(
+			makeAgentConfig({
+				maxInputTokens: 32_000,
+				knownModels: {
+					"claude-3-5-sonnet": {
+						id: "claude-3-5-sonnet",
+						contextWindow: 128_000,
+						maxTokens: 8_192,
+					},
+				},
+			}),
+			deps,
+		);
+		const buildForApi = vi.spyOn(session.messageBuilder, "buildForApi");
+
+		await session.run("go");
+		const beforeModel = configs[0]?.hooks?.beforeModel;
+		await beforeModel?.({
+			snapshot: makeSnapshot(),
+			request: {
+				systemPrompt: "system",
+				messages: [makeAgentMessage("m1", "user", "original")],
+				tools: [],
+			},
+		});
+
+		expect(buildForApi).toHaveBeenCalledWith(expect.any(Array), {
+			maxInputTokens: 32_000,
+		});
+	});
+
 	it("runs registered message builders and API-safe normalization before model calls", async () => {
 		const build = vi.fn(async (messages) => [
 			...messages,
@@ -1496,7 +1529,10 @@ describe("SessionRuntime real AgentRuntime smoke", () => {
 			"assistant",
 			"user",
 		]);
-		expect(session.getMessages().at(-1)?.content[0]?.type).toBe("tool_result");
+		const lastContent = session.getMessages().at(-1)?.content;
+		expect(Array.isArray(lastContent) ? lastContent[0]?.type : undefined).toBe(
+			"tool_result",
+		);
 	});
 });
 

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
@@ -47,6 +47,7 @@ import {
 	mergeModelOptions,
 	type ToolCallRecord,
 } from "@cline/shared";
+import { resolveMaxInputTokens } from "../../extensions/context/compaction-shared";
 import { filterDisabledTools } from "../../services/global-settings";
 import {
 	createAgentModelFromConfig,
@@ -1002,7 +1003,9 @@ export class SessionRuntime {
 		for (const builder of messageBuilders) {
 			providerMessages = await builder.build(providerMessages);
 		}
-		return this.messageBuilder.buildForApi(providerMessages);
+		return this.messageBuilder.buildForApi(providerMessages, {
+			maxInputTokens: resolveSessionMaxInputTokens(this.config),
+		});
 	}
 
 	private handleRuntimeEvent(event: AgentRuntimeEvent): void {
@@ -1373,4 +1376,14 @@ function tryGetModelInfo(config: AgentConfig): ModelInfo | undefined {
 		return resolvedKnownModels[config.modelId];
 	}
 	return undefined;
+}
+
+function resolveSessionMaxInputTokens(config: AgentConfig): number | undefined {
+	const modelInfo = tryGetModelInfo(config);
+	return resolveMaxInputTokens({
+		configMaxInputTokens: config.maxInputTokens,
+		modelMaxInputTokens: modelInfo?.maxInputTokens,
+		contextWindow: modelInfo?.contextWindow,
+		modelMaxTokens: config.maxTokensPerTurn ?? modelInfo?.maxTokens,
+	});
 }

--- a/sdk/packages/core/src/session/services/message-builder.test.ts
+++ b/sdk/packages/core/src/session/services/message-builder.test.ts
@@ -210,14 +210,10 @@ describe("MessageBuilder", () => {
 		expect(block.content).toContain("...[truncated");
 	});
 
-	it("uses an aggressive per-result cap and a loose aggregate budget", () => {
+	it("uses aggressive per-result and bounded aggregate budgets", () => {
 		expect(DEFAULT_MAX_TOOL_RESULT_CHARS).toBe(8_000);
 		expect(DEFAULT_MAX_FILE_CONTENT_CHARS).toBe(50_000);
-		// The aggregate budget stays loose on purpose: budget truncation
-		// rewrites mid-transcript bytes and breaks provider prefix caching, so
-		// it must stay a rare overflow valve while the per-result cap (which
-		// is deterministic per content) does the routine work.
-		expect(DEFAULT_MAX_TOTAL_TEXT_BYTES).toBe(6_000_000);
+		expect(DEFAULT_MAX_TOTAL_TEXT_BYTES).toBe(250_000);
 	});
 
 	it("accepts named limit options for targeted provider payload tests", () => {
@@ -739,6 +735,23 @@ describe("MessageBuilder with structured ToolOperationResult content", () => {
 		return 0;
 	}
 
+	function sumProviderToolTextBytes(messages: Message[]): number {
+		let total = 0;
+		for (const message of messages) {
+			if (!Array.isArray(message.content)) {
+				continue;
+			}
+			for (const block of message.content) {
+				if (block.type === "tool_use") {
+					total += sumStringBytes(block.input);
+				} else if (block.type === "tool_result") {
+					total += sumStringBytes(block.content);
+				}
+			}
+		}
+		return total;
+	}
+
 	function serializeForAiSdk(messages: Message[]): string {
 		const agentMessages = messagesToAgentMessages(messages);
 		const aiSdkMessages = formatMessagesForAiSdk(
@@ -1216,6 +1229,59 @@ describe("MessageBuilder with structured ToolOperationResult content", () => {
 
 		expect(toolResultStringBytes).toBeLessThanOrEqual(100_000);
 		expect(JSON.stringify(result)).toContain("provider request budget");
+	});
+
+	it("applies the default aggregate budget across accumulated tool results", () => {
+		const builder = new MessageBuilder();
+		const messages: Message[] = [];
+		for (let i = 0; i < 40; i++) {
+			messages.push(
+				toolUseMessage(`call_${i}`, "run_commands", {
+					commands: [`cmd ${i}`],
+				}),
+				structuredToolResultMessage(`call_${i}`, "run_commands", [
+					{
+						query: `cmd ${i}`,
+						result: `result_${i}_`.repeat(1_000),
+						success: true,
+					},
+				]),
+			);
+		}
+
+		const result = builder.buildForApi(messages);
+		expect(sumProviderToolTextBytes(result)).toBeLessThanOrEqual(
+			DEFAULT_MAX_TOTAL_TEXT_BYTES,
+		);
+		expect(JSON.stringify(result)).toContain("provider request budget");
+	});
+
+	it("lowers tool-field floors when many small strings exceed the aggregate budget", () => {
+		const builder = new MessageBuilder({
+			maxToolResultChars: 50_000,
+			maxTotalTextBytes: 20_000,
+		});
+		const messages: Message[] = [];
+		for (let i = 0; i < 30; i++) {
+			messages.push(
+				toolUseMessage(`call_${i}`, "run_commands", {
+					commands: [`arg_${i}_`.repeat(150)],
+				}),
+				structuredToolResultMessage(`call_${i}`, "run_commands", [
+					{
+						query: `cmd ${i}`,
+						result: `result_${i}_`.repeat(100),
+						success: true,
+					},
+				]),
+			);
+		}
+		const snapshot = structuredClone(messages);
+
+		const result = builder.buildForApi(messages);
+		expect(sumProviderToolTextBytes(result)).toBeLessThanOrEqual(20_000);
+		expect(JSON.stringify(result)).toContain("provider request budget");
+		expect(messages).toEqual(snapshot);
 	});
 
 	it("does not mutate the original structured tool results", () => {

--- a/sdk/packages/core/src/session/services/message-builder.test.ts
+++ b/sdk/packages/core/src/session/services/message-builder.test.ts
@@ -216,6 +216,116 @@ describe("MessageBuilder", () => {
 		expect(DEFAULT_MAX_TOTAL_TEXT_BYTES).toBe(250_000);
 	});
 
+	it("reports the exact omitted count when marker length crosses a digit boundary", () => {
+		const builder = new MessageBuilder({
+			maxToolResultChars: 8_001,
+			maxTotalTextBytes: 1_000_000,
+		});
+		const original = `${"a".repeat(9_000)}${"b".repeat(9_000)}`;
+		const messages: Message[] = [
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "tool_use",
+						id: "tool_1",
+						name: "run_commands",
+						input: { commands: ["generate output"] },
+					},
+				],
+			},
+			{
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "tool_1",
+						content: original,
+					},
+				],
+			},
+		];
+
+		const result = builder.buildForApi(messages);
+		const block = Array.isArray(result[1].content)
+			? result[1].content[0]
+			: undefined;
+		if (block?.type !== "tool_result" || typeof block.content !== "string") {
+			throw new Error("expected tool_result with string content");
+		}
+		const marker = block.content.match(
+			/\n\n\.\.\.\[truncated (\d+) chars\]\.\.\.\n\n/,
+		);
+		if (!marker) {
+			throw new Error("expected truncation marker");
+		}
+		const omitted = Number(marker[1]);
+		const retained = block.content.length - marker[0].length;
+		expect(omitted).toBe(original.length - retained);
+		expect(block.content.length).toBeLessThanOrEqual(8_001);
+	});
+
+	it("caps mixed array text without reordering image entries", () => {
+		const builder = new MessageBuilder({
+			maxToolResultChars: 5_000,
+			maxTotalTextBytes: 1_000,
+		});
+		const image = {
+			type: "image" as const,
+			data: "AQID",
+			mediaType: "image/png",
+		};
+		const messages: Message[] = [
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "tool_use",
+						id: "tool_1",
+						name: "read_files",
+						input: { file_paths: ["image.png"] },
+					},
+				],
+			},
+			{
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "tool_1",
+						content: [
+							{ type: "text", text: "a".repeat(1_500) },
+							image,
+							{ type: "text", text: "b".repeat(1_500) },
+						],
+					},
+				],
+			},
+		];
+
+		const result = builder.buildForApi(messages);
+		const block = Array.isArray(result[1].content)
+			? result[1].content[0]
+			: undefined;
+		if (block?.type !== "tool_result" || !Array.isArray(block.content)) {
+			throw new Error("expected tool_result with array content");
+		}
+		expect(block.content.map((entry) => entry.type)).toEqual([
+			"text",
+			"image",
+			"text",
+		]);
+		expect(block.content[1]).toEqual(image);
+		const textBytes = block.content.reduce(
+			(total, entry) =>
+				total +
+				(entry.type === "text" ? Buffer.byteLength(entry.text, "utf8") : 0),
+			0,
+		);
+		expect(textBytes).toBeLessThanOrEqual(1_000);
+		expect(JSON.stringify(block.content)).toContain("provider request budget");
+	});
+
 	it("accepts named limit options for targeted provider payload tests", () => {
 		const builder = new MessageBuilder({
 			maxToolResultChars: 120,

--- a/sdk/packages/core/src/session/services/message-builder.test.ts
+++ b/sdk/packages/core/src/session/services/message-builder.test.ts
@@ -15,6 +15,7 @@ import {
 	DEFAULT_MAX_TOTAL_TEXT_BYTES,
 	getMessageBuilderOptionsFromEnv,
 	MessageBuilder,
+	resolveMessageBuilderTextBudget,
 } from "./message-builder";
 
 describe("MessageBuilder", () => {
@@ -216,6 +217,50 @@ describe("MessageBuilder", () => {
 		expect(DEFAULT_MAX_TOTAL_TEXT_BYTES).toBe(250_000);
 	});
 
+	it("scales the aggregate text budget with the model input limit", () => {
+		expect(resolveMessageBuilderTextBudget(undefined)).toBe(250_000);
+		expect(resolveMessageBuilderTextBudget(32_000)).toBe(32_793);
+		expect(resolveMessageBuilderTextBudget(128_000)).toBe(234_393);
+		expect(resolveMessageBuilderTextBudget(1_000_000)).toBe(1_890_000);
+	});
+
+	it("can meet a 32K model budget across multiple assistant messages", () => {
+		const builder = new MessageBuilder({ maxInputTokens: 32_000 });
+		const messages: Message[] = [
+			{ role: "assistant", content: "a".repeat(50_000) },
+			{ role: "assistant", content: "b".repeat(50_000) },
+		];
+
+		const result = builder.buildForApi(messages);
+		const totalBytes = result.reduce(
+			(sum, message) =>
+				sum +
+				(typeof message.content === "string"
+					? Buffer.byteLength(message.content, "utf8")
+					: 0),
+			0,
+		);
+		expect(totalBytes).toBeLessThanOrEqual(
+			resolveMessageBuilderTextBudget(32_000),
+		);
+		expect(JSON.stringify(result)).toContain("provider request budget");
+		expect(messages[0].content).toHaveLength(50_000);
+	});
+
+	it("leaves the same history intact when a larger model has room", () => {
+		const messages: Message[] = [
+			{ role: "assistant", content: "x".repeat(100_000) },
+		];
+
+		const smallContext = new MessageBuilder({ maxInputTokens: 32_000 });
+		const largeContext = new MessageBuilder({ maxInputTokens: 1_000_000 });
+
+		expect(smallContext.buildForApi(messages)[0].content).not.toBe(
+			messages[0].content,
+		);
+		expect(largeContext.buildForApi(messages)).toEqual(messages);
+	});
+
 	it("reports the exact omitted count when marker length crosses a digit boundary", () => {
 		const builder = new MessageBuilder({
 			maxToolResultChars: 8_001,
@@ -240,6 +285,7 @@ describe("MessageBuilder", () => {
 					{
 						type: "tool_result",
 						tool_use_id: "tool_1",
+						name: "run_commands",
 						content: original,
 					},
 				],
@@ -293,6 +339,7 @@ describe("MessageBuilder", () => {
 					{
 						type: "tool_result",
 						tool_use_id: "tool_1",
+						name: "read_files",
 						content: [
 							{ type: "text", text: "a".repeat(1_500) },
 							image,

--- a/sdk/packages/core/src/session/services/message-builder.test.ts
+++ b/sdk/packages/core/src/session/services/message-builder.test.ts
@@ -219,6 +219,9 @@ describe("MessageBuilder", () => {
 
 	it("scales the aggregate text budget with the model input limit", () => {
 		expect(resolveMessageBuilderTextBudget(undefined)).toBe(250_000);
+		expect(resolveMessageBuilderTextBudget(11_904)).toBe(10_713);
+		expect(resolveMessageBuilderTextBudget(16_384)).toBe(14_745);
+		expect(resolveMessageBuilderTextBudget(16_385)).toBe(14_746);
 		expect(resolveMessageBuilderTextBudget(32_000)).toBe(32_793);
 		expect(resolveMessageBuilderTextBudget(128_000)).toBe(234_393);
 		expect(resolveMessageBuilderTextBudget(1_000_000)).toBe(1_890_000);

--- a/sdk/packages/core/src/session/services/message-builder.ts
+++ b/sdk/packages/core/src/session/services/message-builder.ts
@@ -1185,7 +1185,7 @@ export class MessageBuilder {
 			// A large transcript can exceed the aggregate budget through hundreds
 			// of individually small tool fields. Preserve the normal 2KB floor
 			// first, then lower only tool-field floors as an overflow valve.
-			this.truncateCandidatesToTotalTextBudget(
+			totalBytes = this.truncateCandidatesToTotalTextBudget(
 				this.collectTruncationCandidates(
 					next,
 					EMERGENCY_MIN_TOTAL_BUDGET_TOOL_TEXT_BYTES,

--- a/sdk/packages/core/src/session/services/message-builder.ts
+++ b/sdk/packages/core/src/session/services/message-builder.ts
@@ -39,6 +39,7 @@ export const DEFAULT_MAX_ASSISTANT_TOOL_MARKUP_CHARS = 12_000;
 // Batch stale-read rewrites to avoid breaking provider prefix caches on every re-read.
 // 64KB is roughly 8 provider-capped read results; set to 0 for eager rewriting.
 export const DEFAULT_MIN_OUTDATED_REWRITE_BYTES = 65_536;
+const MIN_CONTEXT_HISTORY_RATIO = 1 - DEFAULT_TARGET_RATIO;
 const MIN_TOTAL_BUDGET_TOOL_TEXT_BYTES = 2_000;
 const EMERGENCY_MIN_TOTAL_BUDGET_TEXT_BYTES = 256;
 const MIN_TOTAL_BUDGET_ASSISTANT_TEXT_BYTES = 40_000;
@@ -102,12 +103,15 @@ export function resolveMessageBuilderTextBudget(
 	) {
 		return DEFAULT_MAX_TOTAL_TEXT_BYTES;
 	}
+	const targetHistoryTokens =
+		resolveDefaultContextTriggerTokens(maxInputTokens) * DEFAULT_TARGET_RATIO;
+	// The fixed compaction reserve can consume the entire trigger on small models.
+	// Keep a proportional history slice instead of collapsing their budget to one byte.
+	const minimumHistoryTokens = maxInputTokens * MIN_CONTEXT_HISTORY_RATIO;
 	return Math.max(
 		1,
 		Math.floor(
-			resolveDefaultContextTriggerTokens(maxInputTokens) *
-				DEFAULT_TARGET_RATIO *
-				CHARS_PER_TOKEN,
+			Math.max(targetHistoryTokens, minimumHistoryTokens) * CHARS_PER_TOKEN,
 		),
 	);
 }

--- a/sdk/packages/core/src/session/services/message-builder.ts
+++ b/sdk/packages/core/src/session/services/message-builder.ts
@@ -10,6 +10,7 @@
  */
 
 import {
+	CHARS_PER_TOKEN,
 	type ContentBlock,
 	createMediaBudgetState,
 	IMAGE_OMITTED_PLACEHOLDER,
@@ -24,12 +25,14 @@ import {
 	type ToolResultContent,
 	validateAndReserveImageMedia,
 } from "@cline/shared";
+import {
+	DEFAULT_TARGET_RATIO,
+	resolveDefaultContextTriggerTokens,
+} from "../../extensions/context/compaction-shared";
 
 export const DEFAULT_MAX_TOOL_RESULT_CHARS = 8_000;
 export const DEFAULT_MAX_FILE_CONTENT_CHARS = 50_000;
-// Keep provider-bound history below typical 128K-token context windows while
-// leaving room for the system prompt, tools, and model output. Per-result caps
-// still do the routine work so aggregate rewrites remain an overflow valve.
+// Safe fallback for providers that do not expose model input limits.
 export const DEFAULT_MAX_TOTAL_TEXT_BYTES = 250_000;
 export const DEFAULT_MAX_ASSISTANT_TEXT_CHARS = 200_000;
 export const DEFAULT_MAX_ASSISTANT_TOOL_MARKUP_CHARS = 12_000;
@@ -37,7 +40,7 @@ export const DEFAULT_MAX_ASSISTANT_TOOL_MARKUP_CHARS = 12_000;
 // 64KB is roughly 8 provider-capped read results; set to 0 for eager rewriting.
 export const DEFAULT_MIN_OUTDATED_REWRITE_BYTES = 65_536;
 const MIN_TOTAL_BUDGET_TOOL_TEXT_BYTES = 2_000;
-const EMERGENCY_MIN_TOTAL_BUDGET_TOOL_TEXT_BYTES = 256;
+const EMERGENCY_MIN_TOTAL_BUDGET_TEXT_BYTES = 256;
 const MIN_TOTAL_BUDGET_ASSISTANT_TEXT_BYTES = 40_000;
 const REPEATED_TOOL_CALL_MARKUP_THRESHOLD = 8;
 export const MESSAGE_BUILDER_LIMIT_ENV = {
@@ -78,10 +81,35 @@ export interface MessageBuilderOptions {
 	maxToolResultChars?: number;
 	maxFileContentChars?: number;
 	maxTotalTextBytes?: number;
+	maxInputTokens?: number;
 	mediaBudget?: MediaBudgetOptions;
 	maxAssistantTextChars?: number;
 	maxAssistantToolMarkupChars?: number;
 	minOutdatedRewriteBytes?: number;
+}
+
+export interface MessageBuilderBuildOptions {
+	maxInputTokens?: number;
+}
+
+export function resolveMessageBuilderTextBudget(
+	maxInputTokens: number | undefined,
+): number {
+	if (
+		typeof maxInputTokens !== "number" ||
+		!Number.isFinite(maxInputTokens) ||
+		maxInputTokens <= 0
+	) {
+		return DEFAULT_MAX_TOTAL_TEXT_BYTES;
+	}
+	return Math.max(
+		1,
+		Math.floor(
+			resolveDefaultContextTriggerTokens(maxInputTokens) *
+				DEFAULT_TARGET_RATIO *
+				CHARS_PER_TOKEN,
+		),
+	);
 }
 
 export function getMessageBuilderOptionsFromEnv(
@@ -121,7 +149,8 @@ export class MessageBuilder {
 	private readResultLocatorCache = new WeakMap<object, ReadLocator[]>();
 	private readonly maxToolResultChars: number;
 	private readonly maxFileContentChars: number;
-	private readonly maxTotalTextBytes: number;
+	private readonly maxTotalTextBytesOverride: number | undefined;
+	private readonly defaultMaxInputTokens: number | undefined;
 	private readonly mediaBudget: MediaBudgetOptions;
 	private readonly maxAssistantTextChars: number;
 	private readonly maxAssistantToolMarkupChars: number;
@@ -139,10 +168,14 @@ export class MessageBuilder {
 			options.maxFileContentChars,
 			DEFAULT_MAX_FILE_CONTENT_CHARS,
 		);
-		this.maxTotalTextBytes = normalizePositiveLimit(
-			options.maxTotalTextBytes,
-			DEFAULT_MAX_TOTAL_TEXT_BYTES,
-		);
+		this.maxTotalTextBytesOverride =
+			options.maxTotalTextBytes === undefined
+				? undefined
+				: normalizePositiveLimit(
+						options.maxTotalTextBytes,
+						DEFAULT_MAX_TOTAL_TEXT_BYTES,
+					);
+		this.defaultMaxInputTokens = options.maxInputTokens;
 		this.mediaBudget = options.mediaBudget ?? {};
 		this.maxAssistantTextChars = normalizePositiveLimit(
 			options.maxAssistantTextChars,
@@ -163,7 +196,10 @@ export class MessageBuilder {
 		this.committedOutdatedRewrites.clear();
 	}
 
-	buildForApi(messages: Message[]): Message[] {
+	buildForApi(
+		messages: Message[],
+		options: MessageBuilderBuildOptions = {},
+	): Message[] {
 		this.reindex(messages);
 		this.commitOutdatedRewrites(messages);
 		const repairedMessages = this.addMissingToolResults(messages);
@@ -201,7 +237,12 @@ export class MessageBuilder {
 		});
 
 		const mediaLimited = this.applyMediaBudget(prepared);
-		return this.truncateToTotalTextBudget(mediaLimited);
+		const maxTotalTextBytes =
+			this.maxTotalTextBytesOverride ??
+			resolveMessageBuilderTextBudget(
+				options.maxInputTokens ?? this.defaultMaxInputTokens,
+			);
+		return this.truncateToTotalTextBudget(mediaLimited, maxTotalTextBytes);
 	}
 
 	private transformBlock(
@@ -1159,9 +1200,12 @@ export class MessageBuilder {
 		return false;
 	}
 
-	private truncateToTotalTextBudget(messages: Message[]): Message[] {
+	private truncateToTotalTextBudget(
+		messages: Message[],
+		maxTotalTextBytes: number,
+	): Message[] {
 		let totalBytes = this.countMessageTextBytes(messages);
-		if (totalBytes <= this.maxTotalTextBytes) {
+		if (totalBytes <= maxTotalTextBytes) {
 			return messages;
 		}
 
@@ -1180,17 +1224,20 @@ export class MessageBuilder {
 		totalBytes = this.truncateCandidatesToTotalTextBudget(
 			this.collectTruncationCandidates(next),
 			totalBytes,
+			maxTotalTextBytes,
 		);
-		if (totalBytes > this.maxTotalTextBytes) {
+		if (totalBytes > maxTotalTextBytes) {
 			// A large transcript can exceed the aggregate budget through hundreds
 			// of individually small tool fields. Preserve the normal 2KB floor
-			// first, then lower only tool-field floors as an overflow valve.
+			// first, then lower assistant/tool text floors as an overflow valve.
 			totalBytes = this.truncateCandidatesToTotalTextBudget(
 				this.collectTruncationCandidates(
 					next,
-					EMERGENCY_MIN_TOTAL_BUDGET_TOOL_TEXT_BYTES,
+					EMERGENCY_MIN_TOTAL_BUDGET_TEXT_BYTES,
+					EMERGENCY_MIN_TOTAL_BUDGET_TEXT_BYTES,
 				),
 				totalBytes,
+				maxTotalTextBytes,
 			);
 		}
 
@@ -1200,16 +1247,17 @@ export class MessageBuilder {
 	private truncateCandidatesToTotalTextBudget(
 		candidates: TruncationCandidate[],
 		totalBytes: number,
+		maxTotalTextBytes: number,
 	): number {
 		for (const candidate of candidates) {
-			if (totalBytes <= this.maxTotalTextBytes) {
+			if (totalBytes <= maxTotalTextBytes) {
 				break;
 			}
 			const currentBytes = candidate.byteLength;
 			if (currentBytes <= candidate.minBytes) {
 				continue;
 			}
-			const overflow = totalBytes - this.maxTotalTextBytes;
+			const overflow = totalBytes - maxTotalTextBytes;
 			const targetBytes = Math.max(candidate.minBytes, currentBytes - overflow);
 			const truncated = truncateMiddleToBytes(
 				candidate.get(),
@@ -1265,6 +1313,7 @@ export class MessageBuilder {
 	private collectTruncationCandidates(
 		messages: Message[],
 		minToolTextBytes = MIN_TOTAL_BUDGET_TOOL_TEXT_BYTES,
+		minAssistantTextBytes = MIN_TOTAL_BUDGET_ASSISTANT_TEXT_BYTES,
 	): TruncationCandidate[] {
 		const resultCandidates: TruncationCandidate[] = [];
 		const inputCandidates: TruncationCandidate[] = [];
@@ -1272,7 +1321,7 @@ export class MessageBuilder {
 			if (message.role === "assistant" && typeof message.content === "string") {
 				resultCandidates.push({
 					byteLength: utf8ByteLength(message.content),
-					minBytes: MIN_TOTAL_BUDGET_ASSISTANT_TEXT_BYTES,
+					minBytes: minAssistantTextBytes,
 					makeMarker: TRUNCATE_ASSISTANT_TEXT_BUDGET_MARKER,
 					get: () => message.content as string,
 					set: (value) => {
@@ -1296,7 +1345,7 @@ export class MessageBuilder {
 				if (message.role === "assistant" && block.type === "text") {
 					resultCandidates.push({
 						byteLength: utf8ByteLength(block.text),
-						minBytes: MIN_TOTAL_BUDGET_ASSISTANT_TEXT_BYTES,
+						minBytes: minAssistantTextBytes,
 						makeMarker: TRUNCATE_ASSISTANT_TEXT_BUDGET_MARKER,
 						get: () => block.text,
 						set: (value) => {

--- a/sdk/packages/core/src/session/services/message-builder.ts
+++ b/sdk/packages/core/src/session/services/message-builder.ts
@@ -27,17 +27,17 @@ import {
 
 export const DEFAULT_MAX_TOOL_RESULT_CHARS = 8_000;
 export const DEFAULT_MAX_FILE_CONTENT_CHARS = 50_000;
-// The aggregate budget intentionally stays far above what the per-result cap
-// usually produces: budget truncation rewrites bytes mid-transcript, which
-// invalidates provider prefix caches from the first rewritten block onward,
-// so it must remain a rare overflow valve rather than the steady state.
-export const DEFAULT_MAX_TOTAL_TEXT_BYTES = 6_000_000;
+// Keep provider-bound history below typical 128K-token context windows while
+// leaving room for the system prompt, tools, and model output. Per-result caps
+// still do the routine work so aggregate rewrites remain an overflow valve.
+export const DEFAULT_MAX_TOTAL_TEXT_BYTES = 250_000;
 export const DEFAULT_MAX_ASSISTANT_TEXT_CHARS = 200_000;
 export const DEFAULT_MAX_ASSISTANT_TOOL_MARKUP_CHARS = 12_000;
 // Batch stale-read rewrites to avoid breaking provider prefix caches on every re-read.
 // 64KB is roughly 8 provider-capped read results; set to 0 for eager rewriting.
 export const DEFAULT_MIN_OUTDATED_REWRITE_BYTES = 65_536;
-const MIN_TOTAL_BUDGET_TOOL_RESULT_BYTES = 2_000;
+const MIN_TOTAL_BUDGET_TOOL_TEXT_BYTES = 2_000;
+const EMERGENCY_MIN_TOTAL_BUDGET_TOOL_TEXT_BYTES = 256;
 const MIN_TOTAL_BUDGET_ASSISTANT_TEXT_BYTES = 40_000;
 const REPEATED_TOOL_CALL_MARKUP_THRESHOLD = 8;
 export const MESSAGE_BUILDER_LIMIT_ENV = {
@@ -1177,7 +1177,30 @@ export class MessageBuilder {
 			};
 		});
 
-		const candidates = this.collectTruncationCandidates(next);
+		totalBytes = this.truncateCandidatesToTotalTextBudget(
+			this.collectTruncationCandidates(next),
+			totalBytes,
+		);
+		if (totalBytes > this.maxTotalTextBytes) {
+			// A large transcript can exceed the aggregate budget through hundreds
+			// of individually small tool fields. Preserve the normal 2KB floor
+			// first, then lower only tool-field floors as an overflow valve.
+			this.truncateCandidatesToTotalTextBudget(
+				this.collectTruncationCandidates(
+					next,
+					EMERGENCY_MIN_TOTAL_BUDGET_TOOL_TEXT_BYTES,
+				),
+				totalBytes,
+			);
+		}
+
+		return next;
+	}
+
+	private truncateCandidatesToTotalTextBudget(
+		candidates: TruncationCandidate[],
+		totalBytes: number,
+	): number {
 		for (const candidate of candidates) {
 			if (totalBytes <= this.maxTotalTextBytes) {
 				break;
@@ -1196,8 +1219,7 @@ export class MessageBuilder {
 			candidate.set(truncated);
 			totalBytes -= currentBytes - utf8ByteLength(truncated);
 		}
-
-		return next;
+		return totalBytes;
 	}
 
 	private countMessageTextBytes(messages: Message[]): number {
@@ -1242,6 +1264,7 @@ export class MessageBuilder {
 
 	private collectTruncationCandidates(
 		messages: Message[],
+		minToolTextBytes = MIN_TOTAL_BUDGET_TOOL_TEXT_BYTES,
 	): TruncationCandidate[] {
 		const resultCandidates: TruncationCandidate[] = [];
 		const inputCandidates: TruncationCandidate[] = [];
@@ -1263,7 +1286,11 @@ export class MessageBuilder {
 			}
 			for (const block of message.content) {
 				if (block.type === "tool_use") {
-					collectNestedStringCandidates(block.input, inputCandidates);
+					collectNestedStringCandidates(
+						block.input,
+						inputCandidates,
+						minToolTextBytes,
+					);
 					continue;
 				}
 				if (message.role === "assistant" && block.type === "text") {
@@ -1284,7 +1311,7 @@ export class MessageBuilder {
 				if (typeof block.content === "string") {
 					resultCandidates.push({
 						byteLength: utf8ByteLength(block.content),
-						minBytes: MIN_TOTAL_BUDGET_TOOL_RESULT_BYTES,
+						minBytes: minToolTextBytes,
 						makeMarker: TRUNCATE_MARKER_BUDGET,
 						get: () => block.content as string,
 						set: (value) => {
@@ -1297,7 +1324,7 @@ export class MessageBuilder {
 					if (entry.type === "text") {
 						resultCandidates.push({
 							byteLength: utf8ByteLength(entry.text),
-							minBytes: MIN_TOTAL_BUDGET_TOOL_RESULT_BYTES,
+							minBytes: minToolTextBytes,
 							makeMarker: TRUNCATE_MARKER_BUDGET,
 							get: () => entry.text,
 							set: (value) => {
@@ -1307,7 +1334,7 @@ export class MessageBuilder {
 					} else if (entry.type === "file") {
 						resultCandidates.push({
 							byteLength: utf8ByteLength(entry.content),
-							minBytes: MIN_TOTAL_BUDGET_TOOL_RESULT_BYTES,
+							minBytes: minToolTextBytes,
 							makeMarker: TRUNCATE_MARKER_BUDGET,
 							get: () => entry.content,
 							set: (value) => {
@@ -1315,7 +1342,11 @@ export class MessageBuilder {
 							},
 						});
 					} else if (isStructuredToolResultEntry(entry)) {
-						collectNestedStringCandidates(entry, resultCandidates);
+						collectNestedStringCandidates(
+							entry,
+							resultCandidates,
+							minToolTextBytes,
+						);
 					}
 				}
 			}
@@ -1669,13 +1700,14 @@ function countNestedStringBytes(value: unknown): number {
 function collectNestedStringCandidates(
 	container: unknown,
 	candidates: TruncationCandidate[],
+	minBytes: number,
 ): void {
 	if (Array.isArray(container)) {
 		container.forEach((item, index) => {
 			if (typeof item === "string") {
 				candidates.push({
 					byteLength: utf8ByteLength(item),
-					minBytes: MIN_TOTAL_BUDGET_TOOL_RESULT_BYTES,
+					minBytes,
 					makeMarker: TRUNCATE_MARKER_BUDGET,
 					get: () => container[index] as string,
 					set: (value) => {
@@ -1683,7 +1715,7 @@ function collectNestedStringCandidates(
 					},
 				});
 			} else {
-				collectNestedStringCandidates(item, candidates);
+				collectNestedStringCandidates(item, candidates, minBytes);
 			}
 		});
 		return;
@@ -1698,7 +1730,7 @@ function collectNestedStringCandidates(
 			if (typeof item === "string") {
 				candidates.push({
 					byteLength: utf8ByteLength(item),
-					minBytes: MIN_TOTAL_BUDGET_TOOL_RESULT_BYTES,
+					minBytes,
 					makeMarker: TRUNCATE_MARKER_BUDGET,
 					get: () => record[key] as string,
 					set: (value) => {
@@ -1706,7 +1738,7 @@ function collectNestedStringCandidates(
 					},
 				});
 			} else {
-				collectNestedStringCandidates(item, candidates);
+				collectNestedStringCandidates(item, candidates, minBytes);
 			}
 		}
 	}

--- a/sdk/packages/core/src/session/services/message-builder.ts
+++ b/sdk/packages/core/src/session/services/message-builder.ts
@@ -1571,20 +1571,28 @@ function truncateMiddleByChars(
 	if (text.length <= maxChars) {
 		return text;
 	}
-	// Two-pass: marker length depends on the removed-char count, which depends
-	// on the marker length. Compute a tentative marker, derive the final
-	// removed count, then build the real marker.
-	const tentativeMarker = makeMarker(text.length - maxChars);
-	const tentativeKeep = Math.max(
-		0,
-		Math.floor((maxChars - tentativeMarker.length) / 2),
-	);
-	const removed = Math.max(0, text.length - tentativeKeep * 2);
-	const marker = makeMarker(removed);
-	const keep = Math.max(0, Math.floor((maxChars - marker.length) / 2));
-	const start = text.slice(0, keep);
-	const end = keep > 0 ? text.slice(-keep) : "";
-	return `${start}${marker}${end}`;
+	if (maxChars <= 0) {
+		return "";
+	}
+
+	// Marker length depends on the omitted count. Recompute until the retained
+	// length and marker agree so digit-boundary changes cannot make the count
+	// inaccurate.
+	let keep = Math.max(0, Math.floor(maxChars / 2));
+	while (true) {
+		const removed = Math.max(0, text.length - keep * 2);
+		const marker = makeMarker(removed);
+		if (marker.length > maxChars) {
+			return marker.slice(0, maxChars);
+		}
+		const nextKeep = Math.max(0, Math.floor((maxChars - marker.length) / 2));
+		if (nextKeep === keep) {
+			const start = text.slice(0, keep);
+			const end = keep > 0 ? text.slice(-keep) : "";
+			return `${start}${marker}${end}`;
+		}
+		keep = nextKeep;
+	}
 }
 
 function truncateMiddleToBytes(

--- a/sdk/packages/core/src/types/config.ts
+++ b/sdk/packages/core/src/types/config.ts
@@ -41,6 +41,10 @@ export interface CoreModelConfig {
 	 * Maximum output tokens per API call.
 	 */
 	maxTokensPerTurn?: number;
+	/**
+	 * Maximum input tokens available per API call.
+	 */
+	maxInputTokens?: number;
 }
 
 export interface CoreRuntimeFeatures {

--- a/sdk/packages/shared/src/agents/types.ts
+++ b/sdk/packages/shared/src/agents/types.ts
@@ -712,6 +712,10 @@ export interface AgentConfig {
 	 */
 	maxTokensPerTurn?: number;
 	/**
+	 * Maximum input tokens available per API call
+	 */
+	maxInputTokens?: number;
+	/**
 	 * Timeout for each API call in milliseconds
 	 * @default 180000 (3 minutes)
 	 */
@@ -880,6 +884,7 @@ export const AgentConfigSchema = z.object({
 	maxIterations: z.number().positive().optional(),
 	maxParallelToolCalls: z.number().int().positive().default(8),
 	maxTokensPerTurn: z.number().positive().optional(),
+	maxInputTokens: z.number().positive().optional(),
 	apiTimeoutMs: z.number().positive().default(180000),
 	userFileContentLoader: z
 		.function()


### PR DESCRIPTION
### Related Issue

N/A - provider-request overflow reproduced on the current v4 SDK path.

Supersedes #11706, which targeted the removed pre-v4 VS Code task-history path.

### Description

`MessageBuilder` is the final request-safety layer when transcript compaction is disabled. A single fixed aggregate text cap cannot be correct for both small local-model contexts and 1M-token models.

This change:

- adds an explicit `maxInputTokens` session limit and carries it through root and delegated SDK runtimes;
- resolves catalog model limits in Core and uses the VS Code committed model selection, the same source used by the context indicator, for dynamic/custom providers;
- keeps OpenAI-compatible `knownModels` untouched, preserving the provider-metadata contract restored by #11775;
- derives the provider-history text target with the shared conservative token estimator and existing compaction reserve/target policy;
- leaves requests unchanged while they fit, scales from 32K through 1M contexts, and retains the 250 KB fallback only when model limits are unavailable;
- lowers assistant/tool text floors only as an emergency pass when the normal aggregate pass cannot meet a small model's budget;
- preserves the explicit `CLINE_MESSAGE_BUILDER_MAX_TOTAL_TEXT_BYTES` override and never mutates canonical session history.

The existing per-result caps, UTF-8 accounting, structured tool-result handling, media ordering, and stable middle-truncation markers remain in place.

### Test Procedure

- `bun -F @cline/core build`
- `bun -F @cline/core typecheck`
- shared package typecheck
- VS Code TypeScript check after proto generation
- Core focused tests: 95 passed (`message-builder` and `compaction`)
- VS Code session-factory tests: 48 passed
- Biome checks on all changed files
- `git diff --check`
- pre-commit gitleaks scan

CI confirms the complete Core suite passes on both platforms: 1,230 tests on Ubuntu and 1,229 tests with five platform skips on Windows, including the orchestrator coverage.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [x] Refactor Changes
- [ ] Cosmetic Changes
- [ ] Documentation update
- [ ] Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to this provider-request context-budget fix
- [x] Targeted tests, production build, typechecks, formatting, and secret scan pass as described above
- [x] Previous review feedback and the later OpenAI-compatible metadata revert were audited

### Screenshots

N/A - SDK provider-message handling only.