### PR TITLE
fix(cli): bound the agent loop with a default maxIterations

### DIFF
--- a/apps/cli/src/commands/program.ts
+++ b/apps/cli/src/commands/program.ts
@@ -57,6 +57,10 @@ export function addRootOptions(cmd: Command): Command {
 				"Number of maximum consecutive mistakes (retries) before exiting (default: 6)",
 			)
 			.option(
+				"--max-iterations [value]",
+				"Maximum number of agent loop iterations before exiting (default: 100)",
+			)
+			.option(
 				"-t, --timeout <seconds>",
 				"Optional timeout in seconds (default: 0 for no timeout)",
 			)
@@ -211,6 +215,17 @@ export function commanderToParsedArgs(program: Command): ParsedArgs {
 			result.retries = parsed;
 		} else if (raw) {
 			result.invalidRetries = raw;
+		}
+	}
+
+	// Max iterations (agent loop bound) validation
+	if (opts.maxIterations !== undefined) {
+		const raw = opts.maxIterations.trim();
+		const parsed = Number.parseInt(raw, 10);
+		if (raw && Number.isInteger(parsed) && parsed >= 1) {
+			result.maxIterations = parsed;
+		} else if (raw) {
+			result.invalidMaxIterations = raw;
 		}
 	}
 

--- a/apps/cli/src/main.test.ts
+++ b/apps/cli/src/main.test.ts
@@ -6,6 +6,7 @@ import type {
 	CliMigrationNotice,
 	CliMigrationNoticeOptions,
 } from "./kanban-migration/notice";
