### PR TITLE
fix(core): tolerate string agent message content

### DIFF
--- a/sdk/packages/core/src/runtime/config/agent-message-codec.test.ts
+++ b/sdk/packages/core/src/runtime/config/agent-message-codec.test.ts
@@ -198,4 +198,69 @@ describe("agent message codec", () => {
 			},
 		]);
 	});
+
+	it("filters blank string agent message content before decoding", () => {
+		const persisted = agentMessageToMessageWithMetadata({
+			id: "msg_blank_content",
+			role: "assistant",
+			createdAt: 1,
+			content: " \n\t ",
+		} as unknown as AgentMessage);
+
+		expect(persisted.content).toEqual([]);
+
+		expect(
+			agentMessagesToMessages([
+				{
+					id: "msg_empty_content",
+					role: "assistant",
+					createdAt: 1,
+					content: "",
+				} as unknown as AgentMessage,
+			]),
+		).toEqual([
+			{
+				role: "assistant",
+				content: [],
+			},
+		]);
+	});
+
+	it("tolerates single-part and unknown agent message content before decoding", () => {
+		const singlePart = agentMessageToMessageWithMetadata({
+			id: "msg_single_part",
+			role: "assistant",
+			createdAt: 1,
+			content: { type: "text", text: "single text part" },
+		} as unknown as AgentMessage);
+
+		expect(singlePart.content).toEqual([
+			{ type: "text", text: "single text part" },
+		]);
+
+		const nullContent = agentMessageToMessageWithMetadata({
+			id: "msg_null_content",
+			role: "assistant",
+			createdAt: 1,
+			content: null,
+		} as unknown as AgentMessage);
+
+		expect(nullContent.content).toEqual([]);
+
+		expect(
+			agentMessagesToMessages([
+				{
+					id: "msg_unknown_content",
+					role: "assistant",
+					createdAt: 1,
+					content: { text: "missing type" },
+				} as unknown as AgentMessage,
+			]),
+		).toEqual([
+			{
+				role: "assistant",
+				content: [],
+			},
+		]);
+	});
 });

--- a/sdk/packages/core/src/runtime/config/agent-message-codec.test.ts
+++ b/sdk/packages/core/src/runtime/config/agent-message-codec.test.ts
@@ -1,9 +1,10 @@
-import { EMPTY_CONTENT_TEXT } from "@cline/shared";
+import { type AgentMessage, EMPTY_CONTENT_TEXT } from "@cline/shared";
 import { describe, expect, it } from "vitest";
 import {
+	agentMessagesToMessages,
 	agentMessageToMessageWithMetadata,
-	messageToAgentMessages,
 	messagesToAgentMessages,
+	messageToAgentMessages,
 } from "./agent-message-codec";
 
 describe("agent message codec", () => {
@@ -167,5 +168,34 @@ describe("agent message codec", () => {
 				signature: "sig_4",
 			},
 		});
+	});
+
+	it("normalizes string agent message content before decoding", () => {
+		const persisted = agentMessageToMessageWithMetadata({
+			id: "msg_string_content",
+			role: "assistant",
+			createdAt: 1,
+			content: "plain text payload",
+		} as unknown as AgentMessage);
+
+		expect(persisted.content).toEqual([
+			{ type: "text", text: "plain text payload" },
+		]);
+
+		expect(
+			agentMessagesToMessages([
+				{
+					id: "msg_tool_string_content",
+					role: "tool",
+					createdAt: 1,
+					content: "tool output",
+				} as unknown as AgentMessage,
+			]),
+		).toEqual([
+			{
+				role: "user",
+				content: [{ type: "text", text: "tool output" }],
+			},
+		]);
 	});
 });

--- a/sdk/packages/core/src/runtime/config/agent-message-codec.test.ts
+++ b/sdk/packages/core/src/runtime/config/agent-message-codec.test.ts
@@ -412,4 +412,69 @@ describe("agent message codec", () => {
 			},
 		]);
 	});
