### PR TITLE
Improve CLI resilience for long-running agent workflows

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -50,7 +50,6 @@
 	],
 	"scripts": {
 		"build": "bun run bun.mts",
-		"build:tgz": "bun script/build.ts --single && cd dist/cli-linux-x64 && bun pm pack --destination ..",
 		"build:platforms": "bun script/build.ts --install-native-variants",
 		"build:platforms:single": "bun script/build.ts --single",
 		"prepack": "bun script/guard-direct-publish.ts",

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -50,6 +50,7 @@
 	],
 	"scripts": {
 		"build": "bun run bun.mts",
+		"build:tgz": "bun script/build.ts --single && cd dist/cli-linux-x64 && bun pm pack --destination ..",
 		"build:platforms": "bun script/build.ts --install-native-variants",
 		"build:platforms:single": "bun script/build.ts --single",
 		"prepack": "bun script/guard-direct-publish.ts",

--- a/apps/cli/src/commands/program.ts
+++ b/apps/cli/src/commands/program.ts
@@ -33,7 +33,7 @@ export function addRootOptions(cmd: Command): Command {
 			.option("-c, --cwd <path>", "Working directory")
 			.option(
 				"--thinking <level>",
-				"Set reasoning effort: none|low|medium|high|xhigh. Bare --thinking uses medium; omitted leaves provider default.",
+				"Set reasoning effort: none|minimal|low|medium|high|xhigh|max. Bare --thinking uses medium; omitted leaves provider default.",
 			)
 			.option("--compaction <mode>", CLI_COMPACTION_MODE_OPTION_DESCRIPTION)
 			.option(
@@ -177,10 +177,12 @@ export function commanderToParsedArgs(program: Command): ParsedArgs {
 		const effort = String(opts.thinking).trim().toLowerCase();
 		if (
 			effort === "none" ||
+			effort === "minimal" ||
 			effort === "low" ||
 			effort === "medium" ||
 			effort === "high" ||
-			effort === "xhigh"
+			effort === "xhigh" ||
+			effort === "max"
 		) {
 			result.thinkingExplicitlySet = true;
 			if (effort === "none") {

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -802,7 +802,7 @@ export async function runCli(): Promise<void> {
 
 	if (args.invalidThinkingLevel) {
 		writeErr(
-			`invalid thinking level "${args.invalidThinkingLevel}" (expected "none", "low", "medium", "high", or "xhigh")`,
+			`invalid thinking level "${args.invalidThinkingLevel}" (expected "none", "minimal", "low", "medium", "high", "xhigh", or "max")`,
 		);
 		process.exitCode = 1;
 		return;

--- a/apps/cli/src/tui/components/model-selector/model-selector.tsx
+++ b/apps/cli/src/tui/components/model-selector/model-selector.tsx
@@ -310,15 +310,24 @@ export function ModelSelectorContent(
 
 // -- Thinking level dialog content --
 
-export type ThinkingLevel = "none" | "low" | "medium" | "high" | "xhigh";
+export type ThinkingLevel =
+	| "none"
+	| "minimal"
+	| "low"
+	| "medium"
+	| "high"
+	| "xhigh"
+	| "max";
 
 const THINKING_LEVELS: { value: ThinkingLevel; label: string; desc: string }[] =
 	[
 		{ value: "none", label: "Off", desc: "No extended thinking" },
-		{ value: "low", label: "Low", desc: "Minimal reasoning" },
+		{ value: "minimal", label: "Minimal", desc: "Minimal reasoning" },
+		{ value: "low", label: "Low", desc: "Light reasoning" },
 		{ value: "medium", label: "Medium", desc: "Balanced reasoning" },
 		{ value: "high", label: "High", desc: "Deep reasoning" },
-		{ value: "xhigh", label: "Extra High", desc: "Maximum reasoning" },
+		{ value: "xhigh", label: "Extra High", desc: "Very deep reasoning" },
+		{ value: "max", label: "Maximum", desc: "Maximum reasoning" },
 	];
 
 export function ThinkingLevelContent(

--- a/apps/cli/src/tui/views/onboarding/model.ts
+++ b/apps/cli/src/tui/views/onboarding/model.ts
@@ -15,7 +15,14 @@ export type OnboardingStep =
 	| "thinking_level"
 	| "done";
 
-export type ThinkingLevel = "none" | "low" | "medium" | "high" | "xhigh";
+export type ThinkingLevel =
+	| "none"
+	| "minimal"
+	| "low"
+	| "medium"
+	| "high"
+	| "xhigh"
+	| "max";
 export type ReasoningEffort = Exclude<ThinkingLevel, "none">;
 
 export const THINKING_LEVELS: {
@@ -24,10 +31,12 @@ export const THINKING_LEVELS: {
 	desc: string;
 }[] = [
 	{ value: "none", label: "Off", desc: "No extended thinking" },
-	{ value: "low", label: "Low", desc: "Minimal reasoning" },
+	{ value: "minimal", label: "Minimal", desc: "Minimal reasoning" },
+	{ value: "low", label: "Low", desc: "Light reasoning" },
 	{ value: "medium", label: "Medium", desc: "Balanced reasoning" },
 	{ value: "high", label: "High", desc: "Deep reasoning" },
-	{ value: "xhigh", label: "Extra High", desc: "Maximum reasoning" },
+	{ value: "xhigh", label: "Extra High", desc: "Very deep reasoning" },
+	{ value: "max", label: "Maximum", desc: "Maximum reasoning" },
 ];
 
 export const DEFAULT_THINKING_LEVEL_INDEX = THINKING_LEVELS.findIndex(

--- a/apps/cli/src/utils/helpers.test.ts
+++ b/apps/cli/src/utils/helpers.test.ts
@@ -170,6 +170,16 @@ describe("parseArgs", () => {
 		expect(parsed.reasoningEffort).toBe("high");
 	});
 
+	it.each([
+		"minimal",
+		"xhigh",
+		"max",
+	] as const)("preserves the %s reasoning level", (effort) => {
+		const parsed = parseArgs(["--thinking", effort]);
+		expect(parsed.thinking).toBe(true);
+		expect(parsed.reasoningEffort).toBe(effort);
+	});
+
 	it("parses --thinking none as disabled", () => {
 		const parsed = parseArgs(["--thinking", "none"]);
 		expect(parsed.thinking).toBe(false);

--- a/apps/cli/src/utils/reasoning.test.ts
+++ b/apps/cli/src/utils/reasoning.test.ts
@@ -75,6 +75,18 @@ describe("resolveCliReasoning", () => {
 		});
 	});
 
+	it("preserves persisted maximum effort", () => {
+		expect(
+			resolveCliReasoning({
+				thinking: false,
+				persistedReasoning: { enabled: true, effort: "max" },
+			}),
+		).toEqual({
+			thinking: true,
+			reasoningEffort: "max",
+		});
+	});
+
 	it("uses medium effort when persisted reasoning is enabled without an effort", () => {
 		expect(
 			resolveCliReasoning({

--- a/apps/cli/src/utils/reasoning.ts
+++ b/apps/cli/src/utils/reasoning.ts
@@ -4,10 +4,12 @@ import type { CliReasoningEffort } from "./types";
 type ActiveCliReasoningEffort = Exclude<CliReasoningEffort, "none">;
 
 const ACTIVE_REASONING_EFFORTS = new Set<ActiveCliReasoningEffort>([
+	"minimal",
 	"low",
 	"medium",
 	"high",
 	"xhigh",
+	"max",
 ]);
 
 export interface ResolveCliReasoningInput {

--- a/sdk/packages/core/src/extensions/tools/definitions.test.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.test.ts
@@ -571,6 +571,14 @@ describe("default run_commands tool", () => {
 			.filter((event) => event.event === "sdk.tool_timeout");
 	}
 
+	it("warns against broad process matching that can kill the harness", () => {
+		const tool = createShellTool(async () => "ok");
+
+		expect(tool.description).toContain("capture its PID or process group");
+		expect(tool.description).toContain("pkill -f");
+		expect(tool.description).toContain("parent command line");
+	});
+
 	it("reads telemetry from the internal metadata key", () => {
 		const telemetry = createTelemetryStub();
 

--- a/sdk/packages/core/src/extensions/tools/definitions.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.ts
@@ -396,7 +396,8 @@ export function createSearchTool(
 
 const RUN_COMMANDS_SHARED_INSTRUCTIONS =
 	"Use for listing files, checking git status, running builds, executing tests, etc. " +
-	"Commands must be non-interactive. Commands that require follow-up input like pagers should be skipped or used with supported flags/env (e.g. git --no-pager, --non-interactive) to bypass the interaction steps. ";
+	"Commands must be non-interactive. Commands that require follow-up input like pagers should be skipped or used with supported flags/env (e.g. git --no-pager, --non-interactive) to bypass the interaction steps. " +
+	"When starting background work, capture its PID or process group and use that exact identifier to stop it later. Avoid broad command-line matching such as `pkill -f` because task text can also appear in the agent or harness parent command line. ";
 
 /**
  * Build the run_commands tool description for the shell that will actually

--- a/sdk/packages/core/src/hub/server/handlers/session-handlers.ts
+++ b/sdk/packages/core/src/hub/server/handlers/session-handlers.ts
@@ -46,10 +46,12 @@ function readConnectionReasoningEffort(
 	value: unknown,
 ): SessionConnectionUpdate["reasoningEffort"] | undefined {
 	if (
+		value === "minimal" ||
 		value === "low" ||
 		value === "medium" ||
 		value === "high" ||
 		value === "xhigh" ||
+		value === "max" ||
 		value === null
 	) {
 		return value;

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
@@ -2277,6 +2277,68 @@ describe("SessionRuntime.run — tracker wiring (P1 #3)", () => {
 		expect(abortCalls.length).toBeGreaterThanOrEqual(1);
 	});
 
+	it("does not abort repeated successful calls whose output shows progress", async () => {
+		const successfulCall = (i: number, output: string): AgentRuntimeEvent[] => {
+			const toolCall = {
+				type: "tool-call" as const,
+				toolCallId: `tc${i}`,
+				toolName: "poll",
+				input: { command: "status" },
+			};
+			return [
+				{
+					type: "tool-started",
+					iteration: i,
+					toolCall,
+					snapshot: makeSnapshot(),
+				},
+				{
+					type: "tool-finished",
+					iteration: i,
+					toolCall,
+					message: {
+						id: `m${i}`,
+						role: "tool",
+						content: [
+							{
+								type: "tool-result",
+								toolCallId: toolCall.toolCallId,
+								toolName: toolCall.toolName,
+								output,
+							},
+						],
+						createdAt: i,
+					},
+					snapshot: makeSnapshot(),
+				},
+			];
+		};
+		const { deps, abortCalls } = makeScriptedRuntime({
+			events: [
+				{ type: "turn-started", iteration: 1, snapshot: makeSnapshot() },
+				...successfulCall(1, "10% complete"),
+				...successfulCall(2, "30% complete"),
+				...successfulCall(3, "50% complete"),
+				...successfulCall(4, "70% complete"),
+				...successfulCall(5, "90% complete"),
+				...successfulCall(6, "done"),
+			],
+		});
+		const session = new SessionRuntime(
+			makeAgentConfig({
+				execution: {
+					maxConsecutiveMistakes: 6,
+					loopDetection: { softThreshold: 2, hardThreshold: 3 },
+				},
+			}),
+			deps,
+		);
+
+		await session.run("monitor progress");
+
+		expect(abortCalls).toHaveLength(0);
+	});
+
 	it("resets loop detection when run() starts a fresh conversation", async () => {
 		const identical = (i: number): AgentRuntimeEvent => ({
 			type: "tool-started",

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
@@ -2339,6 +2339,72 @@ describe("SessionRuntime.run — tracker wiring (P1 #3)", () => {
 		expect(abortCalls).toHaveLength(0);
 	});
 
+	it("still aborts repeated built-in failures whose error output changes", async () => {
+		const failedCall = (i: number): AgentRuntimeEvent[] => {
+			const toolCall = {
+				type: "tool-call" as const,
+				toolCallId: `failed-${i}`,
+				toolName: "run_commands",
+				input: { commands: ["false"] },
+			};
+			return [
+				{
+					type: "tool-started",
+					iteration: i,
+					toolCall,
+					snapshot: makeSnapshot(),
+				},
+				{
+					type: "tool-finished",
+					iteration: i,
+					toolCall,
+					message: {
+						id: `failed-message-${i}`,
+						role: "tool",
+						content: [
+							{
+								type: "tool-result",
+								toolCallId: toolCall.toolCallId,
+								toolName: toolCall.toolName,
+								output: [
+									{
+										query: "false",
+										result: "",
+										error: `command failed on attempt ${i}`,
+										success: false,
+									},
+								],
+							},
+						],
+						createdAt: i,
+					},
+					snapshot: makeSnapshot(),
+				},
+			];
+		};
+		const { deps, abortCalls } = makeScriptedRuntime({
+			events: [
+				{ type: "turn-started", iteration: 1, snapshot: makeSnapshot() },
+				...failedCall(1),
+				...failedCall(2),
+				...failedCall(3),
+			],
+		});
+		const session = new SessionRuntime(
+			makeAgentConfig({
+				execution: {
+					maxConsecutiveMistakes: 6,
+					loopDetection: { softThreshold: 2, hardThreshold: 3 },
+				},
+			}),
+			deps,
+		);
+
+		await session.run("repeat a failing command");
+
+		expect(abortCalls.length).toBeGreaterThanOrEqual(1);
+	});
+
 	it("resets loop detection when run() starts a fresh conversation", async () => {
 		const identical = (i: number): AgentRuntimeEvent => ({
 			type: "tool-started",

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
@@ -1108,6 +1108,15 @@ export class SessionRuntime {
 				);
 				const isError =
 					resultPart?.type === "tool-result" && resultPart.isError === true;
+				if (!isError && resultPart?.type === "tool-result") {
+					this.loopTracker.observeSuccessfulOutcome(
+						{
+							name: event.toolCall.toolName,
+							input: event.toolCall.input,
+						},
+						resultPart.output,
+					);
+				}
 				const errorText = isError
 					? formatToolResultError(
 							resultPart?.type === "tool-result"

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
@@ -91,6 +91,17 @@ function formatToolResultError(output: unknown): string {
 	}
 }
 
+function containsFailedToolOperation(output: unknown): boolean {
+	const operations = Array.isArray(output) ? output : [output];
+	return operations.some(
+		(operation) =>
+			operation !== null &&
+			typeof operation === "object" &&
+			!Array.isArray(operation) &&
+			(operation as { success?: unknown }).success === false,
+	);
+}
+
 async function resolveRuleContent(
 	rule: AgentExtensionRule,
 ): Promise<string | undefined> {
@@ -1091,6 +1102,7 @@ export class SessionRuntime {
 				// forceAtLimit:true and abort. Parity with pre-Step-9
 				// agent.ts L917-954.
 				this.inspectLoopForToolCall(
+					event.toolCall.toolCallId,
 					event.toolCall.toolName,
 					event.toolCall.input,
 					event.iteration,
@@ -1108,9 +1120,14 @@ export class SessionRuntime {
 				);
 				const isError =
 					resultPart?.type === "tool-result" && resultPart.isError === true;
-				if (!isError && resultPart?.type === "tool-result") {
+				const isSuccessfulOutcome =
+					!isError &&
+					resultPart?.type === "tool-result" &&
+					!containsFailedToolOperation(resultPart.output);
+				if (isSuccessfulOutcome) {
 					this.loopTracker.observeSuccessfulOutcome(
 						{
+							id: event.toolCall.toolCallId,
 							name: event.toolCall.toolName,
 							input: event.toolCall.input,
 						},
@@ -1251,6 +1268,7 @@ export class SessionRuntime {
 	 *                 abort the active runtime.
 	 */
 	private inspectLoopForToolCall(
+		toolCallId: string,
 		toolName: string,
 		input: unknown,
 		iteration: number,
@@ -1258,7 +1276,11 @@ export class SessionRuntime {
 		if (this.trackerAbortInFlight || this.loopDetectionDisabled) {
 			return;
 		}
-		const verdict = this.loopTracker.inspect({ name: toolName, input });
+		const verdict = this.loopTracker.inspect({
+			id: toolCallId,
+			name: toolName,
+			input,
+		});
 		if (verdict.kind === "ok") {
 			return;
 		}

--- a/sdk/packages/core/src/runtime/safety/loop-detection.test.ts
+++ b/sdk/packages/core/src/runtime/safety/loop-detection.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { LoopDetectionTracker } from "./loop-detection";
+
+describe("LoopDetectionTracker", () => {
+	const call = { name: "poll", input: { command: "status" } };
+
+	it("resets repeated-call counting when successful output changes", () => {
+		const tracker = new LoopDetectionTracker({
+			softThreshold: 2,
+			hardThreshold: 3,
+		});
+
+		expect(tracker.inspect(call).kind).toBe("ok");
+		tracker.observeSuccessfulOutcome(call, "10% complete");
+		expect(tracker.inspect(call).kind).toBe("soft");
+		tracker.observeSuccessfulOutcome(call, "20% complete");
+
+		expect(tracker.inspect(call).kind).toBe("ok");
+	});
+
+	it("still escalates identical calls with identical successful output", () => {
+		const tracker = new LoopDetectionTracker({
+			softThreshold: 2,
+			hardThreshold: 3,
+		});
+
+		expect(tracker.inspect(call).kind).toBe("ok");
+		tracker.observeSuccessfulOutcome(call, "still running");
+		expect(tracker.inspect(call).kind).toBe("soft");
+		tracker.observeSuccessfulOutcome(call, "still running");
+
+		expect(tracker.inspect(call).kind).toBe("hard");
+	});
+});

--- a/sdk/packages/core/src/runtime/safety/loop-detection.test.ts
+++ b/sdk/packages/core/src/runtime/safety/loop-detection.test.ts
@@ -31,4 +31,27 @@ describe("LoopDetectionTracker", () => {
 
 		expect(tracker.inspect(call).kind).toBe("hard");
 	});
+
+	it("does not let a late parallel outcome reset another call's counter", () => {
+		const tracker = new LoopDetectionTracker({
+			softThreshold: 2,
+			hardThreshold: 3,
+		});
+		const firstPoll = { ...call, id: "poll-1" };
+		const secondPoll = { ...call, id: "poll-2" };
+		const otherCall = {
+			id: "other-1",
+			name: "other",
+			input: { command: "status" },
+		};
+
+		expect(tracker.inspect(firstPoll).kind).toBe("ok");
+		tracker.observeSuccessfulOutcome(firstPoll, "10% complete");
+		expect(tracker.inspect(secondPoll).kind).toBe("soft");
+		expect(tracker.inspect(otherCall).kind).toBe("ok");
+
+		tracker.observeSuccessfulOutcome(secondPoll, "20% complete");
+
+		expect(tracker.inspect({ ...otherCall, id: "other-2" }).kind).toBe("soft");
+	});
 });

--- a/sdk/packages/core/src/runtime/safety/loop-detection.ts
+++ b/sdk/packages/core/src/runtime/safety/loop-detection.ts
@@ -125,6 +125,13 @@ const DEFAULT_CONFIG: LoopDetectionConfig = {
 export class LoopDetectionTracker {
 	private readonly config: LoopDetectionConfig;
 	private readonly state: LoopDetectionState = createLoopDetectionState();
+	private lastSuccessfulOutcome:
+		| {
+				toolName: string;
+				toolSignature: string;
+				outputSignature: string;
+		  }
+		| undefined;
 
 	constructor(config?: Partial<LoopDetectionConfig>) {
 		this.config = {
@@ -156,7 +163,34 @@ export class LoopDetectionTracker {
 		return { kind: "ok" };
 	}
 
+	/**
+	 * Record the result of a successful call so repeated status checks can be
+	 * distinguished from a stalled loop. When the same call produces different
+	 * output, it has observed progress and the consecutive-call counter resets.
+	 * Identical calls with identical output continue accumulating normally.
+	 */
+	observeSuccessfulOutcome(call: LoopDetectionCall, output: unknown): void {
+		const toolSignature = toolCallSignature(call.input);
+		const outputSignature = toolCallSignature(output);
+		const previous = this.lastSuccessfulOutcome;
+
+		if (
+			previous?.toolName === call.name &&
+			previous.toolSignature === toolSignature &&
+			previous.outputSignature !== outputSignature
+		) {
+			resetLoopDetectionState(this.state);
+		}
+
+		this.lastSuccessfulOutcome = {
+			toolName: call.name,
+			toolSignature,
+			outputSignature,
+		};
+	}
+
 	reset(): void {
 		resetLoopDetectionState(this.state);
+		this.lastSuccessfulOutcome = undefined;
 	}
 }

--- a/sdk/packages/core/src/runtime/safety/loop-detection.ts
+++ b/sdk/packages/core/src/runtime/safety/loop-detection.ts
@@ -106,6 +106,7 @@ export interface LoopDetectionVerdict {
 
 /** Minimal call shape the tracker needs; matches `AgentToolCallPart` subset. */
 export interface LoopDetectionCall {
+	id?: string;
 	name: string;
 	input: unknown;
 }
@@ -132,6 +133,7 @@ export class LoopDetectionTracker {
 				outputSignature: string;
 		  }
 		| undefined;
+	private latestInspectedCallId: string | undefined;
 
 	constructor(config?: Partial<LoopDetectionConfig>) {
 		this.config = {
@@ -142,6 +144,7 @@ export class LoopDetectionTracker {
 
 	inspect(call: LoopDetectionCall): LoopDetectionVerdict {
 		const signature = toolCallSignature(call.input);
+		this.latestInspectedCallId = call.id;
 		const result = checkRepeatedToolCall(
 			this.state,
 			call.name,
@@ -171,6 +174,14 @@ export class LoopDetectionTracker {
 	 */
 	observeSuccessfulOutcome(call: LoopDetectionCall, output: unknown): void {
 		const toolSignature = toolCallSignature(call.input);
+		const isCurrentCall =
+			this.state.lastToolName === call.name &&
+			this.state.lastToolSignature === toolSignature &&
+			(call.id === undefined || call.id === this.latestInspectedCallId);
+		if (!isCurrentCall) {
+			return;
+		}
+
 		const outputSignature = toolCallSignature(output);
 		const previous = this.lastSuccessfulOutcome;
 
@@ -192,5 +203,6 @@ export class LoopDetectionTracker {
 	reset(): void {
 		resetLoopDetectionState(this.state);
 		this.lastSuccessfulOutcome = undefined;
+		this.latestInspectedCallId = undefined;
 	}
 }

--- a/sdk/packages/core/src/services/llms/provider-settings.ts
+++ b/sdk/packages/core/src/services/llms/provider-settings.ts
@@ -68,7 +68,15 @@ export const AuthSettingsSchema = z.object({
 
 export type AuthSettings = z.infer<typeof AuthSettingsSchema>;
 
-const ReasoningLevelSchema = z.enum(["none", "low", "medium", "high", "xhigh"]);
+const ReasoningLevelSchema = z.enum([
+	"none",
+	"minimal",
+	"low",
+	"medium",
+	"high",
+	"xhigh",
+	"max",
+]);
 
 export const ReasoningSettingsSchema = z.object({
 	enabled: z.boolean().optional(),

--- a/sdk/packages/core/src/services/storage/provider-settings-legacy-migration.ts
+++ b/sdk/packages/core/src/services/storage/provider-settings-legacy-migration.ts
@@ -359,10 +359,12 @@ function resolveReasoning(
 		.find(Boolean);
 	const effort =
 		rawEffort === "none" ||
+		rawEffort === "minimal" ||
 		rawEffort === "low" ||
 		rawEffort === "medium" ||
 		rawEffort === "high" ||
-		rawEffort === "xhigh"
+		rawEffort === "xhigh" ||
+		rawEffort === "max"
 			? rawEffort
 			: undefined;
 	const normalizedBudget =

--- a/sdk/packages/core/src/services/workspace/file-indexer.process.test.ts
+++ b/sdk/packages/core/src/services/workspace/file-indexer.process.test.ts
@@ -1,0 +1,37 @@
+import { execFileSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("file index worker process lifetime", () => {
+	it("settles a foreground mention lookup that shares an unref'ed prewarm", async () => {
+		const cwd = await mkdtemp(
+			path.join(os.tmpdir(), "core-file-index-process-"),
+		);
+		try {
+			await writeFile(path.join(cwd, "README.md"), "# Demo\n", "utf8");
+			const moduleUrl = new URL("./mention-enricher.ts", import.meta.url).href;
+			const script = `
+				import { enrichPromptWithMentions } from ${JSON.stringify(moduleUrl)};
+				import { prewarmFileIndex } from ${JSON.stringify(new URL("./file-indexer.ts", import.meta.url).href)};
+				void prewarmFileIndex(process.cwd());
+				const result = await enrichPromptWithMentions("Inspect @README.md", process.cwd());
+				process.stdout.write(JSON.stringify({ mentions: result.mentions, matchedFiles: result.matchedFiles }));
+			`;
+
+			const stdout = execFileSync("bun", ["--eval", script], {
+				cwd,
+				encoding: "utf8",
+				timeout: 5_000,
+			});
+
+			expect(JSON.parse(stdout)).toEqual({
+				mentions: ["README.md"],
+				matchedFiles: ["README.md"],
+			});
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+});

--- a/sdk/packages/core/src/services/workspace/file-indexer.ts
+++ b/sdk/packages/core/src/services/workspace/file-indexer.ts
@@ -247,11 +247,14 @@ class FileIndexWorkerClient {
 	requestIndex(cwd: string): Promise<string[] | null> {
 		const requestId = ++this.nextRequestId;
 		const result = new Promise<string[] | null>((resolve, reject) => {
+			// Keep the timeout referenced. A foreground caller may be awaiting this
+			// request while the worker itself is unref'ed; if both were unref'ed,
+			// Node/Bun could exit successfully before either the worker response or
+			// fallback timeout settles the promise.
 			const timeout = setTimeout(() => {
 				this.pending.delete(requestId);
 				resolve(null);
 			}, WORKER_INDEX_REQUEST_TIMEOUT_MS);
-			timeout.unref();
 			this.pending.set(requestId, {
 				resolve: (files) => {
 					clearTimeout(timeout);

--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -65,6 +65,12 @@ export function buildAiSdkStreamConfig(
 	};
 }
 
+// AI SDK retries only errors explicitly marked retryable by provider adapters
+// and respects Retry-After while remaining abortable. Five retries cover a full
+// minute of the default 2/4/8/16/32-second backoff without retrying ordinary
+// client errors or continuing indefinitely.
+export const PROVIDER_MAX_RETRIES = 5;
+
 function buildCachedAiSdkMessages(
 	request: GatewayStreamRequest,
 	context: GatewayProviderContext,
@@ -1212,6 +1218,7 @@ function createAiSdkProvider(kind: ProviderModuleKind): GatewayProviderFactory {
 				stream = streamText({
 					model: provider.model(context.model.id) as never,
 					messages: messages as never,
+					maxRetries: PROVIDER_MAX_RETRIES,
 					...(useSystemOption ? { system: systemPrompt } : {}),
 					tools: tools as never,
 					abortSignal: request.signal,

--- a/sdk/packages/llms/src/providers/compat.test.ts
+++ b/sdk/packages/llms/src/providers/compat.test.ts
@@ -402,6 +402,40 @@ describe("createGatewayApiHandler.createMessage", () => {
 		);
 	});
 
+	it("preserves maximum reasoning effort on OpenRouter requests", async () => {
+		streamTextSpy.mockReturnValue({
+			fullStream: (async function* () {
+				yield { type: "finish", finishReason: "stop" };
+			})(),
+			usage: Promise.resolve({ inputTokens: 1, outputTokens: 1 }),
+		});
+
+		const handler = createGatewayApiHandler({
+			providerId: "openrouter",
+			clientType: "openai-compatible",
+			modelId: "reasoning-model",
+			apiKey: "test-key",
+			thinking: true,
+			reasoningEffort: "max",
+		});
+
+		for await (const _chunk of handler.createMessage("", [
+			{ role: "user", content: "Hello" },
+		])) {
+			// Drain the stream so the provider request is executed.
+		}
+
+		expect(streamTextSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				providerOptions: expect.objectContaining({
+					openrouter: expect.objectContaining({
+						reasoning: { effort: "max" },
+					}),
+				}),
+			}),
+		);
+	});
+
 	it("sends configured OpenAI-compatible maxOutputTokens to the provider request", async () => {
 		streamTextSpy.mockReturnValue({
 			fullStream: (async function* () {

--- a/sdk/packages/llms/src/providers/compat.ts
+++ b/sdk/packages/llms/src/providers/compat.ts
@@ -431,14 +431,7 @@ function buildGatewayRequest(
 			config.thinkingBudgetTokens !== undefined
 				? {
 						enabled: config.thinking,
-						effort:
-							config.reasoningEffort === "xhigh"
-								? "high"
-								: config.reasoningEffort === "low" ||
-										config.reasoningEffort === "medium" ||
-										config.reasoningEffort === "high"
-									? config.reasoningEffort
-									: undefined,
+						effort: config.reasoningEffort,
 						budgetTokens: config.thinkingBudgetTokens,
 					}
 				: undefined,

--- a/sdk/packages/llms/src/providers/config.ts
+++ b/sdk/packages/llms/src/providers/config.ts
@@ -5,7 +5,11 @@
  * This replaces the per-provider config chaos with a single structure.
  */
 
-import type { BasicLogger, ExtensionContext } from "@cline/shared";
+import type {
+	BasicLogger,
+	ExtensionContext,
+	GatewayReasoningEffort,
+} from "@cline/shared";
 import type { ModelInfo, ProviderClient } from "../catalog/types";
 import {
 	BUILT_IN_PROVIDER,
@@ -129,7 +133,7 @@ export interface TokenConfig {
  */
 export interface ReasoningConfig {
 	/** Reasoning effort level */
-	reasoningEffort?: "low" | "medium" | "high" | "xhigh";
+	reasoningEffort?: GatewayReasoningEffort;
 	/** Extended thinking budget in tokens */
 	thinkingBudgetTokens?: number;
 	/** Enable thinking with provider/model defaults when supported */

--- a/sdk/packages/llms/src/providers/gateway.ts
+++ b/sdk/packages/llms/src/providers/gateway.ts
@@ -8,6 +8,7 @@ import type {
 	GatewayModelHandleOptions,
 	GatewayModelSelection,
 	GatewayProviderRegistration,
+	GatewayReasoningEffort,
 	GatewayStreamRequest,
 	ITelemetryService,
 } from "@cline/shared";
@@ -62,7 +63,7 @@ class GatewayModelAdapter implements AgentModel {
 		const requestedReasoning = request.options?.reasoning as
 			| {
 					enabled?: boolean;
-					effort?: "low" | "medium" | "high";
+					effort?: GatewayReasoningEffort;
 					budgetTokens?: number;
 			  }
 			| undefined;
@@ -70,15 +71,13 @@ class GatewayModelAdapter implements AgentModel {
 		const reasoningEffort = request.options?.reasoningEffort;
 		const thinkingBudgetTokens = request.options?.thinkingBudgetTokens;
 		const legacyEffort =
-			reasoningEffort === "low" ||
-			reasoningEffort === "medium" ||
-			reasoningEffort === "high"
-				? reasoningEffort
+			typeof reasoningEffort === "string"
+				? (reasoningEffort as GatewayReasoningEffort)
 				: undefined;
 		const legacyReasoning:
 			| {
 					enabled?: boolean;
-					effort?: "low" | "medium" | "high";
+					effort?: GatewayReasoningEffort;
 					budgetTokens?: number;
 			  }
 			| undefined =

--- a/sdk/packages/llms/src/providers/provider-retry.test.ts
+++ b/sdk/packages/llms/src/providers/provider-retry.test.ts
@@ -1,0 +1,149 @@
+import { APICallError } from "@ai-sdk/provider";
+import { simulateReadableStream, streamText } from "ai";
+import { MockLanguageModelV3 } from "ai/test";
+import { describe, expect, it } from "vitest";
+import { PROVIDER_MAX_RETRIES } from "./ai-sdk";
+
+function retryableError(): APICallError {
+	return new APICallError({
+		message: "temporarily rate limited",
+		url: "https://provider.example/v1/chat/completions",
+		requestBodyValues: {},
+		statusCode: 429,
+		responseHeaders: { "retry-after": "0" },
+	});
+}
+
+function successfulStream() {
+	return {
+		stream: simulateReadableStream({
+			chunks: [
+				{ type: "text-start" as const, id: "text-1" },
+				{
+					type: "text-delta" as const,
+					id: "text-1",
+					delta: "recovered",
+				},
+				{ type: "text-end" as const, id: "text-1" },
+				{
+					type: "finish" as const,
+					finishReason: { unified: "stop" as const, raw: undefined },
+					usage: {
+						inputTokens: {
+							total: 1,
+							noCache: 1,
+							cacheRead: undefined,
+							cacheWrite: undefined,
+						},
+						outputTokens: {
+							total: 1,
+							text: 1,
+							reasoning: undefined,
+						},
+					},
+				},
+			],
+			chunkDelayInMs: null,
+			initialDelayInMs: null,
+		}),
+	};
+}
+
+async function drain(
+	result: ReturnType<typeof streamText>,
+): Promise<unknown[]> {
+	const events: unknown[] = [];
+	for await (const event of result.fullStream) {
+		events.push(event);
+	}
+	return events;
+}
+
+describe("provider retry policy", () => {
+	it("recovers from five consecutive retryable failures", async () => {
+		let attempts = 0;
+		const model = new MockLanguageModelV3({
+			doStream: async () => {
+				attempts += 1;
+				if (attempts <= PROVIDER_MAX_RETRIES) {
+					throw retryableError();
+				}
+				return successfulStream();
+			},
+		});
+
+		const events = await drain(
+			streamText({ model, prompt: "hello", maxRetries: PROVIDER_MAX_RETRIES }),
+		);
+
+		expect(attempts).toBe(PROVIDER_MAX_RETRIES + 1);
+		expect(events).toContainEqual(
+			expect.objectContaining({ type: "text-delta", text: "recovered" }),
+		);
+		expect(events).not.toContainEqual(
+			expect.objectContaining({ type: "error" }),
+		);
+	});
+
+	it("stops after the bounded number of retryable attempts", async () => {
+		let attempts = 0;
+		const model = new MockLanguageModelV3({
+			doStream: async () => {
+				attempts += 1;
+				throw retryableError();
+			},
+		});
+
+		const events = await drain(
+			streamText({ model, prompt: "hello", maxRetries: PROVIDER_MAX_RETRIES }),
+		);
+
+		expect(attempts).toBe(PROVIDER_MAX_RETRIES + 1);
+		expect(events).toContainEqual(expect.objectContaining({ type: "error" }));
+	});
+
+	it("does not retry a non-retryable client error", async () => {
+		let attempts = 0;
+		const model = new MockLanguageModelV3({
+			doStream: async () => {
+				attempts += 1;
+				throw new APICallError({
+					message: "invalid request",
+					url: "https://provider.example/v1/chat/completions",
+					requestBodyValues: {},
+					statusCode: 400,
+				});
+			},
+		});
+
+		const events = await drain(
+			streamText({ model, prompt: "hello", maxRetries: PROVIDER_MAX_RETRIES }),
+		);
+
+		expect(attempts).toBe(1);
+		expect(events).toContainEqual(expect.objectContaining({ type: "error" }));
+	});
+
+	it("stops retrying when the request is aborted", async () => {
+		let attempts = 0;
+		const abortController = new AbortController();
+		const model = new MockLanguageModelV3({
+			doStream: async () => {
+				attempts += 1;
+				abortController.abort(new Error("cancelled"));
+				throw retryableError();
+			},
+		});
+
+		await drain(
+			streamText({
+				model,
+				prompt: "hello",
+				maxRetries: PROVIDER_MAX_RETRIES,
+				abortSignal: abortController.signal,
+			}),
+		);
+
+		expect(attempts).toBe(1);
+	});
+});

--- a/sdk/packages/llms/src/providers/routing/anthropic-compatible.ts
+++ b/sdk/packages/llms/src/providers/routing/anthropic-compatible.ts
@@ -4,6 +4,7 @@ import type {
 	GatewayProviderContext,
 	GatewayProviderManifest,
 	GatewayProviderMetadata,
+	GatewayReasoningEffort,
 	GatewayStreamRequest,
 } from "@cline/shared";
 import {
@@ -17,10 +18,29 @@ import { createEphemeralCacheControl, toProviderOptionsKey } from "./utils";
 const ANTHROPIC_DEFAULT_THINKING_BUDGET_TOKENS = 1024;
 const ANTHROPIC_MAX_THINKING_BUDGET_TOKENS = 128000;
 const ANTHROPIC_REASONING_EFFORT_BUDGET_RATIOS: Record<string, number> = {
+	minimal: 0.1,
 	low: 0.2,
 	medium: 0.5,
 	high: 0.8,
+	xhigh: 0.95,
+	max: 1,
 };
+
+export function toAnthropicAdaptiveEffort(
+	effort: GatewayReasoningEffort,
+): "low" | "medium" | "high" | "max" {
+	switch (effort) {
+		case "minimal":
+		case "low":
+			return "low";
+		case "medium":
+		case "high":
+			return effort;
+		case "xhigh":
+		case "max":
+			return "max";
+	}
+}
 
 export type AnthropicReasoningRequestPolicy =
 	| { kind: "none" }
@@ -436,7 +456,7 @@ export function buildAnthropicProviderOptions(
 
 	return {
 		...(policy.kind === "anthropic-adaptive" && request.reasoning?.effort
-			? { effort: request.reasoning.effort }
+			? { effort: toAnthropicAdaptiveEffort(request.reasoning.effort) }
 			: {}),
 		...(thinking ? { thinking } : {}),
 		...(shouldApplyAnthropicCacheBucket(request, context)
@@ -520,7 +540,7 @@ export function buildAnthropicCompatibleReasoningOptions(
 		reasoning.enabled = true;
 	}
 	if (policy.kind === "anthropic-adaptive" && request.reasoning?.effort) {
-		reasoning.effort = request.reasoning.effort;
+		reasoning.effort = toAnthropicAdaptiveEffort(request.reasoning.effort);
 	}
 	if (typeof request.reasoning?.budgetTokens === "number") {
 		reasoning.max_tokens = request.reasoning.budgetTokens;
@@ -587,6 +607,11 @@ export function buildGatewayReasoningOptions(
 		// reasoning. Remove once routed providers normalize disabled reasoning
 		// consistently, or replace with a systematic model policy.
 		!modelRejectsDisabledReasoning(request.modelId);
+	const effort = request.reasoning?.effort
+		? policy.kind === "anthropic-adaptive"
+			? toAnthropicAdaptiveEffort(request.reasoning.effort)
+			: request.reasoning.effort
+		: undefined;
 	const reasoning: Record<string, unknown> = {
 		...(request.reasoning?.enabled === true
 			? { enabled: true }
@@ -595,9 +620,7 @@ export function buildGatewayReasoningOptions(
 				: request.reasoning?.effort
 					? { enabled: true }
 					: {}),
-		...(request.reasoning?.effort && policy.kind !== "anthropic-manual"
-			? { effort: request.reasoning.effort }
-			: {}),
+		...(effort && policy.kind !== "anthropic-manual" ? { effort } : {}),
 	};
 
 	if (typeof budgetTokens === "number" && budgetTokens >= 0) {

--- a/sdk/packages/llms/src/providers/routing/anthropic-compatible.ts
+++ b/sdk/packages/llms/src/providers/routing/anthropic-compatible.ts
@@ -26,22 +26,6 @@ const ANTHROPIC_REASONING_EFFORT_BUDGET_RATIOS: Record<string, number> = {
 	max: 1,
 };
 
-export function toAnthropicAdaptiveEffort(
-	effort: GatewayReasoningEffort,
-): "low" | "medium" | "high" | "max" {
-	switch (effort) {
-		case "minimal":
-		case "low":
-			return "low";
-		case "medium":
-		case "high":
-			return effort;
-		case "xhigh":
-		case "max":
-			return "max";
-	}
-}
-
 export type AnthropicReasoningRequestPolicy =
 	| { kind: "none" }
 	| { kind: "anthropic-manual" }
@@ -376,12 +360,12 @@ function resolveClaudeVersion(modelId: string | undefined) {
 	const majorToken = versionFirstMatch?.[1] ?? tokens[0];
 	const minorToken =
 		versionFirstMatch?.[2] ?? (tokens[1]?.length <= 2 ? tokens[1] : undefined);
-	if (!majorToken || !minorToken) {
+	if (!majorToken) {
 		return undefined;
 	}
 
 	const major = Number.parseInt(majorToken, 10);
-	const minor = Number.parseInt(minorToken, 10);
+	const minor = minorToken ? Number.parseInt(minorToken, 10) : 0;
 	if (!Number.isFinite(major) || !Number.isFinite(minor)) {
 		return undefined;
 	}
@@ -404,6 +388,43 @@ function supportsAnthropicAdaptiveThinkingPolicy(options: {
 	}
 
 	return (line === "opus" || line === "sonnet") && version.minor >= 6;
+}
+
+function supportsAnthropicXHighEffort(options: {
+	modelId?: string;
+	family?: string;
+}): boolean {
+	const line = resolveClaudeLine(options.modelId, options.family);
+	const version = resolveClaudeVersion(options.modelId);
+	if (!line || !version) {
+		return false;
+	}
+
+	if (line === "opus") {
+		return version.major > 4 || (version.major === 4 && version.minor >= 7);
+	}
+	return line === "sonnet" && version.major >= 5;
+}
+
+export function toAnthropicAdaptiveEffort(
+	effort: GatewayReasoningEffort,
+	options: {
+		modelId?: string;
+		family?: string;
+	},
+): "low" | "medium" | "high" | "xhigh" | "max" {
+	switch (effort) {
+		case "minimal":
+		case "low":
+			return "low";
+		case "medium":
+		case "high":
+			return effort;
+		case "xhigh":
+			return supportsAnthropicXHighEffort(options) ? "xhigh" : "max";
+		case "max":
+			return "max";
+	}
 }
 
 export function resolveAnthropicReasoningRequestPolicy(
@@ -456,7 +477,12 @@ export function buildAnthropicProviderOptions(
 
 	return {
 		...(policy.kind === "anthropic-adaptive" && request.reasoning?.effort
-			? { effort: toAnthropicAdaptiveEffort(request.reasoning.effort) }
+			? {
+					effort: toAnthropicAdaptiveEffort(request.reasoning.effort, {
+						modelId: request.modelId,
+						family: resolveModelFamily(context),
+					}),
+				}
 			: {}),
 		...(thinking ? { thinking } : {}),
 		...(shouldApplyAnthropicCacheBucket(request, context)
@@ -540,7 +566,10 @@ export function buildAnthropicCompatibleReasoningOptions(
 		reasoning.enabled = true;
 	}
 	if (policy.kind === "anthropic-adaptive" && request.reasoning?.effort) {
-		reasoning.effort = toAnthropicAdaptiveEffort(request.reasoning.effort);
+		reasoning.effort = toAnthropicAdaptiveEffort(request.reasoning.effort, {
+			modelId: request.modelId,
+			family: resolveModelFamily(context),
+		});
 	}
 	if (typeof request.reasoning?.budgetTokens === "number") {
 		reasoning.max_tokens = request.reasoning.budgetTokens;
@@ -609,7 +638,10 @@ export function buildGatewayReasoningOptions(
 		!modelRejectsDisabledReasoning(request.modelId);
 	const effort = request.reasoning?.effort
 		? policy.kind === "anthropic-adaptive"
-			? toAnthropicAdaptiveEffort(request.reasoning.effort)
+			? toAnthropicAdaptiveEffort(request.reasoning.effort, {
+					modelId: request.modelId,
+					family,
+				})
 			: request.reasoning.effort
 		: undefined;
 	const reasoning: Record<string, unknown> = {

--- a/sdk/packages/llms/src/providers/routing/generic-compatible.ts
+++ b/sdk/packages/llms/src/providers/routing/generic-compatible.ts
@@ -12,6 +12,7 @@ import {
 	resolveAnthropicReasoningRequestPolicy,
 	resolveReasoningRoute,
 	shouldApplyPromptCache,
+	toAnthropicAdaptiveEffort,
 } from "./anthropic-compatible";
 import type {
 	AiSdkProviderOptionsTarget,
@@ -81,10 +82,10 @@ function buildCompatibleEffortOptions(options: {
 		typeof resolveAnthropicReasoningRequestPolicy
 	>["kind"];
 }): Record<string, unknown> {
-	const effort = options.reasoning?.effort;
+	const rawEffort = options.reasoning?.effort;
 	if (
 		options.suppressions.genericEffort ||
-		!effort ||
+		!rawEffort ||
 		options.reasoning?.enabled === false ||
 		options.suppressEffortOptions
 	) {
@@ -96,6 +97,9 @@ function buildCompatibleEffortOptions(options: {
 	if (!allowEffort) {
 		return {};
 	}
+	const effort = options.usesAnthropicReasoningRoute
+		? toAnthropicAdaptiveEffort(rawEffort)
+		: rawEffort;
 	return {
 		effort,
 		reasoningEffort: effort,

--- a/sdk/packages/llms/src/providers/routing/generic-compatible.ts
+++ b/sdk/packages/llms/src/providers/routing/generic-compatible.ts
@@ -75,6 +75,8 @@ function buildCompatibleThinkingOptions(options: {
 
 function buildCompatibleEffortOptions(options: {
 	reasoning: GatewayStreamRequest["reasoning"];
+	modelId: string;
+	family?: string;
 	usesAnthropicReasoningRoute: boolean;
 	suppressEffortOptions: boolean;
 	suppressions: ProviderOptionSuppression;
@@ -98,7 +100,10 @@ function buildCompatibleEffortOptions(options: {
 		return {};
 	}
 	const effort = options.usesAnthropicReasoningRoute
-		? toAnthropicAdaptiveEffort(rawEffort)
+		? toAnthropicAdaptiveEffort(rawEffort, {
+				modelId: options.modelId,
+				family: options.family,
+			})
 		: rawEffort;
 	return {
 		effort,
@@ -143,6 +148,8 @@ export function buildCompatibleProviderOptions(options: {
 		...buildCompatibleThinkingOptions({ request, context, suppressions }),
 		...buildCompatibleEffortOptions({
 			reasoning: request.reasoning,
+			modelId: request.modelId,
+			family,
 			usesAnthropicReasoningRoute,
 			suppressEffortOptions: suppressCompatibleReasoningOptions,
 			suppressions,

--- a/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
@@ -1,4 +1,4 @@
-import { isClineProvider } from "@cline/shared";
+import { type GatewayReasoningEffort, isClineProvider } from "@cline/shared";
 import {
 	isDeepSeekFamily,
 	isGemini3Model,
@@ -127,10 +127,28 @@ function buildReasoningPatchForProvider(
 }
 
 const GEMINI_25_THINKING_BUDGET_BY_EFFORT = {
+	minimal: 128,
 	low: 1_024,
 	medium: 8_192,
 	high: 24_576,
+	xhigh: 24_576,
+	max: 24_576,
 } as const;
+
+function toGemini3ThinkingLevel(
+	effort: GatewayReasoningEffort,
+): "minimal" | "low" | "medium" | "high" {
+	switch (effort) {
+		case "minimal":
+		case "low":
+		case "medium":
+		case "high":
+			return effort;
+		case "xhigh":
+		case "max":
+			return "high";
+	}
+}
 
 function buildGeminiThinkingConfig(input: ProviderOptionBuildInput):
 	| {
@@ -155,7 +173,7 @@ function buildGeminiThinkingConfig(input: ProviderOptionBuildInput):
 			return undefined;
 		}
 		return {
-			thinkingLevel: reasoning.effort,
+			thinkingLevel: toGemini3ThinkingLevel(reasoning.effort),
 			includeThoughts: true,
 		};
 	}

--- a/sdk/packages/llms/src/providers/routing/provider-options.test.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-options.test.ts
@@ -308,32 +308,36 @@ describe("composeAiSdkProviderOptions: Anthropic thinking precedence", () => {
 			],
 		},
 		{
-			name: "Opus 4.6 -> adaptive thinking with effort",
+			name: "Opus 4.6 clamps unsupported xhigh effort to max",
 			request: {
 				providerId: "anthropic",
 				modelId: "claude-opus-4-6",
-				reasoning: { enabled: true, effort: "high" },
+				reasoning: { enabled: true, effort: "xhigh" },
 			},
 			context: { family: "claude-opus" },
 			expect: [
 				{
 					bucket: "anthropic",
-					has: { thinking: ADAPTIVE_THINKING, effort: "high" },
+					has: { thinking: ADAPTIVE_THINKING, effort: "max" },
 				},
 			],
 		},
 		{
-			name: "Opus 4.7 -> adaptive thinking with effort",
+			name: "Opus 4.7 preserves supported xhigh effort",
 			request: {
 				providerId: "anthropic",
 				modelId: "claude-opus-4-7",
-				reasoning: { enabled: true, effort: "high" },
+				reasoning: { enabled: true, effort: "xhigh" },
 			},
 			context: { family: "claude-opus" },
 			expect: [
 				{
 					bucket: "anthropic",
-					has: { thinking: ADAPTIVE_THINKING, effort: "high" },
+					has: { thinking: ADAPTIVE_THINKING, effort: "xhigh" },
+				},
+				{
+					bucket: "openaiCompatible",
+					has: { effort: "xhigh", reasoningEffort: "xhigh" },
 				},
 			],
 		},
@@ -369,17 +373,17 @@ describe("composeAiSdkProviderOptions: Anthropic thinking precedence", () => {
 			],
 		},
 		{
-			name: "future Claude major (Sonnet 5.0) -> adaptive thinking",
+			name: "Sonnet 5 preserves supported xhigh effort",
 			request: {
 				providerId: "anthropic",
-				modelId: "claude-sonnet-5-0",
-				reasoning: { enabled: true, effort: "high" },
+				modelId: "claude-sonnet-5",
+				reasoning: { enabled: true, effort: "xhigh" },
 			},
 			context: { family: "claude-sonnet" },
 			expect: [
 				{
 					bucket: "anthropic",
-					has: { thinking: ADAPTIVE_THINKING, effort: "high" },
+					has: { thinking: ADAPTIVE_THINKING, effort: "xhigh" },
 				},
 			],
 		},
@@ -613,6 +617,22 @@ describe("composeAiSdkProviderOptions: family/provider thinking patches", () => 
 				{
 					bucket: "openaiCompatible",
 					lacks: ["thinking", "reasoning", "effort", "reasoningEffort"],
+				},
+			],
+		},
+		{
+			name: "openrouter preserves supported Anthropic xhigh effort",
+			request: {
+				providerId: "openrouter",
+				modelId: "anthropic/claude-opus-4-7",
+				reasoning: { effort: "xhigh" },
+			},
+			context: { family: "claude-opus" },
+			expect: [
+				{
+					bucket: "openrouter",
+					has: { reasoning: { effort: "xhigh" } },
+					lacks: ["thinking", "reasoningEffort"],
 				},
 			],
 		},

--- a/sdk/packages/llms/src/providers/routing/provider-options.test.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-options.test.ts
@@ -598,6 +598,25 @@ describe("composeAiSdkProviderOptions: family/provider thinking patches", () => 
 			],
 		},
 		{
+			name: "openrouter preserves exact maximum reasoning effort",
+			request: {
+				providerId: "openrouter",
+				modelId: "moonshotai/reasoning-model",
+				reasoning: { effort: "max" },
+			},
+			expect: [
+				{
+					bucket: "openrouter",
+					has: { reasoning: { effort: "max" } },
+					lacks: ["thinking", "effort", "reasoningEffort"],
+				},
+				{
+					bucket: "openaiCompatible",
+					lacks: ["thinking", "reasoning", "effort", "reasoningEffort"],
+				},
+			],
+		},
+		{
 			name: "openrouter reasoning enabled-only -> reasoning.enabled",
 			request: {
 				providerId: "openrouter",

--- a/sdk/packages/llms/src/tests/provider-live-config.ts
+++ b/sdk/packages/llms/src/tests/provider-live-config.ts
@@ -180,10 +180,12 @@ export function toLiveProviderConfig(settingsInput: unknown): ProviderConfig {
 		}
 		if (typeof reasoning.effort === "string" && reasoning.effort !== "none") {
 			config.reasoningEffort = reasoning.effort as
+				| "minimal"
 				| "low"
 				| "medium"
 				| "high"
-				| "xhigh";
+				| "xhigh"
+				| "max";
 		}
 		if (typeof reasoning.budgetTokens === "number") {
 			config.thinkingBudgetTokens = reasoning.budgetTokens;

--- a/sdk/packages/shared/src/agents/types.ts
+++ b/sdk/packages/shared/src/agents/types.ts
@@ -650,9 +650,22 @@ export const AgentResultSchema = z.object({
 /**
  * Reasoning effort level for capable models
  */
-export type ReasoningEffort = "low" | "medium" | "high" | "xhigh";
+export type ReasoningEffort =
+	| "minimal"
+	| "low"
+	| "medium"
+	| "high"
+	| "xhigh"
+	| "max";
 
-export const ReasoningEffortSchema = z.enum(["low", "medium", "high", "xhigh"]);
+export const ReasoningEffortSchema = z.enum([
+	"minimal",
+	"low",
+	"medium",
+	"high",
+	"xhigh",
+	"max",
+]);
 
 /**
  * Configuration for creating an Agent

--- a/sdk/packages/shared/src/llms/gateway.ts
+++ b/sdk/packages/shared/src/llms/gateway.ts
@@ -40,6 +40,13 @@ export type GatewayReasoningFormat =
 	| "anthropic-thinking"
 	| "glm-thinking"
 	| "minimax-thinking";
+export type GatewayReasoningEffort =
+	| "minimal"
+	| "low"
+	| "medium"
+	| "high"
+	| "xhigh"
+	| "max";
 export type GatewayModelRoute =
 	| { matcher: "anthropic-compatible" }
 	| {
@@ -177,7 +184,7 @@ export interface GatewayStreamRequest {
 	metadata?: Record<string, unknown>;
 	reasoning?: {
 		enabled?: boolean;
-		effort?: "low" | "medium" | "high";
+		effort?: GatewayReasoningEffort;
 		budgetTokens?: number;
 	};
 	signal?: AbortSignal;
@@ -210,7 +217,7 @@ export interface GatewayModelHandleOptions {
 	metadata?: Record<string, unknown>;
 	reasoning?: {
 		enabled?: boolean;
-		effort?: "low" | "medium" | "high";
+		effort?: GatewayReasoningEffort;
 		budgetTokens?: number;
 	};
 	signal?: AbortSignal;

--- a/sdk/packages/shared/src/llms/reasoning-effort.test.ts
+++ b/sdk/packages/shared/src/llms/reasoning-effort.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import {
+	resolveEffectiveReasoningEffort,
+	resolveReasoningBudgetFromRatio,
+} from "./reasoning-effort";
+
+describe("reasoning effort", () => {
+	it("recognizes maximum effort", () => {
+		expect(resolveEffectiveReasoningEffort("MAX", true)).toBe("max");
+	});
+
+	it("maps maximum effort to the full available budget", () => {
+		expect(
+			resolveReasoningBudgetFromRatio({ effort: "max", maxBudget: 32_000 }),
+		).toBe(32_000);
+	});
+});

--- a/sdk/packages/shared/src/llms/reasoning-effort.ts
+++ b/sdk/packages/shared/src/llms/reasoning-effort.ts
@@ -1,4 +1,5 @@
 export const REASONING_EFFORT_RATIOS = {
+	max: 1,
 	xhigh: 0.95,
 	high: 0.8,
 	medium: 0.5,

--- a/sdk/packages/shared/src/rpc/runtime.ts
+++ b/sdk/packages/shared/src/rpc/runtime.ts
@@ -292,7 +292,7 @@ export interface SaveProviderSettingsActionRequest {
 	// Reasoning/thinking configuration
 	reasoning?: {
 		enabled?: boolean;
-		effort?: "none" | "low" | "medium" | "high" | "xhigh";
+		effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 		budgetTokens?: number;
 	};
 	// AWS/Bedrock configuration


### PR DESCRIPTION
## Summary

This PR improves Cline CLI reliability for long-running, tool-heavy agent work. It was developed as a controlled Kimi K3 harness investigation, but every retained change is provider- and benchmark-independent:

- preserve `minimal`, `xhigh`, and `max` reasoning effort through shared configuration and OpenRouter-compatible routes, while normalizing only in provider codecs whose wire APIs have narrower enums;
- increase the AI SDK's bounded retry allowance for adapter-classified transient provider failures from 2 to 5;
- make repeated-tool-call detection progress-aware by comparing successful outputs, so identical polling calls with changing output do not abort a productive session;
- keep foreground file-mention enrichment alive until its existing one-second worker fallback resolves, preventing a silent exit before the first model request;
- warn agents to track exact PIDs/process groups for background work and avoid broad command-line matching such as `pkill -f`, which can kill the Cline/harness parent;
- add a safe single-platform CLI tarball build command used to validate the exact evaluated package.

The implementation is split into six clean commits so each mechanism can be reviewed independently. A seventh merge-only commit synchronizes the branch with current `main`; the exact evaluated commit remains in history.

## Why

A 69/89 Terminal-Bench 2.1 baseline exposed several general harness failures rather than model-solution failures:

- five failed trials terminated on transient OpenRouter 429s;
- two productive background workflows were aborted by a loop detector that counted repeated calls before observing their changing outputs;
- one prompt containing ordinary whitespace-prefixed `@token` text exited 0 with no session or provider request because both the file-index worker and timeout were unreferenced;
- two agents killed their own parent process through broad `pkill -f` cleanup;
- Cline could not represent Kimi K3's documented `max` effort even though OpenRouter metadata exposed only that supported effort.

A captured two-turn request also confirmed that the existing non-compacted path correctly returns complete `reasoning_content`, content, tool calls, and tool results. This PR therefore does not rewrite thinking history or claim a compaction fix.

## Changes by commit

1. `d1bc440b9 feat(reasoning): preserve maximum effort through providers`
   - extends shared, persisted, CLI, and UI effort types with `minimal` and `max`;
   - removes the gateway-wide `xhigh -> high` collapse;
   - preserves exact effort on generic/OpenRouter-compatible routes;
   - clamps only for Anthropic- and Gemini-compatible paths that require narrower values.

2. `cabfa9e1b fix(llms): retry transient provider failures longer`
   - sets `streamText.maxRetries` to 5;
   - retains the AI SDK's provider-neutral transient classification, `Retry-After`, bounded backoff, cancellation, and final-error behavior;
   - does not retry ordinary permanent 4xx failures.

3. `1cc792b76 chore(cli): add safe single-platform tarball build`
   - adds `bun run --cwd apps/cli build:tgz`;
   - packages the built Linux/x64 npm artifact, not a raw repository archive.

4. `dbcdba8d0 fix(runtime): recognize progress in repeated tool calls`
   - feeds canonicalized successful tool output into `LoopDetectionTracker`;
   - changed output resets the consecutive count;
   - identical output and failed calls retain the existing soft/hard thresholds.

5. `289cb8289 fix(core): keep foreground file indexing alive`
   - keeps the bounded one-second file-index request timeout referenced;
   - leaves the opportunistic worker unreferenced;
   - prevents Node/Bun from exiting while a foreground mention-enrichment caller awaits the worker/fallback.

6. `23d597053 docs(tools): prevent broad process self-termination`
   - updates generic `run_commands` guidance to capture exact PIDs or process groups;
   - warns that broad command-line matching may also match the agent or harness parent;
   - does not block commands or add any task/process/provider special case.

## Test coverage

Retained mechanisms have focused regressions plus broader validation:

- reasoning: shared effort tests 2/2; LLM compatibility/routing 111/111; CLI parsing/resolution 48/48; affected Core parsing/migrations 23/23;
- retries: four synthetic cases covering fifth-retry recovery, bounded exhaustion, permanent HTTP 400, and cancellation; shared suite 232/232; LLM suite 388 passed, 4 skipped; focused CLI suite 119/119;
- progress-aware loops: tracker/orchestrator 56/56; full Core unit suite 1,353 passed, 4 skipped;
- foreground indexing: workspace tests 10/10, including a fresh child-process liveness regression; full Core unit suite 1,354 passed, 4 skipped;
- process guidance: tool-definition suite 57/57; final full Core suite 1,355 passed, 4 skipped with one worker;
- full monorepo typecheck passed after each retained behavioral change;
- Biome checks passed on changed files and `git diff --check` passed.

After merging current `main`, the effective PR diff remained the same 35 intended files. The merged head passed 296 focused tests, changed-file Biome checks, SDK builds, and full monorepo typecheck. Its serialized full Core run passed 1,410 tests with 4 skipped and one failure in the unchanged current-`main` `src/auth/cline.test.ts`; that same auth telemetry test also fails alone, and no PR diff touches it.

One default-parallel Core run performed while benchmark workloads were competing for the host produced five timeout files and two mock-contamination follow-ons. Those five files immediately passed 25/25 with one worker, followed by the clean 1,355-pass full Core run. Repository-wide formatting also remained red on three unrelated files that were already unformatted before this branch; they were intentionally not touched.

## Controlled evaluation

This was a one-attempt development protocol, not a leaderboard submission:

- dataset: `terminal-bench/terminal-bench-2-1`;
- immutable dataset ref: `sha256:7d7bdc1cbedad549fc1140404bd4dc45e5fd0ea7c4186773687d177ad3a0699a`;
- model/route: `openrouter:moonshotai/kimi-k3`;
- effort: `high` for baseline and every scored candidate (the new `max` representation stayed dormant);
- Modal, all 89 tasks at 89-way concurrency, one attempt;
- task and setup timeout multipliers both 2;
- zero Harbor retries and no resource overrides;
- unchanged tasks, instructions, verifiers, expected outputs, sampling, and timeout policy.

No Harbor production code, benchmark tests, rewards, task resources, task-name detection, benchmark-specific prompt text, or task solutions were changed.

### Preregistered diagnostics

- cumulative retry artifact: 13/14; nine baseline failures flipped to pass, all four pass controls stayed green, and no control regressed;
- progress-aware loop slice: 4/4; both former false-abort tasks passed and neither emitted the former hard-loop signature;
- foreground-indexing probe: 1/1; the deterministic no-session/no-token exit became a real model session and verifier pass;
- background-process slice: 2/2; neither workflow killed its parent. One MIPS trace still issued a broad match later, so the change is correctly described as guidance rather than enforcement.

### Full fixed-artifact runs

| Run | Score | Exceptions | Cost |
| --- | ---: | ---: | ---: |
| Baseline, commit `f053ec48e` | 69/89 (77.53%) | 17 | $79.1077 |
| Stage C | 77/89 (86.52%) | 12 | $65.2608 |
| Confirmation 1 | **79/89 (88.76%)** | 8 | $49.7993 |
| Confirmation 2 | 76/89 (85.39%) | 9 | $48.3158 |
| Confirmation 3 | 78/89 (87.64%) | 6 | $51.9263 |

The three unchanged confirmations were 79, 76, and 78: mean 77.67, median 78, range 76–79. Including Stage C, the four optimized full runs averaged 77.50/89, an 8.5-task gain over baseline. Their aggregate exception rate was 9.83%, versus 19.10% at baseline.

Across the four optimized full runs:

- 66 tasks passed 4/4;
- 12 passed 3/4;
- 4 passed 2/4;
- 2 passed 1/4;
- 5 failed 4/4: `build-pov-ray`, `extract-moves-from-video`, `filter-js-from-html`, `make-doom-for-mips`, and `video-processing`.

Nine baseline failures passed all four optimized runs: `configure-git-webserver`, `gcode-to-text`, `git-multibranch`, `large-scale-text-editing`, `merge-diff-arc-agi-task`, `mteb-leaderboard`, `mteb-retrieve`, `overfull-hbox`, and `sanitize-git-repo`.

Two interrupted confirmation attempts are disclosed but excluded from all scores and aggregates. One stopped with five unresolved trials; the other had two orchestration-induced `CancelledError` outcomes. Neither was resumed or selectively composed into a score. Confirmation 3 retained an external Modal sandbox `NotFoundError` as a loss.

These results establish a repeatable improvement for this fixed development protocol, but they do not isolate the score contribution of every individual commit and should not be presented as leaderboard-equivalent. Moonshot's vendor-reported 88.3% KimiCode result differs in harness, route, effort semantics, and evaluation protocol. The best run numerically exceeds it, while the repeated mean does not; neither is an apples-to-apples comparison.

## Evaluated artifact

- final commit: `23d597053a46c8806c985f8c59dd3692cf6eb3d9`;
- git tree: `d8fe7475c6a9efff450faa0eb8cc6e0d86aecac1`;
- package: `@cline/cli-linux-x64@3.0.40`;
- tarball: `new-cli-cline-cli-linux-x64-3.0.40-20260719T053815Z-23d597053.tgz`;
- SHA-256: `e027570db85cf4de165f986f52ebd595160ceffb5d9ec46a8cb37362dbf30f4c`;
- size: 46,419,999 bytes;
- URL: https://uploading-sdk.s3.us-east-2.amazonaws.com/cline-builds/new-cli-cline-cli-linux-x64-3.0.40-20260719T053815Z-23d597053.tgz

The artifact passed manifest inspection, fresh-prefix install, `cline --version`, public byte-range retrieval, fresh installation from the public URL, and a direct OpenRouter/K3/high inference-and-submission smoke test.

## Reproduction

Build the current review head with Bun 1.3.13 and Node 22+. To reproduce the evaluated 3.0.40 bytes exactly, check out `23d597053a46c8806c985f8c59dd3692cf6eb3d9` first:

```bash
bun install --frozen-lockfile
bun run --cwd apps/cli build:tgz
find apps/cli/dist -maxdepth 1 -name 'cline-cli-linux-x64-*.tgz' -print -exec sha256sum {} \;
```

Run the fixed development protocol:

```bash
uv run harbor run \
  -a cline-cli \
  -m openrouter:moonshotai/kimi-k3 \
  --timeout-multiplier 2.0 \
  --agent-setup-timeout-multiplier 2 \
  --env modal \
  -n 89 -l 89 -y \
  --ak max-consecutive-mistakes=6 \
  --ak setup-retries=3 \
  --ak setup-retry-delay-sec=5 \
  --ak setup-command-timeout-sec=240 \
  --ak tarball_url=https://uploading-sdk.s3.us-east-2.amazonaws.com/cline-builds/new-cli-cline-cli-linux-x64-3.0.40-20260719T053815Z-23d597053.tgz \
  --ak reasoning-effort=high \
  -d terminal-bench/terminal-bench-2-1
```

Run the command as a fresh 89-task job for each repetition; do not combine selective retries. Exact job IDs, task-level flips, invalid-run disclosures, usage, and costs are preserved in the experiment ledger accompanying this investigation.

## Known limitations / follow-ups

- Run a separate `max` configuration experiment; this PR only makes the value representable.
- Audit thinking-block preservation across compaction, not only normal tool turns.
- Improve first-class long-process handles so polling does not depend on ad hoc shell patterns.
- Consider runtime-level protection for unsafe broad process cleanup; prompt guidance reduced the observed failure but did not eliminate every broad-match call.
- Perform a true leaderboard-compatible Stage E (ideally five attempts) before making any public parity claim.
