### PR TITLE
fix(mcp): cap streamable HTTP reconnect flapping

### DIFF
--- a/apps/vscode/src/services/mcp/McpHub.ts
+++ b/apps/vscode/src/services/mcp/McpHub.ts
@@ -44,9 +44,9 @@ import { expandEnvironmentVariables } from "@/utils/envExpansion"
 import type { TelemetryService } from "../telemetry/TelemetryService"
 import { DEFAULT_REQUEST_TIMEOUT_MS } from "./constants"
 import { McpOAuthManager } from "./McpOAuthManager"
-import { updateMcpSettingsFile } from "./settingsLock"
-import { StreamableHttpReconnectHandler } from "./StreamableHttpReconnectHandler"
+import { type ReconnectState, StreamableHttpReconnectHandler } from "./StreamableHttpReconnectHandler"
 import { BaseConfigSchema, McpSettingsSchema, ServerConfigSchema } from "./schemas"
+import { updateMcpSettingsFile } from "./settingsLock"
 import type { McpConnection, McpServerConfig, Transport } from "./types"
 export class McpHub {
 	getMcpServersPath: () => Promise<string>
@@ -54,6 +54,7 @@ export class McpHub {
 	private clientVersion: string
 	private telemetryService: TelemetryService
 	private mcpOAuthManager: McpOAuthManager
+	private streamableHttpReconnectStates = new Map<string, ReconnectState>()
 
 	private settingsWatcher?: FSWatcher
 	private fileWatchers: Map<string, FSWatcher> = new Map()
@@ -604,15 +605,22 @@ export class McpHub {
 						fetch: streamableHttpFetch,
 					})
 
-					const reconnectHandler = new StreamableHttpReconnectHandler(name, {
-						findConnection: () => this.findConnection(name, source),
-						deleteConnection: () => this.deleteConnection(name),
-						connectToServer: () => this.connectToServer(name, config, source),
-						notifyWebviewOfServerChanges: () => this.notifyWebviewOfServerChanges(),
-						appendErrorMessage: (conn, msg) => this.appendErrorMessage(conn as McpConnection, msg),
-						deleteServerKey: (uid) => McpHub.mcpServerKeys.delete(uid),
-						delay: (ms) => setTimeoutPromise(ms),
-					})
+					const reconnectState = this.streamableHttpReconnectStates.get(name) ?? { attempts: 0 }
+					this.streamableHttpReconnectStates.set(name, reconnectState)
+					const reconnectHandler = new StreamableHttpReconnectHandler(
+						name,
+						{
+							findConnection: () => this.findConnection(name, source),
+							deleteConnection: () => this.deleteConnection(name),
+							connectToServer: () => this.connectToServer(name, config, source),
+							notifyWebviewOfServerChanges: () => this.notifyWebviewOfServerChanges(),
+							appendErrorMessage: (conn, msg) => this.appendErrorMessage(conn as McpConnection, msg),
+							deleteServerKey: (uid) => McpHub.mcpServerKeys.delete(uid),
+							delay: (ms) => setTimeoutPromise(ms),
+						},
+						undefined,
+						reconnectState,
+					)
 
 					transport.onerror = (error) => reconnectHandler.handleError(error)
 					break

--- a/apps/vscode/src/services/mcp/StreamableHttpReconnectHandler.ts
+++ b/apps/vscode/src/services/mcp/StreamableHttpReconnectHandler.ts
@@ -29,12 +29,20 @@ export interface ReconnectConfig {
 	maxAttempts: number
 	/** Returns the delay in milliseconds for a given attempt (0-based). */
 	getDelayMs: (attempt: number) => number
+	/** How long a successful connection must remain healthy before resetting attempts. */
+	stabilityWindowMs: number
+}
+
+export interface ReconnectState {
+	attempts: number
+	resetTimer?: ReturnType<typeof setTimeout>
 }
 
 /** Default configuration: up to 6 attempts with exponential backoff starting at 2 s. */
 export const DEFAULT_RECONNECT_CONFIG: ReconnectConfig = {
 	maxAttempts: 6,
 	getDelayMs: (attempt: number) => 2000 * 2 ** attempt,
+	stabilityWindowMs: 30_000,
 }
 
 /**
@@ -50,25 +58,54 @@ export const DEFAULT_RECONNECT_CONFIG: ReconnectConfig = {
  * 5. After exhausting retries, mark the server as disconnected.
  */
 export class StreamableHttpReconnectHandler {
-	private attempts = 0
+	private readonly state: ReconnectState
+	private readonly usesSharedState: boolean
 	private readonly serverName: string
 	private readonly config: ReconnectConfig
 	private readonly callbacks: ReconnectCallbacks
 
-	constructor(serverName: string, callbacks: ReconnectCallbacks, config: ReconnectConfig = DEFAULT_RECONNECT_CONFIG) {
+	constructor(
+		serverName: string,
+		callbacks: ReconnectCallbacks,
+		config: ReconnectConfig = DEFAULT_RECONNECT_CONFIG,
+		state?: ReconnectState,
+	) {
 		this.serverName = serverName
 		this.callbacks = callbacks
 		this.config = config
+		this.state = state ?? { attempts: 0 }
+		this.usesSharedState = state !== undefined
 	}
 
 	/** Number of consecutive reconnect attempts so far */
 	get attemptCount(): number {
-		return this.attempts
+		return this.state.attempts
 	}
 
 	/** Reset the attempt counter (e.g. after a successful long-lived connection) */
 	resetAttempts(): void {
-		this.attempts = 0
+		this.clearResetTimer()
+		this.state.attempts = 0
+	}
+
+	private clearResetTimer(): void {
+		if (this.state.resetTimer) {
+			clearTimeout(this.state.resetTimer)
+			this.state.resetTimer = undefined
+		}
+	}
+
+	private markConnectionHealthy(): void {
+		if (!this.usesSharedState) {
+			this.state.attempts = 0
+			return
+		}
+
+		this.clearResetTimer()
+		this.state.resetTimer = setTimeout(() => {
+			this.state.attempts = 0
+			this.state.resetTimer = undefined
+		}, this.config.stabilityWindowMs)
 	}
 
 	/**
@@ -87,7 +124,9 @@ export class StreamableHttpReconnectHandler {
 			return
 		}
 
-		if (this.attempts >= this.config.maxAttempts) {
+		this.clearResetTimer()
+
+		if (this.state.attempts >= this.config.maxAttempts) {
 			// Max retries exhausted
 			Logger.error(
 				`StreamableHTTP max reconnect attempts (${this.config.maxAttempts}) ` +
@@ -102,11 +141,11 @@ export class StreamableHttpReconnectHandler {
 
 		// First attempt: backoff, verify staleness, then delete + connect.
 		// Subsequent attempts (on connectToServer failure) just backoff + connect.
-		const initialDelay = this.config.getDelayMs(this.attempts)
-		this.attempts++
+		const initialDelay = this.config.getDelayMs(this.state.attempts)
+		this.state.attempts++
 		Logger.log(
 			`StreamableHTTP transport error for "${this.serverName}", attempting reconnect ` +
-				`${this.attempts}/${this.config.maxAttempts} in ${initialDelay / 1000}s...`,
+				`${this.state.attempts}/${this.config.maxAttempts} in ${initialDelay / 1000}s...`,
 		)
 
 		connection.server.status = "connecting"
@@ -126,19 +165,19 @@ export class StreamableHttpReconnectHandler {
 		// established, which would silently break the retry chain.
 		await this.callbacks.deleteConnection()
 
-		while (this.attempts <= this.config.maxAttempts) {
+		while (this.state.attempts <= this.config.maxAttempts) {
 			try {
 				await this.callbacks.connectToServer()
 				Logger.log(`StreamableHTTP reconnect succeeded for "${this.serverName}"`)
-				this.attempts = 0
+				this.markConnectionHealthy()
 				return
 			} catch (reconnectError) {
 				Logger.error(`StreamableHTTP reconnect failed for "${this.serverName}":`, reconnectError)
-				if (this.attempts < this.config.maxAttempts) {
-					const retryDelay = this.config.getDelayMs(this.attempts)
-					this.attempts++
+				if (this.state.attempts < this.config.maxAttempts) {
+					const retryDelay = this.config.getDelayMs(this.state.attempts)
+					this.state.attempts++
 					Logger.log(
-						`StreamableHTTP retrying reconnect ${this.attempts}/${this.config.maxAttempts} ` +
+						`StreamableHTTP retrying reconnect ${this.state.attempts}/${this.config.maxAttempts} ` +
 							`for "${this.serverName}" in ${retryDelay / 1000}s...`,
 					)
 					await this.callbacks.delay(retryDelay)

--- a/apps/vscode/src/services/mcp/__tests__/StreamableHttpReconnectHandler.test.ts
+++ b/apps/vscode/src/services/mcp/__tests__/StreamableHttpReconnectHandler.test.ts
@@ -41,6 +41,7 @@ function makeCallbacks(connection?: ReturnType<typeof makeConnection>): Reconnec
 const TEST_CONFIG: ReconnectConfig = {
 	maxAttempts: 3,
 	getDelayMs: (attempt) => 100 * 2 ** attempt, // 100, 200, 400
+	stabilityWindowMs: 30_000,
 }
 
 describe("StreamableHttpReconnectHandler", () => {
@@ -58,6 +59,7 @@ describe("StreamableHttpReconnectHandler", () => {
 
 	it("should export sensible defaults", () => {
 		DEFAULT_RECONNECT_CONFIG.maxAttempts.should.equal(6)
+		DEFAULT_RECONNECT_CONFIG.stabilityWindowMs.should.equal(30_000)
 		DEFAULT_RECONNECT_CONFIG.getDelayMs(0).should.equal(2000)
 		DEFAULT_RECONNECT_CONFIG.getDelayMs(1).should.equal(4000)
 		DEFAULT_RECONNECT_CONFIG.getDelayMs(2).should.equal(8000)
@@ -115,6 +117,24 @@ describe("StreamableHttpReconnectHandler", () => {
 		handler.attemptCount.should.equal(0)
 		// Status was set to "connecting" during the attempt
 		cbs.stubs.notifyWebviewOfServerChanges.called.should.be.true()
+	})
+
+	it("should preserve the retry budget across transport replacement", async () => {
+		const state = { attempts: 0 }
+		const firstCallbacks = makeCallbacks()
+		const firstHandler = new StreamableHttpReconnectHandler("test-server", firstCallbacks, TEST_CONFIG, state)
+
+		await firstHandler.handleError(new Error("first connection lost"))
+
+		state.attempts.should.equal(1)
+		const secondCallbacks = makeCallbacks()
+		const secondHandler = new StreamableHttpReconnectHandler("test-server", secondCallbacks, TEST_CONFIG, state)
+
+		await secondHandler.handleError(new Error("fast flap"))
+
+		state.attempts.should.equal(2)
+		secondCallbacks.stubs.connectToServer.calledOnce.should.be.true()
+		secondHandler.resetAttempts()
 	})
 
 	it("should use the configured delay for each attempt", async () => {
@@ -201,7 +221,7 @@ describe("StreamableHttpReconnectHandler", () => {
 	it("should exhaust retries when called with attempts already at max", async () => {
 		const conn = makeConnection()
 		const cbs = makeCallbacks(conn)
-		const config: ReconnectConfig = { maxAttempts: 0, getDelayMs: () => 0 }
+		const config: ReconnectConfig = { maxAttempts: 0, getDelayMs: () => 0, stabilityWindowMs: 30_000 }
 		const handler = new StreamableHttpReconnectHandler("test-server", cbs, config)
 
 		await handler.handleError(new Error("final error"))
@@ -290,7 +310,7 @@ describe("StreamableHttpReconnectHandler", () => {
 		const conn = makeConnection()
 		const cbs = makeCallbacks(conn)
 		cbs.stubs.connectToServer.rejects(new Error("fail"))
-		const config: ReconnectConfig = { maxAttempts: 0, getDelayMs: () => 0 }
+		const config: ReconnectConfig = { maxAttempts: 0, getDelayMs: () => 0, stabilityWindowMs: 30_000 }
 		const handler = new StreamableHttpReconnectHandler("test-server", cbs, config)
 
 		// Pass a plain string as the error


### PR DESCRIPTION
## Summary
- preserve the Streamable HTTP retry budget across transport recreation
- reset the budget only after a stable connection window
- add regression coverage for fast-flapping transports

Fixes #12119

## Validation
- `bun test src/services/mcp/__tests__/StreamableHttpReconnectHandler.test.ts`
- Biome check on changed files
- VS Code app typecheck