### PR TITLE
fix(ci): restrict nightly publishing to main

### DIFF
--- a/.github/workflows/ext-vscode-publish-nightly.yml
+++ b/.github/workflows/ext-vscode-publish-nightly.yml
@@ -54,13 +54,11 @@ jobs:
     permissions:
       contents: write
     name: Publish Cline (Nightly) Combined Extension
-    # Branch allowlist: main (the cron + real publishes) plus any branch being
-    # rehearsed with dry-run. NOTE this `if` is advisory only — a dispatched
-    # branch runs its own copy of this file. The enforced gate is the
-    # PublishNightly environment's deployment-branch policy (repo settings),
-    # which must list the same branches. Publish/tag steps are additionally
-    # gated to main below.
-    if: github.repository == 'cline/cline' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/saoudrizwan/extension-ab-loader')
+    # Defense in depth: only protected main may enter the publishing environment.
+    # This `if` is advisory because a dispatched branch runs its own copy of this
+    # file; the enforced gate is the PublishNightly environment's deployment-branch
+    # policy, which must also allow only main.
+    if: github.repository == 'cline/cline' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: PublishNightly
 
@@ -247,9 +245,8 @@ jobs:
           path: staging/cline-nightly-${{ steps.version.outputs.version }}.vsix
           if-no-files-found: error
 
-      # Publish/tag only from main and never on a dry run. Step-level (not
-      # job-level) gating so the PR branch can be dispatched with dry-run to
-      # produce an installable artifact before the workflow lands on main.
+      # The job is main-only; step-level dry-run gating still permits a build-only
+      # rehearsal without publishing or tagging.
       - name: Publish to VS Code Marketplace and Open VSX
         if: github.ref == 'refs/heads/main' && inputs.dry-run != true
         working-directory: staging

--- a/apps/vscode-rollout/README.md
+++ b/apps/vscode-rollout/README.md
@@ -148,9 +148,10 @@ The loader derives the namespace from its own `packageJSON.name` at runtime
 manifest's name — no build flags involved. Nightly builds also show a
 status-bar indicator (`Cline: Next` / `Cline: Legacy`); stable builds never do.
 
-Dispatching the nightly workflow with `dry-run` builds and uploads the
-installable `.vsix` without publishing or tagging — use that (from any branch)
-to verify changes before they reach the cron.
+Dispatching the nightly workflow from `main` with `dry-run` builds and uploads
+the installable `.vsix` without publishing or tagging. The publish job is
+intentionally restricted to `main` by both the workflow and the
+`PublishNightly` environment's deployment-branch policy.
 
 ### Telemetry events
 


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This is a security-hardening follow-up to #12253.

The combined nightly workflow temporarily allowed `saoudrizwan/extension-ab-loader` to enter the `PublishNightly` environment so the rollout pipeline could be rehearsed before merge. That branch has since been deleted, but the checked-in workflow still allowed the branch and the rollout documentation still instructed maintainers to run privileged dry runs from arbitrary branches.

That stale allowlist was more than dead configuration. A `workflow_dispatch` run uses the workflow definition from the selected branch, so the job-level `if` in `main` is only defense in depth; the environment's deployment-branch policy is the authoritative boundary. Leaving the old branch in code made it easier for a future settings change to recreate an unprotected path into the publishing environment.

This change aligns both layers around one invariant: only protected `main` may enter `PublishNightly`. It narrows the workflow condition to `main`, explains why the environment policy must remain `main`-only, and updates the runbook so dry runs are documented as `main`-only.

During investigation, the live environment policy was rechecked through the GitHub API. The temporary branch rule had already been removed by the time this patch was prepared, and the environment currently reports exactly one allowed branch: `main`. This PR closes the remaining code/documentation drift; it does not treat the YAML condition as a replacement for the environment policy.

I considered preserving arbitrary-branch dry runs, but doing that safely requires a separate unprivileged build path without the publishing environment or release credentials. Retaining the old exception in this privileged workflow would weaken the release boundary for convenience, so it is intentionally out of scope here.

### Test Procedure

1. Ran `git diff --check`; it completed without whitespace errors.
2. Searched the workflow and rollout documentation for `saoudrizwan/extension-ab-loader`; no stale reference remains.
3. Queried `repos/cline/cline/environments/PublishNightly/deployment-branch-policies`; it returns only `{ "name": "main", "type": "branch" }`.
4. Pushed the branch and retrieved the workflow through `gh workflow view --ref saoudrizwan/fix-nightly-environment-gate --yaml`; GitHub recognizes the branch version and shows the main-only job condition.
5. Full application tests were not run because this changes only workflow gating, comments, and rollout documentation; no runtime application code or package graph changed.

The main behavior to watch after merge is manual dispatch: `main` dry runs should still build and upload without publishing, while non-main dispatches must not enter the publish job.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable; this change has no user-interface impact.

### Additional Notes

The live `PublishNightly` environment is already `main`-only. That setting remains the enforcement layer and should not be broadened without first creating a separate secretless rehearsal workflow.

The broader audit also identified separately scoped concerns around dispatch-selected source refs and shell validation of the stable version input. They are intentionally not bundled into this narrowly scoped emergency hardening PR.
