### PR TITLE
Add diff view telemetry metrics

### DIFF
--- a/apps/vscode/src/core/task/index.ts
+++ b/apps/vscode/src/core/task/index.ts
@@ -1933,7 +1933,7 @@ export class Task {
 			this.fileContextTracker.dispose();
 			// need to await for when we want to make sure directories/files are reverted before
 			// re-starting the task from a checkpoint
-			await this.diffViewProvider.revertChanges();
+			await this.diffViewProvider.revertChanges("task_aborted");
 			// Clear the notification callback when task is aborted
 			this.mcpHub.clearNotificationCallback();
 			if (this.FocusChainManager) {
@@ -3224,7 +3224,7 @@ export class Task {
 				Session.get().finalizeRequest();
 
 				if (this.diffViewProvider.isEditing) {
-					await this.diffViewProvider.revertChanges(); // closes diff view
+					await this.diffViewProvider.revertChanges("task_aborted"); // closes diff view
 				}
 
 				// if last message is a partial we need to update and save it

--- a/apps/vscode/src/core/task/tools/handlers/ApplyPatchHandler.ts
+++ b/apps/vscode/src/core/task/tools/handlers/ApplyPatchHandler.ts
@@ -304,7 +304,8 @@ export class ApplyPatchHandler implements IFullyManagedTool {
 				if (!approved) {
 					this.config = undefined
 					config.taskState.didRejectTool = true
-					await provider.revertChanges()
+					provider.recordDiffViewRejected()
+					await provider.revertChanges("user_rejected")
 					await provider.reset()
 					return "The user denied this patch operation."
 				}
@@ -406,7 +407,7 @@ export class ApplyPatchHandler implements IFullyManagedTool {
 
 			return responseLines.join("\n")
 		} catch (error) {
-			await provider.revertChanges()
+			await provider.revertChanges("error_cleanup")
 			throw error
 		} finally {
 			await provider.reset()

--- a/apps/vscode/src/core/task/tools/handlers/WriteToFileToolHandler.ts
+++ b/apps/vscode/src/core/task/tools/handlers/WriteToFileToolHandler.ts
@@ -88,7 +88,7 @@ export class WriteToFileToolHandler implements IFullyManagedTool {
 			await config.services.diffViewProvider.update(newContent, false)
 		} catch (error) {
 			// Reset diff view on error
-			await config.services.diffViewProvider.revertChanges()
+			await config.services.diffViewProvider.revertChanges("error_cleanup")
 			await config.services.diffViewProvider.reset()
 			throw error
 		}
@@ -297,7 +297,8 @@ export class WriteToFileToolHandler implements IFullyManagedTool {
 						filesCreated: fileExists ? 0 : 1,
 					})
 
-					await config.services.diffViewProvider.revertChanges()
+					config.services.diffViewProvider.recordDiffViewRejected()
+					await config.services.diffViewProvider.revertChanges("user_rejected")
 					return `The user denied this operation. ${fileDeniedNote}`
 				}
 				// User hit the approve button, and may have provided feedback
@@ -348,7 +349,7 @@ export class WriteToFileToolHandler implements IFullyManagedTool {
 			} catch (error) {
 				const { PreToolUseHookCancellationError } = await import("@core/hooks/PreToolUseHookCancellationError")
 				if (error instanceof PreToolUseHookCancellationError) {
-					await config.services.diffViewProvider.revertChanges()
+					await config.services.diffViewProvider.revertChanges("hook_cancelled")
 					await config.services.diffViewProvider.reset()
 					return formatResponse.toolDenied()
 				}
@@ -412,7 +413,7 @@ export class WriteToFileToolHandler implements IFullyManagedTool {
 			return formatResponse.fileEditWithoutUserChanges(relPath, autoFormattingEdits, finalContent, newProblemsMessage)
 		} catch (error) {
 			// Reset diff view on error
-			await config.services.diffViewProvider.revertChanges()
+			await config.services.diffViewProvider.revertChanges("error_cleanup")
 			await config.services.diffViewProvider.reset()
 			throw error
 		}
@@ -551,7 +552,7 @@ export class WriteToFileToolHandler implements IFullyManagedTool {
 				}
 
 				// Revert changes and reset diff view
-				await config.services.diffViewProvider.revertChanges()
+				await config.services.diffViewProvider.revertChanges("error_cleanup")
 				await config.services.diffViewProvider.reset()
 
 				return

--- a/apps/vscode/src/hosts/external/ExternalDiffviewProvider.ts
+++ b/apps/vscode/src/hosts/external/ExternalDiffviewProvider.ts
@@ -4,6 +4,7 @@ import { DiffViewProvider } from "@/integrations/editor/DiffViewProvider"
 import { Logger } from "@/shared/services/Logger"
 
 export class ExternalDiffViewProvider extends DiffViewProvider {
+	protected readonly editSurface = "external"
 	private activeDiffEditorId: string | undefined
 
 	override async openDiffEditor(): Promise<void> {
@@ -55,7 +56,7 @@ export class ExternalDiffViewProvider extends DiffViewProvider {
 		return lines.length
 	}
 
-	protected async saveDocument(): Promise<Boolean> {
+	protected async saveDocument(): Promise<boolean> {
 		if (!this.activeDiffEditorId) {
 			return false
 		}

--- a/apps/vscode/src/hosts/vscode/VscodeDiffViewProvider.ts
+++ b/apps/vscode/src/hosts/vscode/VscodeDiffViewProvider.ts
@@ -9,6 +9,7 @@ import { arePathsEqual } from "@/utils/path"
 export const DIFF_VIEW_URI_SCHEME = "cline-diff"
 
 export class VscodeDiffViewProvider extends DiffViewProvider {
+	protected readonly editSurface = "vscode_diff"
 	private activeDiffEditor?: vscode.TextEditor
 
 	private fadedOverlayController?: DecorationController
@@ -190,7 +191,7 @@ export class VscodeDiffViewProvider extends DiffViewProvider {
 		return this.activeDiffEditor.document.getText()
 	}
 
-	protected override async saveDocument(): Promise<Boolean> {
+	protected override async saveDocument(): Promise<boolean> {
 		if (!this.activeDiffEditor) {
 			return false
 		}

--- a/apps/vscode/src/integrations/editor/DiffViewProvider.ts
+++ b/apps/vscode/src/integrations/editor/DiffViewProvider.ts
@@ -7,13 +7,24 @@ import * as fs from "fs/promises"
 import * as iconv from "iconv-lite"
 import { HostProvider } from "@/hosts/host-provider"
 import { diagnosticsToProblemsString, getNewDiagnostics } from "@/integrations/diagnostics"
+import { telemetryService } from "@/services/telemetry"
 import { DiagnosticSeverity, FileDiagnostics } from "@/shared/proto/index.cline"
 import { Logger } from "@/shared/services/Logger"
 import { detectEncoding } from "../misc/extract-text"
 import { sanitizeNotebookForLLM } from "../misc/notebook-utils"
 import { openFile } from "../misc/open-file"
 
+export type DiffEditSurface = "vscode_diff" | "background" | "external"
+export type DiffViewOutcome = "accepted" | "rejected"
+export type DiffViewRevertReason = "user_rejected" | "error_cleanup" | "hook_cancelled" | "task_aborted" | "unknown"
+
+export type DiffViewTelemetry = Pick<
+	typeof telemetryService,
+	"captureDiffViewOpened" | "captureDiffViewAccepted" | "captureDiffViewRejected" | "captureDiffViewReverted"
+>
+
 export abstract class DiffViewProvider {
+	protected abstract readonly editSurface: DiffEditSurface
 	editType?: "create" | "modify" | "delete"
 	isEditing = false
 	originalContent: string | undefined
@@ -25,8 +36,10 @@ export abstract class DiffViewProvider {
 	protected fileEncoding: string = "utf8"
 	private streamedLines: string[] = []
 	private newContent?: string
+	private diffViewOutcome?: DiffViewOutcome
+	private diffViewReverted = false
 
-	constructor() {}
+	constructor(protected readonly diffViewTelemetry: DiffViewTelemetry = telemetryService) {}
 
 	public async open(relPath: string, options?: { displayPath?: string }): Promise<void> {
 		this.isEditing = true
@@ -58,8 +71,51 @@ export abstract class DiffViewProvider {
 		// get diagnostics before editing the file, we'll compare to diagnostics after editing to see if cline needs to fix anything
 		this.preDiagnostics = (await HostProvider.workspace.getDiagnostics({})).fileDiagnostics
 		await this.openDiffEditor()
+		this.diffViewTelemetry.captureDiffViewOpened({
+			editType: this.editType,
+			editSurface: this.editSurface,
+			isNotebook: this.isNotebookFile(),
+		})
 		await this.scrollEditorToLine(0)
 		this.streamedLines = []
+	}
+
+	private recordDiffViewAccepted(): void {
+		if (this.diffViewOutcome) {
+			return
+		}
+		this.diffViewTelemetry.captureDiffViewAccepted({
+			editType: this.editType,
+			editSurface: this.editSurface,
+			isNotebook: this.isNotebookFile(),
+		})
+		this.diffViewOutcome = "accepted"
+	}
+
+	public recordDiffViewRejected(): void {
+		if (this.diffViewOutcome) {
+			return
+		}
+		this.diffViewTelemetry.captureDiffViewRejected({
+			editType: this.editType,
+			editSurface: this.editSurface,
+			isNotebook: this.isNotebookFile(),
+		})
+		this.diffViewOutcome = "rejected"
+	}
+
+	private recordDiffViewReverted(reason: DiffViewRevertReason): void {
+		if (this.diffViewReverted) {
+			return
+		}
+		this.diffViewTelemetry.captureDiffViewReverted({
+			editType: this.editType,
+			editSurface: this.editSurface,
+			isNotebook: this.isNotebookFile(),
+			revertReason: reason,
+			previousOutcome: this.diffViewOutcome ?? "none",
+		})
+		this.diffViewReverted = true
 	}
 
 	/**
@@ -158,7 +214,7 @@ export abstract class DiffViewProvider {
 	 *
 	 * @returns true if the file was saved.
 	 */
-	protected abstract saveDocument(): Promise<Boolean>
+	protected abstract saveDocument(): Promise<boolean>
 
 	/**
 	 * Closes all open diff views.
@@ -343,7 +399,7 @@ export abstract class DiffViewProvider {
 		// get the contents before save operation which may do auto-formatting
 		const preSaveContent = await this.getDocumentText()
 
-		if (!this.relPath || !this.absolutePath || !this.newContent || preSaveContent === undefined) {
+		if (!this.relPath || !this.absolutePath || this.newContent === undefined || preSaveContent === undefined) {
 			return {
 				newProblemsMessage: undefined,
 				userEdits: undefined,
@@ -352,7 +408,10 @@ export abstract class DiffViewProvider {
 			}
 		}
 
-		await this.saveDocument()
+		const saved = await this.saveDocument()
+		if (saved) {
+			this.recordDiffViewAccepted()
+		}
 		// get text after save in case there is any auto-formatting done by the editor
 		const postSaveContent = (await this.getDocumentText()) || ""
 
@@ -403,10 +462,11 @@ export abstract class DiffViewProvider {
 		}
 	}
 
-	async revertChanges(): Promise<void> {
+	async revertChanges(reason: DiffViewRevertReason = "unknown"): Promise<void> {
 		if (!this.absolutePath || !this.isEditing) {
 			return
 		}
+		this.recordDiffViewReverted(reason)
 		const fileExists = this.editType === "modify"
 
 		if (!fileExists) {
@@ -501,6 +561,8 @@ export abstract class DiffViewProvider {
 		this.streamedLines = []
 		this.createdDirs = []
 		this.newContent = undefined
+		this.diffViewOutcome = undefined
+		this.diffViewReverted = false
 		this.lastUpdateContentLength = -1
 		this.lastUpdateTime = 0
 

--- a/apps/vscode/src/integrations/editor/FileEditProvider.ts
+++ b/apps/vscode/src/integrations/editor/FileEditProvider.ts
@@ -11,6 +11,7 @@ import { Logger } from "@/shared/services/Logger"
  * This makes it suitable for headless or non-interactive environments.
  */
 export class FileEditProvider extends DiffViewProvider {
+	protected readonly editSurface = "background"
 	private documentContent?: string
 
 	constructor() {
@@ -104,7 +105,7 @@ export class FileEditProvider extends DiffViewProvider {
 		return this.getDocumentText()
 	}
 
-	protected async saveDocument(): Promise<Boolean> {
+	protected async saveDocument(): Promise<boolean> {
 		if (!this.absolutePath || !this.documentContent) {
 			return false
 		}

--- a/apps/vscode/src/integrations/editor/__tests__/DiffViewProvider.test.ts
+++ b/apps/vscode/src/integrations/editor/__tests__/DiffViewProvider.test.ts
@@ -1,13 +1,80 @@
 import * as assert from "assert"
 import { describe, it } from "mocha"
+import * as fs from "fs/promises"
+import * as os from "os"
+import * as path from "path"
+import { HostProvider } from "@/hosts/host-provider"
+import type { DiffEditSurface, DiffViewTelemetry } from "../DiffViewProvider"
 import { DiffViewProvider } from "../DiffViewProvider"
 
+type DiffTelemetryEvent = {
+	type: "opened" | "accepted" | "rejected" | "reverted"
+	attributes: Record<string, unknown>
+}
+
+function stubDiffTelemetry(): { events: DiffTelemetryEvent[]; telemetry: DiffViewTelemetry } {
+	const events: DiffTelemetryEvent[] = []
+	const telemetry = {
+		captureDiffViewOpened: (attributes = {}) => {
+			events.push({ type: "opened", attributes })
+		},
+		captureDiffViewAccepted: (attributes = {}) => {
+			events.push({ type: "accepted", attributes })
+		},
+		captureDiffViewRejected: (attributes = {}) => {
+			events.push({ type: "rejected", attributes })
+		},
+		captureDiffViewReverted: (attributes = {}) => {
+			events.push({ type: "reverted", attributes })
+		},
+	}
+	return { events, telemetry }
+}
+
+function setupHostProviderForDiffTests(workspacePath: string): void {
+	HostProvider.reset()
+	HostProvider.initialize(
+		(() => {}) as never,
+		(() => {}) as never,
+		(() => {}) as never,
+		(() => ({})) as never,
+		{
+			workspaceClient: {
+				getWorkspacePaths: async () => ({ paths: [workspacePath] }),
+				saveOpenDocumentIfDirty: async () => ({}),
+				getDiagnostics: async () => ({ fileDiagnostics: [] }),
+			} as never,
+			envClient: {} as never,
+			windowClient: {} as never,
+			diffClient: {} as never,
+		},
+		() => {},
+		async () => "http://example.com/callback",
+		async () => "/mock/binary",
+		"/mock/extension",
+		"/mock/globalStorage",
+	)
+}
+
 class TestBoundaryDiffViewProvider extends DiffViewProvider {
+	protected readonly editSurface: DiffEditSurface = "vscode_diff"
 	public documentText: string = ""
 	public truncatedAt: number | undefined
+	public openedCount = 0
+	public scrolledToLine: number | undefined
+	private shouldSave = true
 
-	async openDiffEditor(): Promise<void> {}
-	async scrollEditorToLine(line: number): Promise<void> {}
+	constructor(telemetry?: DiffViewTelemetry) {
+		super(telemetry)
+	}
+
+	async openDiffEditor(): Promise<void> {
+		this.openedCount++
+		this.documentText = this.originalContent || ""
+	}
+	async scrollEditorToLine(line: number): Promise<void> {
+		this.scrolledToLine = line
+	}
 	async scrollAnimation(startLine: number, endLine: number): Promise<void> {}
 
 	async truncateDocument(lineNumber: number): Promise<void> {
@@ -26,8 +93,8 @@ class TestBoundaryDiffViewProvider extends DiffViewProvider {
 		return this.documentText
 	}
 
-	async saveDocument(): Promise<Boolean> {
-		return true
+	async saveDocument(): Promise<boolean> {
+		return this.shouldSave
 	}
 	async closeAllDiffViews(): Promise<void> {}
 	async resetDiffView(): Promise<void> {}
@@ -61,6 +128,18 @@ class TestBoundaryDiffViewProvider extends DiffViewProvider {
 		this.documentText = initialContent
 		this.originalContent = initialContent
 		this.truncatedAt = undefined
+	}
+
+	public setupOpenState(absolutePath: string, editType: "create" | "modify" | "delete" = "modify") {
+		this.isEditing = true
+		this.absolutePath = absolutePath
+		this.relPath = absolutePath
+		this.editType = editType
+		this.originalContent = this.documentText
+	}
+
+	public setSaveResult(shouldSave: boolean) {
+		this.shouldSave = shouldSave
 	}
 }
 
@@ -190,6 +269,127 @@ describe("DiffViewProvider content finalization with isFinal=true", () => {
 	})
 })
 
+describe("DiffViewProvider telemetry lifecycle", () => {
+	it("open() emits opened telemetry with edit surface metadata", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "cline-diff-telemetry-open-"))
+		const filePath = path.join(tempDir, "file.txt")
+		await fs.writeFile(filePath, "original")
+		setupHostProviderForDiffTests(tempDir)
+		const { events, telemetry } = stubDiffTelemetry()
+		try {
+			const provider = new TestBoundaryDiffViewProvider(telemetry)
+			provider.editType = "modify"
+
+			await provider.open("file.txt")
+
+			assert.strictEqual(events.length, 1)
+			assert.strictEqual(events[0].type, "opened")
+			assert.strictEqual(events[0].attributes.editType, "modify")
+			assert.strictEqual(events[0].attributes.editSurface, "vscode_diff")
+			assert.strictEqual(events[0].attributes.isNotebook, false)
+			assert.strictEqual(provider.openedCount, 1)
+			assert.strictEqual(provider.scrolledToLine, 0)
+		} finally {
+			HostProvider.reset()
+			await fs.rm(tempDir, { recursive: true, force: true })
+		}
+	})
+
+	it("saveChanges() emits accepted once and reset re-arms accepted telemetry", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "cline-diff-telemetry-accept-"))
+		setupHostProviderForDiffTests(tempDir)
+		const { events, telemetry } = stubDiffTelemetry()
+		try {
+			const provider = new TestBoundaryDiffViewProvider(telemetry)
+			const filePath = path.join(tempDir, "file.txt")
+			provider.setup("original")
+			provider.setupOpenState(filePath, "modify")
+			await provider.update("changed", true)
+
+			await provider.saveChanges()
+			await provider.saveChanges()
+
+			assert.deepStrictEqual(events.map((event) => event.type), ["accepted"])
+
+			await provider.reset()
+			provider.setup("changed")
+			provider.setupOpenState(filePath, "modify")
+			await provider.update("changed again", true)
+			await provider.saveChanges()
+
+			assert.deepStrictEqual(events.map((event) => event.type), ["accepted", "accepted"])
+		} finally {
+			HostProvider.reset()
+			await fs.rm(tempDir, { recursive: true, force: true })
+		}
+	})
+
+	it("saveChanges() does not emit accepted telemetry when saveDocument returns false", async () => {
+		const { events, telemetry } = stubDiffTelemetry()
+		const provider = new TestBoundaryDiffViewProvider(telemetry)
+		provider.setup("original")
+		provider.setupOpenState("/tmp/file.txt", "modify")
+		provider.setSaveResult(false)
+		await provider.update("changed", true)
+
+		await provider.saveChanges()
+
+		assert.deepStrictEqual(events.map((event) => event.type), [])
+	})
+
+	it("recordDiffViewRejected() is idempotent and revert records previous rejected outcome", async () => {
+		const { events, telemetry } = stubDiffTelemetry()
+		try {
+			const provider = new TestBoundaryDiffViewProvider(telemetry)
+			provider.setup("original")
+			provider.setupOpenState("/tmp/file.txt", "modify")
+
+			provider.recordDiffViewRejected()
+			provider.recordDiffViewRejected()
+			await provider.revertChanges("user_rejected")
+
+			assert.deepStrictEqual(events.map((event) => event.type), ["rejected", "reverted"])
+			assert.strictEqual(events[1].attributes.revertReason, "user_rejected")
+			assert.strictEqual(events[1].attributes.previousOutcome, "rejected")
+		} finally {
+		}
+	})
+
+	it("revert after accept records previous accepted outcome", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "cline-diff-telemetry-revert-"))
+		setupHostProviderForDiffTests(tempDir)
+		const { events, telemetry } = stubDiffTelemetry()
+		try {
+			const provider = new TestBoundaryDiffViewProvider(telemetry)
+			provider.setup("original")
+			provider.setupOpenState(path.join(tempDir, "file.txt"), "modify")
+			await provider.update("changed", true)
+			await provider.saveChanges()
+
+			await provider.revertChanges("error_cleanup")
+
+			assert.deepStrictEqual(events.map((event) => event.type), ["accepted", "reverted"])
+			assert.strictEqual(events[1].attributes.revertReason, "error_cleanup")
+			assert.strictEqual(events[1].attributes.previousOutcome, "accepted")
+		} finally {
+			HostProvider.reset()
+			await fs.rm(tempDir, { recursive: true, force: true })
+		}
+	})
+
+	it("revertChanges() emits nothing when not editing", async () => {
+		const { events, telemetry } = stubDiffTelemetry()
+		try {
+			const provider = new TestBoundaryDiffViewProvider(telemetry)
+
+			await provider.revertChanges("error_cleanup")
+
+			assert.deepStrictEqual(events, [])
+		} finally {
+		}
+	})
+})
+
 describe("DiffViewProvider Update Throttling", () => {
 	// Tests for the throttling added in PR #8785 to prevent performance issues
 	// during streaming, especially with large files like notebooks.
@@ -199,6 +399,7 @@ describe("DiffViewProvider Update Throttling", () => {
 	// Only the final line (without trailing newline) is deferred until isFinal=true.
 
 	class ThrottleTestDiffViewProvider extends DiffViewProvider {
+		protected readonly editSurface: DiffEditSurface = "vscode_diff"
 		public documentText: string = ""
 		public replaceTextCallCount = 0
 
@@ -215,7 +416,7 @@ describe("DiffViewProvider Update Throttling", () => {
 			return this.documentText
 		}
 
-		async saveDocument(): Promise<Boolean> {
+		async saveDocument(): Promise<boolean> {
 			return true
 		}
 		async closeAllDiffViews(): Promise<void> {}

--- a/apps/vscode/src/services/telemetry/TelemetryService.ts
+++ b/apps/vscode/src/services/telemetry/TelemetryService.ts
@@ -8,6 +8,7 @@ import { ClineAccountUserInfo } from "@/services/auth/AuthService"
 import { Setting } from "@/shared/proto/index.host"
 import { Logger } from "@/shared/services/Logger"
 import { Mode } from "@/shared/storage/types"
+import type { DiffEditSurface, DiffViewOutcome, DiffViewRevertReason } from "../../integrations/editor/DiffViewProvider"
 import { version as extensionVersion } from "../../../package.json"
 import { setDistinctId } from "../logging/distinctId"
 import type { ITelemetryProvider, TelemetryProperties } from "./providers/ITelemetryProvider"
@@ -192,6 +193,12 @@ export class TelemetryService {
 		},
 		GRPC: {
 			RESPONSE_SIZE_BYTES: "cline.grpc.response.size_bytes",
+		},
+		DIFF_VIEW: {
+			OPENED_TOTAL: "cline.diff_view.opened.total",
+			ACCEPTED_TOTAL: "cline.diff_view.accepted.total",
+			REJECTED_TOTAL: "cline.diff_view.rejected.total",
+			REVERTED_TOTAL: "cline.diff_view.reverted.total",
 		},
 	}
 	// Event constants for tracking user interactions and system events
@@ -552,6 +559,76 @@ export class TelemetryService {
 		const nextValue = (store.get(ulid) ?? 0) + 1
 		store.set(ulid, nextValue)
 		return nextValue
+	}
+
+	private getDiffViewAttributes(attributes?: {
+		editType?: "create" | "modify" | "delete"
+		editSurface?: DiffEditSurface
+		isNotebook?: boolean
+		revertReason?: DiffViewRevertReason
+		previousOutcome?: DiffViewOutcome | "none"
+	}): TelemetryProperties {
+		return {
+			edit_type: attributes?.editType ?? "unknown",
+			edit_surface: attributes?.editSurface ?? "unknown",
+			is_notebook: attributes?.isNotebook ?? false,
+			...(attributes?.revertReason ? { revert_reason: attributes.revertReason } : {}),
+			...(attributes?.previousOutcome ? { previous_outcome: attributes.previousOutcome } : {}),
+		}
+	}
+
+	public captureDiffViewOpened(attributes?: {
+		editType?: "create" | "modify" | "delete"
+		editSurface?: DiffEditSurface
+		isNotebook?: boolean
+	}): void {
+		this.recordCounter(
+			TelemetryService.METRICS.DIFF_VIEW.OPENED_TOTAL,
+			1,
+			this.getDiffViewAttributes(attributes),
+			"Number of Cline diff views opened",
+		)
+	}
+
+	public captureDiffViewAccepted(attributes?: {
+		editType?: "create" | "modify" | "delete"
+		editSurface?: DiffEditSurface
+		isNotebook?: boolean
+	}): void {
+		this.recordCounter(
+			TelemetryService.METRICS.DIFF_VIEW.ACCEPTED_TOTAL,
+			1,
+			this.getDiffViewAttributes(attributes),
+			"Number of Cline diff view changes accepted",
+		)
+	}
+
+	public captureDiffViewRejected(attributes?: {
+		editType?: "create" | "modify" | "delete"
+		editSurface?: DiffEditSurface
+		isNotebook?: boolean
+	}): void {
+		this.recordCounter(
+			TelemetryService.METRICS.DIFF_VIEW.REJECTED_TOTAL,
+			1,
+			this.getDiffViewAttributes(attributes),
+			"Number of Cline diff view changes explicitly rejected by the user",
+		)
+	}
+
+	public captureDiffViewReverted(attributes?: {
+		editType?: "create" | "modify" | "delete"
+		editSurface?: DiffEditSurface
+		isNotebook?: boolean
+		revertReason?: DiffViewRevertReason
+		previousOutcome?: DiffViewOutcome | "none"
+	}): void {
+		this.recordCounter(
+			TelemetryService.METRICS.DIFF_VIEW.REVERTED_TOTAL,
+			1,
+			this.getDiffViewAttributes(attributes),
+			"Number of Cline diff view changes reverted or cleaned up",
+		)
 	}
 
 	private resetTaskAggregates(ulid: string): void {

--- a/apps/vscode/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
+++ b/apps/vscode/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
@@ -383,4 +383,51 @@ describe("TelemetryService metrics", () => {
 		assert.strictEqual(entry.attributes.extension_version, "test")
 		assert.strictEqual(entry.attributes.platform, "test-platform")
 	})
+
+	it("captureDiffView lifecycle methods emit counters with edit metadata", () => {
+		const provider = new FakeProvider()
+		const service = createTelemetryService(provider)
+
+		service.captureDiffViewOpened({ editType: "modify", editSurface: "vscode_diff", isNotebook: false })
+		service.captureDiffViewAccepted({ editType: "modify", editSurface: "background", isNotebook: false })
+		service.captureDiffViewRejected({ editType: "delete", editSurface: "external", isNotebook: true })
+		service.captureDiffViewReverted({
+			editType: "modify",
+			editSurface: "vscode_diff",
+			isNotebook: false,
+			revertReason: "error_cleanup",
+			previousOutcome: "accepted",
+		})
+
+		assert.strictEqual(provider.counters.length, 4)
+		assert.deepStrictEqual(
+			provider.counters.map((entry) => entry.name),
+			[
+				TelemetryService.METRICS.DIFF_VIEW.OPENED_TOTAL,
+				TelemetryService.METRICS.DIFF_VIEW.ACCEPTED_TOTAL,
+				TelemetryService.METRICS.DIFF_VIEW.REJECTED_TOTAL,
+				TelemetryService.METRICS.DIFF_VIEW.REVERTED_TOTAL,
+			],
+		)
+
+		const opened = provider.counters[0]
+		assert.strictEqual(opened.value, 1)
+		assert.strictEqual(opened.attributes.edit_type, "modify")
+		assert.strictEqual(opened.attributes.edit_surface, "vscode_diff")
+		assert.strictEqual(opened.attributes.is_notebook, false)
+		assert.strictEqual(opened.attributes.extension_version, "test")
+
+		const rejected = provider.counters[2]
+		assert.strictEqual(rejected.value, 1)
+		assert.strictEqual(rejected.attributes.edit_type, "delete")
+		assert.strictEqual(rejected.attributes.edit_surface, "external")
+		assert.strictEqual(rejected.attributes.is_notebook, true)
+
+		const reverted = provider.counters[3]
+		assert.strictEqual(reverted.value, 1)
+		assert.strictEqual(reverted.attributes.edit_type, "modify")
+		assert.strictEqual(reverted.attributes.edit_surface, "vscode_diff")
+		assert.strictEqual(reverted.attributes.revert_reason, "error_cleanup")
+		assert.strictEqual(reverted.attributes.previous_outcome, "accepted")
+	})
 })


### PR DESCRIPTION
## Summary
- add diff view lifecycle OTel counters for opened, accepted, rejected, and reverted edits
- include edit_surface attributes for vscode_diff, background, and external edit flows
- distinguish explicit user rejection from automatic revert/cleanup reasons
- add DiffViewProvider lifecycle coverage for telemetry state-machine behavior

## Testing
- git diff --check
- targeted biome checks on changed telemetry/diff-view files
- targeted unit type-check grep for DiffViewProvider/TelemetryService metric tests

Note: direct single-file mocha invocation in this workspace is blocked by ts-node/ESM extensionless import resolution, but the unit tsconfig check no longer reports the reviewed DiffViewProvider abstract-member compile errors.