### PR TITLE
fix(vscode-rollout): align bundle versions and harden combined publish workflows

### DIFF
--- a/.github/workflows/ext-vscode-ab-package.yml
+++ b/.github/workflows/ext-vscode-ab-package.yml
@@ -65,8 +65,28 @@ jobs:
               with:
                   node-version: 22
 
-            - name: Build next bundle
+            - name: Install next workspace dependencies
               working-directory: next-src
+              run: bun install
+
+            # @cline/* are local workspace symlinks to source packages; apps/vscode's
+            # `package` script does NOT build them, so without this the esbuild step
+            # fails on a fresh checkout. (The nightly workflow already does this.)
+            - name: Build SDK packages
+              working-directory: next-src
+              run: bun run build:sdk
+
+            # Stamp the combined version into each bundle's package.json AFTER
+            # install and BEFORE its build: the About tab and telemetry
+            # extension_version read the bundle's own manifest, so without this
+            # the VSIX reports three different versions depending on where you
+            # look. (The nightly workflow gets the same alignment via nightlify.mjs.)
+            - name: Align next bundle version
+              working-directory: next-src/apps/vscode-rollout
+              run: node scripts/set-version.mjs --dir "$GITHUB_WORKSPACE/next-src/apps/vscode" --version "${{ github.event.inputs.version }}"
+
+            - name: Build next bundle
+              working-directory: next-src/apps/vscode
               env:
                   CLINE_ENVIRONMENT: production
                   TELEMETRY_SERVICE_API_KEY: ${{ secrets.TELEMETRY_SERVICE_API_KEY }}
@@ -82,16 +102,17 @@ jobs:
                   OTEL_EXPORTER_OTLP_PROTOCOL: ${{ secrets.OTEL_EXPORTER_OTLP_PROTOCOL }}
                   OTEL_EXPORTER_OTLP_ENDPOINT: ${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT }}
                   OTEL_EXPORTER_OTLP_HEADERS: ${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }}
-              run: |
-                  bun install
-                  cd apps/vscode
-                  bun run package
+              run: bun run package
 
             - name: Install legacy dependencies
               working-directory: legacy-src
               run: |
                   npm --prefix apps/vscode install --include=optional
                   npm --prefix apps/vscode/webview-ui install --include=optional
+
+            - name: Align legacy bundle version
+              working-directory: next-src/apps/vscode-rollout
+              run: node scripts/set-version.mjs --dir "$GITHUB_WORKSPACE/legacy-src/apps/vscode" --version "${{ github.event.inputs.version }}"
 
             - name: Build legacy bundle
               working-directory: legacy-src/apps/vscode

--- a/.github/workflows/ext-vscode-ab-package.yml
+++ b/.github/workflows/ext-vscode-ab-package.yml
@@ -155,15 +155,25 @@ jobs:
 
             # This workflow publishes the STABLE identity. If nightlify ever leaks
             # into this path the union manifest would ship under the wrong name.
+            # The bundle sub-manifest checks guard the set-version.mjs stamping:
+            # the About tab and telemetry extension_version read those files.
             - name: Assert stable manifest identity
               working-directory: staging
+              env:
+                  EXPECTED_VERSION: ${{ github.event.inputs.version }}
               run: |
                   node -e '
-                    const pkg = require("./package.json");
                     const assert = require("node:assert");
+                    const expected = process.env.EXPECTED_VERSION;
+                    const pkg = require("./package.json");
                     assert.equal(pkg.name, "claude-dev", `unexpected name ${pkg.name}`);
                     assert.equal(pkg.publisher, "saoudrizwan", `unexpected publisher ${pkg.publisher}`);
-                    console.log(`stable identity ok: ${pkg.publisher}.${pkg.name}@${pkg.version}`);
+                    assert.equal(pkg.version, expected, `unexpected union version ${pkg.version}`);
+                    for (const bundle of ["next", "legacy"]) {
+                      const sub = require(`./${bundle}/package.json`);
+                      assert.equal(sub.version, expected, `unexpected ${bundle} bundle version ${sub.version}`);
+                    }
+                    console.log(`stable identity ok: ${pkg.publisher}.${pkg.name}@${pkg.version} (bundle versions aligned)`);
                   '
 
             - name: Package VSIX

--- a/.github/workflows/ext-vscode-publish-nightly.yml
+++ b/.github/workflows/ext-vscode-publish-nightly.yml
@@ -217,17 +217,26 @@ jobs:
 
       # The nightly identity must have fully propagated (nightlify -> both
       # bundle manifests -> union manifest) or we'd publish over the stable
-      # extension ID.
+      # extension ID. The bundle sub-manifest checks guard the version
+      # stamping: the About tab and telemetry extension_version read those.
       - name: Assert nightly manifest identity
         working-directory: staging
+        env:
+          EXPECTED_VERSION: ${{ steps.version.outputs.version }}
         run: |
           node -e '
