### PR TITLE
fix(vscode): surface skills in slash-command autocomplete

### DIFF
--- a/apps/vscode/src/core/controller/slash/getAvailableSlashCommands.test.ts
+++ b/apps/vscode/src/core/controller/slash/getAvailableSlashCommands.test.ts
@@ -1,5 +1,5 @@
 import type { CoreSettingsItem } from "@cline/core"
-import type { GlobalInstructionsFile } from "@shared/remote-config/schema"
+import type { ValidatedRemoteSkill } from "@core/context/instructions/user-instructions/skills"
 import { describe, expect, it } from "vitest"
 import { filterEnabledSkillItems } from "./getAvailableSlashCommands"
 
@@ -15,14 +15,14 @@ function skill(overrides: Partial<CoreSettingsItem>): CoreSettingsItem {
 	}
 }
 
-function remoteSkill(overrides: Partial<GlobalInstructionsFile> = {}): GlobalInstructionsFile {
+function remoteSkill(overrides: Partial<ValidatedRemoteSkill> = {}): ValidatedRemoteSkill {
 	return {
 		name: "remote-skill",
 		description: "Remote skill",
 		alwaysEnabled: false,
 		contents: "# Remote skill",
 		...overrides,
-	} as GlobalInstructionsFile
+	}
 }
 
 describe("filterEnabledSkillItems", () => {

--- a/apps/vscode/src/core/controller/slash/getAvailableSlashCommands.test.ts
+++ b/apps/vscode/src/core/controller/slash/getAvailableSlashCommands.test.ts
@@ -20,6 +20,7 @@ function remoteSkill(overrides: Partial<GlobalInstructionsFile> = {}): GlobalIns
 		name: "remote-skill",
 		description: "Remote skill",
 		alwaysEnabled: false,
+		contents: "# Remote skill",
 		...overrides,
 	} as GlobalInstructionsFile
 }
