### PR TITLE
feat(vscode): recognize Chutes provider

### DIFF
--- a/apps/vscode/src/sdk/model-catalog/provider-id.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/provider-id.test.ts
@@ -50,6 +50,7 @@ describe("parseProviderId", () => {
 		parseProviderId("v0")
 		parseProviderId("xiaomi")
 		parseProviderId("tencent-tokenhub")
+		parseProviderId("chutes")
 
 		expect(warnSpy).not.toHaveBeenCalled()
 	})
@@ -66,6 +67,7 @@ describe("isKnownProviderId", () => {
 		expect(isKnownProviderId(parseProviderId("v0"))).toBe(true)
 		expect(isKnownProviderId(parseProviderId("xiaomi"))).toBe(true)
 		expect(isKnownProviderId(parseProviderId("tencent-tokenhub"))).toBe(true)
+		expect(isKnownProviderId(parseProviderId("chutes"))).toBe(true)
 	})
 
 	it("returns false for a custom provider id", () => {

--- a/apps/vscode/src/sdk/model-catalog/provider-id.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/provider-id.test.ts
@@ -56,6 +56,7 @@ describe("parseProviderId", () => {
 		parseProviderId("v0")
 		parseProviderId("xiaomi")
 		parseProviderId("tencent-tokenhub")
+		parseProviderId("chutes")
 
 		expect(warnSpy).not.toHaveBeenCalled()
 	})
@@ -72,6 +73,7 @@ describe("isKnownProviderId", () => {
 		expect(isKnownProviderId(parseProviderId("v0"))).toBe(true)
 		expect(isKnownProviderId(parseProviderId("xiaomi"))).toBe(true)
 		expect(isKnownProviderId(parseProviderId("tencent-tokenhub"))).toBe(true)
+		expect(isKnownProviderId(parseProviderId("chutes"))).toBe(true)
 	})
 
 	it("returns false for a custom provider id", () => {

--- a/apps/vscode/src/sdk/model-catalog/provider-id.ts
+++ b/apps/vscode/src/sdk/model-catalog/provider-id.ts
@@ -58,6 +58,7 @@ const KNOWN_API_PROVIDERS = {
 	wandb: true,
 	xiaomi: true,
 	"tencent-tokenhub": true,
+	chutes: true,
 	"cline-pass": true,
 } satisfies Record<ApiProvider, true>
 

--- a/apps/vscode/src/shared/api.ts
+++ b/apps/vscode/src/shared/api.ts
@@ -50,6 +50,7 @@ export type ApiProvider =
 	| "wandb"
 	| "xiaomi"
 	| "tencent-tokenhub"
+	| "chutes"
 
 export const DEFAULT_API_PROVIDER = "openrouter" as ApiProvider
 

--- a/apps/vscode/src/shared/proto-conversions/models/api-configuration-conversion.test.ts
+++ b/apps/vscode/src/shared/proto-conversions/models/api-configuration-conversion.test.ts
@@ -4,7 +4,7 @@ import { convertApiConfigurationToProto, convertProtoToApiConfiguration } from "
 
 describe("api configuration provider conversion", () => {
 	it("round-trips SDK provider ids added after the legacy enum list", () => {
-		const providers: ApiProvider[] = ["poolside", "v0", "xiaomi", "tencent-tokenhub", "zai-coding-plan"]
+		const providers: ApiProvider[] = ["poolside", "v0", "xiaomi", "tencent-tokenhub", "chutes", "zai-coding-plan"]
 
 		for (const provider of providers) {
 			const proto = convertApiConfigurationToProto({

--- a/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.test.ts
+++ b/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.test.ts
@@ -55,6 +55,7 @@ describe("providerSettingsRegistry", () => {
 		const migratedProviders = [
 			["baseten", "Baseten", "https://app.baseten.co/settings/api_keys"],
 			["cerebras", "Cerebras", "https://cloud.cerebras.ai/"],
+			["chutes", "Chutes", "https://chutes.ai/app/api"],
 			["doubao", "Doubao", "https://console.volcengine.com/home"],
 			["fireworks", "Fireworks", "https://fireworks.ai/"],
 			["groq", "Groq", "https://console.groq.com/keys"],

--- a/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.ts
+++ b/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.ts
@@ -100,6 +100,9 @@ const GENERIC_PROVIDER_PRESENTATION_OVERRIDES: Record<string, GenericProviderPre
 	"tencent-tokenhub": {
 		signupUrl: "https://cloud.tencent.com/document/product/1823/130050",
 	},
+	chutes: {
+		signupUrl: "https://chutes.ai/app/api",
+	},
 	"zai-coding-plan": {},
 }
 
@@ -161,6 +164,7 @@ const FALLBACK_GENERIC_PROVIDER_NAMES = {
 	wandb: "W&B",
 	xiaomi: "Xiaomi",
 	"tencent-tokenhub": "Tencent TokenHub",
+	chutes: "Chutes",
 	"zai-coding-plan": "Z.AI Coding Plan",
 } as const
 


### PR DESCRIPTION
## Related

- Feature Request: [#12284](https://github.com/cline/cline/discussions/12284)
- SDK provider: [#11548](https://github.com/cline/cline/pull/11548)
- Related to [#10495](https://github.com/cline/cline/issues/10495), which includes Chutes-specific provider recognition reports

## What

Adds VS Code-side recognition for the Chutes built-in provider so it appears in provider settings and round-trips through configuration correctly.

This is the extension half of the Chutes integration. The SDK provider and model catalog are supplied separately by #11548, following the same split used for Tencent TokenHub.

## Changes

- Adds `"chutes"` to the `ApiProvider` union and `KNOWN_API_PROVIDERS`.
- Registers the Chutes display name and signup URL (`https://chutes.ai/app/api`) in the generic provider-settings registry.
- Updates provider-ID, settings-registry, and proto round-trip tests.
- Uses the shared generic OpenAI-compatible settings form; no custom UI or transport is added.

## Verification

- Targeted VS Code and webview tests passed locally
- Type checking and Biome passed
- Existing GitHub quality, VS Code, E2E, qlty, Greptile, and Socket checks are green

The two PRs are independent at build and test time. The intended merge order is #11548 first, followed by this PR.