-            const pkg = require("./package.json");
             const assert = require("node:assert");
+            const expected = process.env.EXPECTED_VERSION;
+            const pkg = require("./package.json");
             assert.equal(pkg.name, "cline-nightly", `unexpected name ${pkg.name}`);
             assert.equal(pkg.publisher, "saoudrizwan", `unexpected publisher ${pkg.publisher}`);
-            assert.equal(pkg.version, "${{ steps.version.outputs.version }}", `unexpected version ${pkg.version}`);
-            console.log(`nightly identity ok: ${pkg.publisher}.${pkg.name}@${pkg.version}`);
+            assert.equal(pkg.version, expected, `unexpected union version ${pkg.version}`);
+            for (const bundle of ["next", "legacy"]) {
+              const sub = require(`./${bundle}/package.json`);
+              assert.equal(sub.name, "cline-nightly", `unexpected ${bundle} bundle name ${sub.name}`);
+              assert.equal(sub.version, expected, `unexpected ${bundle} bundle version ${sub.version}`);
+            }
+            console.log(`nightly identity ok: ${pkg.publisher}.${pkg.name}@${pkg.version} (bundle identities aligned)`);
           '
 
       - name: Install Publishing Tools

--- a/.github/workflows/ext-vscode-publish-nightly.yml
+++ b/.github/workflows/ext-vscode-publish-nightly.yml
@@ -279,6 +279,12 @@ jobs:
 
       - name: Tag published commit
         if: github.ref == 'refs/heads/main' && inputs.dry-run != true
+        # Best-effort bookkeeping: the default GITHUB_TOKEN cannot create a ref
+        # whose commit modifies workflow files (no workflows permission exists
+        # for it), so this step fails whenever HEAD touched .github/workflows.
+        # The publish already succeeded by this point — don't mark the run red;
+        # push the tag manually with user credentials when it matters.
+        continue-on-error: true
         working-directory: next-src
         env:
           GH_TOKEN: ${{ github.token }}

