### PR TITLE
fix(desktop): preserve MCP server oauth tokens and metadata across dialog edits

### DIFF
--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -157,8 +157,13 @@ function readMcpServersResponse(): JsonRecord {
 			record.transport && typeof record.transport === "object"
 				? (record.transport as JsonRecord)
 				: undefined;
+		const rawTransportType =
+			transport?.type ?? record.transportType ?? record.type;
 		const transportType = String(
-			transport?.type ?? record.transportType ?? record.type ?? "stdio",
+			rawTransportType ??
+				(typeof transport?.url === "string" || typeof record.url === "string"
+					? "sse"
+					: "stdio"),
 		).trim();
 		return {
 			name,
@@ -215,18 +220,18 @@ function mcpTransportIdentity(record: JsonRecord): string {
 		record.transport && typeof record.transport === "object"
 			? (record.transport as JsonRecord)
 			: undefined;
-	const type = String(
-		transport?.type ?? record.transportType ?? record.type ?? "stdio",
-	).trim();
-	// Core's config-loader maps the legacy "http" transport alias to
-	// streamableHttp; treat them as the same endpoint here too.
-	const normalizedType = type === "http" ? "streamableHttp" : type;
 	const url =
 		typeof transport?.url === "string"
 			? transport.url
 			: typeof record.url === "string"
 				? record.url
 				: "";
+	// Core's config-loader defaults a URL-based legacy record with no explicit
+	// type to SSE and maps the legacy "http" alias to streamableHttp; mirror
+	// both so an unchanged endpoint keeps the same identity.
+	const rawType = transport?.type ?? record.transportType ?? record.type;
+	const type = String(rawType ?? (url ? "sse" : "stdio")).trim();
+	const normalizedType = type === "http" ? "streamableHttp" : type;
 	return `${normalizedType}\u0000${url}`;
 }
 

--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -205,6 +205,28 @@ function readMcpServersResponse(): JsonRecord {
 	return { settingsPath, hasSettingsFile: true, servers: entries };
 }
 
+/**
+ * Transport type + URL a server record actually points at, tolerating both
+ * the nested `transport` shape and legacy flat fields (mirrors
+ * readMcpServersResponse).
+ */
+function mcpTransportIdentity(record: JsonRecord): string {
+	const transport =
+		record.transport && typeof record.transport === "object"
+			? (record.transport as JsonRecord)
+			: undefined;
+	const type = String(
+		transport?.type ?? record.transportType ?? record.type ?? "stdio",
+	).trim();
+	const url =
+		typeof transport?.url === "string"
+			? transport.url
+			: typeof record.url === "string"
+				? record.url
+				: "";
+	return `${type}\u0000${url}`;
+}
+
 function writeMcpServersMap(servers: JsonRecord): void {
 	updateMcpSettingsFileSync(resolveMcpSettingsPath(), (settings) => {
 		settings.mcpServers = servers;
@@ -1243,7 +1265,13 @@ export async function handleCommand(
 				if (upserted.metadata === undefined && record.metadata !== undefined) {
 					upserted.metadata = record.metadata;
 				}
-				if (record.oauth !== undefined) {
+				// OAuth tokens were issued for a specific endpoint; carrying them
+				// onto an edited transport or URL would send the old server's
+				// credentials to a different endpoint.
+				if (
+					record.oauth !== undefined &&
+					mcpTransportIdentity(record) === mcpTransportIdentity(upserted)
+				) {
 					upserted.oauth = record.oauth;
 				}
 			}

--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -218,13 +218,16 @@ function mcpTransportIdentity(record: JsonRecord): string {
 	const type = String(
 		transport?.type ?? record.transportType ?? record.type ?? "stdio",
 	).trim();
+	// Core's config-loader maps the legacy "http" transport alias to
+	// streamableHttp; treat them as the same endpoint here too.
+	const normalizedType = type === "http" ? "streamableHttp" : type;
 	const url =
 		typeof transport?.url === "string"
 			? transport.url
 			: typeof record.url === "string"
 				? record.url
 				: "";
-	return `${type}\u0000${url}`;
+	return `${normalizedType}\u0000${url}`;
 }
 
 function writeMcpServersMap(servers: JsonRecord): void {

--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -1232,10 +1232,25 @@ export async function handleCommand(
 		updateMcpSettingsFileSync(path, (settings) => {
 			const servers = ((settings.mcpServers as JsonRecord | undefined) ??
 				{}) as JsonRecord;
+			// Preserve machine-managed fields the editor dialog doesn't expose:
+			// oauth tokens for remote servers and plugin-ownership metadata.
+			const sourceName =
+				previousName && servers[previousName] ? previousName : name;
+			const existing = servers[sourceName];
+			const upserted = { ...next };
+			if (existing && typeof existing === "object") {
+				const record = existing as JsonRecord;
+				if (upserted.metadata === undefined && record.metadata !== undefined) {
+					upserted.metadata = record.metadata;
+				}
+				if (record.oauth !== undefined) {
+					upserted.oauth = record.oauth;
+				}
+			}
 			if (previousName && previousName !== name) {
 				delete servers[previousName];
 			}
-			servers[name] = next;
+			servers[name] = upserted;
 			settings.mcpServers = servers;
 		});
 		return readMcpServersResponse();


### PR DESCRIPTION
### Related Issue

Linear: [CLINE-2748](https://linear.app/cline-bot/issue/CLINE-2748/simplify-add-mcp-server-menu-in-mac-app) — this PR started as the Add MCP Server dialog simplification, but that shipped separately via #12425 and this branch's parallel dialog commit was dropped during the rebase onto main (main's version is the more evolved one: Local/Remote radio group, Advanced collapsible, etc.). What remains here are the two sidecar bugs found while auditing which dialog fields actually matter.

### Description

#### Bug 1: editing an MCP server through the dialog wiped its OAuth tokens and plugin metadata

`upsert_mcp_server` in the sidecar rebuilt the settings record from scratch from the dialog's input. Any field the dialog doesn't know about — most importantly the `oauth` block holding a remote server's tokens, plus plugin-ownership `metadata` (`{ source: "plugin", pluginName, pluginPath }`, stamped by `plugin-mcp-settings.ts` to track which entries a plugin owns) — was silently dropped on every edit. Core's own plugin-settings code (`createSettingsEntry`) explicitly carries `existing.oauth` forward for exactly this reason; the sidecar didn't.

The fix merges machine-managed fields (`oauth`, and `metadata` when the input doesn't provide one) from the existing record into the upserted one, following `previousName` so renames keep them too. This also makes it safe that the dialog (post-#12425) doesn't expose a metadata field — without this fix, every edit through the dialog erases plugin-ownership markers.

Gotcha for anyone touching this later: the mutator passed to `updateMcpSettingsFileSync` runs twice (purity check), so the merge builds a fresh `{ ...next }` copy inside the mutator rather than mutating the closed-over object.

#### Bug 2: the fix above must NOT carry tokens across an endpoint change

Blanket-preserving `oauth` introduces the opposite problem: edit a remote server's URL (or switch its transport) and the old server's OAuth tokens get carried onto the new registration — credentials issued for one endpoint sent to a different one. The second commit preserves `oauth` only when the *effective* transport type + URL are unchanged, via `mcpTransportIdentity()`, which tolerates both the nested `transport` record shape and legacy flat fields (mirroring `readMcpServersResponse`). Renames of the same endpoint still keep tokens; pointing the entry somewhere else drops them so the server re-auths.

### Test Procedure

- Sidecar tests: `bunx vitest run sidecar/` — 24/24 pass. (Heads up: `bun test sidecar/` shows 2 failures on main too — `observability.test.ts` and `context.test.ts` use `vi.hoisted`, which only exists under vitest. Not related to this change.)
- `tsc --noEmit` reports zero errors under `sidecar/`.
- OAuth-preservation verified end-to-end with a throwaway script calling the real `handleCommand`: pre-seeded a settings file (via `CLINE_MCP_SETTINGS_PATH` — note the sidecar's `resolveMcpSettingsPath` in `sidecar/paths.ts` honors that env var, *not* `CLINE_DIR` like `@cline/shared`; my first attempt hit the real settings file because of this) with a server carrying `oauth.tokens` + plugin metadata, then edited it through `upsert_mcp_server` with a rename and transport change. Result: metadata preserved and old key removed in all cases; tokens preserved on pure rename, dropped when the transport/URL changed.

What could break: anything else writing through `upsert_mcp_server` — but the merge only *adds* previously-dropped fields, never removes ones the input provides; inputs that pass explicit `metadata` still win over the existing value.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

No UI changes — the dialog simplification this PR originally carried shipped via #12425; this is now sidecar-only (settings-file handling).

### Additional Notes

No schema or storage changes; writes still go through the same sidecar command and settings-file lock. The previous revision of this PR (with the dialog screenshots) is preserved in the edit history if anyone needs the original CLINE-2748 write-up.
