### PR TITLE
fix(vscode): complete legacy A/B rollout telemetry attribution

### DIFF
--- a/apps/vscode/esbuild.mjs
+++ b/apps/vscode/esbuild.mjs
@@ -129,6 +129,7 @@ const buildEnvVars = {
 	// Always inline these values so ordinary builds cannot be mislabeled by a
 	// user's runtime environment. Only the combined rollout workflow sets them.
 	"process.env.CLINE_ROLLOUT_VARIANT": JSON.stringify(process.env.CLINE_ROLLOUT_VARIANT || ""),
+	"process.env.CLINE_ROLLOUT_VERSION": JSON.stringify(process.env.CLINE_ROLLOUT_VERSION || ""),
 }
 
 if (production) {

--- a/apps/vscode/src/services/error/providers/PostHogErrorProvider.ts
+++ b/apps/vscode/src/services/error/providers/PostHogErrorProvider.ts
@@ -3,6 +3,7 @@ import { StateManager } from "@/core/storage/StateManager"
 import { HostProvider } from "@/hosts/host-provider"
 import { getDistinctId } from "@/services/logging/distinctId"
 import { PostHogClientProvider } from "@/services/telemetry/providers/posthog/PostHogClientProvider"
+import { attachRolloutTelemetryMetadata } from "@/services/telemetry/rollout-metadata"
 import { fetch } from "@/shared/net"
 import { Setting } from "@/shared/proto/index.host"
 import { Logger } from "@/shared/services/Logger"
@@ -33,7 +34,13 @@ export class PostHogErrorProvider implements IErrorProvider {
 			host: clientConfig.host,
 			fetch: (url, options) => fetch(url, options),
 			enableExceptionAutocapture: clientConfig.enableExceptionAutocapture,
-			before_send: (event) => PostHogClientProvider.eventFilter(event),
+			before_send: (event) => {
+				const filtered = PostHogClientProvider.eventFilter(event)
+				if (filtered) {
+					attachRolloutTelemetryMetadata(filtered)
+				}
+				return filtered
+			},
 		})
 		// Initialize error settings
 		this.errorSettings = {

--- a/apps/vscode/src/services/telemetry/TelemetryService.ts
+++ b/apps/vscode/src/services/telemetry/TelemetryService.ts
@@ -102,6 +102,8 @@ export type TelemetryMetadata = {
 	is_dev: string | undefined
 	/** Present only in bundles built by the combined legacy/next rollout workflow. */
 	extension_variant?: RolloutTelemetryMetadata["extension_variant"]
+	/** Combined VSIX version, distinct from the nested bundle's source version. */
+	rollout_version?: RolloutTelemetryMetadata["rollout_version"]
 }
 
 /**
@@ -587,6 +589,11 @@ export class TelemetryService {
 				attempted_bundle: input.attemptedBundle,
 				actual_bundle: input.actualBundle,
 				fallback: input.fallback,
+				decision_reason: input.decisionReason,
+				loader_version: input.loaderVersion,
+				vscode_version: input.vscodeVersion,
+				ms_since_last_activation: input.msSinceLastActivation,
+				override: input.override,
 				...(input.fallback ? getRolloutErrorProperties(input.error) : {}),
 			},
 		})

--- a/apps/vscode/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
+++ b/apps/vscode/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
@@ -1,7 +1,7 @@
 import { ApiFormat } from "@shared/proto/cline/models"
 import * as assert from "assert"
 import type { ITelemetryProvider, TelemetryProperties, TelemetrySettings } from "../providers/ITelemetryProvider"
-import { ROLLOUT_BUNDLE_ACTIVATED_EVENT, ROLLOUT_ERROR_MESSAGE_LIMIT } from "../rollout-metadata"
+import { ROLLOUT_BUNDLE_ACTIVATED_EVENT } from "../rollout-metadata"
 import { TelemetryMetadata, TelemetryService } from "../TelemetryService"
 
 class FakeProvider implements ITelemetryProvider {
@@ -84,6 +84,7 @@ describe("TelemetryService metrics", () => {
 		const provider = new FakeProvider()
 		const service = createTelemetryService(provider, {
 			extension_variant: "legacy",
+			rollout_version: "4.1.0",
 		})
 
 		service.captureTaskCreated("task-rollout", "anthropic")
@@ -91,8 +92,10 @@ describe("TelemetryService metrics", () => {
 
 		const taskEvent = provider.logs.find((entry) => entry.event === "task.created")
 		assert.strictEqual(taskEvent?.properties?.extension_variant, "legacy")
+		assert.strictEqual(taskEvent?.properties?.rollout_version, "4.1.0")
 		for (const entry of [...provider.counters, ...provider.histograms]) {
 			assert.strictEqual(entry.attributes.extension_variant, "legacy")
+			assert.strictEqual(entry.attributes.rollout_version, "4.1.0")
 		}
 	})
 
@@ -100,13 +103,19 @@ describe("TelemetryService metrics", () => {
 		const provider = new FakeProvider()
 		const service = createTelemetryService(provider, {
 			extension_variant: "legacy",
+			rollout_version: "4.1.0",
 		})
 
 		service.captureRolloutBundleActivated({
 			attemptedBundle: "next",
 			actualBundle: "legacy",
 			fallback: true,
-			error: new TypeError("x".repeat(ROLLOUT_ERROR_MESSAGE_LIMIT + 20)),
+			error: new TypeError("sensitive activation detail"),
+			decisionReason: "cached_next",
+			loaderVersion: "4.1.0",
+			vscodeVersion: "1.103.0",
+			msSinceLastActivation: 1_000,
+			override: "setting",
 		})
 
 		const events = provider.logs.filter((entry) => entry.event === ROLLOUT_BUNDLE_ACTIVATED_EVENT)
@@ -114,9 +123,15 @@ describe("TelemetryService metrics", () => {
 		assert.strictEqual(events[0].properties?.attempted_bundle, "next")
 		assert.strictEqual(events[0].properties?.actual_bundle, "legacy")
 		assert.strictEqual(events[0].properties?.fallback, true)
+		assert.strictEqual(events[0].properties?.decision_reason, "cached_next")
+		assert.strictEqual(events[0].properties?.loader_version, "4.1.0")
+		assert.strictEqual(events[0].properties?.vscode_version, "1.103.0")
+		assert.strictEqual(events[0].properties?.ms_since_last_activation, 1_000)
+		assert.strictEqual(events[0].properties?.override, "setting")
 		assert.strictEqual(events[0].properties?.error_type, "TypeError")
-		assert.strictEqual((events[0].properties?.error_message as string).length, ROLLOUT_ERROR_MESSAGE_LIMIT)
+		assert.strictEqual(events[0].properties?.error_message, undefined)
 		assert.strictEqual(events[0].properties?.extension_variant, "legacy")
+		assert.strictEqual(events[0].properties?.rollout_version, "4.1.0")
 	})
 
 	it("does not capture rollout activation events for ordinary builds", () => {

--- a/apps/vscode/src/services/telemetry/__tests__/rollout-metadata.test.ts
+++ b/apps/vscode/src/services/telemetry/__tests__/rollout-metadata.test.ts
@@ -1,40 +1,78 @@
 import * as assert from "assert"
-import { getRolloutErrorProperties, getRolloutTelemetryMetadata, ROLLOUT_ERROR_MESSAGE_LIMIT } from "../rollout-metadata"
+import {
+	attachRolloutTelemetryMetadata,
+	getRolloutErrorProperties,
+	getRolloutTelemetryMetadata,
+	ROLLOUT_ERROR_TYPE_LIMIT,
+} from "../rollout-metadata"
 
 const originalVariant = process.env.CLINE_ROLLOUT_VARIANT
+const originalRolloutVersion = process.env.CLINE_ROLLOUT_VERSION
 
 afterEach(() => {
 	restoreEnv("CLINE_ROLLOUT_VARIANT", originalVariant)
+	restoreEnv("CLINE_ROLLOUT_VERSION", originalRolloutVersion)
 })
 
 describe("rollout telemetry metadata", () => {
 	it("returns metadata for a rollout build", () => {
 		process.env.CLINE_ROLLOUT_VARIANT = "legacy"
+		process.env.CLINE_ROLLOUT_VERSION = "4.1.0"
 
 		assert.deepStrictEqual(getRolloutTelemetryMetadata(), {
 			extension_variant: "legacy",
+			rollout_version: "4.1.0",
 		})
 	})
 
 	it("omits metadata for ordinary or invalid builds", () => {
 		delete process.env.CLINE_ROLLOUT_VARIANT
+		process.env.CLINE_ROLLOUT_VERSION = "4.1.0"
 		assert.deepStrictEqual(getRolloutTelemetryMetadata(), {})
 
 		process.env.CLINE_ROLLOUT_VARIANT = "invalid"
 		assert.deepStrictEqual(getRolloutTelemetryMetadata(), {})
 	})
 
-	it("bounds fallback errors without including stacks", () => {
-		const error = new TypeError("x".repeat(ROLLOUT_ERROR_MESSAGE_LIMIT + 20))
-		const properties = getRolloutErrorProperties(error)
+	it("decorates accepted error events while preserving their properties", () => {
+		process.env.CLINE_ROLLOUT_VARIANT = "legacy"
+		process.env.CLINE_ROLLOUT_VERSION = "4.1.0"
+		const event: { properties?: Record<string, unknown> } = {
+			properties: { existing: true, extension_variant: "spoofed" },
+		}
 
-		assert.strictEqual(properties.error_type, "TypeError")
-		assert.strictEqual(properties.error_message.length, ROLLOUT_ERROR_MESSAGE_LIMIT)
-		assert.ok(!properties.error_message.includes("TypeError:"))
+		attachRolloutTelemetryMetadata(event)
+
+		assert.deepStrictEqual(event.properties, {
+			existing: true,
+			extension_variant: "legacy",
+			rollout_version: "4.1.0",
+		})
+	})
+
+	it("does not label error events from ordinary builds", () => {
+		delete process.env.CLINE_ROLLOUT_VARIANT
+		delete process.env.CLINE_ROLLOUT_VERSION
+		const event: { properties?: Record<string, unknown> } = {
+			properties: { existing: true },
+		}
+		attachRolloutTelemetryMetadata(event)
+		assert.deepStrictEqual(event.properties, { existing: true })
+	})
+
+	it("reports only a bounded error type and never the raw fallback message", () => {
+		const error = new TypeError('authorization: Bearer abc123 {"apiKey":"secret"}')
+		assert.deepStrictEqual(getRolloutErrorProperties(error), { error_type: "TypeError" })
+
+		error.name = "x".repeat(ROLLOUT_ERROR_TYPE_LIMIT + 1)
+		assert.deepStrictEqual(getRolloutErrorProperties(error), { error_type: "Error" })
+
+		error.name = "Unsafe Error Name"
+		assert.deepStrictEqual(getRolloutErrorProperties(error), { error_type: "Error" })
 	})
 })
 
-function restoreEnv(key: "CLINE_ROLLOUT_VARIANT", value: string | undefined): void {
+function restoreEnv(key: "CLINE_ROLLOUT_VARIANT" | "CLINE_ROLLOUT_VERSION", value: string | undefined): void {
 	if (value === undefined) {
 		delete process.env[key]
 	} else {

--- a/apps/vscode/src/services/telemetry/rollout-metadata.ts
+++ b/apps/vscode/src/services/telemetry/rollout-metadata.ts
@@ -2,6 +2,7 @@ export type ExtensionVariant = "legacy" | "next"
 
 export interface RolloutTelemetryMetadata {
 	extension_variant: ExtensionVariant
+	rollout_version?: string
 }
 
 export interface RolloutBundleActivation {
@@ -9,35 +10,63 @@ export interface RolloutBundleActivation {
 	actualBundle: ExtensionVariant
 	fallback: boolean
 	error?: unknown
+	decisionReason?:
+		| "env_override"
+		| "setting_override"
+		| "killswitch"
+		| "previous_failure"
+		| "cached_next"
+		| "cached_legacy"
+		| "default_legacy"
+	loaderVersion?: string
+	vscodeVersion?: string
+	msSinceLastActivation?: number
+	override?: "env" | "setting"
 }
 
 export const ROLLOUT_BUNDLE_ACTIVATED_EVENT = "extension.rollout.bundle_activated"
-export const ROLLOUT_ERROR_MESSAGE_LIMIT = 500
+export const ROLLOUT_ERROR_TYPE_LIMIT = 64
 
 /** Return rollout metadata only for bundles built by the combined rollout workflow. */
 export function getRolloutTelemetryMetadata(): Partial<RolloutTelemetryMetadata> {
 	const variant = process.env.CLINE_ROLLOUT_VARIANT
+	const rolloutVersion = process.env.CLINE_ROLLOUT_VERSION
 
 	if (variant !== "legacy" && variant !== "next") {
 		return {}
 	}
 
-	return { extension_variant: variant }
+	return {
+		extension_variant: variant,
+		...(rolloutVersion ? { rollout_version: rolloutVersion } : {}),
+	}
+}
+
+export function attachRolloutTelemetryMetadata(event: {
+	properties?: Record<string, unknown>
+}): void {
+	event.properties = {
+		...event.properties,
+		...getRolloutTelemetryMetadata(),
+	}
 }
 
 export function getRolloutErrorProperties(error: unknown): {
 	error_type: string
-	error_message: string
 } {
 	if (error instanceof Error) {
 		return {
-			error_type: error.name || "Error",
-			error_message: error.message.slice(0, ROLLOUT_ERROR_MESSAGE_LIMIT),
+			error_type: normalizeRolloutErrorType(error.name, "Error"),
 		}
 	}
 
 	return {
 		error_type: error === undefined ? "unknown" : error === null ? "null" : typeof error,
-		error_message: (error === undefined ? "Unknown activation error" : String(error)).slice(0, ROLLOUT_ERROR_MESSAGE_LIMIT),
 	}
+}
+
+function normalizeRolloutErrorType(value: string, fallback: string): string {
+	return value.length > 0 && value.length <= ROLLOUT_ERROR_TYPE_LIMIT && /^[A-Za-z][A-Za-z0-9_.-]*$/.test(value)
+		? value
+		: fallback
 }

--- a/apps/vscode/webview-ui/src/CustomPostHogProvider.tsx
+++ b/apps/vscode/webview-ui/src/CustomPostHogProvider.tsx
@@ -4,6 +4,9 @@ import { PostHogProvider } from "posthog-js/react"
 import { type ReactNode, useEffect, useState } from "react"
 import { useExtensionState } from "./context/ExtensionStateContext"
 
+const extensionVariant = process.env.CLINE_ROLLOUT_VARIANT
+const rolloutVersion = process.env.CLINE_ROLLOUT_VERSION
+
 export function CustomPostHogProvider({ children }: { children: ReactNode }) {
 	const { distinctId, version, userInfo, environment, telemetrySetting } = useExtensionState()
 
@@ -31,7 +34,7 @@ export function CustomPostHogProvider({ children }: { children: ReactNode }) {
 			autocapture: false,
 		})
 		setIsActive(true)
-	}, [isSelfHostedOrUnknown])
+	}, [isSelfHostedOrUnknown, isActive])
 
 	useEffect(() => {
 		if (!isActive || !distinctId || !version) {
@@ -48,6 +51,12 @@ export function CustomPostHogProvider({ children }: { children: ReactNode }) {
 				if (payload?.properties) {
 					payload.properties.extension_version = version
 					payload.properties.distinct_id = distinctId
+					if (extensionVariant === "legacy" || extensionVariant === "next") {
+						payload.properties.extension_variant = extensionVariant
+						if (rolloutVersion) {
+							payload.properties.rollout_version = rolloutVersion
+						}
+					}
 				}
 				return payload
 			},
@@ -68,7 +77,7 @@ export function CustomPostHogProvider({ children }: { children: ReactNode }) {
 			// Then opt out of capturing other events
 			posthog.opt_out_capturing()
 		}
-	}, [isActive, isTelemetryEnabled, distinctId, version])
+	}, [isActive, isTelemetryEnabled, distinctId, version, userInfo?.email, userInfo?.displayName])
 
 	return <PostHogProvider client={posthog}>{children}</PostHogProvider>
 }

