### PR TITLE
fix(vscode): forward the configured Claude Code CLI path to SDK sessions

### DIFF
--- a/.changeset/claude-code-cli-path.md
+++ b/.changeset/claude-code-cli-path.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Forward the configured Claude Code CLI path to SDK sessions and the standalone API handler, and fail fast on an invalid path instead of silently running a different binary

--- a/apps/vscode/src/sdk/claude-code-config.test.ts
+++ b/apps/vscode/src/sdk/claude-code-config.test.ts
@@ -1,0 +1,37 @@
+import type { ApiConfiguration } from "@shared/api"
+import { describe, expect, it } from "vitest"
+import { buildClaudeCodeProviderConfig } from "./claude-code-config"
+
+describe("buildClaudeCodeProviderConfig", () => {
+	it("forwards the configured executable path as the provider's pathToClaudeCodeExecutable", () => {
+		const config: ApiConfiguration = { claudeCodePath: "/opt/homebrew/bin/claude" }
+
+		expect(buildClaudeCodeProviderConfig(config)).toEqual({
+			claudeCode: {
+				defaultSettings: { pathToClaudeCodeExecutable: "/opt/homebrew/bin/claude" },
+			},
+		})
+	})
+
+	it("trims surrounding whitespace pasted into the settings field", () => {
+		const config: ApiConfiguration = { claudeCodePath: "  /usr/local/bin/claude\n" }
+
+		expect(buildClaudeCodeProviderConfig(config)).toEqual({
+			claudeCode: {
+				defaultSettings: { pathToClaudeCodeExecutable: "/usr/local/bin/claude" },
+			},
+		})
+	})
+
+	it("emits no override when the setting is unset", () => {
+		expect(buildClaudeCodeProviderConfig({})).toEqual({})
+	})
+
+	it("emits no override when the setting was cleared to blank", () => {
+		// A blank string must not reach the provider: emitting the key at all
+		// suppresses the bundled/PATH fallback, so an empty value would pin the
+		// session to an empty executable path.
+		expect(buildClaudeCodeProviderConfig({ claudeCodePath: "" })).toEqual({})
+		expect(buildClaudeCodeProviderConfig({ claudeCodePath: "   " })).toEqual({})
+	})
+})

--- a/apps/vscode/src/sdk/claude-code-config.ts
+++ b/apps/vscode/src/sdk/claude-code-config.ts
@@ -1,0 +1,37 @@
+// Maps the extension's legacy `claudeCodePath` ApiConfiguration field onto the
+// SDK's structured Claude Code provider options (ProviderConfig.claudeCode).
+//
+// The settings UI persists the executable path, but the SDK-era provider never
+// read it (#11908). buildSessionConfig() and buildSdkProviderConfig() both use
+// this mapper. The provider module only runs its own bundled/PATH resolution
+// when pathToClaudeCodeExecutable is undefined, so emitting the key is what
+// makes the configured path win -- and a blank setting must emit nothing.
+
+import type { ProviderConfig } from "@cline/llms"
+import type { ApiConfiguration } from "@shared/api"
+
+export type ClaudeCodeProviderConfig = Pick<ProviderConfig, "claudeCode">
+
+function trimString(value: unknown): string | undefined {
+	if (typeof value !== "string") {
+		return undefined
+	}
+
+	return value.trim()
+}
+
+export function buildClaudeCodeProviderConfig(config: ApiConfiguration): ClaudeCodeProviderConfig {
+	const pathToClaudeCodeExecutable = trimString(config.claudeCodePath)
+
+	// Unset or cleared-to-blank means "no override": leave the provider's own
+	// bundled/PATH resolution untouched.
+	if (pathToClaudeCodeExecutable === undefined || pathToClaudeCodeExecutable.length === 0) {
+		return {}
+	}
+
+	return {
+		claudeCode: {
+			defaultSettings: { pathToClaudeCodeExecutable },
+		},
+	}
+}

--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -426,6 +426,26 @@ describe("buildSessionConfig", () => {
 		expect(config.providerConfig).not.toHaveProperty("apiKey")
 	})
 
