### PR TITLE
feat(cli): make plan/act mode switches visible to the model

### DIFF
--- a/apps/cli/src/runtime/interactive/mode.test.ts
+++ b/apps/cli/src/runtime/interactive/mode.test.ts
@@ -7,6 +7,7 @@ import {
 	type AppliedModeChange,
 	applyInteractiveModeConfig,
 	createInteractiveModeSwitchTool,
+	createModeSwitchNoticeTracker,
 	type PendingModeChange,
 	sendTurnWithActModeContinuation,
 } from "./mode";
@@ -190,6 +191,44 @@ describe("sendTurnWithActModeContinuation", () => {
 		const result = await run();
 
 		expect(result).toEqual({ finishReason: "completed", iterations: 2 });
+	});
+});
+
+describe("createModeSwitchNoticeTracker", () => {
+	it("records a switch and clears it on consume", () => {
+		const tracker = createModeSwitchNoticeTracker();
+
+		tracker.record("act", "plan");
+
+		expect(tracker.consume()).toEqual({ from: "act", to: "plan" });
+		expect(tracker.consume()).toBeNull();
+	});
+
+	it("cancels a round trip that returns to the mode the model last saw", () => {
+		const tracker = createModeSwitchNoticeTracker();
+
+		tracker.record("act", "plan");
+		tracker.record("plan", "act");
+
+		expect(tracker.consume()).toBeNull();
+	});
+
+	it("keeps the original starting mode across chained switches", () => {
+		const tracker = createModeSwitchNoticeTracker();
+
+		tracker.record("act", "plan");
+		tracker.record("plan", "act");
+		tracker.record("act", "plan");
+
+		expect(tracker.consume()).toEqual({ from: "act", to: "plan" });
+	});
+
+	it("ignores a no-op switch", () => {
+		const tracker = createModeSwitchNoticeTracker();
+
+		tracker.record("plan", "plan");
+
+		expect(tracker.consume()).toBeNull();
 	});
 });
 

--- a/apps/cli/src/runtime/interactive/mode.ts
+++ b/apps/cli/src/runtime/interactive/mode.ts
@@ -107,6 +107,39 @@ export async function sendTurnWithActModeContinuation<
 	};
 }
 
