### PR TITLE
fix(desktop): resolve login shell PATH so agent can find gh and other CLI tools

### DIFF
--- a/apps/examples/desktop-app/README.md
+++ b/apps/examples/desktop-app/README.md
@@ -16,6 +16,20 @@ From `apps/examples/desktop-app/`:
 - `bun run package:desktop` - package the current OS desktop app into `dist/desktop/`
 - `bun run typecheck` - TypeScript check
 
+## Login Shell PATH Resolution
+
+Apps launched from Finder/the Dock inherit launchd's minimal `PATH`
+(`/usr/bin:/bin:/usr/sbin:/sbin`), not the one your shell profiles build, so
+agent-run commands would miss Homebrew-installed tools like `gh` even though
+they work fine from a terminal. At startup the sidecar asks the user's login
+shell — read from the account database via `getpwuid`, falling back to
+`$SHELL` — for its `PATH` and merges it into `process.env.PATH`, which every
+agent-spawned child (run_commands, MCP servers) inherits. Only `PATH` is
+imported, deliberately; other login-environment variables (`SSH_AUTH_SOCK`,
+API keys, `JAVA_HOME`-style tool roots) are not pulled in. Set
+`CLINE_SIDECAR_SKIP_SHELL_PATH=1` to disable. Implementation and details:
+[`sidecar/shell-path.ts`](./sidecar/shell-path.ts).
+
 ## Web Visual System
 
 The framework-neutral color, typography, radius, and navigation contract lives

