### PR TITLE
Add API key support for LM Studio

### DIFF
--- a/apps/vscode/src/core/controller/models/__tests__/providerCatalogHandlers.test.ts
+++ b/apps/vscode/src/core/controller/models/__tests__/providerCatalogHandlers.test.ts
@@ -3,7 +3,9 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import type { EffectiveProviderConfig, ProviderCatalog, ProviderConfigStore } from "@/sdk/model-catalog/contracts"
 import { computeConfigFingerprint } from "@/sdk/model-catalog/fingerprint"
 import { parseProviderId } from "@/sdk/model-catalog/provider-id"
+import { mockFetchForTesting } from "@/shared/net"
 import { ApiFormat, OpenRouterModelInfo } from "@/shared/proto/cline/models"
+import type { Controller } from "../.."
 import type { ProviderCatalogController } from "../providerCatalogShared"
 
 type TestStateManager = {
@@ -153,7 +155,7 @@ describe("provider model catalog handlers", () => {
 			baseUrl: "https://api.example.com/v1",
 			auth: { accessToken: "SECRET_SENTINEL_ACCESS", refreshToken: "SECRET_SENTINEL_REFRESH", accountId: "acct-1" },
 		})
-		const controller = makeController(store, makeCatalog())
+		const controller = makeController(store, makeCatalog()) as unknown as Controller
 
 		const response = await readProviderConfig(controller, { value: "cline" })
 
@@ -208,6 +210,28 @@ describe("provider model catalog handlers", () => {
 		})
 
 		expect(store.write).toHaveBeenCalledWith(providerId, { headers: {} })
+	})
+
+	it("getLmStudioModels sends the saved LM Studio API key when fetching models", async () => {
+		const { getLmStudioModels } = await import("../getLmStudioModels")
+		const providerId = parseProviderId("lmstudio")
+		const store = makeStore({ providerId, apiKey: "lm-studio-token" })
+		const controller = makeController(store, makeCatalog())
+		const fetchMock = vi.fn(
+			async () =>
+				new Response(JSON.stringify({ data: [{ id: "qwen/qwen3" }] }), {
+					headers: { "content-type": "application/json" },
+				}),
+		)
+
+		const response = await mockFetchForTesting(fetchMock, () =>
+			getLmStudioModels(controller, { value: "http://localhost:1234" }),
+		)
+
+		expect(fetchMock).toHaveBeenCalledWith("http://localhost:1234/api/v0/models", {
+			headers: { Authorization: "Bearer lm-studio-token" },
+		})
+		expect(response.values).toEqual([JSON.stringify({ id: "qwen/qwen3" })])
 	})
 
 	it("commitModelSelection validates mode and commits the full selection envelope", async () => {

--- a/apps/vscode/src/core/controller/models/getLmStudioModels.ts
+++ b/apps/vscode/src/core/controller/models/getLmStudioModels.ts
@@ -1,4 +1,5 @@
 import { StringArray, type StringRequest } from "@shared/proto/cline/common"
+import { parseProviderId } from "@/sdk/model-catalog/provider-id"
 import { fetch } from "@/shared/net"
 import { Logger } from "@/shared/services/Logger"
 import type { Controller } from ".."
@@ -9,15 +10,18 @@ import type { Controller } from ".."
  * @param request The request containing the base URL (optional)
  * @returns Array of model names
  */
-export async function getLmStudioModels(_controller: Controller, request: StringRequest): Promise<StringArray> {
+export async function getLmStudioModels(controller: Controller, request: StringRequest): Promise<StringArray> {
 	try {
-		const baseUrl = request.value || "http://localhost:1234"
+		const providerConfig = controller.getProviderConfigStore().read(parseProviderId("lmstudio"))
+		const baseUrl = request.value || providerConfig.baseUrl || "http://localhost:1234"
 		if (!URL.canParse(baseUrl)) {
 			return StringArray.create({ values: [] })
 		}
 		const endpoint = new URL("api/v0/models", baseUrl)
 
-		const response = await fetch(endpoint.href)
+		const response = await fetch(endpoint.href, {
+			headers: providerConfig.apiKey ? { Authorization: `Bearer ${providerConfig.apiKey}` } : undefined,
+		})
 		const data = await response.json()
 		const models = data?.data?.map((m: unknown) => JSON.stringify(m)) || []
 

--- a/apps/vscode/webview-ui/src/components/settings/providers/LMStudioProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/LMStudioProvider.tsx
@@ -8,10 +8,12 @@ import { useExtensionState } from "@/context/ExtensionStateContext"
 import { useProviderConfig } from "@/hooks/useProviderConfig"
 import { useProviderModelSelection } from "@/hooks/useProviderModelSelection"
 import { ModelsServiceClient } from "@/services/grpc-client"
+import { ApiKeyField } from "../common/ApiKeyField"
 import { BaseUrlField } from "../common/BaseUrlField"
 import { DebouncedTextField } from "../common/DebouncedTextField"
 import { DropdownContainer } from "../common/ModelSelector"
 import { useApiConfigurationHandlers } from "../utils/useApiConfigurationHandlers"
+import { useProviderApiKeyField } from "../utils/useProviderApiKeyField"
 
 /**
  * Props for the LMStudioProvider component
@@ -77,6 +79,11 @@ export const LMStudioProvider = ({ currentMode }: LMStudioProviderProps) => {
 		() => config?.baseUrl ?? apiConfiguration?.lmStudioBaseUrl ?? "http://localhost:1234",
 		[apiConfiguration?.lmStudioBaseUrl, config?.baseUrl],
 	)
+	const { savedApiKeyMask, handleApiKeyChange } = useProviderApiKeyField({
+		apiKeyLength: config?.apiKeyLength,
+		providerName: "LM Studio",
+		write,
+	})
 
 	const handleBaseUrlChange = useCallback(
 		(value: string) => {
@@ -158,13 +165,21 @@ export const LMStudioProvider = ({ currentMode }: LMStudioProviderProps) => {
 				placeholder="Default: http://localhost:1234"
 			/>
 
+			<ApiKeyField
+				helpText="Optional API key for LM Studio servers with Require Authentication enabled. Leave empty for local servers without authentication."
+				initialValue={savedApiKeyMask}
+				onChange={handleApiKeyChange}
+				placeholder="Enter API Key (optional)..."
+				providerName="LM Studio"
+			/>
+
 			<div className="font-semibold">Model</div>
 			{lmStudioModels.length > 0 ? (
 				<DropdownContainer className="dropdown-container" zIndex={10}>
 					<VSCodeDropdown
 						className="w-full mb-3"
-						onChange={(e: any) => {
-							const value = e?.target?.value
+						onChange={(e: Event) => {
+							const value = (e.target as HTMLSelectElement | null)?.value
 							if (typeof value === "string") {
 								handleModelChange(value)
 							}


### PR DESCRIPTION
## Summary
- Add an optional API key field to the LM Studio provider settings
- Send the saved LM Studio API key as a Bearer token when refreshing models
- Cover authenticated LM Studio model refresh in provider catalog handler tests

Closes #9668

## Tests
- bunx vitest run src/core/controller/models/__tests__/providerCatalogHandlers.test.ts --config vitest.config.ts
- bunx --bun @biomejs/biome check --config-path ./biome.jsonc src/core/controller/models/getLmStudioModels.ts src/core/controller/models/__tests__/providerCatalogHandlers.test.ts webview-ui/src/components/settings/providers/LMStudioProvider.tsx