### PR TITLE
fix(vscode): preserve chat reading position

### DIFF
--- a/apps/vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -235,9 +235,6 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 
 	// handleFocusChange is already provided by chatState
 
-	// Use message handlers hook
-	const messageHandlers = useMessageHandlers(messages, chatState)
-
 	const { selectedModelInfo } = useNormalizedApiConfiguration(mode)
 
 	const selectFilesAndImages = useCallback(async () => {
@@ -360,6 +357,12 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 
 	// Use scroll behavior hook
 	const scrollBehavior = useScrollBehavior(displayMessages, visibleMessages, groupedMessages, expandedRows, setExpandedRows)
+	const chatStateWithScroll = {
+		...chatState,
+		isAtBottom: scrollBehavior.isAtBottom,
+		disableAutoScrollRef: scrollBehavior.disableAutoScrollRef,
+	}
+	const messageHandlers = useMessageHandlers(messages, chatStateWithScroll)
 
 	const placeholderText = useMemo(() => {
 		const text = task ? "Type a message..." : "Type your task here..."
@@ -394,7 +397,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 				)}
 				{task && (
 					<MessagesArea
-						chatState={chatState}
+						chatState={chatStateWithScroll}
 						groupedMessages={groupedMessages}
 						messageHandlers={messageHandlers}
 						modifiedMessages={modifiedMessages}
@@ -406,7 +409,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 			<footer className="bg-(--vscode-sidebar-background) flex flex-col" style={{ gridRow: "2" }}>
 				<AutoApproveBar />
 				<ActionButtons
-					chatState={chatState}
+					chatState={chatStateWithScroll}
 					messageHandlers={messageHandlers}
 					messages={messages}
 					mode={mode}
@@ -414,7 +417,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 				/>
 				<QueuedPrompts items={queuedPrompts} />
 				<InputSection
-					chatState={chatState}
+					chatState={chatStateWithScroll}
 					messageHandlers={messageHandlers}
 					placeholderText={placeholderText}
 					scrollBehavior={scrollBehavior}

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/MessagesArea.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/MessagesArea.tsx
@@ -234,11 +234,11 @@ export const MessagesArea: React.FC<MessagesAreaProps> = ({
 	useEffect(() => {
 		const prevPhase = prevTurnPhaseRef.current
 		prevTurnPhaseRef.current = turnState?.phase
-		if (turnState?.phase === "streaming" && prevPhase !== "streaming") {
+		if (turnState?.phase === "streaming" && prevPhase !== "streaming" && scrollBehavior.isAtBottom) {
 			disableAutoScrollRef.current = false
 			scrollToBottomSmooth()
 		}
-	}, [turnState?.phase, scrollToBottomSmooth, disableAutoScrollRef])
+	}, [turnState?.phase, scrollBehavior.isAtBottom, scrollToBottomSmooth, disableAutoScrollRef])
 
 	const itemContent = useMemo(
 		() =>

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/MessagesArea.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/MessagesArea.tsx
@@ -294,9 +294,7 @@ export const MessagesArea: React.FC<MessagesAreaProps> = ({
 				<Virtuoso
 					atBottomStateChange={(isAtBottom) => {
 						setIsAtBottom(isAtBottom)
-						if (isAtBottom) {
-							disableAutoScrollRef.current = false
-						}
+						disableAutoScrollRef.current = !isAtBottom
 					}}
 					atBottomThreshold={10} // trick to make sure virtuoso re-renders when task changes, and we use initialTopMostItemIndex to start at the bottom
 					className="scrollable grow overflow-y-scroll"

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.test.tsx
@@ -120,6 +120,38 @@ describe("useMessageHandlers — send routing", () => {
 		expect(trackIntent).not.toHaveBeenCalled()
 	})
 
+	it("preserves the reading position when sending from above the bottom", async () => {
+		mockTurnState = { phase: "completed", seq: 7 }
+		const disableAutoScrollRef = { current: true }
+		const chatState = makeChatState(completedConversation, {
+			isAtBottom: false,
+			disableAutoScrollRef,
+		})
+		const { result } = renderHook(() => useMessageHandlers(completedConversation, chatState))
+
+		await act(async () => {
+			await result.current.handleSendMessage("A follow-up", [], [])
+		})
+
+		expect(disableAutoScrollRef.current).toBe(true)
+	})
+
+	it("keeps live chat pinned when sending at the bottom", async () => {
+		mockTurnState = { phase: "completed", seq: 7 }
+		const disableAutoScrollRef = { current: true }
+		const chatState = makeChatState(completedConversation, {
+			isAtBottom: true,
+			disableAutoScrollRef,
+		})
+		const { result } = renderHook(() => useMessageHandlers(completedConversation, chatState))
+
+		await act(async () => {
+			await result.current.handleSendMessage("A follow-up", [], [])
+		})
+
+		expect(disableAutoScrollRef.current).toBe(false)
+	})
+
 	it("routes the /smol alias to the condense RPC as well", async () => {
 		mockTurnState = { phase: "completed", seq: 7 }
 		const { result } = renderHook(() => useMessageHandlers(completedConversation, makeChatState(completedConversation)))

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.ts
@@ -56,8 +56,8 @@ export function useMessageHandlers(messages: ClineMessage[], chatState: ChatStat
 				)
 				setInputValue("")
 				setActiveQuote(null)
-				if ("disableAutoScrollRef" in chatState) {
-					;(chatState as any).disableAutoScrollRef.current = false
+				if (chatState.isAtBottom && chatState.disableAutoScrollRef) {
+					chatState.disableAutoScrollRef.current = false
 				}
 				return
 			}
@@ -245,9 +245,9 @@ export function useMessageHandlers(messages: ClineMessage[], chatState: ChatStat
 				if (messageSent) {
 					clearSentMessageState()
 
-					// Reset auto-scroll
-					if ("disableAutoScrollRef" in chatState) {
-						;(chatState as any).disableAutoScrollRef.current = false
+					// Keep the reader's position when they sent a follow-up from earlier in the chat.
+					if (chatState.isAtBottom && chatState.disableAutoScrollRef) {
+						chatState.disableAutoScrollRef.current = false
 					}
 				}
 			}
@@ -429,8 +429,8 @@ export function useMessageHandlers(messages: ClineMessage[], chatState: ChatStat
 					break
 			}
 
-			if ("disableAutoScrollRef" in chatState) {
-				;(chatState as any).disableAutoScrollRef.current = false
+			if (chatState.disableAutoScrollRef) {
+				chatState.disableAutoScrollRef.current = false
 			}
 		},
 		[

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/types/chatTypes.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/types/chatTypes.ts
@@ -55,6 +55,7 @@ export interface ChatState {
 
 	// Scroll-related state (will be moved to scroll hook)
 	isAtBottom?: boolean
+	disableAutoScrollRef?: React.MutableRefObject<boolean>
 	pendingScrollToMessage?: number | null
 }
 


### PR DESCRIPTION
## Summary
- preserve the reader's viewport after sending a follow-up from earlier in the conversation
- continue pinning live chat when the reader is already at the bottom
- retain the existing selection-based quote reply and composer context preview flow

Fixes #12466

## Testing
- `bun run test src/components/chat/chat-view/hooks/useMessageHandlers.test.tsx src/components/chat/chat-view/components/layout/InputSection.test.tsx`
- `bun run build` (blocked by existing generated-proto/API mismatches: missing `ClineSay.COMPACTION`, `ModelOverrides`, and `TaskServiceClient.proceedWhileRunningCommand`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only scroll behavior in the VS Code chat webview with targeted tests; no auth, data, or backend changes.
> 
> **Overview**
> Fixes chat jumping to the bottom when users send a follow-up while scrolled up in a long conversation.
> 
> **Scroll state is threaded into send/approve flows** via `chatStateWithScroll` (`isAtBottom` + `disableAutoScrollRef` from `useScrollBehavior`). `useMessageHandlers` only clears `disableAutoScrollRef` after a successful send or `/compact` when the viewport is already at the bottom; otherwise auto-scroll stays disabled so the reader’s position is preserved. `ChatState` now types `disableAutoScrollRef` explicitly instead of duck-typing it.
> 
> **MessagesArea** keeps `disableAutoScrollRef` in sync with Virtuoso’s bottom state (`disableAutoScrollRef = !isAtBottom`), and re-pins on a new streaming turn only when the user was already at the bottom—so plan→act auto-continue does not yank someone reading earlier messages.
> 
> Tests cover send-from-above-bottom vs send-at-bottom behavior for `disableAutoScrollRef`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e06100a5a96041e7ad8d5fe7a368ce033d95bf27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->