### PR TITLE
fix(shared): stop deleting mode_notice from outbound prompts

### DIFF
--- a/apps/cli/src/tui/hooks/use-agent-events.ts
+++ b/apps/cli/src/tui/hooks/use-agent-events.ts
@@ -1,4 +1,5 @@
 import type { AgentEvent, TeamEvent } from "@cline/core";
+import { formatDisplayUserInput } from "@cline/shared";
 import { useCallback, useRef } from "react";
 import type {
 	PendingPromptSnapshot,
@@ -296,7 +297,10 @@ export function useAgentEventHandlers(deps: AgentEventDeps) {
 	const handlePendingPromptSubmitted = useCallback(
 		(event: PendingPromptSubmittedEvent) => {
 			knownPendingPromptIdsRef.current.delete(event.id);
-			appendEntry({ kind: "user_submitted", text: event.prompt });
+			appendEntry({
+				kind: "user_submitted",
+				text: formatDisplayUserInput(event.prompt),
+			});
 		},
 		[appendEntry],
 	);

--- a/apps/cli/src/tui/hooks/use-agent-events.ts
+++ b/apps/cli/src/tui/hooks/use-agent-events.ts
@@ -297,6 +297,9 @@ export function useAgentEventHandlers(deps: AgentEventDeps) {
 	const handlePendingPromptSubmitted = useCallback(
 		(event: PendingPromptSubmittedEvent) => {
 			knownPendingPromptIdsRef.current.delete(event.id);
+			// Display boundary: formatDisplayUserInput strips runtime-generated
+			// notice elements (e.g. mode_notice) that normalizeUserInput must
+			// preserve, since the latter also sanitizes model-bound prompts.
 			appendEntry({
 				kind: "user_submitted",
 				text: formatDisplayUserInput(event.prompt),

--- a/sdk/packages/core/src/services/session-data.ts
+++ b/sdk/packages/core/src/services/session-data.ts
@@ -2,7 +2,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import type * as LlmsProviders from "@cline/llms";
 import type { AgentConfig, AgentEvent, AgentResult } from "@cline/shared";
-import { normalizeUserInput } from "@cline/shared";
+import { normalizeUserInput, stripModeNotices } from "@cline/shared";
 import { nanoid } from "nanoid";
 import {
 	parseSubSessionId,
@@ -231,7 +231,7 @@ export function normalizeTitle(title?: string | null): string | undefined {
 export function deriveTitleFromPrompt(
 	prompt?: string | null,
 ): string | undefined {
-	const normalized = normalizeUserInput(prompt ?? "").trim();
+	const normalized = stripModeNotices(normalizeUserInput(prompt ?? "")).trim();
 	if (!normalized) return undefined;
 	return normalizeTitle(normalized.split("\n")[0]?.trim());
 }

--- a/sdk/packages/core/src/services/session-data.ts
+++ b/sdk/packages/core/src/services/session-data.ts
@@ -231,6 +231,10 @@ export function normalizeTitle(title?: string | null): string | undefined {
 export function deriveTitleFromPrompt(
 	prompt?: string | null,
 ): string | undefined {
+	// Titles are display-only, so runtime-generated notice elements are
+	// stripped here rather than inside normalizeUserInput -- that function also
+	// sanitizes model-bound prompts (prepareTurnInput), where the notice must
+	// survive to reach the model.
 	const normalized = stripModeNotices(normalizeUserInput(prompt ?? "")).trim();
 	if (!normalized) return undefined;
 	return normalizeTitle(normalized.split("\n")[0]?.trim());

--- a/sdk/packages/shared/src/index.browser.ts
+++ b/sdk/packages/shared/src/index.browser.ts
@@ -234,6 +234,7 @@ export {
 	formatUserInputBlock,
 	normalizeUserInput,
 	parseUserCommandEnvelope,
+	stripModeNotices,
 	xmlTagsRemoval,
 } from "./prompt/format";
 export { isClineProvider } from "./providers/utils";

--- a/sdk/packages/shared/src/index.browser.ts
+++ b/sdk/packages/shared/src/index.browser.ts
@@ -235,7 +235,6 @@ export {
 	normalizeUserInput,
 	parseUserCommandEnvelope,
 	stripModeNotices,
-	stripTagElements,
 	xmlTagsRemoval,
 } from "./prompt/format";
 export { isClineProvider } from "./providers/utils";

--- a/sdk/packages/shared/src/index.browser.ts
+++ b/sdk/packages/shared/src/index.browser.ts
@@ -235,6 +235,7 @@ export {
 	normalizeUserInput,
 	parseUserCommandEnvelope,
 	stripModeNotices,
+	stripTagElements,
 	xmlTagsRemoval,
 } from "./prompt/format";
 export { isClineProvider } from "./providers/utils";

--- a/sdk/packages/shared/src/index.ts
+++ b/sdk/packages/shared/src/index.ts
@@ -249,7 +249,6 @@ export {
 	normalizeUserInput,
 	parseUserCommandEnvelope,
 	stripModeNotices,
-	stripTagElements,
 	xmlTagsRemoval,
 } from "./prompt/format";
 export { isClineProvider } from "./providers/utils";

--- a/sdk/packages/shared/src/index.ts
+++ b/sdk/packages/shared/src/index.ts
@@ -248,6 +248,7 @@ export {
 	formatUserInputBlock,
 	normalizeUserInput,
 	parseUserCommandEnvelope,
+	stripModeNotices,
 	xmlTagsRemoval,
 } from "./prompt/format";
 export { isClineProvider } from "./providers/utils";

--- a/sdk/packages/shared/src/index.ts
+++ b/sdk/packages/shared/src/index.ts
@@ -249,6 +249,7 @@ export {
 	normalizeUserInput,
 	parseUserCommandEnvelope,
 	stripModeNotices,
+	stripTagElements,
 	xmlTagsRemoval,
 } from "./prompt/format";
 export { isClineProvider } from "./providers/utils";

--- a/sdk/packages/shared/src/prompt/format.test.ts
+++ b/sdk/packages/shared/src/prompt/format.test.ts
@@ -7,7 +7,6 @@ import {
 	normalizeUserInput,
 	parseUserCommandEnvelope,
 	stripModeNotices,
-	stripTagElements,
 } from "./format";
 
 describe("prompt format helpers", () => {
@@ -63,12 +62,6 @@ describe("prompt format helpers", () => {
 		// signal before the model ever sees it.
 		const prompt = `${formatModeSwitchNotice("plan", "act")}\ndo it`;
 		expect(normalizeUserInput(prompt)).toBe(prompt);
-	});
-
-	it("strips arbitrary tag elements content included", () => {
-		expect(
-			stripTagElements("<foo>x</foo>keep<bar>y</bar>", ["foo", "bar"]),
-		).toBe("keep");
 	});
 
 	it("removes every mode notice and leaves unclosed ones intact", () => {

--- a/sdk/packages/shared/src/prompt/format.test.ts
+++ b/sdk/packages/shared/src/prompt/format.test.ts
@@ -7,6 +7,7 @@ import {
 	normalizeUserInput,
 	parseUserCommandEnvelope,
 	stripModeNotices,
+	stripTagElements,
 } from "./format";
 
 describe("prompt format helpers", () => {
@@ -62,6 +63,12 @@ describe("prompt format helpers", () => {
 		// signal before the model ever sees it.
 		const prompt = `${formatModeSwitchNotice("plan", "act")}\ndo it`;
 		expect(normalizeUserInput(prompt)).toBe(prompt);
+	});
+
+	it("strips arbitrary tag elements content included", () => {
+		expect(
+			stripTagElements("<foo>x</foo>keep<bar>y</bar>", ["foo", "bar"]),
+		).toBe("keep");
 	});
 
 	it("removes every mode notice and leaves unclosed ones intact", () => {

--- a/sdk/packages/shared/src/prompt/format.test.ts
+++ b/sdk/packages/shared/src/prompt/format.test.ts
@@ -6,6 +6,7 @@ import {
 	formatUserInputBlock,
 	normalizeUserInput,
 	parseUserCommandEnvelope,
+	stripModeNotices,
 } from "./format";
 
 describe("prompt format helpers", () => {
@@ -53,26 +54,33 @@ describe("prompt format helpers", () => {
 		expect(formatDisplayUserInput(wrapped)).toBe(
 			"how should we refactor this?",
 		);
-		expect(normalizeUserInput(wrapped)).toBe("how should we refactor this?");
+	});
+
+	it("keeps mode switch notices when normalizing outbound prompts", () => {
+		// prepareTurnInput sanitizes prompts with normalizeUserInput before the
+		// host wraps them; stripping notices here would delete the switch
+		// signal before the model ever sees it.
+		const prompt = `${formatModeSwitchNotice("plan", "act")}\ndo it`;
+		expect(normalizeUserInput(prompt)).toBe(prompt);
 	});
 
 	it("removes every mode notice and leaves unclosed ones intact", () => {
 		expect(
-			normalizeUserInput(
+			stripModeNotices(
 				"<mode_notice>a</mode_notice>hello<mode_notice>b</mode_notice> there",
 			),
 		).toBe("hello there");
-		expect(normalizeUserInput("<mode_notice>dangling")).toBe(
+		expect(stripModeNotices("<mode_notice>dangling")).toBe(
 			"<mode_notice>dangling",
 		);
 	});
 
-	it("normalizes adversarial repeated open tags in linear time", () => {
+	it("strips adversarial repeated open tags in linear time", () => {
 		// Regression guard for CodeQL js/polynomial-redos: many unmatched
 		// opening tags must not trigger quadratic rescanning.
 		const hostile = "<mode_notice>".repeat(50_000);
 		const started = performance.now();
-		const result = normalizeUserInput(hostile);
+		const result = stripModeNotices(hostile);
 		expect(performance.now() - started).toBeLessThan(1_000);
 		expect(result).toBe(hostile);
 	});

--- a/sdk/packages/shared/src/prompt/format.ts
+++ b/sdk/packages/shared/src/prompt/format.ts
@@ -90,15 +90,35 @@ export function normalizeUserInput(input?: string): string {
 }
 
 /**
- * Removes runtime-generated <mode_notice> elements (content included): they
- * are not user-typed text and must not render as such. Deliberately NOT part
- * of normalizeUserInput -- that function also sanitizes outbound prompts
- * before the host wraps them (prepareTurnInput), and stripping there deletes
- * the notice before the model ever sees it.
+ * Tags whose whole element (content included) is runtime-generated context
+ * for the model, not user-typed text, and must be hidden from display.
+ */
+const DISPLAY_HIDDEN_TAGS = ["mode_notice"] as const;
+
+/**
+ * Removes runtime-generated elements that must not render as user text.
+ * Deliberately NOT part of normalizeUserInput -- that function also sanitizes
+ * outbound prompts before the host wraps them (prepareTurnInput), and
+ * stripping there deletes the content before the model ever sees it.
  */
 export function stripModeNotices(input?: string): string {
+	return stripTagElements(input, DISPLAY_HIDDEN_TAGS);
+}
+
+/**
+ * Removes each listed tag's elements entirely, content included. Counterpart
+ * to xmlTagsRemoval, which unwraps a tag but keeps its content.
+ */
+export function stripTagElements(
+	input: string | undefined,
+	tags: readonly string[],
+): string {
 	if (!input?.trim()) return "";
-	return removeTagElements(input, "mode_notice").trim();
+	let result = input;
+	for (const tag of tags) {
+		result = removeTagElements(result, tag);
+	}
+	return result.trim();
 }
 
 // indexOf-based rather than a regex: a lazy dot-all pattern re-scans to the

--- a/sdk/packages/shared/src/prompt/format.ts
+++ b/sdk/packages/shared/src/prompt/format.ts
@@ -90,35 +90,15 @@ export function normalizeUserInput(input?: string): string {
 }
 
 /**
- * Tags whose whole element (content included) is runtime-generated context
- * for the model, not user-typed text, and must be hidden from display.
- */
-const DISPLAY_HIDDEN_TAGS = ["mode_notice"] as const;
-
-/**
- * Removes runtime-generated elements that must not render as user text.
- * Deliberately NOT part of normalizeUserInput -- that function also sanitizes
- * outbound prompts before the host wraps them (prepareTurnInput), and
- * stripping there deletes the content before the model ever sees it.
+ * Removes runtime-generated <mode_notice> elements (content included): they
+ * are not user-typed text and must not render as such. Deliberately NOT part
+ * of normalizeUserInput -- that function also sanitizes outbound prompts
+ * before the host wraps them (prepareTurnInput), and stripping there deletes
+ * the notice before the model ever sees it.
  */
 export function stripModeNotices(input?: string): string {
-	return stripTagElements(input, DISPLAY_HIDDEN_TAGS);
-}
-
-/**
- * Removes each listed tag's elements entirely, content included. Counterpart
- * to xmlTagsRemoval, which unwraps a tag but keeps its content.
- */
-export function stripTagElements(
-	input: string | undefined,
-	tags: readonly string[],
-): string {
 	if (!input?.trim()) return "";
-	let result = input;
-	for (const tag of tags) {
-		result = removeTagElements(result, tag);
-	}
-	return result.trim();
+	return removeTagElements(input, "mode_notice").trim();
 }
 
 // indexOf-based rather than a regex: a lazy dot-all pattern re-scans to the

--- a/sdk/packages/shared/src/prompt/format.ts
+++ b/sdk/packages/shared/src/prompt/format.ts
@@ -16,7 +16,9 @@ export function formatUserCommandBlock(input: string, slash: string): string {
 /**
  * Marks the exact point in the conversation where the user switched between
  * plan and act modes. Prepended to the first user message sent after the
- * switch; stripped from transcript display by normalizeUserInput.
+ * switch. It survives normalizeUserInput (so the outbound sanitize in
+ * prepareTurnInput delivers it to the model) and is hidden from transcript
+ * display by stripModeNotices at display boundaries.
  */
 export function formatModeSwitchNotice(
 	from: "act" | "plan",

--- a/sdk/packages/shared/src/prompt/format.ts
+++ b/sdk/packages/shared/src/prompt/format.ts
@@ -84,10 +84,19 @@ export function normalizeUserInput(input?: string): string {
 				: next.replace(new RegExp(`<${tag}[^>]*>`, "g"), "")
 		).trim();
 	}
-	// mode_notice is runtime-generated context, not user-typed text; unlike the
-	// wrapper tags above, the whole element (content included) is hidden.
-	next = removeTagElements(next, "mode_notice").trim();
 	return next;
+}
+
+/**
+ * Removes runtime-generated <mode_notice> elements (content included): they
+ * are not user-typed text and must not render as such. Deliberately NOT part
+ * of normalizeUserInput -- that function also sanitizes outbound prompts
+ * before the host wraps them (prepareTurnInput), and stripping there deletes
+ * the notice before the model ever sees it.
+ */
+export function stripModeNotices(input?: string): string {
+	if (!input?.trim()) return "";
+	return removeTagElements(input, "mode_notice").trim();
 }
 
 // indexOf-based rather than a regex: a lazy dot-all pattern re-scans to the
@@ -110,7 +119,7 @@ function removeTagElements(input: string, tag: string): string {
 }
 
 export function formatDisplayUserInput(input?: string): string {
-	const normalized = normalizeUserInput(input);
+	const normalized = stripModeNotices(normalizeUserInput(input));
 	const envelope = parseUserCommandEnvelope(input);
 	if (!envelope) {
 		return normalized;


### PR DESCRIPTION
### Related Issue

Fixes a bug in #12057 (merged) — found by live-testing it.

### Description

**The mode-switch notice never reached the model.** #12057 prepends `<mode_notice>The user switched from X mode to Y mode…</mode_notice>` to the first user message after a Tab toggle, and hid it from transcript display by stripping it inside `normalizeUserInput`. What I missed: `normalizeUserInput` isn't display-only — `prepareTurnInput` in `local-runtime-host.ts` runs it on **every outbound prompt** before wrapping (its job there is to strip stale wrappers so re-sends don't double-wrap). So the host deleted the notice from every message before the model ever saw it. The feature was a runtime no-op.

**How this surfaced (fun one):** in a live test, the user toggled plan→act and sent "do it"; the model refused, claiming it was "still in plan mode — no mode switch indicated on this message." The stored transcript confirms the message carried the `user_input mode="act"` wrapper but **no notice**. Worse, in the same session the model had earlier claimed it *did* receive a `mode_notice` when asked — pure confabulation, enabled by the system prompt describing the tag. A good reminder that "the model says it saw X" is not verification; only the stored transcript is.

**The fix:** separate the two concerns that were conflated in one function.

- `normalizeUserInput` (outbound sanitizer + history normalization) now **preserves** notices, with a regression test pinning that behavior and a comment on `stripModeNotices` explaining why it must stay out.
- A new `stripModeNotices()` is applied only at display boundaries:
  - `formatDisplayUserInput` — covers TUI resume hydration, hub views, exports, and `inferTitleFromMessages`.
  - `deriveTitleFromPrompt` (`session-data.ts`) — session titles could otherwise start with "<mode_notice>The user switched…".
  - the TUI queued-prompt echo (`use-agent-events.ts`) — a queued message carrying a notice would otherwise render the raw tag in chat.

**Side benefits:** notices now survive the `message-builder` history normalization (rebuilt sessions keep the switch markers in prior messages) and the pending-prompt queue (queued/steered sends deliver their notice), which also closes the Greptile-flagged edge from #12057 review for the queued path.

### Test Procedure

- Updated `format.test.ts` (8 passing): new regression test that `normalizeUserInput` **preserves** a notice-prefixed prompt verbatim; display tests moved to `formatDisplayUserInput`/`stripModeNotices`; unclosed-tag and adversarial-input (CodeQL linear-time) tests retained on `stripModeNotices`.
- End-to-end pipeline assertion (the exact chain that was broken): CLI-prepended notice → `normalizeUserInput` (host sanitize) → `formatUserInputBlock` (host wrap) → resulting stored message **contains** the notice → `formatDisplayUserInput` of that stored message shows only the user's text.
- `tsc --noEmit` and biome clean. (Local vitest was flaky due to sandbox thread exhaustion — 500+ orphaned shells — so CI is the authoritative full-suite run; the format suite passed locally 8/8.)
- Real verification after merge: toggle plan→act in the TUI, send a message, then check `~/.cline/data/sessions/<id>/<id>.messages.json` — the stored user message must contain both the `user_input` wrapper **and** the `mode_notice` block. Don't ask the model whether it saw the notice; it will happily say yes either way.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Stored message before this fix (notice already deleted by the host — model sees no switch signal):

```json
{"type":"text","text":"<user_input mode=\"act\">do it</user_input>"}
```

After this fix:

```json
{"type":"text","text":"<user_input mode=\"act\"><mode_notice>The user switched from plan mode to act mode before sending this message.</mode_notice>\ndo it</user_input>"}
```

…while TUI resume / hub / exports still display just: `do it`

### Additional Notes

Pre-existing behavior observed while debugging, unchanged here: session restarts normalize *prior* user messages via `message-builder`, which strips their `user_input` wrappers — so after a toggle, only post-restart messages carry mode attributes. With this fix the notices survive that normalization, which partially compensates. If we ever want full mode-attribute history preserved across restarts, that's a separate discussion about `message-builder`'s normalization.
