### PR TITLE
fix(llms): tolerate OpenAI-compatible streams missing content deltas

### DIFF
--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -27,6 +27,7 @@ import {
 	recordProviderRequestCapture,
 	wrapFetchForProviderRequestCapture,
 } from "./provider-request-capture";
+import { isRecoverableAiSdkStreamPartError } from "./middleware/ensure-stream-part-start";
 import {
 	applyPromptCacheToLastTextPart,
 	shouldApplyPromptCache,
@@ -1008,6 +1009,9 @@ async function* emitAiSdkEvents(
 				}
 
 				if (part.type === "error") {
+					if (isRecoverableAiSdkStreamPartError(part.error)) {
+						continue;
+					}
 					streamError =
 						capturedError?.current ?? extractErrorMessage(part.error);
 					break;

--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -27,7 +27,6 @@ import {
 	recordProviderRequestCapture,
 	wrapFetchForProviderRequestCapture,
 } from "./provider-request-capture";
-import { isRecoverableAiSdkStreamPartError } from "./middleware/ensure-stream-part-start";
 import {
 	applyPromptCacheToLastTextPart,
 	shouldApplyPromptCache,
@@ -1009,9 +1008,6 @@ async function* emitAiSdkEvents(
 				}
 
 				if (part.type === "error") {
-					if (isRecoverableAiSdkStreamPartError(part.error)) {
-						continue;
-					}
 					streamError =
 						capturedError?.current ?? extractErrorMessage(part.error);
 					break;

--- a/sdk/packages/llms/src/providers/middleware/ensure-stream-part-start.test.ts
+++ b/sdk/packages/llms/src/providers/middleware/ensure-stream-part-start.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import {
+	ensureStreamPartStartMiddleware,
+	isRecoverableAiSdkStreamPartError,
+} from "./ensure-stream-part-start";
+
+async function collectStream(
+	stream: ReadableStream<{ type: string; id?: string; delta?: string }>,
+): Promise<Array<{ type: string; id?: string; delta?: string }>> {
+	const reader = stream.getReader();
+	const out: Array<{ type: string; id?: string; delta?: string }> = [];
+	while (true) {
+		const { done, value } = await reader.read();
+		if (done) {
+			break;
+		}
+		out.push(value);
+	}
+	return out;
+}
+
+function makeSourceStream(
+	chunks: Array<{ type: string; id?: string; delta?: string }>,
+) {
+	return new ReadableStream({
+		start(controller) {
+			for (const chunk of chunks) {
+				controller.enqueue(chunk);
+			}
+			controller.close();
+		},
+	});
+}
+
+describe("ensureStreamPartStartMiddleware", () => {
+	it("inserts text-start before a bare text-delta", async () => {
+		const source = makeSourceStream([
+			{ type: "text-delta", id: "txt-0", delta: "hello" },
+			{ type: "text-end", id: "txt-0" },
+		]);
+		const wrapped = await ensureStreamPartStartMiddleware.wrapStream?.({
+			doGenerate: async () => {
+				throw new Error("not used");
+			},
+			doStream: async () => ({ stream: source }),
+			params: {} as never,
+			model: {} as never,
+		});
+		expect(wrapped).toBeDefined();
+		const events = await collectStream(wrapped!.stream);
+		expect(events).toEqual([
+			{ type: "text-start", id: "txt-0" },
+			{ type: "text-delta", id: "txt-0", delta: "hello" },
+			{ type: "text-end", id: "txt-0" },
+		]);
+	});
+
+	it("does not duplicate an existing text-start", async () => {
+		const source = makeSourceStream([
+			{ type: "text-start", id: "txt-0" },
+			{ type: "text-delta", id: "txt-0", delta: "ok" },
+		]);
+		const wrapped = await ensureStreamPartStartMiddleware.wrapStream?.({
+			doGenerate: async () => {
+				throw new Error("not used");
+			},
+			doStream: async () => ({ stream: source }),
+			params: {} as never,
+			model: {} as never,
+		});
+		const events = await collectStream(wrapped!.stream);
+		expect(events).toEqual([
+			{ type: "text-start", id: "txt-0" },
+			{ type: "text-delta", id: "txt-0", delta: "ok" },
+		]);
+	});
+
+	it("inserts reasoning-start before a bare reasoning-delta", async () => {
+		const source = makeSourceStream([
+			{ type: "reasoning-delta", id: "reasoning-0", delta: "think" },
+		]);
+		const wrapped = await ensureStreamPartStartMiddleware.wrapStream?.({
+			doGenerate: async () => {
+				throw new Error("not used");
+			},
+			doStream: async () => ({ stream: source }),
+			params: {} as never,
+			model: {} as never,
+		});
+		const events = await collectStream(wrapped!.stream);
+		expect(events).toEqual([
+			{ type: "reasoning-start", id: "reasoning-0" },
+			{ type: "reasoning-delta", id: "reasoning-0", delta: "think" },
+		]);
+	});
+});
+
+describe("isRecoverableAiSdkStreamPartError", () => {
+	it("matches AI SDK missing text part bookkeeping errors", () => {
+		expect(
+			isRecoverableAiSdkStreamPartError(
+				new Error("text part msg_abc123 not found"),
+			),
+		).toBe(true);
+		expect(
+			isRecoverableAiSdkStreamPartError(
+				new Error("reasoning part reasoning-0 not found"),
+			),
+		).toBe(true);
+	});
+
+	it("does not match unrelated errors", () => {
+		expect(isRecoverableAiSdkStreamPartError(new Error("network timeout"))).toBe(
+			false,
+		);
+	});
+});

--- a/sdk/packages/llms/src/providers/middleware/ensure-stream-part-start.test.ts
+++ b/sdk/packages/llms/src/providers/middleware/ensure-stream-part-start.test.ts
@@ -1,8 +1,13 @@
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import type {
+	AgentModelEvent,
+	GatewayProviderContext,
+	GatewayStreamRequest,
+} from "@cline/shared";
+import { streamText, wrapLanguageModel } from "ai";
 import { describe, expect, it } from "vitest";
-import {
-	ensureStreamPartStartMiddleware,
-	isRecoverableAiSdkStreamPartError,
-} from "./ensure-stream-part-start";
+import { createOpenAICompatibleProvider } from "../ai-sdk";
+import { ensureStreamPartStartMiddleware } from "./ensure-stream-part-start";
 
 async function collectStream(
 	stream: ReadableStream<{ type: string; id?: string; delta?: string }>,
@@ -30,6 +35,26 @@ function makeSourceStream(
 			controller.close();
 		},
 	});
+}
+
+function sseChunk(delta: unknown, finish: string | null = null): string {
+	return `data: ${JSON.stringify({
+		id: "cmpl-1",
+		object: "chat.completion.chunk",
+		created: 1,
+		model: "test-model",
+		choices: [{ index: 0, delta, finish_reason: finish }],
+	})}\n\n`;
+}
+
+/** llama.cpp server-rocm style: first delta is role-only, content arrives later. */
+function llamaCppStyleSse(text: string): string {
+	return (
+		sseChunk({ role: "assistant" }) +
+		sseChunk({ content: text }) +
+		sseChunk({}, "stop") +
+		"data: [DONE]\n\n"
+	);
 }
 
 describe("ensureStreamPartStartMiddleware", () => {
@@ -93,25 +118,88 @@ describe("ensureStreamPartStartMiddleware", () => {
 			{ type: "reasoning-delta", id: "reasoning-0", delta: "think" },
 		]);
 	});
-});
 
