### PR TITLE
fix(vscode): restore 'Proceed While Running' for foreground terminal commands

### DIFF
--- a/apps/vscode/proto/cline/task.proto
+++ b/apps/vscode/proto/cline/task.proto
@@ -16,6 +16,9 @@ service TaskService {
   rpc cancelQueuedPrompt(StringRequest) returns (Empty);
   // Cancels the currently running background command
   rpc cancelBackgroundCommand(EmptyRequest) returns (Empty);
+  // Detaches the running foreground terminal command ("Proceed While Running"):
+  // the agent receives the partial output and a log file path for the rest.
+  rpc proceedWhileRunningCommand(EmptyRequest) returns (Empty);
   // Clears the current task
   rpc clearTask(EmptyRequest) returns (Empty);
   // Gets the total size of all tasks

--- a/apps/vscode/src/core/controller/state/getStateToPostToWebview.ts
+++ b/apps/vscode/src/core/controller/state/getStateToPostToWebview.ts
@@ -25,6 +25,7 @@ export async function getStateToPostToWebview(controller: {
 	mcpHub?: any
 	backgroundCommandRunning?: boolean
 	backgroundCommandTaskId?: string
+	foregroundCommandRunning?: boolean
 	workspaceManager?: any
 	checkpointRestoreInput?: ExtensionState["checkpointRestoreInput"]
 }): Promise<ExtensionState> {
@@ -157,6 +158,7 @@ export async function getStateToPostToWebview(controller: {
 		favoritedModelIds,
 		backgroundCommandRunning: controller.backgroundCommandRunning ?? false,
 		backgroundCommandTaskId: controller.backgroundCommandTaskId,
+		foregroundCommandRunning: controller.foregroundCommandRunning ?? false,
 		workspaceRoots: controller.workspaceManager?.getRoots?.() ?? [],
 		primaryRootIndex: controller.workspaceManager?.getPrimaryIndex?.() ?? 0,
 		isMultiRootWorkspace: (controller.workspaceManager?.getRoots?.()?.length ?? 0) > 1,

--- a/apps/vscode/src/core/controller/task/proceedWhileRunningCommand.ts
+++ b/apps/vscode/src/core/controller/task/proceedWhileRunningCommand.ts
@@ -1,0 +1,15 @@
+import { Empty, EmptyRequest } from "@shared/proto/cline/common"
+import { Controller } from ".."
+
+/**
+ * "Proceed While Running": detach the in-flight foreground terminal command(s)
+ * so the agent turn continues with the partial output while the commands keep
+ * running in the user's terminal, streaming further output to a log file.
+ */
+export async function proceedWhileRunningCommand(controller: Controller, _request: EmptyRequest): Promise<Empty> {
+	const controllerWithProceed = controller as Controller & {
+		proceedWhileRunningCommand: () => Promise<void>
+	}
+	await controllerWithProceed.proceedWhileRunningCommand()
+	return Empty.create()
+}

--- a/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalProcess.test.ts
+++ b/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalProcess.test.ts
@@ -694,4 +694,22 @@ describe("TerminalProcess (Integration Tests)", () => {
 		;(emitSpy as sinon.SinonSpy).calledWith("line", "line 3 continued").should.be.true()
 		processAny.buffer.should.equal("")
 	})
+
+	it("detach emits continue but keeps line listeners attached and listening", () => {
+		const processAny = process as any
+		const continueEvents: number[] = []
+		const lines: string[] = []
+		process.on("continue", () => continueEvents.push(1))
+		process.on("line", (line) => lines.push(line))
+
+		process.detach()
+		continueEvents.length.should.equal(1)
+
+		// Unlike continue(), detach must not stop listening or drop 'line'
+		// listeners: output after detach still reaches subscribers (this is
+		// what streams the rest of a detached command to the log file).
+		processAny.isListening.should.be.true()
+		processAny.emitIfEol("after detach\n")
+		lines.should.containEql("after detach")
+	})
 })

--- a/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalProcess.test.ts
+++ b/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalProcess.test.ts
@@ -712,4 +712,23 @@ describe("TerminalProcess (Integration Tests)", () => {
 		processAny.emitIfEol("after detach\n")
 		lines.should.containEql("after detach")
 	})
+
+	it("detach flushes a buffered partial line before emitting continue", () => {
+		const processAny = process as any
+		const events: string[] = []
+		process.on("continue", () => events.push("continue"))
+		process.on("line", (line) => events.push(`line:${line}`))
+
+		// A chunk with no trailing newline stays in the internal buffer.
+		processAny.emitIfEol("partial output")
+		processAny.buffer.should.equal("partial output")
+
+		process.detach()
+
+		// The partial line must reach listeners before 'continue' resolves the
+		// awaited promise; otherwise it is missing from the partial output and
+		// from the log's initial flush.
+		events.should.eql(["line:partial output", "continue"])
+		processAny.buffer.should.equal("")
+	})
 })

--- a/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalProcess.ts
+++ b/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalProcess.ts
@@ -531,6 +531,11 @@ export class VscodeTerminalProcess extends EventEmitter<TerminalProcessEvents> i
 	 * terminal stays busy and is not eligible for reuse until then.
 	 */
 	detach() {
+		// Flush any partial line (no trailing newline yet) so it reaches
+		// listeners before the awaited promise resolves; otherwise it would be
+		// dropped from both the partial output and the log capture if the
+		// command exits without further newline-terminated output.
+		this.emitRemainingBufferIfListening()
 		this.emit("continue")
 	}
 

--- a/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalProcess.ts
+++ b/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalProcess.ts
@@ -16,8 +16,8 @@ import {
 	TRUNCATE_KEEP_LINES,
 } from "@/integrations/terminal/constants"
 import type { ITerminalProcess, TerminalCompletionDetails, TerminalProcessEvents } from "@/integrations/terminal/types"
-import { Logger } from "@/shared/services/Logger"
 import type { MarkerlessCompletionCause } from "@/services/telemetry/TelemetryService"
+import { Logger } from "@/shared/services/Logger"
 import { Osc633EventType, Osc633Parser } from "./osc633Parser"
 import { classifyShellPrompt, getLastLine } from "./shellPromptHeuristics"
 
@@ -519,6 +519,18 @@ export class VscodeTerminalProcess extends EventEmitter<TerminalProcessEvents> i
 		this.emitRemainingBufferIfListening()
 		this.isListening = false
 		this.removeAllListeners("line")
+		this.emit("continue")
+	}
+
+	/**
+	 * Resolve the awaited promise while the command keeps running ("Proceed
+	 * While Running"). Listeners stay attached and 'line' events keep
+	 * flowing — unlike continue() — so callers can stream the remaining
+	 * output until the command actually completes. Because 'completed' is
+	 * only emitted by the read loop when the command genuinely ends, the
+	 * terminal stays busy and is not eligible for reuse until then.
+	 */
+	detach() {
 		this.emit("continue")
 	}
 

