### PR TITLE
fix(vscode): refreshGroqModels caused cacheReadsPrice undefined error

### DIFF
--- a/apps/vscode/src/core/controller/models/__tests__/refreshGroqModels.test.ts
+++ b/apps/vscode/src/core/controller/models/__tests__/refreshGroqModels.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { refreshGroqModels } from "../refreshGroqModels"
+
+const mocks = vi.hoisted(() => ({
+	axiosGet: vi.fn(),
+	captureProviderApiError: vi.fn(),
+	getModelsCache: vi.fn(),
+	getProviderCollectionSync: vi.fn(),
+	getSecretKey: vi.fn(),
+	setModelsCache: vi.fn(),
+	writeFile: vi.fn(),
+}))
+
+vi.mock("@cline/llms", () => ({
+	getProviderCollectionSync: mocks.getProviderCollectionSync,
+}))
+
+vi.mock("@core/storage/disk", () => ({
+	GlobalFileNames: {
+		groqModels: "groq_models.json",
+	},
+	ensureCacheDirectoryExists: vi.fn(async () => "/tmp/cline-cache"),
+}))
+
+vi.mock("@/core/storage/StateManager", () => ({
+	StateManager: {
+		get: () => ({
+			getModelsCache: mocks.getModelsCache,
+			setModelsCache: mocks.setModelsCache,
+		}),
+	},
+}))
+
+vi.mock("@/services/telemetry", () => ({
+	telemetryService: {
+		captureProviderApiError: mocks.captureProviderApiError,
+	},
+}))
+
+vi.mock("@/shared/net", () => ({
+	getAxiosSettings: () => ({}),
+}))
+
+vi.mock("@/shared/services/Logger", () => ({
+	Logger: {
+		error: vi.fn(),
+		log: vi.fn(),
+	},
+}))
+
+vi.mock("@utils/fs", () => ({
+	fileExistsAtPath: vi.fn(async () => false),
+}))
+
+vi.mock("axios", () => ({
+	default: {
+		get: mocks.axiosGet,
+		isAxiosError: vi.fn(() => false),
+	},
+}))
+
+vi.mock("fs/promises", () => ({
+	default: {
+		readFile: vi.fn(),
+		writeFile: mocks.writeFile,
+	},
+}))
+
+describe("refreshGroqModels", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		mocks.getModelsCache.mockReturnValue(null)
+		mocks.getProviderCollectionSync.mockReturnValue({ models: {} })
+		mocks.getSecretKey.mockReturnValue("gsk_test_key")
+		mocks.axiosGet.mockResolvedValue({
+			data: {
+				data: [
+					{
+						id: "groq-new-chat-model",
+						object: "model",
+						active: true,
+						max_completion_tokens: 4096,
+						context_window: 8192,
+						owned_by: "Groq",
+					},
+				],
+			},
+		})
+	})
+
+	it("defaults cache pricing for live models missing SDK catalog metadata", async () => {
+		const controller = {
+			stateManager: {
+				getSecretKey: mocks.getSecretKey,
+			},
+			task: {
+				ulid: "task-1",
+			},
+		} as unknown as Parameters<typeof refreshGroqModels>[0]
+
+		const models = await refreshGroqModels(controller)
+
+		expect(models["groq-new-chat-model"]).toMatchObject({
+			maxTokens: 4096,
+			contextWindow: 8192,
+			cacheWritesPrice: 0,
+			cacheReadsPrice: 0,
+			description: "Groq model with 8,192 token context window",
+		})
+		expect(mocks.captureProviderApiError).not.toHaveBeenCalled()
+		expect(mocks.setModelsCache).toHaveBeenCalledWith("groq", expect.objectContaining(models))
+	})
+})

--- a/apps/vscode/src/core/controller/models/refreshGroqModels.ts
+++ b/apps/vscode/src/core/controller/models/refreshGroqModels.ts
@@ -139,8 +139,8 @@ async function fetchAndCacheModels(controller: Controller): Promise<Record<strin
 						supportsPromptCache: staticModelInfo?.supportsPromptCache || false,
 						inputPrice: staticModelInfo?.inputPrice || 0,
 						outputPrice: staticModelInfo?.outputPrice || 0,
-						cacheWritesPrice: (staticModelInfo as any)?.cacheWritesPrice || 0,
-						cacheReadsPrice: (staticModelInfo as any).cacheReadsPrice || 0,
+						cacheWritesPrice: staticModelInfo?.cacheWritesPrice || 0,
+						cacheReadsPrice: staticModelInfo?.cacheReadsPrice || 0,
 						description: generateModelDescription(rawModel, staticModelInfo),
 					}
 

--- a/apps/vscode/vitest.config.ts
+++ b/apps/vscode/vitest.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
 			"src/core/controller/models/__tests__/resolveModelInfo.test.ts",
 			"src/core/controller/models/__tests__/providerCatalogSmoke.test.ts",
 			"src/core/controller/models/__tests__/refreshClineRecommendedModels.test.ts",
+			"src/core/controller/models/__tests__/refreshGroqModels.test.ts",
 		],
 		environment: "node",
 		// Several suites lazily `await import()` their subject inside the first test


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

**Issue**

Groq’s live `/models` endpoint can return a model that is not yet present in the SDK’s curated model catalog. The extension then enriches each live model with pricing metadata from that catalog.

**Root cause**

At [refreshGroqModels.ts:133](./apps/vscode/src/core/controller/models/refreshGroqModels.ts:133), an unknown model produces an undefined `staticModelInfo`. The code safely handled most properties, but accessed `cacheReadsPrice` without optional chaining:

```ts
(staticModelInfo as any).cacheReadsPrice
```

That caused:

```text
Cannot read properties of undefined (reading 'cacheReadsPrice')
```

The entire refresh operation is inside a broad `try/catch`. Its catch block at [refreshGroqModels.ts:156](./apps/vscode/src/core/controller/models/refreshGroqModels.ts:156) reports every exception through `captureProviderApiError`, including this local processing error. That is why it appeared as `PROVIDER_API_ERROR`; the SDK runtime did not actually fire it.

**Fix**

Both cache pricing properties now use typed optional access and default to zero at [refreshGroqModels.ts:142](./apps/vscode/src/core/controller/models/refreshGroqModels.ts:142):

```ts
cacheWritesPrice: staticModelInfo?.cacheWritesPrice || 0,
cacheReadsPrice: staticModelInfo?.cacheReadsPrice || 0,
```

This also removes the unnecessary `any` casts.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

Added a regression test at [refreshGroqModels.test.ts:91](./apps/vscode/src/core/controller/models/__tests__/refreshGroqModels.test.ts:91) that simulates Groq returning a model absent from the SDK catalog. It verifies that cache pricing defaults to zero, the model is cached successfully, and no provider-error telemetry is emitted. The test was also added to the VS Code Vitest configuration.

Validation passed: the new Vitest test and Biome checks both succeed.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
