### PR TITLE
fix(cli): sign Darwin release binaries

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -48,7 +48,7 @@ jobs:
       github.event.inputs.publish_target == 'main' &&
       github.event.inputs.confirm_publish == 'publish' &&
       !endsWith(github.actor, '[bot]')
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
       - name: Checkout code
@@ -269,7 +269,7 @@ jobs:
           github.event.inputs.publish_target == 'nightly'
         )
       )
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
       - name: Checkout code

--- a/apps/cli/script/build.ts
+++ b/apps/cli/script/build.ts
@@ -222,6 +222,34 @@ async function buildCompiledBinary(input: {
 	await $`rm -rf ${tmpDir}`;
 }
 
+async function signDarwinBinary(input: {
+	os: string;
+	name: string;
+	outfile: string;
+}): Promise<void> {
+	if (input.os !== "darwin") {
+		return;
+	}
+
+	if (process.platform !== "darwin") {
+		if (process.env.CLINE_ALLOW_UNSIGNED_DARWIN_BINARIES === "1") {
+			console.warn(
+				`  Skipping codesign for ${input.name}: host platform is ${process.platform}`,
+			);
+			return;
+		}
+
+		throw new Error(
+			`Darwin CLI binaries must be signed on macOS before publishing (${input.name}). ` +
+				"Run this build on macOS, or set CLINE_ALLOW_UNSIGNED_DARWIN_BINARIES=1 for a local unsigned cross-build.",
+		);
+	}
+
+	console.log(`  Codesign: ${input.outfile}`);
+	await $`codesign --force -s - ${input.outfile}`;
+	await $`codesign --verify --verbose=4 ${input.outfile}`;
+}
+
 for (const item of targets) {
 	// npm treats "win32" specially in os field, but for package naming use "windows"
 	const displayOs = item.os === "win32" ? "windows" : item.os;
@@ -237,6 +265,7 @@ for (const item of targets) {
 	const outfile = join(outDir, binaryName);
 
 	await buildCompiledBinary({ bunTarget, dirName, outfile });
+	await signDarwinBinary({ os: item.os, name, outfile });
 
 	// Smoke test: only run on current platform
 	if (item.os === process.platform && item.arch === process.arch) {


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Fixes the macOS CLI release packaging path so Darwin platform binaries are ad-hoc signed after Bun compile and verified before packaging.

The published `@cline/cli-darwin-arm64@3.0.34` artifact currently fails `codesign --verify` with `invalid signature (code or signature have been modified)`. Bun's compile step leaves a linker-signed ad-hoc signature that can become invalid once the JS bundle is embedded. Re-signing with `codesign --force -s -` after compile repairs the code signature integrity check.

This PR keeps the fix deliberately small:

- Add a Darwin-only signing step in `apps/cli/script/build.ts`.
- Verify the Darwin signature immediately after signing.
- Fail Darwin builds on non-macOS hosts unless `CLINE_ALLOW_UNSIGNED_DARWIN_BINARIES=1` is explicitly set for local unsigned cross-builds.
- Run the CLI publish jobs on macOS so `/usr/bin/codesign` is available.

This does move the publish job host from Ubuntu to macOS. That is broader than the signing call itself, but it keeps the release flow simple and avoids a larger split-artifact workflow.

### Test Procedure

- Downloaded the published `@cline/cli-darwin-arm64@3.0.34` tarball and verified `codesign --verify --verbose=4 package/bin/cline` fails with `invalid signature (code or signature have been modified)`.
- Confirmed the same published binary still runs basic commands locally with `package/bin/cline --version` and `package/bin/cline --help`.
- Copied the published binary, ran `codesign --force -s - ./cline-resigned`, then verified `codesign --verify --verbose=4 ./cline-resigned` succeeds and `./cline-resigned --version` still prints `3.0.34`.
- Ran `bun install --frozen-lockfile`.
- Ran `bun build apps/cli/script/build.ts --target=bun --outfile=/tmp/cline-build-script-check.js`.
- Ran `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/cli-publish.yml"); puts "yaml ok"'`.
- Ran `bun biome check --write .github/workflows/cli-publish.yml apps/cli/script/build.ts`.
- Ran `go run github.com/rhysd/actionlint/cmd/actionlint@latest -ignore 'softprops/action-gh-release@v1' .github/workflows/cli-publish.yml`.
- Attempted `bun -F @cline/cli build:platforms:single`; it is blocked before the patched signing step by an existing Cline Hub webview Vite/Rolldown failure resolving `entities` subpaths (`./escape` and `./decode`).

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

Existing npm releases are immutable, so this fix needs to ship in a new CLI version.

`actionlint` without the ignore flag currently reports the existing `softprops/action-gh-release@v1` action as too old. That warning is unrelated to this change, so the targeted run above ignored only that known warning.
