### PR TITLE
feat(vscode): add Moonshot Kimi K3 support

### DIFF
--- a/apps/vscode/src/core/api/providers/__tests__/moonshot.test.ts
+++ b/apps/vscode/src/core/api/providers/__tests__/moonshot.test.ts
@@ -53,7 +53,7 @@ describe("MoonshotHandler", () => {
 		should(payload.max_tokens).equal(moonshotModels["kimi-k2.6"].maxTokens)
 	})
 
-	it("supports kimi-k3 with its required request parameters", async () => {
+	it("supports kimi-k3 request requirements and scopes reasoning replay", async () => {
 		const handler = new MoonshotHandler({
 			moonshotApiKey: "test-api-key",
 			apiModelId: "kimi-k3",
@@ -69,12 +69,30 @@ describe("MoonshotHandler", () => {
 		})
 
 		const messages: ClineStorageMessage[] = [
-			{ role: "user", content: "first question" },
+			{ role: "user", content: "foreign-provider question" },
 			{
 				role: "assistant",
 				content: [
-					{ type: "thinking", thinking: "Previous reasoning", signature: "" },
-					{ type: "text", text: "First answer" },
+					{ type: "thinking", thinking: "Foreign reasoning", signature: "" },
+					{ type: "text", text: "Foreign answer" },
+				],
+				modelInfo: { providerId: "anthropic", modelId: "claude-sonnet-4", mode: "act" },
+			},
+			{ role: "user", content: "K3 question" },
+			{
+				role: "assistant",
+				content: [
+					{ type: "thinking", thinking: "K3 reasoning", signature: "" },
+					{ type: "text", text: "K3 answer" },
+				],
+				modelInfo: { providerId: "moonshot", modelId: "kimi-k3", mode: "act" },
+			},
+			{ role: "user", content: "legacy question" },
+			{
+				role: "assistant",
+				content: [
+					{ type: "thinking", thinking: "Unattributed reasoning", signature: "" },
+					{ type: "text", text: "Legacy answer" },
 				],
 			},
 			{ role: "user", content: "follow-up question" },
@@ -88,7 +106,9 @@ describe("MoonshotHandler", () => {
 		should(payload.max_completion_tokens).equal(moonshotModels["kimi-k3"].maxTokens)
 		should(payload.max_tokens).equal(undefined)
 		should(payload.temperature).equal(undefined)
-		const assistantMessage = payload.messages?.find((message) => message.role === "assistant")
-		should(assistantMessage?.reasoning_content).equal("Previous reasoning")
+		const assistantReasoning = payload.messages
+			?.filter((message) => message.role === "assistant")
+			.map((message) => message.reasoning_content)
+		should(assistantReasoning).deepEqual([undefined, "K3 reasoning", undefined])
 	})
 })

--- a/apps/vscode/src/core/api/providers/__tests__/moonshot.test.ts
+++ b/apps/vscode/src/core/api/providers/__tests__/moonshot.test.ts
@@ -6,8 +6,10 @@ import { MoonshotHandler } from "../moonshot"
 
 interface MoonshotRequestPayload {
 	model: string
-	temperature: number
-	max_tokens: number
+	messages?: Array<{ role: string; reasoning_content?: string }>
+	temperature?: number
+	max_tokens?: number
+	max_completion_tokens?: number
 }
 
 describe("MoonshotHandler", () => {
@@ -47,7 +49,46 @@ describe("MoonshotHandler", () => {
 
 		const payload = createStub.firstCall.args[0] as MoonshotRequestPayload
 		payload.model.should.equal("kimi-k2.6")
-		payload.temperature.should.equal(moonshotModels["kimi-k2.6"].temperature)
-		payload.max_tokens.should.equal(moonshotModels["kimi-k2.6"].maxTokens)
+		should(payload.temperature).equal(moonshotModels["kimi-k2.6"].temperature)
+		should(payload.max_tokens).equal(moonshotModels["kimi-k2.6"].maxTokens)
+	})
+
+	it("supports kimi-k3 with its required request parameters", async () => {
+		const handler = new MoonshotHandler({
+			moonshotApiKey: "test-api-key",
+			apiModelId: "kimi-k3",
+		})
+
+		const createStub = sinon.stub().resolves(createAsyncIterable([]))
+		sinon.stub(handler as unknown as { ensureClient: () => unknown }, "ensureClient").returns({
+			chat: {
+				completions: {
+					create: createStub,
+				},
+			},
+		})
+
+		const messages: ClineStorageMessage[] = [
+			{ role: "user", content: "first question" },
+			{
+				role: "assistant",
+				content: [
+					{ type: "thinking", thinking: "Previous reasoning", signature: "" },
+					{ type: "text", text: "First answer" },
+				],
+			},
+			{ role: "user", content: "follow-up question" },
+		]
+		for await (const _chunk of handler.createMessage("system", messages)) {
+			// Consume stream to trigger request execution.
+		}
+
+		const payload = createStub.firstCall.args[0] as MoonshotRequestPayload
+		payload.model.should.equal("kimi-k3")
+		should(payload.max_completion_tokens).equal(moonshotModels["kimi-k3"].maxTokens)
+		should(payload.max_tokens).equal(undefined)
+		should(payload.temperature).equal(undefined)
+		const assistantMessage = payload.messages?.find((message) => message.role === "assistant")
+		should(assistantMessage?.reasoning_content).equal("Previous reasoning")
 	})
 })

--- a/apps/vscode/src/core/api/providers/moonshot.ts
+++ b/apps/vscode/src/core/api/providers/moonshot.ts
@@ -52,7 +52,13 @@ export class MoonshotHandler implements ApiHandler {
 		const convertedMessages = convertToOpenAiMessages(messages)
 		const openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = [
 			{ role: "system", content: systemPrompt },
-			...(model.id === "kimi-k3" ? addReasoningContent(convertedMessages, messages, true) : convertedMessages),
+			...(model.id === "kimi-k3"
+				? addReasoningContent(convertedMessages, messages, {
+						includePreviousTurns: true,
+						shouldIncludeReasoning: (message) =>
+							message.modelInfo?.providerId === "moonshot" && message.modelInfo.modelId === "kimi-k3",
+					})
+				: convertedMessages),
 		]
 
 		const stream = await client.chat.completions.create({

--- a/apps/vscode/src/core/api/providers/moonshot.ts
+++ b/apps/vscode/src/core/api/providers/moonshot.ts
@@ -6,6 +6,7 @@ import { createOpenAIClient } from "@/shared/net"
 import { ApiHandler, CommonApiHandlerOptions } from "../index"
 import { withRetry } from "../retry"
 import { convertToOpenAiMessages } from "../transform/openai-format"
+import { addReasoningContent } from "../transform/r1-format"
 import { ApiStream } from "../transform/stream"
 import { getOpenAIToolParams, ToolCallProcessor } from "../transform/tool-call-processor"
 
@@ -48,16 +49,19 @@ export class MoonshotHandler implements ApiHandler {
 		const client = this.ensureClient()
 		const model = this.getModel()
 
+		const convertedMessages = convertToOpenAiMessages(messages)
 		const openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = [
 			{ role: "system", content: systemPrompt },
-			...convertToOpenAiMessages(messages),
+			...(model.id === "kimi-k3" ? addReasoningContent(convertedMessages, messages, true) : convertedMessages),
 		]
 
 		const stream = await client.chat.completions.create({
 			model: model.id,
 			messages: openAiMessages,
-			temperature: model.info.temperature,
-			max_tokens: model.info.maxTokens,
+			// Kimi K3 fixes its sampling parameters and uses max_completion_tokens.
+			...(model.id === "kimi-k3"
+				? { max_completion_tokens: model.info.maxTokens }
+				: { max_tokens: model.info.maxTokens, temperature: model.info.temperature }),
 			stream: true,
 			stream_options: { include_usage: true },
 			...getOpenAIToolParams(tools),

--- a/apps/vscode/src/core/api/transform/r1-format.ts
+++ b/apps/vscode/src/core/api/transform/r1-format.ts
@@ -14,13 +14,14 @@ export type DeepSeekReasonerMessage = OpenAI.Chat.ChatCompletionMessageParam & {
 };
 
 /**
- * Adds reasoning_content to OpenAI messages for DeepSeek Reasoner.
- * Per DeepSeek API: reasoning_content should be passed back during tool calling in the same turn,
- * and omitted when starting a new turn.
+ * Adds reasoning_content to OpenAI-compatible messages.
+ * DeepSeek only needs it during tool calling in the current turn. Providers such as Moonshot K3
+ * can set includePreviousTurns when their API requires the complete assistant history.
  */
 export function addReasoningContent(
 	openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[],
 	originalMessages: ClineStorageMessage[],
+	includePreviousTurns = false,
 ): DeepSeekReasonerMessage[] {
 	// Find last user message index (start of current turn)
 	// If no user message exists (lastUserIndex = -1), all messages are in the "current turn",
@@ -53,12 +54,12 @@ export function addReasoningContent(
 		}
 	}
 
-	// Add reasoning_content only to assistant messages in current turn
+	// Add reasoning_content to assistant messages in the requested scope.
 	let aiIdx = 0;
 	return openAiMessages.map((msg, i): DeepSeekReasonerMessage => {
 		if (msg.role === "assistant") {
 			const thinking = thinkingByIndex.get(aiIdx++);
-			if (thinking && i >= lastUserIndex) {
+			if (thinking && (includePreviousTurns || i >= lastUserIndex)) {
 				return { ...msg, reasoning_content: thinking };
 			}
 		}

--- a/apps/vscode/src/core/api/transform/r1-format.ts
+++ b/apps/vscode/src/core/api/transform/r1-format.ts
@@ -16,13 +16,18 @@ export type DeepSeekReasonerMessage = OpenAI.Chat.ChatCompletionMessageParam & {
 /**
  * Adds reasoning_content to OpenAI-compatible messages.
  * DeepSeek only needs it during tool calling in the current turn. Providers such as Moonshot K3
- * can set includePreviousTurns when their API requires the complete assistant history.
+ * can include previous turns and filter reasoning by its originating message.
  */
 export function addReasoningContent(
 	openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[],
 	originalMessages: ClineStorageMessage[],
-	includePreviousTurns = false,
+	options: {
+		includePreviousTurns?: boolean;
+		shouldIncludeReasoning?: (message: ClineStorageMessage) => boolean;
+	} = {},
 ): DeepSeekReasonerMessage[] {
+	const { includePreviousTurns = false, shouldIncludeReasoning = () => true } = options;
+
 	// Find last user message index (start of current turn)
 	// If no user message exists (lastUserIndex = -1), all messages are in the "current turn",
 	// so reasoning_content will be added to all assistant messages. This is intentional.
@@ -39,7 +44,7 @@ export function addReasoningContent(
 	let assistantIdx = 0;
 	for (const msg of originalMessages) {
 		if (msg.role === "assistant") {
-			if (Array.isArray(msg.content)) {
+			if (Array.isArray(msg.content) && shouldIncludeReasoning(msg)) {
 				const thinking = msg.content
 					.filter(
 						(p): p is ClineAssistantThinkingBlock => p.type === "thinking",

--- a/apps/vscode/src/shared/api.ts
+++ b/apps/vscode/src/shared/api.ts
@@ -4901,6 +4901,16 @@ export const sapAiCoreModels = {
 // Moonshot AI Studio
 // https://platform.moonshot.ai/docs/pricing/chat
 export const moonshotModels = {
+	"kimi-k3": {
+		maxTokens: 131_072,
+		contextWindow: 1_048_576,
+		supportsImages: true,
+		supportsPromptCache: true,
+		supportsReasoning: true,
+		inputPrice: 3.0,
+		outputPrice: 15.0,
+		cacheReadsPrice: 0.3,
+	},
 	"kimi-k2.6": {
 		maxTokens: 32_000,
 		contextWindow: 262_144,


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Adds first-class Kimi K3 support to the Moonshot provider in the shipping VS Code extension.

* Adds `kimi-k3` to the Moonshot model picker with its 1,048,576-token context window, 131,072-token default output limit, multimodal/reasoning capabilities, prompt-cache support, and current token pricing.
* Uses K3's `max_completion_tokens` request field and omits fixed sampling parameters, while preserving the existing request shape for older Kimi models.
* Replays K3 `reasoning_content` across assistant history so follow-up tool calls retain the complete assistant messages required by Moonshot's API.

The request behavior follows Moonshot's K3 API documentation: [https://platform.kimi.ai/docs/guide/kimi-k3-quickstart](<https://platform.kimi.ai/docs/guide/kimi-k3-quickstart>)

### Test Procedure

* From `apps/vscode`, ran the full unit suite with `TS_NODE_PROJECT=./tsconfig.unit-test.json npx mocha --require tsconfig-paths/register` (1,530 passing).
* Ran the focused Moonshot provider suite, including K3 metadata, request parameters, legacy K2.6 compatibility, and multi-turn reasoning replay (2 passing).
* Ran `npm run package`, which passed protobuf generation, extension and webview type checks, the production webview build, lint, and the production extension bundle.
* Ran `git diff --check`.

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [X] I have reviewed [contributor guidelines](<https://github.com/cline/cline/blob/main/CONTRIBUTING.md>)

### Screenshots

Not included. The UI change is the additional model entry supplied to the existing Moonshot model selector; the production webview bundle was built successfully.

### Additional Notes

* A live Moonshot inference call was not run because this worktree does not have a Moonshot API key; the provider request and multi-turn behavior are covered with stubbed transport tests.
* This targets `legacy-extension`, which is the current VS Code extension release line. The SDK catalog on `main` already contains Kimi K3.
* This PR does not add the separate Kimi Code subscription endpoint requested in cline/cline#12399.