### PR TITLE
fix(vscode): inherit base-model capabilities for Bedrock custom-ARN native tool calls

### DIFF
--- a/apps/vscode/src/sdk/model-catalog/store.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/store.test.ts
@@ -1018,5 +1018,10 @@ describe("createProviderConfigStore", () => {
 
 		const capabilities = (selection.modelInfo as unknown as { capabilities?: string[] }).capabilities
 		expect(capabilities).toContain("tools")
+		// Capabilities are inherited from the base model, but the routed model id
+		// must remain the ARN — a Custom-ARN model is used precisely so requests
+		// route through the application-inference-profile (for AIP routing and
+		// billing attribution). Substituting the base id here would break that.
+		expect(selection.modelId).toBe(arn)
 	})
 })

--- a/apps/vscode/src/sdk/model-catalog/store.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/store.test.ts
@@ -989,4 +989,34 @@ describe("createProviderConfigStore", () => {
 		// the SDK's writeModelsFileSync enforces.
 		expect(() => StoredModelEntrySchema.parse(entry)).not.toThrow()
 	})
+
+	// Regression for #12302: a Bedrock Custom-ARN / application-inference-profile
+	// selection stores the raw ARN as its model id, which never matches a catalog
+	// entry. Without inheriting the configured base model's catalog capabilities,
+	// the resolved selection carries no "tools" capability, so no tool schema is
+	// sent while native tool_use/tool_result blocks still are, and Bedrock's
+	// Converse API rejects the request with a toolConfig-required 400.
+	it("inherits base-model capabilities for a Bedrock custom-ARN selection (#12302)", async () => {
+		const arn = "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123"
+		mocks.setGeneratedModels("bedrock", {
+			"anthropic.claude-opus-4-1": {
+				name: "Claude Opus 4.1",
+				contextWindow: 200_000,
+				maxTokens: 8_192,
+				supportsPromptCache: true,
+				capabilities: ["images", "tools", "reasoning", "prompt-cache"],
+			} as ModelInfo,
+		})
+		mocks.setApiConfiguration({
+			actModeApiProvider: "bedrock",
+			actModeApiModelId: arn,
+			actModeAwsBedrockCustomModelBaseId: "anthropic.claude-opus-4-1",
+		} as ApiConfiguration)
+
+		const { resolveRuntimeModelSelection } = await import("./store")
+		const selection = resolveRuntimeModelSelection(parseProviderId("bedrock"), arn)
+
+		const capabilities = (selection.modelInfo as unknown as { capabilities?: string[] }).capabilities
+		expect(capabilities).toContain("tools")
+	})
 })

--- a/apps/vscode/src/sdk/model-catalog/store.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/store.test.ts
@@ -1141,4 +1141,34 @@ describe("createProviderConfigStore", () => {
 		// the SDK's writeModelsFileSync enforces.
 		expect(() => StoredModelEntrySchema.parse(entry)).not.toThrow()
 	})
+
+	// Regression for #12302: a Bedrock Custom-ARN / application-inference-profile
+	// selection stores the raw ARN as its model id, which never matches a catalog
+	// entry. Without inheriting the configured base model's catalog capabilities,
+	// the resolved selection carries no "tools" capability, so no tool schema is
+	// sent while native tool_use/tool_result blocks still are, and Bedrock's
+	// Converse API rejects the request with a toolConfig-required 400.
+	it("inherits base-model capabilities for a Bedrock custom-ARN selection (#12302)", async () => {
+		const arn = "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123"
+		mocks.setGeneratedModels("bedrock", {
+			"anthropic.claude-opus-4-1": {
+				name: "Claude Opus 4.1",
+				contextWindow: 200_000,
+				maxTokens: 8_192,
+				supportsPromptCache: true,
+				capabilities: ["images", "tools", "reasoning", "prompt-cache"],
+			} as ModelInfo,
+		})
+		mocks.setApiConfiguration({
+			actModeApiProvider: "bedrock",
+			actModeApiModelId: arn,
+			actModeAwsBedrockCustomModelBaseId: "anthropic.claude-opus-4-1",
+		} as ApiConfiguration)
+
+		const { resolveRuntimeModelSelection } = await import("./store")
+		const selection = resolveRuntimeModelSelection(parseProviderId("bedrock"), arn)
+
+		const capabilities = (selection.modelInfo as unknown as { capabilities?: string[] }).capabilities
+		expect(capabilities).toContain("tools")
+	})
 })

