### PR TITLE
feat: add Manifest provider

### DIFF
--- a/apps/vscode/src/sdk/model-catalog/provider-id.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/provider-id.test.ts
@@ -50,6 +50,7 @@ describe("parseProviderId", () => {
 		parseProviderId("v0")
 		parseProviderId("xiaomi")
 		parseProviderId("tencent-tokenhub")
+		parseProviderId("manifest")
 
 		expect(warnSpy).not.toHaveBeenCalled()
 	})
@@ -66,6 +67,7 @@ describe("isKnownProviderId", () => {
 		expect(isKnownProviderId(parseProviderId("v0"))).toBe(true)
 		expect(isKnownProviderId(parseProviderId("xiaomi"))).toBe(true)
 		expect(isKnownProviderId(parseProviderId("tencent-tokenhub"))).toBe(true)
+		expect(isKnownProviderId(parseProviderId("manifest"))).toBe(true)
 	})
 
 	it("returns false for a custom provider id", () => {

--- a/apps/vscode/src/sdk/model-catalog/provider-id.ts
+++ b/apps/vscode/src/sdk/model-catalog/provider-id.ts
@@ -58,6 +58,7 @@ const KNOWN_API_PROVIDERS = {
 	wandb: true,
 	xiaomi: true,
 	"tencent-tokenhub": true,
+	manifest: true,
 	"cline-pass": true,
 } satisfies Record<ApiProvider, true>
 

--- a/apps/vscode/src/shared/api.ts
+++ b/apps/vscode/src/shared/api.ts
@@ -50,6 +50,7 @@ export type ApiProvider =
 	| "wandb"
 	| "xiaomi"
 	| "tencent-tokenhub"
+	| "manifest"
 
 export const DEFAULT_API_PROVIDER = "openrouter" as ApiProvider
 

--- a/apps/vscode/src/shared/proto-conversions/models/api-configuration-conversion.test.ts
+++ b/apps/vscode/src/shared/proto-conversions/models/api-configuration-conversion.test.ts
@@ -4,7 +4,7 @@ import { convertApiConfigurationToProto, convertProtoToApiConfiguration } from "
 
 describe("api configuration provider conversion", () => {
 	it("round-trips SDK provider ids added after the legacy enum list", () => {
-		const providers: ApiProvider[] = ["poolside", "v0", "xiaomi", "tencent-tokenhub", "zai-coding-plan"]
+		const providers: ApiProvider[] = ["poolside", "v0", "xiaomi", "tencent-tokenhub", "manifest", "zai-coding-plan"]
 
 		for (const provider of providers) {
 			const proto = convertApiConfigurationToProto({

--- a/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.test.ts
+++ b/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.test.ts
@@ -70,6 +70,7 @@ describe("providerSettingsRegistry", () => {
 			["poolside", "Poolside", undefined],
 			["sambanova", "SambaNova", "https://docs.sambanova.ai/cloud/docs/get-started/overview"],
 			["tencent-tokenhub", "Tencent TokenHub", "https://cloud.tencent.com/document/product/1823/130050"],
+			["manifest", "Manifest", "https://manifest.build/docs"],
 			["vercel-ai-gateway", "Vercel AI Gateway", "https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fai"],
 			["v0", "Vercel v0", undefined],
 			["wandb", "W&B", "https://wandb.ai"],

--- a/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.ts
+++ b/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.ts
@@ -100,7 +100,9 @@ const GENERIC_PROVIDER_PRESENTATION_OVERRIDES: Record<string, GenericProviderPre
 	"tencent-tokenhub": {
 		signupUrl: "https://cloud.tencent.com/document/product/1823/130050",
 	},
-	manifest: {},
+	manifest: {
+		signupUrl: "https://manifest.build/docs",
+	},
 	"zai-coding-plan": {},
 }
 

--- a/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.ts
+++ b/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.ts
@@ -100,6 +100,7 @@ const GENERIC_PROVIDER_PRESENTATION_OVERRIDES: Record<string, GenericProviderPre
 	"tencent-tokenhub": {
 		signupUrl: "https://cloud.tencent.com/document/product/1823/130050",
 	},
+	manifest: {},
 	"zai-coding-plan": {},
 }
 
@@ -158,6 +159,7 @@ const FALLBACK_GENERIC_PROVIDER_NAMES = {
 	poolside: "Poolside",
 	together: "Together",
 	v0: "Vercel v0",
+	manifest: "Manifest",
 	wandb: "W&B",
 	xiaomi: "Xiaomi",
 	"tencent-tokenhub": "Tencent TokenHub",

--- a/sdk/packages/llms/src/catalog/catalog.generated.ts
+++ b/sdk/packages/llms/src/catalog/catalog.generated.ts
@@ -24068,4 +24068,15 @@ export const GENERATED_PROVIDER_MODELS: {
 			},
 		},
 	},
+	manifest: {
+		auto: {
+			id: "auto",
+			name: "Manifest Auto",
+			contextWindow: 200000,
+			maxTokens: 64000,
+			capabilities: [
+				"reasoning",
+			],
+		},
+	},
 };

--- a/sdk/packages/llms/src/catalog/catalog.generated.ts
+++ b/sdk/packages/llms/src/catalog/catalog.generated.ts
@@ -24068,15 +24068,4 @@ export const GENERATED_PROVIDER_MODELS: {
 			},
 		},
 	},
-	manifest: {
-		auto: {
-			id: "auto",
-			name: "Manifest Auto",
-			contextWindow: 200000,
-			maxTokens: 64000,
-			capabilities: [
-				"reasoning",
-			],
-		},
-	},
 };

--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -883,6 +883,18 @@ const OPENAI_COMPATIBLE_SPECS: BuiltinSpec[] = [
 		defaults: { baseUrl: "https://tokenhub.tencentmaas.com/v1" },
 	},
 	{
+		id: "manifest",
+		name: "Manifest",
+		description: "OpenAI-compatible gateway for AI agents with multiprovider fallback and per-message cost tracking",
+		family: "openai-compatible",
+		capabilities: ["reasoning"],
+		defaultModelId: "auto",
+		apiKeyEnv: ["MANIFEST_API_KEY"],
+		modelsProviderId: "manifest",
+		docsUrl: "https://manifest.build/docs",
+		defaults: { baseUrl: "https://app.manifest.build/v1" },
+	},
+	{
 		id: "kilo",
 		name: "Kilo Gateway",
 		description: "Kilo Gateway",

--- a/sdk/packages/llms/src/providers/ids.test.ts
+++ b/sdk/packages/llms/src/providers/ids.test.ts
@@ -189,6 +189,27 @@ describe("provider-ids", () => {
 		});
 	});
 
+	it("registers Manifest as an OpenAI-compatible built-in provider", async () => {
+		await expect(getProvider("manifest")).resolves.toMatchObject({
+			id: "manifest",
+			baseUrl: "https://app.manifest.build/v1",
+			defaultModelId: "auto",
+			client: "openai-compatible",
+		});
+
+		await expect(
+			getModelsForProvider("manifest"),
+		).resolves.toHaveProperty("auto");
+
+		const registration = BUILTIN_PROVIDER_REGISTRATIONS.find(
+			(item) => item.manifest.id === "manifest",
+		);
+		expect(registration).toBeDefined();
+		await expect(registration?.loadProvider()).resolves.toMatchObject({
+			createProvider: createOpenAICompatibleProvider,
+		});
+	});
+
 	it("registers Z.AI Coding Plan with an accessible coding-plan default", async () => {
 		await expect(getProvider("zai-coding-plan")).resolves.toMatchObject({
 			id: "zai-coding-plan",

--- a/sdk/packages/llms/src/providers/ids.ts
+++ b/sdk/packages/llms/src/providers/ids.ts
@@ -48,6 +48,7 @@ export enum BUILT_IN_PROVIDER {
 	WANDB = "wandb",
 	XIAOMI = "xiaomi",
 	TENCENT_TOKENHUB = "tencent-tokenhub",
+	MANIFEST = "manifest",
 	KILO = "kilo",
 	ZAI = "zai",
 	ZAI_CODING_PLAN = "zai-coding-plan",

--- a/sdk/packages/llms/src/providers/provider-keys.ts
+++ b/sdk/packages/llms/src/providers/provider-keys.ts
@@ -120,6 +120,7 @@ const PROVIDER_IDS_MAP: ReadonlyArray<{
 		modelsDevKey: "tencent-tokenhub",
 		generatedProviderId: "tencent-tokenhub",
 	},
+	{ modelsDevKey: "manifest", generatedProviderId: "manifest" },
 	{ modelsDevKey: "v0", generatedProviderId: "v0" },
 ];
 


### PR DESCRIPTION
## Summary

Adds [Manifest](https://manifest.build) — an OpenAI-compatible gateway for AI agents — as a built-in provider in @cline/llms and the VS Code extension.

Manifest exposes a single endpoint in front of multiple providers (API keys, subscriptions, local models), with per-message cost/token tracking and fallback on failures. The served model is resolved server-side from the users dashboard configuration; requests target the single `auto` model id.

## Changes

### SDK (@cline/llms — 3 files)
- **`src/providers/builtins.ts`** — registered Manifest as an OpenAI-compatible built-in provider with `MANIFEST_API_KEY` env var and `https://app.manifest.build/v1` base URL
- **`src/providers/ids.ts`** — added `MANIFEST` to the `BUILT_IN_PROVIDER` enum
- **`src/providers/provider-keys.ts`** — mapped `manifest` modelsDevKey to `manifest` generatedProviderId
- **`src/providers/ids.test.ts`** — test verifying registration, model lookup, and provider factory
- **`src/catalog/catalog.generated.ts`** — updated generated model catalog with manifest/auto entry

### Extension (apps/vscode — 6 files, following the same pattern as the recent TokenHub addition #12028)
- **`src/sdk/model-catalog/provider-id.ts`** — added manifest to `KNOWN_API_PROVIDERS`
- **`src/shared/api.ts`** — added to `ApiProvider` union type
- **`webview-ui/.../providerSettingsRegistry.ts`** — display name + presentation override
- Plus 3 test files for the above

## Related

- Feature request discussion: https://github.com/cline/cline/discussions/12093

- https://manifest.build
- https://github.com/mnfst/manifest (open-source, 7.2k stars)
- https://manifest.build/docs
