### PR TITLE
Remove Cline model picker recommendation copy

### DIFF
--- a/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.tsx
@@ -598,8 +598,7 @@ const ClineModelPicker: React.FC<ClineModelPickerProps> = ({ isPopup, currentMod
 						marginTop: 0,
 						color: "var(--vscode-descriptionForeground)",
 					}}>
-					The extension automatically fetches the latest Cline model list. If you're unsure which model to choose,
-					compare available models by context window, pricing, and capabilities.
+					The extension automatically fetches the latest Cline model list.
 				</p>
 			)}
 		</div>


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Removes the extra fallback advice sentence from the Cline model picker when a typed model does not have catalog info.

On `main`, this removes the remaining model-selection advice sentence so the fallback copy only states that the latest Cline model list is fetched automatically.

### Test Procedure

Ran targeted Biome lint from `apps/vscode`:

`bunx --bun @biomejs/biome lint --config-path ./biome.jsonc webview-ui/src/components/settings/ClineModelPicker.tsx --files-ignore-unknown=true --diagnostic-level=error`

Full package lint was not run; the workspace `webview-ui` lint script could not find the direct `biome` executable in this checkout, so the same file was checked through `bunx` with the VS Code app Biome config.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not included; this is a copy-only fallback text change.

### Additional Notes

None.
