### PR TITLE
fix(vscode): preserve draft when toggling from act to plan

### DIFF
--- a/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -43,6 +43,7 @@ import {
 	validateSlashCommand,
 } from "@/utils/slash-commands"
 import ClineRulesToggleModal from "../cline-rules/ClineRulesToggleModal"
+import { shouldClearModeToggleDraft, shouldRestoreModeToggleDraft } from "./chat-textarea-mode-toggle"
 import ServersToggleModal from "./ServersToggleModal"
 
 const { MAX_IMAGES_AND_FILES_PER_MESSAGE } = CHAT_CONSTANTS
@@ -1036,16 +1037,40 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				)
 				// Focus the textarea after mode toggle with slight delay
 				setTimeout(() => {
-					if (response.value) {
+					const consumedComposerContent = response.value === true
+					const currentText = textAreaRef.current?.value ?? ""
+					if (consumedComposerContent) {
 						// The toggle consumed the composer content as the continuation
 						// message. Clear only what was submitted: the rebuild can take a
 						// moment and the user may have typed or attached new content in
 						// the meantime, which must not be wiped.
-						if ((textAreaRef.current?.value ?? "") === submittedText) {
+						if (
+							shouldClearModeToggleDraft({
+								consumed: consumedComposerContent,
+								currentText,
+								submittedText,
+							})
+						) {
 							setInputValue("")
 						}
 						setSelectedImages((current) => (current === submittedImages ? [] : current))
 						setSelectedFiles((current) => (current === submittedFiles ? [] : current))
+					} else {
+						if (
+							shouldRestoreModeToggleDraft({
+								consumed: consumedComposerContent,
+								currentText,
+								submittedText,
+							})
+						) {
+							setInputValue(submittedText)
+						}
+						if (submittedImages.length > 0) {
+							setSelectedImages((current) => (current.length === 0 ? submittedImages : current))
+						}
+						if (submittedFiles.length > 0) {
+							setSelectedFiles((current) => (current.length === 0 ? submittedFiles : current))
+						}
 					}
 					textAreaRef.current?.focus()
 				}, 100)

--- a/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -43,7 +43,7 @@ import {
 	validateSlashCommand,
 } from "@/utils/slash-commands"
 import ClineRulesToggleModal from "../cline-rules/ClineRulesToggleModal"
-import { shouldClearModeToggleDraft, shouldRestoreModeToggleDraft } from "./chat-textarea-mode-toggle"
+import { getModeToggleDraftAction } from "./chat-textarea-mode-toggle"
 import ServersToggleModal from "./ServersToggleModal"
 
 const { MAX_IMAGES_AND_FILES_PER_MESSAGE } = CHAT_CONSTANTS
@@ -1039,32 +1039,29 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				setTimeout(() => {
 					const consumedComposerContent = response.value === true
 					const currentText = textAreaRef.current?.value ?? ""
-					if (consumedComposerContent) {
-						// The toggle consumed the composer content as the continuation
-						// message. Clear only what was submitted: the rebuild can take a
-						// moment and the user may have typed or attached new content in
-						// the meantime, which must not be wiped.
-						if (
-							shouldClearModeToggleDraft({
-								consumed: consumedComposerContent,
-								currentText,
-								submittedText,
-							})
-						) {
+					// Reconcile only the submitted draft: the rebuild can take a moment
+					// and the user may have typed new content in the meantime.
+					const draftAction = getModeToggleDraftAction({
+						consumed: consumedComposerContent,
+						currentText,
+						submittedText,
+					})
+
+					switch (draftAction) {
+						case "clear":
 							setInputValue("")
-						}
+							break
+						case "restore":
+							setInputValue(submittedText)
+							break
+						case "keep":
+							break
+					}
+
+					if (consumedComposerContent) {
 						setSelectedImages((current) => (current === submittedImages ? [] : current))
 						setSelectedFiles((current) => (current === submittedFiles ? [] : current))
 					} else {
-						if (
-							shouldRestoreModeToggleDraft({
-								consumed: consumedComposerContent,
-								currentText,
-								submittedText,
-							})
-						) {
-							setInputValue(submittedText)
-						}
 						if (submittedImages.length > 0) {
 							setSelectedImages((current) => (current.length === 0 ? submittedImages : current))
 						}

--- a/apps/vscode/webview-ui/src/components/chat/chat-textarea-mode-toggle.test.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-textarea-mode-toggle.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest"
+import { shouldClearModeToggleDraft, shouldRestoreModeToggleDraft } from "./chat-textarea-mode-toggle"
+
+describe("chat textarea mode toggle draft handling", () => {
+	it("clears only when the toggle consumed the submitted text", () => {
+		expect(
+			shouldClearModeToggleDraft({
+				consumed: true,
+				currentText: "draft message",
+				submittedText: "draft message",
+			}),
+		).toBe(true)
+
+		expect(
+			shouldClearModeToggleDraft({
+				consumed: true,
+				currentText: "draft message plus more",
+				submittedText: "draft message",
+			}),
+		).toBe(false)
+	})
+
+	it("restores a dropped draft after an unconsumed toggle", () => {
+		expect(
+			shouldRestoreModeToggleDraft({
+				consumed: false,
+				currentText: "",
+				submittedText: "draft message",
+			}),
+		).toBe(true)
+
+		expect(
+			shouldRestoreModeToggleDraft({
+				consumed: false,
+				currentText: "still here",
+				submittedText: "draft message",
+			}),
+		).toBe(false)
+
+		expect(
+			shouldRestoreModeToggleDraft({
+				consumed: true,
+				currentText: "",
+				submittedText: "draft message",
+			}),
+		).toBe(false)
+	})
+})

--- a/apps/vscode/webview-ui/src/components/chat/chat-textarea-mode-toggle.test.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-textarea-mode-toggle.test.ts
@@ -1,48 +1,48 @@
 import { describe, expect, it } from "vitest"
-import { shouldClearModeToggleDraft, shouldRestoreModeToggleDraft } from "./chat-textarea-mode-toggle"
+import { getModeToggleDraftAction } from "./chat-textarea-mode-toggle"
 
 describe("chat textarea mode toggle draft handling", () => {
 	it("clears only when the toggle consumed the submitted text", () => {
 		expect(
-			shouldClearModeToggleDraft({
+			getModeToggleDraftAction({
 				consumed: true,
 				currentText: "draft message",
 				submittedText: "draft message",
 			}),
-		).toBe(true)
+		).toBe("clear")
 
 		expect(
-			shouldClearModeToggleDraft({
+			getModeToggleDraftAction({
 				consumed: true,
 				currentText: "draft message plus more",
 				submittedText: "draft message",
 			}),
-		).toBe(false)
+		).toBe("keep")
 	})
 
 	it("restores a dropped draft after an unconsumed toggle", () => {
 		expect(
-			shouldRestoreModeToggleDraft({
+			getModeToggleDraftAction({
 				consumed: false,
 				currentText: "",
 				submittedText: "draft message",
 			}),
-		).toBe(true)
+		).toBe("restore")
 
 		expect(
-			shouldRestoreModeToggleDraft({
+			getModeToggleDraftAction({
 				consumed: false,
 				currentText: "still here",
 				submittedText: "draft message",
 			}),
-		).toBe(false)
+		).toBe("keep")
 
 		expect(
-			shouldRestoreModeToggleDraft({
+			getModeToggleDraftAction({
 				consumed: true,
 				currentText: "",
 				submittedText: "draft message",
 			}),
-		).toBe(false)
+		).toBe("keep")
 	})
 })

--- a/apps/vscode/webview-ui/src/components/chat/chat-textarea-mode-toggle.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-textarea-mode-toggle.ts
@@ -1,7 +1,13 @@
-export function shouldClearModeToggleDraft(input: { consumed: boolean; currentText: string; submittedText: string }): boolean {
-	return input.consumed && input.currentText === input.submittedText
-}
+export type ModeToggleDraftAction = "clear" | "restore" | "keep"
 
-export function shouldRestoreModeToggleDraft(input: { consumed: boolean; currentText: string; submittedText: string }): boolean {
-	return !input.consumed && input.currentText.length === 0 && input.submittedText.length > 0
+export function getModeToggleDraftAction(input: {
+	consumed: boolean
+	currentText: string
+	submittedText: string
+}): ModeToggleDraftAction {
+	if (input.consumed) {
+		return input.currentText === input.submittedText ? "clear" : "keep"
+	}
+
+	return input.currentText.length === 0 && input.submittedText.length > 0 ? "restore" : "keep"
 }

--- a/apps/vscode/webview-ui/src/components/chat/chat-textarea-mode-toggle.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-textarea-mode-toggle.ts
@@ -1,0 +1,7 @@
+export function shouldClearModeToggleDraft(input: { consumed: boolean; currentText: string; submittedText: string }): boolean {
+	return input.consumed && input.currentText === input.submittedText
+}
+
+export function shouldRestoreModeToggleDraft(input: { consumed: boolean; currentText: string; submittedText: string }): boolean {
+	return !input.consumed && input.currentText.length === 0 && input.submittedText.length > 0
+}


### PR DESCRIPTION
## Summary
- restore the composer draft if an act to plan toggle does not consume it and the rebuild clears it
- keep the existing consumed-draft clear behavior without wiping newer edits
- add focused coverage for mode-toggle draft reconciliation

Fixes #12237

## Testing
- bun test webview-ui/src/components/chat/chat-textarea-mode-toggle.test.ts
- bun -F @cline/vscode typecheck