### PR TITLE
fix(vscode): show per-file diff for multi-file apply_patch

### DIFF
--- a/apps/vscode/src/sdk/message-translator.test.ts
+++ b/apps/vscode/src/sdk/message-translator.test.ts
@@ -3086,6 +3086,147 @@ describe("sdkToolToClineSayTool — editor diff rendering (S6-48)", () => {
 	})
 })
 
+describe("apply_patch multi-file split (cline#9904)", () => {
+	const startEvent = (patch: string, callId: string): CoreSessionEvent => ({
+		type: "agent_event",
+		payload: {
+			sessionId: "session-1",
+			event: {
+				type: "content_start",
+				contentType: "tool",
+				toolName: "apply_patch",
+				toolCallId: callId,
+				input: { input: patch },
+			} as AgentEvent,
+		},
+	})
+
+	const endEvent = (callId: string): CoreSessionEvent => ({
+		type: "agent_event",
+		payload: {
+			sessionId: "session-1",
+			event: {
+				type: "content_end",
+				contentType: "tool",
+				toolName: "apply_patch",
+				toolCallId: callId,
+			} as AgentEvent,
+		},
+	})
+
+	const TWO_FILE = [
+		"*** Begin Patch",
+		"*** Update File: src/a.ts",
+		"@@",
+		"-const a = 1",
+		"+const a = 2",
+		"*** Add File: src/b.ts",
+		"+export const b = 3",
+		"*** End Patch",
+	].join("\n")
+
+	const DELETE_UPDATE = [
+		"*** Begin Patch",
+		"*** Delete File: src/gone.ts",
+		"*** Update File: src/keep.ts",
+		"@@",
+		"-old",
+		"+new",
+		"*** End Patch",
+	].join("\n")
+
+	const SINGLE_FILE = ["*** Begin Patch", "*** Update File: src/file.ts", "@@", "-old", "+new", "*** End Patch"].join("\n")
+
+	it("content_start streams a single whole-patch preview row for a multi-file patch", () => {
+		const state = new MessageTranslatorState()
+		const result = translateSessionEvent(startEvent(TWO_FILE, "call-1"), state)
+
+		// Streaming preview is intentionally one row (the whole patch); the per-file
+		// split happens only at content_end so the finalized ids match (cline#9904).
+		expect(result.messages).toHaveLength(1)
+		expect(result.messages[0].partial).toBe(true)
+		const tool = JSON.parse(result.messages[0].text!)
+		expect(tool.tool).toBe("editedExistingFile")
+		expect(tool.content).toBe(TWO_FILE)
+	})
+
+	it("content_end finalizes one per-file message for a multi-file patch", () => {
+		const state = new MessageTranslatorState()
+		translateSessionEvent(startEvent(TWO_FILE, "call-1"), state)
+		const result = translateSessionEvent(endEvent("call-1"), state)
+
+		expect(result.messages).toHaveLength(2)
+		expect(result.messages[0].partial).toBe(false)
+		expect(result.messages[1].partial).toBe(false)
+		const a = JSON.parse(result.messages[0].text!)
+		const b = JSON.parse(result.messages[1].text!)
+		expect(a.tool).toBe("editedExistingFile")
+		expect(a.path).toBe("src/a.ts")
+		expect(b.tool).toBe("newFileCreated")
+		expect(b.path).toBe("src/b.ts")
+		expect(a.content).not.toContain("src/b.ts")
+		expect(b.content).not.toContain("src/a.ts")
+	})
+
+	it("reconciles start→end by ts: N rows, none left partial (cline#9904 orphan guard)", () => {
+		const state = new MessageTranslatorState()
+		const startResult = translateSessionEvent(startEvent(TWO_FILE, "call-1"), state)
+		const endResult = translateSessionEvent(endEvent("call-1"), state)
+
+		// Merge both batches by ts the way MessageStateHandler.addMessages does:
+		// a later message with an existing ts replaces the earlier one.
+		const byTs = new Map<number, (typeof startResult.messages)[number]>()
+		for (const message of [...startResult.messages, ...endResult.messages]) {
+			byTs.set(message.ts, message)
+		}
+		const survivors = [...byTs.values()]
+
+		// Exactly one row per file, and no orphaned streaming (partial) row survives.
+		expect(survivors).toHaveLength(2)
+		expect(survivors.every((m) => m.partial === false)).toBe(true)
+		const paths = survivors.map((m) => JSON.parse(m.text!).path).sort()
+		expect(paths).toEqual(["src/a.ts", "src/b.ts"])
+	})
+
+	it("each per-file sub-patch keeps the Begin/End Patch wrapper", () => {
+		const state = new MessageTranslatorState()
+		translateSessionEvent(startEvent(TWO_FILE, "call-1"), state)
+		const result = translateSessionEvent(endEvent("call-1"), state)
+		for (const message of result.messages) {
+			const tool = JSON.parse(message.text!)
+			expect(tool.content.startsWith("*** Begin Patch")).toBe(true)
+			expect(tool.content.trimEnd().endsWith("*** End Patch")).toBe(true)
+		}
+	})
+
+	it("maps delete and update actions to fileDeleted and editedExistingFile", () => {
+		const state = new MessageTranslatorState()
+		translateSessionEvent(startEvent(DELETE_UPDATE, "call-1"), state)
+		const result = translateSessionEvent(endEvent("call-1"), state)
+
+		expect(result.messages).toHaveLength(2)
+		const del = JSON.parse(result.messages[0].text!)
+		const upd = JSON.parse(result.messages[1].text!)
+		expect(del.tool).toBe("fileDeleted")
+		expect(del.path).toBe("src/gone.ts")
+		expect(upd.tool).toBe("editedExistingFile")
+		expect(upd.path).toBe("src/keep.ts")
+		expect(upd.content).not.toContain("src/gone.ts")
+	})
+
+	it("leaves a single-file patch as one message at content_end (S6-48 unchanged)", () => {
+		const state = new MessageTranslatorState()
+		translateSessionEvent(startEvent(SINGLE_FILE, "call-1"), state)
+		const result = translateSessionEvent(endEvent("call-1"), state)
+
+		expect(result.messages).toHaveLength(1)
+		const tool = JSON.parse(result.messages[0].text!)
+		expect(tool.tool).toBe("editedExistingFile")
+		expect(tool.content).toBe(SINGLE_FILE)
+		expect(tool.diff).toBe(SINGLE_FILE)
+	})
+})
+
 // ---------------------------------------------------------------------------
 // MCP tool handling — say="use_mcp_server" + say="mcp_server_response"
 // ---------------------------------------------------------------------------

