### PR TITLE
Fix compaction budget double reserve ENG-2249

### DIFF
--- a/apps/cli/src/runtime/interactive/compaction.test.ts
+++ b/apps/cli/src/runtime/interactive/compaction.test.ts
@@ -138,7 +138,7 @@ describe("compactInteractiveMessages", () => {
 		}));
 		const config = createConfig();
 		const compact = vi.fn((context: CoreCompactionContext) => {
-			expect(context.maxInputTokens).toBe(400_000);
+			expect(context.maxInputTokens).toBe(383_616);
 			return { messages: [messages[0]] };
 		});
 		config.knownModels = {

--- a/sdk/packages/core/src/extensions/context/compaction-shared.ts
+++ b/sdk/packages/core/src/extensions/context/compaction-shared.ts
@@ -16,7 +16,12 @@ import type { ProviderConfig } from "../../types/provider-settings";
 export const DEFAULT_MAX_INPUT_TOKENS = 128_000;
 export const DEFAULT_THRESHOLD_RATIO = 0.9;
 export const DEFAULT_TARGET_RATIO = 0.7;
-export const DEFAULT_RESERVE_TOKENS = 16_384;
+/**
+ * Estimated output reserve for shared-context models that do not declare
+ * `maxTokens`. Only consulted in that fallback; explicit input ceilings
+ * (config or true input limits) never reserve output.
+ */
+export const FALLBACK_OUTPUT_RESERVE_TOKENS = 16_384;
 export const DEFAULT_PRESERVE_RECENT_TOKENS = 20_000;
 export const DEFAULT_SUMMARY_MAX_OUTPUT_TOKENS = 1_024;
 export const TOOL_RESULT_CHAR_LIMIT = 2_000;

--- a/sdk/packages/core/src/extensions/context/compaction.test.ts
+++ b/sdk/packages/core/src/extensions/context/compaction.test.ts
@@ -1105,7 +1105,7 @@ describe("createContextCompactionPrepareTurn", () => {
 		}
 	});
 
