### PR TITLE
fix(sdk): preserve file line endings in the editor tool executor

### DIFF
--- a/sdk/packages/core/src/extensions/tools/executors/editor.test.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/editor.test.ts
@@ -241,6 +241,25 @@ describe("createEditorExecutor", () => {
 		});
 	});
 
+	it("inserts $-sequences in new_text literally", async () => {
+		await withTempFile("a\nb\nc", async (filePath, dir) => {
+			const editor = createEditorExecutor();
+			await editor(
+				{
+					path: filePath,
+					old_text: "b",
+					new_text: "cost=$100 pid=$$ match=$& rest=$'",
+				},
+				dir,
+				context,
+			);
+
+			await expect(fs.readFile(filePath, "utf-8")).resolves.toBe(
+				"a\ncost=$100 pid=$$ match=$& rest=$'\nc",
+			);
+		});
+	});
+
 	it("rejects insert_line 0 with the valid one-based boundary range", async () => {
 		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "agents-editor-"));
 		const filePath = path.join(dir, "example.txt");

--- a/sdk/packages/core/src/extensions/tools/executors/editor.test.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/editor.test.ts
@@ -189,6 +189,58 @@ describe("createEditorExecutor", () => {
 		});
 	});
 
+	it("preserves CRLF line endings when inserting LF-only text into a CRLF file", async () => {
+		await withTempFile("one\r\ntwo\r\nthree", async (filePath, dir) => {
+			const editor = createEditorExecutor();
+			await editor(
+				{
+					path: filePath,
+					new_text: "first\nsecond",
+					insert_line: 2,
+				},
+				dir,
+				context,
+			);
+
+			await expect(fs.readFile(filePath, "utf-8")).resolves.toBe(
+				"one\r\nfirst\r\nsecond\r\ntwo\r\nthree",
+			);
+		});
+	});
+
+	it("replaces multi-line LF old_text in a CRLF file and keeps CRLF endings", async () => {
+		await withTempFile("a\r\nb\r\nc\r\nd", async (filePath, dir) => {
+			const editor = createEditorExecutor();
+			// Reads strip "\r", so the model round-trips LF-only text even
+			// though the file on disk is CRLF.
+			const result = await editor(
+				{ path: filePath, old_text: "b\nc", new_text: "B\nC\nX" },
+				dir,
+				context,
+			);
+
+			expect(result).toBe(
+				`Edited ${filePath}\n\`\`\`diff\n-2: b\n-3: c\n+2: B\n+3: C\n+4: X\n\`\`\``,
+			);
+			await expect(fs.readFile(filePath, "utf-8")).resolves.toBe(
+				"a\r\nB\r\nC\r\nX\r\nd",
+			);
+		});
+	});
+
+	it("replaces text in a pure-LF file without introducing CRLF", async () => {
+		await withTempFile("a\nb\nc", async (filePath, dir) => {
+			const editor = createEditorExecutor();
+			await editor(
+				{ path: filePath, old_text: "b\nc", new_text: "B\r\nC" },
+				dir,
+				context,
+			);
+
+			await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("a\nB\nC");
+		});
+	});
+
 	it("rejects insert_line 0 with the valid one-based boundary range", async () => {
 		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "agents-editor-"));
 		const filePath = path.join(dir, "example.txt");

--- a/sdk/packages/core/src/extensions/tools/executors/editor.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/editor.ts
@@ -64,13 +64,27 @@ function countOccurrences(content: string, needle: string): number {
 	return content.split(needle).length - 1;
 }
 
