### PR TITLE
fix(hub): hydrate tool results in session message mapping

### DIFF
--- a/apps/cline-hub/src/server/session-mapping.test.ts
+++ b/apps/cline-hub/src/server/session-mapping.test.ts
@@ -23,6 +23,7 @@ describe("mapHistoryToWebviewMessages", () => {
 				content: [
 					{
 						type: "tool_result",
+						id: "result-block-1",
 						tool_use_id: "toolu_1",
 						name: "read_file",
 						content: "export const value = 1;",
@@ -61,6 +62,127 @@ describe("mapHistoryToWebviewMessages", () => {
 					state: "output-available",
 					output: "export const value = 1;",
 				}),
+			},
+		]);
+	});
+
+	it("hydrates error tool results", () => {
+		const messages = mapHistoryToWebviewMessages([
+			{
+				id: "assistant-1",
+				role: "assistant",
+				content: [
+					{
+						type: "tool_use",
+						id: "toolu_1",
+						name: "read_file",
+						input: { path: "missing.ts" },
+					},
+				],
+			},
+			{
+				id: "user-1",
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "toolu_1",
+						name: "read_file",
+						content: "File not found",
+						is_error: true,
+					},
+				],
+			},
+		]);
+
+		expect(messages).toHaveLength(1);
+		expect(messages[0].toolEvents).toEqual([
+			expect.objectContaining({
+				toolCallId: "toolu_1",
+				name: "read_file",
+				state: "output-error",
+				output: "File not found",
+				error: "File not found",
+			}),
+		]);
+		expect(messages[0].blocks?.[0]).toMatchObject({
+			type: "tool",
+			toolEvent: {
+				toolCallId: "toolu_1",
+				state: "output-error",
+				error: "File not found",
+			},
+		});
+	});
+
+	it("hydrates orphan tool results as standalone meta tool blocks", () => {
+		const messages = mapHistoryToWebviewMessages([
+			{
+				id: "user-1",
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "toolu_orphan",
+						name: "read_file",
+						content: "orphan output",
+					},
+				],
+			},
+		]);
+
+		expect(messages).toHaveLength(1);
+		expect(messages[0]).toMatchObject({
+			id: "user-1",
+			role: "meta",
+			text: "",
+			toolEvents: [
+				{
+					toolCallId: "toolu_orphan",
+					name: "read_file",
+					state: "output-available",
+					input: undefined,
+					output: "orphan output",
+				},
+			],
+		});
+		expect(messages[0].blocks).toEqual([
+			{
+				id: "user-1:tool:toolu_orphan",
+				type: "tool",
+				toolEvent: expect.objectContaining({
+					toolCallId: "toolu_orphan",
+					input: undefined,
+					output: "orphan output",
+				}),
+			},
+		]);
+	});
+
+	it("hydrates plain string content as a text block", () => {
+		const messages = mapHistoryToWebviewMessages([
+			{
+				id: "assistant-1",
+				role: "assistant",
+				content: "Plain response",
+			},
+		]);
+
+		expect(messages).toEqual([
+			{
+				id: "assistant-1",
+				role: "assistant",
+				text: "Plain response",
+				reasoning: undefined,
+				reasoningRedacted: undefined,
+				toolEvents: undefined,
+				blocks: [
+					{
+						id: "assistant-1:text:0",
+						type: "text",
+						text: "Plain response",
+					},
+				],
 			},
 		]);
 	});

