### PR TITLE
fix(vscode): persist selected account organization

### DIFF
--- a/apps/vscode/webview-ui/src/context/ClineAuthContext.test.tsx
+++ b/apps/vscode/webview-ui/src/context/ClineAuthContext.test.tsx
@@ -1,0 +1,84 @@
+import type { AuthState, UserOrganizationsResponse } from "@shared/proto/cline/account"
+import { act, render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { ClineAuthProvider, useClineAuth } from "./ClineAuthContext"
+
+type AuthStatusCallbacks = {
+	onResponse: (response: AuthState) => void
+}
+
+const grpcMocks = vi.hoisted(() => ({
+	getUserOrganizations: vi.fn(),
+	subscribeToAuthStatusUpdate: vi.fn(),
+	authStatusCallbacks: undefined as AuthStatusCallbacks | undefined,
+}))
+
+vi.mock("@/services/grpc-client", () => ({
+	AccountServiceClient: {
+		getUserOrganizations: grpcMocks.getUserOrganizations,
+		subscribeToAuthStatusUpdate: grpcMocks.subscribeToAuthStatusUpdate,
+	},
+}))
+
+function createDeferred<T>() {
+	let resolve: (value: T) => void = () => {}
+	const promise = new Promise<T>((promiseResolve) => {
+		resolve = promiseResolve
+	})
+	return { promise, resolve }
+}
+
+function AuthStateProbe() {
+	const { clineUser, organizations } = useClineAuth()
+	return (
+		<>
+			<div data-testid="user-state">{clineUser?.uid ?? "signed-out"}</div>
+			<div data-testid="organizations-state">
+				{organizations?.map((organization) => organization.organizationId).join(",") ?? "none"}
+			</div>
+		</>
+	)
+}
+
+describe("ClineAuthProvider", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		grpcMocks.authStatusCallbacks = undefined
+		grpcMocks.subscribeToAuthStatusUpdate.mockImplementation((_request, callbacks: AuthStatusCallbacks) => {
+			grpcMocks.authStatusCallbacks = callbacks
+			return vi.fn()
+		})
+	})
+
+	it("does not restore organizations when an in-flight request resolves after sign-out", async () => {
+		const organizationsRequest = createDeferred<UserOrganizationsResponse>()
+		grpcMocks.getUserOrganizations.mockReturnValue(organizationsRequest.promise)
+
+		render(
+			<ClineAuthProvider>
+				<AuthStateProbe />
+			</ClineAuthProvider>,
+		)
+
+		act(() => {
+			grpcMocks.authStatusCallbacks?.onResponse({ user: { uid: "user-1" } })
+		})
+		expect(grpcMocks.getUserOrganizations).toHaveBeenCalledTimes(1)
+
+		act(() => {
+			grpcMocks.authStatusCallbacks?.onResponse({})
+		})
+
+		await act(async () => {
+			organizationsRequest.resolve({
+				organizations: [
+					{ organizationId: "stale-org", active: true, memberId: "member-1", name: "Stale Org", roles: [] },
+				],
+			})
+			await organizationsRequest.promise
+		})
+
+		expect(screen.getByTestId("user-state")).toHaveTextContent("signed-out")
+		expect(screen.getByTestId("organizations-state")).toHaveTextContent("none")
+	})
+})

--- a/apps/vscode/webview-ui/src/context/ClineAuthContext.tsx
+++ b/apps/vscode/webview-ui/src/context/ClineAuthContext.tsx
@@ -2,7 +2,7 @@ import type { AuthState, UserOrganization } from "@shared/proto/cline/account"
 import { EmptyRequest } from "@shared/proto/cline/common"
 import deepEqual from "fast-deep-equal"
 import type React from "react"
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react"
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react"
 import { AccountServiceClient } from "@/services/grpc-client"
 
 // Define User type (you may need to adjust this based on your actual User type)
