### PR TITLE
fix(core): sanitize session metadata before JSON cloning

### DIFF
--- a/sdk/packages/core/src/hub/runtime-host/hub-runtime-host.ts
+++ b/sdk/packages/core/src/hub/runtime-host/hub-runtime-host.ts
@@ -70,6 +70,7 @@ import type {
 	SessionPendingPrompt,
 } from "../../types/events";
 import type { SessionRecord } from "../../types/sessions";
+import { cloneJsonRecord } from "../../utils/json-record";
 import {
 	type HubClientOptions,
 	isHubCommandTimeoutError,
@@ -83,10 +84,7 @@ function toJsonRecord(
 	if (!value) {
 		return undefined;
 	}
-	return JSON.parse(JSON.stringify(value)) as Record<
-		string,
-		JsonValue | undefined
-	>;
+	return cloneJsonRecord(value) as Record<string, JsonValue | undefined>;
 }
 
 const HUB_HOOK_NAMES = [
@@ -535,7 +533,7 @@ function mapStatus(
 function toSessionRecord(session: HubSessionRecord): SessionRecord {
 	const metadata =
 		session.metadata && typeof session.metadata === "object"
-			? JSON.parse(JSON.stringify(session.metadata))
+			? cloneJsonRecord(session.metadata as Record<string, unknown>)
 			: undefined;
 	return {
 		sessionId: session.sessionId,

--- a/sdk/packages/core/src/hub/server/handlers/session-handlers.ts
+++ b/sdk/packages/core/src/hub/server/handlers/session-handlers.ts
@@ -21,6 +21,7 @@ import {
 } from "../hub-client-contributions";
 import { logHubMessage } from "../hub-server-logging";
 import { toHubSessionRecord } from "../hub-session-records";
+import { cloneJsonRecord } from "../../../utils/json-record";
 import { cancelPendingCapabilityRequests } from "./capability-handlers";
 import {
 	asPlainRecord,
@@ -171,7 +172,7 @@ export async function handleSessionCreate(
 			: {};
 	const metadata =
 		payload.metadata && typeof payload.metadata === "object"
-			? JSON.parse(JSON.stringify(payload.metadata))
+			? (cloneJsonRecord(payload.metadata as Record<string, unknown>) ?? {})
 			: {};
 	const sessionConfig =
 		payload.sessionConfig && typeof payload.sessionConfig === "object"
@@ -464,7 +465,7 @@ export async function handleSessionRestore(
 		);
 		const metadata =
 			payload.metadata && typeof payload.metadata === "object"
-				? JSON.parse(JSON.stringify(payload.metadata))
+				? (cloneJsonRecord(payload.metadata as Record<string, unknown>) ?? {})
 				: {};
 		if (typeof sessionConfig?.mode === "string") {
 			metadata.mode = sessionConfig.mode;

--- a/sdk/packages/core/src/hub/server/hub-session-records.ts
+++ b/sdk/packages/core/src/hub/server/hub-session-records.ts
@@ -5,6 +5,7 @@ import type {
 } from "@cline/shared";
 import type { SessionAccumulatedUsage } from "../../runtime/host/runtime-host";
 import type { SessionRecord as LocalSessionRecord } from "../../types/sessions";
+import { cloneJsonRecord } from "../../utils/json-record";
 
 export type HubSessionState = {
 	createdByClientId?: string;
@@ -36,7 +37,7 @@ function cloneSessionMetadata(
 ): Record<string, JsonValue | undefined> | undefined {
 	const metadata =
 		session.metadata && typeof session.metadata === "object"
-			? (JSON.parse(JSON.stringify(session.metadata)) as Record<
+			? ((cloneJsonRecord(session.metadata) ?? {}) as Record<
 					string,
 					JsonValue | undefined
 				>)

--- a/sdk/packages/core/src/services/storage/sqlite-session-store.ts
+++ b/sdk/packages/core/src/services/storage/sqlite-session-store.ts
@@ -17,6 +17,7 @@ import {
 } from "../../types/common";
 import type { SessionRecord } from "../../types/sessions";
 import type { SessionStore } from "../../types/storage";
+import { stringifyJsonRecord } from "../../utils/json-record";
 
 export interface SqliteSessionStoreOptions {
 	sessionsDir?: string;
@@ -113,7 +114,7 @@ export class SqliteSessionStore implements SessionStore {
 				record.conversationId ?? null,
 				toBoolInt(record.isSubagent),
 				record.prompt ?? null,
-				record.metadata ? JSON.stringify(record.metadata) : null,
+				stringifyJsonRecord(record.metadata),
 				"",
 				record.hookPath ?? "",
 				record.messagesPath ?? null,
@@ -143,7 +144,7 @@ export class SqliteSessionStore implements SessionStore {
 		}
 		if (record.metadata !== undefined) {
 			fields.push("metadata_json = ?");
-			params.push(record.metadata ? JSON.stringify(record.metadata) : null);
+			params.push(stringifyJsonRecord(record.metadata));
 		}
 		if (record.parentSessionId !== undefined) {
 			fields.push("parent_session_id = ?");

--- a/sdk/packages/core/src/session/models/session-row.ts
+++ b/sdk/packages/core/src/session/models/session-row.ts
@@ -1,6 +1,7 @@
 import type { TeamTeammateSpec } from "@cline/shared";
 import type { AgentTeamsRuntime } from "../../extensions/tools/team";
 import type { SessionSource, SessionStatus } from "../../types/common";
+import { stringifyJsonRecord } from "../../utils/json-record";
 import type { SessionManifest } from "./session-manifest";
 
 export interface SessionRow {
@@ -141,8 +142,7 @@ export function patchSqliteRow(raw: Record<string, unknown>): SessionRow {
 export function stringifyMetadata(
 	metadata: Record<string, unknown> | null | undefined,
 ): string | null {
-	if (!metadata || Object.keys(metadata).length === 0) return null;
-	return JSON.stringify(metadata);
+	return stringifyJsonRecord(metadata);
 }
 
 export type TeamRuntimeState = ReturnType<AgentTeamsRuntime["exportState"]>;

--- a/sdk/packages/core/src/session/services/session-service.ts
+++ b/sdk/packages/core/src/session/services/session-service.ts
@@ -307,7 +307,7 @@ export class CoreSessionService extends UnifiedSessionPersistenceService {
 				null,
 				0,
 				input.prompt ?? null,
-				input.metadata ? JSON.stringify(input.metadata) : null,
+				stringifyMetadata(input.metadata),
 				"",
 				"",
 				input.messagesPath,

--- a/sdk/packages/core/src/session/session-snapshot.ts
+++ b/sdk/packages/core/src/session/session-snapshot.ts
@@ -2,6 +2,7 @@ import type * as LlmsProviders from "@cline/llms";
 import type { CheckpointEntry } from "../hooks/checkpoint-hooks";
 import type { SessionAccumulatedUsage } from "../runtime/host/runtime-host";
 import type { SessionRecord } from "../types/sessions";
+import { cloneJsonRecord } from "../utils/json-record";
 
 export interface CoreSessionCheckpointSnapshot {
 	enabled?: boolean;
@@ -56,7 +57,7 @@ export interface CoreSessionSnapshot {
 function cloneJsonObject<T extends Record<string, unknown>>(
 	value: T | undefined,
 ): T | undefined {
-	return value ? (JSON.parse(JSON.stringify(value)) as T) : undefined;
+	return cloneJsonRecord(value) as T | undefined;
 }
 
 function cloneMessages(

--- a/sdk/packages/core/src/utils/json-record.test.ts
+++ b/sdk/packages/core/src/utils/json-record.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { cloneJsonRecord, stringifyJsonRecord } from "./json-record";
+
+describe("json-record helpers", () => {
+	it("converts session metadata into JSON-safe records", () => {
+		const metadata: Record<string, unknown> = {
+			startedAt: new Date("2026-07-07T00:00:00.000Z"),
+			counter: 1n,
+			nested: { ok: true },
+			skipFunction: () => undefined,
+		};
+		metadata.self = metadata;
+		Object.defineProperty(metadata, "badGetter", {
+			enumerable: true,
+			get() {
+				throw new Error("metadata getter failed");
+			},
+		});
+
+		const cloned = cloneJsonRecord(metadata);
+
+		expect(cloned).toEqual({
+			startedAt: "2026-07-07T00:00:00.000Z",
+			counter: "1",
+			nested: { ok: true },
+			self: "[Circular]",
+		});
+	});
+
+	it("stringifies JSON-safe metadata without throwing on circular values", () => {
+		const metadata: Record<string, unknown> = { title: "session" };
+		metadata.self = metadata;
+
+		expect(JSON.parse(stringifyJsonRecord(metadata) ?? "")).toEqual({
+			title: "session",
+			self: "[Circular]",
+		});
+	});
+});

--- a/sdk/packages/core/src/utils/json-record.ts
+++ b/sdk/packages/core/src/utils/json-record.ts
@@ -1,0 +1,76 @@
+function toJsonSafeValue(value: unknown, seen: WeakSet<object>): unknown {
+	if (value === null) return null;
+
+	if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+		return value;
+	}
+	if (typeof value === "bigint") {
+		return value.toString();
+	}
+	if (typeof value === "undefined" || typeof value === "function" || typeof value === "symbol") {
+		return undefined;
+	}
+	if (value instanceof Date) {
+		return Number.isNaN(value.getTime()) ? undefined : value.toISOString();
+	}
+	if (!value || typeof value !== "object") {
+		return undefined;
+	}
+	if (seen.has(value)) {
+		return "[Circular]";
+	}
+	seen.add(value);
+
+	if (Array.isArray(value)) {
+		return value.map((item) => {
+			const next = toJsonSafeValue(item, seen);
+			return next === undefined ? null : next;
+		});
+	}
+
+	const output: Record<string, unknown> = {};
+	let keys: (string | symbol)[];
+	try {
+		keys = Reflect.ownKeys(value);
+	} catch {
+		return undefined;
+	}
+
+	for (const key of keys) {
+		if (typeof key !== "string") continue;
+		let child: unknown;
+		try {
+			child = (value as Record<string, unknown>)[key];
+		} catch {
+			continue;
+		}
+		const next = toJsonSafeValue(child, seen);
+		if (next !== undefined) {
+			output[key] = next;
+		}
+	}
+
+	return output;
+}
+
+export function cloneJsonRecord(
+	value: Record<string, unknown> | null | undefined,
+): Record<string, unknown> | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		return undefined;
+	}
+	const cloned = toJsonSafeValue(value, new WeakSet<object>());
+	return cloned && typeof cloned === "object" && !Array.isArray(cloned)
+		? (cloned as Record<string, unknown>)
+		: undefined;
+}
+
+export function stringifyJsonRecord(
+	value: Record<string, unknown> | null | undefined,
+): string | null {
+	const cloned = cloneJsonRecord(value);
+	if (!cloned || Object.keys(cloned).length === 0) {
+		return null;
+	}
+	return JSON.stringify(cloned);
+}


### PR DESCRIPTION
## Summary

Refs #11879.

This covers Gap 1 from the report: session metadata can contain values that are valid at runtime but unsafe for direct `JSON.parse(JSON.stringify(...))` cloning/persistence, such as `Date`, `bigint`, circular references, or properties that throw while being read.

Changes:
- add a small `json-record` helper for JSON-safe metadata cloning/stringifying
- convert dates to ISO strings and bigint values to strings
- mark circular references as `[Circular]`
- skip unserializable function/symbol/throwing fields instead of failing the whole session path
- use the helper in session create/restore, hub session record projection, snapshots, runtime-host conversion, and SQLite session metadata persistence
- add focused regression coverage for the helper behavior

## Verification

- `git diff --check`
- `node node_modules/.bun/typescript@5.9.3/node_modules/typescript/bin/tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --strict sdk/packages/core/src/utils/json-record.ts`
- Node harness using TypeScript `transpileModule` against the actual `sdk/packages/core/src/utils/json-record.ts` implementation: verified Date, bigint, circular reference, throwing getter, and stringify behavior

Could not run the full repository Bun/Vitest command locally: this checkout did not have dependencies installed, and `npx bun@1.3.13 install --frozen-lockfile` repeatedly failed on Windows with package link/extract errors including missing OpenTelemetry/SAP packages and `dprint-node` tarball extraction. A direct Vitest attempt against the partial install then failed because Vite could not resolve `rolldown`.