--- a/apps/vscode-rollout/scripts/set-version.mjs
+++ b/apps/vscode-rollout/scripts/set-version.mjs
@@ -1,0 +1,55 @@
+/**
+ * Stamp the combined VSIX's version into a bundle checkout's package.json,
+ * in place, BEFORE that bundle builds.
+ *
+ * Why: the union manifest's version (what the Marketplace and auto-update
+ * see) is supplied at stitch time, but each bundle's runtime reads its OWN
+ * package.json — the About tab and every telemetry event's extension_version
+ * come from there. Without this stamp the stable combined VSIX would report
+ * three different versions (union input, main's base version, legacy's base
+ * version) depending on where you look, which turns user bug reports into
+ * archaeology. The nightly path gets the same alignment via nightlify.mjs
+ * (which also rewrites identity); this script is the identity-preserving
+ * version-only equivalent for the stable channel.
+ *
+ * Usage: node set-version.mjs --dir <apps/vscode checkout> --version <x.y.z>
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+export function setPackageVersion(rawContent, version) {
+	if (!version) {
+		throw new Error("version is required");
+	}
+	const pkg = JSON.parse(rawContent);
+	pkg.version = version;
+	return `${JSON.stringify(pkg, null, "\t")}\n`;
+}
+
+function parseArgs(argv) {
+	const args = {};
+	for (let i = 2; i < argv.length; i += 2) {
+		args[argv[i].replace(/^--/, "")] = argv[i + 1];
+	}
+	return args;
+}
+
+if (
+	process.argv[1] &&
+	import.meta.url === `file://${path.resolve(process.argv[1])}`
+) {
+	const { dir, version } = parseArgs(process.argv);
+	if (!dir || !version) {
+		console.error(
+			"usage: node set-version.mjs --dir <apps/vscode checkout> --version <x.y.z>",
+		);
+		process.exit(1);
+	}
+	const packageJsonPath = path.join(dir, "package.json");
+	const before = JSON.parse(readFileSync(packageJsonPath, "utf8")).version;
+	writeFileSync(
+		packageJsonPath,
+		setPackageVersion(readFileSync(packageJsonPath, "utf8"), version),
+	);
+	console.log(`set ${packageJsonPath} version: ${before} -> ${version}`);
+}

--- a/apps/vscode-rollout/scripts/set-version.test.mjs
+++ b/apps/vscode-rollout/scripts/set-version.test.mjs
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "bun:test";
+import { setPackageVersion } from "./set-version.mjs";
+
+const fixture = JSON.stringify(
+	{
+		name: "claude-dev",
+		displayName: "Cline",
+		publisher: "saoudrizwan",
+		version: "4.0.0",
+		contributes: {
+			commands: [{ command: "cline.plusButtonClicked", title: "New Task" }],
+		},
+	},
+	null,
+	"\t",
+);
+
+describe("setPackageVersion", () => {
+	it("stamps the version and touches nothing else", () => {
+		const pkg = JSON.parse(setPackageVersion(fixture, "4.1.0"));
+		expect(pkg.version).toBe("4.1.0");
+		expect(pkg.name).toBe("claude-dev");
+		expect(pkg.displayName).toBe("Cline");
+		expect(pkg.publisher).toBe("saoudrizwan");
+		expect(pkg.contributes.commands[0].command).toBe(
+			"cline.plusButtonClicked",
+		);
+	});
+
+	it("requires a version", () => {
+		expect(() => setPackageVersion(fixture, undefined)).toThrow(/version/);
+		expect(() => setPackageVersion(fixture, "")).toThrow(/version/);
+	});
+});


### PR DESCRIPTION
### Related Issue

Follow-up to #12253, addressing @maxpaulus43's version findings from local testing (comment on that PR) — plus two more fixes discovered while landing it (a latent `build:sdk` gap, and the tag-push failure from the first real combined publish).

### Description

Three related operational fixes to the combined A/B VSIX workflows. The first two touch the **stable channel** (`ext-vscode-ab-package.yml`); the third touches the **nightly** (`ext-vscode-publish-nightly.yml`); the guardrail hardening touches both.

**1. Version alignment (stable channel).** Max found that the combined VSIX reported three different versions depending on where you looked: the Marketplace/auto-update sees the union manifest's version (the `version` dispatch input), but each bundle's About tab and telemetry `extension_version` read that bundle's *own* `package.json` — so next showed main's base `4.0.0` and legacy showed `4.0.8`. User bug reports would cite whichever one they happened to see. The nightly channel never had this problem because `nightlify.mjs` stamps one version into both bundle manifests and the union (verified on the dry-run artifact: all three read the same value; re-verified on the first published nightly `4.0.1784154881`). This PR adds the identity-preserving equivalent for stable: `scripts/set-version.mjs` stamps the dispatch version into each checkout **after dependency install, before its build**.

**2. Latent `build:sdk` gap (stable channel).** While restructuring the steps to place the stamp correctly, it turned out the next-bundle build never ran `build:sdk` — `apps/vscode`'s `package` script doesn't build the `@cline/*` workspace deps, so esbuild would fail on a fresh CI checkout. Nobody hit it because this workflow has never run end-to-end (the `publish` environment's deployment-branch policy rejected all pre-merge dispatches). The steps now mirror the nightly workflow: install → `build:sdk` → align version → build.

**3. Tag push must not fail the nightly run.** The first real combined publish (run [29454994164](https://github.com/cline/cline/actions/runs/29454994164)) published successfully to both registries but the run went **red** at the final step: the default `GITHUB_TOKEN` cannot create a ref whose commit modifies workflow files (`refusing to allow a GitHub App to create or update workflow ... without workflows permission`), and HEAD was the #12253 squash merge — which rewrote the nightly workflow itself. There is no `workflows:` permission grantable to the token in YAML; this recurs any night HEAD touched `.github/workflows` (including the night this PR's own squash merge is HEAD). The tag is bookkeeping — the step is now `continue-on-error: true` with a comment explaining the limitation. (The missing tag for the first publish was pushed manually: `nightly-main-20260715224004-f29c25395c36`.)

**Guardrail hardening (both workflows, from Greptile's review round):** the identity-assert steps now also verify each bundle **sub-manifest's** version (and name, for nightly) matches the expected version — that's the assertion that actually regression-guards the stamping, since the About tab and telemetry read the sub-manifests, not the union. Expected values are routed through `env:` rather than interpolated into script bodies. Union-version-only assertion would pass even if the stamping silently did nothing.

Not addressed here (fine as-is): the combined VSIX's ~83 MB unpacked install size (30 MB next + 53 MB legacy, ~19 MB download) is the inherent two-bundles-in-one cost and goes away when the loader retires.

### Test Procedure

- `cd apps/vscode-rollout && bun run typecheck && bun run test` — 36/36 pass (includes the new `set-version.test.mjs`; set-version also exercised via CLI against a real manifest).
- YAML lint on both workflows.
- Real proof for the stable channel will be the first `ext-vscode-ab-package` dispatch (`publish` unchecked): the hardened assert step verifies union + both sub-manifests equal the dispatch input, and both bundle About tabs should show it.
- The tag fix self-demonstrates on the first post-merge cron whose HEAD touches workflows (likely this PR's own merge): publish succeeds, tag step warns instead of failing the run.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] ♻️ Refactor Code
- [ ] 🧹 Chore
- [ ] 📝 Documentation update
- [x] 🏗️ Infrastructure / CI

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore
- [x] Tests are passing and code is formatted correctly
- [ ] I have created a changeset using `npm run changeset` (not user-facing; workflow-only)
- [x] I have reviewed contributor guidelines
