### PR TITLE
feat(cli): manual API key escape hatch for Cline OAuth providers

### DIFF
--- a/apps/cli/src/tui/components/dialogs/provider-picker-helpers.ts
+++ b/apps/cli/src/tui/components/dialogs/provider-picker-helpers.ts
@@ -1,7 +1,49 @@
+import {
+	getProviderAuthStorageId,
+	type ProviderSettingsManager,
+	saveLocalProviderSettings,
+} from "@cline/core";
 import { CLI_PROMO_CODE } from "../../../utils/cline-pass-errors";
 
 const CLINE_PASS_SUBSCRIPTION_PATH = "/dashboard/subscription";
 const DEFAULT_APP_BASE_URL = "https://app.cline.bot";
+
+/**
+ * Persist a manually entered API key for an OAuth-capable provider — the
+ * escape hatch for when OAuth login isn't working. Any stored OAuth tokens
+ * are cleared: the auth handler prefers auth.accessToken over apiKey, so a
+ * stale token would otherwise keep winning over the manual key.
+ *
+ * The key is written both to the provider's auth storage entry (cline-pass
+ * stores credentials under "cline") and to the provider's own entry: settings
+ * resolution lets a direct entry shadow the storage entry, and provider
+ * switching copies merged settings (including auth) into direct entries, so
+ * both must be updated for the manual key to reliably take effect.
+ */
+export function saveManualProviderApiKey(
+	manager: ProviderSettingsManager,
+	providerId: string,
+	apiKey: string,
+): void {
+	// Empty strings delete these keys from the stored auth object.
+	const clearedAuth = { accessToken: "", refreshToken: "", apiKey: "" };
+	const storageProviderId = getProviderAuthStorageId(providerId) ?? providerId;
+	saveLocalProviderSettings(manager, {
+		providerId: storageProviderId,
+		apiKey,
+		auth: clearedAuth,
+	});
+	if (
+		providerId !== storageProviderId &&
+		manager.read().providers[providerId]
+	) {
+		saveLocalProviderSettings(manager, {
+			providerId,
+			apiKey,
+			auth: clearedAuth,
+		});
+	}
+}
 
 export function buildClinePassSubscriptionPageUrl(
 	appBaseUrl: string | undefined,

--- a/apps/cli/src/tui/components/dialogs/provider-picker.test.ts
+++ b/apps/cli/src/tui/components/dialogs/provider-picker.test.ts
@@ -1,5 +1,16 @@
-import { describe, expect, it } from "vitest";
-import { buildClinePassSubscriptionPageUrl } from "./provider-picker-helpers";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ProviderSettingsManager } from "@cline/core";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	getPersistedProviderApiKey,
+	isProviderConfigured,
+} from "../../../utils/provider-auth";
+import {
+	buildClinePassSubscriptionPageUrl,
+	saveManualProviderApiKey,
+} from "./provider-picker-helpers";
 
 describe("buildClinePassSubscriptionPageUrl", () => {
 	it("opens the personal subscription page on production by default", () => {
@@ -13,6 +24,102 @@ describe("buildClinePassSubscriptionPageUrl", () => {
 			buildClinePassSubscriptionPageUrl("https://staging-app.cline.bot"),
 		).toBe(
 			"https://staging-app.cline.bot/dashboard/subscription?personal=true&code=CLI-8OFF",
+		);
+	});
+});
+
+describe("saveManualProviderApiKey", () => {
+	const tempDirs: string[] = [];
+
+	afterEach(() => {
+		for (const dir of tempDirs.splice(0)) {
+			rmSync(dir, { force: true, recursive: true });
+		}
+	});
+
+	function createManager(): ProviderSettingsManager {
+		const dir = mkdtempSync(join(tmpdir(), "cline-cli-provider-picker-"));
+		tempDirs.push(dir);
+		return new ProviderSettingsManager({
+			filePath: join(dir, "providers.json"),
+		});
+	}
+
+	it("clears stored OAuth tokens so the manual key takes effect", () => {
+		const manager = createManager();
+		manager.saveProviderSettings({
+			provider: "cline",
+			auth: {
+				accessToken: "stale-access-token",
+				refreshToken: "stale-refresh-token",
+				accountId: "acct_123",
+			},
+		});
+
+		saveManualProviderApiKey(manager, "cline", "manual-api-key");
+
+		const settings = manager.getProviderSettings("cline");
+		expect(settings?.apiKey).toBe("manual-api-key");
+		expect(settings?.auth?.accessToken).toBeUndefined();
+		expect(settings?.auth?.refreshToken).toBeUndefined();
+		expect(settings?.auth?.accountId).toBe("acct_123");
+		expect(getPersistedProviderApiKey("cline", settings)).toBe(
+			"manual-api-key",
+		);
+		expect(isProviderConfigured("cline", settings)).toBe(true);
+	});
+
+	it("saves cline-pass keys to the shared cline auth storage entry", () => {
+		const manager = createManager();
+		manager.saveProviderSettings({
+			provider: "cline",
+			auth: {
+				accessToken: "stale-access-token",
+				refreshToken: "stale-refresh-token",
+			},
+		});
+
+		saveManualProviderApiKey(manager, "cline-pass", "manual-api-key");
+
+		// cline-pass inherits auth storage from the "cline" entry, so the key
+		// must land there and the stale tokens must be gone for both providers.
+		const clineSettings = manager.getProviderSettings("cline");
+		expect(clineSettings?.apiKey).toBe("manual-api-key");
+		expect(clineSettings?.auth?.accessToken).toBeUndefined();
+
+		const clinePassSettings = manager.getProviderSettings("cline-pass");
+		expect(getPersistedProviderApiKey("cline-pass", clinePassSettings)).toBe(
+			"manual-api-key",
+		);
+		expect(isProviderConfigured("cline-pass", clinePassSettings)).toBe(true);
+	});
+
+	it("clears stale credentials copied into a direct cline-pass entry", () => {
+		const manager = createManager();
+		manager.saveProviderSettings({
+			provider: "cline",
+			auth: {
+				accessToken: "stale-access-token",
+				refreshToken: "stale-refresh-token",
+			},
+		});
+		// Provider switching copies the merged settings (including auth) into
+		// a direct cline-pass entry, which shadows the shared "cline" entry.
+		manager.saveProviderSettings({
+			provider: "cline-pass",
+			apiKey: "stale-copied-key",
+			auth: {
+				accessToken: "stale-access-token",
+				refreshToken: "stale-refresh-token",
+			},
+		});
+
+		saveManualProviderApiKey(manager, "cline-pass", "manual-api-key");
+
+		const clinePassSettings = manager.getProviderSettings("cline-pass");
+		expect(clinePassSettings?.auth?.accessToken).toBeUndefined();
+		expect(getPersistedProviderApiKey("cline-pass", clinePassSettings)).toBe(
+			"manual-api-key",
 		);
 	});
 });

--- a/apps/cli/src/tui/components/dialogs/provider-picker.tsx
+++ b/apps/cli/src/tui/components/dialogs/provider-picker.tsx
@@ -255,7 +255,6 @@ export function ProviderPickerContent(
 export type ExistingProviderAction =
 	| "use_existing"
 	| "reconfigure"
-	| "use_api_key"
 	| "open_subscription_page"
 	| "open_usage_billing";
 

--- a/apps/cli/src/tui/components/dialogs/provider-picker.tsx
+++ b/apps/cli/src/tui/components/dialogs/provider-picker.tsx
@@ -37,7 +37,10 @@ import {
 	getSearchableListRowsWindow,
 	type SearchableItem,
 } from "../searchable-list";
-import { buildClinePassSubscriptionPageUrl } from "./provider-picker-helpers";
+import {
+	buildClinePassSubscriptionPageUrl,
+	saveManualProviderApiKey,
+} from "./provider-picker-helpers";
 
 interface ProviderItem {
 	id: string;
@@ -252,6 +255,7 @@ export function ProviderPickerContent(
 export type ExistingProviderAction =
 	| "use_existing"
 	| "reconfigure"
+	| "use_api_key"
 	| "open_subscription_page"
 	| "open_usage_billing";
 
@@ -724,13 +728,27 @@ export function CodexCliStatusContent(
 	);
 }
 
+/**
+ * Resolves `true` on successful login, `"use_api_key"` when the user opts
+ * into manual API key entry (only offered with `allowApiKeyFallback`).
+ */
+export type OAuthLoginResult = boolean | "use_api_key";
+
 export function OAuthLoginContent(
-	props: ChoiceContext<boolean> & {
+	props: ChoiceContext<OAuthLoginResult> & {
 		providerId: string;
 		providerName: string;
+		allowApiKeyFallback?: boolean;
 	},
 ) {
-	const { resolve, dismiss, dialogId, providerId, providerName } = props;
+	const {
+		resolve,
+		dismiss,
+		dialogId,
+		providerId,
+		providerName,
+		allowApiKeyFallback,
+	} = props;
 	const [mode, setMode] = useState<"browser" | "device">(
 		providerId === "cline" ? "device" : "browser",
 	);
@@ -863,8 +881,17 @@ export function OAuthLoginContent(
 		if (key.name === "escape") {
 			cancelAuthAttempt();
 			dismiss();
+			return;
+		}
+		if (key.name === "k" && allowApiKeyFallback) {
+			cancelAuthAttempt();
+			resolve("use_api_key");
 		}
 	}, dialogId);
+
+	const escapeHint = allowApiKeyFallback
+		? "K to enter an API key instead, Esc to cancel"
+		: "Esc to cancel";
 
 	if (mode === "device") {
 		return (
@@ -893,7 +920,7 @@ export function OAuthLoginContent(
 				{deviceError && <text fg="red">{deviceError}</text>}
 
 				<text fg="gray">
-					<em>Esc to cancel</em>
+					<em>{escapeHint}</em>
 				</text>
 			</box>
 		);
@@ -916,7 +943,82 @@ export function OAuthLoginContent(
 			{error && <text fg="red">{error}</text>}
 
 			<text fg="gray">
-				<em>Esc to cancel</em>
+				<em>{escapeHint}</em>
+			</text>
+		</box>
+	);
+}
+
+/**
+ * Manual API key entry for OAuth-capable providers — the escape hatch for
+ * when OAuth login isn't working. Saving clears any stored OAuth tokens so
+ * the manual key takes effect (see saveManualProviderApiKey).
+ */
+export function OAuthApiKeyInputContent(
+	props: ChoiceContext<boolean> & {
+		providerId: string;
+		providerName: string;
+		providerSettingsManager: ProviderSettingsManager;
+	},
+) {
+	const {
+		resolve,
+		dismiss,
+		dialogId,
+		providerId,
+		providerName,
+		providerSettingsManager,
+	} = props;
+	const [value, setValue] = useState("");
+
+	const submit = () => {
+		const apiKey = value.trim();
+		if (!apiKey) return;
+		saveManualProviderApiKey(providerSettingsManager, providerId, apiKey);
+		resolve(true);
+	};
+
+	useDialogKeyboard((key) => {
+		if (key.name === "escape") {
+			dismiss();
+			return;
+		}
+		if (key.name === "return") {
+			submit();
+		}
+	}, dialogId);
+
+	return (
+		<box flexDirection="column" paddingX={1} gap={1}>
+			<text fg={palette.act}>
+				<strong>{providerName}</strong>
+			</text>
+
+			<text fg="gray">
+				Use an API key from your Cline dashboard instead of OAuth login. This
+				replaces any saved login tokens.
+			</text>
+
+			<box flexDirection="column">
+				<text fg="gray">API key</text>
+				<box
+					border
+					borderStyle="rounded"
+					borderColor={palette.act}
+					paddingX={1}
+				>
+					<input
+						value={value}
+						onInput={setValue}
+						placeholder="Paste your API key"
+						flexGrow={1}
+						focused
+					/>
+				</box>
+			</box>
+
+			<text fg="gray">
+				<em>Enter to save, Esc to go back</em>
 			</text>
 		</box>
 	);

--- a/apps/cli/src/tui/hooks/use-account-dialog.tsx
+++ b/apps/cli/src/tui/hooks/use-account-dialog.tsx
@@ -7,7 +7,10 @@ import {
 	type AccountDialogAction,
 	AccountDialogContent,
 } from "../components/dialogs/account-dialog";
-import { OAuthLoginContent } from "../components/dialogs/provider-picker";
+import {
+	OAuthLoginContent,
+	type OAuthLoginResult,
+} from "../components/dialogs/provider-picker";
 import type { OpenModelSelectorOptions } from "./use-model-selector";
 
 export function useAccountDialog(opts: {
@@ -60,14 +63,14 @@ export function useAccountDialog(opts: {
 			return;
 		}
 		if (action === "login") {
-			const saved = await dialog.choice<boolean>({
+			const saved = await dialog.choice<OAuthLoginResult>({
 				style: { maxHeight: termHeight - 2 },
 				closeOnEscape: false,
-				content: (ctx: ChoiceContext<boolean>) => (
+				content: (ctx: ChoiceContext<OAuthLoginResult>) => (
 					<OAuthLoginContent {...ctx} providerId="cline" providerName="Cline" />
 				),
 			});
-			if (saved) {
+			if (saved === true) {
 				await onAccountChange?.();
 				await openAccountDialog();
 				return;

--- a/apps/cli/src/tui/hooks/use-model-selector.tsx
+++ b/apps/cli/src/tui/hooks/use-model-selector.tsx
@@ -6,6 +6,7 @@ import {
 	refreshProviderModelsFromSource,
 	resolveProviderConfig,
 } from "@cline/core";
+import { isClineProvider } from "@cline/shared";
 import type { ChoiceContext } from "@opentui-ui/dialog";
 import type { DialogActions } from "@opentui-ui/dialog/react";
 import { useCallback } from "react";
@@ -21,7 +22,9 @@ import {
 	ClinePassSubscriptionContent,
 	CodexCliStatusContent,
 	type ExistingProviderOption,
+	OAuthApiKeyInputContent,
 	OAuthLoginContent,
+	type OAuthLoginResult,
 	ProviderConfigInputContent,
 	ProviderPickerContent,
 	UseExistingOrReconfigureContent,
@@ -131,7 +134,25 @@ async function runProviderChange(
 	);
 	const existingSettings = manager.getProviderSettings(newProviderId);
 
+	// Manual API key entry is the escape hatch for when OAuth login isn't
+	// working; only the Cline providers accept a dashboard API key.
+	const supportsManualApiKey = isClineProvider(newProviderId);
+	const openManualApiKeyDialog = async (): Promise<boolean | undefined> =>
+		await dialog.choice<boolean>({
+			style: { maxHeight: termHeight - 2 },
+			closeOnEscape: false,
+			content: (ctx: ChoiceContext<boolean>) => (
+				<OAuthApiKeyInputContent
+					{...ctx}
+					providerId={newProviderId}
+					providerName={displayName}
+					providerSettingsManager={manager}
+				/>
+			),
+		});
+
 	let needsAuth = true;
+	let useManualApiKey = false;
 	if (isProviderConfigured(newProviderId, existingSettings)) {
 		let option: ExistingProviderOption | undefined;
 		const extraOptions = providerToExistingProviderOptions({
@@ -140,6 +161,12 @@ async function runProviderChange(
 			dialog,
 			termHeight,
 		});
+		if (supportsManualApiKey) {
+			extraOptions.push({
+				value: "use_api_key",
+				label: "Enter API key manually",
+			});
+		}
 		while (true) {
 			option = await dialog.choice<ExistingProviderOption>({
 				style: { maxHeight: termHeight - 2 },
@@ -160,22 +187,30 @@ async function runProviderChange(
 			break;
 		}
 		needsAuth = option.value === "reconfigure";
+		useManualApiKey = option.value === "use_api_key";
 	}
 
-	if (needsAuth) {
+	if (needsAuth || useManualApiKey) {
 		let saved: boolean | undefined;
-		if (isOAuthProvider(newProviderId)) {
-			saved = await dialog.choice<boolean>({
+		if (useManualApiKey) {
+			saved = await openManualApiKeyDialog();
+		} else if (isOAuthProvider(newProviderId)) {
+			const loginResult = await dialog.choice<OAuthLoginResult>({
 				style: { maxHeight: termHeight - 2 },
 				closeOnEscape: false,
-				content: (ctx: ChoiceContext<boolean>) => (
+				content: (ctx: ChoiceContext<OAuthLoginResult>) => (
 					<OAuthLoginContent
 						{...ctx}
 						providerId={newProviderId}
 						providerName={displayName}
+						allowApiKeyFallback={supportsManualApiKey}
 					/>
 				),
 			});
+			saved =
+				loginResult === "use_api_key"
+					? await openManualApiKeyDialog()
+					: loginResult;
 		} else if (isOpenAICodexCliProvider(newProviderId)) {
 			saved = await dialog.choice<boolean>({
 				style: { maxHeight: termHeight - 2 },

--- a/apps/cli/src/tui/hooks/use-model-selector.tsx
+++ b/apps/cli/src/tui/hooks/use-model-selector.tsx
@@ -152,7 +152,6 @@ async function runProviderChange(
 		});
 
 	let needsAuth = true;
-	let useManualApiKey = false;
 	if (isProviderConfigured(newProviderId, existingSettings)) {
 		let option: ExistingProviderOption | undefined;
 		const extraOptions = providerToExistingProviderOptions({
@@ -161,12 +160,6 @@ async function runProviderChange(
 			dialog,
 			termHeight,
 		});
-		if (supportsManualApiKey) {
-			extraOptions.push({
-				value: "use_api_key",
-				label: "Enter API key manually",
-			});
-		}
 		while (true) {
 			option = await dialog.choice<ExistingProviderOption>({
 				style: { maxHeight: termHeight - 2 },
@@ -187,14 +180,11 @@ async function runProviderChange(
 			break;
 		}
 		needsAuth = option.value === "reconfigure";
-		useManualApiKey = option.value === "use_api_key";
 	}
 
-	if (needsAuth || useManualApiKey) {
+	if (needsAuth) {
 		let saved: boolean | undefined;
-		if (useManualApiKey) {
-			saved = await openManualApiKeyDialog();
-		} else if (isOAuthProvider(newProviderId)) {
+		if (isOAuthProvider(newProviderId)) {
 			const loginResult = await dialog.choice<OAuthLoginResult>({
 				style: { maxHeight: termHeight - 2 },
 				closeOnEscape: false,

--- a/apps/cli/src/utils/provider-auth.ts
+++ b/apps/cli/src/utils/provider-auth.ts
@@ -42,11 +42,12 @@ export function getPersistedProviderApiKey(
  * or endpoint config for the provider. Used by the picker to decide whether
  * to offer "Use existing configuration?" before opening the configure dialog.
  *
- * Treats OAuth providers as configured when an access token is present; for
- * everything else, any persisted API key, base URL, or model id counts. We
- * don't enforce required fields here — the runtime no longer pre-flights
- * credentials, so a missing key only matters when the API call actually
- * runs and the provider's own auth error is surfaced.
+ * Treats OAuth providers as configured when an access token or a manually
+ * saved API key is present (the /settings escape hatch for when OAuth isn't
+ * working); for everything else, any persisted API key, base URL, or model id
+ * counts. We don't enforce required fields here — the runtime no longer
+ * pre-flights credentials, so a missing key only matters when the API call
+ * actually runs and the provider's own auth error is surfaced.
  */
 export function isProviderConfigured(
 	providerId: string,
@@ -54,7 +55,8 @@ export function isProviderConfigured(
 ): boolean {
 	if (!settings) return false;
 	if (isOAuthProvider(providerId)) {
-		return Boolean(settings.auth?.accessToken?.trim());
+		// getPersistedProviderApiKey covers both auth.accessToken and apiKey.
+		return Boolean(getPersistedProviderApiKey(providerId, settings));
 	}
 	if (getPersistedProviderApiKey(providerId, settings)) return true;
 	if (settings.baseUrl?.trim()) return true;


### PR DESCRIPTION
### Related Issue

Internal request — escape hatch for users where Cline OAuth login isn't working.

### Description

Adds a way to configure the `cline` / `cline-pass` providers in the CLI TUI with a dashboard API key instead of OAuth. Every path outside the TUI already accepted a manual Cline API key (`-k/--key` root flag, `cline auth --provider cline --apikey ... --modelid ...` quick setup, and the `CLINE_API_KEY` env var) — the interactive `/settings > provider` flow was the only place that forced OAuth with no alternative. When device-code auth is broken for someone (corporate networks, browser issues, WorkOS hiccups), the TUI was a dead end.
<img width="501" height="253" alt="image" src="https://github.com/user-attachments/assets/041d806c-fa3b-43d8-8eb5-774c5d73f30c" />


**What's added:**

- **"Enter API key manually"** option in the "already configured" dialog (`UseExistingOrReconfigureContent`), shown only for the Cline providers (`isClineProvider`), since they're the ones that accept a dashboard API key.
- **`K` keybinding in the OAuth login dialog** (`OAuthLoginContent`, behind a new `allowApiKeyFallback` prop) that cancels the in-flight auth attempt and switches to key entry. This matters because the "already configured" dialog never appears for a fresh install — if OAuth is broken and you have no saved config, the login dialog itself has to offer the way out. The dialog's result type widened to `OAuthLoginResult = boolean | "use_api_key"`; the `/account` login call site was updated to the new type but does not enable the fallback, so its behavior is unchanged.
- **`OAuthApiKeyInputContent`** — a minimal paste-and-Enter key input dialog. After saving, the flow continues into model loading exactly like a successful OAuth login.

### Debugging journey / gotchas

Two non-obvious problems had to be solved for the saved key to actually take effect. Both are encoded in `saveManualProviderApiKey` (provider-picker-helpers.ts) with unit tests:

1. **Stale OAuth tokens silently win over manual keys.** The cline auth handler's `getApiKey` prefers `auth.accessToken` over `settings.apiKey` — so for the common escape-hatch case (user has a *broken* saved token), just writing `apiKey` would do nothing and the CLI would keep using the dead token. Saving now clears `auth.accessToken` / `auth.refreshToken` / `auth.apiKey` (via `saveLocalProviderSettings`'s empty-string-deletes-key semantics). `auth.accountId` is preserved for telemetry identity.

2. **cline-pass has *two* places stale credentials can hide.** cline-pass shares credential storage with `cline` (`getProviderAuthStorageId("cline-pass") === "cline"`), so the key is written to the shared entry. But `runProviderChange`'s post-auth save also copies the *merged* settings — including `auth` and `apiKey` — into a direct `cline-pass` entry, and settings resolution lets that direct entry shadow the shared one. Clearing only the shared entry left the stale copy winning; the helper now clears both (the direct entry only if it already exists, to avoid materializing redundant entries).

One supporting change: `isProviderConfigured` (apps/cli/src/utils/provider-auth.ts) previously counted only `auth.accessToken` for OAuth providers. Without changing it, an escape-hatch user would be treated as unconfigured on every subsequent provider switch and dropped straight back into the broken OAuth flow. It now uses `getPersistedProviderApiKey`, which covers both the access token and a persisted manual key.

### Test Procedure

- New unit tests in `provider-picker.test.ts` for `saveManualProviderApiKey` against a real temp-dir `ProviderSettingsManager`: token clearing on the shared `cline` entry, cline-pass writing to shared storage, and the direct-entry shadowing case (stale copied `auth` + `apiKey` on a direct `cline-pass` entry must be cleared / overridden). Each also asserts `getPersistedProviderApiKey` resolves the manual key and `isProviderConfigured` stays true.
- `bun run typecheck` and `biome check` clean on all touched files.
- Full `apps/cli` unit suite: 833 passed; the one failure (`distribution-package.test.ts` npm-pack guard) fails identically on a clean checkout in this sandbox and is unrelated.

What could break and why it doesn't:
- **Normal OAuth flows**: untouched unless the user explicitly picks the manual-key option or presses `K`; `allowApiKeyFallback` defaults off, and the `/account` dialog doesn't enable it.
- **`isProviderConfigured` widening**: for token-holding users the result is identical (the handler returns the access token first); it only additionally returns true for manual-key users, which is the point.
- **Users who later want OAuth back**: "Configure again" still runs the OAuth flow, and a successful login rewrites `auth` tokens, which then take precedence again by design.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

TUI dialog flow (text UI): the OAuth login dialog hint now reads `K to enter an API key instead, Esc to cancel`; the already-configured dialog gains an `Enter API key manually` row; the key entry dialog is a single bordered input with `Enter to save, Esc to go back`.

### Additional Notes

Follow-up candidates, deliberately out of scope: offering the same fallback in the `/account` login dialog and in the first-run onboarding TUI (`cline auth` interactive), which routes Cline providers straight to device-code auth the same way.
