### PR TITLE
fix(cli): use ClinePass as one word consistently

### DIFF
--- a/apps/cli/src/kanban-migration/notice-dialog.tsx
+++ b/apps/cli/src/kanban-migration/notice-dialog.tsx
@@ -17,10 +17,10 @@ export function MigrationNoticeContent(
 	const [status, setStatus] = useState<string | undefined>();
 
 	const openSubscriptionPage = useCallback(() => {
-		setStatus("Opening Cline Pass in your browser...");
+		setStatus("Opening ClinePass in your browser...");
 		void open(subscriptionUrl, { wait: false })
 			.then(() => {
-				setStatus("Opened Cline Pass in your browser.");
+				setStatus("Opened ClinePass in your browser.");
 			})
 			.catch(() => {
 				setStatus(
@@ -44,7 +44,7 @@ export function MigrationNoticeContent(
 			<text fg={palette.act}>{notice.title}</text>
 			<box flexDirection="column">
 				<text selectable>
-					Cline Pass is a $9.99/month subscription plan to get access to the
+					ClinePass is a $9.99/month subscription plan to get access to the
 					latest open-weight coding models with enough quota for day-to-day
 					work, at a much lower cost than paying API costs directly.
 				</text>
@@ -57,7 +57,7 @@ export function MigrationNoticeContent(
 			</box>
 			<box flexDirection="row">
 				<box paddingX={1} backgroundColor={palette.act}>
-					<text fg={palette.textOnSelection}>Open Cline Pass</text>
+					<text fg={palette.textOnSelection}>Open ClinePass</text>
 				</box>
 			</box>
 			{status && <text fg={palette.muted}>{status}</text>}

--- a/apps/cli/src/kanban-migration/notice.test.ts
+++ b/apps/cli/src/kanban-migration/notice.test.ts
@@ -32,7 +32,7 @@ describe("migration notice", () => {
 	it("returns the notice for a fresh data dir", () => {
 		const dataDir = createTempDataDir();
 
-		expect(getClineCliMigrationNotice(dataDir)?.title).toBe("Try Cline Pass");
+		expect(getClineCliMigrationNotice(dataDir)?.title).toBe("Try ClinePass");
 	});
 
 	it("shows when only the old Kanban notice was marked as shown", () => {

--- a/apps/cli/src/kanban-migration/notice.ts
+++ b/apps/cli/src/kanban-migration/notice.ts
@@ -71,7 +71,7 @@ export function getClineCliMigrationNotice(
 	}
 	return {
 		id: NOTICE_ID,
-		title: "Try Cline Pass",
+		title: "Try ClinePass",
 	};
 }
 

--- a/apps/cli/src/main.test.ts
+++ b/apps/cli/src/main.test.ts
@@ -631,7 +631,7 @@ describe("runCli lightweight command dispatch", () => {
 	it("passes the migration notice marker into interactive mode", async () => {
 		const notice = {
 			id: "cline-cli-cline-pass-intro",
-			title: "Try Cline Pass",
+			title: "Try ClinePass",
 		};
 		migrationNoticeMocks.getClineCliMigrationNotice.mockReturnValue(notice);
 		Object.defineProperty(process.stdout, "isTTY", {


### PR DESCRIPTION
## Problem

We made a batch of CLI changes today introducing the ClinePass startup notice/dialog, but the brand name ended up written inconsistently. Some user-facing strings used "Cline Pass" (two words) while the rest of the codebase uses "ClinePass" (one word). The brand should be one word everywhere.

## Change

Normalized all 7 user-facing occurrences of "Cline Pass" → "ClinePass":

- `kanban-migration/notice.ts` — notice title (`"Try ClinePass"`)
- `kanban-migration/notice-dialog.tsx` — browser open status text, body copy, and the "Open ClinePass" button label
- `kanban-migration/notice.test.ts` and `main.test.ts` — matching test expectations

## Scope / what was intentionally left alone

- Lowercase identifier-style usages (`clinePass`, `clinepass` in env var names like `CLINE_FORCE_CLINE_PASS_NOTICE`, URLs, and function names) are code identifiers, not display text, and are already internally consistent — left untouched.
- One unrelated match in `apps/vscode/src/utils/path.ts` ("...when Cline passes in '../../'") is ordinary prose, not the brand name — skipped.

## Testing

`vitest run` on `notice.test.ts` and `main.test.ts` — 74 tests pass.