+	it("forwards the configured Claude Code executable path", async () => {
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "claude-code",
+			actModeApiModelId: "opus",
+			claudeCodePath: " /Users/test/.local/bin/claude ",
+		} as any)
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+
+		expect(config.providerConfig).toMatchObject({
+			providerId: "claude-code",
+			modelId: "opus",
+			claudeCode: {
+				defaultSettings: {
+					pathToClaudeCodeExecutable: "/Users/test/.local/bin/claude",
+				},
+			},
+		})
+	})
+
 	it("passes OpenAI Compatible max output tokens as an explicit request limit", async () => {
 		mocks.stateManager.getApiConfiguration.mockReturnValue({
 			actModeApiProvider: "openai",

--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -446,6 +446,19 @@ describe("buildSessionConfig", () => {
 		})
 	})
 
+	it("omits a blank Claude Code executable path", async () => {
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "claude-code",
+			actModeApiModelId: "opus",
+			claudeCodePath: "   ",
+		} as any)
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+
+		expect(config.providerConfig).toMatchObject({ providerId: "claude-code", modelId: "opus" })
+		expect(config.providerConfig).not.toHaveProperty("claudeCode")
+	})
+
 	it("passes OpenAI Compatible max output tokens as an explicit request limit", async () => {
 		mocks.stateManager.getApiConfiguration.mockReturnValue({
 			actModeApiProvider: "openai",

--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -20,6 +20,7 @@ import {
 } from "./cline-session-factory"
 import { parseProviderId } from "./model-catalog/provider-id"
 import { createProviderConfigStore } from "./model-catalog/store"
+import { buildSdkProviderConfig } from "./sdk-api-handler"
 
 const mocks = vi.hoisted(() => {
 	const providerSettingsManager = {
@@ -529,6 +530,55 @@ describe("buildSessionConfig", () => {
 		// (open.bigmodel.cn) from apiLine; a pre-filled base URL would win
 		// over that resolution.
 		expect(config.baseUrl).toBeUndefined()
+	})
+
+	it("forwards the configured Claude Code executable so the provider stops ignoring it", async () => {
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "claude-code",
+			actModeApiModelId: "sonnet",
+			claudeCodePath: "  /opt/homebrew/bin/claude  ",
+		} as any)
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+
+		expect(config.providerConfig).toMatchObject({
+			providerId: "claude-code",
+			claudeCode: {
+				defaultSettings: { pathToClaudeCodeExecutable: "/opt/homebrew/bin/claude" },
+			},
+		})
+	})
+
+	it("leaves Claude Code resolution alone when no executable is configured", async () => {
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "claude-code",
+			actModeApiModelId: "sonnet",
+		} as any)
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+
+		expect(config.providerConfig?.providerId).toBe("claude-code")
+		// No key at all, so the provider still resolves the bundled binary/PATH.
+		expect(config.providerConfig && "claudeCode" in config.providerConfig).toBe(false)
+	})
+
+	it("gives sessions and standalone handlers the same Claude Code snapshot", async () => {
+		// Both inference entry points must consume one mapping of the legacy
+		// setting; a second source of truth is how #11908 went unnoticed.
+		const apiConfiguration = {
+			actModeApiProvider: "claude-code",
+			actModeApiModelId: "sonnet",
+			claudeCodePath: "/opt/homebrew/bin/claude",
+		} as const
+		mocks.stateManager.getApiConfiguration.mockReturnValue(apiConfiguration as any)
+
+		const sessionConfig = await buildSessionConfig({ cwd: "/tmp/workspace" })
+		const standaloneConfig = buildSdkProviderConfig(apiConfiguration as any, "act")
+
+		expect(sessionConfig.providerConfig?.claudeCode).toEqual(standaloneConfig.claudeCode)
+		expect(standaloneConfig.claudeCode).toEqual({
+			defaultSettings: { pathToClaudeCodeExecutable: "/opt/homebrew/bin/claude" },
+		})
 	})
 
 	it("falls back to the providers.json apiLine when legacy state has none", async () => {

--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -16,7 +16,7 @@ import {
 	resolveProviderApiKeyFromSettings,
 	type StartSessionResult,
 } from "@cline/core"
-import { getGeneratedModelsForProvider, MODEL_COLLECTIONS_BY_PROVIDER_ID } from "@cline/llms"
+import { getGeneratedModelsForProvider, MODEL_COLLECTIONS_BY_PROVIDER_ID, type ProviderConfig } from "@cline/llms"
 import { buildClineSystemPrompt } from "@cline/shared"
 import type { ApiConfiguration } from "@shared/api"
 import type { HistoryItem } from "@shared/HistoryItem"
@@ -474,6 +474,28 @@ export function resolveVertexProviderConfig(config: ApiConfiguration): Pick<Prov
 	}
 }
 
+/**
+ * Map the legacy `claudeCodePath` setting onto the SDK provider options for the
+ * Claude Code provider. The ai-sdk provider spawns the Claude Code CLI, and
+ * without `pathToClaudeCodeExecutable` the agent SDK falls back to its bundled
+ * binary resolution, which fails for CLI-native installs (e.g. the curl
+ * installer putting `claude` in ~/.local/bin).
+ */
+export function resolveClaudeCodeProviderConfig(config: ApiConfiguration): Pick<ProviderConfig, "claudeCode"> {
+	const executablePath = config.claudeCodePath?.trim()
+	if (!executablePath) {
+		return {}
+	}
+
+	return {
+		claudeCode: {
+			defaultSettings: {
+				pathToClaudeCodeExecutable: executablePath,
+			},
+		},
+	}
+}
+
 export function resolveBaseUrl(providerId: string, config: ApiConfiguration): string | undefined {
 	const baseUrlMap: Record<string, keyof ApiConfiguration> = {
 		anthropic: "anthropicBaseUrl",
@@ -663,16 +685,22 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 	// extension's "openai"). Convert before handing the id to core.
 	const sdkProviderId = toSdkProviderId(providerId)
 
+	// Claude Code runs the local CLI rather than an HTTP endpoint, so the
+	// user-configured executable path has to travel through providerConfig too.
+	const claudeCodeProviderConfig =
+		providerId === "claude-code" && apiConfig ? resolveClaudeCodeProviderConfig(apiConfig) : undefined
+
 	// Always pass a providerConfig so the proxy/CA-aware fetch reaches the SDK
 	// gateway; without it the agent loop uses bare global fetch and corporate
 	// proxy/self-signed CA setups fail on JetBrains and CLI. Cloud providers
 	// additionally need structured options (region/project/auth/SAP OAuth), which core
 	// reads from providerConfig in createAgentModelFromConfig.
-	const cloudProviderConfig = bedrockProviderConfig ?? vertexProviderConfig ?? sapProviderConfig
-	// Spread the cloud config first so the explicit fields below — notably the
+	const structuredProviderConfig =
+		bedrockProviderConfig ?? vertexProviderConfig ?? sapProviderConfig ?? claudeCodeProviderConfig
+	// Spread the structured config first so the explicit fields below — notably the
 	// proxy/CA-aware fetch — can never be clobbered if those types gain matching keys.
 	const providerConfig = {
-		...(cloudProviderConfig ?? {}),
+		...(structuredProviderConfig ?? {}),
 		providerId: sdkProviderId,
 		modelId,
 		...(apiKey ? { apiKey } : {}),

--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -43,6 +43,7 @@ import { ExtensionRegistryInfo } from "@/registry"
 import { getDistinctId } from "@/services/logging/distinctId"
 import { fetch } from "@/shared/net"
 import { type BedrockProviderConfig, buildBedrockProviderConfig } from "./bedrock-config"
+import { buildClaudeCodeProviderConfig, type ClaudeCodeProviderConfig } from "./claude-code-config"
 import { buildAgentHooks } from "./hooks-adapter"
 import { readTaskHistory, resolveDataDir } from "./legacy-state-reader"
 import type { ResolvedModelSelection } from "./model-catalog/contracts"
@@ -787,6 +788,7 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 	let vertexProviderConfig: Pick<ProviderSettings, "gcp" | "region"> | undefined
 	let sapProviderConfig: SapProviderConfig | undefined
 	let ollamaProviderConfig: ReturnType<typeof resolveOllamaProviderConfig> | undefined
+	let claudeCodeProviderConfig: ClaudeCodeProviderConfig | undefined
 
 	try {
 		const stateManager = StateManager.get()
@@ -832,6 +834,13 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 
 			if (providerId === "ollama") {
 				ollamaProviderConfig = resolveOllamaProviderConfig(apiConfig, modelId)
+			}
+
+			// Forward the user's configured Claude Code executable. Without this
+			// the provider resolves the bundled binary (or PATH) and the
+			// persisted setting is silently ignored (#11908).
+			if (providerId === "claude-code") {
+				claudeCodeProviderConfig = buildClaudeCodeProviderConfig(apiConfig)
 			}
 
 			Logger.log(
@@ -988,12 +997,15 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 	// gateway; without it the agent loop uses bare global fetch and corporate
 	// proxy/self-signed CA setups fail on JetBrains and CLI. Cloud providers
 	// additionally need structured options (region/project/auth/SAP OAuth), which core
-	// reads from providerConfig in createAgentModelFromConfig.
-	const cloudProviderConfig = bedrockProviderConfig ?? vertexProviderConfig ?? sapProviderConfig ?? ollamaProviderConfig
-	// Spread the cloud config first so the explicit fields below — notably the
+	// reads from providerConfig in createAgentModelFromConfig. Local CLI-backed
+	// providers (Ollama, Claude Code) use the same slot for their own options.
+	// Only one of these is ever set: each is built under an exclusive provider-id check.
+	const structuredProviderConfig =
+		bedrockProviderConfig ?? vertexProviderConfig ?? sapProviderConfig ?? ollamaProviderConfig ?? claudeCodeProviderConfig
+	// Spread the structured config first so the explicit fields below — notably the
 	// proxy/CA-aware fetch — can never be clobbered if those types gain matching keys.
 	const providerConfig = {
-		...(cloudProviderConfig ?? {}),
+		...(structuredProviderConfig ?? {}),
 		providerId: sdkProviderId,
 		modelId,
 		...(apiKey ? { apiKey } : {}),

--- a/apps/vscode/src/sdk/sdk-api-handler.test.ts
+++ b/apps/vscode/src/sdk/sdk-api-handler.test.ts
@@ -82,4 +82,38 @@ describe("buildSdkProviderConfig", () => {
 		})
 		expect(mocks.providerSettingsManager.getProviderSettings).toHaveBeenCalledWith("v0")
 	})
+
+	it("forwards the configured Claude Code executable path", () => {
+		const providerConfig = buildSdkProviderConfig(
+			{
+				actModeApiProvider: "claude-code",
+				actModeApiModelId: "opus",
+				claudeCodePath: " /Users/test/.local/bin/claude ",
+			},
+			"act",
+		)
+
+		expect(providerConfig).toMatchObject({
+			providerId: "claude-code",
+			modelId: "opus",
+			claudeCode: {
+				defaultSettings: {
+					pathToClaudeCodeExecutable: "/Users/test/.local/bin/claude",
+				},
+			},
+		})
+	})
+
+	it("omits a blank Claude Code executable path", () => {
+		const providerConfig = buildSdkProviderConfig(
+			{
+				actModeApiProvider: "claude-code",
+				actModeApiModelId: "opus",
+				claudeCodePath: "   ",
+			},
+			"act",
+		)
+
+		expect(providerConfig).not.toHaveProperty("claudeCode")
+	})
 })

--- a/apps/vscode/src/sdk/sdk-api-handler.test.ts
+++ b/apps/vscode/src/sdk/sdk-api-handler.test.ts
@@ -104,6 +104,42 @@ describe("buildSdkProviderConfig", () => {
 		})
 	})
 
+	it("forwards the configured Claude Code executable to standalone handlers", () => {
+		mocks.providerSettingsManager.getProviderSettings.mockReturnValue(undefined)
+
+		const providerConfig = buildSdkProviderConfig(
+			{
+				actModeApiProvider: "claude-code",
+				actModeApiModelId: "sonnet",
+				claudeCodePath: "  /opt/homebrew/bin/claude  ",
+			},
+			"act",
+		)
+
+		expect(providerConfig).toMatchObject({
+			providerId: "claude-code",
+			claudeCode: {
+				defaultSettings: { pathToClaudeCodeExecutable: "/opt/homebrew/bin/claude" },
+			},
+		})
+	})
+
+	it("omits the Claude Code override when no executable is configured", () => {
+		mocks.providerSettingsManager.getProviderSettings.mockReturnValue(undefined)
+
+		const providerConfig = buildSdkProviderConfig(
+			{
+				actModeApiProvider: "claude-code",
+				actModeApiModelId: "sonnet",
+			},
+			"act",
+		)
+
+		expect(providerConfig.providerId).toBe("claude-code")
+		// The provider's own bundled-binary/PATH resolution must stay in charge.
+		expect("claudeCode" in providerConfig).toBe(false)
+	})
+
 	it("omits timeoutMs for Ollama when no explicit timeout is configured", () => {
 		mocks.providerSettingsManager.getProviderSettings.mockReturnValue(undefined)
 

--- a/apps/vscode/src/sdk/sdk-api-handler.ts
+++ b/apps/vscode/src/sdk/sdk-api-handler.ts
@@ -12,7 +12,13 @@ import type { ApiConfiguration } from "@shared/api"
 import type { Mode } from "@shared/storage/types"
 import { fetch } from "@/shared/net"
 import { buildBedrockProviderConfig } from "./bedrock-config"
-import { resolveApiKey, resolveBaseUrl, resolveModelId, resolveVertexProviderConfig } from "./cline-session-factory"
+import {
+	resolveApiKey,
+	resolveBaseUrl,
+	resolveClaudeCodeProviderConfig,
+	resolveModelId,
+	resolveVertexProviderConfig,
+} from "./cline-session-factory"
 import { toSdkProviderId } from "./model-catalog/sdk-provider-id"
 
 export interface BuildApiHandlerOptions {
@@ -57,12 +63,17 @@ export function buildSdkProviderConfig(
 
 	const vertexProviderConfig = providerId === "vertex" ? resolveVertexProviderConfig(configuration) : undefined
 
+	// Claude Code spawns the local CLI, so the user-configured executable path
+	// must reach the provider as pathToClaudeCodeExecutable.
+	const claudeCodeProviderConfig = providerId === "claude-code" ? resolveClaudeCodeProviderConfig(configuration) : undefined
+
 	const base: ProviderConfig = {
 		providerId: toSdkProviderId(providerId),
 		modelId: modelId ?? "",
 		apiKey: apiKey ?? "",
 		baseUrl,
 		...(vertexProviderConfig ?? {}),
+		...(claudeCodeProviderConfig ?? {}),
 		// Use the proxy-aware fetch so gateway providers respect corporate proxy
 		// configuration (see .clinerules/network.md).
 		fetch,

--- a/apps/vscode/src/sdk/sdk-api-handler.ts
+++ b/apps/vscode/src/sdk/sdk-api-handler.ts
@@ -13,6 +13,7 @@ import type { Mode } from "@shared/storage/types"
 import { reasoningEffortFromThinkingBudget } from "@shared/utils/reasoning-support"
 import { fetch } from "@/shared/net"
 import { buildBedrockProviderConfig } from "./bedrock-config"
+import { buildClaudeCodeProviderConfig } from "./claude-code-config"
 import {
 	resolveApiKey,
 	resolveBaseUrl,
@@ -82,6 +83,10 @@ export function buildSdkProviderConfig(
 		// ignore an explicit Request Timeout setting and load models with
 		// Ollama's 4096-token server default.
 		...(providerId === "ollama" ? resolveOllamaProviderConfig(configuration, modelId) : {}),
+		// Claude Code spawns a CLI, and the user can configure which executable
+		// to spawn. Without this the configured path is dropped and the provider
+		// falls back to the bundled binary or PATH (#11908).
+		...(providerId === "claude-code" ? buildClaudeCodeProviderConfig(configuration) : {}),
 	}
 
 	if (options?.disableReasoning) {

--- a/sdk/packages/core/src/services/llms/handler-factory.test.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.test.ts
@@ -351,6 +351,85 @@ describe("createAgentModelFromConfig", () => {
 		);
 	});
 
+	it("forwards the configured Claude Code executable alongside the workspace cwd", async () => {
+		const { createAgentModelFromConfig } = await import("./handler-factory");
+
+		createAgentModelFromConfig(
+			{
+				providerId: "claude-code",
+				modelId: "sonnet",
+				systemPrompt: "",
+				tools: [],
+				extensionContext: {
+					workspace: {
+						rootPath: "/home/user/project",
+						cwd: "/home/user/project/packages/app",
+					},
+				},
+				providerConfig: {
+					providerId: "claude-code",
+					modelId: "sonnet",
+					claudeCode: {
+						defaultSettings: {
+							pathToClaudeCodeExecutable: "/opt/homebrew/bin/claude",
+						},
+					},
+				},
+			},
+			undefined,
+		);
+
+		expect(gatewayMock.createGateway).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				providerConfigs: [
+					expect.objectContaining({
+						providerId: "claude-code",
+						options: expect.objectContaining({
+							// The host's configured executable reaches the provider...
+							defaultSettings: {
+								pathToClaudeCodeExecutable: "/opt/homebrew/bin/claude",
+							},
+							// ...without displacing the workspace anchor the CLI needs.
+							cwd: "/home/user/project/packages/app",
+						}),
+					}),
+				],
+			}),
+		);
+	});
+
+	it("lets an explicit Claude Code cwd win over the host workspace", async () => {
+		const { createAgentModelFromConfig } = await import("./handler-factory");
+
+		createAgentModelFromConfig(
+			{
+				providerId: "claude-code",
+				modelId: "sonnet",
+				systemPrompt: "",
+				tools: [],
+				extensionContext: {
+					workspace: { rootPath: "/home/user/project" },
+				},
+				providerConfig: {
+					providerId: "claude-code",
+					modelId: "sonnet",
+					claudeCode: { cwd: "/home/user/other" },
+				},
+			},
+			undefined,
+		);
+
+		expect(gatewayMock.createGateway).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				providerConfigs: [
+					expect.objectContaining({
+						options: expect.objectContaining({ cwd: "/home/user/other" }),
+					}),
+				],
+			}),
+		);
+	});
+
 	it("forwards Vertex GCP settings as gateway provider options", async () => {
 		const { createAgentModelFromConfig } = await import("./handler-factory");
 

--- a/sdk/packages/core/src/services/llms/handler-factory.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.ts
@@ -83,6 +83,12 @@ function buildGatewayProviderOptions(
 		const workspace = config.extensionContext?.workspace;
 		Object.assign(options, {
 			cwd: workspace?.cwd ?? workspace?.rootPath,
+			// Host-mapped Claude Code options (the user's configured executable
+			// path) live on config.claudeCode; mirror @cline/llms's
+			// buildGatewayConfig spread or the session/gateway path drops them.
+			// Spread after cwd so an explicit config wins over the workspace
+			// default.
+			...config.claudeCode,
 		});
 	}
 

--- a/sdk/packages/llms/src/providers/vendors/community.test.ts
+++ b/sdk/packages/llms/src/providers/vendors/community.test.ts
@@ -1,5 +1,32 @@
-import { afterEach, describe, expect, it } from "vitest";
-import { createSapAiCoreProviderModule } from "./community";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	createClaudeCodeProviderModule,
+	createSapAiCoreProviderModule,
+} from "./community";
+
+const claudeCodeMock = vi.hoisted(() => ({
+	createClaudeCode: vi.fn(() => vi.fn()),
+	resolveBundledPackage: vi.fn<(specifier: string) => string>(),
+}));
+
+vi.mock("node:module", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:module")>();
+	return {
+		...actual,
+		createRequire: () => ({ resolve: claudeCodeMock.resolveBundledPackage }),
+	};
+});
+
+// The real provider runs createClaudeCode() at module scope and validates
+// settings against the filesystem. Mocking it keeps these tests about the
+// executable resolution this module owns, and lets them assert the exact
+// settings handed to the provider.
+vi.mock("ai-sdk-provider-claude-code", () => ({
+	createClaudeCode: claudeCodeMock.createClaudeCode,
+}));
 
 const originalServiceKey = process.env.AICORE_SERVICE_KEY;
 
@@ -267,5 +294,213 @@ describe("createSapAiCoreProviderModule", () => {
 				},
 			}),
 		).rejects.toThrow(/baseUrl/);
+	});
+});
+
+describe("createClaudeCodeProviderModule", () => {
+	const originalPath = process.env.PATH;
+	const temporaryDirectories = new Set<string>();
+
+	beforeEach(() => {
+		claudeCodeMock.createClaudeCode.mockClear();
+		claudeCodeMock.resolveBundledPackage.mockReset();
+		claudeCodeMock.resolveBundledPackage.mockImplementation(() => {
+			throw new Error("optional package not installed");
+		});
+	});
+
+	afterEach(() => {
+		process.env.PATH = originalPath;
+		for (const directory of temporaryDirectories) {
+			rmSync(directory, { recursive: true, force: true });
+		}
+		temporaryDirectories.clear();
+	});
+
+	function settingsFromLastCall(): Record<string, unknown> {
+		const [options] = claudeCodeMock.createClaudeCode.mock.calls.at(-1) as [
+			{ defaultSettings: Record<string, unknown> },
+		];
+		return options.defaultSettings;
+	}
+
+	function createExecutable(prefix: string, name: string): string {
+		const directory = mkdtempSync(join(tmpdir(), prefix));
+		temporaryDirectories.add(directory);
+		const executable = join(directory, name);
+		writeFileSync(executable, "#!/bin/sh\n");
+		chmodSync(executable, 0o755);
+		return executable;
+	}
+
+	function createBundledExecutable(): string {
+		const name = process.platform === "win32" ? "claude.exe" : "claude";
+		const executable = createExecutable("cline-claude-code-bundled-", name);
+		const manifest = join(dirname(executable), "package.json");
+		writeFileSync(manifest, "{}");
+		claudeCodeMock.resolveBundledPackage.mockReturnValue(manifest);
+		return executable;
+	}
+
+	function createPathExecutable(): string {
+		const name = process.platform === "win32" ? "claude.exe" : "claude";
+		const executable = createExecutable("cline-claude-code-path-", name);
+		process.env.PATH = dirname(executable);
+		return executable;
+	}
+
+	it("prefers a configured executable over the bundled binary and PATH", async () => {
+		createBundledExecutable();
+		createPathExecutable();
+
+		await createClaudeCodeProviderModule({
+			providerId: "claude-code",
+			options: {
+				cwd: tmpdir(),
+				defaultSettings: { pathToClaudeCodeExecutable: process.execPath },
+			},
+		});
+
+		expect(settingsFromLastCall()).toMatchObject({
+			pathToClaudeCodeExecutable: process.execPath,
+			cwd: tmpdir(),
+		});
+		expect(claudeCodeMock.resolveBundledPackage).not.toHaveBeenCalled();
+	});
+
+	it("prefers the bundled executable over PATH when none is configured", async () => {
+		const bundledExecutable = createBundledExecutable();
+		createPathExecutable();
+
+		await createClaudeCodeProviderModule({
+			providerId: "claude-code",
+			options: { cwd: tmpdir() },
+		});
+
+		expect(settingsFromLastCall()).toMatchObject({
+			pathToClaudeCodeExecutable: bundledExecutable,
+		});
+	});
+
+	it("falls back to PATH when no configured or bundled executable exists", async () => {
+		const pathExecutable = createPathExecutable();
+
+		await createClaudeCodeProviderModule({
+			providerId: "claude-code",
+			options: { cwd: tmpdir() },
+		});
+
+		expect(settingsFromLastCall()).toMatchObject({
+			pathToClaudeCodeExecutable: pathExecutable,
+		});
+	});
+
+	it("resolves a bare command name through PATH and pins the result", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "cline-claude-code-path-"));
+		const name = "cline-test-claude";
+		const resolved = join(dir, name);
+		writeFileSync(resolved, "#!/bin/sh\n");
+		chmodSync(resolved, 0o755);
+		const originalPath = process.env.PATH;
+		process.env.PATH = dir;
+		try {
+			await createClaudeCodeProviderModule({
+				providerId: "claude-code",
+				options: { defaultSettings: { pathToClaudeCodeExecutable: name } },
+			});
+		} finally {
+			process.env.PATH = originalPath;
+			rmSync(dir, { recursive: true, force: true });
+		}
+
+		expect(settingsFromLastCall()).toMatchObject({
+			pathToClaudeCodeExecutable: resolved,
+		});
+	});
+
+	it("fails fast when a bare command name is not on PATH", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "cline-claude-code-path-"));
+		const originalPath = process.env.PATH;
+		process.env.PATH = dir;
+		try {
+			await expect(
+				createClaudeCodeProviderModule({
+					providerId: "claude-code",
+					options: {
+						defaultSettings: {
+							pathToClaudeCodeExecutable: "cline-test-claude-absent",
+						},
+					},
+				}),
+			).rejects.toThrow(
+				"Claude Code CLI Path was not found on PATH: cline-test-claude-absent",
+			);
+		} finally {
+			process.env.PATH = originalPath;
+			rmSync(dir, { recursive: true, force: true });
+		}
+		expect(claudeCodeMock.createClaudeCode).not.toHaveBeenCalled();
+	});
+
+	// accessSync X_OK degrades to a plain existence check on Windows, so the
+	// executable bit is only enforceable on POSIX.
+	it.skipIf(process.platform === "win32")(
+		"fails fast when the configured executable is not executable",
+		async () => {
+			const dir = mkdtempSync(join(tmpdir(), "cline-claude-code-path-"));
+			const plain = join(dir, "not-executable");
+			writeFileSync(plain, "#!/bin/sh\n");
+			chmodSync(plain, 0o644);
+			try {
+				await expect(
+					createClaudeCodeProviderModule({
+						providerId: "claude-code",
+						options: {
+							defaultSettings: { pathToClaudeCodeExecutable: plain },
+						},
+					}),
+				).rejects.toThrow(`Claude Code CLI Path is not executable: ${plain}`);
+			} finally {
+				rmSync(dir, { recursive: true, force: true });
+			}
+			expect(claudeCodeMock.createClaudeCode).not.toHaveBeenCalled();
+		},
+	);
+
+	it("fails fast when the configured executable does not exist", async () => {
+		const missing = join(tmpdir(), "cline-claude-code-does-not-exist");
+
+		await expect(
+			createClaudeCodeProviderModule({
+				providerId: "claude-code",
+				options: {
+					defaultSettings: { pathToClaudeCodeExecutable: missing },
+				},
+			}),
+		).rejects.toThrow(`Claude Code CLI Path does not exist: ${missing}`);
+		expect(claudeCodeMock.createClaudeCode).not.toHaveBeenCalled();
+	});
+
+	it("fails fast when the configured executable is not a file", async () => {
+		await expect(
+			createClaudeCodeProviderModule({
+				providerId: "claude-code",
+				options: {
+					defaultSettings: { pathToClaudeCodeExecutable: tmpdir() },
+				},
+			}),
+		).rejects.toThrow(/Claude Code CLI Path is not a file/);
+		expect(claudeCodeMock.createClaudeCode).not.toHaveBeenCalled();
+	});
+
+	it("fails fast when a blank executable path reaches the provider", async () => {
+		// Hosts are expected to omit the key entirely for a cleared setting; a
+		// blank string would otherwise suppress fallback resolution silently.
+		await expect(
+			createClaudeCodeProviderModule({
+				providerId: "claude-code",
+				options: { defaultSettings: { pathToClaudeCodeExecutable: "  " } },
+			}),
+		).rejects.toThrow(/Claude Code CLI Path is not a valid path/);
 	});
 });

