### PR TITLE
fix(cli): patch @opentui-ui/dialog for opentui 0.4.x remove() contract

### DIFF
--- a/apps/cli/src/tests/interactive/chat.test.ts
+++ b/apps/cli/src/tests/interactive/chat.test.ts
@@ -17,14 +17,19 @@
 //   - Auto-approve all (Shift+Tab)
 // ---------------------------------------------------------------------------
 
-import { test } from "@microsoft/tui-test";
+import { expect, test } from "@microsoft/tui-test";
+import type { Terminal } from "@microsoft/tui-test/lib/terminal/term";
 import { CLINE_BIN, TERMINAL_WIDE } from "../helpers/constants.js";
 import { clineEnv } from "../helpers/env.js";
 import {
 	toggleAutoApproveAll,
 	waitForChatReady,
 } from "../helpers/page-objects/chat.js";
-import { expectVisible } from "../helpers/terminal.js";
+import {
+	expectNotVisible,
+	expectVisible,
+	typeAndSubmit,
+} from "../helpers/terminal.js";
 
 test.describe("cline (authenticated) - shows chat view", () => {
 	test.use({
@@ -51,5 +56,56 @@ test.describe("Auto-approve all - Shift+Tab toggle", () => {
 		await toggleAutoApproveAll(terminal);
 		await expectVisible(terminal, "Auto-approve all disabled");
 		await toggleAutoApproveAll(terminal);
+	});
+});
+
+test.describe("Dialog dismissal - panel is fully removed", () => {
+	test.use({
+		program: { file: CLINE_BIN, args: [] },
+		...TERMINAL_WIDE,
+		env: clineEnv("default"),
+	});
+
+	// The dialog panel's background is @opentui-ui/dialog's DEFAULT_STYLE
+	// (#262626), which xterm reports as this packed 24-bit color.
+	const DIALOG_PANEL_BG = 0x262626;
+
+	const countPanelCells = (terminal: Terminal): number => {
+		let count = 0;
+		for (const shift of terminal.serialize().shifts.values()) {
+			if (shift.bgColor === DIALOG_PANEL_BG) {
+				count++;
+			}
+		}
+		return count;
+	};
+
+	// @opentui-ui/dialog is built against @opentui/core ^0.1.69, whose
+	// Renderable.remove(id) took an id. Core 0.4.x renamed it to
+	// remove(child) and throws on a non-renderable argument, so the
+	// package's removeDialog() aborted before detaching its panel — the React
+	// portal content unmounted, but the imperative grey box stayed on screen
+	// over the chat. Asserting on the panel's background (not its text) is what
+	// distinguishes a leaked box from a clean teardown.
+	test("closing the help dialog removes its grey panel", async ({
+		terminal,
+	}) => {
+		await waitForChatReady(terminal);
+		await typeAndSubmit(terminal, "/help");
+		await expectVisible(terminal, "Keyboard Shortcuts");
+		expect(countPanelCells(terminal)).toBeGreaterThan(0);
+
+		terminal.keyEscape();
+		await expectNotVisible(terminal, "Keyboard Shortcuts");
+
+		// The panel unmounts a frame after its content; poll until the
+		// dialog's imperative box is detached rather than sampling once.
+		const deadline = Date.now() + 10_000;
+		let remaining = countPanelCells(terminal);
+		while (remaining > 0 && Date.now() < deadline) {
+			await new Promise((resolve) => setTimeout(resolve, 100));
+			remaining = countPanelCells(terminal);
+		}
+		expect(remaining).toBe(0);
 	});
 });

--- a/bun.lock
+++ b/bun.lock
@@ -772,6 +772,9 @@
     "better-sqlite3",
     "grpc-tools",
   ],
+  "patchedDependencies": {
+    "@opentui-ui/dialog@0.1.2": "patches/@opentui-ui%2Fdialog@0.1.2.patch",
+  },
   "overrides": {
     "@opentui/core": "0.4.3",
     "@opentui/react": "0.4.3",

--- a/package.json
+++ b/package.json
@@ -86,5 +86,8 @@
         "better-sqlite3",
         "grpc-tools"
     ],
-    "packageManager": "bun@1.3.13"
+    "packageManager": "bun@1.3.13",
+    "patchedDependencies": {
+        "@opentui-ui/dialog@0.1.2": "patches/@opentui-ui%2Fdialog@0.1.2.patch"
+    }
 }