@@ -39,7 +40,7 @@ describe("filterEnabledSkillItems", () => {
 		const result = filterEnabledSkillItems({
 			skills: [
 				skill({ name: "alpha", path: "/skills/alpha/SKILL.md" }),
-				skill({ name: "off", path: "/skills/off/SKILL.md", disabled: true }),
+				skill({ name: "off", path: "/skills/off/SKILL.md", enabled: false }),
 			],
 			remoteConfigSkills: [],
 			remoteSkillsToggles: {},

--- a/apps/vscode/src/core/controller/slash/getAvailableSlashCommands.test.ts
+++ b/apps/vscode/src/core/controller/slash/getAvailableSlashCommands.test.ts
@@ -5,9 +5,9 @@ import { filterEnabledSkillItems } from "./getAvailableSlashCommands"
 
 function skill(overrides: Partial<CoreSettingsItem>): CoreSettingsItem {
 	return {
-		id: overrides.id ?? overrides.path ?? overrides.name ?? "skill",
-		name: overrides.name ?? "skill",
-		path: overrides.path ?? "/skills/skill/SKILL.md",
+		id: overrides.id ?? overrides.path ?? overrides.name ?? "test-skill",
+		name: overrides.name ?? "test-skill",
+		path: overrides.path ?? "/skills/test-skill/SKILL.md",
 		kind: "skill",
 		source: "global",
 		enabled: true,
@@ -59,14 +59,28 @@ describe("filterEnabledSkillItems", () => {
 		expect(result).toEqual([])
 	})
 
-	it("deduplicates remote skill when a local skill with the same name already exists", () => {
+	it("uses disk-global skill when a workspace skill with the same name exists", () => {
 		const result = filterEnabledSkillItems({
-			skills: [skill({ name: "shared", path: "/skills/shared/SKILL.md" })],
+			skills: [
+				skill({ name: "shared", path: "/project/skills/shared/SKILL.md", source: "workspace" }),
+				skill({ name: "shared", path: "/global/skills/shared/SKILL.md", source: "global" }),
+			],
+			remoteConfigSkills: [],
+			remoteSkillsToggles: {},
+		})
+
+		expect(result).toHaveLength(1)
+		expect(result[0].path).toBe("/global/skills/shared/SKILL.md")
+	})
+
+	it("uses remote skill when a local skill with the same name exists", () => {
+		const result = filterEnabledSkillItems({
+			skills: [skill({ name: "shared", path: "/global/skills/shared/SKILL.md" })],
 			remoteConfigSkills: [remoteSkill({ name: "shared" })],
 			remoteSkillsToggles: {},
 		})
 
 		expect(result).toHaveLength(1)
-		expect(result[0].path).toBe("/skills/shared/SKILL.md")
+		expect(result[0].path).toBe("remote:shared")
 	})
 })

--- a/apps/vscode/src/core/controller/slash/getAvailableSlashCommands.test.ts
+++ b/apps/vscode/src/core/controller/slash/getAvailableSlashCommands.test.ts
@@ -1,0 +1,71 @@
+import type { CoreSettingsItem } from "@cline/core"
+import type { GlobalInstructionsFile } from "@shared/remote-config/schema"
+import { describe, expect, it } from "vitest"
+import { filterEnabledSkillItems } from "./getAvailableSlashCommands"
+
+function skill(overrides: Partial<CoreSettingsItem>): CoreSettingsItem {
+	return {
+		id: overrides.id ?? overrides.path ?? overrides.name ?? "skill",
+		name: overrides.name ?? "skill",
+		path: overrides.path ?? "/skills/skill/SKILL.md",
+		kind: "skill",
+		source: "global",
+		enabled: true,
+		...overrides,
+	}
+}
+
+function remoteSkill(overrides: Partial<GlobalInstructionsFile> = {}): GlobalInstructionsFile {
+	return {
+		name: "remote-skill",
+		description: "Remote skill",
+		alwaysEnabled: false,
+		...overrides,
+	} as GlobalInstructionsFile
+}
+
+describe("filterEnabledSkillItems", () => {
+	it("returns local and remote skills that are not explicitly disabled", () => {
+		const result = filterEnabledSkillItems({
+			skills: [skill({ name: "alpha", path: "/skills/alpha/SKILL.md" })],
+			remoteConfigSkills: [remoteSkill({ name: "beta", alwaysEnabled: true })],
+			remoteSkillsToggles: {},
+		})
+
+		expect(result.map((s) => s.name)).toEqual(["alpha", "beta"])
+	})
+
+	it("skips local skills marked as disabled", () => {
+		const result = filterEnabledSkillItems({
+			skills: [
+				skill({ name: "alpha", path: "/skills/alpha/SKILL.md" }),
+				skill({ name: "off", path: "/skills/off/SKILL.md", disabled: true }),
+			],
+			remoteConfigSkills: [],
+			remoteSkillsToggles: {},
+		})
+
+		expect(result.map((s) => s.name)).toEqual(["alpha"])
+	})
+
+	it("skips remote skills that are explicitly disabled by toggle", () => {
+		const result = filterEnabledSkillItems({
+			skills: [],
+			remoteConfigSkills: [remoteSkill({ name: "remote" })],
+			remoteSkillsToggles: { remote: false },
+		})
+
+		expect(result).toEqual([])
+	})
+
+	it("deduplicates remote skill when a local skill with the same name already exists", () => {
+		const result = filterEnabledSkillItems({
+			skills: [skill({ name: "shared", path: "/skills/shared/SKILL.md" })],
+			remoteConfigSkills: [remoteSkill({ name: "shared" })],
+			remoteSkillsToggles: {},
+		})
+
+		expect(result).toHaveLength(1)
+		expect(result[0].path).toBe("/skills/shared/SKILL.md")
+	})
+})

--- a/apps/vscode/src/core/controller/slash/getAvailableSlashCommands.ts
+++ b/apps/vscode/src/core/controller/slash/getAvailableSlashCommands.ts
@@ -113,7 +113,7 @@ export function filterEnabledSkillItems(input: {
 	const seenNames = new Set<string>()
 
 	for (const skill of input.skills) {
-		if (skill.disabled) {
+		if (skill.enabled === false) {
 			continue
 		}
 		if (seenNames.has(skill.name)) {

--- a/apps/vscode/src/core/controller/slash/getAvailableSlashCommands.ts
+++ b/apps/vscode/src/core/controller/slash/getAvailableSlashCommands.ts
@@ -109,29 +109,22 @@ export function filterEnabledSkillItems(input: {
 	remoteConfigSkills: ReturnType<typeof parseRemoteSkillEntries>
 	remoteSkillsToggles: Record<string, boolean>
 }): CoreSettingsItem[] {
-	const enabled: CoreSettingsItem[] = []
-	const seenNames = new Set<string>()
+	const candidates: CoreSettingsItem[] = []
+	const selectedByName = new Map<string, CoreSettingsItem>()
 
 	for (const skill of input.skills) {
 		if (skill.enabled === false) {
 			continue
 		}
-		if (seenNames.has(skill.name)) {
-			continue
-		}
-		seenNames.add(skill.name)
-		enabled.push(skill)
+		candidates.push(skill)
+		selectedByName.set(skill.name, skill)
 	}
 
 	for (const remoteSkill of input.remoteConfigSkills) {
 		if (!remoteSkill.alwaysEnabled && input.remoteSkillsToggles[remoteSkill.name] === false) {
 			continue
 		}
-		if (seenNames.has(remoteSkill.name)) {
-			continue
-		}
-		seenNames.add(remoteSkill.name)
-		enabled.push({
+		const skill = {
 			id: `remote:${remoteSkill.name}`,
 			name: remoteSkill.name,
 			description: remoteSkill.description,
@@ -139,10 +132,12 @@ export function filterEnabledSkillItems(input: {
 			kind: "skill",
 			source: "global",
 			enabled: true,
-		})
+		} satisfies CoreSettingsItem
+		candidates.push(skill)
+		selectedByName.set(skill.name, skill)
 	}
 
-	return enabled
+	return candidates.filter((skill) => selectedByName.get(skill.name) === skill)
 }
 
 async function listEnabledSkills(controller: Controller): Promise<CoreSettingsItem[]> {

--- a/apps/vscode/src/core/controller/slash/getAvailableSlashCommands.ts
+++ b/apps/vscode/src/core/controller/slash/getAvailableSlashCommands.ts
@@ -1,5 +1,9 @@
+import { type CoreSettingsItem, type CoreSettingsSnapshot, createCoreSettingsService } from "@cline/core"
+import { parseRemoteSkillEntries } from "@core/context/instructions/user-instructions/skills"
 import { EmptyRequest } from "@shared/proto/cline/common"
 import { SlashCommandInfo, SlashCommandsResponse } from "@shared/proto/cline/slash"
+import { HostProvider } from "@/hosts/host-provider"
+import { Logger } from "@/shared/services/Logger"
 import { BASE_SLASH_COMMANDS } from "@/shared/slashCommands"
 import { Controller } from ".."
 
@@ -79,10 +83,85 @@ export async function getAvailableSlashCommands(controller: Controller, _request
 		}
 	}
 
+	// Add enabled skills so they surface in the slash-command autocomplete.
+	// Skills share the same custom section and CLI compatibility as workflows.
+	for (const skill of await listEnabledSkills(controller)) {
+		commands.push(
+			SlashCommandInfo.create({
+				name: skill.name,
+				description: skill.description || `Skill: ${skill.name}`,
+				section: "custom",
+				cliCompatible: true,
+			}),
+		)
+	}
+
 	return SlashCommandsResponse.create({ commands })
 }
 
 function fullPathToFileName(path: string): string {
 	// e.g. replace /path/to/workflow.md with workflow.md
 	return path.replace(/^.*[/\\]/, "")
+}
+
+export function filterEnabledSkillItems(input: {
+	skills: CoreSettingsItem[]
+	remoteConfigSkills: ReturnType<typeof parseRemoteSkillEntries>
+	remoteSkillsToggles: Record<string, boolean>
+}): CoreSettingsItem[] {
+	const enabled: CoreSettingsItem[] = []
+	const seenNames = new Set<string>()
+
+	for (const skill of input.skills) {
+		if (skill.disabled) {
+			continue
+		}
+		if (seenNames.has(skill.name)) {
+			continue
+		}
+		seenNames.add(skill.name)
+		enabled.push(skill)
+	}
+
+	for (const remoteSkill of input.remoteConfigSkills) {
+		if (!remoteSkill.alwaysEnabled && input.remoteSkillsToggles[remoteSkill.name] === false) {
+			continue
+		}
+		if (seenNames.has(remoteSkill.name)) {
+			continue
+		}
+		seenNames.add(remoteSkill.name)
+		enabled.push({
+			id: `remote:${remoteSkill.name}`,
+			name: remoteSkill.name,
+			description: remoteSkill.description,
+			path: `remote:${remoteSkill.name}`,
+			kind: "skill",
+			source: "global",
+			enabled: true,
+		})
+	}
+
+	return enabled
+}
+
+async function listEnabledSkills(controller: Controller): Promise<CoreSettingsItem[]> {
+	try {
+		const workspacePaths = await HostProvider.workspace.getWorkspacePaths({})
+		const primaryWorkspace = workspacePaths.paths[0]
+		const settingsSnapshot: CoreSettingsSnapshot = await createCoreSettingsService().list({
+			workspaceRoot: primaryWorkspace,
+		})
+		const remoteConfigSettings = controller.stateManager.getRemoteConfigSettings()
+		const remoteSkillsToggles = controller.stateManager.getGlobalStateKey("remoteSkillsToggles") || {}
+
+		return filterEnabledSkillItems({
+			skills: settingsSnapshot.skills,
+			remoteConfigSkills: parseRemoteSkillEntries(remoteConfigSettings.remoteGlobalSkills || []),
+			remoteSkillsToggles,
+		})
+	} catch (error) {
+		Logger.warn("getAvailableSlashCommands: failed to list skills for autocomplete", error)
+		return []
+	}
 }

--- a/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1,5 +1,5 @@
 import { mentionRegex, mentionRegexGlobal } from "@shared/context-mentions"
-import { StringRequest } from "@shared/proto/cline/common"
+import { EmptyRequest, StringRequest } from "@shared/proto/cline/common"
 import { FileSearchRequest, FileSearchType, RelativePathsRequest } from "@shared/proto/cline/file"
 import { PlanActMode, TogglePlanActModeRequest } from "@shared/proto/cline/state"
 import { type SlashCommand } from "@shared/slashCommands"
@@ -20,7 +20,7 @@ import { useExtensionState } from "@/context/ExtensionStateContext"
 import { usePlatform } from "@/context/PlatformContext"
 import { useNormalizedApiConfiguration } from "@/hooks/useNormalizedApiConfiguration"
 import { cn } from "@/lib/utils"
-import { FileServiceClient, StateServiceClient } from "@/services/grpc-client"
+import { FileServiceClient, SlashServiceClient, StateServiceClient } from "@/services/grpc-client"
 import {
 	ContextMenuOptionType,
 	getContextMenuOptionIndex,
@@ -250,6 +250,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 
 		const [shownTooltipMode, setShownTooltipMode] = useState<Mode | null>(null)
 		const [pendingInsertions, setPendingInsertions] = useState<string[]>([])
+		const [extraSlashCommands, setExtraSlashCommands] = useState<SlashCommand[]>([])
 		const _shiftHoldTimerRef = useRef<NodeJS.Timeout | null>(null)
 		const [showUnsupportedFileError, setShowUnsupportedFileError] = useState(false)
 		const unsupportedFileTimerRef = useRef<NodeJS.Timeout | null>(null)
@@ -306,7 +307,35 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			return () => {
 				document.removeEventListener("mousedown", handleClickOutside)
 			}
-		}, [showContextMenu, setShowContextMenu])
+		}, [showContextMenu])
+
+		// Fetch the server-side slash-command list (skills, remote workflows, etc.) once so
+		// the chat composer mirrors the CLI's slash menu. The menu re-derives as the user
+		// types, so we do not need to re-run the RPC on every keystroke.
+		useEffect(() => {
+			let cancelled = false
+			SlashServiceClient.getAvailableSlashCommands(EmptyRequest.create({}))
+				.then((response) => {
+					if (cancelled) {
+						return
+					}
+					const commands: SlashCommand[] = (response.commands || [])
+						.filter((cmd) => cmd.section !== "default")
+						.map((cmd) => ({
+							name: cmd.name,
+							description: cmd.description || undefined,
+							section: cmd.section === "mcp" ? "mcp" : "custom",
+							cliCompatible: cmd.cliCompatible,
+						}))
+					setExtraSlashCommands(commands)
+				})
+				.catch((error) => {
+					console.error("Failed to load available slash commands", error)
+				})
+			return () => {
+				cancelled = true
+			}
+		}, [])
 
 		useEffect(() => {
 			const handleClickOutsideSlashMenu = (event: MouseEvent) => {
@@ -489,6 +518,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 								remoteWorkflowToggles,
 								remoteConfigSettings?.remoteGlobalWorkflows,
 								mcpServers,
+								extraSlashCommands,
 							)
 
 							if (allCommands.length === 0) {
@@ -514,6 +544,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 							remoteWorkflowToggles,
 							remoteConfigSettings?.remoteGlobalWorkflows,
 							mcpServers,
+							extraSlashCommands,
 						)
 						if (commands.length > 0) {
 							handleSlashCommandsSelect(commands[selectedSlashCommandsIndex])
@@ -1395,6 +1426,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					{showSlashCommandsMenu && (
 						<div ref={slashCommandsMenuContainerRef}>
 							<SlashCommandMenu
+								extraCommands={extraSlashCommands}
 								globalWorkflowToggles={globalWorkflowToggles}
 								localWorkflowToggles={localWorkflowToggles}
 								mcpServers={mcpServers}

--- a/apps/vscode/webview-ui/src/components/chat/SlashCommandMenu.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/SlashCommandMenu.tsx
@@ -16,6 +16,7 @@ interface SlashCommandMenuProps {
 	remoteWorkflowToggles?: Record<string, boolean>
 	remoteWorkflows?: any[]
 	mcpServers?: McpServer[]
+	extraCommands?: SlashCommand[]
 }
 
 const SlashCommandMenu: React.FC<SlashCommandMenuProps> = ({
@@ -29,6 +30,7 @@ const SlashCommandMenu: React.FC<SlashCommandMenuProps> = ({
 	remoteWorkflowToggles,
 	remoteWorkflows,
 	mcpServers = [],
+	extraCommands = [],
 }) => {
 	const menuRef = useRef<HTMLDivElement>(null)
 
@@ -40,6 +42,7 @@ const SlashCommandMenu: React.FC<SlashCommandMenuProps> = ({
 		remoteWorkflowToggles,
 		remoteWorkflows,
 		mcpServers,
+		extraCommands,
 	)
 	const defaultCommands = filteredCommands.filter((cmd) => cmd.section === "default" || !cmd.section)
 	const workflowCommands = filteredCommands.filter((cmd) => cmd.section === "custom")

--- a/apps/vscode/webview-ui/src/utils/slash-commands.ts
+++ b/apps/vscode/webview-ui/src/utils/slash-commands.ts
@@ -181,6 +181,7 @@ export function getMatchingSlashCommands(
 	remoteWorkflowToggles?: Record<string, boolean>,
 	remoteWorkflows?: any[],
 	mcpServers: McpServer[] = [],
+	extraCommands: SlashCommand[] = [],
 ): SlashCommand[] {
 	const workflowCommands = getWorkflowCommands(
 		localWorkflowToggles,
@@ -189,7 +190,7 @@ export function getMatchingSlashCommands(
 		remoteWorkflows,
 	)
 	const mcpPromptCommands = getMcpPromptCommands(mcpServers)
-	const allCommands = [...DEFAULT_SLASH_COMMANDS, ...workflowCommands, ...mcpPromptCommands]
+	const allCommands = [...DEFAULT_SLASH_COMMANDS, ...workflowCommands, ...mcpPromptCommands, ...extraCommands]
 
 	if (!query) {
 		return allCommands


### PR DESCRIPTION
## Summary
- teach the gRPC slash-command list to include enabled local and remote skills
- add a focused vitest suite covering the new skill filter
- wire the webview to consume the gRPC result and merge it into the slash menu

Fixes #12236

## Testing
- bun run test:vitest -- src/core/controller/slash/getAvailableSlashCommands.test.ts
- bun run test:webview -- --run src/utils/__tests__/slash-commands.test.ts
- bun -F @cline/vscode typecheck