### PR TITLE
ci(sdk): create GitHub release and post to Slack on latest SDK publish

### DIFF
--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -277,9 +277,10 @@ jobs:
         run: |
           # Grab content between the first "## " header and the next one in sdk/CHANGELOG.md
           CONTENT=$(awk '/^## [0-9]/{if(found) exit; found=1; next} found{print}' sdk/CHANGELOG.md)
-          echo "content<<EOF" >> $GITHUB_OUTPUT
+          DELIMITER=$(openssl rand -hex 8)
+          echo "content<<${DELIMITER}" >> $GITHUB_OUTPUT
           echo "$CONTENT" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "${DELIMITER}" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
         if: steps.check_commits.outputs.skip != 'true' && steps.channel.outputs.channel == 'latest'

--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -260,6 +260,40 @@ jobs:
             git push origin "refs/tags/${TAG}"
           done
 
+      - name: Get Previous SDK Tag
+        if: steps.check_commits.outputs.skip != 'true' && steps.channel.outputs.channel == 'latest'
+        id: prev_tag
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          # The checkout is shallow and tagless, so fetch the release tags explicitly.
+          git fetch origin "+refs/tags/sdk/sdk/v*:refs/tags/sdk/sdk/v*"
+          PREV_TAG=$(git tag -l 'sdk/sdk/v*' | grep -vx "sdk/sdk/v${VERSION}" | sort -V | tail -1 || echo "")
+          echo "prev_tag=$PREV_TAG" >> $GITHUB_OUTPUT
+
+      - name: Get Changelog Entry
+        if: steps.check_commits.outputs.skip != 'true' && steps.channel.outputs.channel == 'latest'
+        id: changelog
+        run: |
+          # Grab content between the first "## " header and the next one in sdk/CHANGELOG.md
+          CONTENT=$(awk '/^## [0-9]/{if(found) exit; found=1; next} found{print}' sdk/CHANGELOG.md)
+          echo "content<<EOF" >> $GITHUB_OUTPUT
+          echo "$CONTENT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        if: steps.check_commits.outputs.skip != 'true' && steps.channel.outputs.channel == 'latest'
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: sdk/sdk/v${{ steps.version.outputs.version }}
+          name: "SDK v${{ steps.version.outputs.version }}"
+          body: |
+            ${{ steps.changelog.outputs.content }}
+
+            ${{ steps.prev_tag.outputs.prev_tag != '' && format('**Full Changelog**: https://github.com/{0}/compare/{1}...sdk/sdk/v{2}', github.repository, steps.prev_tag.outputs.prev_tag, steps.version.outputs.version) || '' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Summary
         if: steps.check_commits.outputs.skip != 'true'
         env:
@@ -280,3 +314,26 @@ jobs:
             echo "  - sdk/core/v${VERSION}"
             echo "  - sdk/sdk/v${VERSION}"
           fi
+
+      - name: Post release to Slack
+        if: steps.check_commits.outputs.skip != 'true' && steps.channel.outputs.channel == 'latest'
+        uses: slackapi/slack-github-action@v3.0.1
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_RELEASE_BOT_TOKEN }}
+          payload: |
+            channel: "C0APVKGGZFC"
+            text: "Cline SDK v${{ steps.version.outputs.version }}"
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "Cline SDK v${{ steps.version.outputs.version }}"
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: ${{ toJSON(steps.changelog.outputs.content) }}
+              - type: "context"
+                elements:
+                  - type: "mrkdwn"
+                    text: "<https://www.npmjs.com/package/@cline/sdk/v/${{ steps.version.outputs.version }}|View on npm>${{ steps.prev_tag.outputs.prev_tag != '' && format(' | Full Changelog: https://github.com/{0}/compare/{1}...sdk/sdk/v{2}', github.repository, steps.prev_tag.outputs.prev_tag, steps.version.outputs.version) || '' }}"


### PR DESCRIPTION
### Related Issue

N/A — small CI/workflow improvement.

### Description

