### PR TITLE
Remove all ClinePass GLM 5.1 references

### DIFF
--- a/apps/cli/src/connectors/session-runtime.test.ts
+++ b/apps/cli/src/connectors/session-runtime.test.ts
@@ -125,12 +125,12 @@ describe("buildConnectorStartRequest", () => {
 			io: { writeln: vi.fn(), writeErr: vi.fn() },
 			loggerConfig: { enabled: false, level: "info", destination: "stdout" },
 			systemRules: "Rules",
-			defaultModel: "cline-pass/glm-5.1",
+			defaultModel: "cline-pass/glm-5.2",
 		});
 
 		expect(request.provider).toBe("cline-pass");
 		expect(request.apiKey).toBe("workos:resolved-token");
-		expect(request.model).toBe("cline-pass/glm-5.1");
+		expect(request.model).toBe("cline-pass/glm-5.2");
 	});
 
 	it("uses auth material resolved by provider settings manager", async () => {
@@ -153,11 +153,11 @@ describe("buildConnectorStartRequest", () => {
 			io: { writeln: vi.fn(), writeErr: vi.fn() },
 			loggerConfig: { enabled: false, level: "info", destination: "stdout" },
 			systemRules: "Rules",
-			defaultModel: "cline-pass/glm-5.1",
+			defaultModel: "cline-pass/glm-5.2",
 		});
 
 		expect(request.provider).toBe("cline-pass");
 		expect(request.apiKey).toBe("workos:resolved-token");
-		expect(request.model).toBe("cline-pass/glm-5.1");
+		expect(request.model).toBe("cline-pass/glm-5.2");
 	});
 });

