### PR TITLE
fix(vscode): prevent Bedrock prompt cache mode leak

### DIFF
--- a/apps/vscode/src/sdk/bedrock-config.test.ts
+++ b/apps/vscode/src/sdk/bedrock-config.test.ts
@@ -93,6 +93,32 @@ describe("buildBedrockProviderConfig", () => {
 		expect(buildBedrockProviderConfig(config, "act").aws?.customModelBaseId).toBe("act-base")
 	})
 
+	it("does not carry prompt cache from plan mode into an act-mode Haiku base model", () => {
+		const config: ApiConfiguration = {
+			awsAuthentication: "apikey",
+			awsBedrockUsePromptCache: true,
+			planModeAwsBedrockCustomModelBaseId: "anthropic.claude-sonnet-4-5-20250929-v1:0",
+			actModeAwsBedrockCustomModelBaseId: "anthropic.claude-3-haiku-20240307-v1:0",
+		}
+
+		expect(buildBedrockProviderConfig(config, "plan").aws?.usePromptCache).toBe(true)
+		expect(buildBedrockProviderConfig(config, "act").aws?.usePromptCache).toBe(false)
+	})
+
+	it("preserves prompt cache for non-Haiku or unknown Bedrock base models", () => {
+		const sonnetConfig: ApiConfiguration = {
+			awsBedrockUsePromptCache: true,
+			actModeAwsBedrockCustomModelBaseId: "anthropic.claude-sonnet-4-5-20250929-v1:0",
+		}
+		const unknownConfig: ApiConfiguration = {
+			awsBedrockUsePromptCache: true,
+			actModeAwsBedrockCustomModelBaseId: "custom.vendor-model",
+		}
+
+		expect(buildBedrockProviderConfig(sonnetConfig, "act").aws?.usePromptCache).toBe(true)
+		expect(buildBedrockProviderConfig(unknownConfig, "act").aws?.usePromptCache).toBe(true)
+	})
+
 	it("forwards cross-region and global inference flags", () => {
 		const result = buildBedrockProviderConfig(
 			{

--- a/apps/vscode/src/sdk/bedrock-config.ts
+++ b/apps/vscode/src/sdk/bedrock-config.ts
@@ -31,6 +31,25 @@ function trimToUndefined(value: unknown): string | undefined {
 	return trimmed.length > 0 ? trimmed : undefined
 }
 
+function selectedBedrockBaseModelId(configuration: ApiConfiguration, mode: Mode): string | undefined {
+	return trimToUndefined(
+		mode === "plan" ? configuration.planModeAwsBedrockCustomModelBaseId : configuration.actModeAwsBedrockCustomModelBaseId,
+	)
+}
+
+function shouldUseBedrockPromptCache(configuration: ApiConfiguration, mode: Mode): boolean | undefined {
+	if (configuration.awsBedrockUsePromptCache !== true) {
+		return configuration.awsBedrockUsePromptCache
+	}
+
+	const baseModelId = selectedBedrockBaseModelId(configuration, mode)?.toLowerCase()
+	if (baseModelId?.includes("claude") && baseModelId.includes("haiku")) {
+		return false
+	}
+
+	return true
+}
+
 /**
  * Map the webview's `awsAuthentication` radio value onto the SDK's
  * `AwsConfig.authentication` spelling.
@@ -70,13 +89,9 @@ export function buildBedrockProviderConfig(configuration: ApiConfiguration, mode
 		sessionToken: trimToUndefined(configuration.awsSessionToken),
 		authentication,
 		profile: usesProfile ? trimToUndefined(configuration.awsProfile) : undefined,
-		usePromptCache: configuration.awsBedrockUsePromptCache,
+		usePromptCache: shouldUseBedrockPromptCache(configuration, mode),
 		endpoint: trimToUndefined(configuration.awsBedrockEndpoint),
-		customModelBaseId: trimToUndefined(
-			mode === "plan"
-				? configuration.planModeAwsBedrockCustomModelBaseId
-				: configuration.actModeAwsBedrockCustomModelBaseId,
-		),
+		customModelBaseId: selectedBedrockBaseModelId(configuration, mode),
 	}
 	return {
 		region: trimToUndefined(configuration.awsRegion),


### PR DESCRIPTION
### Related Issue

Fixes #12172

### Description

Bedrock prompt caching is stored as a shared `awsBedrockUsePromptCache` setting, but split Plan/Act mode can use different Bedrock base models. That let a cache-enabled Plan model leak the prompt-cache option into an Act model such as Claude Haiku, which can reject the request.

This keeps the existing shared setting for compatibility, but makes the Bedrock bridge mode-aware when building SDK provider config. If the active mode is using a known non-cache Claude Haiku base model, the provider config disables prompt caching for that mode while preserving the setting for Plan/Sonnet and unknown/custom Bedrock models.

### Test Procedure

- `bun test src/sdk/bedrock-config.test.ts`
- `bun -F @cline/vscode typecheck`
- `git diff --check origin/main...HEAD`

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update