### PR TITLE
Evaluation tooling: cost-guarded Cline Auto SDLC benchmark

### DIFF
--- a/evals/e2e/CLINE_BENCH_PILOT.md
+++ b/evals/e2e/CLINE_BENCH_PILOT.md
@@ -23,7 +23,16 @@ environment and is graded by the task's deterministic verifier.
 - The default pilot is bounded to 3 tasks/model, $15/model or less, and $40
   globally.
 - `routerProfile` is validated. A `cline-pass-router` experiment rejects every
-  model that does not use a public `cline-pass/*` ID.
+  model that does not use a public `cline-pass/*` ID, and each profile requires
+  its matching Cline CLI provider.
+- Config, model, and pricing objects reject unknown fields, so accidentally
+  adding a credential cannot copy it into the retained report.
+- Reused job roots carry a provider/model/task/CLI fingerprint, and every reused
+  result revalidates task, CLI version, served provider, and served model.
+- The private jobs-root boundary is canonicalized through symlinks. If Harbor's
+  outer process times out or exits abnormally, the runner removes only Docker
+  containers whose trial IDs belong to that job and recovers usage when
+  possible.
 - The Pass profile uses Cline's distinct `cline-pass` CLI provider and derives
   Harbor's scoped `API_KEY` alias only from the required `CLINE_API_KEY`
   environment value; neither value is written to disk or command arguments.

--- a/evals/e2e/CLINE_BENCH_PILOT.md
+++ b/evals/e2e/CLINE_BENCH_PILOT.md
@@ -34,6 +34,9 @@ environment and is graded by the task's deterministic verifier.
   telemetry is useful for quota/economic comparisons but is not an invoice.
 - The timeout is enforced both in Cline and at Harbor's outer agent boundary;
   interrupted runs count as timed-out failures and retain their usage totals.
+- The Telegram verifier is copied to a private per-run overlay that adds
+  `/root/.local/bin` to PATH. This fixes its upstream `uv` lookup bug without
+  dirtying or forking the `cline-bench` submodule.
 - Harbor exposes cost telemetry after a task completes, not while it is
   running. Therefore dollar limits stop subsequent work, and the 25-minute
   wall timeout is the proactive in-task bound.

--- a/evals/e2e/CLINE_BENCH_PILOT.md
+++ b/evals/e2e/CLINE_BENCH_PILOT.md
@@ -1,0 +1,71 @@
+# Cline SDLC benchmark pilot
+
+This pilot uses three deterministic, production-derived `cline-bench` tasks:
+
+1. reproduce and fix an Axios/React Query error-handling bug, including tests;
+2. create oRPC infrastructure and migrate a Next.js application across files;
+3. refactor a TypeScript monorepo plugin and remove obsolete architecture.
+
+The run order is interleaved as a Latin square so each model sees every task in
+a different position. Each task runs once, sequentially, inside its own Docker
+environment and is graded by the task's deterministic verifier.
+
+## Safety
+
+- Dry-run is the default. Paid calls require `--execute`.
+- The config rejects 100 or more tasks or dollars per model.
+- Harbor receives a small environment allowlist, not the host environment.
+- Jobs and traces are written outside the repository with private permissions.
+- Authentication is inherited only through `CLINE_API_KEY`; it is never stored
+  in the config, command arguments, report, or repository.
+- The Cline CLI version is pinned in configuration for reproducibility. Its
+  built-in consecutive-mistake limit remains enabled.
+- The default pilot is bounded to 3 tasks/model, $15/model or less, and $40
+  globally.
+- `routerProfile` is validated. A `cline-pass-router` experiment rejects every
+  model that does not use a public `cline-pass/*` ID.
+- The Pass profile uses Cline's distinct `cline-pass` CLI provider and derives
+  Harbor's scoped `API_KEY` alias only from the required `CLINE_API_KEY`
+  environment value; neither value is written to disk or command arguments.
+- Optional per-model token prices add cache-read ratio, estimated warm cost,
+  cold-equivalent cost, and estimated cache savings to each report result.
+- `costBasis` distinguishes ordinary reported inference cost from ClinePass
+  reference-quota cost. ClinePass is subscription-billed, so its per-run dollar
+  telemetry is useful for quota/economic comparisons but is not an invoice.
+- The timeout is enforced both in Cline and at Harbor's outer agent boundary;
+  interrupted runs count as timed-out failures and retain their usage totals.
+- Harbor exposes cost telemetry after a task completes, not while it is
+  running. Therefore dollar limits stop subsequent work, and the 25-minute
+  wall timeout is the proactive in-task bound.
+
+## Usage
+
+Validate the exact matrix without spending:
+
+```bash
+bun evals/e2e/run-cline-bench-pilot.ts
+```
+
+Run it after securely exporting a Cline credential:
+
+```bash
+CLINE_API_KEY="$CLINE_API_KEY" \
+  bun evals/e2e/run-cline-bench-pilot.ts --execute
+```
+
+Models, task IDs, timeouts, and budget limits are data in
+`evals/e2e/cline-bench-pilot.config.json`. Copy that file outside the
+repository and pass `--config /absolute/path/config.json` for another arm.
+The checked-in `evals/e2e/cline-bench-pass-pilot.config.json` uses the same
+runner and verifier tasks but constrains candidates to the public Cline Pass
+catalog:
+
+```bash
+bun evals/e2e/run-cline-bench-pilot.ts \
+  --config evals/e2e/cline-bench-pass-pilot.config.json
+```
+
+Use `--stop-after N` to end cleanly after a matrix position; rerunning with the
+same `--jobs-root` reuses verified completed work.
+Use `--only-run N` to execute one missing matrix position while still loading
+completed prior costs into the budget ledger.

--- a/evals/e2e/CLINE_BENCH_PILOT.md
+++ b/evals/e2e/CLINE_BENCH_PILOT.md
@@ -54,9 +54,17 @@ and is graded by the task's deterministic verifier.
   environment value; neither value is written to disk or command arguments.
 - Optional per-model token prices add cache-read ratio, estimated warm cost,
   cold-equivalent cost, and estimated cache savings to each report result.
-- `costBasis` distinguishes ordinary reported inference cost from ClinePass
-  reference-quota cost. ClinePass is subscription-billed, so its per-run dollar
-  telemetry is useful for quota/economic comparisons but is not an invoice.
+- `costBasis` distinguishes ordinary reported inference cost, ClinePass
+  reference-quota cost, and conservative `reserved-exposure`. A completed trial
+  with no cost telemetry is failed and charged at its full reservation rather
+  than reported as free or retried. A canonical terminal error with explicit
+  zero cumulative usage remains a legitimate zero-spend infrastructure failure.
+  ClinePass is subscription-billed, so its per-run dollar telemetry is useful
+  for quota/economic comparisons but is not an invoice.
+- Paid execution fetches Cline's public recommended-model catalog before
+  creating the jobs root or reserving budget. Direct arms must be present in the
+  relevant live catalog; virtual Auto candidates keep Core's internal IDs and
+  are not compared to public picker identifiers.
 - The timeout is enforced both in Cline and at Harbor's outer agent boundary.
   Harbor runs in its own process group; timeout and termination signals stop the
   group and task-scoped containers are removed. Interrupted usage is accepted
@@ -144,8 +152,8 @@ For a local Core API, add:
 ```
 
 Inspect wave 1 outcomes, route evidence, and the provider-side account limit
-before releasing wave 2. Wave 2 adds GPT-5.4 on all eight tasks, reserves no more
-than another $15, and shares the same $50 campaign ledger:
+before releasing wave 2. Wave 2 adds GPT-5.6 Sol on all eight tasks, reserves
+no more than another $14.40, and shares the same $50 campaign ledger:
 
 ```bash
 CLINE_API_KEY="$CLINE_API_KEY" \

--- a/evals/e2e/CLINE_BENCH_PILOT.md
+++ b/evals/e2e/CLINE_BENCH_PILOT.md
@@ -70,10 +70,12 @@ and is graded by the task's deterministic verifier.
   amount. A provider-side/prepaid account limit is the **only true dollar hard
   stop**. The wall timeout is the active-run bound.
 - Optional `--local-core-url http://localhost:7777` is deliberately narrow. It
+  applies only to the virtual `cline/auto` and `cline-pass/auto` arms,
   normalizes to `host.docker.internal:7777`, forwards only
   `CLINE_API_BASE_URL`, and adds only that hostname to Harbor's environment and
-  agent-phase allowlists. Arbitrary URLs and environment passthrough are
-  rejected.
+  agent-phase allowlists. Fixed-model comparators continue to call Cline
+  directly so provider-reported usage and cost remain authoritative. Arbitrary
+  URLs and environment passthrough are rejected.
 - Virtual-model reports retain `requestedModel`, hashed benchmark task/session
   identifiers, and privacy-safe route evidence. Fixed-model results remain
   backward compatible.

--- a/evals/e2e/CLINE_BENCH_PILOT.md
+++ b/evals/e2e/CLINE_BENCH_PILOT.md
@@ -122,8 +122,8 @@ bun evals/e2e/run-cline-bench-pilot.ts \
   --config evals/e2e/cline-bench-router-checkpoint.config.json
 ```
 
-Wave 1 runs `cline/auto` on all eight tasks and Kimi K2.7 Code plus GLM 5.2 on
-Axios, Telegram, Every Plugin, and V-Edit. It reserves no more than $35:
+Wave 1 runs `cline/auto` on all eight tasks and Kimi K3 plus GLM 5.2 on
+Axios, Telegram, Every Plugin, and V-Edit. It reserves no more than $35.20:
 
 ```bash
 CLINE_API_KEY="$CLINE_API_KEY" \

--- a/evals/e2e/CLINE_BENCH_PILOT.md
+++ b/evals/e2e/CLINE_BENCH_PILOT.md
@@ -1,38 +1,50 @@
 # Cline SDLC benchmark pilot
 
-This pilot uses three deterministic, production-derived `cline-bench` tasks:
+The small default smoke pilot uses three deterministic, production-derived
+`cline-bench` tasks:
 
 1. reproduce and fix an Axios/React Query error-handling bug, including tests;
 2. create oRPC infrastructure and migrate a Next.js application across files;
 3. refactor a TypeScript monorepo plugin and remove obsolete architecture.
 
-The run order is interleaved as a Latin square so each model sees every task in
-a different position. Each task runs once, sequentially, inside its own Docker
-environment and is graded by the task's deterministic verifier.
+The staged router checkpoint uses eight tasks across TypeScript, Python, C++,
+and Go, with easy, medium, and hard debugging, migration, refactoring, and
+implementation work. Its checked-in configuration is
+`cline-bench-router-checkpoint.config.json`.
+
+Run order is interleaved so each model sees its assigned task set in a different
+position. Each task runs once, sequentially, inside its own Docker environment
+and is graded by the task's deterministic verifier.
 
 ## Safety
 
 - Dry-run is the default. Paid calls require `--execute`.
-- The config rejects 100 or more tasks or dollars per model.
+- The campaign checkpoint cannot exceed $50. Wave 1 reserves at most $35 and
+  wave 2 reserves at most $15.
+- `--execute` requires an explicit jobs root. Rerunning without intentionally
+  naming the same root cannot silently start a second full campaign.
+- A jobs-root lock rejects concurrent runners. Dead local owners are recovered
+  atomically; ambiguous or live owners fail closed.
+- Every run writes a durable declared-cost reservation before Harbor starts.
+  An interrupted reservation with no unambiguous usage artifact blocks resume.
 - Harbor receives a small environment allowlist, not the host environment.
 - Jobs and traces are written outside the repository with private permissions.
 - Authentication is inherited only through `CLINE_API_KEY`; it is never stored
   in the config, command arguments, report, or repository.
 - The Cline CLI version is pinned in configuration for reproducibility. Its
   built-in consecutive-mistake limit remains enabled.
-- The default pilot is bounded to 3 tasks/model, $15/model or less, and $40
-  globally.
+- The default smoke pilot is bounded to 3 tasks/model, $15/model or less, and
+  $40 globally.
 - `routerProfile` is validated. A `cline-pass-router` experiment rejects every
   model that does not use a public `cline-pass/*` ID, and each profile requires
   its matching Cline CLI provider.
 - Config, model, and pricing objects reject unknown fields, so accidentally
   adding a credential cannot copy it into the retained report.
 - Reused job roots carry a content-addressed execution fingerprint covering the
-  provider/model/task/CLI matrix, the exact `cline-bench` submodule commit, and
-  SHA-256 hashes of the effective task trees Harbor receives (including the
-  private Telegram verifier overlay). Completed reused results also revalidate
-  task, CLI version, served provider, and served model. Reports from before these
-  corpus hashes existed fail closed and require a new jobs root.
+  complete effective config, runner source hash, runner git commit, Harbor
+  version, exact `cline-bench` submodule commit, and SHA-256 hashes of the
+  exact task trees Harbor receives. The manifest is written before Harbor starts. Completed reused
+  results also revalidate task, CLI version, served provider, and served model.
 - The private jobs-root boundary is canonicalized through symlinks. If Harbor's
   outer process times out or exits abnormally, the runner removes only Docker
   containers whose trial IDs belong to that job and recovers usage when
@@ -45,14 +57,26 @@ environment and is graded by the task's deterministic verifier.
 - `costBasis` distinguishes ordinary reported inference cost from ClinePass
   reference-quota cost. ClinePass is subscription-billed, so its per-run dollar
   telemetry is useful for quota/economic comparisons but is not an invoice.
-- The timeout is enforced both in Cline and at Harbor's outer agent boundary;
-  interrupted runs count as timed-out failures and retain their usage totals.
-- The Telegram verifier is copied to a private per-run overlay that adds
-  `/root/.local/bin` to PATH. This fixes its upstream `uv` lookup bug without
-  dirtying or forking the `cline-bench` submodule.
+- The timeout is enforced both in Cline and at Harbor's outer agent boundary.
+  Harbor runs in its own process group; timeout and termination signals stop the
+  group and task-scoped containers are removed. Interrupted usage is accepted
+  only from exactly one attempt and the timestamp-latest cumulative snapshot.
+- Harbor receives a verifier-only `PATH` containing `/root/.local/bin`. This
+  fixes inconsistent `uv` lookup across the selected verifiers without changing
+  the agent environment, task instructions, tests, or `cline-bench` submodule.
 - Harbor exposes cost telemetry after a task completes, not while it is
-  running. Therefore dollar limits stop subsequent work, and the 25-minute
-  wall timeout is the proactive in-task bound.
+  running. Reservations prevent starting work whose declared exposure would
+  cross a checkpoint, but they cannot stop an active request at an exact dollar
+  amount. A provider-side/prepaid account limit is the **only true dollar hard
+  stop**. The wall timeout is the active-run bound.
+- Optional `--local-core-url http://localhost:7777` is deliberately narrow. It
+  normalizes to `host.docker.internal:7777`, forwards only
+  `CLINE_API_BASE_URL`, and adds only that hostname to Harbor's environment and
+  agent-phase allowlists. Arbitrary URLs and environment passthrough are
+  rejected.
+- Virtual-model reports retain `requestedModel`, hashed benchmark task/session
+  identifiers, and privacy-safe route evidence. Fixed-model results remain
+  backward compatible.
 
 ## Usage
 
@@ -66,7 +90,8 @@ Run it after securely exporting a Cline credential:
 
 ```bash
 CLINE_API_KEY="$CLINE_API_KEY" \
-  bun evals/e2e/run-cline-bench-pilot.ts --execute
+  bun evals/e2e/run-cline-bench-pilot.ts --execute \
+  --jobs-root "$HOME/.cache/cline-auto-sdlc-bench/smoke-$(date +%Y%m%d)"
 ```
 
 Models, task IDs, timeouts, and budget limits are data in
@@ -87,3 +112,54 @@ Use `--only-run N` to execute one missing matrix position while still loading
 completed prior costs into the budget ledger.
 If the `cline-bench` commit, a selected task, or its effective verifier overlay
 changes, the runner rejects that jobs root instead of reusing stale results.
+
+## Staged router checkpoint
+
+Validate the 24-run matrix without spending:
+
+```bash
+bun evals/e2e/run-cline-bench-pilot.ts \
+  --config evals/e2e/cline-bench-router-checkpoint.config.json
+```
+
+Wave 1 runs `cline/auto` on all eight tasks and Kimi K2.7 Code plus GLM 5.2 on
+Axios, Telegram, Every Plugin, and V-Edit. It reserves no more than $35:
+
+```bash
+CLINE_API_KEY="$CLINE_API_KEY" \
+  bun evals/e2e/run-cline-bench-pilot.ts --execute --wave 1 \
+  --config evals/e2e/cline-bench-router-checkpoint.config.json \
+  --jobs-root "$HOME/.cache/cline-auto-sdlc-bench/router-checkpoint"
+```
+
+For a local Core API, add:
+
+```bash
+--local-core-url http://localhost:7777
+```
+
+Inspect wave 1 outcomes, route evidence, and the provider-side account limit
+before releasing wave 2. Wave 2 adds GPT-5.4 on all eight tasks, reserves no more
+than another $15, and shares the same $50 campaign ledger:
+
+```bash
+CLINE_API_KEY="$CLINE_API_KEY" \
+  bun evals/e2e/run-cline-bench-pilot.ts --execute --wave 2 \
+  --config evals/e2e/cline-bench-router-checkpoint.config.json \
+  --jobs-root "$HOME/.cache/cline-auto-sdlc-bench/router-checkpoint"
+```
+
+Core route traces can be attached directly from the benchmark JSONL sink. The
+runner validates the exact schema (including the privacy-safe routing features
+and cache/switch gate), reads Cline's `session_id` from Harbor's private
+`agent/trajectory.json`, and correlates it with Core's raw
+`task_id_sha256 = SHA256(session_id)`. Reports retain only hashes, never the raw
+session ID. The earlier camelCase six-field export remains accepted for
+backward compatibility. Attach a trace export without calling a model:
+
+```bash
+bun evals/e2e/run-cline-bench-pilot.ts --ingest-route-traces \
+  --route-traces /absolute/private/path/router-traces.jsonl \
+  --config evals/e2e/cline-bench-router-checkpoint.config.json \
+  --jobs-root "$HOME/.cache/cline-auto-sdlc-bench/router-checkpoint"
+```

--- a/evals/e2e/CLINE_BENCH_PILOT.md
+++ b/evals/e2e/CLINE_BENCH_PILOT.md
@@ -157,12 +157,26 @@ Axios, Telegram, Every Plugin, and V-Edit. All three arms use the same local
 Core transport. It reserves no more than $35.20:
 
 ```bash
-CLINE_API_KEY="$CLINE_API_KEY" \
+trace_path="$HOME/.cache/cline-auto-sdlc-bench/router-checkpoint-traces.jsonl"
+mkdir -p "$(dirname "$trace_path")"
+chmod 700 "$(dirname "$trace_path")"
+if [ ! -e "$trace_path" ]; then install -m 600 /dev/null "$trace_path"; fi
+chmod 600 "$trace_path"
+
+AUTO_ROUTER_BENCHMARK_TRACE_PATH="$trace_path" \
+  CLINE_API_KEY="$CLINE_API_KEY" \
   bun evals/e2e/run-cline-bench-pilot.ts --execute --wave 1 \
   --config evals/e2e/cline-bench-router-checkpoint.config.json \
   --jobs-root "$HOME/.cache/cline-auto-sdlc-bench/router-checkpoint" \
   --local-core-url http://localhost:17777
 ```
+
+Launch Core with the same absolute `AUTO_ROUTER_BENCHMARK_TRACE_PATH`. For a
+selected execution containing local-Core `cline/auto` or `cline-pass/auto`,
+the runner requires an existing private, parseable trace file before creating
+the jobs root or reserving budget. It reloads the JSONL after each virtual-model
+result so Core's newly appended decisions are attached immediately. An explicit
+absolute `--route-traces` path overrides the environment variable.
 
 Inspect wave 1 outcomes, route evidence, and the provider-side account limit
 before releasing wave 2. Wave 2 adds GPT-5.6 Sol on all eight tasks, reserves
@@ -170,7 +184,8 @@ no more than another $14.40 through the direct Cline API, and shares the same
 $50 campaign ledger and execution fingerprint:
 
 ```bash
-CLINE_API_KEY="$CLINE_API_KEY" \
+AUTO_ROUTER_BENCHMARK_TRACE_PATH="$HOME/.cache/cline-auto-sdlc-bench/router-checkpoint-traces.jsonl" \
+  CLINE_API_KEY="$CLINE_API_KEY" \
   bun evals/e2e/run-cline-bench-pilot.ts --execute --wave 2 \
   --config evals/e2e/cline-bench-router-checkpoint.config.json \
   --jobs-root "$HOME/.cache/cline-auto-sdlc-bench/router-checkpoint" \

--- a/evals/e2e/CLINE_BENCH_PILOT.md
+++ b/evals/e2e/CLINE_BENCH_PILOT.md
@@ -59,10 +59,13 @@ and is graded by the task's deterministic verifier.
 - Optional per-model token prices add cache-read ratio, estimated warm cost,
   cold-equivalent cost, and estimated cache savings to each report result.
 - `costBasis` distinguishes ordinary reported inference cost, ClinePass
-  reference-quota cost, and conservative `reserved-exposure`. A completed trial
-  with no cost telemetry is failed and charged at its full reservation rather
-  than reported as free or retried. A canonical terminal error with explicit
-  zero cumulative usage remains a legitimate zero-spend infrastructure failure.
+  reference-quota cost, and `unmeasured`. A completed trial with no usage or
+  cost telemetry is an `infrastructure_invalid` result: `costUsd` is null and
+  `reservedExposureUsd` retains the full reservation as a conservative bound.
+  The budget ledger records that bound as `unmeasured`, never as invented actual
+  model cost, and the position is not silently retried. A canonical terminal
+  error with explicit zero cumulative usage remains a legitimate measured
+  zero-spend infrastructure failure.
   ClinePass is subscription-billed, so its per-run dollar telemetry is useful
   for quota/economic comparisons but is not an invoice.
 - Paid execution fetches Cline's public recommended-model catalog before
@@ -70,6 +73,11 @@ and is graded by the task's deterministic verifier.
   present in the relevant live catalog, regardless of transport; virtual Auto
   candidates keep Core's internal IDs and are not compared to public picker
   identifiers.
+- When a virtual Auto arm uses local Core, paid execution also fetches that
+  Core instance's recommended-model catalog from the host and requires the
+  public virtual ID (`cline/auto` or `cline-pass/auto`) before creating the jobs
+  root or reserving budget. A missing picker/catalog registration therefore
+  cannot become a paid-looking CLI no-op.
 - The timeout is enforced both in Cline and at Harbor's outer agent boundary.
   Harbor runs in its own process group; timeout and termination signals stop the
   group and task-scoped containers are removed. Interrupted usage is accepted

--- a/evals/e2e/CLINE_BENCH_PILOT.md
+++ b/evals/e2e/CLINE_BENCH_PILOT.md
@@ -27,8 +27,12 @@ environment and is graded by the task's deterministic verifier.
   its matching Cline CLI provider.
 - Config, model, and pricing objects reject unknown fields, so accidentally
   adding a credential cannot copy it into the retained report.
-- Reused job roots carry a provider/model/task/CLI fingerprint, and every reused
-  result revalidates task, CLI version, served provider, and served model.
+- Reused job roots carry a content-addressed execution fingerprint covering the
+  provider/model/task/CLI matrix, the exact `cline-bench` submodule commit, and
+  SHA-256 hashes of the effective task trees Harbor receives (including the
+  private Telegram verifier overlay). Completed reused results also revalidate
+  task, CLI version, served provider, and served model. Reports from before these
+  corpus hashes existed fail closed and require a new jobs root.
 - The private jobs-root boundary is canonicalized through symlinks. If Harbor's
   outer process times out or exits abnormally, the runner removes only Docker
   containers whose trial IDs belong to that job and recovers usage when
@@ -81,3 +85,5 @@ Use `--stop-after N` to end cleanly after a matrix position; rerunning with the
 same `--jobs-root` reuses verified completed work.
 Use `--only-run N` to execute one missing matrix position while still loading
 completed prior costs into the budget ledger.
+If the `cline-bench` commit, a selected task, or its effective verifier overlay
+changes, the runner rejects that jobs root instead of reusing stale results.

--- a/evals/e2e/CLINE_BENCH_PILOT.md
+++ b/evals/e2e/CLINE_BENCH_PILOT.md
@@ -62,9 +62,10 @@ and is graded by the task's deterministic verifier.
   ClinePass is subscription-billed, so its per-run dollar telemetry is useful
   for quota/economic comparisons but is not an invoice.
 - Paid execution fetches Cline's public recommended-model catalog before
-  creating the jobs root or reserving budget. Direct arms must be present in the
-  relevant live catalog; virtual Auto candidates keep Core's internal IDs and
-  are not compared to public picker identifiers.
+  creating the jobs root or reserving budget. Fixed comparator IDs must be
+  present in the relevant live catalog, regardless of transport; virtual Auto
+  candidates keep Core's internal IDs and are not compared to public picker
+  identifiers.
 - The timeout is enforced both in Cline and at Harbor's outer agent boundary.
   Harbor runs in its own process group; timeout and termination signals stop the
   group and task-scoped containers are removed. Interrupted usage is accepted
@@ -80,13 +81,16 @@ and is graded by the task's deterministic verifier.
   result file. One in-flight model call can still land after the last usage
   event, so a provider-side/prepaid account limit remains the only true dollar
   hard stop.
-- Optional `--local-core-url http://localhost:7777` is deliberately narrow. It
-  applies only to the virtual `cline/auto` and `cline-pass/auto` arms,
-  normalizes to `host.docker.internal:7777`, forwards only
-  `CLINE_API_BASE_URL`, and adds only that hostname to Harbor's environment and
-  agent-phase allowlists. Fixed-model comparators continue to call Cline
-  directly so provider-reported usage and cost remain authoritative. Arbitrary
-  URLs and environment passthrough are rejected.
+- Optional model-level `transport` is either `cline-api` or `local-core`.
+  Explicit `local-core` arms require `--local-core-url` before the jobs root is
+  created or budget is reserved. The URL remains deliberately narrow: it
+  normalizes localhost ports 7777 or 17777 to `host.docker.internal`, forwards
+  only `CLINE_API_BASE_URL`, and adds only that hostname to Harbor's environment
+  and agent-phase allowlists. This lets fixed comparators and Auto share one
+  controlled Core transport while other arms can continue to call Cline
+  directly. Arbitrary URLs and environment passthrough are rejected. For
+  backward compatibility, an unspecified transport still applies a supplied
+  local Core URL only to `cline/auto` and `cline-pass/auto`.
 - Virtual-model reports retain `requestedModel`, hashed benchmark task/session
   identifiers, and privacy-safe route evidence. Fixed-model results remain
   backward compatible.
@@ -136,30 +140,28 @@ bun evals/e2e/run-cline-bench-pilot.ts \
 ```
 
 Wave 1 runs `cline/auto` on all eight tasks and Kimi K3 plus GLM 5.2 on
-Axios, Telegram, Every Plugin, and V-Edit. It reserves no more than $35.20:
+Axios, Telegram, Every Plugin, and V-Edit. All three arms use the same local
+Core transport. It reserves no more than $35.20:
 
 ```bash
 CLINE_API_KEY="$CLINE_API_KEY" \
   bun evals/e2e/run-cline-bench-pilot.ts --execute --wave 1 \
   --config evals/e2e/cline-bench-router-checkpoint.config.json \
-  --jobs-root "$HOME/.cache/cline-auto-sdlc-bench/router-checkpoint"
-```
-
-For a local Core API, add:
-
-```bash
---local-core-url http://localhost:7777
+  --jobs-root "$HOME/.cache/cline-auto-sdlc-bench/router-checkpoint" \
+  --local-core-url http://localhost:17777
 ```
 
 Inspect wave 1 outcomes, route evidence, and the provider-side account limit
 before releasing wave 2. Wave 2 adds GPT-5.6 Sol on all eight tasks, reserves
-no more than another $14.40, and shares the same $50 campaign ledger:
+no more than another $14.40 through the direct Cline API, and shares the same
+$50 campaign ledger and execution fingerprint:
 
 ```bash
 CLINE_API_KEY="$CLINE_API_KEY" \
   bun evals/e2e/run-cline-bench-pilot.ts --execute --wave 2 \
   --config evals/e2e/cline-bench-router-checkpoint.config.json \
-  --jobs-root "$HOME/.cache/cline-auto-sdlc-bench/router-checkpoint"
+  --jobs-root "$HOME/.cache/cline-auto-sdlc-bench/router-checkpoint" \
+  --local-core-url http://localhost:17777
 ```
 
 Core route traces can be attached directly from the benchmark JSONL sink. The

--- a/evals/e2e/CLINE_BENCH_PILOT.md
+++ b/evals/e2e/CLINE_BENCH_PILOT.md
@@ -33,6 +33,10 @@ and is graded by the task's deterministic verifier.
   in the config, command arguments, report, or repository.
 - The Cline CLI version is pinned in configuration for reproducibility. Its
   built-in consecutive-mistake limit remains enabled.
+- Any explicit `local-core` transport also requires `localCoreRevision` to be
+  the exact 40-character lowercase hexadecimal Core Git commit. It is printed
+  in the dry-run summary and retained in the execution fingerprint, manifest,
+  and report, so a different local Core build cannot silently reuse results.
 - The default smoke pilot is bounded to 3 tasks/model, $15/model or less, and
   $40 globally.
 - `routerProfile` is validated. A `cline-pass-router` experiment rejects every
@@ -82,8 +86,9 @@ and is graded by the task's deterministic verifier.
   event, so a provider-side/prepaid account limit remains the only true dollar
   hard stop.
 - Optional model-level `transport` is either `cline-api` or `local-core`.
-  Explicit `local-core` arms require `--local-core-url` before the jobs root is
-  created or budget is reserved. The URL remains deliberately narrow: it
+  Explicit `local-core` arms require both the pinned config revision above and
+  `--local-core-url` before the jobs root is created or budget is reserved. The
+  URL remains deliberately narrow: it
   normalizes localhost ports 7777 or 17777 to `host.docker.internal`, forwards
   only `CLINE_API_BASE_URL`, and adds only that hostname to Harbor's environment
   and agent-phase allowlists. This lets fixed comparators and Auto share one

--- a/evals/e2e/CLINE_BENCH_PILOT.md
+++ b/evals/e2e/CLINE_BENCH_PILOT.md
@@ -64,11 +64,14 @@ and is graded by the task's deterministic verifier.
 - Harbor receives a verifier-only `PATH` containing `/root/.local/bin`. This
   fixes inconsistent `uv` lookup across the selected verifiers without changing
   the agent environment, task instructions, tests, or `cline-bench` submodule.
-- Harbor exposes cost telemetry after a task completes, not while it is
-  running. Reservations prevent starting work whose declared exposure would
-  cross a checkpoint, but they cannot stop an active request at an exact dollar
-  amount. A provider-side/prepaid account limit is the **only true dollar hard
-  stop**. The wall timeout is the active-run bound.
+- Cline writes cumulative usage after each model turn. The runner polls that
+  private JSONL every 250 ms and stops an active run at the reservation minus
+  `max($0.55, 25%)` headroom (`$1.65` for a `$2.20` reservation). It persists a
+  private recovery marker before terminating Harbor and its task container, so
+  a stopped run is settled and never respent even if Harbor cannot finish its
+  result file. One in-flight model call can still land after the last usage
+  event, so a provider-side/prepaid account limit remains the only true dollar
+  hard stop.
 - Optional `--local-core-url http://localhost:7777` is deliberately narrow. It
   applies only to the virtual `cline/auto` and `cline-pass/auto` arms,
   normalizes to `host.docker.internal:7777`, forwards only

--- a/evals/e2e/cline-bench-pass-pilot.config.json
+++ b/evals/e2e/cline-bench-pass-pilot.config.json
@@ -1,0 +1,64 @@
+{
+	"routerProfile": "cline-pass-router",
+	"provider": "cline-pass",
+	"globalBudgetUsd": 60,
+	"maxRunsPerModel": 2,
+	"timeoutSeconds": 1500,
+	"clineVersion": "3.0.46",
+	"models": [
+		{
+			"id": "cline-pass/kimi-k3",
+			"perTaskBudgetUsd": 5,
+			"perModelBudgetUsd": 10,
+			"pricing": {
+				"inputPerMTok": 3,
+				"cachedInputPerMTok": 0.3,
+				"outputPerMTok": 15
+			}
+		},
+		{
+			"id": "cline-pass/glm-5.2",
+			"perTaskBudgetUsd": 4,
+			"perModelBudgetUsd": 8,
+			"pricing": {
+				"inputPerMTok": 1.4,
+				"cachedInputPerMTok": 0.26,
+				"outputPerMTok": 4.4
+			}
+		},
+		{
+			"id": "cline-pass/deepseek-v4-flash",
+			"perTaskBudgetUsd": 3,
+			"perModelBudgetUsd": 6,
+			"pricing": {
+				"inputPerMTok": 0.14,
+				"cachedInputPerMTok": 0.0028,
+				"outputPerMTok": 0.28
+			}
+		},
+		{
+			"id": "cline-pass/qwen3.7-plus",
+			"perTaskBudgetUsd": 3,
+			"perModelBudgetUsd": 6,
+			"pricing": {
+				"inputPerMTok": 0.4,
+				"cachedInputPerMTok": 0.04,
+				"outputPerMTok": 1.6
+			}
+		},
+		{
+			"id": "cline-pass/deepseek-v4-pro",
+			"perTaskBudgetUsd": 4,
+			"perModelBudgetUsd": 8,
+			"pricing": {
+				"inputPerMTok": 1.74,
+				"cachedInputPerMTok": 0.0145,
+				"outputPerMTok": 3.48
+			}
+		}
+	],
+	"tasks": [
+		"01k6rkmyfgbwpvf7h81gh4pdgd-intercept-axios-error-handling",
+		"01k8251zmv88p0hztas8htr6hw-orpc-client-migration"
+	]
+}

--- a/evals/e2e/cline-bench-pass-pilot.config.json
+++ b/evals/e2e/cline-bench-pass-pilot.config.json
@@ -1,7 +1,7 @@
 {
 	"routerProfile": "cline-pass-router",
 	"provider": "cline-pass",
-	"globalBudgetUsd": 60,
+	"globalBudgetUsd": 50,
 	"maxRunsPerModel": 2,
 	"timeoutSeconds": 1500,
 	"clineVersion": "3.0.46",
@@ -21,9 +21,9 @@
 			"perTaskBudgetUsd": 4,
 			"perModelBudgetUsd": 8,
 			"pricing": {
-				"inputPerMTok": 1.4,
-				"cachedInputPerMTok": 0.26,
-				"outputPerMTok": 4.4
+				"inputPerMTok": 0.8078,
+				"cachedInputPerMTok": 0.15002,
+				"outputPerMTok": 2.5388
 			}
 		},
 		{
@@ -31,9 +31,9 @@
 			"perTaskBudgetUsd": 3,
 			"perModelBudgetUsd": 6,
 			"pricing": {
-				"inputPerMTok": 0.14,
-				"cachedInputPerMTok": 0.0028,
-				"outputPerMTok": 0.28
+				"inputPerMTok": 0.0938,
+				"cachedInputPerMTok": 0.01876,
+				"outputPerMTok": 0.1876
 			}
 		},
 		{
@@ -41,9 +41,9 @@
 			"perTaskBudgetUsd": 3,
 			"perModelBudgetUsd": 6,
 			"pricing": {
-				"inputPerMTok": 0.4,
-				"cachedInputPerMTok": 0.04,
-				"outputPerMTok": 1.6
+				"inputPerMTok": 0.32,
+				"cachedInputPerMTok": 0.064,
+				"outputPerMTok": 1.28
 			}
 		},
 		{
@@ -51,9 +51,9 @@
 			"perTaskBudgetUsd": 4,
 			"perModelBudgetUsd": 8,
 			"pricing": {
-				"inputPerMTok": 1.74,
-				"cachedInputPerMTok": 0.0145,
-				"outputPerMTok": 3.48
+				"inputPerMTok": 0.435,
+				"cachedInputPerMTok": 0.003625,
+				"outputPerMTok": 0.87
 			}
 		}
 	],

--- a/evals/e2e/cline-bench-pilot.config.json
+++ b/evals/e2e/cline-bench-pilot.config.json
@@ -7,13 +7,13 @@
 	"clineVersion": "3.0.46",
 	"models": [
 		{
-			"id": "moonshotai/kimi-k3",
+			"id": "moonshotai/kimi-k2.7-code",
 			"perTaskBudgetUsd": 5,
 			"perModelBudgetUsd": 15,
 			"pricing": {
-				"inputPerMTok": 3,
-				"cachedInputPerMTok": 0.3,
-				"outputPerMTok": 15
+				"inputPerMTok": 1,
+				"cachedInputPerMTok": 0.18,
+				"outputPerMTok": 4.16
 			}
 		},
 		{
@@ -21,8 +21,8 @@
 			"perTaskBudgetUsd": 4,
 			"perModelBudgetUsd": 10,
 			"pricing": {
-				"inputPerMTok": 1.4,
-				"cachedInputPerMTok": 0.26,
+				"inputPerMTok": 1.2,
+				"cachedInputPerMTok": 0.3,
 				"outputPerMTok": 4.4
 			}
 		},

--- a/evals/e2e/cline-bench-pilot.config.json
+++ b/evals/e2e/cline-bench-pilot.config.json
@@ -7,13 +7,13 @@
 	"clineVersion": "3.0.46",
 	"models": [
 		{
-			"id": "moonshotai/kimi-k2.7-code",
+			"id": "moonshotai/kimi-k3",
 			"perTaskBudgetUsd": 5,
 			"perModelBudgetUsd": 15,
 			"pricing": {
-				"inputPerMTok": 1,
-				"cachedInputPerMTok": 0.18,
-				"outputPerMTok": 4.16
+				"inputPerMTok": 3,
+				"cachedInputPerMTok": 0.3,
+				"outputPerMTok": 15
 			}
 		},
 		{

--- a/evals/e2e/cline-bench-pilot.config.json
+++ b/evals/e2e/cline-bench-pilot.config.json
@@ -1,0 +1,45 @@
+{
+	"routerProfile": "cline-router",
+	"provider": "cline",
+	"globalBudgetUsd": 40,
+	"maxRunsPerModel": 3,
+	"timeoutSeconds": 1500,
+	"clineVersion": "3.0.46",
+	"models": [
+		{
+			"id": "moonshotai/kimi-k3",
+			"perTaskBudgetUsd": 5,
+			"perModelBudgetUsd": 15,
+			"pricing": {
+				"inputPerMTok": 3,
+				"cachedInputPerMTok": 0.3,
+				"outputPerMTok": 15
+			}
+		},
+		{
+			"id": "z-ai/glm-5.2",
+			"perTaskBudgetUsd": 4,
+			"perModelBudgetUsd": 10,
+			"pricing": {
+				"inputPerMTok": 1.4,
+				"cachedInputPerMTok": 0.26,
+				"outputPerMTok": 4.4
+			}
+		},
+		{
+			"id": "openai/gpt-5.4",
+			"perTaskBudgetUsd": 5,
+			"perModelBudgetUsd": 15,
+			"pricing": {
+				"inputPerMTok": 2.5,
+				"cachedInputPerMTok": 0.25,
+				"outputPerMTok": 15
+			}
+		}
+	],
+	"tasks": [
+		"01k6rkmyfgbwpvf7h81gh4pdgd-intercept-axios-error-handling",
+		"01k8251zmv88p0hztas8htr6hw-orpc-client-migration",
+		"01k6zz0nyj31znwsevx4sn6zb2-telegram-plugin-refactor"
+	]
+}

--- a/evals/e2e/cline-bench-pilot.config.json
+++ b/evals/e2e/cline-bench-pilot.config.json
@@ -17,23 +17,23 @@
 			}
 		},
 		{
-			"id": "z-ai/glm-5.2",
+			"id": "zai/glm-5.2",
 			"perTaskBudgetUsd": 4,
 			"perModelBudgetUsd": 10,
 			"pricing": {
-				"inputPerMTok": 1.2,
-				"cachedInputPerMTok": 0.3,
+				"inputPerMTok": 1.4,
+				"cachedInputPerMTok": 0.26,
 				"outputPerMTok": 4.4
 			}
 		},
 		{
-			"id": "openai/gpt-5.4",
+			"id": "openai/gpt-5.6-sol",
 			"perTaskBudgetUsd": 5,
 			"perModelBudgetUsd": 15,
 			"pricing": {
-				"inputPerMTok": 2.5,
-				"cachedInputPerMTok": 0.25,
-				"outputPerMTok": 15
+				"inputPerMTok": 5,
+				"cachedInputPerMTok": 0.5,
+				"outputPerMTok": 30
 			}
 		}
 	],

--- a/evals/e2e/cline-bench-router-checkpoint.config.json
+++ b/evals/e2e/cline-bench-router-checkpoint.config.json
@@ -12,6 +12,7 @@
 	"models": [
 		{
 			"id": "cline/auto",
+			"transport": "local-core",
 			"wave": 1,
 			"perTaskBudgetUsd": 2.2,
 			"perModelBudgetUsd": 17.6,
@@ -23,6 +24,7 @@
 		},
 		{
 			"id": "moonshotai/kimi-k3",
+			"transport": "local-core",
 			"wave": 1,
 			"perTaskBudgetUsd": 2.2,
 			"perModelBudgetUsd": 8.8,
@@ -40,6 +42,7 @@
 		},
 		{
 			"id": "zai/glm-5.2",
+			"transport": "local-core",
 			"wave": 1,
 			"perTaskBudgetUsd": 2.2,
 			"perModelBudgetUsd": 8.8,
@@ -57,6 +60,7 @@
 		},
 		{
 			"id": "openai/gpt-5.6-sol",
+			"transport": "cline-api",
 			"wave": 2,
 			"perTaskBudgetUsd": 1.8,
 			"perModelBudgetUsd": 14.4,

--- a/evals/e2e/cline-bench-router-checkpoint.config.json
+++ b/evals/e2e/cline-bench-router-checkpoint.config.json
@@ -3,8 +3,8 @@
 	"provider": "cline",
 	"globalBudgetUsd": 50,
 	"waveBudgetsUsd": {
-		"1": 35,
-		"2": 15
+		"1": 35.2,
+		"2": 14.41
 	},
 	"maxRunsPerModel": 8,
 	"timeoutSeconds": 1500,
@@ -13,19 +13,19 @@
 		{
 			"id": "cline/auto",
 			"wave": 1,
-			"perTaskBudgetUsd": 1.5,
-			"perModelBudgetUsd": 12,
+			"perTaskBudgetUsd": 2.2,
+			"perModelBudgetUsd": 17.6,
 			"allowedCandidates": [
-				"moonshotai/kimi-k2.7-code",
+				"moonshotai/kimi-k3",
 				"z-ai/glm-5.2",
 				"openai/gpt-5.4"
 			]
 		},
 		{
-			"id": "moonshotai/kimi-k2.7-code",
+			"id": "moonshotai/kimi-k3",
 			"wave": 1,
-			"perTaskBudgetUsd": 2.5,
-			"perModelBudgetUsd": 10,
+			"perTaskBudgetUsd": 2.2,
+			"perModelBudgetUsd": 8.8,
 			"tasks": [
 				"01k6rkmyfgbwpvf7h81gh4pdgd-intercept-axios-error-handling",
 				"01k6zz0nyj31znwsevx4sn6zb2-telegram-plugin-refactor",
@@ -33,16 +33,16 @@
 				"01k8mwgj1z6kr0a7q59r6ek2ar-v-edit-workspace-tests"
 			],
 			"pricing": {
-				"inputPerMTok": 1,
-				"cachedInputPerMTok": 0.18,
-				"outputPerMTok": 4.16
+				"inputPerMTok": 3,
+				"cachedInputPerMTok": 0.3,
+				"outputPerMTok": 15
 			}
 		},
 		{
 			"id": "z-ai/glm-5.2",
 			"wave": 1,
-			"perTaskBudgetUsd": 2.5,
-			"perModelBudgetUsd": 10,
+			"perTaskBudgetUsd": 2.2,
+			"perModelBudgetUsd": 8.8,
 			"tasks": [
 				"01k6rkmyfgbwpvf7h81gh4pdgd-intercept-axios-error-handling",
 				"01k6zz0nyj31znwsevx4sn6zb2-telegram-plugin-refactor",

--- a/evals/e2e/cline-bench-router-checkpoint.config.json
+++ b/evals/e2e/cline-bench-router-checkpoint.config.json
@@ -39,7 +39,7 @@
 			}
 		},
 		{
-			"id": "z-ai/glm-5.2",
+			"id": "zai/glm-5.2",
 			"wave": 1,
 			"perTaskBudgetUsd": 2.2,
 			"perModelBudgetUsd": 8.8,
@@ -50,20 +50,20 @@
 				"01k8mwgj1z6kr0a7q59r6ek2ar-v-edit-workspace-tests"
 			],
 			"pricing": {
-				"inputPerMTok": 1.2,
-				"cachedInputPerMTok": 0.3,
+				"inputPerMTok": 1.4,
+				"cachedInputPerMTok": 0.26,
 				"outputPerMTok": 4.4
 			}
 		},
 		{
-			"id": "openai/gpt-5.4",
+			"id": "openai/gpt-5.6-sol",
 			"wave": 2,
 			"perTaskBudgetUsd": 1.8,
 			"perModelBudgetUsd": 14.4,
 			"pricing": {
-				"inputPerMTok": 2.5,
-				"cachedInputPerMTok": 0.25,
-				"outputPerMTok": 15
+				"inputPerMTok": 5,
+				"cachedInputPerMTok": 0.5,
+				"outputPerMTok": 30
 			}
 		}
 	],

--- a/evals/e2e/cline-bench-router-checkpoint.config.json
+++ b/evals/e2e/cline-bench-router-checkpoint.config.json
@@ -9,7 +9,7 @@
 	"maxRunsPerModel": 8,
 	"timeoutSeconds": 1500,
 	"clineVersion": "3.0.46-nightly.1784896623",
-	"localCoreRevision": "587ebe82b3a2337b229d22ed097051215ba145f8",
+	"localCoreRevision": "9799914fa0e0082d27d72267f11eb959975706d0",
 	"models": [
 		{
 			"id": "cline/auto",

--- a/evals/e2e/cline-bench-router-checkpoint.config.json
+++ b/evals/e2e/cline-bench-router-checkpoint.config.json
@@ -8,7 +8,7 @@
 	},
 	"maxRunsPerModel": 8,
 	"timeoutSeconds": 1500,
-	"clineVersion": "3.0.46",
+	"clineVersion": "3.0.46-nightly.1784896623",
 	"models": [
 		{
 			"id": "cline/auto",

--- a/evals/e2e/cline-bench-router-checkpoint.config.json
+++ b/evals/e2e/cline-bench-router-checkpoint.config.json
@@ -1,0 +1,80 @@
+{
+	"routerProfile": "cline-router",
+	"provider": "cline",
+	"globalBudgetUsd": 50,
+	"waveBudgetsUsd": {
+		"1": 35,
+		"2": 15
+	},
+	"maxRunsPerModel": 8,
+	"timeoutSeconds": 1500,
+	"clineVersion": "3.0.46",
+	"models": [
+		{
+			"id": "cline/auto",
+			"wave": 1,
+			"perTaskBudgetUsd": 1.5,
+			"perModelBudgetUsd": 12,
+			"allowedCandidates": [
+				"moonshotai/kimi-k2.7-code",
+				"z-ai/glm-5.2",
+				"openai/gpt-5.4"
+			]
+		},
+		{
+			"id": "moonshotai/kimi-k2.7-code",
+			"wave": 1,
+			"perTaskBudgetUsd": 2.5,
+			"perModelBudgetUsd": 10,
+			"tasks": [
+				"01k6rkmyfgbwpvf7h81gh4pdgd-intercept-axios-error-handling",
+				"01k6zz0nyj31znwsevx4sn6zb2-telegram-plugin-refactor",
+				"01k6kr5hbv8za80v8vnze3at8h-every-plugin-api-migration",
+				"01k8mwgj1z6kr0a7q59r6ek2ar-v-edit-workspace-tests"
+			],
+			"pricing": {
+				"inputPerMTok": 1,
+				"cachedInputPerMTok": 0.18,
+				"outputPerMTok": 4.16
+			}
+		},
+		{
+			"id": "z-ai/glm-5.2",
+			"wave": 1,
+			"perTaskBudgetUsd": 2.5,
+			"perModelBudgetUsd": 10,
+			"tasks": [
+				"01k6rkmyfgbwpvf7h81gh4pdgd-intercept-axios-error-handling",
+				"01k6zz0nyj31znwsevx4sn6zb2-telegram-plugin-refactor",
+				"01k6kr5hbv8za80v8vnze3at8h-every-plugin-api-migration",
+				"01k8mwgj1z6kr0a7q59r6ek2ar-v-edit-workspace-tests"
+			],
+			"pricing": {
+				"inputPerMTok": 1.2,
+				"cachedInputPerMTok": 0.3,
+				"outputPerMTok": 4.4
+			}
+		},
+		{
+			"id": "openai/gpt-5.4",
+			"wave": 2,
+			"perTaskBudgetUsd": 1.8,
+			"perModelBudgetUsd": 14.4,
+			"pricing": {
+				"inputPerMTok": 2.5,
+				"cachedInputPerMTok": 0.25,
+				"outputPerMTok": 15
+			}
+		}
+	],
+	"tasks": [
+		"01k7a12sd1nk15j08e6x0x7v9e-discord-trivia-approval-keyerror",
+		"01k6rkmyfgbwpvf7h81gh4pdgd-intercept-axios-error-handling",
+		"01k6zz0nyj31znwsevx4sn6zb2-telegram-plugin-refactor",
+		"01k6kr5hbv8za80v8vnze3at8h-every-plugin-api-migration",
+		"01k8251zmv88p0hztas8htr6hw-orpc-client-migration",
+		"01k6n26zm27ffa7qqbcx0prrnw-police-sync-segfault",
+		"01k8mwgj1z6kr0a7q59r6ek2ar-v-edit-workspace-tests",
+		"01k7x8zyeg4nzx6ehdb0fg5gfx-terraform-azurerm-deployment-stacks"
+	]
+}

--- a/evals/e2e/cline-bench-router-checkpoint.config.json
+++ b/evals/e2e/cline-bench-router-checkpoint.config.json
@@ -9,6 +9,7 @@
 	"maxRunsPerModel": 8,
 	"timeoutSeconds": 1500,
 	"clineVersion": "3.0.46-nightly.1784896623",
+	"localCoreRevision": "587ebe82b3a2337b229d22ed097051215ba145f8",
 	"models": [
 		{
 			"id": "cline/auto",

--- a/evals/e2e/cline-bench-safety.ts
+++ b/evals/e2e/cline-bench-safety.ts
@@ -330,7 +330,13 @@ export function recoverLatestUsage(logDocuments: readonly string[]): UsageSnapsh
 			const snapshot = usageSnapshot(parsed)
 			if (snapshot) snapshots.push(snapshot)
 		} catch {
-			if (line.includes('"type":"usage"') || line.includes('"type":"run_result"')) {
+			// Harbor exception/result records can embed a truncated copy of the
+			// agent stdout, including telemetry-looking strings. Only classify
+			// canonical top-level Cline event lines as malformed telemetry.
+			if (
+				/^\{"ts":"[^"]+","type":"run_result"/.test(line) ||
+				/^\{"ts":"[^"]+","type":"agent_event","event":\{"type":"usage"/.test(line)
+			) {
 				throw new Error("interrupted cost telemetry contains a malformed usage record")
 			}
 		}

--- a/evals/e2e/cline-bench-safety.ts
+++ b/evals/e2e/cline-bench-safety.ts
@@ -133,7 +133,7 @@ export type BudgetEntry = {
 	wave: number
 	reservedUsd: number
 	actualUsd?: number
-	status: "reserved" | "settled"
+	status: "reserved" | "settled" | "unmeasured"
 	updatedAt: string
 }
 
@@ -215,6 +215,33 @@ export function settleBudget(ledger: BudgetLedger, runKey: string, actualUsd: nu
 						...entry,
 						actualUsd,
 						status: "settled",
+						updatedAt: new Date().toISOString(),
+					}
+				: entry,
+		),
+	}
+}
+
+export function markBudgetUnmeasured(ledger: BudgetLedger, runKey: string): BudgetLedger {
+	const existing = ledger.entries.find((entry) => entry.runKey === runKey)
+	if (!existing) throw new Error(`no budget reservation exists for ${runKey}`)
+	if (existing.status === "unmeasured") return ledger
+	if (
+		existing.status === "settled" &&
+		(existing.actualUsd === undefined || Math.abs(existing.actualUsd - existing.reservedUsd) > 1e-9)
+	) {
+		throw new Error(`cannot discard measured cost for ${runKey}`)
+	}
+	return {
+		...ledger,
+		entries: ledger.entries.map((entry) =>
+			entry.runKey === runKey
+				? {
+						runKey: entry.runKey,
+						model: entry.model,
+						wave: entry.wave,
+						reservedUsd: entry.reservedUsd,
+						status: "unmeasured",
 						updatedAt: new Date().toISOString(),
 					}
 				: entry,

--- a/evals/e2e/cline-bench-safety.ts
+++ b/evals/e2e/cline-bench-safety.ts
@@ -229,37 +229,121 @@ export type UsageSnapshot = {
 	totalOutputTokens: number | null
 }
 
+function requireUsageNumber(value: unknown, field: string, allowMissing: boolean): number | null {
+	if (allowMissing && (value === null || value === undefined)) return null
+	if (
+		typeof value !== "number" ||
+		!Number.isFinite(value) ||
+		!Number.isInteger(value) ||
+		value < 0
+	) {
+		throw new Error(`interrupted cost telemetry has invalid ${field}`)
+	}
+	return value
+}
+
+function recordValue(value: unknown): Record<string, unknown> | null {
+	return value !== null && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: null
+}
+
+function usageSnapshot(value: unknown): UsageSnapshot | null {
+	const parsed = recordValue(value)
+	if (!parsed) return null
+	const event = recordValue(parsed.event)
+	let usage: Record<string, unknown>
+	let allowMissingTokens = false
+	if (event?.type === "usage") {
+		allowMissingTokens = true
+		usage = {
+			totalCost: event.totalCost,
+			totalInputTokens: event.totalInputTokens,
+			totalCacheReadTokens: event.totalCacheReadTokens,
+			totalOutputTokens: event.totalOutputTokens,
+		}
+	} else if (parsed.type === "run_result") {
+		const cumulative = recordValue(parsed.aggregateUsage ?? parsed.usage)
+		if (!cumulative) {
+			throw new Error("interrupted run_result has no cumulative usage")
+		}
+		usage = {
+			totalCost: cumulative.totalCost,
+			totalInputTokens: cumulative.inputTokens,
+			totalCacheReadTokens: cumulative.cacheReadTokens,
+			totalOutputTokens: cumulative.outputTokens,
+		}
+	} else {
+		return null
+	}
+
+	const timestampMs = typeof parsed.ts === "string" ? Date.parse(parsed.ts) : Number.NaN
+	if (!Number.isFinite(timestampMs)) throw new Error("interrupted cost telemetry has invalid timestamp")
+	const totalCost = usage.totalCost
+	if (typeof totalCost !== "number" || !Number.isFinite(totalCost) || totalCost <= 0) {
+		throw new Error("interrupted cost telemetry has invalid totalCost")
+	}
+	return {
+		timestamp: new Date(timestampMs).toISOString(),
+		totalCost,
+		totalInputTokens: requireUsageNumber(usage.totalInputTokens, "totalInputTokens", allowMissingTokens),
+		totalCacheReadTokens: requireUsageNumber(usage.totalCacheReadTokens, "totalCacheReadTokens", allowMissingTokens),
+		totalOutputTokens: requireUsageNumber(usage.totalOutputTokens, "totalOutputTokens", allowMissingTokens),
+	}
+}
+
+function sameUsage(left: UsageSnapshot, right: UsageSnapshot): boolean {
+	return (
+		left.totalCost === right.totalCost &&
+		left.totalInputTokens === right.totalInputTokens &&
+		left.totalCacheReadTokens === right.totalCacheReadTokens &&
+		left.totalOutputTokens === right.totalOutputTokens
+	)
+}
+
 export function recoverLatestUsage(logDocuments: readonly string[]): UsageSnapshot {
 	if (logDocuments.length !== 1) {
 		throw new Error(`interrupted usage recovery requires exactly one attempt; found ${logDocuments.length}`)
 	}
 	const snapshots: UsageSnapshot[] = []
 	for (const line of logDocuments[0].split("\n")) {
-		if (!line.startsWith("{") || !line.includes('"type":"usage"')) continue
+		if (!line.startsWith("{")) continue
 		try {
 			const parsed = JSON.parse(line)
-			if (parsed.event?.type !== "usage") continue
-			const timestampMs = Date.parse(parsed.ts)
-			const totalCost = parsed.event.totalCost
-			if (!Number.isFinite(timestampMs) || !Number.isFinite(totalCost) || totalCost <= 0) continue
-			snapshots.push({
-				timestamp: new Date(timestampMs).toISOString(),
-				totalCost,
-				totalInputTokens: parsed.event.totalInputTokens ?? null,
-				totalCacheReadTokens: parsed.event.totalCacheReadTokens ?? null,
-				totalOutputTokens: parsed.event.totalOutputTokens ?? null,
-			})
+			const snapshot = usageSnapshot(parsed)
+			if (snapshot) snapshots.push(snapshot)
 		} catch {
-			// A force-stopped process can leave one partial final JSON line.
+			if (line.includes('"type":"usage"') || line.includes('"type":"run_result"')) {
+				throw new Error("interrupted cost telemetry contains a malformed usage record")
+			}
 		}
 	}
 	if (snapshots.length === 0) throw new Error("interrupted run has no usable cost telemetry")
 	snapshots.sort((left, right) => Date.parse(left.timestamp) - Date.parse(right.timestamp))
+	for (let index = 1; index < snapshots.length; index += 1) {
+		const previous = snapshots[index - 1]
+		const current = snapshots[index]
+		if (
+			current.totalCost < previous.totalCost ||
+			(current.totalInputTokens ?? 0) < (previous.totalInputTokens ?? 0) ||
+			(current.totalCacheReadTokens ?? 0) < (previous.totalCacheReadTokens ?? 0) ||
+			(current.totalOutputTokens ?? 0) < (previous.totalOutputTokens ?? 0)
+		) {
+			throw new Error("interrupted cost telemetry is non-monotonic")
+		}
+	}
 	const latest = snapshots.at(-1)
 	if (!latest) throw new Error("interrupted run has no latest usage snapshot")
 	const sameTimestamp = snapshots.filter((entry) => entry.timestamp === latest.timestamp)
-	if (sameTimestamp.some((entry) => entry.totalCost !== latest.totalCost)) {
+	if (sameTimestamp.some((entry) => !sameUsage(entry, latest))) {
 		throw new Error("interrupted usage recovery is ambiguous at the latest timestamp")
+	}
+	if (
+		latest.totalInputTokens === null ||
+		latest.totalCacheReadTokens === null ||
+		latest.totalOutputTokens === null
+	) {
+		throw new Error("interrupted latest cumulative usage is incomplete")
 	}
 	return latest
 }

--- a/evals/e2e/cline-bench-safety.ts
+++ b/evals/e2e/cline-bench-safety.ts
@@ -258,6 +258,17 @@ function usageSnapshot(value: unknown): UsageSnapshot | null {
 	let allowZeroNoSpendFailure = false
 	if (event?.type === "usage") {
 		allowMissingTokens = true
+		if (
+			event.totalCost === 0 &&
+			(event.totalInputTokens === 0 || event.totalInputTokens == null) &&
+			(event.totalCacheReadTokens === 0 || event.totalCacheReadTokens == null) &&
+			(event.totalOutputTokens === 0 || event.totalOutputTokens == null)
+		) {
+			// Cline emits an all-zero usage event immediately before some
+			// no-spend failures. It is not a cumulative billing checkpoint;
+			// the terminal error run_result below is.
+			return null
+		}
 		usage = {
 			totalCost: event.totalCost,
 			totalInputTokens: event.totalInputTokens,

--- a/evals/e2e/cline-bench-safety.ts
+++ b/evals/e2e/cline-bench-safety.ts
@@ -29,10 +29,11 @@ export function normalizeLocalCoreUrl(raw: string): string {
 	} catch {
 		throw new Error("--local-core-url must be a valid URL")
 	}
+	const allowedPorts = new Set(["7777", "17777"])
 	if (
 		parsed.protocol !== "http:" ||
 		!["localhost", "127.0.0.1", "host.docker.internal"].includes(parsed.hostname) ||
-		parsed.port !== "7777" ||
+		!allowedPorts.has(parsed.port) ||
 		(parsed.pathname !== "/" && parsed.pathname !== "") ||
 		parsed.username ||
 		parsed.password ||
@@ -40,10 +41,10 @@ export function normalizeLocalCoreUrl(raw: string): string {
 		parsed.hash
 	) {
 		throw new Error(
-			"--local-core-url only accepts http://localhost:7777, http://127.0.0.1:7777, or http://host.docker.internal:7777",
+			"--local-core-url only accepts localhost, 127.0.0.1, or host.docker.internal on port 7777 or 17777",
 		)
 	}
-	return "http://host.docker.internal:7777"
+	return `http://host.docker.internal:${parsed.port}`
 }
 
 type LockOwner = {

--- a/evals/e2e/cline-bench-safety.ts
+++ b/evals/e2e/cline-bench-safety.ts
@@ -1,0 +1,526 @@
+import { createHash, randomUUID } from "node:crypto"
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs"
+import { hostname } from "node:os"
+import { join } from "node:path"
+
+const HASH_PATTERN = /^[0-9a-f]{64}$/
+export const MAX_CHECKPOINT_USD = 50
+
+export function sha256(value: string | Uint8Array): string {
+	return createHash("sha256").update(value).digest("hex")
+}
+
+export function hashPrivateIdentifier(namespace: string, value: string): string {
+	return sha256(`${namespace}\0${value}`)
+}
+
+export function redactSecrets(value: string, secrets: readonly string[]): string {
+	let redacted = value
+	for (const secret of secrets) {
+		if (secret) redacted = redacted.split(secret).join("[REDACTED]")
+	}
+	return redacted
+}
+
+export function normalizeLocalCoreUrl(raw: string): string {
+	let parsed: URL
+	try {
+		parsed = new URL(raw)
+	} catch {
+		throw new Error("--local-core-url must be a valid URL")
+	}
+	if (
+		parsed.protocol !== "http:" ||
+		!["localhost", "127.0.0.1", "host.docker.internal"].includes(parsed.hostname) ||
+		parsed.port !== "7777" ||
+		(parsed.pathname !== "/" && parsed.pathname !== "") ||
+		parsed.username ||
+		parsed.password ||
+		parsed.search ||
+		parsed.hash
+	) {
+		throw new Error(
+			"--local-core-url only accepts http://localhost:7777, http://127.0.0.1:7777, or http://host.docker.internal:7777",
+		)
+	}
+	return "http://host.docker.internal:7777"
+}
+
+type LockOwner = {
+	schemaVersion: 1
+	pid: number
+	host: string
+	token: string
+	acquiredAt: string
+}
+
+export type RunLock = {
+	path: string
+	token: string
+}
+
+function isProcessAlive(pid: number): boolean {
+	if (!Number.isInteger(pid) || pid < 1) return false
+	try {
+		process.kill(pid, 0)
+		return true
+	} catch (error) {
+		return (error as NodeJS.ErrnoException).code === "EPERM"
+	}
+}
+
+export function acquireRunLock(jobsRoot: string): RunLock {
+	const lockPath = join(jobsRoot, ".pilot-run.lock")
+	const ownerPath = join(lockPath, "owner.json")
+	for (let attempt = 0; attempt < 3; attempt += 1) {
+		try {
+			mkdirSync(lockPath, { mode: 0o700 })
+			const owner: LockOwner = {
+				schemaVersion: 1,
+				pid: process.pid,
+				host: hostname(),
+				token: randomUUID(),
+				acquiredAt: new Date().toISOString(),
+			}
+			writeFileSync(ownerPath, `${JSON.stringify(owner, null, 2)}\n`, {
+				mode: 0o600,
+			})
+			return { path: lockPath, token: owner.token }
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error
+			let owner: Partial<LockOwner> = {}
+			try {
+				owner = JSON.parse(readFileSync(ownerPath, "utf8"))
+			} catch {
+				// An owner file can be absent only while another process is
+				// acquiring the lock. Do not delete a fresh ambiguous lock.
+				throw new Error(`benchmark jobs root is locked or lock ownership is ambiguous: ${lockPath}`)
+			}
+			if (owner.host !== hostname() || isProcessAlive(Number(owner.pid))) {
+				throw new Error(`benchmark jobs root is already active (pid=${owner.pid ?? "unknown"}): ${lockPath}`)
+			}
+			const stalePath = `${lockPath}.stale-${Date.now()}-${randomUUID()}`
+			try {
+				renameSync(lockPath, stalePath)
+				rmSync(stalePath, { recursive: true, force: true })
+			} catch (renameError) {
+				if ((renameError as NodeJS.ErrnoException).code !== "ENOENT") throw renameError
+			}
+		}
+	}
+	throw new Error(`could not acquire benchmark jobs-root lock: ${lockPath}`)
+}
+
+export function releaseRunLock(lock: RunLock): void {
+	if (!existsSync(lock.path)) return
+	const ownerPath = join(lock.path, "owner.json")
+	let owner: Partial<LockOwner>
+	try {
+		owner = JSON.parse(readFileSync(ownerPath, "utf8"))
+	} catch {
+		throw new Error(`refusing to release benchmark lock with unreadable owner: ${lock.path}`)
+	}
+	if (owner.token !== lock.token || owner.pid !== process.pid) {
+		throw new Error(`refusing to release benchmark lock owned by another process: ${lock.path}`)
+	}
+	rmSync(lock.path, { recursive: true })
+}
+
+export type BudgetEntry = {
+	runKey: string
+	model: string
+	wave: number
+	reservedUsd: number
+	actualUsd?: number
+	status: "reserved" | "settled"
+	updatedAt: string
+}
+
+export type BudgetLedger = {
+	schemaVersion: 1
+	checkpointUsd: number
+	entries: BudgetEntry[]
+}
+
+export function createBudgetLedger(checkpointUsd: number): BudgetLedger {
+	if (!Number.isFinite(checkpointUsd) || checkpointUsd <= 0 || checkpointUsd > MAX_CHECKPOINT_USD) {
+		throw new Error(`checkpoint budget must be greater than 0 and at most $${MAX_CHECKPOINT_USD}`)
+	}
+	return { schemaVersion: 1, checkpointUsd, entries: [] }
+}
+
+export function ledgerExposure(ledger: BudgetLedger, wave?: number): number {
+	return ledger.entries
+		.filter((entry) => wave === undefined || entry.wave === wave)
+		.reduce((total, entry) => total + (entry.status === "settled" ? entry.actualUsd || 0 : entry.reservedUsd), 0)
+}
+
+export function reserveBudget(
+	ledger: BudgetLedger,
+	input: {
+		runKey: string
+		model: string
+		wave: number
+		exposureUsd: number
+		waveBudgetUsd?: number
+	},
+): BudgetLedger {
+	if (ledger.entries.some((entry) => entry.runKey === input.runKey)) {
+		throw new Error(`budget entry already exists for ${input.runKey}`)
+	}
+	if (!Number.isFinite(input.exposureUsd) || input.exposureUsd <= 0) {
+		throw new Error("declared run exposure must be positive")
+	}
+	if (ledgerExposure(ledger) + input.exposureUsd > ledger.checkpointUsd) {
+		throw new Error(`campaign lacks room under its $${ledger.checkpointUsd.toFixed(2)} checkpoint`)
+	}
+	if (
+		input.waveBudgetUsd !== undefined &&
+		ledgerExposure(ledger, input.wave) + input.exposureUsd > input.waveBudgetUsd
+	) {
+		throw new Error(`wave ${input.wave} lacks room under its $${input.waveBudgetUsd.toFixed(2)} checkpoint`)
+	}
+	return {
+		...ledger,
+		entries: [
+			...ledger.entries,
+			{
+				runKey: input.runKey,
+				model: input.model,
+				wave: input.wave,
+				reservedUsd: input.exposureUsd,
+				status: "reserved",
+				updatedAt: new Date().toISOString(),
+			},
+		],
+	}
+}
+
+export function settleBudget(ledger: BudgetLedger, runKey: string, actualUsd: number): BudgetLedger {
+	if (!Number.isFinite(actualUsd) || actualUsd <= 0) throw new Error("actual run cost must be positive")
+	const existing = ledger.entries.find((entry) => entry.runKey === runKey)
+	if (existing?.status === "settled") {
+		if (Math.abs((existing.actualUsd || 0) - actualUsd) > 1e-9) {
+			throw new Error(`settled cost changed for ${runKey}`)
+		}
+		return ledger
+	}
+	if (!existing) throw new Error(`no budget reservation exists for ${runKey}`)
+	return {
+		...ledger,
+		entries: ledger.entries.map((entry) =>
+			entry.runKey === runKey
+				? {
+						...entry,
+						actualUsd,
+						status: "settled",
+						updatedAt: new Date().toISOString(),
+					}
+				: entry,
+		),
+	}
+}
+
+export type UsageSnapshot = {
+	timestamp: string
+	totalCost: number
+	totalInputTokens: number | null
+	totalCacheReadTokens: number | null
+	totalOutputTokens: number | null
+}
+
+export function recoverLatestUsage(logDocuments: readonly string[]): UsageSnapshot {
+	if (logDocuments.length !== 1) {
+		throw new Error(`interrupted usage recovery requires exactly one attempt; found ${logDocuments.length}`)
+	}
+	const snapshots: UsageSnapshot[] = []
+	for (const line of logDocuments[0].split("\n")) {
+		if (!line.startsWith("{") || !line.includes('"type":"usage"')) continue
+		try {
+			const parsed = JSON.parse(line)
+			if (parsed.event?.type !== "usage") continue
+			const timestampMs = Date.parse(parsed.ts)
+			const totalCost = parsed.event.totalCost
+			if (!Number.isFinite(timestampMs) || !Number.isFinite(totalCost) || totalCost <= 0) continue
+			snapshots.push({
+				timestamp: new Date(timestampMs).toISOString(),
+				totalCost,
+				totalInputTokens: parsed.event.totalInputTokens ?? null,
+				totalCacheReadTokens: parsed.event.totalCacheReadTokens ?? null,
+				totalOutputTokens: parsed.event.totalOutputTokens ?? null,
+			})
+		} catch {
+			// A force-stopped process can leave one partial final JSON line.
+		}
+	}
+	if (snapshots.length === 0) throw new Error("interrupted run has no usable cost telemetry")
+	snapshots.sort((left, right) => Date.parse(left.timestamp) - Date.parse(right.timestamp))
+	const latest = snapshots.at(-1)
+	if (!latest) throw new Error("interrupted run has no latest usage snapshot")
+	const sameTimestamp = snapshots.filter((entry) => entry.timestamp === latest.timestamp)
+	if (sameTimestamp.some((entry) => entry.totalCost !== latest.totalCost)) {
+		throw new Error("interrupted usage recovery is ambiguous at the latest timestamp")
+	}
+	return latest
+}
+
+export type RouteTrace = {
+	source: "core" | "legacy"
+	taskIdSha256?: string
+	taskHash?: string
+	sessionHash?: string
+	requestedModel: string
+	selectedModel: string
+	traceIdHash?: string
+	timestamp: string
+	schemaVersion?: number
+	product?: string
+	action?: string
+	tier?: string
+	mode?: string
+	reason?: string
+	score?: number
+	taskScore?: number
+	gate?: {
+		evaluated: boolean
+		candidateModel: string
+		incumbentModel: string
+		keepIncumbent: boolean
+		lightCallUsd: number
+		switchBackPenaltyUsd: number
+		lightUsd: number
+		incumbentUsd: number
+		savingsUsd: number
+		savingsRatio: number
+	}
+	features?: {
+		schemaVersion: number
+		messageCount: number
+		userInstructionCount: number
+		assistantMessageCount: number
+		toolResultCount: number
+		toolFailureCount: number
+		totalChars: number
+		userInstructionChars: number
+		hasTools: boolean
+		historyTokens: number
+		incumbentStateUnavailable: boolean
+		incumbentCacheStatusKnown: boolean
+		incumbentColdLikely: boolean
+	}
+}
+
+const LEGACY_ROUTE_TRACE_KEYS = new Set([
+	"taskHash",
+	"sessionHash",
+	"requestedModel",
+	"selectedModel",
+	"traceIdHash",
+	"timestamp",
+])
+const CORE_ROUTE_TRACE_KEYS = new Set([
+	"schema_version",
+	"timestamp",
+	"task_id_sha256",
+	"product",
+	"action",
+	"requested_model",
+	"selected_concrete_model",
+	"tier",
+	"mode",
+	"reason",
+	"score",
+	"task_score",
+	"gate",
+	"features",
+])
+const CORE_GATE_KEYS = new Set([
+	"evaluated",
+	"candidate_model",
+	"incumbent_model",
+	"keep_incumbent",
+	"light_call_usd",
+	"switch_back_penalty_usd",
+	"light_usd",
+	"incumbent_usd",
+	"savings_usd",
+	"savings_ratio",
+])
+const CORE_FEATURE_KEYS = new Set([
+	"schema_version",
+	"message_count",
+	"user_instruction_count",
+	"assistant_message_count",
+	"tool_result_count",
+	"tool_failure_count",
+	"total_chars",
+	"user_instruction_chars",
+	"has_tools",
+	"history_tokens",
+	"incumbent_state_unavailable",
+	"incumbent_cache_status_known",
+	"incumbent_cold_likely",
+])
+
+function assertExactObjectKeys(
+	raw: unknown,
+	expected: ReadonlySet<string>,
+	label: string,
+): asserts raw is Record<string, unknown> {
+	if (!raw || typeof raw !== "object" || Array.isArray(raw)) throw new Error(`${label} must be an object`)
+	for (const key of Object.keys(raw)) {
+		if (!expected.has(key)) throw new Error(`unknown ${label} field: ${key}`)
+	}
+	for (const key of expected) {
+		if (!(key in raw)) throw new Error(`${label} is missing field: ${key}`)
+	}
+}
+
+function finiteNumber(value: unknown): value is number {
+	return typeof value === "number" && Number.isFinite(value)
+}
+
+export function parseRouteTraces(text: string): RouteTrace[] {
+	const trimmed = text.trim()
+	if (!trimmed) return []
+	const rawEntries = trimmed.startsWith("[")
+		? JSON.parse(trimmed)
+		: trimmed
+				.split("\n")
+				.filter(Boolean)
+				.map((line) => JSON.parse(line))
+	if (!Array.isArray(rawEntries)) throw new Error("route trace file must contain a JSON array or JSONL")
+	return rawEntries.map((raw, index) => {
+		if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+			throw new Error(`route trace ${index} must be an object`)
+		}
+		if ("task_id_sha256" in raw || "schema_version" in raw) {
+			assertExactObjectKeys(raw, CORE_ROUTE_TRACE_KEYS, `Core route trace ${index}`)
+			assertExactObjectKeys(raw.gate, CORE_GATE_KEYS, `Core route trace ${index} gate`)
+			assertExactObjectKeys(raw.features, CORE_FEATURE_KEYS, `Core route trace ${index} features`)
+			const gate = raw.gate
+			const features = raw.features
+			if (
+				raw.schema_version !== 1 ||
+				typeof raw.timestamp !== "string" ||
+				!Number.isFinite(Date.parse(raw.timestamp)) ||
+				typeof raw.task_id_sha256 !== "string" ||
+				!HASH_PATTERN.test(raw.task_id_sha256) ||
+				typeof raw.product !== "string" ||
+				typeof raw.action !== "string" ||
+				typeof raw.requested_model !== "string" ||
+				typeof raw.selected_concrete_model !== "string" ||
+				typeof raw.tier !== "string" ||
+				typeof raw.mode !== "string" ||
+				typeof raw.reason !== "string" ||
+				!finiteNumber(raw.score) ||
+				!finiteNumber(raw.task_score)
+			) {
+				throw new Error(`Core route trace ${index} has invalid scalar fields`)
+			}
+			if (
+				typeof gate.evaluated !== "boolean" ||
+				typeof gate.candidate_model !== "string" ||
+				typeof gate.incumbent_model !== "string" ||
+				typeof gate.keep_incumbent !== "boolean" ||
+				!finiteNumber(gate.light_call_usd) ||
+				!finiteNumber(gate.switch_back_penalty_usd) ||
+				!finiteNumber(gate.light_usd) ||
+				!finiteNumber(gate.incumbent_usd) ||
+				!finiteNumber(gate.savings_usd) ||
+				!finiteNumber(gate.savings_ratio)
+			) {
+				throw new Error(`Core route trace ${index} has invalid gate fields`)
+			}
+			if (
+				features.schema_version !== 1 ||
+				!finiteNumber(features.message_count) ||
+				!finiteNumber(features.user_instruction_count) ||
+				!finiteNumber(features.assistant_message_count) ||
+				!finiteNumber(features.tool_result_count) ||
+				!finiteNumber(features.tool_failure_count) ||
+				!finiteNumber(features.total_chars) ||
+				!finiteNumber(features.user_instruction_chars) ||
+				typeof features.has_tools !== "boolean" ||
+				!finiteNumber(features.history_tokens) ||
+				typeof features.incumbent_state_unavailable !== "boolean" ||
+				typeof features.incumbent_cache_status_known !== "boolean" ||
+				typeof features.incumbent_cold_likely !== "boolean"
+			) {
+				throw new Error(`Core route trace ${index} has invalid feature fields`)
+			}
+			return {
+				source: "core",
+				taskIdSha256: raw.task_id_sha256,
+				requestedModel: raw.requested_model,
+				selectedModel: raw.selected_concrete_model,
+				timestamp: new Date(raw.timestamp).toISOString(),
+				schemaVersion: raw.schema_version,
+				product: raw.product,
+				action: raw.action,
+				tier: raw.tier,
+				mode: raw.mode,
+				reason: raw.reason,
+				score: raw.score,
+				taskScore: raw.task_score,
+				gate: {
+					evaluated: gate.evaluated,
+					candidateModel: gate.candidate_model,
+					incumbentModel: gate.incumbent_model,
+					keepIncumbent: gate.keep_incumbent,
+					lightCallUsd: gate.light_call_usd,
+					switchBackPenaltyUsd: gate.switch_back_penalty_usd,
+					lightUsd: gate.light_usd,
+					incumbentUsd: gate.incumbent_usd,
+					savingsUsd: gate.savings_usd,
+					savingsRatio: gate.savings_ratio,
+				},
+				features: {
+					schemaVersion: features.schema_version,
+					messageCount: features.message_count,
+					userInstructionCount: features.user_instruction_count,
+					assistantMessageCount: features.assistant_message_count,
+					toolResultCount: features.tool_result_count,
+					toolFailureCount: features.tool_failure_count,
+					totalChars: features.total_chars,
+					userInstructionChars: features.user_instruction_chars,
+					hasTools: features.has_tools,
+					historyTokens: features.history_tokens,
+					incumbentStateUnavailable: features.incumbent_state_unavailable,
+					incumbentCacheStatusKnown: features.incumbent_cache_status_known,
+					incumbentColdLikely: features.incumbent_cold_likely,
+				},
+			}
+		}
+
+		for (const key of Object.keys(raw)) {
+			if (!LEGACY_ROUTE_TRACE_KEYS.has(key)) throw new Error(`unknown route trace field: ${key}`)
+		}
+		if (typeof raw.taskHash !== "string" || !HASH_PATTERN.test(raw.taskHash)) {
+			throw new Error(`route trace ${index} has invalid taskHash`)
+		}
+		if (raw.sessionHash !== undefined && (typeof raw.sessionHash !== "string" || !HASH_PATTERN.test(raw.sessionHash))) {
+			throw new Error(`route trace ${index} has invalid sessionHash`)
+		}
+		if (raw.traceIdHash !== undefined && (typeof raw.traceIdHash !== "string" || !HASH_PATTERN.test(raw.traceIdHash))) {
+			throw new Error(`route trace ${index} has invalid traceIdHash`)
+		}
+		if (
+			typeof raw.requestedModel !== "string" ||
+			typeof raw.selectedModel !== "string" ||
+			typeof raw.timestamp !== "string" ||
+			!Number.isFinite(Date.parse(raw.timestamp))
+		) {
+			throw new Error(`route trace ${index} has invalid model or timestamp fields`)
+		}
+		return {
+			source: "legacy",
+			taskHash: raw.taskHash,
+			sessionHash: typeof raw.sessionHash === "string" ? raw.sessionHash : undefined,
+			requestedModel: raw.requestedModel,
+			selectedModel: raw.selectedModel,
+			traceIdHash: typeof raw.traceIdHash === "string" ? raw.traceIdHash : undefined,
+			timestamp: new Date(raw.timestamp).toISOString(),
+		}
+	})
+}

--- a/evals/e2e/cline-bench-safety.ts
+++ b/evals/e2e/cline-bench-safety.ts
@@ -198,7 +198,7 @@ export function reserveBudget(
 }
 
 export function settleBudget(ledger: BudgetLedger, runKey: string, actualUsd: number): BudgetLedger {
-	if (!Number.isFinite(actualUsd) || actualUsd <= 0) throw new Error("actual run cost must be positive")
+	if (!Number.isFinite(actualUsd) || actualUsd < 0) throw new Error("actual run cost cannot be negative")
 	const existing = ledger.entries.find((entry) => entry.runKey === runKey)
 	if (existing?.status === "settled") {
 		if (Math.abs((existing.actualUsd || 0) - actualUsd) > 1e-9) {
@@ -255,6 +255,7 @@ function usageSnapshot(value: unknown): UsageSnapshot | null {
 	const event = recordValue(parsed.event)
 	let usage: Record<string, unknown>
 	let allowMissingTokens = false
+	let allowZeroNoSpendFailure = false
 	if (event?.type === "usage") {
 		allowMissingTokens = true
 		usage = {
@@ -264,6 +265,7 @@ function usageSnapshot(value: unknown): UsageSnapshot | null {
 			totalOutputTokens: event.totalOutputTokens,
 		}
 	} else if (parsed.type === "run_result") {
+		allowZeroNoSpendFailure = parsed.finishReason === "error"
 		const cumulative = recordValue(parsed.aggregateUsage ?? parsed.usage)
 		if (!cumulative) {
 			throw new Error("interrupted run_result has no cumulative usage")
@@ -281,16 +283,30 @@ function usageSnapshot(value: unknown): UsageSnapshot | null {
 	const timestampMs = typeof parsed.ts === "string" ? Date.parse(parsed.ts) : Number.NaN
 	if (!Number.isFinite(timestampMs)) throw new Error("interrupted cost telemetry has invalid timestamp")
 	const totalCost = usage.totalCost
-	if (typeof totalCost !== "number" || !Number.isFinite(totalCost) || totalCost <= 0) {
+	if (
+		typeof totalCost !== "number" ||
+		!Number.isFinite(totalCost) ||
+		totalCost < 0 ||
+		(totalCost === 0 && !allowZeroNoSpendFailure)
+	) {
 		throw new Error("interrupted cost telemetry has invalid totalCost")
 	}
-	return {
+	const snapshot = {
 		timestamp: new Date(timestampMs).toISOString(),
 		totalCost,
 		totalInputTokens: requireUsageNumber(usage.totalInputTokens, "totalInputTokens", allowMissingTokens),
 		totalCacheReadTokens: requireUsageNumber(usage.totalCacheReadTokens, "totalCacheReadTokens", allowMissingTokens),
 		totalOutputTokens: requireUsageNumber(usage.totalOutputTokens, "totalOutputTokens", allowMissingTokens),
 	}
+	if (
+		totalCost === 0 &&
+		(snapshot.totalInputTokens !== 0 ||
+			snapshot.totalCacheReadTokens !== 0 ||
+			snapshot.totalOutputTokens !== 0)
+	) {
+		throw new Error("zero-cost failed run reported nonzero tokens")
+	}
+	return snapshot
 }
 
 function sameUsage(left: UsageSnapshot, right: UsageSnapshot): boolean {

--- a/evals/e2e/cline-bench-safety.ts
+++ b/evals/e2e/cline-bench-safety.ts
@@ -551,7 +551,7 @@ export function parseRouteTraces(text: string): RouteTrace[] {
 				throw new Error(`Core route trace ${index} has invalid gate fields`)
 			}
 			if (
-				features.schema_version !== 1 ||
+				features.schema_version !== 2 ||
 				!finiteNumber(features.message_count) ||
 				!finiteNumber(features.user_instruction_count) ||
 				!finiteNumber(features.assistant_message_count) ||

--- a/evals/e2e/run-cline-bench-pilot.test.ts
+++ b/evals/e2e/run-cline-bench-pilot.test.ts
@@ -18,6 +18,7 @@ import {
 } from "./cline-bench-safety"
 import {
 	assertReusableFingerprint,
+	assertTraceIngestionCompatibility,
 	buildRunMatrix,
 	type ExecutionProvenance,
 	fingerprintExecution,
@@ -25,6 +26,7 @@ import {
 	localCoreHarborArguments,
 	matchRouteTraces,
 	type PilotConfig,
+	type PilotReport,
 	prepareTaskPath,
 	readConfig,
 	readRecoveredFailedRun,
@@ -152,6 +154,28 @@ describe("Cline benchmark execution fingerprints", () => {
 			"different execution matrix",
 		)
 		expect(() => assertReusableFingerprint({ executionFingerprint: "current" }, "current")).not.toThrow()
+	})
+
+	test("allows parser-only upgrades for offline trace ingestion", () => {
+		const cfg = config()
+		const stored = provenance("a".repeat(64))
+		const existing = {
+			config: cfg,
+			executionProvenance: stored,
+			executionFingerprint: fingerprintExecution(cfg, stored),
+		} as PilotReport
+		const upgradedParser = {
+			...stored,
+			runnerContentSha256: "b".repeat(64),
+			runnerGitCommit: "c".repeat(40),
+		}
+		expect(() => assertTraceIngestionCompatibility(existing, cfg, upgradedParser)).not.toThrow()
+		expect(() =>
+			assertTraceIngestionCompatibility(existing, cfg, {
+				...upgradedParser,
+				clineBenchCommit: "d".repeat(40),
+			}),
+		).toThrow("matrix, endpoint, or task corpus")
 	})
 })
 
@@ -635,7 +659,7 @@ describe("Cline benchmark recovery, privacy, and routing evidence", () => {
 				savings_ratio: 0.67,
 			},
 			features: {
-				schema_version: 1,
+				schema_version: 2,
 				message_count: 4,
 				user_instruction_count: 1,
 				assistant_message_count: 2,

--- a/evals/e2e/run-cline-bench-pilot.test.ts
+++ b/evals/e2e/run-cline-bench-pilot.test.ts
@@ -250,7 +250,7 @@ describe("Cline benchmark configuration and matrix", () => {
 		expect(new Set(checkpoint.tasks).size).toBe(8)
 		expect(matrix.filter((run) => run.model.id === "cline/auto")).toHaveLength(8)
 		expect(matrix.filter((run) => run.model.id === "openai/gpt-5.4")).toHaveLength(8)
-		expect(matrix.filter((run) => run.model.id === "moonshotai/kimi-k2.7-code")).toHaveLength(4)
+		expect(matrix.filter((run) => run.model.id === "moonshotai/kimi-k3")).toHaveLength(4)
 		expect(matrix.filter((run) => run.model.id === "z-ai/glm-5.2")).toHaveLength(4)
 		for (const wave of [1, 2]) {
 			const exposure = matrix

--- a/evals/e2e/run-cline-bench-pilot.test.ts
+++ b/evals/e2e/run-cline-bench-pilot.test.ts
@@ -462,6 +462,7 @@ describe("Cline benchmark recovery, privacy, and routing evidence", () => {
 
 	test("strictly normalizes only the local Core endpoint", () => {
 		expect(normalizeLocalCoreUrl("http://localhost:7777")).toBe("http://host.docker.internal:7777")
+		expect(normalizeLocalCoreUrl("http://127.0.0.1:17777")).toBe("http://host.docker.internal:17777")
 		expect(localCoreHarborArguments("http://localhost:7777")).toEqual([
 			"--ae",
 			"CLINE_API_BASE_URL=http://host.docker.internal:7777",
@@ -472,6 +473,7 @@ describe("Cline benchmark recovery, privacy, and routing evidence", () => {
 		])
 		expect(() => normalizeLocalCoreUrl("https://localhost:7777")).toThrow("only accepts")
 		expect(() => normalizeLocalCoreUrl("http://localhost:7778")).toThrow("only accepts")
+		expect(() => normalizeLocalCoreUrl("http://localhost:17778")).toThrow("only accepts")
 		expect(() => normalizeLocalCoreUrl("http://example.com:7777")).toThrow("only accepts")
 	})
 

--- a/evals/e2e/run-cline-bench-pilot.test.ts
+++ b/evals/e2e/run-cline-bench-pilot.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs"
 import { hostname, tmpdir } from "node:os"
 import { join } from "node:path"
 import {
@@ -23,6 +23,7 @@ import {
 	type ExecutionProvenance,
 	fingerprintExecution,
 	hashDirectoryTree,
+	liveCostStopUsd,
 	localCoreHarborArguments,
 	matchRouteTraces,
 	modelTransportHarborArguments,
@@ -30,6 +31,8 @@ import {
 	type PilotReport,
 	prepareTaskPath,
 	readConfig,
+	readLiveCostStoppedRun,
+	readLiveUsage,
 	readRecoveredFailedRun,
 	readTrialSessionIdentity,
 	reuseCompletedRun,
@@ -572,6 +575,94 @@ describe("Cline benchmark recovery, privacy, and routing evidence", () => {
 		expect(ledgerExposure(ledger)).toBe(0.25)
 	})
 
+	test("recovers a private live-cost marker without a Harbor result and never respends it", () => {
+		const jobsRoot = mkdtempSync(join(tmpdir(), "cline-bench-live-cost-"))
+		temporaryDirectories.push(jobsRoot)
+		const task = "task-a"
+		const model = {
+			id: "moonshotai/kimi-k3",
+			perTaskBudgetUsd: 2.2,
+			perModelBudgetUsd: 2.2,
+			pricing: {
+				inputPerMTok: 3,
+				cachedInputPerMTok: 0.3,
+				outputPerMTok: 15,
+			},
+		}
+		const guardedConfig: PilotConfig = {
+			...config(),
+			models: [model],
+			tasks: [task],
+		}
+		const jobDir = join(jobsRoot, "01-moonshotai-kimi-k3-task-a")
+		mkdirSync(jobDir, { recursive: true })
+		const markerPath = join(jobDir, "live-cost-stop.json")
+		writeFileSync(
+			markerPath,
+			`${JSON.stringify({
+				schemaVersion: 1,
+				model: model.id,
+				taskHash: hashPrivateIdentifier("cline-bench-task", task),
+				startedAt: "2026-01-01T00:00:00Z",
+				stoppedAt: "2026-01-01T00:01:00Z",
+				stopUsd: liveCostStopUsd(model.perTaskBudgetUsd),
+				reservationUsd: model.perTaskBudgetUsd,
+				usage: {
+					timestamp: "2026-01-01T00:00:59Z",
+					totalCost: 1.7,
+					totalInputTokens: 100,
+					totalCacheReadTokens: 80,
+					totalOutputTokens: 10,
+				},
+			})}\n`,
+			{ mode: 0o600 },
+		)
+
+		const stopped = readLiveCostStoppedRun(jobDir, guardedConfig, model, task)
+		expect(stopped.outcome).toBe("failed")
+		expect(stopped.failureClassification).toBe("LiveCostGuardExceeded")
+		expect(stopped.costUsd).toBe(1.7)
+		expect(stopped.cacheTokens).toBe(80)
+		expect(statSync(markerPath).mode & 0o777).toBe(0o600)
+
+		const resumed = reuseCompletedRun(guardedConfig, model, task, jobsRoot, 1)
+		expect(resumed).toEqual(stopped)
+	})
+
+	test("reads only complete live usage records and fails closed on ambiguous attempts", () => {
+		const jobsRoot = mkdtempSync(join(tmpdir(), "cline-bench-live-usage-"))
+		temporaryDirectories.push(jobsRoot)
+		const firstAgentDir = join(jobsRoot, "task__attempt-1", "agent")
+		mkdirSync(firstAgentDir, { recursive: true })
+		const firstLog = join(firstAgentDir, "cline.txt")
+		const usage = (timestamp: string, totalCost: number) =>
+			JSON.stringify({
+				ts: timestamp,
+				type: "agent_event",
+				event: {
+					type: "usage",
+					totalCost,
+					totalInputTokens: Math.round(totalCost * 100),
+					totalCacheReadTokens: Math.round(totalCost * 50),
+					totalOutputTokens: Math.round(totalCost * 10),
+				},
+			})
+
+		writeFileSync(firstLog, `${usage("2026-01-01T00:00:01Z", 0.5)}\n{"ts":`)
+		expect(readLiveUsage(jobsRoot)?.totalCost).toBe(0.5)
+
+		writeFileSync(
+			firstLog,
+			`${usage("2026-01-01T00:00:01Z", 0.5)}\n${usage("2026-01-01T00:00:02Z", 0.75)}\n`,
+		)
+		expect(readLiveUsage(jobsRoot)?.totalCost).toBe(0.75)
+
+		const secondAgentDir = join(jobsRoot, "task__attempt-2", "agent")
+		mkdirSync(secondAgentDir, { recursive: true })
+		writeFileSync(join(secondAgentDir, "cline.txt"), `${usage("2026-01-01T00:00:03Z", 0.8)}\n`)
+		expect(() => readLiveUsage(jobsRoot)).toThrow("exactly one attempt")
+	})
+
 	test("redacts all exact secrets and hashes private identifiers", () => {
 		expect(redactSecrets("alpha secret beta token", ["secret", "token"])).toBe("alpha [REDACTED] beta [REDACTED]")
 		expect(hashPrivateIdentifier("task", "raw-id")).toMatch(/^[0-9a-f]{64}$/)
@@ -579,6 +670,9 @@ describe("Cline benchmark recovery, privacy, and routing evidence", () => {
 	})
 
 	test("strictly normalizes only the local Core endpoint", () => {
+		expect(liveCostStopUsd(2.2)).toBeCloseTo(1.65)
+		expect(liveCostStopUsd(1.8)).toBeCloseTo(1.25)
+		expect(() => liveCostStopUsd(0)).toThrow("positive")
 		expect(normalizeLocalCoreUrl("http://localhost:7777")).toBe("http://host.docker.internal:7777")
 		expect(normalizeLocalCoreUrl("http://127.0.0.1:17777")).toBe("http://host.docker.internal:17777")
 		expect(localCoreHarborArguments("http://localhost:7777")).toEqual([

--- a/evals/e2e/run-cline-bench-pilot.test.ts
+++ b/evals/e2e/run-cline-bench-pilot.test.ts
@@ -25,6 +25,7 @@ import {
 	hashDirectoryTree,
 	localCoreHarborArguments,
 	matchRouteTraces,
+	modelTransportHarborArguments,
 	type PilotConfig,
 	type PilotReport,
 	prepareTaskPath,
@@ -588,6 +589,15 @@ describe("Cline benchmark recovery, privacy, and routing evidence", () => {
 			"--allow-environment-host",
 			"host.docker.internal",
 		])
+		expect(modelTransportHarborArguments("cline/auto", "http://localhost:7777")).toEqual(
+			localCoreHarborArguments("http://localhost:7777"),
+		)
+		expect(modelTransportHarborArguments("cline-pass/auto", "http://localhost:17777")).toEqual(
+			localCoreHarborArguments("http://localhost:17777"),
+		)
+		expect(modelTransportHarborArguments("moonshotai/kimi-k3", "http://localhost:7777")).toEqual([])
+		expect(modelTransportHarborArguments("z-ai/glm-5.2", "http://localhost:7777")).toEqual([])
+		expect(modelTransportHarborArguments("openai/gpt-5.4", "http://localhost:7777")).toEqual([])
 		expect(() => normalizeLocalCoreUrl("https://localhost:7777")).toThrow("only accepts")
 		expect(() => normalizeLocalCoreUrl("http://localhost:7778")).toThrow("only accepts")
 		expect(() => normalizeLocalCoreUrl("http://localhost:17778")).toThrow("only accepts")

--- a/evals/e2e/run-cline-bench-pilot.test.ts
+++ b/evals/e2e/run-cline-bench-pilot.test.ts
@@ -393,6 +393,27 @@ describe("Cline benchmark recovery, privacy, and routing evidence", () => {
 				}),
 			]),
 		).toThrow("malformed usage record")
+		expect(
+			recoverLatestUsage([
+				[
+					JSON.stringify({
+						exception_message:
+							'stdout: {"ts":"2026-01-01T00:00:03Z","type":"run_result" ... [truncated]',
+					}),
+					JSON.stringify({
+						ts: "2026-01-01T00:00:06Z",
+						type: "run_result",
+						finishReason: "error",
+						aggregateUsage: {
+							inputTokens: 0,
+							cacheReadTokens: 0,
+							outputTokens: 0,
+							totalCost: 0,
+						},
+					}),
+				].join("\n"),
+			]),
+		).toMatchObject({ totalCost: 0 })
 	})
 
 	test("records an ApiRateLimitError as failed, settles its reservation, and reuses it without respending", () => {

--- a/evals/e2e/run-cline-bench-pilot.test.ts
+++ b/evals/e2e/run-cline-bench-pilot.test.ts
@@ -18,6 +18,7 @@ import {
 } from "./cline-bench-safety"
 import {
 	assertDirectModelsInLiveCatalog,
+	assertLocalClineVersion,
 	assertReusableFingerprint,
 	assertTraceIngestionCompatibility,
 	buildRunMatrix,
@@ -251,6 +252,7 @@ describe("Cline benchmark configuration and matrix", () => {
 	test("keeps the checked-in 8-task checkpoint within its staged reservations", () => {
 		const checkpoint = readConfig(join(import.meta.dir, "cline-bench-router-checkpoint.config.json"))
 		const matrix = buildRunMatrix(checkpoint)
+		expect(checkpoint.clineVersion).toBe("3.0.46-nightly.1784896623")
 		expect(matrix).toHaveLength(24)
 		expect(new Set(checkpoint.tasks).size).toBe(8)
 		expect(matrix.filter((run) => run.model.id === "cline/auto")).toHaveLength(8)
@@ -286,6 +288,28 @@ describe("Cline benchmark configuration and matrix", () => {
 			"absent from the live Cline cline-router catalog: z-ai/glm-5.2",
 		)
 		expect(checkpoint.models.find((model) => model.id === "cline/auto")?.allowedCandidates).toContain("z-ai/glm-5.2")
+	})
+
+	test("fails closed when the local CLI build differs from the configured Harbor build", () => {
+		const checkpoint = readConfig(join(import.meta.dir, "cline-bench-router-checkpoint.config.json"))
+		expect(() =>
+			assertLocalClineVersion(checkpoint, () => ({
+				status: 0,
+				stdout: "3.0.46\n",
+			})),
+		).toThrow(
+			"local Cline version mismatch before jobs-root creation and budget reservation: expected 3.0.46-nightly.1784896623, installed 3.0.46",
+		)
+	})
+
+	test("accepts only the exact configured local CLI build", () => {
+		const checkpoint = readConfig(join(import.meta.dir, "cline-bench-router-checkpoint.config.json"))
+		expect(() =>
+			assertLocalClineVersion(checkpoint, () => ({
+				status: 0,
+				stdout: "3.0.46-nightly.1784896623\n",
+			})),
+		).not.toThrow()
 	})
 })
 

--- a/evals/e2e/run-cline-bench-pilot.test.ts
+++ b/evals/e2e/run-cline-bench-pilot.test.ts
@@ -635,7 +635,7 @@ describe("Cline benchmark recovery, privacy, and routing evidence", () => {
 		const firstAgentDir = join(jobsRoot, "task__attempt-1", "agent")
 		mkdirSync(firstAgentDir, { recursive: true })
 		const firstLog = join(firstAgentDir, "cline.txt")
-		const usage = (timestamp: string, totalCost: number) =>
+		const usage = (timestamp: string, totalCost: number, includeCache = true) =>
 			JSON.stringify({
 				ts: timestamp,
 				type: "agent_event",
@@ -643,7 +643,7 @@ describe("Cline benchmark recovery, privacy, and routing evidence", () => {
 					type: "usage",
 					totalCost,
 					totalInputTokens: Math.round(totalCost * 100),
-					totalCacheReadTokens: Math.round(totalCost * 50),
+					...(includeCache ? { totalCacheReadTokens: Math.round(totalCost * 50) } : {}),
 					totalOutputTokens: Math.round(totalCost * 10),
 				},
 			})
@@ -653,9 +653,24 @@ describe("Cline benchmark recovery, privacy, and routing evidence", () => {
 
 		writeFileSync(
 			firstLog,
-			`${usage("2026-01-01T00:00:01Z", 0.5)}\n${usage("2026-01-01T00:00:02Z", 0.75)}\n`,
+			`${usage("2026-01-01T00:00:01Z", 0.5)}\n${usage("2026-01-01T00:00:02Z", 0.75, false)}\n`,
 		)
 		expect(readLiveUsage(jobsRoot)?.totalCost).toBe(0.75)
+		expect(readLiveUsage(jobsRoot)?.totalCacheReadTokens).toBeNull()
+
+		writeFileSync(
+			firstLog,
+			`${usage("2026-01-01T00:00:02Z", 0.75)}\n${usage("2026-01-01T00:00:03Z", 0.5)}\n`,
+		)
+		expect(() => readLiveUsage(jobsRoot)).toThrow("non-monotonic")
+
+		writeFileSync(
+			firstLog,
+			`${usage("2026-01-01T00:00:02Z", 0.75)}\n{"ts":"2026-01-01T00:00:03Z","type":"agent_event","event":{"type":"usage"\n`,
+		)
+		expect(() => readLiveUsage(jobsRoot)).toThrow()
+
+		writeFileSync(firstLog, `${usage("2026-01-01T00:00:02Z", 0.75)}\n`)
 
 		const secondAgentDir = join(jobsRoot, "task__attempt-2", "agent")
 		mkdirSync(secondAgentDir, { recursive: true })

--- a/evals/e2e/run-cline-bench-pilot.test.ts
+++ b/evals/e2e/run-cline-bench-pilot.test.ts
@@ -290,6 +290,16 @@ describe("Cline benchmark lock and budget ledger", () => {
 				exposureUsd: 39,
 			}),
 		).toThrow("campaign lacks room")
+
+		let noSpend = createBudgetLedger(5)
+		noSpend = reserveBudget(noSpend, {
+			runKey: "no-spend",
+			model: "cline/auto",
+			wave: 1,
+			exposureUsd: 1,
+		})
+		noSpend = settleBudget(noSpend, "no-spend", 0)
+		expect(ledgerExposure(noSpend)).toBe(0)
 	})
 })
 
@@ -345,6 +355,41 @@ describe("Cline benchmark recovery, privacy, and routing evidence", () => {
 					ts: "2026-01-01T00:00:02Z",
 					type: "run_result",
 					aggregateUsage: { inputTokens: 10, cacheReadTokens: 5, totalCost: 1 },
+				}),
+			]),
+		).toThrow("malformed usage record")
+		expect(
+			recoverLatestUsage([
+				JSON.stringify({
+					ts: "2026-01-01T00:00:04Z",
+					type: "run_result",
+					finishReason: "error",
+					aggregateUsage: {
+						inputTokens: 0,
+						cacheReadTokens: 0,
+						outputTokens: 0,
+						totalCost: 0,
+					},
+				}),
+			]),
+		).toMatchObject({
+			totalCost: 0,
+			totalInputTokens: 0,
+			totalCacheReadTokens: 0,
+			totalOutputTokens: 0,
+		})
+		expect(() =>
+			recoverLatestUsage([
+				JSON.stringify({
+					ts: "2026-01-01T00:00:05Z",
+					type: "run_result",
+					finishReason: "error",
+					aggregateUsage: {
+						inputTokens: 1,
+						cacheReadTokens: 0,
+						outputTokens: 0,
+						totalCost: 0,
+					},
 				}),
 			]),
 		).toThrow("malformed usage record")

--- a/evals/e2e/run-cline-bench-pilot.test.ts
+++ b/evals/e2e/run-cline-bench-pilot.test.ts
@@ -1,7 +1,16 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs"
+import {
+	appendFileSync,
+	chmodSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs"
 import { hostname, tmpdir } from "node:os"
-import { join } from "node:path"
+import { join, resolve } from "node:path"
 import {
 	acquireRunLock,
 	createBudgetLedger,
@@ -23,14 +32,18 @@ import {
 	assertLocalCoreVirtualModelsInCatalog,
 	assertModelTransportPrerequisites,
 	assertReusableFingerprint,
+	assertRouteTracePrerequisites,
 	assertTraceIngestionCompatibility,
 	buildRunMatrix,
 	type ExecutionProvenance,
 	fingerprintExecution,
 	hashDirectoryTree,
 	liveCostStopUsd,
+	loadModelRouteTraces,
+	loadRouteTraceFile,
 	localCoreHarborArguments,
 	matchRouteTraces,
+	missingRouteEvidenceStopReason,
 	modelTransportHarborArguments,
 	type PilotConfig,
 	type PilotReport,
@@ -40,6 +53,7 @@ import {
 	readLiveUsage,
 	readRecoveredFailedRun,
 	readTrialSessionIdentity,
+	resolveRouteTracesPath,
 	reuseCompletedRun,
 	verifierHarborArguments,
 } from "./run-cline-bench-pilot"
@@ -1048,6 +1062,86 @@ describe("Cline benchmark recovery, privacy, and routing evidence", () => {
 				undefined,
 			),
 		).not.toThrow()
+	})
+
+	test("requires traces only when selected execution rows include a local-Core virtual model", () => {
+		const checkpoint = readConfig(join(import.meta.dir, "cline-bench-router-checkpoint.config.json"))
+		const traceRoot = mkdtempSync(join(tmpdir(), "cline-bench-route-preflight-"))
+		temporaryDirectories.push(traceRoot)
+		const configuredPath = join(traceRoot, "routes.jsonl")
+		const explicitPath = join(tmpdir(), "explicit-router-traces.jsonl")
+		writeFileSync(configuredPath, "", { mode: 0o600 })
+
+		expect(resolveRouteTracesPath(undefined, configuredPath)).toBe(resolve(configuredPath))
+		expect(resolveRouteTracesPath(explicitPath, configuredPath)).toBe(resolve(explicitPath))
+		expect(() => resolveRouteTracesPath("relative/routes.jsonl")).toThrow("absolute")
+		expect(() => assertRouteTracePrerequisites(checkpoint, true, undefined, 1)).toThrow(
+			"AUTO_ROUTER_BENCHMARK_TRACE_PATH",
+		)
+		expect(() => assertRouteTracePrerequisites(checkpoint, true, configuredPath, 1)).not.toThrow()
+		expect(() => assertRouteTracePrerequisites(checkpoint, true, undefined, 3)).not.toThrow()
+		expect(() => assertRouteTracePrerequisites(checkpoint, true, undefined, undefined, 2)).not.toThrow()
+		expect(() => assertRouteTracePrerequisites(checkpoint, false, undefined, 1)).not.toThrow()
+	})
+
+	test("preflights an existing private parseable trace before local-Core virtual execution", () => {
+		const checkpoint = readConfig(join(import.meta.dir, "cline-bench-router-checkpoint.config.json"))
+		const traceRoot = mkdtempSync(join(tmpdir(), "cline-bench-route-preflight-"))
+		temporaryDirectories.push(traceRoot)
+		const tracePath = join(traceRoot, "routes.jsonl")
+
+		expect(() => assertRouteTracePrerequisites(checkpoint, true, tracePath, 1)).toThrow("does not exist")
+		writeFileSync(tracePath, "", { mode: 0o644 })
+		expect(() => assertRouteTracePrerequisites(checkpoint, true, tracePath, 1)).toThrow("private")
+		chmodSync(tracePath, 0o600)
+		writeFileSync(tracePath, "{not-json}\n")
+		expect(() => assertRouteTracePrerequisites(checkpoint, true, tracePath, 1)).toThrow()
+		writeFileSync(tracePath, "")
+		expect(() => assertRouteTracePrerequisites(checkpoint, true, tracePath, 1)).not.toThrow()
+	})
+
+	test("reloads a private route trace so Core appends from the current run are visible", () => {
+		const traceRoot = mkdtempSync(join(tmpdir(), "cline-bench-route-traces-"))
+		temporaryDirectories.push(traceRoot)
+		const tracePath = join(traceRoot, "routes.jsonl")
+		const route = (timestamp: string) =>
+			JSON.stringify({
+				taskHash: "a".repeat(64),
+				requestedModel: "cline/auto",
+				selectedModel: "z-ai/glm-5.2",
+				timestamp,
+			})
+
+		writeFileSync(tracePath, `${route("2026-01-01T00:00:00Z")}\n`, { mode: 0o600 })
+		expect(loadRouteTraceFile(tracePath)).toHaveLength(1)
+		appendFileSync(tracePath, `${route("2026-01-01T00:00:01Z")}\n`)
+		expect(loadRouteTraceFile(tracePath)).toHaveLength(2)
+	})
+
+	test("does not load traces for fixed models and stops after missing virtual evidence", () => {
+		const missingPath = join(tmpdir(), "does-not-exist.jsonl")
+		const fixedModel: PilotConfig["models"][number] = {
+			id: "zai/glm-5.2",
+			transport: "local-core",
+			perTaskBudgetUsd: 2.2,
+			perModelBudgetUsd: 8.8,
+		}
+		const virtualModel: PilotConfig["models"][number] = {
+			id: "cline/auto",
+			transport: "local-core",
+			perTaskBudgetUsd: 2.2,
+			perModelBudgetUsd: 17.6,
+			allowedCandidates: ["z-ai/glm-5.2"],
+		}
+
+		expect(loadModelRouteTraces(fixedModel, missingPath)).toEqual([])
+		expect(missingRouteEvidenceStopReason(fixedModel, { routeEvidence: "missing", task: "task-a" })).toBeUndefined()
+		expect(
+			missingRouteEvidenceStopReason(virtualModel, { routeEvidence: "verified", task: "task-a" }),
+		).toBeUndefined()
+		expect(missingRouteEvidenceStopReason(virtualModel, { routeEvidence: "missing", task: "task-a" })).toBe(
+			"missing route evidence for cline/auto × task-a",
+		)
 	})
 
 	test("parses privacy-safe route traces and rejects unknown fields", () => {

--- a/evals/e2e/run-cline-bench-pilot.test.ts
+++ b/evals/e2e/run-cline-bench-pilot.test.ts
@@ -19,6 +19,7 @@ import {
 import {
 	assertDirectModelsInLiveCatalog,
 	assertLocalClineVersion,
+	assertModelTransportPrerequisites,
 	assertReusableFingerprint,
 	assertTraceIngestionCompatibility,
 	buildRunMatrix,
@@ -152,6 +153,16 @@ describe("Cline benchmark execution fingerprints", () => {
 				{ ...base, effectiveConfig: { ...config(), globalBudgetUsd: 9 } },
 			),
 		).not.toBe(first)
+		const localCoreConfig = {
+			...config(),
+			models: config().models.map((model) => ({ ...model, transport: "local-core" as const })),
+		}
+		expect(
+			fingerprintExecution(localCoreConfig, {
+				...base,
+				effectiveConfig: localCoreConfig,
+			}),
+		).not.toBe(first)
 	})
 
 	test("rejects legacy and mismatched reports instead of blessing stale results", () => {
@@ -194,6 +205,16 @@ describe("Cline benchmark configuration and matrix", () => {
 		source.globalBudgetUsd = 51
 		writeFileSync(path, JSON.stringify(source))
 		expect(() => readConfig(path)).toThrow("at most 50")
+	})
+
+	test("rejects unknown model transports", () => {
+		const root = mkdtempSync(join(tmpdir(), "cline-bench-config-"))
+		temporaryDirectories.push(root)
+		const path = join(root, "config.json")
+		const source = JSON.parse(readFileSync(join(import.meta.dir, "cline-bench-pilot.config.json"), "utf8"))
+		source.models[0].transport = "other-proxy"
+		writeFileSync(path, JSON.stringify(source))
+		expect(() => readConfig(path)).toThrow('invalid transport for moonshotai/kimi-k3: "other-proxy"')
 	})
 
 	test("builds model-specific staged arms without duplicate tasks", () => {
@@ -259,6 +280,10 @@ describe("Cline benchmark configuration and matrix", () => {
 		expect(matrix.filter((run) => run.model.id === "openai/gpt-5.6-sol")).toHaveLength(8)
 		expect(matrix.filter((run) => run.model.id === "moonshotai/kimi-k3")).toHaveLength(4)
 		expect(matrix.filter((run) => run.model.id === "zai/glm-5.2")).toHaveLength(4)
+		expect(checkpoint.models.find((model) => model.id === "cline/auto")?.transport).toBe("local-core")
+		expect(checkpoint.models.find((model) => model.id === "moonshotai/kimi-k3")?.transport).toBe("local-core")
+		expect(checkpoint.models.find((model) => model.id === "zai/glm-5.2")?.transport).toBe("local-core")
+		expect(checkpoint.models.find((model) => model.id === "openai/gpt-5.6-sol")?.transport).toBe("cline-api")
 		for (const wave of [1, 2]) {
 			const exposure = matrix
 				.filter((run) => run.wave === wave)
@@ -899,10 +924,38 @@ describe("Cline benchmark recovery, privacy, and routing evidence", () => {
 		expect(modelTransportHarborArguments("moonshotai/kimi-k3", "http://localhost:7777")).toEqual([])
 		expect(modelTransportHarborArguments("z-ai/glm-5.2", "http://localhost:7777")).toEqual([])
 		expect(modelTransportHarborArguments("openai/gpt-5.4", "http://localhost:7777")).toEqual([])
+		expect(modelTransportHarborArguments("moonshotai/kimi-k3", "http://localhost:7777", "local-core")).toEqual(
+			localCoreHarborArguments("http://localhost:7777"),
+		)
+		expect(modelTransportHarborArguments("zai/glm-5.2", "http://localhost:17777", "local-core")).toEqual(
+			localCoreHarborArguments("http://localhost:17777"),
+		)
+		expect(modelTransportHarborArguments("cline/auto", "http://localhost:7777", "cline-api")).toEqual([])
+		expect(() => modelTransportHarborArguments("zai/glm-5.2", undefined, "local-core")).toThrow(
+			"requires --local-core-url",
+		)
 		expect(() => normalizeLocalCoreUrl("https://localhost:7777")).toThrow("only accepts")
 		expect(() => normalizeLocalCoreUrl("http://localhost:7778")).toThrow("only accepts")
 		expect(() => normalizeLocalCoreUrl("http://localhost:17778")).toThrow("only accepts")
 		expect(() => normalizeLocalCoreUrl("http://example.com:7777")).toThrow("only accepts")
+	})
+
+	test("requires local Core transport before jobs-root creation and budget reservation", () => {
+		const checkpoint = readConfig(join(import.meta.dir, "cline-bench-router-checkpoint.config.json"))
+		expect(() => assertModelTransportPrerequisites(checkpoint)).toThrow(
+			"model cline/auto requires --local-core-url for transport=local-core before jobs-root creation and budget reservation",
+		)
+		expect(() => assertModelTransportPrerequisites(checkpoint, "http://host.docker.internal:17777")).not.toThrow()
+		expect(() => assertModelTransportPrerequisites(checkpoint, "http://example.com:17777")).toThrow("only accepts")
+		expect(() =>
+			assertModelTransportPrerequisites(
+				{
+					...checkpoint,
+					models: checkpoint.models.map((model) => ({ ...model, transport: "cline-api" as const })),
+				},
+				undefined,
+			),
+		).not.toThrow()
 	})
 
 	test("parses privacy-safe route traces and rejects unknown fields", () => {

--- a/evals/e2e/run-cline-bench-pilot.test.ts
+++ b/evals/e2e/run-cline-bench-pilot.test.ts
@@ -17,6 +17,7 @@ import {
 	sha256,
 } from "./cline-bench-safety"
 import {
+	assertDirectModelsInLiveCatalog,
 	assertReusableFingerprint,
 	assertTraceIngestionCompatibility,
 	buildRunMatrix,
@@ -253,15 +254,38 @@ describe("Cline benchmark configuration and matrix", () => {
 		expect(matrix).toHaveLength(24)
 		expect(new Set(checkpoint.tasks).size).toBe(8)
 		expect(matrix.filter((run) => run.model.id === "cline/auto")).toHaveLength(8)
-		expect(matrix.filter((run) => run.model.id === "openai/gpt-5.4")).toHaveLength(8)
+		expect(matrix.filter((run) => run.model.id === "openai/gpt-5.6-sol")).toHaveLength(8)
 		expect(matrix.filter((run) => run.model.id === "moonshotai/kimi-k3")).toHaveLength(4)
-		expect(matrix.filter((run) => run.model.id === "z-ai/glm-5.2")).toHaveLength(4)
+		expect(matrix.filter((run) => run.model.id === "zai/glm-5.2")).toHaveLength(4)
 		for (const wave of [1, 2]) {
 			const exposure = matrix
 				.filter((run) => run.wave === wave)
 				.reduce((total, run) => total + run.model.perTaskBudgetUsd, 0)
 			expect(exposure).toBeLessThanOrEqual(checkpoint.waveBudgetsUsd?.[String(wave)] || 0)
 		}
+	})
+
+	test("preflights direct arms against the live catalog but leaves Core Auto candidates internal", async () => {
+		const checkpoint = readConfig(join(import.meta.dir, "cline-bench-router-checkpoint.config.json"))
+		const fetchCatalog = (async () =>
+			new Response(
+				JSON.stringify({
+					recommended: [{ id: "moonshotai/kimi-k3" }, { id: "zai/glm-5.2" }, { id: "openai/gpt-5.6-sol" }],
+					free: [],
+					clinePass: [],
+				}),
+				{ status: 200 },
+			)) as typeof fetch
+		await expect(assertDirectModelsInLiveCatalog(checkpoint, fetchCatalog)).resolves.toBeUndefined()
+
+		const staleDirect = {
+			...checkpoint,
+			models: checkpoint.models.map((model) => (model.id === "zai/glm-5.2" ? { ...model, id: "z-ai/glm-5.2" } : model)),
+		}
+		await expect(assertDirectModelsInLiveCatalog(staleDirect, fetchCatalog)).rejects.toThrow(
+			"absent from the live Cline cline-router catalog: z-ai/glm-5.2",
+		)
+		expect(checkpoint.models.find((model) => model.id === "cline/auto")?.allowedCandidates).toContain("z-ai/glm-5.2")
 	})
 })
 
@@ -573,6 +597,150 @@ describe("Cline benchmark recovery, privacy, and routing evidence", () => {
 		expect(resumed).toEqual(failed)
 		ledger = settleBudget(ledger, "1:1:cline/auto:task-a", resumed?.costUsd || 0)
 		expect(ledgerExposure(ledger)).toBe(0.25)
+	})
+
+	test("charges completed no-telemetry work at its reservation and never reruns it", () => {
+		const jobsRoot = mkdtempSync(join(tmpdir(), "cline-bench-no-telemetry-"))
+		temporaryDirectories.push(jobsRoot)
+		const task = "task-a"
+		const model = {
+			id: "z-ai/glm-5.2",
+			perTaskBudgetUsd: 2.2,
+			perModelBudgetUsd: 2.2,
+		}
+		const noTelemetryConfig: PilotConfig = {
+			...config(),
+			models: [model],
+			tasks: [task],
+		}
+		const jobDir = join(jobsRoot, "01-z-ai-glm-5.2-task-a")
+		const trialName = "task-a__cline__attempt-1"
+		const agentDir = join(jobDir, trialName, "agent")
+		mkdirSync(agentDir, { recursive: true })
+		writeFileSync(
+			join(jobDir, "result.json"),
+			JSON.stringify({
+				started_at: "2026-01-01T00:00:00Z",
+				finished_at: "2026-01-01T00:00:02Z",
+				trial_results: null,
+				stats: {
+					n_input_tokens: null,
+					n_cache_tokens: null,
+					n_output_tokens: null,
+					cost_usd: null,
+				},
+			}),
+		)
+		writeFileSync(
+			join(jobDir, trialName, "result.json"),
+			JSON.stringify({
+				task_name: task,
+				started_at: "2026-01-01T00:00:00Z",
+				finished_at: "2026-01-01T00:00:02Z",
+				agent_info: {
+					version: noTelemetryConfig.clineVersion,
+					model_info: { name: "glm-5.2", provider: "cline:z-ai" },
+				},
+				exception_info: null,
+				verifier_result: { rewards: { reward: 0 } },
+			}),
+		)
+		writeFileSync(join(agentDir, "cline.txt"), "__CLINE_EXIT=0\n")
+
+		const recovered = reuseCompletedRun(noTelemetryConfig, model, task, jobsRoot, 1)
+		expect(recovered).toMatchObject({
+			outcome: "failed",
+			failureClassification: "CompletedWithoutCostTelemetry",
+			passed: false,
+			reward: null,
+			costUsd: 2.2,
+			costBasis: "reserved-exposure",
+			inputTokens: null,
+			cacheTokens: null,
+			outputTokens: null,
+		})
+
+		let ledger = reserveBudget(createBudgetLedger(10), {
+			runKey: "1:1:z-ai/glm-5.2:task-a",
+			model: model.id,
+			wave: 1,
+			exposureUsd: model.perTaskBudgetUsd,
+		})
+		ledger = settleBudget(ledger, "1:1:z-ai/glm-5.2:task-a", recovered?.costUsd || 0)
+		expect(ledgerExposure(ledger)).toBe(2.2)
+
+		const resumed = reuseCompletedRun(noTelemetryConfig, model, task, jobsRoot, 1)
+		expect(resumed).toEqual(recovered)
+	})
+
+	test("keeps a canonical terminal no-spend infrastructure failure at zero", () => {
+		const jobsRoot = mkdtempSync(join(tmpdir(), "cline-bench-zero-spend-"))
+		temporaryDirectories.push(jobsRoot)
+		const task = "task-a"
+		const model = {
+			id: "z-ai/glm-5.2",
+			perTaskBudgetUsd: 2.2,
+			perModelBudgetUsd: 2.2,
+		}
+		const zeroSpendConfig: PilotConfig = {
+			...config(),
+			models: [model],
+			tasks: [task],
+		}
+		const jobDir = join(jobsRoot, "01-z-ai-glm-5.2-task-a")
+		const trialName = "task-a__cline__attempt-1"
+		const agentDir = join(jobDir, trialName, "agent")
+		mkdirSync(agentDir, { recursive: true })
+		writeFileSync(
+			join(jobDir, "result.json"),
+			JSON.stringify({
+				started_at: "2026-01-01T00:00:00Z",
+				finished_at: "2026-01-01T00:00:02Z",
+				trial_results: [],
+				stats: {
+					n_input_tokens: 0,
+					n_cache_tokens: 0,
+					n_output_tokens: 0,
+					cost_usd: 0,
+				},
+			}),
+		)
+		writeFileSync(
+			join(jobDir, trialName, "result.json"),
+			JSON.stringify({
+				task_name: task,
+				started_at: "2026-01-01T00:00:00Z",
+				finished_at: "2026-01-01T00:00:02Z",
+				agent_info: {
+					version: zeroSpendConfig.clineVersion,
+					model_info: { name: "glm-5.2", provider: "cline:z-ai" },
+				},
+				exception_info: { exception_type: "ApiAuthenticationError" },
+				verifier_result: null,
+			}),
+		)
+		writeFileSync(
+			join(agentDir, "cline.txt"),
+			`${JSON.stringify({
+				ts: "2026-01-01T00:00:01Z",
+				type: "run_result",
+				finishReason: "error",
+				aggregateUsage: {
+					inputTokens: 0,
+					cacheReadTokens: 0,
+					outputTokens: 0,
+					totalCost: 0,
+				},
+			})}\n`,
+		)
+
+		const recovered = reuseCompletedRun(zeroSpendConfig, model, task, jobsRoot, 1)
+		expect(recovered).toMatchObject({
+			outcome: "failed",
+			failureClassification: "ApiAuthenticationError",
+			costUsd: 0,
+			costBasis: "reported-inference",
+		})
 	})
 
 	test("recovers a private live-cost marker without a Harbor result and never respends it", () => {

--- a/evals/e2e/run-cline-bench-pilot.test.ts
+++ b/evals/e2e/run-cline-bench-pilot.test.ts
@@ -7,6 +7,7 @@ import {
 	createBudgetLedger,
 	hashPrivateIdentifier,
 	ledgerExposure,
+	markBudgetUnmeasured,
 	normalizeLocalCoreUrl,
 	parseRouteTraces,
 	recoverLatestUsage,
@@ -19,6 +20,7 @@ import {
 import {
 	assertDirectModelsInLiveCatalog,
 	assertLocalClineVersion,
+	assertLocalCoreVirtualModelsInCatalog,
 	assertModelTransportPrerequisites,
 	assertReusableFingerprint,
 	assertTraceIngestionCompatibility,
@@ -354,6 +356,36 @@ describe("Cline benchmark configuration and matrix", () => {
 		expect(checkpoint.models.find((model) => model.id === "cline/auto")?.allowedCandidates).toContain("z-ai/glm-5.2")
 	})
 
+	test("preflights local Core virtual IDs before any budget reservation", async () => {
+		const checkpoint = readConfig(join(import.meta.dir, "cline-bench-router-checkpoint.config.json"))
+		const fetchCatalog = (async (input: URL | RequestInfo) => {
+			expect(String(input)).toBe("http://127.0.0.1:17777/api/v1/ai/cline/recommended-models")
+			return new Response(
+				JSON.stringify({
+					recommended: [{ id: "cline/auto" }],
+					free: [],
+					clinePass: [],
+				}),
+				{ status: 200 },
+			)
+		}) as typeof fetch
+		await expect(
+			assertLocalCoreVirtualModelsInCatalog(checkpoint, "http://host.docker.internal:17777", fetchCatalog),
+		).resolves.toBeUndefined()
+
+		const missingVirtual = (async () =>
+			new Response(JSON.stringify({ recommended: [], free: [], clinePass: [] }), {
+				status: 200,
+			})) as typeof fetch
+		await expect(
+			assertLocalCoreVirtualModelsInCatalog(
+				checkpoint,
+				"http://host.docker.internal:17777",
+				missingVirtual,
+			),
+		).rejects.toThrow("local Core catalog is missing virtual model(s): cline/auto")
+	})
+
 	test("fails closed when the local CLI build differs from the configured Harbor build", () => {
 		const checkpoint = readConfig(join(import.meta.dir, "cline-bench-router-checkpoint.config.json"))
 		expect(() =>
@@ -678,6 +710,7 @@ describe("Cline benchmark recovery, privacy, and routing evidence", () => {
 			wave: 1,
 			exposureUsd: model.perTaskBudgetUsd,
 		})
+		if (failed.costUsd === null) throw new Error("expected recovered measured cost")
 		ledger = settleBudget(ledger, "1:1:cline/auto:task-a", failed.costUsd)
 		expect(ledgerExposure(ledger)).toBe(0.25)
 
@@ -687,7 +720,7 @@ describe("Cline benchmark recovery, privacy, and routing evidence", () => {
 		expect(ledgerExposure(ledger)).toBe(0.25)
 	})
 
-	test("charges completed no-telemetry work at its reservation and never reruns it", () => {
+	test("marks completed no-telemetry work infrastructure-invalid without inventing measured cost", () => {
 		const jobsRoot = mkdtempSync(join(tmpdir(), "cline-bench-no-telemetry-"))
 		temporaryDirectories.push(jobsRoot)
 		const task = "task-a"
@@ -737,12 +770,13 @@ describe("Cline benchmark recovery, privacy, and routing evidence", () => {
 
 		const recovered = reuseCompletedRun(noTelemetryConfig, model, task, jobsRoot, 1)
 		expect(recovered).toMatchObject({
-			outcome: "failed",
+			outcome: "infrastructure_invalid",
 			failureClassification: "CompletedWithoutCostTelemetry",
 			passed: false,
 			reward: null,
-			costUsd: 2.2,
-			costBasis: "reserved-exposure",
+			costUsd: null,
+			costBasis: "unmeasured",
+			reservedExposureUsd: 2.2,
 			inputTokens: null,
 			cacheTokens: null,
 			outputTokens: null,
@@ -754,11 +788,30 @@ describe("Cline benchmark recovery, privacy, and routing evidence", () => {
 			wave: 1,
 			exposureUsd: model.perTaskBudgetUsd,
 		})
-		ledger = settleBudget(ledger, "1:1:z-ai/glm-5.2:task-a", recovered?.costUsd || 0)
+		ledger = markBudgetUnmeasured(ledger, "1:1:z-ai/glm-5.2:task-a")
 		expect(ledgerExposure(ledger)).toBe(2.2)
+		expect(ledger.entries[0]).toMatchObject({
+			status: "unmeasured",
+			reservedUsd: 2.2,
+		})
+		expect(ledger.entries[0].actualUsd).toBeUndefined()
 
 		const resumed = reuseCompletedRun(noTelemetryConfig, model, task, jobsRoot, 1)
 		expect(resumed).toEqual(recovered)
+	})
+
+	test("migrates a legacy full-reservation settlement to unmeasured exposure only", () => {
+		let ledger = reserveBudget(createBudgetLedger(10), {
+			runKey: "legacy",
+			model: "cline/auto",
+			wave: 1,
+			exposureUsd: 2.2,
+		})
+		ledger = settleBudget(ledger, "legacy", 2.2)
+		ledger = markBudgetUnmeasured(ledger, "legacy")
+		expect(ledgerExposure(ledger)).toBe(2.2)
+		expect(ledger.entries[0].status).toBe("unmeasured")
+		expect(ledger.entries[0].actualUsd).toBeUndefined()
 	})
 
 	test("keeps a canonical terminal no-spend infrastructure failure at zero", () => {

--- a/evals/e2e/run-cline-bench-pilot.test.ts
+++ b/evals/e2e/run-cline-bench-pilot.test.ts
@@ -77,10 +77,11 @@ function config(): PilotConfig {
 
 function provenance(contentHash: string, commit = "a".repeat(40)): ExecutionProvenance {
 	return {
-		schemaVersion: 3,
+		schemaVersion: 4,
 		runnerContentSha256: "b".repeat(64),
 		runnerGitCommit: "c".repeat(40),
 		harborVersion: "0.20.0",
+		localCoreRevision: null,
 		effectiveConfig: config(),
 		executionOptions: { localCoreUrl: null },
 		clineBenchCommit: commit,
@@ -155,14 +156,23 @@ describe("Cline benchmark execution fingerprints", () => {
 		).not.toBe(first)
 		const localCoreConfig = {
 			...config(),
+			localCoreRevision: "e".repeat(40),
 			models: config().models.map((model) => ({ ...model, transport: "local-core" as const })),
 		}
+		const localCoreFingerprint = fingerprintExecution(localCoreConfig, {
+			...base,
+			localCoreRevision: localCoreConfig.localCoreRevision,
+			effectiveConfig: localCoreConfig,
+		})
+		expect(localCoreFingerprint).not.toBe(first)
+		const changedRevisionConfig = { ...localCoreConfig, localCoreRevision: "f".repeat(40) }
 		expect(
-			fingerprintExecution(localCoreConfig, {
+			fingerprintExecution(changedRevisionConfig, {
 				...base,
-				effectiveConfig: localCoreConfig,
+				localCoreRevision: changedRevisionConfig.localCoreRevision,
+				effectiveConfig: changedRevisionConfig,
 			}),
-		).not.toBe(first)
+		).not.toBe(localCoreFingerprint)
 	})
 
 	test("rejects legacy and mismatched reports instead of blessing stale results", () => {
@@ -215,6 +225,34 @@ describe("Cline benchmark configuration and matrix", () => {
 		source.models[0].transport = "other-proxy"
 		writeFileSync(path, JSON.stringify(source))
 		expect(() => readConfig(path)).toThrow('invalid transport for moonshotai/kimi-k3: "other-proxy"')
+	})
+
+	test("requires a strict local Core revision only for explicit local-core transports", () => {
+		const root = mkdtempSync(join(tmpdir(), "cline-bench-config-"))
+		temporaryDirectories.push(root)
+		const source = JSON.parse(readFileSync(join(import.meta.dir, "cline-bench-pilot.config.json"), "utf8"))
+		source.models[0].transport = "local-core"
+		const path = join(root, "config.json")
+
+		writeFileSync(path, JSON.stringify(source))
+		expect(() => readConfig(path)).toThrow(
+			"localCoreRevision is required when any model uses transport=local-core",
+		)
+
+		for (const invalid of ["", "a".repeat(39), "a".repeat(41), "A".repeat(40), `${"a".repeat(39)}g`]) {
+			source.localCoreRevision = invalid
+			writeFileSync(path, JSON.stringify(source))
+			expect(() => readConfig(path)).toThrow("exact 40-character lowercase hexadecimal Git commit")
+		}
+
+		source.localCoreRevision = "a".repeat(40)
+		writeFileSync(path, JSON.stringify(source))
+		expect(readConfig(path).localCoreRevision).toBe("a".repeat(40))
+
+		delete source.models[0].transport
+		delete source.localCoreRevision
+		writeFileSync(path, JSON.stringify(source))
+		expect(readConfig(path).localCoreRevision).toBeUndefined()
 	})
 
 	test("builds model-specific staged arms without duplicate tasks", () => {
@@ -274,6 +312,7 @@ describe("Cline benchmark configuration and matrix", () => {
 		const checkpoint = readConfig(join(import.meta.dir, "cline-bench-router-checkpoint.config.json"))
 		const matrix = buildRunMatrix(checkpoint)
 		expect(checkpoint.clineVersion).toBe("3.0.46-nightly.1784896623")
+		expect(checkpoint.localCoreRevision).toBe("587ebe82b3a2337b229d22ed097051215ba145f8")
 		expect(matrix).toHaveLength(24)
 		expect(new Set(checkpoint.tasks).size).toBe(8)
 		expect(matrix.filter((run) => run.model.id === "cline/auto")).toHaveLength(8)

--- a/evals/e2e/run-cline-bench-pilot.test.ts
+++ b/evals/e2e/run-cline-bench-pilot.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import {
+	type ExecutionProvenance,
+	assertReusableFingerprint,
+	fingerprintExecution,
+	hashDirectoryTree,
+	type PilotConfig,
+} from "./run-cline-bench-pilot"
+
+const temporaryDirectories: string[] = []
+
+afterEach(() => {
+	for (const directory of temporaryDirectories.splice(0)) {
+		rmSync(directory, { recursive: true, force: true })
+	}
+})
+
+function taskTree() {
+	const root = mkdtempSync(join(tmpdir(), "cline-bench-fingerprint-"))
+	temporaryDirectories.push(root)
+	mkdirSync(join(root, "tests"))
+	writeFileSync(join(root, "task.toml"), "[agent]\ntimeout_sec = 900\n")
+	writeFileSync(join(root, "instruction.md"), "Fix the production bug.\n")
+	writeFileSync(join(root, "tests", "test.sh"), "#!/bin/bash\nexit 0\n", { mode: 0o755 })
+	return root
+}
+
+function config(): PilotConfig {
+	return {
+		routerProfile: "cline-router",
+		provider: "cline",
+		globalBudgetUsd: 10,
+		maxRunsPerModel: 1,
+		timeoutSeconds: 900,
+		clineVersion: "3.0.46",
+		models: [{ id: "openai/gpt-5.4", perTaskBudgetUsd: 2, perModelBudgetUsd: 2 }],
+		tasks: ["task-a"],
+	}
+}
+
+function provenance(contentHash: string, commit = "a".repeat(40)): ExecutionProvenance {
+	return {
+		schemaVersion: 2,
+		clineBenchCommit: commit,
+		tasks: [{ id: "task-a", effectiveContentSha256: contentHash }],
+	}
+}
+
+describe("Cline benchmark execution fingerprints", () => {
+	test("hashes effective verifier content and executable mode", () => {
+		const root = taskTree()
+		const original = hashDirectoryTree(root)
+
+		writeFileSync(join(root, "tests", "test.sh"), "#!/bin/bash\nexit 1\n", { mode: 0o755 })
+		expect(hashDirectoryTree(root)).not.toBe(original)
+
+		writeFileSync(join(root, "tests", "test.sh"), "#!/bin/bash\nexit 0\n", { mode: 0o755 })
+		expect(hashDirectoryTree(root)).toBe(original)
+
+		chmodSync(join(root, "tests", "test.sh"), 0o644)
+		expect(hashDirectoryTree(root)).not.toBe(original)
+	})
+
+	test("changes when the exact submodule commit changes", () => {
+		const contentHash = hashDirectoryTree(taskTree())
+		const first = fingerprintExecution(config(), provenance(contentHash))
+		const second = fingerprintExecution(config(), provenance(contentHash, "b".repeat(40)))
+
+		expect(second).not.toBe(first)
+	})
+
+	test("changes when any effective task tree changes", () => {
+		const root = taskTree()
+		const firstHash = hashDirectoryTree(root)
+		const first = fingerprintExecution(config(), provenance(firstHash))
+
+		writeFileSync(join(root, "instruction.md"), "Fix the production bug and add a regression test.\n")
+		const secondHash = hashDirectoryTree(root)
+		const second = fingerprintExecution(config(), provenance(secondHash))
+
+		expect(secondHash).not.toBe(firstHash)
+		expect(second).not.toBe(first)
+	})
+
+	test("rejects legacy and mismatched reports instead of blessing stale results", () => {
+		expect(() => assertReusableFingerprint({}, "current")).toThrow(
+			"predates content-addressed task fingerprints",
+		)
+		expect(() =>
+			assertReusableFingerprint({ executionFingerprint: "old" }, "current"),
+		).toThrow("different execution matrix")
+		expect(() =>
+			assertReusableFingerprint({ executionFingerprint: "current" }, "current"),
+		).not.toThrow()
+	})
+})

--- a/evals/e2e/run-cline-bench-pilot.test.ts
+++ b/evals/e2e/run-cline-bench-pilot.test.ts
@@ -1,13 +1,34 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
-import { tmpdir } from "node:os"
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { hostname, tmpdir } from "node:os"
 import { join } from "node:path"
 import {
-	type ExecutionProvenance,
+	acquireRunLock,
+	createBudgetLedger,
+	hashPrivateIdentifier,
+	ledgerExposure,
+	normalizeLocalCoreUrl,
+	parseRouteTraces,
+	recoverLatestUsage,
+	redactSecrets,
+	releaseRunLock,
+	reserveBudget,
+	settleBudget,
+	sha256,
+} from "./cline-bench-safety"
+import {
 	assertReusableFingerprint,
+	buildRunMatrix,
+	type ExecutionProvenance,
 	fingerprintExecution,
 	hashDirectoryTree,
+	localCoreHarborArguments,
+	matchRouteTraces,
 	type PilotConfig,
+	prepareTaskPath,
+	readConfig,
+	readTrialSessionIdentity,
+	verifierHarborArguments,
 } from "./run-cline-bench-pilot"
 
 const temporaryDirectories: string[] = []
@@ -24,7 +45,9 @@ function taskTree() {
 	mkdirSync(join(root, "tests"))
 	writeFileSync(join(root, "task.toml"), "[agent]\ntimeout_sec = 900\n")
 	writeFileSync(join(root, "instruction.md"), "Fix the production bug.\n")
-	writeFileSync(join(root, "tests", "test.sh"), "#!/bin/bash\nexit 0\n", { mode: 0o755 })
+	writeFileSync(join(root, "tests", "test.sh"), "#!/bin/bash\nexit 0\n", {
+		mode: 0o755,
+	})
 	return root
 }
 
@@ -43,7 +66,12 @@ function config(): PilotConfig {
 
 function provenance(contentHash: string, commit = "a".repeat(40)): ExecutionProvenance {
 	return {
-		schemaVersion: 2,
+		schemaVersion: 3,
+		runnerContentSha256: "b".repeat(64),
+		runnerGitCommit: "c".repeat(40),
+		harborVersion: "0.20.0",
+		effectiveConfig: config(),
+		executionOptions: { localCoreUrl: null },
 		clineBenchCommit: commit,
 		tasks: [{ id: "task-a", effectiveContentSha256: contentHash }],
 	}
@@ -54,10 +82,14 @@ describe("Cline benchmark execution fingerprints", () => {
 		const root = taskTree()
 		const original = hashDirectoryTree(root)
 
-		writeFileSync(join(root, "tests", "test.sh"), "#!/bin/bash\nexit 1\n", { mode: 0o755 })
+		writeFileSync(join(root, "tests", "test.sh"), "#!/bin/bash\nexit 1\n", {
+			mode: 0o755,
+		})
 		expect(hashDirectoryTree(root)).not.toBe(original)
 
-		writeFileSync(join(root, "tests", "test.sh"), "#!/bin/bash\nexit 0\n", { mode: 0o755 })
+		writeFileSync(join(root, "tests", "test.sh"), "#!/bin/bash\nexit 0\n", {
+			mode: 0o755,
+		})
 		expect(hashDirectoryTree(root)).toBe(original)
 
 		chmodSync(join(root, "tests", "test.sh"), 0o644)
@@ -85,15 +117,318 @@ describe("Cline benchmark execution fingerprints", () => {
 		expect(second).not.toBe(first)
 	})
 
+	test("changes with runner, Harbor, and complete config", () => {
+		const contentHash = hashDirectoryTree(taskTree())
+		const base = provenance(contentHash)
+		const first = fingerprintExecution(config(), base)
+		expect(
+			fingerprintExecution(config(), {
+				...base,
+				runnerContentSha256: "d".repeat(64),
+			}),
+		).not.toBe(first)
+		expect(fingerprintExecution(config(), { ...base, harborVersion: "0.21.0" })).not.toBe(first)
+		expect(
+			fingerprintExecution(config(), {
+				...base,
+				executionOptions: {
+					localCoreUrl: "http://host.docker.internal:7777",
+				},
+			}),
+		).not.toBe(first)
+		expect(
+			fingerprintExecution(
+				{ ...config(), globalBudgetUsd: 9 },
+				{ ...base, effectiveConfig: { ...config(), globalBudgetUsd: 9 } },
+			),
+		).not.toBe(first)
+	})
+
 	test("rejects legacy and mismatched reports instead of blessing stale results", () => {
-		expect(() => assertReusableFingerprint({}, "current")).toThrow(
-			"predates content-addressed task fingerprints",
+		expect(() => assertReusableFingerprint({}, "current")).toThrow("predates content-addressed task fingerprints")
+		expect(() => assertReusableFingerprint({ executionFingerprint: "old" }, "current")).toThrow(
+			"different execution matrix",
 		)
+		expect(() => assertReusableFingerprint({ executionFingerprint: "current" }, "current")).not.toThrow()
+	})
+})
+
+describe("Cline benchmark configuration and matrix", () => {
+	test("rejects checkpoints above fifty dollars", () => {
+		const root = mkdtempSync(join(tmpdir(), "cline-bench-config-"))
+		temporaryDirectories.push(root)
+		const path = join(root, "config.json")
+		const source = JSON.parse(readFileSync(join(import.meta.dir, "cline-bench-pilot.config.json"), "utf8"))
+		source.globalBudgetUsd = 51
+		writeFileSync(path, JSON.stringify(source))
+		expect(() => readConfig(path)).toThrow("at most 50")
+	})
+
+	test("builds model-specific staged arms without duplicate tasks", () => {
+		const staged: PilotConfig = {
+			...config(),
+			maxRunsPerModel: 3,
+			tasks: ["a", "b", "c"],
+			models: [
+				{
+					id: "cline/auto",
+					perTaskBudgetUsd: 1,
+					perModelBudgetUsd: 3,
+					wave: 1,
+					allowedCandidates: ["x/y"],
+				},
+				{
+					id: "openai/gpt-5.4",
+					perTaskBudgetUsd: 1,
+					perModelBudgetUsd: 2,
+					wave: 2,
+					tasks: ["a", "c"],
+				},
+			],
+		}
+		const matrix = buildRunMatrix(staged)
+		expect(matrix).toHaveLength(5)
+		expect(
+			matrix
+				.filter((run) => run.model.id === "cline/auto")
+				.map((run) => run.task)
+				.sort(),
+		).toEqual(["a", "b", "c"])
+		expect(
+			matrix
+				.filter((run) => run.wave === 2)
+				.map((run) => run.task)
+				.sort(),
+		).toEqual(["a", "c"])
+	})
+
+	test("provides uv PATH to every selected verifier without changing task content or agent environment", () => {
+		const jobsRoot = mkdtempSync(join(tmpdir(), "cline-bench-overlays-"))
+		temporaryDirectories.push(jobsRoot)
+		const checkpoint = readConfig(join(import.meta.dir, "cline-bench-router-checkpoint.config.json"))
+		for (const task of checkpoint.tasks) {
+			const source = join(import.meta.dir, "..", "cline-bench", "tasks", task)
+			expect(readFileSync(join(source, "tests", "test.sh"), "utf8")).toMatch(/^\s*uv\s/m)
+			expect(prepareTaskPath(task, jobsRoot)).toBe(`tasks/${task}`)
+		}
+		expect(verifierHarborArguments()).toEqual([
+			"--ve",
+			"PATH=/root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+		])
+	})
+
+	test("keeps the checked-in 8-task checkpoint within its staged reservations", () => {
+		const checkpoint = readConfig(join(import.meta.dir, "cline-bench-router-checkpoint.config.json"))
+		const matrix = buildRunMatrix(checkpoint)
+		expect(matrix).toHaveLength(24)
+		expect(new Set(checkpoint.tasks).size).toBe(8)
+		expect(matrix.filter((run) => run.model.id === "cline/auto")).toHaveLength(8)
+		expect(matrix.filter((run) => run.model.id === "openai/gpt-5.4")).toHaveLength(8)
+		expect(matrix.filter((run) => run.model.id === "moonshotai/kimi-k2.7-code")).toHaveLength(4)
+		expect(matrix.filter((run) => run.model.id === "z-ai/glm-5.2")).toHaveLength(4)
+		for (const wave of [1, 2]) {
+			const exposure = matrix
+				.filter((run) => run.wave === wave)
+				.reduce((total, run) => total + run.model.perTaskBudgetUsd, 0)
+			expect(exposure).toBeLessThanOrEqual(checkpoint.waveBudgetsUsd?.[String(wave)] || 0)
+		}
+	})
+})
+
+describe("Cline benchmark lock and budget ledger", () => {
+	test("holds an exclusive lock and recovers a dead local owner", () => {
+		const root = mkdtempSync(join(tmpdir(), "cline-bench-lock-"))
+		temporaryDirectories.push(root)
+		const lock = acquireRunLock(root)
+		expect(() => acquireRunLock(root)).toThrow("already active")
+		releaseRunLock(lock)
+
+		const lockDir = join(root, ".pilot-run.lock")
+		mkdirSync(lockDir)
+		writeFileSync(
+			join(lockDir, "owner.json"),
+			JSON.stringify({
+				schemaVersion: 1,
+				pid: 999_999_999,
+				host: hostname(),
+				token: "stale",
+				acquiredAt: new Date(0).toISOString(),
+			}),
+		)
+		const recovered = acquireRunLock(root)
+		releaseRunLock(recovered)
+	})
+
+	test("reserves before spend and enforces campaign and wave checkpoints", () => {
+		let ledger = createBudgetLedger(50)
+		ledger = reserveBudget(ledger, {
+			runKey: "1",
+			model: "cline/auto",
+			wave: 1,
+			exposureUsd: 20,
+			waveBudgetUsd: 35,
+		})
+		expect(ledgerExposure(ledger)).toBe(20)
+		ledger = settleBudget(ledger, "1", 12)
+		expect(ledgerExposure(ledger)).toBe(12)
 		expect(() =>
-			assertReusableFingerprint({ executionFingerprint: "old" }, "current"),
-		).toThrow("different execution matrix")
+			reserveBudget(ledger, {
+				runKey: "2",
+				model: "cline/auto",
+				wave: 1,
+				exposureUsd: 24,
+				waveBudgetUsd: 35,
+			}),
+		).toThrow("wave 1 lacks room")
 		expect(() =>
-			assertReusableFingerprint({ executionFingerprint: "current" }, "current"),
-		).not.toThrow()
+			reserveBudget(ledger, {
+				runKey: "3",
+				model: "openai/gpt-5.4",
+				wave: 2,
+				exposureUsd: 39,
+			}),
+		).toThrow("campaign lacks room")
+	})
+})
+
+describe("Cline benchmark recovery, privacy, and routing evidence", () => {
+	test("recovers timestamp-max usage and rejects multiple attempts", () => {
+		const usage = (ts: string, totalCost: number) =>
+			JSON.stringify({
+				ts,
+				event: {
+					type: "usage",
+					totalCost,
+					totalInputTokens: 10,
+					totalCacheReadTokens: 5,
+					totalOutputTokens: 2,
+				},
+			})
+		const latest = recoverLatestUsage([`${usage("2026-01-01T00:00:02Z", 2)}\n${usage("2026-01-01T00:00:01Z", 1)}\n`])
+		expect(latest.totalCost).toBe(2)
+		expect(() => recoverLatestUsage(["{}", "{}"])).toThrow("exactly one attempt")
+	})
+
+	test("redacts all exact secrets and hashes private identifiers", () => {
+		expect(redactSecrets("alpha secret beta token", ["secret", "token"])).toBe("alpha [REDACTED] beta [REDACTED]")
+		expect(hashPrivateIdentifier("task", "raw-id")).toMatch(/^[0-9a-f]{64}$/)
+		expect(hashPrivateIdentifier("task", "raw-id")).not.toContain("raw-id")
+	})
+
+	test("strictly normalizes only the local Core endpoint", () => {
+		expect(normalizeLocalCoreUrl("http://localhost:7777")).toBe("http://host.docker.internal:7777")
+		expect(localCoreHarborArguments("http://localhost:7777")).toEqual([
+			"--ae",
+			"CLINE_API_BASE_URL=http://host.docker.internal:7777",
+			"--allow-agent-host",
+			"host.docker.internal",
+			"--allow-environment-host",
+			"host.docker.internal",
+		])
+		expect(() => normalizeLocalCoreUrl("https://localhost:7777")).toThrow("only accepts")
+		expect(() => normalizeLocalCoreUrl("http://localhost:7778")).toThrow("only accepts")
+		expect(() => normalizeLocalCoreUrl("http://example.com:7777")).toThrow("only accepts")
+	})
+
+	test("parses privacy-safe route traces and rejects unknown fields", () => {
+		const taskHash = "a".repeat(64)
+		const traces = parseRouteTraces(
+			JSON.stringify({
+				taskHash,
+				requestedModel: "cline/auto",
+				selectedModel: "z-ai/glm-5.2",
+				timestamp: "2026-01-01T00:00:00Z",
+			}),
+		)
+		expect(traces).toHaveLength(1)
+		expect(() =>
+			parseRouteTraces(
+				JSON.stringify({
+					taskHash,
+					requestedModel: "cline/auto",
+					selectedModel: "z-ai/glm-5.2",
+					timestamp: "2026-01-01T00:00:00Z",
+					rawTaskId: "secret",
+				}),
+			),
+		).toThrow("unknown route trace field")
+	})
+
+	test("correlates an exact Core JSONL trace with the Cline session recorded by Harbor", () => {
+		const jobRoot = mkdtempSync(join(tmpdir(), "cline-bench-route-correlation-"))
+		temporaryDirectories.push(jobRoot)
+		const trialName = "task__cline__trial-1"
+		const agentDir = join(jobRoot, trialName, "agent")
+		mkdirSync(agentDir, { recursive: true })
+		const sessionId = "1784094124598_ymnl2"
+		writeFileSync(join(agentDir, "trajectory.json"), JSON.stringify({ session_id: sessionId }))
+
+		const identity = readTrialSessionIdentity(jobRoot, trialName)
+		expect(identity).toEqual({
+			sessionHash: hashPrivateIdentifier("cline-bench-session", sessionId),
+			sessionIdSha256: sha256(sessionId),
+		})
+
+		const coreLine = {
+			schema_version: 1,
+			timestamp: "2026-07-24T12:34:56Z",
+			task_id_sha256: sha256(sessionId),
+			product: "cline-router",
+			action: "route",
+			requested_model: "cline/auto",
+			selected_concrete_model: "z-ai/glm-5.2",
+			tier: "medium",
+			mode: "cost-aware",
+			reason: "classifier",
+			score: 0.84,
+			task_score: 0.71,
+			gate: {
+				evaluated: true,
+				candidate_model: "z-ai/glm-5.2",
+				incumbent_model: "openai/gpt-5.4",
+				keep_incumbent: false,
+				light_call_usd: 0.02,
+				switch_back_penalty_usd: 0.01,
+				light_usd: 0.04,
+				incumbent_usd: 0.12,
+				savings_usd: 0.08,
+				savings_ratio: 0.67,
+			},
+			features: {
+				schema_version: 1,
+				message_count: 4,
+				user_instruction_count: 1,
+				assistant_message_count: 2,
+				tool_result_count: 1,
+				tool_failure_count: 0,
+				total_chars: 1200,
+				user_instruction_chars: 300,
+				has_tools: true,
+				history_tokens: 420,
+				incumbent_state_unavailable: false,
+				incumbent_cache_status_known: true,
+				incumbent_cold_likely: false,
+			},
+		}
+		const traces = parseRouteTraces(`${JSON.stringify(coreLine)}\n`)
+		expect(traces[0]?.source).toBe("core")
+		expect(traces[0]?.features?.historyTokens).toBe(420)
+
+		const matched = matchRouteTraces(traces, {
+			requestedModel: "cline/auto",
+			taskHash: hashPrivateIdentifier("cline-bench-task", "harbor-task-slug"),
+			sessionHash: identity?.sessionHash ?? null,
+			sessionIdSha256: identity?.sessionIdSha256 ?? null,
+		})
+		expect(matched).toHaveLength(1)
+		expect(
+			matchRouteTraces(traces, {
+				requestedModel: "cline/auto",
+				taskHash: hashPrivateIdentifier("cline-bench-task", "harbor-task-slug"),
+				sessionHash: identity?.sessionHash ?? null,
+				sessionIdSha256: sha256("different-session"),
+			}),
+		).toHaveLength(0)
+		expect(JSON.stringify({ identity, traces })).not.toContain(sessionId)
 	})
 })

--- a/evals/e2e/run-cline-bench-pilot.test.ts
+++ b/evals/e2e/run-cline-bench-pilot.test.ts
@@ -314,7 +314,7 @@ describe("Cline benchmark configuration and matrix", () => {
 		const checkpoint = readConfig(join(import.meta.dir, "cline-bench-router-checkpoint.config.json"))
 		const matrix = buildRunMatrix(checkpoint)
 		expect(checkpoint.clineVersion).toBe("3.0.46-nightly.1784896623")
-		expect(checkpoint.localCoreRevision).toBe("587ebe82b3a2337b229d22ed097051215ba145f8")
+		expect(checkpoint.localCoreRevision).toBe("9799914fa0e0082d27d72267f11eb959975706d0")
 		expect(matrix).toHaveLength(24)
 		expect(new Set(checkpoint.tasks).size).toBe(8)
 		expect(matrix.filter((run) => run.model.id === "cline/auto")).toHaveLength(8)

--- a/evals/e2e/run-cline-bench-pilot.test.ts
+++ b/evals/e2e/run-cline-bench-pilot.test.ts
@@ -27,7 +27,9 @@ import {
 	type PilotConfig,
 	prepareTaskPath,
 	readConfig,
+	readRecoveredFailedRun,
 	readTrialSessionIdentity,
+	reuseCompletedRun,
 	verifierHarborArguments,
 } from "./run-cline-bench-pilot"
 
@@ -292,7 +294,7 @@ describe("Cline benchmark lock and budget ledger", () => {
 })
 
 describe("Cline benchmark recovery, privacy, and routing evidence", () => {
-	test("recovers timestamp-max usage and rejects multiple attempts", () => {
+	test("recovers the latest cumulative run_result usage and rejects ambiguous or incomplete telemetry", () => {
 		const usage = (ts: string, totalCost: number) =>
 			JSON.stringify({
 				ts,
@@ -304,9 +306,152 @@ describe("Cline benchmark recovery, privacy, and routing evidence", () => {
 					totalOutputTokens: 2,
 				},
 			})
-		const latest = recoverLatestUsage([`${usage("2026-01-01T00:00:02Z", 2)}\n${usage("2026-01-01T00:00:01Z", 1)}\n`])
-		expect(latest.totalCost).toBe(2)
+		const runResult = JSON.stringify({
+			ts: "2026-01-01T00:00:03Z",
+			type: "run_result",
+			finishReason: "error",
+			usage: {
+				inputTokens: 20,
+				cacheReadTokens: 8,
+				outputTokens: 3,
+				totalCost: 2.5,
+			},
+			aggregateUsage: {
+				inputTokens: 30,
+				cacheReadTokens: 12,
+				outputTokens: 4,
+				totalCost: 3,
+			},
+		})
+		const latest = recoverLatestUsage([
+			`${usage("2026-01-01T00:00:02Z", 2)}\n${usage("2026-01-01T00:00:01Z", 1)}\n${runResult}\n`,
+		])
+		expect(latest).toEqual({
+			timestamp: "2026-01-01T00:00:03.000Z",
+			totalCost: 3,
+			totalInputTokens: 30,
+			totalCacheReadTokens: 12,
+			totalOutputTokens: 4,
+		})
 		expect(() => recoverLatestUsage(["{}", "{}"])).toThrow("exactly one attempt")
+		expect(() =>
+			recoverLatestUsage([
+				`${usage("2026-01-01T00:00:02Z", 2)}\n${usage("2026-01-01T00:00:02Z", 3)}\n`,
+			]),
+		).toThrow(/non-monotonic|ambiguous/)
+		expect(() =>
+			recoverLatestUsage([
+				JSON.stringify({
+					ts: "2026-01-01T00:00:02Z",
+					type: "run_result",
+					aggregateUsage: { inputTokens: 10, cacheReadTokens: 5, totalCost: 1 },
+				}),
+			]),
+		).toThrow("malformed usage record")
+	})
+
+	test("records an ApiRateLimitError as failed, settles its reservation, and reuses it without respending", () => {
+		const jobsRoot = mkdtempSync(join(tmpdir(), "cline-bench-failed-resume-"))
+		temporaryDirectories.push(jobsRoot)
+		const task = "task-a"
+		const model = {
+			id: "cline/auto",
+			perTaskBudgetUsd: 2,
+			perModelBudgetUsd: 2,
+			allowedCandidates: ["z-ai/glm-5.2"],
+		}
+		const failedConfig: PilotConfig = {
+			...config(),
+			models: [model],
+			tasks: [task],
+		}
+		const jobDir = join(jobsRoot, "01-cline-auto-task-a")
+		const trialName = "task-a__cline__attempt-1"
+		const agentDir = join(jobDir, trialName, "agent")
+		mkdirSync(agentDir, { recursive: true })
+		writeFileSync(
+			join(jobDir, "result.json"),
+			JSON.stringify({
+				started_at: "2026-01-01T00:00:00Z",
+				finished_at: "2026-01-01T00:00:04Z",
+				trial_results: [],
+				stats: {
+					n_input_tokens: 30,
+					n_cache_tokens: 12,
+					n_output_tokens: 4,
+					cost_usd: 0.25,
+				},
+			}),
+		)
+		writeFileSync(
+			join(jobDir, trialName, "result.json"),
+			JSON.stringify({
+				task_name: task,
+				started_at: "2026-01-01T00:00:00Z",
+				finished_at: "2026-01-01T00:00:04Z",
+				agent_info: {
+					version: failedConfig.clineVersion,
+					model_info: { name: "auto", provider: "cline:cline" },
+				},
+				exception_info: {
+					exception_type: "ApiRateLimitError",
+					exception_message: "Command failed with private prompt and shell command",
+				},
+				verifier_result: { rewards: { reward: 1 } },
+			}),
+		)
+		writeFileSync(
+			join(agentDir, "cline.txt"),
+			[
+				JSON.stringify({
+					ts: "2026-01-01T00:00:02Z",
+					event: {
+						type: "usage",
+						totalCost: 0.2,
+						totalInputTokens: 20,
+						totalCacheReadTokens: 8,
+						totalOutputTokens: 3,
+					},
+				}),
+				JSON.stringify({
+					ts: "2026-01-01T00:00:03Z",
+					type: "run_result",
+					finishReason: "error",
+					aggregateUsage: {
+						inputTokens: 30,
+						cacheReadTokens: 12,
+						outputTokens: 4,
+						totalCost: 0.25,
+					},
+				}),
+			].join("\n"),
+		)
+
+		const failed = readRecoveredFailedRun(jobDir, failedConfig, model, task)
+		expect(failed.outcome).toBe("failed")
+		expect(failed.passed).toBe(false)
+		expect(failed.reward).toBeNull()
+		expect(failed.failureClassification).toBe("ApiRateLimitError")
+		expect(failed.costUsd).toBe(0.25)
+		expect(failed.inputTokens).toBe(30)
+		expect(failed.cacheTokens).toBe(12)
+		expect(failed.outputTokens).toBe(4)
+		expect(JSON.stringify(failed)).not.toContain("private prompt")
+		expect(JSON.stringify(failed)).not.toContain("shell command")
+
+		let ledger = reserveBudget(createBudgetLedger(10), {
+			runKey: "1:1:cline/auto:task-a",
+			model: model.id,
+			wave: 1,
+			exposureUsd: model.perTaskBudgetUsd,
+		})
+		ledger = settleBudget(ledger, "1:1:cline/auto:task-a", failed.costUsd)
+		expect(ledgerExposure(ledger)).toBe(0.25)
+
+		const resumed = reuseCompletedRun(failedConfig, model, task, jobsRoot, 1)
+		expect(resumed).toEqual(failed)
+		ledger = settleBudget(ledger, "1:1:cline/auto:task-a", resumed?.costUsd || 0)
+		expect(ledgerExposure(ledger)).toBe(0.25)
 	})
 
 	test("redacts all exact secrets and hashes private identifiers", () => {

--- a/evals/e2e/run-cline-bench-pilot.test.ts
+++ b/evals/e2e/run-cline-bench-pilot.test.ts
@@ -378,6 +378,33 @@ describe("Cline benchmark recovery, privacy, and routing evidence", () => {
 			totalCacheReadTokens: 0,
 			totalOutputTokens: 0,
 		})
+		expect(
+			recoverLatestUsage([
+				[
+					JSON.stringify({
+						ts: "2026-01-01T00:00:03Z",
+						type: "agent_event",
+						event: {
+							type: "usage",
+							totalCost: 0,
+							totalInputTokens: 0,
+							totalOutputTokens: 0,
+						},
+					}),
+					JSON.stringify({
+						ts: "2026-01-01T00:00:04Z",
+						type: "run_result",
+						finishReason: "error",
+						aggregateUsage: {
+							inputTokens: 0,
+							cacheReadTokens: 0,
+							outputTokens: 0,
+							totalCost: 0,
+						},
+					}),
+				].join("\n"),
+			]),
+		).toMatchObject({ totalCost: 0 })
 		expect(() =>
 			recoverLatestUsage([
 				JSON.stringify({

--- a/evals/e2e/run-cline-bench-pilot.ts
+++ b/evals/e2e/run-cline-bench-pilot.ts
@@ -431,6 +431,41 @@ type ClineRecommendedCatalog = {
 	clinePass?: unknown
 }
 
+type VersionCommandResult = {
+	status: number | null
+	stdout?: string | Buffer | null
+	stderr?: string | Buffer | null
+	error?: Error
+}
+
+type VersionCommand = (
+	command: string,
+	args: string[],
+	options: { encoding: "utf8"; timeout: number },
+) => VersionCommandResult
+
+export function assertLocalClineVersion(
+	config: PilotConfig,
+	runVersionCommand: VersionCommand = spawnSync,
+): void {
+	const result = runVersionCommand("cline", ["--version"], {
+		encoding: "utf8",
+		timeout: 10_000,
+	})
+	if (result.error || result.status !== 0) {
+		fail("local Cline version preflight failed before jobs-root creation and budget reservation")
+	}
+	const installedVersion = String(result.stdout ?? "").trim()
+	if (!installedVersion || installedVersion.includes("\n") || installedVersion.includes("\r")) {
+		fail("local Cline version preflight returned an invalid version before jobs-root creation and budget reservation")
+	}
+	if (installedVersion !== config.clineVersion) {
+		fail(
+			`local Cline version mismatch before jobs-root creation and budget reservation: expected ${config.clineVersion}, installed ${installedVersion}`,
+		)
+	}
+}
+
 function catalogModelIds(value: unknown, field: string): string[] {
 	if (!Array.isArray(value)) fail(`live Cline catalog has no valid ${field} model list`)
 	return value.map((entry, index) => {
@@ -1797,6 +1832,8 @@ async function main() {
 		return
 	}
 	if (args.execute) {
+		assertLocalClineVersion(config)
+		console.log(`Local Cline ${config.clineVersion} preflight passed before jobs-root creation and budget reservation.`)
 		await assertDirectModelsInLiveCatalog(config)
 		console.log("Live Cline catalog preflight passed before budget reservation.")
 	}

--- a/evals/e2e/run-cline-bench-pilot.ts
+++ b/evals/e2e/run-cline-bench-pilot.ts
@@ -1086,6 +1086,11 @@ export function localCoreHarborArguments(localCoreUrl?: string): string[] {
 	]
 }
 
+export function modelTransportHarborArguments(modelId: string, localCoreUrl?: string): string[] {
+	const usesLocalRouter = modelId === "cline/auto" || modelId === "cline-pass/auto"
+	return usesLocalRouter ? localCoreHarborArguments(localCoreUrl) : []
+}
+
 async function runHarborProcess(args: string[], config: PilotConfig): Promise<HarborProcessResult> {
 	const child = spawn("harbor", args, {
 		cwd: clineBenchDir,
@@ -1213,7 +1218,7 @@ async function runOne(
 		"--yes",
 	]
 	args.push(...verifierHarborArguments())
-	args.push(...localCoreHarborArguments(localCoreUrl))
+	args.push(...modelTransportHarborArguments(model.id, localCoreUrl))
 
 	console.log(`\n[${runNumber}] ${model.id} × ${task}`)
 	const started = Date.now()

--- a/evals/e2e/run-cline-bench-pilot.ts
+++ b/evals/e2e/run-cline-bench-pilot.ts
@@ -118,7 +118,7 @@ export type RunResult = {
 	jobDir: string
 }
 
-type PilotReport = {
+export type PilotReport = {
 	startedAt: string
 	finishedAt?: string
 	mode: "dry-run" | "execute"
@@ -503,6 +503,31 @@ export function assertReusableFingerprint(existing: Partial<PilotReport>, expect
 	}
 	if (existing.executionFingerprint !== expectedFingerprint) {
 		fail("jobs-root belongs to a different execution matrix, cline-bench commit, or effective task corpus")
+	}
+}
+
+export function assertTraceIngestionCompatibility(
+	existing: PilotReport,
+	config: PilotConfig,
+	currentProvenance: ExecutionProvenance,
+) {
+	if (
+		!existing.executionFingerprint ||
+		!existing.executionProvenance ||
+		existing.executionFingerprint !==
+			fingerprintExecution(existing.config, existing.executionProvenance)
+	) {
+		fail("route trace ingestion requires a self-consistent content-addressed pilot report")
+	}
+	const stored = existing.executionProvenance
+	if (
+		JSON.stringify(existing.config) !== JSON.stringify(config) ||
+		JSON.stringify(stored.effectiveConfig) !== JSON.stringify(config) ||
+		JSON.stringify(stored.executionOptions) !== JSON.stringify(currentProvenance.executionOptions) ||
+		stored.clineBenchCommit !== currentProvenance.clineBenchCommit ||
+		JSON.stringify(stored.tasks) !== JSON.stringify(currentProvenance.tasks)
+	) {
+		fail("route trace ingestion does not match the paid run's matrix, endpoint, or task corpus")
 	}
 }
 
@@ -1355,7 +1380,11 @@ async function main() {
 		const existingReportPath = join(jobsRoot, "pilot-report.json")
 		if (existsSync(existingReportPath)) {
 			const existing = JSON.parse(readFileSync(existingReportPath, "utf8")) as Partial<PilotReport>
-			assertReusableFingerprint(existing, fingerprint)
+			if (args.ingestRouteTraces) {
+				assertTraceIngestionCompatibility(existing as PilotReport, config, identity.provenance)
+			} else {
+				assertReusableFingerprint(existing, fingerprint)
+			}
 		} else {
 			const hasUnboundResult = buildRunMatrix(config).some((run, index) => {
 				const jobName = `${String(index + 1).padStart(2, "0")}-${slug(run.model.id)}-${slug(run.task)}`
@@ -1370,7 +1399,6 @@ async function main() {
 		if (args.ingestRouteTraces) {
 			if (!existsSync(existingReportPath)) fail("route trace ingestion requires an existing pilot report")
 			const existing = JSON.parse(readFileSync(existingReportPath, "utf8")) as PilotReport
-			assertReusableFingerprint(existing, fingerprint)
 			existing.results = existing.results.map((result) =>
 				attachRouteEvidence(result, modelForResult(config, result), traces),
 			)

--- a/evals/e2e/run-cline-bench-pilot.ts
+++ b/evals/e2e/run-cline-bench-pilot.ts
@@ -75,16 +75,18 @@ export type PilotConfig = {
 	maxRunsPerModel: number
 	timeoutSeconds: number
 	clineVersion: string
+	localCoreRevision?: string
 	models: ModelConfig[]
 	tasks: string[]
 	waveBudgetsUsd?: Record<string, number>
 }
 
 export type ExecutionProvenance = {
-	schemaVersion: 3
+	schemaVersion: 4
 	runnerContentSha256: string
 	runnerGitCommit: string
 	harborVersion: string
+	localCoreRevision: string | null
 	effectiveConfig: PilotConfig
 	executionOptions: {
 		localCoreUrl: string | null
@@ -129,6 +131,7 @@ export type PilotReport = {
 	config: PilotConfig
 	executionFingerprint: string
 	executionProvenance: ExecutionProvenance
+	localCoreRevision: string | null
 	jobsRoot: string
 	budgetLedger: BudgetLedger
 	results: RunResult[]
@@ -243,6 +246,7 @@ export function readConfig(configPath: string): PilotConfig {
 			"maxRunsPerModel",
 			"timeoutSeconds",
 			"clineVersion",
+			"localCoreRevision",
 			"models",
 			"tasks",
 			"waveBudgetsUsd",
@@ -293,6 +297,7 @@ export function readConfig(configPath: string): PilotConfig {
 		maxRunsPerModel: raw.maxRunsPerModel,
 		timeoutSeconds: raw.timeoutSeconds,
 		clineVersion: raw.clineVersion,
+		...(raw.localCoreRevision !== undefined ? { localCoreRevision: raw.localCoreRevision } : {}),
 		models,
 		tasks: [...raw.tasks],
 		...(raw.waveBudgetsUsd !== undefined ? { waveBudgetsUsd: raw.waveBudgetsUsd } : {}),
@@ -319,6 +324,12 @@ export function readConfig(configPath: string): PilotConfig {
 	}
 	if (typeof config.clineVersion !== "string" || !/^\d+\.\d+\.\d+(?:[-+][a-zA-Z0-9.-]+)?$/.test(config.clineVersion)) {
 		fail("clineVersion must be pinned")
+	}
+	if (config.localCoreRevision !== undefined && !/^[0-9a-f]{40}$/.test(config.localCoreRevision)) {
+		fail("localCoreRevision must be an exact 40-character lowercase hexadecimal Git commit")
+	}
+	if (config.models.some((model) => model.transport === "local-core") && !config.localCoreRevision) {
+		fail("localCoreRevision is required when any model uses transport=local-core")
 	}
 	const seenModels = new Set<string>()
 	for (const model of config.models) {
@@ -612,6 +623,7 @@ export function fingerprintExecution(config: PilotConfig, provenance: ExecutionP
 		runnerContentSha256: provenance.runnerContentSha256,
 		runnerGitCommit: provenance.runnerGitCommit,
 		harborVersion: provenance.harborVersion,
+		localCoreRevision: provenance.localCoreRevision,
 		executionOptions: provenance.executionOptions,
 		clineBenchCommit: provenance.clineBenchCommit,
 		effectiveTasks: provenance.tasks,
@@ -624,7 +636,9 @@ export function assertReusableFingerprint(existing: Partial<PilotReport>, expect
 		fail("jobs-root report predates content-addressed task fingerprints; use a new jobs-root")
 	}
 	if (existing.executionFingerprint !== expectedFingerprint) {
-		fail("jobs-root belongs to a different execution matrix, cline-bench commit, or effective task corpus")
+		fail(
+			"jobs-root belongs to a different execution matrix, local Core revision, cline-bench commit, or effective task corpus",
+		)
 	}
 }
 
@@ -645,6 +659,7 @@ export function assertTraceIngestionCompatibility(
 	if (
 		JSON.stringify(existing.config) !== JSON.stringify(config) ||
 		JSON.stringify(stored.effectiveConfig) !== JSON.stringify(config) ||
+		stored.localCoreRevision !== currentProvenance.localCoreRevision ||
 		JSON.stringify(stored.executionOptions) !== JSON.stringify(currentProvenance.executionOptions) ||
 		stored.clineBenchCommit !== currentProvenance.clineBenchCommit ||
 		JSON.stringify(stored.tasks) !== JSON.stringify(currentProvenance.tasks)
@@ -679,7 +694,7 @@ function commandOutput(command: string, args: string[], label: string, pattern: 
 
 function executionIdentity(config: PilotConfig, jobsRoot: string, localCoreUrl?: string) {
 	const provenance: ExecutionProvenance = {
-		schemaVersion: 3,
+		schemaVersion: 4,
 		runnerContentSha256: sha256(
 			`${readFileSync(fileURLToPath(import.meta.url), "utf8")}\0${readFileSync(join(scriptDir, "cline-bench-safety.ts"), "utf8")}`,
 		),
@@ -690,6 +705,7 @@ function executionIdentity(config: PilotConfig, jobsRoot: string, localCoreUrl?:
 			/^[0-9a-f]{40,64}$/,
 		),
 		harborVersion: commandOutput("harbor", ["--version"], "Harbor version", /^[0-9]+\.[0-9]+\.[0-9]+/),
+		localCoreRevision: config.localCoreRevision ?? null,
 		effectiveConfig: config,
 		executionOptions: {
 			localCoreUrl: localCoreUrl ?? null,
@@ -1819,6 +1835,9 @@ function writeBudgetLedger(jobsRoot: string, ledger: BudgetLedger) {
 function printMatrix(config: PilotConfig) {
 	console.log(`Router profile: ${config.routerProfile}`)
 	console.log(`Provider: ${config.provider}`)
+	if (config.localCoreRevision) {
+		console.log(`Local Core revision: ${config.localCoreRevision}`)
+	}
 	console.log(
 		`Limits: ${config.maxRunsPerModel} runs/model, $${config.globalBudgetUsd.toFixed(2)} global, ${config.timeoutSeconds}s/task`,
 	)
@@ -1929,6 +1948,7 @@ async function main() {
 			config,
 			executionFingerprint: fingerprint,
 			executionProvenance: identity.provenance,
+			localCoreRevision: identity.provenance.localCoreRevision,
 			jobsRoot,
 			budgetLedger,
 			results: [],

--- a/evals/e2e/run-cline-bench-pilot.ts
+++ b/evals/e2e/run-cline-bench-pilot.ts
@@ -1,0 +1,651 @@
+#!/usr/bin/env bun
+
+/**
+ * Cost-guarded Cline benchmark pilot.
+ *
+ * This runner intentionally differs from run-cline-bench.ts:
+ * - dry-run is the default; paid execution requires --execute
+ * - exactly one task runs at a time, once
+ * - only an allowlist of host environment variables reaches Harbor
+ * - task/model/global budget checks stop subsequent work
+ * - jobs and reports live outside the repository with private permissions
+ *
+ * Harbor/Cline currently reports cost only after an agent run finishes. The
+ * per-task budget is therefore a stop-after-run guard, while the wall timeout
+ * is the proactive bound during a run.
+ */
+
+import { spawnSync } from "node:child_process"
+import { chmodSync, existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs"
+import { homedir, tmpdir } from "node:os"
+import { dirname, isAbsolute, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+type ModelConfig = {
+	id: string
+	perTaskBudgetUsd: number
+	perModelBudgetUsd: number
+	pricing?: {
+		inputPerMTok: number
+		cachedInputPerMTok: number
+		outputPerMTok: number
+	}
+}
+
+type PilotConfig = {
+	routerProfile: "cline-router" | "cline-pass-router"
+	provider: string
+	globalBudgetUsd: number
+	maxRunsPerModel: number
+	timeoutSeconds: number
+	clineVersion: string
+	models: ModelConfig[]
+	tasks: string[]
+}
+
+type RunResult = {
+	model: string
+	task: string
+	outcome: "passed" | "failed" | "timed_out"
+	passed: boolean
+	reward: number | null
+	costUsd: number
+	costBasis: "reported-inference" | "cline-pass-reference-quota"
+	durationSeconds: number
+	inputTokens: number | null
+	cacheTokens: number | null
+	outputTokens: number | null
+	cacheReadRatio: number | null
+	estimatedTokenCostUsd: number | null
+	coldEquivalentCostUsd: number | null
+	estimatedCacheSavingsUsd: number | null
+	jobDir: string
+}
+
+type PilotReport = {
+	startedAt: string
+	finishedAt?: string
+	mode: "dry-run" | "execute"
+	config: PilotConfig
+	jobsRoot: string
+	results: RunResult[]
+	stoppedReason?: string
+}
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(scriptDir, "../..")
+const clineBenchDir = join(repoRoot, "evals/cline-bench")
+const defaultConfigPath = join(scriptDir, "cline-bench-pilot.config.json")
+
+function fail(message: string): never {
+	throw new Error(message)
+}
+
+function parseArgs(argv: string[]) {
+	let execute = false
+	let configPath = defaultConfigPath
+	let jobsRoot: string | undefined
+	let stopAfter: number | undefined
+	let onlyRun: number | undefined
+
+	for (let index = 0; index < argv.length; index += 1) {
+		const arg = argv[index]
+		if (arg === "--execute") {
+			execute = true
+		} else if (arg === "--dry-run") {
+			execute = false
+		} else if (arg === "--config") {
+			configPath = argv[++index] ?? fail("--config requires a path")
+		} else if (arg === "--jobs-root") {
+			jobsRoot = argv[++index] ?? fail("--jobs-root requires a path")
+		} else if (arg === "--stop-after") {
+			stopAfter = Number(argv[++index] ?? fail("--stop-after requires a run number"))
+			if (!Number.isInteger(stopAfter) || stopAfter < 1) fail("--stop-after must be a positive integer")
+		} else if (arg === "--only-run") {
+			onlyRun = Number(argv[++index] ?? fail("--only-run requires a run number"))
+			if (!Number.isInteger(onlyRun) || onlyRun < 1) fail("--only-run must be a positive integer")
+		} else if (arg === "--help" || arg === "-h") {
+			console.log(`Usage: bun evals/e2e/run-cline-bench-pilot.ts [options]
+
+Options:
+  --dry-run           Validate and print the run matrix (default)
+  --execute           Run paid model calls
+  --config <path>     JSON configuration file
+  --jobs-root <path>  Private output directory outside the repository
+  --stop-after <n>    Stop cleanly after matrix run n
+  --only-run <n>      Reuse prior work but execute only matrix run n
+  --help              Show this help`)
+			process.exit(0)
+		} else {
+			fail(`Unknown argument: ${arg}`)
+		}
+	}
+
+	if (stopAfter && onlyRun) fail("--stop-after and --only-run cannot be combined")
+	return { execute, configPath: resolve(configPath), jobsRoot, stopAfter, onlyRun }
+}
+
+function readConfig(configPath: string): PilotConfig {
+	const config = JSON.parse(readFileSync(configPath, "utf8")) as PilotConfig
+	if (config.routerProfile !== "cline-router" && config.routerProfile !== "cline-pass-router") {
+		fail("routerProfile must be cline-router or cline-pass-router")
+	}
+	if (!config.provider?.trim()) fail("provider must be configured")
+	if (!Number.isFinite(config.globalBudgetUsd) || config.globalBudgetUsd <= 0 || config.globalBudgetUsd >= 100) {
+		fail("globalBudgetUsd must be greater than 0 and less than 100")
+	}
+	if (!Number.isInteger(config.maxRunsPerModel) || config.maxRunsPerModel < 1 || config.maxRunsPerModel >= 100) {
+		fail("maxRunsPerModel must be an integer from 1 through 99")
+	}
+	if (!Number.isFinite(config.timeoutSeconds) || config.timeoutSeconds < 60 || config.timeoutSeconds > 1800) {
+		fail("timeoutSeconds must be between 60 and 1800")
+	}
+	if (!/^\d+\.\d+\.\d+(?:[-+][a-zA-Z0-9.-]+)?$/.test(config.clineVersion)) fail("clineVersion must be pinned")
+	if (!Array.isArray(config.models) || config.models.length === 0) fail("at least one model is required")
+	if (!Array.isArray(config.tasks) || config.tasks.length === 0) fail("at least one task is required")
+	if (config.tasks.length > config.maxRunsPerModel) {
+		fail(`configured ${config.tasks.length} tasks, exceeding maxRunsPerModel=${config.maxRunsPerModel}`)
+	}
+
+	const seenModels = new Set<string>()
+	for (const model of config.models) {
+		if (!model.id?.trim() || model.id.includes(":")) {
+			fail(`invalid Cline model id: ${JSON.stringify(model.id)}`)
+		}
+		if (seenModels.has(model.id)) fail(`duplicate model: ${model.id}`)
+		seenModels.add(model.id)
+		if (config.routerProfile === "cline-pass-router" && !model.id.startsWith("cline-pass/")) {
+			fail(`cline-pass-router model must use a public cline-pass/* id: ${model.id}`)
+		}
+		if (
+			!Number.isFinite(model.perTaskBudgetUsd) ||
+			model.perTaskBudgetUsd <= 0 ||
+			model.perTaskBudgetUsd >= 100
+		) {
+			fail(`invalid per-task budget for ${model.id}`)
+		}
+		if (
+			!Number.isFinite(model.perModelBudgetUsd) ||
+			model.perModelBudgetUsd <= 0 ||
+			model.perModelBudgetUsd >= 100
+		) {
+			fail(`per-model budget for ${model.id} must be greater than 0 and less than 100`)
+		}
+		if (model.perModelBudgetUsd > config.globalBudgetUsd) {
+			fail(`per-model budget for ${model.id} exceeds the global budget`)
+		}
+		if (model.pricing) {
+			for (const [field, value] of Object.entries(model.pricing)) {
+				if (!Number.isFinite(value) || value < 0) {
+					fail(`invalid ${field} pricing for ${model.id}`)
+				}
+			}
+			if (model.pricing.inputPerMTok <= 0 || model.pricing.outputPerMTok <= 0) {
+				fail(`input and output pricing must be positive for ${model.id}`)
+			}
+		}
+	}
+
+	for (const task of config.tasks) {
+		if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]+$/.test(task)) fail(`invalid task id: ${JSON.stringify(task)}`)
+		const taskDir = join(clineBenchDir, "tasks", task)
+		if (!existsSync(join(taskDir, "task.toml")) || !existsSync(join(taskDir, "instruction.md"))) {
+			fail(`task is missing or incomplete: ${task}`)
+		}
+	}
+
+	return config
+}
+
+function commandExists(command: string): boolean {
+	return spawnSync("which", [command], { encoding: "utf8" }).status === 0
+}
+
+function validatePrerequisites(execute: boolean) {
+	if (!existsSync(clineBenchDir)) fail(`cline-bench submodule is missing: ${clineBenchDir}`)
+	if (!commandExists("harbor")) fail("Harbor is not installed")
+	if (!commandExists("docker")) fail("Docker is not installed")
+	if (execute) {
+		const docker = spawnSync("docker", ["info"], { stdio: "ignore", timeout: 15_000 })
+		if (docker.status !== 0) fail("Docker is not running")
+		if (!process.env.CLINE_API_KEY?.trim()) {
+			fail("CLINE_API_KEY must be inherited from the shell for --execute")
+		}
+	}
+}
+
+function createPrivateJobsRoot(requested?: string): string {
+	const runId = new Date().toISOString().replace(/[:.]/g, "-")
+	const base = requested
+		? resolve(requested)
+		: join(process.env.XDG_CACHE_HOME || join(homedir(), ".cache"), "cline-auto-sdlc-bench", runId)
+	if (base === repoRoot || base.startsWith(`${repoRoot}/`)) {
+		fail("jobs-root must be outside the repository")
+	}
+	mkdirSync(base, { recursive: true, mode: 0o700 })
+	chmodSync(base, 0o700)
+	return base
+}
+
+function safeEnvironment(provider: string): NodeJS.ProcessEnv {
+	const allowedNames = [
+		"CLINE_API_KEY",
+		"DOCKER_CONFIG",
+		"DOCKER_CONTEXT",
+		"DOCKER_HOST",
+		"HOME",
+		"LANG",
+		"LC_ALL",
+		"PATH",
+		"SSL_CERT_FILE",
+		"TMPDIR",
+		"XDG_RUNTIME_DIR",
+	] as const
+	const env: NodeJS.ProcessEnv = {}
+	for (const name of allowedNames) {
+		if (process.env[name]) env[name] = process.env[name]
+	}
+	env.HOME ||= homedir()
+	env.PATH ||= process.env.PATH
+	env.TMPDIR ||= tmpdir()
+	// Harbor's Cline adapter has a named CLINE_API_KEY mapping for the regular
+	// `cline` provider. ClinePass is a distinct CLI provider and currently
+	// falls back to API_KEY, so derive that scoped alias from the same env-only
+	// credential without accepting a broad host API_KEY.
+	if (provider === "cline-pass" && process.env.CLINE_API_KEY) {
+		env.API_KEY = process.env.CLINE_API_KEY
+	}
+	return env
+}
+
+function buildRunMatrix(config: PilotConfig) {
+	const runs: Array<{ model: ModelConfig; task: string }> = []
+	for (let round = 0; round < config.tasks.length; round += 1) {
+		for (let modelIndex = 0; modelIndex < config.models.length; modelIndex += 1) {
+			const taskIndex = (round + modelIndex) % config.tasks.length
+			runs.push({ model: config.models[modelIndex], task: config.tasks[taskIndex] })
+		}
+	}
+	return runs
+}
+
+function slug(value: string): string {
+	return value.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 80)
+}
+
+function redact(value: string, secret: string): string {
+	return secret ? value.split(secret).join("[REDACTED]") : value
+}
+
+function findTrialResult(jobDir: string): any {
+	for (const entry of readdirSync(jobDir, { withFileTypes: true })) {
+		if (!entry.isDirectory()) continue
+		const nestedResultPath = join(jobDir, entry.name, "result.json")
+		if (existsSync(nestedResultPath)) return JSON.parse(readFileSync(nestedResultPath, "utf8"))
+	}
+	return null
+}
+
+function tokenEconomics(
+	model: ModelConfig,
+	inputTokens: number | null,
+	cacheTokens: number | null,
+	outputTokens: number | null,
+) {
+	const cacheReadRatio =
+		inputTokens !== null && cacheTokens !== null && inputTokens > 0 ? cacheTokens / inputTokens : null
+	if (
+		!model.pricing ||
+		inputTokens === null ||
+		cacheTokens === null ||
+		outputTokens === null
+	) {
+		return {
+			cacheReadRatio,
+			estimatedTokenCostUsd: null,
+			coldEquivalentCostUsd: null,
+			estimatedCacheSavingsUsd: null,
+		}
+	}
+	const cached = Math.min(Math.max(cacheTokens, 0), inputTokens)
+	const uncached = inputTokens - cached
+	const estimatedTokenCostUsd =
+		(uncached * model.pricing.inputPerMTok +
+			cached * model.pricing.cachedInputPerMTok +
+			outputTokens * model.pricing.outputPerMTok) /
+		1_000_000
+	const coldEquivalentCostUsd =
+		(inputTokens * model.pricing.inputPerMTok + outputTokens * model.pricing.outputPerMTok) /
+		1_000_000
+	return {
+		cacheReadRatio,
+		estimatedTokenCostUsd,
+		coldEquivalentCostUsd,
+		estimatedCacheSavingsUsd: Math.max(0, coldEquivalentCostUsd - estimatedTokenCostUsd),
+	}
+}
+
+function readJobResult(
+	jobDir: string,
+	provider: string,
+	routerProfile: PilotConfig["routerProfile"],
+	model: ModelConfig,
+	durationSeconds: number,
+): RunResult {
+	const resultPath = join(jobDir, "result.json")
+	if (!existsSync(resultPath)) fail(`Harbor did not write ${resultPath}`)
+	const doc = JSON.parse(readFileSync(resultPath, "utf8")) as any
+	const trial = doc.trial_results?.[0] || findTrialResult(jobDir)
+	if (!trial) fail(`Harbor result has no nested trial: ${resultPath}`)
+	const exceptionType = trial.exception_info?.exception_type
+	const timedOut = exceptionType === "AgentTimeoutError"
+	if (trial.exception_info && !timedOut) {
+		fail(
+			`Harbor trial failed with ${trial.exception_info.exception_type}: ${trial.exception_info.exception_message}`,
+		)
+	}
+
+	const servedModel = trial.agent_info?.model_info?.name
+	const servedProvider = trial.agent_info?.model_info?.provider
+	const expectedModel = model.id
+	const [expectedVendor, ...expectedNameParts] = expectedModel.split("/")
+	const expectedName = expectedNameParts.join("/")
+	const exactSplitMatch = servedProvider === `${provider}:${expectedVendor}` && servedModel === expectedName
+	const acceptedCombinedNames = new Set([expectedModel, `${provider}:${expectedModel}`])
+	if (!exactSplitMatch && !acceptedCombinedNames.has(servedModel)) {
+		fail(
+			`served-model mismatch: expected ${expectedModel}, result recorded provider=${JSON.stringify(servedProvider)} model=${JSON.stringify(servedModel)}`,
+		)
+	}
+
+	const costUsd = doc.stats?.cost_usd
+	if (!Number.isFinite(costUsd) || costUsd <= 0) {
+		fail(`missing or zero cost telemetry for ${expectedModel}`)
+	}
+
+	const rewards = trial.verifier_result?.rewards
+	const rewardValues = rewards && typeof rewards === "object" ? Object.values(rewards) : []
+	const numericRewards = rewardValues.filter((value): value is number => typeof value === "number")
+	const reward = numericRewards.length > 0 ? Math.max(...numericRewards) : null
+	const trialStarted = Date.parse(trial.started_at)
+	const trialFinished = Date.parse(trial.finished_at)
+	const measuredDurationSeconds =
+		durationSeconds > 0
+			? durationSeconds
+			: Number.isFinite(trialStarted) && Number.isFinite(trialFinished)
+				? (trialFinished - trialStarted) / 1000
+				: 0
+
+	const inputTokens = doc.stats?.n_input_tokens ?? null
+	const cacheTokens = doc.stats?.n_cache_tokens ?? null
+	const outputTokens = doc.stats?.n_output_tokens ?? null
+	return {
+		model: expectedModel,
+		task: trial.task_name,
+		outcome: timedOut ? "timed_out" : reward === 1 ? "passed" : "failed",
+		passed: reward === 1,
+		reward,
+		costUsd,
+		costBasis:
+			routerProfile === "cline-pass-router"
+				? "cline-pass-reference-quota"
+				: "reported-inference",
+		durationSeconds: measuredDurationSeconds,
+		inputTokens,
+		cacheTokens,
+		outputTokens,
+		...tokenEconomics(model, inputTokens, cacheTokens, outputTokens),
+		jobDir,
+	}
+}
+
+function readInterruptedRun(
+	jobDir: string,
+	routerProfile: PilotConfig["routerProfile"],
+	model: ModelConfig,
+	task: string,
+): RunResult {
+	const rootResult = JSON.parse(readFileSync(join(jobDir, "result.json"), "utf8")) as any
+	const startedAt = Date.parse(rootResult.started_at)
+	let latestUsage: any = null
+	let latestUsageAt: number | null = null
+	for (const entry of readdirSync(jobDir, { withFileTypes: true })) {
+		if (!entry.isDirectory()) continue
+		const clineLog = join(jobDir, entry.name, "agent", "cline.txt")
+		if (!existsSync(clineLog)) continue
+		for (const line of readFileSync(clineLog, "utf8").split("\n")) {
+			if (!line.startsWith("{") || !line.includes('"type":"usage"')) continue
+			try {
+				const parsed = JSON.parse(line)
+				if (parsed.event?.type === "usage") {
+					latestUsage = parsed.event
+					const parsedTimestamp = Date.parse(parsed.ts)
+					latestUsageAt = Number.isFinite(parsedTimestamp) ? parsedTimestamp : latestUsageAt
+				}
+			} catch {
+				// Ignore partial JSON from a force-stopped final line.
+			}
+		}
+	}
+	const costUsd = latestUsage?.totalCost
+	if (!Number.isFinite(costUsd) || costUsd <= 0) {
+		fail(`interrupted run has no usable cost telemetry: ${jobDir}`)
+	}
+	const inputTokens = latestUsage?.totalInputTokens ?? null
+	const cacheTokens = latestUsage?.totalCacheReadTokens ?? null
+	const outputTokens = latestUsage?.totalOutputTokens ?? null
+	return {
+		model: model.id,
+		task,
+		outcome: "timed_out",
+		passed: false,
+		reward: null,
+		costUsd,
+		costBasis:
+			routerProfile === "cline-pass-router"
+				? "cline-pass-reference-quota"
+				: "reported-inference",
+		durationSeconds:
+			Number.isFinite(startedAt) && latestUsageAt !== null ? (latestUsageAt - startedAt) / 1000 : 0,
+		inputTokens,
+		cacheTokens,
+		outputTokens,
+		...tokenEconomics(model, inputTokens, cacheTokens, outputTokens),
+		jobDir,
+	}
+}
+
+function taskAgentTimeoutSeconds(task: string): number {
+	const taskToml = readFileSync(join(clineBenchDir, "tasks", task, "task.toml"), "utf8")
+	const agentSection = taskToml.match(/\[agent\]([\s\S]*?)(?:\n\[|$)/)?.[1] || ""
+	const configuredTimeout = Number(agentSection.match(/timeout_sec\s*=\s*([0-9.]+)/)?.[1])
+	if (!Number.isFinite(configuredTimeout) || configuredTimeout <= 0) {
+		fail(`task ${task} has no valid [agent].timeout_sec`)
+	}
+	return configuredTimeout
+}
+
+function runOne(
+	config: PilotConfig,
+	model: ModelConfig,
+	task: string,
+	jobsRoot: string,
+	runNumber: number,
+): RunResult {
+	const jobName = `${String(runNumber).padStart(2, "0")}-${slug(model.id)}-${slug(task)}`
+	const jobDir = join(jobsRoot, jobName)
+	const harborModel = `${config.provider}:${model.id}`
+	const timeoutMultiplier = Math.min(1, config.timeoutSeconds / taskAgentTimeoutSeconds(task))
+	const args = [
+		"run",
+		"-p",
+		`tasks/${task}`,
+		"-a",
+		"cline-cli",
+		"-m",
+		harborModel,
+		"--env",
+		"docker",
+		"-n",
+		"1",
+		"-k",
+		"1",
+		"--max-retries",
+		"0",
+		"--agent-timeout-multiplier",
+		timeoutMultiplier.toFixed(6),
+		"--ak",
+		`timeout=${config.timeoutSeconds}`,
+		"--ak",
+		`cline-version=${config.clineVersion}`,
+		"--job-name",
+		jobName,
+		"--jobs-dir",
+		jobsRoot,
+		"--yes",
+	]
+
+	console.log(`\n[${runNumber}] ${model.id} × ${task}`)
+	const started = Date.now()
+	const result = spawnSync("harbor", args, {
+		cwd: clineBenchDir,
+		env: safeEnvironment(config.provider),
+		encoding: "utf8",
+		timeout: (config.timeoutSeconds + 15 * 60) * 1000,
+		maxBuffer: 20 * 1024 * 1024,
+	})
+	const durationSeconds = (Date.now() - started) / 1000
+	const secret = process.env.CLINE_API_KEY || ""
+	const sanitizedOutput = redact(`${result.stdout || ""}\n${result.stderr || ""}`, secret)
+	mkdirSync(jobDir, { recursive: true, mode: 0o700 })
+	writeFileSync(join(jobDir, "harbor-console.log"), sanitizedOutput, { mode: 0o600 })
+
+	if (result.error) fail(`Harbor failed for ${model.id} × ${task}: ${result.error.message}`)
+	if (result.status !== 0) {
+		const tail = sanitizedOutput.trim().split("\n").slice(-20).join("\n")
+		fail(`Harbor exited ${result.status} for ${model.id} × ${task}\n${tail}`)
+	}
+	return readJobResult(jobDir, config.provider, config.routerProfile, model, durationSeconds)
+}
+
+function reuseCompletedRun(
+	config: PilotConfig,
+	model: ModelConfig,
+	task: string,
+	jobsRoot: string,
+	runNumber: number,
+): RunResult | null {
+	const jobName = `${String(runNumber).padStart(2, "0")}-${slug(model.id)}-${slug(task)}`
+	const jobDir = join(jobsRoot, jobName)
+	if (!existsSync(join(jobDir, "result.json"))) return null
+	const rootResult = JSON.parse(readFileSync(join(jobDir, "result.json"), "utf8")) as any
+	if (!rootResult.finished_at && rootResult.stats?.n_running_trials > 0) {
+		const interrupted = readInterruptedRun(jobDir, config.routerProfile, model, task)
+		console.log(`\n[${runNumber}] recording interrupted ${model.id} × ${task} as timed out`)
+		console.log(`  cost=$${interrupted.costUsd.toFixed(4)}`)
+		return interrupted
+	}
+	const result = readJobResult(jobDir, config.provider, config.routerProfile, model, 0)
+	console.log(`\n[${runNumber}] reusing completed ${model.id} × ${task}`)
+	console.log(`  outcome=${result.outcome} reward=${result.reward ?? "missing"} cost=$${result.costUsd.toFixed(4)}`)
+	return result
+}
+
+function writeReport(report: PilotReport) {
+	writeFileSync(join(report.jobsRoot, "pilot-report.json"), `${JSON.stringify(report, null, 2)}\n`, { mode: 0o600 })
+}
+
+function printMatrix(config: PilotConfig) {
+	console.log(`Router profile: ${config.routerProfile}`)
+	console.log(`Provider: ${config.provider}`)
+	console.log(
+		`Limits: ${config.maxRunsPerModel} runs/model, $${config.globalBudgetUsd.toFixed(2)} global, ${config.timeoutSeconds}s/task`,
+	)
+	for (const model of config.models) {
+		console.log(
+			`  ${model.id}: $${model.perTaskBudgetUsd.toFixed(2)}/task stop, $${model.perModelBudgetUsd.toFixed(2)}/model stop`,
+		)
+	}
+	console.log("Latin-square run order:")
+	for (const [index, run] of buildRunMatrix(config).entries()) {
+		console.log(`  ${index + 1}. ${run.model.id} × ${run.task}`)
+	}
+}
+
+function main() {
+	const args = parseArgs(process.argv.slice(2))
+	const config = readConfig(args.configPath)
+	validatePrerequisites(args.execute)
+	printMatrix(config)
+	if (!args.execute) {
+		console.log("\nDry run complete. No model was called. Pass --execute to spend.")
+		return
+	}
+
+	const jobsRoot = createPrivateJobsRoot(args.jobsRoot)
+	const report: PilotReport = {
+		startedAt: new Date().toISOString(),
+		mode: "execute",
+		config,
+		jobsRoot,
+		results: [],
+	}
+	const modelSpend = new Map(config.models.map((model) => [model.id, 0]))
+	let globalSpend = 0
+
+	try {
+		for (const [index, run] of buildRunMatrix(config).entries()) {
+			if (args.stopAfter && index + 1 > args.stopAfter) {
+				report.stoppedReason = `operator stop-after ${args.stopAfter}`
+				break
+			}
+			const reused = reuseCompletedRun(config, run.model, run.task, jobsRoot, index + 1)
+			if (reused) {
+				report.results.push(reused)
+				modelSpend.set(run.model.id, (modelSpend.get(run.model.id) || 0) + reused.costUsd)
+				globalSpend += reused.costUsd
+				writeReport(report)
+				continue
+			}
+			if (args.onlyRun && index + 1 !== args.onlyRun) continue
+			const currentModelSpend = modelSpend.get(run.model.id) || 0
+			if (currentModelSpend >= run.model.perModelBudgetUsd) {
+				fail(`${run.model.id} reached its $${run.model.perModelBudgetUsd.toFixed(2)} model budget`)
+			}
+			if (globalSpend >= config.globalBudgetUsd) {
+				fail(`pilot reached its $${config.globalBudgetUsd.toFixed(2)} global budget`)
+			}
+
+			const result = runOne(config, run.model, run.task, jobsRoot, index + 1)
+			report.results.push(result)
+			modelSpend.set(run.model.id, currentModelSpend + result.costUsd)
+			globalSpend += result.costUsd
+			writeReport(report)
+			console.log(
+				`  outcome=${result.outcome} reward=${result.reward ?? "missing"} cost=$${result.costUsd.toFixed(4)} duration=${result.durationSeconds.toFixed(1)}s`,
+			)
+
+			if (result.costUsd > run.model.perTaskBudgetUsd) {
+				fail(
+					`${run.model.id} exceeded its $${run.model.perTaskBudgetUsd.toFixed(2)} per-task stop after ${run.task}`,
+				)
+			}
+			if ((modelSpend.get(run.model.id) || 0) > run.model.perModelBudgetUsd) {
+				fail(`${run.model.id} exceeded its $${run.model.perModelBudgetUsd.toFixed(2)} model budget`)
+			}
+			if (globalSpend > config.globalBudgetUsd) {
+				fail(`pilot exceeded its $${config.globalBudgetUsd.toFixed(2)} global budget`)
+			}
+		}
+		if (args.onlyRun) report.stoppedReason = `operator only-run ${args.onlyRun}`
+	} catch (error) {
+		report.stoppedReason = error instanceof Error ? error.message : String(error)
+		throw error
+	} finally {
+		report.finishedAt = new Date().toISOString()
+		writeReport(report)
+		console.log(`\nReport: ${join(jobsRoot, "pilot-report.json")}`)
+	}
+}
+
+main()

--- a/evals/e2e/run-cline-bench-pilot.ts
+++ b/evals/e2e/run-cline-bench-pilot.ts
@@ -16,7 +16,15 @@
  */
 
 import { spawnSync } from "node:child_process"
-import { chmodSync, existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs"
+import {
+	chmodSync,
+	cpSync,
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	writeFileSync,
+} from "node:fs"
 import { homedir, tmpdir } from "node:os"
 import { dirname, isAbsolute, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
@@ -465,6 +473,34 @@ function taskAgentTimeoutSeconds(task: string): number {
 	return configuredTimeout
 }
 
+// The upstream Telegram verifier installs uv under /root/.local/bin but does
+// not add that directory to PATH. Harbor's verifier container then reports
+// "uv: command not found" after a valid agent run. Materialize a private task
+// overlay with only that infrastructure correction so the submodule remains
+// clean and the benchmark is reproducible from this branch.
+export function prepareTaskPath(task: string, jobsRoot: string): string {
+	if (task !== "01k6zz0nyj31znwsevx4sn6zb2-telegram-plugin-refactor") {
+		return `tasks/${task}`
+	}
+	const source = join(clineBenchDir, "tasks", task)
+	const overlay = join(jobsRoot, "task-overlays", task)
+	if (!existsSync(overlay)) {
+		mkdirSync(dirname(overlay), { recursive: true, mode: 0o700 })
+		cpSync(source, overlay, { recursive: true })
+		const verifier = join(overlay, "tests", "test.sh")
+		const original = readFileSync(verifier, "utf8")
+		if (!original.includes('export PATH="/root/.local/bin:$PATH"')) {
+			const patched = original.replace(
+				"#!/bin/bash\n",
+				'#!/bin/bash\n\nexport PATH="/root/.local/bin:$PATH"\n',
+			)
+			if (patched === original) fail(`could not patch Telegram verifier: ${verifier}`)
+			writeFileSync(verifier, patched, { mode: 0o755 })
+		}
+	}
+	return overlay
+}
+
 function runOne(
 	config: PilotConfig,
 	model: ModelConfig,
@@ -476,10 +512,11 @@ function runOne(
 	const jobDir = join(jobsRoot, jobName)
 	const harborModel = `${config.provider}:${model.id}`
 	const timeoutMultiplier = Math.min(1, config.timeoutSeconds / taskAgentTimeoutSeconds(task))
+	const taskPath = prepareTaskPath(task, jobsRoot)
 	const args = [
 		"run",
 		"-p",
-		`tasks/${task}`,
+		taskPath,
 		"-a",
 		"cline-cli",
 		"-m",
@@ -648,4 +685,6 @@ function main() {
 	}
 }
 
-main()
+if (import.meta.main) {
+	main()
+}

--- a/evals/e2e/run-cline-bench-pilot.ts
+++ b/evals/e2e/run-cline-bench-pilot.ts
@@ -16,11 +16,13 @@
  */
 
 import { spawnSync } from "node:child_process"
+import { createHash } from "node:crypto"
 import {
 	chmodSync,
 	cpSync,
 	existsSync,
 	mkdirSync,
+	realpathSync,
 	readdirSync,
 	readFileSync,
 	writeFileSync,
@@ -75,6 +77,7 @@ type PilotReport = {
 	finishedAt?: string
 	mode: "dry-run" | "execute"
 	config: PilotConfig
+	executionFingerprint: string
 	jobsRoot: string
 	results: RunResult[]
 	stoppedReason?: string
@@ -133,12 +136,71 @@ Options:
 	return { execute, configPath: resolve(configPath), jobsRoot, stopAfter, onlyRun }
 }
 
+function assertOnlyKeys(value: unknown, allowed: readonly string[], label: string): asserts value is Record<string, any> {
+	if (!value || typeof value !== "object" || Array.isArray(value)) fail(`${label} must be an object`)
+	const allowlist = new Set(allowed)
+	for (const key of Object.keys(value)) {
+		if (!allowlist.has(key)) fail(`unknown ${label} field: ${key}`)
+	}
+}
+
 function readConfig(configPath: string): PilotConfig {
-	const config = JSON.parse(readFileSync(configPath, "utf8")) as PilotConfig
+	const raw: unknown = JSON.parse(readFileSync(configPath, "utf8"))
+	assertOnlyKeys(
+		raw,
+		[
+			"routerProfile",
+			"provider",
+			"globalBudgetUsd",
+			"maxRunsPerModel",
+			"timeoutSeconds",
+			"clineVersion",
+			"models",
+			"tasks",
+		],
+		"config",
+	)
+	if (!Array.isArray(raw.models) || raw.models.length === 0) fail("at least one model is required")
+	if (!Array.isArray(raw.tasks) || raw.tasks.length === 0) fail("at least one task is required")
+	const models = raw.models.map((value, index): ModelConfig => {
+		assertOnlyKeys(value, ["id", "perTaskBudgetUsd", "perModelBudgetUsd", "pricing"], `models[${index}]`)
+		let pricing: ModelConfig["pricing"]
+		if (value.pricing !== undefined) {
+			assertOnlyKeys(
+				value.pricing,
+				["inputPerMTok", "cachedInputPerMTok", "outputPerMTok"],
+				`models[${index}].pricing`,
+			)
+			pricing = {
+				inputPerMTok: value.pricing.inputPerMTok,
+				cachedInputPerMTok: value.pricing.cachedInputPerMTok,
+				outputPerMTok: value.pricing.outputPerMTok,
+			}
+		}
+		return {
+			id: value.id,
+			perTaskBudgetUsd: value.perTaskBudgetUsd,
+			perModelBudgetUsd: value.perModelBudgetUsd,
+			...(pricing ? { pricing } : {}),
+		}
+	})
+	const config: PilotConfig = {
+		routerProfile: raw.routerProfile,
+		provider: raw.provider,
+		globalBudgetUsd: raw.globalBudgetUsd,
+		maxRunsPerModel: raw.maxRunsPerModel,
+		timeoutSeconds: raw.timeoutSeconds,
+		clineVersion: raw.clineVersion,
+		models,
+		tasks: [...raw.tasks],
+	}
 	if (config.routerProfile !== "cline-router" && config.routerProfile !== "cline-pass-router") {
 		fail("routerProfile must be cline-router or cline-pass-router")
 	}
-	if (!config.provider?.trim()) fail("provider must be configured")
+	const expectedProvider = config.routerProfile === "cline-pass-router" ? "cline-pass" : "cline"
+	if (config.provider !== expectedProvider) {
+		fail(`${config.routerProfile} requires provider=${expectedProvider}`)
+	}
 	if (!Number.isFinite(config.globalBudgetUsd) || config.globalBudgetUsd <= 0 || config.globalBudgetUsd >= 100) {
 		fail("globalBudgetUsd must be greater than 0 and less than 100")
 	}
@@ -148,16 +210,19 @@ function readConfig(configPath: string): PilotConfig {
 	if (!Number.isFinite(config.timeoutSeconds) || config.timeoutSeconds < 60 || config.timeoutSeconds > 1800) {
 		fail("timeoutSeconds must be between 60 and 1800")
 	}
-	if (!/^\d+\.\d+\.\d+(?:[-+][a-zA-Z0-9.-]+)?$/.test(config.clineVersion)) fail("clineVersion must be pinned")
-	if (!Array.isArray(config.models) || config.models.length === 0) fail("at least one model is required")
-	if (!Array.isArray(config.tasks) || config.tasks.length === 0) fail("at least one task is required")
+	if (
+		typeof config.clineVersion !== "string" ||
+		!/^\d+\.\d+\.\d+(?:[-+][a-zA-Z0-9.-]+)?$/.test(config.clineVersion)
+	) {
+		fail("clineVersion must be pinned")
+	}
 	if (config.tasks.length > config.maxRunsPerModel) {
 		fail(`configured ${config.tasks.length} tasks, exceeding maxRunsPerModel=${config.maxRunsPerModel}`)
 	}
 
 	const seenModels = new Set<string>()
 	for (const model of config.models) {
-		if (!model.id?.trim() || model.id.includes(":")) {
+		if (typeof model.id !== "string" || !model.id.trim() || model.id.includes(":")) {
 			fail(`invalid Cline model id: ${JSON.stringify(model.id)}`)
 		}
 		if (seenModels.has(model.id)) fail(`duplicate model: ${model.id}`)
@@ -182,6 +247,12 @@ function readConfig(configPath: string): PilotConfig {
 		if (model.perModelBudgetUsd > config.globalBudgetUsd) {
 			fail(`per-model budget for ${model.id} exceeds the global budget`)
 		}
+		if (model.perTaskBudgetUsd > model.perModelBudgetUsd) {
+			fail(`per-task budget for ${model.id} exceeds its model budget`)
+		}
+		if (model.perTaskBudgetUsd > config.globalBudgetUsd) {
+			fail(`per-task budget for ${model.id} exceeds the global budget`)
+		}
 		if (model.pricing) {
 			for (const [field, value] of Object.entries(model.pricing)) {
 				if (!Number.isFinite(value) || value < 0) {
@@ -195,6 +266,7 @@ function readConfig(configPath: string): PilotConfig {
 	}
 
 	for (const task of config.tasks) {
+		if (typeof task !== "string") fail(`invalid task id: ${JSON.stringify(task)}`)
 		if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]+$/.test(task)) fail(`invalid task id: ${JSON.stringify(task)}`)
 		const taskDir = join(clineBenchDir, "tasks", task)
 		if (!existsSync(join(taskDir, "task.toml")) || !existsSync(join(taskDir, "instruction.md"))) {
@@ -227,12 +299,26 @@ function createPrivateJobsRoot(requested?: string): string {
 	const base = requested
 		? resolve(requested)
 		: join(process.env.XDG_CACHE_HOME || join(homedir(), ".cache"), "cline-auto-sdlc-bench", runId)
-	if (base === repoRoot || base.startsWith(`${repoRoot}/`)) {
+	mkdirSync(base, { recursive: true, mode: 0o700 })
+	const canonicalBase = realpathSync(base)
+	const canonicalRepoRoot = realpathSync(repoRoot)
+	if (canonicalBase === canonicalRepoRoot || canonicalBase.startsWith(`${canonicalRepoRoot}/`)) {
 		fail("jobs-root must be outside the repository")
 	}
-	mkdirSync(base, { recursive: true, mode: 0o700 })
-	chmodSync(base, 0o700)
-	return base
+	chmodSync(canonicalBase, 0o700)
+	return canonicalBase
+}
+
+function executionFingerprint(config: PilotConfig): string {
+	const executionConfig = {
+		routerProfile: config.routerProfile,
+		provider: config.provider,
+		timeoutSeconds: config.timeoutSeconds,
+		clineVersion: config.clineVersion,
+		models: config.models.map((model) => model.id),
+		tasks: config.tasks,
+	}
+	return createHash("sha256").update(JSON.stringify(executionConfig)).digest("hex")
 }
 
 function safeEnvironment(provider: string): NodeJS.ProcessEnv {
@@ -264,6 +350,40 @@ function safeEnvironment(provider: string): NodeJS.ProcessEnv {
 		env.API_KEY = process.env.CLINE_API_KEY
 	}
 	return env
+}
+
+function infrastructureEnvironment(): NodeJS.ProcessEnv {
+	const env = safeEnvironment("cline")
+	delete env.CLINE_API_KEY
+	delete env.API_KEY
+	return env
+}
+
+function cleanupJobContainers(jobDir: string): string[] {
+	if (!existsSync(jobDir)) return []
+	const trialNames = readdirSync(jobDir, { withFileTypes: true })
+		.filter((entry) => entry.isDirectory() && entry.name.includes("__"))
+		.map((entry) => entry.name.toLowerCase())
+	if (trialNames.length === 0) return []
+	const listed = spawnSync("docker", ["ps", "-a", "--format", "{{.ID}}\t{{.Names}}"], {
+		env: infrastructureEnvironment(),
+		encoding: "utf8",
+		timeout: 15_000,
+	})
+	if (listed.status !== 0) return []
+	const removed: string[] = []
+	for (const line of listed.stdout.split("\n")) {
+		const [id, name] = line.trim().split("\t")
+		if (!/^[0-9a-f]{12,64}$/.test(id || "") || !name) continue
+		if (!trialNames.some((trialName) => name.toLowerCase().includes(trialName))) continue
+		const cleanup = spawnSync("docker", ["rm", "-f", id], {
+			env: infrastructureEnvironment(),
+			stdio: "ignore",
+			timeout: 30_000,
+		})
+		if (cleanup.status === 0) removed.push(id)
+	}
+	return removed
 }
 
 function buildRunMatrix(config: PilotConfig) {
@@ -335,9 +455,9 @@ function tokenEconomics(
 
 function readJobResult(
 	jobDir: string,
-	provider: string,
-	routerProfile: PilotConfig["routerProfile"],
+	config: PilotConfig,
 	model: ModelConfig,
+	expectedTask: string,
 	durationSeconds: number,
 ): RunResult {
 	const resultPath = join(jobDir, "result.json")
@@ -352,15 +472,25 @@ function readJobResult(
 			`Harbor trial failed with ${trial.exception_info.exception_type}: ${trial.exception_info.exception_message}`,
 		)
 	}
+	if (trial.task_name !== expectedTask) {
+		fail(`task mismatch: expected ${expectedTask}, result recorded ${JSON.stringify(trial.task_name)}`)
+	}
+	if (trial.agent_info?.version !== config.clineVersion) {
+		fail(
+			`Cline version mismatch: expected ${config.clineVersion}, result recorded ${JSON.stringify(trial.agent_info?.version)}`,
+		)
+	}
 
 	const servedModel = trial.agent_info?.model_info?.name
 	const servedProvider = trial.agent_info?.model_info?.provider
 	const expectedModel = model.id
 	const [expectedVendor, ...expectedNameParts] = expectedModel.split("/")
 	const expectedName = expectedNameParts.join("/")
-	const exactSplitMatch = servedProvider === `${provider}:${expectedVendor}` && servedModel === expectedName
-	const acceptedCombinedNames = new Set([expectedModel, `${provider}:${expectedModel}`])
-	if (!exactSplitMatch && !acceptedCombinedNames.has(servedModel)) {
+	const exactSplitMatch =
+		servedProvider === `${config.provider}:${expectedVendor}` && servedModel === expectedName
+	const acceptedCombinedNames = new Set([expectedModel, `${config.provider}:${expectedModel}`])
+	const combinedMatch = servedProvider === config.provider && acceptedCombinedNames.has(servedModel)
+	if (!exactSplitMatch && !combinedMatch) {
 		fail(
 			`served-model mismatch: expected ${expectedModel}, result recorded provider=${JSON.stringify(servedProvider)} model=${JSON.stringify(servedModel)}`,
 		)
@@ -395,7 +525,7 @@ function readJobResult(
 		reward,
 		costUsd,
 		costBasis:
-			routerProfile === "cline-pass-router"
+			config.routerProfile === "cline-pass-router"
 				? "cline-pass-reference-quota"
 				: "reported-inference",
 		durationSeconds: measuredDurationSeconds,
@@ -557,12 +687,30 @@ function runOne(
 	mkdirSync(jobDir, { recursive: true, mode: 0o700 })
 	writeFileSync(join(jobDir, "harbor-console.log"), sanitizedOutput, { mode: 0o600 })
 
-	if (result.error) fail(`Harbor failed for ${model.id} × ${task}: ${result.error.message}`)
-	if (result.status !== 0) {
-		const tail = sanitizedOutput.trim().split("\n").slice(-20).join("\n")
-		fail(`Harbor exited ${result.status} for ${model.id} × ${task}\n${tail}`)
+	if (result.error) {
+		const removed = cleanupJobContainers(jobDir)
+		const errorCode = (result.error as NodeJS.ErrnoException).code
+		if (errorCode === "ETIMEDOUT" && existsSync(join(jobDir, "result.json"))) {
+			try {
+				return readInterruptedRun(jobDir, config.routerProfile, model, task)
+			} catch (usageError) {
+				fail(
+					`Harbor timed out for ${model.id} × ${task}; cleaned ${removed.length} container(s), but usage recovery failed: ${usageError instanceof Error ? usageError.message : String(usageError)}`,
+				)
+			}
+		}
+		fail(
+			`Harbor failed for ${model.id} × ${task}: ${result.error.message}; cleaned ${removed.length} container(s)`,
+		)
 	}
-	return readJobResult(jobDir, config.provider, config.routerProfile, model, durationSeconds)
+	if (result.status !== 0) {
+		const removed = cleanupJobContainers(jobDir)
+		const tail = sanitizedOutput.trim().split("\n").slice(-20).join("\n")
+		fail(
+			`Harbor exited ${result.status} for ${model.id} × ${task}; cleaned ${removed.length} container(s)\n${tail}`,
+		)
+	}
+	return readJobResult(jobDir, config, model, task, durationSeconds)
 }
 
 function reuseCompletedRun(
@@ -582,7 +730,7 @@ function reuseCompletedRun(
 		console.log(`  cost=$${interrupted.costUsd.toFixed(4)}`)
 		return interrupted
 	}
-	const result = readJobResult(jobDir, config.provider, config.routerProfile, model, 0)
+	const result = readJobResult(jobDir, config, model, task, 0)
 	console.log(`\n[${runNumber}] reusing completed ${model.id} × ${task}`)
 	console.log(`  outcome=${result.outcome} reward=${result.reward ?? "missing"} cost=$${result.costUsd.toFixed(4)}`)
 	return result
@@ -620,10 +768,22 @@ function main() {
 	}
 
 	const jobsRoot = createPrivateJobsRoot(args.jobsRoot)
+	const fingerprint = executionFingerprint(config)
+	const existingReportPath = join(jobsRoot, "pilot-report.json")
+	if (existsSync(existingReportPath)) {
+		const existing = JSON.parse(readFileSync(existingReportPath, "utf8")) as Partial<PilotReport>
+		const existingFingerprint =
+			existing.executionFingerprint ||
+			(existing.config ? executionFingerprint(existing.config) : undefined)
+		if (existingFingerprint !== fingerprint) {
+			fail("jobs-root belongs to a different provider/model/task/CLI execution matrix")
+		}
+	}
 	const report: PilotReport = {
 		startedAt: new Date().toISOString(),
 		mode: "execute",
 		config,
+		executionFingerprint: fingerprint,
 		jobsRoot,
 		results: [],
 	}
@@ -649,8 +809,14 @@ function main() {
 			if (currentModelSpend >= run.model.perModelBudgetUsd) {
 				fail(`${run.model.id} reached its $${run.model.perModelBudgetUsd.toFixed(2)} model budget`)
 			}
+			if (currentModelSpend + run.model.perTaskBudgetUsd > run.model.perModelBudgetUsd) {
+				fail(`${run.model.id} lacks room for its declared per-task exposure`)
+			}
 			if (globalSpend >= config.globalBudgetUsd) {
 				fail(`pilot reached its $${config.globalBudgetUsd.toFixed(2)} global budget`)
+			}
+			if (globalSpend + run.model.perTaskBudgetUsd > config.globalBudgetUsd) {
+				fail("pilot lacks room for the next task's declared exposure")
 			}
 
 			const result = runOne(config, run.model, run.task, jobsRoot, index + 1)

--- a/evals/e2e/run-cline-bench-pilot.ts
+++ b/evals/e2e/run-cline-bench-pilot.ts
@@ -1022,12 +1022,12 @@ function readLiveCostStopMarker(jobDir: string, model: ModelConfig, task: string
 		typeof usage.totalCost !== "number" ||
 		!Number.isFinite(usage.totalCost) ||
 		usage.totalCost < expectedStopUsd ||
-		!Number.isInteger(usage.totalInputTokens) ||
-		(usage.totalInputTokens ?? -1) < 0 ||
-		!Number.isInteger(usage.totalCacheReadTokens) ||
-		(usage.totalCacheReadTokens ?? -1) < 0 ||
-		!Number.isInteger(usage.totalOutputTokens) ||
-		(usage.totalOutputTokens ?? -1) < 0
+		(usage.totalInputTokens !== null &&
+			(!Number.isInteger(usage.totalInputTokens) || usage.totalInputTokens < 0)) ||
+		(usage.totalCacheReadTokens !== null &&
+			(!Number.isInteger(usage.totalCacheReadTokens) || usage.totalCacheReadTokens < 0)) ||
+		(usage.totalOutputTokens !== null &&
+			(!Number.isInteger(usage.totalOutputTokens) || usage.totalOutputTokens < 0))
 	) {
 		fail(`live cost stop marker is invalid or belongs to different work: ${path}`)
 	}
@@ -1216,6 +1216,71 @@ export function liveCostStopUsd(perTaskBudgetUsd: number): number {
 	return Math.max(perTaskBudgetUsd * 0.25, perTaskBudgetUsd - headroomUsd)
 }
 
+function liveUsageCount(value: unknown): number | null {
+	if (value === null || value === undefined) return null
+	if (typeof value !== "number" || !Number.isFinite(value) || !Number.isInteger(value) || value < 0) {
+		throw new Error("live cost telemetry has an invalid cumulative token count")
+	}
+	return value
+}
+
+function liveUsageSnapshot(value: unknown): UsageSnapshot | null {
+	if (value === null || typeof value !== "object" || Array.isArray(value)) return null
+	const parsed = value as Record<string, unknown>
+	const event =
+		parsed.event !== null && typeof parsed.event === "object" && !Array.isArray(parsed.event)
+			? (parsed.event as Record<string, unknown>)
+			: null
+	let totalCost: unknown
+	let totalInputTokens: unknown
+	let totalCacheReadTokens: unknown
+	let totalOutputTokens: unknown
+	if (event?.type === "usage") {
+		totalCost = event.totalCost
+		totalInputTokens = event.totalInputTokens
+		totalCacheReadTokens = event.totalCacheReadTokens
+		totalOutputTokens = event.totalOutputTokens
+	} else if (parsed.type === "run_result") {
+		const aggregate =
+			parsed.aggregateUsage !== null &&
+			typeof parsed.aggregateUsage === "object" &&
+			!Array.isArray(parsed.aggregateUsage)
+				? (parsed.aggregateUsage as Record<string, unknown>)
+				: parsed.usage !== null && typeof parsed.usage === "object" && !Array.isArray(parsed.usage)
+					? (parsed.usage as Record<string, unknown>)
+					: null
+		if (!aggregate) throw new Error("live run_result has no cumulative usage")
+		totalCost = aggregate.totalCost
+		totalInputTokens = aggregate.inputTokens
+		totalCacheReadTokens = aggregate.cacheReadTokens
+		totalOutputTokens = aggregate.outputTokens
+	} else {
+		return null
+	}
+	const timestampMs = typeof parsed.ts === "string" ? Date.parse(parsed.ts) : Number.NaN
+	if (!Number.isFinite(timestampMs)) throw new Error("live cost telemetry has an invalid timestamp")
+	if (typeof totalCost !== "number" || !Number.isFinite(totalCost) || totalCost < 0) {
+		throw new Error("live cost telemetry has an invalid totalCost")
+	}
+	if (totalCost === 0) return null
+	return {
+		timestamp: new Date(timestampMs).toISOString(),
+		totalCost,
+		totalInputTokens: liveUsageCount(totalInputTokens),
+		totalCacheReadTokens: liveUsageCount(totalCacheReadTokens),
+		totalOutputTokens: liveUsageCount(totalOutputTokens),
+	}
+}
+
+function sameLiveUsage(left: UsageSnapshot, right: UsageSnapshot): boolean {
+	return (
+		left.totalCost === right.totalCost &&
+		left.totalInputTokens === right.totalInputTokens &&
+		left.totalCacheReadTokens === right.totalCacheReadTokens &&
+		left.totalOutputTokens === right.totalOutputTokens
+	)
+}
+
 export function readLiveUsage(jobDir: string): UsageSnapshot | null {
 	if (!existsSync(jobDir)) return null
 	const logPaths = readdirSync(jobDir, { withFileTypes: true })
@@ -1229,12 +1294,44 @@ export function readLiveUsage(jobDir: string): UsageSnapshot | null {
 	const document = readFileSync(logPaths[0], "utf8")
 	const finalNewline = document.lastIndexOf("\n")
 	if (finalNewline < 0) return null
-	try {
-		return recoverLatestUsage([document.slice(0, finalNewline + 1)])
-	} catch (error) {
-		if (error instanceof Error && error.message === "interrupted run has no usable cost telemetry") return null
-		throw error
+	let latest: UsageSnapshot | null = null
+	for (const line of document.slice(0, finalNewline + 1).split("\n")) {
+		if (!line.startsWith("{")) continue
+		let snapshot: UsageSnapshot | null
+		try {
+			snapshot = liveUsageSnapshot(JSON.parse(line))
+		} catch (error) {
+			if (
+				/^\{"ts":"[^"]+","type":"run_result"/.test(line) ||
+				/^\{"ts":"[^"]+","type":"agent_event","event":\{"type":"usage"/.test(line)
+			) {
+				throw error
+			}
+			continue
+		}
+		if (!snapshot) continue
+		if (latest) {
+			if (
+				snapshot.totalCost < latest.totalCost ||
+				(snapshot.totalInputTokens !== null &&
+					latest.totalInputTokens !== null &&
+					snapshot.totalInputTokens < latest.totalInputTokens) ||
+				(snapshot.totalCacheReadTokens !== null &&
+					latest.totalCacheReadTokens !== null &&
+					snapshot.totalCacheReadTokens < latest.totalCacheReadTokens) ||
+				(snapshot.totalOutputTokens !== null &&
+					latest.totalOutputTokens !== null &&
+					snapshot.totalOutputTokens < latest.totalOutputTokens)
+			) {
+				throw new Error("live cost telemetry is non-monotonic")
+			}
+			if (snapshot.timestamp === latest.timestamp && !sameLiveUsage(snapshot, latest)) {
+				throw new Error("live cost telemetry is ambiguous at the latest timestamp")
+			}
+		}
+		latest = snapshot
 	}
+	return latest
 }
 
 async function runHarborProcess(

--- a/evals/e2e/run-cline-bench-pilot.ts
+++ b/evals/e2e/run-cline-bench-pilot.ts
@@ -15,11 +15,10 @@
  * is the proactive bound during a run.
  */
 
-import { spawnSync } from "node:child_process"
+import { spawn, spawnSync } from "node:child_process"
 import { createHash } from "node:crypto"
 import {
 	chmodSync,
-	cpSync,
 	existsSync,
 	lstatSync,
 	mkdirSync,
@@ -27,17 +26,37 @@ import {
 	readFileSync,
 	readlinkSync,
 	realpathSync,
-	rmSync,
+	renameSync,
 	writeFileSync,
 } from "node:fs"
 import { homedir, tmpdir } from "node:os"
 import { dirname, isAbsolute, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
+import {
+	acquireRunLock,
+	type BudgetLedger,
+	createBudgetLedger,
+	hashPrivateIdentifier,
+	ledgerExposure,
+	MAX_CHECKPOINT_USD,
+	normalizeLocalCoreUrl,
+	parseRouteTraces,
+	type RouteTrace,
+	recoverLatestUsage,
+	redactSecrets,
+	releaseRunLock,
+	reserveBudget,
+	settleBudget,
+	sha256,
+} from "./cline-bench-safety"
 
 type ModelConfig = {
 	id: string
 	perTaskBudgetUsd: number
 	perModelBudgetUsd: number
+	tasks?: string[]
+	wave?: number
+	allowedCandidates?: string[]
 	pricing?: {
 		inputPerMTok: number
 		cachedInputPerMTok: number
@@ -54,10 +73,18 @@ export type PilotConfig = {
 	clineVersion: string
 	models: ModelConfig[]
 	tasks: string[]
+	waveBudgetsUsd?: Record<string, number>
 }
 
 export type ExecutionProvenance = {
-	schemaVersion: 2
+	schemaVersion: 3
+	runnerContentSha256: string
+	runnerGitCommit: string
+	harborVersion: string
+	effectiveConfig: PilotConfig
+	executionOptions: {
+		localCoreUrl: string | null
+	}
 	clineBenchCommit: string
 	tasks: Array<{
 		id: string
@@ -67,7 +94,13 @@ export type ExecutionProvenance = {
 
 type RunResult = {
 	model: string
+	requestedModel: string
 	task: string
+	taskHash: string
+	sessionHash: string | null
+	sessionIdSha256: string | null
+	routeTraces: RouteTrace[]
+	routeEvidence: "not-applicable" | "verified" | "missing"
 	outcome: "passed" | "failed" | "timed_out"
 	passed: boolean
 	reward: number | null
@@ -92,6 +125,7 @@ type PilotReport = {
 	executionFingerprint: string
 	executionProvenance: ExecutionProvenance
 	jobsRoot: string
+	budgetLedger: BudgetLedger
 	results: RunResult[]
 	stoppedReason?: string
 }
@@ -111,6 +145,10 @@ function parseArgs(argv: string[]) {
 	let jobsRoot: string | undefined
 	let stopAfter: number | undefined
 	let onlyRun: number | undefined
+	let wave: number | undefined
+	let localCoreUrl: string | undefined
+	let routeTracesPath: string | undefined
+	let ingestRouteTraces = false
 
 	for (let index = 0; index < argv.length; index += 1) {
 		const arg = argv[index]
@@ -128,6 +166,15 @@ function parseArgs(argv: string[]) {
 		} else if (arg === "--only-run") {
 			onlyRun = Number(argv[++index] ?? fail("--only-run requires a run number"))
 			if (!Number.isInteger(onlyRun) || onlyRun < 1) fail("--only-run must be a positive integer")
+		} else if (arg === "--wave") {
+			wave = Number(argv[++index] ?? fail("--wave requires a wave number"))
+			if (!Number.isInteger(wave) || wave < 1) fail("--wave must be a positive integer")
+		} else if (arg === "--local-core-url") {
+			localCoreUrl = normalizeLocalCoreUrl(argv[++index] ?? fail("--local-core-url requires a URL"))
+		} else if (arg === "--route-traces") {
+			routeTracesPath = resolve(argv[++index] ?? fail("--route-traces requires a path"))
+		} else if (arg === "--ingest-route-traces") {
+			ingestRouteTraces = true
 		} else if (arg === "--help" || arg === "-h") {
 			console.log(`Usage: bun evals/e2e/run-cline-bench-pilot.ts [options]
 
@@ -138,6 +185,11 @@ Options:
   --jobs-root <path>  Private output directory outside the repository
   --stop-after <n>    Stop cleanly after matrix run n
   --only-run <n>      Reuse prior work but execute only matrix run n
+  --wave <n>          Execute only the selected staged wave
+  --local-core-url    Local Core URL (strictly localhost:7777)
+  --route-traces      Privacy-safe Core route trace JSON/JSONL
+  --ingest-route-traces
+                      Attach traces to an existing report without model calls
   --help              Show this help`)
 			process.exit(0)
 		} else {
@@ -146,10 +198,28 @@ Options:
 	}
 
 	if (stopAfter && onlyRun) fail("--stop-after and --only-run cannot be combined")
-	return { execute, configPath: resolve(configPath), jobsRoot, stopAfter, onlyRun }
+	if (ingestRouteTraces && execute) fail("--ingest-route-traces cannot be combined with --execute")
+	if (ingestRouteTraces && !routeTracesPath) fail("--ingest-route-traces requires --route-traces")
+	if (ingestRouteTraces && !jobsRoot) fail("--ingest-route-traces requires --jobs-root")
+	if (execute && !jobsRoot) fail("--execute requires an explicit --jobs-root")
+	return {
+		execute,
+		configPath: resolve(configPath),
+		jobsRoot,
+		stopAfter,
+		onlyRun,
+		wave,
+		localCoreUrl,
+		routeTracesPath,
+		ingestRouteTraces,
+	}
 }
 
-function assertOnlyKeys(value: unknown, allowed: readonly string[], label: string): asserts value is Record<string, any> {
+function assertOnlyKeys(
+	value: unknown,
+	allowed: readonly string[],
+	label: string,
+): asserts value is Record<string, any> {
 	if (!value || typeof value !== "object" || Array.isArray(value)) fail(`${label} must be an object`)
 	const allowlist = new Set(allowed)
 	for (const key of Object.keys(value)) {
@@ -157,7 +227,7 @@ function assertOnlyKeys(value: unknown, allowed: readonly string[], label: strin
 	}
 }
 
-function readConfig(configPath: string): PilotConfig {
+export function readConfig(configPath: string): PilotConfig {
 	const raw: unknown = JSON.parse(readFileSync(configPath, "utf8"))
 	assertOnlyKeys(
 		raw,
@@ -170,20 +240,21 @@ function readConfig(configPath: string): PilotConfig {
 			"clineVersion",
 			"models",
 			"tasks",
+			"waveBudgetsUsd",
 		],
 		"config",
 	)
 	if (!Array.isArray(raw.models) || raw.models.length === 0) fail("at least one model is required")
 	if (!Array.isArray(raw.tasks) || raw.tasks.length === 0) fail("at least one task is required")
 	const models = raw.models.map((value, index): ModelConfig => {
-		assertOnlyKeys(value, ["id", "perTaskBudgetUsd", "perModelBudgetUsd", "pricing"], `models[${index}]`)
+		assertOnlyKeys(
+			value,
+			["id", "perTaskBudgetUsd", "perModelBudgetUsd", "pricing", "tasks", "wave", "allowedCandidates"],
+			`models[${index}]`,
+		)
 		let pricing: ModelConfig["pricing"]
 		if (value.pricing !== undefined) {
-			assertOnlyKeys(
-				value.pricing,
-				["inputPerMTok", "cachedInputPerMTok", "outputPerMTok"],
-				`models[${index}].pricing`,
-			)
+			assertOnlyKeys(value.pricing, ["inputPerMTok", "cachedInputPerMTok", "outputPerMTok"], `models[${index}].pricing`)
 			pricing = {
 				inputPerMTok: value.pricing.inputPerMTok,
 				cachedInputPerMTok: value.pricing.cachedInputPerMTok,
@@ -194,6 +265,9 @@ function readConfig(configPath: string): PilotConfig {
 			id: value.id,
 			perTaskBudgetUsd: value.perTaskBudgetUsd,
 			perModelBudgetUsd: value.perModelBudgetUsd,
+			...(value.tasks !== undefined ? { tasks: value.tasks } : {}),
+			...(value.wave !== undefined ? { wave: value.wave } : {}),
+			...(value.allowedCandidates !== undefined ? { allowedCandidates: value.allowedCandidates } : {}),
 			...(pricing ? { pricing } : {}),
 		}
 	})
@@ -206,6 +280,7 @@ function readConfig(configPath: string): PilotConfig {
 		clineVersion: raw.clineVersion,
 		models,
 		tasks: [...raw.tasks],
+		...(raw.waveBudgetsUsd !== undefined ? { waveBudgetsUsd: raw.waveBudgetsUsd } : {}),
 	}
 	if (config.routerProfile !== "cline-router" && config.routerProfile !== "cline-pass-router") {
 		fail("routerProfile must be cline-router or cline-pass-router")
@@ -214,8 +289,12 @@ function readConfig(configPath: string): PilotConfig {
 	if (config.provider !== expectedProvider) {
 		fail(`${config.routerProfile} requires provider=${expectedProvider}`)
 	}
-	if (!Number.isFinite(config.globalBudgetUsd) || config.globalBudgetUsd <= 0 || config.globalBudgetUsd >= 100) {
-		fail("globalBudgetUsd must be greater than 0 and less than 100")
+	if (
+		!Number.isFinite(config.globalBudgetUsd) ||
+		config.globalBudgetUsd <= 0 ||
+		config.globalBudgetUsd > MAX_CHECKPOINT_USD
+	) {
+		fail(`globalBudgetUsd must be greater than 0 and at most ${MAX_CHECKPOINT_USD}`)
 	}
 	if (!Number.isInteger(config.maxRunsPerModel) || config.maxRunsPerModel < 1 || config.maxRunsPerModel >= 100) {
 		fail("maxRunsPerModel must be an integer from 1 through 99")
@@ -223,16 +302,9 @@ function readConfig(configPath: string): PilotConfig {
 	if (!Number.isFinite(config.timeoutSeconds) || config.timeoutSeconds < 60 || config.timeoutSeconds > 1800) {
 		fail("timeoutSeconds must be between 60 and 1800")
 	}
-	if (
-		typeof config.clineVersion !== "string" ||
-		!/^\d+\.\d+\.\d+(?:[-+][a-zA-Z0-9.-]+)?$/.test(config.clineVersion)
-	) {
+	if (typeof config.clineVersion !== "string" || !/^\d+\.\d+\.\d+(?:[-+][a-zA-Z0-9.-]+)?$/.test(config.clineVersion)) {
 		fail("clineVersion must be pinned")
 	}
-	if (config.tasks.length > config.maxRunsPerModel) {
-		fail(`configured ${config.tasks.length} tasks, exceeding maxRunsPerModel=${config.maxRunsPerModel}`)
-	}
-
 	const seenModels = new Set<string>()
 	for (const model of config.models) {
 		if (typeof model.id !== "string" || !model.id.trim() || model.id.includes(":")) {
@@ -243,18 +315,45 @@ function readConfig(configPath: string): PilotConfig {
 		if (config.routerProfile === "cline-pass-router" && !model.id.startsWith("cline-pass/")) {
 			fail(`cline-pass-router model must use a public cline-pass/* id: ${model.id}`)
 		}
+		const modelTasks = model.tasks ?? config.tasks
 		if (
-			!Number.isFinite(model.perTaskBudgetUsd) ||
-			model.perTaskBudgetUsd <= 0 ||
-			model.perTaskBudgetUsd >= 100
+			!Array.isArray(modelTasks) ||
+			modelTasks.length === 0 ||
+			modelTasks.some((task) => typeof task !== "string" || !config.tasks.includes(task))
 		) {
+			fail(`tasks for ${model.id} must be a non-empty subset of config.tasks`)
+		}
+		if (new Set(modelTasks).size !== modelTasks.length) fail(`duplicate task configured for ${model.id}`)
+		if (modelTasks.length > config.maxRunsPerModel) {
+			fail(`${model.id} has ${modelTasks.length} tasks, exceeding maxRunsPerModel=${config.maxRunsPerModel}`)
+		}
+		if (model.wave !== undefined && (!Number.isInteger(model.wave) || model.wave < 1)) {
+			fail(`wave for ${model.id} must be a positive integer`)
+		}
+		const isVirtual = model.id === "cline/auto" || model.id === "cline-pass/auto"
+		if (isVirtual) {
+			if (!Array.isArray(model.allowedCandidates) || model.allowedCandidates.length === 0) {
+				fail(`virtual model ${model.id} requires allowedCandidates`)
+			}
+			if (
+				model.allowedCandidates.some(
+					(candidate) =>
+						typeof candidate !== "string" ||
+						!candidate ||
+						(config.routerProfile === "cline-pass-router"
+							? !candidate.startsWith("cline-pass/")
+							: candidate.startsWith("cline-pass/")),
+				)
+			) {
+				fail(`virtual model ${model.id} has an invalid cross-product candidate`)
+			}
+		} else if (model.allowedCandidates !== undefined) {
+			fail(`fixed model ${model.id} cannot declare allowedCandidates`)
+		}
+		if (!Number.isFinite(model.perTaskBudgetUsd) || model.perTaskBudgetUsd <= 0 || model.perTaskBudgetUsd >= 100) {
 			fail(`invalid per-task budget for ${model.id}`)
 		}
-		if (
-			!Number.isFinite(model.perModelBudgetUsd) ||
-			model.perModelBudgetUsd <= 0 ||
-			model.perModelBudgetUsd >= 100
-		) {
+		if (!Number.isFinite(model.perModelBudgetUsd) || model.perModelBudgetUsd <= 0 || model.perModelBudgetUsd >= 100) {
 			fail(`per-model budget for ${model.id} must be greater than 0 and less than 100`)
 		}
 		if (model.perModelBudgetUsd > config.globalBudgetUsd) {
@@ -274,6 +373,18 @@ function readConfig(configPath: string): PilotConfig {
 			}
 			if (model.pricing.inputPerMTok <= 0 || model.pricing.outputPerMTok <= 0) {
 				fail(`input and output pricing must be positive for ${model.id}`)
+			}
+		}
+	}
+	if (config.waveBudgetsUsd !== undefined) {
+		assertOnlyKeys(
+			config.waveBudgetsUsd,
+			[...new Set(config.models.map((model) => String(model.wave ?? 1)))],
+			"waveBudgetsUsd",
+		)
+		for (const [wave, budget] of Object.entries(config.waveBudgetsUsd)) {
+			if (!/^[1-9][0-9]*$/.test(wave) || !Number.isFinite(budget) || budget <= 0 || budget > config.globalBudgetUsd) {
+				fail(`invalid wave budget for wave ${wave}`)
 			}
 		}
 	}
@@ -299,7 +410,10 @@ function validatePrerequisites(execute: boolean) {
 	if (!commandExists("harbor")) fail("Harbor is not installed")
 	if (!commandExists("docker")) fail("Docker is not installed")
 	if (execute) {
-		const docker = spawnSync("docker", ["info"], { stdio: "ignore", timeout: 15_000 })
+		const docker = spawnSync("docker", ["info"], {
+			stdio: "ignore",
+			timeout: 15_000,
+		})
 		if (docker.status !== 0) fail("Docker is not running")
 		if (!process.env.CLINE_API_KEY?.trim()) {
 			fail("CLINE_API_KEY must be inherited from the shell for --execute")
@@ -371,12 +485,11 @@ export function hashDirectoryTree(root: string): string {
 export function fingerprintExecution(config: PilotConfig, provenance: ExecutionProvenance): string {
 	const executionConfig = {
 		fingerprintSchemaVersion: provenance.schemaVersion,
-		routerProfile: config.routerProfile,
-		provider: config.provider,
-		timeoutSeconds: config.timeoutSeconds,
-		clineVersion: config.clineVersion,
-		models: config.models.map((model) => model.id),
-		tasks: config.tasks,
+		effectiveConfig: config,
+		runnerContentSha256: provenance.runnerContentSha256,
+		runnerGitCommit: provenance.runnerGitCommit,
+		harborVersion: provenance.harborVersion,
+		executionOptions: provenance.executionOptions,
 		clineBenchCommit: provenance.clineBenchCommit,
 		effectiveTasks: provenance.tasks,
 	}
@@ -399,16 +512,40 @@ function readClineBenchCommit(): string {
 	})
 	const commit = (result.stdout || "").trim()
 	if (result.status !== 0 || !/^[0-9a-f]{40,64}$/.test(commit)) {
-		fail(
-			`could not resolve exact cline-bench submodule commit: ${(result.stderr || "").trim() || "unknown error"}`,
-		)
+		fail(`could not resolve exact cline-bench submodule commit: ${(result.stderr || "").trim() || "unknown error"}`)
 	}
 	return commit
 }
 
-function executionIdentity(config: PilotConfig, jobsRoot: string) {
+function commandOutput(command: string, args: string[], label: string, pattern: RegExp): string {
+	const result = spawnSync(command, args, {
+		encoding: "utf8",
+		env: infrastructureEnvironment(),
+	})
+	const value = (result.stdout || "").trim()
+	if (result.status !== 0 || !pattern.test(value)) {
+		fail(`could not resolve ${label}: ${(result.stderr || "").trim() || "unknown error"}`)
+	}
+	return value
+}
+
+function executionIdentity(config: PilotConfig, jobsRoot: string, localCoreUrl?: string) {
 	const provenance: ExecutionProvenance = {
-		schemaVersion: 2,
+		schemaVersion: 3,
+		runnerContentSha256: sha256(
+			`${readFileSync(fileURLToPath(import.meta.url), "utf8")}\0${readFileSync(join(scriptDir, "cline-bench-safety.ts"), "utf8")}`,
+		),
+		runnerGitCommit: commandOutput(
+			"git",
+			["-C", repoRoot, "rev-parse", "HEAD"],
+			"runner git commit",
+			/^[0-9a-f]{40,64}$/,
+		),
+		harborVersion: commandOutput("harbor", ["--version"], "Harbor version", /^[0-9]+\.[0-9]+\.[0-9]+/),
+		effectiveConfig: config,
+		executionOptions: {
+			localCoreUrl: localCoreUrl ?? null,
+		},
 		clineBenchCommit: readClineBenchCommit(),
 		tasks: config.tasks.map((task) => {
 			const taskPath = prepareTaskPath(task, jobsRoot)
@@ -490,32 +627,68 @@ function cleanupJobContainers(jobDir: string): string[] {
 	return removed
 }
 
-function buildRunMatrix(config: PilotConfig) {
-	const runs: Array<{ model: ModelConfig; task: string }> = []
-	for (let round = 0; round < config.tasks.length; round += 1) {
+function cleanupJobsRootContainers(jobsRoot: string): string[] {
+	const removed = new Set<string>()
+	if (!existsSync(jobsRoot)) return []
+	for (const entry of readdirSync(jobsRoot, { withFileTypes: true })) {
+		if (!entry.isDirectory() || entry.name.startsWith(".")) continue
+		for (const id of cleanupJobContainers(join(jobsRoot, entry.name))) removed.add(id)
+	}
+	return [...removed]
+}
+
+export function buildRunMatrix(config: PilotConfig) {
+	const runs: Array<{ model: ModelConfig; task: string; wave: number }> = []
+	const longestArm = Math.max(...config.models.map((model) => (model.tasks ?? config.tasks).length))
+	for (let round = 0; round < longestArm; round += 1) {
 		for (let modelIndex = 0; modelIndex < config.models.length; modelIndex += 1) {
-			const taskIndex = (round + modelIndex) % config.tasks.length
-			runs.push({ model: config.models[modelIndex], task: config.tasks[taskIndex] })
+			const model = config.models[modelIndex]
+			const modelTasks = model.tasks ?? config.tasks
+			if (round >= modelTasks.length) continue
+			const taskIndex = (round + modelIndex) % modelTasks.length
+			runs.push({ model, task: modelTasks[taskIndex], wave: model.wave ?? 1 })
 		}
 	}
 	return runs
 }
 
 function slug(value: string): string {
-	return value.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 80)
+	return value
+		.replace(/[^a-zA-Z0-9._-]+/g, "-")
+		.replace(/^-+|-+$/g, "")
+		.slice(0, 80)
 }
 
-function redact(value: string, secret: string): string {
-	return secret ? value.split(secret).join("[REDACTED]") : value
-}
-
-function findTrialResult(jobDir: string): any {
+function findTrialResult(jobDir: string): { document: any; trialName: string } | null {
+	const matches: Array<{ document: any; trialName: string }> = []
 	for (const entry of readdirSync(jobDir, { withFileTypes: true })) {
 		if (!entry.isDirectory()) continue
 		const nestedResultPath = join(jobDir, entry.name, "result.json")
-		if (existsSync(nestedResultPath)) return JSON.parse(readFileSync(nestedResultPath, "utf8"))
+		if (existsSync(nestedResultPath)) {
+			matches.push({
+				document: JSON.parse(readFileSync(nestedResultPath, "utf8")),
+				trialName: entry.name,
+			})
+		}
 	}
-	return null
+	if (matches.length > 1) fail(`job contains ambiguous multiple trial attempts: ${jobDir}`)
+	return matches[0] ?? null
+}
+
+export function readTrialSessionIdentity(
+	jobDir: string,
+	trialName: string,
+): { sessionHash: string; sessionIdSha256: string } | null {
+	const trajectoryPath = join(jobDir, trialName, "agent", "trajectory.json")
+	if (!existsSync(trajectoryPath)) return null
+	const trajectory = JSON.parse(readFileSync(trajectoryPath, "utf8")) as { session_id?: unknown }
+	if (typeof trajectory.session_id !== "string" || trajectory.session_id.length === 0) {
+		fail(`trajectory has no valid session_id: ${trajectoryPath}`)
+	}
+	return {
+		sessionHash: hashPrivateIdentifier("cline-bench-session", trajectory.session_id),
+		sessionIdSha256: sha256(trajectory.session_id),
+	}
 }
 
 function tokenEconomics(
@@ -526,12 +699,7 @@ function tokenEconomics(
 ) {
 	const cacheReadRatio =
 		inputTokens !== null && cacheTokens !== null && inputTokens > 0 ? cacheTokens / inputTokens : null
-	if (
-		!model.pricing ||
-		inputTokens === null ||
-		cacheTokens === null ||
-		outputTokens === null
-	) {
+	if (!model.pricing || inputTokens === null || cacheTokens === null || outputTokens === null) {
 		return {
 			cacheReadRatio,
 			estimatedTokenCostUsd: null,
@@ -547,8 +715,7 @@ function tokenEconomics(
 			outputTokens * model.pricing.outputPerMTok) /
 		1_000_000
 	const coldEquivalentCostUsd =
-		(inputTokens * model.pricing.inputPerMTok + outputTokens * model.pricing.outputPerMTok) /
-		1_000_000
+		(inputTokens * model.pricing.inputPerMTok + outputTokens * model.pricing.outputPerMTok) / 1_000_000
 	return {
 		cacheReadRatio,
 		estimatedTokenCostUsd,
@@ -567,14 +734,13 @@ function readJobResult(
 	const resultPath = join(jobDir, "result.json")
 	if (!existsSync(resultPath)) fail(`Harbor did not write ${resultPath}`)
 	const doc = JSON.parse(readFileSync(resultPath, "utf8")) as any
-	const trial = doc.trial_results?.[0] || findTrialResult(jobDir)
+	const nestedTrial = findTrialResult(jobDir)
+	const trial = doc.trial_results?.[0] || nestedTrial?.document
 	if (!trial) fail(`Harbor result has no nested trial: ${resultPath}`)
 	const exceptionType = trial.exception_info?.exception_type
 	const timedOut = exceptionType === "AgentTimeoutError"
 	if (trial.exception_info && !timedOut) {
-		fail(
-			`Harbor trial failed with ${trial.exception_info.exception_type}: ${trial.exception_info.exception_message}`,
-		)
+		fail(`Harbor trial failed with ${trial.exception_info.exception_type}: ${trial.exception_info.exception_message}`)
 	}
 	if (trial.task_name !== expectedTask) {
 		fail(`task mismatch: expected ${expectedTask}, result recorded ${JSON.stringify(trial.task_name)}`)
@@ -590,11 +756,15 @@ function readJobResult(
 	const expectedModel = model.id
 	const [expectedVendor, ...expectedNameParts] = expectedModel.split("/")
 	const expectedName = expectedNameParts.join("/")
-	const exactSplitMatch =
-		servedProvider === `${config.provider}:${expectedVendor}` && servedModel === expectedName
+	const exactSplitMatch = servedProvider === `${config.provider}:${expectedVendor}` && servedModel === expectedName
 	const acceptedCombinedNames = new Set([expectedModel, `${config.provider}:${expectedModel}`])
 	const combinedMatch = servedProvider === config.provider && acceptedCombinedNames.has(servedModel)
-	if (!exactSplitMatch && !combinedMatch) {
+	const virtualModel = expectedModel === "cline/auto" || expectedModel === "cline-pass/auto"
+	const requestedVirtualMatch =
+		virtualModel &&
+		((servedProvider === `${config.provider}:cline` && servedModel === "auto") ||
+			(servedProvider === config.provider && acceptedCombinedNames.has(servedModel)))
+	if (!exactSplitMatch && !combinedMatch && !requestedVirtualMatch) {
 		fail(
 			`served-model mismatch: expected ${expectedModel}, result recorded provider=${JSON.stringify(servedProvider)} model=${JSON.stringify(servedModel)}`,
 		)
@@ -621,17 +791,21 @@ function readJobResult(
 	const inputTokens = doc.stats?.n_input_tokens ?? null
 	const cacheTokens = doc.stats?.n_cache_tokens ?? null
 	const outputTokens = doc.stats?.n_output_tokens ?? null
+	const sessionIdentity = nestedTrial ? readTrialSessionIdentity(jobDir, nestedTrial.trialName) : null
 	return {
 		model: expectedModel,
+		requestedModel: expectedModel,
 		task: trial.task_name,
+		taskHash: hashPrivateIdentifier("cline-bench-task", trial.task_name),
+		sessionHash: sessionIdentity?.sessionHash ?? null,
+		sessionIdSha256: sessionIdentity?.sessionIdSha256 ?? null,
+		routeTraces: [],
+		routeEvidence: virtualModel ? "missing" : "not-applicable",
 		outcome: timedOut ? "timed_out" : reward === 1 ? "passed" : "failed",
 		passed: reward === 1,
 		reward,
 		costUsd,
-		costBasis:
-			config.routerProfile === "cline-pass-router"
-				? "cline-pass-reference-quota"
-				: "reported-inference",
+		costBasis: config.routerProfile === "cline-pass-router" ? "cline-pass-reference-quota" : "reported-inference",
 		durationSeconds: measuredDurationSeconds,
 		inputTokens,
 		cacheTokens,
@@ -649,51 +823,87 @@ function readInterruptedRun(
 ): RunResult {
 	const rootResult = JSON.parse(readFileSync(join(jobDir, "result.json"), "utf8")) as any
 	const startedAt = Date.parse(rootResult.started_at)
-	let latestUsage: any = null
-	let latestUsageAt: number | null = null
+	const logDocuments: string[] = []
+	let trialName: string | null = null
 	for (const entry of readdirSync(jobDir, { withFileTypes: true })) {
 		if (!entry.isDirectory()) continue
 		const clineLog = join(jobDir, entry.name, "agent", "cline.txt")
 		if (!existsSync(clineLog)) continue
-		for (const line of readFileSync(clineLog, "utf8").split("\n")) {
-			if (!line.startsWith("{") || !line.includes('"type":"usage"')) continue
-			try {
-				const parsed = JSON.parse(line)
-				if (parsed.event?.type === "usage") {
-					latestUsage = parsed.event
-					const parsedTimestamp = Date.parse(parsed.ts)
-					latestUsageAt = Number.isFinite(parsedTimestamp) ? parsedTimestamp : latestUsageAt
-				}
-			} catch {
-				// Ignore partial JSON from a force-stopped final line.
-			}
-		}
+		logDocuments.push(readFileSync(clineLog, "utf8"))
+		trialName = entry.name
 	}
-	const costUsd = latestUsage?.totalCost
-	if (!Number.isFinite(costUsd) || costUsd <= 0) {
-		fail(`interrupted run has no usable cost telemetry: ${jobDir}`)
-	}
-	const inputTokens = latestUsage?.totalInputTokens ?? null
-	const cacheTokens = latestUsage?.totalCacheReadTokens ?? null
-	const outputTokens = latestUsage?.totalOutputTokens ?? null
+	const latestUsage = recoverLatestUsage(logDocuments)
+	const costUsd = latestUsage.totalCost
+	const inputTokens = latestUsage.totalInputTokens
+	const cacheTokens = latestUsage.totalCacheReadTokens
+	const outputTokens = latestUsage.totalOutputTokens
+	const virtualModel = model.id === "cline/auto" || model.id === "cline-pass/auto"
+	const sessionIdentity = trialName ? readTrialSessionIdentity(jobDir, trialName) : null
 	return {
 		model: model.id,
+		requestedModel: model.id,
 		task,
+		taskHash: hashPrivateIdentifier("cline-bench-task", task),
+		sessionHash: sessionIdentity?.sessionHash ?? null,
+		sessionIdSha256: sessionIdentity?.sessionIdSha256 ?? null,
+		routeTraces: [],
+		routeEvidence: virtualModel ? "missing" : "not-applicable",
 		outcome: "timed_out",
 		passed: false,
 		reward: null,
 		costUsd,
-		costBasis:
-			routerProfile === "cline-pass-router"
-				? "cline-pass-reference-quota"
-				: "reported-inference",
-		durationSeconds:
-			Number.isFinite(startedAt) && latestUsageAt !== null ? (latestUsageAt - startedAt) / 1000 : 0,
+		costBasis: routerProfile === "cline-pass-router" ? "cline-pass-reference-quota" : "reported-inference",
+		durationSeconds: Number.isFinite(startedAt) ? (Date.parse(latestUsage.timestamp) - startedAt) / 1000 : 0,
 		inputTokens,
 		cacheTokens,
 		outputTokens,
 		...tokenEconomics(model, inputTokens, cacheTokens, outputTokens),
 		jobDir,
+	}
+}
+
+export function matchRouteTraces(
+	traces: readonly RouteTrace[],
+	identity: {
+		requestedModel: string
+		taskHash: string
+		sessionHash: string | null
+		sessionIdSha256: string | null
+	},
+): RouteTrace[] {
+	return traces.filter(
+		(trace) =>
+			trace.requestedModel === identity.requestedModel &&
+			(trace.source === "core"
+				? Boolean(identity.sessionIdSha256) && trace.taskIdSha256 === identity.sessionIdSha256
+				: trace.taskHash === identity.taskHash &&
+					(!trace.sessionHash || !identity.sessionHash || trace.sessionHash === identity.sessionHash)),
+	)
+}
+
+function attachRouteEvidence(result: RunResult, model: ModelConfig, traces: readonly RouteTrace[]): RunResult {
+	result = {
+		...result,
+		requestedModel: result.requestedModel || result.model,
+		taskHash: result.taskHash || hashPrivateIdentifier("cline-bench-task", result.task),
+		sessionHash: result.sessionHash ?? null,
+		sessionIdSha256: result.sessionIdSha256 ?? null,
+		routeTraces: result.routeTraces || [],
+		routeEvidence: result.routeEvidence || "not-applicable",
+	}
+	const virtualModel = model.id === "cline/auto" || model.id === "cline-pass/auto"
+	if (!virtualModel) return { ...result, routeTraces: [], routeEvidence: "not-applicable" }
+	const matched = matchRouteTraces(traces, result)
+	const allowedCandidates = new Set(model.allowedCandidates || [])
+	for (const trace of matched) {
+		if (!allowedCandidates.has(trace.selectedModel)) {
+			fail(`route trace selected disallowed candidate ${trace.selectedModel} for ${model.id} × ${result.task}`)
+		}
+	}
+	return {
+		...result,
+		routeTraces: [...matched].sort((left, right) => Date.parse(left.timestamp) - Date.parse(right.timestamp)),
+		routeEvidence: matched.length > 0 ? "verified" : "missing",
 	}
 }
 
@@ -707,43 +917,132 @@ function taskAgentTimeoutSeconds(task: string): number {
 	return configuredTimeout
 }
 
-// The upstream Telegram verifier installs uv under /root/.local/bin but does
-// not add that directory to PATH. Harbor's verifier container then reports
-// "uv: command not found" after a valid agent run. Materialize a private task
-// overlay with only that infrastructure correction so the submodule remains
-// clean and the benchmark is reproducible from this branch.
 export function prepareTaskPath(task: string, jobsRoot: string): string {
-	if (task !== "01k6zz0nyj31znwsevx4sn6zb2-telegram-plugin-refactor") {
-		return `tasks/${task}`
-	}
-	const source = join(clineBenchDir, "tasks", task)
-	const overlay = join(jobsRoot, "task-overlays", task)
-	// Refresh this generated-only directory before fingerprinting or execution.
-	// Otherwise an old jobs root could retain a verifier copied from an earlier
-	// submodule checkout even when the source task changed.
-	rmSync(overlay, { recursive: true, force: true })
-	mkdirSync(dirname(overlay), { recursive: true, mode: 0o700 })
-	cpSync(source, overlay, { recursive: true })
-	const verifier = join(overlay, "tests", "test.sh")
-	const original = readFileSync(verifier, "utf8")
-	if (!original.includes('export PATH="/root/.local/bin:$PATH"')) {
-		const patched = original.replace(
-			"#!/bin/bash\n",
-			'#!/bin/bash\n\nexport PATH="/root/.local/bin:$PATH"\n',
-		)
-		if (patched === original) fail(`could not patch Telegram verifier: ${verifier}`)
-		writeFileSync(verifier, patched, { mode: 0o755 })
-	}
-	return overlay
+	void jobsRoot
+	return `tasks/${task}`
 }
 
-function runOne(
+// All eight selected verifiers invoke uv, but their task images expose its
+// install directory inconsistently. Harbor's verifier-only environment flag
+// fixes PATH uniformly without changing the agent environment or task corpus.
+export function verifierHarborArguments(): string[] {
+	return ["--ve", "PATH=/root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"]
+}
+
+type HarborProcessResult = {
+	status: number | null
+	stdout: string
+	stderr: string
+	timedOut: boolean
+	signal: NodeJS.Signals | null
+}
+
+export function localCoreHarborArguments(localCoreUrl?: string): string[] {
+	if (!localCoreUrl) return []
+	const normalized = normalizeLocalCoreUrl(localCoreUrl)
+	return [
+		"--ae",
+		`CLINE_API_BASE_URL=${normalized}`,
+		"--allow-agent-host",
+		"host.docker.internal",
+		"--allow-environment-host",
+		"host.docker.internal",
+	]
+}
+
+async function runHarborProcess(args: string[], config: PilotConfig): Promise<HarborProcessResult> {
+	const child = spawn("harbor", args, {
+		cwd: clineBenchDir,
+		env: safeEnvironment(config.provider),
+		detached: process.platform !== "win32",
+		stdio: ["ignore", "pipe", "pipe"],
+	})
+	const maxBuffer = 20 * 1024 * 1024
+	const stdoutChunks: Buffer[] = []
+	const stderrChunks: Buffer[] = []
+	let stdoutBytes = 0
+	let stderrBytes = 0
+	const append = (chunks: Buffer[], chunk: Buffer, current: number) => {
+		if (current >= maxBuffer) return current
+		const remaining = maxBuffer - current
+		chunks.push(chunk.subarray(0, remaining))
+		return current + Math.min(chunk.length, remaining)
+	}
+	child.stdout.on("data", (chunk: Buffer) => {
+		stdoutBytes = append(stdoutChunks, chunk, stdoutBytes)
+	})
+	child.stderr.on("data", (chunk: Buffer) => {
+		stderrBytes = append(stderrChunks, chunk, stderrBytes)
+	})
+
+	const terminateGroup = (signal: NodeJS.Signals) => {
+		if (!child.pid) return
+		try {
+			if (process.platform === "win32") child.kill(signal)
+			else process.kill(-child.pid, signal)
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error
+		}
+	}
+	let timedOut = false
+	let interruptedSignal: NodeJS.Signals | null = null
+	let forceKillTimeout: NodeJS.Timeout | undefined
+	const onSignal = (signal: NodeJS.Signals) => {
+		interruptedSignal = signal
+		terminateGroup("SIGTERM")
+		forceKillTimeout ||= setTimeout(() => terminateGroup("SIGKILL"), 5_000)
+		forceKillTimeout.unref()
+	}
+	const signalHandlers = (["SIGINT", "SIGTERM", "SIGHUP"] as const).map((signal) => {
+		const handler = () => onSignal(signal)
+		process.once(signal, handler)
+		return { signal, handler }
+	})
+	const timeout = setTimeout(
+		() => {
+			timedOut = true
+			terminateGroup("SIGTERM")
+			forceKillTimeout = setTimeout(() => terminateGroup("SIGKILL"), 5_000)
+			forceKillTimeout.unref()
+		},
+		(config.timeoutSeconds + 15 * 60) * 1000,
+	)
+	timeout.unref()
+	let outcome: { status: number | null; signal: NodeJS.Signals | null } | undefined
+	try {
+		outcome = await new Promise<{
+			status: number | null
+			signal: NodeJS.Signals | null
+		}>((resolvePromise, reject) => {
+			child.once("error", reject)
+			child.once("close", (status, signal) => resolvePromise({ status, signal }))
+		})
+	} finally {
+		clearTimeout(timeout)
+		if (forceKillTimeout) clearTimeout(forceKillTimeout)
+		for (const entry of signalHandlers) process.removeListener(entry.signal, entry.handler)
+	}
+	if (interruptedSignal) {
+		throw new Error(`benchmark interrupted by ${interruptedSignal}`)
+	}
+	if (!outcome) throw new Error("Harbor process exited without an outcome")
+	return {
+		status: outcome.status,
+		signal: outcome.signal,
+		timedOut,
+		stdout: Buffer.concat(stdoutChunks).toString("utf8"),
+		stderr: Buffer.concat(stderrChunks).toString("utf8"),
+	}
+}
+
+async function runOne(
 	config: PilotConfig,
 	model: ModelConfig,
 	task: string,
 	jobsRoot: string,
 	runNumber: number,
-): RunResult {
+	localCoreUrl?: string,
+): Promise<RunResult> {
 	const jobName = `${String(runNumber).padStart(2, "0")}-${slug(model.id)}-${slug(task)}`
 	const jobDir = join(jobsRoot, jobName)
 	const harborModel = `${config.provider}:${model.id}`
@@ -777,26 +1076,23 @@ function runOne(
 		jobsRoot,
 		"--yes",
 	]
+	args.push(...verifierHarborArguments())
+	args.push(...localCoreHarborArguments(localCoreUrl))
 
 	console.log(`\n[${runNumber}] ${model.id} × ${task}`)
 	const started = Date.now()
-	const result = spawnSync("harbor", args, {
-		cwd: clineBenchDir,
-		env: safeEnvironment(config.provider),
-		encoding: "utf8",
-		timeout: (config.timeoutSeconds + 15 * 60) * 1000,
-		maxBuffer: 20 * 1024 * 1024,
-	})
+	const result = await runHarborProcess(args, config)
 	const durationSeconds = (Date.now() - started) / 1000
 	const secret = process.env.CLINE_API_KEY || ""
-	const sanitizedOutput = redact(`${result.stdout || ""}\n${result.stderr || ""}`, secret)
+	const sanitizedOutput = redactSecrets(`${result.stdout || ""}\n${result.stderr || ""}`, [secret])
 	mkdirSync(jobDir, { recursive: true, mode: 0o700 })
-	writeFileSync(join(jobDir, "harbor-console.log"), sanitizedOutput, { mode: 0o600 })
+	writeFileSync(join(jobDir, "harbor-console.log"), sanitizedOutput, {
+		mode: 0o600,
+	})
 
-	if (result.error) {
+	if (result.timedOut) {
 		const removed = cleanupJobContainers(jobDir)
-		const errorCode = (result.error as NodeJS.ErrnoException).code
-		if (errorCode === "ETIMEDOUT" && existsSync(join(jobDir, "result.json"))) {
+		if (existsSync(join(jobDir, "result.json"))) {
 			try {
 				return readInterruptedRun(jobDir, config.routerProfile, model, task)
 			} catch (usageError) {
@@ -805,15 +1101,13 @@ function runOne(
 				)
 			}
 		}
-		fail(
-			`Harbor failed for ${model.id} × ${task}: ${result.error.message}; cleaned ${removed.length} container(s)`,
-		)
+		fail(`Harbor timed out for ${model.id} × ${task}; cleaned ${removed.length} container(s)`)
 	}
 	if (result.status !== 0) {
 		const removed = cleanupJobContainers(jobDir)
 		const tail = sanitizedOutput.trim().split("\n").slice(-20).join("\n")
 		fail(
-			`Harbor exited ${result.status} for ${model.id} × ${task}; cleaned ${removed.length} container(s)\n${tail}`,
+			`Harbor exited ${result.status} (signal=${result.signal}) for ${model.id} × ${task}; cleaned ${removed.length} container(s)\n${tail}`,
 		)
 	}
 	return readJobResult(jobDir, config, model, task, durationSeconds)
@@ -842,8 +1136,34 @@ function reuseCompletedRun(
 	return result
 }
 
+function writePrivateJson(path: string, value: unknown) {
+	const temporary = `${path}.tmp-${process.pid}`
+	writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, {
+		mode: 0o600,
+	})
+	renameSync(temporary, path)
+}
+
 function writeReport(report: PilotReport) {
-	writeFileSync(join(report.jobsRoot, "pilot-report.json"), `${JSON.stringify(report, null, 2)}\n`, { mode: 0o600 })
+	writePrivateJson(join(report.jobsRoot, "pilot-report.json"), report)
+}
+
+function budgetLedgerPath(jobsRoot: string): string {
+	return join(jobsRoot, "budget-ledger.json")
+}
+
+function loadBudgetLedger(jobsRoot: string, checkpointUsd: number): BudgetLedger {
+	const path = budgetLedgerPath(jobsRoot)
+	if (!existsSync(path)) return createBudgetLedger(checkpointUsd)
+	const ledger = JSON.parse(readFileSync(path, "utf8")) as BudgetLedger
+	if (ledger.schemaVersion !== 1 || ledger.checkpointUsd !== checkpointUsd || !Array.isArray(ledger.entries)) {
+		fail("budget ledger is missing, incompatible, or belongs to a different checkpoint")
+	}
+	return ledger
+}
+
+function writeBudgetLedger(jobsRoot: string, ledger: BudgetLedger) {
+	writePrivateJson(budgetLedgerPath(jobsRoot), ledger)
 }
 
 function printMatrix(config: PilotConfig) {
@@ -852,73 +1172,160 @@ function printMatrix(config: PilotConfig) {
 	console.log(
 		`Limits: ${config.maxRunsPerModel} runs/model, $${config.globalBudgetUsd.toFixed(2)} global, ${config.timeoutSeconds}s/task`,
 	)
+	if (config.waveBudgetsUsd) {
+		console.log(
+			`Wave checkpoints: ${Object.entries(config.waveBudgetsUsd)
+				.map(([wave, budget]) => `${wave}=$${budget.toFixed(2)}`)
+				.join(", ")}`,
+		)
+	}
 	for (const model of config.models) {
 		console.log(
-			`  ${model.id}: $${model.perTaskBudgetUsd.toFixed(2)}/task stop, $${model.perModelBudgetUsd.toFixed(2)}/model stop`,
+			`  ${model.id} [wave ${model.wave ?? 1}]: $${model.perTaskBudgetUsd.toFixed(2)}/task exposure, $${model.perModelBudgetUsd.toFixed(2)}/model stop`,
 		)
 	}
 	console.log("Latin-square run order:")
 	for (const [index, run] of buildRunMatrix(config).entries()) {
-		console.log(`  ${index + 1}. ${run.model.id} × ${run.task}`)
+		console.log(`  ${index + 1}. [wave ${run.wave}] ${run.model.id} × ${run.task}`)
 	}
 }
 
-function main() {
+function loadRouteTraceFile(path?: string): RouteTrace[] {
+	if (!path) return []
+	if (!existsSync(path)) fail(`route trace file does not exist: ${path}`)
+	const canonicalPath = realpathSync(path)
+	const canonicalRepo = realpathSync(repoRoot)
+	if (canonicalPath === canonicalRepo || canonicalPath.startsWith(`${canonicalRepo}/`)) {
+		fail("route trace file must live outside the repository")
+	}
+	return parseRouteTraces(readFileSync(canonicalPath, "utf8"))
+}
+
+function runKey(index: number, run: ReturnType<typeof buildRunMatrix>[number]): string {
+	return `${index + 1}:${run.wave}:${run.model.id}:${run.task}`
+}
+
+function modelForResult(config: PilotConfig, result: RunResult): ModelConfig {
+	const requestedModel = result.requestedModel || result.model
+	return (
+		config.models.find((model) => model.id === requestedModel) ??
+		fail(`report references unknown requested model: ${requestedModel}`)
+	)
+}
+
+async function main() {
 	const args = parseArgs(process.argv.slice(2))
 	const config = readConfig(args.configPath)
 	validatePrerequisites(args.execute)
 	printMatrix(config)
-	if (!args.execute) {
+	if (!args.execute && !args.ingestRouteTraces) {
 		console.log("\nDry run complete. No model was called. Pass --execute to spend.")
 		return
 	}
 
 	const jobsRoot = createPrivateJobsRoot(args.jobsRoot)
-	const identity = executionIdentity(config, jobsRoot)
-	const fingerprint = identity.fingerprint
-	const existingReportPath = join(jobsRoot, "pilot-report.json")
-	if (existsSync(existingReportPath)) {
-		const existing = JSON.parse(readFileSync(existingReportPath, "utf8")) as Partial<PilotReport>
-		assertReusableFingerprint(existing, fingerprint)
-	} else {
-		const hasUnboundResult = buildRunMatrix(config).some((run, index) => {
-			const jobName = `${String(index + 1).padStart(2, "0")}-${slug(run.model.id)}-${slug(run.task)}`
-			return existsSync(join(jobsRoot, jobName, "result.json"))
-		})
-		if (hasUnboundResult) {
-			fail("jobs-root contains result artifacts without a content-addressed pilot report; use a new jobs-root")
-		}
-	}
-	const report: PilotReport = {
-		startedAt: new Date().toISOString(),
-		mode: "execute",
-		config,
-		executionFingerprint: fingerprint,
-		executionProvenance: identity.provenance,
-		jobsRoot,
-		results: [],
-	}
-	// Bind the jobs root to this exact corpus before Harbor can create result
-	// artifacts. A crash during the first run must not leave reusable,
-	// provenance-free output behind.
-	writeReport(report)
-	const modelSpend = new Map(config.models.map((model) => [model.id, 0]))
-	let globalSpend = 0
-
+	const lock = acquireRunLock(jobsRoot)
+	let report: PilotReport | undefined
 	try {
-		for (const [index, run] of buildRunMatrix(config).entries()) {
+		const removedAtStartup = cleanupJobsRootContainers(jobsRoot)
+		if (removedAtStartup.length > 0) {
+			console.log(`Removed ${removedAtStartup.length} orphaned benchmark container(s) before resume.`)
+		}
+		const identity = executionIdentity(config, jobsRoot, args.localCoreUrl)
+		const fingerprint = identity.fingerprint
+		const existingReportPath = join(jobsRoot, "pilot-report.json")
+		if (existsSync(existingReportPath)) {
+			const existing = JSON.parse(readFileSync(existingReportPath, "utf8")) as Partial<PilotReport>
+			assertReusableFingerprint(existing, fingerprint)
+		} else {
+			const hasUnboundResult = buildRunMatrix(config).some((run, index) => {
+				const jobName = `${String(index + 1).padStart(2, "0")}-${slug(run.model.id)}-${slug(run.task)}`
+				return existsSync(join(jobsRoot, jobName, "result.json"))
+			})
+			if (hasUnboundResult) {
+				fail("jobs-root contains result artifacts without a content-addressed pilot report; use a new jobs-root")
+			}
+		}
+		let budgetLedger = loadBudgetLedger(jobsRoot, config.globalBudgetUsd)
+		const traces = loadRouteTraceFile(args.routeTracesPath)
+		if (args.ingestRouteTraces) {
+			if (!existsSync(existingReportPath)) fail("route trace ingestion requires an existing pilot report")
+			const existing = JSON.parse(readFileSync(existingReportPath, "utf8")) as PilotReport
+			assertReusableFingerprint(existing, fingerprint)
+			existing.results = existing.results.map((result) =>
+				attachRouteEvidence(result, modelForResult(config, result), traces),
+			)
+			existing.finishedAt = new Date().toISOString()
+			writeReport(existing)
+			console.log(`Attached route evidence to ${existing.results.length} result(s). No model was called.`)
+			return
+		}
+		report = {
+			startedAt: new Date().toISOString(),
+			mode: "execute",
+			config,
+			executionFingerprint: fingerprint,
+			executionProvenance: identity.provenance,
+			jobsRoot,
+			budgetLedger,
+			results: [],
+		}
+		writePrivateJson(join(jobsRoot, "execution-manifest.json"), {
+			executionFingerprint: fingerprint,
+			...identity.provenance,
+		})
+		writeBudgetLedger(jobsRoot, budgetLedger)
+		writeReport(report)
+
+		const matrix = buildRunMatrix(config)
+		if (args.onlyRun && args.onlyRun > matrix.length) {
+			fail(`--only-run ${args.onlyRun} exceeds matrix size ${matrix.length}`)
+		}
+		const activeReservations = budgetLedger.entries.filter((entry) => entry.status === "reserved")
+		for (const entry of activeReservations) {
+			const matrixIndex = matrix.findIndex((run, index) => runKey(index, run) === entry.runKey)
+			if (matrixIndex < 0) fail(`budget ledger reservation is not in the execution matrix: ${entry.runKey}`)
+			const run = matrix[matrixIndex]
+			const jobName = `${String(matrixIndex + 1).padStart(2, "0")}-${slug(run.model.id)}-${slug(run.task)}`
+			if (!existsSync(join(jobsRoot, jobName, "result.json"))) {
+				fail(`unsettled prior attempt has no recoverable usage; refusing to spend again: ${entry.runKey}`)
+			}
+		}
+
+		const modelSpend = new Map(config.models.map((model) => [model.id, 0]))
+		let globalSpend = 0
+		for (const [index, run] of matrix.entries()) {
 			if (args.stopAfter && index + 1 > args.stopAfter) {
 				report.stoppedReason = `operator stop-after ${args.stopAfter}`
 				break
 			}
-			const reused = reuseCompletedRun(config, run.model, run.task, jobsRoot, index + 1)
+			const key = runKey(index, run)
+			const reusedRaw = reuseCompletedRun(config, run.model, run.task, jobsRoot, index + 1)
+			const reused = reusedRaw ? attachRouteEvidence(reusedRaw, run.model, traces) : null
 			if (reused) {
 				report.results.push(reused)
 				modelSpend.set(run.model.id, (modelSpend.get(run.model.id) || 0) + reused.costUsd)
 				globalSpend += reused.costUsd
+				if (!budgetLedger.entries.some((entry) => entry.runKey === key)) {
+					budgetLedger = reserveBudget(budgetLedger, {
+						runKey: key,
+						model: run.model.id,
+						wave: run.wave,
+						exposureUsd: run.model.perTaskBudgetUsd,
+						waveBudgetUsd: config.waveBudgetsUsd?.[String(run.wave)],
+					})
+				}
+				budgetLedger = settleBudget(budgetLedger, key, reused.costUsd)
+				writeBudgetLedger(jobsRoot, budgetLedger)
+				report.budgetLedger = budgetLedger
 				writeReport(report)
+				const reusedWaveBudget = config.waveBudgetsUsd?.[String(run.wave)]
+				if (reusedWaveBudget !== undefined && ledgerExposure(budgetLedger, run.wave) > reusedWaveBudget) {
+					fail(`wave ${run.wave} exceeded its $${reusedWaveBudget.toFixed(2)} checkpoint`)
+				}
 				continue
 			}
+			if (args.wave && run.wave !== args.wave) continue
 			if (args.onlyRun && index + 1 !== args.onlyRun) continue
 			const currentModelSpend = modelSpend.get(run.model.id) || 0
 			if (currentModelSpend >= run.model.perModelBudgetUsd) {
@@ -934,8 +1341,27 @@ function main() {
 				fail("pilot lacks room for the next task's declared exposure")
 			}
 
-			const result = runOne(config, run.model, run.task, jobsRoot, index + 1)
+			budgetLedger = reserveBudget(budgetLedger, {
+				runKey: key,
+				model: run.model.id,
+				wave: run.wave,
+				exposureUsd: run.model.perTaskBudgetUsd,
+				waveBudgetUsd: config.waveBudgetsUsd?.[String(run.wave)],
+			})
+			writeBudgetLedger(jobsRoot, budgetLedger)
+			report.budgetLedger = budgetLedger
+			writeReport(report)
+
+			const rawResult = await runOne(config, run.model, run.task, jobsRoot, index + 1, args.localCoreUrl)
+			const result = attachRouteEvidence(rawResult, run.model, traces)
+			budgetLedger = settleBudget(budgetLedger, key, result.costUsd)
+			writeBudgetLedger(jobsRoot, budgetLedger)
+			const waveBudget = config.waveBudgetsUsd?.[String(run.wave)]
+			if (waveBudget !== undefined && ledgerExposure(budgetLedger, run.wave) > waveBudget) {
+				fail(`wave ${run.wave} exceeded its $${waveBudget.toFixed(2)} checkpoint`)
+			}
 			report.results.push(result)
+			report.budgetLedger = budgetLedger
 			modelSpend.set(run.model.id, currentModelSpend + result.costUsd)
 			globalSpend += result.costUsd
 			writeReport(report)
@@ -944,9 +1370,7 @@ function main() {
 			)
 
 			if (result.costUsd > run.model.perTaskBudgetUsd) {
-				fail(
-					`${run.model.id} exceeded its $${run.model.perTaskBudgetUsd.toFixed(2)} per-task stop after ${run.task}`,
-				)
+				fail(`${run.model.id} exceeded its $${run.model.perTaskBudgetUsd.toFixed(2)} per-task stop after ${run.task}`)
 			}
 			if ((modelSpend.get(run.model.id) || 0) > run.model.perModelBudgetUsd) {
 				fail(`${run.model.id} exceeded its $${run.model.perModelBudgetUsd.toFixed(2)} model budget`)
@@ -956,16 +1380,20 @@ function main() {
 			}
 		}
 		if (args.onlyRun) report.stoppedReason = `operator only-run ${args.onlyRun}`
+		if (args.wave) report.stoppedReason = `completed wave ${args.wave}`
 	} catch (error) {
-		report.stoppedReason = error instanceof Error ? error.message : String(error)
+		if (report) report.stoppedReason = error instanceof Error ? error.message : String(error)
 		throw error
 	} finally {
-		report.finishedAt = new Date().toISOString()
-		writeReport(report)
+		if (report) {
+			report.finishedAt = new Date().toISOString()
+			writeReport(report)
+		}
+		releaseRunLock(lock)
 		console.log(`\nReport: ${join(jobsRoot, "pilot-report.json")}`)
 	}
 }
 
 if (import.meta.main) {
-	main()
+	await main()
 }

--- a/evals/e2e/run-cline-bench-pilot.ts
+++ b/evals/e2e/run-cline-bench-pilot.ts
@@ -109,7 +109,7 @@ export type RunResult = {
 	passed: boolean
 	reward: number | null
 	costUsd: number
-	costBasis: "reported-inference" | "cline-pass-reference-quota"
+	costBasis: "reported-inference" | "cline-pass-reference-quota" | "reserved-exposure"
 	durationSeconds: number
 	inputTokens: number | null
 	cacheTokens: number | null
@@ -422,6 +422,72 @@ function validatePrerequisites(execute: boolean) {
 		if (!process.env.CLINE_API_KEY?.trim()) {
 			fail("CLINE_API_KEY must be inherited from the shell for --execute")
 		}
+	}
+}
+
+type ClineRecommendedCatalog = {
+	recommended?: unknown
+	free?: unknown
+	clinePass?: unknown
+}
+
+function catalogModelIds(value: unknown, field: string): string[] {
+	if (!Array.isArray(value)) fail(`live Cline catalog has no valid ${field} model list`)
+	return value.map((entry, index) => {
+		if (
+			!entry ||
+			typeof entry !== "object" ||
+			Array.isArray(entry) ||
+			typeof (entry as Record<string, unknown>).id !== "string" ||
+			!(entry as Record<string, unknown>).id
+		) {
+			fail(`live Cline catalog has an invalid ${field}[${index}] model`)
+		}
+		return (entry as Record<string, unknown>).id as string
+	})
+}
+
+export async function assertDirectModelsInLiveCatalog(
+	config: PilotConfig,
+	fetchImpl: typeof fetch = fetch,
+): Promise<void> {
+	const virtualModel = config.routerProfile === "cline-pass-router" ? "cline-pass/auto" : "cline/auto"
+	const directModels = config.models.filter((model) => model.id !== virtualModel)
+	if (directModels.length === 0) return
+
+	const controller = new AbortController()
+	const timeout = setTimeout(() => controller.abort(), 5_000)
+	timeout.unref()
+	let response: Response
+	try {
+		response = await fetchImpl("https://api.cline.bot/api/v1/ai/cline/recommended-models", {
+			signal: controller.signal,
+		})
+	} catch {
+		fail("live Cline catalog preflight request failed before budget reservation")
+	} finally {
+		clearTimeout(timeout)
+	}
+	if (!response.ok) {
+		fail(`live Cline catalog preflight returned HTTP ${response.status} before budget reservation`)
+	}
+	let raw: ClineRecommendedCatalog
+	try {
+		raw = (await response.json()) as ClineRecommendedCatalog
+	} catch {
+		fail("live Cline catalog preflight returned invalid JSON before budget reservation")
+	}
+	if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+		fail("live Cline catalog preflight returned an invalid document before budget reservation")
+	}
+
+	const allowed =
+		config.routerProfile === "cline-pass-router"
+			? new Set([...catalogModelIds(raw.clinePass, "clinePass"), ...catalogModelIds(raw.free, "free")])
+			: new Set([...catalogModelIds(raw.recommended, "recommended"), ...catalogModelIds(raw.free, "free")])
+	const unavailable = directModels.map((model) => model.id).filter((id) => !allowed.has(id))
+	if (unavailable.length > 0) {
+		fail(`direct model(s) absent from the live Cline ${config.routerProfile} catalog: ${unavailable.join(", ")}`)
 	}
 }
 
@@ -799,11 +865,6 @@ function readJobResult(
 		)
 	}
 
-	const costUsd = doc.stats?.cost_usd
-	if (!Number.isFinite(costUsd) || costUsd <= 0) {
-		fail(`missing or zero cost telemetry for ${expectedModel}`)
-	}
-
 	const rewards = trial.verifier_result?.rewards
 	const rewardValues = rewards && typeof rewards === "object" ? Object.values(rewards) : []
 	const numericRewards = rewardValues.filter((value): value is number => typeof value === "number")
@@ -821,6 +882,48 @@ function readJobResult(
 	const cacheTokens = doc.stats?.n_cache_tokens ?? null
 	const outputTokens = doc.stats?.n_output_tokens ?? null
 	const sessionIdentity = nestedTrial ? readTrialSessionIdentity(jobDir, nestedTrial.trialName) : null
+	const costUsd = doc.stats?.cost_usd
+	if (costUsd === null || costUsd === undefined || costUsd === 0) {
+		// A completed Harbor trial without an exception is not the same thing as
+		// a canonical zero-spend infrastructure failure. Those failures take the
+		// exception path above and must carry Cline's terminal error run_result.
+		//
+		// Some Cline CLI no-op exits instead look "completed" to Harbor while
+		// producing no session, usage, or cost telemetry. Never report those as
+		// free model work or retry the position. Charge the full declared
+		// reservation as conservative exposure and make the missing telemetry a
+		// terminal benchmark failure.
+		return {
+			model: expectedModel,
+			requestedModel: expectedModel,
+			task: trial.task_name,
+			taskHash: hashPrivateIdentifier("cline-bench-task", trial.task_name),
+			sessionHash: sessionIdentity?.sessionHash ?? null,
+			sessionIdSha256: sessionIdentity?.sessionIdSha256 ?? null,
+			routeTraces: [],
+			routeEvidence: virtualModel ? "missing" : "not-applicable",
+			outcome: "failed",
+			failureClassification: "CompletedWithoutCostTelemetry",
+			passed: false,
+			reward: null,
+			costUsd: model.perTaskBudgetUsd,
+			costBasis: "reserved-exposure",
+			durationSeconds: measuredDurationSeconds,
+			inputTokens: Number.isInteger(inputTokens) && inputTokens >= 0 ? inputTokens : null,
+			cacheTokens: Number.isInteger(cacheTokens) && cacheTokens >= 0 ? cacheTokens : null,
+			outputTokens: Number.isInteger(outputTokens) && outputTokens >= 0 ? outputTokens : null,
+			...tokenEconomics(
+				model,
+				Number.isInteger(inputTokens) && inputTokens >= 0 ? inputTokens : null,
+				Number.isInteger(cacheTokens) && cacheTokens >= 0 ? cacheTokens : null,
+				Number.isInteger(outputTokens) && outputTokens >= 0 ? outputTokens : null,
+			),
+			jobDir,
+		}
+	}
+	if (!Number.isFinite(costUsd) || costUsd < 0) {
+		fail(`invalid cost telemetry for ${expectedModel}`)
+	}
 	return {
 		model: expectedModel,
 		requestedModel: expectedModel,
@@ -1692,6 +1795,10 @@ async function main() {
 	if (!args.execute && !args.ingestRouteTraces) {
 		console.log("\nDry run complete. No model was called. Pass --execute to spend.")
 		return
+	}
+	if (args.execute) {
+		await assertDirectModelsInLiveCatalog(config)
+		console.log("Live Cline catalog preflight passed before budget reservation.")
 	}
 
 	const jobsRoot = createPrivateJobsRoot(args.jobsRoot)

--- a/evals/e2e/run-cline-bench-pilot.ts
+++ b/evals/e2e/run-cline-bench-pilot.ts
@@ -21,10 +21,13 @@ import {
 	chmodSync,
 	cpSync,
 	existsSync,
+	lstatSync,
 	mkdirSync,
-	realpathSync,
 	readdirSync,
 	readFileSync,
+	readlinkSync,
+	realpathSync,
+	rmSync,
 	writeFileSync,
 } from "node:fs"
 import { homedir, tmpdir } from "node:os"
@@ -42,7 +45,7 @@ type ModelConfig = {
 	}
 }
 
-type PilotConfig = {
+export type PilotConfig = {
 	routerProfile: "cline-router" | "cline-pass-router"
 	provider: string
 	globalBudgetUsd: number
@@ -51,6 +54,15 @@ type PilotConfig = {
 	clineVersion: string
 	models: ModelConfig[]
 	tasks: string[]
+}
+
+export type ExecutionProvenance = {
+	schemaVersion: 2
+	clineBenchCommit: string
+	tasks: Array<{
+		id: string
+		effectiveContentSha256: string
+	}>
 }
 
 type RunResult = {
@@ -78,6 +90,7 @@ type PilotReport = {
 	mode: "dry-run" | "execute"
 	config: PilotConfig
 	executionFingerprint: string
+	executionProvenance: ExecutionProvenance
 	jobsRoot: string
 	results: RunResult[]
 	stoppedReason?: string
@@ -309,16 +322,107 @@ function createPrivateJobsRoot(requested?: string): string {
 	return canonicalBase
 }
 
-function executionFingerprint(config: PilotConfig): string {
+function appendHashField(hash: ReturnType<typeof createHash>, value: string | Uint8Array) {
+	hash.update(String(typeof value === "string" ? Buffer.byteLength(value) : value.byteLength))
+	hash.update(":")
+	hash.update(value)
+}
+
+// Hash the exact directory tree Harbor receives. Relative names, entry types,
+// executable bits, symlink targets, and file bytes are framed separately so
+// renames and concatenation ambiguities cannot collide accidentally.
+export function hashDirectoryTree(root: string): string {
+	if (!existsSync(root) || !lstatSync(root).isDirectory()) {
+		fail(`cannot fingerprint missing task directory: ${root}`)
+	}
+	const hash = createHash("sha256")
+
+	function visit(directory: string, relativeDirectory: string) {
+		const entries = readdirSync(directory, { withFileTypes: true }).sort((left, right) =>
+			left.name < right.name ? -1 : left.name > right.name ? 1 : 0,
+		)
+		for (const entry of entries) {
+			const relativePath = relativeDirectory ? `${relativeDirectory}/${entry.name}` : entry.name
+			const absolutePath = join(directory, entry.name)
+			if (entry.isDirectory()) {
+				appendHashField(hash, "directory")
+				appendHashField(hash, relativePath)
+				visit(absolutePath, relativePath)
+			} else if (entry.isFile()) {
+				const content = readFileSync(absolutePath)
+				appendHashField(hash, "file")
+				appendHashField(hash, relativePath)
+				appendHashField(hash, String(lstatSync(absolutePath).mode & 0o111))
+				appendHashField(hash, content)
+			} else if (entry.isSymbolicLink()) {
+				appendHashField(hash, "symlink")
+				appendHashField(hash, relativePath)
+				appendHashField(hash, readlinkSync(absolutePath))
+			} else {
+				fail(`cannot fingerprint unsupported task entry: ${absolutePath}`)
+			}
+		}
+	}
+
+	visit(root, "")
+	return hash.digest("hex")
+}
+
+export function fingerprintExecution(config: PilotConfig, provenance: ExecutionProvenance): string {
 	const executionConfig = {
+		fingerprintSchemaVersion: provenance.schemaVersion,
 		routerProfile: config.routerProfile,
 		provider: config.provider,
 		timeoutSeconds: config.timeoutSeconds,
 		clineVersion: config.clineVersion,
 		models: config.models.map((model) => model.id),
 		tasks: config.tasks,
+		clineBenchCommit: provenance.clineBenchCommit,
+		effectiveTasks: provenance.tasks,
 	}
 	return createHash("sha256").update(JSON.stringify(executionConfig)).digest("hex")
+}
+
+export function assertReusableFingerprint(existing: Partial<PilotReport>, expectedFingerprint: string) {
+	if (!existing.executionFingerprint) {
+		fail("jobs-root report predates content-addressed task fingerprints; use a new jobs-root")
+	}
+	if (existing.executionFingerprint !== expectedFingerprint) {
+		fail("jobs-root belongs to a different execution matrix, cline-bench commit, or effective task corpus")
+	}
+}
+
+function readClineBenchCommit(): string {
+	const result = spawnSync("git", ["-C", clineBenchDir, "rev-parse", "--verify", "HEAD^{commit}"], {
+		encoding: "utf8",
+		env: infrastructureEnvironment(),
+	})
+	const commit = (result.stdout || "").trim()
+	if (result.status !== 0 || !/^[0-9a-f]{40,64}$/.test(commit)) {
+		fail(
+			`could not resolve exact cline-bench submodule commit: ${(result.stderr || "").trim() || "unknown error"}`,
+		)
+	}
+	return commit
+}
+
+function executionIdentity(config: PilotConfig, jobsRoot: string) {
+	const provenance: ExecutionProvenance = {
+		schemaVersion: 2,
+		clineBenchCommit: readClineBenchCommit(),
+		tasks: config.tasks.map((task) => {
+			const taskPath = prepareTaskPath(task, jobsRoot)
+			const effectivePath = isAbsolute(taskPath) ? taskPath : join(clineBenchDir, taskPath)
+			return {
+				id: task,
+				effectiveContentSha256: hashDirectoryTree(effectivePath),
+			}
+		}),
+	}
+	return {
+		fingerprint: fingerprintExecution(config, provenance),
+		provenance,
+	}
 }
 
 function safeEnvironment(provider: string): NodeJS.ProcessEnv {
@@ -614,19 +718,21 @@ export function prepareTaskPath(task: string, jobsRoot: string): string {
 	}
 	const source = join(clineBenchDir, "tasks", task)
 	const overlay = join(jobsRoot, "task-overlays", task)
-	if (!existsSync(overlay)) {
-		mkdirSync(dirname(overlay), { recursive: true, mode: 0o700 })
-		cpSync(source, overlay, { recursive: true })
-		const verifier = join(overlay, "tests", "test.sh")
-		const original = readFileSync(verifier, "utf8")
-		if (!original.includes('export PATH="/root/.local/bin:$PATH"')) {
-			const patched = original.replace(
-				"#!/bin/bash\n",
-				'#!/bin/bash\n\nexport PATH="/root/.local/bin:$PATH"\n',
-			)
-			if (patched === original) fail(`could not patch Telegram verifier: ${verifier}`)
-			writeFileSync(verifier, patched, { mode: 0o755 })
-		}
+	// Refresh this generated-only directory before fingerprinting or execution.
+	// Otherwise an old jobs root could retain a verifier copied from an earlier
+	// submodule checkout even when the source task changed.
+	rmSync(overlay, { recursive: true, force: true })
+	mkdirSync(dirname(overlay), { recursive: true, mode: 0o700 })
+	cpSync(source, overlay, { recursive: true })
+	const verifier = join(overlay, "tests", "test.sh")
+	const original = readFileSync(verifier, "utf8")
+	if (!original.includes('export PATH="/root/.local/bin:$PATH"')) {
+		const patched = original.replace(
+			"#!/bin/bash\n",
+			'#!/bin/bash\n\nexport PATH="/root/.local/bin:$PATH"\n',
+		)
+		if (patched === original) fail(`could not patch Telegram verifier: ${verifier}`)
+		writeFileSync(verifier, patched, { mode: 0o755 })
 	}
 	return overlay
 }
@@ -768,15 +874,19 @@ function main() {
 	}
 
 	const jobsRoot = createPrivateJobsRoot(args.jobsRoot)
-	const fingerprint = executionFingerprint(config)
+	const identity = executionIdentity(config, jobsRoot)
+	const fingerprint = identity.fingerprint
 	const existingReportPath = join(jobsRoot, "pilot-report.json")
 	if (existsSync(existingReportPath)) {
 		const existing = JSON.parse(readFileSync(existingReportPath, "utf8")) as Partial<PilotReport>
-		const existingFingerprint =
-			existing.executionFingerprint ||
-			(existing.config ? executionFingerprint(existing.config) : undefined)
-		if (existingFingerprint !== fingerprint) {
-			fail("jobs-root belongs to a different provider/model/task/CLI execution matrix")
+		assertReusableFingerprint(existing, fingerprint)
+	} else {
+		const hasUnboundResult = buildRunMatrix(config).some((run, index) => {
+			const jobName = `${String(index + 1).padStart(2, "0")}-${slug(run.model.id)}-${slug(run.task)}`
+			return existsSync(join(jobsRoot, jobName, "result.json"))
+		})
+		if (hasUnboundResult) {
+			fail("jobs-root contains result artifacts without a content-addressed pilot report; use a new jobs-root")
 		}
 	}
 	const report: PilotReport = {
@@ -784,9 +894,14 @@ function main() {
 		mode: "execute",
 		config,
 		executionFingerprint: fingerprint,
+		executionProvenance: identity.provenance,
 		jobsRoot,
 		results: [],
 	}
+	// Bind the jobs root to this exact corpus before Harbor can create result
+	// artifacts. A crash during the first run must not leave reusable,
+	// provenance-free output behind.
+	writeReport(report)
 	const modelSpend = new Map(config.models.map((model) => [model.id, 0]))
 	let globalSpend = 0
 

--- a/evals/e2e/run-cline-bench-pilot.ts
+++ b/evals/e2e/run-cline-bench-pilot.ts
@@ -149,6 +149,16 @@ function fail(message: string): never {
 	throw new Error(message)
 }
 
+export function resolveRouteTracesPath(
+	explicitPath?: string,
+	configuredPath = process.env.AUTO_ROUTER_BENCHMARK_TRACE_PATH,
+): string | undefined {
+	const selected = explicitPath?.trim() || configuredPath?.trim()
+	if (!selected) return undefined
+	if (!isAbsolute(selected)) fail("route trace path must be absolute")
+	return resolve(selected)
+}
+
 function parseArgs(argv: string[]) {
 	let execute = false
 	let configPath = defaultConfigPath
@@ -182,7 +192,7 @@ function parseArgs(argv: string[]) {
 		} else if (arg === "--local-core-url") {
 			localCoreUrl = normalizeLocalCoreUrl(argv[++index] ?? fail("--local-core-url requires a URL"))
 		} else if (arg === "--route-traces") {
-			routeTracesPath = resolve(argv[++index] ?? fail("--route-traces requires a path"))
+			routeTracesPath = argv[++index] ?? fail("--route-traces requires a path")
 		} else if (arg === "--ingest-route-traces") {
 			ingestRouteTraces = true
 		} else if (arg === "--help" || arg === "-h") {
@@ -197,7 +207,8 @@ Options:
   --only-run <n>      Reuse prior work but execute only matrix run n
   --wave <n>          Execute only the selected staged wave
   --local-core-url    Local Core URL (strictly localhost:7777 or :17777)
-  --route-traces      Privacy-safe Core route trace JSON/JSONL
+  --route-traces <path>
+                      Privacy-safe Core route JSON/JSONL (overrides AUTO_ROUTER_BENCHMARK_TRACE_PATH)
   --ingest-route-traces
                       Attach traces to an existing report without model calls
   --help              Show this help`)
@@ -208,8 +219,11 @@ Options:
 	}
 
 	if (stopAfter && onlyRun) fail("--stop-after and --only-run cannot be combined")
+	routeTracesPath = resolveRouteTracesPath(routeTracesPath)
 	if (ingestRouteTraces && execute) fail("--ingest-route-traces cannot be combined with --execute")
-	if (ingestRouteTraces && !routeTracesPath) fail("--ingest-route-traces requires --route-traces")
+	if (ingestRouteTraces && !routeTracesPath) {
+		fail("--ingest-route-traces requires --route-traces or AUTO_ROUTER_BENCHMARK_TRACE_PATH")
+	}
 	if (ingestRouteTraces && !jobsRoot) fail("--ingest-route-traces requires --jobs-root")
 	if (execute && !jobsRoot) fail("--execute requires an explicit --jobs-root")
 	return {
@@ -1467,6 +1481,29 @@ export function assertModelTransportPrerequisites(config: PilotConfig, localCore
 	}
 }
 
+export function assertRouteTracePrerequisites(
+	config: PilotConfig,
+	execute: boolean,
+	routeTracesPath?: string,
+	onlyRun?: number,
+	wave?: number,
+): void {
+	if (!execute) return
+	const requiresTrace = buildRunMatrix(config).some(
+		(run, index) =>
+			(!onlyRun || index + 1 === onlyRun) &&
+			(!wave || run.wave === wave) &&
+			run.model.transport === "local-core" &&
+			(run.model.id === "cline/auto" || run.model.id === "cline-pass/auto"),
+	)
+	if (requiresTrace && !routeTracesPath) {
+		fail(
+			"local-Core virtual-model execution requires --route-traces or AUTO_ROUTER_BENCHMARK_TRACE_PATH before budget reservation",
+		)
+	}
+	if (requiresTrace) loadRouteTraceFile(routeTracesPath)
+}
+
 export function liveCostStopUsd(perTaskBudgetUsd: number): number {
 	if (!Number.isFinite(perTaskBudgetUsd) || perTaskBudgetUsd <= 0) {
 		throw new Error("per-task budget must be positive")
@@ -1923,15 +1960,36 @@ function printMatrix(config: PilotConfig) {
 	}
 }
 
-function loadRouteTraceFile(path?: string): RouteTrace[] {
+export function loadRouteTraceFile(path?: string): RouteTrace[] {
 	if (!path) return []
+	if (!isAbsolute(path)) fail("route trace path must be absolute")
 	if (!existsSync(path)) fail(`route trace file does not exist: ${path}`)
+	const metadata = lstatSync(path)
+	if (!metadata.isFile()) fail("route trace path must be a regular file")
+	if ((metadata.mode & 0o077) !== 0) fail("route trace file must be private")
 	const canonicalPath = realpathSync(path)
 	const canonicalRepo = realpathSync(repoRoot)
 	if (canonicalPath === canonicalRepo || canonicalPath.startsWith(`${canonicalRepo}/`)) {
 		fail("route trace file must live outside the repository")
 	}
 	return parseRouteTraces(readFileSync(canonicalPath, "utf8"))
+}
+
+function isVirtualModel(model: ModelConfig): boolean {
+	return model.id === "cline/auto" || model.id === "cline-pass/auto"
+}
+
+export function loadModelRouteTraces(model: ModelConfig, path?: string): RouteTrace[] {
+	return isVirtualModel(model) ? loadRouteTraceFile(path) : []
+}
+
+export function missingRouteEvidenceStopReason(
+	model: ModelConfig,
+	result: Pick<RunResult, "routeEvidence" | "task">,
+): string | undefined {
+	return isVirtualModel(model) && result.routeEvidence === "missing"
+		? `missing route evidence for ${model.id} × ${result.task}`
+		: undefined
 }
 
 function runKey(index: number, run: ReturnType<typeof buildRunMatrix>[number]): string {
@@ -1965,6 +2023,7 @@ function resultCostLabel(result: RunResult): string {
 async function main() {
 	const args = parseArgs(process.argv.slice(2))
 	const config = readConfig(args.configPath)
+	assertRouteTracePrerequisites(config, args.execute, args.routeTracesPath, args.onlyRun, args.wave)
 	validatePrerequisites(args.execute)
 	printMatrix(config)
 	if (!args.execute && !args.ingestRouteTraces) {
@@ -2012,8 +2071,8 @@ async function main() {
 			}
 		}
 		let budgetLedger = loadBudgetLedger(jobsRoot, config.globalBudgetUsd)
-		const traces = loadRouteTraceFile(args.routeTracesPath)
 		if (args.ingestRouteTraces) {
+			const traces = loadRouteTraceFile(args.routeTracesPath)
 			if (!existsSync(existingReportPath)) fail("route trace ingestion requires an existing pilot report")
 			const existing = JSON.parse(readFileSync(existingReportPath, "utf8")) as PilotReport
 			existing.results = existing.results.map((result) =>
@@ -2069,7 +2128,9 @@ async function main() {
 			}
 			const key = runKey(index, run)
 			const reusedRaw = reuseCompletedRun(config, run.model, run.task, jobsRoot, index + 1)
-			const reused = reusedRaw ? attachRouteEvidence(reusedRaw, run.model, traces) : null
+			const reused = reusedRaw
+				? attachRouteEvidence(reusedRaw, run.model, loadModelRouteTraces(run.model, args.routeTracesPath))
+				: null
 			if (reused) {
 				report.results.push(reused)
 				const reusedExposure = conservativeRunExposure(reused)
@@ -2091,6 +2152,11 @@ async function main() {
 				const reusedWaveBudget = config.waveBudgetsUsd?.[String(run.wave)]
 				if (reusedWaveBudget !== undefined && ledgerExposure(budgetLedger, run.wave) > reusedWaveBudget) {
 					fail(`wave ${run.wave} exceeded its $${reusedWaveBudget.toFixed(2)} checkpoint`)
+				}
+				const reusedRouteStopReason = missingRouteEvidenceStopReason(run.model, reused)
+				if (reusedRouteStopReason) {
+					report.stoppedReason = reusedRouteStopReason
+					break
 				}
 				continue
 			}
@@ -2122,7 +2188,7 @@ async function main() {
 			writeReport(report)
 
 			const rawResult = await runOne(config, run.model, run.task, jobsRoot, index + 1, args.localCoreUrl)
-			const result = attachRouteEvidence(rawResult, run.model, traces)
+			const result = attachRouteEvidence(rawResult, run.model, loadModelRouteTraces(run.model, args.routeTracesPath))
 			budgetLedger = settleResultBudget(budgetLedger, key, result)
 			writeBudgetLedger(jobsRoot, budgetLedger)
 			const waveBudget = config.waveBudgetsUsd?.[String(run.wave)]
@@ -2148,9 +2214,14 @@ async function main() {
 			if (globalSpend > config.globalBudgetUsd) {
 				fail(`pilot exceeded its $${config.globalBudgetUsd.toFixed(2)} global budget`)
 			}
+			const routeStopReason = missingRouteEvidenceStopReason(run.model, result)
+			if (routeStopReason) {
+				report.stoppedReason = routeStopReason
+				break
+			}
 		}
-		if (args.onlyRun) report.stoppedReason = `operator only-run ${args.onlyRun}`
-		if (args.wave) report.stoppedReason = `completed wave ${args.wave}`
+		if (!report.stoppedReason && args.onlyRun) report.stoppedReason = `operator only-run ${args.onlyRun}`
+		if (!report.stoppedReason && args.wave) report.stoppedReason = `completed wave ${args.wave}`
 	} catch (error) {
 		if (report) report.stoppedReason = error instanceof Error ? error.message : String(error)
 		throw error

--- a/evals/e2e/run-cline-bench-pilot.ts
+++ b/evals/e2e/run-cline-bench-pilot.ts
@@ -55,6 +55,7 @@ import {
 
 export type ModelConfig = {
 	id: string
+	transport?: "cline-api" | "local-core"
 	perTaskBudgetUsd: number
 	perModelBudgetUsd: number
 	tasks?: string[]
@@ -253,7 +254,16 @@ export function readConfig(configPath: string): PilotConfig {
 	const models = raw.models.map((value, index): ModelConfig => {
 		assertOnlyKeys(
 			value,
-			["id", "perTaskBudgetUsd", "perModelBudgetUsd", "pricing", "tasks", "wave", "allowedCandidates"],
+			[
+				"id",
+				"transport",
+				"perTaskBudgetUsd",
+				"perModelBudgetUsd",
+				"pricing",
+				"tasks",
+				"wave",
+				"allowedCandidates",
+			],
 			`models[${index}]`,
 		)
 		let pricing: ModelConfig["pricing"]
@@ -267,6 +277,7 @@ export function readConfig(configPath: string): PilotConfig {
 		}
 		return {
 			id: value.id,
+			...(value.transport !== undefined ? { transport: value.transport } : {}),
 			perTaskBudgetUsd: value.perTaskBudgetUsd,
 			perModelBudgetUsd: value.perModelBudgetUsd,
 			...(value.tasks !== undefined ? { tasks: value.tasks } : {}),
@@ -316,6 +327,13 @@ export function readConfig(configPath: string): PilotConfig {
 		}
 		if (seenModels.has(model.id)) fail(`duplicate model: ${model.id}`)
 		seenModels.add(model.id)
+		if (
+			model.transport !== undefined &&
+			model.transport !== "cline-api" &&
+			model.transport !== "local-core"
+		) {
+			fail(`invalid transport for ${model.id}: ${JSON.stringify(model.transport)}`)
+		}
 		if (config.routerProfile === "cline-pass-router" && !model.id.startsWith("cline-pass/")) {
 			fail(`cline-pass-router model must use a public cline-pass/* id: ${model.id}`)
 		}
@@ -1341,9 +1359,32 @@ export function localCoreHarborArguments(localCoreUrl?: string): string[] {
 	]
 }
 
-export function modelTransportHarborArguments(modelId: string, localCoreUrl?: string): string[] {
-	const usesLocalRouter = modelId === "cline/auto" || modelId === "cline-pass/auto"
-	return usesLocalRouter ? localCoreHarborArguments(localCoreUrl) : []
+export function modelTransportHarborArguments(
+	modelId: string,
+	localCoreUrl?: string,
+	transport?: ModelConfig["transport"],
+): string[] {
+	const isVirtualRouter = modelId === "cline/auto" || modelId === "cline-pass/auto"
+	const usesLocalCore = transport === "local-core" || (transport === undefined && isVirtualRouter)
+	if (transport === "cline-api" || !usesLocalCore) return []
+	if (!localCoreUrl) {
+		if (transport === "local-core") {
+			fail(`model ${modelId} requires --local-core-url for transport=local-core`)
+		}
+		return []
+	}
+	return localCoreHarborArguments(localCoreUrl)
+}
+
+export function assertModelTransportPrerequisites(config: PilotConfig, localCoreUrl?: string): void {
+	if (localCoreUrl) normalizeLocalCoreUrl(localCoreUrl)
+	for (const model of config.models) {
+		if (model.transport === "local-core" && !localCoreUrl) {
+			fail(
+				`model ${model.id} requires --local-core-url for transport=local-core before jobs-root creation and budget reservation`,
+			)
+		}
+	}
 }
 
 export function liveCostStopUsd(perTaskBudgetUsd: number): number {
@@ -1646,7 +1687,7 @@ async function runOne(
 		"--yes",
 	]
 	args.push(...verifierHarborArguments())
-	args.push(...modelTransportHarborArguments(model.id, localCoreUrl))
+	args.push(...modelTransportHarborArguments(model.id, localCoreUrl, model.transport))
 
 	console.log(`\n[${runNumber}] ${model.id} × ${task}`)
 	const startedAt = new Date().toISOString()
@@ -1790,7 +1831,7 @@ function printMatrix(config: PilotConfig) {
 	}
 	for (const model of config.models) {
 		console.log(
-			`  ${model.id} [wave ${model.wave ?? 1}]: $${model.perTaskBudgetUsd.toFixed(2)}/task exposure, $${model.perModelBudgetUsd.toFixed(2)}/model stop`,
+			`  ${model.id} [wave ${model.wave ?? 1}, transport ${model.transport ?? "default"}]: $${model.perTaskBudgetUsd.toFixed(2)}/task exposure, $${model.perModelBudgetUsd.toFixed(2)}/model stop`,
 		)
 	}
 	console.log("Latin-square run order:")
@@ -1832,6 +1873,7 @@ async function main() {
 		return
 	}
 	if (args.execute) {
+		assertModelTransportPrerequisites(config, args.localCoreUrl)
 		assertLocalClineVersion(config)
 		console.log(`Local Cline ${config.clineVersion} preflight passed before jobs-root creation and budget reservation.`)
 		await assertDirectModelsInLiveCatalog(config)

--- a/evals/e2e/run-cline-bench-pilot.ts
+++ b/evals/e2e/run-cline-bench-pilot.ts
@@ -8,11 +8,13 @@
  * - exactly one task runs at a time, once
  * - only an allowlist of host environment variables reaches Harbor
  * - task/model/global budget checks stop subsequent work
+ * - cumulative Cline usage stops an active run with billing headroom
  * - jobs and reports live outside the repository with private permissions
  *
- * Harbor/Cline currently reports cost only after an agent run finishes. The
- * per-task budget is therefore a stop-after-run guard, while the wall timeout
- * is the proactive bound during a run.
+ * Cline writes cumulative usage after each model turn. The runner watches that
+ * private log and terminates Harbor before the per-task reservation is
+ * exhausted. One in-flight turn can still complete before termination, so the
+ * guard retains explicit billing headroom.
  */
 
 import { spawn, spawnSync } from "node:child_process"
@@ -48,6 +50,7 @@ import {
 	reserveBudget,
 	settleBudget,
 	sha256,
+	type UsageSnapshot,
 } from "./cline-bench-safety"
 
 export type ModelConfig = {
@@ -980,6 +983,117 @@ function readInterruptedRun(
 	)
 }
 
+type LiveCostStopMarker = {
+	schemaVersion: 1
+	model: string
+	taskHash: string
+	startedAt: string
+	stoppedAt: string
+	stopUsd: number
+	reservationUsd: number
+	usage: UsageSnapshot
+}
+
+function liveCostStopMarkerPath(jobDir: string): string {
+	return join(jobDir, "live-cost-stop.json")
+}
+
+function readLiveCostStopMarker(jobDir: string, model: ModelConfig, task: string): LiveCostStopMarker {
+	const path = liveCostStopMarkerPath(jobDir)
+	if (!existsSync(path)) fail(`live cost stop marker is missing: ${path}`)
+	const marker = JSON.parse(readFileSync(path, "utf8")) as Partial<LiveCostStopMarker>
+	const expectedTaskHash = hashPrivateIdentifier("cline-bench-task", task)
+	const expectedStopUsd = liveCostStopUsd(model.perTaskBudgetUsd)
+	const usage = marker.usage
+	if (
+		marker.schemaVersion !== 1 ||
+		marker.model !== model.id ||
+		marker.taskHash !== expectedTaskHash ||
+		marker.reservationUsd !== model.perTaskBudgetUsd ||
+		typeof marker.stopUsd !== "number" ||
+		Math.abs(marker.stopUsd - expectedStopUsd) > 1e-9 ||
+		typeof marker.startedAt !== "string" ||
+		!Number.isFinite(Date.parse(marker.startedAt)) ||
+		typeof marker.stoppedAt !== "string" ||
+		!Number.isFinite(Date.parse(marker.stoppedAt)) ||
+		!usage ||
+		typeof usage.timestamp !== "string" ||
+		!Number.isFinite(Date.parse(usage.timestamp)) ||
+		typeof usage.totalCost !== "number" ||
+		!Number.isFinite(usage.totalCost) ||
+		usage.totalCost < expectedStopUsd ||
+		!Number.isInteger(usage.totalInputTokens) ||
+		(usage.totalInputTokens ?? -1) < 0 ||
+		!Number.isInteger(usage.totalCacheReadTokens) ||
+		(usage.totalCacheReadTokens ?? -1) < 0 ||
+		!Number.isInteger(usage.totalOutputTokens) ||
+		(usage.totalOutputTokens ?? -1) < 0
+	) {
+		fail(`live cost stop marker is invalid or belongs to different work: ${path}`)
+	}
+	return marker as LiveCostStopMarker
+}
+
+function markerRunResult(
+	jobDir: string,
+	config: PilotConfig,
+	model: ModelConfig,
+	task: string,
+	marker: LiveCostStopMarker,
+): RunResult {
+	const usage = marker.usage
+	const virtualModel = model.id === "cline/auto" || model.id === "cline-pass/auto"
+	const durationSeconds = Math.max(0, (Date.parse(marker.stoppedAt) - Date.parse(marker.startedAt)) / 1000)
+	return {
+		model: model.id,
+		requestedModel: model.id,
+		task,
+		taskHash: marker.taskHash,
+		sessionHash: null,
+		sessionIdSha256: null,
+		routeTraces: [],
+		routeEvidence: virtualModel ? "missing" : "not-applicable",
+		outcome: "failed",
+		failureClassification: "LiveCostGuardExceeded",
+		passed: false,
+		reward: null,
+		costUsd: usage.totalCost,
+		costBasis: config.routerProfile === "cline-pass-router" ? "cline-pass-reference-quota" : "reported-inference",
+		durationSeconds,
+		inputTokens: usage.totalInputTokens,
+		cacheTokens: usage.totalCacheReadTokens,
+		outputTokens: usage.totalOutputTokens,
+		...tokenEconomics(model, usage.totalInputTokens, usage.totalCacheReadTokens, usage.totalOutputTokens),
+		jobDir,
+	}
+}
+
+export function readLiveCostStoppedRun(
+	jobDir: string,
+	config: PilotConfig,
+	model: ModelConfig,
+	task: string,
+): RunResult {
+	const marker = readLiveCostStopMarker(jobDir, model, task)
+	if (existsSync(join(jobDir, "result.json"))) {
+		try {
+			const recovered = recoveredUnsuccessfulRun(
+				jobDir,
+				config,
+				model,
+				task,
+				"failed",
+				"LiveCostGuardExceeded",
+			)
+			if (recovered.costUsd >= marker.usage.totalCost) return recovered
+		} catch {
+			// The marker is persisted before termination specifically so a
+			// missing or incomplete Harbor result cannot authorize a respent.
+		}
+	}
+	return markerRunResult(jobDir, config, model, task, marker)
+}
+
 export function readRecoveredFailedRun(
 	jobDir: string,
 	config: PilotConfig,
@@ -1070,6 +1184,9 @@ type HarborProcessResult = {
 	stdout: string
 	stderr: string
 	timedOut: boolean
+	liveCostStopped: boolean
+	liveCostAtStopUsd: number | null
+	liveCostGuardError: string | null
 	signal: NodeJS.Signals | null
 }
 
@@ -1091,7 +1208,47 @@ export function modelTransportHarborArguments(modelId: string, localCoreUrl?: st
 	return usesLocalRouter ? localCoreHarborArguments(localCoreUrl) : []
 }
 
-async function runHarborProcess(args: string[], config: PilotConfig): Promise<HarborProcessResult> {
+export function liveCostStopUsd(perTaskBudgetUsd: number): number {
+	if (!Number.isFinite(perTaskBudgetUsd) || perTaskBudgetUsd <= 0) {
+		throw new Error("per-task budget must be positive")
+	}
+	const headroomUsd = Math.max(0.55, perTaskBudgetUsd * 0.25)
+	return Math.max(perTaskBudgetUsd * 0.25, perTaskBudgetUsd - headroomUsd)
+}
+
+export function readLiveUsage(jobDir: string): UsageSnapshot | null {
+	if (!existsSync(jobDir)) return null
+	const logPaths = readdirSync(jobDir, { withFileTypes: true })
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => join(jobDir, entry.name, "agent", "cline.txt"))
+		.filter((path) => existsSync(path))
+	if (logPaths.length === 0) return null
+	if (logPaths.length !== 1) {
+		throw new Error(`live cost guard requires exactly one attempt; found ${logPaths.length}`)
+	}
+	const document = readFileSync(logPaths[0], "utf8")
+	const finalNewline = document.lastIndexOf("\n")
+	if (finalNewline < 0) return null
+	try {
+		return recoverLatestUsage([document.slice(0, finalNewline + 1)])
+	} catch (error) {
+		if (error instanceof Error && error.message === "interrupted run has no usable cost telemetry") return null
+		throw error
+	}
+}
+
+async function runHarborProcess(
+	args: string[],
+	config: PilotConfig,
+	liveCostGuard: {
+		jobDir: string
+		model: string
+		taskHash: string
+		startedAt: string
+		stopUsd: number
+		reservationUsd: number
+	},
+): Promise<HarborProcessResult> {
 	const child = spawn("harbor", args, {
 		cwd: clineBenchDir,
 		env: safeEnvironment(config.provider),
@@ -1126,13 +1283,19 @@ async function runHarborProcess(args: string[], config: PilotConfig): Promise<Ha
 		}
 	}
 	let timedOut = false
+	let liveCostStopped = false
+	let liveCostAtStopUsd: number | null = null
+	let liveCostGuardError: string | null = null
 	let interruptedSignal: NodeJS.Signals | null = null
 	let forceKillTimeout: NodeJS.Timeout | undefined
-	const onSignal = (signal: NodeJS.Signals) => {
-		interruptedSignal = signal
+	const terminateWithFallback = () => {
 		terminateGroup("SIGTERM")
 		forceKillTimeout ||= setTimeout(() => terminateGroup("SIGKILL"), 5_000)
 		forceKillTimeout.unref()
+	}
+	const onSignal = (signal: NodeJS.Signals) => {
+		interruptedSignal = signal
+		terminateWithFallback()
 	}
 	const signalHandlers = (["SIGINT", "SIGTERM", "SIGHUP"] as const).map((signal) => {
 		const handler = () => onSignal(signal)
@@ -1142,13 +1305,39 @@ async function runHarborProcess(args: string[], config: PilotConfig): Promise<Ha
 	const timeout = setTimeout(
 		() => {
 			timedOut = true
-			terminateGroup("SIGTERM")
-			forceKillTimeout = setTimeout(() => terminateGroup("SIGKILL"), 5_000)
-			forceKillTimeout.unref()
+			terminateWithFallback()
 		},
 		(config.timeoutSeconds + 15 * 60) * 1000,
 	)
 	timeout.unref()
+	const costGuardInterval = setInterval(() => {
+		if (liveCostStopped || liveCostGuardError) return
+		try {
+			const latest = readLiveUsage(liveCostGuard.jobDir)
+			if (latest && latest.totalCost >= liveCostGuard.stopUsd) {
+				liveCostStopped = true
+				liveCostAtStopUsd = latest.totalCost
+				mkdirSync(liveCostGuard.jobDir, { recursive: true, mode: 0o700 })
+				writePrivateJson(join(liveCostGuard.jobDir, "live-cost-stop.json"), {
+					schemaVersion: 1,
+					model: liveCostGuard.model,
+					taskHash: liveCostGuard.taskHash,
+					startedAt: liveCostGuard.startedAt,
+					stoppedAt: new Date().toISOString(),
+					stopUsd: liveCostGuard.stopUsd,
+					reservationUsd: liveCostGuard.reservationUsd,
+					usage: latest,
+				})
+				cleanupJobContainers(liveCostGuard.jobDir)
+				terminateWithFallback()
+			}
+		} catch (error) {
+			liveCostGuardError = error instanceof Error ? error.message : String(error)
+			cleanupJobContainers(liveCostGuard.jobDir)
+			terminateWithFallback()
+		}
+	}, 250)
+	costGuardInterval.unref()
 	let outcome: { status: number | null; signal: NodeJS.Signals | null } | undefined
 	try {
 		outcome = await new Promise<{
@@ -1160,6 +1349,7 @@ async function runHarborProcess(args: string[], config: PilotConfig): Promise<Ha
 		})
 	} finally {
 		clearTimeout(timeout)
+		clearInterval(costGuardInterval)
 		if (forceKillTimeout) clearTimeout(forceKillTimeout)
 		for (const entry of signalHandlers) process.removeListener(entry.signal, entry.handler)
 	}
@@ -1171,6 +1361,9 @@ async function runHarborProcess(args: string[], config: PilotConfig): Promise<Ha
 		status: outcome.status,
 		signal: outcome.signal,
 		timedOut,
+		liveCostStopped,
+		liveCostAtStopUsd,
+		liveCostGuardError,
 		stdout: Buffer.concat(stdoutChunks).toString("utf8"),
 		stderr: Buffer.concat(stderrChunks).toString("utf8"),
 	}
@@ -1221,8 +1414,18 @@ async function runOne(
 	args.push(...modelTransportHarborArguments(model.id, localCoreUrl))
 
 	console.log(`\n[${runNumber}] ${model.id} × ${task}`)
+	const startedAt = new Date().toISOString()
 	const started = Date.now()
-	const result = await runHarborProcess(args, config)
+	const stopUsd = liveCostStopUsd(model.perTaskBudgetUsd)
+	console.log(`  live cost guard: $${stopUsd.toFixed(2)} (reservation $${model.perTaskBudgetUsd.toFixed(2)})`)
+	const result = await runHarborProcess(args, config, {
+		jobDir,
+		model: model.id,
+		taskHash: hashPrivateIdentifier("cline-bench-task", task),
+		startedAt,
+		stopUsd,
+		reservationUsd: model.perTaskBudgetUsd,
+	})
 	const durationSeconds = (Date.now() - started) / 1000
 	const secret = process.env.CLINE_API_KEY || ""
 	const sanitizedOutput = redactSecrets(`${result.stdout || ""}\n${result.stderr || ""}`, [secret])
@@ -1231,6 +1434,22 @@ async function runOne(
 		mode: 0o600,
 	})
 
+	if (result.liveCostGuardError) {
+		const removed = cleanupJobContainers(jobDir)
+		fail(
+			`live cost guard failed closed for ${model.id} × ${task}; cleaned ${removed.length} container(s): ${result.liveCostGuardError}`,
+		)
+	}
+	if (result.liveCostStopped) {
+		const removed = cleanupJobContainers(jobDir)
+		try {
+			return readLiveCostStoppedRun(jobDir, config, model, task)
+		} catch (usageError) {
+			fail(
+				`live cost guard stopped ${model.id} × ${task} at $${(result.liveCostAtStopUsd || 0).toFixed(4)}; cleaned ${removed.length} container(s), but usage recovery failed: ${usageError instanceof Error ? usageError.message : String(usageError)}`,
+			)
+		}
+	}
 	if (result.timedOut) {
 		const removed = cleanupJobContainers(jobDir)
 		if (existsSync(join(jobDir, "result.json"))) {
@@ -1271,6 +1490,12 @@ export function reuseCompletedRun(
 ): RunResult | null {
 	const jobName = `${String(runNumber).padStart(2, "0")}-${slug(model.id)}-${slug(task)}`
 	const jobDir = join(jobsRoot, jobName)
+	if (existsSync(liveCostStopMarkerPath(jobDir))) {
+		const stopped = readLiveCostStoppedRun(jobDir, config, model, task)
+		console.log(`\n[${runNumber}] reusing live-cost-stopped ${model.id} × ${task}`)
+		console.log(`  cost=$${stopped.costUsd.toFixed(4)} classification=${stopped.failureClassification}`)
+		return stopped
+	}
 	if (!existsSync(join(jobDir, "result.json"))) return null
 	const rootResult = JSON.parse(readFileSync(join(jobDir, "result.json"), "utf8")) as any
 	if (!rootResult.finished_at && rootResult.stats?.n_running_trials > 0) {
@@ -1393,7 +1618,10 @@ async function main() {
 		} else {
 			const hasUnboundResult = buildRunMatrix(config).some((run, index) => {
 				const jobName = `${String(index + 1).padStart(2, "0")}-${slug(run.model.id)}-${slug(run.task)}`
-				return existsSync(join(jobsRoot, jobName, "result.json"))
+				return (
+					existsSync(join(jobsRoot, jobName, "result.json")) ||
+					existsSync(join(jobsRoot, jobName, "live-cost-stop.json"))
+				)
 			})
 			if (hasUnboundResult) {
 				fail("jobs-root contains result artifacts without a content-addressed pilot report; use a new jobs-root")
@@ -1439,7 +1667,10 @@ async function main() {
 			if (matrixIndex < 0) fail(`budget ledger reservation is not in the execution matrix: ${entry.runKey}`)
 			const run = matrix[matrixIndex]
 			const jobName = `${String(matrixIndex + 1).padStart(2, "0")}-${slug(run.model.id)}-${slug(run.task)}`
-			if (!existsSync(join(jobsRoot, jobName, "result.json"))) {
+			if (
+				!existsSync(join(jobsRoot, jobName, "result.json")) &&
+				!existsSync(join(jobsRoot, jobName, "live-cost-stop.json"))
+			) {
 				fail(`unsettled prior attempt has no recoverable usage; refusing to spend again: ${entry.runKey}`)
 			}
 		}

--- a/evals/e2e/run-cline-bench-pilot.ts
+++ b/evals/e2e/run-cline-bench-pilot.ts
@@ -187,7 +187,7 @@ Options:
   --stop-after <n>    Stop cleanly after matrix run n
   --only-run <n>      Reuse prior work but execute only matrix run n
   --wave <n>          Execute only the selected staged wave
-  --local-core-url    Local Core URL (strictly localhost:7777)
+  --local-core-url    Local Core URL (strictly localhost:7777 or :17777)
   --route-traces      Privacy-safe Core route trace JSON/JSONL
   --ingest-route-traces
                       Attach traces to an existing report without model calls

--- a/evals/e2e/run-cline-bench-pilot.ts
+++ b/evals/e2e/run-cline-bench-pilot.ts
@@ -50,7 +50,7 @@ import {
 	sha256,
 } from "./cline-bench-safety"
 
-type ModelConfig = {
+export type ModelConfig = {
 	id: string
 	perTaskBudgetUsd: number
 	perModelBudgetUsd: number
@@ -92,7 +92,7 @@ export type ExecutionProvenance = {
 	}>
 }
 
-type RunResult = {
+export type RunResult = {
 	model: string
 	requestedModel: string
 	task: string
@@ -102,6 +102,7 @@ type RunResult = {
 	routeTraces: RouteTrace[]
 	routeEvidence: "not-applicable" | "verified" | "missing"
 	outcome: "passed" | "failed" | "timed_out"
+	failureClassification: string | null
 	passed: boolean
 	reward: number | null
 	costUsd: number
@@ -740,7 +741,7 @@ function readJobResult(
 	const exceptionType = trial.exception_info?.exception_type
 	const timedOut = exceptionType === "AgentTimeoutError"
 	if (trial.exception_info && !timedOut) {
-		fail(`Harbor trial failed with ${trial.exception_info.exception_type}: ${trial.exception_info.exception_message}`)
+		return readRecoveredFailedRun(jobDir, config, model, expectedTask)
 	}
 	if (trial.task_name !== expectedTask) {
 		fail(`task mismatch: expected ${expectedTask}, result recorded ${JSON.stringify(trial.task_name)}`)
@@ -802,6 +803,7 @@ function readJobResult(
 		routeTraces: [],
 		routeEvidence: virtualModel ? "missing" : "not-applicable",
 		outcome: timedOut ? "timed_out" : reward === 1 ? "passed" : "failed",
+		failureClassification: timedOut ? "AgentTimeoutError" : null,
 		passed: reward === 1,
 		reward,
 		costUsd,
@@ -815,14 +817,41 @@ function readJobResult(
 	}
 }
 
-function readInterruptedRun(
-	jobDir: string,
-	routerProfile: PilotConfig["routerProfile"],
-	model: ModelConfig,
-	task: string,
-): RunResult {
-	const rootResult = JSON.parse(readFileSync(join(jobDir, "result.json"), "utf8")) as any
-	const startedAt = Date.parse(rootResult.started_at)
+function conciseFailureClassification(value: unknown): string {
+	if (typeof value !== "string" || !/^[A-Za-z][A-Za-z0-9_.:-]{0,127}$/.test(value)) {
+		fail("Harbor failure has no safe concise exception classification")
+	}
+	return value
+}
+
+type RecoveryTrial = {
+	task_name?: unknown
+	started_at?: unknown
+	finished_at?: unknown
+	agent_info?: {
+		version?: unknown
+		model_info?: {
+			name?: unknown
+			provider?: unknown
+		}
+	}
+	exception_info?: {
+		exception_type?: unknown
+	}
+}
+
+type RecoveryRootResult = {
+	started_at?: unknown
+	trial_results?: RecoveryTrial[]
+}
+
+function readRecoveryArtifacts(jobDir: string) {
+	const resultPath = join(jobDir, "result.json")
+	if (!existsSync(resultPath)) fail(`Harbor did not write ${resultPath}`)
+	const rootResult = JSON.parse(readFileSync(resultPath, "utf8")) as RecoveryRootResult
+	const nestedTrial = findTrialResult(jobDir)
+	const trial = rootResult.trial_results?.[0] || (nestedTrial?.document as RecoveryTrial | undefined)
+	if (!trial) fail(`Harbor result has no nested trial: ${resultPath}`)
 	const logDocuments: string[] = []
 	let trialName: string | null = null
 	for (const entry of readdirSync(jobDir, { withFileTypes: true })) {
@@ -832,6 +861,53 @@ function readInterruptedRun(
 		logDocuments.push(readFileSync(clineLog, "utf8"))
 		trialName = entry.name
 	}
+	return { rootResult, trial, logDocuments, trialName }
+}
+
+function validateRecoveredTrial(
+	trial: RecoveryTrial,
+	config: PilotConfig,
+	model: ModelConfig,
+	expectedTask: string,
+): void {
+	if (trial.task_name !== expectedTask) {
+		fail(`task mismatch: expected ${expectedTask}, result recorded ${JSON.stringify(trial.task_name)}`)
+	}
+	if (trial.agent_info?.version !== config.clineVersion) {
+		fail(
+			`Cline version mismatch: expected ${config.clineVersion}, result recorded ${JSON.stringify(trial.agent_info?.version)}`,
+		)
+	}
+	const servedModel = trial.agent_info?.model_info?.name
+	const servedProvider = trial.agent_info?.model_info?.provider
+	const [expectedVendor, ...expectedNameParts] = model.id.split("/")
+	const expectedName = expectedNameParts.join("/")
+	const acceptedCombinedNames = new Set([model.id, `${config.provider}:${model.id}`])
+	const exactSplitMatch = servedProvider === `${config.provider}:${expectedVendor}` && servedModel === expectedName
+	const combinedMatch = servedProvider === config.provider && acceptedCombinedNames.has(servedModel)
+	const virtualModel = model.id === "cline/auto" || model.id === "cline-pass/auto"
+	const requestedVirtualMatch =
+		virtualModel &&
+		((servedProvider === `${config.provider}:cline` && servedModel === "auto") ||
+			(servedProvider === config.provider && acceptedCombinedNames.has(servedModel)))
+	if (!exactSplitMatch && !combinedMatch && !requestedVirtualMatch) {
+		fail(
+			`served-model mismatch: expected ${model.id}, result recorded provider=${JSON.stringify(servedProvider)} model=${JSON.stringify(servedModel)}`,
+		)
+	}
+}
+
+function recoveredUnsuccessfulRun(
+	jobDir: string,
+	config: PilotConfig,
+	model: ModelConfig,
+	task: string,
+	outcome: "failed" | "timed_out",
+	failureClassification: string,
+): RunResult {
+	const { rootResult, trial, logDocuments, trialName } = readRecoveryArtifacts(jobDir)
+	validateRecoveredTrial(trial, config, model, task)
+	const startedAt = typeof rootResult.started_at === "string" ? Date.parse(rootResult.started_at) : Number.NaN
 	const latestUsage = recoverLatestUsage(logDocuments)
 	const costUsd = latestUsage.totalCost
 	const inputTokens = latestUsage.totalInputTokens
@@ -848,11 +924,12 @@ function readInterruptedRun(
 		sessionIdSha256: sessionIdentity?.sessionIdSha256 ?? null,
 		routeTraces: [],
 		routeEvidence: virtualModel ? "missing" : "not-applicable",
-		outcome: "timed_out",
+		outcome,
+		failureClassification,
 		passed: false,
 		reward: null,
 		costUsd,
-		costBasis: routerProfile === "cline-pass-router" ? "cline-pass-reference-quota" : "reported-inference",
+		costBasis: config.routerProfile === "cline-pass-router" ? "cline-pass-reference-quota" : "reported-inference",
 		durationSeconds: Number.isFinite(startedAt) ? (Date.parse(latestUsage.timestamp) - startedAt) / 1000 : 0,
 		inputTokens,
 		cacheTokens,
@@ -860,6 +937,40 @@ function readInterruptedRun(
 		...tokenEconomics(model, inputTokens, cacheTokens, outputTokens),
 		jobDir,
 	}
+}
+
+function readInterruptedRun(
+	jobDir: string,
+	config: PilotConfig,
+	model: ModelConfig,
+	task: string,
+): RunResult {
+	return recoveredUnsuccessfulRun(
+		jobDir,
+		config,
+		model,
+		task,
+		"timed_out",
+		"AgentTimeoutError",
+	)
+}
+
+export function readRecoveredFailedRun(
+	jobDir: string,
+	config: PilotConfig,
+	model: ModelConfig,
+	task: string,
+): RunResult {
+	const { trial } = readRecoveryArtifacts(jobDir)
+	const classification = conciseFailureClassification(trial.exception_info?.exception_type)
+	return recoveredUnsuccessfulRun(
+		jobDir,
+		config,
+		model,
+		task,
+		"failed",
+		classification,
+	)
 }
 
 export function matchRouteTraces(
@@ -1094,7 +1205,7 @@ async function runOne(
 		const removed = cleanupJobContainers(jobDir)
 		if (existsSync(join(jobDir, "result.json"))) {
 			try {
-				return readInterruptedRun(jobDir, config.routerProfile, model, task)
+				return readInterruptedRun(jobDir, config, model, task)
 			} catch (usageError) {
 				fail(
 					`Harbor timed out for ${model.id} × ${task}; cleaned ${removed.length} container(s), but usage recovery failed: ${usageError instanceof Error ? usageError.message : String(usageError)}`,
@@ -1105,15 +1216,23 @@ async function runOne(
 	}
 	if (result.status !== 0) {
 		const removed = cleanupJobContainers(jobDir)
-		const tail = sanitizedOutput.trim().split("\n").slice(-20).join("\n")
+		if (existsSync(join(jobDir, "result.json"))) {
+			try {
+				return readRecoveredFailedRun(jobDir, config, model, task)
+			} catch (usageError) {
+				fail(
+					`Harbor exited ${result.status} for ${model.id} × ${task}; cleaned ${removed.length} container(s), but failure accounting could not be recovered: ${usageError instanceof Error ? usageError.message : String(usageError)}`,
+				)
+			}
+		}
 		fail(
-			`Harbor exited ${result.status} (signal=${result.signal}) for ${model.id} × ${task}; cleaned ${removed.length} container(s)\n${tail}`,
+			`Harbor exited ${result.status} (signal=${result.signal}) for ${model.id} × ${task}; cleaned ${removed.length} container(s) without recoverable result telemetry`,
 		)
 	}
 	return readJobResult(jobDir, config, model, task, durationSeconds)
 }
 
-function reuseCompletedRun(
+export function reuseCompletedRun(
 	config: PilotConfig,
 	model: ModelConfig,
 	task: string,
@@ -1125,7 +1244,7 @@ function reuseCompletedRun(
 	if (!existsSync(join(jobDir, "result.json"))) return null
 	const rootResult = JSON.parse(readFileSync(join(jobDir, "result.json"), "utf8")) as any
 	if (!rootResult.finished_at && rootResult.stats?.n_running_trials > 0) {
-		const interrupted = readInterruptedRun(jobDir, config.routerProfile, model, task)
+		const interrupted = readInterruptedRun(jobDir, config, model, task)
 		console.log(`\n[${runNumber}] recording interrupted ${model.id} × ${task} as timed out`)
 		console.log(`  cost=$${interrupted.costUsd.toFixed(4)}`)
 		return interrupted

--- a/evals/e2e/run-cline-bench-pilot.ts
+++ b/evals/e2e/run-cline-bench-pilot.ts
@@ -41,6 +41,7 @@ import {
 	hashPrivateIdentifier,
 	ledgerExposure,
 	MAX_CHECKPOINT_USD,
+	markBudgetUnmeasured,
 	normalizeLocalCoreUrl,
 	parseRouteTraces,
 	type RouteTrace,
@@ -107,12 +108,13 @@ export type RunResult = {
 	sessionIdSha256: string | null
 	routeTraces: RouteTrace[]
 	routeEvidence: "not-applicable" | "verified" | "missing"
-	outcome: "passed" | "failed" | "timed_out"
+	outcome: "passed" | "failed" | "timed_out" | "infrastructure_invalid"
 	failureClassification: string | null
 	passed: boolean
 	reward: number | null
-	costUsd: number
-	costBasis: "reported-inference" | "cline-pass-reference-quota" | "reserved-exposure"
+	costUsd: number | null
+	costBasis: "reported-inference" | "cline-pass-reference-quota" | "unmeasured"
+	reservedExposureUsd: number
 	durationSeconds: number
 	inputTokens: number | null
 	cacheTokens: number | null
@@ -555,6 +557,63 @@ export async function assertDirectModelsInLiveCatalog(
 	}
 }
 
+export async function assertLocalCoreVirtualModelsInCatalog(
+	config: PilotConfig,
+	localCoreUrl: string | undefined,
+	fetchImpl: typeof fetch = fetch,
+): Promise<void> {
+	const virtualModels = config.models
+		.filter(
+			(model) =>
+				(model.id === "cline/auto" || model.id === "cline-pass/auto") &&
+				(model.transport === "local-core" || model.transport === undefined),
+		)
+		.map((model) => model.id)
+	if (virtualModels.length === 0) return
+	if (!localCoreUrl) {
+		fail("local Core virtual-model catalog preflight requires --local-core-url before budget reservation")
+	}
+
+	const catalogUrl = new URL(normalizeLocalCoreUrl(localCoreUrl))
+	// Harbor reaches the host through host.docker.internal. This preflight runs
+	// on the host, where that Docker-only name is not reliably resolvable.
+	catalogUrl.hostname = "127.0.0.1"
+	catalogUrl.pathname = "/api/v1/ai/cline/recommended-models"
+
+	const controller = new AbortController()
+	const timeout = setTimeout(() => controller.abort(), 5_000)
+	timeout.unref()
+	let response: Response
+	try {
+		response = await fetchImpl(catalogUrl, { signal: controller.signal })
+	} catch {
+		fail("local Core virtual-model catalog preflight request failed before budget reservation")
+	} finally {
+		clearTimeout(timeout)
+	}
+	if (!response.ok) {
+		fail(`local Core virtual-model catalog preflight returned HTTP ${response.status} before budget reservation`)
+	}
+	let raw: ClineRecommendedCatalog
+	try {
+		raw = (await response.json()) as ClineRecommendedCatalog
+	} catch {
+		fail("local Core virtual-model catalog preflight returned invalid JSON before budget reservation")
+	}
+	if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+		fail("local Core virtual-model catalog preflight returned an invalid document before budget reservation")
+	}
+	const allowed = new Set([
+		...catalogModelIds(raw.recommended, "recommended"),
+		...catalogModelIds(raw.free, "free"),
+		...catalogModelIds(raw.clinePass, "clinePass"),
+	])
+	const unavailable = virtualModels.filter((id) => !allowed.has(id))
+	if (unavailable.length > 0) {
+		fail(`local Core catalog is missing virtual model(s): ${unavailable.join(", ")}`)
+	}
+}
+
 function createPrivateJobsRoot(requested?: string): string {
 	const runId = new Date().toISOString().replace(/[:.]/g, "-")
 	const base = requested
@@ -961,7 +1020,8 @@ function readJobResult(
 		// producing no session, usage, or cost telemetry. Never report those as
 		// free model work or retry the position. Charge the full declared
 		// reservation as conservative exposure and make the missing telemetry a
-		// terminal benchmark failure.
+		// terminal benchmark failure. The reservation remains a conservative
+		// exposure bound, but it is not measured model cost.
 		return {
 			model: expectedModel,
 			requestedModel: expectedModel,
@@ -971,12 +1031,13 @@ function readJobResult(
 			sessionIdSha256: sessionIdentity?.sessionIdSha256 ?? null,
 			routeTraces: [],
 			routeEvidence: virtualModel ? "missing" : "not-applicable",
-			outcome: "failed",
+			outcome: "infrastructure_invalid",
 			failureClassification: "CompletedWithoutCostTelemetry",
 			passed: false,
 			reward: null,
-			costUsd: model.perTaskBudgetUsd,
-			costBasis: "reserved-exposure",
+			costUsd: null,
+			costBasis: "unmeasured",
+			reservedExposureUsd: model.perTaskBudgetUsd,
 			durationSeconds: measuredDurationSeconds,
 			inputTokens: Number.isInteger(inputTokens) && inputTokens >= 0 ? inputTokens : null,
 			cacheTokens: Number.isInteger(cacheTokens) && cacheTokens >= 0 ? cacheTokens : null,
@@ -1008,6 +1069,7 @@ function readJobResult(
 		reward,
 		costUsd,
 		costBasis: config.routerProfile === "cline-pass-router" ? "cline-pass-reference-quota" : "reported-inference",
+		reservedExposureUsd: model.perTaskBudgetUsd,
 		durationSeconds: measuredDurationSeconds,
 		inputTokens,
 		cacheTokens,
@@ -1130,6 +1192,7 @@ function recoveredUnsuccessfulRun(
 		reward: null,
 		costUsd,
 		costBasis: config.routerProfile === "cline-pass-router" ? "cline-pass-reference-quota" : "reported-inference",
+		reservedExposureUsd: model.perTaskBudgetUsd,
 		durationSeconds: Number.isFinite(startedAt) ? (Date.parse(latestUsage.timestamp) - startedAt) / 1000 : 0,
 		inputTokens,
 		cacheTokens,
@@ -1231,6 +1294,7 @@ function markerRunResult(
 		reward: null,
 		costUsd: usage.totalCost,
 		costBasis: config.routerProfile === "cline-pass-router" ? "cline-pass-reference-quota" : "reported-inference",
+		reservedExposureUsd: model.perTaskBudgetUsd,
 		durationSeconds,
 		inputTokens: usage.totalInputTokens,
 		cacheTokens: usage.totalCacheReadTokens,
@@ -1257,7 +1321,7 @@ export function readLiveCostStoppedRun(
 				"failed",
 				"LiveCostGuardExceeded",
 			)
-			if (recovered.costUsd >= marker.usage.totalCost) return recovered
+			if (recovered.costUsd !== null && recovered.costUsd >= marker.usage.totalCost) return recovered
 		} catch {
 			// The marker is persisted before termination specifically so a
 			// missing or incomplete Harbor result cannot authorize a respent.
@@ -1785,7 +1849,7 @@ export function reuseCompletedRun(
 	if (existsSync(liveCostStopMarkerPath(jobDir))) {
 		const stopped = readLiveCostStoppedRun(jobDir, config, model, task)
 		console.log(`\n[${runNumber}] reusing live-cost-stopped ${model.id} × ${task}`)
-		console.log(`  cost=$${stopped.costUsd.toFixed(4)} classification=${stopped.failureClassification}`)
+		console.log(`  ${resultCostLabel(stopped)} classification=${stopped.failureClassification}`)
 		return stopped
 	}
 	if (!existsSync(join(jobDir, "result.json"))) return null
@@ -1793,12 +1857,12 @@ export function reuseCompletedRun(
 	if (!rootResult.finished_at && rootResult.stats?.n_running_trials > 0) {
 		const interrupted = readInterruptedRun(jobDir, config, model, task)
 		console.log(`\n[${runNumber}] recording interrupted ${model.id} × ${task} as timed out`)
-		console.log(`  cost=$${interrupted.costUsd.toFixed(4)}`)
+		console.log(`  ${resultCostLabel(interrupted)}`)
 		return interrupted
 	}
 	const result = readJobResult(jobDir, config, model, task, 0)
 	console.log(`\n[${runNumber}] reusing completed ${model.id} × ${task}`)
-	console.log(`  outcome=${result.outcome} reward=${result.reward ?? "missing"} cost=$${result.costUsd.toFixed(4)}`)
+	console.log(`  outcome=${result.outcome} reward=${result.reward ?? "missing"} ${resultCostLabel(result)}`)
 	return result
 }
 
@@ -1882,6 +1946,22 @@ function modelForResult(config: PilotConfig, result: RunResult): ModelConfig {
 	)
 }
 
+function conservativeRunExposure(result: RunResult): number {
+	return result.costUsd ?? result.reservedExposureUsd
+}
+
+function settleResultBudget(ledger: BudgetLedger, runKeyValue: string, result: RunResult): BudgetLedger {
+	return result.costUsd === null
+		? markBudgetUnmeasured(ledger, runKeyValue)
+		: settleBudget(ledger, runKeyValue, result.costUsd)
+}
+
+function resultCostLabel(result: RunResult): string {
+	return result.costUsd === null
+		? `cost=unmeasured reservation=$${result.reservedExposureUsd.toFixed(4)}`
+		: `cost=$${result.costUsd.toFixed(4)}`
+}
+
 async function main() {
 	const args = parseArgs(process.argv.slice(2))
 	const config = readConfig(args.configPath)
@@ -1897,6 +1977,8 @@ async function main() {
 		console.log(`Local Cline ${config.clineVersion} preflight passed before jobs-root creation and budget reservation.`)
 		await assertDirectModelsInLiveCatalog(config)
 		console.log("Live Cline catalog preflight passed before budget reservation.")
+		await assertLocalCoreVirtualModelsInCatalog(config, args.localCoreUrl)
+		console.log("Local Core virtual-model catalog preflight passed before budget reservation.")
 	}
 
 	const jobsRoot = createPrivateJobsRoot(args.jobsRoot)
@@ -1990,8 +2072,9 @@ async function main() {
 			const reused = reusedRaw ? attachRouteEvidence(reusedRaw, run.model, traces) : null
 			if (reused) {
 				report.results.push(reused)
-				modelSpend.set(run.model.id, (modelSpend.get(run.model.id) || 0) + reused.costUsd)
-				globalSpend += reused.costUsd
+				const reusedExposure = conservativeRunExposure(reused)
+				modelSpend.set(run.model.id, (modelSpend.get(run.model.id) || 0) + reusedExposure)
+				globalSpend += reusedExposure
 				if (!budgetLedger.entries.some((entry) => entry.runKey === key)) {
 					budgetLedger = reserveBudget(budgetLedger, {
 						runKey: key,
@@ -2001,7 +2084,7 @@ async function main() {
 						waveBudgetUsd: config.waveBudgetsUsd?.[String(run.wave)],
 					})
 				}
-				budgetLedger = settleBudget(budgetLedger, key, reused.costUsd)
+				budgetLedger = settleResultBudget(budgetLedger, key, reused)
 				writeBudgetLedger(jobsRoot, budgetLedger)
 				report.budgetLedger = budgetLedger
 				writeReport(report)
@@ -2040,7 +2123,7 @@ async function main() {
 
 			const rawResult = await runOne(config, run.model, run.task, jobsRoot, index + 1, args.localCoreUrl)
 			const result = attachRouteEvidence(rawResult, run.model, traces)
-			budgetLedger = settleBudget(budgetLedger, key, result.costUsd)
+			budgetLedger = settleResultBudget(budgetLedger, key, result)
 			writeBudgetLedger(jobsRoot, budgetLedger)
 			const waveBudget = config.waveBudgetsUsd?.[String(run.wave)]
 			if (waveBudget !== undefined && ledgerExposure(budgetLedger, run.wave) > waveBudget) {
@@ -2048,14 +2131,15 @@ async function main() {
 			}
 			report.results.push(result)
 			report.budgetLedger = budgetLedger
-			modelSpend.set(run.model.id, currentModelSpend + result.costUsd)
-			globalSpend += result.costUsd
+			const resultExposure = conservativeRunExposure(result)
+			modelSpend.set(run.model.id, currentModelSpend + resultExposure)
+			globalSpend += resultExposure
 			writeReport(report)
 			console.log(
-				`  outcome=${result.outcome} reward=${result.reward ?? "missing"} cost=$${result.costUsd.toFixed(4)} duration=${result.durationSeconds.toFixed(1)}s`,
+				`  outcome=${result.outcome} reward=${result.reward ?? "missing"} ${resultCostLabel(result)} duration=${result.durationSeconds.toFixed(1)}s`,
 			)
 
-			if (result.costUsd > run.model.perTaskBudgetUsd) {
+			if (result.costUsd !== null && result.costUsd > run.model.perTaskBudgetUsd) {
 				fail(`${run.model.id} exceeded its $${run.model.perTaskBudgetUsd.toFixed(2)} per-task stop after ${run.task}`)
 			}
 			if ((modelSpend.get(run.model.id) || 0) > run.model.perModelBudgetUsd) {


### PR DESCRIPTION
Internal benchmark and evaluation tooling with realistic verifier-backed SDLC tasks, bounded spend, and pinned provenance. No credentials are tracked. Do not merge as production product code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New paid-eval execution path and API-key handling are isolated to eval tooling with strong guards, but misconfiguration or bypassing dry-run could still incur real spend; large new surface area warrants careful review of budget and credential boundaries.
> 
> **Overview**
> Adds a new **cost-guarded** `cline-bench` pilot under `evals/e2e/`: `run-cline-bench-pilot.ts` orchestrates sequential Harbor/Docker runs with **dry-run by default**, explicit `--execute` + `--jobs-root`, campaign/wave/per-model budgets (capped at **$50**), jobs-root locking, and a durable budget ledger (including **unmeasured** exposure when cost telemetry is missing).
> 
> **Safety and resume:** `cline-bench-safety.ts` supplies hashing/redaction, usage recovery, and strict Core/legacy route-trace parsing. Runs get a **content-addressed execution fingerprint** (config, runner hash, Harbor version, `cline-bench` commit, task tree hashes) so stale job roots are rejected; completed work can be reused via `--stop-after` / `--only-run` / `--wave`.
> 
> **Spend control:** Live polling of Cline usage stops Harbor before per-task reservations are exhausted (with headroom) and writes a private recovery marker so stopped runs are not respent. Preflights pin CLI version and live model catalogs (Cline API and optional **local Core** on localhost `7777`/`17777`).
> 
> **Configs and router eval:** Checked-in JSON for smoke (3 tasks), Cline Pass, and an 8-task **router checkpoint** (24-run matrix, `cline/auto` + comparators, route trace ingest). Virtual-model results attach privacy-safe route evidence correlated via hashed session IDs. Documentation in `CLINE_BENCH_PILOT.md`; broad coverage in `run-cline-bench-pilot.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74606ecb5e16e70d0a2d87b7212500d1deb146b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->