### PR TITLE
fix(desktop-app): allow loopback origins for Next dev resources

### DIFF
--- a/apps/examples/desktop-app/webview/next.config.mjs
+++ b/apps/examples/desktop-app/webview/next.config.mjs
@@ -11,6 +11,10 @@ const nextConfig = {
 	turbopack: {
 		root: workspaceRoot,
 	},
+	// Dev-only: Next blocks HMR/font/dev-resource requests from origins that
+	// don't match the dev server's own hostname. Both loopback spellings are
+	// legitimate ways to reach a local or port-forwarded dev server.
+	allowedDevOrigins: ["localhost", "127.0.0.1"],
 	reactStrictMode: true,
 	typescript: {
 		ignoreBuildErrors: true,


### PR DESCRIPTION
### Related Issue

Follow-up to #12250 — the last missing piece for browsing the desktop-app web dev mode.

### Description

**Problem:** with #12250's env vars in place, the page at `http://127.0.0.1:3493` (or any `127.0.0.1`-addressed dev server) would hang while loading. The HTML and JS chunks served fine, but Next 16 blocks its *dev resources* — the HMR websocket (`/_next/webpack-hmr`) and dev font endpoints (`/__nextjs_font/...`) — from any request origin that doesn't match the hostname the dev server believes it's serving on. The dev log fills with:

```
⚠ Blocked cross-origin request to Next.js dev resource /_next/webpack-hmr from "127.0.0.1".
Cross-origin access to Next.js dev resources is blocked by default for safety.
```

This was sneaky to catch: plain `curl` checks of the page and compiled chunks all return 200, because the blocking only applies to those special `/_next` dev endpoints a real browser hits during hydration.

**Fix:** Next's own prescribed escape hatch — `allowedDevOrigins: ["localhost", "127.0.0.1"]` in `webview/next.config.mjs`. Both are loopback spellings of the same machine, so there's no meaningful widening of trust. The option is dev-server-only and ignored by production builds (`output: "export"`), so packaged Tauri behavior is untouched.

### Test Procedure

- Before: browser at `http://127.0.0.1:3493` hangs; dev log shows the blocked-cross-origin warnings above; a websocket upgrade request to `/_next/webpack-hmr` with a `127.0.0.1` host is rejected.
- After restarting the dev server with this config: the same HMR upgrade request returns 101, the page loads and hydrates in the browser, HMR works, and no blocked-origin warnings appear in the log.
- Default flow unaffected: `localhost:3125` browsing already worked (it matched the auto-trusted hostname) and still does.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — dev-server config change; before/after behavior described in Test Procedure.

### Additional Notes

Four-line config addition; biome clean.