### PR TITLE
fix(core): preserve search_files absolute paths

### DIFF
--- a/sdk/packages/core/src/extensions/tools/definitions.test.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import type { ITelemetryService } from "@cline/shared";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -448,7 +449,7 @@ describe("default search_codebase tool", () => {
 
 		expect(execute).toHaveBeenCalledWith(
 			"needle",
-			"/workspace/src",
+			path.resolve("/workspace", "src"),
 			expect.objectContaining({ agentId: "agent-1" }),
 		);
 	});

--- a/sdk/packages/core/src/extensions/tools/definitions.test.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.test.ts
@@ -434,18 +434,15 @@ describe("default search_codebase tool", () => {
 		);
 	});
 
-	it("resolves relative search paths under cwd", async () => {
+	it("resolves relative paths from legacy search_files input under cwd", async () => {
 		const execute = vi.fn(async () => "ok");
 		const tool = createSearchTool(execute, { cwd: "/workspace" });
 
-		await tool.execute(
-			{ queries: ["needle"], path: "src" },
-			{
-				agentId: "agent-1",
-				conversationId: "conv-1",
-				iteration: 1,
-			},
-		);
+		await tool.execute({ regex: "needle", path: "src" } as never, {
+			agentId: "agent-1",
+			conversationId: "conv-1",
+			iteration: 1,
+		});
 
 		expect(execute).toHaveBeenCalledWith(
 			"needle",

--- a/sdk/packages/core/src/extensions/tools/definitions.test.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.test.ts
@@ -412,6 +412,46 @@ describe("default search_codebase tool", () => {
 			},
 		]);
 	});
+
+	it("preserves Windows absolute paths from legacy search_files input", async () => {
+		const execute = vi.fn(async () => "ok");
+		const tool = createSearchTool(execute, { cwd: "/workspace" });
+
+		await tool.execute(
+			{ regex: "needle", path: "C:\\ProgramData\\SDK" } as never,
+			{
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 1,
+			},
+		);
+
+		expect(execute).toHaveBeenCalledWith(
+			"needle",
+			"C:\\ProgramData\\SDK",
+			expect.objectContaining({ agentId: "agent-1" }),
+		);
+	});
+
+	it("resolves relative search paths under cwd", async () => {
+		const execute = vi.fn(async () => "ok");
+		const tool = createSearchTool(execute, { cwd: "/workspace" });
+
+		await tool.execute(
+			{ queries: ["needle"], path: "src" },
+			{
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 1,
+			},
+		);
+
+		expect(execute).toHaveBeenCalledWith(
+			"needle",
+			"/workspace/src",
+			expect.objectContaining({ agentId: "agent-1" }),
+		);
+	});
 });
 
 describe("default apply_patch tool", () => {

--- a/sdk/packages/core/src/extensions/tools/definitions.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.ts
@@ -344,14 +344,12 @@ export function createSearchTool(
 ): AgentTool<SearchCodebaseInput, ToolOperationResult[]> {
 	const timeoutMs = config.searchTimeoutMs ?? 30000;
 	const cwd = config.cwd ?? process.cwd();
-	const isWindowsAbsolutePath = (value: string): boolean =>
-		/^[A-Za-z]:[\\/]/.test(value) || /^\\\\[^\\/]+[\\/][^\\/]+/.test(value);
 	const resolveSearchRoot = (inputPath: string | undefined): string => {
 		const trimmed = inputPath?.trim();
 		if (!trimmed) {
 			return cwd;
 		}
-		if (path.isAbsolute(trimmed) || isWindowsAbsolutePath(trimmed)) {
+		if (path.isAbsolute(trimmed) || path.win32.isAbsolute(trimmed)) {
 			return trimmed;
 		}
 		return path.resolve(cwd, trimmed);

--- a/sdk/packages/core/src/extensions/tools/definitions.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.ts
@@ -4,6 +4,7 @@
  * Factory functions for creating the default tools.
  */
 
+import path from "node:path";
 import {
 	type AgentTool,
 	type AgentToolContext,
@@ -343,6 +344,18 @@ export function createSearchTool(
 ): AgentTool<SearchCodebaseInput, ToolOperationResult[]> {
 	const timeoutMs = config.searchTimeoutMs ?? 30000;
 	const cwd = config.cwd ?? process.cwd();
+	const isWindowsAbsolutePath = (value: string): boolean =>
+		/^[A-Za-z]:[\\/]/.test(value) || /^\\\\[^\\/]+[\\/][^\\/]+/.test(value);
+	const resolveSearchRoot = (inputPath: string | undefined): string => {
+		const trimmed = inputPath?.trim();
+		if (!trimmed) {
+			return cwd;
+		}
+		if (path.isAbsolute(trimmed) || isWindowsAbsolutePath(trimmed)) {
+			return trimmed;
+		}
+		return path.resolve(cwd, trimmed);
+	};
 
 	return createTool<SearchCodebaseInput, ToolOperationResult[]>({
 		name: "search_codebase",
@@ -358,19 +371,28 @@ export function createSearchTool(
 		execute: async (input, context) => {
 			// Validate input with Zod schema
 			const validate = validateWithZod(SearchCodebaseUnionInputSchema, input);
+			const inputPath =
+				typeof validate === "object" &&
+				!Array.isArray(validate) &&
+				"path" in validate
+					? validate.path
+					: undefined;
+			const searchRoot = resolveSearchRoot(inputPath);
 			const queries = Array.isArray(validate)
 				? validate
 				: typeof validate === "object"
-					? Array.isArray(validate.queries)
-						? validate.queries
-						: [validate.queries]
+					? "regex" in validate
+						? [validate.regex]
+						: Array.isArray(validate.queries)
+							? validate.queries
+							: [validate.queries]
 					: [validate];
 
 			return Promise.all(
 				queries.map(async (query): Promise<ToolOperationResult> => {
 					try {
 						const results = await withTimeout(
-							executor(query, cwd, context),
+							executor(query, searchRoot, context),
 							timeoutMs,
 							`Search timed out after ${timeoutMs}ms`,
 						);

--- a/sdk/packages/core/src/extensions/tools/schemas.ts
+++ b/sdk/packages/core/src/extensions/tools/schemas.ts
@@ -110,7 +110,6 @@ export const SearchCodebaseInputSchema = z.object({
 	queries: z
 		.array(z.string())
 		.describe("Array of regex search queries to execute"),
-	path: z.string().optional().describe("Optional directory path to search"),
 });
 
 const LegacySearchFilesInputSchema = z.object({
@@ -125,7 +124,7 @@ export const SearchCodebaseUnionInputSchema = z.union([
 	SearchCodebaseInputSchema,
 	z.array(z.string()),
 	z.string(),
-	z.object({ queries: z.string(), path: z.string().optional() }),
+	z.object({ queries: z.string() }),
 	LegacySearchFilesInputSchema,
 ]);
 

--- a/sdk/packages/core/src/extensions/tools/schemas.ts
+++ b/sdk/packages/core/src/extensions/tools/schemas.ts
@@ -110,6 +110,12 @@ export const SearchCodebaseInputSchema = z.object({
 	queries: z
 		.array(z.string())
 		.describe("Array of regex search queries to execute"),
+	path: z.string().optional().describe("Optional directory path to search"),
+});
+
+const LegacySearchFilesInputSchema = z.object({
+	regex: z.string(),
+	path: z.string().optional(),
 });
 
 /**
@@ -119,7 +125,8 @@ export const SearchCodebaseUnionInputSchema = z.union([
 	SearchCodebaseInputSchema,
 	z.array(z.string()),
 	z.string(),
-	z.object({ queries: z.string() }),
+	z.object({ queries: z.string(), path: z.string().optional() }),
+	LegacySearchFilesInputSchema,
 ]);
 
 const CommandInputSchema = z


### PR DESCRIPTION
## Summary

Legacy `search_files` inputs can include a `path` plus `regex`. The compatibility path for the SDK `search_codebase` tool was dropping that path and always searching from `cwd`. On Windows, drive-letter paths also need to be recognized as absolute before resolving against `cwd`.

## Changes

* Preserve optional `path` for `search_codebase` object inputs
* Support legacy `search_files` input shape `{ regex, path }`
* Treat Windows drive-letter and UNC paths as absolute search roots
* Keep relative search roots resolved under `cwd`
* Add focused coverage for Windows absolute paths and relative search paths

## Verification

* `bun run typecheck` from `sdk/packages/core`
* `bun biome check --no-errors-on-unmatched --files-ignore-unknown=true sdk/packages/core/src/extensions/tools/definitions.ts sdk/packages/core/src/extensions/tools/schemas.ts sdk/packages/core/src/extensions/tools/definitions.test.ts`

Note: focused Vitest fails before collecting tests in this local setup due an existing zod test-environment issue (`z.string` undefined), unrelated to this change.

Closes cline/cline#12099