### PR TITLE
feat(cli): default thinking level picker cursor to Medium instead of Off

### DIFF
--- a/apps/cli/src/tui/components/model-selector/model-selector.tsx
+++ b/apps/cli/src/tui/components/model-selector/model-selector.tsx
@@ -329,7 +329,10 @@ export function ThinkingLevelContent(
 ) {
 	const { resolve, dismiss, dialogId, modelName, currentLevel } = props;
 	const [selected, setSelected] = useState(() => {
-		const idx = THINKING_LEVELS.findIndex((l) => l.value === currentLevel);
+		// Start the cursor on Medium (the recommended level) when thinking is
+		// off, so accepting the default enables it rather than keeping it off.
+		const initialLevel = currentLevel === "none" ? "medium" : currentLevel;
+		const idx = THINKING_LEVELS.findIndex((l) => l.value === initialLevel);
 		return idx >= 0 ? idx : 0;
 	});
 

--- a/apps/cli/src/tui/components/model-selector/model-selector.tsx
+++ b/apps/cli/src/tui/components/model-selector/model-selector.tsx
@@ -329,8 +329,6 @@ export function ThinkingLevelContent(
 ) {
 	const { resolve, dismiss, dialogId, modelName, currentLevel } = props;
 	const [selected, setSelected] = useState(() => {
-		// Start the cursor on Medium (the recommended level) when thinking is
-		// off, so accepting the default enables it rather than keeping it off.
 		const initialLevel = currentLevel === "none" ? "medium" : currentLevel;
 		const idx = THINKING_LEVELS.findIndex((l) => l.value === initialLevel);
 		return idx >= 0 ? idx : 0;

--- a/apps/cli/src/tui/views/onboarding/controller.ts
+++ b/apps/cli/src/tui/views/onboarding/controller.ts
@@ -58,6 +58,7 @@ import { useOnboardingKeyboard } from "./keyboard";
 import {
 	CLINE_PASS_SUBSCRIPTION_OPTIONS,
 	type ClinePassSubscriptionStatus,
+	DEFAULT_THINKING_LEVEL_INDEX,
 	getMainMenuOptions,
 	type ModelEntry,
 	type OnboardingResult,
@@ -237,7 +238,9 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 	}, []);
 
 	// Thinking level
-	const [thinkingSelected, setThinkingSelected] = useState(0);
+	const [thinkingSelected, setThinkingSelected] = useState(
+		DEFAULT_THINKING_LEVEL_INDEX,
+	);
 	const [selectedModelName, setSelectedModelName] = useState("");
 	const [selectedModelId, setSelectedModelId] = useState("");
 	const [selectedThinking, setSelectedThinking] = useState(false);
@@ -641,7 +644,7 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 			const entry = modelEntries.find((m) => m.id === modelId);
 			if (entry?.supportsReasoning) {
 				setSelectedModelName(entry.name);
-				setThinkingSelected(0);
+				setThinkingSelected(DEFAULT_THINKING_LEVEL_INDEX);
 				setStep("thinking_level");
 			} else {
 				setStep("done");
@@ -691,7 +694,7 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 			setSelectedModelId(modelId);
 			if (clineModelReasoningIds.has(modelId)) {
 				setSelectedModelName(modelName);
-				setThinkingSelected(0);
+				setThinkingSelected(DEFAULT_THINKING_LEVEL_INDEX);
 				setStep("thinking_level");
 			} else {
 				setStep("done");

--- a/apps/cli/src/tui/views/onboarding/model.ts
+++ b/apps/cli/src/tui/views/onboarding/model.ts
@@ -30,8 +30,6 @@ export const THINKING_LEVELS: {
 	{ value: "xhigh", label: "Extra High", desc: "Maximum reasoning" },
 ];
 
-// Medium is the recommended starting point, so the picker highlights it
-// rather than "Off" when no thinking level is configured yet.
 export const DEFAULT_THINKING_LEVEL_INDEX = THINKING_LEVELS.findIndex(
 	(l) => l.value === "medium",
 );

--- a/apps/cli/src/tui/views/onboarding/model.ts
+++ b/apps/cli/src/tui/views/onboarding/model.ts
@@ -30,6 +30,12 @@ export const THINKING_LEVELS: {
 	{ value: "xhigh", label: "Extra High", desc: "Maximum reasoning" },
 ];
 
+// Medium is the recommended starting point, so the picker highlights it
+// rather than "Off" when no thinking level is configured yet.
+export const DEFAULT_THINKING_LEVEL_INDEX = THINKING_LEVELS.findIndex(
+	(l) => l.value === "medium",
+);
+
 export interface MenuOption {
 	label: string;
 	value: string;


### PR DESCRIPTION
### Related Issue

N/A — small UX fix.

### Description

When a user picks a model that supports reasoning (welcome onboarding, `/settings` → model, or any in-session model change), we follow up with a thinking-level selector. That selector's cursor was initially landing on **Off** whenever no thinking level was already configured — which is exactly the state every new user is in. So the flow was implicitly nudging new users toward disabling extended thinking, when Medium is the canonical recommendation.

There are two independent implementations of this screen, and both had the problem:

1. **Onboarding flow** (`apps/cli/src/tui/views/onboarding/`) — `controller.ts` hard-reset the cursor with `setThinkingSelected(0)` (index 0 = "Off") every time the `thinking_level` step was entered, from both the regular model list path (`completeModelSelection`) and the featured Cline models picker path (`saveClineModelSelection`). Since onboarding by definition has no pre-existing level, the cursor always landed on Off here.

2. **Model selector dialog** (`ThinkingLevelContent` in `apps/cli/src/tui/components/model-selector/model-selector.tsx`, driven by `use-model-selector.tsx`) — the initial cursor was set to the *computed current level*, and the callers resolve "no reasoning config" to `"none"`, so a thinking-off user opening the dialog got the cursor on Off.

**The fix:**

- Added an exported `DEFAULT_THINKING_LEVEL_INDEX` constant (index of `"medium"` in `THINKING_LEVELS`) to onboarding's `model.ts`, and use it in the controller's initial `useState` and both `setThinkingSelected` reset sites. Computed via `findIndex` rather than a hardcoded `2` so it survives reordering of the levels array.
- In `ThinkingLevelContent`, the `useState` initializer now maps `currentLevel === "none"` → start cursor on `"medium"`. Users who already have an explicit level configured (e.g. High) still get the cursor on their actual level — this only changes the off/unset case.

One deliberate detail: in the dialog, the green `(current)` badge is driven by `currentLevel` and is untouched. So a user who intentionally has thinking off and reopens the selector sees the cursor sitting on **Medium** while `(current)` still marks **Off** — it stays clear what's actually set vs. what's being recommended, and Escape/dismiss changes nothing.

Also worth noting: in the dialog flows, dismissing the thinking selector (Esc) leaves the existing config untouched, and pressing Enter on Medium sets `thinking = true, reasoningEffort = "medium"` — same write path as before, only the starting cursor position changed. No config semantics were altered.

### Test Procedure

- `bun run typecheck` in `apps/cli` passes.
- `bun biome check` on the three changed files — no new errors (only pre-existing a11y warnings on the existing mouse handlers).
- Verified all consumers of `thinkingSelected` (`keyboard.ts` up/down wrapping, `screens.tsx` rendering, Enter-to-save in `keyboard.ts:311`) treat it as a plain index into `THINKING_LEVELS`, so a non-zero initial index composes with wrap-around navigation and selection with no special-casing.
- What could break: someone with an explicit reasoning effort configured getting their cursor moved — checked that both implementations still honor a configured level (`reasoningEffort` set → cursor on that level; only the `none`/unset case redirects to Medium).

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — the only visual change is which row the `❯` cursor starts on in the thinking-level screens.

### Additional Notes

None.