### PR TITLE
feat(vscode): improve ClinePass provider UX

### DIFF
--- a/apps/vscode/src/shared/api.ts
+++ b/apps/vscode/src/shared/api.ts
@@ -1025,7 +1025,7 @@ export const clineDevstralModelInfo: ModelInfo = {
 }
 
 export type ClinePassModelId = keyof typeof clinePassModels
-export const clinePassDefaultModelId = "cline-pass/glm-5.1"
+export const clinePassDefaultModelId = "cline-pass/glm-5.2"
 export const clinePassModelInfoSaneDefaults: ModelInfo = {
 	maxTokens: 8_192,
 	contextWindow: 128_000,
@@ -1039,6 +1039,19 @@ export const clinePassModelInfoSaneDefaults: ModelInfo = {
 	description: "",
 }
 export const clinePassModels = {
+	"cline-pass/glm-5.2": {
+		name: "cline-pass/glm-5.2",
+		maxTokens: 131_072,
+		contextWindow: 202_752,
+		supportsImages: false,
+		supportsPromptCache: true,
+		supportsReasoning: true,
+		inputPrice: 0.98,
+		outputPrice: 3.08,
+		cacheReadsPrice: 0.182,
+		cacheWritesPrice: 0,
+		description: "",
+	},
 	"cline-pass/glm-5.1": {
 		name: "cline-pass/glm-5.1",
 		maxTokens: 131_072,

--- a/apps/vscode/webview-ui/src/components/chat/CreditLimitError.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/CreditLimitError.tsx
@@ -2,8 +2,12 @@ import { AskResponseRequest } from "@shared/proto/cline/task"
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
 import React, { useEffect, useMemo, useState } from "react"
 import VSCodeButtonLink from "@/components/common/VSCodeButtonLink"
+import { CLINE_PASS_FEATURE_FLAG } from "@/constants/featureFlags"
 import { useClineAuth } from "@/context/ClineAuthContext"
+import { useExtensionState } from "@/context/ExtensionStateContext"
+import { useHasFeatureFlag } from "@/hooks/useFeatureFlag"
 import { AccountServiceClient, TaskServiceClient } from "@/services/grpc-client"
+import { useApiConfigurationHandlers } from "../settings/utils/useApiConfigurationHandlers"
 
 interface CreditLimitErrorProps {
 	currentBalance: number
@@ -26,7 +30,12 @@ const CreditLimitError: React.FC<CreditLimitErrorProps> = ({
 	totalSpent,
 }) => {
 	const { activeOrganization } = useClineAuth()
+	const { mode, navigateToSettings } = useExtensionState()
+	const { handleModeFieldChange } = useApiConfigurationHandlers()
+	const isClinePassEnabled = useHasFeatureFlag(CLINE_PASS_FEATURE_FLAG)
 	const [fullBuyCreditsUrl, setFullBuyCreditsUrl] = useState<string>("")
+	const [isSwitchingToClinePass, setIsSwitchingToClinePass] = useState(false)
+	const [didSwitchToClinePass, setDidSwitchToClinePass] = useState(false)
 
 	const dashboardUrl = useMemo(() => {
 		return buyCreditsUrl ?? (activeOrganization?.organizationId ? DEFAULT_BUY_CREDITS_URL.ORG : DEFAULT_BUY_CREDITS_URL.USER)
@@ -48,6 +57,19 @@ const CreditLimitError: React.FC<CreditLimitErrorProps> = ({
 		fetchCallbackUrl()
 	}, [dashboardUrl])
 
+	const handleSwitchToClinePass = async () => {
+		setIsSwitchingToClinePass(true)
+		try {
+			await handleModeFieldChange({ plan: "planModeApiProvider", act: "actModeApiProvider" }, "cline-pass", mode)
+			setDidSwitchToClinePass(true)
+			navigateToSettings("api-config")
+		} catch (error) {
+			console.error("Failed to switch to ClinePass:", error)
+		} finally {
+			setIsSwitchingToClinePass(false)
+		}
+	}
+
 	// We have to divide because the balance is stored in microcredits
 	return (
 		<div className="p-2 border-none rounded-md mb-2 bg-(--vscode-textBlockQuote-background)">
@@ -65,6 +87,26 @@ const CreditLimitError: React.FC<CreditLimitErrorProps> = ({
 					) : null}
 				</div>
 			</div>
+
+			{isClinePassEnabled && (
+				<div className="mb-2">
+					<div className="text-(--vscode-descriptionForeground) text-xs mb-2">
+						Trying to use ClinePass instead of credits?
+					</div>
+					<VSCodeButton
+						appearance="secondary"
+						className="w-full"
+						disabled={isSwitchingToClinePass || didSwitchToClinePass}
+						onClick={handleSwitchToClinePass}>
+						<span className="codicon codicon-arrow-swap mr-1.5" />
+						{isSwitchingToClinePass
+							? "Switching..."
+							: didSwitchToClinePass
+								? "Switched to ClinePass"
+								: "Switch to ClinePass"}
+					</VSCodeButton>
+				</div>
+			)}
 
 			<VSCodeButtonLink className="w-full mb-2" href={fullBuyCreditsUrl}>
 				<span className="codicon codicon-credit-card mr-[6px] text-[14px]" />

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/WelcomeSection.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/WelcomeSection.tsx
@@ -2,22 +2,41 @@ import { BANNER_DATA, BannerAction, BannerActionType, BannerCardData } from "@sh
 import { EmptyRequest } from "@shared/proto/cline/common"
 import type { Worktree } from "@shared/proto/cline/worktree"
 import { TrackWorktreeViewOpenedRequest } from "@shared/proto/cline/worktree"
-import { GitBranch } from "lucide-react"
+import { GitBranch, Sparkles } from "lucide-react"
 import React, { useCallback, useEffect, useMemo, useState } from "react"
-import BannerCarousel from "@/components/common/BannerCarousel"
+import BannerCarousel, { type BannerData } from "@/components/common/BannerCarousel"
 import WhatsNewModal from "@/components/common/WhatsNewModal"
 import HistoryPreview from "@/components/history/HistoryPreview"
 import { useApiConfigurationHandlers } from "@/components/settings/utils/useApiConfigurationHandlers"
+import { Button } from "@/components/ui/button"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import HomeHeader from "@/components/welcome/HomeHeader"
 import { SuggestedTasks } from "@/components/welcome/SuggestedTasks"
 import CreateWorktreeModal from "@/components/worktrees/CreateWorktreeModal"
+import { CLINE_PASS_FEATURE_FLAG } from "@/constants/featureFlags"
 import { useClineAuth } from "@/context/ClineAuthContext"
 import { useExtensionState } from "@/context/ExtensionStateContext"
+import { useHasFeatureFlag } from "@/hooks/useFeatureFlag"
 import { AccountServiceClient, StateServiceClient, UiServiceClient, WorktreeServiceClient } from "@/services/grpc-client"
 import { convertBannerData } from "@/utils/bannerUtils"
 import { getCurrentPlatform } from "@/utils/platformUtils"
 import { WelcomeSectionProps } from "../../types/chatTypes"
+
+const CLINE_PASS_PROMO_BANNER_ID = "cline-pass-home-promo-v2"
+const DEFAULT_CLINE_APP_BASE_URL = "https://app.cline.bot"
+const CLINE_PASS_SUBSCRIPTION_PATH = "dashboard/subscription"
+
+function buildClinePassSubscriptionUrl(appBaseUrl?: string): string {
+	try {
+		const baseUrl = appBaseUrl || DEFAULT_CLINE_APP_BASE_URL
+		const base = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`
+		const url = new URL(CLINE_PASS_SUBSCRIPTION_PATH, base)
+		url.searchParams.set("personal", "true")
+		return url.toString()
+	} catch {
+		return `${DEFAULT_CLINE_APP_BASE_URL}/${CLINE_PASS_SUBSCRIPTION_PATH}?personal=true`
+	}
+}
 
 /**
  * Welcome section shown when there's no active task
@@ -58,6 +77,7 @@ export const WelcomeSection: React.FC<WelcomeSectionProps> = ({
 	}, [])
 
 	const { clineUser } = useClineAuth()
+	const isClinePassEnabled = useHasFeatureFlag(CLINE_PASS_FEATURE_FLAG)
 	const {
 		openRouterModels,
 		navigateToSettings,
@@ -68,6 +88,7 @@ export const WelcomeSection: React.FC<WelcomeSectionProps> = ({
 		welcomeBanners,
 	} = useExtensionState()
 	const { handleFieldsChange } = useApiConfigurationHandlers()
+	const [dismissedLocalBanners, setDismissedLocalBanners] = useState<Set<string>>(() => new Set())
 
 	// Open modal once we have welcome banners
 	useEffect(() => {
@@ -210,6 +231,8 @@ export const WelcomeSection: React.FC<WelcomeSectionProps> = ({
 	 * Dismissal handler - updates version tracking
 	 */
 	const handleBannerDismiss = useCallback((bannerId: string) => {
+		setDismissedLocalBanners((previous) => new Set(previous).add(bannerId))
+
 		// !! Do not continue use these version numbers or add new banners that don't have unique IDs. !!
 		// Banner versions are **deprecated**. Going forward, we are tracking which banners have
 		// been dismissed using the **banner ID**.
@@ -224,6 +247,67 @@ export const WelcomeSection: React.FC<WelcomeSectionProps> = ({
 			StateServiceClient.dismissBanner({ value: bannerId }).catch(console.error)
 		}
 	}, [])
+
+	const clinePassPromoBanner = useMemo((): BannerData | undefined => {
+		if (
+			!isClinePassEnabled ||
+			isBannerDismissed(CLINE_PASS_PROMO_BANNER_ID) ||
+			dismissedLocalBanners.has(CLINE_PASS_PROMO_BANNER_ID)
+		) {
+			return undefined
+		}
+
+		const dismissPromoBanner = () => handleBannerDismiss(CLINE_PASS_PROMO_BANNER_ID)
+		const subscriptionUrl = buildClinePassSubscriptionUrl(clineUser?.appBaseUrl)
+
+		return {
+			id: CLINE_PASS_PROMO_BANNER_ID,
+			icon: <Sparkles className="size-4 text-[var(--vscode-charts-yellow)]" />,
+			title: "Try ClinePass",
+			description: (
+				<div className="flex flex-col gap-2">
+					<p className="m-0">
+						A $9.99/month subscription for the latest open-weights models, at much lower cost than
+						paying for direct API access.
+					</p>
+					<div>
+						<Button
+							onClick={() => {
+								UiServiceClient.openUrl({ value: subscriptionUrl }).catch(console.error)
+							}}
+							size="sm">
+							Get ClinePass
+						</Button>
+					</div>
+					<button
+						className="w-fit cursor-pointer border-0 bg-transparent p-0 text-left text-xs text-[var(--vscode-textLink-foreground)] underline hover:cursor-pointer hover:text-[var(--vscode-textLink-activeForeground,var(--vscode-textLink-foreground))]"
+						onClick={async () => {
+							try {
+								await handleFieldsChange({
+									planModeApiProvider: "cline-pass",
+									actModeApiProvider: "cline-pass",
+								})
+								navigateToSettings("api-config")
+							} catch (error) {
+								console.error("Failed to switch to ClinePass:", error)
+							}
+						}}
+						type="button">
+						Switch to ClinePass provider to access subscription.
+					</button>
+				</div>
+			),
+			onDismiss: dismissPromoBanner,
+		}
+	}, [
+		clineUser?.appBaseUrl,
+		dismissedLocalBanners,
+		handleBannerDismiss,
+		handleFieldsChange,
+		isBannerDismissed,
+		isClinePassEnabled,
+		navigateToSettings,
+	])
 
 	/**
 	 * Build array of active banners for carousel
@@ -247,8 +331,9 @@ export const WelcomeSection: React.FC<WelcomeSectionProps> = ({
 		)
 
 		// Combine both sources: extension state banners first, then hardcoded banners
-		return [...extensionStateBanners, ...hardcodedBanners]
-	}, [bannerConfig, banners, clineUser, handleBannerAction, handleBannerDismiss])
+		const carouselBanners = [...extensionStateBanners, ...hardcodedBanners]
+		return clinePassPromoBanner ? [clinePassPromoBanner, ...carouselBanners] : carouselBanners
+	}, [bannerConfig, banners, clinePassPromoBanner, handleBannerAction, handleBannerDismiss])
 
 	return (
 		<div className="flex flex-col flex-1 w-full h-full p-0 m-0">
@@ -260,10 +345,10 @@ export const WelcomeSection: React.FC<WelcomeSectionProps> = ({
 				welcomeBanners={welcomeBanners}
 			/>
 			<div className="overflow-y-auto flex flex-col pb-2.5">
-				<HomeHeader shouldShowQuickWins={shouldShowQuickWins} />
 				{!showWhatsNewModal && (
 					<>
 						<BannerCarousel banners={activeBanners} />
+						<HomeHeader shouldShowQuickWins={shouldShowQuickWins} />
 						{!shouldShowQuickWins && taskHistory.length > 0 && <HistoryPreview showHistoryView={showHistoryView} />}
 						{/* Quick launch worktree button */}
 						{isGitRepo && worktreesEnabled?.featureFlag && worktreesEnabled?.user && (
@@ -313,6 +398,7 @@ export const WelcomeSection: React.FC<WelcomeSectionProps> = ({
 						)}
 					</>
 				)}
+				{showWhatsNewModal && <HomeHeader shouldShowQuickWins={shouldShowQuickWins} />}
 			</div>
 			<SuggestedTasks shouldShowQuickWins={shouldShowQuickWins} />
 

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/WelcomeSection.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/WelcomeSection.tsx
@@ -19,24 +19,11 @@ import { useExtensionState } from "@/context/ExtensionStateContext"
 import { useHasFeatureFlag } from "@/hooks/useFeatureFlag"
 import { AccountServiceClient, StateServiceClient, UiServiceClient, WorktreeServiceClient } from "@/services/grpc-client"
 import { convertBannerData } from "@/utils/bannerUtils"
+import { buildClinePassSubscriptionUrl } from "@/utils/clinePassSubscription"
 import { getCurrentPlatform } from "@/utils/platformUtils"
 import { WelcomeSectionProps } from "../../types/chatTypes"
 
 const CLINE_PASS_PROMO_BANNER_ID = "cline-pass-home-promo-v2"
-const DEFAULT_CLINE_APP_BASE_URL = "https://app.cline.bot"
-const CLINE_PASS_SUBSCRIPTION_PATH = "dashboard/subscription"
-
-function buildClinePassSubscriptionUrl(appBaseUrl?: string): string {
-	try {
-		const baseUrl = appBaseUrl || DEFAULT_CLINE_APP_BASE_URL
-		const base = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`
-		const url = new URL(CLINE_PASS_SUBSCRIPTION_PATH, base)
-		url.searchParams.set("personal", "true")
-		return url.toString()
-	} catch {
-		return `${DEFAULT_CLINE_APP_BASE_URL}/${CLINE_PASS_SUBSCRIPTION_PATH}?personal=true`
-	}
-}
 
 /**
  * Welcome section shown when there's no active task

--- a/apps/vscode/webview-ui/src/components/common/BannerCarousel.tsx
+++ b/apps/vscode/webview-ui/src/components/common/BannerCarousel.tsx
@@ -49,17 +49,22 @@ const BannerCardContent: React.FC<BannerCardContentProps> = ({ banner, isActive,
 			}}>
 			{/* Title with optional icon */}
 			<h3
-				className={cn("font-semibold mb-2 flex items-center gap-2 text-base pr-0", {
+				className={cn("font-semibold mb-2 flex items-center text-base pr-0", {
+					"gap-2": banner.icon,
 					"pr-6": showDismissButton,
 				})}>
-				<span className="shrink-0">{banner.icon}</span>
+				{banner.icon && <span className="shrink-0">{banner.icon}</span>}
 				{banner.title}
 			</h3>
 
 			{/* Description */}
-			<div className="text-sm text-description leading-relaxed [&>*:last-child]:mb-0 [&_a]:hover:underline">
-				{markdownContent}
-			</div>
+			{typeof banner.description === "string" ? (
+				<div className="text-sm text-description leading-relaxed [&>*:last-child]:mb-0 [&_a]:hover:underline">
+					{markdownContent}
+				</div>
+			) : (
+				<div className="text-sm text-description leading-relaxed">{banner.description}</div>
+			)}
 
 			{/* Action buttons */}
 			{banner.actions?.length ? (

--- a/apps/vscode/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/ApiOptions.tsx
@@ -21,7 +21,6 @@ import { BasetenProvider } from "./providers/BasetenProvider"
 import { BedrockProvider } from "./providers/BedrockProvider"
 import { CerebrasProvider } from "./providers/CerebrasProvider"
 import { ClaudeCodeProvider } from "./providers/ClaudeCodeProvider"
-import { ClinePassProvider } from "./providers/ClinePassProvider"
 import { ClineProvider } from "./providers/ClineProvider"
 import { DeepSeekProvider } from "./providers/DeepSeekProvider"
 import { DifyProvider } from "./providers/DifyProvider"
@@ -157,15 +156,24 @@ const ApiOptions = ({
 		// Filter by remote config if remoteConfiguredProviders is set
 		const remoteProviders: string[] = remoteConfigSettings?.remoteConfiguredProviders || []
 		if (remoteProviders.length > 0) {
-			providers = providers.filter((option) => remoteProviders.includes(option.value))
+			const effectiveRemoteProviders =
+				isClinePassEnabled && remoteProviders.includes("cline-pass") && !remoteProviders.includes("cline")
+					? [...remoteProviders, "cline"]
+					: remoteProviders
+			providers = providers.filter((option) => effectiveRemoteProviders.includes(option.value))
 		}
 
 		return providers
 	}, [isClinePassEnabled, remoteConfigSettings])
 
+	const getProviderDisplayLabel = useCallback((option: (typeof PROVIDERS.list)[number]) => {
+		return option.value === "cline" ? "Cline Usage-Billing" : option.label
+	}, [])
+
 	const currentProviderLabel = useMemo(() => {
-		return providerOptions.find((option) => option.value === selectedProvider)?.label || selectedProvider
-	}, [providerOptions, selectedProvider])
+		const selectedOption = providerOptions.find((option) => option.value === selectedProvider)
+		return selectedOption ? getProviderDisplayLabel(selectedOption) : selectedProvider
+	}, [getProviderDisplayLabel, providerOptions, selectedProvider])
 
 	// Sync search term with current provider when not searching
 	useEffect(() => {
@@ -177,13 +185,19 @@ const ApiOptions = ({
 	const searchableItems = useMemo(() => {
 		return providerOptions.map((option) => ({
 			value: option.value,
-			html: option.label,
+			html: getProviderDisplayLabel(option),
+			searchText:
+				option.value === "cline"
+					? "Cline Usage Billing usage based pay as you go"
+					: option.value === "cline-pass"
+						? "ClinePass subscription included models"
+						: option.label,
 		}))
-	}, [providerOptions])
+	}, [getProviderDisplayLabel, providerOptions])
 
 	const fuse = useMemo(() => {
 		return new Fuse(searchableItems, {
-			keys: ["html"],
+			keys: ["html", "searchText"],
 			threshold: 0.3,
 			shouldSort: true,
 			isCaseSensitive: false,
@@ -366,18 +380,15 @@ const ApiOptions = ({
 				<HicapProvider currentMode={currentMode} isPopup={isPopup} showModelOptions={showModelOptions} />
 			)}
 
-			{apiConfiguration && selectedProvider === "cline" && (
+			{apiConfiguration && (selectedProvider === "cline" || (isClinePassEnabled && selectedProvider === "cline-pass")) && (
 				<ClineProvider
 					currentMode={currentMode}
 					initialModelTab={initialModelTab}
 					isClinePassEnabled={isClinePassEnabled}
 					isPopup={isPopup}
+					selectedProvider={selectedProvider}
 					showModelOptions={showModelOptions}
 				/>
-			)}
-
-			{apiConfiguration && isClinePassEnabled && selectedProvider === "cline-pass" && (
-				<ClinePassProvider currentMode={currentMode} isPopup={isPopup} showModelOptions={showModelOptions} />
 			)}
 
 			{apiConfiguration && selectedProvider === "asksage" && (

--- a/apps/vscode/webview-ui/src/components/settings/ClineAccountInfoCard.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/ClineAccountInfoCard.tsx
@@ -29,7 +29,7 @@ export const ClineAccountInfoCard = () => {
 		<div className="max-w-[600px]">
 			{user ? (
 				<VSCodeButton appearance="secondary" onClick={handleShowAccount}>
-					View Billing & Usage
+					View Billing History
 				</VSCodeButton>
 			) : (
 				<div>
@@ -37,7 +37,7 @@ export const ClineAccountInfoCard = () => {
 						Sign Up with Cline
 						{isLoading && (
 							<span className="ml-1 animate-spin">
-								<span className="codicon codicon-refresh"></span>
+								<span className="codicon codicon-refresh" />
 							</span>
 						)}
 					</VSCodeButton>

--- a/apps/vscode/webview-ui/src/components/settings/providers/ClinePassProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/ClinePassProvider.tsx
@@ -6,14 +6,26 @@ import {
 	resolveClinePassModelInfo,
 } from "@shared/api"
 import { EmptyRequest } from "@shared/proto/cline/common"
+import type { Mode } from "@shared/storage/types"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { ModelsServiceClient } from "@/services/grpc-client"
 import { ClineAccountInfoCard } from "../ClineAccountInfoCard"
 import ClineModelPicker from "../ClineModelPicker"
-import { ClineProvider } from "./ClineProvider"
 
-export const ClinePassProvider: typeof ClineProvider = (props) => {
+interface ClinePassProviderProps {
+	showModelOptions: boolean
+	isPopup?: boolean
+	currentMode: Mode
+	showAccountCard?: boolean
+}
+
+export const ClinePassProvider = ({
+	showModelOptions,
+	isPopup,
+	currentMode,
+	showAccountCard = true,
+}: ClinePassProviderProps) => {
 	const { openRouterModels } = useExtensionState()
 	const openRouterModelsByName = useMemo(() => buildModelInfoNameMap(openRouterModels), [openRouterModels])
 	const [clinePassRecommendedModels, setClinePassRecommendedModels] = useState<Record<string, ModelInfo> | undefined>(undefined)
@@ -63,18 +75,23 @@ export const ClinePassProvider: typeof ClineProvider = (props) => {
 
 	return (
 		<div>
-			<div style={{ marginBottom: 14, marginTop: 4 }}>
-				<ClineAccountInfoCard />
-			</div>
+			{showAccountCard && (
+				<div style={{ marginBottom: 14, marginTop: 4 }}>
+					<ClineAccountInfoCard />
+				</div>
+			)}
 
-			<ClineModelPicker
-				{...props}
-				defaultModelId={clinePassDefaultModel}
-				modelIdFieldPair={{ plan: "planModeClinePassModelId", act: "actModeClinePassModelId" }}
-				modelInfoFieldPair={{ plan: "planModeClinePassModelInfo", act: "actModeClinePassModelInfo" }}
-				models={clinePassModelOptions}
-				showFeaturedModels={false}
-			/>
+			{showModelOptions && (
+				<ClineModelPicker
+					currentMode={currentMode}
+					defaultModelId={clinePassDefaultModel}
+					isPopup={isPopup}
+					modelIdFieldPair={{ plan: "planModeClinePassModelId", act: "actModeClinePassModelId" }}
+					modelInfoFieldPair={{ plan: "planModeClinePassModelInfo", act: "actModeClinePassModelInfo" }}
+					models={clinePassModelOptions}
+					showFeaturedModels={false}
+				/>
+			)}
 		</div>
 	)
 }

--- a/apps/vscode/webview-ui/src/components/settings/providers/ClineProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/ClineProvider.tsx
@@ -1,16 +1,42 @@
-import { Mode } from "@shared/storage/types"
+import type { ApiProvider } from "@shared/api"
+import type { Mode } from "@shared/storage/types"
+import styled from "styled-components"
+import VSCodeButtonLink from "@/components/common/VSCodeButtonLink"
+import { useClineAuth } from "@/context/ClineAuthContext"
 import { ClineAccountInfoCard } from "../ClineAccountInfoCard"
 import ClineModelPicker from "../ClineModelPicker"
+import { useApiConfigurationHandlers } from "../utils/useApiConfigurationHandlers"
+import { ClinePassProvider } from "./ClinePassProvider"
 
 /**
  * Props for the ClineProvider component
  */
-interface ClineProviderProps {
+export interface ClineProviderProps {
 	showModelOptions: boolean
 	isPopup?: boolean
 	currentMode: Mode
 	initialModelTab?: "recommended" | "free"
 	isClinePassEnabled?: boolean
+	selectedProvider?: ApiProvider
+}
+
+type ClineBillingRoute = "cline" | "cline-pass"
+
+const CLINE_PASS_SUBSCRIBE_PATH = "dashboard/subscription"
+
+function buildClinePassSubscribeUrl(appBaseUrl?: string): string | undefined {
+	if (!appBaseUrl) {
+		return undefined
+	}
+
+	try {
+		const base = appBaseUrl.endsWith("/") ? appBaseUrl : `${appBaseUrl}/`
+		const url = new URL(CLINE_PASS_SUBSCRIBE_PATH, base)
+		url.searchParams.set("personal", "true")
+		return url.toString()
+	} catch {
+		return undefined
+	}
 }
 
 /**
@@ -22,23 +48,129 @@ export const ClineProvider = ({
 	currentMode,
 	initialModelTab,
 	isClinePassEnabled,
+	selectedProvider,
 }: ClineProviderProps) => {
+	const { handleModeFieldChange } = useApiConfigurationHandlers()
+	const { clineUser } = useClineAuth()
+	const activeRoute: ClineBillingRoute = selectedProvider === "cline-pass" && isClinePassEnabled ? "cline-pass" : "cline"
+	const clinePassSubscribeUrl = buildClinePassSubscribeUrl(clineUser?.appBaseUrl)
+
+	const handleRouteChange = async (route: ClineBillingRoute) => {
+		if (route === activeRoute) {
+			return
+		}
+
+		await handleModeFieldChange({ plan: "planModeApiProvider", act: "actModeApiProvider" }, route, currentMode)
+	}
+
 	return (
 		<div>
-			{/* Cline Account Info Card */}
-			<div style={{ marginBottom: 14, marginTop: 4 }}>
-				<ClineAccountInfoCard />
-			</div>
+			{isClinePassEnabled && (
+				<RouteContainer>
+					<RouteStatus>
+						{activeRoute === "cline-pass" ? (
+							<>
+								ClinePass lets you use the best open weights models.{" "}
+								<RouteLink
+									href="#"
+									onClick={(event) => {
+										event.preventDefault()
+										handleRouteChange("cline").catch((error) => console.error("Failed to switch to Cline:", error))
+									}}>
+									Switch to Cline Usage-Billing for other models.
+								</RouteLink>
+							</>
+						) : (
+							<>
+								Usage-Billing models bill to your Cline account balance.{" "}
+								<RouteLink
+									href="#"
+									onClick={(event) => {
+										event.preventDefault()
+										handleRouteChange("cline-pass").catch((error) =>
+											console.error("Failed to switch to ClinePass:", error),
+										)
+									}}>
+									Switch to ClinePass provider to access subscription.
+								</RouteLink>
+							</>
+						)}
+					</RouteStatus>
+					<RouteActions>
+						{activeRoute === "cline" && <ClineAccountInfoCard />}
+						{activeRoute === "cline-pass" && clinePassSubscribeUrl && (
+							<>
+								<VSCodeButtonLink appearance="secondary" href={clinePassSubscribeUrl}>
+									Manage ClinePass
+								</VSCodeButtonLink>
+								<VSCodeButtonLink appearance="secondary" href={clinePassSubscribeUrl}>
+									View Billing & Usage
+								</VSCodeButtonLink>
+							</>
+						)}
+					</RouteActions>
+				</RouteContainer>
+			)}
+			{!isClinePassEnabled && (
+				<StandaloneRouteActions>
+					<ClineAccountInfoCard />
+				</StandaloneRouteActions>
+			)}
 
 			{showModelOptions && (
-				<ClineModelPicker
-					currentMode={currentMode}
-					initialTab={initialModelTab}
-					isClinePassEnabled={isClinePassEnabled}
-					isPopup={isPopup}
-					showProviderRouting={true}
-				/>
+				activeRoute === "cline-pass" ? (
+					<ClinePassProvider
+						currentMode={currentMode}
+						isPopup={isPopup}
+						showAccountCard={false}
+						showModelOptions={showModelOptions}
+					/>
+				) : (
+					<ClineModelPicker
+						currentMode={currentMode}
+						initialTab={initialModelTab}
+						isClinePassEnabled={isClinePassEnabled}
+						isPopup={isPopup}
+						showProviderRouting={true}
+					/>
+				)
 			)}
 		</div>
 	)
 }
+
+const RouteContainer = styled.div`
+	margin-bottom: 10px;
+`
+
+const RouteStatus = styled.div`
+	font-size: 11px;
+	line-height: 1.35;
+	color: var(--vscode-descriptionForeground);
+`
+
+const RouteLink = styled.a`
+	color: var(--vscode-textLink-foreground);
+	font: inherit;
+	line-height: inherit;
+	cursor: pointer !important;
+	text-decoration: none;
+
+	&:hover {
+		color: var(--vscode-textLink-activeForeground, var(--vscode-textLink-foreground));
+		cursor: pointer !important;
+		text-decoration: underline;
+	}
+`
+
+const RouteActions = styled.div`
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 6px;
+	margin-top: 8px;
+`
+
+const StandaloneRouteActions = styled(RouteActions)`
+	margin: 4px 0 14px;
+`

--- a/apps/vscode/webview-ui/src/components/settings/providers/ClineProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/ClineProvider.tsx
@@ -3,6 +3,7 @@ import type { Mode } from "@shared/storage/types"
 import styled from "styled-components"
 import VSCodeButtonLink from "@/components/common/VSCodeButtonLink"
 import { useClineAuth } from "@/context/ClineAuthContext"
+import { buildClinePassSubscriptionUrl } from "@/utils/clinePassSubscription"
 import { ClineAccountInfoCard } from "../ClineAccountInfoCard"
 import ClineModelPicker from "../ClineModelPicker"
 import { useApiConfigurationHandlers } from "../utils/useApiConfigurationHandlers"
@@ -22,23 +23,6 @@ export interface ClineProviderProps {
 
 type ClineBillingRoute = "cline" | "cline-pass"
 
-const CLINE_PASS_SUBSCRIBE_PATH = "dashboard/subscription"
-
-function buildClinePassSubscribeUrl(appBaseUrl?: string): string | undefined {
-	if (!appBaseUrl) {
-		return undefined
-	}
-
-	try {
-		const base = appBaseUrl.endsWith("/") ? appBaseUrl : `${appBaseUrl}/`
-		const url = new URL(CLINE_PASS_SUBSCRIBE_PATH, base)
-		url.searchParams.set("personal", "true")
-		return url.toString()
-	} catch {
-		return undefined
-	}
-}
-
 /**
  * The Cline provider configuration component
  */
@@ -53,7 +37,7 @@ export const ClineProvider = ({
 	const { handleModeFieldChange } = useApiConfigurationHandlers()
 	const { clineUser } = useClineAuth()
 	const activeRoute: ClineBillingRoute = selectedProvider === "cline-pass" && isClinePassEnabled ? "cline-pass" : "cline"
-	const clinePassSubscribeUrl = buildClinePassSubscribeUrl(clineUser?.appBaseUrl)
+	const clinePassSubscribeUrl = clineUser ? buildClinePassSubscriptionUrl(clineUser.appBaseUrl) : undefined
 
 	const handleRouteChange = async (route: ClineBillingRoute) => {
 		if (route === activeRoute) {
@@ -98,15 +82,19 @@ export const ClineProvider = ({
 					</RouteStatus>
 					<RouteActions>
 						{activeRoute === "cline" && <ClineAccountInfoCard />}
-						{activeRoute === "cline-pass" && clinePassSubscribeUrl && (
-							<>
-								<VSCodeButtonLink appearance="secondary" href={clinePassSubscribeUrl}>
-									Manage ClinePass
-								</VSCodeButtonLink>
-								<VSCodeButtonLink appearance="secondary" href={clinePassSubscribeUrl}>
-									View Billing & Usage
-								</VSCodeButtonLink>
-							</>
+						{activeRoute === "cline-pass" && (
+							clinePassSubscribeUrl ? (
+								<>
+									<VSCodeButtonLink appearance="secondary" href={clinePassSubscribeUrl}>
+										Manage ClinePass
+									</VSCodeButtonLink>
+									<VSCodeButtonLink appearance="secondary" href={clinePassSubscribeUrl}>
+										View Billing & Usage
+									</VSCodeButtonLink>
+								</>
+							) : (
+								<ClineAccountInfoCard />
+							)
 						)}
 					</RouteActions>
 				</RouteContainer>

--- a/apps/vscode/webview-ui/src/utils/clinePassSubscription.ts
+++ b/apps/vscode/webview-ui/src/utils/clinePassSubscription.ts
@@ -1,0 +1,14 @@
+const DEFAULT_CLINE_APP_BASE_URL = "https://app.cline.bot"
+const CLINE_PASS_SUBSCRIPTION_PATH = "dashboard/subscription"
+
+export function buildClinePassSubscriptionUrl(appBaseUrl?: string): string {
+	try {
+		const baseUrl = appBaseUrl || DEFAULT_CLINE_APP_BASE_URL
+		const base = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`
+		const url = new URL(CLINE_PASS_SUBSCRIPTION_PATH, base)
+		url.searchParams.set("personal", "true")
+		return url.toString()
+	} catch {
+		return `${DEFAULT_CLINE_APP_BASE_URL}/${CLINE_PASS_SUBSCRIPTION_PATH}?personal=true`
+	}
+}


### PR DESCRIPTION
<img width="381" height="242" alt="Code 2026-06-28 14 48 14" src="https://github.com/user-attachments/assets/0b82632c-b45b-449b-a2c2-25c0c2551682" />

<img width="359" height="509" alt="Code 2026-06-28 15 31 30" src="https://github.com/user-attachments/assets/61dab28c-d681-45fb-89ea-0f941191538c" />



This improves the VS Code extension UX around Cline Usage-Billing and ClinePass. Previously, Cline and ClinePass behaved like two unrelated providers: users had to know which provider to select, had little guidance about when to switch, and could hit credit-balance errors even when they were trying to use their ClinePass subscription.

The approach here keeps both providers available in the provider dropdown, but makes the Cline/ClinePass relationship clearer:

- Renames the `Cline` provider label in the settings dropdown to `Cline Usage-Billing`.
- Keeps `ClinePass` available as its own provider option when the ClinePass feature flag is enabled.
- Consolidates the Cline and ClinePass settings UI through the Cline provider component, so switching between the two presents as a related billing/provider choice rather than two unrelated settings pages.
- Replaces the earlier tab-style switcher with inline helper links in the provider description:
  - Usage-Billing explains that models bill to the Cline account balance and links to switch to ClinePass.
  - ClinePass explains that it provides open-weights models and links back to Cline Usage-Billing for other models.
- Adds ClinePass account actions under the ClinePass settings state, including `Manage ClinePass` and `View Billing & Usage`, both linking to the ClinePass subscription page.
- Renames the Cline account action from `View Billing & Usage` to `View Billing History` for the Usage-Billing path.

This also adds a home-screen ClinePass promo banner above the home header. The banner:

- Shows when the ClinePass feature flag is enabled and the banner has not been dismissed.
- Uses the title `Try ClinePass` and explains the `$9.99/month` subscription.
- Includes a `Get ClinePass` button that opens the subscription page.
- Includes an underlined `Switch to ClinePass provider to access subscription.` link that switches both plan and act providers to ClinePass and opens API settings.
- Only dismisses when the user clicks the `X`; opening the subscription page or switching providers does not dismiss it, so users can return to the switch action if needed.

The insufficient-balance error now also points users toward the provider switch. When ClinePass is enabled, the error card shows `Trying to use ClinePass instead of credits?` with a `Switch to ClinePass` button. That button switches the current provider to ClinePass and opens API settings so the user can see the selected provider/model.

Finally, this changes the static ClinePass fallback default model to `cline-pass/glm-5.2`, adding a fallback model entry so users without a saved ClinePass model land on the expected default.
