### PR TITLE
fix(hub): retire stale hubs before respawning in ensureCompatibleLocalHubUrl

### DIFF
--- a/sdk/packages/core/src/hub/client/index.test.ts
+++ b/sdk/packages/core/src/hub/client/index.test.ts
@@ -543,7 +543,9 @@ describe("NodeHubClient", () => {
 			globalThis as unknown as { WebSocket?: typeof RecoveryWebSocket }
 		).WebSocket = RecoveryWebSocket;
 		vi.doMock("../daemon", () => ({
-			spawnDetachedHubServerWithRetry: vi.fn(async () => undefined),
+			ensureDetachedHubServer: vi.fn(async () => {
+				throw new Error("unexpected ensureDetachedHubServer call");
+			}),
 		}));
 		vi.doMock("../discovery/workspace", () => ({
 			resolveProductionHubOwnerContext: () => ({
@@ -698,7 +700,9 @@ describe("NodeHubClient", () => {
 			globalThis as unknown as { WebSocket?: typeof ExplicitEndpointWebSocket }
 		).WebSocket = ExplicitEndpointWebSocket;
 		vi.doMock("../daemon", () => ({
-			spawnDetachedHubServerWithRetry: vi.fn(async () => undefined),
+			ensureDetachedHubServer: vi.fn(async () => {
+				throw new Error("unexpected ensureDetachedHubServer call");
+			}),
 		}));
 		vi.doMock("../discovery/workspace", () => ({
 			resolveProductionHubOwnerContext: () => ({
@@ -959,26 +963,15 @@ describe("resolveCompatibleLocalHubUrl", () => {
 		);
 	});
 
-	it("starts missing local hubs through the retrying daemon spawn API", async () => {
+	it("starts missing local hubs through the daemon ensure API", async () => {
 		vi.stubGlobal("WebSocket", MockWebSocket);
-		const spawnDetachedHubServerWithRetryMock = vi.fn(async () => undefined);
-		const record = {
-			hubId: "hub-test",
-			protocolVersion: "v1",
-			buildId: "test-build",
-			authToken: "token",
-			host: "127.0.0.1",
-			port: 25464,
+		const ensureDetachedHubServerMock = vi.fn(async () => ({
 			url: "ws://127.0.0.1:25464/hub",
-			startedAt: new Date().toISOString(),
-			updatedAt: new Date().toISOString(),
-		};
-		const readHubDiscoveryMock = vi
-			.fn()
-			.mockResolvedValueOnce(undefined)
-			.mockResolvedValueOnce(record);
+			authToken: "token",
+		}));
+		const readHubDiscoveryMock = vi.fn().mockResolvedValue(undefined);
 		vi.doMock("../daemon", () => ({
-			spawnDetachedHubServerWithRetry: spawnDetachedHubServerWithRetryMock,
+			ensureDetachedHubServer: ensureDetachedHubServerMock,
 		}));
 		vi.doMock("../discovery/workspace", () => ({
 			resolveProductionHubOwnerContext: () => ({
@@ -997,7 +990,7 @@ describe("resolveCompatibleLocalHubUrl", () => {
 				...actual,
 				resolveHubBuildId: () => "test-build",
 				readHubDiscovery: readHubDiscoveryMock,
-				probeHubServer: vi.fn(async () => record),
+				probeHubServer: vi.fn(async () => undefined),
 				clearHubDiscovery: vi.fn(async () => undefined),
 			};
 		});
@@ -1010,15 +1003,106 @@ describe("resolveCompatibleLocalHubUrl", () => {
 				cwd: "/tmp/project",
 			}),
 		).resolves.toBe("ws://127.0.0.1:25464/hub");
-		expect(spawnDetachedHubServerWithRetryMock).toHaveBeenCalledWith(
-			"/tmp/project",
-		);
-		expect(
-			spawnDetachedHubServerWithRetryMock.mock.invocationCallOrder[0],
-		).toBeGreaterThan(readHubDiscoveryMock.mock.invocationCallOrder[0]);
-		expect(
-			spawnDetachedHubServerWithRetryMock.mock.invocationCallOrder[0],
-		).toBeLessThan(readHubDiscoveryMock.mock.invocationCallOrder[1]);
+		expect(ensureDetachedHubServerMock).toHaveBeenCalledWith("/tmp/project");
+	});
+
+	it("replaces a stale-build hub through the daemon ensure API without dropping its discovery record", async () => {
+		vi.stubGlobal("WebSocket", MockWebSocket);
+		const clearHubDiscoveryMock = vi.fn();
+		const ensureDetachedHubServerMock = vi.fn(async () => ({
+			url: "ws://127.0.0.1:25465/hub",
+			authToken: "new-token",
+		}));
+		const staleRecord = {
+			hubId: "hub-test",
+			protocolVersion: "v1",
+			buildId: "old-build",
+			authToken: "old-token",
+			host: "127.0.0.1",
+			port: 25464,
+			url: "ws://127.0.0.1:25464/hub",
+			startedAt: new Date().toISOString(),
+			updatedAt: new Date().toISOString(),
+		};
+		vi.doMock("../daemon", () => ({
+			ensureDetachedHubServer: ensureDetachedHubServerMock,
+		}));
+		vi.doMock("../discovery/workspace", () => ({
+			resolveProductionHubOwnerContext: () => ({
+				ownerId: "hub-test",
+				discoveryPath: "/tmp/hub-discovery.json",
+			}),
+			resolveSharedHubOwnerContext: () => ({
+				ownerId: "hub-test",
+				discoveryPath: "/tmp/hub-discovery.json",
+			}),
+		}));
+		vi.doMock("../discovery", async () => {
+			const actual =
+				await vi.importActual<typeof import("../discovery")>("../discovery");
+			return {
+				...actual,
+				resolveHubBuildId: () => "current-build",
+				readHubDiscovery: vi.fn(async () => staleRecord),
+				probeHubServer: vi.fn(async () => staleRecord),
+				clearHubDiscovery: vi.fn(async (...args: unknown[]) => {
+					clearHubDiscoveryMock(...args);
+				}),
+			};
+		});
+
+		const { ensureCompatibleLocalHubUrl } = await import(".");
+
+		await expect(
+			ensureCompatibleLocalHubUrl({
+				workspaceRoot: "/tmp/project",
+				cwd: "/tmp/project",
+			}),
+		).resolves.toBe("ws://127.0.0.1:25465/hub");
+		expect(ensureDetachedHubServerMock).toHaveBeenCalledWith("/tmp/project");
+		// The stale record must survive until the daemon retires the hub; it
+		// carries the authToken/pid the retirement path needs.
+		expect(clearHubDiscoveryMock).not.toHaveBeenCalled();
+	});
+
+	it("returns undefined when the daemon ensure fails", async () => {
+		vi.stubGlobal("WebSocket", MockWebSocket);
+		const ensureDetachedHubServerMock = vi.fn(async () => {
+			throw new Error("could not be retired automatically");
+		});
+		vi.doMock("../daemon", () => ({
+			ensureDetachedHubServer: ensureDetachedHubServerMock,
+		}));
+		vi.doMock("../discovery/workspace", () => ({
+			resolveProductionHubOwnerContext: () => ({
+				ownerId: "hub-test",
+				discoveryPath: "/tmp/hub-discovery.json",
+			}),
+			resolveSharedHubOwnerContext: () => ({
+				ownerId: "hub-test",
+				discoveryPath: "/tmp/hub-discovery.json",
+			}),
+		}));
+		vi.doMock("../discovery", async () => {
+			const actual =
+				await vi.importActual<typeof import("../discovery")>("../discovery");
+			return {
+				...actual,
+				readHubDiscovery: vi.fn(async () => undefined),
+				probeHubServer: vi.fn(async () => undefined),
+				clearHubDiscovery: vi.fn(async () => undefined),
+			};
+		});
+
+		const { ensureCompatibleLocalHubUrl } = await import(".");
+
+		await expect(
+			ensureCompatibleLocalHubUrl({
+				workspaceRoot: "/tmp/project",
+				cwd: "/tmp/project",
+			}),
+		).resolves.toBeUndefined();
+		expect(ensureDetachedHubServerMock).toHaveBeenCalledWith("/tmp/project");
 	});
 
 	it("resolves the shared-owner discovery hub in development builds", async () => {
@@ -1112,7 +1196,9 @@ describe("resolveCompatibleLocalHubUrl", () => {
 			}),
 		}));
 		vi.doMock("../daemon", () => ({
-			spawnDetachedHubServerWithRetry: vi.fn(async () => undefined),
+			ensureDetachedHubServer: vi.fn(async () => {
+				throw new Error("unexpected ensureDetachedHubServer call");
+			}),
 		}));
 		vi.doMock("../discovery", async () => {
 			const actual =

--- a/sdk/packages/core/src/hub/client/index.ts
+++ b/sdk/packages/core/src/hub/client/index.ts
@@ -13,7 +13,7 @@ import {
 	SESSION_NOT_FOUND_ERROR_CODE,
 	SessionNotFoundError,
 } from "../../runtime/host/runtime-host";
-import { spawnDetachedHubServerWithRetry } from "../daemon";
+import { ensureDetachedHubServer } from "../daemon";
 import {
 	clearHubDiscovery,
 	type HubOwnerContext,
@@ -179,8 +179,6 @@ export interface LocalHubResolutionOptions {
 	cwd?: string;
 }
 
-const HUB_STARTUP_TIMEOUT_MS = 8_000;
-const HUB_STARTUP_POLL_MS = 200;
 const GLOBAL_SUBSCRIPTION_KEY = "*";
 const HUB_CONNECT_TIMEOUT_MS = 8_000;
 const HUB_AUTH_PROTOCOL_PREFIX = "cline-hub-auth.";
@@ -890,26 +888,6 @@ async function probeCompatibleHubUrl(
 	};
 }
 
-async function waitForCompatibleHubUrl(
-	owner: HubOwnerContext,
-): Promise<string | undefined> {
-	const deadline = Date.now() + HUB_STARTUP_TIMEOUT_MS;
-	while (Date.now() < deadline) {
-		const record = await readHubDiscovery(owner.discoveryPath);
-		if (record?.url) {
-			const compatible = await probeCompatibleHubUrl(record.url, {
-				verifyConnection: true,
-				authToken: record.authToken,
-			});
-			if (compatible.status === "compatible") {
-				return rememberRecoverableLocalHubUrl(compatible.url, record.authToken);
-			}
-		}
-		await new Promise((resolve) => setTimeout(resolve, HUB_STARTUP_POLL_MS));
-	}
-	return undefined;
-}
-
 async function waitForHubToRetire(url: string): Promise<boolean> {
 	const deadline = Date.now() + HUB_RECOVERY_RETIRE_TIMEOUT_MS;
 	while (Date.now() < deadline) {
@@ -1031,9 +1009,17 @@ export async function ensureCompatibleLocalHubUrl(
 	if (options.endpoint?.trim()) {
 		return undefined;
 	}
-	const owner = resolveDefaultHubOwnerContext();
-	await spawnDetachedHubServerWithRetry(options.workspaceRoot ?? process.cwd());
-	return await waitForCompatibleHubUrl(owner);
+	// Delegate to the daemon module's ensure so a stale hub still holding the
+	// configured port is retired before the replacement spawns; a raw spawn
+	// would die on the occupied port and this would time out to undefined.
+	try {
+		const ensured = await ensureDetachedHubServer(
+			options.workspaceRoot ?? process.cwd(),
+		);
+		return ensured.url;
+	} catch {
+		return undefined;
+	}
 }
 
 export async function requestHubShutdown(


### PR DESCRIPTION
### Related Issue

Stacked on #12329 (review that first — this PR's diff is just the top commit). Split out of #12329 at review time so the behavior change to `ensureCompatibleLocalHubUrl` can be evaluated on its own instead of riding along with the compatibility conditionals.

### Description

**The gap:** #12329 restores build-aware hub compatibility, but `ensureCompatibleLocalHubUrl` keeps its original shape:

```ts
await spawnDetachedHubServerWithRetry(...);   // blind spawn — nobody checks the port
return await waitForCompatibleHubUrl(owner);  // poll discovery for 8s, hoping
```

Trace the upgrade scenario this exists for (old daemon still running and holding the configured port):

1. `resolveCompatibleLocalHubUrl` correctly refuses the old hub (`build_mismatch`).
2. The blind spawn's replacement daemon dies on EADDRINUSE.
3. `waitForCompatibleHubUrl` polls discovery for 8 seconds, keeps finding/probing the old hub, keeps (correctly) rejecting it, and times out to `undefined`.

Net effect: an 8-second stall and no restart. In CLI flows the background `prewarmDetachedHubServer` usually rescues this — it retires the old daemon properly and the poll can pick up its replacement inside the window — but that's a race, and bare SDK callers of `ensureCompatibleLocalHubUrl` with no concurrent prewarm are simply stuck with the stale hub. This was Greptile's P2 on #12329.

**The fix:** delegate to `ensureDetachedHubServer`, which already does this correctly — retire the incompatible hub (graceful `/shutdown` → SIGTERM → port-clear wait), spawn, wait for discovery, verify the websocket. Errors are caught to preserve the function's `undefined`-on-failure contract. `restartLocalHubIfIdleAfterStartupTimeout` recurses through this function, so the idle-restart recovery path gets the same guarantee for free.

With the delegation in place, `waitForCompatibleHubUrl` and its two startup constants (`HUB_STARTUP_TIMEOUT_MS`, `HUB_STARTUP_POLL_MS`) have zero callers left — they existed only to serve the blind-spawn shape — so they're removed rather than left as dead code. That deletion is the bulk of this diff; the actual behavior change is ~10 lines.

**Load-bearing dependency on #12329:** the delegation only works because the base PR keeps the discovery record on `build_mismatch`. That record carries the `authToken`/`pid` retirement runs on; an earlier draft cleared it in the resolver and left `ensureDetachedHubServer` with only an unauthenticated `/health` probe — which can neither `/shutdown` (401) nor SIGTERM (no pid). The regression test here (`replaces a stale-build hub through the daemon ensure API without dropping its discovery record`) pins that ordering.

### Test Procedure

- New: `replaces a stale-build hub through the daemon ensure API without dropping its discovery record` — stale-build record + probe, delegation returns the replacement URL, and the client never clears the record itself (the daemon does, after actually stopping the hub).
- New: `returns undefined when the daemon ensure fails` — the catch path.
- Rewritten: `starts missing local hubs through the daemon ensure API` (was `…through the retrying daemon spawn API`) — no discovery record → delegation → replacement URL.
- The five `../daemon` module mocks switch from `spawnDetachedHubServerWithRetry` to `ensureDetachedHubServer`; mocks in tests that must not spawn throw on call so an unexpected delegation fails loudly.
- Full `src/hub/` suite (174 tests), `src/runtime/host/` (90 tests), both typecheck configs, and biome all pass on the stack tip.

Heads-up for reviewers: this PR targets `saoudrizwan/hub-buildid-restart`, and PRs targeting non-main branches skip the real test workflows — the green "Run Tests" check is a no-op. CI runs for real once #12329 merges and this retargets main.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

If there's a deliberate reason `ensureCompatibleLocalHubUrl` avoided the daemon module's retirement machinery (startup-lock interactions? keeping the client module passive?), this is the PR to raise it on — the base PR is intentionally independent of this change.
