### PR TITLE
fix(core): keep tool-result message ids stable across persist cycles

### DIFF
--- a/sdk/packages/core/src/runtime/config/agent-message-codec.test.ts
+++ b/sdk/packages/core/src/runtime/config/agent-message-codec.test.ts
@@ -1,3 +1,4 @@
+import type { MessageWithMetadata } from "@cline/shared";
 import { EMPTY_CONTENT_TEXT } from "@cline/shared";
 import { describe, expect, it } from "vitest";
 import {
@@ -167,5 +168,113 @@ describe("agent message codec", () => {
 				signature: "sig_4",
 			},
 		});
+	});
+
+	it("keeps tool-result ids stable across repeated encode/decode cycles", () => {
+		// One encode -> decode round trip. Returns the decoded message so the
+		// caller can feed it back in and prove re-encoding does not grow the id.
+		const cycle = (message: MessageWithMetadata): MessageWithMetadata => {
+			const [encoded] = messageToAgentMessages(message);
+			expect(encoded?.id).toBe("msg_x_tool_call_abc");
+			return agentMessageToMessageWithMetadata(
+				encoded ?? { id: "", role: "user", content: [], createdAt: 0 },
+			);
+		};
+
+		const source: MessageWithMetadata = {
+			id: "msg_x",
+			role: "user",
+			ts: 1,
+			content: [
+				{
+					type: "tool_result",
+					tool_use_id: "call_abc",
+					name: "run_commands",
+					content: "tool output",
+				},
+			],
+		};
+
+		let persisted = source;
+		for (let pass = 0; pass < 3; pass += 1) {
+			persisted = cycle(persisted);
+			expect(persisted.id).toBe("msg_x_tool_call_abc");
+		}
+	});
+
+	it("keeps ids stable for a message with multiple tool results", () => {
+		const first = messageToAgentMessages({
+			id: "msg_multi",
+			role: "user",
+			ts: 1,
+			content: [
+				{
+					type: "tool_result",
+					tool_use_id: "call_a",
+					name: "read_files",
+					content: "a",
+				},
+				{
+					type: "tool_result",
+					tool_use_id: "call_b",
+					name: "read_files",
+					content: "b",
+				},
+			],
+		});
+
+		const firstIds = first.map((message) => message.id);
+		expect(firstIds).toEqual([
+			"msg_multi_tool_call_a",
+			"msg_multi_tool_call_b",
+		]);
+
+		const reEncodedIds = first.flatMap((message) =>
+			messageToAgentMessages(agentMessageToMessageWithMetadata(message)).map(
+				(re) => re.id,
+			),
+		);
+		expect(reEncodedIds).toEqual(firstIds);
+	});
+
+	it("keeps ids distinct across re-encode when text surrounds a tool result", () => {
+		// A tool result with non-tool blocks on BOTH sides splits into three
+		// AgentMessages: baseId, baseId_tool_<id>, baseId_part_1. Only the
+		// `_tool_` suffix may be stripped on re-encode — stripping `_part_1`
+		// would collapse the trailing text segment back onto the base id and
+		// collide with the leading one.
+		const first = messageToAgentMessages({
+			id: "msg_mixed_id",
+			role: "user",
+			ts: 1,
+			content: [
+				{ type: "text", text: "before" },
+				{
+					type: "tool_result",
+					tool_use_id: "call_c",
+					name: "editor",
+					content: "done",
+				},
+				{ type: "text", text: "after" },
+			],
+		});
+
+		expect(first.map((message) => message.id)).toEqual([
+			"msg_mixed_id",
+			"msg_mixed_id_tool_call_c",
+			"msg_mixed_id_part_1",
+		]);
+
+		const reEncoded = first.flatMap((message) =>
+			messageToAgentMessages(agentMessageToMessageWithMetadata(message)).map(
+				(re) => re.id,
+			),
+		);
+		expect(reEncoded).toEqual([
+			"msg_mixed_id",
+			"msg_mixed_id_tool_call_c",
+			"msg_mixed_id_part_1",
+		]);
+		expect(new Set(reEncoded).size).toBe(reEncoded.length);
 	});
 });

