### PR TITLE
refactor(core): normalize read file request path aliases

### DIFF
--- a/sdk/packages/core/src/extensions/tools/definitions.test.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.test.ts
@@ -1676,7 +1676,7 @@ describe("zod schema conversion", () => {
 					path: {
 						type: "string",
 						description:
-							"The absolute file path of a text file to read content from",
+							"The absolute path of a text file to read content from",
 					},
 					start_line: {
 						anyOf: [{ type: "integer" }, { type: "null" }],

--- a/sdk/packages/core/src/extensions/tools/schemas.ts
+++ b/sdk/packages/core/src/extensions/tools/schemas.ts
@@ -14,7 +14,7 @@ export const INPUT_ARG_CHAR_LIMIT = 6000;
  */
 const AbsolutePath = z
 	.string()
-	.describe("The absolute file path of a text file to read content from");
+	.describe("The absolute path of a text file to read content from");
 
 export const ReadFileLineRangeSchema = z
 	.object({
@@ -60,22 +60,46 @@ export const ReadFilesInputSchema = z.object({
 		),
 });
 
+const ReadFileRangeAliasFields = {
+	start_line: ReadFileLineRangeSchema.shape.start_line,
+	end_line: ReadFileLineRangeSchema.shape.end_line,
+};
+
+/**
+ * Tolerant per-entry schema for read requests. Some models emit the path
+ * under `file_path`/`filePath` instead of `path`; normalize those aliases to
+ * the canonical shape so downstream code only ever sees `path`.
+ */
+const LooseReadFileRequestSchema = z.union([
+	ReadFileRequestSchema,
+	z
+		.object({ file_path: AbsolutePath, ...ReadFileRangeAliasFields })
+		.transform(({ file_path, ...rest }) => ({ path: file_path, ...rest })),
+	z
+		.object({ filePath: AbsolutePath, ...ReadFileRangeAliasFields })
+		.transform(({ filePath, ...rest }) => ({ path: filePath, ...rest })),
+]);
+
 /**
  * Union schema for read_files tool input, allowing either a single string, an array of strings, or the full object schema
  */
 export const ReadFilesInputUnionSchema = z.union([
 	ReadFilesInputSchema,
-	ReadFileRequestSchema,
-	z.array(ReadFileRequestSchema),
+	LooseReadFileRequestSchema,
+	z.array(LooseReadFileRequestSchema),
 	z.array(z.string()),
 	z.string(),
-	z.object({ files: z.array(z.union([AbsolutePath, ReadFileRequestSchema])) }),
-	z.object({ files: ReadFileRequestSchema }),
+	z.object({
+		files: z.array(z.union([AbsolutePath, LooseReadFileRequestSchema])),
+	}),
+	z.object({ files: LooseReadFileRequestSchema }),
 	z.object({ files: AbsolutePath }),
 	z.object({ file_paths: z.array(AbsolutePath) }),
 	z.object({ file_paths: z.string() }),
-	z.object({ paths: z.array(z.union([AbsolutePath, ReadFileRequestSchema])) }),
-	z.object({ paths: ReadFileRequestSchema }),
+	z.object({
+		paths: z.array(z.union([AbsolutePath, LooseReadFileRequestSchema])),
+	}),
+	z.object({ paths: LooseReadFileRequestSchema }),
 	z.object({ paths: z.string() }),
 ]);
 
@@ -170,7 +194,7 @@ export const EditFileInputSchema = z
 		path: z
 			.string()
 			.min(1)
-			.describe("The absolute file path for the action to be performed on"),
+			.describe("The absolute path for the action to be performed on"),
 		old_text: z
 			.string()
 			.nullable()


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Accept `file_path` and `filePath` in read file requests and normalize them to the canonical `path` field. Apply alias handling to direct, array, and nested inputs to prevent model-generated variants from failing validation.

Clarify path descriptions by removing redundant wording.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

Schemas changed for union type that is used for validation only. No behavior changes.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
