### PR TITLE
fix: SessionRuntime.shutdown auto-aborts instead of throwing

### DIFF
--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
@@ -605,10 +605,8 @@ export class SessionRuntime {
 	/** Shut the session down after any active run drains. */
 	async shutdown(_reason?: string, _timeoutMs?: number): Promise<void> {
 		if (this.running) {
-			if (!this.abortRequested || !this.activeRunPromise) {
-				throw new Error(
-					`SessionRuntime.shutdown called while a run is in progress (agentId=${this.agentId})`,
-				);
+			if (!this.abortRequested) {
+				this.abort(_reason ?? "shutdown");
 			}
 			await this.activeRunPromise;
 		}


### PR DESCRIPTION
When shutdown() is called while a run is in progress without a prior abort() call, it now calls abort() internally and waits for the run to drain instead of throwing.