--- a/sdk/packages/core/src/runtime/config/agent-message-codec.test.ts
+++ b/sdk/packages/core/src/runtime/config/agent-message-codec.test.ts
@@ -277,4 +277,46 @@ describe("agent message codec", () => {
 		]);
 		expect(new Set(reEncoded).size).toBe(reEncoded.length);
 	});
+
+	it("does not strip a base id that contains _tool_ but is not an encoded suffix", () => {
+		// The base id legitimately ends in `_tool_summary`, which is NOT the
+		// message's tool_use_id (`call_d`). Only a `_tool_<toolUseId>` that
+		// matches an actual tool_use_id in the message is treated as an encoded
+		// suffix, so the base id must survive untouched.
+		const [encoded] = messageToAgentMessages({
+			id: "msg_tool_summary",
+			role: "user",
+			ts: 1,
+			content: [
+				{
+					type: "tool_result",
+					tool_use_id: "call_d",
+					name: "editor",
+					content: "done",
+				},
+			],
+		});
+
+		expect(encoded?.id).toBe("msg_tool_summary_tool_call_d");
+
+		const [reEncoded] = messageToAgentMessages(
+			agentMessageToMessageWithMetadata(
+				encoded ?? { id: "", role: "user", content: [], createdAt: 0 },
+			),
+		);
+		expect(reEncoded?.id).toBe("msg_tool_summary_tool_call_d");
+	});
+
+	it("preserves an empty-string message id", () => {
+		// An empty-string id is a real (if unusual) value, distinct from a
+		// missing id. It must be preserved, not replaced with a generated id.
+		const [encoded] = messageToAgentMessages({
+			id: "",
+			role: "user",
+			ts: 1,
+			content: [{ type: "text", text: "hi" }],
+		});
+
+		expect(encoded?.id).toBe("");
+	});
 });

