### PR TITLE
fix(desktop): make plugins actually load in the packaged app and surface load failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,8 +67,10 @@ tests/**/cache
 # Tauri generated code
 apps/*/src-tauri/gen
 apps/*/src-tauri/bin
+apps/*/src-tauri/resources
 apps/examples/*/src-tauri/gen
 apps/examples/*/src-tauri/bin
+apps/examples/*/src-tauri/resources
 # Tauri UI test snapshots
 apps/*/src/tests/.tui-test
 apps/*/src/tests/tui-traces

--- a/apps/examples/desktop-app/scripts/build-sidecar-bin.ts
+++ b/apps/examples/desktop-app/scripts/build-sidecar-bin.ts
@@ -1,3 +1,5 @@
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
 import { $ } from "bun";
 
 const resolveTargetTriple = async (): Promise<string> => {
@@ -44,6 +46,35 @@ const main = async () => {
 	} else {
 		await $`bun build ./sidecar/index.ts --compile --outfile ${outfile}`;
 	}
+
+	// The plugin sandbox runs as a subprocess from a bootstrap file on disk.
+	// The compiled sidecar can't hand its embedded copy to a child process,
+	// and the bundle ships no node_modules, so emit a self-contained bundle
+	// (inlines @cline/shared + jiti) that Tauri ships as a resource. main.rs
+	// points the sidecar at it via CLINE_PLUGIN_SANDBOX_BOOTSTRAP_PATH.
+	// --target=node keeps the bundle runtime-agnostic: the subprocess runtime
+	// may be a host node, a host bun, or the compiled sidecar re-executing
+	// itself via BUN_BE_BUN=1 (bun-targeted output uses import.meta.require,
+	// which breaks under node).
+	const bootstrapEntry =
+		"../../../sdk/packages/core/src/extensions/plugin/plugin-sandbox-bootstrap.ts";
+	await $`mkdir -p src-tauri/resources`;
+	await $`bun build ${bootstrapEntry} --target=node --outfile ./src-tauri/resources/plugin-sandbox-bootstrap.js`;
+
+	// jiti's babel transform is a lazily-required asset that does not survive
+	// bundling (the bundled fallback requires '../dist/babel.cjs' relative to
+	// the bundle). The bootstrap prefers an explicitly resolved transform from
+	// a `node_modules/jiti` found next to itself, so ship the minimal jiti
+	// package alongside the bootstrap resource.
+	// jiti is a dependency of @cline/core, not of this app, so resolve it
+	// through core's module tree (it is not hoisted to the workspace root).
+	const requireFromHere = createRequire(import.meta.url);
+	const requireFromCore = createRequire(requireFromHere.resolve("@cline/core"));
+	const jitiPackageDir = dirname(requireFromCore.resolve("jiti/package.json"));
+	const jitiResourceDir = "./src-tauri/resources/node_modules/jiti";
+	await $`mkdir -p ${join(jitiResourceDir, "dist")}`;
+	await $`cp ${join(jitiPackageDir, "package.json")} ${join(jitiResourceDir, "package.json")}`;
+	await $`cp ${join(jitiPackageDir, "dist", "babel.cjs")} ${join(jitiResourceDir, "dist", "babel.cjs")}`;
 };
 
 main().catch((error: unknown) => {

--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -30,7 +30,7 @@ import {
 	HubScheduleService,
 	listHookConfigFiles,
 	listLocalProviders,
-	listPluginTools,
+	listPluginToolsWithDiagnostics,
 	loginAndSaveLocalProviderOAuthCredentials,
 	markLocalProviderEnabled,
 	normalizeOAuthProvider,
@@ -741,15 +741,18 @@ async function listUserInstructionConfigs(
 		}
 	};
 
-	const loadPlugins = (): Array<{
+	const loadPlugins = (
+		loadFailuresByPath: ReadonlyMap<string, string>,
+	): Array<{
 		name: string;
 		path: string;
 		enabled: boolean;
+		error?: string;
 	}> => {
 		const disabledPlugins = new Set(readGlobalSettings().disabledPlugins ?? []);
 		const pluginsByPath = new Map<
 			string,
-			{ name: string; path: string; enabled: boolean }
+			{ name: string; path: string; enabled: boolean; error?: string }
 		>();
 		const directories = resolvePluginConfigSearchPaths(workspaceRoot).filter(
 			(d) => existsSync(d),
@@ -760,10 +763,12 @@ async function listUserInstructionConfigs(
 					if (pluginsByPath.has(filePath)) {
 						continue;
 					}
+					const error = loadFailuresByPath.get(filePath);
 					pluginsByPath.set(filePath, {
 						name: basename(filePath, extname(filePath)),
 						path: filePath,
 						enabled: !disabledPlugins.has(filePath),
+						...(error ? { error } : {}),
 					});
 				}
 			} catch {
@@ -775,15 +780,32 @@ async function listUserInstructionConfigs(
 		);
 	};
 
-	const [rules, workflows, skills, pluginTools] = await Promise.all([
+	const [rules, workflows, skills, pluginToolsResult] = await Promise.all([
 		loadUserInstructionSnapshot("rule"),
 		loadUserInstructionSnapshot("workflow"),
 		loadUserInstructionSnapshot("skill"),
-		listPluginTools({
+		listPluginToolsWithDiagnostics({
 			workspacePath: workspaceRoot,
 			cwd: workspaceRoot,
-		}),
+		}).catch(
+			(error): Awaited<ReturnType<typeof listPluginToolsWithDiagnostics>> => {
+				warnings.push(
+					`plugins: ${error instanceof Error ? error.message : String(error)}`,
+				);
+				return { tools: [], failures: [], warnings: [] };
+			},
+		),
 	]);
+	const pluginTools = pluginToolsResult.tools;
+	const pluginFailuresByPath = new Map<string, string>();
+	for (const failure of pluginToolsResult.failures) {
+		if (!pluginFailuresByPath.has(failure.pluginPath)) {
+			pluginFailuresByPath.set(failure.pluginPath, failure.message);
+		}
+	}
+	for (const warning of pluginToolsResult.warnings) {
+		warnings.push(`plugins: ${warning.message}`);
+	}
 
 	const disabledTools = new Set(readGlobalSettings().disabledTools ?? []);
 	const builtinToolCatalog = getCoreBuiltinToolCatalog({
@@ -796,7 +818,7 @@ async function listUserInstructionConfigs(
 		workflows,
 		skills,
 		agents: loadAgents(),
-		plugins: loadPlugins(),
+		plugins: loadPlugins(pluginFailuresByPath),
 		tools: [
 			...builtinToolCatalog.map((tool) => ({
 				id: tool.id,
@@ -1371,7 +1393,9 @@ export async function handleCommand(
 				// The OAuth helper's openUrl callback is fire-and-forget; surface
 				// opener failures in the log instead of an unhandled rejection.
 				openUrlInDefaultBrowser(url).catch((error) => {
-					console.warn(`[sidecar] ${error instanceof Error ? error.message : error}`);
+					console.warn(
+						`[sidecar] ${error instanceof Error ? error.message : error}`,
+					);
 				});
 			},
 		);

--- a/apps/examples/desktop-app/src-tauri/src/main.rs
+++ b/apps/examples/desktop-app/src-tauri/src/main.rs
@@ -349,6 +349,44 @@ fn resolve_desktop_backend_binary_path(context: &AppContext) -> Option<PathBuf> 
     candidates.into_iter().find(|path| path.exists())
 }
 
+/// Locate the self-contained plugin-sandbox bootstrap bundle emitted by
+/// `build:sidecar:bin`. The compiled sidecar cannot hand its embedded copy of
+/// the bootstrap to a child process and the app bundle ships no node_modules,
+/// so the sidecar is pointed at this file via
+/// `CLINE_PLUGIN_SANDBOX_BOOTSTRAP_PATH`. Candidate order mirrors
+/// `resolve_desktop_backend_binary_path`: repo checkout first, then the
+/// per-platform resource layouts of a packaged install.
+fn resolve_plugin_sandbox_bootstrap_path(context: &AppContext) -> Option<PathBuf> {
+    let mut candidates = vec![PathBuf::from(&context.workspace_root)
+        .join("apps")
+        .join("examples")
+        .join("desktop-app")
+        .join("src-tauri")
+        .join("resources")
+        .join("plugin-sandbox-bootstrap.js")];
+    if let Some(exe_dir) = std::env::current_exe()
+        .ok()
+        .and_then(|path| path.parent().map(PathBuf::from))
+    {
+        // Windows: resources unpack next to the executable.
+        candidates.push(
+            exe_dir
+                .join("extensions")
+                .join("plugin-sandbox-bootstrap.js"),
+        );
+        // macOS: Contents/MacOS/<exe> -> Contents/Resources/extensions/.
+        if let Some(contents_dir) = exe_dir.parent() {
+            candidates.push(
+                contents_dir
+                    .join("Resources")
+                    .join("extensions")
+                    .join("plugin-sandbox-bootstrap.js"),
+            );
+        }
+    }
+    candidates.into_iter().find(|path| path.exists())
+}
+
 fn spawn_desktop_backend_process(context: &AppContext) -> Result<Child, String> {
     let mut command = if let Some(binary_path) = resolve_desktop_backend_binary_path(context) {
         let mut command = Command::new(binary_path);
@@ -367,6 +405,10 @@ fn spawn_desktop_backend_process(context: &AppContext) -> Result<Child, String> 
             context.workspace_root, context.launch_cwd
         ));
     };
+
+    if let Some(bootstrap_path) = resolve_plugin_sandbox_bootstrap_path(context) {
+        command.env("CLINE_PLUGIN_SANDBOX_BOOTSTRAP_PATH", bootstrap_path);
+    }
 
     command
         .stdin(Stdio::null())

--- a/apps/examples/desktop-app/src-tauri/tauri.conf.json
+++ b/apps/examples/desktop-app/src-tauri/tauri.conf.json
@@ -35,6 +35,9 @@
 		"active": true,
 		"targets": "all",
 		"externalBin": ["bin/code-sidecar"],
+		"resources": {
+			"resources/": "extensions/"
+		},
 		"icon": [
 			"icons/32x32.png",
 			"icons/128x128.png",

--- a/apps/examples/desktop-app/webview/components/views/settings/extensions-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/extensions-view.tsx
@@ -97,6 +97,8 @@ type PluginItem = {
 	name: string;
 	path: string;
 	enabled: boolean;
+	/** Load/setup failure message when the plugin could not be initialized. */
+	error?: string;
 };
 
 type ToolItem = {
@@ -215,6 +217,7 @@ function normalizeInstructionListsResponse(
 
 const EXTENSION_LISTS_CACHE_TTL_MS = 60_000;
 const EXTENSION_HOOK_STATS_CACHE_TTL_MS = 30_000;
+const EXTENSION_FOCUS_REFRESH_MIN_INTERVAL_MS = 5_000;
 
 let extensionListsCache:
 	| (UserInstructionListsResponse & {
@@ -662,6 +665,20 @@ export function CustomizationSectionView({
 			void refresh(false);
 		}, 0);
 		return () => window.clearTimeout(timeoutId);
+	}, [refresh]);
+
+	// Changes made outside the app (e.g. `cline plugin install` in a terminal)
+	// should show up when the user switches back, not after the cache TTL.
+	useEffect(() => {
+		const onFocus = () => {
+			const fetchedAt = extensionListsCache?.fetchedAt ?? 0;
+			if (Date.now() - fetchedAt < EXTENSION_FOCUS_REFRESH_MIN_INTERVAL_MS) {
+				return;
+			}
+			void refresh(true);
+		};
+		window.addEventListener("focus", onFocus);
+		return () => window.removeEventListener("focus", onFocus);
 	}, [refresh]);
 
 	useEffect(() => {
@@ -1503,6 +1520,14 @@ export function CustomizationSectionView({
 									<p className="mt-1 ml-7 text-xs font-mono text-muted-foreground">
 										{plugin.path}
 									</p>
+									{plugin.error && (
+										<div className="mt-2 ml-7 flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+											<TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+											<span className="min-w-0 break-words">
+												Failed to load: {plugin.error}
+											</span>
+										</div>
+									)}
 									<div className="mt-3 ml-7 flex flex-col gap-2">
 										{(
 											pluginToolsByPluginKey.get(
@@ -1542,11 +1567,12 @@ export function CustomizationSectionView({
 										})}
 										{(pluginToolsByPluginKey.get(
 											`${plugin.name}:${plugin.path}`,
-										)?.length ?? 0) === 0 && (
-											<p className="text-xs text-muted-foreground">
-												No plugin tools found.
-											</p>
-										)}
+										)?.length ?? 0) === 0 &&
+											!plugin.error && (
+												<p className="text-xs text-muted-foreground">
+													No plugin tools found.
+												</p>
+											)}
 									</div>
 								</div>
 							))}
@@ -1588,6 +1614,14 @@ export function CustomizationSectionView({
 									<p className="mt-1 ml-7 text-xs font-mono text-muted-foreground">
 										{plugin.path}
 									</p>
+									{plugin.error && (
+										<div className="mt-2 ml-7 flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+											<TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+											<span className="min-w-0 break-words">
+												Failed to load: {plugin.error}
+											</span>
+										</div>
+									)}
 									<div className="mt-3 ml-7 flex flex-col gap-2">
 										{(
 											pluginToolsByPluginKey.get(
@@ -1627,11 +1661,12 @@ export function CustomizationSectionView({
 										})}
 										{(pluginToolsByPluginKey.get(
 											`${plugin.name}:${plugin.path}`,
-										)?.length ?? 0) === 0 && (
-											<p className="text-xs text-muted-foreground">
-												No plugin tools found.
-											</p>
-										)}
+										)?.length ?? 0) === 0 &&
+											!plugin.error && (
+												<p className="text-xs text-muted-foreground">
+													No plugin tools found.
+												</p>
+											)}
 									</div>
 								</div>
 							))}

--- a/sdk/packages/core/src/extensions/plugin/plugin-sandbox-bootstrap.ts
+++ b/sdk/packages/core/src/extensions/plugin/plugin-sandbox-bootstrap.ts
@@ -22,6 +22,13 @@ import {
 	type PluginTargeting,
 } from "./plugin-targeting";
 
+// When the host is a compiled Bun binary it spawns this bootstrap by
+// re-executing itself with BUN_BE_BUN=1. The flag is only meaningful at exec
+// time, so drop it here to keep it from leaking into subprocesses spawned by
+// plugin code, where it would make any bun-compiled binary run as the plain
+// bun CLI instead of its embedded entrypoint.
+delete process.env.BUN_BE_BUN;
+
 // ---------------------------------------------------------------------------
 // Types (intentionally minimal – mirrors only what the RPC protocol needs)
 // ---------------------------------------------------------------------------

--- a/sdk/packages/core/src/extensions/plugin/plugin-sandbox.ts
+++ b/sdk/packages/core/src/extensions/plugin/plugin-sandbox.ts
@@ -137,6 +137,19 @@ function getPlatformPackageName(): string {
 	return `@cline/cli-${platform}-${process.arch}`;
 }
 
+/**
+ * Explicit override for hosts whose bundle layout none of the automatic
+ * candidates match (e.g. the packaged desktop app ships a self-contained
+ * bootstrap as a Tauri resource and points this at it).
+ */
+function resolveBootstrapFromEnv(): string | undefined {
+	const envPath = process.env.CLINE_PLUGIN_SANDBOX_BOOTSTRAP_PATH?.trim();
+	if (!envPath) {
+		return undefined;
+	}
+	return existsSync(envPath) ? envPath : undefined;
+}
+
 function resolveBootstrapFromWrapper(): string | undefined {
 	const wrapperPath = process.env.CLINE_WRAPPER_PATH?.trim();
 	if (!wrapperPath) {
@@ -187,6 +200,7 @@ function resolveBootstrap(): { file: string } | { script: string } {
 	// under dist/extensions/. Keep the older dist/agents/ fallback for
 	// compatibility with previously built layouts.
 	const candidates = [
+		resolveBootstrapFromEnv(),
 		join(dir, "plugin-sandbox-bootstrap.js"),
 		join(dir, "extensions", "plugin-sandbox-bootstrap.js"),
 		join(dir, "agents", "plugin-sandbox-bootstrap.js"),

--- a/sdk/packages/core/src/extensions/plugin/plugin-sandbox.ts
+++ b/sdk/packages/core/src/extensions/plugin/plugin-sandbox.ts
@@ -147,7 +147,15 @@ function resolveBootstrapFromEnv(): string | undefined {
 	if (!envPath) {
 		return undefined;
 	}
-	return existsSync(envPath) ? envPath : undefined;
+	if (!existsSync(envPath)) {
+		// The env var is an explicit override, so a missing file is a
+		// misconfiguration worth surfacing before falling back to discovery.
+		console.warn(
+			`CLINE_PLUGIN_SANDBOX_BOOTSTRAP_PATH points to a missing file, ignoring: ${envPath}`,
+		);
+		return undefined;
+	}
+	return envPath;
 }
 
 function resolveBootstrapFromWrapper(): string | undefined {

--- a/sdk/packages/core/src/runtime/tools/subprocess-sandbox.test.ts
+++ b/sdk/packages/core/src/runtime/tools/subprocess-sandbox.test.ts
@@ -3,6 +3,7 @@ import {
 	buildSubprocessSandboxCommand,
 	CLINE_JS_RUNTIME_PATH_ENV,
 	resolveSubprocessRuntimeExecutable,
+	subprocessRuntimeNeedsBunBeBun,
 } from "./subprocess-sandbox";
 
 describe("SubprocessSandbox runtime resolution", () => {
@@ -28,6 +29,19 @@ describe("SubprocessSandbox runtime resolution", () => {
 				env: {},
 			}),
 		).toBe("node");
+	});
+
+	it("self-execs via BUN_BE_BUN only for the current compiled Bun binary", () => {
+		// A foreign packaged binary (not this process) must never be treated
+		// as a runtime, regardless of the host runtime.
+		expect(subprocessRuntimeNeedsBunBeBun("/usr/local/bin/cline")).toBe(false);
+		// Plain runtimes never need the flag.
+		expect(subprocessRuntimeNeedsBunBeBun("/usr/local/bin/bun")).toBe(false);
+		expect(subprocessRuntimeNeedsBunBeBun("/usr/local/bin/node")).toBe(false);
+		// process.execPath in tests is a real bun/node binary, so even the
+		// self path does not need the flag here; compiled-binary behavior is
+		// covered by desktop-app integration testing.
+		expect(subprocessRuntimeNeedsBunBeBun(process.execPath)).toBe(false);
 	});
 
 	it("allows an explicit helper runtime override", () => {

--- a/sdk/packages/core/src/runtime/tools/subprocess-sandbox.ts
+++ b/sdk/packages/core/src/runtime/tools/subprocess-sandbox.ts
@@ -56,6 +56,29 @@ function asError(value: unknown): Error {
 
 export const CLINE_JS_RUNTIME_PATH_ENV = "CLINE_JS_RUNTIME_PATH";
 
+/**
+ * Whether this process is a Bun single-file executable (`bun build --compile`)
+ * whose binary name is not a plain runtime. Such binaries can still act as a
+ * `bun` runtime for child processes when spawned with `BUN_BE_BUN=1`.
+ */
+function isCompiledBunExecutable(execPath: string | undefined): boolean {
+	return (
+		typeof (globalThis as { Bun?: unknown }).Bun !== "undefined" &&
+		!!execPath &&
+		execPath === process.execPath &&
+		!isRuntimeExecutable(execPath)
+	);
+}
+
+/**
+ * Whether spawning `executable` requires `BUN_BE_BUN=1` in the child env so a
+ * compiled Bun binary re-executes as the plain `bun` runtime instead of its
+ * embedded entrypoint.
+ */
+export function subprocessRuntimeNeedsBunBeBun(executable: string): boolean {
+	return isCompiledBunExecutable(executable);
+}
+
 function isRuntimeExecutable(value: string | undefined): boolean {
 	const trimmed = value?.trim();
 	if (!trimmed) {
@@ -98,6 +121,13 @@ export function resolveSubprocessRuntimeExecutable(
 		if (trimmed && isRuntimeExecutable(trimmed)) {
 			return trimmed;
 		}
+	}
+
+	// A compiled Bun binary (e.g. the packaged desktop sidecar) can serve as
+	// its own runtime via BUN_BE_BUN=1, so prefer self-exec over hoping a
+	// `node` exists on PATH.
+	if (isCompiledBunExecutable(execPath)) {
+		return execPath;
 	}
 
 	return "node";
@@ -164,16 +194,17 @@ export class SubprocessSandbox {
 			name: this.options.name,
 			runtimeExecutable: this.options.runtimeExecutable,
 		});
-		const child = spawn(
-			command[0] ?? resolveSubprocessRuntimeExecutable(this.options),
-			command.slice(1),
-			{
-				stdio: ["ignore", "ignore", "pipe", "ipc"],
-				env: withResolvedClineBuildEnv(process.env),
-				// Prevent a console window from flashing on Windows.
-				windowsHide: true,
-			},
-		);
+		const executable =
+			command[0] ?? resolveSubprocessRuntimeExecutable(this.options);
+		const env = withResolvedClineBuildEnv(process.env);
+		const child = spawn(executable, command.slice(1), {
+			stdio: ["ignore", "ignore", "pipe", "ipc"],
+			env: subprocessRuntimeNeedsBunBeBun(executable)
+				? { ...env, BUN_BE_BUN: "1" }
+				: env,
+			// Prevent a console window from flashing on Windows.
+			windowsHide: true,
+		});
 		this.process = child;
 		let stderrBuffer = "";
 		const appendStderr = (chunk: string) => {


### PR DESCRIPTION
**In the packaged desktop app, no plugin has ever loaded.** The Plugins tab lists them (it's a plain disk scan of `~/.cline/plugins`), but every plugin fails to initialize, contributes zero tools, and does nothing in chat sessions — with no error shown anywhere. This PR makes plugins actually work in the packaged app and makes any future load failure visible instead of silent.

#### Root cause

Loading a plugin (even just to list its tools) spawns a sandbox subprocess: a JS runtime executing `plugin-sandbox-bootstrap.js`. The packaged sidecar is a `bun build --compile` single binary, and in that context the whole chain collapses:

1. `resolveBootstrap()` in `plugin-sandbox.ts` looks for the bootstrap next to the module (`import.meta.url` points into the compiled binary's virtual `/$bunfs` filesystem — nothing there on disk), via `CLINE_WRAPPER_PATH` (unset for the desktop app), and at `dirname(dirname(execPath))/extensions/` (nothing shipped there). All miss, so it falls back to an inline `node -e` script that loads jiti from a bunfs path that doesn't exist outside the binary.
2. The runtime resolution in `subprocess-sandbox.ts` can't use `process.execPath` (basename is `code-sidecar-…`, not `bun`/`node`), so it falls back to literal `node` from PATH — which a GUI-launched app on a machine without dev tools may not even have.
3. The child dies with `Cannot find module 'jiti'`, every plugin gets a phase=`load` failure… and the sidecar called `listPluginTools()`, which **discards the failure list** (`listPluginToolsWithDiagnostics` exists but wasn't used). The UI shows "No plugin tools found." and nothing else.

The CLI never hits this because its npm install ships `extensions/plugin-sandbox-bootstrap.js` inside the platform package *plus* a real `node_modules` tree next to it, and the wrapper runs under node. The desktop bundle has neither.

#### The fix

**Core** (`fix(core)` commit):
- `resolveBootstrap()` gains a first-priority `CLINE_PLUGIN_SANDBOX_BOOTSTRAP_PATH` env override for hosts whose bundle layout none of the automatic candidates match.
- New last-resort runtime: if the current process is a compiled Bun binary (checked as `typeof Bun !== "undefined" && execPath === process.execPath && basename not bun/node`), spawn **itself** with `BUN_BE_BUN=1` in the child env. `BUN_BE_BUN=1` makes a bun-compiled executable behave as the plain `bun` CLI instead of running its embedded entrypoint — verified against bun 1.3.13. The packaged app therefore needs **no** node or bun installed on the user's machine. The flag is injected only for that specific self-exec case; explicit `CLINE_JS_RUNTIME_PATH`, real bun/node execPaths, and the `node` fallback behave exactly as before (the foreign-packaged-binary test still resolves to `node`).

**Desktop packaging** (`fix(desktop): ship plugin-sandbox bootstrap` commit):
- `build-sidecar-bin.ts` now also emits a **self-contained** bootstrap bundle (`bun build --target=node`, inlines `@cline/shared` + jiti, ~0.9 MB) into `src-tauri/resources/`, plus `node_modules/jiti/{package.json,dist/babel.cjs}` next to it (see gotchas below for why both of those details are load-bearing).
- `tauri.conf.json` ships `resources/` → `extensions/` as bundle resources.
- `main.rs` resolves the shipped bootstrap (repo checkout for dev-built binaries, exe-adjacent for Windows-style layouts, `Contents/Resources/extensions/` for macOS) and passes it via `CLINE_PLUGIN_SANDBOX_BOOTSTRAP_PATH` when spawning the sidecar. `tauri dev` is unaffected — debug builds always run the sidecar via `bun run`, where the existing dist-relative resolution works.

**Diagnostics** (`fix(desktop): surface plugin load failures` commit):
- The sidecar's `list_user_instruction_configs` switches to `listPluginToolsWithDiagnostics`. Each plugin list entry now carries an `error` message when it failed to load or its `setup()` threw; duplicate-plugin-override warnings feed the existing top-level warnings banner. A total-failure of the lister degrades to a warning instead of failing the whole command.

**UI** (`feat(desktop)` commit):
- Plugins tab renders a per-plugin red error box ("Failed to load: …") instead of the misleading "No plugin tools found."
- The customization view force-refreshes on window focus (throttled to 5s, using the existing cache timestamp). Rationale: state is shared with the CLI through `~/.cline` but there are deliberately no file watchers, and the webview caches lists for 60s — so `cline plugin install` in a terminal didn't show up in an open app until a manual refresh or cache expiry. Focus is exactly the moment the user comes back from that terminal. `isLoading` only spins the refresh icon (no content swap), so there's no flash.

#### Debugging journey / gotchas (the second bug hiding under the first)

The obvious fix — bundle the bootstrap, ship it as a resource — **appeared** to work immediately, and that green result was a lie. Two traps:

- **jiti's transform cache fakes success.** jiti caches transpiled plugin modules under `$TMPDIR/jiti` keyed by content hash. My earlier dev-mode runs had populated it, so the bundled bootstrap "loaded" plugins without ever exercising its transpiler. With a cold cache it failed: jiti lazily `require`s `../dist/babel.cjs` *relative to wherever its code lives*, which after bundling resolves next to the bundle file — nothing there. The fix leans on a provision already in `plugin-module-import.ts`: it prefers an explicitly resolved babel transform, found by walking for a `node_modules/jiti` near the bootstrap file. Shipping the two-file mini jiti package next to the bootstrap satisfies that walk, and jiti's fragile internal fallback never runs. Any plugin-loading test needs `rm -rf /tmp/jiti` first to be trustworthy.
- **`--target=bun` output dies under node.** Bun-targeted bundles use `import.meta.require`, which is undefined under node — and the sandbox runtime can legitimately be the user's node (e.g. `npm_node_execpath`/`NODE` env vars are considered before the self-exec fallback; my own shell had them set, which is how I caught it). `--target=node` output runs correctly under both node and bun, so the bootstrap is bundled that way and works with whichever runtime the resolution picks.

Also fixed along the way: `src-tauri/resources/` is generated output, added to `.gitignore` alongside the existing `src-tauri/bin` entries.

#### Design notes / alternatives considered

- *Ship bun (or node) as a second externalBin*: ~60 MB per app for something `BUN_BE_BUN=1` gives us for free with the binary we already ship.
- *Copy the CLI's layout exactly (`Contents/extensions/`)*: Tauri resources can only land under `Contents/Resources/` on macOS without post-bundle surgery; the env var is explicit and works across platform layouts.
- *Skip jiti under bun and `import()` plugins natively*: works for the packaged app but forks behavior between runtimes; kept the single jiti path everywhere instead.
- Linux packaged layouts (deb/AppImage resource dirs) aren't in the main.rs candidate list — we don't ship Linux desktop builds; the env override makes it trivial to add later.

### Screenshots

Sidecar response for a plugin whose `setup()` throws, now surfaced end-to-end (previously: silent empty tools):

```json
{
  "plugins": [
    { "name": "broken-plugin", "path": ".../plugins/broken-plugin.js", "enabled": true,
      "error": "intentional setup boom" },
    { "name": "test-plugin", "path": ".../plugins/test-plugin.js", "enabled": true }
  ],
  "pluginTools": [
    { "name": "repro_echo", "pluginName": "repro-test", "source": "global-plugin", "enabled": true }
  ]
}
```

### Additional Notes

The 60s webview cache + no-watcher design is unchanged; focus-refresh just papers over the visible seam. If we ever want instant CLI↔app sync, that's a watcher/push design discussion, not this PR.
