### PR TITLE
feat(llms): make Claude Code and Codex provider packages optional peers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
     },
     "apps/cli": {
       "name": "@cline/cli",
-      "version": "3.0.43",
+      "version": "3.0.44",
       "bin": {
         "cline": "src/index.ts",
       },
@@ -698,18 +698,24 @@
         "@streamparser/json": "^0.0.21",
         "ai": "^6.0.144",
         "ai-sdk-ollama": "^3.8.8",
-        "ai-sdk-provider-claude-code": "^3.4.3",
-        "ai-sdk-provider-codex-cli": "^1.1.0",
         "ai-sdk-provider-opencode-sdk": "^3.0.1",
         "dify-ai-provider": "^1.1.0",
         "nanoid": "^5.1.7",
         "zod": "^4.3.6",
       },
+      "devDependencies": {
+        "ai-sdk-provider-claude-code": "^3.4.3",
+        "ai-sdk-provider-codex-cli": "^1.1.0",
+      },
       "peerDependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.0.0",
+        "ai-sdk-provider-claude-code": "^3.4.3",
+        "ai-sdk-provider-codex-cli": "^1.1.0",
       },
       "optionalPeers": [
         "@aws-sdk/client-bedrock-runtime",
+        "ai-sdk-provider-claude-code",
+        "ai-sdk-provider-codex-cli",
       ],
     },
     "sdk/packages/sdk": {

--- a/sdk/packages/llms/package.json
+++ b/sdk/packages/llms/package.json
@@ -41,6 +41,12 @@
 	"peerDependenciesMeta": {
 		"@aws-sdk/client-bedrock-runtime": {
 			"optional": true
+		},
+		"ai-sdk-provider-claude-code": {
+			"optional": true
+		},
+		"ai-sdk-provider-codex-cli": {
+			"optional": true
 		}
 	},
 	"dependencies": {
@@ -61,14 +67,18 @@
 		"@streamparser/json": "^0.0.21",
 		"ai": "^6.0.144",
 		"ai-sdk-ollama": "^3.8.8",
-		"ai-sdk-provider-claude-code": "^3.4.3",
-		"ai-sdk-provider-codex-cli": "^1.1.0",
 		"ai-sdk-provider-opencode-sdk": "^3.0.1",
 		"dify-ai-provider": "^1.1.0",
 		"nanoid": "^5.1.7",
 		"zod": "^4.3.6"
 	},
 	"peerDependencies": {
-		"@aws-sdk/client-bedrock-runtime": "^3.0.0"
+		"@aws-sdk/client-bedrock-runtime": "^3.0.0",
+		"ai-sdk-provider-claude-code": "^3.4.3",
+		"ai-sdk-provider-codex-cli": "^1.1.0"
+	},
+	"devDependencies": {
+		"ai-sdk-provider-claude-code": "^3.4.3",
+		"ai-sdk-provider-codex-cli": "^1.1.0"
 	}
 }

--- a/sdk/packages/llms/src/providers/vendors/community.ts
+++ b/sdk/packages/llms/src/providers/vendors/community.ts
@@ -1,11 +1,12 @@
+import { accessSync, constants as fsConstants } from "node:fs";
+import { createRequire } from "node:module";
+import { delimiter, dirname, join } from "node:path";
 import type { GatewayResolvedProviderConfig } from "@cline/shared";
 // Keep this import static so the VS Code extension bundle includes the SAP
 // provider. Hiding it behind a computed dynamic import leaves the published
 // extension trying to load @jerome-benoit/sap-ai-provider from node_modules at
 // runtime, but VSIX packaging uses the bundled extension output.
 import { createSAPAIProvider } from "@jerome-benoit/sap-ai-provider";
-import { createClaudeCode } from "ai-sdk-provider-claude-code";
-import { createCodexExec } from "ai-sdk-provider-codex-cli";
 import { createDifyProvider } from "dify-ai-provider";
 import { resolveApiKey } from "../http";
 import type { ProviderFactoryResult } from "./types";
@@ -24,10 +25,94 @@ function readOptions(
 	return (config.options as Record<string, unknown> | undefined) ?? {};
 }
 
