### PR TITLE
Store startedAt in auth metadata when starting a Cline session

### DIFF
--- a/apps/vscode/src/sdk/auth-service.test.ts
+++ b/apps/vscode/src/sdk/auth-service.test.ts
@@ -200,7 +200,18 @@ function createTestOAuthCredentials(): OAuthCredentials {
 		expires: Date.now() + 3600 * 1000, // 1 hour from now (ms)
 		accountId: "acct-456",
 		email: "oauth@example.com",
+		metadata: { sessionStartedAt: 1_700_000_000_000 },
 	}
+}
+
+async function waitForCondition(condition: () => boolean): Promise<void> {
+	for (let i = 0; i < 20; i++) {
+		if (condition()) {
+			return
+		}
+		await new Promise((resolve) => setTimeout(resolve, 0))
+	}
+	throw new Error("Timed out waiting for condition")
 }
 
 // ---------------------------------------------------------------------------
@@ -360,6 +371,23 @@ describe("AuthService", () => {
 			const response = await authService.createAuthRequest()
 
 			expect(response.value).toBe("Enter this code in your browser: ABCD-EFGH")
+		})
+
+		it("persists the session start time in Cline auth metadata", async () => {
+			mockLoginClineOAuth.mockImplementationOnce(async ({ callbacks }) => {
+				callbacks.onAuth({
+					url: "https://example.com/device?user_code=ABCD-EFGH",
+					instructions: "Enter this code in your browser: ABCD-EFGH",
+				})
+
+				return createTestOAuthCredentials()
+			})
+
+			await authService.createAuthRequest()
+			await waitForCondition(() => mockProviderSettings.has("cline"))
+
+			const persisted = mockProviderSettings.get("cline") as { auth?: { metadata?: Record<string, unknown> } }
+			expect(persisted.auth?.metadata?.sessionStartedAt).toBe(1_700_000_000_000)
 		})
 	})
 

--- a/apps/vscode/src/sdk/auth-service.test.ts
+++ b/apps/vscode/src/sdk/auth-service.test.ts
@@ -452,6 +452,7 @@ describe("AuthService", () => {
 
 			expect(testAccess(authService)._authenticated).toBe(true)
 			expect(testAccess(authService)._clineAuthInfo?.idToken).toBe("persisted-access-token")
+			expect(testAccess(authService)._clineAuthInfo?.startedAt).toBeUndefined()
 			expect(
 				(mockProviderSettings.get("cline")?.auth as { metadata?: Record<string, unknown> } | undefined)?.metadata,
 			).toBeUndefined()

--- a/apps/vscode/src/sdk/auth-service.test.ts
+++ b/apps/vscode/src/sdk/auth-service.test.ts
@@ -463,6 +463,43 @@ describe("AuthService", () => {
 			)
 		})
 
+		it("does not let undefined incoming metadata erase existing metadata on restore refresh", async () => {
+			mockProviderSettings.set("cline", {
+				provider: "cline",
+				auth: {
+					accessToken: "workos:persisted-access-token",
+					refreshToken: "persisted-refresh-token",
+					accountId: "user-123",
+					metadata: {
+						provider: "workos",
+						sessionStartedAt: 1_700_000_000_000,
+						tokenType: "Bearer",
+					},
+				},
+			})
+			vi.mocked(getValidClineCredentials).mockResolvedValue({
+				access: "persisted-access-token",
+				refresh: "persisted-refresh-token",
+				expires: Date.now() + 3600 * 1000,
+				accountId: "user-123",
+				email: "test@example.com",
+				metadata: {
+					provider: undefined,
+					sessionStartedAt: 1_700_000_000_000,
+					tokenType: "Bearer",
+				},
+			})
+
+			await authService.restoreRefreshTokenAndRetrieveAuthInfo()
+
+			const persisted = mockProviderSettings.get("cline") as { auth?: { metadata?: Record<string, unknown> } }
+			expect(persisted.auth?.metadata).toMatchObject({
+				provider: "workos",
+				sessionStartedAt: 1_700_000_000_000,
+				tokenType: "Bearer",
+			})
+		})
+
 		it("sets unauthenticated state when providers.json has no Cline auth", async () => {
 			await authService.restoreRefreshTokenAndRetrieveAuthInfo()
 

--- a/apps/vscode/src/sdk/auth-service.test.ts
+++ b/apps/vscode/src/sdk/auth-service.test.ts
@@ -200,7 +200,12 @@ function createTestOAuthCredentials(): OAuthCredentials {
 		expires: Date.now() + 3600 * 1000, // 1 hour from now (ms)
 		accountId: "acct-456",
 		email: "oauth@example.com",
-		metadata: { sessionStartedAt: 1_700_000_000_000 },
+		metadata: {
+			provider: "workos",
+			sessionStartedAt: 1_700_000_000_000,
+			tokenType: "Bearer",
+			userInfo: { email: "oauth@example.com" },
+		},
 	}
 }
 
@@ -387,7 +392,13 @@ describe("AuthService", () => {
 			await waitForCondition(() => mockProviderSettings.has("cline"))
 
 			const persisted = mockProviderSettings.get("cline") as { auth?: { metadata?: Record<string, unknown> } }
-			expect(persisted.auth?.metadata?.sessionStartedAt).toBe(1_700_000_000_000)
+			expect(persisted.auth?.metadata).toMatchObject({
+				provider: "workos",
+				sessionStartedAt: 1_700_000_000_000,
+				tokenType: "Bearer",
+				userInfo: { email: "oauth@example.com" },
+			})
+			expect(persisted.auth?.metadata).not.toHaveProperty("startedAt")
 		})
 	})
 
