### PR TITLE
fix(telemetry): report host identity on SDK-pipeline events

### DIFF
--- a/apps/vscode/src/sdk/sdk-telemetry.test.ts
+++ b/apps/vscode/src/sdk/sdk-telemetry.test.ts
@@ -76,6 +76,24 @@ describe("VscodeTelemetryPolicyService", () => {
 		vi.unstubAllEnvs()
 	})
 
+	it("constructs the handle with unknown host identity fallbacks", () => {
+		// The policy service overrides these from getHostVersion before any event is
+		// emitted; "unknown" must survive a failed lookup instead of a VSCode mislabel.
+		coreTelemetryMocks.createHandle.mockReturnValue(createHandle())
+
+		createVscodeSdkTelemetryHandle()
+
+		expect(coreTelemetryMocks.createConfig).toHaveBeenCalledWith(
+			expect.objectContaining({
+				metadata: expect.objectContaining({
+					cline_type: "unknown",
+					platform: "unknown",
+					platform_version: "unknown",
+				}),
+			}),
+		)
+	})
+
 	it("adds rollout metadata as SDK common properties", () => {
 		vi.stubEnv("CLINE_ROLLOUT_VARIANT", "next")
 		coreTelemetryMocks.createHandle.mockReturnValue(createHandle())

--- a/apps/vscode/src/sdk/sdk-telemetry.test.ts
+++ b/apps/vscode/src/sdk/sdk-telemetry.test.ts
@@ -20,7 +20,7 @@ const telemetryState = vi.hoisted(() => ({
 		platform: "VS Code",
 		version: "1.103.0",
 		clineType: "VSCode Extension",
-	} as { platform: string; version: string; clineType: string; clineVersion?: string },
+	} as { platform?: string; version?: string; clineType?: string; clineVersion?: string },
 	hostVersionError: undefined as Error | undefined,
 	subscribeCallback: undefined as ((event: { isEnabled: number }) => void) | undefined,
 	unsubscribe: vi.fn(),
@@ -174,7 +174,7 @@ describe("VscodeTelemetryPolicyService", () => {
 		expect(handle.telemetry.recordCounter).toHaveBeenCalledWith("required", 1, undefined, undefined, true)
 	})
 
-	it("applies host_plugin_version metadata before enabling events when the host reports one", async () => {
+	it("applies the full host identity metadata before enabling events", async () => {
 		telemetryState.hostVersion = {
 			platform: "IntelliJ IDEA Ultimate",
 			version: "2026.1.1",
@@ -187,14 +187,36 @@ describe("VscodeTelemetryPolicyService", () => {
 
 		service.capture({ event: "task.created" })
 
-		expect(handle.telemetry.updateMetadata).toHaveBeenCalledWith({ host_plugin_version: "1.1.61" })
+		expect(handle.telemetry.updateMetadata).toHaveBeenCalledWith({
+			host_plugin_version: "1.1.61",
+			cline_type: "Cline for JetBrains",
+			platform: "IntelliJ IDEA Ultimate",
+			platform_version: "2026.1.1",
+		})
 		expect(handle.telemetry.capture).toHaveBeenCalledWith({ event: "task.created" })
 		const updateOrder = handle.telemetry.updateMetadata.mock.invocationCallOrder[0]
 		const captureOrder = handle.telemetry.capture.mock.invocationCallOrder[0]
 		expect(updateOrder).toBeLessThan(captureOrder)
 	})
 
-	it("omits host_plugin_version metadata when the host does not report one", async () => {
+	it("omits the metadata fields the host does not report", async () => {
+		// The default host version has no clineVersion, so host_plugin_version must be absent.
+		const handle = createHandle()
+		const service = new VscodeTelemetryPolicyService(handle)
+		await settlePromises()
+
+		service.capture({ event: "task.created" })
+
+		expect(handle.telemetry.updateMetadata).toHaveBeenCalledWith({
+			cline_type: "VSCode Extension",
+			platform: "VS Code",
+			platform_version: "1.103.0",
+		})
+		expect(handle.telemetry.capture).toHaveBeenCalledWith({ event: "task.created" })
+	})
+
+	it("skips the metadata update entirely when the host reports no identity fields", async () => {
+		telemetryState.hostVersion = {}
 		const handle = createHandle()
 		const service = new VscodeTelemetryPolicyService(handle)
 		await settlePromises()

--- a/apps/vscode/src/sdk/sdk-telemetry.test.ts
+++ b/apps/vscode/src/sdk/sdk-telemetry.test.ts
@@ -22,6 +22,7 @@ const telemetryState = vi.hoisted(() => ({
 		clineType: "VSCode Extension",
 	} as { platform?: string; version?: string; clineType?: string; clineVersion?: string },
 	hostVersionError: undefined as Error | undefined,
+	hostVersionGate: undefined as Promise<void> | undefined,
 	subscribeCallback: undefined as ((event: { isEnabled: number }) => void) | undefined,
 	unsubscribe: vi.fn(),
 }))
@@ -40,6 +41,9 @@ vi.mock("@/hosts/host-provider", () => ({
 		env: {
 			getTelemetrySettings: vi.fn(async () => ({ isEnabled: telemetryState.hostSetting })),
 			getHostVersion: vi.fn(async () => {
+				if (telemetryState.hostVersionGate) {
+					await telemetryState.hostVersionGate
+				}
 				if (telemetryState.hostVersionError) {
 					throw telemetryState.hostVersionError
 				}
@@ -65,6 +69,7 @@ describe("VscodeTelemetryPolicyService", () => {
 			clineType: "VSCode Extension",
 		}
 		telemetryState.hostVersionError = undefined
+		telemetryState.hostVersionGate = undefined
 		telemetryState.subscribeCallback = undefined
 		telemetryState.unsubscribe.mockReset()
 		coreTelemetryMocks.createConfig.mockClear()
@@ -90,6 +95,18 @@ describe("VscodeTelemetryPolicyService", () => {
 					platform: "unknown",
 					platform_version: "unknown",
 				}),
+			}),
+		)
+	})
+
+	it("defers the provider_created event so it carries resolved host identity", () => {
+		coreTelemetryMocks.createHandle.mockReturnValue(createHandle())
+
+		createVscodeSdkTelemetryHandle()
+
+		expect(coreTelemetryMocks.createHandle).toHaveBeenCalledWith(
+			expect.objectContaining({
+				deferProviderCreatedEvent: true,
 			}),
 		)
 	})
@@ -174,6 +191,8 @@ describe("VscodeTelemetryPolicyService", () => {
 
 		service.capture({ event: "task.created" })
 		telemetryState.subscribeCallback?.({ isEnabled: Setting.ENABLED })
+		// Subscription updates apply asynchronously, after host metadata resolution.
+		await settlePromises()
 		service.capture({ event: "task.created" })
 
 		expect(handle.telemetry.capture).toHaveBeenCalledTimes(1)
@@ -213,8 +232,10 @@ describe("VscodeTelemetryPolicyService", () => {
 		})
 		expect(handle.telemetry.capture).toHaveBeenCalledWith({ event: "task.created" })
 		const updateOrder = handle.telemetry.updateMetadata.mock.invocationCallOrder[0]
+		const providerCreatedOrder = handle.emitProviderCreated.mock.invocationCallOrder[0]
 		const captureOrder = handle.telemetry.capture.mock.invocationCallOrder[0]
-		expect(updateOrder).toBeLessThan(captureOrder)
+		expect(updateOrder).toBeLessThan(providerCreatedOrder)
+		expect(providerCreatedOrder).toBeLessThan(captureOrder)
 	})
 
 	it("omits the metadata fields the host does not report", async () => {
@@ -245,7 +266,7 @@ describe("VscodeTelemetryPolicyService", () => {
 		expect(handle.telemetry.capture).toHaveBeenCalledWith({ event: "task.created" })
 	})
 
-	it("still enables telemetry when the host version lookup fails", async () => {
+	it("still enables telemetry and emits provider_created when the host version lookup fails", async () => {
 		telemetryState.hostVersionError = new Error("host bridge unavailable")
 		const handle = createHandle()
 		const service = new VscodeTelemetryPolicyService(handle)
@@ -254,7 +275,32 @@ describe("VscodeTelemetryPolicyService", () => {
 		service.capture({ event: "task.created" })
 
 		expect(handle.telemetry.updateMetadata).not.toHaveBeenCalled()
+		expect(handle.emitProviderCreated).toHaveBeenCalledTimes(1)
 		expect(handle.telemetry.capture).toHaveBeenCalledWith({ event: "task.created" })
+	})
+
+	it("holds subscription-driven gate opens until the host identity is applied", async () => {
+		telemetryState.hostSetting = Setting.DISABLED
+		let releaseHostVersion!: () => void
+		telemetryState.hostVersionGate = new Promise((resolve) => {
+			releaseHostVersion = resolve
+		})
+		const handle = createHandle()
+		const service = new VscodeTelemetryPolicyService(handle)
+		await settlePromises()
+
+		telemetryState.subscribeCallback?.({ isEnabled: Setting.ENABLED })
+		await settlePromises()
+		service.capture({ event: "task.created" })
+		expect(handle.telemetry.capture).not.toHaveBeenCalled()
+		expect(handle.emitProviderCreated).not.toHaveBeenCalled()
+
+		releaseHostVersion()
+		await settlePromises()
+		service.capture({ event: "task.created" })
+		expect(handle.telemetry.updateMetadata).toHaveBeenCalledTimes(1)
+		expect(handle.emitProviderCreated).toHaveBeenCalledTimes(1)
+		expect(handle.telemetry.capture).toHaveBeenCalledTimes(1)
 	})
 
 	it("always forwards metadata mutators and cleans up on dispose", async () => {
@@ -270,7 +316,7 @@ describe("VscodeTelemetryPolicyService", () => {
 	})
 })
 
-function createHandle(): ConfiguredTelemetryHandle & { telemetry: MockTelemetry } {
+function createHandle(): ConfiguredTelemetryHandle & { telemetry: MockTelemetry; emitProviderCreated: Mock<() => void> } {
 	const telemetry: MockTelemetry = {
 		setDistinctId: vi.fn<(distinctId?: string) => void>(),
 		setMetadata: vi.fn<ITelemetryService["setMetadata"]>(),
@@ -290,6 +336,7 @@ function createHandle(): ConfiguredTelemetryHandle & { telemetry: MockTelemetry 
 		telemetry,
 		flush: vi.fn(async () => {}),
 		dispose: vi.fn(async () => {}),
+		emitProviderCreated: vi.fn<() => void>(),
 	}
 }
 

--- a/apps/vscode/src/sdk/sdk-telemetry.test.ts
+++ b/apps/vscode/src/sdk/sdk-telemetry.test.ts
@@ -303,6 +303,27 @@ describe("VscodeTelemetryPolicyService", () => {
 		expect(handle.telemetry.capture).toHaveBeenCalledTimes(1)
 	})
 
+	it("emits provider_created on dispose when the host version lookup is still pending", async () => {
+		let releaseHostVersion!: () => void
+		telemetryState.hostVersionGate = new Promise((resolve) => {
+			releaseHostVersion = resolve
+		})
+		const handle = createHandle()
+		const service = new VscodeTelemetryPolicyService(handle)
+		await settlePromises()
+
+		await service.dispose()
+		expect(handle.emitProviderCreated).toHaveBeenCalledTimes(1)
+		const providerCreatedOrder = handle.emitProviderCreated.mock.invocationCallOrder[0]
+		const disposeOrder = handle.dispose.mock.invocationCallOrder[0]
+		expect(providerCreatedOrder).toBeLessThan(disposeOrder)
+
+		// The late continuation must not emit a second event.
+		releaseHostVersion()
+		await settlePromises()
+		expect(handle.emitProviderCreated).toHaveBeenCalledTimes(1)
+	})
+
 	it("always forwards metadata mutators and cleans up on dispose", async () => {
 		const handle = createHandle()
 		const service = new VscodeTelemetryPolicyService(handle)
@@ -316,7 +337,11 @@ describe("VscodeTelemetryPolicyService", () => {
 	})
 })
 
-function createHandle(): ConfiguredTelemetryHandle & { telemetry: MockTelemetry; emitProviderCreated: Mock<() => void> } {
+function createHandle(): ConfiguredTelemetryHandle & {
+	telemetry: MockTelemetry
+	emitProviderCreated: Mock<() => void>
+	dispose: Mock<() => Promise<void>>
+} {
 	const telemetry: MockTelemetry = {
 		setDistinctId: vi.fn<(distinctId?: string) => void>(),
 		setMetadata: vi.fn<ITelemetryService["setMetadata"]>(),

--- a/apps/vscode/src/sdk/sdk-telemetry.ts
+++ b/apps/vscode/src/sdk/sdk-telemetry.ts
@@ -35,11 +35,11 @@ export function createVscodeSdkTelemetryHandle(options: CreateVscodeSdkTelemetry
 			...createClineTelemetryServiceConfig({
 				metadata: {
 					extension_version: ExtensionRegistryInfo.version,
-					// cline_type/platform/platform_version are fallbacks for when the host
-					// version lookup fails; VscodeTelemetryPolicyService replaces them with
-					// the authoritative getHostVersion values before any event is emitted.
-					cline_type: "VSCode Extension",
-					platform: "VS Code",
+					// VscodeTelemetryPolicyService replaces these with the authoritative
+					// getHostVersion values before any event is emitted. "unknown" surfaces
+					// a failed host version lookup instead of mislabeling the host as VSCode.
+					cline_type: "unknown",
+					platform: "unknown",
 					platform_version: "unknown",
 					os_type: process.platform,
 					os_version: os.version(),
@@ -182,7 +182,7 @@ export class VscodeTelemetryPolicyService implements ITelemetryService {
 
 	// Mirrors the classic TelemetryService.create() mapping of GetHostVersionResponse
 	// fields, so both pipelines report the same host identity. Fields the host does not
-	// report are left out to keep the handle's construction-time fallbacks.
+	// report are left out to keep the handle's construction-time "unknown" fallbacks.
 	private async resolveHostMetadata(): Promise<Partial<TelemetryMetadata>> {
 		try {
 			const hostVersion = await HostProvider.env.getHostVersion({})

--- a/apps/vscode/src/sdk/sdk-telemetry.ts
+++ b/apps/vscode/src/sdk/sdk-telemetry.ts
@@ -49,6 +49,10 @@ export function createVscodeSdkTelemetryHandle(options: CreateVscodeSdkTelemetry
 			}),
 			commonProperties: getRolloutTelemetryMetadata(),
 			distinctId: getDistinctId() || undefined,
+			// telemetry.provider_created is otherwise captured during construction,
+			// before the host identity resolves; VscodeTelemetryPolicyService emits
+			// it once the getHostVersion metadata has been applied.
+			deferProviderCreatedEvent: true,
 		})
 
 	const telemetry = new VscodeTelemetryPolicyService(sdkHandle)
@@ -63,6 +67,7 @@ export class VscodeTelemetryPolicyService implements ITelemetryService {
 	private hostTelemetryEnabled = false
 	private disposed = false
 	private unsubscribeHostTelemetrySettings?: () => void
+	private receivedHostSubscriptionUpdate = false
 
 	constructor(private readonly handle: ConfiguredTelemetryHandle) {
 		this.initializeHostTelemetryState()
@@ -149,15 +154,24 @@ export class VscodeTelemetryPolicyService implements ITelemetryService {
 	}
 
 	private initializeHostTelemetryState(): void {
-		// Resolve host-derived metadata together with the telemetry setting and apply
-		// it first: events stay gated until the setting is applied, so this ordering
-		// guarantees no event is emitted before the host identity metadata is in place.
-		Promise.all([this.resolveHostMetadata(), HostProvider.env.getTelemetrySettings({})])
-			.then(([hostMetadata, settings]) => {
-				if (Object.keys(hostMetadata).length > 0) {
-					this.handle.telemetry.updateMetadata(hostMetadata)
+		// Resolve host-derived metadata first and only then let events flow: the gate
+		// below (and every subscription update) waits on this promise, so no event —
+		// including the deferred provider_created — is emitted before the host
+		// identity metadata is in place. Never rejects: resolveHostMetadata catches.
+		const hostMetadataApplied = this.resolveHostMetadata().then((hostMetadata) => {
+			if (Object.keys(hostMetadata).length > 0) {
+				this.handle.telemetry.updateMetadata(hostMetadata)
+			}
+			this.handle.emitProviderCreated?.()
+		})
+
+		Promise.all([hostMetadataApplied, HostProvider.env.getTelemetrySettings({})])
+			.then(([, settings]) => {
+				// A subscription event is always newer than the initial fetch; don't
+				// let a slow fetch overwrite a setting change that already arrived.
+				if (!this.receivedHostSubscriptionUpdate) {
+					this.applyHostTelemetrySetting(settings.isEnabled)
 				}
-				this.applyHostTelemetrySetting(settings.isEnabled)
 			})
 			.catch((error) => {
 				Logger.warn("[SdkTelemetry] Failed to read host telemetry setting; keeping SDK telemetry disabled", error)
@@ -168,7 +182,11 @@ export class VscodeTelemetryPolicyService implements ITelemetryService {
 				{},
 				{
 					onResponse: (event: TelemetrySettingsEvent) => {
-						this.applyHostTelemetrySetting(event.isEnabled)
+						this.receivedHostSubscriptionUpdate = true
+						// Chain on the metadata promise so a setting flip cannot open the
+						// gate while the host identity is still resolving. Chained callbacks
+						// run in attach order, so multiple updates apply in arrival order.
+						hostMetadataApplied.then(() => this.applyHostTelemetrySetting(event.isEnabled))
 					},
 					onError: (error: Error) => {
 						Logger.warn("[SdkTelemetry] Host telemetry subscription failed; keeping last known state", error)

--- a/apps/vscode/src/sdk/sdk-telemetry.ts
+++ b/apps/vscode/src/sdk/sdk-telemetry.ts
@@ -68,6 +68,7 @@ export class VscodeTelemetryPolicyService implements ITelemetryService {
 	private disposed = false
 	private unsubscribeHostTelemetrySettings?: () => void
 	private receivedHostSubscriptionUpdate = false
+	private providerCreatedEmitted = false
 
 	constructor(private readonly handle: ConfiguredTelemetryHandle) {
 		this.initializeHostTelemetryState()
@@ -150,7 +151,19 @@ export class VscodeTelemetryPolicyService implements ITelemetryService {
 		this.disposed = true
 		this.unsubscribeHostTelemetrySettings?.()
 		this.unsubscribeHostTelemetrySettings = undefined
+		// If the host-version lookup is still pending, emit the deferred
+		// provider_created now (with the construction-time fallback identity, as the
+		// undeferred event always did) so disposal never swallows the required event.
+		this.emitProviderCreatedOnce()
 		await this.handle.dispose()
+	}
+
+	private emitProviderCreatedOnce(): void {
+		if (this.providerCreatedEmitted) {
+			return
+		}
+		this.providerCreatedEmitted = true
+		this.handle.emitProviderCreated?.()
 	}
 
 	private initializeHostTelemetryState(): void {
@@ -162,7 +175,7 @@ export class VscodeTelemetryPolicyService implements ITelemetryService {
 			if (Object.keys(hostMetadata).length > 0) {
 				this.handle.telemetry.updateMetadata(hostMetadata)
 			}
-			this.handle.emitProviderCreated?.()
+			this.emitProviderCreatedOnce()
 		})
 
 		Promise.all([hostMetadataApplied, HostProvider.env.getTelemetrySettings({})])

--- a/apps/vscode/src/sdk/sdk-telemetry.ts
+++ b/apps/vscode/src/sdk/sdk-telemetry.ts
@@ -35,6 +35,9 @@ export function createVscodeSdkTelemetryHandle(options: CreateVscodeSdkTelemetry
 			...createClineTelemetryServiceConfig({
 				metadata: {
 					extension_version: ExtensionRegistryInfo.version,
+					// cline_type/platform/platform_version are fallbacks for when the host
+					// version lookup fails; VscodeTelemetryPolicyService replaces them with
+					// the authoritative getHostVersion values before any event is emitted.
 					cline_type: "VSCode Extension",
 					platform: "VS Code",
 					platform_version: "unknown",
@@ -148,11 +151,11 @@ export class VscodeTelemetryPolicyService implements ITelemetryService {
 	private initializeHostTelemetryState(): void {
 		// Resolve host-derived metadata together with the telemetry setting and apply
 		// it first: events stay gated until the setting is applied, so this ordering
-		// guarantees no event is emitted before host_plugin_version is in place.
-		Promise.all([this.resolveHostPluginVersion(), HostProvider.env.getTelemetrySettings({})])
-			.then(([hostPluginVersion, settings]) => {
-				if (hostPluginVersion) {
-					this.handle.telemetry.updateMetadata({ host_plugin_version: hostPluginVersion })
+		// guarantees no event is emitted before the host identity metadata is in place.
+		Promise.all([this.resolveHostMetadata(), HostProvider.env.getTelemetrySettings({})])
+			.then(([hostMetadata, settings]) => {
+				if (Object.keys(hostMetadata).length > 0) {
+					this.handle.telemetry.updateMetadata(hostMetadata)
 				}
 				this.applyHostTelemetrySetting(settings.isEnabled)
 			})
@@ -177,13 +180,21 @@ export class VscodeTelemetryPolicyService implements ITelemetryService {
 		}
 	}
 
-	private async resolveHostPluginVersion(): Promise<string | undefined> {
+	// Mirrors the classic TelemetryService.create() mapping of GetHostVersionResponse
+	// fields, so both pipelines report the same host identity. Fields the host does not
+	// report are left out to keep the handle's construction-time fallbacks.
+	private async resolveHostMetadata(): Promise<Partial<TelemetryMetadata>> {
 		try {
 			const hostVersion = await HostProvider.env.getHostVersion({})
-			return hostVersion.clineVersion || undefined
+			return {
+				...(hostVersion.clineVersion ? { host_plugin_version: hostVersion.clineVersion } : {}),
+				...(hostVersion.clineType ? { cline_type: hostVersion.clineType } : {}),
+				...(hostVersion.platform ? { platform: hostVersion.platform } : {}),
+				...(hostVersion.version ? { platform_version: hostVersion.version } : {}),
+			}
 		} catch (error) {
 			Logger.warn("[SdkTelemetry] Failed to resolve host version for telemetry metadata", error)
-			return undefined
+			return {}
 		}
 	}
 

--- a/apps/vscode/src/test/cline-core-vitest-stub.ts
+++ b/apps/vscode/src/test/cline-core-vitest-stub.ts
@@ -222,6 +222,7 @@ export interface ConfiguredTelemetryHandle {
 	readonly telemetry: ITelemetryService
 	flush(): Promise<void>
 	dispose(): Promise<void>
+	emitProviderCreated?(): void
 }
 
 function createNoopTelemetry(): ITelemetryService {

--- a/sdk/packages/core/src/services/telemetry/OpenTelemetryProvider.test.ts
+++ b/sdk/packages/core/src/services/telemetry/OpenTelemetryProvider.test.ts
@@ -72,6 +72,43 @@ describe("createOpenTelemetryTelemetryService", () => {
 		await provider.dispose();
 	});
 
+	it("defers the provider creation event until emitProviderCreated is called", async () => {
+		const captureRequired = vi
+			.spyOn(TelemetryService.prototype, "captureRequired")
+			.mockImplementation(() => {});
+
+		const { provider, emitProviderCreated } =
+			createOpenTelemetryTelemetryService({
+				metadata: {
+					extension_version: "1.2.3",
+					cline_type: "cli",
+					platform: "terminal",
+					platform_version: process.version,
+					os_type: process.platform,
+					os_version: "unknown",
+				},
+				enabled: true,
+				logsExporter: "console",
+				serviceName: "cline-cli",
+				serviceVersion: "1.2.3",
+				deferProviderCreatedEvent: true,
+			});
+
+		expect(captureRequired).not.toHaveBeenCalled();
+
+		emitProviderCreated();
+
+		expect(captureRequired).toHaveBeenCalledWith(
+			"telemetry.provider_created",
+			expect.objectContaining({
+				provider: "opentelemetry",
+				serviceName: "cline-cli",
+			}),
+		);
+
+		await provider.dispose();
+	});
+
 	it("registers a tracer provider when tracesExporter is set", async () => {
 		const { provider } = createOpenTelemetryTelemetryService({
 			metadata: {

--- a/sdk/packages/core/src/services/telemetry/OpenTelemetryProvider.ts
+++ b/sdk/packages/core/src/services/telemetry/OpenTelemetryProvider.ts
@@ -135,6 +135,14 @@ export interface CreateOpenTelemetryTelemetryServiceOptions
 		> {
 	metadata: TelemetryMetadata;
 	logger?: BasicLogger;
+	/**
+	 * Skip the automatic `telemetry.provider_created` event during construction
+	 * and expose it as {@link ConfiguredTelemetryHandle.emitProviderCreated}
+	 * instead. Metadata is stamped onto events at capture time, so hosts that
+	 * resolve identity metadata asynchronously (e.g. over the host bridge) defer
+	 * the event until that metadata is applied.
+	 */
+	deferProviderCreatedEvent?: boolean;
 }
 
 export class OpenTelemetryProvider {
@@ -330,29 +338,39 @@ export class OpenTelemetryProvider {
 
 export function createOpenTelemetryTelemetryService(
 	options: CreateOpenTelemetryTelemetryServiceOptions,
-): { provider: OpenTelemetryProvider; telemetry: ITelemetryService } {
+): {
+	provider: OpenTelemetryProvider;
+	telemetry: ITelemetryService;
+	emitProviderCreated: () => void;
+} {
 	const provider = new OpenTelemetryProvider(options);
 	const telemetry = provider.createTelemetryService(options);
-	telemetry.captureRequired("telemetry.provider_created", {
-		provider: "opentelemetry",
-		enabled: options.enabled ?? true,
-		logsExporter: Array.isArray(options.logsExporter)
-			? options.logsExporter.join(",")
-			: options.logsExporter,
-		metricsExporter: Array.isArray(options.metricsExporter)
-			? options.metricsExporter.join(",")
-			: options.metricsExporter,
-		tracesExporter: Array.isArray(options.tracesExporter)
-			? options.tracesExporter.join(",")
-			: options.tracesExporter,
-		otlpProtocol: options.otlpProtocol,
-		hasOtlpEndpoint: Boolean(options.otlpEndpoint),
-		serviceName: options.serviceName,
-		serviceVersion: options.serviceVersion,
-	});
+	const emitProviderCreated = () => {
+		telemetry.captureRequired("telemetry.provider_created", {
+			provider: "opentelemetry",
+			enabled: options.enabled ?? true,
+			logsExporter: Array.isArray(options.logsExporter)
+				? options.logsExporter.join(",")
+				: options.logsExporter,
+			metricsExporter: Array.isArray(options.metricsExporter)
+				? options.metricsExporter.join(",")
+				: options.metricsExporter,
+			tracesExporter: Array.isArray(options.tracesExporter)
+				? options.tracesExporter.join(",")
+				: options.tracesExporter,
+			otlpProtocol: options.otlpProtocol,
+			hasOtlpEndpoint: Boolean(options.otlpEndpoint),
+			serviceName: options.serviceName,
+			serviceVersion: options.serviceVersion,
+		});
+	};
+	if (!options.deferProviderCreatedEvent) {
+		emitProviderCreated();
+	}
 	return {
 		provider,
 		telemetry,
+		emitProviderCreated,
 	};
 }
 
@@ -361,6 +379,7 @@ export function createConfiguredTelemetryService(
 ): {
 	provider?: OpenTelemetryProvider;
 	telemetry: ITelemetryService;
+	emitProviderCreated?: () => void;
 } {
 	if (isTelemetryOptedOutGlobally()) {
 		return {
@@ -404,6 +423,12 @@ export interface ConfiguredTelemetryHandle {
 	flush: () => Promise<void>;
 	/** Disposes the telemetry service and its provider concurrently. */
 	dispose: () => Promise<void>;
+	/**
+	 * Emits the `telemetry.provider_created` event. Only present when the
+	 * handle was created with `deferProviderCreatedEvent: true` and telemetry
+	 * is enabled; the host must call it once its identity metadata is applied.
+	 */
+	emitProviderCreated?: () => void;
 }
 
 /**
@@ -415,7 +440,8 @@ export interface ConfiguredTelemetryHandle {
 export function createConfiguredTelemetryHandle(
 	options: CreateOpenTelemetryTelemetryServiceOptions,
 ): ConfiguredTelemetryHandle {
-	const { telemetry, provider } = createConfiguredTelemetryService(options);
+	const { telemetry, provider, emitProviderCreated } =
+		createConfiguredTelemetryService(options);
 
 	const flush = async (): Promise<void> => {
 		const candidate = provider as
@@ -434,7 +460,15 @@ export function createConfiguredTelemetryHandle(
 		await Promise.allSettled([telemetry.dispose(), provider?.dispose()]);
 	};
 
-	return { telemetry, provider, flush, dispose };
+	return {
+		telemetry,
+		provider,
+		flush,
+		dispose,
+		...(options.deferProviderCreatedEvent && emitProviderCreated
+			? { emitProviderCreated }
+			: {}),
+	};
 }
 
 function normalizeExporters(


### PR DESCRIPTION
> Follow-up to #12478 (merged) — rebased onto `main` on top of it.

### Problem

On JetBrains standalone cline-core, SDK-pipeline events (task lifecycle, token usage, tool usage, provider failures) report a hardcoded host identity: `cline_type: "VSCode Extension"`, `platform: "VS Code"`, `platform_version: "unknown"`. The classic `TelemetryService` resolves these from `HostProvider.env.getHostVersion()`, so the two pipelines disagree about what host the event came from.

### Fix

Follow-up to #12478: the same `Promise.all` + `updateMetadata`-before-`applyHostTelemetrySetting` plumbing that resolves `host_plugin_version` now applies the full host identity, using the exact field mapping of the classic `TelemetryService.create()`:

- `cline_type` ← `hostVersion.clineType`
- `platform` ← `hostVersion.platform`
- `platform_version` ← `hostVersion.version`

Events stay gated until the host telemetry setting is applied, which happens after the metadata update in the same continuation — so no event is emitted with the stale hardcoded identity. The construction-time fallbacks are now `"unknown"` (matching the classic pipeline's `|| "unknown"` semantics) instead of VSCode-flavored labels, so a failed `getHostVersion` lookup shows up as `"unknown"` in the data rather than hiding as a plausible-looking VSCode row. A failed lookup still enables telemetry (unchanged behavior).

### provider_created + gate-ordering hardening (review follow-up)

`telemetry.provider_created` was captured synchronously inside the core factory — before the policy service resolves host identity — so that one event always escaped with construction-time metadata (pre-existing: on JetBrains it reported the hardcoded VSCode identity; it also never carried `host_plugin_version`). Metadata is stamped at capture time, so the fix is deferral: an opt-in `deferProviderCreatedEvent` on the core telemetry factories exposes the emission as `ConfiguredTelemetryHandle.emitProviderCreated`, and the policy service fires it right after applying host metadata. All other handle consumers (CLI, hub daemon, examples) keep immediate emission.

Two gate-ordering races on the same guarantee are also closed:
- a host telemetry setting flip arriving over the subscription while `getHostVersion` is still resolving now waits for the metadata to be applied before opening the gate;
- a slow initial `getTelemetrySettings` fetch no longer overwrites a newer subscription update.

### Dashboard impact

- **JetBrains** SDK-pipeline rows flip from `cline_type: "VSCode Extension"` / `platform: "VS Code"` / `platform_version: "unknown"` to `"Cline for JetBrains"` / the IDE product name (e.g. `"IntelliJ IDEA Ultimate"`) / the IDE version. Any dashboard/query that filters SDK-pipeline events by `cline_type = 'VSCode Extension'` and implicitly relied on JB rows being mislabeled will see those rows move.
- **VS Code** rows also become more precise: `platform` changes from the hardcoded `"VS Code"` to `vscode.env.appName` (e.g. `"Visual Studio Code"`) and `platform_version` from `"unknown"` to the real VS Code version — matching what the classic pipeline already reports.

### Tests

Extended the vitest boundary suite in `apps/vscode/src/sdk/sdk-telemetry.test.ts`:
- full host identity applied (JetBrains case) before the first event, ordering asserted
- fields the host omits are left out of the update (default VS Code case, no `clineVersion`)
- no `updateMetadata` call at all when the host reports no identity fields
- construction-time fallbacks are `"unknown"`, not VSCode labels
- `getHostVersion` failure still enables telemetry (pre-existing case, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
