### PR TITLE
fix: split concatenated follow-up options

### DIFF
--- a/apps/vscode/webview-ui/src/components/chat/OptionsButtons.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/OptionsButtons.test.tsx
@@ -58,4 +58,20 @@ describe("OptionsButtons", () => {
 
 		consoleError.mockRestore()
 	})
+
+	it("splits concatenated JSON-like options into separate buttons", () => {
+		render(
+			<OptionsButtons
+				isActive
+				options={[
+					'Implement a new communication protocol handler"] ["Add a display feature/UI element"] ["Improve existing functionality"] | ["Other (Please specify)',
+				]}
+			/>,
+		)
+
+		expect(screen.getByRole("button", { name: "Implement a new communication protocol handler" })).toBeInTheDocument()
+		expect(screen.getByRole("button", { name: "Add a display feature/UI element" })).toBeInTheDocument()
+		expect(screen.getByRole("button", { name: "Improve existing functionality" })).toBeInTheDocument()
+		expect(screen.getByRole("button", { name: "Other (Please specify)" })).toBeInTheDocument()
+	})
 })

--- a/apps/vscode/webview-ui/src/components/chat/OptionsButtons.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/OptionsButtons.tsx
@@ -24,6 +24,43 @@ const OptionButton = styled.button<{ $isSelected?: boolean; $isNotSelectable?: b
 	`}
 `
 
+const normalizeOptions = (options?: string[]) => {
+	if (!options || options.length !== 1) {
+		return options ?? []
+	}
+
+	const option = options[0].trim()
+	if (!option) {
+		return []
+	}
+
+	if (option.startsWith("[") && option.endsWith("]")) {
+		try {
+			const parsed = JSON.parse(option)
+			if (Array.isArray(parsed) && parsed.every((item) => typeof item === "string")) {
+				return parsed.map((item) => item.trim()).filter(Boolean)
+			}
+		} catch {
+			// Fall through to the loose concatenated-option parser below.
+		}
+	}
+
+	if (!/"\s*\]\s*(?:\||,)?\s*\[\s*"/.test(option)) {
+		return options
+	}
+
+	return option
+		.split(/"\s*\]\s*(?:\||,)?\s*\[\s*"/)
+		.map((item) =>
+			item
+				.trim()
+				.replace(/^\[\s*"?/, "")
+				.replace(/"?\s*\]$/, "")
+				.trim(),
+		)
+		.filter(Boolean)
+}
+
 export const OptionsButtons = ({
 	options,
 	selected,
@@ -35,7 +72,7 @@ export const OptionsButtons = ({
 	isActive?: boolean
 	inputValue?: string
 }) => {
-	const optionItems = options ?? []
+	const optionItems = normalizeOptions(options)
 	const optionsKey = optionItems.join("\u0000")
 	const optimisticSelectionKey = `${selected ?? ""}\u0001${optionsKey}`
 	const [optimisticSelection, setOptimisticSelection] = useState<{ key: string; option: string }>()


### PR DESCRIPTION
## Summary
- Normalize malformed follow-up option payloads before rendering option buttons
- Split concatenated JSON-like option strings such as `["A"] ["B"]` back into individual buttons
- Add regression coverage for the malformed options format shown in #12070

## Tests
- `bun run test OptionsButtons.test.tsx` from `apps/vscode/webview-ui`
- `bunx --bun @biomejs/biome check --config-path ./biome.jsonc webview-ui/src/components/chat/OptionsButtons.tsx webview-ui/src/components/chat/OptionsButtons.test.tsx --diagnostic-level=error` from `apps/vscode`

## Notes
Fixes #12070