### PR TITLE
fix(cli): show out-of-credits card for real insufficient_credits API errors

### DIFF
--- a/apps/cli/src/tui/cline-account.test.ts
+++ b/apps/cli/src/tui/cline-account.test.ts
@@ -309,3 +309,62 @@ describe("loadIndividualSubscriptionPlans", () => {
 		expect(result).toEqual(plans);
 	});
 });
+
+describe("isClineAccountCreditsErrorMessage", () => {
+	it("matches the raw insufficient_credits JSON payload from the Cline API 402", async () => {
+		const { isClineAccountCreditsErrorMessage } = await import(
+			"./cline-account"
+		);
+		expect(
+			isClineAccountCreditsErrorMessage(
+				'{"code":"insufficient_credits","current_balance":-0.14,"message":"Not enough credits available"}',
+			),
+		).toBe(true);
+	});
+
+	it("matches the insufficient_credits payload wrapped in an error prefix", async () => {
+		const { isClineAccountCreditsErrorMessage } = await import(
+			"./cline-account"
+		);
+		expect(
+			isClineAccountCreditsErrorMessage(
+				'Error: {"code":"insufficient_credits","current_balance":0,"message":"Not enough credits available"}',
+			),
+		).toBe(true);
+	});
+
+	it("matches the plain human-readable Cline API message", async () => {
+		const { isClineAccountCreditsErrorMessage } = await import(
+			"./cline-account"
+		);
+		expect(
+			isClineAccountCreditsErrorMessage("Not enough credits available"),
+		).toBe(true);
+	});
+
+	it("matches the legacy insufficient balance phrasing", async () => {
+		const { isClineAccountCreditsErrorMessage } = await import(
+			"./cline-account"
+		);
+		expect(
+			isClineAccountCreditsErrorMessage(
+				"Insufficient balance. Your Cline credits balance is $0.00.",
+			),
+		).toBe(true);
+	});
+
+	it("does not match unrelated errors", async () => {
+		const { isClineAccountCreditsErrorMessage } = await import(
+			"./cline-account"
+		);
+		expect(isClineAccountCreditsErrorMessage("Payment Required")).toBe(false);
+		expect(
+			isClineAccountCreditsErrorMessage(
+				"Your credit balance is too low to access the Anthropic API.",
+			),
+		).toBe(false);
+		expect(
+			isClineAccountCreditsErrorMessage("insufficient balance on gateway"),
+		).toBe(false);
+	});
+});

--- a/apps/cli/src/tui/cline-account.ts
+++ b/apps/cli/src/tui/cline-account.ts
@@ -51,9 +51,16 @@ export function isClineAccountAuthErrorMessage(message: string): boolean {
 
 export function isClineAccountCreditsErrorMessage(message: string): boolean {
 	const normalized = message.trim().toLowerCase();
+	// The Cline API's 402 response carries `code: "insufficient_credits"` and
+	// the message "Not enough credits available". Depending on how much of the
+	// payload survives error extraction, the CLI may see the raw JSON blob or
+	// just the human-readable message, so match both. The
+	// "insufficient balance" pair is an older backend phrasing kept for safety.
 	return (
-		normalized.includes("insufficient balance") &&
-		normalized.includes("cline credits balance")
+		normalized.includes("insufficient_credits") ||
+		normalized.includes("not enough credits") ||
+		(normalized.includes("insufficient balance") &&
+			normalized.includes("cline credits balance"))
 	);
 }
 


### PR DESCRIPTION
### Related Issue

User report: when a personal Cline account runs out of credits, the CLI shows a cryptic generic error instead of the out-of-credits card.

### Description

**The problem.** The CLI has a dedicated "Cline Credits depleted" card (`ClineCreditsErrorView` in `chat-entry.tsx`) with purchase links, but it only renders when `isClineAccountCreditsErrorMessage` matches the error text — and that matcher required the message to contain both `"insufficient balance"` **and** `"cline credits balance"`.

The Cline API's actual 402 response contains neither phrase. Its payload is:

```json
{"code": "insufficient_credits", "current_balance": -0.14, "message": "Not enough credits available"}
```

(see the e2e fixture server in `apps/vscode/src/test/e2e/fixtures/server/index.ts`, which mirrors production). Depending on how much of the payload survives `extractErrorMessage` in `@cline/llms`, the CLI's error entry text ends up being either the raw JSON blob or just `"Not enough credits available"` — neither matches, so out-of-credit users get a raw red `Error: {"code":"insufficient_credits",...}` line instead of the card. That's exactly the bug reported ("didn't tell me out of credit but gave me some other error").

**How I found it.** The VS Code extension hit this same mismatch and already patched around it: `reshapeErrorForWebview` in `apps/vscode/src/sdk/message-translator.ts` detects the `insufficient_credits` JSON code plus several plain-text variants, and its comments literally cite `Error: {"code":"insufficient_credits",...}` as the observed input shape. The CLI matcher (added in #11345) never got the equivalent fix — the phrasing it matches (`"cline credits balance"`) appears nowhere else in the repo or its git history, so it either matched an older backend message or never matched at all. It had no test coverage.

**The fix.** Widen the matcher to catch what the API actually sends:
- `insufficient_credits` — the error code, present whenever any part of the JSON payload survives extraction
- `not enough credits` — the human-readable message, for when only that survives
- the legacy `insufficient balance` + `cline credits balance` pair is kept as-is for safety

Deliberately narrow keywords to avoid false positives from other providers (e.g. Anthropic's "Your credit balance is too low to access the Anthropic API" does not match — there's a test asserting that). The matcher is string-based because the error reaches the TUI as plain text; there's an existing FIXME in `cline-account.ts` about passing structured error types through instead, which remains the right long-term fix (a typed `ClineInsufficientCreditsError` in `@cline/llms` would let both CLI and extension delete their string hacks).

### Test Procedure

- Added a `describe("isClineAccountCreditsErrorMessage")` block to `apps/cli/src/tui/cline-account.test.ts` covering: the raw 402 JSON blob, the blob wrapped in an `Error:` prefix, the bare human-readable message, the legacy phrasing, and negative cases (generic `Payment Required`, Anthropic's low-balance message, unrelated "insufficient balance" text).
- `bun run vitest run src/tui/cline-account.test.ts` — 9/9 pass.
- `tsc --noEmit` in `apps/cli` passes; biome check at CI diagnostic level passes.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)