### PR TITLE
feat(cli): restyle chat input with horizontal rules and slim user bubbles

### DIFF
--- a/apps/cli/src/tui/components/chat-entry.tsx
+++ b/apps/cli/src/tui/components/chat-entry.tsx
@@ -291,7 +291,7 @@ function ClineCreditsClinePassErrorView(props: { defaultFg?: string }) {
 				/>
 				<box flexDirection="row">
 					<text fg="gray">Purchase Credits: </text>
-					<text fg="cyan" selectable>
+					<text fg={palette.act} selectable>
 						<a href={CLINE_CREDITS_DASHBOARD_URL}>
 							{CLINE_CREDITS_DASHBOARD_URL}
 						</a>
@@ -299,7 +299,7 @@ function ClineCreditsClinePassErrorView(props: { defaultFg?: string }) {
 				</box>
 				<box flexDirection="row">
 					<text fg="gray">Purchase ClinePass: </text>
-					<text fg="cyan" selectable>
+					<text fg={palette.act} selectable>
 						<a href={subscriptionUrl}>{subscriptionUrl}</a>
 					</text>
 				</box>
@@ -377,13 +377,13 @@ function ClinePassSubscriptionErrorView(props: {
 				)}
 				<box flexDirection="row">
 					<text fg="gray">Subscribe: </text>
-					<text fg="cyan" selectable>
+					<text fg={palette.act} selectable>
 						<a href={subscriptionUrl}>Open subscription page</a>
 					</text>
 				</box>
 				<box flexDirection="row">
 					<text fg="gray">URL: </text>
-					<text fg="cyan" selectable>
+					<text fg={palette.act} selectable>
 						<a href={subscriptionUrl}>{subscriptionUrl}</a>
 					</text>
 				</box>

--- a/apps/cli/src/tui/components/chat-entry.tsx
+++ b/apps/cli/src/tui/components/chat-entry.tsx
@@ -18,7 +18,7 @@ import { useTerminalBackground } from "../hooks/use-terminal-background";
 import {
 	getDefaultForeground,
 	getModeAccent,
-	getModeInputBackground,
+	getUserMessageBackground,
 	palette,
 	type TerminalTheme,
 } from "../palette";
@@ -428,10 +428,7 @@ export function ChatEntryView(props: {
 	const { entry, accent = palette.act, terminalTheme } = props;
 	const terminalBg = useTerminalBackground();
 	const defaultFg = getDefaultForeground(terminalBg);
-	const userMsgBg = getModeInputBackground(
-		accent === palette.plan ? "plan" : "act",
-		terminalBg,
-	);
+	const userMsgBg = getUserMessageBackground(terminalBg);
 
 	switch (entry.kind) {
 		case "user":
@@ -442,10 +439,9 @@ export function ChatEntryView(props: {
 					marginX={-1}
 					paddingLeft={1}
 					paddingRight={2}
-					paddingY={1}
 				>
 					<box width={2}>
-						<text fg={accent}>{">"}</text>
+						<text fg={accent}>{"❯"}</text>
 					</box>
 					<text fg={defaultFg} selectable>
 						{entry.text}
@@ -461,10 +457,9 @@ export function ChatEntryView(props: {
 					marginX={-1}
 					paddingLeft={1}
 					paddingRight={2}
-					paddingY={1}
 				>
 					<box width={2}>
-						<text fg={accent}>{">"}</text>
+						<text fg={accent}>{"❯"}</text>
 					</box>
 					{entry.delivery === "steer" && <text fg="yellow">[steer] </text>}
 					{entry.delivery === "queue" && <text fg="gray">[queued] </text>}

--- a/apps/cli/src/tui/components/dialogs/account-dialog.tsx
+++ b/apps/cli/src/tui/components/dialogs/account-dialog.tsx
@@ -424,7 +424,7 @@ export function AccountDialogContent(
 	if (state.status === "loading") {
 		return (
 			<box flexDirection="column" paddingX={1} gap={1}>
-				<text fg="cyan">Cline Account</text>
+				<text fg={palette.act}>Cline Account</text>
 				<text fg="gray">{state.message}</text>
 				<text fg="gray">Esc to close</text>
 			</box>
@@ -434,7 +434,7 @@ export function AccountDialogContent(
 	if (state.status === "error") {
 		return (
 			<box flexDirection="column" paddingX={1} gap={1}>
-				<text fg="cyan">Cline Account</text>
+				<text fg={palette.act}>Cline Account</text>
 				<text fg="red">{state.message}</text>
 				<text fg="gray">Esc to close</text>
 			</box>
@@ -444,7 +444,7 @@ export function AccountDialogContent(
 	if (state.status === "unauthenticated") {
 		return (
 			<box flexDirection="column" paddingX={1} gap={1}>
-				<text fg="cyan">Cline Account</text>
+				<text fg={palette.act}>Cline Account</text>
 				<text>Sign in or create a Cline account.</text>
 				<text fg="gray">
 					Get access to the latest models with regular free promos and
@@ -473,7 +473,7 @@ export function AccountDialogContent(
 	if (view === "organizations") {
 		return (
 			<box flexDirection="column" paddingX={1}>
-				<text fg="cyan">Change Account</text>
+				<text fg={palette.act}>Change Account</text>
 				<box flexDirection="column" gap={0}>
 					{orgRows.map((row, index) => (
 						<OrganizationRow
@@ -503,7 +503,7 @@ export function AccountDialogContent(
 
 	return (
 		<box flexDirection="column" paddingX={1} gap={1}>
-			<text fg="cyan">Cline Account</text>
+			<text fg={palette.act}>Cline Account</text>
 
 			<box flexDirection="row" gap={2}>
 				<box
@@ -514,7 +514,7 @@ export function AccountDialogContent(
 					border
 					borderColor="gray"
 				>
-					<text fg="cyan">{userInitial(loaded)}</text>
+					<text fg={palette.act}>{userInitial(loaded)}</text>
 				</box>
 				<box flexDirection="column" flexGrow={1}>
 					<text selectable>{displayName}</text>

--- a/apps/cli/src/tui/components/dialogs/command-palette.tsx
+++ b/apps/cli/src/tui/components/dialogs/command-palette.tsx
@@ -191,7 +191,7 @@ export function CommandPaletteContent(
 											{" "}
 										</text>
 										<text
-											fg={isSelected ? palette.textOnSelection : "cyan"}
+											fg={isSelected ? palette.textOnSelection : palette.act}
 											width={shortcutWidth}
 											flexShrink={0}
 										>

--- a/apps/cli/src/tui/components/dialogs/config-dialogs.tsx
+++ b/apps/cli/src/tui/components/dialogs/config-dialogs.tsx
@@ -90,7 +90,7 @@ export function ExtDetailContent(
 								flexDirection="row"
 								justifyContent="space-between"
 							>
-								<text fg="cyan">
+								<text fg={palette.act}>
 									<strong>{row.name}</strong>
 								</text>
 								<text

--- a/apps/cli/src/tui/components/dialogs/help-dialog.tsx
+++ b/apps/cli/src/tui/components/dialogs/help-dialog.tsx
@@ -1,6 +1,7 @@
 // @jsxImportSource @opentui/react
 import type { ChoiceContext } from "@opentui-ui/dialog";
 import { useDialogKeyboard } from "@opentui-ui/dialog/react";
+import { palette } from "../../palette";
 
 type HelpRow =
 	| { kind: "heading"; id: string; text: string }
@@ -277,7 +278,7 @@ export function HelpDialogContent(props: ChoiceContext<void>) {
 						}
 						return (
 							<box key={row.id} flexDirection="row" paddingX={1}>
-								<text fg="cyan" width={KEY_WIDTH} flexShrink={0}>
+								<text fg={palette.act} width={KEY_WIDTH} flexShrink={0}>
 									{row.key}
 								</text>
 								<text fg="gray">{row.desc}</text>

--- a/apps/cli/src/tui/components/dialogs/mcp-manager-dialog.tsx
+++ b/apps/cli/src/tui/components/dialogs/mcp-manager-dialog.tsx
@@ -121,7 +121,7 @@ export function McpManagerContent(
 
 	return (
 		<box flexDirection="column" paddingX={1}>
-			<text fg="cyan">MCP Servers</text>
+			<text fg={palette.act}>MCP Servers</text>
 
 			<text fg="gray" marginTop={1}>
 				Settings file:
@@ -141,7 +141,7 @@ export function McpManagerContent(
 						const enabledIcon =
 							typeof srv.enabled === "boolean" ? (enabled ? "● " : "○ ") : "";
 						const status = getMcpManagerEntryStatus(srv);
-						let rowColor = isSel ? "cyan" : "gray";
+						let rowColor = isSel ? palette.act : "gray";
 						if (enabled && typeof srv.enabled === "boolean") {
 							rowColor = palette.success;
 						}

--- a/apps/cli/src/tui/components/dialogs/provider-picker.tsx
+++ b/apps/cli/src/tui/components/dialogs/provider-picker.tsx
@@ -371,14 +371,14 @@ function ClinePassBrowserPageContent(
 
 	return (
 		<box flexDirection="column" paddingX={1} gap={1}>
-			<text fg="cyan">
+			<text fg={palette.act}>
 				<strong>{providerName}</strong>
 			</text>
 
 			<text>{status}</text>
 
 			<text fg="gray">{pageLabel}:</text>
-			<text fg="cyan" selectable>
+			<text fg={palette.act} selectable>
 				<a href={url}>{url}</a>
 			</text>
 
@@ -596,7 +596,7 @@ export function ProviderConfigInputContent(
 
 	return (
 		<box flexDirection="column" paddingX={1} gap={1}>
-			<text fg="cyan">
+			<text fg={palette.act}>
 				<strong>{providerName}</strong>
 			</text>
 
@@ -689,7 +689,7 @@ export function CodexCliStatusContent(
 
 	return (
 		<box flexDirection="column" paddingX={1} gap={1}>
-			<text fg="cyan">
+			<text fg={palette.act}>
 				<strong>{providerName}</strong>
 			</text>
 
@@ -707,7 +707,7 @@ export function CodexCliStatusContent(
 					<text fg="yellow">Codex CLI was not found</text>
 					<text fg="gray">{status.reason}</text>
 					<text fg="gray">Install Codex CLI from:</text>
-					<text fg="cyan" selectable>
+					<text fg={palette.act} selectable>
 						{CODEX_CLI_INSTALL_URL}
 					</text>
 				</box>
@@ -869,7 +869,7 @@ export function OAuthLoginContent(
 	if (mode === "device") {
 		return (
 			<box flexDirection="column" paddingX={1} gap={1}>
-				<text fg="cyan">
+				<text fg={palette.act}>
 					<strong>{providerName}</strong>
 				</text>
 
@@ -884,7 +884,7 @@ export function OAuthLoginContent(
 							<strong>{deviceUserCode}</strong>
 						</text>
 						<text fg="gray">Visit this URL and enter the code above:</text>
-						<text fg="cyan" selectable>
+						<text fg={palette.act} selectable>
 							<a href={deviceVerifyUrl}>{deviceVerifyUrl}</a>
 						</text>
 					</box>
@@ -901,7 +901,7 @@ export function OAuthLoginContent(
 
 	return (
 		<box flexDirection="column" paddingX={1} gap={1}>
-			<text fg="cyan">
+			<text fg={palette.act}>
 				<strong>{providerName}</strong>
 			</text>
 

--- a/apps/cli/src/tui/components/dialogs/skills-picker.tsx
+++ b/apps/cli/src/tui/components/dialogs/skills-picker.tsx
@@ -142,7 +142,7 @@ export function SkillsPickerContent(props: SkillsPickerContentProps) {
 									onMouseDown={() => resolve(SKILLS_MARKETPLACE_ACTION)}
 									height={1}
 								>
-									<text fg={isSelected ? palette.textOnSelection : "cyan"}>
+									<text fg={isSelected ? palette.textOnSelection : palette.act}>
 										{isSelected ? "❯ " : "  "}
 										Browse more skills at {SKILLS_MARKETPLACE_URL}
 									</text>

--- a/apps/cli/src/tui/components/dialogs/tool-approval.tsx
+++ b/apps/cli/src/tui/components/dialogs/tool-approval.tsx
@@ -155,7 +155,7 @@ export function ToolApprovalContent(
 		<box flexDirection="column" paddingX={1}>
 			<text fg="yellow">Approve tool call?</text>
 
-			<text fg="cyan" marginTop={1}>
+			<text fg={palette.act} marginTop={1}>
 				<strong>{props.request.toolName}</strong>
 			</text>
 

--- a/apps/cli/src/tui/components/input-bar.tsx
+++ b/apps/cli/src/tui/components/input-bar.tsx
@@ -30,7 +30,7 @@ export type TextareaHandle = Pick<
 
 export interface InputBarProps {
 	accent: string;
-	inputBackground: string;
+	ruleColor: string;
 	inputForeground: string;
 	inputPlaceholder: string;
 	placeholder: string;
@@ -62,7 +62,7 @@ function readTextPaste(event: PasteEvent): string | null {
 export function InputBar(props: InputBarProps) {
 	const {
 		accent,
-		inputBackground,
+		ruleColor,
 		inputForeground,
 		inputPlaceholder,
 		placeholder,
@@ -197,13 +197,13 @@ export function InputBar(props: InputBarProps) {
 		<box
 			flexDirection="row"
 			alignItems="flex-start"
-			backgroundColor={inputBackground}
-			paddingX={2}
-			paddingY={1}
+			border={["top", "bottom"]}
+			borderStyle="single"
+			borderColor={ruleColor}
 			onMouseDown={props.onFocusRequest}
 		>
 			<text fg={accent}>
-				<strong>{">"}</strong>
+				<strong>{"❯"}</strong>
 			</text>
 			<box flexGrow={1} paddingLeft={1}>
 				<textarea

--- a/apps/cli/src/tui/components/model-selector/cline-model-picker.tsx
+++ b/apps/cli/src/tui/components/model-selector/cline-model-picker.tsx
@@ -27,7 +27,7 @@ export type ClineModelPickerEntry =
 function tagColor(tag: string): string {
 	if (tag === "FREE") return palette.success;
 	if (tag === "BEST") return "magenta";
-	return "cyan";
+	return palette.act;
 }
 
 function resolveDisplayName(

--- a/apps/cli/src/tui/components/model-selector/cline-model-selector.tsx
+++ b/apps/cli/src/tui/components/model-selector/cline-model-selector.tsx
@@ -17,7 +17,7 @@ type ClineModelEntriesState =
 function tagColor(tag: string): string {
 	if (tag === "FREE") return palette.success;
 	if (tag === "BEST") return "magenta";
-	return "cyan";
+	return palette.act;
 }
 
 function resolveDisplayName(
@@ -272,7 +272,7 @@ export function ClineModelSelectorDialogContent(
 	if (state.status === "error") {
 		return (
 			<box flexDirection="column" gap={1}>
-				<text fg="cyan">Choose a model</text>
+				<text fg={palette.act}>Choose a model</text>
 				<ProviderRow providerName={props.currentProviderName} focused={false} />
 				<text fg="red">{state.message}</text>
 				<text fg="gray">R to retry, Esc to go back</text>
@@ -282,7 +282,7 @@ export function ClineModelSelectorDialogContent(
 
 	return (
 		<box flexDirection="column" gap={1}>
-			<text fg="cyan">Choose a model</text>
+			<text fg={palette.act}>Choose a model</text>
 			<ProviderRow providerName={props.currentProviderName} focused={false} />
 			<text fg="gray">{state.message}</text>
 			<text fg="gray">Esc to go back</text>

--- a/apps/cli/src/tui/components/model-selector/provider-row.tsx
+++ b/apps/cli/src/tui/components/model-selector/provider-row.tsx
@@ -13,7 +13,7 @@ export function ProviderRow({
 			<text fg={focused ? palette.selection : "gray"} flexShrink={0}>
 				{focused ? "❯" : " "}
 			</text>
-			<text fg={focused ? palette.selection : "cyan"} flexShrink={0}>
+			<text fg={focused ? palette.selection : palette.act} flexShrink={0}>
 				Provider:
 			</text>
 			<text fg="white">{providerName}</text>

--- a/apps/cli/src/tui/palette.ts
+++ b/apps/cli/src/tui/palette.ts
@@ -131,20 +131,51 @@ export function getDefaultForeground(
 	return isLightTheme(terminalBg) ? "#1a1a1a" : undefined;
 }
 
-export function getModeInputBackground(
-	mode: string,
+function liftedFromTerminalBg(
 	terminalBg: string | null,
+	baseLift: number,
+	nudgeA: number,
+	nudgeB: number,
 ): string {
 	const hex = normalizeHex(terminalBg) ?? "#000000";
 	const base = hexToOklab(hex);
 	const light = base.L > LIGHT_THEME_THRESHOLD;
-	const lift = BASE_LIFT / (1 + (light ? 1 - base.L : base.L) * LIFT_DAMPING);
-	const warm = mode === "plan";
+	const lift = baseLift / (1 + (light ? 1 - base.L : base.L) * LIFT_DAMPING);
 	return oklabToHex(
 		base.L + (light ? -lift : lift),
-		base.a + (warm ? CHROMA_NUDGE : -CHROMA_NUDGE),
-		base.b + CHROMA_NUDGE,
+		base.a + nudgeA,
+		base.b + nudgeB,
 	);
+}
+
+export function getModeInputBackground(
+	mode: string,
+	terminalBg: string | null,
+): string {
+	const warm = mode === "plan";
+	return liftedFromTerminalBg(
+		terminalBg,
+		BASE_LIFT,
+		warm ? CHROMA_NUDGE : -CHROMA_NUDGE,
+		CHROMA_NUDGE,
+	);
+}
+
+// The `─` rules framing the input field are thin foreground strokes rather
+// than filled cells, so they need a much larger lift than a background tint
+// to register at the same perceptual weight — this lands them around mid-gray
+// on both black and white terminals. They stay neutral (no mode chroma) so
+// the frame doesn't shift color when toggling plan/act.
+const RULE_BASE_LIFT = 0.5;
+
+export function getInputRuleColor(terminalBg: string | null): string {
+	return liftedFromTerminalBg(terminalBg, RULE_BASE_LIFT, 0, 0);
+}
+
+// User message bubbles stay neutral (no mode chroma) so the transcript reads
+// as history rather than tracking whichever mode is currently active.
+export function getUserMessageBackground(terminalBg: string | null): string {
+	return liftedFromTerminalBg(terminalBg, BASE_LIFT, 0, 0);
 }
 
 export function getModeInputForeground(

--- a/apps/cli/src/tui/palette.ts
+++ b/apps/cli/src/tui/palette.ts
@@ -1,9 +1,9 @@
 export const palette = {
-	act: "cyan",
-	plan: "yellow",
-	selection: "cyan",
+	act: "#79b8ff",
+	plan: "#ffea7f",
+	selection: "#79b8ff",
 	error: "red",
-	success: "brightGreen",
+	success: "#99e89b",
 	muted: "gray",
 	textOnSelection: "black",
 } as const;
@@ -16,9 +16,11 @@ export const themePalette = {
 		plan: palette.plan,
 		success: palette.success,
 	},
+	// Same OKLCH hues as the dark accents, darkened to hold >=4.5:1 contrast
+	// on white so the plan/act identity carries across themes.
 	light: {
-		act: "#0969da",
-		plan: "#9a6700",
+		act: "#0f72cb",
+		plan: "#867100",
 		success: "#116329",
 	},
 } as const;
@@ -29,7 +31,7 @@ export const diffPalettes = {
 		removedBg: "#4d1a1a",
 		addedLineNumberBg: "#1a4d1a",
 		removedLineNumberBg: "#4d1a1a",
-		addedSignColor: "#22c55e",
+		addedSignColor: "#99e89b",
 		removedSignColor: "#ef4444",
 		lineNumberFg: "#888888",
 	},
@@ -75,8 +77,8 @@ export function getSuccessColor(theme: TerminalTheme = "dark"): string {
 //      overshoot.
 //   3. On dark themes, raise L (lighten). On light themes, lower L (darken).
 //   4. Nudge the a/b chromatic channels by CHROMA_NUDGE toward the mode's
-//      accent color. For plan (warm/yellow): +a, +b. For act (cool/cyan):
-//      -a, +b. At 0.003 this is ~10x below OKLAB's just-noticeable-difference
+//      accent color. For plan (warm/yellow): +a, +b. For act (cool/blue):
+//      -a, -b. At 0.003 this is ~10x below OKLAB's just-noticeable-difference
 //      threshold (~0.03), so it registers as a "feel" rather than visible color.
 //
 // Sample outputs on common terminals (act mode / plan mode bg):
@@ -157,7 +159,7 @@ export function getModeInputBackground(
 		terminalBg,
 		BASE_LIFT,
 		warm ? CHROMA_NUDGE : -CHROMA_NUDGE,
-		CHROMA_NUDGE,
+		warm ? CHROMA_NUDGE : -CHROMA_NUDGE,
 	);
 }
 
@@ -188,7 +190,7 @@ export function getModeInputForeground(
 	return oklabToHex(
 		base.L,
 		base.a + (warm ? CHROMA_NUDGE : -CHROMA_NUDGE),
-		base.b + CHROMA_NUDGE,
+		base.b + (warm ? CHROMA_NUDGE : -CHROMA_NUDGE),
 	);
 }
 
@@ -202,7 +204,7 @@ export function getModeInputPlaceholder(
 	return oklabToHex(
 		base.L,
 		base.a + (warm ? CHROMA_NUDGE * 2 : -CHROMA_NUDGE * 2),
-		base.b + CHROMA_NUDGE * 2,
+		base.b + (warm ? CHROMA_NUDGE * 2 : -CHROMA_NUDGE * 2),
 	);
 }
 

--- a/apps/cli/src/tui/utils/syntax-style.ts
+++ b/apps/cli/src/tui/utils/syntax-style.ts
@@ -1,5 +1,5 @@
 import { RGBA, type StyleDefinition, SyntaxStyle } from "@opentui/core";
-import type { TerminalTheme } from "../palette";
+import { type TerminalTheme, themePalette } from "../palette";
 
 const instances: Record<TerminalTheme, SyntaxStyle | null> = {
 	dark: null,
@@ -29,27 +29,31 @@ interface SyntaxColors {
 	markdownDefault?: string;
 }
 
+// Dark syntax colors are a pastel family harmonized with the brand accents
+// (act #79b8ff, plan #ffea7f, success #99e89b): every hue sits near the same
+// OKLCH lightness/chroma weight (~L 0.78, C 0.11) so code blocks feel like
+// part of the same palette instead of a bolted-on editor theme.
 const syntaxColors: Record<TerminalTheme, SyntaxColors> = {
 	dark: {
-		keyword: "#c678dd",
-		operator: "#56b6c2",
-		type: "#e5c07b",
-		functionName: "#61afef",
-		variable: "#e06c75",
-		string: "#98c379",
-		number: "#d19a66",
+		keyword: "#d7a0e3",
+		operator: "#9bbbdd",
+		type: "#dfca7d",
+		functionName: themePalette.dark.act,
+		variable: "#ee939b",
+		string: "#99e89b",
+		number: "#f0ad7f",
 		comment: "#5c6370",
 		punctuation: "#abb2bf",
-		property: "#e06c75",
-		constant: "#d19a66",
-		tag: "#e06c75",
-		attribute: "#d19a66",
-		escape: "#56b6c2",
-		markdownCode: "#98c379",
-		markdownHeading: "#56b6c2",
+		property: "#ee939b",
+		constant: "#f0ad7f",
+		tag: "#ee939b",
+		attribute: "#f0ad7f",
+		escape: "#9bbbdd",
+		markdownCode: "#99e89b",
+		markdownHeading: themePalette.dark.act,
 		markdownMuted: "#808080",
-		markdownLink: "#56b6c2",
-		markdownItalic: "#e5c07b",
+		markdownLink: themePalette.dark.act,
+		markdownItalic: "#dfca7d",
 	},
 	light: {
 		keyword: "#cf222e",
@@ -67,9 +71,9 @@ const syntaxColors: Record<TerminalTheme, SyntaxColors> = {
 		attribute: "#0550ae",
 		escape: "#0550ae",
 		markdownCode: "#116329",
-		markdownHeading: "#0969da",
+		markdownHeading: themePalette.light.act,
 		markdownMuted: "#6e7781",
-		markdownLink: "#0969da",
+		markdownLink: themePalette.light.act,
 		markdownItalic: "#8250df",
 		markdownDefault: "#1a1a1a",
 	},

--- a/apps/cli/src/tui/views/chat-view.tsx
+++ b/apps/cli/src/tui/views/chat-view.tsx
@@ -20,6 +20,7 @@ import {
 	useTerminalTheme,
 } from "../hooks/use-terminal-background";
 import {
+	getInputRuleColor,
 	getModeAccent,
 	getModeInputBackground,
 	getModeInputForeground,
@@ -76,6 +77,7 @@ export function ChatView(props: {
 	const terminalTheme = useTerminalTheme();
 	const accent = getModeAccent(session.uiMode, terminalTheme);
 	const inputBackground = getModeInputBackground(session.uiMode, terminalBg);
+	const inputRuleColor = getInputRuleColor(terminalBg);
 	const inputForeground = getModeInputForeground(session.uiMode, terminalBg);
 	const inputPlaceholder = getModeInputPlaceholder(session.uiMode, terminalBg);
 	const placeholder =
@@ -123,10 +125,10 @@ export function ChatView(props: {
 							/>
 						)}
 
-						<box marginBottom={1}>
+						<box>
 							<InputBar
 								accent={accent}
-								inputBackground={inputBackground}
+								ruleColor={inputRuleColor}
 								inputForeground={inputForeground}
 								inputPlaceholder={inputPlaceholder}
 								placeholder={placeholder}

--- a/apps/cli/src/tui/views/config-view.tsx
+++ b/apps/cli/src/tui/views/config-view.tsx
@@ -721,7 +721,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 
 	return (
 		<box flexDirection="column" paddingX={1}>
-			<text fg="cyan">
+			<text fg={palette.act}>
 				<strong>Settings</strong>
 			</text>
 
@@ -793,7 +793,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 								flexDirection="row"
 								justifyContent="space-between"
 							>
-								<text fg={isSel ? "cyan" : undefined}>{pfx}Provider</text>
+								<text fg={isSel ? palette.act : undefined}>{pfx}Provider</text>
 								<text fg="white">{props.providerDisplayName}</text>
 							</box>
 						);
@@ -804,7 +804,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 								flexDirection="row"
 								justifyContent="space-between"
 							>
-								<text fg={isSel ? "cyan" : undefined}>{pfx}Model</text>
+								<text fg={isSel ? palette.act : undefined}>{pfx}Model</text>
 								<text fg="white">{displayName}</text>
 							</box>
 						);
@@ -833,7 +833,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 								flexDirection="row"
 								justifyContent="space-between"
 							>
-								<text fg={isSel ? "cyan" : undefined}>
+								<text fg={isSel ? palette.act : undefined}>
 									{pfx}
 									{row.label}
 								</text>
@@ -866,7 +866,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 								: enabledState === "partial"
 									? "yellow"
 									: isSel
-										? "cyan"
+										? palette.act
 										: "gray";
 						return (
 							<box
@@ -886,7 +886,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 					}
 					case "mcp-manager":
 						return (
-							<text key={absIdx} fg={isSel ? "cyan" : "gray"}>
+							<text key={absIdx} fg={isSel ? palette.act : "gray"}>
 								{pfx}Manage MCP Servers...
 							</text>
 						);

--- a/apps/cli/src/tui/views/home-view.tsx
+++ b/apps/cli/src/tui/views/home-view.tsx
@@ -19,8 +19,8 @@ import {
 } from "../hooks/use-terminal-background";
 import {
 	getDefaultForeground,
+	getInputRuleColor,
 	getModeAccent,
-	getModeInputBackground,
 	getModeInputForeground,
 	getModeInputPlaceholder,
 } from "../palette";
@@ -69,7 +69,7 @@ export function HomeView(props: {
 	const terminalTheme = useTerminalTheme();
 	const defaultFg = getDefaultForeground(terminalBg);
 	const accent = getModeAccent(session.uiMode, terminalTheme);
-	const inputBackground = getModeInputBackground(session.uiMode, terminalBg);
+	const inputRuleColor = getInputRuleColor(terminalBg);
 	const inputForeground = getModeInputForeground(session.uiMode, terminalBg);
 	const inputPlaceholder = getModeInputPlaceholder(session.uiMode, terminalBg);
 	const placeholder =
@@ -80,7 +80,7 @@ export function HomeView(props: {
 		props.autocomplete?.mode && props.autocomplete.options.length > 0;
 	const contentWidth = Math.min(width, HOME_VIEW_MAX_WIDTH);
 	const hasTypedInput = inputValue.trim().length > 0;
-	const inputStartX = Math.floor((width - contentWidth) / 2) + 4;
+	const inputStartX = Math.floor((width - contentWidth) / 2) + 2;
 	const clamp = (value: number, min: number, max: number) =>
 		Math.max(min, Math.min(max, value));
 	const trackedCursorX = hasTypedInput
@@ -116,7 +116,7 @@ export function HomeView(props: {
 			<box flexDirection="column" width={contentWidth} flexShrink={0}>
 				<InputBar
 					accent={accent}
-					inputBackground={inputBackground}
+					ruleColor={inputRuleColor}
 					inputForeground={inputForeground}
 					inputPlaceholder={inputPlaceholder}
 					placeholder={placeholder}

--- a/apps/cli/src/tui/views/onboarding/screens.tsx
+++ b/apps/cli/src/tui/views/onboarding/screens.tsx
@@ -384,7 +384,7 @@ export function OnboardingCodexCliScreen(props: {
 						<text fg="yellow">Codex CLI was not found</text>
 						<text fg="gray">{props.status.reason}</text>
 						<text fg="gray">Install Codex CLI from:</text>
-						<text fg="cyan" selectable>
+						<text fg={palette.act} selectable>
 							{CODEX_CLI_INSTALL_URL}
 						</text>
 					</box>


### PR DESCRIPTION
### Related Issue

N/A — internal TUI design iteration.

### Description

Restyles the CLI chat input field and user message bubbles toward a more minimal look.

**The input field** previously rendered as a full-row tinted block (an OKLAB-lifted, mode-tinted background behind the textarea with a `>` prompt). It's now a bare frame:

```
──────────────────────────────────────────────────────────────
❯ Ask anything...
──────────────────────────────────────────────────────────────
```

- The rules are drawn with `border={["top", "bottom"]}` on the input row's box rather than literal `─` text — the Zig border renderer draws plain horizontals with no corner glyphs when the left/right sides are disabled, and the box auto-sizes as the textarea grows (up to its 5-row max).
- The prompt is a bold `❯` in the mode accent color (cyan for act, yellow for plan), flush left with no horizontal padding.
- Rule color comes from a new `getInputRuleColor(terminalBg)` in `palette.ts`. It reuses the adaptive OKLAB-lift approach that the old input background used, with two deliberate differences: a much larger base lift (0.5 vs 0.24) because thin foreground strokes need more contrast than filled cells to register at the same perceptual weight, and **zero mode chroma** so the frame doesn't shift color when toggling plan/act — the `❯` and placeholder carry the mode signal instead. Sample outputs: `#636363` on pure black, `#717171` on gruvbox, `#4f7784` on solarized dark (keeps the theme's teal cast), `#636363` on pure white.

**User message bubbles** in the transcript match the vibe: a slim bar (vertical padding removed) with the same `❯` glyph and a new *neutral gray* background via `getUserMessageBackground(terminalBg)` — same lift as the old tint but no mode chroma, so past messages read as history instead of re-tinting when you switch modes.

Both new palette functions share a `liftedFromTerminalBg()` helper extracted from `getModeInputBackground`, which is behavior-preserving for that function.

**Gotchas / secondary changes:**
- `InputBarProps.inputBackground` is renamed to `ruleColor` since the component no longer paints a background. `InlineToolResponse` keeps its own tinted shell (unchanged) — it's a distinct interaction card and the tint helps it stand out against the now-flat input.
- HomeView's robot eye-tracking math hardcoded the input text's left offset (`+ 4` = 2 padding + prompt + gap). The new layout is prompt + gap = `+ 2`. Vertical math is unchanged because border rows occupy the same height the old `paddingY={1}` did.
- The `marginBottom={1}` spacer between the input and the status bar in ChatView is removed; the bottom rule now provides that separation.

### Test Procedure

- `bunx tsc --noEmit` clean in `apps/cli`; `biome check` on touched files clean (remaining repo-wide a11y warnings are pre-existing).
- Manually exercised via `bun run dev`: home screen (centered input, robot eye-tracking follows the typed cursor correctly at the new offset), chat view (single and multi-line messages, textarea growth to 5 rows, placeholder rendering, plan/act toggle), and user bubbles for both `user` and `user_submitted` (steer/queued tags) entries.
- Interactive e2e tests (`src/tests/interactive`) assert on text content ("What can I do for you?"), not the prompt glyph or styling, so they're unaffected.

### Type of Change

-   [x] 💅 Cosmetic Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

First of a 2-PR stack; the follow-up swaps the cyan/yellow accent palette.