### PR TITLE
fix(vscode): don't steal editor focus after saving a file edit

### DIFF
--- a/apps/vscode/src/hosts/vscode/VscodeDiffViewProvider.ts
+++ b/apps/vscode/src/hosts/vscode/VscodeDiffViewProvider.ts
@@ -190,7 +190,7 @@ export class VscodeDiffViewProvider extends DiffViewProvider {
 		return this.activeDiffEditor.document.getText()
 	}
 
-	protected override async saveDocument(): Promise<Boolean> {
+	protected override async saveDocument(): Promise<boolean> {
 		if (!this.activeDiffEditor) {
 			return false
 		}
@@ -249,13 +249,16 @@ export class VscodeDiffViewProvider extends DiffViewProvider {
 			// Open with Jupyter notebook editor if available
 			const jupyterExtension = vscode.extensions.getExtension("ms-toolsai.jupyter")
 			if (jupyterExtension) {
-				await vscode.commands.executeCommand("vscode.openWith", uri, "jupyter-notebook")
+				// preserveFocus: this runs on every saveChanges(), including auto-approved
+				// edits with no user interaction, so it must never steal focus away from
+				// wherever the user actually is (e.g. mid-keystroke in the chat composer).
+				await vscode.commands.executeCommand("vscode.openWith", uri, "jupyter-notebook", { preserveFocus: true })
 				return
 			}
 		}
 
-		// Default: open as text
-		await vscode.window.showTextDocument(uri, { preview: false })
+		// Default: open as text. preserveFocus for the same reason as above.
+		await vscode.window.showTextDocument(uri, { preview: false, preserveFocus: true })
 	}
 }
 


### PR DESCRIPTION
## Summary
- `VscodeDiffViewProvider.showFile()` is called by every `saveChanges()`, including auto-approved edits with zero user interaction, and opened the just-saved file without `preserveFocus`. This silently steals real VS Code keyboard focus away from wherever the user actually is.
- Concretely: while typing/editing a prompt in the chat composer, an auto-approved (or just-approved) file edit can yank focus to the file it just saved. A subsequent Ctrl+V/Ctrl+X typed right after lands in the code editor instead of the chat box — in one observed case, cutting code out of the open file instead of the intended chat text.
- Fix: pass `preserveFocus: true` on both the regular-file and Jupyter-notebook branches of `showFile()`, matching the other `showTextDocument`/`openWith`/`openFile` calls already in this same class (`openDiffEditor`, base `DiffViewProvider.showFile`).

## Test plan
- [ ] Enable auto-approve for edits, keep typing in the chat composer while Cline edits a file, and confirm focus stays in the composer (Ctrl+V/Ctrl+X still target the chat box, not the editor).
- [ ] Manually approve an edit and confirm the saved file still opens in the editor as before, just without stealing keyboard focus from the composer.
- [ ] Repeat with a `.ipynb` notebook edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
