### PR TITLE
fix: reject team_run_task targeting lead agent

### DIFF
--- a/sdk/packages/core/src/extensions/tools/team/team-tools.test.ts
+++ b/sdk/packages/core/src/extensions/tools/team/team-tools.test.ts
@@ -780,6 +780,29 @@ describe("createAgentTeamsTools runtime behavior", () => {
 		expect(awaitRuns?.timeoutMs).toBe(60 * 60 * 1000);
 	});
 
+	it("rejects team_run_task calls that target the lead agent", async () => {
+		const runtime = new AgentTeamsRuntime({ teamName: "test-team" });
+		const tools = createAgentTeamsTools({
+			runtime,
+			requesterId: "lead",
+			teammateConfigProvider: makeTeammateConfigProvider(),
+		});
+		const runTask = tools.find((tool) => tool.name === "team_run_task");
+		expect(runTask).toBeDefined();
+		if (!runTask) {
+			throw new Error("Expected team_run_task tool to be defined");
+		}
+
+		await expect(
+			runTask.execute(
+				{ agentId: "lead", task: "Handle this locally", runMode: "sync" },
+				{ agentId: "lead", conversationId: "conv-1", iteration: 1 },
+			),
+		).rejects.toThrow(
+			'team_run_task targets teammates only; "lead" is the lead agent',
+		);
+	});
+
 	it("collapses concurrent sync team_run_task calls to the same agent", async () => {
 		let resolveRoute!: (value: { text: string; iterations: number }) => void;
 		const routePromise = new Promise<{ text: string; iterations: number }>(

--- a/sdk/packages/core/src/extensions/tools/team/team-tools.ts
+++ b/sdk/packages/core/src/extensions/tools/team/team-tools.ts
@@ -494,6 +494,14 @@ export function createAgentTeamsTools(
 			inputSchema: zodToJsonSchema(TeamRunTaskInputSchema),
 			execute: async (input) => {
 				const validatedInput = validateWithZod(TeamRunTaskInputSchema, input);
+				if (
+					validatedInput.agentId === options.requesterId &&
+					options.runtime.getMemberRole(options.requesterId) === "lead"
+				) {
+					throw new Error(
+						`team_run_task targets teammates only; "${validatedInput.agentId}" is the lead agent. Use your own tools for lead work, or choose a teammate agentId.`,
+					);
+				}
 				if (validatedInput.runMode === "async") {
 					const run = options.runtime.startTeammateRun(
 						validatedInput.agentId,


### PR DESCRIPTION
Summary
- Add an explicit guard when `team_run_task` targets the lead agent id.
- Return an actionable error that tells the caller to use lead tools or choose a teammate instead of reporting a missing teammate.
- Add regression coverage for the lead-agent target path.

Tests
- `bun run test:unit src/extensions/tools/team/team-tools.test.ts` from `sdk/packages/core`

Notes
- Built `@cline/shared`, `@cline/llms`, and `@cline/agents` first so the focused core test could resolve workspace package exports in this fresh checkout.

Fixes #12063