### PR TITLE
feat(desktop): env override for update re-check interval

### DIFF
--- a/apps/examples/desktop-app/README.md
+++ b/apps/examples/desktop-app/README.md
@@ -33,7 +33,9 @@ secrets) lives in the `publish-desktop` skill
 (`.cline/skills/publish-desktop/SKILL.md`).
 
 Installed apps auto-update via the Tauri updater: they poll the rolling
-`desktop-latest` release's `latest.json` on launch and every 2 hours, install
+`desktop-latest` release's `latest.json` on launch and every 2 hours
+(`CLINE_CODE_UPDATE_INTERVAL_SECS` overrides the re-check cadence for testing;
+it only takes effect when the app binary is launched from a shell), install
 updates in the background, and prompt for a restart. Two things must never be
 lost: the `desktop-latest` release/tag (its feed URL is baked into shipped
 apps) and the updater private key (`TAURI_SIGNING_PRIVATE_KEY` — without it,

--- a/apps/examples/desktop-app/src-tauri/src/main.rs
+++ b/apps/examples/desktop-app/src-tauri/src/main.rs
@@ -14,6 +14,18 @@ use tauri_plugin_updater::UpdaterExt;
 const UPDATE_INITIAL_DELAY: Duration = Duration::from_secs(10);
 const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(2 * 60 * 60);
 
+// Test override for the periodic re-check cadence (the launch check always
+// runs after UPDATE_INITIAL_DELAY regardless). Only read when launched from a
+// shell, e.g.: CLINE_CODE_UPDATE_INTERVAL_SECS=300 ".../Cline Code.app/Contents/MacOS/cline-app"
+fn update_check_interval() -> Duration {
+    std::env::var("CLINE_CODE_UPDATE_INTERVAL_SECS")
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .filter(|secs| *secs > 0)
+        .map(Duration::from_secs)
+        .unwrap_or(UPDATE_CHECK_INTERVAL)
+}
+
 #[derive(Clone)]
 struct AppContext {
     launch_cwd: String,
@@ -115,10 +127,11 @@ async fn check_and_install_update(app: &tauri::AppHandle, state: &UpdateState) {
 }
 
 async fn run_update_loop(app: tauri::AppHandle, state: Arc<UpdateState>) {
+    let interval = update_check_interval();
     tokio::time::sleep(UPDATE_INITIAL_DELAY).await;
     loop {
         check_and_install_update(&app, &state).await;
-        tokio::time::sleep(UPDATE_CHECK_INTERVAL).await;
+        tokio::time::sleep(interval).await;
     }
 }
 


### PR DESCRIPTION
### Related Issue

Follow-up to #12420 (merged) — testing aid requested while validating the auto-update loop.

### Description

Adds a `CLINE_CODE_UPDATE_INTERVAL_SECS` env override for the updater's periodic re-check cadence, so a long-running instance can be tested against a fresh release without waiting out the 2-hour production default (e.g. `CLINE_CODE_UPDATE_INTERVAL_SECS=300` for 5-minute checks).

Notes:

- The launch-time check (~10s after start) is unaffected and already covers most testing — quit/reopen forces an immediate check. This override only matters for "app left open" scenarios.
- The env var must reach the process, so it only works when the app binary is launched from a shell: `CLINE_CODE_UPDATE_INTERVAL_SECS=300 "/Applications/Cline Code.app/Contents/MacOS/cline-app"`. Launching via Finder/`open` uses the default.
- Invalid or non-positive values fall back to the 2h default; production behavior is unchanged when the var is unset.

### Test Procedure

- Rust-side change is a small env parse + constant substitution; verified by inspection (no mac toolchain in this sandbox — compile is covered by the desktop build).
- README note updated in the Releases & Auto-Updates section.