--- a/apps/examples/desktop-app/sidecar/index.ts
+++ b/apps/examples/desktop-app/sidecar/index.ts
@@ -9,6 +9,7 @@ import {
 import { createDesktopObservability } from "./observability";
 import { resolveWorkspaceRoot } from "./paths";
 import { startServer } from "./server";
+import { ensureLoginShellPath } from "./shell-path";
 import { BunRuntime, SIDECAR_HOST, SIDECAR_MODE, SIDECAR_PORT } from "./types";
 
 const SHUTDOWN_TIMEOUT_MS = 5_000;
@@ -42,6 +43,14 @@ async function main() {
 	setHomeDirIfUnset(homedir());
 	const observability = createDesktopObservability();
 	activeObservability = observability;
+
+	// When launched from Finder/the Dock the app inherits launchd's minimal
+	// PATH, so agent-spawned processes can't find shell-profile-installed
+	// tools like `gh`. Patch PATH from the login shell before anything that
+	// spawns children (agent sessions, MCP servers) is created.
+	const shellPathResult = await ensureLoginShellPath();
+	observability.logger.log("Login shell PATH resolution", shellPathResult);
+
 	const ctx = createSidecarContext(workspaceRoot, observability);
 	observability.logger.log("Desktop sidecar starting", {
 		workspaceRoot,

--- a/apps/examples/desktop-app/sidecar/index.ts
+++ b/apps/examples/desktop-app/sidecar/index.ts
@@ -39,18 +39,17 @@ async function main() {
 		throw new Error("sidecar must be run with Bun");
 	}
 
+	// When launched from Finder/the Dock the app inherits launchd's minimal
+	// PATH, so agent-spawned processes can't find shell-profile-installed
+	// tools like `gh`. Kick resolution off first so it overlaps the rest of
+	// startup, but await it before the session manager exists — that's what
+	// spawns children (agent sessions, MCP servers, scheduled runs).
+	const shellPathPromise = ensureLoginShellPath();
+
 	const workspaceRoot = resolveWorkspaceRoot(process.cwd());
 	setHomeDirIfUnset(homedir());
 	const observability = createDesktopObservability();
 	activeObservability = observability;
-
-	// When launched from Finder/the Dock the app inherits launchd's minimal
-	// PATH, so agent-spawned processes can't find shell-profile-installed
-	// tools like `gh`. Patch PATH from the login shell before anything that
-	// spawns children (agent sessions, MCP servers) is created.
-	const shellPathResult = await ensureLoginShellPath();
-	observability.logger.log("Login shell PATH resolution", shellPathResult);
-
 	const ctx = createSidecarContext(workspaceRoot, observability);
 	observability.logger.log("Desktop sidecar starting", {
 		workspaceRoot,
@@ -58,6 +57,10 @@ async function main() {
 	});
 
 	prewarmWorkspaceMetadata(workspaceRoot);
+	observability.logger.log(
+		"Login shell PATH resolution",
+		await shellPathPromise,
+	);
 	await initializeSessionManager(ctx);
 
 	let shuttingDown = false;

--- a/apps/examples/desktop-app/sidecar/shell-path.test.ts
+++ b/apps/examples/desktop-app/sidecar/shell-path.test.ts
@@ -6,6 +6,7 @@ import {
 	defaultShellFor,
 	ensureLoginShellPath,
 	extractMarkedPath,
+	loginShellFor,
 	mergePaths,
 	resolveLoginShellPath,
 	shellInvocationArgs,
@@ -80,6 +81,17 @@ describe("defaultShellFor", () => {
 	it("uses zsh on macOS and bash elsewhere", () => {
 		expect(defaultShellFor("darwin")).toBe("/bin/zsh");
 		expect(defaultShellFor("linux")).toBe("/bin/bash");
+	});
+});
+
+describe("loginShellFor", () => {
+	it("returns the passwd-database shell when one exists", () => {
+		// The test runner's uid has a passwd entry, so $SHELL must lose.
+		const shell = loginShellFor(process.platform, {
+			SHELL: "/env/should-not-win",
+		});
+		expect(shell.startsWith("/")).toBe(true);
+		expect(shell).not.toBe("/env/should-not-win");
 	});
 });
 
@@ -158,11 +170,12 @@ describe("resolveLoginShellPath", () => {
 describe("ensureLoginShellPath", () => {
 	it("merges the login shell PATH into env.PATH", async () => {
 		const shell = writeFakeShell();
-		const env: NodeJS.ProcessEnv = {
-			SHELL: shell,
-			PATH: "/usr/bin:/bin",
-		};
-		const result = await ensureLoginShellPath({ platform: "darwin", env });
+		const env: NodeJS.ProcessEnv = { PATH: "/usr/bin:/bin" };
+		const result = await ensureLoginShellPath({
+			platform: "darwin",
+			env,
+			userShell: shell,
+		});
 		expect(result).toEqual({
 			status: "applied",
 			pathEntries: 3,
@@ -173,13 +186,11 @@ describe("ensureLoginShellPath", () => {
 
 	it("falls back to the default shell when $SHELL can't resolve", async () => {
 		const fallbackShell = writeFakeShell();
-		const env: NodeJS.ProcessEnv = {
-			SHELL: "/nonexistent/shell",
-			PATH: "/usr/bin",
-		};
+		const env: NodeJS.ProcessEnv = { PATH: "/usr/bin" };
 		const result = await ensureLoginShellPath({
 			platform: "darwin",
 			env,
+			userShell: "/nonexistent/shell",
 			fallbackShell,
 		});
 		expect(result.status).toBe("applied");
@@ -188,13 +199,11 @@ describe("ensureLoginShellPath", () => {
 	});
 
 	it("leaves PATH untouched when every shell fails", async () => {
-		const env: NodeJS.ProcessEnv = {
-			SHELL: "/nonexistent/shell",
-			PATH: "/usr/bin",
-		};
+		const env: NodeJS.ProcessEnv = { PATH: "/usr/bin" };
 		const result = await ensureLoginShellPath({
 			platform: "darwin",
 			env,
+			userShell: "/nonexistent/shell",
 			fallbackShell: "/nonexistent/other-shell",
 		});
 		expect(result).toEqual({ status: "failed", shell: "/nonexistent/shell" });
@@ -219,14 +228,22 @@ describe("ensureLoginShellPath", () => {
 
 	it("never exposes the resolved PATH in its result", async () => {
 		const shell = writeFakeShell();
-		const env: NodeJS.ProcessEnv = { SHELL: shell, PATH: "/usr/bin" };
-		const result = await ensureLoginShellPath({ platform: "darwin", env });
+		const env: NodeJS.ProcessEnv = { PATH: "/usr/bin" };
+		const result = await ensureLoginShellPath({
+			platform: "darwin",
+			env,
+			userShell: shell,
+		});
 		expect(JSON.stringify(result)).not.toContain("/opt/homebrew/bin");
 	});
 
 	it("resolves against a real shell end to end", async () => {
-		const env: NodeJS.ProcessEnv = { SHELL: "/bin/sh", PATH: "/bin" };
-		const result = await ensureLoginShellPath({ platform: "linux", env });
+		const env: NodeJS.ProcessEnv = { PATH: "/bin" };
+		const result = await ensureLoginShellPath({
+			platform: "linux",
+			env,
+			userShell: "/bin/sh",
+		});
 		expect(result.status).toBe("applied");
 		expect(env.PATH).toContain("/bin");
 	});

--- a/apps/examples/desktop-app/sidecar/shell-path.test.ts
+++ b/apps/examples/desktop-app/sidecar/shell-path.test.ts
@@ -8,6 +8,7 @@ import {
 	extractMarkedPath,
 	mergePaths,
 	resolveLoginShellPath,
+	shellInvocationArgs,
 } from "./shell-path";
 
 const MARKER_START = "__CLINE_SIDECAR_PATH_START__";
@@ -15,10 +16,18 @@ const MARKER_END = "__CLINE_SIDECAR_PATH_END__";
 
 let tempDirs: string[] = [];
 
-function writeFakeShell(script: string): string {
+/**
+ * Fake login shell: a /bin/sh script invoked as `fake-shell -i -l -c <cmd>`,
+ * so the command to run arrives as $4. The default body mimics a login shell
+ * whose profile prepends Homebrew before running the command.
+ */
+function writeFakeShell(
+	script = 'PATH="/opt/homebrew/bin:/usr/bin"; eval "$4"',
+	name = "fake-shell",
+): string {
 	const dir = mkdtempSync(join(tmpdir(), "cline-shell-path-"));
 	tempDirs.push(dir);
-	const shellPath = join(dir, "fake-shell");
+	const shellPath = join(dir, name);
 	writeFileSync(shellPath, `#!/bin/sh\n${script}\n`);
 	chmodSync(shellPath, 0o755);
 	return shellPath;
@@ -74,13 +83,44 @@ describe("defaultShellFor", () => {
 	});
 });
 
+describe("shellInvocationArgs", () => {
+	it("uses separate login+interactive flags for posix-style shells", () => {
+		expect(shellInvocationArgs("/bin/zsh", "cmd")).toEqual([
+			"-i",
+			"-l",
+			"-c",
+			"cmd",
+		]);
+		expect(shellInvocationArgs("/opt/homebrew/bin/fish", "cmd")).toEqual([
+			"-i",
+			"-l",
+			"-c",
+			"cmd",
+		]);
+	});
+
+	it("uses only -c for csh-family shells (-l must be the sole flag there)", () => {
+		expect(shellInvocationArgs("/bin/tcsh", "cmd")).toEqual(["-c", "cmd"]);
+		expect(shellInvocationArgs("/bin/csh", "cmd")).toEqual(["-c", "cmd"]);
+	});
+});
+
 describe("resolveLoginShellPath", () => {
 	it("captures PATH from the shell", async () => {
-		// The fake shell ignores the -ilc flags and evaluates the command
-		// with a controlled PATH, mimicking a login shell whose profile
-		// prepends Homebrew.
+		const shell = writeFakeShell();
+		await expect(resolveLoginShellPath(shell)).resolves.toBe(
+			"/opt/homebrew/bin:/usr/bin",
+		);
+	});
+
+	it("reads PATH from the environment, not the shell's own expansion", async () => {
+		// Mimics fish: its "$PATH" expansion would space-join the entries,
+		// but the printf runs inside /bin/sh, which reads the exported
+		// colon-delimited PATH env var — so the shell's expansion rules
+		// never apply. This fake shell never evals the command text; it
+		// only exports PATH and runs the command via sh, like fish would.
 		const shell = writeFakeShell(
-			'PATH="/opt/homebrew/bin:/usr/bin"; eval "$2"',
+			'PATH="/opt/homebrew/bin:/usr/bin"; export PATH; /bin/sh -c "$4"',
 		);
 		await expect(resolveLoginShellPath(shell)).resolves.toBe(
 			"/opt/homebrew/bin:/usr/bin",
@@ -102,29 +142,62 @@ describe("resolveLoginShellPath", () => {
 		const shell = writeFakeShell("sleep 60");
 		await expect(resolveLoginShellPath(shell, 200)).resolves.toBeUndefined();
 	});
+
+	it("invokes csh-family shells without login/interactive flags", async () => {
+		// A csh stand-in that rejects any first flag other than -c.
+		const shell = writeFakeShell(
+			'[ "$1" = "-c" ] || exit 64; PATH="/opt/homebrew/bin:/usr/bin"; eval "$2"',
+			"tcsh",
+		);
+		await expect(resolveLoginShellPath(shell)).resolves.toBe(
+			"/opt/homebrew/bin:/usr/bin",
+		);
+	});
 });
 
 describe("ensureLoginShellPath", () => {
 	it("merges the login shell PATH into env.PATH", async () => {
-		const shell = writeFakeShell(
-			'PATH="/opt/homebrew/bin:/usr/bin"; eval "$2"',
-		);
+		const shell = writeFakeShell();
 		const env: NodeJS.ProcessEnv = {
 			SHELL: shell,
 			PATH: "/usr/bin:/bin",
 		};
 		const result = await ensureLoginShellPath({ platform: "darwin", env });
-		expect(result.status).toBe("applied");
+		expect(result).toEqual({
+			status: "applied",
+			pathEntries: 3,
+			shell,
+		});
 		expect(env.PATH).toBe("/opt/homebrew/bin:/usr/bin:/bin");
 	});
 
-	it("leaves PATH untouched when resolution fails", async () => {
+	it("falls back to the default shell when $SHELL can't resolve", async () => {
+		const fallbackShell = writeFakeShell();
 		const env: NodeJS.ProcessEnv = {
 			SHELL: "/nonexistent/shell",
 			PATH: "/usr/bin",
 		};
-		const result = await ensureLoginShellPath({ platform: "darwin", env });
-		expect(result.status).toBe("failed");
+		const result = await ensureLoginShellPath({
+			platform: "darwin",
+			env,
+			fallbackShell,
+		});
+		expect(result.status).toBe("applied");
+		expect(result).toMatchObject({ shell: fallbackShell });
+		expect(env.PATH).toBe("/opt/homebrew/bin:/usr/bin");
+	});
+
+	it("leaves PATH untouched when every shell fails", async () => {
+		const env: NodeJS.ProcessEnv = {
+			SHELL: "/nonexistent/shell",
+			PATH: "/usr/bin",
+		};
+		const result = await ensureLoginShellPath({
+			platform: "darwin",
+			env,
+			fallbackShell: "/nonexistent/other-shell",
+		});
+		expect(result).toEqual({ status: "failed", shell: "/nonexistent/shell" });
 		expect(env.PATH).toBe("/usr/bin");
 	});
 
@@ -142,6 +215,13 @@ describe("ensureLoginShellPath", () => {
 		const result = await ensureLoginShellPath({ platform: "darwin", env });
 		expect(result.status).toBe("skipped");
 		expect(env.PATH).toBe("/usr/bin");
+	});
+
+	it("never exposes the resolved PATH in its result", async () => {
+		const shell = writeFakeShell();
+		const env: NodeJS.ProcessEnv = { SHELL: shell, PATH: "/usr/bin" };
+		const result = await ensureLoginShellPath({ platform: "darwin", env });
+		expect(JSON.stringify(result)).not.toContain("/opt/homebrew/bin");
 	});
 
 	it("resolves against a real shell end to end", async () => {

--- a/apps/examples/desktop-app/sidecar/shell-path.test.ts
+++ b/apps/examples/desktop-app/sidecar/shell-path.test.ts
@@ -9,7 +9,7 @@ import {
 	loginShellFor,
 	mergePaths,
 	resolveLoginShellPath,
-	shellInvocationArgs,
+	shellInvocation,
 } from "./shell-path";
 
 const MARKER_START = "__CLINE_SIDECAR_PATH_START__";
@@ -95,25 +95,25 @@ describe("loginShellFor", () => {
 	});
 });
 
-describe("shellInvocationArgs", () => {
+describe("shellInvocation", () => {
 	it("uses separate login+interactive flags for posix-style shells", () => {
-		expect(shellInvocationArgs("/bin/zsh", "cmd")).toEqual([
-			"-i",
-			"-l",
-			"-c",
-			"cmd",
-		]);
-		expect(shellInvocationArgs("/opt/homebrew/bin/fish", "cmd")).toEqual([
-			"-i",
-			"-l",
-			"-c",
-			"cmd",
-		]);
+		expect(shellInvocation("/bin/zsh", "cmd")).toEqual({
+			args: ["-i", "-l", "-c", "cmd"],
+		});
+		expect(shellInvocation("/opt/homebrew/bin/fish", "cmd")).toEqual({
+			args: ["-i", "-l", "-c", "cmd"],
+		});
 	});
 
-	it("uses only -c for csh-family shells (-l must be the sole flag there)", () => {
-		expect(shellInvocationArgs("/bin/tcsh", "cmd")).toEqual(["-c", "cmd"]);
-		expect(shellInvocationArgs("/bin/csh", "cmd")).toEqual(["-c", "cmd"]);
+	it("marks csh-family shells as login via argv0 (-l must be their sole flag)", () => {
+		expect(shellInvocation("/bin/tcsh", "cmd")).toEqual({
+			args: ["-c", "cmd"],
+			argv0: "-tcsh",
+		});
+		expect(shellInvocation("/bin/csh", "cmd")).toEqual({
+			args: ["-c", "cmd"],
+			argv0: "-csh",
+		});
 	});
 });
 

--- a/apps/examples/desktop-app/sidecar/shell-path.test.ts
+++ b/apps/examples/desktop-app/sidecar/shell-path.test.ts
@@ -1,0 +1,153 @@
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	defaultShellFor,
+	ensureLoginShellPath,
+	extractMarkedPath,
+	mergePaths,
+	resolveLoginShellPath,
+} from "./shell-path";
+
+const MARKER_START = "__CLINE_SIDECAR_PATH_START__";
+const MARKER_END = "__CLINE_SIDECAR_PATH_END__";
+
+let tempDirs: string[] = [];
+
+function writeFakeShell(script: string): string {
+	const dir = mkdtempSync(join(tmpdir(), "cline-shell-path-"));
+	tempDirs.push(dir);
+	const shellPath = join(dir, "fake-shell");
+	writeFileSync(shellPath, `#!/bin/sh\n${script}\n`);
+	chmodSync(shellPath, 0o755);
+	return shellPath;
+}
+
+afterEach(() => {
+	for (const dir of tempDirs) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+	tempDirs = [];
+});
+
+describe("extractMarkedPath", () => {
+	it("extracts the PATH between markers", () => {
+		expect(
+			extractMarkedPath(
+				`${MARKER_START}/opt/homebrew/bin:/usr/bin${MARKER_END}`,
+			),
+		).toBe("/opt/homebrew/bin:/usr/bin");
+	});
+
+	it("ignores shell profile noise around the markers", () => {
+		const output = `Welcome!\nsome banner\n${MARKER_START}/usr/local/bin${MARKER_END}\ntrailing noise`;
+		expect(extractMarkedPath(output)).toBe("/usr/local/bin");
+	});
+
+	it("returns undefined when markers are missing or empty", () => {
+		expect(extractMarkedPath("no markers here")).toBeUndefined();
+		expect(extractMarkedPath(`${MARKER_START}${MARKER_END}`)).toBeUndefined();
+		expect(extractMarkedPath(`${MARKER_START}/usr/bin`)).toBeUndefined();
+	});
+});
+
+describe("mergePaths", () => {
+	it("puts shell entries first and keeps current-only entries", () => {
+		expect(
+			mergePaths(
+				"/opt/homebrew/bin:/usr/bin:/bin",
+				"/usr/bin:/bin:/custom/bin",
+			),
+		).toBe("/opt/homebrew/bin:/usr/bin:/bin:/custom/bin");
+	});
+
+	it("drops duplicate and empty entries", () => {
+		expect(mergePaths("/a::/b:/a", "/b:/c:")).toBe("/a:/b:/c");
+	});
+});
+
+describe("defaultShellFor", () => {
+	it("uses zsh on macOS and bash elsewhere", () => {
+		expect(defaultShellFor("darwin")).toBe("/bin/zsh");
+		expect(defaultShellFor("linux")).toBe("/bin/bash");
+	});
+});
+
+describe("resolveLoginShellPath", () => {
+	it("captures PATH from the shell", async () => {
+		// The fake shell ignores the -ilc flags and evaluates the command
+		// with a controlled PATH, mimicking a login shell whose profile
+		// prepends Homebrew.
+		const shell = writeFakeShell(
+			'PATH="/opt/homebrew/bin:/usr/bin"; eval "$2"',
+		);
+		await expect(resolveLoginShellPath(shell)).resolves.toBe(
+			"/opt/homebrew/bin:/usr/bin",
+		);
+	});
+
+	it("resolves undefined when the shell prints garbage", async () => {
+		const shell = writeFakeShell('echo "no markers"');
+		await expect(resolveLoginShellPath(shell)).resolves.toBeUndefined();
+	});
+
+	it("resolves undefined when the shell is missing", async () => {
+		await expect(
+			resolveLoginShellPath("/nonexistent/shell"),
+		).resolves.toBeUndefined();
+	});
+
+	it("times out hung shells without rejecting", async () => {
+		const shell = writeFakeShell("sleep 60");
+		await expect(resolveLoginShellPath(shell, 200)).resolves.toBeUndefined();
+	});
+});
+
+describe("ensureLoginShellPath", () => {
+	it("merges the login shell PATH into env.PATH", async () => {
+		const shell = writeFakeShell(
+			'PATH="/opt/homebrew/bin:/usr/bin"; eval "$2"',
+		);
+		const env: NodeJS.ProcessEnv = {
+			SHELL: shell,
+			PATH: "/usr/bin:/bin",
+		};
+		const result = await ensureLoginShellPath({ platform: "darwin", env });
+		expect(result.status).toBe("applied");
+		expect(env.PATH).toBe("/opt/homebrew/bin:/usr/bin:/bin");
+	});
+
+	it("leaves PATH untouched when resolution fails", async () => {
+		const env: NodeJS.ProcessEnv = {
+			SHELL: "/nonexistent/shell",
+			PATH: "/usr/bin",
+		};
+		const result = await ensureLoginShellPath({ platform: "darwin", env });
+		expect(result.status).toBe("failed");
+		expect(env.PATH).toBe("/usr/bin");
+	});
+
+	it("skips on windows", async () => {
+		const env: NodeJS.ProcessEnv = { PATH: "C:\\Windows" };
+		const result = await ensureLoginShellPath({ platform: "win32", env });
+		expect(result).toEqual({ status: "skipped", reason: "windows" });
+	});
+
+	it("skips when the escape hatch is set", async () => {
+		const env: NodeJS.ProcessEnv = {
+			PATH: "/usr/bin",
+			CLINE_SIDECAR_SKIP_SHELL_PATH: "1",
+		};
+		const result = await ensureLoginShellPath({ platform: "darwin", env });
+		expect(result.status).toBe("skipped");
+		expect(env.PATH).toBe("/usr/bin");
+	});
+
+	it("resolves against a real shell end to end", async () => {
+		const env: NodeJS.ProcessEnv = { SHELL: "/bin/sh", PATH: "/bin" };
+		const result = await ensureLoginShellPath({ platform: "linux", env });
+		expect(result.status).toBe("applied");
+		expect(env.PATH).toContain("/bin");
+	});
+});

--- a/apps/examples/desktop-app/sidecar/shell-path.ts
+++ b/apps/examples/desktop-app/sidecar/shell-path.ts
@@ -67,18 +67,32 @@ export function loginShellFor(
 	return env.SHELL?.trim() || defaultShellFor(platform);
 }
 
+export interface ShellInvocation {
+	args: string[];
+	/**
+	 * argv[0] the shell should see. A leading dash is the historical "you
+	 * are a login shell" signal, used where -l can't be passed as a flag.
+	 */
+	argv0?: string;
+}
+
 /**
- * Flags to make a shell source its profiles and run a command. csh/tcsh
- * accept -l only as the sole flag and always source ~/.tcshrc, so they get
- * plain -c; everything else gets login (-l, ~/.zprofile — Homebrew's
- * shellenv) plus interactive (-i, ~/.zshrc — nvm-style version managers).
+ * How to invoke a shell so it sources its profiles and runs a command.
+ * csh/tcsh accept -l only as the sole flag, so they're marked login via the
+ * argv[0] dash convention instead (sources ~/.login on top of the always-read
+ * ~/.cshrc//.tcshrc); everything else gets login (-l, ~/.zprofile —
+ * Homebrew's shellenv) plus interactive (-i, ~/.zshrc — nvm-style version
+ * managers) as separate flags.
  */
-export function shellInvocationArgs(shell: string, command: string): string[] {
+export function shellInvocation(
+	shell: string,
+	command: string,
+): ShellInvocation {
 	const kind = basename(shell);
 	if (kind === "csh" || kind === "tcsh") {
-		return ["-c", command];
+		return { args: ["-c", command], argv0: `-${kind}` };
 	}
-	return ["-i", "-l", "-c", command];
+	return { args: ["-i", "-l", "-c", command] };
 }
 
 /**
@@ -131,7 +145,9 @@ export function resolveLoginShellPath(
 	timeoutMs = SHELL_TIMEOUT_MS,
 ): Promise<string | undefined> {
 	return new Promise((resolve) => {
-		const child = spawn(shell, shellInvocationArgs(shell, PRINT_PATH_COMMAND), {
+		const invocation = shellInvocation(shell, PRINT_PATH_COMMAND);
+		const child = spawn(shell, invocation.args, {
+			argv0: invocation.argv0,
 			stdio: ["ignore", "pipe", "ignore"],
 			detached: true,
 		});

--- a/apps/examples/desktop-app/sidecar/shell-path.ts
+++ b/apps/examples/desktop-app/sidecar/shell-path.ts
@@ -13,6 +13,7 @@
  */
 
 import { spawn } from "node:child_process";
+import { userInfo } from "node:os";
 import { basename, delimiter } from "node:path";
 
 const PATH_MARKER_START = "__CLINE_SIDECAR_PATH_START__";
@@ -41,6 +42,29 @@ const SKIP_ENV_VAR = "CLINE_SIDECAR_SKIP_SHELL_PATH";
 
 export function defaultShellFor(platform: NodeJS.Platform): string {
 	return platform === "darwin" ? "/bin/zsh" : "/bin/bash";
+}
+
+/**
+ * The user's configured login shell. The account database is authoritative:
+ * a GUI-launched process has no parent shell, so $SHELL may be unset there.
+ * userInfo() reads getpwuid(), which on macOS goes through DirectoryServices
+ * — the same source `dscl . -read /Users/$USER UserShell` reports — and on
+ * Linux resolves via NSS (/etc/passwd et al.). $SHELL and the platform
+ * default are fallbacks for environments with no passwd entry.
+ */
+export function loginShellFor(
+	platform: NodeJS.Platform,
+	env: NodeJS.ProcessEnv,
+): string {
+	try {
+		const shell = userInfo().shell?.trim();
+		if (shell) {
+			return shell;
+		}
+	} catch {
+		// No passwd entry for the current uid (some containers) — fall through.
+	}
+	return env.SHELL?.trim() || defaultShellFor(platform);
 }
 
 /**
@@ -143,9 +167,10 @@ export function resolveLoginShellPath(
 }
 
 /**
- * Resolve the login shell's PATH and merge it into process.env.PATH. If the
- * user's $SHELL can't produce a PATH (exotic shell, broken profile), retry
- * once with the platform default shell before giving up.
+ * Resolve the login shell's PATH and merge it into process.env.PATH. The
+ * shell comes from the account database (see loginShellFor); if it can't
+ * produce a PATH (exotic shell, broken profile), retry once with the
+ * platform default shell before giving up.
  *
  * No-op on Windows (the GUI PATH comes from the registry there) and when
  * CLINE_SIDECAR_SKIP_SHELL_PATH is set. Failures are reported via the
@@ -156,6 +181,8 @@ export async function ensureLoginShellPath(options?: {
 	platform?: NodeJS.Platform;
 	env?: NodeJS.ProcessEnv;
 	timeoutMs?: number;
+	/** Test seam: overrides passwd/$SHELL discovery of the user's shell. */
+	userShell?: string;
 	/** Test seam: overrides the platform-default fallback shell. */
 	fallbackShell?: string;
 }): Promise<
@@ -173,7 +200,7 @@ export async function ensureLoginShellPath(options?: {
 		return { status: "skipped", reason: SKIP_ENV_VAR };
 	}
 
-	const userShell = env.SHELL?.trim() || defaultShellFor(platform);
+	const userShell = options?.userShell ?? loginShellFor(platform, env);
 	const fallbackShell = options?.fallbackShell ?? defaultShellFor(platform);
 	const baseTimeoutMs = options?.timeoutMs ?? SHELL_TIMEOUT_MS;
 	// The fallback gets half the budget so the combined worst case stays

--- a/apps/examples/desktop-app/sidecar/shell-path.ts
+++ b/apps/examples/desktop-app/sidecar/shell-path.ts
@@ -1,0 +1,159 @@
+/**
+ * Login-shell PATH resolution for the desktop sidecar.
+ *
+ * When the Tauri app is launched from Finder/the Dock on macOS, it inherits
+ * launchd's minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin) instead of the
+ * user's shell PATH. The sidecar — and every process it spawns for the agent
+ * (bash tool, MCP servers) — then can't find tools like `gh` that live in
+ * /opt/homebrew/bin or other shell-profile-added directories, even though
+ * the same task works from the CLI in a terminal.
+ *
+ * At startup we ask the user's login shell for its PATH and merge it into
+ * process.env.PATH, so child processes see the same PATH a terminal would.
+ */
+
+import { spawn } from "node:child_process";
+import { delimiter } from "node:path";
+
+const PATH_MARKER_START = "__CLINE_SIDECAR_PATH_START__";
+const PATH_MARKER_END = "__CLINE_SIDECAR_PATH_END__";
+const SHELL_TIMEOUT_MS = 5_000;
+
+/**
+ * Escape hatch: set CLINE_SIDECAR_SKIP_SHELL_PATH=1 to leave PATH untouched
+ * (e.g. if a broken shell profile makes resolution misbehave).
+ */
+const SKIP_ENV_VAR = "CLINE_SIDECAR_SKIP_SHELL_PATH";
+
+export function defaultShellFor(platform: NodeJS.Platform): string {
+	return platform === "darwin" ? "/bin/zsh" : "/bin/bash";
+}
+
+/**
+ * Extract the PATH value printed between the sentinel markers, ignoring any
+ * noise a shell profile writes to stdout around it.
+ */
+export function extractMarkedPath(output: string): string | undefined {
+	const start = output.indexOf(PATH_MARKER_START);
+	if (start === -1) {
+		return undefined;
+	}
+	const end = output.indexOf(PATH_MARKER_END, start);
+	if (end === -1) {
+		return undefined;
+	}
+	const value = output.slice(start + PATH_MARKER_START.length, end).trim();
+	return value.length > 0 ? value : undefined;
+}
+
+/**
+ * Merge the login shell's PATH with the current one: shell entries first (so
+ * profile-managed dirs like /opt/homebrew/bin win), then any current entries
+ * the shell PATH doesn't already contain (so explicitly-injected dirs from
+ * the launching environment aren't lost). Duplicates are dropped.
+ */
+export function mergePaths(shellPath: string, currentPath: string): string {
+	const seen = new Set<string>();
+	const merged: string[] = [];
+	for (const entry of [
+		...shellPath.split(delimiter),
+		...currentPath.split(delimiter),
+	]) {
+		const trimmed = entry.trim();
+		if (trimmed.length === 0 || seen.has(trimmed)) {
+			continue;
+		}
+		seen.add(trimmed);
+		merged.push(trimmed);
+	}
+	return merged.join(delimiter);
+}
+
+/**
+ * Run the user's shell as a login+interactive shell and capture its PATH.
+ * Resolves to undefined on any failure (missing shell, timeout, profile
+ * error) — callers should treat that as "keep the current PATH".
+ */
+export function resolveLoginShellPath(
+	shell: string,
+	timeoutMs = SHELL_TIMEOUT_MS,
+): Promise<string | undefined> {
+	return new Promise((resolve) => {
+		// -l sources login profiles (~/.zprofile, where Homebrew installs its
+		// shellenv hook); -i sources interactive rc files (~/.zshrc, where
+		// version managers like nvm typically live). The markers isolate the
+		// PATH value from anything those profiles print.
+		const child = spawn(
+			shell,
+			[
+				"-ilc",
+				`printf '%s%s%s' '${PATH_MARKER_START}' "$PATH" '${PATH_MARKER_END}'`,
+			],
+			{ stdio: ["ignore", "pipe", "ignore"], detached: true },
+		);
+
+		let output = "";
+		let settled = false;
+		const settle = (value: string | undefined) => {
+			if (settled) {
+				return;
+			}
+			settled = true;
+			clearTimeout(timeout);
+			resolve(value);
+		};
+
+		const timeout = setTimeout(() => {
+			try {
+				if (child.pid) {
+					process.kill(-child.pid, "SIGKILL");
+				}
+			} catch {
+				child.kill("SIGKILL");
+			}
+			settle(undefined);
+		}, timeoutMs);
+
+		child.stdout?.on("data", (data: Buffer) => {
+			output += data.toString("utf8");
+		});
+		child.on("error", () => settle(undefined));
+		child.on("close", () => settle(extractMarkedPath(output)));
+	});
+}
+
+/**
+ * Resolve the login shell's PATH and merge it into process.env.PATH.
+ * No-op on Windows (the GUI PATH comes from the registry there) and when
+ * CLINE_SIDECAR_SKIP_SHELL_PATH is set. Failures are reported via the
+ * returned status but never block startup.
+ */
+export async function ensureLoginShellPath(options?: {
+	platform?: NodeJS.Platform;
+	env?: NodeJS.ProcessEnv;
+	timeoutMs?: number;
+}): Promise<
+	| { status: "applied"; path: string; shell: string }
+	| { status: "skipped"; reason: string }
+	| { status: "failed"; shell: string }
+> {
+	const platform = options?.platform ?? process.platform;
+	const env = options?.env ?? process.env;
+
+	if (platform === "win32") {
+		return { status: "skipped", reason: "windows" };
+	}
+	if (env[SKIP_ENV_VAR]?.trim()) {
+		return { status: "skipped", reason: SKIP_ENV_VAR };
+	}
+
+	const shell = env.SHELL?.trim() || defaultShellFor(platform);
+	const shellPath = await resolveLoginShellPath(shell, options?.timeoutMs);
+	if (!shellPath) {
+		return { status: "failed", shell };
+	}
+
+	const merged = mergePaths(shellPath, env.PATH ?? "");
+	env.PATH = merged;
+	return { status: "applied", path: merged, shell };
+}

--- a/apps/examples/desktop-app/sidecar/shell-path.ts
+++ b/apps/examples/desktop-app/sidecar/shell-path.ts
@@ -13,11 +13,25 @@
  */
 
 import { spawn } from "node:child_process";
-import { delimiter } from "node:path";
+import { basename, delimiter } from "node:path";
 
 const PATH_MARKER_START = "__CLINE_SIDECAR_PATH_START__";
 const PATH_MARKER_END = "__CLINE_SIDECAR_PATH_END__";
-const SHELL_TIMEOUT_MS = 5_000;
+
+/**
+ * Kept well under the Tauri shell's 5s endpoint-readiness poll: this
+ * resolution overlaps sidecar startup but is awaited before the server
+ * starts, so a pathological shell profile must not eat the whole window.
+ */
+const SHELL_TIMEOUT_MS = 2_000;
+
+/**
+ * The command every shell is asked to run. $PATH expansion happens inside
+ * POSIX sh — not the user's shell — so shells with different expansion rules
+ * (fish would space-join "$PATH") still produce a colon-delimited value; sh
+ * reads the PATH environment variable the login shell exported.
+ */
+const PRINT_PATH_COMMAND = `/bin/sh -c 'printf "%s%s%s" "${PATH_MARKER_START}" "$PATH" "${PATH_MARKER_END}"'`;
 
 /**
  * Escape hatch: set CLINE_SIDECAR_SKIP_SHELL_PATH=1 to leave PATH untouched
@@ -27,6 +41,20 @@ const SKIP_ENV_VAR = "CLINE_SIDECAR_SKIP_SHELL_PATH";
 
 export function defaultShellFor(platform: NodeJS.Platform): string {
 	return platform === "darwin" ? "/bin/zsh" : "/bin/bash";
+}
+
+/**
+ * Flags to make a shell source its profiles and run a command. csh/tcsh
+ * accept -l only as the sole flag and always source ~/.tcshrc, so they get
+ * plain -c; everything else gets login (-l, ~/.zprofile — Homebrew's
+ * shellenv) plus interactive (-i, ~/.zshrc — nvm-style version managers).
+ */
+export function shellInvocationArgs(shell: string, command: string): string[] {
+	const kind = basename(shell);
+	if (kind === "csh" || kind === "tcsh") {
+		return ["-c", command];
+	}
+	return ["-i", "-l", "-c", command];
 }
 
 /**
@@ -70,7 +98,7 @@ export function mergePaths(shellPath: string, currentPath: string): string {
 }
 
 /**
- * Run the user's shell as a login+interactive shell and capture its PATH.
+ * Run the user's shell with its profiles sourced and capture its PATH.
  * Resolves to undefined on any failure (missing shell, timeout, profile
  * error) — callers should treat that as "keep the current PATH".
  */
@@ -79,18 +107,10 @@ export function resolveLoginShellPath(
 	timeoutMs = SHELL_TIMEOUT_MS,
 ): Promise<string | undefined> {
 	return new Promise((resolve) => {
-		// -l sources login profiles (~/.zprofile, where Homebrew installs its
-		// shellenv hook); -i sources interactive rc files (~/.zshrc, where
-		// version managers like nvm typically live). The markers isolate the
-		// PATH value from anything those profiles print.
-		const child = spawn(
-			shell,
-			[
-				"-ilc",
-				`printf '%s%s%s' '${PATH_MARKER_START}' "$PATH" '${PATH_MARKER_END}'`,
-			],
-			{ stdio: ["ignore", "pipe", "ignore"], detached: true },
-		);
+		const child = spawn(shell, shellInvocationArgs(shell, PRINT_PATH_COMMAND), {
+			stdio: ["ignore", "pipe", "ignore"],
+			detached: true,
+		});
 
 		let output = "";
 		let settled = false;
@@ -123,17 +143,23 @@ export function resolveLoginShellPath(
 }
 
 /**
- * Resolve the login shell's PATH and merge it into process.env.PATH.
+ * Resolve the login shell's PATH and merge it into process.env.PATH. If the
+ * user's $SHELL can't produce a PATH (exotic shell, broken profile), retry
+ * once with the platform default shell before giving up.
+ *
  * No-op on Windows (the GUI PATH comes from the registry there) and when
  * CLINE_SIDECAR_SKIP_SHELL_PATH is set. Failures are reported via the
- * returned status but never block startup.
+ * returned status but never block startup. The result never contains the
+ * resolved PATH itself so it is safe to log verbatim.
  */
 export async function ensureLoginShellPath(options?: {
 	platform?: NodeJS.Platform;
 	env?: NodeJS.ProcessEnv;
 	timeoutMs?: number;
+	/** Test seam: overrides the platform-default fallback shell. */
+	fallbackShell?: string;
 }): Promise<
-	| { status: "applied"; path: string; shell: string }
+	| { status: "applied"; pathEntries: number; shell: string }
 	| { status: "skipped"; reason: string }
 	| { status: "failed"; shell: string }
 > {
@@ -147,13 +173,31 @@ export async function ensureLoginShellPath(options?: {
 		return { status: "skipped", reason: SKIP_ENV_VAR };
 	}
 
-	const shell = env.SHELL?.trim() || defaultShellFor(platform);
-	const shellPath = await resolveLoginShellPath(shell, options?.timeoutMs);
-	if (!shellPath) {
-		return { status: "failed", shell };
-	}
+	const userShell = env.SHELL?.trim() || defaultShellFor(platform);
+	const fallbackShell = options?.fallbackShell ?? defaultShellFor(platform);
+	const baseTimeoutMs = options?.timeoutMs ?? SHELL_TIMEOUT_MS;
+	// The fallback gets half the budget so the combined worst case stays
+	// bounded even when both shells hang (see SHELL_TIMEOUT_MS).
+	const attempts: Array<[shell: string, timeoutMs: number]> =
+		userShell === fallbackShell
+			? [[userShell, baseTimeoutMs]]
+			: [
+					[userShell, baseTimeoutMs],
+					[fallbackShell, baseTimeoutMs / 2],
+				];
 
-	const merged = mergePaths(shellPath, env.PATH ?? "");
-	env.PATH = merged;
-	return { status: "applied", path: merged, shell };
+	for (const [shell, timeoutMs] of attempts) {
+		const shellPath = await resolveLoginShellPath(shell, timeoutMs);
+		if (!shellPath) {
+			continue;
+		}
+		const merged = mergePaths(shellPath, env.PATH ?? "");
+		env.PATH = merged;
+		return {
+			status: "applied",
+			pathEntries: merged.split(delimiter).length,
+			shell,
+		};
+	}
+	return { status: "failed", shell: userShell };
 }

--- a/apps/examples/desktop-app/sidecar/shell-path.ts
+++ b/apps/examples/desktop-app/sidecar/shell-path.ts
@@ -80,7 +80,7 @@ export interface ShellInvocation {
  * How to invoke a shell so it sources its profiles and runs a command.
  * csh/tcsh accept -l only as the sole flag, so they're marked login via the
  * argv[0] dash convention instead (sources ~/.login on top of the always-read
- * ~/.cshrc//.tcshrc); everything else gets login (-l, ~/.zprofile —
+ * ~/.cshrc or ~/.tcshrc); everything else gets login (-l, ~/.zprofile —
  * Homebrew's shellenv) plus interactive (-i, ~/.zshrc — nvm-style version
  * managers) as separate flags.
  */
@@ -119,20 +119,13 @@ export function extractMarkedPath(output: string): string | undefined {
  * the launching environment aren't lost). Duplicates are dropped.
  */
 export function mergePaths(shellPath: string, currentPath: string): string {
-	const seen = new Set<string>();
-	const merged: string[] = [];
-	for (const entry of [
+	const entries = [
 		...shellPath.split(delimiter),
 		...currentPath.split(delimiter),
-	]) {
-		const trimmed = entry.trim();
-		if (trimmed.length === 0 || seen.has(trimmed)) {
-			continue;
-		}
-		seen.add(trimmed);
-		merged.push(trimmed);
-	}
-	return merged.join(delimiter);
+	]
+		.map((entry) => entry.trim())
+		.filter((entry) => entry.length > 0);
+	return Array.from(new Set(entries)).join(delimiter);
 }
 
 /**

--- a/apps/examples/desktop-app/src-tauri/src/main.rs
+++ b/apps/examples/desktop-app/src-tauri/src/main.rs
@@ -346,43 +346,7 @@ fn resolve_desktop_backend_binary_path(context: &AppContext) -> Option<PathBuf> 
     candidates.into_iter().find(|path| path.exists())
 }
 
-fn ensure_desktop_backend_started(
-    state: &Arc<DesktopBackendState>,
-    context: &AppContext,
-) -> Result<(), String> {
-    if state.is_shutting_down() {
-        return Ok(());
-    }
-
-    {
-        let mut process_guard = state
-            .process
-            .lock()
-            .map_err(|_| "failed to lock desktop backend process state")?;
-        if let Some(existing) = process_guard.as_mut() {
-            match existing.try_wait() {
-                Ok(None) => {
-                    if state
-                        .ws_endpoint
-                        .lock()
-                        .ok()
-                        .and_then(|value| value.as_ref().cloned())
-                        .map(|value| !value.trim().is_empty())
-                        .unwrap_or(false)
-                    {
-                        return Ok(());
-                    }
-                }
-                Ok(Some(_)) | Err(_) => {
-                    *process_guard = None;
-                    if let Ok(mut endpoint_guard) = state.ws_endpoint.lock() {
-                        *endpoint_guard = None;
-                    }
-                }
-            }
-        }
-    }
-
+fn spawn_desktop_backend_process(context: &AppContext) -> Result<Child, String> {
     let mut command = if let Some(binary_path) = resolve_desktop_backend_binary_path(context) {
         let mut command = Command::new(binary_path);
         command.current_dir(&context.workspace_root);
@@ -401,12 +365,54 @@ fn ensure_desktop_backend_started(
         ));
     };
 
-    let mut child = command
+    command
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
-        .map_err(|e| format!("failed to start desktop backend sidecar: {e}"))?;
+        .map_err(|e| format!("failed to start desktop backend sidecar: {e}"))
+}
+
+fn ensure_desktop_backend_started(
+    state: &Arc<DesktopBackendState>,
+    context: &AppContext,
+) -> Result<(), String> {
+    ensure_desktop_backend_started_with(state, || spawn_desktop_backend_process(context))
+}
+
+fn ensure_desktop_backend_started_with(
+    state: &Arc<DesktopBackendState>,
+    spawn_backend: impl FnOnce() -> Result<Child, String>,
+) -> Result<(), String> {
+    if state.is_shutting_down() {
+        return Ok(());
+    }
+
+    // Hold the process lock for the entire check-and-spawn so concurrent
+    // callers (setup, the health-check loop, endpoint fetches from the
+    // webview) serialize: the second caller blocks here, then sees the live
+    // child and returns instead of spawning a duplicate.
+    let mut process_guard = state
+        .process
+        .lock()
+        .map_err(|_| "failed to lock desktop backend process state")?;
+    if let Some(existing) = process_guard.as_mut() {
+        match existing.try_wait() {
+            // A live child owns startup even while its endpoint is still
+            // pending (login-shell PATH resolution plus session-manager init
+            // take a few seconds). Spawning again here would orphan it and
+            // race on the port.
+            Ok(None) => return Ok(()),
+            Ok(Some(_)) | Err(_) => {
+                *process_guard = None;
+                if let Ok(mut endpoint_guard) = state.ws_endpoint.lock() {
+                    *endpoint_guard = None;
+                }
+            }
+        }
+    }
+
+    let mut child = spawn_backend()?;
 
     let stdout = child
         .stdout
@@ -417,6 +423,7 @@ fn ensure_desktop_backend_started(
         .take()
         .ok_or_else(|| "failed to capture desktop backend stderr".to_string())?;
 
+    let child_pid = child.id();
     let state_for_stdout = state.clone();
     thread::spawn(move || {
         let mut reader = BufReader::new(stdout);
@@ -445,8 +452,19 @@ fn ensure_desktop_backend_started(
             }
             eprintln!("[desktop-backend] {trimmed}");
         }
-        if let Ok(mut endpoint_guard) = state_for_stdout.ws_endpoint.lock() {
-            *endpoint_guard = None;
+        // Only clear the endpoint if this thread's child is still the one
+        // being tracked — a late EOF from a replaced child must not wipe the
+        // endpoint its successor already published.
+        let owns_tracked_child = state_for_stdout
+            .process
+            .lock()
+            .ok()
+            .map(|guard| guard.as_ref().map(|child| child.id()) == Some(child_pid))
+            .unwrap_or(false);
+        if owns_tracked_child {
+            if let Ok(mut endpoint_guard) = state_for_stdout.ws_endpoint.lock() {
+                *endpoint_guard = None;
+            }
         }
     });
 
@@ -462,10 +480,6 @@ fn ensure_desktop_backend_started(
         }
     });
 
-    let mut process_guard = state
-        .process
-        .lock()
-        .map_err(|_| "failed to lock desktop backend process state")?;
     *process_guard = Some(child);
     Ok(())
 }
@@ -537,6 +551,8 @@ fn get_desktop_backend_endpoint(
     // see sidecar/shell-path.ts) plus session-manager init, whose duration
     // varies by machine. Poll well past that combined worst case; the loop
     // returns as soon as the ready line arrives, so only failure waits long.
+    // While pending this only waits — respawning is ensure's job, and it
+    // refuses to start a second sidecar while the first one is still alive.
     for _ in 0..150 {
         if let Some(endpoint) = backend_state
             .ws_endpoint
@@ -546,6 +562,18 @@ fn get_desktop_backend_endpoint(
             .filter(|value| !value.trim().is_empty())
         {
             return Ok(endpoint);
+        }
+        let child_exited = backend_state
+            .process
+            .lock()
+            .ok()
+            .map(|mut guard| match guard.as_mut() {
+                Some(child) => !matches!(child.try_wait(), Ok(None)),
+                None => true,
+            })
+            .unwrap_or(false);
+        if child_exited {
+            return Err("desktop backend exited before publishing its endpoint".to_string());
         }
         thread::sleep(Duration::from_millis(100));
     }
@@ -663,4 +691,111 @@ fn main() {
             }
             _ => {}
         });
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// A stand-in sidecar that stays alive without ever publishing a ready
+    /// line — the endpoint-pending startup window that used to trigger
+    /// duplicate spawns.
+    fn spawn_pending_sidecar() -> Result<Child, String> {
+        Command::new("sleep")
+            .arg("30")
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| e.to_string())
+    }
+
+    #[test]
+    fn repeated_startup_checks_reuse_live_child_while_endpoint_pending() {
+        let state = Arc::new(DesktopBackendState::default());
+        let spawn_count = AtomicUsize::new(0);
+        for _ in 0..3 {
+            ensure_desktop_backend_started_with(&state, || {
+                spawn_count.fetch_add(1, Ordering::SeqCst);
+                spawn_pending_sidecar()
+            })
+            .expect("startup check should succeed");
+        }
+        assert_eq!(spawn_count.load(Ordering::SeqCst), 1);
+        // Kill the fake sidecar directly so stop() doesn't wait out its
+        // graceful-exit window.
+        if let Ok(mut guard) = state.process.lock() {
+            if let Some(child) = guard.as_mut() {
+                let _ = child.kill();
+            }
+        }
+        state.stop();
+    }
+
+    #[test]
+    fn concurrent_startup_checks_spawn_exactly_one_child() {
+        let state = Arc::new(DesktopBackendState::default());
+        let spawn_count = Arc::new(AtomicUsize::new(0));
+        let handles: Vec<_> = (0..8)
+            .map(|_| {
+                let state = state.clone();
+                let spawn_count = spawn_count.clone();
+                thread::spawn(move || {
+                    ensure_desktop_backend_started_with(&state, || {
+                        spawn_count.fetch_add(1, Ordering::SeqCst);
+                        spawn_pending_sidecar()
+                    })
+                    .expect("startup check should succeed");
+                })
+            })
+            .collect();
+        for handle in handles {
+            handle.join().expect("startup thread should not panic");
+        }
+        assert_eq!(spawn_count.load(Ordering::SeqCst), 1);
+        if let Ok(mut guard) = state.process.lock() {
+            if let Some(child) = guard.as_mut() {
+                let _ = child.kill();
+            }
+        }
+        state.stop();
+    }
+
+    #[test]
+    fn exited_child_is_replaced_on_next_startup_check() {
+        let state = Arc::new(DesktopBackendState::default());
+        let spawn_count = AtomicUsize::new(0);
+        let spawn_exiting = || {
+            spawn_count.fetch_add(1, Ordering::SeqCst);
+            Command::new("true")
+                .stdin(Stdio::null())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .map_err(|e| e.to_string())
+        };
+        ensure_desktop_backend_started_with(&state, || spawn_exiting())
+            .expect("startup check should succeed");
+        // Wait for the first child to exit so the next check sees a dead one.
+        for _ in 0..100 {
+            let exited = state
+                .process
+                .lock()
+                .ok()
+                .map(|mut guard| match guard.as_mut() {
+                    Some(child) => !matches!(child.try_wait(), Ok(None)),
+                    None => true,
+                })
+                .unwrap_or(false);
+            if exited {
+                break;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        ensure_desktop_backend_started_with(&state, || spawn_exiting())
+            .expect("startup check should succeed");
+        assert_eq!(spawn_count.load(Ordering::SeqCst), 2);
+        state.stop();
+    }
 }

--- a/apps/examples/desktop-app/src-tauri/src/main.rs
+++ b/apps/examples/desktop-app/src-tauri/src/main.rs
@@ -122,6 +122,9 @@ async fn run_update_loop(app: tauri::AppHandle, state: Arc<UpdateState>) {
     }
 }
 
+/// Lock order: `process` may be held while acquiring `ws_endpoint`, never
+/// the reverse. Anything that touches both (including stop()) must either
+/// nest in that order or take them strictly sequentially.
 #[derive(Default)]
 struct DesktopBackendState {
     ws_endpoint: Mutex<Option<String>>,

--- a/apps/examples/desktop-app/src-tauri/src/main.rs
+++ b/apps/examples/desktop-app/src-tauri/src/main.rs
@@ -533,7 +533,11 @@ fn get_desktop_backend_endpoint(
     context: State<'_, AppContext>,
 ) -> Result<String, String> {
     ensure_desktop_backend_started(backend_state.inner(), context.inner())?;
-    for _ in 0..50 {
+    // Sidecar startup includes login-shell PATH resolution (bounded at 3s,
+    // see sidecar/shell-path.ts) plus session-manager init, whose duration
+    // varies by machine. Poll well past that combined worst case; the loop
+    // returns as soon as the ready line arrives, so only failure waits long.
+    for _ in 0..150 {
         if let Some(endpoint) = backend_state
             .ws_endpoint
             .lock()


### PR DESCRIPTION
### Related Issue

**Issue:** [CLINE-2740](https://linear.app/cline-bot/issue/CLINE-2740/app-says-gh-is-not-installed-when-pushing-a-pr)

### Description

**The problem.** Asking the desktop app to push a PR fails with "`gh` is not installed" — but the exact same task works fine from the CLI. PM and team hit this while testing the app.

**Root cause.** This is the classic macOS GUI PATH problem. When the Tauri app is launched from Finder/the Dock, launchd hands it the minimal system PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) — none of the user's shell profiles ever run. The chain from there:

1. `src-tauri/src/main.rs` (`ensure_desktop_backend_started`) spawns the sidecar with `Command::new(...)`, inheriting that minimal env verbatim.
2. The SDK's bash executor (`sdk/packages/core/src/extensions/tools/executors/bash.ts`) spawns agent commands with `env: { ...process.env, ...config.env }` through a **non-login** `/bin/bash -c` (`getShellArgs` → `["-c", command]`), so nothing re-sources the profiles either.
3. Homebrew installs `gh` into `/opt/homebrew/bin`, which only gets onto PATH via the `brew shellenv` hook in `~/.zprofile`.

So from the agent's perspective `gh` genuinely doesn't exist — `command -v gh` finds nothing. The CLI never hits this because a terminal already runs inside the login shell with the full PATH. Same class of bug VS Code solves with its "shell environment resolution" and Tauri apps typically solve with the `fix-path-env-rs` crate.

### Approach

New `sidecar/shell-path.ts`, invoked once at the top of the sidecar's `main()` **before** anything that spawns children (agent sessions, MCP servers) is created:

- Runs the user's shell (`$SHELL`, falling back to `/bin/zsh` on darwin / `/bin/bash` elsewhere) as `-ilc` and captures `$PATH`. Both flags matter: `-l` sources `~/.zprofile` (where Homebrew's shellenv lives), `-i` sources `~/.zshrc` (where nvm/pyenv-style version managers typically live). This mirrors what VS Code does (`-ilc`).
- The PATH value is printed between sentinel markers (`__CLINE_SIDECAR_PATH_START__` / `..._END__`) so banners, motd-style output, or anything else a shell profile prints to stdout can't corrupt the captured value.
- Merges into `process.env.PATH`: login-shell entries first (so `/opt/homebrew/bin` wins), then any current-only entries appended (so dirs injected by the launching environment aren't lost), duplicates and empties dropped. Since the bash executor and MCP spawns all build their env from `process.env`, everything downstream inherits the fix.

Failure hardening — a broken shell profile must never brick app startup:

- 5s timeout; hung shells are killed via process group (`kill(-pid)`, spawned detached) so a stuck profile can't leave orphans.
- Any failure (missing shell, timeout, no markers in output) logs a structured result via the sidecar's observability logger and startup proceeds with the original PATH — strictly no worse than today.
- No-op on Windows (GUI PATH comes from the registry there, and the `-ilc` trick is POSIX-only).
- `CLINE_SIDECAR_SKIP_SHELL_PATH=1` escape hatch to disable resolution entirely if someone's profile makes it misbehave.

**Why the sidecar (TS) and not the Rust side?** The canonical Tauri fix is the `fix-path-env` crate in `main.rs`, but: it's a git dependency (not on crates.io), it can't be exercised by this repo's test tooling, and fixing it in the sidecar covers both dev (`bun run sidecar/index.ts`) and packaged-binary modes with one code path. The sidecar is also the process that actually spawns everything that needs PATH — the Tauri shell itself doesn't.

### Test Procedure

- 15 new tests in `sidecar/shell-path.test.ts` (vitest, same setup as the other sidecar tests): marker extraction with profile noise around it, merge ordering/dedupe/empty-entry handling, fake-shell PATH capture (a `#!/bin/sh` stub that ignores `-ilc` and evals the command with a controlled PATH, mimicking a login shell that prepends Homebrew), garbage output → undefined, missing shell binary → undefined, hung shell (`sleep 60`) → killed at timeout without rejecting, Windows + escape-hatch skips, and a real end-to-end run against `/bin/sh`.
- Full sidecar suite passes (39 tests, 6 files), `tsc -p tsconfig.dev.json --noEmit` clean, biome clean.
- **Caveat:** the actual Finder-launch environment can't be reproduced in a Linux dev container, so this deserves one manual check on a real Mac — launch the packaged app from Finder and ask the agent to run `which gh` (or push a PR). Before this change that reports gh missing; after, it should resolve `/opt/homebrew/bin/gh`.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — backend/sidecar change. Repro evidence is in the Linear ticket screenshot (agent reporting `gh` not installed).

### Additional Notes

Only PATH is resolved from the login shell, deliberately — pulling in the full env (API keys, `SSH_AUTH_SOCK`, etc.) has broader behavioral implications and nothing in the ticket needs it. If we later want more env vars (e.g. `SSH_AUTH_SOCK` for git-over-ssh pushes), the marker/timeout machinery here generalizes easily.
