### PR TITLE
fix(vscode): show requested line range on read-file chat rows

### DIFF
--- a/apps/vscode/src/sdk/message-translator.test.ts
+++ b/apps/vscode/src/sdk/message-translator.test.ts
@@ -783,6 +783,101 @@ describe("translateSessionEvent — agent_event content_end", () => {
 		expect(second.path).toBe("/src/package.json")
 	})
 
+	it("content_end for read_files carries the requested line range into the readFile payload", () => {
+		const state = new MessageTranslatorState()
+
+		translateSessionEvent(
+			{
+				type: "agent_event",
+				payload: {
+					sessionId: "s1",
+					event: {
+						type: "content_start",
+						contentType: "tool",
+						toolName: "read_files",
+						toolCallId: "c1",
+						input: { files: [{ path: "/src/big-file.ts", start_line: 100, end_line: 200 }] },
+					} as AgentEvent,
+				},
+			},
+			state,
+		)
+
+		const endResult = translateSessionEvent(
+			{
+				type: "agent_event",
+				payload: {
+					sessionId: "s1",
+					event: {
+						type: "content_end",
+						contentType: "tool",
+						toolName: "read_files",
+						toolCallId: "c1",
+					} as AgentEvent,
+				},
+			},
+			state,
+		)
+
+		const endTool = JSON.parse(endResult.messages[0].text!)
+		expect(endTool.tool).toBe("readFile")
+		expect(endTool.path).toBe("/src/big-file.ts")
+		expect(endTool.readLineStart).toBe(100)
+		expect(endTool.readLineEnd).toBe(200)
+	})
+
+	it("content_end for read_files treats a start_line-only read as open-ended and defaults a missing start_line to 1", () => {
+		const state = new MessageTranslatorState()
+
+		translateSessionEvent(
+			{
+				type: "agent_event",
+				payload: {
+					sessionId: "s1",
+					event: {
+						type: "content_start",
+						contentType: "tool",
+						toolName: "read_files",
+						toolCallId: "c1",
+						input: {
+							files: [
+								{ path: "/src/paged.ts", start_line: 500, end_line: null },
+								{ path: "/src/head.ts", end_line: 50 },
+								{ path: "/src/whole.ts" },
+							],
+						},
+					} as AgentEvent,
+				},
+			},
+			state,
+		)
+
+		const endResult = translateSessionEvent(
+			{
+				type: "agent_event",
+				payload: {
+					sessionId: "s1",
+					event: {
+						type: "content_end",
+						contentType: "tool",
+						toolName: "read_files",
+						toolCallId: "c1",
+					} as AgentEvent,
+				},
+			},
+			state,
+		)
+
+		expect(endResult.messages).toHaveLength(3)
+		const [paged, head, whole] = endResult.messages.map((m) => JSON.parse(m.text!))
+		expect(paged.readLineStart).toBe(500)
+		expect(paged.readLineEnd).toBeUndefined()
+		expect(head.readLineStart).toBe(1)
+		expect(head.readLineEnd).toBe(50)
+		expect(whole.readLineStart).toBeUndefined()
+		expect(whole.readLineEnd).toBeUndefined()
+	})
+
 	it("content_end without prior content_start still works (graceful fallback)", () => {
 		const state = new MessageTranslatorState()
 

--- a/apps/vscode/src/sdk/message-translator.ts
+++ b/apps/vscode/src/sdk/message-translator.ts
@@ -452,10 +452,11 @@ function sdkToolToClineSayTool(toolName: string, input?: unknown): ClineSayTool 
 	switch (toolName) {
 		case "read_files":
 		case "read_file": {
-			const filePath = extractFirstFilePath(parsedInput)
+			const fileRead = extractFileReads(parsedInput)[0]
 			return {
 				tool: "readFile",
-				path: filePath,
+				path: fileRead?.path ?? "",
+				...readLineRangeFields(fileRead),
 			}
 		}
 
@@ -665,32 +666,53 @@ function getCompletionResultText(input: unknown): string {
 	return getStringField(parsed, "summary") ?? getStringField(parsed, "result") ?? ""
 }
 
-/** Extract file paths from a read_files/read_file input */
-function extractFilePaths(input: Record<string, unknown> | undefined): string[] {
+/** A single file read request parsed from a read_files/read_file input */
+interface FileReadRequest {
+	path: string
+	startLine?: number
+	endLine?: number
+}
+
+/** Extract file read requests (path + optional one-based inclusive line range) from a read_files/read_file input */
+function extractFileReads(input: Record<string, unknown> | undefined): FileReadRequest[] {
 	if (!input) return []
 	const files = input.files
 	if (Array.isArray(files) && files.length > 0) {
-		const paths = files
-			.map((f) => {
-				if (typeof f === "string") return f
+		const reads = files
+			.map((f): FileReadRequest => {
+				if (typeof f === "string") return { path: f }
 				if (typeof f === "object" && f !== null) {
-					return ((f as Record<string, unknown>).path as string) ?? ""
+					const entry = f as Record<string, unknown>
+					return {
+						path: (entry.path as string) ?? "",
+						startLine: getNumberField(entry, "start_line"),
+						endLine: getNumberField(entry, "end_line"),
+					}
 				}
-				return ""
+				return { path: "" }
 			})
-			.filter(Boolean)
-		if (paths.length > 0) {
-			return paths
+			.filter((read) => read.path)
+		if (reads.length > 0) {
+			return reads
 		}
 	}
 	const singlePath =
 		(input.path as string) ?? (input.file_path as string) ?? (input.filePath as string) ?? (input.filename as string) ?? ""
-	return singlePath ? [singlePath] : []
+	return singlePath
+		? [{ path: singlePath, startLine: getNumberField(input, "start_line"), endLine: getNumberField(input, "end_line") }]
+		: []
 }
 
-/** Extract the first file path from a read_files input */
-function extractFirstFilePath(input: Record<string, unknown> | undefined): string {
-	return extractFilePaths(input)[0] ?? ""
+/**
+ * Map a read request's line range onto ClineSayTool fields. An omitted start_line with an
+ * explicit end_line means the read began at line 1; an omitted end_line stays undefined
+ * (open-ended read — the UI renders it as "start+").
+ */
+function readLineRangeFields(read: FileReadRequest | undefined): Pick<ClineSayTool, "readLineStart" | "readLineEnd"> {
+	if (!read || (read.startLine == null && read.endLine == null)) {
+		return {}
+	}
+	return { readLineStart: read.startLine ?? 1, readLineEnd: read.endLine }
 }
 
 /** Get a string field from a parsed input object */
@@ -698,6 +720,14 @@ function getStringField(input: Record<string, unknown> | undefined, field: strin
 	if (!input) return undefined
 	const value = input[field]
 	if (typeof value === "string") return value
+	return undefined
+}
+
+/** Get a finite number field from a parsed input object (null/non-number → undefined) */
+function getNumberField(input: Record<string, unknown> | undefined, field: string): number | undefined {
+	if (!input) return undefined
+	const value = input[field]
+	if (typeof value === "number" && Number.isFinite(value)) return value
 	return undefined
 }
 
@@ -1295,16 +1325,17 @@ function translateAgentEvent(event: AgentEvent, state: MessageTranslatorState): 
 					// list reflect what was actually read.
 					if (toolName === "read_files" || toolName === "read_file") {
 						const parsedInput = parseToolInput(storedInput)
-						const filePaths = extractFilePaths(parsedInput)
-						if (filePaths.length > 1) {
-							filePaths.forEach((filePath, index) => {
+						const fileReads = extractFileReads(parsedInput)
+						if (fileReads.length > 1) {
+							fileReads.forEach((fileRead, index) => {
 								messages.push({
 									ts: index === 0 ? ts : state.nextTs(),
 									type: "say",
 									say: "tool",
 									text: JSON.stringify({
 										tool: "readFile",
-										path: filePath,
+										path: fileRead.path,
+										...readLineRangeFields(fileRead),
 									} satisfies ClineSayTool),
 									partial: false,
 								})

--- a/apps/vscode/src/shared/ExtensionMessage.ts
+++ b/apps/vscode/src/shared/ExtensionMessage.ts
@@ -275,7 +275,7 @@ export interface ClineSayTool {
 	operationIsLocatedInWorkspace?: boolean
 	/** Starting line numbers in the original file where each SEARCH block matched */
 	startLineNumbers?: number[]
-	/** Inclusive line range actually returned by read_file (for UI summaries). */
+	/** One-based inclusive line range requested by read_file; readLineEnd omitted = open-ended read (for UI summaries). */
 	readLineStart?: number
 	readLineEnd?: number
 }

--- a/apps/vscode/webview-ui/src/components/chat/ChatRow.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatRow.tsx
@@ -507,10 +507,11 @@ export const ChatRowContent = memo(
 									{tool.path && !tool.path.startsWith(".") && <span>/</span>}
 									<span className="ph-no-capture whitespace-nowrap overflow-hidden text-ellipsis mr-2 text-left [direction: rtl]">
 										{cleanPathPrefix(tool.path ?? "") + "\u200E"}
-										{tool.readLineStart != null && tool.readLineEnd != null ? (
+										{tool.readLineStart != null ? (
 											<span className="opacity-80">
 												{" "}
-												({tool.readLineStart}-{tool.readLineEnd})
+												({tool.readLineStart}
+												{tool.readLineEnd != null ? `-${tool.readLineEnd}` : "+"})
 											</span>
 										) : null}
 									</span>

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/components/messages/ToolGroupRenderer.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/components/messages/ToolGroupRenderer.tsx
@@ -46,7 +46,9 @@ const getActivityText = (tool: ClineSayTool): string | null => {
 				return null
 			}
 			const lineHint =
-				tool.readLineStart != null && tool.readLineEnd != null ? ` (lines ${tool.readLineStart}-${tool.readLineEnd})` : ""
+				tool.readLineStart != null
+					? ` (lines ${tool.readLineStart}${tool.readLineEnd != null ? `-${tool.readLineEnd}` : "+"})`
+					: ""
 			return `Reading ${cleanedPath}${lineHint}...`
 		}
 		case "listFilesTopLevel":
@@ -302,7 +304,9 @@ function getToolDisplayInfo(tool: ClineSayTool) {
 	switch (tool.tool) {
 		case "readFile": {
 			const lineNote =
-				tool.readLineStart != null && tool.readLineEnd != null ? `lines ${tool.readLineStart}-${tool.readLineEnd}` : null
+				tool.readLineStart != null
+					? `lines ${tool.readLineStart}${tool.readLineEnd != null ? `-${tool.readLineEnd}` : "+"}`
+					: null
 			return {
 				icon,
 				path: filePath,


### PR DESCRIPTION
### Related Issue

N/A — small UX fix, noticed while watching successive `read_files` calls in the chat.

### Description

**Problem:** When Cline reads a file, the chat row only shows the file path — even when the read specified a line range. Since the SDK's `read_files` tool is capped and pages through long files with `start_line`/`end_line`, a long file produces a run of consecutive `readFile` rows that all render as the *same bare path*. It looks like Cline is buggy and re-reading the same file over and over, when it's actually reading different slices.

**The gap turned out to be one-sided.** The display layer already fully supports line ranges:

- `ClineSayTool` already has `readLineStart` / `readLineEnd` fields
- `ChatRow.tsx` already renders `path (100-200)` when they're set
- `ToolGroupRenderer.tsx` already renders `Reading path (lines 100-200)...` in the activity line and `path · lines 100-200` in the collapsed group summary
- The CLI TUI already shows ranges (it formats the raw tool input directly)

But nothing ever *populated* those fields. The SDK message translator (`apps/vscode/src/sdk/message-translator.ts`) built the `readFile` payload from just the extracted path — `extractFilePaths()` walked the `files: [{ path, start_line, end_line }]` entries and discarded everything but `path`. So the renderers' range branches were dead code.

**Fix:** replaced `extractFilePaths`/`extractFirstFilePath` with `extractFileReads`, which carries each file's `start_line`/`end_line` through, and populated the fields in both payload-construction sites (the general `sdkToolToClineSayTool` case, and the one-message-per-file emission for multi-file reads).

**Open-ended ranges — the case that actually matters:** the common paging pattern is `start_line` only ("read from line 500 to the read cap"), because the model doesn't know where the file ends. The renderers previously required *both* bounds to be non-null, so the most frequent ranged read would still have shown nothing. Both webview renderers now handle open-ended ranges:

| read request | chat row | group summary |
|---|---|---|
| `start_line: 100, end_line: 200` | `path (100-200)` | `lines 100-200` |
| `start_line: 500` (to cap) | `path (500+)` | `lines 500+` |
| `end_line: 50` only | `path (1-50)` | `lines 1-50` |
| no range | `path` (unchanged) | (unchanged) |

The `end_line`-only case maps to start `1` in the translator since that's what the read actually does — the renderers never need to invent a bound.

Also updated the stale doc comment on the `ClineSayTool` fields: it claimed the range was "actually returned by read_file", but what we have at translation time is the *requested* range (the translator works from the tool input captured at `content_start`; the result event doesn't carry range info).

### Test Procedure

- Two new unit tests in `message-translator.test.ts`:
  - full range flows through `content_start` → `content_end` into the `readFile` payload
  - multi-file read covering all three shapes at once: open-ended (`start_line` + `end_line: null` → end stays undefined), `end_line`-only (start defaults to 1), and rangeless (both fields absent, so legacy rows render exactly as before)
- Full suites: `bun test src/sdk/message-translator.test.ts` (111 pass), `vitest run ToolGroupRenderer.test.ts` (3 pass — existing tests already assert range rendering in the collapse/dedup logic)
- `tsc --noEmit` clean on both the extension and webview-ui; biome check/format clean on touched files

What could break: rangeless reads are the regression surface — guarded by `readLineRangeFields()` returning `{}` when neither bound is present (asserted in the new test), so those payloads are byte-identical to before. The ask/approval path shares `sdkToolToClineSayTool`, so approval rows get the range for free ("readFile" payloads are constructed nowhere else — verified by grep).

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Successive paged reads of one file previously all rendered as `src/big-file.ts`; they now render as `src/big-file.ts (1-500)`, `src/big-file.ts (501+)`, etc.

### Additional Notes

The CLI TUI needed no changes — `apps/cli/src/tui/components/chat-entry.tsx` already renders `start_line`/`end_line` per file from the parsed tool input.
