### PR TITLE
docs(ui): add adoption primer

### DIFF
--- a/sdk/packages/ui/ADOPTION.md
+++ b/sdk/packages/ui/ADOPTION.md
@@ -1,0 +1,262 @@
+# `@cline/ui` adoption primer
+
+This guide is for Cline engineering teams that want a web application to share
+the Cline visual language without copying desktop styles or adopting desktop
+product structure.
+
+## The short version
+
+`@cline/ui` is a CSS theme foundation, not a React component library.
+
+It provides:
+
+- Light and dark semantic colors
+- Standard shadcn token names
+- Typography families, sizes, weights, line heights, and letter spacing
+- Borders, radii, cards, navigation, sidebar, and chart colors
+- Selection and scrollbar values
+- A small brand palette for artwork
+- Tailwind v4 mappings
+- Optional global, interaction, and Markdown styles
+
+Each application continues to own:
+
+- Components and page layouts
+- Navigation and product behavior
+- Font-file loading
+- Framework and runtime integration
+- Shell layout and viewport rules
+- Product-specific animation
+- Deliberate product overrides
+
+This gives Cline web products a shared visual vocabulary without requiring
+identical screens.
+
+## Current status
+
+```json
+{
+  "name": "@cline/ui",
+  "version": "0.0.0",
+  "private": true,
+  "internal": true
+}
+```
+
+The package is currently available only inside the Cline monorepo. It is not
+published to npm and is not part of the public SDK release.
+
+Desktop is the first production-shaped consumer. The next milestone is adoption
+by a second Cline web application so the contract can be tested outside the
+environment that created it.
+
+## Choose an adoption level
+
+| Goal | Import | Tailwind required |
+| --- | --- | --- |
+| Use only light/dark CSS variables | `@cline/ui/theme/tokens.css` | No |
+| Use tokens through Tailwind utilities | `tokens.css` then `theme.css` | Tailwind v4 |
+| Use the complete theme and shared base behavior | `@cline/ui/theme/index.css` | Tailwind v4 |
+
+The package also exports `base.css` separately for consumers that want its
+global, Markdown, scrollbar, selection, cursor, and native `color-scheme`
+behavior.
+
+There is no root JavaScript export and no `@cline/ui/theme` shorthand. Use the
+explicit CSS paths documented below.
+
+## Monorepo setup
+
+Add the workspace dependency:
+
+```json
+{
+  "dependencies": {
+    "@cline/ui": "workspace:*"
+  }
+}
+```
+
+Run the repository's normal package installation workflow after updating the
+manifest and lockfile.
+
+## Option 1: complete Tailwind v4 theme
+
+Import fonts and Tailwind before the complete theme:
+
+```css
+@import "@fontsource-variable/schibsted-grotesk";
+@import "@fontsource/azeret-mono/latin.css";
+@import "tailwindcss";
+@import "@cline/ui/theme/index.css";
+```
+
+This supplies:
+
+- Framework-neutral token values
+- Tailwind semantic mappings and dark variant
+- Global typography and body styles
+- Markdown and code-block styling
+- Scrollbar and selection styling
+- Consistent pointer affordances
+- Native light/dark `color-scheme`
+
+Application-specific CSS should follow these imports.
+
+## Option 2: Tailwind mappings without base styles
+
+Use this when the application wants the shared tokens and utilities but already
+owns document, Markdown, scrollbar, or cursor behavior:
+
+```css
+@import "@fontsource-variable/schibsted-grotesk";
+@import "@fontsource/azeret-mono/latin.css";
+@import "tailwindcss";
+@import "@cline/ui/theme/tokens.css";
+@import "@cline/ui/theme/theme.css";
+```
+
+If the application later opts into the shared base behavior, import
+`@cline/ui/theme/base.css` after `theme.css`.
+
+## Option 3: framework-neutral tokens
+
+Applications without Tailwind can import only the variables:
+
+```css
+@import "@cline/ui/theme/tokens.css";
+```
+
+Token-only consumers must provide:
+
+- Font files
+- Resets and document defaults
+- Native `color-scheme`, if desired
+- Their own mapping from CSS variables to framework utilities
+- Their own dark-mode class activation
+
+For native controls that should follow the selected theme:
+
+```css
+:root {
+  color-scheme: light;
+}
+
+.dark {
+  color-scheme: dark;
+}
+```
+
+## Token usage
+
+Product components should use semantic tokens:
+
+```css
+.card {
+  color: var(--card-foreground);
+  background: var(--card);
+  border-color: var(--border);
+}
+
+.primary-action {
+  color: var(--primary-foreground);
+  background: var(--primary);
+}
+```
+
+Use the small `--brand-*` palette and `--primary-emphasis` for branded
+artwork or deliberate emphasis. Normal product controls should prefer semantic
+tokens so they continue to work across light, dark, and future theme layers.
+
+## Product overrides
+
+Import the package first, then override standard semantic values:
+
+```css
+@import "@cline/ui/theme/index.css";
+
+:root {
+  --primary: /* product-specific value */;
+}
+
+.dark {
+  --primary: /* dark product-specific value */;
+}
+```
+
+Do not copy `tokens.css` into the consuming application. Explicit overrides
+make product differences reviewable and allow future package upgrades.
+
+## Consumer-owned behavior
+
+Keep the following outside `@cline/ui`:
+
+- Next, Tauri, VS Code, and runtime-specific behavior
+- `#__next`, viewport locking, and shell layout
+- Application routes and information architecture
+- Desktop session, workspace, and sidecar behavior
+- Product-specific animation keyframes
+- Components that have not been proven reusable by multiple products
+
+The package should standardize visual language, not erase product boundaries.
+
+## Adoption checklist
+
+- [ ] Add `@cline/ui` through `workspace:*`.
+- [ ] Choose tokens-only, Tailwind mappings, or the complete theme.
+- [ ] Load the required font files.
+- [ ] Import files in the documented order.
+- [ ] Confirm the application's `.dark` behavior.
+- [ ] Put deliberate overrides after package imports.
+- [ ] Remove copied local tokens instead of maintaining two sources.
+- [ ] Build the application in development and production.
+- [ ] Compare representative screens in light and dark modes.
+- [ ] Exercise focus, hover, disabled, and native-control states.
+- [ ] Record required overrides and any missing shared token.
+
+## Contract and compatibility expectations
+
+Until the package has a stable version, contract changes should:
+
+- Include a compatibility note
+- Run package validation and tests
+- Build every active consumer
+- Include light/dark visual evidence when values change
+- Avoid renaming standard shadcn/Tailwind variables
+- Keep `tokens.css` framework-neutral
+- Keep product-specific layout and runtime behavior out of the package
+
+Removing or changing the meaning of a semantic token should eventually be
+treated as a breaking change. Additive tokens and entry points can be introduced
+compatibly.
+
+## Publication status and next steps
+
+Separate repositories cannot install `@cline/ui` from npm yet. Publication
+requires more than removing `private: true`.
+
+Recommended sequence:
+
+1. Adopt the package in a second Cline web application.
+2. Assign design and engineering owners.
+3. Define compatibility, browser, Tailwind, and deprecation policies.
+4. Add token-only and Tailwind consumer fixtures.
+5. Add representative light/dark visual regression coverage.
+6. Verify all exports from a packed artifact in a clean consumer.
+7. Select an initial version and release cadence.
+8. Add changelog, provenance, and npm release automation.
+9. Publish a prerelease before declaring the contract stable.
+
+Shared React components can later live under `@cline/ui/components`, but that
+should be a separate proposal based on repeated needs across applications. The
+CSS token entry point should remain usable without React.
+
+## Useful references
+
+- [Package README](./README.md)
+- [Tokens](./theme/tokens.css)
+- [Tailwind mappings](./theme/theme.css)
+- [Optional base styles](./theme/base.css)
+- [Complete theme](./theme/index.css)
+- [Package manifest](./package.json)
+- [Desktop integration test](../../../apps/examples/desktop-app/webview/styles/theme-integration.test.ts)

