### PR TITLE
feat(cli): promote Cline Pass in startup notice

### DIFF
--- a/apps/cli/src/kanban-migration/notice-dialog.tsx
+++ b/apps/cli/src/kanban-migration/notice-dialog.tsx
@@ -1,7 +1,10 @@
 // @jsxImportSource @opentui/react
 import type { ChoiceContext } from "@opentui-ui/dialog";
 import { useDialogKeyboard } from "@opentui-ui/dialog/react";
+import open from "open";
+import { useCallback, useMemo, useState } from "react";
 import { palette } from "../tui/palette";
+import { getCliSubscriptionUrl } from "../utils/cline-pass-errors";
 import type { CliMigrationNotice } from "./notice";
 
 export function MigrationNoticeContent(
@@ -10,10 +13,29 @@ export function MigrationNoticeContent(
 	},
 ) {
 	const { dialogId, notice, resolve } = props;
+	const subscriptionUrl = useMemo(() => getCliSubscriptionUrl(), []);
+	const [status, setStatus] = useState<string | undefined>();
+
+	const openSubscriptionPage = useCallback(() => {
+		setStatus("Opening Cline Pass in your browser...");
+		void open(subscriptionUrl, { wait: false })
+			.then(() => {
+				setStatus("Opened Cline Pass in your browser.");
+			})
+			.catch(() => {
+				setStatus(
+					"Could not open the browser automatically. Use the URL below.",
+				);
+			});
+	}, [subscriptionUrl]);
 
 	useDialogKeyboard((key) => {
 		if (key.name === "escape") {
 			resolve(true);
+			return;
+		}
+		if (key.name === "return" || key.name === "enter") {
+			openSubscriptionPage();
 		}
 	}, dialogId);
 
@@ -22,25 +44,24 @@ export function MigrationNoticeContent(
 			<text fg={palette.act}>{notice.title}</text>
 			<box flexDirection="column">
 				<text selectable>
-					We rebuilt the CLI from the ground up using the new Cline SDK. Learn
-					more:{" "}
-					<a href="https://github.com/cline/cline">
-						<span fg={palette.act}>https://github.com/cline/cline</span>
-					</a>
+					Cline Pass is a $9.99/month subscription plan to get access to the
+					latest open-weight coding models with enough quota for day-to-day
+					work, at a much lower cost than paying API costs directly.
 				</text>
-				<text selectable>
-					Running{" "}
-					<span fg="#98c379" bg="#1f2937">
-						{" cline "}
-					</span>{" "}
-					now opens the terminal UI. To open Kanban, use /quit and run{" "}
-					<span fg="#98c379" bg="#1f2937">
-						{" cline kanban "}
-					</span>{" "}
-					in your terminal
+				<text selectable>Try it now with a limited-time promo.</text>
+			</box>
+			<box flexDirection="row">
+				<text fg={palette.act} selectable>
+					<a href={subscriptionUrl}>{subscriptionUrl}</a>
 				</text>
 			</box>
-			<text fg={palette.muted}>Press Esc to close</text>
+			<box flexDirection="row">
+				<box paddingX={1} backgroundColor={palette.act}>
+					<text fg={palette.textOnSelection}>Open Cline Pass</text>
+				</box>
+			</box>
+			{status && <text fg={palette.muted}>{status}</text>}
+			<text fg={palette.muted}>Press Enter to open, Esc to close</text>
 		</box>
 	);
 }

--- a/apps/cli/src/kanban-migration/notice.test.ts
+++ b/apps/cli/src/kanban-migration/notice.test.ts
@@ -1,6 +1,12 @@
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
 	getClineCliMigrationNotice,