+
+	it("filters blank string agent message content before decoding", () => {
+		const persisted = agentMessageToMessageWithMetadata({
+			id: "msg_blank_content",
+			role: "assistant",
+			createdAt: 1,
+			content: " \n\t ",
+		} as unknown as AgentMessage);
+
+		expect(persisted.content).toEqual([]);
+
+		expect(
+			agentMessagesToMessages([
+				{
+					id: "msg_empty_content",
+					role: "assistant",
+					createdAt: 1,
+					content: "",
+				} as unknown as AgentMessage,
+			]),
+		).toEqual([
+			{
+				role: "assistant",
+				content: [],
+			},
+		]);
+	});
+
+	it("tolerates single-part and unknown agent message content before decoding", () => {
+		const singlePart = agentMessageToMessageWithMetadata({
+			id: "msg_single_part",
+			role: "assistant",
+			createdAt: 1,
+			content: { type: "text", text: "single text part" },
+		} as unknown as AgentMessage);
+
+		expect(singlePart.content).toEqual([
+			{ type: "text", text: "single text part" },
+		]);
+
+		const nullContent = agentMessageToMessageWithMetadata({
+			id: "msg_null_content",
+			role: "assistant",
+			createdAt: 1,
+			content: null,
+		} as unknown as AgentMessage);
+
+		expect(nullContent.content).toEqual([]);
+
+		expect(
+			agentMessagesToMessages([
+				{
+					id: "msg_unknown_content",
+					role: "assistant",
+					createdAt: 1,
+					content: { text: "missing type" },
+				} as unknown as AgentMessage,
+			]),
+		).toEqual([
+			{
+				role: "assistant",
+				content: [],
+			},
+		]);
+	});
 });

--- a/sdk/packages/core/src/runtime/config/agent-message-codec.test.ts
+++ b/sdk/packages/core/src/runtime/config/agent-message-codec.test.ts
@@ -1,7 +1,12 @@
-import { EMPTY_CONTENT_TEXT, type MessageWithMetadata } from "@cline/shared";
+import {
+	type AgentMessage,
+	EMPTY_CONTENT_TEXT,
+	type MessageWithMetadata,
+} from "@cline/shared";
 import { describe, expect, it } from "vitest";
 import { projectSessionMessagesForDisplay } from "../../session/display-messages";
 import {
+	agentMessagesToMessages,
 	agentMessageToMessageWithMetadata,
 	messagesToAgentMessages,
 	messageToAgentMessages,
@@ -376,6 +381,35 @@ describe("agent message codec", () => {
 			"msg_mixed",
 			"msg_mixed_tool_call_a",
 			"msg_mixed_tool_call_b",
+		]);
+	});
+
+	it("normalizes string agent message content before decoding", () => {
+		const persisted = agentMessageToMessageWithMetadata({
+			id: "msg_string_content",
+			role: "assistant",
+			createdAt: 1,
+			content: "plain text payload",
+		} as unknown as AgentMessage);
+
+		expect(persisted.content).toEqual([
+			{ type: "text", text: "plain text payload" },
+		]);
+
+		expect(
+			agentMessagesToMessages([
+				{
+					id: "msg_tool_string_content",
+					role: "tool",
+					createdAt: 1,
+					content: "tool output",
+				} as unknown as AgentMessage,
+			]),
+		).toEqual([
+			{
+				role: "user",
+				content: [{ type: "text", text: "tool output" }],
+			},
 		]);
 	});
 });