--- a/apps/vscode/webview-ui/vite.config.ts
+++ b/apps/vscode/webview-ui/vite.config.ts
@@ -143,6 +143,12 @@ export default defineConfig(({ mode }) => {
 			"process.env.ENABLE_ERROR_AUTOCAPTURE": JSON.stringify(
 				env.ENABLE_ERROR_AUTOCAPTURE,
 			),
+			"process.env.CLINE_ROLLOUT_VARIANT": JSON.stringify(
+				env.CLINE_ROLLOUT_VARIANT ?? "",
+			),
+			"process.env.CLINE_ROLLOUT_VERSION": JSON.stringify(
+				env.CLINE_ROLLOUT_VERSION ?? "",
+			),
 			// OpenTelemetry environment variables
 			"process.env.OTEL_TELEMETRY_ENABLED": JSON.stringify(
 				env.OTEL_TELEMETRY_ENABLED,


### PR DESCRIPTION
### Related Issue

**Issue:** #12253

Follow-up to #12291. Companion main-branch PR: #12297

### Description

#### Problem

The initial legacy-extension telemetry change added a build-time `extension_variant`, allowing the staged loader to identify telemetry from the legacy bundle. End-to-end validation found several attribution paths that still needed the same rollout context:

- The nested legacy bundle package version may differ from the public combined-extension version, so variant alone cannot identify a release cohort.
- Webview PostHog events and host-side error autocapture do not all flow through the traditional telemetry event service.
- The loader needs a bounded activation result from the bundle that actually ran, including whether a next-to-legacy fallback occurred, while respecting the bundle's existing consent policy.
- PostHog identity effects did not react to all relevant identity and telemetry changes during a running session.

Without this mirror change, fallback sessions could be distinguishable at the loader level but remain partially unattributed once the legacy bundle is active.

#### Technical approach

This follow-up adds a build-time `CLINE_ROLLOUT_VERSION` beside `CLINE_EXTENSION_VARIANT` in both the extension-host and webview build pipelines. Traditional telemetry events and metrics, webview PostHog events, and accepted host-side error events now share the `extension_variant` and `rollout_version` dimensions.

The legacy bundle activation event accepts the bounded loader context and reports the attempted and actual variants, fallback status, decision reason, loader version, VS Code version, cadence, and override. Activation failures include only an error type; raw messages are deliberately omitted to keep free-form user or workspace data out of telemetry.

PostHog identity effects now depend on the relevant user identity and telemetry settings so attribution is refreshed when those values change within the same session.

#### Debugging journey and decisions

The legacy branch has the same split-build constraint as main: constants defined in the extension esbuild configuration do not automatically exist in the Vite-built webview. The rollout dimensions therefore need to be defined and verified independently on both surfaces.

We considered emitting loader-owned telemetry, but that would recreate consent and identity policy in the small bootstrap layer. Keeping reporting in the activated legacy bundle preserves the existing telemetry boundary and allows the loader to remain fail-open if reporting stalls or throws.

The public workflow version is used rather than the nested bundle package version, ensuring that legacy fallback and next activation can be queried as one combined release. Free-form error messages were excluded instead of heuristically redacted because a bounded type is sufficient for rollout diagnostics and materially safer.

### Test Procedure

Validated from a clean legacy-extension worktree using its native npm-based build and test paths:

1. Installed exact extension and webview dependencies with `npm ci`.
2. Rebuilt `grpc-tools` with lifecycle scripts enabled because this environment disables dependency lifecycle scripts by default.
3. Ran the production package command with both rollout build variables set. Type checking, webview build, linting, proto linting, and extension esbuild all passed.
4. Ran the focused telemetry Mocha suite: 20 tests passed.
5. Built the combined `4.1.0` candidate through the A/B packaging worktree and exercised the real packaged VSIX in a VS Code extension host with both forced legacy and forced next overrides. The packaged legacy bundle activated successfully both when selected directly and as the fallback target.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — telemetry and packaging behavior only; there are no user-facing UI changes.

### Additional Notes

This is intentionally a legacy-extension mirror of the rollout attribution behavior in the main companion PR. Both should merge before final release validation of #12253 so a next activation and a legacy selection or fallback emit comparable rollout dimensions.

The ordinary nightly workflow remains next-only; the combined A/B workflow is the release path that exercises this legacy bundle. The rollout version is supplied by that workflow rather than hardcoded.
