### PR TITLE
fix(cli): prevent empty session from racing a mode-change restart

### DIFF
--- a/apps/cli/src/runtime/interactive/session-runtime.test.ts
+++ b/apps/cli/src/runtime/interactive/session-runtime.test.ts
@@ -210,6 +210,40 @@ describe("createInteractiveSessionRuntime", () => {
 		expect(runtime.getActiveSessionId()).toBe("session-2");
 	});
 
+	it("holds concurrent ensureReady during a restart instead of booting an empty session", async () => {
+		const manager = makeManager();
+		const runtime = makeRuntime(manager);
+
+		await runtime.ensureReady();
+		expect(runtime.getActiveSessionId()).toBe("session-1");
+
+		// Keep the replacement session's start in flight so the restart window
+		// (old session stopped, no active session yet) stays open.
+		const gate = deferred<void>();
+		manager.start.mockImplementationOnce(async () => {
+			await gate.promise;
+			return {
+				sessionId: "session-restarted",
+				manifest: { session_id: "session-restarted" },
+			};
+		});
+
+		const restart = runtime.restartWithCurrentMessages();
+		await vi.waitFor(() => {
+			expect(manager.start).toHaveBeenCalledTimes(2);
+		});
+
+		// A message submitted mid-restart (e.g. right after a plan/act toggle)
+		// calls ensureReady; it must wait for the restart instead of booting a
+		// blank session that races the replacement for the active slot.
+		const ready = runtime.ensureReady();
+		gate.resolve();
+		await Promise.all([restart, ready]);
+
+		expect(manager.start).toHaveBeenCalledTimes(2);
+		expect(runtime.getActiveSessionId()).toBe("session-restarted");
+	});
+
 	it("adds a live interactive approval policy hook to started sessions", async () => {
 		const manager = makeManager();
 		const upstreamBeforeTool = vi.fn(async () => ({

--- a/apps/cli/src/runtime/interactive/session-runtime.ts
+++ b/apps/cli/src/runtime/interactive/session-runtime.ts
@@ -383,11 +383,31 @@ export function createInteractiveSessionRuntime(input: {
 	): Promise<void> => {
 		sessionStartGeneration += 1;
 		pendingResumeSessionId = undefined;
-		startupPromise = undefined;
 		startupError = undefined;
-		await stopCurrentSession();
-		clearActiveSession();
-		await startFreshSession(messages, sessionMetadata);
+		// Publish the restart as the in-flight startup. Teardown leaves a window
+		// with no active session, and without this barrier a concurrent
+		// ensureReady() (e.g. a message submitted right after a plan/act toggle)
+		// reads that window as "no session" and boots an empty session that then
+		// races the restarted one for the active slot.
+		const restart = (async () => {
+			await stopCurrentSession();
+			clearActiveSession();
+			await startFreshSession(messages, sessionMetadata);
+		})().catch((error) => {
+			startupError = error;
+			throw error;
+		});
+		startupPromise = restart;
+		try {
+			await restart;
+		} finally {
+			// Restore the pre-restart steady state (startupPromise unset) so a
+			// failed restart stays retryable by the next ensureReady(). A newer
+			// startup that already replaced the barrier is left alone.
+			if (startupPromise === restart) {
+				startupPromise = undefined;
+			}
+		}
 	};
 
 	const restartWithCurrentMessages = async (): Promise<void> => {


### PR DESCRIPTION
### Related Issue

N/A — reproduced live and diagnosed from session transcripts (details below). Small bug fix per the limited-exceptions policy. Related to (but independent of) #12054.

### Description

**Symptom.** In the interactive TUI: present a plan in plan mode, press Tab to switch to act mode yourself, quickly type a follow-up like "go on" — and the model responds *"I don't have a task in front of me yet"*, as if the conversation never happened.

**What's actually going on** (diagnosed from the session files of a live repro — three sessions for one conversation):

- `session A` — the plan-mode session, full history.
- `session B` — the act-mode rebuild triggered by Tab. **It correctly carried the full history**; the restart machinery is not the problem.
- `session C` — created ~550ms after B, **completely empty**, and this is the session that received "go on".

The race: `restartWithMessages` (in `session-runtime.ts`) does teardown/replace like this:

```
sessionStartGeneration += 1
startupPromise = undefined        <-- clears the startup barrier
await stopCurrentSession()        <-- slow
clearActiveSession()              <-- activeSessionId = ""
await startFreshSession(messages) <-- slow (starts the replacement with history)
```

For the several hundred ms of teardown+start, there is **no active session and no startup in flight**. `ensureReady()` — which `onSubmit` calls first thing on every message — interprets exactly that state as "cold start": no resume id, so it boots a **fresh empty session**. Both the rebuild's session and the empty one were created under the same (already-bumped) `sessionStartGeneration`, so the stale-start guard catches neither, and whichever registers last wins `activeSessionId`. The empty one won; "go on" went to it; the model honestly reported an empty conversation.

**The fix.** The runtime already has the right concept — `startupPromise`, which `ensureReady()` awaits when a startup is in flight. The bug is that restarts *cleared* it instead of *using* it. So: publish the restart (teardown + replacement start) as the in-flight `startupPromise`. Any concurrent `ensureReady()` now waits for the restart and returns once the restarted session (with history) is active. The barrier is cleared in a `finally` once the restart settles — success restores today's steady state, and a *failed* restart stays retryable by the next `ensureReady()` instead of replaying a cached rejection forever (with a `startupPromise === restart` guard so a newer startup that already replaced the barrier is left alone).

For reference, the VS Code extension hit this same class of bug and guards it with a dedicated `SdkModeCoordinator.waitForPendingRebuild()` barrier that concurrent message paths must remember to call ("…concurrent message paths must wait on this instead of treating the gap as 'no session' and resuming a parallel session…"). The CLI fix deliberately reuses the existing `startupPromise` mechanism instead of adding a second barrier: every current and future caller of `ensureReady()` is protected automatically, with nothing extra to remember.

**Not caused by #12054** — that PR doesn't touch this path (manual Tab toggle while idle → `applyModeChange` → `restartWithCurrentMessages`), and the race predates it; it just takes toggling and submitting within the sub-second rebuild window to hit, and typing right after approving a plan is a natural way to land in it.

### Test Procedure

- New regression test in `session-runtime.test.ts`: holds the replacement session's `start()` open with a deferred promise to keep the restart window open, fires `ensureReady()` mid-window, then releases the gate. Written test-first: **fails on `main` exactly as diagnosed** (`start` called 3 times — the phantom empty session) and passes with the fix (`start` called twice, restarted session wins the active slot).
- Full CLI runtime + TUI suites: 291 tests passing. `tsc --noEmit` and `biome check` clean.
- The failure-retry semantics are preserved by clearing the barrier in `finally`: a failed restart leaves `startupPromise` unset (same as pre-fix steady state), so the next `ensureReady()` can boot fresh.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

From the live repro — the conversation history was in the rebuilt session, but the empty raced session received the message:

```
session B (act-mode rebuild, 8 messages)        session C (empty, created 554ms later, wins active slot)
user: i want to add a comment to a random file   user: <user_input mode="act">go on</user_input>
assistant: [plan presented ...]                  assistant: I don't have a task in front of me yet...
```

### Additional Notes

The generation counter (`sessionStartGeneration`) can't catch this on its own: the empty session is started *after* the restart bumped the counter, so both starts share the same generation and both pass the staleness check. The barrier removes the competing start entirely rather than trying to referee it after the fact.
