### PR TITLE
fix(sdk): remove regex from zod schema for agent-squad plugin example

### DIFF
--- a/sdk/examples/plugins/agents-squad/index.ts
+++ b/sdk/examples/plugins/agents-squad/index.ts
@@ -440,8 +440,9 @@ const HandoffPathInput = z
 	.trim()
 	.min(1)
 	.max(240)
-	.describe(
-		"Relative file path using letters, numbers, '.', '_', '-', or '/'. Must not be absolute or contain '..' segments.",
+	.regex(
+		/^(?!\/)(?!.*(?:^|\/)\.\.(?:\/|$))[A-Za-z0-9._/-]+$/,
+		"Use a relative file path with letters, numbers, '.', '_', '-', or '/'.",
 	);
 
 const StartSubagentInput = z
@@ -538,7 +539,15 @@ const plugin: AgentPlugin = {
 	name: "portable-subagents",
 	manifest: { capabilities: ["tools"] },
 
-	setup(api) {
+	setup(api, ctx) {
+		const logger = ctx.logger;
+		logger?.log("portable-subagents plugin setup", {
+			sessionId: ctx.session?.sessionId,
+			defaultPreset: DEFAULT_AGENT_PRESET,
+			backendMode: DEFAULT_BACKEND_MODE,
+			workspaceRoot: ctx.workspaceInfo?.rootPath,
+		});
+
 		// -- start_subagent: Start a new subagent session --
 		api.registerTool(
 			toRegisteredTool(
@@ -603,6 +612,14 @@ const plugin: AgentPlugin = {
 							status: "running",
 						};
 						subagents.set(sessionId, subagent);
+						logger?.log("Started subagent", {
+							sessionId,
+							toolName: "start_subagent",
+							label: input.label,
+							preset: def?.name ?? input.preset,
+							providerId,
+							modelId,
+						});
 						void runSubagentTurn(
 							subagent,
 							input.task,
@@ -687,6 +704,11 @@ const plugin: AgentPlugin = {
 						subagent.error = undefined;
 						subagents.set(subagent.sessionId, subagent);
 
+						logger?.log("Queued subagent follow-up", {
+							sessionId: subagent.sessionId,
+							toolName: "message_subagent",
+							label: subagent.name,
+						});
 						void runSubagentTurn(
 							subagent,
 							input.prompt,

--- a/sdk/examples/plugins/agents-squad/index.ts
+++ b/sdk/examples/plugins/agents-squad/index.ts
@@ -5,7 +5,7 @@ import {
 	readFileSync,
 	writeFileSync,
 } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
 	type AgentPlugin,
@@ -90,6 +90,8 @@ const GLOBAL_SKILLS_DIR = join(resolveClineDataDirPath(), "settings", "skills");
 
 /** Safe identifier pattern for conversation IDs used in filesystem paths. */
 const SAFE_ID_RE = /^[A-Za-z0-9_-]+$/;
+const HANDOFF_PATH_ALLOWED_RE = /^[A-Za-z0-9._/-]+$/;
+const HANDOFF_PATH_MAX_LENGTH = 240;
 
 const envOr = (key: string, fallback: string): string =>
 	process.env[key]?.trim() || fallback;
@@ -298,12 +300,43 @@ function resolveHandoffPath(
 	ctx: AgentToolContext,
 	relativePath: string,
 ): string {
+	const handoffPath = validateHandoffRelativePath(relativePath);
 	const dir = handoffsDir(ctx);
-	const resolved = resolve(dir, relativePath);
-	if (!resolved.startsWith(`${dir}/`)) {
+	const resolved = resolve(dir, handoffPath);
+	const pathFromHandoffsDir = relative(dir, resolved);
+	if (
+		!pathFromHandoffsDir ||
+		pathFromHandoffsDir === ".." ||
+		pathFromHandoffsDir.startsWith(`..${sep}`) ||
+		isAbsolute(pathFromHandoffsDir)
+	) {
 		throw new Error(`Handoff path escapes directory: ${relativePath}`);
 	}
 	return resolved;
+}
+
+function validateHandoffRelativePath(relativePath: string): string {
+	const trimmed = relativePath.trim();
+	if (!trimmed) {
+		throw new Error("Handoff path must not be empty");
+	}
+	if (trimmed.length > HANDOFF_PATH_MAX_LENGTH) {
+		throw new Error(
+			`Handoff path must be ${HANDOFF_PATH_MAX_LENGTH} characters or fewer`,
+		);
+	}
+	if (trimmed.startsWith("/")) {
+		throw new Error(`Handoff path must be relative: ${relativePath}`);
+	}
+	if (!HANDOFF_PATH_ALLOWED_RE.test(trimmed)) {
+		throw new Error(
+			"Use a relative file path with letters, numbers, '.', '_', '-', or '/'.",
+		);
+	}
+	if (trimmed.split("/").includes("..")) {
+		throw new Error(`Handoff path must not contain '..': ${relativePath}`);
+	}
+	return trimmed;
 }
 
 function emitSteer(sessionId: string | undefined, prompt: string): void {
@@ -407,9 +440,8 @@ const HandoffPathInput = z
 	.trim()
 	.min(1)
 	.max(240)
-	.regex(
-		/^(?!\/)(?!.*(?:^|\/)\.\.(?:\/|$))[A-Za-z0-9._/-]+$/,
-		"Use a relative file path with letters, numbers, '.', '_', '-', or '/'.",
+	.describe(
+		"Relative file path using letters, numbers, '.', '_', '-', or '/'. Must not be absolute or contain '..' segments.",
 	);
 
 const StartSubagentInput = z
@@ -506,15 +538,7 @@ const plugin: AgentPlugin = {
 	name: "portable-subagents",
 	manifest: { capabilities: ["tools"] },
 
-	setup(api, ctx) {
-		const logger = ctx.logger;
-		logger?.log("portable-subagents plugin setup", {
-			sessionId: ctx.session?.sessionId,
-			defaultPreset: DEFAULT_AGENT_PRESET,
-			backendMode: DEFAULT_BACKEND_MODE,
-			workspaceRoot: ctx.workspaceInfo?.rootPath,
-		});
-
+	setup(api) {
 		// -- start_subagent: Start a new subagent session --
 		api.registerTool(
 			toRegisteredTool(
@@ -579,14 +603,6 @@ const plugin: AgentPlugin = {
 							status: "running",
 						};
 						subagents.set(sessionId, subagent);
-						logger?.log("Started subagent", {
-							sessionId,
-							toolName: "start_subagent",
-							label: input.label,
-							preset: def?.name ?? input.preset,
-							providerId,
-							modelId,
-						});
 						void runSubagentTurn(
 							subagent,
 							input.task,
@@ -671,11 +687,6 @@ const plugin: AgentPlugin = {
 						subagent.error = undefined;
 						subagents.set(subagent.sessionId, subagent);
 
-						logger?.log("Queued subagent follow-up", {
-							sessionId: subagent.sessionId,
-							toolName: "message_subagent",
-							label: subagent.name,
-						});
 						void runSubagentTurn(
 							subagent,
 							input.prompt,


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

The `HandoffPathInput` schema used negative lookaheads to reject absolute paths and `..` traversal segments. When converted to JSON Schema, this regex caused consumers without lookaround support to fail with `invalid JSON schema: regex lookaround is not supported`.

This change removes the lookaround-based regex from the published schema and moves those checks to runtime validation. It preserves validation for allowed characters, absolute paths, traversal segments, and maximum length while strengthening cross-platform directory containment checks using Node’s path utilities.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

Install and enable the agent squad plugin from this branch and verify it doesn't break api requests

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
