### PR TITLE
fix(vscode): show apply_patch previews when background edit is off

### DIFF
--- a/apps/vscode/src/sdk/sdk-diff-edit-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-diff-edit-coordinator.test.ts
@@ -454,13 +454,35 @@ describe("SdkDiffEditCoordinator", () => {
 		expect(callOrder).toEqual(["close", "apply"])
 	})
 
-	it("applies patches without preview sessions directly", async () => {
+	it("shows a brief preview around auto-approved patches", async () => {
+		await writeFile("patched.ts", "line one\nline two\n")
+		const patch = ["*** Begin Patch", "*** Update File: patched.ts", "@@", "-line one", "+line ONE", "*** End Patch"].join(
+			"\n",
+		)
+
+		const result = await coordinator.executeApplyPatchTool({ input: patch }, tempDir, makeContext("tc9"))
+
+		expect(result).toBe("fallback apply_patch result")
+		expect(fallbackApplyPatch).toHaveBeenCalledOnce()
+		expect(previews).toHaveLength(1)
+		expect(previews[0].opened).toMatchObject({
+			absolutePath: path.join(tempDir, "patched.ts"),
+			leftContent: "line one\nline two\n",
+			rightContent: "line ONE\nline two\n",
+		})
+		expect(previews[0].closed).toBe(1)
+	})
+
+	it("applies auto-approved patches without a preview when background edit is enabled", async () => {
+		backgroundEdit = true
 		const result = await coordinator.executeApplyPatchTool(
 			{ input: "*** Begin Patch\n*** End Patch" },
 			tempDir,
 			makeContext("tc9"),
 		)
+
 		expect(result).toBe("fallback apply_patch result")
 		expect(fallbackApplyPatch).toHaveBeenCalledOnce()
+		expect(previews).toHaveLength(0)
 	})
 })

--- a/apps/vscode/src/sdk/sdk-diff-edit-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-diff-edit-coordinator.ts
@@ -122,12 +122,32 @@ export class SdkDiffEditCoordinator {
 	}
 
 	/**
-	 * The `apply_patch` tool executor override: close the preview, then delegate the
-	 * whole patch application to the SDK's default executor.
+	 * The `apply_patch` tool executor override: manually-approved patches close their
+	 * approval preview before applying; auto-approved patches show a brief preview
+	 * around execution, matching the `editor` tool behavior.
 	 */
 	async executeApplyPatchTool(input: ApplyPatchInput, cwd: string, context: AgentToolContext): Promise<string> {
-		await this.discardPreview(context.toolCallId ?? "")
-		return this.fallbackApplyPatchExecutor(input, cwd, context)
+		const toolCallId = context.toolCallId ?? ""
+		const hadPreApprovalPreview = this.sessions.has(toolCallId)
+		try {
+			if (hadPreApprovalPreview) {
+				await this.discardPreview(toolCallId)
+			} else if (!this.options.isBackgroundEditEnabled()) {
+				try {
+					await this.openPatchPreview(toolCallId, input)
+				} catch (error) {
+					Logger.warn(`[SdkDiffEditCoordinator] Failed to show auto-approve patch preview: ${error}`)
+				}
+			}
+
+			const result = await this.fallbackApplyPatchExecutor(input, cwd, context)
+			if (!hadPreApprovalPreview && this.sessions.get(toolCallId)?.preview) {
+				await lingerDelay(this.autoApprovePreviewLingerMs, context.signal)
+			}
+			return result
+		} finally {
+			await this.discardPreview(toolCallId)
+		}
 	}
 
 	/** Closes one preview (reject / abort / edit applied). Never throws; unknown ids are a no-op. */


### PR DESCRIPTION
### Related Issue

**Issue:** N/A — small bug fix

### Description

Auto-approved `apply_patch` edits skipped the approval-time preview and then executed directly through the SDK disk writer. This meant that turning Background Edit off still did not show an edit preview for models routed through `apply_patch`, even though the equivalent `editor` tool path did.

This change gives auto-approved `apply_patch` calls the same preview lifecycle as `editor` calls:

- When Background Edit is off, open an `EditPreview` around execution and briefly linger after the patch is applied.
- When Background Edit is on, continue applying auto-approved patches headlessly.
- For manually approved patches, keep the existing Save/Reject flow and close the approval preview before applying the patch.
- Always clean up the preview, including failed and aborted execution paths.

The preview decision and approval decision are intentionally independent: Background Edit controls whether an editor preview is shown, while edit auto-approval controls whether Save/Reject confirmation is required.

### Test Procedure

Automated:

```sh
cd apps/vscode
bun run test:vitest -- src/sdk/sdk-diff-edit-coordinator.test.ts
bunx biome check --config-path ./biome.jsonc src/sdk/sdk-diff-edit-coordinator.ts src/sdk/sdk-diff-edit-coordinator.test.ts --semicolons=as-needed
```

Result: 32 focused tests passed and both changed files passed Biome.

Manual verification completed:

1. Background Edit off, edit auto-approval off: diff edit view appears with Save/Reject; execution waits for the decision. ✅
2. Background Edit on, edit auto-approval off: in-chat edit appears with Save/Reject; execution waits for the decision. ✅
3. Background Edit off, edit auto-approval on: diff edit view appears without buttons; the model continues working. ✅
4. Background Edit on, edit auto-approval on: in-chat edit appears without buttons; the model continues working. ✅

Reviewer reproduction steps:

1. Build and launch the VS Code extension development host.
2. Use a GPT/Codex or OpenAI-native model so edits are routed through `apply_patch`.
3. Ask Cline to make a small edit to an existing file.
4. Repeat the edit with each combination of:
   - Background Edit on/off in Cline settings.
   - Edit Files auto-approval on/off in the auto-approval menu.
5. Verify the four outcomes listed above. Use a fresh edit for each combination so each tool call has its own preview/approval lifecycle.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not included. The manual test matrix above covers the affected interaction states.

### Additional Notes

The unrelated untracked `.clickhouse/` directory was not included in this branch or commit.
