### PR TITLE
fix: advertise run_commands as shell strings

### DIFF
--- a/sdk/packages/core/src/extensions/tools/definitions.test.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.test.ts
@@ -16,6 +16,19 @@ import { RUN_COMMAND_QUERY_PREVIEW_LIMIT, TimeoutError } from "./helpers";
 import { INPUT_ARG_CHAR_LIMIT } from "./schemas";
 import type { SkillsExecutorWithMetadata } from "./types";
 
+function hasSchemaKey(value: unknown, key: string): boolean {
+	if (Array.isArray(value)) {
+		return value.some((item) => hasSchemaKey(item, key));
+	}
+	if (value && typeof value === "object") {
+		return Object.entries(value).some(
+			([entryKey, entryValue]) =>
+				entryKey === key || hasSchemaKey(entryValue, key),
+		);
+	}
+	return false;
+}
+
 function createMockSkillsExecutor(
 	fn: (...args: unknown[]) => Promise<string> = async () => "ok",
 	configuredSkills?: SkillsExecutorWithMetadata["configuredSkills"],
@@ -608,6 +621,62 @@ describe("default run_commands tool", () => {
 				iteration: 1,
 			}),
 		);
+	});
+
+	it("accepts mixed structured and string command arrays", async () => {
+		const execute = vi.fn(
+			async (command: string | { command: string; args?: string[] }) =>
+				typeof command === "string"
+					? `ran:${command}`
+					: `ran:${command.command}:${(command.args ?? []).join(",")}`,
+		);
+		const tool = createShellTool(execute);
+
+		const result = await tool.execute(
+			{
+				commands: ["pwd", { command: "node", args: ["--version"] }],
+			} as never,
+			{
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 1,
+			},
+		);
+
+		expect(result).toEqual([
+			{ query: "pwd", result: "ran:pwd", success: true },
+			{
+				query: "node --version",
+				result: "ran:node:--version",
+				success: true,
+			},
+		]);
+		expect(execute).toHaveBeenNthCalledWith(
+			1,
+			"pwd",
+			process.cwd(),
+			expect.objectContaining({ iteration: 1 }),
+		);
+		expect(execute).toHaveBeenNthCalledWith(
+			2,
+			{ command: "node", args: ["--version"] },
+			process.cwd(),
+			expect.objectContaining({ iteration: 1 }),
+		);
+	});
+
+	it("rejects invalid text-object command entries", async () => {
+		const execute = vi.fn(async () => "ran");
+		const tool = createShellTool(execute);
+
+		await expect(
+			tool.execute({ commands: [{ $text: "pwd" }] } as never, {
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 1,
+			}),
+		).rejects.toThrow("Invalid input");
+		expect(execute).not.toHaveBeenCalled();
 	});
 
 	it("preserves args on direct structured command objects", async () => {
@@ -1495,6 +1564,22 @@ describe("default read_files tool", () => {
 });
 
 describe("zod schema conversion", () => {
+	it("advertises run_commands as string-only command arrays", () => {
+		const tool = createShellTool(async () => "ok");
+		const inputSchema = tool.inputSchema as Record<string, unknown>;
+		const serialized = JSON.stringify(inputSchema);
+
+		expect(serialized).not.toContain('"anyOf"');
+		expect(serialized).not.toContain("Prefer structured");
+		expect(hasSchemaKey(inputSchema, "command")).toBe(false);
+
+		const properties = inputSchema.properties as Record<string, unknown>;
+		const commands = properties.commands as {
+			items?: { type?: string };
+		};
+		expect(commands.items?.type).toBe("string");
+	});
+
 	it("preserves read_files required properties in generated JSON schema", () => {
 		const tool = createReadFilesTool(async () => "ok");
 		const inputSchema = tool.inputSchema as Record<string, unknown>;

--- a/sdk/packages/core/src/extensions/tools/definitions.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.ts
@@ -49,8 +49,8 @@ import {
 	SearchCodebaseInputSchema,
 	SearchCodebaseUnionInputSchema,
 	type SkillsInput,
-	type StructuredCommandInput,
 	SkillsInputSchema,
+	type StructuredCommandInput,
 	type SubmitInput,
 	SubmitInputSchema,
 } from "./schemas";
@@ -415,7 +415,7 @@ export function createShellTool(
 			? "Run non-interactive shell commands from the root of the workspace in Windows environment. " +
 				RUN_COMMANDS_SHARED_INSTRUCTIONS +
 				`Output beyond ~${Math.round(MAX_COMMAND_OUTPUT_CHARS / 1000)}k characters is middle-truncated (start and end preserved); filter output when you need specific sections. ` +
-				"Prefer structured { command, args } entries for portability; plain string commands should be properly shell-escaped. Include multiple commands in the same call when they are independent and safe to run concurrently. When independent reads, searches, or edits are also needed, call those tools in the same response."
+				"Commands run through PowerShell; quote paths and arguments for PowerShell and use ';' to sequence commands. Include multiple commands in the same call when they are independent and safe to run concurrently. When independent reads, searches, or edits are also needed, call those tools in the same response."
 			: "Run non-interactive shell commands from the root of the workspace. " +
 				RUN_COMMANDS_SHARED_INSTRUCTIONS +
 				"Commands should be properly shell-escaped and targeted to avoid error or timeout. Include multiple commands in the same call when they are independent complete shell commands and safe to run concurrently; multiline scripts and heredocs must be a single command string. When independent reads, searches, or edits are also needed, call those tools in the same response. " +

--- a/sdk/packages/core/src/extensions/tools/schemas.ts
+++ b/sdk/packages/core/src/extensions/tools/schemas.ts
@@ -120,19 +120,14 @@ export const StructuredCommandEntrySchema = z.union([
 	StructuredCommandInputSchema,
 ]);
 
-/**
- * Schema for run_commands tool input.
- *
- * Supports both shell strings and direct structured `{ command, args }` entries
- * on every platform. Plain strings are interpreted by the active shell;
- * structured entries bypass shell parsing and execute the command directly.
- */
 export const RunCommandsInputSchema = z.object({
 	commands: z
-		.array(StructuredCommandEntrySchema)
-		.describe(
-			"Array of commands to execute. Prefer structured { command, args } entries for portability; plain strings are still supported and are interpreted by the active shell.",
-		),
+		.array(CommandInputSchema)
+		.describe("Array of complete shell command strings to execute."),
+});
+
+const StructuredCommandsInputSchema = z.object({
+	commands: z.array(StructuredCommandEntrySchema),
 });
 
 /**
@@ -140,6 +135,7 @@ export const RunCommandsInputSchema = z.object({
  */
 export const RunCommandsInputUnionSchema = z.union([
 	RunCommandsInputSchema,
+	StructuredCommandsInputSchema,
 	z.object({ commands: StructuredCommandEntrySchema }),
 	z.array(StructuredCommandInputSchema),
 	StructuredCommandInputSchema,


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This PR changes the advertised `run_commands` tool schema back to shell command strings:

```json
{
  "commands": ["python3 --version && pip3 --version"]
}
```

while keeping the existing runtime parser tolerant of structured command inputs:

```json
{
  "commands": [{ "command": "python3", "args": ["--version"] }]
}
```

The bug was that we were advertising structured `{ command, args }` command entries to every provider/platform. That shape is valid for direct process execution, but it is a poor fit for the normal shell-command semantics of `run_commands`, especially when the model needs shell syntax like `&&`, pipes, redirects, `cd`, environment assignments, or compound commands.

I think this was accidental overexposure rather than an intentional all-platform contract:

- `f3080423300877db1829141761a2b8276421a86b` introduced the structured command schema for the Windows shell tool path.
- That made sense as a Windows portability/execution concern.
- `f2af0d700cb0428a3c24a647087c5f65acc090b8` later unified/simplified terminal execution and made `RunCommandsInputSchema` advertise structured entries generally.
- The runtime already accepted flexible inputs, but the provider-visible schema became the broadest internal schema instead of the user-facing shell-command schema.

This PR restores the narrower public contract:

- Advertised schema: `commands: string[]`
- Runtime compatibility: still accepts structured command objects and mixed arrays
- Windows wording: no longer tells models to prefer `{ command, args }`

That keeps backward compatibility for already-produced structured inputs without continuing to teach models the wrong shape.

### Test Procedure

Unit/build validation:

- `bun biome check --write sdk/packages/core/src/extensions/tools/schemas.ts sdk/packages/core/src/extensions/tools/definitions.ts sdk/packages/core/src/extensions/tools/definitions.test.ts`
- `bun -F @cline/core test:unit -- src/extensions/tools/definitions.test.ts`
- `bun -F @cline/core test:unit -- src/extensions/tools/executors/bash.test.ts`
- `bun -F @cline/core test:unit -- src/extensions/tools`
- `bun -F @cline/core typecheck`
- `bun -F @cline/core build`
- `bun -F @cline/cli test -- src/tui/utils/tool-errors.test.ts src/commands/history.test.ts`
- `bun -F @cline/cli typecheck`
- `bun -F @cline/cli build`

Added focused tests that prove:

- The generated provider-visible JSON schema for `run_commands` has `commands.items.type === "string"`.
- The advertised schema contains no `anyOf`.
- The advertised schema contains no `command` key.
- Runtime still accepts mixed string/structured arrays.
- Invalid text-object entries like `{ "$text": "pwd" }` are rejected before execution.

Live Linux proof:

- Built and ran the fixed branch inside local Docker Linux with Linux `node_modules`.
- Ran a Terminal-Bench-style pyknotid prompt against MiniMax M3 through the CLI.
- Stopped each attempt after the first observed `run_commands` call.
- Result: `10/10 good`, `0 bad`, `0 no_run_commands`.
- Every observed first `run_commands` input used `commands: string[]`.

Captured wire request proof:

- Enabled provider request capture with:
  - `CLINE_CAPTURE_PROVIDER_REQUEST=full`
  - `CLINE_CAPTURE_WIRE=true`
  - `CLINE_CAPTURE_CLEANUP=off`
- Verified the captured OpenRouter wire request had:
  - `run_commands.parameters.properties.commands.items.type = "string"`
  - no `anyOf`
  - no schema key named `command`

Provider replay proof from that captured fixed request:

- MiniMax M3: clean, `0 bad`
- DeepSeek V4 Flash: clean, `0 bad`
- GLM 5.2: clean, `0 bad`
- Kimi K2.7 Code: clean, `0 bad`

The main regression risk is breaking any caller that sends structured commands. That path is intentionally still accepted by `RunCommandsInputUnionSchema`, and the new tests cover mixed string/structured arrays.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. No UI changes.

### Additional Notes

This is intentionally minimal: it changes the provider-visible contract and prompt wording, while leaving runtime compatibility in place.
