### PR TITLE
fix(vscode): avoid duplicate OpenAI provider settings

### DIFF
--- a/apps/vscode/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/ApiOptions.tsx
@@ -510,7 +510,7 @@ const ApiOptions = ({
 				<AIhubmixProvider currentMode={currentMode} isPopup={isPopup} showModelOptions={showModelOptions} />
 			)}
 
-			{apiConfiguration && (selectedProvider.includes("openai") || isCustomProvider) && (
+			{apiConfiguration && (selectedProvider === "openai" || isCustomProvider) && (
 				<OpenAICompatibleProvider
 					currentMode={currentMode}
 					isPopup={isPopup}

--- a/apps/vscode/webview-ui/src/components/settings/__tests__/APIOptions.spec.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/__tests__/APIOptions.spec.tsx
@@ -97,6 +97,25 @@ describe("ApiOptions Component", () => {
 		expect(modelIdInput).toBeInTheDocument()
 	})
 
+	it.each([
+		["openai-native", "OpenAI API Key"],
+		["openai-codex", "Sign in to OpenAI Codex"],
+	])("renders only the dedicated form for %s", (provider, dedicatedFormText) => {
+		mockExtensionState({
+			planModeApiProvider: provider as any,
+			actModeApiProvider: provider as any,
+		})
+
+		render(
+			<ExtensionStateContextProvider>
+				<ApiOptions currentMode="plan" showModelOptions={false} />
+			</ExtensionStateContextProvider>,
+		)
+
+		expect(screen.getByText(dedicatedFormText)).toBeInTheDocument()
+		expect(screen.queryByText("Custom Headers")).not.toBeInTheDocument()
+	})
+
 	it("renders the OpenAI-compatible form for custom/unknown catalog providers", () => {
 		vi.mocked(useProviderListings).mockReturnValue({
 			providers: [


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

OpenAI Native and OpenAI Codex were rendering both their dedicated provider settings and the OpenAI-compatible settings because provider IDs were matched with `includes("openai")`.

Restrict the OpenAI-compatible view to the `openai` provider and custom providers. Add regression coverage confirming OpenAI Native and OpenAI Codex render only their dedicated forms.

### Test Procedure

- Ran `bun --cwd apps/vscode/webview-ui test src/components/settings/__tests__/APIOptions.spec.tsx`.
- Verified all 11 targeted tests pass, including the new OpenAI Native and OpenAI Codex cases.
- The pre-commit Biome check completed successfully for both changed files.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not included; the regression tests verify that the duplicate OpenAI-compatible form is absent for both affected providers.

### Additional Notes

None.
