### PR TITLE
feat(vscode): add ClinePass limit error (legacy)

### DIFF
--- a/apps/vscode/src/core/task/index.ts
+++ b/apps/vscode/src/core/task/index.ts
@@ -2467,6 +2467,11 @@ export class Task {
 				const isOrgClinePassRestrictionError = clineError.isErrorType(
 					ClineErrorType.OrgClinePassRestriction,
 				);
+				// ClinePass period limits reset in hours/days — auto-retrying is
+				// pointless and only delays the actionable error UI.
+				const isClinePassLimitError = clineError.isErrorType(
+					ClineErrorType.ClinePassLimit,
+				);
 
 				// Check if this is a Cline provider insufficient credits error - don't auto-retry these
 				const isClineProviderInsufficientCredits = (() => {
@@ -2494,6 +2499,7 @@ export class Task {
 					!quotaExceeded &&
 					!isEntitlementError &&
 					!isOrgClinePassRestrictionError &&
+					!isClinePassLimitError &&
 					this.taskState.autoRetryAttempts < 3;
 				if (shouldRetry) {
 					// Auto-retry enabled with max 3 attempts: automatically approve the retry
@@ -2557,7 +2563,8 @@ export class Task {
 						!isSpendLimitError &&
 						!quotaExceeded &&
 						!isEntitlementError &&
-						!isOrgClinePassRestrictionError;
+						!isOrgClinePassRestrictionError &&
+						!isClinePassLimitError;
 					if (showRetry) {
 						await this.say(
 							"error_retry",

--- a/apps/vscode/src/services/error/ClineError.ts
+++ b/apps/vscode/src/services/error/ClineError.ts
@@ -249,8 +249,8 @@ export class ClineError extends Error {
 		const detailMessage =
 			typeof details?.message === "string" ? details.message : undefined;
 		if (
-			(detailMessage ? isClinePassLimitMessage(detailMessage) : false) ||
-			(message ? isClinePassLimitMessage(message) : false)
+			isClinePassLimitMessage(detailMessage ?? "") ||
+			isClinePassLimitMessage(message ?? "")
 		) {
 			return ClineErrorType.ClinePassLimit;
 		}

--- a/apps/vscode/src/services/error/ClineError.ts
+++ b/apps/vscode/src/services/error/ClineError.ts
@@ -10,6 +10,7 @@ export enum ClineErrorType {
 	QuotaExceeded = "quotaExceeded",
 	Entitlement = "entitlement",
 	OrgClinePassRestriction = "orgClinePassRestriction",
+	ClinePassLimit = "clinePassLimit",
 }
 
 interface ErrorDetails {
@@ -56,6 +57,46 @@ const ORG_CLINE_PASS_RESTRICTION_MESSAGE =
 	"organization accounts cannot use individual model inference subscriptions";
 const ORG_CLINE_PASS_RESTRICTION_USER_MESSAGE =
 	"organization accounts cannot use clinepass subscriptions";
+
+// The ClinePass period limit message is dynamic ("weekly"/"5-hour" period, "7d"/"12h"
+// reset), so it is matched by its fixed prefix/suffix with the ClinePass marker in
+// between. Plain indexOf scanning — no regex, so no backtracking on hostile input.
+const CLINE_PASS_LIMIT_PREFIX = "you have reached your";
+const CLINE_PASS_LIMIT_MARKER = "clinepass limit";
+const CLINE_PASS_LIMIT_SUFFIX = "please try again later.";
+
+function findClinePassLimitMessageBounds(
+	text: string,
+): { start: number; end: number } | undefined {
+	const normalized = text.toLowerCase();
+	const start = normalized.indexOf(CLINE_PASS_LIMIT_PREFIX);
+	if (start === -1) {
+		return undefined;
+	}
+
+	const suffixStart = normalized.indexOf(CLINE_PASS_LIMIT_SUFFIX, start);
+	if (suffixStart === -1) {
+		return undefined;
+	}
+
+	const end = suffixStart + CLINE_PASS_LIMIT_SUFFIX.length;
+	if (!normalized.slice(start, end).includes(CLINE_PASS_LIMIT_MARKER)) {
+		return undefined;
+	}
+
+	return { start, end };
+}
+
+export function isClinePassLimitMessage(text: string): boolean {
+	return findClinePassLimitMessageBounds(text) !== undefined;
+}
+
+export function extractClinePassLimitMessage(
+	text: string,
+): string | undefined {
+	const bounds = findClinePassLimitMessageBounds(text);
+	return bounds ? text.slice(bounds.start, bounds.end) : undefined;
+}
 
 export class ClineError extends Error {
 	readonly title = "ClineError";
@@ -200,6 +241,18 @@ export class ClineError extends Error {
 			entitlementText.includes("not subscribed to required model plan")
 		) {
 			return ClineErrorType.Entitlement;
+		}
+
+		// ClinePass period limits (weekly/5-hour) are user-actionable (switch to
+		// usage-based billing) and must not fall through to the generic 403 auth
+		// handling below or the 429 rate-limit patterns.
+		const detailMessage =
+			typeof details?.message === "string" ? details.message : undefined;
+		if (
+			(detailMessage ? isClinePassLimitMessage(detailMessage) : false) ||
+			(message ? isClinePassLimitMessage(message) : false)
+		) {
+			return ClineErrorType.ClinePassLimit;
 		}
 
 		// Check auth errors

--- a/apps/vscode/src/services/error/__tests__/ClineError.test.ts
+++ b/apps/vscode/src/services/error/__tests__/ClineError.test.ts
@@ -1,6 +1,11 @@
 import { describe, it } from "mocha";
 import "should";
-import { ClineError, ClineErrorType } from "../ClineError";
+import {
+	ClineError,
+	ClineErrorType,
+	extractClinePassLimitMessage,
+	isClinePassLimitMessage,
+} from "../ClineError";
 
 describe("ClineError", () => {
 	describe("getErrorType", () => {
@@ -88,6 +93,75 @@ describe("ClineError", () => {
 
 			const result = ClineError.getErrorType(err);
 			(result !== ClineErrorType.OrgClinePassRestriction).should.be.true();
+		});
+
+		it("should classify ClinePass period limit messages as ClinePassLimit", () => {
+			const err = new ClineError(
+				"You have reached your weekly Clinepass limit. The limit resets in 7d, please try again later.",
+			);
+
+			ClineError.getErrorType(err)!.should.equal(ClineErrorType.ClinePassLimit);
+		});
+
+		it("should classify nested ClinePass period limit messages as ClinePassLimit", () => {
+			// ClineError maps `error.error` into `details`, matching the real provider error shape.
+			const err = new ClineError({
+				message: "403 Error 403",
+				error: {
+					message:
+						"You have reached your monthly ClinePass limit. The limit resets in 12h, please try again later.",
+				},
+			});
+
+			ClineError.getErrorType(err)!.should.equal(ClineErrorType.ClinePassLimit);
+		});
+
+		it("should prefer ClinePassLimit over Auth for a 403 with the limit message", () => {
+			// status 403 falls inside the generic auth-status range; the limit message must win.
+			const err = new ClineError({
+				message:
+					"You have reached your 5-hour Clinepass limit. The limit resets in 5h, please try again later.",
+				status: 403,
+			});
+
+			ClineError.getErrorType(err)!.should.equal(ClineErrorType.ClinePassLimit);
+		});
+	});
+
+	describe("isClinePassLimitMessage", () => {
+		it("matches limit messages with variable period and reset", () => {
+			isClinePassLimitMessage(
+				"You have reached your weekly Clinepass limit. The limit resets in 7d, please try again later.",
+			).should.be.true();
+			isClinePassLimitMessage(
+				"You have reached your 5-hour ClinePass limit. The limit resets in 5h, please try again later.",
+			).should.be.true();
+		});
+
+		it("does not match unrelated or partial messages", () => {
+			isClinePassLimitMessage(
+				"the user is not subscribed to required model plan",
+			).should.be.false();
+			isClinePassLimitMessage(
+				`You have reached your\t-\tClinepass limit.The limit resets in\t${"\t".repeat(10_000)}`,
+			).should.be.false();
+		});
+	});
+
+	describe("extractClinePassLimitMessage", () => {
+		it("extracts the limit message out of a wrapped error string", () => {
+			const message =
+				"You have reached your weekly Clinepass limit. The limit resets in 7d, please try again later.";
+
+			extractClinePassLimitMessage(`429 Error: ${message}`)!.should.equal(
+				message,
+			);
+		});
+
+		it("returns undefined when there is no limit message", () => {
+			(
+				extractClinePassLimitMessage("some other error") === undefined
+			).should.be.true();
 		});
 	});
 });

--- a/apps/vscode/webview-ui/src/components/chat/ClinePassLimitError.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ClinePassLimitError.tsx
@@ -1,0 +1,69 @@
+import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
+import { useState } from "react";
+import { useApiConfigurationHandlers } from "@/components/settings/utils/useApiConfigurationHandlers";
+
+interface ClinePassLimitErrorProps {
+	message: string;
+}
+
+const ClinePassLimitError = ({ message }: ClinePassLimitErrorProps) => {
+	const { handleFieldsChange } = useApiConfigurationHandlers();
+	const [isSwitching, setIsSwitching] = useState(false);
+	const [didSwitch, setDidSwitch] = useState(false);
+	const [error, setError] = useState<string | undefined>();
+
+	const handleSwitchToUsageBasedBilling = async () => {
+		setIsSwitching(true);
+		setError(undefined);
+		try {
+			await handleFieldsChange({
+				planModeApiProvider: "cline",
+				actModeApiProvider: "cline",
+			});
+			setDidSwitch(true);
+		} catch (error) {
+			console.error("Failed to switch to Cline usage-based billing:", error);
+			setError(
+				"Failed to switch provider. Select Cline Usage-Billing in API Configuration settings.",
+			);
+		} finally {
+			setIsSwitching(false);
+		}
+	};
+
+	return (
+		<div
+			className="p-2 border-none rounded-md mb-2 bg-(--vscode-textBlockQuote-background)"
+			data-testid="cline-pass-limit-error"
+		>
+			<div className="text-error mb-2">ClinePass limit reached</div>
+			<div className="text-(--vscode-descriptionForeground) text-xs wrap-anywhere">
+				{message}
+			</div>
+			<div className="text-(--vscode-descriptionForeground) text-xs mt-2">
+				Would you like to switch to Usage-Based billing and retry with the
+				Cline provider?
+			</div>
+			<VSCodeButton
+				appearance="primary"
+				className="w-full mt-3"
+				disabled={isSwitching || didSwitch}
+				onClick={handleSwitchToUsageBasedBilling}
+			>
+				{isSwitching
+					? "Switching..."
+					: didSwitch
+						? "Switched to Usage-Based billing"
+						: "Switch to Usage-Based billing"}
+			</VSCodeButton>
+			{didSwitch && (
+				<div className="text-(--vscode-descriptionForeground) text-xs mt-2">
+					Retry the request after switching.
+				</div>
+			)}
+			{error && <div className="text-error text-xs mt-2">{error}</div>}
+		</div>
+	);
+};
+
+export default ClinePassLimitError;

--- a/apps/vscode/webview-ui/src/components/chat/ErrorRow.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ErrorRow.test.tsx
@@ -1,9 +1,17 @@
 import type { ClineMessage } from "@shared/ExtensionMessage";
+import { ApiProvider } from "@shared/proto/cline/models";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import ErrorRow from "./ErrorRow";
 
 const mockSetUserOrganization = vi.hoisted(() => vi.fn());
+const mockUpdateApiConfigurationProto = vi.hoisted(() => vi.fn());
+const mockApiConfiguration = vi.hoisted(() => ({
+	planModeApiProvider: "cline-pass",
+	actModeApiProvider: "cline-pass",
+	planModeClinePassModelId: "cline-pass/test-plan-model",
+	actModeClinePassModelId: "cline-pass/test-act-model",
+}));
 
 // Mock the auth context
 vi.mock("@/context/ClineAuthContext", () => ({
@@ -30,9 +38,18 @@ vi.mock("@/components/chat/EntitlementError", () => ({
 	),
 }));
 
+vi.mock("@/context/ExtensionStateContext", () => ({
+	useExtensionState: () => ({
+		apiConfiguration: mockApiConfiguration,
+	}),
+}));
+
 vi.mock("@/services/grpc-client", () => ({
 	AccountServiceClient: {
 		setUserOrganization: mockSetUserOrganization,
+	},
+	ModelsServiceClient: {
+		updateApiConfigurationProto: mockUpdateApiConfigurationProto,
 	},
 }));
 
@@ -47,7 +64,9 @@ vi.mock("../../../../src/services/error/ClineError", () => ({
 		Auth: "auth",
 		Entitlement: "entitlement",
 		OrgClinePassRestriction: "orgClinePassRestriction",
+		ClinePassLimit: "clinePassLimit",
 	},
+	extractClinePassLimitMessage: vi.fn((text: string) => text),
 }));
 
 describe("ErrorRow", () => {
@@ -61,6 +80,7 @@ describe("ErrorRow", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockSetUserOrganization.mockResolvedValue({});
+		mockUpdateApiConfigurationProto.mockResolvedValue({});
 	});
 
 	it("renders basic error message", () => {
@@ -264,6 +284,83 @@ describe("ErrorRow", () => {
 			expect(
 				screen.getByText("Switched to personal account"),
 			).toBeInTheDocument();
+		});
+
+		it("renders ClinePass limit error and switches to Cline usage-based billing", async () => {
+			const limitMessage =
+				"You have reached your weekly Clinepass limit. The limit resets in 7d, please try again later.";
+			const mockClineError = {
+				message: limitMessage,
+				isErrorType: vi.fn((type) => type === "clinePassLimit"),
+				providerId: "cline-pass",
+				_error: {
+					message: limitMessage,
+				},
+			};
+
+			const { ClineError } = await import(
+				"../../../../src/services/error/ClineError"
+			);
+			vi.mocked(ClineError.parse).mockReturnValue(mockClineError as any);
+
+			render(
+				<ErrorRow
+					apiRequestFailedMessage={limitMessage}
+					errorType="error"
+					message={mockMessage}
+				/>,
+			);
+
+			expect(screen.getByTestId("cline-pass-limit-error")).toBeInTheDocument();
+			expect(screen.getByText(limitMessage)).toBeInTheDocument();
+
+			fireEvent.click(screen.getByText("Switch to Usage-Based billing"));
+
+			await waitFor(() =>
+				expect(mockUpdateApiConfigurationProto).toHaveBeenCalledTimes(1),
+			);
+			// The proto conversion maps provider id strings to ApiProvider enum values.
+			const request = mockUpdateApiConfigurationProto.mock.calls[0][0];
+			expect(request.apiConfiguration.planModeApiProvider).toBe(
+				ApiProvider.CLINE,
+			);
+			expect(request.apiConfiguration.actModeApiProvider).toBe(
+				ApiProvider.CLINE,
+			);
+			expect(
+				screen.getByText("Switched to Usage-Based billing"),
+			).toBeInTheDocument();
+		});
+
+		it("does not offer the usage-based billing switch when already on the cline provider", async () => {
+			const limitMessage =
+				"You have reached your weekly Clinepass limit. The limit resets in 7d, please try again later.";
+			const mockClineError = {
+				message: limitMessage,
+				isErrorType: vi.fn((type) => type === "clinePassLimit"),
+				providerId: "cline",
+				_error: {
+					message: limitMessage,
+				},
+			};
+
+			const { ClineError } = await import(
+				"../../../../src/services/error/ClineError"
+			);
+			vi.mocked(ClineError.parse).mockReturnValue(mockClineError as any);
+
+			render(
+				<ErrorRow
+					apiRequestFailedMessage={limitMessage}
+					errorType="error"
+					message={mockMessage}
+				/>,
+			);
+
+			expect(
+				screen.queryByTestId("cline-pass-limit-error"),
+			).not.toBeInTheDocument();
+			expect(screen.getByText(limitMessage)).toBeInTheDocument();
 		});
 
 		it("renders friendly logged-out message and sign in button when user is not signed in", async () => {

--- a/apps/vscode/webview-ui/src/components/chat/ErrorRow.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ErrorRow.tsx
@@ -1,6 +1,7 @@
 import type { ClineMessage } from "@shared/ExtensionMessage";
 import { isClineProvider } from "@shared/utils/cline";
 import { memo } from "react";
+import ClinePassLimitError from "@/components/chat/ClinePassLimitError";
 import CreditLimitError from "@/components/chat/CreditLimitError";
 import EntitlementError from "@/components/chat/EntitlementError";
 import OrgClinePassRestrictionError from "@/components/chat/OrgClinePassRestrictionError";
@@ -10,6 +11,7 @@ import { useClineAuth, useClineSignIn } from "@/context/ClineAuthContext";
 import {
 	ClineError,
 	ClineErrorType,
+	extractClinePassLimitMessage,
 } from "../../../../src/services/error/ClineError";
 
 const _errorColor = "var(--vscode-errorForeground)";
@@ -88,6 +90,19 @@ const ErrorRow = memo(
 							clineError?.isErrorType(ClineErrorType.OrgClinePassRestriction)
 						) {
 							return <OrgClinePassRestrictionError />;
+						}
+
+						// Gated on the ClinePass provider: users already on usage-based
+						// billing shouldn't be offered a switch to what they're on.
+						if (
+							clineError?.isErrorType(ClineErrorType.ClinePassLimit) &&
+							providerId === "cline-pass"
+						) {
+							const detailMessage =
+								clineError?._error?.details?.message || errorMessage;
+							const limitMessage =
+								extractClinePassLimitMessage(detailMessage) ?? detailMessage;
+							return <ClinePassLimitError message={limitMessage} />;
 						}
 
 						if (clineError?.isErrorType(ClineErrorType.RateLimit)) {


### PR DESCRIPTION
### Description

Legacy-branch port of #12162: when the ClinePass backend rejects a request with a period limit message ("You have reached your weekly Clinepass limit. The limit resets in 7d, please try again later."), show a dedicated error card in the chat with a one-click **Switch to Usage-Based billing** button instead of the generic error / auth fallback.

#### How the pieces map from main (#12162) to this codebase

The main-branch PR spread across `@cline/llms` (message matchers + typed error thrown from the shared fetch hook), `ClineError` classification, and the webview. This branch predates the SDK split, so everything lands in the monolith:

- **Matchers live in `ClineError.ts`** (`isClinePassLimitMessage` / `extractClinePassLimitMessage`) instead of `@cline/llms`. Same prefix/marker/suffix `indexOf` scan as main — the message is dynamic ("weekly"/"5-hour" period, "7d"/"12h" reset), so it's matched by the fixed "you have reached your" prefix + "clinepass limit" marker + "please try again later." suffix. No regex, so no backtracking risk on hostile input; the tests pin that with a 10k-tab input.
- **No throw-site extraction.** On main, the llms fetch hook extracts the clean sentence and throws `ClinePassLimitError` with it. Here the OpenAI SDK error flows through as-is (message may be wrapped, e.g. "429 ..."), so `ErrorRow` runs `extractClinePassLimitMessage` on the detail message before rendering. That's also why `extractClinePassLimitMessage` is exported.
- **Classification ordering matters:** the new check in `getErrorType` sits *before* the generic auth-status check because a 403 falls inside its `status > 400 && status < 429` range — without that ordering the limit error renders as "you're logged out, sign in". There's a dedicated test for exactly this.

#### Differences from the main PR (intentional)

1. **Provider gate.** The error card only renders when the failing request's `providerId === "cline-pass"`. The `cline` and `cline-pass` providers share the same backend, and offering "Switch to Usage-Based billing" to someone already on the usage-based provider is a dead-end button. (This was flagged in review of #12162; the legacy port includes it from the start.) When gated out, the raw message still shows via the generic error display.
2. **Auto-retry exclusion in `task/index.ts`.** The legacy task loop auto-retries failed first-chunk requests 3 times with 2s/4s/8s backoff before surfacing the error UI. A limit that resets in hours/days will never succeed on retry, so `ClinePassLimit` joins `Entitlement`/`OrgClinePassRestriction`/`SpendLimit` in the `shouldRetry` and `showRetry` exclusion lists — the card shows immediately instead of after ~14 seconds of doomed retries. Main didn't need this because the SDK path doesn't auto-retry these.
3. **The switch button uses `useApiConfigurationHandlers().handleFieldsChange`** instead of hand-rolling the proto conversion + `updateApiConfigurationProto` call like the main component does — the hook already exists here and encodes the batch-update-to-avoid-races convention.

Switching sets `planModeApiProvider`/`actModeApiProvider` to `cline` and deliberately leaves the `cline` provider's own model id fields untouched, so the user lands on their previous cline model or the default. The card asks the user to retry after switching (same UX as `OrgClinePassRestrictionError`).

#### Gotchas discovered

- The legacy proto `ApiConfiguration` maps provider ids to the numeric `ApiProvider` enum (main's proto keeps strings) — the `ErrorRow` test asserts `ApiProvider.CLINE`, not `"cline"`. First test run failed with `expected 16 to be 'cline'`.
- The `ErrorRow` test file mocks the whole `ClineError` module, so the new `extractClinePassLimitMessage` export had to be added to the mock or the branch dereferences `undefined`.
- Files touched here aren't biome-formatted on this branch (they predate the biome migration / came in via ported PRs); additions match the surrounding style rather than reformatting whole files, so the diff stays reviewable. `biome lint` (what the legacy publish workflow's `ci:check-all` actually enforces error-level) passes on all changed files.

No version bump / changelog here — per the legacy release process those happen in the release-cut commit, not feature PRs.

### Test Procedure

- `npm run test:unit` (extension, mocha): 1516 passing — includes new `getErrorType` classification tests (plain, nested `error.error` shape, 403-vs-auth precedence) and matcher/extractor tests.
- `npx vitest run src/components/chat/ErrorRow.test.tsx` (webview): 16 passing — includes rendering the card, clicking the switch button and asserting the proto update sets both modes to `ApiProvider.CLINE`, and the negative case (same error with `providerId: "cline"` does *not* render the card).
- `tsc --noEmit` clean for both the extension and webview-ui.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing and code is formatted and linted
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)