-	it("uses the default reserve when no trigger is configured", async () => {
+	it("uses the true input budget when no context window is available", async () => {
 		const compact = vi.fn((_context: CoreCompactionContext) => ({
 			messages: [{ role: "user" as const, content: "Compacted by reserve" }],
 		}));
@@ -1146,7 +1146,7 @@ describe("createContextCompactionPrepareTurn", () => {
 		expect(createHandlerMock).not.toHaveBeenCalled();
 		expect(compact).toHaveBeenCalledTimes(1);
 		const context = compact.mock.calls[0]?.[0];
-		expect(context?.triggerTokens).toBe(0);
+		expect(context?.triggerTokens).toBe(180);
 		expect(result?.messages).toEqual([
 			{ role: "user", content: "Compacted by reserve" },
 		]);
@@ -1367,7 +1367,7 @@ describe("createContextCompactionPrepareTurn", () => {
 		expect(context?.targetTokens).toBe(39);
 	});
 
-	it("derives input budget by reserving model max output tokens from context window", async () => {
+	it("reserves output once for a shared context window", async () => {
 		const compact = vi.fn((_context: CoreCompactionContext) => ({
 			messages: [
 				{ role: "user" as const, content: "Compacted by derived input budget" },
@@ -1413,12 +1413,197 @@ describe("createContextCompactionPrepareTurn", () => {
 
 		expect(compact).toHaveBeenCalledTimes(1);
 		const context = compact.mock.calls[0]?.[0];
-		expect(context?.maxInputTokens).toBe(272_000);
+		expect(context?.maxInputTokens).toBe(400_000);
 		expect(context?.triggerTokens).toBe(244_800);
-		expect(context?.thresholdRatio).toBe(0.9);
+		expect(context?.thresholdRatio).toBe(244_800 / 400_000);
 		expect(result?.messages).toEqual([
 			{ role: "user", content: "Compacted by derived input budget" },
 		]);
+	});
+
+	it("does not double-reserve output for mirrored Qwen context metadata", async () => {
+		const compact = vi.fn((_context: CoreCompactionContext) => ({
+			messages: [{ role: "user" as const, content: "Compacted Qwen" }],
+		}));
+		const prepareTurn = createContextCompactionPrepareTurn({
+			providerId: "openrouter",
+			modelId: "qwen/qwen3-32b",
+			providerConfig: {
+				providerId: "openrouter",
+				modelId: "qwen/qwen3-32b",
+			} as LlmsProviders.ProviderConfig,
+			compaction: { enabled: true, compact },
+			logger: undefined,
+		});
+		const messages: MessageWithMetadata[] = [
+			{ role: "user", content: "large prompt ".repeat(6_000) },
+		];
+
+		await prepareTurn?.({
+			agentId: "agent-1",
+			conversationId: "conv-1",
+			parentAgentId: null,
+			iteration: 1,
+			abortSignal: new AbortController().signal,
+			systemPrompt: "You are helpful.",
+			tools: [],
+			messages,
+			apiMessages: messages,
+			model: {
+				id: "qwen/qwen3-32b",
+				provider: "openrouter",
+				info: {
+					id: "qwen/qwen3-32b",
+					contextWindow: 40_960,
+					maxInputTokens: 40_960,
+					maxTokens: 16_384,
+				},
+			},
+		});
+
+		expect(compact).toHaveBeenCalledTimes(1);
+		const context = compact.mock.calls[0]?.[0];
+		expect(context?.maxInputTokens).toBe(40_960);
+		expect(context?.triggerTokens).toBe(22_118);
+		expect(context?.thresholdRatio).toBe(22_118 / 40_960);
+	});
+
+	it("caps shared-context output reserve at half the context window", async () => {
+		const compact = vi.fn((_context: CoreCompactionContext) => ({
+			messages: [{ role: "user" as const, content: "Compacted capped output" }],
+		}));
+		const prepareTurn = createContextCompactionPrepareTurn({
+			providerId: "kilo",
+			modelId: "qwen/qwen3-32b",
+			providerConfig: {
+				providerId: "kilo",
+				modelId: "qwen/qwen3-32b",
+			} as LlmsProviders.ProviderConfig,
+			compaction: { enabled: true, compact },
+			logger: undefined,
+		});
+		const messages: MessageWithMetadata[] = [
+			{ role: "user", content: "large prompt ".repeat(5_000) },
+		];
+
+		await prepareTurn?.({
+			agentId: "agent-1",
+			conversationId: "conv-1",
+			parentAgentId: null,
+			iteration: 1,
+			abortSignal: new AbortController().signal,
+			systemPrompt: "You are helpful.",
+			tools: [],
+			messages,
+			apiMessages: messages,
+			model: {
+				id: "qwen/qwen3-32b",
+				provider: "kilo",
+				info: {
+					id: "qwen/qwen3-32b",
+					contextWindow: 40_960,
+					maxInputTokens: 40_960,
+					maxTokens: 40_960,
+				},
+			},
+		});
+
+		expect(compact).toHaveBeenCalledTimes(1);
+		const context = compact.mock.calls[0]?.[0];
+		expect(context?.maxInputTokens).toBe(40_960);
+		expect(context?.triggerTokens).toBe(18_432);
+	});
+
+	it("applies explicit threshold ratio to the usable budget", async () => {
+		const compact = vi.fn((_context: CoreCompactionContext) => ({
+			messages: [{ role: "user" as const, content: "Compacted threshold" }],
+		}));
+		const prepareTurn = createContextCompactionPrepareTurn({
+			providerId: "openrouter",
+			modelId: "qwen/qwen3-32b",
+			providerConfig: {
+				providerId: "openrouter",
+				modelId: "qwen/qwen3-32b",
+			} as LlmsProviders.ProviderConfig,
+			compaction: { enabled: true, thresholdRatio: 0.8, compact },
+			logger: undefined,
+		});
+		const messages: MessageWithMetadata[] = [
+			{ role: "user", content: "large prompt ".repeat(6_000) },
+		];
+
+		await prepareTurn?.({
+			agentId: "agent-1",
+			conversationId: "conv-1",
+			parentAgentId: null,
+			iteration: 1,
+			abortSignal: new AbortController().signal,
+			systemPrompt: "You are helpful.",
+			tools: [],
+			messages,
+			apiMessages: messages,
+			model: {
+				id: "qwen/qwen3-32b",
+				provider: "openrouter",
+				info: {
+					id: "qwen/qwen3-32b",
+					contextWindow: 40_960,
+					maxInputTokens: 40_960,
+					maxTokens: 16_384,
+				},
+			},
+		});
+
+		expect(compact).toHaveBeenCalledTimes(1);
+		const context = compact.mock.calls[0]?.[0];
+		expect(context?.triggerTokens).toBe(19_660);
+		expect(context?.thresholdRatio).toBe(0.8);
+	});
+
+	it("applies explicit reserve tokens to the usable budget", async () => {
+		const compact = vi.fn((_context: CoreCompactionContext) => ({
+			messages: [{ role: "user" as const, content: "Compacted reserve" }],
+		}));
+		const prepareTurn = createContextCompactionPrepareTurn({
+			providerId: "openrouter",
+			modelId: "qwen/qwen3-32b",
+			providerConfig: {
+				providerId: "openrouter",
+				modelId: "qwen/qwen3-32b",
+			} as LlmsProviders.ProviderConfig,
+			compaction: { enabled: true, reserveTokens: 4_096, compact },
+			logger: undefined,
+		});
+		const messages: MessageWithMetadata[] = [
+			{ role: "user", content: "large prompt ".repeat(6_000) },
+		];
+
+		await prepareTurn?.({
+			agentId: "agent-1",
+			conversationId: "conv-1",
+			parentAgentId: null,
+			iteration: 1,
+			abortSignal: new AbortController().signal,
+			systemPrompt: "You are helpful.",
+			tools: [],
+			messages,
+			apiMessages: messages,
+			model: {
+				id: "qwen/qwen3-32b",
+				provider: "openrouter",
+				info: {
+					id: "qwen/qwen3-32b",
+					contextWindow: 40_960,
+					maxInputTokens: 40_960,
+					maxTokens: 16_384,
+				},
+			},
+		});
+
+		expect(compact).toHaveBeenCalledTimes(1);
+		const context = compact.mock.calls[0]?.[0];
+		expect(context?.triggerTokens).toBe(20_480);
+		expect(context?.thresholdRatio).toBe(0.5);
 	});
 
 	it("uses the lower split input budget when it is below context-derived input budget", async () => {

--- a/sdk/packages/core/src/extensions/context/compaction.test.ts
+++ b/sdk/packages/core/src/extensions/context/compaction.test.ts
@@ -90,7 +90,6 @@ function runForcedBasicCompaction(
 				info: { id: "mock-model", maxInputTokens: targetTokens },
 			},
 			maxInputTokens: targetTokens,
-			usableBudgetTokens: targetTokens,
 			triggerTokens: targetTokens,
 			thresholdRatio: 1,
 			utilizationRatio: 2,
@@ -266,7 +265,6 @@ describe("createContextCompactionPrepareTurn", () => {
 					info: { id: "mock-model", maxInputTokens: 100_000 },
 				},
 				maxInputTokens: 100_000,
-				usableBudgetTokens: 100_000,
 				triggerTokens: 100_000,
 				thresholdRatio: 1,
 				utilizationRatio: 0.1,
@@ -490,7 +488,6 @@ describe("createContextCompactionPrepareTurn", () => {
 					info: { id: "mock-model", maxInputTokens: 1_000 },
 				},
 				maxInputTokens: 1_000,
-				usableBudgetTokens: 1_000,
 				triggerTokens: 900,
 				targetTokens: 100,
 				thresholdRatio: 0.9,
@@ -1416,9 +1413,9 @@ describe("createContextCompactionPrepareTurn", () => {
 
 		expect(compact).toHaveBeenCalledTimes(1);
 		const context = compact.mock.calls[0]?.[0];
-		expect(context?.maxInputTokens).toBe(400_000);
+		expect(context?.maxInputTokens).toBe(272_000);
 		expect(context?.triggerTokens).toBe(244_800);
-		expect(context?.thresholdRatio).toBe(244_800 / 400_000);
+		expect(context?.thresholdRatio).toBe(0.9);
 		expect(result?.messages).toEqual([
 			{ role: "user", content: "Compacted by derived input budget" },
 		]);
@@ -1466,10 +1463,9 @@ describe("createContextCompactionPrepareTurn", () => {
 
 		expect(compact).toHaveBeenCalledTimes(1);
 		const context = compact.mock.calls[0]?.[0];
-		expect(context?.maxInputTokens).toBe(40_960);
-		expect(context?.usableBudgetTokens).toBe(24_576);
+		expect(context?.maxInputTokens).toBe(24_576);
 		expect(context?.triggerTokens).toBe(22_118);
-		expect(context?.thresholdRatio).toBe(22_118 / 40_960);
+		expect(context?.thresholdRatio).toBe(22_118 / 24_576);
 	});
 
 	it("caps shared-context output reserve at half the context window", async () => {
@@ -1514,7 +1510,7 @@ describe("createContextCompactionPrepareTurn", () => {
 
 		expect(compact).toHaveBeenCalledTimes(1);
 		const context = compact.mock.calls[0]?.[0];
-		expect(context?.maxInputTokens).toBe(40_960);
+		expect(context?.maxInputTokens).toBe(20_480);
 		expect(context?.triggerTokens).toBe(18_432);
 	});
 
@@ -1561,7 +1557,7 @@ describe("createContextCompactionPrepareTurn", () => {
 		expect(compact).toHaveBeenCalledTimes(1);
 		const context = compact.mock.calls[0]?.[0];
 		expect(context?.triggerTokens).toBe(19_660);
-		expect(context?.thresholdRatio).toBe(19_660 / 40_960);
+		expect(context?.thresholdRatio).toBe(19_660 / 24_576);
 	});
 
 	it("applies explicit reserve tokens to the usable budget", async () => {
@@ -1607,7 +1603,7 @@ describe("createContextCompactionPrepareTurn", () => {
 		expect(compact).toHaveBeenCalledTimes(1);
 		const context = compact.mock.calls[0]?.[0];
 		expect(context?.triggerTokens).toBe(20_480);
-		expect(context?.thresholdRatio).toBe(0.5);
+		expect(context?.thresholdRatio).toBe(20_480 / 24_576);
 	});
 
 	it("uses the lower split input budget when it is below context-derived input budget", async () => {
@@ -2013,7 +2009,6 @@ describe("createContextCompactionPrepareTurn", () => {
 					info: { id: "mock-model", maxInputTokens: 100 },
 				},
 				maxInputTokens: 100,
-				usableBudgetTokens: 100,
 				triggerTokens: 100,
 				thresholdRatio: 1,
 				utilizationRatio: 0.1,

--- a/sdk/packages/core/src/extensions/context/compaction.test.ts
+++ b/sdk/packages/core/src/extensions/context/compaction.test.ts
@@ -90,6 +90,7 @@ function runForcedBasicCompaction(
 				info: { id: "mock-model", maxInputTokens: targetTokens },
 			},
 			maxInputTokens: targetTokens,
+			usableBudgetTokens: targetTokens,
 			triggerTokens: targetTokens,
 			thresholdRatio: 1,
 			utilizationRatio: 2,
@@ -265,6 +266,7 @@ describe("createContextCompactionPrepareTurn", () => {
 					info: { id: "mock-model", maxInputTokens: 100_000 },
 				},
 				maxInputTokens: 100_000,
+				usableBudgetTokens: 100_000,
 				triggerTokens: 100_000,
 				thresholdRatio: 1,
 				utilizationRatio: 0.1,
@@ -488,6 +490,7 @@ describe("createContextCompactionPrepareTurn", () => {
 					info: { id: "mock-model", maxInputTokens: 1_000 },
 				},
 				maxInputTokens: 1_000,
+				usableBudgetTokens: 1_000,
 				triggerTokens: 900,
 				targetTokens: 100,
 				thresholdRatio: 0.9,
@@ -1464,6 +1467,7 @@ describe("createContextCompactionPrepareTurn", () => {
 		expect(compact).toHaveBeenCalledTimes(1);
 		const context = compact.mock.calls[0]?.[0];
 		expect(context?.maxInputTokens).toBe(40_960);
+		expect(context?.usableBudgetTokens).toBe(24_576);
 		expect(context?.triggerTokens).toBe(22_118);
 		expect(context?.thresholdRatio).toBe(22_118 / 40_960);
 	});
@@ -1557,7 +1561,7 @@ describe("createContextCompactionPrepareTurn", () => {
 		expect(compact).toHaveBeenCalledTimes(1);
 		const context = compact.mock.calls[0]?.[0];
 		expect(context?.triggerTokens).toBe(19_660);
-		expect(context?.thresholdRatio).toBe(0.8);
+		expect(context?.thresholdRatio).toBe(19_660 / 40_960);
 	});
 
 	it("applies explicit reserve tokens to the usable budget", async () => {
@@ -2009,6 +2013,7 @@ describe("createContextCompactionPrepareTurn", () => {
 					info: { id: "mock-model", maxInputTokens: 100 },
 				},
 				maxInputTokens: 100,
+				usableBudgetTokens: 100,
 				triggerTokens: 100,
 				thresholdRatio: 1,
 				utilizationRatio: 0.1,

--- a/sdk/packages/core/src/extensions/context/compaction.ts
+++ b/sdk/packages/core/src/extensions/context/compaction.ts
@@ -159,13 +159,8 @@ function resolveCompactionBudget(input: {
 		usableBudgetTokens,
 		outputReserveTokens,
 		triggerTokens,
-		// Preserve explicit thresholdRatio as configured; usableThresholdRatio records the effective trigger point.
 		thresholdRatio:
-			typeof input.config.thresholdRatio === "number"
-				? input.config.thresholdRatio
-				: ceilingTokens > 0
-					? triggerTokens / ceilingTokens
-					: 0,
+			ceilingTokens > 0 ? triggerTokens / ceilingTokens : 0,
 		usableThresholdRatio:
 			usableBudgetTokens > 0 ? triggerTokens / usableBudgetTokens : 0,
 		ceilingSource,
@@ -424,6 +419,7 @@ export function createContextCompactionPrepareTurn(
 			messages: context.messages,
 			model: context.model,
 			maxInputTokens,
+			usableBudgetTokens: compactionBudget.usableBudgetTokens,
 			triggerTokens: targetState.triggerTokens,
 			targetTokens,
 			thresholdRatio: targetState.thresholdRatio,

--- a/sdk/packages/core/src/extensions/context/compaction.ts
+++ b/sdk/packages/core/src/extensions/context/compaction.ts
@@ -78,7 +78,6 @@ export interface ContextCompactionPrepareTurnOptions {
 	manualTargetRatio?: number;
 }
 
-const MIN_CONTEXT_DERIVED_INPUT_RATIO = 0.5;
 const LONG_CONVERSATION_TARGET_RATIO = 0.5;
 
 function safeJsonSize(value: unknown): number {
@@ -93,35 +92,88 @@ function isPositiveFiniteNumber(value: unknown): value is number {
 	return typeof value === "number" && Number.isFinite(value) && value > 0;
 }
 
-function resolveMaxInputTokens(input: {
-	configMaxInputTokens?: number;
+type CompactionBudgetSource = "config" | "true_input" | "context" | "default";
+
+interface CompactionBudget {
+	ceilingTokens: number;
+	usableBudgetTokens: number;
+	outputReserveTokens: number;
+	triggerTokens: number;
+	thresholdRatio: number;
+	usableThresholdRatio: number;
+	ceilingSource: CompactionBudgetSource;
+	reserveCapped: boolean;
+}
+
+function resolveCompactionBudget(input: {
+	config: CoreCompactionConfig;
 	modelMaxInputTokens?: number;
 	contextWindow?: number;
 	modelMaxTokens?: number;
-}): number {
-	const candidates: number[] = [];
-	if (isPositiveFiniteNumber(input.configMaxInputTokens)) {
-		candidates.push(input.configMaxInputTokens);
+}): CompactionBudget {
+	let ceilingTokens = DEFAULT_MAX_INPUT_TOKENS;
+	let ceilingSource: CompactionBudgetSource = "default";
+
+	if (isPositiveFiniteNumber(input.config.maxInputTokens)) {
+		ceilingTokens = input.config.maxInputTokens;
+		ceilingSource = "config";
+	} else if (
+		isPositiveFiniteNumber(input.modelMaxInputTokens) &&
+		(!isPositiveFiniteNumber(input.contextWindow) ||
+			input.modelMaxInputTokens < input.contextWindow)
+	) {
+		ceilingTokens = input.modelMaxInputTokens;
+		ceilingSource = "true_input";
+	} else if (isPositiveFiniteNumber(input.contextWindow)) {
+		ceilingTokens = input.contextWindow;
+		ceilingSource = "context";
 	}
-	if (isPositiveFiniteNumber(input.modelMaxInputTokens)) {
-		candidates.push(input.modelMaxInputTokens);
+
+	const maxReserveTokens = Math.floor(ceilingTokens / 2);
+	const outputReserveTokens =
+		ceilingSource === "config" ||
+		ceilingSource === "true_input" ||
+		ceilingSource === "default"
+			? 0
+			: isPositiveFiniteNumber(input.modelMaxTokens)
+				? Math.min(input.modelMaxTokens, maxReserveTokens)
+				: Math.min(DEFAULT_RESERVE_TOKENS, Math.floor(ceilingTokens * 0.25));
+	const usableBudgetTokens = Math.max(1, ceilingTokens - outputReserveTokens);
+
+	let triggerTokens: number;
+	if (typeof input.config.reserveTokens === "number") {
+		triggerTokens = Math.max(
+			0,
+			usableBudgetTokens - Math.max(0, input.config.reserveTokens),
+		);
+	} else if (typeof input.config.thresholdRatio === "number") {
+		triggerTokens = Math.floor(
+			usableBudgetTokens * input.config.thresholdRatio,
+		);
+	} else {
+		triggerTokens = Math.floor(usableBudgetTokens * DEFAULT_THRESHOLD_RATIO);
 	}
-	if (isPositiveFiniteNumber(input.contextWindow)) {
-		candidates.push(input.contextWindow);
-		const derivedInputTokens = isPositiveFiniteNumber(input.modelMaxTokens)
-			? input.contextWindow - input.modelMaxTokens
-			: undefined;
-		if (
-			isPositiveFiniteNumber(derivedInputTokens) &&
-			derivedInputTokens >=
-				input.contextWindow * MIN_CONTEXT_DERIVED_INPUT_RATIO
-		) {
-			candidates.push(derivedInputTokens);
-		}
-	}
-	return candidates.length > 0
-		? Math.min(...candidates)
-		: DEFAULT_MAX_INPUT_TOKENS;
+
+	return {
+		ceilingTokens,
+		usableBudgetTokens,
+		outputReserveTokens,
+		triggerTokens,
+		// Preserve explicit thresholdRatio as configured; usableThresholdRatio records the effective trigger point.
+		thresholdRatio:
+			typeof input.config.thresholdRatio === "number"
+				? input.config.thresholdRatio
+				: ceilingTokens > 0
+					? triggerTokens / ceilingTokens
+					: 0,
+		usableThresholdRatio:
+			usableBudgetTokens > 0 ? triggerTokens / usableBudgetTokens : 0,
+		ceilingSource,
+		reserveCapped:
+			ceilingSource === "context" &&
+			isPositiveFiniteNumber(input.modelMaxTokens) &&
+			input.modelMaxTokens > maxReserveTokens,
+	};
 }
 
 function summarizeToolResults(messages: CoreCompactionContext["messages"]): {
@@ -189,47 +241,6 @@ const BUILTIN_COMPACTION_STRATEGIES = {
 		}),
 } satisfies Record<CoreCompactionStrategy, BuiltinCompactionStrategyRunner>;
 
-function resolveTriggerState(input: {
-	inputTokens: number;
-	maxInputTokens: number;
-	config: CoreCompactionConfig;
-}): { shouldCompact: boolean; triggerTokens: number; thresholdRatio: number } {
-	if (typeof input.config.reserveTokens === "number") {
-		const reserveTokens = Math.max(0, input.config.reserveTokens);
-		const triggerTokens = Math.max(0, input.maxInputTokens - reserveTokens);
-		return {
-			shouldCompact: input.inputTokens > triggerTokens,
-			triggerTokens,
-			thresholdRatio:
-				input.maxInputTokens > 0 ? triggerTokens / input.maxInputTokens : 0,
-		};
-	}
-
-	if (typeof input.config.thresholdRatio === "number") {
-		const thresholdRatio = input.config.thresholdRatio;
-		const triggerTokens = input.maxInputTokens * thresholdRatio;
-		return {
-			shouldCompact: input.inputTokens > triggerTokens,
-			triggerTokens,
-			thresholdRatio,
-		};
-	}
-
-	const triggerTokens = Math.max(
-		0,
-		Math.min(
-			input.maxInputTokens - DEFAULT_RESERVE_TOKENS,
-			input.maxInputTokens * DEFAULT_THRESHOLD_RATIO,
-		),
-	);
-	return {
-		shouldCompact: input.inputTokens > triggerTokens,
-		triggerTokens,
-		thresholdRatio:
-			input.maxInputTokens > 0 ? triggerTokens / input.maxInputTokens : 0,
-	};
-}
-
 function resolveManualTargetState(input: {
 	inputTokens: number;
 	maxInputTokens: number;
@@ -258,7 +269,8 @@ function resolveManualTargetState(input: {
 }
 
 function resolveBasicTargetTokens(input: {
-	maxInputTokens: number;
+	ceilingTokens: number;
+	usableBudgetTokens: number;
 	modelMaxTokens?: number;
 	triggerTokens: number;
 	messagePairCount: number;
@@ -267,13 +279,13 @@ function resolveBasicTargetTokens(input: {
 		input.messagePairCount >= 5 &&
 		typeof input.modelMaxTokens === "number" &&
 		Number.isFinite(input.modelMaxTokens) &&
-		input.modelMaxTokens < input.maxInputTokens
-			? Math.floor(input.maxInputTokens * LONG_CONVERSATION_TARGET_RATIO)
+		input.modelMaxTokens < input.ceilingTokens
+			? Math.floor(input.usableBudgetTokens * LONG_CONVERSATION_TARGET_RATIO)
 			: Math.floor(input.triggerTokens * DEFAULT_TARGET_RATIO);
 	const triggerCeiling = Math.max(1, input.triggerTokens - 1);
 	return Math.max(
 		1,
-		Math.min(targetTokens, input.maxInputTokens, triggerCeiling),
+		Math.min(targetTokens, input.usableBudgetTokens, triggerCeiling),
 	);
 }
 
@@ -348,22 +360,18 @@ export function createContextCompactionPrepareTurn(
 			(total: number, message) => total + estimateMessageTokens(message),
 			0,
 		);
-		const maxInputTokens = resolveMaxInputTokens({
-			configMaxInputTokens: userCompaction?.maxInputTokens,
-			modelMaxInputTokens: context.model.info?.maxInputTokens,
-			contextWindow: context.model.info?.contextWindow,
-			modelMaxTokens: context.model.info?.maxTokens,
-		});
-
-		const triggerState = resolveTriggerState({
-			inputTokens,
-			maxInputTokens,
+		const compactionBudget = resolveCompactionBudget({
 			config: {
 				maxInputTokens: userCompaction?.maxInputTokens,
 				reserveTokens: userCompaction?.reserveTokens,
 				thresholdRatio: userCompaction?.thresholdRatio,
 			},
+			modelMaxInputTokens: context.model.info?.maxInputTokens,
+			contextWindow: context.model.info?.contextWindow,
+			modelMaxTokens: context.model.info?.maxTokens,
 		});
+		const maxInputTokens = compactionBudget.ceilingTokens;
+		const shouldCompact = inputTokens > compactionBudget.triggerTokens;
 		config.logger?.debug("Context compaction diagnostics", {
 			mode,
 			strategy,
@@ -372,15 +380,20 @@ export function createContextCompactionPrepareTurn(
 			modelId: config.modelId,
 			inputTokens,
 			maxInputTokens,
-			triggerTokens: triggerState.triggerTokens,
-			thresholdRatio: triggerState.thresholdRatio,
-			shouldCompact: triggerState.shouldCompact,
+			usableBudgetTokens: compactionBudget.usableBudgetTokens,
+			outputReserveTokens: compactionBudget.outputReserveTokens,
+			ceilingSource: compactionBudget.ceilingSource,
+			reserveCapped: compactionBudget.reserveCapped,
+			triggerTokens: compactionBudget.triggerTokens,
+			thresholdRatio: compactionBudget.thresholdRatio,
+			usableThresholdRatio: compactionBudget.usableThresholdRatio,
+			shouldCompact,
 			messageCount: context.messages.length,
 			apiMessageCount: context.apiMessages.length,
 			apiMessagesJsonChars: safeJsonSize(context.apiMessages),
 			...summarizeToolResults(context.apiMessages),
 		});
-		if (mode === "auto" && !triggerState.shouldCompact) {
+		if (mode === "auto" && !shouldCompact) {
 			return undefined;
 		}
 		const targetState =
@@ -388,14 +401,15 @@ export function createContextCompactionPrepareTurn(
 				? resolveManualTargetState({
 						inputTokens,
 						maxInputTokens,
-						autoTriggerTokens: triggerState.triggerTokens,
+						autoTriggerTokens: compactionBudget.triggerTokens,
 						manualTargetRatio: options.manualTargetRatio,
 					})
-				: triggerState;
+				: compactionBudget;
 		const targetTokens =
 			mode === "auto"
 				? resolveBasicTargetTokens({
-						maxInputTokens,
+						ceilingTokens: compactionBudget.ceilingTokens,
+						usableBudgetTokens: compactionBudget.usableBudgetTokens,
 						modelMaxTokens: context.model.info?.maxTokens,
 						triggerTokens: targetState.triggerTokens,
 						messagePairCount: countUserAssistantPairs(context.messages),
@@ -426,6 +440,9 @@ export function createContextCompactionPrepareTurn(
 				iteration: context.iteration,
 				triggerTokens: targetState.triggerTokens,
 				maxInputTokens,
+				usableBudgetTokens: compactionBudget.usableBudgetTokens,
+				outputReserveTokens: compactionBudget.outputReserveTokens,
+				ceilingSource: compactionBudget.ceilingSource,
 			},
 		);
 
@@ -467,6 +484,10 @@ export function createContextCompactionPrepareTurn(
 				severity: "info",
 				strategy: strategy,
 				maxInputTokens,
+				usableBudgetTokens: compactionBudget.usableBudgetTokens,
+				outputReserveTokens: compactionBudget.outputReserveTokens,
+				ceilingSource: compactionBudget.ceilingSource,
+				reserveCapped: compactionBudget.reserveCapped,
 				inputTokens,
 				afterTokens,
 				tokensSaved: inputTokens - afterTokens,

--- a/sdk/packages/core/src/extensions/context/compaction.ts
+++ b/sdk/packages/core/src/extensions/context/compaction.ts
@@ -22,9 +22,9 @@ import {
 	createTokenEstimator,
 	DEFAULT_MAX_INPUT_TOKENS,
 	DEFAULT_PRESERVE_RECENT_TOKENS,
-	DEFAULT_RESERVE_TOKENS,
 	DEFAULT_TARGET_RATIO,
 	DEFAULT_THRESHOLD_RATIO,
+	FALLBACK_OUTPUT_RESERVE_TOKENS,
 } from "./compaction-shared";
 
 export interface ContextPipelinePrepareTurnInput {
@@ -129,6 +129,9 @@ function resolveCompactionBudget(input: {
 		ceilingSource = "context";
 	}
 
+	// Output space is reserved once, and only when the ceiling is a shared
+	// context window. Explicit config and true input limits already describe
+	// input-only budgets, so reserving there would double-count output.
 	const maxReserveTokens = Math.floor(ceilingTokens / 2);
 	const outputReserveTokens =
 		ceilingSource === "config" ||
@@ -137,7 +140,10 @@ function resolveCompactionBudget(input: {
 			? 0
 			: isPositiveFiniteNumber(input.modelMaxTokens)
 				? Math.min(input.modelMaxTokens, maxReserveTokens)
-				: Math.min(DEFAULT_RESERVE_TOKENS, Math.floor(ceilingTokens * 0.25));
+				: Math.min(
+						FALLBACK_OUTPUT_RESERVE_TOKENS,
+						Math.floor(ceilingTokens * 0.25),
+					);
 	const usableBudgetTokens = Math.max(1, ceilingTokens - outputReserveTokens);
 
 	let triggerTokens: number;

--- a/sdk/packages/core/src/extensions/context/compaction.ts
+++ b/sdk/packages/core/src/extensions/context/compaction.ts
@@ -100,7 +100,6 @@ interface CompactionBudget {
 	outputReserveTokens: number;
 	triggerTokens: number;
 	thresholdRatio: number;
-	usableThresholdRatio: number;
 	ceilingSource: CompactionBudgetSource;
 	reserveCapped: boolean;
 }
@@ -166,8 +165,6 @@ function resolveCompactionBudget(input: {
 		outputReserveTokens,
 		triggerTokens,
 		thresholdRatio:
-			ceilingTokens > 0 ? triggerTokens / ceilingTokens : 0,
-		usableThresholdRatio:
 			usableBudgetTokens > 0 ? triggerTokens / usableBudgetTokens : 0,
 		ceilingSource,
 		reserveCapped:
@@ -371,7 +368,7 @@ export function createContextCompactionPrepareTurn(
 			contextWindow: context.model.info?.contextWindow,
 			modelMaxTokens: context.model.info?.maxTokens,
 		});
-		const maxInputTokens = compactionBudget.ceilingTokens;
+		const maxInputTokens = compactionBudget.usableBudgetTokens;
 		const shouldCompact = inputTokens > compactionBudget.triggerTokens;
 		config.logger?.debug("Context compaction diagnostics", {
 			mode,
@@ -381,13 +378,12 @@ export function createContextCompactionPrepareTurn(
 			modelId: config.modelId,
 			inputTokens,
 			maxInputTokens,
-			usableBudgetTokens: compactionBudget.usableBudgetTokens,
+			ceilingTokens: compactionBudget.ceilingTokens,
 			outputReserveTokens: compactionBudget.outputReserveTokens,
 			ceilingSource: compactionBudget.ceilingSource,
 			reserveCapped: compactionBudget.reserveCapped,
 			triggerTokens: compactionBudget.triggerTokens,
 			thresholdRatio: compactionBudget.thresholdRatio,
-			usableThresholdRatio: compactionBudget.usableThresholdRatio,
 			shouldCompact,
 			messageCount: context.messages.length,
 			apiMessageCount: context.apiMessages.length,
@@ -425,7 +421,6 @@ export function createContextCompactionPrepareTurn(
 			messages: context.messages,
 			model: context.model,
 			maxInputTokens,
-			usableBudgetTokens: compactionBudget.usableBudgetTokens,
 			triggerTokens: targetState.triggerTokens,
 			targetTokens,
 			thresholdRatio: targetState.thresholdRatio,
@@ -442,7 +437,7 @@ export function createContextCompactionPrepareTurn(
 				iteration: context.iteration,
 				triggerTokens: targetState.triggerTokens,
 				maxInputTokens,
-				usableBudgetTokens: compactionBudget.usableBudgetTokens,
+				ceilingTokens: compactionBudget.ceilingTokens,
 				outputReserveTokens: compactionBudget.outputReserveTokens,
 				ceilingSource: compactionBudget.ceilingSource,
 			},
@@ -486,7 +481,7 @@ export function createContextCompactionPrepareTurn(
 				severity: "info",
 				strategy: strategy,
 				maxInputTokens,
-				usableBudgetTokens: compactionBudget.usableBudgetTokens,
+				ceilingTokens: compactionBudget.ceilingTokens,
 				outputReserveTokens: compactionBudget.outputReserveTokens,
 				ceilingSource: compactionBudget.ceilingSource,
 				reserveCapped: compactionBudget.reserveCapped,

--- a/sdk/packages/core/src/types/config.ts
+++ b/sdk/packages/core/src/types/config.ts
@@ -67,20 +67,15 @@ export interface CoreCompactionContext {
 		info?: ModelInfo;
 	};
 	/**
-	 * Full input ceiling for the model (context window or explicit override),
-	 * before any output-token reserve is subtracted.
+	 * Usable input budget after reserving any shared context window space needed
+	 * for model output.
 	 */
 	maxInputTokens: number;
-	/**
-	 * Tokens the input may actually occupy: `maxInputTokens` minus the output
-	 * reserve held back on shared-context models. Compact below this value.
-	 */
-	usableBudgetTokens: number;
 	triggerTokens: number;
 	targetTokens?: number;
 	/**
-	 * Effective trigger point as a fraction of `maxInputTokens`
-	 * (`triggerTokens / maxInputTokens`), not the raw configured ratio.
+	 * Effective trigger point as a fraction of the usable input budget
+	 * (`triggerTokens / maxInputTokens`).
 	 */
 	thresholdRatio: number;
 	utilizationRatio: number;

--- a/sdk/packages/core/src/types/config.ts
+++ b/sdk/packages/core/src/types/config.ts
@@ -66,9 +66,22 @@ export interface CoreCompactionContext {
 		provider: string;
 		info?: ModelInfo;
 	};
+	/**
+	 * Full input ceiling for the model (context window or explicit override),
+	 * before any output-token reserve is subtracted.
+	 */
 	maxInputTokens: number;
+	/**
+	 * Tokens the input may actually occupy: `maxInputTokens` minus the output
+	 * reserve held back on shared-context models. Compact below this value.
+	 */
+	usableBudgetTokens: number;
 	triggerTokens: number;
 	targetTokens?: number;
+	/**
+	 * Effective trigger point as a fraction of `maxInputTokens`
+	 * (`triggerTokens / maxInputTokens`), not the raw configured ratio.
+	 */
 	thresholdRatio: number;
 	utilizationRatio: number;
 }


### PR DESCRIPTION
### Related Issue

**Issue:** [ENG-2249](https://linear.app/cline-bot/issue/ENG-2249/investigate-qwen-over-compaction-from-max-token-budget-resolution)

### Description

This fixes an early auto-compaction trigger for providers whose model metadata reports a shared context window and output limit in a way that looked like an input limit.

The concrete failure case was `openrouter:qwen/qwen3-32b`. Its metadata is effectively:

```text
contextWindow = 40960
maxInputTokens = 40960
maxTokens = 16384
```

Before this change, compaction treated `contextWindow - maxTokens` as a lower input ceiling:

```text
40960 - 16384 = 24576
```

Then the default trigger logic reserved output space again:

```text
24576 - 16384 = 8192
```

That produced Harbor diagnostics like `maxInputTokens=24576` and `triggerTokens=8192`, so Cline compacted much earlier than the provider/model budget required.

This PR replaces the split `resolveMaxInputTokens()` plus `resolveTriggerState()` flow with one budget resolver that chooses a single ceiling source, computes one output reserve, then derives the compaction trigger from the usable input budget.

The new decision model is:

1. `config.maxInputTokens` wins when explicitly configured.
2. A provider/model `maxInputTokens` is treated as a true input limit only when it is lower than `contextWindow`, or when no context window is known.
3. Mirrored `maxInputTokens === contextWindow` is treated as shared-context metadata, not a pre-reserved input ceiling.
4. Shared-context models reserve output exactly once.
5. Output reserve is capped at half the context window so bad or overly broad `maxTokens` metadata cannot collapse the usable budget.
6. Explicit `reserveTokens` and `thresholdRatio` apply to the usable budget.

For Qwen-style mirrored metadata, the default calculation is now:

```text
ceiling = 40960
outputReserve = 16384
maxInputTokens = usableBudget = 24576
trigger = floor(24576 * 0.9) = 22118
```

That keeps the advertised output headroom while avoiding the previous double reserve to `8192`.

The public compaction callback/telemetry contract remains simple: `maxInputTokens` means the usable input budget after any shared-context output reserve. `thresholdRatio` is still `triggerTokens / maxInputTokens`, so the common model remains true:

```text
triggerTokens = maxInputTokens * thresholdRatio
```

Raw context-window accounting stays internal and diagnostic-only through log/status metadata such as `ceilingTokens`, `outputReserveTokens`, `ceilingSource`, and `reserveCapped`. No public `usableBudgetTokens` or `usableThresholdRatio` field is exposed.

### Examples

```text
Shared context model:
contextWindow = 400000
maxTokens = 128000
maxInputTokens = 400000 - 128000 = 272000
triggerTokens = floor(272000 * 0.9) = 244800
thresholdRatio = 0.9
```

```text
Qwen mirrored metadata:
contextWindow = 40960
maxInputTokens metadata = 40960
maxTokens = 16384
public maxInputTokens = 40960 - 16384 = 24576
triggerTokens = floor(24576 * 0.9) = 22118
```

```text
True split input limit:
contextWindow = 400000
maxInputTokens metadata = 200000
maxTokens = 128000
public maxInputTokens = 200000
triggerTokens = floor(200000 * 0.9) = 180000
```

### Test Procedure

Focused verification:

```bash
bun test sdk/packages/core/src/extensions/context/compaction.test.ts
bun run typecheck # from sdk/packages/core
bun biome check --diagnostic-level=error sdk/packages/core/src/extensions/context/compaction.ts sdk/packages/core/src/extensions/context/compaction.test.ts sdk/packages/core/src/types/config.ts
```

Results:

```text
compaction.test.ts: 44 passed
core typecheck: passed
biome changed-file check: passed
```

Full-suite verification:

```bash
bun run test
```

Result: attempted, but the repo-wide suite currently fails on unrelated baseline/environment issues before this compaction change is implicated. Observed failures include missing `ajv/dist/compile/codegen` from `ajv-formats`, SAP/winston `isStream is not a function`, provider-default catalog assertions, and session-runtime assertions outside the compaction path. The focused compaction suite and core typecheck both pass after this change.

Risk areas checked:

- Reviewed with Claude/Fable after Bee's feedback: public `maxInputTokens` should be the usable input budget, not the raw context ceiling.
- Mirrored Qwen metadata no longer double-reserves output.
- True split input limits still win when `maxInputTokens < contextWindow`.
- Shared-context output reserve is capped at half the window.
- Explicit `thresholdRatio` and `reserveTokens` are applied to usable budget.
- Manual compaction still uses the resolved auto trigger for its target calculation.
- Existing telemetry event shape remains structurally unchanged.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

No UI change. This diagram is included only as reviewer context for the budget resolver; it is not part of this PR's code diff.

![Compaction budget resolver](https://raw.githubusercontent.com/cline/cline/0bbddd5a52c258d52a664f467893262b4e762232/docs/assets/compaction-budget-resolver.png)

### Additional Notes

Only compaction resolver code, its focused tests, and the public compaction context type are included in this PR. The implementation files are `sdk/packages/core/src/extensions/context/compaction.ts`, `sdk/packages/core/src/extensions/context/compaction.test.ts`, and `sdk/packages/core/src/types/config.ts`.

The diagram image is hosted from a separate asset-only branch so reviewers can see it in the PR body without adding the design doc or diagram files to this PR.