--- a/apps/vscode/src/sdk/model-catalog/store.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/store.test.ts
@@ -1170,5 +1170,10 @@ describe("createProviderConfigStore", () => {
 
 		const capabilities = (selection.modelInfo as unknown as { capabilities?: string[] }).capabilities
 		expect(capabilities).toContain("tools")
+		// Capabilities are inherited from the base model, but the routed model id
+		// must remain the ARN — a Custom-ARN model is used precisely so requests
+		// route through the application-inference-profile (for AIP routing and
+		// billing attribution). Substituting the base id here would break that.
+		expect(selection.modelId).toBe(arn)
 	})
 })

--- a/apps/vscode/src/sdk/model-catalog/store.ts
+++ b/apps/vscode/src/sdk/model-catalog/store.ts
@@ -410,7 +410,46 @@ function readBaseModelInfoForProvider(providerId: ProviderId, modelId: string): 
 		}
 	}
 
+	// Bedrock Custom-ARN / application-inference-profile selections store the raw
+	// ARN as their model id, which never matches a catalog entry. Inherit the
+	// configured base model's catalog metadata (capabilities, context window,
+	// pricing) so a custom-ARN model advertises the same capabilities as the
+	// base model it proxies — without this, `capabilities` is empty and the
+	// "tools" capability is dropped, so native tool_use/tool_result blocks are
+	// sent with no tool schema and Bedrock's Converse API returns a 400 (#12302).
+	const bedrockBaseModelId = readBedrockCustomModelBaseId(providerId, modelId)
+	if (bedrockBaseModelId) {
+		return readBaseModelInfoForProvider(providerId, bedrockBaseModelId)
+	}
+
 	return undefined
+}
+
+/**
+ * For a Bedrock Custom-ARN selection whose model id is an ARN the catalog does
+ * not know, return the configured base model id (`{plan,act}ModeAwsBedrockCustomModelBaseId`)
+ * so capability metadata can be inherited from it. Returns undefined unless the
+ * provider is Bedrock, the requested id is not itself a known base id (avoids
+ * infinite recursion), and a distinct base id is configured.
+ *
+ * The base id is read mode-agnostically (`actMode ?? planMode`) because the
+ * store writes both keys to the same value in a single patch (see
+ * `writeStateFields`, which sets `planModeAwsBedrockCustomModelBaseId` and
+ * `actModeAwsBedrockCustomModelBaseId` together), so they never diverge through
+ * the store. If a future write path can set them independently, thread the
+ * active `mode` from `readSelectionFromState` down through `resolveSelection`
+ * and read the mode-specific key instead (as sibling call sites like
+ * `bedrock-config.ts` already do).
+ */
+function readBedrockCustomModelBaseId(providerId: ProviderId, modelId: string): string | undefined {
+	if (toSdkProviderId(providerId) !== "bedrock") {
+		return undefined
+	}
+	const apiConfiguration = StateManager.get().getApiConfiguration()
+	const baseId = (
+		apiConfiguration.actModeAwsBedrockCustomModelBaseId ?? apiConfiguration.planModeAwsBedrockCustomModelBaseId
+	)?.trim()
+	return baseId && baseId.length > 0 && baseId !== modelId ? baseId : undefined
 }
 
 function resolveSelection(selection: ModelSelection, stateModelInfoHint?: ModelInfo): ResolvedModelSelection {

--- a/apps/vscode/src/sdk/model-catalog/store.ts
+++ b/apps/vscode/src/sdk/model-catalog/store.ts
@@ -410,7 +410,46 @@ function readBaseModelInfoForProvider(providerId: ProviderId, modelId: string): 
 		}
 	}
 
