### PR TITLE
Internal demo: Cline Auto model picker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,19 @@ We also welcome contributions to our [documentation](https://github.com/cline/cl
     requires a backend that resolves the virtual `cline/auto` and
     `cline-pass/auto` IDs before normal model lookup.
 
+    With the local Core Platform API running on port 7777, launch the extension
+    host from `apps/vscode`:
+
+    ```bash
+    CLINE_ENVIRONMENT=local \
+      CLINE_AUTO_MODEL_PICKER_ENABLED=true \
+      CLINE_PASS_AUTO_MODEL_PICKER_ENABLED=true \
+      bash scripts/run-extension-host.sh
+    ```
+
+    Select the **Cline** provider in the launched Extension Development Host.
+    The local environment automatically targets `http://localhost:7777`.
+
 3. **Linux-specific Setup**
     VS Code extension tests on Linux require the following system libraries:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,18 +96,20 @@ We also welcome contributions to our [documentation](https://github.com/cline/cl
     requires a backend that resolves the virtual `cline/auto` and
     `cline-pass/auto` IDs before normal model lookup.
 
-    With the local Core Platform API running on port 7777, launch the extension
+    With the isolated Core Platform API running on port 17777, launch the extension
     host from `apps/vscode`:
 
     ```bash
     CLINE_ENVIRONMENT=local \
+      CLINE_LOCAL_API_BASE_URL=http://localhost:17777 \
       CLINE_AUTO_MODEL_PICKER_ENABLED=true \
       CLINE_PASS_AUTO_MODEL_PICKER_ENABLED=true \
       bash scripts/run-extension-host.sh
     ```
 
     Select the **Cline** provider in the launched Extension Development Host.
-    The local environment automatically targets `http://localhost:7777`.
+    The loopback-only override targets the isolated Core launcher on port
+    `17777`; omit it to use the standard local Core port `7777`.
 
 3. **Linux-specific Setup**
     VS Code extension tests on Linux require the following system libraries:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,9 +107,29 @@ We also welcome contributions to our [documentation](https://github.com/cline/cl
       bash scripts/run-extension-host.sh
     ```
 
+    The launcher builds the extension, opens an isolated VS Code profile, and
+    starts all three watchers. It uses a four-pane `tmux` session when `tmux` is
+    installed and automatically falls back to the current terminal with private
+    watcher logs when it is not. Close the Extension Development Host window or
+    press Ctrl+C in the launcher to stop only the processes and temporary
+    profile created by that run.
+
+    Before the demo, validate the local settings without building, launching VS
+    Code, or contacting the API:
+
+    ```bash
+    CLINE_ENVIRONMENT=local \
+      CLINE_LOCAL_API_BASE_URL=http://localhost:17777 \
+      CLINE_AUTO_MODEL_PICKER_ENABLED=true \
+      CLINE_PASS_AUTO_MODEL_PICKER_ENABLED=true \
+      bash scripts/run-extension-host.sh --check
+    ```
+
     Select the **Cline** provider in the launched Extension Development Host.
     The loopback-only override targets the isolated Core launcher on port
-    `17777`; omit it to use the standard local Core port `7777`.
+    `17777`; omit it to use the standard local Core port `7777`. The auto-router
+    options only become usable after that Core API is healthy and the Cline
+    account is signed in; merely opening the picker does not make a model call.
 
 3. **Linux-specific Setup**
     VS Code extension tests on Linux require the following system libraries:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,21 @@ We also welcome contributions to our [documentation](https://github.com/cline/cl
     - **Terminal Workflow**: Use `bun run dev` (generates protos + runs watch mode) or `bun run watch` (if protos already generated)
     - Before submitting PR, run `bun run format:fix` to format your code
 
+    To test the experimental auto-router entries locally, add both build-time
+    overrides to `apps/vscode/.env`, then restart the webview build and select
+    the **Cline** provider:
+
+    ```dotenv
+    CLINE_ENVIRONMENT=local
+    CLINE_AUTO_MODEL_PICKER_ENABLED=true
+    CLINE_PASS_AUTO_MODEL_PICKER_ENABLED=true
+    ```
+
+    The second override exposes `cline-pass/auto` inside the Cline picker
+    without exposing the standalone Cline Pass provider. Sending requests still
+    requires a backend that resolves the virtual `cline/auto` and
+    `cline-pass/auto` IDs before normal model lookup.
+
 3. **Linux-specific Setup**
     VS Code extension tests on Linux require the following system libraries:
 

--- a/apps/vscode/.env.example
+++ b/apps/vscode/.env.example
@@ -9,6 +9,17 @@
 # IS_DEV=true
 # CLINE_ENVIRONMENT=local
 
+# Expose the experimental cline/auto and cline-pass/auto entries in the Cline
+# provider's model picker. Outside the local override below, the Cline Pass entry
+# also requires the ext-cline-pass feature flag. Requests require a backend that
+# resolves these virtual IDs.
+# CLINE_AUTO_MODEL_PICKER_ENABLED=true
+
+# Local-only override for testing cline-pass/auto without a remote ext-cline-pass
+# assignment. It is ignored unless CLINE_ENVIRONMENT=local and does not expose
+# the standalone Cline Pass provider.
+# CLINE_PASS_AUTO_MODEL_PICKER_ENABLED=true
+
 # ============================================================================
 # POSTHOG TELEMETRY (Existing)
 # ============================================================================

--- a/apps/vscode/.env.example
+++ b/apps/vscode/.env.example
@@ -9,6 +9,10 @@
 # IS_DEV=true
 # CLINE_ENVIRONMENT=local
 
+# Optional local-only Core API target. Only loopback HTTP URLs on ports 7777
+# and 17777 are accepted; invalid values fall back to http://localhost:7777.
+# CLINE_LOCAL_API_BASE_URL=http://localhost:17777
+
 # Expose the experimental cline/auto and cline-pass/auto entries in the Cline
 # provider's model picker. Outside the local override below, the Cline Pass entry
 # also requires the ext-cline-pass feature flag. Requests require a backend that

--- a/apps/vscode/scripts/run-extension-host.sh
+++ b/apps/vscode/scripts/run-extension-host.sh
@@ -156,13 +156,89 @@ mkdir -p "$user_data_dir" "$extensions_dir"
 watcher_pids=()
 cleaned_up=false
 
-stop_isolated_extension_host() {
+escape_ere() {
+  sed 's/[][\\.^$*+?(){}|]/\\&/g' <<<"$1"
+}
+
+user_data_process_pattern="$(escape_ere "$user_data_dir")"
+
+process_tree_has_renderer() {
+  local child command_line depth pid
+  pid="$1"
+  depth="${2:-0}"
+  if [ "$depth" -gt 12 ]; then
+    return 1
+  fi
+
+  command_line="$(ps -p "$pid" -o command= 2>/dev/null || true)"
+  if [[ "$command_line" == *"--type=renderer"* ]]; then
+    return 0
+  fi
+
+  while IFS= read -r child; do
+    if [ -n "$child" ] && process_tree_has_renderer "$child" "$((depth + 1))"; then
+      return 0
+    fi
+  done < <(pgrep -P "$pid" 2>/dev/null || true)
+  return 1
+}
+
+isolated_renderer_is_running() {
   local pid
   while IFS= read -r pid; do
+    if [ -z "$pid" ] || [ "$pid" = "$$" ]; then
+      continue
+    fi
+    # The macOS Electron main process has the isolated --user-data-dir, while
+    # its renderer can omit that argument. Walk descendants instead of only
+    # matching the renderer's own command line.
+    if process_tree_has_renderer "$pid"; then
+      return 0
+    fi
+  done < <(pgrep -f -- "$user_data_process_pattern" 2>/dev/null || true)
+  return 1
+}
+
+wait_for_isolated_renderer_start() {
+  local attempt
+  for attempt in {1..100}; do
+    if isolated_renderer_is_running; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  return 1
+}
+
+stop_isolated_extension_host() {
+  local all_stopped attempt pid
+  local isolated_pids=()
+  while IFS= read -r pid; do
     if [ -n "$pid" ] && [ "$pid" != "$$" ]; then
+      isolated_pids+=("$pid")
       kill "$pid" 2>/dev/null || true
     fi
-  done < <(pgrep -f -- "--user-data-dir[= ]$user_data_dir" 2>/dev/null || true)
+  done < <(pgrep -f -- "$user_data_process_pattern" 2>/dev/null || true)
+
+  for attempt in {1..50}; do
+    all_stopped=true
+    for pid in "${isolated_pids[@]:-}"; do
+      if kill -0 "$pid" 2>/dev/null; then
+        all_stopped=false
+        break
+      fi
+    done
+    if [ "$all_stopped" = true ]; then
+      return
+    fi
+    sleep 0.1
+  done
+
+  # These PIDs were resolved from the launcher's unique temporary profile.
+  # Force-stop only that isolated instance if Electron ignores termination.
+  for pid in "${isolated_pids[@]:-}"; do
+    kill -KILL "$pid" 2>/dev/null || true
+  done
 }
 
 cleanup() {
@@ -195,7 +271,9 @@ cleanup() {
   rmdir "$runtime_root" 2>/dev/null || true
   echo "Stopped"
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 code_args=(
   code
@@ -236,7 +314,57 @@ if [ "$MODE" = "plain" ]; then
 
   echo "Launching isolated Extension Development Host..."
   echo "Close the Extension Development Host window or press Ctrl+C here to stop."
-  "${code_args[@]}"
+  code_started_at=$SECONDS
+  code_status=0
+  "${code_args[@]}" || code_status=$?
+  code_elapsed_seconds=$((SECONDS - code_started_at))
+
+  if [ "$code_status" -ne 0 ]; then
+    echo "VS Code exited with status $code_status." >&2
+    exit "$code_status"
+  fi
+
+  # On some macOS launches the VS Code CLI returns 0 before its isolated
+  # renderer is ready, even with --wait. Without this handoff the EXIT trap
+  # immediately tears down the profile and the user never sees a window.
+  monitor_renderer=false
+  if [ "$code_elapsed_seconds" -lt 5 ]; then
+    if wait_for_isolated_renderer_start; then
+      monitor_renderer=true
+    else
+      echo "VS Code CLI returned before startup; retrying once."
+      stop_isolated_extension_host
+      code_started_at=$SECONDS
+      code_status=0
+      "${code_args[@]}" || code_status=$?
+      code_elapsed_seconds=$((SECONDS - code_started_at))
+
+      if [ "$code_status" -ne 0 ]; then
+        echo "VS Code retry exited with status $code_status." >&2
+        exit "$code_status"
+      fi
+
+      if [ "$code_elapsed_seconds" -lt 5 ]; then
+        if ! wait_for_isolated_renderer_start; then
+          echo "VS Code returned before an isolated Extension Development Host started." >&2
+          exit 1
+        fi
+        monitor_renderer=true
+      fi
+    fi
+  fi
+
+  if [ "$monitor_renderer" = true ]; then
+    if ! isolated_renderer_is_running; then
+      echo "VS Code returned before an isolated Extension Development Host started." >&2
+      exit 1
+    fi
+
+    echo "VS Code CLI returned early; monitoring the isolated Extension Development Host."
+    while isolated_renderer_is_running; do
+      sleep 1
+    done
+  fi
 else
   if tmux has-session -t "$SESSION" 2>/dev/null; then
     echo "tmux session '$SESSION' already exists." >&2

--- a/apps/vscode/scripts/run-extension-host.sh
+++ b/apps/vscode/scripts/run-extension-host.sh
@@ -21,10 +21,17 @@ Options:
            without building, opening VS Code, or contacting an API.
 
 Environment:
+  CLINE_ENVIRONMENT=local
+  CLINE_LOCAL_API_BASE_URL=http://localhost:17777
+  CLINE_AUTO_MODEL_PICKER_ENABLED=true
+  CLINE_PASS_AUTO_MODEL_PICKER_ENABLED=true
   CLINE_EXTENSION_HOST_MODE=auto|tmux|plain
   CLINE_EXTENSION_HOST_SESSION=<tmux-session-name>
   CLINE_EXTENSION_HOST_USER_DATA_DIR=<persistent-isolated-profile>
   CLINE_EXTENSION_HOST_EXTENSIONS_DIR=<persistent-isolated-extensions-dir>
+
+The four local demo values expose cline/auto and cline-pass/auto only inside
+the Cline provider. --check and opening the picker do not make a model request.
 EOF
 }
 
@@ -107,7 +114,22 @@ echo "Extension Host launcher check:"
 echo "  workspace: $WORKSPACE"
 echo "  process mode: $MODE"
 echo "  CLINE_ENVIRONMENT: $CLINE_ENVIRONMENT"
-echo "  CLINE_LOCAL_API_BASE_URL: ${CLINE_LOCAL_API_BASE_URL:-<default>}"
+case "${CLINE_LOCAL_API_BASE_URL:-}" in
+  "")
+    local_api_display="<default>"
+    ;;
+  http://localhost:7777|http://localhost:7777/|http://localhost:17777|http://localhost:17777/|\
+    http://127.0.0.1:7777|http://127.0.0.1:7777/|http://127.0.0.1:17777|http://127.0.0.1:17777/|\
+    http://\[::1\]:7777|http://\[::1\]:7777/|http://\[::1\]:17777|http://\[::1\]:17777/)
+    local_api_display="$CLINE_LOCAL_API_BASE_URL"
+    ;;
+  *)
+    # Do not echo arbitrary URL contents: this check is often pasted into demo
+    # logs, and a malformed override may contain credentials or query secrets.
+    local_api_display="<invalid; extension falls back to http://localhost:7777>"
+    ;;
+esac
+echo "  CLINE_LOCAL_API_BASE_URL: $local_api_display"
 echo "  CLINE_AUTO_MODEL_PICKER_ENABLED: ${CLINE_AUTO_MODEL_PICKER_ENABLED:-false}"
 echo "  CLINE_PASS_AUTO_MODEL_PICKER_ENABLED: ${CLINE_PASS_AUTO_MODEL_PICKER_ENABLED:-false}"
 

--- a/apps/vscode/scripts/run-extension-host.sh
+++ b/apps/vscode/scripts/run-extension-host.sh
@@ -1,72 +1,263 @@
 #!/usr/bin/env bash
 
-SESSION="cline-dev"
+set -Eeuo pipefail
+
+SESSION="${CLINE_EXTENSION_HOST_SESSION:-cline-dev}"
 WORKSPACE="${CLINE_WORKSPACE:-$(cd "$(dirname "$0")/.." && pwd)}"
 ENVIRONMENT="${CLINE_ENVIRONMENT:-production}"
+MODE="${CLINE_EXTENSION_HOST_MODE:-auto}"
+CHECK_ONLY=false
+
+usage() {
+  cat <<'EOF'
+Usage: bash scripts/run-extension-host.sh [--check]
+
+Build and launch the Cline Extension Development Host. When tmux is installed,
+the launcher uses four panes. Otherwise it automatically runs the watchers in
+the current shell and writes their output to a private temporary log directory.
+
+Options:
+  --check  Validate the launcher and print the non-secret demo configuration
+           without building, opening VS Code, or contacting an API.
+
+Environment:
+  CLINE_EXTENSION_HOST_MODE=auto|tmux|plain
+  CLINE_EXTENSION_HOST_SESSION=<tmux-session-name>
+  CLINE_EXTENSION_HOST_USER_DATA_DIR=<persistent-isolated-profile>
+  CLINE_EXTENSION_HOST_EXTENSIONS_DIR=<persistent-isolated-extensions-dir>
+EOF
+}
+
+case "${1:-}" in
+  "")
+    ;;
+  --check)
+    CHECK_ONLY=true
+    ;;
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac
+
+case "$MODE" in
+  auto)
+    if command -v tmux >/dev/null 2>&1; then
+      MODE="tmux"
+    else
+      MODE="plain"
+    fi
+    ;;
+  tmux)
+    if ! command -v tmux >/dev/null 2>&1; then
+      echo "CLINE_EXTENSION_HOST_MODE=tmux was requested, but tmux is not installed." >&2
+      exit 1
+    fi
+    ;;
+  plain)
+    ;;
+  *)
+    echo "CLINE_EXTENSION_HOST_MODE must be auto, tmux, or plain (got: $MODE)." >&2
+    exit 2
+    ;;
+esac
+
+for dependency in bun code; do
+  if ! command -v "$dependency" >/dev/null 2>&1; then
+    echo "Required command not found: $dependency" >&2
+    exit 1
+  fi
+done
 
 cd "$WORKSPACE"
 
-# Export env vars -- tmux inherits them automatically
-export IS_DEV=true
-export DEV_WORKSPACE_FOLDER="$WORKSPACE"
-export CLINE_ENVIRONMENT="$ENVIRONMENT"
+# The command-line environment wins over .env for the local demo controls.
+local_api_was_set="${CLINE_LOCAL_API_BASE_URL+x}"
+local_api_value="${CLINE_LOCAL_API_BASE_URL:-}"
+auto_picker_was_set="${CLINE_AUTO_MODEL_PICKER_ENABLED+x}"
+auto_picker_value="${CLINE_AUTO_MODEL_PICKER_ENABLED:-}"
+pass_picker_was_set="${CLINE_PASS_AUTO_MODEL_PICKER_ENABLED+x}"
+pass_picker_value="${CLINE_PASS_AUTO_MODEL_PICKER_ENABLED:-}"
+
 if [ -f .env ]; then
   set -a
+  # shellcheck disable=SC1091
   source .env
   set +a
 fi
 
-# Step 1: Build protos (everything depends on this)
+export IS_DEV=true
+export DEV_WORKSPACE_FOLDER="$WORKSPACE"
+export CLINE_ENVIRONMENT="$ENVIRONMENT"
+if [ -n "$local_api_was_set" ]; then
+  export CLINE_LOCAL_API_BASE_URL="$local_api_value"
+fi
+if [ -n "$auto_picker_was_set" ]; then
+  export CLINE_AUTO_MODEL_PICKER_ENABLED="$auto_picker_value"
+fi
+if [ -n "$pass_picker_was_set" ]; then
+  export CLINE_PASS_AUTO_MODEL_PICKER_ENABLED="$pass_picker_value"
+fi
+
+echo "Extension Host launcher check:"
+echo "  workspace: $WORKSPACE"
+echo "  process mode: $MODE"
+echo "  CLINE_ENVIRONMENT: $CLINE_ENVIRONMENT"
+echo "  CLINE_LOCAL_API_BASE_URL: ${CLINE_LOCAL_API_BASE_URL:-<default>}"
+echo "  CLINE_AUTO_MODEL_PICKER_ENABLED: ${CLINE_AUTO_MODEL_PICKER_ENABLED:-false}"
+echo "  CLINE_PASS_AUTO_MODEL_PICKER_ENABLED: ${CLINE_PASS_AUTO_MODEL_PICKER_ENABLED:-false}"
+
+if [ "$CHECK_ONLY" = true ]; then
+  echo "Check complete. No build, VS Code launch, or API request was made."
+  exit 0
+fi
+
+if [ "$CLINE_ENVIRONMENT" = "local" ] &&
+  { [ "${CLINE_AUTO_MODEL_PICKER_ENABLED:-}" != "true" ] ||
+    [ "${CLINE_PASS_AUTO_MODEL_PICKER_ENABLED:-}" != "true" ]; }; then
+  echo "Warning: one or both local auto-router picker entries are disabled." >&2
+fi
+
 echo "Building protos..."
-bun run protos || { echo "Protos build failed"; exit 1; }
+bun run protos || { echo "Protos build failed" >&2; exit 1; }
 
-# Step 2: Build webview once
 echo "Building webview..."
-bun run build:webview || { echo "Webview build failed"; exit 1; }
+bun run build:webview || { echo "Webview build failed" >&2; exit 1; }
 
-# Step 3: Kill existing session if one is running
-tmux kill-session -t "$SESSION" 2>/dev/null
-true
+echo "Building extension..."
+bun esbuild.mjs || { echo "Extension build failed" >&2; exit 1; }
 
-# Step 4: Create tmux session with 4 vertical panes
-#
-#   ┌────────────┬────────────┬────────────┬────────────┐
-#   │  esbuild   │    tsc     │  webview   │  ext host  │
-#   └────────────┴────────────┴────────────┴────────────┘
+runtime_root="$(mktemp -d "${TMPDIR:-/tmp}/cline-extension-host.XXXXXX")"
+log_dir="$runtime_root/logs"
+mkdir -p "$log_dir"
+chmod 700 "$runtime_root" "$log_dir"
 
-echo "Starting tmux session..."
-tmux new-session -d -s "$SESSION" -c "$WORKSPACE"
-tmux split-window -h -t "$SESSION" -c "$WORKSPACE"
-tmux split-window -h -t "$SESSION:0.0" -c "$WORKSPACE"
-tmux split-window -h -t "$SESSION:0.2" -c "$WORKSPACE"
-tmux select-layout -t "$SESSION" even-horizontal
+remove_user_data_dir=true
+if [ -n "${CLINE_EXTENSION_HOST_USER_DATA_DIR:-}" ]; then
+  user_data_dir="$CLINE_EXTENSION_HOST_USER_DATA_DIR"
+  remove_user_data_dir=false
+else
+  user_data_dir="$runtime_root/user-data"
+fi
 
-# Ctrl+C kills the whole session
-tmux bind-key -T root C-c kill-session
+remove_extensions_dir=true
+if [ -n "${CLINE_EXTENSION_HOST_EXTENSIONS_DIR:-}" ]; then
+  extensions_dir="$CLINE_EXTENSION_HOST_EXTENSIONS_DIR"
+  remove_extensions_dir=false
+else
+  extensions_dir="$runtime_root/extensions"
+fi
 
-tmux send-keys -t "$SESSION:0.0" "bun run watch:esbuild" Enter
-tmux send-keys -t "$SESSION:0.1" "bun run watch:tsc" Enter
-tmux send-keys -t "$SESSION:0.2" "bun run dev:webview" Enter
-tmux send-keys -t "$SESSION:0.3" "while [ ! -f '$WORKSPACE/dist/extension.js' ]; do sleep 0.5; done && echo 'Launching Extension Host...' && code --extensionDevelopmentPath='$WORKSPACE' --disable-workspace-trust --disable-extension saoudrizwan.claude-dev --disable-extension saoudrizwan.cline-nightly '$WORKSPACE' && echo 'Extension Host launched.'" Enter
+mkdir -p "$user_data_dir" "$extensions_dir"
+watcher_pids=()
+cleaned_up=false
 
-# Attach to the session
-tmux attach-session -t "$SESSION"
+stop_isolated_extension_host() {
+  local pid
+  while IFS= read -r pid; do
+    if [ -n "$pid" ] && [ "$pid" != "$$" ]; then
+      kill "$pid" 2>/dev/null || true
+    fi
+  done < <(pgrep -f -- "--user-data-dir[= ]$user_data_dir" 2>/dev/null || true)
+}
 
-# Session ended -- run full cleanup
-tmux unbind-key -T root C-c 2>/dev/null
-# Kill watcher processes and their node children
-pkill -f "watch:esbuild|watch:tsc|dev:webview" 2>/dev/null
-pkill -f "esbuild.mjs --watch" 2>/dev/null
-pkill -f "tsc --noEmit --watch" 2>/dev/null
-pkill -f "vite.*/webview-ui" 2>/dev/null
-# Close the Extension Development Host window
-osascript -e '
-tell application "System Events"
-  tell process "Electron"
-    set windowList to every window whose title contains "Extension Development Host"
-    repeat with w in windowList
-      click button 1 of w
-    end repeat
-  end tell
-end tell' 2>/dev/null
-echo "Stopped"
+cleanup() {
+  if [ "$cleaned_up" = true ]; then
+    return
+  fi
+  cleaned_up=true
+
+  if [ "$MODE" = "tmux" ]; then
+    tmux kill-session -t "$SESSION" 2>/dev/null || true
+  fi
+
+  local pid
+  for pid in "${watcher_pids[@]:-}"; do
+    kill "$pid" 2>/dev/null || true
+  done
+  for pid in "${watcher_pids[@]:-}"; do
+    wait "$pid" 2>/dev/null || true
+  done
+
+  stop_isolated_extension_host
+
+  if [ "$remove_user_data_dir" = true ]; then
+    find "$user_data_dir" -depth -delete 2>/dev/null || true
+  fi
+  if [ "$remove_extensions_dir" = true ]; then
+    find "$extensions_dir" -depth -delete 2>/dev/null || true
+  fi
+  find "$log_dir" -depth -delete 2>/dev/null || true
+  rmdir "$runtime_root" 2>/dev/null || true
+  echo "Stopped"
+}
+trap cleanup EXIT INT TERM
+
+code_args=(
+  code
+  --wait
+  --new-window
+  --user-data-dir "$user_data_dir"
+  --extensions-dir "$extensions_dir"
+  --extensionDevelopmentPath="$WORKSPACE"
+  --disable-workspace-trust
+  --disable-extension saoudrizwan.claude-dev
+  --disable-extension saoudrizwan.cline-nightly
+  "$WORKSPACE"
+)
+
+if [ "$MODE" = "plain" ]; then
+  echo "tmux is unavailable or plain mode was selected."
+  echo "Watcher logs: $log_dir"
+
+  watcher_names=(esbuild tsc webview)
+  bun run watch:esbuild >"$log_dir/esbuild.log" 2>&1 &
+  watcher_pids+=("$!")
+  bun run watch:tsc >"$log_dir/tsc.log" 2>&1 &
+  watcher_pids+=("$!")
+  bun run dev:webview >"$log_dir/webview.log" 2>&1 &
+  watcher_pids+=("$!")
+
+  # Catch missing dependencies and occupied dev-server ports before VS Code
+  # opens. The complete log remains available until this launcher exits.
+  sleep 1
+  for index in 0 1 2; do
+    if ! kill -0 "${watcher_pids[$index]}" 2>/dev/null; then
+      watcher_name="${watcher_names[$index]}"
+      echo "$watcher_name watcher failed to start:" >&2
+      tail -n 40 "$log_dir/$watcher_name.log" >&2 || true
+      exit 1
+    fi
+  done
+
+  echo "Launching isolated Extension Development Host..."
+  echo "Close the Extension Development Host window or press Ctrl+C here to stop."
+  "${code_args[@]}"
+else
+  if tmux has-session -t "$SESSION" 2>/dev/null; then
+    echo "tmux session '$SESSION' already exists." >&2
+    echo "Attach with 'tmux attach-session -t $SESSION' or choose another CLINE_EXTENSION_HOST_SESSION." >&2
+    exit 1
+  fi
+
+  echo "Starting tmux session..."
+  tmux new-session -d -s "$SESSION" -c "$WORKSPACE"
+  tmux split-window -h -t "$SESSION" -c "$WORKSPACE"
+  tmux split-window -h -t "$SESSION:0.0" -c "$WORKSPACE"
+  tmux split-window -h -t "$SESSION:0.2" -c "$WORKSPACE"
+  tmux select-layout -t "$SESSION" even-horizontal
+  tmux bind-key -T root C-c kill-session
+
+  printf -v quoted_code_command '%q ' "${code_args[@]}"
+  tmux send-keys -t "$SESSION:0.0" "bun run watch:esbuild" Enter
+  tmux send-keys -t "$SESSION:0.1" "bun run watch:tsc" Enter
+  tmux send-keys -t "$SESSION:0.2" "bun run dev:webview" Enter
+  tmux send-keys -t "$SESSION:0.3" "echo 'Launching isolated Extension Development Host...' && $quoted_code_command" Enter
+
+  echo "Ctrl+C inside tmux stops this launcher and its isolated Extension Host."
+  tmux attach-session -t "$SESSION"
+fi

--- a/apps/vscode/src/__tests__/config.test.ts
+++ b/apps/vscode/src/__tests__/config.test.ts
@@ -18,12 +18,15 @@ mock.module("node:os", osMock)
 import os from "os"
 import { ClineConfigurationError, ClineEndpoint, ClineEnv, Environment } from "../config"
 
+const originalLocalApiBaseUrl = process.env.CLINE_LOCAL_API_BASE_URL
+
 describe("ClineEndpoint configuration", () => {
 	let sandbox: sinon.SinonSandbox
 	let tempDir: string
 	let originalHomedir: typeof os.homedir
 
 	beforeEach(async () => {
+		delete process.env.CLINE_LOCAL_API_BASE_URL
 		sandbox = sinon.createSandbox()
 		tempDir = path.join(os.tmpdir(), `config-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
 		await fs.mkdir(tempDir, { recursive: true })
@@ -43,6 +46,11 @@ describe("ClineEndpoint configuration", () => {
 	})
 
 	afterEach(async () => {
+		if (originalLocalApiBaseUrl === undefined) {
+			delete process.env.CLINE_LOCAL_API_BASE_URL
+		} else {
+			process.env.CLINE_LOCAL_API_BASE_URL = originalLocalApiBaseUrl
+		}
 		sandbox.restore()
 		// Reset singleton state
 		;(ClineEndpoint as any)._instance = null
@@ -115,6 +123,57 @@ describe("ClineEndpoint configuration", () => {
 
 			const config = ClineEndpoint.config
 			config.appBaseUrl.should.equal("https://proxy.enterprise.com/cline/app")
+		})
+	})
+
+	describe("local Core API override", () => {
+		it("uses the isolated auto-router port in the local environment", async () => {
+			process.env.CLINE_LOCAL_API_BASE_URL = "http://localhost:17777"
+			await ClineEndpoint.initialize(tempDir)
+			ClineEnv.setEnvironment("local")
+
+			ClineEndpoint.config.apiBaseUrl.should.equal("http://localhost:17777")
+		})
+
+		it("accepts loopback addresses on the standard local port", async () => {
+			process.env.CLINE_LOCAL_API_BASE_URL = "http://127.0.0.1:7777/"
+			await ClineEndpoint.initialize(tempDir)
+			ClineEnv.setEnvironment("local")
+
+			ClineEndpoint.config.apiBaseUrl.should.equal("http://127.0.0.1:7777")
+		})
+
+		it("ignores unsafe or unsupported URLs", async () => {
+			const invalidValues = [
+				"https://localhost:17777",
+				"http://example.com:17777",
+				"http://user:password@localhost:17777",
+				"http://localhost:17777/api",
+				"http://localhost:17778",
+				"not-a-url",
+			]
+
+			for (const value of invalidValues) {
+				;(ClineEndpoint as any)._instance = null
+				;(ClineEndpoint as any)._initialized = false
+				process.env.CLINE_LOCAL_API_BASE_URL = value
+
+				await ClineEndpoint.initialize(tempDir)
+				ClineEnv.setEnvironment("local")
+
+				ClineEndpoint.config.apiBaseUrl.should.equal("http://localhost:7777")
+			}
+		})
+
+		it("does not affect staging or production endpoints", async () => {
+			process.env.CLINE_LOCAL_API_BASE_URL = "http://localhost:17777"
+			await ClineEndpoint.initialize(tempDir)
+
+			ClineEnv.setEnvironment("staging")
+			ClineEndpoint.config.apiBaseUrl.should.equal("https://core-api.staging.int.cline.bot")
+
+			ClineEnv.setEnvironment("production")
+			ClineEndpoint.config.apiBaseUrl.should.equal("https://api.cline.bot")
 		})
 	})
 

--- a/apps/vscode/src/config.ts
+++ b/apps/vscode/src/config.ts
@@ -15,6 +15,41 @@ interface EndpointsFileSchema {
 	mcpBaseUrl: string
 }
 
+const DEFAULT_LOCAL_API_BASE_URL = "http://localhost:7777"
+const ALLOWED_LOCAL_API_PORTS = new Set(["7777", "17777"])
+const LOOPBACK_HOSTNAMES = new Set(["localhost", "127.0.0.1", "[::1]"])
+
+/**
+ * Resolve an optional development-only Core API override.
+ *
+ * This deliberately accepts only the two local Core ports used by the normal
+ * development stack and the isolated auto-router launcher. Invalid values are
+ * ignored so they cannot redirect extension credentials or traffic away from
+ * loopback.
+ */
+function resolveLocalApiBaseUrl(rawValue: string | undefined): string {
+	if (!rawValue) {
+		return DEFAULT_LOCAL_API_BASE_URL
+	}
+
+	try {
+		const url = new URL(rawValue)
+		const isAllowed =
+			url.protocol === "http:" &&
+			LOOPBACK_HOSTNAMES.has(url.hostname) &&
+			ALLOWED_LOCAL_API_PORTS.has(url.port) &&
+			url.username === "" &&
+			url.password === "" &&
+			(url.pathname === "" || url.pathname === "/") &&
+			url.search === "" &&
+			url.hash === ""
+
+		return isAllowed ? url.origin : DEFAULT_LOCAL_API_BASE_URL
+	} catch {
+		return DEFAULT_LOCAL_API_BASE_URL
+	}
+}
+
 /**
  * Error thrown when the Cline configuration file exists but is invalid.
  * This error prevents Cline from starting to avoid misconfiguration in enterprise environments.
@@ -317,7 +352,7 @@ class ClineEndpoint {
 				return {
 					environment: Environment.local,
 					appBaseUrl: "http://localhost:3000",
-					apiBaseUrl: "http://localhost:7777",
+					apiBaseUrl: resolveLocalApiBaseUrl(process.env.CLINE_LOCAL_API_BASE_URL),
 					mcpBaseUrl: "https://api.cline.bot/v1/mcp",
 				}
 			default:

--- a/apps/vscode/src/sdk/auth-service.test.ts
+++ b/apps/vscode/src/sdk/auth-service.test.ts
@@ -10,7 +10,7 @@
 
 import { getValidClineCredentials, type ITelemetryService, type OAuthCredentials } from "@cline/core"
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { AuthService, type ClineAuthInfo, LogoutReason } from "./auth-service"
+import { AuthService, type ClineAuthInfo, LogoutReason, summarizeAuthFetchError } from "./auth-service"
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -222,6 +222,36 @@ async function waitForCondition(condition: () => boolean): Promise<void> {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+describe("summarizeAuthFetchError", () => {
+	it("keeps useful Axios diagnostics without retaining request headers", () => {
+		const summary = summarizeAuthFetchError({
+			name: "AxiosError",
+			message: "Request failed with status code 500",
+			code: "ERR_BAD_RESPONSE",
+			response: { status: 500, data: { error: "internal" } },
+			config: {
+				headers: { Authorization: "Bearer secret-access-token" },
+			},
+		})
+
+		expect(summary).toEqual({
+			name: "AxiosError",
+			message: "Request failed with status code 500",
+			code: "ERR_BAD_RESPONSE",
+			status: 500,
+		})
+		expect(JSON.stringify(summary)).not.toContain("secret-access-token")
+		expect(JSON.stringify(summary)).not.toContain("Authorization")
+	})
+
+	it("returns a stable summary for non-object failures", () => {
+		expect(summarizeAuthFetchError("network failure")).toEqual({
+			name: "Error",
+			message: "Failed to fetch user info",
+		})
+	})
+})
 
 describe("AuthService", () => {
 	let authService: AuthService

--- a/apps/vscode/src/sdk/auth-service.ts
+++ b/apps/vscode/src/sdk/auth-service.ts
@@ -70,6 +70,22 @@ export interface ClineAccountOrganization {
 	roles: string[]
 }
 
+export function summarizeAuthFetchError(error: unknown): {
+	name: string
+	message: string
+	code?: string
+	status?: number
+} {
+	const value = error && typeof error === "object" ? (error as Record<string, unknown>) : null
+	const response = value?.response && typeof value.response === "object" ? (value.response as Record<string, unknown>) : null
+	return {
+		name: typeof value?.name === "string" ? value.name : "Error",
+		message: typeof value?.message === "string" ? value.message : "Failed to fetch user info",
+		...(typeof value?.code === "string" ? { code: value.code } : {}),
+		...(typeof response?.status === "number" ? { status: response.status } : {}),
+	}
+}
+
 /** Logout reason for telemetry */
 export enum LogoutReason {
 	USER_INITIATED = "user_initiated",
@@ -319,7 +335,10 @@ export class AuthService {
 			sdkDebug(`[SdkAuthService] fetchUserInfoFromApi: response status=${response.status}`)
 			return response.data?.data ?? null
 		} catch (error) {
-			Logger.error("[SdkAuthService] Failed to fetch user info from API:", error)
+			// Axios errors include the full request config, including Authorization.
+			// Log only non-sensitive diagnostics so a local/backend failure cannot
+			// copy an access token into extension-host logs.
+			Logger.error("[SdkAuthService] Failed to fetch user info from API:", summarizeAuthFetchError(error))
 			return null
 		}
 	}

--- a/apps/vscode/src/shared/services/feature-flags/feature-flags.ts
+++ b/apps/vscode/src/shared/services/feature-flags/feature-flags.ts
@@ -16,6 +16,8 @@ export enum FeatureFlag {
 	EXTENSION_CLINE_MODELS_ENDPOINT = "extension_cline_models_endpoint",
 	// Enables ClinePass provider/model list exposure.
 	CLINE_PASS = "ext-cline-pass",
+	// Exposes virtual auto-router model entries in the Cline provider picker.
+	CLINE_AUTO_MODEL_PICKER = "ext-cline-auto-model-picker",
 	// Rollout flag for fetching recommended Cline models from the upstream endpoint.
 	CLINE_RECOMMENDED_MODELS_UPSTREAM = "cline_recommended_models_upstream",
 	// Use the websocket mode for OpenAI native Responses API format
@@ -30,6 +32,8 @@ export const FeatureFlagDefaultValue: Partial<Record<FeatureFlag, FeatureFlagPay
 	[FeatureFlag.REMOTE_WELCOME_BANNERS]: process.env.E2E_TEST === "true" || process.env.IS_DEV === "true",
 	[FeatureFlag.EXTENSION_CLINE_MODELS_ENDPOINT]: false,
 	[FeatureFlag.CLINE_PASS]: false,
+	[FeatureFlag.CLINE_AUTO_MODEL_PICKER]:
+		process.env.CLINE_ENVIRONMENT === "local" && process.env.CLINE_AUTO_MODEL_PICKER_ENABLED === "true",
 	[FeatureFlag.CLINE_RECOMMENDED_MODELS_UPSTREAM]: false,
 	[FeatureFlag.OPENAI_RESPONSES_WEBSOCKET_MODE]: false,
 }

--- a/apps/vscode/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/ApiOptions.tsx
@@ -8,7 +8,7 @@ import styled from "styled-components"
 
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { PLATFORM_CONFIG, PlatformType } from "@/config/platform.config"
-import { CLINE_PASS_FEATURE_FLAG } from "@/constants/featureFlags"
+import { CLINE_AUTO_MODEL_PICKER_FEATURE_FLAG, CLINE_PASS_FEATURE_FLAG } from "@/constants/featureFlags"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { useHasFeatureFlag } from "@/hooks/useFeatureFlag"
 import { useProviderListings } from "@/hooks/useProviderListings"
@@ -97,6 +97,12 @@ const ApiOptions = ({
 	// Use full context state for immediate save payload
 	const { apiConfiguration, remoteConfigSettings } = useExtensionState()
 	const isClinePassEnabled = useHasFeatureFlag(CLINE_PASS_FEATURE_FLAG)
+	const allowsLocalAutoPickerOverrides = process.env.CLINE_ENVIRONMENT === "local"
+	const isAutoModelPickerEnabled =
+		useHasFeatureFlag(CLINE_AUTO_MODEL_PICKER_FEATURE_FLAG) ||
+		(allowsLocalAutoPickerOverrides && process.env.CLINE_AUTO_MODEL_PICKER_ENABLED === "true")
+	const isClinePassAutoModelEnabled =
+		isClinePassEnabled || (allowsLocalAutoPickerOverrides && process.env.CLINE_PASS_AUTO_MODEL_PICKER_ENABLED === "true")
 
 	const selectedProviderRaw =
 		(currentMode === "plan" ? apiConfiguration?.planModeApiProvider : apiConfiguration?.actModeApiProvider) || "anthropic"
@@ -394,6 +400,8 @@ const ApiOptions = ({
 				<ClineProvider
 					currentMode={currentMode}
 					initialModelTab={initialModelTab}
+					isAutoModelPickerEnabled={isAutoModelPickerEnabled}
+					isClinePassAutoModelEnabled={isClinePassAutoModelEnabled}
 					isPopup={isPopup}
 					showModelOptions={showModelOptions}
 				/>

--- a/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.test.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.test.tsx
@@ -108,6 +108,114 @@ describe("ClineModelPicker", () => {
 		})
 	})
 
+	it("commits a feature-gated virtual model through the existing Cline selection path", async () => {
+		render(<ClineModelPicker currentMode="act" isAutoModelPickerEnabled={true} isClinePassAutoModelEnabled={true} />)
+
+		fireEvent.focus(screen.getByRole("combobox"))
+		const clinePassAutoOption = screen
+			.getAllByRole("option")
+			.find((option) => option.textContent?.includes("cline-pass/auto"))
+		if (!clinePassAutoOption) {
+			throw new Error("expected cline-pass/auto option")
+		}
+		fireEvent.click(clinePassAutoOption)
+
+		await waitFor(() => expect(mocks.commitSelection).toHaveBeenCalledTimes(1))
+		expect(mocks.commitSelection).toHaveBeenCalledWith("act", {
+			providerId: "cline",
+			modelId: "cline-pass/auto",
+		})
+		await waitFor(() => expect(mocks.updateApiConfigurationProto).toHaveBeenCalledTimes(1))
+		expect(mocks.updateApiConfigurationProto).toHaveBeenCalledWith(
+			expect.objectContaining({
+				apiConfiguration: expect.objectContaining({
+					actModeClineModelId: "cline-pass/auto",
+					actModeClineModelInfo: expect.objectContaining({
+						supportsPromptCache: true,
+					}),
+				}),
+			}),
+		)
+	})
+
+	it("normalizes a persisted cline/auto selection when the master flag is disabled", async () => {
+		vi.mocked(useExtensionState).mockReturnValue({
+			apiConfiguration: {
+				actModeClineModelId: "cline/auto",
+				actModeClineModelInfo: {
+					name: "Cline Auto",
+					supportsPromptCache: true,
+				},
+			},
+			favoritedModelIds: [],
+			planActSeparateModelsSetting: true,
+		} as ReturnType<typeof useExtensionState>)
+		vi.mocked(useProviderConfig).mockReturnValue({
+			config: {
+				providerId: "cline",
+				actSelection: {
+					providerId: "cline",
+					modelId: "cline/auto",
+					modelInfo: toProtobufModelInfo({
+						name: "Cline Auto",
+						supportsPromptCache: true,
+					}),
+				},
+			},
+			write: mocks.writeProviderConfig,
+			commitSelection: mocks.commitSelection,
+		})
+
+		render(<ClineModelPicker currentMode="act" isAutoModelPickerEnabled={false} />)
+
+		expect(screen.getByRole("combobox")).toHaveValue("cline-default")
+		await waitFor(() =>
+			expect(mocks.commitSelection).toHaveBeenCalledWith("act", {
+				providerId: "cline",
+				modelId: "cline-default",
+			}),
+		)
+		await waitFor(() =>
+			expect(mocks.updateApiConfigurationProto).toHaveBeenCalledWith(
+				expect.objectContaining({
+					apiConfiguration: expect.objectContaining({
+						actModeClineModelId: "cline-default",
+					}),
+				}),
+			),
+		)
+	})
+
+	it("normalizes a persisted cline-pass/auto selection when only the Pass flag is disabled", async () => {
+		vi.mocked(useExtensionState).mockReturnValue({
+			apiConfiguration: {
+				actModeClineModelId: "cline-pass/auto",
+				actModeClineModelInfo: {
+					name: "Cline Pass Auto",
+					supportsPromptCache: true,
+				},
+			},
+			favoritedModelIds: [],
+			planActSeparateModelsSetting: true,
+		} as ReturnType<typeof useExtensionState>)
+
+		render(<ClineModelPicker currentMode="act" isAutoModelPickerEnabled={true} isClinePassAutoModelEnabled={false} />)
+
+		expect(screen.getByRole("combobox")).toHaveValue("cline-default")
+		await waitFor(() =>
+			expect(mocks.commitSelection).toHaveBeenCalledWith("act", {
+				providerId: "cline",
+				modelId: "cline-default",
+			}),
+		)
+		expect(mocks.commitSelection).not.toHaveBeenCalledWith(
+			"act",
+			expect.objectContaining({
+				providerId: "cline-pass",
+			}),
+		)
+	})
+
 	it("hydrates the selected Cline model from provider config when legacy settings are empty", () => {
 		vi.mocked(useExtensionState).mockReturnValue({
 			apiConfiguration: {},

--- a/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.tsx
@@ -16,6 +16,7 @@ import { useProviderConfig } from "@/hooks/useProviderConfig"
 import { useProviderModels } from "@/hooks/useProviderModels"
 import { ModelsServiceClient, StateServiceClient } from "@/services/grpc-client"
 import { highlight } from "../history/HistoryView"
+import { shouldNormalizeClineAutoModel, withClineAutoModels } from "./clineAutoModels"
 import { ModelInfoView } from "./common/ModelInfoView"
 import FeaturedModelCard from "./FeaturedModelCard"
 import ReasoningEffortSelector from "./ReasoningEffortSelector"
@@ -52,6 +53,8 @@ interface ClineModelPickerProps {
 	currentMode: Mode
 	showProviderRouting?: boolean
 	initialTab?: "recommended" | "free"
+	isAutoModelPickerEnabled?: boolean
+	isClinePassAutoModelEnabled?: boolean
 }
 
 interface FeaturedModelCardEntry {
@@ -92,23 +95,43 @@ const FREE_MODELS_FALLBACK: FeaturedModelCardEntry[] = CLINE_RECOMMENDED_MODELS_
 	.map((model) => toFeaturedModelCardEntry(model, "FREE"))
 	.filter((model): model is FeaturedModelCardEntry => model !== null)
 
-const ClineModelPicker: React.FC<ClineModelPickerProps> = ({ isPopup, currentMode, showProviderRouting, initialTab }) => {
+const ClineModelPicker: React.FC<ClineModelPickerProps> = ({
+	isPopup,
+	currentMode,
+	showProviderRouting,
+	initialTab,
+	isAutoModelPickerEnabled = false,
+	isClinePassAutoModelEnabled = false,
+}) => {
 	const { handleModeFieldsChange, handleFieldChange } = useApiConfigurationHandlers()
 	const { apiConfiguration, favoritedModelIds } = useExtensionState()
 	const { models: catalogClineModels, defaultModelId: clineDefaultModelId } = useProviderModels("cline")
 	const { config, write: writeProviderConfig, commitSelection } = useProviderConfig("cline")
 	const modeFields = getModeSpecificFields(apiConfiguration, currentMode)
-	const effectiveClineModels = catalogClineModels
+	const effectiveClineModels = useMemo(
+		() =>
+			withClineAutoModels(catalogClineModels, {
+				enabled: isAutoModelPickerEnabled,
+				isClinePassAutoModelEnabled,
+			}),
+		[catalogClineModels, isAutoModelPickerEnabled, isClinePassAutoModelEnabled],
+	)
 	const committedSelection = currentMode === "plan" ? config?.planSelection : config?.actSelection
 	const committedModelInfo = committedSelection?.modelInfo ? fromProtobufModelInfo(committedSelection.modelInfo) : undefined
-	const currentClineModelId =
-		committedSelection?.modelId ||
-		modeFields.clineModelId ||
-		clineDefaultModelId ||
-		Object.keys(effectiveClineModels ?? {})[0] ||
+	const persistedClineModelId = committedSelection?.modelId || modeFields.clineModelId
+	const shouldNormalizePersistedModel = shouldNormalizeClineAutoModel(persistedClineModelId, {
+		enabled: isAutoModelPickerEnabled,
+		isClinePassAutoModelEnabled,
+	})
+	const concreteFallbackModelId =
+		(clineDefaultModelId && effectiveClineModels[clineDefaultModelId] ? clineDefaultModelId : undefined) ||
+		Object.keys(effectiveClineModels)[0] ||
 		""
+	const currentClineModelId =
+		(shouldNormalizePersistedModel ? concreteFallbackModelId : persistedClineModelId) || concreteFallbackModelId
 	const [searchTerm, setSearchTerm] = useState(currentClineModelId)
 	const searchTermEditedByUserRef = useRef(false)
+	const normalizedSelectionKeyRef = useRef<string | null>(null)
 	const [isDropdownVisible, setIsDropdownVisible] = useState(false)
 	const [selectedIndex, setSelectedIndex] = useState(-1)
 	const [clineRecommendedModels, setClineRecommendedModels] = useState<FeaturedModelCardEntry[]>([])
@@ -206,38 +229,55 @@ const ClineModelPicker: React.FC<ClineModelPickerProps> = ({ isPopup, currentMod
 	const itemRefs = useRef<(HTMLDivElement | null)[]>([])
 	const dropdownListRef = useRef<HTMLDivElement>(null)
 
-	const handleModelChange = (newModelId: string) => {
-		searchTermEditedByUserRef.current = false
-		setSearchTerm(newModelId)
+	const handleModelChange = useCallback(
+		(newModelId: string) => {
+			searchTermEditedByUserRef.current = false
+			setSearchTerm(newModelId)
 
-		const modelInfo = effectiveClineModels?.[newModelId] ?? {
-			...openAiModelInfoSafeDefaults,
-			name: newModelId,
+			const modelInfo = effectiveClineModels?.[newModelId] ?? {
+				...openAiModelInfoSafeDefaults,
+				name: newModelId,
+			}
+
+			void commitSelection(currentMode, {
+				providerId: "cline",
+				modelId: newModelId,
+			}).catch((err) => console.error("Failed to commit Cline model selection:", err))
+
+			void handleModeFieldsChange(
+				{
+					clineModelId: {
+						plan: "planModeClineModelId",
+						act: "actModeClineModelId",
+					},
+					clineModelInfo: {
+						plan: "planModeClineModelInfo",
+						act: "actModeClineModelInfo",
+					},
+				},
+				{
+					clineModelId: newModelId,
+					clineModelInfo: modelInfo,
+				},
+				currentMode,
+			)
+		},
+		[commitSelection, currentMode, effectiveClineModels, handleModeFieldsChange],
+	)
+
+	useEffect(() => {
+		if (!shouldNormalizePersistedModel || !persistedClineModelId || !concreteFallbackModelId) {
+			normalizedSelectionKeyRef.current = null
+			return
 		}
 
-		void commitSelection(currentMode, {
-			providerId: "cline",
-			modelId: newModelId,
-		}).catch((err) => console.error("Failed to commit Cline model selection:", err))
-
-		void handleModeFieldsChange(
-			{
-				clineModelId: {
-					plan: "planModeClineModelId",
-					act: "actModeClineModelId",
-				},
-				clineModelInfo: {
-					plan: "planModeClineModelInfo",
-					act: "actModeClineModelInfo",
-				},
-			},
-			{
-				clineModelId: newModelId,
-				clineModelInfo: modelInfo,
-			},
-			currentMode,
-		)
-	}
+		const normalizationKey = `${currentMode}:${persistedClineModelId}:${concreteFallbackModelId}`
+		if (normalizedSelectionKeyRef.current === normalizationKey) {
+			return
+		}
+		normalizedSelectionKeyRef.current = normalizationKey
+		handleModelChange(concreteFallbackModelId)
+	}, [concreteFallbackModelId, currentMode, handleModelChange, persistedClineModelId, shouldNormalizePersistedModel])
 
 	const baseSelection = useDynamicProviderSelection("cline", apiConfiguration, currentMode)
 	const { selectedModelId, selectedModelInfo } = useMemo(() => {

--- a/apps/vscode/webview-ui/src/components/settings/clineAutoModels.test.ts
+++ b/apps/vscode/webview-ui/src/components/settings/clineAutoModels.test.ts
@@ -33,6 +33,7 @@ describe("withClineAutoModels", () => {
 
 		expect(models[CLINE_AUTO_MODEL_ID]).toMatchObject({
 			name: "Cline Auto",
+			supportsImages: false,
 			supportsPromptCache: true,
 		})
 		expect(models[CLINE_PASS_AUTO_MODEL_ID]).toBeUndefined()
@@ -43,6 +44,7 @@ describe("withClineAutoModels", () => {
 
 		expect(models[CLINE_AUTO_MODEL_ID]?.supportsPromptCache).toBe(true)
 		expect(models[CLINE_PASS_AUTO_MODEL_ID]?.supportsPromptCache).toBe(true)
+		expect(models[CLINE_PASS_AUTO_MODEL_ID]?.supportsImages).toBe(false)
 	})
 
 	it("preserves live endpoint metadata when a gated virtual model is present", () => {

--- a/apps/vscode/webview-ui/src/components/settings/clineAutoModels.test.ts
+++ b/apps/vscode/webview-ui/src/components/settings/clineAutoModels.test.ts
@@ -1,0 +1,92 @@
+import type { ModelInfo } from "@shared/api"
+import { describe, expect, it } from "vitest"
+import {
+	CLINE_AUTO_MODEL_ID,
+	CLINE_PASS_AUTO_MODEL_ID,
+	shouldNormalizeClineAutoModel,
+	withClineAutoModels,
+} from "./clineAutoModels"
+
+const catalog: Record<string, ModelInfo> = {
+	"anthropic/claude-sonnet": {
+		name: "Claude Sonnet",
+		supportsPromptCache: true,
+	},
+}
+
+describe("withClineAutoModels", () => {
+	it("does not expose either virtual model while the picker flag is disabled", () => {
+		const models = withClineAutoModels(
+			{
+				...catalog,
+				[CLINE_AUTO_MODEL_ID]: { name: "Endpoint Auto", supportsPromptCache: true },
+				[CLINE_PASS_AUTO_MODEL_ID]: { name: "Endpoint Pass Auto", supportsPromptCache: true },
+			},
+			{ enabled: false, isClinePassAutoModelEnabled: true },
+		)
+
+		expect(models).toEqual(catalog)
+	})
+
+	it("exposes only cline/auto when Cline Pass is not enabled", () => {
+		const models = withClineAutoModels(catalog, { enabled: true, isClinePassAutoModelEnabled: false })
+
+		expect(models[CLINE_AUTO_MODEL_ID]).toMatchObject({
+			name: "Cline Auto",
+			supportsPromptCache: true,
+		})
+		expect(models[CLINE_PASS_AUTO_MODEL_ID]).toBeUndefined()
+	})
+
+	it("exposes both cache-aware virtual models when both rollout gates are enabled", () => {
+		const models = withClineAutoModels(catalog, { enabled: true, isClinePassAutoModelEnabled: true })
+
+		expect(models[CLINE_AUTO_MODEL_ID]?.supportsPromptCache).toBe(true)
+		expect(models[CLINE_PASS_AUTO_MODEL_ID]?.supportsPromptCache).toBe(true)
+	})
+
+	it("preserves live endpoint metadata when a gated virtual model is present", () => {
+		const models = withClineAutoModels(
+			{
+				...catalog,
+				[CLINE_AUTO_MODEL_ID]: {
+					name: "Endpoint Auto",
+					supportsPromptCache: true,
+					contextWindow: 200_000,
+				},
+			},
+			{ enabled: true, isClinePassAutoModelEnabled: false },
+		)
+
+		expect(models[CLINE_AUTO_MODEL_ID]).toEqual({
+			name: "Endpoint Auto",
+			supportsPromptCache: true,
+			contextWindow: 200_000,
+		})
+	})
+})
+
+describe("shouldNormalizeClineAutoModel", () => {
+	it("normalizes both virtual IDs when the master picker flag is disabled", () => {
+		const options = { enabled: false, isClinePassAutoModelEnabled: true }
+
+		expect(shouldNormalizeClineAutoModel(CLINE_AUTO_MODEL_ID, options)).toBe(true)
+		expect(shouldNormalizeClineAutoModel(CLINE_PASS_AUTO_MODEL_ID, options)).toBe(true)
+	})
+
+	it("normalizes only the Pass virtual ID when its entitlement flag is disabled", () => {
+		const options = { enabled: true, isClinePassAutoModelEnabled: false }
+
+		expect(shouldNormalizeClineAutoModel(CLINE_AUTO_MODEL_ID, options)).toBe(false)
+		expect(shouldNormalizeClineAutoModel(CLINE_PASS_AUTO_MODEL_ID, options)).toBe(true)
+	})
+
+	it("leaves concrete model IDs unchanged", () => {
+		expect(
+			shouldNormalizeClineAutoModel("anthropic/claude-sonnet", {
+				enabled: false,
+				isClinePassAutoModelEnabled: false,
+			}),
+		).toBe(false)
+	})
+})

--- a/apps/vscode/webview-ui/src/components/settings/clineAutoModels.ts
+++ b/apps/vscode/webview-ui/src/components/settings/clineAutoModels.ts
@@ -5,7 +5,10 @@ export const CLINE_PASS_AUTO_MODEL_ID = "cline-pass/auto"
 
 const CLINE_AUTO_MODEL_INFO: ModelInfo = {
 	name: "Cline Auto",
-	supportsImages: true,
+	// Keep the virtual capability surface to the intersection of every route.
+	// The current balanced GLM candidate does not accept images, and Core does
+	// not yet constrain image requests to a vision-capable candidate.
+	supportsImages: false,
 	supportsPromptCache: true,
 	description:
 		"Automatically routes each turn to an eligible Cline model while accounting for prompt-cache reuse and switching cost.",
@@ -13,7 +16,8 @@ const CLINE_AUTO_MODEL_INFO: ModelInfo = {
 
 const CLINE_PASS_AUTO_MODEL_INFO: ModelInfo = {
 	name: "Cline Pass Auto",
-	supportsImages: true,
+	// The Pass balanced/heavy candidates are text-only today.
+	supportsImages: false,
 	supportsPromptCache: true,
 	inputPrice: 0,
 	outputPrice: 0,

--- a/apps/vscode/webview-ui/src/components/settings/clineAutoModels.ts
+++ b/apps/vscode/webview-ui/src/components/settings/clineAutoModels.ts
@@ -1,0 +1,72 @@
+import type { ModelInfo } from "@shared/api"
+
+export const CLINE_AUTO_MODEL_ID = "cline/auto"
+export const CLINE_PASS_AUTO_MODEL_ID = "cline-pass/auto"
+
+const CLINE_AUTO_MODEL_INFO: ModelInfo = {
+	name: "Cline Auto",
+	supportsImages: true,
+	supportsPromptCache: true,
+	description:
+		"Automatically routes each turn to an eligible Cline model while accounting for prompt-cache reuse and switching cost.",
+}
+
+const CLINE_PASS_AUTO_MODEL_INFO: ModelInfo = {
+	name: "Cline Pass Auto",
+	supportsImages: true,
+	supportsPromptCache: true,
+	inputPrice: 0,
+	outputPrice: 0,
+	cacheReadsPrice: 0,
+	cacheWritesPrice: 0,
+	description:
+		"Automatically routes each turn using only Cline Pass models while accounting for prompt-cache reuse and switching cost.",
+}
+
+interface ClineAutoModelOptions {
+	enabled: boolean
+	isClinePassAutoModelEnabled: boolean
+}
+
+export function shouldNormalizeClineAutoModel(modelId: string | undefined, options: ClineAutoModelOptions): boolean {
+	if (modelId === CLINE_AUTO_MODEL_ID) {
+		return !options.enabled
+	}
+	if (modelId === CLINE_PASS_AUTO_MODEL_ID) {
+		return !options.enabled || !options.isClinePassAutoModelEnabled
+	}
+	return false
+}
+
+/**
+ * Adds the feature-gated virtual router entries to the Cline provider catalog.
+ *
+ * Keep this as a view over the live SDK catalog: the virtual entries are not
+ * real SDK models, and the backend must resolve them before normal model
+ * lookup. If the endpoint eventually returns either entry, its live metadata
+ * wins over the local fallback.
+ */
+export function withClineAutoModels(
+	models: Record<string, ModelInfo> | undefined,
+	options: ClineAutoModelOptions,
+): Record<string, ModelInfo> {
+	const effectiveModels = { ...models }
+	const liveClineAutoModel = effectiveModels[CLINE_AUTO_MODEL_ID]
+	const liveClinePassAutoModel = effectiveModels[CLINE_PASS_AUTO_MODEL_ID]
+
+	// The endpoint may learn these IDs before the rollout is complete. Remove
+	// them first so visibility still follows the client-side rollout gates.
+	delete effectiveModels[CLINE_AUTO_MODEL_ID]
+	delete effectiveModels[CLINE_PASS_AUTO_MODEL_ID]
+
+	if (!options.enabled) {
+		return effectiveModels
+	}
+
+	effectiveModels[CLINE_AUTO_MODEL_ID] = liveClineAutoModel ?? CLINE_AUTO_MODEL_INFO
+	if (options.isClinePassAutoModelEnabled) {
+		effectiveModels[CLINE_PASS_AUTO_MODEL_ID] = liveClinePassAutoModel ?? CLINE_PASS_AUTO_MODEL_INFO
+	}
+
+	return effectiveModels
+}

--- a/apps/vscode/webview-ui/src/components/settings/providers/ClineProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/ClineProvider.tsx
@@ -10,12 +10,21 @@ interface ClineProviderProps {
 	isPopup?: boolean
 	currentMode: Mode
 	initialModelTab?: "recommended" | "free"
+	isAutoModelPickerEnabled?: boolean
+	isClinePassAutoModelEnabled?: boolean
 }
 
 /**
  * The Cline provider configuration component
  */
-export const ClineProvider = ({ showModelOptions, isPopup, currentMode, initialModelTab }: ClineProviderProps) => {
+export const ClineProvider = ({
+	showModelOptions,
+	isPopup,
+	currentMode,
+	initialModelTab,
+	isAutoModelPickerEnabled,
+	isClinePassAutoModelEnabled,
+}: ClineProviderProps) => {
 	return (
 		<div>
 			{/* Cline Account Info Card */}
@@ -27,6 +36,8 @@ export const ClineProvider = ({ showModelOptions, isPopup, currentMode, initialM
 				<ClineModelPicker
 					currentMode={currentMode}
 					initialTab={initialModelTab}
+					isAutoModelPickerEnabled={isAutoModelPickerEnabled}
+					isClinePassAutoModelEnabled={isClinePassAutoModelEnabled}
 					isPopup={isPopup}
 					showProviderRouting={true}
 				/>

--- a/apps/vscode/webview-ui/src/constants/featureFlags.ts
+++ b/apps/vscode/webview-ui/src/constants/featureFlags.ts
@@ -1,3 +1,4 @@
 // Webview copies of feature-flag strings. Must match the extension's FeatureFlag
 // enum, which can't be imported here (it pulls in Node-only deps).
 export const CLINE_PASS_FEATURE_FLAG = "ext-cline-pass"
+export const CLINE_AUTO_MODEL_PICKER_FEATURE_FLAG = "ext-cline-auto-model-picker"

--- a/apps/vscode/webview-ui/vite.config.ts
+++ b/apps/vscode/webview-ui/vite.config.ts
@@ -132,6 +132,8 @@ export default defineConfig({
 		__PLATFORM__: JSON.stringify(platform),
 		__NODE_PLATFORM__: JSON.stringify(process.platform),
 		"process.env.CLINE_ENVIRONMENT": JSON.stringify(process.env.CLINE_ENVIRONMENT ?? "production"),
+		"process.env.CLINE_AUTO_MODEL_PICKER_ENABLED": JSON.stringify(process.env.CLINE_AUTO_MODEL_PICKER_ENABLED),
+		"process.env.CLINE_PASS_AUTO_MODEL_PICKER_ENABLED": JSON.stringify(process.env.CLINE_PASS_AUTO_MODEL_PICKER_ENABLED),
 		"process.env.IS_DEV": JSON.stringify(process.env.IS_DEV),
 		"process.env.IS_TEST": JSON.stringify(process.env.IS_TEST),
 		"process.env.CI": JSON.stringify(process.env.CI),


### PR DESCRIPTION
Feature-flagged internal demo of cline/auto and cline-pass/auto under the Cline provider. Defaults remain off. Includes local Core override and hardened demo launcher. Do not merge wholesale; production changes will be split into focused PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes model selection and local API targeting (mitigated by loopback-only override); virtual model IDs require backend resolution before real requests work.
> 
> **Overview**
> Adds a **feature-flagged** path to show virtual **`cline/auto`** and **`cline-pass/auto`** entries only inside the **Cline** provider model picker (not the standalone Cline Pass provider). Rollout uses **`ext-cline-auto-model-picker`** plus local build-time env overrides; persisted virtual IDs are **normalized back** to a concrete default when gates are off.
> 
> **Local demo wiring:** optional **`CLINE_LOCAL_API_BASE_URL`** (loopback ports **7777** / **17777** only) for local Core; **`run-extension-host.sh`** gains **`--check`**, tmux/plain modes, isolated VS Code profiles, and safer teardown. Auth user-info fetch errors are logged via **`summarizeAuthFetchError`** so tokens are not written to logs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18ba52d991fd5c1bbb7b8139c96d64c137019d05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->