--- a/sdk/packages/llms/src/providers/vendors/community.ts
+++ b/sdk/packages/llms/src/providers/vendors/community.ts
@@ -1,6 +1,11 @@
-import { accessSync, existsSync, constants as fsConstants } from "node:fs";
+import {
+	accessSync,
+	existsSync,
+	constants as fsConstants,
+	statSync,
+} from "node:fs";
 import { createRequire } from "node:module";
-import { delimiter, dirname, join } from "node:path";
+import { basename, delimiter, dirname, join } from "node:path";
 import type { GatewayResolvedProviderConfig } from "@cline/shared";
 // Keep this import static so the VS Code extension bundle includes the SAP
 // provider. Hiding it behind a computed dynamic import leaves the published
@@ -79,6 +84,55 @@ function resolveClaudeExecutable(): string | undefined {
 	return findExecutableOnPath("claude");
 }
 
+// A configured `pathToClaudeCodeExecutable` is an explicit user choice, so
+// validate it and fail loudly instead of falling back: silently spawning some
+// other `claude` than the one the user pointed at hides the misconfiguration
+// behind confusing downstream behavior. A bare command name (the settings
+// placeholder suggests `claude`) is resolved through PATH the way a shell
+// would; paths must pass the same X_OK probe the bundled/PATH candidates do.
+function resolveConfiguredClaudeExecutable(value: unknown): string {
+	const hint =
+		"Set the Claude Code CLI Path to the `claude` executable to use, or clear it to use the bundled executable or one found on PATH.";
+	if (typeof value !== "string" || value.trim().length === 0) {
+		throw new Error(
+			`The configured Claude Code CLI Path is not a valid path. ${hint}`,
+		);
+	}
+	if (basename(value) === value) {
+		const resolved = findExecutableOnPath(value);
+		if (resolved === undefined) {
+			throw new Error(
+				`The configured Claude Code CLI Path was not found on PATH: ${value}. ${hint}`,
+			);
+		}
+		return resolved;
+	}
+	let isFile: boolean;
+	try {
+		isFile = statSync(value).isFile();
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		throw new Error(
+			code === "ENOENT"
+				? `The configured Claude Code CLI Path does not exist: ${value}. ${hint}`
+				: `The configured Claude Code CLI Path could not be read: ${value}. ${hint}`,
+		);
+	}
+	if (!isFile) {
+		throw new Error(
+			`The configured Claude Code CLI Path is not a file: ${value}. ${hint}`,
+		);
+	}
+	try {
+		accessSync(value, fsConstants.X_OK);
+	} catch {
+		throw new Error(
+			`The configured Claude Code CLI Path is not executable: ${value}. ${hint}`,
+		);
+	}
+	return value;
+}
+
 export async function createClaudeCodeProviderModule(
 	config: GatewayResolvedProviderConfig,
 ): Promise<ProviderFactoryResult> {
@@ -101,11 +155,22 @@ export async function createClaudeCodeProviderModule(
 	const defaultSettings: Record<string, unknown> = {
 		...((options.defaultSettings as Record<string, unknown> | undefined) ?? {}),
 	};
+	// Resolution precedence: a configured executable wins, then the bundled
+	// per-platform binary, then a `claude` on PATH. Hosts forward the user's
+	// configured path as defaultSettings.pathToClaudeCodeExecutable (e.g. the
+	// VS Code extension's claudeCodePath setting), so its mere presence is what
+	// suppresses the fallback below -- hosts must omit the key when unset
+	// rather than pass a blank string.
 	if (defaultSettings.pathToClaudeCodeExecutable === undefined) {
 		const executable = resolveClaudeExecutable();
 		if (executable !== undefined) {
 			defaultSettings.pathToClaudeCodeExecutable = executable;
 		}
+	} else {
+		defaultSettings.pathToClaudeCodeExecutable =
+			resolveConfiguredClaudeExecutable(
+				defaultSettings.pathToClaudeCodeExecutable,
+			);
 	}
 	// Hosts forward the workspace root as a top-level `cwd` option (e.g.
 	// @cline/core's buildGatewayProviderOptions). Anchor the spawned agent


### PR DESCRIPTION
### Related Issue

**Issue:** #11908

### Description

The VS Code setting persists `claudeCodePath`, but SDK-based inference never mapped it into `ProviderConfig.claudeCode`. Both new sessions and the standalone API handler therefore ignored the selected executable and fell back to the bundled binary or `PATH`.

This change adds a shared mapper at the VS Code provider-config boundary and uses it from both entry points. It trims `claudeCodePath` into `claudeCode.defaultSettings.pathToClaudeCodeExecutable`; blank or unset values omit the override so the existing fallback remains in charge.

The session path also spreads `config.claudeCode` through `buildGatewayProviderOptions` while preserving the workspace `cwd`. Without this, core drops the mapped setting while the standalone path keeps it. This mirrors `buildGatewayConfig` in `@cline/llms` and covers the cross-package gap described in the [follow-up comment](https://github.com/cline/cline/pull/12039#issuecomment-5505356863).

At provider creation, an explicitly configured executable is validated and never falls back silently. Bare command names are resolved through `PATH` and pinned to the resolved executable. Explicit paths must exist, be files, and pass the executable access check. If no override is configured, the existing bundled-binary-then-`PATH` fallback remains unchanged. Regression tests cover the full configured → bundled → `PATH` precedence.

### Test Procedure

- `bun run build:sdk`
- `bun -F @cline/llms test`: 794 passed, 4 skipped
- `sdk/packages/core/src/services/llms/handler-factory.test.ts`: 19 passed
- VS Code mapper, session-factory, and API-handler suites: 90 passed
- `@cline/llms`, `@cline/core`, and VS Code typechecks passed
- `bun run format` and `bun run lint` completed successfully
- Verified the executable-precedence tests by temporarily breaking each branch independently:
  - configured executable over bundled
  - bundled over `PATH`
  - `PATH` fallback
  Each mutation failed the corresponding test.
- A packaged-extension manual E2E was not run.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality not to work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — no UI changes.

### Additional Notes

Includes a patch changeset for `claude-dev`.
