### PR TITLE
fix(vscode): complete A/B rollout telemetry attribution

### DIFF
--- a/apps/vscode/esbuild.mjs
+++ b/apps/vscode/esbuild.mjs
@@ -91,6 +91,7 @@ const buildEnvVars = {
 	// Always inline these values so ordinary builds cannot be mislabeled by a
 	// user's runtime environment. Only the combined rollout workflow sets them.
 	"process.env.CLINE_ROLLOUT_VARIANT": JSON.stringify(process.env.CLINE_ROLLOUT_VARIANT || ""),
+	"process.env.CLINE_ROLLOUT_VERSION": JSON.stringify(process.env.CLINE_ROLLOUT_VERSION || ""),
 }
 
 if (production) {

--- a/apps/vscode/src/sdk/sdk-telemetry.test.ts
+++ b/apps/vscode/src/sdk/sdk-telemetry.test.ts
@@ -52,6 +52,7 @@ describe("VscodeTelemetryPolicyService", () => {
 		coreTelemetryMocks.createConfig.mockClear()
 		coreTelemetryMocks.createHandle.mockReset()
 		vi.stubEnv("CLINE_ROLLOUT_VARIANT", "")
+		vi.stubEnv("CLINE_ROLLOUT_VERSION", "")
 	})
 
 	afterEach(() => {
@@ -60,6 +61,7 @@ describe("VscodeTelemetryPolicyService", () => {
 
 	it("adds rollout metadata as SDK common properties", () => {
 		vi.stubEnv("CLINE_ROLLOUT_VARIANT", "next")
+		vi.stubEnv("CLINE_ROLLOUT_VERSION", "4.1.0")
 		coreTelemetryMocks.createHandle.mockReturnValue(createHandle())
 
 		createVscodeSdkTelemetryHandle()
@@ -68,6 +70,7 @@ describe("VscodeTelemetryPolicyService", () => {
 			expect.objectContaining({
 				commonProperties: {
 					extension_variant: "next",
+					rollout_version: "4.1.0",
 				},
 			}),
 		)

--- a/apps/vscode/src/services/error/providers/PostHogErrorProvider.ts
+++ b/apps/vscode/src/services/error/providers/PostHogErrorProvider.ts
@@ -3,6 +3,7 @@ import { StateManager } from "@/core/storage/StateManager"
 import { HostProvider } from "@/hosts/host-provider"
 import { getDistinctId } from "@/services/logging/distinctId"
 import { PostHogClientProvider } from "@/services/telemetry/providers/posthog/PostHogClientProvider"
+import { attachRolloutTelemetryMetadata } from "@/services/telemetry/rollout-metadata"
 import { fetch } from "@/shared/net"
 import { Setting } from "@/shared/proto/index.host"
 import { Logger } from "@/shared/services/Logger"
@@ -33,7 +34,13 @@ export class PostHogErrorProvider implements IErrorProvider {
 			host: clientConfig.host,
 			fetch: (url, options) => fetch(url, options),
 			enableExceptionAutocapture: clientConfig.enableExceptionAutocapture,
-			before_send: (event) => PostHogClientProvider.eventFilter(event),
+			before_send: (event) => {
+				const filtered = PostHogClientProvider.eventFilter(event)
+				if (filtered) {
+					attachRolloutTelemetryMetadata(filtered)
+				}
+				return filtered
+			},
 		})
 		// Initialize error settings
 		this.errorSettings = {

--- a/apps/vscode/src/services/telemetry/TelemetryService.ts
+++ b/apps/vscode/src/services/telemetry/TelemetryService.ts
@@ -120,6 +120,8 @@ export type TelemetryMetadata = {
 	is_dev: string | undefined
 	/** Present only in bundles built by the combined legacy/next rollout workflow. */
 	extension_variant?: RolloutTelemetryMetadata["extension_variant"]
+	/** Combined VSIX version, distinct from the nested bundle's source version. */
+	rollout_version?: RolloutTelemetryMetadata["rollout_version"]
 }
 
 /**
@@ -631,6 +633,11 @@ export class TelemetryService {
 				attempted_bundle: input.attemptedBundle,
 				actual_bundle: input.actualBundle,
 				fallback: input.fallback,
+				decision_reason: input.decisionReason,
+				loader_version: input.loaderVersion,
+				vscode_version: input.vscodeVersion,
+				ms_since_last_activation: input.msSinceLastActivation,
+				override: input.override,
 				...(input.fallback ? getRolloutErrorProperties(input.error) : {}),
 			},
 		})

--- a/apps/vscode/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
+++ b/apps/vscode/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
@@ -3,7 +3,7 @@ import { ApiFormat } from "@shared/proto/cline/models"
 import * as assert from "assert"
 import { PROVIDER_FAILURE_ERROR_TYPE, PROVIDER_FAILURE_PHASE } from "../../../sdk/provider-failure-telemetry"
 import type { ITelemetryProvider, TelemetryProperties, TelemetrySettings } from "../providers/ITelemetryProvider"
-import { ROLLOUT_BUNDLE_ACTIVATED_EVENT, ROLLOUT_ERROR_MESSAGE_LIMIT } from "../rollout-metadata"
+import { ROLLOUT_BUNDLE_ACTIVATED_EVENT } from "../rollout-metadata"
 import { TelemetryMetadata, TelemetryService } from "../TelemetryService"
 
 class FakeProvider implements ITelemetryProvider {
@@ -86,6 +86,7 @@ describe("TelemetryService metrics", () => {
 		const provider = new FakeProvider()
 		const service = createTelemetryService(provider, {
 			extension_variant: "next",
+			rollout_version: "4.1.0",
 		})
 
 		service.captureTaskCreated("task-rollout", "anthropic")
@@ -93,8 +94,10 @@ describe("TelemetryService metrics", () => {
 
 		const taskEvent = provider.logs.find((entry) => entry.event === "task.created")
 		assert.strictEqual(taskEvent?.properties?.extension_variant, "next")
+		assert.strictEqual(taskEvent?.properties?.rollout_version, "4.1.0")
 		for (const entry of [...provider.counters, ...provider.histograms]) {
 			assert.strictEqual(entry.attributes.extension_variant, "next")
+			assert.strictEqual(entry.attributes.rollout_version, "4.1.0")
 		}
 	})
 
@@ -102,13 +105,19 @@ describe("TelemetryService metrics", () => {
 		const provider = new FakeProvider()
 		const service = createTelemetryService(provider, {
 			extension_variant: "legacy",
+			rollout_version: "4.1.0",
 		})
 
 		service.captureRolloutBundleActivated({
 			attemptedBundle: "next",
 			actualBundle: "legacy",
 			fallback: true,
-			error: new TypeError("x".repeat(ROLLOUT_ERROR_MESSAGE_LIMIT + 20)),
+			error: new TypeError("sensitive activation detail"),
+			decisionReason: "cached_next",
+			loaderVersion: "4.1.0",
+			vscodeVersion: "1.103.0",
+			msSinceLastActivation: 1_000,
+			override: "setting",
 		})
 
 		const events = provider.logs.filter((entry) => entry.event === ROLLOUT_BUNDLE_ACTIVATED_EVENT)
@@ -116,9 +125,15 @@ describe("TelemetryService metrics", () => {
 		assert.strictEqual(events[0].properties?.attempted_bundle, "next")
 		assert.strictEqual(events[0].properties?.actual_bundle, "legacy")
 		assert.strictEqual(events[0].properties?.fallback, true)
+		assert.strictEqual(events[0].properties?.decision_reason, "cached_next")
+		assert.strictEqual(events[0].properties?.loader_version, "4.1.0")
+		assert.strictEqual(events[0].properties?.vscode_version, "1.103.0")
+		assert.strictEqual(events[0].properties?.ms_since_last_activation, 1_000)
+		assert.strictEqual(events[0].properties?.override, "setting")
 		assert.strictEqual(events[0].properties?.error_type, "TypeError")
-		assert.strictEqual((events[0].properties?.error_message as string).length, ROLLOUT_ERROR_MESSAGE_LIMIT)
+		assert.strictEqual(events[0].properties?.error_message, undefined)
 		assert.strictEqual(events[0].properties?.extension_variant, "legacy")
+		assert.strictEqual(events[0].properties?.rollout_version, "4.1.0")
 	})
 
 	it("does not capture rollout activation events for ordinary builds", () => {

--- a/apps/vscode/src/services/telemetry/rollout-metadata.test.ts
+++ b/apps/vscode/src/services/telemetry/rollout-metadata.test.ts
@@ -1,40 +1,78 @@
 import { afterEach, describe, expect, it } from "bun:test"
-import { getRolloutErrorProperties, getRolloutTelemetryMetadata, ROLLOUT_ERROR_MESSAGE_LIMIT } from "./rollout-metadata"
+import {
+	attachRolloutTelemetryMetadata,
+	getRolloutErrorProperties,
+	getRolloutTelemetryMetadata,
+	ROLLOUT_ERROR_TYPE_LIMIT,
+} from "./rollout-metadata"
 
 const originalVariant = process.env.CLINE_ROLLOUT_VARIANT
+const originalRolloutVersion = process.env.CLINE_ROLLOUT_VERSION
 
 afterEach(() => {
 	restoreEnv("CLINE_ROLLOUT_VARIANT", originalVariant)
+	restoreEnv("CLINE_ROLLOUT_VERSION", originalRolloutVersion)
 })
 
 describe("rollout telemetry metadata", () => {
 	it("returns metadata for a rollout build", () => {
 		process.env.CLINE_ROLLOUT_VARIANT = "next"
+		process.env.CLINE_ROLLOUT_VERSION = "4.1.0"
 
 		expect(getRolloutTelemetryMetadata()).toEqual({
 			extension_variant: "next",
+			rollout_version: "4.1.0",
 		})
 	})
 
 	it("omits metadata for ordinary or invalid builds", () => {
 		delete process.env.CLINE_ROLLOUT_VARIANT
+		process.env.CLINE_ROLLOUT_VERSION = "4.1.0"
 		expect(getRolloutTelemetryMetadata()).toEqual({})
 
 		process.env.CLINE_ROLLOUT_VARIANT = "invalid"
 		expect(getRolloutTelemetryMetadata()).toEqual({})
 	})
 
-	it("bounds fallback errors without including stacks", () => {
-		const error = new TypeError("x".repeat(ROLLOUT_ERROR_MESSAGE_LIMIT + 20))
-		const properties = getRolloutErrorProperties(error)
+	it("decorates accepted error events while preserving their properties", () => {
+		process.env.CLINE_ROLLOUT_VARIANT = "next"
+		process.env.CLINE_ROLLOUT_VERSION = "4.1.0"
+		const event: { properties?: Record<string, unknown> } = {
+			properties: { existing: true, extension_variant: "spoofed" },
+		}
 
-		expect(properties.error_type).toBe("TypeError")
-		expect(properties.error_message).toHaveLength(ROLLOUT_ERROR_MESSAGE_LIMIT)
-		expect(properties.error_message).not.toContain("TypeError:")
+		attachRolloutTelemetryMetadata(event)
+
+		expect(event.properties).toEqual({
+			existing: true,
+			extension_variant: "next",
+			rollout_version: "4.1.0",
+		})
+	})
+
+	it("does not label error events from ordinary builds", () => {
+		delete process.env.CLINE_ROLLOUT_VARIANT
+		delete process.env.CLINE_ROLLOUT_VERSION
+		const event: { properties?: Record<string, unknown> } = {
+			properties: { existing: true },
+		}
+		attachRolloutTelemetryMetadata(event)
+		expect(event.properties).toEqual({ existing: true })
+	})
+
+	it("reports only a bounded error type and never the raw fallback message", () => {
+		const error = new TypeError('authorization: Bearer abc123 {"apiKey":"secret"}')
+		expect(getRolloutErrorProperties(error)).toEqual({ error_type: "TypeError" })
+
+		error.name = "x".repeat(ROLLOUT_ERROR_TYPE_LIMIT + 1)
+		expect(getRolloutErrorProperties(error)).toEqual({ error_type: "Error" })
+
+		error.name = "Unsafe Error Name"
+		expect(getRolloutErrorProperties(error)).toEqual({ error_type: "Error" })
 	})
 })
 
-function restoreEnv(key: "CLINE_ROLLOUT_VARIANT", value: string | undefined): void {
+function restoreEnv(key: "CLINE_ROLLOUT_VARIANT" | "CLINE_ROLLOUT_VERSION", value: string | undefined): void {
 	if (value === undefined) {
 		delete process.env[key]
 	} else {

--- a/apps/vscode/src/services/telemetry/rollout-metadata.ts
+++ b/apps/vscode/src/services/telemetry/rollout-metadata.ts
@@ -2,6 +2,7 @@ export type ExtensionVariant = "legacy" | "next"
 
 export interface RolloutTelemetryMetadata {
 	extension_variant: ExtensionVariant
+	rollout_version?: string
 }
 
 export interface RolloutBundleActivation {
@@ -9,35 +10,61 @@ export interface RolloutBundleActivation {
 	actualBundle: ExtensionVariant
 	fallback: boolean
 	error?: unknown
+	decisionReason?:
+		| "env_override"
+		| "setting_override"
+		| "killswitch"
+		| "previous_failure"
+		| "cached_next"
+		| "cached_legacy"
+		| "default_legacy"
+	loaderVersion?: string
+	vscodeVersion?: string
+	msSinceLastActivation?: number
+	override?: "env" | "setting"
 }
 
 export const ROLLOUT_BUNDLE_ACTIVATED_EVENT = "extension.rollout.bundle_activated"
-export const ROLLOUT_ERROR_MESSAGE_LIMIT = 500
+export const ROLLOUT_ERROR_TYPE_LIMIT = 64
 
 /** Return rollout metadata only for bundles built by the combined rollout workflow. */
 export function getRolloutTelemetryMetadata(): Partial<RolloutTelemetryMetadata> {
 	const variant = process.env.CLINE_ROLLOUT_VARIANT
+	const rolloutVersion = process.env.CLINE_ROLLOUT_VERSION
 
 	if (variant !== "legacy" && variant !== "next") {
 		return {}
 	}
 
-	return { extension_variant: variant }
+	return {
+		extension_variant: variant,
+		...(rolloutVersion ? { rollout_version: rolloutVersion } : {}),
+	}
+}
+
+export function attachRolloutTelemetryMetadata(event: { properties?: Record<string, unknown> }): void {
+	event.properties = {
+		...event.properties,
+		...getRolloutTelemetryMetadata(),
+	}
 }
 
 export function getRolloutErrorProperties(error: unknown): {
 	error_type: string
-	error_message: string
 } {
 	if (error instanceof Error) {
 		return {
-			error_type: error.name || "Error",
-			error_message: error.message.slice(0, ROLLOUT_ERROR_MESSAGE_LIMIT),
+			error_type: normalizeRolloutErrorType(error.name, "Error"),
 		}
 	}
 
 	return {
 		error_type: error === undefined ? "unknown" : error === null ? "null" : typeof error,
-		error_message: (error === undefined ? "Unknown activation error" : String(error)).slice(0, ROLLOUT_ERROR_MESSAGE_LIMIT),
 	}
+}
+
+function normalizeRolloutErrorType(value: string, fallback: string): string {
+	return value.length > 0 && value.length <= ROLLOUT_ERROR_TYPE_LIMIT && /^[A-Za-z][A-Za-z0-9_.-]*$/.test(value)
+		? value
+		: fallback
 }

--- a/apps/vscode/webview-ui/src/CustomPostHogProvider.tsx
+++ b/apps/vscode/webview-ui/src/CustomPostHogProvider.tsx
@@ -4,6 +4,9 @@ import { PostHogProvider } from "posthog-js/react"
 import { type ReactNode, useEffect, useState } from "react"
 import { useExtensionState } from "./context/ExtensionStateContext"
 
+const extensionVariant = process.env.CLINE_ROLLOUT_VARIANT
+const rolloutVersion = process.env.CLINE_ROLLOUT_VERSION
+
 export function CustomPostHogProvider({ children }: { children: ReactNode }) {
 	const { distinctId, version, userInfo, environment, telemetrySetting } = useExtensionState()
 
@@ -48,6 +51,12 @@ export function CustomPostHogProvider({ children }: { children: ReactNode }) {
 				if (payload?.properties) {
 					payload.properties.extension_version = version
 					payload.properties.distinct_id = distinctId
+					if (extensionVariant === "legacy" || extensionVariant === "next") {
+						payload.properties.extension_variant = extensionVariant
+						if (rolloutVersion) {
+							payload.properties.rollout_version = rolloutVersion
+						}
+					}
 				}
 				return payload
 			},

--- a/apps/vscode/webview-ui/src/CustomPostHogProvider.tsx
+++ b/apps/vscode/webview-ui/src/CustomPostHogProvider.tsx
@@ -34,7 +34,7 @@ export function CustomPostHogProvider({ children }: { children: ReactNode }) {
 			autocapture: false,
 		})
 		setIsActive(true)
-	}, [isSelfHostedOrUnknown])
+	}, [isSelfHostedOrUnknown, isActive])
 
 	useEffect(() => {
 		if (!isActive || !distinctId || !version) {
@@ -76,7 +76,7 @@ export function CustomPostHogProvider({ children }: { children: ReactNode }) {
 			// Then opt out of capturing other events
 			posthog.opt_out_capturing()
 		}
-	}, [isActive, isTelemetryEnabled, distinctId, version])
+	}, [isActive, isTelemetryEnabled, distinctId, version, userInfo?.email, userInfo?.displayName])
 
 	return <PostHogProvider client={posthog}>{children}</PostHogProvider>
 }

--- a/apps/vscode/webview-ui/vite.config.ts
+++ b/apps/vscode/webview-ui/vite.config.ts
@@ -139,6 +139,8 @@ export default defineConfig({
 		"process.env.TELEMETRY_SERVICE_API_KEY": JSON.stringify(process.env.TELEMETRY_SERVICE_API_KEY),
 		"process.env.ERROR_SERVICE_API_KEY": JSON.stringify(process.env.ERROR_SERVICE_API_KEY),
 		"process.env.ENABLE_ERROR_AUTOCAPTURE": JSON.stringify(process.env.ENABLE_ERROR_AUTOCAPTURE),
+		"process.env.CLINE_ROLLOUT_VARIANT": JSON.stringify(process.env.CLINE_ROLLOUT_VARIANT ?? ""),
+		"process.env.CLINE_ROLLOUT_VERSION": JSON.stringify(process.env.CLINE_ROLLOUT_VERSION ?? ""),
 		// OpenTelemetry environment variables
 		"process.env.OTEL_TELEMETRY_ENABLED": JSON.stringify(process.env.OTEL_TELEMETRY_ENABLED),
 		"process.env.OTEL_METRICS_EXPORTER": JSON.stringify(process.env.OTEL_METRICS_EXPORTER),

--- a/sdk/packages/core/src/services/agent-events.telemetry.test.ts
+++ b/sdk/packages/core/src/services/agent-events.telemetry.test.ts
@@ -1,0 +1,50 @@
+import type { AgentEvent, ITelemetryService } from "@cline/shared";
+import { describe, expect, test, vi } from "vitest";
+import { type AgentEventContext, handleAgentEvent } from "./agent-events";
+import { CORE_TELEMETRY_EVENTS } from "./telemetry/core-events";
+import { createInitialAccumulatedUsage } from "./usage";
+
+describe("handleAgentEvent telemetry", () => {
+	test("passes the configured provider through the production usage-event path", () => {
+		const capture = vi.fn();
+		const telemetry = { capture } as unknown as ITelemetryService;
+		const baseline = createInitialAccumulatedUsage();
+		const context = {
+			sessionId: "session-1",
+			config: {
+				providerId: "anthropic",
+				modelId: "claude-sonnet",
+				mode: "act",
+				telemetry,
+			},
+			liveSession: {
+				runtime: { teamRuntime: undefined },
+				turnUsageBaseline: baseline,
+				turnAggregateUsageBaseline: baseline,
+			},
+			usageBySession: new Map(),
+			aggregateUsageBySession: new Map(),
+			persistMessages: vi.fn(),
+			emit: vi.fn(),
+		} as unknown as AgentEventContext;
+		const event = {
+			type: "usage",
+			inputTokens: 120,
+			outputTokens: 80,
+			cacheWriteTokens: 10,
+			cacheReadTokens: 20,
+			cost: 0.01,
+		} as AgentEvent;
+
+		handleAgentEvent(context, event);
+
+		expect(capture).toHaveBeenCalledWith({
+			event: CORE_TELEMETRY_EVENTS.TASK.TOKEN_USAGE,
+			properties: expect.objectContaining({
+				ulid: "session-1",
+				provider: "anthropic",
+				model: "claude-sonnet",
+			}),
+		});
+	});
+});

--- a/sdk/packages/core/src/services/agent-events.ts
+++ b/sdk/packages/core/src/services/agent-events.ts
@@ -255,6 +255,7 @@ export function handleAgentEvent(
 				cacheWriteTokens: event.cacheWriteTokens,
 				cacheReadTokens: event.cacheReadTokens,
 				totalCost: event.cost,
+				provider: config.providerId,
 				model: config.modelId,
 				...agentIdentity,
 			});

--- a/sdk/packages/core/src/services/telemetry/core-events.test.ts
+++ b/sdk/packages/core/src/services/telemetry/core-events.test.ts
@@ -12,6 +12,7 @@ import {
 	captureProviderConfigured,
 	captureRunCommandsTimeout,
 	captureTelemetryOptOut,
+	captureTokenUsage,
 	captureWorkspaceInitError,
 	captureWorkspaceInitialized,
 	captureWorkspacePathResolved,
@@ -78,6 +79,30 @@ describe("captureTelemetryOptOut", () => {
 			"user.opt_out",
 			undefined,
 		);
+	});
+});
+
+describe("captureTokenUsage", () => {
+	test("includes provider so rollout cohorts can be compared with the same dimension", () => {
+		const stub = createTelemetryStub();
+		captureTokenUsage(stub.telemetry, {
+			ulid: "task-1",
+			tokensIn: 120,
+			tokensOut: 80,
+			provider: "anthropic",
+			model: "claude-sonnet",
+		});
+
+		expect(captureCallAt(stub, 0)).toEqual({
+			event: "task.tokens",
+			properties: {
+				ulid: "task-1",
+				tokensIn: 120,
+				tokensOut: 80,
+				provider: "anthropic",
+				model: "claude-sonnet",
+			},
+		});
 	});
 });
 

--- a/sdk/packages/core/src/services/telemetry/core-events.ts
+++ b/sdk/packages/core/src/services/telemetry/core-events.ts
@@ -417,6 +417,7 @@ export function captureTokenUsage(
 		cacheWriteTokens?: number;
 		cacheReadTokens?: number;
 		totalCost?: number;
+		provider?: string;
 		model: string;
 	} & Partial<TelemetryAgentIdentityProperties>,
 ): void {


### PR DESCRIPTION
### Related Issue

**Issue:** #12253

Follow-up to #12292. Companion legacy-extension PR: #12298

### Description

#### Problem

The initial main-branch telemetry change added a build-time `extension_variant`, which lets us distinguish legacy and next bundles during the staged extension rollout. End-to-end validation exposed a few remaining attribution gaps that would make the rollout harder to operate safely:

- The combined extension contains nested bundles whose package versions do not necessarily match the public rollout version, so variant alone is not enough to identify the release being observed.
- Webview PostHog events and host-side error autocapture do not all pass through the traditional telemetry event service, so only changing that service leaves meaningful traffic unattributed.
- The loader needs a bounded activation result from the bundle that actually ran, including fallback context, without putting telemetry delivery on the activation critical path.
- Token-usage telemetry accepted a provider field but dropped it before emitting the event, which prevented provider-level analysis during the rollout.
- PostHog identity effects did not react to all identity and consent changes, which could retain stale attribution within a running session.

#### Technical approach

This follow-up adds a build-time `CLINE_ROLLOUT_VERSION` beside `CLINE_EXTENSION_VARIANT` and carries both values through the independent extension-host and webview builds. Traditional telemetry events and metrics now include `extension_variant` and `rollout_version`; the SDK common properties use the same dimensions; and webview PostHog events are labeled in `before_send`. Accepted host-side error events receive the same rollout metadata.

The bundle activation event now reports the attempted variant, actual variant, whether fallback occurred, the loader decision reason and version, VS Code version, release cadence, and any explicit override. Activation failures are represented only by a bounded error type; raw error messages are intentionally excluded to avoid leaking user or workspace data. The loader remains responsible for selecting the bundle, while the activated bundle remains responsible for applying consent-aware telemetry policy.

The token-usage path now preserves the provider through the SDK boundary, with a production-callsite regression test. The PostHog identity effects also include the relevant identity and telemetry settings in their dependency lists so a running session refreshes when those values change.

#### Debugging journey and decisions

The main gotcha was that this extension has separate build pipelines. Defining rollout metadata only in the extension esbuild configuration does not reach the Vite-built webview, so both build surfaces need explicit inlining and tests.

We considered having the loader send activation telemetry directly, but that would duplicate consent, environment, and PostHog identity behavior outside the application telemetry layer. Passing bounded activation context into the bundle preserves the existing policy boundary. We also avoided runtime environment lookups because build-time constants are deterministic for a packaged artifact and cannot be altered by the extension host after packaging.

For activation errors, sanitizing arbitrary messages still leaves room for accidental disclosure. Emitting only the error type gives us enough operational grouping without carrying free-form data. For rollout versioning, the public workflow-supplied version is used instead of a nested bundle package version so both variants can be queried as one release cohort.

### Test Procedure

Validated from a clean worktree with the same production build paths used for packaging:

1. Installed dependencies with `bun install --frozen-lockfile`.
2. Built the SDK with `bun run build:sdk`.
3. Ran the VS Code production package command with both rollout build variables set. Type checking, compatibility checks, webview build, linting, proto linting, and extension esbuild all passed.
4. Ran the focused Bun telemetry suite: 21 tests passed.
5. Ran the VS Code SDK Vitest suite: 9 tests passed.
6. Ran the SDK core Vitest suite: 44 tests passed.
7. Built the combined `4.1.0` candidate through the A/B packaging worktree and exercised the real packaged VSIX in a VS Code extension host with both forced legacy and forced next overrides. Both variants activated successfully.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — telemetry and packaging behavior only; there are no user-facing UI changes.

### Additional Notes

This PR and its legacy companion should merge before the final release validation of #12253 so the combined artifact reports the same dimensions regardless of which nested bundle activates. The ordinary nightly workflow remains next-only; the A/B workflow is the path that builds the combined candidate.

The rollout version is supplied by the release workflow rather than hardcoded. The final validation candidate used `4.1.0`, while the Marketplace version checked during validation was `4.0.8`.
