### PR TITLE
feat(cli): replace cyan accent with new plan/act palette

### DIFF
--- a/apps/cli/src/tui/components/chat-entry.tsx
+++ b/apps/cli/src/tui/components/chat-entry.tsx
@@ -291,7 +291,7 @@ function ClineCreditsClinePassErrorView(props: { defaultFg?: string }) {
 				/>
 				<box flexDirection="row">
 					<text fg="gray">Purchase Credits: </text>
-					<text fg="cyan" selectable>
+					<text fg={palette.act} selectable>
 						<a href={CLINE_CREDITS_DASHBOARD_URL}>
 							{CLINE_CREDITS_DASHBOARD_URL}
 						</a>
@@ -299,7 +299,7 @@ function ClineCreditsClinePassErrorView(props: { defaultFg?: string }) {
 				</box>
 				<box flexDirection="row">
 					<text fg="gray">Purchase ClinePass: </text>
-					<text fg="cyan" selectable>
+					<text fg={palette.act} selectable>
 						<a href={subscriptionUrl}>{subscriptionUrl}</a>
 					</text>
 				</box>
@@ -377,13 +377,13 @@ function ClinePassSubscriptionErrorView(props: {
 				)}
 				<box flexDirection="row">
 					<text fg="gray">Subscribe: </text>
-					<text fg="cyan" selectable>
+					<text fg={palette.act} selectable>
 						<a href={subscriptionUrl}>Open subscription page</a>
 					</text>
 				</box>
 				<box flexDirection="row">
 					<text fg="gray">URL: </text>
-					<text fg="cyan" selectable>
+					<text fg={palette.act} selectable>
 						<a href={subscriptionUrl}>{subscriptionUrl}</a>
 					</text>
 				</box>

--- a/apps/cli/src/tui/components/dialogs/account-dialog.tsx
+++ b/apps/cli/src/tui/components/dialogs/account-dialog.tsx
@@ -424,7 +424,7 @@ export function AccountDialogContent(
 	if (state.status === "loading") {
 		return (
 			<box flexDirection="column" paddingX={1} gap={1}>
-				<text fg="cyan">Cline Account</text>
+				<text fg={palette.act}>Cline Account</text>
 				<text fg="gray">{state.message}</text>
 				<text fg="gray">Esc to close</text>
 			</box>
@@ -434,7 +434,7 @@ export function AccountDialogContent(
 	if (state.status === "error") {
 		return (
 			<box flexDirection="column" paddingX={1} gap={1}>
-				<text fg="cyan">Cline Account</text>
+				<text fg={palette.act}>Cline Account</text>
 				<text fg="red">{state.message}</text>
 				<text fg="gray">Esc to close</text>
 			</box>
@@ -444,7 +444,7 @@ export function AccountDialogContent(
 	if (state.status === "unauthenticated") {
 		return (
 			<box flexDirection="column" paddingX={1} gap={1}>
-				<text fg="cyan">Cline Account</text>
+				<text fg={palette.act}>Cline Account</text>
 				<text>Sign in or create a Cline account.</text>
 				<text fg="gray">
 					Get access to the latest models with regular free promos and
@@ -473,7 +473,7 @@ export function AccountDialogContent(
 	if (view === "organizations") {
 		return (
 			<box flexDirection="column" paddingX={1}>
-				<text fg="cyan">Change Account</text>
+				<text fg={palette.act}>Change Account</text>
 				<box flexDirection="column" gap={0}>
 					{orgRows.map((row, index) => (
 						<OrganizationRow
@@ -503,7 +503,7 @@ export function AccountDialogContent(
 
 	return (
 		<box flexDirection="column" paddingX={1} gap={1}>
-			<text fg="cyan">Cline Account</text>
+			<text fg={palette.act}>Cline Account</text>
 
 			<box flexDirection="row" gap={2}>
 				<box
@@ -514,7 +514,7 @@ export function AccountDialogContent(
 					border
 					borderColor="gray"
 				>
-					<text fg="cyan">{userInitial(loaded)}</text>
+					<text fg={palette.act}>{userInitial(loaded)}</text>
 				</box>
 				<box flexDirection="column" flexGrow={1}>
 					<text selectable>{displayName}</text>

--- a/apps/cli/src/tui/components/dialogs/command-palette.tsx
+++ b/apps/cli/src/tui/components/dialogs/command-palette.tsx
@@ -191,7 +191,7 @@ export function CommandPaletteContent(
 											{" "}
 										</text>
 										<text
-											fg={isSelected ? palette.textOnSelection : "cyan"}
+											fg={isSelected ? palette.textOnSelection : palette.act}
 											width={shortcutWidth}
 											flexShrink={0}
 										>

--- a/apps/cli/src/tui/components/dialogs/config-dialogs.tsx
+++ b/apps/cli/src/tui/components/dialogs/config-dialogs.tsx
@@ -90,7 +90,7 @@ export function ExtDetailContent(
 								flexDirection="row"
 								justifyContent="space-between"
 							>
-								<text fg="cyan">
+								<text fg={palette.act}>
 									<strong>{row.name}</strong>
 								</text>
 								<text

--- a/apps/cli/src/tui/components/dialogs/help-dialog.tsx
+++ b/apps/cli/src/tui/components/dialogs/help-dialog.tsx
@@ -1,6 +1,7 @@
 // @jsxImportSource @opentui/react
 import type { ChoiceContext } from "@opentui-ui/dialog";
 import { useDialogKeyboard } from "@opentui-ui/dialog/react";
+import { palette } from "../../palette";
 
 type HelpRow =
 	| { kind: "heading"; id: string; text: string }
@@ -277,7 +278,7 @@ export function HelpDialogContent(props: ChoiceContext<void>) {
 						}
 						return (
 							<box key={row.id} flexDirection="row" paddingX={1}>
-								<text fg="cyan" width={KEY_WIDTH} flexShrink={0}>
+								<text fg={palette.act} width={KEY_WIDTH} flexShrink={0}>
 									{row.key}
 								</text>
 								<text fg="gray">{row.desc}</text>

--- a/apps/cli/src/tui/components/dialogs/mcp-manager-dialog.tsx
+++ b/apps/cli/src/tui/components/dialogs/mcp-manager-dialog.tsx
@@ -121,7 +121,7 @@ export function McpManagerContent(
 
 	return (
 		<box flexDirection="column" paddingX={1}>
-			<text fg="cyan">MCP Servers</text>
+			<text fg={palette.act}>MCP Servers</text>
 
 			<text fg="gray" marginTop={1}>
 				Settings file:
@@ -141,7 +141,7 @@ export function McpManagerContent(
 						const enabledIcon =
 							typeof srv.enabled === "boolean" ? (enabled ? "● " : "○ ") : "";
 						const status = getMcpManagerEntryStatus(srv);
-						let rowColor = isSel ? "cyan" : "gray";
+						let rowColor = isSel ? palette.act : "gray";
 						if (enabled && typeof srv.enabled === "boolean") {
 							rowColor = palette.success;
 						}

--- a/apps/cli/src/tui/components/dialogs/provider-picker.tsx
+++ b/apps/cli/src/tui/components/dialogs/provider-picker.tsx
@@ -371,14 +371,14 @@ function ClinePassBrowserPageContent(
 
 	return (
 		<box flexDirection="column" paddingX={1} gap={1}>
-			<text fg="cyan">
+			<text fg={palette.act}>
 				<strong>{providerName}</strong>
 			</text>
 
 			<text>{status}</text>
 
 			<text fg="gray">{pageLabel}:</text>
-			<text fg="cyan" selectable>
+			<text fg={palette.act} selectable>
 				<a href={url}>{url}</a>
 			</text>
 
@@ -596,7 +596,7 @@ export function ProviderConfigInputContent(
 
 	return (
 		<box flexDirection="column" paddingX={1} gap={1}>
-			<text fg="cyan">
+			<text fg={palette.act}>
 				<strong>{providerName}</strong>
 			</text>
 
@@ -689,7 +689,7 @@ export function CodexCliStatusContent(
 
 	return (
 		<box flexDirection="column" paddingX={1} gap={1}>
-			<text fg="cyan">
+			<text fg={palette.act}>
 				<strong>{providerName}</strong>
 			</text>
 
@@ -707,7 +707,7 @@ export function CodexCliStatusContent(
 					<text fg="yellow">Codex CLI was not found</text>
 					<text fg="gray">{status.reason}</text>
 					<text fg="gray">Install Codex CLI from:</text>
-					<text fg="cyan" selectable>
+					<text fg={palette.act} selectable>
 						{CODEX_CLI_INSTALL_URL}
 					</text>
 				</box>
@@ -869,7 +869,7 @@ export function OAuthLoginContent(
 	if (mode === "device") {
 		return (
 			<box flexDirection="column" paddingX={1} gap={1}>
-				<text fg="cyan">
+				<text fg={palette.act}>
 					<strong>{providerName}</strong>
 				</text>
 
@@ -884,7 +884,7 @@ export function OAuthLoginContent(
 							<strong>{deviceUserCode}</strong>
 						</text>
 						<text fg="gray">Visit this URL and enter the code above:</text>
-						<text fg="cyan" selectable>
+						<text fg={palette.act} selectable>
 							<a href={deviceVerifyUrl}>{deviceVerifyUrl}</a>
 						</text>
 					</box>
@@ -901,7 +901,7 @@ export function OAuthLoginContent(
 
 	return (
 		<box flexDirection="column" paddingX={1} gap={1}>
-			<text fg="cyan">
+			<text fg={palette.act}>
 				<strong>{providerName}</strong>
 			</text>
 

--- a/apps/cli/src/tui/components/dialogs/skills-picker.tsx
+++ b/apps/cli/src/tui/components/dialogs/skills-picker.tsx
@@ -142,7 +142,7 @@ export function SkillsPickerContent(props: SkillsPickerContentProps) {
 									onMouseDown={() => resolve(SKILLS_MARKETPLACE_ACTION)}
 									height={1}
 								>
-									<text fg={isSelected ? palette.textOnSelection : "cyan"}>
+									<text fg={isSelected ? palette.textOnSelection : palette.act}>
 										{isSelected ? "❯ " : "  "}
 										Browse more skills at {SKILLS_MARKETPLACE_URL}
 									</text>

--- a/apps/cli/src/tui/components/dialogs/tool-approval.tsx
+++ b/apps/cli/src/tui/components/dialogs/tool-approval.tsx
@@ -155,7 +155,7 @@ export function ToolApprovalContent(
 		<box flexDirection="column" paddingX={1}>
 			<text fg="yellow">Approve tool call?</text>
 
-			<text fg="cyan" marginTop={1}>
+			<text fg={palette.act} marginTop={1}>
 				<strong>{props.request.toolName}</strong>
 			</text>
 

--- a/apps/cli/src/tui/components/model-selector/cline-model-picker.tsx
+++ b/apps/cli/src/tui/components/model-selector/cline-model-picker.tsx
@@ -27,7 +27,7 @@ export type ClineModelPickerEntry =
 function tagColor(tag: string): string {
 	if (tag === "FREE") return palette.success;
 	if (tag === "BEST") return "magenta";
-	return "cyan";
+	return palette.act;
 }
 
 function resolveDisplayName(

--- a/apps/cli/src/tui/components/model-selector/cline-model-selector.tsx
+++ b/apps/cli/src/tui/components/model-selector/cline-model-selector.tsx
@@ -17,7 +17,7 @@ type ClineModelEntriesState =
 function tagColor(tag: string): string {
 	if (tag === "FREE") return palette.success;
 	if (tag === "BEST") return "magenta";
-	return "cyan";
+	return palette.act;
 }
 
 function resolveDisplayName(
@@ -272,7 +272,7 @@ export function ClineModelSelectorDialogContent(
 	if (state.status === "error") {
 		return (
 			<box flexDirection="column" gap={1}>
-				<text fg="cyan">Choose a model</text>
+				<text fg={palette.act}>Choose a model</text>
 				<ProviderRow providerName={props.currentProviderName} focused={false} />
 				<text fg="red">{state.message}</text>
 				<text fg="gray">R to retry, Esc to go back</text>
@@ -282,7 +282,7 @@ export function ClineModelSelectorDialogContent(
 
 	return (
 		<box flexDirection="column" gap={1}>
-			<text fg="cyan">Choose a model</text>
+			<text fg={palette.act}>Choose a model</text>
 			<ProviderRow providerName={props.currentProviderName} focused={false} />
 			<text fg="gray">{state.message}</text>
 			<text fg="gray">Esc to go back</text>

--- a/apps/cli/src/tui/components/model-selector/provider-row.tsx
+++ b/apps/cli/src/tui/components/model-selector/provider-row.tsx
@@ -13,7 +13,7 @@ export function ProviderRow({
 			<text fg={focused ? palette.selection : "gray"} flexShrink={0}>
 				{focused ? "❯" : " "}
 			</text>
-			<text fg={focused ? palette.selection : "cyan"} flexShrink={0}>
+			<text fg={focused ? palette.selection : palette.act} flexShrink={0}>
 				Provider:
 			</text>
 			<text fg="white">{providerName}</text>

--- a/apps/cli/src/tui/palette.ts
+++ b/apps/cli/src/tui/palette.ts
@@ -3,7 +3,7 @@ export const palette = {
 	plan: "#ffea7f",
 	selection: "#79b8ff",
 	error: "red",
-	success: "brightGreen",
+	success: "#87af87",
 	muted: "gray",
 	textOnSelection: "black",
 } as const;
@@ -31,7 +31,7 @@ export const diffPalettes = {
 		removedBg: "#4d1a1a",
 		addedLineNumberBg: "#1a4d1a",
 		removedLineNumberBg: "#4d1a1a",
-		addedSignColor: "#22c55e",
+		addedSignColor: "#87af87",
 		removedSignColor: "#ef4444",
 		lineNumberFg: "#888888",
 	},

--- a/apps/cli/src/tui/palette.ts
+++ b/apps/cli/src/tui/palette.ts
@@ -1,7 +1,7 @@
 export const palette = {
-	act: "cyan",
-	plan: "yellow",
-	selection: "cyan",
+	act: "#79b8ff",
+	plan: "#ffea7f",
+	selection: "#79b8ff",
 	error: "red",
 	success: "brightGreen",
 	muted: "gray",
@@ -16,9 +16,11 @@ export const themePalette = {
 		plan: palette.plan,
 		success: palette.success,
 	},
+	// Same OKLCH hues as the dark accents, darkened to hold >=4.5:1 contrast
+	// on white so the plan/act identity carries across themes.
 	light: {
-		act: "#0969da",
-		plan: "#9a6700",
+		act: "#0f72cb",
+		plan: "#867100",
 		success: "#116329",
 	},
 } as const;
@@ -75,8 +77,8 @@ export function getSuccessColor(theme: TerminalTheme = "dark"): string {
 //      overshoot.
 //   3. On dark themes, raise L (lighten). On light themes, lower L (darken).
 //   4. Nudge the a/b chromatic channels by CHROMA_NUDGE toward the mode's
-//      accent color. For plan (warm/yellow): +a, +b. For act (cool/cyan):
-//      -a, +b. At 0.003 this is ~10x below OKLAB's just-noticeable-difference
+//      accent color. For plan (warm/yellow): +a, +b. For act (cool/blue):
+//      -a, -b. At 0.003 this is ~10x below OKLAB's just-noticeable-difference
 //      threshold (~0.03), so it registers as a "feel" rather than visible color.
 //
 // Sample outputs on common terminals (act mode / plan mode bg):
@@ -157,7 +159,7 @@ export function getModeInputBackground(
 		terminalBg,
 		BASE_LIFT,
 		warm ? CHROMA_NUDGE : -CHROMA_NUDGE,
-		CHROMA_NUDGE,
+		warm ? CHROMA_NUDGE : -CHROMA_NUDGE,
 	);
 }
 
@@ -188,7 +190,7 @@ export function getModeInputForeground(
 	return oklabToHex(
 		base.L,
 		base.a + (warm ? CHROMA_NUDGE : -CHROMA_NUDGE),
-		base.b + CHROMA_NUDGE,
+		base.b + (warm ? CHROMA_NUDGE : -CHROMA_NUDGE),
 	);
 }
 
@@ -202,7 +204,7 @@ export function getModeInputPlaceholder(
 	return oklabToHex(
 		base.L,
 		base.a + (warm ? CHROMA_NUDGE * 2 : -CHROMA_NUDGE * 2),
-		base.b + CHROMA_NUDGE * 2,
+		base.b + (warm ? CHROMA_NUDGE * 2 : -CHROMA_NUDGE * 2),
 	);
 }
 

--- a/apps/cli/src/tui/palette.ts
+++ b/apps/cli/src/tui/palette.ts
@@ -3,7 +3,7 @@ export const palette = {
 	plan: "#ffea7f",
 	selection: "#79b8ff",
 	error: "red",
-	success: "#87af87",
+	success: "#8bd28d",
 	muted: "gray",
 	textOnSelection: "black",
 } as const;
@@ -31,7 +31,7 @@ export const diffPalettes = {
 		removedBg: "#4d1a1a",
 		addedLineNumberBg: "#1a4d1a",
 		removedLineNumberBg: "#4d1a1a",
-		addedSignColor: "#87af87",
+		addedSignColor: "#8bd28d",
 		removedSignColor: "#ef4444",
 		lineNumberFg: "#888888",
 	},

--- a/apps/cli/src/tui/palette.ts
+++ b/apps/cli/src/tui/palette.ts
@@ -3,7 +3,7 @@ export const palette = {
 	plan: "#ffea7f",
 	selection: "#79b8ff",
 	error: "red",
-	success: "#8bd28d",
+	success: "#99e89b",
 	muted: "gray",
 	textOnSelection: "black",
 } as const;
@@ -31,7 +31,7 @@ export const diffPalettes = {
 		removedBg: "#4d1a1a",
 		addedLineNumberBg: "#1a4d1a",
 		removedLineNumberBg: "#4d1a1a",
-		addedSignColor: "#8bd28d",
+		addedSignColor: "#99e89b",
 		removedSignColor: "#ef4444",
 		lineNumberFg: "#888888",
 	},

--- a/apps/cli/src/tui/utils/syntax-style.ts
+++ b/apps/cli/src/tui/utils/syntax-style.ts
@@ -30,7 +30,7 @@ interface SyntaxColors {
 }
 
 // Dark syntax colors are a pastel family harmonized with the brand accents
-// (act #79b8ff, plan #ffea7f, success #87af87): every hue sits near the same
+// (act #79b8ff, plan #ffea7f, success #8bd28d): every hue sits near the same
 // OKLCH lightness/chroma weight (~L 0.78, C 0.11) so code blocks feel like
 // part of the same palette instead of a bolted-on editor theme.
 const syntaxColors: Record<TerminalTheme, SyntaxColors> = {
@@ -40,7 +40,7 @@ const syntaxColors: Record<TerminalTheme, SyntaxColors> = {
 		type: "#dfca7d",
 		functionName: themePalette.dark.act,
 		variable: "#ee939b",
-		string: "#87af87",
+		string: "#8bd28d",
 		number: "#f0ad7f",
 		comment: "#5c6370",
 		punctuation: "#abb2bf",
@@ -49,7 +49,7 @@ const syntaxColors: Record<TerminalTheme, SyntaxColors> = {
 		tag: "#ee939b",
 		attribute: "#f0ad7f",
 		escape: "#9bbbdd",
-		markdownCode: "#87af87",
+		markdownCode: "#8bd28d",
 		markdownHeading: themePalette.dark.act,
 		markdownMuted: "#808080",
 		markdownLink: themePalette.dark.act,

--- a/apps/cli/src/tui/utils/syntax-style.ts
+++ b/apps/cli/src/tui/utils/syntax-style.ts
@@ -30,7 +30,7 @@ interface SyntaxColors {
 }
 
 // Dark syntax colors are a pastel family harmonized with the brand accents
-// (act #79b8ff, plan #ffea7f, success #8bd28d): every hue sits near the same
+// (act #79b8ff, plan #ffea7f, success #99e89b): every hue sits near the same
 // OKLCH lightness/chroma weight (~L 0.78, C 0.11) so code blocks feel like
 // part of the same palette instead of a bolted-on editor theme.
 const syntaxColors: Record<TerminalTheme, SyntaxColors> = {
@@ -40,7 +40,7 @@ const syntaxColors: Record<TerminalTheme, SyntaxColors> = {
 		type: "#dfca7d",
 		functionName: themePalette.dark.act,
 		variable: "#ee939b",
-		string: "#8bd28d",
+		string: "#99e89b",
 		number: "#f0ad7f",
 		comment: "#5c6370",
 		punctuation: "#abb2bf",
@@ -49,7 +49,7 @@ const syntaxColors: Record<TerminalTheme, SyntaxColors> = {
 		tag: "#ee939b",
 		attribute: "#f0ad7f",
 		escape: "#9bbbdd",
-		markdownCode: "#8bd28d",
+		markdownCode: "#99e89b",
 		markdownHeading: themePalette.dark.act,
 		markdownMuted: "#808080",
 		markdownLink: themePalette.dark.act,

--- a/apps/cli/src/tui/utils/syntax-style.ts
+++ b/apps/cli/src/tui/utils/syntax-style.ts
@@ -1,5 +1,5 @@
 import { RGBA, type StyleDefinition, SyntaxStyle } from "@opentui/core";
-import type { TerminalTheme } from "../palette";
+import { type TerminalTheme, themePalette } from "../palette";
 
 const instances: Record<TerminalTheme, SyntaxStyle | null> = {
 	dark: null,
@@ -46,9 +46,9 @@ const syntaxColors: Record<TerminalTheme, SyntaxColors> = {
 		attribute: "#d19a66",
 		escape: "#56b6c2",
 		markdownCode: "#98c379",
-		markdownHeading: "#56b6c2",
+		markdownHeading: themePalette.dark.act,
 		markdownMuted: "#808080",
-		markdownLink: "#56b6c2",
+		markdownLink: themePalette.dark.act,
 		markdownItalic: "#e5c07b",
 	},
 	light: {
@@ -67,9 +67,9 @@ const syntaxColors: Record<TerminalTheme, SyntaxColors> = {
 		attribute: "#0550ae",
 		escape: "#0550ae",
 		markdownCode: "#116329",
-		markdownHeading: "#0969da",
+		markdownHeading: themePalette.light.act,
 		markdownMuted: "#6e7781",
-		markdownLink: "#0969da",
+		markdownLink: themePalette.light.act,
 		markdownItalic: "#8250df",
 		markdownDefault: "#1a1a1a",
 	},

--- a/apps/cli/src/tui/utils/syntax-style.ts
+++ b/apps/cli/src/tui/utils/syntax-style.ts
@@ -29,27 +29,31 @@ interface SyntaxColors {
 	markdownDefault?: string;
 }
 
+// Dark syntax colors are a pastel family harmonized with the brand accents
+// (act #79b8ff, plan #ffea7f, success #87af87): every hue sits near the same
+// OKLCH lightness/chroma weight (~L 0.78, C 0.11) so code blocks feel like
+// part of the same palette instead of a bolted-on editor theme.
 const syntaxColors: Record<TerminalTheme, SyntaxColors> = {
 	dark: {
-		keyword: "#c678dd",
-		operator: "#56b6c2",
-		type: "#e5c07b",
-		functionName: "#61afef",
-		variable: "#e06c75",
-		string: "#98c379",
-		number: "#d19a66",
+		keyword: "#d7a0e3",
+		operator: "#9bbbdd",
+		type: "#dfca7d",
+		functionName: themePalette.dark.act,
+		variable: "#ee939b",
+		string: "#87af87",
+		number: "#f0ad7f",
 		comment: "#5c6370",
 		punctuation: "#abb2bf",
-		property: "#e06c75",
-		constant: "#d19a66",
-		tag: "#e06c75",
-		attribute: "#d19a66",
-		escape: "#56b6c2",
-		markdownCode: "#98c379",
+		property: "#ee939b",
+		constant: "#f0ad7f",
+		tag: "#ee939b",
+		attribute: "#f0ad7f",
+		escape: "#9bbbdd",
+		markdownCode: "#87af87",
 		markdownHeading: themePalette.dark.act,
 		markdownMuted: "#808080",
 		markdownLink: themePalette.dark.act,
-		markdownItalic: "#e5c07b",
+		markdownItalic: "#dfca7d",
 	},
 	light: {
 		keyword: "#cf222e",

--- a/apps/cli/src/tui/views/config-view.tsx
+++ b/apps/cli/src/tui/views/config-view.tsx
@@ -721,7 +721,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 
 	return (
 		<box flexDirection="column" paddingX={1}>
-			<text fg="cyan">
+			<text fg={palette.act}>
 				<strong>Settings</strong>
 			</text>
 
@@ -793,7 +793,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 								flexDirection="row"
 								justifyContent="space-between"
 							>
-								<text fg={isSel ? "cyan" : undefined}>{pfx}Provider</text>
+								<text fg={isSel ? palette.act : undefined}>{pfx}Provider</text>
 								<text fg="white">{props.providerDisplayName}</text>
 							</box>
 						);
@@ -804,7 +804,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 								flexDirection="row"
 								justifyContent="space-between"
 							>
-								<text fg={isSel ? "cyan" : undefined}>{pfx}Model</text>
+								<text fg={isSel ? palette.act : undefined}>{pfx}Model</text>
 								<text fg="white">{displayName}</text>
 							</box>
 						);
@@ -833,7 +833,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 								flexDirection="row"
 								justifyContent="space-between"
 							>
-								<text fg={isSel ? "cyan" : undefined}>
+								<text fg={isSel ? palette.act : undefined}>
 									{pfx}
 									{row.label}
 								</text>
@@ -866,7 +866,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 								: enabledState === "partial"
 									? "yellow"
 									: isSel
-										? "cyan"
+										? palette.act
 										: "gray";
 						return (
 							<box
@@ -886,7 +886,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 					}
 					case "mcp-manager":
 						return (
-							<text key={absIdx} fg={isSel ? "cyan" : "gray"}>
+							<text key={absIdx} fg={isSel ? palette.act : "gray"}>
 								{pfx}Manage MCP Servers...
 							</text>
 						);

--- a/apps/cli/src/tui/views/onboarding/screens.tsx
+++ b/apps/cli/src/tui/views/onboarding/screens.tsx
@@ -384,7 +384,7 @@ export function OnboardingCodexCliScreen(props: {
 						<text fg="yellow">Codex CLI was not found</text>
 						<text fg="gray">{props.status.reason}</text>
 						<text fg="gray">Install Codex CLI from:</text>
-						<text fg="cyan" selectable>
+						<text fg={palette.act} selectable>
 							{CODEX_CLI_INSTALL_URL}
 						</text>
 					</box>


### PR DESCRIPTION
### Related Issue

N/A — internal TUI design iteration. Stacked on #12074.

### Description

Retires ANSI cyan as the CLI's act-mode accent and moves both mode accents to fixed hexes:

| | Dark themes | Light themes |
|---|---|---|
| **Act** | `#79b8ff` | `#0f72cb` |
| **Plan** | `#ffea7f` | `#867100` |

**How the colors were chosen.** The light-theme values aren't eyeballed — they're derived in OKLCH from the dark ones: same hue exactly, lightness dropped until they pass ≥4.5:1 WCAG contrast on white (4.9:1 and 4.8:1 respectively). So the plan/act color identity carries across themes instead of light mode getting unrelated colors. Theme selection flows through the existing `getModeAccent(mode, theme)` / `themePalette` switch driven by terminal background detection; no new mechanism.

**Single source of truth.** There were 39 hardcoded `"cyan"` fg literals scattered across the dialogs (account, help, provider picker, MCP manager, command palette, skills picker, tool approval, config), the model selector, config view, and onboarding. All now reference `palette.act`, so the next accent change is a one-line edit. `palette.selection` (selected-row background with black text) follows the act color.

**Tradeoff to be aware of:** plan was previously the *named* ANSI color `"yellow"`, which adapted to whatever the user's terminal 16-color theme mapped it to. It's now a fixed hex, so it renders identically everywhere — more consistent, but no longer inherits terminal-theme personality. Act (cyan) makes the same trade. Semantic `fg="yellow"` warning text (e.g. `[steer]` tags, warning glyphs) is intentionally untouched — that's a warning color, not the plan accent.

**Subliminal detail:** the input background/foreground/placeholder OKLAB chroma nudge (±0.003, ~10× below just-noticeable-difference) previously leaned act toward cyan (`-a, +b`); it now leans blue (`-a, -b`) to match the new hue. Imperceptible by design but keeps the "feel" pointing at the right color.

**Known gap (pre-existing, not introduced here):** the direct `palette.act` consumers (dialogs etc.) don't go through the theme switch, so light-theme terminals see `#79b8ff` there — somewhat washed on white, but no worse than the cyan it replaces. A `useThemedPalette()` hook pass would fix this properly; deliberately out of scope.

**Follow-up commits after initial review rounds:**

- **Success green**: `palette.success` moves from ANSI `brightGreen` (and the diff added-sign `#22c55e`) to `#99e89b` — covers the auto-approve banner, git `+stats`, diff views, FREE tags, and approve buttons. Derived in OKLCH at the same weight as the act/plan anchors (L 0.86, C 0.13); earlier candidates `#87af87` and `#8bd28d` read too muted next to them. Light themes keep `#116329`.
- **Markdown accents**: headings, bold, list markers, links, and table headers in the OpenTUI markdown renderer now use the act accent via `themePalette` (dark `#79b8ff`, light `#0f72cb`) instead of hardcoded one-dark cyan `#56b6c2`.
- **Syntax highlighting harmonized**: the dark code-highlighting palette is regenerated as a pastel family around the brand anchors — functions = act blue, strings/inline code = success green, types/italics = dimmed plan yellow `#dfca7d`, keyword purple `#d7a0e3`, variable coral `#ee939b`, number orange `#f0ad7f`, operator ice-blue `#9bbbdd` — all at ~L 0.78, C 0.11 in OKLCH so code blocks read as part of the same palette instead of a bolted-on editor theme. Light theme keeps its GitHub-light set.

### Test Procedure

- `bunx tsc --noEmit` clean in `apps/cli` (also caught the one file that used cyan without importing the palette — help-dialog — which now imports it).
- Verified no `"cyan"` literals remain under `src/tui` outside tests.
- Manually exercised via `bun run dev` on a dark terminal: plan/act toggle on home and chat views, dialogs, model selector, command palette selection highlight.

### Type of Change

-   [x] 💅 Cosmetic Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

⚠️ Stacked PR targeting `saoudrizwan/tui-chatfield-rules` (#12074) — note that PRs targeting non-main branches skip the real test workflows (the green "Run Tests" check is a no-op), so CI signal here is meaningless until this is retargeted to main after #12074 merges.
