### PR TITLE
fix(sdk): prevent agent commands from blocking on pagers

### DIFF
--- a/sdk/packages/core/src/extensions/tools/executors/bash.test.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/bash.test.ts
@@ -15,6 +15,38 @@ describe("createShellExecutor", () => {
 		expect(output.trim()).toBe("hello");
 	});
 
+	it("sets non-interactive command defaults while honoring overrides", async () => {
+		const shell = createShellExecutor();
+		const output = await shell(
+			{
+				command: process.execPath,
+				args: [
+					"-e",
+					"process.stdout.write(JSON.stringify({ pager: process.env.PAGER, gitPager: process.env.GIT_PAGER, gitPrompt: process.env.GIT_TERMINAL_PROMPT }))",
+				],
+			},
+			process.cwd(),
+			ctx,
+		);
+
+		expect(JSON.parse(output)).toEqual({
+			pager: "cat",
+			gitPager: "cat",
+			gitPrompt: "0",
+		});
+
+		const overridden = createShellExecutor({ env: { PAGER: "less" } });
+		const overriddenOutput = await overridden(
+			{
+				command: process.execPath,
+				args: ["-e", "process.stdout.write(process.env.PAGER || '')"],
+			},
+			process.cwd(),
+			ctx,
+		);
+		expect(overriddenOutput).toBe("less");
+	});
+
 	it("rejects on non-zero exit code", async () => {
 		const shell = createShellExecutor();
 		await expect(shell("exit 1", process.cwd(), ctx)).rejects.toThrow();

--- a/sdk/packages/core/src/extensions/tools/executors/bash.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/bash.ts
@@ -18,6 +18,16 @@ import {
 	truncateCommandOutput,
 } from "./output-limits";
 
+// Agent commands must not block waiting for terminal input. Callers can still
+// override these values through ShellExecutorOptions.env when needed.
+const NON_INTERACTIVE_ENV = {
+	GIT_PAGER: "cat",
+	GIT_TERMINAL_PROMPT: "0",
+	GH_PAGER: "cat",
+	PAGER: "cat",
+	SYSTEMD_PAGER: "cat",
+} as const;
+
 export class CommandExitError extends Error {
 	constructor(
 		readonly exitCode: number,
@@ -280,9 +290,10 @@ export function createShellExecutor(
 	const {
 		shell = getDefaultShell(process.platform),
 		timeoutMs = 30000,
-		env = {},
+		env: optionsEnv = {},
 		combineOutput = true,
 	} = options;
+	const env = { ...NON_INTERACTIVE_ENV, ...optionsEnv };
 	const maxOutputChars =
 		options.maxOutputChars ??
 		options.maxOutputBytes ??


### PR DESCRIPTION
## Summary

Fixes #12395.

Agent shell commands are expected to be non-interactive, but the executor previously inherited pager and Git prompt settings from the host environment. Commands such as `git diff` could therefore wait for terminal input and stall the task.

This change adds non-interactive defaults for the headless shell executor:

- `PAGER=cat`
- `GIT_PAGER=cat`
- `GH_PAGER=cat`
- `SYSTEMD_PAGER=cat`
- `GIT_TERMINAL_PROMPT=0`

Explicit `ShellExecutorOptions.env` values still override these defaults. The change is limited to the headless executor and does not alter user-visible interactive VS Code terminal sessions.

## Validation

- `bun -F @cline/core typecheck`
- Biome check passed for changed files
- Added executor coverage for defaults and overrides

The focused executor test is currently blocked before collection by the existing workspace Zod runtime-resolution failure (`z.string` is undefined in `extensions/tools/schemas.ts`).