### PR TITLE
fix(vscode): include untracked files in commit message generation

### DIFF
--- a/apps/vscode/src/utils/__tests__/git.test.ts
+++ b/apps/vscode/src/utils/__tests__/git.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, it } from "bun:test"
+import { exec } from "node:child_process"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { promisify } from "node:util"
+import "should"
+import { getGitDiff } from "../git"
+
+const execAsync = promisify(exec)
+
+describe("getGitDiff", () => {
+	let repoDir: string
+
+	async function git(args: string): Promise<void> {
+		await execAsync(`git ${args}`, { cwd: repoDir })
+	}
+
+	beforeEach(async () => {
+		repoDir = await mkdtemp(path.join(tmpdir(), "cline-git-diff-"))
+		await git("init")
+		await git('config user.email "test@example.com"')
+		await git('config user.name "Test"')
+	})
+
+	afterEach(async () => {
+		await rm(repoDir, { recursive: true, force: true })
+	})
+
+	it("includes untracked files when nothing is staged (add-only working tree)", async () => {
+		// Reproduces #12060: a brand-new file that has never been staged is
+		// invisible to `git diff` and `git diff --staged`, so commit-message
+		// generation used to fail with "No changes in workspace for commit message".
+		await writeFile(path.join(repoDir, "new-file.txt"), "hello from an untracked file\n")
+
+		const diff = await getGitDiff(repoDir, false)
+
+		diff.should.match(/new-file\.txt/)
+		diff.should.match(/hello from an untracked file/)
+	})
+
+	it("includes untracked files alongside an existing commit", async () => {
+		await writeFile(path.join(repoDir, "tracked.txt"), "tracked\n")
+		await git("add tracked.txt")
+		await git('commit -m "initial"')
+		await writeFile(path.join(repoDir, "untracked.txt"), "brand new\n")
+
+		const diff = await getGitDiff(repoDir, false)
+
+		diff.should.match(/untracked\.txt/)
+		diff.should.match(/brand new/)
+	})
+
+	it("handles untracked filenames with spaces and shell metacharacters", async () => {
+		// The filename is passed as a separate argv entry (no shell), so a name
+		// containing spaces and `$` must not break the diff or execute anything.
+		const trickyName = "a file with $VAR and spaces.txt"
+		await writeFile(path.join(repoDir, trickyName), "content of the tricky file\n")
+
+		const diff = await getGitDiff(repoDir, false)
+
+		diff.should.match(/content of the tricky file/)
+	})
+
+	it("prefers staged changes over untracked files", async () => {
+		await writeFile(path.join(repoDir, "staged.txt"), "staged content\n")
+		await git("add staged.txt")
+		await writeFile(path.join(repoDir, "untracked.txt"), "untracked content\n")
+
+		const diff = await getGitDiff(repoDir, true)
+
+		diff.should.match(/staged\.txt/)
+		diff.should.not.match(/untracked\.txt/)
+	})
+
+	it("throws when there are no changes at all", async () => {
+		await writeFile(path.join(repoDir, "committed.txt"), "done\n")
+		await git("add committed.txt")
+		await git('commit -m "only commit"')
+
+		let error: Error | undefined
+		try {
+			await getGitDiff(repoDir, false)
+		} catch (e) {
+			error = e as Error
+		}
+		;(error !== undefined).should.be.true()
+		error!.message.should.equal("No changes in workspace for commit message")
+	})
+})

--- a/apps/vscode/src/utils/__tests__/git.test.ts
+++ b/apps/vscode/src/utils/__tests__/git.test.ts
@@ -62,6 +62,22 @@ describe("getGitDiff", () => {
 		diff.should.match(/content of the tricky file/)
 	})
 
