### PR TITLE
fix(vscode): clarify ClinePass description in provider settings

### DIFF
--- a/apps/vscode/webview-ui/src/components/settings/providers/ClineProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/ClineProvider.tsx
@@ -54,7 +54,7 @@ export const ClineProvider = ({
 					<RouteStatus>
 						{activeRoute === "cline-pass" ? (
 							<>
-								ClinePass lets you use the best open weights models.{" "}
+								ClinePass is a low cost subscription plan including usage of the best open weights models.{" "}
 								<RouteLink
 									href="#"
 									onClick={(event) => {


### PR DESCRIPTION
### Related Issue

N/A — minor wording improvement (falls under the limited exceptions for small copy fixes).

### Description

The ClinePass route status in the Cline provider settings read:

> ClinePass lets you use the best open weights models.

This didn't convey what ClinePass actually *is* — a subscription plan — which is the key distinction from usage-billing right next to it in the same toggle. Updated the copy to:

> ClinePass is a low cost subscription plan including usage of the best open weights models.

One-line change in `apps/vscode/webview-ui/src/components/settings/providers/ClineProvider.tsx`. The adjacent "Switch to Cline Usage-Billing for other models." link and the usage-billing branch of the toggle are untouched.

### Test Procedure

Text-only change inside an existing JSX text node — no logic, props, or state touched. Grepped the repo for the old string to confirm this was the only occurrence (no tests, snapshots, or docs reference it).

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 🛠️ Refactor Suggestion
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Change