--- a/patches/@opentui-ui%2Fdialog@0.1.2.patch
+++ b/patches/@opentui-ui%2Fdialog@0.1.2.patch
@@ -1,0 +1,39 @@
+diff --git a/dist/dialog-container-Btgzkwy7.mjs b/dist/dialog-container-Btgzkwy7.mjs
+index fa1f29023479d5df2daf399c42f1d492365365aa..9a576b394c551269e6944bbb08fb43f7a7d3a8ca 100644
+--- a/dist/dialog-container-Btgzkwy7.mjs
++++ b/dist/dialog-container-Btgzkwy7.mjs
+@@ -677,7 +677,7 @@ var DialogContainerRenderable = class extends BoxRenderable {
+ 		const renderable = this._dialogRenderables.get(id);
+ 		if (renderable) {
+ 			this._dialogRenderables.delete(id);
+-			this.remove(renderable.id);
++			this.remove(renderable);
+ 			renderable.destroyRecursively();
+ 			this.updateBackdropVisibility();
+ 			this.updateBackdropStyle();
+diff --git a/dist/react.mjs b/dist/react.mjs
+index 157bd9c3ba3101810e02da720b8763425fd7b0fd..70bb55028ff815a82fea84205c61fb85d2aac03a 100644
+--- a/dist/react.mjs
++++ b/dist/react.mjs
+@@ -169,7 +169,7 @@ function DialogProvider(props) {
+ 		renderer.root.add(container);
+ 		return () => {
+ 			container.destroyRecursively();
+-			renderer.root.remove(container.id);
++			renderer.root.remove(container);
+ 			manager.destroy();
+ 		};
+ 	}, [
+diff --git a/dist/solid.mjs b/dist/solid.mjs
+index 2aea0ede350d79b5a8e533323fe70480bbd7f3ce..f075087a57c68875f341baa9ada67231fcc9cb10 100644
+--- a/dist/solid.mjs
++++ b/dist/solid.mjs
+@@ -192,7 +192,7 @@ function DialogProvider(props) {
+ 		unsubscribe();
+ 		portalItemCache.clear();
+ 		container.destroyRecursively();
+-		renderer.root.remove(container.id);
++		renderer.root.remove(container);
+ 		manager.destroy();
+ 	});
+ 	createEffect(() => {


### PR DESCRIPTION
### Related Issue

**Issue:** cline/cline#12506

### Description

Switching models (`Ctrl+P → Change Model`) — and dismissing any CLI dialog —<br>left an empty grey box rendered over the chat after the dialog closed. The<br>issue bisected this to cline/cline#12453, the `@opentui/core`/`@opentui/react`<br>`0.1.102 → 0.4.3` upgrade.

Root cause is an external contract break. `@opentui-ui/dialog@0.1.2` is built<br>against `@opentui/core` peer `^0.1.69`, whose `Renderable.remove(id: string)`<br>took a string id. Core `0.4.x` renamed it to `remove(child: BaseRenderable)`<br>and now **throws** when handed anything that is not a renderable:

```
remove expects a renderable child object
```

The dialog package still calls `this.remove(renderable.id)` (and<br>`renderer.root.remove(container.id)`). On `0.4.3` those calls throw inside the<br>manager's subscriber, which the manager catches and logs — so `removeDialog()`<br>aborts **after** deleting its bookkeeping entry but **before** detaching the<br>panel from the render tree. The React portal content unmounts (that is<br>declarative), but the imperative dialog box (`DEFAULT_STYLE` background<br>`#262626`) is never removed, so it persists over live console output. This is<br>exactly the "content is gone, but its box is not un-rendered" symptom.

Because the bug is 100% deterministic at the JS level, "can't reproduce on<br>Mac" was not idiosyncratic to our machines — it is a `bun install` timing<br>artifact. The `.bun` store can retain a nested `@opentui/core@0.1.102` copy<br>under the dialog package from before the upgrade; whichever store variant the<br>dialog happens to link against decides whether `remove` is the old<br>id-accepting version (no box) or the new object-only version (grey box). A<br>fresh install from the current lockfile always links `0.4.3`, so the grey box<br>is what everyone gets going forward.

`@opentui-ui/dialog` is abandoned upstream at `0.1.2`, so the fix is a<br>`bun patch` that passes the renderable object instead of its id in all three<br>bindings (`dist/dialog-container-*.mjs`, `dist/react.mjs`, `dist/solid.mjs`).<br>The patch is recorded in `patchedDependencies`, so it is applied on every<br>install and baked into the published binary (which bundles the dialog package<br>at build time).

### Test Procedure

Automated regression (tui-test), added in this PR:

```bash
bun -F @cline/cli build
cd apps/cli/src/tests && npx tui-test 'interactive/chat.test.ts'
```

The new test opens `/help`, confirms the dialog's `#262626` panel is present,<br>presses Esc, and asserts the panel background is fully gone — not just its<br>text. Text alone does not catch the bug (the React portal always unmounts); the<br>leaked artifact is the imperative box, so the assertion samples the cell<br>background color via `terminal.serialize()`.

Verified the test has teeth: against the unpatched dialog it fails with the<br>grey panel still present (`expect(remaining).toBe(0)` receives `2`); with the<br>patch it passes.

Also verified:

```bash
cd apps/cli && bun run test:unit   # 903 passed
cd apps/cli && bun run typecheck   # clean
bun biome check apps/cli/src/tests/interactive/chat.test.ts   # clean
```

And that the patch survives a clean install and reaches the shipped artifact:<br>`rm -rf` the dialog store dir, `bun install`, and confirm the store copy<br>contains `this.remove(renderable)`; `bun script/build.ts --single` produces a<br>binary that bundles the patched package.

### Type of Change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [X] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
- [X] I have reviewed [contributor guidelines](<https://github.com/cline/cline/blob/main/CONTRIBUTING.md>)

### Additional Notes

cc reviewers of cline/cline#12453: @abeatrix @saoudrizwan

One benign artifact remains at full-app teardown: `DialogProvider`'s unmount<br>runs `container.destroyRecursively()` (which detaches the container) before<br>`renderer.root.remove(container)`, so core logs `Renderable ... is not a child of __root__, skipping remove`. That path previously *threw* on `0.4.x`; the<br>patch downgrades it to a harmless warn during shutdown and does not affect the<br>grey-box fix.

---

> \[!NOTE\]<br>**Low Risk**<br>Targeted vendor patch plus regression test; no auth or data paths, only dialog teardown behavior in the CLI TUI.
>
> **Overview**<br>Fixes a **persistent grey dialog overlay** after closing CLI modals (e.g. `/help`, model picker) by aligning `@opentui-ui/dialog` with `@opentui/core` **0.4.x**, where `remove()` expects a renderable child instead of an id.
>
> A `bun patch` on `@opentui-ui/dialog@0.1.2` updates three dist entry points to call `remove(renderable)` / `remove(container)` instead of passing `.id`, and `patchedDependencies` is wired in the root `package.json` and lockfile so every install applies it.
>
> Adds an interactive **tui-test** that opens `/help`, confirms the `#262626` panel cells exist, dismisses with Esc, and polls until no dialog background remains—catching the case where portal text disappears but the imperative box leaks.
>
> Reviewed by [Cursor Bugbot](<https://cursor.com/bugbot>) for commit 1ac8fd5a29d5c220064a69114a931c556b406418. Bugbot is set up for automated code reviews on this repo. Configure [here](<https://www.cursor.com/dashboard/bugbot>).