### PR TITLE
docs: add DaoXE OpenAI-compatible setup examples

### DIFF
--- a/docs/provider-config/openai-compatible.mdx
+++ b/docs/provider-config/openai-compatible.mdx
@@ -7,6 +7,7 @@ Cline supports a wide range of AI model providers that offer APIs compatible wit
 
 -   **Local models** running through tools like Ollama and LM Studio (which are covered in their respective sections).
 -   **Cloud providers** like Perplexity, Together AI, Anyscale, and many others.
+-   **Multi-model gateways** such as [DaoXE](https://daoxe.com) (`https://daoxe.com/v1`).
 -   **Any other provider** that offers an OpenAI-compatible API endpoint.
 
 This document focuses on setting up providers _other than_ the official OpenAI API (which has its own [dedicated configuration page](/provider-config/openai)).
@@ -25,6 +26,20 @@ You'll find these settings in the Cline settings panel (click the ⚙️ icon):
 -   **Base URL:** Enter the base URL provided by your chosen provider. **This is a crucial step.**
 -   **API Key:** Enter your API key from the provider.
 -   **Model:** Choose or enter the model ID.
+
+### Example: DaoXE
+
+[DaoXE](https://daoxe.com) is a multi-model multi-protocol AI API gateway.
+
+1. Select **OpenAI Compatible** as the API Provider.
+2. Set **Base URL** to `https://daoxe.com/v1`.
+3. Paste your DaoXE API key.
+4. Enter an exact model ID currently available to your DaoXE account.
+
+DaoXE supports OpenAI Chat Completions, OpenAI Responses, Anthropic Messages, and image-compatible endpoints. Cline uses the OpenAI Chat Completions path above.
+
+DaoXE is **not available in mainland China**. Public examples: [DaoXE-AI](https://github.com/seven7763/DaoXE-AI).
+
 -   **Use Azure Identity Authentication:** Check the box to authenticate with your Azure managed identity (Note that this will not trigger the authentication, it will use the existing one (e.g., "az login"))
 -   **Model Configuration:** This section allows you to customize advanced parameters for the model, such as:
     -   Max Output Tokens

--- a/docs/provider-config/openai-compatible.mdx
+++ b/docs/provider-config/openai-compatible.mdx
@@ -29,9 +29,9 @@ You'll find these settings in the Cline settings panel (click the ⚙️ icon):
 
 ### Example: DaoXE
 
-[DaoXE](https://daoxe.com) is a multi-model multi-protocol AI API gateway.
+[DaoXE](https://daoxe.com) is a multi-model multi-protocol AI API gateway. DaoXE is **not** a first-class entry in Cline’s API Provider dropdown. Configure it through **OpenAI Compatible** with a custom base URL.
 
-1. Select **OpenAI Compatible** as the API Provider.
+1. Select **OpenAI Compatible** as the API Provider (there is no separate `DaoXE` provider option).
 2. Set **Base URL** to `https://daoxe.com/v1`.
 3. Paste your DaoXE API key.
 4. Enter an exact model ID currently available to your DaoXE account.

--- a/docs/provider-config/other-30-plus-providers.mdx
+++ b/docs/provider-config/other-30-plus-providers.mdx
@@ -15,6 +15,7 @@ Use this page for providers that follow the same setup pattern.
   - [Cerebras](#cerebras)
   - [Dify.ai](#difyai)
   - [Doubao](#doubao)
+  - [DaoXE](#daoxe)
   - [Fireworks AI](#fireworks-ai)
   - [GCP Vertex AI](#gcp-vertex-ai)
   - [Groq](#groq)
@@ -111,6 +112,21 @@ Doubao is ByteDance’s model family, typically accessed through Volcengine serv
 1. Sign in to Volcengine and enable model access.
 2. Generate API credentials for Doubao endpoints.
 3. In Cline, select **Doubao** and paste credentials.
+
+### DaoXE
+DaoXE is a multi-model multi-protocol AI API gateway for developers.
+
+**Website:** [https://daoxe.com](https://daoxe.com)
+
+#### Basic Setup
+
+1. Create/sign in to your DaoXE account and generate an API key.
+2. In Cline, choose **OpenAI Compatible**.
+3. Set **Base URL** to `https://daoxe.com/v1`.
+4. Paste your API key and enter an exact currently available model ID.
+
+DaoXE is not available in mainland China. Public examples: [DaoXE-AI](https://github.com/seven7763/DaoXE-AI).
+
 
 ### Fireworks AI
 Fireworks AI provides hosted inference for open models and performance-focused deployment.

--- a/docs/provider-config/other-30-plus-providers.mdx
+++ b/docs/provider-config/other-30-plus-providers.mdx
@@ -15,7 +15,6 @@ Use this page for providers that follow the same setup pattern.
   - [Cerebras](#cerebras)
   - [Dify.ai](#difyai)
   - [Doubao](#doubao)
-  - [DaoXE](#daoxe)
   - [Fireworks AI](#fireworks-ai)
   - [GCP Vertex AI](#gcp-vertex-ai)
   - [Groq](#groq)
@@ -112,21 +111,6 @@ Doubao is ByteDance’s model family, typically accessed through Volcengine serv
 1. Sign in to Volcengine and enable model access.
 2. Generate API credentials for Doubao endpoints.
 3. In Cline, select **Doubao** and paste credentials.
-
-### DaoXE
-DaoXE is a multi-model multi-protocol AI API gateway for developers.
-
-**Website:** [https://daoxe.com](https://daoxe.com)
-
-#### Basic Setup
-
-1. Create/sign in to your DaoXE account and generate an API key.
-2. In Cline, choose **OpenAI Compatible**.
-3. Set **Base URL** to `https://daoxe.com/v1`.
-4. Paste your API key and enter an exact currently available model ID.
-
-DaoXE is not available in mainland China. Public examples: [DaoXE-AI](https://github.com/seven7763/DaoXE-AI).
-
 
 ### Fireworks AI
 Fireworks AI provides hosted inference for open models and performance-focused deployment.


### PR DESCRIPTION
## Summary
- Add a **DaoXE** example to the OpenAI Compatible provider guide.
- List DaoXE under **Other 30+ Providers** with Base URL `https://daoxe.com/v1`.
- Note multi-protocol scope and mainland-China unavailability.
- Link public examples: https://github.com/seven7763/DaoXE-AI

## Disclosure
I am affiliated with DaoXE.

## Test plan
- [ ] Docs render
- [ ] Links resolve