### PR TITLE
fix(agents): recover inline-XML tool invocations from text-delta streams (#9848)

### DIFF
--- a/sdk/packages/agents/src/agent-runtime.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.test.ts
@@ -1803,4 +1803,78 @@ describe("AgentRuntime", () => {
 			totalCost: 1.0,
 		});
 	});
+
+	it("recovers a tool call from inline XML markup emitted in text-delta chunks (cline#9848)", async () => {
+		// Models fronted by transports that do not relay native tool_use
+		// blocks (e.g. some OpenAI-compatible gateways) emit tool
+		// invocations as inline XML in the assistant text. The runtime
+		// must parse those into proper tool-call events and execute them.
+		const model = new ScriptedModel([
+			() => [
+				{ type: "text-delta", text: "Let me echo that. " },
+				{ type: "text-delta", text: '<invoke name="echo">' },
+				{ type: "text-delta", text: '<parameter name="text">hi</parameter>' },
+				{ type: "text-delta", text: "</invoke>" },
+				{ type: "finish", reason: "tool-calls" },
+			],
+			() => [
+				{ type: "text-delta", text: "done" },
+				{ type: "finish", reason: "stop" },
+			],
+		]);
+		const runtime = new AgentRuntime({
+			model,
+			tools: [createEchoTool()],
+		});
+
+		const result = await runtime.run("Hi");
+
+		expect(result.status).toBe("completed");
+		const toolMessage = result.messages.find((m) => m.role === "tool");
+		expect(toolMessage).toBeDefined();
+		const toolResult = toolMessage?.content.find(
+			(c) => c.type === "tool-result",
+		);
+		expect(toolResult).toMatchObject({
+			type: "tool-result",
+			toolName: "echo",
+		});
+		// The recovered tool call should not leak the XML markup into the
+		// final assistant transcript as plain text.
+		const assistantMessages = result.messages.filter(
+			(m) => m.role === "assistant",
+		);
+		const assistantText = assistantMessages
+			.flatMap((m) => m.content)
+			.filter((c) => c.type === "text")
+			.map((c) => (c as { type: "text"; text: string }).text)
+			.join("");
+		expect(assistantText).not.toContain("<invoke");
+		expect(assistantText).not.toContain("</invoke>");
+	});
+
+	it("treats malformed XML in text-delta chunks as plain text", async () => {
+		// A <invoke> tag with no `name="..."` attribute must not be turned
+		// into a tool call. The runtime should pass the markup through to
+		// the assistant message as text.
+		const model = new ScriptedModel([
+			() => [
+				{ type: "text-delta", text: "Oops " },
+				{ type: "text-delta", text: "<invoke>missing name</invoke>" },
+				{ type: "finish", reason: "stop" },
+			],
+		]);
+		const runtime = new AgentRuntime({ model });
+
+		const result = await runtime.run("Hi");
+
+		expect(result.status).toBe("completed");
+		const assistant = result.messages.find((m) => m.role === "assistant");
+		expect(assistant?.content.some((c) => c.type === "tool-call")).toBe(false);
+		const text = assistant?.content
+			.filter((c) => c.type === "text")
+			.map((c) => (c as { type: "text"; text: string }).text)
+			.join("");
+		expect(text).toContain("<invoke>");
+	});
 });

--- a/sdk/packages/agents/src/agent-runtime.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.test.ts
@@ -1877,4 +1877,48 @@ describe("AgentRuntime", () => {
 			.join("");
 		expect(text).toContain("<invoke>");
 	});
+
+	it("emits assistant-text-delta for text released by the tool-call parser flush", async () => {
+		// Regression: when the model stream ends mid-markup (last delta ends
+		// with '<inv'), the parser flushes the held-back tail as text. The
+		// flush path must fire assistant-text-delta so subscribers that
+		// accumulate text from those events see the full transcript —
+		// without it, the final characters appear in the message but were
+		// silently skipped during the stream.
+		const model = new ScriptedModel([
+			() => [
+				{ type: "text-delta", text: "Hello " },
+				{ type: "text-delta", text: "world" },
+				{ type: "text-delta", text: "<inv" },
+				{ type: "finish", reason: "stop" },
+			],
+		]);
+		const runtime = new AgentRuntime({ model });
+
+		const textDeltas: Array<{
+			text: string;
+			accumulatedText: string;
+		}> = [];
+		runtime.subscribe((event) => {
+			if (event.type === "assistant-text-delta") {
+				textDeltas.push({
+					text: event.text,
+					accumulatedText: event.accumulatedText,
+				});
+			}
+		});
+
+		const result = await runtime.run("Hi");
+
+		expect(result.status).toBe("completed");
+		// One delta per inline text piece plus one for the flushed tail.
+		expect(textDeltas.map((d) => d.text)).toEqual(["Hello ", "world", "<inv"]);
+		// Each accumulatedText includes the current piece plus everything
+		// that came before it — including the flushed tail.
+		expect(textDeltas.map((d) => d.accumulatedText)).toEqual([
+			"Hello ",
+			"Hello world",
+			"Hello world<inv",
+		]);
+	});
 });

--- a/sdk/packages/agents/src/agent-runtime.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.test.ts
@@ -2121,4 +2121,78 @@ describe("AgentRuntime", () => {
 			totalCost: 1.0,
 		});
 	});
+
+	it("recovers a tool call from inline XML markup emitted in text-delta chunks (cline#9848)", async () => {
+		// Models fronted by transports that do not relay native tool_use
+		// blocks (e.g. some OpenAI-compatible gateways) emit tool
+		// invocations as inline XML in the assistant text. The runtime
+		// must parse those into proper tool-call events and execute them.
+		const model = new ScriptedModel([
+			() => [
+				{ type: "text-delta", text: "Let me echo that. " },
+				{ type: "text-delta", text: '<invoke name="echo">' },
+				{ type: "text-delta", text: '<parameter name="text">hi</parameter>' },
+				{ type: "text-delta", text: "</invoke>" },
+				{ type: "finish", reason: "tool-calls" },
+			],
+			() => [
+				{ type: "text-delta", text: "done" },
+				{ type: "finish", reason: "stop" },
+			],
+		]);
+		const runtime = new AgentRuntime({
+			model,
+			tools: [createEchoTool()],
+		});
+
+		const result = await runtime.run("Hi");
+
+		expect(result.status).toBe("completed");
+		const toolMessage = result.messages.find((m) => m.role === "tool");
+		expect(toolMessage).toBeDefined();
+		const toolResult = toolMessage?.content.find(
+			(c) => c.type === "tool-result",
+		);
+		expect(toolResult).toMatchObject({
+			type: "tool-result",
+			toolName: "echo",
+		});
+		// The recovered tool call should not leak the XML markup into the
+		// final assistant transcript as plain text.
+		const assistantMessages = result.messages.filter(
+			(m) => m.role === "assistant",
+		);
+		const assistantText = assistantMessages
+			.flatMap((m) => m.content)
+			.filter((c) => c.type === "text")
+			.map((c) => (c as { type: "text"; text: string }).text)
+			.join("");
+		expect(assistantText).not.toContain("<invoke");
+		expect(assistantText).not.toContain("</invoke>");
+	});
+
+	it("treats malformed XML in text-delta chunks as plain text", async () => {
+		// A <invoke> tag with no `name="..."` attribute must not be turned
+		// into a tool call. The runtime should pass the markup through to
+		// the assistant message as text.
+		const model = new ScriptedModel([
+			() => [
+				{ type: "text-delta", text: "Oops " },
+				{ type: "text-delta", text: "<invoke>missing name</invoke>" },
+				{ type: "finish", reason: "stop" },
+			],
+		]);
+		const runtime = new AgentRuntime({ model });
+
+		const result = await runtime.run("Hi");
+
+		expect(result.status).toBe("completed");
+		const assistant = result.messages.find((m) => m.role === "assistant");
+		expect(assistant?.content.some((c) => c.type === "tool-call")).toBe(false);
+		const text = assistant?.content
+			.filter((c) => c.type === "text")
+			.map((c) => (c as { type: "text"; text: string }).text)
+			.join("");
+		expect(text).toContain("<invoke>");
+	});
 });

--- a/sdk/packages/agents/src/agent-runtime.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.test.ts
@@ -2195,4 +2195,48 @@ describe("AgentRuntime", () => {
 			.join("");
 		expect(text).toContain("<invoke>");
 	});
+
+	it("emits assistant-text-delta for text released by the tool-call parser flush", async () => {
+		// Regression: when the model stream ends mid-markup (last delta ends
+		// with '<inv'), the parser flushes the held-back tail as text. The
+		// flush path must fire assistant-text-delta so subscribers that
+		// accumulate text from those events see the full transcript —
+		// without it, the final characters appear in the message but were
+		// silently skipped during the stream.
+		const model = new ScriptedModel([
+			() => [
+				{ type: "text-delta", text: "Hello " },
+				{ type: "text-delta", text: "world" },
+				{ type: "text-delta", text: "<inv" },
+				{ type: "finish", reason: "stop" },
+			],
+		]);
+		const runtime = new AgentRuntime({ model });
+
+		const textDeltas: Array<{
+			text: string;
+			accumulatedText: string;
+		}> = [];
+		runtime.subscribe((event) => {
+			if (event.type === "assistant-text-delta") {
+				textDeltas.push({
+					text: event.text,
+					accumulatedText: event.accumulatedText,
+				});
+			}
+		});
+
+		const result = await runtime.run("Hi");
+
+		expect(result.status).toBe("completed");
+		// One delta per inline text piece plus one for the flushed tail.
+		expect(textDeltas.map((d) => d.text)).toEqual(["Hello ", "world", "<inv"]);
+		// Each accumulatedText includes the current piece plus everything
+		// that came before it — including the flushed tail.
+		expect(textDeltas.map((d) => d.accumulatedText)).toEqual([
+			"Hello ",
+			"Hello world",
+			"Hello world<inv",
+		]);
+	});
 });

