### PR TITLE
Add an intermediate step before going to ClinePass model selection

### DIFF
--- a/apps/cli/src/tui/cline-account.test.ts
+++ b/apps/cli/src/tui/cline-account.test.ts
@@ -13,6 +13,7 @@ const coreMocks = vi.hoisted(() => {
 		fetchBalance: vi.fn(),
 		fetchOrganizationBalance: vi.fn(),
 		fetchAvailableSubscriptionPlans: vi.fn(),
+		fetchCurrentUserPlan: vi.fn(),
 		serviceOptions,
 	};
 });
@@ -44,6 +45,9 @@ vi.mock("@cline/core", async (importOriginal) => {
 				type?: "individual" | "teams";
 			}) {
 				return coreMocks.fetchAvailableSubscriptionPlans(input);
+			}
+			fetchCurrentUserPlan() {
+				return coreMocks.fetchCurrentUserPlan();
 			}
 		},
 		ProviderSettingsManager: class {
@@ -107,6 +111,7 @@ describe("createClineAccountService", () => {
 		coreMocks.fetchBalance.mockReset();
 		coreMocks.fetchOrganizationBalance.mockReset();
 		coreMocks.fetchAvailableSubscriptionPlans.mockReset();
+		coreMocks.fetchCurrentUserPlan.mockReset();
 		coreMocks.serviceOptions.length = 0;
 		telemetryMocks.identifyTelemetryAccount.mockReset();
 	});
@@ -204,6 +209,7 @@ describe("loadClineAccountSnapshot", () => {
 		coreMocks.fetchBalance.mockReset();
 		coreMocks.fetchOrganizationBalance.mockReset();
 		coreMocks.fetchAvailableSubscriptionPlans.mockReset();
+		coreMocks.fetchCurrentUserPlan.mockReset();
 		coreMocks.serviceOptions.length = 0;
 		telemetryMocks.identifyTelemetryAccount.mockReset();
 	});
@@ -268,6 +274,7 @@ describe("loadIndividualSubscriptionPlans", () => {
 		coreMocks.fetchBalance.mockReset();
 		coreMocks.fetchOrganizationBalance.mockReset();
 		coreMocks.fetchAvailableSubscriptionPlans.mockReset();
+		coreMocks.fetchCurrentUserPlan.mockReset();
 		coreMocks.serviceOptions.length = 0;
 		telemetryMocks.identifyTelemetryAccount.mockReset();
 	});

--- a/apps/cli/src/tui/cline-account.ts
+++ b/apps/cli/src/tui/cline-account.ts
@@ -3,6 +3,7 @@ import {
 	type ClineAccountOrganization,
 	type ClineAccountOrganizationBalance,
 	type ClineSubscriptionPlan,
+	type UserCurrentPlan,
 	ClineAccountService,
 	type ClineAccountUser,
 	formatProviderOAuthApiKey,
@@ -125,8 +126,9 @@ export async function createClineAccountService(input: {
 	config: ClineAccountConfig;
 	clineApiBaseUrl?: string;
 	clineProviderSettings?: ProviderSettings;
+	providerSettingsManager?: ProviderSettingsManager;
 }): Promise<ClineAccountService | undefined> {
-	const manager = new ProviderSettingsManager();
+	const manager = input.providerSettingsManager ?? new ProviderSettingsManager();
 	const settings =
 		manager.getProviderSettings("cline") ?? input.clineProviderSettings;
 	const apiBaseUrl = resolveAccountApiBaseUrl({
@@ -210,6 +212,48 @@ export async function loadIndividualSubscriptionPlans(input: {
 	clineProviderSettings?: ProviderSettings;
 }): Promise<ClineSubscriptionPlan[]> {
 	const service = await createClineAccountService(input);
+	if (!service) {
+		throw new Error("No Cline account auth token found");
+	}
+	return service.fetchAvailableSubscriptionPlans({ type: "individual" });
+}
+
+export async function loadCurrentUserPlan(input: {
+	config: ClineAccountConfig;
+	clineApiBaseUrl?: string;
+	clineProviderSettings?: ProviderSettings;
+}): Promise<UserCurrentPlan | undefined> {
+	const service = await createClineAccountService(input);
+	if (!service) {
+		throw new Error("No Cline account auth token found");
+	}
+	return service.fetchCurrentUserPlan();
+}
+
+export async function loadCurrentUserPlanFromProviderSettings(input: {
+	providerSettingsManager: ProviderSettingsManager;
+	clineApiBaseUrl?: string;
+}): Promise<UserCurrentPlan | undefined> {
+	const service = await createClineAccountService({
+		config: { apiKey: "", logger: undefined, providerId: "cline" },
+		clineApiBaseUrl: input.clineApiBaseUrl,
+		providerSettingsManager: input.providerSettingsManager,
+	});
+	if (!service) {
+		throw new Error("No Cline account auth token found");
+	}
+	return service.fetchCurrentUserPlan();
+}
+
+export async function loadIndividualSubscriptionPlansFromProviderSettings(input: {
+	providerSettingsManager: ProviderSettingsManager;
+	clineApiBaseUrl?: string;
+}): Promise<ClineSubscriptionPlan[]> {
+	const service = await createClineAccountService({
+		config: { apiKey: "", logger: undefined, providerId: "cline" },
+		clineApiBaseUrl: input.clineApiBaseUrl,
+		providerSettingsManager: input.providerSettingsManager,
+	});
 	if (!service) {
 		throw new Error("No Cline account auth token found");
 	}

--- a/apps/cli/src/tui/components/chat-entry.tsx
+++ b/apps/cli/src/tui/components/chat-entry.tsx
@@ -6,6 +6,7 @@ import "opentui-spinner/react";
 import {
 	getClineOrgIndividualInferenceSubscriptionMessage,
 	getCliSubscriptionUrl,
+	getIndividualPlanFeatures,
 	isClineOrgIndividualInferenceSubscriptionErrorMessage,
 	isClinePassSubscriptionError,
 } from "../../utils/cline-pass-errors";
@@ -36,12 +37,6 @@ import {
 	shortenPath,
 } from "../utils/tool-parsing";
 import { ToolOutput } from "./tool-output";
-
-function getIndividualPlanFeatures(plans: ClineSubscriptionPlan[]): string[] {
-	const planWithFeatures = plans.find((plan) => plan.interval === "Monthly");
-
-	return planWithFeatures?.features?.included ?? [];
-}
 
 function trimLeading(text: string): string {
 	return text.replace(/^\n+/, "");
@@ -406,12 +401,10 @@ function ClinePassSubscriptionErrorView(props: {
 					<box flexDirection="column" marginTop={1}>
 						<text fg={props.defaultFg}>ClinePass includes:</text>
 						{planFeatures.map((feature) => (
-							<box key={feature} flexDirection="row">
-								<text fg="green" content="✓ " />
-								<text fg={props.defaultFg} selectable>
-									{feature}
-								</text>
-							</box>
+							<text key={feature} fg={props.defaultFg} selectable>
+								<span fg="green">✓ </span>
+								<span>{feature}</span>
+							</text>
 						))}
 					</box>
 				)}

--- a/apps/cli/src/tui/views/onboarding/controller.ts
+++ b/apps/cli/src/tui/views/onboarding/controller.ts
@@ -285,13 +285,25 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 		setClinePassCurrentPlanName("");
 		setClinePassPlanFeatures([]);
 
-		Promise.allSettled([
-			loadCurrentUserPlanFromProviderSettings({ providerSettingsManager }),
-			loadIndividualSubscriptionPlansFromProviderSettings({
-				providerSettingsManager,
-			}),
-		])
-			.then(([currentPlanResult, availablePlansResult]) => {
+		loadCurrentUserPlanFromProviderSettings({ providerSettingsManager })
+			.then(
+				(value) => ({ status: "fulfilled" as const, value }),
+				(reason) => ({ status: "rejected" as const, reason }),
+			)
+			.then((currentPlanResult) =>
+				loadIndividualSubscriptionPlansFromProviderSettings({
+					providerSettingsManager,
+				})
+					.then(
+						(value) => ({ status: "fulfilled" as const, value }),
+						(reason) => ({ status: "rejected" as const, reason }),
+					)
+					.then((availablePlansResult) => ({
+						availablePlansResult,
+						currentPlanResult,
+					})),
+			)
+			.then(({ currentPlanResult, availablePlansResult }) => {
 				if (availablePlansResult.status === "fulfilled") {
 					setClinePassPlanFeatures(
 						getIndividualPlanFeatures(availablePlansResult.value),

--- a/apps/cli/src/tui/views/onboarding/controller.ts
+++ b/apps/cli/src/tui/views/onboarding/controller.ts
@@ -312,9 +312,12 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 
 				if (currentPlanResult.status === "rejected") {
 					const error = currentPlanResult.reason;
-					setClinePassSubscriptionError(
-						error instanceof Error ? error.message : String(error),
-					);
+					const message = error instanceof Error ? error.message : String(error);
+					if (message.trim().toLowerCase() === "no plan found for user") {
+						setClinePassSubscriptionStatus("unsubscribed");
+						return;
+					}
+					setClinePassSubscriptionError(message);
 					setClinePassSubscriptionStatus("error");
 					return;
 				}

--- a/apps/cli/src/tui/views/onboarding/controller.ts
+++ b/apps/cli/src/tui/views/onboarding/controller.ts
@@ -283,24 +283,31 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 		setClinePassSubscriptionStatus("loading");
 		setClinePassSubscriptionError("");
 		setClinePassCurrentPlanName("");
+		setClinePassPlanFeatures([]);
 
-		Promise.all([
-			loadCurrentUserPlanFromProviderSettings({
-				providerSettingsManager,
-			}).catch((error: unknown) => {
-				// We need to catch loadCurrentUserPlan errors because fetching plan details will fail otherwise
-				setClinePassSubscriptionError(
-					error instanceof Error ? error.message : String(error),
-				);
-				setClinePassSubscriptionStatus("error");
-			}),
+		Promise.allSettled([
+			loadCurrentUserPlanFromProviderSettings({ providerSettingsManager }),
 			loadIndividualSubscriptionPlansFromProviderSettings({
 				providerSettingsManager,
 			}),
 		])
-			.then(([currentPlan, availablePlans]) => {
-				const plan = currentPlan?.plan;
-				setClinePassPlanFeatures(getIndividualPlanFeatures(availablePlans));
+			.then(([currentPlanResult, availablePlansResult]) => {
+				if (availablePlansResult.status === "fulfilled") {
+					setClinePassPlanFeatures(
+						getIndividualPlanFeatures(availablePlansResult.value),
+					);
+				}
+
+				if (currentPlanResult.status === "rejected") {
+					const error = currentPlanResult.reason;
+					setClinePassSubscriptionError(
+						error instanceof Error ? error.message : String(error),
+					);
+					setClinePassSubscriptionStatus("error");
+					return;
+				}
+
+				const plan = currentPlanResult.value?.plan;
 				if (plan) {
 					setClinePassCurrentPlanName(
 						plan.displayName || plan.name || plan.id || "ClinePass",
@@ -309,12 +316,6 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 				} else {
 					setClinePassSubscriptionStatus("unsubscribed");
 				}
-			})
-			.catch((error: unknown) => {
-				setClinePassSubscriptionError(
-					error instanceof Error ? error.message : String(error),
-				);
-				setClinePassSubscriptionStatus("error");
 			});
 	}, [providerSettingsManager]);
 

--- a/apps/cli/src/tui/views/onboarding/controller.ts
+++ b/apps/cli/src/tui/views/onboarding/controller.ts
@@ -11,6 +11,7 @@ import {
 } from "@cline/core";
 import { isClineProvider } from "@cline/shared";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { getIndividualPlanFeatures } from "../../../utils/cline-pass-errors";
 import {
 	type CodexCliStatus,
 	checkCodexCliInstalled,
@@ -20,6 +21,10 @@ import { getCliFeatureFlagsService } from "../../../utils/feature-flags";
 import { getPersistedProviderApiKey } from "../../../utils/provider-auth";
 import { listLocalProviders } from "../../../utils/provider-catalog";
 import { getCliTelemetryService } from "../../../utils/telemetry";
+import {
+	loadCurrentUserPlanFromProviderSettings,
+	loadIndividualSubscriptionPlansFromProviderSettings,
+} from "../../cline-account";
 import {
 	buildClineModelEntries,
 	type ClineModelPickerEntry,
@@ -48,6 +53,7 @@ import {
 import { FIELD_ORDER } from "./fields";
 import { useOnboardingKeyboard } from "./keyboard";
 import {
+	type ClinePassSubscriptionStatus,
 	getMainMenuOptions,
 	type ModelEntry,
 	type OnboardingResult,
@@ -150,6 +156,14 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 	const [modelsDefaultId, setModelsDefaultId] = useState("");
 	const [customModelId, setCustomModelId] = useState("");
 	const [customModelError, setCustomModelError] = useState("");
+	const [clinePassSubscriptionStatus, setClinePassSubscriptionStatus] =
+		useState<ClinePassSubscriptionStatus>("loading");
+	const [clinePassSubscriptionError, setClinePassSubscriptionError] =
+		useState("");
+	const [clinePassCurrentPlanName, setClinePassCurrentPlanName] = useState("");
+	const [clinePassPlanFeatures, setClinePassPlanFeatures] = useState<string[]>(
+		[],
+	);
 
 	const modelItems: SearchableItem[] = useMemo(
 		() =>
@@ -265,6 +279,45 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 		[providerSettingsManager],
 	);
 
+	const refreshClinePassSubscriptionStatus = useCallback(() => {
+		setClinePassSubscriptionStatus("loading");
+		setClinePassSubscriptionError("");
+		setClinePassCurrentPlanName("");
+
+		Promise.all([
+			loadCurrentUserPlanFromProviderSettings({
+				providerSettingsManager,
+			}).catch((error: unknown) => {
+				// We need to catch loadCurrentUserPlan errors because fetching plan details will fail otherwise
+				setClinePassSubscriptionError(
+					error instanceof Error ? error.message : String(error),
+				);
+				setClinePassSubscriptionStatus("error");
+			}),
+			loadIndividualSubscriptionPlansFromProviderSettings({
+				providerSettingsManager,
+			}),
+		])
+			.then(([currentPlan, availablePlans]) => {
+				const plan = currentPlan?.plan;
+				setClinePassPlanFeatures(getIndividualPlanFeatures(availablePlans));
+				if (plan) {
+					setClinePassCurrentPlanName(
+						plan.displayName || plan.name || plan.id || "ClinePass",
+					);
+					setClinePassSubscriptionStatus("subscribed");
+				} else {
+					setClinePassSubscriptionStatus("unsubscribed");
+				}
+			})
+			.catch((error: unknown) => {
+				setClinePassSubscriptionError(
+					error instanceof Error ? error.message : String(error),
+				);
+				setClinePassSubscriptionStatus("error");
+			});
+	}, [providerSettingsManager]);
+
 	const transitionToModelPicker = useCallback(
 		(providerId: string) => {
 			setActiveProviderId(providerId);
@@ -286,6 +339,26 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 			}
 		},
 		[providers, loadModelsForProvider, providerSettingsManager],
+	);
+
+	const transitionToClinePassSubscription = useCallback(() => {
+		setActiveProviderId("cline-pass");
+		const provider = providers.find((p) => p.id === "cline-pass");
+		setActiveProviderName(provider?.name ?? "ClinePass");
+		setModelsDefaultId(provider?.defaultModelId ?? "");
+		setStep("cline_pass_subscription");
+		refreshClinePassSubscriptionStatus();
+	}, [providers, refreshClinePassSubscriptionStatus]);
+
+	const handleAuthComplete = useCallback(
+		(providerId: OnboardingOAuthProviderId) => {
+			if (providerId === "cline-pass") {
+				transitionToClinePassSubscription();
+				return;
+			}
+			transitionToModelPicker(providerId);
+		},
+		[transitionToClinePassSubscription, transitionToModelPicker],
 	);
 
 	const resetAuth = useCallback(() => {
@@ -313,11 +386,11 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 				setVerifyUrl: setDeviceVerifyUrl,
 				setStatus: setDeviceStatus,
 				setError: setDeviceError,
-				onComplete: transitionToModelPicker,
+				onComplete: handleAuthComplete,
 				telemetry: getCliTelemetryService(),
 			});
 		},
-		[providerSettingsManager, transitionToModelPicker],
+		[providerSettingsManager, handleAuthComplete],
 	);
 
 	const startOAuthFlow = useCallback(
@@ -339,17 +412,30 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 				setStatus: setAuthStatus,
 				setAuthUrl,
 				setError: setAuthError,
-				onComplete: transitionToModelPicker,
+				onComplete: handleAuthComplete,
 				telemetry: getCliTelemetryService(),
 			});
 		},
 		[
 			providerSettingsManager,
 			resetAuth,
-			transitionToModelPicker,
+			handleAuthComplete,
 			startDeviceCodeFlow,
 		],
 	);
+
+	const continueFromClinePassSubscription = useCallback(() => {
+		transitionToModelPicker("cline-pass");
+	}, [transitionToModelPicker]);
+
+	useEffect(() => {
+		if (
+			step === "cline_pass_subscription" &&
+			clinePassSubscriptionStatus === "subscribed"
+		) {
+			transitionToModelPicker("cline-pass");
+		}
+	}, [step, clinePassSubscriptionStatus, transitionToModelPicker]);
 
 	const refreshCodexCliStatus = useCallback(() => {
 		setCodexCliStatus(undefined);
@@ -632,6 +718,7 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 		modelList,
 		clineEntries,
 		clineModelSelected,
+		clinePassSubscriptionStatus,
 		thinkingSelected,
 		setStep,
 		setMenuSelected,
@@ -649,6 +736,8 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 		setDeviceStatus,
 		setClineModelSelected,
 		setThinkingSelected,
+		continueFromClinePassSubscription,
+		refreshClinePassSubscriptionStatus,
 		abortOAuth: () => {
 			authAbortRef.current = true;
 		},
@@ -683,6 +772,10 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 		clineEntries,
 		clineKnownModels,
 		clineModelSelected,
+		clinePassCurrentPlanName,
+		clinePassPlanFeatures,
+		clinePassSubscriptionError,
+		clinePassSubscriptionStatus,
 		deviceError,
 		deviceStatus,
 		deviceUserCode,

--- a/apps/cli/src/tui/views/onboarding/keyboard.ts
+++ b/apps/cli/src/tui/views/onboarding/keyboard.ts
@@ -12,6 +12,7 @@ import {
 	type MenuOption,
 	type OnboardingStep,
 	THINKING_LEVELS,
+	type ClinePassSubscriptionStatus,
 	type ThinkingLevel,
 } from "./model";
 
@@ -26,6 +27,7 @@ export function useOnboardingKeyboard(input: {
 	modelList: SearchableListState;
 	clineEntries: ClineModelPickerEntry[];
 	clineModelSelected: number;
+	clinePassSubscriptionStatus: ClinePassSubscriptionStatus;
 	thinkingSelected: number;
 	setStep: (step: OnboardingStep) => void;
 	setMenuSelected: Dispatch<SetStateAction<number>>;
@@ -39,6 +41,8 @@ export function useOnboardingKeyboard(input: {
 	setDeviceStatus: (value: string) => void;
 	setClineModelSelected: Dispatch<SetStateAction<number>>;
 	setThinkingSelected: Dispatch<SetStateAction<number>>;
+	continueFromClinePassSubscription: () => void;
+	refreshClinePassSubscriptionStatus: () => void;
 	abortOAuth: () => void;
 	abortDeviceCode: () => void;
 	resetAuth: () => void;
@@ -93,6 +97,11 @@ export function useOnboardingKeyboard(input: {
 				input.setStep("byo_provider");
 				return;
 			}
+			if (input.step === "cline_pass_subscription") {
+				input.setStep("menu");
+				input.setMenuSelected(0);
+				return;
+			}
 			if (input.step === "cline_model") {
 				input.setStep("menu");
 				input.setMenuSelected(0);
@@ -134,6 +143,19 @@ export function useOnboardingKeyboard(input: {
 		}
 
 		if (input.step === "device_code") return;
+
+		if (input.step === "cline_pass_subscription") {
+			if (key.name === "r") {
+				input.refreshClinePassSubscriptionStatus();
+				return;
+			}
+			if (key.name === "return") {
+				if (input.clinePassSubscriptionStatus !== "loading") {
+					input.continueFromClinePassSubscription();
+				}
+			}
+			return;
+		}
 
 		if (input.step === "menu") {
 			if (key.name === "up") {

--- a/apps/cli/src/tui/views/onboarding/model.ts
+++ b/apps/cli/src/tui/views/onboarding/model.ts
@@ -8,6 +8,7 @@ export type OnboardingStep =
 	| "byo_provider"
 	| "byo_apikey"
 	| "codex_cli_setup"
+	| "cline_pass_subscription"
 	| "cline_model"
 	| "model_picker"
 	| "custom_model_id"
@@ -95,6 +96,8 @@ export interface ModelEntry {
 	name: string;
 	supportsReasoning: boolean;
 }
+
+export type ClinePassSubscriptionStatus = "loading" | "subscribed" | "unsubscribed" | "error";
 
 export interface ProviderCatalogItem {
 	id: string;

--- a/apps/cli/src/tui/views/onboarding/screens.tsx
+++ b/apps/cli/src/tui/views/onboarding/screens.tsx
@@ -486,6 +486,7 @@ export function OnboardingClinePassSubscriptionScreen(props: {
 	const subscriptionUrl = getCliSubscriptionUrl();
 	const isLoading = props.status === "loading";
 	const isSubscribed = props.status === "subscribed";
+	const isError = props.status === "error";
 
 	return (
 		<OnboardingFrame
@@ -516,6 +517,12 @@ export function OnboardingClinePassSubscriptionScreen(props: {
 					<text fg={defaultFg} selectable>
 						Current plan: {props.currentPlanName || "ClinePass"}
 					</text>
+				) : isError ? (
+					<text
+						fg={defaultFg}
+						selectable
+						content="Could not verify your ClinePass subscription. Re-check before choosing a ClinePass model."
+					/>
 				) : (
 					<text
 						fg={defaultFg}

--- a/apps/cli/src/tui/views/onboarding/screens.tsx
+++ b/apps/cli/src/tui/views/onboarding/screens.tsx
@@ -21,7 +21,11 @@ import {
 import { useTerminalBackground } from "../../hooks/use-terminal-background";
 import { getDefaultForeground, palette } from "../../palette";
 import { FIELD_ORDER } from "./fields";
-import { type MenuOption, THINKING_LEVELS } from "./model";
+import {
+	type ClinePassSubscriptionStatus,
+	type MenuOption,
+	THINKING_LEVELS,
+} from "./model";
 
 type MouseTrackerState = ReturnType<typeof useMouseTracker>;
 
@@ -469,37 +473,119 @@ export function OnboardingClineModelScreen(props: {
 	);
 }
 
-function ClinePassWarning() {
+export function OnboardingClinePassSubscriptionScreen(props: {
+	compact: boolean;
+	contentWidth: number;
+	currentPlanName: string;
+	error: string;
+	mouse: MouseTrackerState;
+	planFeatures: string[];
+	status: ClinePassSubscriptionStatus;
+}) {
 	const defaultFg = useDefaultFg();
 	const subscriptionUrl = getCliSubscriptionUrl();
+	const isLoading = props.status === "loading";
+	const isSubscribed = props.status === "subscribed";
 
 	return (
-		<box
-			flexDirection="column"
-			border
-			borderStyle="rounded"
-			borderColor="#333333"
-			paddingX={1}
-			paddingY={1}
+		<OnboardingFrame
+			compact={props.compact}
+			contentWidth={props.contentWidth}
+			mouse={props.mouse}
 		>
-			<text fg={defaultFg}>
-				<strong>Subscribe to ClinePass if you have not</strong>
-			</text>
-			<text fg="gray">Visit this page before choosing a ClinePass model:</text>
-			<text fg={palette.act} selectable>
-				<a href={subscriptionUrl}>{subscriptionUrl}</a>
-			</text>
-			<text fg="gray">
+			<box
+				flexDirection="column"
+				border
+				borderStyle="rounded"
+				borderColor={isSubscribed ? palette.success : "yellow"}
+				paddingX={1}
+				paddingY={1}
+			>
+				<text fg={isSubscribed ? palette.success : "yellow"}>
+					{isSubscribed
+						? "ClinePass subscription active"
+						: "ClinePass subscription required"}
+				</text>
+
+				{isLoading ? (
+					<box flexDirection="row" gap={1}>
+						<spinner name="dots" color="gray" />
+						<text fg="gray">Checking your ClinePass subscription...</text>
+					</box>
+				) : isSubscribed ? (
+					<text fg={defaultFg} selectable>
+						Current plan: {props.currentPlanName || "ClinePass"}
+					</text>
+				) : (
+					<text
+						fg={defaultFg}
+						selectable
+						content="No access to ClinePass subscription models yet. Subscribe to ClinePass, the low cost open weights model coding plan."
+					/>
+				)}
+
+				{props.status === "error" &&
+					props.error &&
+					props.error !== "no plan found for user" && (
+						<text fg="red" selectable>
+							{props.error}
+						</text>
+					)}
+
+				{!isSubscribed && props.planFeatures.length > 0 && (
+					<box flexDirection="column" marginTop={1}>
+						<text fg={defaultFg}>ClinePass includes:</text>
+						{props.planFeatures.map((feature) => {
+							if (
+								feature === "Generous limits and reliable access" ||
+								feature === "Built for as many programmers as possible"
+							) {
+								return null;
+							}
+
+							return (
+								<text key={feature} fg={defaultFg} selectable>
+									<span fg="green">✓ </span>
+									<span>{feature}</span>
+								</text>
+							);
+						})}
+					</box>
+				)}
+
+				{!isSubscribed && (
+					<box flexDirection="column" marginTop={1}>
+						<box flexDirection="row">
+							<text fg="gray">Subscribe: </text>
+							<text fg="cyan" selectable>
+								<a href={subscriptionUrl}>Open subscription page</a>
+							</text>
+						</box>
+						<box flexDirection="row">
+							<text fg="gray">URL: </text>
+							<text fg="cyan" selectable>
+								<a href={subscriptionUrl}>{subscriptionUrl}</a>
+							</text>
+						</box>
+						<text fg="gray">
+							<em>You can highlight/select the URL text to copy it.</em>
+						</text>
+					</box>
+				)}
+			</box>
+
+			<text fg="gray" paddingX={1}>
 				<em>
-					You can CMD/Ctrl+Click the link to open or highlight to copy it.
+					{isLoading
+						? "Checking subscription, Ctrl+C to exit"
+						: "Enter to continue, R to re-check, Esc to go back, Ctrl+C to exit"}
 				</em>
 			</text>
-		</box>
+		</OnboardingFrame>
 	);
 }
 
 export function OnboardingModelPickerScreen(props: {
-	activeProviderId: string;
 	activeProviderName: string;
 	compact: boolean;
 	contentWidth: number;
@@ -515,8 +601,6 @@ export function OnboardingModelPickerScreen(props: {
 			contentWidth={props.contentWidth}
 			mouse={props.mouse}
 		>
-			{props.activeProviderId === "cline-pass" && <ClinePassWarning />}
-
 			<text fg={defaultFg} paddingX={1}>
 				<strong>Choose a model for {props.activeProviderName}</strong>
 			</text>

--- a/apps/cli/src/tui/views/onboarding/view.tsx
+++ b/apps/cli/src/tui/views/onboarding/view.tsx
@@ -6,6 +6,7 @@ import { useOnboardingController } from "./controller";
 import { getOAuthProviderLabel, type OnboardingResult } from "./model";
 import {
 	OnboardingClineModelScreen,
+	OnboardingClinePassSubscriptionScreen,
 	OnboardingCodexCliScreen,
 	OnboardingCustomModelIdScreen,
 	OnboardingDeviceCodeScreen,
@@ -121,10 +122,23 @@ export function OnboardingView(props: OnboardingViewProps) {
 		);
 	}
 
+	if (state.step === "cline_pass_subscription") {
+		return (
+			<OnboardingClinePassSubscriptionScreen
+				compact={compact}
+				contentWidth={contentWidth}
+				currentPlanName={state.clinePassCurrentPlanName}
+				error={state.clinePassSubscriptionError}
+				mouse={mouse}
+				planFeatures={state.clinePassPlanFeatures}
+				status={state.clinePassSubscriptionStatus}
+			/>
+		);
+	}
+
 	if (state.step === "model_picker") {
 		return (
 			<OnboardingModelPickerScreen
-				activeProviderId={state.activeProviderId}
 				activeProviderName={state.activeProviderName}
 				compact={compact}
 				contentWidth={contentWidth}

--- a/apps/cli/src/utils/cline-pass-errors.ts
+++ b/apps/cli/src/utils/cline-pass-errors.ts
@@ -1,4 +1,5 @@
 import {
+	type ClineSubscriptionPlan,
 	getClineOrgIndividualInferenceSubscriptionMessage,
 	isClineNotSubscribedError,
 	isClineNotSubscribedMessage,
@@ -19,6 +20,14 @@ export function getCliSubscriptionUrl(): string {
 
 export function getCliNotSubscribedMessage(): string {
 	return `No access to ClinePass subscription models yet. Subscribe to ClinePass, the low cost open weights model coding plan: ${getCliSubscriptionUrl()}`;
+}
+
+export function getIndividualPlanFeatures(
+	plans: ClineSubscriptionPlan[],
+): string[] {
+	const planWithFeatures = plans.find((plan) => plan.interval === "Monthly");
+
+	return planWithFeatures?.features?.included ?? [];
 }
 
 function isFormattedClinePassSubscriptionMessage(message: string): boolean {

--- a/sdk/packages/core/src/account/cline-account-service.test.ts
+++ b/sdk/packages/core/src/account/cline-account-service.test.ts
@@ -153,6 +153,40 @@ describe("ClineAccountService", () => {
 		expect(plans).toEqual(plansPayload);
 	});
 
+	it("fetches the current user's subscription plan", async () => {
+		const planPayload = {
+			plan: {
+				id: "plan-1",
+				displayName: "ClinePass Monthly",
+				interval: "Monthly",
+			},
+			planHistoryId: "history-1",
+			subscriptionId: "sub-1",
+			userId: "user-1",
+		};
+		const fetchImpl = vi.fn(async (input: unknown, init?: RequestInit) => {
+			expect(String(input)).toBe(
+				"https://api.cline.bot/api/v1/users/me/plan",
+			);
+			expect(init?.headers).toMatchObject({
+				Authorization: "Bearer workos:token-123",
+			});
+			return new Response(
+				JSON.stringify({ success: true, data: planPayload }),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+		});
+
+		const service = new ClineAccountService({
+			apiBaseUrl: "https://api.cline.bot",
+			getAuthToken: async () => "workos:token-123",
+			fetchImpl: fetchImpl as unknown as typeof fetch,
+		});
+
+		const plan = await service.fetchCurrentUserPlan();
+		expect(plan).toEqual(planPayload);
+	});
+
 	it("fetches remote config with fallback org selected", async () => {
 		const remoteConfigPayload = {
 			organizationId: "org-fallback",

--- a/sdk/packages/core/src/account/cline-account-service.ts
+++ b/sdk/packages/core/src/account/cline-account-service.ts
@@ -9,6 +9,7 @@ import type {
 	ClineOrganization,
 	ClineSubscriptionPlan,
 	FeaturebaseTokenResponse,
+	UserCurrentPlan,
 	UserRemoteConfigResponse,
 } from "./types";
 
@@ -154,6 +155,10 @@ export class ClineAccountService {
 		return this.request<ClineSubscriptionPlan[]>(
 			`${path.pathname}${path.search}`,
 		);
+	}
+
+	public async fetchCurrentUserPlan(): Promise<UserCurrentPlan | undefined> {
+		return this.request<UserCurrentPlan | undefined>("/api/v1/users/me/plan");
 	}
 
 	public async fetchOrganization(
@@ -334,9 +339,7 @@ export class ClineAccountService {
 					if (!envelope.success) {
 						throw new Error(envelope.error || "Cline account request failed");
 					}
-					if (envelope.data !== undefined) {
-						return envelope.data;
-					}
+					return envelope.data as T;
 				}
 			}
 

--- a/sdk/packages/core/src/account/index.ts
+++ b/sdk/packages/core/src/account/index.ts
@@ -20,6 +20,7 @@ export type {
 	ClineOrganization,
 	ClineSubscriptionPlan,
 	FeaturebaseTokenResponse,
+	UserCurrentPlan,
 	UserRemoteConfigOrganization,
 	UserRemoteConfigResponse,
 } from "./types";

--- a/sdk/packages/core/src/account/types.ts
+++ b/sdk/packages/core/src/account/types.ts
@@ -97,6 +97,18 @@ export interface ClineSubscriptionPlan {
 	[key: string]: unknown;
 }
 
+export interface UserCurrentPlan {
+	cancelAt?: string;
+	canceledAt?: string;
+	currentPeriodEnd?: string;
+	currentPeriodStart?: string;
+	plan?: ClineSubscriptionPlan | null;
+	planHistoryId?: string;
+	subscriptionId?: string;
+	userId?: string;
+	[key: string]: unknown;
+}
+
 export interface ClineAccountOrganizationUsageTransaction {
 	aiInferenceProviderName: string;
 	aiModelName: string;

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -130,6 +130,7 @@ export {
 	RpcClineAccountService,
 	type UserRemoteConfigOrganization,
 	type UserRemoteConfigResponse,
+	type UserCurrentPlan,
 } from "./account";
 export {
 	createOAuthClientCallbacks,

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
@@ -1496,7 +1496,10 @@ describe("SessionRuntime real AgentRuntime smoke", () => {
 			"assistant",
 			"user",
 		]);
-		expect(session.getMessages().at(-1)?.content[0]?.type).toBe("tool_result");
+		const lastContent = session.getMessages().at(-1)?.content[0];
+		expect(typeof lastContent === "object" ? lastContent.type : undefined).toBe(
+			"tool_result",
+		);
 	});
 });
 


### PR DESCRIPTION
### Description

This PR introduces an intermediate step before the Cline pass model selection that verifies subscription status and prompts the user to subscribe.

### Test Procedure

Tested locally
<img width="532" height="273" alt="image" src="https://github.com/user-attachments/assets/57d5dd32-5e96-43a7-9e3d-c2980322570f" />


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)