### PR TITLE
fix(shared): keep valid OTEL headers when one entry is malformed

### DIFF
--- a/sdk/packages/shared/src/parse/headers/utils.test.ts
+++ b/sdk/packages/shared/src/parse/headers/utils.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { parseKeyPairsIntoRecord } from "./utils";
+
+describe("parseKeyPairsIntoRecord", () => {
+	it("parses comma-separated key=value pairs", () => {
+		expect(parseKeyPairsIntoRecord("a=1,b=2,c=3")).toEqual({
+			a: "1",
+			b: "2",
+			c: "3",
+		});
+	});
+
+	it("returns an empty record for empty or undefined input", () => {
+		expect(parseKeyPairsIntoRecord("")).toEqual({});
+		expect(parseKeyPairsIntoRecord(undefined)).toEqual({});
+	});
+
+	it("trims whitespace and decodes percent-encoded keys and values", () => {
+		expect(parseKeyPairsIntoRecord(" Authorization = Bearer%20abc ")).toEqual({
+			Authorization: "Bearer abc",
+		});
+	});
+
+	it("skips entries without a separator or with an empty key", () => {
+		expect(parseKeyPairsIntoRecord("novalue,=nokey,good=1")).toEqual({
+			good: "1",
+		});
+	});
+
+	it("keeps well-formed entries when a later entry is malformed", () => {
+		// `b=%` is an invalid percent-encoding: decodeURIComponent throws on it.
+		// The malformed entry must be skipped without discarding `a` or `c`.
+		expect(parseKeyPairsIntoRecord("a=1,b=%,c=3")).toEqual({
+			a: "1",
+			c: "3",
+		});
+	});
+
+	it("skips only the malformed pair in a realistic OTEL header string", () => {
+		expect(
+			parseKeyPairsIntoRecord(
+				"Authorization=Bearer abc,X-Tenant=acme%,X-Trace=on",
+			),
+		).toEqual({
+			Authorization: "Bearer abc",
+			"X-Trace": "on",
+		});
+	});
+});

--- a/sdk/packages/shared/src/parse/headers/utils.ts
+++ b/sdk/packages/shared/src/parse/headers/utils.ts
@@ -7,11 +7,11 @@ export function parseKeyPairsIntoRecord(
 		return result;
 	}
 
-	try {
-		value.split(",").forEach((entry) => {
-			const separatorIndex = entry.indexOf("=");
-			if (separatorIndex <= 0) return;
+	value.split(",").forEach((entry) => {
+		const separatorIndex = entry.indexOf("=");
+		if (separatorIndex <= 0) return;
 
+		try {
 			// From the beginning to the equal sign is the key, from the equal sign to the end is the value
 			const key = decodeURIComponent(entry.substring(0, separatorIndex).trim());
 			const value = decodeURIComponent(
@@ -21,8 +21,12 @@ export function parseKeyPairsIntoRecord(
 			if (!key || !value) return;
 
 			result[key] = value;
-		});
-	} catch {}
+		} catch {
+			// Skip a single malformed entry (e.g. an invalid percent-encoding
+			// that makes decodeURIComponent throw) rather than aborting the
+			// whole list and silently dropping every remaining pair.
+		}
+	});
 
 	return result;
 }


### PR DESCRIPTION
### Related Issue

No linked issue. Per CONTRIBUTING.md, small bug fixes may be submitted directly without a prior issue. Happy to open one if you would prefer this tracked.

### Description

`parseKeyPairsIntoRecord` (`sdk/packages/shared/src/parse/headers/utils.ts`) wraps its entire `forEach` loop in a single `try/catch`. If `decodeURIComponent` throws on one entry (an invalid percent-encoding, for example a stray `%`), the exception aborts the whole loop and the empty `catch {}` swallows it, so every entry after the malformed one is silently dropped.

The only caller is OpenTelemetry exporter config: `sdk/packages/shared/src/services/telemetry-config.ts:28` parses `process.env.OTEL_EXPORTER_OTLP_HEADERS` into `otlpHeaders`. A single malformed header value can therefore silently discard the remaining headers, which may include `Authorization`, causing telemetry export to fail with no error surfaced.

The fix moves the `try/catch` inside the loop so that only the malformed entry is skipped, consistent with the existing per-entry skip (`if (!key || !value) return`). Output is identical for all valid input; only malformed entries change (skipped rather than aborting the rest of the list).

### Test Procedure

Added `sdk/packages/shared/src/parse/headers/utils.test.ts` (this function had no prior test coverage).

- `vitest run src/parse/headers/utils.test.ts`: 6/6 pass.
- Reverting only the fix and re-running the same tests fails the two "malformed entry in the middle" cases (they drop the trailing header), confirming the tests guard the regression rather than passing trivially.
- Full `@cline/shared` suite: 219/219 pass, so no sibling tests regressed.
- `biome check` on both files: clean. `tsc --noEmit` on `@cline/shared`: passes.

Corrected behavior:

```
parseKeyPairsIntoRecord("Authorization=Bearer abc,X-Tenant=acme%,X-Trace=on")
// before: { Authorization: "Bearer abc" }                 (X-Trace silently dropped)
// after:  { Authorization: "Bearer abc", "X-Trace": "on" }
```

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed the contributor guidelines

### Screenshots

Not applicable (backend-only change; behavior is covered by the unit tests above).

### Additional Notes

Scope is intentionally minimal. The VS Code app imports this helper from `@opentelemetry/core` instead of this SDK copy (`apps/vscode/src/shared/services/config/otel-config.ts:1`), so this change is limited to the one place the buggy implementation is used and no other call sites are affected.