+function findExecutableOnPath(name: string): string | undefined {
+	const extensions =
+		process.platform === "win32" ? [".exe", ".cmd", ".bat", ""] : [""];
+	for (const dir of (process.env.PATH ?? "").split(delimiter)) {
+		if (!dir) continue;
+		for (const ext of extensions) {
+			const candidate = join(dir, `${name}${ext}`);
+			try {
+				accessSync(candidate, fsConstants.X_OK);
+				return candidate;
+			} catch {
+				// not here; keep looking
+			}
+		}
+	}
+	return undefined;
+}
+
+// The agent SDK spawns a `claude` executable shipped in per-platform optional
+// packages (@anthropic-ai/claude-agent-sdk-<platform>-<arch>[-musl]). Those
+// are no longer installed by default (~250MB), so resolve an explicit path:
+// the bundled platform binary when present, otherwise a user-installed
+// Claude Code from PATH. The SDK's own resolution cannot be relied on here:
+// inside a Bun-compiled binary it anchors on the virtual bunfs, where
+// node_modules lookups never see packages on disk.
+function resolveClaudeExecutable(): string | undefined {
+	const suffixes =
+		process.platform === "linux"
+			? [
+					`${process.platform}-${process.arch}`,
+					`${process.platform}-${process.arch}-musl`,
+				]
+			: [`${process.platform}-${process.arch}`];
+	const executableName = process.platform === "win32" ? "claude.exe" : "claude";
+	// Anchor on the real executable location first so resolution works from
+	// compiled binaries; fall back to this module's location for plain node.
+	const anchors = [
+		join(dirname(process.execPath), "noop.js"),
+		import.meta.url,
+	];
+	for (const anchor of anchors) {
+		for (const suffix of suffixes) {
+			try {
+				const manifest = createRequire(anchor).resolve(
+					`@anthropic-ai/claude-agent-sdk-${suffix}/package.json`,
+				);
+				const executable = join(dirname(manifest), executableName);
+				accessSync(executable, fsConstants.X_OK);
+				return executable;
+			} catch {
+				// keep looking
+			}
+		}
+	}
+	return findExecutableOnPath("claude");
+}
+
 export async function createClaudeCodeProviderModule(
 	config: GatewayResolvedProviderConfig,
 ): Promise<ProviderFactoryResult> {
-	const provider = createClaudeCode(readOptions(config));
+	// Dynamic import is intentional: ai-sdk-provider-claude-code is an
+	// optional peer dependency so default installs skip its ~250MB
+	// @anthropic-ai/claude-agent-sdk platform binary. It also runs
+	// createClaudeCode() at module scope, so loading lazily contains that
+	// side effect to actual Claude Code usage.
+	let createClaudeCode: typeof import("ai-sdk-provider-claude-code").createClaudeCode;
+	try {
+		({ createClaudeCode } = await import("ai-sdk-provider-claude-code"));
+	} catch (error) {
+		throw new Error(
+			"The Claude Code provider requires the optional 'ai-sdk-provider-claude-code' package. " +
+				"Install it alongside @cline/llms to use this provider.",
+			{ cause: error },
+		);
+	}
+	const options = readOptions(config);
+	const defaultSettings =
+		(options.defaultSettings as Record<string, unknown> | undefined) ?? {};
+	if (defaultSettings.pathToClaudeCodeExecutable === undefined) {
+		const executable = resolveClaudeExecutable();
+		if (executable !== undefined) {
+			options.defaultSettings = {
+				...defaultSettings,
+				pathToClaudeCodeExecutable: executable,
+			};
+		}
+	}
+	const provider = createClaudeCode(options);
 	return {
 		model: (modelId) => provider(modelId),
 	};
@@ -36,6 +121,20 @@ export async function createClaudeCodeProviderModule(
 export async function createOpenAICodexProviderModule(
 	config: GatewayResolvedProviderConfig,
 ): Promise<ProviderFactoryResult> {
+	// Dynamic import is intentional: ai-sdk-provider-codex-cli is an optional
+	// peer dependency so default installs skip its ~105MB @openai/codex
+	// optional dependency. The provider itself degrades gracefully when the
+	// bundled binary is absent (npx -y @openai/codex, then `codex` on PATH).
+	let createCodexExec: typeof import("ai-sdk-provider-codex-cli").createCodexExec;
+	try {
+		({ createCodexExec } = await import("ai-sdk-provider-codex-cli"));
+	} catch (error) {
+		throw new Error(
+			"The OpenAI Codex provider requires the optional 'ai-sdk-provider-codex-cli' package. " +
+				"Install it alongside @cline/llms to use this provider.",
+			{ cause: error },
+		);
+	}
 	const provider = createCodexExec(readOptions(config));
 	return {
 		model: (modelId) => provider(modelId),


### PR DESCRIPTION
### Related Issue

N/A — install-size/packaging improvement discovered while debugging why `npm i -g cline` takes forever.

### Description

**Problem:** `npm i -g cline` downloads **~640MB**. The two biggest chunks are native binaries most users never use:

| package | size | pulled in by |
|---|---|---|
| `@anthropic-ai/claude-agent-sdk-<platform>` | ~249MB | `ai-sdk-provider-claude-code` (hard dep of `@cline/llms`) |
| `@openai/codex-<platform>` | ~105MB | `ai-sdk-provider-codex-cli` (hard dep of `@cline/llms`) |

These only exist to power the `claude-code` and `openai-codex` providers, but they install for everyone because they're hard `dependencies` of `@cline/llms`, and the published `cline` wrapper depends on `@cline/sdk → @cline/core → @cline/llms` at runtime. This PR cuts the default install roughly **640MB → ~285MB**.

**Approach** (modeled on how opencode handles the same problem — they bundle zero provider binaries):

1. **`@cline/llms/package.json`**: move both provider packages from `dependencies` to `peerDependencies` + `peerDependenciesMeta.optional`. They stay as `devDependencies` so monorepo builds (compiled CLI, VSIX) still bundle the JS. Note: plain `optionalDependencies` would NOT work — npm installs optional deps by default (that's exactly why the codex binary lands today despite already being optional one level down).
2. **`community.ts`**: convert both static imports to literal dynamic imports inside the factory functions, mirroring the existing `ai-sdk-provider-opencode-sdk` pattern in the same file (which was itself introduced to fix the module-scope SIGINT/SIGTERM crash, #138/#145 in the old sdk repo). `ai-sdk-provider-claude-code` also runs `createClaudeCode()` at module scope, so lazy loading contains that side effect too. Literal (non-computed) specifiers keep esbuild/Bun bundling working — the SAP comment at the top of the file only warns about *computed* dynamic imports.
3. **Explicit claude executable resolution**: the agent SDK spawns a `claude` executable and resolves it via `createRequire(import.meta.url)` — which **does not work inside Bun-compiled binaries** (`import.meta.url` anchors on the virtual `/$bunfs/`, where node_modules lookups never see packages on disk). New `resolveClaudeExecutable()` resolves the bundled platform package anchored on `process.execPath` (real filesystem) first, then falls back to `claude` on PATH, and passes the result via `defaultSettings.pathToClaudeCodeExecutable`.

**Debugging journey / gotchas for reviewers:**

- First version passed `pathToClaudeCodeExecutable` at the top level of `createClaudeCode(options)` — it is **silently ignored** there. It must be nested under `defaultSettings` (`ClaudeCodeProviderSettings.defaultSettings: ClaudeCodeSettings`). Caught only by the compiled-binary smoke test.
- Second finding: even with the platform package on disk, the SDK's own resolution failed from the compiled binary (the `/$bunfs/` issue above). This suggests the claude-code provider may have been broken in the compiled CLI **even with** the 250MB binary installed — this PR likely fixes that as a side effect.
- `@cline/llms`'s `bun.mts` externalizes `dependencies` + `peerDependencies`, so peer-optional placement automatically keeps the dynamic import external in the published dist (a true runtime import), while devDeps placement gets it inlined into the compiled CLI. The dep-type change and the laziness are coupled through the build config — if you move these deps again, check `bun.mts`.

**Behavior change:** slim installs need Claude Code installed (`claude` on PATH) to use the claude-code provider. Near-zero regression: that provider piggybacks on the user's claude login/subscription, so they necessarily have it installed. Codex needs nothing — `ai-sdk-provider-codex-cli` already degrades to `npx -y @openai/codex`, then `codex` on PATH.

npm consumers of `@cline/llms` who want these providers now install them explicitly alongside (they get a clear error message otherwise).

### Test Procedure

- `bun run test` in `sdk/packages/llms`: 414 passed, 4 skipped (includes existing `vi.mock`s of `ai-sdk-provider-codex-cli`, which intercept dynamic imports fine). Typecheck + biome format clean.
- Built the compiled binary (`bun script/build.ts --single`) and smoke-tested against the exact scenario a slim install produces (no provider packages on disk):
  - `--version` / `--help`: no startup crash (the module-scope side effect concern).
  - **claude-code with `claude` on PATH: full end-to-end success** — provider dynamically imported inside the compiled binary, PATH claude discovered and spawned, real request completed (`"text":"OK","finishReason":"completed"`).
  - claude-code with no claude anywhere: clean terminating error, no crash.
  - openai-codex: loads via dynamic import, reaches the auth layer, clean error.
- Verified the published llms dist keeps `import("ai-sdk-provider-claude-code")` external (runtime import), and the compiled binary contains the provider JS inline (strings check).
- Verified nothing else in the monorepo imports either package statically (only vitest mocks).

### Type of Change

-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)