### PR TITLE
fix(core): forward session metadata to the agent tool context

### DIFF
--- a/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
@@ -361,6 +361,59 @@ describe("LocalRuntimeHost", () => {
 		);
 	});
 
+	it("forwards session metadata to the agent tool context", async () => {
+		const sessionId = "sess-tool-metadata";
+		const manifest = createManifest(sessionId);
+		const sessionService = {
+			ensureSessionsDir: vi.fn().mockReturnValue("/tmp/sessions"),
+			createRootSessionWithArtifacts: vi.fn().mockResolvedValue({
+				manifestPath: "/tmp/manifest.json",
+				messagesPath: "/tmp/messages.json",
+				manifest,
+			}),
+			persistSessionMessages: vi.fn(),
+			writeSessionManifest: vi.fn(),
+			listSessions: vi.fn().mockResolvedValue([]),
+			deleteSession: vi.fn().mockResolvedValue({ deleted: true }),
+		};
+		const runtimeBuilder = {
+			build: vi.fn().mockReturnValue({ tools: [], shutdown: vi.fn() }),
+		};
+		const agent = {
+			run: vi.fn().mockResolvedValue(createResult()),
+			continue: vi.fn().mockResolvedValue(createResult()),
+			getMessages: vi.fn().mockReturnValue([]),
+			getAgentId: vi.fn().mockReturnValue("agent-root-1"),
+			getConversationId: vi.fn().mockReturnValue("conv-root-1"),
+			abort: vi.fn(),
+			subscribeEvents: vi.fn().mockReturnValue(() => {}),
+			canStartRun: vi.fn().mockReturnValue(true),
+			shutdown: vi.fn().mockResolvedValue(undefined),
+		};
+		const createAgent = vi.fn(() => agent as never);
+		const manager = new RuntimeHostUnderTest({
+			distinctId,
+			sessionService: sessionService as never,
+			runtimeBuilder: runtimeBuilder as never,
+			createAgent,
+		});
+
+		const sessionMetadata = { tenantId: "acme", requestId: "req-42" };
+		await manager.startSession(
+			normalizeStartInput({
+				config: createConfig({ sessionId }),
+				prompt: "hello",
+				sessionMetadata,
+			}),
+		);
+
+		expect(createAgent).toHaveBeenCalledWith(
+			expect.objectContaining({
+				toolContextMetadata: sessionMetadata,
+			}),
+		);
+	});
+
 	it("captures active session lookup misses as handled telemetry", async () => {
 		const adapter = {
 			name: "test",

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
@@ -539,6 +539,59 @@ describe("LocalRuntimeHost", () => {
 		);
 	});
 
+	it("forwards session metadata to the agent tool context", async () => {
+		const sessionId = "sess-tool-metadata";
+		const manifest = createManifest(sessionId);
+		const sessionService = {
+			ensureSessionsDir: vi.fn().mockReturnValue("/tmp/sessions"),
+			createRootSessionWithArtifacts: vi.fn().mockResolvedValue({
+				manifestPath: "/tmp/manifest.json",
+				messagesPath: "/tmp/messages.json",
+				manifest,
+			}),
+			persistSessionMessages: vi.fn(),
+			writeSessionManifest: vi.fn(),
+			listSessions: vi.fn().mockResolvedValue([]),
+			deleteSession: vi.fn().mockResolvedValue({ deleted: true }),
+		};
+		const runtimeBuilder = {
+			build: vi.fn().mockReturnValue({ tools: [], shutdown: vi.fn() }),
+		};
+		const agent = {
+			run: vi.fn().mockResolvedValue(createResult()),
+			continue: vi.fn().mockResolvedValue(createResult()),
+			getMessages: vi.fn().mockReturnValue([]),
+			getAgentId: vi.fn().mockReturnValue("agent-root-1"),
+			getConversationId: vi.fn().mockReturnValue("conv-root-1"),
+			abort: vi.fn(),
+			subscribeEvents: vi.fn().mockReturnValue(() => {}),
+			canStartRun: vi.fn().mockReturnValue(true),
+			shutdown: vi.fn().mockResolvedValue(undefined),
+		};
+		const createAgent = vi.fn(() => agent as never);
+		const manager = new RuntimeHostUnderTest({
+			distinctId,
+			sessionService: sessionService as never,
+			runtimeBuilder: runtimeBuilder as never,
+			createAgent,
+		});
+
+		const sessionMetadata = { tenantId: "acme", requestId: "req-42" };
+		await manager.startSession(
+			normalizeStartInput({
+				config: createConfig({ sessionId }),
+				prompt: "hello",
+				sessionMetadata,
+			}),
+		);
+
+		expect(createAgent).toHaveBeenCalledWith(
+			expect.objectContaining({
+				toolContextMetadata: sessionMetadata,
+			}),
+		);
+	});
+
 	it("persists provider/model connection updates to the session manifest", async () => {
 		const sessionId = "sess-connection-manifest-update";
 		const manifest = createManifest(sessionId);

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -478,6 +478,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 			extensions,
 			hookErrorMode: configWithProvider.hookErrorMode,
 			initialMessages: bootstrap.effectiveInput.initialMessages,
+			toolContextMetadata: startInput.sessionMetadata,
 			userFileContentLoader: loadUserFileContent,
 			toolPolicies: bootstrap.toolPolicies,
 			requestToolApproval: bootstrap.requestToolApproval

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -737,6 +737,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 			extensions,
 			hookErrorMode: configWithProvider.hookErrorMode,
 			initialMessages: bootstrap.effectiveInput.initialMessages,
+			toolContextMetadata: startInput.sessionMetadata,
 			userFileContentLoader: loadUserFileContent,
 			toolPolicies: bootstrap.toolPolicies,
 			requestToolApproval: bootstrap.requestToolApproval


### PR DESCRIPTION
### Related Issue

**Issue:** #12035

### Description

Session metadata passed to `ClineCore.start` never reaches tools. In `LocalRuntimeHost.startSession` the `agentConfig` object is assembled without a `toolContextMetadata` field, so the session's `sessionMetadata` is dropped before the agent is created.

Downstream, `SessionRuntimeOrchestrator` builds the tool context metadata by spreading `this.config.toolContextMetadata` on top of `modelSupportsImages`:

```ts
toolContextMetadata: {
    modelSupportsImages: modelInfo?.capabilities?.includes("images") ?? true,
    ...this.config.toolContextMetadata,
    ...
}
```

Because `toolContextMetadata` on the config was always `undefined`, tools only ever saw `modelSupportsImages` — exactly the symptom reported in the issue (custom tools couldn't read the metadata fields set at session start).

The fix wires `startInput.sessionMetadata` into `agentConfig.toolContextMetadata`. The types already line up: `StartSessionInput.sessionMetadata` and `AgentConfig.toolContextMetadata` are both `Record<string, unknown>`.

### Test Procedure

Added a unit test in `local-runtime-host.test.ts` that starts a session with `sessionMetadata` and asserts the config handed to `createAgent` carries it as `toolContextMetadata`.

- Fails before the change (config has no `toolContextMetadata`).
- Passes after the change.
- Full file green: `57 passed (57)`.

```
cd sdk/packages/core
vitest run --config vitest.config.ts src/runtime/host/local-runtime-host.test.ts
# Test Files  1 passed (1)
# Tests  57 passed (57)
```

`biome check` on both touched files is clean.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

Fixes #12035.