### PR TITLE
Update ClinePass model ordering

### DIFF
--- a/apps/vscode/src/core/controller/models/__tests__/refreshClineRecommendedModels.test.ts
+++ b/apps/vscode/src/core/controller/models/__tests__/refreshClineRecommendedModels.test.ts
@@ -11,6 +11,19 @@ import {
 	resetClineRecommendedModelsCacheForTests,
 } from "../refreshClineRecommendedModels";
 
+const expectedClinePassModelOrder = [
+	"cline-pass/glm-5.2",
+	"cline-pass/deepseek-v4-pro",
+	"cline-pass/deepseek-v4-flash",
+	"cline-pass/kimi-k2.7-code",
+	"cline-pass/kimi-k2.6",
+	"cline-pass/mimo-v2.5-pro",
+	"cline-pass/mimo-v2.5",
+	"cline-pass/minimax-m3",
+	"cline-pass/qwen3.7-max",
+	"cline-pass/qwen3.7-plus",
+] as const;
+
 describe("refreshClineRecommendedModels", () => {
 	let sandbox: sinon.SinonSandbox;
 
@@ -126,6 +139,41 @@ describe("refreshClineRecommendedModels", () => {
 
 		expect(axiosGetStub.calledOnce).to.equal(true);
 		expect(secondResult).to.deep.equal(firstResult);
+	});
+
+	it("orders ClinePass models using the curated display order", async () => {
+		sandbox.stub(ClineEnv, "config").returns({
+			environment: Environment.production,
+			appBaseUrl: "https://app.cline-mock.bot",
+			apiBaseUrl: "https://api.cline-mock.bot",
+			mcpBaseUrl: "https://api.cline-mock.bot/v1/mcp",
+		});
+		sandbox.stub(disk, "ensureCacheDirectoryExists").resolves("/tmp");
+		sandbox.stub(fs, "writeFile").resolves();
+		sandbox.stub(axios, "get").resolves({
+			data: {
+				clinePass: [
+					{ id: "cline-pass/qwen3.7-plus" },
+					{ id: "cline-pass/new-model" },
+					{ id: "cline-pass/deepseek-v4-flash" },
+					{ id: "cline-pass/glm-5.2" },
+					{ id: "cline-pass/qwen3.7-max" },
+					{ id: "cline-pass/deepseek-v4-pro" },
+					{ id: "cline-pass/minimax-m3" },
+					{ id: "cline-pass/kimi-k2.6" },
+					{ id: "cline-pass/mimo-v2.5" },
+					{ id: "cline-pass/mimo-v2.5-pro" },
+					{ id: "cline-pass/kimi-k2.7-code" },
+				],
+			},
+		});
+
+		const result = await refreshClineRecommendedModels();
+
+		expect(result.clinePass.map((model) => model.id)).to.deep.equal([
+			...expectedClinePassModelOrder,
+			"cline-pass/new-model",
+		]);
 	});
 
 	it("normalizes Cline provider Z.ai recommended IDs to the Cline API alias", async () => {

--- a/apps/vscode/src/core/controller/models/refreshClineRecommendedModels.ts
+++ b/apps/vscode/src/core/controller/models/refreshClineRecommendedModels.ts
@@ -26,6 +26,21 @@ const RECOMMENDED_MODELS_CACHE_TTL_MS = 60 * 60 * 1000;
 const CLINE_PASS_MODEL_ID_ALIAS_RULES = [
 	{ canonicalPrefix: "cline-pass/zai/", aliasPrefix: "cline-pass/z-ai/" },
 ] as const;
+const CLINE_PASS_MODEL_ORDER = [
+	"cline-pass/glm-5.2",
+	"cline-pass/deepseek-v4-pro",
+	"cline-pass/deepseek-v4-flash",
+	"cline-pass/kimi-k2.7-code",
+	"cline-pass/kimi-k2.6",
+	"cline-pass/mimo-v2.5-pro",
+	"cline-pass/mimo-v2.5",
+	"cline-pass/minimax-m3",
+	"cline-pass/qwen3.7-max",
+	"cline-pass/qwen3.7-plus",
+] as const;
+const CLINE_PASS_MODEL_ORDER_INDEX = new Map<string, number>(
+	CLINE_PASS_MODEL_ORDER.map((modelId, index) => [modelId, index]),
+);
 
 function normalizeClineProviderRecommendedModelId(modelId: string): string {
 	const zaiPrefix = "zai/";
@@ -72,6 +87,18 @@ function preferCanonicalRecommendedModels(
 		}
 
 		return true;
+	});
+}
+
+function orderClinePassRecommendedModels(
+	models: ClineRecommendedModelData[],
+): ClineRecommendedModelData[] {
+	return [...models].sort((a, b) => {
+		const aIndex =
+			CLINE_PASS_MODEL_ORDER_INDEX.get(a.id) ?? Number.MAX_SAFE_INTEGER;
+		const bIndex =
+			CLINE_PASS_MODEL_ORDER_INDEX.get(b.id) ?? Number.MAX_SAFE_INTEGER;
+		return aIndex - bIndex;
 	});
 }
 
@@ -137,7 +164,9 @@ function normalizeRecommendedModelsResponse(
 	return {
 		recommended: normalizeClineProviderRecommendedModels(recommended),
 		free: normalizeClineProviderRecommendedModels(free),
-		clinePass: preferCanonicalRecommendedModels(clinePass),
+		clinePass: orderClinePassRecommendedModels(
+			preferCanonicalRecommendedModels(clinePass),
+		),
 	};
 }
 


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Updates the legacy extension's ClinePass recommended-model normalization so the `clinePass` list from `/api/v1/ai/cline/recommended-models` is displayed in this order:

glm5.2, DeepSeek V4 Pro, DeepSeek V4 Flash, Kimi K2.7 Code, Kimi K2.6, MiMo V2.5 Pro, MiMo V2.5, MiniMax M3, Qwen 3.7 Max, Qwen 3.7 Plus.

Unknown future ClinePass model IDs are kept after the curated list in their original API order.

### Test Procedure

- Ran `node node_modules/typescript/bin/tsc --noEmit --project tsconfig.unit-test.json` in `apps/vscode`.
- Ran `git diff --check`.
- Ran a direct `ts-node` smoke test through `refreshClineRecommendedModels` with a shuffled ClinePass payload and verified the normalized order.
- Attempted the focused Mocha command, but this worktree's Mocha/Node loader path did not resolve TS path aliases for `@core/*`; the targeted TypeScript check and direct module smoke test passed.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

The PR targets the `legacy-extension` branch.