@@ -26,8 +32,25 @@ describe("migration notice", () => {
 	it("returns the notice for a fresh data dir", () => {
 		const dataDir = createTempDataDir();
 
-		expect(getClineCliMigrationNotice(dataDir)?.title).toBe(
-			"Welcome to the new Cline CLI",
+		expect(getClineCliMigrationNotice(dataDir)?.title).toBe("Try Cline Pass");
+	});
+
+	it("shows when only the old Kanban notice was marked as shown", () => {
+		const dataDir = createTempDataDir();
+		const noticePath = resolveCliNoticeStatePath(dataDir);
+		mkdirSync(dirname(noticePath), { recursive: true, mode: 0o700 });
+		writeFileSync(
+			noticePath,
+			`${JSON.stringify(
+				{ shown: { "cline-cli-tui-default": true } },
+				null,
+				2,
+			)}\n`,
+			"utf8",
+		);
+
+		expect(getClineCliMigrationNotice(dataDir)?.id).toBe(
+			"cline-cli-cline-pass-intro",
 		);
 	});
 
@@ -46,7 +69,7 @@ describe("migration notice", () => {
 
 		expect(
 			getClineCliMigrationNotice(dataDir, {
-				CLINE_FORCE_MIGRATION_NOTICE: "1",
+				CLINE_FORCE_CLINE_PASS_NOTICE: "1",
 			}),
 		).toBeDefined();
 	});
@@ -56,7 +79,7 @@ describe("migration notice", () => {
 
 		expect(
 			getClineCliMigrationNotice(dataDir, {
-				CLINE_DISABLE_MIGRATION_NOTICE: "1",
+				CLINE_DISABLE_CLINE_PASS_NOTICE: "1",
 			}),
 		).toBeUndefined();
 	});
@@ -66,8 +89,8 @@ describe("migration notice", () => {
 
 		expect(
 			getClineCliMigrationNotice(dataDir, {
-				CLINE_DISABLE_MIGRATION_NOTICE: "1",
-				CLINE_FORCE_MIGRATION_NOTICE: "1",
+				CLINE_DISABLE_CLINE_PASS_NOTICE: "1",
+				CLINE_FORCE_CLINE_PASS_NOTICE: "1",
 			}),
 		).toBeDefined();
 	});
@@ -78,7 +101,7 @@ describe("migration notice", () => {
 		markClineCliMigrationNoticeShown(dataDir);
 
 		const rawState = readFileSync(resolveCliNoticeStatePath(dataDir), "utf8");
-		expect(rawState).toContain("cline-cli-tui-default");
+		expect(rawState).toContain("cline-cli-cline-pass-intro");
 		expect(getClineCliMigrationNotice(dataDir)).toBeUndefined();
 	});
 });

--- a/apps/cli/src/kanban-migration/notice.ts
+++ b/apps/cli/src/kanban-migration/notice.ts
@@ -2,9 +2,9 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { resolveClineDataDir } from "@cline/shared/storage";
 
-const NOTICE_ID = "cline-cli-tui-default";
-const FORCE_NOTICE_ENV = "CLINE_FORCE_MIGRATION_NOTICE";
-const DISABLE_NOTICE_ENV = "CLINE_DISABLE_MIGRATION_NOTICE";
+const NOTICE_ID = "cline-cli-cline-pass-intro";
+const FORCE_NOTICE_ENV = "CLINE_FORCE_CLINE_PASS_NOTICE";
+const DISABLE_NOTICE_ENV = "CLINE_DISABLE_CLINE_PASS_NOTICE";
 
 export interface CliMigrationNotice {
 	id: string;
@@ -71,7 +71,7 @@ export function getClineCliMigrationNotice(
 	}
 	return {
 		id: NOTICE_ID,
-		title: "Welcome to the new Cline CLI",
+		title: "Try Cline Pass",
 	};
 }
 

--- a/apps/cli/src/main.test.ts
+++ b/apps/cli/src/main.test.ts
@@ -630,8 +630,8 @@ describe("runCli lightweight command dispatch", () => {
 
 	it("passes the migration notice marker into interactive mode", async () => {
 		const notice = {
-			id: "cline-cli-tui-default",
-			title: "Welcome to the new Cline CLI",
+			id: "cline-cli-cline-pass-intro",
+			title: "Try Cline Pass",
 		};
 		migrationNoticeMocks.getClineCliMigrationNotice.mockReturnValue(notice);
 		Object.defineProperty(process.stdout, "isTTY", {

--- a/apps/cli/src/tests/helpers/env.ts
+++ b/apps/cli/src/tests/helpers/env.ts
@@ -124,7 +124,7 @@ export function clineEnv(
 				}),
 		CLINE_SESSION_DATA_DIR: path.join(dataDir, "sessions"),
 		CLINE_TEAM_DATA_DIR: path.join(dataDir, "teams"),
-		CLINE_DISABLE_MIGRATION_NOTICE: "1",
+		CLINE_DISABLE_CLINE_PASS_NOTICE: "1",
 		NO_UPDATE_NOTIFIER: "1",
 		CLINE_NO_AUTO_UPDATE: "1",
 		...extra,


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This updates the CLI startup notice that previously introduced the Kanban/TUI migration so it now promotes Cline Pass instead.

The existing startup notice lifecycle is preserved:

- The notice is still only prepared for interactive TTY startup.
- The notice is still skipped when launching directly into the config view.
- Dismissal is still persisted through `settings/cli-notices.json`.
- The existing force/disable environment override shape is preserved, but the names are now Cline Pass specific.

The important behavior change is the persisted notice identifier. The old Kanban notice used `cline-cli-tui-default`; this PR changes the ID to `cline-cli-cline-pass-intro` so users who already dismissed the Kanban notice will still see the Cline Pass notice once. The regression test explicitly writes the old Kanban marker and verifies the new Cline Pass notice still appears.

The dialog copy now describes Cline Pass as a `$9.99/month` subscription plan for access to the latest open-weight coding models, with a limited-time promo. The dialog also shows the existing CLI subscription URL, includes an `Open Cline Pass` action, and opens the subscription page on Enter. Esc still closes the dialog.

During implementation, the only notable integration issue was that the branch started from a local `main` that was one commit behind `origin/main`. I created `saoudrizwan/cli-cline-pass-notice`, committed the scoped CLI notice changes, then rebased onto the latest `origin/main`. The rebase initially paused while applying the notice commit because `origin/main` had just advanced, but continuing the rebase completed cleanly and the focused checks passed afterward.

### Test Procedure

Validated the notice state logic and CLI startup handoff with:

```bash
bun run test:unit src/kanban-migration/notice.test.ts src/main.test.ts
```

Validated CLI TypeScript after adding the dialog browser-open behavior:

```bash
bun run typecheck
```

Validated formatting/linting for the edited notice/helper files:

```bash
bun biome check --diagnostic-level=error apps/cli/src/kanban-migration/notice.ts apps/cli/src/kanban-migration/notice-dialog.tsx apps/cli/src/kanban-migration/notice.test.ts apps/cli/src/tests/helpers/env.ts
```

The commit hook also ran `gitleaks git --pre-commit --redact --staged --verbose` and reported no leaks.

Potentially affected behavior is limited to the CLI startup notice path. The tests cover fresh state, dismissed state, force/disable env vars, old Kanban marker compatibility, and the main CLI path that passes the notice into interactive mode.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

No screenshot captured. This is a startup TUI notice, and the behavior was validated through the focused notice and CLI startup tests listed above.

### Additional Notes

The new manual override flags are:

```bash
CLINE_FORCE_CLINE_PASS_NOTICE=1 cline
CLINE_DISABLE_CLINE_PASS_NOTICE=1 cline
```
