### PR TITLE
chore(vscode): drop the dead claude_code entry from PROVIDER_API_KEY_MAP

### DIFF
--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -253,7 +253,6 @@ const PROVIDER_API_KEY_MAP: Record<string, keyof ApiConfiguration> = {
 	aihubmix: "aihubmixApiKey",
 	nousResearch: "nousResearchApiKey",
 	"vercel-ai-gateway": "vercelAiGatewayApiKey",
-	claude_code: "apiKey", // Claude Code uses anthropic key
 	wandb: "wandbApiKey",
 	"qwen-code": "qwenApiKey",
 	oca: "ocaApiKey",


### PR DESCRIPTION
### Related Issue

**Issue:** #12040

### Description

Removes the dead `claude_code: "apiKey"` entry from `PROVIDER_API_KEY_MAP`. The canonical provider id is `claude-code` (hyphen), so both `resolveApiKey()` lookups miss this key and the entry has never matched — details in #12040.

Removing rather than renaming, deliberately: renaming the key to `claude-code` would silently start forwarding the legacy Anthropic `apiKey` field to the Claude Code provider, which manages its own auth through the CLI. That would be a behavior change and deserves its own decision — happy to do that instead if it's the intended direction.

### Test Procedure

- Dead-code removal, no behavior change: the lookup already returned `undefined` for `claude-code`, so `resolveApiKey()` takes exactly the same path before and after.
- `vitest src/sdk/cline-session-factory.test.ts src/sdk/sdk-api-handler.test.ts` (49 tests) and `tsc --noEmit` pass.
- Verified `claude_code` appears nowhere else as a provider id (remaining repo hits are snake_case proto field names).

### Type of Change

-   [x] ♻️ Refactor Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
