### PR TITLE
fix(vscode): preserve Plan mode tool result ordering

### DIFF
--- a/apps/vscode/src/sdk/webview-grpc-bridge.test.ts
+++ b/apps/vscode/src/sdk/webview-grpc-bridge.test.ts
@@ -76,6 +76,33 @@ describe("WebviewGrpcBridge", () => {
 
 			expect(sendPartialMessageEvent).toHaveBeenCalledTimes(2)
 		})
+
+		it("should preserve message order when a send is slow", async () => {
+			const { sendPartialMessageEvent } = await import("@core/controller/ui/subscribeToPartialMessage")
+			const sent: string[] = []
+			let releaseFirst: (() => void) | undefined
+			;(sendPartialMessageEvent as any).mockImplementationOnce(async (message: { text: string }) => {
+				sent.push(message.text)
+				await new Promise<void>((resolve) => {
+					releaseFirst = resolve
+				})
+			})
+			;(sendPartialMessageEvent as any).mockImplementationOnce(async (message: { text: string }) => {
+				sent.push(message.text)
+			})
+
+			const listener = bridge.createListener()
+			const event = { type: "status", payload: { sessionId: "s1", status: "running" } }
+			// biome-ignore lint/suspicious/noExplicitAny: test-only event type
+			listener([{ ts: 1, type: "say" as const, say: "tool" as const, text: "started", partial: true }], event as any)
+			listener([{ ts: 1, type: "say" as const, say: "tool" as const, text: "finished", partial: false }], event as any)
+
+			await Promise.resolve()
+			expect(sent).toEqual(["started"])
+			releaseFirst?.()
+			await new Promise((resolve) => setTimeout(resolve, 0))
+			expect(sent).toEqual(["started", "finished"])
+		})
 	})
 
 	describe("pushStateUpdateFromController", () => {

--- a/apps/vscode/src/sdk/webview-grpc-bridge.ts
+++ b/apps/vscode/src/sdk/webview-grpc-bridge.ts
@@ -91,12 +91,7 @@ export class WebviewGrpcBridge {
 	 * Push a ClineMessage to the webview via the subscribeToPartialMessage stream.
 	 */
 	private async pushPartialMessage(message: ClineMessage): Promise<void> {
-		try {
-			const protoMessage: ProtoClineMessage = convertClineMessageToProto(message)
-			await sendPartialMessageEvent(protoMessage)
-		} catch (error) {
-			Logger.error("[WebviewGrpcBridge] Failed to push partial message:", error)
-		}
+		await enqueuePartialMessage(message)
 	}
 
 	/**
@@ -152,10 +147,22 @@ export class WebviewGrpcBridge {
  * Useful for one-off messages outside the bridge's event loop.
  */
 export async function pushMessageToWebview(message: ClineMessage): Promise<void> {
-	try {
-		const protoMessage: ProtoClineMessage = convertClineMessageToProto(message)
-		await sendPartialMessageEvent(protoMessage)
-	} catch (error) {
-		Logger.error("[WebviewGrpcBridge] Failed to push message to webview:", error)
-	}
+	await enqueuePartialMessage(message)
+}
+
+let partialMessageQueue = Promise.resolve()
+
+function enqueuePartialMessage(message: ClineMessage): Promise<void> {
+	// The gRPC send is asynchronous; serialize it so a final tool result cannot
+	// overtake the preceding tool-start message in the webview.
+	const send = partialMessageQueue.then(async () => {
+		try {
+			const protoMessage: ProtoClineMessage = convertClineMessageToProto(message)
+			await sendPartialMessageEvent(protoMessage)
+		} catch (error) {
+			Logger.error("[WebviewGrpcBridge] Failed to push partial message:", error)
+		}
+	})
+	partialMessageQueue = send.catch(() => {})
+	return send
 }


### PR DESCRIPTION
## Summary

Fixes #12300.

- Serialize partial-message gRPC sends so tool lifecycle messages reach the webview in order.
- Prevent a completed read result from overtaking its tool-start message when a send is slow.
- Add a regression test covering delayed sends.

## Verification

- `bun -F claude-dev test:vitest -- src/sdk/webview-grpc-bridge.test.ts`
- Biome lint/check passed for changed files
- Full VS Code typecheck remains blocked by the existing `OpenAiModelsRequest.providerId` error in `src/core/controller/models/refreshOpenAiModels.ts`