### PR TITLE
fix(cli): keep Hub daemon alive after turn aborts

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -16,6 +16,10 @@ initVcr(process.env.CLINE_VCR);
 
 if (!isMainThread) {
 	// Worker imports of the bundled CLI entrypoint should not start the CLI.
+} else if (isHubDaemonProcess()) {
+	// The hub daemon owns its process-level abort handling. Installing the CLI's
+	// fatal rejection handler first would make expected abort rejections exit it.
+	void import("@cline/core/hub/daemon-entry");
 } else {
 	let shuttingDown = false;
 	let handlingFatalProcessError = false;
@@ -57,11 +61,6 @@ if (!isMainThread) {
 	});
 
 	void (async () => {
-		if (isHubDaemonProcess()) {
-			await import("@cline/core/hub/daemon-entry");
-			return;
-		}
-
 		let exitCode = 0;
 		try {
 			const { runCli } = await import("./main");


### PR DESCRIPTION
## Summary

Fixes #12493.

Hub daemon subprocesses previously registered the CLI entrypoint’s fatal `unhandledRejection` handler before loading the daemon entrypoint. Expected `AgentRuntimeAbortError` rejections could therefore trigger the CLI fatal handler and terminate the daemon, even though the daemon entrypoint explicitly treats those abort rejections as non-fatal.

This starts the daemon entrypoint before the CLI installs signal and fatal-process handlers, leaving daemon lifecycle and abort handling entirely to `@cline/core/hub/daemon-entry`. Avoiding the daemon exit also prevents the downstream `session_not_found` recovery path from cloning a session into a new history entry.

## Validation

- `bun -F @cline/cli typecheck`
- `bunx biome check ../apps/cli/src/index.ts` from `sdk/`
- `bun -F @cline/cli build` built the Hub webview, then failed on an unrelated stale SDK artifact mismatch: `@cline/shared/dist` lacks `estimateRequestInputTokens` required by `@cline/llms/src/providers/gateway.ts`.

A focused entrypoint test was not retained because loading the CLI SDK graph under Vitest is blocked by the existing workspace Zod runtime-resolution failure.