### PR TITLE
fix(sdk): make MCP server initialize timeout configurable

### DIFF
--- a/sdk/packages/core/src/extensions/mcp/client.test.ts
+++ b/sdk/packages/core/src/extensions/mcp/client.test.ts
@@ -1,0 +1,62 @@
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { spawnMock } = vi.hoisted(() => ({ spawnMock: vi.fn() }));
+
+vi.mock("node:child_process", async (importOriginal) => ({
+	...(await importOriginal<typeof import("node:child_process")>()),
+	spawn: spawnMock,
+}));
+
+vi.mock("./oauth", () => ({
+	createMcpOAuthProviderContext: vi.fn(),
+	createMcpSdkTransport: vi.fn(),
+}));
+
+import { createDefaultMcpServerClientFactory } from "./client";
+
+function createChildProcess(): ChildProcessWithoutNullStreams {
+	const child = new EventEmitter() as ChildProcessWithoutNullStreams;
+	Object.assign(child, {
+		stdin: new PassThrough(),
+		stdout: new PassThrough(),
+		stderr: new PassThrough(),
+		kill: vi.fn(() => true),
+	});
+	return child;
+}
+
+describe("stdio mcp client", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+		spawnMock.mockReset();
+	});
+
+	it("uses the configured initialize timeout for each protocol attempt", async () => {
+		vi.useFakeTimers();
+		spawnMock.mockImplementation(createChildProcess);
+		const client = await createDefaultMcpServerClientFactory()({
+			name: "slow-server",
+			transport: { type: "stdio", command: "slow-server" },
+			initializeTimeoutMs: 250,
+		});
+
+		const connection = client.connect();
+		const result = connection.catch((error: unknown) => error);
+		await vi.advanceTimersByTimeAsync(0);
+		expect(spawnMock).toHaveBeenCalledTimes(1);
+
+		await vi.advanceTimersByTimeAsync(249);
+		expect(spawnMock).toHaveBeenCalledTimes(1);
+
+		await vi.advanceTimersByTimeAsync(1);
+		expect(spawnMock).toHaveBeenCalledTimes(2);
+
+		await vi.advanceTimersByTimeAsync(250);
+		expect(await result).toEqual(
+			new Error('MCP request timed out for "slow-server" (initialize).'),
+		);
+	});
+});

--- a/sdk/packages/core/src/extensions/mcp/client.ts
+++ b/sdk/packages/core/src/extensions/mcp/client.ts
@@ -172,7 +172,7 @@ class StdioMcpClient implements McpServerClient {
 							version: "0.0.0",
 						},
 					},
-					MCP_CONNECT_TIMEOUT_MS,
+					this.registration.initializeTimeoutMs ?? MCP_CONNECT_TIMEOUT_MS,
 				);
 				this.notify("notifications/initialized");
 				this.connected = true;

