### PR TITLE
fix(sdk): set versioned Cline client-identity headers for Cline provider

### DIFF
--- a/apps/cli/src/acp/acpAgent.ts
+++ b/apps/cli/src/acp/acpAgent.ts
@@ -511,6 +511,7 @@ export class AcpAgent implements Agent {
 
 	private async buildConfig(session: SessionState): Promise<Config> {
 		const cwd = session.cwd || process.cwd();
+		const workspaceRoot = resolveWorkspaceRoot(cwd);
 		// Resolve credentials: env vars take precedence, then session provider.
 		const providerId = process.env.CLINE_PROVIDER ?? session.currentProviderId;
 		const apiKey = process.env.CLINE_API_KEY ?? this.authResult?.apiKey ?? "";
@@ -519,6 +520,7 @@ export class AcpAgent implements Agent {
 			providerId,
 			mode: session.currentMode,
 		});
+		const cliBuildInfo = getCliBuildInfo();
 
 		return {
 			providerId,
@@ -537,7 +539,17 @@ export class AcpAgent implements Agent {
 			enableAgentTeams: false,
 			enableTools: true,
 			cwd,
-			workspaceRoot: resolveWorkspaceRoot(cwd),
+			workspaceRoot,
+			extensionContext: {
+				client: { name: "cline-cli", version: cliBuildInfo.version },
+				workspace: {
+					rootPath: workspaceRoot,
+					cwd,
+					workspaceName: cwd,
+					ide: "Terminal Shell",
+					platform: process.platform,
+				},
+			},
 		};
 	}
 }

--- a/apps/cli/src/acp/acpAgent.ts
+++ b/apps/cli/src/acp/acpAgent.ts
@@ -1,32 +1,32 @@
 import type {
-	Agent,
-	AgentSideConnection,
-	AuthenticateRequest,
-	AuthenticateResponse,
-	CancelNotification,
-	ContentBlock,
-	InitializeRequest,
-	InitializeResponse,
-	NewSessionRequest,
-	NewSessionResponse,
-	PromptRequest,
-	PromptResponse,
-	SessionConfigOption,
-	SetSessionConfigOptionRequest,
-	SetSessionConfigOptionResponse,
-	SetSessionModelRequest,
-	SetSessionModelResponse,
-	SetSessionModeRequest,
-	SetSessionModeResponse,
-	StopReason,
+    Agent,
+    AgentSideConnection,
+    AuthenticateRequest,
+    AuthenticateResponse,
+    CancelNotification,
+    ContentBlock,
+    InitializeRequest,
+    InitializeResponse,
+    NewSessionRequest,
+    NewSessionResponse,
+    PromptRequest,
+    PromptResponse,
+    SessionConfigOption,
+    SetSessionConfigOptionRequest,
+    SetSessionConfigOptionResponse,
+    SetSessionModelRequest,
+    SetSessionModelResponse,
+    SetSessionModeRequest,
+    SetSessionModeResponse,
+    StopReason,
 } from "@agentclientprotocol/sdk";
 import { PROTOCOL_VERSION, RequestError } from "@agentclientprotocol/sdk";
 import {
-	type AgentEvent,
-	type ClineCore,
-	Llms,
-	ProviderSettingsManager,
-	SessionSource,
+    type AgentEvent,
+    type ClineCore,
+    Llms,
+    ProviderSettingsManager,
+    SessionSource,
 } from "@cline/core";
 import type { Message } from "@cline/shared";
 import { getPersistedProviderApiKey } from "../commands/auth";
