### PR TITLE
Omit unsupported temperature from AI SDK requests

### DIFF
--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -35,6 +35,7 @@ import {
 	type AiSdkProviderOptionsTarget,
 	composeAiSdkProviderOptions,
 } from "./routing/provider-options";
+import { resolveAiSdkTemperature } from "./temperature";
 import type {
 	AiSdkStreamPart,
 	AiSdkStreamResult,
@@ -55,13 +56,14 @@ type ProviderModuleKind = AiSdkProviderOptionsTarget;
 
 export function buildAiSdkStreamConfig(
 	request: GatewayStreamRequest,
-	_context: GatewayProviderContext,
+	context: GatewayProviderContext,
 ): Partial<CallSettings> {
+	const temperature = resolveAiSdkTemperature(request, context);
 	return {
 		...(request.maxTokens !== undefined
 			? { maxOutputTokens: request.maxTokens }
 			: {}),
-		temperature: request.temperature,
+		...(temperature !== undefined ? { temperature } : {}),
 	};
 }
 

--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -461,6 +461,9 @@ function modelInfoToGateway(
 	if (info.releaseDate) {
 		metadata.releaseDate = info.releaseDate;
 	}
+	if (info.capabilities) {
+		metadata.supportsTemperature = info.capabilities.includes("temperature");
+	}
 	if (typeof info.metadata?.reasoningDefaultOn === "boolean") {
 		metadata.reasoningDefaultOn = info.metadata.reasoningDefaultOn;
 	}

--- a/sdk/packages/llms/src/providers/compat.ts
+++ b/sdk/packages/llms/src/providers/compat.ts
@@ -108,6 +108,7 @@ function toGatewayModelDefinition(
 			pricing: model.pricing,
 			status: model.status,
 			releaseDate: model.releaseDate,
+			supportsTemperature: model.capabilities?.includes("temperature"),
 		},
 	};
 }

--- a/sdk/packages/llms/src/providers/temperature.test.ts
+++ b/sdk/packages/llms/src/providers/temperature.test.ts
@@ -1,0 +1,42 @@
+import type {
+	GatewayProviderContext,
+	GatewayStreamRequest,
+} from "@cline/shared";
+import { describe, expect, it } from "vitest";
+import { resolveAiSdkTemperature } from "./temperature";
+
+describe("AI SDK temperature routing", () => {
+	const request = { temperature: 0.7 } as GatewayStreamRequest;
+
+	it("omits temperature for models that explicitly do not support it", () => {
+		expect(
+			resolveAiSdkTemperature(request, contextWithTemperatureSupport(false)),
+		).toBeUndefined();
+	});
+
+	it("preserves temperature for models that support it", () => {
+		expect(
+			resolveAiSdkTemperature(request, contextWithTemperatureSupport(true)),
+		).toBe(0.7);
+	});
+
+	it("preserves temperature when dynamic model capabilities are unknown", () => {
+		expect(
+			resolveAiSdkTemperature(request, contextWithTemperatureSupport()),
+		).toBe(0.7);
+	});
+});
+
+function contextWithTemperatureSupport(
+	supportsTemperature?: boolean,
+): GatewayProviderContext {
+	return {
+		model: {
+			id: "claude-sonnet-5",
+			name: "Claude Sonnet 5",
+			providerId: "bedrock",
+			metadata:
+				supportsTemperature === undefined ? undefined : { supportsTemperature },
+		},
+	} as GatewayProviderContext;
+}

--- a/sdk/packages/llms/src/providers/temperature.ts
+++ b/sdk/packages/llms/src/providers/temperature.ts
@@ -1,0 +1,13 @@
+import type {
+	GatewayProviderContext,
+	GatewayStreamRequest,
+} from "@cline/shared";
+
+export function resolveAiSdkTemperature(
+	request: GatewayStreamRequest,
+	context: GatewayProviderContext,
+): number | undefined {
+	return context.model.metadata?.supportsTemperature === false
+		? undefined
+		: request.temperature;
+}

--- a/sdk/packages/llms/src/providers/vendors/openai.test.ts
+++ b/sdk/packages/llms/src/providers/vendors/openai.test.ts
@@ -56,6 +56,17 @@ describe("createOpenAIProviderModule", () => {
 		expect(streamConfig).not.toHaveProperty("maxOutputTokens");
 	});
 
