### PR TITLE
Add awaiting-user task state telemetry

### DIFF
--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -41,6 +41,7 @@ import { UrlContentFetcher } from "@/services/browser/UrlContentFetcher"
 import { ClineError } from "@/services/error/ClineError"
 import { McpHub } from "@/services/mcp/McpHub"
 import { telemetryService } from "@/services/telemetry"
+import type { TaskAwaitingUserActionTelemetry } from "@/services/telemetry/TelemetryService"
 import type { ClineExtensionContext } from "@/shared/cline"
 import { ShowMessageRequest, ShowMessageType } from "@/shared/proto/host/window"
 import { Logger } from "@/shared/services/Logger"
@@ -48,6 +49,7 @@ import { isClineProvider } from "@/shared/utils/cline"
 import { arePathsEqual, getDesktopDir } from "@/utils/path"
 import { ClineAccountService } from "./account-service"
 import { AuthService, LogoutReason } from "./auth-service"
+import type { SdkAwaitingUserActionTelemetry } from "./awaiting-user-action-telemetry"
 import { buildStartSessionInput, createHistoryItemFromSession } from "./cline-session-factory"
 import { MessageTranslatorState, reshapeErrorForWebview } from "./message-translator"
 import { createProviderCatalog } from "./model-catalog/catalog"
@@ -280,6 +282,7 @@ export class Controller {
 			// asks, ask_question, user_feedback) never collide with translator-minted ids.
 			getMinter: () => this.messageTranslatorState.getMinter(),
 			setTurnPhase: (phase, anchorTs) => this.turnStateTracker.set(phase, anchorTs),
+			captureTaskAwaitingUserAction: (event) => this.captureTaskAwaitingUserAction(event),
 			recordApprovedToolMessage: (toolCallId, messageTs) =>
 				this.messageTranslatorState.recordApprovedToolMessageTs(toolCallId, messageTs),
 			recordDeniedToolApproval: (toolCallId, toolName, reason) =>
@@ -520,6 +523,7 @@ export class Controller {
 			getTask: () => this.task,
 			postStateToWebview: () => this.postStateToWebview(),
 			setTurnPhase: (phase, anchorTs) => this.turnStateTracker.set(phase, anchorTs),
+			captureTaskAwaitingUserAction: (event) => this.captureTaskAwaitingUserAction(event),
 			captureProviderApiError: (event) => this.captureProviderFailure(event),
 			beginProviderFailureTelemetryTurn: () => this.beginProviderFailureTelemetryTurn(),
 		})
