### PR TITLE
fix(llms): add Kimi K3 to bundled ClinePass model fallback

### DIFF
--- a/sdk/packages/llms/src/catalog/catalog.generated.ts
+++ b/sdk/packages/llms/src/catalog/catalog.generated.ts
@@ -4253,6 +4253,30 @@ export const GENERATED_PROVIDER_MODELS: {
 				family: "glm",
 				description: "Best open weights model",
 			},
+			"cline-pass/kimi-k3": {
+				name: "Kimi K3",
+				id: "cline-pass/kimi-k3",
+				contextWindow: 1048576,
+				maxInputTokens: 1048576,
+				maxTokens: 1048576,
+				capabilities: [
+					"images",
+					"tools",
+					"reasoning",
+					"structured_output",
+					"prompt-cache",
+				],
+				pricing: {
+					input: 3,
+					output: 15,
+					cacheRead: 0.3,
+					cacheWrite: 0,
+				},
+				releaseDate: "2026-07-16",
+				family: "kimi-k3",
+				description:
+					"Leading open weights model (reliability might be unstable and will consume usage faster than others)",
+			},
 			"cline-pass/deepseek-v4-pro": {
 				name: "DeepSeek V4 Pro",
 				id: "cline-pass/deepseek-v4-pro",

--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -9,6 +9,7 @@ import {
 	type ProviderCapability,
 	type ProviderConfigField,
 } from "@cline/shared";
+import { GENERATED_PROVIDER_MODELS } from "../catalog/catalog.generated";
 import { getGeneratedModelsForProvider } from "../catalog/catalog.generated-access";
 import {
 	isCanonicalModelIdForAliasRules,
@@ -307,7 +308,13 @@ function generatedModels(providerId: string): Record<string, ModelInfo> {
 }
 
 function firstGeneratedModelId(providerId: string): string {
-	const generatedModelList = Object.keys(generatedModels(providerId));
+	// Use the catalog's authored order, not release-date order. The cline-pass
+	// block mirrors the recommended-models endpoint, which lists the intended
+	// default subscription model first — the newest model is not necessarily a
+	// safe default.
+	const generatedModelList = Object.keys(
+		GENERATED_PROVIDER_MODELS.providers[providerId] ?? {},
+	);
 	if (!generatedModelList.length) {
 		return "";
 	}


### PR DESCRIPTION
### Related Issue

Users reported that the **Kimi K3** ClinePass model was not appearing in the model picker, while other ClinePass models showed up fine.

### Description

**Problem:** The ClinePass model list is fetched live from `GET /api/v1/ai/cline/recommended-models`. When that fetch succeeds, the picker renders exactly what the endpoint returns. When it **fails or returns empty** (blocked network, offline, degraded connectivity, etc.), the code falls back to a bundled snapshot compiled into the shipped extension.

The fallback lives in `sdk/packages/llms/src/catalog/catalog.generated.ts` under the `"cline-pass"` block, and is consumed by `mergeKnownModels` in `sdk/packages/core/src/services/llms/provider-defaults.ts`:

```ts
if (providerId === "cline-pass" && Object.keys(liveModels).length > 0) {
  return { ...liveModels, ...userKnownModels }; // live path — endpoint as-is
}
// ...otherwise falls through to the bundled `generated` snapshot
```

`catalog.generated.ts` is produced by `scripts/generate-models.ts`, which snapshots that same endpoint at build time. The committed snapshot was **stale**: it predated Kimi K3 being added to the endpoint, so it carried 10 cline-pass models and was missing `cline-pass/kimi-k3`.

**Result:**
- Users with a working connection to the endpoint → saw Kimi K3 fine.
- Users hitting the fallback → got the stale list without Kimi K3. These are the people who complained.

I confirmed the live endpoint currently returns 11 cline-pass models including `cline-pass/kimi-k3`, and that the bundled snapshot was identical except for that one missing model.

**Fix (commit 1):** Added the `cline-pass/kimi-k3` entry to the bundled fallback, positioned right after `glm-5.2` to match the live endpoint's ordering. The entry mirrors exactly what a regeneration produces — capabilities/pricing/context (1M window, $3/$15 in/out) are sourced from the OpenRouter `moonshotai/kimi-k3` entry that the generator uses, with the id/description taken from the endpoint.

I intentionally hand-added the single entry rather than running a full `bun run build:models` regeneration, to keep the diff surgical and avoid churning the entire ~25k-line catalog (and unrelated models.dev drift) into a hotfix release. Since the endpoint already serves K3, the next full regeneration will reproduce this exact entry, so there's no drift risk.

### Regression found and fixed while validating (commit 2)

Adding K3 to the catalog alone would have **silently flipped the ClinePass default model to Kimi K3**:

- `builtins.ts` sets ClinePass's `defaultModelId` from `firstGeneratedModelId("cline-pass")`, which read the bundled catalog through `getGeneratedModelsForProvider` — i.e. **sorted newest-release-date-first**.
- Before this PR, the newest cline-pass entry was `glm-5.2` (2026-06-13), so the derived default happened to match the endpoint's curated first model. The new K3 entry (2026-07-16) became the newest, so the derived default flipped to `cline-pass/kimi-k3` — the model whose own description warns "reliability might be unstable and will consume usage faster than others".
- Because K3 *is* in the live list, the existing "bundled default id rotated out of the live list" safeguard would never correct it — every fresh ClinePass setup would default to K3. The existing test only asserts the default id exists in the model map, so CI stayed green.

Note this wasn't specific to the hand-edit: the next full catalog regeneration would have pulled K3 in with the same release date and flipped the default identically.

**Fix:** `firstGeneratedModelId` (only used by cline-pass) now reads the catalog's **authored order** (`GENERATED_PROVIDER_MODELS` insertion order) instead of the release-date-sorted view. The authored order mirrors the recommended-models endpoint's curated list — intended default first, subscription models before free ones — so the default stays `cline-pass/glm-5.2` now and stays correct after future regens.

### Test Procedure

- `bun -F @cline/llms typecheck` passes; `bun biome check` clean on both changed files.
- `bun -F @cline/llms test` passes (414 passed / 4 skipped), including the cline-pass builtin spec tests.
- Core `provider-defaults.test.ts` passes (16 tests).
- Verified through the real provider registry (not just unit tests): `getProvider("cline-pass").defaultModelId === "cline-pass/glm-5.2"`, `cline-pass/kimi-k3` present in `getModelsForProvider("cline-pass")`, and the default id resolves to an existing model.
- Verified the resulting bundled cline-pass list now matches the live endpoint's 11-model list exactly.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore
-   [x] Tests are passing (`bun test`) and code is formatted and linted
-   [x] I have reviewed contributor guidelines

### Additional Notes

- This only affects users on the fallback path; anyone with a working connection to the recommended-models endpoint already sees Kimi K3. If a significant number of users are hitting the fallback, it may be worth separately investigating *why* their live fetch to the endpoint is failing.
- Follow-up idea (out of scope): a test asserting the cline-pass `defaultModelId` is the catalog's first authored entry (or explicitly not a free/warned model) would catch future default flips that the current "default exists in models" assertion misses.
