### PR TITLE
fix(cli): prevent ask_question spinner in TUI

### DIFF
--- a/apps/cli/src/tui/hooks/use-agent-events.ts
+++ b/apps/cli/src/tui/hooks/use-agent-events.ts
@@ -6,7 +6,10 @@ import type {
 	PendingPromptSubmittedEvent,
 } from "../../runtime/session-events";
 import { formatCliErrorMessage } from "../../utils/cline-pass-errors";
-import { resolveNonCompactionStatusLabel } from "../../utils/events";
+import {
+	resolveNonCompactionStatusLabel,
+	shouldRenderGenericToolEvent,
+} from "../../utils/events";
 import {
 	formatToolInput,
 	formatToolOutput,
@@ -90,6 +93,9 @@ export function useAgentEventHandlers(deps: AgentEventDeps) {
 
 	const closeToolEntry = useCallback(
 		(event: AgentEvent & { type: "content_end" }) => {
+			if (!shouldRenderGenericToolEvent(event.toolName ?? "unknown_tool")) {
+				return;
+			}
 			const error = event.error ?? undefined;
 			const output = event.output;
 			const result = {
@@ -179,6 +185,9 @@ export function useAgentEventHandlers(deps: AgentEventDeps) {
 						case "tool": {
 							closeInlineStream();
 							const toolName = event.toolName ?? "unknown_tool";
+							if (!shouldRenderGenericToolEvent(toolName)) {
+								break;
+							}
 							appendEntry({
 								kind: "tool_call",
 								toolCallId: event.toolCallId,

--- a/apps/cli/src/utils/events.test.ts
+++ b/apps/cli/src/utils/events.test.ts
@@ -4,6 +4,7 @@ import {
 	handleEvent,
 	handleTeamEvent,
 	resolveStatusNoticeLabel,
+	shouldRenderGenericToolEvent,
 } from "./events";
 import { setCurrentOutputMode } from "./output";
 import type { Config } from "./types";
@@ -145,6 +146,11 @@ describe("handleEvent text formatting", () => {
 		);
 
 		expect(output).toBe("");
+	});
+
+	it("marks ask_question as handled outside the generic tool renderer", () => {
+		expect(shouldRenderGenericToolEvent("ask_question")).toBe(false);
+		expect(shouldRenderGenericToolEvent("read_files")).toBe(true);
 	});
 
 	it("prints tool errors inline", () => {

--- a/apps/cli/src/utils/events.ts
+++ b/apps/cli/src/utils/events.ts
@@ -61,6 +61,10 @@ export function resolveNonCompactionStatusLabel(
 	return event.message.trim() || undefined;
 }
 
+export function shouldRenderGenericToolEvent(toolName: string): boolean {
+	return toolName !== "ask_question";
+}
+
 export function closeInlineStreamIfNeeded(): void {
 	if (!inlineStreamHasOutput) {
 		return;
@@ -142,7 +146,7 @@ export function handleEvent(event: AgentEvent, config: Config): void {
 					closeInlineStreamIfNeeded();
 					const toolName = event.toolName ?? "unknown_tool";
 					const inputStr = formatToolInput(toolName, event.input);
-					if (toolName === "ask_question") {
+					if (!shouldRenderGenericToolEvent(toolName)) {
 						break;
 					}
 					write(
@@ -161,7 +165,7 @@ export function handleEvent(event: AgentEvent, config: Config): void {
 					break;
 				case "tool":
 					closeInlineStreamIfNeeded();
-					if (event.toolName === "ask_question") {
+					if (!shouldRenderGenericToolEvent(event.toolName ?? "unknown_tool")) {
 						break;
 					}
 					if (event.error) {


### PR DESCRIPTION
## Summary
- skip `ask_question` in the generic CLI tool event renderer
- apply the same behavior in the TUI transcript so the dedicated question UI handles responses
- add regression coverage for generic tool rendering

## Testing
- `bun -F @cline/cli typecheck`
- `bunx biome check apps/cli/src/tui/hooks/use-agent-events.ts apps/cli/src/utils/events.ts apps/cli/src/utils/events.test.ts`
- `bun -F @cline/cli test -- src/utils/events.test.ts` *(blocked before test collection by the existing Zod runtime import issue)*

Replaces #12222.
Closes #12220