### PR TITLE
fix(core): stop read_files results from teaching models an invalid in…

### DIFF
--- a/apps/cline-hub/src/webview/src/Chat.tsx
+++ b/apps/cline-hub/src/webview/src/Chat.tsx
@@ -330,6 +330,31 @@ type ToolResultEntry = {
 	success?: boolean;
 };
 
+// read_files queries are JSON object strings ({"path":...,"start_line":...});
+// render them as a compact path:start-end label instead of raw JSON.
+function toolResultEntryLabel(entry: ToolResultEntry): string {
+	const query = entry.query ?? "";
+	if (!query.startsWith("{")) {
+		return query;
+	}
+	try {
+		const parsed = JSON.parse(query) as {
+			path?: string;
+			start_line?: number;
+			end_line?: number;
+		};
+		if (typeof parsed.path !== "string") {
+			return query;
+		}
+		if (parsed.start_line == null && parsed.end_line == null) {
+			return parsed.path;
+		}
+		return `${parsed.path}:${parsed.start_line ?? 1}-${parsed.end_line ?? "EOF"}`;
+	} catch {
+		return query;
+	}
+}
+
 function isToolResultArray(value: unknown): value is ToolResultEntry[] {
 	return (
 		Array.isArray(value) &&
@@ -379,7 +404,7 @@ function formatRawOutput(output: unknown, fallback: string): string {
 function expandToolEvent(toolEvent: ToolEvent): ExpandedToolEvent[] {
 	if (isToolResultArray(toolEvent.output)) {
 		return toolEvent.output.map((entry, index) => {
-			const query = entry.query ?? "";
+			const query = toolResultEntryLabel(entry);
 			const title = query ? `${toolEvent.name}: ${query}` : toolEvent.name;
 			const state: ToolEvent["state"] =
 				entry.success === false ? "output-error" : toolEvent.state;

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-messages.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-messages.tsx
@@ -1082,6 +1082,22 @@ function asStringArray(value: unknown): string[] {
 	);
 }
 
+// read_files result queries are JSON object strings ({"path":...,"start_line":...});
+// render them as a compact path:start-end label instead of raw JSON.
+function formatReadQueryLabel(query: string): string {
+	if (!query.startsWith("{")) return query;
+	try {
+		const parsed = asRecord(JSON.parse(query));
+		if (typeof parsed?.path !== "string") return query;
+		const start = parsed.start_line;
+		const end = parsed.end_line;
+		if (start == null && end == null) return parsed.path;
+		return `${parsed.path}:${start ?? 1}-${end ?? "EOF"}`;
+	} catch {
+		return query;
+	}
+}
+
 /**
  * read_files accepts many input shapes: { files: [{ path }] }, { files: path },
  * { file_paths: [...] }, { paths: [...] }, a bare request, an array, or a string.
@@ -1297,10 +1313,9 @@ function buildToolSummary(
 		return { label: detail, details: [] };
 	}
 
+	const rawQuery = asRecord(result)?.query;
 	const query =
-		typeof asRecord(result)?.query === "string"
-			? (asRecord(result)?.query as string)
-			: "";
+		typeof rawQuery === "string" ? formatReadQueryLabel(rawQuery) : "";
 	const fallback =
 		query || (inProgress ? `Running ${toolName}` : toolName) || "Tool";
 	return { label: fallback, details: [fallback] };

--- a/apps/examples/vscode/src/webview/src/Chat.tsx
+++ b/apps/examples/vscode/src/webview/src/Chat.tsx
@@ -308,6 +308,31 @@ type ToolResultEntry = {
 	success?: boolean;
 };
 
+// read_files queries are JSON object strings ({"path":...,"start_line":...});
+// render them as a compact path:start-end label instead of raw JSON.
+function toolResultEntryLabel(entry: ToolResultEntry): string {
+	const query = entry.query ?? "";
+	if (!query.startsWith("{")) {
+		return query;
+	}
+	try {
+		const parsed = JSON.parse(query) as {
+			path?: string;
+			start_line?: number;
+			end_line?: number;
+		};
+		if (typeof parsed.path !== "string") {
+			return query;
+		}
+		if (parsed.start_line == null && parsed.end_line == null) {
+			return parsed.path;
+		}
+		return `${parsed.path}:${parsed.start_line ?? 1}-${parsed.end_line ?? "EOF"}`;
+	} catch {
+		return query;
+	}
+}
+
 function isToolResultArray(value: unknown): value is ToolResultEntry[] {
 	return (
 		Array.isArray(value) &&
@@ -357,7 +382,7 @@ function formatRawOutput(output: unknown, fallback: string): string {
 function expandToolEvent(toolEvent: ToolEvent): ExpandedToolEvent[] {
 	if (isToolResultArray(toolEvent.output)) {
 		return toolEvent.output.map((entry, index) => {
-			const query = entry.query ?? "";
+			const query = toolResultEntryLabel(entry);
 			const title = query ? `${toolEvent.name}: ${query}` : toolEvent.name;
 			const state: ToolEvent["state"] =
 				entry.success === false ? "output-error" : toolEvent.state;

--- a/sdk/packages/core/src/extensions/tools/definitions.test.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.test.ts
@@ -1313,7 +1313,7 @@ describe("default read_files tool", () => {
 
 		expect(result).toEqual([
 			{
-				query: "/tmp/example.ts:3-5",
+				query: '{"path":"/tmp/example.ts","start_line":3,"end_line":5}',
 				result: "selected lines",
 				success: true,
 			},
@@ -1428,6 +1428,108 @@ describe("default read_files tool", () => {
 		);
 	});
 
+	it("accepts filePath/file_path aliases and echoes canonical keys in results", async () => {
+		const execute = vi.fn(
+			async (request: { path: string }) => `content:${request.path}`,
+		);
+		const tool = createReadFilesTool(execute);
+
+		// The exact drift observed in the wild: camelCase key on each entry.
+		const camelResult = await tool.execute(
+			{
+				files: [
+					{ filePath: "/tmp/client.go", start_line: 1, end_line: 200 },
+					{ filePath: "/tmp/service.go" },
+				],
+			} as never,
+			{
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 1,
+			},
+		);
+		const snakeResult = await tool.execute(
+			{ files: [{ file_path: "/tmp/queries.go", start_line: 2 }] } as never,
+			{
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 2,
+			},
+		);
+
+		expect(execute).toHaveBeenNthCalledWith(
+			1,
+			{ path: "/tmp/client.go", start_line: 1, end_line: 200 },
+			expect.objectContaining({ iteration: 1 }),
+		);
+		expect(execute).toHaveBeenNthCalledWith(
+			2,
+			{ path: "/tmp/service.go" },
+			expect.objectContaining({ iteration: 1 }),
+		);
+		expect(execute).toHaveBeenNthCalledWith(
+			3,
+			{ path: "/tmp/queries.go", start_line: 2 },
+			expect.objectContaining({ iteration: 2 }),
+		);
+		expect(camelResult).toEqual([
+			{
+				query: '{"path":"/tmp/client.go","start_line":1,"end_line":200}',
+				result: "content:/tmp/client.go",
+				success: true,
+			},
+			{
+				query: '{"path":"/tmp/service.go"}',
+				result: "content:/tmp/service.go",
+				success: true,
+			},
+		]);
+		expect(snakeResult).toEqual([
+			{
+				query: '{"path":"/tmp/queries.go","start_line":2}',
+				result: "content:/tmp/queries.go",
+				success: true,
+			},
+		]);
+	});
+
+	it("accepts path-key aliases on bare and paths-keyed entries", async () => {
+		const execute = vi.fn(
+			async (request: { path: string }) => `content:${request.path}`,
+		);
+		const tool = createReadFilesTool(execute);
+
+		await tool.execute({ filePath: "/tmp/bare.ts", end_line: 9 } as never, {
+			agentId: "agent-1",
+			conversationId: "conv-1",
+			iteration: 1,
+		});
+		await tool.execute(
+			{ paths: [{ file_path: "/tmp/listed.ts" }, "/tmp/plain.ts"] } as never,
+			{
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 2,
+			},
+		);
+
+		expect(execute).toHaveBeenNthCalledWith(
+			1,
+			{ path: "/tmp/bare.ts", end_line: 9 },
+			expect.objectContaining({ iteration: 1 }),
+		);
+		expect(execute).toHaveBeenNthCalledWith(
+			2,
+			{ path: "/tmp/listed.ts" },
+			expect.objectContaining({ iteration: 2 }),
+		);
+		expect(execute).toHaveBeenNthCalledWith(
+			3,
+			{ path: "/tmp/plain.ts" },
+			expect.objectContaining({ iteration: 2 }),
+		);
+	});
+
 	it("folds orphan range entries into the preceding file entry", async () => {
 		const execute = vi.fn(
 			async (request: { path: string }) => `content:${request.path}`,
@@ -1455,6 +1557,19 @@ describe("default read_files tool", () => {
 				iteration: 2,
 			},
 		);
+		await tool.execute(
+			{
+				files: [
+					{ filePath: "/tmp/aliased.ts" },
+					{ start_line: 3, end_line: 7 },
+				],
+			} as never,
+			{
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 3,
+			},
+		);
 
 		expect(execute).toHaveBeenNthCalledWith(
 			1,
@@ -1470,6 +1585,11 @@ describe("default read_files tool", () => {
 			3,
 			{ path: "/tmp/b.ts" },
 			expect.objectContaining({ iteration: 2 }),
+		);
+		expect(execute).toHaveBeenNthCalledWith(
+			4,
+			{ path: "/tmp/aliased.ts", start_line: 3, end_line: 7 },
+			expect.objectContaining({ iteration: 3 }),
 		);
 	});
 
@@ -1511,7 +1631,7 @@ describe("default read_files tool", () => {
 		expect(execute).not.toHaveBeenCalled();
 	});
 
-	it("rejects invalid union inputs before calling the executor", async () => {
+	it("rejects invalid union inputs with a canonical-shape hint before calling the executor", async () => {
 		const execute = vi.fn(async () => "should not run");
 		const tool = createReadFilesTool(execute);
 
@@ -1521,7 +1641,9 @@ describe("default read_files tool", () => {
 				conversationId: "conv-1",
 				iteration: 1,
 			}),
-		).rejects.toThrow();
+		).rejects.toThrow(
+			/Expected input like: \{"files": \[\{"path": "\/absolute\/path\/to\/file\.ts", "start_line": 1, "end_line": 100\}\]\}/,
+		);
 
 		expect(execute).not.toHaveBeenCalled();
 	});
@@ -1549,7 +1671,7 @@ describe("default read_files tool", () => {
 
 		expect(result).toEqual([
 			{
-				query: "/tmp/example.ts",
+				query: '{"path":"/tmp/example.ts"}',
 				result: "full file",
 				success: true,
 			},
@@ -1601,19 +1723,19 @@ describe("default read_files tool", () => {
 
 		expect(result).toEqual([
 			{
-				query: "/tmp/valid-a.ts:1-2",
+				query: '{"path":"/tmp/valid-a.ts","start_line":1,"end_line":2}',
 				result: "content for /tmp/valid-a.ts",
 				success: true,
 			},
 			{
-				query: "/tmp/reversed.ts:5-3",
+				query: '{"path":"/tmp/reversed.ts","start_line":5,"end_line":3}',
 				result: "",
 				error:
 					"Invalid file range: start_line must be less than or equal to end_line (received start_line: 5, end_line: 3)",
 				success: false,
 			},
 			{
-				query: "/tmp/valid-b.ts",
+				query: '{"path":"/tmp/valid-b.ts"}',
 				result: "content for /tmp/valid-b.ts",
 				success: true,
 			},
@@ -1676,7 +1798,7 @@ describe("zod schema conversion", () => {
 					path: {
 						type: "string",
 						description:
-							"The absolute file path of a text file to read content from",
+							"The absolute path of a text file to read content from",
 					},
 					start_line: {
 						anyOf: [{ type: "integer" }, { type: "null" }],

--- a/sdk/packages/core/src/extensions/tools/definitions.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.ts
@@ -260,6 +260,9 @@ export function createReadFilesTool(
 			const validate = validateWithZod(
 				ReadFilesInputUnionSchema,
 				coalesceOrphanReadRanges(input),
+				{
+					hint: 'Expected input like: {"files": [{"path": "/absolute/path/to/file.ts", "start_line": 1, "end_line": 100}]} — each entry needs "path"; "start_line"/"end_line" are optional',
+				},
 			);
 			let requests: ReadFileRequest[];
 			if (typeof validate === "string") {
@@ -293,10 +296,13 @@ export function createReadFilesTool(
 
 			return Promise.all(
 				requests.map(async (request): Promise<ToolOperationResult> => {
+					// The query echoes the request under its canonical input keys
+					// so results keep reinforcing the shape the model must emit.
+					const query = formatReadFileQuery(request);
 					const rangeError = getReadFileRangeError(request);
 					if (rangeError) {
 						return {
-							query: formatReadFileQuery(request),
+							query,
 							result: "",
 							error: `Invalid file range: ${rangeError}`,
 							success: false,
@@ -310,14 +316,14 @@ export function createReadFilesTool(
 							`File read timed out after ${timeoutMs}ms`,
 						);
 						return {
-							query: formatReadFileQuery(request),
+							query,
 							result: content,
 							success: true,
 						};
 					} catch (error) {
 						const msg = formatError(error);
 						return {
-							query: formatReadFileQuery(request),
+							query,
 							result: "",
 							error: `Error reading file: ${msg}`,
 							success: false,

--- a/sdk/packages/core/src/extensions/tools/helpers.ts
+++ b/sdk/packages/core/src/extensions/tools/helpers.ts
@@ -58,14 +58,22 @@ export function withTimeout<T>(
 	]);
 }
 
+/**
+ * Echo a read request into a result's `query` field as a JSON object string
+ * (e.g. `{"path":"/a/b.ts","start_line":3,"end_line":5}`). Restating the
+ * request under its canonical input keys keeps every successful result
+ * reinforcing the exact shape the model must emit on its next call, unlike
+ * the previous fused `path:start-end` format which taught an invalid one.
+ */
 export function formatReadFileQuery(request: ReadFileRequest): string {
-	const { path, start_line, end_line } = request;
-	if (start_line == null && end_line == null) {
-		return path;
+	const echo: Record<string, string | number> = { path: request.path };
+	if (request.start_line != null) {
+		echo.start_line = request.start_line;
 	}
-	const start = start_line ?? 1;
-	const end = end_line ?? "EOF";
-	return `${path}:${start}-${end}`;
+	if (request.end_line != null) {
+		echo.end_line = request.end_line;
+	}
+	return JSON.stringify(echo);
 }
 
 export function getReadFileRangeError(request: ReadFileRequest): string | null {
@@ -78,6 +86,13 @@ export function getReadFileRangeError(request: ReadFileRequest): string | null {
 }
 
 const READ_RANGE_KEYS = new Set(["start_line", "end_line"]);
+
+/** Path keys accepted on read entries; aliases are normalized to `path` during validation. */
+const READ_PATH_KEYS = ["path", "file_path", "filePath"] as const;
+
+function hasReadPathKey(value: object): boolean {
+	return READ_PATH_KEYS.some((key) => key in value);
+}
 
 function isOrphanReadRangeEntry(
 	value: unknown,
@@ -102,7 +117,7 @@ function coalesceOrphanReadRangeEntries(entries: unknown[]): unknown[] {
 				previous !== null &&
 				typeof previous === "object" &&
 				!Array.isArray(previous) &&
-				"path" in previous &&
+				hasReadPathKey(previous) &&
 				Object.keys(entry).every((key) => !(key in previous))
 			) {
 				coalesced[coalesced.length - 1] = { ...previous, ...entry };

--- a/sdk/packages/core/src/extensions/tools/schemas.ts
+++ b/sdk/packages/core/src/extensions/tools/schemas.ts
@@ -14,7 +14,7 @@ export const INPUT_ARG_CHAR_LIMIT = 6000;
  */
 const AbsolutePath = z
 	.string()
-	.describe("The absolute file path of a text file to read content from");
+	.describe("The absolute path of a text file to read content from");
 
 export const ReadFileLineRangeSchema = z
 	.object({
@@ -60,22 +60,46 @@ export const ReadFilesInputSchema = z.object({
 		),
 });
 
+const ReadFileRangeAliasFields = {
+	start_line: ReadFileLineRangeSchema.shape.start_line,
+	end_line: ReadFileLineRangeSchema.shape.end_line,
+};
+
+/**
+ * Tolerant per-entry schema for read requests. Some models emit the path
+ * under `file_path`/`filePath` instead of `path`; normalize those aliases to
+ * the canonical shape so downstream code only ever sees `path`.
+ */
+const LooseReadFileRequestSchema = z.union([
+	ReadFileRequestSchema,
+	z
+		.object({ file_path: AbsolutePath, ...ReadFileRangeAliasFields })
+		.transform(({ file_path, ...rest }) => ({ path: file_path, ...rest })),
+	z
+		.object({ filePath: AbsolutePath, ...ReadFileRangeAliasFields })
+		.transform(({ filePath, ...rest }) => ({ path: filePath, ...rest })),
+]);
+
 /**
  * Union schema for read_files tool input, allowing either a single string, an array of strings, or the full object schema
  */
 export const ReadFilesInputUnionSchema = z.union([
 	ReadFilesInputSchema,
-	ReadFileRequestSchema,
-	z.array(ReadFileRequestSchema),
+	LooseReadFileRequestSchema,
+	z.array(LooseReadFileRequestSchema),
 	z.array(z.string()),
 	z.string(),
-	z.object({ files: z.array(z.union([AbsolutePath, ReadFileRequestSchema])) }),
-	z.object({ files: ReadFileRequestSchema }),
+	z.object({
+		files: z.array(z.union([AbsolutePath, LooseReadFileRequestSchema])),
+	}),
+	z.object({ files: LooseReadFileRequestSchema }),
 	z.object({ files: AbsolutePath }),
 	z.object({ file_paths: z.array(AbsolutePath) }),
 	z.object({ file_paths: z.string() }),
-	z.object({ paths: z.array(z.union([AbsolutePath, ReadFileRequestSchema])) }),
-	z.object({ paths: ReadFileRequestSchema }),
+	z.object({
+		paths: z.array(z.union([AbsolutePath, LooseReadFileRequestSchema])),
+	}),
+	z.object({ paths: LooseReadFileRequestSchema }),
 	z.object({ paths: z.string() }),
 ]);
 
@@ -170,7 +194,7 @@ export const EditFileInputSchema = z
 		path: z
 			.string()
 			.min(1)
-			.describe("The absolute file path for the action to be performed on"),
+			.describe("The absolute path for the action to be performed on"),
 		old_text: z
 			.string()
 			.nullable()

--- a/sdk/packages/core/src/session/services/message-builder.test.ts
+++ b/sdk/packages/core/src/session/services/message-builder.test.ts
@@ -1545,6 +1545,64 @@ describe("MessageBuilder default-on truncation", () => {
 		expect(JSON.stringify(result[2].content)).toContain("NEW CONTENT");
 	});
 
+	it("rewrites outdated reads whose query is a JSON object string", () => {
+		const builder = new MessageBuilder({ minOutdatedRewriteBytes: 0 });
+		const readUse = (id: string) => ({
+			role: "assistant" as const,
+			content: [
+				{
+					type: "tool_use" as const,
+					id,
+					name: "read_files",
+					input: {
+						files: [{ path: "/tmp/a.txt", start_line: 3, end_line: 5 }],
+					},
+				},
+			],
+		});
+		const readResult = (id: string, content: string) => ({
+			role: "user" as const,
+			content: [
+				{
+					type: "tool_result" as const,
+					tool_use_id: id,
+					name: "read_files",
+					content,
+				},
+			],
+		});
+		const messages: Message[] = [
+			readUse("call_1"),
+			readResult(
+				"call_1",
+				JSON.stringify([
+					{
+						query: '{"path":"/tmp/a.txt","start_line":3,"end_line":5}',
+						result: "OLD RANGE",
+						success: true,
+					},
+				]),
+			),
+			readUse("call_2"),
+			readResult(
+				"call_2",
+				JSON.stringify([
+					{
+						query: '{"path":"/tmp/a.txt","start_line":3,"end_line":5}',
+						result: "NEW RANGE",
+						success: true,
+					},
+				]),
+			),
+		];
+
+		const result = builder.buildForApi(messages);
+		const serializedOld = JSON.stringify(result[1].content);
+		expect(serializedOld).toContain("[outdated - see the latest file content]");
+		expect(serializedOld).not.toContain("OLD RANGE");
+		expect(JSON.stringify(result[3].content)).toContain("NEW RANGE");
+	});
+
 	it("truncates unsupported document data blocks nested in structured results", () => {
 		const builder = new MessageBuilder({
 			maxToolResultChars: 100,

--- a/sdk/packages/core/src/session/services/message-builder.ts
+++ b/sdk/packages/core/src/session/services/message-builder.ts
@@ -863,7 +863,16 @@ export class MessageBuilder {
 		return typeof value === "number" && Number.isInteger(value) ? value : null;
 	}
 
+	/**
+	 * Read-result queries echo the request as a JSON object string
+	 * (`{"path":...,"start_line":...}`); older transcripts carry the legacy
+	 * fused `path:start-end` format, so both must parse.
+	 */
 	private parseReadQuery(query: string): ReadLocator {
+		const jsonLocator = this.parseJsonReadQuery(query);
+		if (jsonLocator) {
+			return jsonLocator;
+		}
 		const match = /^(.*):(\d+)-(EOF|\d+)$/.exec(query);
 		if (!match) {
 			return { path: query, startLine: null, endLine: null };
@@ -873,6 +882,17 @@ export class MessageBuilder {
 			startLine: Number(match[2]),
 			endLine: match[3] === "EOF" ? null : Number(match[3]),
 		};
+	}
+
+	private parseJsonReadQuery(query: string): ReadLocator | undefined {
+		if (!query.startsWith("{")) {
+			return undefined;
+		}
+		try {
+			return this.extractLocatorFromReadRequest(JSON.parse(query));
+		} catch {
+			return undefined;
+		}
 	}
 
 	private dedupeReadLocators(locators: ReadLocator[]): ReadLocator[] {

--- a/sdk/packages/shared/src/parse/zod.test.ts
+++ b/sdk/packages/shared/src/parse/zod.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { validateWithZod } from "./zod";
+
+const UnionSchema = z.union([
+	z.object({ files: z.array(z.object({ path: z.string() })) }),
+	z.string(),
+]);
+
+const ObjectSchema = z.object({
+	path: z.string(),
+	start_line: z.number().int().optional(),
+});
+
+const HINT = 'Expected input like: {"files": [{"path": "/abs/file.ts"}]}';
+
+describe("validateWithZod", () => {
+	it("returns parsed data on success", () => {
+		expect(validateWithZod(UnionSchema, "/tmp/a.ts", { hint: HINT })).toBe(
+			"/tmp/a.ts",
+		);
+	});
+
+	it("appends the hint on root-level union failures", () => {
+		expect(() =>
+			validateWithZod(UnionSchema, { files: [42] }, { hint: HINT }),
+		).toThrow(`✖ Invalid input. ${HINT}`);
+	});
+
+	it("omits the hint on field-level failures where the message is already specific", () => {
+		let message = "";
+		try {
+			validateWithZod(
+				ObjectSchema,
+				{ path: "/tmp/a.ts", start_line: "3" },
+				{ hint: HINT },
+			);
+		} catch (error) {
+			message = (error as Error).message;
+		}
+		expect(message).toContain("start_line");
+		expect(message).not.toContain(HINT);
+	});
+
+	it("keeps the bare message when no hint is provided", () => {
+		expect(() => validateWithZod(UnionSchema, { files: [42] })).toThrow(
+			"✖ Invalid input",
+		);
+	});
+});

--- a/sdk/packages/shared/src/parse/zod.ts
+++ b/sdk/packages/shared/src/parse/zod.ts
@@ -9,11 +9,21 @@ import { z } from "zod";
 /**
  * Validate input using a Zod schema
  * Throws a formatted error if validation fails
+ *
+ * Root-level union failures prettify to a bare "✖ Invalid input" with no
+ * field-level detail, so callers validating union schemas should pass a
+ * `hint` describing the canonical input shape (ideally with an example) to
+ * give the model something actionable to recover with.
  */
-export function validateWithZod<T>(schema: z.ZodType<T>, input: unknown): T {
+export function validateWithZod<T>(
+	schema: z.ZodType<T>,
+	input: unknown,
+	options?: { hint?: string },
+): T {
 	const result = schema.safeParse(input);
 	if (!result.success) {
-		throw new Error(z.prettifyError(result.error));
+		const message = z.prettifyError(result.error);
+		throw new Error(options?.hint ? `${message}. ${options.hint}` : message);
 	}
 	return result.data;
 }

--- a/sdk/packages/shared/src/parse/zod.ts
+++ b/sdk/packages/shared/src/parse/zod.ts
@@ -13,7 +13,9 @@ import { z } from "zod";
  * Root-level union failures prettify to a bare "✖ Invalid input" with no
  * field-level detail, so callers validating union schemas should pass a
  * `hint` describing the canonical input shape (ideally with an example) to
- * give the model something actionable to recover with.
+ * give the model something actionable to recover with. The hint is appended
+ * only on such union failures; field-level errors are already specific and
+ * would only be muddied by restating the whole shape.
  */
 export function validateWithZod<T>(
 	schema: z.ZodType<T>,
@@ -23,9 +25,19 @@ export function validateWithZod<T>(
 	const result = schema.safeParse(input);
 	if (!result.success) {
 		const message = z.prettifyError(result.error);
-		throw new Error(options?.hint ? `${message}. ${options.hint}` : message);
+		throw new Error(
+			options?.hint && hasRootUnionIssue(result.error)
+				? `${message}. ${options.hint}`
+				: message,
+		);
 	}
 	return result.data;
+}
+
+function hasRootUnionIssue(error: z.ZodError): boolean {
+	return error.issues.some(
+		(issue) => issue.code === "invalid_union" && issue.path.length === 0,
+	);
 }
 
 export function zodToJsonSchema(schema: z.ZodTypeAny): Record<string, unknown> {


### PR DESCRIPTION
…put shape

<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Issue

A shared session transcript showed a model calling `read_files` correctly on its first
attempt, then drifting to `filePath` instead of `path` on its second call — which failed
validation with an unhelpful `✖ Invalid input` and no way to recover:

```json
// call 1 (works)
{"files": [{"path": "/…/Sidebar.tsx", "start_line": 140, "end_line": 190}]}
// call 2 (fails)
{"files": [{"filePath": "/…/client.go", "start_line": 1, "end_line": 200}]}
```

Three compounding problems:

1. The tool result erased the very key it needed to reinforce. Each read result echoed the request as a fused string under a differently-named key: {"query": "/path/file.ts:140-190", ...}. After the first successful call, the freshest representation of a file read in context contained no path key at all — so nothing anchored the model to the canonical input name, and the fused path:start-end format modeled a representation that isn't valid input either. Models with a camelCase prior drift to filePath (notably, the model kept start_line/end_line correct — those names are reinforced throughout the tool description).
2. The input union tolerated almost every wrong shape except this one. ReadFilesInputUnionSchema already accepts bare strings, arrays, file_paths, paths, and orphan ranges — but not file_path/filePath on an entry, even though the SDK's own message-builder already treats those keys as path aliases when parsing results.
3. The validation error was a dead end. Zod v4 collapses root-level union failures to a bare ✖ Invalid input (no field, no expected shape), giving the model nothing to self-correct with.


Fixes

- Result echo now restates the request under its canonical input keys. formatReadFileQuery returns a JSON object string, so every result reinforces the exact shape the model must emit next: {"query": "{\"path\":\"/a/b.ts\",\"start_line\":3,\"end_line\":5}", "result": …}. The uniform ToolOperationResult {query, result, success} envelope is unchanged (start_line/end_line are omitted from the echo when not requested).
- Input union accepts file_path/filePath per entry via LooseReadFileRequestSchema, normalized to canonical {path, …} with zod transforms so downstream code only ever sees path. Orphan-range coalescing recognizes the alias keys on a preceding entry too.
- Validation failures are now actionable. validateWithZod gained an optional hint, and read_files uses it: ✖ Invalid input. Expected input like: {"files": [{"path": "/absolute/path/to/file.ts", "start_line": 1, "end_line": 100}]} — each entry needs "path"; "start_line"/"end_line" are optional.
- Consumers updated for the new query format:
- message-builder parseReadQuery parses the JSON-object query first (falling back to the legacy fused path:start-end format so stale-read rewriting keeps working on old persisted transcripts).
- The three webview renderers (apps/examples/vscode, apps/cline-hub, apps/examples/desktop-app) parse the JSON query into a compact path:start-end display label instead of showing raw JSON.


### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

- New unit tests: alias entries (filePath/file_path, incl. the exact input from the transcript) normalize to canonical path and echo it back; alias entries work under bare / paths / orphan-range inputs; invalid input errors carry the canonical-shape hint; message-builder marks JSON-format read queries outdated on re-read.
- Updated existing read_files result-shape assertions to the new query format; legacy-format fixtures kept intentionally as back-compat coverage.
- sdk/packages/core unit suite: 1354 passed. sdk/packages/shared: 223 passed. Typechecks clean for core, shared, and all three webview apps; biome clean.
- End-to-end smoke run of the real tool + executor confirming all three behaviors, including the drifted filePath input now succeeding and echoing canonical keys.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
