### PR TITLE
docs: polish README model table grammar and wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Toggle between Plan mode and Act mode. In Plan mode, Cline explores your codebas
 
 ## Rules and Skills
 
-Define project-specific rules in `.clinerules` files that guide how Cline works in your codebase: coding standards, architecture conventions, deployment procedures, testing requirements. Rules are picked up automatically by the CLI, VS Code extension, and JetBrains plugin. Use skills to let the model load specific rules when needed. 
+Define project-specific rules in `.clinerules` files that guide how Cline works in your codebase: coding standards, architecture conventions, deployment procedures, testing requirements. Rules are picked up automatically by the CLI, VS Code extension, and JetBrains plugin. Use skills to let the model load specific rules when needed.
 
 ## Works With Every Model
 
@@ -158,10 +158,10 @@ Cline is not locked to a single AI provider. Use whichever model fits your workf
 | Provider | Models |
 |----------|--------|
 | Anthropic | Claude Opus, Sonnet, Haiku |
-| OpenAI | GPT series model |
-| Google | Gemini series model |
+| OpenAI | GPT series models |
+| Google | Gemini series models |
 | OpenRouter | 200+ models from any provider |
-| Vercel AI Gateway | Models through Vercel AI Gateway |
+| Vercel AI Gateway | Route to many providers through one gateway |
 | AWS Bedrock | Claude, Llama, and more |
 | Azure / GCP Vertex | All hosted models |
 | Cerebras / Groq | Fast inference models |


### PR DESCRIPTION
### Related Issue

Minor wording/typo improvements — no linked issue (covered by the template's exception for "minor wording improvements").

### Description

A small polish pass on the top-level `README.md` to fix grammar and remove redundancy in the "Works With Every Model" table:

- **Grammar:** "GPT series model" → "GPT series models" and "Gemini series model" → "Gemini series models" (both providers offer multiple models).
- **Redundancy:** the Vercel AI Gateway row described itself ("Models through Vercel AI Gateway") — replaced with "Route to many providers through one gateway", which actually explains what the gateway does.
- **Whitespace:** removed a trailing space at the end of the "Rules and Skills" paragraph.

No content, links, or structure were changed beyond these four lines.

### Test Procedure

Documentation-only change. Verified the rendered Markdown table still parses correctly and that `git diff` contains exactly the four intended line changes and nothing else.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (docs-only change; no code affected)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — text-only documentation change.

### Additional Notes

Requested via Slack: https://cline-space.slack.com/archives/C08JEJDCN21/p1783373909172269?thread_ts=1783373731.306999&cid=C08JEJDCN21

---
_Generated by [Claude Code](https://claude.ai/code/session_017VJNCE1o6zzcVfpjpTVnt5)_