### PR TITLE
feat(vscode): allow selecting Cline free models on ClinePass provider

### DIFF
--- a/apps/vscode/src/core/api/__tests__/index.test.ts
+++ b/apps/vscode/src/core/api/__tests__/index.test.ts
@@ -1,0 +1,104 @@
+import "should"
+import {
+	type ApiConfiguration,
+	clinePassDefaultModelId,
+	clinePassModelInfoSaneDefaults,
+	clinePassModels,
+	type ModelInfo,
+} from "@shared/api"
+import type { Mode } from "@shared/storage/types"
+import sinon from "sinon"
+import { ClineAccountService } from "@/services/account/ClineAccountService"
+import { AuthService } from "@/services/auth/AuthService"
+import { buildApiHandler } from "../index"
+
+describe("buildApiHandler", () => {
+	beforeEach(() => {
+		sinon.stub(ClineAccountService, "getInstance").returns({} as any)
+		sinon.stub(AuthService, "getInstance").returns({} as any)
+	})
+
+	afterEach(() => {
+		sinon.restore()
+	})
+
+	const buildClinePassHandler = (configuration: Partial<ApiConfiguration>, mode: Mode = "act") =>
+		buildApiHandler(
+			{
+				planModeApiProvider: "cline-pass",
+				actModeApiProvider: "cline-pass",
+				...configuration,
+			} as ApiConfiguration,
+			mode,
+		)
+
+	describe("cline-pass provider", () => {
+		const freeModelInfo: ModelInfo = {
+			...clinePassModelInfoSaneDefaults,
+			maxTokens: 32_768,
+			contextWindow: 256_000,
+			description: "A free model",
+		}
+
+		it("passes a free (non cline-pass prefixed) model id through with its stored info", () => {
+			const handler = buildClinePassHandler({
+				actModeClinePassModelId: "kwaipilot/kat-coder-pro",
+				actModeClinePassModelInfo: freeModelInfo,
+			})
+
+			const model = handler.getModel()
+			model.id.should.equal("kwaipilot/kat-coder-pro")
+			model.info.should.deepEqual(freeModelInfo)
+		})
+
+		it("passes a :free suffixed model id through with its stored info", () => {
+			const handler = buildClinePassHandler({
+				actModeClinePassModelId: "arcee-ai/trinity-large-preview:free",
+				actModeClinePassModelInfo: freeModelInfo,
+			})
+
+			const model = handler.getModel()
+			model.id.should.equal("arcee-ai/trinity-large-preview:free")
+			model.info.should.deepEqual(freeModelInfo)
+		})
+
+		it("falls back to sane defaults for a free model id without stored info", () => {
+			const handler = buildClinePassHandler({
+				actModeClinePassModelId: "kwaipilot/kat-coder-pro",
+			})
+
+			const model = handler.getModel()
+			model.id.should.equal("kwaipilot/kat-coder-pro")
+			model.info.should.deepEqual(clinePassModelInfoSaneDefaults)
+		})
+
+		it("resolves cline-pass ids against the static model table", () => {
+			const handler = buildClinePassHandler({
+				actModeClinePassModelId: "cline-pass/glm-5.2",
+			})
+
+			const model = handler.getModel()
+			model.id.should.equal("cline-pass/glm-5.2")
+			model.info.should.deepEqual(clinePassModels["cline-pass/glm-5.2"])
+		})
+
+		it("falls back to the default pass model when no model id is configured", () => {
+			const handler = buildClinePassHandler({})
+
+			const model = handler.getModel()
+			model.id.should.equal(clinePassDefaultModelId)
+			model.info.should.deepEqual(clinePassModels[clinePassDefaultModelId])
+		})
+
+		it("resolves plan and act mode model ids independently", () => {
+			const configuration: Partial<ApiConfiguration> = {
+				planModeClinePassModelId: "kwaipilot/kat-coder-pro",
+				planModeClinePassModelInfo: freeModelInfo,
+				actModeClinePassModelId: "cline-pass/glm-5.2",
+			}
+
+			buildClinePassHandler(configuration, "plan").getModel().id.should.equal("kwaipilot/kat-coder-pro")
+			buildClinePassHandler(configuration, "act").getModel().id.should.equal("cline-pass/glm-5.2")
+		})
+	})
+})

