### PR TITLE
fix(sdk): disable bash tool in plan mode to prevent destructive operations

### DIFF
--- a/sdk/packages/core/src/extensions/tools/presets.ts
+++ b/sdk/packages/core/src/extensions/tools/presets.ts
@@ -43,7 +43,7 @@ export const ToolPresets = {
 	plan: {
 		enableReadFiles: true,
 		enableSearch: true,
-		enableBash: true,
+		enableBash: false,
 		enableWebFetch: true,
 		enableApplyPatch: false,
 		enableEditor: false,


### PR DESCRIPTION
## Summary

Plan mode's tool preset had `enableBash: true` despite the doc comment saying "no shell access". The only enforcement was a system prompt instruction telling the model not to run destructive commands — which the model can ignore, as reported in #12021.

With `enableBash: true` the model could execute shell commands like `rm`, `mv`, `dd`, etc. in plan mode, bypassing the intent that plan mode should be read-only.

## Fix

Changed `enableBash: true` → `enableBash: false` in the `plan` tool preset (`sdk/packages/core/src/extensions/tools/presets.ts:46`).

The model still has access to:
- `read_files`, `search_codebase` — for code analysis
- `web_fetch` — for research
- `ask_question` — for clarification
- `switch_to_act_mode` — to explicitly opt into write/execution mode

## Test plan

- All 6 presets tests pass.
- All 56 definitions tests pass.
- All 17 bash executor tests pass.
- The pre-existing 2 failures in `provider-defaults.test.ts` are GPT model metadata issues unrelated to this change.

Fixes #12021