### PR TITLE
fix(vscode): show disabled MCP servers in webview on IDE restart

### DIFF
--- a/apps/vscode/src/core/controller/mcp/subscribeToMcpServers.ts
+++ b/apps/vscode/src/core/controller/mcp/subscribeToMcpServers.ts
@@ -36,7 +36,7 @@ export async function subscribeToMcpServers(
 
 	// Send initial state if available
 	if (controller.mcpHub) {
-		const mcpServers = controller.mcpHub.getServers()
+		const mcpServers = controller.mcpHub.getAllServers()
 		if (mcpServers.length > 0) {
 			try {
 				const protoServers = McpServers.create({

--- a/apps/vscode/src/services/mcp/McpHub.ts
+++ b/apps/vscode/src/services/mcp/McpHub.ts
@@ -44,9 +44,9 @@ import { expandEnvironmentVariables } from "@/utils/envExpansion"
 import type { TelemetryService } from "../telemetry/TelemetryService"
 import { DEFAULT_REQUEST_TIMEOUT_MS } from "./constants"
 import { McpOAuthManager } from "./McpOAuthManager"
-import { updateMcpSettingsFile } from "./settingsLock"
 import { StreamableHttpReconnectHandler } from "./StreamableHttpReconnectHandler"
 import { BaseConfigSchema, McpSettingsSchema, ServerConfigSchema } from "./schemas"
+import { updateMcpSettingsFile } from "./settingsLock"
 import type { McpConnection, McpServerConfig, Transport } from "./types"
 export class McpHub {
 	getMcpServersPath: () => Promise<string>
@@ -129,6 +129,14 @@ export class McpHub {
 		// Only return enabled servers
 
 		return this.connections.filter((conn) => !conn.server.disabled).map((conn) => conn.server)
+	}
+
+	/**
+	 * Returns all servers including disabled ones.
+	 * Used for the webview subscription which needs to show the full server list.
+	 */
+	getAllServers(): McpServer[] {
+		return this.connections.map((conn) => conn.server)
 	}
 
 	/**


### PR DESCRIPTION
## Summary

When a user disabled an MCP server and restarted VS Code, the server disappeared entirely from the MCP server list instead of showing as disabled. Re-enabling or removing it was impossible without editing the settings file manually.

## Root cause

`subscribeToMcpServers` used `McpHub.getServers()` which intentionally filters out disabled servers (it's used elsewhere for tool-building and auto-approval policies). On IDE restart, the initial subscription state only included enabled servers, so disabled ones were never sent to the webview.

## Fix

Added `getAllServers()` to `McpHub` that returns all connections including disabled stubs, and use it in the subscription initial state. The webview already handles disabled servers correctly (toggle unchecked, buttons disabled) — it was just never receiving them.

`getServers()` remains unchanged for its existing use cases (tool provider, auto-approval).

Fixes #12176