--- a/apps/vscode/src/core/api/index.ts
+++ b/apps/vscode/src/core/api/index.ts
@@ -292,9 +292,9 @@ function createHandlerForProvider(
 				mode === "plan" ? options.planModeClinePassModelId : options.actModeClinePassModelId
 			const configuredClinePassModelInfo =
 				mode === "plan" ? options.planModeClinePassModelInfo : options.actModeClinePassModelInfo
-			const clineModelId = configuredClinePassModelId?.startsWith("cline-pass/")
-				? configuredClinePassModelId
-				: clinePassDefaultModelId
+			// ClinePass users may also select Cline free models (OpenRouter-style ids without
+			// the cline-pass/ prefix), so pass any configured id through to the Cline API.
+			const clineModelId = configuredClinePassModelId || clinePassDefaultModelId
 			const clineModelInfo = resolveClinePassModelInfo(
 				clineModelId,
 				configuredClinePassModelInfo

--- a/apps/vscode/src/shared/__tests__/api.test.ts
+++ b/apps/vscode/src/shared/__tests__/api.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai"
 import {
 	buildModelInfoNameMap,
+	clinePassModelInfoSaneDefaults,
 	internationalZAiModels,
 	mainlandZAiModels,
 	type ModelInfo,
@@ -49,6 +50,22 @@ describe("ClinePass model info", () => {
 		expect(modelInfo.name).to.equal("New model")
 		expect(modelInfo.supportsReasoning).to.equal(false)
 		expect(modelInfo.thinkingConfig).to.deep.equal({ maxBudget: 16_384 })
+	})
+
+	it("returns stored info for a free (non cline-pass prefixed) model id", () => {
+		const freeModelInfo = createModelInfo("Trinity Large Preview", 512_000)
+		const modelInfo = resolveClinePassModelInfo(
+			"arcee-ai/trinity-large-preview:free",
+			buildModelInfoNameMap({ "arcee-ai/trinity-large-preview:free": freeModelInfo }),
+		)
+
+		expect(modelInfo).to.deep.equal(freeModelInfo)
+	})
+
+	it("falls back to sane defaults for a free model id without dynamic metadata", () => {
+		const modelInfo = resolveClinePassModelInfo("kwaipilot/kat-coder-pro")
+
+		expect(modelInfo).to.deep.equal(clinePassModelInfoSaneDefaults)
 	})
 })
 

--- a/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1107,7 +1107,11 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				case "cline":
 					return `${selectedProvider}:${selectedModelId}`
 				case "cline-pass":
-					return `${selectedProvider}:${selectedModelId.replace(/^cline-pass\//, "")}`
+					// Free models selected on ClinePass go through Cline usage billing,
+					// so label them the same way as the cline provider
+					return selectedModelId.startsWith("cline-pass/")
+						? `${selectedProvider}:${selectedModelId.replace(/^cline-pass\//, "")}`
+						: `cline:${selectedModelId}`
 				case "openai":
 					return `openai-compat:${selectedModelId}`
 				case "vscode-lm":

--- a/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.tsx
@@ -74,6 +74,8 @@ export interface FeaturedModelCardEntry {
 	id: string
 	description: string
 	label: string
+	// Shown on the card instead of the id (e.g. ClinePass ids without their prefix)
+	displayName?: string
 }
 
 const CLINE_RECOMMENDED_MODELS_RETRY_DELAY_MS = 5000
@@ -505,7 +507,7 @@ const ClineModelPicker: React.FC<ClineModelPickerProps> = ({
 									isSelected={selectedModelId === model.id}
 									key={model.id}
 									label={model.label}
-									modelId={model.id}
+									modelId={model.displayName ?? model.id}
 									onClick={() => {
 										handleModelChange(model.id)
 										setIsDropdownVisible(false)

--- a/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.tsx
@@ -60,7 +60,7 @@ export interface ClineModelPickerProps {
 	showFeaturedModels?: boolean
 }
 
-interface FeaturedModelCardEntry {
+export interface FeaturedModelCardEntry {
 	id: string
 	description: string
 	label: string
@@ -72,7 +72,7 @@ function normalizeModelId(modelId: string): string {
 	return modelId.trim().toLowerCase()
 }
 
-function toFeaturedModelCardEntry(
+export function toFeaturedModelCardEntry(
 	model: Pick<ClineRecommendedModel, "id" | "description" | "tags">,
 	fallbackLabel: string,
 ): FeaturedModelCardEntry | null {
@@ -234,7 +234,10 @@ const ClineModelPicker: React.FC<ClineModelPickerProps> = ({
 	const itemRefs = useRef<(HTMLDivElement | null)[]>([])
 	const dropdownListRef = useRef<HTMLDivElement>(null)
 
-	const handleModelChange = (newModelId: string) => {
+	const handleModelChange = (rawModelId: string) => {
+		// When a fixed models map is provided (ClinePass), only ids in the map may be
+		// stored — otherwise the host would send arbitrary typed text to the API.
+		const newModelId = models && !(rawModelId in models) ? resolveModelId(rawModelId) : rawModelId
 		setSearchTerm(newModelId)
 
 		handleModeFieldsChange(

--- a/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.tsx
@@ -47,6 +47,13 @@ const StarIcon = ({ isFavorite, onClick }: { isFavorite: boolean; onClick: (e: R
 	)
 }
 
+export interface FeaturedModelTab {
+	label: string
+	models: FeaturedModelCardEntry[]
+	// Optional explanatory copy shown between the tab bar and the model cards
+	description?: string
+}
+
 export interface ClineModelPickerProps {
 	isPopup?: boolean
 	currentMode: Mode
@@ -58,6 +65,9 @@ export interface ClineModelPickerProps {
 	models?: Record<string, ModelInfo>
 	isClinePassEnabled?: boolean
 	showFeaturedModels?: boolean
+	// Custom featured tabs (e.g. ClinePass "Subscribed"/"Free") shown instead of the
+	// built-in Recommended/Free tabs
+	featuredTabs?: FeaturedModelTab[]
 }
 
 export interface FeaturedModelCardEntry {
@@ -109,6 +119,7 @@ const ClineModelPicker: React.FC<ClineModelPickerProps> = ({
 	models,
 	isClinePassEnabled = true,
 	showFeaturedModels = true,
+	featuredTabs,
 }) => {
 	const { handleModeFieldsChange, handleFieldChange } = useApiConfigurationHandlers()
 	const { apiConfiguration, favoritedModelIds, clineModels, openRouterModels, refreshClineModels } = useExtensionState()
@@ -150,6 +161,7 @@ const ClineModelPicker: React.FC<ClineModelPickerProps> = ({
 		[freeClineModelIds],
 	)
 	const [activeTab, setActiveTab] = useState<"recommended" | "free">(initialTab ?? "recommended")
+	const [activeFeaturedTabIndex, setActiveFeaturedTabIndex] = useState(0)
 	const recommendedModels = useMemo(
 		() => (clineRecommendedModels.length > 0 ? clineRecommendedModels : RECOMMENDED_MODELS_FALLBACK),
 		[clineRecommendedModels],
@@ -230,6 +242,18 @@ const ClineModelPicker: React.FC<ClineModelPickerProps> = ({
 		const currentModelId = resolveModelId(configuredModelId)
 		setActiveTab(freeClineModelIdSet.has(normalizeModelId(currentModelId)) ? "free" : "recommended")
 	}, [configuredModelId, freeClineModelIdSet, initialTab, resolveModelId])
+
+	// Keep the active custom tab on the tab containing the configured model
+	useEffect(() => {
+		if (!featuredTabs) {
+			return
+		}
+		const currentModelId = resolveModelId(configuredModelId)
+		const tabIndex = featuredTabs.findIndex((tab) => tab.models.some((model) => model.id === currentModelId))
+		if (tabIndex >= 0) {
+			setActiveFeaturedTabIndex(tabIndex)
+		}
+	}, [configuredModelId, featuredTabs, resolveModelId])
 	const dropdownRef = useRef<HTMLDivElement>(null)
 	const itemRefs = useRef<(HTMLDivElement | null)[]>([])
 	const dropdownListRef = useRef<HTMLDivElement>(null)
@@ -447,7 +471,52 @@ const ClineModelPicker: React.FC<ClineModelPickerProps> = ({
 					<span style={{ fontWeight: 500 }}>Model</span>
 				</label>
 
-				{showFeaturedModels && (
+				{showFeaturedModels && featuredTabs && (
+					<>
+						{/* Custom Tabs (e.g. ClinePass Subscribed/Free) */}
+						<TabsContainer style={{ marginTop: 4 }}>
+							{featuredTabs.map((tab, index) => (
+								<Tab
+									active={activeFeaturedTabIndex === index}
+									key={tab.label}
+									onClick={() => setActiveFeaturedTabIndex(index)}>
+									{tab.label}
+								</Tab>
+							))}
+						</TabsContainer>
+
+						{/* Tab Description */}
+						{featuredTabs[activeFeaturedTabIndex]?.description && (
+							<p
+								style={{
+									fontSize: "11px",
+									margin: "4px 0 6px 0",
+									color: "var(--vscode-descriptionForeground)",
+								}}>
+								{featuredTabs[activeFeaturedTabIndex].description}
+							</p>
+						)}
+
+						{/* Model Cards */}
+						<div style={{ marginBottom: "6px" }}>
+							{featuredTabs[activeFeaturedTabIndex]?.models.map((model) => (
+								<FeaturedModelCard
+									description={model.description}
+									isSelected={selectedModelId === model.id}
+									key={model.id}
+									label={model.label}
+									modelId={model.id}
+									onClick={() => {
+										handleModelChange(model.id)
+										setIsDropdownVisible(false)
+									}}
+								/>
+							))}
+						</div>
+					</>
+				)}
+
+				{showFeaturedModels && !featuredTabs && (
 					<>
 						{/* Tabs */}
 						<TabsContainer style={{ marginTop: 4 }}>

--- a/apps/vscode/webview-ui/src/components/settings/providers/ClinePassProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/ClinePassProvider.tsx
@@ -33,7 +33,6 @@ const CLINE_PASS_MODEL_FIELD_PAIRS = {
 	modelInfo: { plan: "planModeClinePassModelInfo", act: "actModeClinePassModelInfo" },
 } as const
 
-const SUBSCRIBED_CARD_DESCRIPTION = "Included with your ClinePass subscription"
 const FREE_TAB_DESCRIPTION =
 	"A rotating set of models with limited free usage — included at no cost and separate from your ClinePass quota."
 
@@ -148,19 +147,18 @@ export const ClinePassProvider = ({
 			: (Object.keys(clinePassModelOptions)[0] ?? clinePassDefaultModelId)
 	}, [clinePassModelOptions])
 
+	// Subscription models are a uniform list, so the cards show just the model name —
+	// no label chip or repeated description
 	const subscribedModelCards = useMemo<FeaturedModelCardEntry[]>(() => {
-		if (clinePassRawModels.length > 0) {
-			return clinePassRawModels.map((model) => ({
-				id: model.id,
-				label: (model.tags?.[0] || "INCLUDED").toUpperCase(),
-				description: model.description || SUBSCRIBED_CARD_DESCRIPTION,
-			}))
-		}
-
-		return Object.entries(clinePassRecommendedModels ?? clinePassModels).map(([id, info]) => ({
+		const modelIds =
+			clinePassRawModels.length > 0
+				? clinePassRawModels.map((model) => model.id)
+				: Object.keys(clinePassRecommendedModels ?? clinePassModels)
+		return modelIds.map((id) => ({
 			id,
-			label: "INCLUDED",
-			description: info.description || SUBSCRIBED_CARD_DESCRIPTION,
+			displayName: id.replace(/^cline-pass\//, ""),
+			label: "",
+			description: "",
 		}))
 	}, [clinePassRawModels, clinePassRecommendedModels])
 

--- a/apps/vscode/webview-ui/src/components/settings/providers/ClinePassProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/ClinePassProvider.tsx
@@ -147,18 +147,21 @@ export const ClinePassProvider = ({
 			: (Object.keys(clinePassModelOptions)[0] ?? clinePassDefaultModelId)
 	}, [clinePassModelOptions])
 
-	// Subscription models are a uniform list, so the cards show just the model name —
-	// no label chip or repeated description
+	// Subscription models show their endpoint description but no label chip — the
+	// whole list is included with the plan, so a per-card tag adds nothing
 	const subscribedModelCards = useMemo<FeaturedModelCardEntry[]>(() => {
-		const modelIds =
+		const models =
 			clinePassRawModels.length > 0
-				? clinePassRawModels.map((model) => model.id)
-				: Object.keys(clinePassRecommendedModels ?? clinePassModels)
-		return modelIds.map((id) => ({
-			id,
-			displayName: id.replace(/^cline-pass\//, ""),
+				? clinePassRawModels.map((model) => ({ id: model.id, description: model.description }))
+				: Object.entries(clinePassRecommendedModels ?? clinePassModels).map(([id, info]) => ({
+						id,
+						description: info.description,
+					}))
+		return models.map((model) => ({
+			id: model.id,
+			displayName: model.id.replace(/^cline-pass\//, ""),
 			label: "",
-			description: "",
+			description: model.description || "",
 		}))
 	}, [clinePassRawModels, clinePassRecommendedModels])
 

--- a/apps/vscode/webview-ui/src/components/settings/providers/ClinePassProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/ClinePassProvider.tsx
@@ -1,17 +1,23 @@
 import {
 	buildModelInfoNameMap,
 	clinePassDefaultModelId,
+	clinePassModelInfoSaneDefaults,
 	clinePassModels,
 	type ModelInfo,
 	resolveClinePassModelInfo,
 } from "@shared/api"
+import { CLINE_RECOMMENDED_MODELS_FALLBACK } from "@shared/cline/recommended-models"
 import { EmptyRequest } from "@shared/proto/cline/common"
+import type { ClineRecommendedModel } from "@shared/proto/cline/models"
 import type { Mode } from "@shared/storage/types"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { ModelsServiceClient } from "@/services/grpc-client"
 import { ClineAccountInfoCard } from "../ClineAccountInfoCard"
-import ClineModelPicker from "../ClineModelPicker"
+import ClineModelPicker, { type FeaturedModelCardEntry, toFeaturedModelCardEntry } from "../ClineModelPicker"
+import FeaturedModelCard from "../FeaturedModelCard"
+import { getModeSpecificFields } from "../utils/providerUtils"
+import { useApiConfigurationHandlers } from "../utils/useApiConfigurationHandlers"
 
 interface ClinePassProviderProps {
 	showModelOptions: boolean
@@ -20,15 +26,32 @@ interface ClinePassProviderProps {
 	showAccountCard?: boolean
 }
 
+const CLINE_PASS_MODEL_FIELD_PAIRS = {
+	modelId: { plan: "planModeClinePassModelId", act: "actModeClinePassModelId" },
+	modelInfo: { plan: "planModeClinePassModelInfo", act: "actModeClinePassModelInfo" },
+} as const
+
+function zeroPriced(info: ModelInfo): ModelInfo {
+	return {
+		...info,
+		inputPrice: 0,
+		outputPrice: 0,
+		cacheReadsPrice: 0,
+		cacheWritesPrice: 0,
+	}
+}
+
 export const ClinePassProvider = ({
 	showModelOptions,
 	isPopup,
 	currentMode,
 	showAccountCard = true,
 }: ClinePassProviderProps) => {
-	const { openRouterModels } = useExtensionState()
+	const { apiConfiguration, openRouterModels, clineModels, refreshClineModels } = useExtensionState()
+	const { handleModeFieldsChange } = useApiConfigurationHandlers()
 	const openRouterModelsByName = useMemo(() => buildModelInfoNameMap(openRouterModels), [openRouterModels])
 	const [clinePassRecommendedModels, setClinePassRecommendedModels] = useState<Record<string, ModelInfo> | undefined>(undefined)
+	const [clineFreeModels, setClineFreeModels] = useState<ClineRecommendedModel[]>([])
 
 	const refreshClinePassModels = useCallback(async () => {
 		try {
@@ -53,6 +76,7 @@ export const ClinePassProvider = ({
 					}),
 			)
 			setClinePassRecommendedModels(Object.keys(models).length > 0 ? models : undefined)
+			setClineFreeModels((response.free ?? []).filter((model) => model.id))
 		} catch (error) {
 			console.error("Failed to refresh ClinePass models:", error)
 		}
@@ -62,7 +86,52 @@ export const ClinePassProvider = ({
 		void refreshClinePassModels()
 	}, [refreshClinePassModels])
 
-	const clinePassModelOptions = clinePassRecommendedModels ?? clinePassModels
+	// The picker skips its own catalog refresh when a models map is provided, but the
+	// free-model entries below resolve their capabilities from the cline catalog.
+	useEffect(() => {
+		refreshClineModels()
+	}, [refreshClineModels])
+
+	const freeRecommendedModels = useMemo(
+		() => (clineFreeModels.length > 0 ? clineFreeModels : CLINE_RECOMMENDED_MODELS_FALLBACK.free),
+		[clineFreeModels],
+	)
+
+	// Free models are OpenRouter-style ids billed at $0, so resolve their info by full id
+	// from the dynamic catalogs and store them zero-priced.
+	const freeModelEntries = useMemo(() => {
+		const modelCatalog: Record<string, ModelInfo> = { ...openRouterModels, ...clineModels }
+		return Object.fromEntries(
+			freeRecommendedModels
+				.filter((model) => model.id)
+				.map((model) => {
+					const base = modelCatalog[model.id] ?? clinePassModelInfoSaneDefaults
+					return [
+						model.id,
+						zeroPriced({
+							...base,
+							name: model.name || base.name || model.id,
+							description: model.description || base.description,
+						}),
+					]
+				}),
+		)
+	}, [freeRecommendedModels, openRouterModels, clineModels])
+
+	const { clinePassModelId: configuredClinePassModelId, clinePassModelInfo: configuredClinePassModelInfo } =
+		getModeSpecificFields(apiConfiguration, currentMode)
+
+	const clinePassModelOptions = useMemo(() => {
+		// ClinePass entries first so the default-model fallback below stays a pass model.
+		const merged: Record<string, ModelInfo> = { ...(clinePassRecommendedModels ?? clinePassModels), ...freeModelEntries }
+		// Keep a previously selected model visible even if it later drops out of the
+		// endpoint's buckets, so the picker doesn't display a model the host won't send.
+		if (configuredClinePassModelId && !(configuredClinePassModelId in merged) && configuredClinePassModelInfo) {
+			merged[configuredClinePassModelId] = configuredClinePassModelInfo
+		}
+		return merged
+	}, [clinePassRecommendedModels, freeModelEntries, configuredClinePassModelId, configuredClinePassModelInfo])
+
 	const clinePassDefaultModel = useMemo(() => {
 		if (!clinePassModelOptions) {
 			return undefined
@@ -73,6 +142,33 @@ export const ClinePassProvider = ({
 			: (Object.keys(clinePassModelOptions)[0] ?? clinePassDefaultModelId)
 	}, [clinePassModelOptions])
 
+	const selectedModelId =
+		configuredClinePassModelId && configuredClinePassModelId in clinePassModelOptions
+			? configuredClinePassModelId
+			: clinePassDefaultModel
+
+	const freeModelCards = useMemo(
+		() =>
+			freeRecommendedModels
+				.map((model) => toFeaturedModelCardEntry(model, "FREE"))
+				.filter((model): model is FeaturedModelCardEntry => model !== null),
+		[freeRecommendedModels],
+	)
+
+	const handleFreeModelSelect = (modelId: string) => {
+		handleModeFieldsChange(
+			{
+				clineModelId: CLINE_PASS_MODEL_FIELD_PAIRS.modelId,
+				clineModelInfo: CLINE_PASS_MODEL_FIELD_PAIRS.modelInfo,
+			},
+			{
+				clineModelId: modelId,
+				clineModelInfo: clinePassModelOptions[modelId],
+			},
+			currentMode,
+		)
+	}
+
 	return (
 		<div>
 			{showAccountCard && (
@@ -82,15 +178,34 @@ export const ClinePassProvider = ({
 			)}
 
 			{showModelOptions && (
-				<ClineModelPicker
-					currentMode={currentMode}
-					defaultModelId={clinePassDefaultModel}
-					isPopup={isPopup}
-					modelIdFieldPair={{ plan: "planModeClinePassModelId", act: "actModeClinePassModelId" }}
-					modelInfoFieldPair={{ plan: "planModeClinePassModelInfo", act: "actModeClinePassModelInfo" }}
-					models={clinePassModelOptions}
-					showFeaturedModels={false}
-				/>
+				<>
+					<ClineModelPicker
+						currentMode={currentMode}
+						defaultModelId={clinePassDefaultModel}
+						isPopup={isPopup}
+						modelIdFieldPair={CLINE_PASS_MODEL_FIELD_PAIRS.modelId}
+						modelInfoFieldPair={CLINE_PASS_MODEL_FIELD_PAIRS.modelInfo}
+						models={clinePassModelOptions}
+						showFeaturedModels={false}
+					/>
+					{freeModelCards.length > 0 && (
+						<div style={{ marginTop: 10 }}>
+							<span style={{ fontWeight: 500 }}>Free models</span>
+							<div style={{ marginTop: 4 }}>
+								{freeModelCards.map((model) => (
+									<FeaturedModelCard
+										description={model.description}
+										isSelected={selectedModelId === model.id}
+										key={model.id}
+										label={model.label}
+										modelId={model.id}
+										onClick={() => handleFreeModelSelect(model.id)}
+									/>
+								))}
+							</div>
+						</div>
+					)}
+				</>
 			)}
 		</div>
 	)

--- a/apps/vscode/webview-ui/src/components/settings/providers/ClinePassProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/ClinePassProvider.tsx
@@ -74,7 +74,9 @@ export const ClinePassProvider = ({
 						{
 							...fallback,
 							name: model.name || fallback.name || model.id,
-							description: model.description || fallback.description,
+							// The info panel shows the full catalog description; the endpoint's
+							// short blurb is only for the featured cards
+							description: fallback.description || model.description,
 						},
 					]
 				}),
@@ -116,7 +118,9 @@ export const ClinePassProvider = ({
 						zeroPriced({
 							...base,
 							name: model.name || base.name || model.id,
-							description: model.description || base.description,
+							// The info panel shows the full catalog description; the endpoint's
+							// short blurb is only for the featured cards
+							description: base.description || model.description,
 						}),
 					]
 				}),

--- a/apps/vscode/webview-ui/src/components/settings/providers/ClinePassProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/ClinePassProvider.tsx
@@ -34,7 +34,7 @@ const CLINE_PASS_MODEL_FIELD_PAIRS = {
 } as const
 
 const FREE_TAB_DESCRIPTION =
-	"A rotating set of models with limited free usage — included at no cost and separate from your ClinePass quota."
+	"Try these models with limited free usage, included at no cost and separate from your ClinePass quota."
 
 function zeroPriced(info: ModelInfo): ModelInfo {
 	return {

--- a/apps/vscode/webview-ui/src/components/settings/providers/ClinePassProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/ClinePassProvider.tsx
@@ -14,10 +14,12 @@ import { useCallback, useEffect, useMemo, useState } from "react"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { ModelsServiceClient } from "@/services/grpc-client"
 import { ClineAccountInfoCard } from "../ClineAccountInfoCard"
-import ClineModelPicker, { type FeaturedModelCardEntry, toFeaturedModelCardEntry } from "../ClineModelPicker"
-import FeaturedModelCard from "../FeaturedModelCard"
+import ClineModelPicker, {
+	type FeaturedModelCardEntry,
+	type FeaturedModelTab,
+	toFeaturedModelCardEntry,
+} from "../ClineModelPicker"
 import { getModeSpecificFields } from "../utils/providerUtils"
-import { useApiConfigurationHandlers } from "../utils/useApiConfigurationHandlers"
 
 interface ClinePassProviderProps {
 	showModelOptions: boolean
@@ -30,6 +32,10 @@ const CLINE_PASS_MODEL_FIELD_PAIRS = {
 	modelId: { plan: "planModeClinePassModelId", act: "actModeClinePassModelId" },
 	modelInfo: { plan: "planModeClinePassModelInfo", act: "actModeClinePassModelInfo" },
 } as const
+
+const SUBSCRIBED_CARD_DESCRIPTION = "Included with your ClinePass subscription"
+const FREE_TAB_DESCRIPTION =
+	"A rotating set of models with limited free usage — included at no cost and separate from your ClinePass quota."
 
 function zeroPriced(info: ModelInfo): ModelInfo {
 	return {
@@ -48,33 +54,33 @@ export const ClinePassProvider = ({
 	showAccountCard = true,
 }: ClinePassProviderProps) => {
 	const { apiConfiguration, openRouterModels, clineModels, refreshClineModels } = useExtensionState()
-	const { handleModeFieldsChange } = useApiConfigurationHandlers()
 	const openRouterModelsByName = useMemo(() => buildModelInfoNameMap(openRouterModels), [openRouterModels])
+	const [clinePassRawModels, setClinePassRawModels] = useState<ClineRecommendedModel[]>([])
 	const [clinePassRecommendedModels, setClinePassRecommendedModels] = useState<Record<string, ModelInfo> | undefined>(undefined)
 	const [clineFreeModels, setClineFreeModels] = useState<ClineRecommendedModel[]>([])
 
 	const refreshClinePassModels = useCallback(async () => {
 		try {
 			const response = await ModelsServiceClient.refreshClineRecommendedModelsRpc(EmptyRequest.create({}))
+			const clinePassResponseModels = (response.clinePass ?? []).filter((model) => model.id)
 			const models = Object.fromEntries(
-				(response.clinePass ?? [])
-					.filter((model) => model.id)
-					.map((model) => {
-						// ClinePass model IDs omit the upstream lab, so look up capabilities using
-						// the model slug (for example, glm-5.1 instead of cline-pass/glm-5.1).
-						// If the model is not in OpenRouter yet, use conservative generic defaults
-						// instead of copying GLM-5.1-specific context/max-token values.
-						const fallback = resolveClinePassModelInfo(model.id, openRouterModelsByName)
-						return [
-							model.id,
-							{
-								...fallback,
-								name: model.name || fallback.name || model.id,
-								description: model.description || fallback.description,
-							},
-						]
-					}),
+				clinePassResponseModels.map((model) => {
+					// ClinePass model IDs omit the upstream lab, so look up capabilities using
+					// the model slug (for example, glm-5.1 instead of cline-pass/glm-5.1).
+					// If the model is not in OpenRouter yet, use conservative generic defaults
+					// instead of copying GLM-5.1-specific context/max-token values.
+					const fallback = resolveClinePassModelInfo(model.id, openRouterModelsByName)
+					return [
+						model.id,
+						{
+							...fallback,
+							name: model.name || fallback.name || model.id,
+							description: model.description || fallback.description,
+						},
+					]
+				}),
 			)
+			setClinePassRawModels(clinePassResponseModels)
 			setClinePassRecommendedModels(Object.keys(models).length > 0 ? models : undefined)
 			setClineFreeModels((response.free ?? []).filter((model) => model.id))
 		} catch (error) {
@@ -142,10 +148,21 @@ export const ClinePassProvider = ({
 			: (Object.keys(clinePassModelOptions)[0] ?? clinePassDefaultModelId)
 	}, [clinePassModelOptions])
 
-	const selectedModelId =
-		configuredClinePassModelId && configuredClinePassModelId in clinePassModelOptions
-			? configuredClinePassModelId
-			: clinePassDefaultModel
+	const subscribedModelCards = useMemo<FeaturedModelCardEntry[]>(() => {
+		if (clinePassRawModels.length > 0) {
+			return clinePassRawModels.map((model) => ({
+				id: model.id,
+				label: (model.tags?.[0] || "INCLUDED").toUpperCase(),
+				description: model.description || SUBSCRIBED_CARD_DESCRIPTION,
+			}))
+		}
+
+		return Object.entries(clinePassRecommendedModels ?? clinePassModels).map(([id, info]) => ({
+			id,
+			label: "INCLUDED",
+			description: info.description || SUBSCRIBED_CARD_DESCRIPTION,
+		}))
+	}, [clinePassRawModels, clinePassRecommendedModels])
 
 	const freeModelCards = useMemo(
 		() =>
@@ -155,19 +172,13 @@ export const ClinePassProvider = ({
 		[freeRecommendedModels],
 	)
 
-	const handleFreeModelSelect = (modelId: string) => {
-		handleModeFieldsChange(
-			{
-				clineModelId: CLINE_PASS_MODEL_FIELD_PAIRS.modelId,
-				clineModelInfo: CLINE_PASS_MODEL_FIELD_PAIRS.modelInfo,
-			},
-			{
-				clineModelId: modelId,
-				clineModelInfo: clinePassModelOptions[modelId],
-			},
-			currentMode,
-		)
-	}
+	const featuredTabs = useMemo<FeaturedModelTab[]>(() => {
+		const tabs: FeaturedModelTab[] = [{ label: "Subscribed", models: subscribedModelCards }]
+		if (freeModelCards.length > 0) {
+			tabs.push({ label: "Free", models: freeModelCards, description: FREE_TAB_DESCRIPTION })
+		}
+		return tabs
+	}, [subscribedModelCards, freeModelCards])
 
 	return (
 		<div>
@@ -178,34 +189,15 @@ export const ClinePassProvider = ({
 			)}
 
 			{showModelOptions && (
-				<>
-					<ClineModelPicker
-						currentMode={currentMode}
-						defaultModelId={clinePassDefaultModel}
-						isPopup={isPopup}
-						modelIdFieldPair={CLINE_PASS_MODEL_FIELD_PAIRS.modelId}
-						modelInfoFieldPair={CLINE_PASS_MODEL_FIELD_PAIRS.modelInfo}
-						models={clinePassModelOptions}
-						showFeaturedModels={false}
-					/>
-					{freeModelCards.length > 0 && (
-						<div style={{ marginTop: 10 }}>
-							<span style={{ fontWeight: 500 }}>Free models</span>
-							<div style={{ marginTop: 4 }}>
-								{freeModelCards.map((model) => (
-									<FeaturedModelCard
-										description={model.description}
-										isSelected={selectedModelId === model.id}
-										key={model.id}
-										label={model.label}
-										modelId={model.id}
-										onClick={() => handleFreeModelSelect(model.id)}
-									/>
-								))}
-							</div>
-						</div>
-					)}
-				</>
+				<ClineModelPicker
+					currentMode={currentMode}
+					defaultModelId={clinePassDefaultModel}
+					featuredTabs={featuredTabs}
+					isPopup={isPopup}
+					modelIdFieldPair={CLINE_PASS_MODEL_FIELD_PAIRS.modelId}
+					modelInfoFieldPair={CLINE_PASS_MODEL_FIELD_PAIRS.modelInfo}
+					models={clinePassModelOptions}
+				/>
 			)}
 		</div>
 	)

--- a/apps/vscode/webview-ui/src/components/settings/providers/ClineProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/ClineProvider.tsx
@@ -54,14 +54,15 @@ export const ClineProvider = ({
 					<RouteStatus>
 						{activeRoute === "cline-pass" ? (
 							<>
-								ClinePass is a low cost subscription plan including usage of the best open weights models.{" "}
+								ClinePass is a low cost subscription plan including usage of the best open weights models, plus
+								Cline's free models.{" "}
 								<RouteLink
 									href="#"
 									onClick={(event) => {
 										event.preventDefault()
 										handleRouteChange("cline").catch((error) => console.error("Failed to switch to Cline:", error))
 									}}>
-									Switch to Cline Usage-Billing for other models.
+									Switch to Cline Usage-Billing for the full model catalog.
 								</RouteLink>
 							</>
 						) : (

--- a/apps/vscode/webview-ui/src/components/settings/providers/ClineProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/ClineProvider.tsx
@@ -54,15 +54,14 @@ export const ClineProvider = ({
 					<RouteStatus>
 						{activeRoute === "cline-pass" ? (
 							<>
-								ClinePass is a low cost subscription plan including usage of the best open weights models, plus
-								Cline's free models.{" "}
+								ClinePass is a low cost subscription plan including usage of the best open weights models.{" "}
 								<RouteLink
 									href="#"
 									onClick={(event) => {
 										event.preventDefault()
 										handleRouteChange("cline").catch((error) => console.error("Failed to switch to Cline:", error))
 									}}>
-									Switch to Cline Usage-Billing for the full model catalog.
+									Switch to Cline Usage-Billing for other models.
 								</RouteLink>
 							</>
 						) : (

--- a/apps/vscode/webview-ui/src/components/settings/utils/__tests__/providerUtils.test.ts
+++ b/apps/vscode/webview-ui/src/components/settings/utils/__tests__/providerUtils.test.ts
@@ -1,0 +1,87 @@
+import type { ApiConfiguration, ModelInfo } from "@shared/api"
+import { clinePassDefaultModelId, clinePassModels } from "@shared/api"
+import { describe, expect, it } from "vitest"
+import { normalizeApiConfiguration, syncModeConfigurations } from "../providerUtils"
+
+describe("providerUtils", () => {
+	const freeModelInfo: ModelInfo = {
+		maxTokens: 32_768,
+		contextWindow: 256_000,
+		supportsImages: false,
+		supportsPromptCache: false,
+		supportsReasoning: true,
+		inputPrice: 0,
+		outputPrice: 0,
+		cacheReadsPrice: 0,
+		cacheWritesPrice: 0,
+		description: "A free model",
+	}
+
+	describe("normalizeApiConfiguration cline-pass", () => {
+		it("passes a free (non cline-pass prefixed) model id through with its stored info", () => {
+			const apiConfiguration: ApiConfiguration = {
+				actModeApiProvider: "cline-pass",
+				actModeClinePassModelId: "kwaipilot/kat-coder-pro",
+				actModeClinePassModelInfo: freeModelInfo,
+			}
+
+			const normalized = normalizeApiConfiguration(apiConfiguration, "act", { isClinePassEnabled: true })
+			expect(normalized.selectedProvider).toBe("cline-pass")
+			expect(normalized.selectedModelId).toBe("kwaipilot/kat-coder-pro")
+			expect(normalized.selectedModelInfo).toEqual(freeModelInfo)
+		})
+
+		it("passes a :free suffixed model id through with its stored info", () => {
+			const apiConfiguration: ApiConfiguration = {
+				actModeApiProvider: "cline-pass",
+				actModeClinePassModelId: "arcee-ai/trinity-large-preview:free",
+				actModeClinePassModelInfo: freeModelInfo,
+			}
+
+			const normalized = normalizeApiConfiguration(apiConfiguration, "act", { isClinePassEnabled: true })
+			expect(normalized.selectedModelId).toBe("arcee-ai/trinity-large-preview:free")
+			expect(normalized.selectedModelInfo).toEqual(freeModelInfo)
+		})
+
+		it("keeps cline-pass prefixed ids resolved against the static model table", () => {
+			const apiConfiguration: ApiConfiguration = {
+				actModeApiProvider: "cline-pass",
+				actModeClinePassModelId: "cline-pass/glm-5.2",
+			}
+
+			const normalized = normalizeApiConfiguration(apiConfiguration, "act", { isClinePassEnabled: true })
+			expect(normalized.selectedModelId).toBe("cline-pass/glm-5.2")
+			expect(normalized.selectedModelInfo).toEqual(clinePassModels["cline-pass/glm-5.2"])
+		})
+
+		it("falls back to the default pass model when no model id is configured", () => {
+			const apiConfiguration: ApiConfiguration = {
+				actModeApiProvider: "cline-pass",
+			}
+
+			const normalized = normalizeApiConfiguration(apiConfiguration, "act", { isClinePassEnabled: true })
+			expect(normalized.selectedModelId).toBe(clinePassDefaultModelId)
+			expect(normalized.selectedModelInfo).toEqual(clinePassModels[clinePassDefaultModelId])
+		})
+	})
+
+	describe("syncModeConfigurations cline-pass", () => {
+		it("copies a free model id and info across plan and act modes", async () => {
+			const apiConfiguration: ApiConfiguration = {
+				planModeApiProvider: "cline-pass",
+				actModeApiProvider: "cline-pass",
+				actModeClinePassModelId: "kwaipilot/kat-coder-pro",
+				actModeClinePassModelInfo: freeModelInfo,
+			}
+
+			let updates: Partial<ApiConfiguration> | undefined
+			await syncModeConfigurations(apiConfiguration, "act", async (fields) => {
+				updates = fields
+			})
+
+			expect(updates?.planModeClinePassModelId).toBe("kwaipilot/kat-coder-pro")
+			expect(updates?.planModeClinePassModelInfo).toEqual(freeModelInfo)
+			expect(updates?.actModeClinePassModelId).toBe("kwaipilot/kat-coder-pro")
+		})
+	})
+})

--- a/apps/vscode/webview-ui/src/components/settings/utils/providerUtils.ts
+++ b/apps/vscode/webview-ui/src/components/settings/utils/providerUtils.ts
@@ -355,11 +355,10 @@ export function normalizeApiConfiguration(
 				currentMode === "plan"
 					? apiConfiguration?.planModeClinePassModelId
 					: apiConfiguration?.actModeClinePassModelId;
-			const clinePassModelId = configuredClinePassModelId?.startsWith(
-				"cline-pass/",
-			)
-				? configuredClinePassModelId
-				: clinePassDefaultModelId;
+			// ClinePass users may also select Cline free models (OpenRouter-style ids
+			// without the cline-pass/ prefix), so pass any configured id through.
+			const clinePassModelId =
+				configuredClinePassModelId || clinePassDefaultModelId;
 			const clinePassModelInfo =
 				currentMode === "plan"
 					? apiConfiguration?.planModeClinePassModelInfo

--- a/apps/vscode/webview-ui/src/utils/validate.ts
+++ b/apps/vscode/webview-ui/src/utils/validate.ts
@@ -1,4 +1,5 @@
 import { ApiConfiguration, clinePassDefaultModelId, clinePassModels, ModelInfo, openRouterDefaultModelId } from "@shared/api"
+import { CLINE_RECOMMENDED_MODELS_FALLBACK } from "@shared/cline/recommended-models"
 import { Mode } from "@shared/storage/types"
 import { getModeSpecificFields } from "@/components/settings/utils/providerUtils"
 
@@ -222,7 +223,10 @@ export function validateModelId(
 				}
 				if (
 					!Object.keys(clinePassModels).includes(clinePassResolvedModelId) &&
-					!clinePassResolvedModelId.startsWith("cline-pass/")
+					!clinePassResolvedModelId.startsWith("cline-pass/") &&
+					// ClinePass users may also select Cline free models (OpenRouter-style ids)
+					!(clineModels && Object.keys(clineModels).includes(clinePassResolvedModelId)) &&
+					!CLINE_RECOMMENDED_MODELS_FALLBACK.free.some((model) => model.id === clinePassResolvedModelId)
 				) {
 					return "The model ID you provided is not available. Please choose a different model."
 				}


### PR DESCRIPTION
### Related Issue

No linked issue — this addresses a user complaint that free models are hard to discover/use while on the ClinePass provider. First of three planned changes (this legacy branch, then the SDK extension on `main`, then the CLI).

### Description

**Problem.** ClinePass (`cline-pass`) and Cline usage-billing (`cline`) are the same `ClineHandler` under the hood: same `/api/v1/chat/completions` endpoint, same credentials — the only runtime difference is the model ID string sent. But users on ClinePass couldn't see or use the free models that the usage-billing route shows in its "Free" tab. They had to switch providers, pick a free model there, and lose their ClinePass context. Since the recommended-models endpoint (`GET /api/v1/ai/cline/recommended-models`) already returns `{recommended, free, clinePass}` buckets and the webview already receives all three via `refreshClineRecommendedModelsRpc`, no server/proto work was needed — this is purely client plumbing + UI.

**What actually blocked it.** Three independent guards all coerced/rejected any model ID not prefixed `cline-pass/`:

1. `buildApiHandler`'s `case "cline-pass"` (`src/core/api/index.ts`) silently replaced non-prefixed IDs with `clinePassDefaultModelId` (`cline-pass/glm-5.2`) at request time.
2. `normalizeApiConfiguration`'s `case "cline-pass"` (`webview-ui/.../utils/providerUtils.ts`) did the same for display.
3. `validateModelId`'s `case "cline-pass"` (`webview-ui/src/utils/validate.ts`) rejected such IDs (turns out this function has zero callers — dead code — but we kept its contract consistent anyway).

Guard #1 is the nasty one: even if you got a free ID stored, the request would silently go out with the **paid** default pass model instead. That failure mode drove the key design decision below.

**Design decision: pass-through, not allowlist.** `buildApiHandler` is synchronous, so it can't await the recommended-models fetch to check "is this ID actually free". We considered validating against a synchronously-available cached free-ID set, but its failure mode is terrible: empty cache at startup → a legitimately selected free model silently swaps to the paid default. Instead, the dispatch now passes any configured non-empty ID through (`configuredClinePassModelId || clinePassDefaultModelId`), exactly mirroring the `cline` case. The worst case for a stale/garbage stored ID is an explicit server-side entitlement error — same as the `cline` provider behaves today — which is strictly better than silently charging the user. What can be *stored* is gated UI-side (see below).

**Latent bug this exposed (and the fix).** `ClineModelPicker`'s search field commits on blur: `handleModelChange(searchTerm)` stores whatever text is in the box. Previously harmless on the ClinePass route because guard #1 coerced at read time; with pass-through it would send arbitrary typed text to the API. `handleModelChange` now coerces at **storage** time when a fixed `models` map is provided: IDs not in the map resolve back to the default before being stored. Only `ClinePassProvider` passes a `models` map (verified — sole caller), so the `cline`/OpenRouter routes are untouched.

**UI: Subscribed / Free tabs.** The ClinePass route now mirrors the usage-billing route's tabbed featured-models UI, via a new generic `featuredTabs` prop on `ClineModelPicker` (label + card entries + optional description per tab; the built-in Recommended/Free tabs are untouched when the prop is absent). The picker auto-selects the tab containing the configured model.

- **Subscribed** — every model from the endpoint's `clinePass` bucket (falling back to the static `clinePassModels` table) as standard featured cards showing the model name (with the `cline-pass/` prefix stripped via a new optional `displayName` on card entries; selection still uses the full ID) and the endpoint's short description. No label chip — the whole list is included with the plan, so a per-card tag adds nothing.
- **Free** — the endpoint's `free` bucket as descriptive cards with the FREE chip, plus explanatory copy under the tab bar: *"Try these models with limited free usage, included at no cost and separate from your ClinePass quota."*
- The dropdown search below the tabs covers both sets.

Selecting a free card writes the same `{plan,act}ModeClinePassModelId/Info` fields the picker uses, so plan/act sync (`syncModeConfigurations` copies these verbatim) and the "use different models for Plan/Act" setting work with zero changes. The chat-field model badge labels free selections as `cline:<model-id>` (instead of `cline-pass:<model-id>`) so it's clear the request rides Cline usage billing, not the ClinePass quota.

**Description precedence (cards vs. info panel).** The endpoint's short admin-curated blurbs render on the featured cards; the info panel under the picker keeps the full catalog description (`fallback/base.description || model.description`). Before the admin descriptions existed this distinction was invisible (endpoint fields were empty, so the catalog text showed everywhere); once they were populated they started silently replacing the catalog paragraph in the info panel, so the precedence there is now explicitly catalog-first — matching how the usage-billing route behaves.

**Model info resolution nuance.** ClinePass normally resolves model info through `resolveClinePassModelInfo` (slug lookup → hardcoded `clinePassModels` table → sane defaults), because pass IDs omit the upstream lab. Free models are OpenRouter-style full IDs, so slug-based lookup risks collisions (and `:free`-suffixed slugs like `trinity-large-preview:free` are meaningless in the pass table). Free entries therefore resolve by **full ID** against `{...openRouterModels, ...clineModels}` and are stored with **prices zeroed at storage time** — so the persisted `ModelInfo` is already correct for cost calculation and context-window management, no display-time patching. (Runtime cost was already safe either way: `ClineHandler.getFreeModelIdSet()` includes the `free` bucket and zeroes `totalCost`.) Note `resolveClinePassModelInfo` itself needed no changes — the stored-info name map round-trips `:free` suffixes correctly, which the new tests pin down.

**Stale-selection safeguard.** If a previously selected free model later drops out of the endpoint's `free` bucket, the merged models map re-adds the configured ID from stored info, so the picker keeps displaying what the host will actually send instead of showing the default while sending something else. The merged map also keeps pass entries spread first so the `Object.keys(...)[0]` default-model fallback stays a pass model.

**Not in this PR (deliberately scoped out):**
- A "See more" description-expansion bug in `ModelDescriptionMarkdown` (outer wrapper hardcodes `line-clamp-3`, so expanding barely changes anything) was fixed here originally but pulled out to keep this PR focused — it affects all providers and also exists on `main`; will land separately. Relatedly, ~300 of 343 catalog descriptions from `/api/v1/ai/cline/models` are pre-truncated at ~200 chars ending in `"..."` — that's a backend data issue, not a client one.
- `ClineProvider.tsx` (the Cline/ClinePass route switch) is untouched — the route copy from #12103 stands as-is.
- The recommended-models endpoint's `free` array ordering is not stable between requests, so Free-tab card order shuffles per cache refresh — needs a server-side sort eventually.

### Test Procedure

- `npm run test:unit` — 1509 passing. New `src/core/api/__tests__/index.test.ts` covers the dispatch: free ID + stored info passes through, `:free`-suffixed IDs round-trip the slug map, `cline-pass/*` IDs still resolve from the static table, empty falls back to the default, and plan/act resolve independently (there was previously **no** test coverage for this dispatch case at all). `src/shared/__tests__/api.test.ts` gains `resolveClinePassModelInfo` cases for non-prefixed free IDs with/without dynamic metadata.
- `npm run test:webview` — 167 passing. New `providerUtils.test.ts` covers `normalizeApiConfiguration` cline-pass pass-through/fallback and `syncModeConfigurations` copying free IDs across modes.
- `npm run check-types` — clean for both host and webview. Biome lint clean on all changed files.
- Biome *format*: byte-identical error set to the branch baseline (the legacy branch has pre-existing `--changed --since main` noise because `main` diverged) — this PR introduces zero new diagnostics.
- Heads-up for reviewers: PRs targeting `legacy-extension` don't run the real test workflows (the green "Run Tests" check is a no-op), so the local runs above are the actual gate.

Manual verification checklist (extension dev host):
1. Settings → ClinePass route: Subscribed/Free tabs above the dropdown; Subscribed shows model-name + description cards (no chips), Free shows descriptive FREE-chip cards + the limited-usage copy line (fallback cards render if the endpoint is unreachable).
2. Click a free card → card highlights, search field shows the ID, ModelInfo shows $0 prices, provider stays `cline-pass`, chat badge reads `cline:<model-id>`.
3. Send a task → request carries the free model ID, cost shows $0.
4. Reload window → selection persists and the picker lands on the tab containing it (previously the model silently reverted to `cline-pass/glm-5.2` at request time).
5. Re-select a Subscribed model → paid pass behavior unchanged, badge reads `cline-pass:<model>`.
6. Type garbage in the search field and blur → snaps back to a valid model, nothing invalid stored.
7. Note: the extension caches the recommended-models payload for 1h — reload the window when verifying against fresh endpoint data.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

_Webview UI change (Subscribed/Free tabs on the ClinePass route) — screenshots to be added from a dev-host run; the tabs/cards reuse the existing featured-model components from the usage-billing route._

### Additional Notes

- **No version bump / CHANGELOG entry here** — legacy release mechanics (version monotonicity above the last published marketplace version, root CHANGELOG heading check) happen at release time per the legacy publish workflow.
- Known edge: a user who previously typed junk into the ClinePass search field has that junk stored; post-upgrade it's sent verbatim and errors explicitly until they re-pick (previously it was silently coerced to the paid default). New occurrences are impossible after the storage-time coercion.
- Greptile's review was posted against the very first commit: its P1 (stale `searchTerm` on external card clicks) targets a code path removed by the tabs rework (free cards now select through the picker's own `handleModelChange`), and its P2 concerns the zero-caller `validateModelId` dead code.
- Follow-ups (separate PRs): same feature for the SDK extension on `main`, the CLI, and the "See more" clamp fix.
