### PR TITLE
feat(cli): tint assistant markdown accents by the mode they were produced in

### DIFF
--- a/apps/cli/src/tui/components/chat-entry.tsx
+++ b/apps/cli/src/tui/components/chat-entry.tsx
@@ -23,7 +23,7 @@ import {
 	type TerminalTheme,
 } from "../palette";
 import type { ChatEntry } from "../types";
-import { getSyntaxStyle } from "../utils/syntax-style";
+import { getSyntaxStyle, type SyntaxAccentMode } from "../utils/syntax-style";
 import { isWarningToolError } from "../utils/tool-errors";
 import {
 	parseApplyPatchInput,
@@ -422,10 +422,12 @@ function ClineOrgIndividualInferenceSubscriptionErrorView(props: {
 export function ChatEntryView(props: {
 	entry: ChatEntry;
 	accent?: string;
+	/** Mode the entry was produced in (resolved with the current-mode fallback). */
+	mode?: SyntaxAccentMode;
 	loadIndividualSubscriptionPlans?: () => Promise<ClineSubscriptionPlan[]>;
 	terminalTheme: TerminalTheme;
 }) {
-	const { entry, accent = palette.act, terminalTheme } = props;
+	const { entry, accent = palette.act, mode = "act", terminalTheme } = props;
 	const terminalBg = useTerminalBackground();
 	const defaultFg = getDefaultForeground(terminalBg);
 	const userMsgBg = getUserMessageBackground(terminalBg);
@@ -484,7 +486,7 @@ export function ChatEntryView(props: {
 					<box flexGrow={1}>
 						<markdown
 							content={content}
-							syntaxStyle={getSyntaxStyle(terminalTheme)}
+							syntaxStyle={getSyntaxStyle(terminalTheme, mode)}
 							streaming={entry.streaming}
 							fg={defaultFg}
 						/>

--- a/apps/cli/src/tui/components/chat-message-list.tsx
+++ b/apps/cli/src/tui/components/chat-message-list.tsx
@@ -96,6 +96,7 @@ export const ChatMessageList = forwardRef<
 			<box flexDirection="column" paddingX={1} paddingY={1} gap={1}>
 				{props.entries.map((entry, i) => {
 					const key = `${i}:${entry.kind}`;
+					const entryMode = entry.mode ?? props.uiMode ?? "act";
 					return (
 						<ChatEntryView
 							key={key}
@@ -103,6 +104,7 @@ export const ChatMessageList = forwardRef<
 							accent={
 								entry.mode ? getModeAccent(entry.mode, terminalTheme) : accent
 							}
+							mode={entryMode === "plan" ? "plan" : "act"}
 							loadIndividualSubscriptionPlans={
 								props.loadIndividualSubscriptionPlans
 							}

--- a/apps/cli/src/tui/components/chat-message-list.tsx
+++ b/apps/cli/src/tui/components/chat-message-list.tsx
@@ -96,14 +96,14 @@ export const ChatMessageList = forwardRef<
 			<box flexDirection="column" paddingX={1} paddingY={1} gap={1}>
 				{props.entries.map((entry, i) => {
 					const key = `${i}:${entry.kind}`;
+					// Single source of truth for the entry's mode: the glyph accent
+					// and the markdown accent must never diverge.
 					const entryMode = entry.mode ?? props.uiMode ?? "act";
 					return (
 						<ChatEntryView
 							key={key}
 							entry={entry}
-							accent={
-								entry.mode ? getModeAccent(entry.mode, terminalTheme) : accent
-							}
+							accent={getModeAccent(entryMode, terminalTheme)}
 							mode={entryMode === "plan" ? "plan" : "act"}
 							loadIndividualSubscriptionPlans={
 								props.loadIndividualSubscriptionPlans

--- a/apps/cli/src/tui/utils/syntax-style.test.ts
+++ b/apps/cli/src/tui/utils/syntax-style.test.ts
@@ -63,6 +63,16 @@ describe("getSyntaxStyle", () => {
 		).toEqual([0xff, 0xea, 0x7f, 255]);
 	});
 
+	it("tints light-theme markdown accents by mode", () => {
+		// act #0f72cb vs plan #867100 (light theme accents)
+		expect(
+			getSyntaxStyle("light", "act").getStyle("markup.heading")?.fg?.toInts(),
+		).toEqual([0x0f, 0x72, 0xcb, 255]);
+		expect(
+			getSyntaxStyle("light", "plan").getStyle("markup.heading")?.fg?.toInts(),
+		).toEqual([0x86, 0x71, 0x00, 255]);
+	});
+
 	it("keeps code token colors constant across modes", () => {
 		expect(getSyntaxStyle("dark", "plan").getStyle("keyword")).toEqual(
 			getSyntaxStyle("dark", "act").getStyle("keyword"),

--- a/apps/cli/src/tui/utils/syntax-style.test.ts
+++ b/apps/cli/src/tui/utils/syntax-style.test.ts
@@ -49,4 +49,23 @@ describe("getSyntaxStyle", () => {
 
 		expect(style?.fg?.toInts()).toEqual([26, 26, 26, 255]);
 	});
+
+	it("tints markdown accents by mode", () => {
+		// act #79b8ff vs plan #ffea7f (dark theme accents)
+		expect(
+			getSyntaxStyle("dark", "act").getStyle("markup.heading")?.fg?.toInts(),
+		).toEqual([0x79, 0xb8, 0xff, 255]);
+		expect(
+			getSyntaxStyle("dark", "plan").getStyle("markup.heading")?.fg?.toInts(),
+		).toEqual([0xff, 0xea, 0x7f, 255]);
+		expect(
+			getSyntaxStyle("dark", "plan").getStyle("markup.link")?.fg?.toInts(),
+		).toEqual([0xff, 0xea, 0x7f, 255]);
+	});
+
+	it("keeps code token colors constant across modes", () => {
+		expect(getSyntaxStyle("dark", "plan").getStyle("keyword")).toEqual(
+			getSyntaxStyle("dark", "act").getStyle("keyword"),
+		);
+	});
 });

--- a/apps/cli/src/tui/utils/syntax-style.ts
+++ b/apps/cli/src/tui/utils/syntax-style.ts
@@ -1,10 +1,12 @@
 import { RGBA, type StyleDefinition, SyntaxStyle } from "@opentui/core";
 import { type TerminalTheme, themePalette } from "../palette";
 
-const instances: Record<TerminalTheme, SyntaxStyle | null> = {
-	dark: null,
-	light: null,
-};
+// Markdown's prominent elements (headings, bold, list markers, links) take
+// the accent of the mode the content was produced in, so assistant output
+// reads plan-yellow or act-blue alongside the rest of the transcript.
+export type SyntaxAccentMode = "act" | "plan";
+
+const instances = new Map<string, SyntaxStyle>();
 
 interface SyntaxColors {
 	keyword: string;
@@ -22,9 +24,7 @@ interface SyntaxColors {
 	attribute: string;
 	escape: string;
 	markdownCode: string;
-	markdownHeading: string;
 	markdownMuted: string;
-	markdownLink: string;
 	markdownItalic: string;
 	markdownDefault?: string;
 }
@@ -50,9 +50,7 @@ const syntaxColors: Record<TerminalTheme, SyntaxColors> = {
 		attribute: "#f0ad7f",
 		escape: "#9bbbdd",
 		markdownCode: "#99e89b",
-		markdownHeading: themePalette.dark.act,
 		markdownMuted: "#808080",
-		markdownLink: themePalette.dark.act,
 		markdownItalic: "#dfca7d",
 	},
 	light: {
@@ -71,9 +69,7 @@ const syntaxColors: Record<TerminalTheme, SyntaxColors> = {
 		attribute: "#0550ae",
 		escape: "#0550ae",
 		markdownCode: "#116329",
-		markdownHeading: themePalette.light.act,
 		markdownMuted: "#6e7781",
-		markdownLink: themePalette.light.act,
 		markdownItalic: "#8250df",
 		markdownDefault: "#1a1a1a",
 	},
@@ -95,16 +91,16 @@ function italic(hex: string): StyleDefinition {
 	return { fg: color(hex), italic: true };
 }
 
-function underline(hex: string): StyleDefinition {
-	return { fg: color(hex), underline: true };
-}
-
-function buildSyntaxStyle(theme: TerminalTheme): SyntaxStyle {
+function buildSyntaxStyle(
+	theme: TerminalTheme,
+	mode: SyntaxAccentMode,
+): SyntaxStyle {
 	const colors = syntaxColors[theme];
-	const markdownHeading = color(colors.markdownHeading);
+	const accent = color(themePalette[theme][mode]);
+	const markdownHeading = accent;
 	const markdownCode = color(colors.markdownCode);
 	const markdownMuted = color(colors.markdownMuted);
-	const markdownLink = color(colors.markdownLink);
+	const markdownLink = accent;
 
 	return SyntaxStyle.fromStyles({
 		...(colors.markdownDefault ? { default: fg(colors.markdownDefault) } : {}),
@@ -149,10 +145,19 @@ function buildSyntaxStyle(theme: TerminalTheme): SyntaxStyle {
 		"markup.link.url": { fg: markdownLink, underline: true },
 		label: { fg: markdownLink },
 		conceal: { fg: markdownMuted },
-		"string.special.url": underline(colors.markdownLink),
+		"string.special.url": { fg: markdownLink, underline: true },
 	});
 }
 
-export function getSyntaxStyle(theme: TerminalTheme = "dark"): SyntaxStyle {
-	return (instances[theme] ??= buildSyntaxStyle(theme));
+export function getSyntaxStyle(
+	theme: TerminalTheme = "dark",
+	mode: SyntaxAccentMode = "act",
+): SyntaxStyle {
+	const key = `${theme}:${mode}`;
+	let style = instances.get(key);
+	if (!style) {
+		style = buildSyntaxStyle(theme, mode);
+		instances.set(key, style);
+	}
+	return style;
 }


### PR DESCRIPTION
### Related Issue

N/A — internal TUI design iteration. Follow-up to the per-mode transcript coloring stack (#12074/#12075/#12077).

### Description

Completes the per-mode transcript coloring: assistant markdown now tints with the mode its entry was produced in. Previously the markdown prominent elements (headings, bold, list markers, links) were hardcoded to the act accent, so a plan-mode response rendered blue markdown next to its yellow `❯`/`*` glyphs.

- `getSyntaxStyle(theme)` becomes `getSyntaxStyle(theme, mode)` (`mode: "act" | "plan"`, defaults to act). The markdown accent elements resolve from `themePalette[theme][mode]` — plan `#ffea7f` / act `#79b8ff` on dark, with the darkened light-theme counterparts. Styles are memoized per `theme:mode` pair (a Map replaces the two-slot record).
- `ChatEntryView` receives the entry's resolved mode from `ChatMessageList` (`entry.mode` with the same current-mode fallback the glyph accent uses) and passes it to the `<markdown>` syntax style.
- **Deliberately unchanged**: code token colors inside fenced blocks (keyword/string/function/etc.) stay constant across modes — only the markdown structural accents flip. `tool-output` code/diff rendering keeps the default act style for the same reason.

### Test Procedure

- New unit tests assert `markup.heading`/`markup.link` resolve to the plan vs act accents per mode and that code token styles are identical across modes (4/4 passing in `syntax-style.test.ts`).
- `bunx tsc --noEmit` and biome clean (remaining warnings pre-existing).
- Manually verified in the TUI: markdown-heavy responses in a mixed plan/act session render yellow-tinted headings/links in plan segments and blue in act, stable across Tab toggles and `/history` resume.

### Type of Change

-   [x] 💅 Cosmetic Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

Targets main directly — the per-mode coloring stack this builds on is fully merged.