### PR TITLE
fix(core): use no-emit TypeScript config for checks

### DIFF
--- a/sdk/packages/core/src/auth/cline.test.ts
+++ b/sdk/packages/core/src/auth/cline.test.ts
@@ -1,4 +1,3 @@
-import net from "node:net";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ClineOAuthCredentials } from "./cline";
 import { getValidClineCredentials, loginClineOAuth } from "./cline";
@@ -7,21 +6,6 @@ const PROVIDER_OPTIONS = {
 	apiBaseUrl: "https://auth.example.com",
 };
 const ORIGINAL_FETCH = globalThis.fetch;
-const socketBindingSupported = await (async () => {
-	try {
-		const srv = net.createServer();
-		await new Promise<void>((resolve, reject) => {
-			srv.listen(0, "127.0.0.1", () => resolve());
-			srv.once("error", reject);
-		});
-		await new Promise<void>((resolve, reject) =>
-			srv.close((err) => (err ? reject(err) : resolve())),
-		);
-		return true;
-	} catch {
-		return false;
-	}
-})();
 
 function createCredentials(
 	overrides: Partial<ClineOAuthCredentials> = {},

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
@@ -1,4 +1,3 @@
-import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -150,25 +149,6 @@ function normalizeStartInput(
 		...input,
 		...split,
 	};
-}
-
-function _createGitRepo(cwd: string): void {
-	execFileSync("git", ["-C", cwd, "init"], { stdio: "pipe" });
-	execFileSync("git", ["-C", cwd, "config", "user.name", "Codex Test"], {
-		stdio: "pipe",
-	});
-	execFileSync(
-		"git",
-		["-C", cwd, "config", "user.email", "codex@example.com"],
-		{
-			stdio: "pipe",
-		},
-	);
-	writeFileSync(join(cwd, "note.txt"), "base\n", "utf8");
-	execFileSync("git", ["-C", cwd, "add", "note.txt"], { stdio: "pipe" });
-	execFileSync("git", ["-C", cwd, "commit", "-m", "initial"], {
-		stdio: "pipe",
-	});
 }
 
 describe("LocalRuntimeHost", () => {

--- a/sdk/packages/core/tsconfig.dev.json
+++ b/sdk/packages/core/tsconfig.dev.json
@@ -1,3 +1,7 @@
 {
-	"extends": "./tsconfig.json"
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noUnusedLocals": false,
+		"noUnusedParameters": false
+	}
 }

--- a/sdk/packages/core/tsconfig.dev.json
+++ b/sdk/packages/core/tsconfig.dev.json
@@ -1,8 +1,3 @@
 {
-	"extends": "./tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "..",
-		"noUnusedLocals": false,
-		"noUnusedParameters": false
-	}
+	"extends": "./tsconfig.json"
 }

--- a/sdk/packages/core/tsconfig.json
+++ b/sdk/packages/core/tsconfig.json
@@ -3,8 +3,6 @@
 	"compilerOptions": {
 		"rootDir": "..",
 		"noEmit": true,
-		"noUnusedLocals": false,
-		"noUnusedParameters": false,
 		"paths": {
 			"@cline/agents": ["../agents/src/index.ts"],
 			"@cline/agents/*": ["../agents/src/*", "../agents/src/*/index.ts"],

--- a/sdk/packages/core/tsconfig.json
+++ b/sdk/packages/core/tsconfig.json
@@ -1,10 +1,10 @@
 {
 	"extends": "../tsconfig.base.json",
 	"compilerOptions": {
-		"outDir": "./dist",
-		"rootDir": "./src",
-		"sourceMap": false,
-		"emitDeclarationOnly": true,
+		"rootDir": "..",
+		"noEmit": true,
+		"noUnusedLocals": false,
+		"noUnusedParameters": false,
 		"paths": {
 			"@cline/agents": ["../agents/src/index.ts"],
 			"@cline/agents/*": ["../agents/src/*", "../agents/src/*/index.ts"],


### PR DESCRIPTION


<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Update the core package TypeScript config to run checks without emitting files, allowing broader workspace sources via the package parent rootDir. Simplify the dev config so it only extends the main package config and avoids duplicated compiler overrides.

Fix vs code error "'rootDir' is expected to contain all source files.\n  The file is in the program because:\n    Imported via \"@cline/agents\" from file" from sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