--- a/sdk/packages/core/src/extensions/mcp/config-loader.test.ts
+++ b/sdk/packages/core/src/extensions/mcp/config-loader.test.ts
@@ -16,13 +16,13 @@ import {
 	hasMcpSettingsFile,
 	listMcpServerOAuthStatuses,
 	loadMcpSettingsFile,
+	McpSettingsMutatorPurityError,
 	registerMcpServersFromSettingsFile,
 	resolveMcpServerRegistrations,
 	setMcpServerDisabled,
 	updateMcpServerOAuthState,
 	updateMcpSettingsFile,
 	updateMcpSettingsFileSync,
-	McpSettingsMutatorPurityError,
 } from "./config-loader";
 
 describe("mcp config loader", () => {
@@ -52,6 +52,7 @@ describe("mcp config loader", () => {
 								command: "npx",
 								args: ["-y", "@modelcontextprotocol/server-filesystem"],
 							},
+							initializeTimeoutMs: 2_500,
 						},
 						search: {
 							transport: {
@@ -85,6 +86,7 @@ describe("mcp config loader", () => {
 				disabled: undefined,
 				metadata: undefined,
 				oauth: undefined,
+				initializeTimeoutMs: 2_500,
 			},
 			{
 				name: "search",
@@ -95,8 +97,31 @@ describe("mcp config loader", () => {
 				disabled: true,
 				metadata: undefined,
 				oauth: undefined,
+				initializeTimeoutMs: undefined,
 			},
 		]);
+	});
+
+	it("rejects initialize timeouts below 100ms", async () => {
+		const tempRoot = await mkdtemp(join(tmpdir(), "core-mcp-config-loader-"));
+		tempRoots.push(tempRoot);
+		const filePath = join(tempRoot, "cline_mcp_settings.json");
+		await writeFile(
+			filePath,
+			JSON.stringify({
+				mcpServers: {
+					docs: {
+						transport: { type: "stdio", command: "npx" },
+						initializeTimeoutMs: 99,
+					},
+				},
+			}),
+			"utf8",
+		);
+
+		expect(() => loadMcpSettingsFile({ filePath })).toThrow(
+			/initializeTimeoutMs/,
+		);
 	});
 
 	it("registers loaded servers with an mcp manager", async () => {

--- a/sdk/packages/core/src/extensions/mcp/config-loader.ts
+++ b/sdk/packages/core/src/extensions/mcp/config-loader.ts
@@ -67,6 +67,7 @@ const nestedRegistrationBodySchema = z.object({
 	disabled: z.boolean().optional(),
 	metadata: metadataSchema.optional(),
 	oauth: oauthStateSchema.optional(),
+	initializeTimeoutMs: z.number().int().min(100).optional(),
 });
 
 const legacyTransportTypeSchema = z
@@ -79,6 +80,7 @@ const legacyRegistrationBaseSchema = z.object({
 	disabled: z.boolean().optional(),
 	metadata: metadataSchema.optional(),
 	oauth: oauthStateSchema.optional(),
+	initializeTimeoutMs: z.number().int().min(100).optional(),
 });
 
 function mapLegacyTransportType(
@@ -122,6 +124,7 @@ const legacyStdioRegistrationSchema = legacyRegistrationBaseSchema
 		disabled: value.disabled,
 		metadata: value.metadata,
 		oauth: value.oauth,
+		initializeTimeoutMs: value.initializeTimeoutMs,
 	}));
 
 const legacyUrlRegistrationSchema = legacyRegistrationBaseSchema
@@ -154,6 +157,7 @@ const legacyUrlRegistrationSchema = legacyRegistrationBaseSchema
 				disabled: value.disabled,
 				metadata: value.metadata,
 				oauth: value.oauth,
+				initializeTimeoutMs: value.initializeTimeoutMs,
 			};
 		}
 		return {
@@ -165,6 +169,7 @@ const legacyUrlRegistrationSchema = legacyRegistrationBaseSchema
 			disabled: value.disabled,
 			metadata: value.metadata,
 			oauth: value.oauth,
+			initializeTimeoutMs: value.initializeTimeoutMs,
 		};
 	});
 
@@ -686,6 +691,7 @@ export function resolveMcpServerRegistrations(
 		disabled: value.disabled,
 		metadata: value.metadata,
 		oauth: value.oauth,
+		initializeTimeoutMs: value.initializeTimeoutMs,
 	}));
 }
 

--- a/sdk/packages/core/src/extensions/mcp/types.ts
+++ b/sdk/packages/core/src/extensions/mcp/types.ts
@@ -77,6 +77,7 @@ export interface McpServerRegistration {
 	disabled?: boolean;
 	metadata?: Record<string, unknown>;
 	oauth?: McpServerOAuthState;
+	/** Timeout for each stdio initialize attempt. Newline and framed modes are attempted separately. */
 	initializeTimeoutMs?: number;
 }
 

--- a/sdk/packages/core/src/extensions/mcp/types.ts
+++ b/sdk/packages/core/src/extensions/mcp/types.ts
@@ -77,6 +77,7 @@ export interface McpServerRegistration {
 	disabled?: boolean;
 	metadata?: Record<string, unknown>;
 	oauth?: McpServerOAuthState;
+	initializeTimeoutMs?: number;
 }
 
 export interface McpServerSnapshot {


### PR DESCRIPTION
## Summary

MCP server initialize handshake timeout was hardcoded to 1500ms in `StdioMcpClient`. On slower machines or under load, this is insufficient and MCP servers fail with `initialize timed out`.

## Fix

Added optional `initializeTimeoutMs` field to `McpServerRegistration` with a minimum of 100ms. Falls back to the existing 1500ms default when not specified.

Users can now configure per-server:

```json
{ "mcpServers": { "my-server": { "transport": {...}, "initializeTimeoutMs": 5000 } } }
```

### Files changed
- `sdk/packages/core/src/extensions/mcp/types.ts` — added field to interface
- `sdk/packages/core/src/extensions/mcp/config-loader.ts` — added to all 3 config schema paths (nested, legacy stdio, legacy URL)
- `sdk/packages/core/src/extensions/mcp/client.ts` — use registration timeout in StdioMcpClient.connect()

### Code validation
- Builds clean (`bun run build:sdk`)
- All MCP tests pass (manager, plugin-server-registration, name-transform)
- No breaking change — defaults to 1500ms when not specified

Fixes #12044