### PR TITLE
fix(core): restore per-turn environment details

### DIFF
--- a/sdk/packages/core/src/runtime/host/environment-details.test.ts
+++ b/sdk/packages/core/src/runtime/host/environment-details.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+	appendEnvironmentDetails,
+	buildEnvironmentDetails,
+} from "./environment-details";
+
+describe("environment details", () => {
+	it("builds a classic environment_details block", () => {
+		const details = buildEnvironmentDetails({
+			cwd: "/tmp/project",
+			mode: "plan",
+			workspaceMetadata: '{"root":"/tmp/project"}',
+			now: new Date("2026-07-03T12:00:00.000Z"),
+		});
+
+		expect(details).toContain("<environment_details>");
+		expect(details).toContain("# Current Working Directory\n/tmp/project");
+		expect(details).toContain(
+			'# Workspace Configuration\n{"root":"/tmp/project"}',
+		);
+		expect(details).toContain("# Current Time\n");
+		expect(details).toContain("# Current Mode\nPLAN MODE");
+		expect(details).toContain("</environment_details>");
+	});
+
+	it("does not append a duplicate environment_details block", () => {
+		const prompt =
+			'<user_input mode="act">hello</user_input>\n\n<environment_details>\nexisting\n</environment_details>';
+
+		expect(
+			appendEnvironmentDetails(prompt, {
+				cwd: "/tmp/project",
+				mode: "act",
+			}),
+		).toBe(prompt);
+	});
+});

