### PR TITLE
polish(ui): reasoning trigger reads just 'Thinking'

### DIFF
--- a/sdk/packages/ui/components/agent-chat/agent-chat.css
+++ b/sdk/packages/ui/components/agent-chat/agent-chat.css
@@ -216,12 +216,6 @@
 		color: var(--foreground);
 	}
 
-	.cline-chat-reasoning-status {
-		color: var(--muted-foreground);
-		font-size: var(--text-xs);
-		font-weight: var(--font-weight-normal);
-	}
-
 	.cline-chat-disclosure-icon {
 		flex: 0 0 auto;
 		transition: transform 150ms ease;

--- a/sdk/packages/ui/components/agent-chat/index.tsx
+++ b/sdk/packages/ui/components/agent-chat/index.tsx
@@ -495,7 +495,7 @@ export type ReasoningTriggerProps = Omit<
 export const ReasoningTrigger = ({
 	children,
 	className,
-	completeLabel = "Thought process",
+	completeLabel = "Thinking",
 	onClick,
 	streamingLabel = "Thinking",
 	...props
@@ -515,11 +515,7 @@ export const ReasoningTrigger = ({
 		>
 			{children ?? (
 				<>
-					<BrainIcon />
 					<span>{isStreaming ? streamingLabel : completeLabel}</span>
-					<span aria-live="polite" className="cline-chat-reasoning-status">
-						{isStreaming ? "In progress" : "Complete"}
-					</span>
 					<ChevronDownIcon className="cline-chat-disclosure-icon" />
 				</>
 			)}
@@ -750,26 +746,6 @@ function ChevronDownIcon({ className }: { className?: string }) {
 				strokeLinecap="round"
 				strokeLinejoin="round"
 				strokeWidth="2"
-			/>
-		</svg>
-	);
-}
-
-function BrainIcon() {
-	return (
-		<svg
-			aria-hidden="true"
-			fill="none"
-			height="16"
-			viewBox="0 0 24 24"
-			width="16"
-		>
-			<path
-				d="M9.5 4.5A3 3 0 0 0 4 6a3 3 0 0 0 .5 5.9A3.5 3.5 0 0 0 8 17h1.5m5-12.5A3 3 0 0 1 20 6a3 3 0 0 1-.5 5.9A3.5 3.5 0 0 1 16 17h-1.5M9.5 4.5V20m5-15.5V20M9.5 9H7m7.5 3H17m-7.5 4H7m7.5 1h2"
-				stroke="currentColor"
-				strokeLinecap="round"
-				strokeLinejoin="round"
-				strokeWidth="1.75"
 			/>
 		</svg>
 	);


### PR DESCRIPTION
### Related Issue

PM copy feedback while testing the desktop app (also the vehicle for the first end-to-end auto-update test: v0.0.2 → v0.0.3).

### Description

The collapsed reasoning block header in the chat transcript read `🧠 Thought process · Complete` (or `· In progress` while streaming). Feedback: the status text and brain icon are noise. It now renders as just `Thinking ⌄` in both states.

Changed in the shared `@cline/ui` `agent-chat` component, so the hub and vscode-example webviews (which render the same trigger) pick up the same cleanup. No callers passed `completeLabel`/`streamingLabel` or referenced the removed `cline-chat-reasoning-status` class, so this is copy + dead-code removal only. The props remain for per-surface overrides.

Note: the removed status span had `aria-live="polite"`; state changes are still conveyed via `aria-expanded` on the trigger button, and the label no longer changes between states so there's nothing left to announce.

### Test Procedure

- `bun -F @cline/ui build` — theme contract valid
- `bun -F @cline/code typecheck` — clean
- Desktop chat suite (`test:chat-ui`) — 13 passed
- Biome clean