--- a/sdk/packages/ui/README.md
+++ b/sdk/packages/ui/README.md
@@ -4,6 +4,9 @@ Shared, framework-independent UI foundations for Cline web products. The
 package is internal to this monorepo while the first consumers settle the
 contract; it is not part of the public SDK release yet.
 
+See the [adoption primer](./ADOPTION.md) for integration choices, copy-paste
+setup, consumer responsibilities, and publication status.
+
 ## Theme entry points
 
 | Import | Contents | Requires Tailwind |


### PR DESCRIPTION
### Related Issue

**Issue:** N/A — documentation follow-up to #12285

### Description

The initial `@cline/ui` README documents the package entry points and their
basic import order, but it assumes the reader already understands where the
shared theme should stop and application ownership should begin. That is enough
for maintaining the package; it is not enough for another web-app team deciding
whether to adopt it.

This PR adds an adoption-oriented primer next to the package and links it from
the existing README. The primer gives consuming teams:

- A plain-language explanation of what `@cline/ui` standardizes and what
  remains application-owned.
- A decision table for token-only, Tailwind-mapping, and complete-theme usage.
- Copy-paste monorepo dependency and CSS import examples.
- Guidance for font loading, dark mode, native `color-scheme`, semantic token
  usage, product overrides, and import order.
- An adoption checklist for development, production, light/dark, interaction,
  and visual review.
- Interim compatibility expectations while the package remains unstable.
- A concrete sequence for validating a second consumer and preparing a future
  public release.

The document deliberately describes `@cline/ui` as a CSS theme foundation,
not a React component library or a mandate for identical product layouts. It
also makes the current distribution boundary explicit: the package is still
`0.0.0`, `private`, `internal`, and available only through the monorepo
workspace.

Several non-obvious integration details are called out because they are easy to
miss when copying the desktop setup:

- Consumers must use explicit exported CSS paths such as
  `@cline/ui/theme/index.css`; there is no root JavaScript export or
  `@cline/ui/theme` shorthand.
- Token-only consumers do not receive font assets, resets, or native
  `color-scheme`.
- Tailwind consumers must import Tailwind before the theme mapping.
- `base.css` is optional and intentionally more opinionated than the token and
  mapping layers.
- Product differences should be represented as post-import semantic overrides,
  not copied token files.

There are no changes to tokens, styles, exports, dependencies, runtime behavior,
or package publication in this PR.

### Test Procedure

1. Ran `bun -F @cline/ui build`.
   - The theme contract validator passed.
2. Ran `bun -F @cline/ui test`.
   - 1 test file / 4 tests passed.
3. Ran `git diff --check origin/main..HEAD`.
   - No whitespace errors were reported.
4. Manually checked every import example against the current package
   `exports` map and verified all relative reference links target existing
   package or desktop files.
5. Reviewed the primer against the current `0.0.0`, `private`, and
   `internal` manifest so it does not imply that npm installation is already
   supported.

This is a documentation-only change. Repository CI remains the final
full-monorepo formatting and test gate.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — documentation only.

### Additional Notes

This is intentionally an adoption guide rather than a publication PR.
`@cline/ui` remains internal and workspace-only. A later implementation can
use the primer's publication-readiness checklist to define ownership, consumer
coverage, versioning, packed-artifact verification, and release automation
before changing that status.

The separate meeting-notes file created under `/workspace` is a local handoff
artifact and is not part of this repository change.
