### PR TITLE
refactor

### DIFF
--- a/apps/vscode/src/common.ts
+++ b/apps/vscode/src/common.ts
@@ -49,6 +49,7 @@ export async function initialize(storageContext: StorageContext): Promise<Webvie
 			type: ShowMessageType.ERROR,
 			message: "Failed to initialize storage. Please check logs for details or try restarting the client.",
 		})
+		throw error
 	}
 
 	// Register host-only SDK provider handlers (e.g. VS Code Language Model API),

--- a/apps/vscode/src/core/storage/remote-config/fetch.ts
+++ b/apps/vscode/src/core/storage/remote-config/fetch.ts
@@ -55,7 +55,7 @@ async function makeAuthenticatedRequest<T>(endpoint: string, organizationId: str
 		headers: {
 			Authorization: `Bearer ${authToken}`,
 			"Content-Type": "application/json",
-			...(await buildBasicClineHeaders()),
+			...buildBasicClineHeaders(),
 		},
 		...getAxiosSettings(),
 	}

--- a/apps/vscode/src/core/storage/remote-config/sdk-control-plane.ts
+++ b/apps/vscode/src/core/storage/remote-config/sdk-control-plane.ts
@@ -63,7 +63,7 @@ async function makeAuthenticatedRequest<T>(endpoint: string, organizationId: str
 		headers: {
 			Authorization: `Bearer ${authToken}`,
 			"Content-Type": "application/json",
-			...(await buildBasicClineHeaders()),
+			...buildBasicClineHeaders(),
 		},
 		...getAxiosSettings(),
 	}

--- a/apps/vscode/src/registry.ts
+++ b/apps/vscode/src/registry.ts
@@ -95,5 +95,10 @@ export const HostRegistryInfo = {
 		const ide = host.clineType || "unknown"
 		hostInfo = { hostVersion, extensionVersion, platform, os, ide, distinctId }
 	},
-	get: () => hostInfo,
+	get: () => {
+		if (!hostInfo) {
+			throw new Error("HostRegistryInfo has not been initialized. Call initialize() before using host metadata.")
+		}
+		return hostInfo
+	},
 }

