### PR TITLE
fix(cli): recover missing interactive sessions on message reads

### DIFF
--- a/apps/cli/src/runtime/interactive/session-runtime.test.ts
+++ b/apps/cli/src/runtime/interactive/session-runtime.test.ts
@@ -365,6 +365,48 @@ describe("createInteractiveSessionRuntime", () => {
 		expect(runtime.getActiveSessionId()).toBe("session-2");
 	});
 
+	it("recovers empty read-driven restarts when the active interactive session disappeared", async () => {
+		const manager = makeManager();
+		manager.readMessages.mockRejectedValueOnce(
+			new SessionNotFoundError("session-1"),
+		);
+		const runtime = makeRuntime(manager);
+
+		await runtime.ensureReady();
+		await runtime.restartWithCurrentMessages();
+
+		expect(manager.readMessages).toHaveBeenCalledWith("session-1");
+		expect(manager.start).toHaveBeenCalledTimes(2);
+		expect(manager.start).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining({
+				initialMessages: [],
+			}),
+		);
+		expect(runtime.getActiveSessionId()).toBe("session-2");
+	});
+
+	it("does not restart with stale messages when another operation changes the active session during a read", async () => {
+		const manager = makeManager();
+		let runtime!: ReturnType<typeof makeRuntime>;
+		manager.readMessages.mockImplementationOnce(async () => {
+			await runtime.restartEmpty();
+			return [
+				{
+					role: "user" as const,
+					content: [{ type: "text" as const, text: "stale" }],
+				},
+			];
+		});
+		runtime = makeRuntime(manager);
+
+		await runtime.ensureReady();
+		await runtime.restartWithCurrentMessages();
+
+		expect(manager.start).toHaveBeenCalledTimes(2);
+		expect(runtime.getActiveSessionId()).toBe("session-2");
+	});
+
 	it("waits for missing-session recovery before cleanup disposes the manager", async () => {
 		const manager = makeManager();
 		const recoveryRead = deferred<Message[]>();

--- a/apps/cli/src/runtime/interactive/session-runtime.ts
+++ b/apps/cli/src/runtime/interactive/session-runtime.ts
@@ -49,6 +49,13 @@ type CurrentTurnResult = Awaited<ReturnType<CliCore["send"]>>;
 type AskQuestionRef = {
 	current: ((question: string, options: string[]) => Promise<string>) | null;
 };
+type CurrentMessagesRead =
+	| { messages: Message[]; status: "read" }
+	| { messages: Message[]; status: "recovered" }
+	| { messages: Message[]; status: "stale" };
+type MissingSessionRecovery = {
+	messages: Message[];
+};
 type ToolPolicyResolver = (
 	toolName: string,
 ) => NonNullable<Config["toolPolicies"]>[string];
@@ -103,7 +110,9 @@ export function createInteractiveSessionRuntime(input: {
 	let shutdownRequested = false;
 	let activeSessionId = "";
 	let abortRequested = false;
-	let missingSessionRecoveryPromise: Promise<void> | undefined;
+	let missingSessionRecoveryPromise:
+		| Promise<MissingSessionRecovery>
+		| undefined;
 	// A reset can happen while an earlier manager.start() is still in flight.
 	// Bump this before resets and restarts so stale starts cannot become active.
 	let sessionStartGeneration = 0;
@@ -275,14 +284,34 @@ export function createInteractiveSessionRuntime(input: {
 		return await startupPromise;
 	};
 
-	const readCurrentMessages = async (): Promise<Message[]> => {
-		if (!sessionManager || !activeSessionId) {
-			return [];
+	const readCurrentMessages = async (): Promise<CurrentMessagesRead> => {
+		const manager = sessionManager;
+		const sessionId = activeSessionId;
+		if (!manager || !sessionId) {
+			return { messages: [], status: "read" };
 		}
-		return (await sessionManager.readMessages(activeSessionId)) ?? [];
+		try {
+			const messages = (await manager.readMessages(sessionId)) ?? [];
+			return {
+				messages,
+				status: activeSessionId === sessionId ? "read" : "stale",
+			};
+		} catch (error) {
+			if (
+				abortRequested ||
+				shutdownRequested ||
+				!isSessionNotFoundError(error)
+			) {
+				throw error;
+			}
+			const recovery = await recoverMissingActiveSession(error);
+			return { messages: recovery.messages, status: "recovered" };
+		}
 	};
 
-	const recoverMissingActiveSession = async (error: unknown): Promise<void> => {
+	const recoverMissingActiveSession = async (
+		error: unknown,
+	): Promise<MissingSessionRecovery> => {
 		if (missingSessionRecoveryPromise) {
 			return await missingSessionRecoveryPromise;
 		}
@@ -290,7 +319,7 @@ export function createInteractiveSessionRuntime(input: {
 			const manager = sessionManager;
 			const missingSessionId = activeSessionId;
 			if (!manager || !missingSessionId || shutdownRequested) {
-				return;
+				return { messages: [] };
 			}
 			const messages = await manager
 				.readMessages(missingSessionId)
@@ -307,6 +336,7 @@ export function createInteractiveSessionRuntime(input: {
 			startupError = undefined;
 			clearActiveSession();
 			await startFreshSession(messages);
+			return { messages };
 		})().finally(() => {
 			missingSessionRecoveryPromise = undefined;
 		});
@@ -361,7 +391,13 @@ export function createInteractiveSessionRuntime(input: {
 	};
 
 	const restartWithCurrentMessages = async (): Promise<void> => {
-		const messages = await readCurrentMessages();
+		const { messages, status } = await readCurrentMessages();
+		if (status !== "read") {
+			// If reading recovered a missing hub session, the current messages are
+			// already in the replacement session. If the read is stale, another async
+			// operation changed the active session while this read was in flight.
+			return;
+		}
 		await restartWithMessages(messages);
 	};
 
@@ -510,7 +546,13 @@ export function createInteractiveSessionRuntime(input: {
 		if (!sessionManager) {
 			return { messagesBefore: 0, messagesAfter: 0, compacted: false };
 		}
-		const messages = await readCurrentMessages();
+		const { messages, status } = await readCurrentMessages();
+		if (status === "stale" || (status === "recovered" && !activeSessionId)) {
+			return { messagesBefore: 0, messagesAfter: 0, compacted: false };
+		}
+		// If reading messages recovered the session, `messages` are the same messages
+		// used to seed the replacement session, so it is safe to compact the current
+		// active session with them.
 		const messagesBefore = messages.length;
 		if (messagesBefore === 0) {
 			return { messagesBefore: 0, messagesAfter: 0, compacted: false };
@@ -551,7 +593,10 @@ export function createInteractiveSessionRuntime(input: {
 			return undefined;
 		}
 		const checkpointHistory = readSessionCheckpointHistory(sessionRecord);
-		const messages = await readCurrentMessages();
+		const { messages, status } = await readCurrentMessages();
+		if (status !== "read") {
+			return undefined;
+		}
 		return { messages, checkpointHistory };
 	};
 

--- a/apps/cli/src/runtime/run-interactive.ts
+++ b/apps/cli/src/runtime/run-interactive.ts
@@ -389,7 +389,7 @@ export async function runInteractive(
 		? async () => {
 				try {
 					await sessionRuntime.ensureReady();
-					const messages = await sessionRuntime.readCurrentMessages();
+					const { messages } = await sessionRuntime.readCurrentMessages();
 					const usage = await sessionRuntime.getAccumulatedUsage({
 						inputTokens: 0,
 						outputTokens: 0,


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Fixes a CLI interactive session recovery crash when the active hub-backed session disappears before a read-driven restart, such as toggling Plan/Act mode or refreshing config after the local hub has been stopped.

The interactive runtime already recovered missing sessions during `sendCurrentTurn`, but reads of the current session messages could still throw `SessionNotFoundError`. This updates current-message reads to recover missing active sessions, return whether the active session changed, and preserve recovered messages for callers like manual compaction.

### Test Procedure

- Ran targeted unit tests:
  - `bun -F @cline/cli test:unit -- runtime/interactive/session-runtime.test.ts`
- Ran typecheck:
  - `bun -F @cline/cli typecheck`
- Manually verified the repro no longer crashes:
  1. In window A:
     ```sh
     env -u CLINE_BUILD_ENV -u NODE_ENV CLINE_SESSION_BACKEND_MODE=hub bun apps/cli/src/index.ts
     ```
  2. In window B:
     ```sh
     env -u CLINE_BUILD_ENV -u NODE_ENV CLINE_SESSION_BACKEND_MODE=hub bun apps/cli/src/index.ts hub stop
     ```
  3. Back in window A, hit Tab to toggle mode.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - CLI runtime behavior only.

### Additional Notes

This keeps `restartWithCurrentMessages()` from restarting again after recovery has already created a replacement session, while allowing compaction to continue using the recovered messages on the replacement session.
