### PR TITLE
test(cli): relax cold history dispatch timeout

### DIFF
--- a/apps/cli/src/main.test.ts
+++ b/apps/cli/src/main.test.ts
@@ -333,7 +333,7 @@ describe("runCli lightweight command dispatch", () => {
 		expect(historyListCalls[0]?.[0]).not.toHaveProperty("workspaceRoot");
 		expect(mockState.runAgentImports).toBe(0);
 		expect(mockState.runInteractiveImports).toBe(0);
-	});
+	}, 30_000);
 
 	it("does not load runtime modules for root update", async () => {
 		mockState.runAgentImports = 0;


### PR DESCRIPTION
### Description

Raises the timeout for the first CLI lightweight-dispatch test from 15s to 30s. This test pays the cold `main.ts` module-import cost while the monorepo test command runs packages concurrently; it is a correctness/import-boundary assertion, not a performance benchmark.

Recent successful `main` jobs took 12.7s, 13.3s, and 14.4s for this test. PR #12364 then failed twice at 15.075s and 15.040s while all other 890 CLI tests passed, demonstrating that the existing threshold has insufficient runner-load headroom.

No production code changes.

### Verification

- `bunx biome check --diagnostic-level=error src/main.test.ts`
- `bunx vitest run src/main.test.ts --config vitest.config.ts` — 71 passed
- [Manually dispatched full `sdk-test` workflow](https://github.com/cline/cline/actions/runs/30042327487) — Quality, Ubuntu, and Windows passed