--- a/sdk/packages/core/src/runtime/config/agent-message-codec.ts
+++ b/sdk/packages/core/src/runtime/config/agent-message-codec.ts
@@ -20,7 +20,9 @@ export function messageToAgentMessages(
 ): AgentMessage[] {
 	const blocks = normalizeContentBlocks(message.content);
 	const out: AgentMessage[] = [];
-	const baseId = message.id ?? generateMessageId();
+	const baseId = message.id
+		? stripEncodedIdSuffix(message.id)
+		: generateMessageId();
 	let nonToolSegmentCount = 0;
 	let nonToolBlocks: Exclude<ContentBlock, ToolResultContent>[] = [];
 
@@ -298,4 +300,20 @@ let msgSeq = 0;
 function generateMessageId(): string {
 	msgSeq += 1;
 	return `msg_${Date.now().toString(36)}_${msgSeq.toString(36)}`;
+}
+
+/**
+ * Strips a trailing `_tool_<toolUseId>` suffix that a previous encode appended
+ * to a tool-result message id, so that re-encoding an already-persisted message
+ * produces a stable, byte-identical id instead of growing the suffix on every
+ * persist cycle.
+ *
+ * Only the `_tool_` suffix is stripped. The `_part_<n>` suffix used for split
+ * non-tool segments must NOT be stripped: on decode each segment becomes its own
+ * single-block message, so re-encoding never regenerates `_part_<n>`. Stripping
+ * it would collapse a `..._part_1` id back to the bare base id and collide with
+ * the message's first segment.
+ */
+function stripEncodedIdSuffix(id: string): string {
+	return id.replace(/_tool_.+$/, "");
 }

--- a/sdk/packages/core/src/runtime/config/agent-message-codec.ts
+++ b/sdk/packages/core/src/runtime/config/agent-message-codec.ts
@@ -20,9 +20,10 @@ export function messageToAgentMessages(
 ): AgentMessage[] {
 	const blocks = normalizeContentBlocks(message.content);
 	const out: AgentMessage[] = [];
-	const baseId = message.id
-		? stripEncodedIdSuffix(message.id)
-		: generateMessageId();
+	const baseId =
+		message.id == null
+			? generateMessageId()
+			: stripEncodedIdSuffix(message.id, blocks);
 	let nonToolSegmentCount = 0;
 	let nonToolBlocks: Exclude<ContentBlock, ToolResultContent>[] = [];
 
@@ -303,17 +304,33 @@ function generateMessageId(): string {
 }
 
 /**
- * Strips a trailing `_tool_<toolUseId>` suffix that a previous encode appended
- * to a tool-result message id, so that re-encoding an already-persisted message
- * produces a stable, byte-identical id instead of growing the suffix on every
- * persist cycle.
+ * Recovers the original base id from a message id that a previous encode may
+ * have suffixed, so that re-encoding an already-persisted message produces a
+ * stable, byte-identical id instead of growing the suffix on every persist
+ * cycle.
  *
- * Only the `_tool_` suffix is stripped. The `_part_<n>` suffix used for split
- * non-tool segments must NOT be stripped: on decode each segment becomes its own
- * single-block message, so re-encoding never regenerates `_part_<n>`. Stripping
- * it would collapse a `..._part_1` id back to the bare base id and collide with
- * the message's first segment.
+ * A tool-result block is encoded as `${baseId}_tool_${block.tool_use_id}`. To
+ * avoid mistaking an id that legitimately contains `_tool_` for an encoded
+ * suffix, only a trailing `_tool_<toolUseId>` whose `<toolUseId>` matches a
+ * tool_use_id actually present in this message is stripped.
+ *
+ * The `_part_<n>` suffix used for split non-tool segments is intentionally not
+ * stripped: on decode each segment becomes its own single-block message, so
+ * re-encoding never regenerates `_part_<n>`, and stripping it would collapse a
+ * `..._part_1` id back onto the base id and collide with the first segment.
  */
-function stripEncodedIdSuffix(id: string): string {
-	return id.replace(/_tool_.+$/, "");
+function stripEncodedIdSuffix(
+	id: string,
+	blocks: readonly ContentBlock[],
+): string {
+	for (const block of blocks) {
+		if (block.type !== "tool_result") {
+			continue;
+		}
+		const suffix = `_tool_${block.tool_use_id}`;
+		if (id.endsWith(suffix)) {
+			return id.slice(0, -suffix.length);
+		}
+	}
+	return id;
 }


### PR DESCRIPTION
Fixes #11941

## Problem

messageToAgentMessages builds each tool-result AgentMessage id as \\_tool_\\, where baseId is the message's existing id. The decode side preserves that id verbatim, so every persist -> rehydrate -> re-encode cycle re-appends the suffix and tool-result ids grow without bound (msg_x_tool_call_abc_tool_call_abc..., up to 23x in the issue). The corrupted ids break TUI session resume: hydrate-messages can no longer match tool results to their tool calls.

## Fix

Strip a single trailing _tool_<toolUseId> suffix from the base id before re-appending, so re-encoding an already-persisted message produces a byte-identical id. Stops the growth at the encoder, no persistence migration.

The parallel _part_<n> suffix (split non-tool segments) is deliberately NOT stripped: on decode each segment becomes its own single-block message that never regenerates _part_<n>, so stripping it would collapse a trailing segment onto the base id and collide with the leading one. A test covers this exact shape.

## Tests

Round-trip (encode -> decode -> re-encode) tests in agent-message-codec.test.ts: single tool result stable across 3 cycles; multiple tool results stable with no cross-contamination; text-tool-text message keeps all three ids distinct. All existing codec tests pass; typecheck and biome lint are clean.