@@ -441,6 +452,9 @@ describe("AuthService", () => {
 
 			expect(testAccess(authService)._authenticated).toBe(true)
 			expect(testAccess(authService)._clineAuthInfo?.idToken).toBe("persisted-access-token")
+			expect(
+				(mockProviderSettings.get("cline")?.auth as { metadata?: Record<string, unknown> } | undefined)?.metadata,
+			).toBeUndefined()
 			expect(getValidClineCredentials).toHaveBeenCalledWith(
 				expect.any(Object),
 				expect.objectContaining({ telemetry: mockSdkTelemetry }),

--- a/apps/vscode/src/sdk/auth-service.ts
+++ b/apps/vscode/src/sdk/auth-service.ts
@@ -8,7 +8,7 @@
 // disk — it's fetched from the Cline API on startup and cached in memory.
 // This matches the CLI's pattern (see apps/cli/src/runtime/interactive-welcome.ts).
 
-import type { ITelemetryService, OAuthCredentials } from "@cline/core"
+import type { ITelemetryService, OAuthCredentials, ProviderSettings } from "@cline/core"
 import {
 	createOAuthClientCallbacks,
 	getValidClineCredentials,
@@ -84,6 +84,20 @@ export enum LogoutReason {
 
 const WORKOS_TOKEN_PREFIX = "workos:"
 
+type AuthMetadata = Record<string, unknown>
+
+function getAuthMetadata(auth: ProviderSettings["auth"]): AuthMetadata | undefined {
+	const metadata = (auth as { metadata?: unknown }).metadata
+	return metadata && typeof metadata === "object" && !Array.isArray(metadata) ? (metadata as AuthMetadata) : undefined
+}
+
+function readSessionStartedAt(metadata: AuthMetadata | undefined): number | undefined {
+	if (!metadata) return undefined
+
+	const value = (metadata as { sessionStartedAt?: unknown }).sessionStartedAt
+	return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined
+}
+
 // ---------------------------------------------------------------------------
 // providers.json helpers
 // ---------------------------------------------------------------------------
@@ -97,6 +111,7 @@ function readClineCredentials(): {
 	refreshToken?: string
 	expiresAt?: number // milliseconds since epoch (providers.json convention)
 	accountId?: string
+	sessionStartedAt?: number // milliseconds since epoch
 } | null {
 	try {
 		const manager = getProviderSettingsManager()
@@ -117,9 +132,10 @@ function readClineCredentials(): {
 			refreshToken: settings.auth.refreshToken,
 			expiresAt: (settings.auth as { expiresAt?: number }).expiresAt,
 			accountId: settings.auth.accountId,
+			sessionStartedAt: readSessionStartedAt(getAuthMetadata(settings.auth)),
 		}
 		sdkDebug(
-			`[SdkAuthService] readClineCredentials: found credentials (accessHash=${hashSecret(result.accessToken)}, refreshHash=${hashSecret(result.refreshToken)}, expiresAt=${result.expiresAt})`,
+			`[SdkAuthService] readClineCredentials: found credentials (accessHash=${hashSecret(result.accessToken)}, refreshHash=${hashSecret(result.refreshToken)}, expiresAt=${result.expiresAt}, sessionStartedAt=${result.sessionStartedAt})`,
 		)
 		return result
 	} catch (error) {
@@ -136,10 +152,13 @@ function writeClineCredentials(credentials: {
 	refreshToken?: string
 	expiresAt?: number // milliseconds since epoch
 	accountId?: string
+	sessionStartedAt?: number // milliseconds since epoch
 }): void {
 	try {
 		const manager = getProviderSettingsManager()
 		const existing = manager.getProviderSettings("cline")
+		const existingMetadata = getAuthMetadata(existing?.auth)
+		const sessionStartedAt = credentials.sessionStartedAt ?? readSessionStartedAt(existingMetadata)
 
 		const auth = {
 			...(existing?.auth ?? {}),
@@ -147,6 +166,12 @@ function writeClineCredentials(credentials: {
 			refreshToken: credentials.refreshToken,
 			accountId: credentials.accountId,
 		} as Record<string, unknown>
+		if (sessionStartedAt !== undefined) {
+			auth.metadata = {
+				...(existingMetadata ?? {}),
+				sessionStartedAt,
+			}
+		}
 		if (credentials.expiresAt !== undefined) {
 			auth.expiresAt = credentials.expiresAt
 		}
@@ -155,12 +180,12 @@ function writeClineCredentials(credentials: {
 			{
 				...(existing ?? { provider: "cline" }),
 				provider: "cline",
-				auth: auth as { accessToken?: string; refreshToken?: string; accountId?: string },
+				auth: auth as { accessToken?: string; refreshToken?: string; accountId?: string; metadata?: AuthMetadata },
 			},
 			{ tokenSource: "oauth", setLastUsed: true },
 		)
 		sdkDebug(
-			`[SdkAuthService] writeClineCredentials: wrote (accessHash=${hashSecret(credentials.accessToken)}, refreshHash=${hashSecret(credentials.refreshToken)}, expiresAt=${credentials.expiresAt})`,
+			`[SdkAuthService] writeClineCredentials: wrote (accessHash=${hashSecret(credentials.accessToken)}, refreshHash=${hashSecret(credentials.refreshToken)}, expiresAt=${credentials.expiresAt}, sessionStartedAt=${sessionStartedAt})`,
 		)
 	} catch (error) {
 		Logger.error("[SdkAuthService] Failed to write credentials to providers.json:", error)
@@ -242,6 +267,7 @@ export class AuthService {
 	private async credentialsToAuthInfo(credentials: OAuthCredentials, provider: string): Promise<ClineAuthInfo> {
 		// Fetch full user info from the API using the access token
 		const userInfo = await this.fetchUserInfoFromApi(credentials.access)
+		const startedAt = readSessionStartedAt(credentials.metadata) ?? Date.now()
 
 		return {
 			idToken: credentials.access,
@@ -254,7 +280,7 @@ export class AuthService {
 				organizations: [],
 			},
 			provider,
-			startedAt: Date.now(),
+			startedAt,
 		}
 	}
 
@@ -294,6 +320,7 @@ export class AuthService {
 			expires: authInfo.expiresAt ? authInfo.expiresAt * 1000 : 0,
 			accountId: authInfo.userInfo.id || undefined,
 			email: authInfo.userInfo.email || undefined,
+			metadata: authInfo.startedAt ? { sessionStartedAt: authInfo.startedAt } : undefined,
 		}
 	}
 
@@ -407,6 +434,7 @@ export class AuthService {
 						refreshToken: newCredentials.refresh,
 						expiresAt: newCredentials.expires,
 						accountId: this._clineAuthInfo.userInfo.id,
+						sessionStartedAt: this._clineAuthInfo.startedAt,
 					})
 
 					setImmediate(() => {
@@ -538,6 +566,7 @@ export class AuthService {
 					refreshToken: credentials.refresh,
 					expiresAt: credentials.expires,
 					accountId: authInfo.userInfo.id || credentials.accountId,
+					sessionStartedAt: authInfo.startedAt,
 				})
 
 				// Push auth state update
@@ -589,6 +618,7 @@ export class AuthService {
 			throw new Error("Invalid response from mock server")
 		}
 
+		const sessionStartedAt = Date.now()
 		this._clineAuthInfo = {
 			idToken: tokenData.accessToken,
 			refreshToken: tokenData.refreshToken,
@@ -603,7 +633,7 @@ export class AuthService {
 				subject: tokenData.userInfo?.subject,
 			},
 			provider: "cline",
-			startedAt: Date.now(),
+			startedAt: sessionStartedAt,
 		}
 		this._authenticated = true
 
@@ -614,6 +644,7 @@ export class AuthService {
 			refreshToken: tokenData.refreshToken,
 			expiresAt: new Date(tokenData.expiresAt).getTime(),
 			accountId: this._clineAuthInfo.userInfo.id,
+			sessionStartedAt,
 		})
 
 		await this.sendAuthStatusUpdate()
@@ -649,6 +680,7 @@ export class AuthService {
 				refreshToken: credentials.refresh,
 				expiresAt: credentials.expires,
 				accountId: authInfo.userInfo.id || credentials.accountId,
+				sessionStartedAt: authInfo.startedAt,
 			})
 
 			await this.sendAuthStatusUpdate()
@@ -811,6 +843,7 @@ export class AuthService {
 			// Fetch full user info
 			const userInfo = await this.fetchUserInfoFromApi(tokenData.accessToken)
 
+			const sessionStartedAt = Date.now()
 			const authInfo: ClineAuthInfo = {
 				idToken: tokenData.accessToken,
 				refreshToken: tokenData.refreshToken,
@@ -823,7 +856,7 @@ export class AuthService {
 				},
 				expiresAt: new Date(tokenData.expiresAt).getTime() / 1000,
 				provider: "cline",
-				startedAt: Date.now(),
+				startedAt: sessionStartedAt,
 			}
 
 			this._clineAuthInfo = authInfo
@@ -835,6 +868,7 @@ export class AuthService {
 				refreshToken: tokenData.refreshToken,
 				expiresAt: new Date(tokenData.expiresAt).getTime(),
 				accountId: authInfo.userInfo.id,
+				sessionStartedAt,
 			})
 
 			await this.sendAuthStatusUpdate()
@@ -882,6 +916,7 @@ export class AuthService {
 					organizations: [],
 				},
 				provider: "cline",
+				startedAt: creds.sessionStartedAt,
 			}
 
 			const validCredentials = await this.resolveValidClineCredentials(restoredAuthInfo)
@@ -898,6 +933,7 @@ export class AuthService {
 				refreshToken: validCredentials.refresh,
 				expiresAt: validCredentials.expires,
 				accountId: validCredentials.accountId ?? restoredAuthInfo.userInfo.id,
+				sessionStartedAt: restoredAuthInfo.startedAt,
 			})
 
 			this._clineAuthInfo = {
@@ -910,6 +946,7 @@ export class AuthService {
 					email: validCredentials.email ?? restoredAuthInfo.userInfo.email,
 				},
 				provider: restoredAuthInfo.provider,
+				startedAt: restoredAuthInfo.startedAt,
 			}
 			this._authenticated = true
 

--- a/apps/vscode/src/sdk/auth-service.ts
+++ b/apps/vscode/src/sdk/auth-service.ts
@@ -276,7 +276,7 @@ export class AuthService {
 	private async credentialsToAuthInfo(credentials: OAuthCredentials, provider: string): Promise<ClineAuthInfo> {
 		// Fetch full user info from the API using the access token
 		const userInfo = await this.fetchUserInfoFromApi(credentials.access)
-		const startedAt = readSessionStartedAt(credentials.metadata) ?? Date.now()
+		const startedAt = readSessionStartedAt(credentials.metadata)
 
 		return {
 			idToken: credentials.access,
@@ -430,7 +430,7 @@ export class AuthService {
 					expiresAt: newCredentials.expires ? newCredentials.expires / 1000 : undefined,
 					userInfo: userInfo ?? currentInfo.userInfo,
 					provider: currentInfo.provider,
-					startedAt: currentInfo.startedAt ?? Date.now(),
+					startedAt: currentInfo.startedAt,
 				}
 				this._authenticated = true
 

--- a/apps/vscode/src/sdk/auth-service.ts
+++ b/apps/vscode/src/sdk/auth-service.ts
@@ -170,10 +170,10 @@ function writeClineCredentials(credentials: {
 			refreshToken: credentials.refreshToken,
 			accountId: credentials.accountId,
 		} as Record<string, unknown>
-		const metadata = {
-			...(existingMetadata ?? {}),
-			...(credentials.metadata ?? {}),
-		}
+		const incomingMetadata = Object.fromEntries(
+			Object.entries(credentials.metadata ?? {}).filter(([, value]) => value !== undefined),
+		)
+		const metadata = { ...(existingMetadata ?? {}), ...incomingMetadata }
 		delete metadata.startedAt
 		if (sessionStartedAt !== undefined) {
 			metadata.sessionStartedAt = sessionStartedAt

--- a/apps/vscode/src/sdk/auth-service.ts
+++ b/apps/vscode/src/sdk/auth-service.ts
@@ -87,6 +87,8 @@ const WORKOS_TOKEN_PREFIX = "workos:"
 type AuthMetadata = Record<string, unknown>
 
 function getAuthMetadata(auth: ProviderSettings["auth"]): AuthMetadata | undefined {
+	if (!auth) return undefined
+
 	const metadata = (auth as { metadata?: unknown }).metadata
 	return metadata && typeof metadata === "object" && !Array.isArray(metadata) ? (metadata as AuthMetadata) : undefined
 }
@@ -94,7 +96,7 @@ function getAuthMetadata(auth: ProviderSettings["auth"]): AuthMetadata | undefin
 function readSessionStartedAt(metadata: AuthMetadata | undefined): number | undefined {
 	if (!metadata) return undefined
 
-	const value = (metadata as { sessionStartedAt?: unknown }).sessionStartedAt
+	const value = metadata.sessionStartedAt
 	return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined
 }
 
@@ -152,13 +154,15 @@ function writeClineCredentials(credentials: {
 	refreshToken?: string
 	expiresAt?: number // milliseconds since epoch
 	accountId?: string
+	metadata?: AuthMetadata
 	sessionStartedAt?: number // milliseconds since epoch
 }): void {
 	try {
 		const manager = getProviderSettingsManager()
 		const existing = manager.getProviderSettings("cline")
 		const existingMetadata = getAuthMetadata(existing?.auth)
-		const sessionStartedAt = credentials.sessionStartedAt ?? readSessionStartedAt(existingMetadata)
+		const sessionStartedAt =
+			credentials.sessionStartedAt ?? readSessionStartedAt(credentials.metadata) ?? readSessionStartedAt(existingMetadata)
 
 		const auth = {
 			...(existing?.auth ?? {}),
@@ -166,11 +170,16 @@ function writeClineCredentials(credentials: {
 			refreshToken: credentials.refreshToken,
 			accountId: credentials.accountId,
 		} as Record<string, unknown>
+		const metadata = {
+			...(existingMetadata ?? {}),
+			...(credentials.metadata ?? {}),
+		}
+		delete metadata.startedAt
 		if (sessionStartedAt !== undefined) {
-			auth.metadata = {
-				...(existingMetadata ?? {}),
-				sessionStartedAt,
-			}
+			metadata.sessionStartedAt = sessionStartedAt
+		}
+		if (Object.keys(metadata).length > 0) {
+			auth.metadata = metadata
 		}
 		if (credentials.expiresAt !== undefined) {
 			auth.expiresAt = credentials.expiresAt
@@ -434,7 +443,8 @@ export class AuthService {
 						refreshToken: newCredentials.refresh,
 						expiresAt: newCredentials.expires,
 						accountId: this._clineAuthInfo.userInfo.id,
-						sessionStartedAt: this._clineAuthInfo.startedAt,
+						metadata: newCredentials.metadata,
+						sessionStartedAt: readSessionStartedAt(newCredentials.metadata),
 					})
 
 					setImmediate(() => {
@@ -566,6 +576,7 @@ export class AuthService {
 					refreshToken: credentials.refresh,
 					expiresAt: credentials.expires,
 					accountId: authInfo.userInfo.id || credentials.accountId,
+					metadata: credentials.metadata,
 					sessionStartedAt: authInfo.startedAt,
 				})
 
@@ -644,6 +655,7 @@ export class AuthService {
 			refreshToken: tokenData.refreshToken,
 			expiresAt: new Date(tokenData.expiresAt).getTime(),
 			accountId: this._clineAuthInfo.userInfo.id,
+			metadata: { sessionStartedAt },
 			sessionStartedAt,
 		})
 
@@ -680,6 +692,7 @@ export class AuthService {
 				refreshToken: credentials.refresh,
 				expiresAt: credentials.expires,
 				accountId: authInfo.userInfo.id || credentials.accountId,
+				metadata: credentials.metadata,
 				sessionStartedAt: authInfo.startedAt,
 			})
 
@@ -868,6 +881,12 @@ export class AuthService {
 				refreshToken: tokenData.refreshToken,
 				expiresAt: new Date(tokenData.expiresAt).getTime(),
 				accountId: authInfo.userInfo.id,
+				metadata: {
+					provider,
+					sessionStartedAt,
+					tokenType: tokenData.tokenType,
+					userInfo: tokenData.userInfo,
+				},
 				sessionStartedAt,
 			})
 
@@ -933,7 +952,8 @@ export class AuthService {
 				refreshToken: validCredentials.refresh,
 				expiresAt: validCredentials.expires,
 				accountId: validCredentials.accountId ?? restoredAuthInfo.userInfo.id,
-				sessionStartedAt: restoredAuthInfo.startedAt,
+				metadata: validCredentials.metadata,
+				sessionStartedAt: readSessionStartedAt(validCredentials.metadata),
 			})
 
 			this._clineAuthInfo = {

--- a/sdk/packages/core/src/auth/cline.test.ts
+++ b/sdk/packages/core/src/auth/cline.test.ts
@@ -41,7 +41,10 @@ describe("auth/cline getValidClineCredentials", () => {
 
 	it("refreshes expired credentials", async () => {
 		const nowSpy = vi.spyOn(Date, "now").mockReturnValue(100_000);
-		const current = createCredentials({ expires: 101_000 });
+		const current = createCredentials({
+			expires: 101_000,
+			metadata: { provider: "google", sessionStartedAt: 12_345 },
+		});
 		const fetchMock = vi.fn(
 			async () =>
 				new Response(
@@ -72,6 +75,11 @@ describe("auth/cline getValidClineCredentials", () => {
 			refresh: "refresh-new",
 			accountId: "acct-2",
 			email: "new@example.com",
+			metadata: {
+				provider: "google",
+				sessionStartedAt: 12_345,
+				tokenType: "Bearer",
+			},
 		});
 		nowSpy.mockRestore();
 	});
@@ -202,6 +210,7 @@ describe("auth/cline loginClineOAuth", () => {
 	});
 
 	it("completes WorkOS device auth and registers tokens", async () => {
+		const nowSpy = vi.spyOn(Date, "now").mockReturnValue(200_000);
 		const fetchMock = vi
 			.fn()
 			.mockResolvedValueOnce(
@@ -271,6 +280,10 @@ describe("auth/cline loginClineOAuth", () => {
 			refresh: "cline-refresh",
 			accountId: "acct-1",
 			email: "user@example.com",
+			metadata: {
+				sessionStartedAt: 200_000,
+				tokenType: "Bearer",
+			},
 		});
 		expect(fetchMock).toHaveBeenCalledTimes(3);
 		const registerCallBody = JSON.parse(
@@ -283,5 +296,6 @@ describe("auth/cline loginClineOAuth", () => {
 			accessToken: "workos-access",
 			refreshToken: "workos-refresh",
 		});
+		nowSpy.mockRestore();
 	});
 });

--- a/sdk/packages/core/src/auth/cline.test.ts
+++ b/sdk/packages/core/src/auth/cline.test.ts
@@ -84,6 +84,45 @@ describe("auth/cline getValidClineCredentials", () => {
 		nowSpy.mockRestore();
 	});
 
+	it("does not add sessionStartedAt when refreshing credentials that do not already have it", async () => {
+		const nowSpy = vi.spyOn(Date, "now").mockReturnValue(100_000);
+		const current = createCredentials({
+			expires: 101_000,
+			metadata: { provider: "google" },
+		});
+		const fetchMock = vi.fn(
+			async () =>
+				new Response(
+					JSON.stringify({
+						success: true,
+						data: {
+							accessToken: "access-new",
+							refreshToken: "refresh-new",
+							tokenType: "Bearer",
+							expiresAt: "2030-01-01T00:00:00.000Z",
+							userInfo: {
+								subject: "sub-1",
+								email: "new@example.com",
+								name: "New User",
+								clineUserId: "acct-2",
+								accounts: [],
+							},
+						},
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				),
+		);
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const result = await getValidClineCredentials(current, PROVIDER_OPTIONS);
+		expect(result?.metadata).toMatchObject({
+			provider: "google",
+			tokenType: "Bearer",
+		});
+		expect(result?.metadata).not.toHaveProperty("sessionStartedAt");
+		nowSpy.mockRestore();
+	});
+
 	it("returns null when refresh fails with invalid_grant", async () => {
 		const nowSpy = vi.spyOn(Date, "now").mockReturnValue(100_000);
 		const current = createCredentials({ expires: 101_000 });

--- a/sdk/packages/core/src/auth/cline.ts
+++ b/sdk/packages/core/src/auth/cline.ts
@@ -138,9 +138,6 @@ function toClineCredentials(
 ): ClineOAuthCredentials {
 	const accountId = responseData.userInfo.clineUserId ?? fallback.accountId;
 	const refreshToken = responseData.refreshToken ?? fallback.refresh;
-	const sessionStartedAt =
-		typeof fallback.metadata?.sessionStartedAt === "number" ? fallback.metadata.sessionStartedAt : undefined;
-
 	if (!refreshToken) {
 		throw new Error("Token response did not include a refresh token");
 	}
@@ -150,9 +147,6 @@ function toClineCredentials(
 		tokenType: responseData.tokenType,
 		userInfo: responseData.userInfo,
 	};
-	if (sessionStartedAt !== undefined) {
-		metadata.sessionStartedAt = sessionStartedAt;
-	}
 	delete metadata.startedAt;
 
 	return {

--- a/sdk/packages/core/src/auth/cline.ts
+++ b/sdk/packages/core/src/auth/cline.ts
@@ -138,10 +138,22 @@ function toClineCredentials(
 ): ClineOAuthCredentials {
 	const accountId = responseData.userInfo.clineUserId ?? fallback.accountId;
 	const refreshToken = responseData.refreshToken ?? fallback.refresh;
+	const sessionStartedAt =
+		typeof fallback.metadata?.sessionStartedAt === "number" ? fallback.metadata.sessionStartedAt : undefined;
 
 	if (!refreshToken) {
 		throw new Error("Token response did not include a refresh token");
 	}
+	const metadata: Record<string, unknown> = {
+		...(fallback.metadata ?? {}),
+		provider,
+		tokenType: responseData.tokenType,
+		userInfo: responseData.userInfo,
+	};
+	if (sessionStartedAt !== undefined) {
+		metadata.sessionStartedAt = sessionStartedAt;
+	}
+	delete metadata.startedAt;
 
 	return {
 		access: responseData.accessToken,
@@ -149,12 +161,7 @@ function toClineCredentials(
 		expires: toEpochMs(responseData.expiresAt),
 		accountId: accountId ?? undefined,
 		email: responseData.userInfo.email || fallback.email,
-		metadata: {
-			...(fallback.metadata ?? {}),
-			provider,
-			tokenType: responseData.tokenType,
-			userInfo: responseData.userInfo,
-		},
+		metadata,
 	};
 }
 
@@ -390,6 +397,7 @@ async function registerWorkOSTokens(
 	return toClineCredentials(
 		requireClineTokenResponse(json, "Invalid token exchange response"),
 		provider ?? options.provider,
+		{ metadata: { sessionStartedAt: Date.now() } },
 	);
 }
 
@@ -435,6 +443,7 @@ async function exchangeAuthorizationCode(
 	return toClineCredentials(
 		requireClineTokenResponse(json, "Invalid token exchange response"),
 		provider ?? options.provider,
+		{ metadata: { sessionStartedAt: Date.now() } },
 	);
 }
 

--- a/sdk/packages/core/src/auth/cline.ts
+++ b/sdk/packages/core/src/auth/cline.ts
@@ -150,6 +150,7 @@ function toClineCredentials(
 		accountId: accountId ?? undefined,
 		email: responseData.userInfo.email || fallback.email,
 		metadata: {
+			...(fallback.metadata ?? {}),
 			provider,
 			tokenType: responseData.tokenType,
 			userInfo: responseData.userInfo,

--- a/sdk/packages/core/src/auth/provider-auth-registry.test.ts
+++ b/sdk/packages/core/src/auth/provider-auth-registry.test.ts
@@ -4,6 +4,7 @@ import {
 	getPersistedProviderApiKey,
 	getProviderAuthHandler,
 	getProviderAuthStorageId,
+	getProviderOAuthCredentialsFromSettings,
 	isOAuthProvider,
 	loginAndSaveProviderOAuthCredentials,
 	resolveProviderApiKeyFromSettings,
@@ -76,6 +77,7 @@ describe("provider auth registry", () => {
 			refresh: "new-refresh",
 			expires: 4_000_000_000_000,
 			accountId: "acct-new",
+			metadata: { sessionStartedAt: 1_700_000_000_000 },
 		});
 		const getProviderSettings = vi.fn().mockReturnValue({
 			provider: "cline",
@@ -107,6 +109,7 @@ describe("provider auth registry", () => {
 				refreshToken: "new-refresh",
 				accountId: "acct-new",
 				expiresAt: 4_000_000_000_000,
+				metadata: { sessionStartedAt: 1_700_000_000_000 },
 			},
 		});
 		expect(saveProviderSettings).toHaveBeenCalledWith(
@@ -134,6 +137,7 @@ describe("provider auth registry", () => {
 			refresh: "new-refresh",
 			expires: 4_000_000_000_000,
 			accountId: "acct-new",
+			metadata: { sessionStartedAt: 1_700_000_000_001 },
 		});
 		const getProviderSettings = vi.fn().mockReturnValue({
 			provider: "cline",
@@ -161,11 +165,33 @@ describe("provider auth registry", () => {
 				refreshToken: "new-refresh",
 				accountId: "acct-new",
 				expiresAt: 4_000_000_000_000,
+				metadata: { sessionStartedAt: 1_700_000_000_001 },
 			},
 		});
 		expect(saveProviderSettings).toHaveBeenCalledWith(
 			expect.objectContaining({ provider: "cline" }),
 			{ tokenSource: "oauth" },
 		);
+	});
+
+	it("reads persisted auth metadata back into OAuth credentials", () => {
+		const handler = getProviderAuthHandler("cline")
+		const credentials = handler && getProviderOAuthCredentialsFromSettings("cline", {
+			provider: "cline",
+			auth: {
+				accessToken: "workos:stored-access",
+				refreshToken: "stored-refresh",
+				expiresAt: 4_000_000_000_000,
+				accountId: "acct-stored",
+				metadata: { sessionStartedAt: 1_700_000_000_002 },
+			},
+		})
+
+		expect(credentials).toMatchObject({
+			access: "stored-access",
+			refresh: "stored-refresh",
+			accountId: "acct-stored",
+			metadata: { sessionStartedAt: 1_700_000_000_002 },
+		})
 	});
 });

--- a/sdk/packages/core/src/auth/provider-auth-registry.test.ts
+++ b/sdk/packages/core/src/auth/provider-auth-registry.test.ts
@@ -174,6 +174,94 @@ describe("provider auth registry", () => {
 		);
 	});
 
+	it("login/save preserves existing auth metadata when incoming metadata is missing", async () => {
+		loginClineOAuth.mockResolvedValueOnce({
+			access: "new-access",
+			refresh: "new-refresh",
+			expires: 4_000_000_000_000,
+			accountId: "acct-new",
+		});
+		const getProviderSettings = vi.fn().mockReturnValue({
+			provider: "cline",
+			auth: {
+				accessToken: "workos:old-access",
+				refreshToken: "old-refresh",
+				accountId: "acct-old",
+				metadata: {
+					provider: "workos",
+					sessionStartedAt: 1_700_000_000_003,
+				},
+			},
+		});
+		const saveProviderSettings = vi.fn();
+		const manager = {
+			getProviderSettings,
+			saveProviderSettings,
+		} as never;
+
+		const saved = await loginAndSaveProviderOAuthCredentials(manager, "cline", {
+			callbacks: {
+				onAuth: vi.fn(),
+				onPrompt: vi.fn(async () => ""),
+			},
+		});
+
+		expect(saved).toMatchObject({
+			auth: {
+				accessToken: "workos:new-access",
+				metadata: {
+					provider: "workos",
+					sessionStartedAt: 1_700_000_000_003,
+				},
+			},
+		});
+	});
+
+	it("login/save does not let undefined incoming metadata erase existing metadata", async () => {
+		loginClineOAuth.mockResolvedValueOnce({
+			access: "new-access",
+			refresh: "new-refresh",
+			expires: 4_000_000_000_000,
+			accountId: "acct-new",
+			metadata: { provider: undefined, tokenType: "Bearer" },
+		});
+		const getProviderSettings = vi.fn().mockReturnValue({
+			provider: "cline",
+			auth: {
+				accessToken: "workos:old-access",
+				refreshToken: "old-refresh",
+				accountId: "acct-old",
+				metadata: {
+					provider: "workos",
+					sessionStartedAt: 1_700_000_000_004,
+				},
+			},
+		});
+		const saveProviderSettings = vi.fn();
+		const manager = {
+			getProviderSettings,
+			saveProviderSettings,
+		} as never;
+
+		const saved = await loginAndSaveProviderOAuthCredentials(manager, "cline", {
+			callbacks: {
+				onAuth: vi.fn(),
+				onPrompt: vi.fn(async () => ""),
+			},
+		});
+
+		expect(saved).toMatchObject({
+			auth: {
+				accessToken: "workos:new-access",
+				metadata: {
+					provider: "workos",
+					sessionStartedAt: 1_700_000_000_004,
+					tokenType: "Bearer",
+				},
+			},
+		});
+	});
+
 	it("reads persisted auth metadata back into OAuth credentials", () => {
 		const handler = getProviderAuthHandler("cline")
 		const credentials = handler && getProviderOAuthCredentialsFromSettings("cline", {

--- a/sdk/packages/core/src/auth/provider-auth-registry.ts
+++ b/sdk/packages/core/src/auth/provider-auth-registry.ts
@@ -139,8 +139,14 @@ function saveOAuthCredentials(input: {
 		accountId: input.credentials.accountId,
 		expiresAt: input.credentials.expires,
 	};
-	if (input.credentials.metadata) {
-		auth.metadata = input.credentials.metadata;
+	const incomingMetadata = Object.fromEntries(
+		Object.entries(input.credentials.metadata ?? {}).filter(
+			([, value]) => value !== undefined,
+		),
+	);
+	const metadata = { ...(input.settings?.auth?.metadata ?? {}), ...incomingMetadata };
+	if (Object.keys(metadata).length > 0) {
+		auth.metadata = metadata;
 	}
 
 	const merged: ProviderSettings = {

--- a/sdk/packages/core/src/auth/provider-auth-registry.ts
+++ b/sdk/packages/core/src/auth/provider-auth-registry.ts
@@ -116,6 +116,7 @@ function createCredentialsFromSettings(
 		refresh: refreshToken,
 		expires: deriveCredentialExpiry(settings, access),
 		accountId: settings.auth?.accountId,
+		metadata: settings.auth?.metadata,
 	};
 }
 
@@ -131,13 +132,16 @@ function saveOAuthCredentials(input: {
 	const accessToken =
 		input.formatAccessToken?.(input.credentials.access) ??
 		input.credentials.access;
-	const auth = {
+	const auth: NonNullable<ProviderSettings["auth"]> = {
 		...(input.settings?.auth ?? {}),
 		accessToken,
 		refreshToken: input.credentials.refresh,
 		accountId: input.credentials.accountId,
 		expiresAt: input.credentials.expires,
 	};
+	if (input.credentials.metadata) {
+		auth.metadata = input.credentials.metadata;
+	}
 
 	const merged: ProviderSettings = {
 		...(input.settings ?? {

--- a/sdk/packages/core/src/services/llms/provider-settings.ts
+++ b/sdk/packages/core/src/services/llms/provider-settings.ts
@@ -59,6 +59,7 @@ export const AuthSettingsSchema = z.object({
 	refreshToken: z.string().optional(),
 	expiresAt: z.number().int().positive().optional(),
 	accountId: z.string().optional(),
+	metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
 export type AuthSettings = z.infer<typeof AuthSettingsSchema>;


### PR DESCRIPTION
### Description

I want the startedAt metadata to make problematic logs easier to fix. Sessions that get logged out despite having started only recently should be investigated.

This PR only introduces the metadata; I will include it in the events in another PR I have that already adds some other properties to the events.

### Test Procedure

Tested locally
<img width="403" height="154" alt="image" src="https://github.com/user-attachments/assets/185eb89a-71c4-41b3-bd2a-272b0ae33d04" />


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)