### PR TITLE
feat(vscode): add rollout telemetry to legacy extension

### DIFF
--- a/apps/vscode/esbuild.mjs
+++ b/apps/vscode/esbuild.mjs
@@ -126,6 +126,9 @@ const copyWasmFiles = {
 const buildEnvVars = {
 	"import.meta.url": "_importMetaUrl",
 	"process.env.IS_STANDALONE": JSON.stringify(standalone ? "true" : "false"),
+	// Always inline these values so ordinary builds cannot be mislabeled by a
+	// user's runtime environment. Only the combined rollout workflow sets them.
+	"process.env.CLINE_ROLLOUT_VARIANT": JSON.stringify(process.env.CLINE_ROLLOUT_VARIANT || ""),
 }
 
 if (production) {

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -53,9 +53,14 @@ import { ExtensionRegistryInfo } from "./registry"
 import { AuthService } from "./services/auth/AuthService"
 import { LogoutReason } from "./services/auth/types"
 import { telemetryService } from "./services/telemetry"
+import type { RolloutBundleActivation } from "./services/telemetry/rollout-metadata"
 import { LG_TASK_URI_PATH, SharedUriHandler, TASK_URI_PATH } from "./services/uri/SharedUriHandler"
 import { ShowMessageType } from "./shared/proto/host/window"
 import { fileExistsAtPath } from "./utils/fs"
+
+export async function reportRolloutActivation(input: RolloutBundleActivation): Promise<void> {
+	await telemetryService.captureRolloutBundleActivated(input)
+}
 
 // This method is called when the VS Code extension is activated.
 // NOTE: This is VS Code specific - services that should be registered

--- a/apps/vscode/src/services/telemetry/TelemetryService.ts
+++ b/apps/vscode/src/services/telemetry/TelemetryService.ts
@@ -11,6 +11,13 @@ import { Mode } from "@/shared/storage/types"
 import { version as extensionVersion } from "../../../package.json"
 import { setDistinctId } from "../logging/distinctId"
 import type { ITelemetryProvider, TelemetryProperties } from "./providers/ITelemetryProvider"
+import {
+	getRolloutErrorProperties,
+	getRolloutTelemetryMetadata,
+	ROLLOUT_BUNDLE_ACTIVATED_EVENT,
+	type RolloutBundleActivation,
+	type RolloutTelemetryMetadata,
+} from "./rollout-metadata"
 import { TelemetryProviderFactory } from "./TelemetryProviderFactory"
 
 /**
@@ -93,6 +100,8 @@ export type TelemetryMetadata = {
 	is_remote_workspace: boolean
 	/** Whether the extension is running in development mode */
 	is_dev: string | undefined
+	/** Present only in bundles built by the combined legacy/next rollout workflow. */
+	extension_variant?: RolloutTelemetryMetadata["extension_variant"]
 }
 
 /**
@@ -365,6 +374,7 @@ export class TelemetryService {
 			// `remoteName` is normalized by the host bridge to `undefined` for local workspaces.
 			is_remote_workspace: !!hostVersion.remoteName,
 			is_dev: process.env.IS_DEV,
+			...getRolloutTelemetryMetadata(),
 		}
 		return new TelemetryService(providers, metadata)
 	}
@@ -563,6 +573,22 @@ export class TelemetryService {
 	public captureExtensionActivated() {
 		this.capture({
 			event: TelemetryService.EVENTS.USER.EXTENSION_ACTIVATED,
+		})
+	}
+
+	public captureRolloutBundleActivated(input: RolloutBundleActivation): void {
+		if (!this.telemetryMetadata.extension_variant) {
+			return
+		}
+
+		this.capture({
+			event: ROLLOUT_BUNDLE_ACTIVATED_EVENT,
+			properties: {
+				attempted_bundle: input.attemptedBundle,
+				actual_bundle: input.actualBundle,
+				fallback: input.fallback,
+				...(input.fallback ? getRolloutErrorProperties(input.error) : {}),
+			},
 		})
 	}
 

--- a/apps/vscode/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
+++ b/apps/vscode/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
@@ -1,6 +1,7 @@
 import { ApiFormat } from "@shared/proto/cline/models"
 import * as assert from "assert"
 import type { ITelemetryProvider, TelemetryProperties, TelemetrySettings } from "../providers/ITelemetryProvider"
+import { ROLLOUT_BUNDLE_ACTIVATED_EVENT, ROLLOUT_ERROR_MESSAGE_LIMIT } from "../rollout-metadata"
 import { TelemetryMetadata, TelemetryService } from "../TelemetryService"
 
 class FakeProvider implements ITelemetryProvider {
@@ -79,6 +80,61 @@ function createTelemetryService(provider: FakeProvider, overrides: Partial<Telem
 }
 
 describe("TelemetryService metrics", () => {
+	it("includes rollout metadata on legacy events and metrics", () => {
+		const provider = new FakeProvider()
+		const service = createTelemetryService(provider, {
+			extension_variant: "legacy",
+		})
+
+		service.captureTaskCreated("task-rollout", "anthropic")
+		service.captureTokenUsage("task-rollout", 120, 80, "anthropic", "model-a")
+
+		const taskEvent = provider.logs.find((entry) => entry.event === "task.created")
+		assert.strictEqual(taskEvent?.properties?.extension_variant, "legacy")
+		for (const entry of [...provider.counters, ...provider.histograms]) {
+			assert.strictEqual(entry.attributes.extension_variant, "legacy")
+		}
+	})
+
+	it("captures one bounded rollout fallback event for rollout builds", () => {
+		const provider = new FakeProvider()
+		const service = createTelemetryService(provider, {
+			extension_variant: "legacy",
+		})
+
+		service.captureRolloutBundleActivated({
+			attemptedBundle: "next",
+			actualBundle: "legacy",
+			fallback: true,
+			error: new TypeError("x".repeat(ROLLOUT_ERROR_MESSAGE_LIMIT + 20)),
+		})
+
+		const events = provider.logs.filter((entry) => entry.event === ROLLOUT_BUNDLE_ACTIVATED_EVENT)
+		assert.strictEqual(events.length, 1)
+		assert.strictEqual(events[0].properties?.attempted_bundle, "next")
+		assert.strictEqual(events[0].properties?.actual_bundle, "legacy")
+		assert.strictEqual(events[0].properties?.fallback, true)
+		assert.strictEqual(events[0].properties?.error_type, "TypeError")
+		assert.strictEqual((events[0].properties?.error_message as string).length, ROLLOUT_ERROR_MESSAGE_LIMIT)
+		assert.strictEqual(events[0].properties?.extension_variant, "legacy")
+	})
+
+	it("does not capture rollout activation events for ordinary builds", () => {
+		const provider = new FakeProvider()
+		const service = createTelemetryService(provider)
+
+		service.captureRolloutBundleActivated({
+			attemptedBundle: "legacy",
+			actualBundle: "legacy",
+			fallback: false,
+		})
+
+		assert.strictEqual(
+			provider.logs.some((entry) => entry.event === ROLLOUT_BUNDLE_ACTIVATED_EVENT),
+			false,
+		)
+	})
+
 	it("captureTokenUsage emits token counters and histograms", () => {
 		const provider = new FakeProvider()
 		const service = createTelemetryService(provider)

--- a/apps/vscode/src/services/telemetry/__tests__/rollout-metadata.test.ts
+++ b/apps/vscode/src/services/telemetry/__tests__/rollout-metadata.test.ts
@@ -1,0 +1,43 @@
+import * as assert from "assert"
+import { getRolloutErrorProperties, getRolloutTelemetryMetadata, ROLLOUT_ERROR_MESSAGE_LIMIT } from "../rollout-metadata"
+
+const originalVariant = process.env.CLINE_ROLLOUT_VARIANT
+
+afterEach(() => {
+	restoreEnv("CLINE_ROLLOUT_VARIANT", originalVariant)
+})
+
+describe("rollout telemetry metadata", () => {
+	it("returns metadata for a rollout build", () => {
+		process.env.CLINE_ROLLOUT_VARIANT = "legacy"
+
+		assert.deepStrictEqual(getRolloutTelemetryMetadata(), {
+			extension_variant: "legacy",
+		})
+	})
+
+	it("omits metadata for ordinary or invalid builds", () => {
+		delete process.env.CLINE_ROLLOUT_VARIANT
+		assert.deepStrictEqual(getRolloutTelemetryMetadata(), {})
+
+		process.env.CLINE_ROLLOUT_VARIANT = "invalid"
+		assert.deepStrictEqual(getRolloutTelemetryMetadata(), {})
+	})
+
+	it("bounds fallback errors without including stacks", () => {
+		const error = new TypeError("x".repeat(ROLLOUT_ERROR_MESSAGE_LIMIT + 20))
+		const properties = getRolloutErrorProperties(error)
+
+		assert.strictEqual(properties.error_type, "TypeError")
+		assert.strictEqual(properties.error_message.length, ROLLOUT_ERROR_MESSAGE_LIMIT)
+		assert.ok(!properties.error_message.includes("TypeError:"))
+	})
+})
+
+function restoreEnv(key: "CLINE_ROLLOUT_VARIANT", value: string | undefined): void {
+	if (value === undefined) {
+		delete process.env[key]
+	} else {
+		process.env[key] = value
+	}
+}

--- a/apps/vscode/src/services/telemetry/rollout-metadata.ts
+++ b/apps/vscode/src/services/telemetry/rollout-metadata.ts
@@ -1,0 +1,43 @@
+export type ExtensionVariant = "legacy" | "next"
+
+export interface RolloutTelemetryMetadata {
+	extension_variant: ExtensionVariant
+}
+
+export interface RolloutBundleActivation {
+	attemptedBundle: ExtensionVariant
+	actualBundle: ExtensionVariant
+	fallback: boolean
+	error?: unknown
+}
+
+export const ROLLOUT_BUNDLE_ACTIVATED_EVENT = "extension.rollout.bundle_activated"
+export const ROLLOUT_ERROR_MESSAGE_LIMIT = 500
+
+/** Return rollout metadata only for bundles built by the combined rollout workflow. */
+export function getRolloutTelemetryMetadata(): Partial<RolloutTelemetryMetadata> {
+	const variant = process.env.CLINE_ROLLOUT_VARIANT
+
+	if (variant !== "legacy" && variant !== "next") {
+		return {}
+	}
+
+	return { extension_variant: variant }
+}
+
+export function getRolloutErrorProperties(error: unknown): {
+	error_type: string
+	error_message: string
+} {
+	if (error instanceof Error) {
+		return {
+			error_type: error.name || "Error",
+			error_message: error.message.slice(0, ROLLOUT_ERROR_MESSAGE_LIMIT),
+		}
+	}
+
+	return {
+		error_type: error === undefined ? "unknown" : error === null ? "null" : typeof error,
+		error_message: (error === undefined ? "Unknown activation error" : String(error)).slice(0, ROLLOUT_ERROR_MESSAGE_LIMIT),
+	}
+}


### PR DESCRIPTION
### Related Issue

**Issue:** Internal staged SDK extension rollout; related to #12253

### Description

The staged VS Code rollout ships legacy and next bundles in one VSIX, but existing OpenTelemetry signals do not say which bundle actually produced them. Joining telemetry to the PostHog rollout flag is not reliable because assignment is sticky, applies on a later window, and can be overridden by activation fallback.

This PR adds the legacy half of an explicit telemetry contract:

- Rollout builds attach `extension_variant=legacy` to every existing telemetry event and metric.
- Ordinary legacy builds omit the attribute entirely.
- The rollout variant is injected at build time, so a user's runtime environment cannot mislabel a normal build.
- The extension exports `reportRolloutActivation()`, allowing the combined loader to report the final activation outcome through the already initialized, opt-out-respecting telemetry pipeline.
- Fallback errors contain a bounded error type/message and no stack trace.

This makes legacy-vs-next task counts, DAU, provider error rates, fallback rates, and token usage directly separable in ClickHouse without feature-flag joins. Release-specific filtering continues to use the existing nested `extension_version`.

The companion next-bundle implementation is in #12292; it adds the same shared contract plus SDK-specific telemetry propagation. Loader/workflow wiring remains a separate follow-up so this PR stays limited to the legacy bundle.

### Test Procedure

From `apps/vscode` on this branch:

1. Generate required sources and type-check:
   ```bash
   npm run protos
   npx tsc --noEmit
   ```
2. Run the complete legacy unit suite:
   ```bash
   npm run test:unit
   ```
   Expected: 1,526 passing tests.
3. Verify the rollout build path:
   ```bash
   CLINE_ROLLOUT_VARIANT=legacy node esbuild.mjs
   ```
   Confirm the built bundle exports `reportRolloutActivation` and includes the `extension.rollout.bundle_activated` event contract.
4. Verify an ordinary build cannot read a rollout value from the user's runtime environment:
   ```bash
   node esbuild.mjs
   rg 'CLINE_ROLLOUT_VARIANT' dist/extension.js
   ```
   Expected: no matches.

The added unit tests specifically verify event and metric attribution, ordinary-build omission, exactly one fallback event, and bounded fallback error data. The full suite, TypeScript check, lint check, rollout build, and ordinary build passed locally.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable; this change has no UI.

### Additional Notes

The shared production contract was cherry-picked from the next implementation; legacy-specific tests use this branch's Mocha test harness. The combined rollout workflow must set `CLINE_ROLLOUT_VARIANT=legacy` when building this branch.
