### PR TITLE
fix(vscode): roll out Cline native tools behind flag

### DIFF
--- a/apps/vscode/src/core/prompts/system-prompt/types.ts
+++ b/apps/vscode/src/core/prompts/system-prompt/types.ts
@@ -124,6 +124,7 @@ export interface SystemPromptContext {
 	readonly isSubagentRun?: boolean
 	readonly isCliEnvironment?: boolean
 	readonly enableNativeToolCalls?: boolean
+	readonly enableAllClineProviderNativeTools?: boolean
 	readonly enableParallelToolCalling?: boolean
 	readonly terminalExecutionMode?: "vscodeTerminal" | "backgroundExec"
 }

--- a/apps/vscode/src/core/prompts/system-prompt/variants/native-next-gen/config.ts
+++ b/apps/vscode/src/core/prompts/system-prompt/variants/native-next-gen/config.ts
@@ -1,4 +1,4 @@
-import { isGPT5ModelFamily, isNextGenModelFamily, isNextGenModelProvider } from "@utils/model-utils"
+import { isClineProvider, isGPT5ModelFamily, isNextGenModelFamily, isNextGenModelProvider } from "@utils/model-utils"
 import { ModelFamily } from "@/shared/prompts"
 import { Logger } from "@/shared/services/Logger"
 import { ClineDefaultTool } from "@/shared/tools"
@@ -27,7 +27,10 @@ export const config = createVariant(ModelFamily.NATIVE_NEXT_GEN)
 			return false
 		}
 		const modelId = providerInfo.model.id.toLowerCase()
