### PR TITLE
fix(vscode): update ClinePass onboarding option copy

### DIFF
--- a/apps/vscode/webview-ui/src/components/onboarding/OnboardingView.tsx
+++ b/apps/vscode/webview-ui/src/components/onboarding/OnboardingView.tsx
@@ -1,5 +1,7 @@
 import { buildModelInfoNameMap, type ModelInfo, openAiModelInfoSafeDefaults, resolveClinePassModelInfo } from "@shared/api"
+import { StringRequest } from "@shared/proto/cline/common"
 import type { OnboardingModel, OnboardingModelGroup, OpenRouterModelInfo } from "@shared/proto/index.cline"
+import { VSCodeLink } from "@vscode/webview-ui-toolkit/react"
 import { AlertCircleIcon, CircleCheckIcon, CircleIcon, ListIcon, LoaderCircleIcon, ZapIcon } from "lucide-react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import ClineLogoWhite from "@/assets/ClineLogoWhite"
@@ -13,7 +15,7 @@ import { useHasFeatureFlag } from "@/hooks/useFeatureFlag"
 import { useProviderConfig } from "@/hooks/useProviderConfig"
 import { useProviderModels } from "@/hooks/useProviderModels"
 import { cn } from "@/lib/utils"
-import { AccountServiceClient, StateServiceClient } from "@/services/grpc-client"
+import { AccountServiceClient, StateServiceClient, UiServiceClient } from "@/services/grpc-client"
 import ApiConfigurationSection from "../settings/sections/ApiConfigurationSection"
 import { useApiConfigurationHandlers } from "../settings/utils/useApiConfigurationHandlers"
 import WelcomeView from "../welcome/WelcomeView"
@@ -272,7 +274,25 @@ const UserTypeSelectionStep = ({ userType, onSelectUserType, userTypeSelections 
 						</ItemMedia>
 						<ItemContent className="w-full">
 							<ItemTitle>{option.title}</ItemTitle>
-							<ItemDescription>{option.description}</ItemDescription>
+							<ItemDescription>
+								{option.description}
+								{option.learnMoreUrl && (
+									<>
+										{" "}
+										<VSCodeLink
+											className="inline"
+											style={{ fontSize: "inherit" }}
+											onClick={(e) => {
+												e.stopPropagation()
+												UiServiceClient.openUrl(
+													StringRequest.create({ value: option.learnMoreUrl }),
+												).catch((err) => console.error("Failed to open learn more link:", err))
+											}}>
+											Learn more
+										</VSCodeLink>
+									</>
+								)}
+							</ItemDescription>
 						</ItemContent>
 					</Item>
 				)

--- a/apps/vscode/webview-ui/src/components/onboarding/data-steps.ts
+++ b/apps/vscode/webview-ui/src/components/onboarding/data-steps.ts
@@ -9,6 +9,7 @@ type UserTypeSelection = {
 	title: string
 	description: string
 	type: NEW_USER_TYPE
+	learnMoreUrl?: string
 }
 
 export const STEP_CONFIG = {
@@ -56,9 +57,10 @@ export const STEP_CONFIG = {
 } as const
 
 const CLINE_PASS_USER_TYPE_SELECTION: UserTypeSelection = {
-	title: "ClinePass (Recommended)",
-	description: "One subscription, curated models, no API keys",
+	title: "ClinePass",
+	description: "Low cost subscription plan for best open weights model.",
 	type: NEW_USER_TYPE.CLINE_PASS,
+	learnMoreUrl: "https://docs.cline.bot/getting-started/clinepass",
 }
 
 const BASE_USER_TYPE_SELECTIONS: UserTypeSelection[] = [


### PR DESCRIPTION
### Related Issue

N/A — copy change requested internally. Main-branch port of #12167 (same change on `legacy-extension`).

### Description

Updates the ClinePass option on the first onboarding screen ("How will you use Cline?"):

- **Removes the "(Recommended)" suffix** from the ClinePass option title — it now reads just "ClinePass".
- **Replaces the description copy**: "One subscription, curated models, no API keys" → "Low cost subscription plan for best open weights model."
- **Adds a "Learn more" link** after the description pointing to https://docs.cline.bot/getting-started/clinepass.

Implementation notes (same approach as #12167):

- The onboarding option data in `data-steps.ts` only supports plain-string descriptions, so this adds an optional `learnMoreUrl` field to `UserTypeSelection`; `OnboardingView.tsx` renders a `VSCodeLink` after the description whenever the field is present.
- The link opens the browser through `UiServiceClient.openUrl(StringRequest...)` — the same extension-host RPC pattern used by `clinePassSubscribe.ts` in the same directory and the welcome banner links — rather than a raw `href`, so it reliably opens externally via `vscode.env.openExternal`.
- `e.stopPropagation()` on the link click prevents it from also toggling the option selection underneath.
- `className="inline"` + `style={{ fontSize: "inherit" }}` keeps the link inline and matches `ItemDescription`'s `text-sm` size instead of the toolkit's default type ramp (same pattern as `OpenRouterModelPicker`'s inline links). No `text-inherit`, so the link keeps the standard `--vscode-textLink-foreground` color rather than the muted description gray.

The ClinePass option only appears when ClinePass models are available (`getUserTypeSelections(hasClinePassModels)`); the fallback Free / Frontier / BYOK list is untouched.

### Test Procedure

- `npx tsc -b` in `apps/vscode/webview-ui` — clean (after regenerating protos with `node scripts/build-proto.mjs`).
- `npx vitest run src/components/onboarding` — all 9 tests pass (`data-steps.test.ts` asserts on option types/order, not title text, so no updates needed).
- `npx biome check` on the onboarding directory — the only hit is a pre-existing `useExhaustiveDependencies` warning on `finishOnboarding` (line 447), unrelated to this diff.

### Type of Change

-   [x] 💅 Cosmetic Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

Counterpart to #12167, which ships the identical change on the `legacy-extension` shipping line. The two branches' onboarding files had drifted slightly (the legacy patch didn't apply cleanly), so this was ported by hand with all three review fixes from that PR folded in (link color, `openUrl` RPC, font size).