### PR TITLE
fix: add API Key field to LM Studio provider for authenticated servers

### DIFF
--- a/apps/vscode/webview-ui/src/components/settings/providers/LMStudioProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/LMStudioProvider.tsx
@@ -8,10 +8,12 @@ import { useExtensionState } from "@/context/ExtensionStateContext"
 import { useProviderConfig } from "@/hooks/useProviderConfig"
 import { useProviderModelSelection } from "@/hooks/useProviderModelSelection"
 import { ModelsServiceClient } from "@/services/grpc-client"
+import { ApiKeyField } from "../common/ApiKeyField"
 import { BaseUrlField } from "../common/BaseUrlField"
 import { DebouncedTextField } from "../common/DebouncedTextField"
 import { DropdownContainer } from "../common/ModelSelector"
 import { useApiConfigurationHandlers } from "../utils/useApiConfigurationHandlers"
+import { useProviderApiKeyField } from "../utils/useProviderApiKeyField"
 
 /**
  * Props for the LMStudioProvider component
@@ -85,6 +87,12 @@ export const LMStudioProvider = ({ currentMode }: LMStudioProviderProps) => {
 		[write],
 	)
 
+	const { savedApiKeyMask, handleApiKeyChange } = useProviderApiKeyField({
+		apiKeyLength: config?.apiKeyLength,
+		providerName: "LM Studio",
+		write,
+	})
+
 	const handleModelChange = useCallback(
 		(modelId: string) => {
 			const trimmedModelId = modelId.trim()
@@ -151,6 +159,14 @@ export const LMStudioProvider = ({ currentMode }: LMStudioProviderProps) => {
 
 	return (
 		<div className="flex flex-col gap-2">
+			<ApiKeyField
+				initialValue={savedApiKeyMask || ""}
+				onChange={handleApiKeyChange}
+				providerName="LM Studio"
+				placeholder="Enter API key (required if LM Studio has auth enabled)"
+				helpText="Required if your LM Studio server has authentication enabled. This key is stored locally."
+			/>
+
 			<BaseUrlField
 				initialValue={config?.baseUrl ?? apiConfiguration?.lmStudioBaseUrl}
 				label="Use custom base URL"


### PR DESCRIPTION
## Summary

LM Studio can enable authentication (`Require Authentication` in Server settings), but the LM Studio provider settings in Cline had no API key input field. Users had to work around this by switching to the "OpenAI Compatible" provider or disabling auth on LM Studio.

## Changes

Added an `ApiKeyField` component to the LM Studio provider settings, following the same pattern as XAI, ZAI, and other providers:

- **`useProviderApiKeyField` hook** — provides masked input + persistence via `write({ apiKey })`
- **`ApiKeyField` component** — password field with help text, placed before the Base URL field
- The key is stored **provider-scoped** (not global `apiConfiguration`)

## UI

```
API Key:     [Enter API key (required if LM Studio has auth enabled)___]
Base URL:    [http://localhost:1234/v1                                     ]
Model:       [dropdown...                                                    ]
```

## Testing

- API key field appears in LM Studio provider settings
- Key is persisted via the provider-scoped config system
- Saved key length is masked on re-render (same pattern as other providers)
- Leaves `apiKeyEnv: ["LMSTUDIO_API_KEY"]` in `builtins.ts` intact for server-side env var support

Closes #9668