### PR TITLE
fix(vscode): clear stale thinking after mode changes

### DIFF
--- a/apps/vscode/src/sdk/sdk-message-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-message-coordinator.test.ts
@@ -66,6 +66,16 @@ describe("SdkMessageCoordinator", () => {
 		expect(JSON.parse(finalized[2].text ?? "{}")).toEqual({ cancelReason: "user_cancelled" })
 	})
 
+	it("preserves a specific cancellation reason for mode changes", () => {
+		const coordinator = new SdkMessageCoordinator({ getTask: () => undefined })
+		const finalized = coordinator.finalizeMessagesForSave(
+			[{ ts: 1, type: "say", say: "api_req_started", text: JSON.stringify({}), partial: true }],
+			"mode_changed",
+		)
+
+		expect(JSON.parse(finalized[0].text ?? "{}")).toEqual({ cancelReason: "mode_changed" })
+	})
+
 	it("stamps seq and epoch from the shared minter on append", () => {
 		const minter = new MessageIdMinter()
 		const task = createTaskProxy("session-123", vi.fn(), vi.fn())

--- a/apps/vscode/src/sdk/sdk-message-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-message-coordinator.ts
@@ -110,7 +110,10 @@ export class SdkMessageCoordinator {
 	 * - Strips `partial` flags so the UI doesn't show a streaming/cancel state
 	 * - Updates the last `api_req_started` with a cancel reason if it has no cost
 	 */
-	finalizeMessagesForSave(messages: ClineMessage[]): ClineMessage[] {
+	finalizeMessagesForSave(
+		messages: ClineMessage[],
+		cancelReason: ClineApiReqInfo["cancelReason"] = "user_cancelled",
+	): ClineMessage[] {
 		return messages.map((msg, index) => {
 			const updated = { ...msg }
 
@@ -124,7 +127,7 @@ export class SdkMessageCoordinator {
 					if (info.cost === undefined && info.cancelReason === undefined) {
 						const isLast = !messages.slice(index + 1).some((m) => m.type === "say" && m.say === "api_req_started")
 						if (isLast) {
-							info.cancelReason = "user_cancelled"
+							info.cancelReason = cancelReason
 							updated.text = JSON.stringify(info)
 						}
 					}

--- a/apps/vscode/src/sdk/sdk-mode-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-mode-coordinator.test.ts
@@ -466,7 +466,10 @@ describe("SdkModeCoordinator", () => {
 		expect(options.messages.cancelPendingSave).toHaveBeenCalledOnce()
 		expect(activeSession.sdkHost.abort).toHaveBeenCalledWith("old-session")
 		expect(options.sessions.setRunning).toHaveBeenCalledWith(false)
-		expect(options.messages.finalizeMessagesForSave).toHaveBeenCalledWith(task.messageStateHandler.getClineMessages())
+		expect(options.messages.finalizeMessagesForSave).toHaveBeenCalledWith(
+			task.messageStateHandler.getClineMessages(),
+			"mode_changed",
+		)
 		expect(options.messages.appendMessages).toHaveBeenCalledWith([{ ts: 1, type: "say", say: "text", text: "done" }])
 	})
 

--- a/apps/vscode/src/sdk/sdk-mode-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-mode-coordinator.ts
@@ -396,7 +396,7 @@ export class SdkModeCoordinator {
 		}
 
 		const current = task.messageStateHandler.getClineMessages()
-		const finalized = this.options.messages.finalizeMessagesForSave(current)
+		const finalized = this.options.messages.finalizeMessagesForSave(current, "mode_changed")
 		this.options.messages.appendMessages(finalized)
 	}
 }

--- a/apps/vscode/src/shared/ExtensionMessage.ts
+++ b/apps/vscode/src/shared/ExtensionMessage.ts
@@ -380,6 +380,6 @@ export interface ClineSubagentUsageInfo {
 	cost: number
 }
 
-type ClineApiReqCancelReason = "streaming_failed" | "user_cancelled" | "retries_exhausted"
+type ClineApiReqCancelReason = "streaming_failed" | "user_cancelled" | "mode_changed" | "retries_exhausted"
 
 export const COMPLETION_RESULT_CHANGES_FLAG = "HAS_CHANGES"

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/utils/messageUtils.test.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/utils/messageUtils.test.ts
@@ -1,6 +1,12 @@
 import type { ClineMessage } from "@shared/ExtensionMessage"
 import { describe, expect, it } from "vitest"
-import { canRestoreWorkspaceFromMessage, filterVisibleMessages, groupLowStakesTools, isToolGroup } from "./messageUtils"
+import {
+	canRestoreWorkspaceFromMessage,
+	filterVisibleMessages,
+	findReasoningForApiReq,
+	groupLowStakesTools,
+	isToolGroup,
+} from "./messageUtils"
 
 const createTextMessage = (ts: number, text: string): ClineMessage => ({
 	type: "say",
@@ -52,6 +58,34 @@ const createAskMessage = (
 })
 
 describe("filterVisibleMessages", () => {
+	it("hides reasoning from a request cancelled by a mode change", () => {
+		const messages: ClineMessage[] = [
+			{
+				type: "say",
+				say: "api_req_started",
+				text: JSON.stringify({ cancelReason: "mode_changed" }),
+				ts: 1,
+			},
+			createReasoningMessage(2, "stale thinking"),
+		]
+
+		expect(filterVisibleMessages(messages)).toEqual([messages[0]])
+	})
+
+	it("keeps reasoning from a regular user-cancelled request", () => {
+		const messages: ClineMessage[] = [
+			{
+				type: "say",
+				say: "api_req_started",
+				text: JSON.stringify({ cancelReason: "user_cancelled" }),
+				ts: 1,
+			},
+			createReasoningMessage(2, "user-visible thinking"),
+		]
+
+		expect(filterVisibleMessages(messages)).toEqual(messages)
+	})
+
 	it("hides exact user feedback echoes for selected follow-up options", () => {
 		const askMessage = createAskMessage(1, "followup", ["Use this", "Use that"], "Use this")
 		const visible = filterVisibleMessages([askMessage, createUserFeedbackMessage(2, "Use this")])
@@ -90,6 +124,22 @@ describe("filterVisibleMessages", () => {
 		const visible = filterVisibleMessages([askMessage, userMessage])
 
 		expect(visible).toEqual([askMessage, userMessage])
+	})
+})
+
+describe("findReasoningForApiReq", () => {
+	it("does not report reasoning from a request cancelled by a mode change", () => {
+		const messages: ClineMessage[] = [
+			{
+				type: "say",
+				say: "api_req_started",
+				text: JSON.stringify({ cancelReason: "mode_changed" }),
+				ts: 1,
+			},
+			createReasoningMessage(2, "stale thinking"),
+		]
+
+		expect(findReasoningForApiReq(1, messages)).toEqual({ reasoning: undefined, responseStarted: false })
 	})
 })
 

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/utils/messageUtils.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/utils/messageUtils.ts
@@ -159,6 +159,22 @@ export function filterVisibleMessages(messages: ClineMessage[]): ClineMessage[] 
 				}
 				return false
 			}
+			case "reasoning": {
+				// A mode change cancels the in-flight request before rebuilding the
+				// session. Do not keep rendering that request's stale thinking row.
+				for (let i = index - 1; i >= 0; i--) {
+					const previous = arr[i]
+					if (previous.say !== "api_req_started") {
+						continue
+					}
+					try {
+						return JSON.parse(previous.text || "{}").cancelReason !== "mode_changed"
+					} catch {
+						return true
+					}
+				}
+				break
+			}
 			case "text":
 				// Sometimes cline returns an empty text message, we don't want to render these. (We also use a say text for user messages, so in case they just sent images we still render that)
 				if ((message.text ?? "") === "" && (message.images?.length ?? 0) === 0) {
@@ -276,6 +292,15 @@ export function findReasoningForApiReq(
 	const apiReqIndex = allMessages.findIndex((m) => m.ts === apiReqTs && m.say === "api_req_started")
 	if (apiReqIndex === -1) {
 		return { reasoning: undefined, responseStarted: false }
+	}
+
+	try {
+		const requestInfo = JSON.parse(allMessages[apiReqIndex].text || "{}")
+		if (requestInfo.cancelReason === "mode_changed") {
+			return { reasoning: undefined, responseStarted: false }
+		}
+	} catch {
+		// Preserve the existing tolerant behavior for legacy request metadata.
 	}
 
 	// Collect reasoning and check if response content has started


### PR DESCRIPTION
### Related Issue

Fixes #12265

### Description

Switching Plan/Act mode while a request is actively reasoning cancels the old session and rebuilds it. The old `api_req_started` message was finalized as a generic cancellation, but its reasoning messages remained associated with the request, so the webview continued to show a stale Thinking state after the mode switch.

This change gives mode-change cancellation its own `mode_changed` reason. The webview then suppresses reasoning associated with that canceled request in both rendering paths:

- the synthetic reasoning state derived by `findReasoningForApiReq`
- standalone reasoning messages filtered by `filterVisibleMessages`

Regular user-cancelled reasoning remains unchanged.

### Test Procedure

- `bun test src/components/chat/chat-view/utils/messageUtils.test.ts` from `apps/vscode/webview-ui`
- `bun test src/sdk/sdk-mode-coordinator.test.ts src/sdk/sdk-message-coordinator.test.ts` from `apps/vscode`
- `bun -F @cline/vscode typecheck`
- `git diff --check`

All focused tests and typecheck passed.