### PR TITLE
fix(desktop): rebuild sessions when switching providers

### DIFF
--- a/apps/examples/desktop-app/sidecar/chat-session.test.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.test.ts
@@ -178,6 +178,9 @@ describe("first-send connection updates", () => {
 				start,
 				stop,
 				updateSessionConnection,
+				pendingPrompts: {
+					list: vi.fn(async () => []),
+				},
 			},
 		} as unknown as SidecarContext;
 		return {
@@ -312,6 +315,50 @@ describe("first-send connection updates", () => {
 		await switching;
 	});
 
+	it.each([
+		"queue",
+		"steer",
+	] as const)("locks provider-switch preparation for explicit %s delivery", async (delivery) => {
+		let resolveMessages:
+			| ((messages: Array<{ role: string; content: string }>) => void)
+			| undefined;
+		const messages = new Promise<Array<{ role: string; content: string }>>(
+			(resolve) => {
+				resolveMessages = resolve;
+			},
+		);
+		const { ctx, readMessages, sessionId } = createContext();
+		readMessages.mockImplementationOnce(async () => await messages);
+
+		const switching = handleChatSessionCommand(ctx, {
+			action: "send",
+			sessionId,
+			prompt: "queue this for Codex",
+			delivery,
+			config: {
+				...baseConfig,
+				provider: "openai-codex",
+				model: "gpt-5.3-codex",
+			},
+		});
+		await vi.waitFor(() => expect(readMessages).toHaveBeenCalledOnce());
+
+		await expect(
+			handleChatSessionCommand(ctx, {
+				action: "send",
+				sessionId,
+				prompt: "racing prompt",
+				config: { ...baseConfig },
+			}),
+		).rejects.toThrow("A provider switch is already in progress");
+
+		resolveMessages?.([
+			{ role: "user", content: "first prompt" },
+			{ role: "assistant", content: "first response" },
+		]);
+		await switching;
+	});
+
 	it("restores the previous provider runtime when replacement startup fails", async () => {
 		const { ctx, send, sessionId, start, stop } = createContext();
 		const previousKanbanDataDir = process.env.CLINE_KANBAN_DATA_DIR;
@@ -360,6 +407,74 @@ describe("first-send connection updates", () => {
 				config: { ...baseConfig },
 			});
 			expect(send).toHaveBeenCalledOnce();
+		} finally {
+			if (previousKanbanDataDir === undefined) {
+				delete process.env.CLINE_KANBAN_DATA_DIR;
+			} else {
+				process.env.CLINE_KANBAN_DATA_DIR = previousKanbanDataDir;
+			}
+			rmSync(testKanbanDataDir, { recursive: true, force: true });
+		}
+	});
+
+	it("restores the previous provider when replacement label sync fails", async () => {
+		const { ctx, send, sessionId, start, stop, updateSessionConnection } =
+			createContext();
+		const previousKanbanDataDir = process.env.CLINE_KANBAN_DATA_DIR;
+		const testKanbanDataDir = join(
+			tmpdir(),
+			`cline-provider-label-rollback-${process.pid}`,
+		);
+		process.env.CLINE_KANBAN_DATA_DIR = testKanbanDataDir;
+		try {
+			updateSessionConnection
+				.mockRejectedValueOnce(new Error("manifest write failed"))
+				.mockResolvedValueOnce(undefined);
+
+			const result = (await handleChatSessionCommand(ctx, {
+				action: "send",
+				sessionId,
+				prompt: "continue with Codex",
+				config: {
+					...baseConfig,
+					provider: "openai-codex",
+					model: "gpt-5.3-codex",
+				},
+			})) as { result?: { finishReason?: string; text?: string } };
+
+			expect(stop).toHaveBeenCalledTimes(2);
+			expect(start).toHaveBeenCalledTimes(2);
+			expect(start.mock.calls[1]?.[0]).toEqual(
+				expect.objectContaining({
+					config: expect.objectContaining({
+						providerId: "cline",
+						modelId: "anthropic/claude-sonnet-4.6",
+						sessionId,
+					}),
+				}),
+			);
+			expect(updateSessionConnection).toHaveBeenNthCalledWith(2, sessionId, {
+				providerId: "cline",
+				modelId: "anthropic/claude-sonnet-4.6",
+				thinking: true,
+				reasoningEffort: "high",
+				thinkingBudgetTokens: null,
+			});
+			expect(send).not.toHaveBeenCalled();
+			expect(result.result).toEqual({
+				finishReason: "error",
+				text: "manifest write failed",
+			});
+			expect(ctx.liveSessions.get(sessionId)?.config).toEqual(baseConfig);
+
+			await handleChatSessionCommand(ctx, {
+				action: "send",
+				sessionId,
+				prompt: "continue with Cline",
+				config: { ...baseConfig },
+			});
+			expect(send).toHaveBeenCalledOnce();
+			expect(start).toHaveBeenCalledTimes(2);
 		} finally {
 			if (previousKanbanDataDir === undefined) {
 				delete process.env.CLINE_KANBAN_DATA_DIR;

--- a/apps/examples/desktop-app/sidecar/chat-session.test.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.test.ts
@@ -3,6 +3,7 @@ import {
 	buildSessionConnectionUpdate,
 	consumeWorkspaceMetadata,
 	handleChatSessionCommand,
+	hasProviderChanged,
 	prewarmWorkspaceMetadata,
 	shouldUpdateSessionConnection,
 	WORKSPACE_METADATA_PREWARM_TTL_MS,
@@ -87,6 +88,23 @@ describe("shouldUpdateSessionConnection", () => {
 	});
 });
 
+describe("hasProviderChanged", () => {
+	it("distinguishes provider switches from model switches", () => {
+		expect(
+			hasProviderChanged(
+				{ provider: "cline", model: "anthropic/claude-sonnet-4.6" },
+				{ provider: "openai-codex", model: "gpt-5.3-codex" },
+			),
+		).toBe(true);
+		expect(
+			hasProviderChanged(
+				{ provider: "cline", model: "anthropic/claude-sonnet-4.6" },
+				{ provider: "cline", model: "openai/gpt-5.3-codex" },
+			),
+		).toBe(false);
+	});
+});
+
 describe("first-send connection updates", () => {
 	const baseConfig = {
 		provider: "cline",
@@ -105,7 +123,14 @@ describe("first-send connection updates", () => {
 			finishReason: "completed",
 			messages: [],
 		}));
+		const readMessages = vi.fn(async () => [
+			{ role: "user", content: "first prompt" },
+			{ role: "assistant", content: "first response" },
+		]);
+		const readSessionCompactionState = vi.fn(async () => undefined);
+		const stop = vi.fn(async () => undefined);
 		const sessionId = "session-connection-test";
+		const start = vi.fn(async () => ({ sessionId }));
 		const ctx = {
 			liveSessions: new Map([
 				[
@@ -121,9 +146,24 @@ describe("first-send connection updates", () => {
 					},
 				],
 			]),
-			sessionManager: { send, updateSessionConnection },
+			sessionManager: {
+				readMessages,
+				readSessionCompactionState,
+				send,
+				start,
+				stop,
+				updateSessionConnection,
+			},
 		} as unknown as SidecarContext;
-		return { ctx, send, sessionId, updateSessionConnection };
+		return {
+			ctx,
+			readMessages,
+			send,
+			sessionId,
+			start,
+			stop,
+			updateSessionConnection,
+		};
 	}
 
 	it("skips an identical update for a locally-created session", async () => {
@@ -154,6 +194,55 @@ describe("first-send connection updates", () => {
 
 		expect(updateSessionConnection).toHaveBeenCalledTimes(1);
 		expect(updateSessionConnection.mock.invocationCallOrder[0]).toBeLessThan(
+			send.mock.invocationCallOrder[0] ?? 0,
+		);
+	});
+
+	it("rebuilds the same session with its transcript before a provider switch", async () => {
+		const {
+			ctx,
+			readMessages,
+			send,
+			sessionId,
+			start,
+			stop,
+			updateSessionConnection,
+		} = createContext();
+
+		await handleChatSessionCommand(ctx, {
+			action: "send",
+			sessionId,
+			prompt: "continue with Codex",
+			config: {
+				...baseConfig,
+				provider: "openai-codex",
+				model: "gpt-5.3-codex",
+			},
+		});
+
+		expect(readMessages).toHaveBeenCalledWith(sessionId);
+		expect(stop).toHaveBeenCalledWith(sessionId);
+		expect(start).toHaveBeenCalledWith(
+			expect.objectContaining({
+				config: expect.objectContaining({
+					providerId: "openai-codex",
+					modelId: "gpt-5.3-codex",
+					sessionId,
+				}),
+				initialMessages: [
+					{ role: "user", content: "first prompt" },
+					{ role: "assistant", content: "first response" },
+				],
+			}),
+		);
+		expect(updateSessionConnection).toHaveBeenCalledWith(sessionId, {
+			providerId: "openai-codex",
+			modelId: "gpt-5.3-codex",
+			thinking: true,
+			reasoningEffort: "high",
+			thinkingBudgetTokens: null,
+		});
+		expect(start.mock.invocationCallOrder[0]).toBeLessThan(
 			send.mock.invocationCallOrder[0] ?? 0,
 		);
 	});

--- a/apps/examples/desktop-app/sidecar/chat-session.test.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.test.ts
@@ -1,9 +1,13 @@
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
 	buildSessionConnectionUpdate,
 	consumeWorkspaceMetadata,
 	handleChatSessionCommand,
 	hasProviderChanged,
+	mergeSessionConfig,
 	prewarmWorkspaceMetadata,
 	shouldUpdateSessionConnection,
 	WORKSPACE_METADATA_PREWARM_TTL_MS,
@@ -103,6 +107,25 @@ describe("hasProviderChanged", () => {
 			),
 		).toBe(false);
 	});
+
+	it("honors a providerId-only update when the stored config uses provider", () => {
+		const current = {
+			provider: "cline",
+			model: "anthropic/claude-sonnet-4.6",
+		};
+		const update = {
+			providerId: "openai-codex",
+			modelId: "gpt-5.3-codex",
+		};
+
+		expect(hasProviderChanged(current, update)).toBe(true);
+		expect(mergeSessionConfig(current, update)).toMatchObject({
+			provider: "openai-codex",
+			providerId: "openai-codex",
+			model: "gpt-5.3-codex",
+			modelId: "gpt-5.3-codex",
+		});
+	});
 });
 
 describe("first-send connection updates", () => {
@@ -130,7 +153,7 @@ describe("first-send connection updates", () => {
 		const readSessionCompactionState = vi.fn(async () => undefined);
 		const stop = vi.fn(async () => undefined);
 		const sessionId = "session-connection-test";
-		const start = vi.fn(async () => ({ sessionId }));
+		const start = vi.fn(async (_input?: unknown) => ({ sessionId }));
 		const ctx = {
 			liveSessions: new Map([
 				[
@@ -146,6 +169,8 @@ describe("first-send connection updates", () => {
 					},
 				],
 			]),
+			streamIndices: new Map(),
+			wsClients: new Set(),
 			sessionManager: {
 				readMessages,
 				readSessionCompactionState,
@@ -245,6 +270,104 @@ describe("first-send connection updates", () => {
 		expect(start.mock.invocationCallOrder[0]).toBeLessThan(
 			send.mock.invocationCallOrder[0] ?? 0,
 		);
+	});
+
+	it("blocks a concurrent send throughout provider-switch preparation", async () => {
+		let resolveMessages:
+			| ((messages: Array<{ role: string; content: string }>) => void)
+			| undefined;
+		const messages = new Promise<Array<{ role: string; content: string }>>(
+			(resolve) => {
+				resolveMessages = resolve;
+			},
+		);
+		const { ctx, readMessages, sessionId } = createContext();
+		readMessages.mockImplementationOnce(async () => await messages);
+
+		const switching = handleChatSessionCommand(ctx, {
+			action: "send",
+			sessionId,
+			prompt: "continue with Codex",
+			config: {
+				...baseConfig,
+				provider: "openai-codex",
+				model: "gpt-5.3-codex",
+			},
+		});
+		await vi.waitFor(() => expect(readMessages).toHaveBeenCalledOnce());
+
+		await expect(
+			handleChatSessionCommand(ctx, {
+				action: "send",
+				sessionId,
+				prompt: "racing prompt",
+				config: { ...baseConfig },
+			}),
+		).rejects.toThrow("A provider switch is already in progress");
+
+		resolveMessages?.([
+			{ role: "user", content: "first prompt" },
+			{ role: "assistant", content: "first response" },
+		]);
+		await switching;
+	});
+
+	it("restores the previous provider runtime when replacement startup fails", async () => {
+		const { ctx, send, sessionId, start, stop } = createContext();
+		const previousKanbanDataDir = process.env.CLINE_KANBAN_DATA_DIR;
+		const testKanbanDataDir = join(
+			tmpdir(),
+			`cline-provider-rollback-${process.pid}`,
+		);
+		process.env.CLINE_KANBAN_DATA_DIR = testKanbanDataDir;
+		start
+			.mockRejectedValueOnce(new Error("Codex bootstrap failed"))
+			.mockResolvedValueOnce({ sessionId });
+
+		try {
+			const result = (await handleChatSessionCommand(ctx, {
+				action: "send",
+				sessionId,
+				prompt: "continue with Codex",
+				config: {
+					...baseConfig,
+					provider: "openai-codex",
+					model: "gpt-5.3-codex",
+				},
+			})) as { result?: { finishReason?: string; text?: string } };
+
+			expect(stop).toHaveBeenCalledOnce();
+			expect(start).toHaveBeenCalledTimes(2);
+			expect(start.mock.calls[1]?.[0]).toEqual(
+				expect.objectContaining({
+					config: expect.objectContaining({
+						providerId: "cline",
+						modelId: "anthropic/claude-sonnet-4.6",
+						sessionId,
+					}),
+				}),
+			);
+			expect(send).not.toHaveBeenCalled();
+			expect(result.result).toEqual({
+				finishReason: "error",
+				text: "Codex bootstrap failed",
+			});
+
+			await handleChatSessionCommand(ctx, {
+				action: "send",
+				sessionId,
+				prompt: "continue with Cline",
+				config: { ...baseConfig },
+			});
+			expect(send).toHaveBeenCalledOnce();
+		} finally {
+			if (previousKanbanDataDir === undefined) {
+				delete process.env.CLINE_KANBAN_DATA_DIR;
+			} else {
+				process.env.CLINE_KANBAN_DATA_DIR = previousKanbanDataDir;
+			}
+			rmSync(testKanbanDataDir, { recursive: true, force: true });
+		}
 	});
 
 	it("refreshes hub-attached sessions even when the cached config matches", async () => {

--- a/apps/examples/desktop-app/sidecar/chat-session.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.ts
@@ -628,6 +628,7 @@ async function rebuildSessionForProviderChange(
 		]);
 
 	await manager.stop(sessionId);
+	let replacementStarted = false;
 	try {
 		await startRebuiltSession(
 			manager,
@@ -637,8 +638,19 @@ async function rebuildSessionForProviderChange(
 			messages,
 			compactionState,
 		);
+		replacementStarted = true;
+		// Reusing a session id preserves its existing manifest. Treat refreshing
+		// its connection label as part of the replacement transaction so a
+		// persistence failure cannot leave runtime and cached state diverged.
+		await manager.updateSessionConnection(
+			sessionId,
+			buildSessionConnectionUpdate(nextConfig),
+		);
 	} catch (replacementError) {
 		try {
+			if (replacementStarted) {
+				await manager.stop(sessionId);
+			}
 			await startRebuiltSession(
 				manager,
 				sessionId,
@@ -659,13 +671,6 @@ async function rebuildSessionForProviderChange(
 		}
 		throw replacementError;
 	}
-
-	// Reusing a session id preserves its existing manifest. Refresh the
-	// connection label after the rebuilt runtime is live.
-	await manager.updateSessionConnection(
-		sessionId,
-		buildSessionConnectionUpdate(nextConfig),
-	);
 }
 
 async function handleSend(
@@ -699,11 +704,15 @@ async function handleSend(
 	const ownsBusyState = Boolean(
 		session && delivery !== "queue" && delivery !== "steer",
 	);
-	if (session && ownsBusyState) {
-		session.prompt = prompt;
-		session.busy = true;
-		session.status = "running";
-		session.transitioningProvider = providerChanged;
+	if (session) {
+		if (ownsBusyState) {
+			session.prompt = prompt;
+			session.busy = true;
+			session.status = "running";
+		}
+		if (providerChanged) {
+			session.transitioningProvider = true;
+		}
 	}
 	try {
 		if (request.config && nextConfig) {
@@ -809,9 +818,13 @@ async function handleSend(
 			},
 		};
 	} finally {
-		if (session && ownsBusyState) {
-			session.busy = false;
-			session.transitioningProvider = false;
+		if (session) {
+			if (ownsBusyState) {
+				session.busy = false;
+			}
+			if (providerChanged) {
+				session.transitioningProvider = false;
+			}
 		}
 	}
 }

--- a/apps/examples/desktop-app/sidecar/chat-session.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.ts
@@ -8,6 +8,7 @@ import {
 	type CoreSessionConfig,
 	createSessionCompactionState,
 	projectSessionCompactionState,
+	type SessionCompactionState,
 	type SessionPendingPrompt,
 	SessionSource,
 	splitCoreSessionConfig,
@@ -298,13 +299,52 @@ export function shouldUpdateSessionConnection(
 	);
 }
 
+function readAliasedString(
+	config: JsonRecord,
+	primaryKey: string,
+	aliasKey: string,
+): string | undefined {
+	for (const key of [primaryKey, aliasKey]) {
+		if (!Object.hasOwn(config, key)) continue;
+		const value = String(config[key] ?? "").trim();
+		return value || undefined;
+	}
+	return undefined;
+}
+
+export function mergeSessionConfig(
+	currentConfig: JsonRecord,
+	updates: JsonRecord,
+): JsonRecord {
+	const providerId =
+		readAliasedString(updates, "provider", "providerId") ??
+		readAliasedString(currentConfig, "provider", "providerId");
+	const modelId =
+		readAliasedString(updates, "model", "modelId") ??
+		readAliasedString(currentConfig, "model", "modelId");
+	return {
+		...currentConfig,
+		...updates,
+		...(providerId ? { provider: providerId, providerId } : {}),
+		...(modelId ? { model: modelId, modelId } : {}),
+	};
+}
+
 export function hasProviderChanged(
 	currentConfig: JsonRecord,
 	nextConfig: JsonRecord,
 ): boolean {
-	const readProviderId = (config: JsonRecord) =>
-		String(config.provider ?? config.providerId ?? "").trim();
-	return readProviderId(currentConfig) !== readProviderId(nextConfig);
+	const currentProviderId = readAliasedString(
+		currentConfig,
+		"provider",
+		"providerId",
+	);
+	const nextProviderId = readAliasedString(
+		nextConfig,
+		"provider",
+		"providerId",
+	);
+	return nextProviderId !== undefined && currentProviderId !== nextProviderId;
 }
 
 async function resolveSystemPrompt(config: JsonRecord): Promise<string> {
@@ -525,6 +565,109 @@ async function handleAttach(
 	};
 }
 
+async function startRebuiltSession(
+	manager: ClineCore,
+	sessionId: string,
+	config: JsonRecord,
+	systemPrompt: string,
+	messages: Message[],
+	compactionState: SessionCompactionState | undefined,
+): Promise<void> {
+	const projectedMessages = compactionState
+		? projectSessionCompactionState(compactionState, messages)
+		: undefined;
+	const restarted = await manager.start({
+		...splitCoreSessionConfig(
+			buildCoreSessionConfig({
+				...config,
+				sessionId,
+				systemPrompt,
+			}) as unknown as CoreSessionConfig,
+		),
+		source: SessionSource.DESKTOP,
+		interactive: true,
+		initialMessages: messages,
+		...(projectedMessages
+			? {
+					initialCompactionState: createSessionCompactionState({
+						sourceMessages: messages,
+						compactedMessages: projectedMessages,
+						systemPrompt: compactionState?.system_prompt,
+					}),
+				}
+			: {}),
+		toolPolicies: resolveToolPolicies(config),
+	});
+	if (restarted.sessionId !== sessionId) {
+		throw new Error(
+			`Provider switch changed session id from ${sessionId} to ${restarted.sessionId}`,
+		);
+	}
+}
+
+async function rebuildSessionForProviderChange(
+	ctx: SidecarContext,
+	manager: ClineCore,
+	sessionId: string,
+	previousConfig: JsonRecord,
+	nextConfig: JsonRecord,
+): Promise<void> {
+	const [messages, compactionState, previousSystemPrompt, nextSystemPrompt] =
+		await Promise.all([
+			manager.readMessages(sessionId),
+			manager.readSessionCompactionState(sessionId).catch((error) => {
+				ctx.logger?.log?.("Failed to read desktop session compaction state", {
+					sessionId,
+					error,
+					severity: "warn",
+				});
+				return undefined;
+			}),
+			resolveSystemPrompt(previousConfig),
+			resolveSystemPrompt(nextConfig),
+		]);
+
+	await manager.stop(sessionId);
+	try {
+		await startRebuiltSession(
+			manager,
+			sessionId,
+			nextConfig,
+			nextSystemPrompt,
+			messages,
+			compactionState,
+		);
+	} catch (replacementError) {
+		try {
+			await startRebuiltSession(
+				manager,
+				sessionId,
+				previousConfig,
+				previousSystemPrompt,
+				messages,
+				compactionState,
+			);
+			await manager.updateSessionConnection(
+				sessionId,
+				buildSessionConnectionUpdate(previousConfig),
+			);
+		} catch (rollbackError) {
+			throw new AggregateError(
+				[replacementError, rollbackError],
+				"Provider switch and rollback both failed",
+			);
+		}
+		throw replacementError;
+	}
+
+	// Reusing a session id preserves its existing manifest. Refresh the
+	// connection label after the rebuilt runtime is live.
+	await manager.updateSessionConnection(
+		sessionId,
+		buildSessionConnectionUpdate(nextConfig),
+	);
+}
+
 async function handleSend(
 	ctx: SidecarContext,
 	request: ChatSessionCommandRequest,
@@ -535,119 +678,80 @@ async function handleSend(
 	if (!prompt) throw new Error("prompt is required");
 	const manager = getSessionManager(ctx);
 	const session = ctx.liveSessions.get(sessionId);
-	if (request.config) {
-		const nextConfig = session
-			? { ...session.config, ...request.config, sessionId }
-			: request.config;
-		const providerChanged = Boolean(
-			session && hasProviderChanged(session.config, nextConfig),
-		);
-		if (providerChanged) {
-			if (session?.busy) {
-				throw new Error("Cannot switch providers while a turn is running");
-			}
-			const [messages, compactionState] = await Promise.all([
-				manager.readMessages(sessionId),
-				manager.readSessionCompactionState(sessionId).catch((error) => {
-					ctx.logger?.log?.("Failed to read desktop session compaction state", {
-						sessionId,
-						error,
-						severity: "warn",
-					});
-					return undefined;
-				}),
-			]);
-			const projectedMessages = compactionState
-				? projectSessionCompactionState(compactionState, messages)
-				: undefined;
-			const systemPrompt = await resolveSystemPrompt(nextConfig);
-			await manager.stop(sessionId);
-			const restarted = await manager.start({
-				...splitCoreSessionConfig(
-					buildCoreSessionConfig({
-						...nextConfig,
-						systemPrompt,
-					}) as unknown as CoreSessionConfig,
-				),
-				source: SessionSource.DESKTOP,
-				interactive: true,
-				initialMessages: messages,
-				...(projectedMessages
-					? {
-							initialCompactionState: createSessionCompactionState({
-								sourceMessages: messages,
-								compactedMessages: projectedMessages,
-								systemPrompt: compactionState?.system_prompt,
-							}),
-						}
-					: {}),
-				toolPolicies: resolveToolPolicies(nextConfig),
-			});
-			if (restarted.sessionId !== sessionId) {
-				throw new Error(
-					`Provider switch changed session id from ${sessionId} to ${restarted.sessionId}`,
-				);
-			}
-			// Reusing a session id preserves its existing manifest. Refresh the
-			// connection label after the rebuilt runtime is live.
-			await manager.updateSessionConnection(
-				sessionId,
-				buildSessionConnectionUpdate(nextConfig),
-			);
-		} else if (
-			!session ||
-			session.attachedViaHub ||
-			shouldUpdateSessionConnection(session.config, nextConfig)
-		) {
-			await manager.updateSessionConnection(
-				sessionId,
-				buildSessionConnectionUpdate(nextConfig),
-			);
-		}
-		if (session) {
-			session.config = nextConfig;
-			if (providerChanged) {
-				session.attachedViaHub = false;
-			}
-		}
+	if (session?.transitioningProvider) {
+		throw new Error("A provider switch is already in progress");
 	}
-
-	// Determine effective delivery mode.
-	// When the session is busy and no explicit delivery was requested, queue it
-	// via Core so that Core's own pending-prompts mechanism handles draining.
-	// This avoids a sidecar-only local queue that never calls manager.send().
 	let delivery = request.delivery;
 	if (!delivery && session?.busy) {
 		delivery = "queue";
 	}
-
-	if (delivery === "queue") {
-		if (session) {
-			session.prompt = prompt;
-		}
-		// Delegate queuing to Core — it will drain the prompt once the current
-		// turn finishes and emit pending_prompts / pending_prompt_submitted events.
-		await manager.send({
-			sessionId,
-			prompt,
-			delivery: "queue",
-			userImages: request.attachments?.userImages,
-		});
-		const prompts = await manager.pendingPrompts.list({ sessionId });
-		return {
-			sessionId,
-			ok: true,
-			queued: true,
-			promptsInQueue: applyPendingPrompts(ctx, sessionId, prompts),
-		};
+	const nextConfig = request.config
+		? mergeSessionConfig(session?.config ?? {}, request.config)
+		: undefined;
+	const providerChanged = Boolean(
+		session &&
+			request.config &&
+			hasProviderChanged(session.config, request.config),
+	);
+	if (providerChanged && session?.busy) {
+		throw new Error("Cannot switch providers while a turn is running");
 	}
-
-	if (session) {
+	const ownsBusyState = Boolean(
+		session && delivery !== "queue" && delivery !== "steer",
+	);
+	if (session && ownsBusyState) {
 		session.prompt = prompt;
 		session.busy = true;
 		session.status = "running";
+		session.transitioningProvider = providerChanged;
 	}
 	try {
+		if (request.config && nextConfig) {
+			if (providerChanged && session) {
+				await rebuildSessionForProviderChange(
+					ctx,
+					manager,
+					sessionId,
+					session.config,
+					nextConfig,
+				);
+			} else if (
+				!session ||
+				session.attachedViaHub ||
+				shouldUpdateSessionConnection(session.config, nextConfig)
+			) {
+				await manager.updateSessionConnection(
+					sessionId,
+					buildSessionConnectionUpdate(nextConfig),
+				);
+			}
+			if (session) {
+				session.config = nextConfig;
+				if (providerChanged) {
+					session.attachedViaHub = false;
+				}
+			}
+		}
+
+		if (delivery === "queue") {
+			if (session) {
+				session.prompt = prompt;
+			}
+			await manager.send({
+				sessionId,
+				prompt,
+				delivery: "queue",
+				userImages: request.attachments?.userImages,
+			});
+			const prompts = await manager.pendingPrompts.list({ sessionId });
+			return {
+				sessionId,
+				ok: true,
+				queued: true,
+				promptsInQueue: applyPendingPrompts(ctx, sessionId, prompts),
+			};
+		}
+
 		ctx.logger?.debug("Sending desktop chat prompt", {
 			sessionId,
 			promptLength: prompt.length,
@@ -664,8 +768,7 @@ async function handleSend(
 			finishReason: result?.finishReason,
 			textLength: result?.text?.length ?? 0,
 		});
-		if (session) {
-			session.busy = false;
+		if (session && ownsBusyState) {
 			session.status = "idle";
 			if (result?.messages) session.messages = result.messages as unknown[];
 		}
@@ -685,8 +788,7 @@ async function handleSend(
 		};
 	} catch (error) {
 		ctx.logger?.error?.("Desktop chat prompt failed", { sessionId, error });
-		if (session) {
-			session.busy = false;
+		if (session && ownsBusyState) {
 			session.status = "error";
 		}
 		emitChunk(
@@ -706,6 +808,11 @@ async function handleSend(
 				text: error instanceof Error ? error.message : String(error),
 			},
 		};
+	} finally {
+		if (session && ownsBusyState) {
+			session.busy = false;
+			session.transitioningProvider = false;
+		}
 	}
 }
 

--- a/apps/examples/desktop-app/sidecar/chat-session.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.ts
@@ -6,6 +6,8 @@ import {
 	buildWorkspaceMetadata,
 	type ClineCore,
 	type CoreSessionConfig,
+	createSessionCompactionState,
+	projectSessionCompactionState,
 	type SessionPendingPrompt,
 	SessionSource,
 	splitCoreSessionConfig,
@@ -212,6 +214,9 @@ function buildCoreSessionConfig(config: JsonRecord): JsonRecord {
 		modelId: config.model ?? config.modelId ?? "",
 		mode: config.mode ?? "act",
 		apiKey: config.apiKey ?? config.api_key ?? "",
+		baseUrl: config.baseUrl,
+		headers: config.headers,
+		providerConfig: config.providerConfig,
 		workspaceRoot: config.workspaceRoot ?? config.workspace_root ?? "",
 		cwd: config.cwd ?? config.workspaceRoot ?? config.workspace_root ?? "",
 		systemPrompt: config.systemPrompt ?? config.system_prompt ?? "",
@@ -291,6 +296,15 @@ export function shouldUpdateSessionConnection(
 		buildSessionConnectionUpdate(currentConfig),
 		buildSessionConnectionUpdate(nextConfig),
 	);
+}
+
+export function hasProviderChanged(
+	currentConfig: JsonRecord,
+	nextConfig: JsonRecord,
+): boolean {
+	const readProviderId = (config: JsonRecord) =>
+		String(config.provider ?? config.providerId ?? "").trim();
+	return readProviderId(currentConfig) !== readProviderId(nextConfig);
 }
 
 async function resolveSystemPrompt(config: JsonRecord): Promise<string> {
@@ -522,16 +536,79 @@ async function handleSend(
 	const manager = getSessionManager(ctx);
 	const session = ctx.liveSessions.get(sessionId);
 	if (request.config) {
-		if (
+		const nextConfig = session
+			? { ...session.config, ...request.config, sessionId }
+			: request.config;
+		const providerChanged = Boolean(
+			session && hasProviderChanged(session.config, nextConfig),
+		);
+		if (providerChanged) {
+			if (session?.busy) {
+				throw new Error("Cannot switch providers while a turn is running");
+			}
+			const [messages, compactionState] = await Promise.all([
+				manager.readMessages(sessionId),
+				manager.readSessionCompactionState(sessionId).catch((error) => {
+					ctx.logger?.log?.("Failed to read desktop session compaction state", {
+						sessionId,
+						error,
+						severity: "warn",
+					});
+					return undefined;
+				}),
+			]);
+			const projectedMessages = compactionState
+				? projectSessionCompactionState(compactionState, messages)
+				: undefined;
+			const systemPrompt = await resolveSystemPrompt(nextConfig);
+			await manager.stop(sessionId);
+			const restarted = await manager.start({
+				...splitCoreSessionConfig(
+					buildCoreSessionConfig({
+						...nextConfig,
+						systemPrompt,
+					}) as unknown as CoreSessionConfig,
+				),
+				source: SessionSource.DESKTOP,
+				interactive: true,
+				initialMessages: messages,
+				...(projectedMessages
+					? {
+							initialCompactionState: createSessionCompactionState({
+								sourceMessages: messages,
+								compactedMessages: projectedMessages,
+								systemPrompt: compactionState?.system_prompt,
+							}),
+						}
+					: {}),
+				toolPolicies: resolveToolPolicies(nextConfig),
+			});
+			if (restarted.sessionId !== sessionId) {
+				throw new Error(
+					`Provider switch changed session id from ${sessionId} to ${restarted.sessionId}`,
+				);
+			}
+			// Reusing a session id preserves its existing manifest. Refresh the
+			// connection label after the rebuilt runtime is live.
+			await manager.updateSessionConnection(
+				sessionId,
+				buildSessionConnectionUpdate(nextConfig),
+			);
+		} else if (
 			!session ||
 			session.attachedViaHub ||
-			shouldUpdateSessionConnection(session.config, request.config)
+			shouldUpdateSessionConnection(session.config, nextConfig)
 		) {
-			const connectionUpdate = buildSessionConnectionUpdate(request.config);
-			await manager.updateSessionConnection(sessionId, connectionUpdate);
+			await manager.updateSessionConnection(
+				sessionId,
+				buildSessionConnectionUpdate(nextConfig),
+			);
 		}
 		if (session) {
-			session.config = { ...session.config, ...request.config };
+			session.config = nextConfig;
+			if (providerChanged) {
+				session.attachedViaHub = false;
+			}
 		}
 	}
 

--- a/apps/examples/desktop-app/sidecar/types.ts
+++ b/apps/examples/desktop-app/sidecar/types.ts
@@ -53,6 +53,7 @@ export type LiveSession = {
 	startedAt: number;
 	endedAt?: number;
 	status: string;
+	transitioningProvider?: boolean;
 	prompt?: string;
 	title?: string;
 	attachedViaHub?: boolean;


### PR DESCRIPTION

<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:**  https://linear.app/cline-bot/issue/CLINE-2741

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Recreate active sessions with their existing transcript and compaction state before sending to a different provider. Preserve provider-specific connection settings and distinguish provider changes from model-only updates.

Add coverage to verify provider switches rebuild the session before sending.

Currently SendSessionInput has no provider/model configuration, so the desktop client must perform that lifecycle transition before sending. The cleaner long-term API would make provider selection part of an atomic turn request—something like send({ sessionId, prompt, providerId, modelId })—and let Core decide whether rebootstrap is necessary.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

1. Start new session in Desktop app with Cline provider
2. submit a prompt
3. wait for response
4. Switch provider to Codex 
5. Submit a prompt
6. Verify you are getting response back after the switch

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