When the CLI is published (`cli-publish.yml`), the workflow creates a GitHub release from the changelog and posts an announcement to Slack. The SDK publish workflow (`sdk-publish.yml`) did neither — a `latest` SDK publish would push npm packages and git tags and then finish silently. This PR mirrors the CLI's release/announcement steps into the SDK publish workflow.

Four new steps run at the end of `publish-sdk`, all gated on `channel == 'latest'` (plus the existing `skip` check), so nightly publishes are unaffected — matching how CLI nightlies also skip release creation and Slack:

1. **Get Previous SDK Tag** — finds the prior release tag for the "Full Changelog" compare link. One non-obvious difference from the CLI workflow: `cli-publish.yml` uses `git describe --tags --abbrev=0 --match 'cli-v*'`, which needs full history — its checkout uses `fetch-depth: 0` + `fetch-tags: true`. The SDK workflow's checkout is a default shallow, tagless clone, so `git describe` can't work here. Instead this step explicitly fetches `refs/tags/sdk/sdk/v*` and picks the highest `sort -V` version that isn't the one being published. (Deliberately did not change the checkout to `fetch-depth: 0` — the shallow clone is also what makes the existing "commits in last 24h" nightly check behave the way it currently does, and cloning full history on every nightly run would be wasted work.)

2. **Get Changelog Entry** — extracts the top entry from `sdk/CHANGELOG.md` using the same awk one-liner as the CLI workflow. The header format is identical (`## 0.0.59`), so the `/^## [0-9]/` pattern carries over unchanged.

3. **Create GitHub Release** — anchored to the existing `sdk/sdk/v<version>` tag, which the "Create package tags for production publish" step creates and pushes immediately beforehand (the umbrella `@cline/sdk` package tag). No new tag scheme is introduced, and the release intentionally doesn't duplicate the four per-package tags (`sdk/shared/...`, `sdk/llms/...`, etc.). Named `SDK v0.0.X` to sit alongside the existing `CLI v3.0.X` releases in the releases list. The compare link uses `sdk/sdk/vA...sdk/sdk/vB` — GitHub's compare endpoint handles slashes in ref names fine since it splits on `...`.

4. **Post release to Slack** — same channel (`C0APVKGGZFC`) and `SLACK_RELEASE_BOT_TOKEN` secret as the CLI workflow, same block structure (header, changelog body via `toJSON(...)`, context line linking to npm + full changelog). Links to `@cline/sdk` on npm as the representative package.

No permission changes were needed — the job already has `contents: write` (it pushes the release tags), which is what `softprops/action-gh-release` needs.

**Known shared caveat:** like the CLI workflow, the Slack `chat.postMessage` call will fail if the extracted changelog entry is empty (Slack rejects empty section text). This means `sdk/CHANGELOG.md` needs its top entry present before running a `latest` publish — which is already the release practice (the top entry `## 0.0.59` matches the current package version). Failure mode is benign: packages/tags/release are already published by that point, only the announcement step fails.

### Test Procedure

- Validated the workflow YAML parses cleanly and produces the expected step list.
- The release/Slack steps are near-verbatim copies of the corresponding steps in `cli-publish.yml`, which run successfully on every CLI release (most recently `cli-v3.0.39`).
- Verified against the live repo state: `sdk/sdk/v0.0.59` etc. tags exist (so the release tag anchor and prev-tag lookup have real data to work with), and `sdk/CHANGELOG.md`'s top entry matches the awk extraction pattern.
- Dry-run of the prev-tag logic locally: fetching `refs/tags/sdk/sdk/v*` into a shallow clone and running the `git tag -l | grep -vx | sort -V | tail -1` pipeline yields `sdk/sdk/v0.0.58` when publishing `0.0.59`, as expected.
- Not exercised end-to-end (that requires an actual `latest` publish run); the next production SDK publish will be the real verification. If the new steps fail, the publish itself is already complete — nothing about npm publishing or tag creation was touched.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — CI workflow change; the Slack message mirrors the existing CLI release announcements.

### Additional Notes

Follow-up ideas (out of scope here): validating that the top `sdk/CHANGELOG.md` entry version matches the published version before publishing, and doing the same in `cli-publish.yml`.
