### PR TITLE
fix: honor MCP stdio timeout during initialize

### DIFF
--- a/sdk/packages/core/src/extensions/mcp/client.ts
+++ b/sdk/packages/core/src/extensions/mcp/client.ts
@@ -140,9 +140,13 @@ class StdioMcpClient implements McpServerClient {
 	private stderrBuffer = "";
 	private connected = false;
 	private protocolMode: StdioProtocolMode = "newline";
+	private readonly requestTimeoutMs: number;
+	private readonly connectTimeoutMs: number;
 
 	constructor(registration: McpServerRegistration) {
 		this.registration = registration;
+		this.requestTimeoutMs = registration.timeoutMs ?? MCP_REQUEST_TIMEOUT_MS;
+		this.connectTimeoutMs = registration.timeoutMs ?? MCP_CONNECT_TIMEOUT_MS;
 	}
 
 	async connect(): Promise<void> {
@@ -172,7 +176,7 @@ class StdioMcpClient implements McpServerClient {
 							version: "0.0.0",
 						},
 					},
-					MCP_CONNECT_TIMEOUT_MS,
+					this.connectTimeoutMs,
 				);
 				this.notify("notifications/initialized");
 				this.connected = true;
@@ -360,7 +364,7 @@ class StdioMcpClient implements McpServerClient {
 	private async request(
 		method: string,
 		params?: Record<string, unknown>,
-		timeoutMs = MCP_REQUEST_TIMEOUT_MS,
+		timeoutMs = this.requestTimeoutMs,
 	): Promise<unknown> {
 		const child = this.process;
 		if (!child?.stdin.writable) {

--- a/sdk/packages/core/src/extensions/mcp/config-loader.test.ts
+++ b/sdk/packages/core/src/extensions/mcp/config-loader.test.ts
@@ -52,6 +52,7 @@ describe("mcp config loader", () => {
 								command: "npx",
 								args: ["-y", "@modelcontextprotocol/server-filesystem"],
 							},
+							timeoutMs: 12_000,
 						},
 						search: {
 							transport: {
@@ -59,6 +60,7 @@ describe("mcp config loader", () => {
 								url: "https://mcp.example.com",
 							},
 							disabled: true,
+							timeout: 30,
 						},
 					},
 				},
@@ -83,6 +85,7 @@ describe("mcp config loader", () => {
 					args: ["-y", "@modelcontextprotocol/server-filesystem"],
 				},
 				disabled: undefined,
+				timeoutMs: 12_000,
 				metadata: undefined,
 				oauth: undefined,
 			},
@@ -93,6 +96,7 @@ describe("mcp config loader", () => {
 					url: "https://mcp.example.com",
 				},
 				disabled: true,
+				timeoutMs: 30_000,
 				metadata: undefined,
 				oauth: undefined,
 			},

--- a/sdk/packages/core/src/extensions/mcp/config-loader.ts
+++ b/sdk/packages/core/src/extensions/mcp/config-loader.ts
@@ -24,6 +24,10 @@ import type {
 
 const stringRecordSchema = z.record(z.string(), z.string());
 const metadataSchema = z.record(z.string(), z.unknown());
+const timeoutFieldsSchema = {
+	timeout: z.number().positive().finite().optional(),
+	timeoutMs: z.number().int().positive().optional(),
+};
 const oauthStateSchema = z
 	.object({
 		clientInformation: z.record(z.string(), z.unknown()).optional(),
@@ -62,12 +66,24 @@ const mcpTransportSchema = z.discriminatedUnion("type", [
 	streamableHttpTransportSchema,
 ]);
 
-const nestedRegistrationBodySchema = z.object({
-	transport: mcpTransportSchema,
-	disabled: z.boolean().optional(),
-	metadata: metadataSchema.optional(),
-	oauth: oauthStateSchema.optional(),
-});
+const nestedRegistrationBodySchema = z
+	.object({
+		transport: mcpTransportSchema,
+		disabled: z.boolean().optional(),
+		...timeoutFieldsSchema,
+		metadata: metadataSchema.optional(),
+		oauth: oauthStateSchema.optional(),
+	})
+	.transform((value) => {
+		const timeoutMs = normalizeTimeoutMs(value);
+		return {
+			transport: value.transport,
+			disabled: value.disabled,
+			...(timeoutMs ? { timeoutMs } : {}),
+			metadata: value.metadata,
+			oauth: value.oauth,
+		};
+	});
 
 const legacyTransportTypeSchema = z
 	.enum(["stdio", "sse", "http", "streamableHttp"])
@@ -77,9 +93,23 @@ const legacyRegistrationBaseSchema = z.object({
 	type: z.enum(["stdio", "sse", "streamableHttp"]).optional(),
 	transportType: legacyTransportTypeSchema,
 	disabled: z.boolean().optional(),
+	...timeoutFieldsSchema,
 	metadata: metadataSchema.optional(),
 	oauth: oauthStateSchema.optional(),
 });
+
+function normalizeTimeoutMs(value: {
+	timeout?: number;
+	timeoutMs?: number;
+}): number | undefined {
+	if (typeof value.timeoutMs === "number") {
+		return value.timeoutMs;
+	}
+	if (typeof value.timeout === "number") {
+		return Math.ceil(value.timeout * 1000);
+	}
+	return undefined;
+}
 
 function mapLegacyTransportType(
 	transportType: z.infer<typeof legacyTransportTypeSchema>,
@@ -111,18 +141,22 @@ const legacyStdioRegistrationSchema = legacyRegistrationBaseSchema
 			});
 		}
 	})
-	.transform((value) => ({
-		transport: {
-			type: "stdio" as const,
-			command: value.command,
-			args: value.args,
-			cwd: value.cwd,
-			env: value.env,
-		},
-		disabled: value.disabled,
-		metadata: value.metadata,
-		oauth: value.oauth,
-	}));
+	.transform((value) => {
+		const timeoutMs = normalizeTimeoutMs(value);
+		return {
+			transport: {
+				type: "stdio" as const,
+				command: value.command,
+				args: value.args,
+				cwd: value.cwd,
+				env: value.env,
+			},
+			disabled: value.disabled,
+			...(timeoutMs ? { timeoutMs } : {}),
+			metadata: value.metadata,
+			oauth: value.oauth,
+		};
+	});
 
 const legacyUrlRegistrationSchema = legacyRegistrationBaseSchema
 	.extend({
@@ -145,6 +179,7 @@ const legacyUrlRegistrationSchema = legacyRegistrationBaseSchema
 		const resolvedType =
 			value.type ?? mapLegacyTransportType(value.transportType) ?? "sse";
 		if (resolvedType === "streamableHttp") {
+			const timeoutMs = normalizeTimeoutMs(value);
 			return {
 				transport: {
 					type: "streamableHttp" as const,
@@ -152,10 +187,12 @@ const legacyUrlRegistrationSchema = legacyRegistrationBaseSchema
 					headers: value.headers,
 				},
 				disabled: value.disabled,
+				...(timeoutMs ? { timeoutMs } : {}),
 				metadata: value.metadata,
 				oauth: value.oauth,
 			};
 		}
+		const timeoutMs = normalizeTimeoutMs(value);
 		return {
 			transport: {
 				type: "sse" as const,
@@ -163,6 +200,7 @@ const legacyUrlRegistrationSchema = legacyRegistrationBaseSchema
 				headers: value.headers,
 			},
 			disabled: value.disabled,
+			...(timeoutMs ? { timeoutMs } : {}),
 			metadata: value.metadata,
 			oauth: value.oauth,
 		};

--- a/sdk/packages/core/src/extensions/mcp/types.ts
+++ b/sdk/packages/core/src/extensions/mcp/types.ts
@@ -75,6 +75,7 @@ export interface McpServerRegistration {
 	name: string;
 	transport: McpServerTransportConfig;
 	disabled?: boolean;
+	timeoutMs?: number;
 	metadata?: Record<string, unknown>;
 	oauth?: McpServerOAuthState;
 }

--- a/sdk/packages/core/src/runtime/orchestration/runtime-builder.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-builder.test.ts
@@ -474,6 +474,74 @@ process.stdin.on("data", (chunk) => {
 		}
 	});
 
+	it("uses configured MCP timeout during stdio initialize", async () => {
+		const tempRoot = mkdtempSync(join(tmpdir(), "runtime-builder-mcp-timeout-"));
+		const serverPath = join(tempRoot, "slow-mcp-server.js");
+		const settingsPath = join(tempRoot, "cline_mcp_settings.json");
+		const previousSettingsPath = process.env.CLINE_MCP_SETTINGS_PATH;
+
+		writeFileSync(
+			serverPath,
+			`let buffer = "";
+function write(payload) {
+  process.stdout.write(JSON.stringify(payload) + "\\n");
+}
+function handle(message) {
+  if (message.method === "initialize") {
+    setTimeout(() => {
+      write({ jsonrpc: "2.0", id: message.id, result: { protocolVersion: "2024-11-05", capabilities: { tools: {} }, serverInfo: { name: "slow", version: "1.0.0" } } });
+    }, 1700);
+    return;
+  }
+  if (message.method === "tools/list") {
+    write({ jsonrpc: "2.0", id: message.id, result: { tools: [{ name: "echo", description: "Echo tool", inputSchema: { type: "object", properties: {}, required: [] } }] } });
+  }
+}
+process.stdin.on("data", (chunk) => {
+  buffer += chunk.toString("utf8");
+  while (true) {
+    const separator = buffer.indexOf("\\n");
+    if (separator < 0) break;
+    const line = buffer.slice(0, separator).trim();
+    buffer = buffer.slice(separator + 1);
+    if (!line) continue;
+    const message = JSON.parse(line);
+    if (message.method === "notifications/initialized") continue;
+    handle(message);
+  }
+});`,
+			"utf8",
+		);
+		writeFileSync(
+			settingsPath,
+			JSON.stringify(
+				{
+					mcpServers: {
+						slow: {
+							command: process.execPath,
+							args: [serverPath],
+							timeoutMs: 2_500,
+						},
+					},
+				},
+				null,
+				2,
+			),
+			"utf8",
+		);
+
+		process.env.CLINE_MCP_SETTINGS_PATH = settingsPath;
+		try {
+			const runtime = await new DefaultRuntimeBuilder().build({
+				config: makeBaseConfig(),
+			});
+			expect(runtime.tools.map((tool) => tool.name)).toContain("slow__echo");
+			await runtime.shutdown("test");
+		} finally {
+			process.env.CLINE_MCP_SETTINGS_PATH = previousSettingsPath;
+		}
+	});
+
 	it("skips MCP settings tools when disableMcpSettingsTools is true", async () => {
 		const tempRoot = mkdtempSync(
 			join(tmpdir(), "runtime-builder-mcp-disabled-"),


### PR DESCRIPTION
Summary
- Parse per-server MCP `timeout` / `timeoutMs` settings into core MCP registrations.
- Use the configured timeout for stdio MCP `initialize` handshakes instead of the fixed 1.5s connect timeout.
- Keep the same configured timeout for subsequent stdio MCP JSON-RPC requests, with coverage for a slow-initialize mock server.

Tests
- `git diff --check`
- Commit hook gitleaks check passed

Notes
- Tried running targeted vitest coverage, but this checkout is missing root dev dependencies and `bun install` failed with ENOSPC while linking packages. The added runtime-builder test covers a 1.7s initialize response with `timeoutMs: 2500`, which would fail under the previous 1.5s handshake timeout.

Fixes #12344