--- a/apps/cline-hub/src/server/session-mapping.test.ts
+++ b/apps/cline-hub/src/server/session-mapping.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { mapHistoryToWebviewMessages } from "./session-mapping";
+
+describe("mapHistoryToWebviewMessages", () => {
+	it("hydrates assistant tool uses with following user tool results", () => {
+		const messages = mapHistoryToWebviewMessages([
+			{
+				id: "assistant-1",
+				role: "assistant",
+				content: [
+					{ type: "text", text: "I'll inspect the file." },
+					{
+						type: "tool_use",
+						id: "toolu_1",
+						name: "read_file",
+						input: { path: "src/index.ts" },
+					},
+				],
+			},
+			{
+				id: "user-1",
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "toolu_1",
+						name: "read_file",
+						content: "export const value = 1;",
+					},
+				],
+			},
+		]);
+
+		expect(messages).toHaveLength(1);
+		expect(messages[0]).toMatchObject({
+			id: "assistant-1",
+			role: "assistant",
+			text: "I'll inspect the file.",
+			toolEvents: [
+				{
+					toolCallId: "toolu_1",
+					name: "read_file",
+					state: "output-available",
+					input: { path: "src/index.ts" },
+					output: "export const value = 1;",
+				},
+			],
+		});
+		expect(messages[0].blocks).toEqual([
+			{
+				id: "assistant-1:text:0",
+				type: "text",
+				text: "I'll inspect the file.",
+			},
+			{
+				id: "assistant-1:tool:toolu_1",
+				type: "tool",
+				toolEvent: expect.objectContaining({
+					toolCallId: "toolu_1",
+					name: "read_file",
+					state: "output-available",
+					output: "export const value = 1;",
+				}),
+			},
+		]);
+	});
+
+	it("hydrates same-message tool-call and tool-result blocks", () => {
+		const messages = mapHistoryToWebviewMessages([
+			{
+				id: "assistant-1",
+				role: "assistant",
+				content: [
+					{
+						type: "tool-call",
+						toolCallId: "call_1",
+						toolName: "search",
+						input: { query: "cline" },
+					},
+					{
+						type: "tool-result",
+						toolCallId: "call_1",
+						toolName: "search",
+						output: [{ query: "cline", result: "found", success: true }],
+					},
+				],
+			},
+		]);
+
+		expect(messages).toHaveLength(1);
+		expect(messages[0].toolEvents).toEqual([
+			expect.objectContaining({
+				toolCallId: "call_1",
+				name: "search",
+				state: "output-available",
+				input: { query: "cline" },
+				output: [{ query: "cline", result: "found", success: true }],
+			}),
+		]);
+		expect(messages[0].blocks).toHaveLength(1);
+		expect(messages[0].blocks?.[0]).toMatchObject({
+			type: "tool",
+			toolEvent: {
+				toolCallId: "call_1",
+				state: "output-available",
+			},
+		});
+	});
+});

--- a/apps/cline-hub/src/server/session-mapping.ts
+++ b/apps/cline-hub/src/server/session-mapping.ts
@@ -9,6 +9,7 @@ import type { HubContext } from "./state";
 import type { SessionContext, TrackedClient, TrackedSession } from "./types";
 import {
 	asNumber,
+	asRecord,
 	asString,
 	asTimestamp,
 	basename,
@@ -88,27 +89,275 @@ function summarizeClient(client: TrackedClient): {
 	};
 }
 