--- a/apps/vscode/src/integrations/terminal/types.ts
+++ b/apps/vscode/src/integrations/terminal/types.ts
@@ -63,9 +63,16 @@ export interface ITerminalProcess extends EventEmitter<TerminalProcessEvents> {
 	/**
 	 * Continue execution without waiting for completion.
 	 * Stops event emission and resolves the promise.
-	 * This is called when user clicks "Proceed While Running".
 	 */
 	continue(): void
+
+	/**
+	 * Resolve the awaited promise while the command keeps running ("Proceed
+	 * While Running"). Unlike continue(), output listeners stay attached and
+	 * 'line'/'completed' events keep flowing, so callers can stream the rest
+	 * of the output (e.g. to a log file) until the command completes.
+	 */
+	detach(): void
 
 	/**
 	 * Get output that hasn't been retrieved yet.

--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -68,6 +68,7 @@ import {
 import { SdkCompactionCoordinator } from "./sdk-compaction-coordinator"
 import { SdkDiffEditCoordinator } from "./sdk-diff-edit-coordinator"
 import { SdkFollowupCoordinator } from "./sdk-followup-coordinator"
+import { SdkForegroundCommandCoordinator } from "./sdk-foreground-command-coordinator"
 import { SdkInteractionCoordinator } from "./sdk-interaction-coordinator"
 import { SdkMcpCoordinator } from "./sdk-mcp-coordinator"
 import { SdkMessageCoordinator, type SessionEventListener } from "./sdk-message-coordinator"
@@ -204,6 +205,15 @@ export class Controller {
 	// standalone (JetBrains/CLI) host run commands through the SDK's built-in tool.
 	private _terminalManager?: VscodeTerminalManager
 
+	// Registry of in-flight foreground (VS Code terminal) command executions.
+	// Owned here — not by the session — so it survives session rebuilds, which
+	// recreate the tool set. Drives the "Proceed While Running" button.
+	private readonly foregroundCommands = new SdkForegroundCommandCoordinator({
+		onRunningChanged: () => {
+			void this.postStateToWebview()
+		},
+	})
+
 	// Private state kept for stub compatibility
 	private backgroundCommandRunning = false
 	private backgroundCommandTaskId?: string
@@ -330,6 +340,7 @@ export class Controller {
 			},
 			onDidBecomeIdle: () => this.handleSessionBecameIdle(),
 			getRemoteConfigIntegration: () => this.remoteConfigCoreIntegration,
+			foregroundCommands: this.foregroundCommands,
 			getTerminalManager: () => {
 				// Guarded by getEffectiveTerminalExecutionMode() at the read sites
 				// (vscode-session-host.ts, sdk-terminal-execution-mode-coordinator.ts):
@@ -1174,6 +1185,19 @@ export class Controller {
 		stubWarn("cancelBackgroundCommand")
 	}
 
+	/**
+	 * "Proceed While Running": detach every in-flight foreground terminal
+	 * command. Each pending run_commands call returns its partial output plus
+	 * the log file path the remaining output is redirected to, and the agent
+	 * turn continues while the commands keep running in their terminals.
+	 */
+	async proceedWhileRunningCommand(): Promise<void> {
+		const detached = this.foregroundCommands.proceedWhileRunning()
+		if (detached === 0) {
+			Logger.warn("[SdkController] proceedWhileRunningCommand: No foreground command is running")
+		}
+	}
+
 	async cancelQueuedPrompt(promptId: string): Promise<void> {
 		const trimmedPromptId = promptId.trim()
 		if (!trimmedPromptId) {
@@ -1868,6 +1892,7 @@ export class Controller {
 				mcpHub: this.mcpHub,
 				backgroundCommandRunning: this.backgroundCommandRunning,
 				backgroundCommandTaskId: this.backgroundCommandTaskId,
+				foregroundCommandRunning: this.foregroundCommands.isRunning,
 			})
 			const sdkTaskHistory = (await this.taskHistory.listHistory({ limit: 100, hydrate: false }))
 				.map(sessionHistoryRecordToHistoryItem)

--- a/apps/vscode/src/sdk/sdk-foreground-command-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-foreground-command-coordinator.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest"
+import { SdkForegroundCommandCoordinator } from "./sdk-foreground-command-coordinator"
+
+describe("SdkForegroundCommandCoordinator", () => {
+	it("reports isRunning while a handle is registered and notifies on changes", () => {
+		const onRunningChanged = vi.fn()
+		const coordinator = new SdkForegroundCommandCoordinator({ onRunningChanged })
+
+		expect(coordinator.isRunning).toBe(false)
+
+		const unregister = coordinator.register({ detach: () => {} })
+		expect(coordinator.isRunning).toBe(true)
+		expect(onRunningChanged).toHaveBeenCalledWith(true)
+
+		unregister()
+		expect(coordinator.isRunning).toBe(false)
+		expect(onRunningChanged).toHaveBeenCalledWith(false)
+	})
+
+	it("only notifies on actual transitions, not per handle", () => {
+		const onRunningChanged = vi.fn()
+		const coordinator = new SdkForegroundCommandCoordinator({ onRunningChanged })
+
+		const unregister1 = coordinator.register({ detach: () => {} })
+		const unregister2 = coordinator.register({ detach: () => {} })
+		expect(onRunningChanged).toHaveBeenCalledTimes(1)
+
+		unregister1()
+		expect(onRunningChanged).toHaveBeenCalledTimes(1)
+		unregister2()
+		expect(onRunningChanged).toHaveBeenCalledTimes(2)
+	})
+
+	it("unregister is idempotent", () => {
+		const onRunningChanged = vi.fn()
+		const coordinator = new SdkForegroundCommandCoordinator({ onRunningChanged })
+
+		const unregister = coordinator.register({ detach: () => {} })
+		unregister()
+		unregister()
+		expect(onRunningChanged).toHaveBeenCalledTimes(2)
+	})
+
+	it("proceedWhileRunning detaches every registered handle and reports the count", () => {
+		const coordinator = new SdkForegroundCommandCoordinator()
+		const detach1 = vi.fn()
+		const detach2 = vi.fn()
+		coordinator.register({ detach: detach1 })
+		coordinator.register({ detach: detach2 })
+
+		expect(coordinator.proceedWhileRunning()).toBe(2)
+		expect(detach1).toHaveBeenCalledTimes(1)
+		expect(detach2).toHaveBeenCalledTimes(1)
+	})
+
+	it("proceedWhileRunning is a no-op returning 0 when nothing is running", () => {
+		const coordinator = new SdkForegroundCommandCoordinator()
+		expect(coordinator.proceedWhileRunning()).toBe(0)
+	})
+
+	it("proceedWhileRunning survives a handle whose detach throws", () => {
+		const coordinator = new SdkForegroundCommandCoordinator()
+		const detach2 = vi.fn()
+		coordinator.register({
+			detach: () => {
+				throw new Error("boom")
+			},
+		})
+		coordinator.register({ detach: detach2 })
+
+		expect(coordinator.proceedWhileRunning()).toBe(2)
+		expect(detach2).toHaveBeenCalledTimes(1)
+	})
+})

--- a/apps/vscode/src/sdk/sdk-foreground-command-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-foreground-command-coordinator.ts
@@ -1,0 +1,80 @@
+/**
+ * Tracks in-flight foreground (VS Code terminal) command executions so the
+ * "Proceed While Running" button can detach them: each pending tool call
+ * returns with its partial output while the command keeps running in the
+ * user's terminal, streaming further output to a log file.
+ *
+ * Owned by SdkController so it outlives session rebuilds (which recreate the
+ * tool set and its reused executor closure). Handles are registered per tool
+ * invocation — never on the reused executor — so parallel commands in one
+ * tool call each get their own handle and log file.
+ */
+
+import { Logger } from "@/shared/services/Logger"
+
+export interface ForegroundCommandHandle {
+	/**
+	 * Stop waiting for the command: flush the output captured so far to a
+	 * log file, keep appending until the command completes, and resolve the
+	 * pending tool execution with the partial output. Idempotent.
+	 */
+	detach(): void
+}
+
+export interface SdkForegroundCommandCoordinatorOptions {
+	/** Called whenever isRunning flips; used to push the flag to the webview. */
+	onRunningChanged?: (running: boolean) => void
+}
+
+export class SdkForegroundCommandCoordinator {
+	private readonly handles = new Set<ForegroundCommandHandle>()
+
+	constructor(private readonly options: SdkForegroundCommandCoordinatorOptions = {}) {}
+
+	/** Whether any foreground command is currently awaited by a tool call. */
+	get isRunning(): boolean {
+		return this.handles.size > 0
+	}
+
+	/**
+	 * Track one in-flight foreground execution. Returns an unregister
+	 * function the caller must invoke when the execution settles (completes,
+	 * fails, aborts, or detaches) — typically from a `finally` block.
+	 */
+	register(handle: ForegroundCommandHandle): () => void {
+		const wasRunning = this.isRunning
+		this.handles.add(handle)
+		this.notifyIfChanged(wasRunning)
+		return () => {
+			const wasRunningBefore = this.isRunning
+			if (this.handles.delete(handle)) {
+				this.notifyIfChanged(wasRunningBefore)
+			}
+		}
+	}
+
+	/**
+	 * Detach every in-flight foreground command ("Proceed While Running").
+	 * Each pending tool execution resolves with its partial output and log
+	 * file path; the commands keep running in their terminals.
+	 *
+	 * @returns the number of commands detached (0 when none were running).
+	 */
+	proceedWhileRunning(): number {
+		const handles = [...this.handles]
+		for (const handle of handles) {
+			try {
+				handle.detach()
+			} catch (error) {
+				Logger.error("[ForegroundCommands] Failed to detach foreground command:", error)
+			}
+		}
+		return handles.length
+	}
+
+	private notifyIfChanged(wasRunning: boolean): void {
+		if (this.isRunning !== wasRunning) {
+			this.options.onRunningChanged?.(this.isRunning)
+		}
+	}
+}

--- a/apps/vscode/src/sdk/sdk-session-lifecycle.ts
+++ b/apps/vscode/src/sdk/sdk-session-lifecycle.ts
@@ -12,6 +12,7 @@ import type { VscodeTerminalManager } from "@/hosts/vscode/terminal/VscodeTermin
 import { McpHub } from "@/services/mcp/McpHub"
 import { Logger } from "@/shared/services/Logger"
 import type { ActiveSession } from "./cline-session-factory"
+import type { SdkForegroundCommandCoordinator } from "./sdk-foreground-command-coordinator"
 import { buildToolPolicies } from "./sdk-tool-policies"
 import type { SdkSessionHost } from "./session-host"
 import { VscodeSessionHost } from "./vscode-session-host"
@@ -32,6 +33,8 @@ export interface SdkSessionLifecycleOptions {
 	onSessionEvent: (event: CoreSessionEvent) => void
 	/** Lazy factory for the VscodeTerminalManager (foreground terminal support). */
 	getTerminalManager?: () => VscodeTerminalManager
+	/** Registry of in-flight foreground executions for "Proceed While Running". */
+	foregroundCommands?: SdkForegroundCommandCoordinator
 	/** Returns the latest prepared remote-config integration, if remote config is active. */
 	getRemoteConfigIntegration?: () => PreparedRemoteConfigCoreIntegration | undefined
 	/** Shared SDK telemetry service owned by SdkController. */
@@ -322,6 +325,7 @@ export class SdkSessionLifecycle {
 				editorExecutor: this.options.editorExecutor,
 				applyPatchExecutor: this.options.applyPatchExecutor,
 				getTerminalManager: this.options.getTerminalManager,
+				foregroundCommands: this.options.foregroundCommands,
 				getRemoteConfigIntegration: this.options.getRemoteConfigIntegration,
 				telemetry: this.options.telemetry,
 			})

--- a/apps/vscode/src/sdk/vscode-run-commands-tool.test.ts
+++ b/apps/vscode/src/sdk/vscode-run-commands-tool.test.ts
@@ -1,9 +1,21 @@
 import { CommandExitError } from "@cline/core"
 import { EventEmitter } from "events"
-import { describe, expect, it } from "vitest"
-import type { TerminalCompletionDetails } from "@/integrations/terminal/types"
+import * as fs from "fs"
+import { describe, expect, it, vi } from "vitest"
 import type { VscodeTerminalManager } from "@/hosts/vscode/terminal/VscodeTerminalManager"
+import type { TerminalCompletionDetails } from "@/integrations/terminal/types"
+import { SdkForegroundCommandCoordinator } from "./sdk-foreground-command-coordinator"
 import { executeForeground, formatCommandForTerminal } from "./vscode-run-commands-tool"
+
+// The real telemetry proxy lazily initializes TelemetryService, which requires
+// a HostProvider that unit tests don't set up.
+vi.mock("@services/telemetry", () => ({
+	TerminalUserInterventionAction: { PROCESS_WHILE_RUNNING: "process_while_running" },
+	telemetryService: {
+		captureTerminalUserIntervention: () => {},
+		captureTerminalExecution: () => {},
+	},
+}))
 
 /**
  * Minimal fake of the process object returned by VscodeTerminalManager.runCommand():
@@ -40,6 +52,50 @@ function createFakeTerminalManager(process: ReturnType<VscodeTerminalManager["ru
 		getOrCreateTerminal: async () => ({ terminal: { show: () => {} } }) as never,
 		runCommand: () => process,
 	} as unknown as VscodeTerminalManager
+}
+
+/**
+ * A controllable fake terminal process for detach tests: the caller decides
+ * when lines are emitted and when the command completes. Mirrors the real
+ * VscodeTerminalProcess contract: detach() resolves the awaited promise while
+ * 'line'/'completed' events keep flowing.
+ */
+function createControllableTerminalProcess() {
+	const emitter = new EventEmitter()
+	let resolvePromise!: () => void
+	const promise = new Promise<void>((resolve) => {
+		resolvePromise = resolve
+	})
+	const fakeProcess = Object.assign(emitter, {
+		then: promise.then.bind(promise),
+		catch: promise.catch.bind(promise),
+		finally: promise.finally.bind(promise),
+		getCompletionDetails: () => ({}),
+		detach: () => {
+			emitter.emit("continue")
+			resolvePromise()
+		},
+	})
+	return {
+		process: fakeProcess as unknown as ReturnType<VscodeTerminalManager["runCommand"]>,
+		emitLine: (line: string) => emitter.emit("line", line),
+		complete: (details?: TerminalCompletionDetails) => {
+			emitter.emit("completed", details)
+			emitter.emit("continue")
+			resolvePromise()
+		},
+	}
+}
+
+/** Poll until the predicate holds, for asserting on async log-file writes. */
+async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+	const start = Date.now()
+	while (!predicate()) {
+		if (Date.now() - start > timeoutMs) {
+			throw new Error("waitFor timed out")
+		}
+		await new Promise((resolve) => setTimeout(resolve, 10))
+	}
 }
 
 describe("formatCommandForTerminal", () => {
@@ -171,5 +227,109 @@ describe("executeForeground", () => {
 			expect(error).toBeInstanceOf(CommandExitError)
 			expect((error as InstanceType<typeof CommandExitError>).output).toContain("Terminal closed")
 		}
+	})
+
+	it("unregisters its foreground handle when the command completes normally", async () => {
+		const coordinator = new SdkForegroundCommandCoordinator()
+		const terminalManager = createFakeTerminalManager(createFakeTerminalProcess({ lines: ["hello"] }))
+
+		const result = await executeForeground("echo hello", "/workspace", terminalManager, 1000, undefined, coordinator)
+
+		expect(result).toBe("hello")
+		expect(coordinator.isRunning).toBe(false)
+	})
+})
+
+describe("executeForeground — Proceed While Running", () => {
+	it("detach returns the partial output with the log file path, and later output lands in the log", async () => {
+		const coordinator = new SdkForegroundCommandCoordinator()
+		const { process, emitLine, complete } = createControllableTerminalProcess()
+		const terminalManager = createFakeTerminalManager(process)
+
+		const resultPromise = executeForeground("devserver", "/workspace", terminalManager, 100_000, undefined, coordinator)
+
+		await waitFor(() => coordinator.isRunning)
+		emitLine("listening on :3000")
+
+		expect(coordinator.proceedWhileRunning()).toBe(1)
+		const result = await resultPromise
+
+		expect(result).toContain("still running")
+		expect(result).toContain("listening on :3000")
+		const logFilePath = /redirected to this file[^:]*: (.+)$/m.exec(result)?.[1]?.trim()
+		expect(logFilePath).toBeTruthy()
+
+		// The handle is unregistered once the tool call returns.
+		expect(coordinator.isRunning).toBe(false)
+
+		// Output emitted after detach is appended to the log file, and
+		// completion closes it out with a completion marker.
+		emitLine("compiled successfully")
+		complete({ exitCode: 0 })
+		await waitFor(() => {
+			try {
+				return fs.readFileSync(logFilePath!, "utf8").includes("[Command completed with exit code 0]")
+			} catch {
+				return false
+			}
+		})
+		const log = fs.readFileSync(logFilePath!, "utf8")
+		expect(log).toContain("listening on :3000") // buffered lines flushed at detach
+		expect(log).toContain("compiled successfully") // streamed after detach
+		fs.rmSync(logFilePath!, { force: true })
+	})
+
+	it("detaches each parallel command into its own log file", async () => {
+		const coordinator = new SdkForegroundCommandCoordinator()
+		const first = createControllableTerminalProcess()
+		const second = createControllableTerminalProcess()
+
+		const firstPromise = executeForeground(
+			"first-cmd",
+			"/workspace",
+			createFakeTerminalManager(first.process),
+			100_000,
+			undefined,
+			coordinator,
+		)
+		const secondPromise = executeForeground(
+			"second-cmd",
+			"/workspace",
+			createFakeTerminalManager(second.process),
+			100_000,
+			undefined,
+			coordinator,
+		)
+
+		await waitFor(() => coordinator.isRunning)
+		first.emitLine("first output")
+		second.emitLine("second output")
+
+		expect(coordinator.proceedWhileRunning()).toBe(2)
+		const [firstResult, secondResult] = await Promise.all([firstPromise, secondPromise])
+
+		const firstLog = /redirected to this file[^:]*: (.+)$/m.exec(firstResult)?.[1]?.trim()
+		const secondLog = /redirected to this file[^:]*: (.+)$/m.exec(secondResult)?.[1]?.trim()
+		expect(firstLog).toBeTruthy()
+		expect(secondLog).toBeTruthy()
+		expect(firstLog).not.toBe(secondLog)
+		expect(coordinator.isRunning).toBe(false)
+
+		first.complete()
+		second.complete()
+		await waitFor(() => {
+			try {
+				return (
+					fs.readFileSync(firstLog!, "utf8").includes("[Command completed]") &&
+					fs.readFileSync(secondLog!, "utf8").includes("[Command completed]")
+				)
+			} catch {
+				return false
+			}
+		})
+		expect(fs.readFileSync(firstLog!, "utf8")).toContain("first output")
+		expect(fs.readFileSync(secondLog!, "utf8")).toContain("second output")
+		fs.rmSync(firstLog!, { force: true })
+		fs.rmSync(secondLog!, { force: true })
 	})
 })

