### PR TITLE
feat(vscode): show compaction progress and results in the webview

### DIFF
--- a/apps/vscode/proto/cline/ui.proto
+++ b/apps/vscode/proto/cline/ui.proto
@@ -74,6 +74,7 @@ enum ClineSay {
   SUBAGENT_STATUS = 34;
   USE_SUBAGENTS_SAY = 35;
   SUBAGENT_USAGE = 36;
+  COMPACTION = 37;
 }
 
 // Enum for ClineSayTool tool types

--- a/apps/vscode/src/sdk/message-translator.test.ts
+++ b/apps/vscode/src/sdk/message-translator.test.ts
@@ -1643,6 +1643,115 @@ describe("translateSessionEvent — agent_event notice", () => {
 		expect(result.messages[0].text).toBe("Retrying API request...")
 		expect(result.messages[0].partial).toBe(false)
 	})
+
+	function noticeEvent(message: string, metadata?: Record<string, unknown>): CoreSessionEvent {
+		return {
+			type: "agent_event",
+			payload: {
+				sessionId: "session-1",
+				event: {
+					type: "notice",
+					noticeType: "status",
+					displayRole: "status",
+					message,
+					metadata,
+				} as AgentEvent,
+			},
+		}
+	}
+
+	it("translates compaction status notices into a divider row updated in place", () => {
+		const state = new MessageTranslatorState()
+
+		const started = translateSessionEvent(
+			noticeEvent("auto-compacting", { kind: "auto_compaction", phase: "started" }),
+			state,
+		).messages
+		expect(started).toHaveLength(1)
+		expect(started[0].say).toBe("compaction")
+		expect(JSON.parse(started[0].text ?? "{}")).toMatchObject({ status: "started", mode: "auto" })
+
+		const completed = translateSessionEvent(
+			noticeEvent("auto-compacted", {
+				kind: "auto_compaction",
+				phase: "completed",
+				tokensBefore: 120_000,
+				tokensAfter: 40_000,
+				messagesBefore: 80,
+				messagesAfter: 12,
+			}),
+			state,
+		).messages
+		expect(completed).toHaveLength(1)
+		expect(completed[0].say).toBe("compaction")
+		// Same ts: the webview replaces the "started" spinner row in place.
+		expect(completed[0].ts).toBe(started[0].ts)
+		expect(JSON.parse(completed[0].text ?? "{}")).toMatchObject({
+			status: "completed",
+			mode: "auto",
+			tokensBefore: 120_000,
+			tokensAfter: 40_000,
+			messagesBefore: 80,
+			messagesAfter: 12,
+		})
+	})
+
+	it("suppresses non-compaction status notices instead of rendering raw slugs", () => {
+		const state = new MessageTranslatorState()
+		const result = translateSessionEvent(
+			noticeEvent("compaction-budget-adjusted", { kind: "compaction_budget_emergency", actionCount: 1 }),
+			state,
+		)
+		expect(result.messages).toHaveLength(0)
+	})
+
+	it("finalizes a dangling compaction divider as failed when the turn errors", () => {
+		const state = new MessageTranslatorState()
+		const started = translateSessionEvent(
+			noticeEvent("auto-compacting", { kind: "auto_compaction", phase: "started" }),
+			state,
+		).messages
+
+		const errored = translateSessionEvent(
+			{
+				type: "agent_event",
+				payload: {
+					sessionId: "session-1",
+					event: { type: "error", error: new Error("boom"), recoverable: false } as unknown as AgentEvent,
+				},
+			},
+			state,
+		).messages
+
+		const divider = errored.find((message) => message.say === "compaction")
+		expect(divider).toBeDefined()
+		expect(divider?.ts).toBe(started[0].ts)
+		expect(JSON.parse(divider?.text ?? "{}")).toMatchObject({ status: "failed" })
+	})
+
+	it("finalizes a dangling compaction divider as cancelled when the turn ends", () => {
+		const state = new MessageTranslatorState()
+		const started = translateSessionEvent(
+			noticeEvent("auto-compacting", { kind: "auto_compaction", phase: "started" }),
+			state,
+		).messages
+
+		const done = translateSessionEvent(
+			{
+				type: "agent_event",
+				payload: {
+					sessionId: "session-1",
+					event: { type: "done", reason: "aborted" } as unknown as AgentEvent,
+				},
+			},
+			state,
+		).messages
+
+		const divider = done.find((message) => message.say === "compaction")
+		expect(divider).toBeDefined()
+		expect(divider?.ts).toBe(started[0].ts)
+		expect(JSON.parse(divider?.text ?? "{}")).toMatchObject({ status: "cancelled" })
+	})
 })
 
 // ---------------------------------------------------------------------------

--- a/apps/vscode/src/sdk/message-translator.test.ts
+++ b/apps/vscode/src/sdk/message-translator.test.ts
@@ -1696,13 +1696,23 @@ describe("translateSessionEvent — agent_event notice", () => {
 		})
 	})
 