+	// Bedrock Custom-ARN / application-inference-profile selections store the raw
+	// ARN as their model id, which never matches a catalog entry. Inherit the
+	// configured base model's catalog metadata (capabilities, context window,
+	// pricing) so a custom-ARN model advertises the same capabilities as the
+	// base model it proxies — without this, `capabilities` is empty and the
+	// "tools" capability is dropped, so native tool_use/tool_result blocks are
+	// sent with no tool schema and Bedrock's Converse API returns a 400 (#12302).
+	const bedrockBaseModelId = readBedrockCustomModelBaseId(providerId, modelId)
+	if (bedrockBaseModelId) {
+		return readBaseModelInfoForProvider(providerId, bedrockBaseModelId)
+	}
+
 	return undefined
+}
+
+/**
+ * For a Bedrock Custom-ARN selection whose model id is an ARN the catalog does
+ * not know, return the configured base model id (`{plan,act}ModeAwsBedrockCustomModelBaseId`)
+ * so capability metadata can be inherited from it. Returns undefined unless the
+ * provider is Bedrock, the requested id is not itself a known base id (avoids
+ * infinite recursion), and a distinct base id is configured.
+ *
+ * The base id is read mode-agnostically (`actMode ?? planMode`) because the
+ * store writes both keys to the same value in a single patch (see
+ * `writeStateFields`, which sets `planModeAwsBedrockCustomModelBaseId` and
+ * `actModeAwsBedrockCustomModelBaseId` together), so they never diverge through
+ * the store. If a future write path can set them independently, thread the
+ * active `mode` from `readSelectionFromState` down through `resolveSelection`
+ * and read the mode-specific key instead (as sibling call sites like
+ * `bedrock-config.ts` already do).
+ */
+function readBedrockCustomModelBaseId(providerId: ProviderId, modelId: string): string | undefined {
+	if (toSdkProviderId(providerId) !== "bedrock") {
+		return undefined
+	}
+	const apiConfiguration = StateManager.get().getApiConfiguration()
+	const baseId = (
+		apiConfiguration.actModeAwsBedrockCustomModelBaseId ?? apiConfiguration.planModeAwsBedrockCustomModelBaseId
+	)?.trim()
+	return baseId && baseId.length > 0 && baseId !== modelId ? baseId : undefined
 }
 
 interface BaseModelInfoHint {


### PR DESCRIPTION
Fixes #12302

## Root cause

A Bedrock **Custom-ARN / application-inference-profile** model stores the raw ARN as its model id. `readBaseModelInfoForProvider` (`apps/vscode/src/sdk/model-catalog/store.ts`) looks the id up in the model catalog, misses (the ARN is not a catalog key), and falls back to capability-less safe defaults. Because Bedrock models advertise native-tool support through the catalog `capabilities` array (which includes `tools`), the resolved model ends up with **no `tools` capability**. The SDK gateway's `toAiSdkTools` then returns `undefined` for the empty tool list, so no tool schema is sent - yet the request still contains native `tool_use`/`tool_result` blocks, and Bedrock's Converse API rejects it:

```
ValidationException: The toolConfig field must be defined when using toolUse and toolResult content blocks.
```

The configured base model id (`aws.customModelBaseId`), which *does* resolve in the catalog, was never consulted for capability inheritance.

## The fix

When a Bedrock model id misses the catalog, `readBaseModelInfoForProvider` now resolves the configured base model id (`{plan,act}ModeAwsBedrockCustomModelBaseId`) and inherits its catalog metadata (capabilities, context window, pricing). A Custom-ARN model therefore advertises the same capabilities - including `tools` - as the base model it proxies, so the tool schema is sent and the Converse request is valid.

- Localized to the resolution helper; a `baseId !== modelId` guard caps the recursion at depth 2 (the base id is a constant state read), so a typo'd or ARN-valued base id can't loop.
- The base id is read mode-agnostically (`actMode ?? planMode`) because the store writes both mode keys in a single patch and they never diverge through it; a code comment notes mode-threading as the follow-up if a future write path can set them independently.

## Testing

- `cd apps/vscode && bunx vitest run --config vitest.config.ts src/sdk/model-catalog/store.test.ts` - 37 passing, including a new regression test that asserts a Custom-ARN selection inherits the base model's `tools` capability (fails on `main`: capabilities are `undefined`).
- `bunx vitest run --config vitest.config.ts src/sdk` - 766 passing (no regressions in capability resolution).
- `bunx tsc --noEmit -p .` - clean. `bunx biome check` on the changed files - clean.