### PR TITLE
docs: add Cline free models page

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -67,6 +67,7 @@
 							"getting-started/installing-cline",
 							"getting-started/cline-provider",
 							"getting-started/clinepass",
+							"getting-started/free-models",
 							{
 								"group": "Other Models & Providers",
 								"pages": [

--- a/docs/getting-started/free-models.mdx
+++ b/docs/getting-started/free-models.mdx
@@ -1,0 +1,65 @@
+---
+title: "Cline Free Models"
+description: "Limited-time free model promotions for users with a Cline account."
+---
+
+Cline periodically offers **free model promotions** that let you try select models at no cost, up to a limited usage quota. It's a simple way to explore Cline and experiment with different models before choosing a paid option.
+
+<Note>
+Free model promotions are offered on a rotating, limited-time basis. The specific free models available may change over time.
+</Note>
+
+## How it works
+
+Free models are available to any user with a Cline account.
+
+After you use your free model quota, you can continue coding with Cline by switching to either:
+
+- **[ClinePass](/getting-started/clinepass)** — a flat $9.99/month subscription with 2-5x API rate limits on popular open coding models
+- **[Cline (usage-billing)](/getting-started/cline-provider)** — pay-as-you-go access with Cline credits across 100+ models
+
+Both options let you keep working after your free quota is exhausted.
+
+## Where to find free models
+
+You can find free models under **both** Cline providers:
+
+### Cline (usage-billing)
+
+In the Cline (usage-billing) provider, look for models tagged **FREE** in the model selector.
+
+- **IDE Extension**: Go to IDE extension settings, set **API Provider** to **Cline**, and look for free-tagged models.
+- **CLI**: Go to `/settings`, select **Cline** as your provider, and browse available free models.
+
+### ClinePass
+
+During promotional periods, free models are also available through the ClinePass provider.
+
+- **IDE Extension**: Go to IDE extension settings, set **API Provider** to **ClinePass**, and sign in.
+- **CLI**: Go to `/settings`, select **ClinePass** as your provider.
+
+## Important notes
+
+### API access
+
+Free model usage is **not supported through the Cline API**. Free models are only available in the Cline IDE Extension and CLI.
+
+### Model improvements
+
+Free model usage may be used to help improve model performance and quality.
+
+## After your free quota
+
+When your free quota runs out, you have several options:
+
+| Option | Best for |
+|--------|----------|
+| [ClinePass](/getting-started/clinepass) ($9.99/mo) | Frequent users who want reliable access to curated open models with higher rate limits |
+| [Cline (usage-billing)](/getting-started/cline-provider) | Flexible, pay-as-you-go access across 100+ models |
+| [Bring your own API key](/provider-config/anthropic) | Users who already have API keys from other providers |
+
+## Related
+
+- [ClinePass](/getting-started/clinepass)
+- [Cline (usage-billing)](/getting-started/cline-provider)
+- [Authorization](/getting-started/authorizing-with-cline)


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Adds a new "Cline Free Models" documentation page under Getting Started, immediately after the ClinePass page.

This page explains:

- Free models are available to any user with a Cline account
- Free model promotions are limited by quota and may change over time
- Users can find free models under both Cline (usage-billing) and ClinePass providers
- Free model usage is not supported through the Cline API
- Free model usage may be used to help improve model performance and quality
- Users can switch to ClinePass or Cline (usage-billing) after exhausting free quota

### Test Procedure

- Verified `docs/docs.json` parses as valid JSON.
- Ran `npm run check` in `docs/` and confirmed Mintlify reported no broken links.
- Reviewed the new MDX page and navigation entry.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — docs-only content update. Screenshots for Extension and CLI can be added later when available.

### Additional Notes

This PR intentionally uses `#XXXX` for the related issue placeholder because no issue number was provided for this small documentation update.
