### PR TITLE
fix(cli): use adaptive plan accent for ClinePass prompts

### DIFF
--- a/apps/cli/src/tui/components/chat-entry.tsx
+++ b/apps/cli/src/tui/components/chat-entry.tsx
@@ -18,6 +18,7 @@ import {
 import { useTerminalBackground } from "../hooks/use-terminal-background";
 import {
 	getDefaultForeground,
+	getModeAccent,
 	getModeInputBackground,
 	palette,
 	type TerminalTheme,
@@ -356,9 +357,11 @@ function ClineCreditsErrorView(props: { defaultFg?: string }) {
 function ClinePassSubscriptionErrorView(props: {
 	defaultFg?: string;
 	loadIndividualSubscriptionPlans?: () => Promise<ClineSubscriptionPlan[]>;
+	terminalTheme: TerminalTheme;
 }) {
 	const subscriptionUrl = getCliSubscriptionUrl();
 	const [planFeatures, setPlanFeatures] = useState<string[]>([]);
+	const planAccent = getModeAccent("plan", props.terminalTheme);
 
 	useEffect(() => {
 		if (!props.loadIndividualSubscriptionPlans) {
@@ -383,15 +386,15 @@ function ClinePassSubscriptionErrorView(props: {
 
 	return (
 		<box flexDirection="row">
-			<text fg="yellow" content="* " />
+			<text fg={planAccent} content="* " />
 			<box
 				flexDirection="column"
 				border
 				borderStyle="rounded"
-				borderColor="yellow"
+				borderColor={planAccent}
 				paddingX={1}
 			>
-				<text fg="yellow">ClinePass subscription required</text>
+				<text fg={planAccent}>ClinePass subscription required</text>
 				<text
 					fg={props.defaultFg}
 					selectable
@@ -427,18 +430,21 @@ function ClinePassSubscriptionErrorView(props: {
 
 function ClineOrgIndividualInferenceSubscriptionErrorView(props: {
 	defaultFg?: string;
+	terminalTheme: TerminalTheme;
 }) {
+	const planAccent = getModeAccent("plan", props.terminalTheme);
+
 	return (
 		<box flexDirection="row">
-			<text fg="yellow" content="* " />
+			<text fg={planAccent} content="* " />
 			<box
 				flexDirection="column"
 				border
 				borderStyle="rounded"
-				borderColor="yellow"
+				borderColor={planAccent}
 				paddingX={1}
 			>
-				<text fg="yellow">Personal ClinePass required</text>
+				<text fg={planAccent}>Personal ClinePass required</text>
 				<text
 					fg={props.defaultFg}
 					selectable
@@ -552,6 +558,7 @@ export function ChatEntryView(props: {
 				return (
 					<ClineOrgIndividualInferenceSubscriptionErrorView
 						defaultFg={defaultFg}
+						terminalTheme={terminalTheme}
 					/>
 				);
 			}
@@ -562,6 +569,7 @@ export function ChatEntryView(props: {
 						loadIndividualSubscriptionPlans={
 							props.loadIndividualSubscriptionPlans
 						}
+						terminalTheme={terminalTheme}
 					/>
 				);
 			}

--- a/apps/cli/src/tui/views/onboarding/screens.tsx
+++ b/apps/cli/src/tui/views/onboarding/screens.tsx
@@ -19,8 +19,11 @@ import {
 	TrackedRobot,
 	type useMouseTracker,
 } from "../../components/tracked-robot";
-import { useTerminalBackground } from "../../hooks/use-terminal-background";
-import { getDefaultForeground, palette } from "../../palette";
+import {
+	useTerminalBackground,
+	useTerminalTheme,
+} from "../../hooks/use-terminal-background";
+import { getDefaultForeground, getModeAccent, palette } from "../../palette";
 import { FIELD_ORDER } from "./fields";
 import {
 	type ClinePassSubscriptionOption,
@@ -492,6 +495,8 @@ export function OnboardingClinePassSubscriptionScreen(props: {
 	status: ClinePassSubscriptionStatus;
 }) {
 	const defaultFg = useDefaultFg();
+	const terminalTheme = useTerminalTheme();
+	const planAccent = getModeAccent("plan", terminalTheme);
 	const scrollRef = useRef<ScrollBoxRenderable | null>(null);
 	const isLoading = props.status === "loading";
 	const isSubscribed = props.status === "subscribed";
@@ -523,7 +528,7 @@ export function OnboardingClinePassSubscriptionScreen(props: {
 				flexDirection="column"
 				border
 				borderStyle="rounded"
-				borderColor={isSubscribed ? palette.success : "yellow"}
+				borderColor={isSubscribed ? palette.success : planAccent}
 				paddingX={1}
 				paddingY={1}
 				height={bodyHeight}
@@ -539,7 +544,10 @@ export function OnboardingClinePassSubscriptionScreen(props: {
 					contentOptions={{ flexDirection: "column" }}
 				>
 					<box flexDirection="column" width="100%" flexShrink={0}>
-						<text fg={isSubscribed ? palette.success : "yellow"} flexShrink={0}>
+						<text
+							fg={isSubscribed ? palette.success : planAccent}
+							flexShrink={0}
+						>
 							{isSubscribed
 								? "ClinePass subscription active"
 								: "ClinePass subscription required"}


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

The CLI ClinePass subscription-required surfaces were using raw ANSI `yellow` for their title text, leading marker, and rounded border. That looks fine on dark terminals, but on light terminal backgrounds it reads as a pale warning color on white and feels inconsistent with the rest of plan-mode UI.

This PR reuses the existing plan-mode palette path instead of introducing a new color. The chat-side ClinePass subscription error, the personal-account ClinePass restriction error, and the onboarding ClinePass subscription screen now derive their warning accent from `getModeAccent("plan", terminalTheme)`. Dark terminals keep the existing `yellow` behavior, while light terminals use the darker plan accent already used by the status bar (`#9a6700`).

The change is intentionally scoped to the ClinePass subscription-required panels. Other raw `yellow` warning affordances, such as tool approval prompts and Codex CLI warning text, were left alone because this report was about the ClinePass subscription-required UI specifically.

### Test Procedure

Verified the change at the type and targeted unit-test level:

```bash
cd apps/cli
bun run typecheck
bunx vitest run --config vitest.config.ts src/tui/palette.test.ts src/tui/components/status-bar.test.ts
```

Also checked formatting/whitespace and ran Biome on the changed files:

```bash
git diff --check
bun biome check apps/cli/src/tui/components/chat-entry.tsx apps/cli/src/tui/views/onboarding/screens.tsx
```

`bun biome check` completed without errors and reported only pre-existing warning-level a11y findings in these files around interactive `<box>` usage. I did not change those unrelated areas in this PR.

The main behavior to protect is the existing dark-terminal appearance. Because `getModeAccent("plan", "dark")` still resolves to `yellow`, dark-theme output remains unchanged. Light terminals now get the same darker plan color already used by the plan/act mode indicator.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not included. This is a terminal color token change and was verified through the existing palette/status-bar tests plus typechecking.

### Additional Notes

No new color tokens were added. The implementation follows the existing adaptive plan-mode foreground behavior so any future palette updates continue to apply consistently to these ClinePass prompts.
