### PR TITLE
Fix VS Code F5 webview debug flow

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -68,7 +68,7 @@
 			"command": "bun run build:webview",
 			"group": "build",
 			"problemMatcher": [],
-			"isBackground": true,
+			"isBackground": false,
 			"label": "npm: build:webview",
 			"dependsOn": [
 				"npm: protos"
@@ -89,7 +89,7 @@
 			"command": "bun run build:webview:test",
 			"group": "build",
 			"problemMatcher": [],
-			"isBackground": true,
+			"isBackground": false,
 			"label": "npm: build:webview:test",
 			"dependsOn": [
 				"npm: protos"
@@ -108,22 +108,22 @@
 		},
 		{
 			"type": "shell",
-			"command": "bun run dev:webview",
+			"command": "rm -rf webview-ui/node_modules/.vite && bun run dev:webview",
 			"group": "build",
 			"problemMatcher": [
 				{
 					"pattern": [
 						{
-							"regexp": ".",
+							"regexp": "^(?!)((?:.*))$",
+							"kind": "file",
 							"file": 1,
-							"location": 2,
-							"message": 3
+							"message": 1
 						}
 					],
 					"background": {
 						"activeOnStart": true,
-						"beginsPattern": ".",
-						"endsPattern": "."
+						"beginsPattern": "^Building webview for|^\\s*VITE",
+						"endsPattern": "^.*Local:\\s+http://localhost:[0-9]+/"
 					}
 				}
 			],

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -108,7 +108,7 @@
 		},
 		{
 			"type": "shell",
-			"command": "rm -rf webview-ui/node_modules/.vite && bun run dev:webview",
+			"command": "bun run dev:webview",
 			"group": "build",
 			"problemMatcher": [
 				{

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -394,7 +394,7 @@
 		"test:e2e:optimal": "bun run test:e2e:build && node src/test/e2e/utils/build.mjs && playwright test",
 		"test:e2e:ui": "bun scripts/interactive-playwright.ts",
 		"install:all": "bun install",
-		"dev:webview": "cd webview-ui && bun run dev",
+		"dev:webview": "node scripts/clean-webview-vite-cache.mjs && cd webview-ui && bun run dev",
 		"build:webview": "bun run protos && cd webview-ui && bun run build",
 		"test:webview": "cd webview-ui && bun run test",
 		"publish:marketplace": "node scripts/publish-marketplace.mjs",

--- a/apps/vscode/scripts/clean-webview-vite-cache.mjs
+++ b/apps/vscode/scripts/clean-webview-vite-cache.mjs
@@ -1,0 +1,6 @@
+import { rm } from "node:fs/promises"
+import path from "node:path"
+
+const viteCachePath = path.join(import.meta.dirname, "..", "webview-ui", "node_modules", ".vite")
+
+await rm(viteCachePath, { recursive: true, force: true })

--- a/apps/vscode/src/core/webview/WebviewProvider.ts
+++ b/apps/vscode/src/core/webview/WebviewProvider.ts
@@ -117,7 +117,6 @@ export abstract class WebviewProvider {
 				<noscript>You need to enable JavaScript to run this app.</noscript>
 				<div id="root"></div>
 				<script type="module" nonce="${nonce}" src="${scriptUrl}"></script>
-				<script src="http://localhost:8097"></script> 
 			</body>
 		</html>
 		`
@@ -204,7 +203,6 @@ export abstract class WebviewProvider {
 			<!DOCTYPE html>
 			<html lang="en">
 				<head>
-					${process.env.IS_DEV ? '<script src="http://localhost:8097"></script>' : ""}
 					<meta charset="utf-8">
 					<meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
 					<meta http-equiv="Content-Security-Policy" content="${csp.join("; ")}">

--- a/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1642,6 +1642,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 											"pt-0.5 pb-px px-2 z-10 text-xs w-1/2 text-center bg-transparent",
 											mode === m.toLowerCase() ? "text-white" : "text-input-foreground",
 										)}
+										key={m}
 										onMouseLeave={() => setShownTooltipMode(null)}
 										onMouseOver={() => setShownTooltipMode(m.toLowerCase() === "plan" ? "plan" : "act")}
 										role="switch">

--- a/apps/vscode/webview-ui/vite.config.ts
+++ b/apps/vscode/webview-ui/vite.config.ts
@@ -110,7 +110,7 @@ export default defineConfig({
 	server: {
 		port: 25463,
 		fs: {
-			allow: [resolve(__dirname, "..")],
+			allow: [resolve(__dirname, "../src/shared")],
 		},
 		hmr: {
 			host: "localhost",

--- a/apps/vscode/webview-ui/vite.config.ts
+++ b/apps/vscode/webview-ui/vite.config.ts
@@ -47,9 +47,6 @@ console.log("Building webview for", platform)
 
 export default defineConfig({
 	base: "./",
-	optimizeDeps: {
-		force: true, // Forces re-optimization
-	},
 	plugins: [react(), tailwindcss(), writePortToFile()],
 	test: {
 		environment: "jsdom",
@@ -112,6 +109,9 @@ export default defineConfig({
 	},
 	server: {
 		port: 25463,
+		fs: {
+			allow: [resolve(__dirname, "..")],
+		},
 		hmr: {
 			host: "localhost",
 			protocol: "ws",


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Fixes the VS Code F5 debug flow for the extension/webview development setup.

This PR:

- Marks finite webview build tasks as non-background tasks so VS Code does not wait on them incorrectly.
- Makes the `dev:webview` background task report readiness when Vite prints its local server URL.
- Clears Vite's optimized dependency cache before starting the webview dev server to avoid stale `Outdated Optimize Dep` chunks in the debug webview.
- Removes stale `localhost:8097` script injection from webview HTML.
- Allows Vite dev-server filesystem access to the extension parent directory.
- Adds a missing React key on the plan/act mode switch buttons.

### Test Procedure

- Verified the Vite dev server starts and prints a matching `Local: http://localhost:<port>/` ready line.
- Verified the task problem matcher regex matches Vite's actual ready output.
- Manually exercised the VS Code F5 debug flow while investigating the issue.

Potentially affected area is local VS Code extension development only; production webview bundling should continue using bundled assets.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — local development workflow fix.

### Additional Notes

No linked issue; this is a small local development workflow fix.