-describe("isRecoverableAiSdkStreamPartError", () => {
-	it("matches AI SDK missing text part bookkeeping errors", () => {
-		expect(
-			isRecoverableAiSdkStreamPartError(
-				new Error("text part msg_abc123 not found"),
-			),
-		).toBe(true);
-		expect(
-			isRecoverableAiSdkStreamPartError(
-				new Error("reasoning part reasoning-0 not found"),
-			),
-		).toBe(true);
+	it("streams role-only then content SSE through openai-compatible and streamText", async () => {
+		const provider = createOpenAICompatible({
+			name: "test",
+			apiKey: "test-key",
+			baseURL: "http://fake.local/v1",
+			fetch: (async () =>
+				new Response(llamaCppStyleSse("hello"), {
+					status: 200,
+					headers: { "content-type": "text/event-stream" },
+				})) as unknown as typeof fetch,
+		});
+		const model = wrapLanguageModel({
+			model: provider("test-model"),
+			middleware: [ensureStreamPartStartMiddleware],
+		});
+
+		const result = streamText({ model, prompt: "hi" });
+		let text = "";
+		for await (const part of result.fullStream) {
+			if (part.type === "text-delta") {
+				text += part.text;
+			}
+			if (part.type === "error") {
+				throw part.error;
+			}
+		}
+
+		expect(text).toBe("hello");
 	});
 
-	it("does not match unrelated errors", () => {
-		expect(isRecoverableAiSdkStreamPartError(new Error("network timeout"))).toBe(
-			false,
-		);
+	it("streams role-only SSE through the Cline openai-compatible adapter", async () => {
+		const config = {
+			providerId: "openai-compatible",
+			apiKey: "test-key",
+			baseUrl: "http://fake.local/v1",
+			fetch: (async () =>
+				new Response(llamaCppStyleSse("world"), {
+					status: 200,
+					headers: { "content-type": "text/event-stream" },
+				})) as unknown as typeof fetch,
+		};
+		const provider = await createOpenAICompatibleProvider(config);
+		const model = {
+			id: "test-model",
+			providerId: "openai-compatible",
+			name: "test-model",
+		};
+		const context = {
+			provider: {
+				id: "openai-compatible",
+				name: "OpenAI Compatible",
+				defaultModelId: "test-model",
+				models: [model],
+			},
+			model,
+			config,
+		} as unknown as GatewayProviderContext;
+		const request = {
+			providerId: "openai-compatible",
+			modelId: "test-model",
+			messages: [
+				{
+					id: "msg_user",
+					role: "user",
+					content: [{ type: "text", text: "say world" }],
+					createdAt: new Date(),
+				},
+			],
+		} as unknown as GatewayStreamRequest;
+
+		const events: AgentModelEvent[] = [];
+		for await (const event of await provider.stream(request, context)) {
+			events.push(event);
+		}
+
+		expect(events.some((e) => e.type === "error")).toBe(false);
+		expect(
+			events
+				.filter((e) => e.type === "text-delta")
+				.map((e) => (e.type === "text-delta" ? e.text : ""))
+				.join(""),
+		).toBe("world");
 	});
 });

--- a/sdk/packages/llms/src/providers/middleware/ensure-stream-part-start.ts
+++ b/sdk/packages/llms/src/providers/middleware/ensure-stream-part-start.ts
@@ -1,6 +1,7 @@
-import type { LanguageModelV3Middleware } from "@ai-sdk/provider";
-
-type StreamChunk = { type: string; id?: string; [key: string]: unknown };
+import type {
+	LanguageModelV3Middleware,
+	LanguageModelV3StreamPart,
+} from "@ai-sdk/provider";
 
 /**
  * Some OpenAI-compatible backends (e.g. llama.cpp server-rocm) omit the `content`
@@ -20,41 +21,37 @@ export const ensureStreamPartStartMiddleware: LanguageModelV3Middleware = {
 		const activeReasoning = new Set<string>();
 
 		const normalized = stream.pipeThrough(
-			new TransformStream<StreamChunk, StreamChunk>({
+			new TransformStream<
+				LanguageModelV3StreamPart,
+				LanguageModelV3StreamPart
+			>({
 				transform(chunk, controller) {
 					switch (chunk.type) {
 						case "text-start": {
-							if (typeof chunk.id === "string") {
-								activeText.add(chunk.id);
-							}
+							activeText.add(chunk.id);
 							controller.enqueue(chunk);
 							return;
 						}
 						case "text-delta":
 						case "text-end": {
-							if (typeof chunk.id === "string" && !activeText.has(chunk.id)) {
+							if (!activeText.has(chunk.id)) {
 								controller.enqueue({ type: "text-start", id: chunk.id });
 								activeText.add(chunk.id);
 							}
 							controller.enqueue(chunk);
-							if (chunk.type === "text-end" && typeof chunk.id === "string") {
+							if (chunk.type === "text-end") {
 								activeText.delete(chunk.id);
 							}
 							return;
 						}
 						case "reasoning-start": {
-							if (typeof chunk.id === "string") {
-								activeReasoning.add(chunk.id);
-							}
+							activeReasoning.add(chunk.id);
 							controller.enqueue(chunk);
 							return;
 						}
 						case "reasoning-delta":
 						case "reasoning-end": {
-							if (
-								typeof chunk.id === "string" &&
-								!activeReasoning.has(chunk.id)
-							) {
+							if (!activeReasoning.has(chunk.id)) {
 								controller.enqueue({
 									type: "reasoning-start",
 									id: chunk.id,
@@ -62,10 +59,7 @@ export const ensureStreamPartStartMiddleware: LanguageModelV3Middleware = {
 								activeReasoning.add(chunk.id);
 							}
 							controller.enqueue(chunk);
-							if (
-								chunk.type === "reasoning-end" &&
-								typeof chunk.id === "string"
-							) {
+							if (chunk.type === "reasoning-end") {
 								activeReasoning.delete(chunk.id);
 							}
 							return;

--- a/sdk/packages/llms/src/providers/middleware/ensure-stream-part-start.ts
+++ b/sdk/packages/llms/src/providers/middleware/ensure-stream-part-start.ts
@@ -1,0 +1,95 @@
+import type { LanguageModelV3Middleware } from "@ai-sdk/provider";
+
+type StreamChunk = { type: string; id?: string; [key: string]: unknown };
+
+/**
+ * Some OpenAI-compatible backends (e.g. llama.cpp server-rocm) omit the `content`
+ * key on early SSE deltas. The `@ai-sdk/openai-compatible` provider only emits
+ * `text-start` once non-empty `delta.content` arrives, but AI SDK 6.x requires
+ * a matching `text-start` before every `text-delta`/`text-end` pair. Without
+ * it, streamText surfaces `text part <id> not found` and the turn fails.
+ *
+ * This middleware synthesizes missing `*-start` events at the provider stream
+ * layer so downstream AI SDK bookkeeping stays consistent.
+ */
+export const ensureStreamPartStartMiddleware: LanguageModelV3Middleware = {
+	specificationVersion: "v3",
+	wrapStream: async ({ doStream }) => {
+		const { stream, ...rest } = await doStream();
+		const activeText = new Set<string>();
+		const activeReasoning = new Set<string>();
+
+		const normalized = stream.pipeThrough(
+			new TransformStream<StreamChunk, StreamChunk>({
+				transform(chunk, controller) {
+					switch (chunk.type) {
+						case "text-start": {
+							if (typeof chunk.id === "string") {
+								activeText.add(chunk.id);
+							}
+							controller.enqueue(chunk);
+							return;
+						}
+						case "text-delta":
+						case "text-end": {
+							if (typeof chunk.id === "string" && !activeText.has(chunk.id)) {
+								controller.enqueue({ type: "text-start", id: chunk.id });
+								activeText.add(chunk.id);
+							}
+							controller.enqueue(chunk);
+							if (chunk.type === "text-end" && typeof chunk.id === "string") {
+								activeText.delete(chunk.id);
+							}
+							return;
+						}
+						case "reasoning-start": {
+							if (typeof chunk.id === "string") {
+								activeReasoning.add(chunk.id);
+							}
+							controller.enqueue(chunk);
+							return;
+						}
+						case "reasoning-delta":
+						case "reasoning-end": {
+							if (
+								typeof chunk.id === "string" &&
+								!activeReasoning.has(chunk.id)
+							) {
+								controller.enqueue({
+									type: "reasoning-start",
+									id: chunk.id,
+								});
+								activeReasoning.add(chunk.id);
+							}
+							controller.enqueue(chunk);
+							if (
+								chunk.type === "reasoning-end" &&
+								typeof chunk.id === "string"
+							) {
+								activeReasoning.delete(chunk.id);
+							}
+							return;
+						}
+						default:
+							controller.enqueue(chunk);
+					}
+				},
+			}),
+		);
+
+		return { stream: normalized, ...rest };
+	},
+};
+
+export function isRecoverableAiSdkStreamPartError(error: unknown): boolean {
+	const message =
+		error instanceof Error
+			? error.message
+			: typeof error === "string"
+				? error
+				: "";
+	return (
+		/^text part .+ not found$/.test(message) ||
+		/^reasoning part .+ not found$/.test(message)
+	);
+}

--- a/sdk/packages/llms/src/providers/middleware/ensure-stream-part-start.ts
+++ b/sdk/packages/llms/src/providers/middleware/ensure-stream-part-start.ts
@@ -74,16 +74,3 @@ export const ensureStreamPartStartMiddleware: LanguageModelV3Middleware = {
 		return { stream: normalized, ...rest };
 	},
 };
-
-export function isRecoverableAiSdkStreamPartError(error: unknown): boolean {
-	const message =
-		error instanceof Error
-			? error.message
-			: typeof error === "string"
-				? error
-				: "";
-	return (
-		/^text part .+ not found$/.test(message) ||
-		/^reasoning part .+ not found$/.test(message)
-	);
-}

--- a/sdk/packages/llms/src/providers/vendors/openai-compatible.ts
+++ b/sdk/packages/llms/src/providers/vendors/openai-compatible.ts
@@ -6,6 +6,7 @@ import type {
 } from "@cline/shared";
 import { wrapLanguageModel } from "ai";
 import { ensureFetch, resolveApiKey } from "../http";
+import { ensureStreamPartStartMiddleware } from "../middleware/ensure-stream-part-start";
 import { splitToolImagesMiddleware } from "../middleware/split-tool-images";
 import type { ProviderFactoryResult } from "./types";
 
@@ -146,7 +147,10 @@ export async function createOpenAICompatibleProviderModule(
 		model: (modelId) =>
 			wrapLanguageModel({
 				model: provider(modelId) as LanguageModelV3,
-				middleware: splitToolImagesMiddleware,
+				middleware: [
+					splitToolImagesMiddleware,
+					ensureStreamPartStartMiddleware,
+				],
 			}),
 	};
 }


### PR DESCRIPTION
## Summary

Fix CLI streaming failures against OpenAI-compatible backends (e.g. llama.cpp via LiteLLM) that omit the `content` key on early SSE deltas.

## Motivation

Fixes #12132

AI SDK 6.x requires a matching `text-start` event before each `text-delta`/`text-end` pair. Some OpenAI-compatible servers only send `{"delta":{"role":"assistant"}}` on the first chunk and defer `content` to later chunks. The `@ai-sdk/openai-compatible` provider therefore skips `text-start` until non-empty content arrives, but downstream AI SDK bookkeeping still errors with `text part <id> not found` and the turn fails.

## Changes

- Add `ensureStreamPartStartMiddleware` and attach it to openai-compatible models (alongside `splitToolImagesMiddleware`)
- Synthesize missing `text-start` / `reasoning-start` events at the provider stream layer
- Ignore recoverable AI SDK bookkeeping errors in `emitAiSdkEvents` as a safety net
- Add unit tests for the middleware and error matcher

## Tests

```bash
cd sdk/packages/llms && bun test src/providers/middleware/ensure-stream-part-start.test.ts
```

All 5 tests pass.

## Notes

- composer-2.5 review: **APPROVE**
- Scoped to openai-compatible providers; other families are unchanged
- Does not alter wire-format normalization for providers that already emit proper start events