### PR TITLE
fix(cli): reload provider configuration after switching providers

### DIFF
--- a/apps/cli/src/runtime/interactive/session-runtime.test.ts
+++ b/apps/cli/src/runtime/interactive/session-runtime.test.ts
@@ -815,18 +815,47 @@ describe("createInteractiveSessionRuntime", () => {
 		expect(runtime.getActiveSessionId()).toBe("session-2");
 	});
 
-	it("preserves the session id when restarting with the current messages", async () => {
+	it("preserves the session id and applies changed provider config when restarting with the current messages", async () => {
 		const manager = makeManager();
-		const runtime = await makeRuntime(manager);
+		const config = {
+			...createConfig(),
+			providerId: "cline",
+			modelId: "anthropic/claude-sonnet-4.6",
+			apiKey: "cline-key",
+		};
+		const messages: Message[] = [
+			{ role: "user", content: [{ type: "text", text: "hello" }] },
+		];
+		manager.readMessages.mockResolvedValue(messages);
+		const runtime = await makeRuntime(manager, { config });
 
 		await runtime.ensureReady();
+		expect(manager.start).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining({
+				config: expect.objectContaining({
+					providerId: "cline",
+					modelId: "anthropic/claude-sonnet-4.6",
+					apiKey: "cline-key",
+				}),
+			}),
+		);
+		config.providerId = "openai-compatible";
+		config.modelId = "custom-model";
+		config.apiKey = "new-key";
 		await runtime.restartWithCurrentMessages();
 
 		expect(manager.start).toHaveBeenCalledTimes(2);
 		expect(manager.start).toHaveBeenNthCalledWith(
 			2,
 			expect.objectContaining({
-				config: expect.objectContaining({ sessionId: "session-1" }),
+				config: expect.objectContaining({
+					sessionId: "session-1",
+					providerId: "openai-compatible",
+					modelId: "custom-model",
+					apiKey: "new-key",
+				}),
+				initialMessages: messages,
 			}),
 		);
 	});

--- a/apps/cli/src/runtime/run-interactive.test.ts
+++ b/apps/cli/src/runtime/run-interactive.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from "vitest";
-import { resolveReasoningForModelChange } from "./run-interactive";
+import { describe, expect, it, vi } from "vitest";
+import type { Config } from "../utils/types";
+import {
+	applyInteractiveModelChange,
+	resolveReasoningForModelChange,
+} from "./run-interactive";
 
 describe("resolveReasoningForModelChange", () => {
 	it("persists disabled reasoning only when thinking is explicitly false", () => {
@@ -36,5 +40,71 @@ describe("resolveReasoningForModelChange", () => {
 				{ reasoning: { enabled: true, effort: "medium" } },
 			),
 		).toEqual({ enabled: true, effort: "medium" });
+	});
+});
+
+describe("applyInteractiveModelChange", () => {
+	it("restarts with the current transcript so a provider switch reloads its complete configuration", async () => {
+		const config = {
+			providerId: "openai-compatible",
+			modelId: "custom-model",
+			apiKey: "new-key",
+			thinking: undefined,
+			reasoningEffort: undefined,
+		} as Config;
+		const getProviderSettings = vi.fn(() => ({
+			provider: "openai-compatible",
+			apiKey: "new-key",
+			baseUrl: "https://example.com/v1",
+			headers: { "X-Custom-Header": "custom-value" },
+			client: "openai-compatible" as const,
+			protocol: "openai-chat" as const,
+			model: "old-model",
+		}));
+		const saveProviderSettings = vi.fn(() => ({
+			version: 1 as const,
+			providers: {},
+		}));
+		const ensureReady = vi.fn(async () => {});
+		const restartWithCurrentMessages = vi.fn(async () => {});
+		const updateCurrentSessionConnection = vi.fn(async () => {});
+
+		await applyInteractiveModelChange({
+			config,
+			providerSettingsManager: {
+				getProviderSettings,
+				saveProviderSettings,
+			},
+			sessionRuntime: {
+				ensureReady,
+				restartWithCurrentMessages,
+				updateCurrentSessionConnection,
+			},
+		});
+
+		expect(saveProviderSettings).toHaveBeenCalledWith({
+			provider: "openai-compatible",
+			apiKey: "new-key",
+			baseUrl: "https://example.com/v1",
+			headers: { "X-Custom-Header": "custom-value" },
+			client: "openai-compatible",
+			protocol: "openai-chat",
+			model: "custom-model",
+		});
+		expect(ensureReady).toHaveBeenCalledOnce();
+		expect(restartWithCurrentMessages).toHaveBeenCalledOnce();
+		expect(updateCurrentSessionConnection).toHaveBeenCalledWith({
+			providerId: "openai-compatible",
+			modelId: "custom-model",
+		});
+		expect(ensureReady.mock.invocationCallOrder[0]).toBeLessThan(
+			restartWithCurrentMessages.mock.invocationCallOrder[0] ?? 0,
+		);
+		expect(saveProviderSettings.mock.invocationCallOrder[0]).toBeLessThan(
+			restartWithCurrentMessages.mock.invocationCallOrder[0] ?? 0,
+		);
+		expect(restartWithCurrentMessages.mock.invocationCallOrder[0]).toBeLessThan(
+			updateCurrentSessionConnection.mock.invocationCallOrder[0] ?? 0,
+		);
 	});
 });

--- a/apps/cli/src/runtime/run-interactive.ts
+++ b/apps/cli/src/runtime/run-interactive.ts
@@ -1,5 +1,4 @@
 import {
-	buildConnectionUpdate,
 	getCurrentContextSize,
 	type ProviderSettings,
 	ProviderSettingsManager,
@@ -81,6 +80,51 @@ export function resolveReasoningForModelChange(
 	}
 	if (config.thinking === true) return { enabled: true };
 	return existing.reasoning;
+}
+
+export async function applyInteractiveModelChange(input: {
+	config: Config;
+	providerSettingsManager: Pick<
+		ProviderSettingsManager,
+		"getProviderSettings" | "saveProviderSettings"
+	>;
+	sessionRuntime: Pick<
+		ReturnType<typeof createInteractiveSessionRuntime>,
+		| "ensureReady"
+		| "restartWithCurrentMessages"
+		| "updateCurrentSessionConnection"
+	>;
+}): Promise<void> {
+	const { config, providerSettingsManager, sessionRuntime } = input;
+	await sessionRuntime.ensureReady();
+	await onProviderChange({
+		config,
+		providerId: config.providerId,
+	});
+	const existing = providerSettingsManager.getProviderSettings(
+		config.providerId,
+	) ?? {
+		provider: config.providerId,
+	};
+	const reasoning = resolveReasoningForModelChange(config, existing);
+	providerSettingsManager.saveProviderSettings({
+		...existing,
+		model: config.modelId,
+		...(reasoning === undefined ? {} : { reasoning }),
+	});
+
+	// Provider changes affect more than the model connection: startup resolves
+	// the endpoint, headers, provider-specific options, tools, and plugins. Rebuild
+	// the runtime with the existing transcript so all of that state changes
+	// together. restartWithCurrentMessages preserves the session ID.
+	await sessionRuntime.restartWithCurrentMessages();
+	// A same-ID restart reuses the existing manifest. Sync its connection label
+	// after the fully configured runtime is live so session history reflects the
+	// provider/model that will handle subsequent turns.
+	await sessionRuntime.updateCurrentSessionConnection({
+		providerId: config.providerId,
+		modelId: config.modelId,
+	});
 }
 
 export async function runInteractive(
@@ -688,36 +732,12 @@ export async function runInteractive(
 		onNewSession: async () => {
 			await sessionRuntime.resetForNewSession();
 		},
-		onModelChange: async () => {
-			await sessionRuntime.ensureReady();
-			await onProviderChange({
+		onModelChange: () =>
+			applyInteractiveModelChange({
 				config,
-				providerId: config.providerId,
-			});
-			const existing = providerSettingsManager.getProviderSettings(
-				config.providerId,
-			) ?? {
-				provider: config.providerId,
-			};
-			const reasoning = resolveReasoningForModelChange(config, existing);
-			providerSettingsManager.saveProviderSettings({
-				...existing,
-				model: config.modelId,
-				...(reasoning === undefined ? {} : { reasoning }),
-			});
-			// A model/provider switch only changes connection options, so update
-			// the live session in place instead of restarting it — a restart would
-			// split the conversation into a new session history entry.
-			await sessionRuntime.updateCurrentSessionConnection(
-				buildConnectionUpdate({
-					providerId: config.providerId,
-					modelId: config.modelId,
-					apiKey: config.apiKey,
-					thinking: config.thinking,
-					reasoningEffort: config.reasoningEffort,
-				}),
-			);
-		},
+				providerSettingsManager,
+				sessionRuntime,
+			}),
 		onSessionRestart: async () => {
 			await sessionRuntime.ensureReady();
 			await sessionRuntime.restartEmpty();


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Fixes an interactive CLI regression when changing providers from an existing chat session.

The failure was reproducible by starting a chat with the Cline provider, opening `/settings`, switching to OpenAI Compatible, entering a key and model, and then sending the next message. The CLI showed a Cline-branded unauthorized response. Starting a fresh session with `/new` made the same OpenAI-compatible configuration work.

The settings dialog correctly persisted the new provider, but the active runtime was updated in place with only `providerId`, `modelId`, API key, and reasoning fields. The live agent retained connection state flattened during Cline session startup, including Cline's base URL and headers. The next turn therefore combined the new OpenAI-compatible identity and credentials with the old Cline endpoint.

This change routes interactive provider/model changes through the existing transcript-preserving restart path. That path keeps the same session ID and messages while rerunning Core's canonical provider bootstrap, which resolves:

- the persisted base URL and custom headers;
- provider-specific protocol, cloud, and authentication options;
- Cline-required client headers and runtime defaults;
- provider/model-sensitive tools, plugins, and delegated-agent defaults.

After the runtime is rebuilt, a provider/model-only connection update synchronizes the reused session manifest. This keeps `/history` aligned with the provider that will serve subsequent turns without overwriting the freshly resolved endpoint or credentials.

I considered expanding the in-place connection update to copy `baseUrl`, headers, and `providerConfig`. A restart is safer because optional connection fields do not have consistent cross-backend clearing semantics, and manually reconstructing `providerConfig` in the CLI would duplicate Core bootstrap logic while missing session-derived headers and other provider-sensitive runtime state.

### Test Procedure

1. Ran the focused regression suites:

   ```bash
   cd apps/cli
   bunx vitest run --config vitest.config.ts \
     src/runtime/run-interactive.test.ts \
     src/runtime/interactive/session-runtime.test.ts
   ```

   Result: 2 files passed, 21 tests passed.

2. Added coverage that starts with a Cline provider configuration, switches to OpenAI Compatible, and verifies the restart preserves the transcript and session ID while applying the new provider, model, and key.

3. Added callback-level coverage that verifies persisted OpenAI-compatible endpoint, custom headers, client, and protocol settings are retained; settings are saved before restart; and the manifest label is synchronized afterward.

4. Ran the remainder of the CLI unit suite while excluding the environment-sensitive distribution packaging test:

   ```bash
   bunx vitest run --config vitest.config.ts \
     --exclude src/commands/distribution-package.test.ts
   ```

   Result: 109 files passed, 825 tests passed.

5. Ran CLI typechecking, formatting/lint checks for the changed files, and the production build:

   ```bash
   (cd apps/cli && bun run typecheck)
   bun biome check \
     apps/cli/src/runtime/run-interactive.ts \
     apps/cli/src/runtime/run-interactive.test.ts \
     apps/cli/src/runtime/interactive/session-runtime.test.ts
   (cd apps/cli && bun run build)
   ```

   All passed.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable; this changes runtime behavior without altering the UI.

### Additional Notes

The full CLI unit command has one unrelated failure in `src/commands/distribution-package.test.ts`: this environment's Bun exits successfully for `bun pm pack --dry-run` without invoking the package's prepack guard. The test also fails in isolation and is untouched by this PR. All other CLI unit tests pass, and the focused regression tests, typecheck, Biome checks, and build are green.
