### PR TITLE
feat(core): emit mistake-limit telemetry from the session runtime

### DIFF
--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -15,12 +15,7 @@ import {
 	setTelemetryOptOutGlobally,
 	type UserInstructionConfigService,
 } from "@cline/core"
-import {
-	type ConsecutiveMistakeLimitContext,
-	formatDisplayUserInput,
-	type RemoteConfig,
-	type RemoteConfigBundle,
-} from "@cline/shared"
+import { formatDisplayUserInput, type RemoteConfig, type RemoteConfigBundle } from "@cline/shared"
 import type { ApiConfiguration, ModelInfo } from "@shared/api"
 import type { ChatContent } from "@shared/ChatContent"
 import { CLINE_ACCOUNT_AUTH_ERROR_MESSAGE } from "@shared/ClineAccount"
@@ -302,10 +297,7 @@ export class Controller {
 				this.mode.queueSwitchToActMode()
 			},
 			shouldStopAfterModeSwitch: () => this.mode.hasPendingModeChange(),
-			onConsecutiveMistakeLimitReached: (context) => {
-				this.captureMistakeLimitReached(context)
-				return this.interactions.handleConsecutiveMistakeLimitReached(context)
-			},
+			onConsecutiveMistakeLimitReached: (context) => this.interactions.handleConsecutiveMistakeLimitReached(context),
 		})
 		this.diffEdits = new SdkDiffEditCoordinator({
 			getCwd: () => this.getWorkspaceRoot(),
@@ -973,25 +965,6 @@ export class Controller {
 
 	private beginProviderFailureTelemetryTurn(): void {
 		this.providerFailureTelemetryTurnGate.beginTurn()
-	}
-
-	/**
-	 * Fires once per consecutive-mistake-limit hit, right before the
-	 * mistake_limit_reached ask is surfaced to the user.
-	 */
-	private captureMistakeLimitReached(context: ConsecutiveMistakeLimitContext): void {
-		const ulid = this.sessions.getActiveSession()?.sessionId ?? this.task?.taskId
-		if (!ulid) {
-			return
-		}
-		telemetryService.captureMistakeLimitReached({
-			ulid,
-			model: this.getSessionModelId() ?? this.getTaskModelId() ?? "unknown",
-			provider: this.getSessionProviderId() ?? "unknown",
-			reason: context.reason,
-			consecutiveMistakes: context.consecutiveMistakes,
-			maxConsecutiveMistakes: context.maxConsecutiveMistakes,
-		})
 	}
 
 	/**

--- a/apps/vscode/src/services/telemetry/TelemetryService.ts
+++ b/apps/vscode/src/services/telemetry/TelemetryService.ts
@@ -313,8 +313,6 @@ export class TelemetryService {
 			GEMINI_API_PERFORMANCE: "task.gemini_api_performance",
 			// Tracks when API providers return errors
 			PROVIDER_API_ERROR: "task.provider_api_error",
-			// Tracks when the consecutive mistake limit is reached and the user is prompted
-			MISTAKE_LIMIT_REACHED: "task.mistake_limit_reached",
 			// Tracks when users enable the focus chain feature
 			FOCUS_CHAIN_ENABLED: "task.focus_chain_enabled",
 			// Tracks when users disable the focus chain feature
@@ -1500,33 +1498,6 @@ export class TelemetryService {
 		}
 		const errorCount = this.incrementTaskCounter(this.taskErrorCounts, args.ulid)
 		this.recordHistogram(TelemetryService.METRICS.ERRORS.PER_TASK, errorCount, errorAttributes)
-	}
-
-	/**
-	 * Records when the consecutive mistake limit is reached and the user is shown
-	 * the mistake_limit_reached prompt
-	 * @param ulid Unique identifier for the task/session
-	 * @param model Identifier of the model used
-	 * @param provider Identifier of the API provider used
-	 * @param reason What kind of mistake tripped the limit (api_error, invalid_tool_call, tool_execution_failed)
-	 * @param consecutiveMistakes Number of consecutive mistakes recorded when the limit was hit
-	 * @param maxConsecutiveMistakes The configured mistake limit
-	 */
-	public captureMistakeLimitReached(args: {
-		ulid: string
-		model: string
-		provider: string
-		reason: string
-		consecutiveMistakes: number
-		maxConsecutiveMistakes: number
-	}) {
-		this.capture({
-			event: TelemetryService.EVENTS.TASK.MISTAKE_LIMIT_REACHED,
-			properties: {
-				...args,
-				timestamp: new Date().toISOString(),
-			},
-		})
 	}
 
 	/**

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -137,11 +137,6 @@ export {
 	type UserRemoteConfigResponse,
 } from "./account";
 export {
-	hashSecret,
-	setSdkLogger,
-	sdkDebug,
-} from "./logging/early-logger";
-export {
 	createOAuthClientCallbacks,
 	type OAuthClientCallbacksOptions,
 } from "./auth/client";
@@ -407,6 +402,11 @@ export * from "./hub";
 export { HubRuntimeHost } from "./hub/runtime-host/hub-runtime-host";
 export { RemoteRuntimeHost } from "./hub/runtime-host/remote-runtime-host";
 export {
+	hashSecret,
+	sdkDebug,
+	setSdkLogger,
+} from "./logging/early-logger";
+export {
 	buildRemoteConfigSessionBlobUploadMetadata,
 	createRemoteConfigSessionMessagesArtifactUploader,
 	type PreparedRemoteConfigCoreIntegration,
@@ -651,6 +651,7 @@ export {
 	captureMentionFailed,
 	captureMentionSearchResults,
 	captureMentionUsed,
+	captureMistakeLimitReached,
 	captureModeSwitch,
 	captureProviderApiError,
 	captureProviderConfigured,

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
@@ -2189,6 +2189,61 @@ describe("SessionRuntime.run — tracker wiring (P1 #3)", () => {
 		expect(abortCalls).toHaveLength(0);
 	});
 
+	it("captures task.mistake_limit_reached telemetry exactly once when the limit is hit", async () => {
+		const capture = vi.fn();
+		const telemetry = {
+			capture,
+			captureRequired: vi.fn(),
+			setDistinctId: vi.fn(),
+			setMetadata: vi.fn(),
+			updateMetadata: vi.fn(),
+			setCommonProperties: vi.fn(),
+			updateCommonProperties: vi.fn(),
+			isEnabled: vi.fn(() => true),
+			recordCounter: vi.fn(),
+			recordHistogram: vi.fn(),
+			recordGauge: vi.fn(),
+			flush: vi.fn(async () => {}),
+			dispose: vi.fn(async () => {}),
+		};
+		const { deps } = makeScriptedRuntime({
+			events: failedToolTurnEvents(),
+		});
+		const session = new SessionRuntime(
+			makeAgentConfig({
+				execution: { maxConsecutiveMistakes: 2 },
+				sessionId: "sess_mistakes",
+				telemetry,
+			}),
+			deps,
+		);
+
+		await session.run("one");
+		// First failed turn — counter 1 < 2, no telemetry yet.
+		const limitEvents = () =>
+			capture.mock.calls
+				.map((call) => call[0])
+				.filter((event) => event.event === "task.mistake_limit_reached");
+		expect(limitEvents()).toHaveLength(0);
+
+		await session.continue("two");
+		// Second failed turn hits the limit: exactly one event, even though
+		// no `onConsecutiveMistakeLimitReached` callback is configured (the
+		// tracker falls back to the default stop decision).
+		const events = limitEvents();
+		expect(events).toHaveLength(1);
+		expect(events[0].properties).toMatchObject({
+			ulid: "sess_mistakes",
+			model: "claude-3-5-sonnet",
+			provider: "anthropic",
+			reason: "tool_execution_failed",
+			consecutiveMistakes: 2,
+			maxConsecutiveMistakes: 2,
+			isSubagent: false,
+		});
+		expect(events[0].properties.agentId).toMatch(/^agent_/);
+	});
+
 	it("aborts on hard-threshold loop detection of identical tool calls", async () => {
 		const identical = (i: number): AgentRuntimeEvent => ({
 			type: "tool-started",

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
@@ -52,6 +52,7 @@ import {
 	createAgentModelFromConfig,
 	resolveKnownModelsFromConfig,
 } from "../../services/llms/handler-factory";
+import { captureMistakeLimitReached } from "../../services/telemetry/core-events";
 import { CLINE_INTERNAL_TELEMETRY_METADATA_KEY } from "../../services/telemetry/tool-context";
 import {
 	getMessageBuilderOptionsFromEnv,
@@ -276,10 +277,10 @@ export class SessionRuntime {
 	private readonly agentId: string;
 	private readonly parentAgentId?: string;
 	private readonly logger?: BasicLogger;
-	// Reserved for §3.4.4 telemetry parity (not yet consumed — §3.4.4
-	// listed as explicitly deferred until telemetry wiring is added).
-	// Typed as `readonly` to preserve the field slot for future use
-	// without re-touching the constructor.
+	// §3.4.4 telemetry parity. Currently consumed by the MistakeTracker's
+	// `onLimitTelemetry` hook (task.mistake_limit_reached); most other
+	// runtime telemetry is emitted host-side from the agent event stream
+	// (services/agent-events.ts).
 	readonly telemetry?: ITelemetryService;
 	private readonly conversation: ConversationStore;
 	private readonly mistakeTracker: MistakeTracker;
@@ -401,6 +402,22 @@ export class SessionRuntime {
 		this.mistakeTracker = new MistakeTracker({
 			maxConsecutiveMistakes: maxMistakes,
 			onLimitReached: config.onConsecutiveMistakeLimitReached,
+			onLimitTelemetry: (context) => {
+				// Read connection fields from `this.config` at fire time so a
+				// mid-session `updateConnection` is reflected in the event.
+				captureMistakeLimitReached(this.telemetry, {
+					ulid: this.config.sessionId ?? this.conversation.getConversationId(),
+					model: this.config.modelId,
+					provider: this.config.providerId,
+					reason: context.reason,
+					consecutiveMistakes: context.consecutiveMistakes,
+					maxConsecutiveMistakes: context.maxConsecutiveMistakes,
+					agentId: this.agentId,
+					conversationId: this.conversation.getConversationId(),
+					parentAgentId: this.parentAgentId,
+					isSubagent: Boolean(this.parentAgentId),
+				});
+			},
 			emit: (event) => this.emitLegacyEvent(event),
 			log: (level, message, metadata) =>
 				leveledLog(this.logger, level, message, metadata),

--- a/sdk/packages/core/src/runtime/safety/mistake-tracker.ts
+++ b/sdk/packages/core/src/runtime/safety/mistake-tracker.ts
@@ -60,6 +60,12 @@ export interface MistakeTrackerOptions {
 	) =>
 		| Promise<ConsecutiveMistakeLimitDecision>
 		| ConsecutiveMistakeLimitDecision;
+	/**
+	 * Observability hook fired exactly once per limit hit, right before the
+	 * limit decision is resolved — regardless of whether `onLimitReached` is
+	 * configured or what it decides. Used for telemetry.
+	 */
+	readonly onLimitTelemetry?: (ctx: ConsecutiveMistakeLimitContext) => void;
 	readonly emit: (event: AgentEvent) => void;
 	readonly log: LeveledLog;
 	readonly agentId: string;
@@ -107,14 +113,16 @@ export class MistakeTracker {
 			return { action: "continue" };
 		}
 
+		const limitContext: ConsecutiveMistakeLimitContext = {
+			iteration: input.iteration,
+			consecutiveMistakes: next,
+			maxConsecutiveMistakes: max,
+			reason: input.reason,
+			details: input.details,
+		};
+		this.options.onLimitTelemetry?.(limitContext);
 		const decision = await resolveConsecutiveMistakeDecision(
-			{
-				iteration: input.iteration,
-				consecutiveMistakes: next,
-				maxConsecutiveMistakes: max,
-				reason: input.reason,
-				details: input.details,
-			},
+			limitContext,
 			this.options.onLimitReached,
 		);
 

--- a/sdk/packages/core/src/services/telemetry/core-events.test.ts
+++ b/sdk/packages/core/src/services/telemetry/core-events.test.ts
@@ -9,6 +9,7 @@ import {
 	captureCompactionExecuted,
 	captureCompactionSkipped,
 	captureExtensionActivated,
+	captureMistakeLimitReached,
 	captureProviderConfigured,
 	captureRunCommandsTimeout,
 	captureTelemetryOptOut,
@@ -270,6 +271,35 @@ describe("captureWorkspacePathResolved", () => {
 		).not.toThrow();
 	});
 });
+
+describe("captureMistakeLimitReached", () => {
+	const baseProps = {
+		ulid: "sess-1",
+		model: "claude-3-5-sonnet",
+		provider: "anthropic",
+		reason: "tool_execution_failed",
+		consecutiveMistakes: 3,
+		maxConsecutiveMistakes: 3,
+	};
+
+	test("emits task.mistake_limit_reached with limit context and a timestamp", () => {
+		const stub = createTelemetryStub();
+		captureMistakeLimitReached(stub.telemetry, baseProps);
+		expect(stub.capture).toHaveBeenCalledTimes(1);
+		expect(stub.captureRequired).not.toHaveBeenCalled();
+		const { event, properties } = captureCallAt(stub, 0);
+		expect(event).toBe("task.mistake_limit_reached");
+		expect(properties).toMatchObject(baseProps);
+		expect(typeof properties?.timestamp).toBe("string");
+	});
+
+	test("no-ops when telemetry is undefined", () => {
+		expect(() =>
+			captureMistakeLimitReached(undefined, baseProps),
+		).not.toThrow();
+	});
+});
+
 describe("captureCompactionExecuted", () => {
 	const baseProps = {
 		ulid: "ulid-1",

--- a/sdk/packages/core/src/services/telemetry/core-events.ts
+++ b/sdk/packages/core/src/services/telemetry/core-events.ts
@@ -63,6 +63,7 @@ export const CORE_TELEMETRY_EVENTS = {
 		SKILL_USED: "task.skill_used",
 		DIFF_EDIT_FAILED: "task.diff_edit_failed",
 		PROVIDER_API_ERROR: "task.provider_api_error",
+		MISTAKE_LIMIT_REACHED: "task.mistake_limit_reached",
 		MENTION_USED: "task.mention_used",
 		MENTION_FAILED: "task.mention_failed",
 		MENTION_SEARCH_RESULTS: "task.mention_search_results",
@@ -486,6 +487,28 @@ export function captureProviderApiError(
 	emit(telemetry, CORE_TELEMETRY_EVENTS.TASK.PROVIDER_API_ERROR, {
 		...properties,
 		errorMessage: truncateErrorMessage(properties.errorMessage) ?? "unknown",
+		timestamp: new Date().toISOString(),
+	});
+}
+
+/**
+ * Records when the consecutive mistake limit is reached, right before the
+ * limit decision (host prompt / auto-stop) is resolved.
+ */
+export function captureMistakeLimitReached(
+	telemetry: ITelemetryService | undefined,
+	properties: {
+		ulid: string;
+		model: string;
+		provider?: string;
+		/** What kind of mistake tripped the limit. */
+		reason: string;
+		consecutiveMistakes: number;
+		maxConsecutiveMistakes: number;
+	} & Partial<TelemetryAgentIdentityProperties>,
+): void {
+	emit(telemetry, CORE_TELEMETRY_EVENTS.TASK.MISTAKE_LIMIT_REACHED, {
+		...properties,
 		timestamp: new Date().toISOString(),
 	});
 }


### PR DESCRIPTION
### Related Issue

Follow-up to #12354 (`task.mistake_limit_reached` telemetry).

### Description

#12354 added the `task.mistake_limit_reached` event, but captured it at the VS Code extension's callback boundary (`SdkController`'s `onConsecutiveMistakeLimitReached` wrapper). The mistake-limit *detection* lives in `@cline/core`'s `MistakeTracker`, which every host wires up — so the CLI, hub daemon, and any SDK consumer hit the same limit without emitting the event. This PR moves the capture into core so every host gets it for free, and removes the now-redundant extension-side wrapper so VS Code doesn't double-count.

**How it works:**

- `MistakeTracker` gains an `onLimitTelemetry` observability hook, fired **exactly once per limit hit**, right before the limit decision is resolved — regardless of whether an `onConsecutiveMistakeLimitReached` callback is configured or what it decides. Notably this also covers the default-stop path (no host callback configured), which the extension-side capture structurally missed: `resolveConsecutiveMistakeDecision` falls back to `{ action: "stop" }` without ever invoking the host callback, so a wrapper around that callback never fires there.
- `SessionRuntime` (the orchestrator) wires the hook to a new `captureMistakeLimitReached()` helper in `core-events.ts`, using its `telemetry` field — which was reserved in the code with a "§3.4.4 telemetry parity, not yet consumed" comment, i.e. exactly this purpose. The event name and property shape (`ulid`, `model`, `provider`, `reason`, `consecutiveMistakes`, `maxConsecutiveMistakes`, `timestamp`) match what #12354 shipped, plus the agent-identity properties (`agentId`, `conversationId`, `parentAgentId`, `isSubagent`) that other core task events carry.
- Connection fields are read from `this.config` **at fire time**, not captured in the closure, so a mid-session `updateConnection` (model/provider switch) is reflected in the event.

**Why not other approaches considered:**

- *Emit an `AgentNoticeEvent` with `reason: "mistake_limit"` (the schema slot already exists) and capture in `agent-events.ts` like `api_error` does:* notices are user-visible — the extension's message translator renders **every** notice as a `say: "info"` message, so this would inject a duplicate UI message right before the `mistake_limit_reached` ask. Rejected to keep this telemetry-only.
- *Wrap `onConsecutiveMistakeLimitReached` in the orchestrator or `local-runtime-host`:* an always-present wrapper changes the "no callback configured" semantics (the default-stop decision in `resolveConsecutiveMistakeDecision` would be bypassed or need duplicating). The tracker-level hook avoids touching decision semantics entirely.

**Host coverage after this change:**

| Host | Before | After |
|------|--------|-------|
| VS Code extension | ✅ via `SdkController` wrapper | ✅ via core (SDK telemetry handle → same PostHog pipeline + distinct-id) |
| CLI | ❌ | ✅ (already passes its telemetry service into core; zero CLI changes) |
| Hub daemon sessions | ❌ | ✅ (orchestrator runs in the daemon with daemon telemetry) |
| Default-stop path (no host callback) | ❌ | ✅ |

The extension's `TelemetryService.captureMistakeLimitReached` method and `MISTAKE_LIMIT_REACHED` event constant are removed along with the wrapper — leaving them would double-count every limit hit in VS Code. #12354 merged today and hasn't shipped in an extension release, so there's no dashboard-continuity concern with swapping the emission source; the event name and shape are unchanged either way.

### Test Procedure

- New orchestrator-level test: drives scripted failed-tool turns through the real `SessionRuntime` → `MistakeTracker` pipeline with `maxConsecutiveMistakes: 2` and asserts zero events after the first failed turn, then exactly one `task.mistake_limit_reached` with the full property payload after the second — with **no** `onConsecutiveMistakeLimitReached` configured, proving the default-stop path emits.
- New `core-events.test.ts` cases for `captureMistakeLimitReached` (event name, payload, timestamp, undefined-telemetry no-op), matching the existing helper-test pattern.
- Ran: `@cline/core` typecheck, `@cline/cli` typecheck, extension `check-types`, orchestrator suite (55/55), core-events + core TelemetryService suites, extension `SdkController.test.ts`, biome on all touched files. All green.
- Potential breakage considered: double-counting in VS Code (removed the ext wrapper in the same commit), changed limit-decision semantics (hook is fire-and-forget, added before `resolveConsecutiveMistakeDecision` without altering its inputs), and hosts with no telemetry configured (`captureMistakeLimitReached` no-ops on `undefined`, covered by test).

### Type of Change

-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [x] ♻️ Refactor Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

This needs an SDK release (`@cline/core` change) before the next CLI release — planned as SDK v0.0.63 followed by CLI v3.0.43.
