### PR TITLE
fix(core): return completed status for sync team runs

### DIFF
--- a/sdk/packages/core/src/extensions/tools/team/team-tools.test.ts
+++ b/sdk/packages/core/src/extensions/tools/team/team-tools.test.ts
@@ -820,7 +820,11 @@ describe("createAgentTeamsTools runtime behavior", () => {
 
 		// Both callers should receive the same result from the shared in-flight run.
 		resolveRoute({ text: "Probability explained", iterations: 3 });
-		const result1 = (await call1) as { text?: string; iterations?: number };
+		const result1 = (await call1) as {
+			text?: string;
+			iterations?: number;
+			status?: string;
+		};
 		const result2 = (await call2) as {
 			text?: string;
 			iterations?: number;
@@ -830,6 +834,7 @@ describe("createAgentTeamsTools runtime behavior", () => {
 		};
 		expect(result1.text).toBe("Probability explained");
 		expect(result1.iterations).toBe(3);
+		expect(result1.status).toBe("completed");
 		expect(result2.text).toBe("Probability explained");
 		expect(result2.iterations).toBe(3);
 		expect(result2.status).toBe("joined");

--- a/sdk/packages/core/src/extensions/tools/team/team-tools.ts
+++ b/sdk/packages/core/src/extensions/tools/team/team-tools.ts
@@ -542,7 +542,7 @@ export function createAgentTeamsTools(
 						validateWithZod(TeamRunTaskToolResultSchema, {
 							agentId: validatedInput.agentId,
 							mode: "sync" as const,
-							status: "running" as const,
+							status: "completed" as const,
 							dispatched: true,
 							message: `Task dispatched to ${validatedInput.agentId} and completed in sync mode.`,
 							text: result.text,

--- a/sdk/packages/core/src/extensions/tools/team/team-tools.ts
+++ b/sdk/packages/core/src/extensions/tools/team/team-tools.ts
@@ -538,7 +538,7 @@ export function createAgentTeamsTools(
 						validateWithZod(TeamRunTaskToolResultSchema, {
 							agentId: validatedInput.agentId,
 							mode: "sync" as const,
-							status: "running" as const,
+							status: "completed" as const,
 							dispatched: true,
 							message: `Task dispatched to ${validatedInput.agentId} and completed in sync mode.`,
 							text: result.text,

--- a/sdk/packages/shared/src/team/schema.ts
+++ b/sdk/packages/shared/src/team/schema.ts
@@ -327,7 +327,7 @@ export const TeamTaskToolResultSchema = z.discriminatedUnion("action", [
 export const TeamRunTaskToolResultSchema = z.object({
 	agentId: z.string(),
 	mode: z.enum(["sync", "async"]),
-	status: z.enum(["dispatched", "running", "queued", "joined"]),
+	status: z.enum(["completed", "dispatched", "running", "queued", "joined"]),
 	dispatched: z.boolean(),
 	message: z.string(),
 	deduped: z.boolean().optional(),


### PR DESCRIPTION
## Summary
- return `completed` for sync `team_run_task` results after the teammate run finishes
- add `completed` to the team run task result schema
- add regression coverage for the sync result status

Closes #12062

## Verification
- `bun -F @cline/shared typecheck`
- `bun -F @cline/core typecheck`
- `bun -F @cline/core test:unit`
- manual tool-path check returned `status: "completed"`