--- a/sdk/packages/agents/src/agent-runtime.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.test.ts
@@ -20,6 +20,7 @@ import { AgentRuntime } from "./index";
 
 class ScriptedModel implements AgentModel {
 	public readonly requests: AgentModelRequest[] = [];
+	public readonly supportsInlineXmlToolCalls: boolean;
 
 	constructor(
 		private readonly steps: Array<
@@ -27,7 +28,10 @@ class ScriptedModel implements AgentModel {
 				request: AgentModelRequest,
 			) => Iterable<AgentModelEvent> | AsyncIterable<AgentModelEvent>
 		>,
-	) {}
+		supportsInlineXmlToolCalls = false,
+	) {
+		this.supportsInlineXmlToolCalls = supportsInlineXmlToolCalls;
+	}
 
 	async stream(
 		request: AgentModelRequest,
@@ -2127,19 +2131,22 @@ describe("AgentRuntime", () => {
 		// blocks (e.g. some OpenAI-compatible gateways) emit tool
 		// invocations as inline XML in the assistant text. The runtime
 		// must parse those into proper tool-call events and execute them.
-		const model = new ScriptedModel([
-			() => [
-				{ type: "text-delta", text: "Let me echo that. " },
-				{ type: "text-delta", text: '<invoke name="echo">' },
-				{ type: "text-delta", text: '<parameter name="text">hi</parameter>' },
-				{ type: "text-delta", text: "</invoke>" },
-				{ type: "finish", reason: "tool-calls" },
+		const model = new ScriptedModel(
+			[
+				() => [
+					{ type: "text-delta", text: "Let me echo that. " },
+					{ type: "text-delta", text: '<invoke name="echo">' },
+					{ type: "text-delta", text: '<parameter name="text">hi</parameter>' },
+					{ type: "text-delta", text: "</invoke>" },
+					{ type: "finish", reason: "tool-calls" },
+				],
+				() => [
+					{ type: "text-delta", text: "done" },
+					{ type: "finish", reason: "stop" },
+				],
 			],
-			() => [
-				{ type: "text-delta", text: "done" },
-				{ type: "finish", reason: "stop" },
-			],
-		]);
+			true,
+		);
 		const runtime = new AgentRuntime({
 			model,
 			tools: [createEchoTool()],
@@ -2196,6 +2203,33 @@ describe("AgentRuntime", () => {
 		expect(text).toContain("<invoke>");
 	});
 
+	it("preserves complete inline XML as text when recovery is disabled", async () => {
+		const model = new ScriptedModel([
+			() => [
+				{
+					type: "text-delta",
+					text: '<invoke name="echo"><parameter name="text">hi</parameter></invoke>',
+				},
+				{ type: "finish", reason: "stop" },
+			],
+		]);
+		const runtime = new AgentRuntime({ model, tools: [createEchoTool()] });
+
+		const result = await runtime.run("Hi");
+
+		expect(result.status).toBe("completed");
+		expect(result.messages.some((message) => message.role === "tool")).toBe(
+			false,
+		);
+		const text = result.messages
+			.filter((message) => message.role === "assistant")
+			.flatMap((message) => message.content)
+			.filter((content) => content.type === "text")
+			.map((content) => (content as { type: "text"; text: string }).text)
+			.join("");
+		expect(text).toContain('<invoke name="echo">');
+	});
+
 	it("emits assistant-text-delta for text released by the tool-call parser flush", async () => {
 		// Regression: when the model stream ends mid-markup (last delta ends
 		// with '<inv'), the parser flushes the held-back tail as text. The
@@ -2203,14 +2237,17 @@ describe("AgentRuntime", () => {
 		// accumulate text from those events see the full transcript —
 		// without it, the final characters appear in the message but were
 		// silently skipped during the stream.
-		const model = new ScriptedModel([
-			() => [
-				{ type: "text-delta", text: "Hello " },
-				{ type: "text-delta", text: "world" },
-				{ type: "text-delta", text: "<inv" },
-				{ type: "finish", reason: "stop" },
+		const model = new ScriptedModel(
+			[
+				() => [
+					{ type: "text-delta", text: "Hello " },
+					{ type: "text-delta", text: "world" },
+					{ type: "text-delta", text: "<inv" },
+					{ type: "finish", reason: "stop" },
+				],
 			],
-		]);
+			true,
+		);
 		const runtime = new AgentRuntime({ model });
 
 		const textDeltas: Array<{
@@ -2238,5 +2275,157 @@ describe("AgentRuntime", () => {
 			"Hello world",
 			"Hello world<inv",
 		]);
+	});
+
+	it("P0: fails closed when the model's capability is undefined (no parser)", async () => {
+		// f08: the capability must default to off and never auto-derive from
+		// request data. An adapter that omits the field entirely must not get
+		// the parser enabled.
+		const model = new (class implements AgentModel {
+			// intentionally no `supportsInlineXmlToolCalls` field
+			async *stream(): AsyncIterable<AgentModelEvent> {
+				yield {
+					type: "text-delta",
+					text: '<invoke name="echo"><parameter name="text">hi</parameter></invoke>',
+				};
+				yield { type: "finish", reason: "stop" };
+			}
+		})();
+		const runtime = new AgentRuntime({ model, tools: [createEchoTool()] });
+
+		const result = await runtime.run("Hi");
+
+		expect(result.status).toBe("completed");
+		expect(result.messages.some((m) => m.role === "tool")).toBe(false);
+		const assistant = result.messages.find((m) => m.role === "assistant");
+		const text = assistant?.content
+			.filter((c) => c.type === "text")
+			.map((c) => (c as { type: "text"; text: string }).text)
+			.join("");
+		expect(text).toContain('<invoke name="echo">');
+	});
+
+	it("P1: native tool-call-delta disables inline-XML parser for the rest of the stream", async () => {
+		// f13: when the model emits a native tool-call-delta, the parser must
+		// be dropped for the remainder of the stream — otherwise a buffered
+		// partial `<inv` markup in the parser's buffer would be released as
+		// text after the native call, and a subsequent `<invoke>...</invoke>`
+		// from inline XML would create a duplicate assembly keyed differently
+		// than the native call.
+		const model = new ScriptedModel(
+			[
+				() => [
+					{ type: "text-delta", text: "Here " },
+					{
+						type: "tool-call-delta",
+						toolCallId: "c-native",
+						toolName: "echo",
+						input: { text: "native" },
+					},
+					{
+						type: "text-delta",
+						text: ' and <invoke name="echo"><parameter name="text">recovered</parameter></invoke>',
+					},
+					{ type: "finish", reason: "tool-calls" },
+				],
+				() => [
+					{ type: "text-delta", text: "done" },
+					{ type: "finish", reason: "stop" },
+				],
+			],
+			true,
+		);
+		const runtime = new AgentRuntime({ model, tools: [createEchoTool()] });
+
+		const result = await runtime.run("Hi");
+
+		expect(result.status).toBe("completed");
+		expect(result.lastError).toBeUndefined();
+		// Exactly one tool call: the native one. The inline-XML recovery must
+		// not have produced a duplicate assembly after the native delta.
+		const assistant = result.messages.find((m) => m.role === "assistant");
+		const toolCalls =
+			assistant?.content.filter((c) => c.type === "tool-call") ?? [];
+		expect(toolCalls).toHaveLength(1);
+		const text = assistant?.content
+			.filter((c) => c.type === "text")
+			.map((c) => (c as { type: "text"; text: string }).text)
+			.join("");
+		expect(text).toContain('<invoke name="echo">');
+	});
+
+	it("P1: native tool-call-delta releases any buffered partial markup as text", async () => {
+		// f13: the parser held `<inv` in its buffer when the native delta
+		// arrived. After dropping the parser, the held `<inv` must surface
+		// as an `assistant-text-delta` so subscribers see the full transcript.
+		const model = new ScriptedModel(
+			[
+				() => [
+					{ type: "text-delta", text: "Before <inv" },
+					{
+						type: "tool-call-delta",
+						toolCallId: "c-native",
+						toolName: "echo",
+						input: { text: "native" },
+					},
+					{ type: "finish", reason: "tool-calls" },
+				],
+				() => [
+					{ type: "text-delta", text: "done" },
+					{ type: "finish", reason: "stop" },
+				],
+			],
+			true,
+		);
+		const runtime = new AgentRuntime({ model, tools: [createEchoTool()] });
+
+		const textDeltas: string[] = [];
+		runtime.subscribe((event) => {
+			if (event.type === "assistant-text-delta") {
+				textDeltas.push(event.text);
+			}
+		});
+
+		const result = await runtime.run("Hi");
+
+		expect(result.status).toBe("completed");
+		expect(result.lastError).toBeUndefined();
+		// The full transcript (including the flushed tail of `<inv`) must
+		// reach the subscriber.
+		expect(textDeltas.join("")).toContain("<inv");
+	});
+
+	it("P0: split-delta path is disabled when capability is false (no recovery)", async () => {
+		// f11: when the adapter sets `supportsInlineXmlToolCalls` to false
+		// explicitly, the parser is never instantiated and inline-XML
+		// markup in the text stream is treated as plain prose — the runtime
+		// must not execute any tool call derived from it.
+		const model = new ScriptedModel(
+			[
+				() => [
+					// split-delta feed: complete `<invoke>` is split across two
+					// text-delta events. With the parser disabled, the runtime
+					// never reconciles the markup into a tool call.
+					{
+						type: "text-delta",
+						text: '<invoke name="echo"><parameter name="text">split</parameter></invoke>',
+					},
+					{ type: "finish", reason: "stop" },
+				],
+			],
+			false,
+		);
+		const runtime = new AgentRuntime({ model, tools: [createEchoTool()] });
+
+		const result = await runtime.run("Hi");
+
+		expect(result.status).toBe("completed");
+		expect(result.messages.some((m) => m.role === "tool")).toBe(false);
+		const assistant = result.messages.find((m) => m.role === "assistant");
+		const text = assistant?.content
+			.filter((c) => c.type === "text")
+			.map((c) => (c as { type: "text"; text: string }).text)
+			.join("");
+		expect(text).toContain('<invoke name="echo">');
 	});
 });

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -1004,6 +1004,13 @@ export class AgentRuntime {
 							part: { type: "text", text: piece.text },
 						});
 					}
+					await this.emit({
+						type: "assistant-text-delta",
+						snapshot: this.snapshot(),
+						iteration: this.state.iteration,
+						text: piece.text,
+						accumulatedText,
+					});
 				} else {
 					const key = piece.toolCallId;
 					let assembly = toolAssemblies.get(key);

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -33,6 +33,7 @@ import {
 	trimNonEmpty,
 } from "@cline/shared";
 import { nanoid } from "nanoid";
+import { TextDeltaToolCallParser } from "./text-delta-tool-call-parser";
 
 // Local `createUID` helper. The clinee source imports this from
 // `@cline/shared` (see `packages/shared/dist/identifier.ts`), but
@@ -411,6 +412,10 @@ export class AgentRuntime {
 	};
 	private initialization?: Promise<void>;
 	private abortController?: AbortController;
+	// Per-stream parser that splits text-delta chunks into either prose or
+	// synthetic tool-call events when the model emits inline XML like
+	// `<invoke name="...">...</invoke>` (see cline/cline#9848).
+	private toolCallParser: TextDeltaToolCallParser | undefined;
 
 	constructor(config: AgentRuntimeConfig) {
 		const resolved = resolveRuntimeConfig(config);
@@ -849,28 +854,57 @@ export class AgentRuntime {
 		let finishReason: AgentModelFinishReason = "stop";
 		let accumulatedText = "";
 		let accumulatedReasoning = "";
+		this.toolCallParser = new TextDeltaToolCallParser(() => createUID("tool"));
 
 		for await (const event of stream) {
 			this.throwIfAborted();
 			switch (event.type) {
 				case "text-delta": {
-					accumulatedText += event.text;
-					const last = sequence.at(-1);
-					if (last?.type === "part" && last.part.type === "text") {
-						last.part.text += event.text;
-					} else {
-						sequence.push({
-							type: "part",
-							part: { type: "text", text: event.text },
-						});
+					const parsed = this.toolCallParser.consume(event.text);
+					for (const piece of parsed) {
+						if (piece.kind === "text") {
+							accumulatedText += piece.text;
+							const last = sequence.at(-1);
+							if (last?.type === "part" && last.part.type === "text") {
+								last.part.text += piece.text;
+							} else {
+								sequence.push({
+									type: "part",
+									part: { type: "text", text: piece.text },
+								});
+							}
+							await this.emit({
+								type: "assistant-text-delta",
+								snapshot: this.snapshot(),
+								iteration: this.state.iteration,
+								text: piece.text,
+								accumulatedText,
+							});
+						} else {
+							// Recovered from inline XML. Synthesize a
+							// tool-call-delta that flows through the existing
+							// assembly + sequence machinery below.
+							const key = piece.toolCallId;
+							let assembly = toolAssemblies.get(key);
+							if (!assembly) {
+								assembly = {
+									toolCallId: piece.toolCallId,
+									toolName: piece.toolName,
+									inputText: "",
+									inputValue: piece.input,
+								};
+								toolAssemblies.set(key, assembly);
+								sequence.push({ type: "tool", key });
+							} else {
+								if (piece.toolName) {
+									assembly.toolName = piece.toolName;
+								}
+								if (piece.input && Object.keys(piece.input).length > 0) {
+									assembly.inputValue = piece.input;
+								}
+							}
+						}
 					}
-					await this.emit({
-						type: "assistant-text-delta",
-						snapshot: this.snapshot(),
-						iteration: this.state.iteration,
-						text: event.text,
-						accumulatedText,
-					});
 					break;
 				}
 				case "reasoning-delta": {
@@ -952,6 +986,40 @@ export class AgentRuntime {
 					break;
 				}
 			}
+		}
+
+		// Flush any remaining buffered text in the XML tool-call parser.
+		// Inlined XML blocks that never produced a complete
+		// <invoke>...</invoke> become ordinary text here.
+		if (this.toolCallParser) {
+			for (const piece of this.toolCallParser.flush()) {
+				if (piece.kind === "text") {
+					accumulatedText += piece.text;
+					const last = sequence.at(-1);
+					if (last?.type === "part" && last.part.type === "text") {
+						last.part.text += piece.text;
+					} else {
+						sequence.push({
+							type: "part",
+							part: { type: "text", text: piece.text },
+						});
+					}
+				} else {
+					const key = piece.toolCallId;
+					let assembly = toolAssemblies.get(key);
+					if (!assembly) {
+						assembly = {
+							toolCallId: piece.toolCallId,
+							toolName: piece.toolName,
+							inputText: "",
+							inputValue: piece.input,
+						};
+						toolAssemblies.set(key, assembly);
+						sequence.push({ type: "tool", key });
+					}
+				}
+			}
+			this.toolCallParser = undefined;
 		}
 
 		for (const item of sequence) {

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -41,6 +41,7 @@ import {
 	trimNonEmpty,
 } from "@cline/shared";
 import { nanoid } from "nanoid";
+import { TextDeltaToolCallParser } from "./text-delta-tool-call-parser";
 
 const MAX_TOKENS_INCOMPLETE_TURN_MESSAGE =
 	"Model reached the maximum output token limit before completing the turn";
@@ -424,6 +425,10 @@ export class AgentRuntime {
 	private abortController?: AbortController;
 	private readonly telemetryProviderId?: string;
 	private readonly telemetryModelId?: string;
+	// Per-stream parser that splits text-delta chunks into either prose or
+	// synthetic tool-call events when the model emits inline XML like
+	// `<invoke name="...">...</invoke>` (see cline/cline#9848).
+	private toolCallParser: TextDeltaToolCallParser | undefined;
 
 	constructor(config: AgentRuntimeConfig) {
 		this.telemetryProviderId =
@@ -909,28 +914,57 @@ export class AgentRuntime {
 		let finishReason: AgentModelFinishReason = "stop";
 		let accumulatedText = "";
 		let accumulatedReasoning = "";
+		this.toolCallParser = new TextDeltaToolCallParser(() => createUID("tool"));
 
 		for await (const event of stream) {
 			this.throwIfAborted();
 			switch (event.type) {
 				case "text-delta": {
-					accumulatedText += event.text;
-					const last = sequence.at(-1);
-					if (last?.type === "part" && last.part.type === "text") {
-						last.part.text += event.text;
-					} else {
-						sequence.push({
-							type: "part",
-							part: { type: "text", text: event.text },
-						});
+					const parsed = this.toolCallParser.consume(event.text);
+					for (const piece of parsed) {
+						if (piece.kind === "text") {
+							accumulatedText += piece.text;
+							const last = sequence.at(-1);
+							if (last?.type === "part" && last.part.type === "text") {
+								last.part.text += piece.text;
+							} else {
+								sequence.push({
+									type: "part",
+									part: { type: "text", text: piece.text },
+								});
+							}
+							await this.emit({
+								type: "assistant-text-delta",
+								snapshot: this.snapshot(),
+								iteration: this.state.iteration,
+								text: piece.text,
+								accumulatedText,
+							});
+						} else {
+							// Recovered from inline XML. Synthesize a
+							// tool-call-delta that flows through the existing
+							// assembly + sequence machinery below.
+							const key = piece.toolCallId;
+							let assembly = toolAssemblies.get(key);
+							if (!assembly) {
+								assembly = {
+									toolCallId: piece.toolCallId,
+									toolName: piece.toolName,
+									inputText: "",
+									inputValue: piece.input,
+								};
+								toolAssemblies.set(key, assembly);
+								sequence.push({ type: "tool", key });
+							} else {
+								if (piece.toolName) {
+									assembly.toolName = piece.toolName;
+								}
+								if (piece.input && Object.keys(piece.input).length > 0) {
+									assembly.inputValue = piece.input;
+								}
+							}
+						}
 					}
-					await this.emit({
-						type: "assistant-text-delta",
-						snapshot: this.snapshot(),
-						iteration: this.state.iteration,
-						text: event.text,
-						accumulatedText,
-					});
 					break;
 				}
 				case "reasoning-delta": {
@@ -1012,6 +1046,40 @@ export class AgentRuntime {
 					break;
 				}
 			}
+		}
+
+		// Flush any remaining buffered text in the XML tool-call parser.
+		// Inlined XML blocks that never produced a complete
+		// <invoke>...</invoke> become ordinary text here.
+		if (this.toolCallParser) {
+			for (const piece of this.toolCallParser.flush()) {
+				if (piece.kind === "text") {
+					accumulatedText += piece.text;
+					const last = sequence.at(-1);
+					if (last?.type === "part" && last.part.type === "text") {
+						last.part.text += piece.text;
+					} else {
+						sequence.push({
+							type: "part",
+							part: { type: "text", text: piece.text },
+						});
+					}
+				} else {
+					const key = piece.toolCallId;
+					let assembly = toolAssemblies.get(key);
+					if (!assembly) {
+						assembly = {
+							toolCallId: piece.toolCallId,
+							toolName: piece.toolName,
+							inputText: "",
+							inputValue: piece.input,
+						};
+						toolAssemblies.set(key, assembly);
+						sequence.push({ type: "tool", key });
+					}
+				}
+			}
+			this.toolCallParser = undefined;
 		}
 
 		for (const item of sequence) {

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -247,6 +247,73 @@ class ControlledStopError extends Error {
 	}
 }
 
+type AssistantTextPart = { type: "text"; text: string };
+type SequenceItem = (
+	| { type: "tool"; key: string }
+	| { type: "part"; part: AgentMessagePart }
+)[];
+
+/**
+ * Append `text` to the trailing assistant text part in `sequence`, or
+ * push a new text part if the tail is not a text part. The `accumulate`
+ * callback runs with the appended text so the caller can update its own
+ * running total.
+ */
+function appendAssistantTextPart(
+	text: string,
+	sequence: SequenceItem,
+	accumulate: (text: string) => void,
+): void {
+	accumulate(text);
+	const last = sequence.at(-1);
+	if (last?.type === "part" && last.part.type === "text") {
+		(last.part as AssistantTextPart).text += text;
+		return;
+	}
+	sequence.push({
+		type: "part",
+		part: { type: "text", text },
+	});
+}
+
+/**
+ * Register a tool-call recovered from inline-XML markup. Mirrors the
+ * native tool-call-delta behavior: create-or-update the PendingToolAssembly
+ * keyed by `piece.toolCallId`, push a sequence entry if new. The runtime
+ * keeps the assembly as a `tool` sequence entry until the post-stream
+ * drain converts it into a content part.
+ */
+function registerRecoveredToolAssembly(
+	piece: {
+		kind: "tool-call";
+		toolCallId: string;
+		toolName: string;
+		input: Record<string, unknown>;
+	},
+	toolAssemblies: Map<string, PendingToolAssembly>,
+	sequence: SequenceItem,
+): void {
+	const key = piece.toolCallId;
+	let assembly = toolAssemblies.get(key);
+	if (!assembly) {
+		assembly = {
+			toolCallId: piece.toolCallId,
+			toolName: piece.toolName,
+			inputText: "",
+			inputValue: piece.input,
+		};
+		toolAssemblies.set(key, assembly);
+		sequence.push({ type: "tool", key });
+		return;
+	}
+	if (piece.toolName) {
+		assembly.toolName = piece.toolName;
+	}
+	if (piece.input && Object.keys(piece.input).length > 0) {
+		assembly.inputValue = piece.input;
+	}
+}
+
 export class AgentRuntimeAbortError extends Error {
 	readonly reason?: unknown;
 
@@ -425,10 +492,6 @@ export class AgentRuntime {
 	private abortController?: AbortController;
 	private readonly telemetryProviderId?: string;
 	private readonly telemetryModelId?: string;
-	// Per-stream parser that splits text-delta chunks into either prose or
-	// synthetic tool-call events when the model emits inline XML like
-	// `<invoke name="...">...</invoke>` (see cline/cline#9848).
-	private toolCallParser: TextDeltaToolCallParser | undefined;
 
 	constructor(config: AgentRuntimeConfig) {
 		this.telemetryProviderId =
@@ -914,25 +977,30 @@ export class AgentRuntime {
 		let finishReason: AgentModelFinishReason = "stop";
 		let accumulatedText = "";
 		let accumulatedReasoning = "";
-		this.toolCallParser = new TextDeltaToolCallParser(() => createUID("tool"));
+		// Inline-XML recovery is enabled only when the model explicitly opts in.
+		// Once any native tool-call-delta is observed in the current stream, we
+		// suppress the parser for the remainder of the stream — otherwise the
+		// parser and the native branch would emit two separate PendingToolAssembly
+		// entries for the same logical tool call (parser keys on createUID,
+		// native keys on event.toolCallId), both of which would execute.
+		const inlineXmlEnabled =
+			this.config.model.supportsInlineXmlToolCalls === true;
+		let toolCallParser: TextDeltaToolCallParser | undefined = inlineXmlEnabled
+			? new TextDeltaToolCallParser(() => createUID("tool"))
+			: undefined;
 
 		for await (const event of stream) {
 			this.throwIfAborted();
 			switch (event.type) {
 				case "text-delta": {
-					const parsed = this.toolCallParser.consume(event.text);
+					const parsed = toolCallParser
+						? toolCallParser.consume(event.text)
+						: [{ kind: "text" as const, text: event.text }];
 					for (const piece of parsed) {
 						if (piece.kind === "text") {
-							accumulatedText += piece.text;
-							const last = sequence.at(-1);
-							if (last?.type === "part" && last.part.type === "text") {
-								last.part.text += piece.text;
-							} else {
-								sequence.push({
-									type: "part",
-									part: { type: "text", text: piece.text },
-								});
-							}
+							appendAssistantTextPart(piece.text, sequence, (text) => {
+								accumulatedText += text;
+							});
 							await this.emit({
 								type: "assistant-text-delta",
 								snapshot: this.snapshot(),
@@ -941,28 +1009,7 @@ export class AgentRuntime {
 								accumulatedText,
 							});
 						} else {
-							// Recovered from inline XML. Synthesize a
-							// tool-call-delta that flows through the existing
-							// assembly + sequence machinery below.
-							const key = piece.toolCallId;
-							let assembly = toolAssemblies.get(key);
-							if (!assembly) {
-								assembly = {
-									toolCallId: piece.toolCallId,
-									toolName: piece.toolName,
-									inputText: "",
-									inputValue: piece.input,
-								};
-								toolAssemblies.set(key, assembly);
-								sequence.push({ type: "tool", key });
-							} else {
-								if (piece.toolName) {
-									assembly.toolName = piece.toolName;
-								}
-								if (piece.input && Object.keys(piece.input).length > 0) {
-									assembly.inputValue = piece.input;
-								}
-							}
+							registerRecoveredToolAssembly(piece, toolAssemblies, sequence);
 						}
 					}
 					break;
@@ -997,6 +1044,32 @@ export class AgentRuntime {
 					break;
 				}
 				case "tool-call-delta": {
+					// Native tool-call path: suppress the inline-XML parser for the
+					// remainder of this stream. The parser is dropped (not just
+					// disabled) so any buffered partial markup — e.g. `<inv` that
+					// the parser was holding — is released as ordinary text below
+					// rather than stranded in the buffer. The parser is local to
+					// this stream iteration; on the next iteration it is built
+					// fresh from the model's capability flag.
+					if (toolCallParser) {
+						const released = toolCallParser.flush();
+						toolCallParser = undefined;
+						for (const piece of released) {
+							// parser.flush() only emits kind:"text" events; narrow
+							// explicitly so the helper signature is satisfied.
+							if (piece.kind !== "text") continue;
+							appendAssistantTextPart(piece.text, sequence, (text) => {
+								accumulatedText += text;
+							});
+							await this.emit({
+								type: "assistant-text-delta",
+								snapshot: this.snapshot(),
+								iteration: this.state.iteration,
+								text: piece.text,
+								accumulatedText,
+							});
+						}
+					}
 					const key =
 						event.toolCallId ?? `tool_${event.index ?? nextToolIndex}`;
 					if (event.index == null && event.toolCallId == null) {
@@ -1051,42 +1124,24 @@ export class AgentRuntime {
 		// Flush any remaining buffered text in the XML tool-call parser.
 		// Inlined XML blocks that never produced a complete
 		// <invoke>...</invoke> become ordinary text here.
-		if (this.toolCallParser) {
-			for (const piece of this.toolCallParser.flush()) {
-				if (piece.kind === "text") {
-					accumulatedText += piece.text;
-					const last = sequence.at(-1);
-					if (last?.type === "part" && last.part.type === "text") {
-						last.part.text += piece.text;
-					} else {
-						sequence.push({
-							type: "part",
-							part: { type: "text", text: piece.text },
-						});
-					}
-					await this.emit({
-						type: "assistant-text-delta",
-						snapshot: this.snapshot(),
-						iteration: this.state.iteration,
-						text: piece.text,
-						accumulatedText,
-					});
-				} else {
-					const key = piece.toolCallId;
-					let assembly = toolAssemblies.get(key);
-					if (!assembly) {
-						assembly = {
-							toolCallId: piece.toolCallId,
-							toolName: piece.toolName,
-							inputText: "",
-							inputValue: piece.input,
-						};
-						toolAssemblies.set(key, assembly);
-						sequence.push({ type: "tool", key });
-					}
-				}
+		if (toolCallParser) {
+			const released = toolCallParser.flush();
+			toolCallParser = undefined;
+			for (const piece of released) {
+				// parser.flush() only emits kind:"text" events; narrow
+				// explicitly so the helper signature is satisfied.
+				if (piece.kind !== "text") continue;
+				appendAssistantTextPart(piece.text, sequence, (text) => {
+					accumulatedText += text;
+				});
+				await this.emit({
+					type: "assistant-text-delta",
+					snapshot: this.snapshot(),
+					iteration: this.state.iteration,
+					text: piece.text,
+					accumulatedText,
+				});
 			}
-			this.toolCallParser = undefined;
 		}
 
 		for (const item of sequence) {

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -1064,6 +1064,13 @@ export class AgentRuntime {
 							part: { type: "text", text: piece.text },
 						});
 					}
+					await this.emit({
+						type: "assistant-text-delta",
+						snapshot: this.snapshot(),
+						iteration: this.state.iteration,
+						text: piece.text,
+						accumulatedText,
+					});
 				} else {
 					const key = piece.toolCallId;
 					let assembly = toolAssemblies.get(key);

--- a/sdk/packages/agents/src/text-delta-tool-call-parser.test.ts
+++ b/sdk/packages/agents/src/text-delta-tool-call-parser.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from "vitest";
+import { TextDeltaToolCallParser } from "./text-delta-tool-call-parser";
+
+function makeUid(prefix = "tool"): () => string {
+	let n = 0;
+	return () => `${prefix}_${++n}`;
+}
+
+describe("TextDeltaToolCallParser", () => {
+	it("passes plain prose straight through as text", () => {
+		const parser = new TextDeltaToolCallParser(makeUid());
+
+		const events = parser.consume("I'll read the file and check the contents.");
+
+		expect(events).toEqual([
+			{ kind: "text", text: "I'll read the file and check the contents." },
+		]);
+	});
+
+	it("parses an <invoke> block that arrives in a single delta", () => {
+		const parser = new TextDeltaToolCallParser(makeUid());
+
+		const events = parser.consume(
+			'<invoke name="read_file"><parameter name="path">/tmp/a.txt</parameter></invoke>',
+		);
+
+		expect(events).toEqual([
+			{
+				kind: "tool-call",
+				toolCallId: "tool_1",
+				toolName: "read_file",
+				input: { path: "/tmp/a.txt" },
+			},
+		]);
+	});
+
+	it("emits prose before and after an <invoke> block", () => {
+		const parser = new TextDeltaToolCallParser(makeUid());
+
+		const events = parser.consume(
+			'Let me check that. <invoke name="list_files"><parameter name="path">.</parameter></invoke> Done.',
+		);
+
+		expect(events).toEqual([
+			{ kind: "text", text: "Let me check that. " },
+			{
+				kind: "tool-call",
+				toolCallId: "tool_1",
+				toolName: "list_files",
+				input: { path: "." },
+			},
+			{ kind: "text", text: " Done." },
+		]);
+	});
+
+	it("parses multiple <invoke> blocks in sequence", () => {
+		const parser = new TextDeltaToolCallParser(makeUid());
+
+		const events = parser.consume(
+			'<invoke name="a"><parameter name="x">1</parameter></invoke>' +
+				'<invoke name="b"><parameter name="y">2</parameter></invoke>',
+		);
+
+		expect(events).toEqual([
+			{
+				kind: "tool-call",
+				toolCallId: "tool_1",
+				toolName: "a",
+				input: { x: "1" },
+			},
+			{
+				kind: "tool-call",
+				toolCallId: "tool_2",
+				toolName: "b",
+				input: { y: "2" },
+			},
+		]);
+	});
+
+	it("reassembles an <invoke> block split across multiple deltas", () => {
+		const parser = new TextDeltaToolCallParser(makeUid());
+
+		const deltas = [
+			'<invoke name="rea',
+			"d_file",
+			'"><parameter name="pat',
+			'h">/tmp/a.txt</parameter>',
+			"</invoke>",
+		];
+
+		const events = deltas.flatMap((d) => parser.consume(d));
+
+		expect(events).toEqual([
+			{
+				kind: "tool-call",
+				toolCallId: "tool_1",
+				toolName: "read_file",
+				input: { path: "/tmp/a.txt" },
+			},
+		]);
+	});
+
+	it("buffers a partial opening tag and emits it as text once flushed", () => {
+		const parser = new TextDeltaToolCallParser(makeUid());
+
+		const events = parser.consume("Hello <inv");
+		// "Hello " has no '<' anywhere in its tail, so it's safe to emit.
+		// "<inv" stays buffered because it could be the start of an
+		// <invoke> opening tag that has not finished arriving.
+		expect(events).toEqual([{ kind: "text", text: "Hello " }]);
+
+		const flushed = parser.flush();
+		expect(flushed).toEqual([{ kind: "text", text: "<inv" }]);
+	});
+
+	it("passes malformed XML through as text without throwing", () => {
+		const parser = new TextDeltaToolCallParser(makeUid());
+
+		const consumed = parser.consume("<invoke>nope no name attribute</invoke>");
+		const flushed = parser.flush();
+
+		expect([...consumed, ...flushed]).toEqual([
+			{ kind: "text", text: "<invoke>" },
+			{ kind: "text", text: "nope no name attribute" },
+			{ kind: "text", text: "</invoke>" },
+		]);
+	});
+
+	it("emits prose interleaved with tool calls across streamed deltas", () => {
+		const parser = new TextDeltaToolCallParser(makeUid());
+
+		const deltas = [
+			"Looking at ",
+			"the ",
+			"directory. ",
+			'<invoke name="ls">',
+			'<parameter name="p">.</parameter>',
+			"</invoke>",
+			" Got 3 files.",
+		];
+
+		const events: Array<
+			| { kind: "text"; text: string }
+			| {
+					kind: "tool-call";
+					toolCallId: string;
+					toolName: string;
+					input: Record<string, unknown>;
+			  }
+		> = [];
+		for (const d of deltas) {
+			events.push(...parser.consume(d));
+		}
+		events.push(...parser.flush());
+
+		// After flush, the prose collapses into a single run with a single
+		// tool call embedded in it.
+		expect(events).toEqual([
+			{ kind: "text", text: "Looking at " },
+			{ kind: "text", text: "the " },
+			{ kind: "text", text: "directory. " },
+			{
+				kind: "tool-call",
+				toolCallId: "tool_1",
+				toolName: "ls",
+				input: { p: "." },
+			},
+			{ kind: "text", text: " Got 3 files." },
+		]);
+	});
+
+	it("treats JSON-like text with curly braces as plain text", () => {
+		// Regression guard: the parser must not accidentally consume JSON.
+		const parser = new TextDeltaToolCallParser(makeUid());
+
+		const events = parser.consume('{"key": "value", "items": [1, 2, 3]}');
+
+		expect(events).toEqual([
+			{ kind: "text", text: '{"key": "value", "items": [1, 2, 3]}' },
+		]);
+	});
+
+	it("handles parameter values containing angle brackets", () => {
+		const parser = new TextDeltaToolCallParser(makeUid());
+
+		// The parameter body can contain raw '<' and '>' — the regex uses
+		// [\s\S]*? (any character) and only stops at the explicit
+		// </parameter> closer. HTML entity decoding is not the parser's job.
+		const events = parser.consume(
+			'<invoke name="run"><parameter name="code">if (x < 10) { y > 0 }</parameter></invoke>',
+		);
+
+		expect(events).toEqual([
+			{
+				kind: "tool-call",
+				toolCallId: "tool_1",
+				toolName: "run",
+				input: { code: "if (x < 10) { y > 0 }" },
+			},
+		]);
+	});
+
+	it("skips parameters with no name attribute and keeps the rest", () => {
+		const parser = new TextDeltaToolCallParser(makeUid());
+
+		const events = parser.consume(
+			'<invoke name="x"><parameter>orphan</parameter><parameter name="k">v</parameter></invoke>',
+		);
+
+		expect(events).toEqual([
+			{
+				kind: "tool-call",
+				toolCallId: "tool_1",
+				toolName: "x",
+				input: { k: "v" },
+			},
+		]);
+	});
+
+	it("caps buffer size and flushes everything as text when exceeded", () => {
+		const parser = new TextDeltaToolCallParser(makeUid());
+
+		// 64 KiB buffer limit. Feed a single 128 KiB chunk with no <invoke>.
+		const huge = "x".repeat(128 * 1024);
+		const events = parser.consume(huge);
+
+		expect(events).toHaveLength(1);
+		expect(events[0].kind).toBe("text");
+		if (events[0].kind === "text") {
+			expect(events[0].text.length).toBeGreaterThanOrEqual(128 * 1024);
+		}
+	});
+
+	it("flush returns empty when there is no buffered text", () => {
+		const parser = new TextDeltaToolCallParser(makeUid());
+
+		expect(parser.flush()).toEqual([]);
+	});
+});

--- a/sdk/packages/agents/src/text-delta-tool-call-parser.test.ts
+++ b/sdk/packages/agents/src/text-delta-tool-call-parser.test.ts
@@ -273,6 +273,48 @@ describe("TextDeltaToolCallParser", () => {
 		]);
 	});
 
+	it("treats </parameter> inside a parameter body as content, not a close tag", () => {
+		// Regression (Greptile follow-up): a parameter value that documents
+		// the very format we parse must not be mistaken for the parameter's
+		// closer. The outer <invoke>...</invoke> scan was already correct
+		// (see findCloseTag); parseParameters must mirror that at the
+		// parameter layer.
+		const parser = new TextDeltaToolCallParser(makeUid());
+
+		const events = parser.consume(
+			'<invoke name="write_file"><parameter name="content">has </parameter> here</parameter></invoke>',
+		);
+
+		expect(events).toEqual([
+			{
+				kind: "tool-call",
+				toolCallId: "tool_1",
+				toolName: "write_file",
+				input: { content: "has </parameter> here" },
+			},
+		]);
+	});
+
+	it("handles </parameter> embedded in a later parameter of a multi-parameter block", () => {
+		// Symmetric to the </invoke>-embedded test above: an earlier
+		// parameter closes cleanly, then a later parameter contains the
+		// literal </parameter> substring and must not truncate.
+		const parser = new TextDeltaToolCallParser(makeUid());
+
+		const events = parser.consume(
+			'<invoke name="a"><parameter name="x">safe</parameter><parameter name="y">has </parameter> here</parameter></invoke>',
+		);
+
+		expect(events).toEqual([
+			{
+				kind: "tool-call",
+				toolCallId: "tool_1",
+				toolName: "a",
+				input: { x: "safe", y: "has </parameter> here" },
+			},
+		]);
+	});
+
 	it("handles a self-closing <parameter> tag", () => {
 		const parser = new TextDeltaToolCallParser(makeUid());
 

--- a/sdk/packages/agents/src/text-delta-tool-call-parser.test.ts
+++ b/sdk/packages/agents/src/text-delta-tool-call-parser.test.ts
@@ -236,4 +236,57 @@ describe("TextDeltaToolCallParser", () => {
 
 		expect(parser.flush()).toEqual([]);
 	});
+
+	it("treats </invoke> inside a parameter body as content, not a close tag", () => {
+		// Regression: a parameter value that documents the very format we
+		// parse must not be mistaken for the block's closing tag.
+		const parser = new TextDeltaToolCallParser(makeUid());
+
+		const events = parser.consume(
+			'<invoke name="write_file"><parameter name="content">end: </invoke></parameter></invoke>',
+		);
+
+		expect(events).toEqual([
+			{
+				kind: "tool-call",
+				toolCallId: "tool_1",
+				toolName: "write_file",
+				input: { content: "end: </invoke>" },
+			},
+		]);
+	});
+
+	it("handles </invoke> embedded in a later parameter of a multi-parameter block", () => {
+		const parser = new TextDeltaToolCallParser(makeUid());
+
+		const events = parser.consume(
+			'<invoke name="a"><parameter name="x">safe</parameter><parameter name="y">has </invoke> here</parameter></invoke>',
+		);
+
+		expect(events).toEqual([
+			{
+				kind: "tool-call",
+				toolCallId: "tool_1",
+				toolName: "a",
+				input: { x: "safe", y: "has </invoke> here" },
+			},
+		]);
+	});
+
+	it("handles a self-closing <parameter> tag", () => {
+		const parser = new TextDeltaToolCallParser(makeUid());
+
+		const events = parser.consume(
+			'<invoke name="x"><parameter name="k"/></invoke>',
+		);
+
+		expect(events).toEqual([
+			{
+				kind: "tool-call",
+				toolCallId: "tool_1",
+				toolName: "x",
+				input: { k: "" },
+			},
+		]);
+	});
 });

--- a/sdk/packages/agents/src/text-delta-tool-call-parser.ts
+++ b/sdk/packages/agents/src/text-delta-tool-call-parser.ts
@@ -30,10 +30,6 @@ const MAX_BUFFER_BYTES = 64 * 1024;
 const INVOKE_OPEN_PATTERN = /<\s*invoke\b[^>]*>/gi;
 // `name="..."` attribute extractor (no /g flag — single match per tag).
 const NAME_ATTR_PATTERN = /\bname\s*=\s*"([^"]*)"/i;
-// `<parameter name="K">V</parameter>` (or self-closing). Global so we can
-// iterate parameters inside a single `<invoke>` body.
-const PARAMETER_PATTERN =
-	/<\s*parameter\b([^>]*?)(?:\/\s*>|>([\s\S]*?)<\s*\/\s*parameter\s*>)/gi;
 
 export type ParsedDelta =
 	| { kind: "text"; text: string }
@@ -183,19 +179,99 @@ function matchFirst(
 	return { start: m.index, end: m.index + m[0].length };
 }
 
+/**
+ * Parse `<parameter ...>...</parameter>` (or self-closing) blocks out of the
+ * content between `<invoke>` and `</invoke>`. Walks forward to classify
+ * every `<parameter>` open, self-close, and `</parameter>` close, then
+ * processes opens LEFT to RIGHT, binding each open to the LAST `</parameter>`
+ * that lies within its scope (i.e. between this open's end and the next
+ * open's start, or end of buffer). Any `</parameter>` that sits between an
+ * open and its binding close is absorbed as content rather than treated
+ * as the open's closer.
+ *
+ * This is what lets a parameter value contain the literal `</parameter>`
+ * without truncating: the stray close inside the value lands between the
+ * open and the LAST close in scope, so it ends up inside the slice that
+ * becomes the value. Tolerant of malformed input: an open whose close
+ * never arrives keeps the remainder as its value rather than throwing.
+ */
 function parseParameters(content: string): Record<string, unknown> {
 	const result: Record<string, unknown> = {};
-	PARAMETER_PATTERN.lastIndex = 0;
-	let m: RegExpExecArray | null;
-	while ((m = PARAMETER_PATTERN.exec(content)) !== null) {
-		const attrs = m[1];
-		const innerText = (m[2] ?? "").trim();
-		const nameMatch = NAME_ATTR_PATTERN.exec(attrs);
-		if (!nameMatch || !nameMatch[1]) {
+	const closeParam = /^<\s*\/\s*parameter\s*>/i;
+	const selfCloseParam = /^<\s*parameter\b[^>]*\/\s*>/i;
+	const openParam = /^<\s*parameter\b[^>]*>/i;
+
+	type Open = { start: number; end: number; key: string | null };
+	const opens: Open[] = [];
+	const selfs: Open[] = [];
+	const closes: { start: number; end: number }[] = [];
+
+	let i = 0;
+	while (i < content.length) {
+		const lt = content.indexOf("<", i);
+		if (lt === -1) {
+			break;
+		}
+		const slice = content.slice(lt);
+		let m: RegExpExecArray | null;
+		if ((m = selfCloseParam.exec(slice))) {
+			const nameMatch = NAME_ATTR_PATTERN.exec(slice);
+			selfs.push({
+				start: lt,
+				end: lt + m[0].length,
+				key: nameMatch?.[1] ?? null,
+			});
+			i = lt + m[0].length;
+		} else if ((m = openParam.exec(slice))) {
+			const nameMatch = NAME_ATTR_PATTERN.exec(slice);
+			opens.push({
+				start: lt,
+				end: lt + m[0].length,
+				key: nameMatch?.[1] ?? null,
+			});
+			i = lt + m[0].length;
+		} else if ((m = closeParam.exec(slice))) {
+			closes.push({ start: lt, end: lt + m[0].length });
+			i = lt + m[0].length;
+		} else {
+			// Anything else (prose '<' or other tag) — step over.
+			i = lt + 1;
+		}
+	}
+
+	// Self-closing tags resolve immediately — empty value, no pairing needed.
+	for (const s of selfs) {
+		if (s.key !== null) {
+			result[s.key] = "";
+		}
+	}
+
+	// Process opens LEFT to RIGHT. For each open, find the LAST close that
+	// lies within its scope (after this open's end and before the next
+	// open's start, or end of buffer). That close binds the open; any
+	// other closes between the open's end and the binding close are
+	// absorbed into the value as content. If no close is in scope, the
+	// open keeps the remainder as its value (tolerant of malformed input).
+	for (let oi = 0; oi < opens.length; oi++) {
+		const open = opens[oi];
+		if (open.key === null) {
 			continue;
 		}
-		result[nameMatch[1]] = innerText;
+		const nextStart =
+			oi + 1 < opens.length ? opens[oi + 1].start : content.length;
+		let binding: { start: number; end: number } | null = null;
+		for (const close of closes) {
+			if (close.start >= open.end && close.end <= nextStart) {
+				binding = close;
+			}
+		}
+		if (binding) {
+			result[open.key] = content.slice(open.end, binding.start).trim();
+		} else {
+			result[open.key] = content.slice(open.end, nextStart).trim();
+		}
 	}
+
 	return result;
 }
 

--- a/sdk/packages/agents/src/text-delta-tool-call-parser.ts
+++ b/sdk/packages/agents/src/text-delta-tool-call-parser.ts
@@ -28,8 +28,6 @@ const MAX_BUFFER_BYTES = 64 * 1024;
 // `<invoke ...>` opening tag. Matches `<invoke`, `<invoke>`, `< invoke >`,
 // `<invoke\n name="...">`, etc.
 const INVOKE_OPEN_PATTERN = /<\s*invoke\b[^>]*>/gi;
-// `</invoke>` closing tag.
-const INVOKE_CLOSE_PATTERN = /<\s*\/\s*invoke\s*>/gi;
 // `name="..."` attribute extractor (no /g flag — single match per tag).
 const NAME_ATTR_PATTERN = /\bname\s*=\s*"([^"]*)"/i;
 // `<parameter name="K">V</parameter>` (or self-closing). Global so we can
@@ -81,10 +79,11 @@ export class TextDeltaToolCallParser {
 				break;
 			}
 
-			// Look for a matching closing tag *after* the opening tag.
-			const closeRegex = new RegExp(INVOKE_CLOSE_PATTERN.source, "gi");
-			closeRegex.lastIndex = openMatch.end;
-			const closeMatch = closeRegex.exec(this.buffer);
+			// Look for a matching closing tag *after* the opening tag,
+			// skipping any `</invoke>` that appears inside an unclosed
+			// `<parameter>...</parameter>` body (e.g. a parameter value
+			// whose contents describe this format).
+			const closeMatch = findCloseTag(this.buffer, openMatch.end);
 
 			if (!closeMatch) {
 				// Incomplete: closing tag not yet seen. Emit the prefix
@@ -113,7 +112,7 @@ export class TextDeltaToolCallParser {
 			}
 
 			const toolName = nameMatch[1];
-			const innerContent = this.buffer.slice(openMatch.end, closeMatch.index);
+			const innerContent = this.buffer.slice(openMatch.end, closeMatch.start);
 			const input = parseParameters(innerContent);
 
 			if (openMatch.start > 0) {
@@ -130,7 +129,7 @@ export class TextDeltaToolCallParser {
 				input,
 			});
 
-			this.buffer = this.buffer.slice(closeMatch.index + closeMatch[0].length);
+			this.buffer = this.buffer.slice(closeMatch.end);
 		}
 
 		// No more complete tool calls in the buffer. Emit any buffer
@@ -198,4 +197,59 @@ function parseParameters(content: string): Record<string, unknown> {
 		result[nameMatch[1]] = innerText;
 	}
 	return result;
+}
+
+/**
+ * Forward scan from `openEnd` in `buffer` for the real `</invoke>` closer
+ * of the current `<invoke>` block. Tracks `<parameter>` depth so that
+ * `</invoke>` candidates appearing inside an unclosed parameter body are
+ * skipped (they are content, not the block closer). Linear in body length,
+ * bounded by buffer size.
+ *
+ * Returns `{ start, end }` of the matching `</invoke>` tag, or `null` if
+ * the scan runs off the end without finding one (caller should keep the
+ * tail buffered for more input).
+ */
+function findCloseTag(
+	buffer: string,
+	openEnd: number,
+): { start: number; end: number } | null {
+	const closeInvoke = /^<\s*\/\s*invoke\s*>/i;
+	const closeParam = /^<\s*\/\s*parameter\s*>/i;
+	const selfCloseParam = /^<\s*parameter\b[^>]*\/\s*>/i;
+	const openParam = /^<\s*parameter\b[^>]*>/i;
+
+	let paramDepth = 0;
+	let i = openEnd;
+	while (i < buffer.length) {
+		const lt = buffer.indexOf("<", i);
+		if (lt === -1) {
+			return null;
+		}
+		const slice = buffer.slice(lt);
+		let m: RegExpExecArray | null;
+		if ((m = closeInvoke.exec(slice))) {
+			if (paramDepth === 0) {
+				return { start: lt, end: lt + m[0].length };
+			}
+			i = lt + m[0].length;
+		} else if ((m = closeParam.exec(slice))) {
+			if (paramDepth > 0) {
+				paramDepth--;
+			}
+			i = lt + m[0].length;
+		} else if ((m = selfCloseParam.exec(slice))) {
+			i = lt + m[0].length;
+		} else if ((m = openParam.exec(slice))) {
+			paramDepth++;
+			i = lt + m[0].length;
+		} else {
+			// Anything else (prose '<' or other tag) — step over and keep
+			// scanning. Depth is unchanged for non-parameter tags, so a
+			// stray '<' inside a parameter body does not corrupt depth
+			// tracking.
+			i = lt + 1;
+		}
+	}
+	return null;
 }

--- a/sdk/packages/agents/src/text-delta-tool-call-parser.ts
+++ b/sdk/packages/agents/src/text-delta-tool-call-parser.ts
@@ -1,0 +1,201 @@
+/**
+ * Streaming parser that splits a stream of `text-delta` chunks into either
+ * text events or synthetic tool-call events. Used to recover tool
+ * invocations from models that emit XML markup in their text instead of
+ * native `tool_use` blocks — e.g. when the model is fronted by a transport
+ * that does not relay structured tool-call parts (see cline/cline#9848).
+ *
+ * Recognized shape:
+ *
+ *     <invoke name="TOOL_NAME">
+ *       <parameter name="KEY">VALUE</parameter>
+ *       ...
+ *     </invoke>
+ *
+ * Anything that does not match this shape is passed through as text.
+ * Malformed XML (missing `name` attribute, mismatched tags, runaway partial
+ * markup) is passed through as text — the parser never throws on bad
+ * input, never silently swallows a closed `<invoke>` block.
+ *
+ * State: the parser buffers text across calls so that markup split across
+ * multiple deltas is correctly reassembled. The buffer is bounded by
+ * `MAX_BUFFER_BYTES` to prevent unbounded growth on runaway / malformed
+ * streams.
+ */
+
+const MAX_BUFFER_BYTES = 64 * 1024;
+
+// `<invoke ...>` opening tag. Matches `<invoke`, `<invoke>`, `< invoke >`,
+// `<invoke\n name="...">`, etc.
+const INVOKE_OPEN_PATTERN = /<\s*invoke\b[^>]*>/gi;
+// `</invoke>` closing tag.
+const INVOKE_CLOSE_PATTERN = /<\s*\/\s*invoke\s*>/gi;
+// `name="..."` attribute extractor (no /g flag — single match per tag).
+const NAME_ATTR_PATTERN = /\bname\s*=\s*"([^"]*)"/i;
+// `<parameter name="K">V</parameter>` (or self-closing). Global so we can
+// iterate parameters inside a single `<invoke>` body.
+const PARAMETER_PATTERN =
+	/<\s*parameter\b([^>]*?)(?:\/\s*>|>([\s\S]*?)<\s*\/\s*parameter\s*>)/gi;
+
+export type ParsedDelta =
+	| { kind: "text"; text: string }
+	| {
+			kind: "tool-call";
+			toolCallId: string;
+			toolName: string;
+			input: Record<string, unknown>;
+	  };
+
+export class TextDeltaToolCallParser {
+	private buffer = "";
+	private readonly toolCallIdFactory: () => string;
+
+	constructor(toolCallIdFactory: () => string) {
+		this.toolCallIdFactory = toolCallIdFactory;
+	}
+
+	/**
+	 * Consume a text delta. Returns zero or more events to emit downstream:
+	 * - `text` events for prose that did not parse as a tool call
+	 * - `tool-call` events for each complete `<invoke>...</invoke>` block found
+	 */
+	consume(delta: string): ParsedDelta[] {
+		if (!delta) {
+			return [];
+		}
+
+		this.buffer += delta;
+
+		// Bound the buffer. If exceeded, flush everything as text and reset.
+		if (this.buffer.length > MAX_BUFFER_BYTES) {
+			const events: ParsedDelta[] = [{ kind: "text", text: this.buffer }];
+			this.buffer = "";
+			return events;
+		}
+
+		const events: ParsedDelta[] = [];
+
+		while (true) {
+			const openMatch = matchFirst(this.buffer, INVOKE_OPEN_PATTERN);
+			if (!openMatch) {
+				break;
+			}
+
+			// Look for a matching closing tag *after* the opening tag.
+			const closeRegex = new RegExp(INVOKE_CLOSE_PATTERN.source, "gi");
+			closeRegex.lastIndex = openMatch.end;
+			const closeMatch = closeRegex.exec(this.buffer);
+
+			if (!closeMatch) {
+				// Incomplete: closing tag not yet seen. Emit the prefix
+				// (text before the partial opening tag) and keep only the
+				// partial opening tag and what follows in the buffer.
+				if (openMatch.start > 0) {
+					events.push({
+						kind: "text",
+						text: this.buffer.slice(0, openMatch.start),
+					});
+					this.buffer = this.buffer.slice(openMatch.start);
+				}
+				return events;
+			}
+
+			// Extract the `name="..."` attribute from the opening tag.
+			const openTag = this.buffer.slice(openMatch.start, openMatch.end);
+			const nameMatch = NAME_ATTR_PATTERN.exec(openTag);
+			if (!nameMatch || !nameMatch[1]) {
+				// Malformed: opening tag has no `name` attribute. Emit the
+				// opening tag as text and continue scanning the rest of
+				// the buffer.
+				events.push({ kind: "text", text: openTag });
+				this.buffer = this.buffer.slice(openMatch.end);
+				continue;
+			}
+
+			const toolName = nameMatch[1];
+			const innerContent = this.buffer.slice(openMatch.end, closeMatch.index);
+			const input = parseParameters(innerContent);
+
+			if (openMatch.start > 0) {
+				events.push({
+					kind: "text",
+					text: this.buffer.slice(0, openMatch.start),
+				});
+			}
+
+			events.push({
+				kind: "tool-call",
+				toolCallId: this.toolCallIdFactory(),
+				toolName,
+				input,
+			});
+
+			this.buffer = this.buffer.slice(closeMatch.index + closeMatch[0].length);
+		}
+
+		// No more complete tool calls in the buffer. Emit any buffer
+		// content that is unambiguously prose as text, but keep a tail
+		// that might still be the start of an XML block.
+		if (this.buffer.length > 0) {
+			const safe = this.findSafeEmitBoundary(this.buffer);
+			if (safe > 0) {
+				events.push({ kind: "text", text: this.buffer.slice(0, safe) });
+				this.buffer = this.buffer.slice(safe);
+			}
+		}
+
+		return events;
+	}
+
+	/**
+	 * Flush any remaining buffer as text. Called when the model stream ends
+	 * (or is aborted). After this call the parser is reset.
+	 */
+	flush(): ParsedDelta[] {
+		if (this.buffer.length === 0) {
+			return [];
+		}
+		const events: ParsedDelta[] = [{ kind: "text", text: this.buffer }];
+		this.buffer = "";
+		return events;
+	}
+
+	/**
+	 * Find the largest prefix of `text` that cannot be the start of an
+	 * `<invoke>` block, even with more bytes appended. We keep any suffix
+	 * starting from the last '<' in the buffer, because we cannot yet tell
+	 * whether it's a tool-call opener or just an angle bracket in prose.
+	 */
+	private findSafeEmitBoundary(text: string): number {
+		const lastLt = text.lastIndexOf("<");
+		return lastLt === -1 ? text.length : lastLt;
+	}
+}
+
+function matchFirst(
+	text: string,
+	regex: RegExp,
+): { start: number; end: number } | null {
+	regex.lastIndex = 0;
+	const m = regex.exec(text);
+	if (!m) {
+		return null;
+	}
+	return { start: m.index, end: m.index + m[0].length };
+}
+
+function parseParameters(content: string): Record<string, unknown> {
+	const result: Record<string, unknown> = {};
+	PARAMETER_PATTERN.lastIndex = 0;
+	let m: RegExpExecArray | null;
+	while ((m = PARAMETER_PATTERN.exec(content)) !== null) {
+		const attrs = m[1];
+		const innerText = (m[2] ?? "").trim();
+		const nameMatch = NAME_ATTR_PATTERN.exec(attrs);
+		if (!nameMatch || !nameMatch[1]) {
+			continue;
+		}
+		result[nameMatch[1]] = innerText;
+	}
+	return result;
+}

--- a/sdk/packages/agents/src/text-delta-tool-call-parser.ts
+++ b/sdk/packages/agents/src/text-delta-tool-call-parser.ts
@@ -30,6 +30,12 @@ const MAX_BUFFER_BYTES = 64 * 1024;
 const INVOKE_OPEN_PATTERN = /<\s*invoke\b[^>]*>/gi;
 // `name="..."` attribute extractor (no /g flag — single match per tag).
 const NAME_ATTR_PATTERN = /\bname\s*=\s*"([^"]*)"/i;
+// `<parameter ...>...</parameter>` block tokens. Anchored to the start of
+// the test string passed to `RegExp#exec`; hoisted to module scope so each
+// `parseParameters` call doesn't recompile the patterns.
+const PARAM_SELF_CLOSE_PATTERN = /^<\s*parameter\b[^>]*\/\s*>/i;
+const PARAM_OPEN_PATTERN = /^<\s*parameter\b[^>]*>/i;
+const PARAM_CLOSE_PATTERN = /^<\s*\/\s*parameter\s*>/i;
 
 export type ParsedDelta =
 	| { kind: "text"; text: string }
@@ -197,10 +203,6 @@ function matchFirst(
  */
 function parseParameters(content: string): Record<string, unknown> {
 	const result: Record<string, unknown> = {};
-	const closeParam = /^<\s*\/\s*parameter\s*>/i;
-	const selfCloseParam = /^<\s*parameter\b[^>]*\/\s*>/i;
-	const openParam = /^<\s*parameter\b[^>]*>/i;
-
 	type Open = { start: number; end: number; key: string | null };
 	const opens: Open[] = [];
 	const selfs: Open[] = [];
@@ -214,7 +216,7 @@ function parseParameters(content: string): Record<string, unknown> {
 		}
 		const slice = content.slice(lt);
 		let m: RegExpExecArray | null;
-		if ((m = selfCloseParam.exec(slice))) {
+		if ((m = PARAM_SELF_CLOSE_PATTERN.exec(slice))) {
 			const nameMatch = NAME_ATTR_PATTERN.exec(slice);
 			selfs.push({
 				start: lt,
@@ -222,7 +224,7 @@ function parseParameters(content: string): Record<string, unknown> {
 				key: nameMatch?.[1] ?? null,
 			});
 			i = lt + m[0].length;
-		} else if ((m = openParam.exec(slice))) {
+		} else if ((m = PARAM_OPEN_PATTERN.exec(slice))) {
 			const nameMatch = NAME_ATTR_PATTERN.exec(slice);
 			opens.push({
 				start: lt,
@@ -230,7 +232,7 @@ function parseParameters(content: string): Record<string, unknown> {
 				key: nameMatch?.[1] ?? null,
 			});
 			i = lt + m[0].length;
-		} else if ((m = closeParam.exec(slice))) {
+		} else if ((m = PARAM_CLOSE_PATTERN.exec(slice))) {
 			closes.push({ start: lt, end: lt + m[0].length });
 			i = lt + m[0].length;
 		} else {
@@ -291,9 +293,6 @@ function findCloseTag(
 	openEnd: number,
 ): { start: number; end: number } | null {
 	const closeInvoke = /^<\s*\/\s*invoke\s*>/i;
-	const closeParam = /^<\s*\/\s*parameter\s*>/i;
-	const selfCloseParam = /^<\s*parameter\b[^>]*\/\s*>/i;
-	const openParam = /^<\s*parameter\b[^>]*>/i;
 
 	let paramDepth = 0;
 	let i = openEnd;
@@ -309,14 +308,14 @@ function findCloseTag(
 				return { start: lt, end: lt + m[0].length };
 			}
 			i = lt + m[0].length;
-		} else if ((m = closeParam.exec(slice))) {
+		} else if ((m = PARAM_CLOSE_PATTERN.exec(slice))) {
 			if (paramDepth > 0) {
 				paramDepth--;
 			}
 			i = lt + m[0].length;
-		} else if ((m = selfCloseParam.exec(slice))) {
+		} else if ((m = PARAM_SELF_CLOSE_PATTERN.exec(slice))) {
 			i = lt + m[0].length;
-		} else if ((m = openParam.exec(slice))) {
+		} else if ((m = PARAM_OPEN_PATTERN.exec(slice))) {
 			paramDepth++;
 			i = lt + m[0].length;
 		} else {

--- a/sdk/packages/core/src/services/llms/apihandler-agent-model-adapter.test.ts
+++ b/sdk/packages/core/src/services/llms/apihandler-agent-model-adapter.test.ts
@@ -228,4 +228,34 @@ describe("createAgentModelFromApiHandler", () => {
 			{ type: "finish", reason: "error", error: "no vscode.lm" },
 		]);
 	});
+
+	describe("inline-XML capability channel", () => {
+		it("defaults supportsInlineXmlToolCalls to falsy (fail-closed)", () => {
+			const handler = fakeHandler([]);
+			const model = createAgentModelFromApiHandler(handler);
+			// The runtime reads `supportsInlineXmlToolCalls` off the model and
+			// gates inline-XML recovery on it being `=== true`. Anything else
+			// (undefined, false, null) is treated as off.
+			expect(model.supportsInlineXmlToolCalls).toBeFalsy();
+		});
+
+		it("passes an explicit `true` through to the AgentModel", () => {
+			const handler = fakeHandler([]);
+			const model = createAgentModelFromApiHandler(handler, {
+				supportsInlineXmlToolCalls: true,
+			});
+			expect(model.supportsInlineXmlToolCalls).toBe(true);
+		});
+
+		it("treats non-true capability values as off", () => {
+			const handler = fakeHandler([]);
+			// `as any` simulates a caller passing a non-boolean truthy value
+			// (e.g. from a misconfigured upstream); the adapter must still
+			// fail closed rather than treat it as on.
+			const model = createAgentModelFromApiHandler(handler, {
+				supportsInlineXmlToolCalls: "yes" as unknown as boolean,
+			});
+			expect(model.supportsInlineXmlToolCalls).toBeFalsy();
+		});
+	});
 });

--- a/sdk/packages/core/src/services/llms/apihandler-agent-model-adapter.ts
+++ b/sdk/packages/core/src/services/llms/apihandler-agent-model-adapter.ts
@@ -111,11 +111,28 @@ export type ApiHandlerSource =
 
 /**
  * Build an `AgentModel` that delegates to a registered `ApiHandler`.
+ *
+ * `capabilities.supportsInlineXmlToolCalls` opts the adapter into the
+ * inline-XML recovery flow used by the agent runtime. The handler itself
+ * decides whether to set the flag — typically by inspecting its provider
+ * ID / model ID at construction time. The runtime reads the flag off the
+ * returned `AgentModel`; it does not derive the flag from request data.
  */
 export function createAgentModelFromApiHandler(
 	source: ApiHandlerSource,
+	capabilities: {
+		/**
+		 * Whether the wrapped handler's transport emits inline-XML tool
+		 * invocations in its text stream rather than structured tool-call
+		 * events. Default `false`. The runtime fail-closes when this is
+		 * not explicitly `true`.
+		 */
+		readonly supportsInlineXmlToolCalls?: boolean;
+	} = {},
 ): AgentModel {
 	return {
+		supportsInlineXmlToolCalls:
+			capabilities.supportsInlineXmlToolCalls === true,
 		async *stream(request: AgentModelRequest): AsyncGenerator<AgentModelEvent> {
 			let sawFinish = false;
 			let sawToolCall = false;

--- a/sdk/packages/core/src/services/llms/handler-factory.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.ts
@@ -211,6 +211,15 @@ export function createAgentModelFromConfig(
 	// contract the runtime expects. The handler is built lazily (via
 	// `createHandlerAsync`) on the first stream so that providers registered
 	// with `registerAsyncHandler` resolve correctly.
+	//
+	// Inline-XML tool-call recovery is opt-in: it is enabled only when the
+	// resolved model explicitly carries the capability. The current
+	// default is fail-closed — no provider is auto-enabled — because the
+	// capability is adapter-owned and depends on whether a given handler
+	// emits structured tool-call events or only text containing inline
+	// markup. Callers that know their handler emits inline-XML markup
+	// should construct the model directly via
+	// `createAgentModelFromApiHandler(source, { supportsInlineXmlToolCalls: true })`.
 	if (
 		hasRegisteredHandler(
 			normalizeProviderId(normalizedProviderConfig.providerId),

--- a/sdk/packages/shared/src/agent.ts
+++ b/sdk/packages/shared/src/agent.ts
@@ -257,6 +257,13 @@ export type AgentModelEvent =
 	  };
 
 export interface AgentModel {
+	/**
+	 * Whether text deltas may contain executable inline-XML tool invocations.
+	 * This is an adapter-owned capability and must not be derived from request data.
+	 * Marked readonly so third-party AgentModel implementations cannot mutate the
+	 * gate after construction; the field is opt-in and defaults to undefined/false.
+	 */
+	readonly supportsInlineXmlToolCalls?: boolean;
 	stream: (
 		request: AgentModelRequest,
 	) => AsyncIterable<AgentModelEvent> | Promise<AsyncIterable<AgentModelEvent>>;


### PR DESCRIPTION
## Summary

When a model is fronted by a transport that does not relay native tool_use blocks (for example, some OpenAI-compatible gateways used with Claude), the model emits tool invocations as inline XML markup in its assistant text:

    <invoke name="read_file">
      <parameter name="path">/tmp/a.txt</parameter>
    </invoke>

Until now the agent runtime treated that markup as plain prose: the XML was rendered verbatim to the user and no tool ever ran. This PR teaches the runtime to parse <invoke>...</invoke> blocks out of the streaming text and dispatch them through the existing tool-assembly machinery, so downstream events (tool-started, content_start/update/end) and execution paths are unchanged.

Fixes #9848

## How it works

A new TextDeltaToolCallParser (sdk/packages/agents/src/text-delta-tool-call-parser.ts) is a stateful streaming parser that:

- Splits each text-delta chunk into either text events or synthetic tool-call events.
- Recognizes <invoke name=\"TOOL_NAME\"><parameter name=\"K\">V</parameter>...</invoke>.
- Buffers across deltas so markup split across chunk boundaries is correctly reassembled.
- Falls back to text on malformed input — the parser never throws on bad input and never silently swallows a closed <invoke> block.
- Caps the buffer at 64 KiB so runaway / malformed streams cannot grow unbounded.

AgentRuntime wires the parser into the text-delta switch case. Recovered tool calls are registered into the existing PendingToolAssembly / sequence machinery, then flow through the standard parseToolInput -> executePreparedTool path. At end-of-stream the parser is flushed so any unfinished markup degrades gracefully to plain text.

## Scope

- Parses the <invoke>...</invoke> shape that the issue reports.
- Defers <DSML.invoke>, <tool_calls>, and <function_calls> variants to follow-up PRs.

## Test coverage

- 13 unit tests on the parser covering happy path, split deltas, malformed XML, oversized input, JSON regression, and partial-tag buffering.
- 2 integration tests on AgentRuntime proving the runtime end-to-end recovers a tool call from inline XML and that malformed markup degrades to plain text.

All 61 tests in sdk/packages/agents pass.

## Checklist

- [x] Bug fix targeting a single, well-scoped issue
- [x] Tests added (unit + integration)
- [x] bun -F @cline/agents typecheck clean
- [x] Biome check clean on changed files