### PR TITLE
fix: polish ClinePass and Z AI model metadata

### DIFF
--- a/apps/vscode/src/shared/__tests__/api.test.ts
+++ b/apps/vscode/src/shared/__tests__/api.test.ts
@@ -1,5 +1,11 @@
 import { expect } from "chai"
-import { buildModelInfoNameMap, type ModelInfo, resolveClinePassModelInfo } from "../api"
+import {
+	buildModelInfoNameMap,
+	internationalZAiModels,
+	mainlandZAiModels,
+	type ModelInfo,
+	resolveClinePassModelInfo,
+} from "../api"
 
 describe("ClinePass model info", () => {
 	const createModelInfo = (name: string, contextWindow: number): ModelInfo => ({
@@ -11,13 +17,21 @@ describe("ClinePass model info", () => {
 		thinkingConfig: { maxBudget: 16_384 },
 	})
 
-	it("resolves ClinePass GLM aliases to the static ClinePass metadata", () => {
+	it("prefers dynamic model metadata for ClinePass GLM aliases", () => {
 		const modelInfo = resolveClinePassModelInfo(
 			"cline-pass/z-ai/glm-5.2",
 			buildModelInfoNameMap({
-				"z-ai/glm-5.2": createModelInfo("OpenRouter GLM 5.2", 128_000),
+				"z-ai/glm-5.2": createModelInfo("OpenRouter GLM 5.2", 1_000_000),
 			}),
 		)
+
+		expect(modelInfo.name).to.equal("OpenRouter GLM 5.2")
+		expect(modelInfo.contextWindow).to.equal(1_000_000)
+		expect(modelInfo.thinkingConfig).to.deep.equal({ maxBudget: 16_384 })
+	})
+
+	it("falls back to static ClinePass metadata when dynamic metadata is unavailable", () => {
+		const modelInfo = resolveClinePassModelInfo("cline-pass/glm-5.2")
 
 		expect(modelInfo.contextWindow).to.equal(202_752)
 		expect(modelInfo.supportsReasoning).to.equal(true)
@@ -35,5 +49,17 @@ describe("ClinePass model info", () => {
 		expect(modelInfo.name).to.equal("New model")
 		expect(modelInfo.supportsReasoning).to.equal(false)
 		expect(modelInfo.thinkingConfig).to.deep.equal({ maxBudget: 16_384 })
+	})
+})
+
+describe("Z AI model info", () => {
+	it("includes GLM 5.2 for both direct Z AI entrypoints", () => {
+		for (const models of [internationalZAiModels, mainlandZAiModels]) {
+			expect(models["glm-5.2"].contextWindow).to.equal(1_000_000)
+			expect(models["glm-5.2"].maxTokens).to.equal(128_000)
+			expect(models["glm-5.2"].inputPrice).to.equal(1.4)
+			expect(models["glm-5.2"].outputPrice).to.equal(4.4)
+			expect(models["glm-5.2"].cacheReadsPrice).to.equal(0.26)
+		}
 	})
 })

--- a/apps/vscode/src/shared/api.ts
+++ b/apps/vscode/src/shared/api.ts
@@ -1085,9 +1085,9 @@ export function resolveClinePassModelInfo(modelId: string, modelInfoByName?: Rec
 	const modelSlug = getModelSlug(modelId)
 	const clinePassSlugModelId = `cline-pass/${modelSlug}`
 	return (
+		modelInfoByName?.[modelSlug] ??
 		clinePassModels[modelId as keyof typeof clinePassModels] ??
 		clinePassModels[clinePassSlugModelId as keyof typeof clinePassModels] ??
-		modelInfoByName?.[modelSlug] ??
 		clinePassModelInfoSaneDefaults
 	)
 }
@@ -4999,12 +4999,22 @@ export type BasetenModelId = keyof typeof basetenModels
 export const basetenDefaultModelId = "zai-org/GLM-4.6" satisfies BasetenModelId
 
 // Z AI
+// https://docs.z.ai/guides/llm/glm-5.2
 // https://docs.z.ai/guides/llm/glm-5.1
 // https://docs.z.ai/guides/llm/glm-5
 // https://docs.z.ai/guides/overview/pricing
 export type internationalZAiModelId = keyof typeof internationalZAiModels
 export const internationalZAiDefaultModelId: internationalZAiModelId = "glm-5.1"
 export const internationalZAiModels = {
+	"glm-5.2": {
+		maxTokens: 128_000,
+		contextWindow: 1_000_000,
+		supportsImages: false,
+		supportsPromptCache: true,
+		cacheReadsPrice: 0.26,
+		inputPrice: 1.4,
+		outputPrice: 4.4,
+	},
 	"glm-5.1": {
 		maxTokens: 128_000,
 		contextWindow: 200_000,
@@ -5070,6 +5080,15 @@ export const internationalZAiModels = {
 export type mainlandZAiModelId = keyof typeof mainlandZAiModels
 export const mainlandZAiDefaultModelId: mainlandZAiModelId = "glm-5.1"
 export const mainlandZAiModels = {
+	"glm-5.2": {
+		maxTokens: 128_000,
+		contextWindow: 1_000_000,
+		supportsImages: false,
+		supportsPromptCache: true,
+		cacheReadsPrice: 0.26,
+		inputPrice: 1.4,
+		outputPrice: 4.4,
+	},
 	"glm-5.1": {
 		maxTokens: 128_000,
 		contextWindow: 200_000,

--- a/apps/vscode/webview-ui/src/components/settings/providers/ClineProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/ClineProvider.tsx
@@ -84,14 +84,9 @@ export const ClineProvider = ({
 						{activeRoute === "cline" && <ClineAccountInfoCard />}
 						{activeRoute === "cline-pass" && (
 							clinePassSubscribeUrl ? (
-								<>
-									<VSCodeButtonLink appearance="secondary" href={clinePassSubscribeUrl}>
-										Manage ClinePass
-									</VSCodeButtonLink>
-									<VSCodeButtonLink appearance="secondary" href={clinePassSubscribeUrl}>
-										View Billing & Usage
-									</VSCodeButtonLink>
-								</>
+								<VSCodeButtonLink appearance="secondary" href={clinePassSubscribeUrl}>
+									Manage ClinePass or See Usage
+								</VSCodeButtonLink>
 							) : (
 								<ClineAccountInfoCard />
 							)


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This PR groups a few small fixes around the ClinePass/Z.AI model UX and metadata:

- Fixes ClinePass model metadata resolution so dynamic provider/backend metadata wins over stale hardcoded ClinePass fallback metadata. This is what caused `cline-pass/glm-5.2` to show a ~203k context window even though the dynamic GLM 5.2 metadata reports a 1M context window.
- Keeps the hardcoded ClinePass model table as a fallback for cases where dynamic metadata is unavailable.
- Combines the duplicate ClinePass settings CTAs, `Manage ClinePass` and `View Billing & Usage`, into a single `Manage ClinePass or See Usage` button because both buttons go to the same destination.
- Adds `glm-5.2` to the direct Z.AI provider model tables for both `api.z.ai` and `open.bigmodel.cn`, with 1M context and the same current pricing shape as GLM 5.1.

The main gotcha here was the ClinePass resolver precedence. The existing unit test was asserting that ClinePass GLM aliases should prefer static metadata, which made the stale 202,752-token context window look intentional. This PR flips that precedence and updates the test to match the desired behavior: dynamic metadata by model slug first, static ClinePass metadata second, sane defaults last.

### Test Procedure

Ran focused unit coverage for the changed shared model metadata behavior:

```sh
npm run test:unit -- --grep "ClinePass model info|Z AI model info"
```

This verifies:

- ClinePass GLM aliases prefer dynamic metadata, including 1M context for GLM 5.2.
- ClinePass still falls back to static metadata when dynamic metadata is unavailable.
- Direct Z.AI model tables include `glm-5.2` for both entrypoints with the expected context window, max output tokens, and pricing metadata.

Ran TypeScript verification for the VS Code extension and webview:

```sh
npm run check-types
```

This covers the exported model ID union changes from adding `glm-5.2` to the direct Z.AI tables.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not included. The only UI change is replacing two same-destination ClinePass buttons with one combined button label.

### Additional Notes

I did not change the direct Z.AI default model. It remains `glm-5.1`; this PR only adds `glm-5.2` as a selectable direct Z.AI model.
