### PR TITLE
fix(core): strip UTF-8 BOM before parsing settings JSON

### DIFF
--- a/sdk/packages/core/src/extensions/mcp/config-loader.test.ts
+++ b/sdk/packages/core/src/extensions/mcp/config-loader.test.ts
@@ -99,6 +99,55 @@ describe("mcp config loader", () => {
 		]);
 	});
 
+	it("loads MCP settings files with a leading UTF-8 BOM", async () => {
+		const tempRoot = await mkdtemp(join(tmpdir(), "core-mcp-config-loader-"));
+		tempRoots.push(tempRoot);
+		const filePath = join(tempRoot, "cline_mcp_settings.json");
+		await writeFile(
+			filePath,
+			`\uFEFF${JSON.stringify({
+				mcpServers: {
+					docs: {
+						transport: {
+							type: "stdio",
+							command: "node",
+						},
+					},
+				},
+			})}`,
+			"utf8",
+		);
+
+		expect(loadMcpSettingsFile({ filePath }).mcpServers.docs.transport).toEqual({
+			type: "stdio",
+			command: "node",
+		});
+	});
+
+	it("updates MCP settings files with a leading UTF-8 BOM", async () => {
+		const tempRoot = await mkdtemp(join(tmpdir(), "core-mcp-config-loader-"));
+		tempRoots.push(tempRoot);
+		const filePath = join(tempRoot, "cline_mcp_settings.json");
+		await writeFile(
+			filePath,
+			`\uFEFF${JSON.stringify({
+				mcpServers: {
+					docs: {
+						transport: {
+							type: "stdio",
+							command: "node",
+						},
+					},
+				},
+			})}`,
+			"utf8",
+		);
+
+		setMcpServerDisabled({ filePath, name: "docs", disabled: true });
+
+		expect(loadMcpSettingsFile({ filePath }).mcpServers.docs.disabled).toBe(true);
+	});
+
 	it("registers loaded servers with an mcp manager", async () => {
 		const tempRoot = await mkdtemp(join(tmpdir(), "core-mcp-config-loader-"));
 		tempRoots.push(tempRoot);

--- a/sdk/packages/core/src/extensions/mcp/config-loader.test.ts
+++ b/sdk/packages/core/src/extensions/mcp/config-loader.test.ts
@@ -189,6 +189,49 @@ describe("mcp config loader", () => {
 		).toEqual([undefined, undefined]);
 	});
 
+	it("loads MCP settings files with a leading UTF-8 BOM", async () => {
+		const tempRoot = await mkdtemp(join(tmpdir(), "core-mcp-config-loader-"));
+		tempRoots.push(tempRoot);
+		const filePath = join(tempRoot, "cline_mcp_settings.json");
+		await writeFile(
+			filePath,
+			`\uFEFF${JSON.stringify({
+				mcpServers: {
+					docs: {
+						transport: { type: "stdio", command: "node" },
+					},
+				},
+			})}`,
+			"utf8",
+		);
+
+		expect(loadMcpSettingsFile({ filePath }).mcpServers.docs.transport).toEqual({
+			type: "stdio",
+			command: "node",
+		});
+	});
+
+	it("updates MCP settings files with a leading UTF-8 BOM", async () => {
+		const tempRoot = await mkdtemp(join(tmpdir(), "core-mcp-config-loader-"));
+		tempRoots.push(tempRoot);
+		const filePath = join(tempRoot, "cline_mcp_settings.json");
+		await writeFile(
+			filePath,
+			`\uFEFF${JSON.stringify({
+				mcpServers: {
+					docs: {
+						transport: { type: "stdio", command: "node" },
+					},
+				},
+			})}`,
+			"utf8",
+		);
+
+		setMcpServerDisabled({ filePath, name: "docs", disabled: true });
+
+		expect(loadMcpSettingsFile({ filePath }).mcpServers.docs.disabled).toBe(true);
+	});
+
 	it("registers loaded servers with an mcp manager", async () => {
 		const tempRoot = await mkdtemp(join(tmpdir(), "core-mcp-config-loader-"));
 		tempRoots.push(tempRoot);

--- a/sdk/packages/core/src/extensions/mcp/config-loader.ts
+++ b/sdk/packages/core/src/extensions/mcp/config-loader.ts
@@ -550,11 +550,15 @@ function runPureSettingsMutator<T>(
 	return result;
 }
 
+function stripJsonBom(raw: string): string {
+	return raw.charCodeAt(0) === 0xfeff ? raw.slice(1) : raw;
+}
+
 function readJsonObject(filePath: string): Record<string, unknown> {
 	const raw = readFileSync(filePath, "utf8");
 	let parsed: unknown;
 	try {
-		parsed = JSON.parse(raw);
+		parsed = JSON.parse(stripJsonBom(raw));
 	} catch (error) {
 		const details = error instanceof Error ? error.message : String(error);
 		throw new Error(
@@ -616,7 +620,7 @@ export function loadMcpSettingsFile(
 	const raw = readFileSync(filePath, "utf8");
 	let parsed: unknown;
 	try {
-		parsed = JSON.parse(raw);
+		parsed = JSON.parse(stripJsonBom(raw));
 	} catch (error) {
 		const details = error instanceof Error ? error.message : String(error);
 		throw new Error(

--- a/sdk/packages/core/src/extensions/mcp/config-loader.ts
+++ b/sdk/packages/core/src/extensions/mcp/config-loader.ts
@@ -16,6 +16,7 @@ import type { BasicLogger } from "@cline/shared";
 import {
 	isMcpTimeoutConfigured,
 	resolveMcpTimeoutSeconds,
+	stripUtf8Bom,
 } from "@cline/shared";
 import { resolveMcpSettingsPath } from "@cline/shared/storage";
 import { z } from "zod";
@@ -615,7 +616,7 @@ function readJsonObject(filePath: string): Record<string, unknown> {
 	const raw = readFileSync(filePath, "utf8");
 	let parsed: unknown;
 	try {
-		parsed = JSON.parse(raw);
+		parsed = JSON.parse(stripUtf8Bom(raw));
 	} catch (error) {
 		const details = error instanceof Error ? error.message : String(error);
 		throw new Error(
@@ -677,7 +678,7 @@ export function loadMcpSettingsFile(
 	const raw = readFileSync(filePath, "utf8");
 	let parsed: unknown;
 	try {
-		parsed = JSON.parse(raw);
+		parsed = JSON.parse(stripUtf8Bom(raw));
 	} catch (error) {
 		const details = error instanceof Error ? error.message : String(error);
 		throw new Error(

--- a/sdk/packages/core/src/services/global-settings.test.ts
+++ b/sdk/packages/core/src/services/global-settings.test.ts
@@ -129,6 +129,31 @@ describe("global-settings", () => {
 		}
 	});
 
+	it("loads global settings files with a leading UTF-8 BOM", async () => {
+		const root = await mkdtemp(join(tmpdir(), "core-global-settings-"));
+		try {
+			const settingsPath = join(root, "global-settings.json");
+			process.env.CLINE_GLOBAL_SETTINGS_PATH = settingsPath;
+
+			await writeFile(
+				settingsPath,
+				`\uFEFF${JSON.stringify({
+					disabledTools: ["editor"],
+					telemetryOptOut: true,
+				})}`,
+				"utf8",
+			);
+
+			expect(readGlobalSettings()).toEqual({
+				autoUpdateEnabled: true,
+				disabledTools: ["editor"],
+				telemetryOptOut: true,
+			});
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+
 	it("preserves disabled tools and plugins across targeted updates", async () => {
 		const root = await mkdtemp(join(tmpdir(), "core-global-settings-"));
 		try {

--- a/sdk/packages/core/src/services/global-settings.test.ts
+++ b/sdk/packages/core/src/services/global-settings.test.ts
@@ -139,6 +139,31 @@ describe("global-settings", () => {
 		}
 	});
 
+	it("loads global settings files with a leading UTF-8 BOM", async () => {
+		const root = await mkdtemp(join(tmpdir(), "core-global-settings-"));
+		try {
+			const settingsPath = join(root, "global-settings.json");
+			process.env.CLINE_GLOBAL_SETTINGS_PATH = settingsPath;
+
+			await writeFile(
+				settingsPath,
+				`\uFEFF${JSON.stringify({
+					disabledTools: ["editor"],
+					telemetryOptOut: true,
+				})}`,
+				"utf8",
+			);
+
+			expect(readGlobalSettings()).toEqual({
+				autoUpdateEnabled: true,
+				disabledTools: ["editor"],
+				telemetryOptOut: true,
+			});
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+
 	it("preserves disabled tools and plugins across targeted updates", async () => {
 		const root = await mkdtemp(join(tmpdir(), "core-global-settings-"));
 		try {

--- a/sdk/packages/core/src/services/global-settings.ts
+++ b/sdk/packages/core/src/services/global-settings.ts
@@ -75,6 +75,10 @@ export interface WriteGlobalSettingsOptions {
 	telemetry?: ITelemetryService;
 }
 
+function stripJsonBom(raw: string): string {
+	return raw.charCodeAt(0) === 0xfeff ? raw.slice(1) : raw;
+}
+
 function defaultGlobalSettings(): GlobalSettings {
 	return GlobalSettingsSchema.parse({});
 }
@@ -110,7 +114,7 @@ function loadSettingsFromDisk(filePath: string): GlobalSettings {
 		return defaultGlobalSettings();
 	}
 	try {
-		const result = GlobalSettingsSchema.safeParse(JSON.parse(raw));
+		const result = GlobalSettingsSchema.safeParse(JSON.parse(stripJsonBom(raw)));
 		return result.success ? result.data : defaultGlobalSettings();
 	} catch {
 		return defaultGlobalSettings();

--- a/sdk/packages/core/src/services/global-settings.ts
+++ b/sdk/packages/core/src/services/global-settings.ts
@@ -7,6 +7,7 @@ import {
 	type ConfigurableModelToolName,
 	type ITelemetryService,
 	type ModelToolSettings,
+	stripUtf8Bom,
 } from "@cline/shared";
 import { resolveGlobalSettingsPath } from "@cline/shared/storage";
 import { z } from "zod";
@@ -162,7 +163,7 @@ function loadSettingsFromDisk(filePath: string): GlobalSettings {
 		return defaultGlobalSettings();
 	}
 	try {
-		const result = GlobalSettingsSchema.safeParse(JSON.parse(raw));
+		const result = GlobalSettingsSchema.safeParse(JSON.parse(stripUtf8Bom(raw)));
 		return result.success ? result.data : defaultGlobalSettings();
 	} catch {
 		return defaultGlobalSettings();


### PR DESCRIPTION
## Summary

- strip a leading UTF-8 BOM (`﻿`) before parsing MCP settings JSON
- strip a leading UTF-8 BOM before parsing global settings JSON
- add regression coverage for MCP settings load/update paths and global settings load path

## Why

Some editors/tools write otherwise-valid JSON files with a UTF-8 BOM. Node's `readFileSync(..., "utf8")` preserves the leading BOM as `﻿`, and `JSON.parse(raw)` rejects it:

- MCP settings can throw a parse error before reaching schema validation
- global settings catch the parse error and silently fall back to defaults, dropping the user's configured settings for that read

This change only removes a BOM at the beginning of the file, immediately before JSON parsing. It does not alter whitespace or any other file content.

Related: https://github.com/cline/cline/issues/2459

## Testing

- `git diff --check`

Not run locally: official unit/typecheck commands require `bun` (`packageManager: bun@1.3.13`), and `bun`/`bunx` are not installed in this environment; `corepack prepare bun@1.3.13 --activate` does not support Bun here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
