### PR TITLE
fix(llms): keep error detail extraction for Error instances

### DIFF
--- a/sdk/packages/llms/src/providers/format.ts
+++ b/sdk/packages/llms/src/providers/format.ts
@@ -1,48 +1,21 @@
 export function extractErrorMessage(error: unknown): string {
-	const extractStructuredMessage = (value: unknown): string | undefined => {
-		if (!value) {
-			return undefined;
-		}
-		if (typeof value === "string") {
-			try {
-				return extractStructuredMessage(JSON.parse(value));
-			} catch {
-				return value.trim() || undefined;
-			}
-		}
-		if (typeof value !== "object") {
-			return undefined;
-		}
-		if (value instanceof Error) {
-			const causeMessage = extractStructuredMessage(
-				(value as { cause?: unknown }).cause,
-			);
-			const message = value.message.trim();
-			if (causeMessage && message && causeMessage !== message) {
-				const cause = (value as { cause?: unknown }).cause;
-				const causeName =
-					cause instanceof Error && cause.name && cause.name !== "Error"
-						? `${cause.name}: `
-						: "";
-				const causeCode =
-					cause && typeof cause === "object" && "code" in cause
-						? (cause as { code?: unknown }).code
-						: undefined;
-				const codeSuffix =
-					typeof causeCode === "string" && causeCode.trim()
-						? ` (${causeCode})`
-						: "";
-				return `${message}: ${causeName}${causeMessage}${codeSuffix}`;
-			}
-			return causeMessage ?? (message || undefined);
-		}
+	// Generic SDK wrappers carry no signal of their own — when present we prefer
+	// the underlying cause/detail (e.g. AI SDK's AI_NoOutputGeneratedError).
+	const GENERIC_WRAPPER_MESSAGES = new Set([
+		"no output generated. check the stream for errors.",
+	]);
+	const isGenericWrapperMessage = (message: string): boolean =>
+		GENERIC_WRAPPER_MESSAGES.has(message.trim().toLowerCase());
+
+	// Pulls a human-readable message out of structured provider fields
+	// (error/detail/errors/responseBody) without falling back to a top-level
+	// `message`. Shared by the Error and plain-object branches.
+	const extractStructuredDetail = (value: object): string | undefined => {
 		const payload = value as {
 			error?: { message?: string } | string;
 			errors?: unknown;
 			detail?: string;
-			message?: string;
 			responseBody?: unknown;
-			cause?: unknown;
 		};
 		if (typeof payload.error === "string" && payload.error.trim()) {
 			return payload.error;
@@ -59,8 +32,8 @@ export function extractErrorMessage(error: unknown): string {
 			return payload.detail;
 		}
 		if (Array.isArray(payload.errors)) {
-			for (const error of payload.errors) {
-				const nested = extractStructuredMessage(error);
+			for (const nestedError of payload.errors) {
+				const nested = extractStructuredMessage(nestedError);
 				if (nested) {
 					return nested;
 				}
@@ -72,6 +45,67 @@ export function extractErrorMessage(error: unknown): string {
 				return nested;
 			}
 		}
+		return undefined;
+	};
+
+	const extractStructuredMessage = (value: unknown): string | undefined => {
+		if (!value) {
+			return undefined;
+		}
+		if (typeof value === "string") {
+			try {
+				return extractStructuredMessage(JSON.parse(value));
+			} catch {
+				return value.trim() || undefined;
+			}
+		}
+		if (typeof value !== "object") {
+			return undefined;
+		}
+		if (value instanceof Error) {
+			const message = value.message.trim();
+			const detailMessage = extractStructuredDetail(value);
+			const cause = (value as { cause?: unknown }).cause;
+			const causeMessage = extractStructuredMessage(cause);
+
+			// Generic wrappers (e.g. "No output generated...") only matter as a
+			// fallback — surface the underlying detail/cause instead.
+			if (message && isGenericWrapperMessage(message)) {
+				return detailMessage ?? causeMessage ?? undefined;
+			}
+
+			// Structured provider detail attached directly to the error
+			// (responseBody/detail/error fields) is more useful than the bland
+			// top-level Error message.
+			if (detailMessage && detailMessage !== message) {
+				return detailMessage;
+			}
+
+			// Otherwise preserve the wrapper message alongside its cause, e.g.
+			// "fetch failed: SocketError: other side closed (UND_ERR_SOCKET)".
+			if (causeMessage && message && causeMessage !== message) {
+				const causeName =
+					cause instanceof Error && cause.name && cause.name !== "Error"
+						? `${cause.name}: `
+						: "";
+				const causeCode =
+					cause && typeof cause === "object" && "code" in cause
+						? (cause as { code?: unknown }).code
+						: undefined;
+				const codeSuffix =
+					typeof causeCode === "string" && causeCode.trim()
+						? ` (${causeCode})`
+						: "";
+				return `${message}: ${causeName}${causeMessage}${codeSuffix}`;
+			}
+			return causeMessage ?? (message || undefined);
+		}
+
+		const detail = extractStructuredDetail(value);
+		if (detail) {
+			return detail;
+		}
+		const payload = value as { cause?: unknown; message?: string };
 		if ("cause" in payload && payload.cause !== value) {
 			const nested = extractStructuredMessage(payload.cause);
 			if (nested) {


### PR DESCRIPTION
### Related Issue

N/A — small bug fix (regression introduced by #11928). Qualifies under the template's "small bug fixes" exception.

### Description

The CLI nightly publish has been failing all day (both the scheduled `cli-publish` run and a manually dispatched one) at the **Run tests** step. The publish workflow gates on the whole monorepo's `bun run test`, so a failure in any package blocks the CLI release — and two tests in `@cline/llms` were red.

The culprit is **#11928** ("fix(llms): preserve fetch error cause details"). That PR added an `instanceof Error` branch to `extractErrorMessage` so native transport errors keep their wrapper + cause metadata (e.g. `fetch failed: SocketError: other side closed (UND_ERR_SOCKET)`). Good change, but the new branch took over **all** Error instances and regressed two pre-existing behaviors that the gateway relies on:

1. **Generic SDK wrappers were no longer dropped.** The AI SDK throws `AI_NoOutputGeneratedError` with the message `"No output generated. Check the stream for errors."` and the real error tucked in `.cause`. The new branch concatenated them, so users saw `No output generated. Check the stream for errors.: Invalid API key` instead of just `Invalid API key`.
2. **`responseBody`/`detail` on Error instances was ignored.** Provider SDK errors attach structured detail to the error object (`responseBody`, `detail`, `error` fields). Because the `instanceof Error` branch only looked at `.message` and `.cause`, an error like `Error("Bad Request")` carrying `responseBody: {"detail":"Instructions are required"}` surfaced the bland `Bad Request` instead of `Instructions are required`. That structured-field extraction only ran for plain objects, which an `Error` instance never reaches.

### Approach

Reworked the `instanceof Error` branch in `format.ts` so it:

- **Drops known generic wrappers** in favor of the underlying cause/detail. Generic messages live in a small `GENERIC_WRAPPER_MESSAGES` set (currently just the AI SDK no-output message); easy to extend if more turn up.
- **Extracts structured detail** from the error's own `responseBody`/`error`/`detail`/`errors` fields before falling back to `.message`.
- **Still preserves the transport-wrapper concat** (`fetch failed: SocketError: … (UND_ERR_SOCKET)`) that #11928 added.

To keep the Error path and the plain-object path from drifting apart again, the structured-field extraction is factored into a single shared `extractStructuredDetail` helper used by both branches.

#### Resulting priority for an `Error`

1. If the message is a generic wrapper → underlying detail, else cause.
2. Else structured detail from the error's own fields (responseBody/detail/error/errors).
3. Else wrapper message + cause concatenated (transport errors).
4. Else the plain message.

### Test Procedure

The two regressed tests already encode the intended behavior, and the transport-error test from #11928 must keep passing — all three are covered:

- `src/providers/format.test.ts` + `src/providers/gateway.test.ts`: **94 passed**
- Full `@cline/llms` suite: **334 passed / 4 skipped** (was 332 passed / **2 failed** before this change)

```
bun run test   # in sdk/packages/llms
 Test Files  20 passed | 4 skipped (24)
      Tests  334 passed | 4 skipped (338)
```

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ♻️ Refactor Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore
-   [x] Tests are passing (`bun test`) and code is formatted and linted
-   [x] I have reviewed contributor guidelines

### Additional Notes

This unblocks the CLI nightly. Once merged to `main`, the nightly can be re-triggered (`cli-publish` → `publish_target=nightly`) and should go green.
