### PR TITLE
fix(llms): strip embedded MiniMax reasoning tags in openai-compatible streams

### DIFF
--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -19,6 +19,10 @@ import { jsonSchema, NoSuchToolError, streamText } from "ai";
 import { nanoid } from "nanoid";
 import { extractErrorMessage } from "./format";
 import {
+	EmbeddedReasoningTagParser,
+	shouldStripEmbeddedReasoningTags,
+} from "./middleware/strip-embedded-reasoning-tags";
+import {
 	isAnthropicCompatibleModel,
 	isCerebrasProvider,
 	resolveModelFamily,
@@ -902,6 +906,47 @@ async function* emitAiSdkEvents(
 	let streamError: string | undefined;
 	let finishUsage: unknown;
 	let finishProviderMetadata: unknown;
+	const embeddedReasoningParser = shouldStripEmbeddedReasoningTags(
+		request.providerId,
+		request.modelId,
+	)
+		? new EmbeddedReasoningTagParser()
+		: undefined;
+
+	const emitParsedTextDelta = function* (text: string) {
+		if (!embeddedReasoningParser) {
+			yield { type: "text-delta" as const, text };
+			return;
+		}
+		for (const chunk of embeddedReasoningParser.push(text)) {
+			if (chunk.kind === "text") {
+				yield { type: "text-delta" as const, text: chunk.text };
+				continue;
+			}
+			yield {
+				type: "reasoning-delta" as const,
+				text: chunk.text,
+				redacted: chunk.redacted,
+			};
+		}
+	};
+
+	const flushEmbeddedReasoningParser = function* () {
+		if (!embeddedReasoningParser) {
+			return;
+		}
+		for (const chunk of embeddedReasoningParser.flush()) {
+			if (chunk.kind === "text") {
+				yield { type: "text-delta" as const, text: chunk.text };
+				continue;
+			}
+			yield {
+				type: "reasoning-delta" as const,
+				text: chunk.text,
+				redacted: chunk.redacted,
+			};
+		}
+	};
 
 	try {
 		if (stream.fullStream) {
@@ -912,7 +957,7 @@ async function* emitAiSdkEvents(
 						(part.text as string | undefined) ??
 						(part.delta as string | undefined);
 					if (text) {
-						yield { type: "text-delta", text };
+						yield* emitParsedTextDelta(text);
 					}
 					continue;
 				}
@@ -926,6 +971,10 @@ async function* emitAiSdkEvents(
 						yield {
 							type: "reasoning-delta",
 							text,
+							redacted:
+								(part as { redacted?: boolean }).redacted === true
+									? true
+									: undefined,
 							metadata: extractGoogleThoughtMetadata(part),
 						};
 					}
@@ -1020,9 +1069,10 @@ async function* emitAiSdkEvents(
 			}
 		} else if (stream.textStream) {
 			for await (const text of stream.textStream) {
-				yield { type: "text-delta", text };
+				yield* emitParsedTextDelta(text);
 			}
 		}
+		yield* flushEmbeddedReasoningParser();
 	} catch (error) {
 		// Prefer the real provider error from onError over the generic
 		// NoOutputGeneratedError the AI SDK throws when 0 steps are recorded.

--- a/sdk/packages/llms/src/providers/middleware/strip-embedded-reasoning-tags.test.ts
+++ b/sdk/packages/llms/src/providers/middleware/strip-embedded-reasoning-tags.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import {
+	EmbeddedReasoningTagParser,
+	shouldStripEmbeddedReasoningTags,
+	__testing__suffixPartialTagLength,
+} from "./strip-embedded-reasoning-tags";
+
+function collect(parser: EmbeddedReasoningTagParser, chunks: string[]) {
+	const out = [];
+	for (const chunk of chunks) {
+		out.push(...parser.push(chunk));
+	}
+	out.push(...parser.flush());
+	return out;
+}
+
+const REDACTED_OPEN = "<" + "redacted_thinking" + ">";
+const REDACTED_CLOSE = "<" + "/redacted_thinking" + ">";
+const THINK_OPEN = "\u003cthink\u003e";
+const THINK_CLOSE = "\u003c/think\u003e";
+
+describe("shouldStripEmbeddedReasoningTags", () => {
+	it("enables stripping for MiniMax models on openai-compatible", () => {
+		expect(
+			shouldStripEmbeddedReasoningTags(
+				"openai-compatible",
+				"MiniMax-M2.7-highspeed",
+			),
+		).toBe(true);
+	});
+
+	it("skips non-openai-compatible providers", () => {
+		expect(shouldStripEmbeddedReasoningTags("minimax", "MiniMax-M2.7")).toBe(
+			false,
+		);
+	});
+
+	it("skips unrelated openai-compatible models", () => {
+		expect(
+			shouldStripEmbeddedReasoningTags("openai-compatible", "deepseek-v4-pro"),
+		).toBe(false);
+	});
+});
+
+describe("EmbeddedReasoningTagParser", () => {
+	it("passes through plain text unchanged", () => {
+		const parser = new EmbeddedReasoningTagParser();
+		expect(collect(parser, ["Hello", " world"])).toEqual([
+			{ kind: "text", text: "Hello" },
+			{ kind: "text", text: " world" },
+		]);
+	});
+
+	it("splits a redacted thinking block from surrounding text", () => {
+		const parser = new EmbeddedReasoningTagParser();
+		const input = `Before${REDACTED_OPEN}secret${REDACTED_CLOSE}After`;
+		expect(collect(parser, [input])).toEqual([
+			{ kind: "text", text: "Before" },
+			{ kind: "reasoning", text: "secret", redacted: true },
+			{ kind: "text", text: "After" },
+		]);
+	});
+
+	it("handles redacted thinking split across chunks", () => {
+		const parser = new EmbeddedReasoningTagParser();
+		expect(
+			collect(parser, [
+				"Hi " + REDACTED_OPEN.slice(0, 14),
+				REDACTED_OPEN.slice(14) + "rea",
+				"son" + REDACTED_CLOSE + " there",
+			]),
+		).toEqual([
+			{ kind: "text", text: "Hi " },
+			{ kind: "reasoning", text: "rea", redacted: true },
+			{ kind: "reasoning", text: "son", redacted: true },
+			{ kind: "text", text: " there" },
+		]);
+	});
+
+	it("splits think blocks without marking them redacted", () => {
+		const parser = new EmbeddedReasoningTagParser();
+		expect(
+			collect(parser, ["A" + THINK_OPEN + "thought" + THINK_CLOSE + "B"]),
+		).toEqual([
+			{ kind: "text", text: "A" },
+			{ kind: "reasoning", text: "thought", redacted: false },
+			{ kind: "text", text: "B" },
+		]);
+	});
+
+	it("does not emit partial tag prefixes as visible text", () => {
+		expect(
+			__testing__suffixPartialTagLength(
+				REDACTED_OPEN.slice(0, -1),
+				[REDACTED_OPEN],
+			),
+		).toBeGreaterThan(0);
+		const parser = new EmbeddedReasoningTagParser();
+		expect(parser.push(REDACTED_OPEN.slice(0, -1))).toEqual([]);
+		expect(parser.flush()).toEqual([
+			{ kind: "text", text: REDACTED_OPEN.slice(0, -1) },
+		]);
+	});
+
+	it("flushes trailing reasoning when close tag never arrives", () => {
+		const parser = new EmbeddedReasoningTagParser();
+		expect(collect(parser, [REDACTED_OPEN + "trail"])).toEqual([
+			{ kind: "reasoning", text: "trail", redacted: true },
+		]);
+	});
+});

--- a/sdk/packages/llms/src/providers/middleware/strip-embedded-reasoning-tags.ts
+++ b/sdk/packages/llms/src/providers/middleware/strip-embedded-reasoning-tags.ts
@@ -1,0 +1,216 @@
+/**
+ * Some OpenAI-compatible backends (e.g. MiniMax M2.7) embed reasoning inside
+ * plain `content` deltas using XML-like tags instead of native reasoning fields.
+ * The generic openai-compatible handler forwards these as `text-delta`, so users
+ * see literal `<think>` labels in assistant output.
+ *
+ * This parser splits embedded reasoning tags out of streamed text so callers can
+ * emit proper `reasoning-delta` events (with `redacted: true` for redacted blocks).
+ */
+
+export type EmbeddedReasoningChunk =
+	| { kind: "text"; text: string }
+	| { kind: "reasoning"; text: string; redacted: boolean };
+
+const REDACTED_OPEN = "<" + "redacted_thinking" + ">";
+const REDACTED_CLOSE = "<" + "/redacted_thinking" + ">";
+const THINK_OPEN = "\u003cthink\u003e";
+const THINK_CLOSE = "\u003c/think\u003e";
+
+const OPEN_TAGS = [
+	{ open: REDACTED_OPEN, close: REDACTED_CLOSE, redacted: true },
+	{ open: THINK_OPEN, close: THINK_CLOSE, redacted: false },
+] as const;
+
+const MAX_PARTIAL_PREFIX = Math.max(
+	...OPEN_TAGS.flatMap((tag) => [tag.open.length, tag.close.length]),
+);
+
+type ParseMode = "text" | "reasoning";
+
+function suffixPartialTagLength(buffer: string, tags: readonly string[]): number {
+	let hold = 0;
+	const maxLen = Math.min(buffer.length, MAX_PARTIAL_PREFIX);
+	for (let len = 1; len <= maxLen; len++) {
+		const suffix = buffer.slice(-len);
+		if (tags.some((tag) => tag.startsWith(suffix))) {
+			hold = len;
+		}
+	}
+	return hold;
+}
+
+function findEarliestOpenTag(buffer: string):
+	| {
+			index: number;
+			open: string;
+			close: string;
+			redacted: boolean;
+	  }
+	| undefined {
+	let earliest:
+		| {
+				index: number;
+				open: string;
+				close: string;
+				redacted: boolean;
+		  }
+		| undefined;
+
+	for (const tag of OPEN_TAGS) {
+		const index = buffer.indexOf(tag.open);
+		if (index === -1) {
+			continue;
+		}
+		if (!earliest || index < earliest.index) {
+			earliest = {
+				index,
+				open: tag.open,
+				close: tag.close,
+				redacted: tag.redacted,
+			};
+		}
+	}
+
+	return earliest;
+}
+
+export class EmbeddedReasoningTagParser {
+	private buffer = "";
+	private mode: ParseMode = "text";
+	private activeCloseTag: string | undefined;
+	private activeRedacted = false;
+
+	push(chunk: string): EmbeddedReasoningChunk[] {
+		if (!chunk) {
+			return [];
+		}
+		this.buffer += chunk;
+		return this.drain();
+	}
+
+	flush(): EmbeddedReasoningChunk[] {
+		if (!this.buffer) {
+			return [];
+		}
+		const trailing = this.buffer;
+		this.buffer = "";
+		if (this.mode === "text") {
+			return trailing ? [{ kind: "text", text: trailing }] : [];
+		}
+		return [
+			{
+				kind: "reasoning",
+				text: trailing,
+				redacted: this.activeRedacted,
+			},
+		];
+	}
+
+	private drain(): EmbeddedReasoningChunk[] {
+		const out: EmbeddedReasoningChunk[] = [];
+
+		while (this.buffer.length > 0) {
+			if (this.mode === "text") {
+				const openTag = findEarliestOpenTag(this.buffer);
+				if (!openTag) {
+					const hold = suffixPartialTagLength(
+						this.buffer,
+						OPEN_TAGS.map((tag) => tag.open),
+					);
+					const emitLength = this.buffer.length - hold;
+					if (emitLength === 0) {
+						break;
+					}
+					out.push({
+						kind: "text",
+						text: this.buffer.slice(0, emitLength),
+					});
+					this.buffer = this.buffer.slice(emitLength);
+					continue;
+				}
+
+				if (openTag.index > 0) {
+					out.push({
+						kind: "text",
+						text: this.buffer.slice(0, openTag.index),
+					});
+					this.buffer = this.buffer.slice(openTag.index);
+				}
+
+				if (!this.buffer.startsWith(openTag.open)) {
+					break;
+				}
+
+				this.buffer = this.buffer.slice(openTag.open.length);
+				this.mode = "reasoning";
+				this.activeCloseTag = openTag.close;
+				this.activeRedacted = openTag.redacted;
+				continue;
+			}
+
+			const closeIndex = this.activeCloseTag
+				? this.buffer.indexOf(this.activeCloseTag)
+				: -1;
+			if (closeIndex === -1) {
+				const hold = suffixPartialTagLength(
+					this.buffer,
+					this.activeCloseTag ? [this.activeCloseTag] : [],
+				);
+				const emitLength = this.buffer.length - hold;
+				if (emitLength === 0) {
+					break;
+				}
+				out.push({
+					kind: "reasoning",
+					text: this.buffer.slice(0, emitLength),
+					redacted: this.activeRedacted,
+				});
+				this.buffer = this.buffer.slice(emitLength);
+				continue;
+			}
+
+			if (closeIndex > 0) {
+				out.push({
+					kind: "reasoning",
+					text: this.buffer.slice(0, closeIndex),
+					redacted: this.activeRedacted,
+				});
+				this.buffer = this.buffer.slice(closeIndex);
+			}
+
+			if (
+				!this.activeCloseTag ||
+				!this.buffer.startsWith(this.activeCloseTag)
+			) {
+				break;
+			}
+
+			this.buffer = this.buffer.slice(this.activeCloseTag.length);
+			this.mode = "text";
+			this.activeCloseTag = undefined;
+			this.activeRedacted = false;
+		}
+
+		return out;
+	}
+}
+
+export function shouldStripEmbeddedReasoningTags(
+	providerId: string,
+	modelId: string,
+): boolean {
+	if (providerId !== "openai-compatible") {
+		return false;
+	}
+	const normalized = modelId.trim().toLowerCase();
+	return normalized.includes("minimax");
+}
+
+/** @internal Exported for tests. */
+export function __testing__suffixPartialTagLength(
+	buffer: string,
+	tags: readonly string[],
+): number {
+	return suffixPartialTagLength(buffer, tags);
+}


### PR DESCRIPTION
## Summary

Strip embedded `<think>` / ` tags from MiniMax model output when used via the OpenAI-compatible provider, and route that content to `reasoning-delta` events instead of visible assistant text.

## Motivation

Fixes #9880

When MiniMax M2.7 is configured as an OpenAI-compatible provider, reasoning tokens arrive inside plain `content` deltas wrapped in XML-like tags. The generic handler forwards them as `text-delta`, so users see literal `<think>` labels in the UI. The native MiniMax provider already handles reasoning correctly; this brings openai-compatible mode to parity for MiniMax models.

## Changes

- Add `EmbeddedReasoningTagParser` with streaming-safe tag detection and partial-prefix holdback
- Enable parsing only for `openai-compatible` provider + MiniMax model IDs
- Integrate in `emitAiSdkEvents` for both `fullStream` and `textStream`, with end-of-stream flush
- Emit `reasoning-delta` with `redacted: true` for `<think>` blocks

## Tests

```bash
cd sdk/packages/llms && bun test src/providers/middleware/strip-embedded-reasoning-tags.test.ts
cd sdk/packages/llms && bun run typecheck
```

- 9 unit tests pass
- typecheck passes

## Notes

- Scoped to MiniMax on openai-compatible to avoid parsing tag-like text from unrelated models
- composer-2.5 review: **APPROVE**
- Maintainer workaround (use native MiniMax provider) remains valid; this fixes the openai-compatible path described in the issue thread