### PR TITLE
fix(vscode): enable ClinePass by default

### DIFF
--- a/apps/vscode/src/core/task/index.ts
+++ b/apps/vscode/src/core/task/index.ts
@@ -87,7 +87,6 @@ import {
 } from "@shared/Languages";
 import { USER_CONTENT_TAGS } from "@shared/messages/constants";
 import { convertClineMessageToProto } from "@shared/proto-conversions/cline-message";
-import { FeatureFlag } from "@shared/services/feature-flags/feature-flags";
 import { type ClineDefaultTool, READ_ONLY_TOOLS } from "@shared/tools";
 import type { ClineAskResponse } from "@shared/WebviewMessage";
 import {
@@ -2039,9 +2038,9 @@ export class Task {
 				? apiConfig.planModeApiProvider
 				: apiConfig.actModeApiProvider
 		) as string;
+		const isClinePassEnabled = true;
 		const providerId =
-			configuredProviderId === "cline-pass" &&
-			!featureFlagsService.getBooleanFlagEnabled(FeatureFlag.CLINE_PASS)
+			configuredProviderId === "cline-pass" && !isClinePassEnabled
 				? "cline"
 				: configuredProviderId;
 		const customPrompt = this.stateManager.getGlobalSettingsKey("customPrompt");

--- a/apps/vscode/webview-ui/src/components/chat/CreditLimitError.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/CreditLimitError.tsx
@@ -2,10 +2,8 @@ import { AskResponseRequest } from "@shared/proto/cline/task"
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
 import React, { useEffect, useMemo, useState } from "react"
 import VSCodeButtonLink from "@/components/common/VSCodeButtonLink"
-import { CLINE_PASS_FEATURE_FLAG } from "@/constants/featureFlags"
 import { useClineAuth } from "@/context/ClineAuthContext"
 import { useExtensionState } from "@/context/ExtensionStateContext"
-import { useHasFeatureFlag } from "@/hooks/useFeatureFlag"
 import { AccountServiceClient, TaskServiceClient } from "@/services/grpc-client"
 import { useApiConfigurationHandlers } from "../settings/utils/useApiConfigurationHandlers"
 
@@ -32,7 +30,7 @@ const CreditLimitError: React.FC<CreditLimitErrorProps> = ({
 	const { activeOrganization } = useClineAuth()
 	const { mode, navigateToSettings } = useExtensionState()
 	const { handleModeFieldChange } = useApiConfigurationHandlers()
-	const isClinePassEnabled = useHasFeatureFlag(CLINE_PASS_FEATURE_FLAG)
+	const isClinePassEnabled = true
 	const [fullBuyCreditsUrl, setFullBuyCreditsUrl] = useState<string>("")
 	const [isSwitchingToClinePass, setIsSwitchingToClinePass] = useState(false)
 	const [didSwitchToClinePass, setDidSwitchToClinePass] = useState(false)

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/WelcomeSection.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/WelcomeSection.tsx
@@ -13,10 +13,8 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import HomeHeader from "@/components/welcome/HomeHeader"
 import { SuggestedTasks } from "@/components/welcome/SuggestedTasks"
 import CreateWorktreeModal from "@/components/worktrees/CreateWorktreeModal"
-import { CLINE_PASS_FEATURE_FLAG } from "@/constants/featureFlags"
 import { useClineAuth } from "@/context/ClineAuthContext"
 import { useExtensionState } from "@/context/ExtensionStateContext"
-import { useHasFeatureFlag } from "@/hooks/useFeatureFlag"
 import { AccountServiceClient, StateServiceClient, UiServiceClient, WorktreeServiceClient } from "@/services/grpc-client"
 import { convertBannerData } from "@/utils/bannerUtils"
 import { buildClinePassSubscriptionUrl } from "@/utils/clinePassSubscription"
@@ -64,7 +62,7 @@ export const WelcomeSection: React.FC<WelcomeSectionProps> = ({
 	}, [])
 
 	const { clineUser } = useClineAuth()
-	const isClinePassEnabled = useHasFeatureFlag(CLINE_PASS_FEATURE_FLAG)
+	const isClinePassEnabled = true
 	const {
 		openRouterModels,
 		navigateToSettings,

--- a/apps/vscode/webview-ui/src/components/onboarding/OnboardingView.tsx
+++ b/apps/vscode/webview-ui/src/components/onboarding/OnboardingView.tsx
@@ -7,9 +7,7 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Item, ItemContent, ItemDescription, ItemHeader, ItemMedia, ItemTitle } from "@/components/ui/item"
-import { CLINE_PASS_FEATURE_FLAG } from "@/constants/featureFlags"
 import { useExtensionState } from "@/context/ExtensionStateContext"
-import { useHasFeatureFlag } from "@/hooks/useFeatureFlag"
 import { cn } from "@/lib/utils"
 import { AccountServiceClient, StateServiceClient } from "@/services/grpc-client"
 import { setPendingClinePassSubscribe } from "./clinePassSubscribe"
@@ -301,7 +299,7 @@ const OnboardingStepContent = ({
 const OnboardingViewContent = ({ onboardingModels }: { onboardingModels: OnboardingModelGroup }) => {
 	const { handleFieldsChange } = useApiConfigurationHandlers()
 	const { openRouterModels, hideSettings, hideAccount, setShowWelcome } = useExtensionState()
-	const isClinePassEnabled = useHasFeatureFlag(CLINE_PASS_FEATURE_FLAG)
+	const isClinePassEnabled = true
 	const userTypeSelections = useMemo(() => getUserTypeSelections(isClinePassEnabled), [isClinePassEnabled])
 
 	const [stepNumber, setStepNumber] = useState(0)

--- a/apps/vscode/webview-ui/src/components/onboarding/useOnboardingModels.ts
+++ b/apps/vscode/webview-ui/src/components/onboarding/useOnboardingModels.ts
@@ -4,9 +4,7 @@ import { EmptyRequest } from "@shared/proto/cline/common"
 import type { ClineRecommendedModel } from "@shared/proto/cline/models"
 import type { OnboardingModel, OnboardingModelGroup } from "@shared/proto/cline/state"
 import { useEffect, useMemo, useState } from "react"
-import { CLINE_PASS_FEATURE_FLAG } from "@/constants/featureFlags"
 import { useExtensionState } from "@/context/ExtensionStateContext"
-import { useHasFeatureFlag } from "@/hooks/useFeatureFlag"
 import { ModelsServiceClient } from "@/services/grpc-client"
 import { CLINEPASS_GROUP, getRecommendedModelsData, type RecommendedModelsData } from "./data-models"
 
@@ -51,7 +49,7 @@ type FetchState = { status: "loading" } | { status: "success"; data: Recommended
 
 export function useOnboardingModels(): UseOnboardingModelsResult {
 	const { openRouterModels, clineModels, refreshClineModels } = useExtensionState()
-	const isClinePassEnabled = useHasFeatureFlag(CLINE_PASS_FEATURE_FLAG)
+	const isClinePassEnabled = true
 	const [fetchState, setFetchState] = useState<FetchState>({ status: "loading" })
 
 	useEffect(() => {

--- a/apps/vscode/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/ApiOptions.tsx
@@ -9,9 +9,7 @@ import styled from "styled-components"
 import { normalizeApiConfiguration } from "@/components/settings/utils/providerUtils"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { PLATFORM_CONFIG, PlatformType } from "@/config/platform.config"
-import { CLINE_PASS_FEATURE_FLAG } from "@/constants/featureFlags"
 import { useExtensionState } from "@/context/ExtensionStateContext"
-import { useHasFeatureFlag } from "@/hooks/useFeatureFlag"
 import { ModelsServiceClient } from "@/services/grpc-client"
 import { OPENROUTER_MODEL_PICKER_Z_INDEX } from "./OpenRouterModelPicker"
 import { AIhubmixProvider } from "./providers/AihubmixProvider"
@@ -101,7 +99,7 @@ const ApiOptions = ({
 }: ApiOptionsProps) => {
 	// Use full context state for immediate save payload
 	const { apiConfiguration, remoteConfigSettings } = useExtensionState()
-	const isClinePassEnabled = useHasFeatureFlag(CLINE_PASS_FEATURE_FLAG)
+	const isClinePassEnabled = true
 
 	const { selectedProvider } = normalizeApiConfiguration(apiConfiguration, currentMode, { isClinePassEnabled })
 


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This PR enables ClinePass by default in the legacy VS Code extension by bypassing the `ext-cline-pass` feature flag at the same product-surface gates where the flag could hide or demote ClinePass.

The immediate problem is that ClinePass availability has been depending on a backend feature flag path that can be wrong or unavailable. When that happens, users who should be able to use ClinePass see the feature hidden from onboarding/settings, miss the ClinePass CTA on credit-limit errors, do not see the welcome promo, or have a saved `cline-pass` provider treated as regular `cline` in task provider metadata. That creates the same user-facing class of failure that the CLI recently addressed by treating ClinePass as enabled regardless of the remote flag.

The approach here intentionally mirrors that CLI fix rather than changing the shared feature flag service. I left the generic feature flag hook and flag registry alone, and only replaced the ClinePass flag reads at the relevant VS Code call sites with `isClinePassEnabled = true`. That keeps the change explicit and narrowly scoped: ClinePass is always available in these surfaces, while every other feature flag continues to behave exactly as before.

Concretely, this affects:

- onboarding option visibility and ClinePass recommended model inclusion
- settings provider dropdown and normalization for `cline-pass`
- the credit-limit error CTA that lets users switch to ClinePass
- the welcome screen ClinePass promo banner
- task provider metadata so a configured `cline-pass` provider is not downgraded when the remote flag is false

I considered special-casing `useHasFeatureFlag()` or `FeatureFlagsService.getBooleanFlagEnabled()` for ClinePass, but that hides a product decision inside generic flag infrastructure. The call-site override is more direct and matches the CLI precedent: this feature should now be available, so the ClinePass-specific gates should behave as enabled.

### Test Procedure

I verified the change with focused checks around the touched VS Code and webview code:

```bash
cd apps/vscode
npx biome lint --config-path ./biome.jsonc src/core/task/index.ts webview-ui/src/components/chat/CreditLimitError.tsx webview-ui/src/components/chat/chat-view/components/layout/WelcomeSection.tsx webview-ui/src/components/onboarding/OnboardingView.tsx webview-ui/src/components/onboarding/useOnboardingModels.ts webview-ui/src/components/settings/ApiOptions.tsx --no-errors-on-unmatched --files-ignore-unknown=true --diagnostic-level=error
```

```bash
cd apps/vscode/webview-ui
npx tsc --noEmit --project tsconfig.json --pretty false
npm run test -- data-steps.test.ts data-models.test.ts
```

```bash
cd apps/vscode
npx tsc --noEmit --project tsconfig.json --pretty false
```

I also scanned for remaining direct ClinePass feature flag reads in the VS Code surfaces:

```bash
rg -n "useHasFeatureFlag\(CLINE_PASS_FEATURE_FLAG\)|getBooleanFlagEnabled\(FeatureFlag\.CLINE_PASS" apps/vscode/src apps/vscode/webview-ui/src -S
```

That search returns no remaining direct reads, so the known ClinePass gates no longer depend on the remote flag. The existing helper APIs and data tests remain intact, which keeps this patch small and avoids broader cleanup that can happen separately.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

No screenshots included. This change preserves existing UI layout and only changes whether existing ClinePass surfaces are visible/usable.

### Additional Notes

This intentionally leaves the stale ClinePass feature flag definitions and helper parameters in place. That is deliberate for parity with the CLI patch and to keep this PR focused on unblocking users. A later cleanup can remove the unused ClinePass rollout plumbing once we are comfortable treating ClinePass as permanently enabled everywhere.
