### PR TITLE
fix(agents): surface clear error when model exhausts token budget with no output

### DIFF
--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -619,6 +619,11 @@ export class AgentRuntime {
 					throw this.normalizeAbortError();
 				}
 				if (message.content.length === 0) {
+					if (finishReason === "max-tokens") {
+						throw new Error(
+							"Model reached its token limit before generating a response. Consider increasing the output token limit.",
+						)
+					}
 					throw new Error(
 						finishReason === "error"
 							? (this.state.lastError ?? "Model stream failed")


### PR DESCRIPTION
## Summary

When a reasoning model like `zai-glm-4.7` (used via Cerebras/OpenRouter) spends its entire token budget on reasoning tokens, the API returns `finish_reason: "length"` with empty `content` — the model produced reasoning but no final text.

Previously the agent-runtime threw `"Model returned empty response"` with no indication that it was a token budget issue. This generic message gets treated as a connection error by the VSCode extension, showing the misleading "Connection error" reported in #12018.

## Fix

In `agent-runtime.ts`, added a specific check: when `finishReason === "max-tokens"` (mapped from API's `finish_reason: "length"`) and content is empty, the error message now explains the real cause:

> "Model reached its token limit before generating a response. Consider increasing the output token limit."

## Test

All 46 `@cline/agents` tests pass, including 38 agent-runtime tests.

Fixes #12018