### PR TITLE
fix(vscode-rollout): enable OpenTelemetry in combined builds

### DIFF
--- a/.github/workflows/ext-vscode-ab-package.yml
+++ b/.github/workflows/ext-vscode-ab-package.yml
@@ -75,6 +75,13 @@ jobs:
                   # extension_variant and unlocks the bundle's authoritative
                   # extension.rollout.bundle_activated capture. Rollout builds only.
                   CLINE_ROLLOUT_VARIANT: next
+                  # Match the stable publish workflow's OpenTelemetry production defaults.
+                  OTEL_TELEMETRY_ENABLED: ${{ secrets.OTEL_TELEMETRY_ENABLED }}
+                  OTEL_LOGS_EXPORTER: otlp
+                  OTEL_METRICS_EXPORTER: otlp
+                  OTEL_EXPORTER_OTLP_PROTOCOL: ${{ secrets.OTEL_EXPORTER_OTLP_PROTOCOL }}
+                  OTEL_EXPORTER_OTLP_ENDPOINT: ${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT }}
+                  OTEL_EXPORTER_OTLP_HEADERS: ${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }}
               run: |
                   bun install
                   cd apps/vscode
@@ -93,6 +100,13 @@ jobs:
                   TELEMETRY_SERVICE_API_KEY: ${{ secrets.TELEMETRY_SERVICE_API_KEY }}
                   ERROR_SERVICE_API_KEY: ${{ secrets.ERROR_SERVICE_API_KEY }}
                   CLINE_ROLLOUT_VARIANT: legacy
+                  # Match the stable publish workflow's OpenTelemetry production defaults.
+                  OTEL_TELEMETRY_ENABLED: ${{ secrets.OTEL_TELEMETRY_ENABLED }}
+                  OTEL_LOGS_EXPORTER: otlp
+                  OTEL_METRICS_EXPORTER: otlp
+                  OTEL_EXPORTER_OTLP_PROTOCOL: ${{ secrets.OTEL_EXPORTER_OTLP_PROTOCOL }}
+                  OTEL_EXPORTER_OTLP_ENDPOINT: ${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT }}
+                  OTEL_EXPORTER_OTLP_HEADERS: ${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }}
               run: npm run package
 
             - name: Build loader and run rollout tests


### PR DESCRIPTION
### Related Issue

**Related PR:** #12253

### Description

The combined legacy/next rollout workflow builds both extension bundles without the OpenTelemetry production configuration used by the normal stable publish workflow.

This is especially important for the SDK-based `next` bundle: agent-loop events such as `task.created`, `task.completed`, `task.tokens`, `task.tool_used`, and `task.conversation_turn` are emitted through the SDK's OpenTelemetry handle. Without `OTEL_TELEMETRY_ENABLED` and the OTLP exporter configuration at build time, that handle has no production exporter, so those events cannot reach the OTel/ClickHouse pipeline. The legacy bundle also needs the same configuration so rollout dashboards can compare both cohorts over the same telemetry destination.

This change mirrors the stable workflow's OTel production defaults into both bundle build steps:

- Enables OpenTelemetry using the existing repository secret.
- Configures OTLP log and metric exporters.
- Supplies the existing protocol, endpoint, and headers secrets.
- Keeps both legacy and next builds on identical exporter settings.

This does not change the PostHog rollout flags, telemetry consent policy, or application behavior. It only ensures the combined rollout artifact has the same build-time OTel configuration as the normal production builds.

### Test Procedure

- Ran `git diff --check` against `saoudrizwan/extension-ab-loader`.
- Parsed `.github/workflows/ext-vscode-ab-package.yml` successfully as YAML.
- Verified both `Build next bundle` and `Build legacy bundle` contain all six OTel variables used by `.github/workflows/ext-vscode-publish-stable.yml`.
- No application tests were run because this PR only changes GitHub Actions environment configuration.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable — workflow-only change.

### Additional Notes

All referenced secrets already exist in the stable publish workflow; this PR introduces no new secret names or credentials. The rollout workflow still keeps PostHog as its flag provider. OTel remains the destination used for cohort-comparable logs and metrics.