+import { CLI_DEFAULT_MAX_ITERATIONS } from "./runtime/defaults";
 
 /** Real `fstatSync`: used when tests stub only stdin (fd 0); throwing for every fd breaks imports and session I/O. */
 const fsActual = vi.hoisted(() => ({
@@ -569,6 +570,42 @@ describe("runCli lightweight command dispatch", () => {
 		expect(runtimeMocks.runAgent).toHaveBeenCalledWith(
 			"hello world",
 			expect.any(Object),
+			expect.anything(),
+		);
+	});
+
+	it("bounds a prompt run with the default iteration cap", async () => {
+		forcePromptModeInput();
+		process.argv = ["bun", "src/index.ts", "hello world"];
+
+		const { runCli } = await import("./main");
+
+		await expect(runCli()).resolves.toBeUndefined();
+		expect(runtimeMocks.runAgent).toHaveBeenCalledWith(
+			"hello world",
+			expect.objectContaining({
+				maxIterations: CLI_DEFAULT_MAX_ITERATIONS,
+			}),
+			expect.anything(),
+		);
+	});
+
+	it("honors an explicit --max-iterations override", async () => {
+		forcePromptModeInput();
+		process.argv = [
+			"bun",
+			"src/index.ts",
+			"--max-iterations",
+			"7",
+			"hello world",
+		];
+
+		const { runCli } = await import("./main");
+
+		await expect(runCli()).resolves.toBeUndefined();
+		expect(runtimeMocks.runAgent).toHaveBeenCalledWith(
+			"hello world",
+			expect.objectContaining({ maxIterations: 7 }),
 			expect.anything(),
 		);
 	});

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -14,7 +14,10 @@ import {
 	autoUpdateOnStartup,
 	getPreferredKanbanInstaller,
 } from "./commands/update";
-import { CLI_DEFAULT_CHECKPOINT_CONFIG } from "./runtime/defaults";
+import {
+	CLI_DEFAULT_CHECKPOINT_CONFIG,
+	CLI_DEFAULT_MAX_ITERATIONS,
+} from "./runtime/defaults";
 import { getCliBuildInfo } from "./utils/common";
 import {
 	buildCliCompactionConfig,
@@ -1091,6 +1094,7 @@ export async function runCli(): Promise<void> {
 			execution: {
 				maxConsecutiveMistakes: args.retries ?? 3,
 			},
+			maxIterations: CLI_DEFAULT_MAX_ITERATIONS,
 			checkpoint: CLI_DEFAULT_CHECKPOINT_CONFIG,
 			compaction: buildCliCompactionConfig(args.compactionMode),
 			timeoutSeconds: args.timeoutSeconds,

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -754,6 +754,11 @@ export async function runCli(): Promise<void> {
 			`${c.dim}[warn] ignoring invalid --retries value "${args.invalidRetries}" (expected integer >= 1)${c.reset}`,
 		);
 	}
+	if (args.invalidMaxIterations) {
+		writeln(
+			`${c.dim}[warn] ignoring invalid --max-iterations value "${args.invalidMaxIterations}" (expected integer >= 1)${c.reset}`,
+		);
+	}
 	if (args.hooksDir?.trim()) {
 		process.env.CLINE_HOOKS_DIR = args.hooksDir.trim();
 	}
@@ -1025,7 +1030,7 @@ export async function runCli(): Promise<void> {
 			execution: {
 				maxConsecutiveMistakes: args.retries ?? 3,
 			},
-			maxIterations: CLI_DEFAULT_MAX_ITERATIONS,
+			maxIterations: args.maxIterations ?? CLI_DEFAULT_MAX_ITERATIONS,
 			checkpoint: CLI_DEFAULT_CHECKPOINT_CONFIG,
 			compaction: buildCliCompactionConfig(effectiveCompactionMode),
 			timeoutSeconds: args.timeoutSeconds,

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -15,7 +15,10 @@ import {
 	autoUpdateOnStartup,
 	getPreferredKanbanInstaller,
 } from "./commands/update";
-import { CLI_DEFAULT_CHECKPOINT_CONFIG } from "./runtime/defaults";
+import {
+	CLI_DEFAULT_CHECKPOINT_CONFIG,
+	CLI_DEFAULT_MAX_ITERATIONS,
+} from "./runtime/defaults";
 import type { TuiStartupTarget } from "./tui/types";
 import { getCliBuildInfo } from "./utils/common";
 import {
@@ -1022,6 +1025,7 @@ export async function runCli(): Promise<void> {
 			execution: {
 				maxConsecutiveMistakes: args.retries ?? 3,
 			},
+			maxIterations: CLI_DEFAULT_MAX_ITERATIONS,
 			checkpoint: CLI_DEFAULT_CHECKPOINT_CONFIG,
 			compaction: buildCliCompactionConfig(effectiveCompactionMode),
 			timeoutSeconds: args.timeoutSeconds,

--- a/apps/cli/src/runtime/defaults.ts
+++ b/apps/cli/src/runtime/defaults.ts
@@ -16,3 +16,11 @@ export const CLI_DEFAULT_LOOP_DETECTION = {
 export const CLI_DEFAULT_CHECKPOINT_CONFIG = {
 	enabled: true,
 } as const;
+
+/**
+ * Default iteration cap for the CLI.
+ * The agent core leaves maxIterations unset (unbounded) by default;
+ * the CLI bounds it so a provider that keeps returning tool calls
+ * cannot drive an endless request loop on a non-interactive run.
+ */
+export const CLI_DEFAULT_MAX_ITERATIONS = 100;

--- a/apps/cli/src/utils/types.ts
+++ b/apps/cli/src/utils/types.ts
@@ -94,6 +94,8 @@ export interface ParsedArgs {
 	id?: string;
 	retries?: number;
 	invalidRetries?: string;
+	maxIterations?: number;
+	invalidMaxIterations?: string;
 	cwd?: string;
 	teamName?: string;
 	defaultToolAutoApprove: boolean;

--- a/sdk/packages/agents/src/agent-runtime.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.test.ts
@@ -968,6 +968,36 @@ describe("AgentRuntime", () => {
 		expect(result.outputText).toBe("done");
 	});
 
+	it("bounds the loop and fails when maxIterations is reached", async () => {
+		let requestCount = 0;
+		const model: AgentModel = {
+			async stream() {
+				requestCount += 1;
+				return toAsyncIterable([
+					{
+						type: "tool-call-delta",
+						toolCallId: `call_${requestCount}`,
+						toolName: "echo",
+						inputText: `{"text":"loop_${requestCount}"}`,
+					},
+					{ type: "finish", reason: "tool-calls" },
+				]);
+			},
+		};
+		const runtime = new AgentRuntime({
+			model,
+			tools: [createEchoTool()],
+			maxIterations: 5,
+		});
+
+		const result = await runtime.run("Start");
+
+		expect(result.status).toBe("failed");
+		expect(result.error?.message).toContain("exceeded maxIterations");
+		expect(result.iterations).toBe(5);
+		expect(requestCount).toBe(5);
+	});
+
 	it("supports plugin-contributed tools and hooks", async () => {
 		const beforeRun = vi.fn();
 		const plugin: AgentRuntimePlugin = {

--- a/sdk/packages/agents/src/agent-runtime.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.test.ts
@@ -1052,6 +1052,36 @@ describe("AgentRuntime", () => {
 		expect(result.outputText).toBe("done");
 	});
 
+	it("bounds the loop and fails when maxIterations is reached", async () => {
+		let requestCount = 0;
+		const model: AgentModel = {
+			async stream() {
+				requestCount += 1;
+				return toAsyncIterable([
+					{
+						type: "tool-call-delta",
+						toolCallId: `call_${requestCount}`,
+						toolName: "echo",
+						inputText: `{"text":"loop_${requestCount}"}`,
+					},
+					{ type: "finish", reason: "tool-calls" },
+				]);
+			},
+		};
+		const runtime = new AgentRuntime({
+			model,
+			tools: [createEchoTool()],
+			maxIterations: 5,
+		});
+
+		const result = await runtime.run("Start");
+
+		expect(result.status).toBe("failed");
+		expect(result.error?.message).toContain("exceeded maxIterations");
+		expect(result.iterations).toBe(5);
+		expect(requestCount).toBe(5);
+	});
+
 	it("supports plugin-contributed tools and hooks", async () => {
 		const beforeRun = vi.fn();
 		const plugin: AgentRuntimePlugin = {


### PR DESCRIPTION
### Related Issue

Refs #11542

### Description

Problem: on a non-interactive CLI run, the agent loop has no upper bound. A provider that keeps returning tool calls makes the CLI issue a follow-up request after every completed tool call, forever -- the issue's reproducer observed ~870 provider requests before the process was killed by timeout.

Root cause: the loop guard in `@cline/agents` (`sdk/packages/agents/src/agent-runtime.ts:604`) is `while (maxIterations === undefined || iteration < maxIterations)`. `undefined` means unbounded, and that's intentional at the agents layer -- there's a test that asserts "unset maxIterations = unlimited". The bound is meant to come from the host. But the CLI's single-prompt path (`apps/cli/src/main.ts`) never sets it, so it stays `undefined`.

The two guards that do exist both miss this exact case:
- `maxConsecutiveMistakes` counts *errors* only. A provider that keeps *successfully* completing tool calls records zero mistakes, so `--retries` never trips (raising it makes the loop longer-lived).
- `loopDetection` only catches consecutive *identical* calls. The reproducer varies the command each turn (`printf ..._{{request_number}}`), so the identical-call counter keeps resetting.

Fix: default `maxIterations` on the CLI's run config, exactly how the CLI already defaults loop-detection and checkpoints (`apps/cli/src/runtime/defaults.ts`). When the cap is reached, the existing `Agent runtime exceeded maxIterations` error surfaces as a clean `failed` result instead of an unbounded request stream -- which is the behavior asked for in the issue.

What did NOT change: no production code in `@cline/agents` -- the "unset = unlimited" contract is untouched. Only the CLI now passes a value. The cron/hub/team paths set their own `maxIterations` from their spec and are unaffected. The value already flows Config → runtime host → orchestrator → loop today, so this only populates it.

**On the default number:** I picked `100` (well above a realistic single task, far below the 870 runaway) but it's a one-line constant and easy to tune -- I'm happy to set whatever you'd prefer.

### Test Procedure

Added a regression test in `sdk/packages/agents/src/agent-runtime.test.ts` -- a provider that returns a (varying-arg) tool call every turn, with `maxIterations: 5`, asserting the run bounds and fails with the clear error:

    bun -F @cline/agents test
    # Test Files 2 passed (2) / Tests 47 passed (47)

    cd apps/cli && bun run typecheck   # exit 0
    bun -F @cline/agents typecheck     # exit 0

The new test fails without the bound (loops until the mock is exhausted) and passes with it; verified non-vacuous by mutating the expected iteration count and confirming red.

### Impact / regression risk

Behavior only changes for a run that would otherwise loop past 100 iterations -- previously unbounded, now a clean failure. No change for any run that completes normally under 100 iterations. No change to `@cline/agents` defaults or to the hub/cron/team paths.

### Scope

The cap is set on the CLI's shared run config, but only the `runAgent` path forwards it to the session runtime (`run-agent.ts` spreads `...config` into `sessionManager.start`). `runZen` constructs its own `ChatStartSessionRequest` with an explicit field list, and the interactive session-runtime likewise selects explicit fields, neither includes `maxIterations`. So this takes effect on the single-prompt and piped-stdin paths, which is the reported failure mode.

`100` is a default, not a ceiling: `--max-iterations <n>` overrides it, with the same validation as `--retries` (integer >= 1; invalid values warn and fall back to the default).