### PR TITLE
fix(cli): detect bun global installs after symlink resolution in auto-update

### DIFF
--- a/apps/cli/src/commands/update.test.ts
+++ b/apps/cli/src/commands/update.test.ts
@@ -101,6 +101,22 @@ describe("getInstallationInfo", () => {
 		});
 	});
 
+	it("detects bun global installs from the resolved install path", () => {
+		// bun symlinks ~/.bun/bin/cline -> ~/.bun/install/global/node_modules/...,
+		// and realpathSync resolves through the symlink before detection runs.
+		const wrapperPath = createTempFile(
+			".bun/install/global/node_modules/cline/bin/cline",
+		);
+		process.env.CLINE_WRAPPER_PATH = wrapperPath;
+		process.argv = ["bun", "/$bunfs/root/cline", "update", "--verbose"];
+
+		expect(getInstallationInfo("1.2.3")).toEqual({
+			packageManager: PackageManager.BUN,
+			packageName: "cline",
+			updateCommand: "bun add -g cline@latest",
+		});
+	});
+
 	it("falls back to unknown when only Bun's virtual compiled path is available", () => {
 		delete process.env.CLINE_WRAPPER_PATH;
 		process.argv = ["bun", "/$bunfs/root/cline", "update", "--verbose"];

--- a/apps/cli/src/commands/update.ts
+++ b/apps/cli/src/commands/update.ts
@@ -118,7 +118,12 @@ export function getInstallationInfo(currentVersion: string): InstallationInfo {
 				updateCommand: `yarn global add ${DEFAULT_PACKAGE_NAME}@${tag}`,
 			};
 		}
-		if (scriptPath.includes("/.bun/bin")) {
+		// `bun add -g` symlinks bins into ~/.bun/bin, but realpathSync resolves
+		// them to ~/.bun/install/global/node_modules/..., so match both.
+		if (
+			scriptPath.includes("/.bun/bin") ||
+			scriptPath.includes("/.bun/install/global/")
+		) {
 			return {
 				packageManager: PackageManager.BUN,
 				packageName: DEFAULT_PACKAGE_NAME,


### PR DESCRIPTION
### Related Issue

N/A — found while auditing the CLI auto-update logic.

### Description

**Problem:** CLIs installed via `bun add -g cline` never auto-update (and `cline update` is a silent no-op for them).

`bun add -g` creates a symlink at `~/.bun/bin/cline` pointing to `~/.bun/install/global/node_modules/cline/bin/cline`. Package-manager detection in `getInstallationInfo()` runs `realpathSync()` on the wrapper path (and the bin wrapper itself also sets `CLINE_WRAPPER_PATH` from `fs.realpathSync(__filename)`), so by the time the path is checked, the symlink is already fully resolved. The existing bun check looks for `/.bun/bin`, which can never appear in a resolved path — that branch was effectively dead code. The path then falls through to the generic `/node_modules/` check and gets misdetected as an **npm** install.

The consequence: on a bun-installed machine, auto-update runs `npm update -g cline`, and since cline isn't installed in npm's global prefix, npm reports "up to date" and installs nothing (verified empirically — it does *not* install a stray duplicate copy, it just does nothing). So bun users silently stay on whatever version they installed, forever.

**Fix:** also match `/.bun/install/global/` in the bun branch (which runs before the `/node_modules/` fallthrough). The `/.bun/bin` check is kept for any path that reaches detection unresolved.

**How this was found:** while double-checking the auto-update logic end-to-end, I installed a package with `bun add -g` in a sandbox and confirmed the bin symlink resolves to `~/.bun/install/global/node_modules/...`:

```
$ ls -la ~/.bun/bin/semver
~/.bun/bin/semver -> ../install/global/node_modules/semver/bin/semver.js
$ realpath ~/.bun/bin/semver
/home/node/.bun/install/global/node_modules/semver/bin/semver.js
```

For context, the rest of the detection matrix checked out fine in the same audit: npm global layout hits the `/node_modules/` branch correctly, pnpm's shims exec `$PNPM_HOME/global/v11/<hash>/node_modules/...` which matches the `/pnpm/global` check under the default `PNPM_HOME`, and npx paths are caught before anything else. The generated npm commands were also verified against the live registry (`npm update -g cline --tag latest|nightly --min-release-age=0` correctly moved 3.0.38 → 3.0.39 and 3.0.38-nightly → 3.0.39-nightly in a scratch prefix). Bun was the only broken branch.

### Test Procedure

- Added a regression test mirroring the existing npm/nightly detection tests: writes a fake wrapper at `.bun/install/global/node_modules/cline/bin/cline`, points `CLINE_WRAPPER_PATH` at it, and asserts `PackageManager.BUN` with `bun add -g cline@latest`. This fails without the fix (detects NPM) and passes with it.
- `bunx vitest run src/commands/update.test.ts` — 8/8 pass.
- `tsc --noEmit` and `biome check` clean on the touched files.

Note the docs only advertise `npm install -g cline`, so this only affects users who opted into bun themselves — but for those users auto-update was completely non-functional.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A (CLI backend change; test output above).

### Additional Notes

The `/.bun/bin` check kept alongside the new one costs nothing and covers hypothetical setups where the wrapper path reaches detection unresolved.