### PR TITLE
fix(cli): suppress ClinePass notice after onboarding

### DIFF
--- a/apps/cli/src/kanban-migration/notice.test.ts
+++ b/apps/cli/src/kanban-migration/notice.test.ts
@@ -12,6 +12,7 @@ import {
 	getClineCliMigrationNotice,
 	markClineCliMigrationNoticeShown,
 	resolveCliNoticeStatePath,
+	shouldSuppressClineCliMigrationNoticeForActiveProvider,
 } from "./notice";
 
 const tempDirs: string[] = [];
@@ -94,6 +95,20 @@ describe("migration notice", () => {
 				{ activeProviderId: "cline-pass" },
 			),
 		).toBeUndefined();
+	});
+
+	it("suppresses the active ClinePass provider even when the provider id has surrounding whitespace", () => {
+		expect(
+			shouldSuppressClineCliMigrationNoticeForActiveProvider(" cline-pass "),
+		).toBe(true);
+	});
+
+	it("does not suppress the active ClinePass provider when forced", () => {
+		expect(
+			shouldSuppressClineCliMigrationNoticeForActiveProvider("cline-pass", {
+				CLINE_FORCE_CLINE_PASS_NOTICE: "1",
+			}),
+		).toBe(false);
 	});
 
 	it("shows for the active ClinePass provider when forced", () => {

--- a/apps/cli/src/kanban-migration/notice.ts
+++ b/apps/cli/src/kanban-migration/notice.ts
@@ -53,6 +53,19 @@ function readNoticeState(filePath: string): CliNoticeState {
 	return { shown };
 }
 
+function isForceNoticeEnabled(env: NodeJS.ProcessEnv): boolean {
+	return env[FORCE_NOTICE_ENV]?.trim() === "1";
+}
+
+export function shouldSuppressClineCliMigrationNoticeForActiveProvider(
+	activeProviderId: string | undefined,
+	env: NodeJS.ProcessEnv = process.env,
+): boolean {
+	return (
+		activeProviderId?.trim() === "cline-pass" && !isForceNoticeEnabled(env)
+	);
+}
+
 export function resolveCliNoticeStatePath(
 	dataDir = resolveClineDataDir(),
 ): string {
@@ -66,12 +79,17 @@ export function getClineCliMigrationNotice(
 ): CliMigrationNotice | undefined {
 	const noticePath = resolveCliNoticeStatePath(dataDir);
 	const noticeState = readNoticeState(noticePath);
-	const forceNotice = env[FORCE_NOTICE_ENV]?.trim() === "1";
+	const forceNotice = isForceNoticeEnabled(env);
 	const disableNotice = env[DISABLE_NOTICE_ENV]?.trim() === "1";
 	if (disableNotice && !forceNotice) {
 		return undefined;
 	}
-	if (options.activeProviderId?.trim() === "cline-pass" && !forceNotice) {
+	if (
+		shouldSuppressClineCliMigrationNoticeForActiveProvider(
+			options.activeProviderId,
+			env,
+		)
+	) {
 		return undefined;
 	}
 	if (noticeState.shown[NOTICE_ID] && !forceNotice) {

--- a/apps/cli/src/tui/root.tsx
+++ b/apps/cli/src/tui/root.tsx
@@ -10,6 +10,7 @@ import {
 	useDialogState,
 } from "@opentui-ui/dialog/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { shouldSuppressClineCliMigrationNoticeForActiveProvider } from "../kanban-migration/notice";
 import { MigrationNoticeContent } from "../kanban-migration/notice-dialog";
 import type { RepoStatus } from "../utils/repo-status";
 import { readRepoStatus } from "../utils/repo-status";
@@ -541,10 +542,17 @@ function App(props: TuiProps) {
 
 	const notice = props.initialNotice;
 	const onInitialNoticeShown = props.onInitialNoticeShown;
+	const currentProviderId = props.config.providerId;
 	useEffect(() => {
 		if (!notice) return;
 		if (initialNoticeShownRef.current) return;
 		if (appView !== "home") return;
+		if (
+			shouldSuppressClineCliMigrationNoticeForActiveProvider(currentProviderId)
+		) {
+			initialNoticeShownRef.current = true;
+			return;
+		}
 
 		initialNoticeShownRef.current = true;
 		const timeout = setTimeout(() => {
@@ -560,7 +568,7 @@ function App(props: TuiProps) {
 				});
 		}, 0);
 		return () => clearTimeout(timeout);
-	}, [appView, dialog, notice, onInitialNoticeShown]);
+	}, [appView, currentProviderId, dialog, notice, onInitialNoticeShown]);
 
 	const {
 		appendEntry: appendSessionEntry,


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This fixes a timing bug in the CLI ClinePass intro notice.

The previous fix correctly suppressed the `Try ClinePass` notice when the CLI started and the persisted active provider was already `cline-pass`. That covered returning users, but it missed the fresh onboarding path:

1. Start with an empty data dir, for example `cline --data-dir "$(mktemp -d)"`.
2. Startup computes `initialNotice` before onboarding runs. Because the provider is still the default startup provider at that point, the ClinePass intro notice can be queued.
3. The user chooses ClinePass in onboarding.
4. Onboarding mutates the runtime config to `providerId = "cline-pass"` and sends the app to the home view.
5. The TUI root effect sees the queued `initialNotice` and opens it without re-checking the now-current provider.

That meant a user could complete the ClinePass onboarding flow and immediately see a dialog asking them to try ClinePass.

The fix keeps the startup behavior from the previous PR, but extracts the active-provider suppression rule into a shared helper and reuses it at the point where the home view is about to open the dialog. If onboarding has just selected ClinePass, the queued notice is marked as handled in-memory and is not shown. The force flag behavior is preserved: `CLINE_FORCE_CLINE_PASS_NOTICE=1` still allows the notice for debugging/manual verification.

I intentionally kept this scoped to the existing notice path. The `kanban-migration` folder name is stale now that the notice is a ClinePass promo, but renaming that module would be unrelated churn for this bug fix.

### Test Procedure

Ran the focused notice tests:

```sh
bun vitest run --config vitest.config.ts src/kanban-migration/notice.test.ts
```

Ran CLI typecheck:

```sh
bun -F @cline/cli typecheck
```

Ran Biome on the touched files:

```sh
bunx --bun @biomejs/biome check apps/cli/src/kanban-migration/notice.ts apps/cli/src/kanban-migration/notice.test.ts apps/cli/src/tui/root.tsx --diagnostic-level=error
```

The main risk area is accidentally changing the force/disable notice semantics. I added unit coverage for the extracted suppression helper, including the force-flag case, and left the existing `getClineCliMigrationNotice` tests intact.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable. This is a TUI dialog timing fix with focused unit/type/format coverage.

### Additional Notes

This PR builds on the earlier startup-time ClinePass notice suppression. The behavioral difference is that suppression now also happens at dialog-open time, which catches provider changes made during onboarding.
