### PR TITLE
fix(cli): show ClinePass subscription URL fallback

### DIFF
--- a/apps/cli/src/tui/views/onboarding/controller.ts
+++ b/apps/cli/src/tui/views/onboarding/controller.ts
@@ -173,6 +173,7 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 		useState(0);
 	const [clinePassSubscriptionOpenStatus, setClinePassSubscriptionOpenStatus] =
 		useState("");
+	const clinePassSubscriptionUrl = useMemo(() => getCliSubscriptionUrl(), []);
 
 	const modelItems: SearchableItem[] = useMemo(
 		() =>
@@ -456,9 +457,8 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 	}, [transitionToModelPicker]);
 
 	const openClinePassSubscriptionPage = useCallback(() => {
-		const subscriptionUrl = getCliSubscriptionUrl();
 		setClinePassSubscriptionOpenStatus("Opening subscription page...");
-		void open(subscriptionUrl, { wait: false })
+		void open(clinePassSubscriptionUrl, { wait: false })
 			.then(() => {
 				setClinePassSubscriptionOpenStatus(
 					"Opened subscription page in your browser.",
@@ -466,10 +466,10 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 			})
 			.catch(() => {
 				setClinePassSubscriptionOpenStatus(
-					`Could not open browser automatically. Open ${subscriptionUrl}`,
+					`Could not open browser automatically. Open ${clinePassSubscriptionUrl}`,
 				);
 			});
-	}, []);
+	}, [clinePassSubscriptionUrl]);
 
 	useEffect(() => {
 		if (
@@ -826,6 +826,7 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 		clinePassSubscriptionOptions: CLINE_PASS_SUBSCRIPTION_OPTIONS,
 		clinePassSubscriptionSelected,
 		clinePassSubscriptionStatus,
+		clinePassSubscriptionUrl,
 		deviceError,
 		deviceStatus,
 		deviceUserCode,

--- a/apps/cli/src/tui/views/onboarding/screens.tsx
+++ b/apps/cli/src/tui/views/onboarding/screens.tsx
@@ -490,6 +490,7 @@ export function OnboardingClinePassSubscriptionScreen(props: {
 	planFeatures: string[];
 	selected: number;
 	status: ClinePassSubscriptionStatus;
+	subscriptionUrl: string;
 }) {
 	const defaultFg = useDefaultFg();
 	const scrollRef = useRef<ScrollBoxRenderable | null>(null);
@@ -577,6 +578,17 @@ export function OnboardingClinePassSubscriptionScreen(props: {
 									{props.error}
 								</text>
 							)}
+
+						{!isSubscribed && (
+							<box flexDirection="column" marginTop={1} flexShrink={0}>
+								<text fg="gray" flexShrink={0}>
+									If the browser button does not work:
+								</text>
+								<text fg={palette.act} selectable flexShrink={0}>
+									<a href={props.subscriptionUrl}>{props.subscriptionUrl}</a>
+								</text>
+							</box>
+						)}
 
 						{!isSubscribed && props.planFeatures.length > 0 && (
 							<box flexDirection="column" marginTop={1} flexShrink={0}>

--- a/apps/cli/src/tui/views/onboarding/screens.tsx
+++ b/apps/cli/src/tui/views/onboarding/screens.tsx
@@ -579,17 +579,6 @@ export function OnboardingClinePassSubscriptionScreen(props: {
 								</text>
 							)}
 
-						{!isSubscribed && (
-							<box flexDirection="column" marginTop={1} flexShrink={0}>
-								<text fg="gray" flexShrink={0}>
-									If the browser button does not work:
-								</text>
-								<text fg={palette.act} selectable flexShrink={0}>
-									<a href={props.subscriptionUrl}>{props.subscriptionUrl}</a>
-								</text>
-							</box>
-						)}
-
 						{!isSubscribed && props.planFeatures.length > 0 && (
 							<box flexDirection="column" marginTop={1} flexShrink={0}>
 								<text fg={defaultFg}>ClinePass includes:</text>
@@ -654,6 +643,17 @@ export function OnboardingClinePassSubscriptionScreen(props: {
 							<text fg="gray" selectable flexShrink={0}>
 								{props.openStatus}
 							</text>
+						)}
+
+						{!isSubscribed && (
+							<box flexDirection="column" marginTop={1} flexShrink={0}>
+								<text fg="gray" flexShrink={0}>
+									If the browser button does not work:
+								</text>
+								<text fg={palette.act} selectable flexShrink={0}>
+									<a href={props.subscriptionUrl}>{props.subscriptionUrl}</a>
+								</text>
+							</box>
 						)}
 					</box>
 				</scrollbox>

--- a/apps/cli/src/tui/views/onboarding/view.tsx
+++ b/apps/cli/src/tui/views/onboarding/view.tsx
@@ -135,6 +135,7 @@ export function OnboardingView(props: OnboardingViewProps) {
 				planFeatures={state.clinePassPlanFeatures}
 				selected={state.clinePassSubscriptionSelected}
 				status={state.clinePassSubscriptionStatus}
+				subscriptionUrl={state.clinePassSubscriptionUrl}
 			/>
 		);
 	}


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This PR restores a visible fallback subscription URL in the CLI onboarding ClinePass subscription gate.

A recent onboarding UX update kept the `Subscribe to ClinePass` action that opens the subscription page in the browser, but removed the always-visible URL from the screen. That makes the flow brittle for users whose terminal, remote environment, browser integration, or OS opener cannot launch the page successfully. The open action already reports the URL on failure, but that still requires the user to select the action and have the failure path fire. This change makes the fallback explicit up front.

Technical approach:

- Resolve the ClinePass subscription URL once in `useOnboardingController` with `getCliSubscriptionUrl()`.
- Reuse that same URL for the browser open action and for the visible screen state, so the button behavior and fallback text cannot drift.
- Pass the URL through `OnboardingView` into `OnboardingClinePassSubscriptionScreen`.
- Render a selectable linked URL whenever the user is on the ClinePass subscription gate and is not already subscribed.

The existing scrollbox behavior from the onboarding UX update is preserved. The new fallback sits above the plan-feature list and action menu so it remains part of the subscription-gate content without changing keyboard handling or the subscribe/refresh/skip/back option model.

### Test Procedure

I verified this with targeted checks for the affected CLI onboarding code:

- Ran Biome formatting on the changed onboarding files:

```sh
bun biome format --write apps/cli/src/tui/views/onboarding/controller.ts apps/cli/src/tui/views/onboarding/view.tsx apps/cli/src/tui/views/onboarding/screens.tsx
```

- Ran the CLI TypeScript check:

```sh
bun -F @cline/cli typecheck
```

Both completed successfully.

Potential impact considered:

- The visible URL uses the same `getCliSubscriptionUrl()` value as the browser-opening action, so there is no second URL source to keep in sync.
- The fallback only renders when the ClinePass subscription screen is shown for a non-subscribed/non-verified user, so subscribed users still continue through the existing auto-transition path.
- Keyboard navigation is unchanged because this only adds static selectable text inside the existing scrollable subscription body.

I did not run the full repo `bun test`, full `bun run format`, or full `bun run lint` because this is a narrow CLI TUI display change and the targeted format/typecheck pass covers the changed TypeScript surface.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

No screenshot included. This is a CLI TUI text fallback change; the rendered subscription gate now shows selectable fallback text:

```text
If the browser button does not work:
<subscription URL>
```

### Additional Notes

This intentionally keeps the browser-opening button/status flow intact. The visible URL is a fallback for environments where the opener does not work reliably or where the user prefers to copy the URL manually.
