### PR TITLE
feat(vscode): capture telemetry when consecutive mistake limit is reached

### DIFF
--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -15,7 +15,12 @@ import {
 	setTelemetryOptOutGlobally,
 	type UserInstructionConfigService,
 } from "@cline/core"
-import { formatDisplayUserInput, type RemoteConfig, type RemoteConfigBundle } from "@cline/shared"
+import {
+	type ConsecutiveMistakeLimitContext,
+	formatDisplayUserInput,
+	type RemoteConfig,
+	type RemoteConfigBundle,
+} from "@cline/shared"
 import type { ApiConfiguration, ModelInfo } from "@shared/api"
 import type { ChatContent } from "@shared/ChatContent"
 import { CLINE_ACCOUNT_AUTH_ERROR_MESSAGE } from "@shared/ClineAccount"
@@ -297,7 +302,10 @@ export class Controller {
 				this.mode.queueSwitchToActMode()
 			},
 			shouldStopAfterModeSwitch: () => this.mode.hasPendingModeChange(),
-			onConsecutiveMistakeLimitReached: (context) => this.interactions.handleConsecutiveMistakeLimitReached(context),
+			onConsecutiveMistakeLimitReached: (context) => {
+				this.captureMistakeLimitReached(context)
+				return this.interactions.handleConsecutiveMistakeLimitReached(context)
+			},
 		})
 		this.diffEdits = new SdkDiffEditCoordinator({
 			getCwd: () => this.getWorkspaceRoot(),
@@ -965,6 +973,25 @@ export class Controller {
 
 	private beginProviderFailureTelemetryTurn(): void {
 		this.providerFailureTelemetryTurnGate.beginTurn()
+	}
+
+	/**
+	 * Fires once per consecutive-mistake-limit hit, right before the
+	 * mistake_limit_reached ask is surfaced to the user.
+	 */
+	private captureMistakeLimitReached(context: ConsecutiveMistakeLimitContext): void {
+		const ulid = this.sessions.getActiveSession()?.sessionId ?? this.task?.taskId
+		if (!ulid) {
+			return
+		}
+		telemetryService.captureMistakeLimitReached({
+			ulid,
+			model: this.getSessionModelId() ?? this.getTaskModelId() ?? "unknown",
+			provider: this.getSessionProviderId() ?? "unknown",
+			reason: context.reason,
+			consecutiveMistakes: context.consecutiveMistakes,
+			maxConsecutiveMistakes: context.maxConsecutiveMistakes,
+		})
 	}
 
 	/**

--- a/apps/vscode/src/services/telemetry/TelemetryService.ts
+++ b/apps/vscode/src/services/telemetry/TelemetryService.ts
@@ -313,6 +313,8 @@ export class TelemetryService {
 			GEMINI_API_PERFORMANCE: "task.gemini_api_performance",
 			// Tracks when API providers return errors
 			PROVIDER_API_ERROR: "task.provider_api_error",
+			// Tracks when the consecutive mistake limit is reached and the user is prompted
+			MISTAKE_LIMIT_REACHED: "task.mistake_limit_reached",
 			// Tracks when users enable the focus chain feature
 			FOCUS_CHAIN_ENABLED: "task.focus_chain_enabled",
 			// Tracks when users disable the focus chain feature
@@ -1498,6 +1500,33 @@ export class TelemetryService {
 		}
 		const errorCount = this.incrementTaskCounter(this.taskErrorCounts, args.ulid)
 		this.recordHistogram(TelemetryService.METRICS.ERRORS.PER_TASK, errorCount, errorAttributes)
+	}
+
+	/**
+	 * Records when the consecutive mistake limit is reached and the user is shown
+	 * the mistake_limit_reached prompt
+	 * @param ulid Unique identifier for the task/session
+	 * @param model Identifier of the model used
+	 * @param provider Identifier of the API provider used
+	 * @param reason What kind of mistake tripped the limit (api_error, invalid_tool_call, tool_execution_failed)
+	 * @param consecutiveMistakes Number of consecutive mistakes recorded when the limit was hit
+	 * @param maxConsecutiveMistakes The configured mistake limit
+	 */
+	public captureMistakeLimitReached(args: {
+		ulid: string
+		model: string
+		provider: string
+		reason: string
+		consecutiveMistakes: number
+		maxConsecutiveMistakes: number
+	}) {
+		this.capture({
+			event: TelemetryService.EVENTS.TASK.MISTAKE_LIMIT_REACHED,
+			properties: {
+				...args,
+				timestamp: new Date().toISOString(),
+			},
+		})
 	}
 
 	/**


### PR DESCRIPTION
### Related Issue

N/A — PM request for telemetry coverage on the mistake-limit flow.

### Description

**Problem:** When the model repeatedly fails (bad tool calls, tool execution errors, API errors) and hits `maxConsecutiveMistakes`, the extension surfaces a `mistake_limit_reached` ask ("Cline ran into repeated tool errors (N/N)…") — but nothing is captured in analytics. We have no way to answer "what % of tasks hit the mistake wall?" or "which models/providers trip it most?"

This gap goes back to the legacy extension too: the old `task/index.ts` showed the "Cline uses complex prompts… may be challenging for less capable models" warning at the same trigger point, also with zero telemetry. The new SDK-based extension flattened that copy into a generic message but kept the tracking gap.

**Why nothing existing covers it:** the closest event is `task.provider_api_error`, but it only fires on provider API/streaming failures. It doesn't fire for `invalid_tool_call` or `tool_execution_failed` mistakes, and it doesn't fire at the *limit* moment — so you can't derive limit-hit rates from it.

**Approach:** fire a new `task.mistake_limit_reached` event exactly once per limit-hit, from the `SdkController` wrapper around `onConsecutiveMistakeLimitReached` — right before `SdkInteractionCoordinator.handleConsecutiveMistakeLimitReached()` renders the ask.

Properties: `ulid`, `model`, `provider`, `reason` (`api_error` | `invalid_tool_call` | `tool_execution_failed`), `consecutiveMistakes`, `maxConsecutiveMistakes`.

**Decisions / alternatives considered:**
- **Fired from the vscode adapter, not SDK core.** The `MistakeTracker` in `sdk/packages/core` is the component that actually counts mistakes, but core is host-agnostic and shouldn't reach into the extension's `TelemetryService`. Core already emits a recoverable error event per mistake; the adapter is where product analytics belongs.
- **Fired from `SdkController`'s callback wrapper, not inside the coordinator.** The controller already has `getSessionModelId()` / `getSessionProviderId()` / `getTaskModelId()` in scope (same resolution chain `captureProviderFailure` uses), so the coordinator stays telemetry-free and no new options need threading.
- **Event-only, no OTel counter/histogram.** Per-mistake errors already flow into `METRICS.ERRORS.*` via other paths; this event is for PostHog funnel analysis, keyed by `ulid`.

**How to query the rate:** `distinct ulid` with `task.mistake_limit_reached` ÷ `task.created` count = % of tasks that hit the wall. Split by `model` / `provider` to see whether it concentrates in weaker models (the question the old legacy warning copy was implicitly about).

### Test Procedure

- `bunx tsc --noEmit` (apps/vscode) — clean
- `biome lint` + `format` on both touched files — clean
- `bun scripts/run-bun-unit-tests.ts` — 65 files, 992 pass, 0 fail
- Behavior risk is minimal by construction: the capture is fired-and-forgotten before delegating to the existing `handleConsecutiveMistakeLimitReached`, whose return value is passed through unchanged. If no session/task id can be resolved the capture is skipped entirely.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — no UI change; the mistake-limit prompt renders exactly as before.

### Additional Notes

The legacy extension (`legacy-extension` branch) has the same blind spot at its `mistake_limit_reached` ask. Happy to port a matching event there in a follow-up if we want rollout-comparison data across both extensions.
