### PR TITLE
fix: generalize model capability warning

### DIFF
--- a/apps/vscode/src/core/task/index.ts
+++ b/apps/vscode/src/core/task/index.ts
@@ -2844,7 +2844,7 @@ export class Task {
 				"mistake_limit_reached",
 				this.api.getModel().id.includes("claude")
 					? `This may indicate a failure in Cline's thought process or inability to use a tool properly, which can be mitigated with some user guidance (e.g. "Try breaking down the task into smaller steps").`
-					: "Cline uses complex prompts and iterative task execution that may be challenging for less capable models. For best results, it's recommended to use Claude 4.5 Sonnet for its advanced agentic coding capabilities.",
+					: "Cline uses complex prompts and iterative task execution that may be challenging for less capable models. For best results, it's recommended to use a stronger model with better tool-calling and agentic coding capabilities.",
 			);
 			if (response === "messageResponse") {
 				// Display the user's message in the chat UI


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This PR updates the mistake-limit warning shown when Cline is running on a non-Claude model and hits the consecutive mistake threshold.

Previously, the warning specifically recommended "Claude 4.5 Sonnet" for its agentic coding capabilities. That model-specific copy can become stale as model recommendations change, and it is more prescriptive than necessary for this failure mode.

The new wording keeps the useful diagnostic context, but makes the recommendation provider-neutral: use a stronger model with better tool-calling and agentic coding capabilities. This better matches the underlying issue, which is that Cline's complex prompts and iterative tool workflow can be difficult for less capable models, without tying the guidance to a specific model name.

This is a copy-only change. It does not change task execution logic, model selection, provider behavior, or the mistake-limit flow.

### Test Procedure

I verified the change by:

- Searching for the exact old warning copy and confirming this was the only matching user-facing occurrence in the task flow.
- Reviewing the surrounding `mistake_limit_reached` logic to confirm the copy is only used for non-Claude models after the consecutive mistake threshold is reached.
- Reviewing the final diff against `legacy-extension` to confirm the PR contains a single string replacement.

I did not run the full test suite because this is a one-line text-only change with no behavioral or type-level impact.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. This is a warning-copy update in an existing task error flow.

### Additional Notes

This falls under the template's limited exception for minor wording improvements. No prior feature discussion should be needed.
