### PR TITLE
docs: add DaoXE to Other 30+ Providers

### DIFF
--- a/docs/provider-config/other-30-plus-providers.mdx
+++ b/docs/provider-config/other-30-plus-providers.mdx
@@ -13,6 +13,7 @@ Use this page for providers that follow the same setup pattern.
   - [AskSage](#asksage)
   - [Baseten](#baseten)
   - [Cerebras](#cerebras)
+  - [DaoXE](#daoxe)
   - [Dify.ai](#difyai)
   - [Doubao](#doubao)
   - [Fireworks AI](#fireworks-ai)
@@ -89,6 +90,17 @@ Cerebras offers very fast hosted inference for supported model families.
 1. Sign in to Cerebras Cloud.
 2. Create or retrieve your API key.
 3. In Cline, select **Cerebras** and enter the key.
+
+### DaoXE
+DaoXE is an OpenAI-compatible, multi-protocol model gateway (Chat Completions, OpenAI Responses, and Anthropic Messages) that exposes Claude, GPT, Gemini, DeepSeek, Kimi, Qwen and Doubao behind one API key.
+
+**Website:** [https://daoxe.com/](https://daoxe.com/)
+
+#### Basic Setup
+
+1. Create or sign in to your DaoXE account and generate an API key.
+2. In Cline, select **OpenAI Compatible** as the API Provider.
+3. Set **Base URL** to `https://daoxe.com/v1`, paste your API key, and enter a Model ID from `GET /v1/models`.
 
 ### Dify.ai
 Dify.ai is a workflow-centric AI platform with app and pipeline capabilities.


### PR DESCRIPTION
Adds DaoXE (an OpenAI-compatible, multi-protocol model gateway) to the "Other 30+ Providers" reference list, alongside similar aggregators already listed there (AIHubMix, Requesty, Vercel AI Gateway). Cline's OpenAI Compatible provider works out of the box with base URL https://daoxe.com/v1.

- Menu entry + `### DaoXE` section in docs/provider-config/other-30-plus-providers.mdx (matches existing entry format).

Disclosure: DaoXE is a service we operate. Not available in mainland China.

Made with [Cursor](https://cursor.com)