+export type ModeSwitchNotice = {
+	from: InteractiveUiMode;
+	to: InteractiveUiMode;
+};
+
+/**
+ * Tracks a user-initiated mode switch so the next user message can carry a
+ * <mode_notice> marking it. Only UI toggles are recorded: the model-initiated
+ * switch_to_act_mode path already announces itself via the continuation
+ * prompt. A round trip (plan -> act -> plan before sending anything) cancels
+ * out, since the mode the model last saw never effectively changed.
+ */
+export function createModeSwitchNoticeTracker() {
+	let pending: ModeSwitchNotice | null = null;
+	return {
+		record(from: InteractiveUiMode, to: InteractiveUiMode): void {
+			if (from === to) {
+				return;
+			}
+			if (pending) {
+				pending = pending.from === to ? null : { from: pending.from, to };
+				return;
+			}
+			pending = { from, to };
+		},
+		consume(): ModeSwitchNotice | null {
+			const notice = pending;
+			pending = null;
+			return notice;
+		},
+	};
+}
+
 export async function applyInteractiveModeConfig(input: {
 	config: Config;
 	mode: InteractiveUiMode;

--- a/apps/cli/src/runtime/prompt.ts
+++ b/apps/cli/src/runtime/prompt.ts
@@ -9,6 +9,10 @@ import {
 import { type AgentMode, buildClineSystemPrompt } from "@cline/shared";
 import { isImagePath, loadImageAsDataUrl } from "../utils/image-attachments";
 
+const MODE_TAG_INSTRUCTIONS = `# Plan / Act Modes
+
+User messages arrive wrapped in a <user_input mode="..."> tag. The mode attribute is the interaction mode the user was in when they sent that message: "plan" means plan-mode constraints applied (explore, analyze, and align on a plan -- no edits or state-changing commands), while "act" (or "yolo") means implementation was allowed. If the mode attribute changes between messages, the user switched modes -- the newest message's mode is what governs right now, regardless of what earlier messages allowed. A <mode_notice> block inside a message marks exactly when such a switch happened.`;
+
 const PLAN_MODE_INSTRUCTIONS = `# Plan Mode
 
 You are in Plan mode. Your role is to explore, analyze, and plan -- not to execute.
@@ -31,10 +35,13 @@ export async function resolveSystemPrompt(input: {
 }): Promise<string> {
 	const metadata = await buildWorkspaceMetadata(input.cwd);
 	let rules = mergeRulesForSystemPrompt(undefined, input.rules);
+	// Both modes get the mode-tag explanation: after a switch, the transcript
+	// still contains messages tagged with the other mode.
+	rules = rules
+		? `${rules}\n\n${MODE_TAG_INSTRUCTIONS}`
+		: MODE_TAG_INSTRUCTIONS;
 	if (input.mode === "plan") {
-		rules = rules
-			? `${rules}\n\n${PLAN_MODE_INSTRUCTIONS}`
-			: PLAN_MODE_INSTRUCTIONS;
+		rules = `${rules}\n\n${PLAN_MODE_INSTRUCTIONS}`;
 	}
 	return buildClineSystemPrompt({
 		ide: "Terminal Shell",

--- a/apps/cli/src/runtime/run-interactive.ts
+++ b/apps/cli/src/runtime/run-interactive.ts
@@ -4,6 +4,7 @@ import {
 	ProviderSettingsManager,
 	type UserInstructionConfigService,
 } from "@cline/core";
+import { formatModeSwitchNotice } from "@cline/shared";
 import type { CliMigrationNotice } from "../kanban-migration/notice";
 import { logCliError } from "../logging/errors";
 import {
@@ -55,6 +56,7 @@ import { createMistakeLimitDecisionResolver } from "./interactive/mistakes";
 import {
 	type AppliedModeChange,
 	createInteractiveModeSwitchTool,
+	createModeSwitchNoticeTracker,
 	type PendingModeChange,
 	sendTurnWithActModeContinuation,
 } from "./interactive/mode";
@@ -210,6 +212,7 @@ export async function runInteractive(
 	});
 	let modeChangePromise: Promise<void> | undefined;
 	let modeChangeTarget: "plan" | "act" | undefined;
+	const modeSwitchNotice = createModeSwitchNoticeTracker();
 
 	const isInteractiveMode = (mode: unknown): mode is "plan" | "act" =>
 		mode === "plan" || mode === "act";
@@ -224,7 +227,11 @@ export async function runInteractive(
 				await modeChangePromise;
 			}
 			await sessionRuntime.ensureReady();
+			const from = config.mode;
 			await sessionRuntime.applyMode(mode);
+			if (isInteractiveMode(from)) {
+				modeSwitchNotice.record(from, mode);
+			}
 		})().finally(() => {
 			if (modeChangePromise === next) {
 				modeChangePromise = undefined;
@@ -526,6 +533,13 @@ export async function runInteractive(
 					...(attachments?.userImages ?? []),
 					...userImages,
 				];
+				// Mark a preceding user-initiated mode switch on this message so
+				// the model sees exactly when the rules changed, instead of only
+				// inferring it from the user_input mode attribute flipping.
+				const switchNotice = modeSwitchNotice.consume();
+				const noticedUserInput = switchNotice
+					? `${formatModeSwitchNotice(switchNotice.from, switchNotice.to)}\n${userInput}`
+					: userInput;
 
 				const applyPendingModeChange = async (): Promise<
 					AppliedModeChange | undefined
@@ -537,15 +551,21 @@ export async function runInteractive(
 					};
 					pendingModeChange.current = null;
 					pendingModeChange.source = null;
+					const from = config.mode;
 					await sessionRuntime.applyMode(applied.mode);
 					tuiModeChanged.current?.(applied.mode);
+					// The switch_to_act_mode path announces itself through the
+					// continuation prompt; only UI toggles need a notice.
+					if (applied.source === "ui" && isInteractiveMode(from)) {
+						modeSwitchNotice.record(from, applied.mode);
+					}
 					return applied;
 				};
 
 				const result = await sendTurnWithActModeContinuation({
 					sendInitialTurn: () =>
 						sessionRuntime.sendCurrentTurn({
-							prompt: userInput,
+							prompt: noticedUserInput,
 							mode,
 							userImages:
 								mergedUserImages.length > 0 ? mergedUserImages : undefined,

--- a/sdk/packages/shared/src/index.browser.ts
+++ b/sdk/packages/shared/src/index.browser.ts
@@ -229,6 +229,7 @@ export { buildClineSystemPrompt } from "./prompt/cline";
 export {
 	formatDisplayUserInput,
 	formatFileContentBlock,
+	formatModeSwitchNotice,
 	formatUserCommandBlock,
 	formatUserInputBlock,
 	normalizeUserInput,

--- a/sdk/packages/shared/src/index.ts
+++ b/sdk/packages/shared/src/index.ts
@@ -243,6 +243,7 @@ export { buildClineSystemPrompt, processWorkspaceInfo } from "./prompt/cline";
 export {
 	formatDisplayUserInput,
 	formatFileContentBlock,
+	formatModeSwitchNotice,
 	formatUserCommandBlock,
 	formatUserInputBlock,
 	normalizeUserInput,

--- a/sdk/packages/shared/src/prompt/format.test.ts
+++ b/sdk/packages/shared/src/prompt/format.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
 	formatDisplayUserInput,
+	formatModeSwitchNotice,
 	formatUserCommandBlock,
+	formatUserInputBlock,
 	normalizeUserInput,
 	parseUserCommandEnvelope,
 } from "./format";
@@ -35,5 +37,22 @@ describe("prompt format helpers", () => {
 			"team",
 		);
 		expect(formatDisplayUserInput(wrapped)).toBe("/team inspect rpc startup");
+	});
+
+	it("formats a mode switch notice", () => {
+		expect(formatModeSwitchNotice("plan", "act")).toBe(
+			"<mode_notice>The user switched from plan mode to act mode before sending this message.</mode_notice>",
+		);
+	});
+
+	it("hides mode switch notices from displayed user input", () => {
+		const wrapped = formatUserInputBlock(
+			`${formatModeSwitchNotice("act", "plan")}\nhow should we refactor this?`,
+			"plan",
+		);
+		expect(formatDisplayUserInput(wrapped)).toBe(
+			"how should we refactor this?",
+		);
+		expect(normalizeUserInput(wrapped)).toBe("how should we refactor this?");
 	});
 });

--- a/sdk/packages/shared/src/prompt/format.test.ts
+++ b/sdk/packages/shared/src/prompt/format.test.ts
@@ -55,4 +55,25 @@ describe("prompt format helpers", () => {
 		);
 		expect(normalizeUserInput(wrapped)).toBe("how should we refactor this?");
 	});
+
+	it("removes every mode notice and leaves unclosed ones intact", () => {
+		expect(
+			normalizeUserInput(
+				"<mode_notice>a</mode_notice>hello<mode_notice>b</mode_notice> there",
+			),
+		).toBe("hello there");
+		expect(normalizeUserInput("<mode_notice>dangling")).toBe(
+			"<mode_notice>dangling",
+		);
+	});
+
+	it("normalizes adversarial repeated open tags in linear time", () => {
+		// Regression guard for CodeQL js/polynomial-redos: many unmatched
+		// opening tags must not trigger quadratic rescanning.
+		const hostile = "<mode_notice>".repeat(50_000);
+		const started = performance.now();
+		const result = normalizeUserInput(hostile);
+		expect(performance.now() - started).toBeLessThan(1_000);
+		expect(result).toBe(hostile);
+	});
 });

--- a/sdk/packages/shared/src/prompt/format.ts
+++ b/sdk/packages/shared/src/prompt/format.ts
@@ -86,8 +86,27 @@ export function normalizeUserInput(input?: string): string {
 	}
 	// mode_notice is runtime-generated context, not user-typed text; unlike the
 	// wrapper tags above, the whole element (content included) is hidden.
-	next = next.replace(/<mode_notice>[\s\S]*?<\/mode_notice>/gi, "").trim();
+	next = removeTagElements(next, "mode_notice").trim();
 	return next;
+}
+
+// indexOf-based rather than a regex: a lazy dot-all pattern re-scans to the
+// end of the string from every unmatched opening tag, which is polynomial on
+// adversarial transcript content (CodeQL js/polynomial-redos).
+function removeTagElements(input: string, tag: string): string {
+	const open = `<${tag}>`;
+	const close = `</${tag}>`;
+	let result = input;
+	let start = result.indexOf(open);
+	while (start !== -1) {
+		const end = result.indexOf(close, start + open.length);
+		if (end === -1) {
+			break;
+		}
+		result = result.slice(0, start) + result.slice(end + close.length);
+		start = result.indexOf(open, start);
+	}
+	return result;
 }
 
 export function formatDisplayUserInput(input?: string): string {

--- a/sdk/packages/shared/src/prompt/format.ts
+++ b/sdk/packages/shared/src/prompt/format.ts
@@ -13,6 +13,18 @@ export function formatUserCommandBlock(input: string, slash: string): string {
 	return `<user_command slash="${slash}">${input}</user_command>`;
 }
 
+/**
+ * Marks the exact point in the conversation where the user switched between
+ * plan and act modes. Prepended to the first user message sent after the
+ * switch; stripped from transcript display by normalizeUserInput.
+ */
+export function formatModeSwitchNotice(
+	from: "act" | "plan",
+	to: "act" | "plan",
+): string {
+	return `<mode_notice>The user switched from ${from} mode to ${to} mode before sending this message.</mode_notice>`;
+}
+
 export type UserCommandEnvelope = {
 	slash: string;
 	content: string;
@@ -72,6 +84,9 @@ export function normalizeUserInput(input?: string): string {
 				: next.replace(new RegExp(`<${tag}[^>]*>`, "g"), "")
 		).trim();
 	}
+	// mode_notice is runtime-generated context, not user-typed text; unlike the
+	// wrapper tags above, the whole element (content included) is hidden.
+	next = next.replace(/<mode_notice>[\s\S]*?<\/mode_notice>/gi, "").trim();
 	return next;
 }
 


### PR DESCRIPTION
### Related Issue

N/A — follow-up to #12054/#12056, from testing plan/act switching in the interactive TUI.

### Description

**Problem.** The model's only knowledge of plan/act mode lives in the system prompt, and mode *switches* are completely invisible to it:

- Every user message is already wrapped `<user_input mode="plan|act|yolo">` by the runtime host — but nothing anywhere explains what that attribute means. It's unexplained XML the model may or may not intuit.
- A manual Tab toggle swaps the system prompt and tool set via session rebuild, which the model cannot perceive: models don't diff system prompts between turns. After act→plan, the model sits with plan instructions atop a transcript full of its own edits — a distant instruction losing to recent contrary evidence. This is the classic recency problem, and it's why both ancestors of this product put mode state in the message stream: Claude Code injects a plan-mode reminder into every user turn, and the legacy Cline extension appended `# Current Mode: PLAN MODE / ACT MODE` to every message via `environment_details`. The new stack dropped that and kept only the cryptic attribute.

**Fix — two small pieces:**

1. **Explain the existing signal** (CLI system prompt, both modes): a short `# Plan / Act Modes` block documenting the `mode` attribute — plan means explore/align only, act means implementation allowed, a mid-conversation attribute change means the user switched, and the newest message's mode governs. Included in *both* modes because after a switch the transcript still contains messages tagged with the other mode. This turns the per-message tag that already exists on every user message into exactly the front-and-center reminder we want, at zero per-turn token cost.

2. **Mark the switch event** (CLI + shared): a user-initiated Tab toggle stamps the *next* user message with a notice:
   ```
   <user_input mode="plan"><mode_notice>The user switched from act mode to plan mode before sending this message.</mode_notice>
   how should we refactor this?</user_input>
   ```
   Division of labor: the notice states the *event*, the system prompt block supplies the *semantics*.

**Design decisions worth knowing:**

- **Only UI toggles emit the notice.** The model-initiated `switch_to_act_mode` path already announces itself via the act-mode continuation prompt (#12054); stamping it again would double-signal. The `AppliedModeChange.source` tag from #12054 makes this a one-line distinction.
- **Round trips cancel.** Tab to plan, Tab back to act before sending anything → no notice, because the mode the model last saw never effectively changed. Chained flips keep the original starting mode. Logic lives in `createModeSwitchNoticeTracker()` (`mode.ts`), extracted for unit testing.
- **Trigger in the CLI, vocabulary in `@cline/shared`.** The SDK has no "mode switch" primitive to hook — mode is session config and a switch is the client rebuilding the session, so host-side detection would mean transcript inference (and double-signaling for VS Code, which announces switches its own way). The CLI knows the moment, direction, and source of the toggle explicitly. But the `<mode_notice>` tag itself sits in shared next to `formatUserInputBlock` (the wrapper it extends), and `normalizeUserInput` hides the whole element structurally — the same mechanism that strips `user_input`/`user_command` — so every display surface (TUI resume hydration, hub views, exports) hides it centrally instead of each client string-matching. (An all-CLI version was considered: it saves ~2 lines and leaks the raw tag into hub/export views.)
- The notice rides inside the user prompt string, so it flows through any backend (local/hub) with no `SendSessionInput`/RPC changes and never appears in the live TUI (user bubbles are locally echoed from raw input).

### Test Procedure

- `createModeSwitchNoticeTracker`: records a switch, consume clears, round trip cancels, chained switches keep the original starting mode, same-mode no-ops (4 new tests in `mode.test.ts`).
- Shared format: notice shape, and end-to-end display hiding — a wrapped message containing a notice normalizes/displays as just the user's text (2 new tests in `format.test.ts`).
- Full suites: 295 CLI runtime+TUI tests, 184 shared tests, `tsc --noEmit`, biome — all green.
- Manual verification to try: Tab from act to plan mid-session and ask for an edit — the model should now decline citing plan mode (previously it often complied, since plan constraints lived only in a system prompt it couldn't see change).

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

What the model sees after an act→plan Tab toggle followed by "can you add that comment now?":

```
<user_input mode="plan"><mode_notice>The user switched from act mode to plan mode before sending this message.</mode_notice>
can you add that comment now?</user_input>
```

…while the transcript display (TUI resume, hub, exports) shows only: `can you add that comment now?`

### Additional Notes

Escalation path if adherence still slips in long sessions: Claude-Code-style standing per-turn plan reminders (a `<mode_notice>`-like block on *every* plan-mode message, ~30 tokens/turn) — deliberately not included here to keep this minimal and measure the cheap fix first. Also pre-existing and untouched: plan mode's `run_commands` can still write files (`ToolPresets.plan` has `enableBash: true`), which caps how much any prompting can guarantee.
