### PR TITLE
feat(cli): show team active indicator in status bar

### DIFF
--- a/apps/cli/src/tui/components/status-bar.tsx
+++ b/apps/cli/src/tui/components/status-bar.tsx
@@ -146,6 +146,7 @@ export interface StatusBarProps {
 	} | null;
 	onToggleMode?: () => void;
 	variant?: "home" | "chat";
+	isTeamActive?: boolean;
 }
 
 export function StatusBar(props: StatusBarProps) {
@@ -247,6 +248,12 @@ export function StatusBar(props: StatusBarProps) {
 					flexShrink={0}
 					onMouseDown={onToggleMode}
 				>
+					{props.isTeamActive && (
+						<>
+							<text fg="cyan">@team</text>
+							<text fg="gray">|</text>
+						</>
+					)}
 					<text fg={uiMode === "plan" ? planAccent : "gray"}>
 						{uiMode === "plan" ? "●" : "○"} Plan
 					</text>

--- a/apps/cli/src/tui/contexts/session-context.tsx
+++ b/apps/cli/src/tui/contexts/session-context.tsx
@@ -24,6 +24,8 @@ interface SessionContextValue {
 	lastTotalTokens: number;
 	lastTotalCost: number;
 	isExitRequested: boolean;
+	isTeamActive: boolean;
+	teamRunCount: number;
 
 	appendEntry: (entry: ChatEntry) => void;
 	updateLastEntry: (updater: (prev: ChatEntry) => ChatEntry) => void;
@@ -45,6 +47,7 @@ interface SessionContextValue {
 	requestExit: () => void;
 	clearEntries: () => void;
 	replaceEntries: (entries: ChatEntry[]) => void;
+	setTeamActive: (active: boolean) => void;
 }
 
 type UsageDelta = {
@@ -126,6 +129,8 @@ export function SessionProvider(props: {
 		() => initialUsage?.totalCost ?? 0,
 	);
 	const [isExitRequested, setIsExitRequested] = useState(false);
+	const [isTeamActive, setIsTeamActive] = useState(false);
+	const [teamRunCount, setTeamRunCount] = useState(0);
 
 	const activeInlineStreamRef = useRef<InlineStream>(undefined);
 
@@ -248,6 +253,16 @@ export function SessionProvider(props: {
 		);
 	}, []);
 
+	const setTeamActive = useCallback(
+		(active: boolean) => {
+			setIsTeamActive(active);
+			if (!active) {
+				setTeamRunCount(0);
+			}
+		},
+		[],
+	);
+
 	const value: SessionContextValue = {
 		entries,
 		isRunning,
@@ -260,6 +275,8 @@ export function SessionProvider(props: {
 		lastTotalTokens,
 		lastTotalCost,
 		isExitRequested,
+		isTeamActive,
+		teamRunCount,
 		appendEntry,
 		updateLastEntry,
 		updateEntry,
@@ -279,6 +296,7 @@ export function SessionProvider(props: {
 		requestExit,
 		clearEntries,
 		replaceEntries,
+		setTeamActive,
 	};
 
 	return (

--- a/apps/cli/src/tui/hooks/use-agent-events.ts
+++ b/apps/cli/src/tui/hooks/use-agent-events.ts
@@ -29,6 +29,7 @@ interface AgentEventDeps {
 	}) => void;
 	onTurnErrorReported: TuiProps["onTurnErrorReported"];
 	verbose: boolean;
+	setTeamActive: (active: boolean) => void;
 }
 
 export function useAgentEventHandlers(deps: AgentEventDeps) {
@@ -43,6 +44,7 @@ export function useAgentEventHandlers(deps: AgentEventDeps) {
 		addUsageDelta,
 		onTurnErrorReported,
 		verbose,
+		setTeamActive,
 	} = deps;
 
 	const closeToolEntry = useCallback(
@@ -211,6 +213,8 @@ export function useAgentEventHandlers(deps: AgentEventDeps) {
 		],
 	);
 
+	const activeTeamRunsRef = useRef(0);
+
 	const handleTeamEvent = useCallback(
 		(event: TeamEvent) => {
 			const team = (text: string) => {
@@ -238,6 +242,8 @@ export function useAgentEventHandlers(deps: AgentEventDeps) {
 					);
 					break;
 				case "run_queued":
+					activeTeamRunsRef.current += 1;
+					setTeamActive(true);
 					team(`[team run] queued ${event.run.id} -> ${event.run.agentId} ...`);
 					break;
 				case "run_started":
@@ -250,17 +256,33 @@ export function useAgentEventHandlers(deps: AgentEventDeps) {
 					team(`[team run] progress ${event.run.id}: ${event.message}`);
 					break;
 				case "run_completed":
+					activeTeamRunsRef.current = Math.max(0, activeTeamRunsRef.current - 1);
+					if (activeTeamRunsRef.current === 0) {
+						setTeamActive(false);
+					}
 					team(`[team run] completed ${event.run.id}`);
 					break;
 				case "run_failed":
+					activeTeamRunsRef.current = Math.max(0, activeTeamRunsRef.current - 1);
+					if (activeTeamRunsRef.current === 0) {
+						setTeamActive(false);
+					}
 					team(
 						`[team run] failed ${event.run.id}: ${event.run.error ?? "unknown error"}`,
 					);
 					break;
 				case "run_cancelled":
+					activeTeamRunsRef.current = Math.max(0, activeTeamRunsRef.current - 1);
+					if (activeTeamRunsRef.current === 0) {
+						setTeamActive(false);
+					}
 					team(`[team run] cancelled ${event.run.id}`);
 					break;
 				case "run_interrupted":
+					activeTeamRunsRef.current = Math.max(0, activeTeamRunsRef.current - 1);
+					if (activeTeamRunsRef.current === 0) {
+						setTeamActive(false);
+					}
 					team(`[team run] interrupted ${event.run.id}`);
 					break;
 				case "outcome_created":
@@ -287,7 +309,7 @@ export function useAgentEventHandlers(deps: AgentEventDeps) {
 					break;
 			}
 		},
-		[appendEntry, closeInlineStream],
+		[appendEntry, closeInlineStream, setTeamActive],
 	);
 
 	const handlePendingPrompts = useCallback((event: PendingPromptSnapshot) => {

--- a/apps/cli/src/tui/root.tsx
+++ b/apps/cli/src/tui/root.tsx
@@ -731,6 +731,7 @@ function App(props: TuiProps) {
 		addUsageDelta: session.addUsageDelta,
 		onTurnErrorReported: props.onTurnErrorReported,
 		verbose: props.config.verbose ?? false,
+		setTeamActive: session.setTeamActive,
 	});
 
 	const promptInput = usePromptInputController({

--- a/apps/cli/src/tui/views/chat-view.tsx
+++ b/apps/cli/src/tui/views/chat-view.tsx
@@ -162,6 +162,7 @@ export function ChatView(props: {
 					gitDiffStats={repoStatus.diffStats}
 					onToggleMode={props.onToggleMode}
 					variant="chat"
+					isTeamActive={session.isTeamActive}
 				/>
 			</box>
 		</box>


### PR DESCRIPTION
## Summary

When using `/team` to spawn agents, there was **no visible indication** in the CLI TUI that team tasks were running. Users had to scroll through the chat transcript to find `[team]` entries to confirm teams were active.

## Fix

Added an **`@team` indicator** in cyan to the status bar, shown next to the Plan/Act toggle when team runs are active.

```
<cyan>@team</cyan> <gray>|</gray> ○ Plan ● Act (Tab)
```

The indicator appears when a team run is queued and disappears when all runs complete.

### Implementation
- **`session-context.tsx`** — added `isTeamActive` state and `setTeamActive` setter
- **`use-agent-events.ts`** — tracks active runs via `useRef` counter; increments on `run_queued`, decrements on `run_completed/run_failed/run_cancelled/run_interrupted`
- **`status-bar.tsx`** — renders `@team` cyan indicator when `isTeamActive`
- **`chat-view.tsx`** / **`root.tsx`** — wires the new state through

## Test

- CLI build passes clean
- Test failures are pre-existing (Zod import issues in test infra)

Fixes #12090