### PR TITLE
fix(cli): make ClinePass subscription screen selectable

### DIFF
--- a/apps/cli/src/tui/views/onboarding/controller.ts
+++ b/apps/cli/src/tui/views/onboarding/controller.ts
@@ -10,8 +10,12 @@ import {
 	saveLocalProviderSettings,
 } from "@cline/core";
 import { isClineProvider } from "@cline/shared";
+import open from "open";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { getIndividualPlanFeatures } from "../../../utils/cline-pass-errors";
+import {
+	getCliSubscriptionUrl,
+	getIndividualPlanFeatures,
+} from "../../../utils/cline-pass-errors";
 import {
 	type CodexCliStatus,
 	checkCodexCliInstalled,
@@ -53,6 +57,7 @@ import {
 import { FIELD_ORDER } from "./fields";
 import { useOnboardingKeyboard } from "./keyboard";
 import {
+	CLINE_PASS_SUBSCRIPTION_OPTIONS,
 	type ClinePassSubscriptionStatus,
 	getMainMenuOptions,
 	type ModelEntry,
@@ -164,6 +169,10 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 	const [clinePassPlanFeatures, setClinePassPlanFeatures] = useState<string[]>(
 		[],
 	);
+	const [clinePassSubscriptionSelected, setClinePassSubscriptionSelected] =
+		useState(0);
+	const [clinePassSubscriptionOpenStatus, setClinePassSubscriptionOpenStatus] =
+		useState("");
 
 	const modelItems: SearchableItem[] = useMemo(
 		() =>
@@ -284,6 +293,7 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 		setClinePassSubscriptionError("");
 		setClinePassCurrentPlanName("");
 		setClinePassPlanFeatures([]);
+		setClinePassSubscriptionOpenStatus("");
 
 		loadCurrentUserPlanFromProviderSettings({ providerSettingsManager })
 			.then(
@@ -312,7 +322,8 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 
 				if (currentPlanResult.status === "rejected") {
 					const error = currentPlanResult.reason;
-					const message = error instanceof Error ? error.message : String(error);
+					const message =
+						error instanceof Error ? error.message : String(error);
 					if (message.trim().toLowerCase() === "no plan found for user") {
 						setClinePassSubscriptionStatus("unsubscribed");
 						return;
@@ -362,6 +373,7 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 		const provider = providers.find((p) => p.id === "cline-pass");
 		setActiveProviderName(provider?.name ?? "ClinePass");
 		setModelsDefaultId(provider?.defaultModelId ?? "");
+		setClinePassSubscriptionSelected(0);
 		setStep("cline_pass_subscription");
 		refreshClinePassSubscriptionStatus();
 	}, [providers, refreshClinePassSubscriptionStatus]);
@@ -443,6 +455,22 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 	const continueFromClinePassSubscription = useCallback(() => {
 		transitionToModelPicker("cline-pass");
 	}, [transitionToModelPicker]);
+
+	const openClinePassSubscriptionPage = useCallback(() => {
+		const subscriptionUrl = getCliSubscriptionUrl();
+		setClinePassSubscriptionOpenStatus("Opening subscription page...");
+		void open(subscriptionUrl, { wait: false })
+			.then(() => {
+				setClinePassSubscriptionOpenStatus(
+					"Opened subscription page in your browser.",
+				);
+			})
+			.catch(() => {
+				setClinePassSubscriptionOpenStatus(
+					`Could not open browser automatically. Open ${subscriptionUrl}`,
+				);
+			});
+	}, []);
 
 	useEffect(() => {
 		if (
@@ -735,6 +763,8 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 		clineEntries,
 		clineModelSelected,
 		clinePassSubscriptionStatus,
+		clinePassSubscriptionOptions: CLINE_PASS_SUBSCRIPTION_OPTIONS,
+		clinePassSubscriptionSelected,
 		thinkingSelected,
 		setStep,
 		setMenuSelected,
@@ -751,9 +781,11 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 		setDeviceError,
 		setDeviceStatus,
 		setClineModelSelected,
+		setClinePassSubscriptionSelected,
 		setThinkingSelected,
 		continueFromClinePassSubscription,
 		refreshClinePassSubscriptionStatus,
+		openClinePassSubscriptionPage,
 		abortOAuth: () => {
 			authAbortRef.current = true;
 		},
@@ -791,6 +823,9 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 		clinePassCurrentPlanName,
 		clinePassPlanFeatures,
 		clinePassSubscriptionError,
+		clinePassSubscriptionOpenStatus,
+		clinePassSubscriptionOptions: CLINE_PASS_SUBSCRIPTION_OPTIONS,
+		clinePassSubscriptionSelected,
 		clinePassSubscriptionStatus,
 		deviceError,
 		deviceStatus,

--- a/apps/cli/src/tui/views/onboarding/keyboard.ts
+++ b/apps/cli/src/tui/views/onboarding/keyboard.ts
@@ -9,10 +9,11 @@ import {
 } from "./auth";
 import { FIELD_ORDER } from "./fields";
 import {
+	type ClinePassSubscriptionOption,
+	type ClinePassSubscriptionStatus,
 	type MenuOption,
 	type OnboardingStep,
 	THINKING_LEVELS,
-	type ClinePassSubscriptionStatus,
 	type ThinkingLevel,
 } from "./model";
 
@@ -28,6 +29,8 @@ export function useOnboardingKeyboard(input: {
 	clineEntries: ClineModelPickerEntry[];
 	clineModelSelected: number;
 	clinePassSubscriptionStatus: ClinePassSubscriptionStatus;
+	clinePassSubscriptionOptions: ClinePassSubscriptionOption[];
+	clinePassSubscriptionSelected: number;
 	thinkingSelected: number;
 	setStep: (step: OnboardingStep) => void;
 	setMenuSelected: Dispatch<SetStateAction<number>>;
@@ -40,9 +43,11 @@ export function useOnboardingKeyboard(input: {
 	setDeviceError: (value: string) => void;
 	setDeviceStatus: (value: string) => void;
 	setClineModelSelected: Dispatch<SetStateAction<number>>;
+	setClinePassSubscriptionSelected: Dispatch<SetStateAction<number>>;
 	setThinkingSelected: Dispatch<SetStateAction<number>>;
 	continueFromClinePassSubscription: () => void;
 	refreshClinePassSubscriptionStatus: () => void;
+	openClinePassSubscriptionPage: () => void;
 	abortOAuth: () => void;
 	abortDeviceCode: () => void;
 	resetAuth: () => void;
@@ -145,13 +150,37 @@ export function useOnboardingKeyboard(input: {
 		if (input.step === "device_code") return;
 
 		if (input.step === "cline_pass_subscription") {
-			if (key.name === "r") {
-				input.refreshClinePassSubscriptionStatus();
+			const total = input.clinePassSubscriptionOptions.length;
+			if (total === 0) return;
+			if (key.name === "up" || (key.ctrl && key.name === "p")) {
+				input.setClinePassSubscriptionSelected((s) =>
+					s <= 0 ? total - 1 : s - 1,
+				);
 				return;
 			}
-			if (key.name === "return") {
-				if (input.clinePassSubscriptionStatus !== "loading") {
+			if (key.name === "down" || (key.ctrl && key.name === "n")) {
+				input.setClinePassSubscriptionSelected((s) =>
+					s >= total - 1 ? 0 : s + 1,
+				);
+				return;
+			}
+			if (key.name === "return" || key.name === "enter") {
+				const option =
+					input.clinePassSubscriptionOptions[
+						Math.min(input.clinePassSubscriptionSelected, total - 1)
+					];
+				if (!option) return;
+				if (option.value === "subscribe") {
+					input.openClinePassSubscriptionPage();
+				} else if (option.value === "refresh") {
+					if (input.clinePassSubscriptionStatus !== "loading") {
+						input.refreshClinePassSubscriptionStatus();
+					}
+				} else if (option.value === "skip") {
 					input.continueFromClinePassSubscription();
+				} else if (option.value === "back") {
+					input.setStep("menu");
+					input.setMenuSelected(0);
 				}
 			}
 			return;

--- a/apps/cli/src/tui/views/onboarding/model.ts
+++ b/apps/cli/src/tui/views/onboarding/model.ts
@@ -37,6 +37,18 @@ export interface MenuOption {
 	icon: string;
 }
 
+export type ClinePassSubscriptionAction =
+	| "subscribe"
+	| "refresh"
+	| "skip"
+	| "back";
+
+export interface ClinePassSubscriptionOption {
+	value: ClinePassSubscriptionAction;
+	label: string;
+	detail: string;
+}
+
 export const MAIN_MENU: MenuOption[] = [
 	{
 		label: "Sign in with Cline",
@@ -72,6 +84,29 @@ export function getMainMenuOptions(options?: {
 	);
 }
 
+export const CLINE_PASS_SUBSCRIPTION_OPTIONS: ClinePassSubscriptionOption[] = [
+	{
+		value: "subscribe",
+		label: "Subscribe to ClinePass",
+		detail: "Open the subscription page in your browser",
+	},
+	{
+		value: "refresh",
+		label: "Re-check subscription status",
+		detail: "Verify your plan again",
+	},
+	{
+		value: "skip",
+		label: "Skip for now",
+		detail: "Choose a ClinePass model without verifying",
+	},
+	{
+		value: "back",
+		label: "Go back",
+		detail: "Return to provider options",
+	},
+];
+
 export interface OnboardingResult {
 	providerId: string;
 	modelId: string;
@@ -97,7 +132,11 @@ export interface ModelEntry {
 	supportsReasoning: boolean;
 }
 
-export type ClinePassSubscriptionStatus = "loading" | "subscribed" | "unsubscribed" | "error";
+export type ClinePassSubscriptionStatus =
+	| "loading"
+	| "subscribed"
+	| "unsubscribed"
+	| "error";
 
 export interface ProviderCatalogItem {
 	id: string;

--- a/apps/cli/src/tui/views/onboarding/screens.tsx
+++ b/apps/cli/src/tui/views/onboarding/screens.tsx
@@ -1,6 +1,5 @@
 import "opentui-spinner/react";
 import type { ReactNode } from "react";
-import { getCliSubscriptionUrl } from "../../../utils/cline-pass-errors";
 import {
 	CODEX_CLI_INSTALL_URL,
 	type CodexCliStatus,
@@ -22,6 +21,7 @@ import { useTerminalBackground } from "../../hooks/use-terminal-background";
 import { getDefaultForeground, palette } from "../../palette";
 import { FIELD_ORDER } from "./fields";
 import {
+	type ClinePassSubscriptionOption,
 	type ClinePassSubscriptionStatus,
 	type MenuOption,
 	THINKING_LEVELS,
@@ -479,11 +479,13 @@ export function OnboardingClinePassSubscriptionScreen(props: {
 	currentPlanName: string;
 	error: string;
 	mouse: MouseTrackerState;
+	openStatus: string;
+	options: ClinePassSubscriptionOption[];
 	planFeatures: string[];
+	selected: number;
 	status: ClinePassSubscriptionStatus;
 }) {
 	const defaultFg = useDefaultFg();
-	const subscriptionUrl = getCliSubscriptionUrl();
 	const isLoading = props.status === "loading";
 	const isSubscribed = props.status === "subscribed";
 	const isError = props.status === "error";
@@ -562,31 +564,44 @@ export function OnboardingClinePassSubscriptionScreen(props: {
 
 				{!isSubscribed && (
 					<box flexDirection="column" marginTop={1}>
-						<box flexDirection="row">
-							<text fg="gray">Subscribe: </text>
-							<text fg="cyan" selectable>
-								<a href={subscriptionUrl}>Open subscription page</a>
-							</text>
-						</box>
-						<box flexDirection="row">
-							<text fg="gray">URL: </text>
-							<text fg="cyan" selectable>
-								<a href={subscriptionUrl}>{subscriptionUrl}</a>
-							</text>
-						</box>
-						<text fg="gray">
-							<em>You can highlight/select the URL text to copy it.</em>
-						</text>
+						{props.options.map((option, i) => {
+							const isSel = i === props.selected;
+							return (
+								<box
+									key={option.value}
+									paddingX={1}
+									flexDirection="row"
+									gap={1}
+									backgroundColor={isSel ? palette.selection : undefined}
+									height={1}
+								>
+									<text
+										fg={isSel ? palette.textOnSelection : "gray"}
+										flexShrink={0}
+									>
+										{isSel ? "\u276f" : " "}
+									</text>
+									<text fg={isSel ? palette.textOnSelection : defaultFg}>
+										{option.label}
+									</text>
+									<text fg={isSel ? palette.textOnSelection : "gray"}>
+										{option.detail}
+									</text>
+								</box>
+							);
+						})}
 					</box>
+				)}
+
+				{props.openStatus && (
+					<text fg="gray" selectable>
+						{props.openStatus}
+					</text>
 				)}
 			</box>
 
 			<text fg="gray" paddingX={1}>
-				<em>
-					{isLoading
-						? "Checking subscription, Ctrl+C to exit"
-						: "Enter to continue, R to re-check, Esc to go back, Ctrl+C to exit"}
-				</em>
+				<em>↑/↓ navigate, Enter to select, Esc to go back, Ctrl+C to exit</em>
 			</text>
 		</OnboardingFrame>
 	);

--- a/apps/cli/src/tui/views/onboarding/view.tsx
+++ b/apps/cli/src/tui/views/onboarding/view.tsx
@@ -130,7 +130,10 @@ export function OnboardingView(props: OnboardingViewProps) {
 				currentPlanName={state.clinePassCurrentPlanName}
 				error={state.clinePassSubscriptionError}
 				mouse={mouse}
+				openStatus={state.clinePassSubscriptionOpenStatus}
+				options={state.clinePassSubscriptionOptions}
 				planFeatures={state.clinePassPlanFeatures}
+				selected={state.clinePassSubscriptionSelected}
 				status={state.clinePassSubscriptionStatus}
 			/>
 		);


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This PR updates the ClinePass subscription-required step in the CLI onboarding welcome flow.

Previously this screen behaved differently from the rest of the TUI onboarding flow: it rendered a clickable subscription URL, told the user they could copy/highlight the URL, and exposed action behavior through ad hoc shortcuts like `R` for re-check. That made this screen feel unlike the surrounding provider/model pickers, where users move through visible options with the keyboard and press Enter.

The new flow replaces the URL/shortcut block with an explicit selectable action list:

- `Subscribe to ClinePass` opens the ClinePass subscription page in the default browser.
- `Re-check subscription status` refreshes entitlement status, while preserving the existing loading guard.
- `Skip for now` continues to ClinePass model selection, matching the previous non-loading Enter behavior.
- `Go back` returns to the provider options menu.

Implementation-wise, the ClinePass subscription actions now live in the onboarding model layer, and the controller owns the selected action index plus browser-open status. The keyboard handler uses the same navigation pattern as other onboarding lists: Up/Down and Ctrl+P/Ctrl+N cycle through actions, and Enter dispatches the selected action. The screen renderer now draws highlighted rows with the same `❯` selection marker used elsewhere and keeps the footer focused on `Esc` to go back and `Ctrl+C` to exit.

The subscription URL is still used internally by the `Subscribe to ClinePass` action via the existing `getCliSubscriptionUrl()` helper, but it is no longer shown as the primary interaction affordance on the onboarding screen.

### Test Procedure

I verified the changed CLI onboarding files with:

```bash
bun run --cwd apps/cli typecheck
bun biome check --diagnostic-level=error apps/cli/src/tui/views/onboarding/controller.ts apps/cli/src/tui/views/onboarding/keyboard.ts apps/cli/src/tui/views/onboarding/model.ts apps/cli/src/tui/views/onboarding/screens.tsx apps/cli/src/tui/views/onboarding/view.tsx
```

During implementation, Biome initially reported formatting/import-order issues in the touched files. I applied the safe Biome fixes with `bun biome check --write --diagnostic-level=error ...` and reran both commands above successfully.

The main behavior risk is keyboard regression in onboarding. The new branch is scoped to `cline_pass_subscription`; existing escape handling still returns to the menu, Ctrl+C still exits, and other onboarding steps keep their existing keyboard branches. The previous implicit Enter-to-continue path is preserved as the explicit `Skip for now` action.

I did not run the full repository test suite or capture a terminal screenshot in this environment.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not captured in this environment.

### Additional Notes

Focused verification passed, but I intentionally left the full-suite checklist item unchecked because I did not run `bun test`, `bun run format`, or `bun run lint` across the whole repo.