--- a/apps/vscode/src/sdk/vscode-run-commands-tool.test.ts
+++ b/apps/vscode/src/sdk/vscode-run-commands-tool.test.ts
@@ -24,11 +24,13 @@ vi.mock("@services/telemetry", () => ({
  */
 function createFakeTerminalProcess(options: { lines?: string[]; completionDetails?: TerminalCompletionDetails } = {}) {
 	const emitter = new EventEmitter()
+	let resolvePromise!: () => void
 	// Emit on a macrotask (not a microtask) so executeForeground's
 	// `await terminalManager.getOrCreateTerminal(cwd)` and subsequent
 	// `process.on("line", ...)` registration are guaranteed to run first,
 	// matching the ordering a real terminal process provides.
 	const promise = new Promise<void>((resolve) => {
+		resolvePromise = resolve
 		setTimeout(() => {
 			for (const line of options.lines ?? []) {
 				emitter.emit("line", line)
@@ -43,6 +45,10 @@ function createFakeTerminalProcess(options: { lines?: string[]; completionDetail
 		catch: promise.catch.bind(promise),
 		finally: promise.finally.bind(promise),
 		getCompletionDetails: () => options.completionDetails ?? {},
+		detach: () => {
+			emitter.emit("continue")
+			resolvePromise()
+		},
 	})
 	return fakeProcess as unknown as ReturnType<VscodeTerminalManager["runCommand"]>
 }
@@ -367,6 +373,35 @@ describe("executeForeground — Proceed While Running", () => {
 		expect(log).not.toContain("xxxx")
 		expect(log).not.toContain("after the cap")
 		expect(log.length).toBeLessThan(PROCEED_LOG_MAX_BYTES)
+		fs.rmSync(logFilePath!, { force: true })
+	})
+
+	it("applies the size cap to lines buffered before detach", async () => {
+		const coordinator = new SdkForegroundCommandCoordinator()
+		const { process, emitLine, complete } = createControllableTerminalProcess()
+		const terminalManager = createFakeTerminalManager(process)
+
+		const resultPromise = executeForeground("devserver", "/workspace", terminalManager, 100_000, undefined, coordinator)
+		await waitFor(() => coordinator.isRunning)
+		emitLine("x".repeat(PROCEED_LOG_MAX_BYTES))
+
+		expect(coordinator.proceedWhileRunning()).toBe(1)
+		const result = await resultPromise
+		const logFilePath = /redirected to this file[^:]*: (.+)$/m.exec(result)?.[1]?.trim()
+		expect(logFilePath).toBeTruthy()
+		complete({ exitCode: 0 })
+
+		await waitFor(() => {
+			try {
+				return fs.readFileSync(logFilePath!, "utf8").includes("[Command completed with exit code 0]")
+			} catch {
+				return false
+			}
+		})
+		const log = fs.readFileSync(logFilePath!, "utf8")
+		expect(log).toContain(`[Log size cap of ${PROCEED_LOG_MAX_BYTES} bytes reached`)
+		expect(log).not.toContain("xxxx")
+		expect(Buffer.byteLength(log)).toBeLessThanOrEqual(PROCEED_LOG_MAX_BYTES)
 		fs.rmSync(logFilePath!, { force: true })
 	})
 

--- a/apps/vscode/src/sdk/vscode-run-commands-tool.test.ts
+++ b/apps/vscode/src/sdk/vscode-run-commands-tool.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from "vitest"
 import type { VscodeTerminalManager } from "@/hosts/vscode/terminal/VscodeTerminalManager"
 import type { TerminalCompletionDetails } from "@/integrations/terminal/types"
 import { SdkForegroundCommandCoordinator } from "./sdk-foreground-command-coordinator"
-import { executeForeground, formatCommandForTerminal } from "./vscode-run-commands-tool"
+import { executeForeground, formatCommandForTerminal, PROCEED_LOG_MAX_BYTES } from "./vscode-run-commands-tool"
 
 // The real telemetry proxy lazily initializes TelemetryService, which requires
 // a HostProvider that unit tests don't set up.
@@ -331,5 +331,75 @@ describe("executeForeground — Proceed While Running", () => {
 		expect(fs.readFileSync(secondLog!, "utf8")).toContain("second output")
 		fs.rmSync(firstLog!, { force: true })
 		fs.rmSync(secondLog!, { force: true })
+	})
+
+	it("stops logging before a line that would exceed the size cap", async () => {
+		const coordinator = new SdkForegroundCommandCoordinator()
+		const { process, emitLine, complete } = createControllableTerminalProcess()
+		const terminalManager = createFakeTerminalManager(process)
+
+		const resultPromise = executeForeground("devserver", "/workspace", terminalManager, 100_000, undefined, coordinator)
+		await waitFor(() => coordinator.isRunning)
+
+		expect(coordinator.proceedWhileRunning()).toBe(1)
+		const result = await resultPromise
+		const logFilePath = /redirected to this file[^:]*: (.+)$/m.exec(result)?.[1]?.trim()
+		expect(logFilePath).toBeTruthy()
+
+		// A single line larger than the whole cap must not be written at all —
+		// the cap is checked before writing, so one huge line (e.g. a dumped
+		// blob) cannot blow the log far past PROCEED_LOG_MAX_BYTES.
+		emitLine("small line before the blob")
+		emitLine("x".repeat(PROCEED_LOG_MAX_BYTES))
+		emitLine("after the cap")
+		complete({ exitCode: 0 })
+
+		await waitFor(() => {
+			try {
+				return fs.readFileSync(logFilePath!, "utf8").includes("[Command completed with exit code 0]")
+			} catch {
+				return false
+			}
+		})
+		const log = fs.readFileSync(logFilePath!, "utf8")
+		expect(log).toContain("small line before the blob")
+		expect(log).toContain(`[Log size cap of ${PROCEED_LOG_MAX_BYTES} bytes reached`)
+		expect(log).not.toContain("xxxx")
+		expect(log).not.toContain("after the cap")
+		expect(log.length).toBeLessThan(PROCEED_LOG_MAX_BYTES)
+		fs.rmSync(logFilePath!, { force: true })
+	})
+
+	it("freezes the partial output at detach while later output still reaches the log", async () => {
+		const coordinator = new SdkForegroundCommandCoordinator()
+		const { process, emitLine, complete } = createControllableTerminalProcess()
+		const terminalManager = createFakeTerminalManager(process)
+
+		const resultPromise = executeForeground("devserver", "/workspace", terminalManager, 100_000, undefined, coordinator)
+		await waitFor(() => coordinator.isRunning)
+		emitLine("before detach")
+
+		expect(coordinator.proceedWhileRunning()).toBe(1)
+		// Emitted after detach but before the tool call's result is built:
+		// must appear only in the log, never in the partial output.
+		emitLine("after detach")
+		const result = await resultPromise
+
+		expect(result).toContain("before detach")
+		expect(result).not.toContain("after detach")
+
+		const logFilePath = /redirected to this file[^:]*: (.+)$/m.exec(result)?.[1]?.trim()
+		complete({ exitCode: 0 })
+		await waitFor(() => {
+			try {
+				return fs.readFileSync(logFilePath!, "utf8").includes("[Command completed with exit code 0]")
+			} catch {
+				return false
+			}
+		})
+		const log = fs.readFileSync(logFilePath!, "utf8")
+		expect(log).toContain("before detach")
+		expect(log).toContain("after detach")
+		fs.rmSync(logFilePath!, { force: true })
 	})
 })

--- a/apps/vscode/src/sdk/vscode-run-commands-tool.ts
+++ b/apps/vscode/src/sdk/vscode-run-commands-tool.ts
@@ -21,12 +21,16 @@ import {
 	truncateCommandOutput,
 } from "@cline/core"
 import type { AgentTool } from "@cline/shared"
-import { telemetryService } from "@services/telemetry"
+import { TerminalUserInterventionAction, telemetryService } from "@services/telemetry"
+import { ClineTempManager } from "@services/temp"
+import * as fs from "fs"
 import { StateManager } from "@/core/storage/StateManager"
 import type { VscodeTerminalManager } from "@/hosts/vscode/terminal/VscodeTerminalManager"
 import { MAX_UNRETRIEVED_LINES } from "@/integrations/terminal/constants"
+import type { ITerminalProcess } from "@/integrations/terminal/types"
 import { Logger } from "@/shared/services/Logger"
 import { getShellForProfile } from "@/utils/shell"
+import type { SdkForegroundCommandCoordinator } from "./sdk-foreground-command-coordinator"
 
 // ---------------------------------------------------------------------------
 // Types
@@ -38,6 +42,14 @@ type VscodeTerminalExecutionMode = "vscodeTerminal" | "backgroundExec"
 /** Foreground VS Code terminals cannot be forcibly terminated; give long-running commands room to finish. */
 export const VSCODE_FOREGROUND_RUN_COMMANDS_TIMEOUT_MS = 60 * 60 * 1000
 
+/**
+ * Cap on the "Proceed While Running" log file. A detached devserver can log
+ * for days; once the cap is hit we stop appending and note the truncation.
+ * ClineTempManager's periodic cleanup (age + total-size caps) is the backstop
+ * for the files themselves.
+ */
+export const PROCEED_LOG_MAX_BYTES = 10 * 1024 * 1024
+
 /** Options for creating the VSCode run_commands tool. */
 export interface VscodeRunCommandsToolOptions {
 	/** Workspace root directory. */
@@ -48,6 +60,14 @@ export interface VscodeRunCommandsToolOptions {
 	bashTimeoutMs?: number
 	/** Terminal execution mode captured when this session's tool set is built. */
 	vscodeTerminalExecutionMode?: VscodeTerminalExecutionMode
+	/**
+	 * Registry of in-flight foreground executions, owned by SdkController.
+	 * When provided, each foreground command can be detached via the
+	 * "Proceed While Running" button. Foreground-only: background (SDK
+	 * child_process) executions cannot be detached — their abort signal
+	 * kills the process tree.
+	 */
+	foregroundCommands?: SdkForegroundCommandCoordinator
 }
 
 // ---------------------------------------------------------------------------
@@ -74,6 +94,55 @@ export function formatCommandForTerminal(command: ShellCommand): string {
 	return [command.command, ...(command.args ?? [])].map(quoteShellArg).join(" ")
 }
 
+/**
+ * Stream the rest of a detached command's output to a log file: write the
+ * lines buffered so far, then append each further 'line' event until
+ * 'completed'. The write volume is capped at PROCEED_LOG_MAX_BYTES; the
+ * stream is always closed by the 'completed' event, which the terminal
+ * process emits on every exit path (command end, Ctrl+C, terminal closed,
+ * markerless fallback).
+ */
+function beginLogCapture(process: ITerminalProcess, terminalCommand: string, existingLines: string[]): string {
+	const logFilePath = ClineTempManager.createTempFilePath("proceed-while-running")
+	const stream = fs.createWriteStream(logFilePath, { flags: "a" })
+	stream.on("error", (error) => {
+		Logger.error(`[VscodeRunCommands] Failed writing proceed-while-running log ${logFilePath}:`, error)
+	})
+
+	let bytesWritten = 0
+	const writeLine = (line: string): void => {
+		const chunk = `${line}\n`
+		bytesWritten += Buffer.byteLength(chunk)
+		stream.write(chunk)
+	}
+
+	writeLine(`[Running command: ${terminalCommand}]`)
+	for (const line of existingLines) {
+		writeLine(line)
+	}
+
+	const onLine = (line: string): void => {
+		writeLine(line)
+		if (bytesWritten > PROCEED_LOG_MAX_BYTES) {
+			writeLine(`[Log size cap of ${PROCEED_LOG_MAX_BYTES} bytes reached; further output is not logged.]`)
+			process.removeListener("line", onLine)
+		}
+	}
+	process.on("line", onLine)
+	process.once("completed", (details) => {
+		process.removeListener("line", onLine)
+		const exitCode = details?.exitCode
+		writeLine(
+			exitCode !== undefined && exitCode !== null
+				? `[Command completed with exit code ${exitCode}]`
+				: "[Command completed]",
+		)
+		stream.end()
+	})
+
+	return logFilePath
+}
+
 /** Exported for direct unit testing of the CommandExitError/terminalClosed mapping. */
 export async function executeForeground(
 	command: ShellCommand,
@@ -81,6 +150,7 @@ export async function executeForeground(
 	terminalManager: VscodeTerminalManager,
 	maxOutputChars: number,
 	abortSignal?: AbortSignal,
+	foregroundCommands?: SdkForegroundCommandCoordinator,
 ): Promise<string> {
 	const terminalCommand = formatCommandForTerminal(command)
 	const terminalInfo = await terminalManager.getOrCreateTerminal(cwd)
@@ -121,8 +191,28 @@ export async function executeForeground(
 		process.once("continue", cleanupAbortListener)
 	}
 
-	// Wait for completion
-	await process
+	// "Proceed While Running": register a per-invocation handle so the user
+	// can detach this command. Detaching redirects the remaining output to a
+	// log file and resolves the awaited promise; the command keeps running in
+	// the user's terminal (and the terminal stays busy until it completes).
+	let detachedLogFilePath: string | undefined
+	const unregister = foregroundCommands?.register({
+		detach: () => {
+			if (detachedLogFilePath !== undefined) {
+				return
+			}
+			detachedLogFilePath = beginLogCapture(process, terminalCommand, outputLines)
+			telemetryService.captureTerminalUserIntervention(TerminalUserInterventionAction.PROCESS_WHILE_RUNNING, "vscode")
+			process.detach()
+		},
+	})
+
+	try {
+		// Wait for completion (or detach, which also resolves the promise)
+		await process
+	} finally {
+		unregister?.()
+	}
 	if (abortSignal?.aborted) {
 		throw new Error("Command execution aborted")
 	}
@@ -134,6 +224,14 @@ export async function executeForeground(
 	const output = truncateCommandOutput(bufferedOutput.trim(), {
 		maxChars: maxOutputChars,
 	})
+
+	if (detachedLogFilePath !== undefined) {
+		return [
+			"The user chose to proceed while the command is still running in their terminal.",
+			`This is partial output; further output is being redirected to this file, which you can read to check progress: ${detachedLogFilePath}`,
+			output.length > 0 ? `Output so far:\n${output}` : "No output so far.",
+		].join("\n")
+	}
 
 	const completionDetails = process.getCompletionDetails?.()
 
@@ -240,6 +338,13 @@ function createVscodeShellExecutor(options: VscodeRunCommandsToolOptions): Shell
 		if (!terminalManager) {
 			terminalManager = getTerminalManager()
 		}
-		return await executeForeground(command, commandCwd || cwd, terminalManager, MAX_COMMAND_OUTPUT_CHARS, context.signal)
+		return await executeForeground(
+			command,
+			commandCwd || cwd,
+			terminalManager,
+			MAX_COMMAND_OUTPUT_CHARS,
+			context.signal,
+			options.foregroundCommands,
+		)
 	}
 }

--- a/apps/vscode/src/sdk/vscode-run-commands-tool.ts
+++ b/apps/vscode/src/sdk/vscode-run-commands-tool.ts
@@ -105,37 +105,48 @@ export function formatCommandForTerminal(command: ShellCommand): string {
 function beginLogCapture(process: ITerminalProcess, terminalCommand: string, existingLines: string[]): string {
 	const logFilePath = ClineTempManager.createTempFilePath("proceed-while-running")
 	const stream = fs.createWriteStream(logFilePath, { flags: "a" })
+	const sizeCapMessage = `[Log size cap of ${PROCEED_LOG_MAX_BYTES} bytes reached; further output is not logged.]`
 	stream.on("error", (error) => {
 		Logger.error(`[VscodeRunCommands] Failed writing proceed-while-running log ${logFilePath}:`, error)
 	})
 
 	let bytesWritten = 0
-	const writeLine = (line: string): void => {
+	const tryWriteLine = (line: string): boolean => {
 		const chunk = `${line}\n`
-		bytesWritten += Buffer.byteLength(chunk)
+		const chunkBytes = Buffer.byteLength(chunk)
+		if (bytesWritten + chunkBytes > PROCEED_LOG_MAX_BYTES) {
+			return false
+		}
+		bytesWritten += chunkBytes
 		stream.write(chunk)
+		return true
 	}
 
-	writeLine(`[Running command: ${terminalCommand}]`)
+	let sizeCapReached = !tryWriteLine(`[Running command: ${terminalCommand}]`)
 	for (const line of existingLines) {
-		writeLine(line)
+		if (!tryWriteLine(line)) {
+			sizeCapReached = true
+			break
+		}
 	}
 
 	const onLine = (line: string): void => {
 		// Check the cap before writing: a single huge line (e.g. a dumped
 		// binary blob or minified bundle) must not blow past the cap.
-		if (bytesWritten + Buffer.byteLength(line) + 1 > PROCEED_LOG_MAX_BYTES) {
-			writeLine(`[Log size cap of ${PROCEED_LOG_MAX_BYTES} bytes reached; further output is not logged.]`)
+		if (!tryWriteLine(line)) {
+			tryWriteLine(sizeCapMessage)
 			process.removeListener("line", onLine)
-			return
 		}
-		writeLine(line)
 	}
-	process.on("line", onLine)
+	if (sizeCapReached) {
+		tryWriteLine(sizeCapMessage)
+	} else {
+		process.on("line", onLine)
+	}
 	process.once("completed", (details) => {
 		process.removeListener("line", onLine)
 		const exitCode = details?.exitCode
-		writeLine(
+		tryWriteLine(
 			exitCode !== undefined && exitCode !== null
 				? `[Command completed with exit code ${exitCode}]`
 				: "[Command completed]",

--- a/apps/vscode/src/sdk/vscode-run-commands-tool.ts
+++ b/apps/vscode/src/sdk/vscode-run-commands-tool.ts
@@ -122,11 +122,14 @@ function beginLogCapture(process: ITerminalProcess, terminalCommand: string, exi
 	}
 
 	const onLine = (line: string): void => {
-		writeLine(line)
-		if (bytesWritten > PROCEED_LOG_MAX_BYTES) {
+		// Check the cap before writing: a single huge line (e.g. a dumped
+		// binary blob or minified bundle) must not blow past the cap.
+		if (bytesWritten + Buffer.byteLength(line) + 1 > PROCEED_LOG_MAX_BYTES) {
 			writeLine(`[Log size cap of ${PROCEED_LOG_MAX_BYTES} bytes reached; further output is not logged.]`)
 			process.removeListener("line", onLine)
+			return
 		}
+		writeLine(line)
 	}
 	process.on("line", onLine)
 	process.once("completed", (details) => {
@@ -170,7 +173,7 @@ export async function executeForeground(
 	// truncateCommandOutput's own head/tail strategy below — since build/test
 	// failures usually appear at the end of output.
 	const maxBufferedLines = MAX_UNRETRIEVED_LINES
-	process.on("line", (line: string) => {
+	const bufferLine = (line: string): void => {
 		if (outputLines.length < maxBufferedLines) {
 			outputLines.push(line)
 		} else {
@@ -178,7 +181,8 @@ export async function executeForeground(
 			outputLines.push(line)
 			droppedLines++
 		}
-	})
+	}
+	process.on("line", bufferLine)
 
 	// Handle abort signal
 	if (abortSignal) {
@@ -203,7 +207,12 @@ export async function executeForeground(
 			}
 			detachedLogFilePath = beginLogCapture(process, terminalCommand, outputLines)
 			telemetryService.captureTerminalUserIntervention(TerminalUserInterventionAction.PROCESS_WHILE_RUNNING, "vscode")
+			// detach() flushes any partial line (reaching both bufferLine and
+			// the log) before resolving the awaited promise. After that the
+			// partial output is final: stop buffering so the remaining
+			// (log-only) output doesn't mutate outputLines while it's read.
 			process.detach()
+			process.removeListener("line", bufferLine)
 		},
 	})
 

--- a/apps/vscode/src/sdk/vscode-runtime-builder.ts
+++ b/apps/vscode/src/sdk/vscode-runtime-builder.ts
@@ -3,6 +3,7 @@ import { type AgentTool, type AgentToolContext, createTool } from "@cline/shared
 import type { VscodeTerminalManager } from "@/hosts/vscode/terminal/VscodeTerminalManager"
 import type { McpHub } from "@/services/mcp/McpHub"
 import { Logger } from "@/shared/services/Logger"
+import type { SdkForegroundCommandCoordinator } from "./sdk-foreground-command-coordinator"
 import { createVscodeRunCommandsTool, VSCODE_FOREGROUND_RUN_COMMANDS_TIMEOUT_MS } from "./vscode-run-commands-tool"
 
 interface McpToolDescriptor {
@@ -124,6 +125,8 @@ export interface VscodeExtraToolsOptions {
 	getTerminalManager?: () => VscodeTerminalManager
 	/** Current VS Code terminal execution mode, captured when the session tools are built. */
 	vscodeTerminalExecutionMode?: "vscodeTerminal" | "backgroundExec"
+	/** Registry of in-flight foreground executions for "Proceed While Running". */
+	foregroundCommands?: SdkForegroundCommandCoordinator
 }
 
 export async function createVscodeExtraTools(mcpHub: McpHub, options?: VscodeExtraToolsOptions): Promise<AgentTool[]> {
@@ -159,6 +162,7 @@ export async function createVscodeExtraTools(mcpHub: McpHub, options?: VscodeExt
 				getTerminalManager: options.getTerminalManager,
 				bashTimeoutMs: executionMode === "vscodeTerminal" ? VSCODE_FOREGROUND_RUN_COMMANDS_TIMEOUT_MS : undefined,
 				vscodeTerminalExecutionMode: executionMode,
+				foregroundCommands: options.foregroundCommands,
 			}),
 		)
 		Logger.log(

--- a/apps/vscode/src/sdk/vscode-session-host.ts
+++ b/apps/vscode/src/sdk/vscode-session-host.ts
@@ -36,9 +36,10 @@ import type { VscodeTerminalManager } from "@/hosts/vscode/terminal/VscodeTermin
 import { getDistinctId } from "@/services/logging/distinctId"
 import type { McpHub } from "@/services/mcp/McpHub"
 import { Logger } from "@/shared/services/Logger"
+import type { SdkForegroundCommandCoordinator } from "./sdk-foreground-command-coordinator"
 import type { SdkSessionHost } from "./session-host"
-import { getEffectiveTerminalExecutionMode } from "./vscode-terminal-execution-mode"
 import { createVscodeExtraTools } from "./vscode-runtime-builder"
+import { getEffectiveTerminalExecutionMode } from "./vscode-terminal-execution-mode"
 
 export interface VscodeSessionHostOptions {
 	mcpHub: McpHub
@@ -75,6 +76,8 @@ export interface VscodeSessionHostOptions {
 	 * with a custom tool that supports foreground/background terminal execution.
 	 */
 	getTerminalManager?: () => VscodeTerminalManager
+	/** Registry of in-flight foreground executions for "Proceed While Running". */
+	foregroundCommands?: SdkForegroundCommandCoordinator
 }
 
 export class VscodeSessionHost implements SdkSessionHost {
@@ -133,6 +136,7 @@ export class VscodeSessionHost implements SdkSessionHost {
 						cwd: inputWithRemoteConfig.config.cwd,
 						getTerminalManager: options.getTerminalManager,
 						vscodeTerminalExecutionMode: getEffectiveTerminalExecutionMode(requestedTerminalExecutionMode),
+						foregroundCommands: options.foregroundCommands,
 					})
 					return {
 						...inputWithRemoteConfig,

--- a/apps/vscode/src/sdk/webview-grpc-bridge.ts
+++ b/apps/vscode/src/sdk/webview-grpc-bridge.ts
@@ -124,6 +124,7 @@ export class WebviewGrpcBridge {
 					stateManager,
 					mcpHub: undefined,
 					backgroundCommandRunning: false,
+					foregroundCommandRunning: false,
 					backgroundCommandTaskId: undefined,
 				})
 				await sendStateUpdate(state)

--- a/apps/vscode/src/shared/ExtensionMessage.ts
+++ b/apps/vscode/src/shared/ExtensionMessage.ts
@@ -93,6 +93,11 @@ export interface ExtensionState {
 	vscodeTerminalExecutionMode: string
 	backgroundCommandRunning?: boolean
 	backgroundCommandTaskId?: string
+	/**
+	 * True while a foreground (VS Code terminal) command is awaited by a
+	 * run_commands tool call. Drives the "Proceed While Running" button.
+	 */
+	foregroundCommandRunning?: boolean
 	lastCompletedCommandTs?: number
 	userInfo?: UserInfo
 	version: string

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/ActionButtons.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/ActionButtons.tsx
@@ -20,7 +20,7 @@ interface ActionButtonsProps {
  */
 export const ActionButtons: React.FC<ActionButtonsProps> = ({ task, messages, chatState, mode, messageHandlers }) => {
 	const { inputValue, selectedImages, selectedFiles, setSendingDisabled } = chatState
-	const { turnState } = useExtensionState()
+	const { turnState, foregroundCommandRunning } = useExtensionState()
 
 	// Tracks the ask the user last acted on. Clicking a footer button latches this so the
 	// buttons disable immediately (and survive the trailing bookkeeping re-renders before the
@@ -41,8 +41,8 @@ export const ActionButtons: React.FC<ActionButtonsProps> = ({ task, messages, ch
 	// buttons immune to trailing bookkeeping messages and never disagree with the thinking
 	// indicator (RC1).
 	const buttonConfig = useMemo(() => {
-		return getButtonConfigFromState(messages, turnState, mode)
-	}, [messages, turnState, mode])
+		return getButtonConfigFromState(messages, turnState, mode, foregroundCommandRunning)
+	}, [messages, turnState, mode, foregroundCommandRunning])
 
 	// Identity of the ask that currently owns the footer buttons. The button config objects are
 	// shared singletons (e.g. BUTTON_CONFIGS.tool_approve), so two consecutive identical asks

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.ts
@@ -367,6 +367,15 @@ export function useMessageHandlers(messages: ClineMessage[], chatState: ChatStat
 					clearInputState()
 					break
 
+				case "proceed_while_running":
+					// Detach the running foreground terminal command: the agent
+					// receives the partial output plus a log file path for the
+					// rest, and the command keeps running in the terminal.
+					await TaskServiceClient.proceedWhileRunningCommand(EmptyRequest.create({})).catch((err) =>
+						console.error("Failed to proceed while running:", err),
+					)
+					break
+
 				case "new_task":
 					if (clineAsk === "new_task") {
 						await TaskServiceClient.newTask(

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/shared/buttonConfig.test.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/shared/buttonConfig.test.ts
@@ -252,4 +252,19 @@ describe("getButtonConfigFromState (dispatch + legacy fallback)", () => {
 		const turnState: TurnState = { phase: "completed", seq: 3 }
 		expect(getButtonConfigFromState(messages, turnState, "act")).toEqual(BUTTON_CONFIGS.completion_result)
 	})
+
+	it("streaming phase shows Proceed While Running when a foreground command is running", () => {
+		const messages: ClineMessage[] = [{ ts: 1, type: "say", say: "command", text: "npm run dev", partial: true }]
+		const turnState: TurnState = { phase: "streaming", seq: 4 }
+		expect(getButtonConfigFromState(messages, turnState, "act", true)).toEqual(BUTTON_CONFIGS.foreground_command_running)
+		expect(getButtonConfigFromState(messages, turnState, "act", false)).toEqual(BUTTON_CONFIGS.partial)
+	})
+
+	it("foreground command flag only affects the streaming phase", () => {
+		const messages: ClineMessage[] = []
+		expect(getButtonConfigFromState(messages, { phase: "completed", seq: 5 }, "act", true)).toEqual(
+			BUTTON_CONFIGS.completion_result,
+		)
+		expect(getButtonConfigFromState(messages, { phase: "idle", seq: 6 }, "act", true)).toEqual(BUTTON_CONFIGS.default)
+	})
 })

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/shared/buttonConfig.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/shared/buttonConfig.ts
@@ -8,6 +8,7 @@ export type ButtonActionType =
 	| "approve" // Send yesButtonClicked
 	| "reject" // Send noButtonClicked
 	| "proceed" // Send messageResponse or yesButtonClicked
+	| "proceed_while_running" // Detach the running foreground terminal command
 	| "new_task" // Start a new task
 	| "cancel" // Cancel streaming
 	| "utility" // Execute utility function (condense, report_bug)
@@ -188,6 +189,17 @@ export const BUTTON_CONFIGS: Record<string, ButtonConfig> = {
 		secondaryAction: "cancel",
 	},
 
+	// A foreground terminal command is running (SDK path): the user can detach
+	// it and let the agent proceed with the partial output, or cancel the task.
+	foreground_command_running: {
+		sendingDisabled: true,
+		enableButtons: true,
+		primaryText: "Proceed While Running",
+		secondaryText: "Cancel",
+		primaryAction: "proceed_while_running",
+		secondaryAction: "cancel",
+	},
+
 	// Default states
 	default: {
 		sendingDisabled: false,
@@ -360,12 +372,19 @@ export function getButtonConfigForMessages(messages: ClineMessage[], mode: Mode 
  * The button SET is chosen by phase; the LABEL/variant for approvals (Save vs Approve, command
  * vs tool vs MCP vs subagents) comes from the anchored message (turnState.anchorTs).
  */
-export function buttonsForPhase(turnState: TurnState, anchoredMessage: ClineMessage | undefined): ButtonConfig {
+export function buttonsForPhase(
+	turnState: TurnState,
+	anchoredMessage: ClineMessage | undefined,
+	foregroundCommandRunning = false,
+): ButtonConfig {
 	switch (turnState.phase) {
 		case "idle":
 			return BUTTON_CONFIGS.default
 		case "streaming":
-			return BUTTON_CONFIGS.partial
+			// A running foreground terminal command offers "Proceed While Running":
+			// detach the command (output continues to a log file) and let the
+			// agent continue with the partial output.
+			return foregroundCommandRunning ? BUTTON_CONFIGS.foreground_command_running : BUTTON_CONFIGS.partial
 		case "completed":
 			return BUTTON_CONFIGS.completion_result
 		case "resumable":
@@ -398,10 +417,11 @@ export function getButtonConfigFromState(
 	messages: ClineMessage[],
 	turnState: TurnState | undefined,
 	mode: Mode = "act",
+	foregroundCommandRunning = false,
 ): ButtonConfig {
 	if (turnState) {
 		const anchored = turnState.anchorTs !== undefined ? messages.find((m) => m.ts === turnState.anchorTs) : undefined
-		return buttonsForPhase(turnState, anchored)
+		return buttonsForPhase(turnState, anchored, foregroundCommandRunning)
 	}
 	return getButtonConfigForMessages(messages, mode)
 }

--- a/apps/vscode/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/apps/vscode/webview-ui/src/context/ExtensionStateContext.tsx
@@ -311,6 +311,7 @@ export const ExtensionStateContextProvider: React.FC<{
 		remoteConfigSettings: {},
 		backgroundCommandRunning: false,
 		backgroundCommandTaskId: undefined,
+		foregroundCommandRunning: false,
 		lastDismissedCliBannerVersion: 0,
 		backgroundEditEnabled: false,
 		showFeatureTips: true,


### PR DESCRIPTION
### Description

When `run_commands` executes in a VS Code integrated terminal (`vscodeTerminal` mode), the tool call blocks until the command exits — a dev server or long test run stalls the whole agent turn. This restores the **"Proceed While Running"** button for that case: while a foreground terminal command is awaited, the user can detach it so the tool call resolves immediately with the partial output plus the path of a log file that captures the rest, while the command keeps running in the terminal.

The pieces, in the order a click flows through them:

1. **Webview**: while `turnState.phase === "streaming"` and `foregroundCommandRunning` is set in `ExtensionState`, the footer shows "Proceed While Running" / "Cancel" instead of the plain "Cancel" (`buttonConfig.ts`, `ActionButtons.tsx`). Clicking calls the new `TaskService.proceedWhileRunningCommand` RPC (`task.proto`, `useMessageHandlers.ts`).
2. **Controller**: `SdkController` owns a new `SdkForegroundCommandCoordinator` — a registry of in-flight foreground executions. It outlives session rebuilds (which recreate the tool set), and flips `foregroundCommandRunning` state pushes as executions register/unregister. The RPC detaches every registered handle.
3. **Tool**: `executeForeground` in `vscode-run-commands-tool.ts` registers a per-invocation handle. Detach flushes any buffered partial line, freezes the partial output, starts a log capture (`beginLogCapture`: flushes buffered lines, appends further `line` events until `completed`, capped at 10 MB checked before each write), and calls the new `ITerminalProcess.detach()`, which resolves the awaited promise without emitting a synthetic `completed` — the terminal stays busy and the real completion still lands in the log.

Background (`backgroundExec`) executions are deliberately not detachable: their SDK-managed abort signal kills the process tree, so there is nothing to leave running.

### Test Procedure

Automated:

```bash
cd apps/vscode
bunx vitest run --config vitest.config.ts src/sdk/sdk-foreground-command-coordinator.test.ts src/sdk/vscode-run-commands-tool.test.ts
cd webview-ui && bunx vitest run src/components/chat/chat-view/shared/buttonConfig.test.ts
```

`VscodeTerminalProcess.test.ts` (detach semantics, partial-line flush) runs with the mocha integration suite: `bun run test:integration`.

Manual:

1. `./run-extension-host.sh` (from `apps/vscode`), set Terminal Execution Mode to VS Code terminal in settings
2. Ask Cline to run a long command (e.g. a dev server) and approve Run Command
3. "Proceed While Running" appears while the command runs; clicking it lets the turn continue with the partial output and a log file path, and the command keeps running in the terminal
4. When the command finishes, the log file ends with `[Command completed with exit code N]`

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="399" height="611" alt="image" src="https://github.com/user-attachments/assets/79fd64c8-0eb8-4473-8b40-13d15006fba5" />
