### PR TITLE
fix(terminal): read host IDE shell from CLINE_TERMINAL_SHELL_PATH instead of COMSPEC/SHELL

### DIFF
--- a/apps/vscode/src/test/shell.test.ts
+++ b/apps/vscode/src/test/shell.test.ts
@@ -15,7 +15,7 @@ const osMock = () => ({ ...osMockNamespace, default: osMockNamespace })
 mock.module("os", osMock)
 mock.module("node:os", osMock)
 
-import { getShell } from "@utils/shell"
+import { getShell, HOST_SHELL_ENV_VAR } from "@utils/shell"
 
 describe("Shell Detection Tests", () => {
 	let originalPlatform: string
@@ -49,6 +49,7 @@ describe("Shell Detection Tests", () => {
 		// Clear environment variables for a clean test
 		delete process.env.SHELL
 		delete process.env.COMSPEC
+		delete process.env[HOST_SHELL_ENV_VAR]
 
 		// Default userInfo() mock
 		userInfoImpl = (() => ({ shell: null })) as any
@@ -60,6 +61,42 @@ describe("Shell Detection Tests", () => {
 		process.env = originalEnv
 		vscode.workspace.getConfiguration = originalGetConfig
 		userInfoImpl = originalUserInfo
+	})
+
+	// --------------------------------------------------------------------------
+	// Host-Provided Shell Override (CLINE_TERMINAL_SHELL_PATH)
+	// --------------------------------------------------------------------------
+	describe("Host-Provided Shell Override", () => {
+		it("wins over VS Code config, userInfo, and COMSPEC on Windows", () => {
+			Object.defineProperty(process, "platform", { value: "win32" })
+			mockVsCodeConfig("windows", "PowerShell", {
+				PowerShell: { path: "C:\\Program Files\\PowerShell\\7\\pwsh.exe" },
+			})
+			userInfoImpl = (() => ({ shell: "C:\\Custom\\PowerShell.exe" })) as any
+			process.env.COMSPEC = "C:\\Windows\\System32\\cmd.exe"
+			process.env[HOST_SHELL_ENV_VAR] = "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"
+
+			expect(getShell()).to.equal("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe")
+		})
+
+		it("wins over userInfo and SHELL on POSIX", () => {
+			Object.defineProperty(process, "platform", { value: "darwin" })
+			vscode.workspace.getConfiguration = () => ({ get: () => undefined }) as any
+			userInfoImpl = (() => ({ shell: "/bin/zsh" })) as any
+			process.env.SHELL = "/bin/bash"
+			process.env[HOST_SHELL_ENV_VAR] = "/usr/local/bin/fish"
+
+			expect(getShell()).to.equal("/usr/local/bin/fish")
+		})
+
+		it("is ignored when blank", () => {
+			Object.defineProperty(process, "platform", { value: "darwin" })
+			vscode.workspace.getConfiguration = () => ({ get: () => undefined }) as any
+			userInfoImpl = (() => ({ shell: "/bin/zsh" })) as any
+			process.env[HOST_SHELL_ENV_VAR] = "   "
+
+			expect(getShell()).to.equal("/bin/zsh")
+		})
 	})
 
 	// --------------------------------------------------------------------------

--- a/apps/vscode/src/utils/shell.ts
+++ b/apps/vscode/src/utils/shell.ts
@@ -49,6 +49,28 @@ interface LinuxTerminalProfile {
 type LinuxTerminalProfiles = Record<string, LinuxTerminalProfile>
 
 // -----------------------------------------------------
+// 0) Host-Provided Shell Override
+// -----------------------------------------------------
+
+/**
+ * Environment variable through which host integrations (e.g. the JetBrains
+ * plugin) forward the user's IDE terminal profile shell to cline-core.
+ *
+ * A dedicated variable is used instead of overriding COMSPEC/SHELL because
+ * COMSPEC is an OS-level contract that must keep pointing at cmd.exe:
+ * cross-spawn, Node's `shell: true`, and npm `.cmd` shims all pass cmd-style
+ * `/d /s /c` arguments to whatever COMSPEC references. Overriding it with
+ * PowerShell breaks every such child process (see cline/cline#11290).
+ */
+export const HOST_SHELL_ENV_VAR = "CLINE_TERMINAL_SHELL_PATH"
+
+/** Returns the shell explicitly forwarded by the host IDE, or null. */
+export function getHostProvidedShell(): string | null {
+	const shell = process.env[HOST_SHELL_ENV_VAR]?.trim()
+	return shell || null
+}
+
+// -----------------------------------------------------
 // 1) VS Code Terminal Configuration Helpers
 // -----------------------------------------------------
 
@@ -305,6 +327,12 @@ export function getShellForProfile(profileId: string): string {
 // -----------------------------------------------------
 
 export function getShell(): string {
+	// 0. A shell explicitly forwarded by the host IDE wins over detection.
+	const hostShell = getHostProvidedShell()
+	if (hostShell) {
+		return hostShell
+	}
+
 	// 1. Check VS Code config first.
 	if (process.platform === "win32") {
 		// Special logic for Windows


### PR DESCRIPTION
## Problem

Host integrations (the JetBrains plugin) forward the user's IDE terminal-profile shell to cline-core by overriding `COMSPEC` (Windows) / `SHELL` (POSIX) on the child process env (cline/intellij-plugin#892). On Windows, IntelliJ's effective terminal shell defaults to PowerShell even when the user never configured one — so virtually every Windows JetBrains user runs cline-core with `COMSPEC=powershell.exe`.

`COMSPEC` is an OS-level contract that must keep pointing at `cmd.exe`: cross-spawn, Node's `shell: true`, and npm `.cmd` shims all pass cmd-style `/d /s /c` arguments to whatever it references. Overriding it breaks **every `.cmd`/`.bat`-shimmed child process cline-core spawns**. Known affected surfaces on JetBrains + Windows:

- **Claude Code provider** — fails with `/d : The term '/d' is not recognized as the name of a cmdlet ...` (#11290)
- **MCP stdio servers whose `command` is a `.cmd`/`.bat` file** (e.g. `npx.cmd`) — the MCP SDK spawns via cross-spawn, which rewrites the launch to `%COMSPEC% /d /s /c "npx.cmd ..."`; PowerShell chokes on `/d`, the server exits before the handshake, and the user only sees `MCP error -32000: Connection closed` ([user report on Reddit](https://www.reddit.com/r/CLine/comments/1uw59ll/troubleshooting_mcp_server/))

## Fix

Introduce a dedicated `CLINE_TERMINAL_SHELL_PATH` env var that hosts can set safely. It takes precedence in `getShell()` (step 0, before VS Code config / OS detection), while `COMSPEC`/`SHELL` keep their OS semantics untouched.

Part of #11290 — the actual breakage is removed by the companion JetBrains plugin PR (which stops overriding `COMSPEC`); this PR restores the intended "respect the IDE terminal profile" behavior through the new variable.

## Companion PRs

- JetBrains plugin (sets the variable): cline/intellij-plugin#1041 — should ship **after** this change is released, otherwise `execute_command` falls back to the OS default shell
- `legacy-extension` equivalent: cline/cline#12351

## Testing

- Unit tests added in `apps/vscode/src/test/shell.test.ts` covering the new precedence and the empty/whitespace cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
