### PR TITLE
fix(cli): support Windows x64 CPUs without AVX2

### DIFF
--- a/apps/cli/script/build.ts
+++ b/apps/cli/script/build.ts
@@ -164,6 +164,9 @@ function getBunTarget(
 	item: (typeof allTargets)[number],
 ): Bun.Build.CompileTarget {
 	const targetOs = item.os === "win32" ? "windows" : item.os;
+	if (targetOs === "windows" && item.arch === "x64") {
+		return "bun-windows-x64-baseline";
+	}
 	return `bun-${targetOs}-${item.arch}` as Bun.Build.CompileTarget;
 }
 
@@ -218,7 +221,10 @@ async function buildCompiledBinary(input: {
 		process.exit(1);
 	}
 
-	await $`cp ${tmpOutfile} ${input.outfile} && chmod 755 ${input.outfile}`;
+	await $`cp ${tmpOutfile} ${input.outfile}`;
+	if (targetOs !== "windows") {
+		await $`chmod 755 ${input.outfile}`;
+	}
 	await $`rm -rf ${tmpDir}`;
 }
 


### PR DESCRIPTION
## Summary

- compile the existing Windows x64 CLI package with Bun's `bun-windows-x64-baseline` target
- avoid running POSIX `chmod` when the build itself runs on Windows

## Root cause and impact

The published `@cline/cli-windows-x64` binary is currently compiled with Bun's standard x64 target, which requires AVX2. On an Intel Core i7-3770 (Ivy Bridge, AVX but no AVX2), Cline CLI 3.0.40 terminates before it can print `--version` (Windows exit status `0xC0000005`). The same source compiled with Bun 1.3.13's baseline target starts normally.

Using the baseline target for the existing Windows x64 package preserves the current package and resolver contract while allowing Cline to start on pre-Haswell Windows CPUs. The `chmod` split is needed because the existing combined `cp && chmod` post-build step fails on native Windows even after compilation succeeds.

## Validation

Tested on Windows 11 x64 with an Intel Core i7-3770:

- SDK packages built successfully
- `bun script/build.ts --single --skip-sdk-build` completed and its built-in `cline.exe --version` smoke test printed `3.0.40`
- the baseline binary passed `--version`, `--help`, and `doctor`
- `apps/cli` TypeScript typecheck passed
- repository pre-commit Gitleaks and lint-staged hooks passed
- the full CLI unit suite was attempted, but did not terminate within ten minutes on this host; it is therefore not claimed as passing here

## Related work

This is the Windows counterpart to the Linux baseline/resolver work in #11412 and adds Windows reproduction evidence for #11539.