### PR TITLE
feat(cli): color transcript entries by the mode they were produced in

### DIFF
--- a/apps/cli/src/session/export.ts
+++ b/apps/cli/src/session/export.ts
@@ -1,7 +1,7 @@
 import {
 	type ContentBlock,
+	formatDisplayUserInput,
 	type MessageWithMetadata,
-	normalizeUserInput,
 	type ToolResultContent,
 	type ToolUseContent,
 } from "@cline/shared";
@@ -681,7 +681,7 @@ function renderContentHTML(
 	toolResultsMap: Map<string, ToolResultContent>,
 ): string {
 	if (typeof content === "string") {
-		const text = isUser ? normalizeUserInput(content) : content;
+		const text = isUser ? formatDisplayUserInput(content) : content;
 		return renderTextHTML(text);
 	}
 
@@ -689,7 +689,7 @@ function renderContentHTML(
 		.map((block) => {
 			switch (block.type) {
 				case "text": {
-					const text = isUser ? normalizeUserInput(block.text) : block.text;
+					const text = isUser ? formatDisplayUserInput(block.text) : block.text;
 					return renderTextHTML(text);
 				}
 				case "tool_use":

--- a/apps/cli/src/tui/components/chat-message-list.tsx
+++ b/apps/cli/src/tui/components/chat-message-list.tsx
@@ -100,7 +100,9 @@ export const ChatMessageList = forwardRef<
 						<ChatEntryView
 							key={key}
 							entry={entry}
-							accent={accent}
+							accent={
+								entry.mode ? getModeAccent(entry.mode, terminalTheme) : accent
+							}
 							loadIndividualSubscriptionPlans={
 								props.loadIndividualSubscriptionPlans
 							}

--- a/apps/cli/src/tui/contexts/session-context.tsx
+++ b/apps/cli/src/tui/contexts/session-context.tsx
@@ -103,9 +103,16 @@ export function SessionProvider(props: {
 	const [hasSubmitted, setHasSubmitted] = useState(
 		(initialEntries?.length ?? 0) > 0,
 	);
-	const [uiMode, setUiMode] = useState<AgentMode>(
+	const [uiMode, _setUiMode] = useState<AgentMode>(
 		config.mode === "plan" ? "plan" : "act",
 	);
+	// Mirror for appendEntry: entries are appended from event-handler
+	// callbacks that must see the mode at append time, not at closure time.
+	const uiModeRef = useRef<AgentMode>(config.mode === "plan" ? "plan" : "act");
+	const setUiMode = useCallback((mode: AgentMode) => {
+		uiModeRef.current = mode;
+		_setUiMode(mode);
+	}, []);
 	const initialAutoApproveAll = config.toolPolicies["*"]?.autoApprove !== false;
 	const autoApproveAllRef = useRef(initialAutoApproveAll);
 	const [autoApproveAll, _setAutoApproveAll] = useState(initialAutoApproveAll);
@@ -132,8 +139,9 @@ export function SessionProvider(props: {
 	);
 
 	const appendEntry = useCallback((entry: ChatEntry) => {
+		const stamped = entry.mode ? entry : { ...entry, mode: uiModeRef.current };
 		setEntries((prev) => {
-			const next = [...prev, entry];
+			const next = [...prev, stamped];
 			return next.length <= MAX_BUFFERED_LINES
 				? next
 				: next.slice(next.length - MAX_BUFFERED_LINES);
@@ -188,8 +196,8 @@ export function SessionProvider(props: {
 	}, []);
 
 	const toggleMode = useCallback(() => {
-		setUiMode((m) => (m === "act" ? "plan" : "act"));
-	}, []);
+		setUiMode(uiModeRef.current === "act" ? "plan" : "act");
+	}, [setUiMode]);
 
 	const toggleAutoApprove = useCallback(() => {
 		const next = !autoApproveAllRef.current;

--- a/apps/cli/src/tui/hooks/use-local-command-actions.tsx
+++ b/apps/cli/src/tui/hooks/use-local-command-actions.tsx
@@ -75,9 +75,10 @@ export function useLocalCommandActions(input: {
 						});
 					} else {
 						session.clearEntries();
-						for (const entry of entries) {
-							session.appendEntry(entry);
-						}
+						// replaceEntries rather than appendEntry: appendEntry
+						// stamps unstamped entries with the CURRENT mode, which
+						// would lock hydrated history to the resume-time accent.
+						session.replaceEntries(entries);
 						if (typeof result.currentContextSize === "number") {
 							session.setLastTotalTokens(result.currentContextSize);
 						}

--- a/apps/cli/src/tui/root.tsx
+++ b/apps/cli/src/tui/root.tsx
@@ -401,9 +401,10 @@ function App(props: TuiProps) {
 			if (lastEntry && lastEntry.kind === "user_submitted") {
 				entries.pop();
 			}
-			for (const entry of entries) {
-				session.appendEntry(entry);
-			}
+			// replaceEntries rather than appendEntry: appendEntry stamps
+			// unstamped entries with the CURRENT mode, which would lock
+			// hydrated history to the restore-time accent.
+			session.replaceEntries(entries);
 			session.setHasSubmitted(entries.length > 0);
 			setAppView(entries.length > 0 ? "chat" : "home");
 			populateInputRef.current(picked.fullText);

--- a/apps/cli/src/tui/types.ts
+++ b/apps/cli/src/tui/types.ts
@@ -25,7 +25,7 @@ import type {
 } from "./interactive-config";
 import type { InteractiveSlashCommand } from "./interactive-welcome";
 
-export type ChatEntry =
+export type ChatEntry = (
 	| { kind: "user"; text: string }
 	| { kind: "assistant_text"; text: string; streaming: boolean }
 	| { kind: "reasoning"; text: string; streaming: boolean }
@@ -52,7 +52,17 @@ export type ChatEntry =
 			cost: number;
 			elapsed: string;
 			iterations: number;
-	  };
+	  }
+) & {
+	/**
+	 * Agent mode active when the entry was produced. Stamped by appendEntry
+	 * (live sessions) and hydrateSessionMessages (resumed sessions) so the
+	 * transcript renders each entry with the accent of its own mode instead
+	 * of retinting everything to the current mode. Absent on entries from
+	 * transcripts that predate mode stamping.
+	 */
+	mode?: AgentMode;
+};
 
 export interface InteractiveTurnResult {
 	usage: {

--- a/apps/cli/src/tui/utils/hydrate-messages.test.ts
+++ b/apps/cli/src/tui/utils/hydrate-messages.test.ts
@@ -13,7 +13,7 @@ describe("hydrateSessionMessages", () => {
 		] as Message[];
 
 		expect(hydrateSessionMessages(messages)).toEqual([
-			{ kind: "user_submitted", text: "lets do it" },
+			{ kind: "user_submitted", text: "lets do it", mode: "plan" },
 		]);
 	});
 
@@ -39,7 +39,116 @@ describe("hydrateSessionMessages", () => {
 		] as Message[];
 
 		expect(hydrateSessionMessages(messages)).toEqual([
-			{ kind: "assistant_text", text: "On it.", streaming: false },
+			{ kind: "assistant_text", text: "On it.", streaming: false, mode: "act" },
+		]);
+	});
+
+	it("stamps entries with the mode of the user message that produced them", () => {
+		const messages = [
+			{
+				role: "user",
+				content: '<user_input mode="plan">plan this out</user_input>',
+			},
+			{ role: "assistant", content: "Here is the plan." },
+			{
+				role: "user",
+				content: '<user_input mode="act">do it</user_input>',
+			},
+			{ role: "assistant", content: "Doing it." },
+		] as Message[];
+
+		expect(hydrateSessionMessages(messages)).toEqual([
+			{ kind: "user_submitted", text: "plan this out", mode: "plan" },
+			{
+				kind: "assistant_text",
+				text: "Here is the plan.",
+				streaming: false,
+				mode: "plan",
+			},
+			{ kind: "user_submitted", text: "do it", mode: "act" },
+			{
+				kind: "assistant_text",
+				text: "Doing it.",
+				streaming: false,
+				mode: "act",
+			},
+		]);
+	});
+
+	it("switches to act mode after a switch_to_act_mode tool call", () => {
+		const messages = [
+			{
+				role: "user",
+				content: '<user_input mode="plan">plan then build</user_input>',
+			},
+			{
+				role: "assistant",
+				content: [
+					{ type: "text", text: "Plan looks good, switching." },
+					{
+						type: "tool_use",
+						id: "tool-1",
+						name: "switch_to_act_mode",
+						input: {},
+					},
+					{ type: "text", text: "Building now." },
+				],
+			},
+		] as Message[];
+
+		expect(hydrateSessionMessages(messages)).toEqual([
+			{ kind: "user_submitted", text: "plan then build", mode: "plan" },
+			{
+				kind: "assistant_text",
+				text: "Plan looks good, switching.",
+				streaming: false,
+				mode: "plan",
+			},
+			{
+				kind: "tool_call",
+				toolName: "switch_to_act_mode",
+				inputSummary: expect.any(String),
+				rawInput: {},
+				streaming: false,
+				mode: "plan",
+			},
+			{
+				kind: "assistant_text",
+				text: "Building now.",
+				streaming: false,
+				mode: "act",
+			},
+		]);
+	});
+
+	it("strips mode switch notices from displayed user text", () => {
+		const messages = [
+			{
+				role: "user",
+				content:
+					'<user_input mode="plan"><mode_notice>The user switched from act mode to plan mode before sending this message.</mode_notice>\nare you okay?</user_input>',
+			},
+		] as Message[];
+
+		expect(hydrateSessionMessages(messages)).toEqual([
+			{ kind: "user_submitted", text: "are you okay?", mode: "plan" },
+		]);
+	});
+
+	it("leaves mode undefined for transcripts without user_input wrappers", () => {
+		const messages = [
+			{ role: "user", content: "plain old message" },
+			{ role: "assistant", content: "reply" },
+		] as Message[];
+
+		expect(hydrateSessionMessages(messages)).toEqual([
+			{ kind: "user_submitted", text: "plain old message", mode: undefined },
+			{
+				kind: "assistant_text",
+				text: "reply",
+				streaming: false,
+				mode: undefined,
+			},
 		]);
 	});
 });

--- a/apps/cli/src/tui/utils/hydrate-messages.ts
+++ b/apps/cli/src/tui/utils/hydrate-messages.ts
@@ -1,4 +1,9 @@
-import { formatDisplayUserInput, type Message } from "@cline/shared";
+import type { AgentMode } from "@cline/core";
+import {
+	formatDisplayUserInput,
+	type Message,
+	parseUserInputMode,
+} from "@cline/shared";
 import { ACT_MODE_CONTINUATION_PROMPT } from "../../runtime/interactive/mode";
 import { formatToolInput } from "../../utils/helpers";
 import type { ChatEntry } from "../types";
@@ -37,6 +42,12 @@ function stringifyToolResult(
 export function hydrateSessionMessages(messages: Message[]): ChatEntry[] {
 	const entries: ChatEntry[] = [];
 	const toolUseMap = new Map<string, number>();
+	// Mode each entry was produced in, recovered from <user_input mode="...">
+	// wrappers and switch_to_act_mode tool calls as we walk the transcript.
+	// Stays undefined for transcripts with no mode markers (pre-wrapper
+	// builds, or transcripts laundered by older builds that stripped the
+	// wrappers on session restarts).
+	let mode: AgentMode | undefined;
 
 	for (const msg of messages as PersistedMessage[]) {
 		const displayRole = getDisplayRole(msg);
@@ -46,15 +57,17 @@ export function hydrateSessionMessages(messages: Message[]): ChatEntry[] {
 
 		if (typeof msg.content === "string") {
 			if (msg.role === "user") {
+				mode = parseUserInputMode(msg.content) ?? mode;
 				const text = formatDisplayUserInput(msg.content);
 				if (text && !isSyntheticUserText(text)) {
-					entries.push({ kind: "user_submitted", text });
+					entries.push({ kind: "user_submitted", text, mode });
 				}
 			} else {
 				entries.push({
 					kind: "assistant_text",
 					text: msg.content,
 					streaming: false,
+					mode,
 				});
 			}
 			continue;
@@ -71,6 +84,7 @@ export function hydrateSessionMessages(messages: Message[]): ChatEntry[] {
 						kind: "assistant_text",
 						text: block.text,
 						streaming: false,
+						mode,
 					});
 				}
 				continue;
@@ -81,6 +95,7 @@ export function hydrateSessionMessages(messages: Message[]): ChatEntry[] {
 					kind: "reasoning",
 					text: block.thinking,
 					streaming: false,
+					mode,
 				});
 				continue;
 			}
@@ -96,8 +111,14 @@ export function hydrateSessionMessages(messages: Message[]): ChatEntry[] {
 					inputSummary: formatToolInput(block.name, block.input),
 					rawInput: block.input,
 					streaming: false,
+					mode,
 				});
 				toolUseMap.set(block.id, entries.length - 1);
+				// The switch tool flips the session to act mid-run; everything
+				// after it was produced in act mode.
+				if (block.name === "switch_to_act_mode") {
+					mode = "act";
+				}
 				continue;
 			}
 
@@ -123,9 +144,10 @@ export function hydrateSessionMessages(messages: Message[]): ChatEntry[] {
 
 		if (msg.role === "user" && userTextParts.length > 0) {
 			const combined = userTextParts.join("\n");
+			mode = parseUserInputMode(combined) ?? mode;
 			const text = formatDisplayUserInput(combined);
 			if (text && !isSyntheticUserText(text)) {
-				entries.push({ kind: "user_submitted", text });
+				entries.push({ kind: "user_submitted", text, mode });
 			}
 		}
 	}

--- a/apps/cline-hub/src/server/session-mapping.ts
+++ b/apps/cline-hub/src/server/session-mapping.ts
@@ -1,3 +1,4 @@
+import { formatDisplayUserInput } from "@cline/shared";
 import type {
 	WebviewActionSessionSummary,
 	WebviewChatMessage,
@@ -213,10 +214,16 @@ export function mapHistoryToWebviewMessages(
 		const currentToolBlockIndexes = new Map<string, number>();
 		let reasoningRedacted = false;
 
+		// Persisted user text arrives raw, including runtime-generated
+		// <user_input>/<mode_notice> wrappers -- format at this display
+		// boundary so the webview never renders them.
+		const displayText = (text: string): string =>
+			role === "user" ? formatDisplayUserInput(text) : text;
+
 		const contentParts = historyContentParts(record.content);
 		if (contentParts.length === 0) {
 			const text = stringifyContent(record.content ?? record.text ?? record);
-			pushTextBlock(blocks, textParts, messageKey, 0, text);
+			pushTextBlock(blocks, textParts, messageKey, 0, displayText(text));
 		}
 
 		for (const [partIndex, part] of contentParts.entries()) {
@@ -227,7 +234,7 @@ export function mapHistoryToWebviewMessages(
 					textParts,
 					messageKey,
 					partIndex,
-					asString(part.text) ?? asString(part.content) ?? "",
+					displayText(asString(part.text) ?? asString(part.content) ?? ""),
 				);
 				continue;
 			}

--- a/sdk/packages/core/src/runtime/host/runtime-host-support.test.ts
+++ b/sdk/packages/core/src/runtime/host/runtime-host-support.test.ts
@@ -13,7 +13,11 @@ afterEach(async () => {
 });
 
 describe("readPersistedMessagesFile", () => {
-	it("strips wrapped user_input envelopes from user history messages", async () => {
+	it("returns persisted messages verbatim, wrappers included", async () => {
+		// The user_input wrapper records which mode each message was sent in
+		// and session restarts re-seed through this read path, so stripping
+		// here would destroy that history a little more on every restart.
+		// Display surfaces format for themselves via formatDisplayUserInput.
 		const dir = await mkdtemp(join(tmpdir(), "runtime-host-support-"));
 		tempDirs.push(dir);
 		const messagesPath = join(dir, "messages.json");
@@ -33,7 +37,7 @@ describe("readPersistedMessagesFile", () => {
 					content: [
 						{
 							type: "text",
-							text: '<user_input mode="plan">inspect repo</user_input>',
+							text: '<user_input mode="plan"><mode_notice>The user switched from act mode to plan mode before sending this message.</mode_notice>\ninspect repo</user_input>',
 						},
 					],
 				},
@@ -43,12 +47,14 @@ describe("readPersistedMessagesFile", () => {
 
 		const messages = await readPersistedMessagesFile(messagesPath);
 
-		expect(messages[0]?.content).toBe("spawn a team of agents");
+		expect(messages[0]?.content).toBe(
+			'<user_input mode="act">spawn a team of agents</user_input>',
+		);
 		expect(messages[1]?.content).toBe("Working on it.");
 		expect(messages[2]?.content).toEqual([
 			{
 				type: "text",
-				text: "inspect repo",
+				text: '<user_input mode="plan"><mode_notice>The user switched from act mode to plan mode before sending this message.</mode_notice>\ninspect repo</user_input>',
 			},
 		]);
 	});

--- a/sdk/packages/core/src/runtime/host/runtime-host-support.ts
+++ b/sdk/packages/core/src/runtime/host/runtime-host-support.ts
@@ -1,7 +1,6 @@
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import type * as LlmsProviders from "@cline/llms";
-import { formatDisplayUserInput } from "@cline/shared";
 import type { HookEventPayload } from "../../hooks";
 import type { CoreSessionEvent } from "../../types/events";
 import type {
@@ -44,6 +43,13 @@ export class RuntimeHostEventBus {
 	}
 }
 
+// Returns the persisted messages verbatim. User messages keep their
+// runtime-generated <user_input mode="..."> wrappers and <mode_notice>
+// elements: they are the durable record of which mode each message was sent
+// in, and session restarts re-seed new sessions through this read path, so
+// stripping here would launder that history off disk (and out of the model's
+// context) a little more on every restart. Display surfaces are responsible
+// for their own formatting via formatDisplayUserInput.
 export async function readPersistedMessagesFile(
 	messagesPath?: string | null,
 ): Promise<LlmsProviders.Message[]> {
@@ -54,50 +60,18 @@ export async function readPersistedMessagesFile(
 		if (!raw) return [];
 		const parsed = JSON.parse(raw) as unknown;
 		if (Array.isArray(parsed)) {
-			return sanitizeDisplayMessages(parsed as LlmsProviders.Message[]);
+			return parsed as LlmsProviders.Message[];
 		}
 		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
 			const messages = (parsed as { messages?: unknown }).messages;
 			if (Array.isArray(messages)) {
-				return sanitizeDisplayMessages(messages as LlmsProviders.Message[]);
+				return messages as LlmsProviders.Message[];
 			}
 		}
 		return [];
 	} catch {
 		return [];
 	}
-}
-
-function sanitizeDisplayMessage(
-	message: LlmsProviders.Message,
-): LlmsProviders.Message {
-	if (message.role !== "user") {
-		return message;
-	}
-	if (typeof message.content === "string") {
-		return {
-			...message,
-			content: formatDisplayUserInput(message.content),
-		};
-	}
-	return {
-		...message,
-		content: message.content.map((part) => {
-			if (part.type !== "text" || typeof part.text !== "string") {
-				return part;
-			}
-			return {
-				...part,
-				text: formatDisplayUserInput(part.text),
-			};
-		}),
-	};
-}
-
-function sanitizeDisplayMessages(
-	messages: LlmsProviders.Message[],
-): LlmsProviders.Message[] {
-	return messages.map(sanitizeDisplayMessage);
 }
 
 export function cloneAccumulatedUsage(

--- a/sdk/packages/shared/src/index.ts
+++ b/sdk/packages/shared/src/index.ts
@@ -248,6 +248,7 @@ export {
 	formatUserInputBlock,
 	normalizeUserInput,
 	parseUserCommandEnvelope,
+	parseUserInputMode,
 	stripModeNotices,
 	xmlTagsRemoval,
 } from "./prompt/format";

--- a/sdk/packages/shared/src/prompt/format.test.ts
+++ b/sdk/packages/shared/src/prompt/format.test.ts
@@ -6,6 +6,7 @@ import {
 	formatUserInputBlock,
 	normalizeUserInput,
 	parseUserCommandEnvelope,
+	parseUserInputMode,
 	stripModeNotices,
 } from "./format";
 
@@ -38,6 +39,28 @@ describe("prompt format helpers", () => {
 			"team",
 		);
 		expect(formatDisplayUserInput(wrapped)).toBe("/team inspect rpc startup");
+	});
+
+	it("parses the mode attribute from a user_input wrapper", () => {
+		expect(
+			parseUserInputMode(formatUserInputBlock("hello", "plan")),
+		).toBe("plan");
+		expect(parseUserInputMode(formatUserInputBlock("hello", "act"))).toBe(
+			"act",
+		);
+	});
+
+	it("parses the mode when a mode notice precedes the wrapper", () => {
+		const input = `${formatModeSwitchNotice("act", "plan")}${formatUserInputBlock("hello", "plan")}`;
+		expect(parseUserInputMode(input)).toBe("plan");
+	});
+
+	it("returns undefined for unwrapped or unknown-mode input", () => {
+		expect(parseUserInputMode("plain text")).toBeUndefined();
+		expect(parseUserInputMode(undefined)).toBeUndefined();
+		expect(
+			parseUserInputMode('<user_input mode="warp">hello</user_input>'),
+		).toBeUndefined();
 	});
 
 	it("formats a mode switch notice", () => {

--- a/sdk/packages/shared/src/prompt/format.ts
+++ b/sdk/packages/shared/src/prompt/format.ts
@@ -13,6 +13,25 @@ export function formatUserCommandBlock(input: string, slash: string): string {
 	return `<user_command slash="${slash}">${input}</user_command>`;
 }
 
+// Searches rather than anchors: persisted user content can carry prepended
+// <mode_notice> elements or trailing attachment blocks around the wrapper.
+const USER_INPUT_MODE_RE = /<user_input\b[^>]*\bmode="(act|plan|yolo|zen)"/i;
+
+/**
+ * Recovers the agent mode a persisted user message was sent in from its
+ * <user_input mode="..."> wrapper. Returns undefined when the input isn't
+ * wrapped (plain text, user_command envelopes, older transcripts).
+ */
+export function parseUserInputMode(
+	input?: string,
+): "act" | "plan" | "yolo" | "zen" | undefined {
+	const match = USER_INPUT_MODE_RE.exec(input ?? "");
+	return match
+		? (match[1]?.toLowerCase() as "act" | "plan" | "yolo" | "zen")
+		: undefined;
+}
+
+
 /**
  * Marks the exact point in the conversation where the user switched between
  * plan and act modes. Prepended to the first user message sent after the

--- a/sdk/packages/shared/src/prompt/format.ts
+++ b/sdk/packages/shared/src/prompt/format.ts
@@ -13,9 +13,11 @@ export function formatUserCommandBlock(input: string, slash: string): string {
 	return `<user_command slash="${slash}">${input}</user_command>`;
 }
 
-// Searches rather than anchors: persisted user content can carry prepended
-// <mode_notice> elements or trailing attachment blocks around the wrapper.
-const USER_INPUT_MODE_RE = /<user_input\b[^>]*\bmode="(act|plan|yolo|zen)"/i;
+// Mirrors exactly what formatUserInputBlock writes (lowercase tag, lowercase
+// mode values), but searches rather than anchors: persisted user content can
+// carry prepended <mode_notice> elements or trailing attachment blocks
+// around the wrapper.
+const USER_INPUT_MODE_RE = /<user_input\b[^>]*\bmode="(act|plan|yolo)"/;
 
 /**
  * Recovers the agent mode a persisted user message was sent in from its
@@ -24,13 +26,10 @@ const USER_INPUT_MODE_RE = /<user_input\b[^>]*\bmode="(act|plan|yolo|zen)"/i;
  */
 export function parseUserInputMode(
 	input?: string,
-): "act" | "plan" | "yolo" | "zen" | undefined {
+): "act" | "plan" | "yolo" | undefined {
 	const match = USER_INPUT_MODE_RE.exec(input ?? "");
-	return match
-		? (match[1]?.toLowerCase() as "act" | "plan" | "yolo" | "zen")
-		: undefined;
+	return match ? (match[1] as "act" | "plan" | "yolo") : undefined;
 }
-
 
 /**
  * Marks the exact point in the conversation where the user switched between


### PR DESCRIPTION
### Related Issue

N/A — internal TUI design iteration. Stacked on #12077 (← #12075 ← #12074).

### Description

Previously the whole transcript retinted to the current mode's accent on every plan/act toggle. Entries now record the agent mode active when they were produced and keep that accent permanently — a session reads as a visible history of plan (yellow) and act (blue) segments, mixed in one transcript.

**How the mode is captured:**

- **Live sessions**: `appendEntry` in `SessionProvider` stamps every new entry from a `uiMode` ref, so all creation sites (agent events, prompt controller) get stamping for free — including mid-run `switch_to_act_mode` flips, which already call `setUiMode` through the runtime dialog bridge. The ref is updated *synchronously* in a wrapped `setUiMode` (not render-synced) because agent events can append entries between a mid-run mode switch and the next React render.
- **Resumed sessions**: `hydrateSessionMessages` recovers the mode from the persisted `<user_input mode="...">` wrappers via a new shared `parseUserInputMode` helper (which lives next to `formatUserInputBlock`, the function that writes the wrapper), and flips to act when it encounters a `switch_to_act_mode` tool call. Transcripts without wrappers stay unstamped and keep the dynamic current-mode accent — identical to today's behavior.
- **Restores**: the `/history` resume and checkpoint-restore paths now insert hydrated history via `replaceEntries` instead of `appendEntry` loops. This matters: the live-entry stamping in `appendEntry` would otherwise overwrite hydration's stamps and lock the whole resumed transcript to the resume-time accent. (Also collapses N sequential setState calls into one.)

### The debugging journey / the load-bearing core fix

The TUI side worked on the first pass — and yet resumed sessions kept coloring wrong. The trail (traced with file logging at every pipeline boundary, since the TUI is a thin client and all turn execution happens in a long-lived hub daemon that does NOT reload when you restart `bun run dev` — that cost us several false "it's fixed" rounds):

1. Turn prompts ARE wrapped (`prepareTurnInput` → `formatModePrompt`) and ARE persisted wrapped by `persistMessages`. The data was on disk.
2. But `readPersistedMessagesFile` ran `sanitizeDisplayMessages` on **every read**, stripping `<user_input>` wrappers and `<mode_notice>` elements from user text ("display sanitization").
3. That same read path feeds **session restarts** — mode toggle, compaction-mode change, model change, fork, recovery — which re-persist what they read. So every restart laundered the mode markers off disk (and out of the model's seeded context, undermining #12057's intent that the model see mode wrappers on history). A session's mode history degraded a little more with every toggle, and `/history` resume received pre-stripped text even for fresh sessions.

**Fix**: `readPersistedMessagesFile` now returns persisted messages **verbatim**; formatting is the display surface's responsibility (`formatDisplayUserInput`). This makes restarts lossless round-trips. An audit of every `readMessages` consumer found:

- Already formatting at their boundary: CLI TUI hydration, session-list title derivation, VS Code SDK history loader (`sanitizeSdkUserMessagesForDisplay`), the examples desktop app.
- **Fixed in this PR** (would have shown raw wrappers): the cline-hub webview history mapping (`session-mapping.ts` — formats user text at the mapping boundary) and the CLI HTML session export (which used `normalizeUserInput` only and was *already* leaking `mode_notice` text into exports — pre-existing bug, now fixed by switching to `formatDisplayUserInput`).
- Not display-facing (raw is correct or better): connectors (only surface assistant text), usage math, restart re-seeding, compaction model input, checkpoint plumbing.

⚠️ **Behavior change to public SDK API**: `ClineCore.readMessages` now returns raw persisted user text (wrappers included) instead of display-formatted text. SDK consumers that render user messages should apply `formatDisplayUserInput` themselves. This is deliberate: a read API that silently mutates data corrupted state when its output was written back. `apps/examples/vscode`'s webview renders raw text and will show wrappers — left as-is (example app), can fix in a follow-up.

Considered and rejected along the way (for reviewers wondering): recovering the mode into message `metadata` inside the sanitizer (kept the lossy read but preserved the info — worked, but papered over the real defect), and a `parseModeSwitchNotice`-based retroactive backfill for laundered legacy transcripts (correct but only served transcripts written by pre-fix builds; those now simply fall back to current-mode coloring and the problem ages out).

### Test Procedure

- New unit tests: `parseUserInputMode` (shared), hydration mode stamping incl. mid-run `switch_to_act_mode` and markerless fallback (CLI), verbatim reads (core). All suites pass; CLI and cline-hub typecheck clean.
- Manually verified end-to-end with real persisted session files: sessions with mixed plan/act turns hydrate with correct per-segment modes through the actual read path, and a simulated restart round-trip (read → re-persist → read) retains the wrappers.
- Live-verified in the TUI: mixed transcript keeps plan segments yellow / act segments blue across toggles, `/history` resume restores the same coloring.

### Type of Change

-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [x] 💥 Breaking change (`ClineCore.readMessages` raw-text behavior change for SDK display consumers)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

⚠️ Fourth PR in the stack: #12074 ← #12075 ← #12077 ← this. Targets a non-main branch, so the green "Run Tests" check is the no-op workflow — real CI runs once retargeted after parents merge.

Note for testers: transcripts written by pre-fix builds were already laundered (markers destroyed on each mode toggle), so resuming an *old* session shows fallback coloring. Sessions created after this change retain full mode history permanently.