### PR TITLE
fix(llms): stop AI SDK from rejecting malformed tool calls before flexible tool executors can handle them

### DIFF
--- a/sdk/packages/llms/src/providers/ai-sdk.tool-calls.test.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.tool-calls.test.ts
@@ -1,0 +1,264 @@
+import type {
+	AgentModelEvent,
+	AgentToolDefinition,
+	GatewayProviderContext,
+	GatewayStreamRequest,
+} from "@cline/shared";
+import { NoSuchToolError } from "ai";
+import { describe, expect, it } from "vitest";
+import {
+	createOpenAICompatibleProvider,
+	repairMalformedToolCall,
+} from "./ai-sdk";
+
+/**
+ * Integration tests for malformed tool-call handling in the AI SDK adapter.
+ *
+ * Weaker models routinely emit tool calls with type mismatches (a bare string
+ * where the schema wants an array) or arguments that are not valid JSON
+ * (truncated payloads, single quotes). These tests drive the real adapter
+ * with a fake OpenAI-compatible SSE response and assert that such calls are
+ * coerced/repaired instead of being rejected before execution
+ * (`metadata.inputParseError`), which surfaced as the
+ * tool_call_type_validation / tool_call_invalid_json buckets under
+ * task.provider_api_error.
+ */
+
+const RUN_COMMANDS_TOOL: AgentToolDefinition = {
+	name: "run_commands",
+	description: "Run shell commands",
+	inputSchema: {
+		type: "object",
+		properties: {
+			commands: { type: "array", items: { type: "string" } },
+		},
+		required: ["commands"],
+	},
+};
+
+const READ_FILES_TOOL: AgentToolDefinition = {
+	name: "read_files",
+	description: "Read files",
+	inputSchema: {
+		type: "object",
+		properties: {
+			files: {
+				type: "array",
+				items: {
+					type: "object",
+					properties: { path: { type: "string" } },
+					required: ["path"],
+				},
+			},
+		},
+		required: ["files"],
+	},
+};
+
+function sseToolCall(toolName: string, args: string): string {
+	const chunk = (delta: unknown, finish: string | null = null) =>
+		`data: ${JSON.stringify({
+			id: "cmpl-1",
+			object: "chat.completion.chunk",
+			created: 1,
+			model: "test-model",
+			choices: [{ index: 0, delta, finish_reason: finish }],
+		})}\n\n`;
+	return (
+		chunk({
+			role: "assistant",
+			tool_calls: [
+				{
+					index: 0,
+					id: "call_1",
+					type: "function",
+					function: { name: toolName, arguments: "" },
+				},
+			],
+		}) +
+		chunk({ tool_calls: [{ index: 0, function: { arguments: args } }] }) +
+		chunk({}, "tool_calls") +
+		"data: [DONE]\n\n"
+	);
+}
+
+async function streamToolCallEvents(
+	sseBody: string,
+	tools: AgentToolDefinition[],
+): Promise<AgentModelEvent[]> {
+	const config = {
+		providerId: "openai-compatible",
+		apiKey: "test-key",
+		baseUrl: "http://fake.local/v1",
+		fetch: (async () =>
+			new Response(sseBody, {
+				status: 200,
+				headers: { "content-type": "text/event-stream" },
+			})) as unknown as typeof fetch,
+	};
+	const provider = await createOpenAICompatibleProvider(config);
+	const model = {
+		id: "test-model",
+		providerId: "openai-compatible",
+		name: "test-model",
+	};
+	const context = {
+		provider: {
+			id: "openai-compatible",
+			name: "OpenAI Compatible",
+			defaultModelId: "test-model",
+			models: [model],
+		},
+		model,
+		config,
+	} as unknown as GatewayProviderContext;
+	const request = {
+		providerId: "openai-compatible",
+		modelId: "test-model",
+		messages: [
+			{
+				id: "msg_user",
+				role: "user",
+				content: [{ type: "text", text: "do the thing" }],
+				createdAt: new Date(),
+			},
+		],
+		tools,
+	} as unknown as GatewayStreamRequest;
+
+	const events: AgentModelEvent[] = [];
+	for await (const event of await provider.stream(request, context)) {
+		events.push(event);
+	}
+	return events;
+}
+
+function findParseError(events: AgentModelEvent[]): string | undefined {
+	for (const event of events) {
+		if (event.type !== "tool-call-delta") continue;
+		const metadata = event.metadata as Record<string, unknown> | undefined;
+		if (typeof metadata?.inputParseError === "string") {
+			return metadata.inputParseError;
+		}
+	}
+	return undefined;
+}
+
+function findToolInput(events: AgentModelEvent[]): unknown {
+	for (const event of events) {
+		if (event.type === "tool-call-delta" && event.input !== undefined) {
+			return event.input;
+		}
+	}
+	return undefined;
+}
+
+describe("ai-sdk adapter malformed tool calls", () => {
+	it("passes schema-mismatched input through to the tool instead of rejecting", async () => {
+		// The executor's lenient union schema accepts a bare string for a
+		// string[] property; rejecting at the adapter would prevent that.
+		const events = await streamToolCallEvents(
+			sseToolCall("run_commands", '{"commands": "ls -la"}'),
+			[RUN_COMMANDS_TOOL],
+		);
+
+		expect(findParseError(events)).toBeUndefined();
+		expect(findToolInput(events)).toEqual({ commands: "ls -la" });
+	});
+
+	it("passes well-formed input through unchanged", async () => {
+		const events = await streamToolCallEvents(
+			sseToolCall("run_commands", '{"commands": ["ls", "pwd"]}'),
+			[RUN_COMMANDS_TOOL],
+		);
+
+		expect(findParseError(events)).toBeUndefined();
+		expect(findToolInput(events)).toEqual({ commands: ["ls", "pwd"] });
+	});
+
+	it("repairs truncated JSON arguments", async () => {
+		const events = await streamToolCallEvents(
+			sseToolCall("read_files", '{"files": [{"path": "/tmp/a.txt"}]'),
+			[READ_FILES_TOOL],
+		);
+
+		expect(findParseError(events)).toBeUndefined();
+		expect(findToolInput(events)).toEqual({ files: [{ path: "/tmp/a.txt" }] });
+	});
+
+	it("repairs single-quoted JSON arguments", async () => {
+		const events = await streamToolCallEvents(
+			sseToolCall("run_commands", "{'commands': ['ls']}"),
+			[RUN_COMMANDS_TOOL],
+		);
+
+		expect(findParseError(events)).toBeUndefined();
+		expect(findToolInput(events)).toEqual({ commands: ["ls"] });
+	});
+
+	it("still surfaces a parse error for unrepairable argument text", async () => {
+		const events = await streamToolCallEvents(
+			sseToolCall("run_commands", "run ls for me please"),
+			[RUN_COMMANDS_TOOL],
+		);
+
+		expect(findParseError(events)).toContain("Invalid input");
+	});
+
+	it("keeps the unavailable-tool error for unknown tools", async () => {
+		const events = await streamToolCallEvents(
+			sseToolCall("editor", '{"path": "/tmp/a.txt", "new_text": "x"}'),
+			[RUN_COMMANDS_TOOL, READ_FILES_TOOL],
+		);
+
+		expect(findParseError(events)).toContain("unavailable tool 'editor'");
+	});
+});
+
+describe("repairMalformedToolCall", () => {
+	const toolCall = (input: string) => ({
+		toolCallId: "call_1",
+		toolName: "run_commands",
+		input,
+	});
+
+	it("repairs truncated JSON", async () => {
+		const repaired = await repairMalformedToolCall({
+			toolCall: toolCall('{"commands": ["ls"'),
+			error: new Error("JSON parsing failed"),
+		});
+		expect(repaired?.input).toBe('{"commands":["ls"]}');
+	});
+
+	it("repairs single-quoted JSON", async () => {
+		const repaired = await repairMalformedToolCall({
+			toolCall: toolCall("{'commands': ['ls']}"),
+			error: new Error("JSON parsing failed"),
+		});
+		expect(repaired?.input).toBe('{"commands":["ls"]}');
+	});
+
+	it("returns null for already-valid JSON (schema failures are not repairable here)", async () => {
+		const repaired = await repairMalformedToolCall({
+			toolCall: toolCall('{"commands": "ls"}'),
+			error: new Error("Type validation failed"),
+		});
+		expect(repaired).toBeNull();
+	});
+
+	it("returns null for unknown-tool errors", async () => {
+		const repaired = await repairMalformedToolCall({
+			toolCall: toolCall('{"commands": ["ls"]}'),
+			error: new NoSuchToolError({ toolName: "run_commands" }),
+		});
+		expect(repaired).toBeNull();
+	});
+
+	it("returns null for unrepairable garbage", async () => {
+		const repaired = await repairMalformedToolCall({
+			toolCall: toolCall("run ls for me"),
+			error: new Error("JSON parsing failed"),
+		});
+		expect(repaired).toBeNull();
+	});
+});