--- a/sdk/packages/core/src/runtime/host/environment-details.ts
+++ b/sdk/packages/core/src/runtime/host/environment-details.ts
@@ -1,0 +1,72 @@
+import type { AgentMode } from "@cline/shared";
+
+const ENVIRONMENT_DETAILS_OPEN = "<environment_details>";
+const ENVIRONMENT_DETAILS_CLOSE = "</environment_details>";
+const WORKSPACE_CONFIGURATION_HEADING = "# Workspace Configuration";
+
+export interface EnvironmentDetailsInput {
+	cwd: string;
+	mode?: AgentMode;
+	workspaceMetadata?: string;
+	now?: Date;
+}
+
+function formatMode(mode: AgentMode | undefined): string {
+	switch (mode) {
+		case "plan":
+			return "PLAN MODE";
+		case "yolo":
+			return "YOLO MODE";
+		case "zen":
+			return "ZEN MODE";
+		case "act":
+		default:
+			return "ACT MODE";
+	}
+}
+
+function formatCurrentTime(now: Date): string {
+	return now.toLocaleString("en-US", {
+		year: "numeric",
+		month: "long",
+		day: "numeric",
+		hour: "numeric",
+		minute: "2-digit",
+		second: "2-digit",
+		timeZoneName: "short",
+	});
+}
+
+export function buildEnvironmentDetails({
+	cwd,
+	mode,
+	workspaceMetadata,
+	now = new Date(),
+}: EnvironmentDetailsInput): string {
+	const sections = [`# Current Working Directory\n${cwd}`];
+	const metadata = workspaceMetadata?.trim();
+
+	if (metadata) {
+		sections.push(
+			metadata.startsWith(WORKSPACE_CONFIGURATION_HEADING)
+				? metadata
+				: `${WORKSPACE_CONFIGURATION_HEADING}\n${metadata}`,
+		);
+	}
+
+	sections.push(`# Current Time\n${formatCurrentTime(now)}`);
+	sections.push(`# Current Mode\n${formatMode(mode)}`);
+
+	return `${ENVIRONMENT_DETAILS_OPEN}\n${sections.join("\n\n")}\n${ENVIRONMENT_DETAILS_CLOSE}`;
+}
+
+export function appendEnvironmentDetails(
+	prompt: string,
+	input: EnvironmentDetailsInput,
+): string {
+	if (prompt.includes(ENVIRONMENT_DETAILS_OPEN)) {
+		return prompt;
+	}
+
+	return `${prompt}\n\n${buildEnvironmentDetails(input)}`;
+}

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
@@ -468,6 +468,12 @@ describe("LocalRuntimeHost", () => {
 			undefined,
 			undefined,
 		);
+		const initialPrompt = agent.run.mock.calls[0]?.[0] as string;
+		expect(initialPrompt).toContain("<environment_details>");
+		expect(initialPrompt).toContain(
+			"# Current Working Directory\n/tmp/project",
+		);
+		expect(initialPrompt).toContain("# Current Mode\nACT MODE");
 	});
 
 	it("marks interactive sessions pending while awaiting tool approval", async () => {
@@ -2041,11 +2047,12 @@ describe("LocalRuntimeHost", () => {
 		await vi.waitFor(() => {
 			expect(continueFn).toHaveBeenCalledTimes(2);
 		});
-		expect(continueFn).toHaveBeenLastCalledWith(
+		const steeredPrompt = continueFn.mock.calls.at(-1)?.[0] as string;
+		expect(steeredPrompt).toContain(
 			'<user_input mode="act">async result</user_input>',
-			undefined,
-			undefined,
 		);
+		expect(steeredPrompt).toContain("<environment_details>");
+		expect(steeredPrompt).toContain("# Current Mode\nACT MODE");
 	});
 
 	it("promotes queued prompts to the front when they become steer", async () => {
@@ -2196,7 +2203,11 @@ describe("LocalRuntimeHost", () => {
 		const consumed = await Promise.resolve(
 			agentConfig?.consumePendingUserMessage?.(),
 		);
-		expect(consumed).toBe('<user_input mode="plan">steer this</user_input>');
+		expect(consumed).toContain(
+			'<user_input mode="plan">steer this</user_input>',
+		);
+		expect(consumed).toContain("<environment_details>");
+		expect(consumed).toContain("# Current Mode\nPLAN MODE");
 		expect(agentConfig?.telemetry).toBe(telemetry);
 	});
 
@@ -2794,16 +2805,16 @@ describe("LocalRuntimeHost", () => {
 		expect(second?.text).toBe("second");
 		expect(run).toHaveBeenCalledTimes(1);
 		expect(continueFn).toHaveBeenCalledTimes(1);
-		expect(run).toHaveBeenCalledWith(
-			'<user_input mode="act">first</user_input>',
-			undefined,
-			undefined,
-		);
-		expect(continueFn).toHaveBeenCalledWith(
+		const runPrompt = run.mock.calls[0]?.[0] as string;
+		const continuedPrompt = continueFn.mock.calls[0]?.[0] as string;
+		expect(runPrompt).toContain('<user_input mode="act">first</user_input>');
+		expect(runPrompt).toContain("<environment_details>");
+		expect(runPrompt).toContain("# Current Mode\nACT MODE");
+		expect(continuedPrompt).toContain(
 			'<user_input mode="plan">second</user_input>',
-			undefined,
-			undefined,
 		);
+		expect(continuedPrompt).toContain("<environment_details>");
+		expect(continuedPrompt).toContain("# Current Mode\nPLAN MODE");
 		expect(sessionService.persistSessionMessages).toHaveBeenCalledTimes(2);
 	});
 
@@ -4404,8 +4415,13 @@ describe("LocalRuntimeHost", () => {
 				userFiles: ["note.md"],
 			});
 
-			expect(run).toHaveBeenCalledWith(
+			const prompt = run.mock.calls[0]?.[0] as string;
+			expect(prompt).toContain(
 				'<user_input mode="act">explain @src/app.ts</user_input>',
+			);
+			expect(prompt).toContain("<environment_details>");
+			expect(run).toHaveBeenCalledWith(
+				expect.any(String),
 				undefined,
 				expect.arrayContaining([mentionPath, explicitPath]),
 			);

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -83,6 +83,7 @@ import {
 import type { RuntimeBuilder } from "../orchestration/session-runtime";
 import { SessionRuntime } from "../orchestration/session-runtime-orchestrator";
 import { PendingPromptsController } from "../turn-queue/pending-prompt-service";
+import { appendEnvironmentDetails } from "./environment-details";
 import { manifestToSessionRecord } from "./history";
 import { AgentEventBridge } from "./local/agent-event-bridge";
 import {
@@ -510,9 +511,16 @@ export class LocalRuntimeHost implements RuntimeHost {
 			consumePendingUserMessage: () => {
 				const entry = this.pendingPromptsController.consumeSteer(sessionId);
 				return entry
-					? formatModePrompt(
-							entry.prompt,
-							entry.mode ?? configWithProvider.mode,
+					? appendEnvironmentDetails(
+							formatModePrompt(
+								entry.prompt,
+								entry.mode ?? configWithProvider.mode,
+							),
+							{
+								cwd: configWithProvider.cwd,
+								mode: entry.mode ?? configWithProvider.mode,
+								workspaceMetadata: configWithProvider.workspaceMetadata,
+							},
 						)
 					: undefined;
 			},
@@ -1272,9 +1280,14 @@ export class LocalRuntimeHost implements RuntimeHost {
 		);
 		emitMentionTelemetry(session.config.telemetry, enriched);
 
-		const prompt = formatModePrompt(
-			enriched.prompt,
-			input.mode ?? session.config.mode,
+		const mode = input.mode ?? session.config.mode;
+		const prompt = appendEnvironmentDetails(
+			formatModePrompt(enriched.prompt, mode),
+			{
+				cwd: session.config.cwd,
+				mode,
+				workspaceMetadata: session.config.workspaceMetadata,
+			},
 		);
 		const explicitUserFiles = this.resolveAbsoluteFilePaths(
 			session.config.cwd,


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Restores a classic per-turn `<environment_details>` user-message block for ClineCore clients.

The SDK/Core prompt path currently wraps user input but does not append the environment details block that older Cline task prompts provided on each model turn. This adds a small shared formatter and applies it at the Core host boundary for both normal turns and queued steer prompts, using the environment data Core already has: current working directory, workspace metadata, current time, and current mode.

This intentionally lives in Core instead of the CLI or VS Code client layers so the behavior is shared by ClineCore clients, including CLI, VS Code SDK sessions, and the default hub-backed runtime path. This PR is split from the Cline provider header fixes so reviewers can evaluate prompt restoration separately from request metadata/header restoration.

### Test Procedure

- Ran focused formatting/lint check:
  - `bun biome check --diagnostic-level=error sdk/packages/core/src/runtime/host/environment-details.ts sdk/packages/core/src/runtime/host/environment-details.test.ts sdk/packages/core/src/runtime/host/local-runtime-host.ts sdk/packages/core/src/runtime/host/local-runtime-host.test.ts`
- Ran focused Core unit tests:
  - `bun -F @cline/core test:unit -- src/runtime/host/environment-details.test.ts src/runtime/host/local-runtime-host.test.ts`

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. Backend/Core prompt construction change only.

### Additional Notes

This restores the shared per-turn environment details block using data available to Core. It does not synthesize client-specific details such as VS Code visible files, open tabs, or terminal panes; those would require a follow-up host contribution/hook so each client can supply richer dynamic context.
