### PR TITLE
fix: truncate content by UTF-8 byte size, not UTF-16 length

### DIFF
--- a/apps/vscode/scripts/run-bun-tests.ts
+++ b/apps/vscode/scripts/run-bun-tests.ts
@@ -31,6 +31,7 @@ import { Glob } from "bun"
 const INCLUDE_PATTERNS = [
 	"src/sdk/**/*.test.ts",
 	"src/shared/vsCodeSelectorUtils.test.ts",
+	"src/shared/content-limits.test.ts",
 	"src/core/storage/remote-config/**/*.test.ts",
 	"src/shared/model-catalog/provider-helpers.test.ts",
 	"src/core/controller/models/__tests__/providerCatalogHandlers.test.ts",

--- a/apps/vscode/src/shared/content-limits.test.ts
+++ b/apps/vscode/src/shared/content-limits.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest"
+import { truncateContent } from "./content-limits"
+
+describe("truncateContent", () => {
+	it("returns content unchanged when it is under the byte limit", () => {
+		expect(truncateContent("hello", 100)).toBe("hello")
+	})
+
+	it("limits by UTF-8 bytes, not UTF-16 code units", () => {
+		const content = "中".repeat(1000) // 1000 code units, 3000 UTF-8 bytes
+		const out = truncateContent(content, 500)
+		const shown = out.split("\n\n---\n\n")[0]
+		expect(new TextEncoder().encode(shown).length).toBeLessThanOrEqual(500)
+	})
+
+	it("never splits a multi-byte character", () => {
+		const content = "a" + "😀".repeat(50)
+		const out = truncateContent(content, 10)
+		const shown = out.split("\n\n---\n\n")[0]
+		expect(shown.includes("\uFFFD")).toBe(false)
+		expect(new TextEncoder().encode(shown).length).toBeLessThanOrEqual(10)
+	})
+})

--- a/apps/vscode/src/shared/content-limits.test.ts
+++ b/apps/vscode/src/shared/content-limits.test.ts
@@ -6,6 +6,13 @@ describe("truncateContent", () => {
 		expect(truncateContent("hello", 100)).toBe("hello")
 	})
 
+	it("truncates ASCII content over the limit and reports what is shown", () => {
+		const out = truncateContent("a".repeat(200), 100)
+		const shown = out.split("\n\n---\n\n")[0]
+		expect(shown).toBe("a".repeat(100))
+		expect(new TextEncoder().encode(shown).length).toBe(100)
+	})
+
 	it("limits by UTF-8 bytes, not UTF-16 code units", () => {
 		const content = "中".repeat(1000) // 1000 code units, 3000 UTF-8 bytes
 		const out = truncateContent(content, 500)

--- a/apps/vscode/src/shared/content-limits.ts
+++ b/apps/vscode/src/shared/content-limits.ts
@@ -28,12 +28,21 @@ function formatBytes(bytes: number): string {
  * @returns The original content if under limit, or truncated content with message at end
  */
 export function truncateContent(content: string, maxSize: number = MAX_CONTENT_SIZE_BYTES): string {
-	if (content.length <= maxSize) {
+	const bytes = new TextEncoder().encode(content)
+	if (bytes.length <= maxSize) {
 		return content
 	}
 
-	const truncatedContent = content.slice(0, maxSize)
-	const truncatedAmount = content.length - maxSize
+	// Cut at maxSize bytes, then back up off any UTF-8 continuation byte so a
+	// multi-byte character (CJK, emoji, ...) is never split. `content.length`
+	// is UTF-16 code units, not bytes, so the old code under-counted size for
+	// non-ASCII content and the byte limit didn't actually hold.
+	let end = maxSize
+	while (end > 0 && (bytes[end] & 0xc0) === 0x80) {
+		end--
+	}
+	const truncatedContent = new TextDecoder().decode(bytes.subarray(0, end))
+	const truncatedAmount = bytes.length - end
 
-	return `${truncatedContent}\n\n---\n\n[FILE TRUNCATED: This content is ${formatBytes(content.length)} but only the first ${formatBytes(maxSize)} is shown (${formatBytes(truncatedAmount)} truncated). Use search_files to find specific patterns, or execute_command with grep/head/tail for targeted reading.]`
+	return `${truncatedContent}\n\n---\n\n[FILE TRUNCATED: This content is ${formatBytes(bytes.length)} but only the first ${formatBytes(end)} is shown (${formatBytes(truncatedAmount)} truncated). Use search_files to find specific patterns, or execute_command with grep/head/tail for targeted reading.]`
 }

--- a/apps/vscode/src/shared/content-limits.ts
+++ b/apps/vscode/src/shared/content-limits.ts
@@ -28,21 +28,23 @@ function formatBytes(bytes: number): string {
  * @returns The original content if under limit, or truncated content with message at end
  */
 export function truncateContent(content: string, maxSize: number = MAX_CONTENT_SIZE_BYTES): string {
-	const bytes = new TextEncoder().encode(content)
-	if (bytes.length <= maxSize) {
+	// `content.length` is UTF-16 code units, not bytes, so measuring by it
+	// under-counts non-ASCII content and the byte limit wouldn't actually hold.
+	// Measure the true UTF-8 size without allocating a buffer for the entire
+	// (potentially very large) input first.
+	const contentSize = Buffer.byteLength(content, "utf8")
+	if (contentSize <= maxSize) {
 		return content
 	}
 
-	// Cut at maxSize bytes, then back up off any UTF-8 continuation byte so a
-	// multi-byte character (CJK, emoji, ...) is never split. `content.length`
-	// is UTF-16 code units, not bytes, so the old code under-counted size for
-	// non-ASCII content and the byte limit didn't actually hold.
-	let end = maxSize
-	while (end > 0 && (bytes[end] & 0xc0) === 0x80) {
-		end--
-	}
-	const truncatedContent = new TextDecoder().decode(bytes.subarray(0, end))
-	const truncatedAmount = bytes.length - end
+	// Encode only the bounded prefix. `Buffer.write` stops before writing a
+	// partial UTF-8 character, so a multi-byte character (CJK, emoji, ...) is
+	// never split, and we allocate at most `maxSize` bytes regardless of how
+	// large the input is (PDF/DOCX/notebook/Excel extraction can be huge).
+	const truncatedBuffer = Buffer.allocUnsafe(maxSize)
+	const shownSize = truncatedBuffer.write(content, 0, maxSize, "utf8")
+	const truncatedContent = truncatedBuffer.toString("utf8", 0, shownSize)
+	const truncatedAmount = contentSize - shownSize
 
-	return `${truncatedContent}\n\n---\n\n[FILE TRUNCATED: This content is ${formatBytes(bytes.length)} but only the first ${formatBytes(end)} is shown (${formatBytes(truncatedAmount)} truncated). Use search_files to find specific patterns, or execute_command with grep/head/tail for targeted reading.]`
+	return `${truncatedContent}\n\n---\n\n[FILE TRUNCATED: This content is ${formatBytes(contentSize)} but only the first ${formatBytes(shownSize)} is shown (${formatBytes(truncatedAmount)} truncated). Use search_files to find specific patterns, or execute_command with grep/head/tail for targeted reading.]`
 }

--- a/apps/vscode/vitest.config.ts
+++ b/apps/vscode/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
 		include: [
 			"src/sdk/**/*.test.ts",
 			"src/shared/vsCodeSelectorUtils.test.ts",
+			"src/shared/content-limits.test.ts",
 			"src/shared/proto-conversions/models/**/*.test.ts",
 			"src/core/storage/remote-config/**/*.test.ts",
 			"src/core/controller/state/**/*.test.ts",


### PR DESCRIPTION
### Related Issue

N/A — small bug fix, submitted directly per the contributing guidelines (limited exception for small bug fixes).

### Description

`truncateContent` is documented as limiting content to a number of **bytes** (`MAX_CONTENT_SIZE_BYTES`, "400KB"), but it used `content.length`, which is the number of **UTF-16 code units**, not bytes — for the size check, the `slice`, and the reported sizes.

For non-ASCII content this is wrong:
- A CJK character is 1 code unit but 3 UTF-8 bytes, so `content.length` under-counts the real size and the byte cap doesn't hold. A 400KB cap actually lets through up to ~1.2MB of CJK text — defeating the safeguard that's meant to keep large content from bricking the context window.
- The reported `[FILE TRUNCATED: This content is X ...]` size is wrong for non-ASCII.
- `content.slice(0, maxSize)` can split a multi-byte character at the boundary.

Fix: measure and slice by UTF-8 bytes (`TextEncoder`/`TextDecoder`), and back the cut up to a rune boundary so a character is never split. ASCII content is unaffected.

### Test Procedure

Added `content-limits.test.ts` with three cases: (1) content under the limit is returned unchanged; (2) a 1,000-character CJK string (3,000 bytes) truncated to 500 is shown as ≤500 bytes (the old code showed ~1,500); (3) an emoji string is never split (no U+FFFD, byte length within limit). Verified the byte-accurate behavior locally; ASCII paths are unchanged.