### PR TITLE
fix(vscode): flush buffered OpenTelemetry events on shutdown and after identify

### DIFF
--- a/apps/vscode/src/common.ts
+++ b/apps/vscode/src/common.ts
@@ -153,7 +153,8 @@ async function checkWorktreeAutoOpen(stateManager: StateManager): Promise<void> 
 export async function tearDown(): Promise<void> {
 	AgentConfigLoader.getInstance()?.dispose()
 	PostHogClientProvider.getInstance().dispose()
-	telemetryService.dispose()
+	// Await so buffered OTel logs/metrics finish exporting before the host exits
+	await telemetryService.dispose()
 	ErrorService.get().dispose()
 	featureFlagsService.dispose()
 	// Dispose all webview instances

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -693,7 +693,7 @@ async function getBinaryLocation(name: string): Promise<string> {
 // This method is called when your extension is deactivated
 export async function deactivate() {
 	// Dispose Non-VSCode-specific services
-	tearDown()
+	await tearDown()
 
 	// VSCode-specific services
 	disposeVscodeCommentReviewController()

--- a/apps/vscode/src/services/telemetry/providers/opentelemetry/OpenTelemetryTelemetryProvider.ts
+++ b/apps/vscode/src/services/telemetry/providers/opentelemetry/OpenTelemetryTelemetryProvider.ts
@@ -164,6 +164,11 @@ export class OpenTelemetryTelemetryProvider implements ITelemetryProvider {
 
 			// Ensure distinct ID is updated so that we will not identify the user again
 			setDistinctId(userInfo.id)
+
+			// Flush immediately so the machine-id -> user-id link survives even if the
+			// extension host exits before the next batch export (common for brand-new
+			// users who sign up, run one task, and close the window).
+			this.forceFlush().catch((error) => Logger.error("[OTEL] Failed to flush after identify", error))
 		}
 	}
 
@@ -324,8 +329,11 @@ export class OpenTelemetryTelemetryProvider implements ITelemetryProvider {
 	}
 
 	public async dispose(): Promise<void> {
-		// OpenTelemetry client provider handles shutdown
-		// Individual providers don't need to do anything
+		// The OpenTelemetryClientProvider that created these providers is not retained
+		// anywhere, so this is the only place buffered logs/metrics can be flushed.
+		// Logs batch on a 5s timer and metrics export every 60s by default - without
+		// this shutdown, everything buffered since the last export is lost on exit.
+		await Promise.allSettled([this.meterProvider?.shutdown(), this.loggerProvider?.shutdown()])
 	}
 
 	/**


### PR DESCRIPTION
### Related Issue

Internal investigation (CLINE-2406 follow-up) — no public issue. Context: the ~50% gap between ClinePass billing users in the backend and their OTel telemetry footprint.

### Description

## Background: the honest read on the OTel-vs-backend gap

Backend usage data (source of truth) shows far more DAU/tokens than OTel — ~10% gap for usage-based billing users, ~50% for ClinePass users, with ~35% of ClinePass users on accounts under an hour old at first use and 99.5% of the zero-OTel cohort having no telemetry init record at all (i.e. not opt-out).

After auditing the full pipeline, the gap decomposes into four independent holes; **this PR fixes the one that lives in the deployed legacy extension**:

1. Headless CLI telemetry is anonymous in every shipped CLI release (fix merged to main in #11581, ships in cli-v3.0.39) — not this PR.
2. The hub daemon process emits zero telemetry (SDK-side, fixed on main) — not this PR, doesn't affect the legacy extension, which runs its own in-process telemetry stack.
3. No machine-id → user-id bridge in the SDK (fixed on main). **The legacy extension already has its bridge**: `identifyUser` emits `user_identified` with an `alias` attribute every session (the distinct id is in-memory and resets to the machine id each activation, so the event re-fires on every auth restore). The dbt models just need to use it.
4. **The extension never flushes OTel on shutdown — this PR.**

Also confirmed but deliberately untouched: users with VS Code's `telemetry.telemetryLevel: "off"` are fully suppressed (including the init/status event) without registering as a Cline opt-out. That's the setting working as intended; that cohort is irreducibly dark client-side and should be handled as a coverage factor in dashboards, measured from the backend.

## The bug

OTel logs batch on a **5s timer** and metrics export every **60s** (`OpenTelemetryClientProvider`, `BatchLogRecordProcessor` config), and nothing ever flushed them at exit:

- `OpenTelemetryTelemetryProvider.dispose()` was a **no-op** ("client provider handles shutdown") — but the `OpenTelemetryClientProvider` that actually owns `shutdown()` is constructed and immediately discarded in `TelemetryProviderFactory.createProvider()`. Nothing retains it; its `dispose()` is unreachable.
- Even if it had done something, the promise was dropped at every level of the chain: `deactivate()` called `tearDown()` without await, and `tearDown()` called `telemetryService.dispose()` without await.

Net effect: everything buffered since the last export is lost when the extension host exits. For a long session that's the last few seconds of logs and up to a minute of metrics — a rounding error. For a **short session it can be the entire footprint**. That's exactly the profile of a brand-new ClinePass user: install → sign up → run one task on free models → close the window. If they don't come back (typical free-tier behavior), that lossy session is their *lifetime* OTel record, and joined by user id it rounds to zero — while their backend usage recorded normally. Same bug for everyone, wildly different exposure per cohort, which is a big part of why ClinePass reads ~50% dark while usage-based reads ~10%.

## The fix

Three small changes:

1. **`OpenTelemetryTelemetryProvider.dispose()` shuts down the meter/logger providers it already holds.** The provider instance keeps references to both (it needs them for `forceFlush()`), so no factory surgery is required — `shutdown()` flushes pending batches and terminates. `Promise.allSettled` so one failing provider can't block the other.
2. **The await chain is restored**: `tearDown()` awaits `telemetryService.dispose()` (which already `Promise.allSettled`s across providers), and `deactivate()` awaits `tearDown()`. VS Code gives deactivate a bounded window, and the OTLP exporters carry their own timeouts, so this can't hang shutdown indefinitely.
3. **`identifyUser` force-flushes right after emitting `user_identified`** (fire-and-forget with error logging). The sign-up moment is the single most valuable event for ClinePass attribution — it's the record that links the anonymous machine id to the account id — so it shouldn't sit in a batch buffer hoping deactivate runs cleanly.

No behavior change for the PostHog provider, opt-out handling, or the VS Code telemetry-level gating — this only makes already-captured OTel events actually reach the collector.

### Test Procedure

- `tsc --noEmit` passes for `apps/vscode`.
- Full mocha unit suite: **1527 passing** (includes `TelemetryService.test.ts`, `TelemetryService.metrics.test.ts`, `OpenTelemetryTelemetryProvider.test.ts`).
- Reviewed that `TelemetryService.dispose()` already `Promise.allSettled`s across providers, so a throwing provider can't wedge deactivate; exporter-level timeouts bound the flush.
- What could break: slower window close if the collector is unreachable — bounded by the OTLP exporter timeouts and VS Code's own deactivate deadline (it kills the host regardless, which is no worse than today's behavior of losing the events).

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing and code is formatted and linted
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — telemetry lifecycle change only.

### Additional Notes

- This should go out as a **legacy patch release (4.0.7)** — the deployed extension is what ~90% of users (and all current ClinePass extension users) run; landing this only on main would do nothing for the gap until the SDK migration ships. The identical fix is forward-ported to main's `apps/vscode` in the sister PR.
- Worth verifying alongside this: that the legacy publish workflow's `OTEL_TELEMETRY_ENABLED` / endpoint secrets are populated (the legacy branch has its own publish workflow; if a secret is empty, whole builds ship OTel-dark with no error — the same failure class that shipped cli 3.0.0–3.0.13 silently).
- For the data team: the `user_identified` event (with `alias` = machine id) already flows from this extension every session — bridging machine-id events to user ids in the dbt models is the measurement-side half of this fix.