+type HistoryToolLocation = {
+	messageIndex: number;
+	blockIndex: number;
+};
+
+function historyContentParts(content: unknown): Record<string, unknown>[] {
+	if (Array.isArray(content)) {
+		return content
+			.map((part) => asRecord(part))
+			.filter((part): part is Record<string, unknown> => Boolean(part));
+	}
+	if (typeof content === "string" && content.trim()) {
+		return [{ type: "text", text: content }];
+	}
+	return [];
+}
+
+function blockType(block: Record<string, unknown>): string {
+	return asString(block.type)?.toLowerCase() ?? "";
+}
+
+function toolCallIdFor(block: Record<string, unknown>): string | undefined {
+	return (
+		asString(block.id) ??
+		asString(block.toolCallId) ??
+		asString(block.tool_call_id) ??
+		asString(block.tool_use_id)
+	);
+}
+
+function toolNameFor(block: Record<string, unknown>): string {
+	return (
+		asString(block.name) ??
+		asString(block.toolName) ??
+		asString(block.tool_name) ??
+		"tool"
+	);
+}
+
+function toolInputFor(block: Record<string, unknown>): unknown {
+	return block.input ?? block.args ?? block.arguments;
+}
+
+function toolOutputFor(block: Record<string, unknown>): unknown {
+	return block.output ?? block.result ?? block.content;
+}
+
+function isErrorToolResult(block: Record<string, unknown>): boolean {
+	return block.is_error === true || block.isError === true || block.error === true;
+}
+
+function pushTextBlock(
+	blocks: NonNullable<WebviewChatMessage["blocks"]>,
+	textParts: string[],
+	messageKey: string | number,
+	partIndex: number,
+	text: string,
+): void {
+	if (!text) return;
+	textParts.push(text);
+	blocks.push({
+		id: `${messageKey}:text:${partIndex}`,
+		type: "text",
+		text,
+	});
+}
+
+function pushReasoningBlock(
+	blocks: NonNullable<WebviewChatMessage["blocks"]>,
+	reasoningParts: string[],
+	messageKey: string | number,
+	partIndex: number,
+	text: string,
+	redacted?: boolean,
+): boolean {
+	if (!text) return false;
+	reasoningParts.push(text);
+	blocks.push({
+		id: `${messageKey}:reasoning:${partIndex}`,
+		type: "reasoning",
+		text,
+		redacted,
+	});
+	return redacted === true;
+}
+
 export function mapHistoryToWebviewMessages(
 	history: unknown[],
 ): WebviewChatMessage[] {
-	return history.map((entry, index) => {
+	const mapped: WebviewChatMessage[] = [];
+	const toolLocations = new Map<string, HistoryToolLocation>();
+
+	for (const [index, entry] of history.entries()) {
 		const record =
 			entry && typeof entry === "object"
 				? (entry as Record<string, unknown>)
 				: { content: entry };
+		const messageKey = asString(record.id) ?? `history-${index}`;
 		const rawRole = asString(record.role)?.toLowerCase();
-		const role: WebviewChatMessage["role"] =
+		let role: WebviewChatMessage["role"] =
 			rawRole === "user" || rawRole === "assistant" || rawRole === "error"
 				? rawRole
 				: "meta";
-		const text = stringifyContent(record.content ?? record.text ?? record);
-		return {
-			id: asString(record.id) ?? `history-${index}`,
+		const blocks: NonNullable<WebviewChatMessage["blocks"]> = [];
+		const textParts: string[] = [];
+		const reasoningParts: string[] = [];
+		const toolEvents = new Map<
+			string,
+			NonNullable<WebviewChatMessage["toolEvents"]>[number]
+		>();
+		const currentToolBlockIndexes = new Map<string, number>();
+		let reasoningRedacted = false;
+
+		const contentParts = historyContentParts(record.content);
+		if (contentParts.length === 0) {
+			const text = stringifyContent(record.content ?? record.text ?? record);
+			pushTextBlock(blocks, textParts, messageKey, 0, text);
+		}
+
+		for (const [partIndex, part] of contentParts.entries()) {
+			const type = blockType(part);
+			if (type === "text") {
+				pushTextBlock(
+					blocks,
+					textParts,
+					messageKey,
+					partIndex,
+					asString(part.text) ?? asString(part.content) ?? "",
+				);
+				continue;
+			}
+
+			if (type === "thinking" || type === "reasoning") {
+				reasoningRedacted =
+					pushReasoningBlock(
+						blocks,
+						reasoningParts,
+						messageKey,
+						partIndex,
+						asString(part.thinking) ??
+							asString(part.reasoning) ??
+							asString(part.text) ??
+							"",
+						part.redacted === true,
+					) || reasoningRedacted;
+				continue;
+			}
+
+			if (type === "redacted_thinking") {
+				reasoningRedacted =
+					pushReasoningBlock(
+						blocks,
+						reasoningParts,
+						messageKey,
+						partIndex,
+						"[redacted]",
+						true,
+					) || reasoningRedacted;
+				continue;
+			}
+
+			if (type === "tool_use" || type === "tool-call") {
+				const toolCallId = toolCallIdFor(part) ?? `${messageKey}:${partIndex}`;
+				const name = toolNameFor(part);
+				const toolEvent = {
+					id: `${messageKey}:${toolCallId}`,
+					toolCallId,
+					name,
+					text: `Running ${name}...`,
+					state: "input-available" as const,
+					input: toolInputFor(part),
+				};
+				toolEvents.set(toolCallId, toolEvent);
+				blocks.push({
+					id: `${messageKey}:tool:${toolCallId}`,
+					type: "tool",
+					toolEvent,
+				});
+				currentToolBlockIndexes.set(toolCallId, blocks.length - 1);
+				toolLocations.set(toolCallId, {
+					messageIndex: mapped.length,
+					blockIndex: blocks.length - 1,
+				});
+				continue;
+			}
+
+			if (type === "tool_result" || type === "tool-result") {
+				const toolCallId = toolCallIdFor(part) ?? `${messageKey}:${partIndex}`;
+				const name = toolNameFor(part);
+				const output = toolOutputFor(part);
+				const isError = isErrorToolResult(part);
+				const currentBlockIndex = currentToolBlockIndexes.get(toolCallId);
+				const existingLocation = toolLocations.get(toolCallId);
+				const existing =
+					currentBlockIndex !== undefined
+						? blocks[currentBlockIndex]
+						: existingLocation !== undefined
+						? mapped[existingLocation.messageIndex]?.blocks?.[
+								existingLocation.blockIndex
+							]
+						: undefined;
+				const existingToolEvent =
+					existing?.type === "tool" ? existing.toolEvent : undefined;
+				const toolEvent = {
+					id: existingToolEvent?.id ?? `${messageKey}:${toolCallId}`,
+					toolCallId,
+					name: existingToolEvent?.name ?? name,
+					text: isError
+						? `${existingToolEvent?.name ?? name} failed`
+						: `${existingToolEvent?.name ?? name} completed`,
+					state: isError
+						? ("output-error" as const)
+						: ("output-available" as const),
+					input: existingToolEvent?.input,
+					output,
+					error: isError ? stringifyContent(output) : undefined,
+				};
+
+				if (currentBlockIndex !== undefined && existing?.type === "tool") {
+					blocks[currentBlockIndex] = {
+						...existing,
+						toolEvent,
+					};
+					toolEvents.set(toolCallId, toolEvent);
+				} else if (existingLocation !== undefined && existing?.type === "tool") {
+					const target = mapped[existingLocation.messageIndex];
+					const targetBlocks = target.blocks;
+					const targetBlock = targetBlocks?.[existingLocation.blockIndex];
+					if (targetBlocks && targetBlock?.type === "tool") {
+						targetBlocks[existingLocation.blockIndex] = {
+							...targetBlock,
+							toolEvent,
+						};
+					}
+					target.toolEvents = (target.toolEvents ?? []).map((event) =>
+						event.toolCallId === toolCallId ? toolEvent : event,
+					);
+				} else {
+					toolEvents.set(toolCallId, toolEvent);
+					blocks.push({
+						id: `${messageKey}:tool:${toolCallId}`,
+						type: "tool",
+						toolEvent,
+					});
+				}
+			}
+		}
+
+		const text = textParts.join("\n");
+		const toolEventList = [...toolEvents.values()];
+		if (!text && reasoningParts.length === 0 && toolEventList.length === 0) {
+			continue;
+		}
+		if (!text && role === "user" && toolEventList.length > 0) {
+			role = "meta";
+		}
+		mapped.push({
+			id: messageKey,
 			role,
 			text,
-			blocks: text ? [{ id: `history-${index}-text`, type: "text", text }] : [],
-		};
-	});
+			reasoning:
+				reasoningParts.length > 0 ? reasoningParts.join("\n") : undefined,
+			reasoningRedacted: reasoningRedacted || undefined,
+			toolEvents: toolEventList.length > 0 ? toolEventList : undefined,
+			blocks,
+		});
+	}
+
+	return mapped;
 }
 
 export function trackSession(record: unknown): TrackedSession | undefined {

--- a/apps/cline-hub/src/server/session-mapping.ts
+++ b/apps/cline-hub/src/server/session-mapping.ts
@@ -110,12 +110,21 @@ function blockType(block: Record<string, unknown>): string {
 	return asString(block.type)?.toLowerCase() ?? "";
 }
 
-function toolCallIdFor(block: Record<string, unknown>): string | undefined {
+function toolCallIdForCall(block: Record<string, unknown>): string | undefined {
 	return (
 		asString(block.id) ??
 		asString(block.toolCallId) ??
-		asString(block.tool_call_id) ??
-		asString(block.tool_use_id)
+		asString(block.tool_call_id)
+	);
+}
+
+function toolCallIdForResult(
+	block: Record<string, unknown>,
+): string | undefined {
+	return (
+		asString(block.tool_use_id) ??
+		asString(block.toolCallId) ??
+		asString(block.tool_call_id)
 	);
 }
 
@@ -251,7 +260,8 @@ export function mapHistoryToWebviewMessages(
 			}
 
 			if (type === "tool_use" || type === "tool-call") {
-				const toolCallId = toolCallIdFor(part) ?? `${messageKey}:${partIndex}`;
+				const toolCallId =
+					toolCallIdForCall(part) ?? `${messageKey}:${partIndex}`;
 				const name = toolNameFor(part);
 				const toolEvent = {
 					id: `${messageKey}:${toolCallId}`,
@@ -276,7 +286,8 @@ export function mapHistoryToWebviewMessages(
 			}
 
 			if (type === "tool_result" || type === "tool-result") {
-				const toolCallId = toolCallIdFor(part) ?? `${messageKey}:${partIndex}`;
+				const toolCallId =
+					toolCallIdForResult(part) ?? `${messageKey}:${partIndex}`;
 				const name = toolNameFor(part);
 				const output = toolOutputFor(part);
 				const isError = isErrorToolResult(part);

--- a/apps/cline-hub/src/webview/src/components/views/page-layout.tsx
+++ b/apps/cline-hub/src/webview/src/components/views/page-layout.tsx
@@ -21,7 +21,7 @@ export function PageFrame({
 					className,
 				)}
 			>
-				<div className={cn("max-w-[86rem]", contentClassName)}>{children}</div>
+				<div className={cn("max-w-344", contentClassName)}>{children}</div>
 			</div>
 		</ScrollArea>
 	);

--- a/apps/cline-hub/src/webview/src/components/views/settings/provider-list-view.tsx
+++ b/apps/cline-hub/src/webview/src/components/views/settings/provider-list-view.tsx
@@ -134,7 +134,7 @@ export function ProviderListContent({
 								isPanel ? "text-[24px]" : "text-[32px]",
 							)}
 						>
-							Models
+							Model Providers
 						</h1>
 						<p className="mt-3 text-[15px] leading-6 text-muted-foreground">
 							Configure model providers and choose which ones are available.{" "}


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Map historical tool call/use and tool result blocks into webview tool events, including same-message results and following user result messages. Add tests to verify hydrated outputs and block ordering so restored sessions render completed tool interactions correctly.


### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

Open Cline Hub UI in dev mode and verify tool blocks are showing up in the chat session view

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
