### PR TITLE
feat(models): add Claude Opus 5 provider support (legacy)

### DIFF
--- a/apps/vscode/src/core/api/providers/__tests__/anthropic.test.ts
+++ b/apps/vscode/src/core/api/providers/__tests__/anthropic.test.ts
@@ -64,6 +64,30 @@ describe("AnthropicHandler", () => {
 			result.info.should.deepEqual(anthropicModels["claude-opus-4-7:1m"])
 		})
 
+		it("should return the Opus 5 model when configured", () => {
+			const handler = new AnthropicHandler({
+				apiKey: "test-api-key",
+				apiModelId: "claude-opus-5",
+			})
+
+			const result = handler.getModel()
+
+			result.id.should.equal("claude-opus-5")
+			result.info.should.deepEqual(anthropicModels["claude-opus-5"])
+		})
+
+		it("should return the Opus 5 1m model when configured", () => {
+			const handler = new AnthropicHandler({
+				apiKey: "test-api-key",
+				apiModelId: "claude-opus-5:1m",
+			})
+
+			const result = handler.getModel()
+
+			result.id.should.equal("claude-opus-5:1m")
+			result.info.should.deepEqual(anthropicModels["claude-opus-5:1m"])
+		})
+
 		it("should return the 4.8 model when configured", () => {
 			const handler = new AnthropicHandler({
 				apiKey: "test-api-key",

--- a/apps/vscode/src/core/api/providers/__tests__/bedrock.test.ts
+++ b/apps/vscode/src/core/api/providers/__tests__/bedrock.test.ts
@@ -215,6 +215,11 @@ describe("AwsBedrockHandler", () => {
 			bedrockModels["anthropic.claude-opus-4-8:1m"].supportsGlobalEndpoint.should.equal(true)
 		})
 
+		it("should mark Bedrock Opus 5 variants as global-endpoint capable", () => {
+			bedrockModels["anthropic.claude-opus-5"].supportsGlobalEndpoint.should.equal(true)
+			bedrockModels["anthropic.claude-opus-5:1m"].supportsGlobalEndpoint.should.equal(true)
+		})
+
 		it("should mark Bedrock Fable 5 variants as global-endpoint capable", () => {
 			bedrockModels["anthropic.claude-fable-5"].supportsGlobalEndpoint.should.equal(true)
 			bedrockModels["anthropic.claude-fable-5:1m"].supportsGlobalEndpoint.should.equal(true)
@@ -237,6 +242,13 @@ describe("AwsBedrockHandler", () => {
 			vertexModels["claude-opus-4-8:1m"].supportsGlobalEndpoint.should.equal(true)
 			vertexGlobalModels.should.have.property("claude-opus-4-8")
 			vertexGlobalModels.should.have.property("claude-opus-4-8:1m")
+		})
+
+		it("should include Vertex Opus 5 variants in the derived global model list", () => {
+			vertexModels["claude-opus-5"].supportsGlobalEndpoint.should.equal(true)
+			vertexModels["claude-opus-5:1m"].supportsGlobalEndpoint.should.equal(true)
+			vertexGlobalModels.should.have.property("claude-opus-5")
+			vertexGlobalModels.should.have.property("claude-opus-5:1m")
 		})
 
 		it("should include Vertex Fable 5 variants in the derived global model list", () => {

--- a/apps/vscode/src/core/api/providers/__tests__/claude-code.test.ts
+++ b/apps/vscode/src/core/api/providers/__tests__/claude-code.test.ts
@@ -396,6 +396,26 @@ describe("ClaudeCodeHandler", () => {
 			model.info.contextWindow.should.equal(1_000_000)
 		})
 
+		it("should support Opus 5 model id", () => {
+			const handler = new ClaudeCodeHandler({
+				apiModelId: "claude-opus-5",
+			})
+
+			const model = handler.getModel()
+			model.id.should.equal("claude-opus-5")
+			model.info.contextWindow.should.equal(200_000)
+		})
+
+		it("should support Opus 5 1m model id", () => {
+			const handler = new ClaudeCodeHandler({
+				apiModelId: "claude-opus-5[1m]",
+			})
+
+			const model = handler.getModel()
+			model.id.should.equal("claude-opus-5[1m]")
+			model.info.contextWindow.should.equal(1_000_000)
+		})
+
 		it("should support Opus 4.8 model id", () => {
 			const handler = new ClaudeCodeHandler({
 				apiModelId: "claude-opus-4-8",

--- a/apps/vscode/src/core/api/transform/openrouter-stream.ts
+++ b/apps/vscode/src/core/api/transform/openrouter-stream.ts
@@ -4,13 +4,14 @@ import {
 	ModelInfo,
 	OPENROUTER_PROVIDER_PREFERENCES,
 	openRouterClaudeFable51mModelId,
+	openRouterClaudeOpus51mModelId,
 	openRouterClaudeOpus461mModelId,
 	openRouterClaudeOpus471mModelId,
 	openRouterClaudeOpus481mModelId,
 	openRouterClaudeSonnet41mModelId,
+	openRouterClaudeSonnet51mModelId,
 	openRouterClaudeSonnet451mModelId,
 	openRouterClaudeSonnet461mModelId,
-	openRouterClaudeSonnet51mModelId,
 } from "@shared/api"
 import { normalizeOpenaiReasoningEffort } from "@shared/storage/types"
 import { isClaudeOpusAdaptiveThinkingModel, resolveClaudeOpusAdaptiveThinking } from "@shared/utils/reasoning-support"
@@ -67,6 +68,7 @@ export async function createOpenRouterStream(
 		model.id === openRouterClaudeOpus461mModelId ||
 		model.id === openRouterClaudeOpus471mModelId ||
 		model.id === openRouterClaudeOpus481mModelId ||
+		model.id === openRouterClaudeOpus51mModelId ||
 		model.id === openRouterClaudeFable51mModelId
 	if (isClaude1m) {
 		// remove the custom :1m suffix, to create the model id openrouter API expects

--- a/apps/vscode/src/core/api/transform/vercel-ai-gateway-stream.ts
+++ b/apps/vscode/src/core/api/transform/vercel-ai-gateway-stream.ts
@@ -3,13 +3,14 @@ import {
 	CLAUDE_SONNET_1M_SUFFIX,
 	ModelInfo,
 	openRouterClaudeFable51mModelId,
+	openRouterClaudeOpus51mModelId,
 	openRouterClaudeOpus461mModelId,
 	openRouterClaudeOpus471mModelId,
 	openRouterClaudeOpus481mModelId,
 	openRouterClaudeSonnet41mModelId,
+	openRouterClaudeSonnet51mModelId,
 	openRouterClaudeSonnet451mModelId,
 	openRouterClaudeSonnet461mModelId,
-	openRouterClaudeSonnet51mModelId,
 } from "@shared/api"
 import { normalizeOpenaiReasoningEffort } from "@shared/storage/types"
 import { isClaudeOpusAdaptiveThinkingModel, resolveClaudeOpusAdaptiveThinking } from "@shared/utils/reasoning-support"
@@ -43,6 +44,7 @@ export async function createVercelAIGatewayStream(
 		model.id === openRouterClaudeOpus461mModelId ||
 		model.id === openRouterClaudeOpus471mModelId ||
 		model.id === openRouterClaudeOpus481mModelId ||
+		model.id === openRouterClaudeOpus51mModelId ||
 		model.id === openRouterClaudeFable51mModelId
 	if (isClaude1m) {
 		// remove the custom :1m suffix, to create the model id the API expects

--- a/apps/vscode/src/core/controller/models/__tests__/refreshClineModels.test.ts
+++ b/apps/vscode/src/core/controller/models/__tests__/refreshClineModels.test.ts
@@ -1,5 +1,5 @@
 import * as disk from "@core/storage/disk"
-import { openRouterClaudeFable51mModelId } from "@shared/api"
+import { openRouterClaudeFable51mModelId, openRouterClaudeOpus51mModelId } from "@shared/api"
 import axios from "axios"
 import { expect } from "chai"
 import fs from "fs/promises"
@@ -134,6 +134,65 @@ describe("refreshClineModels", () => {
 		expect(fable.cacheReadsPrice).to.equal(1)
 		expect(fable1m.contextWindow).to.equal(1_000_000)
 		expect(fable1m.tiers).to.not.equal(undefined)
+	})
+
+	it("adds Claude Opus 5 context variants to the Cline model list", async () => {
+		sandbox.stub(getFeatureFlagsService(), "getBooleanFlagEnabled").callsFake((flag) => {
+			return flag === FeatureFlag.EXTENSION_CLINE_MODELS_ENDPOINT
+		})
+		sandbox.stub(ClineEnv, "config").returns({
+			environment: Environment.production,
+			appBaseUrl: "https://app.cline-mock.bot",
+			apiBaseUrl: "https://api.cline-mock.bot",
+			mcpBaseUrl: "https://api.cline-mock.bot/v1/mcp",
+		})
+		sandbox.stub(StateManager, "get").returns({
+			getModelsCache: () => null,
+			setModelsCache: () => {},
+		} as unknown as StateManager)
+		sandbox.stub(disk, "ensureCacheDirectoryExists").resolves("/tmp")
+		sandbox.stub(fs, "writeFile").resolves()
+		sandbox.stub(axios, "get").resolves({
+			data: {
+				data: [
+					{
+						id: "anthropic/claude-opus-5",
+						name: "Claude Opus 5",
+						description: "Fetched description",
+						context_length: 1_000_000,
+						top_provider: {
+							max_completion_tokens: 128_000,
+							context_length: 1_000_000,
+							is_moderated: false,
+						},
+						architecture: {
+							modality: ["text", "image"],
+						},
+						pricing: {
+							prompt: "0.000005",
+							completion: "0.000025",
+							input_cache_read: "0.0000005",
+							input_cache_write: "0.00000625",
+						},
+						supported_parameters: ["include_reasoning", "reasoning"],
+					},
+				],
+			},
+		})
+
+		const models = await refreshClineModels({} as Controller)
+		const opus5 = models["anthropic/claude-opus-5"]
+		const opus51m = models[openRouterClaudeOpus51mModelId]
+
+		expect(opus5.contextWindow).to.equal(200_000)
+		expect(opus5.maxTokens).to.equal(128_000)
+		expect(opus5.supportsPromptCache).to.equal(true)
+		expect(opus5.inputPrice).to.equal(5)
+		expect(opus5.outputPrice).to.equal(25)
+		expect(opus5.cacheWritesPrice).to.equal(6.25)
+		expect(opus5.cacheReadsPrice).to.equal(0.5)
+		expect(opus51m.contextWindow).to.equal(1_000_000)
+		expect(opus51m.tiers).to.not.equal(undefined)
 	})
 
 	it("prefers Vercel-style Z.ai IDs when the Cline model list includes OpenRouter aliases", async () => {

--- a/apps/vscode/src/core/controller/models/refreshClineModels.ts
+++ b/apps/vscode/src/core/controller/models/refreshClineModels.ts
@@ -15,13 +15,14 @@ import {
 	CLAUDE_OPUS_1M_TIERS,
 	CLAUDE_SONNET_1M_TIERS,
 	openRouterClaudeFable51mModelId,
+	openRouterClaudeOpus51mModelId,
 	openRouterClaudeOpus461mModelId,
 	openRouterClaudeOpus471mModelId,
 	openRouterClaudeOpus481mModelId,
 	openRouterClaudeSonnet41mModelId,
+	openRouterClaudeSonnet51mModelId,
 	openRouterClaudeSonnet451mModelId,
 	openRouterClaudeSonnet461mModelId,
-	openRouterClaudeSonnet51mModelId,
 } from "@/shared/api"
 import { getAxiosSettings } from "@/shared/net"
 import { FeatureFlag } from "@/shared/services/feature-flags/feature-flags"
@@ -239,6 +240,15 @@ async function fetchAndCacheClineModels(): Promise<Record<string, ModelInfo>> {
 					modelInfo.cacheWritesPrice = 3.75
 					modelInfo.cacheReadsPrice = 0.3
 					break
+				case "anthropic/claude-opus-5":
+				case "anthropic/claude-5-opus":
+					modelInfo.contextWindow = 200_000
+					modelInfo.supportsPromptCache = true
+					modelInfo.inputPrice = 5.0
+					modelInfo.outputPrice = 25.0
+					modelInfo.cacheWritesPrice = 6.25
+					modelInfo.cacheReadsPrice = 0.5
+					break
 				case "anthropic/claude-opus-4.6":
 				case "anthropic/claude-opus-4.7":
 				case "anthropic/claude-opus-4.8":
@@ -354,6 +364,12 @@ async function fetchAndCacheClineModels(): Promise<Record<string, ModelInfo>> {
 				if (rawModel.id === "anthropic/claude-opus-4.8") {
 					models[openRouterClaudeOpus481mModelId] = claudeOpus1mModelInfo
 				}
+			}
+			if (rawModel.id === "anthropic/claude-opus-5" || rawModel.id === "anthropic/claude-5-opus") {
+				const claudeOpus51mModelInfo = cloneDeep(modelInfo)
+				claudeOpus51mModelInfo.contextWindow = 1_000_000
+				claudeOpus51mModelInfo.tiers = CLAUDE_OPUS_1M_TIERS
+				models[openRouterClaudeOpus51mModelId] = claudeOpus51mModelInfo
 			}
 			if (rawModel.id === "anthropic/claude-fable-5") {
 				const claudeFable1mModelInfo = cloneDeep(modelInfo)

--- a/apps/vscode/src/core/controller/models/refreshOpenRouterModels.ts
+++ b/apps/vscode/src/core/controller/models/refreshOpenRouterModels.ts
@@ -12,13 +12,14 @@ import {
 	CLAUDE_OPUS_1M_TIERS,
 	CLAUDE_SONNET_1M_TIERS,
 	openRouterClaudeFable51mModelId,
+	openRouterClaudeOpus51mModelId,
 	openRouterClaudeOpus461mModelId,
 	openRouterClaudeOpus471mModelId,
 	openRouterClaudeOpus481mModelId,
 	openRouterClaudeSonnet41mModelId,
+	openRouterClaudeSonnet51mModelId,
 	openRouterClaudeSonnet451mModelId,
 	openRouterClaudeSonnet461mModelId,
-	openRouterClaudeSonnet51mModelId,
 } from "@/shared/api"
 import { getAxiosSettings } from "@/shared/net"
 import { Logger } from "@/shared/services/Logger"
@@ -184,6 +185,15 @@ async function fetchAndCacheModels(controller: Controller): Promise<Record<strin
 						modelInfo.cacheWritesPrice = 3.75
 						modelInfo.cacheReadsPrice = 0.3
 						break
+					case "anthropic/claude-opus-5":
+					case "anthropic/claude-5-opus":
+						modelInfo.contextWindow = 200_000 // restrict to 200k, 1m variant created below
+						modelInfo.supportsPromptCache = true
+						modelInfo.inputPrice = 5.0
+						modelInfo.outputPrice = 25.0
+						modelInfo.cacheWritesPrice = 6.25
+						modelInfo.cacheReadsPrice = 0.5
+						break
 					case "anthropic/claude-opus-4.6":
 					case "anthropic/claude-opus-4.7":
 					case "anthropic/claude-opus-4.8":
@@ -348,6 +358,12 @@ async function fetchAndCacheModels(controller: Controller): Promise<Record<strin
 					if (rawModel.id === "anthropic/claude-opus-4.8") {
 						models[openRouterClaudeOpus481mModelId] = claudeOpus1mModelInfo
 					}
+				}
+				if (rawModel.id === "anthropic/claude-opus-5" || rawModel.id === "anthropic/claude-5-opus") {
+					const claudeOpus51mModelInfo = cloneDeep(modelInfo)
+					claudeOpus51mModelInfo.contextWindow = 1_000_000
+					claudeOpus51mModelInfo.tiers = CLAUDE_OPUS_1M_TIERS
+					models[openRouterClaudeOpus51mModelId] = claudeOpus51mModelInfo
 				}
 				if (rawModel.id === "anthropic/claude-fable-5") {
 					const claudeFable1mModelInfo = cloneDeep(modelInfo)

--- a/apps/vscode/src/shared/api.ts
+++ b/apps/vscode/src/shared/api.ts
@@ -129,6 +129,7 @@ export const CLAUDE_SONNET_1M_TIERS = [
 		cacheReadsPrice: 0.6,
 	},
 ]
+// Claude 4.6+ opus models include the full 1M context window at standard pricing (no long-context premium)
 export const CLAUDE_OPUS_1M_TIERS = [
 	{
 		contextWindow: 200000,
@@ -139,10 +140,10 @@ export const CLAUDE_OPUS_1M_TIERS = [
 	},
 	{
 		contextWindow: Number.MAX_SAFE_INTEGER,
-		inputPrice: 10,
-		outputPrice: 37.5,
-		cacheWritesPrice: 12.5,
-		cacheReadsPrice: 1.0,
+		inputPrice: 5.0,
+		outputPrice: 25,
+		cacheWritesPrice: 6.25,
+		cacheReadsPrice: 0.5,
 	},
 ]
 export const CLAUDE_FABLE_1M_TIERS = [

--- a/apps/vscode/src/shared/api.ts
+++ b/apps/vscode/src/shared/api.ts
@@ -335,6 +335,29 @@ export const anthropicModels = {
 		description:
 			"Anthropic fast mode preview for Claude Opus 4.6 with the 1M context beta enabled. Same model and capabilities with higher output token speed at premium pricing across the full 1M context window. Requires both fast mode and 1M context access on your Anthropic account.",
 	},
+	"claude-opus-5": {
+		maxTokens: 128_000,
+		contextWindow: 200_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		supportsReasoning: true,
+		inputPrice: 5.0,
+		outputPrice: 25.0,
+		cacheWritesPrice: 6.25,
+		cacheReadsPrice: 0.5,
+	},
+	"claude-opus-5:1m": {
+		maxTokens: 128_000,
+		contextWindow: 1_000_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		supportsReasoning: true,
+		inputPrice: 5.0,
+		outputPrice: 25.0,
+		cacheWritesPrice: 6.25,
+		cacheReadsPrice: 0.5,
+		tiers: CLAUDE_OPUS_1M_TIERS,
+	},
 	"claude-opus-4-8": {
 		maxTokens: 128_000,
 		contextWindow: 200_000,
@@ -507,13 +530,13 @@ export const claudeCodeModels = {
 		supportsPromptCache: false,
 	},
 	opus: {
-		...anthropicModels["claude-opus-4-8"],
+		...anthropicModels["claude-opus-5"],
 		contextWindow: 200_000,
 		supportsImages: false,
 		supportsPromptCache: false,
 	},
 	"opus[1m]": {
-		...anthropicModels["claude-opus-4-8:1m"],
+		...anthropicModels["claude-opus-5:1m"],
 		supportsImages: false,
 		supportsPromptCache: false,
 	},
@@ -564,6 +587,17 @@ export const claudeCodeModels = {
 	},
 	"claude-opus-4-6[1m]": {
 		...anthropicModels["claude-opus-4-6:1m"],
+		supportsImages: false,
+		supportsPromptCache: false,
+	},
+	"claude-opus-5": {
+		...anthropicModels["claude-opus-5"],
+		contextWindow: 200_000,
+		supportsImages: false,
+		supportsPromptCache: false,
+	},
+	"claude-opus-5[1m]": {
+		...anthropicModels["claude-opus-5:1m"],
 		supportsImages: false,
 		supportsPromptCache: false,
 	},
@@ -757,6 +791,31 @@ export const bedrockModels = {
 		cacheReadsPrice: 0.5,
 	},
 	"anthropic.claude-opus-4-6-v1:1m": {
+		maxTokens: 128_000,
+		contextWindow: 1_000_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		supportsReasoning: true,
+		supportsGlobalEndpoint: true,
+		inputPrice: 5.0,
+		outputPrice: 25.0,
+		cacheWritesPrice: 6.25,
+		cacheReadsPrice: 0.5,
+		tiers: CLAUDE_OPUS_1M_TIERS,
+	},
+	"anthropic.claude-opus-5": {
+		maxTokens: 128_000,
+		contextWindow: 200_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		supportsReasoning: true,
+		supportsGlobalEndpoint: true,
+		inputPrice: 5.0,
+		outputPrice: 25.0,
+		cacheWritesPrice: 6.25,
+		cacheReadsPrice: 0.5,
+	},
+	"anthropic.claude-opus-5:1m": {
 		maxTokens: 128_000,
 		contextWindow: 1_000_000,
 		supportsImages: true,
@@ -1057,6 +1116,7 @@ export const openRouterClaudeSonnet51mModelId = `anthropic/claude-sonnet-5${CLAU
 export const openRouterClaudeOpus461mModelId = `anthropic/claude-opus-4.6${CLAUDE_SONNET_1M_SUFFIX}`
 export const openRouterClaudeOpus471mModelId = `anthropic/claude-opus-4.7${CLAUDE_SONNET_1M_SUFFIX}`
 export const openRouterClaudeOpus481mModelId = `anthropic/claude-opus-4.8${CLAUDE_SONNET_1M_SUFFIX}`
+export const openRouterClaudeOpus51mModelId = `anthropic/claude-opus-5${CLAUDE_SONNET_1M_SUFFIX}`
 export const openRouterClaudeFable51mModelId = `anthropic/claude-fable-5${CLAUDE_SONNET_1M_SUFFIX}`
 export const openRouterDefaultModelInfo: ModelInfo = {
 	maxTokens: 128_000,
@@ -1414,6 +1474,32 @@ export const vertexModels = {
 		tiers: CLAUDE_OPUS_1M_TIERS,
 	},
 	"claude-opus-4-6:1m": {
+		maxTokens: 128_000,
+		contextWindow: 1_000_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		supportsGlobalEndpoint: true,
+		inputPrice: 5.0,
+		outputPrice: 25.0,
+		cacheWritesPrice: 6.25,
+		cacheReadsPrice: 0.5,
+		supportsReasoning: true,
+		tiers: CLAUDE_OPUS_1M_TIERS,
+	},
+	"claude-opus-5": {
+		maxTokens: 128_000,
+		contextWindow: 1_000_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		supportsGlobalEndpoint: true,
+		inputPrice: 5.0,
+		outputPrice: 25.0,
+		cacheWritesPrice: 6.25,
+		cacheReadsPrice: 0.5,
+		supportsReasoning: true,
+		tiers: CLAUDE_OPUS_1M_TIERS,
+	},
+	"claude-opus-5:1m": {
 		maxTokens: 128_000,
 		contextWindow: 1_000_000,
 		supportsImages: true,

--- a/apps/vscode/src/shared/utils/reasoning-support.ts
+++ b/apps/vscode/src/shared/utils/reasoning-support.ts
@@ -18,6 +18,8 @@ export function isClaudeAdaptiveThinkingModel(modelId?: string): boolean {
 		id.includes("claude-fable-5") ||
 		id.includes("claude-sonnet-5") ||
 		id.includes("claude-5-sonnet") ||
+		id.includes("claude-opus-5") ||
+		id.includes("claude-5-opus") ||
 		adaptiveVersions.some((version) => id.includes(`claude-opus-${version}`) || id.includes(`claude-${version}-opus`))
 	)
 }

--- a/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.tsx
@@ -654,6 +654,14 @@ const ClineModelPicker: React.FC<ClineModelPickerProps> = ({
 					selectedModelId={selectedModelId}
 				/>
 
+				{/* Context window switcher for Claude Opus 5 */}
+				<ContextWindowSwitcher
+					base1mModelId={`anthropic/claude-opus-5${CLAUDE_SONNET_1M_SUFFIX}`}
+					base200kModelId="anthropic/claude-opus-5"
+					onModelChange={handleModelChange}
+					selectedModelId={selectedModelId}
+				/>
+
 				{/* Context window switcher for Claude Opus 4.8 */}
 				<ContextWindowSwitcher
 					base1mModelId={`anthropic/claude-opus-4.8${CLAUDE_SONNET_1M_SUFFIX}`}

--- a/apps/vscode/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
@@ -341,6 +341,14 @@ const OpenRouterModelPicker: React.FC<OpenRouterModelPickerProps> = ({ isPopup, 
 					selectedModelId={selectedModelId}
 				/>
 
+				{/* Context window switcher for Claude Opus 5 */}
+				<ContextWindowSwitcher
+					base1mModelId={`anthropic/claude-opus-5${CLAUDE_SONNET_1M_SUFFIX}`}
+					base200kModelId="anthropic/claude-opus-5"
+					onModelChange={handleModelChange}
+					selectedModelId={selectedModelId}
+				/>
+
 				{/* Context window switcher for Claude Opus 4.8 */}
 				<ContextWindowSwitcher
 					base1mModelId={`anthropic/claude-opus-4.8${CLAUDE_SONNET_1M_SUFFIX}`}

--- a/apps/vscode/webview-ui/src/components/settings/providers/ClaudeCodeProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/ClaudeCodeProvider.tsx
@@ -15,6 +15,7 @@ const SUPPORTED_CLAUDE_CODE_THINKING_MODELS = [
 	"sonnet[1m]",
 	"claude-sonnet-5[1m]",
 	"claude-fable-5[1m]",
+	"claude-opus-5[1m]",
 	"claude-opus-4-8[1m]",
 	"claude-opus-4-7[1m]",
 	"claude-sonnet-4-6[1m]",

--- a/apps/vscode/webview-ui/src/components/settings/providers/VertexProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/VertexProvider.tsx
@@ -42,6 +42,8 @@ const SUPPORTED_THINKING_MODELS = [
 	"claude-opus-4-6",
 	"claude-opus-4-7",
 	"claude-opus-4-8",
+	"claude-opus-5",
+	"claude-opus-5:1m",
 	"gemini-2.5-flash",
 	"gemini-2.5-pro",
 	"gemini-2.5-flash-lite-preview-06-17",


### PR DESCRIPTION
### Related Issue

N/A — model catalog update for the Claude Opus 5 release (July 2026).

### Description

Anthropic released **Claude Opus 5** (`claude-opus-5`): $5/$25 per MTok (same as Opus 4.8), cache writes $6.25 / reads $0.50, 1M context window, 128K max output, adaptive thinking only. Dateless pinned model ID, Bedrock ID `anthropic.claude-opus-5`, Vertex ID `claude-opus-5`. This wires it through every provider surface in the legacy extension, mirroring the Opus 4.8 (#11110) and Fable 5 (#11384) additions:

- **`shared/api.ts`** — `claude-opus-5` + `claude-opus-5:1m` entries in the Anthropic, Claude Code, Bedrock (`anthropic.` prefix), and Vertex catalogs; new `openRouterClaudeOpus51mModelId` constant. The Claude Code `opus` / `opus[1m]` aliases now resolve to Opus 5 (they pointed at 4.8), matching how they were bumped at each prior Opus release.
- **`refreshClineModels.ts` / `refreshOpenRouterModels.ts`** — model-specific overrides (restrict to 200k, cache prices) plus derived `:1m` variants. Both `anthropic/claude-opus-5` **and** `anthropic/claude-5-opus` slugs are handled, same dual-slug treatment sonnet-5 got — OpenRouter/Vercel have been inconsistent about `claude-5-sonnet` vs `claude-sonnet-5` style slugs, so covering both is cheap insurance.
- **`openrouter-stream.ts` / `vercel-ai-gateway-stream.ts`** — the `:1m` suffix-stripping check now includes the Opus 5 1m ID.
- **`reasoning-support.ts`** — `claude-opus-5` / `claude-5-opus` register as adaptive-thinking models so they get the reasoning-effort selector instead of the legacy thinking-budget slider.
- **Webview** — ContextWindowSwitchers for Opus 5 in the Cline and OpenRouter pickers; `claude-opus-5[1m]` in the Claude Code thinking-model list; Opus 5 variants in the Vertex thinking-model list.

**Second commit — `CLAUDE_OPUS_1M_TIERS` long-context premium removed.** While adding the Opus 5 `:1m` entries I noticed the shared opus tiers constant still charges 2x above 200k ($10/$37.50, cache 12.5/1.0). Anthropic's pricing docs now state Claude 4.6+ models include the full 1M window at **standard** pricing ("A 900k-token request is billed at the same per-token rate as a 9k-token request") — the premium is a holdover from the original 1M-beta era. Fable 5 already shipped with flat tiers (`CLAUDE_FABLE_1M_TIERS`) for the same reason. I initially added a separate flat `CLAUDE_OPUS_5_1M_TIERS` constant to avoid touching the older models' displayed pricing, but flattening the shared constant is the simpler and more accurate fix — it corrects cost display for the opus 4.6/4.7/4.8 `:1m` variants too, which were overstating costs on long-context requests.

Note this constant only affects **displayed** cost estimates; actual billing happens server-side. Fast-mode variants (`:fast`) were not added for Opus 5 — only 4.6 ever had them, consistent with 4.8.

### Test Procedure

- **New tests** mirroring the 4.8/Fable additions: Anthropic handler resolves `claude-opus-5` / `claude-opus-5:1m`; Bedrock + Vertex variants are global-endpoint capable and appear in the derived vertex global list; Claude Code handler resolves `claude-opus-5` (200k) and `claude-opus-5[1m]` (1M); `refreshClineModels` derives the `:1m` variant with tiers from a mocked `anthropic/claude-opus-5` API row.
- Full legacy unit suite: 1540 passing; the only failure is the pre-existing flaky `UserPromptSubmit` hook timeout (fails on the parent commit too, unrelated to models).
- `tsc --noEmit` clean for both the host and `webview-ui`; `biome check` (legacy `biome.jsonc`) clean on all touched files.
- No tests asserted the old premium tier values, so the tiers flattening required no test updates.
- Grep-verified every place 4.8/fable were registered got an Opus 5 counterpart (catalogs, refreshers, stream transforms, reasoning detection, pickers, provider lists).

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — catalog/backend change; the pickers reuse the existing ContextWindowSwitcher UI.

### Additional Notes

Targets `legacy-extension`, so per the usual caveat the green "Run Tests" check is the no-op workflow — verification above was run locally at this commit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Non-breaking catalog and UI wiring with mirrored tests; the main behavioral nuance is Claude Code defaulting `opus` to Opus 5 and lower displayed long-context costs (billing unchanged).
> 
> **Overview**
> Adds **Claude Opus 5** (`claude-opus-5` / `:1m`, Bedrock `anthropic.claude-opus-5`, Vertex `claude-opus-5`) end-to-end in the legacy extension: static catalogs in `shared/api.ts`, derived OpenRouter/Cline `:1m` rows in the model refreshers (including both `anthropic/claude-opus-5` and `anthropic/claude-5-opus` slugs), `:1m` suffix stripping in OpenRouter/Vercel gateway streams, and adaptive-thinking detection for Opus 5.
> 
> **Claude Code** `opus` / `opus[1m]` aliases now resolve to Opus 5 instead of 4.8. Settings pickers gain Opus 5 context-window switchers and provider allowlists (Claude Code thinking, Vertex).
> 
> **`CLAUDE_OPUS_1M_TIERS`** no longer applies a 2× long-context premium above 200k; tiers use standard Opus pricing for the full 1M window (display-only cost estimates for Opus 4.6+ `:1m` variants as well). Tests mirror prior Opus/Fable additions across handlers and `refreshClineModels`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97ab75b0b1feb3372e78b2a6c7292c9caafb9ded. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->