### PR TITLE
fix(litellm): fall back to /v1/models when /model/info is forbidden

### DIFF
--- a/sdk/packages/core/src/services/llms/provider-defaults.test.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.test.ts
@@ -480,6 +480,61 @@ describe("resolveProviderConfig", () => {
 		expect(resolved?.knownModels?.["gpt-5.4"]).toBeUndefined();
 	});
 
+	it("falls back to OpenAI-compatible /v1/models when /model/info is forbidden for LiteLLM", async () => {
+		// LiteLLM virtual keys get 403 on /v1/model/info and /model/info
+		// (admin-only routes), but can reach the OpenAI-compatible /v1/models.
+		const forbidden = new Response('{"error":"forbidden"}', { status: 403 });
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(forbidden) // /v1/model/info x-litellm-api-key
+			.mockResolvedValueOnce(forbidden) // /v1/model/info Authorization
+			.mockResolvedValueOnce(forbidden) // /model/info x-litellm-api-key
+			.mockResolvedValueOnce(forbidden) // /model/info Authorization
+			.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						data: [
+							{ id: "openai/gpt-4o-mini", object: "model", owned_by: "openai" },
+							{ id: "anthropic/claude-3-5-sonnet", object: "model" },
+						],
+					}),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				),
+			);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const resolved = await resolveProviderConfig(
+			"litellm",
+			{ failOnError: true, cacheTtlMs: 0 },
+			{
+				providerId: "litellm",
+				modelId: "",
+				apiKey: "litellm-key",
+				baseUrl: "http://localhost:4000/v1/",
+			},
+		);
+
+		expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
+			"http://localhost:4000/v1/model/info",
+			"http://localhost:4000/v1/model/info",
+			"http://localhost:4000/model/info",
+			"http://localhost:4000/model/info",
+			"http://localhost:4000/v1/models",
+		]);
+		// /v1/models returns only an id, so each model is registered by id
+		// without capability metadata or a separate display name.
+		expect(Object.keys(resolved?.knownModels ?? {}).sort()).toEqual([
+			"anthropic/claude-3-5-sonnet",
+			"openai/gpt-4o-mini",
+		]);
+		expect(resolved?.knownModels?.["openai/gpt-4o-mini"]).toEqual(
+			expect.objectContaining({
+				id: "openai/gpt-4o-mini",
+				name: "openai/gpt-4o-mini",
+			}),
+		);
+	});
+
 	it("returns an empty authoritative LiteLLM model list without auth", async () => {
 		const fetchMock = vi.fn();
 		vi.stubGlobal("fetch", fetchMock);

--- a/sdk/packages/core/src/services/llms/provider-defaults.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.ts
@@ -543,6 +543,17 @@ interface LiteLlmModelInfoResponse {
 	};
 }
 
+/**
+ * OpenAI-compatible `/v1/models` entry, as returned by LiteLLM's virtual-key
+ * accessible route. Only `id` is required; the rest are optional metadata
+ * that LiteLLM includes when it can.
+ */
+interface LiteLlmOpenAiModelEntry {
+	id?: string;
+	object?: string;
+	owned_by?: string;
+}
+
 function normalizeLiteLlmBaseUrl(baseUrl: string | undefined): string {
 	const normalized = normalizeBaseUrl(baseUrl).replace(/\/+$/, "");
 	if (!normalized) {
@@ -552,7 +563,17 @@ function normalizeLiteLlmBaseUrl(baseUrl: string | undefined): string {
 }
 
 function buildLiteLlmModelInfoUrls(baseUrl: string): string[] {
-	return [`${baseUrl}/v1/model/info`, `${baseUrl}/model/info`];
+	// LiteLLM's `/v1/model/info` and `/model/info` expose the rich
+	// `{ model_name, litellm_params, model_info }` payload, but they are
+	// admin-only routes: virtual keys (the recommended per-developer
+	// credential) get 403 by default. The OpenAI-compatible `/v1/models`
+	// route is virtual-key accessible, so it is tried last as a fallback
+	// to keep the richer payload when it is available.
+	return [
+		`${baseUrl}/v1/model/info`,
+		`${baseUrl}/model/info`,
+		`${baseUrl}/v1/models`,
+	];
 }
 
 async function describeLiteLlmHttpFailure(response: Response): Promise<string> {
@@ -590,18 +611,16 @@ async function fetchLiteLlmPrivateModels(
 
 				if (response.ok) {
 					const payload = (await response.json()) as {
-						data?: LiteLlmModelInfoResponse[];
+						data?: LiteLlmModelInfoResponse[] | LiteLlmOpenAiModelEntry[];
 					};
 					const entries = payload?.data ?? [];
 					const models: Record<string, ModelInfo> = {};
 					for (const model of entries) {
-						const displayName = model.model_name?.trim();
-						const actualModelId = model.litellm_params?.model?.trim();
-						const modelId = actualModelId || displayName;
-						if (!modelId) {
+						const parsed = parseLiteLlmModelEntry(model);
+						if (!parsed) {
 							continue;
 						}
-						const info = model.model_info;
+						const { modelId, displayName, info } = parsed;
 						const converted = buildModelFromPrivateSource(modelId, {
 							name: displayName ?? modelId,
 							maxTokens: info?.max_output_tokens ?? info?.max_tokens,
@@ -637,6 +656,40 @@ async function fetchLiteLlmPrivateModels(
 	throw new Error(
 		`LiteLLM model refresh failed. Attempts: ${failures.join("; ")}`,
 	);
+}
+
+/**
+ * Normalizes a single model entry from a LiteLLM model-list response into the
+ * rich shape, or `undefined` when the entry carries no usable identifier.
+ *
+ * LiteLLM's `/v1/model/info` and `/model/info` routes return entries with
+ * `model_name`, `litellm_params.model`, and `model_info`. The
+ * OpenAI-compatible `/v1/models` route (the only one virtual keys can reach
+ * by default) returns entries with just `id`, so capability metadata is
+ * unavailable there and is left undefined.
+ */
+function parseLiteLlmModelEntry(
+	model: LiteLlmModelInfoResponse | LiteLlmOpenAiModelEntry,
+):
+	| {
+			modelId: string;
+			displayName?: string;
+			info?: LiteLlmModelInfoResponse["model_info"];
+	  }
+	| undefined {
+	const litellmEntry = model as LiteLlmModelInfoResponse;
+	const displayName = litellmEntry.model_name?.trim();
+	const actualModelId = litellmEntry.litellm_params?.model?.trim();
+	if (actualModelId || displayName) {
+		return {
+			modelId: actualModelId || displayName!,
+			displayName,
+			info: litellmEntry.model_info,
+		};
+	}
+	// OpenAI-compatible `/v1/models` shape: only `id` is present.
+	const openAiId = (model as LiteLlmOpenAiModelEntry).id?.trim();
+	return openAiId ? { modelId: openAiId } : undefined;
 }
 
 type PrivateProviderModelFetcher = (


### PR DESCRIPTION
### Related Issue

**Issue:** #12406

### Description

LiteLLM's `/v1/model/info` and `/model/info` routes are admin-only: virtual keys (the recommended per-developer credential) get 403 by default. Cline only tried those two routes, so against a LiteLLM instance using virtual keys the model dropdown came back empty and chat calls failed with `Failed to fetch LiteLLM model info: Forbidden`.

This adds the OpenAI-compatible `/v1/models` route (which virtual keys can reach) as a final fallback in `buildLiteLlmModelInfoUrls`. The richer `/model/info` payload is still preferred when reachable.

`/v1/models` returns OpenAI-shaped entries (`{ id, object, owned_by }`) without `litellm_params` or `model_info`, so a small `parseLiteLlmModelEntry` helper distinguishes the two response shapes. Capability metadata (max tokens, vision, reasoning, prompt caching) is left undefined when only the id is available; the model is still registered by id so the dropdown and chat work.

### Test Procedure

- Added a vitest case `falls back to OpenAI-compatible /v1/models when /model/info is forbidden for LiteLLM` that mocks 403s for both auth headers on `/v1/model/info` and `/model/info`, then a 200 on `/v1/models` with OpenAI-shaped entries. It asserts the URL sequence and that both models are registered by id without a separate display name.
- Re-ran the existing `falls back to /model/info for LiteLLM private models` test to confirm the richer payload path (and the early-exit before reaching `/v1/models`) still works.
- `bun run -F @cline/core test:unit` for `provider-defaults.test.ts`: 17/17 passing (was 16, +1 new).
- `bun run -F @cline/core typecheck`: clean.
- `biome check` on both changed files: clean.

What could break: only the LiteLLM model discovery path. Other providers are untouched. The fallback only triggers when both `/model/info` routes fail, so existing admin-key setups keep using the richer payload.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

This is a small bug fix per the PR template's "Limited exceptions" clause (small bug fixes may be submitted directly without prior discussion). No CLA on file for cline; happy to sign one if required.

AI-assisted: this PR was authored with AI assistance and has been reviewed by the contributor.
