### PR TITLE
docs: add Kimi K3 to ClinePass model list and pricing

### DIFF
--- a/docs/getting-started/clinepass.mdx
+++ b/docs/getting-started/clinepass.mdx
@@ -50,6 +50,7 @@ ClinePass includes the following models, tested and benchmarked for coding agent
 | Model | Model ID |
 |-------|------------|
 | GLM-5.2 | `cline-pass/glm-5.2` |
+| Kimi K3 | `cline-pass/kimi-k3` |
 | Kimi K2.7 Code | `cline-pass/kimi-k2.7-code` |
 | Kimi K2.6 | `cline-pass/kimi-k2.6` |
 | DeepSeek V4 Pro | `cline-pass/deepseek-v4-pro` |
@@ -91,6 +92,7 @@ ClinePass is a flat monthly subscription, so you are not charged the individual 
 | Model | Input | Output | Cached Read | Cached Write |
 |-------|-------|--------|-------------|--------------|
 | GLM-5.2 | $1.40 | $4.40 | $0.26 | - |
+| Kimi K3 | $3.00 | $15.00 | $0.30 | - |
 | Kimi K2.7 Code | $0.95 | $4.00 | $0.19 | - |
 | Kimi K2.6 | $0.95 | $4.00 | $0.16 | - |
 | DeepSeek V4 Pro | $1.74 | $3.48 | $0.0145 | - |


### PR DESCRIPTION
### Related Issue

Follow-up to #12392. The **Kimi K3** ClinePass model was missing from the docs' model list and reference-pricing table, even though it's live on the endpoint.

### Description

`docs/getting-started/clinepass.mdx` is the only docs page that enumerates the ClinePass models, and it was missing Kimi K3. This adds it to both tables:

- **Models table:** `Kimi K3` → `cline-pass/kimi-k3`, placed right after GLM-5.2 to match the recommended-models endpoint's curated ordering.
- **Reference pricing table:** `$3.00 in / $15.00 out / $0.30 cached read`, sourced from the same catalog entry the shipped models use (OpenRouter `moonshotai/kimi-k3`).

The runtime side (bundled model catalog + default-model handling) was fixed in #12392; this is the docs-only counterpart.

### Test Procedure

Docs-only change — no code affected. Verified the model id and pricing match the shipped catalog entry from #12392 and the live `recommended-models` endpoint. Mintlify deployment preview will render the updated tables.

### Type of Change

-   [x] 📚 Documentation update

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore
-   [x] I have reviewed contributor guidelines

### Additional Notes

The endpoint's own description for K3 notes "reliability might be unstable and will consume usage faster than others." I did not add that caveat to the docs since it's a positioning/voice call — happy to add a footnote if desired.
