### PR TITLE
fix(mcp): install stdio servers from marketplace

### DIFF
--- a/sdk/packages/core/src/services/mcp-install.test.ts
+++ b/sdk/packages/core/src/services/mcp-install.test.ts
@@ -110,6 +110,17 @@ describe("MCP install service", () => {
 		);
 	});
 
+	it("parses marketplace stdio args after the command separator", () => {
+		expect(
+			parseMcpInstallArgs(["aikido", "--", "npx", "-y", "@aikidosec/mcp@1.0.9"]),
+		).toEqual({
+			name: "aikido",
+			transport: undefined,
+			targetArgs: ["npx", "-y", "@aikidosec/mcp@1.0.9"],
+			headers: [],
+		});
+	});
+
 	it("keeps transport-like values as stdio command args for direct builder input", () => {
 		expect(
 			buildMcpInstallTransport({

--- a/sdk/packages/core/src/services/mcp-install.ts
+++ b/sdk/packages/core/src/services/mcp-install.ts
@@ -196,12 +196,13 @@ export function buildMcpInstallTransport(options: {
 }
 
 export function parseMcpInstallArgs(args: string[]): McpInstallOptions {
-	const [name, ...targetArgs] = args;
+	const [name, ...rawTargetArgs] = args;
 	if (!name) {
 		throw new Error(
 			"Marketplace MCP install args must start with a server name.",
 		);
 	}
+	const targetArgs = rawTargetArgs[0] === "--" ? rawTargetArgs.slice(1) : rawTargetArgs;
 	return {
 		name,
 		...splitTargetArgsAndHeaders({


### PR DESCRIPTION
## Summary
- strip the standalone `--` command separator from marketplace MCP install args
- ensure stdio catalog entries use their actual executable instead of `--`
- add regression coverage for Aikido-style marketplace arguments

Fixes #12174

## Validation
- `bun -F @cline/core typecheck`
- `bunx vitest run src/services/mcp-install.test.ts` is currently blocked by the existing Zod runtime-resolution failure in `sdk/packages/core/src/extensions/mcp/config-loader.ts`