@@ -880,6 +884,25 @@ export class Controller {
 
 	private beginProviderFailureTelemetryTurn(): void {
 		this.providerFailureTelemetryTurnGate.beginTurn()
+	}
+
+	private captureTaskAwaitingUserAction(event: SdkAwaitingUserActionTelemetry): void {
+		const ulid = event.sessionId ?? this.task?.taskId ?? this.sessions.getActiveSession()?.sessionId
+		if (!ulid) {
+			return
+		}
+
+		const mode = this.stateManager.getGlobalSettingsKey("mode") === "plan" ? "plan" : "act"
+		const payload: TaskAwaitingUserActionTelemetry = {
+			ulid,
+			awaitingType: event.awaitingType,
+			askType: event.askType,
+			provider: this.getSessionProviderId(event.sessionId) ?? this.getActiveProviderId(),
+			modelId: this.getSessionModelId(event.sessionId) ?? this.getTaskModelId(),
+			mode,
+		}
+
+		telemetryService.captureTaskAwaitingUserAction(payload)
 	}
 
 	/**

--- a/apps/vscode/src/sdk/awaiting-user-action-telemetry.ts
+++ b/apps/vscode/src/sdk/awaiting-user-action-telemetry.ts
@@ -1,0 +1,43 @@
+import type { ClineAsk } from "@shared/ExtensionMessage"
+import type { TaskAwaitingUserActionType } from "@/services/telemetry/TelemetryService"
+
+export interface SdkAwaitingUserActionTelemetry {
+	sessionId?: string
+	awaitingType: TaskAwaitingUserActionType
+	askType?: ClineAsk
+}
+
+export function awaitingUserActionTypeForAsk(askType: ClineAsk): TaskAwaitingUserActionType {
+	switch (askType) {
+		case "followup":
+			return "followup"
+		case "plan_mode_respond":
+			return "plan_response"
+		case "act_mode_respond":
+			return "act_response"
+		case "tool":
+			return "tool_approval"
+		case "command":
+		case "command_output":
+			return "command_approval"
+		case "use_mcp_server":
+			return "mcp_approval"
+		case "use_subagents":
+			return "subagent_approval"
+		case "browser_action_launch":
+			return "browser_action"
+		case "api_req_failed":
+			return "api_retry"
+		case "mistake_limit_reached":
+			return "mistake_limit"
+		case "condense":
+			return "condense"
+		case "summarize_task":
+			return "summarize_task"
+		case "completion_result":
+		case "resume_completed_task":
+			return "completion_result"
+		default:
+			return "unknown"
+	}
+}

--- a/apps/vscode/src/sdk/sdk-interaction-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-interaction-coordinator.test.ts
@@ -21,11 +21,13 @@ describe("SdkInteractionCoordinator", () => {
 		const listener = vi.fn()
 		const postStateToWebview = vi.fn().mockResolvedValue(undefined)
 		const recordApprovedToolMessage = vi.fn()
+		const captureTaskAwaitingUserAction = vi.fn()
 		const coordinator = new SdkInteractionCoordinator({
 			messages,
 			getSessionId: () => "session-123",
 			postStateToWebview,
 			recordApprovedToolMessage,
+			captureTaskAwaitingUserAction,
 		})
 		messages.onSessionEvent(listener)
 
@@ -46,6 +48,11 @@ describe("SdkInteractionCoordinator", () => {
 		expect(clineMessages[0].ask).toBe("tool")
 		expect(JSON.parse(clineMessages[0].text || "{}")).toMatchObject({ tool: "readFile", path: "README.md" })
 		expect(listener).toHaveBeenCalledOnce()
+		expect(captureTaskAwaitingUserAction).toHaveBeenCalledWith({
+			sessionId: "session-123",
+			awaitingType: "tool_approval",
+			askType: "tool",
+		})
 
 		expect(coordinator.resolvePendingToolApproval(undefined, "yesButtonClicked")).toBe(true)
 		expect(recordApprovedToolMessage).toHaveBeenCalledWith("tool-call", clineMessages[0].ts)
@@ -265,10 +272,12 @@ describe("SdkInteractionCoordinator", () => {
 
 	it("emits an MCP approval ask with server, tool, and arguments", async () => {
 		const task = createTaskProxy("session-123", vi.fn(), vi.fn())
+		const captureTaskAwaitingUserAction = vi.fn()
 		const coordinator = new SdkInteractionCoordinator({
 			messages: new SdkMessageCoordinator({ getTask: () => task }),
 			getSessionId: () => "session-123",
 			postStateToWebview: vi.fn().mockResolvedValue(undefined),
+			captureTaskAwaitingUserAction,
 		})
 
 		void coordinator.handleRequestToolApproval({
@@ -290,15 +299,22 @@ describe("SdkInteractionCoordinator", () => {
 			toolName: "search-repos",
 			arguments: '{\n  "query": "cline"\n}',
 		})
+		expect(captureTaskAwaitingUserAction).toHaveBeenCalledWith({
+			sessionId: "session-123",
+			awaitingType: "mcp_approval",
+			askType: "use_mcp_server",
+		})
 	})
 
 	it("emits ask_question and resolves it with rendered user feedback", async () => {
 		const task = createTaskProxy("session-123", vi.fn(), vi.fn())
 		const messages = new SdkMessageCoordinator({ getTask: () => task })
+		const captureTaskAwaitingUserAction = vi.fn()
 		const coordinator = new SdkInteractionCoordinator({
 			messages,
 			getSessionId: () => "session-123",
 			postStateToWebview: vi.fn().mockResolvedValue(undefined),
+			captureTaskAwaitingUserAction,
 		})
 
 		const answerPromise = coordinator.handleAskQuestion("Continue?", ["Yes"], undefined)
@@ -311,16 +327,23 @@ describe("SdkInteractionCoordinator", () => {
 			{ type: "ask", ask: "followup" },
 			{ type: "say", say: "user_feedback", text: "yes" },
 		])
+		expect(captureTaskAwaitingUserAction).toHaveBeenCalledWith({
+			sessionId: "session-123",
+			awaitingType: "followup",
+			askType: "followup",
+		})
 	})
 
 	it("emits mistake_limit_reached and resolves proceed as SDK recovery guidance", async () => {
 		const task = createTaskProxy("session-123", vi.fn(), vi.fn())
 		const setTurnPhase = vi.fn()
+		const captureTaskAwaitingUserAction = vi.fn()
 		const coordinator = new SdkInteractionCoordinator({
 			messages: new SdkMessageCoordinator({ getTask: () => task }),
 			getSessionId: () => "session-123",
 			postStateToWebview: vi.fn().mockResolvedValue(undefined),
 			setTurnPhase,
+			captureTaskAwaitingUserAction,
 		})
 
 		const decisionPromise = coordinator.handleConsecutiveMistakeLimitReached({
@@ -338,6 +361,11 @@ describe("SdkInteractionCoordinator", () => {
 			partial: false,
 		})
 		expect(setTurnPhase).toHaveBeenCalledWith("error", task.messageStateHandler.getClineMessages()[0].ts)
+		expect(captureTaskAwaitingUserAction).toHaveBeenCalledWith({
+			sessionId: "session-123",
+			awaitingType: "mistake_limit",
+			askType: "mistake_limit_reached",
+		})
 
 		expect(coordinator.resolvePendingMistakeLimit("try smaller steps", "yesButtonClicked")).toBe(true)
 		await expect(decisionPromise).resolves.toEqual({

--- a/apps/vscode/src/sdk/sdk-interaction-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-interaction-coordinator.ts
@@ -1,7 +1,11 @@
 import type { ConsecutiveMistakeLimitContext, ConsecutiveMistakeLimitDecision } from "@cline/shared"
-import type { ClineAskQuestion, ClineMessage, TurnPhase } from "@shared/ExtensionMessage"
+import type { ClineAsk, ClineAskQuestion, ClineMessage, TurnPhase } from "@shared/ExtensionMessage"
 import type { ClineAskResponse } from "@shared/WebviewMessage"
 import { Logger } from "@/shared/services/Logger"
+import {
+	awaitingUserActionTypeForAsk,
+	type SdkAwaitingUserActionTelemetry,
+} from "./awaiting-user-action-telemetry"
 import { MessageIdMinter } from "./message-id-minter"
 import { buildToolApprovalAskMessage } from "./message-translator"
 import type { SdkMessageCoordinator } from "./sdk-message-coordinator"
@@ -36,6 +40,7 @@ export interface SdkInteractionCoordinatorOptions {
 	 * Optional for tests.
 	 */
 	setTurnPhase?: (phase: TurnPhase, anchorTs?: number) => void
+	captureTaskAwaitingUserAction?: (event: SdkAwaitingUserActionTelemetry) => void
 }
 
 export class SdkInteractionCoordinator {
@@ -70,6 +75,7 @@ export class SdkInteractionCoordinator {
 			payload: { sessionId: this.options.getSessionId(), status: "running" },
 		})
 		this.options.setTurnPhase?.("error", askMessage.ts)
