### PR TITLE
feat(telemetry): emit host_plugin_version metadata on all events (legacy)

### DIFF
--- a/apps/vscode/src/services/telemetry/TelemetryService.test.ts
+++ b/apps/vscode/src/services/telemetry/TelemetryService.test.ts
@@ -99,47 +99,44 @@ describe("Telemetry system is abstracted and can easily switch between providers
 		})
 
 		it("should derive host_plugin_version from the host's clineVersion", async () => {
-			const jetbrainsProvider = new NoOpTelemetryProvider()
-			const noVersionProvider = new NoOpTelemetryProvider()
-			const jetbrainsLogSpy = sinon.spy(jetbrainsProvider, "log")
-			const noVersionLogSpy = sinon.spy(noVersionProvider, "log")
-			const hostVersionStub = sinon.stub(HostProvider.env, "getHostVersion")
-			const createProvidersStub = sinon.stub(TelemetryProviderFactory, "createProviders")
+			const cases = [
+				{
+					hostVersion: {
+						platform: "IntelliJ IDEA Ultimate",
+						version: "2026.1.1",
+						clineType: "Cline for JetBrains",
+						clineVersion: "1.1.61",
+					},
+					expectedHostPluginVersion: "1.1.61" as string | undefined,
+				},
+				{
+					hostVersion: {
+						platform: "VS Code",
+						version: "1.103.0",
+						clineType: "VSCode Extension",
+					},
+					expectedHostPluginVersion: undefined,
+				},
+			]
 
-			hostVersionStub.onFirstCall().resolves({
-				platform: "IntelliJ IDEA Ultimate",
-				version: "2026.1.1",
-				clineType: "Cline for JetBrains",
-				clineVersion: "1.1.61",
-			})
-			hostVersionStub.onSecondCall().resolves({
-				platform: "VS Code",
-				version: "1.103.0",
-				clineType: "VSCode Extension",
-			})
-			createProvidersStub.onFirstCall().resolves([jetbrainsProvider])
-			createProvidersStub.onSecondCall().resolves([noVersionProvider])
+			for (const { hostVersion, expectedHostPluginVersion } of cases) {
+				const provider = new NoOpTelemetryProvider()
+				const logSpy = sinon.spy(provider, "log")
+				const hostVersionStub = sinon.stub(HostProvider.env, "getHostVersion").resolves(hostVersion)
+				const createProvidersStub = sinon.stub(TelemetryProviderFactory, "createProviders").resolves([provider])
 
-			const jetbrainsService = await TelemetryService.create()
-			const noVersionService = await TelemetryService.create()
+				const service = await TelemetryService.create()
+				logSpy.resetHistory()
+				service.captureTaskCreated("task-123", "openai")
 
-			jetbrainsLogSpy.resetHistory()
-			noVersionLogSpy.resetHistory()
+				assert.ok(logSpy.calledOnce, `service should emit an event (${hostVersion.clineType})`)
+				assert.strictEqual(logSpy.firstCall.args[1]?.host_plugin_version, expectedHostPluginVersion)
 
-			jetbrainsService.captureTaskCreated("task-jb", "openai")
-			noVersionService.captureTaskCreated("task-no-version", "openai")
-
-			assert.ok(jetbrainsLogSpy.calledOnce, "JetBrains service should emit an event")
-			assert.ok(noVersionLogSpy.calledOnce, "no-version service should emit an event")
-			assert.strictEqual(jetbrainsLogSpy.firstCall.args[1]?.host_plugin_version, "1.1.61")
-			assert.strictEqual(noVersionLogSpy.firstCall.args[1]?.host_plugin_version, undefined)
-
-			hostVersionStub.restore()
-			createProvidersStub.restore()
-			jetbrainsLogSpy.restore()
-			noVersionLogSpy.restore()
-			await jetbrainsService.dispose()
-			await noVersionService.dispose()
+				hostVersionStub.restore()
+				createProvidersStub.restore()
+				logSpy.restore()
+				await service.dispose()
+			}
 		})
 
 		it("should include remote workspace metadata on workspace.initialized events", async () => {

--- a/apps/vscode/src/services/telemetry/TelemetryService.test.ts
+++ b/apps/vscode/src/services/telemetry/TelemetryService.test.ts
@@ -98,6 +98,50 @@ describe("Telemetry system is abstracted and can easily switch between providers
 			await localService.dispose()
 		})
 
+		it("should derive host_plugin_version from the host's clineVersion", async () => {
+			const jetbrainsProvider = new NoOpTelemetryProvider()
+			const noVersionProvider = new NoOpTelemetryProvider()
+			const jetbrainsLogSpy = sinon.spy(jetbrainsProvider, "log")
+			const noVersionLogSpy = sinon.spy(noVersionProvider, "log")
+			const hostVersionStub = sinon.stub(HostProvider.env, "getHostVersion")
+			const createProvidersStub = sinon.stub(TelemetryProviderFactory, "createProviders")
+
+			hostVersionStub.onFirstCall().resolves({
+				platform: "IntelliJ IDEA Ultimate",
+				version: "2026.1.1",
+				clineType: "Cline for JetBrains",
+				clineVersion: "1.1.61",
+			})
+			hostVersionStub.onSecondCall().resolves({
+				platform: "VS Code",
+				version: "1.103.0",
+				clineType: "VSCode Extension",
+			})
+			createProvidersStub.onFirstCall().resolves([jetbrainsProvider])
+			createProvidersStub.onSecondCall().resolves([noVersionProvider])
+
+			const jetbrainsService = await TelemetryService.create()
+			const noVersionService = await TelemetryService.create()
+
+			jetbrainsLogSpy.resetHistory()
+			noVersionLogSpy.resetHistory()
+
+			jetbrainsService.captureTaskCreated("task-jb", "openai")
+			noVersionService.captureTaskCreated("task-no-version", "openai")
+
+			assert.ok(jetbrainsLogSpy.calledOnce, "JetBrains service should emit an event")
+			assert.ok(noVersionLogSpy.calledOnce, "no-version service should emit an event")
+			assert.strictEqual(jetbrainsLogSpy.firstCall.args[1]?.host_plugin_version, "1.1.61")
+			assert.strictEqual(noVersionLogSpy.firstCall.args[1]?.host_plugin_version, undefined)
+
+			hostVersionStub.restore()
+			createProvidersStub.restore()
+			jetbrainsLogSpy.restore()
+			noVersionLogSpy.restore()
+			await jetbrainsService.dispose()
+			await noVersionService.dispose()
+		})
+
 		it("should include remote workspace metadata on workspace.initialized events", async () => {
 			const noOpProvider = new NoOpTelemetryProvider()
 			const logSpy = sinon.spy(noOpProvider, "log")

--- a/apps/vscode/src/services/telemetry/TelemetryService.test.ts
+++ b/apps/vscode/src/services/telemetry/TelemetryService.test.ts
@@ -120,22 +120,24 @@ describe("Telemetry system is abstracted and can easily switch between providers
 			]
 
 			for (const { hostVersion, expectedHostPluginVersion } of cases) {
-				const provider = new NoOpTelemetryProvider()
-				const logSpy = sinon.spy(provider, "log")
-				const hostVersionStub = sinon.stub(HostProvider.env, "getHostVersion").resolves(hostVersion)
-				const createProvidersStub = sinon.stub(TelemetryProviderFactory, "createProviders").resolves([provider])
+				const sandbox = sinon.createSandbox()
+				let service: TelemetryService | undefined
+				try {
+					const provider = new NoOpTelemetryProvider()
+					const logSpy = sandbox.spy(provider, "log")
+					sandbox.stub(HostProvider.env, "getHostVersion").resolves(hostVersion)
+					sandbox.stub(TelemetryProviderFactory, "createProviders").resolves([provider])
 
-				const service = await TelemetryService.create()
-				logSpy.resetHistory()
-				service.captureTaskCreated("task-123", "openai")
+					service = await TelemetryService.create()
+					logSpy.resetHistory()
+					service.captureTaskCreated("task-123", "openai")
 
-				assert.ok(logSpy.calledOnce, `service should emit an event (${hostVersion.clineType})`)
-				assert.strictEqual(logSpy.firstCall.args[1]?.host_plugin_version, expectedHostPluginVersion)
-
-				hostVersionStub.restore()
-				createProvidersStub.restore()
-				logSpy.restore()
-				await service.dispose()
+					assert.ok(logSpy.calledOnce, `service should emit an event (${hostVersion.clineType})`)
+					assert.strictEqual(logSpy.firstCall.args[1]?.host_plugin_version, expectedHostPluginVersion)
+				} finally {
+					sandbox.restore()
+					await service?.dispose()
+				}
 			}
 		})
 

--- a/apps/vscode/src/services/telemetry/TelemetryService.ts
+++ b/apps/vscode/src/services/telemetry/TelemetryService.ts
@@ -87,6 +87,12 @@ export type TelemetryMetadata = {
 	 * all use the same extension or plugin.
 	 */
 	cline_type: string
+	/**
+	 * The version of the host-side Cline distribution package: the JetBrains plugin version
+	 * (e.g. 1.1.61) on JetBrains, the extension version on VSCode (where it matches
+	 * `extension_version`). Absent when the host does not report one (e.g. CLI).
+	 */
+	host_plugin_version?: string
 	/** The name of the host IDE or environment e.g. VSCode, Cursor, IntelliJ Professional Edition, etc. */
 	platform: string
 	/** The version of the host environment */
@@ -368,6 +374,7 @@ export class TelemetryService {
 		const hostVersion = await HostProvider.env.getHostVersion({})
 		const metadata: TelemetryMetadata = {
 			extension_version: extensionVersion,
+			...(hostVersion.clineVersion ? { host_plugin_version: hostVersion.clineVersion } : {}),
 			platform: hostVersion.platform || "unknown",
 			platform_version: hostVersion.version || "unknown",
 			cline_type: hostVersion.clineType || "unknown",


### PR DESCRIPTION
Cherry-pick of #12478 onto `legacy-extension`, so the field shows up in currently-shipping JetBrains telemetry.

## Problem

There is no way to tell which JetBrains plugin version a telemetry event came from: `extension_version` is the cline-core bundle version, `platform_version` is the IDE version, and the plugin version the JetBrains host already sends over the hostbridge (`getHostVersion.clineVersion`) was ignored by `TelemetryService.create()`.

## Change

Attach `hostVersion.clineVersion` to the telemetry metadata as a new optional `host_plugin_version` property:

- **JetBrains**: the Marketplace plugin version, e.g. `1.1.61`
- **VSCode**: the extension version (matches `extension_version` there)
- **Hosts that don't report one** (e.g. CLI): field omitted

No host-side changes needed. The cherry-pick applied cleanly — the touched code is identical on both lines.

## Testing

Added unit test covering populated and absent cases; passing on this branch under the `@vscode/test-cli` host (`vscode-test --grep host_plugin_version`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)