### PR TITLE
fix(cli): prevent spawned agent output from breaking per-word in TUI

### DIFF
--- a/apps/cli/src/tui/utils/tool-parsing.ts
+++ b/apps/cli/src/tui/utils/tool-parsing.ts
@@ -203,7 +203,7 @@ export function extractFullOutputText(raw: unknown): string | undefined {
 				}
 			}
 		}
-		if (parts.length > 0) return parts.join("\n");
+		if (parts.length > 0) return parts.join(" ");
 	}
 
 	if (typeof raw === "object") {


### PR DESCRIPTION
## Summary

When spawning agents to review code changes, the review messages appeared with each word on its own line, making them unreadable.

## Root cause

`extractFullOutputText` in `tool-parsing.ts` joined text content parts with `"\n"` (newline). When a spawned agent returned output as an array of text items (common in ACP tool results), each text fragment rendered on a separate line.

## Fix

Changed `join("\n")` to `join(" ")` — text content parts are contiguous content, so joining with spaces is correct. Internal line breaks within individual text parts are preserved.

Fixes #12184