+/**
+ * Dominant end-of-line sequence of the file. Reads produced via readline strip
+ * "\r", so models emit LF-only text even for CRLF files; edits must be
+ * normalized to the file's own EOL or they create mixed line endings and
+ * break subsequent exact-match replacements.
+ */
+function detectLineEnding(content: string): "\r\n" | "\n" {
+	return content.includes("\r\n") ? "\r\n" : "\n";
+}
+
+function normalizeLineEndings(text: string, eol: "\r\n" | "\n"): string {
+	return text.split(/\r\n|\n/).join(eol);
+}
+
 function createLineDiff(
 	oldContent: string,
 	newContent: string,
 	maxLines: number,
 ): string {
-	const oldLines = oldContent.split("\n");
-	const newLines = newContent.split("\n");
+	const oldLines = oldContent.split(/\r\n|\n/);
+	const newLines = newContent.split(/\r\n|\n/);
 
 	// Trim the common prefix and suffix so only the changed region is emitted;
 	// a naive positional compare would mispair every line after an edit that
@@ -155,7 +169,10 @@ async function replaceInFile(
 	maxDiffLines: number,
 ): Promise<string> {
 	const content = await fs.readFile(filePath, encoding);
-	const occurrences = countOccurrences(content, oldStr);
+	const eol = detectLineEnding(content);
+	const normalizedOldStr = normalizeLineEndings(oldStr, eol);
+	const normalizedNewStr = normalizeLineEndings(newStr ?? "", eol);
+	const occurrences = countOccurrences(content, normalizedOldStr);
 
 	if (occurrences === 0) {
 		throw new Error(`No replacement performed: text not found in ${filePath}.`);
@@ -167,7 +184,7 @@ async function replaceInFile(
 		);
 	}
 
-	const updated = content.replace(oldStr, newStr ?? "");
+	const updated = content.replace(normalizedOldStr, normalizedNewStr);
 	await fs.writeFile(filePath, updated, { encoding });
 
 	const diff = createLineDiff(content, updated, maxDiffLines);
@@ -181,7 +198,8 @@ async function insertInFile(
 	encoding: BufferEncoding,
 ): Promise<string> {
 	const content = await fs.readFile(filePath, encoding);
-	const lines = content.split("\n");
+	const eol = detectLineEnding(content);
+	const lines = content.split(/\r\n|\n/);
 	const maxBoundaryLine = lines.length + 1;
 
 	if (insertLineOneBased < 1 || insertLineOneBased > maxBoundaryLine) {
@@ -191,8 +209,8 @@ async function insertInFile(
 	}
 
 	const insertLine = insertLineOneBased - 1;
-	lines.splice(insertLine, 0, ...newStr.split("\n"));
-	await fs.writeFile(filePath, lines.join("\n"), { encoding });
+	lines.splice(insertLine, 0, ...newStr.split(/\r\n|\n/));
+	await fs.writeFile(filePath, lines.join(eol), { encoding });
 
 	return `Inserted content at line ${insertLineOneBased} in ${filePath}.`;
 }

--- a/sdk/packages/core/src/extensions/tools/executors/editor.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/editor.ts
@@ -65,12 +65,16 @@ function countOccurrences(content: string, needle: string): number {
 }
 
 /**
- * Returns "\r\n" if the content contains any CRLF sequence, otherwise "\n".
- * A presence check rather than a majority vote: in practice files are
- * uniformly CRLF or uniformly LF, and the first occurrence is sufficient.
- * Reads produced via readline strip "\r", so models emit LF-only text even
- * for CRLF files; edits must be normalized to the file's own EOL or they
- * create mixed line endings and break subsequent exact-match replacements.
+ * Returns "\r\n" if "\r\n" appears anywhere in the content, otherwise "\n" —
+ * including for content with no line breaks at all. Files are uniformly CRLF
+ * or uniformly LF in practice; the mixed case that matters is a CRLF file
+ * with LF-only lines inserted by earlier releases of this tool, and any
+ * surviving "\r\n" — wherever it sits — should pull such a file back to
+ * CRLF, which is why this checks for "\r\n" anywhere rather than looking at
+ * the first line break. Reads produced via readline strip "\r", so models
+ * emit LF-only text even for CRLF files; edits must be normalized to the
+ * file's own EOL or they create mixed line endings and break subsequent
+ * exact-match replacements.
  */
 function detectLineEnding(content: string): "\r\n" | "\n" {
 	return content.includes("\r\n") ? "\r\n" : "\n";

--- a/sdk/packages/core/src/extensions/tools/executors/editor.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/editor.ts
@@ -65,10 +65,12 @@ function countOccurrences(content: string, needle: string): number {
 }
 
 /**
- * Dominant end-of-line sequence of the file. Reads produced via readline strip
- * "\r", so models emit LF-only text even for CRLF files; edits must be
- * normalized to the file's own EOL or they create mixed line endings and
- * break subsequent exact-match replacements.
+ * Returns "\r\n" if the content contains any CRLF sequence, otherwise "\n".
+ * A presence check rather than a majority vote: in practice files are
+ * uniformly CRLF or uniformly LF, and the first occurrence is sufficient.
+ * Reads produced via readline strip "\r", so models emit LF-only text even
+ * for CRLF files; edits must be normalized to the file's own EOL or they
+ * create mixed line endings and break subsequent exact-match replacements.
  */
 function detectLineEnding(content: string): "\r\n" | "\n" {
 	return content.includes("\r\n") ? "\r\n" : "\n";
@@ -184,7 +186,9 @@ async function replaceInFile(
 		);
 	}
 
-	const updated = content.replace(normalizedOldStr, normalizedNewStr);
+	// Replacer function so "$"-sequences in new_text ($&, $', $`, $$, $n)
+	// are inserted literally instead of being expanded by String.replace.
+	const updated = content.replace(normalizedOldStr, () => normalizedNewStr);
 	await fs.writeFile(filePath, updated, { encoding });
 
 	const diff = createLineDiff(content, updated, maxDiffLines);


### PR DESCRIPTION
## Problem

Reported via JetBrains marketplace review #141234 (DeepSeek + CLion on Windows).

The native editor executor (`sdk/packages/core/src/extensions/tools/executors/editor.ts`) split and joined file content on `"\n"` only:

- **`insertInFile` corrupted CRLF files.** Existing lines kept their trailing `\r` (since splitting on `"\n"` leaves it attached), while the inserted `new_text` lines were LF-only — producing mixed line endings on disk.
- **`replaceInFile` then failed on those files** (and on pure-CRLF files with any multi-line `old_text`). The read tool (`file-read.ts`) goes through `readline` with `crlfDelay`, which strips `\r`, so the model always emits LF-only `old_text`. Exact byte matching against CRLF content finds no occurrence, and the edit loop dead-ends with "text not found".

## Fix

- Detect the file's dominant EOL: `content.includes("\r\n") ? "\r\n" : "\n"`.
- `insertInFile`: split both the file content and `new_text` on `/\r\n|\n/`, join with the detected EOL.
- `replaceInFile`: normalize `old_text`/`new_text` to the detected EOL before matching and replacing, so LF-only `old_text` matches CRLF files (and CRLF `old_text` matches LF files).
- `createLineDiff`: split on `/\r\n|\n/` so the diff echoed back to the model doesn't embed stray `\r` characters.

## Tests

Added to `editor.test.ts`:
- insert of LF-only text into a CRLF file preserves CRLF throughout
- multi-line replace with LF `old_text`/`new_text` on a CRLF file matches and stays CRLF
- replace with CRLF-containing `new_text` on an LF file stays LF

`vitest run src/extensions/tools/executors/editor.test.ts`: 11/11 pass. `tsc -p tsconfig.dev.json --noEmit`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)