### PR TITLE
docs: fix typos, incorrect slash command, and hooks vs plugins mismatch

### DIFF
--- a/docs/customization/hooks.mdx
+++ b/docs/customization/hooks.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Hooks"
 sidebarTitle: "Hooks"
-description: "See details under SDK Hooks page."
+description: "See details under SDK Plugins page."
 ---
 
 See details under [SDK Plugins](/sdk/plugins).

--- a/docs/getting-started/installing-cline.mdx
+++ b/docs/getting-started/installing-cline.mdx
@@ -7,7 +7,7 @@ description: "Choose your installation path: IDE Extension, CLI, SDK, or Kanban"
 
 - [IDE Extension](#ide-extension) — VS Code, Cursor, JetBrains, Windsurf, VSCodium, Antigravity
 - [CLI](#cli) — terminal workflows
-- [Kanban](#kanban) (preview) — easily manage through multiple agents through a kanban board
+- [Kanban](#kanban) (preview) — easily manage multiple agents through a kanban board
 - [SDK](#sdk) — build with `@cline/sdk`
 
 ## IDE Extension

--- a/docs/provider-config/minimax.mdx
+++ b/docs/provider-config/minimax.mdx
@@ -1,6 +1,6 @@
 ---
 title: "MiniMax"
-description: "Learn how to configure and use MiniMax provider with Cline.."
+description: "Learn how to configure and use MiniMax provider with Cline."
 ---
 
 MiniMax provides AI models with large context windows and competitive pricing, featuring the MiniMax-M2 series.

--- a/docs/usage/ide.mdx
+++ b/docs/usage/ide.mdx
@@ -257,6 +257,6 @@ These same patterns work for any project, from simple scripts to full applicatio
 
 ## Need Help?
 
-- **Start a fresh conversation**: Type `/new` in the chat input to begin a new task
+- **Start a fresh conversation**: Type `/newtask` in the chat input to begin a new task
 - **Report issues**: Use `/reportbug` to help us improve
 - **Get support**: Join our [Discord community](https://discord.gg/cline)


### PR DESCRIPTION
Fixes four documentation issues:

1. **MiniMax provider description** — removed duplicate period at end of sentence
2. **Install page** — removed duplicate 'through' in kanban bullet (`manage through multiple agents through`)
3. **IDE usage page** — corrected `/new` to `/newtask` (the correct slash command for starting a fresh conversation)
4. **Hooks page** — description said 'SDK Hooks page' but content links to SDK Plugins; aligned description with actual destination