--- a/apps/vscode/src/sdk/message-translator.test.ts
+++ b/apps/vscode/src/sdk/message-translator.test.ts
@@ -3188,6 +3188,42 @@ describe("apply_patch multi-file split (cline#9904)", () => {
 		expect(paths).toEqual(["src/a.ts", "src/b.ts"])
 	})
 
+	const bareStartEvent = (patch: string, callId: string): CoreSessionEvent => ({
+		type: "agent_event",
+		payload: {
+			sessionId: "session-1",
+			event: {
+				type: "content_start",
+				contentType: "tool",
+				toolName: "apply_patch",
+				toolCallId: callId,
+				input: patch,
+			} as AgentEvent,
+		},
+	})
+
+	it("reconciles start→end by ts for a bare-string multi-file patch (no { input } wrapper)", () => {
+		const state = new MessageTranslatorState()
+		const startResult = translateSessionEvent(bareStartEvent(TWO_FILE, "call-1"), state)
+
+		expect(startResult.messages).toHaveLength(1)
+		expect(startResult.messages[0].partial).toBe(true)
+		expect(JSON.parse(startResult.messages[0].text!).content).toBe(TWO_FILE)
+
+		const endResult = translateSessionEvent(endEvent("call-1"), state)
+
+		const byTs = new Map<number, (typeof startResult.messages)[number]>()
+		for (const message of [...startResult.messages, ...endResult.messages]) {
+			byTs.set(message.ts, message)
+		}
+		const survivors = [...byTs.values()]
+
+		expect(survivors).toHaveLength(2)
+		expect(survivors.every((m) => m.partial === false)).toBe(true)
+		const paths = survivors.map((m) => JSON.parse(m.text!).path).sort()
+		expect(paths).toEqual(["src/a.ts", "src/b.ts"])
+	})
+
 	it("each per-file sub-patch keeps the Begin/End Patch wrapper", () => {
 		const state = new MessageTranslatorState()
 		translateSessionEvent(startEvent(TWO_FILE, "call-1"), state)

--- a/apps/vscode/src/sdk/message-translator.ts
+++ b/apps/vscode/src/sdk/message-translator.ts
@@ -753,6 +753,75 @@ function getNumberField(input: Record<string, unknown> | undefined, field: strin
 	return undefined
 }
 
+// apply_patch grammar markers. Duplicated as local literals rather than imported
+// from the SDK's apply-patch-parser (World A / bun) to avoid a bun→npm cross-world
+// import; they are stable literals shared with the webview's DiffEditRow parser.
+const AP_MARKERS = {
+	BEGIN: "*** Begin Patch",
+	END: "*** End Patch",
+	ADD: "*** Add File: ",
+	UPDATE: "*** Update File: ",
+	DELETE: "*** Delete File: ",
+} as const
+
+/**
+ * Extract the raw patch string from an apply_patch tool input. The SDK sends it as
+ * `{ input: '...' }`; classic callers use `{ patch }` / `{ diff }`. Kept in sync with
+ * the `case "apply_patch"` field precedence in sdkToolToClineSayTool.
+ */
+function getApplyPatchString(input: unknown): string | undefined {
+	const parsed = parseToolInput(input)
+	return getStringField(parsed, "patch") ?? getStringField(parsed, "diff") ?? getStringField(parsed, "input")
+}
+
+/**
+ * Split a multi-file apply_patch string into one ClineSayTool per file so each
+ * "Cline wants to edit this file" row renders only that file's diff (cline#9904).
+ *
+ * Returns [] for single-file (or unparseable) patches so callers keep the existing
+ * single-message behavior — only genuinely multi-file patches are split.
+ */
+function splitApplyPatchByFile(patch: string): ClineSayTool[] {
+	const lines = patch.split("\n")
+	const blocks: { tool: ClineSayTool["tool"]; path: string; lines: string[] }[] = []
+	let current: { tool: ClineSayTool["tool"]; path: string; lines: string[] } | undefined
+
+	for (const line of lines) {
+		if (line === AP_MARKERS.END) {
+			break
+		}
+		const marker = [AP_MARKERS.ADD, AP_MARKERS.UPDATE, AP_MARKERS.DELETE].find((m) => line.startsWith(m))
+		if (marker) {
+			if (current) {
+				blocks.push(current)
+			}
+			const tool: ClineSayTool["tool"] =
+				marker === AP_MARKERS.ADD ? "newFileCreated" : marker === AP_MARKERS.DELETE ? "fileDeleted" : "editedExistingFile"
+			current = { tool, path: line.substring(marker.length).trim(), lines: [line] }
+		} else if (current) {
+			current.lines.push(line)
+		}
+	}
+	if (current) {
+		blocks.push(current)
+	}
+
+	// Only split genuine multi-file patches. Bail out (→ single whole-patch
+	// message) if fewer than two files, or if any block has an empty path — a
+	// pathless row can't route to the per-file diff view (cline#9904).
+	if (blocks.length < 2 || blocks.some((block) => block.path === "")) {
+		return []
+	}
+
+	return blocks.map((block) => {
+		if (block.tool === "fileDeleted") {
+			return { tool: block.tool, path: block.path }
+		}
+		const subPatch = [AP_MARKERS.BEGIN, ...block.lines, AP_MARKERS.END].join("\n")
+		return { tool: block.tool, path: block.path, content: subPatch, diff: subPatch }
+	})
+}
+
 /** Get an array field from a parsed input object */
 function getArrayField(input: Record<string, unknown> | undefined, field: string): string[] | undefined {
 	if (!input) return undefined
@@ -1168,6 +1237,11 @@ function translateAgentEvent(event: AgentEvent, state: MessageTranslatorState): 
 					}
 
 					// All other tools → say="tool" with ClineSayTool JSON
+					// apply_patch is intentionally NOT split per-file here: the streaming
+					// (partial) row shows the whole patch, and the per-file split happens
+					// only at content_end (see below), mirroring read_files. Splitting at
+					// content_start would mint streaming ids that content_end cannot
+					// reproduce for files ≥2, orphaning those partial rows (cline#9904).
 					const sayTool = sdkToolToClineSayTool(toolName, input)
 					messages.push({
 						ts: state.getStreamingToolTs(),
@@ -1436,6 +1510,27 @@ function translateAgentEvent(event: AgentEvent, state: MessageTranslatorState): 
 										path: fileRead.path,
 										...readLineRangeFields(fileRead),
 									} satisfies ClineSayTool),
+									partial: false,
+								})
+							})
+							break
+						}
+					}
+
+					// apply_patch may edit multiple files in one call. Emit one tool
+					// message per file so each diff row shows only that file's changes
+					// instead of the whole multi-file patch (cline#9904). Single-file
+					// patches fall through to the single-message path below.
+					if (toolName === "apply_patch" && !event.error) {
+						const patch = getApplyPatchString(storedInput)
+						const perFileTools = patch ? splitApplyPatchByFile(patch) : []
+						if (perFileTools.length > 1) {
+							perFileTools.forEach((sayTool, index) => {
+								messages.push({
+									ts: index === 0 ? ts : state.nextTs(),
+									type: "say",
+									say: "tool",
+									text: JSON.stringify(sayTool),
 									partial: false,
 								})
 							})

--- a/apps/vscode/src/sdk/message-translator.ts
+++ b/apps/vscode/src/sdk/message-translator.ts
@@ -26,6 +26,7 @@
 // - SDK "ended" event → finalizes the session
 
 import type { CoreSessionEvent } from "@cline/core"
+import { PATCH_MARKERS } from "@cline/core"
 import type { Message as SdkMessage } from "@cline/llms"
 import { type AgentEvent, formatDisplayUserInput } from "@cline/shared"
 import { COMMAND_OUTPUT_STRING } from "@shared/combineCommandSequences"
@@ -535,17 +536,10 @@ function sdkToolToClineSayTool(toolName: string, input?: unknown): ClineSayTool 
 
 		case "apply_patch": {
 			const filePath = getStringField(parsedInput, "path") ?? ""
-			// The SDK sends apply_patch input as { input: 'apply_patch <<"EOF"\n*** Begin Patch\n...' }
-			// Also check the "patch" and "diff" fields for compatibility.
-			const patch =
-				getStringField(parsedInput, "patch") ??
-				getStringField(parsedInput, "diff") ??
-				getStringField(parsedInput, "input")
+			const patch = getApplyPatchString(input)
 			return {
 				tool: "editedExistingFile",
 				path: filePath,
-				// ChatRow passes `content` to DiffEditRow's `patch` prop,
-				// so we must populate `content` for the diff to render.
 				content: patch,
 				diff: patch,
 			}
@@ -753,25 +747,13 @@ function getNumberField(input: Record<string, unknown> | undefined, field: strin
 	return undefined
 }
 
-// apply_patch grammar markers. Duplicated as local literals rather than imported
-// from the SDK's apply-patch-parser (World A / bun) to avoid a bun→npm cross-world
-// import; they are stable literals shared with the webview's DiffEditRow parser.
-const AP_MARKERS = {
-	BEGIN: "*** Begin Patch",
-	END: "*** End Patch",
-	ADD: "*** Add File: ",
-	UPDATE: "*** Update File: ",
-	DELETE: "*** Delete File: ",
-} as const
-
-/**
- * Extract the raw patch string from an apply_patch tool input. The SDK sends it as
- * `{ input: '...' }`; classic callers use `{ patch }` / `{ diff }`. Kept in sync with
- * the `case "apply_patch"` field precedence in sdkToolToClineSayTool.
- */
 function getApplyPatchString(input: unknown): string | undefined {
 	const parsed = parseToolInput(input)
-	return getStringField(parsed, "patch") ?? getStringField(parsed, "diff") ?? getStringField(parsed, "input")
+	const fromFields = getStringField(parsed, "patch") ?? getStringField(parsed, "diff") ?? getStringField(parsed, "input")
+	if (fromFields !== undefined) {
+		return fromFields
+	}
+	return typeof input === "string" ? input : undefined
 }
 
 /**
@@ -787,16 +769,20 @@ function splitApplyPatchByFile(patch: string): ClineSayTool[] {
 	let current: { tool: ClineSayTool["tool"]; path: string; lines: string[] } | undefined
 
 	for (const line of lines) {
-		if (line === AP_MARKERS.END) {
+		if (line === PATCH_MARKERS.END) {
 			break
 		}
-		const marker = [AP_MARKERS.ADD, AP_MARKERS.UPDATE, AP_MARKERS.DELETE].find((m) => line.startsWith(m))
+		const marker = [PATCH_MARKERS.ADD, PATCH_MARKERS.UPDATE, PATCH_MARKERS.DELETE].find((m) => line.startsWith(m))
 		if (marker) {
 			if (current) {
 				blocks.push(current)
 			}
 			const tool: ClineSayTool["tool"] =
-				marker === AP_MARKERS.ADD ? "newFileCreated" : marker === AP_MARKERS.DELETE ? "fileDeleted" : "editedExistingFile"
+				marker === PATCH_MARKERS.ADD
+					? "newFileCreated"
+					: marker === PATCH_MARKERS.DELETE
+						? "fileDeleted"
+						: "editedExistingFile"
 			current = { tool, path: line.substring(marker.length).trim(), lines: [line] }
 		} else if (current) {
 			current.lines.push(line)
@@ -817,7 +803,7 @@ function splitApplyPatchByFile(patch: string): ClineSayTool[] {
 		if (block.tool === "fileDeleted") {
 			return { tool: block.tool, path: block.path }
 		}
-		const subPatch = [AP_MARKERS.BEGIN, ...block.lines, AP_MARKERS.END].join("\n")
+		const subPatch = [PATCH_MARKERS.BEGIN, ...block.lines, PATCH_MARKERS.END].join("\n")
 		return { tool: block.tool, path: block.path, content: subPatch, diff: subPatch }
 	})
 }

--- a/apps/vscode/src/test/cline-core-vitest-stub.ts
+++ b/apps/vscode/src/test/cline-core-vitest-stub.ts
@@ -113,7 +113,7 @@ export {
 	createApplyPatchExecutor,
 	type PatchFileChange,
 } from "../../../../sdk/packages/core/src/extensions/tools/executors/apply-patch"
-export { PatchActionType } from "../../../../sdk/packages/core/src/extensions/tools/executors/apply-patch-parser"
+export { PATCH_MARKERS, PatchActionType } from "../../../../sdk/packages/core/src/extensions/tools/executors/apply-patch-parser"
 export { createEditorExecutor } from "../../../../sdk/packages/core/src/extensions/tools/executors/editor"
 export type { EditFileInput } from "../../../../sdk/packages/core/src/extensions/tools/schemas"
 export type { ApplyPatchExecutor, EditorExecutor } from "../../../../sdk/packages/core/src/extensions/tools/types"

--- a/sdk/packages/core/src/extensions/tools/executors/index.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/index.ts
@@ -30,7 +30,7 @@ export {
 	createApplyPatchExecutor,
 	type PatchFileChange,
 } from "./apply-patch";
-export { PatchActionType } from "./apply-patch-parser";
+export { PATCH_MARKERS, PatchActionType } from "./apply-patch-parser";
 export {
 	CommandExitError,
 	createShellExecutor,

--- a/sdk/packages/core/src/extensions/tools/index.ts
+++ b/sdk/packages/core/src/extensions/tools/index.ts
@@ -37,6 +37,7 @@ export {
 	type DefaultExecutorsOptions,
 	type EditorExecutorOptions,
 	type FileReadExecutorOptions,
+	PATCH_MARKERS,
 	PatchActionType,
 	type PatchFileChange,
 	type SearchExecutorOptions,

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -831,6 +831,7 @@ export {
 	getCoreDefaultEnabledToolIds,
 	getCoreHeadlessToolNames,
 	MAX_COMMAND_OUTPUT_CHARS,
+	PATCH_MARKERS,
 	PatchActionType,
 	type PatchFileChange,
 	resolveCoreSelectedToolIds,


### PR DESCRIPTION
﻿### Related Issue
**Issue:** #9904
Closes #9904

### Description
When `apply_patch` edits **multiple files in one call**, each per-file "Cline wants to edit this file" diff row rendered the **entire multi-file patch** (all files) instead of just that file's changes.

After the apply_patch tool migrated into the SDK, `apps/vscode/src/sdk/message-translator.ts` maps an `apply_patch` call to a single `editedExistingFile` message whose `content` is the whole patch string. The webview `DiffEditRow.parseNewFormat` then loops over every `*** ΓÇª File:` block in that string and renders them all in one row.

This PR adds `splitApplyPatchByFile()`, which splits a multi-file patch into one tool message per file (Add ΓåÆ `newFileCreated`, Delete ΓåÆ `fileDeleted`, Update ΓåÆ `editedExistingFile`), each carrying only that file's sub-patch (re-wrapped in `*** Begin Patch` / `*** End Patch`). It's wired in at **content_end only**, mirroring the existing `read_files` multi-file split, splitting at content_start would mint streaming message ids that content_end can't reproduce for files ΓëÑ2, orphaning those rows. Single-file patches keep the existing single-message behavior unchanged.

The webview (`DiffEditRow` / `ChatRow`) and the SDK executor are untouched.

### Test Procedure
- `apps/vscode`: `npx vitest run --config vitest.config.ts src/sdk/message-translator.test.ts` ΓåÆ 114 pass.
- Added tests: content_start shows one whole-patch preview row; content_end yields one finalized row per file (each isolated to its own file); a ts-reconciliation test that merges the start+end batches the way `MessageStateHandler.addMessages` does and asserts exactly N rows survive with none left partial (guards the orphan-row regression); delete+update mapping; and the existing single-file (S6-48) behavior unchanged.
- `bunx tsc --noEmit` clean; `biome` clean.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist
- [x] Changes are limited to a single bugfix
- [x] Tests are passing and code is formatted and linted
- [x] I have reviewed the contributor guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to VS Code SDK event translation for `apply_patch`; webview and executor unchanged, with regression tests and unchanged single-file behavior.
> 
> **Overview**
> Fixes **#9904**: multi-file `apply_patch` tool calls no longer show the full patch on every per-file diff row in the VS Code chat.
> 
> **`message-translator.ts`** adds `splitApplyPatchByFile()` to parse `*** Add/Update/Delete File:` blocks and emit one `ClineSayTool` per file (`newFileCreated`, `editedExistingFile`, `fileDeleted`), each with a re-wrapped sub-patch. Splitting runs only on **`content_end`** (like `read_files`); **`content_start`** still streams a single partial row with the whole patch so message timestamps reconcile and partial rows are not orphaned.
> 
> Single-file patches and unparseable input keep the previous one-message behavior. Tests cover streaming vs finalize, ts merge, action mapping, and sub-patch wrappers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f890d6fc8e518cbb27c60127d3737b6a15cf8f61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->