@@ -25,10 +25,15 @@ export const ClineAuthContext = createContext<ClineAuthContextType | undefined>(
 export const ClineAuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
 	const [user, setUser] = useState<ClineUser | null>(null)
 	const [userOrganizations, setUserOrganizations] = useState<UserOrganization[] | null>(null)
+	const organizationsRequestIdRef = useRef(0)
 
 	const getUserOrganizations = useCallback(async () => {
+		const requestId = ++organizationsRequestIdRef.current
 		try {
 			const response = await AccountServiceClient.getUserOrganizations(EmptyRequest.create())
+			if (requestId !== organizationsRequestIdRef.current) {
+				return
+			}
 			setUserOrganizations((old) => {
 				if (!deepEqual(response.organizations, old)) {
 					return response.organizations
@@ -52,9 +57,10 @@ export const ClineAuthProvider: React.FC<{ children: React.ReactNode }> = ({ chi
 	// Handle auth status update events
 	useEffect(() => {
 		const cancelSubscription = AccountServiceClient.subscribeToAuthStatusUpdate(EmptyRequest.create(), {
-			onResponse: async (response: AuthState) => {
+			onResponse: (response: AuthState) => {
 				const responseUser = response.user
 				if (!responseUser?.uid) {
+					organizationsRequestIdRef.current++
 					setUser(null)
 					setUserOrganizations(null)
 					return
@@ -79,6 +85,7 @@ export const ClineAuthProvider: React.FC<{ children: React.ReactNode }> = ({ chi
 
 		// Cleanup function to cancel subscription when component unmounts
 		return () => {
+			organizationsRequestIdRef.current++
 			cancelSubscription()
 		}
 	}, [getUserOrganizations])

--- a/apps/vscode/webview-ui/src/context/ClineAuthContext.tsx
+++ b/apps/vscode/webview-ui/src/context/ClineAuthContext.tsx
@@ -1,4 +1,4 @@
-import type { UserOrganization } from "@shared/proto/cline/account"
+import type { AuthState, UserOrganization } from "@shared/proto/cline/account"
 import { EmptyRequest } from "@shared/proto/cline/common"
 import deepEqual from "fast-deep-equal"
 import type React from "react"
@@ -52,22 +52,22 @@ export const ClineAuthProvider: React.FC<{ children: React.ReactNode }> = ({ chi
 	// Handle auth status update events
 	useEffect(() => {
 		const cancelSubscription = AccountServiceClient.subscribeToAuthStatusUpdate(EmptyRequest.create(), {
-			onResponse: async (response: any) => {
-				setUser((oldUser) => {
-					if (!response?.user?.uid) {
-						return null
-					}
+			onResponse: async (response: AuthState) => {
+				const responseUser = response.user
+				if (!responseUser?.uid) {
+					setUser(null)
+					setUserOrganizations(null)
+					return
+				}
 
-					if (response?.user && oldUser?.uid !== response.user.uid) {
-						// Once we have a new user, fetch organizations that
-						// allow us to display the active account in account view UI
-						// and fetch the correct credit balance to display on mount
-						getUserOrganizations()
-						return response.user
-					}
+				// Refresh organizations on every auth status update, not just user
+				// changes. Switching organizations doesn't change the uid, so gating
+				// this on uid changes leaves stale `active` flags — which reset the
+				// account view's org dropdown on remount. The deepEqual guard in
+				// getUserOrganizations prevents no-op re-renders.
+				getUserOrganizations()
 
-					return oldUser
-				})
+				setUser((oldUser) => (oldUser?.uid !== responseUser.uid ? responseUser : oldUser))
 			},
 			onError: (error: Error) => {
 				console.error("Error in auth callback subscription:", error)


### PR DESCRIPTION
### Related Issue

**Issue:** go to your account page, switch orgs, click done, then go back to your account page
Expectation: I should see the new org
Actual: I still see the old org

### Description

Refresh the authenticated user’s organization list on every auth status update instead of only when the user ID changes.

Switching organizations does not change the user ID, so the webview previously kept stale `active` organization flags. Navigating away from the account view and returning remounted the organization selector from that stale context, causing it to reset to the previously active/default account.

This also clears cached organizations when the user signs out and replaces the untyped auth response with the generated `AuthState` type.

### Test Procedure

- Generated current VS Code protobuf artifacts with `bun run protos` from `apps/vscode` to synchronize local generated sources.
- Ran `bunx tsc -b` from `apps/vscode/webview-ui`.
- Ran `bunx biome lint src/context/ClineAuthContext.tsx` from `apps/vscode/webview-ui`.
- Ran the complete webview test suite with `bun run test` from `apps/vscode/webview-ui`.
- Verified the PR contains only the account auth-context change.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable; this fixes state synchronization without changing the account UI.

### Additional Notes

No related issue was provided for this small bug fix.
