### PR TITLE
fix(vscode): restore multi-root mention resolution and validate stored task cwd

### DIFF
--- a/apps/vscode/src/core/workspace/WorkspaceRootManager.ts
+++ b/apps/vscode/src/core/workspace/WorkspaceRootManager.ts
@@ -42,6 +42,28 @@ export class WorkspaceRootManager {
 	}
 
 	/**
+	 * Initialize from host-provided workspace folder paths (multi-root aware)
+	 */
+	static async fromPaths(paths: string[]): Promise<WorkspaceRootManager> {
+		const roots: WorkspaceRoot[] = await Promise.all(
+			paths.map(async (workspacePath) => {
+				const vcs = await WorkspaceRootManager.detectVcs(workspacePath)
+				const gitHash = vcs === VcsType.Git ? await getLatestGitCommitHash(workspacePath) : null
+				const commitHash = gitHash === null ? undefined : gitHash
+
+				return {
+					path: workspacePath,
+					name: path.basename(workspacePath),
+					vcs,
+					commitHash,
+				}
+			}),
+		)
+
+		return new WorkspaceRootManager(roots, 0)
+	}
+
+	/**
 	 * Detect version control system for a directory
 	 */
 	private static async detectVcs(dirPath: string): Promise<VcsType> {

--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -32,7 +32,7 @@ import { ensureMcpServersDirectoryExists } from "@/core/storage/disk"
 import { refreshSdkRemoteConfig } from "@/core/storage/remote-config/sdk-refresh"
 import { clearRemoteConfig } from "@/core/storage/remote-config/utils"
 import { StateManager } from "@/core/storage/StateManager"
-import type { WorkspaceRootManager } from "@/core/workspace/WorkspaceRootManager"
+import { WorkspaceRootManager } from "@/core/workspace/WorkspaceRootManager"
 import { HostProvider } from "@/hosts/host-provider"
 import type { ITerminalManager } from "@/integrations/terminal/types"
 import { ExtensionRegistryInfo } from "@/registry"
@@ -1917,8 +1917,26 @@ export class Controller {
 
 	// ---- Workspace (kept from classic) ----
 
+	private _workspaceManager?: WorkspaceRootManager
+	private _workspaceManagerPathsKey?: string
+
 	async ensureWorkspaceManager(): Promise<WorkspaceRootManager | undefined> {
-		stubWarn("ensureWorkspaceManager")
-		return undefined
+		try {
+			const { paths } = await HostProvider.workspace.getWorkspacePaths({})
+			const validPaths = (paths ?? []).filter((workspacePath) => workspacePath.trim().length > 0)
+			if (validPaths.length === 0) {
+				return undefined
+			}
+			// Rebuild only when the set of workspace folders changes
+			const pathsKey = validPaths.join(" ")
+			if (!this._workspaceManager || this._workspaceManagerPathsKey !== pathsKey) {
+				this._workspaceManager = await WorkspaceRootManager.fromPaths(validPaths)
+				this._workspaceManagerPathsKey = pathsKey
+			}
+			return this._workspaceManager
+		} catch (error) {
+			Logger.warn("[SdkController] Failed to build workspace manager:", error)
+			return undefined
+		}
 	}
 }

--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -1928,7 +1928,7 @@ export class Controller {
 				return undefined
 			}
 			// Rebuild only when the set of workspace folders changes
-			const pathsKey = validPaths.join(" ")
+			const pathsKey = JSON.stringify(validPaths)
 			if (!this._workspaceManager || this._workspaceManagerPathsKey !== pathsKey) {
 				this._workspaceManager = await WorkspaceRootManager.fromPaths(validPaths)
 				this._workspaceManagerPathsKey = pathsKey

--- a/apps/vscode/src/sdk/sdk-task-start-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-task-start-coordinator.test.ts
@@ -1,6 +1,7 @@
 import type { HistoryItem } from "@shared/HistoryItem"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import type { StateManager } from "@/core/storage/StateManager"
+import { isDirectory } from "@/utils/fs"
 import { PROVIDER_FAILURE_ERROR_TYPE, PROVIDER_FAILURE_PHASE } from "./provider-failure-telemetry"
 import { SdkTaskStartCoordinator, type SdkTaskStartCoordinatorOptions } from "./sdk-task-start-coordinator"
 
@@ -12,9 +13,14 @@ vi.mock("@/shared/services/Logger", () => ({
 	},
 }))
 
+vi.mock("@/utils/fs", () => ({
+	isDirectory: vi.fn(),
+}))
+
 describe("SdkTaskStartCoordinator", () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
+		vi.mocked(isDirectory).mockResolvedValue(false)
 	})
 
 	it("initializes a new task, emits the task message, and sends the resolved prompt", async () => {
@@ -138,6 +144,7 @@ describe("SdkTaskStartCoordinator", () => {
 	})
 
 	it("reinitializes an existing task with preserved initial messages", async () => {
+		vi.mocked(isDirectory).mockResolvedValue(true)
 		const historyItem: HistoryItem = {
 			id: "task-1",
 			task: "old task",
@@ -153,6 +160,8 @@ describe("SdkTaskStartCoordinator", () => {
 
 		expect(options.clearTask).toHaveBeenCalledOnce()
 		expect(options.taskHistory.findHistoryItem).toHaveBeenCalledWith("task-1")
+		expect(isDirectory).toHaveBeenCalledWith("/task-cwd")
+		expect(options.getWorkspaceRoot).not.toHaveBeenCalled()
 		expect(options.sessionConfigBuilder.build).toHaveBeenCalledWith({ cwd: "/task-cwd", mode: "act" })
 		expect(options.createTempSessionHost).toHaveBeenCalledOnce()
 		expect(options.loadInitialMessages).toHaveBeenCalledWith(tempHost, "task-1")
@@ -168,6 +177,25 @@ describe("SdkTaskStartCoordinator", () => {
 		})
 		expect(state.task?.taskId).toBe("session-123")
 		expect(options.postStateToWebview).toHaveBeenCalledOnce()
+	})
+
+	it("falls back to the workspace root when a stored task cwd is unavailable", async () => {
+		const historyItem: HistoryItem = {
+			id: "task-1",
+			task: "old task",
+			ts: 1,
+			tokensIn: 0,
+			tokensOut: 0,
+			totalCost: 0,
+			cwdOnTaskInitialization: "/missing-task-cwd",
+		}
+		const { coordinator, options } = makeCoordinator({ historyItem })
+
+		await coordinator.reinitExistingTaskFromId("task-1")
+
+		expect(isDirectory).toHaveBeenCalledWith("/missing-task-cwd")
+		expect(options.getWorkspaceRoot).toHaveBeenCalledOnce()
+		expect(options.sessionConfigBuilder.build).toHaveBeenCalledWith({ cwd: "/workspace", mode: "act" })
 	})
 
 	it("emits Cline auth errors when reinitialization fails due auth", async () => {

--- a/apps/vscode/src/sdk/sdk-task-start-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-task-start-coordinator.ts
@@ -7,6 +7,7 @@ import type { Settings } from "@shared/storage/state-keys"
 import type { Mode } from "@shared/storage/types"
 import type { StateManager } from "@/core/storage/StateManager"
 import { Logger } from "@/shared/services/Logger"
+import { isDirectory } from "@/utils/fs"
 import { PROVIDER_FAILURE_ERROR_TYPE, PROVIDER_FAILURE_PHASE, type ProviderFailureTelemetry } from "./provider-failure-telemetry"
 import type { SdkMessageCoordinator } from "./sdk-message-coordinator"
 import type { SdkSessionConfigBuilder } from "./sdk-session-config-builder"
@@ -175,7 +176,12 @@ export class SdkTaskStartCoordinator {
 				return
 			}
 
-			const cwd = historyItem.cwdOnTaskInitialization ?? (await this.options.getWorkspaceRoot())
+			// A task's stored cwd may have been deleted/moved since the task ran
+			// (or migrated from another machine) — feeding a stale path into the
+			// session bootstrap makes workspace init fail. Fall back to the live
+			// workspace root instead.
+			const storedCwd = historyItem.cwdOnTaskInitialization
+			const cwd = storedCwd && (await isDirectory(storedCwd)) ? storedCwd : await this.options.getWorkspaceRoot()
 			const config = await this.options.sessionConfigBuilder.build({
 				cwd,
 				mode: "act",


### PR DESCRIPTION
### Related Issue

**Linear:** [ENG-2245 — mention failure spike during migration process](https://linear.app/cline-bot/issue/ENG-2245/mention-failure-spike-during-migration-process) (also the stale-cwd half of [ENG-2244](https://linear.app/cline-bot/issue/ENG-2244/workspace-init-error-spike-during-migration-process))

### Description

During the v4.0.0 window we saw a large spike in `captureMentionFailed(..., "not_found")` telemetry (ENG-2245). The mention-parsing code (`core/mentions/index.ts`) didn't change in the SDK migration — **the caller did**, and that's where the regression lives.

**The debugging journey:** comparing the pre-migration call site (`git show 864419d8b:apps/vscode/src/core/task/index.ts` — `parseMentions(text, this.cwd, ..., this.workspaceManager)` with a real `WorkspaceRootManager`) against the migrated one (`SdkController.resolveContextMentions()`), the SDK adapter passes `workspaceManager` from `ensureWorkspaceManager()` — **which was a stub that logged a warning and always returned `undefined`**.

That single `undefined` silently disabled multi-root mention resolution: `isMultiRoot` in `parseMentions` is always false, so every `@/path` mention resolves only against the primary cwd. A mention of a file in a **secondary workspace root** — which resolved fine pre-migration via parallel search across all roots — now ENOENTs and emits `not_found`. Worse, `resolveContextMentions` swallows failures back to raw text, so users never saw an error; the model just silently never got the referenced file content. The telemetry spike was the only visible signal.

**Fix 1 (`ensureWorkspaceManager`):** build a real `WorkspaceRootManager` from the host's actual workspace folders via a new `WorkspaceRootManager.fromPaths()` factory (multi-root-aware sibling of the existing `fromLegacyCwd()`, including per-root VCS detection and commit hash). The manager is cached and only rebuilt when the set of workspace folders changes, since `fromPaths` shells out for VCS detection per root.

**Fix 2 (`sdk-task-start-coordinator`):** resumed tasks used `historyItem.cwdOnTaskInitialization` with no existence check. If that directory was deleted/moved since the task ran (or the history item was migrated), the stale path flowed into session bootstrap → git-based workspace init failed → `workspace.init_error` telemetry (the extension-side half of ENG-2244). Now validated with `isDirectory()` and falls back to the live workspace root.

**Non-obvious gotcha for reviewers:** `getWorkspaceRoot()`'s Desktop fallback (when no workspace folder is open) is left as-is — it exists to avoid the extension host's `process.cwd()` (often `/`). This PR narrows how often bad paths reach git, it doesn't redesign root resolution. The broader `WorkspaceRootManager` port (other stubbed call sites on `SdkController`) is intentionally not attempted here.

### Test Procedure

- `bunx tsc --noEmit` clean for the extension (and webview untouched); biome lint clean on all three changed files
- `bunx vitest run src/sdk/toggle-plan-act-mode.test.ts` + workspace tests pass
- Manual reasoning on the cache: key is the joined valid-paths list, so adding/removing a workspace folder rebuilds the manager; same folders reuse it (mention parsing runs per message containing `@`, and `fromPaths` spawns git per root — we don't want that on every message)
- What could break: `parseMentions` behavior for single-root users. It now receives a real manager with 1 root instead of `undefined`; `isMultiRoot` requires `getRoots().length > 1`, so single-root users stay on the legacy code path — behavior unchanged for them.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

Sibling PR #12189 fixes the SDK-core half of ENG-2244 (benign git states misreported as init errors). To confirm impact after shipping: mention `not_found` failures should drop for multi-root sessions specifically, and `[SdkController] STUB: ensureWorkspaceManager` should disappear from extension logs.
