### PR TITLE
fix(vscode): skip telemetry provider init when setting is disabled

### DIFF
--- a/apps/vscode/src/common.ts
+++ b/apps/vscode/src/common.ts
@@ -58,9 +58,17 @@ export async function initialize(storageContext: StorageContext): Promise<Webvie
 
 	// =============== External services ===============
 	await ErrorService.initialize()
-	// Initialize PostHog client provider (skip in self-hosted mode)
+	// Initialize PostHog client provider (skip in self-hosted mode or when telemetry is disabled)
 	if (!ClineEndpoint.isSelfHosted()) {
-		PostHogClientProvider.getInstance()
+		try {
+			const telemetrySetting = StateManager.get().getGlobalSettingsKey("telemetrySetting")
+			if (telemetrySetting !== "disabled") {
+				PostHogClientProvider.getInstance()
+			}
+		} catch {
+			// StateManager not available yet; initialize PostHog client as default behavior
+			PostHogClientProvider.getInstance()
+		}
 	}
 
 	// =============== Webview services ===============

--- a/apps/vscode/src/services/error/ErrorProviderFactory.ts
+++ b/apps/vscode/src/services/error/ErrorProviderFactory.ts
@@ -1,4 +1,5 @@
 import { ClineEndpoint } from "@/config"
+import { StateManager } from "@/core/storage/StateManager"
 import { isPostHogConfigValid, PostHogClientConfig, posthogConfig } from "@/shared/services/config/posthog-config"
 import { Logger } from "@/shared/services/Logger"
 import { ClineError } from "./ClineError"
@@ -53,12 +54,23 @@ export class ErrorProviderFactory {
 	 * @returns Default configuration using PostHog, or no-op for self-hosted mode
 	 */
 	public static getDefaultConfig(): ErrorProviderConfig {
-		// Use no-op provider in self-hosted mode to avoid external network calls
+		// Use no-op provider in self-hosted mode or when telemetry is disabled
 		if (ClineEndpoint.isSelfHosted()) {
 			return {
 				type: "no-op",
 				config: posthogConfig,
 			}
+		}
+		try {
+			const telemetrySetting = StateManager.get().getGlobalSettingsKey("telemetrySetting")
+			if (telemetrySetting === "disabled") {
+				return {
+					type: "no-op",
+					config: posthogConfig,
+				}
+			}
+		} catch {
+			// StateManager not available yet; use PostHog as default
 		}
 		return {
 			type: "posthog",

--- a/apps/vscode/src/services/telemetry/TelemetryProviderFactory.ts
+++ b/apps/vscode/src/services/telemetry/TelemetryProviderFactory.ts
@@ -1,4 +1,5 @@
 import { ClineEndpoint } from "@/config"
+import { StateManager } from "@/core/storage/StateManager"
 import {
 	getValidOpenTelemetryConfig,
 	getValidRuntimeOpenTelemetryConfig,
@@ -26,6 +27,19 @@ export type TelemetryProviderConfig =
 	 */
 	| { type: "opentelemetry"; config: OpenTelemetryClientValidConfig; bypassUserSettings: boolean }
 	| { type: "no-op" }
+
+/**
+ * Returns true when the user has explicitly opted out of telemetry in Cline settings.
+ * During extension activation the state manager may not be ready yet; defaults to false.
+ */
+function isTelemetryExplicitlyDisabled(): boolean {
+	try {
+		const stateManager = StateManager.get()
+		return stateManager.getGlobalSettingsKey("telemetrySetting") === "disabled"
+	} catch {
+		return false
+	}
+}
 
 /**
  * Factory class for creating telemetry providers
@@ -100,16 +114,17 @@ export class TelemetryProviderFactory {
 	 */
 	public static getDefaultConfigs(): TelemetryProviderConfig[] {
 		const configs: TelemetryProviderConfig[] = []
+		const telemetryDisabled = isTelemetryExplicitlyDisabled()
 
 		// Skip PostHog in selfHosted mode - enterprise customers should not send telemetry to PostHog
-		if (!ClineEndpoint.isSelfHosted() && isPostHogConfigValid(posthogConfig)) {
+		if (!ClineEndpoint.isSelfHosted() && !telemetryDisabled && isPostHogConfigValid(posthogConfig)) {
 			configs.push({ type: "posthog", ...posthogConfig })
 		}
 
 		// Skip build-time OTEL in selfHosted mode - enterprise customers should not send telemetry to Cline's collector
 		// Note: Runtime env OTEL and remote config OTEL are still allowed (user/org explicitly configured them)
 		const otelConfig = getValidOpenTelemetryConfig()
-		if (!ClineEndpoint.isSelfHosted() && otelConfig) {
+		if (!ClineEndpoint.isSelfHosted() && !telemetryDisabled && otelConfig) {
 			configs.push({
 				type: "opentelemetry",
 				config: otelConfig,


### PR DESCRIPTION
## Summary

When telemetry was disabled in Cline settings, PostHog and OpenTelemetry clients were **still initialized** during extension activation. The `telemetrySetting` was only checked at event-capture time (`isEnabled()`), not at init time. This caused unnecessary network client setup and a \~6s shutdown delay on VS Code quit (macOS).

## Fix

### 1. TelemetryProviderFactory.getDefaultConfigs() (`TelemetryProviderFactory.ts`)
Skip PostHog and built-in OTEL provider configs when `telemetrySetting === "disabled"`. Runtime OTEL (env-configured, `bypassUserSettings: true`) is still allowed since the user explicitly opted in via environment.

### 2. ErrorProviderFactory.getDefaultConfig() (`ErrorProviderFactory.ts`)
Return no-op error provider when telemetry is disabled, avoiding PostHogErrorProvider client creation.

### 3. common.ts — PostHogClientProvider initialization
Skip `PostHogClientProvider.getInstance()` when telemetry is disabled.

All guards have `try-catch` fallback to default behavior when StateManager isn't available yet (early activation).

Fixes #12115