### PR TITLE
fix(vscode): prefer canonical Cline Z.ai model ids

### DIFF
--- a/apps/vscode/src/core/controller/models/__tests__/refreshClineModels.test.ts
+++ b/apps/vscode/src/core/controller/models/__tests__/refreshClineModels.test.ts
@@ -135,4 +135,72 @@ describe("refreshClineModels", () => {
 		expect(fable1m.contextWindow).to.equal(1_000_000)
 		expect(fable1m.tiers).to.not.equal(undefined)
 	})
+
+	it("prefers Vercel-style Z.ai IDs when the Cline model list includes OpenRouter aliases", async () => {
+		sandbox.stub(getFeatureFlagsService(), "getBooleanFlagEnabled").callsFake((flag) => {
+			return flag === FeatureFlag.EXTENSION_CLINE_MODELS_ENDPOINT
+		})
+		sandbox.stub(ClineEnv, "config").returns({
+			environment: Environment.production,
+			appBaseUrl: "https://app.cline-mock.bot",
+			apiBaseUrl: "https://api.cline-mock.bot",
+			mcpBaseUrl: "https://api.cline-mock.bot/v1/mcp",
+		})
+		sandbox.stub(StateManager, "get").returns({
+			getModelsCache: () => null,
+			setModelsCache: () => {},
+		} as unknown as StateManager)
+		sandbox.stub(disk, "ensureCacheDirectoryExists").resolves("/tmp")
+		sandbox.stub(fs, "writeFile").resolves()
+		sandbox.stub(axios, "get").resolves({
+			data: {
+				data: [
+					{
+						id: "z-ai/glm-5.2",
+						name: "OpenRouter GLM 5.2",
+						description: "OpenRouter alias",
+						context_length: 128_000,
+						top_provider: {
+							max_completion_tokens: 8_192,
+							context_length: 128_000,
+							is_moderated: false,
+						},
+						architecture: {
+							modality: "text->text",
+						},
+						pricing: {
+							prompt: "0.00000098",
+							completion: "0.00000308",
+						},
+						supported_parameters: ["include_reasoning", "reasoning"],
+					},
+					{
+						id: "zai/glm-5.2",
+						name: "GLM 5.2",
+						description: "Vercel canonical ID",
+						context_length: 1_000_000,
+						top_provider: {
+							max_completion_tokens: 131_072,
+							context_length: 1_000_000,
+							is_moderated: false,
+						},
+						architecture: {
+							modality: "text->text",
+						},
+						pricing: {
+							prompt: "0.0000015",
+							completion: "0.0000045",
+						},
+						supported_parameters: ["include_reasoning", "reasoning"],
+					},
+				],
+			},
+		})
+
+		const models = await refreshClineModels({} as Controller)
+
+		expect(models["zai/glm-5.2"]).to.not.equal(undefined)
+		expect(models["zai/glm-5.2"].contextWindow).to.equal(1_000_000)
+		expect(models["z-ai/glm-5.2"]).to.equal(undefined)
+	})
 })