+	it("includes both a tracked unstaged edit and an untracked file", async () => {
+		// A modified tracked file makes `git diff HEAD` non-empty; the new file must
+		// still be appended so the commit message covers the whole working tree.
+		await writeFile(path.join(repoDir, "tracked.txt"), "original\n")
+		await git("add tracked.txt")
+		await git('commit -m "initial"')
+		await writeFile(path.join(repoDir, "tracked.txt"), "original\nmodified line\n")
+		await writeFile(path.join(repoDir, "brand-new.txt"), "the new file\n")
+
+		const diff = await getGitDiff(repoDir, false)
+
+		diff.should.match(/modified line/)
+		diff.should.match(/brand-new\.txt/)
+		diff.should.match(/the new file/)
+	})
+
 	it("prefers staged changes over untracked files", async () => {
 		await writeFile(path.join(repoDir, "staged.txt"), "staged content\n")
 		await git("add staged.txt")

--- a/apps/vscode/src/utils/git.ts
+++ b/apps/vscode/src/utils/git.ts
@@ -6,6 +6,10 @@ const execAsync = promisify(exec)
 const execFileAsync = promisify(execFile)
 const GIT_OUTPUT_LINE_LIMIT = 500
 
+// A human-readable label for the returned output header, not a runnable command
+// (each untracked file is diffed separately against /dev/null).
+const UNTRACKED_DIFF_LABEL = "git diff --no-index (untracked files)"
+
 export interface GitCommit {
 	hash: string
 	shortHash: string
@@ -215,14 +219,14 @@ export async function getGitDiff(cwd: string, stagedOnly = false): Promise<strin
 			diff = unstaged.trim()
 		}
 
-		// `git diff` never reports untracked (new, never-staged) files, so an
-		// add-only working tree produces an empty diff above. Include them here so
-		// commit-message generation works before the user stages anything.
-		if (!stagedOnly && !diff) {
+		// `git diff` never reports untracked (new, never-staged) files, so they are
+		// missing from both diffs above. Append them in the non-staged path so an
+		// add-only working tree works AND a mix of edited + new files includes both.
+		if (!stagedOnly) {
 			const untracked = await getUntrackedFilesDiff(cwd)
 			if (untracked) {
-				command = "git --no-pager diff --no-index -- /dev/null (per untracked file)"
-				diff = untracked
+				diff = diff ? `${diff}\n\n${untracked}` : untracked
+				command = diff === untracked ? UNTRACKED_DIFF_LABEL : `${command} + ${UNTRACKED_DIFF_LABEL}`
 			}
 		}
 
@@ -255,13 +259,19 @@ async function getUntrackedFilesDiff(cwd: string): Promise<string> {
 	for (const file of files) {
 		// Pass the filename as a separate argv entry (no shell) so names containing
 		// quotes, `$`, backticks, or spaces can't be interpreted as shell syntax.
-		// `git diff --no-index` exits with code 1 when the files differ (the normal
-		// case here), which rejects the promise — capture stdout from the error too.
+		// `git diff --no-index` exits 1 when the files differ (the normal case here),
+		// which rejects the promise — capture stdout from that. Exit 2 is a real git
+		// error (unreadable file, bad install), so re-throw it instead of swallowing.
 		const { stdout } = await execFileAsync(
 			"git",
 			["--no-pager", "diff", "--no-index", "--diff-filter=d", "--", "/dev/null", file],
 			{ cwd },
-		).catch((error: { stdout?: string }) => ({ stdout: error?.stdout ?? "" }))
+		).catch((error: { code?: number; stdout?: string }) => {
+			if (error.code === 1) {
+				return { stdout: error.stdout ?? "" }
+			}
+			throw error
+		})
 		const trimmed = stdout.trim()
 		if (trimmed) {
 			diffs.push(trimmed)

--- a/apps/vscode/src/utils/git.ts
+++ b/apps/vscode/src/utils/git.ts
@@ -1,8 +1,9 @@
-import { exec } from "child_process"
+import { exec, execFile } from "child_process"
 import { promisify } from "util"
 import { Logger } from "@/shared/services/Logger"
 
 const execAsync = promisify(exec)
+const execFileAsync = promisify(execFile)
 const GIT_OUTPUT_LINE_LIMIT = 500
 
 export interface GitCommit {
@@ -214,6 +215,17 @@ export async function getGitDiff(cwd: string, stagedOnly = false): Promise<strin
 			diff = unstaged.trim()
 		}
 
+		// `git diff` never reports untracked (new, never-staged) files, so an
+		// add-only working tree produces an empty diff above. Include them here so
+		// commit-message generation works before the user stages anything.
+		if (!stagedOnly && !diff) {
+			const untracked = await getUntrackedFilesDiff(cwd)
+			if (untracked) {
+				command = "git --no-pager diff --no-index -- /dev/null (per untracked file)"
+				diff = untracked
+			}
+		}
+
 		if (!diff) {
 			throw new Error("No changes in workspace for commit message")
 		}
@@ -222,6 +234,40 @@ export async function getGitDiff(cwd: string, stagedOnly = false): Promise<strin
 	} catch (error) {
 		throw error
 	}
+}
+
+/**
+ * Builds a diff for untracked (new, never-staged) files, which `git diff` and
+ * `git diff --staged` both omit. Each file is diffed against an empty file via
+ * `git diff --no-index` so the output looks like a normal added-file diff.
+ * Returns an empty string when there are no untracked files.
+ */
+async function getUntrackedFilesDiff(cwd: string): Promise<string> {
+	// `-z` returns NUL-separated, unquoted paths so filenames with spaces or
+	// special characters survive intact.
+	const { stdout: list } = await execFileAsync("git", ["ls-files", "--others", "--exclude-standard", "-z"], { cwd })
+	const files = list.split("\0").filter((file) => file.length > 0)
+	if (files.length === 0) {
+		return ""
+	}
+
+	const diffs: string[] = []
+	for (const file of files) {
+		// Pass the filename as a separate argv entry (no shell) so names containing
+		// quotes, `$`, backticks, or spaces can't be interpreted as shell syntax.
+		// `git diff --no-index` exits with code 1 when the files differ (the normal
+		// case here), which rejects the promise — capture stdout from the error too.
+		const { stdout } = await execFileAsync(
+			"git",
+			["--no-pager", "diff", "--no-index", "--diff-filter=d", "--", "/dev/null", file],
+			{ cwd },
+		).catch((error: { stdout?: string }) => ({ stdout: error?.stdout ?? "" }))
+		const trimmed = stdout.trim()
+		if (trimmed) {
+			diffs.push(trimmed)
+		}
+	}
+	return diffs.join("\n\n")
 }
 
 export async function getGitRemoteUrls(cwd: string): Promise<string[]> {


### PR DESCRIPTION
Closes #12060

## What

Fixes "Generate Git Commit Message" failing with `No changes in workspace for commit message` when the working tree contains only untracked (new, never-staged) files.

`getGitDiff()` gathered changes with `git diff --staged` and `git diff HEAD`. Neither of those reports untracked files, so an add-only working tree produced an empty diff and the feature threw. This adds a fallback that collects untracked files and diffs each against an empty file, so their contents are included.

## Why

Untracked files are a normal state, you add a new file and immediately want a commit message for it. Requiring the user to `git add` first (the current workaround from the issue) is surprising, since the SCM "Generate" button doesn't otherwise care whether changes are staged. The staged-first priority is preserved: if anything is staged, only staged changes are used (unchanged behavior).

## How

- New helper `getUntrackedFilesDiff(cwd)` lists untracked files with `git ls-files --others --exclude-standard -z` and diffs each with `git --no-pager diff --no-index -- /dev/null <file>`, joining the results.
- `getGitDiff()` calls it in the non-staged path only when the staged/`HEAD` diff is empty.
- Filenames are passed as separate argv entries via `execFile` (not interpolated into a shell string), so names containing spaces, `$`, quotes, or backticks are handled safely and can't be interpreted as shell syntax.
- `git diff --no-index` exits non-zero when files differ (the normal case), so its `stdout` is captured from the rejected promise.

## Testing

Added `apps/vscode/src/utils/__tests__/git.test.ts` (bun:test, real temp git repos):

- includes untracked files when nothing is staged (the reported case)
- includes untracked files alongside an existing commit
- handles untracked filenames with spaces and shell metacharacters
- prefers staged changes over untracked files
- still throws when there are genuinely no changes

Verified locally: `bun test src/utils/__tests__/git.test.ts` → 5 pass. Confirmed the two untracked-file tests fail without the fix and pass with it. `tsc --noEmit`, biome lint, and biome format all clean.