### PR TITLE
docs(readme): add HVTracker trust badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,13 @@ git diff origin/main | cline  "Review these changes for issues"
 cline --json "List all TODO comments" | jq -r 'select(.type == "agent_event" and .event.text) | .event.text'
 ```
 
+<div align="center">
+
+[![HVTrust](https://hvtracker.net/badge/cline.svg)](https://hvtracker.net/agents/cline/)
+[![Evidence Grade](https://hvtracker.net/badge/cline-grade.svg)](https://hvtracker.net/agents/cline/)
+
+</div>
+
 ## Contributing
 
 Start with the [Contributing Guide](CONTRIBUTING.md). Join our [Discord](https://discord.gg/cline) and head to the `#contributors` channel to connect with other contributors. Check our [careers page](https://cline.bot/join-us) for full-time roles.


### PR DESCRIPTION
Closes #11157

Adds HVTracker trust and evidence-grade badges to the README so users can inspect Cline's trust profile directly from the repository.

- [HVTrust](https://hvtracker.net/agents/cline/) badge
- [Evidence Grade](https://hvtracker.net/agents/cline/) badge