-	it("suppresses non-compaction status notices instead of rendering raw slugs", () => {
+	it("suppresses known-internal status notices instead of rendering raw slugs", () => {
 		const state = new MessageTranslatorState()
 		const result = translateSessionEvent(
 			noticeEvent("compaction-budget-adjusted", { kind: "compaction_budget_emergency", actionCount: 1 }),
 			state,
 		)
 		expect(result.messages).toHaveLength(0)
+	})
+
+	it("renders an unrecognized status notice as an info row rather than dropping it", () => {
+		// Only the known-internal set is suppressed; a status notice added to the
+		// SDK later should surface (even as a raw slug) instead of vanishing.
+		const state = new MessageTranslatorState()
+		const result = translateSessionEvent(noticeEvent("some-future-status", { kind: "something_new" }), state)
+		expect(result.messages).toHaveLength(1)
+		expect(result.messages[0].say).toBe("info")
+		expect(result.messages[0].text).toBe("some-future-status")
 	})
 
 	it("finalizes a dangling compaction divider as failed when the turn errors", () => {

--- a/apps/vscode/src/sdk/message-translator.ts
+++ b/apps/vscode/src/sdk/message-translator.ts
@@ -33,6 +33,7 @@ import type {
 	ClineApiReqInfo,
 	ClineAskUseMcpServer,
 	ClineAskUseSubagents,
+	ClineCompactionInfo,
 	ClineMessage,
 	ClineSay,
 	ClineSaySubagentStatus,
@@ -124,6 +125,14 @@ export class MessageTranslatorState {
 	private streamingToolName: string | undefined
 	/** Approved tool-call ids mapped to the approval row that should be updated in place. */
 	private approvedToolMessageTsByCallId = new Map<string, number>()
+	/**
+	 * The in-flight compaction divider's ts, so the "completed"/"skipped" notice
+	 * (or a turn error/abort) updates the same row in place. Deliberately NOT
+	 * cleared by the per-iteration `reset()`: the started/completed notices both
+	 * fire inside prepareTurn, before the next `iteration_start`, but an error
+	 * or abort mid-compaction must still be able to finalize the open row.
+	 */
+	private openCompactionTs: number | undefined
 	/** Tool calls rejected by the user; they should not render as red tool failures. */
 	private deniedToolApprovalsByCallId = new Map<string, { toolName: string; reason: string }>()
 	/**
@@ -152,6 +161,19 @@ export class MessageTranslatorState {
 	/** Generate a unique message id (identity). Pure monotonic counter; never reads the clock. */
 	nextTs(): number {
 		return this.minter.nextId()
+	}
+
+	/** Mint and remember the ts of an in-flight compaction divider. */
+	beginCompaction(): number {
+		this.openCompactionTs = this.nextTs()
+		return this.openCompactionTs
+	}
+
+	/** Take (and clear) the in-flight compaction divider's ts, if any. */
+	takeOpenCompactionTs(): number | undefined {
+		const ts = this.openCompactionTs
+		this.openCompactionTs = undefined
+		return ts
 	}
 
 	/** Get and increment for streaming text */
@@ -923,6 +945,68 @@ export function buildToolApprovalAskMessage(toolName: string, input: unknown, ts
 /**
  * Translate an SDK AgentEvent into ClineMessage(s).
  */
+/**
+ * Extract a compaction divider payload from a status notice's metadata.
+ * Mirrors the CLI's parseCompactionNoticeMetadata
+ * (apps/cli/src/tui/utils/compaction-status.ts). Returns undefined for
+ * non-compaction status notices.
+ */
+export function parseCompactionNoticeMetadata(metadata: Record<string, unknown> | undefined): ClineCompactionInfo | undefined {
+	if (!metadata || (metadata.phase !== "started" && metadata.phase !== "completed" && metadata.phase !== "skipped")) {
+		return undefined
+	}
+	const kind = metadata.kind ?? metadata.reason
+	if (kind !== "auto_compaction" && kind !== "manual_compaction") {
+		return undefined
+	}
+	const mode = kind === "manual_compaction" ? "manual" : "auto"
+	if (metadata.phase === "started") {
+		return { status: "started", mode }
+	}
+	if (metadata.phase === "skipped") {
+		return { status: "skipped", mode }
+	}
+	return {
+		status: "completed",
+		mode,
+		tokensBefore: asFiniteNumber(metadata.tokensBefore),
+		tokensAfter: asFiniteNumber(metadata.tokensAfter),
+		messagesBefore: asFiniteNumber(metadata.messagesBefore),
+		messagesAfter: asFiniteNumber(metadata.messagesAfter),
+	}
+}
+
+function asFiniteNumber(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) ? value : undefined
+}
+
+/** Build the say:"compaction" divider message for a compaction status payload. */
+export function buildCompactionMessage(info: ClineCompactionInfo, ts: number): ClineMessage {
+	return {
+		ts,
+		type: "say",
+		say: "compaction",
+		text: JSON.stringify(info),
+		partial: false,
+	}
+}
+
+/**
+ * Finalize a dangling "started" compaction divider when the turn ends without
+ * the completed/skipped notice (mid-compaction abort or error).
+ */
+function finalizeDanglingCompaction(
+	state: MessageTranslatorState,
+	messages: ClineMessage[],
+	status: "cancelled" | "failed",
+): void {
+	const ts = state.takeOpenCompactionTs()
+	if (ts === undefined) {
+		return
+	}
+	messages.push(buildCompactionMessage({ status, mode: "auto" }, ts))
+}
+
 function translateAgentEvent(event: AgentEvent, state: MessageTranslatorState): ClineMessage[] {
 	const messages: ClineMessage[] = []
 
@@ -1401,7 +1485,23 @@ function translateAgentEvent(event: AgentEvent, state: MessageTranslatorState): 
 		}
 
 		case "notice": {
-			// Agent notices are informational
+			// Status notices carry structured runtime progress (compaction phases,
+			// budget adjustments). Compaction ones become a live divider row that is
+			// updated in place from "started" to its terminal state; the rest are
+			// internal and would render as raw slugs ("auto-compacting"), so drop them.
+			if (event.noticeType === "status") {
+				const compaction = parseCompactionNoticeMetadata(event.metadata)
+				if (compaction) {
+					const ts =
+						compaction.status === "started"
+							? state.beginCompaction()
+							: (state.takeOpenCompactionTs() ?? state.nextTs())
+					messages.push(buildCompactionMessage(compaction, ts))
+				}
+				break
+			}
+
+			// Non-status agent notices are informational
 			messages.push({
 				ts: state.nextTs(),
 				type: "say",
@@ -1440,10 +1540,13 @@ function translateAgentEvent(event: AgentEvent, state: MessageTranslatorState): 
 			// session-event coordinator sets on turn end (completed when the completion tool was
 			// used this turn, otherwise awaiting_followup), and the green "Task Completed" box
 			// comes from the say:"completion_result" emitted at the completion tool's content_end.
+			// A compaction divider still open here means the turn was aborted mid-compaction.
+			finalizeDanglingCompaction(state, messages, "cancelled")
 			break
 		}
 
 		case "error": {
+			finalizeDanglingCompaction(state, messages, "failed")
 			if (state.isSuppressedToolApprovalDenial(event.error)) {
 				break
 			}

--- a/apps/vscode/src/sdk/message-translator.ts
+++ b/apps/vscode/src/sdk/message-translator.ts
@@ -980,6 +980,16 @@ function asFiniteNumber(value: unknown): number | undefined {
 	return typeof value === "number" && Number.isFinite(value) ? value : undefined
 }
 
+/**
+ * Status notices that are internal diagnostics with no user-facing copy — their
+ * `message` is a slug, not prose. Only these are suppressed; an unlisted status
+ * notice renders as an info row so it doesn't vanish silently. Keep in sync
+ * with the `emitStatusNotice` call sites in
+ * sdk/packages/core/src/extensions/context/compaction.ts (the compaction phase
+ * slugs are handled above via parseCompactionNoticeMetadata instead).
+ */
+const INTERNAL_STATUS_NOTICES = new Set(["compaction-budget-adjusted"])
+
 /** Build the say:"compaction" divider message for a compaction status payload. */
 export function buildCompactionMessage(info: ClineCompactionInfo, ts: number): ClineMessage {
 	return {
@@ -994,6 +1004,11 @@ export function buildCompactionMessage(info: ClineCompactionInfo, ts: number): C
 /**
  * Finalize a dangling "started" compaction divider when the turn ends without
  * the completed/skipped notice (mid-compaction abort or error).
+ *
+ * This covers auto compaction (driven by turn events). Manual compaction runs
+ * outside a turn, so SdkCompactionCoordinator.runCompaction finalizes its own
+ * dangling divider in its catch block — if the terminal-state rules change
+ * here, change them there too.
  */
 function finalizeDanglingCompaction(
 	state: MessageTranslatorState,
@@ -1485,10 +1500,12 @@ function translateAgentEvent(event: AgentEvent, state: MessageTranslatorState): 
 		}
 
 		case "notice": {
-			// Status notices carry structured runtime progress (compaction phases,
-			// budget adjustments). Compaction ones become a live divider row that is
-			// updated in place from "started" to its terminal state; the rest are
-			// internal and would render as raw slugs ("auto-compacting"), so drop them.
+			// Status notices carry structured runtime progress. Compaction ones
+			// become a live divider row that is updated in place from "started" to
+			// its terminal state; the known-internal ones are diagnostics with no
+			// user-facing copy, so drop them explicitly. Any other status notice
+			// falls through to the info row below so a future one surfaces (as its
+			// raw slug) instead of silently vanishing.
 			if (event.noticeType === "status") {
 				const compaction = parseCompactionNoticeMetadata(event.metadata)
 				if (compaction) {
@@ -1497,11 +1514,14 @@ function translateAgentEvent(event: AgentEvent, state: MessageTranslatorState): 
 							? state.beginCompaction()
 							: (state.takeOpenCompactionTs() ?? state.nextTs())
 					messages.push(buildCompactionMessage(compaction, ts))
+					break
 				}
-				break
+				if (INTERNAL_STATUS_NOTICES.has(event.message ?? "")) {
+					break
+				}
 			}
 
-			// Non-status agent notices are informational
+			// Non-status agent notices (and unrecognized status notices) are informational
 			messages.push({
 				ts: state.nextTs(),
 				type: "say",

--- a/apps/vscode/src/sdk/sdk-compaction-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-compaction-coordinator.test.ts
@@ -84,7 +84,7 @@ describe("SdkCompactionCoordinator", () => {
 		)
 	})
 
-	it("reports when the strategy declines to compact", async () => {
+	it("shows a skipped divider when the strategy declines to compact", async () => {
 		const activeSession = makeActiveSession()
 		const { coordinator, options } = makeCoordinator({ activeSession })
 		mockCreateContextCompactionPrepareTurn.mockReturnValueOnce(vi.fn().mockResolvedValue(undefined))
@@ -93,10 +93,11 @@ describe("SdkCompactionCoordinator", () => {
 
 		expect(mockCreateContextCompactionPrepareTurn).toHaveBeenCalledOnce()
 		expect(options.sessions.replaceActiveSession).not.toHaveBeenCalled()
-		expect(options.messages.appendAndEmit).toHaveBeenCalledWith(
-			[expect.objectContaining({ say: "info", text: "No compaction needed." })],
-			expect.anything(),
-		)
+		const rows = compactionRows(options)
+		expect(rows[0].info.status).toBe("started")
+		expect(rows[1].info.status).toBe("skipped")
+		// The terminal row updates the started row in place (same ts).
+		expect(rows[1].ts).toBe(rows[0].ts)
 	})
 
 	it("compacts and persists the sidecar without rebuilding the session", async () => {
@@ -118,10 +119,40 @@ describe("SdkCompactionCoordinator", () => {
 			messages: [{ role: "user", content: "summary" }],
 		})
 		expect(options.sessions.replaceActiveSession).not.toHaveBeenCalled()
-		expect(options.messages.appendAndEmit).toHaveBeenCalledWith(
-			[expect.objectContaining({ say: "info", text: "Compacted 3 messages to 1." })],
-			expect.anything(),
+		const rows = compactionRows(options)
+		expect(rows[0].info).toMatchObject({ status: "started", mode: "manual" })
+		expect(rows[1].info).toMatchObject({ status: "completed", mode: "manual", messagesBefore: 3, messagesAfter: 1 })
+		expect(rows[1].ts).toBe(rows[0].ts)
+	})
+
+	it("prefers the SDK's token counters from its status notice for the completed divider", async () => {
+		const activeSession = makeActiveSession()
+		const { coordinator, options } = makeCoordinator({ activeSession })
+		mockCreateContextCompactionPrepareTurn.mockReturnValueOnce(
+			vi.fn().mockImplementation((context: { emitStatusNotice?: (message: string, metadata?: unknown) => void }) => {
+				context.emitStatusNotice?.("compacted", {
+					kind: "manual_compaction",
+					phase: "completed",
+					tokensBefore: 25_000,
+					tokensAfter: 6_000,
+					messagesBefore: 42,
+					messagesAfter: 5,
+				})
+				return Promise.resolve({ messages: [{ role: "user", content: "summary" }] })
+			}),
 		)
+
+		await coordinator.compactTask()
+
+		const rows = compactionRows(options)
+		expect(rows[1].info).toMatchObject({
+			status: "completed",
+			mode: "manual",
+			tokensBefore: 25_000,
+			tokensAfter: 6_000,
+			messagesBefore: 42,
+			messagesAfter: 5,
+		})
 	})
 
 	it("does not append compaction status to a different active session", async () => {
@@ -129,7 +160,7 @@ describe("SdkCompactionCoordinator", () => {
 		const { coordinator, options } = makeCoordinator({ activeSession })
 		options.sessions.getActiveSession
 			.mockReturnValueOnce(activeSession)
-			.mockReturnValueOnce(makeActiveSession({ sessionId: "other-session" }))
+			.mockReturnValue(makeActiveSession({ sessionId: "other-session" }))
 		mockCreateContextCompactionPrepareTurn.mockReturnValueOnce(
 			vi.fn().mockResolvedValue({ messages: [{ role: "user", content: "summary" }] }),
 		)
@@ -151,6 +182,8 @@ describe("SdkCompactionCoordinator", () => {
 		await coordinator.compactTask()
 
 		expect(options.sessions.replaceActiveSession).not.toHaveBeenCalled()
+		const rows = compactionRows(options)
+		expect(rows[rows.length - 1].info.status).toBe("failed")
 		expect(options.messages.appendAndEmit).toHaveBeenCalledWith(
 			[expect.objectContaining({ say: "info", text: "Couldn't compact the conversation. Please try again." })],
 			expect.anything(),
@@ -165,12 +198,22 @@ describe("SdkCompactionCoordinator", () => {
 		await coordinator.compactTask()
 
 		expect(options.sessions.replaceActiveSession).not.toHaveBeenCalled()
+		const rows = compactionRows(options)
+		expect(rows[rows.length - 1].info.status).toBe("failed")
 		expect(options.messages.appendAndEmit).toHaveBeenCalledWith(
 			[expect.objectContaining({ say: "info", text: "Couldn't compact the conversation. Please try again." })],
 			expect.anything(),
 		)
 	})
 })
+
+/** Collect all say:"compaction" rows emitted through appendAndEmit, in order. */
+function compactionRows(options: { messages: { appendAndEmit: ReturnType<typeof vi.fn> } }) {
+	return options.messages.appendAndEmit.mock.calls
+		.flatMap((call) => call[0] as Array<{ say?: string; text?: string; ts: number }>)
+		.filter((message) => message.say === "compaction")
+		.map((message) => ({ ts: message.ts, info: JSON.parse(message.text ?? "{}") }))
+}
 
 interface MakeCoordinatorInput {
 	activeSession: ReturnType<typeof makeActiveSession> | undefined

--- a/apps/vscode/src/sdk/sdk-compaction-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-compaction-coordinator.ts
@@ -162,7 +162,11 @@ export class SdkCompactionCoordinator {
 
 			Logger.log(`[SdkController] Compacted session ${sessionId}: ${messagesBefore} -> ${result.messages.length} messages`)
 		} catch (error) {
+			// Manual-mode counterpart of the translator's finalizeDanglingCompaction
+			// (message-translator.ts), which handles auto compaction from turn
+			// events — keep the terminal-state rules of the two in sync.
 			this.emitCompactionRow({ status: "failed", mode: "manual" }, compactionTs, sessionId)
+			await this.options.postStateToWebview()
 			throw error
 		}
 	}

--- a/apps/vscode/src/sdk/sdk-compaction-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-compaction-coordinator.ts
@@ -14,10 +14,11 @@
 // fake "Conversation Summary" instead of compacting (CLINE-2503).
 
 import type { Message as SdkMessage } from "@cline/llms"
-import type { ClineMessage } from "@shared/ExtensionMessage"
+import type { ClineCompactionInfo, ClineMessage } from "@shared/ExtensionMessage"
 import type { Mode } from "@shared/storage/types"
 import type { StateManager } from "@/core/storage/StateManager"
 import { Logger } from "@/shared/services/Logger"
+import { buildCompactionMessage, parseCompactionNoticeMetadata } from "./message-translator"
 import { compactSessionMessages } from "./sdk-compaction"
 import type { SdkMessageCoordinator } from "./sdk-message-coordinator"
 import type { SdkSessionConfigBuilder } from "./sdk-session-config-builder"
@@ -101,38 +102,69 @@ export class SdkCompactionCoordinator {
 		const mode = this.getCurrentMode()
 		const config = await this.options.sessionConfigBuilder.build({ cwd, mode })
 
-		const result = await compactSessionMessages({
-			config: {
-				providerConfig: config.providerConfig,
-				providerId: config.providerId,
-				modelId: config.modelId,
-				knownModels: config.knownModels,
-				compaction: config.compaction,
-				logger: config.logger,
-				telemetry: config.telemetry,
-			},
-			sessionId,
-			messages,
-		})
-
-		if (!result.compacted) {
-			this.emitInfo("No compaction needed.", sessionId)
-			await this.options.postStateToWebview()
-			return
-		}
-
-		if (!result.compactionState) {
-			throw new Error("Compaction did not return durable state.")
-		}
-		const persisted = await sdkHost.updateSessionCompactionState(sessionId, result.compactionState)
-		if (!persisted.updated) {
-			throw new Error("Compaction sidecar could not be persisted.")
-		}
-
-		this.emitInfo(this.formatCompactionStatus(messagesBefore, result.messages.length), sessionId)
+		// A live divider row, updated in place (same ts) from "started" to its
+		// terminal state — the same UX as the CLI's compaction divider.
+		const compactionTs = Date.now()
+		this.emitCompactionRow({ status: "started", mode: "manual" }, compactionTs, sessionId)
 		await this.options.postStateToWebview()
 
-		Logger.log(`[SdkController] Compacted session ${sessionId}: ${messagesBefore} -> ${result.messages.length} messages`)
+		// The SDK reports the compaction's token/message counters through its
+		// status notices; capture the terminal one for the final divider.
+		let noticeInfo: ClineCompactionInfo | undefined
+		try {
+			const result = await compactSessionMessages({
+				config: {
+					providerConfig: config.providerConfig,
+					providerId: config.providerId,
+					modelId: config.modelId,
+					knownModels: config.knownModels,
+					compaction: config.compaction,
+					logger: config.logger,
+					telemetry: config.telemetry,
+				},
+				sessionId,
+				messages,
+				emitStatusNotice: (_message, metadata) => {
+					const parsed = parseCompactionNoticeMetadata(metadata)
+					if (parsed && parsed.status !== "started") {
+						noticeInfo = { ...parsed, mode: "manual" }
+					}
+				},
+			})
+
+			if (!result.compacted) {
+				this.emitCompactionRow(noticeInfo ?? { status: "skipped", mode: "manual" }, compactionTs, sessionId)
+				await this.options.postStateToWebview()
+				return
+			}
+
+			if (!result.compactionState) {
+				throw new Error("Compaction did not return durable state.")
+			}
+			const persisted = await sdkHost.updateSessionCompactionState(sessionId, result.compactionState)
+			if (!persisted.updated) {
+				throw new Error("Compaction sidecar could not be persisted.")
+			}
+
+			this.emitCompactionRow(
+				noticeInfo?.status === "completed"
+					? noticeInfo
+					: {
+							status: "completed",
+							mode: "manual",
+							messagesBefore,
+							messagesAfter: result.messages.length,
+						},
+				compactionTs,
+				sessionId,
+			)
+			await this.options.postStateToWebview()
+
+			Logger.log(`[SdkController] Compacted session ${sessionId}: ${messagesBefore} -> ${result.messages.length} messages`)
+		} catch (error) {
+			this.emitCompactionRow({ status: "failed", mode: "manual" }, compactionTs, sessionId)
+			throw error
+		}
 	}
 
 	private getCurrentMode(): Mode {
@@ -140,12 +172,17 @@ export class SdkCompactionCoordinator {
 		return m === "plan" ? m : "act"
 	}
 
-	private formatCompactionStatus(messagesBefore: number, messagesAfter: number): string {
-		// Mirrors apps/cli/src/tui/utils/compaction-status.ts wording.
-		if (messagesBefore === messagesAfter) {
-			return `Compacted context; message count stayed at ${messagesAfter}.`
+	/** Append or update-in-place (same ts) the compaction divider row. */
+	private emitCompactionRow(info: ClineCompactionInfo, ts: number, sessionId: string): void {
+		const activeSessionId = this.options.sessions.getActiveSession()?.sessionId
+		if (activeSessionId !== sessionId) {
+			Logger.warn(`[SdkController] compactTask: skipped compaction row for inactive session ${sessionId}`)
+			return
 		}
-		return `Compacted ${messagesBefore} messages to ${messagesAfter}.`
+		this.options.messages.appendAndEmit([buildCompactionMessage(info, ts)], {
+			type: "status",
+			payload: { sessionId, status: "running" },
+		})
 	}
 
 	private emitInfo(text: string, sessionId?: string): void {

--- a/apps/vscode/src/sdk/sdk-compaction.ts
+++ b/apps/vscode/src/sdk/sdk-compaction.ts
@@ -34,6 +34,11 @@ export interface CompactSessionMessagesInput {
 	sessionId: string
 	/** The conversation transcript to compact (SDK message shape). */
 	messages: SdkMessage[]
+	/**
+	 * Receives the SDK's compaction status notices (started/completed/skipped
+	 * with token + message counters) so the caller can drive progress UI.
+	 */
+	emitStatusNotice?: (message: string, metadata?: Record<string, unknown>) => void
 }
 
 export interface CompactSessionMessagesResult {
@@ -104,6 +109,7 @@ export async function compactSessionMessages(input: CompactSessionMessagesInput)
 			provider: input.config.providerId,
 			info: compactionModelInfo,
 		},
+		emitStatusNotice: input.emitStatusNotice,
 	})
 	if (!result) {
 		return { compacted: false, messages: input.messages }

--- a/apps/vscode/src/shared/ExtensionMessage.ts
+++ b/apps/vscode/src/shared/ExtensionMessage.ts
@@ -257,6 +257,7 @@ export type ClineSay =
 	| "use_subagents"
 	| "subagent_usage"
 	| "conditional_rules_applied"
+	| "compaction" // context compaction progress/result divider
 
 export interface ClineSayTool {
 	tool:
@@ -374,6 +375,20 @@ export interface ClineApiReqInfo {
 		delaySec: number
 		errorSnippet?: string
 	}
+}
+
+/**
+ * JSON payload of a say:"compaction" message. Mirrors the CLI's compaction
+ * divider (apps/cli/src/tui/utils/compaction-status.ts): a "started" row shows
+ * a spinner and is later updated in place (same ts) to its terminal status.
+ */
+export interface ClineCompactionInfo {
+	status: "started" | "completed" | "skipped" | "failed" | "cancelled"
+	mode: "auto" | "manual"
+	tokensBefore?: number
+	tokensAfter?: number
+	messagesBefore?: number
+	messagesAfter?: number
 }
 
 export interface ClineSubagentUsageInfo {

--- a/apps/vscode/src/shared/__tests__/getApiMetrics.test.ts
+++ b/apps/vscode/src/shared/__tests__/getApiMetrics.test.ts
@@ -101,16 +101,79 @@ describe("getLastApiReqTotalTokens", () => {
 		assert.equal(total, 23)
 	})
 
-	it("uses the compacted size when a compaction completed after the last request", () => {
+	it("scales the last request by the shrink ratio of a compaction completed after it", () => {
+		// The compaction counters are the SDK's estimate — a different scale from
+		// the provider-reported request total. Only the ratio carries over.
 		const messages: ClineMessage[] = [
 			{
 				ts: 1,
 				type: "say",
 				say: "api_req_started",
-				text: JSON.stringify({ tokensIn: 90_000, tokensOut: 5_000 }),
+				text: JSON.stringify({ tokensIn: 90_000, tokensOut: 5_000, cacheReads: 5_000 }),
 			},
 			{
 				ts: 2,
+				type: "say",
+				say: "compaction",
+				text: JSON.stringify({ status: "completed", mode: "manual", tokensBefore: 200_000, tokensAfter: 50_000 }),
+			},
+		]
+
+		const total = getLastApiReqTotalTokens(messages)
+		assert.equal(total, 25_000)
+	})
+
+	it("compounds multiple compactions completed since the last request", () => {
+		const messages: ClineMessage[] = [
+			{
+				ts: 1,
+				type: "say",
+				say: "api_req_started",
+				text: JSON.stringify({ tokensIn: 100_000 }),
+			},
+			{
+				ts: 2,
+				type: "say",
+				say: "compaction",
+				text: JSON.stringify({ status: "completed", mode: "manual", tokensBefore: 200_000, tokensAfter: 100_000 }),
+			},
+			{
+				ts: 3,
+				type: "say",
+				say: "compaction",
+				text: JSON.stringify({ status: "completed", mode: "manual", tokensBefore: 100_000, tokensAfter: 50_000 }),
+			},
+		]
+
+		const total = getLastApiReqTotalTokens(messages)
+		assert.equal(total, 25_000)
+	})
+
+	it("leaves the request total unscaled when a completed compaction lacks token counters", () => {
+		// The coordinator's fallback divider carries only message counts.
+		const messages: ClineMessage[] = [
+			{
+				ts: 1,
+				type: "say",
+				say: "api_req_started",
+				text: JSON.stringify({ tokensIn: 40_000, tokensOut: 2_000 }),
+			},
+			{
+				ts: 2,
+				type: "say",
+				say: "compaction",
+				text: JSON.stringify({ status: "completed", mode: "manual", messagesBefore: 40, messagesAfter: 6 }),
+			},
+		]
+
+		const total = getLastApiReqTotalTokens(messages)
+		assert.equal(total, 42_000)
+	})
+
+	it("returns 0 when a compaction completed but no request preceded it", () => {
+		const messages: ClineMessage[] = [
+			{
+				ts: 1,
 				type: "say",
 				say: "compaction",
 				text: JSON.stringify({ status: "completed", mode: "manual", tokensBefore: 95_000, tokensAfter: 30_000 }),
@@ -118,7 +181,7 @@ describe("getLastApiReqTotalTokens", () => {
 		]
 
 		const total = getLastApiReqTotalTokens(messages)
-		assert.equal(total, 30_000)
+		assert.equal(total, 0)
 	})
 
 	it("ignores compaction rows without a usable compacted size", () => {

--- a/apps/vscode/src/shared/__tests__/getApiMetrics.test.ts
+++ b/apps/vscode/src/shared/__tests__/getApiMetrics.test.ts
@@ -100,4 +100,70 @@ describe("getLastApiReqTotalTokens", () => {
 		const total = getLastApiReqTotalTokens(messages)
 		assert.equal(total, 23)
 	})
+
+	it("uses the compacted size when a compaction completed after the last request", () => {
+		const messages: ClineMessage[] = [
+			{
+				ts: 1,
+				type: "say",
+				say: "api_req_started",
+				text: JSON.stringify({ tokensIn: 90_000, tokensOut: 5_000 }),
+			},
+			{
+				ts: 2,
+				type: "say",
+				say: "compaction",
+				text: JSON.stringify({ status: "completed", mode: "manual", tokensBefore: 95_000, tokensAfter: 30_000 }),
+			},
+		]
+
+		const total = getLastApiReqTotalTokens(messages)
+		assert.equal(total, 30_000)
+	})
+
+	it("ignores compaction rows without a usable compacted size", () => {
+		const messages: ClineMessage[] = [
+			{
+				ts: 1,
+				type: "say",
+				say: "api_req_started",
+				text: JSON.stringify({ tokensIn: 11, tokensOut: 7, cacheWrites: 2, cacheReads: 3 }),
+			},
+			{
+				ts: 2,
+				type: "say",
+				say: "compaction",
+				text: JSON.stringify({ status: "started", mode: "auto" }),
+			},
+			{
+				ts: 3,
+				type: "say",
+				say: "compaction",
+				text: JSON.stringify({ status: "failed", mode: "auto" }),
+			},
+		]
+
+		const total = getLastApiReqTotalTokens(messages)
+		assert.equal(total, 23)
+	})
+
+	it("prefers a request newer than the last compaction", () => {
+		const messages: ClineMessage[] = [
+			{
+				ts: 1,
+				type: "say",
+				say: "compaction",
+				text: JSON.stringify({ status: "completed", mode: "auto", tokensBefore: 95_000, tokensAfter: 30_000 }),
+			},
+			{
+				ts: 2,
+				type: "say",
+				say: "api_req_started",
+				text: JSON.stringify({ tokensIn: 31_000, tokensOut: 1_000 }),
+			},
+		]
+
+		const total = getLastApiReqTotalTokens(messages)
+		assert.equal(total, 32_000)
+	})
 })

--- a/apps/vscode/src/shared/getApiMetrics.ts
+++ b/apps/vscode/src/shared/getApiMetrics.ts
@@ -77,13 +77,30 @@ export function getApiMetrics(messages: ClineMessage[]): ApiMetrics {
  * This is used for context window progress display - it shows how much of the
  * context window is used in the current/most recent request, not cumulative totals.
  *
+ * A completed compaction divider that postdates the last request reports the
+ * compacted working-context size, so the context-window bar drops immediately
+ * after a compaction instead of waiting for the next request to run.
+ *
  * @param messages - An array of ClineMessage objects to process.
- * @returns The total tokens (tokensIn + tokensOut + cacheWrites + cacheReads) from the last api_req_started message, or 0 if none found.
+ * @returns The total tokens (tokensIn + tokensOut + cacheWrites + cacheReads) from the last api_req_started message, the compacted size (tokensAfter) if a compaction happened after it, or 0 if none found.
  */
 export function getLastApiReqTotalTokens(messages: ClineMessage[]): number {
 	for (let i = messages.length - 1; i >= 0; i--) {
 		const msg = messages[i]
-		if (msg.type === "say" && msg.say === "api_req_started" && msg.text) {
+		if (msg.type !== "say" || !msg.text) {
+			continue
+		}
+		if (msg.say === "compaction") {
+			try {
+				const { status, tokensAfter } = JSON.parse(msg.text)
+				if (status === "completed" && typeof tokensAfter === "number" && tokensAfter > 0) {
+					return tokensAfter
+				}
+			} catch {
+				// Ignore JSON parse errors, continue searching
+			}
+		}
+		if (msg.say === "api_req_started") {
 			try {
 				const { tokensIn, tokensOut, cacheWrites, cacheReads } = JSON.parse(msg.text)
 				const total = (tokensIn || 0) + (tokensOut || 0) + (cacheWrites || 0) + (cacheReads || 0)

--- a/apps/vscode/src/shared/getApiMetrics.ts
+++ b/apps/vscode/src/shared/getApiMetrics.ts
@@ -77,14 +77,22 @@ export function getApiMetrics(messages: ClineMessage[]): ApiMetrics {
  * This is used for context window progress display - it shows how much of the
  * context window is used in the current/most recent request, not cumulative totals.
  *
- * A completed compaction divider that postdates the last request reports the
- * compacted working-context size, so the context-window bar drops immediately
- * after a compaction instead of waiting for the next request to run.
+ * A completed compaction divider that postdates the last request shrinks that
+ * request's total by the compaction's tokensAfter/tokensBefore ratio, so the
+ * context-window bar drops immediately instead of waiting for the next request
+ * to run. The ratio is used rather than tokensAfter itself because the
+ * compaction counters are the SDK's estimate (chars/4-class), a different
+ * scale from the provider-reported usage that normally drives this value —
+ * substituting the estimate would make the bar visibly re-snap when the next
+ * request's real usage lands. Both counters come from the same estimator, so
+ * their ratio is scale-free. Multiple compactions since the last request
+ * compound.
  *
  * @param messages - An array of ClineMessage objects to process.
- * @returns The total tokens (tokensIn + tokensOut + cacheWrites + cacheReads) from the last api_req_started message, the compacted size (tokensAfter) if a compaction happened after it, or 0 if none found.
+ * @returns The total tokens (tokensIn + tokensOut + cacheWrites + cacheReads) from the last api_req_started message, scaled down by any completed compactions that happened after it, or 0 if none found.
  */
 export function getLastApiReqTotalTokens(messages: ClineMessage[]): number {
+	let shrinkFraction: number | undefined
 	for (let i = messages.length - 1; i >= 0; i--) {
 		const msg = messages[i]
 		if (msg.type !== "say" || !msg.text) {
@@ -92,9 +100,15 @@ export function getLastApiReqTotalTokens(messages: ClineMessage[]): number {
 		}
 		if (msg.say === "compaction") {
 			try {
-				const { status, tokensAfter } = JSON.parse(msg.text)
-				if (status === "completed" && typeof tokensAfter === "number" && tokensAfter > 0) {
-					return tokensAfter
+				const { status, tokensBefore, tokensAfter } = JSON.parse(msg.text)
+				if (
+					status === "completed" &&
+					typeof tokensBefore === "number" &&
+					typeof tokensAfter === "number" &&
+					tokensBefore > 0 &&
+					tokensAfter > 0
+				) {
+					shrinkFraction = (shrinkFraction ?? 1) * Math.min(1, tokensAfter / tokensBefore)
 				}
 			} catch {
 				// Ignore JSON parse errors, continue searching
@@ -105,7 +119,7 @@ export function getLastApiReqTotalTokens(messages: ClineMessage[]): number {
 				const { tokensIn, tokensOut, cacheWrites, cacheReads } = JSON.parse(msg.text)
 				const total = (tokensIn || 0) + (tokensOut || 0) + (cacheWrites || 0) + (cacheReads || 0)
 				if (total > 0) {
-					return total
+					return shrinkFraction === undefined ? total : Math.ceil(total * shrinkFraction)
 				}
 			} catch {
 				// Ignore JSON parse errors, continue searching

--- a/apps/vscode/src/shared/proto-conversions/cline-message.ts
+++ b/apps/vscode/src/shared/proto-conversions/cline-message.ts
@@ -108,6 +108,7 @@ function convertClineSayToProtoEnum(say: AppClineSay | undefined): ClineSay | un
 		subagent: ClineSay.SUBAGENT_STATUS,
 		use_subagents: ClineSay.USE_SUBAGENTS_SAY,
 		subagent_usage: ClineSay.SUBAGENT_USAGE,
+		compaction: ClineSay.COMPACTION,
 	}
 
 	const result = mapping[say]
@@ -158,6 +159,7 @@ function convertProtoEnumToClineSay(say: ClineSay): AppClineSay | undefined {
 		[ClineSay.SUBAGENT_STATUS]: "subagent",
 		[ClineSay.USE_SUBAGENTS_SAY]: "use_subagents",
 		[ClineSay.SUBAGENT_USAGE]: "subagent_usage",
+		[ClineSay.COMPACTION]: "compaction",
 	}
 
 	return mapping[say]

--- a/apps/vscode/webview-ui/src/components/chat/ChatRow.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatRow.tsx
@@ -46,6 +46,7 @@ import { FileServiceClient, UiServiceClient } from "@/services/grpc-client"
 import { findMatchingResourceOrTemplate } from "@/utils/mcp"
 import CodeAccordian, { cleanPathPrefix } from "../common/CodeAccordian"
 import { CommandOutputContent, CommandOutputRow } from "./CommandOutputRow"
+import CompactionRow from "./CompactionRow"
 import { CompletionOutputRow } from "./CompletionOutputRow"
 import { DiffEditRow } from "./DiffEditRow"
 import ErrorRow from "./ErrorRow"
@@ -1054,6 +1055,8 @@ export const ChatRowContent = memo(
 						)
 					case "task_progress":
 						return <InvisibleSpacer /> // task_progress messages should be displayed in TaskHeader only, not in chat
+					case "compaction":
+						return <CompactionRow message={message} />
 					default:
 						return (
 							<div>

--- a/apps/vscode/webview-ui/src/components/chat/CompactionRow.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/CompactionRow.tsx
@@ -1,0 +1,92 @@
+import type { ClineCompactionInfo, ClineMessage } from "@shared/ExtensionMessage"
+import { FoldVerticalIcon, LoaderCircleIcon } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+/** Mirrors the CLI's formatTokenCount (apps/cli/src/tui/utils/compaction-status.ts). */
+function formatTokenCount(count: number): string {
+	if (count < 1_000) {
+		return `${count}`
+	}
+	if (count < 1_000_000) {
+		return `${(count / 1_000).toFixed(1).replace(/\.0$/, "")}k`
+	}
+	return `${(count / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`
+}
+
+function parseCompactionInfo(text: string | undefined): ClineCompactionInfo | undefined {
+	if (!text) {
+		return undefined
+	}
+	try {
+		const parsed = JSON.parse(text)
+		if (parsed && typeof parsed === "object" && typeof parsed.status === "string") {
+			return parsed as ClineCompactionInfo
+		}
+	} catch {
+		// Fall through to undefined for malformed payloads.
+	}
+	return undefined
+}
+
+/** Mirrors the CLI's formatCompactionDividerLabel wording for product consistency. */
+function formatCompactionLabel(info: ClineCompactionInfo): string {
+	if (info.status === "started") {
+		return info.mode === "manual" ? "Compacting context" : "Auto compacting context"
+	}
+	if (info.status === "failed") {
+		return "Compaction failed"
+	}
+	if (info.status === "cancelled") {
+		return "Compaction cancelled"
+	}
+	if (info.status === "skipped") {
+		return "Compaction skipped"
+	}
+	const parts: string[] = [info.mode === "manual" ? "Context compacted (manual)" : "Context compacted"]
+	if (typeof info.tokensBefore === "number" && typeof info.tokensAfter === "number") {
+		parts.push(`${formatTokenCount(info.tokensBefore)} → ${formatTokenCount(info.tokensAfter)} tokens`)
+	}
+	if (typeof info.messagesBefore === "number" && typeof info.messagesAfter === "number") {
+		parts.push(`${info.messagesBefore} → ${info.messagesAfter} messages`)
+	}
+	return parts.join(" · ")
+}
+
+/**
+ * Divider row for context compaction progress and results — the webview
+ * counterpart of the CLI's CompactionDividerRow. Shows a spinner while a
+ * compaction is running; the same message (same ts) is updated in place to
+ * its terminal state when it finishes.
+ */
+export const CompactionRow = ({ message }: { message: ClineMessage }) => {
+	const info = parseCompactionInfo(message.text)
+	if (!info) {
+		// Virtuoso cannot handle zero-height items; render a spacer instead of null.
+		return <div aria-hidden className="h-px" />
+	}
+
+	const inProgress = info.status === "started"
+	const isFailed = info.status === "failed"
+	const isMuted = info.status === "skipped" || info.status === "cancelled"
+
+	return (
+		<div
+			className={cn("flex items-center gap-2 py-1.5 text-description", {
+				"text-error": isFailed,
+				"opacity-70": isMuted,
+			})}>
+			{inProgress ? (
+				<LoaderCircleIcon className="size-2 shrink-0 animate-spin" />
+			) : (
+				<FoldVerticalIcon className="size-2 shrink-0" />
+			)}
+			<span className="whitespace-nowrap">
+				{formatCompactionLabel(info)}
+				{inProgress ? "…" : ""}
+			</span>
+			<div className="flex-1 border-t border-description/30" />
+		</div>
+	)
+}
+
+export default CompactionRow

--- a/apps/vscode/webview-ui/src/components/settings/sections/FeatureSettingsSection.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/sections/FeatureSettingsSection.tsx
@@ -208,7 +208,7 @@ const FeatureSettingsSection = ({ renderSectionHeader }: FeatureSettingsSectionP
 								<Select
 									disabled={!useAutoCondense}
 									onValueChange={(value) => updateSetting("compactionStrategy", value)}
-									value={compactionStrategy ?? "basic"}>
+									value={compactionStrategy ?? "agentic"}>
 									<SelectTrigger className="w-full">
 										<SelectValue />
 									</SelectTrigger>


### PR DESCRIPTION
### Related Issue

**Issue:** https://linear.app/cline-bot/issue/CLINE-2577

### Description

The CLI got a proper compaction UX in #12137 (live divider with a spinner, then `Context compacted · 25.1k → 6.3k tokens · 142 → 9 messages`), but none of it reached the VS Code webview. What extension users saw during compaction was, in order of badness:

1. **Nothing while it runs.** The SDK's compaction status notices (`emitStatusNotice` → `status-notice` → `AgentNoticeEvent` with `noticeType: "status"`) hit `message-translator.ts`, which pushed them as `say:"info"` rows containing the raw notice slug — so an auto-compaction rendered as a literal `auto-compacting` text line, then `auto-compacted`. Manual `/compact` showed nothing until a plain "Compacted 142 messages to 9." info line at the end.
2. **The context window bar never moved.** The bar is driven by `getLastApiReqTotalTokens`, which only reads the last `api_req_started` row's token counts. Compaction emits no `api_req_started`, so after compacting, the bar stayed pinned at the pre-compaction number until the next real turn ran. Users reasonably concluded compaction did nothing — this is almost certainly a big chunk of the "compaction is broken" reports behind CLINE-2577.
3. **The settings UI lied about the default.** The "Auto Compact Strategy" selector fell back to `"basic"` when unset, but since #12317 the effective default (core `strategy ?? "agentic"`, `readCompactionStrategyGlobally() ?? "agentic"`, and the schema's `.catch("agentic")`) is agentic.

This PR ports the CLI's compaction UX to the webview:

**New `say:"compaction"` message type** (proto enum `COMPACTION = 37`, `ClineCompactionInfo` JSON payload: `status` started/completed/skipped/failed/cancelled, `mode` auto/manual, token + message before/after counters). Rendered by a new `CompactionRow` component — spinner + "Auto compacting context…" while running, fold icon + `Context compacted · 118k → 39k tokens · 80 → 12 messages` divider when done, red for failed, dimmed for skipped/cancelled. Label wording mirrors the CLI's `formatCompactionDividerLabel` for product consistency.

**In-place row updates.** The webview's `MessageStateHandler.addMessages` updates a message in place when the `ts` matches (the partial→final streaming mechanism). The translator mints one ts for the "started" row (`state.beginCompaction()`) and re-emits the terminal state on the same ts, so the spinner row *becomes* the result divider — no duplicate rows. The open-compaction ts deliberately survives the per-iteration `reset()` (started/completed both fire inside `prepareTurn`, before the next `iteration_start`), and dangling rows are finalized as `failed`/`cancelled` from the turn's `error`/`done` events — same approach as the CLI's `finalizeDanglingCompactionEntry`.

**Manual `/compact` drives the same divider.** `sdk-compaction.ts` now forwards an `emitStatusNotice` callback into the SDK's manual-mode compaction context (the field already existed on `ContextPipelinePrepareTurnInput`; we just never passed it). The coordinator appends a started row, captures the SDK's terminal notice (which carries the real token counters), and updates the row in place — falling back to message counts if no notice fired. Failure paths flip the row to `failed` (plus the existing explanatory info line); "no compaction needed" becomes a `skipped` divider.

**Context bar drops immediately.** `getLastApiReqTotalTokens` now scans for the newest of (last `api_req_started` with tokens, last `completed` compaction row with `tokensAfter`) and returns that. After a manual compact you see the bar fall right away instead of after the next turn. `tokensAfter` is the SDK's estimate of the next request's input size, which is exactly what the bar is trying to show.

**Non-compaction status notices are suppressed** rather than rendered as raw slugs (`compaction-budget-adjusted` etc. are internal).

Gotchas discovered along the way:

- The raw-slug info rows (`auto-compacting` appearing as chat text) were a real user-visible artifact of the old `case "notice"` handling — worth knowing when triaging old screenshots.
- `ClineSay` is a proto enum, not just a TS union — a new say type needs `ui.proto`, both direction mappings in `proto-conversions/cline-message.ts`, and a proto regen (`bun run protos`; the generated file is gitignored).
- The coordinator's "different active session" guard (`emitCompactionRow` re-checks `getActiveSession()` per emit) is preserved; the pre-existing test needed its mock adjusted since the coordinator now checks the active session once per row rather than once total.

Deliberately **not** in this PR (tracked separately):
- Compact-on-history-task no-op — that's @dominiccooney's #12002, still in flight.
- Core-side issues: the agentic summarizer's cost/usage is never accounted anywhere (side-channel `createHandlerAsync`, usage chunks discarded), silent agentic→basic fallback, chars÷4 token estimation, one-line summary prompt.

### Test Procedure

- New translator tests: started→completed same-ts in-place update with counters; non-compaction status notices suppressed; dangling divider finalized as failed on turn error and cancelled on done.
- Coordinator tests updated/added: started/skipped/completed/failed divider flows, SDK notice counters preferred over message-count fallback, inactive-session guard, persistence-failure path.
- `getLastApiReqTotalTokens`: compaction-newer-than-request, request-newer-than-compaction, and no-usable-tokens cases.
- `bunx vitest run src/sdk` (56 files / 780 tests) and `bun test src/shared/__tests__/getApiMetrics.test.ts` pass; `tsc --noEmit` clean for both extension and webview.
- Not yet done: visual pass in a real extension host (sandbox is headless). The row renders through the standard ChatRow switch and `filterVisibleMessages` passes unknown say types through, but someone should eyeball a real auto-compaction + `/compact` before merge.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
