### PR TITLE
docs(authorizing): remove model-specific wording from generic setup step

### DIFF
--- a/docs/getting-started/authorizing-with-cline.mdx
+++ b/docs/getting-started/authorizing-with-cline.mdx
@@ -33,7 +33,7 @@ Cline connects to AI models through a **provider**. You have three common paths:
   </Step>
 
   <Step title="Select Model">
-    Choose your desired Claude model from the **Model** dropdown.
+    Choose your desired model from the **Model** dropdown.
   </Step>
 </Steps>
 


### PR DESCRIPTION
Step 4 in the IDE setup flow says 'Choose your desired Claude model' but this step applies to all providers (OpenAI, Gemini, DeepSeek, local, etc.), not just Claude. Drop 'Claude' to keep it provider-agnostic.