### PR TITLE
feat(vscode): add GPT-5.6 ChatGPT subscription models

### DIFF
--- a/apps/vscode/src/shared/api.ts
+++ b/apps/vscode/src/shared/api.ts
@@ -2532,6 +2532,42 @@ export const openAiNativeModels = {
 export type OpenAiCodexModelId = keyof typeof openAiCodexModels
 export const openAiCodexDefaultModelId: OpenAiCodexModelId = "gpt-5.3-codex"
 export const openAiCodexModels = {
+	"gpt-5.6-sol": {
+		maxTokens: 128_000,
+		contextWindow: 372_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		supportsReasoning: true,
+		apiFormat: ApiFormat.OPENAI_RESPONSES,
+		// Subscription-based: no per-token costs
+		inputPrice: 0,
+		outputPrice: 0,
+		description: "GPT-5.6 Sol: OpenAI's latest frontier agentic coding model via ChatGPT subscription",
+	},
+	"gpt-5.6-terra": {
+		maxTokens: 128_000,
+		contextWindow: 372_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		supportsReasoning: true,
+		apiFormat: ApiFormat.OPENAI_RESPONSES,
+		// Subscription-based: no per-token costs
+		inputPrice: 0,
+		outputPrice: 0,
+		description: "GPT-5.6 Terra: OpenAI's balanced agentic coding model via ChatGPT subscription",
+	},
+	"gpt-5.6-luna": {
+		maxTokens: 128_000,
+		contextWindow: 372_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		supportsReasoning: true,
+		apiFormat: ApiFormat.OPENAI_RESPONSES,
+		// Subscription-based: no per-token costs
+		inputPrice: 0,
+		outputPrice: 0,
+		description: "GPT-5.6 Luna: OpenAI's fast agentic coding model via ChatGPT subscription",
+	},
 	"gpt-5.5": {
 		maxTokens: 128_000,
 		contextWindow: 1_000_000,

--- a/apps/vscode/src/utils/__tests__/model-utils.test.ts
+++ b/apps/vscode/src/utils/__tests__/model-utils.test.ts
@@ -7,6 +7,7 @@ import {
 	isClaude4PlusModelFamily,
 	isGeminiFlashModel,
 	isGLMModelFamily,
+	isGPT51PlusModel,
 	isGPT5ModelFamily,
 	isGptOssModelFamily,
 	isNativeToolCallingConfig,
@@ -142,6 +143,14 @@ describe("isGPT5ModelFamily", () => {
 		isGPT5ModelFamily("gpt-oss-120b").should.equal(false)
 		isGPT5ModelFamily("claude-3-sonnet").should.equal(false)
 		isGPT5ModelFamily("gemini-pro").should.equal(false)
+	})
+})
+
+describe("isGPT51PlusModel", () => {
+	it("should recognize GPT-5.6 model ID variants", () => {
+		isGPT51PlusModel("gpt-5.6-sol").should.equal(true)
+		isGPT51PlusModel("gpt-5-6-terra").should.equal(true)
+		isGPT51PlusModel("openai/gpt-5.6-luna").should.equal(true)
 	})
 })
 

--- a/apps/vscode/src/utils/model-utils.ts
+++ b/apps/vscode/src/utils/model-utils.ts
@@ -115,7 +115,9 @@ export function isGPT51PlusModel(id: string): boolean {
 		modelId.includes("gpt-5.4") ||
 		modelId.includes("gpt-5-4") ||
 		modelId.includes("gpt-5.5") ||
-		modelId.includes("gpt-5-5")
+		modelId.includes("gpt-5-5") ||
+		modelId.includes("gpt-5.6") ||
+		modelId.includes("gpt-5-6")
 	)
 }
 


### PR DESCRIPTION
### Related Issue

**Issue:** N/A (small model-catalog fix prompted by a user report)

### Description

The legacy extension's hard-coded ChatGPT subscription catalog stops at GPT-5.5, so newly released GPT-5.6 models do not appear in the model picker.

This change:

- adds the upstream Codex model IDs `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` to the ChatGPT subscription catalog;
- preserves subscription pricing semantics (zero per-token API cost);
- classifies GPT-5.6 as GPT-5.1+ so it selects the native-tool prompt variant; and
- adds a focused regression test for dotted, hyphenated, and provider-prefixed GPT-5.6 IDs.

### Test Procedure

From `apps/vscode`:

1. `npm run check-types`
2. `npm run lint`
3. `npm run test:unit -- --grep isGPT51PlusModel` (1 passing)
4. Loaded `openAiCodexModels` through the test TypeScript configuration and asserted that all three GPT-5.6 IDs exist with reasoning enabled and zero input/output prices.
5. `git diff --check`

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — the model selector renders directly from the updated catalog.

### Additional Notes

- Model IDs and display order match the [upstream Codex model catalog](https://github.com/openai/codex/blob/main/codex-rs/models-manager/models.json).
- GPT-5.6 availability is documented in the [OpenAI announcement](https://openai.com/index/gpt-5-6/).
- The existing default model remains unchanged; this PR only makes the new models selectable.