--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -12,11 +12,11 @@ import {
 	type AiSdkFormatterPart,
 	captureSdkError,
 	formatMessagesForAiSdk,
+	parseJsonStream,
 	sanitizeSurrogates,
 } from "@cline/shared";
-import { jsonSchema, streamText } from "ai";
+import { jsonSchema, NoSuchToolError, streamText } from "ai";
 import { nanoid } from "nanoid";
-import { z } from "zod";
 import { extractErrorMessage } from "./format";
 import {
 	isAnthropicCompatibleModel,
@@ -373,6 +373,11 @@ function toAiSdkTools(
 		return undefined;
 	}
 
+	// No validate callback on purpose: schema validation belongs to the tools
+	// themselves (core executors validate with lenient union schemas that
+	// accept common weak-model shapes like a bare string for a string[]
+	// property). Rejecting here would return an error to the model without
+	// the tool's own input handling ever seeing the call.
 	return Object.fromEntries(
 		request.tools.map((definition) => [
 			definition.name,
@@ -380,20 +385,51 @@ function toAiSdkTools(
 				description: definition.description,
 				inputSchema: jsonSchema(
 					normalizeAiSdkToolInputSchema(definition.inputSchema),
-					{
-						validate: async (value) => {
-							const result = await z
-								.fromJSONSchema(definition.inputSchema)
-								.safeParseAsync(value);
-							return result.success
-								? { success: true, value: result.data }
-								: { success: false, error: result.error };
-						},
-					},
 				) as never,
 			} as unknown,
 		]),
 	);
+}
+
+interface RepairableToolCall {
+	toolCallId: string;
+	toolName: string;
+	input: string;
+}
+
+/**
+ * Last-chance repair for tool calls whose arguments are not valid JSON
+ * (truncated payloads, single quotes, unescaped newlines — common with
+ * weaker models). Runs the raw argument text through the shared jsonrepair
+ * strategies; unknown tool names and already-valid JSON are not repairable
+ * here, and returning null preserves the AI SDK's original error behavior.
+ */
+export async function repairMalformedToolCall<T extends RepairableToolCall>({
+	toolCall,
+	error,
+}: {
+	toolCall: T;
+	error: unknown;
+}): Promise<T | null> {
+	if (NoSuchToolError.isInstance(error)) {
+		return null;
+	}
+	if (typeof toolCall.input !== "string" || toolCall.input.trim() === "") {
+		return null;
+	}
+	try {
+		JSON.parse(toolCall.input);
+		// Valid JSON means the failure was schema validation, which the
+		// lenient validate callback already had its chance to coerce.
+		return null;
+	} catch {
+		// Not valid JSON — attempt repair below.
+	}
+	const repaired = parseJsonStream(toolCall.input);
+	if (repaired === toolCall.input || typeof repaired === "string") {
+		return null;
+	}
+	return { ...toolCall, input: JSON.stringify(repaired) };
 }
 
 function normalizeAiSdkToolInputSchema(
@@ -1160,6 +1196,7 @@ function createAiSdkProvider(kind: ProviderModuleKind): GatewayProviderFactory {
 						? { maxOutputTokens: request.maxTokens }
 						: {}),
 					abortSignal: request.signal,
+					experimental_repairToolCall: repairMalformedToolCall as never,
 					experimental_telemetry: {
 						isEnabled: langfuse,
 					},

--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -419,8 +419,9 @@ export async function repairMalformedToolCall<T extends RepairableToolCall>({
 	}
 	try {
 		JSON.parse(toolCall.input);
-		// Valid JSON means the failure was schema validation, which the
-		// lenient validate callback already had its chance to coerce.
+		// Valid JSON means the failure was a schema mismatch, not a parse
+		// error. That is left to the tool executor's own lenient union
+		// schemas; there is nothing to repair here.
 		return null;
 	} catch {
 		// Not valid JSON — attempt repair below.


### PR DESCRIPTION
Driven by internal telemetry triage: the largest raw error buckets under `task.provider_api_error` are `tool_call_type_validation`, `tool_call_invalid_json`, and `tool_call_unavailable_tool` — agent/tool-call issues rather than provider failures, concentrated on weaker models (representative payloads: invalid JSON arguments for `run_commands` and `read_files`, and calls to unavailable tools like `editor`).

#### The problem

Weaker models routinely fumble tool calls in two ways:

1. **Schema mismatch, valid JSON** — e.g. `{"commands": "ls -la"}` (bare string where the schema wants `string[]`)
2. **Unparsable JSON** — truncated payloads (`{"files": [{"path": "a.txt"}]` missing a brace), single-quoted JSON, unescaped newlines

The SDK already has lenient handling for exactly these shapes — and none of it was reachable. The core tool executors validate with permissive union schemas (`RunCommandsInputUnionSchema` accepts a bare string, `{"command": ...}` singular, a plain array, etc.), `@cline/shared` ships a jsonrepair-based parser (`parseJsonStream`), and the agent runtime has `normalizeJsonLikeStringsForSchema`. All three are downstream of a chokepoint that rejected the call first.

#### Where the calls actually died

`toAiSdkTools` in `sdk/packages/llms/src/providers/ai-sdk.ts` handed the Vercel AI SDK a **strict** validator built from the advertised JSON schema (`z.fromJSONSchema(inputSchema).safeParseAsync`). The AI SDK parses the raw argument text, then runs that validator; if either step fails it emits a `tool-error` stream part. The adapter converts that into `metadata.inputParseError` on the tool call, and the agent runtime treats that flag as an absolute "do not execute" — the error text goes back to the model and the tool's `execute` (where all the leniency lives) never runs.

So the pipeline was: strict bouncer at the front door of a building whose whole point is being lenient. The bouncer arrived with the Tool→AgentTool refactor (sdk#346); the union schemas predate it and were effective in the legacy extension architecture, which had no early validation.

This was verified end-to-end with a repro that drives the real `createOpenAICompatibleProvider` with a canned OpenAI-compatible SSE response and replays the events through the real `AgentRuntime` with the real core tools: all malformed scenarios errored without ever invoking an executor, while `normalizeRunCommandsInput({commands: "ls -la"})` and `parseJsonStream('{"files": [{"path": …}]')` each handled the exact failing payloads.

Why this pollutes provider telemetry: when a turn's tool calls all fail, the orchestrator records a mistake, the `MistakeTracker` emits a `{type: "error"}` event, and `handleAgentEvent` maps **every** error event to `captureProviderApiError`. Model fumbles therefore surface as provider API errors.

#### The fix (one file, two changes)

1. **Drop the `validate` callback.** Without it the AI SDK passes the parsed input through untouched (`safeValidateTypes` short-circuits when `schema.validate == null`), and validation happens where it always lived: in the tools. Core executors validate with their lenient union schemas and produce better, shape-aware error messages when input is genuinely bad. This also covers shapes no generic coercion could fix, like `{"command": "ls"}` with a singular key — the union schema accepts it.
2. **Add `experimental_repairToolCall`.** Unparsable JSON fails *before* there is any input to pass through, so removal alone can't fix it. The AI SDK's purpose-built repair hook now runs the raw argument text through the shared jsonrepair strategies (`parseJsonStream`). If repair succeeds the call proceeds normally; if not, we return `null` and the current error behavior happens unchanged. Already-valid JSON and unknown-tool errors are deliberately not "repaired".


