### PR TITLE
chore(greptile): update telemetry review rules for the monorepo layout

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -39,14 +39,6 @@
 				"sdk/packages/core/src/auth/**"
 			],
 			"severity": "high"
-		},
-		{
-			"id": "sdk-telemetry-doc-update",
-			"rule": "Any PR that adds new event constants to CORE_TELEMETRY_EVENTS in packages/core/src/services/telemetry/core-events.ts, adds new capture* helper functions, or changes the payload shape of an existing event must update the Event Catalog section in DOC.md. Flag PRs that modify core-events.ts without a corresponding change to DOC.md.",
-			"scope": [
-				"sdk/packages/core/src/services/telemetry/core-events.ts"
-			],
-			"severity": "medium"
 		}
 	]
 }

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -17,12 +17,8 @@
 			"description": "OpenTelemetry-backed provider that wires logs/metrics/traces exporters. Contains createConfiguredTelemetryService and createConfiguredTelemetryHandle, the canonical factories every host should use."
 		},
 		{
-			"path": "DOC.md",
-			"description": "Public API and event documentation. The Event Catalog and 'Activation funnel' sections must be kept in sync with core-events.ts. Host integration rules (CLI dir ordering, hub daemon metadata forwarding) are documented here."
-		},
-		{
 			"path": "sdk/ARCHITECTURE.md",
-			"description": "Architecture reference. Telemetry design decisions, completion semantics (submit_and_exit anchoring), and hub-daemon telemetry forwarding are documented here. Use as ground truth for design intent."
+			"description": "Architecture reference. Telemetry design decisions and completion semantics (submit_and_exit anchoring) are documented here. Use as ground truth for design intent."
 		},
 		{
 			"path": "sdk/AGENTS.md",

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -36,8 +36,11 @@ event names. It exports:
 
 1. Add the constant to `CORE_TELEMETRY_EVENTS`
 2. Add a typed `capture*()` helper alongside it (with a typed `properties` parameter)
-3. Update the Event Catalog section in `DOC.md`
-4. Add a unit test in `core-events.test.ts` asserting the event is dropped when telemetry is opted out
+3. Add a unit test in `core-events.test.ts` asserting the event flows through the
+   opt-out-respecting `capture` path and never `captureRequired` (opt-out is enforced by
+   `OptedOutTelemetryService`, whose `capture` is a no-op — the test convention is
+   "emits X as a normal opt-out-respecting event"). Events that intentionally bypass
+   opt-out must use `captureRequired` and assert that explicitly.
 
 ## The Activation Funnel
 
@@ -82,7 +85,7 @@ The CLI accepts `--config <dir>`. The CLI **must** apply `setClineDir(...)` and
 and any other on-disk telemetry state lands under `~/.cline` instead of the user's chosen
 config dir.
 
-The canonical pattern is in `apps/cli/src/main.ts` (PR #357):
+The canonical pattern is in `apps/cli/src/main.ts`:
 
 ```ts
 if (configDir) setClineDir(configDir);
@@ -90,18 +93,18 @@ setHomeDir(homedir());
 captureCliExtensionActivated();   // <-- after dir overrides
 ```
 
-## Hub Daemon Metadata Forwarding
+## Hub Daemon Telemetry
 
-Hosts that spawn a detached `@cline/core/hub/daemon-entry` process must forward telemetry
-metadata into the daemon argv so the daemon can reconstruct an equivalent
-`ITelemetryService`. The expected payload is base64-encoded JSON with snake_case keys:
+The detached hub daemon (`sdk/packages/core/src/hub/daemon/entry.ts`) hosts the
+`LocalRuntimeHost` that emits `task.conversation_turn` and `task.tokens` for every
+hub-backed session, so the daemon must own its own `ITelemetryService`. It builds one via
+`createHubDaemonTelemetry()` (`sdk/packages/core/src/hub/daemon/telemetry.ts`), which
+identifies from the cached cline account (re-resolved periodically, since the daemon often
+starts before login) and flushes on every shutdown path, including startup failure.
 
-```
-{ extension_version, cline_type, platform, platform_version, os_type, os_version, is_remote_workspace }
-```
-
-The reference implementation is `apps/vscode/src/hub-daemon.ts` (PR #357). Without this
-forwarding, hub-backed sessions silently drop their lifecycle telemetry.
+Flag changes that remove this wiring, construct runtime hosts inside the daemon without
+passing its telemetry handle, or add daemon exit paths that skip the flush — hub-backed
+sessions would silently drop their lifecycle telemetry (this exact bug shipped once).
 
 ## Auth Lifecycle Completeness
 
@@ -120,10 +123,10 @@ canonical examples of all four phases.
 
 ## Single Telemetry Service Per Host
 
-On VS Code, the telemetry handle is built **once** in `activate()`
-(`apps/vscode/src/telemetry.ts`) and the same instance is passed into the sidebar, panel
-command, and daemon spawn payload. Do not let individual controllers construct their own
-`ITelemetryService` — that fragments distinct-id state, opt-out tracking, and flush ownership.
+On VS Code, all callers go through the lazy `telemetryService` proxy in
+`apps/vscode/src/services/telemetry/index.ts`, which constructs the service once on first
+use. Do not let individual controllers construct their own `ITelemetryService` — that
+fragments distinct-id state, opt-out tracking, and flush ownership.
 
 The CLI follows the same pattern via the `getCliTelemetryService()` singleton in
 `apps/cli/src/utils/telemetry.ts`, which is memoized by the activation gate in


### PR DESCRIPTION
### Related Issue

Follow-up from the Greptile review on #12177, which surfaced that the `.greptile` telemetry config is partially stale.

### Description

The `.greptile/` config (added in #11233) was written for the pre-merge standalone `cline/sdk` repo and carries several references that don't exist in this monorepo. Concretely, on #12177 Greptile emitted a P2 demanding an Event Catalog update in `DOC.md` — a file that doesn't exist anywhere in the repo — and it will do the same on every future PR that touches `core-events.ts`.

What's fixed:

- **`config.json`**: removed the `sdk-telemetry-doc-update` rule (enforced `DOC.md`, which doesn't exist). If we ever bootstrap a real event catalog, the rule can come back pointing at it.
- **`files.json`**: removed the `DOC.md` entry; trimmed the `sdk/ARCHITECTURE.md` description's claim that it documents "hub-daemon telemetry forwarding" (it doesn't).
- **`rules.md`**:
  - The new-event checklist no longer requires a `DOC.md` update, and the opted-out-test step now describes the actual convention: opt-out is enforced by `OptedOutTelemetryService` (whose `capture` is a no-op), so tests assert the event flows through `capture` and never `captureRequired` — matching the existing "emits X as a normal opt-out-respecting event" tests in `core-events.test.ts`.
  - "Hub Daemon Metadata Forwarding" described an argv/base64 metadata payload with a reference implementation (`apps/vscode/src/hub-daemon.ts`, "PR #357") that was never implemented in this repo. Replaced with the real pattern from #12177: the daemon owns its own handle via `createHubDaemonTelemetry()`, identifies from cached credentials, and flushes on every exit path. The rule now guards against regressing that wiring (this exact bug shipped once — the daemon emitted zero telemetry).
  - "Single Telemetry Service Per Host" now points at the actual VS Code singleton (the lazy `telemetryService` proxy in `apps/vscode/src/services/telemetry/index.ts`) instead of a nonexistent `apps/vscode/src/telemetry.ts`.
  - Dropped the dangling "PR #357" citations.

Note: the rules.md daemon section references `sdk/packages/core/src/hub/daemon/telemetry.ts`, which lands in #12177 — merge that first (or accept a briefly dangling doc reference; it's review guidance, not code).

### Test Procedure

Docs/config only — validated both JSON files parse (`python3 json.load`) and that removed references (`DOC.md`, `apps/vscode/src/telemetry.ts`, `apps/vscode/src/hub-daemon.ts`) genuinely don't exist in the repo while the retained ones (`sdk/ARCHITECTURE.md`, `sdk/AGENTS.md`, `setClineDir`/`setHomeDir`, `getCliTelemetryService`, the vscode telemetry proxy) do.

### Type of Change

-   [x] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing and code is formatted and linted
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

N/A