+	it("omits temperature when the model does not support it", async () => {
+		const provider = await createOpenAIProviderModule(config(), context(false));
+
+		const streamConfig = provider.buildStreamConfig?.(
+			request({ temperature: 0.7 }),
+			context(false),
+		);
+
+		expect(streamConfig).not.toHaveProperty("temperature");
+	});
+
 	it("drops explicit caps for the ChatGPT OAuth backend", async () => {
 		const provider = await createOpenAIProviderModule(
 			config({ baseUrl: "https://chatgpt.com/backend-api/codex" }),
@@ -101,7 +112,7 @@ function config(
 	};
 }
 
-function context() {
+function context(supportsTemperature?: boolean) {
 	return {
 		provider: {
 			id: "openai-native",
@@ -113,6 +124,9 @@ function context() {
 			providerId: "openai-native",
 			id: "gpt-5-mini",
 			name: "gpt-5-mini",
+			...(supportsTemperature === undefined
+				? {}
+				: { metadata: { supportsTemperature } }),
 		},
 		config: config(),
 	};

--- a/sdk/packages/llms/src/providers/vendors/openai.ts
+++ b/sdk/packages/llms/src/providers/vendors/openai.ts
@@ -4,6 +4,7 @@ import type {
 	GatewayResolvedProviderConfig,
 } from "@cline/shared";
 import { resolveApiKey } from "../http";
+import { resolveAiSdkTemperature } from "../temperature";
 import type { ProviderFactoryResult } from "./types";
 
 function isChatGptOAuthBaseUrl(baseUrl: string | undefined): boolean {
@@ -39,13 +40,16 @@ export async function createOpenAIProviderModule(
 	const isChatGptOAuth = isChatGptOAuthBaseUrl(config.baseUrl);
 	return {
 		model: (modelId) => provider.responses(modelId),
-		buildStreamConfig: (request) => ({
-			...(!isChatGptOAuth &&
-			request.maxTokens !== undefined &&
-			request.defaultedMaxTokens !== true
-				? { maxOutputTokens: request.maxTokens }
-				: {}),
-			temperature: request.temperature,
-		}),
+		buildStreamConfig: (request, requestContext) => {
+			const temperature = resolveAiSdkTemperature(request, requestContext);
+			return {
+				...(!isChatGptOAuth &&
+				request.maxTokens !== undefined &&
+				request.defaultedMaxTokens !== true
+					? { maxOutputTokens: request.maxTokens }
+					: {}),
+				...(temperature !== undefined ? { temperature } : {}),
+			};
+		},
 	};
 }


### PR DESCRIPTION
## Summary
- preserve catalog temperature support as gateway model metadata
- omit `temperature` when a model explicitly does not support it
- retain existing behavior for supported models and dynamic models with unknown capabilities

## Testing
- `bun -F @cline/llms test -- src/providers/temperature.test.ts`
- `bunx biome check packages/llms/src/providers/ai-sdk.ts packages/llms/src/providers/ai-sdk.test.ts packages/llms/src/providers/temperature.ts packages/llms/src/providers/temperature.test.ts packages/llms/src/providers/compat.ts packages/llms/src/providers/builtins.ts`
- `bun -F @cline/llms typecheck` *(blocked by the existing missing `ai-sdk-ollama` module in `src/providers/vendors/ollama.ts`)*

Closes #12252

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted request-shaping change with conservative defaults when capability is unknown; covered by unit tests.
> 
> **Overview**
> Stops sending **`temperature`** to the AI SDK when the resolved model is marked as not supporting it, avoiding provider errors for models that reject that parameter.
> 
> Catalog **`temperature`** capability is now exposed on gateway model metadata as **`supportsTemperature`** (builtins and compat paths). A shared **`resolveAiSdkTemperature`** helper drops the field only when **`supportsTemperature === false`**; supported models and models with unknown capabilities still forward the caller’s temperature.
> 
> **`buildAiSdkStreamConfig`** and the OpenAI vendor **`buildStreamConfig`** use this helper so temperature is omitted from the stream payload when appropriate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7c55755dec2f18f4a5e80873553423437d0cb30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->