### PR TITLE
fix(cli): update ClinePass tests for forced-enabled behavior

### DIFF
--- a/apps/cli/src/connectors/session-runtime.test.ts
+++ b/apps/cli/src/connectors/session-runtime.test.ts
@@ -101,7 +101,7 @@ describe("buildConnectorStartRequest", () => {
 		expect(request.apiKey).toBe("env-openrouter-key");
 		expect(request.model).toBe("anthropic/claude-sonnet-4.6");
 		expect(mockGetLastUsedProviderSettings).toHaveBeenCalledWith({
-			isClinePassEnabled: false,
+			isClinePassEnabled: true,
 		});
 	});
 

--- a/apps/cli/src/main.test.ts
+++ b/apps/cli/src/main.test.ts
@@ -122,6 +122,7 @@ const telemetryMocks = vi.hoisted(() => ({
 const featureFlagMocks = vi.hoisted(() => ({
 	getBooleanFlagEnabled: vi.fn(() => false),
 	setCliFeatureFlagsAccountContext: vi.fn(),
+	refreshCliFeatureFlagsInBackground: vi.fn(),
 }));
 
 function forcePromptModeInput() {
@@ -186,7 +187,8 @@ vi.mock("./utils/feature-flags", () => ({
 	getCliFeatureFlagsService: () => ({
 		getBooleanFlagEnabled: featureFlagMocks.getBooleanFlagEnabled,
 	}),
-	refreshCliFeatureFlagsInBackground: vi.fn(),
+	refreshCliFeatureFlagsInBackground:
+		featureFlagMocks.refreshCliFeatureFlagsInBackground,
 	setCliFeatureFlagsAccountContext:
 		featureFlagMocks.setCliFeatureFlagsAccountContext,
 }));
@@ -265,6 +267,7 @@ describe("runCli lightweight command dispatch", () => {
 		featureFlagMocks.getBooleanFlagEnabled.mockReset();
 		featureFlagMocks.getBooleanFlagEnabled.mockReturnValue(false);
 		featureFlagMocks.setCliFeatureFlagsAccountContext.mockReset();
+		featureFlagMocks.refreshCliFeatureFlagsInBackground.mockReset();
 		kanbanMocks.launchKanban.mockReset();
 		kanbanMocks.launchKanban.mockResolvedValue(0);
 		dashboardMocks.runDashboardCommand.mockReset();
@@ -980,7 +983,7 @@ describe("runCli lightweight command dispatch", () => {
 		);
 	});
 
-	it("seeds feature flag identity from persisted Cline account id before checking flags", async () => {
+	it("seeds feature flag identity from persisted Cline account id before refreshing flags", async () => {
 		const clineSettings = {
 			provider: "cline",
 			model: "anthropic/claude-sonnet-4.6",
@@ -999,11 +1002,14 @@ describe("runCli lightweight command dispatch", () => {
 		expect(
 			featureFlagMocks.setCliFeatureFlagsAccountContext,
 		).toHaveBeenCalledWith({ id: "acct-startup" });
+		// The account identity must be seeded before flags are refreshed/used so
+		// the background refresh resolves flags for the correct account.
 		expect(
 			featureFlagMocks.setCliFeatureFlagsAccountContext.mock
 				.invocationCallOrder[0],
 		).toBeLessThan(
-			featureFlagMocks.getBooleanFlagEnabled.mock.invocationCallOrder[0],
+			featureFlagMocks.refreshCliFeatureFlagsInBackground.mock
+				.invocationCallOrder[0],
 		);
 	});
 

--- a/apps/cli/src/utils/provider-catalog.test.ts
+++ b/apps/cli/src/utils/provider-catalog.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
 	listLocalProviders: vi.fn(async () => ({ providers: [], settingsPath: "" })),
-	getBooleanFlagEnabled: vi.fn(() => true),
 }));
 
 vi.mock("@cline/core", async (importOriginal) => {
@@ -13,20 +12,13 @@ vi.mock("@cline/core", async (importOriginal) => {
 	};
 });
 
-vi.mock("./feature-flags", () => ({
-	getCliFeatureFlagsService: () => ({
-		getBooleanFlagEnabled: mocks.getBooleanFlagEnabled,
-	}),
-}));
-
 describe("listLocalProviders", () => {
-	it("passes the ClinePass feature flag into the SDK provider list", async () => {
+	it("enables ClinePass when listing the SDK provider list", async () => {
 		const { listLocalProviders } = await import("./provider-catalog");
 		const manager = {} as never;
 
 		await listLocalProviders(manager);
 
-		expect(mocks.getBooleanFlagEnabled).toHaveBeenCalledWith("ext-cline-pass");
 		expect(mocks.listLocalProviders).toHaveBeenCalledWith(manager, {
 			isClinePassEnabled: true,
 		});


### PR DESCRIPTION
## Summary

**#11986 ("Forcefully enable ClinePass on the CLI")** hardcoded `isClinePassEnabled: true` in the CLI source (`session-runtime.ts`, `provider-catalog.ts`, `main.ts`) and removed the `ext-cline-pass` feature-flag check — but left the corresponding tests asserting the old flag-driven / disabled behavior. Those tests now fail on `main`, which red-lines the `Test (ubuntu-latest, Node 24.x)` job on `main` and **every branch that merges main**.

Reproduced on clean latest `main`:
```
FAIL src/connectors/session-runtime.test.ts  expected isClinePassEnabled: false → Received: true
FAIL src/utils/provider-catalog.test.ts      getBooleanFlagEnabled('ext-cline-pass') never called
FAIL src/main.test.ts                        getBooleanFlagEnabled never called → invocationCallOrder[0] undefined
```

## Fix (tests only — aligns them with #11986's intended behavior)

- **`session-runtime.test.ts`** — assert `getLastUsedProviderSettings` is called with `isClinePassEnabled: true`.
- **`provider-catalog.test.ts`** — drop the obsolete `getBooleanFlagEnabled('ext-cline-pass')` assertion (the source no longer reads the flag — it hardcodes `true`) and its now-unused `./feature-flags` mock; keep the `isClinePassEnabled: true` expectation.
- **`main.test.ts`** — `getBooleanFlagEnabled` is no longer called during startup, so the "seed identity before checking flags" ordering assertion targeted an uncalled mock. Re-target it at `refreshCliFeatureFlagsInBackground`, which **is** still invoked right after the identity is seeded (so the intent — seed the account identity before flags are refreshed/used — is preserved), and wire that mock through `featureFlagMocks`.

No source/behavior changes — only the tests are updated to match the shipped #11986 behavior.

## Verification

- The 3 files: `bunx vitest run` — **72 passed** (were 3 failing on clean main).

## Note (separate, pre-existing)

The full `@cline/cli` suite also has one **unrelated** pre-existing failure on `main`: `src/commands/doctor.test.ts > doctor --fix clears wedged hub startup artifacts when no server is actually running`. Confirmed it fails on clean `main` with this PR's changes stashed, so it is out of scope here and should be fixed separately.
