### PR TITLE
fix(vscode): make 'Proceed While Running' sticky to the command batch

### DIFF
--- a/apps/vscode/src/sdk/vscode-run-commands-tool.test.ts
+++ b/apps/vscode/src/sdk/vscode-run-commands-tool.test.ts
@@ -175,6 +175,7 @@ function createControllableTerminalProcess() {
 	return {
 		process: fakeProcess as unknown as ReturnType<VscodeTerminalManager["runCommand"]>,
 		emitLine: (line: string) => emitter.emit("line", line),
+		fail: (error: Error) => emitter.emit("error", error),
 		complete: (details?: TerminalCompletionDetails) => {
 			emitter.emit("completed", details)
 			emitter.emit("continue")
@@ -358,6 +359,7 @@ describe("executeForeground — Proceed While Running", () => {
 		const resultPromise = executeForeground("devserver", "/workspace", terminalManager, 100_000, undefined, coordinator)
 
 		await waitFor(() => coordinator.isRunning)
+		await waitFor(() => process.listenerCount("line") > 0)
 		emitLine("listening on :3000")
 
 		expect(coordinator.proceedWhileRunning()).toBe(1)
@@ -411,6 +413,7 @@ describe("executeForeground — Proceed While Running", () => {
 		)
 
 		await waitFor(() => coordinator.isRunning)
+		await waitFor(() => first.process.listenerCount("line") > 0 && second.process.listenerCount("line") > 0)
 		first.emitLine("first output")
 		second.emitLine("second output")
 
@@ -442,6 +445,267 @@ describe("executeForeground — Proceed While Running", () => {
 		fs.rmSync(secondLog!, { force: true })
 	})
 
+	it("registers with the coordinator before terminal acquisition", async () => {
+		const coordinator = new SdkForegroundCommandCoordinator()
+		const { process, complete } = createControllableTerminalProcess()
+		// A terminal acquisition that never settles until released — the
+		// registration must not wait for it.
+		let releaseTerminal!: () => void
+		const terminalGate = new Promise<void>((resolve) => {
+			releaseTerminal = resolve
+		})
+		const terminalManager = {
+			getOrCreateTerminal: async () => {
+				await terminalGate
+				return { terminal: { show: () => {} } } as never
+			},
+			runCommand: () => process,
+		} as unknown as VscodeTerminalManager
+
+		const resultPromise = executeForeground("slow-acquire", "/workspace", terminalManager, 1000, undefined, coordinator)
+
+		await waitFor(() => coordinator.isRunning)
+		releaseTerminal()
+		await waitFor(() => process.listenerCount("line") > 0)
+		complete({ exitCode: 0 })
+		await resultPromise
+		expect(coordinator.isRunning).toBe(false)
+	})
+
+	it("unregisters when terminal acquisition fails", async () => {
+		const coordinator = new SdkForegroundCommandCoordinator()
+		let rejectTerminal!: (error: Error) => void
+		const terminalGate = new Promise<never>((_, reject) => {
+			rejectTerminal = reject
+		})
+		const terminalManager = {
+			getOrCreateTerminal: () => terminalGate,
+			runCommand: vi.fn(),
+		} as unknown as VscodeTerminalManager
+
+		const resultPromise = executeForeground("failed-acquire", "/workspace", terminalManager, 1000, undefined, coordinator)
+
+		expect(coordinator.isRunning).toBe(true)
+		rejectTerminal(new Error("terminal unavailable"))
+		await expect(resultPromise).rejects.toThrow("terminal unavailable")
+		expect(coordinator.isRunning).toBe(false)
+		expect(terminalManager.runCommand).not.toHaveBeenCalled()
+	})
+
+	it("aborts during terminal acquisition without starting the command later", async () => {
+		const coordinator = new SdkForegroundCommandCoordinator()
+		const abortController = new AbortController()
+		let releaseTerminal!: () => void
+		const terminalGate = new Promise<void>((resolve) => {
+			releaseTerminal = resolve
+		})
+		const runCommand = vi.fn()
+		const terminalManager = {
+			getOrCreateTerminal: async () => {
+				await terminalGate
+				return { terminal: { show: () => {} } } as never
+			},
+			runCommand,
+		} as unknown as VscodeTerminalManager
+
+		const resultPromise = executeForeground(
+			"cancelled-before-start",
+			"/workspace",
+			terminalManager,
+			1000,
+			abortController.signal,
+			coordinator,
+		)
+
+		expect(coordinator.isRunning).toBe(true)
+		abortController.abort()
+		await expect(resultPromise).rejects.toThrow("Command execution aborted")
+		expect(coordinator.isRunning).toBe(false)
+
+		releaseTerminal()
+		await new Promise((resolve) => setTimeout(resolve, 0))
+		expect(runCommand).not.toHaveBeenCalled()
+	})
+
+	it("detach requested during terminal acquisition applies once the command starts", async () => {
+		const coordinator = new SdkForegroundCommandCoordinator()
+		const { process, emitLine, complete } = createControllableTerminalProcess()
+		let releaseTerminal!: () => void
+		const terminalGate = new Promise<void>((resolve) => {
+			releaseTerminal = resolve
+		})
+		const terminalManager = {
+			getOrCreateTerminal: async () => {
+				await terminalGate
+				return { terminal: { show: () => {} } } as never
+			},
+			runCommand: () => process,
+		} as unknown as VscodeTerminalManager
+
+		const resultPromise = executeForeground("late-cmd", "/workspace", terminalManager, 100_000, undefined, coordinator)
+		await waitFor(() => coordinator.isRunning)
+
+		// Proceed While Running fires while this command is still waiting for
+		// its terminal. The detach must stick: once the command starts, it
+		// resolves as detached instead of re-blocking the turn.
+		expect(coordinator.proceedWhileRunning()).toBe(1)
+		const result = await resultPromise
+		expect(result).toContain("still running")
+		expect(coordinator.isRunning).toBe(false)
+
+		// The tool result settles before terminal acquisition. Once the bounded
+		// acquisition finishes, the approved command starts and streams to the log.
+		const logFilePath = /redirected to this file[^:]*: (.+)$/m.exec(result)?.[1]?.trim()
+		expect(logFilePath).toBeTruthy()
+		releaseTerminal()
+		await waitFor(() => process.listenerCount("line") > 0)
+		emitLine("started late")
+		complete({ exitCode: 0 })
+		await waitFor(() => {
+			try {
+				return fs.readFileSync(logFilePath!, "utf8").includes("[Command completed with exit code 0]")
+			} catch {
+				return false
+			}
+		})
+		expect(fs.readFileSync(logFilePath!, "utf8")).toContain("started late")
+		fs.rmSync(logFilePath!, { force: true })
+	})
+
+	it("records terminal acquisition failure after detach in the promised log", async () => {
+		const coordinator = new SdkForegroundCommandCoordinator()
+		let rejectTerminal!: (error: Error) => void
+		const terminalGate = new Promise<never>((_, reject) => {
+			rejectTerminal = reject
+		})
+		const terminalManager = {
+			getOrCreateTerminal: () => terminalGate,
+			runCommand: vi.fn(),
+		} as unknown as VscodeTerminalManager
+
+		const resultPromise = executeForeground(
+			"failed-after-detach",
+			"/workspace",
+			terminalManager,
+			1000,
+			undefined,
+			coordinator,
+		)
+		expect(coordinator.proceedWhileRunning()).toBe(1)
+		const result = await resultPromise
+		const logFilePath = /redirected to this file[^:]*: (.+)$/m.exec(result)?.[1]?.trim()
+		expect(logFilePath).toBeTruthy()
+		expect(coordinator.isRunning).toBe(false)
+
+		rejectTerminal(new Error("terminal unavailable"))
+		await waitFor(() => {
+			try {
+				return fs.readFileSync(logFilePath!, "utf8").includes("terminal unavailable")
+			} catch {
+				return false
+			}
+		})
+		expect(terminalManager.runCommand).not.toHaveBeenCalled()
+		fs.rmSync(logFilePath!, { force: true })
+	})
+
+	it("records a detached process failure after the tool result settles", async () => {
+		const coordinator = new SdkForegroundCommandCoordinator()
+		const { process, fail } = createControllableTerminalProcess()
+		const resultPromise = executeForeground(
+			"failed-process",
+			"/workspace",
+			createFakeTerminalManager(process),
+			1000,
+			undefined,
+			coordinator,
+		)
+
+		await waitFor(() => process.listenerCount("line") > 0)
+		expect(coordinator.proceedWhileRunning()).toBe(1)
+		const result = await resultPromise
+		const logFilePath = /redirected to this file[^:]*: (.+)$/m.exec(result)?.[1]?.trim()
+		expect(logFilePath).toBeTruthy()
+
+		fail(new Error("terminal process failed"))
+		await waitFor(() => {
+			try {
+				return fs.readFileSync(logFilePath!, "utf8").includes("terminal process failed")
+			} catch {
+				return false
+			}
+		})
+		expect(process.listenerCount("line")).toBe(0)
+		fs.rmSync(logFilePath!, { force: true })
+	})
+
+	it("detaches a whole parallel batch even when one command is still awaiting its terminal", async () => {
+		const coordinator = new SdkForegroundCommandCoordinator()
+		const first = createControllableTerminalProcess()
+		const second = createControllableTerminalProcess()
+		let releaseSecondTerminal!: () => void
+		const secondTerminalGate = new Promise<void>((resolve) => {
+			releaseSecondTerminal = resolve
+		})
+		const secondTerminalManager = {
+			getOrCreateTerminal: async () => {
+				await secondTerminalGate
+				return { terminal: { show: () => {} } } as never
+			},
+			runCommand: () => second.process,
+		} as unknown as VscodeTerminalManager
+
+		const firstPromise = executeForeground(
+			"first-cmd",
+			"/workspace",
+			createFakeTerminalManager(first.process),
+			100_000,
+			undefined,
+			coordinator,
+		)
+		const secondPromise = executeForeground(
+			"second-cmd",
+			"/workspace",
+			secondTerminalManager,
+			100_000,
+			undefined,
+			coordinator,
+		)
+		await waitFor(() => coordinator.isRunning)
+
+		// The user clicks Proceed While Running while the second command is
+		// still waiting for a terminal; both must be counted and both must
+		// resolve detached — the late one must not keep the turn blocked.
+		expect(coordinator.proceedWhileRunning()).toBe(2)
+		const [firstResult, secondResult] = await Promise.all([firstPromise, secondPromise])
+		expect(firstResult).toContain("still running")
+		expect(secondResult).toContain("still running")
+		expect(coordinator.isRunning).toBe(false)
+
+		const logFilePaths = [firstResult, secondResult].map((result) =>
+			/redirected to this file[^:]*: (.+)$/m.exec(result)?.[1]?.trim(),
+		)
+		for (const logFilePath of logFilePaths) {
+			expect(logFilePath).toBeTruthy()
+		}
+		releaseSecondTerminal()
+		await waitFor(() => first.process.listenerCount("line") > 0 && second.process.listenerCount("line") > 0)
+		first.complete()
+		second.complete()
+		await waitFor(() =>
+			logFilePaths.every((logFilePath) => {
+				try {
+					return fs.readFileSync(logFilePath!, "utf8").includes("[Command completed]")
+				} catch {
+					return false
+				}
+			}),
+		)
+		for (const logFilePath of logFilePaths) {
+			fs.rmSync(logFilePath!, { force: true })
+		}
+	})
+
 	it("stops logging before a line that would exceed the size cap", async () => {
 		const coordinator = new SdkForegroundCommandCoordinator()
 		const { process, emitLine, complete } = createControllableTerminalProcess()
@@ -449,6 +713,7 @@ describe("executeForeground — Proceed While Running", () => {
 
 		const resultPromise = executeForeground("devserver", "/workspace", terminalManager, 100_000, undefined, coordinator)
 		await waitFor(() => coordinator.isRunning)
+		await waitFor(() => process.listenerCount("line") > 0)
 
 		expect(coordinator.proceedWhileRunning()).toBe(1)
 		const result = await resultPromise
@@ -486,6 +751,7 @@ describe("executeForeground — Proceed While Running", () => {
 
 		const resultPromise = executeForeground("devserver", "/workspace", terminalManager, 100_000, undefined, coordinator)
 		await waitFor(() => coordinator.isRunning)
+		await waitFor(() => process.listenerCount("line") > 0)
 		emitLine("x".repeat(PROCEED_LOG_MAX_BYTES))
 
 		expect(coordinator.proceedWhileRunning()).toBe(1)
@@ -515,6 +781,7 @@ describe("executeForeground — Proceed While Running", () => {
 
 		const resultPromise = executeForeground("devserver", "/workspace", terminalManager, 100_000, undefined, coordinator)
 		await waitFor(() => coordinator.isRunning)
+		await waitFor(() => process.listenerCount("line") > 0)
 		emitLine("before detach")
 
 		expect(coordinator.proceedWhileRunning()).toBe(1)

--- a/apps/vscode/src/sdk/vscode-run-commands-tool.ts
+++ b/apps/vscode/src/sdk/vscode-run-commands-tool.ts
@@ -98,11 +98,17 @@ export function formatCommandForTerminal(command: ShellCommand): string {
  * Stream the rest of a detached command's output to a log file: write the
  * lines buffered so far, then append each further 'line' event until
  * 'completed'. The write volume is capped at PROCEED_LOG_MAX_BYTES; the
- * stream is always closed by the 'completed' event, which the terminal
- * process emits on every exit path (command end, Ctrl+C, terminal closed,
- * markerless fallback).
+ * stream is closed when the command completes or its process/acquisition
+ * fails. Completion covers command end, Ctrl+C, terminal close, and the
+ * markerless fallback.
  */
-function beginLogCapture(process: ITerminalProcess, terminalCommand: string, existingLines: string[]): string {
+interface DetachedCommandLog {
+	path: string
+	attach(process: ITerminalProcess): void
+	fail(error: unknown): void
+}
+
+function createDetachedCommandLog(terminalCommand: string, existingLines: string[]): DetachedCommandLog {
 	const logFilePath = ClineTempManager.createTempFilePath("proceed-while-running")
 	const stream = fs.createWriteStream(logFilePath, { flags: "a" })
 	const sizeCapMessage = `[Log size cap of ${PROCEED_LOG_MAX_BYTES} bytes reached; further output is not logged.]`
@@ -130,32 +136,67 @@ function beginLogCapture(process: ITerminalProcess, terminalCommand: string, exi
 		}
 	}
 
-	const onLine = (line: string): void => {
-		// Check the cap before writing: a single huge line (e.g. a dumped
-		// binary blob or minified bundle) must not blow past the cap.
-		if (!tryWriteLine(line)) {
-			tryWriteLine(sizeCapMessage)
-			process.removeListener("line", onLine)
+	let settled = false
+	let removeAttachedListeners = (): void => {}
+	const end = (message: string): void => {
+		if (settled) {
+			return
 		}
-	}
-	if (sizeCapReached) {
-		tryWriteLine(sizeCapMessage)
-	} else {
-		process.on("line", onLine)
-	}
-	process.once("completed", (details) => {
-		process.removeListener("line", onLine)
-		const exitCode = details?.exitCode
-		tryWriteLine(
-			exitCode !== undefined && exitCode !== null
-				? `[Command completed with exit code ${exitCode}]`
-				: "[Command completed]",
-		)
+		settled = true
+		removeAttachedListeners()
+		tryWriteLine(message)
 		stream.end()
-	})
+	}
 
-	return logFilePath
+	return {
+		path: logFilePath,
+		attach: (process) => {
+			const onLine = (line: string): void => {
+				// Check the cap before writing: a single huge line (e.g. a dumped
+				// binary blob or minified bundle) must not blow past the cap.
+				if (!tryWriteLine(line)) {
+					tryWriteLine(sizeCapMessage)
+					process.removeListener("line", onLine)
+				}
+			}
+			const onCompleted = (details?: { exitCode?: number | null }): void => {
+				const exitCode = details?.exitCode
+				end(
+					exitCode !== undefined && exitCode !== null
+						? `[Command completed with exit code ${exitCode}]`
+						: "[Command completed]",
+				)
+			}
+			const onError = (error: Error): void => end(`[Command failed before log capture completed: ${error.message}]`)
+			removeAttachedListeners = () => {
+				process.removeListener("line", onLine)
+				process.removeListener("completed", onCompleted)
+				process.removeListener("error", onError)
+			}
+			if (sizeCapReached) {
+				tryWriteLine(sizeCapMessage)
+			} else {
+				process.on("line", onLine)
+			}
+			process.once("completed", onCompleted)
+			process.once("error", onError)
+		},
+		fail: (error) => {
+			const message = error instanceof Error ? error.message : String(error)
+			end(`[Command failed before log capture completed: ${message}]`)
+		},
+	}
 }
+
+function formatDetachedResult(logFilePath: string, output: string): string {
+	return [
+		"The user chose to proceed while the command is starting or still running in their terminal.",
+		`This is partial output; further output is being redirected to this file, which you can read to check progress: ${logFilePath}`,
+		output.length > 0 ? `Output so far:\n${output}` : "No output so far.",
+	].join("\n")
+}
+
+type PreStartControl = "detach" | "abort"
 
 /** Exported for direct unit testing of the CommandExitError/terminalClosed mapping. */
 export async function executeForeground(
@@ -168,56 +209,148 @@ export async function executeForeground(
 	terminalProfileId?: string,
 ): Promise<string> {
 	const terminalCommand = formatCommandForTerminal(command)
-	const terminalInfo = await terminalManager.getOrCreateTerminal(cwd, terminalProfileId)
-	terminalInfo.terminal.show()
-
-	const process = terminalManager.runCommand(terminalInfo, terminalCommand)
-	const outputLines: string[] = []
-	let droppedLines = 0
-
-	// Accumulate output lines to return the full output once the command completes.
-	// The chat shows command output at completion, not incrementally.
-	//
-	// This is a second buffer on top of the process's own `fullOutput` (capped at
-	// MAX_FULL_OUTPUT_SIZE — see VscodeTerminalProcess), so it needs its own cap:
-	// a long-running command emitting many lines must not accumulate them here
-	// without bound. Once the cap is hit, keep only the head and tail — matching
-	// truncateCommandOutput's own head/tail strategy below — since build/test
-	// failures usually appear at the end of output.
-	const maxBufferedLines = MAX_UNRETRIEVED_LINES
-	const bufferLine = (line: string): void => {
-		if (outputLines.length < maxBufferedLines) {
-			outputLines.push(line)
-		} else {
-			outputLines.shift()
-			outputLines.push(line)
-			droppedLines++
-		}
-	}
-	process.on("line", bufferLine)
-
-	// Handle abort signal
-	if (abortSignal) {
-		const onAbort = () => {
-			process.continue()
-		}
-		const cleanupAbortListener = () => abortSignal.removeEventListener("abort", onAbort)
-		abortSignal.addEventListener("abort", onAbort, { once: true })
-		process.once("completed", cleanupAbortListener)
-		process.once("continue", cleanupAbortListener)
-	}
 
 	// "Proceed While Running": register a per-invocation handle so the user
 	// can detach this command. Detaching redirects the remaining output to a
 	// log file and resolves the awaited promise; the command keeps running in
 	// the user's terminal (and the terminal stays busy until it completes).
-	let detachedLogFilePath: string | undefined
+	//
+	// Registered BEFORE terminal acquisition so every command in a parallel
+	// run_commands batch is registered before the user can click the button.
+	// A command still awaiting its terminal when the user detaches records the
+	// request and applies it the moment its process starts — otherwise that
+	// late command would re-block the turn the button just released.
+	const state: { phase: "waiting" | "started" | "detached" | "aborted" } = { phase: "waiting" }
+	let detachedLog: DetachedCommandLog | undefined
+	let applyDetach: (() => void) | undefined
+	let resolvePreStartControl!: (control: PreStartControl) => void
+	const preStartControl = new Promise<PreStartControl>((resolve) => {
+		resolvePreStartControl = resolve
+	})
 	const unregister = foregroundCommands?.register({
 		detach: () => {
-			if (detachedLogFilePath !== undefined) {
+			if (state.phase === "waiting") {
+				state.phase = "detached"
+				detachedLog = createDetachedCommandLog(terminalCommand, [])
+				telemetryService.captureTerminalUserIntervention(TerminalUserInterventionAction.PROCESS_WHILE_RUNNING, "vscode")
+				resolvePreStartControl("detach")
+			} else if (state.phase === "started") {
+				applyDetach?.()
+			}
+		},
+	})
+	const onAbort = (): void => {
+		if (state.phase === "waiting") {
+			state.phase = "aborted"
+			resolvePreStartControl("abort")
+		} else if (state.phase === "started") {
+			applyAbort?.()
+		}
+	}
+	let applyAbort: (() => void) | undefined
+	abortSignal?.addEventListener("abort", onAbort, { once: true })
+	if (abortSignal?.aborted) {
+		onAbort()
+	}
+
+	try {
+		const terminalPromise = terminalManager.getOrCreateTerminal(cwd, terminalProfileId)
+		const startDetached = (terminalInfo: Awaited<typeof terminalPromise>, log: DetachedCommandLog): void => {
+			try {
+				terminalInfo.terminal.show()
+				const process = terminalManager.runCommand(terminalInfo, terminalCommand)
+				log.attach(process)
+				void process.catch((error) => log.fail(error))
+				process.detach()
+			} catch (error) {
+				log.fail(error)
+			}
+		}
+		const acquisition = terminalPromise.then(
+			(terminalInfo) => ({ type: "terminal" as const, terminalInfo }),
+			(error: unknown) => ({ type: "error" as const, error }),
+		)
+		const finishDetachedAcquisition = (outcome: Awaited<typeof acquisition>, log: DetachedCommandLog): void => {
+			if (outcome.type === "terminal") {
+				startDetached(outcome.terminalInfo, log)
+			} else {
+				log.fail(outcome.error)
+			}
+		}
+		const firstOutcome = await Promise.race([
+			acquisition,
+			preStartControl.then((control) => ({ type: "control" as const, control })),
+		])
+
+		if (firstOutcome.type === "control") {
+			if (firstOutcome.control === "abort") {
+				throw new Error("Command execution aborted")
+			}
+
+			const log = detachedLog
+			if (!log) {
+				throw new Error("Detached command log was not initialized")
+			}
+			void acquisition.then((outcome) => finishDetachedAcquisition(outcome, log))
+			return formatDetachedResult(log.path, "")
+		}
+
+		// Acquisition and a user action can resolve in the same microtask turn.
+		// Re-check the invocation phase after the await so an already-queued
+		// terminal outcome cannot overwrite a detach or abort that happened while
+		// the promise continuation was pending.
+		if (state.phase === "aborted") {
+			throw new Error("Command execution aborted")
+		}
+		if (state.phase === "detached") {
+			const log = detachedLog
+			if (!log) {
+				throw new Error("Detached command log was not initialized")
+			}
+			finishDetachedAcquisition(firstOutcome, log)
+			return formatDetachedResult(log.path, "")
+		}
+		if (firstOutcome.type === "error") {
+			throw firstOutcome.error
+		}
+
+		state.phase = "started"
+		const { terminalInfo } = firstOutcome
+		terminalInfo.terminal.show()
+
+		const process = terminalManager.runCommand(terminalInfo, terminalCommand)
+		const outputLines: string[] = []
+		let droppedLines = 0
+
+		// Accumulate output lines to return the full output once the command completes.
+		// The chat shows command output at completion, not incrementally.
+		//
+		// This is a second buffer on top of the process's own `fullOutput` (capped at
+		// MAX_FULL_OUTPUT_SIZE — see VscodeTerminalProcess), so it needs its own cap:
+		// a long-running command emitting many lines must not accumulate them here
+		// without bound. Once the cap is hit, keep only the head and tail — matching
+		// truncateCommandOutput's own head/tail strategy below — since build/test
+		// failures usually appear at the end of output.
+		const maxBufferedLines = MAX_UNRETRIEVED_LINES
+		const bufferLine = (line: string): void => {
+			if (outputLines.length < maxBufferedLines) {
+				outputLines.push(line)
+			} else {
+				outputLines.shift()
+				outputLines.push(line)
+				droppedLines++
+			}
+		}
+		process.on("line", bufferLine)
+
+		applyAbort = () => process.continue()
+
+		applyDetach = () => {
+			if (detachedLog !== undefined) {
 				return
 			}
-			detachedLogFilePath = beginLogCapture(process, terminalCommand, outputLines)
+			detachedLog = createDetachedCommandLog(terminalCommand, outputLines)
+			detachedLog.attach(process)
 			telemetryService.captureTerminalUserIntervention(TerminalUserInterventionAction.PROCESS_WHILE_RUNNING, "vscode")
 			// detach() flushes any partial line (reaching both bufferLine and
 			// the log) before resolving the awaited promise. After that the
@@ -225,65 +358,61 @@ export async function executeForeground(
 			// (log-only) output doesn't mutate outputLines while it's read.
 			process.detach()
 			process.removeListener("line", bufferLine)
-		},
-	})
+		}
 
-	try {
 		// Wait for completion (or detach, which also resolves the promise)
 		await process
+
+		if (abortSignal?.aborted) {
+			throw new Error("Command execution aborted")
+		}
+
+		const bufferedOutput =
+			droppedLines > 0
+				? [...outputLines, `\n... (${droppedLines} earlier lines dropped) ...\n`].join("\n")
+				: outputLines.join("\n")
+		const output = truncateCommandOutput(bufferedOutput.trim(), {
+			maxChars: maxOutputChars,
+		})
+
+		if (detachedLog !== undefined) {
+			return formatDetachedResult(detachedLog.path, output)
+		}
+
+		const completionDetails = process.getCompletionDetails?.()
+
+		// A terminal closed mid-command has no exit code and no reliable output —
+		// whatever the command was doing (e.g. running a test suite) was interrupted,
+		// so this must never look like success to the agent.
+		if (completionDetails?.terminalClosed) {
+			const result =
+				output.length > 0
+					? `[Terminal closed while the command was running; output may be incomplete]\n${output}`
+					: "[Terminal closed while the command was running; no output was captured]"
+			throw new CommandExitError(1, result)
+		}
+
+		// Plumb the exit code from onDidEndTerminalShellExecution through to the tool
+		// result. When shell integration reports a non-zero exit code, throw
+		// CommandExitError so the SDK's shell tool wrapper marks the result as
+		// `success: false` and includes the exit code in the error message —
+		// matching the background (child_process) executor's behavior.
+		// If no exit code was captured (shell integration present but not reporting
+		// completion for this execution — e.g. a command run inside an ssh session),
+		// we can't determine success/failure, so we return the output as-is
+		// (success: true).
+		const exitCode = completionDetails?.exitCode
+		if (exitCode !== undefined && exitCode !== null && exitCode !== 0) {
+			const result =
+				output.length > 0 ? `[Command exited with code ${exitCode}]\n${output}` : `[Command exited with code ${exitCode}]`
+			throw new CommandExitError(exitCode, result)
+		}
+
+		return output
 	} finally {
+		abortSignal?.removeEventListener("abort", onAbort)
 		unregister?.()
 	}
-	if (abortSignal?.aborted) {
-		throw new Error("Command execution aborted")
-	}
-
-	const bufferedOutput =
-		droppedLines > 0
-			? [...outputLines, `\n... (${droppedLines} earlier lines dropped) ...\n`].join("\n")
-			: outputLines.join("\n")
-	const output = truncateCommandOutput(bufferedOutput.trim(), {
-		maxChars: maxOutputChars,
-	})
-
-	if (detachedLogFilePath !== undefined) {
-		return [
-			"The user chose to proceed while the command is still running in their terminal.",
-			`This is partial output; further output is being redirected to this file, which you can read to check progress: ${detachedLogFilePath}`,
-			output.length > 0 ? `Output so far:\n${output}` : "No output so far.",
-		].join("\n")
-	}
-
-	const completionDetails = process.getCompletionDetails?.()
-
-	// A terminal closed mid-command has no exit code and no reliable output —
-	// whatever the command was doing (e.g. running a test suite) was interrupted,
-	// so this must never look like success to the agent.
-	if (completionDetails?.terminalClosed) {
-		const result =
-			output.length > 0
-				? `[Terminal closed while the command was running; output may be incomplete]\n${output}`
-				: "[Terminal closed while the command was running; no output was captured]"
-		throw new CommandExitError(1, result)
-	}
-
-	// Plumb the exit code from onDidEndTerminalShellExecution through to the tool
-	// result. When shell integration reports a non-zero exit code, throw
-	// CommandExitError so the SDK's shell tool wrapper marks the result as
-	// `success: false` and includes the exit code in the error message —
-	// matching the background (child_process) executor's behavior.
-	// If no exit code was captured (shell integration present but not reporting
-	// completion for this execution — e.g. a command run inside an ssh session),
-	// we can't determine success/failure, so we return the output as-is
-	// (success: true).
-	const exitCode = completionDetails?.exitCode
-	if (exitCode !== undefined && exitCode !== null && exitCode !== 0) {
-		const result =
-			output.length > 0 ? `[Command exited with code ${exitCode}]\n${output}` : `[Command exited with code ${exitCode}]`
-		throw new CommandExitError(exitCode, result)
-	}
-
-	return output
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### Related Issue

Follow-up to #12320 (review feedback: https://github.com/cline/cline/pull/12320#pullrequestreview-4710747297).

### Description

Foreground commands in one parallel `run_commands` invocation share the user's **Proceed While Running** decision. Terminal acquisition can suspend some commands before they start, so a one-shot detach previously missed late commands and kept the turn blocked.

This PR registers every foreground invocation before terminal acquisition. A pre-start detach settles that tool result immediately and transfers the approved command to an owned detached lifecycle that logs acquisition, output, completion, or failure. A pre-start cancellation unregisters the invocation and prevents it from starting later. The decision remains scoped to that command batch.

### Test Procedure

```bash
cd apps/vscode
bunx vitest run --config vitest.config.ts src/sdk/vscode-run-commands-tool.test.ts
bunx tsc --noEmit
bunx tsc --project tsconfig.vscode-compat.json --noEmit
cd webview-ui && bunx tsc --noEmit
```

Verified locally: 33 focused tests pass; extension, VS Code compatibility, and webview typechecks pass; Biome passes on both changed files.

Manual: in `vscodeTerminal` mode, run a parallel `run_commands` batch while one command is still acquiring a terminal, click **Proceed While Running**, and verify the turn continues immediately with a separate log path for every command.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Cosmetic change
- [ ] Documentation update
- [ ] Workflow change

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore
- [x] Relevant tests, typechecks, formatting, and lint checks pass
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

The partial-line buffer cap and Cancel-vs-running-command concerns from #12320 are addressed separately.