### PR TITLE
fix(cli): preserve ClinePass provider on startup

### DIFF
--- a/apps/cli/src/connectors/session-runtime.test.ts
+++ b/apps/cli/src/connectors/session-runtime.test.ts
@@ -1,17 +1,15 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 const {
 	mockGetLastUsedProviderSettings,
 	mockGetProviderSettings,
 	mockResolveSystemPrompt,
 	mockGetProviderCollection,
-	mockGetBooleanFlagEnabled,
 } = vi.hoisted(() => ({
 	mockGetLastUsedProviderSettings: vi.fn(),
 	mockGetProviderSettings: vi.fn(),
 	mockResolveSystemPrompt: vi.fn(),
 	mockGetProviderCollection: vi.fn(),
-	mockGetBooleanFlagEnabled: vi.fn(),
 }));
 
 vi.mock("@cline/core", async () => {
@@ -45,12 +43,6 @@ vi.mock("../utils/helpers", () => ({
 	resolveWorkspaceRoot: vi.fn((cwd: string) => cwd),
 }));
 
-vi.mock("../utils/feature-flags", () => ({
-	getCliFeatureFlagsService: () => ({
-		getBooleanFlagEnabled: mockGetBooleanFlagEnabled,
-	}),
-}));
-
 vi.mock("../commands/auth", async () => {
 	const actual =
 		await vi.importActual<typeof import("../commands/auth")>(
@@ -65,10 +57,6 @@ vi.mock("../commands/auth", async () => {
 import { buildConnectorStartRequest } from "./session-runtime";
 
 describe("buildConnectorStartRequest", () => {
-	beforeEach(() => {
-		mockGetBooleanFlagEnabled.mockReturnValue(false);
-	});
-
 	afterEach(() => {
 		vi.clearAllMocks();
 		delete process.env.OPENROUTER_API_KEY;
@@ -100,9 +88,7 @@ describe("buildConnectorStartRequest", () => {
 		expect(request.provider).toBe("openrouter");
 		expect(request.apiKey).toBe("env-openrouter-key");
 		expect(request.model).toBe("anthropic/claude-sonnet-4.6");
-		expect(mockGetLastUsedProviderSettings).toHaveBeenCalledWith({
-			isClinePassEnabled: false,
-		});
+		expect(mockGetLastUsedProviderSettings).toHaveBeenCalledWith(undefined);
 	});
 
 	it("uses auth material resolved by provider settings manager", async () => {

--- a/apps/cli/src/connectors/session-runtime.ts
+++ b/apps/cli/src/connectors/session-runtime.ts
@@ -16,7 +16,6 @@ import {
 import type { CliLoggerAdapter } from "../logging/adapter";
 import { resolveSystemPrompt } from "../runtime/prompt";
 import { resolveCliSessionMetadata } from "../utils/enterprise";
-import { getCliFeatureFlagsService } from "../utils/feature-flags";
 import { resolveWorkspaceRoot } from "../utils/helpers";
 import {
 	parseLocalRowMetadata,
@@ -63,10 +62,7 @@ export async function buildConnectorStartRequest(input: {
 }): Promise<ChatStartSessionRequest> {
 	const providerSettingsManager = new ProviderSettingsManager();
 	const lastUsedProviderSettings =
-		providerSettingsManager.getLastUsedProviderSettings({
-			isClinePassEnabled:
-				getCliFeatureFlagsService().getBooleanFlagEnabled("ext-cline-pass"),
-		});
+		providerSettingsManager.getLastUsedProviderSettings();
 	const provider = normalizeProviderId(
 		input.options.provider?.trim() ||
 			lastUsedProviderSettings?.provider ||

--- a/apps/cli/src/main.test.ts
+++ b/apps/cli/src/main.test.ts
@@ -684,6 +684,9 @@ describe("runCli lightweight command dispatch", () => {
 
 		await expect(runCli()).resolves.toBeUndefined();
 		expect(
+			providerSettingsMocks.getLastUsedProviderSettings,
+		).toHaveBeenCalledWith(undefined);
+		expect(
 			migrationNoticeMocks.getClineCliMigrationNotice,
 		).toHaveBeenCalledWith(undefined, process.env, {
 			activeProviderId: "cline-pass",
@@ -980,7 +983,7 @@ describe("runCli lightweight command dispatch", () => {
 		);
 	});
 
-	it("seeds feature flag identity from persisted Cline account id before checking flags", async () => {
+	it("seeds feature flag identity from persisted Cline account id before restoring provider", async () => {
 		const clineSettings = {
 			provider: "cline",
 			model: "anthropic/claude-sonnet-4.6",
@@ -1003,8 +1006,12 @@ describe("runCli lightweight command dispatch", () => {
 			featureFlagMocks.setCliFeatureFlagsAccountContext.mock
 				.invocationCallOrder[0],
 		).toBeLessThan(
-			featureFlagMocks.getBooleanFlagEnabled.mock.invocationCallOrder[0],
+			providerSettingsMocks.getLastUsedProviderSettings.mock
+				.invocationCallOrder[0],
 		);
+		expect(
+			providerSettingsMocks.getLastUsedProviderSettings,
+		).toHaveBeenCalledWith(undefined);
 	});
 
 	it("runs kanban before loading runtime modules", async () => {

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -20,7 +20,6 @@ import {
 	CLI_COMPACTION_MODE_EXPECTED_TEXT,
 } from "./utils/compaction-mode";
 import {
-	getCliFeatureFlagsService,
 	refreshCliFeatureFlagsInBackground,
 	setCliFeatureFlagsAccountContext,
 } from "./utils/feature-flags";
@@ -955,10 +954,7 @@ export async function runCli(): Promise<void> {
 		}
 		refreshCliFeatureFlagsInBackground();
 		const lastUsedProviderSettings =
-			providerSettingsManager.getLastUsedProviderSettings({
-				isClinePassEnabled:
-					getCliFeatureFlagsService().getBooleanFlagEnabled("ext-cline-pass"),
-			});
+			providerSettingsManager.getLastUsedProviderSettings();
 		const provider = normalizeProviderId(
 			args.provider?.trim() || lastUsedProviderSettings?.provider || "cline",
 		);


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This fixes a CLI startup path where a saved ClinePass provider selection could be silently restored as regular Cline API mode when the local `ext-cline-pass` feature flag cache was false or stale.

The CLI previously passed `isClinePassEnabled` into `ProviderSettingsManager.getLastUsedProviderSettings()` during startup. In core, that option is not just a UI filter: when the saved last-used provider is `cline-pass` and the flag is false, it intentionally resolves the provider back to `cline`. That is appropriate for hiding ClinePass from discovery surfaces, but it is too aggressive for restoring an already persisted user selection. It means a user who had selected ClinePass could start a new CLI session while the feature flag was still refreshing in the background and end up running with the old Cline provider instead.

The change keeps feature flag refresh/identity seeding intact, but removes the feature-flag gate from provider restoration in:

- normal CLI startup
- connector session startup

Provider catalogs and onboarding/menu discovery can still use the feature flag to decide whether to expose ClinePass. The important behavioral change is that startup no longer lets a stale rollout flag rewrite persisted user intent.

I also updated the affected tests so they assert that startup restores provider settings without passing `isClinePassEnabled`, while still preserving the ordering that seeds feature-flag account context before provider restoration.

### Test Procedure

Ran the focused CLI startup and connector tests:

```sh
bun vitest run --config vitest.config.ts src/main.test.ts src/connectors/session-runtime.test.ts
```

Ran Biome on the touched files:

```sh
bun biome check --diagnostic-level=error apps/cli/src/main.ts apps/cli/src/connectors/session-runtime.ts apps/cli/src/main.test.ts apps/cli/src/connectors/session-runtime.test.ts
```

Ran the CLI typecheck:

```sh
bun run typecheck
```

Also ran the full CLI unit suite:

```sh
bun run test:unit
```

That broader suite currently fails in `src/commands/distribution-package.test.ts` (`rejects direct source package packing by default`) because the package dry-run exits `0` instead of being rejected by the direct publish guard. The failure is outside the changed provider restore paths; 107 test files passed and 1 failed.

The main thing this could affect is fallback behavior for users whose last-used provider is `cline-pass` while their local feature flag cache is false. That is the intended change: persisted/explicit provider selection should win at runtime. Discovery surfaces can continue using the feature flag independently.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. CLI runtime behavior change only.

### Additional Notes

This intentionally does not remove ClinePass feature flag checks from provider listing/onboarding surfaces. It only removes the flag from last-used provider restoration paths where the flag could cause a stale downgrade from `cline-pass` to `cline`.
