### PR TITLE
max/improve provider schema

### DIFF
--- a/apps/vscode/proto/cline/models.proto
+++ b/apps/vscode/proto/cline/models.proto
@@ -63,7 +63,7 @@ service ModelsService {
   rpc readProviderConfig(StringRequest) returns (ProviderConfigResponse);
   // Writes provider configuration fields and returns redacted effective configuration
   rpc writeProviderConfig(WriteProviderConfigRequest) returns (ProviderConfigResponse);
-  // Commits a mode-specific model selection atomically with its model metadata
+  // Commits a mode-specific model ID with optional user-authored metadata overrides
   rpc commitModelSelection(CommitModelSelectionRequest) returns (Empty);
 }
 
@@ -120,6 +120,36 @@ message OpenRouterModelInfo {
   optional double temperature = 14;
   optional bool supports_reasoning = 15;
   optional ApiFormat api_format = 16;
+}
+
+// User-authored per-model metadata stored in models.json.
+//
+// Semantics:
+//  - `capabilities` accepts only the SDK ModelCapability values (e.g.
+//    "images", "tools", "prompt-cache", "reasoning", "files"); unknown
+//    strings are silently dropped by the host. The array is additive over
+//    the base metadata; the explicit supports_* booleans win when both are
+//    present.
+//  - `is_r1_format_required` is a legacy alias that forces the R1 chat
+//    format only when true; `api_format` is canonical.
+//  - Invalid numbers (non-positive token limits, negative prices or
+//    temperature, non-finite values) are silently discarded, not rejected.
+message ModelOverrides {
+  optional string name = 1;
+  optional int64 max_tokens = 2;
+  optional int64 context_window = 3;
+  optional int64 max_input_tokens = 4;
+  repeated string capabilities = 5;
+  optional bool supports_vision = 6;
+  optional bool supports_attachments = 7;
+  optional bool supports_reasoning = 8;
+  optional double input_price = 9;
+  optional double output_price = 10;
+  optional double cache_reads_price = 11;
+  optional double cache_writes_price = 12;
+  optional double temperature = 13;
+  optional ApiFormat api_format = 14;
+  optional bool is_r1_format_required = 15;
 }
 
 // Shared response message for model information
