### PR TITLE
Schedule nightly VS Code extension publish

### DIFF
--- a/.github/workflows/ext-vscode-publish-nightly.yml
+++ b/.github/workflows/ext-vscode-publish-nightly.yml
@@ -1,6 +1,9 @@
 name: ext-vscode-publish-nightly
 
 on:
+  schedule:
+    # Every day at 4:00 AM PST (12:00 UTC)
+    - cron: "0 12 * * *"
   workflow_dispatch:
 
 run-name: "Publish Nightly from ${{ github.ref_name }} @ ${{ github.sha }}"


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Schedules the `ext-vscode-publish-nightly` workflow to run automatically every day at 4:00 AM UTC, while keeping manual `workflow_dispatch` available.

### Test Procedure

Verified the workflow YAML change locally by reviewing the diff. No runtime tests were run; this is a GitHub Actions schedule-only change.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

GitHub Actions cron schedules use UTC.