--- a/apps/vscode/src/core/controller/models/refreshClineModels.ts
+++ b/apps/vscode/src/core/controller/models/refreshClineModels.ts
@@ -87,6 +87,37 @@ interface ClineRawModelInfo {
 // Track pending refresh promise to prevent duplicate concurrent fetches
 let pendingRefresh: Promise<Record<string, ModelInfo>> | null = null
 
+interface ModelIdAliasRule {
+	canonicalPrefix: string
+	aliasPrefix: string
+}
+
+// Mirrors @cline/llms VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES.
+const VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES = [
+	{ canonicalPrefix: "zai/", aliasPrefix: "z-ai/" },
+] as const satisfies readonly ModelIdAliasRule[]
+
+function preferCanonicalModelIds<T>(models: Record<string, T>, rules: readonly ModelIdAliasRule[]): Record<string, T> {
+	return Object.fromEntries(
+		Object.entries(models).filter(([modelId]) => {
+			for (const rule of rules) {
+				if (!modelId.startsWith(rule.aliasPrefix)) {
+					continue
+				}
+				const canonicalModelId = `${rule.canonicalPrefix}${modelId.slice(rule.aliasPrefix.length)}`
+				if (canonicalModelId in models) {
+					return false
+				}
+			}
+			return true
+		}),
+	)
+}
+
+function preferClineCanonicalModelIds(models: Record<string, ModelInfo>): Record<string, ModelInfo> {
+	return preferCanonicalModelIds(models, VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES)
+}
+
 async function fetchRawClineModels(): Promise<ClineRawModelInfo[]> {
 	const apiBaseUrl = ClineEnv.config().apiBaseUrl
 	const response = await axios.get(`${apiBaseUrl}/api/v1/ai/cline/models`, getAxiosSettings())
@@ -107,13 +138,13 @@ async function fetchRawClineModels(): Promise<ClineRawModelInfo[]> {
 export async function refreshClineModels(controller: Controller): Promise<Record<string, ModelInfo>> {
 	const shouldUseClineEndpointSource = featureFlagsService.getBooleanFlagEnabled(FeatureFlag.EXTENSION_CLINE_MODELS_ENDPOINT)
 	if (!shouldUseClineEndpointSource) {
-		return refreshOpenRouterModels(controller)
+		return preferClineCanonicalModelIds(await refreshOpenRouterModels(controller))
 	}
 
 	// Check in-memory cache first
 	const cache = StateManager.get().getModelsCache("cline")
 	if (cache) {
-		return cache
+		return preferClineCanonicalModelIds(cache)
 	}
 
 	// If a fetch is already in progress, return the same promise
@@ -319,6 +350,8 @@ async function fetchAndCacheClineModels(): Promise<Record<string, ModelInfo>> {
 		if (Object.keys(models).length === 0) {
 			throw new Error("No Cline models returned from API")
 		}
+		models = preferClineCanonicalModelIds(models)
+
 		// Save models and cache them in memory
 		await fs.writeFile(clineModelsFilePath, JSON.stringify(models))
 		Logger.log("Cline models fetched and saved")
@@ -340,6 +373,7 @@ async function fetchAndCacheClineModels(): Promise<Record<string, ModelInfo>> {
 
 	// Avoid poisoning in-memory cache with an empty model map after transient failures.
 	if (Object.keys(models).length > 0) {
+		models = preferClineCanonicalModelIds(models)
 		StateManager.get().setModelsCache("cline", models)
 	}
 

--- a/apps/vscode/src/core/controller/models/refreshClineModels.ts
+++ b/apps/vscode/src/core/controller/models/refreshClineModels.ts
@@ -144,7 +144,7 @@ export async function refreshClineModels(controller: Controller): Promise<Record
 	// Check in-memory cache first
 	const cache = StateManager.get().getModelsCache("cline")
 	if (cache) {
-		return preferClineCanonicalModelIds(cache)
+		return cache
 	}
 
 	// If a fetch is already in progress, return the same promise
@@ -350,10 +350,9 @@ async function fetchAndCacheClineModels(): Promise<Record<string, ModelInfo>> {
 		if (Object.keys(models).length === 0) {
 			throw new Error("No Cline models returned from API")
 		}
-		models = preferClineCanonicalModelIds(models)
 
 		// Save models and cache them in memory
-		await fs.writeFile(clineModelsFilePath, JSON.stringify(models))
+		await fs.writeFile(clineModelsFilePath, JSON.stringify(preferClineCanonicalModelIds(models)))
 		Logger.log("Cline models fetched and saved")
 	} catch (error) {
 		Logger.error("Error fetching Cline models:", error)


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This fixes the VS Code extension's Cline model catalog handling for Z.ai GLM models whose model IDs differ between OpenRouter and Vercel-style gateway catalogs.

The CLI/SDK already handles this by treating `zai/` as the canonical ID prefix for Cline while filtering out duplicate OpenRouter-style `z-ai/` aliases when the canonical ID is present. The VS Code extension's Cline model refresh path did not apply that same canonical-over-alias filtering, so users could see stale or incorrect model info for models such as GLM 5.2 depending on which ID spelling populated the catalog.

This change keeps the fix scoped to the VS Code Cline model refresh path. OpenRouter's own catalog remains unchanged. The helper in `refreshClineModels.ts` mirrors the SDK alias rule and `preferCanonicalModelIds` behavior: it only removes an alias when the canonical model ID exists in the same model map.

### Test Procedure

- Ran Biome on the touched VS Code files:
  - `./node_modules/.bin/biome check --config-path ./biome.jsonc src/core/controller/models/refreshClineModels.ts src/core/controller/models/__tests__/refreshClineModels.test.ts`
- Ran `git diff --check` to verify whitespace/patch cleanliness.
- Added a unit test covering a Cline catalog that includes both `z-ai/glm-5.2` and `zai/glm-5.2`, verifying the canonical `zai/` model info is retained and the OpenRouter alias is removed.

I did not run the full VS Code extension suite in this worktree because the local VS Code app install/generated artifacts are incomplete and unrelated type/module failures block full-suite execution.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - no UI layout changes.

### Additional Notes

This intentionally does not add an `@cline/llms` dependency to `apps/vscode/package.json`; the extension package does not currently declare that dependency. The local helper mirrors the SDK's existing alias rule and filter behavior without introducing package or lockfile churn.