--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -622,16 +622,16 @@ describe("buildSessionConfig", () => {
 	it("uses ClinePass model storage and omits empty nested apiKey so SDK OAuth can fill it", async () => {
 		mocks.stateManager.getApiConfiguration.mockReturnValue({
 			actModeApiProvider: "cline-pass",
-			actModeClinePassModelId: "cline-pass/glm-5.1",
+			actModeClinePassModelId: "cline-pass/glm-5.2",
 		} as any)
 		mocks.providerSettingsManager.getProviderSettings.mockReturnValue(undefined)
 
 		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
 
 		expect(config.providerId).toBe("cline-pass")
-		expect(config.modelId).toBe("cline-pass/glm-5.1")
+		expect(config.modelId).toBe("cline-pass/glm-5.2")
 		expect(config.apiKey).toBe("")
-		expect(config.providerConfig).toMatchObject({ providerId: "cline-pass", modelId: "cline-pass/glm-5.1" })
+		expect(config.providerConfig).toMatchObject({ providerId: "cline-pass", modelId: "cline-pass/glm-5.2" })
 		expect(config.providerConfig).not.toHaveProperty("apiKey")
 	})
 

--- a/apps/vscode/src/sdk/sdk-api-handler.test.ts
+++ b/apps/vscode/src/sdk/sdk-api-handler.test.ts
@@ -43,14 +43,14 @@ describe("buildSdkProviderConfig", () => {
 		const providerConfig = buildSdkProviderConfig(
 			{
 				actModeApiProvider: "cline-pass",
-				actModeClinePassModelId: "cline-pass/glm-5.1",
+				actModeClinePassModelId: "cline-pass/glm-5.2",
 			},
 			"act",
 		)
 
 		expect(providerConfig).toMatchObject({
 			providerId: "cline-pass",
-			modelId: "cline-pass/glm-5.1",
+			modelId: "cline-pass/glm-5.2",
 			apiKey: "workos:shared-cline-token",
 		})
 		expect(mocks.providerSettingsManager.getProviderSettings).toHaveBeenCalledWith("cline")

--- a/apps/vscode/src/shared/api.ts
+++ b/apps/vscode/src/shared/api.ts
@@ -142,8 +142,7 @@ export const openRouterDefaultModelInfo: ModelInfo = {
 		"Claude Sonnet 4.5 is an Anthropic model for coding, agentic search, and AI agent workflows. It supports planning and implementation tasks across the software development lifecycle.\n\nRead more in the [blog post here](https://www.anthropic.com/claude/sonnet)",
 }
 
-export type ClinePassModelId = keyof typeof clinePassModels
-export const clinePassDefaultModelId = "cline-pass/glm-5.1"
+export const clinePassDefaultModelId = "cline-pass/glm-5.2"
 export const clinePassModelInfoSaneDefaults: ModelInfo = {
 	maxTokens: 8_192,
 	contextWindow: 128_000,
@@ -156,21 +155,6 @@ export const clinePassModelInfoSaneDefaults: ModelInfo = {
 	cacheWritesPrice: 0,
 	description: "",
 }
-export const clinePassModels = {
-	"cline-pass/glm-5.1": {
-		name: "cline-pass/glm-5.1",
-		maxTokens: 131_072,
-		contextWindow: 202_752,
-		supportsImages: false,
-		supportsPromptCache: true,
-		supportsReasoning: true,
-		inputPrice: 0.98,
-		outputPrice: 3.08,
-		cacheReadsPrice: 0.182,
-		cacheWritesPrice: 0,
-		description: "",
-	},
-} as const satisfies Record<string, ModelInfo>
 
 export function getModelSlug(modelId: string): string {
 	return modelId.split("/").at(-1) ?? modelId
@@ -187,11 +171,7 @@ export function buildModelInfoNameMap(models: Record<string, ModelInfo>): Record
 }
 
 export function resolveClinePassModelInfo(modelId: string, modelInfoByName?: Record<string, ModelInfo>): ModelInfo {
-	return (
-		clinePassModels[modelId as keyof typeof clinePassModels] ??
-		modelInfoByName?.[getModelSlug(modelId)] ??
-		clinePassModelInfoSaneDefaults
-	)
+	return modelInfoByName?.[getModelSlug(modelId)] ?? clinePassModelInfoSaneDefaults
 }
 
 export const openAiModelInfoSafeDefaults: OpenAiCompatibleModelInfo = {

--- a/apps/vscode/webview-ui/src/components/onboarding/OnboardingView.tsx
+++ b/apps/vscode/webview-ui/src/components/onboarding/OnboardingView.tsx
@@ -356,7 +356,7 @@ const OnboardingViewContent = ({ onboardingModels }: { onboardingModels: Onboard
 	// Gate on models too, so a fallback/empty response can't route flagged users into the dead-end empty step.
 	const showClinePass = isClinePassEnabled && models.clinePass.length > 0
 	const userTypeSelections = useMemo(() => getUserTypeSelections(showClinePass), [showClinePass])
-	// ClinePass model IDs (e.g. "cline-pass/glm-5.1") aren't keyed in openRouterModels,
+	// ClinePass model IDs (e.g. "cline-pass/glm-5.2") aren't keyed in openRouterModels,
 	// so resolve their info via the slug-based lookup used by ClinePassProvider.
 	const openRouterModelsByName = useMemo(() => buildModelInfoNameMap(openRouterModels), [openRouterModels])
 	const onboardingModelById = useMemo(() => {

--- a/apps/vscode/webview-ui/src/components/onboarding/__tests__/data-models.test.ts
+++ b/apps/vscode/webview-ui/src/components/onboarding/__tests__/data-models.test.ts
@@ -27,7 +27,7 @@ describe("getClineUIOnboardingGroups", () => {
 	it("buckets ClinePass models into the clinePass group", () => {
 		const result = getClineUIOnboardingGroups(
 			groupOf([
-				model("cline-pass/glm-5.1", CLINEPASS_GROUP),
+				model("cline-pass/glm-5.2", CLINEPASS_GROUP),
 				model("free-model", "free"),
 				model("anthropic/claude", "frontier"),
 				model("z-ai/glm", "open source"),
@@ -36,7 +36,7 @@ describe("getClineUIOnboardingGroups", () => {
 
 		expect(result.clinePass).toHaveLength(1)
 		expect(result.clinePass[0].group).toBe(CLINEPASS_GROUP)
-		expect(result.clinePass[0].models.map((m) => m.id)).toEqual(["cline-pass/glm-5.1"])
+		expect(result.clinePass[0].models.map((m) => m.id)).toEqual(["cline-pass/glm-5.2"])
 		expect(result.free[0].models.map((m) => m.id)).toEqual(["free-model"])
 		expect(result.power.flatMap((g) => g.models.map((m) => m.id))).toEqual(["anthropic/claude", "z-ai/glm"])
 	})
@@ -58,22 +58,22 @@ describe("getRecommendedModelsData", () => {
 		const result = getRecommendedModelsData({
 			recommended: [],
 			free: [],
-			clinePass: [{ id: "cline-pass/glm-5.1", name: "GLM 5.1", description: "", tags: [] }],
+			clinePass: [{ id: "cline-pass/glm-5.2", name: "GLM 5.1", description: "", tags: [] }],
 		})
 
-		expect(result?.clinePass.map((model) => model.id)).toEqual(["cline-pass/glm-5.1"])
+		expect(result?.clinePass.map((model) => model.id)).toEqual(["cline-pass/glm-5.2"])
 	})
 
 	it("keeps classic recommended/free responses and ClinePass responses", () => {
 		const result = getRecommendedModelsData({
 			recommended: [{ id: "anthropic/claude", name: "Claude", description: "", tags: [] }],
 			free: [{ id: "free-model", name: "Free", description: "", tags: [] }],
-			clinePass: [{ id: "cline-pass/glm-5.1", name: "GLM 5.1", description: "", tags: [] }],
+			clinePass: [{ id: "cline-pass/glm-5.2", name: "GLM 5.1", description: "", tags: [] }],
 		})
 
 		expect(result?.recommended.map((model) => model.id)).toEqual(["anthropic/claude"])
 		expect(result?.free.map((model) => model.id)).toEqual(["free-model"])
-		expect(result?.clinePass.map((model) => model.id)).toEqual(["cline-pass/glm-5.1"])
+		expect(result?.clinePass.map((model) => model.id)).toEqual(["cline-pass/glm-5.2"])
 	})
 
 	it("returns undefined when every recommended bucket is empty", () => {

--- a/apps/vscode/webview-ui/src/components/onboarding/useOnboardingModels.ts
+++ b/apps/vscode/webview-ui/src/components/onboarding/useOnboardingModels.ts
@@ -86,7 +86,7 @@ export function useOnboardingModels(): UseOnboardingModelsResult {
 		return { ...openRouterModels, ...(clineModels ?? {}) }
 	}, [openRouterModels, clineModels])
 
-	// ClinePass model IDs omit the upstream lab (e.g. "cline-pass/glm-5.1"), so look up
+	// ClinePass model IDs omit the upstream lab (e.g. "cline-pass/glm-5.2"), so look up
 	// capabilities via the model slug against the OpenRouter catalog, falling back to
 	// conservative ClinePass defaults. Mirrors ClinePassProvider's resolution.
 	const openRouterModelsByName = useMemo(() => buildModelInfoNameMap(openRouterModels), [openRouterModels])

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
@@ -343,7 +343,7 @@ describe("LocalRuntimeHost", () => {
 				config: createConfig({
 					sessionId,
 					providerId: "cline-pass",
-					modelId: "cline-pass/glm-5.1",
+					modelId: "cline-pass/glm-5.2",
 					apiKey: undefined,
 				}),
 				prompt: "hello",

--- a/sdk/packages/core/src/services/storage/provider-settings-manager.test.ts
+++ b/sdk/packages/core/src/services/storage/provider-settings-manager.test.ts
@@ -89,14 +89,14 @@ describe("ProviderSettingsManager", () => {
 		manager.saveProviderSettings(
 			{
 				provider: "cline-pass",
-				model: "cline-pass/glm-5.1",
+				model: "cline-pass/glm-5.2",
 			},
 			{ setLastUsed: true },
 		);
 
 		expect(manager.getProviderSettings("cline-pass")).toEqual({
 			provider: "cline-pass",
-			model: "cline-pass/glm-5.1",
+			model: "cline-pass/glm-5.2",
 			baseUrl: "https://api.example.test",
 			auth: {
 				accessToken: "workos:shared-token",
@@ -128,14 +128,14 @@ describe("ProviderSettingsManager", () => {
 		manager.saveProviderSettings(
 			{
 				provider: "cline-pass",
-				model: "cline-pass/glm-5.1",
+				model: "cline-pass/glm-5.2",
 			},
 			{ setLastUsed: true },
 		);
 
 		expect(manager.getLastUsedProviderSettings()).toMatchObject({
 			provider: "cline-pass",
-			model: "cline-pass/glm-5.1",
+			model: "cline-pass/glm-5.2",
 		});
 		expect(
 			manager.getLastUsedProviderSettings({ isClinePassEnabled: false }),
@@ -168,7 +168,7 @@ describe("ProviderSettingsManager", () => {
 		manager.saveProviderSettings(
 			{
 				provider: "cline-pass",
-				model: "cline-pass/glm-5.1",
+				model: "cline-pass/glm-5.2",
 			},
 			{ setLastUsed: true },
 		);

--- a/sdk/packages/llms/src/catalog/catalog-cline-recommended.ts
+++ b/sdk/packages/llms/src/catalog/catalog-cline-recommended.ts
@@ -45,7 +45,7 @@ function findORModelCapabilities(
 }
 
 // Cline-Pass models have only the model name (and not the lab),
-// so we need to look-up using glm-5.1 instead of cline-pass/glm-5.1
+// so we need to look-up using glm-5.1 instead of cline-pass/glm-5.2
 function buildModelsNameMap(
 	openrouterModels: Record<string, ModelInfo>,
 ): Record<string, ModelInfo> {

--- a/sdk/packages/llms/src/catalog/catalog-cline-recommended.ts
+++ b/sdk/packages/llms/src/catalog/catalog-cline-recommended.ts
@@ -45,7 +45,7 @@ function findORModelCapabilities(
 }
 
 // Cline-Pass models have only the model name (and not the lab),
-// so we need to look-up using glm-5.1 instead of cline-pass/glm-5.2
+// so we need to look-up using glm-5.2 instead of cline-pass/glm-5.2
 function buildModelsNameMap(
 	openrouterModels: Record<string, ModelInfo>,
 ): Record<string, ModelInfo> {

--- a/sdk/packages/llms/src/catalog/catalog-live.test.ts
+++ b/sdk/packages/llms/src/catalog/catalog-live.test.ts
@@ -75,7 +75,7 @@ describe("models-dev-catalog", () => {
 			{
 				clinePass: [
 					{
-						id: "cline-pass/cline-pass/glm-5.1",
+						id: "cline-pass/cline-pass/glm-5.2",
 						name: "zai/glm-5.1",
 					},
 				],
@@ -94,9 +94,9 @@ describe("models-dev-catalog", () => {
 		);
 
 		expect(
-			result["cline-pass"]?.["cline-pass/cline-pass/glm-5.1"],
+			result["cline-pass"]?.["cline-pass/cline-pass/glm-5.2"],
 		).toMatchObject({
-			id: "cline-pass/cline-pass/glm-5.1",
+			id: "cline-pass/cline-pass/glm-5.2",
 			name: "GLM 5.1",
 			contextWindow: 256_000,
 			maxInputTokens: 200_000,

--- a/sdk/packages/llms/src/catalog/catalog-live.test.ts
+++ b/sdk/packages/llms/src/catalog/catalog-live.test.ts
@@ -76,14 +76,14 @@ describe("models-dev-catalog", () => {
 				clinePass: [
 					{
 						id: "cline-pass/cline-pass/glm-5.2",
-						name: "zai/glm-5.1",
+						name: "zai/glm-5.2",
 					},
 				],
 			},
 			{
-				"z-ai/glm-5.1": {
-					id: "z-ai/glm-5.1",
-					name: "GLM 5.1",
+				"z-ai/glm-5.2": {
+					id: "z-ai/glm-5.2",
+					name: "GLM 5.2",
 					contextWindow: 256_000,
 					maxInputTokens: 200_000,
 					maxTokens: 32_000,
@@ -97,7 +97,7 @@ describe("models-dev-catalog", () => {
 			result["cline-pass"]?.["cline-pass/cline-pass/glm-5.2"],
 		).toMatchObject({
 			id: "cline-pass/cline-pass/glm-5.2",
-			name: "GLM 5.1",
+			name: "GLM 5.2",
 			contextWindow: 256_000,
 			maxInputTokens: 200_000,
 			maxTokens: 32_000,


### PR DESCRIPTION
We don't offer GLM 5.1 in ClinePass. We have to remove all references.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)