### PR TITLE
feat(telemetry): emit host_plugin_version metadata on all events

### DIFF
--- a/apps/vscode/src/sdk/sdk-telemetry.test.ts
+++ b/apps/vscode/src/sdk/sdk-telemetry.test.ts
@@ -16,6 +16,12 @@ vi.mock("@cline/core", () => ({
 const telemetryState = vi.hoisted(() => ({
 	clineTelemetrySetting: "unset" as string | undefined,
 	hostSetting: 1,
+	hostVersion: {
+		platform: "VS Code",
+		version: "1.103.0",
+		clineType: "VSCode Extension",
+	} as { platform: string; version: string; clineType: string; clineVersion?: string },
+	hostVersionError: undefined as Error | undefined,
 	subscribeCallback: undefined as ((event: { isEnabled: number }) => void) | undefined,
 	unsubscribe: vi.fn(),
 }))
@@ -33,6 +39,12 @@ vi.mock("@/hosts/host-provider", () => ({
 	HostProvider: {
 		env: {
 			getTelemetrySettings: vi.fn(async () => ({ isEnabled: telemetryState.hostSetting })),
+			getHostVersion: vi.fn(async () => {
+				if (telemetryState.hostVersionError) {
+					throw telemetryState.hostVersionError
+				}
+				return telemetryState.hostVersion
+			}),
 			subscribeToTelemetrySettings: vi.fn((_request, callbacks: { onResponse: (event: { isEnabled: number }) => void }) => {
 				telemetryState.subscribeCallback = callbacks.onResponse
 				return telemetryState.unsubscribe
@@ -47,6 +59,12 @@ describe("VscodeTelemetryPolicyService", () => {
 	beforeEach(() => {
 		telemetryState.clineTelemetrySetting = "unset"
 		telemetryState.hostSetting = Setting.ENABLED
+		telemetryState.hostVersion = {
+			platform: "VS Code",
+			version: "1.103.0",
+			clineType: "VSCode Extension",
+		}
+		telemetryState.hostVersionError = undefined
 		telemetryState.subscribeCallback = undefined
 		telemetryState.unsubscribe.mockReset()
 		coreTelemetryMocks.createConfig.mockClear()
@@ -156,6 +174,49 @@ describe("VscodeTelemetryPolicyService", () => {
 		expect(handle.telemetry.recordCounter).toHaveBeenCalledWith("required", 1, undefined, undefined, true)
 	})
 
+	it("applies host_plugin_version metadata before enabling events when the host reports one", async () => {
+		telemetryState.hostVersion = {
+			platform: "IntelliJ IDEA Ultimate",
+			version: "2026.1.1",
+			clineType: "Cline for JetBrains",
+			clineVersion: "1.1.61",
+		}
+		const handle = createHandle()
+		const service = new VscodeTelemetryPolicyService(handle)
+		await settlePromises()
+
+		service.capture({ event: "task.created" })
+
+		expect(handle.telemetry.updateMetadata).toHaveBeenCalledWith({ host_plugin_version: "1.1.61" })
+		expect(handle.telemetry.capture).toHaveBeenCalledWith({ event: "task.created" })
+		const updateOrder = handle.telemetry.updateMetadata.mock.invocationCallOrder[0]
+		const captureOrder = handle.telemetry.capture.mock.invocationCallOrder[0]
+		expect(updateOrder).toBeLessThan(captureOrder)
+	})
+
+	it("omits host_plugin_version metadata when the host does not report one", async () => {
+		const handle = createHandle()
+		const service = new VscodeTelemetryPolicyService(handle)
+		await settlePromises()
+
+		service.capture({ event: "task.created" })
+
+		expect(handle.telemetry.updateMetadata).not.toHaveBeenCalled()
+		expect(handle.telemetry.capture).toHaveBeenCalledWith({ event: "task.created" })
+	})
+
+	it("still enables telemetry when the host version lookup fails", async () => {
+		telemetryState.hostVersionError = new Error("host bridge unavailable")
+		const handle = createHandle()
+		const service = new VscodeTelemetryPolicyService(handle)
+		await settlePromises()
+
+		service.capture({ event: "task.created" })
+
+		expect(handle.telemetry.updateMetadata).not.toHaveBeenCalled()
+		expect(handle.telemetry.capture).toHaveBeenCalledWith({ event: "task.created" })
+	})
+
 	it("always forwards metadata mutators and cleans up on dispose", async () => {
 		const handle = createHandle()
 		const service = new VscodeTelemetryPolicyService(handle)
@@ -196,10 +257,12 @@ type MockTelemetry = ITelemetryService & {
 	capture: ITelemetryService["capture"] & Mock<ITelemetryService["capture"]>
 	captureRequired: ITelemetryService["captureRequired"] & Mock<ITelemetryService["captureRequired"]>
 	recordCounter: ITelemetryService["recordCounter"] & Mock<ITelemetryService["recordCounter"]>
+	updateMetadata: ITelemetryService["updateMetadata"] & Mock<ITelemetryService["updateMetadata"]>
 	updateCommonProperties: ITelemetryService["updateCommonProperties"] & Mock<ITelemetryService["updateCommonProperties"]>
 }
 
 async function settlePromises(): Promise<void> {
-	await Promise.resolve()
-	await Promise.resolve()
+	for (let i = 0; i < 6; i++) {
+		await Promise.resolve()
+	}
 }

--- a/apps/vscode/src/sdk/sdk-telemetry.ts
+++ b/apps/vscode/src/sdk/sdk-telemetry.ts
@@ -146,9 +146,14 @@ export class VscodeTelemetryPolicyService implements ITelemetryService {
 	}
 
 	private initializeHostTelemetryState(): void {
-		HostProvider.env
-			.getTelemetrySettings({})
-			.then((settings) => {
+		// Resolve host-derived metadata together with the telemetry setting and apply
+		// it first: events stay gated until the setting is applied, so this ordering
+		// guarantees no event is emitted before host_plugin_version is in place.
+		Promise.all([this.resolveHostPluginVersion(), HostProvider.env.getTelemetrySettings({})])
+			.then(([hostPluginVersion, settings]) => {
+				if (hostPluginVersion) {
+					this.handle.telemetry.updateMetadata({ host_plugin_version: hostPluginVersion })
+				}
 				this.applyHostTelemetrySetting(settings.isEnabled)
 			})
 			.catch((error) => {
@@ -169,6 +174,16 @@ export class VscodeTelemetryPolicyService implements ITelemetryService {
 			)
 		} catch (error) {
 			Logger.warn("[SdkTelemetry] Failed to subscribe to host telemetry changes", error)
+		}
+	}
+
+	private async resolveHostPluginVersion(): Promise<string | undefined> {
+		try {
+			const hostVersion = await HostProvider.env.getHostVersion({})
+			return hostVersion.clineVersion || undefined
+		} catch (error) {
+			Logger.warn("[SdkTelemetry] Failed to resolve host version for telemetry metadata", error)
+			return undefined
 		}
 	}
 

--- a/apps/vscode/src/services/telemetry/TelemetryService.test.ts
+++ b/apps/vscode/src/services/telemetry/TelemetryService.test.ts
@@ -99,6 +99,50 @@ describe("Telemetry system is abstracted and can easily switch between providers
 			await localService.dispose()
 		})
 
+		it("should derive host_plugin_version from the host's clineVersion", async () => {
+			const jetbrainsProvider = new NoOpTelemetryProvider()
+			const noVersionProvider = new NoOpTelemetryProvider()
+			const jetbrainsLogSpy = sinon.spy(jetbrainsProvider, "log")
+			const noVersionLogSpy = sinon.spy(noVersionProvider, "log")
+			const hostVersionStub = sinon.stub(HostProvider.env, "getHostVersion")
+			const createProvidersStub = sinon.stub(TelemetryProviderFactory, "createProviders")
+
+			hostVersionStub.onFirstCall().resolves({
+				platform: "IntelliJ IDEA Ultimate",
+				version: "2026.1.1",
+				clineType: "Cline for JetBrains",
+				clineVersion: "1.1.61",
+			})
+			hostVersionStub.onSecondCall().resolves({
+				platform: "VS Code",
+				version: "1.103.0",
+				clineType: "VSCode Extension",
+			})
+			createProvidersStub.onFirstCall().resolves([jetbrainsProvider])
+			createProvidersStub.onSecondCall().resolves([noVersionProvider])
+
+			const jetbrainsService = await TelemetryService.create()
+			const noVersionService = await TelemetryService.create()
+
+			jetbrainsLogSpy.resetHistory()
+			noVersionLogSpy.resetHistory()
+
+			jetbrainsService.captureTaskCreated("task-jb", "openai")
+			noVersionService.captureTaskCreated("task-no-version", "openai")
+
+			assert.ok(jetbrainsLogSpy.calledOnce, "JetBrains service should emit an event")
+			assert.ok(noVersionLogSpy.calledOnce, "no-version service should emit an event")
+			assert.strictEqual(jetbrainsLogSpy.firstCall.args[1]?.host_plugin_version, "1.1.61")
+			assert.strictEqual(noVersionLogSpy.firstCall.args[1]?.host_plugin_version, undefined)
+
+			hostVersionStub.restore()
+			createProvidersStub.restore()
+			jetbrainsLogSpy.restore()
+			noVersionLogSpy.restore()
+			await jetbrainsService.dispose()
+			await noVersionService.dispose()
+		})
+
 		it("should include remote workspace metadata on workspace.initialized events", async () => {
 			const noOpProvider = new NoOpTelemetryProvider()
 			const logSpy = sinon.spy(noOpProvider, "log")

--- a/apps/vscode/src/services/telemetry/TelemetryService.test.ts
+++ b/apps/vscode/src/services/telemetry/TelemetryService.test.ts
@@ -121,22 +121,24 @@ describe("Telemetry system is abstracted and can easily switch between providers
 			]
 
 			for (const { hostVersion, expectedHostPluginVersion } of cases) {
-				const provider = new NoOpTelemetryProvider()
-				const logSpy = sinon.spy(provider, "log")
-				const hostVersionStub = sinon.stub(HostProvider.env, "getHostVersion").resolves(hostVersion)
-				const createProvidersStub = sinon.stub(TelemetryProviderFactory, "createProviders").resolves([provider])
+				const sandbox = sinon.createSandbox()
+				let service: TelemetryService | undefined
+				try {
+					const provider = new NoOpTelemetryProvider()
+					const logSpy = sandbox.spy(provider, "log")
+					sandbox.stub(HostProvider.env, "getHostVersion").resolves(hostVersion)
+					sandbox.stub(TelemetryProviderFactory, "createProviders").resolves([provider])
 
-				const service = await TelemetryService.create()
-				logSpy.resetHistory()
-				service.captureTaskCreated("task-123", "openai")
+					service = await TelemetryService.create()
+					logSpy.resetHistory()
+					service.captureTaskCreated("task-123", "openai")
 
-				assert.ok(logSpy.calledOnce, `service should emit an event (${hostVersion.clineType})`)
-				assert.strictEqual(logSpy.firstCall.args[1]?.host_plugin_version, expectedHostPluginVersion)
-
-				hostVersionStub.restore()
-				createProvidersStub.restore()
-				logSpy.restore()
-				await service.dispose()
+					assert.ok(logSpy.calledOnce, `service should emit an event (${hostVersion.clineType})`)
+					assert.strictEqual(logSpy.firstCall.args[1]?.host_plugin_version, expectedHostPluginVersion)
+				} finally {
+					sandbox.restore()
+					await service?.dispose()
+				}
 			}
 		})
 

--- a/apps/vscode/src/services/telemetry/TelemetryService.test.ts
+++ b/apps/vscode/src/services/telemetry/TelemetryService.test.ts
@@ -100,47 +100,44 @@ describe("Telemetry system is abstracted and can easily switch between providers
 		})
 
 		it("should derive host_plugin_version from the host's clineVersion", async () => {
-			const jetbrainsProvider = new NoOpTelemetryProvider()
-			const noVersionProvider = new NoOpTelemetryProvider()
-			const jetbrainsLogSpy = sinon.spy(jetbrainsProvider, "log")
-			const noVersionLogSpy = sinon.spy(noVersionProvider, "log")
-			const hostVersionStub = sinon.stub(HostProvider.env, "getHostVersion")
-			const createProvidersStub = sinon.stub(TelemetryProviderFactory, "createProviders")
+			const cases = [
+				{
+					hostVersion: {
+						platform: "IntelliJ IDEA Ultimate",
+						version: "2026.1.1",
+						clineType: "Cline for JetBrains",
+						clineVersion: "1.1.61",
+					},
+					expectedHostPluginVersion: "1.1.61" as string | undefined,
+				},
+				{
+					hostVersion: {
+						platform: "VS Code",
+						version: "1.103.0",
+						clineType: "VSCode Extension",
+					},
+					expectedHostPluginVersion: undefined,
+				},
+			]
 
-			hostVersionStub.onFirstCall().resolves({
-				platform: "IntelliJ IDEA Ultimate",
-				version: "2026.1.1",
-				clineType: "Cline for JetBrains",
-				clineVersion: "1.1.61",
-			})
-			hostVersionStub.onSecondCall().resolves({
-				platform: "VS Code",
-				version: "1.103.0",
-				clineType: "VSCode Extension",
-			})
-			createProvidersStub.onFirstCall().resolves([jetbrainsProvider])
-			createProvidersStub.onSecondCall().resolves([noVersionProvider])
+			for (const { hostVersion, expectedHostPluginVersion } of cases) {
+				const provider = new NoOpTelemetryProvider()
+				const logSpy = sinon.spy(provider, "log")
+				const hostVersionStub = sinon.stub(HostProvider.env, "getHostVersion").resolves(hostVersion)
+				const createProvidersStub = sinon.stub(TelemetryProviderFactory, "createProviders").resolves([provider])
 
-			const jetbrainsService = await TelemetryService.create()
-			const noVersionService = await TelemetryService.create()
+				const service = await TelemetryService.create()
+				logSpy.resetHistory()
+				service.captureTaskCreated("task-123", "openai")
 
-			jetbrainsLogSpy.resetHistory()
-			noVersionLogSpy.resetHistory()
+				assert.ok(logSpy.calledOnce, `service should emit an event (${hostVersion.clineType})`)
+				assert.strictEqual(logSpy.firstCall.args[1]?.host_plugin_version, expectedHostPluginVersion)
 
-			jetbrainsService.captureTaskCreated("task-jb", "openai")
-			noVersionService.captureTaskCreated("task-no-version", "openai")
-
-			assert.ok(jetbrainsLogSpy.calledOnce, "JetBrains service should emit an event")
-			assert.ok(noVersionLogSpy.calledOnce, "no-version service should emit an event")
-			assert.strictEqual(jetbrainsLogSpy.firstCall.args[1]?.host_plugin_version, "1.1.61")
-			assert.strictEqual(noVersionLogSpy.firstCall.args[1]?.host_plugin_version, undefined)
-
-			hostVersionStub.restore()
-			createProvidersStub.restore()
-			jetbrainsLogSpy.restore()
-			noVersionLogSpy.restore()
-			await jetbrainsService.dispose()
-			await noVersionService.dispose()
+				hostVersionStub.restore()
+				createProvidersStub.restore()
+				logSpy.restore()
+				await service.dispose()
+			}
 		})
 
 		it("should include remote workspace metadata on workspace.initialized events", async () => {

--- a/apps/vscode/src/services/telemetry/TelemetryService.ts
+++ b/apps/vscode/src/services/telemetry/TelemetryService.ts
@@ -105,6 +105,12 @@ export type TelemetryMetadata = {
 	 * all use the same extension or plugin.
 	 */
 	cline_type: string
+	/**
+	 * The version of the host-side Cline distribution package: the JetBrains plugin version
+	 * (e.g. 1.1.61) on JetBrains, the extension version on VSCode (where it matches
+	 * `extension_version`). Absent when the host does not report one (e.g. CLI).
+	 */
+	host_plugin_version?: string
 	/** The name of the host IDE or environment e.g. VSCode, Cursor, IntelliJ Professional Edition, etc. */
 	platform: string
 	/** The version of the host environment */
@@ -410,6 +416,7 @@ export class TelemetryService {
 		const hostVersion = await HostProvider.env.getHostVersion({})
 		const metadata: TelemetryMetadata = {
 			extension_version: extensionVersion,
+			...(hostVersion.clineVersion ? { host_plugin_version: hostVersion.clineVersion } : {}),
 			platform: hostVersion.platform || "unknown",
 			platform_version: hostVersion.version || "unknown",
 			cline_type: hostVersion.clineType || "unknown",

--- a/sdk/packages/shared/src/services/telemetry.ts
+++ b/sdk/packages/shared/src/services/telemetry.ts
@@ -82,6 +82,12 @@ export interface CaptureTaskLifecycleEventInput {
 
 export interface TelemetryMetadata {
 	extension_version: string;
+	/**
+	 * The version of the host-side Cline distribution package: the JetBrains plugin version
+	 * (e.g. 1.1.61) on JetBrains, the extension version on VSCode (where it matches
+	 * `extension_version`). Absent when the host does not report one.
+	 */
+	host_plugin_version?: string;
 	cline_type: string;
 	platform: string;
 	platform_version: string;


### PR DESCRIPTION
## Problem

There is currently no way to tell which JetBrains plugin version a telemetry event came from:

- `extension_version` is the **cline-core bundle version** (`apps/vscode/package.json`), not the plugin version — on JetBrains rows it's a 3.x core version, not the 1.1.x Marketplace release.
- `platform_version` is the **IDE** version (e.g. `2026.1.1`).
- The JetBrains host already sends its real plugin version over the hostbridge (`getHostVersion.clineVersion`, populated from `PluginManager` on the Kotlin side), but neither telemetry pipeline attached it — the classic `TelemetryService` ignored the field, and the SDK telemetry service's metadata is built independently without it.

## Change

Attach the host-reported plugin version as a new optional `host_plugin_version` metadata property on **both** telemetry pipelines, so it rides along on every event:

- **Classic `TelemetryService`**: populated in `create()` from the `getHostVersion` response.
- **SDK pipeline** (`SdkController` → `VscodeTelemetryPolicyService`): the field was added to the shared SDK `TelemetryMetadata` contract, and the policy service resolves it from the authoritative `getHostVersion` response during init. The metadata update is sequenced before the host telemetry setting is applied, and all events stay gated until that setting lands — so no event can be emitted without the field in place. A failed host-version lookup degrades to the previous behavior (field absent, telemetry still enabled).

Values by host:

- **JetBrains**: the Marketplace plugin version, e.g. `1.1.61`
- **VSCode**: the extension version (matches `extension_version` there)
- **Hosts that don't report one** (e.g. CLI): field omitted

No host-side changes needed — the value was already transmitted.

## Testing

- Classic pipeline: mocha test covering the populated (JetBrains-shaped `getHostVersion` response) and absent cases, with sandbox-guaranteed stub cleanup; runs under the `@vscode/test-cli` host (`vscode-test --grep host_plugin_version`), passing.
- SDK pipeline: vitest boundary tests asserting the metadata update lands before the first forwarded event (invocation order), the absent-version case, and that a host-bridge failure still enables telemetry. Full `src/sdk/` vitest directory passing (787 tests).
- Full bun unit suite passing.

Companion PR against `legacy-extension`: #12480 (classic pipeline only — that branch has no SDK telemetry pipeline), so the field shows up in currently-shipping JetBrains telemetry too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)