### PR TITLE
feat(desktop-app): env-configurable sidecar bind host, trusted origins, and webview WS endpoint

### DIFF
--- a/apps/examples/desktop-app/sidecar/index.ts
+++ b/apps/examples/desktop-app/sidecar/index.ts
@@ -5,7 +5,7 @@ import {
 } from "./context";
 import { resolveWorkspaceRoot } from "./paths";
 import { startServer } from "./server";
-import { BunRuntime, SIDECAR_MODE, SIDECAR_PORT } from "./types";
+import { BunRuntime, SIDECAR_HOST, SIDECAR_MODE, SIDECAR_PORT } from "./types";
 
 const SHUTDOWN_TIMEOUT_MS = 5_000;
 
@@ -59,8 +59,10 @@ async function main() {
 
 	const { port } = startServer(ctx, SIDECAR_PORT, shutdown);
 
-	const endpoint = `http://127.0.0.1:${port}`;
-	const wsEndpoint = `ws://127.0.0.1:${port}/transport`;
+	// A wildcard bind isn't a dialable address; advertise loopback instead.
+	const dialHost = SIDECAR_HOST === "0.0.0.0" ? "127.0.0.1" : SIDECAR_HOST;
+	const endpoint = `http://${dialHost}:${port}`;
+	const wsEndpoint = `ws://${dialHost}:${port}/transport`;
 	process.stdout.write(
 		`${JSON.stringify({
 			type: "ready",

--- a/apps/examples/desktop-app/sidecar/server.ts
+++ b/apps/examples/desktop-app/sidecar/server.ts
@@ -4,6 +4,7 @@ import { sendEvent } from "./context";
 import { fetchMarketplaceCatalog } from "./marketplace";
 import {
 	BunRuntime,
+	SIDECAR_HOST,
 	SIDECAR_MODE,
 	SIDECAR_PORT,
 	type SidecarContext,
@@ -15,12 +16,20 @@ type SidecarServer = {
 	upgrade(req: Request): boolean;
 };
 
+// Comma-separated extra origins (e.g. a dev server on a nonstandard port when
+// the sidecar runs inside a container). Origin validation itself stays on.
+const EXTRA_TRUSTED_ORIGINS = (process.env.CLINE_SIDECAR_TRUSTED_ORIGINS ?? "")
+	.split(",")
+	.map((origin) => origin.trim())
+	.filter(Boolean);
+
 const TRUSTED_BROWSER_ORIGINS = new Set([
 	"tauri://localhost",
 	"http://tauri.localhost",
 	"https://tauri.localhost",
 	"http://localhost:3125",
 	"http://127.0.0.1:3125",
+	...EXTRA_TRUSTED_ORIGINS,
 ]);
 
 const JSON_HEADERS = {
@@ -115,7 +124,7 @@ export function startServer(
 	for (const candidate of candidates) {
 		try {
 			server = BunRuntime.serve({
-				hostname: "127.0.0.1",
+				hostname: SIDECAR_HOST,
 				port: candidate,
 				fetch: createFetchHandler(ctx, onShutdown),
 				websocket: createWebSocketHandler(ctx),

--- a/apps/examples/desktop-app/sidecar/types.ts
+++ b/apps/examples/desktop-app/sidecar/types.ts
@@ -115,4 +115,7 @@ export type BunRuntimeApi = {
 export const BunRuntime = (globalThis as { Bun?: BunRuntimeApi }).Bun;
 
 export const SIDECAR_PORT = Number(process.env.CLINE_SIDECAR_PORT) || 3126;
+// Loopback-only by default. Set CLINE_SIDECAR_HOST=0.0.0.0 to accept
+// connections from outside the local host (e.g. Docker port publishing).
+export const SIDECAR_HOST = process.env.CLINE_SIDECAR_HOST?.trim() || "127.0.0.1";
 export const SIDECAR_MODE = "sidecar";

--- a/apps/examples/desktop-app/sidecar/types.ts
+++ b/apps/examples/desktop-app/sidecar/types.ts
@@ -117,5 +117,6 @@ export const BunRuntime = (globalThis as { Bun?: BunRuntimeApi }).Bun;
 export const SIDECAR_PORT = Number(process.env.CLINE_SIDECAR_PORT) || 3126;
 // Loopback-only by default. Set CLINE_SIDECAR_HOST=0.0.0.0 to accept
 // connections from outside the local host (e.g. Docker port publishing).
-export const SIDECAR_HOST = process.env.CLINE_SIDECAR_HOST?.trim() || "127.0.0.1";
+export const SIDECAR_HOST =
+	process.env.CLINE_SIDECAR_HOST?.trim() || "127.0.0.1";
 export const SIDECAR_MODE = "sidecar";

--- a/apps/examples/desktop-app/webview/lib/desktop-client.ts
+++ b/apps/examples/desktop-app/webview/lib/desktop-client.ts
@@ -35,8 +35,9 @@ let resolvedEndpointCache: string | null = null;
  *    or an integration test harness.
  * 2. Tauri `get_desktop_backend_endpoint` command — used when running inside
  *    the full Tauri app shell.
- * 3. Fallback to `ws://127.0.0.1:3126/transport` — the sidecar's default port
- *    when running in plain web/dev mode (`bun run dev:sidecar` + `bun run dev:web`).
+ * 3. `NEXT_PUBLIC_SIDECAR_WS_ENDPOINT` (inlined at build time), then fallback
+ *    to `ws://127.0.0.1:3126/transport` — the sidecar's default port when
+ *    running in plain web/dev mode (`bun run dev:sidecar` + `bun run dev:web`).
  */
 export async function resolveDesktopBackendWsEndpoint(): Promise<string> {
 	if (resolvedEndpointCache) return resolvedEndpointCache;
@@ -64,8 +65,10 @@ export async function resolveDesktopBackendWsEndpoint(): Promise<string> {
 		throw new Error("Tauri returned an empty desktop backend endpoint");
 	}
 
-	// 3. Default sidecar port for local dev mode without the Tauri bridge.
-	resolvedEndpointCache = "ws://127.0.0.1:3126/transport";
+	// 3. Env override, then default sidecar port for local dev mode without
+	// the Tauri bridge.
+	const envEndpoint = process.env.NEXT_PUBLIC_SIDECAR_WS_ENDPOINT?.trim();
+	resolvedEndpointCache = envEndpoint || "ws://127.0.0.1:3126/transport";
 	return resolvedEndpointCache;
 }
 

--- a/apps/examples/desktop-app/webview/next-env.d.ts
+++ b/apps/examples/desktop-app/webview/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
### Related Issue

N/A — small dev-workflow enablement for the desktop-app example (no functional change with defaults).

### Description

**Problem:** the desktop app's plain web dev mode (`bun run dev:web` + `bun run dev:sidecar`) is unusable from inside a Docker container (or any remote dev box) with a browser on the host, because three things are hardcoded:

1. The Bun sidecar binds `hostname: "127.0.0.1"` in `Bun.serve` — Docker port publishing can't reach a loopback-only bind.
2. The sidecar's origin allowlist only contains the Tauri origins plus `http://localhost:3125` / `http://127.0.0.1:3125` — a dev UI served from any other port gets its WebSocket upgrade rejected (falls through to 404) and preflights 403'd.
3. The webview's non-Tauri fallback WS endpoint is hardcoded to `ws://127.0.0.1:3126/transport`. When the browser runs on the Docker *host*, it needs to dial whatever host port is published, not the container-internal default.

**Fix:** three env vars, all optional, all defaulting to today's behavior:

- `CLINE_SIDECAR_HOST` — sidecar bind hostname (default stays `127.0.0.1`; set `0.0.0.0` for container use). When bound to a wildcard, the printed `ready` endpoint advertises `127.0.0.1` since `0.0.0.0` isn't a dialable address.
- `CLINE_SIDECAR_TRUSTED_ORIGINS` — comma-separated origins appended to `TRUSTED_BROWSER_ORIGINS`. Deliberately additive: origin validation itself stays on, you just declare the specific dev origin you're serving from (e.g. `http://127.0.0.1:3493`).
- `NEXT_PUBLIC_SIDECAR_WS_ENDPOINT` — overrides the hardcoded fallback in `resolveDesktopBackendWsEndpoint()`. It sits at priority 3 (after `window.__SIDECAR_WS_ENDPOINT__` injection and the Tauri `get_desktop_backend_endpoint` command), so the packaged Tauri app never hits it.

Example container usage, with the UI on 3493 and sidecar on 3494 (both published to the host):

```bash
CLINE_SIDECAR_HOST=0.0.0.0 CLINE_SIDECAR_PORT=3494 \
CLINE_SIDECAR_TRUSTED_ORIGINS="http://127.0.0.1:3493,http://localhost:3493" \
bun run dev:sidecar

NEXT_PUBLIC_SIDECAR_WS_ENDPOINT="ws://127.0.0.1:3494/transport" \
bunx next dev webview -p 3493 -H 0.0.0.0 --turbo
```

**Also included:** `git rm --cached webview/next-env.d.ts`. It was added to the root `.gitignore` at some point but never untracked, and gitignore has no effect on tracked files — so it dirtied the working tree on every `next dev`/`next build`, since Next 16 rewrites its `routes.d.ts` import between `./.next/types/...` (build) and `./.next/dev/types/...` (dev). The file is regenerated by Next on every run, and the app's `typecheck` script (`tsconfig.dev.json`) excludes `webview/` entirely, so nothing needs it tracked. In `webview/tsconfig.json` it's only referenced via `include` globs, where a missing file is not an error.

### Test Procedure

Verified end-to-end from inside a Linux container with only ports 3493/3494 published to the macOS host:

- Sidecar with the env vars set binds `0.0.0.0:3494` (checked `/proc/net/tcp`), `/health` responds.
- Origin validation: `OPTIONS` with the declared origin → 204 + `Access-Control-Allow-Origin` echoed; `OPTIONS` with `https://attacker.example` → 403; WS upgrade with attacker origin → 404; WS upgrade with the declared origin → 101.
- Full transport round-trip through a WebSocket client sending the browser origin header: `host_ready` event received, `list_chat_sessions` command returned `ok: true` with real sessions.
- `NEXT_PUBLIC_SIDECAR_WS_ENDPOINT` confirmed inlined into the compiled client chunk served by `next dev`.
- UI loads in the host browser and connects to the sidecar with no CORS/origin errors.
- **Defaults regression:** sidecar started with *no* env vars binds `127.0.0.1:3126` and prints the identical `ready` line as before (`{"type":"ready","endpoint":"http://127.0.0.1:3126",...}`). The Tauri path in `desktop-client.ts` is untouched (env override only applies at the final fallback step).
- `bun run typecheck` (desktop-app) passes; `bunx vitest run sidecar/server.test.ts` (the existing origin-check tests) passes 4/4; `git diff --check` clean; biome clean on changed files.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — backend/dev-workflow change; terminal evidence summarized in Test Procedure.

### Additional Notes

The `next-env.d.ts` untracking could have been a separate PR, but it's a two-line index change that every desktop-app dev hits immediately when running this dev mode, so it rides along here.