### PR TITLE
fix(core): use curated default for legacy migration

### DIFF
--- a/sdk/packages/core/src/services/storage/provider-settings-legacy-migration.test.ts
+++ b/sdk/packages/core/src/services/storage/provider-settings-legacy-migration.test.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import * as LlmsModels from "@cline/llms";
 import { afterEach, describe, expect, it } from "vitest";
 import {
 	type LegacyClineUserInfo,
@@ -146,9 +147,13 @@ describe("migrateLegacyProviderSettings", () => {
 		expect(manager.getProviderSettings("openai")?.apiKey).toBe(
 			"already-migrated",
 		);
+		const anthropicDefault =
+			LlmsModels.getProviderCollectionSync("anthropic")?.provider
+				.defaultModelId;
+		expect(anthropicDefault).toBeDefined();
 		expect(manager.getProviderSettings("anthropic")).toEqual({
 			provider: "anthropic",
-			model: "claude-fable-5",
+			model: anthropicDefault,
 			apiKey: "legacy-key",
 		});
 		expect(manager.read().providers.openai?.tokenSource).toBe("manual");

--- a/sdk/packages/core/src/services/storage/provider-settings-legacy-migration.ts
+++ b/sdk/packages/core/src/services/storage/provider-settings-legacy-migration.ts
@@ -416,6 +416,12 @@ function resolveLegacyCodexAuth(
 
 function getDefaultModelForProvider(providerId: string): string | undefined {
 	const builtInModels = LlmsModels.getGeneratedModelsForProvider(providerId);
+	const providerCollection = LlmsModels.getProviderCollectionSync(providerId);
+	const defaultModelId = providerCollection?.provider.defaultModelId;
+	if (defaultModelId && builtInModels[defaultModelId]) {
+		return defaultModelId;
+	}
+
 	const firstModelId = Object.keys(builtInModels)[0];
 	return firstModelId ?? undefined;
 }


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Legacy provider migration was using the first generated model as the fallback default. Because generated models are sorted by release date, Anthropic migrations started depending on whichever Claude model was newest in the catalog.

This changes the fallback to prefer the provider's curated default model when that default exists in the generated model set, then falls back to the previous first-generated-model behavior. That keeps the existing behavior for providers without generated catalog defaults, such as OpenAI Codex OAuth migration.

### Test Procedure

Ran focused local checks in a fresh worktree:

- `bun install --frozen-lockfile`
- `bun -F @cline/shared build`
- `bun -F @cline/llms build`
- `bun -F @cline/agents build`
- `bunx vitest run --config vitest.config.ts sdk/packages/core/src/services/storage/provider-settings-legacy-migration.test.ts -t "migrates missing providers without overwriting existing providers"`
- `bunx vitest run --config vitest.config.ts sdk/packages/core/src/services/storage/provider-settings-legacy-migration.test.ts`
- `bunx biome check sdk/packages/core/src/services/storage/provider-settings-legacy-migration.ts sdk/packages/core/src/services/storage/provider-settings-legacy-migration.test.ts`

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

This intentionally does not hard-code the current Anthropic default in the test, so future intentional default changes do not break the migration test.
