### PR TITLE
fix(protos): self-heal protoc download when bun skips grpc-tools postinstall

### DIFF
--- a/apps/vscode/scripts/build-proto.mjs
+++ b/apps/vscode/scripts/build-proto.mjs
@@ -14,18 +14,66 @@ import { main as generateProtoBusSetup } from "./generate-protobus-setup.mjs"
 
 const require = createRequire(import.meta.url)
 const isWindows = process.platform === "win32"
-const GRPC_TOOLS_PROTOC = path.join(require.resolve("grpc-tools"), "../bin", isWindows ? "protoc.exe" : "protoc")
+// Resolve the grpc-tools package root via its package.json (stable regardless of `main`), so we
+// can both locate the bundled protoc and re-run its install script when the binary is missing.
+const GRPC_TOOLS_DIR = path.dirname(require.resolve("grpc-tools/package.json"))
+const GRPC_TOOLS_PROTOC = path.join(GRPC_TOOLS_DIR, "bin", isWindows ? "protoc.exe" : "protoc")
 // Legacy compatibility: some older/local Windows setups provision protoc into tmp-protoc.
 // Prefer that path when present, but fall back to the grpc-tools bundled binary used by CI/npm installs.
 const LEGACY_WINDOWS_PROTOC = path.resolve("tmp-protoc/bin/protoc.exe")
 const PROTOC = isWindows && fsSync.existsSync(LEGACY_WINDOWS_PROTOC) ? LEGACY_WINDOWS_PROTOC : GRPC_TOOLS_PROTOC
 
+// `bun install` skips grpc-tools' `install` lifecycle script (`node-pre-gyp install`), so the prebuilt
+// protoc is never downloaded into bin/. When it's missing, run that same command here to fetch it.
+// grpc-tools depends on @mapbox/node-pre-gyp, which exposes the `node-pre-gyp` CLI.
+function resolveNodePreGypCli() {
+	const candidates = ["@mapbox/node-pre-gyp/bin/node-pre-gyp", "node-pre-gyp/bin/node-pre-gyp"]
+	for (const candidate of candidates) {
+		try {
+			// Resolve from the grpc-tools package (its direct dependency).
+			return require.resolve(candidate, { paths: [GRPC_TOOLS_DIR] })
+		} catch {
+			// Fall back to resolving from this script's location (covers hoisted installs).
+			try {
+				return require.resolve(candidate)
+			} catch {
+				// try the next candidate
+			}
+		}
+	}
+	return null
+}
+
+function ensureProtocBinary() {
+	console.warn(chalk.yellow(`protoc not found at ${GRPC_TOOLS_PROTOC}; downloading the grpc-tools prebuilt binary...`))
+	const nodePreGypCli = resolveNodePreGypCli()
+	if (!nodePreGypCli) {
+		console.error(
+			chalk.red(
+				`Could not resolve the node-pre-gyp CLI from ${GRPC_TOOLS_DIR}. Run \`bun install\`, then retry \`bun run protos\`.`,
+			),
+		)
+		process.exit(1)
+	}
+	try {
+		// Mirrors grpc-tools' `scripts.install` ("node-pre-gyp install"): downloads the prebuilt
+		// protoc for the current platform/arch into grpc-tools/bin.
+		execFileSync(process.execPath, [nodePreGypCli, "install"], { cwd: GRPC_TOOLS_DIR, stdio: "inherit" })
+	} catch (error) {
+		console.error(chalk.red(`Failed to download protoc via node-pre-gyp: ${error?.message ?? error}`))
+		process.exit(1)
+	}
+	if (!fsSync.existsSync(GRPC_TOOLS_PROTOC)) {
+		console.error(chalk.red(`protoc still not found at ${GRPC_TOOLS_PROTOC} after node-pre-gyp install.`))
+		process.exit(1)
+	}
+	console.log(chalk.green("✓ protoc binary installed."))
+}
+
 if (!fsSync.existsSync(PROTOC)) {
-	const windowsHint = isWindows
-		? ` Neither ${LEGACY_WINDOWS_PROTOC} nor the grpc-tools bundled protoc at ${GRPC_TOOLS_PROTOC} exists.`
-		: ""
-	console.error(chalk.red(`protoc not found at ${PROTOC}.${windowsHint}`))
-	process.exit(1)
+	// PROTOC only differs from GRPC_TOOLS_PROTOC when the legacy Windows path exists, so a missing
+	// PROTOC always means the grpc-tools-bundled protoc needs to be fetched.
+	ensureProtocBinary()
 }
 
 const PROTO_DIR = path.resolve("proto")


