### PR TITLE
Rename sessionStartedAt to sessionStartedAtMs

### DIFF
--- a/apps/vscode/src/sdk/auth-service.test.ts
+++ b/apps/vscode/src/sdk/auth-service.test.ts
@@ -202,7 +202,7 @@ function createTestOAuthCredentials(): OAuthCredentials {
 		email: "oauth@example.com",
 		metadata: {
 			provider: "workos",
-			sessionStartedAt: 1_700_000_000_000,
+			sessionStartedAtMs: 1_700_000_000_000,
 			tokenType: "Bearer",
 			userInfo: { email: "oauth@example.com" },
 		},
@@ -394,7 +394,7 @@ describe("AuthService", () => {
 			const persisted = mockProviderSettings.get("cline") as { auth?: { metadata?: Record<string, unknown> } }
 			expect(persisted.auth?.metadata).toMatchObject({
 				provider: "workos",
-				sessionStartedAt: 1_700_000_000_000,
+				sessionStartedAtMs: 1_700_000_000_000,
 				tokenType: "Bearer",
 				userInfo: { email: "oauth@example.com" },
 			})
@@ -472,7 +472,7 @@ describe("AuthService", () => {
 					accountId: "user-123",
 					metadata: {
 						provider: "workos",
-						sessionStartedAt: 1_700_000_000_000,
+						sessionStartedAtMs: 1_700_000_000_000,
 						tokenType: "Bearer",
 					},
 				},
@@ -485,7 +485,7 @@ describe("AuthService", () => {
 				email: "test@example.com",
 				metadata: {
 					provider: undefined,
-					sessionStartedAt: 1_700_000_000_000,
+					sessionStartedAtMs: 1_700_000_000_000,
 					tokenType: "Bearer",
 				},
 			})
@@ -495,7 +495,7 @@ describe("AuthService", () => {
 			const persisted = mockProviderSettings.get("cline") as { auth?: { metadata?: Record<string, unknown> } }
 			expect(persisted.auth?.metadata).toMatchObject({
 				provider: "workos",
-				sessionStartedAt: 1_700_000_000_000,
+				sessionStartedAtMs: 1_700_000_000_000,
 				tokenType: "Bearer",
 			})
 		})

--- a/apps/vscode/src/sdk/auth-service.ts
+++ b/apps/vscode/src/sdk/auth-service.ts
@@ -93,10 +93,10 @@ function getAuthMetadata(auth: ProviderSettings["auth"]): AuthMetadata | undefin
 	return metadata && typeof metadata === "object" && !Array.isArray(metadata) ? (metadata as AuthMetadata) : undefined
 }
 
-function readSessionStartedAt(metadata: AuthMetadata | undefined): number | undefined {
+function readSessionStartedAtMs(metadata: AuthMetadata | undefined): number | undefined {
 	if (!metadata) return undefined
 
-	const value = metadata.sessionStartedAt
+	const value = metadata.sessionStartedAtMs
 	return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined
 }
 
@@ -113,7 +113,7 @@ function readClineCredentials(): {
 	refreshToken?: string
 	expiresAt?: number // milliseconds since epoch (providers.json convention)
 	accountId?: string
-	sessionStartedAt?: number // milliseconds since epoch
+	sessionStartedAtMs?: number // milliseconds since epoch
 } | null {
 	try {
 		const manager = getProviderSettingsManager()
@@ -134,10 +134,10 @@ function readClineCredentials(): {
 			refreshToken: settings.auth.refreshToken,
 			expiresAt: (settings.auth as { expiresAt?: number }).expiresAt,
 			accountId: settings.auth.accountId,
-			sessionStartedAt: readSessionStartedAt(getAuthMetadata(settings.auth)),
+			sessionStartedAtMs: readSessionStartedAtMs(getAuthMetadata(settings.auth)),
 		}
 		sdkDebug(
-			`[SdkAuthService] readClineCredentials: found credentials (accessHash=${hashSecret(result.accessToken)}, refreshHash=${hashSecret(result.refreshToken)}, expiresAt=${result.expiresAt}, sessionStartedAt=${result.sessionStartedAt})`,
+			`[SdkAuthService] readClineCredentials: found credentials (accessHash=${hashSecret(result.accessToken)}, refreshHash=${hashSecret(result.refreshToken)}, expiresAt=${result.expiresAt}, sessionStartedAtMs=${result.sessionStartedAtMs})`,
 		)
 		return result
 	} catch (error) {
@@ -155,14 +155,16 @@ function writeClineCredentials(credentials: {
 	expiresAt?: number // milliseconds since epoch
 	accountId?: string
 	metadata?: AuthMetadata
-	sessionStartedAt?: number // milliseconds since epoch
+	sessionStartedAtMs?: number // milliseconds since epoch
 }): void {
 	try {
 		const manager = getProviderSettingsManager()
 		const existing = manager.getProviderSettings("cline")
 		const existingMetadata = getAuthMetadata(existing?.auth)
-		const sessionStartedAt =
-			credentials.sessionStartedAt ?? readSessionStartedAt(credentials.metadata) ?? readSessionStartedAt(existingMetadata)
+		const sessionStartedAtMs =
+			credentials.sessionStartedAtMs ??
+			readSessionStartedAtMs(credentials.metadata) ??
+			readSessionStartedAtMs(existingMetadata)
 
 		const auth = {
 			...(existing?.auth ?? {}),
@@ -175,8 +177,8 @@ function writeClineCredentials(credentials: {
 		)
 		const metadata = { ...(existingMetadata ?? {}), ...incomingMetadata }
 		delete metadata.startedAt
-		if (sessionStartedAt !== undefined) {
-			metadata.sessionStartedAt = sessionStartedAt
+		if (sessionStartedAtMs !== undefined) {
+			metadata.sessionStartedAtMs = sessionStartedAtMs
 		}
 		if (Object.keys(metadata).length > 0) {
 			auth.metadata = metadata
@@ -194,7 +196,7 @@ function writeClineCredentials(credentials: {
 			{ tokenSource: "oauth", setLastUsed: true },
 		)
 		sdkDebug(
-			`[SdkAuthService] writeClineCredentials: wrote (accessHash=${hashSecret(credentials.accessToken)}, refreshHash=${hashSecret(credentials.refreshToken)}, expiresAt=${credentials.expiresAt}, sessionStartedAt=${sessionStartedAt})`,
+			`[SdkAuthService] writeClineCredentials: wrote (accessHash=${hashSecret(credentials.accessToken)}, refreshHash=${hashSecret(credentials.refreshToken)}, expiresAt=${credentials.expiresAt}, sessionStartedAtMs=${sessionStartedAtMs})`,
 		)
 	} catch (error) {
 		Logger.error("[SdkAuthService] Failed to write credentials to providers.json:", error)
@@ -276,7 +278,7 @@ export class AuthService {
 	private async credentialsToAuthInfo(credentials: OAuthCredentials, provider: string): Promise<ClineAuthInfo> {
 		// Fetch full user info from the API using the access token
 		const userInfo = await this.fetchUserInfoFromApi(credentials.access)
-		const startedAt = readSessionStartedAt(credentials.metadata)
+		const startedAt = readSessionStartedAtMs(credentials.metadata)
 
 		return {
 			idToken: credentials.access,
@@ -329,7 +331,7 @@ export class AuthService {
 			expires: authInfo.expiresAt ? authInfo.expiresAt * 1000 : 0,
 			accountId: authInfo.userInfo.id || undefined,
 			email: authInfo.userInfo.email || undefined,
-			metadata: authInfo.startedAt ? { sessionStartedAt: authInfo.startedAt } : undefined,
+			metadata: authInfo.startedAt ? { sessionStartedAtMs: authInfo.startedAt } : undefined,
 		}
 	}
 
@@ -444,7 +446,7 @@ export class AuthService {
 						expiresAt: newCredentials.expires,
 						accountId: this._clineAuthInfo.userInfo.id,
 						metadata: newCredentials.metadata,
-						sessionStartedAt: readSessionStartedAt(newCredentials.metadata),
+						sessionStartedAtMs: readSessionStartedAtMs(newCredentials.metadata),
 					})
 
 					setImmediate(() => {
@@ -577,7 +579,7 @@ export class AuthService {
 					expiresAt: credentials.expires,
 					accountId: authInfo.userInfo.id || credentials.accountId,
 					metadata: credentials.metadata,
-					sessionStartedAt: authInfo.startedAt,
+					sessionStartedAtMs: authInfo.startedAt,
 				})
 
 				// Push auth state update
@@ -629,7 +631,7 @@ export class AuthService {
 			throw new Error("Invalid response from mock server")
 		}
 
-		const sessionStartedAt = Date.now()
+		const sessionStartedAtMs = Date.now()
 		this._clineAuthInfo = {
 			idToken: tokenData.accessToken,
 			refreshToken: tokenData.refreshToken,
@@ -644,7 +646,7 @@ export class AuthService {
 				subject: tokenData.userInfo?.subject,
 			},
 			provider: "cline",
-			startedAt: sessionStartedAt,
+			startedAt: sessionStartedAtMs,
 		}
 		this._authenticated = true
 
@@ -655,8 +657,8 @@ export class AuthService {
 			refreshToken: tokenData.refreshToken,
 			expiresAt: new Date(tokenData.expiresAt).getTime(),
 			accountId: this._clineAuthInfo.userInfo.id,
-			metadata: { sessionStartedAt },
-			sessionStartedAt,
+			metadata: { sessionStartedAtMs },
+			sessionStartedAtMs,
 		})
 
 		await this.sendAuthStatusUpdate()
@@ -693,7 +695,7 @@ export class AuthService {
 				expiresAt: credentials.expires,
 				accountId: authInfo.userInfo.id || credentials.accountId,
 				metadata: credentials.metadata,
-				sessionStartedAt: authInfo.startedAt,
+				sessionStartedAtMs: authInfo.startedAt,
 			})
 
 			await this.sendAuthStatusUpdate()
@@ -856,7 +858,7 @@ export class AuthService {
 			// Fetch full user info
 			const userInfo = await this.fetchUserInfoFromApi(tokenData.accessToken)
 
-			const sessionStartedAt = Date.now()
+			const sessionStartedAtMs = Date.now()
 			const authInfo: ClineAuthInfo = {
 				idToken: tokenData.accessToken,
 				refreshToken: tokenData.refreshToken,
@@ -869,7 +871,7 @@ export class AuthService {
 				},
 				expiresAt: new Date(tokenData.expiresAt).getTime() / 1000,
 				provider: "cline",
-				startedAt: sessionStartedAt,
+				startedAt: sessionStartedAtMs,
 			}
 
 			this._clineAuthInfo = authInfo
@@ -883,11 +885,11 @@ export class AuthService {
 				accountId: authInfo.userInfo.id,
 				metadata: {
 					provider,
-					sessionStartedAt,
+					sessionStartedAtMs,
 					tokenType: tokenData.tokenType,
 					userInfo: tokenData.userInfo,
 				},
-				sessionStartedAt,
+				sessionStartedAtMs,
 			})
 
 			await this.sendAuthStatusUpdate()
@@ -935,7 +937,7 @@ export class AuthService {
 					organizations: [],
 				},
 				provider: "cline",
-				startedAt: creds.sessionStartedAt,
+				startedAt: creds.sessionStartedAtMs,
 			}
 
 			const validCredentials = await this.resolveValidClineCredentials(restoredAuthInfo)
@@ -953,7 +955,7 @@ export class AuthService {
 				expiresAt: validCredentials.expires,
 				accountId: validCredentials.accountId ?? restoredAuthInfo.userInfo.id,
 				metadata: validCredentials.metadata,
-				sessionStartedAt: readSessionStartedAt(validCredentials.metadata),
+				sessionStartedAtMs: readSessionStartedAtMs(validCredentials.metadata),
 			})
 
 			this._clineAuthInfo = {

--- a/sdk/packages/core/src/auth/cline.test.ts
+++ b/sdk/packages/core/src/auth/cline.test.ts
@@ -43,7 +43,7 @@ describe("auth/cline getValidClineCredentials", () => {
 		const nowSpy = vi.spyOn(Date, "now").mockReturnValue(100_000);
 		const current = createCredentials({
 			expires: 101_000,
-			metadata: { provider: "google", sessionStartedAt: 12_345 },
+			metadata: { provider: "google", sessionStartedAtMs: 12_345 },
 		});
 		const fetchMock = vi.fn(
 			async () =>
@@ -77,14 +77,14 @@ describe("auth/cline getValidClineCredentials", () => {
 			email: "new@example.com",
 			metadata: {
 				provider: "google",
-				sessionStartedAt: 12_345,
+				sessionStartedAtMs: 12_345,
 				tokenType: "Bearer",
 			},
 		});
 		nowSpy.mockRestore();
 	});
 
-	it("does not add sessionStartedAt when refreshing credentials that do not already have it", async () => {
+	it("does not add sessionStartedAtMs when refreshing credentials that do not already have it", async () => {
 		const nowSpy = vi.spyOn(Date, "now").mockReturnValue(100_000);
 		const current = createCredentials({
 			expires: 101_000,
@@ -119,7 +119,7 @@ describe("auth/cline getValidClineCredentials", () => {
 			provider: "google",
 			tokenType: "Bearer",
 		});
-		expect(result?.metadata).not.toHaveProperty("sessionStartedAt");
+		expect(result?.metadata).not.toHaveProperty("sessionStartedAtMs");
 		nowSpy.mockRestore();
 	});
 
@@ -320,7 +320,7 @@ describe("auth/cline loginClineOAuth", () => {
 			accountId: "acct-1",
 			email: "user@example.com",
 			metadata: {
-				sessionStartedAt: 200_000,
+				sessionStartedAtMs: 200_000,
 				tokenType: "Bearer",
 			},
 		});

--- a/sdk/packages/core/src/auth/cline.ts
+++ b/sdk/packages/core/src/auth/cline.ts
@@ -391,7 +391,7 @@ async function registerWorkOSTokens(
 	return toClineCredentials(
 		requireClineTokenResponse(json, "Invalid token exchange response"),
 		provider ?? options.provider,
-		{ metadata: { sessionStartedAt: Date.now() } },
+		{ metadata: { sessionStartedAtMs: Date.now() } },
 	);
 }
 
@@ -437,7 +437,7 @@ async function exchangeAuthorizationCode(
 	return toClineCredentials(
 		requireClineTokenResponse(json, "Invalid token exchange response"),
 		provider ?? options.provider,
-		{ metadata: { sessionStartedAt: Date.now() } },
+		{ metadata: { sessionStartedAtMs: Date.now() } },
 	);
 }
 

--- a/sdk/packages/core/src/auth/provider-auth-registry.test.ts
+++ b/sdk/packages/core/src/auth/provider-auth-registry.test.ts
@@ -77,7 +77,7 @@ describe("provider auth registry", () => {
 			refresh: "new-refresh",
 			expires: 4_000_000_000_000,
 			accountId: "acct-new",
-			metadata: { sessionStartedAt: 1_700_000_000_000 },
+			metadata: { sessionStartedAtMs: 1_700_000_000_000 },
 		});
 		const getProviderSettings = vi.fn().mockReturnValue({
 			provider: "cline",
@@ -109,7 +109,7 @@ describe("provider auth registry", () => {
 				refreshToken: "new-refresh",
 				accountId: "acct-new",
 				expiresAt: 4_000_000_000_000,
-				metadata: { sessionStartedAt: 1_700_000_000_000 },
+				metadata: { sessionStartedAtMs: 1_700_000_000_000 },
 			},
 		});
 		expect(saveProviderSettings).toHaveBeenCalledWith(
@@ -137,7 +137,7 @@ describe("provider auth registry", () => {
 			refresh: "new-refresh",
 			expires: 4_000_000_000_000,
 			accountId: "acct-new",
-			metadata: { sessionStartedAt: 1_700_000_000_001 },
+			metadata: { sessionStartedAtMs: 1_700_000_000_001 },
 		});
 		const getProviderSettings = vi.fn().mockReturnValue({
 			provider: "cline",
@@ -165,7 +165,7 @@ describe("provider auth registry", () => {
 				refreshToken: "new-refresh",
 				accountId: "acct-new",
 				expiresAt: 4_000_000_000_000,
-				metadata: { sessionStartedAt: 1_700_000_000_001 },
+				metadata: { sessionStartedAtMs: 1_700_000_000_001 },
 			},
 		});
 		expect(saveProviderSettings).toHaveBeenCalledWith(
@@ -189,7 +189,7 @@ describe("provider auth registry", () => {
 				accountId: "acct-old",
 				metadata: {
 					provider: "workos",
-					sessionStartedAt: 1_700_000_000_003,
+					sessionStartedAtMs: 1_700_000_000_003,
 				},
 			},
 		});
@@ -211,7 +211,7 @@ describe("provider auth registry", () => {
 				accessToken: "workos:new-access",
 				metadata: {
 					provider: "workos",
-					sessionStartedAt: 1_700_000_000_003,
+					sessionStartedAtMs: 1_700_000_000_003,
 				},
 			},
 		});
@@ -233,7 +233,7 @@ describe("provider auth registry", () => {
 				accountId: "acct-old",
 				metadata: {
 					provider: "workos",
-					sessionStartedAt: 1_700_000_000_004,
+					sessionStartedAtMs: 1_700_000_000_004,
 				},
 			},
 		});
@@ -255,7 +255,7 @@ describe("provider auth registry", () => {
 				accessToken: "workos:new-access",
 				metadata: {
 					provider: "workos",
-					sessionStartedAt: 1_700_000_000_004,
+					sessionStartedAtMs: 1_700_000_000_004,
 					tokenType: "Bearer",
 				},
 			},
@@ -263,23 +263,25 @@ describe("provider auth registry", () => {
 	});
 
 	it("reads persisted auth metadata back into OAuth credentials", () => {
-		const handler = getProviderAuthHandler("cline")
-		const credentials = handler && getProviderOAuthCredentialsFromSettings("cline", {
-			provider: "cline",
-			auth: {
-				accessToken: "workos:stored-access",
-				refreshToken: "stored-refresh",
-				expiresAt: 4_000_000_000_000,
-				accountId: "acct-stored",
-				metadata: { sessionStartedAt: 1_700_000_000_002 },
-			},
-		})
+		const handler = getProviderAuthHandler("cline");
+		const credentials =
+			handler &&
+			getProviderOAuthCredentialsFromSettings("cline", {
+				provider: "cline",
+				auth: {
+					accessToken: "workos:stored-access",
+					refreshToken: "stored-refresh",
+					expiresAt: 4_000_000_000_000,
+					accountId: "acct-stored",
+					metadata: { sessionStartedAtMs: 1_700_000_000_002 },
+				},
+			});
 
 		expect(credentials).toMatchObject({
 			access: "stored-access",
 			refresh: "stored-refresh",
 			accountId: "acct-stored",
-			metadata: { sessionStartedAt: 1_700_000_000_002 },
-		})
+			metadata: { sessionStartedAtMs: 1_700_000_000_002 },
+		});
 	});
 });


### PR DESCRIPTION
Small PR to rename the sessionStartedAt to sessionStartedAtMs. We weren't using it anywhere, and we haven't deployed the PR that adds it to the Cline provider, so we won't be losing data by not migrating it.