--- a/apps/vscode/src/sdk/account-service.ts
+++ b/apps/vscode/src/sdk/account-service.ts
@@ -60,7 +60,7 @@ export class ClineAccountService {
 			headers: {
 				Authorization: `Bearer ${clineAccountAuthToken}`,
 				"Content-Type": "application/json",
-				...(await buildBasicClineHeaders()),
+				...buildBasicClineHeaders(),
 				...config.headers,
 			},
 			...getAxiosSettings(),

--- a/apps/vscode/src/sdk/auth-service.test.ts
+++ b/apps/vscode/src/sdk/auth-service.test.ts
@@ -77,7 +77,7 @@ vi.mock("@/shared/net", () => ({
 
 // Mock buildBasicClineHeaders
 vi.mock("@/services/EnvUtils", () => ({
-	buildBasicClineHeaders: async () => ({}),
+	buildBasicClineHeaders: () => ({}),
 }))
 
 // Mock feature flags

--- a/apps/vscode/src/sdk/auth-service.ts
+++ b/apps/vscode/src/sdk/auth-service.ts
@@ -255,7 +255,7 @@ export class AuthService {
 				headers: {
 					Authorization: `Bearer ${bearerToken}`,
 					"Content-Type": "application/json",
-					...(await buildBasicClineHeaders()),
+					...buildBasicClineHeaders(),
 				},
 				...getAxiosSettings(),
 			})
@@ -483,7 +483,7 @@ export class AuthService {
 					apiBaseUrl,
 					// Use WorkOS device auth so the browser confirmation code can be surfaced in the extension.
 					useWorkOSDeviceAuth: true,
-					headers: await buildBasicClineHeaders(),
+					headers: buildBasicClineHeaders(),
 					callbacks: createOAuthClientCallbacks({
 						onOutput: (message) => {
 							resolveAuthMessage(message)
@@ -544,7 +544,7 @@ export class AuthService {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
-				...(await buildBasicClineHeaders()),
+				...buildBasicClineHeaders(),
 			},
 			body: JSON.stringify({
 				code: "test-personal-token",
@@ -755,7 +755,7 @@ export class AuthService {
 				headers: {
 					Accept: "application/json",
 					"Content-Type": "application/json",
-					...(await buildBasicClineHeaders()),
+					...buildBasicClineHeaders(),
 				},
 				body: JSON.stringify({
 					grant_type: "authorization_code",

--- a/apps/vscode/src/sdk/sdk-remote-config-control-plane.test.ts
+++ b/apps/vscode/src/sdk/sdk-remote-config-control-plane.test.ts
@@ -41,7 +41,7 @@ vi.mock("@/core/storage/remote-config/utils", () => ({
 	isRemoteConfigEnabled,
 }))
 
-vi.mock("@/services/EnvUtils", () => ({ buildBasicClineHeaders: async () => ({}) }))
+vi.mock("@/services/EnvUtils", () => ({ buildBasicClineHeaders: () => ({}) }))
 vi.mock("@/shared/net", () => ({ getAxiosSettings: () => ({}) }))
 vi.mock("axios", () => ({ default: { request: vi.fn() } }))
 

--- a/apps/vscode/src/services/EnvUtils.ts
+++ b/apps/vscode/src/services/EnvUtils.ts
@@ -37,22 +37,11 @@ export function buildExternalBasicHeaders(): Record<string, string> {
 
 function getHostRuntimeInfo(): HostRuntimeInfo {
 	const host = HostRegistryInfo.get()
-
-	if (host) {
-		return {
-			platform: host.platform || "unknown",
-			platformVersion: host.hostVersion || "unknown",
-			clientName: host.ide || "unknown",
-			clientVersion: host.extensionVersion || ExtensionRegistryInfo.version,
-		}
-	}
-
-	Logger.log("HostRegistryInfo is not initialized; falling back to unknown host runtime info.")
 	return {
-		platform: "unknown",
-		platformVersion: "unknown",
-		clientName: "unknown",
-		clientVersion: ExtensionRegistryInfo.version,
+		platform: host.platform || "unknown",
+		platformVersion: host.hostVersion || "unknown",
+		clientName: host.ide || "unknown",
+		clientVersion: host.extensionVersion || ExtensionRegistryInfo.version,
 	}
 }
 

--- a/apps/vscode/src/services/EnvUtils.ts
+++ b/apps/vscode/src/services/EnvUtils.ts
@@ -1,6 +1,5 @@
 import { HostProvider } from "@/hosts/host-provider"
-import { ExtensionRegistryInfo } from "@/registry"
-import { EmptyRequest } from "@/shared/proto/cline/common"
+import { ExtensionRegistryInfo, HostRegistryInfo } from "@/registry"
 import { Logger } from "@/shared/services/Logger"
 
 // Canonical header names for extra client/host context
@@ -36,23 +35,24 @@ export function buildExternalBasicHeaders(): Record<string, string> {
 	}
 }
 
-async function getHostRuntimeInfo(): Promise<HostRuntimeInfo> {
-	try {
-		const host = await HostProvider.env.getHostVersion(EmptyRequest.create({}))
+function getHostRuntimeInfo(): HostRuntimeInfo {
+	const host = HostRegistryInfo.get()
+
+	if (host) {
 		return {
 			platform: host.platform || "unknown",
-			platformVersion: host.version || "unknown",
-			clientName: host.clineType || "unknown",
-			clientVersion: host.clineVersion || ExtensionRegistryInfo.version,
+			platformVersion: host.hostVersion || "unknown",
+			clientName: host.ide || "unknown",
+			clientVersion: host.extensionVersion || ExtensionRegistryInfo.version,
 		}
-	} catch (error) {
-		Logger.log("Failed to get IDE/platform info via HostBridge EnvService.getHostVersion", error)
-		return {
-			platform: "unknown",
-			platformVersion: "unknown",
-			clientName: "unknown",
-			clientVersion: ExtensionRegistryInfo.version,
-		}
+	}
+
+	Logger.log("HostRegistryInfo is not initialized; falling back to unknown host runtime info.")
+	return {
+		platform: "unknown",
+		platformVersion: "unknown",
+		clientName: "unknown",
+		clientVersion: ExtensionRegistryInfo.version,
 	}
 }
 
@@ -67,7 +67,7 @@ async function isMultiRootWorkspace(): Promise<boolean> {
 }
 
 export async function buildClientRuntimeContext(): Promise<ClientRuntimeContext> {
-	const host = await getHostRuntimeInfo()
+	const host = getHostRuntimeInfo()
 	return {
 		...host,
 		userAgent: buildExternalBasicHeaders()["User-Agent"],
@@ -76,8 +76,8 @@ export async function buildClientRuntimeContext(): Promise<ClientRuntimeContext>
 	}
 }
 
-export async function buildBasicClineHeaders(): Promise<Record<string, string>> {
-	const host = await getHostRuntimeInfo()
+export function buildBasicClineHeaders(): Record<string, string> {
+	const host = getHostRuntimeInfo()
 	const headers: Record<string, string> = buildExternalBasicHeaders()
 	headers[ClineHeaders.PLATFORM] = host.platform
 	headers[ClineHeaders.PLATFORM_VERSION] = host.platformVersion

--- a/apps/vscode/src/services/account/ClineAccountService.ts
+++ b/apps/vscode/src/services/account/ClineAccountService.ts
@@ -69,7 +69,7 @@ export class ClineAccountService {
 			headers: {
 				Authorization: `Bearer ${clineAccountAuthToken}`,
 				"Content-Type": "application/json",
-				...(await buildBasicClineHeaders()),
+				...buildBasicClineHeaders(),
 				...config.headers,
 			},
 			...getAxiosSettings(),

--- a/apps/vscode/src/services/banner/BannerService.ts
+++ b/apps/vscode/src/services/banner/BannerService.ts
@@ -257,7 +257,7 @@ export class BannerService {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					...(await buildBasicClineHeaders()),
+					...buildBasicClineHeaders(),
 				},
 				body: JSON.stringify({
 					banner_id: bannerId,
@@ -299,7 +299,7 @@ export class BannerService {
 			const url = this.buildFetchUrl()
 			const headers: Record<string, string> = {
 				"Content-Type": "application/json",
-				...(await buildBasicClineHeaders()),
+				...buildBasicClineHeaders(),
 			}
 			const authToken = await AuthService.getInstance().getAuthToken()
 			if (authToken) {

--- a/apps/vscode/src/services/banner/BannerService.ts
+++ b/apps/vscode/src/services/banner/BannerService.ts
@@ -71,9 +71,6 @@ export class BannerService {
 			return BannerService.instance
 		}
 		const hostInfo = HostRegistryInfo.get()
-		if (!hostInfo) {
-			throw new Error("[BannerService] Ensure HostRegistryInfo is initialized before BannerService.")
-		}
 		BannerService.instance = new BannerService(controller, hostInfo)
 		return BannerService.instance
 	}

--- a/sdk/packages/core/src/services/llms/handler-factory.test.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.test.ts
@@ -599,6 +599,9 @@ describe("createAgentModelFromConfig", () => {
 
 	it("uses a registered handler (adapter) instead of the gateway, building it lazily", async () => {
 		const { createAgentModelFromConfig } = await import("./handler-factory");
+		const extensionContext = {
+			client: { name: "cline-vscode", version: "1.2.3" },
+		} satisfies NonNullable<AgentConfig["extensionContext"]>;
 
 		// Pretend a host handler is registered for this provider.
 		gatewayMock.hasRegisteredHandler.mockReturnValue(true);
@@ -620,6 +623,7 @@ describe("createAgentModelFromConfig", () => {
 				apiKey: "",
 				systemPrompt: "",
 				tools: [],
+				extensionContext,
 			},
 			undefined,
 		);
@@ -638,5 +642,8 @@ describe("createAgentModelFromConfig", () => {
 			// drain
 		}
 		expect(gatewayMock.createHandlerAsync).toHaveBeenCalledTimes(1);
+		expect(gatewayMock.createHandlerAsync).toHaveBeenCalledWith(
+			expect.objectContaining({ extensionContext }),
+		);
 	});
 });

--- a/sdk/packages/core/src/services/llms/handler-factory.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.ts
@@ -10,6 +10,7 @@ import {
 	type AgentModel,
 	type BasicLogger,
 	buildClineRequestHeaders,
+	type ExtensionContext,
 	type GatewayModelDefinition,
 	type ITelemetryService,
 	isClineProvider,
@@ -114,14 +115,13 @@ function mergeHeaders(
 function resolveHeadersFromConfig(
 	config: AgentConfig,
 	baseProviderConfig: ProviderConfig | undefined,
+	extensionContext: ExtensionContext | undefined,
 ): Record<string, string> | undefined {
 	const providerId = normalizeProviderId(config.providerId);
 	if (!isClineProvider(providerId)) {
 		return config.headers ?? baseProviderConfig?.headers;
 	}
 
-	const extensionContext =
-		config.extensionContext ?? baseProviderConfig?.extensionContext;
 	const headers = mergeHeaders(baseProviderConfig?.headers, config.headers);
 
 	return buildClineRequestHeaders({
@@ -183,6 +183,13 @@ function toGatewayConfiguredModel(
 	};
 }
 
+function resolveExtensionContext(
+	config: AgentConfig,
+	baseProviderConfig: ProviderConfig | undefined,
+): ExtensionContext | undefined {
+	return config.extensionContext ?? baseProviderConfig?.extensionContext;
+}
+
 export function createAgentModelFromConfig(
 	config: AgentConfig,
 	logger: BasicLogger | undefined,
@@ -191,21 +198,24 @@ export function createAgentModelFromConfig(
 	const pc = config.providerConfig as ProviderConfig | undefined;
 	const baseProviderConfig =
 		pc?.providerId === config.providerId ? pc : undefined;
+	const extensionContext = resolveExtensionContext(config, baseProviderConfig);
 	const normalizedProviderConfig: ProviderConfig = {
 		...(baseProviderConfig ?? {}),
 		providerId: config.providerId,
 		modelId: config.modelId,
 		apiKey: config.apiKey ?? baseProviderConfig?.apiKey,
 		baseUrl: config.baseUrl ?? baseProviderConfig?.baseUrl,
-		headers: resolveHeadersFromConfig(config, baseProviderConfig),
+		headers: resolveHeadersFromConfig(
+			config,
+			baseProviderConfig,
+			extensionContext,
+		),
 		knownModels: resolveKnownModelsFromConfig(config),
 		maxOutputTokens: config.maxTokensPerTurn,
 		reasoningEffort: config.reasoningEffort,
 		thinkingBudgetTokens: config.thinkingBudgetTokens,
 		thinking: config.thinking,
 		logger,
-		extensionContext:
-			config.extensionContext ?? baseProviderConfig?.extensionContext,
 	};
 
 	// Host-registered custom handlers (e.g. VS Code LM, which needs the host's
@@ -220,7 +230,10 @@ export function createAgentModelFromConfig(
 		)
 	) {
 		return createAgentModelFromApiHandler(() =>
-			createHandlerAsync(normalizedProviderConfig),
+			createHandlerAsync({
+				...normalizedProviderConfig,
+				...(extensionContext ? { extensionContext } : {}),
+			}),
 		);
 	}
 
@@ -246,8 +259,7 @@ export function createAgentModelFromConfig(
 			},
 		],
 		logger,
-		telemetry:
-			telemetry ?? config.telemetry ?? config.extensionContext?.telemetry,
+		telemetry: telemetry ?? config.telemetry ?? extensionContext?.telemetry,
 	}).createAgentModel(
 		{
 			providerId: normalizedProviderConfig.providerId,

--- a/sdk/packages/core/src/services/local-runtime-bootstrap.test.ts
+++ b/sdk/packages/core/src/services/local-runtime-bootstrap.test.ts
@@ -439,9 +439,8 @@ describe("prepareLocalRuntimeBootstrap", () => {
 		expect(bootstrap.providerConfig.headers).toEqual({
 			"x-stored": "stored",
 		});
-		expect(
-			bootstrap.providerConfig.extensionContext?.requestMetadata,
-		).toMatchObject({
+		expect(bootstrap.providerConfig.extensionContext).toBeUndefined();
+		expect(bootstrap.config.extensionContext?.requestMetadata).toMatchObject({
 			clientType: "VSCode Extension",
 			platform: "Visual Studio Code",
 		});

--- a/sdk/packages/core/src/services/local-runtime-bootstrap.ts
+++ b/sdk/packages/core/src/services/local-runtime-bootstrap.ts
@@ -270,9 +270,6 @@ function buildProviderConfig(
 	if (config.knownModels) {
 		providerConfig.knownModels = config.knownModels;
 	}
-	if (config.extensionContext) {
-		providerConfig.extensionContext = config.extensionContext;
-	}
 	// Thread a host-provided custom fetch through to the AI gateway providers.
 	// Precedence: explicit per-session config > stored provider settings > host default.
 	const sessionFetch = (config as { fetch?: typeof fetch }).fetch;

--- a/sdk/packages/shared/src/agents/types.ts
+++ b/sdk/packages/shared/src/agents/types.ts
@@ -815,7 +815,8 @@ export interface AgentConfig {
 	telemetry?: ITelemetryService;
 	/**
 	 * Ambient runtime context: user identity, client surface, workspace, logger,
-	 * and telemetry. Threaded through to ProviderConfig so handlers can access it.
+	 * telemetry, and host request metadata. Used by runtime extension setup and
+	 * forwarded to registered provider handlers that need host-local context.
 	 */
 	extensionContext?: ExtensionContext;
 


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->


This PR clean up two sources of duplicated metadata handling.

First, [EnvUtils.ts](/Users/beatrix/dev/cline/apps/vscode/src/services/EnvUtils.ts:38) now reuses `HostRegistryInfo.get()` for host/client metadata instead of calling `HostProvider.env.getHostVersion()` again in both `buildClientRuntimeContext()` and `buildBasicClineHeaders()`. That fixes the duplicate host-runtime lookup and makes `buildBasicClineHeaders()` synchronous. Call sites now just spread `...buildBasicClineHeaders()` directly.

Second, the SDK header path is clearer. [handler-factory.ts](/Users/beatrix/dev/cline/sdk/packages/core/src/services/llms/handler-factory.ts:115) now resolves `extensionContext` once and passes it into `resolveHeadersFromConfig()`, where Cline request headers are built via the existing `buildClineRequestHeaders()` helper. We no longer copy `extensionContext` into `ProviderConfig` during local bootstrap just to recover it later.

The split is now:
- `AgentConfig.extensionContext` remains the runtime context for plugins/hooks/logger/telemetry and request metadata.
- `resolveHeadersFromConfig()` owns Cline header construction.
- `ProviderConfig.extensionContext` is only forwarded for registered custom handlers that actually receive only provider config.

This avoids treating ambient runtime context as provider settings, removes the duplicate bootstrap copy, and reuses existing shared header/registry code instead of adding another metadata adapter path.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

All tests updated

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