-		return !isGPT5ModelFamily(modelId) && isNextGenModelFamily(modelId)
+		return (
+			!isGPT5ModelFamily(modelId) &&
+			((isClineProvider(providerInfo) && context.enableAllClineProviderNativeTools) || isNextGenModelFamily(modelId))
+		)
 	})
 	.template(TEMPLATE_OVERRIDES.BASE)
 	.components(

--- a/apps/vscode/src/core/task/index.ts
+++ b/apps/vscode/src/core/task/index.ts
@@ -91,8 +91,10 @@ import { type ClineDefaultTool, READ_ONLY_TOOLS } from "@shared/tools";
 import type { ClineAskResponse } from "@shared/WebviewMessage";
 import {
 	isClaude4PlusModelFamily,
+	isClineProvider,
 	isGPT5ModelFamily,
 	isLocalModel,
+	isNativeToolCallingConfig,
 	isNextGenModelFamily,
 	isParallelToolCallingEnabled,
 } from "@utils/model-utils";
@@ -132,6 +134,7 @@ import { ApiFormat } from "@/shared/proto/cline/models";
 import { ShowMessageType } from "@/shared/proto/index.host";
 import { Logger } from "@/shared/services/Logger";
 import { Session } from "@/shared/services/Session";
+import { FeatureFlag } from "@/shared/services/feature-flags/feature-flags";
 import { RuleContextBuilder } from "../context/instructions/user-instructions/RuleContextBuilder";
 import { ensureLocalClineDirExists } from "../context/instructions/user-instructions/rule-helpers";
 import { discoverAvailableSkills } from "../context/instructions/user-instructions/skills";
@@ -2296,6 +2299,14 @@ export class Task {
 			open: openTabPaths.slice(0, cap),
 			visible: visibleTabPaths.slice(0, cap),
 		};
+		const enableAllClineProviderNativeTools =
+			isClineProvider(providerInfo) &&
+			featureFlagsService.getBooleanFlagEnabled(
+				FeatureFlag.CLINE_PROVIDER_NATIVE_TOOLS,
+			);
+		const nativeToolCallsRequested =
+			providerInfo.model.info.apiFormat === ApiFormat.OPENAI_RESPONSES ||
+			this.stateManager.getGlobalStateKey("nativeToolCallEnabled");
 
 		const promptContext: SystemPromptContext = {
 			cwd: this.cwd,
@@ -2329,8 +2340,8 @@ export class Task {
 			isSubagentRun: false,
 			isCliEnvironment,
 			enableNativeToolCalls:
-				providerInfo.model.info.apiFormat === ApiFormat.OPENAI_RESPONSES ||
-				this.stateManager.getGlobalStateKey("nativeToolCallEnabled"),
+				nativeToolCallsRequested || enableAllClineProviderNativeTools,
+			enableAllClineProviderNativeTools,
 			enableParallelToolCalling: this.isParallelToolCallingEnabled(),
 			terminalExecutionMode: this.terminalExecutionMode,
 		};
@@ -3940,10 +3951,13 @@ export class Task {
 		const ulid = this.ulid;
 		const focusChainSettings =
 			this.stateManager.getGlobalSettingsKey("focusChainSettings");
-		const useNativeToolCalls = this.stateManager.getGlobalStateKey(
-			"nativeToolCallEnabled",
-		);
 		const providerInfo = this.getCurrentProviderInfo();
+		const useNativeToolCalls = isNativeToolCallingConfig(
+			providerInfo,
+			providerInfo.model.info.apiFormat === ApiFormat.OPENAI_RESPONSES ||
+				this.stateManager.getGlobalStateKey("nativeToolCallEnabled"),
+			featureFlagsService.getBooleanFlagEnabled(FeatureFlag.CLINE_PROVIDER_NATIVE_TOOLS),
+		);
 		const cwd = this.cwd;
 		const { localWorkflowToggles, globalWorkflowToggles } =
 			await refreshWorkflowToggles(this.controller, cwd);

--- a/apps/vscode/src/core/task/tools/subagent/SubagentRunner.ts
+++ b/apps/vscode/src/core/task/tools/subagent/SubagentRunner.ts
@@ -20,9 +20,11 @@ import { checkContextWindowExceededError } from "@/core/context/context-manageme
 import { getContextWindowInfo } from "@/core/context/context-management/context-window-utils";
 import { HostRegistryInfo } from "@/registry";
 import { ClineError, ClineErrorType } from "@/services/error";
+import { featureFlagsService } from "@/services/feature-flags";
 import { ApiFormat } from "@/shared/proto/cline/models";
+import { FeatureFlag } from "@/shared/services/feature-flags/feature-flags";
 import { calculateApiCostAnthropic } from "@/utils/cost";
-import { isNextGenModelFamily } from "@/utils/model-utils";
+import { isClineProvider, isNextGenModelFamily } from "@/utils/model-utils";
 import { TaskState } from "../../TaskState";
 import { ToolExecutorCoordinator } from "../ToolExecutorCoordinator";
 import { ToolValidator } from "../ToolValidator";
@@ -378,8 +380,13 @@ export class SubagentRunner {
 			stats.contextWindow = providerInfo.model.info.contextWindow || 0;
 			const nativeToolCallsRequested =
 				providerInfo.model.info.apiFormat === ApiFormat.OPENAI_RESPONSES ||
-				!!this.baseConfig.services.stateManager.getGlobalStateKey(
-					"nativeToolCallEnabled",
+					!!this.baseConfig.services.stateManager.getGlobalStateKey(
+						"nativeToolCallEnabled",
+					);
+			const enableAllClineProviderNativeTools =
+				isClineProvider(providerInfo) &&
+				featureFlagsService.getBooleanFlagEnabled(
+					FeatureFlag.CLINE_PROVIDER_NATIVE_TOOLS,
 				);
 
 			const host = HostRegistryInfo.get();
@@ -432,7 +439,9 @@ export class SubagentRunner {
 				focusChainSettings: this.baseConfig.focusChainSettings,
 				browserSettings: this.baseConfig.browserSettings,
 				yoloModeToggled: false,
-				enableNativeToolCalls: nativeToolCallsRequested,
+				enableNativeToolCalls:
+					nativeToolCallsRequested || enableAllClineProviderNativeTools,
+				enableAllClineProviderNativeTools,
 				enableParallelToolCalling: false,
 				isSubagentRun: true,
 			};

--- a/apps/vscode/src/shared/services/feature-flags/feature-flags.ts
+++ b/apps/vscode/src/shared/services/feature-flags/feature-flags.ts
@@ -19,6 +19,8 @@ export enum FeatureFlag {
 	CLINE_PASS = "ext-cline-pass",
 	// Use the websocket mode for OpenAI native Responses API format
 	OPENAI_RESPONSES_WEBSOCKET_MODE = "openai-responses-websocket-mode",
+	// Gradual rollout of native tools for every model on Cline Provider.
+	CLINE_PROVIDER_NATIVE_TOOLS = "extension-cline-provider-native-tools",
 }
 
 export const FeatureFlagDefaultValue: Partial<Record<FeatureFlag, FeatureFlagPayload>> = {
@@ -31,6 +33,7 @@ export const FeatureFlagDefaultValue: Partial<Record<FeatureFlag, FeatureFlagPay
 	[FeatureFlag.EXTENSION_CLINE_MODELS_ENDPOINT]: false,
 	[FeatureFlag.CLINE_PASS]: false,
 	[FeatureFlag.OPENAI_RESPONSES_WEBSOCKET_MODE]: false,
+	[FeatureFlag.CLINE_PROVIDER_NATIVE_TOOLS]: false,
 }
 
 export const FEATURE_FLAGS = Object.values(FeatureFlag)

--- a/apps/vscode/src/utils/__tests__/native-tool-selector.test.ts
+++ b/apps/vscode/src/utils/__tests__/native-tool-selector.test.ts
@@ -1,0 +1,109 @@
+import type { ApiHandlerModel, ApiProviderInfo } from "@core/api"
+import { expect } from "chai"
+import { describe, it } from "mocha"
+import "should"
+import { PromptRegistry } from "@/core/prompts/system-prompt/registry/PromptRegistry"
+import type { SystemPromptContext } from "@/core/prompts/system-prompt/types"
+import { ModelFamily } from "@/shared/prompts"
+import { FeatureFlag, FeatureFlagDefaultValue } from "@/shared/services/feature-flags/feature-flags"
+import {
+	isClineProvider,
+	isNativeToolCallingConfig,
+	isParallelToolCallingEnabled,
+} from "../model-utils"
+
+const providerInfo = (providerId: string, modelId: string): ApiProviderInfo => ({
+	providerId,
+	model: { id: modelId, info: { supportsPromptCache: false } } as ApiHandlerModel,
+	mode: "act",
+})
+
+const reportModels = [
+	"deepseek/deepseek-v4-pro",
+	"deepseek/deepseek-v4-flash",
+	"zai/glm-5.2",
+	"stepfun/step-3.7-flash-20260528",
+	"stepfun/step-3.5-flash",
+	"xiaomi/mimo-v2.5-20260422",
+	"google/gemma-4-31b-it",
+	"alibaba/qwen3.6-plus",
+	"alibaba/qwen3.7-max",
+	"alibaba/qwen3.7-plus",
+	"minimax/minimax-m3",
+	"minimax/minimax-m2.5-20260211",
+	"moonshotai/kimi-k2.7-code",
+	"google/gemini-3.1-flash-lite",
+	"poolside/laguna-m.1",
+]
+
+describe("native tool selector", () => {
+	it("should default the Cline Provider rollout to disabled", () => {
+		expect(FeatureFlagDefaultValue[FeatureFlag.CLINE_PROVIDER_NATIVE_TOOLS]).to.equal(false)
+	})
+
+	it("should make the rollout flag additive for Cline Provider", () => {
+		const provider = providerInfo("cline", "any-model")
+		isNativeToolCallingConfig(provider, false, true).should.equal(true)
+	})
+
+	it("should preserve original Cline behavior when the rollout flag is disabled", () => {
+		isNativeToolCallingConfig(providerInfo("cline", "minimax-m3"), true, false).should.equal(true)
+		isNativeToolCallingConfig(providerInfo("cline", "zai/glm-5.2"), true, false).should.equal(false)
+		isNativeToolCallingConfig(providerInfo("cline", "zai/glm-5.2"), false, false).should.equal(false)
+
+		const registry = PromptRegistry.getInstance()
+		const glmFamily = registry.getModelFamily({
+			providerInfo: providerInfo("cline", "zai/glm-5.2"),
+			enableNativeToolCalls: true,
+			enableAllClineProviderNativeTools: false,
+		} as SystemPromptContext)
+		const minimaxFamily = registry.getModelFamily({
+			providerInfo: providerInfo("cline", "minimax-m3"),
+			enableNativeToolCalls: true,
+			enableAllClineProviderNativeTools: false,
+		} as SystemPromptContext)
+		expect(glmFamily).to.equal(ModelFamily.GLM)
+		expect(minimaxFamily).to.equal(ModelFamily.NATIVE_NEXT_GEN)
+	})
+
+	it("should ignore the rollout flag for other providers", () => {
+		isNativeToolCallingConfig(providerInfo("openrouter", "unrecognized-model"), false, true).should.equal(false)
+	})
+
+	it("should enable native tools for every model on Cline Provider", () => {
+		const registry = PromptRegistry.getInstance()
+
+		for (const modelId of reportModels) {
+			const provider = providerInfo("cline", modelId)
+			isNativeToolCallingConfig(provider, true, true).should.equal(true)
+			const family = registry.getModelFamily({
+				providerInfo: provider,
+				enableNativeToolCalls: true,
+				enableAllClineProviderNativeTools: true,
+			} as SystemPromptContext)
+			expect([ModelFamily.NATIVE_NEXT_GEN, ModelFamily.GEMINI_3]).to.include(family)
+		}
+	})
+
+	it("should limit the model-family bypass to Cline Provider", () => {
+		isClineProvider(providerInfo("CLINE", "any-model")).should.equal(true)
+		isNativeToolCallingConfig(providerInfo("cline-pass", "unrecognized-future-model"), true).should.equal(false)
+		isNativeToolCallingConfig(providerInfo("deepseek", "deepseek-v4-pro"), true).should.equal(false)
+		isNativeToolCallingConfig(providerInfo("openrouter", "zai/glm-5.2"), true).should.equal(false)
+	})
+
+	it("should retain legacy native selection for other providers", () => {
+		isNativeToolCallingConfig(providerInfo("minimax", "minimax-m3"), true).should.equal(true)
+		isNativeToolCallingConfig(providerInfo("openrouter", "moonshotai/kimi-k2.7-code"), true).should.equal(true)
+	})
+
+	it("should retain the setting guard", () => {
+		isNativeToolCallingConfig(providerInfo("cline", "any-model"), false).should.equal(false)
+	})
+
+	it("should not infer parallel tool support for an unrecognized model", () => {
+		const provider = providerInfo("cline", "unrecognized-future-model")
+		isParallelToolCallingEnabled(false, provider).should.equal(false)
+		isParallelToolCallingEnabled(true, provider).should.equal(true)
+	})
+})

--- a/apps/vscode/src/utils/model-utils.ts
+++ b/apps/vscode/src/utils/model-utils.ts
@@ -28,6 +28,10 @@ export function isNextGenModelProvider(providerInfo: ApiProviderInfo): boolean {
 	].some((id) => providerId === id)
 }
 
+export function isClineProvider(providerInfo: ApiProviderInfo): boolean {
+	return normalize(providerInfo.providerId) === "cline"
+}
+
 export function modelDoesntSupportWebp(apiHandlerModel: ApiHandlerModel): boolean {
 	const modelId = apiHandlerModel.id.toLowerCase()
 	// Grok doesn't support WebP via its API.
@@ -236,20 +240,27 @@ export function parsePrice(priceString: string | undefined): number {
 
 /**
  * Determines if the given provider and model combination will use native tool calling.
+ * The Cline Provider rollout can additionally enable native tools for every model.
  * Helpful if we need to quickly check this for prompts or other logic.
  * @param providerInfo The provider and model information
  * @param enableNativeToolCalls Whether the native tool calls setting is enabled
  * @returns true if the model will use native tool calling, false otherwise
  */
-export function isNativeToolCallingConfig(providerInfo: ApiProviderInfo, enableNativeToolCalls: boolean): boolean {
+export function isNativeToolCallingConfig(
+	providerInfo: ApiProviderInfo,
+	enableNativeToolCalls: boolean,
+	enableAllClineProviderNativeTools = false,
+): boolean {
+	if (enableAllClineProviderNativeTools && isClineProvider(providerInfo)) {
+		return true
+	}
 	if (!enableNativeToolCalls) {
 		return false
 	}
 	if (!isNextGenModelProvider(providerInfo)) {
 		return false
 	}
-	const modelId = providerInfo.model.id.toLowerCase()
-	return isNextGenModelFamily(modelId)
+	return isNextGenModelFamily(providerInfo.model.id)
 }
 
 /**


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

The legacy native-tool selector uses a hard-coded model-family allowlist. Newly added models available through Cline Provider therefore receive XML prompts until their names are manually added to that list.

This change introduces the additive `extension-cline-provider-native-tools` rollout flag:

- Flag disabled: behavior is exactly unchanged. Existing native models remain native, existing XML models remain XML, and the local native-tools setting continues to work as before.
- Flag enabled + Cline Provider: every Cline model receives the native-tools prompt and structured schemas.
- Other providers ignore the rollout flag and retain their existing setting, provider, and model-family gates.
- The flag defaults to disabled, so merging the PR does not change behavior until rollout begins.
- Main task prompts, slash-command formatting, and subagent prompts all apply the same additive override.
- Automatic parallel tool calling remains unchanged.

### Test Procedure

- Verified the rollout flag defaults to disabled.
- Verified flag-off behavior preserves the original Cline split: MiniMax remains native while GLM 5.2 remains on its specialized XML prompt.
- Verified flag-on behavior enables native tools for every model family named in the supplied report: DeepSeek V4, GLM 5.2, Step 3.5/3.7, MiMo 2.5, Gemma 4, Qwen 3.6/3.7, MiniMax, Kimi, Gemini 3.1, and Laguna.
- Verified other providers ignore the rollout override and retain their existing selection behavior.
- Verified Cline Pass, direct DeepSeek V4, and OpenRouter GLM do not receive the Cline-only bypass.
- Verified automatic parallel tool calling is unchanged.
- Ran the selector, model-utils, and prompt registry suites: 52 passing.
- Ran `npm run lint`: passed across 1,372 files, including proto lint.
- Ran `git diff --check`: passed.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable; no UI changes.

### Additional Notes

Create the new PostHog flag at 0% before rollout, then increase its percentage gradually. Do not reuse the historical `native_tool_calls_next_gen` flag because that stale flag is already configured at 100%.

This PR changes prompt/schema selection for Cline Provider when the new flag is enabled. It does not remove the legacy XML compatibility parser.

The focused unit tests and full lint pass. A broad local typecheck could not be completed because this legacy checkout's protobuf generation reports that `grpc-tools/bin/protoc` is unavailable; CI performs the canonical generated-code setup.