@@ -37,18 +37,18 @@ import { getCliBuildInfo } from "../utils/common";
 import { randomSessionId, resolveWorkspaceRoot } from "../utils/helpers";
 import type { Config } from "../utils/types";
 import {
-	ACP_AUTH_METHODS,
-	type AcpAuthMethodId,
-	type AcpAuthResult,
-	authenticateAcpProvider,
-	isAcpAuthMethodId,
+    ACP_AUTH_METHODS,
+    type AcpAuthMethodId,
+    type AcpAuthResult,
+    authenticateAcpProvider,
+    isAcpAuthMethodId,
 } from "./auth";
 import { requestAcpToolApproval } from "./permissions";
 import {
-	forwardAgentEvent,
-	sendConfigOptionUpdate,
-	sendCurrentModeUpdate,
-	sendSessionInfoUpdate,
+    forwardAgentEvent,
+    sendConfigOptionUpdate,
+    sendCurrentModeUpdate,
+    sendSessionInfoUpdate,
 } from "./session-updates";
 
 interface SessionState {
@@ -541,7 +541,13 @@ export class AcpAgent implements Agent {
 			cwd,
 			workspaceRoot,
 			extensionContext: {
-				client: { name: "cline-cli", version: cliBuildInfo.version },
+				client: {
+					name: "cline-acp",
+					version: cliBuildInfo.version,
+					platform: "cli",
+					platformVersion: cliBuildInfo.version,
+					isMultiRoot: false,
+				},
 				workspace: {
 					rootPath: workspaceRoot,
 					cwd,

--- a/apps/cli/src/acp/acpAgent.ts
+++ b/apps/cli/src/acp/acpAgent.ts
@@ -1,32 +1,32 @@
 import type {
-    Agent,
-    AgentSideConnection,
-    AuthenticateRequest,
-    AuthenticateResponse,
-    CancelNotification,
-    ContentBlock,
-    InitializeRequest,
-    InitializeResponse,
-    NewSessionRequest,
-    NewSessionResponse,
-    PromptRequest,
-    PromptResponse,
-    SessionConfigOption,
-    SetSessionConfigOptionRequest,
-    SetSessionConfigOptionResponse,
-    SetSessionModelRequest,
-    SetSessionModelResponse,
-    SetSessionModeRequest,
-    SetSessionModeResponse,
-    StopReason,
+	Agent,
+	AgentSideConnection,
+	AuthenticateRequest,
+	AuthenticateResponse,
+	CancelNotification,
+	ContentBlock,
+	InitializeRequest,
+	InitializeResponse,
+	NewSessionRequest,
+	NewSessionResponse,
+	PromptRequest,
+	PromptResponse,
+	SessionConfigOption,
+	SetSessionConfigOptionRequest,
+	SetSessionConfigOptionResponse,
+	SetSessionModelRequest,
+	SetSessionModelResponse,
+	SetSessionModeRequest,
+	SetSessionModeResponse,
+	StopReason,
 } from "@agentclientprotocol/sdk";
 import { PROTOCOL_VERSION, RequestError } from "@agentclientprotocol/sdk";
 import {
-    type AgentEvent,
-    type ClineCore,
-    Llms,
-    ProviderSettingsManager,
-    SessionSource,
+	type AgentEvent,
+	type ClineCore,
+	Llms,
+	ProviderSettingsManager,
+	SessionSource,
 } from "@cline/core";
 import type { Message } from "@cline/shared";
 import { getPersistedProviderApiKey } from "../commands/auth";
@@ -37,18 +37,18 @@ import { getCliBuildInfo } from "../utils/common";
 import { randomSessionId, resolveWorkspaceRoot } from "../utils/helpers";
 import type { Config } from "../utils/types";
 import {
-    ACP_AUTH_METHODS,
-    type AcpAuthMethodId,
-    type AcpAuthResult,
-    authenticateAcpProvider,
-    isAcpAuthMethodId,
+	ACP_AUTH_METHODS,
+	type AcpAuthMethodId,
+	type AcpAuthResult,
+	authenticateAcpProvider,
+	isAcpAuthMethodId,
 } from "./auth";
 import { requestAcpToolApproval } from "./permissions";
 import {
-    forwardAgentEvent,
-    sendConfigOptionUpdate,
-    sendCurrentModeUpdate,
-    sendSessionInfoUpdate,
+	forwardAgentEvent,
+	sendConfigOptionUpdate,
+	sendCurrentModeUpdate,
+	sendSessionInfoUpdate,
 } from "./session-updates";
 
 interface SessionState {

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -1095,7 +1095,13 @@ export async function runCli(): Promise<void> {
 			cwd,
 			workspaceRoot,
 			extensionContext: {
-				client: { name: "cline-cli", version: cliBuildInfo.version },
+				client: {
+					name: "cline-cli",
+					version: cliBuildInfo.version,
+					platform: "cli",
+					platformVersion: cliBuildInfo.version,
+					isMultiRoot: false,
+				},
 				workspace: {
 					rootPath: workspaceRoot,
 					cwd,

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -15,6 +15,7 @@ import {
 	getPreferredKanbanInstaller,
 } from "./commands/update";
 import { CLI_DEFAULT_CHECKPOINT_CONFIG } from "./runtime/defaults";
+import { getCliBuildInfo } from "./utils/common";
 import {
 	buildCliCompactionConfig,
 	CLI_COMPACTION_MODE_EXPECTED_TEXT,
@@ -1043,6 +1044,7 @@ export async function runCli(): Promise<void> {
 			reasoningEffort: args.reasoningEffort,
 			persistedReasoning: selectedProviderSettings?.reasoning,
 		});
+		const cliBuildInfo = getCliBuildInfo();
 		const { createCliLoggerAdapter } = await import("./logging/adapter");
 		const loggerAdapter = createCliLoggerAdapter({
 			runtime: "cli",
@@ -1093,7 +1095,7 @@ export async function runCli(): Promise<void> {
 			cwd,
 			workspaceRoot,
 			extensionContext: {
-				client: { name: "cline-cli" },
+				client: { name: "cline-cli", version: cliBuildInfo.version },
 				workspace: {
 					rootPath: workspaceRoot,
 					cwd,

--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -27,8 +27,8 @@ import { Logger } from "@shared/services/Logger"
 import type { Settings } from "@shared/storage/state-keys"
 import type { Mode } from "@shared/storage/types"
 import { stringifyVsCodeLmModelSelector } from "@shared/vsCodeSelectorUtils"
-import * as vscode from "vscode"
 import { StateManager } from "@/core/storage/StateManager"
+import { HostProvider } from "@/hosts/host-provider"
 import { ExtensionRegistryInfo } from "@/registry"
 import { getFeatureFlagsService } from "@/services/feature-flags"
 import { getDistinctId } from "@/services/logging/distinctId"
@@ -116,6 +116,31 @@ function createSdkLogger() {
 		error: (message: string, metadata?: Record<string, unknown>) => {
 			Logger.error(message, metadata)
 		},
+	}
+}
+
+/**
+ * Host identity for the session's client context, resolved through HostProvider
+ * rather than the `vscode` module directly: this file is also bundled into the
+ * standalone cline-core (JetBrains), where `vscode` is a Proxy-stub module and
+ * direct API reads would yield non-string values. The hostbridge returns the
+ * per-host values (e.g. "Cline for JetBrains" + IDE version on JetBrains).
+ */
+async function resolveHostIdentity() {
+	try {
+		return await HostProvider.env.getHostVersion({})
+	} catch (error) {
+		Logger.debug("Failed to resolve host version for client identity", error)
+		return undefined
+	}
+}
+
+async function resolveIsMultiRootWorkspace(): Promise<boolean> {
+	try {
+		const { paths } = await HostProvider.workspace.getWorkspacePaths({})
+		return paths.length > 1
+	} catch {
+		return false
 	}
 }
 
@@ -666,6 +691,8 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 	// own provider id spelling (e.g. "openai-compatible" rather than the
 	// extension's "openai"). Convert before handing the id to core.
 	const sdkProviderId = toSdkProviderId(providerId)
+	const hostIdentity = await resolveHostIdentity()
+	const isMultiRoot = await resolveIsMultiRootWorkspace()
 
 	// Always pass a providerConfig so the proxy/CA-aware fetch reaches the SDK
 	// gateway; without it the agent loop uses bare global fetch and corporate
@@ -716,11 +743,11 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 		extensionContext: {
 			user: distinctId ? { distinctId } : undefined,
 			client: {
-				name: ClineClient.VSCode,
-				version: ExtensionRegistryInfo.version,
-				platform: vscode.env.appName,
-				platformVersion: vscode.version,
-				isMultiRoot: (vscode.workspace.workspaceFolders?.length ?? 0) > 1,
+				name: hostIdentity?.clineType || ClineClient.VSCode,
+				version: hostIdentity?.clineVersion || ExtensionRegistryInfo.version,
+				platform: hostIdentity?.platform || undefined,
+				platformVersion: hostIdentity?.version || undefined,
+				isMultiRoot,
 			},
 			workspace: {
 				rootPath: workspaceRoot,

--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -20,12 +20,14 @@ import {
 import { getGeneratedModelsForProvider, MODEL_COLLECTIONS_BY_PROVIDER_ID } from "@cline/llms"
 import { buildClineSystemPrompt } from "@cline/shared"
 import type { ApiConfiguration } from "@shared/api"
+import { ClineClient } from "@shared/cline"
 import type { HistoryItem } from "@shared/HistoryItem"
 import { DEFAULT_LANGUAGE_SETTINGS, getLanguageKey, type LanguageDisplay } from "@shared/Languages"
 import { Logger } from "@shared/services/Logger"
 import type { Settings } from "@shared/storage/state-keys"
 import type { Mode } from "@shared/storage/types"
 import { stringifyVsCodeLmModelSelector } from "@shared/vsCodeSelectorUtils"
+import * as vscode from "vscode"
 import { StateManager } from "@/core/storage/StateManager"
 import { ExtensionRegistryInfo } from "@/registry"
 import { getFeatureFlagsService } from "@/services/feature-flags"
@@ -714,8 +716,11 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 		extensionContext: {
 			user: distinctId ? { distinctId } : undefined,
 			client: {
-				name: "cline-vscode",
+				name: ClineClient.VSCode,
 				version: ExtensionRegistryInfo.version,
+				platform: vscode.env.appName,
+				platformVersion: vscode.version,
+				isMultiRoot: (vscode.workspace.workspaceFolders?.length ?? 0) > 1,
 			},
 			workspace: {
 				rootPath: workspaceRoot,

--- a/sdk/packages/core/src/ClineCore.test.ts
+++ b/sdk/packages/core/src/ClineCore.test.ts
@@ -364,6 +364,61 @@ describe("ClineCore", () => {
 		);
 	});
 
+	it("normalizes config extension context into local runtime before delegating to the host", async () => {
+		const host = {
+			runtimeAddress: undefined,
+			startSession: vi.fn(async (_input: StartSessionInput) =>
+				createStartResult("session-extension-context"),
+			),
+			runTurn: vi.fn(),
+			getAccumulatedUsage: vi.fn(),
+			abort: vi.fn(),
+			stopSession: vi.fn(),
+			dispose: vi.fn(),
+			getSession: vi.fn(async () => undefined),
+			listSessions: vi.fn(),
+			deleteSession: vi.fn(),
+			readSessionMessages: vi.fn(),
+			subscribe: vi.fn(() => () => {}),
+			updateSessionModel: vi.fn(),
+		};
+		createRuntimeHostMock.mockResolvedValue(host);
+
+		const onTeamRestored = vi.fn();
+		const clientContext = {
+			name: "VSCode Extension",
+			version: "3.27.0",
+			platform: "Visual Studio Code",
+			platformVersion: "1.102.3",
+			isMultiRoot: true,
+		};
+		const core = await ClineCore.create();
+
+		await core.start({
+			...createStartInput(),
+			config: {
+				...createStartInput().config,
+				extensionContext: {
+					client: clientContext,
+				},
+			},
+			localRuntime: {
+				onTeamRestored,
+			},
+		});
+
+		const startInput = vi.mocked(host.startSession).mock.calls.at(-1)?.[0] as
+			| StartSessionInput
+			| undefined;
+		expect(startInput).toBeDefined();
+		if (!startInput) throw new Error("Expected host.startSession to be called");
+		expect(startInput.config).not.toHaveProperty("extensionContext");
+		expect(startInput.localRuntime?.extensionContext?.client).toEqual(
+			clientContext,
+		);
+		expect(startInput.localRuntime?.onTeamRestored).toBe(onTeamRestored);
+	});
+
 	it("prefers the per-session telemetry service over the ClineCore one", async () => {
 		const host = {
 			runtimeAddress: undefined,

--- a/sdk/packages/core/src/hub/runtime-host/hub-runtime-host.test.ts
+++ b/sdk/packages/core/src/hub/runtime-host/hub-runtime-host.test.ts
@@ -1,5 +1,6 @@
 import type { AgentToolContext, HubEventEnvelope } from "@cline/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { version as corePackageVersion } from "../../../package.json";
 import { createSessionCompactionState } from "../../session/models/session-compaction";
 import { SessionSource } from "../../types/common";
 
@@ -100,6 +101,11 @@ describe("HubRuntimeHost", () => {
 		const started = await host.startSession({
 			config: createConfig(),
 			source: SessionSource.CLI,
+			localRuntime: {
+				extensionContext: {
+					client: { name: "cline-cli", version: "3.0.38" },
+				},
+			},
 			prompt: "Hey",
 		});
 
@@ -123,6 +129,18 @@ describe("HubRuntimeHost", () => {
 				enableTools: true,
 				enableSpawnAgent: true,
 				enableAgentTeams: true,
+				headers: expect.objectContaining({
+					"HTTP-Referer": "https://cline.bot",
+					"X-Title": "Cline",
+					"User-Agent": "Cline/3.0.38",
+					"X-IS-MULTIROOT": "false",
+					"X-CLIENT-TYPE": "cline-cli",
+					"X-CLIENT-VERSION": "3.0.38",
+					"X-PLATFORM": "cli",
+					"X-PLATFORM-VERSION": "3.0.38",
+					"X-CORE-VERSION": corePackageVersion,
+					"X-Task-ID": expect.any(String),
+				}),
 			}),
 			metadata: expect.objectContaining({
 				source: SessionSource.CLI,

--- a/sdk/packages/core/src/hub/runtime-host/hub-runtime-host.ts
+++ b/sdk/packages/core/src/hub/runtime-host/hub-runtime-host.ts
@@ -932,9 +932,16 @@ export class HubRuntimeHost implements RuntimeHost {
 					manifest: [],
 					handlers: new Map<string, ClientContributionHandler>(),
 				};
-		const plannedSessionId = startConfig
-			? startConfig.config.sessionId?.trim() || createSessionId()
-			: undefined;
+		let plannedSessionId: string | undefined;
+		let startSessionConfig: Record<string, unknown> | undefined;
+		if (startConfig) {
+			plannedSessionId =
+				startConfig.config.sessionId?.trim() || createSessionId();
+			startSessionConfig = buildCommandSessionConfig(
+				startConfig,
+				plannedSessionId,
+			);
+		}
 		if (plannedSessionId && capabilities) {
 			this.sessionCapabilities.set(plannedSessionId, capabilities);
 		}
@@ -945,10 +952,6 @@ export class HubRuntimeHost implements RuntimeHost {
 			);
 			this.ensureSessionSubscription(plannedSessionId);
 		}
-		const startSessionConfig =
-			startConfig && plannedSessionId
-				? buildCommandSessionConfig(startConfig, plannedSessionId)
-				: undefined;
 		let reply: Awaited<ReturnType<NodeHubClient["command"]>>;
 		try {
 			reply = await this.client.command(

--- a/sdk/packages/core/src/hub/runtime-host/hub-runtime-host.ts
+++ b/sdk/packages/core/src/hub/runtime-host/hub-runtime-host.ts
@@ -137,8 +137,13 @@ function buildCommandSessionConfig(
 		sessionId,
 		source: input.source,
 		defaultSource: SessionSource.CORE,
+		clientName: input.localRuntime?.extensionContext?.client?.name,
 		clientVersion: input.localRuntime?.extensionContext?.client?.version,
 		clientVersionHeaderFallback: input.config.headers?.["X-CLIENT-VERSION"],
+		platform: input.localRuntime?.extensionContext?.client?.platform,
+		platformVersion:
+			input.localRuntime?.extensionContext?.client?.platformVersion,
+		isMultiRoot: input.localRuntime?.extensionContext?.client?.isMultiRoot,
 		coreVersion: corePackageVersion,
 		headers: [input.config.headers],
 	});

--- a/sdk/packages/core/src/hub/runtime-host/hub-runtime-host.ts
+++ b/sdk/packages/core/src/hub/runtime-host/hub-runtime-host.ts
@@ -22,7 +22,9 @@ import {
 	HUB_TOOL_EXECUTOR_CAPABILITY_PREFIX,
 	HUB_USER_INSTRUCTIONS_SNAPSHOT_CAPABILITY,
 	isHubToolExecutorName,
+	mergeClineClientRequestHeaders,
 } from "@cline/shared";
+import { version as corePackageVersion } from "../../../package.json";
 import type { HookEventPayload } from "../../hooks";
 import type { RuntimeCapabilities } from "../../runtime/capabilities";
 import { normalizeRuntimeCapabilities } from "../../runtime/capabilities";
@@ -120,6 +122,30 @@ function serializeSettingsInput(
 	const { userInstructionService: _userInstructionService, ...serializable } =
 		input;
 	return JSON.parse(JSON.stringify(serializable)) as Record<string, unknown>;
+}
+
+function buildCommandSessionConfig(
+	input: StartSessionInput,
+	sessionId: string,
+): Record<string, unknown> {
+	const sessionConfig: Record<string, unknown> = {
+		...(input.config as Record<string, unknown>),
+		sessionId,
+	};
+	const headers = mergeClineClientRequestHeaders({
+		providerId: input.config.providerId,
+		sessionId,
+		source: input.source,
+		defaultSource: SessionSource.CORE,
+		clientVersion: input.localRuntime?.extensionContext?.client?.version,
+		clientVersionHeaderFallback: input.config.headers?.["X-CLIENT-VERSION"],
+		coreVersion: corePackageVersion,
+		headers: [input.config.headers],
+	});
+	if (headers) {
+		sessionConfig.headers = headers;
+	}
+	return sessionConfig;
 }
 
 function parseToolContext(value: unknown): AgentToolContext {
@@ -798,10 +824,9 @@ export class HubRuntimeHost implements RuntimeHost {
 			this.client.command("session.create", {
 				workspaceRoot: input.config.workspaceRoot?.trim() || input.config.cwd,
 				cwd: input.config.cwd,
-				sessionConfig: toJsonRecord({
-					...(input.config as Record<string, unknown>),
-					sessionId: plannedSessionId,
-				}),
+				sessionConfig: toJsonRecord(
+					buildCommandSessionConfig(input, plannedSessionId),
+				),
 				metadata: {
 					...(input.sessionMetadata ?? {}),
 					source: input.source ?? SessionSource.CORE,
@@ -920,6 +945,10 @@ export class HubRuntimeHost implements RuntimeHost {
 			);
 			this.ensureSessionSubscription(plannedSessionId);
 		}
+		const startSessionConfig =
+			startConfig && plannedSessionId
+				? buildCommandSessionConfig(startConfig, plannedSessionId)
+				: undefined;
 		let reply: Awaited<ReturnType<NodeHubClient["command"]>>;
 		try {
 			reply = await this.client.command(
@@ -934,10 +963,7 @@ export class HubRuntimeHost implements RuntimeHost {
 									startConfig.config.workspaceRoot?.trim() ||
 									startConfig.config.cwd,
 								cwd: startConfig.config.cwd ?? input.cwd,
-								sessionConfig: toJsonRecord({
-									...(startConfig.config as Record<string, unknown>),
-									sessionId: plannedSessionId,
-								}),
+								sessionConfig: toJsonRecord(startSessionConfig),
 								metadata: {
 									...(startConfig.sessionMetadata ?? {}),
 									source: startConfig.source ?? SessionSource.CORE,

--- a/sdk/packages/core/src/services/local-runtime-bootstrap.test.ts
+++ b/sdk/packages/core/src/services/local-runtime-bootstrap.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { version as corePackageVersion } from "../../package.json";
 import type { ProviderSettings } from "../types/provider-settings";
 
 function createProviderSettingsManager(settings?: ProviderSettings) {
@@ -392,6 +393,139 @@ describe("prepareLocalRuntimeBootstrap", () => {
 		});
 
 		expect(bootstrap.providerConfig.fetch).toBeUndefined();
+	});
+
+	it.each([
+		"cline",
+		"cline-pass",
+	])("adds required source request headers for %s", async (providerId) => {
+		const { prepareLocalRuntimeBootstrap } = await import(
+			"./local-runtime-bootstrap"
+		);
+
+		const input = createStartInput();
+		input.config.providerId = providerId;
+		input.config.modelId =
+			providerId === "cline-pass"
+				? "cline-pass/test-model"
+				: "anthropic/claude-haiku-4.5";
+		const config = input.config as typeof input.config & {
+			headers: Record<string, string>;
+			providerConfig: {
+				providerId: string;
+				headers: Record<string, string>;
+			};
+		};
+		config.headers = {
+			"X-CLIENT-TYPE": "config-client",
+			"X-Task-ID": "config-task",
+			"x-config": "config",
+			"x-shared": "config-wins",
+		};
+		config.providerConfig = {
+			providerId,
+			headers: {
+				"X-CLIENT-VERSION": "provider-config-version",
+				"x-provider-config": "provider-config",
+			},
+		};
+
+		const bootstrap = await prepareLocalRuntimeBootstrap({
+			input,
+			localRuntime: {
+				extensionContext: {
+					client: { name: "cline-cli", version: "3.0.38" },
+				},
+			},
+			sessionId: "sess-cline-headers",
+			providerSettingsManager: createProviderSettingsManager({
+				provider: providerId,
+				model: input.config.modelId,
+				headers: {
+					"X-CLIENT-TYPE": "stored-client",
+					"x-stored": "stored",
+					"x-shared": "stored-loses",
+				},
+			}) as never,
+			defaultTelemetry: undefined,
+			defaultToolPolicies: undefined,
+			onPluginEvent: () => {},
+			onTeamEvent: () => {},
+			createSpawnTool,
+			readSessionMetadata: async () => undefined,
+			writeSessionMetadata: async () => {},
+		});
+
+		expect(bootstrap.providerConfig.headers).toMatchObject({
+			"HTTP-Referer": "https://cline.bot",
+			"X-Title": "Cline",
+			"User-Agent": "Cline/3.0.38",
+			"X-IS-MULTIROOT": "false",
+			"X-CLIENT-TYPE": "cline-cli",
+			"X-CLIENT-VERSION": "3.0.38",
+			"X-PLATFORM": "cli",
+			"X-PLATFORM-VERSION": "3.0.38",
+			"X-CORE-VERSION": corePackageVersion,
+			"X-Task-ID": "sess-cline-headers",
+			"x-config": "config",
+			"x-provider-config": "provider-config",
+			"x-shared": "config-wins",
+			"x-stored": "stored",
+		});
+	});
+
+	it("adds source request headers for Cline providers on core sessions", async () => {
+		const { prepareLocalRuntimeBootstrap } = await import(
+			"./local-runtime-bootstrap"
+		);
+
+		const input = {
+			...createStartInput(),
+			source: "core" as const,
+		};
+		const config = input.config as typeof input.config & {
+			headers: Record<string, string>;
+		};
+		config.headers = { "x-config": "config" };
+
+		const bootstrap = await prepareLocalRuntimeBootstrap({
+			input,
+			localRuntime: {
+				extensionContext: {
+					client: { name: "cline-sdk", version: "9.9.9" },
+				},
+			},
+			sessionId: "sess-non-cli",
+			providerSettingsManager: createProviderSettingsManager({
+				provider: "cline",
+				model: input.config.modelId,
+				headers: {
+					"x-stored": "stored",
+				},
+			}) as never,
+			defaultTelemetry: undefined,
+			defaultToolPolicies: undefined,
+			onPluginEvent: () => {},
+			onTeamEvent: () => {},
+			createSpawnTool,
+			readSessionMetadata: async () => undefined,
+			writeSessionMetadata: async () => {},
+		});
+
+		expect(bootstrap.providerConfig.headers).toMatchObject({
+			"HTTP-Referer": "https://cline.bot",
+			"X-Title": "Cline",
+			"User-Agent": "Cline/9.9.9",
+			"X-IS-MULTIROOT": "false",
+			"X-CLIENT-TYPE": "cline-core",
+			"X-CLIENT-VERSION": "9.9.9",
+			"X-PLATFORM": "core",
+			"X-PLATFORM-VERSION": "9.9.9",
+			"X-CORE-VERSION": corePackageVersion,
+			"X-Task-ID": "sess-non-cli",
+			"x-config": "config",
+			"x-stored": "stored",
+		});
 	});
 
 	it("adds Codex backend headers for openai-codex from stored OAuth settings", async () => {

--- a/sdk/packages/core/src/services/local-runtime-bootstrap.test.ts
+++ b/sdk/packages/core/src/services/local-runtime-bootstrap.test.ts
@@ -474,7 +474,7 @@ describe("prepareLocalRuntimeBootstrap", () => {
 		});
 	});
 
-	it("adds source request headers for Cline providers on core sessions", async () => {
+	it("uses host request headers for Cline providers on core sessions", async () => {
 		const { prepareLocalRuntimeBootstrap } = await import(
 			"./local-runtime-bootstrap"
 		);
@@ -492,7 +492,13 @@ describe("prepareLocalRuntimeBootstrap", () => {
 			input,
 			localRuntime: {
 				extensionContext: {
-					client: { name: "cline-sdk", version: "9.9.9" },
+					client: {
+						name: "VSCode Extension",
+						version: "9.9.9",
+						platform: "Visual Studio Code",
+						platformVersion: "1.103.0",
+						isMultiRoot: true,
+					},
 				},
 			},
 			sessionId: "sess-non-cli",
@@ -516,11 +522,11 @@ describe("prepareLocalRuntimeBootstrap", () => {
 			"HTTP-Referer": "https://cline.bot",
 			"X-Title": "Cline",
 			"User-Agent": "Cline/9.9.9",
-			"X-IS-MULTIROOT": "false",
-			"X-CLIENT-TYPE": "cline-core",
+			"X-IS-MULTIROOT": "true",
+			"X-CLIENT-TYPE": "VSCode Extension",
 			"X-CLIENT-VERSION": "9.9.9",
-			"X-PLATFORM": "core",
-			"X-PLATFORM-VERSION": "9.9.9",
+			"X-PLATFORM": "Visual Studio Code",
+			"X-PLATFORM-VERSION": "1.103.0",
 			"X-CORE-VERSION": corePackageVersion,
 			"X-Task-ID": "sess-non-cli",
 			"x-config": "config",

--- a/sdk/packages/core/src/services/local-runtime-bootstrap.ts
+++ b/sdk/packages/core/src/services/local-runtime-bootstrap.ts
@@ -10,7 +10,12 @@ import type {
 	ToolApprovalResult,
 	WorkspaceInfo,
 } from "@cline/shared";
-import { hasRuntimeConfigExtension } from "@cline/shared";
+import {
+	buildClineClientRequestHeaders,
+	hasRuntimeConfigExtension,
+	mergeClineClientRequestHeaders,
+} from "@cline/shared";
+import { version as corePackageVersion } from "../../package.json";
 import { decodeJwtPayload } from "../auth/utils";
 import {
 	resolveAndLoadAgentPlugins,
@@ -38,6 +43,7 @@ import type {
 	StartSessionInput,
 } from "../runtime/host/runtime-host";
 import type { RuntimeBuilderInput } from "../runtime/orchestration/session-runtime";
+import { SessionSource } from "../types/common";
 import type { CoreSessionConfig } from "../types/config";
 import {
 	type ProviderConfig,
@@ -182,6 +188,7 @@ function deriveOpenAICodexAccountId(
 function buildProviderConfig(
 	config: CoreSessionConfig,
 	sessionId: string,
+	source: StartSessionInput["source"],
 	providerSettingsManager: ProviderSettingsManager,
 	modelCatalogDefaults?: Partial<ProviderSettings["modelCatalog"]>,
 	defaultFetch?: typeof fetch,
@@ -198,23 +205,44 @@ function buildProviderConfig(
 		config.providerConfig?.providerId === config.providerId
 			? config.providerConfig
 			: undefined;
+	const clineClientHeaders = buildClineClientRequestHeaders({
+		providerId: config.providerId,
+		sessionId,
+		source,
+		defaultSource: SessionSource.CLI,
+		clientVersion: config.extensionContext?.client?.version,
+		clientVersionHeaderFallback: config.headers?.["X-CLIENT-VERSION"],
+		coreVersion: corePackageVersion,
+	});
+	const resolvedHeaders =
+		config.providerId === "openai-codex"
+			? buildOpenAICodexHeaders({
+					sessionId,
+					configHeaders: config.headers,
+					storedHeaders: stored?.headers,
+					accountId: stored?.auth?.accountId,
+					accessToken:
+						config.apiKey ?? stored?.auth?.accessToken ?? stored?.apiKey,
+				})
+			: clineClientHeaders
+				? mergeClineClientRequestHeaders({
+						providerId: config.providerId,
+						sessionId,
+						source,
+						defaultSource: SessionSource.CLI,
+						clientVersion: config.extensionContext?.client?.version,
+						clientVersionHeaderFallback: config.headers?.["X-CLIENT-VERSION"],
+						coreVersion: corePackageVersion,
+						headers: [stored?.headers, config.headers],
+					})
+				: (config.headers ?? stored?.headers);
 	const settings: ProviderSettings = {
 		...(stored ?? {}),
 		provider: config.providerId,
 		model: config.modelId,
 		apiKey: config.apiKey ?? stored?.apiKey,
 		baseUrl: config.baseUrl ?? stored?.baseUrl,
-		headers:
-			config.providerId === "openai-codex"
-				? buildOpenAICodexHeaders({
-						sessionId,
-						configHeaders: config.headers,
-						storedHeaders: stored?.headers,
-						accountId: stored?.auth?.accountId,
-						accessToken:
-							config.apiKey ?? stored?.auth?.accessToken ?? stored?.apiKey,
-					})
-				: (config.headers ?? stored?.headers),
+		headers: resolvedHeaders,
 		reasoning: resolveReasoningSettings(config, stored?.reasoning),
 		modelCatalog,
 	};
@@ -222,6 +250,13 @@ function buildProviderConfig(
 		...toProviderConfig(settings),
 		...(sessionProviderConfig ?? {}),
 	};
+	if (clineClientHeaders) {
+		providerConfig.headers = {
+			...(resolvedHeaders ?? {}),
+			...(sessionProviderConfig?.headers ?? {}),
+			...clineClientHeaders,
+		};
+	}
 	if (config.knownModels) {
 		providerConfig.knownModels = config.knownModels;
 	}
@@ -419,6 +454,7 @@ export async function prepareLocalRuntimeBootstrap(
 	const providerConfig = buildProviderConfig(
 		baseConfig,
 		sessionId,
+		input.source,
 		providerSettingsManager,
 		modelCatalogDefaults,
 		defaultFetch,

--- a/sdk/packages/core/src/services/local-runtime-bootstrap.ts
+++ b/sdk/packages/core/src/services/local-runtime-bootstrap.ts
@@ -1,54 +1,53 @@
 import type {
-	AgentConfig,
-	AgentEvent,
-	AgentHooks,
-	AgentTool,
-	ExtensionContext,
-	ITelemetryService,
-	RuntimeConfigExtensionKind,
-	ToolApprovalRequest,
-	ToolApprovalResult,
-	WorkspaceInfo,
+    AgentConfig,
+    AgentEvent,
+    AgentHooks,
+    AgentTool,
+    ExtensionContext,
+    ITelemetryService,
+    RuntimeConfigExtensionKind,
+    ToolApprovalRequest,
+    ToolApprovalResult,
+    WorkspaceInfo,
 } from "@cline/shared";
 import {
-	buildClineClientRequestHeaders,
-	hasRuntimeConfigExtension,
-	mergeClineClientRequestHeaders,
+    buildClineClientRequestHeaders,
+    hasRuntimeConfigExtension,
 } from "@cline/shared";
 import { version as corePackageVersion } from "../../package.json";
 import { decodeJwtPayload } from "../auth/utils";
 import {
-	resolveAndLoadAgentPlugins,
-	resolvePluginSkillDirectoriesFromPaths,
+    resolveAndLoadAgentPlugins,
+    resolvePluginSkillDirectoriesFromPaths,
 } from "../extensions/plugin/plugin-config-loader";
 import type {
-	PluginInitializationFailure,
-	PluginInitializationWarning,
+    PluginInitializationFailure,
+    PluginInitializationWarning,
 } from "../extensions/plugin/plugin-load-report";
 import type {
-	SubAgentEndContext,
-	SubAgentStartContext,
-	TeamEvent,
+    SubAgentEndContext,
+    SubAgentStartContext,
+    TeamEvent,
 } from "../extensions/tools/team";
 import { createCheckpointHooks } from "../hooks/checkpoint-hooks";
 import {
-	createHookAuditHooks,
-	createHookConfigFileExtension,
-	mergeAgentHooks,
+    createHookAuditHooks,
+    createHookConfigFileExtension,
+    mergeAgentHooks,
 } from "../hooks/hook-file-hooks";
 import type { RuntimeCapabilities } from "../runtime/capabilities";
 import { normalizeRuntimeCapabilities } from "../runtime/capabilities";
 import type {
-	LocalRuntimeStartOptions,
-	StartSessionInput,
+    LocalRuntimeStartOptions,
+    StartSessionInput,
 } from "../runtime/host/runtime-host";
 import type { RuntimeBuilderInput } from "../runtime/orchestration/session-runtime";
 import { SessionSource } from "../types/common";
 import type { CoreSessionConfig } from "../types/config";
 import {
-	type ProviderConfig,
-	type ProviderSettings,
-	toProviderConfig,
+    type ProviderConfig,
+    type ProviderSettings,
+    toProviderConfig,
 } from "../types/provider-settings";
 import { resolveWorkspacePath } from "./config";
 import { filterExtensionToolRegistrations } from "./global-settings";
@@ -214,6 +213,7 @@ function buildProviderConfig(
 		clientVersionHeaderFallback: config.headers?.["X-CLIENT-VERSION"],
 		coreVersion: corePackageVersion,
 	});
+	// TODO: (bee) Move header resolution logic into @cline/llms
 	const resolvedHeaders =
 		config.providerId === "openai-codex"
 			? buildOpenAICodexHeaders({
@@ -225,16 +225,11 @@ function buildProviderConfig(
 						config.apiKey ?? stored?.auth?.accessToken ?? stored?.apiKey,
 				})
 			: clineClientHeaders
-				? mergeClineClientRequestHeaders({
-						providerId: config.providerId,
-						sessionId,
-						source,
-						defaultSource: SessionSource.CLI,
-						clientVersion: config.extensionContext?.client?.version,
-						clientVersionHeaderFallback: config.headers?.["X-CLIENT-VERSION"],
-						coreVersion: corePackageVersion,
-						headers: [stored?.headers, config.headers],
-					})
+				? {
+						...(stored?.headers ?? {}),
+						...(config.headers ?? {}),
+						...clineClientHeaders,
+					}
 				: (config.headers ?? stored?.headers);
 	const settings: ProviderSettings = {
 		...(stored ?? {}),

--- a/sdk/packages/core/src/services/local-runtime-bootstrap.ts
+++ b/sdk/packages/core/src/services/local-runtime-bootstrap.ts
@@ -1,53 +1,53 @@
 import type {
-    AgentConfig,
-    AgentEvent,
-    AgentHooks,
-    AgentTool,
-    ExtensionContext,
-    ITelemetryService,
-    RuntimeConfigExtensionKind,
-    ToolApprovalRequest,
-    ToolApprovalResult,
-    WorkspaceInfo,
+	AgentConfig,
+	AgentEvent,
+	AgentHooks,
+	AgentTool,
+	ExtensionContext,
+	ITelemetryService,
+	RuntimeConfigExtensionKind,
+	ToolApprovalRequest,
+	ToolApprovalResult,
+	WorkspaceInfo,
 } from "@cline/shared";
 import {
-    buildClineClientRequestHeaders,
-    hasRuntimeConfigExtension,
+	buildClineClientRequestHeaders,
+	hasRuntimeConfigExtension,
 } from "@cline/shared";
 import { version as corePackageVersion } from "../../package.json";
 import { decodeJwtPayload } from "../auth/utils";
 import {
-    resolveAndLoadAgentPlugins,
-    resolvePluginSkillDirectoriesFromPaths,
+	resolveAndLoadAgentPlugins,
+	resolvePluginSkillDirectoriesFromPaths,
 } from "../extensions/plugin/plugin-config-loader";
 import type {
-    PluginInitializationFailure,
-    PluginInitializationWarning,
+	PluginInitializationFailure,
+	PluginInitializationWarning,
 } from "../extensions/plugin/plugin-load-report";
 import type {
-    SubAgentEndContext,
-    SubAgentStartContext,
-    TeamEvent,
+	SubAgentEndContext,
+	SubAgentStartContext,
+	TeamEvent,
 } from "../extensions/tools/team";
 import { createCheckpointHooks } from "../hooks/checkpoint-hooks";
 import {
-    createHookAuditHooks,
-    createHookConfigFileExtension,
-    mergeAgentHooks,
+	createHookAuditHooks,
+	createHookConfigFileExtension,
+	mergeAgentHooks,
 } from "../hooks/hook-file-hooks";
 import type { RuntimeCapabilities } from "../runtime/capabilities";
 import { normalizeRuntimeCapabilities } from "../runtime/capabilities";
 import type {
-    LocalRuntimeStartOptions,
-    StartSessionInput,
+	LocalRuntimeStartOptions,
+	StartSessionInput,
 } from "../runtime/host/runtime-host";
 import type { RuntimeBuilderInput } from "../runtime/orchestration/session-runtime";
 import { SessionSource } from "../types/common";
 import type { CoreSessionConfig } from "../types/config";
 import {
-    type ProviderConfig,
-    type ProviderSettings,
-    toProviderConfig,
+	type ProviderConfig,
+	type ProviderSettings,
+	toProviderConfig,
 } from "../types/provider-settings";
 import { resolveWorkspacePath } from "./config";
 import { filterExtensionToolRegistrations } from "./global-settings";
@@ -209,8 +209,12 @@ function buildProviderConfig(
 		sessionId,
 		source,
 		defaultSource: SessionSource.CLI,
+		clientName: config.extensionContext?.client?.name,
 		clientVersion: config.extensionContext?.client?.version,
 		clientVersionHeaderFallback: config.headers?.["X-CLIENT-VERSION"],
+		platform: config.extensionContext?.client?.platform,
+		platformVersion: config.extensionContext?.client?.platformVersion,
+		isMultiRoot: config.extensionContext?.client?.isMultiRoot,
 		coreVersion: corePackageVersion,
 	});
 	// TODO: (bee) Move header resolution logic into @cline/llms

--- a/sdk/packages/shared/src/extensions/context.ts
+++ b/sdk/packages/shared/src/extensions/context.ts
@@ -10,6 +10,7 @@ import type {
  * The IDE or client surface the user is running Cline from.
  */
 export type ClientName =
+	| "VSCode Extension"
 	| "cline-vscode"
 	| "cline-jetbrains"
 	| "cline-cli"
@@ -20,13 +21,19 @@ export type ClientName =
 	| (string & {});
 
 /**
- * Identity of the calling client (surface + version).
+ * Identity of the calling client and host surface.
  */
 export interface ClientContext {
-	/** e.g. "cline-vscode", "cline-cli", "cline-sdk" */
+	/** e.g. "VSCode Extension", "cline-cli", "cline-sdk" */
 	name: ClientName;
-	/** Semver string, e.g. "3.12.0" */
+	/** Cline client/extension semver string, e.g. "3.12.0" */
 	version?: string;
+	/** Host platform display name, e.g. "Visual Studio Code", "Cursor", "cli" */
+	platform?: string;
+	/** Host platform version, e.g. vscode.version or the CLI version */
+	platformVersion?: string;
+	/** Whether the host workspace currently has multiple roots. */
+	isMultiRoot?: boolean;
 }
 
 /**

--- a/sdk/packages/shared/src/extensions/context.ts
+++ b/sdk/packages/shared/src/extensions/context.ts
@@ -10,7 +10,6 @@ import type {
  * The IDE or client surface the user is running Cline from.
  */
 export type ClientName =
-	| "VSCode Extension"
 	| "cline-vscode"
 	| "cline-jetbrains"
 	| "cline-cli"
@@ -24,7 +23,7 @@ export type ClientName =
  * Identity of the calling client and host surface.
  */
 export interface ClientContext {
-	/** e.g. "VSCode Extension", "cline-cli", "cline-sdk" */
+	/** Client type emitted to Cline request headers, e.g. "VSCode Extension", "cline-cli", "cline-sdk" */
 	name: ClientName;
 	/** Cline client/extension semver string, e.g. "3.12.0" */
 	version?: string;

--- a/sdk/packages/shared/src/index.browser.ts
+++ b/sdk/packages/shared/src/index.browser.ts
@@ -193,7 +193,14 @@ export {
 	resolveReasoningBudgetFromRatio,
 	resolveReasoningEffortRatio,
 } from "./llms/reasoning-effort";
-export { DEFAULT_REQUEST_HEADERS, serializeAbortReason } from "./llms/requests";
+export {
+	buildClineClientRequestHeaders,
+	type ClineClientRequestHeadersInput,
+	DEFAULT_REQUEST_HEADERS,
+	type MergeClineClientRequestHeadersInput,
+	mergeClineClientRequestHeaders,
+	serializeAbortReason,
+} from "./llms/requests";
 export { CHARS_PER_TOKEN, estimateTokens } from "./llms/tokens";
 export type {
 	ToolApprovalRequest,

--- a/sdk/packages/shared/src/index.ts
+++ b/sdk/packages/shared/src/index.ts
@@ -207,7 +207,14 @@ export {
 	resolveReasoningBudgetFromRatio,
 	resolveReasoningEffortRatio,
 } from "./llms/reasoning-effort";
-export { DEFAULT_REQUEST_HEADERS, serializeAbortReason } from "./llms/requests";
+export {
+	buildClineClientRequestHeaders,
+	type ClineClientRequestHeadersInput,
+	DEFAULT_REQUEST_HEADERS,
+	type MergeClineClientRequestHeadersInput,
+	mergeClineClientRequestHeaders,
+	serializeAbortReason,
+} from "./llms/requests";
 export { CHARS_PER_TOKEN, estimateTokens } from "./llms/tokens";
 export type {
 	ToolApprovalRequest,

--- a/sdk/packages/shared/src/llms/requests.ts
+++ b/sdk/packages/shared/src/llms/requests.ts
@@ -5,6 +5,78 @@ export const DEFAULT_REQUEST_HEADERS: Record<string, string> = {
 	"X-CLIENT-TYPE": "cline-sdk",
 };
 
+function isClineBillingProvider(providerId: string): boolean {
+	return providerId === "cline" || providerId === "cline-pass";
+}
+
+function trimNonEmpty(value: string | undefined): string | undefined {
+	const trimmed = value?.trim();
+	return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}
+
+function resolveSource(
+	source: string | undefined,
+	defaultSource: string,
+): string {
+	return trimNonEmpty(source) ?? defaultSource;
+}
+
+function resolveClineClientVersion(input: {
+	clientVersion?: string;
+	clientVersionHeaderFallback?: string;
+}): string {
+	return (
+		trimNonEmpty(input.clientVersion) ??
+		trimNonEmpty(input.clientVersionHeaderFallback) ??
+		"unknown"
+	);
+}
+
+export interface ClineClientRequestHeadersInput {
+	providerId: string;
+	sessionId: string;
+	source?: string;
+	defaultSource: string;
+	clientVersion?: string;
+	clientVersionHeaderFallback?: string;
+	coreVersion: string;
+}
+
+export function buildClineClientRequestHeaders(
+	input: ClineClientRequestHeadersInput,
+): Record<string, string> | undefined {
+	if (!isClineBillingProvider(input.providerId)) {
+		return undefined;
+	}
+	const source = resolveSource(input.source, input.defaultSource);
+	const clientVersion = resolveClineClientVersion(input);
+	return {
+		...DEFAULT_REQUEST_HEADERS,
+		"User-Agent": `Cline/${clientVersion}`,
+		"X-CLIENT-TYPE": `cline-${source}`,
+		"X-CLIENT-VERSION": clientVersion,
+		"X-PLATFORM": source,
+		"X-PLATFORM-VERSION": clientVersion,
+		"X-CORE-VERSION": input.coreVersion,
+		"X-Task-ID": input.sessionId,
+	};
+}
+
+export interface MergeClineClientRequestHeadersInput
+	extends ClineClientRequestHeadersInput {
+	headers: ReadonlyArray<Record<string, string> | undefined>;
+}
+
+export function mergeClineClientRequestHeaders(
+	input: MergeClineClientRequestHeadersInput,
+): Record<string, string> | undefined {
+	const requiredHeaders = buildClineClientRequestHeaders(input);
+	if (!requiredHeaders) {
+		return undefined;
+	}
+	return Object.assign({}, ...input.headers, requiredHeaders);
+}
+
 export function serializeAbortReason(reason: unknown): unknown {
 	return reason instanceof Error
 		? { name: reason.name, message: reason.message }

--- a/sdk/packages/shared/src/llms/requests.ts
+++ b/sdk/packages/shared/src/llms/requests.ts
@@ -32,13 +32,21 @@ function resolveClineClientVersion(input: {
 	);
 }
 
+function resolveOptionalHeader(value: string | undefined): string | undefined {
+	return trimNonEmpty(value);
+}
+
 export interface ClineClientRequestHeadersInput {
 	providerId: string;
 	sessionId: string;
 	source?: string;
 	defaultSource: string;
+	clientName?: string;
 	clientVersion?: string;
 	clientVersionHeaderFallback?: string;
+	platform?: string;
+	platformVersion?: string;
+	isMultiRoot?: boolean;
 	coreVersion: string;
 }
 
@@ -49,14 +57,20 @@ export function buildClineClientRequestHeaders(
 		return undefined;
 	}
 	const source = resolveSource(input.source, input.defaultSource);
+	const clientName =
+		resolveOptionalHeader(input.clientName) ?? `cline-${source}`;
 	const clientVersion = resolveClineClientVersion(input);
+	const platform = resolveOptionalHeader(input.platform) ?? source;
+	const platformVersion =
+		resolveOptionalHeader(input.platformVersion) ?? clientVersion;
 	return {
 		...DEFAULT_REQUEST_HEADERS,
 		"User-Agent": `Cline/${clientVersion}`,
-		"X-CLIENT-TYPE": `cline-${source}`,
+		"X-IS-MULTIROOT": input.isMultiRoot === true ? "true" : "false",
+		"X-CLIENT-TYPE": clientName,
 		"X-CLIENT-VERSION": clientVersion,
-		"X-PLATFORM": source,
-		"X-PLATFORM-VERSION": clientVersion,
+		"X-PLATFORM": platform,
+		"X-PLATFORM-VERSION": platformVersion,
 		"X-CORE-VERSION": input.coreVersion,
 		"X-Task-ID": input.sessionId,
 	};

--- a/sdk/packages/shared/src/llms/requests.ts
+++ b/sdk/packages/shared/src/llms/requests.ts
@@ -1,3 +1,5 @@
+import type { ClientName } from "../extensions/context";
+
 export const DEFAULT_REQUEST_HEADERS: Record<string, string> = {
 	"HTTP-Referer": "https://cline.bot",
 	"X-Title": "Cline",
@@ -41,7 +43,7 @@ export interface ClineClientRequestHeadersInput {
 	sessionId: string;
 	source?: string;
 	defaultSource: string;
-	clientName?: string;
+	clientName?: ClientName;
 	clientVersion?: string;
 	clientVersionHeaderFallback?: string;
 	platform?: string;
@@ -57,7 +59,7 @@ export function buildClineClientRequestHeaders(
 		return undefined;
 	}
 	const source = resolveSource(input.source, input.defaultSource);
-	const clientName =
+	const clientType =
 		resolveOptionalHeader(input.clientName) ?? `cline-${source}`;
 	const clientVersion = resolveClineClientVersion(input);
 	const platform = resolveOptionalHeader(input.platform) ?? source;
@@ -67,7 +69,7 @@ export function buildClineClientRequestHeaders(
 		...DEFAULT_REQUEST_HEADERS,
 		"User-Agent": `Cline/${clientVersion}`,
 		"X-IS-MULTIROOT": input.isMultiRoot === true ? "true" : "false",
-		"X-CLIENT-TYPE": clientName,
+		"X-CLIENT-TYPE": clientType,
 		"X-CLIENT-VERSION": clientVersion,
 		"X-PLATFORM": platform,
 		"X-PLATFORM-VERSION": platformVersion,


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->
Requests to Cline's billing providers (`cline` and `cline-pass`) now carry a
consistent, versioned set of client-identity headers regardless of which runtime
issued them — the VS Code extension, standalone `cline-core`, or the CLI/ACP agent.
Previously these headers were built ad-hoc and were incomplete: the client
**version** was not propagated (the CLI sent a client name with no version, and
the ACP agent sent no client context at all), and only `openai-codex` had a
dedicated header-construction path.
### What changed
- **New shared header builders** in `@cline/shared` (`llms/requests.ts`), exported
  from both the node and browser entrypoints:
  - `buildClineClientRequestHeaders(...)` returns the canonical Cline header set
    (`HTTP-Referer`, `X-Title`, `X-IS-MULTIROOT`, `User-Agent`, `X-CLIENT-TYPE`,
    `X-CLIENT-VERSION`, `X-PLATFORM`, `X-PLATFORM-VERSION`, `X-CORE-VERSION`,
    `X-Task-ID`) **only** for Cline billing providers, and `undefined` otherwise.
  - `mergeClineClientRequestHeaders(...)` merges caller-supplied headers
    (stored → config) and overlays the required Cline headers so they always win.
  - Version resolution falls back `clientVersion` → `X-CLIENT-VERSION` → `"unknown"`;
    source falls back to a per-runtime default.
- **`local-runtime-bootstrap`**: threads the session `source` through and applies
  the Cline headers to both provider settings and the resolved provider config,
  while preserving the existing `openai-codex` path.
- **`hub-runtime-host`**: builds the same headers for `session.create` / start-session
  via a new `buildCommandSessionConfig(...)` helper.
- **CLI (`main.ts`) & ACP (`acpAgent.ts`)**: now pass a real client `version` from
  `getCliBuildInfo()`; ACP now supplies the full `extensionContext` (client +
  workspace metadata) it previously omitted.
  
### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

Before behavior
- Requests to cline / cline-pass went out without consistent client-identity headers.
- No client version was propagated (CLI sent name only; ACP sent nothing).
- Header building in local-runtime-bootstrap only had a dedicated path for openai-codex; everything else just passed through config.headers ?? stored?.headers.

After behavior
- A shared header builder lives in sdk/packages/shared/src/llms/requests.ts:
  - buildClineClientRequestHeaders(...) — returns the canonical header set only when the provider is a Cline billing provider (cline / cline-pass), otherwise undefined.
  - mergeClineClientRequestHeaders(...) — merges caller-supplied headers (stored → config) and then overlays the required Cline headers so the required ones always win.
  - Both are re-exported from @cline/shared (node + browser entrypoints).
- Version resolution has a sensible fallback chain: clientVersion → X-CLIENT-VERSION header fallback → "unknown"; source falls back to a per-runtime default (CLI in bootstrap, CORE in the hub host).
- local-runtime-bootstrap.ts now builds these headers (threading through the session source) and applies them to both settings.headers and the resolved providerConfig.headers, while preserving the existing openai-codex path.
- hub-runtime-host.ts builds the same headers for the session.create / start-session command config via a new buildCommandSessionConfig(...) helper.
- The CLI (main.ts) and ACP agent (acpAgent.ts) now pass a real client version from getCliBuildInfo(), and ACP now supplies a full extensionContext (client + workspace metadata) it previously omitted.
- New tests assert the exact header set for cline, cline-pass, and core-source sessions, and header precedence (config wins over stored; required Cline headers win over both).


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
