### PR TITLE
fix(vscode): exclude vitest-owned tests from the mocha integration compile

### DIFF
--- a/apps/vscode/scripts/build-tests.js
+++ b/apps/vscode/scripts/build-tests.js
@@ -61,33 +61,36 @@ async function main() {
 fs.rmSync(path.join(__dirname, "..", "out", "src"), { recursive: true, force: true })
 fs.rmSync(path.join(__dirname, "..", "out", "packages"), { recursive: true, force: true })
 
-// Single source of truth for the bun-vs-integration test split: any *.test.ts that
-// imports from "bun:test" is owned by the bun runner (scripts/run-bun-unit-tests.ts)
-// and must NOT be compiled into the Node-based @vscode/test-cli `out/` tree (Node
-// cannot load the `bun:test` builtin, and these files use bun-only APIs like
-// `mock.module` / 3-arg `it`). Generate a tsconfig that excludes them so the
+// Single source of truth for the test-runner split: any *.test.ts that imports
+// from "bun:test" is owned by the bun runner (scripts/run-bun-unit-tests.ts),
+// and any that imports from "vitest" is owned by the vitest runner (test:vitest,
+// see vitest.config.ts). Neither may be compiled into the Node-based
+// @vscode/test-cli `out/` tree: Node cannot load `bun:test`, and vitest suites
+// use vitest-only APIs/matchers (e.g. `toHaveBeenCalledWith`) that the mocha
+// runner does not provide. Generate a tsconfig that excludes them so the
 // integration compile only ever sees mocha-owned tests.
 const projectRoot = path.join(__dirname, "..")
-const bunTestImport = /from\s+["']bun:test["']/
-function collectBunTestFiles(dir, acc) {
+const nonMochaTestImport =
+	/from\s+["'](?:bun:test|vitest(?:\/[^"']*)?|@vitest\/[^"']*)["']/
+function collectNonMochaTestFiles(dir, acc) {
 	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
 		if (entry.name === "node_modules") continue
 		const full = path.join(dir, entry.name)
 		if (entry.isDirectory()) {
-			collectBunTestFiles(full, acc)
+			collectNonMochaTestFiles(full, acc)
 		} else if (entry.isFile() && entry.name.endsWith(".test.ts")) {
-			if (bunTestImport.test(fs.readFileSync(full, "utf-8"))) {
+			if (nonMochaTestImport.test(fs.readFileSync(full, "utf-8"))) {
 				acc.push(path.relative(projectRoot, full).split(path.sep).join("/"))
 			}
 		}
 	}
 	return acc
 }
-const bunOwnedTests = collectBunTestFiles(path.join(projectRoot, "src"), [])
+const nonMochaOwnedTests = collectNonMochaTestFiles(path.join(projectRoot, "src"), [])
 // tsconfig.test.json is JSONC (contains comments); parse with json5 (a project dep).
 const JSON5 = require("json5")
 const baseTestConfig = JSON5.parse(fs.readFileSync(path.join(projectRoot, "tsconfig.test.json"), "utf-8"))
-baseTestConfig.exclude = [...(baseTestConfig.exclude ?? []), ...bunOwnedTests]
+baseTestConfig.exclude = [...(baseTestConfig.exclude ?? []), ...nonMochaOwnedTests]
 const generatedConfigPath = path.join(projectRoot, "tsconfig.test.generated.json")
 fs.writeFileSync(generatedConfigPath, JSON.stringify(baseTestConfig, null, "\t"))
 


### PR DESCRIPTION
## Summary

The `vscode test` job (Extension Integration Tests) is failing on `main` (and every branch that merges it) with:

```
TypeError: (0 , vitest_1.expect)(...).toHaveBeenCalledWith is not a function
TypeError: (0 , vitest_1.expect)(...).toHaveBeenCalledOnce is not a function
TypeError: (0 , vitest_1.expect)(...).not.toHaveBeenCalled is not a function
```

in the `updateAutoApprovalSettings` suite.

## Root cause

`apps/vscode/src/core/controller/state/updateAutoApprovalSettings.test.ts` (added in #11929) is **vitest-native** — declared in `vitest.config.ts` `include` and run via `test:vitest`. But the Mocha `@vscode/test-cli` integration runner also collects it (its glob covers `core/**`), and the Mocha extension-host runner does not register vitest's `expect` jest-matchers (`toHaveBeenCalledWith`, etc.), so the suite is double-collected and fails.

## Fix

`apps/vscode/scripts/build-tests.js` is the **single source of truth for the runner split**: it already scans for `bun:test`-owned tests and excludes them from the Node-based `out/` tree (so Mocha never compiles/collects them). This PR extends that exact mechanism to also exclude **vitest-owned** tests — files importing from `vitest` (including subpaths like `vitest/globals` and `@vitest/*`).

Result: neither bun- nor vitest-owned suites are ever compiled into the Mocha `out/` tree, so the integration runner physically cannot collect them — regardless of glob nuances.

## Why the compile-step (not a runner glob)

Excluding at compile time is the root-cause lever and matches the existing `bun:test` convention. A `.vscode-test.mjs` glob exclude was tried first but is the wrong layer (the test still compiles into `out/` and can be collected).

## Verification

- `node --check scripts/build-tests.js` — OK.
- Local dry-run of the detection: catches the `state` suite, catches all 48 `sdk` vitest suites, and still catches the existing 60 `__tests__` (bun) files — 123 non-mocha test files excluded total, zero mocha-owned tests affected.
- **No coverage lost** — these suites run under `test:vitest` / bun.

## Scope

One file (`apps/vscode/scripts/build-tests.js`), generalizing an existing exclusion. Surgical and idiomatic.

