### PR TITLE
fix(core): omit telemetry from hub tool contexts

### DIFF
--- a/sdk/packages/core/src/hub/server/hub-capability-tool-executors.test.ts
+++ b/sdk/packages/core/src/hub/server/hub-capability-tool-executors.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { CLINE_INTERNAL_TELEMETRY_METADATA_KEY } from "../../services/telemetry/tool-context";
 import { handleCapabilityProgress } from "./handlers/capability-handlers";
 import type { HubTransportContext } from "./handlers/context";
 import {
@@ -110,6 +111,58 @@ describe("handleCapabilityProgress", () => {
 });
 
 describe("hub client runtime capabilities", () => {
+	it("omits process-local telemetry from proxied tool contexts", async () => {
+		const telemetry: Record<string, unknown> = {};
+		telemetry.self = telemetry;
+		const request: ClientContributionRequest = vi.fn(
+			async (_sessionId, _capabilityName, payload) => {
+				expect(() => JSON.stringify(payload)).not.toThrow();
+				return { result: "ok" };
+			},
+		);
+		const runtime = createHubClientContributionRuntime({
+			sessionId: "session-1",
+			targetClientId: "client-1",
+			contributions: [
+				{
+					kind: "toolExecutor",
+					executor: "askQuestion",
+					capabilityName: "tool_executor.askQuestion",
+				},
+				{
+					kind: "tool",
+					name: "switch_to_act_mode",
+					description: "Switch to act mode.",
+					inputSchema: { type: "object" },
+					capabilityName: "custom_tool.switch_to_act_mode",
+				},
+			],
+			requestCapability: request,
+		});
+		const context = {
+			agentId: "agent-1",
+			conversationId: "conv-1",
+			iteration: 2,
+			metadata: {
+				modelSupportsImages: true,
+				[CLINE_INTERNAL_TELEMETRY_METADATA_KEY]: telemetry,
+			},
+		};
+
+		await runtime.toolExecutors?.askQuestion?.("Continue?", ["Yes"], context);
+		await runtime.localRuntime.extraTools?.[0]?.execute({}, context);
+
+		expect(request).toHaveBeenCalledTimes(2);
+		for (const [, , payload] of vi.mocked(request).mock.calls) {
+			expect(payload.context).toEqual({
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 2,
+				metadata: { modelSupportsImages: true },
+			});
+		}
+	});
+
 	it("proxies lifecycle hooks through capability requests", async () => {
 		const request = vi.fn(async () => ({
 			control: { context: "extra context" },

--- a/sdk/packages/core/src/hub/server/hub-client-contributions.ts
+++ b/sdk/packages/core/src/hub/server/hub-client-contributions.ts
@@ -51,6 +51,7 @@ import type {
 	RuntimeSessionConfig,
 } from "../../runtime/host/runtime-host";
 import { formatRulesForSystemPrompt } from "../../runtime/safety/rules";
+import { CLINE_INTERNAL_TELEMETRY_METADATA_KEY } from "../../services/telemetry/tool-context";
 import type { CoreSessionConfig } from "../../types/config";
 
 type RequestCapability = (
@@ -218,11 +219,16 @@ export function parseHubClientContributions(
 function serializeToolContext(
 	context: AgentToolContext,
 ): Record<string, unknown> {
+	const metadata = context.metadata ? { ...context.metadata } : undefined;
+	if (metadata) {
+		delete metadata[CLINE_INTERNAL_TELEMETRY_METADATA_KEY];
+	}
 	return {
 		agentId: context.agentId,
 		conversationId: context.conversationId,
 		iteration: context.iteration,
-		metadata: context.metadata,
+		metadata:
+			metadata && Object.keys(metadata).length > 0 ? metadata : undefined,
 	};
 }
 


### PR DESCRIPTION
### Related Issue

**Issue:** N/A — small regression fix identified from an interactive CLI session

### Description

Hub-backed interactive sessions could hang indefinitely when the model invoked a client-owned tool such as `ask_question` or `switch_to_act_mode`.

The daemon adds its telemetry service to `AgentToolContext.metadata` under the internal `__clineInternalTelemetry` key so daemon-owned tools can emit telemetry. The hub capability proxy then forwarded that metadata unchanged to the client. A live OpenTelemetry service contains cyclic object references, so the WebSocket adapter's `JSON.stringify` failed before sending the capability request.

Because the adapter logged and swallowed that serialization failure, the server still treated the request as published and waited forever for a response the client could never send. For `ask_question`, changing modes aborted the stranded request and surfaced the misleading `Interactive runtime abort requested` tool error. `switch_to_act_mode` remained in a loading state because its request was never aborted.

This change keeps the fix at the process boundary: it shallow-copies tool metadata and removes only the process-local telemetry service before building a hub capability payload. Other metadata, including `modelSupportsImages`, continues to cross the hub unchanged.

The regression test exercises both capability paths with deliberately cyclic internal telemetry metadata. It verifies that the resulting payloads are JSON-serializable and that ordinary metadata is preserved.

I intentionally did not add generic cycle-tolerant serialization, change daemon version-reuse policy, or redesign WebSocket error propagation. Those are broader resilience concerns; transporting a live telemetry service is incorrect regardless, and removing that one internal value fixes the observed regression directly.

### Test Procedure

Run the focused hub capability test:

```bash
cd sdk/packages/core
bunx vitest run src/hub/server/hub-capability-tool-executors.test.ts --config vitest.config.ts
```

Result: 1 test file passed, 5 tests passed.

Verify formatting and lint rules for the changed code:

```bash
bun biome check sdk/packages/core/src/hub/server/hub-client-contributions.ts sdk/packages/core/src/hub/server/hub-capability-tool-executors.test.ts
```

Verify the core package typechecks:

```bash
bun -F @cline/core typecheck
```

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable; this is a backend hub serialization fix with no UI changes.

### Additional Notes

The active global hub observed during debugging was older than the CLI client, but the same serialization path remains present in current `main`. Restarting the daemon alone is therefore not a complete fix.
