### PR TITLE
fix(cli): improve API key fallback hint visibility

### DIFF
--- a/apps/cli/src/tui/components/dialogs/provider-picker.tsx
+++ b/apps/cli/src/tui/components/dialogs/provider-picker.tsx
@@ -891,6 +891,7 @@ export function OAuthLoginContent(
 	const escapeHint = allowApiKeyFallback
 		? "K to enter an API key instead, Esc to cancel"
 		: "Esc to cancel";
+	const escapeHintColor = allowApiKeyFallback ? "white" : "gray";
 
 	if (mode === "device") {
 		return (
@@ -918,7 +919,7 @@ export function OAuthLoginContent(
 
 				{deviceError && <text fg="red">{deviceError}</text>}
 
-				<text fg="gray">
+				<text fg={escapeHintColor}>
 					<em>{escapeHint}</em>
 				</text>
 			</box>
@@ -941,7 +942,7 @@ export function OAuthLoginContent(
 
 			{error && <text fg="red">{error}</text>}
 
-			<text fg="gray">
+			<text fg={escapeHintColor}>
 				<em>{escapeHint}</em>
 			</text>
 		</box>


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

The Cline authentication screen offers `K to enter an API key instead`, but the entire shortcut row used the same muted gray as secondary status text. Even when intentionally looking for an API-key alternative, the action was easy to miss.

This change derives the hint color from whether the API-key fallback is available:

- Authentication screens that advertise the `K` shortcut now render the final hint row in white.
- Ordinary `Esc to cancel` hints remain gray, preserving the existing visual hierarchy where no alternate authentication action is available.

`OAuthLoginContent` has separate device-code and browser-login render branches, so both now use the same computed hint color. The wording, italic styling, keyboard behavior, and surrounding authentication flow remain unchanged. A conditional local color was chosen instead of changing the shared palette or brightening every cancellation hint, keeping the visual impact limited to the discoverability problem.

### Test Procedure

Automated verification performed from the repository root:

```sh
bun biome check --diagnostic-level=error apps/cli/src/tui/components/dialogs/provider-picker.tsx
bun -F @cline/cli typecheck
bun --cwd apps/cli vitest run --config vitest.config.ts src/tui/components/dialogs/provider-picker.test.ts
```

Biome and TypeScript completed successfully. The focused provider-picker suite passed all 5 tests. `git diff --check` also passed.

The main regression risk is accidentally brightening OAuth screens that only expose cancellation. The color remains conditional on `allowApiKeyFallback`, so those screens continue using gray. There is currently no color-aware OpenTUI component snapshot harness in this package, so the change is intentionally covered by static checks and the existing focused behavioral suite rather than adding a new renderer test framework for a color-only adjustment.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

No screenshot is included. The visible change is limited to rendering the existing final shortcut row in white when the API-key fallback is available.

### Additional Notes

This is a small cosmetic readability fix and does not change authentication logic or persisted provider settings. No linked issue was provided.
