### PR TITLE
fix(vscode): compact tasks opened from history

### DIFF
--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -512,6 +512,7 @@ export class Controller {
 				await this.mode.waitForPendingRebuild()
 				await this.sessionRebuilds.waitUntilSettled()
 			},
+			runExclusive: (operation) => this.sessionRebuilds.runExclusive(operation),
 			getTask: () => this.task,
 			createTempSessionHost: () => VscodeSessionHost.create({ mcpHub: this.mcpHub }),
 			getWorkspaceRoot: () => this.getWorkspaceRoot(),
@@ -524,6 +525,13 @@ export class Controller {
 			postStateToWebview: () => this.postStateToWebview(),
 			onResumeFailed: () => {
 				this.turnStateTracker.set("error")
+			},
+			onFollowUpAbandoned: () => {
+				// Settle the streaming phase askResponse pre-set, unless a turn
+				// (for example on the newly displayed task) has actually started.
+				if (this.turnStateTracker.currentPhase === "streaming" && !this.sessions.getActiveSession()?.isRunning) {
+					this.turnStateTracker.set("idle")
+				}
 			},
 		})
 		this.taskControl = new SdkTaskControlCoordinator({
@@ -575,8 +583,13 @@ export class Controller {
 		this.compaction = new SdkCompactionCoordinator({
 			stateManager: this.stateManager,
 			sessions: this.sessions,
+			rebuilds: this.sessionRebuilds,
 			messages: this.messages,
+			taskHistory: this.taskHistory,
 			sessionConfigBuilder: this.sessionConfigBuilder,
+			getDisplayedTaskId: () => this.task?.taskId,
+			createTempSessionHost: () => VscodeSessionHost.create({ mcpHub: this.mcpHub }),
+			loadInitialMessages: (reader, taskId) => this.sessionHistory.loadInitialMessages(reader, taskId),
 			getWorkspaceRoot: () => this.getWorkspaceRoot(),
 			postStateToWebview: () => this.postStateToWebview(),
 		})

--- a/apps/vscode/src/sdk/sdk-compaction-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-compaction-coordinator.test.ts
@@ -27,15 +27,15 @@ describe("SdkCompactionCoordinator", () => {
 		vi.clearAllMocks()
 	})
 
-	it("emits an info message and does not rebuild when there is no active session", async () => {
+	it("reports when there is no active session or displayed task", async () => {
 		const { coordinator, options } = makeCoordinator({ activeSession: undefined })
 
 		await coordinator.compactTask()
 
-		expect(options.sessions.replaceActiveSession).not.toHaveBeenCalled()
+		expect(options.sessions.startNewSession).not.toHaveBeenCalled()
 		expect(mockCreateContextCompactionPrepareTurn).not.toHaveBeenCalled()
 		expect(options.messages.appendAndEmit).toHaveBeenCalledWith(
-			[expect.objectContaining({ say: "info", text: "There is no active task to compact." })],
+			[expect.objectContaining({ say: "info", text: "There is no task to compact." })],
 			expect.anything(),
 		)
 	})
@@ -47,7 +47,7 @@ describe("SdkCompactionCoordinator", () => {
 		await coordinator.compactTask()
 
 		expect(mockCreateContextCompactionPrepareTurn).not.toHaveBeenCalled()
-		expect(options.sessions.replaceActiveSession).not.toHaveBeenCalled()
+		expect(options.sessions.startNewSession).not.toHaveBeenCalled()
 		expect(options.messages.appendAndEmit).toHaveBeenCalledWith(
 			[expect.objectContaining({ say: "info", text: expect.stringContaining("Cannot compact while a response") })],
 			expect.anything(),
@@ -62,7 +62,6 @@ describe("SdkCompactionCoordinator", () => {
 		await coordinator.compactTask()
 
 		expect(mockCreateContextCompactionPrepareTurn).not.toHaveBeenCalled()
-		expect(options.sessions.replaceActiveSession).not.toHaveBeenCalled()
 		expect(options.messages.appendAndEmit).toHaveBeenCalledWith(
 			[expect.objectContaining({ say: "info", text: "No messages to compact." })],
 			expect.anything(),
@@ -92,12 +91,59 @@ describe("SdkCompactionCoordinator", () => {
 		await coordinator.compactTask()
 
 		expect(mockCreateContextCompactionPrepareTurn).toHaveBeenCalledOnce()
-		expect(options.sessions.replaceActiveSession).not.toHaveBeenCalled()
 		const rows = compactionRows(options)
 		expect(rows[0].info.status).toBe("started")
 		expect(rows[1].info.status).toBe("skipped")
 		// The terminal row updates the started row in place (same ts).
 		expect(rows[1].ts).toBe(rows[0].ts)
+	})
+
+	it("holds active-session compaction inside the rebuild mutex", async () => {
+		const activeSession = makeActiveSession()
+		const { coordinator, options } = makeCoordinator({ activeSession })
+		mockCreateContextCompactionPrepareTurn.mockReturnValueOnce(
+			vi.fn().mockResolvedValue({ messages: [{ role: "user", content: "summary" }] }),
+		)
+
+		await coordinator.compactTask()
+
+		expect(options.rebuilds.runExclusive).toHaveBeenCalledOnce()
+		expect(activeSession.sdkHost.updateSessionCompactionState).toHaveBeenCalled()
+	})
+
+	it("does not compact a different session installed while waiting for the mutex", async () => {
+		const activeSession = makeActiveSession()
+		const replacementSession = makeActiveSession({ sessionId: "different-task" })
+		const { coordinator, options } = makeCoordinator({ activeSession })
+		// Entry check sees the original session; inside the mutex a different
+		// task's session has taken its place.
+		options.sessions.getActiveSession.mockReturnValueOnce(activeSession).mockReturnValue(replacementSession)
+
+		await coordinator.compactTask()
+
+		expect(mockCreateContextCompactionPrepareTurn).not.toHaveBeenCalled()
+		expect(activeSession.sdkHost.readMessages).not.toHaveBeenCalled()
+		expect(replacementSession.sdkHost.readMessages).not.toHaveBeenCalled()
+	})
+
+	it("compacts through the rebuilt host when an idle rebuild replaced the session object", async () => {
+		const activeSession = makeActiveSession()
+		// Same conversation (sessionId), new session object and host after a
+		// provider/MCP/terminal-mode rebuild drained while we waited.
+		const rebuiltSession = makeActiveSession()
+		const { coordinator, options } = makeCoordinator({ activeSession })
+		options.sessions.getActiveSession.mockReturnValueOnce(activeSession).mockReturnValue(rebuiltSession)
+		mockCreateContextCompactionPrepareTurn.mockReturnValueOnce(
+			vi.fn().mockResolvedValue({ messages: [{ role: "user", content: "summary" }] }),
+		)
+
+		await coordinator.compactTask()
+
+		expect(activeSession.sdkHost.readMessages).not.toHaveBeenCalled()
+		expect(rebuiltSession.sdkHost.updateSessionCompactionState).toHaveBeenCalledWith("old-session", {
+			version: 1,
+			messages: [{ role: "user", content: "summary" }],
+		})
 	})
 
 	it("compacts and persists the sidecar without rebuilding the session", async () => {
@@ -118,13 +164,12 @@ describe("SdkCompactionCoordinator", () => {
 			version: 1,
 			messages: [{ role: "user", content: "summary" }],
 		})
-		expect(options.sessions.replaceActiveSession).not.toHaveBeenCalled()
+		expect(options.sessions.startNewSession).not.toHaveBeenCalled()
 		const rows = compactionRows(options)
 		expect(rows[0].info).toMatchObject({ status: "started", mode: "manual" })
 		expect(rows[1].info).toMatchObject({ status: "completed", mode: "manual", messagesBefore: 3, messagesAfter: 1 })
 		expect(rows[1].ts).toBe(rows[0].ts)
 	})
-
 	it("prefers the SDK's token counters from its status notice for the completed divider", async () => {
 		const activeSession = makeActiveSession()
 		const { coordinator, options } = makeCoordinator({ activeSession })
@@ -158,7 +203,10 @@ describe("SdkCompactionCoordinator", () => {
 	it("does not append compaction status to a different active session", async () => {
 		const activeSession = makeActiveSession()
 		const { coordinator, options } = makeCoordinator({ activeSession })
+		// Same session at the entry check and the inside-mutex identity check;
+		// replaced during compaction so the emit-time fencing must engage.
 		options.sessions.getActiveSession
+			.mockReturnValueOnce(activeSession)
 			.mockReturnValueOnce(activeSession)
 			.mockReturnValue(makeActiveSession({ sessionId: "other-session" }))
 		mockCreateContextCompactionPrepareTurn.mockReturnValueOnce(
@@ -171,7 +219,7 @@ describe("SdkCompactionCoordinator", () => {
 		expect(options.messages.appendAndEmit).not.toHaveBeenCalled()
 	})
 
-	it("does not restart or report success when sidecar persistence fails", async () => {
+	it("does not report success when sidecar persistence fails", async () => {
 		const activeSession = makeActiveSession()
 		activeSession.sdkHost.updateSessionCompactionState.mockResolvedValueOnce({ updated: false })
 		const { coordinator, options } = makeCoordinator({ activeSession })
@@ -181,7 +229,6 @@ describe("SdkCompactionCoordinator", () => {
 
 		await coordinator.compactTask()
 
-		expect(options.sessions.replaceActiveSession).not.toHaveBeenCalled()
 		const rows = compactionRows(options)
 		expect(rows[rows.length - 1].info.status).toBe("failed")
 		expect(options.messages.appendAndEmit).toHaveBeenCalledWith(
@@ -197,13 +244,133 @@ describe("SdkCompactionCoordinator", () => {
 
 		await coordinator.compactTask()
 
-		expect(options.sessions.replaceActiveSession).not.toHaveBeenCalled()
 		const rows = compactionRows(options)
 		expect(rows[rows.length - 1].info.status).toBe("failed")
 		expect(options.messages.appendAndEmit).toHaveBeenCalledWith(
 			[expect.objectContaining({ say: "info", text: "Couldn't compact the conversation. Please try again." })],
 			expect.anything(),
 		)
+	})
+	it("resumes a displayed history task in an isolated host, compacts it, then disposes it", async () => {
+		const { coordinator, options, resumedHost } = makeCoordinator({
+			activeSession: undefined,
+			displayedTaskId: "history-task",
+		})
+		resumedHost.readMessages.mockResolvedValueOnce([
+			{ role: "user", content: "1" },
+			{ role: "assistant", content: "2" },
+		])
+		mockCreateContextCompactionPrepareTurn.mockReturnValueOnce(
+			vi.fn().mockResolvedValue({ messages: [{ role: "user", content: "summary" }] }),
+		)
+
+		await coordinator.compactTask()
+
+		expect(options.rebuilds.runExclusive).toHaveBeenCalledOnce()
+		expect(resumedHost.start).toHaveBeenCalledWith(
+			expect.objectContaining({ config: expect.objectContaining({ sessionId: "history-task" }), interactive: true }),
+		)
+		expect(resumedHost.updateSessionCompactionState).toHaveBeenCalledWith("history-task", {
+			version: 1,
+			messages: [{ role: "user", content: "summary" }],
+		})
+		expect(resumedHost.stop).toHaveBeenCalledWith("history-task")
+		expect(resumedHost.dispose).toHaveBeenCalledWith("compactDisplayedTask")
+		expect(options.sessions.startNewSession).not.toHaveBeenCalled()
+		expect(options.sessions.endActiveSession).not.toHaveBeenCalled()
+		const rows = compactionRows(options)
+		expect(rows[rows.length - 1].info).toMatchObject({ status: "completed", messagesBefore: 2, messagesAfter: 1 })
+	})
+
+	it("waits for the task's in-flight stop before starting the isolated session", async () => {
+		const { coordinator, options, resumedHost } = makeCoordinator({
+			activeSession: undefined,
+			displayedTaskId: "history-task",
+		})
+		let stopSettled = false
+		options.sessions.waitForPendingStop.mockImplementationOnce(async () => {
+			stopSettled = true
+		})
+		resumedHost.start.mockImplementationOnce(async (input: { config?: { sessionId?: string } }) => {
+			expect(stopSettled).toBe(true)
+			return { sessionId: input.config?.sessionId ?? "resumed-session" }
+		})
+		mockCreateContextCompactionPrepareTurn.mockReturnValueOnce(
+			vi.fn().mockResolvedValue({ messages: [{ role: "user", content: "summary" }] }),
+		)
+
+		await coordinator.compactTask()
+
+		expect(options.sessions.waitForPendingStop).toHaveBeenCalledWith("history-task")
+		expect(resumedHost.start).toHaveBeenCalledOnce()
+	})
+
+	it("disposes the isolated session even when displayed-task compaction fails", async () => {
+		const { coordinator, options, resumedHost } = makeCoordinator({
+			activeSession: undefined,
+			displayedTaskId: "history-task",
+		})
+		resumedHost.readMessages.mockRejectedValueOnce(new Error("boom"))
+
+		await coordinator.compactTask()
+
+		expect(resumedHost.stop).toHaveBeenCalledWith("history-task")
+		expect(resumedHost.dispose).toHaveBeenCalledWith("compactDisplayedTask")
+		expect(options.messages.appendAndEmit).toHaveBeenCalledWith(
+			[expect.objectContaining({ say: "info", text: "Couldn't compact the conversation. Please try again." })],
+			expect.anything(),
+		)
+	})
+
+	it("compacts the live session when the displayed task became active while waiting for the mutex", async () => {
+		const { coordinator, options } = makeCoordinator({
+			activeSession: undefined,
+			displayedTaskId: "history-task",
+		})
+		const liveSession = makeActiveSession({ sessionId: "history-task" })
+		liveSession.sdkHost.readMessages.mockResolvedValue([{ role: "user", content: "1" }])
+		// Idle at the compactTask entry check, then active once inside runExclusive.
+		options.sessions.getActiveSession.mockReturnValueOnce(undefined).mockReturnValue(liveSession)
+		mockCreateContextCompactionPrepareTurn.mockReturnValueOnce(
+			vi.fn().mockResolvedValue({ messages: [{ role: "user", content: "summary" }] }),
+		)
+
+		await coordinator.compactTask()
+
+		expect(options.sessions.startNewSession).not.toHaveBeenCalled()
+		expect(liveSession.sdkHost.updateSessionCompactionState).toHaveBeenCalledWith("history-task", {
+			version: 1,
+			messages: [{ role: "user", content: "summary" }],
+		})
+		expect(options.sessions.endActiveSession).not.toHaveBeenCalled()
+	})
+
+	it("finishes owned compaction without emitting into a replacement active session", async () => {
+		const { coordinator, options, resumedHost } = makeCoordinator({
+			activeSession: undefined,
+			displayedTaskId: "history-task",
+		})
+		const replacementSession = makeActiveSession({ sessionId: "replacement-task" })
+		resumedHost.start.mockImplementationOnce(async () => {
+			options.sessions.getActiveSession.mockReturnValue(replacementSession)
+			return { sessionId: "history-task" }
+		})
+		mockCreateContextCompactionPrepareTurn.mockReturnValueOnce(
+			vi.fn().mockResolvedValue({ messages: [{ role: "user", content: "summary" }] }),
+		)
+
+		await coordinator.compactTask()
+
+		expect(mockCreateContextCompactionPrepareTurn).toHaveBeenCalledOnce()
+		expect(resumedHost.updateSessionCompactionState).toHaveBeenCalledWith(
+			"history-task",
+			expect.objectContaining({ messages: expect.any(Array) }),
+		)
+		expect(options.messages.appendAndEmit).not.toHaveBeenCalled()
+		expect(replacementSession.sdkHost.stop).not.toHaveBeenCalled()
+		expect(options.sessions.endActiveSession).not.toHaveBeenCalled()
+		expect(resumedHost.stop).toHaveBeenCalledWith("history-task")
+		expect(resumedHost.dispose).toHaveBeenCalledWith("compactDisplayedTask")
 	})
 })
 
@@ -217,10 +384,14 @@ function compactionRows(options: { messages: { appendAndEmit: ReturnType<typeof 
 
 interface MakeCoordinatorInput {
 	activeSession: ReturnType<typeof makeActiveSession> | undefined
+	displayedTaskId: string | undefined
 }
 
 function makeCoordinator(input: Partial<MakeCoordinatorInput> = {}) {
 	const activeSession = "activeSession" in input ? input.activeSession : makeActiveSession()
+	// The isolated session used to resume a displayed task; its host owns the
+	// session and is where the sidecar is persisted and its transcript is read.
+	const resumedHost = makeSessionHost()
 	const config = {
 		providerConfig: { providerId: "anthropic", modelId: "claude" },
 		providerId: "anthropic",
@@ -237,52 +408,72 @@ function makeCoordinator(input: Partial<MakeCoordinatorInput> = {}) {
 		} as unknown as StateManager,
 		sessions: {
 			getActiveSession: vi.fn(() => activeSession),
-			replaceActiveSession: vi.fn().mockResolvedValue({
-				startResult: { sessionId: "new-session" },
-				sdkHost: { send: vi.fn() },
-			}),
+			startNewSession: vi.fn(async (startInput: { config?: { sessionId?: string } }) => ({
+				startResult: { sessionId: startInput.config?.sessionId ?? "resumed-session" },
+				sdkHost: resumedHost,
+			})),
+			setRunning: vi.fn(),
+			endActiveSession: vi.fn().mockResolvedValue(undefined),
+			waitForPendingStop: vi.fn().mockResolvedValue(undefined),
+		},
+		rebuilds: {
+			runExclusive: vi.fn(async (operation: () => Promise<unknown>) => operation()),
 		},
 		messages: {
 			appendAndEmit: vi.fn(),
 		},
+		taskHistory: {
+			findHistoryItem: vi.fn().mockResolvedValue(undefined),
+			isLegacyTask: vi.fn().mockResolvedValue(false),
+			getLegacyResumeInitialMessages: vi.fn(async (_taskId: string, fallback?: unknown[]) => fallback),
+		},
 		sessionConfigBuilder: {
 			build: vi.fn().mockResolvedValue(config),
 		},
+		getDisplayedTaskId: vi.fn(() => input.displayedTaskId),
+		createTempSessionHost: vi.fn().mockResolvedValue(resumedHost),
+		loadInitialMessages: vi.fn().mockResolvedValue([{ role: "user", content: "1" }]),
 		getWorkspaceRoot: vi.fn().mockResolvedValue("/workspace"),
 		postStateToWebview: vi.fn().mockResolvedValue(undefined),
 	} as unknown as SdkCompactionCoordinatorOptions & {
-		sessions: SdkCompactionCoordinatorOptions["sessions"] & {
+		sessions: {
 			getActiveSession: ReturnType<typeof vi.fn>
-			replaceActiveSession: ReturnType<typeof vi.fn>
+			startNewSession: ReturnType<typeof vi.fn>
+			setRunning: ReturnType<typeof vi.fn>
+			endActiveSession: ReturnType<typeof vi.fn>
+			waitForPendingStop: ReturnType<typeof vi.fn>
 		}
-		messages: SdkCompactionCoordinatorOptions["messages"] & {
-			appendAndEmit: ReturnType<typeof vi.fn>
-		}
-		sessionConfigBuilder: SdkCompactionCoordinatorOptions["sessionConfigBuilder"] & {
-			build: ReturnType<typeof vi.fn>
-		}
-		postStateToWebview: ReturnType<typeof vi.fn>
+		rebuilds: { runExclusive: ReturnType<typeof vi.fn> }
+		messages: { appendAndEmit: ReturnType<typeof vi.fn> }
 	}
 
 	return {
 		coordinator: new SdkCompactionCoordinator(options),
 		options,
+		resumedHost,
+	}
+}
+
+function makeSessionHost() {
+	return {
+		start: vi.fn().mockImplementation(async (input: { config?: { sessionId?: string } }) => ({
+			sessionId: input.config?.sessionId ?? "resumed-session",
+		})),
+		readMessages: vi.fn().mockResolvedValue([{ role: "user", content: "1" }]),
+		updateSessionCompactionState: vi.fn().mockResolvedValue({ updated: true }),
+		send: vi.fn(),
+		abort: vi.fn().mockResolvedValue(undefined),
+		stop: vi.fn().mockResolvedValue(undefined),
+		dispose: vi.fn().mockResolvedValue(undefined),
 	}
 }
 
 function makeActiveSession(input: { isRunning?: boolean; sessionId?: string } = {}) {
 	return {
 		sessionId: input.sessionId ?? "old-session",
-		sdkHost: {
-			readMessages: vi.fn().mockResolvedValue([{ role: "user", content: "1" }]),
-			updateSessionCompactionState: vi.fn().mockResolvedValue({ updated: true }),
-			send: vi.fn(),
-			abort: vi.fn().mockResolvedValue(undefined),
-			stop: vi.fn().mockResolvedValue(undefined),
-			dispose: vi.fn().mockResolvedValue(undefined),
-		},
+		sdkHost: makeSessionHost(),
 		unsubscribe: vi.fn(),
-		startResult: { sessionId: "old-session" },
+		startResult: { sessionId: input.sessionId ?? "old-session" },
 		isRunning: input.isRunning ?? false,
 	}
 }

--- a/apps/vscode/src/sdk/sdk-compaction-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-compaction-coordinator.ts
@@ -4,10 +4,21 @@
 // VSCode compact button or slash command. This mirrors the CLI's
 // `compactCurrentSession` (apps/cli/src/runtime/interactive/session-runtime.ts):
 //
-//   1. Read the active session's transcript.
+//   1. Read the session's transcript.
 //   2. Run a manual SDK compaction over it (sdk-compaction.ts).
 //   3. Persist the SDK compaction sidecar so the next turn and resumes keep
 //      using the compacted working context.
+//
+// Compaction always runs against an active session. When the user compacts a
+// task opened from history (a displayed, non-running task with no active
+// session, including a legacy task not yet migrated), we first resume it into
+// an isolated session — using the same resume preparation as the follow-up
+// path, which also migrates legacy tasks — then compact it through the single
+// path below. The coordinator owns this session's host, so another task can
+// replace the controller's active session without compaction stopping it during
+// cleanup. Resuming and compaction both run inside the session-rebuild mutex, so
+// a concurrent follow-up (which awaits that mutex before choosing a host)
+// cannot interleave with the read/compact/persist sequence.
 //
 // Before this, the VSCode button sent the literal text "/compact" to the model,
 // which the SDK does not treat as a runtime command, so the model improvised a
@@ -23,16 +34,27 @@ import { compactSessionMessages } from "./sdk-compaction"
 import type { SdkMessageCoordinator } from "./sdk-message-coordinator"
 import type { SdkSessionConfigBuilder } from "./sdk-session-config-builder"
 import type { SdkSessionLifecycle } from "./sdk-session-lifecycle"
+import type { SdkSessionRebuildScheduler } from "./sdk-session-rebuild-scheduler"
+import type { SdkTaskHistory } from "./sdk-task-history"
+import { prepareTaskResumeStartInput } from "./sdk-task-resume"
 import type { SdkSessionHost } from "./session-host"
 
 const COMPACTION_FAILURE_MESSAGE = "Couldn't compact the conversation. Please try again."
 const COMPACTION_UNSUPPORTED_MESSAGE = "Compaction is not supported by this runtime yet. Please update Cline and try again."
+const COMPACTION_TURN_RUNNING_MESSAGE =
+	"Cannot compact while a response is in progress. Try again once the current turn finishes."
 
 export interface SdkCompactionCoordinatorOptions {
 	stateManager: StateManager
 	sessions: SdkSessionLifecycle
+	rebuilds: SdkSessionRebuildScheduler
 	messages: SdkMessageCoordinator
+	taskHistory: SdkTaskHistory
 	sessionConfigBuilder: SdkSessionConfigBuilder
+	/** The task currently shown in the webview (may have no active session). */
+	getDisplayedTaskId: () => string | undefined
+	createTempSessionHost: () => Promise<SdkSessionHost>
+	loadInitialMessages: (sessionHost: SdkSessionHost, taskId: string) => Promise<unknown[] | undefined>
 	getWorkspaceRoot: () => Promise<string>
 	postStateToWebview: () => Promise<void>
 }
@@ -43,9 +65,9 @@ export class SdkCompactionCoordinator {
 	constructor(private readonly options: SdkCompactionCoordinatorOptions) {}
 
 	/**
-	 * Compact the active session's conversation. Mirrors the CLI's `/compact`
+	 * Compact the displayed task's conversation. Mirrors the CLI's `/compact`
 	 * (alias `/smol`) local command. No-ops with a status message when there is
-	 * no active session or nothing to compact.
+	 * nothing to compact or a turn is running.
 	 */
 	async compactTask(): Promise<void> {
 		if (this.compactInFlight) {
@@ -54,34 +76,126 @@ export class SdkCompactionCoordinator {
 		}
 
 		const activeSession = this.options.sessions.getActiveSession()
-		if (!activeSession) {
-			Logger.warn("[SdkController] compactTask: No active session to compact")
-			this.emitInfo("There is no active task to compact.")
-			await this.options.postStateToWebview()
+		if (activeSession) {
+			// A turn is still running; compacting mid-turn would race the live agent
+			// loop's own message persistence. Ask the user to wait until it finishes.
+			if (activeSession.isRunning) {
+				this.emitInfo(COMPACTION_TURN_RUNNING_MESSAGE, activeSession.sessionId)
+				await this.options.postStateToWebview()
+				return
+			}
+
+			this.compactInFlight = true
+			try {
+				// Hold the same boundary as idle follow-up sends so a follow-up
+				// cannot grow the transcript between this read/compact/persist
+				// sequence and its persistence.
+				await this.options.rebuilds.runExclusive(async () => {
+					// Compare by sessionId, not object identity: idle rebuilds
+					// (provider/MCP/terminal mode) replace the session object but
+					// reuse the sessionId for the same conversation, which is what
+					// the user asked to compact. Use the current host either way.
+					const current = this.options.sessions.getActiveSession()
+					if (current?.sessionId !== activeSession.sessionId) {
+						Logger.log("[SdkController] compactTask: Target changed while waiting for the mutex; cancelling")
+						return
+					}
+					if (current.isRunning) {
+						this.emitInfo(COMPACTION_TURN_RUNNING_MESSAGE, current.sessionId)
+						await this.options.postStateToWebview()
+						return
+					}
+					await this.runCompaction(current.sdkHost, current.sessionId)
+				})
+			} catch (error) {
+				Logger.error("[SdkController] compactTask failed:", error)
+				this.emitInfo(COMPACTION_FAILURE_MESSAGE, activeSession.sessionId)
+				await this.options.postStateToWebview()
+			} finally {
+				this.compactInFlight = false
+			}
 			return
 		}
 
-		// A turn is still running; compacting mid-turn would race the live agent
-		// loop's own message persistence. Ask the user to wait until it finishes.
-		if (activeSession.isRunning) {
-			this.emitInfo(
-				"Cannot compact while a response is in progress. Try again once the current turn finishes.",
-				activeSession.sessionId,
-			)
+		const displayedTaskId = this.options.getDisplayedTaskId()
+		if (!displayedTaskId) {
+			Logger.warn("[SdkController] compactTask: No active session or displayed task to compact")
+			this.emitInfo("There is no task to compact.")
 			await this.options.postStateToWebview()
 			return
 		}
 
 		this.compactInFlight = true
 		try {
-			await this.runCompaction(activeSession.sdkHost, activeSession.sessionId)
+			await this.compactDisplayedTask(displayedTaskId)
 		} catch (error) {
 			Logger.error("[SdkController] compactTask failed:", error)
-			this.emitInfo(COMPACTION_FAILURE_MESSAGE, activeSession.sessionId)
+			this.emitInfo(COMPACTION_FAILURE_MESSAGE, displayedTaskId)
 			await this.options.postStateToWebview()
 		} finally {
 			this.compactInFlight = false
 		}
+	}
+
+	/**
+	 * Resume a displayed history task in an isolated host, compact it, then
+	 * dispose the owned host so the task stays "displayed only". Runs inside the
+	 * session-rebuild mutex so a concurrent follow-up cannot resume the same task
+	 * in parallel; the follow-up waits, then reads the sidecar this persisted.
+	 */
+	private async compactDisplayedTask(taskId: string): Promise<void> {
+		await this.options.rebuilds.runExclusive(async () => {
+			// Another path may have made this task active while we waited for the
+			// mutex. If so, compact that live session instead of resuming a second.
+			const active = this.options.sessions.getActiveSession()
+			if (active) {
+				if (active.sessionId !== taskId) {
+					Logger.log(`[SdkController] compactTask: Target changed while waiting to compact ${taskId}; cancelling`)
+					return
+				}
+				if (active.isRunning) {
+					this.emitInfo(COMPACTION_TURN_RUNNING_MESSAGE, taskId)
+					await this.options.postStateToWebview()
+					return
+				}
+				await this.runCompaction(active.sdkHost, taskId)
+				return
+			}
+
+			const resumeStart = await prepareTaskResumeStartInput(this.options, taskId)
+			if (this.options.sessions.getActiveSession() || this.options.getDisplayedTaskId() !== taskId) {
+				Logger.log(`[SdkController] compactTask: Target changed before resuming ${taskId}; cancelling`)
+				return
+			}
+
+			// Opening a task from history fires an un-awaited endActiveSession for
+			// this sessionId; core cleanup is keyed by sessionId, so starting over
+			// that in-flight stop would let the old session's late cleanup tear
+			// down this one. Enforce the same stop-before-start as startNewSession.
+			await this.options.sessions.waitForPendingStop(taskId)
+
+			const sdkHost = await this.options.createTempSessionHost()
+			let sessionId: string | undefined
+			try {
+				const startResult = await sdkHost.start({
+					...resumeStart,
+					interactive: true,
+				})
+				sessionId = startResult.sessionId
+				// Starting may persist legacy conversion. Once it succeeds, complete
+				// compaction even if navigation changes the displayed/active task. The
+				// isolated host owns this session, while UI emitters fence stale rows.
+				await this.runCompaction(sdkHost, sessionId)
+			} finally {
+				try {
+					if (sessionId) {
+						await sdkHost.stop(sessionId)
+					}
+				} finally {
+					await sdkHost.dispose("compactDisplayedTask")
+				}
+			}
+		})
 	}
 
 	private async runCompaction(sdkHost: SdkSessionHost, sessionId: string): Promise<void> {
@@ -178,8 +292,8 @@ export class SdkCompactionCoordinator {
 
 	/** Append or update-in-place (same ts) the compaction divider row. */
 	private emitCompactionRow(info: ClineCompactionInfo, ts: number, sessionId: string): void {
-		const activeSessionId = this.options.sessions.getActiveSession()?.sessionId
-		if (activeSessionId !== sessionId) {
+		const targetSessionId = this.getTargetSessionId()
+		if (targetSessionId !== sessionId) {
 			Logger.warn(`[SdkController] compactTask: skipped compaction row for inactive session ${sessionId}`)
 			return
 		}
@@ -190,12 +304,11 @@ export class SdkCompactionCoordinator {
 	}
 
 	private emitInfo(text: string, sessionId?: string): void {
-		const activeSessionId = this.options.sessions.getActiveSession()?.sessionId
-		if (sessionId && activeSessionId !== sessionId) {
+		const targetSessionId = this.getTargetSessionId()
+		if (sessionId && targetSessionId !== sessionId) {
 			Logger.warn(`[SdkController] compactTask: skipped info for inactive session ${sessionId}`)
 			return
 		}
-		const targetSessionId = sessionId ?? activeSessionId ?? ""
 		const infoMessage: ClineMessage = {
 			ts: Date.now(),
 			type: "say",
@@ -205,7 +318,16 @@ export class SdkCompactionCoordinator {
 		}
 		this.options.messages.appendAndEmit([infoMessage], {
 			type: "status",
-			payload: { sessionId: targetSessionId, status: "running" },
+			payload: { sessionId: sessionId ?? targetSessionId ?? "", status: "running" },
 		})
+	}
+
+	/**
+	 * The session a compaction row belongs to: the active session if one exists,
+	 * otherwise the displayed task. The fallback lets the displayed-task path's
+	 * terminal failure message land after its transient session has been ended.
+	 */
+	private getTargetSessionId(): string | undefined {
+		return this.options.sessions.getActiveSession()?.sessionId ?? this.options.getDisplayedTaskId()
 	}
 }

--- a/apps/vscode/src/sdk/sdk-followup-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-followup-coordinator.test.ts
@@ -302,6 +302,77 @@ describe("SdkFollowupCoordinator", () => {
 		expect(options.postStateToWebview).toHaveBeenCalledOnce()
 	})
 
+	it("ends a resumed session without mutating a task selected while start was pending", async () => {
+		const task = makeTask("task-1")
+		const replacementTask = makeTask("task-2")
+		const { coordinator, options } = makeCoordinator({ task })
+		options.sessions.startNewSession.mockImplementationOnce(async () => {
+			const sdkHost = { send: vi.fn() }
+			options.getTask.mockReturnValue(replacementTask)
+			options.sessions.getActiveSession.mockReturnValue({
+				sessionId: "resumed-session",
+				sdkHost,
+				isRunning: true,
+			})
+			return { startResult: { sessionId: "resumed-session" }, sdkHost }
+		})
+
+		await coordinator.askResponse("continue")
+
+		expect(replacementTask.taskId).toBe("task-2")
+		expect(options.sessions.endActiveSession).toHaveBeenCalledWith("followupTargetChanged", { awaitStop: true })
+		expect(options.sessions.fireAndForgetSend).not.toHaveBeenCalled()
+		// askResponse pre-set the streaming phase; abandoning must settle it.
+		expect(options.onFollowUpAbandoned).toHaveBeenCalledOnce()
+	})
+
+	it("settles the turn phase when the task changes before the resume starts", async () => {
+		const task = makeTask("task-1")
+		const replacementTask = makeTask("task-2")
+		const { coordinator, options } = makeCoordinator({ task })
+		options.loadInitialMessages.mockImplementationOnce(async () => {
+			options.getTask.mockReturnValue(replacementTask)
+			return [{ role: "user", content: "hello" }]
+		})
+
+		await coordinator.askResponse("continue")
+
+		expect(options.sessions.startNewSession).not.toHaveBeenCalled()
+		expect(options.onFollowUpAbandoned).toHaveBeenCalledOnce()
+		expect(options.postStateToWebview).toHaveBeenCalled()
+	})
+
+	it("holds transcript preparation and session start inside the rebuild scheduler", async () => {
+		const task = makeTask("task-1")
+		let runOperation: (() => Promise<void>) | undefined
+		const runExclusive = vi.fn(
+			(operation: () => Promise<void>) =>
+				new Promise<void>((resolve, reject) => {
+					runOperation = async () => {
+						try {
+							await operation()
+							resolve()
+						} catch (error) {
+							reject(error)
+						}
+					}
+				}),
+		)
+		const { coordinator, options } = makeCoordinator({ task, runExclusive })
+
+		const sendPromise = coordinator.askResponse("continue")
+		await vi.waitFor(() => expect(runExclusive).toHaveBeenCalledOnce())
+
+		expect(options.loadInitialMessages).not.toHaveBeenCalled()
+		expect(options.sessions.startNewSession).not.toHaveBeenCalled()
+
+		await runOperation?.()
+		await sendPromise
+
+		expect(options.loadInitialMessages).toHaveBeenCalledOnce()
+		expect(options.sessions.startNewSession).toHaveBeenCalledOnce()
+	})
+
 	it("adds a legacy warning to initial messages when resuming a legacy task", async () => {
 		const task = makeTask("legacy-task")
 		const historyItem = {
@@ -424,6 +495,7 @@ function makeCoordinator(input: Partial<MakeCoordinatorInput> = {}) {
 				startResult: { sessionId: "resumed-session" },
 				sdkHost: { send: vi.fn() },
 			}),
+			endActiveSession: vi.fn().mockResolvedValue(undefined),
 		},
 		messages: {
 			appendAndEmit: vi.fn(),
@@ -450,7 +522,9 @@ function makeCoordinator(input: Partial<MakeCoordinatorInput> = {}) {
 		resetMessageTranslator: vi.fn(),
 		postStateToWebview: vi.fn().mockResolvedValue(undefined),
 		waitForPendingRebuilds: input.waitForPendingRebuilds ?? vi.fn().mockResolvedValue(undefined),
+		runExclusive: input.runExclusive ?? vi.fn(async (operation: () => Promise<unknown>) => operation()),
 		onResumeFailed: vi.fn(),
+		onFollowUpAbandoned: vi.fn(),
 	} as unknown as SdkFollowupCoordinatorOptions & {
 		interactions: SdkFollowupCoordinatorOptions["interactions"] & {
 			resolvePendingToolApproval: ReturnType<typeof vi.fn>
@@ -461,6 +535,7 @@ function makeCoordinator(input: Partial<MakeCoordinatorInput> = {}) {
 			setRunning: ReturnType<typeof vi.fn>
 			fireAndForgetSend: ReturnType<typeof vi.fn>
 			startNewSession: ReturnType<typeof vi.fn>
+			endActiveSession: ReturnType<typeof vi.fn>
 		}
 		messages: SdkFollowupCoordinatorOptions["messages"] & {
 			appendAndEmit: ReturnType<typeof vi.fn>
@@ -483,7 +558,9 @@ function makeCoordinator(input: Partial<MakeCoordinatorInput> = {}) {
 		emitClineAuthError: ReturnType<typeof vi.fn>
 		resetMessageTranslator: ReturnType<typeof vi.fn>
 		postStateToWebview: ReturnType<typeof vi.fn>
+		runExclusive: ReturnType<typeof vi.fn>
 		onResumeFailed: ReturnType<typeof vi.fn>
+		onFollowUpAbandoned: ReturnType<typeof vi.fn>
 	}
 
 	return {
@@ -508,6 +585,7 @@ interface MakeCoordinatorInput {
 	mode: "act" | "plan"
 	isLegacyTask: boolean
 	waitForPendingRebuilds: () => Promise<void>
+	runExclusive: (operation: () => Promise<void>) => Promise<void>
 }
 
 function makeActiveSession(input: { isRunning?: boolean } = {}) {

--- a/apps/vscode/src/sdk/sdk-followup-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-followup-coordinator.test.ts
@@ -326,6 +326,28 @@ describe("SdkFollowupCoordinator", () => {
 		expect(options.onFollowUpAbandoned).toHaveBeenCalledOnce()
 	})
 
+	it("delivers the follow-up when the same task was reloaded with a new proxy", async () => {
+		const task = makeTask("task-1")
+		// showTaskWithId allocates a fresh proxy for the same task id.
+		const reloadedProxy = makeTask("task-1")
+		const { coordinator, options } = makeCoordinator({ task })
+		options.loadInitialMessages.mockImplementationOnce(async () => {
+			options.getTask.mockReturnValue(reloadedProxy)
+			return [{ role: "user", content: "hello" }]
+		})
+
+		await coordinator.askResponse("continue")
+
+		expect(options.onFollowUpAbandoned).not.toHaveBeenCalled()
+		expect(options.sessions.fireAndForgetSend).toHaveBeenCalledWith(
+			expect.anything(),
+			"resumed-session",
+			"resolved: continue",
+			undefined,
+			undefined,
+		)
+	})
+
 	it("settles the turn phase when the task changes before the resume starts", async () => {
 		const task = makeTask("task-1")
 		const replacementTask = makeTask("task-2")

--- a/apps/vscode/src/sdk/sdk-followup-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-followup-coordinator.ts
@@ -85,7 +85,9 @@ export class SdkFollowupCoordinator {
 		await this.options.runExclusive(async () => {
 			// Task navigation does not use the rebuild scheduler. Do not deliver a
 			// prompt submitted from one task into a task selected while we waited.
-			if (task && this.options.getTask() !== task) {
+			// Compare by taskId: reloading the same task allocates a new TaskProxy,
+			// and the user's follow-up should survive that.
+			if (task && this.options.getTask()?.taskId !== task.taskId) {
 				await this.abandonFollowUp(
 					`askResponse: Task changed while waiting to resume ${task.taskId}; cancelling follow-up`,
 				)
@@ -147,7 +149,7 @@ export class SdkFollowupCoordinator {
 		try {
 			await this.resumeSessionFromTask(task, prompt, images, files)
 		} catch (error) {
-			if (this.options.getTask() !== task) {
+			if (this.options.getTask()?.taskId !== task.taskId) {
 				// Settle the pre-set streaming phase, but do not emit the stale
 				// failure into the newly displayed task's transcript.
 				await this.abandonFollowUp(`Suppressing resume failure for task no longer displayed: ${task.taskId}`)
@@ -189,7 +191,10 @@ export class SdkFollowupCoordinator {
 
 		const historyItem = await this.options.taskHistory.findHistoryItem(taskId)
 		const resumeStart = await prepareTaskResumeStartInput(this.options, taskId)
-		if (this.options.getTask() !== task) {
+		// Targeting checks below compare by taskId (logical identity): reloading
+		// the same task allocates a new TaskProxy and must not cancel the
+		// follow-up. Cleanup (endStartedResume) uses object identity instead.
+		if (this.options.getTask()?.taskId !== taskId) {
 			await this.abandonFollowUp(`Task changed before resume start for ${taskId}; cancelling follow-up`)
 			return
 		}
@@ -201,7 +206,7 @@ export class SdkFollowupCoordinator {
 			interactive: true,
 		})
 
-		if (this.options.getTask() !== task) {
+		if (this.options.getTask()?.taskId !== taskId) {
 			await this.endStartedResume(sdkHost, startResult.sessionId)
 			await this.abandonFollowUp(`Task changed during resume start for ${taskId}; cancelled follow-up`)
 			return
@@ -212,7 +217,7 @@ export class SdkFollowupCoordinator {
 				historyItem.ts = Date.now()
 				historyItem.modelId = resumeStart.config.modelId
 				await this.options.taskHistory.updateTaskHistoryItem(historyItem)
-				if (this.options.getTask() !== task) {
+				if (this.options.getTask()?.taskId !== taskId) {
 					await this.endStartedResume(sdkHost, startResult.sessionId)
 					await this.abandonFollowUp(`Task changed while updating history for ${taskId}; cancelled follow-up`)
 					return
@@ -225,7 +230,7 @@ export class SdkFollowupCoordinator {
 					? `[TASK RESUMPTION] This task was interrupted. It may or may not be complete, so please reassess the task context. The conversation history has been preserved. New instructions from the user: ${historyItem.task}`
 					: "[TASK RESUMPTION] Please continue where you left off.")
 			const resolvedPrompt = await this.options.resolveContextMentions(effectivePrompt)
-			if (this.options.getTask() !== task) {
+			if (this.options.getTask()?.taskId !== taskId) {
 				await this.endStartedResume(sdkHost, startResult.sessionId)
 				await this.abandonFollowUp(`Task changed while resolving mentions for ${taskId}; cancelled follow-up`)
 				return
@@ -246,7 +251,9 @@ export class SdkFollowupCoordinator {
 			}
 
 			await this.options.postStateToWebview()
-			if (this.options.getTask() !== task) {
+			// Compare against the original taskId: a proxy reloaded from history
+			// carries it, while task.taskId may have been reassigned above.
+			if (this.options.getTask()?.taskId !== taskId && this.options.getTask() !== task) {
 				await this.endStartedResume(sdkHost, startResult.sessionId)
 				await this.abandonFollowUp(`Task changed while posting resumed state for ${taskId}; cancelled follow-up`)
 				return

--- a/apps/vscode/src/sdk/sdk-followup-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-followup-coordinator.ts
@@ -8,13 +8,13 @@ import type { SdkInteractionCoordinator } from "./sdk-interaction-coordinator"
 import type { SdkMessageCoordinator } from "./sdk-message-coordinator"
 import type { SdkSessionConfigBuilder } from "./sdk-session-config-builder"
 import type { SdkSessionLifecycle } from "./sdk-session-lifecycle"
-import { historyItemToSessionMetadata, type SdkTaskHistory } from "./sdk-task-history"
+import type { SdkTaskHistory } from "./sdk-task-history"
+import { prepareTaskResumeStartInput } from "./sdk-task-resume"
 import type { SdkSessionHost } from "./session-host"
 import type { TaskProxy } from "./task-proxy"
 import type { VscodeSessionHost } from "./vscode-session-host"
 
 type StartInput = Parameters<VscodeSessionHost["start"]>[0]
-type InitialMessages = StartInput["initialMessages"]
 type SessionConfig = Awaited<ReturnType<SdkSessionConfigBuilder["build"]>>
 
 export interface SdkFollowupCoordinatorOptions {
@@ -36,12 +36,20 @@ export interface SdkFollowupCoordinatorOptions {
 	postStateToWebview: () => Promise<void>
 	/** Resolves once no session rebuild is in flight. */
 	waitForPendingRebuilds: () => Promise<void>
+	/** Serializes transcript preparation and session start with rebuilds and displayed-task compaction. */
+	runExclusive: (operation: () => Promise<void>) => Promise<void>
 	/**
 	 * Called when resuming a task fails. askResponse moved the turn phase to
 	 * streaming before delegating here, so the failure must move it to a
 	 * terminal phase or the footer stays stuck on Thinking/Cancel.
 	 */
 	onResumeFailed: () => void
+	/**
+	 * Called when a follow-up ends without starting a turn (the displayed task
+	 * changed, or no session could be chosen). Settles the streaming phase that
+	 * askResponse pre-set, for the same reason as onResumeFailed.
+	 */
+	onFollowUpAbandoned: () => void
 }
 
 export class SdkFollowupCoordinator {
@@ -62,31 +70,58 @@ export class SdkFollowupCoordinator {
 			return
 		}
 
-		let activeSession = this.options.sessions.getActiveSession()
+		const activeSession = this.options.sessions.getActiveSession()
 		const task = this.options.getTask()
 		const submittedDuringActiveTurn = turnPhaseAtSubmit === "streaming" || turnPhaseAtSubmit === "awaiting_approval"
-		const isActiveTurnInProgress = () => !!activeSession && (activeSession.isRunning || submittedDuringActiveTurn)
-		if (!isActiveTurnInProgress()) {
-			// Rebuilds replace the active session. Wait before choosing the host so
-			// this follow-up cannot be sent to the session being replaced.
-			await this.options.waitForPendingRebuilds()
-			activeSession = this.options.sessions.getActiveSession()
-		}
-		if (!isActiveTurnInProgress() && task) {
-			Logger.log(`[SdkController] askResponse: No active session but task exists (${task.taskId}), resuming...`)
-			await this.tryResumeSessionFromTask(task.taskId, prompt, images, files)
+		if (activeSession && (activeSession.isRunning || submittedDuringActiveTurn)) {
+			await this.sendToActiveSession(activeSession, true, prompt, images, files)
 			return
 		}
 
-		if (!activeSession) {
-			Logger.error("[SdkController] askResponse: No active session")
-			return
-		}
+		// Rebuilds replace idle sessions. Wait before acquiring the shared
+		// prepare/start boundary so this follow-up cannot target a replaced host.
+		await this.options.waitForPendingRebuilds()
 
+		await this.options.runExclusive(async () => {
+			// Task navigation does not use the rebuild scheduler. Do not deliver a
+			// prompt submitted from one task into a task selected while we waited.
+			if (task && this.options.getTask() !== task) {
+				await this.abandonFollowUp(
+					`askResponse: Task changed while waiting to resume ${task.taskId}; cancelling follow-up`,
+				)
+				return
+			}
+
+			const currentSession = this.options.sessions.getActiveSession()
+			if (currentSession && (currentSession.isRunning || submittedDuringActiveTurn)) {
+				await this.sendToActiveSession(currentSession, true, prompt, images, files)
+				return
+			}
+
+			if (task) {
+				Logger.log(`[SdkController] askResponse: Resuming task ${task.taskId} before follow-up`)
+				await this.tryResumeSessionFromTask(task, prompt, images, files)
+				return
+			}
+
+			if (!currentSession) {
+				Logger.error("[SdkController] askResponse: No active session")
+				await this.abandonFollowUp("askResponse: No active session to receive the follow-up")
+				return
+			}
+
+			await this.sendToActiveSession(currentSession, false, prompt, images, files)
+		})
+	}
+
+	private async sendToActiveSession(
+		activeSession: NonNullable<ReturnType<SdkSessionLifecycle["getActiveSession"]>>,
+		shouldQueue: boolean,
+		prompt?: string,
+		images?: string[],
+		files?: string[],
+	): Promise<void> {
 		const { sdkHost, sessionId } = activeSession
-		const shouldQueue = isActiveTurnInProgress()
-		const delivery = shouldQueue ? ("queue" as const) : undefined
-
 		if (shouldQueue) {
 			Logger.log(`[SdkController] Session is running - queuing follow-up message for session: ${sessionId}`)
 		}
@@ -94,20 +129,30 @@ export class SdkFollowupCoordinator {
 		this.options.sessions.setRunning(true)
 		if (!shouldQueue) {
 			this.emitUserFeedback(sessionId, prompt, images, files)
-		}
-
-		if (!shouldQueue) {
 			this.options.resetMessageTranslator()
 		}
 
 		const resolvedPrompt = prompt ? await this.options.resolveContextMentions(prompt) : ""
-		this.options.sessions.fireAndForgetSend(sdkHost, sessionId, resolvedPrompt, images, files, delivery)
+		this.options.sessions.fireAndForgetSend(
+			sdkHost,
+			sessionId,
+			resolvedPrompt,
+			images,
+			files,
+			shouldQueue ? "queue" : undefined,
+		)
 	}
 
-	private async tryResumeSessionFromTask(taskId: string, prompt?: string, images?: string[], files?: string[]): Promise<void> {
+	private async tryResumeSessionFromTask(task: TaskProxy, prompt?: string, images?: string[], files?: string[]): Promise<void> {
 		try {
-			await this.resumeSessionFromTask(taskId, prompt, images, files)
+			await this.resumeSessionFromTask(task, prompt, images, files)
 		} catch (error) {
+			if (this.options.getTask() !== task) {
+				// Settle the pre-set streaming phase, but do not emit the stale
+				// failure into the newly displayed task's transcript.
+				await this.abandonFollowUp(`Suppressing resume failure for task no longer displayed: ${task.taskId}`)
+				return
+			}
 			Logger.error("[SdkController] Failed to resume session from task:", error)
 
 			const errorMsg = error instanceof Error ? error.message : String(error)
@@ -130,7 +175,7 @@ export class SdkFollowupCoordinator {
 							partial: false,
 						},
 					],
-					{ type: "status", payload: { sessionId: taskId, status: "error" } },
+					{ type: "status", payload: { sessionId: task.taskId, status: "error" } },
 				)
 			}
 			this.options.onResumeFailed()
@@ -138,66 +183,96 @@ export class SdkFollowupCoordinator {
 		}
 	}
 
-	private async resumeSessionFromTask(taskId: string, prompt?: string, images?: string[], files?: string[]): Promise<void> {
+	private async resumeSessionFromTask(task: TaskProxy, prompt?: string, images?: string[], files?: string[]): Promise<void> {
+		const taskId = task.taskId
 		Logger.log(`[SdkController] Resuming session from task: ${taskId}`)
 
 		const historyItem = await this.options.taskHistory.findHistoryItem(taskId)
-		const cwd = historyItem?.cwdOnTaskInitialization ?? (await this.options.getWorkspaceRoot())
+		const resumeStart = await prepareTaskResumeStartInput(this.options, taskId)
+		if (this.options.getTask() !== task) {
+			await this.abandonFollowUp(`Task changed before resume start for ${taskId}; cancelling follow-up`)
+			return
+		}
 
-		const modeValue = this.options.stateManager.getGlobalSettingsKey("mode")
-		const mode: Mode = modeValue === "plan" || modeValue === "act" ? modeValue : "act"
-		const config = await this.options.sessionConfigBuilder.build({ cwd, mode })
-		config.sessionId = taskId
-
-		const isLegacyTask = await this.options.taskHistory.isLegacyTask(taskId)
-		const tempManager = await this.options.createTempSessionHost()
-		const persistedInitialMessages = await this.options.loadInitialMessages(tempManager, taskId)
-		await tempManager.dispose("readMessages")
-		const initialMessages = isLegacyTask
-			? await this.options.taskHistory.getLegacyResumeInitialMessages(taskId, persistedInitialMessages)
-			: persistedInitialMessages
-
-		Logger.log(`[SdkController] Resuming with ${initialMessages?.length ?? 0} initial messages`)
+		Logger.log(`[SdkController] Resuming with ${resumeStart.initialMessages?.length ?? 0} initial messages`)
 
 		const { startResult, sdkHost } = await this.options.sessions.startNewSession({
-			config,
+			...resumeStart,
 			interactive: true,
-			...(initialMessages ? { initialMessages: initialMessages as InitialMessages } : {}),
-			...(historyItem ? { sessionMetadata: historyItemToSessionMetadata(historyItem, config.modelId) } : {}),
 		})
 
-		const task = this.options.getTask()
-		if (task && task.taskId !== startResult.sessionId) {
-			task.taskId = startResult.sessionId
+		if (this.options.getTask() !== task) {
+			await this.endStartedResume(sdkHost, startResult.sessionId)
+			await this.abandonFollowUp(`Task changed during resume start for ${taskId}; cancelled follow-up`)
+			return
 		}
 
-		this.options.resetMessageTranslator()
+		try {
+			if (historyItem) {
+				historyItem.ts = Date.now()
+				historyItem.modelId = resumeStart.config.modelId
+				await this.options.taskHistory.updateTaskHistoryItem(historyItem)
+				if (this.options.getTask() !== task) {
+					await this.endStartedResume(sdkHost, startResult.sessionId)
+					await this.abandonFollowUp(`Task changed while updating history for ${taskId}; cancelled follow-up`)
+					return
+				}
+			}
 
-		if (historyItem) {
-			historyItem.ts = Date.now()
-			historyItem.modelId = config.modelId
-			await this.options.taskHistory.updateTaskHistoryItem(historyItem)
+			const effectivePrompt =
+				prompt?.trim() ||
+				(historyItem
+					? `[TASK RESUMPTION] This task was interrupted. It may or may not be complete, so please reassess the task context. The conversation history has been preserved. New instructions from the user: ${historyItem.task}`
+					: "[TASK RESUMPTION] Please continue where you left off.")
+			const resolvedPrompt = await this.options.resolveContextMentions(effectivePrompt)
+			if (this.options.getTask() !== task) {
+				await this.endStartedResume(sdkHost, startResult.sessionId)
+				await this.abandonFollowUp(`Task changed while resolving mentions for ${taskId}; cancelled follow-up`)
+				return
+			}
+
+			if (task.taskId !== startResult.sessionId) {
+				task.taskId = startResult.sessionId
+			}
+			this.options.resetMessageTranslator()
+
+			// Echo whenever the user supplied content, including attachment-only
+			// resumes, and include the attachments in the bubble. This also keeps the
+			// visible transcript aligned with SDK history for edit/regenerate ordinal
+			// mapping: a resumption prompt carrying user attachments is counted as a
+			// visible user message, a bare resumption prompt is not.
+			if (prompt?.trim() || images?.length || files?.length) {
+				this.emitUserFeedback(startResult.sessionId, prompt, images, files)
+			}
+
+			await this.options.postStateToWebview()
+			if (this.options.getTask() !== task) {
+				await this.endStartedResume(sdkHost, startResult.sessionId)
+				await this.abandonFollowUp(`Task changed while posting resumed state for ${taskId}; cancelled follow-up`)
+				return
+			}
+
+			this.options.sessions.fireAndForgetSend(sdkHost, startResult.sessionId, resolvedPrompt, images, files)
+		} catch (error) {
+			await this.endStartedResume(sdkHost, startResult.sessionId)
+			throw error
 		}
+	}
 
-		// Echo whenever the user supplied content, including attachment-only
-		// resumes, and include the attachments in the bubble. This also keeps the
-		// visible transcript aligned with SDK history for edit/regenerate ordinal
-		// mapping: a resumption prompt carrying user attachments is counted as a
-		// visible user message, a bare resumption prompt is not.
-		if (prompt?.trim() || images?.length || files?.length) {
-			this.emitUserFeedback(startResult.sessionId, prompt, images, files)
+	private async endStartedResume(sdkHost: SdkSessionHost, sessionId: string): Promise<void> {
+		// startNewSession installs the session before resolving. Clear that exact
+		// session synchronously, but never stop a replacement session.
+		const activeSession = this.options.sessions.getActiveSession()
+		if (activeSession?.sdkHost === sdkHost && activeSession.sessionId === sessionId) {
+			await this.options.sessions.endActiveSession("followupTargetChanged", { awaitStop: true })
 		}
+	}
 
+	/** Settle the pre-set streaming phase for a follow-up that started no turn. */
+	private async abandonFollowUp(detail: string): Promise<void> {
+		Logger.log(`[SdkController] ${detail}`)
+		this.options.onFollowUpAbandoned()
 		await this.options.postStateToWebview()
-
-		const effectivePrompt =
-			prompt?.trim() ||
-			(historyItem
-				? `[TASK RESUMPTION] This task was interrupted. It may or may not be complete, so please reassess the task context. The conversation history has been preserved. New instructions from the user: ${historyItem.task}`
-				: "[TASK RESUMPTION] Please continue where you left off.")
-
-		const resolvedPrompt = await this.options.resolveContextMentions(effectivePrompt)
-		this.options.sessions.fireAndForgetSend(sdkHost, startResult.sessionId, resolvedPrompt, images, files)
 	}
 
 	private emitUserFeedback(sessionId: string, prompt?: string, images?: string[], files?: string[]): void {

--- a/apps/vscode/src/sdk/sdk-session-lifecycle.ts
+++ b/apps/vscode/src/sdk/sdk-session-lifecycle.ts
@@ -116,6 +116,19 @@ export class SdkSessionLifecycle {
 		return activeSession
 	}
 
+	/**
+	 * Resolves once any in-flight stop for `sessionId` has settled. Callers that
+	 * start a session outside startNewSession (e.g. on an isolated host) must
+	 * wait here first, or the old session's late cleanup tears down the new one.
+	 */
+	async waitForPendingStop(sessionId: string): Promise<void> {
+		const pendingStop = this.pendingStops.get(sessionId)
+		if (pendingStop) {
+			Logger.log(`[SdkController] Waiting for session ${sessionId} to stop before restarting it`)
+			await pendingStop
+		}
+	}
+
 	async updateActiveSessionModel(modelId: string): Promise<boolean> {
 		const activeSession = this.activeSession
 		if (!activeSession?.sdkHost.updateSessionModel) {
@@ -136,10 +149,8 @@ export class SdkSessionLifecycle {
 		// Same-id starts must wait for the previous session's stop to finish;
 		// see pendingStops. A fresh id cannot conflict, so it never waits.
 		const requestedSessionId = startInput.config?.sessionId?.trim()
-		const pendingStop = requestedSessionId ? this.pendingStops.get(requestedSessionId) : undefined
-		if (pendingStop) {
-			Logger.log(`[SdkController] Waiting for session ${requestedSessionId} to stop before restarting it`)
-			await pendingStop
+		if (requestedSessionId) {
+			await this.waitForPendingStop(requestedSessionId)
 		}
 
 		const autoApprovalSettings = StateManager.get().getGlobalSettingsKey("autoApprovalSettings")

--- a/apps/vscode/src/sdk/sdk-task-resume.test.ts
+++ b/apps/vscode/src/sdk/sdk-task-resume.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest"
+import type { StateManager } from "@/core/storage/StateManager"
+import { type PrepareTaskResumeStartDeps, prepareTaskResumeStartInput } from "./sdk-task-resume"
+
+function makeDeps(overrides: Partial<Record<string, unknown>> = {}) {
+	const tempHost = { dispose: vi.fn().mockResolvedValue(undefined) }
+	const deps = {
+		stateManager: { getGlobalSettingsKey: vi.fn(() => "act") } as unknown as StateManager,
+		taskHistory: {
+			findHistoryItem: vi.fn().mockResolvedValue(undefined),
+			isLegacyTask: vi.fn().mockResolvedValue(false),
+			getLegacyResumeInitialMessages: vi.fn(async (_taskId: string, fallback?: unknown[]) => fallback),
+		},
+		sessionConfigBuilder: {
+			build: vi.fn().mockResolvedValue({ modelId: "claude", sessionId: undefined as string | undefined }),
+		},
+		getWorkspaceRoot: vi.fn().mockResolvedValue("/workspace"),
+		createTempSessionHost: vi.fn().mockResolvedValue(tempHost),
+		loadInitialMessages: vi.fn().mockResolvedValue([{ role: "user", content: "sdk" }]),
+		...overrides,
+	} as unknown as PrepareTaskResumeStartDeps & {
+		taskHistory: {
+			findHistoryItem: ReturnType<typeof vi.fn>
+			isLegacyTask: ReturnType<typeof vi.fn>
+			getLegacyResumeInitialMessages: ReturnType<typeof vi.fn>
+		}
+		loadInitialMessages: ReturnType<typeof vi.fn>
+	}
+	return { deps, tempHost }
+}
+
+describe("prepareTaskResumeStartInput", () => {
+	it("pins the config sessionId to the task and reads its persisted transcript", async () => {
+		const { deps, tempHost } = makeDeps()
+
+		const result = await prepareTaskResumeStartInput(deps, "task-1")
+
+		expect(result.config.sessionId).toBe("task-1")
+		expect(result.initialMessages).toEqual([{ role: "user", content: "sdk" }])
+		expect(deps.taskHistory.getLegacyResumeInitialMessages).not.toHaveBeenCalled()
+		// The transient reader host is always disposed.
+		expect(tempHost.dispose).toHaveBeenCalledWith("readMessages")
+	})
+
+	it("converts a legacy task's transcript through the legacy resume path", async () => {
+		const { deps } = makeDeps()
+		deps.taskHistory.isLegacyTask.mockResolvedValueOnce(true)
+		deps.taskHistory.getLegacyResumeInitialMessages.mockResolvedValueOnce([{ role: "user", content: "legacy" }])
+
+		const result = await prepareTaskResumeStartInput(deps, "legacy-task")
+
+		expect(deps.taskHistory.getLegacyResumeInitialMessages).toHaveBeenCalledWith("legacy-task", [
+			{ role: "user", content: "sdk" },
+		])
+		expect(result.initialMessages).toEqual([{ role: "user", content: "legacy" }])
+	})
+
+	it("disposes the reader host even when reading messages throws", async () => {
+		const { deps, tempHost } = makeDeps()
+		deps.loadInitialMessages.mockRejectedValueOnce(new Error("read failed"))
+
+		await expect(prepareTaskResumeStartInput(deps, "task-1")).rejects.toThrow("read failed")
+		expect(tempHost.dispose).toHaveBeenCalledWith("readMessages")
+	})
+})

--- a/apps/vscode/src/sdk/sdk-task-resume.ts
+++ b/apps/vscode/src/sdk/sdk-task-resume.ts
@@ -1,0 +1,71 @@
+// Shared "prepare an idle session from a history task" step.
+//
+// Resuming a task and compacting a displayed (non-running) task both need the
+// same thing: read the task's persisted transcript, convert legacy tasks into
+// SDK messages, and build the start input that seeds a session with that
+// transcript. Starting such a session with initialMessages persists them (see
+// LocalRuntimeHost.startSession), so this is also how a pure-legacy task is
+// migrated into an SDK session. Deriving both callers from one function keeps
+// resume and compaction from drifting apart.
+
+import type { Mode } from "@shared/storage/types"
+import type { StateManager } from "@/core/storage/StateManager"
+import type { SdkSessionConfigBuilder } from "./sdk-session-config-builder"
+import { historyItemToSessionMetadata, type SdkTaskHistory } from "./sdk-task-history"
+import type { SdkSessionHost } from "./session-host"
+import type { VscodeSessionHost } from "./vscode-session-host"
+
+type StartInput = Parameters<VscodeSessionHost["start"]>[0]
+type InitialMessages = StartInput["initialMessages"]
+type SessionConfig = Awaited<ReturnType<SdkSessionConfigBuilder["build"]>>
+
+export interface TaskResumeStartInput {
+	config: SessionConfig
+	initialMessages?: InitialMessages
+	sessionMetadata?: ReturnType<typeof historyItemToSessionMetadata>
+}
+
+export interface PrepareTaskResumeStartDeps {
+	stateManager: StateManager
+	taskHistory: SdkTaskHistory
+	sessionConfigBuilder: SdkSessionConfigBuilder
+	getWorkspaceRoot: () => Promise<string>
+	createTempSessionHost: () => Promise<SdkSessionHost>
+	loadInitialMessages: (sessionHost: SdkSessionHost, taskId: string) => Promise<unknown[] | undefined>
+}
+
+/**
+ * Build the start input that resumes `taskId` into a session seeded with its
+ * persisted (or legacy-converted) transcript. The returned config has its
+ * `sessionId` pinned to `taskId` so the resumed session reuses the task's id.
+ */
+export async function prepareTaskResumeStartInput(
+	deps: PrepareTaskResumeStartDeps,
+	taskId: string,
+): Promise<TaskResumeStartInput> {
+	const historyItem = await deps.taskHistory.findHistoryItem(taskId)
+	const cwd = historyItem?.cwdOnTaskInitialization ?? (await deps.getWorkspaceRoot())
+
+	const modeValue = deps.stateManager.getGlobalSettingsKey("mode")
+	const mode: Mode = modeValue === "plan" || modeValue === "act" ? modeValue : "act"
+	const config = await deps.sessionConfigBuilder.build({ cwd, mode })
+	config.sessionId = taskId
+
+	const isLegacyTask = await deps.taskHistory.isLegacyTask(taskId)
+	const tempManager = await deps.createTempSessionHost()
+	let persistedInitialMessages: unknown[] | undefined
+	try {
+		persistedInitialMessages = await deps.loadInitialMessages(tempManager, taskId)
+	} finally {
+		await tempManager.dispose("readMessages")
+	}
+	const initialMessages = isLegacyTask
+		? await deps.taskHistory.getLegacyResumeInitialMessages(taskId, persistedInitialMessages)
+		: persistedInitialMessages
+
+	return {
+		config,
+		...(initialMessages ? { initialMessages: initialMessages as InitialMessages } : {}),
+		...(historyItem ? { sessionMetadata: historyItemToSessionMetadata(historyItem, config.modelId) } : {}),
+	}
+}


### PR DESCRIPTION
### Description

The compact button only worked while a session was actively running. Opening a task from history and clicking "compact" errored with "There is no active task to compact."

Compaction is defined only over an active session's transcript. Rather than grow a second, parallel path for displayed tasks, this resumes a displayed (non-running) history task into an idle session — the *same* resume the follow-up path already uses, which also migrates legacy tasks not yet converted to the SDK — compacts it through the single existing path, then ends the transient session so the task stays "displayed only" with its compaction sidecar persisted.

Resume and compaction both run inside the session-rebuild mutex, so a concurrent follow-up (which awaits that mutex before choosing a host) cannot interleave with the read → compact → persist sequence.

The resume-start preparation shared by the follow-up and compaction coordinators is extracted into `prepareTaskResumeStartInput` (`sdk-task-resume.ts`) so the two callers — including the legacy-conversion step — cannot drift apart.

This is stacked on #12487, which owns the compaction divider UX (the `say:"compaction"` row and the context-meter shrink). This PR reuses that UX unchanged and adds only the action that lets history-opened and legacy tasks reach it; the earlier revision's parallel `context_compacted` say and its own context-meter math are dropped in favor of #12487's.

### Test Procedure

Automated:

```
# VSCode SDK adapter suites (resume + compaction coordinators)
cd apps/vscode && bunx vitest run --config vitest.config.ts src/sdk/sdk-compaction-coordinator.test.ts src/sdk/sdk-task-resume.test.ts

# Type check
cd apps/vscode && bunx tsc --noEmit
```

Manual (extension host):

1. `apps/vscode/scripts/run-extension-host.ps1` (or `.sh`).
2. Open a large task from history (not running).
3. Click the compact button and confirm.

A "Context compacted (manual)" divider appears and a follow-up turn resumes the compacted context.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

- [x] Changes are limited to a single bugfix
- [x] Tests are passing
- [x] Reviewed contributor guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session lifecycle, mutex ordering, and compaction persistence with many navigation race guards; scope is localized to VSCode SDK coordinators with broad test coverage.
> 
> **Overview**
> **Compact** now targets the **displayed** task, not only an active session. History-opened idle tasks resume on an **isolated host**, compact through the existing read → compact → persist path, then **stop/dispose** so the task stays view-only with the sidecar saved.
> 
> **Concurrency:** compaction and idle follow-up **resume** both run inside `sessionRebuilds.runExclusive`, with `waitForPendingStop` before isolated starts. Follow-ups **abandon** safely when the user switches tasks mid-resume (`onFollowUpAbandoned` settles the pre-set streaming UI).
> 
> **Shared resume prep** is extracted to `prepareTaskResumeStartInput` (`sdk-task-resume.ts`) so follow-up and compaction stay aligned on legacy migration and transcript loading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52c387741a4aa2c91fefa1b6804e5b4182cb7379. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->