### PR TITLE
feat(vscode): add Claude Sonnet 5 support

### DIFF
--- a/apps/vscode/src/core/api/providers/__tests__/bedrock.test.ts
+++ b/apps/vscode/src/core/api/providers/__tests__/bedrock.test.ts
@@ -220,6 +220,11 @@ describe("AwsBedrockHandler", () => {
 			bedrockModels["anthropic.claude-fable-5:1m"].supportsGlobalEndpoint.should.equal(true)
 		})
 
+		it("should mark Bedrock Sonnet 5 variants as global-endpoint capable", () => {
+			bedrockModels["anthropic.claude-sonnet-5"].supportsGlobalEndpoint.should.equal(true)
+			bedrockModels["anthropic.claude-sonnet-5:1m"].supportsGlobalEndpoint.should.equal(true)
+		})
+
 		it("should include Vertex Opus 4.7 variants in the derived global model list", () => {
 			vertexModels["claude-opus-4-7"].supportsGlobalEndpoint.should.equal(true)
 			vertexModels["claude-opus-4-7:1m"].supportsGlobalEndpoint.should.equal(true)
@@ -988,6 +993,19 @@ describe("AwsBedrockHandler", () => {
 
 			const modelId = await jpHandler.getModelId()
 			modelId.should.equal("jp.anthropic.claude-sonnet-4-6")
+		})
+
+		it("should apply JP cross-region prefix for sonnet 5", async () => {
+			const jpOptions: AwsBedrockHandlerOptions = {
+				...mockOptions,
+				awsUseCrossRegionInference: true,
+				apiModelId: "anthropic.claude-sonnet-5",
+				awsRegion: "ap-northeast-1",
+			}
+			const jpHandler = new AwsBedrockHandler(jpOptions)
+
+			const modelId = await jpHandler.getModelId()
+			modelId.should.equal("jp.anthropic.claude-sonnet-5")
 		})
 
 		it("should apply global cross-region prefix for supported models", async () => {

--- a/apps/vscode/src/core/api/providers/__tests__/claude-code.test.ts
+++ b/apps/vscode/src/core/api/providers/__tests__/claude-code.test.ts
@@ -426,6 +426,26 @@ describe("ClaudeCodeHandler", () => {
 			model.info.contextWindow.should.equal(200_000)
 		})
 
+		it("should support Sonnet 5 model id", () => {
+			const handler = new ClaudeCodeHandler({
+				apiModelId: "claude-sonnet-5",
+			})
+
+			const model = handler.getModel()
+			model.id.should.equal("claude-sonnet-5")
+			model.info.contextWindow.should.equal(200_000)
+		})
+
+		it("should support Sonnet 5 1m model id", () => {
+			const handler = new ClaudeCodeHandler({
+				apiModelId: "claude-sonnet-5[1m]",
+			})
+
+			const model = handler.getModel()
+			model.id.should.equal("claude-sonnet-5[1m]")
+			model.info.contextWindow.should.equal(1_000_000)
+		})
+
 		it("should support Fable 5 1m model id", () => {
 			const handler = new ClaudeCodeHandler({
 				apiModelId: "claude-fable-5[1m]",

--- a/apps/vscode/src/core/api/providers/__tests__/sapaicore.test.ts
+++ b/apps/vscode/src/core/api/providers/__tests__/sapaicore.test.ts
@@ -69,6 +69,7 @@ describe("SapAiCoreHandler", () => {
 
 		it("should support different Claude model variants", () => {
 			const modelVariants = [
+				"anthropic--claude-sonnet-5",
 				"anthropic--claude-4.6-sonnet",
 				"anthropic--claude-4-sonnet",
 				"anthropic--claude-4-opus",

--- a/apps/vscode/src/core/api/providers/bedrock.ts
+++ b/apps/vscode/src/core/api/providers/bedrock.ts
@@ -134,9 +134,11 @@ interface ProviderChainOptions {
 	profile?: string
 }
 
-// a special jp inference profile was created for sonnet 4.6, opus 4.6, sonnet 4.5 & haiku 4.5
+// a special jp inference profile was created for newer Claude CRIS models
 // https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
 const JP_SUPPORTED_CRIS_MODELS = [
+	"anthropic.claude-sonnet-5",
+	"anthropic.claude-sonnet-5:1m",
 	"anthropic.claude-sonnet-4-6",
 	"anthropic.claude-sonnet-4-6:1m",
 	"anthropic.claude-opus-4-6-v1",

--- a/apps/vscode/src/core/api/providers/sapaicore.ts
+++ b/apps/vscode/src/core/api/providers/sapaicore.ts
@@ -672,6 +672,7 @@ export class SapAiCoreHandler implements ApiHandler {
 
 		const anthropicModels = [
 			"anthropic--claude-4.5-haiku",
+			"anthropic--claude-sonnet-5",
 			"anthropic--claude-4.7-opus",
 			"anthropic--claude-4.6-opus",
 			"anthropic--claude-4.5-opus",
@@ -725,6 +726,7 @@ export class SapAiCoreHandler implements ApiHandler {
 			"amazon--nova-micro",
 		];
 		const converseStreamModels = [
+			"anthropic--claude-sonnet-5",
 			"anthropic--claude-4.7-opus",
 			"anthropic--claude-4.6-opus",
 			"anthropic--claude-4.5-opus",

--- a/apps/vscode/src/core/api/transform/__tests__/openrouter-stream.test.ts
+++ b/apps/vscode/src/core/api/transform/__tests__/openrouter-stream.test.ts
@@ -78,6 +78,19 @@ describe("createOpenRouterStream", () => {
 		payload.should.not.have.property("max_tokens")
 	})
 
+	it("strips the custom Sonnet 5 1m suffix and pins Anthropic/Vertex routing", async () => {
+		const { client, create } = createClient()
+
+		await createOpenRouterStream(client as any, "system prompt", [{ role: "user", content: "hello" }] as any, {
+			id: "anthropic/claude-sonnet-5:1m",
+			info: createModelInfo(128_000),
+		})
+
+		const payload = create.firstCall.args[0] as any
+		payload.should.have.property("model", "anthropic/claude-sonnet-5")
+		payload.provider.should.deepEqual({ order: ["anthropic", "google-vertex/global"], allow_fallbacks: false })
+	})
+
 	it("adds cache_control blocks for Qwen models that require explicit OpenRouter caching", async () => {
 		for (const modelId of ["qwen/qwen3.6-plus", "qwen/qwen3.7-max"]) {
 			const { client, create } = createClient()

--- a/apps/vscode/src/core/api/transform/openrouter-stream.ts
+++ b/apps/vscode/src/core/api/transform/openrouter-stream.ts
@@ -10,6 +10,7 @@ import {
 	openRouterClaudeSonnet41mModelId,
 	openRouterClaudeSonnet451mModelId,
 	openRouterClaudeSonnet461mModelId,
+	openRouterClaudeSonnet51mModelId,
 } from "@shared/api"
 import { normalizeOpenaiReasoningEffort } from "@shared/storage/types"
 import { isClaudeOpusAdaptiveThinkingModel, resolveClaudeOpusAdaptiveThinking } from "@shared/utils/reasoning-support"
@@ -62,6 +63,7 @@ export async function createOpenRouterStream(
 		model.id === openRouterClaudeSonnet41mModelId ||
 		model.id === openRouterClaudeSonnet451mModelId ||
 		model.id === openRouterClaudeSonnet461mModelId ||
+		model.id === openRouterClaudeSonnet51mModelId ||
 		model.id === openRouterClaudeOpus461mModelId ||
 		model.id === openRouterClaudeOpus471mModelId ||
 		model.id === openRouterClaudeOpus481mModelId ||
@@ -147,6 +149,8 @@ export async function createOpenRouterStream(
 		switch (model.id) {
 			case "anthropic/claude-haiku-4.5":
 			case "anthropic/claude-4.5-haiku":
+			case "anthropic/claude-sonnet-5":
+			case "anthropic/claude-5-sonnet":
 			case "anthropic/claude-sonnet-4.6":
 			case "anthropic/claude-4.6-sonnet":
 			case "anthropic/claude-sonnet-4.5":

--- a/apps/vscode/src/core/api/transform/vercel-ai-gateway-stream.ts
+++ b/apps/vscode/src/core/api/transform/vercel-ai-gateway-stream.ts
@@ -9,6 +9,7 @@ import {
 	openRouterClaudeSonnet41mModelId,
 	openRouterClaudeSonnet451mModelId,
 	openRouterClaudeSonnet461mModelId,
+	openRouterClaudeSonnet51mModelId,
 } from "@shared/api"
 import { normalizeOpenaiReasoningEffort } from "@shared/storage/types"
 import { isClaudeOpusAdaptiveThinkingModel, resolveClaudeOpusAdaptiveThinking } from "@shared/utils/reasoning-support"
@@ -38,6 +39,7 @@ export async function createVercelAIGatewayStream(
 		model.id === openRouterClaudeSonnet41mModelId ||
 		model.id === openRouterClaudeSonnet451mModelId ||
 		model.id === openRouterClaudeSonnet461mModelId ||
+		model.id === openRouterClaudeSonnet51mModelId ||
 		model.id === openRouterClaudeOpus461mModelId ||
 		model.id === openRouterClaudeOpus471mModelId ||
 		model.id === openRouterClaudeOpus481mModelId ||

--- a/apps/vscode/src/core/controller/models/__tests__/refreshClineRecommendedModels.test.ts
+++ b/apps/vscode/src/core/controller/models/__tests__/refreshClineRecommendedModels.test.ts
@@ -39,7 +39,7 @@ describe("refreshClineRecommendedModels", () => {
 			data: {
 				recommended: [
 					{
-						id: "anthropic/claude-sonnet-4.6",
+						id: "anthropic/claude-sonnet-5",
 						description: "Remote recommended",
 						tags: ["NEW"],
 					},
@@ -61,8 +61,8 @@ describe("refreshClineRecommendedModels", () => {
 		expect(result).to.deep.equal({
 			recommended: [
 				{
-					id: "anthropic/claude-sonnet-4.6",
-					name: "anthropic/claude-sonnet-4.6",
+					id: "anthropic/claude-sonnet-5",
+					name: "anthropic/claude-sonnet-5",
 					description: "Remote recommended",
 					tags: ["NEW"],
 				},

--- a/apps/vscode/src/core/controller/models/refreshClineModels.ts
+++ b/apps/vscode/src/core/controller/models/refreshClineModels.ts
@@ -21,6 +21,7 @@ import {
 	openRouterClaudeSonnet41mModelId,
 	openRouterClaudeSonnet451mModelId,
 	openRouterClaudeSonnet461mModelId,
+	openRouterClaudeSonnet51mModelId,
 } from "@/shared/api"
 import { getAxiosSettings } from "@/shared/net"
 import { FeatureFlag } from "@/shared/services/feature-flags/feature-flags"
@@ -212,6 +213,8 @@ async function fetchAndCacheClineModels(): Promise<Record<string, ModelInfo>> {
 
 			// Apply model-specific overrides for known models
 			switch (rawModel.id) {
+				case "anthropic/claude-sonnet-5":
+				case "anthropic/claude-5-sonnet":
 				case "anthropic/claude-sonnet-4.6":
 				case "anthropic/claude-4.6-sonnet":
 				case "anthropic/claude-sonnet-4.5":
@@ -304,12 +307,17 @@ async function fetchAndCacheClineModels(): Promise<Record<string, ModelInfo>> {
 				rawModel.id === "anthropic/claude-sonnet-4" ||
 				rawModel.id === "anthropic/claude-sonnet-4.5" ||
 				rawModel.id === "anthropic/claude-sonnet-4.6" ||
-				rawModel.id === "anthropic/claude-4.6-sonnet"
+				rawModel.id === "anthropic/claude-4.6-sonnet" ||
+				rawModel.id === "anthropic/claude-sonnet-5" ||
+				rawModel.id === "anthropic/claude-5-sonnet"
 			) {
 				const claudeSonnet1mModelInfo = cloneDeep(modelInfo)
 				claudeSonnet1mModelInfo.contextWindow = 1_000_000
 				claudeSonnet1mModelInfo.tiers = CLAUDE_SONNET_1M_TIERS
 
+				if (rawModel.id === "anthropic/claude-sonnet-5" || rawModel.id === "anthropic/claude-5-sonnet") {
+					models[openRouterClaudeSonnet51mModelId] = claudeSonnet1mModelInfo
+				}
 				if (rawModel.id === "anthropic/claude-sonnet-4") {
 					models[openRouterClaudeSonnet41mModelId] = claudeSonnet1mModelInfo
 				}

--- a/apps/vscode/src/core/controller/models/refreshOpenRouterModels.ts
+++ b/apps/vscode/src/core/controller/models/refreshOpenRouterModels.ts
@@ -18,6 +18,7 @@ import {
 	openRouterClaudeSonnet41mModelId,
 	openRouterClaudeSonnet451mModelId,
 	openRouterClaudeSonnet461mModelId,
+	openRouterClaudeSonnet51mModelId,
 } from "@/shared/api"
 import { getAxiosSettings } from "@/shared/net"
 import { Logger } from "@/shared/services/Logger"
@@ -150,6 +151,8 @@ async function fetchAndCacheModels(controller: Controller): Promise<Record<strin
 				}
 
 				switch (rawModel.id) {
+					case "anthropic/claude-sonnet-5":
+					case "anthropic/claude-5-sonnet":
 					case "anthropic/claude-sonnet-4.6":
 					case "anthropic/claude-4.6-sonnet":
 					case "anthropic/claude-sonnet-4.5":
@@ -294,11 +297,17 @@ async function fetchAndCacheModels(controller: Controller): Promise<Record<strin
 					rawModel.id === "anthropic/claude-sonnet-4.5" ||
 					rawModel.id === "anthropic/claude-4.5-sonnet" ||
 					rawModel.id === "anthropic/claude-sonnet-4.6" ||
-					rawModel.id === "anthropic/claude-4.6-sonnet"
+					rawModel.id === "anthropic/claude-4.6-sonnet" ||
+					rawModel.id === "anthropic/claude-sonnet-5" ||
+					rawModel.id === "anthropic/claude-5-sonnet"
 				) {
 					const claudeSonnet1mModelInfo = cloneDeep(modelInfo)
 					claudeSonnet1mModelInfo.contextWindow = 1_000_000 // limiting providers to those that support 1m context window
 					claudeSonnet1mModelInfo.tiers = CLAUDE_SONNET_1M_TIERS
+					// sonnet 5
+					if (rawModel.id === "anthropic/claude-sonnet-5" || rawModel.id === "anthropic/claude-5-sonnet") {
+						models[openRouterClaudeSonnet51mModelId] = claudeSonnet1mModelInfo
+					}
 					// sonnet 4
 					if (rawModel.id === "anthropic/claude-sonnet-4") {
 						models[openRouterClaudeSonnet41mModelId] = claudeSonnet1mModelInfo

--- a/apps/vscode/src/shared/api.ts
+++ b/apps/vscode/src/shared/api.ts
@@ -179,10 +179,33 @@ export const hicapModelInfoSaneDefaults: HicapCompatibleModelInfo = {
 // Anthropic
 // https://docs.anthropic.com/en/docs/about-claude/models // prices updated 2025-01-02
 export type AnthropicModelId = keyof typeof anthropicModels
-export const anthropicDefaultModelId: AnthropicModelId = "claude-sonnet-4-5-20250929"
+export const anthropicDefaultModelId: AnthropicModelId = "claude-sonnet-5"
 export const ANTHROPIC_MIN_THINKING_BUDGET = 1_024
 export const ANTHROPIC_MAX_THINKING_BUDGET = 6_000
 export const anthropicModels = {
+	"claude-sonnet-5": {
+		maxTokens: 128_000,
+		contextWindow: 200_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		supportsReasoning: true,
+		inputPrice: 3.0,
+		outputPrice: 15.0,
+		cacheWritesPrice: 3.75,
+		cacheReadsPrice: 0.3,
+	},
+	"claude-sonnet-5:1m": {
+		maxTokens: 128_000,
+		contextWindow: 1_000_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		supportsReasoning: true,
+		inputPrice: 3.0,
+		outputPrice: 15.0,
+		cacheWritesPrice: 3.75,
+		cacheReadsPrice: 0.3,
+		tiers: CLAUDE_SONNET_1M_TIERS,
+	},
 	"claude-sonnet-4-6": {
 		maxTokens: 64_000,
 		contextWindow: 200_000,
@@ -471,15 +494,15 @@ export const anthropicModels = {
 
 // Claude Code
 export type ClaudeCodeModelId = keyof typeof claudeCodeModels
-export const claudeCodeDefaultModelId: ClaudeCodeModelId = "claude-sonnet-4-5-20250929"
+export const claudeCodeDefaultModelId: ClaudeCodeModelId = "claude-sonnet-5"
 export const claudeCodeModels = {
 	sonnet: {
-		...anthropicModels["claude-sonnet-4-5-20250929"],
+		...anthropicModels["claude-sonnet-5"],
 		supportsImages: false,
 		supportsPromptCache: false,
 	},
 	"sonnet[1m]": {
-		...anthropicModels["claude-sonnet-4-5-20250929:1m"],
+		...anthropicModels["claude-sonnet-5:1m"],
 		supportsImages: false,
 		supportsPromptCache: false,
 	},
@@ -496,6 +519,16 @@ export const claudeCodeModels = {
 	},
 	"claude-haiku-4-5-20251001": {
 		...anthropicModels["claude-haiku-4-5-20251001"],
+		supportsImages: false,
+		supportsPromptCache: false,
+	},
+	"claude-sonnet-5": {
+		...anthropicModels["claude-sonnet-5"],
+		supportsImages: false,
+		supportsPromptCache: false,
+	},
+	"claude-sonnet-5[1m]": {
+		...anthropicModels["claude-sonnet-5:1m"],
 		supportsImages: false,
 		supportsPromptCache: false,
 	},
@@ -597,8 +630,33 @@ export const claudeCodeModels = {
 // AWS Bedrock
 // https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html
 export type BedrockModelId = keyof typeof bedrockModels
-export const bedrockDefaultModelId: BedrockModelId = "anthropic.claude-sonnet-4-5-20250929-v1:0"
+export const bedrockDefaultModelId: BedrockModelId = "anthropic.claude-sonnet-5"
 export const bedrockModels = {
+	"anthropic.claude-sonnet-5": {
+		maxTokens: 128_000,
+		contextWindow: 200_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		supportsReasoning: true,
+		supportsGlobalEndpoint: true,
+		inputPrice: 3.0,
+		outputPrice: 15.0,
+		cacheWritesPrice: 3.75,
+		cacheReadsPrice: 0.3,
+	},
+	"anthropic.claude-sonnet-5:1m": {
+		maxTokens: 128_000,
+		contextWindow: 1_000_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		supportsReasoning: true,
+		supportsGlobalEndpoint: true,
+		inputPrice: 3.0,
+		outputPrice: 15.0,
+		cacheWritesPrice: 3.75,
+		cacheReadsPrice: 0.3,
+		tiers: CLAUDE_SONNET_1M_TIERS,
+	},
 	"anthropic.claude-sonnet-4-6": {
 		maxTokens: 64_000,
 		contextWindow: 200_000,
@@ -991,16 +1049,17 @@ export const bedrockModels = {
 
 // OpenRouter
 // https://openrouter.ai/models?order=newest&supported_parameters=tools
-export const openRouterDefaultModelId = "anthropic/claude-sonnet-4.5" // will always exist in openRouterModels
+export const openRouterDefaultModelId = "anthropic/claude-sonnet-5" // will always exist in openRouterModels
 export const openRouterClaudeSonnet41mModelId = `anthropic/claude-sonnet-4${CLAUDE_SONNET_1M_SUFFIX}`
 export const openRouterClaudeSonnet451mModelId = `anthropic/claude-sonnet-4.5${CLAUDE_SONNET_1M_SUFFIX}`
 export const openRouterClaudeSonnet461mModelId = `anthropic/claude-sonnet-4.6${CLAUDE_SONNET_1M_SUFFIX}`
+export const openRouterClaudeSonnet51mModelId = `anthropic/claude-sonnet-5${CLAUDE_SONNET_1M_SUFFIX}`
 export const openRouterClaudeOpus461mModelId = `anthropic/claude-opus-4.6${CLAUDE_SONNET_1M_SUFFIX}`
 export const openRouterClaudeOpus471mModelId = `anthropic/claude-opus-4.7${CLAUDE_SONNET_1M_SUFFIX}`
 export const openRouterClaudeOpus481mModelId = `anthropic/claude-opus-4.8${CLAUDE_SONNET_1M_SUFFIX}`
 export const openRouterClaudeFable51mModelId = `anthropic/claude-fable-5${CLAUDE_SONNET_1M_SUFFIX}`
 export const openRouterDefaultModelInfo: ModelInfo = {
-	maxTokens: 64_000,
+	maxTokens: 128_000,
 	contextWindow: 200_000,
 	supportsImages: true,
 	supportsPromptCache: true,
@@ -1009,7 +1068,7 @@ export const openRouterDefaultModelInfo: ModelInfo = {
 	cacheWritesPrice: 3.75,
 	cacheReadsPrice: 0.3,
 	description:
-		"Claude Sonnet 4.5 delivers superior intelligence across coding, agentic search, and AI agent capabilities. It's a powerful choice for agentic coding, and can complete tasks across the entire software development lifecycle, from initial planning to bug fixes, maintenance to large refactors. It offers strong performance in both planning and solving for complex coding tasks, making it an ideal choice to power end-to-end software development processes.\n\nRead more in the [blog post here](https://www.anthropic.com/claude/sonnet)",
+		"Claude Sonnet 5 is Anthropic's latest Sonnet model for coding, agents, and professional work. It supports adaptive thinking, prompt caching, image inputs, and long-context workflows.",
 }
 
 // Cline custom model - Devstral
@@ -1245,6 +1304,29 @@ export const vertexModels = {
 			geminiThinkingLevel: "high",
 			supportsThinkingLevel: true,
 		},
+	},
+	"claude-sonnet-5": {
+		maxTokens: 128_000,
+		contextWindow: 200_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 3.0,
+		outputPrice: 15.0,
+		cacheWritesPrice: 3.75,
+		cacheReadsPrice: 0.3,
+		supportsReasoning: true,
+	},
+	"claude-sonnet-5:1m": {
+		maxTokens: 128_000,
+		contextWindow: 1_000_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 3.0,
+		outputPrice: 15.0,
+		cacheWritesPrice: 3.75,
+		cacheReadsPrice: 0.3,
+		supportsReasoning: true,
+		tiers: CLAUDE_SONNET_1M_TIERS,
 	},
 	"claude-sonnet-4-6": {
 		maxTokens: 64_000,
@@ -4376,9 +4458,9 @@ export const groqModels = {
 
 // Requesty
 // https://requesty.ai/models
-export const requestyDefaultModelId = "anthropic/claude-3-7-sonnet-latest"
+export const requestyDefaultModelId = "anthropic/claude-sonnet-5"
 export const requestyDefaultModelInfo: ModelInfo = {
-	maxTokens: 8192,
+	maxTokens: 128_000,
 	contextWindow: 200_000,
 	supportsImages: true,
 
@@ -4387,7 +4469,7 @@ export const requestyDefaultModelInfo: ModelInfo = {
 	outputPrice: 15.0,
 	cacheWritesPrice: 3.75,
 	cacheReadsPrice: 0.3,
-	description: "Anthropic's most intelligent model. Highest level of intelligence and capability.",
+	description: "Anthropic's latest Sonnet model for coding, agents, and professional work.",
 }
 
 // SAP AI Core
@@ -4396,6 +4478,13 @@ export const sapAiCoreDefaultModelId: SapAiCoreModelId = "anthropic--claude-3.5-
 // Pricing is calculated using Capacity Units, not directly in USD
 const sapAiCoreModelDescription = "Pricing is calculated using SAP's Capacity Units rather than direct USD pricing."
 export const sapAiCoreModels = {
+	"anthropic--claude-sonnet-5": {
+		maxTokens: 128_000,
+		contextWindow: 200_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		description: sapAiCoreModelDescription,
+	},
 	"anthropic--claude-4.5-haiku": {
 		maxTokens: 64000,
 		contextWindow: 200_000,

--- a/apps/vscode/src/shared/cline/onboarding.ts
+++ b/apps/vscode/src/shared/cline/onboarding.ts
@@ -55,8 +55,8 @@ export const CLINE_ONBOARDING_MODELS: OnboardingModel[] = [
 	},
 	{
 		group: "frontier",
-		id: "anthropic/claude-sonnet-4.5",
-		name: "Anthropic: Claude Sonnet 4.5",
+		id: "anthropic/claude-sonnet-5",
+		name: "Anthropic: Claude Sonnet 5",
 		badge: "Best",
 		score: 97,
 		latency: 3,

--- a/apps/vscode/src/shared/cline/recommended-models.ts
+++ b/apps/vscode/src/shared/cline/recommended-models.ts
@@ -22,8 +22,8 @@ export const CLINE_RECOMMENDED_MODELS_FALLBACK: ClineRecommendedModelsData = {
 			tags: ["NEW"],
 		},
 		{
-			id: "anthropic/claude-sonnet-4.6",
-			name: "Anthropic Claude Sonnet 4.6",
+			id: "anthropic/claude-sonnet-5",
+			name: "Anthropic Claude Sonnet 5",
 			description: "Latest Sonnet release with strong coding and agent performance",
 			tags: ["NEW"],
 		},

--- a/apps/vscode/src/shared/utils/reasoning-support.ts
+++ b/apps/vscode/src/shared/utils/reasoning-support.ts
@@ -1,11 +1,13 @@
 import { normalizeOpenaiReasoningEffort, type OpenaiReasoningEffort } from "../storage/types"
 
-export interface ClaudeOpusAdaptiveThinkingSettings {
+export interface ClaudeAdaptiveThinkingSettings {
 	enabled: boolean
 	effort?: OpenaiReasoningEffort
 }
 
-export function isClaudeOpusAdaptiveThinkingModel(modelId?: string): boolean {
+export type ClaudeOpusAdaptiveThinkingSettings = ClaudeAdaptiveThinkingSettings
+
+export function isClaudeAdaptiveThinkingModel(modelId?: string): boolean {
 	if (!modelId) {
 		return false
 	}
@@ -14,14 +16,18 @@ export function isClaudeOpusAdaptiveThinkingModel(modelId?: string): boolean {
 	const adaptiveVersions = ["4-6", "4.6", "4-7", "4.7", "4-8", "4.8"]
 	return (
 		id.includes("claude-fable-5") ||
+		id.includes("claude-sonnet-5") ||
+		id.includes("claude-5-sonnet") ||
 		adaptiveVersions.some((version) => id.includes(`claude-opus-${version}`) || id.includes(`claude-${version}-opus`))
 	)
 }
 
-export function resolveClaudeOpusAdaptiveThinking(
+export const isClaudeOpusAdaptiveThinkingModel = isClaudeAdaptiveThinkingModel
+
+export function resolveClaudeAdaptiveThinking(
 	reasoningEffort?: string,
 	legacyThinkingBudgetTokens?: number,
-): ClaudeOpusAdaptiveThinkingSettings {
+): ClaudeAdaptiveThinkingSettings {
 	if (reasoningEffort) {
 		const effort = normalizeOpenaiReasoningEffort(reasoningEffort)
 		return effort === "none" ? { enabled: false } : { enabled: true, effort }
@@ -29,6 +35,8 @@ export function resolveClaudeOpusAdaptiveThinking(
 
 	return legacyThinkingBudgetTokens && legacyThinkingBudgetTokens > 0 ? { enabled: true, effort: "high" } : { enabled: false }
 }
+
+export const resolveClaudeOpusAdaptiveThinking = resolveClaudeAdaptiveThinking
 
 export function supportsReasoningEffortForModel(modelId?: string): boolean {
 	if (!modelId) {

--- a/apps/vscode/src/test/e2e/fixtures/server/api.ts
+++ b/apps/vscode/src/test/e2e/fixtures/server/api.ts
@@ -94,8 +94,8 @@ export const E2E_MOCK_CLINE_RECOMMENDED_MODELS = {
 	],
 	recommended: [
 		{
-			id: "anthropic/claude-sonnet-4.6",
-			name: "anthropic/claude-sonnet-4.6",
+			id: "anthropic/claude-sonnet-5",
+			name: "anthropic/claude-sonnet-5",
 			description: "Recommended model for e2e onboarding",
 			tags: ["BEST"],
 		},
@@ -123,12 +123,12 @@ export const E2E_MOCK_CLINE_MODELS = [
 		supported_parameters: [],
 	},
 	{
-		id: "anthropic/claude-sonnet-4.6",
-		name: "anthropic/claude-sonnet-4.6",
+		id: "anthropic/claude-sonnet-5",
+		name: "anthropic/claude-sonnet-5",
 		description: "Recommended model for e2e onboarding",
 		context_length: 200_000,
 		top_provider: {
-			max_completion_tokens: 64_000,
+			max_completion_tokens: 128_000,
 			context_length: 200_000,
 			is_moderated: false,
 		},

--- a/apps/vscode/src/utils/__tests__/model-utils.test.ts
+++ b/apps/vscode/src/utils/__tests__/model-utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "mocha"
 import "should"
 import type { ApiHandlerModel, ApiProviderInfo } from "@core/api"
+import { isClaudeAdaptiveThinkingModel } from "@shared/utils/reasoning-support"
 import {
 	GEMINI_FLASH_MAX_OUTPUT_TOKENS,
 	isClaude4PlusModelFamily,
@@ -101,6 +102,18 @@ describe("isClaude4PlusModelFamily", () => {
 		isClaude4PlusModelFamily("gpt-4").should.equal(false)
 		isClaude4PlusModelFamily("gemini-pro").should.equal(false)
 		isClaude4PlusModelFamily("llama-3").should.equal(false)
+	})
+})
+
+describe("isClaudeAdaptiveThinkingModel", () => {
+	it("should return true for Claude Sonnet 5 IDs across provider naming variants", () => {
+		for (const modelId of [
+			"claude-sonnet-5",
+			"anthropic/claude-sonnet-5:1m",
+			"anthropic/claude-5-sonnet",
+		]) {
+			isClaudeAdaptiveThinkingModel(modelId).should.equal(true)
+		}
 	})
 })
 

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/WelcomeSection.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/WelcomeSection.tsx
@@ -165,7 +165,7 @@ export const WelcomeSection: React.FC<WelcomeSectionProps> = ({
 					break
 
 				case BannerActionType.SetModel: {
-					const modelId = action.arg || "anthropic/claude-sonnet-4.5"
+					const modelId = action.arg || "anthropic/claude-sonnet-5"
 					const initialModelTab = action.tab || "recommended"
 					handleFieldsChange({
 						planModeOpenRouterModelId: modelId,

--- a/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.tsx
@@ -414,6 +414,8 @@ const ClineModelPicker: React.FC<ClineModelPickerProps> = ({
 			Object.entries(resolvedModels ?? {})?.some(([id, m]) => id === selectedModelId && m.thinkingConfig) ||
 			selectedModelIdLower.includes("claude-haiku-4.5") ||
 			selectedModelIdLower.includes("claude-4.5-haiku") ||
+			selectedModelIdLower.includes("claude-sonnet-5") ||
+			selectedModelIdLower.includes("claude-5-sonnet") ||
 			selectedModelIdLower.includes("claude-sonnet-4.6") ||
 			selectedModelIdLower.includes("claude-sonnet-4-6") ||
 			selectedModelIdLower.includes("claude-4.6-sonnet") ||
@@ -570,6 +572,14 @@ const ClineModelPicker: React.FC<ClineModelPickerProps> = ({
 					selectedModelId={selectedModelId}
 				/>
 
+				{/* Context window switcher for Claude Sonnet 5 */}
+				<ContextWindowSwitcher
+					base1mModelId={`anthropic/claude-sonnet-5${CLAUDE_SONNET_1M_SUFFIX}`}
+					base200kModelId="anthropic/claude-sonnet-5"
+					onModelChange={handleModelChange}
+					selectedModelId={selectedModelId}
+				/>
+
 				{/* Context window switcher for Claude Opus 4.8 */}
 				<ContextWindowSwitcher
 					base1mModelId={`anthropic/claude-opus-4.8${CLAUDE_SONNET_1M_SUFFIX}`}
@@ -655,7 +665,7 @@ const ClineModelPicker: React.FC<ClineModelPickerProps> = ({
 						color: "var(--vscode-descriptionForeground)",
 					}}>
 					The extension automatically fetches the latest Cline model list. If you're unsure which model to choose, Cline
-					works best with <strong>anthropic/claude-sonnet-4.5</strong>.
+					works best with <strong>anthropic/claude-sonnet-5</strong>.
 				</p>
 			)}
 		</div>

--- a/apps/vscode/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
@@ -221,6 +221,8 @@ const OpenRouterModelPicker: React.FC<OpenRouterModelPickerProps> = ({ isPopup, 
 			Object.entries(openRouterModels)?.some(([id, m]) => id === selectedModelId && m.thinkingConfig) ||
 			selectedModelIdLower.includes("claude-haiku-4.5") ||
 			selectedModelIdLower.includes("claude-4.5-haiku") ||
+			selectedModelIdLower.includes("claude-sonnet-5") ||
+			selectedModelIdLower.includes("claude-5-sonnet") ||
 			selectedModelIdLower.includes("claude-sonnet-4.6") ||
 			selectedModelIdLower.includes("claude-sonnet-4-6") ||
 			selectedModelIdLower.includes("claude-4.6-sonnet") ||
@@ -331,6 +333,14 @@ const OpenRouterModelPicker: React.FC<OpenRouterModelPickerProps> = ({ isPopup, 
 					selectedModelId={selectedModelId}
 				/>
 
+				{/* Context window switcher for Claude Sonnet 5 */}
+				<ContextWindowSwitcher
+					base1mModelId={`anthropic/claude-sonnet-5${CLAUDE_SONNET_1M_SUFFIX}`}
+					base200kModelId="anthropic/claude-sonnet-5"
+					onModelChange={handleModelChange}
+					selectedModelId={selectedModelId}
+				/>
+
 				{/* Context window switcher for Claude Opus 4.8 */}
 				<ContextWindowSwitcher
 					base1mModelId={`anthropic/claude-opus-4.8${CLAUDE_SONNET_1M_SUFFIX}`}
@@ -421,9 +431,9 @@ const OpenRouterModelPicker: React.FC<OpenRouterModelPickerProps> = ({ isPopup, 
 					</VSCodeLink>
 					If you're unsure which model to choose, Cline works best with{" "}
 					<VSCodeLink
-						onClick={() => handleModelChange("anthropic/claude-sonnet-4.6")}
+						onClick={() => handleModelChange("anthropic/claude-sonnet-5")}
 						style={{ display: "inline", fontSize: "inherit" }}>
-						anthropic/claude-sonnet-4.6.
+						anthropic/claude-sonnet-5.
 					</VSCodeLink>
 					You can also try searching "free" for no-cost options currently available.
 				</p>

--- a/apps/vscode/webview-ui/src/components/settings/VercelModelPicker.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/VercelModelPicker.tsx
@@ -179,6 +179,8 @@ const VercelModelPicker: React.FC<VercelModelPickerProps> = ({ isPopup, currentM
 		return (
 			selectedModelIdLower.includes("claude-haiku-4.5") ||
 			selectedModelIdLower.includes("claude-4.5-haiku") ||
+			selectedModelIdLower.includes("claude-sonnet-5") ||
+			selectedModelIdLower.includes("claude-5-sonnet") ||
 			selectedModelIdLower.includes("claude-sonnet-4.6") ||
 			selectedModelIdLower.includes("claude-sonnet-4-6") ||
 			selectedModelIdLower.includes("claude-4.6-sonnet") ||

--- a/apps/vscode/webview-ui/src/components/settings/providers/AnthropicProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/AnthropicProvider.tsx
@@ -15,6 +15,8 @@ import { useApiConfigurationHandlers } from "../utils/useApiConfigurationHandler
 
 // Anthropic models that support thinking/reasoning mode
 export const SUPPORTED_ANTHROPIC_THINKING_MODELS = [
+	"claude-sonnet-5",
+	`claude-sonnet-5${CLAUDE_SONNET_1M_SUFFIX}`,
 	"claude-sonnet-4-6",
 	`claude-sonnet-4-6${CLAUDE_SONNET_1M_SUFFIX}`,
 	"claude-3-7-sonnet-20250219",
@@ -87,6 +89,14 @@ export const AnthropicProvider = ({ showModelOptions, isPopup, currentMode }: An
 								currentMode,
 							)
 						}
+						selectedModelId={selectedModelId}
+					/>
+
+					{/* Context window switcher for Claude Sonnet 5 */}
+					<ContextWindowSwitcher
+						base1mModelId={`claude-sonnet-5${CLAUDE_SONNET_1M_SUFFIX}`}
+						base200kModelId="claude-sonnet-5"
+						onModelChange={handleModelChange}
 						selectedModelId={selectedModelId}
 					/>
 

--- a/apps/vscode/webview-ui/src/components/settings/providers/BedrockProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/BedrockProvider.tsx
@@ -24,6 +24,8 @@ import { getModeSpecificFields, normalizeApiConfiguration } from "../utils/provi
 import { useApiConfigurationHandlers } from "../utils/useApiConfigurationHandlers"
 
 export const SUPPORTED_BEDROCK_THINKING_MODELS = [
+	"anthropic.claude-sonnet-5",
+	`anthropic.claude-sonnet-5${CLAUDE_SONNET_1M_SUFFIX}`,
 	"anthropic.claude-sonnet-4-6",
 	`anthropic.claude-sonnet-4-6${CLAUDE_SONNET_1M_SUFFIX}`,
 	"anthropic.claude-3-7-sonnet-20250219-v1:0",

--- a/apps/vscode/webview-ui/src/components/settings/providers/ClaudeCodeProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/ClaudeCodeProvider.tsx
@@ -13,6 +13,7 @@ const SUPPORTED_CLAUDE_CODE_THINKING_MODELS = [
 	...SUPPORTED_ANTHROPIC_THINKING_MODELS,
 	"sonnet",
 	"sonnet[1m]",
+	"claude-sonnet-5[1m]",
 	"claude-fable-5[1m]",
 	"claude-opus-4-8[1m]",
 	"claude-opus-4-7[1m]",

--- a/apps/vscode/webview-ui/src/components/settings/providers/VertexProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/VertexProvider.tsx
@@ -25,6 +25,8 @@ interface VertexProviderProps {
 
 // Vertex models that support thinking
 const SUPPORTED_THINKING_MODELS = [
+	"claude-sonnet-5",
+	"claude-sonnet-5:1m",
 	"claude-sonnet-4-6",
 	"claude-sonnet-4-6:1m",
 	"claude-haiku-4-5@20251001",


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Adds Claude Sonnet 5 support to the legacy VS Code extension release branch only.

This updates the hard-coded model surfaces that still live under `apps/vscode`, including the provider catalogs, defaults, model refresh derivation, reasoning/adaptive-thinking detection, 1M context variants, onboarding/recommended model fallbacks, and the model picker UI paths. The change mirrors the previous Opus 4.8 and Sonnet model-update patterns, with extra Sonnet-specific work because Sonnet is used as the default/recommended model in several places.

Notable implementation details:

- Adds Sonnet 5 and Sonnet 5 `:1m` metadata for Anthropic, Claude Code, Bedrock, Vertex, OpenRouter/Cline defaults, Requesty, and SAP AI Core.
- Updates Anthropic, Claude Code, Bedrock, and OpenRouter/Cline default model IDs to Sonnet 5 where Sonnet is the default path.
- Adds OpenRouter/Cline synthetic `:1m` derivation for both `anthropic/claude-sonnet-5` and the alternate `anthropic/claude-5-sonnet` ID shape.
- Wires the OpenRouter and Vercel AI Gateway transforms to strip the custom Sonnet 5 `:1m` suffix before sending requests.
- Updates adaptive-thinking detection so Sonnet 5 uses the reasoning-effort/adaptive-thinking path instead of legacy token-budget thinking.
- Updates onboarding and recommended-model fallbacks to surface `anthropic/claude-sonnet-5` to new users.
- Updates model picker context-window switchers and thinking/reasoning selector allowlists across Anthropic, Bedrock, Vertex, Claude Code, Cline, OpenRouter, and Vercel picker paths.

While auditing this against the prior Opus 4.8 model-add commit, I found one easy-to-miss gap: the OpenRouter/Cline dynamic model refresh code must handle both `anthropic/claude-sonnet-5` and `anthropic/claude-5-sonnet`, just like prior Sonnet releases had multiple ID shapes. That is covered here.

### Test Procedure

Ran TypeScript, focused lint, and targeted model/provider tests from `apps/vscode`:

```sh
npx tsc --noEmit && cd webview-ui && npx tsc --noEmit
```

```sh
npx biome lint --config-path ./biome.jsonc --no-errors-on-unmatched --files-ignore-unknown=true --diagnostic-level=error src/core/api/providers/__tests__/bedrock.test.ts src/core/api/providers/__tests__/claude-code.test.ts src/core/api/providers/__tests__/sapaicore.test.ts src/core/api/providers/bedrock.ts src/core/api/providers/sapaicore.ts src/core/api/transform/__tests__/openrouter-stream.test.ts src/core/api/transform/openrouter-stream.ts src/core/api/transform/vercel-ai-gateway-stream.ts src/core/controller/models/__tests__/refreshClineRecommendedModels.test.ts src/core/controller/models/refreshClineModels.ts src/core/controller/models/refreshOpenRouterModels.ts src/shared/api.ts src/shared/cline/onboarding.ts src/shared/cline/recommended-models.ts src/shared/utils/reasoning-support.ts src/test/e2e/fixtures/server/api.ts src/utils/__tests__/model-utils.test.ts webview-ui/src/components/chat/chat-view/components/layout/WelcomeSection.tsx webview-ui/src/components/settings/ClineModelPicker.tsx webview-ui/src/components/settings/OpenRouterModelPicker.tsx webview-ui/src/components/settings/providers/AnthropicProvider.tsx webview-ui/src/components/settings/providers/BedrockProvider.tsx webview-ui/src/components/settings/providers/ClaudeCodeProvider.tsx webview-ui/src/components/settings/providers/VertexProvider.tsx
```

```sh
npx cross-env TS_NODE_PROJECT=./tsconfig.unit-test.json mocha src/core/api/providers/__tests__/bedrock.test.ts src/core/api/providers/__tests__/claude-code.test.ts src/core/api/providers/__tests__/sapaicore.test.ts src/utils/__tests__/model-utils.test.ts src/core/controller/models/__tests__/refreshClineRecommendedModels.test.ts src/core/api/transform/__tests__/openrouter-stream.test.ts
```

The targeted mocha run completed with `1501 passing` and `4 pending`.

I also ran full `npm run lint`. It still fails on unrelated existing issues in the current branch:

- SVG parser errors in `assets/icons/cline-bot.svg`, `assets/icons/icon.svg`, and `assets/icons/sleepy-cline.svg`
- `lint/suspicious/noDuplicateTestHooks` in `src/core/hooks/__tests__/hook-factory.test.ts`
- `lint/suspicious/noExportsInTest` in `src/core/prompts/system-prompt/__tests__/integration.test.ts`

I did not change those unrelated files.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not included. This is mostly model metadata and provider wiring; UI impact is limited to model list entries and context-window/thinking controls.

### Additional Notes

This PR targets `legacy-extension` for the legacy VS Code extension release branch, not mainline SDK/provider metadata work.
