### PR TITLE
docs: mark .clineignore as deprecated soon

### DIFF
--- a/docs/core-workflows/task-management.mdx
+++ b/docs/core-workflows/task-management.mdx
@@ -49,8 +49,6 @@ When the context window approaches its limit, Cline automatically compresses old
 
 This is why task scoping matters: a focused task keeps relevant information in the context window. A sprawling task fills the window with noise, pushing out useful context.
 
-If your starting context seems high even for simple prompts, add a [`.clineignore`](/customization/clineignore) file to exclude dependencies, build artifacts, and other files Cline doesn't need. This can dramatically reduce your baseline token usage.
-
 <Tip>
 For long-running tasks, enable [Auto-Compact](/features/auto-compact) to intelligently manage context as you work.
 </Tip>

--- a/docs/customization/clineignore.mdx
+++ b/docs/customization/clineignore.mdx
@@ -117,6 +117,27 @@ You can still reference ignored files explicitly using [@ mentions](/core-workfl
 
 To keep context manageable, scope your tasks tightly.
 
+## Restricting File Access with a Plugin
+
+While `.clineignore` is being phased out, you can achieve a stronger, enforced restriction on **file reads and edits** using the [Block Ignored File Access](/sdk/plugin-examples#block-ignored-file-access) plugin example.
+
+Unlike `.clineignore` (a context filter that can still be bypassed via `@` mentions or shell commands), this plugin uses a `beforeTool` runtime hook to actively **block** tool calls: when `read_files`, `editor`, or `apply_patch` targets a file ignored by your workspace `.gitignore`, the hook returns `{ skip: true }` and the tool records a policy error instead of accessing the file.
+
+Install it into your project with:
+
+```bash
+cline plugin install https://github.com/cline/cline/blob/main/sdk/examples/plugins/gitignore-read-files-guard.ts --cwd .
+```
+
+<Note>
+This plugin covers only part of what `.clineignore` did:
+- It **guards file reads/edits** (`read_files`, `editor`, `apply_patch`) — it does **not** filter `search_files`/`list_files` results or guard shell commands, so it is not a full context-reduction tool.
+- It reads your **`.gitignore`** (not a separate `.clineignore`) and requires a Git repository.
+- Plugins run on the Cline **SDK, CLI, and Kanban**. Support in the VS Code and JetBrains extensions arrives as they migrate onto the SDK.
+
+See [Plugins](/customization/plugins) for installation details and scopes.
+</Note>
+
 ## Related
 
 - [Cline Rules](/customization/cline-rules) - Define persistent instructions for Cline

--- a/docs/customization/clineignore.mdx
+++ b/docs/customization/clineignore.mdx
@@ -11,7 +11,37 @@ description: "Control which files and directories Cline can access in your proje
 
 </Warning>
 
+## Deprecation
+
+`.clineignore` will be deprecated soon. The rationale:
+
+- **Ignore rules are context filters, not security controls.** `.clineignore` only filters what Cline loads automatically; however, it is hard and nearly impossible to prevent agent access to matching files. Ignored files can still be read through explicit `@` mentions or shell commands, and `.clineignore` should not be treated as a security or access-control boundary.
+
+To keep context manageable, scope your tasks tightly.
+
+## Restricting File Access with a Plugin
+
+While `.clineignore` is being phased out, you can achieve a stronger, enforced restriction on **file reads and edits** using the [Block Ignored File Access](https://docs.cline.bot/sdk/plugin-examples#block-ignored-file-access) plugin example.
+
+Unlike `.clineignore` (a context filter that can still be bypassed via `@` mentions or shell commands), this plugin uses a `beforeTool` runtime hook to actively **block** tool calls: when `read_files`, `editor`, or `apply_patch` targets a file ignored by your workspace `.gitignore`, the hook returns `{ skip: true }` and the tool records a policy error instead of accessing the file.
+
+Install it into your project with:
+
+```bash
+cline plugin install https://github.com/cline/cline/blob/main/sdk/examples/plugins/gitignore-read-files-guard.ts --cwd .
+```
+
+<Note>
+This plugin covers only part of what `.clineignore` did:
+- It **guards file reads/edits** (`read_files`, `editor`, `apply_patch`) — it does **not** filter `search_files`/`list_files` results or guard shell commands, so it is not a full context-reduction tool.
+- It reads your **`.gitignore`** (not a separate `.clineignore`) and requires a Git repository.
+- Plugins run on the Cline **SDK, CLI, and Kanban**. Support in the VS Code and JetBrains extensions arrives as they migrate onto the SDK.
+
+See [Plugins](/customization/plugins) for installation details and scopes.
+</Note>
+
 The `.clineignore` file tells Cline which files and directories to skip when analyzing your codebase. It works like `.gitignore`: create a file named `.clineignore` in your project root, add patterns for files you want excluded, and Cline will ignore them.
+
 
 ## Why It Matters
 
@@ -109,36 +139,8 @@ You can still reference ignored files explicitly using [@ mentions](/core-workfl
 - If Cline seems to be missing context about a file, check whether it's being excluded by your ignore patterns.
 - For monorepos or multi-root workspaces, each workspace root can have its own `.clineignore`. See [Multi-Root Workspaces](/features/multiroot-workspace) for details.
 
-## Deprecation
-
-`.clineignore` will be deprecated soon. The rationale:
-
-- **Ignore rules are context filters, not security controls.** `.clineignore` only filters what Cline loads automatically; however, it is hard and nearly impossible to prevent agent access to matching files. Ignored files can still be read through explicit `@` mentions or shell commands, and `.clineignore` should not be treated as a security or access-control boundary.
-
-To keep context manageable, scope your tasks tightly.
-
-## Restricting File Access with a Plugin
-
-While `.clineignore` is being phased out, you can achieve a stronger, enforced restriction on **file reads and edits** using the [Block Ignored File Access](https://docs.cline.bot/sdk/plugin-examples#block-ignored-file-access) plugin example.
-
-Unlike `.clineignore` (a context filter that can still be bypassed via `@` mentions or shell commands), this plugin uses a `beforeTool` runtime hook to actively **block** tool calls: when `read_files`, `editor`, or `apply_patch` targets a file ignored by your workspace `.gitignore`, the hook returns `{ skip: true }` and the tool records a policy error instead of accessing the file.
-
-Install it into your project with:
-
-```bash
-cline plugin install https://github.com/cline/cline/blob/main/sdk/examples/plugins/gitignore-read-files-guard.ts --cwd .
-```
-
-<Note>
-This plugin covers only part of what `.clineignore` did:
-- It **guards file reads/edits** (`read_files`, `editor`, `apply_patch`) — it does **not** filter `search_files`/`list_files` results or guard shell commands, so it is not a full context-reduction tool.
-- It reads your **`.gitignore`** (not a separate `.clineignore`) and requires a Git repository.
-- Plugins run on the Cline **SDK, CLI, and Kanban**. Support in the VS Code and JetBrains extensions arrives as they migrate onto the SDK.
-
-See [Plugins](/customization/plugins) for installation details and scopes.
-</Note>
-
 ## Related
+
 
 - [Cline Rules](/customization/cline-rules) - Define persistent instructions for Cline
 - [Task Management](/core-workflows/task-management#context-window) - Understand how context windows work

--- a/docs/customization/clineignore.mdx
+++ b/docs/customization/clineignore.mdx
@@ -119,7 +119,7 @@ To keep context manageable, scope your tasks tightly.
 
 ## Restricting File Access with a Plugin
 
-While `.clineignore` is being phased out, you can achieve a stronger, enforced restriction on **file reads and edits** using the [Block Ignored File Access](/sdk/plugin-examples#block-ignored-file-access) plugin example.
+While `.clineignore` is being phased out, you can achieve a stronger, enforced restriction on **file reads and edits** using the [Block Ignored File Access](https://docs.cline.bot/sdk/plugin-examples#block-ignored-file-access) plugin example.
 
 Unlike `.clineignore` (a context filter that can still be bypassed via `@` mentions or shell commands), this plugin uses a `beforeTool` runtime hook to actively **block** tool calls: when `read_files`, `editor`, or `apply_patch` targets a file ignored by your workspace `.gitignore`, the hook returns `{ skip: true }` and the tool records a policy error instead of accessing the file.
 

--- a/docs/customization/clineignore.mdx
+++ b/docs/customization/clineignore.mdx
@@ -113,9 +113,9 @@ You can still reference ignored files explicitly using [@ mentions](/core-workfl
 
 `.clineignore` will be deprecated soon. The rationale:
 
-- **Ignore rules are context filters, not security controls.** `.clineignore` only filters what Cline loads automatically; it does not prevent access to matching files. Ignored files can still be read through explicit `@` mentions or shell commands, so `.clineignore` should not be treated as a security or access-control boundary.
+- **Ignore rules are context filters, not security controls.** `.clineignore` only filters what Cline loads automatically; however, it is hard and nearly impossible to prevent agent access to matching files. Ignored files can still be read through explicit `@` mentions or shell commands, and `.clineignore` should not be treated as a security or access-control boundary.
 
-To keep context manageable, scope your tasks tightly and use [Auto-Compact](/features/auto-compact) for long-running work.
+To keep context manageable, scope your tasks tightly.
 
 ## Related
 

--- a/docs/customization/clineignore.mdx
+++ b/docs/customization/clineignore.mdx
@@ -40,7 +40,14 @@ This plugin covers only part of what `.clineignore` did:
 See [Plugins](/customization/plugins) for installation details and scopes.
 </Note>
 
+---
+
+<Info>
+  The rest of this page is the original `.clineignore` reference, retained for existing users while the feature is phased out.
+</Info>
+
 The `.clineignore` file tells Cline which files and directories to skip when analyzing your codebase. It works like `.gitignore`: create a file named `.clineignore` in your project root, add patterns for files you want excluded, and Cline will ignore them.
+
 
 
 ## Why It Matters

--- a/docs/customization/clineignore.mdx
+++ b/docs/customization/clineignore.mdx
@@ -1,8 +1,15 @@
 ---
 title: ".clineignore"
 sidebarTitle: ".clineignore"
-description: "Control which files and directories Cline can access in your project."
+description: "Control which files and directories Cline can access in your project. This feature will be deprecated soon."
 ---
+
+<Warning>
+  **The `.clineignore` feature will be deprecated soon.**
+
+  Reliable enforcement of ignore rules isn't possible as the model capability evolves — agents can get around them, for example by reading ignored files through explicit `@` mentions or shell commands. Because `.clineignore` can only reduce noise, not actually restrict access, we're moving away from it as a supported feature.
+
+</Warning>
 
 The `.clineignore` file tells Cline which files and directories to skip when analyzing your codebase. It works like `.gitignore`: create a file named `.clineignore` in your project root, add patterns for files you want excluded, and Cline will ignore them.
 
@@ -101,6 +108,14 @@ You can still reference ignored files explicitly using [@ mentions](/core-workfl
 - Check your token usage in the task header after adding a `.clineignore`. The difference is often dramatic.
 - If Cline seems to be missing context about a file, check whether it's being excluded by your ignore patterns.
 - For monorepos or multi-root workspaces, each workspace root can have its own `.clineignore`. See [Multi-Root Workspaces](/features/multiroot-workspace) for details.
+
+## Deprecation
+
+`.clineignore` will be deprecated soon. The rationale:
+
+- **Enforcement is extremely difficult as agent capability evolves.** Ignore rules only filter what Cline loads automatically — they can't actually restrict access. An agent can read any ignored file through an explicit `@` mention or a shell command, so `.clineignore` cannot serve as a security or access-control boundary.
+
+To keep context manageable, scope your tasks tightly and use [Auto-Compact](/features/auto-compact) for long-running work.
 
 ## Related
 

--- a/docs/customization/clineignore.mdx
+++ b/docs/customization/clineignore.mdx
@@ -1,13 +1,13 @@
 ---
-title: ".clineignore"
-sidebarTitle: ".clineignore"
+title: ".clineignore (deprecate soon)"
+sidebarTitle: ".clineignore (deprecate soon)"
 description: "Control which files and directories Cline can access in your project. This feature will be deprecated soon."
 ---
 
 <Warning>
   **The `.clineignore` feature will be deprecated soon.**
 
-  Reliable enforcement of ignore rules isn't possible as the model capability evolves — agents can get around them, for example by reading ignored files through explicit `@` mentions or shell commands. Because `.clineignore` can only reduce noise, not actually restrict access, we're moving away from it as a supported feature.
+  `.clineignore` helps reduce automatic context, but it is not a reliable access-control boundary. Ignored files can still be read when referenced explicitly with `@` mentions or accessed through shell commands, so we're moving away from it as a supported feature.
 
 </Warning>
 
@@ -113,7 +113,7 @@ You can still reference ignored files explicitly using [@ mentions](/core-workfl
 
 `.clineignore` will be deprecated soon. The rationale:
 
-- **Enforcement is extremely difficult as agent capability evolves.** Ignore rules only filter what Cline loads automatically — they can't actually restrict access. An agent can read any ignored file through an explicit `@` mention or a shell command, so `.clineignore` cannot serve as a security or access-control boundary.
+- **Ignore rules are context filters, not security controls.** `.clineignore` only filters what Cline loads automatically; it does not prevent access to matching files. Ignored files can still be read through explicit `@` mentions or shell commands, so `.clineignore` should not be treated as a security or access-control boundary.
 
 To keep context manageable, scope your tasks tightly and use [Auto-Compact](/features/auto-compact) for long-running work.
 

--- a/docs/customization/clineignore.mdx
+++ b/docs/customization/clineignore.mdx
@@ -5,25 +5,14 @@ description: "Control which files and directories Cline can access in your proje
 ---
 
 <Warning>
-  **The `.clineignore` feature will be deprecated soon.**
+  **`.clineignore` will be deprecated soon.**
 
-  `.clineignore` helps reduce automatic context, but it is not a reliable access-control boundary. Ignored files can still be read when referenced explicitly with `@` mentions or accessed through shell commands, so we're moving away from it as a supported feature.
-
+  `.clineignore` filters what Cline loads automatically, but it is not a security or access-control boundary — ignored files can still be read via explicit `@` mentions or shell commands. We're moving away from it as a supported feature.
 </Warning>
-
-## Deprecation
-
-`.clineignore` will be deprecated soon. The rationale:
-
-- **Ignore rules are context filters, not security controls.** `.clineignore` only filters what Cline loads automatically; however, it is hard and nearly impossible to prevent agent access to matching files. Ignored files can still be read through explicit `@` mentions or shell commands, and `.clineignore` should not be treated as a security or access-control boundary.
-
-To keep context manageable, scope your tasks tightly.
 
 ## Restricting File Access with a Plugin
 
-While `.clineignore` is being phased out, you can achieve a stronger, enforced restriction on **file reads and edits** using the [Block Ignored File Access](https://docs.cline.bot/sdk/plugin-examples#block-ignored-file-access) plugin example.
-
-Unlike `.clineignore` (a context filter that can still be bypassed via `@` mentions or shell commands), this plugin uses a `beforeTool` runtime hook to actively **block** tool calls: when `read_files`, `editor`, or `apply_patch` targets a file ignored by your workspace `.gitignore`, the hook returns `{ skip: true }` and the tool records a policy error instead of accessing the file.
+While `.clineignore` is being phased out, you can get a stronger, enforced restriction on **file reads and edits** with the [Block Ignored File Access](https://docs.cline.bot/sdk/plugin-examples#block-ignored-file-access) Cline plugin example. Unlike `.clineignore`, it uses a `beforeTool` runtime hook to actively **block** tool calls: when `read_files`, `editor`, or `apply_patch` targets a file ignored by your workspace's `.gitignore` file. 
 
 Install it into your project with:
 
@@ -133,7 +122,7 @@ When Cline scans your project to build context, it checks each file path against
 - Automatic context gathering during conversations
 - Search results when Cline looks for relevant code
 
-You can still reference ignored files explicitly using [@ mentions](/core-workflows/working-with-files). If you type `@/node_modules/some-package/index.js`, Cline will read that specific file even though `node_modules/` is in your `.clineignore`. The ignore rules control automatic loading, not explicit access.
+As noted above, explicit [@ mentions](/core-workflows/working-with-files) still bypass these rules — for example, `@/node_modules/some-package/index.js` reads that file even though `node_modules/` is ignored. Ignore rules control automatic loading, not explicit access.
 
 <Note>
 `.clineignore` is separate from `.gitignore`. Files tracked by Git but irrelevant to Cline (like large test fixtures or data files) should go in `.clineignore` even if they're not in `.gitignore`.
@@ -141,7 +130,6 @@ You can still reference ignored files explicitly using [@ mentions](/core-workfl
 
 ## Tips
 
-- Add `.clineignore` early in your project. It's easier to start with broad exclusions and narrow them than to debug why context is bloated later.
 - Check your token usage in the task header after adding a `.clineignore`. The difference is often dramatic.
 - If Cline seems to be missing context about a file, check whether it's being excluded by your ignore patterns.
 - For monorepos or multi-root workspaces, each workspace root can have its own `.clineignore`. See [Multi-Root Workspaces](/features/multiroot-workspace) for details.

--- a/docs/features/multiroot-workspace.mdx
+++ b/docs/features/multiroot-workspace.mdx
@@ -251,18 +251,3 @@ Both limitations are restored when you return to a single-folder workspace.
 
 - Break large tasks into workspace-specific operations when possible
 - Use [Plan mode](/core-workflows/plan-and-act) to let Cline understand structure first
-- Add a `.clineignore` file to reduce noise, speed up scanning, and keep Cline focused on source code:
-
-```text
-# Dependencies
-**/node_modules/
-
-# Build outputs
-**/dist/
-**/build/
-
-# VCS metadata
-**/.git/
-```
-
-For more patterns and gotchas, see the [.clineignore File Guide](/customization/clineignore).

--- a/docs/getting-started/config.mdx
+++ b/docs/getting-started/config.mdx
@@ -154,7 +154,7 @@ Rules:
 - [Skills](/customization/skills)
 - [Hooks](/customization/hooks)
 - [Plugins](/customization/plugins)
-- [.clineignore](/customization/clineignore)
+- [.clineignore](/customization/clineignore) (deprecated)
 
 ## Security Notes
 


### PR DESCRIPTION
## Summary

Marks the `.clineignore` feature as deprecated-soon across the docs. All references to `.clineignore` in the Task Management and Multi-Root Workspace pages are removed entirely (rather than left as deprecation notes), since we don't want to recommend a soon-to-be-deprecated feature.

## Background

`.clineignore` is being deprecated because enforcement of ignore rules is extremely difficult as model/agent capability evolves — agents can get around them (e.g. via explicit `@` mentions or shell commands), so it can only reduce noise, not serve as an access-control boundary.

## Changes

- `customization/clineignore.mdx`
  - Added a `<Warning>` deprecation banner at the top.
  - Added a **Deprecation** section (`#deprecation` anchor) with the rationale.
  - Updated the frontmatter `description` to note the upcoming deprecation.
- `core-workflows/task-management.mdx`
  - Removed the paragraph that recommended adding a `.clineignore` file.
- `features/multiroot-workspace.mdx`
  - Removed the bullet point, code sample, and "for more patterns" link that referenced `.clineignore`.
- `getting-started/config.mdx`
  - Marked the related-docs link as `(deprecated)`.

## Validation

- `mintlify broken-links` → no broken links found.
