### PR TITLE
Fix unbounded detached hub daemon logs

### DIFF
--- a/sdk/ARCHITECTURE.md
+++ b/sdk/ARCHITECTURE.md
@@ -109,7 +109,7 @@ Design rules:
 - `core` is the app-facing orchestration layer over `agents`.
 - hub-related modules live under `packages/core/src/hub/`, grouped by service:
   - `client/` contains host-facing hub clients and browser connection helpers
-  - `daemon/` contains detached daemon startup, entrypoint, and local runtime handler wiring
+  - `daemon/` contains detached daemon startup, entrypoint, local runtime handler wiring, and size-based rotation of `hub-daemon.log`
   - `discovery/` contains endpoint defaults, discovery records, and workspace owner resolution
   - `server/` contains WebSocket server startup, native/browser socket adapters, server transport, server helpers, and `handlers/` for hub command dispatch
 - settings mutations belong in core services and hub commands, not in host-specific file writes. Hosts should call the core settings facade or the `settings.*` hub command family and react to `settings.changed`.

--- a/sdk/packages/core/src/hub/daemon/entry.ts
+++ b/sdk/packages/core/src/hub/daemon/entry.ts
@@ -1,12 +1,15 @@
+import { join } from "node:path";
 import { AgentRuntimeAbortError } from "@cline/agents";
 import { initVcr, resolveClineBuildEnv } from "@cline/shared";
 import { createLocalHubScheduleRuntimeHandlers } from "../daemon/runtime-handlers";
+import { resolveClineDataDir } from "../discovery";
 import { resolveHubEndpointOptions } from "../discovery/defaults";
 import {
 	resolveProductionHubOwnerContext,
 	resolveSharedHubOwnerContext,
 } from "../discovery/workspace";
 import { startHubWebSocketServer } from "../server";
+import { startHubLogRotation } from "./log-rotation";
 import { createHubDaemonTelemetry } from "./telemetry";
 
 initVcr(process.env.CLINE_VCR);
@@ -55,6 +58,7 @@ function parseArgs(argv: string[]): {
 async function main(): Promise<void> {
 	const options = parseArgs(process.argv.slice(2));
 	process.chdir(options.cwd);
+	startHubLogRotation(join(resolveClineDataDir(), "logs", "hub-daemon.log"));
 
 	const endpoint = resolveHubEndpointOptions({
 		host: options.host,

--- a/sdk/packages/core/src/hub/daemon/log-rotation.test.ts
+++ b/sdk/packages/core/src/hub/daemon/log-rotation.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { copyFile, stat, truncate } = vi.hoisted(() => ({
+	copyFile: vi.fn(),
+	stat: vi.fn(),
+	truncate: vi.fn(),
+}));
+
+vi.mock("node:fs/promises", () => ({ copyFile, stat, truncate }));
+
+import { startHubLogRotation } from "./log-rotation";
+
+describe("startHubLogRotation", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.clearAllMocks();
+		copyFile.mockResolvedValue(undefined);
+		truncate.mockResolvedValue(undefined);
+	});
+
+	it("retains one backup and truncates a log at the size limit", async () => {
+		stat.mockResolvedValue({ size: 100 });
+
+		const stop = startHubLogRotation("/logs/hub-daemon.log", {
+			maxBytes: 100,
+			intervalMs: 1_000,
+		});
+		await vi.waitFor(() => expect(truncate).toHaveBeenCalledOnce());
+
+		expect(copyFile).toHaveBeenCalledWith(
+			"/logs/hub-daemon.log",
+			"/logs/hub-daemon.log.1",
+		);
+		expect(copyFile.mock.invocationCallOrder[0]).toBeLessThan(
+			truncate.mock.invocationCallOrder[0],
+		);
+		stop();
+	});
+
+	it("leaves logs below the size limit unchanged", async () => {
+		stat.mockResolvedValue({ size: 99 });
+
+		const stop = startHubLogRotation("/logs/hub-daemon.log", {
+			maxBytes: 100,
+		});
+		await vi.waitFor(() => expect(stat).toHaveBeenCalledOnce());
+
+		expect(copyFile).not.toHaveBeenCalled();
+		expect(truncate).not.toHaveBeenCalled();
+		stop();
+	});
+
+	it("keeps checking after a filesystem error", async () => {
+		stat
+			.mockRejectedValueOnce(new Error("busy"))
+			.mockResolvedValueOnce({ size: 100 });
+
+		const stop = startHubLogRotation("/logs/hub-daemon.log", {
+			maxBytes: 100,
+			intervalMs: 1_000,
+		});
+		await vi.waitFor(() => expect(stat).toHaveBeenCalledOnce());
+		await vi.advanceTimersByTimeAsync(1_000);
+		await vi.waitFor(() => expect(truncate).toHaveBeenCalledOnce());
+
+		stop();
+	});
+});

--- a/sdk/packages/core/src/hub/daemon/log-rotation.ts
+++ b/sdk/packages/core/src/hub/daemon/log-rotation.ts
@@ -1,0 +1,33 @@
+import { copyFile, stat, truncate } from "node:fs/promises";
+
+const HUB_LOG_MAX_BYTES = 25 * 1024 * 1024;
+const HUB_LOG_CHECK_INTERVAL_MS = 60_000;
+
+export function startHubLogRotation(
+	logPath: string,
+	options: { maxBytes?: number; intervalMs?: number } = {},
+): () => void {
+	const maxBytes = options.maxBytes ?? HUB_LOG_MAX_BYTES;
+	const intervalMs = options.intervalMs ?? HUB_LOG_CHECK_INTERVAL_MS;
+	let rotating = false;
+
+	const rotateIfNeeded = async (): Promise<void> => {
+		if (rotating) return;
+		rotating = true;
+		try {
+			const logStat = await stat(logPath);
+			if (logStat.size < maxBytes) return;
+			await copyFile(logPath, `${logPath}.1`);
+			await truncate(logPath, 0);
+		} catch {
+			// Logging must never prevent the hub from running.
+		} finally {
+			rotating = false;
+		}
+	};
+
+	void rotateIfNeeded();
+	const timer = setInterval(() => void rotateIfNeeded(), intervalMs);
+	timer.unref();
+	return () => clearInterval(timer);
+}


### PR DESCRIPTION
## Summary
- rotate `hub-daemon.log` while the detached daemon is still running
- cap the active log at 25 MiB and retain one backup
- keep rotation failures non-fatal and document the daemon responsibility

## Testing
- `bun -F @cline/core test:unit -- src/hub/daemon/log-rotation.test.ts src/hub/daemon/entry.test.ts src/hub/daemon/index.test.ts`
- `bunx biome check packages/core/src/hub/daemon/log-rotation.ts packages/core/src/hub/daemon/log-rotation.test.ts packages/core/src/hub/daemon/entry.ts ARCHITECTURE.md`
- `bun -F @cline/core typecheck` *(blocked by the existing missing `ai-sdk-ollama` module in `packages/llms/src/providers/vendors/ollama.ts`)*

Closes #12108