### PR DESCRIPTION
### Description

`bun install` is the package manager for this repo, but it does not run `grpc-tools`' `install` lifecycle script (`node-pre-gyp install`). That script is what downloads the prebuilt `protoc` binary into `grpc-tools/bin/`. Without it, `protoc` is absent and `bun run protos` (and everything downstream: `dev`, `check-types`, `ci:build`) fails at startup with `protoc not found`.

`build-proto.mjs` now self-heals: when `protoc` is missing, it runs the same `node-pre-gyp install` command that `grpc-tools`' own `package.json` would have run. It resolves the `@mapbox/node-pre-gyp` CLI (the package that provides the `node-pre-gyp` command, which `grpc-tools` depends on) from the `grpc-tools` package directory and executes it with `cwd` set to the `grpc-tools` package root, so the prebuilt `protoc` lands in `bin/` exactly where the rest of the script expects it.

The check is idempotent — once `protoc` exists (whether downloaded by this step, a future bun fix, or a manual `npx node-pre-gyp install`), the download is skipped and the script proceeds straight to compilation. This makes the build resilient to any reason `protoc` might be absent (bun skipping scripts, cache restoration without the binary, fresh worktrees), not just the specific `trustedDependencies` interaction.

### Test Procedure

1. `bun install` (from repo root) — confirmed `protoc` is **missing** at `node_modules/.bun/grpc-tools@1.13.1/node_modules/grpc-tools/bin/protoc`, reproducing the bug.
2. `cd apps/vscode && bun run protos` — the self-heal triggered:
   - Logged `protoc not found at …/grpc-tools/bin/protoc; downloading the grpc-tools prebuilt binary...`
   - `node-pre-gyp@2.0.3` downloaded `darwin-arm64.tar.gz` and unpacked `protoc`
   - Logged `✓ protoc binary installed.`
   - Proto compilation then completed successfully (23 proto files processed), and `postprotos` formatting ran (`Formatted 293 files`).
3. Ran `bun run protos` a second time — the download step was skipped entirely (went straight to `Compiling Protocol Buffers...`), confirming the self-heal is idempotent.

The `node-pre-gyp install` step requires network access to `node-precompiled-binaries.grpc.io`. If that fails, the script exits with a clear error (`Failed to download protoc via node-pre-gyp: …`) rather than proceeding with a missing binary. If `@mapbox/node-pre-gyp` cannot be resolved at all (e.g., dependencies not installed), it exits with guidance to run `bun install` first.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Terminal output from the self-heal run (step 2 above):

```
$ node scripts/build-proto.mjs
protoc not found at …/grpc-tools/bin/protoc; downloading the grpc-tools prebuilt binary...
[info] it worked if it ends with ok
[info] using node-pre-gyp@2.0.3
[info] using node@22.22.0 | darwin | arm64
[log] GET https://node-precompiled-binaries.grpc.io/grpc-tools/v1.13.1/darwin-arm64.tar.gz
[info] install unpacking arm64/protoc
[info] extracted file count: 3
[grpc-tools] Success: "…/grpc-tools/bin/grpc_tools.node" is installed via remote
[info] ok
✓ protoc binary installed.
Compiling Protocol Buffers...
Processing 23 proto files from …/apps/vscode/proto
```

### Additional Notes

The `grpc-tools` package root is now resolved via its `package.json` (`require.resolve("grpc-tools/package.json")`) rather than `require.resolve("grpc-tools")` + `../bin`. The `main` entry (`index.js`) resolves to the package root anyway, but resolving `package.json` is stable regardless of how `main` is set, and gives us the directory we need to both locate `protoc` and re-run the install script.
