### PR TITLE
fix(hub): retire hub daemons from a different build on upgrade

### DIFF
--- a/sdk/packages/core/src/hub/client/index.test.ts
+++ b/sdk/packages/core/src/hub/client/index.test.ts
@@ -543,9 +543,7 @@ describe("NodeHubClient", () => {
 			globalThis as unknown as { WebSocket?: typeof RecoveryWebSocket }
 		).WebSocket = RecoveryWebSocket;
 		vi.doMock("../daemon", () => ({
-			ensureDetachedHubServer: vi.fn(async () => {
-				throw new Error("unexpected ensureDetachedHubServer call");
-			}),
+			spawnDetachedHubServerWithRetry: vi.fn(async () => undefined),
 		}));
 		vi.doMock("../discovery/workspace", () => ({
 			resolveProductionHubOwnerContext: () => ({
@@ -700,9 +698,7 @@ describe("NodeHubClient", () => {
 			globalThis as unknown as { WebSocket?: typeof ExplicitEndpointWebSocket }
 		).WebSocket = ExplicitEndpointWebSocket;
 		vi.doMock("../daemon", () => ({
-			ensureDetachedHubServer: vi.fn(async () => {
-				throw new Error("unexpected ensureDetachedHubServer call");
-			}),
+			spawnDetachedHubServerWithRetry: vi.fn(async () => undefined),
 		}));
 		vi.doMock("../discovery/workspace", () => ({
 			resolveProductionHubOwnerContext: () => ({
@@ -963,15 +959,26 @@ describe("resolveCompatibleLocalHubUrl", () => {
 		);
 	});
 
-	it("starts missing local hubs through the daemon ensure API", async () => {
+	it("starts missing local hubs through the retrying daemon spawn API", async () => {
 		vi.stubGlobal("WebSocket", MockWebSocket);
-		const ensureDetachedHubServerMock = vi.fn(async () => ({
-			url: "ws://127.0.0.1:25464/hub",
+		const spawnDetachedHubServerWithRetryMock = vi.fn(async () => undefined);
+		const record = {
+			hubId: "hub-test",
+			protocolVersion: "v1",
+			buildId: "test-build",
 			authToken: "token",
-		}));
-		const readHubDiscoveryMock = vi.fn().mockResolvedValue(undefined);
+			host: "127.0.0.1",
+			port: 25464,
+			url: "ws://127.0.0.1:25464/hub",
+			startedAt: new Date().toISOString(),
+			updatedAt: new Date().toISOString(),
+		};
+		const readHubDiscoveryMock = vi
+			.fn()
+			.mockResolvedValueOnce(undefined)
+			.mockResolvedValueOnce(record);
 		vi.doMock("../daemon", () => ({
-			ensureDetachedHubServer: ensureDetachedHubServerMock,
+			spawnDetachedHubServerWithRetry: spawnDetachedHubServerWithRetryMock,
 		}));
 		vi.doMock("../discovery/workspace", () => ({
 			resolveProductionHubOwnerContext: () => ({
@@ -990,7 +997,7 @@ describe("resolveCompatibleLocalHubUrl", () => {
 				...actual,
 				resolveHubBuildId: () => "test-build",
 				readHubDiscovery: readHubDiscoveryMock,
-				probeHubServer: vi.fn(async () => undefined),
+				probeHubServer: vi.fn(async () => record),
 				clearHubDiscovery: vi.fn(async () => undefined),
 			};
 		});
@@ -1003,106 +1010,15 @@ describe("resolveCompatibleLocalHubUrl", () => {
 				cwd: "/tmp/project",
 			}),
 		).resolves.toBe("ws://127.0.0.1:25464/hub");
-		expect(ensureDetachedHubServerMock).toHaveBeenCalledWith("/tmp/project");
-	});
-
-	it("replaces a stale-build hub through the daemon ensure API without dropping its discovery record", async () => {
-		vi.stubGlobal("WebSocket", MockWebSocket);
-		const clearHubDiscoveryMock = vi.fn();
-		const ensureDetachedHubServerMock = vi.fn(async () => ({
-			url: "ws://127.0.0.1:25465/hub",
-			authToken: "new-token",
-		}));
-		const staleRecord = {
-			hubId: "hub-test",
-			protocolVersion: "v1",
-			buildId: "old-build",
-			authToken: "old-token",
-			host: "127.0.0.1",
-			port: 25464,
-			url: "ws://127.0.0.1:25464/hub",
-			startedAt: new Date().toISOString(),
-			updatedAt: new Date().toISOString(),
-		};
-		vi.doMock("../daemon", () => ({
-			ensureDetachedHubServer: ensureDetachedHubServerMock,
-		}));
-		vi.doMock("../discovery/workspace", () => ({
-			resolveProductionHubOwnerContext: () => ({
-				ownerId: "hub-test",
-				discoveryPath: "/tmp/hub-discovery.json",
-			}),
-			resolveSharedHubOwnerContext: () => ({
-				ownerId: "hub-test",
-				discoveryPath: "/tmp/hub-discovery.json",
-			}),
-		}));
-		vi.doMock("../discovery", async () => {
-			const actual =
-				await vi.importActual<typeof import("../discovery")>("../discovery");
-			return {
-				...actual,
-				resolveHubBuildId: () => "current-build",
-				readHubDiscovery: vi.fn(async () => staleRecord),
-				probeHubServer: vi.fn(async () => staleRecord),
-				clearHubDiscovery: vi.fn(async (...args: unknown[]) => {
-					clearHubDiscoveryMock(...args);
-				}),
-			};
-		});
-
-		const { ensureCompatibleLocalHubUrl } = await import(".");
-
-		await expect(
-			ensureCompatibleLocalHubUrl({
-				workspaceRoot: "/tmp/project",
-				cwd: "/tmp/project",
-			}),
-		).resolves.toBe("ws://127.0.0.1:25465/hub");
-		expect(ensureDetachedHubServerMock).toHaveBeenCalledWith("/tmp/project");
-		// The stale record must survive until the daemon retires the hub; it
-		// carries the authToken/pid the retirement path needs.
-		expect(clearHubDiscoveryMock).not.toHaveBeenCalled();
-	});
-
-	it("returns undefined when the daemon ensure fails", async () => {
-		vi.stubGlobal("WebSocket", MockWebSocket);
-		const ensureDetachedHubServerMock = vi.fn(async () => {
-			throw new Error("could not be retired automatically");
-		});
-		vi.doMock("../daemon", () => ({
-			ensureDetachedHubServer: ensureDetachedHubServerMock,
-		}));
-		vi.doMock("../discovery/workspace", () => ({
-			resolveProductionHubOwnerContext: () => ({
-				ownerId: "hub-test",
-				discoveryPath: "/tmp/hub-discovery.json",
-			}),
-			resolveSharedHubOwnerContext: () => ({
-				ownerId: "hub-test",
-				discoveryPath: "/tmp/hub-discovery.json",
-			}),
-		}));
-		vi.doMock("../discovery", async () => {
-			const actual =
-				await vi.importActual<typeof import("../discovery")>("../discovery");
-			return {
-				...actual,
-				readHubDiscovery: vi.fn(async () => undefined),
-				probeHubServer: vi.fn(async () => undefined),
-				clearHubDiscovery: vi.fn(async () => undefined),
-			};
-		});
-
-		const { ensureCompatibleLocalHubUrl } = await import(".");
-
-		await expect(
-			ensureCompatibleLocalHubUrl({
-				workspaceRoot: "/tmp/project",
-				cwd: "/tmp/project",
-			}),
-		).resolves.toBeUndefined();
-		expect(ensureDetachedHubServerMock).toHaveBeenCalledWith("/tmp/project");
+		expect(spawnDetachedHubServerWithRetryMock).toHaveBeenCalledWith(
+			"/tmp/project",
+		);
+		expect(
+			spawnDetachedHubServerWithRetryMock.mock.invocationCallOrder[0],
+		).toBeGreaterThan(readHubDiscoveryMock.mock.invocationCallOrder[0]);
+		expect(
+			spawnDetachedHubServerWithRetryMock.mock.invocationCallOrder[0],
+		).toBeLessThan(readHubDiscoveryMock.mock.invocationCallOrder[1]);
 	});
 
 	it("resolves the shared-owner discovery hub in development builds", async () => {
@@ -1196,9 +1112,7 @@ describe("resolveCompatibleLocalHubUrl", () => {
 			}),
 		}));
 		vi.doMock("../daemon", () => ({
-			ensureDetachedHubServer: vi.fn(async () => {
-				throw new Error("unexpected ensureDetachedHubServer call");
-			}),
+			spawnDetachedHubServerWithRetry: vi.fn(async () => undefined),
 		}));
 		vi.doMock("../discovery", async () => {
 			const actual =

--- a/sdk/packages/core/src/hub/client/index.test.ts
+++ b/sdk/packages/core/src/hub/client/index.test.ts
@@ -814,7 +814,7 @@ describe("resolveCompatibleLocalHubUrl", () => {
 		expect(clearHubDiscoveryMock).not.toHaveBeenCalled();
 	});
 
-	it("clears discovery on build mismatch when protocol is compatible", async () => {
+	it("returns undefined on build mismatch but keeps discovery for retirement", async () => {
 		const clearHubDiscoveryMock = vi.fn();
 		vi.doMock("../discovery/workspace", () => ({
 			resolveProductionHubOwnerContext: () => ({
@@ -861,12 +861,10 @@ describe("resolveCompatibleLocalHubUrl", () => {
 		const { resolveCompatibleLocalHubUrl } = await import(".");
 
 		await expect(resolveCompatibleLocalHubUrl()).resolves.toBeUndefined();
-		expect(clearHubDiscoveryMock).toHaveBeenCalledWith(
-			"/tmp/hub-discovery.json",
-		);
+		expect(clearHubDiscoveryMock).not.toHaveBeenCalled();
 	});
 
-	it("clears discovery when a hub omits build metadata", async () => {
+	it("returns undefined and keeps discovery when a hub omits build metadata", async () => {
 		const clearHubDiscoveryMock = vi.fn();
 		vi.doMock("../discovery/workspace", () => ({
 			resolveProductionHubOwnerContext: () => ({
@@ -911,9 +909,7 @@ describe("resolveCompatibleLocalHubUrl", () => {
 		const { resolveCompatibleLocalHubUrl } = await import(".");
 
 		await expect(resolveCompatibleLocalHubUrl()).resolves.toBeUndefined();
-		expect(clearHubDiscoveryMock).toHaveBeenCalledWith(
-			"/tmp/hub-discovery.json",
-		);
+		expect(clearHubDiscoveryMock).not.toHaveBeenCalled();
 	});
 
 	it("clears discovery on protocol mismatch", async () => {
@@ -1008,6 +1004,65 @@ describe("resolveCompatibleLocalHubUrl", () => {
 			}),
 		).resolves.toBe("ws://127.0.0.1:25464/hub");
 		expect(ensureDetachedHubServerMock).toHaveBeenCalledWith("/tmp/project");
+	});
+
+	it("replaces a stale-build hub through the daemon ensure API without dropping its discovery record", async () => {
+		vi.stubGlobal("WebSocket", MockWebSocket);
+		const clearHubDiscoveryMock = vi.fn();
+		const ensureDetachedHubServerMock = vi.fn(async () => ({
+			url: "ws://127.0.0.1:25465/hub",
+			authToken: "new-token",
+		}));
+		const staleRecord = {
+			hubId: "hub-test",
+			protocolVersion: "v1",
+			buildId: "old-build",
+			authToken: "old-token",
+			host: "127.0.0.1",
+			port: 25464,
+			url: "ws://127.0.0.1:25464/hub",
+			startedAt: new Date().toISOString(),
+			updatedAt: new Date().toISOString(),
+		};
+		vi.doMock("../daemon", () => ({
+			ensureDetachedHubServer: ensureDetachedHubServerMock,
+		}));
+		vi.doMock("../discovery/workspace", () => ({
+			resolveProductionHubOwnerContext: () => ({
+				ownerId: "hub-test",
+				discoveryPath: "/tmp/hub-discovery.json",
+			}),
+			resolveSharedHubOwnerContext: () => ({
+				ownerId: "hub-test",
+				discoveryPath: "/tmp/hub-discovery.json",
+			}),
+		}));
+		vi.doMock("../discovery", async () => {
+			const actual =
+				await vi.importActual<typeof import("../discovery")>("../discovery");
+			return {
+				...actual,
+				resolveHubBuildId: () => "current-build",
+				readHubDiscovery: vi.fn(async () => staleRecord),
+				probeHubServer: vi.fn(async () => staleRecord),
+				clearHubDiscovery: vi.fn(async (...args: unknown[]) => {
+					clearHubDiscoveryMock(...args);
+				}),
+			};
+		});
+
+		const { ensureCompatibleLocalHubUrl } = await import(".");
+
+		await expect(
+			ensureCompatibleLocalHubUrl({
+				workspaceRoot: "/tmp/project",
+				cwd: "/tmp/project",
+			}),
+		).resolves.toBe("ws://127.0.0.1:25465/hub");
+		expect(ensureDetachedHubServerMock).toHaveBeenCalledWith("/tmp/project");
+		// The stale record must survive until the daemon retires the hub; it
+		// carries the authToken/pid the retirement path needs.
+		expect(clearHubDiscoveryMock).not.toHaveBeenCalled();
 	});
 
 	it("returns undefined when the daemon ensure fails", async () => {

--- a/sdk/packages/core/src/hub/client/index.test.ts
+++ b/sdk/packages/core/src/hub/client/index.test.ts
@@ -810,7 +810,7 @@ describe("resolveCompatibleLocalHubUrl", () => {
 		expect(clearHubDiscoveryMock).not.toHaveBeenCalled();
 	});
 
-	it("keeps discovery on build mismatch when protocol is compatible", async () => {
+	it("clears discovery on build mismatch when protocol is compatible", async () => {
 		const clearHubDiscoveryMock = vi.fn();
 		vi.doMock("../discovery/workspace", () => ({
 			resolveProductionHubOwnerContext: () => ({
@@ -856,13 +856,13 @@ describe("resolveCompatibleLocalHubUrl", () => {
 
 		const { resolveCompatibleLocalHubUrl } = await import(".");
 
-		await expect(resolveCompatibleLocalHubUrl()).resolves.toBe(
-			"ws://127.0.0.1:59999/hub",
+		await expect(resolveCompatibleLocalHubUrl()).resolves.toBeUndefined();
+		expect(clearHubDiscoveryMock).toHaveBeenCalledWith(
+			"/tmp/hub-discovery.json",
 		);
-		expect(clearHubDiscoveryMock).not.toHaveBeenCalled();
 	});
 
-	it("keeps discovery when a hub omits build metadata but has compatible protocol", async () => {
+	it("clears discovery when a hub omits build metadata", async () => {
 		const clearHubDiscoveryMock = vi.fn();
 		vi.doMock("../discovery/workspace", () => ({
 			resolveProductionHubOwnerContext: () => ({
@@ -906,10 +906,10 @@ describe("resolveCompatibleLocalHubUrl", () => {
 
 		const { resolveCompatibleLocalHubUrl } = await import(".");
 
-		await expect(resolveCompatibleLocalHubUrl()).resolves.toBe(
-			"ws://127.0.0.1:59999/hub",
+		await expect(resolveCompatibleLocalHubUrl()).resolves.toBeUndefined();
+		expect(clearHubDiscoveryMock).toHaveBeenCalledWith(
+			"/tmp/hub-discovery.json",
 		);
-		expect(clearHubDiscoveryMock).not.toHaveBeenCalled();
 	});
 
 	it("clears discovery on protocol mismatch", async () => {
@@ -1062,6 +1062,7 @@ describe("resolveCompatibleLocalHubUrl", () => {
 				await vi.importActual<typeof import("../discovery")>("../discovery");
 			return {
 				...actual,
+				resolveHubBuildId: () => "test-build",
 				readHubDiscovery: readHubDiscoveryMock,
 				probeHubServer: vi.fn(async () => record),
 				clearHubDiscovery: vi.fn(async () => undefined),

--- a/sdk/packages/core/src/hub/client/index.test.ts
+++ b/sdk/packages/core/src/hub/client/index.test.ts
@@ -543,7 +543,9 @@ describe("NodeHubClient", () => {
 			globalThis as unknown as { WebSocket?: typeof RecoveryWebSocket }
 		).WebSocket = RecoveryWebSocket;
 		vi.doMock("../daemon", () => ({
-			spawnDetachedHubServerWithRetry: vi.fn(async () => undefined),
+			ensureDetachedHubServer: vi.fn(async () => {
+				throw new Error("unexpected ensureDetachedHubServer call");
+			}),
 		}));
 		vi.doMock("../discovery/workspace", () => ({
 			resolveProductionHubOwnerContext: () => ({
@@ -698,7 +700,9 @@ describe("NodeHubClient", () => {
 			globalThis as unknown as { WebSocket?: typeof ExplicitEndpointWebSocket }
 		).WebSocket = ExplicitEndpointWebSocket;
 		vi.doMock("../daemon", () => ({
-			spawnDetachedHubServerWithRetry: vi.fn(async () => undefined),
+			ensureDetachedHubServer: vi.fn(async () => {
+				throw new Error("unexpected ensureDetachedHubServer call");
+			}),
 		}));
 		vi.doMock("../discovery/workspace", () => ({
 			resolveProductionHubOwnerContext: () => ({
@@ -963,26 +967,15 @@ describe("resolveCompatibleLocalHubUrl", () => {
 		);
 	});
 
-	it("starts missing local hubs through the retrying daemon spawn API", async () => {
+	it("starts missing local hubs through the daemon ensure API", async () => {
 		vi.stubGlobal("WebSocket", MockWebSocket);
-		const spawnDetachedHubServerWithRetryMock = vi.fn(async () => undefined);
-		const record = {
-			hubId: "hub-test",
-			protocolVersion: "v1",
-			buildId: "test-build",
-			authToken: "token",
-			host: "127.0.0.1",
-			port: 25464,
+		const ensureDetachedHubServerMock = vi.fn(async () => ({
 			url: "ws://127.0.0.1:25464/hub",
-			startedAt: new Date().toISOString(),
-			updatedAt: new Date().toISOString(),
-		};
-		const readHubDiscoveryMock = vi
-			.fn()
-			.mockResolvedValueOnce(undefined)
-			.mockResolvedValueOnce(record);
+			authToken: "token",
+		}));
+		const readHubDiscoveryMock = vi.fn().mockResolvedValue(undefined);
 		vi.doMock("../daemon", () => ({
-			spawnDetachedHubServerWithRetry: spawnDetachedHubServerWithRetryMock,
+			ensureDetachedHubServer: ensureDetachedHubServerMock,
 		}));
 		vi.doMock("../discovery/workspace", () => ({
 			resolveProductionHubOwnerContext: () => ({
@@ -1001,7 +994,7 @@ describe("resolveCompatibleLocalHubUrl", () => {
 				...actual,
 				resolveHubBuildId: () => "test-build",
 				readHubDiscovery: readHubDiscoveryMock,
-				probeHubServer: vi.fn(async () => record),
+				probeHubServer: vi.fn(async () => undefined),
 				clearHubDiscovery: vi.fn(async () => undefined),
 			};
 		});
@@ -1014,18 +1007,50 @@ describe("resolveCompatibleLocalHubUrl", () => {
 				cwd: "/tmp/project",
 			}),
 		).resolves.toBe("ws://127.0.0.1:25464/hub");
-		expect(spawnDetachedHubServerWithRetryMock).toHaveBeenCalledWith(
-			"/tmp/project",
-		);
-		expect(
-			spawnDetachedHubServerWithRetryMock.mock.invocationCallOrder[0],
-		).toBeGreaterThan(readHubDiscoveryMock.mock.invocationCallOrder[0]);
-		expect(
-			spawnDetachedHubServerWithRetryMock.mock.invocationCallOrder[0],
-		).toBeLessThan(readHubDiscoveryMock.mock.invocationCallOrder[1]);
+		expect(ensureDetachedHubServerMock).toHaveBeenCalledWith("/tmp/project");
 	});
 
-	it("waits on shared discovery after spawning in development builds", async () => {
+	it("returns undefined when the daemon ensure fails", async () => {
+		vi.stubGlobal("WebSocket", MockWebSocket);
+		const ensureDetachedHubServerMock = vi.fn(async () => {
+			throw new Error("could not be retired automatically");
+		});
+		vi.doMock("../daemon", () => ({
+			ensureDetachedHubServer: ensureDetachedHubServerMock,
+		}));
+		vi.doMock("../discovery/workspace", () => ({
+			resolveProductionHubOwnerContext: () => ({
+				ownerId: "hub-test",
+				discoveryPath: "/tmp/hub-discovery.json",
+			}),
+			resolveSharedHubOwnerContext: () => ({
+				ownerId: "hub-test",
+				discoveryPath: "/tmp/hub-discovery.json",
+			}),
+		}));
+		vi.doMock("../discovery", async () => {
+			const actual =
+				await vi.importActual<typeof import("../discovery")>("../discovery");
+			return {
+				...actual,
+				readHubDiscovery: vi.fn(async () => undefined),
+				probeHubServer: vi.fn(async () => undefined),
+				clearHubDiscovery: vi.fn(async () => undefined),
+			};
+		});
+
+		const { ensureCompatibleLocalHubUrl } = await import(".");
+
+		await expect(
+			ensureCompatibleLocalHubUrl({
+				workspaceRoot: "/tmp/project",
+				cwd: "/tmp/project",
+			}),
+		).resolves.toBeUndefined();
+		expect(ensureDetachedHubServerMock).toHaveBeenCalledWith("/tmp/project");
+	});
+
+	it("resolves the shared-owner discovery hub in development builds", async () => {
 		vi.stubGlobal("WebSocket", MockWebSocket);
 		const originalBuildEnv = process.env.CLINE_BUILD_ENV;
 		process.env.CLINE_BUILD_ENV = "development";
@@ -1116,7 +1141,9 @@ describe("resolveCompatibleLocalHubUrl", () => {
 			}),
 		}));
 		vi.doMock("../daemon", () => ({
-			spawnDetachedHubServerWithRetry: vi.fn(async () => undefined),
+			ensureDetachedHubServer: vi.fn(async () => {
+				throw new Error("unexpected ensureDetachedHubServer call");
+			}),
 		}));
 		vi.doMock("../discovery", async () => {
 			const actual =

--- a/sdk/packages/core/src/hub/client/index.ts
+++ b/sdk/packages/core/src/hub/client/index.ts
@@ -13,7 +13,7 @@ import {
 	SESSION_NOT_FOUND_ERROR_CODE,
 	SessionNotFoundError,
 } from "../../runtime/host/runtime-host";
-import { spawnDetachedHubServerWithRetry } from "../daemon";
+import { ensureDetachedHubServer } from "../daemon";
 import {
 	clearHubDiscovery,
 	type HubOwnerContext,
@@ -179,8 +179,6 @@ export interface LocalHubResolutionOptions {
 	cwd?: string;
 }
 
-const HUB_STARTUP_TIMEOUT_MS = 8_000;
-const HUB_STARTUP_POLL_MS = 200;
 const GLOBAL_SUBSCRIPTION_KEY = "*";
 const HUB_CONNECT_TIMEOUT_MS = 8_000;
 const HUB_AUTH_PROTOCOL_PREFIX = "cline-hub-auth.";
@@ -890,26 +888,6 @@ async function probeCompatibleHubUrl(
 	};
 }
 
-async function waitForCompatibleHubUrl(
-	owner: HubOwnerContext,
-): Promise<string | undefined> {
-	const deadline = Date.now() + HUB_STARTUP_TIMEOUT_MS;
-	while (Date.now() < deadline) {
-		const record = await readHubDiscovery(owner.discoveryPath);
-		if (record?.url) {
-			const compatible = await probeCompatibleHubUrl(record.url, {
-				verifyConnection: true,
-				authToken: record.authToken,
-			});
-			if (compatible.status === "compatible") {
-				return rememberRecoverableLocalHubUrl(compatible.url, record.authToken);
-			}
-		}
-		await new Promise((resolve) => setTimeout(resolve, HUB_STARTUP_POLL_MS));
-	}
-	return undefined;
-}
-
 async function waitForHubToRetire(url: string): Promise<boolean> {
 	const deadline = Date.now() + HUB_RECOVERY_RETIRE_TIMEOUT_MS;
 	while (Date.now() < deadline) {
@@ -1030,9 +1008,17 @@ export async function ensureCompatibleLocalHubUrl(
 	if (options.endpoint?.trim()) {
 		return undefined;
 	}
-	const owner = resolveDefaultHubOwnerContext();
-	await spawnDetachedHubServerWithRetry(options.workspaceRoot ?? process.cwd());
-	return await waitForCompatibleHubUrl(owner);
+	// Delegate to the daemon module's ensure so a stale hub still holding the
+	// configured port is retired before the replacement spawns; a raw spawn
+	// would die on the occupied port and this would time out to undefined.
+	try {
+		const ensured = await ensureDetachedHubServer(
+			options.workspaceRoot ?? process.cwd(),
+		);
+		return ensured.url;
+	} catch {
+		return undefined;
+	}
 }
 
 export async function requestHubShutdown(

--- a/sdk/packages/core/src/hub/client/index.ts
+++ b/sdk/packages/core/src/hub/client/index.ts
@@ -19,6 +19,7 @@ import {
 	type HubOwnerContext,
 	probeHubServer,
 	readHubDiscovery,
+	resolveHubBuildId,
 } from "../discovery";
 import {
 	resolveProductionHubOwnerContext,
@@ -831,7 +832,7 @@ type HubProbeResult =
 			url: string;
 	  }
 	| {
-			status: "unreachable" | "protocol_mismatch";
+			status: "unreachable" | "protocol_mismatch" | "build_mismatch";
 			url: string;
 	  };
 
@@ -857,6 +858,16 @@ async function probeCompatibleHubUrl(
 	if (!isHubProtocolCompatible(record).compatible) {
 		return {
 			status: "protocol_mismatch",
+			url: normalized,
+		};
+	}
+	// A protocol-compatible hub from an older build keeps serving stale code
+	// after an upgrade; report it so callers stop reusing it and the daemon
+	// ensure/prewarm paths retire it. Missing/blank buildId counts as stale.
+	const recordBuildId = record.buildId?.trim();
+	if (!recordBuildId || recordBuildId !== resolveHubBuildId()) {
+		return {
+			status: "build_mismatch",
 			url: normalized,
 		};
 	}
@@ -994,7 +1005,10 @@ export async function resolveCompatibleLocalHubUrl(
 	if (compatible.status === "compatible") {
 		return rememberRecoverableLocalHubUrl(compatible.url, record.authToken);
 	}
-	if (compatible.status === "protocol_mismatch") {
+	if (
+		compatible.status === "protocol_mismatch" ||
+		compatible.status === "build_mismatch"
+	) {
 		await clearHubDiscovery(owner.discoveryPath).catch(() => undefined);
 	}
 	return undefined;

--- a/sdk/packages/core/src/hub/client/index.ts
+++ b/sdk/packages/core/src/hub/client/index.ts
@@ -13,7 +13,7 @@ import {
 	SESSION_NOT_FOUND_ERROR_CODE,
 	SessionNotFoundError,
 } from "../../runtime/host/runtime-host";
-import { ensureDetachedHubServer } from "../daemon";
+import { spawnDetachedHubServerWithRetry } from "../daemon";
 import {
 	clearHubDiscovery,
 	type HubOwnerContext,
@@ -179,6 +179,8 @@ export interface LocalHubResolutionOptions {
 	cwd?: string;
 }
 
+const HUB_STARTUP_TIMEOUT_MS = 8_000;
+const HUB_STARTUP_POLL_MS = 200;
 const GLOBAL_SUBSCRIPTION_KEY = "*";
 const HUB_CONNECT_TIMEOUT_MS = 8_000;
 const HUB_AUTH_PROTOCOL_PREFIX = "cline-hub-auth.";
@@ -888,6 +890,26 @@ async function probeCompatibleHubUrl(
 	};
 }
 
+async function waitForCompatibleHubUrl(
+	owner: HubOwnerContext,
+): Promise<string | undefined> {
+	const deadline = Date.now() + HUB_STARTUP_TIMEOUT_MS;
+	while (Date.now() < deadline) {
+		const record = await readHubDiscovery(owner.discoveryPath);
+		if (record?.url) {
+			const compatible = await probeCompatibleHubUrl(record.url, {
+				verifyConnection: true,
+				authToken: record.authToken,
+			});
+			if (compatible.status === "compatible") {
+				return rememberRecoverableLocalHubUrl(compatible.url, record.authToken);
+			}
+		}
+		await new Promise((resolve) => setTimeout(resolve, HUB_STARTUP_POLL_MS));
+	}
+	return undefined;
+}
+
 async function waitForHubToRetire(url: string): Promise<boolean> {
 	const deadline = Date.now() + HUB_RECOVERY_RETIRE_TIMEOUT_MS;
 	while (Date.now() < deadline) {
@@ -1009,17 +1031,9 @@ export async function ensureCompatibleLocalHubUrl(
 	if (options.endpoint?.trim()) {
 		return undefined;
 	}
-	// Delegate to the daemon module's ensure so a stale hub still holding the
-	// configured port is retired before the replacement spawns; a raw spawn
-	// would die on the occupied port and this would time out to undefined.
-	try {
-		const ensured = await ensureDetachedHubServer(
-			options.workspaceRoot ?? process.cwd(),
-		);
-		return ensured.url;
-	} catch {
-		return undefined;
-	}
+	const owner = resolveDefaultHubOwnerContext();
+	await spawnDetachedHubServerWithRetry(options.workspaceRoot ?? process.cwd());
+	return await waitForCompatibleHubUrl(owner);
 }
 
 export async function requestHubShutdown(

--- a/sdk/packages/core/src/hub/client/index.ts
+++ b/sdk/packages/core/src/hub/client/index.ts
@@ -983,10 +983,11 @@ export async function resolveCompatibleLocalHubUrl(
 	if (compatible.status === "compatible") {
 		return rememberRecoverableLocalHubUrl(compatible.url, record.authToken);
 	}
-	if (
-		compatible.status === "protocol_mismatch" ||
-		compatible.status === "build_mismatch"
-	) {
+	// Keep the discovery record on build_mismatch: it carries the authToken
+	// and pid the daemon ensure/prewarm paths need to retire the stale hub
+	// gracefully. Clearing it here would leave retirement with only an
+	// unauthenticated /health probe, which cannot stop the old daemon.
+	if (compatible.status === "protocol_mismatch") {
 		await clearHubDiscovery(owner.discoveryPath).catch(() => undefined);
 	}
 	return undefined;

--- a/sdk/packages/core/src/hub/daemon/index.test.ts
+++ b/sdk/packages/core/src/hub/daemon/index.test.ts
@@ -303,7 +303,7 @@ describe("ensureDetachedHubServer", () => {
 		}
 	});
 
-	it("reuses a protocol-compatible healthy hub from a different build", async () => {
+	it("retires a healthy hub from a different build and starts a replacement", async () => {
 		const kill = vi.spyOn(process, "kill").mockImplementation(() => true);
 		try {
 			readHubDiscovery
@@ -311,13 +311,24 @@ describe("ensureDetachedHubServer", () => {
 					url: "ws://127.0.0.1:25463/hub",
 					authToken: "old-token",
 				})
-				.mockResolvedValueOnce(undefined);
-			probeHubServer.mockResolvedValueOnce({
-				url: "ws://127.0.0.1:25463/hub",
-				protocolVersion: "v1",
-				buildId: "old-build",
-				pid: 12345,
-			});
+				.mockResolvedValueOnce({
+					url: "ws://127.0.0.1:25463/hub",
+					authToken: "new-token",
+				});
+			probeHubServer
+				.mockResolvedValueOnce({
+					url: "ws://127.0.0.1:25463/hub",
+					protocolVersion: "v1",
+					buildId: "old-build",
+					pid: 12345,
+				})
+				.mockResolvedValueOnce(undefined)
+				.mockResolvedValueOnce(undefined)
+				.mockResolvedValueOnce({
+					url: "ws://127.0.0.1:25463/hub",
+					protocolVersion: "v1",
+					buildId: "current-build",
+				});
 			verifyHubConnection.mockResolvedValueOnce(true);
 
 			const { ensureDetachedHubServer } = await import(".");
@@ -325,12 +336,15 @@ describe("ensureDetachedHubServer", () => {
 
 			expect(result).toEqual({
 				url: "ws://127.0.0.1:25463/hub",
-				authToken: "old-token",
+				authToken: "new-token",
 			});
-			expect(requestHubShutdown).not.toHaveBeenCalled();
-			expect(clearHubDiscovery).not.toHaveBeenCalled();
-			expect(kill).not.toHaveBeenCalled();
-			expect(spawn).not.toHaveBeenCalled();
+			expect(requestHubShutdown).toHaveBeenCalledWith(
+				"ws://127.0.0.1:25463/hub",
+				"old-token",
+			);
+			expect(kill).toHaveBeenCalledWith(12345, "SIGTERM");
+			expect(clearHubDiscovery).toHaveBeenCalledWith("/tmp/hub-discovery.json");
+			expect(spawn).toHaveBeenCalledOnce();
 			expect(verifyHubConnection).toHaveBeenCalledOnce();
 		} finally {
 			kill.mockRestore();

--- a/sdk/packages/core/src/hub/daemon/index.ts
+++ b/sdk/packages/core/src/hub/daemon/index.ts
@@ -22,6 +22,7 @@ import {
 	probeHubServer,
 	readHubDiscovery,
 	resolveClineDataDir,
+	resolveHubBuildId,
 } from "../discovery";
 import {
 	type HubEndpointOverrides,
@@ -66,7 +67,14 @@ function resolveDefaultHubOwnerContext() {
 }
 
 function isCompatibleHubRecord(record: HubServerProbeRecord): boolean {
-	return isHubProtocolCompatible(record).compatible;
+	if (!isHubProtocolCompatible(record).compatible) {
+		return false;
+	}
+	// A protocol-compatible hub from an older build keeps serving stale code
+	// after an upgrade, so require the running hub's build to match ours.
+	// Missing/blank buildId means a pre-buildId daemon and is also retired.
+	const recordBuildId = record.buildId?.trim();
+	return !!recordBuildId && recordBuildId === resolveHubBuildId();
 }
 
 function withMatchingDiscoveryRetirementMetadata(

--- a/sdk/packages/core/src/hub/server/hub-websocket-server.ts
+++ b/sdk/packages/core/src/hub/server/hub-websocket-server.ts
@@ -610,6 +610,10 @@ export async function ensureHubWebSocketServer(
 			if (
 				healthy?.url &&
 				isHubProtocolCompatible(healthy).compatible &&
+				// Never reuse a hub from a different build: it keeps serving
+				// stale code after an upgrade. The authenticated probe reads
+				// /status, which always reports buildId.
+				healthy.buildId?.trim() === resolveHubBuildId() &&
 				(await verifyHubConnection(healthy.url, {
 					authToken: discovered.authToken,
 				}))

--- a/sdk/packages/core/src/hub/server/hub-websocket-server.ts
+++ b/sdk/packages/core/src/hub/server/hub-websocket-server.ts
@@ -364,6 +364,11 @@ export async function startHubWebSocketServer(
 				minClientProtocolVersion: versionPayload.minClientProtocolVersion,
 				maxClientProtocolVersion: versionPayload.maxClientProtocolVersion,
 				coreVersion: versionPayload.coreVersion,
+				// Unauthenticated probes rely on /health to judge build
+				// compatibility; without buildId every probe would classify this
+				// hub as a stale build. No new exposure: buildId defaults to
+				// coreVersion (above) and /version already serves it untokened.
+				buildId: versionPayload.buildId,
 				host,
 				port,
 				url,

--- a/sdk/packages/core/src/hub/server/index.test.ts
+++ b/sdk/packages/core/src/hub/server/index.test.ts
@@ -223,6 +223,38 @@ describe("hub server startup", () => {
 		expect(payload.buildId).toBe(resolveHubBuildId());
 	});
 
+	it("does not reuse a discovered hub from a different build", async () => {
+		const owner = createInMemoryHubOwnerContext("hub-server-test-stale-build");
+		vi.stubEnv("CLINE_HUB_BUILD_ID", "old-build");
+		try {
+			const stale = await startHubWebSocketServer({
+				owner,
+				host: "127.0.0.1",
+				port: 0,
+				pathname: "/hub",
+				runtimeHandlers: createLocalHubScheduleRuntimeHandlers(),
+			});
+			servers.add(stale);
+
+			vi.stubEnv("CLINE_HUB_BUILD_ID", "new-build");
+			const result = await ensureHubWebSocketServer({
+				owner,
+				host: "127.0.0.1",
+				port: 0,
+				pathname: "/hub",
+				allowPortFallback: true,
+				runtimeHandlers: createLocalHubScheduleRuntimeHandlers(),
+			});
+
+			expect(result.action).toBe("started");
+			expect(result.url).not.toBe(stale.url);
+			servers.add(requireServer(result.server));
+		} finally {
+			vi.unstubAllEnvs();
+			await clearHubDiscovery(owner.discoveryPath);
+		}
+	});
+
 	it("shuts down active server through the shutdown endpoint", async () => {
 		const owner = createInMemoryHubOwnerContext("hub-server-test-shutdown");
 		const result = await ensureHubWebSocketServer({

--- a/sdk/packages/core/src/hub/server/index.test.ts
+++ b/sdk/packages/core/src/hub/server/index.test.ts
@@ -11,6 +11,7 @@ import {
 	clearHubDiscovery,
 	createInMemoryHubOwnerContext,
 	readHubDiscovery,
+	resolveHubBuildId,
 	toHubHealthUrl,
 	writeHubDiscovery,
 } from "../discovery";
@@ -203,6 +204,23 @@ describe("hub server startup", () => {
 			});
 			await clearHubDiscovery(owner.discoveryPath);
 		}
+	});
+
+	it("reports its buildId on the unauthenticated health endpoint", async () => {
+		const owner = createInMemoryHubOwnerContext("hub-server-test-health-build");
+		const result = await ensureHubWebSocketServer({
+			owner,
+			host: "127.0.0.1",
+			port: 0,
+			pathname: "/hub",
+			runtimeHandlers: createLocalHubScheduleRuntimeHandlers(),
+		});
+		servers.add(requireServer(result.server));
+
+		const health = await fetch(new URL("/health", toHubHealthUrl(result.url)));
+		expect(health.status).toBe(200);
+		const payload = (await health.json()) as { buildId?: string };
+		expect(payload.buildId).toBe(resolveHubBuildId());
 	});
 
 	it("shuts down active server through the shutdown endpoint", async () => {


### PR DESCRIPTION
### Related Issue

User report: upgrading the globally-installed CLI (`npm i -g cline`, 3.0.41 → 3.0.42 / core 0.0.61 → 0.0.62) left the old hub daemon running, so the fixes shipped in the new version never took effect.

### Description

**The bug:** upgrading the CLI/SDK does not restart the local hub daemon. The new client probes the running hub, sees a compatible protocol, and reuses it — even though the daemon is executing last release's code. Sessions, schedules, connectors, everything hub-side keeps running the stale build until the user happens to run `cline hub stop` or `cline update`.

**Why the existing check doesn't catch it:** since #11372, the only compatibility gate is `isHubProtocolCompatible`, which compares the hand-maintained wire-protocol constant `CURRENT_HUB_PROTOCOL_VERSION = "v1"` (`sdk/packages/shared/src/hub.ts`). That constant has never changed, so every release is "compatible" with every other release forever. Meanwhile the hub has been faithfully publishing its `buildId` (= the `@cline/core` version it was built from, via `resolveHubBuildId()`) in both the `/health` response and the discovery record the whole time — nothing reads it. It's dead metadata.

**The history (this is the interesting part):**

- `946a548d2b` — *"feat: Make hub startup self-heal stale and incompatible daemon versions"* (old sdk repo #269, Apr 2026) added a strict `buildId` equality check to both the daemon's `isCompatibleHubRecord` and the client's `probeCompatibleHubUrl`, specifically to fix this exact symptom. Its PR description opens with: *"users or developers could end up connected to an old running hub after updating the CLI."*
- `6138bdfe40` — *"feat: Enforce a production singleton Cline Hub"* (#11372, Jun 2026) replaced both buildId checks with the protocol-version check. The swap was conscious at the test level — a test was literally renamed from `"does not reuse a healthy hub from a different build"` to `"reuses a protocol-compatible healthy hub from a different build"` — but the PR description never mentions dropping version-based retirement; it's framed entirely as singleton/owner-context work. So #11372 silently reverted the headline behavior #269 shipped.

**Why nobody noticed:** `cline update` force-restarts the hub unconditionally after a successful update (`restartHubServerIfRunning` in `apps/cli/src/commands/update.ts`), so anyone upgrading through the CLI's own updater gets a fresh hub regardless of the compatibility gate. Only `npm i -g cline` upgrades (and anything else that swaps the binary out-of-band) hit the reuse path — which is exactly how the reporter upgraded.

**The fix** restores the pre-#11372 condition, layered on top of the protocol check rather than replacing it:

- `sdk/packages/core/src/hub/daemon/index.ts` — `isCompatibleHubRecord` now requires protocol compatibility **and** `buildId === resolveHubBuildId()`. This is the predicate behind every reuse/retire decision in `ensureDetachedHubServer` and `prewarmDetachedHubServer`, so an old-build hub now flows through the existing `retireIncompatibleHub` machinery (graceful `/shutdown` → SIGTERM → clear discovery → spawn replacement). No new retirement code.
- `sdk/packages/core/src/hub/client/index.ts` — `probeCompatibleHubUrl` reports a restored `build_mismatch` status (same name #269 used). Passive resolvers (runtime host `auto` backend, menubar sidecar, etc.) stop handing out stale-hub URLs. Unlike `protocol_mismatch`, `resolveCompatibleLocalHubUrl` deliberately does **not** clear the discovery record on `build_mismatch`: the record carries the `authToken`/`pid` the retirement machinery needs, and the daemon path clears it itself after the hub is actually stopped. (First cut of this PR did clear it — which quietly destroyed the retirement credentials right before the ensure/prewarm paths needed them, leaving only an unauthenticated `/health` probe that can neither `/shutdown` (401) nor SIGTERM (no pid). Caught in self-review; the keep-record tests here pin it, and #12330 adds an end-to-end regression test on top.)
- `sdk/packages/core/src/hub/server/hub-websocket-server.ts` — `/health` now includes `buildId`. It previously only appeared on the authenticated `/status`, so every unauthenticated probe (the daemon's expected-url checks, explicit-endpoint resolution) would have classified *any* hub — including a just-spawned same-build one — as a stale build. No new exposure: `/health` already served `coreVersion` (the default `buildId` value) and `/version` already served `buildId` without auth.
- `sdk/packages/core/src/hub/server/hub-websocket-server.ts` — `ensureHubWebSocketServer` (the in-process ensure exported from `@cline/core`, used by SDK embedders and the vscode example app) was a third reuse gate still deciding on protocol alone; it now also requires the discovered hub's `buildId` to match. Its probe is authenticated, so `/status` always carries the field.

Missing/blank `buildId` is treated as stale (a pre-buildId daemon), matching #269's semantics. That asymmetry is intentional: old daemons predate the `/health` field, and they're precisely the ones that must be retired on upgrade.

**Behavior consequences worth knowing:**

- The "compatible hub already running but discovery record missing" error in `ensureDetachedHubServer` now only triggers for *same-build* hubs. An old-build hub squatting the expected port without a discovery record gets retired and replaced automatically instead of throwing — strictly better for the upgrade case.
- If two products bundling *different* `@cline/core` versions share the production hub, each will retire the other's hub at its own startup (startup-time only — there's no watcher, so no retire loop). That's the same tradeoff #269 originally accepted, and "latest-started client wins" beats "stale code runs forever." When core versions match (the normal case for a coordinated release), nothing changes.
- `CLINE_HUB_BUILD_ID` still overrides `resolveHubBuildId()` for anyone who genuinely wants to pin a hub across builds.

**Scope: conditionals only.** This PR deliberately leaves `ensureCompatibleLocalHubUrl` in its original spawn-and-poll shape. That function has a known gap under the new gate (Greptile's P2): if the stale daemon still holds the port, its blind spawn dies on EADDRINUSE and the 8s discovery poll times out — in CLI flows the background prewarm (which retires correctly, using the discovery record this PR now preserves) usually wins the race and the poll picks up the replacement, but bare SDK callers without a prewarm don't restart the hub through that path. The retire-before-spawn fix is stacked as #12330 so it can be reviewed as its own behavior change.

Also deliberately **not** done: no active-session check before retiring (the hub gets a graceful shutdown request first, same as every other retirement path), no protocol-version bump, no refactoring of the discovery/owner-context machinery. Minimal restoration of the deleted condition.

### Test Procedure

- Flipped the #11372 test back: `"retires a healthy hub from a different build and starts a replacement"` now asserts the old-build hub gets `requestHubShutdown` + SIGTERM + discovery cleared + a replacement spawned and verified (daemon/index.test.ts).
- Flipped the two client tests that asserted stale reuse: build-mismatch and missing-build-metadata now resolve `undefined` while keeping the discovery record for retirement (client/index.test.ts). Protocol mismatch keeps its existing clear-discovery behavior.
- New server tests: `/health` reports `buildId`, and `ensureHubWebSocketServer` does not reuse a discovered hub started under a different `CLINE_HUB_BUILD_ID` (server/index.test.ts).
- One pre-existing test (`"waits on shared discovery after spawning in development builds"`, renamed since it resolves via discovery) mocked `../discovery` without overriding `resolveHubBuildId`, so its `"test-build"` record started mismatching the real core version; gave it the same `resolveHubBuildId: () => "test-build"` override its sibling tests already use.
- `vitest run src/hub/` in `@cline/core`: 22 files / 172 tests pass. `src/runtime/host/`: 90 tests pass. CLI `hub`/`doctor`/`update` command tests: 16 pass. `bun run typecheck` (dev + smoke tsconfigs) clean, biome clean.
- Manual repro path for reviewers: install old CLI → run `cline` (hub spawns, note `pid`/`buildId` in `~/.cline/data/locks/hub/production.json`) → `npm i -g cline@latest` → run `cline` → discovery record should show a new pid and the new core version as `buildId`.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

If we ever *want* cross-version hub reuse again (e.g. to keep long-lived sessions alive across patch releases), the right shape is probably an explicit hub-side "drain and hand off" rather than quietly reusing stale code — but that's a design conversation, not this PR.
