### PR TITLE
Run tests when opening PRs against the legacy extension

### DIFF
--- a/.github/workflows/ext-vscode-test.yml
+++ b/.github/workflows/ext-vscode-test.yml
@@ -8,6 +8,7 @@ on:
     pull_request:
         branches:
             - main
+            - legacy-extension
     workflow_call:
 
 # Set default permissions for all jobs


### PR DESCRIPTION
This line is why PRs against the legacy extension never run the `test` required check