### PR TITLE
fix(sdk): don't log users out when token refresh fails due to network/server errors

### DIFF
--- a/sdk/packages/core/src/auth/cline.test.ts
+++ b/sdk/packages/core/src/auth/cline.test.ts
@@ -122,6 +122,31 @@ describe("auth/cline getValidClineCredentials", () => {
 		expect(result).toBe(current);
 		nowSpy.mockRestore();
 	});
+
+	it("throws on transient refresh error when the token is already expired", async () => {
+		// A network blip landing after expiry is NOT an invalid grant; returning
+		// null here is what made clients wipe stored credentials over an outage.
+		const nowSpy = vi.spyOn(Date, "now").mockReturnValue(100_000);
+		const current = createCredentials({ expires: 90_000 });
+		globalThis.fetch = vi.fn(
+			async () =>
+				new Response(
+					JSON.stringify({
+						error: "server_error",
+						error_description: "temporary issue",
+					}),
+					{
+						status: 500,
+						headers: { "Content-Type": "application/json" },
+					},
+				),
+		) as unknown as typeof fetch;
+
+		await expect(
+			getValidClineCredentials(current, PROVIDER_OPTIONS),
+		).rejects.toThrow("Token refresh failed: 500");
+		nowSpy.mockRestore();
+	});
 });
 
 describe("auth/cline loginClineOAuth", () => {

--- a/sdk/packages/core/src/auth/cline.ts
+++ b/sdk/packages/core/src/auth/cline.ts
@@ -2,6 +2,7 @@ import {
 	getClineEnvironmentConfig,
 	type ITelemetryService,
 } from "@cline/shared";
+import { hashSecret, sdkDebug } from "../logging/early-logger";
 import {
 	captureAuthFailed,
 	captureAuthLoggedOut,
@@ -11,7 +12,6 @@ import {
 } from "../services/telemetry/core-events";
 import { startLocalOAuthServer } from "./server";
 import type { OAuthCredentials, OAuthLoginCallbacks } from "./types";
-import { hashSecret, sdkDebug } from "../logging/early-logger";
 import {
 	isCredentialLikelyExpired,
 	parseAuthorizationInput,
@@ -622,30 +622,34 @@ export async function refreshClineToken(
 	current: ClineOAuthCredentials,
 	options: ClineOAuthProviderOptions,
 ): Promise<ClineOAuthCredentials> {
-	const refreshUrl = resolveUrl(options.apiBaseUrl, DEFAULT_AUTH_ENDPOINTS.refresh);
-	sdkDebug(`cline.refresh.request url=${refreshUrl} refreshTokenHash=${hashSecret(current.refresh)}`);
-	const response = await fetch(
-		refreshUrl,
-		{
-			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-				...(await resolveHeaders(options.headers)),
-			},
-			body: JSON.stringify({
-				refreshToken: current.refresh,
-				grantType: "refresh_token",
-			}),
-			signal: AbortSignal.timeout(
-				options.requestTimeoutMs ?? DEFAULT_HTTP_TIMEOUT_MS,
-			),
-		},
+	const refreshUrl = resolveUrl(
+		options.apiBaseUrl,
+		DEFAULT_AUTH_ENDPOINTS.refresh,
 	);
+	sdkDebug(
+		`cline.refresh.request url=${refreshUrl} refreshTokenHash=${hashSecret(current.refresh)}`,
+	);
+	const response = await fetch(refreshUrl, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			...(await resolveHeaders(options.headers)),
+		},
+		body: JSON.stringify({
+			refreshToken: current.refresh,
+			grantType: "refresh_token",
+		}),
+		signal: AbortSignal.timeout(
+			options.requestTimeoutMs ?? DEFAULT_HTTP_TIMEOUT_MS,
+		),
+	});
 
 	if (!response.ok) {
 		const text = await response.text().catch(() => "");
 		const details = parseOAuthError(text);
-		sdkDebug(`cline.refresh.error status=${response.status} errorCode=${details.code ?? "none"} message=${details.message ?? "none"}`);
+		sdkDebug(
+			`cline.refresh.error status=${response.status} errorCode=${details.code ?? "none"} message=${details.message ?? "none"}`,
+		);
 		throw new ClineOAuthTokenError(
 			`Token refresh failed: ${response.status}${details.message ? ` - ${details.message}` : ""}`,
 			{ status: response.status, errorCode: details.code },
@@ -660,10 +664,20 @@ export async function refreshClineToken(
 		provider,
 		current,
 	);
-	sdkDebug(`cline.refresh.success newAccessTokenHash=${hashSecret(result.access)} newRefreshTokenHash=${hashSecret(result.refresh)} expires=${result.expires}`);
+	sdkDebug(
+		`cline.refresh.success newAccessTokenHash=${hashSecret(result.access)} newRefreshTokenHash=${hashSecret(result.refresh)} expires=${result.expires}`,
+	);
 	return result;
 }
 
+/**
+ * Resolve valid Cline credentials, refreshing when needed.
+ *
+ * Contract: returns refreshed/current credentials when usable; returns `null`
+ * ONLY when the refresh token was rejected (invalid grant — re-auth required);
+ * THROWS on transient failures (network, timeout, 5xx) so callers can leave
+ * stored credentials untouched and retry later.
+ */
 export async function getValidClineCredentials(
 	currentCredentials: ClineOAuthCredentials | null,
 	providerOptions: ClineOAuthProviderOptions,
@@ -683,17 +697,23 @@ export async function getValidClineCredentials(
 		!forceRefresh &&
 		!isCredentialLikelyExpired(currentCredentials, refreshBufferMs)
 	) {
-		sdkDebug(`cline.getCredentials outcome=still_valid forceRefresh=${forceRefresh}`);
+		sdkDebug(
+			`cline.getCredentials outcome=still_valid forceRefresh=${forceRefresh}`,
+		);
 		return currentCredentials;
 	}
 
-	sdkDebug(`cline.getCredentials outcome=needs_refresh forceRefresh=${forceRefresh} accessTokenHash=${hashSecret(currentCredentials.access)}`);
+	sdkDebug(
+		`cline.getCredentials outcome=needs_refresh forceRefresh=${forceRefresh} accessTokenHash=${hashSecret(currentCredentials.access)}`,
+	);
 
 	try {
 		return await refreshClineToken(currentCredentials, providerOptions);
 	} catch (error) {
 		if (error instanceof ClineOAuthTokenError && error.isLikelyInvalidGrant()) {
-			sdkDebug(`cline.getCredentials outcome=invalid_grant status=${error.status} errorCode=${error.errorCode ?? "none"}`);
+			sdkDebug(
+				`cline.getCredentials outcome=invalid_grant status=${error.status} errorCode=${error.errorCode ?? "none"}`,
+			);
 			captureAuthLoggedOut(
 				providerOptions.telemetry,
 				providerOptions.provider ?? "cline",
@@ -703,10 +723,19 @@ export async function getValidClineCredentials(
 		}
 		if (currentCredentials.expires - Date.now() > retryableTokenGraceMs) {
 			// Keep current token on transient refresh failures while still valid.
-			sdkDebug(`cline.getCredentials outcome=transient_failure_kept_current error=${error instanceof Error ? error.message : String(error)}`);
+			sdkDebug(
+				`cline.getCredentials outcome=transient_failure_kept_current error=${error instanceof Error ? error.message : String(error)}`,
+			);
 			return currentCredentials;
 		}
-		sdkDebug(`cline.getCredentials outcome=transient_failure_expired error=${error instanceof Error ? error.message : String(error)}`);
-		return null;
+		// Transient failure with an already-expired token: rethrow instead of
+		// returning null. A null from this function means the refresh token was
+		// REJECTED (re-auth required); a network blip that happens to land after
+		// expiry must not be mistaken for that — callers were wiping stored
+		// credentials over it, logging out every Cline process on the machine.
+		sdkDebug(
+			`cline.getCredentials outcome=transient_failure_rethrown error=${error instanceof Error ? error.message : String(error)}`,
+		);
+		throw error;
 	}
 }

--- a/sdk/packages/core/src/services/storage/provider-settings-manager.test.ts
+++ b/sdk/packages/core/src/services/storage/provider-settings-manager.test.ts
@@ -1,4 +1,11 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import * as LlmsModels from "@cline/llms";
@@ -49,6 +56,50 @@ describe("ProviderSettingsManager", () => {
 			reloaded.getProviderConfig("anthropic", { includeKnownModels: false }),
 		).not.toHaveProperty("knownModels");
 		expect(reloaded.read().providers.anthropic?.tokenSource).toBe("manual");
+	});
+
+	it("writes atomically, leaving no temp file behind", () => {
+		const tempDir = mkdtempSync(
+			path.join(os.tmpdir(), "core-provider-settings-"),
+		);
+		tempDirs.push(tempDir);
+		const filePath = path.join(tempDir, "provider-settings.json");
+		const manager = new ProviderSettingsManager({ filePath });
+
+		manager.saveProviderSettings(
+			{ provider: "anthropic", apiKey: "test-key" },
+			{ setLastUsed: true },
+		);
+
+		const siblings = readdirSync(tempDir);
+		expect(siblings).toEqual(["provider-settings.json"]);
+	});
+
+	it("preserves the previous file when the staged write cannot be renamed", () => {
+		const tempDir = mkdtempSync(
+			path.join(os.tmpdir(), "core-provider-settings-"),
+		);
+		tempDirs.push(tempDir);
+		const filePath = path.join(tempDir, "provider-settings.json");
+		const manager = new ProviderSettingsManager({ filePath });
+		manager.saveProviderSettings(
+			{ provider: "anthropic", apiKey: "before" },
+			{ setLastUsed: true },
+		);
+		const before = readFileSync(filePath, "utf8");
+
+		// Occupying the temp path with a directory makes writeFileSync fail,
+		// simulating a mid-write crash: the destination must be untouched.
+		mkdirSync(`${filePath}.${process.pid}.tmp`);
+		expect(() =>
+			manager.saveProviderSettings(
+				{ provider: "anthropic", apiKey: "after" },
+				{ setLastUsed: true },
+			),
+		).toThrow();
+		rmSync(`${filePath}.${process.pid}.tmp`, { recursive: true, force: true });
+
+		expect(readFileSync(filePath, "utf8")).toBe(before);
 	});
 
 	it("resolves auth storage settings for providers registered with a storage provider id", () => {

--- a/sdk/packages/core/src/services/storage/provider-settings-manager.ts
+++ b/sdk/packages/core/src/services/storage/provider-settings-manager.ts
@@ -3,12 +3,15 @@ import {
 	existsSync,
 	mkdirSync,
 	readFileSync,
+	renameSync,
+	rmSync,
 	writeFileSync,
 } from "node:fs";
 import { basename, dirname } from "node:path";
 import { resolveProviderSettingsPath } from "@cline/shared/storage";
 import { getLiveModelsCatalog } from "../..";
 import { getProviderAuthHandler } from "../../auth/provider-auth-registry";
+import { hashSecret, sdkDebug } from "../../logging/early-logger";
 import {
 	emptyStoredProviderSettings,
 	type ProviderConfig,
@@ -24,7 +27,6 @@ import {
 	ensureCustomProvidersLoadedSync,
 	registerConfiguredProvidersFromSettings,
 } from "../providers/local-provider-registry";
-import { hashSecret, sdkDebug } from "../../logging/early-logger";
 import { migrateLegacyProviderSettings } from "./provider-settings-legacy-migration";
 
 function nowIso(): string {
@@ -119,11 +121,21 @@ export class ProviderSettingsManager {
 		if (!existsSync(dir)) {
 			mkdirSync(dir, { recursive: true, mode: 0o700 });
 		}
-		writeFileSync(
-			this.filePath,
-			`${JSON.stringify(normalized, null, 2)}\n`,
-			"utf8",
-		);
+		// Stage to a pid-unique temp file and rename into place. Concurrent
+		// Cline processes (CLI, extension, hub) share this file; a bare
+		// writeFileSync lets readers catch a partial file, which read() treats
+		// as empty settings — indistinguishable from being logged out.
+		const tempPath = `${this.filePath}.${process.pid}.tmp`;
+		try {
+			writeFileSync(tempPath, `${JSON.stringify(normalized, null, 2)}\n`, {
+				encoding: "utf8",
+				mode: 0o600,
+			});
+			renameSync(tempPath, this.filePath);
+		} catch (error) {
+			rmSync(tempPath, { force: true });
+			throw error;
+		}
 		// Restrict file to owner-only read/write (best-effort; no-op on Windows).
 		try {
 			chmodSync(this.filePath, 0o600);


### PR DESCRIPTION
### Related Issue

**Issue:** N/A — recurring user reports (support + X) of `Error: Unauthorized: Please make sure you're using the latest version of Cline and re-authenticate your Cline account.` on the CLI and extension despite valid subscriptions, plus the internal Slack investigation into WorkOS refresh-token races.

### Description

#### The problem

Cline account users get intermittently but permanently logged out: the CLI/extension errors with the server's "Unauthorized … re-authenticate" 401 body, and the stored credentials are gone, forcing a manual re-login. The Slack investigation blamed WorkOS refresh-token rotation races between processes. That theory turned out to be mostly wrong — the highest-frequency cause requires **no token rotation at all**.

#### Root cause

`getValidClineCredentials()` (`sdk/packages/core/src/auth/cline.ts`) returned `null` for two completely different situations:

1. the refresh endpoint **rejected the refresh token** (400/401 invalid_grant → genuine "session dead"), and
2. **any transient failure** (network down, timeout, 5xx) that happened while the access token was already past its 30s grace window.

Every caller treats `null` as "re-auth required". The extension's `AuthService.refreshAccessToken` goes further and **wipes the Cline auth entry out of `~/.cline/data/settings/providers.json`** on any `null` — and since that file is shared by every Cline process on the machine, the CLI finds its credentials gone too. That's the whole story behind the CLI reports: the CLI never clears credentials itself.

The everyday trigger is embarrassing in hindsight: laptop sleeps past the ~1h access-token expiry, wakes up, and a background job (balance/banner/remote-config polling all funnel through `getAuthToken()`) fires a refresh before Wi-Fi is back → fetch fails → token already expired → `null` → wipe. No user action, no WorkOS involvement. This also explains why the rotation theory never reproduced: Dominic and Tomás hammered WorkOS with thousands of refresh-token reuses and never saw rotation, and the docs only say tokens "may be rotated".

#### How we proved it

I built a reproduction harness (mock `/api/v1/auth/refresh` with switchable rotation semantics + fault injection) and ran the **real SDK code** as separate OS processes sharing one tmp `CLINE_DIR` — actual `RuntimeOAuthTokenManager` workers (the exact CLI path) plus a worker faithfully replaying the extension's `AuthService` semantics. Two env vars make this possible with zero product-code changes: `CLINE_DIR` redirects providers.json, and the refresh URL comes from `settings.baseUrl` inside providers.json.

On current `main`, in **permissive mode** — the mock never rotates a token and never returns a single invalid_grant — a 10-second window of 500s after token expiry deterministically produced the hard logout: extension wiped providers.json, CLI died with "no credentials", and the CLI *also* independently misclassified the outage as `OAuthReauthRequiredError` (the user-visible "re-authenticate" moment). With this patch, the same scenario matrix produces **zero hard logouts in any mode**, because only a server-rejected refresh token can clear credentials now.

#### The fix (deliberately minimal)

**Commit 1 — `cline.ts`:** transient failure with an expired token now **throws** instead of returning `null`. The contract is documented on the function: credentials = usable, `null` = refresh token rejected (re-auth required), throw = transient, keep stored credentials and retry later. No app changes needed — the extension's existing `catch` in `refreshAccessToken` already logs-and-keeps on a throw, and the CLI surfaces a truthful network error instead of the false re-auth demand. The unmodified `RuntimeOAuthTokenManager` tests passing unchanged is the evidence this composes cleanly.

**Commit 2 — atomic providers.json writes:** `ProviderSettingsManager.write()` was a bare `writeFileSync` on a file read concurrently by every Cline process, and `read()` silently treats unparseable content as **empty settings** — indistinguishable from logged-out, and a subsequent save from that process would persist the empty state, erasing every configured provider. Now staged to a pid-unique temp file and `renameSync`d into place (same pattern as `file-team-store.ts`; pid suffix avoids cross-process temp collisions; try/catch removes the temp on failure so a crashed write leaves the previous file intact).

#### What this deliberately does NOT do (and why)

The investigation's rotation-race mechanisms are real in the sense that they reproduce under a server that enforces single-use refresh tokens — the harness confirms the extension's refresh-from-stale-in-memory-tokens and the unlocked read-modify-write in `saveProviderSettings` can both burn a rotated token in that world. But nobody has ever observed WorkOS rotating in practice, so the hardening for it (cross-process refresh lock, adopt-rotated-token-from-disk recovery, migrating all four rotators onto one shared helper, a mutation lock for saves) is parked on `saoudrizwan/auth-refresh-races` as a follow-up rather than shipped speculatively. Two things worth flagging:

- **Behavior change:** `getValidClineCredentials` now throws where it previously returned `null` (transient + expired). All in-repo callers were audited: registry handler propagates (CLI keeps credentials, surfaces network error), extension `refreshAccessToken`/`restoreRefreshTokenAndRetrieveAuthInfo` catch and keep, `apps/cli/src/tui/cline-account.ts` and hub `desktop-commands.ts` surface a truthful error instead of "requires re-authentication". External SDK consumers relying on null-on-transient will see a throw.
- **Known remaining wipe path:** the new extension's cross-window listener (`extension.ts:531`) still blindly deauths + wipes providers.json when the *legacy* extension removes its `cline:clineAccountId` secret. Legacy's own refresh handling is fine (verified on the `legacy-extension` branch — it keeps credentials on transient errors and only clears on genuine 400/401), but a legit legacy logout still cascades into the new stack even though they hold *different* WorkOS sessions. ~20-line fix (reconcile against providers.json before deauthing) is written and tested on the follow-up branch.

### Test Procedure

- **New unit tests:** transient-500 + expired token → throws (not null) in `cline.test.ts`; atomic-write tests in `provider-settings-manager.test.ts` (no `.tmp` sibling left behind; simulated mid-write crash leaves the previous file intact).
- **Existing suites:** `sdk/packages/core` — `cline.test.ts`, `provider-settings-manager.test.ts`, and the **unmodified** `runtime-oauth-token-manager.test.ts` all pass; core typecheck clean. (`local-runtime-bootstrap*.test.ts` full-suite failures reproduce identically on unmodified main in this sandbox — pre-existing, unrelated.)
- **Multi-process race harness:** mock auth API (permissive / rotate-reuse-ok / rotate-single-use / rotate-and-revoke-on-reuse semantics, 500-outage injection) driving real SDK classes as separate processes. Baseline main: 4 of 5 scenarios end in wiped credentials, including the zero-rotation outage scenario. With this patch: **no scenario wipes credentials**; genuinely consumed/revoked tokens surface as truthful re-auth errors without destroying state. Happy to share the harness (currently `scratch/`, uncommitted) if we want it in-tree.
- What could break: anything treating a `getValidClineCredentials` throw as fatal-and-clear. Audited all five call sites (registry handler, extension refresh + restore, CLI TUI account, hub desktop-commands) — each already had a keep-credentials path for thrown errors.