@@ -228,6 +258,7 @@ message CommittedModelSelection {
   string provider_id = 1;
   string model_id = 2;
   OpenRouterModelInfo model_info = 3;
+  optional ModelOverrides overrides = 4;
 }
 
 message ProviderReasoningPatch {
@@ -257,10 +288,18 @@ message WriteProviderConfigRequest {
 }
 
 message CommitModelSelectionRequest {
+  // Field 4 carried `OpenRouterModelInfo model_info` in earlier releases.
+  // Reusing the number with a different message type mis-decodes on version
+  // skew, so the retired field stays reserved.
+  reserved 4;
+  reserved "model_info";
   string provider_id = 1;
   string mode = 2;
   string model_id = 3;
-  OpenRouterModelInfo model_info = 4;
+  // Tri-state: ABSENT leaves the model's stored overrides unchanged, an
+  // explicitly EMPTY message clears them, and a populated message replaces
+  // them wholesale (no per-field merge).
+  optional ModelOverrides overrides = 5;
 }
 
 message ClineRecommendedModel {

--- a/apps/vscode/src/core/controller/models/__tests__/providerCatalogHandlers.test.ts
+++ b/apps/vscode/src/core/controller/models/__tests__/providerCatalogHandlers.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import type { EffectiveProviderConfig, ProviderCatalog, ProviderConfigStore } from "@/sdk/model-catalog/contracts"
 import { computeConfigFingerprint } from "@/sdk/model-catalog/fingerprint"
 import { parseProviderId } from "@/sdk/model-catalog/provider-id"
-import { ApiFormat, OpenRouterModelInfo } from "@/shared/proto/cline/models"
+import { ApiFormat, ModelOverrides } from "@/shared/proto/cline/models"
 import type { ProviderCatalogController } from "../providerCatalogShared"
 
 type TestStateManager = {
@@ -153,6 +153,22 @@ describe("provider model catalog handlers", () => {
 			baseUrl: "https://api.example.com/v1",
 			auth: { accessToken: "SECRET_SENTINEL_ACCESS", refreshToken: "SECRET_SENTINEL_REFRESH", accountId: "acct-1" },
 		})
+		vi.mocked(store.readSelection).mockImplementation((_providerId, mode) =>
+			mode === "act"
+				? {
+						providerId,
+						modelId: "custom-model",
+						overrides: {
+							capabilities: ["tools", "custom-capability"],
+							inputPrice: 1.25,
+							supportsVision: false,
+							temperature: 0.3,
+							apiFormat: ApiFormat.OPENAI_RESPONSES,
+						},
+						modelInfo: { name: "Custom model", contextWindow: 64_000, supportsPromptCache: false },
+					}
+				: undefined,
+		)
 		const controller = makeController(store, makeCatalog())
 
 		const response = await readProviderConfig(controller, { value: "cline" })
@@ -165,10 +181,24 @@ describe("provider model catalog handlers", () => {
 			hasRefreshToken: true,
 			accountId: "acct-1",
 		})
-		expect(JSON.stringify(response)).not.toContain("SECRET_SENTINEL")
+		expect(response.actSelection).toMatchObject({
+			providerId: "cline",
+			modelId: "custom-model",
+			modelInfo: { name: "Custom model", contextWindow: 64_000 },
+			overrides: {
+				capabilities: ["tools", "custom-capability"],
+				inputPrice: 1.25,
+				supportsVision: false,
+				temperature: 0.3,
+				apiFormat: ApiFormat.OPENAI_RESPONSES,
+			},
+		})
+		expect(JSON.stringify(response)).not.toContain("SECRET_SENTINEL_API_KEY")
+		expect(JSON.stringify(response)).not.toContain("SECRET_SENTINEL_ACCESS")
+		expect(JSON.stringify(response)).not.toContain("SECRET_SENTINEL_REFRESH")
 	})
 
-	it("writeProviderConfig writes a patch and returns redacted updated config", async () => {
+	it("writeProviderConfig writes a patch and returns a redacted response", async () => {
 		const { writeProviderConfig } = await import("../writeProviderConfig")
 		const providerId = parseProviderId("ollama")
 		const updatedConfig: EffectiveProviderConfig = {
@@ -188,8 +218,10 @@ describe("provider model catalog handlers", () => {
 			apiKey: "SECRET_SENTINEL_OLLAMA",
 			baseUrl: "http://localhost:11434/v1",
 		})
-		expect(response.apiKeyLength).toBe("SECRET_SENTINEL_OLLAMA".length)
-		expect(JSON.stringify(response)).not.toContain("SECRET_SENTINEL")
+		expect(response).toMatchObject({
+			apiKeyLength: "SECRET_SENTINEL_OLLAMA".length,
+		})
+		expect(JSON.stringify(response)).not.toContain("SECRET_SENTINEL_OLLAMA")
 	})
 
 	it("writeProviderConfig can explicitly clear headers", async () => {
@@ -210,7 +242,7 @@ describe("provider model catalog handlers", () => {
 		expect(store.write).toHaveBeenCalledWith(providerId, { headers: {} })
 	})
 
-	it("commitModelSelection validates mode and commits the full selection envelope", async () => {
+	it("commitModelSelection validates mode and commits model settings", async () => {
 		const { commitModelSelection } = await import("../commitModelSelection")
 		const providerId = parseProviderId("deepseek")
 		const store = makeStore({ providerId })
@@ -224,22 +256,20 @@ describe("provider model catalog handlers", () => {
 			providerId: "deepseek",
 			mode: "act",
 			modelId: "deepseek-v4-flash",
-			modelInfo: OpenRouterModelInfo.create({
+			overrides: ModelOverrides.create({
 				name: "DeepSeek V4 Flash",
 				contextWindow: 456,
-				supportsPromptCache: true,
-				apiFormat: ApiFormat.OPENAI_CHAT,
+				capabilities: ["prompt-cache"],
 			}),
 		})
 
 		expect(store.commitSelection).toHaveBeenCalledWith(providerId, "act", {
 			providerId,
 			modelId: "deepseek-v4-flash",
-			modelInfo: expect.objectContaining({
+			overrides: expect.objectContaining({
 				name: "DeepSeek V4 Flash",
 				contextWindow: 456,
-				supportsPromptCache: true,
-				apiFormat: ApiFormat.OPENAI_CHAT,
+				capabilities: ["prompt-cache"],
 			}),
 		})
 		expect(stateManager.setGlobalStateBatch).toHaveBeenCalledWith({
@@ -247,6 +277,49 @@ describe("provider model catalog handlers", () => {
 			actModeApiModelId: "deepseek-v4-flash",
 		})
 		expect(stateManager.flushPendingState).toHaveBeenCalledTimes(1)
+	})
+
+	// The overrides field is tri-state: absent preserves the model's stored
+	// overrides, an explicitly empty message clears them, and a populated
+	// message replaces them. The two boundary cases are pinned here because
+	// the webview relies on both (see useProviderConfig.test.ts).
+	it("commitModelSelection maps an ABSENT overrides field to undefined (preserve stored overrides)", async () => {
+		const { commitModelSelection } = await import("../commitModelSelection")
+		const providerId = parseProviderId("deepseek")
+		const store = makeStore({ providerId })
+		const controller = makeController(store, makeCatalog())
+
+		await commitModelSelection(controller, {
+			providerId: "deepseek",
+			mode: "act",
+			modelId: "deepseek-v4-flash",
+		})
+
+		expect(store.commitSelection).toHaveBeenCalledWith(providerId, "act", {
+			providerId,
+			modelId: "deepseek-v4-flash",
+			overrides: undefined,
+		})
+	})
+
+	it("commitModelSelection maps an EMPTY overrides message to an empty object (clear stored overrides)", async () => {
+		const { commitModelSelection } = await import("../commitModelSelection")
+		const providerId = parseProviderId("deepseek")
+		const store = makeStore({ providerId })
+		const controller = makeController(store, makeCatalog())
+
+		await commitModelSelection(controller, {
+			providerId: "deepseek",
+			mode: "act",
+			modelId: "deepseek-v4-flash",
+			overrides: ModelOverrides.create({}),
+		})
+
+		expect(store.commitSelection).toHaveBeenCalledWith(providerId, "act", {
+			providerId,
+			modelId: "deepseek-v4-flash",
+			overrides: {},
+		})
 	})
 
 	it("commitModelSelection reports provider changes when config is initialized", async () => {
@@ -268,10 +341,7 @@ describe("provider model catalog handlers", () => {
 			providerId: "deepseek",
 			mode: "act",
 			modelId: "deepseek-v4-flash",
-			modelInfo: OpenRouterModelInfo.create({
-				name: "DeepSeek V4 Flash",
-				apiFormat: ApiFormat.OPENAI_CHAT,
-			}),
+			overrides: ModelOverrides.create({ name: "DeepSeek V4 Flash" }),
 		})
 
 		expect(handleApiConfigurationChanged).toHaveBeenCalledWith({}, { actModeApiProvider: "deepseek" })
@@ -289,7 +359,7 @@ describe("provider model catalog handlers", () => {
 				providerId: "deepseek",
 				mode: "invalid",
 				modelId: "deepseek-v4-flash",
-				modelInfo: OpenRouterModelInfo.create({ supportsPromptCache: true }),
+				overrides: ModelOverrides.create({ capabilities: ["prompt-cache"] }),
 			}),
 		).rejects.toThrow('mode must be "plan" or "act"')
 		expect(store.commitSelection).not.toHaveBeenCalled()

--- a/apps/vscode/src/core/controller/models/__tests__/providerCatalogSmoke.test.ts
+++ b/apps/vscode/src/core/controller/models/__tests__/providerCatalogSmoke.test.ts
@@ -75,7 +75,6 @@ describe("provider model catalog backend smoke", () => {
 				providerId: "deepseek",
 				mode: "act",
 				modelId,
-				modelInfo,
 			}),
 		)
 

--- a/apps/vscode/src/core/controller/models/providerCatalogShared.ts
+++ b/apps/vscode/src/core/controller/models/providerCatalogShared.ts
@@ -3,12 +3,14 @@ import type {
 	EffectiveProviderConfig,
 	Mode,
 	ModelSelection,
+	ModelSelectionOverrides,
 	ProviderCatalog,
 	ProviderConfigPatch,
 	ProviderConfigStore,
 	ProviderId,
 	ProviderListing,
 	ProviderModelsResult,
+	ResolvedModelSelection,
 } from "@/sdk/model-catalog/contracts"
 import { parseProviderId } from "@/sdk/model-catalog/provider-id"
 import {
@@ -17,13 +19,15 @@ import {
 	CommitModelSelectionRequest,
 	CommittedModelSelection,
 	GcpProviderConfig,
+	ModelOverrides as ModelOverridesProto,
 	OpenRouterModelInfo,
 	ProviderConfigResponse,
 	ProviderListing as ProviderListingProto,
 	ProviderModelsResponse,
 	WriteProviderConfigPatch,
 } from "@/shared/proto/cline/models"
-import { fromProtobufModelInfo, toProtobufModelInfo } from "@/shared/proto-conversions/models/typeConversion"
+import { fromProtobufModelOverrides, toProtobufModelOverrides } from "@/shared/proto-conversions/models/modelOverrides"
+import { toProtobufModelInfo } from "@/shared/proto-conversions/models/typeConversion"
 import type { GlobalStateAndSettings } from "@/shared/storage/state-keys"
 
 export interface ProviderCatalogController {
@@ -94,7 +98,11 @@ function toProtobufModels(models: ReadonlyMap<string, ModelInfo>): Record<string
 	return result
 }
 
-function toCommittedModelSelectionProto(selection: ModelSelection | undefined): CommittedModelSelection | undefined {
+function toModelOverridesProto(overrides: ModelSelectionOverrides | undefined): ModelOverridesProto | undefined {
+	return overrides ? toProtobufModelOverrides(overrides) : undefined
+}
+
+function toCommittedModelSelectionProto(selection: ResolvedModelSelection | undefined): CommittedModelSelection | undefined {
 	if (!selection) {
 		return undefined
 	}
@@ -102,6 +110,7 @@ function toCommittedModelSelectionProto(selection: ModelSelection | undefined): 
 		providerId: selection.providerId,
 		modelId: selection.modelId,
 		modelInfo: toProtobufModelInfo(selection.modelInfo),
+		overrides: toModelOverridesProto(selection.overrides),
 	})
 }
 
@@ -241,17 +250,18 @@ export function toProviderConfigPatch(protoPatch: WriteProviderConfigPatch | und
 	}
 }
 
+function toSelectionOverrides(overrides: ModelOverridesProto | undefined): ModelSelectionOverrides | undefined {
+	return fromProtobufModelOverrides(overrides)
+}
+
 export function toModelSelection(request: CommitModelSelectionRequest, providerId: ProviderId): ModelSelection {
 	const modelId = request.modelId.trim()
 	if (!modelId) {
 		throw new Error("model_id is required")
 	}
-	if (!request.modelInfo) {
-		throw new Error("model_info is required")
-	}
 	return {
 		providerId,
 		modelId,
-		modelInfo: fromProtobufModelInfo(request.modelInfo),
+		overrides: toSelectionOverrides(request.overrides),
 	}
 }

--- a/apps/vscode/src/core/controller/models/resolveModelInfo.ts
+++ b/apps/vscode/src/core/controller/models/resolveModelInfo.ts
@@ -12,10 +12,11 @@ import { type ProviderCatalogController, parseProviderIdRequest } from "./provid
  * Resolution order:
  *
  *   1. Committed selection — the user's most-recently-chosen plan/act
- *      selection in the provider config store. This is the source of
- *      truth for dynamic-list providers (openrouter, openai-compatible,
- *      ollama, lmstudio, requesty, litellm, …) where the picker writes
- *      the live `ModelInfo` into the selection when the user commits.
+ *      model ID resolved against SDK catalog metadata, the picker's state
+ *      snapshot, and stored overrides by the provider config store. A
+ *      selection whose metadata is pure fallback fabrication (no catalog or
+ *      state base, no overrides) is deferred behind the catalog steps below
+ *      and only returned as a last resort.
  *
  *   2. Catalog peek — a non-fetching look-up of the catalog cache for
  *      the provider's current effective config fingerprint. Hits when
@@ -41,23 +42,24 @@ export async function resolveModelInfo(
 	const requestedModelId = request.modelId?.trim() || ""
 
 	const store = controller.getProviderConfigStore()
+	// A committed selection whose metadata is pure fallback fabrication (no
+	// catalog/state base and no user overrides) must not shadow the live
+	// catalog below; it is kept only as a last resort before "unknown".
+	let fallbackSelection: ReturnType<typeof store.readSelection>
 	if (requestedModelId) {
-		const actSelection = store.readSelection(providerId, "act")
-		if (actSelection?.modelId === requestedModelId) {
+		for (const mode of ["act", "plan"] as const) {
+			const selection = store.readSelection(providerId, mode)
+			if (selection?.modelId !== requestedModelId) {
+				continue
+			}
+			if (selection.modelInfoSource === "fallback" && !selection.overrides) {
+				fallbackSelection ??= selection
+				continue
+			}
 			return ResolveModelInfoResponse.create({
 				providerId,
-				modelId: actSelection.modelId,
-				modelInfo: toProtobufModelInfo(actSelection.modelInfo),
-				source: "committed-selection",
-			})
-		}
-
-		const planSelection = store.readSelection(providerId, "plan")
-		if (planSelection?.modelId === requestedModelId) {
-			return ResolveModelInfoResponse.create({
-				providerId,
-				modelId: planSelection.modelId,
-				modelInfo: toProtobufModelInfo(planSelection.modelInfo),
+				modelId: selection.modelId,
+				modelInfo: toProtobufModelInfo(selection.modelInfo),
 				source: "committed-selection",
 			})
 		}
@@ -74,7 +76,9 @@ export async function resolveModelInfo(
 	const cached = catalog.peekModels(providerId)
 	if (cached?.ok) {
 		const hit = pickFromCatalog(cached, requestedModelId, allowCustomModelIds)
-		if (hit) {
+		// A default-model substitution answers a question about a different
+		// model; the committed selection, even fallback-grade, is closer.
+		if (hit && (hit.matchedRequested || !fallbackSelection)) {
 			return ResolveModelInfoResponse.create({
 				providerId,
 				modelId: hit.modelId,
@@ -90,7 +94,7 @@ export async function resolveModelInfo(
 	const resolved = await catalog.resolveModels(providerId).catch(() => undefined)
 	if (resolved?.ok) {
 		const hit = pickFromCatalog(resolved, requestedModelId, allowCustomModelIds)
-		if (hit) {
+		if (hit && (hit.matchedRequested || !fallbackSelection)) {
 			return ResolveModelInfoResponse.create({
 				providerId,
 				modelId: hit.modelId,
@@ -98,6 +102,15 @@ export async function resolveModelInfo(
 				source: hit.matchedRequested ? "sdk-known-models" : "sdk-default",
 			})
 		}
+	}
+
+	if (fallbackSelection) {
+		return ResolveModelInfoResponse.create({
+			providerId,
+			modelId: fallbackSelection.modelId,
+			modelInfo: toProtobufModelInfo(fallbackSelection.modelInfo),
+			source: "committed-selection",
+		})
 	}
 
 	return ResolveModelInfoResponse.create({

--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -2,6 +2,9 @@ import fs from "node:fs"
 import os from "node:os"
 import path from "node:path"
 import type { CoreSessionConfig } from "@cline/core"
+import * as LlmsModels from "@cline/llms"
+import { ApiFormat } from "@shared/proto/cline/models"
+import { Logger } from "@shared/services/Logger"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import {
 	buildResumeSessionInput,
@@ -15,9 +18,12 @@ import {
 	resolveApiKey,
 	updateHistoryItem,
 } from "./cline-session-factory"
+import { parseProviderId } from "./model-catalog/provider-id"
+import { createProviderConfigStore } from "./model-catalog/store"
 
 const mocks = vi.hoisted(() => {
 	const providerSettingsManager = {
+		getFilePath: vi.fn(() => path.join(tempDir, "settings", "providers.json")),
 		getLastUsedProviderSettings: vi.fn(() => undefined),
 		getProviderSettings: vi.fn((_providerId?: string) => undefined),
 		saveProviderSettings: vi.fn(),
@@ -39,6 +45,9 @@ const mocks = vi.hoisted(() => {
 				}
 				return undefined
 			}),
+			setGlobalStateBatch: vi.fn(),
+			setGlobalState: vi.fn(),
+			setSecret: vi.fn(),
 		},
 	}
 })
@@ -72,11 +81,14 @@ vi.mock("@shared/services/Logger", () => ({
 
 let tempDir: string
 const previousGlobalSettingsPath = process.env.CLINE_GLOBAL_SETTINGS_PATH
+const previousDataDir = process.env.CLINE_DATA_DIR
 
 beforeEach(() => {
 	tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "cline-session-factory-"))
+	process.env.CLINE_DATA_DIR = tempDir
 	process.env.CLINE_GLOBAL_SETTINGS_PATH = path.join(tempDir, "global-settings.json")
 	vi.clearAllMocks()
+	LlmsModels.resetRegistry()
 	mocks.stateManager.getApiConfiguration.mockReturnValue({
 		actModeApiProvider: "anthropic",
 		actModeApiModelId: "claude-sonnet-4-6",
@@ -88,12 +100,14 @@ beforeEach(() => {
 		}
 		return undefined
 	})
+	mocks.providerSettingsManager.getFilePath.mockReturnValue(path.join(tempDir, "settings", "providers.json"))
 	mocks.providerSettingsManager.getLastUsedProviderSettings.mockReturnValue(undefined)
 	mocks.providerSettingsManager.getProviderSettings.mockReturnValue(undefined)
 })
 
 afterEach(() => {
 	process.env.CLINE_GLOBAL_SETTINGS_PATH = previousGlobalSettingsPath
+	process.env.CLINE_DATA_DIR = previousDataDir
 	fs.rmSync(tempDir, { recursive: true, force: true })
 })
 
@@ -429,6 +443,40 @@ describe("buildSessionConfig", () => {
 		expect(config.providerConfig).not.toHaveProperty("apiKey")
 	})
 
+	it("preserves rich SDK catalog entries without extension-side replacement", async () => {
+		const expectedModel = structuredClone((await LlmsModels.getModelsForProvider("anthropic"))["claude-sonnet-4-6"])
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "anthropic",
+			actModeApiModelId: "claude-sonnet-4-6",
+			apiKey: "anthropic-key",
+		} as any)
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+		const knownModel = (config.providerConfig as any).knownModels["claude-sonnet-4-6"]
+
+		expect(knownModel).toEqual(expectedModel)
+		expect(knownModel.capabilities).toEqual(
+			expect.arrayContaining(["images", "files", "tools", "reasoning", "structured_output", "temperature", "prompt-cache"]),
+		)
+		expect(knownModel.pricing).toEqual(expectedModel.pricing)
+		expect(knownModel.releaseDate).toBe(expectedModel.releaseDate)
+		expect(knownModel.family).toBe(expectedModel.family)
+	})
+
+	it("keeps session creation non-fatal when known-model lookup fails", async () => {
+		const lookupError = new Error("registry unavailable")
+		const getModelsSpy = vi.spyOn(LlmsModels, "getModelsForProvider").mockRejectedValueOnce(lookupError)
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+
+		expect(config.providerConfig).not.toHaveProperty("knownModels")
+		expect(Logger.warn).toHaveBeenCalledWith(
+			"[SessionFactory] Failed to resolve known models for provider=anthropic:",
+			lookupError,
+		)
+		getModelsSpy.mockRestore()
+	})
+
 	it("passes OpenAI Compatible max output tokens as an explicit request limit", async () => {
 		mocks.stateManager.getApiConfiguration.mockReturnValue({
 			actModeApiProvider: "openai",
@@ -451,9 +499,85 @@ describe("buildSessionConfig", () => {
 		expect(config.providerId).toBe("openai-compatible")
 		expect(config.modelId).toBe("custom-reasoner")
 		expect(config.knownModels).toBeUndefined()
-		expect((config.providerConfig as any).knownModels).toBeUndefined()
+		expect((config.providerConfig as any).knownModels).toBeDefined()
 		expect((config.providerConfig as any).maxOutputTokens).toBeUndefined()
 		expect((config as any).maxTokensPerTurn).toBe(4_096)
+	})
+
+	it("uses OpenAI Compatible overrides from models.json for runtime request settings", async () => {
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "openai",
+			actModeOpenAiModelId: "custom-reasoner",
+			openAiApiKey: "openai-compatible-key",
+			openAiBaseUrl: "https://openai-compatible.example/v1",
+			actModeOpenAiModelInfo: { supportsPromptCache: false },
+		} as any)
+		createProviderConfigStore().commitSelection(parseProviderId("openai"), "act", {
+			providerId: parseProviderId("openai"),
+			modelId: "custom-reasoner",
+			overrides: {
+				name: "Custom Reasoner",
+				contextWindow: 16_000,
+				maxInputTokens: 15_000,
+				maxTokens: 1_234,
+				capabilities: ["images", "reasoning", "streaming", "tools"],
+				supportsVision: false,
+				supportsAttachments: true,
+				supportsReasoning: false,
+				temperature: 0,
+				inputPrice: 1,
+				outputPrice: 2,
+				cacheReadsPrice: 0.1,
+				cacheWritesPrice: 0.5,
+				apiFormat: ApiFormat.OPENAI_RESPONSES,
+			},
+		})
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+		const knownModel = (config.providerConfig as any).knownModels["custom-reasoner"]
+
+		expect(config.providerId).toBe("openai-compatible")
+		expect(config.modelId).toBe("custom-reasoner")
+		expect((config as any).maxTokensPerTurn).toBe(1_234)
+		expect((config as any).temperature).toBe(0)
+		expect(knownModel).toMatchObject({
+			id: "custom-reasoner",
+			name: "Custom Reasoner",
+			contextWindow: 16_000,
+			maxInputTokens: 15_000,
+			maxTokens: 1_234,
+			capabilities: ["streaming", "tools", "files"],
+			apiFormat: "openai-responses",
+			temperature: 0,
+			pricing: { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 0.5 },
+		})
+	})
+
+	it("keeps -1 OpenAI Compatible values out of request settings and fallback knownModels", async () => {
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "openai",
+			actModeOpenAiModelId: "custom-reasoner",
+			openAiApiKey: "openai-compatible-key",
+			openAiBaseUrl: "https://openai-compatible.example/v1",
+			actModeOpenAiModelInfo: { supportsPromptCache: false },
+		} as any)
+		createProviderConfigStore().commitSelection(parseProviderId("openai"), "act", {
+			providerId: parseProviderId("openai"),
+			modelId: "custom-reasoner",
+			overrides: {
+				name: "Custom Reasoner",
+				maxTokens: -1,
+				temperature: -1,
+			},
+		})
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+
+		expect((config as any).maxTokensPerTurn).toBeUndefined()
+		expect((config as any).temperature).toBeUndefined()
+		const knownModel = (config.providerConfig as any).knownModels["custom-reasoner"]
+		expect(knownModel).not.toHaveProperty("maxTokens")
+		expect(knownModel).not.toHaveProperty("temperature", -1)
 	})
 
 	it("passes OCA reasoning effort from legacy mode settings to SDK sessions", async () => {

--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -17,7 +17,8 @@ import {
 	resolveProviderApiKeyFromSettings,
 	type StartSessionResult,
 } from "@cline/core"
-import { getGeneratedModelsForProvider, MODEL_COLLECTIONS_BY_PROVIDER_ID } from "@cline/llms"
+import type { ModelInfo as SdkModelInfo } from "@cline/llms"
+import { getGeneratedModelsForProvider, getModelsForProvider, MODEL_COLLECTIONS_BY_PROVIDER_ID } from "@cline/llms"
 import { buildClineSystemPrompt } from "@cline/shared"
 import type { ApiConfiguration } from "@shared/api"
 import { ClineClient } from "@shared/cline"
@@ -37,7 +38,11 @@ import { FeatureFlag } from "@/shared/services/feature-flags/feature-flags"
 import { type BedrockProviderConfig, buildBedrockProviderConfig } from "./bedrock-config"
 import { buildAgentHooks } from "./hooks-adapter"
 import { readTaskHistory, resolveDataDir } from "./legacy-state-reader"
+import type { ResolvedModelSelection } from "./model-catalog/contracts"
+import { nonNegativeFiniteNumber, positiveFiniteNumber, toSdkApiFormat } from "./model-catalog/model-values"
+import { parseProviderId } from "./model-catalog/provider-id"
 import { toSdkProviderId } from "./model-catalog/sdk-provider-id"
+import { createProviderConfigStore, resolveRuntimeModelSelection } from "./model-catalog/store"
 import { getProviderSettingsManager } from "./provider-migration"
 import { buildSapProviderConfig, type SapProviderConfig } from "./sap-config"
 import type { SdkSessionHost } from "./session-host"
@@ -209,8 +214,73 @@ function resolveOcaReasoningConfig(mode: Mode, apiConfig: ApiConfiguration | und
 
 function resolveOpenAiCompatibleMaxTokens(config: ApiConfiguration | undefined, mode: Mode): number | undefined {
 	const modelInfo = mode === "plan" ? config?.planModeOpenAiModelInfo : config?.actModeOpenAiModelInfo
-	const maxTokens = modelInfo?.maxTokens
-	return typeof maxTokens === "number" && Number.isFinite(maxTokens) && maxTokens > 0 ? maxTokens : undefined
+	return positiveFiniteNumber(modelInfo?.maxTokens)
+}
+
+function toSdkModelInfo(selection: ResolvedModelSelection): SdkModelInfo {
+	const modelInfo = selection.modelInfo
+	const capabilities = new Set<NonNullable<SdkModelInfo["capabilities"]>[number]>(
+		(selection.overrides?.capabilities ?? []) as NonNullable<SdkModelInfo["capabilities"]>,
+	)
+	const setCapability = (capability: NonNullable<SdkModelInfo["capabilities"]>[number], enabled: boolean): void => {
+		if (enabled) capabilities.add(capability)
+		else capabilities.delete(capability)
+	}
+	if (modelInfo.supportsImages !== undefined) setCapability("images", modelInfo.supportsImages)
+	setCapability("prompt-cache", modelInfo.supportsPromptCache)
+	if (modelInfo.supportsReasoning !== undefined) setCapability("reasoning", modelInfo.supportsReasoning)
+	if (selection.overrides?.supportsAttachments !== undefined) setCapability("files", selection.overrides.supportsAttachments)
+
+	const maxTokens = positiveFiniteNumber(modelInfo.maxTokens)
+	const contextWindow = positiveFiniteNumber(modelInfo.contextWindow)
+	const maxInputTokens = positiveFiniteNumber(selection.overrides?.maxInputTokens)
+	const temperature = nonNegativeFiniteNumber(modelInfo.temperature)
+	const inputPrice = nonNegativeFiniteNumber(modelInfo.inputPrice)
+	const outputPrice = nonNegativeFiniteNumber(modelInfo.outputPrice)
+	const cacheRead = nonNegativeFiniteNumber(modelInfo.cacheReadsPrice)
+	const cacheWrite = nonNegativeFiniteNumber(modelInfo.cacheWritesPrice)
+	const apiFormat = toSdkApiFormat(modelInfo.apiFormat)
+	const hasPricing =
+		inputPrice !== undefined || outputPrice !== undefined || cacheRead !== undefined || cacheWrite !== undefined
+
+	return {
+		id: selection.modelId,
+		name: modelInfo.name ?? selection.modelId,
+		...(maxTokens !== undefined ? { maxTokens } : {}),
+		...(contextWindow !== undefined ? { contextWindow } : {}),
+		...(maxInputTokens !== undefined ? { maxInputTokens } : {}),
+		...(capabilities.size > 0 ? { capabilities: [...capabilities] } : {}),
+		...(apiFormat !== undefined ? { apiFormat } : {}),
+		...(temperature !== undefined ? { temperature } : {}),
+		...(hasPricing
+			? {
+					pricing: {
+						...(inputPrice !== undefined ? { input: inputPrice } : {}),
+						...(outputPrice !== undefined ? { output: outputPrice } : {}),
+						...(cacheRead !== undefined ? { cacheRead } : {}),
+						...(cacheWrite !== undefined ? { cacheWrite } : {}),
+					},
+				}
+			: {}),
+	}
+}
+
+function resolveCommittedRuntimeModel(
+	providerId: string,
+	mode: Mode,
+	modelId: string | undefined,
+): ResolvedModelSelection | undefined {
+	if (!modelId) {
+		return undefined
+	}
+	try {
+		const parsedProviderId = parseProviderId(providerId)
+		const selection = createProviderConfigStore().readSelection(parsedProviderId, mode)
+		return selection?.modelId === modelId ? selection : resolveRuntimeModelSelection(parsedProviderId, modelId)
+	} catch (error) {
+		Logger.warn(`[SessionFactory] Failed to resolve committed model settings for provider=${providerId}:`, error)
+		return undefined
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -611,7 +681,12 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 		apiKey = resolveApiKey(providerId, apiConfig)
 	}
 	apiKey = apiKey ?? ""
-	const maxTokensPerTurn = providerId === "openai" ? resolveOpenAiCompatibleMaxTokens(apiConfig, mode) : undefined
+	const committedRuntimeModel = resolveCommittedRuntimeModel(providerId, mode, modelId)
+	const overriddenMaxTokens = committedRuntimeModel?.overrides?.maxTokens
+	const maxTokensPerTurn =
+		positiveFiniteNumber(overriddenMaxTokens) ??
+		(providerId === "openai" ? resolveOpenAiCompatibleMaxTokens(apiConfig, mode) : undefined)
+	const temperature = nonNegativeFiniteNumber(committedRuntimeModel?.overrides?.temperature)
 	const reasoningConfig =
 		providerId === "oca"
 			? (resolveOcaReasoningConfig(mode, apiConfig) ?? resolveProviderReasoningConfig(providerId))
@@ -662,6 +737,27 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 	const sdkProviderId = toSdkProviderId(providerId)
 	const hostIdentity = await resolveHostIdentity()
 	const isMultiRoot = await resolveIsMultiRootWorkspace()
+	let knownModels: Awaited<ReturnType<typeof getModelsForProvider>> | undefined
+	try {
+		// Constructing the settings manager loads providers.json and models.json into
+		// the @cline/llms registry. Reading models from that registry ensures custom
+		// model overrides are included in the inference provider config, not just in
+		// the webview/display path.
+		getProviderSettingsManager(resolveDataDir())
+		knownModels = await getModelsForProvider(sdkProviderId)
+		// Only inject host-resolved metadata that carries real information
+		// (catalog/state base or user overrides). Pure fallback fabrications
+		// must not reach the runtime; the SDK's own resolution handles those.
+		const isPureFallbackModel = committedRuntimeModel?.modelInfoSource === "fallback" && !committedRuntimeModel.overrides
+		if (committedRuntimeModel && !isPureFallbackModel && !knownModels?.[modelId]) {
+			knownModels = {
+				...(knownModels ?? {}),
+				[modelId]: toSdkModelInfo(committedRuntimeModel),
+			}
+		}
+	} catch (error) {
+		Logger.warn(`[SessionFactory] Failed to resolve known models for provider=${sdkProviderId}:`, error)
+	}
 
 	// Always pass a providerConfig so the proxy/CA-aware fetch reaches the SDK
 	// gateway; without it the agent loop uses bare global fetch and corporate
@@ -677,6 +773,7 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 		modelId,
 		...(apiKey ? { apiKey } : {}),
 		...(baseUrl !== undefined ? { baseUrl } : {}),
+		...(knownModels && Object.keys(knownModels).length > 0 ? { knownModels } : {}),
 		fetch,
 	}
 
@@ -707,6 +804,7 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 		mode: mode === "plan" ? "plan" : "act",
 		...reasoningConfig,
 		...(maxTokensPerTurn !== undefined ? { maxTokensPerTurn } : {}),
+		...(temperature !== undefined ? { temperature } : {}),
 		maxIterations: undefined,
 		logger: sdkLogger,
 		extensionContext: {

--- a/apps/vscode/src/sdk/model-catalog/catalog.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/catalog.test.ts
@@ -3,10 +3,10 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 import type {
 	EffectiveProviderConfig,
 	Fingerprint,
-	ModelSelection,
 	ProviderConfigChange,
 	ProviderConfigReader,
 	ProviderModelsResult,
+	ResolvedModelSelection,
 } from "./contracts"
 import { computeConfigFingerprint } from "./fingerprint"
 import { parseProviderId } from "./provider-id"
@@ -95,7 +95,7 @@ function record(
 	}
 }
 
-function makeReader(initialConfig: EffectiveProviderConfig, selection?: ModelSelection): TestReader {
+function makeReader(initialConfig: EffectiveProviderConfig, selection?: ResolvedModelSelection): TestReader {
 	let config = initialConfig
 	const listeners = new Set<(event: ProviderConfigChange) => void>()
 	return {
@@ -241,7 +241,7 @@ describe("ProviderCatalog Phase 3.2 resolveModels happy path", () => {
 		})
 		const providerId = parseProviderId("openrouter")
 		const config: EffectiveProviderConfig = { providerId, apiKey: "secret", baseUrl: "https://provider.example.com" }
-		const selection: ModelSelection = { providerId, modelId: "selected", modelInfo }
+		const selection: ResolvedModelSelection = { providerId, modelId: "selected", modelInfo }
 		const reader = makeReader(config, selection)
 		const catalog = createProviderCatalog(reader)
 
@@ -507,7 +507,7 @@ describe("ProviderCatalog Phase 3.4 store-driven invalidation", () => {
 		const providerId = parseProviderId("openrouter")
 		const reader = makeReader({ providerId, apiKey: "same" })
 		const catalog = createProviderCatalog(reader)
-		const selection: ModelSelection = { providerId, modelId: "different", modelInfo }
+		const selection: ResolvedModelSelection = { providerId, modelId: "different", modelInfo }
 
 		const first = await catalog.resolveModels(providerId)
 		reader.emit({ kind: "selection", providerId, mode: "act", selection })
@@ -692,7 +692,7 @@ describe("ProviderCatalog Phase 3.6 subscribe", () => {
 		const reader = makeReader({ providerId, baseUrl: "http://localhost:11434/v1" })
 		const catalog = createProviderCatalog(reader)
 		const listener = vi.fn()
-		const selection: ModelSelection = { providerId, modelId: "custom:latest", modelInfo }
+		const selection: ResolvedModelSelection = { providerId, modelId: "custom:latest", modelInfo }
 		catalog.subscribe(providerId, listener)
 
 		reader.emit({ kind: "selection", providerId, mode: "act", selection })

--- a/apps/vscode/src/sdk/model-catalog/contracts.ts
+++ b/apps/vscode/src/sdk/model-catalog/contracts.ts
@@ -68,8 +68,8 @@ export type Fingerprint = string & { readonly [FingerprintBrand]: void }
  *  - Two reads with no intervening write return structurally equal values.
  *  - Consumers must not mutate. The shape is `Readonly`.
  *
- * Mode-dependent selection (modelId, modelInfo) is *not* part of this
- * type. Use `ProviderConfigStore.readSelection(providerId, mode)`.
+ * Mode-dependent selection is *not* part of this type. Use
+ * `ProviderConfigStore.readSelection(providerId, mode)`.
  */
 export interface AwsProviderConfig {
 	readonly accessKey?: string
@@ -119,9 +119,9 @@ export interface EffectiveProviderConfig {
  * A patch describing a field-level write to `ProviderConfigStore`.
  *
  * Invariant: `ProviderConfigPatch` cannot describe a model selection. The
- * type does not contain `modelId` or `modelInfo`. To write a selection,
- * use `commitSelection`, which is a structurally distinct method on the
- * store.
+ * type does not contain `modelId` or per-model overrides. To write a
+ * selection, use `commitSelection`, which is a structurally distinct method
+ * on the store.
  *
  * Empty patches are allowed and are no-ops. A field present with value
  * `null` means "clear this field"; an absent field means "leave unchanged."
@@ -153,22 +153,65 @@ export interface ProviderConfigPatch {
 // Model selection
 // ---------------------------------------------------------------------------
 
+/** Per-model metadata overrides authored by the user for custom models. */
+export interface ModelSelectionOverrides {
+	readonly name?: string
+	readonly maxTokens?: number
+	readonly contextWindow?: number
+	readonly maxInputTokens?: number
+	readonly capabilities?: readonly string[]
+	readonly supportsVision?: boolean
+	readonly supportsAttachments?: boolean
+	readonly supportsReasoning?: boolean
+	readonly inputPrice?: number
+	readonly outputPrice?: number
+	readonly cacheReadsPrice?: number
+	readonly cacheWritesPrice?: number
+	readonly temperature?: number
+	readonly apiFormat?: ModelInfo["apiFormat"]
+	readonly isR1FormatRequired?: boolean
+}
+
 /**
- * A user's committed model selection. The triple is atomic by type: every
- * write of `modelId` carries its `modelInfo` envelope, and vice versa.
+ * A user's committed model selection. The committed write stores only the
+ * selected model id plus optional user-authored overrides. `ModelInfo` is
+ * derived by the host from the SDK catalog, then layered with `models.json`
+ * overrides, then per-provider safe fallback metadata.
  *
  * Invariants:
- *  - `modelInfo` was either taken from a `ProviderCatalog.resolveModels`
- *    result, or constructed from per-provider safe defaults when the user
- *    entered a custom id manually. Either way it represents the picker's
- *    best knowledge at the moment of commit. The runtime uses it verbatim.
- *  - The stored selection wins over later SDK catalog changes. Refresh
- *    does not retroactively change committed selections.
+ *  - The webview does not commit a `ModelInfo` snapshot.
+ *  - Catalog metadata updates may affect the resolved `ModelInfo` for an
+ *    existing selection unless the user has explicitly overridden the field.
  */
 export interface ModelSelection {
 	readonly providerId: ProviderId
 	readonly modelId: string
+	readonly overrides?: ModelSelectionOverrides
+}
+
+/** A committed selection as read back by consumers that need display/runtime metadata. */
+export interface ResolvedModelSelection extends ModelSelection {
 	readonly modelInfo: ModelInfo
+	/**
+	 * Where the base `modelInfo` came from, before overrides were applied:
+	 *
+	 *  - "catalog"  — SDK catalog metadata (generated snapshot or registry).
+	 *  - "state"    — the mode-specific `*ModeModelInfo` snapshot persisted by
+	 *    the picker at selection time. Authoritative for dynamic-list providers
+	 *    (openrouter, litellm, requesty, …) whose models are not in the static
+	 *    catalog.
+	 *  - "fallback" — provider-safe defaults fabricated because nothing better
+	 *    was available. Consumers should treat a "fallback" resolution without
+	 *    overrides as weak data and prefer live catalog lookups over it.
+	 */
+	readonly modelInfoSource?: "catalog" | "state" | "fallback"
+	/**
+	 * The base metadata `modelInfo` was resolved from, before overrides were
+	 * applied. Persisted (rather than the resolved value) into the legacy
+	 * state snapshot so that deleting an override cannot resurrect it from a
+	 * snapshot it was previously baked into.
+	 */
+	readonly baseModelInfo?: ModelInfo
 }
 
 // ---------------------------------------------------------------------------
@@ -190,7 +233,7 @@ export type ProviderConfigChange =
 			readonly kind: "selection"
 			readonly providerId: ProviderId
 			readonly mode: Mode
-			readonly selection: ModelSelection
+			readonly selection: ResolvedModelSelection
 	  }
 
 export type ProviderConfigChangeListener = (event: ProviderConfigChange) => void
@@ -317,7 +360,7 @@ export interface ProviderModelsEvent {
  */
 export interface ProviderConfigReader {
 	read(providerId: ProviderId): EffectiveProviderConfig
-	readSelection(providerId: ProviderId, mode: Mode): ModelSelection | undefined
+	readSelection(providerId: ProviderId, mode: Mode): ResolvedModelSelection | undefined
 	subscribe(listener: ProviderConfigChangeListener): Disposable
 }
 
@@ -351,8 +394,9 @@ export interface ProviderConfigStore extends ProviderConfigReader {
 	write(providerId: ProviderId, patch: ProviderConfigPatch): EffectiveProviderConfig
 
 	/**
-	 * Commit a model selection atomically with its info envelope. The only
-	 * entry point that writes `{providerId, modelId, modelInfo}` triples.
+	 * Commit a model ID atomically with optional user-authored overrides.
+	 * Supplying overrides replaces that model's stored override entry; omitting
+	 * them leaves the existing entry unchanged.
 	 *
 	 * I2: refresh handlers do not have access to this method by type, since
 	 * `ProviderCatalog` holds only a `ProviderConfigReader`.

--- a/apps/vscode/src/sdk/model-catalog/model-values.ts
+++ b/apps/vscode/src/sdk/model-catalog/model-values.ts
@@ -1,0 +1,45 @@
+import type { ModelInfo } from "@shared/api"
+import { ApiFormat } from "@shared/proto/cline/models"
+
+/** SDK string spelling of an API format (matches @cline/shared ApiFormatSchema). */
+export type SdkApiFormatString = "r1" | "openai-responses" | "default"
+
+export function finiteNumber(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) ? value : undefined
+}
+
+export function positiveFiniteNumber(value: unknown): number | undefined {
+	const number = finiteNumber(value)
+	return number !== undefined && number > 0 ? number : undefined
+}
+
+export function nonNegativeFiniteNumber(value: unknown): number | undefined {
+	const number = finiteNumber(value)
+	return number !== undefined && number >= 0 ? number : undefined
+}
+
+export function toSdkApiFormat(apiFormat: ModelInfo["apiFormat"]): SdkApiFormatString | undefined {
+	switch (apiFormat) {
+		case ApiFormat.R1_CHAT:
+			return "r1"
+		case ApiFormat.OPENAI_RESPONSES:
+			return "openai-responses"
+		case ApiFormat.OPENAI_CHAT:
+			return "default"
+		default:
+			return undefined
+	}
+}
+
+export function fromSdkApiFormat(apiFormat: string | undefined): ModelInfo["apiFormat"] | undefined {
+	switch (apiFormat) {
+		case "r1":
+			return ApiFormat.R1_CHAT
+		case "openai-responses":
+			return ApiFormat.OPENAI_RESPONSES
+		case "default":
+			return ApiFormat.OPENAI_CHAT
+		default:
+			return undefined
+	}
+}

--- a/apps/vscode/src/sdk/model-catalog/store.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/store.test.ts
@@ -1,4 +1,6 @@
-import type { ApiConfiguration, ModelInfo } from "@shared/api"
+import { syncStoredProviderRegistration } from "@cline/core"
+import { type ApiConfiguration, type ModelInfo, openAiModelInfoSafeDefaults } from "@shared/api"
+import { ApiFormat } from "@shared/proto/cline/models"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import type { ProviderConfigChange } from "./contracts"
 import { parseProviderId } from "./provider-id"
@@ -7,6 +9,11 @@ const mocks = vi.hoisted(() => {
 	type MockApiConfiguration = ApiConfiguration & { planActSeparateModelsSetting?: boolean }
 	let apiConfiguration: MockApiConfiguration = {}
 	let providerSettingsById: Record<string, Record<string, unknown>> = {}
+	let generatedModelsByProvider: Record<string, Record<string, ModelInfo>> = {}
+	let modelsFile: { version: 1; providers: Record<string, { models?: Record<string, Record<string, unknown>> }> } = {
+		version: 1,
+		providers: {},
+	}
 	const saveProviderSettings = vi.fn((settings: Record<string, unknown>, _options?: { setLastUsed?: boolean }) => {
 		const provider = settings.provider
 		if (typeof provider !== "string") {
@@ -20,6 +27,8 @@ const mocks = vi.hoisted(() => {
 		reset(): void {
 			apiConfiguration = {}
 			providerSettingsById = {}
+			generatedModelsByProvider = {}
+			modelsFile = { version: 1, providers: {} }
 			saveProviderSettings.mockClear()
 		},
 		setApiConfiguration(value: MockApiConfiguration): void {
@@ -27,6 +36,12 @@ const mocks = vi.hoisted(() => {
 		},
 		setProviderSettings(value: Record<string, Record<string, unknown>>): void {
 			providerSettingsById = { ...value }
+		},
+		setGeneratedModels(providerId: string, models: Record<string, ModelInfo>): void {
+			generatedModelsByProvider = { ...generatedModelsByProvider, [providerId]: models }
+		},
+		getGeneratedModels(providerId: string): Record<string, ModelInfo> {
+			return generatedModelsByProvider[providerId] ?? {}
 		},
 		getSavedProviderSettings(providerId: string): Record<string, unknown> | undefined {
 			return providerSettingsById[providerId]
@@ -36,6 +51,12 @@ const mocks = vi.hoisted(() => {
 		},
 		getSaveProviderSettingsMock(): typeof saveProviderSettings {
 			return saveProviderSettings
+		},
+		getModelsFile() {
+			return modelsFile
+		},
+		setModelsFile(value: typeof modelsFile): void {
+			modelsFile = value
 		},
 		getStateManager() {
 			return {
@@ -69,11 +90,24 @@ vi.mock("../provider-migration", () => ({
 	getProviderSettingsManager: mocks.getProviderSettingsManager,
 }))
 
+vi.mock("@cline/core", () => ({
+	syncStoredProviderRegistration: vi.fn(),
+	readModelsFileSync: vi.fn(() => mocks.getModelsFile()),
+	resolveModelsRegistryPath: vi.fn(() => "/tmp/models.json"),
+	writeModelsFileSync: vi.fn((_filePath: string, state: ReturnType<typeof mocks.getModelsFile>) => mocks.setModelsFile(state)),
+}))
+
+vi.mock("@cline/llms", () => ({
+	getGeneratedModelsForProvider: vi.fn((providerId: string) => mocks.getGeneratedModels(providerId)),
+	MODEL_COLLECTIONS_BY_PROVIDER_ID: {},
+}))
+
 const modelInfoA: ModelInfo = {
 	name: "Model A",
 	contextWindow: 128_000,
 	maxTokens: 8_192,
 	supportsPromptCache: true,
+	apiFormat: ApiFormat.OPENAI_RESPONSES,
 }
 
 const modelInfoB: ModelInfo = {
@@ -83,9 +117,41 @@ const modelInfoB: ModelInfo = {
 	supportsPromptCache: false,
 }
 
+function selectionFromModelInfo(providerId: ReturnType<typeof parseProviderId>, modelId: string, modelInfo: ModelInfo) {
+	const capabilities: string[] = []
+	if (modelInfo.supportsPromptCache) capabilities.push("prompt-cache")
+	if (modelInfo.supportsImages) capabilities.push("images")
+	if (modelInfo.supportsReasoning) capabilities.push("reasoning")
+	return {
+		providerId,
+		modelId,
+		overrides: {
+			name: modelInfo.name,
+			contextWindow: modelInfo.contextWindow,
+			maxTokens: modelInfo.maxTokens,
+			...(modelInfo.apiFormat !== undefined ? { apiFormat: modelInfo.apiFormat } : {}),
+			...(capabilities.length > 0 ? { capabilities } : {}),
+		},
+	}
+}
+
+function expectResolvedSelection(
+	actual: unknown,
+	selection: ReturnType<typeof selectionFromModelInfo>,
+	modelInfo: ModelInfo,
+): void {
+	expect(actual).toMatchObject({
+		providerId: selection.providerId,
+		modelId: selection.modelId,
+		overrides: selection.overrides,
+		modelInfo,
+	})
+}
+
 describe("createProviderConfigStore", () => {
 	beforeEach(() => {
 		mocks.reset()
+		vi.clearAllMocks()
 		vi.resetModules()
 	})
 
@@ -121,22 +187,29 @@ describe("createProviderConfigStore", () => {
 		const { createProviderConfigStore } = await import("./store")
 		const store = createProviderConfigStore()
 		const providerId = parseProviderId("openrouter")
-		const selection = { providerId, modelId: "anthropic/claude-sonnet-4", modelInfo: modelInfoA }
+		const selection = selectionFromModelInfo(providerId, "anthropic/claude-sonnet-4", modelInfoA)
 
 		store.commitSelection(providerId, "act", selection)
 
-		expect(store.readSelection(providerId, "act")).toEqual(selection)
+		expectResolvedSelection(store.readSelection(providerId, "act"), selection, modelInfoA)
+		expect(mocks.getModelsFile().providers.openrouter?.models?.["anthropic/claude-sonnet-4"]).toMatchObject({
+			name: "Model A",
+			contextWindow: 128_000,
+			maxTokens: 8_192,
+			apiFormat: "openai-responses",
+			capabilities: ["prompt-cache"],
+		})
 	})
 
 	it("round-trips generic provider selections using the in-process modelInfo envelope", async () => {
 		const { createProviderConfigStore } = await import("./store")
 		const store = createProviderConfigStore()
 		const providerId = parseProviderId("deepseek")
-		const selection = { providerId, modelId: "deepseek-v4-pro", modelInfo: modelInfoA }
+		const selection = selectionFromModelInfo(providerId, "deepseek-v4-pro", modelInfoA)
 
 		store.commitSelection(providerId, "act", selection)
 
-		expect(store.readSelection(providerId, "act")).toEqual(selection)
+		expectResolvedSelection(store.readSelection(providerId, "act"), selection, modelInfoA)
 	})
 
 	it("hydrates a generic provider selection from providers.json after reload", async () => {
@@ -148,6 +221,8 @@ describe("createProviderConfigStore", () => {
 		expect(store.readSelection(providerId, "act")).toEqual({
 			providerId,
 			modelId: "manual-zai-model",
+			modelInfoSource: "fallback",
+			baseModelInfo: expect.objectContaining({ name: "manual-zai-model" }),
 			modelInfo: expect.objectContaining({
 				name: "manual-zai-model",
 				supportsPromptCache: false,
@@ -160,27 +235,27 @@ describe("createProviderConfigStore", () => {
 		const store = createProviderConfigStore()
 		const geminiProviderId = parseProviderId("gemini")
 		const deepSeekProviderId = parseProviderId("deepseek")
-		const geminiSelection = { providerId: geminiProviderId, modelId: "gemini-3.1-pro-preview", modelInfo: modelInfoA }
-		const deepSeekSelection = { providerId: deepSeekProviderId, modelId: "deepseek-v4-pro", modelInfo: modelInfoB }
+		const geminiSelection = selectionFromModelInfo(geminiProviderId, "gemini-3.1-pro-preview", modelInfoA)
+		const deepSeekSelection = selectionFromModelInfo(deepSeekProviderId, "deepseek-v4-pro", modelInfoB)
 
 		store.commitSelection(geminiProviderId, "act", geminiSelection)
 		store.commitSelection(deepSeekProviderId, "act", deepSeekSelection)
 
-		expect(store.readSelection(geminiProviderId, "act")).toEqual(geminiSelection)
-		expect(store.readSelection(deepSeekProviderId, "act")).toEqual(deepSeekSelection)
+		expectResolvedSelection(store.readSelection(geminiProviderId, "act"), geminiSelection, modelInfoA)
+		expectResolvedSelection(store.readSelection(deepSeekProviderId, "act"), deepSeekSelection, modelInfoB)
 	})
 
 	it("handles normalized nousResearch provider casing for writes and selections", async () => {
 		const { createProviderConfigStore } = await import("./store")
 		const store = createProviderConfigStore()
 		const providerId = parseProviderId("nousResearch")
-		const selection = { providerId, modelId: "nousresearch/hermes-4-70b", modelInfo: modelInfoA }
+		const selection = selectionFromModelInfo(providerId, "nousresearch/hermes-4-70b", modelInfoA)
 
 		const written = store.write(providerId, { apiKey: "nous-key" })
 		store.commitSelection(providerId, "act", selection)
 
 		expect(written).toEqual({ providerId, apiKey: "nous-key" })
-		expect(store.readSelection(providerId, "act")).toEqual(selection)
+		expectResolvedSelection(store.readSelection(providerId, "act"), selection, modelInfoA)
 		expect(mocks.getSavedProviderSettings("nousResearch")).toMatchObject({
 			provider: "nousResearch",
 			apiKey: "nous-key",
@@ -227,6 +302,179 @@ describe("createProviderConfigStore", () => {
 		})
 	})
 
+	it("lazily migrates meaningful legacy custom-model metadata once", async () => {
+		const legacyModelInfo = {
+			name: "Legacy Custom",
+			maxTokens: 4_096,
+			contextWindow: 64_000,
+			supportsImages: false,
+			supportsPromptCache: true,
+			supportsReasoning: true,
+			inputPrice: 1,
+			outputPrice: 2,
+			cacheReadsPrice: 0.25,
+			cacheWritesPrice: 0.5,
+			temperature: 0.3,
+			apiFormat: ApiFormat.OPENAI_RESPONSES,
+			isR1FormatRequired: true,
+		}
+		mocks.setApiConfiguration({
+			actModeOpenAiModelId: "legacy-custom",
+			actModeOpenAiModelInfo: legacyModelInfo,
+		})
+		const { createProviderConfigStore } = await import("./store")
+		const store = createProviderConfigStore()
+		const providerId = parseProviderId("openai")
+
+		const first = store.readSelection(providerId, "act")
+		const second = store.readSelection(providerId, "act")
+
+		expect(mocks.getModelsFile().providers["openai-compatible"]?.models?.["legacy-custom"]).toEqual({
+			name: "Legacy Custom",
+			maxTokens: 4_096,
+			contextWindow: 64_000,
+			capabilities: ["prompt-cache"],
+			supportsVision: false,
+			supportsReasoning: true,
+			inputPrice: 1,
+			outputPrice: 2,
+			cacheReadsPrice: 0.25,
+			cacheWritesPrice: 0.5,
+			temperature: 0.3,
+			apiFormat: "openai-responses",
+			isR1FormatRequired: true,
+		})
+		expect(first?.overrides).toEqual(second?.overrides)
+		expect(first?.modelInfo).toMatchObject({
+			name: "Legacy Custom",
+			maxTokens: 4_096,
+			contextWindow: 64_000,
+			supportsImages: false,
+			supportsPromptCache: true,
+			supportsReasoning: true,
+			inputPrice: 1,
+			outputPrice: 2,
+			cacheReadsPrice: 0.25,
+			cacheWritesPrice: 0.5,
+			temperature: 0.3,
+			apiFormat: ApiFormat.R1_CHAT,
+		})
+		expect(syncStoredProviderRegistration).toHaveBeenCalledTimes(1)
+	})
+
+	it("does not create migration noise for legacy safe defaults", async () => {
+		mocks.setApiConfiguration({
+			actModeOpenAiModelId: "default-custom",
+			actModeOpenAiModelInfo: { ...openAiModelInfoSafeDefaults, name: "default-custom" },
+		})
+		const { createProviderConfigStore } = await import("./store")
+		const store = createProviderConfigStore()
+		const providerId = parseProviderId("openai")
+
+		const first = store.readSelection(providerId, "act")
+		const second = store.readSelection(providerId, "act")
+
+		expect(mocks.getModelsFile().providers["openai-compatible"]?.models?.["default-custom"]).toBeUndefined()
+		expect(first?.overrides).toBeUndefined()
+		expect(second?.overrides).toBeUndefined()
+		expect(first?.modelInfo).toMatchObject({ contextWindow: 128_000, supportsImages: true, temperature: 0 })
+		expect(first?.modelInfo.maxTokens).toBeUndefined()
+		expect(syncStoredProviderRegistration).not.toHaveBeenCalled()
+	})
+
+	it("never overwrites an existing models.json entry during migration", async () => {
+		mocks.setModelsFile({
+			version: 1,
+			providers: {
+				"openai-compatible": { models: { "existing-custom": { temperature: 0.7 } } },
+			},
+		})
+		mocks.setApiConfiguration({
+			actModeOpenAiModelId: "existing-custom",
+			actModeOpenAiModelInfo: { ...openAiModelInfoSafeDefaults, temperature: 0.2 },
+		})
+		const { createProviderConfigStore } = await import("./store")
+		const store = createProviderConfigStore()
+		const providerId = parseProviderId("openai")
+
+		const selection = store.readSelection(providerId, "act")
+
+		expect(mocks.getModelsFile().providers["openai-compatible"]?.models?.["existing-custom"]).toEqual({
+			temperature: 0.7,
+		})
+		expect(selection?.overrides).toEqual({ temperature: 0.7 })
+		expect(selection?.modelInfo.temperature).toBe(0.7)
+		expect(syncStoredProviderRegistration).not.toHaveBeenCalled()
+	})
+
+	it("does not migrate stale legacy snapshots for catalog-known models", async () => {
+		mocks.setGeneratedModels("openai-compatible", {
+			"known-model": {
+				name: "Current Catalog Model",
+				contextWindow: 256_000,
+				supportsPromptCache: false,
+				temperature: 0.1,
+			},
+		})
+		mocks.setApiConfiguration({
+			actModeOpenAiModelId: "known-model",
+			actModeOpenAiModelInfo: {
+				name: "Stale Catalog Model",
+				contextWindow: 32_000,
+				supportsPromptCache: false,
+				temperature: 0.9,
+			},
+		})
+		const { createProviderConfigStore } = await import("./store")
+		const store = createProviderConfigStore()
+		const providerId = parseProviderId("openai")
+
+		const selection = store.readSelection(providerId, "act")
+
+		expect(mocks.getModelsFile().providers["openai-compatible"]?.models?.["known-model"]).toBeUndefined()
+		expect(selection?.overrides).toBeUndefined()
+		expect(selection?.modelInfo).toMatchObject({
+			name: "Current Catalog Model",
+			contextWindow: 256_000,
+			temperature: 0.1,
+		})
+		expect(syncStoredProviderRegistration).not.toHaveBeenCalled()
+	})
+
+	it("migrates separate Plan and Act legacy custom models independently", async () => {
+		mocks.setApiConfiguration({
+			planActSeparateModelsSetting: true,
+			planModeOpenAiModelId: "legacy-plan",
+			planModeOpenAiModelInfo: {
+				...openAiModelInfoSafeDefaults,
+				contextWindow: 64_000,
+				apiFormat: ApiFormat.OPENAI_RESPONSES,
+			},
+			actModeOpenAiModelId: "legacy-act",
+			actModeOpenAiModelInfo: {
+				...openAiModelInfoSafeDefaults,
+				maxTokens: 2_048,
+				isR1FormatRequired: true,
+			},
+		})
+		const { createProviderConfigStore } = await import("./store")
+		const store = createProviderConfigStore()
+		const providerId = parseProviderId("openai")
+
+		const plan = store.readSelection(providerId, "plan")
+		const act = store.readSelection(providerId, "act")
+		store.readSelection(providerId, "plan")
+		store.readSelection(providerId, "act")
+
+		expect(mocks.getModelsFile().providers["openai-compatible"]?.models).toMatchObject({
+			"legacy-plan": { contextWindow: 64_000, apiFormat: "openai-responses" },
+			"legacy-act": { maxTokens: 2_048, isR1FormatRequired: true },
+		})
+		expect(plan?.modelInfo).toMatchObject({ contextWindow: 64_000, apiFormat: ApiFormat.OPENAI_RESPONSES })
+		expect(act?.modelInfo).toMatchObject({ maxTokens: 2_048, apiFormat: ApiFormat.R1_CHAT })
+		expect(syncStoredProviderRegistration).toHaveBeenCalledTimes(2)
+	})
+
 	it("preserves migrated OpenAI Compatible settings when committing model selections", async () => {
 		const { createProviderConfigStore } = await import("./store")
 		mocks.setProviderSettings({
@@ -237,7 +485,7 @@ describe("createProviderConfigStore", () => {
 		})
 		const store = createProviderConfigStore()
 		const providerId = parseProviderId("openai")
-		const selection = { providerId, modelId: "gpt-oss-120b", modelInfo: modelInfoA }
+		const selection = selectionFromModelInfo(providerId, "gpt-oss-120b", modelInfoA)
 
 		store.commitSelection(providerId, "act", selection)
 
@@ -245,6 +493,242 @@ describe("createProviderConfigStore", () => {
 			provider: "openai-compatible",
 			apiKey: "migrated-openai-compatible-key",
 			model: "gpt-oss-120b",
+		})
+	})
+
+	it("preserves per-model OpenAI Compatible overrides when switching models without new overrides", async () => {
+		const { createProviderConfigStore } = await import("./store")
+		const store = createProviderConfigStore()
+		const providerId = parseProviderId("openai")
+		const modelASelection = selectionFromModelInfo(providerId, "model-a", modelInfoA)
+
+		store.commitSelection(providerId, "act", modelASelection)
+		store.commitSelection(providerId, "act", { providerId, modelId: "model-b" })
+		store.commitSelection(providerId, "act", { providerId, modelId: "model-a" })
+
+		expectResolvedSelection(store.readSelection(providerId, "act"), modelASelection, modelInfoA)
+		expect(mocks.getModelsFile().providers["openai-compatible"]?.models?.["model-a"]).toMatchObject({
+			name: "Model A",
+			maxTokens: 8_192,
+			contextWindow: 128_000,
+		})
+	})
+
+	it("deletes a model entry when an explicit replacement override set is empty", async () => {
+		const { createProviderConfigStore } = await import("./store")
+		const store = createProviderConfigStore()
+		const providerId = parseProviderId("openai")
+
+		store.commitSelection(providerId, "act", {
+			providerId,
+			modelId: "custom-model",
+			overrides: {
+				apiFormat: ApiFormat.OPENAI_RESPONSES,
+				capabilities: ["tools", "streaming"],
+				temperature: 0.2,
+			},
+		})
+		expect(mocks.getModelsFile().providers["openai-compatible"]?.models?.["custom-model"]).toMatchObject({
+			apiFormat: "openai-responses",
+			capabilities: ["tools", "streaming"],
+			temperature: 0.2,
+		})
+
+		store.commitSelection(providerId, "act", { providerId, modelId: "custom-model", overrides: {} })
+
+		expect(mocks.getModelsFile().providers["openai-compatible"]?.models?.["custom-model"]).toBeUndefined()
+		expect(store.readSelection(providerId, "act")?.overrides).toBeUndefined()
+	})
+
+	it("replaces an existing model override set instead of merging stale fields", async () => {
+		const { createProviderConfigStore } = await import("./store")
+		const store = createProviderConfigStore()
+		const providerId = parseProviderId("openai")
+
+		store.commitSelection(providerId, "act", {
+			providerId,
+			modelId: "custom-model",
+			overrides: { apiFormat: ApiFormat.OPENAI_RESPONSES, inputPrice: 1, temperature: 0.2 },
+		})
+		store.commitSelection(providerId, "act", {
+			providerId,
+			modelId: "custom-model",
+			overrides: { temperature: 0.4 },
+		})
+
+		expect(mocks.getModelsFile().providers["openai-compatible"]?.models?.["custom-model"]).toEqual({ temperature: 0.4 })
+		expect(store.readSelection(providerId, "act")?.overrides).toEqual({ temperature: 0.4 })
+	})
+
+	it.each([
+		[ApiFormat.OPENAI_CHAT, "default"],
+		[ApiFormat.R1_CHAT, "r1"],
+		[ApiFormat.OPENAI_RESPONSES, "openai-responses"],
+	] as const)("round-trips supported apiFormat %s through models.json", async (apiFormat, storedApiFormat) => {
+		const { createProviderConfigStore } = await import("./store")
+		const store = createProviderConfigStore()
+		const providerId = parseProviderId("openai")
+
+		store.commitSelection(providerId, "act", {
+			providerId,
+			modelId: "custom-model",
+			overrides: { apiFormat },
+		})
+
+		expect(mocks.getModelsFile().providers["openai-compatible"]?.models?.["custom-model"]).toEqual({
+			apiFormat: storedApiFormat,
+		})
+		expect(store.readSelection(providerId, "act")?.overrides).toEqual({ apiFormat })
+	})
+
+	it("normalizes invalid override values before storage and resolved legacy state", async () => {
+		const { createProviderConfigStore } = await import("./store")
+		const store = createProviderConfigStore()
+		const providerId = parseProviderId("openai")
+
+		store.commitSelection(providerId, "act", {
+			providerId,
+			modelId: "custom-model",
+			overrides: {
+				name: "Custom model",
+				maxTokens: -1,
+				contextWindow: Number.POSITIVE_INFINITY,
+				maxInputTokens: 0,
+				capabilities: ["tools", "tools", "vision", "unknown"],
+				supportsVision: false,
+				supportsReasoning: false,
+				inputPrice: Number.NaN,
+				outputPrice: 2,
+				cacheReadsPrice: 0,
+				cacheWritesPrice: -1,
+				temperature: -1,
+				apiFormat: 999 as ApiFormat,
+			},
+		})
+
+		expect(mocks.getModelsFile().providers["openai-compatible"]?.models?.["custom-model"]).toEqual({
+			name: "Custom model",
+			capabilities: ["tools"],
+			supportsVision: false,
+			supportsReasoning: false,
+			outputPrice: 2,
+			cacheReadsPrice: 0,
+		})
+		const selection = store.readSelection(providerId, "act")
+		expect(selection?.overrides).toEqual({
+			name: "Custom model",
+			capabilities: ["tools"],
+			supportsVision: false,
+			supportsReasoning: false,
+			outputPrice: 2,
+			cacheReadsPrice: 0,
+		})
+		expect(selection?.modelInfo.maxTokens).toBeUndefined()
+		expect(selection?.modelInfo.temperature).toBe(0)
+		expect(mocks.getApiConfiguration().actModeOpenAiModelInfo).not.toHaveProperty("maxTokens")
+		expect(mocks.getApiConfiguration().actModeOpenAiModelInfo).not.toHaveProperty("temperature", -1)
+		expect(syncStoredProviderRegistration).toHaveBeenCalledTimes(1)
+	})
+
+	it("deletes a stored entry when normalization removes every replacement field", async () => {
+		const { createProviderConfigStore } = await import("./store")
+		const store = createProviderConfigStore()
+		const providerId = parseProviderId("openai")
+
+		store.commitSelection(providerId, "act", {
+			providerId,
+			modelId: "custom-model",
+			overrides: { temperature: 0.2 },
+		})
+		store.commitSelection(providerId, "act", {
+			providerId,
+			modelId: "custom-model",
+			overrides: {
+				maxTokens: -1,
+				contextWindow: 0,
+				capabilities: ["vision", "unknown"],
+				inputPrice: Number.NaN,
+				temperature: -1,
+				apiFormat: 999 as ApiFormat,
+			},
+		})
+
+		expect(mocks.getModelsFile().providers["openai-compatible"]?.models?.["custom-model"]).toBeUndefined()
+		expect(store.readSelection(providerId, "act")?.overrides).toBeUndefined()
+		expect(syncStoredProviderRegistration).toHaveBeenCalledTimes(2)
+	})
+
+	it("normalizes invalid values already present in models.json on read", async () => {
+		const { createProviderConfigStore } = await import("./store")
+		mocks.setProviderSettings({
+			"openai-compatible": { provider: "openai-compatible", model: "custom-model" },
+		})
+		mocks.setModelsFile({
+			version: 1,
+			providers: {
+				"openai-compatible": {
+					models: {
+						"custom-model": {
+							maxTokens: -1,
+							contextWindow: 64_000,
+							inputPrice: -2,
+							temperature: -1,
+							capabilities: ["tools"],
+						},
+					},
+				},
+			},
+		})
+		const store = createProviderConfigStore()
+		const providerId = parseProviderId("openai")
+
+		const selection = store.readSelection(providerId, "act")
+
+		expect(selection?.overrides).toEqual({ contextWindow: 64_000, capabilities: ["tools"] })
+		expect(selection?.modelInfo.maxTokens).toBeUndefined()
+		expect(selection?.modelInfo.temperature).toBe(0)
+		expect(syncStoredProviderRegistration).not.toHaveBeenCalled()
+	})
+
+	it("lets explicit capability booleans win and applies the R1 alias deterministically", async () => {
+		const { createProviderConfigStore } = await import("./store")
+		const store = createProviderConfigStore()
+		const providerId = parseProviderId("openai")
+
+		store.commitSelection(providerId, "act", {
+			providerId,
+			modelId: "custom-model",
+			overrides: {
+				apiFormat: ApiFormat.OPENAI_RESPONSES,
+				capabilities: ["images", "prompt-cache", "reasoning"],
+				supportsVision: false,
+				supportsReasoning: false,
+				isR1FormatRequired: false,
+			},
+		})
+		let selection = store.readSelection(providerId, "act")
+		expect(selection?.modelInfo).toMatchObject({
+			supportsImages: false,
+			supportsPromptCache: true,
+			supportsReasoning: false,
+			apiFormat: ApiFormat.OPENAI_RESPONSES,
+		})
+
+		store.commitSelection(providerId, "act", {
+			providerId,
+			modelId: "custom-model",
+			overrides: {
+				apiFormat: ApiFormat.OPENAI_RESPONSES,
+				capabilities: ["prompt-cache"],
+				supportsVision: true,
+				isR1FormatRequired: true,
+			},
+		})
+		selection = store.readSelection(providerId, "act")
+		expect(selection?.modelInfo).toMatchObject({
+			supportsImages: true,
+			supportsPromptCache: true,
+			apiFormat: ApiFormat.R1_CHAT,
 		})
 	})
 
@@ -259,14 +743,14 @@ describe("createProviderConfigStore", () => {
 		})
 		const store = createProviderConfigStore()
 		const providerId = parseProviderId("openai")
-		const planSelection = { providerId, modelId: "plan-openai-model", modelInfo: modelInfoA }
-		const actSelection = { providerId, modelId: "act-openai-model", modelInfo: modelInfoB }
+		const planSelection = selectionFromModelInfo(providerId, "plan-openai-model", modelInfoA)
+		const actSelection = selectionFromModelInfo(providerId, "act-openai-model", modelInfoB)
 
 		store.commitSelection(providerId, "plan", planSelection)
 		store.commitSelection(providerId, "act", actSelection)
 
-		expect(store.readSelection(providerId, "plan")).toEqual(planSelection)
-		expect(store.readSelection(providerId, "act")).toEqual(actSelection)
+		expectResolvedSelection(store.readSelection(providerId, "plan"), planSelection, modelInfoA)
+		expectResolvedSelection(store.readSelection(providerId, "act"), actSelection, modelInfoB)
 		expect(mocks.getApiConfiguration()).toMatchObject({
 			planModeOpenAiModelId: "plan-openai-model",
 			planModeOpenAiModelInfo: modelInfoA,
@@ -286,12 +770,12 @@ describe("createProviderConfigStore", () => {
 		mocks.setApiConfiguration({ planActSeparateModelsSetting: false })
 		const store = createProviderConfigStore()
 		const providerId = parseProviderId("openai")
-		const selection = { providerId, modelId: "shared-openai-model", modelInfo: modelInfoA }
+		const selection = selectionFromModelInfo(providerId, "shared-openai-model", modelInfoA)
 
 		store.commitSelection(providerId, "act", selection)
 
-		expect(store.readSelection(providerId, "plan")).toEqual(selection)
-		expect(store.readSelection(providerId, "act")).toEqual(selection)
+		expectResolvedSelection(store.readSelection(providerId, "plan"), selection, modelInfoA)
+		expectResolvedSelection(store.readSelection(providerId, "act"), selection, modelInfoA)
 		expect(mocks.getApiConfiguration()).toMatchObject({
 			planModeOpenAiModelId: "shared-openai-model",
 			planModeOpenAiModelInfo: modelInfoA,
@@ -320,14 +804,22 @@ describe("createProviderConfigStore", () => {
 		expect(mocks.getApiConfiguration().zaiApiKey).toBe("shared-zai-key")
 	})
 
-	it("returns undefined from readSelection when modelId or modelInfo is missing", async () => {
+	it("resolves a bare state modelId with fallback metadata and ignores a bare modelInfo", async () => {
 		const { createProviderConfigStore } = await import("./store")
 		const store = createProviderConfigStore()
 		const providerId = parseProviderId("openrouter")
 
+		// The mode-specific model id alone identifies the selection; commits
+		// whose resolution was pure fallback intentionally leave the state
+		// modelInfo snapshot unset.
 		mocks.setApiConfiguration({ actModeOpenRouterModelId: "anthropic/claude-sonnet-4" })
-		expect(store.readSelection(providerId, "act")).toBeUndefined()
+		expect(store.readSelection(providerId, "act")).toMatchObject({
+			providerId,
+			modelId: "anthropic/claude-sonnet-4",
+			modelInfoSource: "fallback",
+		})
 
+		// A modelInfo snapshot without a model id is not a selection.
 		mocks.setApiConfiguration({ actModeOpenRouterModelInfo: modelInfoA })
 		expect(store.readSelection(providerId, "act")).toBeUndefined()
 	})
@@ -337,14 +829,14 @@ describe("createProviderConfigStore", () => {
 		mocks.setApiConfiguration({ planActSeparateModelsSetting: true })
 		const store = createProviderConfigStore()
 		const providerId = parseProviderId("openrouter")
-		const planSelection = { providerId, modelId: "provider/model-a", modelInfo: modelInfoA }
-		const actSelection = { providerId, modelId: "provider/model-b", modelInfo: modelInfoB }
+		const planSelection = selectionFromModelInfo(providerId, "provider/model-a", modelInfoA)
+		const actSelection = selectionFromModelInfo(providerId, "provider/model-b", modelInfoB)
 
 		store.commitSelection(providerId, "plan", planSelection)
 		store.commitSelection(providerId, "act", actSelection)
 
-		expect(store.readSelection(providerId, "plan")).toEqual(planSelection)
-		expect(store.readSelection(providerId, "act")).toEqual(actSelection)
+		expectResolvedSelection(store.readSelection(providerId, "plan"), planSelection, modelInfoA)
+		expectResolvedSelection(store.readSelection(providerId, "act"), actSelection, modelInfoB)
 		expect(mocks.getSavedProviderSettings("openrouter")).toMatchObject({
 			provider: "openrouter",
 			model: "provider/model-b",
@@ -361,7 +853,7 @@ describe("createProviderConfigStore", () => {
 		})
 		const store = createProviderConfigStore()
 		const providerId = parseProviderId("openrouter")
-		const selection = { providerId, modelId: "provider/model-a", modelInfo: modelInfoA }
+		const selection = selectionFromModelInfo(providerId, "provider/model-a", modelInfoA)
 
 		store.commitSelection(providerId, "act", selection)
 
@@ -381,7 +873,7 @@ describe("createProviderConfigStore", () => {
 		const { createProviderConfigStore } = await import("./store")
 		const store = createProviderConfigStore()
 		const providerId = parseProviderId("claude-code")
-		const selection = { providerId, modelId: "haiku", modelInfo: modelInfoA }
+		const selection = selectionFromModelInfo(providerId, "haiku", modelInfoA)
 
 		store.commitSelection(providerId, "act", selection)
 
@@ -423,7 +915,7 @@ describe("createProviderConfigStore", () => {
 		const store = createProviderConfigStore()
 		const providerId = parseProviderId("openrouter")
 		const events: ProviderConfigChange[] = []
-		const selection = { providerId, modelId: "provider/model-a", modelInfo: modelInfoA }
+		const selection = selectionFromModelInfo(providerId, "provider/model-a", modelInfoA)
 
 		store.subscribe((event) => events.push(event))
 		store.write(providerId, { apiKey: "openrouter-key" })
@@ -431,7 +923,12 @@ describe("createProviderConfigStore", () => {
 
 		expect(events.map((event) => event.kind)).toEqual(["fields", "selection"])
 		expect(events[0]).toMatchObject({ kind: "fields", providerId })
-		expect(events[1]).toEqual({ kind: "selection", providerId, mode: "act", selection })
+		expect(events[1]).toEqual({
+			kind: "selection",
+			providerId,
+			mode: "act",
+			selection: store.readSelection(providerId, "act"),
+		})
 	})
 
 	it("dispose unregisters listeners", async () => {
@@ -445,5 +942,51 @@ describe("createProviderConfigStore", () => {
 		store.write(providerId, { apiKey: "deepseek-key" })
 
 		expect(listener).not.toHaveBeenCalled()
+	})
+
+	// Contract test against the REAL SDK schemas (imported by relative path,
+	// bypassing the @cline/core mock above): the store's converters must pass
+	// every SDK capability through, and a fully-populated stored entry must
+	// parse under the schema `writeModelsFileSync` enforces in production.
+	it("round-trips every SDK model capability and a full override set under the real stored-entry schema", async () => {
+		const { ModelCapabilitySchema } = await import("@cline/shared")
+		// vi.importActual bypasses the @cline/core mock above and resolves via
+		// the vitest alias to the stub, which re-exports the real schema.
+		const { StoredModelEntrySchema } = (await vi.importActual("@cline/core")) as {
+			StoredModelEntrySchema: { parse(input: unknown): unknown }
+		}
+		const { createProviderConfigStore } = await import("./store")
+		const store = createProviderConfigStore()
+		const providerId = parseProviderId("openai")
+
+		store.commitSelection(providerId, "act", {
+			providerId,
+			modelId: "contract-model",
+			overrides: {
+				name: "Contract Model",
+				maxTokens: 1024,
+				contextWindow: 200_000,
+				maxInputTokens: 100_000,
+				capabilities: [...ModelCapabilitySchema.options],
+				supportsVision: true,
+				supportsAttachments: true,
+				supportsReasoning: true,
+				inputPrice: 0.5,
+				outputPrice: 1.5,
+				cacheReadsPrice: 0.1,
+				cacheWritesPrice: 0.2,
+				temperature: 0.7,
+				apiFormat: ApiFormat.OPENAI_RESPONSES,
+				isR1FormatRequired: true,
+			},
+		})
+
+		const entry = mocks.getModelsFile().providers["openai-compatible"]?.models?.["contract-model"]
+		expect(entry).toBeDefined()
+		// No SDK capability may be silently stripped by the store's converter.
+		expect([...(entry?.capabilities as string[])].sort()).toEqual([...ModelCapabilitySchema.options].sort())
+		// The entry written by the extension must satisfy the real schema that
+		// the SDK's writeModelsFileSync enforces.
+		expect(() => StoredModelEntrySchema.parse(entry)).not.toThrow()
 	})
 })

--- a/apps/vscode/src/sdk/model-catalog/store.ts
+++ b/apps/vscode/src/sdk/model-catalog/store.ts
@@ -1,5 +1,15 @@
+import {
+	readModelsFileSync,
+	resolveModelsRegistryPath,
+	type StoredModelEntry,
+	syncStoredProviderRegistration,
+	writeModelsFileSync,
+} from "@cline/core"
 import { getGeneratedModelsForProvider, MODEL_COLLECTIONS_BY_PROVIDER_ID } from "@cline/llms"
+import { ModelCapabilitySchema } from "@cline/shared"
 import { type ApiConfiguration, type ApiProvider, type ModelInfo, openAiModelInfoSafeDefaults } from "@shared/api"
+import { ApiFormat } from "@shared/proto/cline/models"
+import { Logger } from "@shared/services/Logger"
 import { getProviderModelIdKey } from "@shared/storage/provider-keys"
 import { isSecretKey, isSettingsKey, type SecretKey, type SettingsKey } from "@shared/storage/state-keys"
 import { StateManager } from "@/core/storage/StateManager"
@@ -9,14 +19,17 @@ import type {
 	EffectiveProviderConfig,
 	Mode,
 	ModelSelection,
+	ModelSelectionOverrides,
 	ProviderConfigChange,
 	ProviderConfigChangeListener,
 	ProviderConfigPatch,
 	ProviderConfigStore,
 	ProviderId,
+	ResolvedModelSelection,
 } from "./contracts"
 import { buildEffectiveProviderConfig } from "./effective-config"
 import { applyHostModelInfoOverrides } from "./host-overrides"
+import { fromSdkApiFormat, nonNegativeFiniteNumber, positiveFiniteNumber, toSdkApiFormat } from "./model-values"
 import { toSdkProviderId } from "./sdk-provider-id"
 import { adaptSdkModelInfo } from "./shape-adapter"
 
@@ -113,7 +126,7 @@ const modelInfoKeysByProvider: Partial<Record<string, ModelInfoKeys>> = {
 // provider+mode so that switching between providers that share the same
 // `*ModeApiModelId` key does not combine one provider's model id with
 // another provider's model info.
-const selectionMemory = new Map<string, ModelSelection>()
+const selectionMemory = new Map<string, ResolvedModelSelection>()
 
 function providerKey(providerId: ProviderId): string {
 	return providerId.toString()
@@ -168,11 +181,210 @@ function readProviderSettingsModelId(providerId: ProviderId): string | undefined
 	return typeof model === "string" && model.trim().length > 0 ? model.trim() : undefined
 }
 
-function fallbackModelInfo(modelId: string): ModelInfo {
-	return { ...openAiModelInfoSafeDefaults, name: modelId }
+function sanitizeResolvedModelInfo(modelInfo: ModelInfo): ModelInfo {
+	const next = { ...modelInfo }
+	if (positiveFiniteNumber(next.maxTokens) === undefined) delete next.maxTokens
+	if (nonNegativeFiniteNumber(next.temperature) === undefined) delete next.temperature
+	return next
 }
 
-function readKnownModelInfoForProvider(providerId: ProviderId, modelId: string): ModelInfo | undefined {
+function fallbackModelInfo(modelId: string): ModelInfo {
+	return sanitizeResolvedModelInfo({ ...openAiModelInfoSafeDefaults, name: modelId })
+}
+
+function toStoredCapabilities(capabilities: readonly string[] | undefined): StoredModelEntry["capabilities"] | undefined {
+	if (!capabilities) {
+		return undefined
+	}
+	// Validate against the SDK schema rather than a hardcoded list so new
+	// capabilities added to ModelCapabilitySchema are never silently stripped.
+	const next = new Set<NonNullable<StoredModelEntry["capabilities"]>[number]>()
+	for (const capability of capabilities) {
+		const parsed = ModelCapabilitySchema.safeParse(capability)
+		if (parsed.success) {
+			next.add(parsed.data)
+		}
+	}
+	return next.size > 0 ? [...next] : undefined
+}
+
+function toStoredApiFormat(apiFormat: ModelInfo["apiFormat"]): StoredModelEntry["apiFormat"] | undefined {
+	return toSdkApiFormat(apiFormat)
+}
+
+function fromStoredApiFormat(apiFormat: StoredModelEntry["apiFormat"]): ModelInfo["apiFormat"] | undefined {
+	return fromSdkApiFormat(apiFormat)
+}
+
+function readModelsState() {
+	return readModelsFileSync(resolveModelsRegistryPath(getProviderSettingsManager()))
+}
+
+/**
+ * Normalizes user-authored model metadata at the host/storage boundary.
+ * Token limits must be positive, prices and temperatures non-negative, and
+ * unsupported capabilities/formats are omitted. UI sentinels never cross
+ * this boundary; an object with no meaningful fields becomes undefined.
+ */
+function normalizeModelSelectionOverrides(overrides: ModelSelectionOverrides | undefined): ModelSelectionOverrides | undefined {
+	if (!overrides) {
+		return undefined
+	}
+	const maxTokens = positiveFiniteNumber(overrides.maxTokens)
+	const contextWindow = positiveFiniteNumber(overrides.contextWindow)
+	const maxInputTokens = positiveFiniteNumber(overrides.maxInputTokens)
+	const capabilities = toStoredCapabilities(overrides.capabilities)
+	const inputPrice = nonNegativeFiniteNumber(overrides.inputPrice)
+	const outputPrice = nonNegativeFiniteNumber(overrides.outputPrice)
+	const cacheReadsPrice = nonNegativeFiniteNumber(overrides.cacheReadsPrice)
+	const cacheWritesPrice = nonNegativeFiniteNumber(overrides.cacheWritesPrice)
+	const temperature = nonNegativeFiniteNumber(overrides.temperature)
+	const apiFormat = toStoredApiFormat(overrides.apiFormat) !== undefined ? overrides.apiFormat : undefined
+	const next: ModelSelectionOverrides = {
+		...(overrides.name !== undefined ? { name: overrides.name } : {}),
+		...(maxTokens !== undefined ? { maxTokens } : {}),
+		...(contextWindow !== undefined ? { contextWindow } : {}),
+		...(maxInputTokens !== undefined ? { maxInputTokens } : {}),
+		...(capabilities !== undefined ? { capabilities } : {}),
+		...(overrides.supportsVision !== undefined ? { supportsVision: overrides.supportsVision } : {}),
+		...(overrides.supportsAttachments !== undefined ? { supportsAttachments: overrides.supportsAttachments } : {}),
+		...(overrides.supportsReasoning !== undefined ? { supportsReasoning: overrides.supportsReasoning } : {}),
+		...(inputPrice !== undefined ? { inputPrice } : {}),
+		...(outputPrice !== undefined ? { outputPrice } : {}),
+		...(cacheReadsPrice !== undefined ? { cacheReadsPrice } : {}),
+		...(cacheWritesPrice !== undefined ? { cacheWritesPrice } : {}),
+		...(temperature !== undefined ? { temperature } : {}),
+		...(apiFormat !== undefined ? { apiFormat } : {}),
+		...(overrides.isR1FormatRequired !== undefined ? { isR1FormatRequired: overrides.isR1FormatRequired } : {}),
+	}
+	return Object.keys(next).length > 0 ? next : undefined
+}
+
+function toStoredModelEntry(overrides: ModelSelectionOverrides): StoredModelEntry {
+	const capabilities = toStoredCapabilities(overrides.capabilities)
+	const apiFormat = toStoredApiFormat(overrides.apiFormat)
+	return {
+		...(overrides.name !== undefined ? { name: overrides.name } : {}),
+		...(overrides.maxTokens !== undefined ? { maxTokens: overrides.maxTokens } : {}),
+		...(overrides.contextWindow !== undefined ? { contextWindow: overrides.contextWindow } : {}),
+		...(overrides.maxInputTokens !== undefined ? { maxInputTokens: overrides.maxInputTokens } : {}),
+		...(capabilities !== undefined ? { capabilities } : {}),
+		...(overrides.supportsVision !== undefined ? { supportsVision: overrides.supportsVision } : {}),
+		...(overrides.supportsAttachments !== undefined ? { supportsAttachments: overrides.supportsAttachments } : {}),
+		...(overrides.supportsReasoning !== undefined ? { supportsReasoning: overrides.supportsReasoning } : {}),
+		...(overrides.inputPrice !== undefined ? { inputPrice: overrides.inputPrice } : {}),
+		...(overrides.outputPrice !== undefined ? { outputPrice: overrides.outputPrice } : {}),
+		...(overrides.cacheReadsPrice !== undefined ? { cacheReadsPrice: overrides.cacheReadsPrice } : {}),
+		...(overrides.cacheWritesPrice !== undefined ? { cacheWritesPrice: overrides.cacheWritesPrice } : {}),
+		...(overrides.temperature !== undefined ? { temperature: overrides.temperature } : {}),
+		...(apiFormat !== undefined ? { apiFormat } : {}),
+		...(overrides.isR1FormatRequired !== undefined ? { isR1FormatRequired: overrides.isR1FormatRequired } : {}),
+	}
+}
+
+function toSelectionOverrides(entry: StoredModelEntry | undefined): ModelSelectionOverrides | undefined {
+	if (!entry) {
+		return undefined
+	}
+	const apiFormat = fromStoredApiFormat(entry.apiFormat)
+	return normalizeModelSelectionOverrides({
+		...(entry.name !== undefined ? { name: entry.name } : {}),
+		...(entry.maxTokens !== undefined ? { maxTokens: entry.maxTokens } : {}),
+		...(entry.contextWindow !== undefined ? { contextWindow: entry.contextWindow } : {}),
+		...(entry.maxInputTokens !== undefined ? { maxInputTokens: entry.maxInputTokens } : {}),
+		...(entry.capabilities !== undefined ? { capabilities: [...entry.capabilities] } : {}),
+		...(entry.supportsVision !== undefined ? { supportsVision: entry.supportsVision } : {}),
+		...(entry.supportsAttachments !== undefined ? { supportsAttachments: entry.supportsAttachments } : {}),
+		...(entry.supportsReasoning !== undefined ? { supportsReasoning: entry.supportsReasoning } : {}),
+		...(entry.inputPrice !== undefined ? { inputPrice: entry.inputPrice } : {}),
+		...(entry.outputPrice !== undefined ? { outputPrice: entry.outputPrice } : {}),
+		...(entry.cacheReadsPrice !== undefined ? { cacheReadsPrice: entry.cacheReadsPrice } : {}),
+		...(entry.cacheWritesPrice !== undefined ? { cacheWritesPrice: entry.cacheWritesPrice } : {}),
+		...(entry.temperature !== undefined ? { temperature: entry.temperature } : {}),
+		...(apiFormat !== undefined ? { apiFormat } : {}),
+		...(entry.isR1FormatRequired !== undefined ? { isR1FormatRequired: entry.isR1FormatRequired } : {}),
+	})
+}
+
+function readStoredModelEntry(providerId: ProviderId, modelId: string): { exists: boolean; entry: StoredModelEntry | undefined } {
+	const models = readModelsState().providers[providerSettingsProviderId(providerId)]?.models
+	return {
+		exists: models ? Object.hasOwn(models, modelId) : false,
+		entry: models?.[modelId],
+	}
+}
+
+function readModelOverrides(providerId: ProviderId, modelId: string): ModelSelectionOverrides | undefined {
+	return toSelectionOverrides(readStoredModelEntry(providerId, modelId).entry)
+}
+
+function writeModelOverrides(providerId: ProviderId, modelId: string, overrides: ModelSelectionOverrides | undefined): void {
+	const modelsPath = resolveModelsRegistryPath(getProviderSettingsManager())
+	const state = readModelsFileSync(modelsPath)
+	const provider = providerSettingsProviderId(providerId)
+	const providerEntry = state.providers[provider] ?? {}
+	const nextModels = { ...(providerEntry.models ?? {}) }
+	const normalizedOverrides = normalizeModelSelectionOverrides(overrides)
+	const storedEntry = normalizedOverrides ? toStoredModelEntry(normalizedOverrides) : undefined
+	if (storedEntry && Object.keys(storedEntry).length > 0) {
+		nextModels[modelId] = storedEntry
+	} else {
+		delete nextModels[modelId]
+	}
+	const nextProviderEntry = {
+		...providerEntry,
+		models: nextModels,
+	}
+	writeModelsFileSync(modelsPath, {
+		...state,
+		providers: {
+			...state.providers,
+			[provider]: nextProviderEntry,
+		},
+	})
+	// ensureCustomProvidersLoadedSync is load-once per path and would no-op
+	// here; sync the live registry explicitly so this write is visible to new
+	// sessions without a restart.
+	syncStoredProviderRegistration(provider, state.providers[provider], nextProviderEntry)
+}
+
+function applyModelOverrides(modelInfo: ModelInfo, overrides: ModelSelectionOverrides | undefined): ModelInfo {
+	if (!overrides) {
+		return modelInfo
+	}
+	const next: ModelInfo = { ...modelInfo }
+	if (overrides.name !== undefined) next.name = overrides.name
+	if (overrides.maxTokens !== undefined) next.maxTokens = overrides.maxTokens
+	if (overrides.contextWindow !== undefined) next.contextWindow = overrides.contextWindow
+	if (overrides.maxInputTokens !== undefined)
+		(next as ModelInfo & { maxInputTokens?: number }).maxInputTokens = overrides.maxInputTokens
+	if (overrides.inputPrice !== undefined) next.inputPrice = overrides.inputPrice
+	if (overrides.outputPrice !== undefined) next.outputPrice = overrides.outputPrice
+	if (overrides.cacheReadsPrice !== undefined) next.cacheReadsPrice = overrides.cacheReadsPrice
+	if (overrides.cacheWritesPrice !== undefined) next.cacheWritesPrice = overrides.cacheWritesPrice
+	if (overrides.temperature !== undefined) next.temperature = overrides.temperature
+	if (overrides.apiFormat !== undefined) next.apiFormat = overrides.apiFormat
+
+	// Capability arrays are additive fallback flags: they can only enable
+	// capabilities the base metadata lacks, never disable base capabilities
+	// (an array authored for one purpose, e.g. prompt-cache, must not strip
+	// unrelated base flags like vision). Explicit booleans win when both
+	// representations are present.
+	if (overrides.capabilities !== undefined) {
+		if (overrides.capabilities.includes("images")) next.supportsImages = true
+		if (overrides.capabilities.includes("prompt-cache")) next.supportsPromptCache = true
+		if (overrides.capabilities.includes("reasoning")) next.supportsReasoning = true
+	}
+	if (overrides.supportsVision !== undefined) next.supportsImages = overrides.supportsVision
+	if (overrides.supportsReasoning !== undefined) next.supportsReasoning = overrides.supportsReasoning
+
+	// apiFormat is canonical. The legacy R1 flag remains a compatibility alias
+	// that forces R1 only when explicitly true.
+	if (overrides.isR1FormatRequired) next.apiFormat = ApiFormat.R1_CHAT
+	return next
+}
+
+function readBaseModelInfoForProvider(providerId: ProviderId, modelId: string): ModelInfo | undefined {
 	const sdkProviderId = toSdkProviderId(providerId)
 	const generatedModelInfo = getGeneratedModelsForProvider(sdkProviderId)[modelId]
 	if (isModelInfo(generatedModelInfo)) {
@@ -201,17 +413,36 @@ function readKnownModelInfoForProvider(providerId: ProviderId, modelId: string):
 	return undefined
 }
 
-function readSelectionFromProviderSettings(providerId: ProviderId): ModelSelection | undefined {
+function resolveSelection(selection: ModelSelection, stateModelInfoHint?: ModelInfo): ResolvedModelSelection {
+	const overrides = normalizeModelSelectionOverrides(
+		selection.overrides ?? readModelOverrides(selection.providerId, selection.modelId),
+	)
+	// Base resolution order: SDK catalog, then the picker's persisted state
+	// snapshot (the only accurate data for dynamic-list models the static
+	// catalog does not know), then provider-safe fallback defaults.
+	const catalogModelInfo = readBaseModelInfoForProvider(selection.providerId, selection.modelId)
+	const baseModelInfo = catalogModelInfo ?? stateModelInfoHint ?? fallbackModelInfo(selection.modelId)
+	const modelInfoSource = catalogModelInfo ? "catalog" : stateModelInfoHint ? "state" : "fallback"
+	return {
+		...selection,
+		overrides,
+		modelInfoSource,
+		baseModelInfo,
+		modelInfo: sanitizeResolvedModelInfo(applyModelOverrides(baseModelInfo, overrides)),
+	}
+}
+
+export function resolveRuntimeModelSelection(providerId: ProviderId, modelId: string): ResolvedModelSelection {
+	return resolveSelection({ providerId, modelId })
+}
+
+function readSelectionFromProviderSettings(providerId: ProviderId): ResolvedModelSelection | undefined {
 	const modelId = readProviderSettingsModelId(providerId)
 	if (!modelId) {
 		return undefined
 	}
 
-	return {
-		providerId,
-		modelId,
-		modelInfo: readKnownModelInfoForProvider(providerId, modelId) ?? fallbackModelInfo(modelId),
-	}
+	return resolveSelection({ providerId, modelId })
 }
 
 function writeStateKey(key: SecretKey | SettingsKey, value: unknown): void {
@@ -389,13 +620,27 @@ function syncedModes(mode: Mode): Mode[] {
 	return StateManager.get().getGlobalSettingsKey("planActSeparateModelsSetting") ? [mode] : ["plan", "act"]
 }
 
-function writeSelectionToState(providerId: ProviderId, mode: Mode, selection: ModelSelection): void {
+function writeSelectionToState(providerId: ProviderId, mode: Mode, selection: ResolvedModelSelection): void {
 	const updates: Partial<Record<SettingsKey, unknown>> = {}
 	for (const targetMode of syncedModes(mode)) {
 		updates[getModelIdKey(providerId, targetMode)] = selection.modelId
 		const modelInfoKey = getModelInfoKey(providerId, targetMode)
 		if (modelInfoKey) {
-			updates[modelInfoKey] = selection.modelInfo
+			// For hint-eligible providers the snapshot must stay genuine base
+			// metadata: never persist fabricated fallback data (later reads
+			// would treat it as authoritative "state" data and shadow live
+			// catalog lookups), and persist the pre-override base rather than
+			// the resolved value (a deleted override must not be resurrected
+			// from a snapshot it was baked into). openai-compatible keeps the
+			// legacy resolved write — its snapshot is never used as a
+			// resolution base, and old extension versions still read it after
+			// a rollback.
+			if (usesStateModelInfoHint(providerId)) {
+				updates[modelInfoKey] =
+					selection.modelInfoSource === "fallback" ? undefined : (selection.baseModelInfo ?? selection.modelInfo)
+			} else {
+				updates[modelInfoKey] = selection.modelInfo
+			}
 		}
 		selectionMemory.set(memoryKey(providerId, targetMode), { ...selection, providerId })
 	}
@@ -411,21 +656,153 @@ function writeSelectionToProviderSettings(providerId: ProviderId, selection: Mod
 	saveProviderSettings(providerId, next)
 }
 
-function readSelectionFromState(providerId: ProviderId, mode: Mode): ModelSelection | undefined {
+type LegacyModelInfo = ModelInfo & { maxInputTokens?: number; isR1FormatRequired?: boolean }
+type MutableModelSelectionOverrides = { -readonly [Key in keyof ModelSelectionOverrides]: ModelSelectionOverrides[Key] }
+
+function legacyModelInfoToOverrides(modelInfo: LegacyModelInfo, fallback: ModelInfo): ModelSelectionOverrides | undefined {
+	const fallbackInfo = fallback as LegacyModelInfo
+	const overrides: MutableModelSelectionOverrides = {}
+	if (modelInfo.name !== undefined && modelInfo.name !== fallback.name) overrides.name = modelInfo.name
+	if (modelInfo.maxTokens !== undefined && modelInfo.maxTokens !== fallback.maxTokens) overrides.maxTokens = modelInfo.maxTokens
+	if (modelInfo.contextWindow !== undefined && modelInfo.contextWindow !== fallback.contextWindow)
+		overrides.contextWindow = modelInfo.contextWindow
+	if (modelInfo.maxInputTokens !== undefined && modelInfo.maxInputTokens !== fallbackInfo.maxInputTokens)
+		overrides.maxInputTokens = modelInfo.maxInputTokens
+
+	const supportsVision = modelInfo.supportsImages ?? fallback.supportsImages
+	if (Boolean(supportsVision) !== Boolean(fallback.supportsImages)) overrides.supportsVision = Boolean(supportsVision)
+	if (Boolean(modelInfo.supportsReasoning) !== Boolean(fallback.supportsReasoning))
+		overrides.supportsReasoning = Boolean(modelInfo.supportsReasoning)
+	if (modelInfo.supportsPromptCache !== fallback.supportsPromptCache) {
+		const capabilities: string[] = []
+		if (supportsVision) capabilities.push("images")
+		if (modelInfo.supportsPromptCache) capabilities.push("prompt-cache")
+		overrides.capabilities = capabilities
+	}
+
+	if (modelInfo.inputPrice !== undefined && modelInfo.inputPrice !== fallback.inputPrice)
+		overrides.inputPrice = modelInfo.inputPrice
+	if (modelInfo.outputPrice !== undefined && modelInfo.outputPrice !== fallback.outputPrice)
+		overrides.outputPrice = modelInfo.outputPrice
+	if (modelInfo.cacheReadsPrice !== undefined && modelInfo.cacheReadsPrice !== fallback.cacheReadsPrice)
+		overrides.cacheReadsPrice = modelInfo.cacheReadsPrice
+	if (modelInfo.cacheWritesPrice !== undefined && modelInfo.cacheWritesPrice !== fallback.cacheWritesPrice)
+		overrides.cacheWritesPrice = modelInfo.cacheWritesPrice
+	if (modelInfo.temperature !== undefined && modelInfo.temperature !== fallback.temperature)
+		overrides.temperature = modelInfo.temperature
+	if (modelInfo.apiFormat !== undefined && modelInfo.apiFormat !== fallback.apiFormat) overrides.apiFormat = modelInfo.apiFormat
+	if (modelInfo.isR1FormatRequired === true && fallbackInfo.isR1FormatRequired !== true) overrides.isR1FormatRequired = true
+	return normalizeModelSelectionOverrides(overrides)
+}
+
+// Providers/models whose legacy-state migration has already been attempted in
+// this process. The migration runs from the read path, so it must be cheap on
+// repeat reads and must never run more than once per selection — including
+// when the legacy snapshot diffs to an empty override set and nothing is
+// written.
+const attemptedLegacyMigrations = new Set<string>()
+
+function migrateLegacyModelOverridesIfNeeded(providerId: ProviderId, modelId: string, modelInfo: ModelInfo): void {
+	if (providerSettingsProviderId(providerId) !== "openai-compatible") {
+		return
+	}
+	const migrationKey = `${providerId}:${modelId}`
+	if (attemptedLegacyMigrations.has(migrationKey)) {
+		return
+	}
+	attemptedLegacyMigrations.add(migrationKey)
+	if (readStoredModelEntry(providerId, modelId).exists) {
+		return
+	}
+	if (readBaseModelInfoForProvider(providerId, modelId) !== undefined) {
+		return
+	}
+	const overrides = legacyModelInfoToOverrides(modelInfo as LegacyModelInfo, fallbackModelInfo(modelId))
+	if (overrides) {
+		try {
+			writeModelOverrides(providerId, modelId, overrides)
+		} catch (error) {
+			// The migration is best-effort and runs inside read paths; a
+			// failed write (read-only fs, disk full) must not fail read RPCs.
+			Logger.warn(
+				`[ModelCatalog] Failed to migrate legacy overrides for provider=${providerId} model=${modelId}: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			)
+		}
+	}
+}
+
+/**
+ * The picker writes the live model metadata to the mode-specific
+ * `*ModeModelInfo` state key before committing. When the state still refers to
+ * the model being resolved, that snapshot is the best available base for
+ * dynamic-list models the static catalog does not know.
+ *
+ * openai-compatible is excluded: its legacy state snapshot is user-authored
+ * metadata that {@link migrateLegacyModelOverridesIfNeeded} converts into
+ * models.json overrides, which are the source of truth there. Feeding the
+ * snapshot back as a base would resurrect overrides the user deleted.
+ */
+function usesStateModelInfoHint(providerId: ProviderId): boolean {
+	return providerSettingsProviderId(providerId) !== "openai-compatible"
+}
+
+/**
+ * Pickers write `{ ...openAiModelInfoSafeDefaults, name: modelId }` to the
+ * state key when the user selects an id the live model list does not (yet)
+ * contain. Such a snapshot carries no real information and must not be
+ * treated as authoritative "state" metadata.
+ */
+function isSafeDefaultsSnapshot(modelInfo: ModelInfo, modelId: string): boolean {
+	const fabricated: Record<string, unknown> = { ...openAiModelInfoSafeDefaults, name: modelId }
+	const snapshot = modelInfo as unknown as Record<string, unknown>
+	for (const key of new Set([...Object.keys(fabricated), ...Object.keys(snapshot)])) {
+		if (fabricated[key] !== snapshot[key]) {
+			return false
+		}
+	}
+	return true
+}
+
+function readStateModelInfoHint(providerId: ProviderId, mode: Mode, modelId: string): ModelInfo | undefined {
+	if (!usesStateModelInfoHint(providerId)) {
+		return undefined
+	}
+	const modelInfoKey = getModelInfoKey(providerId, mode)
+	if (!modelInfoKey) {
+		return undefined
+	}
+	const apiConfiguration = StateManager.get().getApiConfiguration()
+	const stateModelId = apiConfiguration[getModelIdKey(providerId, mode)]
+	const stateModelInfo = apiConfiguration[modelInfoKey]
+	return stateModelId === modelId && isModelInfo(stateModelInfo) && !isSafeDefaultsSnapshot(stateModelInfo, modelId)
+		? stateModelInfo
+		: undefined
+}
+
+function readSelectionFromState(providerId: ProviderId, mode: Mode): ResolvedModelSelection | undefined {
 	const apiConfiguration = StateManager.get().getApiConfiguration()
 	const modelId = apiConfiguration[getModelIdKey(providerId, mode)]
 	const modelInfoKey = getModelInfoKey(providerId, mode)
 	const rememberedSelection = selectionMemory.get(memoryKey(providerId, mode))
-	const providerSettingsSelection = readSelectionFromProviderSettings(providerId)
 
 	if (modelInfoKey) {
 		const modelInfo = apiConfiguration[modelInfoKey]
-		if (typeof modelId !== "string" || modelId.length === 0 || !isModelInfo(modelInfo)) {
-			return providerSettingsSelection
+		if (typeof modelId !== "string" || modelId.length === 0) {
+			return readSelectionFromProviderSettings(providerId)
 		}
-		return { providerId, modelId, modelInfo }
+		// The mode-specific model id alone identifies the selection; the state
+		// modelInfo snapshot is optional input for legacy migration and, for
+		// dynamic-list providers, the base-metadata hint. Fallback-tier commits
+		// intentionally leave it unset.
+		if (isModelInfo(modelInfo)) {
+			migrateLegacyModelOverridesIfNeeded(providerId, modelId, modelInfo)
+		}
+		return resolveSelection({ providerId, modelId }, readStateModelInfoHint(providerId, mode, modelId))
 	}
 
+	const providerSettingsSelection = readSelectionFromProviderSettings(providerId)
 	const activeProvider = mode === "plan" ? apiConfiguration.planModeApiProvider : apiConfiguration.actModeApiProvider
 	const provider = providerForStorage(providerId)
 	if (activeProvider !== provider) {
@@ -464,7 +841,7 @@ export function createProviderConfigStore(): ProviderConfigStore {
 			return { ...buildEffectiveProviderConfig(providerId) }
 		},
 
-		readSelection(providerId: ProviderId, mode: Mode): ModelSelection | undefined {
+		readSelection(providerId: ProviderId, mode: Mode): ResolvedModelSelection | undefined {
 			return readSelectionFromState(providerId, mode)
 		},
 
@@ -482,9 +859,17 @@ export function createProviderConfigStore(): ProviderConfigStore {
 		},
 
 		commitSelection(providerId: ProviderId, mode: Mode, selection: ModelSelection): void {
-			writeSelectionToState(providerId, mode, selection)
 			writeSelectionToProviderSettings(providerId, selection)
-			emit({ kind: "selection", providerId, mode, selection })
+			if (selection.overrides !== undefined) {
+				writeModelOverrides(providerId, selection.modelId, selection.overrides)
+			}
+			// Read the picker-written state snapshot before writeSelectionToState
+			// replaces it, so dynamic-list models keep their live metadata instead
+			// of being re-resolved to fallback defaults.
+			const stateModelInfoHint = readStateModelInfoHint(providerId, mode, selection.modelId)
+			const resolvedSelection = resolveSelection({ providerId, modelId: selection.modelId }, stateModelInfoHint)
+			writeSelectionToState(providerId, mode, resolvedSelection)
+			emit({ kind: "selection", providerId, mode, selection: resolvedSelection })
 		},
 	}
 }

--- a/apps/vscode/src/sdk/model-catalog/test-stub-isolation.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/test-stub-isolation.test.ts
@@ -1,0 +1,36 @@
+import { readModelsFileSync, writeModelsFileSync } from "@cline/core"
+import { describe, expect, it } from "vitest"
+
+type StoredModelsFile = ReturnType<typeof readModelsFileSync>
+
+const firstPath = "/tmp/first-models.json"
+const secondPath = "/tmp/second-models.json"
+
+const storedModelsFile = (): StoredModelsFile => ({
+	version: 1,
+	providers: {
+		"openai-compatible": {
+			models: {
+				custom: { name: "Custom", capabilities: ["tools"] },
+			},
+		},
+	},
+})
+
+describe("cline core model-file test stub", () => {
+	it("isolates paths and returns defensive copies", () => {
+		const input = storedModelsFile()
+		writeModelsFileSync(firstPath, input)
+
+		input.providers["openai-compatible"].models!.custom.name = "mutated input"
+		const firstRead = readModelsFileSync(firstPath)
+		firstRead.providers["openai-compatible"].models!.custom.name = "mutated read"
+
+		expect(readModelsFileSync(firstPath)).toEqual(storedModelsFile())
+		expect(readModelsFileSync(secondPath)).toEqual({ version: 1, providers: {} })
+	})
+
+	it("cannot observe model writes from the preceding test", () => {
+		expect(readModelsFileSync(firstPath)).toEqual({ version: 1, providers: {} })
+	})
+})

--- a/apps/vscode/src/shared/proto-conversions/models/modelOverrides.ts
+++ b/apps/vscode/src/shared/proto-conversions/models/modelOverrides.ts
@@ -1,0 +1,85 @@
+import type { ModelInfo } from "@shared/api"
+import { ModelOverrides } from "@shared/proto/cline/models"
+
+/**
+ * Domain shape of user-authored per-model metadata overrides, shared by the
+ * webview (commit path) and the host (read/commit handlers). Mirrors the
+ * `ModelOverrides` proto message.
+ *
+ * Semantics (enforced host-side in the provider config store):
+ *  - `capabilities` accepts only SDK `ModelCapability` values; unknown
+ *    strings are silently dropped. The array is additive over the base
+ *    metadata; the explicit `supports*` booleans win when both are present.
+ *  - `isR1FormatRequired` is a legacy alias that forces the R1 chat format
+ *    only when true; `apiFormat` is canonical.
+ *  - Invalid numbers (non-positive token limits, negative prices or
+ *    temperature, non-finite values) are silently discarded, not rejected.
+ *
+ * When committing a selection, the overrides value is tri-state: `undefined`
+ * preserves the model's stored overrides, an explicitly empty object clears
+ * them, and a non-empty object replaces them wholesale (no per-field merge).
+ */
+export interface ProviderModelOverrides {
+	name?: string
+	maxTokens?: number
+	contextWindow?: number
+	maxInputTokens?: number
+	capabilities?: readonly string[]
+	supportsVision?: boolean
+	supportsAttachments?: boolean
+	supportsReasoning?: boolean
+	inputPrice?: number
+	outputPrice?: number
+	cacheReadsPrice?: number
+	cacheWritesPrice?: number
+	temperature?: number
+	apiFormat?: ModelInfo["apiFormat"]
+	isR1FormatRequired?: boolean
+}
+
+export function toProtobufModelOverrides(overrides: ProviderModelOverrides): ModelOverrides {
+	return ModelOverrides.create({
+		name: overrides.name,
+		maxTokens: overrides.maxTokens,
+		contextWindow: overrides.contextWindow,
+		maxInputTokens: overrides.maxInputTokens,
+		capabilities: overrides.capabilities ? [...overrides.capabilities] : [],
+		supportsVision: overrides.supportsVision,
+		supportsAttachments: overrides.supportsAttachments,
+		supportsReasoning: overrides.supportsReasoning,
+		inputPrice: overrides.inputPrice,
+		outputPrice: overrides.outputPrice,
+		cacheReadsPrice: overrides.cacheReadsPrice,
+		cacheWritesPrice: overrides.cacheWritesPrice,
+		temperature: overrides.temperature,
+		apiFormat: overrides.apiFormat,
+		isR1FormatRequired: overrides.isR1FormatRequired,
+	})
+}
+
+/**
+ * Preserves the proto tri-state: `undefined` stays `undefined` (no override
+ * payload), and an empty message becomes an empty object (explicit clear).
+ */
+export function fromProtobufModelOverrides(overrides: ModelOverrides | undefined): ProviderModelOverrides | undefined {
+	if (!overrides) {
+		return undefined
+	}
+	return {
+		...(overrides.name !== undefined ? { name: overrides.name } : {}),
+		...(overrides.maxTokens !== undefined ? { maxTokens: overrides.maxTokens } : {}),
+		...(overrides.contextWindow !== undefined ? { contextWindow: overrides.contextWindow } : {}),
+		...(overrides.maxInputTokens !== undefined ? { maxInputTokens: overrides.maxInputTokens } : {}),
+		...(overrides.capabilities.length > 0 ? { capabilities: [...overrides.capabilities] } : {}),
+		...(overrides.supportsVision !== undefined ? { supportsVision: overrides.supportsVision } : {}),
+		...(overrides.supportsAttachments !== undefined ? { supportsAttachments: overrides.supportsAttachments } : {}),
+		...(overrides.supportsReasoning !== undefined ? { supportsReasoning: overrides.supportsReasoning } : {}),
+		...(overrides.inputPrice !== undefined ? { inputPrice: overrides.inputPrice } : {}),
+		...(overrides.outputPrice !== undefined ? { outputPrice: overrides.outputPrice } : {}),
+		...(overrides.cacheReadsPrice !== undefined ? { cacheReadsPrice: overrides.cacheReadsPrice } : {}),
+		...(overrides.cacheWritesPrice !== undefined ? { cacheWritesPrice: overrides.cacheWritesPrice } : {}),
+		...(overrides.temperature !== undefined ? { temperature: overrides.temperature } : {}),
+		...(overrides.apiFormat !== undefined ? { apiFormat: overrides.apiFormat } : {}),
+		...(overrides.isR1FormatRequired !== undefined ? { isR1FormatRequired: overrides.isR1FormatRequired } : {}),
+	}
+}

--- a/apps/vscode/src/test/bun-test-preload.ts
+++ b/apps/vscode/src/test/bun-test-preload.ts
@@ -32,8 +32,9 @@
 // Importing the real package here is safe: the preload runs before any test
 // file, so this is the only point the real module is linked, and we only read
 // its export *names*, never its behavior (the mock shadows it everywhere tests look).
-import { vi as bunVi, mock } from "bun:test"
+import { beforeEach as bunBeforeEach, vi as bunVi, mock } from "bun:test"
 import * as realClineCore from "@cline/core"
+import * as LlmsModels from "@cline/llms"
 import * as clineCoreStub from "./cline-core-vitest-stub"
 import * as vscodeStub from "./vscode-vitest-stub"
 
@@ -42,6 +43,13 @@ for (const name of Object.keys(realClineCore)) {
 	clineCoreNamespace[name] = undefined
 }
 Object.assign(clineCoreNamespace, clineCoreStub)
+
+bunBeforeEach(() => {
+	clineCoreStub.resetModelsFileState()
+	// The stub's syncStoredProviderRegistration mutates the real shared
+	// @cline/llms registry; reset it so registrations never leak across tests.
+	LlmsModels.resetRegistry()
+})
 
 mock.module("@cline/core", () => clineCoreNamespace)
 

--- a/apps/vscode/src/test/cline-core-vitest-stub.ts
+++ b/apps/vscode/src/test/cline-core-vitest-stub.ts
@@ -13,6 +13,54 @@ export interface StartSessionResult {
 
 export const MAX_COMMAND_OUTPUT_CHARS = 200_000
 
+export interface StoredModelEntry {
+	id?: string
+	name?: string
+	maxTokens?: number
+	contextWindow?: number
+	maxInputTokens?: number
+	capabilities?: string[]
+	[key: string]: unknown
+}
+
+export interface StoredModelsFile {
+	version: 1
+	providers: Record<string, { models?: Record<string, StoredModelEntry> }>
+}
+
+const modelsFiles = new Map<string, StoredModelsFile>()
+
+function cloneModelsFile(modelsFile: StoredModelsFile): StoredModelsFile {
+	return structuredClone(modelsFile)
+}
+
+export function resetModelsFileState(): void {
+	modelsFiles.clear()
+}
+
+export function readModelsFileSync(filePath: string): StoredModelsFile {
+	return cloneModelsFile(modelsFiles.get(filePath) ?? { version: 1, providers: {} })
+}
+
+export function writeModelsFileSync(filePath: string, next: StoredModelsFile): void {
+	modelsFiles.set(filePath, cloneModelsFile(next))
+}
+
+export function resolveModelsRegistryPath(): string {
+	return "/tmp/models.json"
+}
+
+export function ensureCustomProvidersLoadedSync(): void {}
+
+// Real implementation re-exported from the sdk source (same pattern as the
+// apply-patch executors below) so store writes are reflected in the live
+// @cline/llms registry exactly as in production. Tests that touch it must
+// reset the registry (LlmsModels.resetRegistry()) between tests.
+export {
+	StoredModelEntrySchema,
+	syncStoredProviderRegistration,
+} from "../../../../sdk/packages/core/src/services/providers/local-provider-registry"
+
 export type GlobalCompactionStrategy = "basic" | "agentic"
 
 export function readCompactionStrategyGlobally(): GlobalCompactionStrategy {

--- a/apps/vscode/src/test/vitest-setup.ts
+++ b/apps/vscode/src/test/vitest-setup.ts
@@ -1,0 +1,15 @@
+// Under vitest, `@cline/core` is aliased to src/test/cline-core-vitest-stub.ts
+// (see vitest.config.ts), which holds models.json state in memory and exposes
+// the stub-only `resetModelsFileState` — hence the cast below.
+import * as ClineCore from "@cline/core"
+import { resetRegistry } from "@cline/llms"
+import { beforeEach } from "vitest"
+
+const { resetModelsFileState } = ClineCore as typeof ClineCore & { resetModelsFileState(): void }
+
+beforeEach(() => {
+	resetModelsFileState()
+	// The stub's syncStoredProviderRegistration mutates the real shared
+	// @cline/llms registry; reset it so registrations never leak across tests.
+	resetRegistry()
+})

--- a/apps/vscode/vitest.config.ts
+++ b/apps/vscode/vitest.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
 			"src/core/controller/models/__tests__/refreshGroqModels.test.ts",
 		],
 		environment: "node",
+		setupFiles: ["./src/test/vitest-setup.ts"],
 		// Several suites lazily `await import()` their subject inside the first test
 		// (needed so vi.mock factories apply first). That import pulls in heavy
 		// workspace packages (@cline/core/@cline/llms/@cline/shared), and on loaded

--- a/apps/vscode/webview-ui/src/components/onboarding/OnboardingView.tsx
+++ b/apps/vscode/webview-ui/src/components/onboarding/OnboardingView.tsx
@@ -471,12 +471,10 @@ const OnboardingViewContent = ({ onboardingModels }: { onboardingModels: Onboard
 						commitSelection("plan", {
 							providerId: "cline",
 							modelId: selectedModelId,
-							modelInfo: selectedModelInfo,
 						}),
 						commitSelection("act", {
 							providerId: "cline",
 							modelId: selectedModelId,
-							modelInfo: selectedModelInfo,
 						}),
 					])
 

--- a/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.test.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.test.tsx
@@ -105,11 +105,6 @@ describe("ClineModelPicker", () => {
 		expect(mocks.commitSelection).toHaveBeenCalledWith("act", {
 			providerId: "cline",
 			modelId: "cline-next",
-			modelInfo: {
-				name: "Cline Next",
-				supportsPromptCache: true,
-				contextWindow: 128_000,
-			},
 		})
 	})
 

--- a/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.tsx
@@ -218,7 +218,6 @@ const ClineModelPicker: React.FC<ClineModelPickerProps> = ({ isPopup, currentMod
 		void commitSelection(currentMode, {
 			providerId: "cline",
 			modelId: newModelId,
-			modelInfo,
 		}).catch((err) => console.error("Failed to commit Cline model selection:", err))
 
 		void handleModeFieldsChange(

--- a/apps/vscode/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
@@ -77,7 +77,7 @@ const OpenRouterModelPicker: React.FC<OpenRouterModelPickerProps> = ({ isPopup, 
 			currentMode,
 		)
 
-		void commitSelection(currentMode, { providerId: "openrouter", modelId: newModelId, modelInfo }).catch((err) =>
+		void commitSelection(currentMode, { providerId: "openrouter", modelId: newModelId }).catch((err) =>
 			console.error("Failed to commit OpenRouter model selection:", err),
 		)
 	}

--- a/apps/vscode/webview-ui/src/components/settings/providers/GenericProviderSettings.test.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/GenericProviderSettings.test.tsx
@@ -97,7 +97,6 @@ describe("GenericProviderSettings", () => {
 		expect(commitSelection).toHaveBeenCalledWith("act", {
 			providerId: "deepseek",
 			modelId: "deepseek-reasoner",
-			modelInfo: { name: "DeepSeek Reasoner", supportsPromptCache: true, contextWindow: 128_000, supportsReasoning: true },
 		})
 		expect(useProviderModels).toHaveBeenCalledWith("deepseek")
 		expect(useProviderConfig).toHaveBeenCalledWith("deepseek")

--- a/apps/vscode/webview-ui/src/components/settings/providers/OpenAICompatible.test.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/OpenAICompatible.test.tsx
@@ -1,0 +1,517 @@
+import { ApiFormat } from "@shared/proto/cline/models"
+import { act, fireEvent, render, screen } from "@testing-library/react"
+import type { ChangeEventHandler, ReactNode } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { OpenAICompatibleProvider } from "./OpenAICompatible"
+
+const mocks = vi.hoisted(() => ({
+	commitSelection: vi.fn(),
+	handleFieldChange: vi.fn(),
+	handleModeFieldChange: vi.fn(),
+	refreshOpenAiModels: vi.fn(),
+	useDynamicProviderSelection: vi.fn(),
+	useExtensionState: vi.fn(),
+	useProviderConfig: vi.fn(),
+	write: vi.fn(),
+}))
+
+vi.mock("@/context/ExtensionStateContext", () => ({
+	useExtensionState: mocks.useExtensionState,
+}))
+
+vi.mock("@/hooks/useDynamicProviderSelection", () => ({
+	useDynamicProviderSelection: mocks.useDynamicProviderSelection,
+}))
+
+vi.mock("@/hooks/useProviderConfig", () => ({
+	fromProtobufProviderModelOverrides: (overrides: Record<string, unknown> | undefined) =>
+		overrides ? { ...overrides } : undefined,
+	useProviderConfig: mocks.useProviderConfig,
+}))
+
+vi.mock("@/services/grpc-client", () => ({
+	ModelsServiceClient: {
+		refreshOpenAiModels: mocks.refreshOpenAiModels,
+	},
+}))
+
+vi.mock("../utils/useApiConfigurationHandlers", () => ({
+	useApiConfigurationHandlers: () => ({
+		handleFieldChange: mocks.handleFieldChange,
+		handleModeFieldChange: mocks.handleModeFieldChange,
+	}),
+}))
+
+vi.mock("@radix-ui/react-tooltip", () => ({
+	TooltipContent: ({ children }: { children?: ReactNode }) => <>{children}</>,
+	TooltipTrigger: ({ children }: { children?: ReactNode }) => <>{children}</>,
+}))
+
+vi.mock("@/components/ui/tooltip", () => ({
+	Tooltip: ({ children }: { children?: ReactNode }) => <>{children}</>,
+}))
+
+vi.mock("@vscode/webview-ui-toolkit/react", () => ({
+	VSCodeButton: ({ children, disabled, onClick }: { children?: ReactNode; disabled?: boolean; onClick?: () => void }) => (
+		<button disabled={disabled} onClick={onClick} type="button">
+			{children}
+		</button>
+	),
+	VSCodeCheckbox: ({
+		checked,
+		children,
+		onChange,
+	}: {
+		checked?: boolean
+		children?: ReactNode
+		onChange?: ChangeEventHandler<HTMLInputElement>
+	}) => (
+		<label>
+			<input checked={checked} onChange={onChange} type="checkbox" />
+			{children}
+		</label>
+	),
+}))
+
+vi.mock("../common/ApiKeyField", () => ({
+	ApiKeyField: ({
+		initialValue,
+		onChange,
+		providerName,
+	}: {
+		initialValue?: string
+		onChange: (value: string) => void
+		providerName: string
+	}) => (
+		<input aria-label={`${providerName} API key`} onChange={(event) => onChange(event.target.value)} value={initialValue} />
+	),
+}))
+
+vi.mock("../common/BaseUrlField", () => ({
+	BaseUrlField: ({
+		disabled,
+		initialValue,
+		label,
+		onChange,
+	}: {
+		disabled?: boolean
+		initialValue?: string
+		label: string
+		onChange: (value: string) => void
+	}) => (
+		<label>
+			{label}
+			<input
+				aria-label={label}
+				disabled={disabled}
+				onChange={(event) => onChange(event.target.value)}
+				value={initialValue ?? ""}
+			/>
+		</label>
+	),
+}))
+
+vi.mock("../common/DebouncedTextField", () => ({
+	DebouncedTextField: ({
+		children,
+		disabled,
+		initialValue,
+		onChange,
+		placeholder,
+	}: {
+		children?: ReactNode
+		disabled?: boolean
+		initialValue?: string
+		onChange: (value: string) => void
+		placeholder?: string
+	}) => (
+		<label>
+			{children}
+			<input
+				disabled={disabled}
+				onChange={(event) => onChange(event.target.value)}
+				placeholder={placeholder}
+				value={initialValue ?? ""}
+			/>
+		</label>
+	),
+}))
+
+vi.mock("../common/ModelInfoView", () => ({ ModelInfoView: () => null }))
+vi.mock("../ReasoningEffortSelector", () => ({ default: () => null }))
+
+function deferred<T>() {
+	let resolve!: (value: T) => void
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise
+	})
+	return { promise, resolve }
+}
+
+function renderProvider() {
+	return render(<OpenAICompatibleProvider currentMode="act" providerId="custom-openai" showModelOptions={false} />)
+}
+
+function setCommittedSelection(overrides: Record<string, unknown>, modelInfo: Record<string, unknown> = {}) {
+	mocks.useProviderConfig.mockReturnValue({
+		config: {
+			actSelection: {
+				providerId: "custom-openai",
+				modelId: "custom-model",
+				modelInfo: {
+					contextWindow: 128_000,
+					inputPrice: 0,
+					maxTokens: -1,
+					outputPrice: 0,
+					temperature: 0,
+					tiers: [],
+					...modelInfo,
+				},
+				overrides,
+			},
+			apiKeyLength: 12,
+			baseUrl: "http://localhost:1234/v1",
+			headers: {},
+			providerId: "custom-openai",
+		},
+		commitSelection: mocks.commitSelection,
+		write: mocks.write,
+	})
+}
+
+describe("OpenAICompatibleProvider", () => {
+	beforeEach(() => {
+		vi.useRealTimers()
+		vi.clearAllMocks()
+		mocks.commitSelection.mockResolvedValue(undefined)
+		mocks.write.mockResolvedValue(undefined)
+		mocks.refreshOpenAiModels.mockResolvedValue({ values: [] })
+		mocks.useExtensionState.mockReturnValue({
+			apiConfiguration: { azureApiVersion: "2025-04-01-preview", azureIdentity: false },
+			remoteConfigSettings: undefined,
+		})
+		mocks.useDynamicProviderSelection.mockReturnValue({
+			selectedModelId: "custom-model",
+			selectedModelInfo: {
+				contextWindow: 128_000,
+				inputPrice: 0,
+				maxTokens: -1,
+				outputPrice: 0,
+				temperature: 0,
+			},
+		})
+		mocks.useProviderConfig.mockReturnValue({
+			config: {
+				apiKeyLength: 12,
+				baseUrl: "http://localhost:1234/v1",
+				headers: {},
+				providerId: "custom-openai",
+			},
+			commitSelection: mocks.commitSelection,
+			write: mocks.write,
+		})
+	})
+
+	it("refreshes keyless endpoints and displays only the saved-key mask", async () => {
+		renderProvider()
+
+		await act(async () => {})
+
+		expect(mocks.refreshOpenAiModels).toHaveBeenCalledWith(
+			expect.objectContaining({ baseUrl: "http://localhost:1234/v1", apiKey: "" }),
+		)
+		expect(screen.getByLabelText("OpenAI Compatible API key")).toHaveValue("••••••••••••")
+	})
+
+	it("writes a newly entered API key without echoing a stored key into config", async () => {
+		renderProvider()
+		await act(async () => {})
+
+		fireEvent.change(screen.getByLabelText("OpenAI Compatible API key"), { target: { value: "new-secret" } })
+
+		expect(mocks.write).toHaveBeenCalledWith({ apiKey: "new-secret" })
+	})
+
+	it("commits ordinary model selections by ID only", async () => {
+		mocks.refreshOpenAiModels.mockResolvedValue({ values: ["listed-model"] })
+		renderProvider()
+		await act(async () => {})
+
+		fireEvent.change(screen.getByLabelText("Model ID"), { target: { value: "listed-model" } })
+
+		expect(mocks.commitSelection).toHaveBeenCalledWith("act", {
+			providerId: "custom-openai",
+			modelId: "listed-model",
+		})
+	})
+
+	it("persists only the edited vision field while preserving existing overrides", async () => {
+		setCommittedSelection({
+			apiFormat: ApiFormat.OPENAI_RESPONSES,
+			cacheReadsPrice: 0.5,
+			cacheWritesPrice: 0.75,
+			capabilities: ["tools", "streaming"],
+			outputPrice: 2,
+		})
+		renderProvider()
+		await act(async () => {})
+		fireEvent.click(screen.getByText("Model Configuration"))
+
+		fireEvent.click(screen.getByRole("checkbox", { name: "Supports Images" }))
+
+		expect(mocks.commitSelection).toHaveBeenCalledWith("act", {
+			providerId: "custom-openai",
+			modelId: "custom-model",
+			overrides: {
+				apiFormat: ApiFormat.OPENAI_RESPONSES,
+				cacheReadsPrice: 0.5,
+				cacheWritesPrice: 0.75,
+				capabilities: ["tools", "streaming"],
+				outputPrice: 2,
+				supportsVision: true,
+			},
+		})
+	})
+
+	it("restores the R1 checkbox from authored override readback", async () => {
+		setCommittedSelection({ isR1FormatRequired: true })
+		renderProvider()
+		await act(async () => {})
+		fireEvent.click(screen.getByText("Model Configuration"))
+
+		expect(screen.getByRole("checkbox", { name: "Enable R1 messages format" })).toBeChecked()
+	})
+
+	it("restores the R1 checkbox from canonical resolved apiFormat", async () => {
+		setCommittedSelection({}, { apiFormat: ApiFormat.R1_CHAT })
+		renderProvider()
+		await act(async () => {})
+		fireEvent.click(screen.getByText("Model Configuration"))
+
+		expect(screen.getByRole("checkbox", { name: "Enable R1 messages format" })).toBeChecked()
+	})
+
+	it("persists the R1 checkbox as one explicit override", async () => {
+		renderProvider()
+		await act(async () => {})
+		fireEvent.click(screen.getByText("Model Configuration"))
+
+		fireEvent.click(screen.getByRole("checkbox", { name: "Enable R1 messages format" }))
+
+		expect(mocks.commitSelection).toHaveBeenCalledWith("act", {
+			providerId: "custom-openai",
+			modelId: "custom-model",
+			overrides: { isR1FormatRequired: true },
+		})
+	})
+
+	it("persists a temperature edit without adding resolved defaults", async () => {
+		renderProvider()
+		await act(async () => {})
+		fireEvent.click(screen.getByText("Model Configuration"))
+
+		fireEvent.change(screen.getByLabelText("Temperature"), { target: { value: "0.25" } })
+
+		expect(mocks.commitSelection).toHaveBeenCalledWith("act", {
+			providerId: "custom-openai",
+			modelId: "custom-model",
+			overrides: { temperature: 0.25 },
+		})
+	})
+
+	it.each([
+		["Context Window Size", "contextWindow", "64000", 64_000],
+		["Max Output Tokens", "maxTokens", "4096", 4_096],
+		["Output Price / 1M tokens", "outputPrice", "2.5", 2.5],
+	] as const)("maps %s only to the %s override", async (label, key, input, expected) => {
+		renderProvider()
+		await act(async () => {})
+		fireEvent.click(screen.getByText("Model Configuration"))
+
+		fireEvent.change(screen.getByLabelText(label), { target: { value: input } })
+
+		expect(mocks.commitSelection).toHaveBeenCalledWith("act", {
+			providerId: "custom-openai",
+			modelId: "custom-model",
+			overrides: { [key]: expected },
+		})
+	})
+
+	it("clears one override while preserving unrelated fields", async () => {
+		setCommittedSelection({
+			apiFormat: ApiFormat.OPENAI_RESPONSES,
+			capabilities: ["tools", "streaming"],
+			temperature: 0.4,
+		})
+		renderProvider()
+		await act(async () => {})
+		fireEvent.click(screen.getByText("Model Configuration"))
+
+		fireEvent.change(screen.getByLabelText("Temperature"), { target: { value: "" } })
+
+		expect(mocks.commitSelection).toHaveBeenCalledWith("act", {
+			providerId: "custom-openai",
+			modelId: "custom-model",
+			overrides: {
+				apiFormat: ApiFormat.OPENAI_RESPONSES,
+				capabilities: ["tools", "streaming"],
+			},
+		})
+	})
+
+	it("preserves apiFormat while editing pricing", async () => {
+		setCommittedSelection({
+			apiFormat: ApiFormat.OPENAI_RESPONSES,
+			capabilities: ["tools"],
+		})
+		renderProvider()
+		await act(async () => {})
+		fireEvent.click(screen.getByText("Model Configuration"))
+
+		fireEvent.change(screen.getByLabelText("Input Price / 1M tokens"), { target: { value: "1.25" } })
+
+		expect(mocks.commitSelection).toHaveBeenCalledWith("act", {
+			providerId: "custom-openai",
+			modelId: "custom-model",
+			overrides: {
+				apiFormat: ApiFormat.OPENAI_RESPONSES,
+				capabilities: ["tools"],
+				inputPrice: 1.25,
+			},
+		})
+	})
+
+	it("sends an empty replacement when the final override is cleared", async () => {
+		setCommittedSelection({ temperature: 0.4 })
+		renderProvider()
+		await act(async () => {})
+		fireEvent.click(screen.getByText("Model Configuration"))
+
+		fireEvent.change(screen.getByLabelText("Temperature"), { target: { value: "" } })
+
+		expect(mocks.commitSelection).toHaveBeenCalledWith("act", {
+			providerId: "custom-openai",
+			modelId: "custom-model",
+			overrides: {},
+		})
+	})
+
+	it("shows invalid-number feedback without committing", async () => {
+		renderProvider()
+		await act(async () => {})
+		fireEvent.click(screen.getByText("Model Configuration"))
+
+		fireEvent.change(screen.getByLabelText("Max Output Tokens"), { target: { value: "80000o" } })
+
+		expect(screen.getByRole("alert")).toHaveTextContent("Max Output Tokens must be a valid number.")
+		expect(mocks.commitSelection).not.toHaveBeenCalled()
+	})
+
+	it("merges rapid edits using the pending override set", async () => {
+		renderProvider()
+		await act(async () => {})
+		fireEvent.click(screen.getByText("Model Configuration"))
+
+		fireEvent.change(screen.getByLabelText("Temperature"), { target: { value: "0.25" } })
+		fireEvent.change(screen.getByLabelText("Input Price / 1M tokens"), { target: { value: "1.5" } })
+
+		expect(mocks.commitSelection).toHaveBeenLastCalledWith("act", {
+			providerId: "custom-openai",
+			modelId: "custom-model",
+			overrides: { inputPrice: 1.5, temperature: 0.25 },
+		})
+	})
+
+	it("debounces model refreshes triggered by base URL edits", async () => {
+		vi.useFakeTimers()
+		renderProvider()
+		await act(async () => {})
+		expect(mocks.refreshOpenAiModels).toHaveBeenCalledTimes(1)
+
+		fireEvent.change(screen.getByDisplayValue("http://localhost:1234/v1"), {
+			target: { value: "http://localhost:5678/v1" },
+		})
+		expect(mocks.refreshOpenAiModels).toHaveBeenCalledTimes(1)
+
+		await act(async () => {
+			vi.advanceTimersByTime(499)
+		})
+		expect(mocks.refreshOpenAiModels).toHaveBeenCalledTimes(1)
+
+		await act(async () => {
+			vi.advanceTimersByTime(1)
+		})
+		expect(mocks.refreshOpenAiModels).toHaveBeenCalledTimes(2)
+	})
+
+	it("ignores a stale model-list response", async () => {
+		vi.useFakeTimers()
+		const oldRequest = deferred<{ values: string[] }>()
+		const newRequest = deferred<{ values: string[] }>()
+		mocks.refreshOpenAiModels.mockReturnValueOnce(oldRequest.promise).mockReturnValueOnce(newRequest.promise)
+		renderProvider()
+
+		fireEvent.change(screen.getByDisplayValue("http://localhost:1234/v1"), {
+			target: { value: "http://localhost:5678/v1" },
+		})
+		await act(async () => {
+			vi.advanceTimersByTime(500)
+		})
+
+		await act(async () => {
+			newRequest.resolve({ values: ["new-model"] })
+		})
+		expect(screen.getByRole("option", { name: "new-model" })).toBeInTheDocument()
+
+		await act(async () => {
+			oldRequest.resolve({ values: ["stale-model"] })
+		})
+		expect(screen.queryByRole("option", { name: "stale-model" })).not.toBeInTheDocument()
+		expect(screen.getByRole("option", { name: "new-model" })).toBeInTheDocument()
+	})
+
+	it("cancels a pending debounced refresh when unmounted", async () => {
+		vi.useFakeTimers()
+		const view = renderProvider()
+		await act(async () => {})
+
+		fireEvent.change(screen.getByDisplayValue("http://localhost:1234/v1"), {
+			target: { value: "http://localhost:5678/v1" },
+		})
+		view.unmount()
+		await act(async () => {
+			vi.advanceTimersByTime(500)
+		})
+
+		expect(mocks.refreshOpenAiModels).toHaveBeenCalledTimes(1)
+	})
+
+	it("restores Azure settings and remote-config locks", async () => {
+		mocks.useExtensionState.mockReturnValue({
+			apiConfiguration: { azureApiVersion: "2025-04-01-preview", azureIdentity: true },
+			remoteConfigSettings: {
+				azureApiVersion: "2025-04-01-preview",
+				openAiBaseUrl: "https://managed.example/v1",
+				openAiHeaders: { "x-managed": "true" },
+			},
+		})
+		renderProvider()
+		await act(async () => {})
+
+		expect(screen.getByDisplayValue("http://localhost:1234/v1")).toBeDisabled()
+		expect(screen.getByRole("button", { name: "Add Header" })).toBeDisabled()
+		expect(screen.getByLabelText("Set Azure API version")).toBeDisabled()
+		expect(screen.getByRole("checkbox", { name: "Use Azure Identity Authentication" })).toBeChecked()
+	})
+
+	it("writes editable Azure settings through the legacy handlers", async () => {
+		renderProvider()
+		await act(async () => {})
+
+		fireEvent.change(screen.getByLabelText("Set Azure API version"), { target: { value: "2026-01-01" } })
+		fireEvent.click(screen.getByRole("checkbox", { name: "Use Azure Identity Authentication" }))
+
+		expect(mocks.handleFieldChange).toHaveBeenCalledWith("azureApiVersion", "2026-01-01")
+		expect(mocks.handleFieldChange).toHaveBeenCalledWith("azureIdentity", true)
+	})
+})

--- a/apps/vscode/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
@@ -1,11 +1,6 @@
 import { TooltipContent, TooltipTrigger } from "@radix-ui/react-tooltip"
-import {
-	azureOpenAiDefaultApiVersion,
-	type ModelInfo,
-	type OpenAiCompatibleModelInfo,
-	openAiModelInfoSafeDefaults,
-} from "@shared/api"
-import { OpenAiModelsRequest } from "@shared/proto/cline/models"
+import { azureOpenAiDefaultApiVersion, type OpenAiCompatibleModelInfo, openAiModelInfoSafeDefaults } from "@shared/api"
+import { ApiFormat, OpenAiModelsRequest } from "@shared/proto/cline/models"
 import { fromProtobufModelInfo } from "@shared/proto-conversions/models/typeConversion"
 import type { Mode } from "@shared/storage/types"
 import { VSCodeButton, VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react"
@@ -13,7 +8,7 @@ import { useCallback, useEffect, useRef, useState } from "react"
 import { Tooltip } from "@/components/ui/tooltip"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { useDynamicProviderSelection } from "@/hooks/useDynamicProviderSelection"
-import { useProviderConfig } from "@/hooks/useProviderConfig"
+import { fromProtobufProviderModelOverrides, type ProviderModelOverrides, useProviderConfig } from "@/hooks/useProviderConfig"
 import { ModelsServiceClient } from "@/services/grpc-client"
 import { getAsVar, VSC_DESCRIPTION_FOREGROUND } from "@/utils/vscStyles"
 import { ApiKeyField } from "../common/ApiKeyField"
@@ -21,7 +16,6 @@ import { BaseUrlField } from "../common/BaseUrlField"
 import { DebouncedTextField } from "../common/DebouncedTextField"
 import { ModelInfoView } from "../common/ModelInfoView"
 import ReasoningEffortSelector from "../ReasoningEffortSelector"
-import { parsePrice } from "../utils/pricingUtils"
 import { useApiConfigurationHandlers } from "../utils/useApiConfigurationHandlers"
 import { useProviderApiKeyField } from "../utils/useProviderApiKeyField"
 
@@ -53,6 +47,7 @@ export const OpenAICompatibleProvider = ({
 	const [availableOpenAiModels, setAvailableOpenAiModels] = useState<string[]>([])
 	const [isRefreshingOpenAiModels, setIsRefreshingOpenAiModels] = useState(false)
 	const [openAiModelsError, setOpenAiModelsError] = useState<string | undefined>(undefined)
+	const [modelFieldErrors, setModelFieldErrors] = useState<Partial<Record<NumericModelOverrideKey, string>>>({})
 	// Only the built-in "openai" provider stores its API key in the legacy
 	// ApiConfiguration field; custom providers keep it in their per-provider
 	// config (available only as a masked length), so there is no plaintext key
@@ -92,34 +87,100 @@ export const OpenAICompatibleProvider = ({
 	// The Model Configuration section reads/writes the resolved model info.
 	// OpenAiCompatibleModelInfo only adds optional fields over ModelInfo, so a
 	// resolved ModelInfo satisfies it structurally.
-	const openAiModelInfo: OpenAiCompatibleModelInfo = selectedModelInfo
+	const openAiModelInfo: OpenAiCompatibleModelInfo = selectedModelInfo ?? openAiModelInfoSafeDefaults
+	const selectedModelOverrides = fromProtobufProviderModelOverrides(committedSelection?.overrides) ?? {}
+	const selectedModelOverridesRef = useRef<{ modelId: string | undefined; overrides: ProviderModelOverrides }>({
+		modelId: selectedModelId,
+		overrides: selectedModelOverrides,
+	})
+
+	// Counts commits whose commit+read-back round-trip has not finished yet.
+	const pendingCommitsRef = useRef(0)
+
+	useEffect(() => {
+		// Do not reseed the pending-override accumulator from server state
+		// while commits are in flight: an earlier commit's read-back can land
+		// after a later local edit, and reseeding from that stale snapshot
+		// would silently drop the already-committed newer field.
+		if (pendingCommitsRef.current > 0) {
+			return
+		}
+		selectedModelOverridesRef.current = { modelId: selectedModelId, overrides: selectedModelOverrides }
+	}, [committedSelection?.overrides, selectedModelId])
 
 	const commitOpenAiSelection = useCallback(
-		(modelId: string, modelInfo = openAiModelInfo ?? openAiModelInfoSafeDefaults) => {
+		(modelId: string, overrides?: ProviderModelOverrides) => {
 			if (!modelId.trim()) {
 				return
 			}
 
+			pendingCommitsRef.current += 1
 			void commitSelection(currentMode, {
 				providerId,
 				modelId,
-				modelInfo: {
-					...modelInfo,
-					supportsPromptCache: modelInfo.supportsPromptCache ?? openAiModelInfoSafeDefaults.supportsPromptCache,
-				},
-			}).catch((error) => handleProviderConfigWriteError("model selection", error))
+				...(overrides !== undefined ? { overrides } : {}),
+			})
+				.catch((error) => handleProviderConfigWriteError("model selection", error))
+				.finally(() => {
+					pendingCommitsRef.current -= 1
+				})
 		},
-		[commitSelection, currentMode, handleProviderConfigWriteError, openAiModelInfo],
+		[commitSelection, currentMode, handleProviderConfigWriteError, providerId],
 	)
 
-	const handleOpenAiModelInfoChange = useCallback(
-		(modelInfo: typeof openAiModelInfoSafeDefaults) => {
-			if (isOpenAiProvider) {
-				handleModeFieldChange({ plan: "planModeOpenAiModelInfo", act: "actModeOpenAiModelInfo" }, modelInfo, currentMode)
+	const updateModelOverride = useCallback(
+		<K extends keyof ProviderModelOverrides>(key: K, value: ProviderModelOverrides[K] | undefined) => {
+			const modelId = selectedModelId?.trim()
+			if (!modelId) {
+				return
 			}
-			commitOpenAiSelection(selectedModelId || "", modelInfo)
+
+			const currentOverrides =
+				selectedModelOverridesRef.current.modelId === modelId ? selectedModelOverridesRef.current.overrides : {}
+			const nextOverrides = { ...currentOverrides }
+			if (value === undefined) {
+				delete nextOverrides[key]
+			} else {
+				Object.assign(nextOverrides, { [key]: value })
+			}
+			selectedModelOverridesRef.current = { modelId, overrides: nextOverrides }
+			commitOpenAiSelection(modelId, nextOverrides)
 		},
-		[commitOpenAiSelection, currentMode, handleModeFieldChange, isOpenAiProvider, selectedModelId],
+		[commitOpenAiSelection, selectedModelId],
+	)
+
+	const updateNumericModelOverride = useCallback(
+		(key: NumericModelOverrideKey, label: string, value: string) => {
+			const parsed = parseOptionalFiniteNumber(value)
+			if (!parsed.valid) {
+				setModelFieldErrors((current) => ({ ...current, [key]: `${label} must be a valid number.` }))
+				return
+			}
+			setModelFieldErrors((current) => {
+				const next = { ...current }
+				delete next[key]
+				return next
+			})
+			// Debounced fields fire with their initial value on mount and on
+			// model/mode switches; committing that echo would persist resolved
+			// catalog values as user overrides. Only commit actual edits.
+			// Compare against the pending override when one is in flight so a
+			// quick revert during a commit round-trip is not mistaken for an
+			// echo of the (stale) displayed value.
+			const pendingOverrides =
+				selectedModelOverridesRef.current.modelId === selectedModelId?.trim()
+					? selectedModelOverridesRef.current.overrides
+					: undefined
+			const effectiveValue =
+				pendingOverrides && Object.hasOwn(pendingOverrides, key)
+					? displayedModelNumber(pendingOverrides[key] as number | undefined)
+					: displayedModelNumber(openAiModelInfo?.[key])
+			if (parsed.value === effectiveValue) {
+				return
+			}
+			updateModelOverride(key, parsed.value)
+		},
+		[updateModelOverride, openAiModelInfo, selectedModelId],
 	)
 
 	// Debounced function to refresh OpenAI models (prevents excessive API calls while typing)
@@ -130,6 +191,7 @@ export const OpenAICompatibleProvider = ({
 			if (debounceTimerRef.current) {
 				clearTimeout(debounceTimerRef.current)
 			}
+			openAiModelsRequestRef.current += 1
 		}
 	}, [])
 
@@ -196,22 +258,14 @@ export const OpenAICompatibleProvider = ({
 		void refreshOpenAiModels(config?.baseUrl, latestOpenAiApiKeyRef.current)
 	}, [config?.baseUrl, refreshOpenAiModels])
 
-	const toOpenAiModelInfo = useCallback(
-		(modelId: string): ModelInfo => ({
-			...openAiModelInfoSafeDefaults,
-			name: modelId,
-		}),
-		[],
-	)
-
 	const handleOpenAiModelSelection = useCallback(
-		(modelId: string, modelInfo = toOpenAiModelInfo(modelId)) => {
+		(modelId: string) => {
 			if (isOpenAiProvider) {
 				handleModeFieldChange({ plan: "planModeOpenAiModelId", act: "actModeOpenAiModelId" }, modelId, currentMode)
 			}
-			commitOpenAiSelection(modelId, modelInfo)
+			commitOpenAiSelection(modelId)
 		},
-		[commitOpenAiSelection, currentMode, handleModeFieldChange, isOpenAiProvider, toOpenAiModelInfo],
+		[commitOpenAiSelection, currentMode, handleModeFieldChange, isOpenAiProvider],
 	)
 
 	const { savedApiKeyMask, handleApiKeyChange } = useProviderApiKeyField({
@@ -261,7 +315,10 @@ export const OpenAICompatibleProvider = ({
 
 			<ApiKeyField initialValue={savedApiKeyMask} onChange={handleApiKeyChange} providerName="OpenAI Compatible" />
 
-			{isRefreshingOpenAiModels && <div role="status">Loading models…</div>}
+			<label htmlFor="openai-compatible-model-picker">
+				<span style={{ fontWeight: 500 }}>Model ID</span>
+				{isRefreshingOpenAiModels && <span> Loading models…</span>}
+			</label>
 			{openAiModelsError && <div role="alert">{openAiModelsError}</div>}
 			{availableOpenAiModels.length > 0 ? (
 				<div
@@ -271,9 +328,6 @@ export const OpenAICompatibleProvider = ({
 						gap: 8,
 						marginBottom: 10,
 					}}>
-					<label htmlFor="openai-compatible-model-picker">
-						<span style={{ fontWeight: 500 }}>Model ID</span>
-					</label>
 					<select
 						aria-label="Model ID"
 						id="openai-compatible-model-picker"
@@ -316,9 +370,8 @@ export const OpenAICompatibleProvider = ({
 					initialValue={selectedModelId || ""}
 					onChange={(value) => handleOpenAiModelSelection(value)}
 					placeholder={"Enter Model ID..."}
-					style={{ width: "100%", marginBottom: 10 }}>
-					<span style={{ fontWeight: 500 }}>Model ID</span>
-				</DebouncedTextField>
+					style={{ width: "100%", marginBottom: 10 }}
+				/>
 			)}
 
 			{/* OpenAI Compatible Custom Headers */}
@@ -475,105 +528,67 @@ export const OpenAICompatibleProvider = ({
 				<>
 					<VSCodeCheckbox
 						checked={!!openAiModelInfo?.supportsImages}
-						onChange={(e: any) => {
-							const isChecked = e.target.checked === true
-							const modelInfo = openAiModelInfo ? { ...openAiModelInfo } : { ...openAiModelInfoSafeDefaults }
-							modelInfo.supportsImages = isChecked
-							handleOpenAiModelInfoChange(modelInfo)
-						}}>
+						onChange={(e: any) => updateModelOverride("supportsVision", e.target.checked === true)}>
 						Supports Images
 					</VSCodeCheckbox>
 
 					<VSCodeCheckbox
-						checked={!!openAiModelInfo?.isR1FormatRequired}
-						onChange={(e: any) => {
-							const isChecked = e.target.checked === true
-							let modelInfo = openAiModelInfo ? { ...openAiModelInfo } : { ...openAiModelInfoSafeDefaults }
-							modelInfo = { ...modelInfo, isR1FormatRequired: isChecked }
-
-							handleOpenAiModelInfoChange(modelInfo)
-						}}>
+						checked={selectedModelOverrides.isR1FormatRequired ?? openAiModelInfo.apiFormat === ApiFormat.R1_CHAT}
+						onChange={(e: any) => updateModelOverride("isR1FormatRequired", e.target.checked === true)}>
 						Enable R1 messages format
 					</VSCodeCheckbox>
 
 					<div style={{ display: "flex", gap: 10, marginTop: "5px" }}>
-						<DebouncedTextField
-							initialValue={
-								openAiModelInfo?.contextWindow
-									? openAiModelInfo.contextWindow.toString()
-									: (openAiModelInfoSafeDefaults.contextWindow?.toString() ?? "")
-							}
-							onChange={(value) => {
-								const modelInfo = openAiModelInfo ? { ...openAiModelInfo } : { ...openAiModelInfoSafeDefaults }
-								modelInfo.contextWindow = Number(value)
-								handleOpenAiModelInfoChange(modelInfo)
-							}}
-							style={{ flex: 1 }}>
-							<span style={{ fontWeight: 500 }}>Context Window Size</span>
-						</DebouncedTextField>
+						<div style={{ flex: 1 }}>
+							<DebouncedTextField
+								initialValue={formatOptionalModelNumber(openAiModelInfo?.contextWindow)}
+								onChange={(value) => updateNumericModelOverride("contextWindow", "Context Window Size", value)}>
+								<span style={{ fontWeight: 500 }}>Context Window Size</span>
+							</DebouncedTextField>
+							{modelFieldErrors.contextWindow && <div role="alert">{modelFieldErrors.contextWindow}</div>}
+						</div>
 
-						<DebouncedTextField
-							initialValue={
-								openAiModelInfo?.maxTokens
-									? openAiModelInfo.maxTokens.toString()
-									: (openAiModelInfoSafeDefaults.maxTokens?.toString() ?? "")
-							}
-							onChange={(value) => {
-								const modelInfo = openAiModelInfo ? { ...openAiModelInfo } : { ...openAiModelInfoSafeDefaults }
-								modelInfo.maxTokens = Number(value)
-								handleOpenAiModelInfoChange(modelInfo)
-							}}
-							style={{ flex: 1 }}>
-							<span style={{ fontWeight: 500 }}>Max Output Tokens</span>
-						</DebouncedTextField>
+						<div style={{ flex: 1 }}>
+							<DebouncedTextField
+								initialValue={formatOptionalModelNumber(openAiModelInfo?.maxTokens)}
+								onChange={(value) => updateNumericModelOverride("maxTokens", "Max Output Tokens", value)}
+								placeholder="not set">
+								<span style={{ fontWeight: 500 }}>Max Output Tokens</span>
+							</DebouncedTextField>
+							{modelFieldErrors.maxTokens && <div role="alert">{modelFieldErrors.maxTokens}</div>}
+						</div>
 					</div>
 
 					<div style={{ display: "flex", gap: 10, marginTop: "5px" }}>
-						<DebouncedTextField
-							initialValue={
-								openAiModelInfo?.inputPrice
-									? openAiModelInfo.inputPrice.toString()
-									: (openAiModelInfoSafeDefaults.inputPrice?.toString() ?? "")
-							}
-							onChange={(value) => {
-								const modelInfo = openAiModelInfo ? { ...openAiModelInfo } : { ...openAiModelInfoSafeDefaults }
-								modelInfo.inputPrice = parsePrice(value, openAiModelInfoSafeDefaults.inputPrice ?? 0)
-								handleOpenAiModelInfoChange(modelInfo)
-							}}
-							style={{ flex: 1 }}>
-							<span style={{ fontWeight: 500 }}>Input Price / 1M tokens</span>
-						</DebouncedTextField>
+						<div style={{ flex: 1 }}>
+							<DebouncedTextField
+								initialValue={formatOptionalModelNumber(openAiModelInfo?.inputPrice)}
+								onChange={(value) => updateNumericModelOverride("inputPrice", "Input Price", value)}>
+								<span style={{ fontWeight: 500 }}>Input Price / 1M tokens</span>
+							</DebouncedTextField>
+							{modelFieldErrors.inputPrice && <div role="alert">{modelFieldErrors.inputPrice}</div>}
+						</div>
 
-						<DebouncedTextField
-							initialValue={
-								openAiModelInfo?.outputPrice
-									? openAiModelInfo.outputPrice.toString()
-									: (openAiModelInfoSafeDefaults.outputPrice?.toString() ?? "")
-							}
-							onChange={(value) => {
-								const modelInfo = openAiModelInfo ? { ...openAiModelInfo } : { ...openAiModelInfoSafeDefaults }
-								modelInfo.outputPrice = parsePrice(value, openAiModelInfoSafeDefaults.outputPrice ?? 0)
-								handleOpenAiModelInfoChange(modelInfo)
-							}}
-							style={{ flex: 1 }}>
-							<span style={{ fontWeight: 500 }}>Output Price / 1M tokens</span>
-						</DebouncedTextField>
+						<div style={{ flex: 1 }}>
+							<DebouncedTextField
+								initialValue={formatOptionalModelNumber(openAiModelInfo?.outputPrice)}
+								onChange={(value) => updateNumericModelOverride("outputPrice", "Output Price", value)}>
+								<span style={{ fontWeight: 500 }}>Output Price / 1M tokens</span>
+							</DebouncedTextField>
+							{modelFieldErrors.outputPrice && <div role="alert">{modelFieldErrors.outputPrice}</div>}
+						</div>
 					</div>
 
 					<div style={{ display: "flex", gap: 10, marginTop: "5px" }}>
-						<DebouncedTextField
-							initialValue={
-								openAiModelInfo?.temperature
-									? openAiModelInfo.temperature.toString()
-									: (openAiModelInfoSafeDefaults.temperature?.toString() ?? "")
-							}
-							onChange={(value) => {
-								const modelInfo = openAiModelInfo ? { ...openAiModelInfo } : { ...openAiModelInfoSafeDefaults }
-								modelInfo.temperature = parsePrice(value, openAiModelInfoSafeDefaults.temperature ?? 0)
-								handleOpenAiModelInfoChange(modelInfo)
-							}}>
-							<span style={{ fontWeight: 500 }}>Temperature</span>
-						</DebouncedTextField>
+						<div>
+							<DebouncedTextField
+								initialValue={formatOptionalModelNumber(openAiModelInfo?.temperature)}
+								onChange={(value) => updateNumericModelOverride("temperature", "Temperature", value)}
+								placeholder="not set">
+								<span style={{ fontWeight: 500 }}>Temperature</span>
+							</DebouncedTextField>
+							{modelFieldErrors.temperature && <div role="alert">{modelFieldErrors.temperature}</div>}
+						</div>
 					</div>
 				</>
 			)}
@@ -609,4 +624,26 @@ export const OpenAICompatibleProvider = ({
 			)}
 		</div>
 	)
+}
+
+type NumericModelOverrideKey = "contextWindow" | "maxTokens" | "inputPrice" | "outputPrice" | "temperature"
+
+type ParsedOptionalNumber = { valid: true; value: number | undefined } | { valid: false }
+
+// -1 is the legacy UI sentinel for "not set"; it renders (and compares) as unset.
+function displayedModelNumber(value: number | undefined): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) && value !== -1 ? value : undefined
+}
+
+function formatOptionalModelNumber(value: number | undefined): string {
+	return displayedModelNumber(value)?.toString() ?? ""
+}
+
+function parseOptionalFiniteNumber(value: string): ParsedOptionalNumber {
+	const trimmed = value.trim()
+	if (!trimmed) {
+		return { valid: true, value: undefined }
+	}
+	const parsed = Number(trimmed)
+	return Number.isFinite(parsed) ? { valid: true, value: parsed } : { valid: false }
 }

--- a/apps/vscode/webview-ui/src/components/settings/providers/OpenAiCodexProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/OpenAiCodexProvider.tsx
@@ -1,4 +1,3 @@
-import { openAiModelInfoSafeDefaults } from "@shared/api"
 import { fromProtobufModelInfo } from "@shared/proto-conversions/models/typeConversion"
 import type { Mode } from "@shared/storage/types"
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
@@ -35,7 +34,6 @@ export const OpenAiCodexProvider = ({ showModelOptions, isPopup, currentMode }: 
 	const { config, commitSelection } = useProviderConfig(OPENAI_CODEX_PROVIDER_ID)
 	const {
 		models,
-		defaultModelId,
 		selectedModelId: legacySelectedModelId,
 		selectedModelInfo: legacySelectedModelInfo,
 		hideUsageCost,
@@ -53,13 +51,9 @@ export const OpenAiCodexProvider = ({ showModelOptions, isPopup, currentMode }: 
 			return
 		}
 
-		const fallbackModelId = defaultModelId || Object.keys(models)[0] || modelId
-		const modelInfo = models[modelId] ?? models[fallbackModelId] ?? selectedModelInfo ?? openAiModelInfoSafeDefaults
-
 		void commitSelection(currentMode, {
 			providerId: OPENAI_CODEX_PROVIDER_ID,
 			modelId,
-			modelInfo,
 		}).catch((err) => console.error("Failed to commit OpenAI Codex model selection:", err))
 	}
 

--- a/apps/vscode/webview-ui/src/components/settings/providers/VSCodeLmProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/VSCodeLmProvider.tsx
@@ -1,4 +1,3 @@
-import { openAiModelInfoSafeDefaults } from "@shared/api"
 import { EmptyRequest } from "@shared/proto/cline/common"
 import type { Mode } from "@shared/storage/types"
 import { parseVsCodeLmModelSelector, stringifyVsCodeLmModelSelector } from "@shared/vsCodeSelectorUtils"
@@ -66,8 +65,7 @@ export const VSCodeLmProvider = ({ currentMode }: VSCodeLmProviderProps) => {
 		void commitSelection(currentMode, {
 			providerId: "vscode-lm",
 			modelId,
-			modelInfo: {
-				...openAiModelInfoSafeDefaults,
+			overrides: {
 				name: [selector.vendor, selector.family].filter(Boolean).join(" - ") || modelId,
 			},
 		}).catch((err) => console.error("Failed to commit VS Code LM model selection:", err))

--- a/apps/vscode/webview-ui/src/hooks/useProviderConfig.test.ts
+++ b/apps/vscode/webview-ui/src/hooks/useProviderConfig.test.ts
@@ -1,9 +1,9 @@
 import { StringRequest } from "@shared/proto/cline/common"
-import { ApiFormat, ProviderConfigResponse } from "@shared/proto/cline/models"
+import { ApiFormat, ModelOverrides, ProviderConfigResponse } from "@shared/proto/cline/models"
 import { act, renderHook, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { ModelsServiceClient } from "@/services/grpc-client"
-import { useProviderConfig } from "./useProviderConfig"
+import { fromProtobufProviderModelOverrides, toProtobufProviderModelOverrides, useProviderConfig } from "./useProviderConfig"
 
 vi.mock("@/services/grpc-client", () => ({
 	ModelsServiceClient: {
@@ -57,7 +57,7 @@ describe("useProviderConfig", () => {
 		expect(result.current.config?.baseUrl).toBe("https://custom.example/v1")
 	})
 
-	it("commitSelection sends the full selection envelope and refreshes config", async () => {
+	it("commitSelection sends model settings and refreshes config", async () => {
 		vi.mocked(ModelsServiceClient.readProviderConfig)
 			.mockResolvedValueOnce(config())
 			.mockResolvedValueOnce(
@@ -76,6 +76,11 @@ describe("useProviderConfig", () => {
 							apiFormat: ApiFormat.OPENAI_CHAT,
 							tiers: [],
 						},
+						overrides: ModelOverrides.create({
+							apiFormat: ApiFormat.OPENAI_RESPONSES,
+							capabilities: ["tools", "streaming"],
+							temperature: 0.4,
+						}),
 					},
 				}),
 			)
@@ -87,7 +92,7 @@ describe("useProviderConfig", () => {
 			await result.current.commitSelection("act", {
 				providerId: "deepseek",
 				modelId: "deepseek-v4-flash",
-				modelInfo: { name: "DeepSeek V4 Flash", supportsPromptCache: true, apiFormat: ApiFormat.OPENAI_CHAT },
+				overrides: { name: "DeepSeek V4 Flash", capabilities: ["prompt-cache"] },
 			})
 		})
 
@@ -96,15 +101,64 @@ describe("useProviderConfig", () => {
 				providerId: "deepseek",
 				mode: "act",
 				modelId: "deepseek-v4-flash",
-				modelInfo: expect.objectContaining({
+				overrides: expect.objectContaining({
 					name: "DeepSeek V4 Flash",
-					supportsPromptCache: true,
-					apiFormat: ApiFormat.OPENAI_CHAT,
+					capabilities: ["prompt-cache"],
 				}),
 			}),
 		)
 		expect(ModelsServiceClient.readProviderConfig).toHaveBeenCalledTimes(2)
 		expect(result.current.config?.actSelection?.modelId).toBe("deepseek-v4-flash")
+		expect(fromProtobufProviderModelOverrides(result.current.config?.actSelection?.overrides)).toEqual({
+			apiFormat: ApiFormat.OPENAI_RESPONSES,
+			capabilities: ["tools", "streaming"],
+			temperature: 0.4,
+		})
+	})
+
+	it("converts every domain override field explicitly and preserves an empty override message", () => {
+		const overrides = {
+			name: "Custom",
+			maxTokens: 8_192,
+			contextWindow: 128_000,
+			maxInputTokens: 120_000,
+			capabilities: ["tools", "streaming"],
+			supportsVision: false,
+			supportsAttachments: true,
+			supportsReasoning: false,
+			inputPrice: 1,
+			outputPrice: 2,
+			cacheReadsPrice: 3,
+			cacheWritesPrice: 4,
+			temperature: 0.2,
+			apiFormat: ApiFormat.OPENAI_RESPONSES,
+			isR1FormatRequired: false,
+		}
+
+		expect(fromProtobufProviderModelOverrides(toProtobufProviderModelOverrides(overrides))).toEqual(overrides)
+		expect(toProtobufProviderModelOverrides({})).toEqual(ModelOverrides.create({}))
+	})
+
+	it("sends an explicit empty override message so the host can clear stored overrides", async () => {
+		vi.mocked(ModelsServiceClient.readProviderConfig).mockResolvedValue(config())
+		vi.mocked(ModelsServiceClient.commitModelSelection).mockResolvedValue({})
+		const { result } = renderHook(() => useProviderConfig("deepseek"))
+		await waitFor(() => expect(result.current.config).toBeDefined())
+
+		await act(async () => {
+			await result.current.commitSelection("act", {
+				providerId: "deepseek",
+				modelId: "custom-model",
+				overrides: {},
+			})
+		})
+
+		expect(ModelsServiceClient.commitModelSelection).toHaveBeenCalledWith(
+			expect.objectContaining({
+				modelId: "custom-model",
+				overrides: ModelOverrides.create({}),
+			}),
+		)
 	})
 
 	it("commitSelection rejects mismatched provider ids without calling RPC", async () => {
@@ -116,7 +170,6 @@ describe("useProviderConfig", () => {
 			result.current.commitSelection("act", {
 				providerId: "openrouter",
 				modelId: "deepseek-v4-flash",
-				modelInfo: { supportsPromptCache: true },
 			}),
 		).rejects.toThrow("selection providerId openrouter does not match hook providerId deepseek")
 		expect(ModelsServiceClient.commitModelSelection).not.toHaveBeenCalled()

--- a/apps/vscode/webview-ui/src/hooks/useProviderConfig.ts
+++ b/apps/vscode/webview-ui/src/hooks/useProviderConfig.ts
@@ -7,11 +7,13 @@ import {
 	WriteProviderConfigPatch,
 	WriteProviderConfigRequest,
 } from "@shared/proto/cline/models"
-import { toProtobufModelInfo } from "@shared/proto-conversions/models/typeConversion"
+import {
+	type ProviderModelOverrides,
+	toProtobufModelOverrides as toProtobufProviderModelOverrides,
+} from "@shared/proto-conversions/models/modelOverrides"
 import { useCallback, useEffect, useState } from "react"
 import type { ProviderId } from "@/context/ExtensionStateContext"
 import { ModelsServiceClient } from "@/services/grpc-client"
-import type { ModelInfo } from "../../../src/shared/api"
 
 export type ProviderConfigWritePatch = Partial<Omit<WriteProviderConfigPatch, "headers" | "aws" | "gcp">> & {
 	headers?: Record<string, string>
@@ -19,10 +21,23 @@ export type ProviderConfigWritePatch = Partial<Omit<WriteProviderConfigPatch, "h
 	gcp?: Partial<GcpProviderConfig>
 }
 
+// The overrides domain type and its proto conversions are shared with the
+// host; see the tri-state and normalization semantics documented there.
+export {
+	fromProtobufModelOverrides as fromProtobufProviderModelOverrides,
+	toProtobufModelOverrides as toProtobufProviderModelOverrides,
+} from "@shared/proto-conversions/models/modelOverrides"
+export type { ProviderModelOverrides }
+
 export interface ProviderModelSelection {
 	providerId: ProviderId
 	modelId: string
-	modelInfo: ModelInfo
+	/**
+	 * Tri-state: `undefined` preserves the model's stored overrides, an
+	 * explicitly empty object clears them, and a non-empty object replaces
+	 * them wholesale.
+	 */
+	overrides?: ProviderModelOverrides
 }
 
 function toWriteProviderConfigPatch(patch: ProviderConfigWritePatch): WriteProviderConfigPatch {
@@ -74,7 +89,8 @@ export function useProviderConfig(providerId: ProviderId) {
 					providerId,
 					mode,
 					modelId: selection.modelId,
-					modelInfo: toProtobufModelInfo(selection.modelInfo),
+					overrides:
+						selection.overrides !== undefined ? toProtobufProviderModelOverrides(selection.overrides) : undefined,
 				}),
 			)
 			await read()

--- a/apps/vscode/webview-ui/src/hooks/useProviderModelSelection.test.ts
+++ b/apps/vscode/webview-ui/src/hooks/useProviderModelSelection.test.ts
@@ -1,0 +1,66 @@
+import { ApiFormat } from "@shared/proto/cline/models"
+import { act, renderHook } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { useProviderModelSelection } from "./useProviderModelSelection"
+
+describe("useProviderModelSelection", () => {
+	it("does not turn custom fallback model info into persisted overrides", async () => {
+		const commitSelection = vi.fn(async () => undefined)
+		const customModelInfo = {
+			name: "Custom model",
+			contextWindow: 128_000,
+			maxTokens: -1,
+			inputPrice: 0,
+			outputPrice: 0,
+			temperature: 0,
+		}
+		const { result } = renderHook(() =>
+			useProviderModelSelection("custom-provider", "act", {
+				models: {},
+				commitSelection,
+				customModelInfo: () => customModelInfo,
+			}),
+		)
+
+		await act(async () => {
+			await result.current.commitModelSelection({ modelId: "custom-model", modelInfo: customModelInfo })
+		})
+
+		expect(commitSelection).toHaveBeenCalledWith("act", {
+			providerId: "custom-provider",
+			modelId: "custom-model",
+		})
+	})
+
+	it("forwards only explicitly supplied overrides", async () => {
+		const commitSelection = vi.fn(async () => undefined)
+		const { result } = renderHook(() =>
+			useProviderModelSelection("custom-provider", "act", {
+				models: {},
+				commitSelection,
+			}),
+		)
+
+		await act(async () => {
+			await result.current.commitModelSelection({
+				modelId: "custom-model",
+				modelInfo: { contextWindow: 128_000, maxTokens: -1, temperature: -1 },
+				overrides: {
+					apiFormat: ApiFormat.OPENAI_RESPONSES,
+					capabilities: ["tools", "streaming"],
+					temperature: 0.2,
+				},
+			})
+		})
+
+		expect(commitSelection).toHaveBeenCalledWith("act", {
+			providerId: "custom-provider",
+			modelId: "custom-model",
+			overrides: {
+				apiFormat: ApiFormat.OPENAI_RESPONSES,
+				capabilities: ["tools", "streaming"],
+				temperature: 0.2,
+			},
+		})
+	})
+})

--- a/apps/vscode/webview-ui/src/hooks/useProviderModelSelection.ts
+++ b/apps/vscode/webview-ui/src/hooks/useProviderModelSelection.ts
@@ -6,6 +6,14 @@ import { useCallback } from "react"
 import type { ProviderId } from "@/context/ExtensionStateContext"
 import type { ProviderModelSelection } from "./useProviderConfig"
 
+type ProviderModelSelectionInput =
+	| (Omit<ProviderModelSelection, "providerId"> & { modelInfo?: ModelInfo })
+	| (ProviderModelSelection & { modelInfo?: ModelInfo })
+
+interface DisplayProviderModelSelection extends ProviderModelSelection {
+	modelInfo: ModelInfo
+}
+
 interface UseProviderModelSelectionOptions {
 	models: Record<string, ModelInfo>
 	defaultModelId?: string
@@ -36,17 +44,18 @@ export function useProviderModelSelection(
 			(selectedModelId && customModelInfo ? customModelInfo(selectedModelId) : undefined) ??
 			fallbackModelInfo)
 
-	const selectedModel: ProviderModelSelection = {
+	const selectedModel: DisplayProviderModelSelection = {
 		providerId,
 		modelId: selectedModelId,
 		modelInfo: selectedModelInfo,
 	}
 
 	const commitModelSelection = useCallback(
-		(selection: Omit<ProviderModelSelection, "providerId"> | ProviderModelSelection) => {
+		(selection: ProviderModelSelectionInput) => {
 			return commitSelection(currentMode, {
-				...selection,
 				providerId,
+				modelId: selection.modelId,
+				...(selection.overrides !== undefined ? { overrides: selection.overrides } : {}),
 			})
 		},
 		[commitSelection, currentMode, providerId],

--- a/sdk/packages/core/src/extensions/tools/team/delegated-agent.ts
+++ b/sdk/packages/core/src/extensions/tools/team/delegated-agent.ts
@@ -30,6 +30,7 @@ export type DelegatedAgentConnectionConfig = Pick<
 	| "reasoningEffort"
 	| "thinkingBudgetTokens"
 	| "maxTokensPerTurn"
+	| "temperature"
 >;
 
 export interface DelegatedAgentRuntimeConfig
@@ -93,6 +94,7 @@ export function createDelegatedAgentConfigProvider(
 			reasoningEffort: runtimeConfig.reasoningEffort,
 			thinkingBudgetTokens: runtimeConfig.thinkingBudgetTokens,
 			maxTokensPerTurn: runtimeConfig.maxTokensPerTurn,
+			temperature: runtimeConfig.temperature,
 		}),
 		updateConnectionDefaults: (overrides) => {
 			runtimeConfig = {

--- a/sdk/packages/core/src/extensions/tools/team/spawn-agent-tool.test.ts
+++ b/sdk/packages/core/src/extensions/tools/team/spawn-agent-tool.test.ts
@@ -340,6 +340,7 @@ describe("createSpawnAgentTool", () => {
 			providerId: "cline",
 			modelId: "stale-model",
 			apiKey: "oauth-access-old",
+			temperature: 0.3,
 		});
 		const updateConnectionDefaults = vi.spyOn(
 			configProvider,
@@ -372,6 +373,7 @@ describe("createSpawnAgentTool", () => {
 			expect.objectContaining({
 				apiKey: "oauth-access-new",
 				modelId: "updated-model",
+				temperature: 0.3,
 			}),
 		);
 	});

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -577,6 +577,15 @@ export type {
 } from "./services/plugin-uninstall";
 export { uninstallPlugin } from "./services/plugin-uninstall";
 export {
+	ensureCustomProvidersLoadedSync,
+	readModelsFileSync,
+	resolveModelsRegistryPath,
+	type StoredModelEntry,
+	type StoredProviderEntry,
+	syncStoredProviderRegistration,
+	writeModelsFileSync,
+} from "./services/providers/local-provider-registry";
+export {
 	addLocalProvider,
 	type DeleteLocalProviderRequest,
 	deleteLocalProvider,

--- a/sdk/packages/core/src/runtime/config/agent-runtime-config-builder.test.ts
+++ b/sdk/packages/core/src/runtime/config/agent-runtime-config-builder.test.ts
@@ -57,6 +57,7 @@ describe("buildModelOptions", () => {
 			reasoningEffort: "high",
 			thinkingBudgetTokens: 1024,
 			maxTokensPerTurn: 4096,
+			temperature: 0.2,
 			apiTimeoutMs: 60_000,
 		});
 		expect(buildModelOptions(config)).toEqual({
@@ -64,6 +65,7 @@ describe("buildModelOptions", () => {
 			reasoningEffort: "high",
 			thinkingBudgetTokens: 1024,
 			maxTokensPerTurn: 4096,
+			temperature: 0.2,
 			apiTimeoutMs: 60_000,
 		});
 	});

--- a/sdk/packages/core/src/runtime/config/agent-runtime-config-builder.ts
+++ b/sdk/packages/core/src/runtime/config/agent-runtime-config-builder.ts
@@ -144,6 +144,9 @@ export function buildModelOptions(
 	if (config.maxTokensPerTurn !== undefined) {
 		options.maxTokensPerTurn = config.maxTokensPerTurn;
 	}
+	if (config.temperature !== undefined) {
+		options.temperature = config.temperature;
+	}
 	if (config.apiTimeoutMs !== undefined) {
 		options.apiTimeoutMs = config.apiTimeoutMs;
 	}

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
@@ -565,6 +565,7 @@ describe("LocalRuntimeHost", () => {
 					thinking: true,
 					reasoningEffort: "high",
 					thinkingBudgetTokens: 1024,
+					temperature: 0.3,
 				}),
 				prompt: "hello",
 				interactive: true,
@@ -576,6 +577,7 @@ describe("LocalRuntimeHost", () => {
 				thinking: true,
 				reasoningEffort: "high",
 				thinkingBudgetTokens: 1024,
+				temperature: 0.3,
 			}),
 		);
 

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -571,6 +571,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 				configWithProvider.reasoningEffort ?? providerConfig.reasoningEffort,
 			thinkingBudgetTokens: configWithProvider.thinkingBudgetTokens,
 			maxTokensPerTurn: configWithProvider.maxTokensPerTurn,
+			temperature: configWithProvider.temperature,
 			systemPrompt: configWithProvider.systemPrompt,
 			maxIterations: configWithProvider.maxIterations,
 			execution: configWithProvider.execution,

--- a/sdk/packages/core/src/runtime/orchestration/runtime-builder.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-builder.ts
@@ -488,6 +488,7 @@ export class DefaultRuntimeBuilder implements RuntimeBuilder {
 			reasoningEffort: config.reasoningEffort,
 			thinkingBudgetTokens: config.thinkingBudgetTokens,
 			maxTokensPerTurn: config.maxTokensPerTurn,
+			temperature: config.temperature,
 			maxIterations: config.maxIterations,
 			hooks,
 			extensions: runtimeExtensions,

--- a/sdk/packages/core/src/services/llms/handler-factory.test.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.test.ts
@@ -200,7 +200,7 @@ describe("createAgentModelFromConfig", () => {
 		});
 	});
 
-	it("uses explicit per-turn max tokens for gateway request limits", async () => {
+	it("uses explicit per-turn max tokens and temperature for gateway request limits", async () => {
 		const { createAgentModelFromConfig } = await import("./handler-factory");
 
 		createAgentModelFromConfig(
@@ -211,6 +211,7 @@ describe("createAgentModelFromConfig", () => {
 				systemPrompt: "",
 				tools: [],
 				maxTokensPerTurn: 4_096,
+				temperature: 0,
 				providerConfig: {
 					providerId: "openai-compatible",
 					modelId: "custom-model",
@@ -221,7 +222,7 @@ describe("createAgentModelFromConfig", () => {
 
 		expect(gatewayMock.createAgentModel).toHaveBeenLastCalledWith(
 			{ providerId: "openai-compatible", modelId: "custom-model" },
-			{ maxTokens: 4_096 },
+			{ maxTokens: 4_096, temperature: 0 },
 		);
 	});
 

--- a/sdk/packages/core/src/services/llms/handler-factory.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.ts
@@ -164,6 +164,7 @@ export function createAgentModelFromConfig(
 		headers: config.headers ?? baseProviderConfig?.headers,
 		knownModels: resolveKnownModelsFromConfig(config),
 		maxOutputTokens: config.maxTokensPerTurn,
+		temperature: config.temperature,
 		reasoningEffort: config.reasoningEffort,
 		thinkingBudgetTokens: config.thinkingBudgetTokens,
 		thinking: config.thinking,
@@ -216,6 +217,9 @@ export function createAgentModelFromConfig(
 			providerId: normalizedProviderConfig.providerId,
 			modelId: normalizedProviderConfig.modelId,
 		},
-		{ maxTokens: normalizedProviderConfig.maxOutputTokens },
+		{
+			maxTokens: normalizedProviderConfig.maxOutputTokens,
+			temperature: normalizedProviderConfig.temperature,
+		},
 	);
 }

--- a/sdk/packages/core/src/services/providers/local-provider-registry.ts
+++ b/sdk/packages/core/src/services/providers/local-provider-registry.ts
@@ -1,8 +1,16 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import * as LlmsModels from "@cline/llms";
 import {
+	ApiFormatSchema,
 	type ModelCapability,
 	ModelCapabilitySchema,
 	type ModelInfo,
@@ -15,23 +23,44 @@ import {
 	ProviderProtocolSchema,
 } from "@cline/shared";
 import { z } from "zod";
+import { sdkDebug } from "../../logging/early-logger";
 import type {
 	ProviderSettings,
 	StoredProviderSettings,
 } from "../../types/provider-settings";
 import type { ProviderSettingsManager } from "../storage/provider-settings-manager";
 
+const OptionalPositiveFiniteNumberSchema = z
+	.number()
+	.finite()
+	.positive()
+	.optional()
+	.catch(undefined);
+const OptionalNonNegativeFiniteNumberSchema = z
+	.number()
+	.finite()
+	.nonnegative()
+	.optional()
+	.catch(undefined);
+
 export const StoredModelEntrySchema = z
 	.object({
 		id: z.string().optional(),
 		name: z.string().optional(),
-		maxTokens: z.number().optional(),
-		contextWindow: z.number().optional(),
-		maxInputTokens: z.number().optional(),
+		maxTokens: OptionalPositiveFiniteNumberSchema,
+		contextWindow: OptionalPositiveFiniteNumberSchema,
+		maxInputTokens: OptionalPositiveFiniteNumberSchema,
 		capabilities: z.array(ModelCapabilitySchema).optional(),
 		supportsVision: z.boolean().optional(),
 		supportsAttachments: z.boolean().optional(),
 		supportsReasoning: z.boolean().optional(),
+		inputPrice: OptionalNonNegativeFiniteNumberSchema,
+		outputPrice: OptionalNonNegativeFiniteNumberSchema,
+		cacheReadsPrice: OptionalNonNegativeFiniteNumberSchema,
+		cacheWritesPrice: OptionalNonNegativeFiniteNumberSchema,
+		temperature: OptionalNonNegativeFiniteNumberSchema,
+		apiFormat: ApiFormatSchema.optional(),
+		isR1FormatRequired: z.boolean().optional(),
 	})
 	.passthrough();
 
@@ -93,6 +122,7 @@ export function emptyModelsFile(): StoredModelsFile {
 export function parseModelsFile(input: unknown): StoredModelsFile {
 	const result = StoredModelsFileEnvelopeSchema.safeParse(input);
 	if (!result.success) {
+		sdkDebug("models.json content is not a valid models file envelope; starting from an empty registry");
 		return emptyModelsFile();
 	}
 
@@ -101,6 +131,10 @@ export function parseModelsFile(input: unknown): StoredModelsFile {
 		const provider = StoredProviderEntrySchema.safeParse(entry);
 		if (provider.success) {
 			providers[providerId] = provider.data;
+		} else {
+			sdkDebug(
+				`models.json: dropping invalid entry for provider=${providerId}`,
+			);
 		}
 	}
 	return { version: 1, providers };
@@ -114,7 +148,13 @@ export function readModelsFileSync(filePath: string): StoredModelsFile {
 		const raw = readFileSync(filePath, "utf8");
 		return parseModelsFile(JSON.parse(raw) as unknown);
 	} catch {
-		// Invalid or missing files fall back to an empty registry.
+		// The file exists but could not be read/parsed. Falling back to an
+		// empty registry is required for reads, but callers that then WRITE
+		// the empty state back would permanently destroy the user's data —
+		// leave a trace so that is diagnosable.
+		sdkDebug(
+			`models.json at ${filePath} exists but is unreadable or invalid JSON; treating as an empty registry`,
+		);
 	}
 	return emptyModelsFile();
 }
@@ -125,19 +165,35 @@ export async function readModelsFile(
 	try {
 		const raw = await readFile(filePath, "utf8");
 		return parseModelsFile(JSON.parse(raw) as unknown);
-	} catch {
-		// Invalid or missing files fall back to an empty registry.
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException | undefined)?.code !== "ENOENT") {
+			sdkDebug(
+				`models.json at ${filePath} exists but is unreadable or invalid JSON; treating as an empty registry`,
+			);
+		}
 	}
 	return emptyModelsFile();
 }
 
+// Stage to a pid-unique temp file and rename into place (mirrors
+// ProviderSettingsManager.write). Concurrent Cline processes (CLI, extension,
+// hub) share models.json; a bare writeFileSync lets readers catch a partial
+// file, which read paths treat as an empty registry — and the next
+// read-modify-write would persist that loss.
 export function writeModelsFileSync(
 	filePath: string,
 	state: StoredModelsFile,
 ): void {
 	mkdirSync(dirname(filePath), { recursive: true });
 	const parsed = StoredModelsFileSchema.parse(state);
-	writeFileSync(filePath, `${JSON.stringify(parsed, null, 2)}\n`, "utf8");
+	const tempPath = `${filePath}.${process.pid}.tmp`;
+	try {
+		writeFileSync(tempPath, `${JSON.stringify(parsed, null, 2)}\n`, "utf8");
+		renameSync(tempPath, filePath);
+	} catch (error) {
+		rmSync(tempPath, { force: true });
+		throw error;
+	}
 }
 
 export async function writeModelsFile(
@@ -146,7 +202,14 @@ export async function writeModelsFile(
 ): Promise<void> {
 	await mkdir(dirname(filePath), { recursive: true });
 	const parsed = StoredModelsFileSchema.parse(state);
-	await writeFile(filePath, `${JSON.stringify(parsed, null, 2)}\n`, "utf8");
+	const tempPath = `${filePath}.${process.pid}.tmp`;
+	try {
+		await writeFile(tempPath, `${JSON.stringify(parsed, null, 2)}\n`, "utf8");
+		await rename(tempPath, filePath);
+	} catch (error) {
+		await rm(tempPath, { force: true }).catch(() => {});
+		throw error;
+	}
 }
 
 export function toProviderModel(
@@ -245,17 +308,58 @@ function toStoredModelInfo(
 	const capabilities = new Set<ModelCapability>(
 		model?.capabilities ?? fallbackCapabilities ?? [],
 	);
-	if (model?.supportsVision) capabilities.add("images");
-	if (model?.supportsAttachments) capabilities.add("files");
-	if (model?.supportsReasoning) capabilities.add("reasoning");
+	if (model?.supportsVision !== undefined) {
+		if (model.supportsVision) capabilities.add("images");
+		else capabilities.delete("images");
+	}
+	if (model?.supportsAttachments !== undefined) {
+		if (model.supportsAttachments) capabilities.add("files");
+		else capabilities.delete("files");
+	}
+	if (model?.supportsReasoning !== undefined) {
+		if (model.supportsReasoning) capabilities.add("reasoning");
+		else capabilities.delete("reasoning");
+	}
 
+	const apiFormat = model?.isR1FormatRequired ? "r1" : model?.apiFormat;
+	const hasPricing =
+		model?.inputPrice !== undefined ||
+		model?.outputPrice !== undefined ||
+		model?.cacheReadsPrice !== undefined ||
+		model?.cacheWritesPrice !== undefined;
 	return {
 		id: modelId,
 		name: model?.name ?? modelId,
-		maxTokens: model?.maxTokens,
-		contextWindow: model?.contextWindow,
-		maxInputTokens: model?.maxInputTokens,
-		capabilities: capabilities.size > 0 ? [...capabilities] : undefined,
+		...(model?.maxTokens !== undefined ? { maxTokens: model.maxTokens } : {}),
+		...(model?.contextWindow !== undefined
+			? { contextWindow: model.contextWindow }
+			: {}),
+		...(model?.maxInputTokens !== undefined
+			? { maxInputTokens: model.maxInputTokens }
+			: {}),
+		...(capabilities.size > 0 ? { capabilities: [...capabilities] } : {}),
+		...(model?.temperature !== undefined
+			? { temperature: model.temperature }
+			: {}),
+		...(apiFormat !== undefined ? { apiFormat } : {}),
+		...(hasPricing
+			? {
+					pricing: {
+						...(model?.inputPrice !== undefined
+							? { input: model.inputPrice }
+							: {}),
+						...(model?.outputPrice !== undefined
+							? { output: model.outputPrice }
+							: {}),
+						...(model?.cacheReadsPrice !== undefined
+							? { cacheRead: model.cacheReadsPrice }
+							: {}),
+						...(model?.cacheWritesPrice !== undefined
+							? { cacheWrite: model.cacheWritesPrice }
+							: {}),
+					},
+				}
+			: {}),
 	};
 }
 
@@ -439,6 +543,60 @@ export function registerCustomProvider(
 	});
 }
 
+/**
+ * Apply a single provider's updated models.json entry to the live @cline/llms
+ * registry. Unlike {@link ensureCustomProvidersLoadedSync}, which loads a
+ * models.json path at most once per process, this applies on every call so
+ * writes made after startup are reflected immediately: models removed from the
+ * entry are unregistered, and the remaining entry is (re-)registered.
+ */
+export function syncStoredProviderRegistration(
+	providerId: string,
+	previous: StoredProviderEntry | undefined,
+	next: StoredProviderEntry | undefined,
+): void {
+	const nextModels = next?.models ?? {};
+	const removedModelIds = new Set<string>();
+	for (const [modelKey, model] of Object.entries(previous?.models ?? {})) {
+		if (Object.hasOwn(nextModels, modelKey)) {
+			continue;
+		}
+		const modelId = model.id?.trim() || modelKey.trim();
+		if (modelId) {
+			removedModelIds.add(modelId);
+			LlmsModels.unregisterModel(providerId, modelId);
+		}
+	}
+	if (!next) {
+		return;
+	}
+	const liveCollection = LlmsModels.getProviderCollectionSync(providerId);
+	registerCustomProvider(providerId, next);
+	// For entries with complete provider metadata, registerCustomProvider
+	// replaces the live collection with one built from models.json alone.
+	// Merge back models that came from other sources (generated catalog,
+	// providers.json settings), letting the fresh models.json entries win and
+	// dropping models removed by this write.
+	const registered = LlmsModels.getProviderCollectionSync(providerId);
+	if (liveCollection && registered && registered !== liveCollection) {
+		const preservedModels = Object.fromEntries(
+			Object.entries(liveCollection.models).filter(
+				([modelId]) => !removedModelIds.has(modelId),
+			),
+		);
+		LlmsModels.registerProvider({
+			...registered,
+			models: { ...preservedModels, ...registered.models },
+		});
+	}
+}
+
+/**
+ * Load models.json into the @cline/llms registry at most once per path per
+ * process; subsequent calls are no-ops. It does NOT re-read the file after
+ * writes — use {@link syncStoredProviderRegistration} to reflect a write in
+ * the live registry.
+ */
 export function ensureCustomProvidersLoadedSync(
 	manager: ProviderSettingsManager,
 ): void {

--- a/sdk/packages/core/src/services/providers/local-provider-service.test.ts
+++ b/sdk/packages/core/src/services/providers/local-provider-service.test.ts
@@ -71,6 +71,12 @@ describe("models registry parsing", () => {
 						alpha: {
 							name: "Alpha",
 							capabilities: ["reasoning"],
+							inputPrice: 1.25,
+							outputPrice: 3.5,
+							cacheReadsPrice: 0.25,
+							cacheWritesPrice: 1.5,
+							temperature: 0.2,
+							isR1FormatRequired: true,
 						},
 					},
 				},
@@ -94,7 +100,81 @@ describe("models registry parsing", () => {
 		});
 		await expect(
 			LlmsModels.getModelsForProvider("schema-provider"),
-		).resolves.toHaveProperty("alpha");
+		).resolves.toMatchObject({
+			alpha: {
+				pricing: {
+					input: 1.25,
+					output: 3.5,
+					cacheRead: 0.25,
+					cacheWrite: 1.5,
+				},
+				temperature: 0.2,
+				apiFormat: "r1",
+			},
+		});
+	});
+
+	it("drops invalid model numbers and lets explicit capability booleans win", async () => {
+		const parsed = parseModelsFile({
+			version: 1,
+			providers: {
+				"normalized-provider": {
+					provider: {
+						name: "Normalized Provider",
+						baseUrl: "https://normalized.example.invalid/v1",
+					},
+					models: {
+						alpha: {
+							maxTokens: -1,
+							contextWindow: Number.POSITIVE_INFINITY,
+							maxInputTokens: 0,
+							capabilities: ["images", "files", "reasoning", "tools"],
+							supportsVision: false,
+							supportsAttachments: false,
+							supportsReasoning: false,
+							inputPrice: Number.NaN,
+							outputPrice: 2,
+							cacheReadsPrice: -1,
+							temperature: -1,
+							apiFormat: "openai-responses",
+							isR1FormatRequired: false,
+						},
+					},
+				},
+			},
+		});
+
+		const entry = parsed.providers["normalized-provider"];
+		expect(entry?.models?.alpha).toEqual({
+			capabilities: ["images", "files", "reasoning", "tools"],
+			supportsVision: false,
+			supportsAttachments: false,
+			supportsReasoning: false,
+			outputPrice: 2,
+			apiFormat: "openai-responses",
+			isR1FormatRequired: false,
+		});
+		if (!entry) {
+			throw new Error("expected normalized provider entry");
+		}
+
+		registerCustomProvider("normalized-provider", entry);
+
+		await expect(
+			LlmsModels.getModelsForProvider("normalized-provider"),
+		).resolves.toMatchObject({
+			alpha: {
+				capabilities: ["tools"],
+				apiFormat: "openai-responses",
+				pricing: { output: 2 },
+			},
+		});
+		const model = (await LlmsModels.getModelsForProvider("normalized-provider"))
+			.alpha;
+		expect(model).not.toHaveProperty("maxTokens");
+		expect(model).not.toHaveProperty("contextWindow");
+		expect(model).not.toHaveProperty("maxInputTokens");
+		expect(model).not.toHaveProperty("temperature");
 	});
 
 	it("skips malformed provider entries while preserving valid providers", () => {

--- a/sdk/packages/core/src/types/config.ts
+++ b/sdk/packages/core/src/types/config.ts
@@ -45,6 +45,10 @@ export interface CoreModelConfig {
 	 * Maximum output tokens per API call.
 	 */
 	maxTokensPerTurn?: number;
+	/**
+	 * Sampling temperature per API call.
+	 */
+	temperature?: number;
 }
 
 export interface CoreRuntimeFeatures {

--- a/sdk/packages/llms/src/index.ts
+++ b/sdk/packages/llms/src/index.ts
@@ -29,6 +29,7 @@ export {
 	registerProvider,
 	resetRegistry,
 	sortModelsByReleaseDate,
+	unregisterModel,
 	unregisterProvider,
 	VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES,
 } from "./models";

--- a/sdk/packages/llms/src/models.ts
+++ b/sdk/packages/llms/src/models.ts
@@ -33,6 +33,7 @@ export {
 	registerModel,
 	registerProvider,
 	resetRegistry,
+	unregisterModel,
 	unregisterProvider,
 } from "./providers/model-registry";
 export {

--- a/sdk/packages/llms/src/providers/config.ts
+++ b/sdk/packages/llms/src/providers/config.ts
@@ -120,6 +120,8 @@ export interface TokenConfig {
 	maxInputTokens?: number;
 	/** Maximum output tokens (overrides model default) */
 	maxOutputTokens?: number;
+	/** Sampling temperature (overrides model default) */
+	temperature?: number;
 }
 
 /**

--- a/sdk/packages/llms/src/providers/model-registry.ts
+++ b/sdk/packages/llms/src/providers/model-registry.ts
@@ -92,6 +92,10 @@ export function registerModel(
 	CUSTOM_MODELS.get(providerId)?.set(modelId, { ...info, id: modelId });
 }
 
+export function unregisterModel(providerId: string, modelId: string): boolean {
+	return CUSTOM_MODELS.get(providerId)?.delete(modelId) ?? false;
+}
+
 export function unregisterProvider(providerId: string): boolean {
 	CUSTOM_MODELS.delete(providerId);
 	return CUSTOM_PROVIDERS.delete(providerId);

--- a/sdk/packages/shared/src/agents/types.ts
+++ b/sdk/packages/shared/src/agents/types.ts
@@ -714,6 +714,10 @@ export interface AgentConfig {
 	 */
 	maxTokensPerTurn?: number;
 	/**
+	 * Sampling temperature per API call
+	 */
+	temperature?: number;
+	/**
 	 * Timeout for each API call in milliseconds
 	 * @default 180000 (3 minutes)
 	 */
@@ -888,6 +892,7 @@ export const AgentConfigSchema = z.object({
 	maxIterations: z.number().positive().optional(),
 	maxParallelToolCalls: z.number().int().positive().default(8),
 	maxTokensPerTurn: z.number().positive().optional(),
+	temperature: z.number().nonnegative().optional(),
 	apiTimeoutMs: z.number().positive().default(180000),
 	userFileContentLoader: z
 		.function()


### PR DESCRIPTION
# Resolve model metadata host-side

## Summary

Today, when you pick a model in the settings UI, the webview mails the extension a full `ModelInfo` snapshot ("this model has a 128k context window, costs $3/M tokens, supports images, …") and that snapshot becomes the truth forever. This PR flips the ownership: **the webview commits only the model ID plus any fields the user explicitly edited (`ModelOverrides`), and the extension host resolves the full metadata itself** — from the SDK catalog, from user-authored overrides in `~/.cline/data/settings/models.json`, and from safe fallbacks.

### Why

- **Frontend-owned snapshots go stale.** A model's pricing or context window changes in the catalog, but the frozen snapshot from the day you picked it keeps winning. With host-side resolution, catalog updates flow through automatically unless the user explicitly overrode a field.
- **User edits and catalog facts were indistinguishable.** The old snapshot mixed "the catalog said this" with "the user typed this". Now user-authored metadata lives as sparse overrides in `models.json`, so we always know which is which — and only user intent is persisted.
- **Custom model metadata belongs to the SDK layer.** Overrides in `models.json` feed the shared `@cline/llms` registry, so the same custom-model metadata works for the extension, CLI, and SDK consumers, and reaches the actual inference path via `providerConfig.knownModels` (previously overrides only affected the display).
- **Webview is untrusted-ish.** The runtime no longer accepts model metadata verbatim from the webview; the host normalizes and validates everything at the boundary.

## The big picture (before → after)

```
BEFORE:  picker → commit(modelId + full ModelInfo snapshot) → stored verbatim → runtime & display

AFTER:   picker → commit(modelId [+ sparse user overrides])
                        │
                        ▼
         host store resolves ModelInfo =
             base metadata            (1. SDK catalog → 2. picker's live state snapshot → 3. safe fallback)
           + user overrides           (models.json, validated & normalized)
                        │
                        ├─→ display (settings UI, context-window indicator, cost)
                        ├─→ runtime (providerConfig.knownModels → SDK gateway)
                        └─→ legacy globalState keys (derived compatibility cache)
```

Each resolution is tagged with where its base metadata came from (`modelInfoSource: "catalog" | "state" | "fallback"`). That tag matters: **fabricated fallback data is deliberately treated as weak** — it never shadows live catalog lookups, is never persisted into the state snapshot, and never reaches the inference config. This is what keeps a "we had to make something up" resolution from masquerading as truth later.

## Reviewer's map

Read in this order — each section builds on the previous one.

### 1. The wire contract

| file | what & why |
|---|---|
| `apps/vscode/proto/cline/models.proto` | New `ModelOverrides` message (15 sparse, optional fields). `CommitModelSelectionRequest` drops `model_info` and gains `optional overrides`. **The retired field number 4 is `reserved`** — reusing it with a new message type would silently mis-decode version-skewed clients (a stale client's `context_window` bytes would decode as `max_tokens`, etc.) and persist the garbage. `overrides` lives at field 5. The overrides field is **tri-state**: absent = keep stored overrides, empty message = clear them, populated = replace wholesale. |
| `apps/vscode/src/shared/proto-conversions/models/modelOverrides.ts` | **New.** The single shared proto↔domain conversion for overrides, used by both the webview and the host (previously implemented twice, byte-identically — a 16th field would have required touching 4 converters in 2 runtimes). The tri-state and normalization semantics are documented here. |
| `apps/vscode/src/core/controller/models/providerCatalogShared.ts` | gRPC boundary: maps requests through the shared conversions; readback still returns fully-resolved `modelInfo` (plus the raw `overrides`) so the UI can distinguish "resolved value" from "user-authored value". |

### 2. The host store — where resolution lives

| file | what & why |
|---|---|
| `apps/vscode/src/sdk/model-catalog/contracts.ts` | Write type (`ModelSelection`: id + overrides) split from read type (`ResolvedModelSelection`: + resolved `modelInfo`, `modelInfoSource`, `baseModelInfo`). Writing a choice and reading the fully-explained choice are different things now. |
| `apps/vscode/src/sdk/model-catalog/store.ts` | The heart of the PR. Selected model id → `providers.json`; user overrides → `models.json` (normalized: capabilities validated against the SDK's `ModelCapabilitySchema`, invalid numbers dropped, `-1` legacy sentinels stripped); resolution layers catalog → state snapshot → safe defaults, then applies overrides. Also: a one-shot lazy **migration** converts pre-existing openai-compatible legacy metadata (diffed against safe defaults, so unchanged fields don't become noise) into `models.json` overrides — wrapped in try/catch and memoized so a broken disk can't fail read RPCs and the check doesn't rerun forever. After every `models.json` write the live `@cline/llms` registry is synced via `syncStoredProviderRegistration` (see §4 — the naive "reload" API is load-once and would silently no-op). |
| `apps/vscode/src/sdk/model-catalog/model-values.ts` | **New.** Shared numeric guards + proto↔SDK `ApiFormat` mapping, previously copy-pasted between the store and the session factory. |
| `apps/vscode/src/core/controller/models/resolveModelInfo.ts` | Read path for the webview's status surfaces. Committed selections win — **unless** their metadata is pure fallback fabrication with no overrides, in which case the live catalog peek/resolve is preferred and the committed selection is only a last resort before `"unknown"`. A catalog *default-model substitution* never shadows the committed selection either (it would answer a question about model X with model Y). |

### 3. The runtime path — overrides reach inference

| file | what & why |
|---|---|
| `apps/vscode/src/sdk/cline-session-factory.ts` | Session creation loads `knownModels` from the `@cline/llms` registry (which now includes `models.json` overrides) and passes them into `providerConfig.knownModels`, so context-window management, pricing, capabilities, and apiFormat at inference time reflect the user's edits. Committed `maxTokens`/`temperature` overrides map to `maxTokensPerTurn`/`temperature`. Pure-fallback resolutions are **not** injected — fabricated 128k/$0 metadata must not reach the gateway; the SDK's own resolution handles those. |
| `sdk/packages/*` (`handler-factory`, `runtime-builder`, `local-runtime-host`, `agent-runtime-config-builder`, `types/config.ts`, `shared/agents/types.ts`, `llms/providers/config.ts`) | Plumbs the new per-session `temperature` through the SDK: `AgentConfig.temperature` → runtime → handler factory → gateway defaults. Additive, optional fields throughout. |

### 4. The SDK registry — `models.json` as shared infrastructure

| file | what & why |
|---|---|
| `sdk/packages/core/src/services/providers/local-provider-registry.ts` | `StoredModelEntrySchema` gains pricing, temperature, `apiFormat`, `isR1FormatRequired`. **Writes are now atomic** (pid-unique temp file + rename, same pattern as `ProviderSettingsManager`) — a bare `writeFileSync` let a concurrent window read a partial file as "empty registry" and then persist the loss of every user override. Reads that discard invalid content now leave an `sdkDebug` trace instead of silently returning empty. New `syncStoredProviderRegistration` applies a write to the live registry on every call (unregisters removed models, re-registers, and merges back models that came from other sources) — this exists because `ensureCustomProvidersLoadedSync` is load-once-per-path by contract and calling it after a write is a guaranteed no-op, which would have meant override edits never reached inference until a restart. |
| `sdk/packages/llms/src/providers/model-registry.ts` | New `unregisterModel` so deleting an override entry actually removes the custom model from the registry instead of leaving a stale copy. |
| `sdk/packages/core/src/index.ts`, `llms/src/index.ts` | Export the new APIs. |

### 5. The webview — send intent, not encyclopedias

| file | what & why |
|---|---|
| `webview-ui/src/hooks/useProviderConfig.ts` | `commitSelection` sends overrides via the shared conversion module; types re-exported from there. |
| `webview-ui/src/hooks/useProviderModelSelection.ts` | Bridges existing pickers during migration: catalog picks commit with no overrides. |
| `webview-ui/src/components/settings/providers/OpenAICompatible.tsx` | The main override-editing UI. User edits to context window / max tokens / pricing / temperature / image support / R1 format become sparse overrides. Two subtle guards worth reviewing: (a) debounced fields fire their initial value ~100ms after mount, so **merely expanding "Model Configuration" (or switching models with it open) used to silently persist the displayed resolved values as user overrides** — an equal-value check suppresses the echo; (b) a pending-commit counter prevents a stale read-back from reseeding the local override accumulator mid-edit and silently dropping an already-committed field. |
| Pickers (`ClineModelPicker`, `OpenRouterModelPicker`, `OnboardingView`, `OpenAiCodexProvider`, `VSCodeLmProvider`) | Stop sending `modelInfo` on commit; the host resolves it. |

### 6. Test infrastructure

| file | what & why |
|---|---|
| `apps/vscode/src/test/cline-core-vitest-stub.ts`, `vitest-setup.ts`, `bun-test-preload.ts`, `vitest.config.ts` | Vitest/bun alias `@cline/core` to an in-memory stub for `models.json` I/O. The stub **re-exports the real** `syncStoredProviderRegistration` and `StoredModelEntrySchema` (rather than faking them) so tests exercise the production registry path and the production Zod validation — a hand-written fake here previously masked the registry-staleness bug entirely. Registry + models-file state reset before every test in both runners. |
| `store.test.ts` (+601 lines) | Migration matrix, sentinel scrubbing, plan/act separation, tri-state clear/preserve/replace semantics, fallback-tier state handling, and a **schema contract test**: every `ModelCapabilitySchema` value plus a fully-populated override set must round-trip through the store's converters and parse under the real `StoredModelEntrySchema` — so extension/SDK vocabulary drift fails in CI instead of production. |
| `providerCatalogHandlers.test.ts` | Pins the tri-state at the gRPC boundary (absent → `undefined`, empty message → `{}`). |
| `OpenAICompatible.test.tsx` (new, 517 lines), hook tests, session-factory tests | Behavior coverage for the reworked UI, override round-tripping, and runtime settings. |

## Manual testing

### Catalog model commit
1. In settings, select a catalog model for Cline or OpenRouter.
2. Confirm the selection persists and displays correct metadata.
3. Confirm **no** entry appears for it in `~/.cline/data/settings/models.json` (catalog picks need no overrides) and `providers.json` records the selected `model`.

### Custom OpenAI-compatible overrides
1. Configure an OpenAI-compatible provider, enter a custom model id.
2. Expand **Model Configuration** and *only look at it* — then check `models.json`: **no entry should appear** (regression test for the phantom-override bug).
3. Now edit context window, pricing, temperature, image support, or R1 format.
4. Confirm only the edited fields appear as a sparse entry in `models.json` (not in `providers.json`).
5. Clear every edited field / untick the checkboxes → the model's entry in `models.json` should be **deleted**, not left as an empty husk.

### Overrides reach inference *without a restart*
1. With a custom model selected, edit its context window or apiFormat in settings.
2. Start a **new task immediately** (no window reload) and confirm the session uses the new values (e.g. wire format changes, context-window truncation math, cost display).
   This is the regression test for the registry-staleness bug: previously the in-memory registry only picked up `models.json` on startup.

### Dynamic-provider metadata stays real
1. Select an OpenRouter model that is popular *now* (i.e. likely absent from the build-time catalog snapshot).
2. Confirm the context-window indicator and pricing show the live values from the picker, **not** 128k/$0 defaults.
3. Restart the extension and re-check — the values should survive.

### Readback / migration
1. Upgrade from a build with pre-existing custom openai-compatible model metadata.
2. Open settings: the edited fields should appear, and `models.json` should now contain them as a migrated entry (only fields differing from defaults).
3. Restart; selection and metadata persist. Plan/act mode separation (with "use different models" enabled) keeps independent selections.

## Semantics reviewers should hold in their head

- **Tri-state overrides:** absent = preserve, empty = clear, present = replace wholesale (no per-field merge). The webview sends an explicitly empty message to clear.
- **`modelInfoSource` tiers:** `catalog` and `state` are real data; `fallback` is fabricated and deliberately quarantined — never persisted into state snapshots, never injected into `knownModels`, never allowed to shadow live catalog lookups.
- **Capabilities are additive:** the `capabilities` array can only *enable* flags over the base metadata; explicit `supports*` booleans win over the array. Unknown capability strings are dropped (validated against the SDK schema, not a hardcoded list).
- **`isR1FormatRequired` is a legacy alias** that forces R1 only when true; `apiFormat` is canonical.
- **Legacy globalState model keys are still written** as a derived compatibility cache (and for rollback: an older extension version reading state written by this version degrades gracefully). Removing them is an explicit follow-up, not part of this PR. The one exception: fallback-tier resolutions for dynamic-list providers write `undefined` there, because persisting fabrications would launder them into authoritative-looking data on the next read.

## Follow-ups (intentionally out of scope)

- Remove the legacy globalState model-key writes and make runtime code read the provider config store directly.
- Read-path caching for `models.json` (currently re-read per resolution; small file, but it's uncached sync I/O).
- Surface host-side numeric validation in the UI (values like a negative price are currently dropped silently host-side).
- Drop the accepted-but-ignored `modelInfo` parameter from `commitModelSelection`'s input type and its dead construction at picker call sites.
- Regenerate (or stop tracking) the stale `apps/vscode/proto/descriptor_set.pb`.
- SDK changelog entries for `AgentConfig.temperature` and the new `@cline/core`/`@cline/llms` exports when the next SDK release is cut.
