### PR TITLE
feat(vscode): recognize Tencent TokenHub provider

### DIFF
--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -378,7 +378,7 @@ describe("buildSessionConfig", () => {
 		const providers = [
 			{ providerId: "poolside", modelId: "poolside/laguna-m.1" },
 			{ providerId: "v0", modelId: "v0-1.5-md" },
-			{ providerId: "xiaomi", modelId: "mimo-v2-omni" },
+			{ providerId: "xiaomi", modelId: "mimo-v2.5" },
 			{ providerId: "zai-coding-plan", modelId: "glm-5.2" },
 		] as const
 

--- a/apps/vscode/src/sdk/model-catalog/provider-id.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/provider-id.test.ts
@@ -49,6 +49,7 @@ describe("parseProviderId", () => {
 		parseProviderId("poolside")
 		parseProviderId("v0")
 		parseProviderId("xiaomi")
+		parseProviderId("tencent-tokenhub")
 
 		expect(warnSpy).not.toHaveBeenCalled()
 	})
@@ -64,6 +65,7 @@ describe("isKnownProviderId", () => {
 		expect(isKnownProviderId(parseProviderId("poolside"))).toBe(true)
 		expect(isKnownProviderId(parseProviderId("v0"))).toBe(true)
 		expect(isKnownProviderId(parseProviderId("xiaomi"))).toBe(true)
+		expect(isKnownProviderId(parseProviderId("tencent-tokenhub"))).toBe(true)
 	})
 
 	it("returns false for a custom provider id", () => {

--- a/apps/vscode/src/sdk/model-catalog/provider-id.ts
+++ b/apps/vscode/src/sdk/model-catalog/provider-id.ts
@@ -57,6 +57,7 @@ const KNOWN_API_PROVIDERS = {
 	nousResearch: true,
 	wandb: true,
 	xiaomi: true,
+	"tencent-tokenhub": true,
 	"cline-pass": true,
 } satisfies Record<ApiProvider, true>
 

--- a/apps/vscode/src/shared/api.ts
+++ b/apps/vscode/src/shared/api.ts
@@ -49,6 +49,7 @@ export type ApiProvider =
 	| "nousResearch"
 	| "wandb"
 	| "xiaomi"
+	| "tencent-tokenhub"
 
 export const DEFAULT_API_PROVIDER = "openrouter" as ApiProvider
 

--- a/apps/vscode/src/shared/proto-conversions/models/api-configuration-conversion.test.ts
+++ b/apps/vscode/src/shared/proto-conversions/models/api-configuration-conversion.test.ts
@@ -4,7 +4,7 @@ import { convertApiConfigurationToProto, convertProtoToApiConfiguration } from "
 
 describe("api configuration provider conversion", () => {
 	it("round-trips SDK provider ids added after the legacy enum list", () => {
-		const providers: ApiProvider[] = ["poolside", "v0", "xiaomi", "zai-coding-plan"]
+		const providers: ApiProvider[] = ["poolside", "v0", "xiaomi", "tencent-tokenhub", "zai-coding-plan"]
 
 		for (const provider of providers) {
 			const proto = convertApiConfigurationToProto({

--- a/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.test.ts
+++ b/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.test.ts
@@ -69,6 +69,7 @@ describe("providerSettingsRegistry", () => {
 			["nousResearch", "NousResearch", undefined],
 			["poolside", "Poolside", undefined],
 			["sambanova", "SambaNova", "https://docs.sambanova.ai/cloud/docs/get-started/overview"],
+			["tencent-tokenhub", "Tencent TokenHub", "https://cloud.tencent.com/document/product/1823/130050"],
 			["vercel-ai-gateway", "Vercel AI Gateway", "https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fai"],
 			["v0", "Vercel v0", undefined],
 			["wandb", "W&B", "https://wandb.ai"],

--- a/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.ts
+++ b/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.ts
@@ -97,6 +97,9 @@ const GENERIC_PROVIDER_PRESENTATION_OVERRIDES: Record<string, GenericProviderPre
 		signupUrl: "https://wandb.ai",
 	},
 	xiaomi: {},
+	"tencent-tokenhub": {
+		signupUrl: "https://cloud.tencent.com/document/product/1823/130050",
+	},
 	"zai-coding-plan": {},
 }
 
@@ -157,6 +160,7 @@ const FALLBACK_GENERIC_PROVIDER_NAMES = {
 	v0: "Vercel v0",
 	wandb: "W&B",
 	xiaomi: "Xiaomi",
+	"tencent-tokenhub": "Tencent TokenHub",
 	"zai-coding-plan": "Z.AI Coding Plan",
 } as const
 


### PR DESCRIPTION
### Related Issue

**Issue:** #11826

### Description

Companion PR to #12014. This keeps the VS Code/provider-settings integration separate from the SDK provider registration so the app-side changes can be rolled back independently if needed.

This PR:

- adds `tencent-tokenhub` to the VS Code `ApiProvider` union and known-provider parser
- adds proto conversion round-trip coverage for `tencent-tokenhub`
- adds generic provider settings metadata for Tencent TokenHub
- updates the Xiaomi fixture in `cline-session-factory.test.ts` to the current generated default model, `mimo-v2.5`

The SDK built-in provider, generated catalog entry, and live inference verification are handled in #12014.

### Test Procedure

Focused verification run locally:

- `cd apps/vscode && bun biome format --write src/sdk/cline-session-factory.test.ts src/sdk/model-catalog/provider-id.test.ts src/sdk/model-catalog/provider-id.ts src/shared/api.ts src/shared/proto-conversions/models/api-configuration-conversion.test.ts webview-ui/src/components/settings/providers/providerSettingsRegistry.test.ts webview-ui/src/components/settings/providers/providerSettingsRegistry.ts`
- `cd apps/vscode && bun vitest run --config vitest.config.ts src/sdk/model-catalog/provider-id.test.ts src/sdk/cline-session-factory.test.ts src/shared/proto-conversions/models/api-configuration-conversion.test.ts`
- `git diff --check`

Known local test issue not introduced by this PR:

- `cd apps/vscode/webview-ui && bun run test src/components/settings/providers/providerSettingsRegistry.test.ts` fails before test collection with `ERR_PACKAGE_PATH_NOT_EXPORTED` for `entities/decode`.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality not to work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

This should merge after #12014, since that PR adds the SDK built-in provider and generated model catalog entry.