+		this.captureAwaitingUserAction("mistake_limit_reached")
 		await this.options.postStateToWebview()
 
 		return new Promise<ConsecutiveMistakeLimitDecision>((resolve) => {
@@ -90,6 +96,9 @@ export class SdkInteractionCoordinator {
 			payload: { sessionId: this.options.getSessionId(), status: "running" },
 		})
 		this.options.setTurnPhase?.("awaiting_approval", toolAskMessage.ts)
+		if (toolAskMessage.ask) {
+			this.captureAwaitingUserAction(toolAskMessage.ask)
+		}
 		await this.options.postStateToWebview()
 
 		return new Promise<{ approved: boolean; reason?: string }>((resolve) => {
@@ -120,6 +129,7 @@ export class SdkInteractionCoordinator {
 			payload: { sessionId: this.options.getSessionId(), status: "running" },
 		})
 		this.options.setTurnPhase?.("awaiting_followup", askMessage.ts)
+		this.captureAwaitingUserAction("followup")
 		await this.options.postStateToWebview()
 
 		return new Promise<string>((resolve) => {
@@ -292,5 +302,13 @@ export class SdkInteractionCoordinator {
 			this.fallbackMinter = new MessageIdMinter()
 		}
 		return this.fallbackMinter
+	}
+
+	private captureAwaitingUserAction(askType: ClineAsk): void {
+		this.options.captureTaskAwaitingUserAction?.({
+			sessionId: this.options.getSessionId(),
+			awaitingType: awaitingUserActionTypeForAsk(askType),
+			askType,
+		})
 	}
 }

--- a/apps/vscode/src/sdk/sdk-session-event-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-session-event-coordinator.test.ts
@@ -109,7 +109,47 @@ describe("SdkSessionEventCoordinator", () => {
 		await coordinator.handleSessionEvent(event)
 
 		expect(options.setTurnPhase).toHaveBeenCalledWith("awaiting_followup")
+		expect(options.captureTaskAwaitingUserAction).toHaveBeenCalledWith({
+			sessionId: "session-123",
+			awaitingType: "turn_finished_without_completion",
+			askType: undefined,
+		})
 		expect(options.postStateToWebview).toHaveBeenCalledOnce()
+	})
+
+	it("classifies a turn-ending API error ask as an awaiting retry state", async () => {
+		const errorAsk: ClineMessage = { ts: 1, type: "ask", ask: "api_req_failed", text: "{}" }
+		const { coordinator, options, event } = makeCoordinator({
+			translation: {
+				messages: [errorAsk],
+				sessionEnded: false,
+				turnComplete: true,
+			},
+		})
+
+		await coordinator.handleSessionEvent(event)
+
+		expect(options.captureTaskAwaitingUserAction).toHaveBeenCalledWith({
+			sessionId: "session-123",
+			awaitingType: "api_retry",
+			askType: "api_req_failed",
+		})
+	})
+
+	it("does not emit awaiting-user telemetry for completed attempt_completion turns", async () => {
+		const { coordinator, options, event } = makeCoordinator({
+			translation: {
+				messages: [],
+				sessionEnded: false,
+				turnComplete: true,
+			},
+		})
+		options.messageTranslatorState.setAttemptCompletionSeen()
+
+		await coordinator.handleSessionEvent(event)
+
+		expect(options.setTurnPhase).toHaveBeenCalledWith("completed")
+		expect(options.captureTaskAwaitingUserAction).not.toHaveBeenCalled()
 	})
 
 	it("marks a submitted queued prompt as a new streaming turn", async () => {
@@ -186,6 +226,7 @@ describe("SdkSessionEventCoordinator", () => {
 		await coordinator.handleSessionEvent(event)
 
 		expect(options.setTurnPhase).not.toHaveBeenCalled()
+		expect(options.captureTaskAwaitingUserAction).not.toHaveBeenCalled()
 	})
 
 	it("updates task usage when the active session has a start result", async () => {
@@ -367,6 +408,7 @@ function makeCoordinator(input: Partial<MakeCoordinatorInput> = {}) {
 		getTask: vi.fn(() => input.task),
 		postStateToWebview: vi.fn().mockResolvedValue(undefined),
 		setTurnPhase: vi.fn(),
+		captureTaskAwaitingUserAction: vi.fn(),
 		captureProviderApiError: vi.fn(),
 		beginProviderFailureTelemetryTurn: vi.fn(),
 		translateSessionEvent: vi.fn(() => input.translation ?? { messages: [], sessionEnded: false, turnComplete: false }),
@@ -387,6 +429,7 @@ function makeCoordinator(input: Partial<MakeCoordinatorInput> = {}) {
 		}
 		taskHistory: SdkSessionEventCoordinatorOptions["taskHistory"] & { updateTaskUsage: ReturnType<typeof vi.fn> }
 		postStateToWebview: ReturnType<typeof vi.fn>
+		captureTaskAwaitingUserAction: ReturnType<typeof vi.fn>
 		captureProviderApiError: ReturnType<typeof vi.fn>
 		beginProviderFailureTelemetryTurn: ReturnType<typeof vi.fn>
 		translateSessionEvent: ReturnType<typeof vi.fn>

--- a/apps/vscode/src/sdk/sdk-session-event-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-session-event-coordinator.ts
@@ -2,8 +2,9 @@ import type { AgentEvent, CoreSessionEvent } from "@cline/core"
 import { refreshClineRecommendedModels } from "@/core/controller/models/refreshClineRecommendedModels"
 import type { StateManager } from "@/core/storage/StateManager"
 import { CLINE_RECOMMENDED_MODELS_FALLBACK } from "@/shared/cline/recommended-models"
-import type { ClineApiReqInfo, TurnPhase } from "@/shared/ExtensionMessage"
+import type { ClineApiReqInfo, ClineAsk, ClineMessage, TurnPhase } from "@/shared/ExtensionMessage"
 import { Logger } from "@/shared/services/Logger"
+import { awaitingUserActionTypeForAsk, type SdkAwaitingUserActionTelemetry } from "./awaiting-user-action-telemetry"
 import type { MessageTranslatorState, TranslationResult } from "./message-translator"
 import { translateSessionEvent } from "./message-translator"
 import { PROVIDER_FAILURE_ERROR_TYPE, PROVIDER_FAILURE_PHASE, type ProviderFailureTelemetry } from "./provider-failure-telemetry"
@@ -40,6 +41,7 @@ export interface SdkSessionEventCoordinatorOptions {
 	 * error. Optional for tests.
 	 */
 	setTurnPhase?: (phase: TurnPhase, anchorTs?: number) => void
+	captureTaskAwaitingUserAction?: (event: SdkAwaitingUserActionTelemetry) => void
 	captureProviderApiError?: (event: ProviderFailureTelemetry) => void
 	beginProviderFailureTelemetryTurn?: () => void
 }
@@ -117,6 +119,7 @@ export class SdkSessionEventCoordinator {
 					this.options.setTurnPhase?.("completed")
 				} else {
 					this.options.setTurnPhase?.("awaiting_followup")
+					this.captureAwaitingUserActionForTurnEnd(activeSession.sessionId, result.messages)
 				}
 
 				this.options.sessions.setRunning(false)
@@ -187,6 +190,18 @@ export class SdkSessionEventCoordinator {
 			}
 		}
 		return undefined
+	}
+
+	private captureAwaitingUserActionForTurnEnd(sessionId: string, messages: ClineMessage[]): void {
+		const askType = messages.find((message): message is ClineMessage & { type: "ask"; ask: ClineAsk } => {
+			return message.type === "ask" && typeof message.ask === "string"
+		})?.ask
+
+		this.options.captureTaskAwaitingUserAction?.({
+			sessionId,
+			awaitingType: askType ? awaitingUserActionTypeForAsk(askType) : "turn_finished_without_completion",
+			askType,
+		})
 	}
 
 	private zeroCostForFreeClineModel(result: TranslationResult): Promise<void> | undefined {

--- a/apps/vscode/src/services/telemetry/TelemetryService.ts
+++ b/apps/vscode/src/services/telemetry/TelemetryService.ts
@@ -104,6 +104,32 @@ export interface TokenUsage {
 	totalCost?: number
 }
 
+export type TaskAwaitingUserActionType =
+	| "followup"
+	| "plan_response"
+	| "act_response"
+	| "tool_approval"
+	| "command_approval"
+	| "mcp_approval"
+	| "subagent_approval"
+	| "browser_action"
+	| "api_retry"
+	| "mistake_limit"
+	| "condense"
+	| "summarize_task"
+	| "completion_result"
+	| "turn_finished_without_completion"
+	| "unknown"
+
+export interface TaskAwaitingUserActionTelemetry {
+	ulid: string
+	awaitingType: TaskAwaitingUserActionType
+	askType?: string
+	provider?: string
+	modelId?: string
+	mode?: Mode
+}
+
 /**
  * Maximum length for error messages to prevent excessive data
  */
@@ -247,6 +273,8 @@ export class TelemetryService {
 			RESTARTED: "task.restarted",
 			// Tracks when a task is finished, with acceptance or rejection status
 			COMPLETED: "task.completed",
+			// Tracks when a live task reaches a user-waiting state without ending the task
+			AWAITING_USER_ACTION: "task.awaiting_user_action",
 			// Tracks user feedback on completed tasks
 			FEEDBACK: "task.feedback",
 			// Tracks when a message is sent in a conversation
@@ -772,6 +800,21 @@ export class TelemetryService {
 		}
 
 		this.resetTaskAggregates(ulid)
+	}
+
+	public captureTaskAwaitingUserAction(args: TaskAwaitingUserActionTelemetry) {
+		if (!args.ulid || !args.awaitingType) {
+			Logger.warn("TelemetryService: Missing required parameters for awaiting user action capture")
+			return
+		}
+
+		this.capture({
+			event: TelemetryService.EVENTS.TASK.AWAITING_USER_ACTION,
+			properties: {
+				...args,
+				timestamp: new Date().toISOString(),
+			},
+		})
 	}
 
 	/**

--- a/apps/vscode/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
+++ b/apps/vscode/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
@@ -353,6 +353,30 @@ describe("TelemetryService metrics", () => {
 		assert.strictEqual(durationMetric?.attributes.scope, "task")
 	})
 
+	it("captureTaskAwaitingUserAction records a low-cardinality waiting-state payload", () => {
+		const provider = new FakeProvider()
+		const service = createTelemetryService(provider)
+
+		service.captureTaskAwaitingUserAction({
+			ulid: "task-5",
+			awaitingType: "tool_approval",
+			askType: "tool",
+			provider: "cline",
+			modelId: "deepseek/deepseek-v4-flash",
+			mode: "act",
+		})
+
+		const waitingEvent = provider.logs.find((entry) => entry.event === "task.awaiting_user_action")
+		assert.ok(waitingEvent)
+		assert.strictEqual(waitingEvent?.properties?.ulid, "task-5")
+		assert.strictEqual(waitingEvent?.properties?.awaitingType, "tool_approval")
+		assert.strictEqual(waitingEvent?.properties?.askType, "tool")
+		assert.strictEqual(waitingEvent?.properties?.provider, "cline")
+		assert.strictEqual(waitingEvent?.properties?.modelId, "deepseek/deepseek-v4-flash")
+		assert.strictEqual(waitingEvent?.properties?.mode, "act")
+		assert.strictEqual(typeof waitingEvent?.properties?.timestamp, "string")
+	})
+
 	it("captureGrpcResponseSize records histogram with correct name, value, and attributes", () => {
 		const provider = new FakeProvider()
 		const service = createTelemetryService(provider)


### PR DESCRIPTION
### Related Issue

**Issue:** N/A - internal onboarding/funnel telemetry follow-up

### Description

Adds a small semantic telemetry event, `task.awaiting_user_action`, for task states where the agent is no longer actively streaming and is waiting on the user instead of reaching `task.completed`.

This is intentionally scoped to the ambiguity we saw in the `agent_turn -> task_completed` funnel:

- Captures approval waits from existing SDK interaction boundaries: tool approval, command approval, MCP approval, and subagent approval.
- Captures follow-up waits from `ask_question`.
- Captures mistake-limit recovery prompts.
- Captures SDK turn-end states where no `attempt_completion` was seen, using `turn_finished_without_completion` unless the turn ended on a specific ask like `api_req_failed`.
- Attaches only low-cardinality task context: `ulid`, `awaitingType`, `askType`, provider, model id, mode, and timestamp.

Scope management:

- No prompt text, tool input, model output, or user response content is emitted.
- No new info logs are added.
- No trace sampling behavior is changed.
- This does not attempt to add cancellation telemetry; it only records user-waiting task states.

### Test Procedure

- `bun run --cwd apps/vscode format:fix`
- `bun run --cwd apps/vscode check-types`
- `cd apps/vscode && bun run test:vitest src/sdk/sdk-interaction-coordinator.test.ts src/sdk/sdk-session-event-coordinator.test.ts`
- `cd apps/vscode && bun scripts/run-bun-tests.ts src/services/telemetry/__tests__/TelemetryService.metrics.test.ts`
- `git diff --check`

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - telemetry-only change.

### Additional Notes

This is meant to complement, not replace, the existing provider/streaming telemetry. Provider failures still flow through `task.provider_api_error`; this event marks the user-facing task state when the task is blocked waiting for the user or ends a turn without `attempt_completion`.
