### PR TITLE
fix(sdk): derive checkpoint runCount from genuine user turns, not run/continue invocations

### DIFF
--- a/sdk/packages/agents/src/agent-runtime.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.test.ts
@@ -398,6 +398,10 @@ describe("AgentRuntime", () => {
 						(part) => part.type === "text" && part.text.includes("submit"),
 					),
 				).toBe(true);
+				// This synthetic system-injected reminder must be tagged so
+				// checkpoint run counting doesn't mistake it for a genuine
+				// user turn - see checkpoint-run-counting.ts.
+				expect(reminder?.metadata?.kind).toBe("completion_reminder");
 				return [
 					{
 						type: "tool-call-delta",

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -560,7 +560,14 @@ export class AgentRuntime {
 	}
 
 	private async addUserReminderMessage(text: string): Promise<AgentMessage> {
-		const reminderMessage = createMessage("user", [{ type: "text", text }]);
+		// Tag this synthetic system-injected message so checkpoint run
+		// counting (which counts genuine user-authored turns) can exclude it -
+		// see sdk/packages/core/src/hooks/checkpoint-run-counting.ts.
+		const reminderMessage = createMessage(
+			"user",
+			[{ type: "text", text }],
+			{ kind: "completion_reminder" },
+		);
 		this.state.messages.push(reminderMessage);
 		await this.emit({
 			type: "message-added",

--- a/sdk/packages/core/src/hooks/checkpoint-hooks.test.ts
+++ b/sdk/packages/core/src/hooks/checkpoint-hooks.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
+import type { AgentMessage } from "@cline/shared";
 import { describe, expect, it } from "vitest";
 import {
 	type CheckpointEntry,
@@ -30,29 +31,59 @@ async function createGitRepo(): Promise<string> {
 	return cwd;
 }
 
+// Checkpoint runCount is derived from the count of genuine user-authored
+// messages in the snapshot (see ./checkpoint-run-counting.ts) rather than a
+// counter incremented on every root run/continue invocation - so test
+// fixtures build up the message list explicitly instead of relying on an
+// internal counter or an `initialRunCount` option (both removed).
+let nextMessageId = 0;
+
+function userMessage(
+	text: string,
+	metadata?: Record<string, unknown>,
+): AgentMessage {
+	nextMessageId += 1;
+	return {
+		id: `msg_${nextMessageId}`,
+		role: "user",
+		content: [{ type: "text", text }],
+		createdAt: nextMessageId,
+		...(metadata ? { metadata } : {}),
+	};
+}
+
+function assistantMessage(text: string): AgentMessage {
+	nextMessageId += 1;
+	return {
+		id: `msg_${nextMessageId}`,
+		role: "assistant",
+		content: [{ type: "text", text }],
+		createdAt: nextMessageId,
+	};
+}
+
 async function runCheckpointHooks(
 	hooks: ReturnType<typeof createCheckpointHooks>,
+	messages: AgentMessage[],
 	options: { parentAgentId?: string | null } = {},
 ): Promise<void> {
-	const snapshot = {
-		agentId: options.parentAgentId ? "agent_child" : "agent_1",
-		parentAgentId: options.parentAgentId,
-		conversationId: options.parentAgentId ? "conv_child" : "conv_1",
-		runId: options.parentAgentId ? "run_child" : "run_1",
-		status: "running" as const,
-		iteration: 1,
-		messages: [],
-		pendingToolCalls: [],
-		usage: {
-			inputTokens: 0,
-			outputTokens: 0,
-			cacheReadTokens: 0,
-			cacheWriteTokens: 0,
-		},
-	};
-	await hooks.beforeRun?.({ snapshot: { ...snapshot, iteration: 0 } });
 	await hooks.beforeModel?.({
-		snapshot,
+		snapshot: {
+			agentId: options.parentAgentId ? "agent_child" : "agent_1",
+			parentAgentId: options.parentAgentId,
+			conversationId: options.parentAgentId ? "conv_child" : "conv_1",
+			runId: options.parentAgentId ? "run_child" : "run_1",
+			status: "running" as const,
+			iteration: 1,
+			messages,
+			pendingToolCalls: [],
+			usage: {
+				inputTokens: 0,
+				outputTokens: 0,
+				cacheReadTokens: 0,
+				cacheWriteTokens: 0,
+			},
+		},
 		request: {
 			messages: [],
 			tools: [],
@@ -69,13 +100,13 @@ describe("createCheckpointHooks", () => {
 				cwd,
 				sessionId: "sess_1",
 				readSessionMetadata: async () => metadata,
-				writeSessionMetadata: async (next) => {
-					metadata = next;
+				writeSessionMetadata: async (updater) => {
+					metadata = updater(metadata);
 				},
 			});
 
 			await writeFile(join(cwd, "note.txt"), "run-one\n", "utf8");
-			await runCheckpointHooks(hooks);
+			await runCheckpointHooks(hooks, [userMessage("first")]);
 
 			const first = metadata?.checkpoint as CheckpointMetadata;
 			expect(first.history).toHaveLength(1);
@@ -83,7 +114,11 @@ describe("createCheckpointHooks", () => {
 			expect(first.latest.ref).toMatch(/^[0-9a-f]{40}$/);
 
 			await writeFile(join(cwd, "note.txt"), "run-two\n", "utf8");
-			await runCheckpointHooks(hooks);
+			await runCheckpointHooks(hooks, [
+				userMessage("first"),
+				assistantMessage("reply"),
+				userMessage("second"),
+			]);
 
 			const checkpoint = metadata?.checkpoint as CheckpointMetadata;
 			expect(checkpoint.latest.runCount).toBe(2);
@@ -105,12 +140,12 @@ describe("createCheckpointHooks", () => {
 				cwd,
 				sessionId: "sess_clean",
 				readSessionMetadata: async () => metadata,
-				writeSessionMetadata: async (next) => {
-					metadata = next;
+				writeSessionMetadata: async (updater) => {
+					metadata = updater(metadata);
 				},
 			});
 
-			await runCheckpointHooks(hooks);
+			await runCheckpointHooks(hooks, [userMessage("first")]);
 
 			const checkpoint = metadata?.checkpoint as CheckpointMetadata;
 			expect(checkpoint.history).toHaveLength(1);
@@ -129,18 +164,22 @@ describe("createCheckpointHooks", () => {
 				cwd,
 				sessionId: "sess_no_change",
 				readSessionMetadata: async () => metadata,
-				writeSessionMetadata: async (next) => {
-					metadata = next;
+				writeSessionMetadata: async (updater) => {
+					metadata = updater(metadata);
 				},
 			});
 
-			await runCheckpointHooks(hooks);
+			const messages = [userMessage("first")];
+			await runCheckpointHooks(hooks, messages);
 
 			const first = metadata?.checkpoint as CheckpointMetadata;
 			expect(first.history).toHaveLength(1);
 			expect(first.latest.kind).toBe("commit");
 
-			await runCheckpointHooks(hooks);
+			// Same message count (no new genuine user turn) and a still-clean
+			// worktree - HEAD hasn't moved, so this must be recognized as the
+			// same checkpoint and not appended again.
+			await runCheckpointHooks(hooks, messages);
 
 			const checkpoint = metadata?.checkpoint as CheckpointMetadata;
 			expect(checkpoint.history).toHaveLength(1);
@@ -164,7 +203,11 @@ describe("createCheckpointHooks", () => {
 			});
 
 			await writeFile(join(cwd, "note.txt"), "subagent-dirty\n", "utf8");
-			await runCheckpointHooks(hooks, { parentAgentId: "agent_root" });
+			await runCheckpointHooks(
+				hooks,
+				[userMessage("subagent turn")],
+				{ parentAgentId: "agent_root" },
+			);
 
 			expect(writes).toBe(0);
 		} finally {
@@ -184,17 +227,56 @@ describe("createCheckpointHooks", () => {
 				kind: "commit",
 			}),
 			readSessionMetadata: async () => metadata,
-			writeSessionMetadata: async (next) => {
-				metadata = next;
+			writeSessionMetadata: async (updater) => {
+				metadata = updater(metadata);
 			},
 		});
 
-		await runCheckpointHooks(hooks, { parentAgentId: "agent_root" });
-		await runCheckpointHooks(hooks);
+		// A subagent run has its own, unrelated conversation - it must never
+		// influence the root session's checkpoint numbering.
+		await runCheckpointHooks(
+			hooks,
+			[userMessage("a"), userMessage("b"), userMessage("c")],
+			{ parentAgentId: "agent_root" },
+		);
+		await runCheckpointHooks(hooks, [userMessage("root turn one")]);
 
 		const checkpoint = metadata?.checkpoint as CheckpointMetadata;
 		expect(checkpoint.latest.runCount).toBe(1);
 		expect(checkpoint.history.map((entry) => entry.runCount)).toEqual([1]);
+	});
+
+	it("ignores synthetic system-injected messages when computing runCount", async () => {
+		let metadata: Record<string, unknown> | undefined;
+		const hooks = createCheckpointHooks({
+			cwd: "/tmp",
+			sessionId: "sess_synthetic",
+			createCheckpoint: ({ runCount }) => ({
+				ref: `checkpoint-${runCount}`,
+				createdAt: runCount,
+				runCount,
+				kind: "commit",
+			}),
+			readSessionMetadata: async () => metadata,
+			writeSessionMetadata: async (updater) => {
+				metadata = updater(metadata);
+			},
+		});
+
+		// Two genuine user turns, plus several synthetic `role: "user"`
+		// messages the system injects internally (completion reminders,
+		// recovery notices, etc - see checkpoint-run-counting.ts). None of
+		// these should count as a new run.
+		await runCheckpointHooks(hooks, [
+			userMessage("first"),
+			assistantMessage("reply"),
+			userMessage("reminder", { kind: "completion_reminder" }),
+			userMessage("recovered", { kind: "recovery_notice" }),
+			userMessage("second"),
+		]);
+
+		const checkpoint = metadata?.checkpoint as CheckpointMetadata;
+		expect(checkpoint.latest.runCount).toBe(2);
 	});
 
 	it("continues checkpoint numbering after seeded messages", async () => {
@@ -204,15 +286,22 @@ describe("createCheckpointHooks", () => {
 			const hooks = createCheckpointHooks({
 				cwd,
 				sessionId: "sess_seeded",
-				initialRunCount: 2,
 				readSessionMetadata: async () => metadata,
-				writeSessionMetadata: async (next) => {
-					metadata = next;
+				writeSessionMetadata: async (updater) => {
+					metadata = updater(metadata);
 				},
 			});
 
+			// Two prior turns already seeded into the conversation (e.g. after
+			// a checkpoint restore), plus one new turn for this run.
 			await writeFile(join(cwd, "note.txt"), "run-three\n", "utf8");
-			await runCheckpointHooks(hooks);
+			await runCheckpointHooks(hooks, [
+				userMessage("seeded one"),
+				assistantMessage("seeded reply one"),
+				userMessage("seeded two"),
+				assistantMessage("seeded reply two"),
+				userMessage("run three"),
+			]);
 
 			const checkpoint = metadata?.checkpoint as CheckpointMetadata;
 			expect(checkpoint.latest.runCount).toBe(3);
@@ -245,7 +334,6 @@ describe("createCheckpointHooks", () => {
 		const hooks = createCheckpointHooks({
 			cwd: "/tmp",
 			sessionId: "sess_replace",
-			initialRunCount: 2,
 			createCheckpoint: ({ runCount }) => ({
 				ref: "new-three",
 				createdAt: 4,
@@ -253,12 +341,16 @@ describe("createCheckpointHooks", () => {
 				kind: "commit",
 			}),
 			readSessionMetadata: async () => metadata,
-			writeSessionMetadata: async (next) => {
-				metadata = next;
+			writeSessionMetadata: async (updater) => {
+				metadata = updater(metadata);
 			},
 		});
 
-		await runCheckpointHooks(hooks);
+		await runCheckpointHooks(hooks, [
+			userMessage("one"),
+			userMessage("two"),
+			userMessage("three"),
+		]);
 
 		const checkpoint = metadata?.checkpoint as CheckpointMetadata;
 		expect(checkpoint.latest).toMatchObject({

--- a/sdk/packages/core/src/hooks/checkpoint-hooks.ts
+++ b/sdk/packages/core/src/hooks/checkpoint-hooks.ts
@@ -1,6 +1,7 @@
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
 import type { AgentHooks, BasicLogger } from "@cline/shared";
+import { countGenuineUserPromptMessages } from "./checkpoint-run-counting";
 
 const execFile = promisify(execFileCallback);
 
@@ -21,8 +22,17 @@ type CreateCheckpointHooksOptions = {
 	sessionId: string;
 	logger?: BasicLogger;
 	readSessionMetadata: () => Promise<Record<string, unknown> | undefined>;
+	/**
+	 * Applies an update to session metadata against the freshest persisted
+	 * value available at write time (not a value captured earlier). This
+	 * avoids clobbering concurrent metadata writes - a stale
+	 * `readSessionMetadata()` snapshot merged against and then written back
+	 * would drop entries written in between.
+	 */
 	writeSessionMetadata: (
-		metadata: Record<string, unknown>,
+		updater: (
+			current: Record<string, unknown> | undefined,
+		) => Record<string, unknown>,
 	) => Promise<void> | void;
 	/**
 	 * Optional custom checkpoint implementation. When provided, the built-in
@@ -34,13 +44,6 @@ type CreateCheckpointHooksOptions = {
 		sessionId: string;
 		runCount: number;
 	}) => Promise<CheckpointEntry | undefined> | CheckpointEntry | undefined;
-	/**
-	 * Starting value for the internal run counter. Use this when a session
-	 * is created with initial messages (e.g. after a checkpoint restore) so
-	 * that new checkpoint entries get runCount values that don't collide
-	 * with entries carried over from the source session.
-	 */
-	initialRunCount?: number;
 };
 
 function warn(logger: BasicLogger | undefined, message: string): void {
@@ -155,7 +158,6 @@ function upsertCheckpointHistory(
 export function createCheckpointHooks(
 	options: CreateCheckpointHooksOptions,
 ): AgentHooks {
-	let runCount = options.initialRunCount ?? 0;
 	let repoSupported: boolean | undefined;
 
 	const ensureGitRepository = async (): Promise<boolean> => {
@@ -174,7 +176,9 @@ export function createCheckpointHooks(
 		return repoSupported;
 	};
 
-	const createCheckpoint = async (): Promise<CheckpointEntry | undefined> => {
+	const createCheckpoint = async (
+		runCount: number,
+	): Promise<CheckpointEntry | undefined> => {
 		if (options.createCheckpoint) {
 			return await options.createCheckpoint({
 				cwd: options.cwd,
@@ -253,37 +257,51 @@ export function createCheckpointHooks(
 	};
 
 	return {
-		beforeRun: async ({ snapshot }) => {
-			if (snapshot.parentAgentId != null) {
-				return undefined;
-			}
-			runCount += 1;
-			return undefined;
-		},
+		// `AgentRuntime.run()` and `.continue()` both funnel into the same
+		// `execute()`, which invokes `beforeRun` unconditionally regardless of
+		// whether this is a new user turn or an internal continuation (a
+		// retry, a provider-side key rotation, an auto-continue after a tool
+		// call, etc). Incrementing a counter here therefore counts internal
+		// invocations, not user-visible turns - which silently diverges from
+		// the webview's own turn counter (apps/vscode/src/sdk/sdk-checkpoints.ts,
+		// which counts genuine user-authored messages) and causes checkpoint
+		// restore to fail with "No checkpoint found at or before run N" once a
+		// provider issues internal continuations between visible turns.
+		// `beforeModel` below derives the run number directly from the count
+		// of genuine user-authored messages in the snapshot instead, which is
+		// immune to internal continuations that add no new message (or only
+		// synthetic ones - see checkpoint-run-counting.ts).
 		beforeModel: async ({ snapshot }) => {
-			if (
-				snapshot.parentAgentId != null ||
-				snapshot.iteration !== 1 ||
-				runCount < 1
-			) {
+			if (snapshot.parentAgentId != null || snapshot.iteration !== 1) {
 				return undefined;
 			}
-			const entry = await createCheckpoint();
+			const runCount = countGenuineUserPromptMessages(snapshot.messages);
+			if (runCount < 1) {
+				return undefined;
+			}
+			const entry = await createCheckpoint(runCount);
 			if (!entry) {
 				return undefined;
 			}
-			const metadata = await options.readSessionMetadata();
-			const existing = readCheckpointMetadata(metadata);
-			if (existing?.latest.ref === entry.ref) {
+			const staleExisting = readCheckpointMetadata(
+				await options.readSessionMetadata(),
+			);
+			if (staleExisting?.latest.ref === entry.ref) {
 				return undefined;
 			}
-			const history = upsertCheckpointHistory(existing?.history ?? [], entry);
-			await options.writeSessionMetadata({
-				...(metadata ?? {}),
-				checkpoint: {
-					latest: entry,
-					history,
-				} satisfies CheckpointMetadata,
+			await options.writeSessionMetadata((current) => {
+				const existing = readCheckpointMetadata(current);
+				const history = upsertCheckpointHistory(
+					existing?.history ?? [],
+					entry,
+				);
+				return {
+					...(current ?? {}),
+					checkpoint: {
+						latest: entry,
+						history,
+					} satisfies CheckpointMetadata,
+				};
 			});
 			return undefined;
 		},

--- a/sdk/packages/core/src/hooks/checkpoint-run-counting.test.ts
+++ b/sdk/packages/core/src/hooks/checkpoint-run-counting.test.ts
@@ -1,0 +1,60 @@
+import type { AgentMessage } from "@cline/shared";
+import { describe, expect, it } from "vitest";
+import {
+	countGenuineUserPromptMessages,
+	isGenuineUserPromptMessage,
+} from "./checkpoint-run-counting";
+
+function message(
+	role: AgentMessage["role"],
+	metadata?: Record<string, unknown>,
+): AgentMessage {
+	return {
+		id: "m",
+		role,
+		content: [{ type: "text", text: "x" }],
+		createdAt: 0,
+		...(metadata ? { metadata } : {}),
+	};
+}
+
+describe("isGenuineUserPromptMessage (AgentMessage)", () => {
+	it("accepts a plain user message", () => {
+		expect(isGenuineUserPromptMessage(message("user"))).toBe(true);
+	});
+
+	it("rejects assistant and tool roles", () => {
+		expect(isGenuineUserPromptMessage(message("assistant"))).toBe(false);
+		expect(isGenuineUserPromptMessage(message("tool"))).toBe(false);
+	});
+
+	it("rejects a completion-tool reminder message", () => {
+		expect(
+			isGenuineUserPromptMessage(
+				message("user", { kind: "completion_reminder" }),
+			),
+		).toBe(false);
+	});
+
+	it("accepts a genuinely queued/steered user message", () => {
+		// consumePendingUserMessage() pushes an untagged role:"user" message -
+		// it must keep counting as a real turn.
+		expect(isGenuineUserPromptMessage(message("user"))).toBe(true);
+	});
+});
+
+describe("countGenuineUserPromptMessages (AgentMessage)", () => {
+	it("ignores tool-role messages and tagged synthetic reminders", () => {
+		const messages: AgentMessage[] = [
+			message("user"),
+			message("assistant"),
+			message("tool"),
+			message("assistant"),
+			message("user", { kind: "completion_reminder" }),
+			message("user", { kind: "completion_reminder" }),
+			message("user"),
+		];
+
+		expect(countGenuineUserPromptMessages(messages)).toBe(2);
+	});
+});

--- a/sdk/packages/core/src/hooks/checkpoint-run-counting.ts
+++ b/sdk/packages/core/src/hooks/checkpoint-run-counting.ts
@@ -1,0 +1,52 @@
+// This file is the live-runtime counterpart of
+// ../session/checkpoint-message-filter.ts: it defines "a genuine user turn"
+// for the `AgentMessage` shape used by the agent runtime's snapshot
+// (`sdk/packages/agents/src/agent-runtime.ts`), as opposed to the persisted
+// `LlmsProviders.Message` shape used for stored conversation history. The two
+// shapes model tool results differently (a distinct `role: "tool"` here, vs.
+// `tool_result` content blocks folded into `role: "user"` there), so they
+// need separate filters - do not try to unify them.
+import type { AgentMessage } from "@cline/shared";
+
+/**
+ * Metadata `kind` tags that mark a `role: "user"` AgentMessage as a
+ * synthetic, system-injected message rather than something the user typed.
+ * Keep in sync with the tags applied in agent-runtime.ts (addUserReminderMessage)
+ * and, transitively, whatever survives from the persisted layer's own tags
+ * (see checkpoint-message-filter.ts) if a compacted/resumed conversation is
+ * re-seeded as AgentMessage initialMessages.
+ */
+const SYNTHETIC_USER_MESSAGE_KINDS = new Set([
+	"completion_reminder",
+	"recovery_notice",
+	"compaction_summary",
+	"loop_detection_notice",
+	"mistake_stop_notice",
+]);
+
+/**
+ * A live AgentMessage counts as a genuine user-initiated turn only if:
+ *  - its role is "user" (tool results have their own "tool" role here, so
+ *    unlike the persisted message shape, no content-block filtering is
+ *    needed to exclude them), and
+ *  - it isn't tagged as one of the synthetic system-injected kinds above.
+ */
+export function isGenuineUserPromptMessage(message: AgentMessage): boolean {
+	if (message.role !== "user") {
+		return false;
+	}
+	const kind = message.metadata?.kind;
+	return !(typeof kind === "string" && SYNTHETIC_USER_MESSAGE_KINDS.has(kind));
+}
+
+export function countGenuineUserPromptMessages(
+	messages: readonly AgentMessage[],
+): number {
+	let count = 0;
+	for (const message of messages) {
+		if (isGenuineUserPromptMessage(message)) {
+			count += 1;
+		}
+	}
+	return count;
+}

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
@@ -2023,7 +2023,42 @@ describe("LocalRuntimeHost", () => {
 							parentAgentId: null,
 							status: "running" as const,
 							iteration: 1,
-							messages: [],
+							// Checkpoint runCount is derived from genuine user
+							// messages in the snapshot (checkpoint-run-counting.ts),
+							// so this fake agent must mirror the real
+							// AgentRuntime's behavior of seeding `state.messages`
+							// from `initialMessages` instead of hardcoding `[]`.
+							messages: [
+								{
+									id: "m1",
+									role: "user" as const,
+									content: [{ type: "text" as const, text: "first" }],
+									createdAt: 1,
+								},
+								{
+									id: "m2",
+									role: "assistant" as const,
+									content: [
+										{ type: "text" as const, text: "first response" },
+									],
+									createdAt: 2,
+								},
+								{
+									id: "m3",
+									role: "user" as const,
+									content: [{ type: "text" as const, text: "second" }],
+									createdAt: 3,
+								},
+								// The new prompt for this run ("hello"), as a real
+								// AgentRuntime would have already pushed it to
+								// state.messages before beforeModel fires.
+								{
+									id: "m4",
+									role: "user" as const,
+									content: [{ type: "text" as const, text: "hello" }],
+									createdAt: 4,
+								},
+							],
 							pendingToolCalls: [],
 							usage: {
 								inputTokens: 0,
@@ -2032,9 +2067,6 @@ describe("LocalRuntimeHost", () => {
 								cacheWriteTokens: 0,
 							},
 						};
-						await config.hooks?.beforeRun?.({
-							snapshot: { ...snapshot, iteration: 0 },
-						});
 						await config.hooks?.beforeModel?.({
 							snapshot,
 							request: { messages: [], tools: [] },
@@ -2109,6 +2141,146 @@ describe("LocalRuntimeHost", () => {
 				totalCost: 0,
 			}),
 		});
+	});
+
+	it("preserves checkpoint history when resuming a session with a new prompt", async () => {
+		const sessionId = "sess-checkpoint-resume-with-prompt";
+		const repoCwd = join(isolatedHomeDir, "checkpoint-resume-repo");
+		const existingManifest: SessionManifest = {
+			...createManifest(sessionId),
+			metadata: {
+				checkpoint: {
+					latest: {
+						ref: "old-ref",
+						createdAt: 1,
+						runCount: 1,
+						kind: "commit",
+					},
+					history: [
+						{
+							ref: "old-ref",
+							createdAt: 1,
+							runCount: 1,
+							kind: "commit",
+						},
+					],
+				},
+			},
+		};
+		const newCheckpointRef = "b".repeat(40);
+		const createCheckpoint = vi.fn(({ runCount }) => ({
+			ref: newCheckpointRef,
+			createdAt: 456,
+			runCount,
+			kind: "commit" as const,
+		}));
+		const readSessionManifest = vi.fn().mockResolvedValue(existingManifest);
+		const createRootSessionWithArtifacts = vi
+			.fn()
+			.mockImplementation((input: { metadata?: Record<string, unknown> }) => ({
+				manifestPath: "/tmp/manifest-checkpoint-resume.json",
+				messagesPath: "/tmp/messages-checkpoint-resume.json",
+				manifest: { ...existingManifest, metadata: input.metadata },
+			}));
+		const updateSession = vi.fn().mockResolvedValue({ updated: true });
+		const sessionService = {
+			ensureSessionsDir: vi.fn().mockReturnValue("/tmp/sessions"),
+			readSessionManifest,
+			createRootSessionWithArtifacts,
+			persistSessionMessages: vi.fn(),
+			updateSession,
+			updateSessionStatus: vi.fn().mockResolvedValue({ updated: true }),
+			writeSessionManifest: vi.fn(),
+			listSessions: vi.fn().mockResolvedValue([]),
+			deleteSession: vi.fn().mockResolvedValue({ deleted: true }),
+		};
+		const runtimeBuilder = {
+			build: vi.fn().mockImplementation(() => {
+				return {
+					tools: [],
+					shutdown: vi.fn(),
+				};
+			}),
+		};
+		const manager = new RuntimeHostUnderTest({
+			distinctId,
+			sessionService: sessionService as never,
+			runtimeBuilder,
+			createAgent: (config) =>
+				({
+					run: vi.fn().mockImplementation(async () => {
+						const snapshot = {
+							agentId: "agent_1",
+							runId: "conv_1",
+							parentAgentId: null,
+							status: "running" as const,
+							iteration: 1,
+							messages: [],
+							pendingToolCalls: [],
+							usage: {
+								inputTokens: 0,
+								outputTokens: 0,
+								cacheReadTokens: 0,
+								cacheWriteTokens: 0,
+							},
+						};
+						await config.hooks?.beforeModel?.({
+							snapshot,
+							request: { messages: [], tools: [] },
+						});
+						return createResult();
+					}),
+					continue: vi.fn(),
+					abort: vi.fn(),
+					subscribeEvents: vi.fn().mockReturnValue(() => {}),
+					canStartRun: vi.fn().mockReturnValue(true),
+					getAgentId: vi.fn().mockReturnValue("agent-root-1"),
+					getConversationId: vi.fn().mockReturnValue("conv-root-1"),
+					shutdown: vi.fn().mockResolvedValue(undefined),
+					getMessages: vi.fn().mockReturnValue([]),
+					messages: [],
+				}) as never,
+		});
+
+		// Simulates continuing an existing task with a new message: a
+		// sessionId is already assigned and prior turns are seeded via
+		// initialMessages, but a new prompt is also attached. This makes
+		// `isReadOnlyResumeStart` false, so `resumedArtifacts` stays unset,
+		// and `ensureSessionPersisted` lazily calls
+		// `createRootSessionWithArtifacts` on this turn - which performs a
+		// wholesale upsert of session metadata into storage. Without
+		// preserving the existing checkpoint history first, that upsert
+		// would silently wipe every earlier checkpoint entry.
+		await manager.startSession(
+			normalizeStartInput({
+				config: {
+					...createConfig({ sessionId, cwd: repoCwd }),
+					checkpoint: { enabled: true, createCheckpoint },
+				},
+				prompt: "continue please",
+				initialMessages: [
+					{ role: "user", content: "first" },
+					{ role: "assistant", content: "first response" },
+				],
+				interactive: true,
+			}),
+		);
+
+		expect(readSessionManifest).toHaveBeenCalledWith(sessionId);
+		expect(createRootSessionWithArtifacts).toHaveBeenCalledWith(
+			expect.objectContaining({
+				metadata: expect.objectContaining({
+					checkpoint: expect.objectContaining({
+						history: expect.arrayContaining([
+							expect.objectContaining({
+								ref: "old-ref",
+								runCount: 1,
+							}),
+						]),
+					}),
+				}),
+			}),
+		);
 	});
 
 	it("persists assistant message metadata for usage and model identity", async () => {

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -1838,17 +1838,36 @@ export class LocalRuntimeHost implements RuntimeHost {
 		) => Record<string, unknown> | undefined,
 	): Promise<void> {
 		const session = this.sessions.get(sessionId);
+		if (!session?.artifacts) {
+			return;
+		}
+		// Prefer mergeSessionMetadata: unlike updateSession, it re-applies
+		// `resolveMetadata` against the freshly-read row on every OCC retry
+		// attempt, so a concurrent metadata write (e.g. a checkpoint write
+		// racing a usage/cost write for the same turn) can't be silently
+		// discarded by whichever write wins the retry. Falls back to the
+		// old read-once-then-write behavior for backends that don't
+		// implement it (e.g. test doubles).
+		const merged = await this.invokeOptionalValue<{
+			updated?: boolean;
+			metadata?: Record<string, unknown>;
+		}>("mergeSessionMetadata", sessionId, resolveMetadata);
+		if (merged !== undefined) {
+			if (merged.updated === false) {
+				return;
+			}
+			session.sessionMetadata = merged.metadata;
+			session.artifacts.manifest.metadata = merged.metadata;
+			return;
+		}
 		const currentManifest =
 			(await this.invokeOptionalValue<SessionManifest>(
 				"readSessionManifest",
 				sessionId,
-			)) ?? session?.artifacts?.manifest;
+			)) ?? session.artifacts.manifest;
 		const metadata = resolveMetadata(
 			currentManifest?.metadata as Record<string, unknown> | undefined,
 		);
-		if (!session?.artifacts) {
-			return;
-		}
 		const result = await this.invokeOptionalValue<{ updated?: boolean }>(
 			"updateSession",
 			{

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -398,6 +398,33 @@ export class LocalRuntimeHost implements RuntimeHost {
 					);
 			}
 		}
+		// A continuation carrying a new prompt (e.g. resuming after an
+		// interruption, or an auto-continue after a retry) is not
+		// `isReadOnlyResumeStart`, so `resumedArtifacts` stays unset above.
+		// `session.sessionMetadata` (seeded from `initialSessionMetadata`
+		// below) is what `ensureSessionPersisted` later upserts wholesale
+		// into storage the first time this in-memory session object needs
+		// to persist - if that metadata is left at its git-only default,
+		// checkpoint history (and anything else previously accumulated)
+		// gets silently overwritten even though it's still on disk/in the
+		// DB, because checkpoint history has no other source to recompute
+		// from. Preserve the existing persisted metadata as a fallback base
+		// in this case, without touching the read-only-resume path above.
+		let existingMetadataOnContinuation: Record<string, unknown> | undefined;
+		if (
+			!resumedArtifacts &&
+			requestedSessionId.length > 0 &&
+			initialMessages.length > 0
+		) {
+			const existingManifestForContinuation =
+				await this.invokeOptionalValue<SessionManifest>(
+					"readSessionManifest",
+					sessionId,
+				);
+			existingMetadataOnContinuation = existingManifestForContinuation?.metadata as
+				| Record<string, unknown>
+				| undefined;
+		}
 		const initialAggregateUsage = await this.seedAggregateUsageFromArtifacts({
 			initialUsage,
 			sessionDir,
@@ -477,12 +504,13 @@ export class LocalRuntimeHost implements RuntimeHost {
 				(await this.getSession(sessionId))?.metadata as
 					| Record<string, unknown>
 					| undefined,
-			writeSessionMetadata: async (metadata) => {
-				await this.persistSessionMetadata(sessionId, () => metadata);
-			},
+			writeSessionMetadata: (updater) =>
+				this.persistSessionMetadata(sessionId, updater),
 		});
 		const initialSessionMetadata = withSessionGitMetadata(
-			startInput.sessionMetadata ?? resumedArtifacts?.manifest.metadata,
+			startInput.sessionMetadata ??
+				resumedArtifacts?.manifest.metadata ??
+				existingMetadataOnContinuation,
 			bootstrap.gitState,
 		);
 		if (!resumedArtifacts) manifest.metadata = initialSessionMetadata;

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
@@ -2143,6 +2143,50 @@ describe("SessionRuntime.run — tracker wiring (P1 #3)", () => {
 		await session.continue("two");
 		// Second failed turn — counter reaches 2, tracker calls abort.
 		expect(abortCalls.length).toBeGreaterThanOrEqual(1);
+		// The mistake-limit stop notice is a synthetic system-injected
+		// `role: "user"` message; it must be tagged so checkpoint run
+		// counting doesn't mistake it for a genuine user turn.
+		const notice = session
+			.getMessages()
+			.find(
+				(message) =>
+					(message.metadata as Record<string, unknown> | undefined)?.kind ===
+					"mistake_stop_notice",
+			);
+		expect(notice).toBeDefined();
+		expect(notice?.role).toBe("user");
+	});
+
+	// When a consecutive-mistake limit decision resolves to "continue" with
+	// guidance, the guidance is appended as a synthetic system-injected
+	// `role: "user"` recovery notice - it must be tagged so checkpoint run
+	// counting doesn't mistake it for a genuine user turn.
+	it("tags the mistake-limit recovery notice as a synthetic message", async () => {
+		const { deps, abortCalls } = makeScriptedRuntime({
+			events: failedToolTurnEvents(),
+		});
+		const session = new SessionRuntime(
+			makeAgentConfig({
+				execution: { maxConsecutiveMistakes: 2 },
+				onConsecutiveMistakeLimitReached: () => ({
+					action: "continue",
+					guidance: "try a different approach",
+				}),
+			}),
+			deps,
+		);
+		await session.run("one");
+		await session.continue("two");
+		expect(abortCalls).toHaveLength(0);
+		const notice = session
+			.getMessages()
+			.find(
+				(message) =>
+					(message.metadata as Record<string, unknown> | undefined)?.kind ===
+					"recovery_notice",
+			);
+		expect(notice).toBeDefined();
+		expect(notice?.role).toBe("user");
 	});
 
 	it("serializes structured tool errors in mistake details", async () => {
@@ -2309,6 +2353,50 @@ describe("SessionRuntime.run — tracker wiring (P1 #3)", () => {
 		expect(abortCalls).toHaveLength(0);
 		await session.run("task two");
 		expect(abortCalls).toHaveLength(0);
+	});
+
+	// The soft-threshold loop warning is a synthetic system-injected
+	// `role: "user"` message; it must be tagged so checkpoint run counting
+	// doesn't mistake it for a genuine user turn.
+	it("tags the soft-threshold loop-detection warning as a synthetic message", async () => {
+		const identical = (i: number): AgentRuntimeEvent => ({
+			type: "tool-started",
+			iteration: i,
+			toolCall: {
+				type: "tool-call",
+				toolCallId: `tc${i}`,
+				toolName: "same",
+				input: { a: 1 },
+			},
+			snapshot: makeSnapshot(),
+		});
+		const { deps, abortCalls } = makeScriptedRuntime({
+			events: [
+				{ type: "turn-started", iteration: 1, snapshot: makeSnapshot() },
+				identical(1),
+				identical(1),
+			],
+		});
+		const session = new SessionRuntime(
+			makeAgentConfig({
+				execution: {
+					maxConsecutiveMistakes: 6,
+					loopDetection: { softThreshold: 2, hardThreshold: 3 },
+				},
+			}),
+			deps,
+		);
+		await session.run("loop-me");
+		expect(abortCalls).toHaveLength(0);
+		const notice = session
+			.getMessages()
+			.find(
+				(message) =>
+					(message.metadata as Record<string, unknown> | undefined)?.kind ===
+					"loop_detection_notice",
+			);
+		expect(notice).toBeDefined();
+		expect(notice?.role).toBe("user");
 	});
 
 	it("does not trigger loop-detection when execution.loopDetection === false", async () => {

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
@@ -425,9 +425,13 @@ export class SessionRuntime {
 			getConversationId: () => this.conversation.getConversationId(),
 			getActiveRunId: () => this.activeRunId ?? "",
 			appendRecoveryNotice: (message, _reason) => {
+				// Tag this synthetic system message so checkpoint run
+				// counting excludes it - see
+				// sdk/packages/core/src/session/checkpoint-message-filter.ts.
 				this.conversation.appendMessage({
 					role: "user",
 					content: [{ type: "text", text: message }],
+					metadata: { kind: "recovery_notice" },
 				});
 			},
 		});
@@ -1220,9 +1224,13 @@ export class SessionRuntime {
 		}
 		if (verdict.kind === "soft") {
 			if (verdict.message) {
+				// Tag this synthetic system message so checkpoint run
+				// counting excludes it - see
+				// sdk/packages/core/src/session/checkpoint-message-filter.ts.
 				this.conversation.appendMessage({
 					role: "user",
 					content: [{ type: "text", text: verdict.message }],
+					metadata: { kind: "loop_detection_notice" },
 				});
 			}
 			return;
@@ -1265,9 +1273,13 @@ export class SessionRuntime {
 			const outcome = await this.mistakeTracker.record(input);
 			if (outcome.action === "stop") {
 				this.trackerAbortInFlight = true;
+				// Tag this synthetic system message so checkpoint run
+				// counting excludes it - see
+				// sdk/packages/core/src/session/checkpoint-message-filter.ts.
 				this.conversation.appendMessage({
 					role: "user",
 					content: [{ type: "text", text: outcome.message }],
+					metadata: { kind: "mistake_stop_notice" },
 				});
 				this.activeRuntime?.abort(outcome.reason ?? outcome.message);
 			}

--- a/sdk/packages/core/src/services/local-runtime-bootstrap.ts
+++ b/sdk/packages/core/src/services/local-runtime-bootstrap.ts
@@ -113,25 +113,6 @@ function hasConfigExtension(
 	return hasRuntimeConfigExtension(extensions, kind);
 }
 
-function countSeededRootRuns(
-	messages: StartSessionInput["initialMessages"],
-): number {
-	let count = 0;
-	for (const message of messages ?? []) {
-		if (message.role !== "user") continue;
-		const metadata =
-			"metadata" in message &&
-			message.metadata &&
-			typeof message.metadata === "object" &&
-			!Array.isArray(message.metadata)
-				? (message.metadata as Record<string, unknown>)
-				: undefined;
-		if (metadata?.kind === "recovery_notice") continue;
-		count += 1;
-	}
-	return count;
-}
-
 function buildProviderConfig(
 	config: CoreSessionConfig,
 	sessionId: string,
@@ -237,7 +218,9 @@ export interface PrepareLocalRuntimeBootstrapOptions {
 	createSpawnTool: () => AgentTool;
 	readSessionMetadata: () => Promise<Record<string, unknown> | undefined>;
 	writeSessionMetadata: (
-		metadata: Record<string, unknown>,
+		updater: (
+			current: Record<string, unknown> | undefined,
+		) => Record<string, unknown>,
 	) => Promise<void> | void;
 }
 
@@ -415,7 +398,6 @@ export async function prepareLocalRuntimeBootstrap(
 					sessionId,
 					logger: baseConfig.logger,
 					createCheckpoint: baseConfig.checkpoint?.createCheckpoint,
-					initialRunCount: countSeededRootRuns(input.initialMessages),
 					readSessionMetadata,
 					writeSessionMetadata,
 				})

--- a/sdk/packages/core/src/session/checkpoint-message-filter.test.ts
+++ b/sdk/packages/core/src/session/checkpoint-message-filter.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import {
+	countGenuineUserPromptMessages,
+	isGenuineUserPromptMessage,
+} from "./checkpoint-message-filter";
+
+describe("isGenuineUserPromptMessage", () => {
+	it("rejects non-user roles", () => {
+		expect(isGenuineUserPromptMessage({ role: "assistant", content: "hi" })).toBe(
+			false,
+		);
+	});
+
+	it("accepts plain text user messages", () => {
+		expect(isGenuineUserPromptMessage({ role: "user", content: "hi" })).toBe(
+			true,
+		);
+	});
+
+	it("rejects empty string content", () => {
+		expect(isGenuineUserPromptMessage({ role: "user", content: "   " })).toBe(
+			false,
+		);
+	});
+
+	it("rejects messages consisting solely of tool_result blocks", () => {
+		expect(
+			isGenuineUserPromptMessage({
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "call_1",
+						name: "read_file",
+						content: "contents",
+					},
+				],
+			}),
+		).toBe(false);
+	});
+
+	it("accepts messages mixing text and tool_result blocks", () => {
+		expect(
+			isGenuineUserPromptMessage({
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "call_1",
+						name: "read_file",
+						content: "contents",
+					},
+					{ type: "text", text: "here's the file, also please fix X" },
+				],
+			}),
+		).toBe(true);
+	});
+
+	it("rejects known synthetic system-injected kinds", () => {
+		for (const kind of [
+			"recovery_notice",
+			"compaction_summary",
+			"loop_detection_notice",
+			"mistake_stop_notice",
+		]) {
+			expect(
+				isGenuineUserPromptMessage({
+					role: "user",
+					content: "synthetic",
+					metadata: { kind },
+				}),
+			).toBe(false);
+		}
+	});
+});
+
+describe("countGenuineUserPromptMessages", () => {
+	it("counts only genuine user turns across a mixed conversation", () => {
+		const messages = [
+			{ role: "user" as const, content: "first" },
+			{ role: "assistant" as const, content: "reply" },
+			{
+				role: "user" as const,
+				content: [
+					{
+						type: "tool_result" as const,
+						tool_use_id: "call_1",
+						name: "read_file",
+						content: "contents",
+					},
+				],
+			},
+			{
+				role: "user" as const,
+				content: "reminder",
+				metadata: { kind: "completion_reminder" },
+			},
+			{ role: "user" as const, content: "second" },
+		];
+
+		expect(countGenuineUserPromptMessages(messages)).toBe(2);
+	});
+});

--- a/sdk/packages/core/src/session/checkpoint-message-filter.ts
+++ b/sdk/packages/core/src/session/checkpoint-message-filter.ts
@@ -1,0 +1,76 @@
+// This file provides a single, shared definition of "a genuine user turn"
+// for the persisted conversation format (`LlmsProviders.Message`), reused by
+// both checkpoint creation (via checkpoint-run-counting.ts) and checkpoint
+// restore so the two can never drift from each other again.
+import type * as LlmsProviders from "@cline/llms";
+
+/**
+ * Metadata `kind` tags that mark a `role: "user"` message as a synthetic,
+ * system-injected notice rather than something the user actually typed.
+ * Keep this in sync with every `metadata: { kind: "..." }` tag applied to a
+ * `role: "user"` message across the codebase.
+ */
+const SYNTHETIC_USER_MESSAGE_KINDS = new Set([
+	"recovery_notice",
+	"compaction_summary",
+	"loop_detection_notice",
+	"mistake_stop_notice",
+	// Tagged at the live-runtime layer (agent-runtime.ts's
+	// addUserReminderMessage) - included here too since metadata survives the
+	// AgentMessage <-> LlmsProviders.Message conversion (agent-message-codec.ts),
+	// so a reminder can end up persisted into the stored conversation.
+	"completion_reminder",
+]);
+
+type GenericMessage = LlmsProviders.Message | LlmsProviders.MessageWithMetadata;
+
+function readMessageMetadata(
+	message: GenericMessage,
+): Record<string, unknown> | undefined {
+	return "metadata" in message &&
+		message.metadata &&
+		typeof message.metadata === "object" &&
+		!Array.isArray(message.metadata)
+		? (message.metadata as Record<string, unknown>)
+		: undefined;
+}
+
+/**
+ * A stored/persisted message counts as a genuine user-initiated turn only if:
+ *  - its role is "user",
+ *  - it isn't tagged as one of the synthetic system-injected kinds above, and
+ *  - its content carries at least one block that isn't a tool_result (tool
+ *    results are modeled as `role: "user"` messages in this wire format - see
+ *    ToolResultContent in @cline/shared - so a message consisting solely of
+ *    tool_result blocks is an internal continuation, not a user turn). A
+ *    message mixing real content with a tool_result still counts as genuine.
+ */
+export function isGenuineUserPromptMessage(message: GenericMessage): boolean {
+	if (message.role !== "user") {
+		return false;
+	}
+	const kind = readMessageMetadata(message)?.kind;
+	if (typeof kind === "string" && SYNTHETIC_USER_MESSAGE_KINDS.has(kind)) {
+		return false;
+	}
+	const content = message.content;
+	if (typeof content === "string") {
+		return content.trim().length > 0;
+	}
+	if (!Array.isArray(content) || content.length === 0) {
+		return false;
+	}
+	return content.some((block) => block.type !== "tool_result");
+}
+
+export function countGenuineUserPromptMessages(
+	messages: readonly GenericMessage[],
+): number {
+	let count = 0;
+	for (const message of messages) {
+		if (isGenuineUserPromptMessage(message)) {
+			count += 1;
+		}
+	}
+	return count;
+}

--- a/sdk/packages/core/src/session/checkpoint-restore.test.ts
+++ b/sdk/packages/core/src/session/checkpoint-restore.test.ts
@@ -105,6 +105,31 @@ describe("checkpoint message trimming", () => {
 		]);
 	});
 
+	// Tool results are modeled as `role: "user"` messages in this wire format
+	// (ToolResultContent blocks) - they must not be mistaken for a genuine
+	// user turn when locating the checkpoint's message index.
+	it("does not count tool_result-only messages as a user turn", () => {
+		const messages = [
+			{ role: "user" as const, content: "first" },
+			{ role: "assistant" as const, content: "first response" },
+			{
+				role: "user" as const,
+				content: [
+					{
+						type: "tool_result" as const,
+						tool_use_id: "call_1",
+						name: "read_file",
+						content: "file contents",
+					},
+				],
+			},
+			{ role: "assistant" as const, content: "second response" },
+			{ role: "user" as const, content: "second" },
+		];
+
+		expect(trimMessagesToCheckpoint(messages, 2)).toEqual(messages.slice(0, 5));
+	});
+
 	it("uses the nearest earlier checkpoint when an identical snapshot was deduplicated", () => {
 		const messages = [
 			{ role: "user" as const, content: "first" },

--- a/sdk/packages/core/src/session/checkpoint-restore.ts
+++ b/sdk/packages/core/src/session/checkpoint-restore.ts
@@ -6,6 +6,7 @@ import type {
 	CheckpointMetadata,
 } from "../hooks/checkpoint-hooks";
 import type { SessionRecord } from "../types/sessions";
+import { isGenuineUserPromptMessage } from "./checkpoint-message-filter";
 
 const execFile = promisify(execFileCallback);
 
@@ -83,16 +84,7 @@ function findCheckpointMessageIndex(
 	let userRunCount = 0;
 	for (let index = 0; index < messages.length; index += 1) {
 		const message = messages[index];
-		if (message?.role !== "user") {
-			continue;
-		}
-		const metadata =
-			"metadata" in message &&
-			message.metadata &&
-			typeof message.metadata === "object"
-				? (message.metadata as Record<string, unknown>)
-				: undefined;
-		if (metadata?.kind === "recovery_notice") {
+		if (!message || !isGenuineUserPromptMessage(message)) {
 			continue;
 		}
 		userRunCount += 1;

--- a/sdk/packages/core/src/session/services/persistence-service.test.ts
+++ b/sdk/packages/core/src/session/services/persistence-service.test.ts
@@ -14,6 +14,8 @@ import { SessionSource } from "../../types/common";
 import { createSessionCompactionState } from "../models/session-compaction";
 import { FileSessionService } from "../services/file-session-service";
 import { CoreSessionService } from "../services/session-service";
+import type { SessionPersistenceAdapter } from "./persistence-service";
+import { UnifiedSessionPersistenceService } from "./persistence-service";
 
 const require = createRequire(import.meta.url);
 const sqliteAvailable = (() => {
@@ -535,6 +537,88 @@ describe("UnifiedSessionPersistenceService", () => {
 
 		const [row] = await service.listSessions(10);
 		expect(row?.metadata).toMatchObject({ title: "first saved prompt" });
+	});
+
+	it("mergeSessionMetadata re-applies the resolver against fresh state on every OCC retry", async () => {
+		const sessionsDir = mkdtempSync(join(tmpdir(), "merge-metadata-race-"));
+		tempDirs.push(sessionsDir);
+
+		let statusLock = 0;
+		let metadata: Record<string, unknown> | undefined = { existing: "value" };
+		let updateSessionCalls = 0;
+
+		const fakeAdapter: SessionPersistenceAdapter = {
+			ensureSessionsDir: () => sessionsDir,
+			upsertSession: async () => {},
+			getSession: async (sessionId) => ({
+				sessionId,
+				source: "cli",
+				pid: 1,
+				startedAt: "2026-01-01T00:00:00.000Z",
+				endedAt: null,
+				exitCode: null,
+				status: "running",
+				statusLock,
+				interactive: true,
+				provider: "mock",
+				model: "mock",
+				cwd: "/tmp/project",
+				workspaceRoot: "/tmp/project",
+				teamName: null,
+				enableTools: true,
+				enableSpawn: true,
+				enableTeams: false,
+				parentSessionId: null,
+				parentAgentId: null,
+				agentId: null,
+				conversationId: null,
+				isSubagent: false,
+				prompt: null,
+				metadata,
+				hookPath: "",
+				messagesPath: null,
+				updatedAt: "2026-01-01T00:00:00.000Z",
+			}),
+			listSessions: async () => [],
+			updateSession: async (input) => {
+				updateSessionCalls += 1;
+				if (updateSessionCalls === 1) {
+					// Simulate a concurrent writer (e.g. a usage/cost update for
+					// the same turn) committing between our read and our write.
+					statusLock += 1;
+					metadata = { ...metadata, concurrentWrite: true };
+					return { updated: false, statusLock };
+				}
+				if (input.expectedStatusLock !== statusLock) {
+					return { updated: false, statusLock };
+				}
+				statusLock += 1;
+				metadata = (input.metadata ?? undefined) as
+					| Record<string, unknown>
+					| undefined;
+				return { updated: true, statusLock };
+			},
+			deleteSession: async () => true,
+			enqueueSpawnRequest: async () => {},
+			claimSpawnRequest: async () => undefined,
+		};
+
+		const service = new UnifiedSessionPersistenceService(fakeAdapter);
+
+		const result = await service.mergeSessionMetadata("sess-race", (current) => ({
+			...(current ?? {}),
+			ourCheckpoint: "run-1",
+		}));
+
+		expect(updateSessionCalls).toBe(2);
+		expect(result).toEqual({
+			updated: true,
+			metadata: {
+				existing: "value",
+				concurrentWrite: true,
+				ourCheckpoint: "run-1",
+			},
+		});
 	});
 
 	sqliteIt(

--- a/sdk/packages/core/src/session/services/persistence-service.ts
+++ b/sdk/packages/core/src/session/services/persistence-service.ts
@@ -284,6 +284,54 @@ export class UnifiedSessionPersistenceService {
 		return { updated: false };
 	}
 
+	// Not exposed on the public RuntimeHost/ClineCore API - internal use only
+	// (via LocalRuntimeHost.persistSessionMetadata), so it can't be a breaking
+	// change for external callers of updateSession() who expect
+	// replace-semantics.
+	//
+	// `updateSession()` above already retries on an OCC lock conflict, but on
+	// each retry it re-writes the SAME `input.metadata` the caller computed
+	// once, before the retry loop even started - it never re-merges against
+	// the freshly-read `row.metadata` obtained on that attempt. Two callers
+	// racing to update metadata (e.g. a checkpoint write and a usage/cost
+	// write for the same turn) can each pass the OCC check on a later retry
+	// while blindly overwriting whatever the other committed in between - a
+	// classic lost update, silently invisible to both callers (both see
+	// `updated: true`). This variant re-applies `resolveMetadata` against the
+	// freshly-read row on every attempt, so a retry can never discard a
+	// concurrent writer's change.
+	async mergeSessionMetadata(
+		sessionId: string,
+		resolveMetadata: (
+			current: Record<string, unknown> | undefined,
+		) => Record<string, unknown> | undefined,
+	): Promise<{ updated: boolean; metadata?: Record<string, unknown> }> {
+		for (let attempt = 0; attempt < OCC_MAX_RETRIES; attempt++) {
+			const row = await this.adapter.getSession(sessionId);
+			if (!row) return { updated: false };
+			const nextMeta =
+				sanitizeMetadata(resolveMetadata(row.metadata ?? undefined)) ?? {};
+			const changed = await this.adapter.updateSession({
+				sessionId,
+				metadata: Object.keys(nextMeta).length > 0 ? nextMeta : null,
+				expectedStatusLock: row.statusLock,
+			});
+			if (!changed.updated) continue;
+			const { path: manifestPath, manifest } =
+				this.manifestStore.readManifestFile(sessionId);
+			if (manifest) {
+				manifest.metadata =
+					Object.keys(nextMeta).length > 0 ? nextMeta : undefined;
+				this.manifestStore.writeSessionManifest(manifestPath, manifest);
+			}
+			return {
+				updated: true,
+				metadata: Object.keys(nextMeta).length > 0 ? nextMeta : undefined,
+			};
+		}
+		return { updated: false };
+	}
+
 	queueSpawnRequest(event: HookEventPayload): Promise<void> {
 		return this.teamChildren.queueSpawnRequest(event);
 	}


### PR DESCRIPTION
Fixes #12388

## Summary

Checkpoint restore fails with `No checkpoint found at or before run N in session ...` whenever a provider issues internal continuations between visible user turns (retries, transient-error recovery, etc). This is reproducible with any provider, but becomes near-universal once continuations are frequent.

**Root cause:** `AgentRuntime.run()` and `.continue()` both funnel into the same `execute()`, which invokes the `beforeRun` hook unconditionally - regardless of whether the call represents a new user turn or an internal continuation. The checkpoint hook (`sdk/packages/core/src/hooks/checkpoint-hooks.ts`) incremented its `runCount` on that same signal, so it counted low-level runtime invocations instead of user-visible turns - silently diverging from the webview's own turn counter (`apps/vscode/src/sdk/sdk-checkpoints.ts`), which counts genuine user-authored messages. The two scales never reconcile, so restoring an early checkpoint fails as soon as any internal continuation has occurred since session start.

**Fix:** derive the checkpoint run number directly from the count of genuine user-authored messages in the snapshot instead of a mutable counter incremented per invocation. This requires distinguishing real user messages from synthetic system-injected ones (completion-tool reminders, recovery notices, loop-detection warnings, mistake-limit stop notices, compaction summaries) via `metadata.kind` - several of these tags didn't exist yet and are added here. Two small modules centralize the "is this a genuine user turn?" definition for the two message shapes in play:
- `checkpoint-run-counting.ts` for the live `AgentMessage` runtime snapshot (tool results have their own `role: "tool"`)
- `checkpoint-message-filter.ts` for the persisted `LlmsProviders.Message` conversation format (tool results are folded into `role: "user"` messages via `ToolResultContent` blocks)

so checkpoint creation and checkpoint restore can never drift from each other again.

Also fixes two related data-loss bugs found while tracking this down:
- `writeSessionMetadata` now merges against the freshest persisted value at write time instead of a value captured earlier, closing a race that could silently drop concurrently-written metadata.
- Resuming a session with a new prompt (as opposed to a read-only reopen) now preserves existing checkpoint history instead of letting the first lazy persistence pass overwrite it with a git-only default.

**Third fix (added after further real-world testing):** even with the above, fast/tool-heavy sessions (many turns in quick succession) still lost most of their checkpoint history. `UnifiedSessionPersistenceService.updateSession()` already retries on an OCC status-lock conflict, but every retry re-writes the *same* metadata object the caller computed once before the retry loop started - it never re-merges against the freshly-read row obtained on that attempt. Two callers racing to update metadata for the same session (e.g. a checkpoint write and a usage/cost write for the same turn) can each pass the OCC check on a later retry while blindly overwriting whatever the other committed in between - a lost update invisible to both callers. Added `mergeSessionMetadata()`, which re-applies the resolver against the freshly-read row on every retry attempt. It's intentionally not exposed on the public RuntimeHost/ClineCore API (only used internally by `LocalRuntimeHost.persistSessionMetadata`), so it can't be a breaking change for existing `updateSession()` callers that expect replace semantics.

## Test plan

- [x] `bun run typecheck` clean on `sdk/packages/core` and `sdk/packages/agents`
- [x] New/updated unit tests for `checkpoint-run-counting.ts`, `checkpoint-message-filter.ts`, `checkpoint-hooks.ts`, `checkpoint-restore.ts`, `agent-runtime.ts`, `session-runtime-orchestrator.ts`, `local-runtime-host.ts`, `persistence-service.ts` (including a test that deterministically reproduces the concurrent-write lost update and fails without the `mergeSessionMetadata` fix) - 190+ tests passing across the affected suites
- [x] Manually reproduced the original failure (checkpoint restore on an early prompt after several internal continuations, and separately on a fast tool-heavy session) and confirmed both are fixed after this change