### PR TITLE
docs: fix tool result JSON example

### DIFF
--- a/docs/api/chat-completions.mdx
+++ b/docs/api/chat-completions.mdx
@@ -205,7 +205,7 @@ To continue the conversation after a tool call, include the tool result:
   "messages": [
     {"role": "user", "content": "What's the weather in San Francisco?"},
     {"role": "assistant", "tool_calls": [{"id": "call_abc123", "type": "function", "function": {"name": "get_weather", "arguments": "{\"location\": \"San Francisco, CA\"}"}}]},
-    {"role": "tool", "tool_call_id": "call_abc123", "content": "{\"temperature\": 62, \"condition\": \"foggy\"}"},
+    {"role": "tool", "tool_call_id": "call_abc123", "content": "{\"temperature\": 62, \"condition\": \"foggy\"}"}
   ]
 }
 ```


### PR DESCRIPTION
## Summary

Removes the trailing comma from the final item in the tool-result continuation example in the Chat Completions API guide.

## Why

The example is labeled as JSON, but its trailing comma makes it invalid JSON when copied. Removing it lets developers parse the example directly while preserving the documented request structure.

## Validation

- Parsed the exact JSON code block with `JSON.parse`.
- Ran `git diff --check`.