--- a/sdk/packages/core/src/runtime/config/agent-message-codec.ts
+++ b/sdk/packages/core/src/runtime/config/agent-message-codec.ts
@@ -137,7 +137,7 @@ function normalizeAgentMessageParts(content: unknown): AgentMessagePart[] {
 		return content;
 	}
 	if (typeof content === "string") {
-		return [{ type: "text", text: content }];
+		return content.trim().length > 0 ? [{ type: "text", text: content }] : [];
 	}
 	if (content && typeof content === "object" && "type" in content) {
 		return [content as AgentMessagePart];

--- a/sdk/packages/core/src/runtime/config/agent-message-codec.ts
+++ b/sdk/packages/core/src/runtime/config/agent-message-codec.ts
@@ -86,7 +86,7 @@ export function messagesToAgentMessages(
 export function agentMessageToMessageWithMetadata(
 	message: AgentMessage,
 ): MessageWithMetadata {
-	const content = message.content
+	const content = normalizeAgentMessageParts(message.content)
 		.map(agentPartToContentBlock)
 		.filter((block): block is ContentBlock => block !== undefined);
 	return {
@@ -111,7 +111,7 @@ export function agentMessagesToMessages(
 ): Message[] {
 	const out: Message[] = [];
 	for (const message of messages) {
-		const content = message.content
+		const content = normalizeAgentMessageParts(message.content)
 			.map(agentPartToContentBlock)
 			.filter((block): block is ContentBlock => block !== undefined);
 		const role = message.role === "tool" ? "user" : message.role;
@@ -130,6 +130,19 @@ export function agentMessagesToMessages(
 		out.push({ role, content });
 	}
 	return out;
+}
+
+function normalizeAgentMessageParts(content: unknown): AgentMessagePart[] {
+	if (Array.isArray(content)) {
+		return content;
+	}
+	if (typeof content === "string") {
+		return [{ type: "text", text: content }];
+	}
+	if (content && typeof content === "object" && "type" in content) {
+		return [content as AgentMessagePart];
+	}
+	return [];
 }
 
 function normalizeContentBlocks(content: Message["content"]): ContentBlock[] {

--- a/sdk/packages/core/src/runtime/config/agent-message-codec.ts
+++ b/sdk/packages/core/src/runtime/config/agent-message-codec.ts
@@ -121,7 +121,7 @@ export function messagesToAgentMessages(
 export function agentMessageToMessageWithMetadata(
 	message: AgentMessage,
 ): MessageWithMetadata {
-	const content = message.content
+	const content = normalizeAgentMessageParts(message.content)
 		.map(agentPartToContentBlock)
 		.filter((block): block is ContentBlock => block !== undefined);
 	return {
@@ -146,7 +146,7 @@ export function agentMessagesToMessages(
 ): Message[] {
 	const out: Message[] = [];
 	for (const message of messages) {
-		const content = message.content
+		const content = normalizeAgentMessageParts(message.content)
 			.map(agentPartToContentBlock)
 			.filter((block): block is ContentBlock => block !== undefined);
 		const role = message.role === "tool" ? "user" : message.role;
@@ -165,6 +165,19 @@ export function agentMessagesToMessages(
 		out.push({ role, content });
 	}
 	return out;
+}
+
+function normalizeAgentMessageParts(content: unknown): AgentMessagePart[] {
+	if (Array.isArray(content)) {
+		return content;
+	}
+	if (typeof content === "string") {
+		return [{ type: "text", text: content }];
+	}
+	if (content && typeof content === "object" && "type" in content) {
+		return [content as AgentMessagePart];
+	}
+	return [];
 }
 
 function normalizeContentBlocks(content: Message["content"]): ContentBlock[] {

--- a/sdk/packages/core/src/runtime/config/agent-message-codec.ts
+++ b/sdk/packages/core/src/runtime/config/agent-message-codec.ts
@@ -172,7 +172,7 @@ function normalizeAgentMessageParts(content: unknown): AgentMessagePart[] {
 		return content;
 	}
 	if (typeof content === "string") {
-		return [{ type: "text", text: content }];
+		return content.trim().length > 0 ? [{ type: "text", text: content }] : [];
 	}
 	if (content && typeof content === "object" && "type" in content) {
 		return [content as AgentMessagePart];


### PR DESCRIPTION
Fixes #12004

The agent message codec assumed `AgentMessage.content` is always an array and called `.map()` directly in both decode paths. Runtime or serialized payloads can still reach this boundary with string content, which crashes CLI sessions with `content.map is not a function`.

This keeps the change scoped to the decode boundary:
- existing array content is unchanged
- string content is normalized to a text part
- single part-shaped objects are wrapped
- null/unknown content no longer crashes
- regression test covers single-message and batch decode paths

Validation:
- `../../../node_modules/.bin/vitest run --config vitest.config.ts src/runtime/config/agent-message-codec.test.ts`
- `./node_modules/.bin/biome check --diagnostic-level=error sdk/packages/core/src/runtime/config/agent-message-codec.ts sdk/packages/core/src/runtime/config/agent-message-codec.test.ts`
- `../../../node_modules/.bin/tsc -p tsconfig.smoke.json --noEmit`
- `git diff --check`