### PR TITLE
fix(llms): OpenAI Codex model metadata for GPT Subscription provider

### DIFF
--- a/sdk/packages/core/src/services/llms/provider-defaults.test.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.test.ts
@@ -216,8 +216,8 @@ describe("resolveProviderConfig", () => {
 									family: "gpt",
 									release_date: "2027-01-01",
 								},
-								"gpt-5.4-live": {
-									name: "GPT-5.4 Live",
+								"gpt-5.3-live": {
+									name: "GPT-5.3 Live",
 									tool_call: true,
 									reasoning: true,
 									family: "gpt",
@@ -256,7 +256,7 @@ describe("resolveProviderConfig", () => {
 		});
 
 		expect(resolved?.knownModels?.["gpt-5.6-live"]?.name).toBe("GPT-5.6 Live");
-		expect(resolved?.knownModels?.["gpt-5.4-live"]).toBeUndefined();
+		expect(resolved?.knownModels?.["gpt-5.3-live"]).toBeUndefined();
 		expect(resolved?.knownModels?.["gpt-5.4-nano"]).toBeUndefined();
 		expect(resolved?.knownModels?.["o-live"]).toBeUndefined();
 	});
@@ -481,9 +481,8 @@ describe("resolveProviderConfig", () => {
 		const openAiResolved = await resolveProviderConfig("openai-native");
 		const modelIds = Object.keys(resolved?.knownModels ?? {});
 
-		expect(modelIds).toEqual(
-			expect.arrayContaining(["gpt-5.5", "gpt-5.5-pro", "gpt-5.4"]),
-		);
+		expect(modelIds).toEqual(expect.arrayContaining(["gpt-5.5", "gpt-5.4"]));
+		expect(modelIds).not.toContain("gpt-5.5-pro");
 		expect(modelIds).not.toContain("gpt-5.1-codex-max");
 		expect(modelIds).not.toContain("gpt-5.2-codex");
 		expect(modelIds).not.toContain("gpt-5.4-nano");
@@ -492,8 +491,10 @@ describe("resolveProviderConfig", () => {
 		expect(resolved?.knownModels?.["gpt-5.5"]).toEqual(
 			expect.objectContaining({
 				...openAiResolved?.knownModels?.["gpt-5.5"],
-				maxInputTokens: 272_000,
+				// ChatGPT/Codex backend caps: 272K input at the 95% effective budget
+				maxInputTokens: 272_000 * 0.95,
 				contextWindow: 400_000,
+				maxTokens: 128_000,
 			}),
 		);
 	});
@@ -516,7 +517,8 @@ describe("resolveProviderConfig", () => {
 		expect(resolved?.knownModels?.["gpt-5.4-mini"]).toEqual(
 			expect.objectContaining({
 				name: "GPT-5.4 mini",
-				maxInputTokens: 272_000,
+				// catalog input cap scaled to the 95% effective Codex budget
+				maxInputTokens: 272_000 * 0.95,
 				contextWindow: 400_000,
 			}),
 		);

--- a/sdk/packages/llms/src/index.browser.ts
+++ b/sdk/packages/llms/src/index.browser.ts
@@ -7,6 +7,7 @@ export type {
 	ProviderInfo,
 } from "./models";
 export {
+	CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
 	filterOpenAICodexModels,
 	getAllProviders,
 	getGeneratedModelsForProvider,

--- a/sdk/packages/llms/src/index.ts
+++ b/sdk/packages/llms/src/index.ts
@@ -9,6 +9,7 @@ export type {
 	ProviderProtocol,
 } from "./models";
 export {
+	CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
 	fetchLiveProviderModels,
 	fetchModelsDevProviderModels,
 	filterOpenAICodexModels,

--- a/sdk/packages/llms/src/models.ts
+++ b/sdk/packages/llms/src/models.ts
@@ -35,4 +35,7 @@ export {
 	resetRegistry,
 	unregisterProvider,
 } from "./providers/model-registry";
-export { filterOpenAICodexModels } from "./providers/openai-codex-models";
+export {
+	CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
+	filterOpenAICodexModels,
+} from "./providers/openai-codex-models";

--- a/sdk/packages/llms/src/providers/builtins.test.ts
+++ b/sdk/packages/llms/src/providers/builtins.test.ts
@@ -120,13 +120,9 @@ describe("built-in provider metadata", () => {
 		const modelIds = Object.keys(chatGptModels);
 
 		expect(modelIds).toEqual(
-			expect.arrayContaining([
-				"gpt-5.5",
-				"gpt-5.5-pro",
-				"gpt-5.4",
-				"gpt-5.4-mini",
-			]),
+			expect.arrayContaining(["gpt-5.5", "gpt-5.4", "gpt-5.4-mini"]),
 		);
+		expect(modelIds).not.toContain("gpt-5.5-pro");
 		expect(modelIds).not.toContain("gpt-5.1-codex-max");
 		expect(modelIds).not.toContain("gpt-5.2");
 		expect(modelIds).not.toContain("gpt-5.2-codex");
@@ -137,8 +133,10 @@ describe("built-in provider metadata", () => {
 		expect(chatGptModels["gpt-5.5"]).toEqual(
 			expect.objectContaining({
 				...openAiModels["gpt-5.5"],
-				maxInputTokens: 272_000,
+				// ChatGPT/Codex backend caps: 272K input at the 95% effective budget
+				maxInputTokens: 272_000 * 0.95,
 				contextWindow: 400_000,
+				maxTokens: 128_000,
 			}),
 		);
 		expect(chatGptModels["gpt-5.4"]).toEqual(

--- a/sdk/packages/llms/src/providers/openai-codex-models.test.ts
+++ b/sdk/packages/llms/src/providers/openai-codex-models.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import type { ModelInfo } from "../catalog/types";
+import {
+	CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
+	filterOpenAICodexModels,
+} from "./openai-codex-models";
+
+function makeModel(id: string, overrides: Partial<ModelInfo> = {}): ModelInfo {
+	return {
+		id,
+		contextWindow: 400_000,
+		maxInputTokens: 300_000,
+		maxTokens: 100_000,
+		family: id.replace(/^gpt-/, "gpt"),
+		...overrides,
+	};
+}
+
+function filterOne(
+	id: string,
+	overrides: Partial<ModelInfo> = {},
+): ModelInfo | undefined {
+	return filterOpenAICodexModels({ [id]: makeModel(id, overrides) })[id];
+}
+
+describe("filterOpenAICodexModels", () => {
+	describe("model eligibility", () => {
+		it.each([
+			["gpt-5.4", true],
+			["gpt-5.5", true],
+			["gpt-5.5-codex", true],
+			["gpt-6.0", true],
+			["gpt-10.1", true],
+		])("allows %s (newer than 5.3)", (id, allowed) => {
+			expect(filterOne(id) !== undefined).toBe(allowed);
+		});
+
+		it.each([
+			["gpt-5.3", "at the 5.3 cutoff"],
+			["gpt-5.1", "older than 5.3"],
+			["gpt-4.1", "older major version"],
+			["gpt-5", "no minor version"],
+			["chatgpt-5.5", "id does not start with gpt-"],
+			["davinci", "not a gpt model"],
+		])("rejects %s (%s)", (id) => {
+			expect(filterOne(id)).toBeUndefined();
+		});
+
+		it.each([
+			["o-series", "o4"],
+			["pro variant", "gpt5.5-pro"],
+			["nano variant", "gpt5.5-nano"],
+		])("rejects %s families regardless of id version", (_label, family) => {
+			expect(filterOne("gpt-6.0", { family })).toBeUndefined();
+		});
+
+		it("falls back to the id version check when family is missing", () => {
+			expect(filterOne("gpt-6.0", { family: undefined })).toBeDefined();
+			expect(filterOne("gpt-5.0", { family: undefined })).toBeUndefined();
+		});
+	});
+
+	describe("context window adjustment", () => {
+		it("scales maxInputTokens down to the effective Codex budget", () => {
+			const maxInputTokens = 200_000;
+			const result = filterOne("gpt-6.0", { maxInputTokens });
+			expect(result?.maxInputTokens).toBe(
+				maxInputTokens * CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
+			);
+		});
+
+		it("leaves other limits untouched for non-5.5 models", () => {
+			const result = filterOne("gpt-6.0", {
+				contextWindow: 500_000,
+				maxTokens: 64_000,
+			});
+			expect(result?.contextWindow).toBe(500_000);
+			expect(result?.maxTokens).toBe(64_000);
+		});
+
+		it("preserves an undefined maxInputTokens instead of producing NaN", () => {
+			const result = filterOne("gpt-6.0", { maxInputTokens: undefined });
+			expect(result?.maxInputTokens).toBeUndefined();
+		});
+
+		it("overrides gpt-5.5 limits with the ChatGPT backend caps", () => {
+			const result = filterOne("gpt-5.5-codex", {
+				contextWindow: 1_000_000,
+				maxInputTokens: 900_000,
+				maxTokens: 900_000,
+			});
+			expect(result).toMatchObject({
+				contextWindow: 400_000,
+				maxInputTokens: 272_000 * CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
+				maxTokens: 128_000,
+			});
+		});
+
+		it("does not mutate the input models", () => {
+			const model = makeModel("gpt-6.0");
+			const snapshot = structuredClone(model);
+			filterOpenAICodexModels({ "gpt-6.0": model });
+			expect(model).toEqual(snapshot);
+		});
+	});
+
+	it("keeps allowed models and drops disallowed ones from a mixed catalog", () => {
+		const models: Record<string, ModelInfo> = {
+			"gpt-5.5": makeModel("gpt-5.5"),
+			"gpt-6.0": makeModel("gpt-6.0"),
+			"gpt-5.1": makeModel("gpt-5.1"),
+			"o4-mini": makeModel("o4-mini", { family: "o4" }),
+		};
+		expect(Object.keys(filterOpenAICodexModels(models)).sort()).toEqual([
+			"gpt-5.5",
+			"gpt-6.0",
+		]);
+	});
+});

--- a/sdk/packages/llms/src/providers/openai-codex-models.test.ts
+++ b/sdk/packages/llms/src/providers/openai-codex-models.test.ts
@@ -61,13 +61,16 @@ describe("filterOpenAICodexModels", () => {
 	});
 
 	describe("context window adjustment", () => {
-		it("scales maxInputTokens down to the effective Codex budget", () => {
-			const maxInputTokens = 200_000;
-			const result = filterOne("gpt-6.0", { maxInputTokens });
-			expect(result?.maxInputTokens).toBe(
-				maxInputTokens * CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
-			);
-		});
+		it.each(["gpt-5.4", "gpt-5.4-mini", "gpt-6.0"])(
+			"scales %s maxInputTokens down to the effective Codex budget — the backend cap applies to every model, not just gpt-5.5",
+			(id) => {
+				const maxInputTokens = 200_000;
+				const result = filterOne(id, { maxInputTokens });
+				expect(result?.maxInputTokens).toBe(
+					maxInputTokens * CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
+				);
+			},
+		);
 
 		it("leaves other limits untouched for non-5.5 models", () => {
 			const result = filterOne("gpt-6.0", {

--- a/sdk/packages/llms/src/providers/openai-codex-models.ts
+++ b/sdk/packages/llms/src/providers/openai-codex-models.ts
@@ -1,9 +1,12 @@
 import type { ModelInfo } from "../catalog/types";
 
-// The ChatGPT/Codex backend starts rejecting requests around 95% of a
-// model's advertised input cap, so every model exposed through this
-// provider gets its maxInputTokens scaled down to the effective budget.
-// REF: https://github.com/openai/codex/issues/19319
+/**
+ * The ChatGPT/Codex backend starts rejecting requests around 95% of a
+ * model's advertised input cap, so every model exposed through this
+ * provider gets its maxInputTokens scaled down to the effective budget.
+ *
+ * REF: https://github.com/openai/codex/issues/19319
+ */
 export const CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT = 0.95;
 
 const GPT_VERSION_REGEX = /^gpt-(\d+\.\d+)/;
@@ -24,10 +27,12 @@ function isOpenAICodexAllowedModel(id: string, model: ModelInfo): boolean {
 	return match ? Number.parseFloat(match[1]) > 5.3 : false;
 }
 
-// Applies the effective input budget to every allowed model. GPT-5.5
-// additionally gets hardcoded limits because the ChatGPT/Codex backend
-// enforces a 272K input / 128K output cap that is lower than what the
-// generated OpenAI API catalog reports.
+/**
+ * Applies the effective input budget to every allowed model. GPT-5.5
+ * additionally gets hardcoded limits because the ChatGPT/Codex backend
+ * enforces a 272K input / 128K output cap that is lower than what the
+ * generated OpenAI API catalog reports.
+ */
 function toOpenAICodexModel(id: string, model: ModelInfo): ModelInfo {
 	if (id.includes("gpt-5.5")) {
 		return {

--- a/sdk/packages/llms/src/providers/openai-codex-models.ts
+++ b/sdk/packages/llms/src/providers/openai-codex-models.ts
@@ -1,5 +1,8 @@
 import type { ModelInfo } from "../catalog/types";
 
+// The ChatGPT/Codex backend starts rejecting requests around 95% of a
+// model's advertised input cap, so every model exposed through this
+// provider gets its maxInputTokens scaled down to the effective budget.
 // REF: https://github.com/openai/codex/issues/19319
 export const CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT = 0.95;
 
@@ -21,10 +24,11 @@ function isOpenAICodexAllowedModel(id: string, model: ModelInfo): boolean {
 	return match ? Number.parseFloat(match[1]) > 5.3 : false;
 }
 
+// Applies the effective input budget to every allowed model. GPT-5.5
+// additionally gets hardcoded limits because the ChatGPT/Codex backend
+// enforces a 272K input / 128K output cap that is lower than what the
+// generated OpenAI API catalog reports.
 function toOpenAICodexModel(id: string, model: ModelInfo): ModelInfo {
-	// The ChatGPT/Codex backend enforces lower GPT-5.5 limits than the
-	// generated OpenAI API catalog. Requests start failing around 95% of
-	// the 272K input cap, so expose the effective input budget here.
 	if (id.includes("gpt-5.5")) {
 		return {
 			...model,

--- a/sdk/packages/llms/src/providers/openai-codex-models.ts
+++ b/sdk/packages/llms/src/providers/openai-codex-models.ts
@@ -1,7 +1,7 @@
 import type { ModelInfo } from "../catalog/types";
 
 // REF: https://github.com/openai/codex/issues/19319
-const CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT = 0.95;
+export const CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT = 0.95;
 
 const GPT_VERSION_REGEX = /^gpt-(\d+\.\d+)/;
 
@@ -10,7 +10,9 @@ function isOpenAICodexAllowedModel(id: string, model: ModelInfo): boolean {
 	const family = model.family;
 	if (
 		family &&
-		(family.startsWith("o") || family.includes("pro") || family.includes("nano"))
+		(family.startsWith("o") ||
+			family.includes("pro") ||
+			family.includes("nano"))
 	) {
 		return false;
 	}

--- a/sdk/packages/llms/src/providers/openai-codex-models.ts
+++ b/sdk/packages/llms/src/providers/openai-codex-models.ts
@@ -1,35 +1,52 @@
 import type { ModelInfo } from "../catalog/types";
 
-const OPENAI_CODEX_ALLOWED_MODELS = new Set([
-	"gpt-5.5",
-	"gpt-5.4",
-	"gpt-5.4-mini",
-]);
+// REF: https://github.com/openai/codex/issues/19319
+const CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT = 0.95;
 
-function isOpenAICodexAllowedModel(id: string): boolean {
-	if (OPENAI_CODEX_ALLOWED_MODELS.has(id)) return true;
-	const match = id.match(/^gpt-(\d+\.\d+)/);
-	return match ? Number.parseFloat(match[1]) > 5.4 : false;
+const GPT_VERSION_REGEX = /^gpt-(\d+\.\d+)/;
+
+function isOpenAICodexAllowedModel(id: string, model: ModelInfo): boolean {
+	// O, pro, and nano variants are not supported
+	const family = model.family;
+	if (
+		family &&
+		(family.startsWith("o") || family.includes("pro") || family.includes("nano"))
+	) {
+		return false;
+	}
+	// Must be newer than 5.3
+	const match = id.match(GPT_VERSION_REGEX);
+	return match ? Number.parseFloat(match[1]) > 5.3 : false;
 }
 
 function toOpenAICodexModel(id: string, model: ModelInfo): ModelInfo {
-	if (!id.includes("gpt-5.5")) {
-		return model;
+	// The ChatGPT/Codex backend enforces lower GPT-5.5 limits than the
+	// generated OpenAI API catalog. Requests start failing around 95% of
+	// the 272K input cap, so expose the effective input budget here.
+	if (id.includes("gpt-5.5")) {
+		return {
+			...model,
+			contextWindow: 400_000,
+			maxInputTokens: 272_000 * CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
+			maxTokens: 128_000,
+		};
 	}
 	return {
 		...model,
-		contextWindow: 400_000,
-		maxInputTokens: 272_000,
-		maxTokens: 128_000,
+		maxInputTokens: model.maxInputTokens
+			? model.maxInputTokens * CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT
+			: model.maxInputTokens,
 	};
 }
 
 export function filterOpenAICodexModels(
 	models: Record<string, ModelInfo>,
 ): Record<string, ModelInfo> {
-	return Object.fromEntries(
-		Object.entries(models)
-			.filter(([id]) => isOpenAICodexAllowedModel(id))
-			.map(([id, model]) => [id, toOpenAICodexModel(id, model)]),
-	);
+	const result: Record<string, ModelInfo> = {};
+	for (const [id, model] of Object.entries(models)) {
+		if (isOpenAICodexAllowedModel(id, model)) {
+			result[id] = toOpenAICodexModel(id, model);
+		}
+	}
+	return result;
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** https://github.com/cline/cline/issues/12111

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Fix OpenAI Codex model metadata so Cline only exposes supported ChatGPT subscription models and compacts GPT-5.5 sessions before hitting the backend’s effective context limit.

### Problem

The OpenAI Codex provider reuses the generated OpenAI model catalog, but the ChatGPT/Codex backend does not support every model variant from that catalog. As a result, Cline could show unsupported models such as GPT-5.4 Nano and GPT-5.5 Pro in the OpenAI Codex model list.

GPT-5.5 also has lower effective input limits through the Codex backend than the generated OpenAI API catalog suggests. Users reported that long GPT-5.5 sessions fail around 258K context tokens. This aligns with Codex treating only 95% of the 272K input cap for GPT 5.5 as usable. The same 95% also applies to input cap for all codex-supported models.

### Changes

- Filter OpenAI Codex models by supported GPT version and family.
- Exclude unsupported o-series, Pro, and Nano variants from the OpenAI Codex model list.
- Keep supported GPT-5.4 / GPT-5.4 Mini / GPT-5.5 models available.
- Override GPT-5.5 Codex metadata with the effective backend limits:
  - `contextWindow: 400_000`
  - `maxInputTokens: 272_000 * 0.95`
  - `maxTokens: 128_000`
-  filterOpenAICodexModels now builds the result object in one loop instead of Object.entries → filter → map → Object.fromEntries, which allocated two intermediate arrays plus tuple arrays per entry.

### Impact

This prevents users from selecting unsupported ChatGPT subscription models and gives auto-compaction a safer GPT-5.5 input budget, reducing context-limit failures during long tasks.


### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

1. bun run cli
2. /settings
3. Select chatgpt sub provider
4. Go to model list
5. Verify the GPT 5.5 Pro that doesnt work with the provider is removed from the model list
6. Verify the server-capped context window with 95% discount is showing as the context window for gpt models in the model list

<img width="483" height="280" alt="image" src="https://github.com/user-attachments/assets/19d0e34e-9e8b-48af-a72c-3671d92b3b40" />

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->


### Additional Notes

<!-- Add any additional notes for reviewers -->
