### PR TITLE
fix(cli): use unique keys for read_files rows

### DIFF
--- a/apps/cli/src/tui/components/chat-entry.tsx
+++ b/apps/cli/src/tui/components/chat-entry.tsx
@@ -29,6 +29,7 @@ import { formatCompactionDividerLabel } from "../utils/compaction-status";
 import { getSyntaxStyle, type SyntaxAccentMode } from "../utils/syntax-style";
 import { isWarningToolError } from "../utils/tool-errors";
 import {
+	buildReadFilesKeys,
 	parseApplyPatchInput,
 	parseAskQuestionInput,
 	parseEditorInput,
@@ -129,12 +130,13 @@ function formatToolParams(
 		case "read_files": {
 			const info = parseReadFilesInput(rawInput);
 			if (!info?.files.length) return fallback;
+			const keys = buildReadFilesKeys(info.files);
 			return info.files.map((f, i) => {
 				const sl = f.startLine != null ? String(f.startLine) : "undefined";
 				const el = f.endLine != null ? String(f.endLine) : "undefined";
 				const sep = i > 0 ? "; " : "";
 				return (
-					<span key={`${f.path}:${sl}:${el}`}>
+					<span key={keys[i]}>
 						{sep}
 						{shortenPath(f.path)}
 						<span fg="gray">

--- a/apps/cli/src/tui/components/dialogs/tool-approval.tsx
+++ b/apps/cli/src/tui/components/dialogs/tool-approval.tsx
@@ -4,6 +4,7 @@ import { useDialogKeyboard } from "@opentui-ui/dialog/react";
 import type React from "react";
 import { palette } from "../../palette";
 import {
+	buildReadFilesKeys,
 	parseApplyPatchInput,
 	parseEditorInput,
 	parseReadFilesInput,
@@ -22,13 +23,14 @@ export function formatApprovalParams(
 		case "read_files": {
 			const info = parseReadFilesInput(rawInput);
 			if (!info?.files.length) break;
+			const keys = buildReadFilesKeys(info.files);
 			return info.files.map((f, i) => {
 				const range =
 					f.startLine != null
 						? ` lines ${f.startLine}-${f.endLine ?? "end"}`
 						: "";
 				return (
-					<text key={f.path} fg="gray" selectable>
+					<text key={keys[i]} fg="gray" selectable>
 						{"  "}
 						{shortenPath(f.path, 60)}
 						{range && <span fg="gray">{range}</span>}

--- a/apps/cli/src/tui/utils/tool-parsing.test.ts
+++ b/apps/cli/src/tui/utils/tool-parsing.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { buildReadFilesKeys, parseReadFilesInput } from "./tool-parsing";
+
+describe("buildReadFilesKeys", () => {
+	it("produces unique keys when the same path is read twice", () => {
+		const info = parseReadFilesInput({
+			files: [{ path: "/a/SKILL.md" }, { path: "/a/SKILL.md" }],
+		});
+		const keys = buildReadFilesKeys(info?.files ?? []);
+
+		expect(keys).toHaveLength(2);
+		expect(new Set(keys).size).toBe(keys.length);
+	});
+
+	it("produces unique keys for duplicate paths from the file_paths shape", () => {
+		const info = parseReadFilesInput({
+			file_paths: ["/a/SKILL.md", "/a/SKILL.md", "/b/SKILL.md"],
+		});
+		const keys = buildReadFilesKeys(info?.files ?? []);
+
+		expect(keys).toHaveLength(3);
+		expect(new Set(keys).size).toBe(keys.length);
+	});
+
+	it("keeps distinct paths in unique keys", () => {
+		const keys = buildReadFilesKeys([{ path: "/a.ts" }, { path: "/b.ts" }]);
+
+		expect(new Set(keys).size).toBe(2);
+	});
+
+	it("returns no keys for an empty list", () => {
+		expect(buildReadFilesKeys([])).toEqual([]);
+	});
+});

--- a/apps/cli/src/tui/utils/tool-parsing.ts
+++ b/apps/cli/src/tui/utils/tool-parsing.ts
@@ -91,6 +91,12 @@ export function parseReadFilesInput(input: unknown): ReadFilesInfo | undefined {
 	return undefined;
 }
 
+// A read_files call can list the same path more than once, so the raw path is
+// not a unique React key. Prefix the array index to keep keys unique per row.
+export function buildReadFilesKeys(files: { path: string }[]): string[] {
+	return files.map((f, i) => `${i}:${f.path}`);
+}
+
 export interface RunCommandsInfo {
 	commands: string[];
 }


### PR DESCRIPTION
## What
The CLI logs `Encountered two children with the same key, .../SKILL.md` when navigating `/skills` after adding a skill.

## Root cause
The `read_files` tool-param formatter renders the file list keyed by the raw path (`key={f.path}`) and doesn't dedupe. A `read_files` call can legitimately list the same path more than once. The `find-skills` skill reads the same `SKILL.md` repeatedly so two rows get the same React key. It re-fires on every re-render, which is why it appears while moving through `/skills`.
Note this is *not* the skills picker (which keys by command name) or the core loader (which dedupes skills by name). It's purely a render-key defect over a legitimately-repeatable array.

## Fix
Add a small `buildReadFilesKeys` helper that returns index-namespaced keys (`${i}:${path}`), and use it at both render sites: `chat-entry.tsx` and `tool-approval.tsx`. Same approach as the existing `8648154a` logo-key fix. `@cline/core` is not touched.

## What could break
Nothing functional, the key change only affects React reconciliation identity for these leaf `<span>`/`<text>` nodes, which hold no state and are re-derived each render, so an index-based key is safe (no reorder/state-loss risk). The visible output (paths, line ranges) is unchanged.

## Tests
Added `apps/cli/src/tui/utils/tool-parsing.test.ts`: asserts key uniqueness when a path repeats (both the `files` and `file_paths` input shapes). Fails on `main` (duplicate keys), passes with the fix.
```
cd apps/cli && bun run test:unit tool-parsing
```

Fixes #9784

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only render-key change with no state on affected nodes; behavior and output are unchanged.
> 
> **Overview**
> Fixes React **duplicate key** warnings when `read_files` lists the same path more than once (e.g. repeated `SKILL.md` reads while using `/skills`).
> 
> Adds **`buildReadFilesKeys`** in tool-parsing, which namespaces each row with its index (`${i}:${path}`), and wires it into **`formatToolParams`** in chat-entry and **`formatApprovalParams`** in the tool-approval dialog. Displayed paths and line ranges are unchanged; only reconciliation keys differ.
> 
> Unit tests cover repeated paths for both `files` and `file_paths` input shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a793e067b5b95ec317d4ea79f52b7a683dcf4ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->