### PR TITLE
fix: OpenAI Compatible model list fails when base URL has a trailing slash

### DIFF
--- a/.changeset/lazy-pugs-cheer.md
+++ b/.changeset/lazy-pugs-cheer.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fix: strip trailing slashes from the OpenAI Compatible base URL when fetching the model list, so `/models` is queried correctly and the model dropdown populates

--- a/apps/vscode/src/core/controller/models/__tests__/refreshOpenAiModels.test.ts
+++ b/apps/vscode/src/core/controller/models/__tests__/refreshOpenAiModels.test.ts
@@ -1,3 +1,4 @@
+import { OpenAiModelsRequest } from "@shared/proto/cline/models"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { refreshOpenAiModels } from "../refreshOpenAiModels"
 
@@ -49,7 +50,7 @@ describe("refreshOpenAiModels", () => {
 			headers: { "x-custom": "yes" },
 		})
 
-		const response = await refreshOpenAiModels(makeController(), { providerId: "openai", baseUrl: "", apiKey: "" })
+		const response = await refreshOpenAiModels(makeController(), OpenAiModelsRequest.create({ providerId: "openai" }))
 
 		expect(response.values).toEqual(["model-alpha", "model-beta"])
 		expect(mocks.axiosGet).toHaveBeenCalledWith(
@@ -66,7 +67,7 @@ describe("refreshOpenAiModels", () => {
 	it("strips trailing slashes from the base URL before appending /models", async () => {
 		mocks.readProviderConfig.mockReturnValue({ baseUrl: "http://localhost:1234/v1/" })
 
-		await refreshOpenAiModels(makeController(), { providerId: "openai", baseUrl: "", apiKey: "" })
+		await refreshOpenAiModels(makeController(), OpenAiModelsRequest.create({ providerId: "openai" }))
 
 		expect(mocks.axiosGet).toHaveBeenCalledWith("http://localhost:1234/v1/models", expect.anything())
 	})
@@ -74,7 +75,7 @@ describe("refreshOpenAiModels", () => {
 	it("returns an empty list when no base URL is configured", async () => {
 		mocks.readProviderConfig.mockReturnValue({})
 
-		const response = await refreshOpenAiModels(makeController(), { providerId: "openai", baseUrl: "", apiKey: "" })
+		const response = await refreshOpenAiModels(makeController(), OpenAiModelsRequest.create({ providerId: "openai" }))
 
 		expect(response.values).toEqual([])
 		expect(mocks.axiosGet).not.toHaveBeenCalled()
@@ -84,7 +85,7 @@ describe("refreshOpenAiModels", () => {
 		mocks.readProviderConfig.mockReturnValue({ baseUrl: "http://localhost:1234/v1" })
 		mocks.axiosGet.mockRejectedValue(new Error("boom"))
 
-		const response = await refreshOpenAiModels(makeController(), { providerId: "openai", baseUrl: "", apiKey: "" })
+		const response = await refreshOpenAiModels(makeController(), OpenAiModelsRequest.create({ providerId: "openai" }))
 
 		expect(response.values).toEqual([])
 	})

--- a/apps/vscode/src/core/controller/models/__tests__/refreshOpenAiModels.test.ts
+++ b/apps/vscode/src/core/controller/models/__tests__/refreshOpenAiModels.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { refreshOpenAiModels } from "../refreshOpenAiModels"
+
+const mocks = vi.hoisted(() => ({
+	axiosGet: vi.fn(),
+	readProviderConfig: vi.fn(),
+}))
+
+vi.mock("axios", () => ({
+	default: {
+		get: mocks.axiosGet,
+		isAxiosError: vi.fn(() => false),
+	},
+}))
+
+vi.mock("@/shared/net", () => ({
+	getAxiosSettings: () => ({}),
+}))
+
+vi.mock("@/shared/services/Logger", () => ({
+	Logger: {
+		error: vi.fn(),
+		log: vi.fn(),
+	},
+}))
+
+function makeController() {
+	return {
+		getProviderConfigStore: () => ({
+			read: mocks.readProviderConfig,
+		}),
+	} as unknown as Parameters<typeof refreshOpenAiModels>[0]
+}
+
+describe("refreshOpenAiModels", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		mocks.axiosGet.mockResolvedValue({
+			data: {
+				data: [{ id: "model-alpha" }, { id: "model-beta" }, { id: "model-alpha" }],
+			},
+		})
+	})
+
+	it("fetches and dedupes the model list using the stored provider config", async () => {
+		mocks.readProviderConfig.mockReturnValue({
+			baseUrl: "http://localhost:1234/v1",
+			apiKey: "secret-key",
+			headers: { "x-custom": "yes" },
+		})
+
+		const response = await refreshOpenAiModels(makeController(), { providerId: "openai", baseUrl: "", apiKey: "" })
+
+		expect(response.values).toEqual(["model-alpha", "model-beta"])
+		expect(mocks.axiosGet).toHaveBeenCalledWith(
+			"http://localhost:1234/v1/models",
+			expect.objectContaining({
+				headers: {
+					"x-custom": "yes",
+					Authorization: "Bearer secret-key",
+				},
+			}),
+		)
+	})
+
+	it("strips trailing slashes from the base URL before appending /models", async () => {
+		mocks.readProviderConfig.mockReturnValue({ baseUrl: "http://localhost:1234/v1/" })
+
+		await refreshOpenAiModels(makeController(), { providerId: "openai", baseUrl: "", apiKey: "" })
+
+		expect(mocks.axiosGet).toHaveBeenCalledWith("http://localhost:1234/v1/models", expect.anything())
+	})
+
+	it("returns an empty list when no base URL is configured", async () => {
+		mocks.readProviderConfig.mockReturnValue({})
+
+		const response = await refreshOpenAiModels(makeController(), { providerId: "openai", baseUrl: "", apiKey: "" })
+
+		expect(response.values).toEqual([])
+		expect(mocks.axiosGet).not.toHaveBeenCalled()
+	})
+
+	it("returns an empty list when the request fails", async () => {
+		mocks.readProviderConfig.mockReturnValue({ baseUrl: "http://localhost:1234/v1" })
+		mocks.axiosGet.mockRejectedValue(new Error("boom"))
+
+		const response = await refreshOpenAiModels(makeController(), { providerId: "openai", baseUrl: "", apiKey: "" })
+
+		expect(response.values).toEqual([])
+	})
+})

--- a/apps/vscode/src/core/controller/models/refreshOpenAiModels.ts
+++ b/apps/vscode/src/core/controller/models/refreshOpenAiModels.ts
@@ -16,7 +16,10 @@ import { Controller } from ".."
 export async function refreshOpenAiModels(controller: Controller, request: OpenAiModelsRequest): Promise<StringArray> {
 	try {
 		const providerConfig = controller.getProviderConfigStore().read(parseProviderId(request.providerId || "openai"))
-		const baseUrl = providerConfig.baseUrl
+		// Trailing slashes would produce "<baseUrl>//models", which many
+		// servers reject even though chat completions still work (the AI SDK
+		// normalizes the base URL for those).
+		const baseUrl = providerConfig.baseUrl?.trim().replace(/\/+$/, "")
 		const apiKey = providerConfig.apiKey
 
 		if (!baseUrl) {

--- a/apps/vscode/vitest.config.ts
+++ b/apps/vscode/vitest.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
 			"src/core/controller/models/__tests__/providerCatalogSmoke.test.ts",
 			"src/core/controller/models/__tests__/refreshClineRecommendedModels.test.ts",
 			"src/core/controller/models/__tests__/refreshGroqModels.test.ts",
+			"src/core/controller/models/__tests__/refreshOpenAiModels.test.ts",
 		],
 		environment: "node",
 		setupFiles: ["./src/test/vitest-setup.ts"],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Related Issue

User report: OpenAI Compatible provider settings did not populate the model list from an endpoint that exposes `/models`; the user had to type the model ID manually.

### Description

The host-side `refreshOpenAiModels` handler builds the request URL with raw string concatenation (`${baseUrl}/models`). If the saved base URL ends with a slash (e.g. `https://host/v1/`), the request becomes `https://host/v1//models`, which many servers reject with 404. Because the handler swallows errors and returns an empty list, the settings UI silently falls back to the free-text "Enter Model ID..." input — matching the report exactly.

Chat completions are unaffected by the trailing slash because the AI SDK normalizes the base URL (`withoutTrailingSlash`), so a user can have working inference but a broken model dropdown. The CLI's equivalent (`fetchOpenAiCompatibleModelIds` in `apps/cli`) already strips trailing slashes; this PR brings the extension handler in line.

Changes:
- `apps/vscode/src/core/controller/models/refreshOpenAiModels.ts`: trim and strip trailing slashes from the stored base URL before appending `/models`.
- New unit test `refreshOpenAiModels.test.ts` (added to the vitest include list) covering the trailing-slash normalization, header/API-key forwarding, dedupe, empty base URL, and request-failure fallback.
- Changeset for a `claude-dev` patch release.

### Test Procedure

- Verified the happy paths end-to-end in a dev VS Code host against a mock OpenAI-compatible server: keyless endpoint and auth-required endpoint (`Authorization: Bearer …` from the stored provider key) both populate the Model ID dropdown.
- Reproduced the bug before the fix: with base URL `http://127.0.0.1:8199/v1/`, the server log showed `GET /v1//models` (404) and the dropdown never appeared.
- After the fix, the same trailing-slash base URL produces `GET /v1/models` and the dropdown populates with the mock models (see recording below).
- `bunx vitest run` in `apps/vscode`: 71 files, 847 tests passed.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Before the fix — trailing-slash base URL, model list silently empty, free-text fallback:

![Bug: no dropdown with trailing slash](https://cursor.com/artifacts/c/art-2662717a-75e2-4155-b80b-6c7a80b7576f)

After the fix — same trailing-slash base URL, dropdown populated:

<a href="https://cursor.com/agents/bc-b0a0382a-6130-41d0-b182-f637738fc7c8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fopenai_compatible_model_dropdown_with_trailing_slash_baseurl.mp4"><img src="https://cursor.com/artifacts/c/art-a13f7658-4ce8-4bf3-a643-ea3a10be3491" alt="openai_compatible_model_dropdown_with_trailing_slash_baseurl.mp4" /></a>

Auth-required endpoint also works (key read from the provider config store host-side):

![Dropdown populated on auth-required endpoint](https://cursor.com/artifacts/c/art-4515a7a6-7592-48b8-b853-3e63d1ec537b)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0a0382a-6130-41d0-b182-f637738fc7c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0a0382a-6130-41d0-b182-f637738fc7c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

