### PR TITLE
fix(vscode): handle cumulative OpenAI usage chunks

### DIFF
--- a/apps/vscode/src/core/api/providers/__tests__/openai.test.ts
+++ b/apps/vscode/src/core/api/providers/__tests__/openai.test.ts
@@ -1,0 +1,104 @@
+import "should"
+import type OpenAI from "openai"
+import sinon from "sinon"
+import type { ApiStreamChunk } from "../../transform/stream"
+import { OpenAiHandler } from "../openai"
+
+describe("OpenAiHandler", () => {
+	afterEach(() => {
+		sinon.restore()
+	})
+
+	const createAsyncIterable = (data: unknown[] = []) => ({
+		[Symbol.asyncIterator]: async function* () {
+			yield* data
+		},
+	})
+
+	const createHandler = (chunks: unknown[]) => {
+		const handler = new OpenAiHandler({
+			openAiApiKey: "test-api-key",
+			openAiModelId: "test-model",
+		})
+		const fakeClient = {
+			chat: {
+				completions: {
+					create: sinon.stub().resolves(createAsyncIterable(chunks)),
+				},
+			},
+		}
+		sinon.stub(handler as unknown as { ensureClient: () => OpenAI }, "ensureClient").returns(fakeClient as unknown as OpenAI)
+		return handler
+	}
+
+	it("should emit the latest cumulative usage snapshot only once", async () => {
+		const handler = createHandler([
+			{
+				choices: [{ delta: { content: "O" } }],
+				usage: {
+					prompt_tokens: 48,
+					completion_tokens: 1,
+					total_tokens: 49,
+					prompt_tokens_details: { cached_tokens: 32 },
+				},
+			},
+			{
+				choices: [{ delta: { content: "K" } }],
+				usage: {
+					prompt_tokens: 48,
+					completion_tokens: 2,
+					total_tokens: 50,
+					prompt_tokens_details: { cached_tokens: 32 },
+				},
+			},
+			{ choices: [{ delta: {}, finish_reason: "stop" }], usage: null },
+		])
+
+		const chunks: ApiStreamChunk[] = []
+		for await (const chunk of handler.createMessage("system", [{ role: "user", content: "hi" }])) {
+			chunks.push(chunk)
+		}
+
+		chunks.should.deepEqual([
+			{ type: "text", text: "O" },
+			{ type: "text", text: "K" },
+			{
+				type: "usage",
+				inputTokens: 48,
+				outputTokens: 2,
+				cacheReadTokens: 32,
+				cacheWriteTokens: 0,
+			},
+		])
+	})
+
+	it("should preserve providers that emit usage only on the final chunk", async () => {
+		const handler = createHandler([
+			{ choices: [{ delta: { content: "OK" } }] },
+			{
+				choices: [],
+				usage: {
+					prompt_tokens: 17,
+					completion_tokens: 9,
+					total_tokens: 26,
+				},
+			},
+		])
+
+		const chunks: ApiStreamChunk[] = []
+		for await (const chunk of handler.createMessage("system", [{ role: "user", content: "hi" }])) {
+			chunks.push(chunk)
+		}
+
+		chunks.should.deepEqual([
+			{ type: "text", text: "OK" },
+			{
+				type: "usage",
+				inputTokens: 17,
+				outputTokens: 9,
+				cacheReadTokens: 0,
+				cacheWriteTokens: 0,
+			},
+		])
+	})
+})

--- a/apps/vscode/src/core/api/providers/openai.ts
+++ b/apps/vscode/src/core/api/providers/openai.ts
@@ -145,6 +145,7 @@ export class OpenAiHandler implements ApiHandler {
 		})
 
 		const toolCallProcessor = new ToolCallProcessor()
+		let latestUsage: OpenAI.Completions.CompletionUsage | undefined
 
 		for await (const chunk of stream) {
 			const delta = chunk.choices?.[0]?.delta
@@ -167,14 +168,18 @@ export class OpenAiHandler implements ApiHandler {
 			}
 
 			if (chunk.usage) {
-				yield {
-					type: "usage",
-					inputTokens: chunk.usage.prompt_tokens || 0,
-					outputTokens: chunk.usage.completion_tokens || 0,
-					cacheReadTokens: chunk.usage.prompt_tokens_details?.cached_tokens || 0,
-					// @ts-expect-error-next-line
-					cacheWriteTokens: chunk.usage.prompt_cache_miss_tokens || 0,
-				}
+				latestUsage = chunk.usage
+			}
+		}
+
+		if (latestUsage) {
+			yield {
+				type: "usage",
+				inputTokens: latestUsage.prompt_tokens || 0,
+				outputTokens: latestUsage.completion_tokens || 0,
+				cacheReadTokens: latestUsage.prompt_tokens_details?.cached_tokens || 0,
+				// @ts-expect-error-next-line
+				cacheWriteTokens: latestUsage.prompt_cache_miss_tokens || 0,
 			}
 		}
 	}


### PR DESCRIPTION
### Related Issue

**Issue:** N/A — small provider compatibility bug reported directly by Poolside

### Description

Some OpenAI-compatible providers, including Poolside and Hugging Face Inference Providers, include a cumulative `usage` object on every streamed chunk and may send `usage: null` on the final chunk. The legacy OpenAI-compatible handler forwarded every non-null snapshot as a separate usage event, while task accounting treats usage events as additive deltas. This repeatedly counted prompt/cache tokens and summed increasing completion totals, causing a short response to appear as 1M+ tokens.

Keep the latest non-null usage snapshot while streaming and emit it once after the stream completes. This preserves the usual OpenAI/OpenRouter final-only usage behavior while correctly handling cumulative per-chunk providers.

### Test Procedure

- Reproduced against `https://inference.poolside.ai/v1/chat/completions`: a 16-token response returned 16 cumulative usage snapshots from 48 input / 1 output through 48 input / 16 output. The old handler would record 768 input / 136 output; the fixed behavior records 48 input / 16 output.
- Added a regression test for cumulative usage snapshots followed by `usage: null`.
- Added coverage for providers that emit usage only on the final chunk.
- Ran all legacy provider unit tests: 134 passing.
- Ran the full legacy extension TypeScript check: passing.
- Ran Biome checks on the changed files and `git diff --check`.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable; this change corrects provider usage accounting without changing UI layout.

### Additional Notes

The SDK-based extension path on `main` already consumes the final normalized stream usage once. This PR applies the equivalent behavior to the maintained `legacy-extension` branch only.
