### PR TITLE
Recognize progress in repeated tool-call loops

### DIFF
--- a/sdk/ARCHITECTURE.md
+++ b/sdk/ARCHITECTURE.md
@@ -126,6 +126,16 @@ Design rules:
 6. `@cline/agents` runs the loop using `@cline/llms` handlers.
 7. `@cline/core` persists state, artifacts, and metadata.
 
+Before each tool starts, the core session runtime applies repeated-call safety
+to the tool name and normalized input. Identical calls produce a recovery
+warning at the configured soft threshold and stop at the hard threshold.
+Successful result changes reset the ordinary consecutive-call count only after
+volatile timestamps, request IDs, and log-tail noise are normalized away;
+failed operations never count as progress. An absolute repeated-batch ceiling
+still bounds continually changing results, and parallel identical calls are
+correlated as one batch without discarding outcomes that finish around an
+interleaved tool call.
+
 Completion telemetry is anchored to the assistant's explicit completion
 declaration, not session shutdown. After each agent turn, the local
 runtime inspects `AgentResult.toolCalls` and emits `task.completed` the

--- a/sdk/ARCHITECTURE.md
+++ b/sdk/ARCHITECTURE.md
@@ -131,10 +131,10 @@ to the tool name and normalized input. Identical calls produce a recovery
 warning at the configured soft threshold and stop at the hard threshold.
 Successful result changes reset the ordinary consecutive-call count only after
 volatile timestamps, request IDs, and log-tail noise are normalized away;
-failed operations never count as progress. An absolute repeated-batch ceiling
-still bounds continually changing results, and parallel identical calls are
-correlated as one batch without discarding outcomes that finish around an
-interleaved tool call.
+failed operations never count as progress. An absolute per-signature
+repeated-batch ceiling still bounds continually changing results across
+interleaved tools, and parallel identical calls are correlated as one batch
+without discarding outcomes that finish around an interleaved tool call.
 
 Completion telemetry is anchored to the assistant's explicit completion
 declaration, not session shutdown. After each agent turn, the local

--- a/sdk/ARCHITECTURE.md
+++ b/sdk/ARCHITECTURE.md
@@ -126,15 +126,11 @@ Design rules:
 6. `@cline/agents` runs the loop using `@cline/llms` handlers.
 7. `@cline/core` persists state, artifacts, and metadata.
 
-Before each tool starts, the core session runtime applies repeated-call safety
-to the tool name and normalized input. Identical calls produce a recovery
-warning at the configured soft threshold and stop at the hard threshold.
-Successful result changes reset the ordinary consecutive-call count only after
-volatile timestamps, request IDs, and log-tail noise are normalized away;
-failed operations never count as progress. An absolute per-signature
-repeated-batch ceiling still bounds continually changing results across
-interleaved tools, and parallel identical calls are correlated as one batch
-without discarding outcomes that finish around an interleaved tool call.
+Before each tool starts, the core session runtime checks its name and normalized
+input for repetition. Meaningfully changed successful results reset the ordinary
+counter; failed results and volatile output do not. Parallel identical calls
+form one batch, and a per-signature ceiling still bounds continually changing
+results.
 
 Completion telemetry is anchored to the assistant's explicit completion
 declaration, not session shutdown. After each agent turn, the local

--- a/sdk/ARCHITECTURE.md
+++ b/sdk/ARCHITECTURE.md
@@ -126,12 +126,6 @@ Design rules:
 6. `@cline/agents` runs the loop using `@cline/llms` handlers.
 7. `@cline/core` persists state, artifacts, and metadata.
 
-Before each tool starts, the core session runtime checks its name and normalized
-input for repetition. Meaningfully changed successful results reset the ordinary
-counter; failed results and volatile output do not. Parallel identical calls
-form one batch, and a per-signature ceiling still bounds continually changing
-results.
-
 Completion telemetry is anchored to the assistant's explicit completion
 declaration, not session shutdown. After each agent turn, the local
 runtime inspects `AgentResult.toolCalls` and emits `task.completed` the

--- a/sdk/packages/core/src/extensions/mcp/tools.test.ts
+++ b/sdk/packages/core/src/extensions/mcp/tools.test.ts
@@ -1,0 +1,29 @@
+import type { AgentToolContext } from "@cline/shared";
+import { describe, expect, it, vi } from "vitest";
+import { createMcpTools } from "./tools";
+
+const context: AgentToolContext = {
+	agentId: "agent-1",
+	conversationId: "conversation-1",
+	iteration: 1,
+};
+
+describe("createMcpTools", () => {
+	it("promotes MCP error responses to tool execution failures", async () => {
+		const provider = {
+			listTools: vi.fn(async () => [
+				{
+					name: "poll",
+					inputSchema: { type: "object", properties: {} },
+				},
+			]),
+			callTool: vi.fn(async () => ({
+				content: [{ type: "text", text: "job failed" }],
+				isError: true,
+			})),
+		};
+		const [tool] = await createMcpTools({ serverName: "server", provider });
+
+		await expect(tool.execute({}, context)).rejects.toThrow("job failed");
+	});
+});

--- a/sdk/packages/core/src/extensions/mcp/tools.ts
+++ b/sdk/packages/core/src/extensions/mcp/tools.ts
@@ -2,6 +2,30 @@ import { type AgentTool, createTool } from "@cline/shared";
 import { defaultMcpToolNameTransform } from "./name-transform";
 import type { CreateMcpToolsOptions, McpToolDescriptor } from "./types";
 
+function mcpErrorMessage(result: unknown): string | undefined {
+	if (
+		result === null ||
+		typeof result !== "object" ||
+		Array.isArray(result) ||
+		(result as { isError?: unknown }).isError !== true
+	) {
+		return undefined;
+	}
+	const content = (result as { content?: unknown }).content;
+	if (!Array.isArray(content)) return "MCP tool returned an error";
+	const text = content
+		.flatMap((part) =>
+			part !== null &&
+			typeof part === "object" &&
+			(part as { type?: unknown }).type === "text" &&
+			typeof (part as { text?: unknown }).text === "string"
+				? [(part as { text: string }).text]
+				: [],
+		)
+		.join("\n");
+	return text || "MCP tool returned an error";
+}
+
 function defaultMcpDescription(
 	serverName: string,
 	tool: McpToolDescriptor,
@@ -32,8 +56,8 @@ export async function createMcpTools(
 			timeoutMs: options.timeoutMs,
 			retryable: options.retryable,
 			maxRetries: options.maxRetries,
-			execute: async (input: unknown, context) =>
-				options.provider.callTool({
+			execute: async (input: unknown, context) => {
+				const result = await options.provider.callTool({
 					serverName: options.serverName,
 					toolName: descriptor.name,
 					arguments:
@@ -41,7 +65,11 @@ export async function createMcpTools(
 							? (input as Record<string, unknown>)
 							: undefined,
 					context,
-				}),
+				});
+				const error = mcpErrorMessage(result);
+				if (error) throw new Error(error);
+				return result;
+			},
 		});
 	});
 }

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
@@ -2277,6 +2277,68 @@ describe("SessionRuntime.run — tracker wiring (P1 #3)", () => {
 		expect(abortCalls.length).toBeGreaterThanOrEqual(1);
 	});
 
+	it("does not abort repeated successful calls whose output shows progress", async () => {
+		const successfulCall = (i: number, output: string): AgentRuntimeEvent[] => {
+			const toolCall = {
+				type: "tool-call" as const,
+				toolCallId: `tc${i}`,
+				toolName: "poll",
+				input: { command: "status" },
+			};
+			return [
+				{
+					type: "tool-started",
+					iteration: i,
+					toolCall,
+					snapshot: makeSnapshot(),
+				},
+				{
+					type: "tool-finished",
+					iteration: i,
+					toolCall,
+					message: {
+						id: `m${i}`,
+						role: "tool",
+						content: [
+							{
+								type: "tool-result",
+								toolCallId: toolCall.toolCallId,
+								toolName: toolCall.toolName,
+								output,
+							},
+						],
+						createdAt: i,
+					},
+					snapshot: makeSnapshot(),
+				},
+			];
+		};
+		const { deps, abortCalls } = makeScriptedRuntime({
+			events: [
+				{ type: "turn-started", iteration: 1, snapshot: makeSnapshot() },
+				...successfulCall(1, "10% complete"),
+				...successfulCall(2, "30% complete"),
+				...successfulCall(3, "50% complete"),
+				...successfulCall(4, "70% complete"),
+				...successfulCall(5, "90% complete"),
+				...successfulCall(6, "done"),
+			],
+		});
+		const session = new SessionRuntime(
+			makeAgentConfig({
+				execution: {
+					maxConsecutiveMistakes: 6,
+					loopDetection: { softThreshold: 2, hardThreshold: 3 },
+				},
+			}),
+			deps,
+		);
+
+		await session.run("monitor progress");
+
+		expect(abortCalls).toHaveLength(0);
+	});
+
 	it("resets loop detection when run() starts a fresh conversation", async () => {
 		const identical = (i: number): AgentRuntimeEvent => ({
 			type: "tool-started",

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
@@ -2339,6 +2339,72 @@ describe("SessionRuntime.run — tracker wiring (P1 #3)", () => {
 		expect(abortCalls).toHaveLength(0);
 	});
 
+	it("still aborts repeated built-in failures whose error output changes", async () => {
+		const failedCall = (i: number): AgentRuntimeEvent[] => {
+			const toolCall = {
+				type: "tool-call" as const,
+				toolCallId: `failed-${i}`,
+				toolName: "run_commands",
+				input: { commands: ["false"] },
+			};
+			return [
+				{
+					type: "tool-started",
+					iteration: i,
+					toolCall,
+					snapshot: makeSnapshot(),
+				},
+				{
+					type: "tool-finished",
+					iteration: i,
+					toolCall,
+					message: {
+						id: `failed-message-${i}`,
+						role: "tool",
+						content: [
+							{
+								type: "tool-result",
+								toolCallId: toolCall.toolCallId,
+								toolName: toolCall.toolName,
+								output: [
+									{
+										query: "false",
+										result: "",
+										error: `command failed on attempt ${i}`,
+										success: false,
+									},
+								],
+							},
+						],
+						createdAt: i,
+					},
+					snapshot: makeSnapshot(),
+				},
+			];
+		};
+		const { deps, abortCalls } = makeScriptedRuntime({
+			events: [
+				{ type: "turn-started", iteration: 1, snapshot: makeSnapshot() },
+				...failedCall(1),
+				...failedCall(2),
+				...failedCall(3),
+			],
+		});
+		const session = new SessionRuntime(
+			makeAgentConfig({
+				execution: {
+					maxConsecutiveMistakes: 6,
+					loopDetection: { softThreshold: 2, hardThreshold: 3 },
+				},
+			}),
+			deps,
+		);
+
+		await session.run("repeat a failing command");
+
+		expect(abortCalls.length).toBeGreaterThanOrEqual(1);
+	});
+
 	it("resets loop detection when run() starts a fresh conversation", async () => {
 		const identical = (i: number): AgentRuntimeEvent => ({
 			type: "tool-started",

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
@@ -2425,6 +2425,74 @@ describe("SessionRuntime.run — tracker wiring (P1 #3)", () => {
 		expect(abortCalls).toHaveLength(0);
 	});
 
+	it("preserves identical parallel progress across an interleaved tool call", async () => {
+		const toolCall = (id: string, name = "poll") => ({
+			type: "tool-call" as const,
+			toolCallId: id,
+			toolName: name,
+			input: { command: "status" },
+		});
+		const started = (id: string, name?: string): AgentRuntimeEvent => ({
+			type: "tool-started",
+			iteration: 1,
+			toolCall: toolCall(id, name),
+			snapshot: makeSnapshot(),
+		});
+		const finished = (
+			id: string,
+			output: string,
+			name?: string,
+		): AgentRuntimeEvent => ({
+			type: "tool-finished",
+			iteration: 1,
+			toolCall: toolCall(id, name),
+			message: {
+				id: `message-${id}`,
+				role: "tool",
+				content: [
+					{
+						type: "tool-result",
+						toolCallId: id,
+						toolName: name ?? "poll",
+						output,
+					},
+				],
+				createdAt: 1,
+			},
+			snapshot: makeSnapshot(),
+		});
+		const { deps, abortCalls } = makeScriptedRuntime({
+			events: [
+				{ type: "turn-started", iteration: 1, snapshot: makeSnapshot() },
+				started("baseline"),
+				finished("baseline", "10% complete"),
+				started("parallel-1"),
+				started("other-1", "other"),
+				finished("other-1", "unchanged", "other"),
+				started("parallel-2"),
+				finished("parallel-1", "20% complete"),
+				finished("parallel-2", "10% complete"),
+				started("poll-3"),
+				finished("poll-3", "10% complete"),
+				started("poll-4"),
+				finished("poll-4", "10% complete"),
+			],
+		});
+		const session = new SessionRuntime(
+			makeAgentConfig({
+				execution: {
+					maxConsecutiveMistakes: 6,
+					loopDetection: { softThreshold: 2, hardThreshold: 3 },
+				},
+			}),
+			deps,
+		);
+
+		await session.run("monitor interleaved parallel progress");
+
+		expect(abortCalls).toHaveLength(0);
+	});
+
 	it("still aborts repeated built-in failures whose error output changes", async () => {
 		const failedCall = (i: number): AgentRuntimeEvent[] => {
 			const toolCall = {

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
@@ -2046,6 +2046,7 @@ interface ScriptedToolOptions {
 	iteration?: number;
 	name?: string;
 	input?: unknown;
+	isError?: boolean;
 }
 
 function toolStarted(
@@ -2086,6 +2087,7 @@ function completedTool(
 						toolCallId: id,
 						toolName: started.toolCall.toolName,
 						output,
+						isError: options.isError,
 					},
 				],
 				createdAt: 1,
@@ -2417,21 +2419,19 @@ describe("SessionRuntime.run — tracker wiring (P1 #3)", () => {
 		expect(abortCalls.length).toBeGreaterThanOrEqual(1);
 	});
 
-	it("still aborts repeated MCP failures whose error output changes", async () => {
+	it("still aborts repeated adapter-promoted MCP failures", async () => {
 		const { session, abortCalls } = loopSession({
 			events: [
 				turnStarted(),
 				...[1, 2, 3].flatMap((index) =>
 					completedTool(
 						`mcp-failed-${index}`,
-						{
-							content: [{ type: "text", text: `attempt ${index}` }],
-							isError: true,
-						},
+						{ error: `attempt ${index}` },
 						{
 							iteration: index,
 							name: "server__poll",
 							input: { jobId: "job-1" },
+							isError: true,
 						},
 					),
 				),
@@ -2441,6 +2441,29 @@ describe("SessionRuntime.run — tracker wiring (P1 #3)", () => {
 		await session.run("repeat a failing MCP poll");
 
 		expect(abortCalls.length).toBeGreaterThanOrEqual(1);
+	});
+
+	it("allows successful non-MCP outputs containing isError data", async () => {
+		const { session, abortCalls } = loopSession({
+			events: [
+				turnStarted(),
+				...[3, 2, 1].flatMap((pendingChecks, index) =>
+					completedTool(
+						`status-${index}`,
+						{ isError: true, pendingChecks },
+						{
+							iteration: index + 1,
+							name: "status",
+							input: { jobId: "job-1" },
+						},
+					),
+				),
+			],
+		});
+
+		await session.run("monitor a successful custom tool");
+
+		expect(abortCalls).toHaveLength(0);
 	});
 
 	it("resets loop detection when run() starts a fresh conversation", async () => {

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
@@ -1982,6 +1982,7 @@ describe("SessionRuntime.run — initialMessages seeding (P1 #1)", () => {
  */
 function makeScriptedRuntime(script: {
 	events: readonly AgentRuntimeEvent[];
+	eventRuns?: readonly (readonly AgentRuntimeEvent[])[];
 }): {
 	deps: SessionRuntimeOrchestratorDeps;
 	abortCalls: string[];
@@ -2003,13 +2004,19 @@ function makeScriptedRuntime(script: {
 		},
 	};
 	let listener: ((e: AgentRuntimeEvent) => void) | undefined;
+	let runIndex = 0;
+	const emitEvents = () => {
+		const events = script.eventRuns?.[runIndex] ?? script.events;
+		runIndex++;
+		for (const event of events) listener?.(event);
+	};
 	const runtime = {
 		async run() {
-			for (const e of script.events) listener?.(e);
+			emitEvents();
 			return baseResult;
 		},
 		async continue() {
-			for (const e of script.events) listener?.(e);
+			emitEvents();
 			return baseResult;
 		},
 		abort(reason?: string) {
@@ -2489,6 +2496,49 @@ describe("SessionRuntime.run — tracker wiring (P1 #3)", () => {
 		);
 
 		await session.run("monitor interleaved parallel progress");
+
+		expect(abortCalls).toHaveLength(0);
+	});
+
+	it("drops unfinished loop batches before a continuation", async () => {
+		const started = (id: string): AgentRuntimeEvent => ({
+			type: "tool-started",
+			iteration: 1,
+			toolCall: {
+				type: "tool-call",
+				toolCallId: id,
+				toolName: "poll",
+				input: { command: "status" },
+			},
+			snapshot: makeSnapshot(),
+		});
+		const { deps, abortCalls } = makeScriptedRuntime({
+			events: [],
+			eventRuns: [
+				[
+					{ type: "turn-started", iteration: 1, snapshot: makeSnapshot() },
+					started("orphaned"),
+				],
+				[
+					{ type: "turn-started", iteration: 1, snapshot: makeSnapshot() },
+					...Array.from({ length: 11 }, (_, index) =>
+						started(`continued-${index}`),
+					),
+				],
+			],
+		});
+		const session = new SessionRuntime(
+			makeAgentConfig({
+				execution: {
+					maxConsecutiveMistakes: 6,
+					loopDetection: { softThreshold: 2, hardThreshold: 3 },
+				},
+			}),
+			deps,
+		);
+
+		await session.run("start poll");
+		await session.continue("resume poll");
 
 		expect(abortCalls).toHaveLength(0);
 	});

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
@@ -2036,6 +2036,95 @@ function makeScriptedRuntime(script: {
 	};
 }
 
+const turnStarted = (): AgentRuntimeEvent => ({
+	type: "turn-started",
+	iteration: 1,
+	snapshot: makeSnapshot(),
+});
+
+function scriptedToolCall(
+	id: string,
+	name = "poll",
+	input: unknown = { command: "status" },
+) {
+	return {
+		type: "tool-call" as const,
+		toolCallId: id,
+		toolName: name,
+		input,
+	};
+}
+
+function toolStarted(
+	id: string,
+	name?: string,
+	input?: unknown,
+): AgentRuntimeEvent {
+	return {
+		type: "tool-started",
+		iteration: 1,
+		toolCall: scriptedToolCall(id, name, input),
+		snapshot: makeSnapshot(),
+	};
+}
+
+function toolFinished(
+	id: string,
+	output: unknown,
+	name?: string,
+	input?: unknown,
+): AgentRuntimeEvent {
+	const toolCall = scriptedToolCall(id, name, input);
+	return {
+		type: "tool-finished",
+		iteration: 1,
+		toolCall,
+		message: {
+			id: `message-${id}`,
+			role: "tool",
+			content: [
+				{
+					type: "tool-result",
+					toolCallId: id,
+					toolName: toolCall.toolName,
+					output,
+				},
+			],
+			createdAt: 1,
+		},
+		snapshot: makeSnapshot(),
+	};
+}
+
+function completedTool(
+	id: string,
+	output: unknown,
+	name?: string,
+	input?: unknown,
+): AgentRuntimeEvent[] {
+	return [toolStarted(id, name, input), toolFinished(id, output, name, input)];
+}
+
+function loopSession(script: {
+	events?: readonly AgentRuntimeEvent[];
+	eventRuns?: readonly (readonly AgentRuntimeEvent[])[];
+}) {
+	const { deps, abortCalls } = makeScriptedRuntime({
+		events: script.events ?? [],
+		eventRuns: script.eventRuns,
+	});
+	const session = new SessionRuntime(
+		makeAgentConfig({
+			execution: {
+				maxConsecutiveMistakes: 6,
+				loopDetection: { softThreshold: 2, hardThreshold: 3 },
+			},
+		}),
+		deps,
+	);
+	return { session, abortCalls };
+}
+
 function failedToolTurnEvents(): AgentRuntimeEvent[] {
 	return [
 		{ type: "turn-started", iteration: 1, snapshot: makeSnapshot() },
@@ -2252,118 +2341,29 @@ describe("SessionRuntime.run — tracker wiring (P1 #3)", () => {
 	});
 
 	it("aborts on hard-threshold loop detection of identical tool calls", async () => {
-		const identical = (i: number): AgentRuntimeEvent[] => {
-			const toolCall = {
-				type: "tool-call",
-				toolCallId: `tc${i}`,
-				toolName: "same",
-				input: { a: 1 },
-			} as const;
-			return [
-				{
-					type: "tool-started",
-					iteration: i,
-					toolCall,
-					snapshot: makeSnapshot(),
-				},
-				{
-					type: "tool-finished",
-					iteration: i,
-					toolCall,
-					message: {
-						id: `message-${i}`,
-						role: "tool",
-						content: [
-							{
-								type: "tool-result",
-								toolCallId: toolCall.toolCallId,
-								toolName: toolCall.toolName,
-								output: "unchanged",
-							},
-						],
-						createdAt: i,
-					},
-					snapshot: makeSnapshot(),
-				},
-			];
-		};
-		const { deps, abortCalls } = makeScriptedRuntime({
+		const { session, abortCalls } = loopSession({
 			events: [
-				{ type: "turn-started", iteration: 1, snapshot: makeSnapshot() },
-				...identical(1),
-				...identical(2),
-				...identical(3),
+				turnStarted(),
+				...completedTool("same-1", "unchanged", "same", { a: 1 }),
+				...completedTool("same-2", "unchanged", "same", { a: 1 }),
+				...completedTool("same-3", "unchanged", "same", { a: 1 }),
 			],
 		});
-		const session = new SessionRuntime(
-			makeAgentConfig({
-				execution: {
-					maxConsecutiveMistakes: 6,
-					loopDetection: { softThreshold: 2, hardThreshold: 3 },
-				},
-			}),
-			deps,
-		);
+
 		await session.run("loop-me");
+
 		expect(abortCalls.length).toBeGreaterThanOrEqual(1);
 	});
 
 	it("does not abort repeated successful calls whose output shows progress", async () => {
-		const successfulCall = (i: number, output: string): AgentRuntimeEvent[] => {
-			const toolCall = {
-				type: "tool-call" as const,
-				toolCallId: `tc${i}`,
-				toolName: "poll",
-				input: { command: "status" },
-			};
-			return [
-				{
-					type: "tool-started",
-					iteration: i,
-					toolCall,
-					snapshot: makeSnapshot(),
-				},
-				{
-					type: "tool-finished",
-					iteration: i,
-					toolCall,
-					message: {
-						id: `m${i}`,
-						role: "tool",
-						content: [
-							{
-								type: "tool-result",
-								toolCallId: toolCall.toolCallId,
-								toolName: toolCall.toolName,
-								output,
-							},
-						],
-						createdAt: i,
-					},
-					snapshot: makeSnapshot(),
-				},
-			];
-		};
-		const { deps, abortCalls } = makeScriptedRuntime({
+		const { session, abortCalls } = loopSession({
 			events: [
-				{ type: "turn-started", iteration: 1, snapshot: makeSnapshot() },
-				...successfulCall(1, "10% complete"),
-				...successfulCall(2, "30% complete"),
-				...successfulCall(3, "50% complete"),
-				...successfulCall(4, "70% complete"),
-				...successfulCall(5, "90% complete"),
-				...successfulCall(6, "done"),
+				turnStarted(),
+				...["10%", "30%", "50%", "70%", "90%", "done"].flatMap(
+					(output, index) => completedTool(`progress-${index}`, output),
+				),
 			],
 		});
-		const session = new SessionRuntime(
-			makeAgentConfig({
-				execution: {
-					maxConsecutiveMistakes: 6,
-					loopDetection: { softThreshold: 2, hardThreshold: 3 },
-				},
-			}),
-			deps,
-		);
 
 		await session.run("monitor progress");
 
@@ -2371,61 +2371,19 @@ describe("SessionRuntime.run — tracker wiring (P1 #3)", () => {
 	});
 
 	it("does not abort identical parallel calls before their progress is observed", async () => {
-		const toolCall = (id: string) => ({
-			type: "tool-call" as const,
-			toolCallId: id,
-			toolName: "poll",
-			input: { command: "status" },
-		});
-		const started = (id: string): AgentRuntimeEvent => ({
-			type: "tool-started",
-			iteration: 1,
-			toolCall: toolCall(id),
-			snapshot: makeSnapshot(),
-		});
-		const finished = (id: string, output: string): AgentRuntimeEvent => ({
-			type: "tool-finished",
-			iteration: 1,
-			toolCall: toolCall(id),
-			message: {
-				id: `message-${id}`,
-				role: "tool",
-				content: [
-					{
-						type: "tool-result",
-						toolCallId: id,
-						toolName: "poll",
-						output,
-					},
-				],
-				createdAt: 1,
-			},
-			snapshot: makeSnapshot(),
-		});
-		const { deps, abortCalls } = makeScriptedRuntime({
+		const { session, abortCalls } = loopSession({
 			events: [
-				{ type: "turn-started", iteration: 1, snapshot: makeSnapshot() },
-				started("baseline"),
-				finished("baseline", "10% complete"),
-				started("parallel-1"),
-				started("parallel-2"),
-				started("parallel-3"),
-				finished("parallel-1", "20% complete"),
-				finished("parallel-2", "10% complete"),
-				finished("parallel-3", "10% complete"),
-				started("next"),
-				finished("next", "30% complete"),
+				turnStarted(),
+				...completedTool("baseline", "10%"),
+				toolStarted("parallel-1"),
+				toolStarted("parallel-2"),
+				toolStarted("parallel-3"),
+				toolFinished("parallel-1", "20%"),
+				toolFinished("parallel-2", "10%"),
+				toolFinished("parallel-3", "10%"),
+				...completedTool("next", "30%"),
 			],
 		});
-		const session = new SessionRuntime(
-			makeAgentConfig({
-				execution: {
-					maxConsecutiveMistakes: 6,
-					loopDetection: { softThreshold: 2, hardThreshold: 3 },
-				},
-			}),
-			deps,
-		);
 
 		await session.run("monitor parallel progress");
 
@@ -2433,67 +2391,18 @@ describe("SessionRuntime.run — tracker wiring (P1 #3)", () => {
 	});
 
 	it("preserves completed poll progress across an interleaved tool call", async () => {
-		const toolCall = (id: string, name = "poll") => ({
-			type: "tool-call" as const,
-			toolCallId: id,
-			toolName: name,
-			input: { command: "status" },
-		});
-		const started = (id: string, name?: string): AgentRuntimeEvent => ({
-			type: "tool-started",
-			iteration: 1,
-			toolCall: toolCall(id, name),
-			snapshot: makeSnapshot(),
-		});
-		const finished = (
-			id: string,
-			output: string,
-			name?: string,
-		): AgentRuntimeEvent => ({
-			type: "tool-finished",
-			iteration: 1,
-			toolCall: toolCall(id, name),
-			message: {
-				id: `message-${id}`,
-				role: "tool",
-				content: [
-					{
-						type: "tool-result",
-						toolCallId: id,
-						toolName: name ?? "poll",
-						output,
-					},
-				],
-				createdAt: 1,
-			},
-			snapshot: makeSnapshot(),
-		});
-		const { deps, abortCalls } = makeScriptedRuntime({
+		const { session, abortCalls } = loopSession({
 			events: [
-				{ type: "turn-started", iteration: 1, snapshot: makeSnapshot() },
-				started("baseline"),
-				finished("baseline", "10% complete"),
-				started("parallel-1"),
-				started("other-1", "other"),
-				finished("other-1", "unchanged", "other"),
-				finished("parallel-1", "20% complete"),
-				started("parallel-2"),
-				finished("parallel-2", "10% complete"),
-				started("poll-3"),
-				finished("poll-3", "10% complete"),
-				started("poll-4"),
-				finished("poll-4", "10% complete"),
+				turnStarted(),
+				...completedTool("baseline", "10%"),
+				toolStarted("parallel-1"),
+				...completedTool("other-1", "unchanged", "other"),
+				toolFinished("parallel-1", "20%"),
+				...completedTool("parallel-2", "10%"),
+				...completedTool("poll-3", "10%"),
+				...completedTool("poll-4", "10%"),
 			],
 		});
-		const session = new SessionRuntime(
-			makeAgentConfig({
-				execution: {
-					maxConsecutiveMistakes: 6,
-					loopDetection: { softThreshold: 2, hardThreshold: 3 },
-				},
-			}),
-			deps,
-		);
 
 		await session.run("monitor interleaved parallel progress");
 
@@ -2501,41 +2410,17 @@ describe("SessionRuntime.run — tracker wiring (P1 #3)", () => {
 	});
 
 	it("drops unfinished loop batches before a continuation", async () => {
-		const started = (id: string): AgentRuntimeEvent => ({
-			type: "tool-started",
-			iteration: 1,
-			toolCall: {
-				type: "tool-call",
-				toolCallId: id,
-				toolName: "poll",
-				input: { command: "status" },
-			},
-			snapshot: makeSnapshot(),
-		});
-		const { deps, abortCalls } = makeScriptedRuntime({
-			events: [],
+		const { session, abortCalls } = loopSession({
 			eventRuns: [
+				[turnStarted(), toolStarted("orphaned")],
 				[
-					{ type: "turn-started", iteration: 1, snapshot: makeSnapshot() },
-					started("orphaned"),
-				],
-				[
-					{ type: "turn-started", iteration: 1, snapshot: makeSnapshot() },
+					turnStarted(),
 					...Array.from({ length: 11 }, (_, index) =>
-						started(`continued-${index}`),
+						toolStarted(`continued-${index}`),
 					),
 				],
 			],
 		});
-		const session = new SessionRuntime(
-			makeAgentConfig({
-				execution: {
-					maxConsecutiveMistakes: 6,
-					loopDetection: { softThreshold: 2, hardThreshold: 3 },
-				},
-			}),
-			deps,
-		);
 
 		await session.run("start poll");
 		await session.continue("resume poll");
@@ -2544,65 +2429,19 @@ describe("SessionRuntime.run — tracker wiring (P1 #3)", () => {
 	});
 
 	it("still aborts repeated built-in failures whose error output changes", async () => {
-		const failedCall = (i: number): AgentRuntimeEvent[] => {
-			const toolCall = {
-				type: "tool-call" as const,
-				toolCallId: `failed-${i}`,
-				toolName: "run_commands",
-				input: { commands: ["false"] },
-			};
-			return [
-				{
-					type: "tool-started",
-					iteration: i,
-					toolCall,
-					snapshot: makeSnapshot(),
-				},
-				{
-					type: "tool-finished",
-					iteration: i,
-					toolCall,
-					message: {
-						id: `failed-message-${i}`,
-						role: "tool",
-						content: [
-							{
-								type: "tool-result",
-								toolCallId: toolCall.toolCallId,
-								toolName: toolCall.toolName,
-								output: [
-									{
-										query: "false",
-										result: "",
-										error: `command failed on attempt ${i}`,
-										success: false,
-									},
-								],
-							},
-						],
-						createdAt: i,
-					},
-					snapshot: makeSnapshot(),
-				},
-			];
-		};
-		const { deps, abortCalls } = makeScriptedRuntime({
+		const { session, abortCalls } = loopSession({
 			events: [
-				{ type: "turn-started", iteration: 1, snapshot: makeSnapshot() },
-				...failedCall(1),
-				...failedCall(2),
-				...failedCall(3),
+				turnStarted(),
+				...[1, 2, 3].flatMap((index) =>
+					completedTool(
+						`failed-${index}`,
+						[{ error: `attempt ${index}`, success: false }],
+						"run_commands",
+						{ commands: ["false"] },
+					),
+				),
 			],
 		});
-		const session = new SessionRuntime(
-			makeAgentConfig({
-				execution: {
-					maxConsecutiveMistakes: 6,
-					loopDetection: { softThreshold: 2, hardThreshold: 3 },
-				},
-			}),
-			deps,
-		);
 
 		await session.run("repeat a failing command");
 

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
@@ -2417,6 +2417,32 @@ describe("SessionRuntime.run — tracker wiring (P1 #3)", () => {
 		expect(abortCalls.length).toBeGreaterThanOrEqual(1);
 	});
 
+	it("still aborts repeated MCP failures whose error output changes", async () => {
+		const { session, abortCalls } = loopSession({
+			events: [
+				turnStarted(),
+				...[1, 2, 3].flatMap((index) =>
+					completedTool(
+						`mcp-failed-${index}`,
+						{
+							content: [{ type: "text", text: `attempt ${index}` }],
+							isError: true,
+						},
+						{
+							iteration: index,
+							name: "server__poll",
+							input: { jobId: "job-1" },
+						},
+					),
+				),
+			],
+		});
+
+		await session.run("repeat a failing MCP poll");
+
+		expect(abortCalls.length).toBeGreaterThanOrEqual(1);
+	});
+
 	it("resets loop detection when run() starts a fresh conversation", async () => {
 		const identical = (i: number): AgentRuntimeEvent => ({
 			type: "tool-started",

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
@@ -2042,55 +2042,24 @@ const turnStarted = (): AgentRuntimeEvent => ({
 	snapshot: makeSnapshot(),
 });
 
-function scriptedToolCall(
-	id: string,
-	name = "poll",
-	input: unknown = { command: "status" },
-) {
-	return {
-		type: "tool-call" as const,
-		toolCallId: id,
-		toolName: name,
-		input,
-	};
+interface ScriptedToolOptions {
+	iteration?: number;
+	name?: string;
+	input?: unknown;
 }
 
 function toolStarted(
 	id: string,
-	name?: string,
-	input?: unknown,
-): AgentRuntimeEvent {
+	options: ScriptedToolOptions = {},
+): Extract<AgentRuntimeEvent, { type: "tool-started" }> {
 	return {
 		type: "tool-started",
-		iteration: 1,
-		toolCall: scriptedToolCall(id, name, input),
-		snapshot: makeSnapshot(),
-	};
-}
-
-function toolFinished(
-	id: string,
-	output: unknown,
-	name?: string,
-	input?: unknown,
-): AgentRuntimeEvent {
-	const toolCall = scriptedToolCall(id, name, input);
-	return {
-		type: "tool-finished",
-		iteration: 1,
-		toolCall,
-		message: {
-			id: `message-${id}`,
-			role: "tool",
-			content: [
-				{
-					type: "tool-result",
-					toolCallId: id,
-					toolName: toolCall.toolName,
-					output,
-				},
-			],
-			createdAt: 1,
+		iteration: options.iteration ?? 1,
+		toolCall: {
+			type: "tool-call",
+			toolCallId: id,
+			toolName: options.name ?? "poll",
+			input: options.input ?? { command: "status" },
 		},
 		snapshot: makeSnapshot(),
 	};
@@ -2099,10 +2068,31 @@ function toolFinished(
 function completedTool(
 	id: string,
 	output: unknown,
-	name?: string,
-	input?: unknown,
+	options: ScriptedToolOptions = {},
 ): AgentRuntimeEvent[] {
-	return [toolStarted(id, name, input), toolFinished(id, output, name, input)];
+	const started = toolStarted(id, options);
+	return [
+		started,
+		{
+			type: "tool-finished",
+			iteration: started.iteration,
+			toolCall: started.toolCall,
+			message: {
+				id: `message-${id}`,
+				role: "tool",
+				content: [
+					{
+						type: "tool-result",
+						toolCallId: id,
+						toolName: started.toolCall.toolName,
+						output,
+					},
+				],
+				createdAt: 1,
+			},
+			snapshot: makeSnapshot(),
+		},
+	];
 }
 
 function loopSession(script: {
@@ -2344,9 +2334,21 @@ describe("SessionRuntime.run — tracker wiring (P1 #3)", () => {
 		const { session, abortCalls } = loopSession({
 			events: [
 				turnStarted(),
-				...completedTool("same-1", "unchanged", "same", { a: 1 }),
-				...completedTool("same-2", "unchanged", "same", { a: 1 }),
-				...completedTool("same-3", "unchanged", "same", { a: 1 }),
+				...completedTool("same-1", "unchanged", {
+					iteration: 1,
+					name: "same",
+					input: { a: 1 },
+				}),
+				...completedTool("same-2", "unchanged", {
+					iteration: 2,
+					name: "same",
+					input: { a: 1 },
+				}),
+				...completedTool("same-3", "unchanged", {
+					iteration: 3,
+					name: "same",
+					input: { a: 1 },
+				}),
 			],
 		});
 
@@ -2360,51 +2362,15 @@ describe("SessionRuntime.run — tracker wiring (P1 #3)", () => {
 			events: [
 				turnStarted(),
 				...["10%", "30%", "50%", "70%", "90%", "done"].flatMap(
-					(output, index) => completedTool(`progress-${index}`, output),
+					(output, index) =>
+						completedTool(`progress-${index}`, output, {
+							iteration: index + 1,
+						}),
 				),
 			],
 		});
 
 		await session.run("monitor progress");
-
-		expect(abortCalls).toHaveLength(0);
-	});
-
-	it("does not abort identical parallel calls before their progress is observed", async () => {
-		const { session, abortCalls } = loopSession({
-			events: [
-				turnStarted(),
-				...completedTool("baseline", "10%"),
-				toolStarted("parallel-1"),
-				toolStarted("parallel-2"),
-				toolStarted("parallel-3"),
-				toolFinished("parallel-1", "20%"),
-				toolFinished("parallel-2", "10%"),
-				toolFinished("parallel-3", "10%"),
-				...completedTool("next", "30%"),
-			],
-		});
-
-		await session.run("monitor parallel progress");
-
-		expect(abortCalls).toHaveLength(0);
-	});
-
-	it("preserves completed poll progress across an interleaved tool call", async () => {
-		const { session, abortCalls } = loopSession({
-			events: [
-				turnStarted(),
-				...completedTool("baseline", "10%"),
-				toolStarted("parallel-1"),
-				...completedTool("other-1", "unchanged", "other"),
-				toolFinished("parallel-1", "20%"),
-				...completedTool("parallel-2", "10%"),
-				...completedTool("poll-3", "10%"),
-				...completedTool("poll-4", "10%"),
-			],
-		});
-
-		await session.run("monitor interleaved parallel progress");
 
 		expect(abortCalls).toHaveLength(0);
 	});
@@ -2436,8 +2402,11 @@ describe("SessionRuntime.run — tracker wiring (P1 #3)", () => {
 					completedTool(
 						`failed-${index}`,
 						[{ error: `attempt ${index}`, success: false }],
-						"run_commands",
-						{ commands: ["false"] },
+						{
+							iteration: index,
+							name: "run_commands",
+							input: { commands: ["false"] },
+						},
 					),
 				),
 			],

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
@@ -2245,23 +2245,47 @@ describe("SessionRuntime.run — tracker wiring (P1 #3)", () => {
 	});
 
 	it("aborts on hard-threshold loop detection of identical tool calls", async () => {
-		const identical = (i: number): AgentRuntimeEvent => ({
-			type: "tool-started",
-			iteration: i,
-			toolCall: {
+		const identical = (i: number): AgentRuntimeEvent[] => {
+			const toolCall = {
 				type: "tool-call",
 				toolCallId: `tc${i}`,
 				toolName: "same",
 				input: { a: 1 },
-			},
-			snapshot: makeSnapshot(),
-		});
+			} as const;
+			return [
+				{
+					type: "tool-started",
+					iteration: i,
+					toolCall,
+					snapshot: makeSnapshot(),
+				},
+				{
+					type: "tool-finished",
+					iteration: i,
+					toolCall,
+					message: {
+						id: `message-${i}`,
+						role: "tool",
+						content: [
+							{
+								type: "tool-result",
+								toolCallId: toolCall.toolCallId,
+								toolName: toolCall.toolName,
+								output: "unchanged",
+							},
+						],
+						createdAt: i,
+					},
+					snapshot: makeSnapshot(),
+				},
+			];
+		};
 		const { deps, abortCalls } = makeScriptedRuntime({
 			events: [
 				{ type: "turn-started", iteration: 1, snapshot: makeSnapshot() },
-				identical(1),
-				identical(1),
-				identical(1),
+				...identical(1),
+				...identical(2),
+				...identical(3),
 			],
 		});
 		const session = new SessionRuntime(
@@ -2335,6 +2359,68 @@ describe("SessionRuntime.run — tracker wiring (P1 #3)", () => {
 		);
 
 		await session.run("monitor progress");
+
+		expect(abortCalls).toHaveLength(0);
+	});
+
+	it("does not abort identical parallel calls before their progress is observed", async () => {
+		const toolCall = (id: string) => ({
+			type: "tool-call" as const,
+			toolCallId: id,
+			toolName: "poll",
+			input: { command: "status" },
+		});
+		const started = (id: string): AgentRuntimeEvent => ({
+			type: "tool-started",
+			iteration: 1,
+			toolCall: toolCall(id),
+			snapshot: makeSnapshot(),
+		});
+		const finished = (id: string, output: string): AgentRuntimeEvent => ({
+			type: "tool-finished",
+			iteration: 1,
+			toolCall: toolCall(id),
+			message: {
+				id: `message-${id}`,
+				role: "tool",
+				content: [
+					{
+						type: "tool-result",
+						toolCallId: id,
+						toolName: "poll",
+						output,
+					},
+				],
+				createdAt: 1,
+			},
+			snapshot: makeSnapshot(),
+		});
+		const { deps, abortCalls } = makeScriptedRuntime({
+			events: [
+				{ type: "turn-started", iteration: 1, snapshot: makeSnapshot() },
+				started("baseline"),
+				finished("baseline", "10% complete"),
+				started("parallel-1"),
+				started("parallel-2"),
+				started("parallel-3"),
+				finished("parallel-1", "20% complete"),
+				finished("parallel-2", "10% complete"),
+				finished("parallel-3", "10% complete"),
+				started("next"),
+				finished("next", "30% complete"),
+			],
+		});
+		const session = new SessionRuntime(
+			makeAgentConfig({
+				execution: {
+					maxConsecutiveMistakes: 6,
+					loopDetection: { softThreshold: 2, hardThreshold: 3 },
+				},
+			}),
+			deps,
+		);
+
+		await session.run("monitor parallel progress");
 
 		expect(abortCalls).toHaveLength(0);
 	});

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
@@ -2425,7 +2425,7 @@ describe("SessionRuntime.run — tracker wiring (P1 #3)", () => {
 		expect(abortCalls).toHaveLength(0);
 	});
 
-	it("preserves identical parallel progress across an interleaved tool call", async () => {
+	it("preserves completed poll progress across an interleaved tool call", async () => {
 		const toolCall = (id: string, name = "poll") => ({
 			type: "tool-call" as const,
 			toolCallId: id,
@@ -2469,8 +2469,8 @@ describe("SessionRuntime.run — tracker wiring (P1 #3)", () => {
 				started("parallel-1"),
 				started("other-1", "other"),
 				finished("other-1", "unchanged", "other"),
-				started("parallel-2"),
 				finished("parallel-1", "20% complete"),
+				started("parallel-2"),
 				finished("parallel-2", "10% complete"),
 				started("poll-3"),
 				finished("poll-3", "10% complete"),

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
@@ -2147,6 +2147,7 @@ describe("SessionRuntime.run — initialMessages seeding (P1 #1)", () => {
  */
 function makeScriptedRuntime(script: {
 	events: readonly AgentRuntimeEvent[];
+	eventRuns?: readonly (readonly AgentRuntimeEvent[])[];
 }): {
 	deps: SessionRuntimeOrchestratorDeps;
 	abortCalls: string[];
@@ -2168,13 +2169,19 @@ function makeScriptedRuntime(script: {
 		},
 	};
 	let listener: ((e: AgentRuntimeEvent) => void) | undefined;
+	let runIndex = 0;
+	const emitEvents = () => {
+		const events = script.eventRuns?.[runIndex] ?? script.events;
+		runIndex++;
+		for (const event of events) listener?.(event);
+	};
 	const runtime = {
 		async run() {
-			for (const e of script.events) listener?.(e);
+			emitEvents();
 			return baseResult;
 		},
 		async continue() {
-			for (const e of script.events) listener?.(e);
+			emitEvents();
 			return baseResult;
 		},
 		abort(reason?: string) {
@@ -2192,6 +2199,87 @@ function makeScriptedRuntime(script: {
 		deps: { createAgentRuntimeImpl: () => runtime },
 		abortCalls,
 	};
+}
+
+const turnStarted = (): AgentRuntimeEvent => ({
+	type: "turn-started",
+	iteration: 1,
+	snapshot: makeSnapshot(),
+});
+
+interface ScriptedToolOptions {
+	iteration?: number;
+	name?: string;
+	input?: unknown;
+	isError?: boolean;
+}
+
+function toolStarted(
+	id: string,
+	options: ScriptedToolOptions = {},
+): Extract<AgentRuntimeEvent, { type: "tool-started" }> {
+	return {
+		type: "tool-started",
+		iteration: options.iteration ?? 1,
+		toolCall: {
+			type: "tool-call",
+			toolCallId: id,
+			toolName: options.name ?? "poll",
+			input: options.input ?? { command: "status" },
+		},
+		snapshot: makeSnapshot(),
+	};
+}
+
+function completedTool(
+	id: string,
+	output: unknown,
+	options: ScriptedToolOptions = {},
+): AgentRuntimeEvent[] {
+	const started = toolStarted(id, options);
+	return [
+		started,
+		{
+			type: "tool-finished",
+			iteration: started.iteration,
+			toolCall: started.toolCall,
+			message: {
+				id: `message-${id}`,
+				role: "tool",
+				content: [
+					{
+						type: "tool-result",
+						toolCallId: id,
+						toolName: started.toolCall.toolName,
+						output,
+						isError: options.isError,
+					},
+				],
+				createdAt: 1,
+			},
+			snapshot: makeSnapshot(),
+		},
+	];
+}
+
+function loopSession(script: {
+	events?: readonly AgentRuntimeEvent[];
+	eventRuns?: readonly (readonly AgentRuntimeEvent[])[];
+}) {
+	const { deps, abortCalls } = makeScriptedRuntime({
+		events: script.events ?? [],
+		eventRuns: script.eventRuns,
+	});
+	const session = new SessionRuntime(
+		makeAgentConfig({
+			execution: {
+				maxConsecutiveMistakes: 6,
+				loopDetection: { softThreshold: 2, hardThreshold: 3 },
+			},
+		}),
+		deps,
+	);
+	return { session, abortCalls };
 }
 
 function failedToolTurnEvents(): AgentRuntimeEvent[] {
@@ -2410,36 +2498,241 @@ describe("SessionRuntime.run — tracker wiring (P1 #3)", () => {
 	});
 
 	it("aborts on hard-threshold loop detection of identical tool calls", async () => {
-		const identical = (i: number): AgentRuntimeEvent => ({
-			type: "tool-started",
-			iteration: i,
-			toolCall: {
-				type: "tool-call",
-				toolCallId: `tc${i}`,
-				toolName: "same",
-				input: { a: 1 },
-			},
-			snapshot: makeSnapshot(),
-		});
-		const { deps, abortCalls } = makeScriptedRuntime({
+		const { session, abortCalls } = loopSession({
 			events: [
-				{ type: "turn-started", iteration: 1, snapshot: makeSnapshot() },
-				identical(1),
-				identical(1),
-				identical(1),
+				turnStarted(),
+				...completedTool("same-1", "unchanged", {
+					iteration: 1,
+					name: "same",
+					input: { a: 1 },
+				}),
+				...completedTool("same-2", "unchanged", {
+					iteration: 2,
+					name: "same",
+					input: { a: 1 },
+				}),
+				...completedTool("same-3", "unchanged", {
+					iteration: 3,
+					name: "same",
+					input: { a: 1 },
+				}),
 			],
 		});
-		const session = new SessionRuntime(
-			makeAgentConfig({
-				execution: {
-					maxConsecutiveMistakes: 6,
-					loopDetection: { softThreshold: 2, hardThreshold: 3 },
-				},
-			}),
-			deps,
-		);
+
 		await session.run("loop-me");
+
 		expect(abortCalls.length).toBeGreaterThanOrEqual(1);
+	});
+
+	it("does not abort repeated successful calls whose output shows progress", async () => {
+		const { session, abortCalls } = loopSession({
+			events: [
+				turnStarted(),
+				...["10%", "30%", "50%", "70%", "90%", "done"].flatMap(
+					(output, index) =>
+						completedTool(`progress-${index}`, output, {
+							iteration: index + 1,
+						}),
+				),
+			],
+		});
+
+		await session.run("monitor progress");
+
+		expect(abortCalls).toHaveLength(0);
+	});
+
+	it("drops unfinished loop batches before a continuation", async () => {
+		const { session, abortCalls } = loopSession({
+			eventRuns: [
+				[turnStarted(), toolStarted("orphaned")],
+				[
+					turnStarted(),
+					...Array.from({ length: 11 }, (_, index) =>
+						toolStarted(`continued-${index}`),
+					),
+				],
+			],
+		});
+
+		await session.run("start poll");
+		await session.continue("resume poll");
+
+		expect(abortCalls).toHaveLength(0);
+	});
+
+	it("still aborts repeated built-in failures whose error output changes", async () => {
+		const { session, abortCalls } = loopSession({
+			events: [
+				turnStarted(),
+				...[1, 2, 3].flatMap((index) =>
+					completedTool(
+						`failed-${index}`,
+						[
+							{
+								query: "false",
+								result: "",
+								error: `attempt ${index}`,
+								success: false,
+							},
+						],
+						{
+							iteration: index,
+							name: "run_commands",
+							input: { commands: ["false"] },
+						},
+					),
+				),
+			],
+		});
+
+		await session.run("repeat a failing command");
+
+		expect(abortCalls.length).toBeGreaterThanOrEqual(1);
+	});
+
+	it("retains successful progress from mixed built-in operation results", async () => {
+		const { session, abortCalls } = loopSession({
+			events: [
+				turnStarted(),
+				...[25, 50, 75].flatMap((progress, index) =>
+					completedTool(
+						`mixed-${index}`,
+						[
+							{
+								query: "poll",
+								result: { progress },
+								success: true,
+							},
+							{
+								query: "optional-check",
+								result: "",
+								error: `attempt ${index + 1}`,
+								success: false,
+							},
+						],
+						{
+							iteration: index + 1,
+							name: "run_commands",
+							input: { commands: ["poll", "optional-check"] },
+						},
+					),
+				),
+			],
+		});
+
+		await session.run("monitor a partially successful command batch");
+
+		expect(abortCalls).toHaveLength(0);
+	});
+
+	it("ignores changing failures when mixed built-in success is unchanged", async () => {
+		const { session, abortCalls } = loopSession({
+			events: [
+				turnStarted(),
+				...[1, 2, 3].flatMap((index) =>
+					completedTool(
+						`mixed-stalled-${index}`,
+						[
+							{
+								query: "poll",
+								result: { progress: 50 },
+								success: true,
+							},
+							{
+								query: "optional-check",
+								result: "",
+								error: `attempt ${index}`,
+								success: false,
+							},
+						],
+						{
+							iteration: index,
+							name: "run_commands",
+							input: { commands: ["poll", "optional-check"] },
+						},
+					),
+				),
+			],
+		});
+
+		await session.run("monitor a stalled partially successful command batch");
+
+		expect(abortCalls.length).toBeGreaterThanOrEqual(1);
+	});
+
+	it("still aborts repeated adapter-promoted MCP failures", async () => {
+		const { session, abortCalls } = loopSession({
+			events: [
+				turnStarted(),
+				...[1, 2, 3].flatMap((index) =>
+					completedTool(
+						`mcp-failed-${index}`,
+						{ error: `attempt ${index}` },
+						{
+							iteration: index,
+							name: "server__poll",
+							input: { jobId: "job-1" },
+							isError: true,
+						},
+					),
+				),
+			],
+		});
+
+		await session.run("repeat a failing MCP poll");
+
+		expect(abortCalls.length).toBeGreaterThanOrEqual(1);
+	});
+
+	it("allows successful non-MCP outputs containing isError data", async () => {
+		const { session, abortCalls } = loopSession({
+			events: [
+				turnStarted(),
+				...[3, 2, 1].flatMap((pendingChecks, index) =>
+					completedTool(
+						`status-${index}`,
+						{ isError: true, pendingChecks },
+						{
+							iteration: index + 1,
+							name: "status",
+							input: { jobId: "job-1" },
+						},
+					),
+				),
+			],
+		});
+
+		await session.run("monitor a successful custom tool");
+
+		expect(abortCalls).toHaveLength(0);
+	});
+
+	it("allows successful custom outputs containing success data", async () => {
+		const { session, abortCalls } = loopSession({
+			events: [
+				turnStarted(),
+				...[25, 50, 75].flatMap((progress, index) =>
+					completedTool(
+						`custom-status-${index}`,
+						{
+							query: "remote-job",
+							result: { progress },
+							success: false,
+						},
+						{
+							iteration: index + 1,
+							name: "custom_status",
+							input: { jobId: "job-1" },
+						},
+					),
+				),
+			],
+		});
+
+		await session.run("monitor successful custom result data");
+
+		expect(abortCalls).toHaveLength(0);
 	});
 
 	it("resets loop detection when run() starts a fresh conversation", async () => {

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
@@ -2461,6 +2461,41 @@ describe("SessionRuntime.run — tracker wiring (P1 #3)", () => {
 		expect(abortCalls).toHaveLength(0);
 	});
 
+	it("ignores changing failures when mixed built-in success is unchanged", async () => {
+		const { session, abortCalls } = loopSession({
+			events: [
+				turnStarted(),
+				...[1, 2, 3].flatMap((index) =>
+					completedTool(
+						`mixed-stalled-${index}`,
+						[
+							{
+								query: "poll",
+								result: { progress: 50 },
+								success: true,
+							},
+							{
+								query: "optional-check",
+								result: "",
+								error: `attempt ${index}`,
+								success: false,
+							},
+						],
+						{
+							iteration: index,
+							name: "run_commands",
+							input: { commands: ["poll", "optional-check"] },
+						},
+					),
+				),
+			],
+		});
+
+		await session.run("monitor a stalled partially successful command batch");
+
+		expect(abortCalls.length).toBeGreaterThanOrEqual(1);
+	});
+
 	it("still aborts repeated adapter-promoted MCP failures", async () => {
 		const { session, abortCalls } = loopSession({
 			events: [

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
@@ -2403,7 +2403,14 @@ describe("SessionRuntime.run — tracker wiring (P1 #3)", () => {
 				...[1, 2, 3].flatMap((index) =>
 					completedTool(
 						`failed-${index}`,
-						[{ error: `attempt ${index}`, success: false }],
+						[
+							{
+								query: "false",
+								result: "",
+								error: `attempt ${index}`,
+								success: false,
+							},
+						],
 						{
 							iteration: index,
 							name: "run_commands",
@@ -2417,6 +2424,41 @@ describe("SessionRuntime.run — tracker wiring (P1 #3)", () => {
 		await session.run("repeat a failing command");
 
 		expect(abortCalls.length).toBeGreaterThanOrEqual(1);
+	});
+
+	it("retains successful progress from mixed built-in operation results", async () => {
+		const { session, abortCalls } = loopSession({
+			events: [
+				turnStarted(),
+				...[25, 50, 75].flatMap((progress, index) =>
+					completedTool(
+						`mixed-${index}`,
+						[
+							{
+								query: "poll",
+								result: { progress },
+								success: true,
+							},
+							{
+								query: "optional-check",
+								result: "",
+								error: `attempt ${index + 1}`,
+								success: false,
+							},
+						],
+						{
+							iteration: index + 1,
+							name: "run_commands",
+							input: { commands: ["poll", "optional-check"] },
+						},
+					),
+				),
+			],
+		});
+
+		await session.run("monitor a partially successful command batch");
+
+		expect(abortCalls).toHaveLength(0);
 	});
 
 	it("still aborts repeated adapter-promoted MCP failures", async () => {
@@ -2462,6 +2504,33 @@ describe("SessionRuntime.run — tracker wiring (P1 #3)", () => {
 		});
 
 		await session.run("monitor a successful custom tool");
+
+		expect(abortCalls).toHaveLength(0);
+	});
+
+	it("allows successful custom outputs containing success data", async () => {
+		const { session, abortCalls } = loopSession({
+			events: [
+				turnStarted(),
+				...[25, 50, 75].flatMap((progress, index) =>
+					completedTool(
+						`custom-status-${index}`,
+						{
+							query: "remote-job",
+							result: { progress },
+							success: false,
+						},
+						{
+							iteration: index + 1,
+							name: "custom_status",
+							input: { jobId: "job-1" },
+						},
+					),
+				),
+			],
+		});
+
+		await session.run("monitor successful custom result data");
 
 		expect(abortCalls).toHaveLength(0);
 	});

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
@@ -1108,6 +1108,15 @@ export class SessionRuntime {
 				);
 				const isError =
 					resultPart?.type === "tool-result" && resultPart.isError === true;
+				if (!isError && resultPart?.type === "tool-result") {
+					this.loopTracker.observeSuccessfulOutcome(
+						{
+							name: event.toolCall.toolName,
+							input: event.toolCall.input,
+						},
+						resultPart.output,
+					);
+				}
 				const errorText = isError
 					? formatToolResultError(
 							resultPart?.type === "tool-result"

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
@@ -91,6 +91,17 @@ function formatToolResultError(output: unknown): string {
 	}
 }
 
+function containsFailedToolOperation(output: unknown): boolean {
+	const operations = Array.isArray(output) ? output : [output];
+	return operations.some(
+		(operation) =>
+			operation !== null &&
+			typeof operation === "object" &&
+			!Array.isArray(operation) &&
+			(operation as { success?: unknown }).success === false,
+	);
+}
+
 async function resolveRuleContent(
 	rule: AgentExtensionRule,
 ): Promise<string | undefined> {
@@ -1091,6 +1102,7 @@ export class SessionRuntime {
 				// forceAtLimit:true and abort. Parity with pre-Step-9
 				// agent.ts L917-954.
 				this.inspectLoopForToolCall(
+					event.toolCall.toolCallId,
 					event.toolCall.toolName,
 					event.toolCall.input,
 					event.iteration,
@@ -1108,9 +1120,14 @@ export class SessionRuntime {
 				);
 				const isError =
 					resultPart?.type === "tool-result" && resultPart.isError === true;
-				if (!isError && resultPart?.type === "tool-result") {
+				const isSuccessfulOutcome =
+					!isError &&
+					resultPart?.type === "tool-result" &&
+					!containsFailedToolOperation(resultPart.output);
+				if (isSuccessfulOutcome) {
 					this.loopTracker.observeSuccessfulOutcome(
 						{
+							id: event.toolCall.toolCallId,
 							name: event.toolCall.toolName,
 							input: event.toolCall.input,
 						},
@@ -1251,6 +1268,7 @@ export class SessionRuntime {
 	 *                 abort the active runtime.
 	 */
 	private inspectLoopForToolCall(
+		toolCallId: string,
 		toolName: string,
 		input: unknown,
 		iteration: number,
@@ -1258,7 +1276,11 @@ export class SessionRuntime {
 		if (this.trackerAbortInFlight || this.loopDetectionDisabled) {
 			return;
 		}
-		const verdict = this.loopTracker.inspect({ name: toolName, input });
+		const verdict = this.loopTracker.inspect({
+			id: toolCallId,
+			name: toolName,
+			input,
+		});
 		if (verdict.kind === "ok") {
 			return;
 		}

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
@@ -1124,16 +1124,20 @@ export class SessionRuntime {
 					!isError &&
 					resultPart?.type === "tool-result" &&
 					!containsFailedToolOperation(resultPart.output);
-				if (isSuccessfulOutcome) {
-					this.loopTracker.observeSuccessfulOutcome(
-						{
-							id: event.toolCall.toolCallId,
-							name: event.toolCall.toolName,
-							input: event.toolCall.input,
-						},
-						resultPart.output,
-					);
-				}
+				this.loopTracker.observeOutcome(
+					{
+						id: event.toolCall.toolCallId,
+						name: event.toolCall.toolName,
+						input: event.toolCall.input,
+					},
+					{
+						successful: isSuccessfulOutcome,
+						output:
+							resultPart?.type === "tool-result"
+								? resultPart.output
+								: undefined,
+					},
+				);
 				const errorText = isError
 					? formatToolResultError(
 							resultPart?.type === "tool-result"

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
@@ -1103,7 +1103,6 @@ export class SessionRuntime {
 				// forceAtLimit:true and abort. Parity with pre-Step-9
 				// agent.ts L917-954.
 				this.inspectLoopForToolCall(
-					event.toolCall.toolCallId,
 					event.toolCall.toolName,
 					event.toolCall.input,
 					event.iteration,
@@ -1127,7 +1126,7 @@ export class SessionRuntime {
 					!containsFailedToolOperation(resultPart.output);
 				this.loopTracker.observeOutcome(
 					{
-						id: event.toolCall.toolCallId,
+						iteration: event.iteration,
 						name: event.toolCall.toolName,
 						input: event.toolCall.input,
 					},
@@ -1273,7 +1272,6 @@ export class SessionRuntime {
 	 *                 abort the active runtime.
 	 */
 	private inspectLoopForToolCall(
-		toolCallId: string,
 		toolName: string,
 		input: unknown,
 		iteration: number,
@@ -1282,7 +1280,7 @@ export class SessionRuntime {
 			return;
 		}
 		const verdict = this.loopTracker.inspect({
-			id: toolCallId,
+			iteration,
 			name: toolName,
 			input,
 		});

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
@@ -98,8 +98,7 @@ function containsFailedToolOperation(output: unknown): boolean {
 			operation !== null &&
 			typeof operation === "object" &&
 			!Array.isArray(operation) &&
-			((operation as { success?: unknown }).success === false ||
-				(operation as { isError?: unknown }).isError === true),
+			(operation as { success?: unknown }).success === false,
 	);
 }
 

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
@@ -905,6 +905,7 @@ export class SessionRuntime {
 					{ agentId: this.agentId, error },
 				);
 			}
+			this.loopTracker.clearPendingCalls();
 			this.activeRuntime = null;
 			this.running = false;
 			this.abortRequested = false;

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
@@ -98,7 +98,8 @@ function containsFailedToolOperation(output: unknown): boolean {
 			operation !== null &&
 			typeof operation === "object" &&
 			!Array.isArray(operation) &&
-			(operation as { success?: unknown }).success === false,
+			((operation as { success?: unknown }).success === false ||
+				(operation as { isError?: unknown }).isError === true),
 	);
 }
 

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
@@ -101,26 +101,39 @@ const OPERATION_RESULT_TOOL_NAMES = new Set<string>([
 	DefaultToolNames.EDITOR,
 ]);
 
-function containsOnlyFailedToolOperations(
+function isToolOperationResult(
+	value: unknown,
+): value is { query: string; result: unknown; success: boolean } {
+	return (
+		value !== null &&
+		typeof value === "object" &&
+		!Array.isArray(value) &&
+		typeof (value as { query?: unknown }).query === "string" &&
+		"result" in value &&
+		typeof (value as { success?: unknown }).success === "boolean"
+	);
+}
+
+function classifyToolOutcome(
 	toolName: string,
 	output: unknown,
-): boolean {
+): { successful: boolean; output: unknown } {
 	if (!OPERATION_RESULT_TOOL_NAMES.has(toolName)) {
-		return false;
+		return { successful: true, output };
 	}
 	const operations = Array.isArray(output) ? output : [output];
-	return (
-		operations.length > 0 &&
-		operations.every(
-			(operation) =>
-				operation !== null &&
-				typeof operation === "object" &&
-				!Array.isArray(operation) &&
-				typeof (operation as { query?: unknown }).query === "string" &&
-				"result" in operation &&
-				(operation as { success?: unknown }).success === false,
-		)
+	if (operations.length === 0 || !operations.every(isToolOperationResult)) {
+		return { successful: true, output };
+	}
+	const successfulOperations = operations.filter(
+		(operation) => operation.success,
 	);
+	return {
+		successful: successfulOperations.length > 0,
+		output: Array.isArray(output)
+			? successfulOperations
+			: successfulOperations[0],
+	};
 }
 
 async function resolveRuleContent(
@@ -1141,26 +1154,23 @@ export class SessionRuntime {
 				);
 				const isError =
 					resultPart?.type === "tool-result" && resultPart.isError === true;
-				const isSuccessfulOutcome =
-					!isError &&
-					resultPart?.type === "tool-result" &&
-					!containsOnlyFailedToolOperations(
-						event.toolCall.toolName,
-						resultPart.output,
-					);
+				const loopOutcome =
+					!isError && resultPart?.type === "tool-result"
+						? classifyToolOutcome(event.toolCall.toolName, resultPart.output)
+						: {
+								successful: false,
+								output:
+									resultPart?.type === "tool-result"
+										? resultPart.output
+										: undefined,
+							};
 				this.loopTracker.observeOutcome(
 					{
 						iteration: event.iteration,
 						name: event.toolCall.toolName,
 						input: event.toolCall.input,
 					},
-					{
-						successful: isSuccessfulOutcome,
-						output:
-							resultPart?.type === "tool-result"
-								? resultPart.output
-								: undefined,
-					},
+					loopOutcome,
 				);
 				const errorText = isError
 					? formatToolResultError(

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
@@ -48,6 +48,7 @@ import {
 	mergeModelOptions,
 	type ToolCallRecord,
 } from "@cline/shared";
+import { DefaultToolNames } from "../../extensions/tools/constants";
 import { filterDisabledTools } from "../../services/global-settings";
 import {
 	createAgentModelFromConfig,
@@ -91,14 +92,34 @@ function formatToolResultError(output: unknown): string {
 	}
 }
 
-function containsFailedToolOperation(output: unknown): boolean {
+const OPERATION_RESULT_TOOL_NAMES = new Set<string>([
+	DefaultToolNames.READ_FILES,
+	DefaultToolNames.SEARCH_CODEBASE,
+	DefaultToolNames.RUN_COMMANDS,
+	DefaultToolNames.FETCH_WEB_CONTENT,
+	DefaultToolNames.APPLY_PATCH,
+	DefaultToolNames.EDITOR,
+]);
+
+function containsOnlyFailedToolOperations(
+	toolName: string,
+	output: unknown,
+): boolean {
+	if (!OPERATION_RESULT_TOOL_NAMES.has(toolName)) {
+		return false;
+	}
 	const operations = Array.isArray(output) ? output : [output];
-	return operations.some(
-		(operation) =>
-			operation !== null &&
-			typeof operation === "object" &&
-			!Array.isArray(operation) &&
-			(operation as { success?: unknown }).success === false,
+	return (
+		operations.length > 0 &&
+		operations.every(
+			(operation) =>
+				operation !== null &&
+				typeof operation === "object" &&
+				!Array.isArray(operation) &&
+				typeof (operation as { query?: unknown }).query === "string" &&
+				"result" in operation &&
+				(operation as { success?: unknown }).success === false,
+		)
 	);
 }
 
@@ -1123,7 +1144,10 @@ export class SessionRuntime {
 				const isSuccessfulOutcome =
 					!isError &&
 					resultPart?.type === "tool-result" &&
-					!containsFailedToolOperation(resultPart.output);
+					!containsOnlyFailedToolOperations(
+						event.toolCall.toolName,
+						resultPart.output,
+					);
 				this.loopTracker.observeOutcome(
 					{
 						iteration: event.iteration,

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
@@ -50,6 +50,7 @@ import {
 	type ToolCallRecord,
 	usesImageGenerationOperation,
 } from "@cline/shared";
+import { DefaultToolNames } from "../../extensions/tools/constants";
 import { filterDisabledTools } from "../../services/global-settings";
 import {
 	createAgentModelFromConfig,
@@ -114,6 +115,50 @@ function formatToolResultError(output: unknown): string {
 	} catch {
 		return String(output);
 	}
+}
+
+const OPERATION_RESULT_TOOL_NAMES = new Set<string>([
+	DefaultToolNames.READ_FILES,
+	DefaultToolNames.SEARCH_CODEBASE,
+	DefaultToolNames.RUN_COMMANDS,
+	DefaultToolNames.FETCH_WEB_CONTENT,
+	DefaultToolNames.APPLY_PATCH,
+	DefaultToolNames.EDITOR,
+]);
+
+function isToolOperationResult(
+	value: unknown,
+): value is { query: string; result: unknown; success: boolean } {
+	return (
+		value !== null &&
+		typeof value === "object" &&
+		!Array.isArray(value) &&
+		typeof (value as { query?: unknown }).query === "string" &&
+		"result" in value &&
+		typeof (value as { success?: unknown }).success === "boolean"
+	);
+}
+
+function classifyToolOutcome(
+	toolName: string,
+	output: unknown,
+): { successful: boolean; output: unknown } {
+	if (!OPERATION_RESULT_TOOL_NAMES.has(toolName)) {
+		return { successful: true, output };
+	}
+	const operations = Array.isArray(output) ? output : [output];
+	if (operations.length === 0 || !operations.every(isToolOperationResult)) {
+		return { successful: true, output };
+	}
+	const successfulOperations = operations.filter(
+		(operation) => operation.success,
+	);
+	return {
+		successful: successfulOperations.length > 0,
+		output: Array.isArray(output)
+			? successfulOperations
+			: successfulOperations[0],
+	};
 }
 
 async function resolveRuleContent(
@@ -936,6 +981,7 @@ export class SessionRuntime {
 					{ agentId: this.agentId, error },
 				);
 			}
+			this.loopTracker.clearPendingCalls();
 			this.activeRuntime = null;
 			this.running = false;
 			this.abortRequested = false;
@@ -1154,6 +1200,24 @@ export class SessionRuntime {
 				);
 				const isError =
 					resultPart?.type === "tool-result" && resultPart.isError === true;
+				const loopOutcome =
+					!isError && resultPart?.type === "tool-result"
+						? classifyToolOutcome(event.toolCall.toolName, resultPart.output)
+						: {
+								successful: false,
+								output:
+									resultPart?.type === "tool-result"
+										? resultPart.output
+										: undefined,
+							};
+				this.loopTracker.observeOutcome(
+					{
+						iteration: event.iteration,
+						name: event.toolCall.toolName,
+						input: event.toolCall.input,
+					},
+					loopOutcome,
+				);
 				const errorText = isError
 					? formatToolResultError(
 							resultPart?.type === "tool-result"
@@ -1299,7 +1363,11 @@ export class SessionRuntime {
 		if (this.trackerAbortInFlight || this.loopDetectionDisabled) {
 			return;
 		}
-		const verdict = this.loopTracker.inspect({ name: toolName, input });
+		const verdict = this.loopTracker.inspect({
+			iteration,
+			name: toolName,
+			input,
+		});
 		if (verdict.kind === "ok") {
 			return;
 		}

--- a/sdk/packages/core/src/runtime/safety/loop-detection.test.ts
+++ b/sdk/packages/core/src/runtime/safety/loop-detection.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { LoopDetectionTracker } from "./loop-detection";
+
+describe("LoopDetectionTracker", () => {
+	const call = { name: "poll", input: { command: "status" } };
+
+	it("resets repeated-call counting when successful output changes", () => {
+		const tracker = new LoopDetectionTracker({
+			softThreshold: 2,
+			hardThreshold: 3,
+		});
+
+		expect(tracker.inspect(call).kind).toBe("ok");
+		tracker.observeSuccessfulOutcome(call, "10% complete");
+		expect(tracker.inspect(call).kind).toBe("soft");
+		tracker.observeSuccessfulOutcome(call, "20% complete");
+
+		expect(tracker.inspect(call).kind).toBe("ok");
+	});
+
+	it("still escalates identical calls with identical successful output", () => {
+		const tracker = new LoopDetectionTracker({
+			softThreshold: 2,
+			hardThreshold: 3,
+		});
+
+		expect(tracker.inspect(call).kind).toBe("ok");
+		tracker.observeSuccessfulOutcome(call, "still running");
+		expect(tracker.inspect(call).kind).toBe("soft");
+		tracker.observeSuccessfulOutcome(call, "still running");
+
+		expect(tracker.inspect(call).kind).toBe("hard");
+	});
+});

--- a/sdk/packages/core/src/runtime/safety/loop-detection.test.ts
+++ b/sdk/packages/core/src/runtime/safety/loop-detection.test.ts
@@ -31,4 +31,27 @@ describe("LoopDetectionTracker", () => {
 
 		expect(tracker.inspect(call).kind).toBe("hard");
 	});
+
+	it("does not let a late parallel outcome reset another call's counter", () => {
+		const tracker = new LoopDetectionTracker({
+			softThreshold: 2,
+			hardThreshold: 3,
+		});
+		const firstPoll = { ...call, id: "poll-1" };
+		const secondPoll = { ...call, id: "poll-2" };
+		const otherCall = {
+			id: "other-1",
+			name: "other",
+			input: { command: "status" },
+		};
+
+		expect(tracker.inspect(firstPoll).kind).toBe("ok");
+		tracker.observeSuccessfulOutcome(firstPoll, "10% complete");
+		expect(tracker.inspect(secondPoll).kind).toBe("soft");
+		expect(tracker.inspect(otherCall).kind).toBe("ok");
+
+		tracker.observeSuccessfulOutcome(secondPoll, "20% complete");
+
+		expect(tracker.inspect({ ...otherCall, id: "other-2" }).kind).toBe("soft");
+	});
 });

--- a/sdk/packages/core/src/runtime/safety/loop-detection.test.ts
+++ b/sdk/packages/core/src/runtime/safety/loop-detection.test.ts
@@ -136,16 +136,17 @@ describe("LoopDetectionTracker", () => {
 		expect(tracker.inspect(call).kind).toBe("hard");
 	});
 
-	it("allows long-running calls that report explicit semantic progress", () => {
+	it("bounds long-running calls even when progress-classified values change", () => {
 		const tracker = new LoopDetectionTracker({
 			softThreshold: 2,
 			hardThreshold: 3,
 		});
 
-		for (let index = 1; index <= 20; index++) {
+		for (let index = 1; index < 12; index++) {
 			expect(tracker.inspect(call).kind).not.toBe("hard");
-			observeSuccess(tracker, call, `${index}/20 complete`);
+			observeSuccess(tracker, call, { status: `waiting-${index}` });
 		}
+		expect(tracker.inspect(call).kind).toBe("hard");
 	});
 
 	it("counts identical parallel calls as one batch and accepts every outcome", () => {
@@ -224,6 +225,20 @@ describe("LoopDetectionTracker", () => {
 		expect(inspectBatch("c")[0]).toBe("hard");
 	});
 
+	it("bounds an identical parallel batch when earlier calls never finish", () => {
+		const tracker = new LoopDetectionTracker({
+			softThreshold: 2,
+			hardThreshold: 3,
+		});
+
+		for (let index = 1; index < 12; index++) {
+			expect(
+				tracker.inspect({ ...call, id: `pending-${index}` }).kind,
+			).not.toBe("hard");
+		}
+		expect(tracker.inspect({ ...call, id: "pending-12" }).kind).toBe("hard");
+	});
+
 	it("does not let a late parallel outcome reset another call's counter", () => {
 		const tracker = new LoopDetectionTracker({
 			softThreshold: 2,
@@ -246,5 +261,34 @@ describe("LoopDetectionTracker", () => {
 		observeSuccess(tracker, secondPoll, "20% complete");
 
 		expect(tracker.inspect({ ...otherCall, id: "other-2" }).kind).toBe("soft");
+	});
+
+	it("keeps earlier identical parallel outcomes across an interleaved call", () => {
+		const tracker = new LoopDetectionTracker({
+			softThreshold: 2,
+			hardThreshold: 3,
+		});
+		const baseline = { ...call, id: "baseline" };
+		const firstPoll = { ...call, id: "poll-1" };
+		const secondPoll = { ...call, id: "poll-2" };
+		const otherCall = {
+			id: "other-1",
+			name: "other",
+			input: { command: "status" },
+		};
+
+		expect(tracker.inspect(baseline).kind).toBe("ok");
+		observeSuccess(tracker, baseline, "10% complete");
+		expect(tracker.inspect(firstPoll).kind).toBe("soft");
+		expect(tracker.inspect(otherCall).kind).toBe("ok");
+		expect(tracker.inspect(secondPoll).kind).toBe("ok");
+
+		observeSuccess(tracker, firstPoll, "20% complete");
+		observeSuccess(tracker, secondPoll, "10% complete");
+
+		const thirdPoll = { ...call, id: "poll-3" };
+		expect(tracker.inspect(thirdPoll).kind).toBe("soft");
+		observeSuccess(tracker, thirdPoll, "10% complete");
+		expect(tracker.inspect({ ...call, id: "poll-4" }).kind).toBe("ok");
 	});
 });

--- a/sdk/packages/core/src/runtime/safety/loop-detection.test.ts
+++ b/sdk/packages/core/src/runtime/safety/loop-detection.test.ts
@@ -289,6 +289,35 @@ describe("LoopDetectionTracker", () => {
 		expect(tracker.inspect({ ...call, id: "poll-3" }).kind).toBe("ok");
 	});
 
+	it("starts a fresh batch when an older interleaved poll remains pending", () => {
+		const tracker = new LoopDetectionTracker({
+			softThreshold: 2,
+			hardThreshold: 3,
+		});
+		const baseline = { ...call, id: "baseline" };
+		const stalePoll = { ...call, id: "stale-poll" };
+		const otherCall = {
+			id: "other-1",
+			name: "other",
+			input: { command: "status" },
+		};
+
+		expect(tracker.inspect(baseline).kind).toBe("ok");
+		observeSuccess(tracker, baseline, "10% complete");
+		expect(tracker.inspect(stalePoll).kind).toBe("soft");
+		expect(tracker.inspect(otherCall).kind).toBe("ok");
+		observeSuccess(tracker, otherCall, "unchanged");
+
+		const resumedPoll = { ...call, id: "resumed-poll" };
+		expect(tracker.inspect(resumedPoll).kind).toBe("ok");
+		observeSuccess(tracker, resumedPoll, "20% complete");
+
+		const nextPoll = { ...call, id: "next-poll" };
+		expect(tracker.inspect(nextPoll).kind).toBe("soft");
+		observeSuccess(tracker, nextPoll, "30% complete");
+		expect(tracker.inspect({ ...call, id: "after-progress" }).kind).toBe("ok");
+	});
+
 	it("keeps earlier identical parallel outcomes across an interleaved call", () => {
 		const tracker = new LoopDetectionTracker({
 			softThreshold: 2,
@@ -313,8 +342,8 @@ describe("LoopDetectionTracker", () => {
 		observeSuccess(tracker, secondPoll, "10% complete");
 
 		const thirdPoll = { ...call, id: "poll-3" };
-		expect(tracker.inspect(thirdPoll).kind).toBe("soft");
+		expect(tracker.inspect(thirdPoll).kind).toBe("ok");
 		observeSuccess(tracker, thirdPoll, "10% complete");
-		expect(tracker.inspect({ ...call, id: "poll-4" }).kind).toBe("ok");
+		expect(tracker.inspect({ ...call, id: "poll-4" }).kind).toBe("soft");
 	});
 });

--- a/sdk/packages/core/src/runtime/safety/loop-detection.test.ts
+++ b/sdk/packages/core/src/runtime/safety/loop-detection.test.ts
@@ -1,265 +1,139 @@
 import { describe, expect, it } from "vitest";
 import { type LoopDetectionCall, LoopDetectionTracker } from "./loop-detection";
 
-const baseCall = { name: "poll", input: { command: "status" } };
 const createTracker = () =>
 	new LoopDetectionTracker({ softThreshold: 2, hardThreshold: 3 });
-const identified = (
-	id: string,
-	name = baseCall.name,
-	input: unknown = baseCall.input,
-): LoopDetectionCall => ({ id, name, input });
-const inspect = (
+
+function call(
+	iteration: number,
+	name = "poll",
+	input: unknown = { command: "status" },
+): LoopDetectionCall {
+	return { iteration, name, input };
+}
+
+function inspect(
 	tracker: LoopDetectionTracker,
-	call: LoopDetectionCall = baseCall,
-) => tracker.inspect(call).kind;
-const succeed = (
+	iteration: number,
+	name?: string,
+	input?: unknown,
+) {
+	return tracker.inspect(call(iteration, name, input)).kind;
+}
+
+function completeBatch(
 	tracker: LoopDetectionTracker,
-	call: LoopDetectionCall,
-	output: unknown,
-) => tracker.observeOutcome(call, { successful: true, output });
-const cycle = (
-	tracker: LoopDetectionTracker,
-	output: unknown,
-	call: LoopDetectionCall = baseCall,
-) => {
-	const verdict = inspect(tracker, call);
-	succeed(tracker, call, output);
-	return verdict;
-};
-const runBatch = (
-	tracker: LoopDetectionTracker,
-	prefix: string,
+	iteration: number,
 	outputs: unknown[],
-) => {
-	const calls = outputs.map((_, index) => identified(`${prefix}-${index + 1}`));
-	const verdicts = calls.map((call) => inspect(tracker, call));
-	calls.forEach((call, index) => {
-		succeed(tracker, call, outputs[index]);
-	});
+	options: { name?: string; input?: unknown; successful?: boolean } = {},
+) {
+	const batchCall = call(iteration, options.name, options.input);
+	const verdicts = outputs.map(() => tracker.inspect(batchCall).kind);
+	for (const output of outputs) {
+		tracker.observeOutcome(batchCall, {
+			successful: options.successful ?? true,
+			output,
+		});
+	}
 	return verdicts;
-};
+}
 
 describe("LoopDetectionTracker", () => {
-	it("resets repeated-call counting when successful output changes meaningfully", () => {
+	it("resets the ordinary counter after changed successful output", () => {
 		const tracker = createTracker();
 
-		expect(cycle(tracker, "10% complete")).toBe("ok");
-		expect(cycle(tracker, "20% complete")).toBe("soft");
-		expect(inspect(tracker)).toBe("ok");
+		expect(completeBatch(tracker, 1, ["10%"])).toEqual(["ok"]);
+		expect(completeBatch(tracker, 2, ["20%"])).toEqual(["soft"]);
+		expect(inspect(tracker, 3)).toBe("ok");
 	});
 
-	it.each([
-		{
-			name: "timestamps and request IDs",
-			first: {
-				status: "pending",
-				timestamp: "2026-07-25T01:00:00Z",
-				elapsedMs: 60_000,
-				requestId: "9be5a8dd-7214-4d51-8b04-261e54e62ac2",
-				message:
-					"status=pending request-id=9be5a8dd-7214-4d51-8b04-261e54e62ac2 elapsed=60s at 2026-07-25T01:00:00Z",
-			},
-			second: {
-				status: "pending",
-				timestamp: "2026-07-25T01:00:01Z",
-				elapsedMs: 61_000,
-				requestId: "6b265eb9-cc65-4577-87e1-03d4328a06d4",
-				message:
-					"status=pending request-id=6b265eb9-cc65-4577-87e1-03d4328a06d4 elapsed=61s at 2026-07-25T01:00:01Z",
-			},
-		},
-		{
-			name: "append-only heartbeat text",
-			first: [
-				"2026-07-25T01:00:00Z heartbeat",
-				"2026-07-25T01:00:01Z heartbeat",
-			].join("\n"),
-			second: [
-				"2026-07-25T01:00:00Z heartbeat",
-				"2026-07-25T01:00:01Z heartbeat",
-				"2026-07-25T01:00:02Z heartbeat",
-			].join("\n"),
-		},
-		{
-			name: "structured log tails",
-			first: {
-				status: "pending",
-				logs: [{ timestamp: "2026-07-25T01:00:00Z", message: "heartbeat" }],
-			},
-			second: {
-				status: "pending",
-				logs: [
-					{ timestamp: "2026-07-25T01:00:00Z", message: "heartbeat" },
-					{ timestamp: "2026-07-25T01:00:01Z", message: "heartbeat 2" },
-				],
-			},
-		},
-	])("does not treat volatile $name as progress", ({ first, second }) => {
+	it("escalates unchanged successful output", () => {
 		const tracker = createTracker();
 
-		expect(cycle(tracker, first)).toBe("ok");
-		expect(cycle(tracker, second)).toBe("soft");
-		expect(inspect(tracker)).toBe("hard");
+		expect(completeBatch(tracker, 1, ["same"])).toEqual(["ok"]);
+		expect(completeBatch(tracker, 2, ["same"])).toEqual(["soft"]);
+		expect(inspect(tracker, 3)).toBe("hard");
 	});
 
-	it("still escalates identical successful output", () => {
+	it("does not treat changing failures as progress", () => {
 		const tracker = createTracker();
 
-		expect(cycle(tracker, "still running")).toBe("ok");
-		expect(cycle(tracker, "still running")).toBe("soft");
-		expect(inspect(tracker)).toBe("hard");
+		expect(
+			completeBatch(tracker, 1, ["error 1"], { successful: false }),
+		).toEqual(["ok"]);
+		expect(
+			completeBatch(tracker, 2, ["error 2"], { successful: false }),
+		).toEqual(["soft"]);
+		expect(inspect(tracker, 3)).toBe("hard");
 	});
 
-	it.each([
-		["unclassified output", (index: number) => `changing output ${index}`],
-		[
-			"progress-classified output",
-			(index: number) => ({ status: `waiting-${index}` }),
-		],
-	] as const)("enforces an absolute limit across %s", (_name, outputFor) => {
+	it("bounds continually changing output without interpreting it", () => {
 		const tracker = createTracker();
 
-		for (let index = 1; index < 12; index++) {
-			expect(cycle(tracker, outputFor(index))).not.toBe("hard");
-		}
-		expect(inspect(tracker)).toBe("hard");
-	});
-
-	it("keeps the absolute limit across interleaved tool signatures", () => {
-		const tracker = createTracker();
-
-		for (let index = 1; index < 12; index++) {
-			const poll = identified(`poll-${index}`);
-			expect(cycle(tracker, { status: `waiting-${index}` }, poll)).not.toBe(
-				"hard",
-			);
+		for (let iteration = 1; iteration < 12; iteration++) {
 			expect(
-				inspect(
-					tracker,
-					identified(`other-${index}`, "other", { step: index }),
-				),
-			).toBe("ok");
+				completeBatch(tracker, iteration, [
+					{ status: "pending", timestamp: iteration },
+				])[0],
+			).not.toBe("hard");
 		}
-		expect(inspect(tracker, identified("poll-12"))).toBe("hard");
+		expect(inspect(tracker, 12)).toBe("hard");
 	});
 
-	it("counts parallel calls as one order-independent batch", () => {
+	it("keeps the absolute limit across interleaved signatures", () => {
 		const tracker = createTracker();
 
-		expect(runBatch(tracker, "a", ["10% complete", "20% complete"])).toEqual([
-			"ok",
-			"ok",
-		]);
-		expect(runBatch(tracker, "b", ["20% complete", "10% complete"])).toEqual([
-			"soft",
-			"ok",
-		]);
-		expect(inspect(tracker, identified("c-1"))).toBe("hard");
+		for (let iteration = 1; iteration < 12; iteration++) {
+			expect(
+				completeBatch(tracker, iteration, [`poll ${iteration}`])[0],
+			).not.toBe("hard");
+			completeBatch(tracker, iteration, ["other"], { name: "other" });
+		}
+		expect(inspect(tracker, 12)).toBe("hard");
 	});
 
-	it("accepts progress from every parallel outcome", () => {
+	it("treats parallel outcomes as one order-independent batch", () => {
 		const tracker = createTracker();
 
-		expect(runBatch(tracker, "a", ["10% complete", "10% complete"])).toEqual([
-			"ok",
-			"ok",
-		]);
-		expect(runBatch(tracker, "b", ["20% complete", "20% complete"])).toEqual([
-			"soft",
-			"ok",
-		]);
-		expect(inspect(tracker, identified("c-1"))).toBe("ok");
+		expect(completeBatch(tracker, 1, ["10%", "20%"])).toEqual(["ok", "ok"]);
+		expect(completeBatch(tracker, 2, ["20%", "10%"])).toEqual(["soft", "ok"]);
+		expect(inspect(tracker, 3)).toBe("hard");
 	});
 
-	it("still escalates repeated parallel batches without progress", () => {
+	it("retains progress from every parallel outcome", () => {
 		const tracker = createTracker();
 
-		expect(runBatch(tracker, "a", ["same", "same"])).toEqual(["ok", "ok"]);
-		expect(runBatch(tracker, "b", ["same", "same"])).toEqual(["soft", "ok"]);
-		expect(runBatch(tracker, "c", ["same", "same"])[0]).toBe("hard");
+		expect(completeBatch(tracker, 1, ["10%", "10%"])).toEqual(["ok", "ok"]);
+		expect(completeBatch(tracker, 2, ["20%", "10%"])).toEqual(["soft", "ok"]);
+		expect(inspect(tracker, 3)).toBe("ok");
 	});
 
 	it("bounds a parallel batch whose calls never finish", () => {
 		const tracker = createTracker();
 
-		for (let index = 1; index < 12; index++) {
-			expect(inspect(tracker, identified(`pending-${index}`))).not.toBe("hard");
+		for (let callIndex = 1; callIndex < 12; callIndex++) {
+			expect(inspect(tracker, 1)).not.toBe("hard");
 		}
-		expect(inspect(tracker, identified("pending-12"))).toBe("hard");
+		expect(inspect(tracker, 1)).toBe("hard");
 	});
 
-	it("does not let a late outcome reset another tool's counter", () => {
+	it("drops unfinished batches between runtime invocations", () => {
 		const tracker = createTracker();
-		const firstPoll = identified("poll-1");
-		const secondPoll = identified("poll-2");
-		const other = identified("other-1", "other");
 
-		expect(cycle(tracker, "10% complete", firstPoll)).toBe("ok");
-		expect(inspect(tracker, secondPoll)).toBe("soft");
-		expect(cycle(tracker, "unchanged", other)).toBe("ok");
-		succeed(tracker, secondPoll, "20% complete");
+		expect(inspect(tracker, 1)).toBe("ok");
+		expect(inspect(tracker, 1)).toBe("ok");
+		tracker.clearPendingCalls();
 
-		expect(inspect(tracker, identified("other-2", "other"))).toBe("soft");
+		expect(inspect(tracker, 1)).toBe("soft");
 	});
 
-	it("applies a completed outcome after an interleaved call", () => {
-		const tracker = createTracker();
-		const delayedPoll = identified("poll-1");
-
-		expect(cycle(tracker, "10% complete", identified("baseline"))).toBe("ok");
-		expect(inspect(tracker, delayedPoll)).toBe("soft");
-		expect(cycle(tracker, "unchanged", identified("other-1", "other"))).toBe(
-			"ok",
-		);
-		succeed(tracker, delayedPoll, "20% complete");
-
-		expect(cycle(tracker, "10% complete", identified("poll-2"))).toBe("ok");
-		expect(inspect(tracker, identified("poll-3"))).toBe("ok");
-	});
-
-	it("starts a new batch when an older interleaved poll remains pending", () => {
+	it("uses stable object fingerprints", () => {
 		const tracker = createTracker();
 
-		expect(cycle(tracker, "10% complete", identified("baseline"))).toBe("ok");
-		expect(inspect(tracker, identified("stale"))).toBe("soft");
-		expect(cycle(tracker, "unchanged", identified("other", "other"))).toBe(
-			"ok",
-		);
-		expect(cycle(tracker, "20% complete", identified("resumed"))).toBe("ok");
-		expect(cycle(tracker, "30% complete", identified("next"))).toBe("ok");
-		expect(inspect(tracker, identified("after-progress"))).toBe("ok");
-	});
-
-	it("ignores an older batch that finishes after a newer outcome", () => {
-		const tracker = createTracker();
-		const oldPoll = identified("old");
-
-		expect(cycle(tracker, "10% complete", identified("baseline"))).toBe("ok");
-		expect(inspect(tracker, oldPoll)).toBe("soft");
-		expect(cycle(tracker, "unchanged", identified("other", "other"))).toBe(
-			"ok",
-		);
-		expect(cycle(tracker, "20% complete", identified("new"))).toBe("ok");
-		expect(cycle(tracker, "20% complete", identified("repeated"))).toBe("ok");
-		succeed(tracker, oldPoll, "30% complete");
-
-		expect(inspect(tracker, identified("after-stale"))).toBe("soft");
-	});
-
-	it("retains earlier parallel outcomes across an interleaved call", () => {
-		const tracker = createTracker();
-		const first = identified("poll-1");
-		const second = identified("poll-2");
-
-		expect(cycle(tracker, "10% complete", identified("baseline"))).toBe("ok");
-		expect(inspect(tracker, first)).toBe("soft");
-		expect(inspect(tracker, identified("other", "other"))).toBe("ok");
-		expect(inspect(tracker, second)).toBe("ok");
-		succeed(tracker, first, "20% complete");
-		succeed(tracker, second, "10% complete");
-
-		expect(cycle(tracker, "10% complete", identified("poll-3"))).toBe("ok");
-		expect(inspect(tracker, identified("poll-4"))).toBe("soft");
+		completeBatch(tracker, 1, [{ first: 1, second: 2 }]);
+		expect(completeBatch(tracker, 2, [{ second: 2, first: 1 }])).toEqual([
+			"soft",
+		]);
+		expect(inspect(tracker, 3)).toBe("hard");
 	});
 });

--- a/sdk/packages/core/src/runtime/safety/loop-detection.test.ts
+++ b/sdk/packages/core/src/runtime/safety/loop-detection.test.ts
@@ -149,6 +149,28 @@ describe("LoopDetectionTracker", () => {
 		expect(tracker.inspect(call).kind).toBe("hard");
 	});
 
+	it("keeps the absolute limit across interleaved tool signatures", () => {
+		const tracker = new LoopDetectionTracker({
+			softThreshold: 2,
+			hardThreshold: 3,
+		});
+
+		for (let index = 1; index < 12; index++) {
+			const poll = { ...call, id: `poll-${index}` };
+			expect(tracker.inspect(poll).kind).not.toBe("hard");
+			observeSuccess(tracker, poll, { status: `waiting-${index}` });
+			expect(
+				tracker.inspect({
+					id: `other-${index}`,
+					name: "other",
+					input: { step: index },
+				}).kind,
+			).toBe("ok");
+		}
+
+		expect(tracker.inspect({ ...call, id: "poll-12" }).kind).toBe("hard");
+	});
+
 	it("counts identical parallel calls as one batch and accepts every outcome", () => {
 		const tracker = new LoopDetectionTracker({
 			softThreshold: 2,
@@ -313,9 +335,40 @@ describe("LoopDetectionTracker", () => {
 		observeSuccess(tracker, resumedPoll, "20% complete");
 
 		const nextPoll = { ...call, id: "next-poll" };
-		expect(tracker.inspect(nextPoll).kind).toBe("soft");
+		expect(tracker.inspect(nextPoll).kind).toBe("ok");
 		observeSuccess(tracker, nextPoll, "30% complete");
 		expect(tracker.inspect({ ...call, id: "after-progress" }).kind).toBe("ok");
+	});
+
+	it("ignores an older batch that finishes after a newer poll outcome", () => {
+		const tracker = new LoopDetectionTracker({
+			softThreshold: 2,
+			hardThreshold: 3,
+		});
+		const baseline = { ...call, id: "baseline" };
+		const oldPoll = { ...call, id: "old-poll" };
+		const otherCall = {
+			id: "other-1",
+			name: "other",
+			input: { command: "status" },
+		};
+
+		expect(tracker.inspect(baseline).kind).toBe("ok");
+		observeSuccess(tracker, baseline, "10% complete");
+		expect(tracker.inspect(oldPoll).kind).toBe("soft");
+		expect(tracker.inspect(otherCall).kind).toBe("ok");
+		observeSuccess(tracker, otherCall, "unchanged");
+
+		const newPoll = { ...call, id: "new-poll" };
+		expect(tracker.inspect(newPoll).kind).toBe("ok");
+		observeSuccess(tracker, newPoll, "20% complete");
+		const repeatedPoll = { ...call, id: "repeated-poll" };
+		expect(tracker.inspect(repeatedPoll).kind).toBe("ok");
+		observeSuccess(tracker, repeatedPoll, "20% complete");
+
+		observeSuccess(tracker, oldPoll, "30% complete");
+
+		expect(tracker.inspect({ ...call, id: "after-stale" }).kind).toBe("soft");
 	});
 
 	it("keeps earlier identical parallel outcomes across an interleaved call", () => {

--- a/sdk/packages/core/src/runtime/safety/loop-detection.test.ts
+++ b/sdk/packages/core/src/runtime/safety/loop-detection.test.ts
@@ -114,6 +114,19 @@ describe("LoopDetectionTracker", () => {
 		expect(inspect(tracker, 3)).toBe("hard");
 	});
 
+	it("treats sequential outcomes in one iteration as one batch", () => {
+		const tracker = createTracker();
+		const batchCall = call(1);
+		const verdicts = ["same", "same", "same"].map((output) => {
+			const verdict = tracker.inspect(batchCall).kind;
+			tracker.observeOutcome(batchCall, { successful: true, output });
+			return verdict;
+		});
+
+		expect(verdicts).toEqual(["ok", "ok", "ok"]);
+		expect(inspect(tracker, 2)).toBe("soft");
+	});
+
 	it("retains progress from every parallel outcome", () => {
 		const tracker = createTracker();
 
@@ -139,6 +152,18 @@ describe("LoopDetectionTracker", () => {
 		tracker.clearPendingCalls();
 
 		expect(inspect(tracker, 1)).toBe("soft");
+	});
+
+	it("does not charge unfinished batches to the absolute limit", () => {
+		const tracker = createTracker();
+
+		for (let iteration = 1; iteration <= 12; iteration++) {
+			expect(inspect(tracker, iteration)).not.toBe("hard");
+			const separator = call(iteration, "other", { iteration });
+			expect(tracker.inspect(separator).kind).not.toBe("hard");
+			tracker.observeOutcome(separator, { successful: true, output: "done" });
+			tracker.clearPendingCalls();
+		}
 	});
 
 	it("uses stable object fingerprints", () => {

--- a/sdk/packages/core/src/runtime/safety/loop-detection.test.ts
+++ b/sdk/packages/core/src/runtime/safety/loop-detection.test.ts
@@ -80,6 +80,20 @@ describe("LoopDetectionTracker", () => {
 		expect(inspect(tracker, 12)).toBe("hard");
 	});
 
+	it.each([
+		["percentages", (step: number) => `${step}%`],
+		["numeric progress fields", (step: number) => ({ progress: step / 100 })],
+		["ratios", (step: number) => `${step}/100`],
+	] as const)("allows explicit %s beyond the fallback limit", (_name, output) => {
+		const tracker = createTracker();
+
+		for (let iteration = 1; iteration <= 15; iteration++) {
+			expect(
+				completeBatch(tracker, iteration, [output(iteration)])[0],
+			).not.toBe("hard");
+		}
+	});
+
 	it("keeps the absolute limit across interleaved signatures", () => {
 		const tracker = createTracker();
 

--- a/sdk/packages/core/src/runtime/safety/loop-detection.test.ts
+++ b/sdk/packages/core/src/runtime/safety/loop-detection.test.ts
@@ -263,6 +263,32 @@ describe("LoopDetectionTracker", () => {
 		expect(tracker.inspect({ ...otherCall, id: "other-2" }).kind).toBe("soft");
 	});
 
+	it("applies a completed poll outcome after an interleaved call finishes", () => {
+		const tracker = new LoopDetectionTracker({
+			softThreshold: 2,
+			hardThreshold: 3,
+		});
+		const baseline = { ...call, id: "baseline" };
+		const firstPoll = { ...call, id: "poll-1" };
+		const otherCall = {
+			id: "other-1",
+			name: "other",
+			input: { command: "status" },
+		};
+
+		expect(tracker.inspect(baseline).kind).toBe("ok");
+		observeSuccess(tracker, baseline, "10% complete");
+		expect(tracker.inspect(firstPoll).kind).toBe("soft");
+		expect(tracker.inspect(otherCall).kind).toBe("ok");
+		observeSuccess(tracker, otherCall, "unchanged");
+		observeSuccess(tracker, firstPoll, "20% complete");
+
+		const secondPoll = { ...call, id: "poll-2" };
+		expect(tracker.inspect(secondPoll).kind).toBe("ok");
+		observeSuccess(tracker, secondPoll, "10% complete");
+		expect(tracker.inspect({ ...call, id: "poll-3" }).kind).toBe("ok");
+	});
+
 	it("keeps earlier identical parallel outcomes across an interleaved call", () => {
 		const tracker = new LoopDetectionTracker({
 			softThreshold: 2,

--- a/sdk/packages/core/src/runtime/safety/loop-detection.test.ts
+++ b/sdk/packages/core/src/runtime/safety/loop-detection.test.ts
@@ -107,6 +107,30 @@ describe("LoopDetectionTracker", () => {
 		}
 	});
 
+	it("allows bounded explicit progress restarts", () => {
+		const tracker = createTracker();
+		const steps = [0, 25, 50, 75, 100];
+
+		for (let iteration = 1; iteration <= 20; iteration++) {
+			expect(
+				completeBatch(tracker, iteration, [
+					{ progress: steps[(iteration - 1) % steps.length] },
+				])[0],
+			).not.toBe("hard");
+		}
+	});
+
+	it("bounds oscillating explicit progress", () => {
+		const tracker = createTracker();
+
+		for (let iteration = 1; iteration < 113; iteration++) {
+			expect(
+				completeBatch(tracker, iteration, [{ progress: iteration % 2 }])[0],
+			).not.toBe("hard");
+		}
+		expect(inspect(tracker, 113)).toBe("hard");
+	});
+
 	it("keeps the absolute limit across interleaved signatures", () => {
 		const tracker = createTracker();
 

--- a/sdk/packages/core/src/runtime/safety/loop-detection.test.ts
+++ b/sdk/packages/core/src/runtime/safety/loop-detection.test.ts
@@ -175,4 +175,16 @@ describe("LoopDetectionTracker", () => {
 		]);
 		expect(inspect(tracker, 3)).toBe("hard");
 	});
+
+	it.each([
+		["number and string", 1, "1"],
+		["null and string", null, "null"],
+		["boolean and string", true, "true"],
+	] as const)("preserves output types for %s", (_name, first, second) => {
+		const tracker = createTracker();
+
+		expect(completeBatch(tracker, 1, [first])).toEqual(["ok"]);
+		expect(completeBatch(tracker, 2, [second])).toEqual(["soft"]);
+		expect(inspect(tracker, 3)).toBe("ok");
+	});
 });

--- a/sdk/packages/core/src/runtime/safety/loop-detection.test.ts
+++ b/sdk/packages/core/src/runtime/safety/loop-detection.test.ts
@@ -187,4 +187,20 @@ describe("LoopDetectionTracker", () => {
 		expect(completeBatch(tracker, 2, [second])).toEqual(["soft"]);
 		expect(inspect(tracker, 3)).toBe("ok");
 	});
+
+	it("preserves serializable non-plain output values", () => {
+		const tracker = createTracker();
+
+		expect(
+			completeBatch(tracker, 1, [
+				{ updatedAt: new Date("2026-01-01T00:00:00.000Z") },
+			]),
+		).toEqual(["ok"]);
+		expect(
+			completeBatch(tracker, 2, [
+				{ updatedAt: new Date("2026-01-02T00:00:00.000Z") },
+			]),
+		).toEqual(["soft"]);
+		expect(inspect(tracker, 3)).toBe("ok");
+	});
 });

--- a/sdk/packages/core/src/runtime/safety/loop-detection.test.ts
+++ b/sdk/packages/core/src/runtime/safety/loop-detection.test.ts
@@ -80,6 +80,19 @@ describe("LoopDetectionTracker", () => {
 		expect(inspect(tracker, 12)).toBe("hard");
 	});
 
+	it("does not interpret dates as ratio progress", () => {
+		const tracker = createTracker();
+
+		for (let iteration = 1; iteration < 12; iteration++) {
+			expect(
+				completeBatch(tracker, iteration, [
+					{ timestamp: `${iteration}/${iteration + 1}/2026`, nonce: iteration },
+				])[0],
+			).not.toBe("hard");
+		}
+		expect(inspect(tracker, 12)).toBe("hard");
+	});
+
 	it.each([
 		["percentages", (step: number) => `${step}%`],
 		["numeric progress fields", (step: number) => ({ progress: step / 100 })],

--- a/sdk/packages/core/src/runtime/safety/loop-detection.test.ts
+++ b/sdk/packages/core/src/runtime/safety/loop-detection.test.ts
@@ -1,402 +1,265 @@
 import { describe, expect, it } from "vitest";
 import { type LoopDetectionCall, LoopDetectionTracker } from "./loop-detection";
 
+const baseCall = { name: "poll", input: { command: "status" } };
+const createTracker = () =>
+	new LoopDetectionTracker({ softThreshold: 2, hardThreshold: 3 });
+const identified = (
+	id: string,
+	name = baseCall.name,
+	input: unknown = baseCall.input,
+): LoopDetectionCall => ({ id, name, input });
+const inspect = (
+	tracker: LoopDetectionTracker,
+	call: LoopDetectionCall = baseCall,
+) => tracker.inspect(call).kind;
+const succeed = (
+	tracker: LoopDetectionTracker,
+	call: LoopDetectionCall,
+	output: unknown,
+) => tracker.observeOutcome(call, { successful: true, output });
+const cycle = (
+	tracker: LoopDetectionTracker,
+	output: unknown,
+	call: LoopDetectionCall = baseCall,
+) => {
+	const verdict = inspect(tracker, call);
+	succeed(tracker, call, output);
+	return verdict;
+};
+const runBatch = (
+	tracker: LoopDetectionTracker,
+	prefix: string,
+	outputs: unknown[],
+) => {
+	const calls = outputs.map((_, index) => identified(`${prefix}-${index + 1}`));
+	const verdicts = calls.map((call) => inspect(tracker, call));
+	calls.forEach((call, index) => {
+		succeed(tracker, call, outputs[index]);
+	});
+	return verdicts;
+};
+
 describe("LoopDetectionTracker", () => {
-	const call = { name: "poll", input: { command: "status" } };
-	const observeSuccess = (
-		tracker: LoopDetectionTracker,
-		inspectedCall: LoopDetectionCall,
-		output: unknown,
-	) => {
-		tracker.observeOutcome(inspectedCall, { successful: true, output });
-	};
-
 	it("resets repeated-call counting when successful output changes meaningfully", () => {
-		const tracker = new LoopDetectionTracker({
-			softThreshold: 2,
-			hardThreshold: 3,
-		});
+		const tracker = createTracker();
 
-		expect(tracker.inspect(call).kind).toBe("ok");
-		observeSuccess(tracker, call, "10% complete");
-		expect(tracker.inspect(call).kind).toBe("soft");
-		observeSuccess(tracker, call, "20% complete");
-
-		expect(tracker.inspect(call).kind).toBe("ok");
+		expect(cycle(tracker, "10% complete")).toBe("ok");
+		expect(cycle(tracker, "20% complete")).toBe("soft");
+		expect(inspect(tracker)).toBe("ok");
 	});
 
-	it("ignores volatile timestamps and request IDs when detecting progress", () => {
-		const tracker = new LoopDetectionTracker({
-			softThreshold: 2,
-			hardThreshold: 3,
-		});
-
-		expect(tracker.inspect(call).kind).toBe("ok");
-		observeSuccess(tracker, call, {
-			status: "pending",
-			timestamp: "2026-07-25T01:00:00Z",
-			startedAt: "2026-07-25T00:59:00Z",
-			elapsedMs: 60_000,
-			requestId: "9be5a8dd-7214-4d51-8b04-261e54e62ac2",
-			message:
-				"status=pending request-id=9be5a8dd-7214-4d51-8b04-261e54e62ac2 elapsed=60s at 2026-07-25T01:00:00Z",
-		});
-		expect(tracker.inspect(call).kind).toBe("soft");
-		observeSuccess(tracker, call, {
-			status: "pending",
-			timestamp: "2026-07-25T01:00:01Z",
-			startedAt: "2026-07-25T00:59:00Z",
-			elapsedMs: 61_000,
-			requestId: "6b265eb9-cc65-4577-87e1-03d4328a06d4",
-			message:
-				"status=pending request-id=6b265eb9-cc65-4577-87e1-03d4328a06d4 elapsed=61s at 2026-07-25T01:00:01Z",
-		});
-
-		expect(tracker.inspect(call).kind).toBe("hard");
-	});
-
-	it("ignores append-only heartbeat log tails without semantic progress", () => {
-		const tracker = new LoopDetectionTracker({
-			softThreshold: 2,
-			hardThreshold: 3,
-		});
-
-		expect(tracker.inspect(call).kind).toBe("ok");
-		observeSuccess(
-			tracker,
-			call,
-			[
+	it.each([
+		{
+			name: "timestamps and request IDs",
+			first: {
+				status: "pending",
+				timestamp: "2026-07-25T01:00:00Z",
+				elapsedMs: 60_000,
+				requestId: "9be5a8dd-7214-4d51-8b04-261e54e62ac2",
+				message:
+					"status=pending request-id=9be5a8dd-7214-4d51-8b04-261e54e62ac2 elapsed=60s at 2026-07-25T01:00:00Z",
+			},
+			second: {
+				status: "pending",
+				timestamp: "2026-07-25T01:00:01Z",
+				elapsedMs: 61_000,
+				requestId: "6b265eb9-cc65-4577-87e1-03d4328a06d4",
+				message:
+					"status=pending request-id=6b265eb9-cc65-4577-87e1-03d4328a06d4 elapsed=61s at 2026-07-25T01:00:01Z",
+			},
+		},
+		{
+			name: "append-only heartbeat text",
+			first: [
+				"2026-07-25T01:00:00Z heartbeat",
+				"2026-07-25T01:00:01Z heartbeat",
+			].join("\n"),
+			second: [
 				"2026-07-25T01:00:00Z heartbeat",
 				"2026-07-25T01:00:01Z heartbeat",
 				"2026-07-25T01:00:02Z heartbeat",
 			].join("\n"),
-		);
-		expect(tracker.inspect(call).kind).toBe("soft");
-		observeSuccess(
-			tracker,
-			call,
-			[
-				"2026-07-25T01:00:00Z heartbeat",
-				"2026-07-25T01:00:01Z heartbeat",
-				"2026-07-25T01:00:02Z heartbeat",
-				"2026-07-25T01:00:03Z heartbeat",
-			].join("\n"),
-		);
+		},
+		{
+			name: "structured log tails",
+			first: {
+				status: "pending",
+				logs: [{ timestamp: "2026-07-25T01:00:00Z", message: "heartbeat" }],
+			},
+			second: {
+				status: "pending",
+				logs: [
+					{ timestamp: "2026-07-25T01:00:00Z", message: "heartbeat" },
+					{ timestamp: "2026-07-25T01:00:01Z", message: "heartbeat 2" },
+				],
+			},
+		},
+	])("does not treat volatile $name as progress", ({ first, second }) => {
+		const tracker = createTracker();
 
-		expect(tracker.inspect(call).kind).toBe("hard");
+		expect(cycle(tracker, first)).toBe("ok");
+		expect(cycle(tracker, second)).toBe("soft");
+		expect(inspect(tracker)).toBe("hard");
 	});
 
-	it("ignores growth in structured log-tail fields", () => {
-		const tracker = new LoopDetectionTracker({
-			softThreshold: 2,
-			hardThreshold: 3,
-		});
+	it("still escalates identical successful output", () => {
+		const tracker = createTracker();
 
-		expect(tracker.inspect(call).kind).toBe("ok");
-		observeSuccess(tracker, call, {
-			status: "pending",
-			logs: [{ timestamp: "2026-07-25T01:00:00Z", message: "heartbeat" }],
-		});
-		expect(tracker.inspect(call).kind).toBe("soft");
-		observeSuccess(tracker, call, {
-			status: "pending",
-			logs: [
-				{ timestamp: "2026-07-25T01:00:00Z", message: "heartbeat" },
-				{ timestamp: "2026-07-25T01:00:01Z", message: "heartbeat" },
-			],
-		});
-
-		expect(tracker.inspect(call).kind).toBe("hard");
+		expect(cycle(tracker, "still running")).toBe("ok");
+		expect(cycle(tracker, "still running")).toBe("soft");
+		expect(inspect(tracker)).toBe("hard");
 	});
 
-	it("still escalates identical calls with identical successful output", () => {
-		const tracker = new LoopDetectionTracker({
-			softThreshold: 2,
-			hardThreshold: 3,
-		});
-
-		expect(tracker.inspect(call).kind).toBe("ok");
-		observeSuccess(tracker, call, "still running");
-		expect(tracker.inspect(call).kind).toBe("soft");
-		observeSuccess(tracker, call, "still running");
-
-		expect(tracker.inspect(call).kind).toBe("hard");
-	});
-
-	it("enforces an absolute limit across repeatedly changing outcomes", () => {
-		const tracker = new LoopDetectionTracker({
-			softThreshold: 2,
-			hardThreshold: 3,
-		});
+	it.each([
+		["unclassified output", (index: number) => `changing output ${index}`],
+		[
+			"progress-classified output",
+			(index: number) => ({ status: `waiting-${index}` }),
+		],
+	] as const)("enforces an absolute limit across %s", (_name, outputFor) => {
+		const tracker = createTracker();
 
 		for (let index = 1; index < 12; index++) {
-			expect(tracker.inspect(call).kind).not.toBe("hard");
-			observeSuccess(tracker, call, `changing output ${index}`);
+			expect(cycle(tracker, outputFor(index))).not.toBe("hard");
 		}
-		expect(tracker.inspect(call).kind).toBe("hard");
-	});
-
-	it("bounds long-running calls even when progress-classified values change", () => {
-		const tracker = new LoopDetectionTracker({
-			softThreshold: 2,
-			hardThreshold: 3,
-		});
-
-		for (let index = 1; index < 12; index++) {
-			expect(tracker.inspect(call).kind).not.toBe("hard");
-			observeSuccess(tracker, call, { status: `waiting-${index}` });
-		}
-		expect(tracker.inspect(call).kind).toBe("hard");
+		expect(inspect(tracker)).toBe("hard");
 	});
 
 	it("keeps the absolute limit across interleaved tool signatures", () => {
-		const tracker = new LoopDetectionTracker({
-			softThreshold: 2,
-			hardThreshold: 3,
-		});
+		const tracker = createTracker();
 
 		for (let index = 1; index < 12; index++) {
-			const poll = { ...call, id: `poll-${index}` };
-			expect(tracker.inspect(poll).kind).not.toBe("hard");
-			observeSuccess(tracker, poll, { status: `waiting-${index}` });
+			const poll = identified(`poll-${index}`);
+			expect(cycle(tracker, { status: `waiting-${index}` }, poll)).not.toBe(
+				"hard",
+			);
 			expect(
-				tracker.inspect({
-					id: `other-${index}`,
-					name: "other",
-					input: { step: index },
-				}).kind,
+				inspect(
+					tracker,
+					identified(`other-${index}`, "other", { step: index }),
+				),
 			).toBe("ok");
 		}
-
-		expect(tracker.inspect({ ...call, id: "poll-12" }).kind).toBe("hard");
+		expect(inspect(tracker, identified("poll-12"))).toBe("hard");
 	});
 
-	it("counts identical parallel calls as one batch and accepts every outcome", () => {
-		const tracker = new LoopDetectionTracker({
-			softThreshold: 2,
-			hardThreshold: 3,
-		});
-		const firstBatch = ["a1", "a2", "a3"].map((id) => ({ ...call, id }));
-		const secondBatch = ["b1", "b2", "b3"].map((id) => ({ ...call, id }));
+	it("counts parallel calls as one order-independent batch", () => {
+		const tracker = createTracker();
 
-		expect(firstBatch.map((entry) => tracker.inspect(entry).kind)).toEqual([
-			"ok",
+		expect(runBatch(tracker, "a", ["10% complete", "20% complete"])).toEqual([
 			"ok",
 			"ok",
 		]);
-		for (const entry of firstBatch) {
-			observeSuccess(tracker, entry, "10% complete");
-		}
-
-		expect(secondBatch.map((entry) => tracker.inspect(entry).kind)).toEqual([
-			"soft",
-			"ok",
-			"ok",
-		]);
-		observeSuccess(tracker, secondBatch[0], "20% complete");
-		observeSuccess(tracker, secondBatch[1], "20% complete");
-		observeSuccess(tracker, secondBatch[2], "20% complete");
-
-		expect(tracker.inspect({ ...call, id: "c1" }).kind).toBe("ok");
-	});
-
-	it("compares parallel outcomes as an order-independent batch", () => {
-		const tracker = new LoopDetectionTracker({
-			softThreshold: 2,
-			hardThreshold: 3,
-		});
-		const firstBatch = ["a1", "a2"].map((id) => ({ ...call, id }));
-		const secondBatch = ["b1", "b2"].map((id) => ({ ...call, id }));
-
-		expect(firstBatch.map((entry) => tracker.inspect(entry).kind)).toEqual([
-			"ok",
-			"ok",
-		]);
-		observeSuccess(tracker, firstBatch[0], "10% complete");
-		observeSuccess(tracker, firstBatch[1], "20% complete");
-
-		expect(secondBatch.map((entry) => tracker.inspect(entry).kind)).toEqual([
+		expect(runBatch(tracker, "b", ["20% complete", "10% complete"])).toEqual([
 			"soft",
 			"ok",
 		]);
-		observeSuccess(tracker, secondBatch[0], "20% complete");
-		observeSuccess(tracker, secondBatch[1], "10% complete");
+		expect(inspect(tracker, identified("c-1"))).toBe("hard");
+	});
 
-		expect(tracker.inspect({ ...call, id: "c1" }).kind).toBe("hard");
+	it("accepts progress from every parallel outcome", () => {
+		const tracker = createTracker();
+
+		expect(runBatch(tracker, "a", ["10% complete", "10% complete"])).toEqual([
+			"ok",
+			"ok",
+		]);
+		expect(runBatch(tracker, "b", ["20% complete", "20% complete"])).toEqual([
+			"soft",
+			"ok",
+		]);
+		expect(inspect(tracker, identified("c-1"))).toBe("ok");
 	});
 
 	it("still escalates repeated parallel batches without progress", () => {
-		const tracker = new LoopDetectionTracker({
-			softThreshold: 2,
-			hardThreshold: 3,
-		});
-		const inspectBatch = (prefix: string) => {
-			const batch = [1, 2, 3].map((index) => ({
-				...call,
-				id: `${prefix}${index}`,
-			}));
-			const verdicts = batch.map((entry) => tracker.inspect(entry).kind);
-			for (const entry of batch) {
-				observeSuccess(tracker, entry, "still running");
-			}
-			return verdicts;
-		};
+		const tracker = createTracker();
 
-		expect(inspectBatch("a")).toEqual(["ok", "ok", "ok"]);
-		expect(inspectBatch("b")).toEqual(["soft", "ok", "ok"]);
-		expect(inspectBatch("c")[0]).toBe("hard");
+		expect(runBatch(tracker, "a", ["same", "same"])).toEqual(["ok", "ok"]);
+		expect(runBatch(tracker, "b", ["same", "same"])).toEqual(["soft", "ok"]);
+		expect(runBatch(tracker, "c", ["same", "same"])[0]).toBe("hard");
 	});
 
-	it("bounds an identical parallel batch when earlier calls never finish", () => {
-		const tracker = new LoopDetectionTracker({
-			softThreshold: 2,
-			hardThreshold: 3,
-		});
+	it("bounds a parallel batch whose calls never finish", () => {
+		const tracker = createTracker();
 
 		for (let index = 1; index < 12; index++) {
-			expect(
-				tracker.inspect({ ...call, id: `pending-${index}` }).kind,
-			).not.toBe("hard");
+			expect(inspect(tracker, identified(`pending-${index}`))).not.toBe("hard");
 		}
-		expect(tracker.inspect({ ...call, id: "pending-12" }).kind).toBe("hard");
+		expect(inspect(tracker, identified("pending-12"))).toBe("hard");
 	});
 
-	it("does not let a late parallel outcome reset another call's counter", () => {
-		const tracker = new LoopDetectionTracker({
-			softThreshold: 2,
-			hardThreshold: 3,
-		});
-		const firstPoll = { ...call, id: "poll-1" };
-		const secondPoll = { ...call, id: "poll-2" };
-		const otherCall = {
-			id: "other-1",
-			name: "other",
-			input: { command: "status" },
-		};
+	it("does not let a late outcome reset another tool's counter", () => {
+		const tracker = createTracker();
+		const firstPoll = identified("poll-1");
+		const secondPoll = identified("poll-2");
+		const other = identified("other-1", "other");
 
-		expect(tracker.inspect(firstPoll).kind).toBe("ok");
-		observeSuccess(tracker, firstPoll, "10% complete");
-		expect(tracker.inspect(secondPoll).kind).toBe("soft");
-		expect(tracker.inspect(otherCall).kind).toBe("ok");
-		observeSuccess(tracker, otherCall, "still running");
+		expect(cycle(tracker, "10% complete", firstPoll)).toBe("ok");
+		expect(inspect(tracker, secondPoll)).toBe("soft");
+		expect(cycle(tracker, "unchanged", other)).toBe("ok");
+		succeed(tracker, secondPoll, "20% complete");
 
-		observeSuccess(tracker, secondPoll, "20% complete");
-
-		expect(tracker.inspect({ ...otherCall, id: "other-2" }).kind).toBe("soft");
+		expect(inspect(tracker, identified("other-2", "other"))).toBe("soft");
 	});
 
-	it("applies a completed poll outcome after an interleaved call finishes", () => {
-		const tracker = new LoopDetectionTracker({
-			softThreshold: 2,
-			hardThreshold: 3,
-		});
-		const baseline = { ...call, id: "baseline" };
-		const firstPoll = { ...call, id: "poll-1" };
-		const otherCall = {
-			id: "other-1",
-			name: "other",
-			input: { command: "status" },
-		};
+	it("applies a completed outcome after an interleaved call", () => {
+		const tracker = createTracker();
+		const delayedPoll = identified("poll-1");
 
-		expect(tracker.inspect(baseline).kind).toBe("ok");
-		observeSuccess(tracker, baseline, "10% complete");
-		expect(tracker.inspect(firstPoll).kind).toBe("soft");
-		expect(tracker.inspect(otherCall).kind).toBe("ok");
-		observeSuccess(tracker, otherCall, "unchanged");
-		observeSuccess(tracker, firstPoll, "20% complete");
+		expect(cycle(tracker, "10% complete", identified("baseline"))).toBe("ok");
+		expect(inspect(tracker, delayedPoll)).toBe("soft");
+		expect(cycle(tracker, "unchanged", identified("other-1", "other"))).toBe(
+			"ok",
+		);
+		succeed(tracker, delayedPoll, "20% complete");
 
-		const secondPoll = { ...call, id: "poll-2" };
-		expect(tracker.inspect(secondPoll).kind).toBe("ok");
-		observeSuccess(tracker, secondPoll, "10% complete");
-		expect(tracker.inspect({ ...call, id: "poll-3" }).kind).toBe("ok");
+		expect(cycle(tracker, "10% complete", identified("poll-2"))).toBe("ok");
+		expect(inspect(tracker, identified("poll-3"))).toBe("ok");
 	});
 
-	it("starts a fresh batch when an older interleaved poll remains pending", () => {
-		const tracker = new LoopDetectionTracker({
-			softThreshold: 2,
-			hardThreshold: 3,
-		});
-		const baseline = { ...call, id: "baseline" };
-		const stalePoll = { ...call, id: "stale-poll" };
-		const otherCall = {
-			id: "other-1",
-			name: "other",
-			input: { command: "status" },
-		};
+	it("starts a new batch when an older interleaved poll remains pending", () => {
+		const tracker = createTracker();
 
-		expect(tracker.inspect(baseline).kind).toBe("ok");
-		observeSuccess(tracker, baseline, "10% complete");
-		expect(tracker.inspect(stalePoll).kind).toBe("soft");
-		expect(tracker.inspect(otherCall).kind).toBe("ok");
-		observeSuccess(tracker, otherCall, "unchanged");
-
-		const resumedPoll = { ...call, id: "resumed-poll" };
-		expect(tracker.inspect(resumedPoll).kind).toBe("ok");
-		observeSuccess(tracker, resumedPoll, "20% complete");
-
-		const nextPoll = { ...call, id: "next-poll" };
-		expect(tracker.inspect(nextPoll).kind).toBe("ok");
-		observeSuccess(tracker, nextPoll, "30% complete");
-		expect(tracker.inspect({ ...call, id: "after-progress" }).kind).toBe("ok");
+		expect(cycle(tracker, "10% complete", identified("baseline"))).toBe("ok");
+		expect(inspect(tracker, identified("stale"))).toBe("soft");
+		expect(cycle(tracker, "unchanged", identified("other", "other"))).toBe(
+			"ok",
+		);
+		expect(cycle(tracker, "20% complete", identified("resumed"))).toBe("ok");
+		expect(cycle(tracker, "30% complete", identified("next"))).toBe("ok");
+		expect(inspect(tracker, identified("after-progress"))).toBe("ok");
 	});
 
-	it("ignores an older batch that finishes after a newer poll outcome", () => {
-		const tracker = new LoopDetectionTracker({
-			softThreshold: 2,
-			hardThreshold: 3,
-		});
-		const baseline = { ...call, id: "baseline" };
-		const oldPoll = { ...call, id: "old-poll" };
-		const otherCall = {
-			id: "other-1",
-			name: "other",
-			input: { command: "status" },
-		};
+	it("ignores an older batch that finishes after a newer outcome", () => {
+		const tracker = createTracker();
+		const oldPoll = identified("old");
 
-		expect(tracker.inspect(baseline).kind).toBe("ok");
-		observeSuccess(tracker, baseline, "10% complete");
-		expect(tracker.inspect(oldPoll).kind).toBe("soft");
-		expect(tracker.inspect(otherCall).kind).toBe("ok");
-		observeSuccess(tracker, otherCall, "unchanged");
+		expect(cycle(tracker, "10% complete", identified("baseline"))).toBe("ok");
+		expect(inspect(tracker, oldPoll)).toBe("soft");
+		expect(cycle(tracker, "unchanged", identified("other", "other"))).toBe(
+			"ok",
+		);
+		expect(cycle(tracker, "20% complete", identified("new"))).toBe("ok");
+		expect(cycle(tracker, "20% complete", identified("repeated"))).toBe("ok");
+		succeed(tracker, oldPoll, "30% complete");
 
-		const newPoll = { ...call, id: "new-poll" };
-		expect(tracker.inspect(newPoll).kind).toBe("ok");
-		observeSuccess(tracker, newPoll, "20% complete");
-		const repeatedPoll = { ...call, id: "repeated-poll" };
-		expect(tracker.inspect(repeatedPoll).kind).toBe("ok");
-		observeSuccess(tracker, repeatedPoll, "20% complete");
-
-		observeSuccess(tracker, oldPoll, "30% complete");
-
-		expect(tracker.inspect({ ...call, id: "after-stale" }).kind).toBe("soft");
+		expect(inspect(tracker, identified("after-stale"))).toBe("soft");
 	});
 
-	it("keeps earlier identical parallel outcomes across an interleaved call", () => {
-		const tracker = new LoopDetectionTracker({
-			softThreshold: 2,
-			hardThreshold: 3,
-		});
-		const baseline = { ...call, id: "baseline" };
-		const firstPoll = { ...call, id: "poll-1" };
-		const secondPoll = { ...call, id: "poll-2" };
-		const otherCall = {
-			id: "other-1",
-			name: "other",
-			input: { command: "status" },
-		};
+	it("retains earlier parallel outcomes across an interleaved call", () => {
+		const tracker = createTracker();
+		const first = identified("poll-1");
+		const second = identified("poll-2");
 
-		expect(tracker.inspect(baseline).kind).toBe("ok");
-		observeSuccess(tracker, baseline, "10% complete");
-		expect(tracker.inspect(firstPoll).kind).toBe("soft");
-		expect(tracker.inspect(otherCall).kind).toBe("ok");
-		expect(tracker.inspect(secondPoll).kind).toBe("ok");
+		expect(cycle(tracker, "10% complete", identified("baseline"))).toBe("ok");
+		expect(inspect(tracker, first)).toBe("soft");
+		expect(inspect(tracker, identified("other", "other"))).toBe("ok");
+		expect(inspect(tracker, second)).toBe("ok");
+		succeed(tracker, first, "20% complete");
+		succeed(tracker, second, "10% complete");
 
-		observeSuccess(tracker, firstPoll, "20% complete");
-		observeSuccess(tracker, secondPoll, "10% complete");
-
-		const thirdPoll = { ...call, id: "poll-3" };
-		expect(tracker.inspect(thirdPoll).kind).toBe("ok");
-		observeSuccess(tracker, thirdPoll, "10% complete");
-		expect(tracker.inspect({ ...call, id: "poll-4" }).kind).toBe("soft");
+		expect(cycle(tracker, "10% complete", identified("poll-3"))).toBe("ok");
+		expect(inspect(tracker, identified("poll-4"))).toBe("soft");
 	});
 });

--- a/sdk/packages/core/src/runtime/safety/loop-detection.test.ts
+++ b/sdk/packages/core/src/runtime/safety/loop-detection.test.ts
@@ -1,21 +1,112 @@
 import { describe, expect, it } from "vitest";
-import { LoopDetectionTracker } from "./loop-detection";
+import { type LoopDetectionCall, LoopDetectionTracker } from "./loop-detection";
 
 describe("LoopDetectionTracker", () => {
 	const call = { name: "poll", input: { command: "status" } };
+	const observeSuccess = (
+		tracker: LoopDetectionTracker,
+		inspectedCall: LoopDetectionCall,
+		output: unknown,
+	) => {
+		tracker.observeOutcome(inspectedCall, { successful: true, output });
+	};
 
-	it("resets repeated-call counting when successful output changes", () => {
+	it("resets repeated-call counting when successful output changes meaningfully", () => {
 		const tracker = new LoopDetectionTracker({
 			softThreshold: 2,
 			hardThreshold: 3,
 		});
 
 		expect(tracker.inspect(call).kind).toBe("ok");
-		tracker.observeSuccessfulOutcome(call, "10% complete");
+		observeSuccess(tracker, call, "10% complete");
 		expect(tracker.inspect(call).kind).toBe("soft");
-		tracker.observeSuccessfulOutcome(call, "20% complete");
+		observeSuccess(tracker, call, "20% complete");
 
 		expect(tracker.inspect(call).kind).toBe("ok");
+	});
+
+	it("ignores volatile timestamps and request IDs when detecting progress", () => {
+		const tracker = new LoopDetectionTracker({
+			softThreshold: 2,
+			hardThreshold: 3,
+		});
+
+		expect(tracker.inspect(call).kind).toBe("ok");
+		observeSuccess(tracker, call, {
+			status: "pending",
+			timestamp: "2026-07-25T01:00:00Z",
+			startedAt: "2026-07-25T00:59:00Z",
+			elapsedMs: 60_000,
+			requestId: "9be5a8dd-7214-4d51-8b04-261e54e62ac2",
+			message:
+				"status=pending request-id=9be5a8dd-7214-4d51-8b04-261e54e62ac2 elapsed=60s at 2026-07-25T01:00:00Z",
+		});
+		expect(tracker.inspect(call).kind).toBe("soft");
+		observeSuccess(tracker, call, {
+			status: "pending",
+			timestamp: "2026-07-25T01:00:01Z",
+			startedAt: "2026-07-25T00:59:00Z",
+			elapsedMs: 61_000,
+			requestId: "6b265eb9-cc65-4577-87e1-03d4328a06d4",
+			message:
+				"status=pending request-id=6b265eb9-cc65-4577-87e1-03d4328a06d4 elapsed=61s at 2026-07-25T01:00:01Z",
+		});
+
+		expect(tracker.inspect(call).kind).toBe("hard");
+	});
+
+	it("ignores append-only heartbeat log tails without semantic progress", () => {
+		const tracker = new LoopDetectionTracker({
+			softThreshold: 2,
+			hardThreshold: 3,
+		});
+
+		expect(tracker.inspect(call).kind).toBe("ok");
+		observeSuccess(
+			tracker,
+			call,
+			[
+				"2026-07-25T01:00:00Z heartbeat",
+				"2026-07-25T01:00:01Z heartbeat",
+				"2026-07-25T01:00:02Z heartbeat",
+			].join("\n"),
+		);
+		expect(tracker.inspect(call).kind).toBe("soft");
+		observeSuccess(
+			tracker,
+			call,
+			[
+				"2026-07-25T01:00:00Z heartbeat",
+				"2026-07-25T01:00:01Z heartbeat",
+				"2026-07-25T01:00:02Z heartbeat",
+				"2026-07-25T01:00:03Z heartbeat",
+			].join("\n"),
+		);
+
+		expect(tracker.inspect(call).kind).toBe("hard");
+	});
+
+	it("ignores growth in structured log-tail fields", () => {
+		const tracker = new LoopDetectionTracker({
+			softThreshold: 2,
+			hardThreshold: 3,
+		});
+
+		expect(tracker.inspect(call).kind).toBe("ok");
+		observeSuccess(tracker, call, {
+			status: "pending",
+			logs: [{ timestamp: "2026-07-25T01:00:00Z", message: "heartbeat" }],
+		});
+		expect(tracker.inspect(call).kind).toBe("soft");
+		observeSuccess(tracker, call, {
+			status: "pending",
+			logs: [
+				{ timestamp: "2026-07-25T01:00:00Z", message: "heartbeat" },
+				{ timestamp: "2026-07-25T01:00:01Z", message: "heartbeat" },
+			],
+		});
+
+		expect(tracker.inspect(call).kind).toBe("hard");
 	});
 
 	it("still escalates identical calls with identical successful output", () => {
@@ -25,11 +116,112 @@ describe("LoopDetectionTracker", () => {
 		});
 
 		expect(tracker.inspect(call).kind).toBe("ok");
-		tracker.observeSuccessfulOutcome(call, "still running");
+		observeSuccess(tracker, call, "still running");
 		expect(tracker.inspect(call).kind).toBe("soft");
-		tracker.observeSuccessfulOutcome(call, "still running");
+		observeSuccess(tracker, call, "still running");
 
 		expect(tracker.inspect(call).kind).toBe("hard");
+	});
+
+	it("enforces an absolute limit across repeatedly changing outcomes", () => {
+		const tracker = new LoopDetectionTracker({
+			softThreshold: 2,
+			hardThreshold: 3,
+		});
+
+		for (let index = 1; index < 12; index++) {
+			expect(tracker.inspect(call).kind).not.toBe("hard");
+			observeSuccess(tracker, call, `changing output ${index}`);
+		}
+		expect(tracker.inspect(call).kind).toBe("hard");
+	});
+
+	it("allows long-running calls that report explicit semantic progress", () => {
+		const tracker = new LoopDetectionTracker({
+			softThreshold: 2,
+			hardThreshold: 3,
+		});
+
+		for (let index = 1; index <= 20; index++) {
+			expect(tracker.inspect(call).kind).not.toBe("hard");
+			observeSuccess(tracker, call, `${index}/20 complete`);
+		}
+	});
+
+	it("counts identical parallel calls as one batch and accepts every outcome", () => {
+		const tracker = new LoopDetectionTracker({
+			softThreshold: 2,
+			hardThreshold: 3,
+		});
+		const firstBatch = ["a1", "a2", "a3"].map((id) => ({ ...call, id }));
+		const secondBatch = ["b1", "b2", "b3"].map((id) => ({ ...call, id }));
+
+		expect(firstBatch.map((entry) => tracker.inspect(entry).kind)).toEqual([
+			"ok",
+			"ok",
+			"ok",
+		]);
+		for (const entry of firstBatch) {
+			observeSuccess(tracker, entry, "10% complete");
+		}
+
+		expect(secondBatch.map((entry) => tracker.inspect(entry).kind)).toEqual([
+			"soft",
+			"ok",
+			"ok",
+		]);
+		observeSuccess(tracker, secondBatch[0], "20% complete");
+		observeSuccess(tracker, secondBatch[1], "20% complete");
+		observeSuccess(tracker, secondBatch[2], "20% complete");
+
+		expect(tracker.inspect({ ...call, id: "c1" }).kind).toBe("ok");
+	});
+
+	it("compares parallel outcomes as an order-independent batch", () => {
+		const tracker = new LoopDetectionTracker({
+			softThreshold: 2,
+			hardThreshold: 3,
+		});
+		const firstBatch = ["a1", "a2"].map((id) => ({ ...call, id }));
+		const secondBatch = ["b1", "b2"].map((id) => ({ ...call, id }));
+
+		expect(firstBatch.map((entry) => tracker.inspect(entry).kind)).toEqual([
+			"ok",
+			"ok",
+		]);
+		observeSuccess(tracker, firstBatch[0], "10% complete");
+		observeSuccess(tracker, firstBatch[1], "20% complete");
+
+		expect(secondBatch.map((entry) => tracker.inspect(entry).kind)).toEqual([
+			"soft",
+			"ok",
+		]);
+		observeSuccess(tracker, secondBatch[0], "20% complete");
+		observeSuccess(tracker, secondBatch[1], "10% complete");
+
+		expect(tracker.inspect({ ...call, id: "c1" }).kind).toBe("hard");
+	});
+
+	it("still escalates repeated parallel batches without progress", () => {
+		const tracker = new LoopDetectionTracker({
+			softThreshold: 2,
+			hardThreshold: 3,
+		});
+		const inspectBatch = (prefix: string) => {
+			const batch = [1, 2, 3].map((index) => ({
+				...call,
+				id: `${prefix}${index}`,
+			}));
+			const verdicts = batch.map((entry) => tracker.inspect(entry).kind);
+			for (const entry of batch) {
+				observeSuccess(tracker, entry, "still running");
+			}
+			return verdicts;
+		};
+
+		expect(inspectBatch("a")).toEqual(["ok", "ok", "ok"]);
+		expect(inspectBatch("b")).toEqual(["soft", "ok", "ok"]);
+		expect(inspectBatch("c")[0]).toBe("hard");
 	});
 
 	it("does not let a late parallel outcome reset another call's counter", () => {
@@ -46,11 +238,12 @@ describe("LoopDetectionTracker", () => {
 		};
 
 		expect(tracker.inspect(firstPoll).kind).toBe("ok");
-		tracker.observeSuccessfulOutcome(firstPoll, "10% complete");
+		observeSuccess(tracker, firstPoll, "10% complete");
 		expect(tracker.inspect(secondPoll).kind).toBe("soft");
 		expect(tracker.inspect(otherCall).kind).toBe("ok");
+		observeSuccess(tracker, otherCall, "still running");
 
-		tracker.observeSuccessfulOutcome(secondPoll, "20% complete");
+		observeSuccess(tracker, secondPoll, "20% complete");
 
 		expect(tracker.inspect({ ...otherCall, id: "other-2" }).kind).toBe("soft");
 	});

--- a/sdk/packages/core/src/runtime/safety/loop-detection.test.ts
+++ b/sdk/packages/core/src/runtime/safety/loop-detection.test.ts
@@ -1,0 +1,316 @@
+import { describe, expect, it } from "vitest";
+import { type LoopDetectionCall, LoopDetectionTracker } from "./loop-detection";
+
+const createTracker = () =>
+	new LoopDetectionTracker({ softThreshold: 2, hardThreshold: 3 });
+
+function call(
+	iteration: number,
+	name = "poll",
+	input: unknown = { command: "status" },
+): LoopDetectionCall {
+	return { iteration, name, input };
+}
+
+function inspect(
+	tracker: LoopDetectionTracker,
+	iteration: number,
+	name?: string,
+	input?: unknown,
+) {
+	return tracker.inspect(call(iteration, name, input)).kind;
+}
+
+function completeBatch(
+	tracker: LoopDetectionTracker,
+	iteration: number,
+	outputs: unknown[],
+	options: { name?: string; input?: unknown; successful?: boolean } = {},
+) {
+	const batchCall = call(iteration, options.name, options.input);
+	const verdicts = outputs.map(() => tracker.inspect(batchCall).kind);
+	for (const output of outputs) {
+		tracker.observeOutcome(batchCall, {
+			successful: options.successful ?? true,
+			output,
+		});
+	}
+	return verdicts;
+}
+
+type TrackerInternals = {
+	state: { lastToolSignature: string };
+	pendingBatches: Map<string, unknown>;
+	signatures: Map<string, { lastOutputSignature?: string }>;
+};
+
+function internals(tracker: LoopDetectionTracker): TrackerInternals {
+	return tracker as unknown as TrackerInternals;
+}
+
+describe("LoopDetectionTracker", () => {
+	it("resets the ordinary counter after changed successful output", () => {
+		const tracker = createTracker();
+
+		expect(completeBatch(tracker, 1, ["10%"])).toEqual(["ok"]);
+		expect(completeBatch(tracker, 2, ["20%"])).toEqual(["soft"]);
+		expect(inspect(tracker, 3)).toBe("ok");
+	});
+
+	it("escalates unchanged successful output", () => {
+		const tracker = createTracker();
+
+		expect(completeBatch(tracker, 1, ["same"])).toEqual(["ok"]);
+		expect(completeBatch(tracker, 2, ["same"])).toEqual(["soft"]);
+		expect(inspect(tracker, 3)).toBe("hard");
+	});
+
+	it("does not treat changing failures as progress", () => {
+		const tracker = createTracker();
+
+		expect(
+			completeBatch(tracker, 1, ["error 1"], { successful: false }),
+		).toEqual(["ok"]);
+		expect(
+			completeBatch(tracker, 2, ["error 2"], { successful: false }),
+		).toEqual(["soft"]);
+		expect(inspect(tracker, 3)).toBe("hard");
+	});
+
+	it("bounds continually changing output without interpreting it", () => {
+		const tracker = createTracker();
+
+		for (let iteration = 1; iteration < 12; iteration++) {
+			expect(
+				completeBatch(tracker, iteration, [
+					{ status: "pending", timestamp: iteration },
+				])[0],
+			).not.toBe("hard");
+		}
+		expect(inspect(tracker, 12)).toBe("hard");
+	});
+
+	it("does not interpret dates as ratio progress", () => {
+		const tracker = createTracker();
+
+		for (let iteration = 1; iteration < 12; iteration++) {
+			expect(
+				completeBatch(tracker, iteration, [
+					{ timestamp: `${iteration}/${iteration + 1}/2026`, nonce: iteration },
+				])[0],
+			).not.toBe("hard");
+		}
+		expect(inspect(tracker, 12)).toBe("hard");
+	});
+
+	it.each([
+		["percentages", (step: number) => `${step}%`],
+		["numeric progress fields", (step: number) => ({ progress: step / 100 })],
+		["ratios", (step: number) => `${step}/100`],
+	] as const)("allows explicit %s beyond the fallback limit", (_name, output) => {
+		const tracker = createTracker();
+
+		for (let iteration = 1; iteration <= 15; iteration++) {
+			expect(
+				completeBatch(tracker, iteration, [output(iteration)])[0],
+			).not.toBe("hard");
+		}
+	});
+
+	it("allows bounded explicit progress restarts", () => {
+		const tracker = createTracker();
+		const steps = [0, 25, 50, 75, 100];
+
+		for (let iteration = 1; iteration <= 20; iteration++) {
+			expect(
+				completeBatch(tracker, iteration, [
+					{ progress: steps[(iteration - 1) % steps.length] },
+				])[0],
+			).not.toBe("hard");
+		}
+	});
+
+	it("bounds oscillating explicit progress", () => {
+		const tracker = createTracker();
+
+		for (let iteration = 1; iteration < 113; iteration++) {
+			expect(
+				completeBatch(tracker, iteration, [{ progress: iteration % 2 }])[0],
+			).not.toBe("hard");
+		}
+		expect(inspect(tracker, 113)).toBe("hard");
+	});
+
+	it("keeps the absolute limit across interleaved signatures", () => {
+		const tracker = createTracker();
+
+		for (let iteration = 1; iteration < 12; iteration++) {
+			expect(
+				completeBatch(tracker, iteration, [`poll ${iteration}`])[0],
+			).not.toBe("hard");
+			completeBatch(tracker, iteration, ["other"], { name: "other" });
+		}
+		expect(inspect(tracker, 12)).toBe("hard");
+	});
+
+	it("treats parallel outcomes as one order-independent batch", () => {
+		const tracker = createTracker();
+
+		expect(completeBatch(tracker, 1, ["10%", "20%"])).toEqual(["ok", "ok"]);
+		expect(completeBatch(tracker, 2, ["20%", "10%"])).toEqual(["soft", "ok"]);
+		expect(inspect(tracker, 3)).toBe("hard");
+	});
+
+	it("treats sequential outcomes in one iteration as one batch", () => {
+		const tracker = createTracker();
+		const batchCall = call(1);
+		const verdicts = ["same", "same", "same"].map((output) => {
+			const verdict = tracker.inspect(batchCall).kind;
+			tracker.observeOutcome(batchCall, { successful: true, output });
+			return verdict;
+		});
+
+		expect(verdicts).toEqual(["ok", "ok", "ok"]);
+		expect(inspect(tracker, 2)).toBe("soft");
+	});
+
+	it("retains progress from every parallel outcome", () => {
+		const tracker = createTracker();
+
+		expect(completeBatch(tracker, 1, ["10%", "10%"])).toEqual(["ok", "ok"]);
+		expect(completeBatch(tracker, 2, ["20%", "10%"])).toEqual(["soft", "ok"]);
+		expect(inspect(tracker, 3)).toBe("ok");
+	});
+
+	it("bounds a parallel batch whose calls never finish", () => {
+		const tracker = createTracker();
+
+		for (let callIndex = 1; callIndex < 12; callIndex++) {
+			expect(inspect(tracker, 1)).not.toBe("hard");
+		}
+		expect(inspect(tracker, 1)).toBe("hard");
+	});
+
+	it("drops unfinished batches between runtime invocations", () => {
+		const tracker = createTracker();
+
+		expect(inspect(tracker, 1)).toBe("ok");
+		expect(inspect(tracker, 1)).toBe("ok");
+		tracker.clearPendingCalls();
+
+		expect(inspect(tracker, 1)).toBe("soft");
+	});
+
+	it("does not charge unfinished batches to the absolute limit", () => {
+		const tracker = createTracker();
+
+		for (let iteration = 1; iteration <= 12; iteration++) {
+			expect(inspect(tracker, iteration)).not.toBe("hard");
+			const separator = call(iteration, "other", { iteration });
+			expect(tracker.inspect(separator).kind).not.toBe("hard");
+			tracker.observeOutcome(separator, { successful: true, output: "done" });
+			tracker.clearPendingCalls();
+		}
+	});
+
+	it("uses stable object fingerprints", () => {
+		const tracker = createTracker();
+
+		completeBatch(tracker, 1, [{ first: 1, second: 2 }]);
+		expect(completeBatch(tracker, 2, [{ second: 2, first: 1 }])).toEqual([
+			"soft",
+		]);
+		expect(inspect(tracker, 3)).toBe("hard");
+	});
+
+	it.each([
+		["number and string", 1, "1"],
+		["null and string", null, "null"],
+		["boolean and string", true, "true"],
+	] as const)("preserves output types for %s", (_name, first, second) => {
+		const tracker = createTracker();
+
+		expect(completeBatch(tracker, 1, [first])).toEqual(["ok"]);
+		expect(completeBatch(tracker, 2, [second])).toEqual(["soft"]);
+		expect(inspect(tracker, 3)).toBe("ok");
+	});
+
+	it("preserves serializable non-plain output values", () => {
+		const tracker = createTracker();
+
+		expect(
+			completeBatch(tracker, 1, [
+				{ updatedAt: new Date("2026-01-01T00:00:00.000Z") },
+			]),
+		).toEqual(["ok"]);
+		expect(
+			completeBatch(tracker, 2, [
+				{ updatedAt: new Date("2026-01-02T00:00:00.000Z") },
+			]),
+		).toEqual(["soft"]);
+		expect(inspect(tracker, 3)).toBe("ok");
+	});
+
+	it("retains fixed-size hashes instead of raw input and output", () => {
+		const tracker = createTracker();
+		const input = { secret: "input-marker".repeat(10_000) };
+		const output = { content: "output-marker".repeat(10_000) };
+
+		completeBatch(tracker, 1, [output], { input });
+		tracker.clearPendingCalls();
+
+		const state = internals(tracker);
+		const [[key, signatureState]] = [...state.signatures];
+		expect(key).toHaveLength(64);
+		expect(state.state.lastToolSignature).toHaveLength(64);
+		expect(signatureState.lastOutputSignature).toHaveLength(64);
+		expect(
+			`${key}${state.state.lastToolSignature}${signatureState.lastOutputSignature}`,
+		).not.toContain("marker");
+	});
+
+	it("caps completed signature history with least-recently-used eviction", () => {
+		const tracker = createTracker();
+
+		for (let index = 0; index < 128; index++) {
+			completeBatch(tracker, index + 1, ["done"], {
+				input: { job: index },
+			});
+		}
+		tracker.clearPendingCalls();
+		const state = internals(tracker);
+		const [oldestKey, secondOldestKey] = state.signatures.keys();
+
+		completeBatch(tracker, 129, ["done"], { input: { job: 0 } });
+		completeBatch(tracker, 130, ["done"], { input: { job: 128 } });
+		tracker.clearPendingCalls();
+
+		expect(state.signatures.size).toBe(128);
+		expect(state.signatures.has(oldestKey)).toBe(true);
+		expect(state.signatures.has(secondOldestKey)).toBe(false);
+	});
+
+	it("never evicts signatures that still have pending batches", () => {
+		const tracker = createTracker();
+		const calls = Array.from({ length: 129 }, (_, index) =>
+			call(1, "poll", { job: index }),
+		);
+
+		for (const pendingCall of calls) {
+			tracker.inspect(pendingCall);
+		}
+		const state = internals(tracker);
+		expect(state.pendingBatches.size).toBe(129);
+		expect(state.signatures.size).toBe(129);
+
+		for (const pendingCall of calls) {
+			tracker.observeOutcome(pendingCall, {
+				successful: true,
+				output: "done",
+			});
+		}
+		tracker.clearPendingCalls();
+		expect(state.pendingBatches.size).toBe(0);
+		expect(state.signatures.size).toBe(128);
+	});
+});

--- a/sdk/packages/core/src/runtime/safety/loop-detection.ts
+++ b/sdk/packages/core/src/runtime/safety/loop-detection.ts
@@ -125,6 +125,13 @@ const DEFAULT_CONFIG: LoopDetectionConfig = {
 export class LoopDetectionTracker {
 	private readonly config: LoopDetectionConfig;
 	private readonly state: LoopDetectionState = createLoopDetectionState();
+	private lastSuccessfulOutcome:
+		| {
+				toolName: string;
+				toolSignature: string;
+				outputSignature: string;
+		  }
+		| undefined;
 
 	constructor(config?: Partial<LoopDetectionConfig>) {
 		this.config = {
@@ -156,7 +163,34 @@ export class LoopDetectionTracker {
 		return { kind: "ok" };
 	}
 
+	/**
+	 * Record the result of a successful call so repeated status checks can be
+	 * distinguished from a stalled loop. When the same call produces different
+	 * output, it has observed progress and the consecutive-call counter resets.
+	 * Identical calls with identical output continue accumulating normally.
+	 */
+	observeSuccessfulOutcome(call: LoopDetectionCall, output: unknown): void {
+		const toolSignature = toolCallSignature(call.input);
+		const outputSignature = toolCallSignature(output);
+		const previous = this.lastSuccessfulOutcome;
+
+		if (
+			previous?.toolName === call.name &&
+			previous.toolSignature === toolSignature &&
+			previous.outputSignature !== outputSignature
+		) {
+			resetLoopDetectionState(this.state);
+		}
+
+		this.lastSuccessfulOutcome = {
+			toolName: call.name,
+			toolSignature,
+			outputSignature,
+		};
+	}
+
 	reset(): void {
 		resetLoopDetectionState(this.state);
+		this.lastSuccessfulOutcome = undefined;
 	}
 }

--- a/sdk/packages/core/src/runtime/safety/loop-detection.ts
+++ b/sdk/packages/core/src/runtime/safety/loop-detection.ts
@@ -106,6 +106,7 @@ export interface LoopDetectionVerdict {
 
 /** Minimal call shape the tracker needs; matches `AgentToolCallPart` subset. */
 export interface LoopDetectionCall {
+	id?: string;
 	name: string;
 	input: unknown;
 }
@@ -132,6 +133,7 @@ export class LoopDetectionTracker {
 				outputSignature: string;
 		  }
 		| undefined;
+	private latestInspectedCallId: string | undefined;
 
 	constructor(config?: Partial<LoopDetectionConfig>) {
 		this.config = {
@@ -142,6 +144,7 @@ export class LoopDetectionTracker {
 
 	inspect(call: LoopDetectionCall): LoopDetectionVerdict {
 		const signature = toolCallSignature(call.input);
+		this.latestInspectedCallId = call.id;
 		const result = checkRepeatedToolCall(
 			this.state,
 			call.name,
@@ -171,6 +174,14 @@ export class LoopDetectionTracker {
 	 */
 	observeSuccessfulOutcome(call: LoopDetectionCall, output: unknown): void {
 		const toolSignature = toolCallSignature(call.input);
+		const isCurrentCall =
+			this.state.lastToolName === call.name &&
+			this.state.lastToolSignature === toolSignature &&
+			(call.id === undefined || call.id === this.latestInspectedCallId);
+		if (!isCurrentCall) {
+			return;
+		}
+
 		const outputSignature = toolCallSignature(output);
 		const previous = this.lastSuccessfulOutcome;
 
@@ -192,5 +203,6 @@ export class LoopDetectionTracker {
 	reset(): void {
 		resetLoopDetectionState(this.state);
 		this.lastSuccessfulOutcome = undefined;
+		this.latestInspectedCallId = undefined;
 	}
 }

--- a/sdk/packages/core/src/runtime/safety/loop-detection.ts
+++ b/sdk/packages/core/src/runtime/safety/loop-detection.ts
@@ -6,9 +6,8 @@
  *
  * The pure helpers (`createLoopDetectionState`, `resetLoopDetectionState`,
  * `toolCallSignature`, `checkRepeatedToolCall`) are ported verbatim. The
- * `LoopDetectionTracker` owns the repeated-call state, correlates parallel
- * outcomes, and distinguishes semantic result progress from volatile output
- * before `SessionRuntime` decides whether to warn or abort.
+ * `LoopDetectionTracker` owns the repeated-call state and groups parallel calls
+ * by agent iteration before `SessionRuntime` decides whether to warn or abort.
  */
 
 import type { LoopDetectionConfig } from "@cline/shared";
@@ -104,9 +103,9 @@ export interface LoopDetectionVerdict {
 	message?: string;
 }
 
-/** Minimal call shape the tracker needs; matches `AgentToolCallPart` subset. */
+/** Minimal runtime call shape needed by the tracker. */
 export interface LoopDetectionCall {
-	id?: string;
+	iteration: number;
 	name: string;
 	input: unknown;
 }
@@ -116,145 +115,36 @@ const DEFAULT_CONFIG: LoopDetectionConfig = {
 	hardThreshold: 5,
 };
 
-// Output comparison is necessarily heuristic for arbitrary tools. Keep an
-// absolute ceiling so even unrecognized volatile changes cannot grant progress
-// forever, while allowing several normal polling windows to complete.
-const MAX_PROGRESS_WINDOWS = 4;
+// Changed output may be real progress or volatile noise. The absolute ceiling
+// keeps either case bounded without guessing the meaning of arbitrary output.
+const ABSOLUTE_LIMIT_MULTIPLIER = 4;
 
-const VOLATILE_OUTPUT_KEY =
-	/^(?:correlationid|checkedat|createdat|duration(?:ms)?|elapsed(?:ms)?|endedat|eventid|finishedat|lastseenat|polledat|requestid|spanid|startedat|time|timestamp|traceid|updatedat)$/;
-const LOG_OUTPUT_KEY = /^(?:log|logs|logtail|stderr|stdout|tail)$/;
-
-const PROGRESS_TEXT_PATTERN =
-	/\b(?:complete(?:d)?|done|failed|phase|progress|queued|running|stage|state|status|succeeded|success)\b|\b\d+(?:\.\d+)?%|\b\d+\s*\/\s*\d+\b/i;
-
-function compactOutputKey(key: string): string {
-	return key.replaceAll(/[^a-z0-9]/gi, "").toLowerCase();
-}
-
-function normalizeOutputText(value: string, logLike: boolean): string {
-	const normalized = value
-		.replaceAll(
-			/\b(?:correlation|event|request|span|trace)[-_ ]?id\s*[:=]\s*["']?[a-z0-9._:/-]+/gi,
-			"<volatile-id>",
-		)
-		.replaceAll(
-			/\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/gi,
-			"<volatile-id>",
-		)
-		.replaceAll(
-			/\b(?:checked|created|elapsed|ended|finished|polled|started|time|timestamp|updated)(?:[-_ ]?at)?\s*[:=]\s*["']?(?:\d{10,13}|\d+(?:\.\d+)?(?:ms|s))/gi,
-			"<volatile-time>",
-		)
-		.replaceAll(
-			/\b\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?\b/g,
-			"<volatile-time>",
-		)
-		.replaceAll(
-			/\b(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:\.\d+)?\b/g,
-			"<volatile-time>",
-		);
-	const lines = normalized
-		.split(/\r?\n/)
-		.map((line) => line.trim().replaceAll(/\s+/g, " "))
-		.filter(Boolean);
-
-	const uniqueLines = [...new Set(lines)];
-	if (!logLike) return uniqueLines.join("\n");
-	return (
-		uniqueLines.filter((line) => PROGRESS_TEXT_PATTERN.test(line)).join("\n") ||
-		"<log-output>"
-	);
-}
-
-function normalizeToolOutcome(value: unknown, parentKey?: string): unknown {
-	if (typeof value === "string") {
-		return normalizeOutputText(
-			value,
-			parentKey !== undefined &&
-				LOG_OUTPUT_KEY.test(compactOutputKey(parentKey)),
-		);
-	}
-	if (value == null || typeof value !== "object") return value;
-	if (Array.isArray(value)) {
-		const normalizedEntries = value.map((entry) =>
-			normalizeToolOutcome(entry, parentKey),
-		);
-		if (
-			parentKey !== undefined &&
-			LOG_OUTPUT_KEY.test(compactOutputKey(parentKey))
-		) {
-			const progressEntries = normalizedEntries
-				.map((entry) => JSON.stringify(entry) ?? "null")
-				.filter((entry) => PROGRESS_TEXT_PATTERN.test(entry));
-			return progressEntries.length === 0
-				? ["<log-output>"]
-				: [...new Set(progressEntries)].sort();
-		}
-		return normalizedEntries;
-	}
-
-	const normalized: Record<string, unknown> = {};
-	for (const key of Object.keys(value as Record<string, unknown>).sort()) {
-		if (VOLATILE_OUTPUT_KEY.test(compactOutputKey(key))) continue;
-		normalized[key] = normalizeToolOutcome(
-			(value as Record<string, unknown>)[key],
-			key,
-		);
-	}
-	return normalized;
-}
-
-function toolOutcomeFingerprint(output: unknown): string {
-	try {
-		return JSON.stringify(normalizeToolOutcome(output)) ?? "undefined";
-	} catch {
-		return normalizeOutputText(String(output), false);
-	}
-}
-
-function sequenceKey(toolName: string, toolSignature: string): string {
+function callKey(toolName: string, toolSignature: string): string {
 	return JSON.stringify([toolName, toolSignature]);
 }
 
-interface PendingBatch {
-	key: string;
+interface ToolBatch {
 	pendingCount: number;
 	outcomes: Set<string>;
 }
 
-interface SignatureProgressState {
+interface SignatureState {
 	totalBatchCount: number;
-	latestOutcomeBatchId: number;
 	lastOutputSignature?: string;
-	progressVersion: number;
-}
-
-interface ActiveSequence {
-	key: string;
-	observedProgressVersion: number;
-	activeBatchId?: number;
+	hasProgress: boolean;
 }
 
 /**
  * Per-session repeated-tool-call detector.
  *
- * `SessionRuntime` owns the instance and installs a `beforeTool` hook
- * (see `AgentRuntimeHooks.beforeTool`) that calls `inspect()` to decide
- * whether to return `{ skip, stop, reason }`.
+ * `SessionRuntime` owns the instance and calls `inspect()` for every
+ * `tool-started` event.
  */
 export class LoopDetectionTracker {
 	private readonly config: LoopDetectionConfig;
 	private readonly state: LoopDetectionState = createLoopDetectionState();
-	private currentSequence: ActiveSequence | undefined;
-	private nextBatchId = 1;
-	private readonly pendingCalls = new Map<string, number>();
-	private anonymousPendingBatchId: number | undefined;
-	private readonly pendingBatches = new Map<number, PendingBatch>();
-	private readonly signatureProgress = new Map<
-		string,
-		SignatureProgressState
-	>();
+	private readonly pendingBatches = new Map<string, ToolBatch>();
+	private readonly signatures = new Map<string, SignatureState>();
 
 	constructor(config?: Partial<LoopDetectionConfig>) {
 		this.config = {
@@ -265,44 +155,25 @@ export class LoopDetectionTracker {
 
 	inspect(call: LoopDetectionCall): LoopDetectionVerdict {
 		const signature = toolCallSignature(call.input);
-		const key = sequenceKey(call.name, signature);
-		const progress = this.getProgress(key);
-		let sequence = this.currentSequence;
-		if (sequence?.key !== key) {
-			sequence = {
-				key,
-				observedProgressVersion: progress.progressVersion,
-			};
-			this.currentSequence = sequence;
-		} else if (sequence.observedProgressVersion !== progress.progressVersion) {
+		const key = callKey(call.name, signature);
+		const signatureState = this.getSignature(key);
+		if (signatureState.hasProgress) {
 			resetLoopDetectionState(this.state);
-			sequence.observedProgressVersion = progress.progressVersion;
+			signatureState.hasProgress = false;
 		}
 
-		// Calls without ids cannot be correlated safely, so only identified calls
-		// join an unfinished batch from the current uninterrupted sequence.
-		let batchId = call.id === undefined ? undefined : sequence.activeBatchId;
-		let batch =
-			batchId === undefined ? undefined : this.pendingBatches.get(batchId);
+		const batchId = JSON.stringify([call.iteration, key]);
+		let batch = this.pendingBatches.get(batchId);
 		const isNewBatch = batch === undefined;
 		if (batch === undefined) {
-			batchId = this.nextBatchId++;
-			batch = { key, pendingCount: 0, outcomes: new Set() };
+			batch = { pendingCount: 0, outcomes: new Set() };
 			this.pendingBatches.set(batchId, batch);
-			sequence.activeBatchId = batchId;
-			progress.totalBatchCount++;
-		}
-		if (batchId === undefined) {
-			throw new Error("Loop detection batch was not initialized");
+			signatureState.totalBatchCount++;
 		}
 		batch.pendingCount++;
-		if (call.id !== undefined) {
-			this.pendingCalls.set(call.id, batchId);
-		} else {
-			this.anonymousPendingBatchId = batchId;
-		}
 
-		const absoluteHardLimit = this.config.hardThreshold * MAX_PROGRESS_WINDOWS;
+		const absoluteHardLimit =
+			this.config.hardThreshold * ABSOLUTE_LIMIT_MULTIPLIER;
 		if (batch.pendingCount >= absoluteHardLimit) {
 			return this.hard(
 				`Detected ${batch.pendingCount} identical calls to \`${call.name}\` still pending in one batch; stopping because earlier calls did not complete.`,
@@ -318,11 +189,11 @@ export class LoopDetectionTracker {
 		);
 		if (
 			result.hardEscalation ||
-			progress.totalBatchCount >= absoluteHardLimit
+			signatureState.totalBatchCount >= absoluteHardLimit
 		) {
 			return this.hard(
-				progress.totalBatchCount >= absoluteHardLimit
-					? `Detected ${progress.totalBatchCount} repeated batches of identical calls to \`${call.name}\` despite changing results; stopping to avoid a loop.`
+				signatureState.totalBatchCount >= absoluteHardLimit
+					? `Detected ${signatureState.totalBatchCount} repeated batches of identical calls to \`${call.name}\` despite changing results; stopping to avoid a loop.`
 					: `Detected ${this.state.consecutiveIdenticalCount} consecutive identical calls to \`${call.name}\`; stopping to avoid a loop.`,
 			);
 		}
@@ -336,54 +207,38 @@ export class LoopDetectionTracker {
 	}
 
 	/**
-	 * Complete an inspected call. Parallel calls in one uninterrupted sequence
-	 * share a batch, so every outcome contributes regardless of finish order.
-	 * Completed batches are applied by start order; failed outcomes only close
-	 * their pending call.
+	 * Complete an inspected call. AgentRuntime finishes every tool in an
+	 * iteration before starting the next iteration, so iteration plus signature
+	 * is the complete parallel-batch identity.
 	 */
 	observeOutcome(
 		call: LoopDetectionCall,
 		outcome: { successful: boolean; output?: unknown },
 	): void {
-		const batchId =
-			call.id === undefined
-				? this.anonymousPendingBatchId
-				: this.pendingCalls.get(call.id);
-		if (call.id !== undefined) {
-			this.pendingCalls.delete(call.id);
-		} else {
-			this.anonymousPendingBatchId = undefined;
-		}
-		if (batchId === undefined) return;
+		const key = callKey(call.name, toolCallSignature(call.input));
+		const batchId = JSON.stringify([call.iteration, key]);
 		const batch = this.pendingBatches.get(batchId);
 		if (batch === undefined) return;
 
-		const key = sequenceKey(call.name, toolCallSignature(call.input));
-		if (batch.key === key && outcome.successful) {
-			batch.outcomes.add(toolOutcomeFingerprint(outcome.output));
+		if (outcome.successful) {
+			batch.outcomes.add(toolCallSignature(outcome.output));
 		}
 		batch.pendingCount--;
 		if (batch.pendingCount > 0) return;
 
 		this.pendingBatches.delete(batchId);
-		if (this.currentSequence?.activeBatchId === batchId) {
-			this.currentSequence.activeBatchId = undefined;
-		}
 		if (batch.outcomes.size === 0) return;
 
-		const progress = this.signatureProgress.get(batch.key);
-		if (progress === undefined || batchId <= progress.latestOutcomeBatchId) {
-			return;
-		}
+		const signatureState = this.signatures.get(key);
+		if (signatureState === undefined) return;
 		const outputSignature = JSON.stringify([...batch.outcomes].sort());
 		if (
-			progress.lastOutputSignature !== undefined &&
-			progress.lastOutputSignature !== outputSignature
+			signatureState.lastOutputSignature !== undefined &&
+			signatureState.lastOutputSignature !== outputSignature
 		) {
-			progress.progressVersion++;
+			signatureState.hasProgress = true;
 		}
-		progress.latestOutcomeBatchId = batchId;
-		progress.lastOutputSignature = outputSignature;
+		signatureState.lastOutputSignature = outputSignature;
 	}
 
 	/**
@@ -392,35 +247,25 @@ export class LoopDetectionTracker {
 	 * available to a subsequent continuation.
 	 */
 	clearPendingCalls(): void {
-		this.pendingCalls.clear();
-		this.anonymousPendingBatchId = undefined;
 		this.pendingBatches.clear();
-		if (this.currentSequence !== undefined) {
-			this.currentSequence.activeBatchId = undefined;
-		}
 	}
 
 	reset(): void {
 		resetLoopDetectionState(this.state);
-		this.currentSequence = undefined;
-		this.nextBatchId = 1;
-		this.pendingCalls.clear();
-		this.anonymousPendingBatchId = undefined;
 		this.pendingBatches.clear();
-		this.signatureProgress.clear();
+		this.signatures.clear();
 	}
 
-	private getProgress(key: string): SignatureProgressState {
-		let progress = this.signatureProgress.get(key);
-		if (progress === undefined) {
-			progress = {
+	private getSignature(key: string): SignatureState {
+		let state = this.signatures.get(key);
+		if (state === undefined) {
+			state = {
 				totalBatchCount: 0,
-				latestOutcomeBatchId: 0,
-				progressVersion: 0,
+				hasProgress: false,
 			};
-			this.signatureProgress.set(key, progress);
+			this.signatures.set(key, state);
 		}
-		return progress;
+		return state;
 	}
 
 	private hard(message: string): LoopDetectionVerdict {

--- a/sdk/packages/core/src/runtime/safety/loop-detection.ts
+++ b/sdk/packages/core/src/runtime/safety/loop-detection.ts
@@ -61,7 +61,9 @@ function toolOutputSignature(output: unknown): string {
 	const type =
 		output === null ? "null" : Array.isArray(output) ? "array" : typeof output;
 	try {
-		return `${type}:${JSON.stringify(sortKeys(output))}`;
+		const serialized = JSON.stringify(output);
+		if (serialized === undefined) return `${type}:undefined`;
+		return `${type}:${JSON.stringify(sortKeys(JSON.parse(serialized)))}`;
 	} catch {
 		return `${type}:${String(output)}`;
 	}

--- a/sdk/packages/core/src/runtime/safety/loop-detection.ts
+++ b/sdk/packages/core/src/runtime/safety/loop-detection.ts
@@ -123,14 +123,41 @@ function callKey(toolName: string, toolSignature: string): string {
 	return JSON.stringify([toolName, toolSignature]);
 }
 
+function progressStep(signature: string): number | undefined {
+	const percent = signature.match(/\b(\d+(?:\.\d+)?)\s*%/);
+	if (percent) {
+		const value = Number(percent[1]);
+		return value <= 100 ? Math.floor(value) : undefined;
+	}
+
+	const named = signature.match(
+		/"(?:progress|percent|percentage|percentComplete)"\s*:\s*(\d+(?:\.\d+)?)/i,
+	);
+	if (named) {
+		const value = Number(named[1]);
+		const percentage = value <= 1 ? value * 100 : value;
+		return percentage <= 100 ? Math.floor(percentage) : undefined;
+	}
+
+	const ratio = signature.match(/\b(\d+)\s*\/\s*(\d+)\b/);
+	if (!ratio) return undefined;
+	const current = Number(ratio[1]);
+	const total = Number(ratio[2]);
+	return total > 0 && current <= total
+		? Math.floor((current / total) * 100)
+		: undefined;
+}
+
 interface ToolBatch {
 	pendingCount: number;
 	outcomes: Set<string>;
+	highestProgressStep?: number;
 }
 
 interface SignatureState {
 	totalBatchCount: number;
 	lastOutputSignature?: string;
+	highestProgressStep?: number;
 	hasProgress: boolean;
 }
 
@@ -221,7 +248,16 @@ export class LoopDetectionTracker {
 		if (batch === undefined) return;
 
 		if (outcome.successful) {
-			batch.outcomes.add(toolCallSignature(outcome.output));
+			const outputSignature = toolCallSignature(outcome.output);
+			batch.outcomes.add(outputSignature);
+			const step = progressStep(outputSignature);
+			if (
+				step !== undefined &&
+				(batch.highestProgressStep === undefined ||
+					step > batch.highestProgressStep)
+			) {
+				batch.highestProgressStep = step;
+			}
 		}
 		batch.pendingCount--;
 		if (batch.pendingCount > 0) return;
@@ -237,6 +273,14 @@ export class LoopDetectionTracker {
 			signatureState.lastOutputSignature !== outputSignature
 		) {
 			signatureState.hasProgress = true;
+		}
+		if (
+			batch.highestProgressStep !== undefined &&
+			(signatureState.highestProgressStep === undefined ||
+				batch.highestProgressStep > signatureState.highestProgressStep)
+		) {
+			signatureState.highestProgressStep = batch.highestProgressStep;
+			signatureState.totalBatchCount = 0;
 		}
 		signatureState.lastOutputSignature = outputSignature;
 	}

--- a/sdk/packages/core/src/runtime/safety/loop-detection.ts
+++ b/sdk/packages/core/src/runtime/safety/loop-detection.ts
@@ -130,6 +130,9 @@ const DEFAULT_CONFIG: LoopDetectionConfig = {
 // Changed output may be real progress or volatile noise. The absolute ceiling
 // keeps either case bounded without guessing the meaning of arbitrary output.
 const ABSOLUTE_LIMIT_MULTIPLIER = 4;
+// Progress is normalized to the integer range 0..100. Permit the same bounded
+// number of renewals even when a multi-phase operation restarts at zero.
+const MAX_PROGRESS_CHANGES = 101;
 
 function callKey(toolName: string, toolSignature: string): string {
 	return JSON.stringify([toolName, toolSignature]);
@@ -210,7 +213,8 @@ interface ToolBatch {
 interface SignatureState {
 	totalBatchCount: number;
 	lastOutputSignature?: string;
-	highestProgressStep?: number;
+	lastProgressStep?: number;
+	progressChangeCount: number;
 	hasProgress: boolean;
 }
 
@@ -343,6 +347,7 @@ export class LoopDetectionTracker {
 		if (state === undefined) {
 			state = {
 				totalBatchCount: 0,
+				progressChangeCount: 0,
 				hasProgress: false,
 			};
 			this.signatures.set(key, state);
@@ -373,10 +378,11 @@ export class LoopDetectionTracker {
 		}
 		if (
 			batch.highestProgressStep !== undefined &&
-			(signatureState.highestProgressStep === undefined ||
-				batch.highestProgressStep > signatureState.highestProgressStep)
+			batch.highestProgressStep !== signatureState.lastProgressStep &&
+			signatureState.progressChangeCount < MAX_PROGRESS_CHANGES
 		) {
-			signatureState.highestProgressStep = batch.highestProgressStep;
+			signatureState.lastProgressStep = batch.highestProgressStep;
+			signatureState.progressChangeCount++;
 			signatureState.totalBatchCount = 0;
 		}
 		signatureState.lastOutputSignature = outputSignature;

--- a/sdk/packages/core/src/runtime/safety/loop-detection.ts
+++ b/sdk/packages/core/src/runtime/safety/loop-detection.ts
@@ -121,36 +121,9 @@ const DEFAULT_CONFIG: LoopDetectionConfig = {
 // forever, while allowing several normal polling windows to complete.
 const MAX_PROGRESS_WINDOWS = 4;
 
-const VOLATILE_OUTPUT_KEYS = new Set([
-	"correlationid",
-	"checkedat",
-	"createdat",
-	"duration",
-	"durationms",
-	"elapsed",
-	"elapsedms",
-	"endedat",
-	"eventid",
-	"finishedat",
-	"lastseenat",
-	"polledat",
-	"requestid",
-	"spanid",
-	"startedat",
-	"time",
-	"timestamp",
-	"traceid",
-	"updatedat",
-]);
-
-const LOG_OUTPUT_KEYS = new Set([
-	"log",
-	"logs",
-	"logtail",
-	"stderr",
-	"stdout",
-	"tail",
-]);
+const VOLATILE_OUTPUT_KEY =
+	/^(?:correlationid|checkedat|createdat|duration(?:ms)?|elapsed(?:ms)?|endedat|eventid|finishedat|lastseenat|polledat|requestid|spanid|startedat|time|timestamp|traceid|updatedat)$/;
+const LOG_OUTPUT_KEY = /^(?:log|logs|logtail|stderr|stdout|tail)$/;
 
 const PROGRESS_TEXT_PATTERN =
 	/\b(?:complete(?:d)?|done|failed|phase|progress|queued|running|stage|state|status|succeeded|success)\b|\b\d+(?:\.\d+)?%|\b\d+\s*\/\s*\d+\b/i;
@@ -160,7 +133,7 @@ function compactOutputKey(key: string): string {
 }
 
 function normalizeOutputText(value: string, logLike: boolean): string {
-	const lines = value
+	const normalized = value
 		.replaceAll(
 			/\b(?:correlation|event|request|span|trace)[-_ ]?id\s*[:=]\s*["']?[a-z0-9._:/-]+/gi,
 			"<volatile-id>",
@@ -180,62 +153,50 @@ function normalizeOutputText(value: string, logLike: boolean): string {
 		.replaceAll(
 			/\b(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:\.\d+)?\b/g,
 			"<volatile-time>",
-		)
+		);
+	const lines = normalized
 		.split(/\r?\n/)
 		.map((line) => line.trim().replaceAll(/\s+/g, " "))
 		.filter(Boolean);
 
 	const uniqueLines = [...new Set(lines)];
-	if (!logLike) {
-		return uniqueLines.join("\n");
-	}
-
-	const progressLines = uniqueLines.filter((line) =>
-		PROGRESS_TEXT_PATTERN.test(line),
+	if (!logLike) return uniqueLines.join("\n");
+	return (
+		uniqueLines.filter((line) => PROGRESS_TEXT_PATTERN.test(line)).join("\n") ||
+		"<log-output>"
 	);
-	if (progressLines.length === 0) {
-		return "<log-output>";
-	}
-	return [...new Set(progressLines)].join("\n");
 }
 
 function normalizeToolOutcome(value: unknown, parentKey?: string): unknown {
 	if (typeof value === "string") {
-		const compactParentKey =
-			parentKey === undefined ? undefined : compactOutputKey(parentKey);
 		return normalizeOutputText(
 			value,
-			compactParentKey !== undefined && LOG_OUTPUT_KEYS.has(compactParentKey),
+			parentKey !== undefined &&
+				LOG_OUTPUT_KEY.test(compactOutputKey(parentKey)),
 		);
 	}
-	if (value == null || typeof value !== "object") {
-		return value;
-	}
+	if (value == null || typeof value !== "object") return value;
 	if (Array.isArray(value)) {
 		const normalizedEntries = value.map((entry) =>
 			normalizeToolOutcome(entry, parentKey),
 		);
-		const compactParentKey =
-			parentKey === undefined ? undefined : compactOutputKey(parentKey);
 		if (
-			compactParentKey !== undefined &&
-			LOG_OUTPUT_KEYS.has(compactParentKey)
+			parentKey !== undefined &&
+			LOG_OUTPUT_KEY.test(compactOutputKey(parentKey))
 		) {
-			return [
-				...new Set(
-					normalizedEntries.map((entry) => JSON.stringify(entry) ?? "null"),
-				),
-			].sort();
+			const progressEntries = normalizedEntries
+				.map((entry) => JSON.stringify(entry) ?? "null")
+				.filter((entry) => PROGRESS_TEXT_PATTERN.test(entry));
+			return progressEntries.length === 0
+				? ["<log-output>"]
+				: [...new Set(progressEntries)].sort();
 		}
 		return normalizedEntries;
 	}
 
 	const normalized: Record<string, unknown> = {};
 	for (const key of Object.keys(value as Record<string, unknown>).sort()) {
-		const compactKey = compactOutputKey(key);
-		if (VOLATILE_OUTPUT_KEYS.has(compactKey)) {
-			continue;
-		}
+		if (VOLATILE_OUTPUT_KEY.test(compactOutputKey(key))) continue;
 		normalized[key] = normalizeToolOutcome(
 			(value as Record<string, unknown>)[key],
 			key,
@@ -244,21 +205,11 @@ function normalizeToolOutcome(value: unknown, parentKey?: string): unknown {
 	return normalized;
 }
 
-interface ToolOutcomeFingerprint {
-	signature: string;
-}
-
-function toolOutcomeFingerprint(output: unknown): ToolOutcomeFingerprint {
+function toolOutcomeFingerprint(output: unknown): string {
 	try {
-		const normalized = normalizeToolOutcome(output);
-		return {
-			signature: JSON.stringify(normalized) ?? "undefined",
-		};
+		return JSON.stringify(normalizeToolOutcome(output)) ?? "undefined";
 	} catch {
-		const normalized = normalizeOutputText(String(output), false);
-		return {
-			signature: normalized,
-		};
+		return normalizeOutputText(String(output), false);
 	}
 }
 
@@ -266,11 +217,10 @@ function sequenceKey(toolName: string, toolSignature: string): string {
 	return JSON.stringify([toolName, toolSignature]);
 }
 
-interface InspectedCall {
-	batchId: number;
-	generation: number;
-	toolName: string;
-	toolSignature: string;
+interface PendingBatch {
+	key: string;
+	pendingCount: number;
+	outcomes: Set<string>;
 }
 
 interface SignatureProgressState {
@@ -278,6 +228,12 @@ interface SignatureProgressState {
 	latestOutcomeBatchId: number;
 	lastOutputSignature?: string;
 	progressVersion: number;
+}
+
+interface ActiveSequence {
+	key: string;
+	observedProgressVersion: number;
+	activeBatchId?: number;
 }
 
 /**
@@ -290,19 +246,11 @@ interface SignatureProgressState {
 export class LoopDetectionTracker {
 	private readonly config: LoopDetectionConfig;
 	private readonly state: LoopDetectionState = createLoopDetectionState();
-	private currentSequence:
-		| {
-				generation: number;
-				toolName: string;
-				toolSignature: string;
-				observedProgressVersion: number;
-		  }
-		| undefined;
-	private nextGeneration = 1;
+	private currentSequence: ActiveSequence | undefined;
 	private nextBatchId = 1;
-	private readonly pendingCalls = new Map<string, InspectedCall>();
-	private anonymousPendingCall: InspectedCall | undefined;
-	private readonly batchOutcomes = new Map<number, ToolOutcomeFingerprint[]>();
+	private readonly pendingCalls = new Map<string, number>();
+	private anonymousPendingBatchId: number | undefined;
+	private readonly pendingBatches = new Map<number, PendingBatch>();
 	private readonly signatureProgress = new Map<
 		string,
 		SignatureProgressState
@@ -317,72 +265,51 @@ export class LoopDetectionTracker {
 
 	inspect(call: LoopDetectionCall): LoopDetectionVerdict {
 		const signature = toolCallSignature(call.input);
-		const progressKey = sequenceKey(call.name, signature);
-		let progress = this.signatureProgress.get(progressKey);
-		if (progress === undefined) {
-			progress = {
-				totalBatchCount: 0,
-				latestOutcomeBatchId: 0,
-				progressVersion: 0,
-			};
-			this.signatureProgress.set(progressKey, progress);
-		}
+		const key = sequenceKey(call.name, signature);
+		const progress = this.getProgress(key);
 		let sequence = this.currentSequence;
-		if (
-			sequence === undefined ||
-			sequence.toolName !== call.name ||
-			sequence.toolSignature !== signature
-		) {
+		if (sequence?.key !== key) {
 			sequence = {
-				generation: this.nextGeneration++,
-				toolName: call.name,
-				toolSignature: signature,
+				key,
 				observedProgressVersion: progress.progressVersion,
 			};
 			this.currentSequence = sequence;
-			this.anonymousPendingCall = undefined;
 		} else if (sequence.observedProgressVersion !== progress.progressVersion) {
 			resetLoopDetectionState(this.state);
 			sequence.observedProgressVersion = progress.progressVersion;
 		}
 
-		const parallelCall =
-			call.id === undefined
-				? undefined
-				: [...this.pendingCalls.values()].find(
-						(pending) =>
-							pending.generation === sequence.generation &&
-							pending.toolName === call.name &&
-							pending.toolSignature === signature,
-					);
-		const inspected: InspectedCall = {
-			batchId: parallelCall?.batchId ?? this.nextBatchId++,
-			generation: sequence.generation,
-			toolName: call.name,
-			toolSignature: signature,
-		};
-		if (call.id !== undefined) {
-			this.pendingCalls.set(call.id, inspected);
-		} else {
-			this.anonymousPendingCall = inspected;
+		// Calls without ids cannot be correlated safely, so only identified calls
+		// join an unfinished batch from the current uninterrupted sequence.
+		let batchId = call.id === undefined ? undefined : sequence.activeBatchId;
+		let batch =
+			batchId === undefined ? undefined : this.pendingBatches.get(batchId);
+		const isNewBatch = batch === undefined;
+		if (batch === undefined) {
+			batchId = this.nextBatchId++;
+			batch = { key, pendingCount: 0, outcomes: new Set() };
+			this.pendingBatches.set(batchId, batch);
+			sequence.activeBatchId = batchId;
+			progress.totalBatchCount++;
 		}
-		const absoluteHardLimit = this.config.hardThreshold * MAX_PROGRESS_WINDOWS;
-		const pendingBatchCallCount =
-			[...this.pendingCalls.values()].filter(
-				(pending) => pending.batchId === inspected.batchId,
-			).length +
-			(this.anonymousPendingCall?.batchId === inspected.batchId ? 1 : 0);
-		if (parallelCall !== undefined) {
-			if (pendingBatchCallCount >= absoluteHardLimit) {
-				return {
-					kind: "hard",
-					message: `Detected ${pendingBatchCallCount} identical calls to \`${call.name}\` still pending in one batch; stopping because earlier calls did not complete.`,
-				};
-			}
-			return { kind: "ok" };
+		if (batchId === undefined) {
+			throw new Error("Loop detection batch was not initialized");
+		}
+		batch.pendingCount++;
+		if (call.id !== undefined) {
+			this.pendingCalls.set(call.id, batchId);
+		} else {
+			this.anonymousPendingBatchId = batchId;
 		}
 
-		progress.totalBatchCount++;
+		const absoluteHardLimit = this.config.hardThreshold * MAX_PROGRESS_WINDOWS;
+		if (batch.pendingCount >= absoluteHardLimit) {
+			return this.hard(
+				`Detected ${batch.pendingCount} identical calls to \`${call.name}\` still pending in one batch; stopping because earlier calls did not complete.`,
+			);
+		}
+
+		if (!isNewBatch) return { kind: "ok" };
 		const result = checkRepeatedToolCall(
 			this.state,
 			call.name,
@@ -391,18 +318,13 @@ export class LoopDetectionTracker {
 		);
 		if (
 			result.hardEscalation ||
-			progress.totalBatchCount >= absoluteHardLimit ||
-			pendingBatchCallCount >= absoluteHardLimit
+			progress.totalBatchCount >= absoluteHardLimit
 		) {
-			return {
-				kind: "hard",
-				message:
-					pendingBatchCallCount >= absoluteHardLimit
-						? `Detected ${pendingBatchCallCount} identical calls to \`${call.name}\` still pending in one batch; stopping because earlier calls did not complete.`
-						: progress.totalBatchCount >= absoluteHardLimit
-							? `Detected ${progress.totalBatchCount} repeated batches of identical calls to \`${call.name}\` despite changing results; stopping to avoid a loop.`
-							: `Detected ${this.state.consecutiveIdenticalCount} consecutive identical calls to \`${call.name}\`; stopping to avoid a loop.`,
-			};
+			return this.hard(
+				progress.totalBatchCount >= absoluteHardLimit
+					? `Detected ${progress.totalBatchCount} repeated batches of identical calls to \`${call.name}\` despite changing results; stopping to avoid a loop.`
+					: `Detected ${this.state.consecutiveIdenticalCount} consecutive identical calls to \`${call.name}\`; stopping to avoid a loop.`,
+			);
 		}
 		if (result.softWarning) {
 			return {
@@ -414,80 +336,53 @@ export class LoopDetectionTracker {
 	}
 
 	/**
-	 * Complete an inspected call. Parallel calls in the same generation share a
-	 * batch, so every outcome contributes regardless of finish order. Completed
-	 * batches are applied by start order; a late older batch cannot masquerade as
-	 * fresh progress. Failed outcomes only close their pending call.
+	 * Complete an inspected call. Parallel calls in one uninterrupted sequence
+	 * share a batch, so every outcome contributes regardless of finish order.
+	 * Completed batches are applied by start order; failed outcomes only close
+	 * their pending call.
 	 */
 	observeOutcome(
 		call: LoopDetectionCall,
 		outcome: { successful: boolean; output?: unknown },
 	): void {
-		const toolSignature = toolCallSignature(call.input);
-		const inspected =
+		const batchId =
 			call.id === undefined
-				? this.anonymousPendingCall
+				? this.anonymousPendingBatchId
 				: this.pendingCalls.get(call.id);
 		if (call.id !== undefined) {
 			this.pendingCalls.delete(call.id);
 		} else {
-			this.anonymousPendingCall = undefined;
+			this.anonymousPendingBatchId = undefined;
 		}
-		const isInspectedCall =
-			inspected !== undefined &&
-			inspected.toolName === call.name &&
-			inspected.toolSignature === toolSignature;
-		if (!isInspectedCall) {
-			if (
-				inspected !== undefined &&
-				![...this.pendingCalls.values()].some(
-					(pending) => pending.batchId === inspected.batchId,
-				) &&
-				this.anonymousPendingCall?.batchId !== inspected.batchId
-			) {
-				this.batchOutcomes.delete(inspected.batchId);
-			}
-			return;
-		}
+		if (batchId === undefined) return;
+		const batch = this.pendingBatches.get(batchId);
+		if (batch === undefined) return;
 
-		if (outcome.successful) {
-			const outcomes = this.batchOutcomes.get(inspected.batchId) ?? [];
-			outcomes.push(toolOutcomeFingerprint(outcome.output));
-			this.batchOutcomes.set(inspected.batchId, outcomes);
+		const key = sequenceKey(call.name, toolCallSignature(call.input));
+		if (batch.key === key && outcome.successful) {
+			batch.outcomes.add(toolOutcomeFingerprint(outcome.output));
 		}
-		const hasPendingBatchCall =
-			[...this.pendingCalls.values()].some(
-				(pending) => pending.batchId === inspected.batchId,
-			) || this.anonymousPendingCall?.batchId === inspected.batchId;
-		if (hasPendingBatchCall) {
-			return;
-		}
+		batch.pendingCount--;
+		if (batch.pendingCount > 0) return;
 
-		const outcomes = this.batchOutcomes.get(inspected.batchId) ?? [];
-		this.batchOutcomes.delete(inspected.batchId);
-		if (outcomes.length === 0) {
-			return;
+		this.pendingBatches.delete(batchId);
+		if (this.currentSequence?.activeBatchId === batchId) {
+			this.currentSequence.activeBatchId = undefined;
 		}
-		const outputSignature = JSON.stringify(
-			[...new Set(outcomes.map((entry) => entry.signature))].sort(),
-		);
-		const progress = this.signatureProgress.get(
-			sequenceKey(call.name, toolSignature),
-		);
-		if (
-			progress === undefined ||
-			inspected.batchId <= progress.latestOutcomeBatchId
-		) {
-			return;
-		}
+		if (batch.outcomes.size === 0) return;
 
+		const progress = this.signatureProgress.get(batch.key);
+		if (progress === undefined || batchId <= progress.latestOutcomeBatchId) {
+			return;
+		}
+		const outputSignature = JSON.stringify([...batch.outcomes].sort());
 		if (
 			progress.lastOutputSignature !== undefined &&
 			progress.lastOutputSignature !== outputSignature
 		) {
 			progress.progressVersion++;
 		}
-		progress.latestOutcomeBatchId = inspected.batchId;
+		progress.latestOutcomeBatchId = batchId;
 		progress.lastOutputSignature = outputSignature;
 	}
 
@@ -498,8 +393,11 @@ export class LoopDetectionTracker {
 	 */
 	clearPendingCalls(): void {
 		this.pendingCalls.clear();
-		this.anonymousPendingCall = undefined;
-		this.batchOutcomes.clear();
+		this.anonymousPendingBatchId = undefined;
+		this.pendingBatches.clear();
+		if (this.currentSequence !== undefined) {
+			this.currentSequence.activeBatchId = undefined;
+		}
 	}
 
 	reset(): void {
@@ -507,8 +405,25 @@ export class LoopDetectionTracker {
 		this.currentSequence = undefined;
 		this.nextBatchId = 1;
 		this.pendingCalls.clear();
-		this.anonymousPendingCall = undefined;
-		this.batchOutcomes.clear();
+		this.anonymousPendingBatchId = undefined;
+		this.pendingBatches.clear();
 		this.signatureProgress.clear();
+	}
+
+	private getProgress(key: string): SignatureProgressState {
+		let progress = this.signatureProgress.get(key);
+		if (progress === undefined) {
+			progress = {
+				totalBatchCount: 0,
+				latestOutcomeBatchId: 0,
+				progressVersion: 0,
+			};
+			this.signatureProgress.set(key, progress);
+		}
+		return progress;
+	}
+
+	private hard(message: string): LoopDetectionVerdict {
+		return { kind: "hard", message };
 	}
 }

--- a/sdk/packages/core/src/runtime/safety/loop-detection.ts
+++ b/sdk/packages/core/src/runtime/safety/loop-detection.ts
@@ -6,9 +6,9 @@
  *
  * The pure helpers (`createLoopDetectionState`, `resetLoopDetectionState`,
  * `toolCallSignature`, `checkRepeatedToolCall`) are ported verbatim. The
- * `LoopDetectionTracker` class is a thin wrapper that owns a
- * `LoopDetectionState` and exposes the `inspect()` / `reset()` surface that
- * `SessionRuntime` installs as a `beforeTool` hook per §3.2.3.
+ * `LoopDetectionTracker` owns the repeated-call state, correlates parallel
+ * outcomes, and distinguishes semantic result progress from volatile output
+ * before `SessionRuntime` decides whether to warn or abort.
  */
 
 import type { LoopDetectionConfig } from "@cline/shared";
@@ -116,6 +116,223 @@ const DEFAULT_CONFIG: LoopDetectionConfig = {
 	hardThreshold: 5,
 };
 
+// Output comparison is necessarily heuristic for arbitrary tools. Keep an
+// absolute ceiling so even unrecognized volatile changes cannot grant progress
+// forever, while allowing several normal polling windows to complete.
+const MAX_PROGRESS_WINDOWS = 4;
+
+const VOLATILE_OUTPUT_KEYS = new Set([
+	"correlationid",
+	"checkedat",
+	"createdat",
+	"duration",
+	"durationms",
+	"elapsed",
+	"elapsedms",
+	"endedat",
+	"eventid",
+	"finishedat",
+	"lastseenat",
+	"polledat",
+	"requestid",
+	"spanid",
+	"startedat",
+	"time",
+	"timestamp",
+	"traceid",
+	"updatedat",
+]);
+
+const LOG_OUTPUT_KEYS = new Set([
+	"log",
+	"logs",
+	"logtail",
+	"stderr",
+	"stdout",
+	"tail",
+]);
+
+const PROGRESS_OUTPUT_KEYS = new Set([
+	"complete",
+	"completed",
+	"current",
+	"done",
+	"percent",
+	"percentage",
+	"phase",
+	"progress",
+	"stage",
+	"state",
+	"status",
+	"success",
+	"succeeded",
+	"total",
+]);
+
+const PROGRESS_TEXT_PATTERN =
+	/\b(?:complete(?:d)?|done|failed|phase|progress|queued|running|stage|state|status|succeeded|success)\b|\b\d+(?:\.\d+)?%|\b\d+\s*\/\s*\d+\b/i;
+const PROGRESS_TEXT_TOKEN_PATTERN =
+	/\b(?:complete(?:d)?|done|failed|phase|progress|queued|running|stage|state|status|succeeded|success)\b|\b\d+(?:\.\d+)?%|\b\d+\s*\/\s*\d+\b/gi;
+
+function compactOutputKey(key: string): string {
+	return key.replaceAll(/[^a-z0-9]/gi, "").toLowerCase();
+}
+
+function normalizeOutputText(value: string, logLike: boolean): string {
+	const lines = value
+		.replaceAll(
+			/\b(?:correlation|event|request|span|trace)[-_ ]?id\s*[:=]\s*["']?[a-z0-9._:/-]+/gi,
+			"<volatile-id>",
+		)
+		.replaceAll(
+			/\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/gi,
+			"<volatile-id>",
+		)
+		.replaceAll(
+			/\b(?:checked|created|elapsed|ended|finished|polled|started|time|timestamp|updated)(?:[-_ ]?at)?\s*[:=]\s*["']?(?:\d{10,13}|\d+(?:\.\d+)?(?:ms|s))/gi,
+			"<volatile-time>",
+		)
+		.replaceAll(
+			/\b\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?\b/g,
+			"<volatile-time>",
+		)
+		.replaceAll(
+			/\b(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:\.\d+)?\b/g,
+			"<volatile-time>",
+		)
+		.split(/\r?\n/)
+		.map((line) => line.trim().replaceAll(/\s+/g, " "))
+		.filter(Boolean);
+
+	const uniqueLines = [...new Set(lines)];
+	if (!logLike) {
+		return uniqueLines.join("\n");
+	}
+
+	const progressLines = uniqueLines.filter((line) =>
+		PROGRESS_TEXT_PATTERN.test(line),
+	);
+	if (progressLines.length === 0) {
+		return "<log-output>";
+	}
+	return [...new Set(progressLines)].join("\n");
+}
+
+function normalizeToolOutcome(value: unknown, parentKey?: string): unknown {
+	if (typeof value === "string") {
+		const compactParentKey =
+			parentKey === undefined ? undefined : compactOutputKey(parentKey);
+		return normalizeOutputText(
+			value,
+			compactParentKey !== undefined && LOG_OUTPUT_KEYS.has(compactParentKey),
+		);
+	}
+	if (value == null || typeof value !== "object") {
+		return value;
+	}
+	if (Array.isArray(value)) {
+		const normalizedEntries = value.map((entry) =>
+			normalizeToolOutcome(entry, parentKey),
+		);
+		const compactParentKey =
+			parentKey === undefined ? undefined : compactOutputKey(parentKey);
+		if (
+			compactParentKey !== undefined &&
+			LOG_OUTPUT_KEYS.has(compactParentKey)
+		) {
+			return [
+				...new Set(
+					normalizedEntries.map((entry) => JSON.stringify(entry) ?? "null"),
+				),
+			].sort();
+		}
+		return normalizedEntries;
+	}
+
+	const normalized: Record<string, unknown> = {};
+	for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+		const compactKey = compactOutputKey(key);
+		if (VOLATILE_OUTPUT_KEYS.has(compactKey)) {
+			continue;
+		}
+		normalized[key] = normalizeToolOutcome(
+			(value as Record<string, unknown>)[key],
+			key,
+		);
+	}
+	return normalized;
+}
+
+function explicitProgressValue(value: unknown, parentKey?: string): unknown {
+	if (typeof value === "string") {
+		const normalized = normalizeOutputText(value, false);
+		const tokens = [...normalized.matchAll(PROGRESS_TEXT_TOKEN_PATTERN)].map(
+			(match) => match[0].toLowerCase().replaceAll(/\s+/g, ""),
+		);
+		return tokens.length > 0 ? [...new Set(tokens)] : undefined;
+	}
+	if (value == null || typeof value !== "object") {
+		return parentKey !== undefined &&
+			PROGRESS_OUTPUT_KEYS.has(compactOutputKey(parentKey))
+			? value
+			: undefined;
+	}
+	if (Array.isArray(value)) {
+		const entries = value
+			.map((entry) => explicitProgressValue(entry, parentKey))
+			.filter((entry) => entry !== undefined);
+		if (entries.length === 0) {
+			return undefined;
+		}
+		return [
+			...new Set(entries.map((entry) => JSON.stringify(entry) ?? "null")),
+		].sort();
+	}
+
+	const progress: Record<string, unknown> = {};
+	for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+		const progressValue = PROGRESS_OUTPUT_KEYS.has(compactOutputKey(key))
+			? entry
+			: explicitProgressValue(entry, key);
+		if (progressValue !== undefined) {
+			progress[key] = progressValue;
+		}
+	}
+	return Object.keys(progress).length > 0 ? progress : undefined;
+}
+
+interface ToolOutcomeFingerprint {
+	signature: string;
+	progressSignature?: string;
+}
+
+function toolOutcomeFingerprint(output: unknown): ToolOutcomeFingerprint {
+	try {
+		const normalized = normalizeToolOutcome(output);
+		const progress = explicitProgressValue(normalized);
+		return {
+			signature: JSON.stringify(normalized) ?? "undefined",
+			progressSignature:
+				progress === undefined ? undefined : JSON.stringify(progress),
+		};
+	} catch {
+		const normalized = normalizeOutputText(String(output), false);
+		const progress = explicitProgressValue(normalized);
+		return {
+			signature: normalized,
+			progressSignature:
+				progress === undefined ? undefined : JSON.stringify(progress),
+		};
+	}
+}
+
+interface InspectedCall {
+	batchId: number;
+	generation: number;
+	toolName: string;
+	toolSignature: string;
+}
+
 /**
  * Per-session repeated-tool-call detector.
  *
@@ -126,14 +343,26 @@ const DEFAULT_CONFIG: LoopDetectionConfig = {
 export class LoopDetectionTracker {
 	private readonly config: LoopDetectionConfig;
 	private readonly state: LoopDetectionState = createLoopDetectionState();
-	private lastSuccessfulOutcome:
+	private currentSequence:
 		| {
+				generation: number;
 				toolName: string;
 				toolSignature: string;
-				outputSignature: string;
+				nextBatchId: number;
+				totalBatchCount: number;
 		  }
 		| undefined;
-	private latestInspectedCallId: string | undefined;
+	private nextGeneration = 1;
+	private readonly pendingCalls = new Map<string, InspectedCall>();
+	private anonymousPendingCall: InspectedCall | undefined;
+	private readonly batchOutcomes = new Map<number, ToolOutcomeFingerprint[]>();
+	private lastSuccessfulOutcome:
+		| {
+				generation: number;
+				outputSignature: string;
+				progressSignature?: string;
+		  }
+		| undefined;
 
 	constructor(config?: Partial<LoopDetectionConfig>) {
 		this.config = {
@@ -144,17 +373,64 @@ export class LoopDetectionTracker {
 
 	inspect(call: LoopDetectionCall): LoopDetectionVerdict {
 		const signature = toolCallSignature(call.input);
-		this.latestInspectedCallId = call.id;
+		let sequence = this.currentSequence;
+		if (
+			sequence === undefined ||
+			sequence.toolName !== call.name ||
+			sequence.toolSignature !== signature
+		) {
+			sequence = {
+				generation: this.nextGeneration++,
+				toolName: call.name,
+				toolSignature: signature,
+				nextBatchId: 1,
+				totalBatchCount: 0,
+			};
+			this.currentSequence = sequence;
+			this.pendingCalls.clear();
+			this.anonymousPendingCall = undefined;
+			this.batchOutcomes.clear();
+		}
+
+		const parallelCall =
+			call.id === undefined
+				? undefined
+				: [...this.pendingCalls.values()].find(
+						(pending) => pending.generation === sequence.generation,
+					);
+		const inspected: InspectedCall = {
+			batchId: parallelCall?.batchId ?? sequence.nextBatchId++,
+			generation: sequence.generation,
+			toolName: call.name,
+			toolSignature: signature,
+		};
+		if (call.id !== undefined) {
+			this.pendingCalls.set(call.id, inspected);
+		} else {
+			this.anonymousPendingCall = inspected;
+		}
+		if (parallelCall !== undefined) {
+			return { kind: "ok" };
+		}
+
+		sequence.totalBatchCount++;
 		const result = checkRepeatedToolCall(
 			this.state,
 			call.name,
 			signature,
 			this.config,
 		);
-		if (result.hardEscalation) {
+		const absoluteHardLimit = this.config.hardThreshold * MAX_PROGRESS_WINDOWS;
+		if (
+			result.hardEscalation ||
+			sequence.totalBatchCount >= absoluteHardLimit
+		) {
 			return {
 				kind: "hard",
-				message: `Detected ${this.state.consecutiveIdenticalCount} consecutive identical calls to \`${call.name}\`; stopping to avoid a loop.`,
+				message:
+					sequence.totalBatchCount >= absoluteHardLimit
+						? `Detected ${sequence.totalBatchCount} repeated batches of identical calls to \`${call.name}\` despite changing results; stopping to avoid a loop.`
+						: `Detected ${this.state.consecutiveIdenticalCount} consecutive identical calls to \`${call.name}\`; stopping to avoid a loop.`,
 			};
 		}
 		if (result.softWarning) {
@@ -167,42 +443,99 @@ export class LoopDetectionTracker {
 	}
 
 	/**
-	 * Record the result of a successful call so repeated status checks can be
-	 * distinguished from a stalled loop. When the same call produces different
-	 * output, it has observed progress and the consecutive-call counter resets.
-	 * Identical calls with identical output continue accumulating normally.
+	 * Complete an inspected call. Parallel calls in the same batch share a
+	 * generation, so every outcome can contribute progress regardless of finish
+	 * order. Failed outcomes only close their pending call and never reset loop
+	 * detection.
 	 */
-	observeSuccessfulOutcome(call: LoopDetectionCall, output: unknown): void {
+	observeOutcome(
+		call: LoopDetectionCall,
+		outcome: { successful: boolean; output?: unknown },
+	): void {
 		const toolSignature = toolCallSignature(call.input);
+		const inspected =
+			call.id === undefined
+				? this.anonymousPendingCall
+				: this.pendingCalls.get(call.id);
+		if (call.id !== undefined) {
+			this.pendingCalls.delete(call.id);
+		} else {
+			this.anonymousPendingCall = undefined;
+		}
 		const isCurrentCall =
-			this.state.lastToolName === call.name &&
-			this.state.lastToolSignature === toolSignature &&
-			(call.id === undefined || call.id === this.latestInspectedCallId);
+			inspected !== undefined &&
+			inspected.generation === this.currentSequence?.generation &&
+			inspected.toolName === call.name &&
+			inspected.toolSignature === toolSignature;
 		if (!isCurrentCall) {
 			return;
 		}
 
-		const outputSignature = toolCallSignature(output);
+		if (outcome.successful) {
+			const outcomes = this.batchOutcomes.get(inspected.batchId) ?? [];
+			outcomes.push(toolOutcomeFingerprint(outcome.output));
+			this.batchOutcomes.set(inspected.batchId, outcomes);
+		}
+		const hasPendingBatchCall =
+			[...this.pendingCalls.values()].some(
+				(pending) =>
+					pending.generation === inspected.generation &&
+					pending.batchId === inspected.batchId,
+			) ||
+			(this.anonymousPendingCall?.generation === inspected.generation &&
+				this.anonymousPendingCall.batchId === inspected.batchId);
+		if (hasPendingBatchCall) {
+			return;
+		}
+
+		const outcomes = this.batchOutcomes.get(inspected.batchId) ?? [];
+		this.batchOutcomes.delete(inspected.batchId);
+		if (outcomes.length === 0) {
+			return;
+		}
+		const outputSignature = JSON.stringify(
+			[...new Set(outcomes.map((entry) => entry.signature))].sort(),
+		);
+		const progressSignatures = [
+			...new Set(
+				outcomes
+					.map((entry) => entry.progressSignature)
+					.filter((entry): entry is string => entry !== undefined),
+			),
+		].sort();
+		const progressSignature =
+			progressSignatures.length === 0
+				? undefined
+				: JSON.stringify(progressSignatures);
 		const previous = this.lastSuccessfulOutcome;
 
 		if (
-			previous?.toolName === call.name &&
-			previous.toolSignature === toolSignature &&
+			previous?.generation === inspected.generation &&
 			previous.outputSignature !== outputSignature
 		) {
 			resetLoopDetectionState(this.state);
+			if (
+				progressSignature !== undefined &&
+				progressSignature !== previous.progressSignature &&
+				this.currentSequence
+			) {
+				this.currentSequence.totalBatchCount = 0;
+			}
 		}
 
 		this.lastSuccessfulOutcome = {
-			toolName: call.name,
-			toolSignature,
+			generation: inspected.generation,
 			outputSignature,
+			progressSignature,
 		};
 	}
 
 	reset(): void {
 		resetLoopDetectionState(this.state);
+		this.currentSequence = undefined;
+		this.pendingCalls.clear();
+		this.anonymousPendingCall = undefined;
+		this.batchOutcomes.clear();
 		this.lastSuccessfulOutcome = undefined;
-		this.latestInspectedCallId = undefined;
 	}
 }

--- a/sdk/packages/core/src/runtime/safety/loop-detection.ts
+++ b/sdk/packages/core/src/runtime/safety/loop-detection.ts
@@ -149,6 +149,8 @@ function progressStep(signature: string): number | undefined {
 }
 
 interface ToolBatch {
+	iteration: number;
+	key: string;
 	pendingCount: number;
 	outcomes: Set<string>;
 	highestProgressStep?: number;
@@ -181,6 +183,7 @@ export class LoopDetectionTracker {
 	}
 
 	inspect(call: LoopDetectionCall): LoopDetectionVerdict {
+		this.finalizeCompletedBatchesBefore(call.iteration);
 		const signature = toolCallSignature(call.input);
 		const key = callKey(call.name, signature);
 		const signatureState = this.getSignature(key);
@@ -193,9 +196,13 @@ export class LoopDetectionTracker {
 		let batch = this.pendingBatches.get(batchId);
 		const isNewBatch = batch === undefined;
 		if (batch === undefined) {
-			batch = { pendingCount: 0, outcomes: new Set() };
+			batch = {
+				iteration: call.iteration,
+				key,
+				pendingCount: 0,
+				outcomes: new Set(),
+			};
 			this.pendingBatches.set(batchId, batch);
-			signatureState.totalBatchCount++;
 		}
 		batch.pendingCount++;
 
@@ -208,19 +215,17 @@ export class LoopDetectionTracker {
 		}
 
 		if (!isNewBatch) return { kind: "ok" };
+		const totalBatchCount = signatureState.totalBatchCount + 1;
 		const result = checkRepeatedToolCall(
 			this.state,
 			call.name,
 			signature,
 			this.config,
 		);
-		if (
-			result.hardEscalation ||
-			signatureState.totalBatchCount >= absoluteHardLimit
-		) {
+		if (result.hardEscalation || totalBatchCount >= absoluteHardLimit) {
 			return this.hard(
-				signatureState.totalBatchCount >= absoluteHardLimit
-					? `Detected ${signatureState.totalBatchCount} repeated batches of identical calls to \`${call.name}\` despite changing results; stopping to avoid a loop.`
+				totalBatchCount >= absoluteHardLimit
+					? `Detected ${totalBatchCount} repeated batches of identical calls to \`${call.name}\` despite changing results; stopping to avoid a loop.`
 					: `Detected ${this.state.consecutiveIdenticalCount} consecutive identical calls to \`${call.name}\`; stopping to avoid a loop.`,
 			);
 		}
@@ -259,38 +264,20 @@ export class LoopDetectionTracker {
 				batch.highestProgressStep = step;
 			}
 		}
-		batch.pendingCount--;
-		if (batch.pendingCount > 0) return;
-
-		this.pendingBatches.delete(batchId);
-		if (batch.outcomes.size === 0) return;
-
-		const signatureState = this.signatures.get(key);
-		if (signatureState === undefined) return;
-		const outputSignature = JSON.stringify([...batch.outcomes].sort());
-		if (
-			signatureState.lastOutputSignature !== undefined &&
-			signatureState.lastOutputSignature !== outputSignature
-		) {
-			signatureState.hasProgress = true;
-		}
-		if (
-			batch.highestProgressStep !== undefined &&
-			(signatureState.highestProgressStep === undefined ||
-				batch.highestProgressStep > signatureState.highestProgressStep)
-		) {
-			signatureState.highestProgressStep = batch.highestProgressStep;
-			signatureState.totalBatchCount = 0;
-		}
-		signatureState.lastOutputSignature = outputSignature;
+		batch.pendingCount = Math.max(0, batch.pendingCount - 1);
 	}
 
 	/**
-	 * Drop correlation state for calls that did not finish before their runtime
-	 * stopped. Completed outcome history and repeated-call counters remain
-	 * available to a subsequent continuation.
+	 * Finalize completed batches and drop calls that did not finish before their
+	 * runtime stopped. Unfinished batches never consume the completed-batch
+	 * fallback budget.
 	 */
 	clearPendingCalls(): void {
+		for (const batch of this.pendingBatches.values()) {
+			if (batch.pendingCount === 0) {
+				this.finalizeBatch(batch);
+			}
+		}
 		this.pendingBatches.clear();
 	}
 
@@ -310,6 +297,38 @@ export class LoopDetectionTracker {
 			this.signatures.set(key, state);
 		}
 		return state;
+	}
+
+	private finalizeCompletedBatchesBefore(iteration: number): void {
+		for (const [batchId, batch] of this.pendingBatches) {
+			if (batch.iteration === iteration || batch.pendingCount > 0) continue;
+			this.pendingBatches.delete(batchId);
+			this.finalizeBatch(batch);
+		}
+	}
+
+	private finalizeBatch(batch: ToolBatch): void {
+		const signatureState = this.signatures.get(batch.key);
+		if (signatureState === undefined) return;
+		signatureState.totalBatchCount++;
+		if (batch.outcomes.size === 0) return;
+
+		const outputSignature = JSON.stringify([...batch.outcomes].sort());
+		if (
+			signatureState.lastOutputSignature !== undefined &&
+			signatureState.lastOutputSignature !== outputSignature
+		) {
+			signatureState.hasProgress = true;
+		}
+		if (
+			batch.highestProgressStep !== undefined &&
+			(signatureState.highestProgressStep === undefined ||
+				batch.highestProgressStep > signatureState.highestProgressStep)
+		) {
+			signatureState.highestProgressStep = batch.highestProgressStep;
+			signatureState.totalBatchCount = 0;
+		}
+		signatureState.lastOutputSignature = outputSignature;
 	}
 
 	private hard(message: string): LoopDetectionVerdict {

--- a/sdk/packages/core/src/runtime/safety/loop-detection.ts
+++ b/sdk/packages/core/src/runtime/safety/loop-detection.ts
@@ -135,29 +135,68 @@ function callKey(toolName: string, toolSignature: string): string {
 	return JSON.stringify([toolName, toolSignature]);
 }
 
-function progressStep(signature: string): number | undefined {
-	const percent = signature.match(/\b(\d+(?:\.\d+)?)\s*%/);
-	if (percent) {
-		const value = Number(percent[1]);
-		return value <= 100 ? Math.floor(value) : undefined;
-	}
-
-	const named = signature.match(
-		/"(?:progress|percent|percentage|percentComplete)"\s*:\s*(\d+(?:\.\d+)?)/i,
-	);
-	if (named) {
-		const value = Number(named[1]);
+function explicitProgressStep(
+	value: unknown,
+	allowNumber = false,
+): number | undefined {
+	if (typeof value === "number") {
+		if (!allowNumber) return undefined;
 		const percentage = value <= 1 ? value * 100 : value;
+		return percentage >= 0 && percentage <= 100
+			? Math.floor(percentage)
+			: undefined;
+	}
+	if (typeof value !== "string") return undefined;
+
+	const percent = value.trim().match(/^(\d+(?:\.\d+)?)\s*%$/);
+	if (percent) {
+		const percentage = Number(percent[1]);
 		return percentage <= 100 ? Math.floor(percentage) : undefined;
 	}
 
-	const ratio = signature.match(/\b(\d+)\s*\/\s*(\d+)\b/);
+	const ratio = value.trim().match(/^(\d+)\s*\/\s*(\d+)$/);
 	if (!ratio) return undefined;
 	const current = Number(ratio[1]);
 	const total = Number(ratio[2]);
 	return total > 0 && current <= total
 		? Math.floor((current / total) * 100)
 		: undefined;
+}
+
+const PROGRESS_FIELDS = new Set([
+	"progress",
+	"percent",
+	"percentage",
+	"percentcomplete",
+]);
+
+function progressStep(output: unknown): number | undefined {
+	const direct = explicitProgressStep(output);
+	if (direct !== undefined) return direct;
+	if (output === null || typeof output !== "object") return undefined;
+
+	const seen = new WeakSet<object>();
+	const visit = (value: object): number | undefined => {
+		if (seen.has(value)) return undefined;
+		seen.add(value);
+		let highest: number | undefined;
+		for (const [key, candidate] of Object.entries(value)) {
+			const step = PROGRESS_FIELDS.has(key.toLowerCase())
+				? explicitProgressStep(candidate, true)
+				: candidate !== null && typeof candidate === "object"
+					? visit(candidate)
+					: undefined;
+			if (step !== undefined && (highest === undefined || step > highest)) {
+				highest = step;
+			}
+		}
+		return highest;
+	};
+	try {
+		return visit(output);
+	} catch {
+		return undefined;
+	}
 }
 
 interface ToolBatch {
@@ -267,7 +306,7 @@ export class LoopDetectionTracker {
 		if (outcome.successful) {
 			const outputSignature = toolOutputSignature(outcome.output);
 			batch.outcomes.add(outputSignature);
-			const step = progressStep(outputSignature);
+			const step = progressStep(outcome.output);
 			if (
 				step !== undefined &&
 				(batch.highestProgressStep === undefined ||

--- a/sdk/packages/core/src/runtime/safety/loop-detection.ts
+++ b/sdk/packages/core/src/runtime/safety/loop-detection.ts
@@ -494,6 +494,17 @@ export class LoopDetectionTracker {
 		};
 	}
 
+	/**
+	 * Drop correlation state for calls that did not finish before their runtime
+	 * stopped. Completed outcome history and repeated-call counters remain
+	 * available to a subsequent continuation.
+	 */
+	clearPendingCalls(): void {
+		this.pendingCalls.clear();
+		this.anonymousPendingCall = undefined;
+		this.batchOutcomes.clear();
+	}
+
 	reset(): void {
 		resetLoopDetectionState(this.state);
 		this.currentSequence = undefined;

--- a/sdk/packages/core/src/runtime/safety/loop-detection.ts
+++ b/sdk/packages/core/src/runtime/safety/loop-detection.ts
@@ -262,6 +262,10 @@ function toolOutcomeFingerprint(output: unknown): ToolOutcomeFingerprint {
 	}
 }
 
+function sequenceKey(toolName: string, toolSignature: string): string {
+	return JSON.stringify([toolName, toolSignature]);
+}
+
 interface InspectedCall {
 	batchId: number;
 	generation: number;
@@ -292,6 +296,7 @@ export class LoopDetectionTracker {
 	private readonly pendingCalls = new Map<string, InspectedCall>();
 	private anonymousPendingCall: InspectedCall | undefined;
 	private readonly batchOutcomes = new Map<number, ToolOutcomeFingerprint[]>();
+	private readonly deferredSuccessfulOutcomes = new Map<string, string>();
 	private lastSuccessfulOutcome:
 		| {
 				generation: number;
@@ -323,6 +328,18 @@ export class LoopDetectionTracker {
 			};
 			this.currentSequence = sequence;
 			startedNewSequence = true;
+			const deferredOutcome = this.deferredSuccessfulOutcomes.get(
+				sequenceKey(call.name, signature),
+			);
+			if (deferredOutcome !== undefined) {
+				this.lastSuccessfulOutcome = {
+					generation: sequence.generation,
+					outputSignature: deferredOutcome,
+				};
+				this.deferredSuccessfulOutcomes.delete(
+					sequenceKey(call.name, signature),
+				);
+			}
 			this.anonymousPendingCall = undefined;
 		}
 
@@ -412,13 +429,11 @@ export class LoopDetectionTracker {
 		} else {
 			this.anonymousPendingCall = undefined;
 		}
-		const isCurrentCall =
+		const isInspectedCall =
 			inspected !== undefined &&
-			this.currentSequence?.toolName === call.name &&
-			this.currentSequence.toolSignature === toolSignature &&
 			inspected.toolName === call.name &&
 			inspected.toolSignature === toolSignature;
-		if (!isCurrentCall) {
+		if (!isInspectedCall) {
 			if (
 				inspected !== undefined &&
 				![...this.pendingCalls.values()].some(
@@ -452,6 +467,16 @@ export class LoopDetectionTracker {
 		const outputSignature = JSON.stringify(
 			[...new Set(outcomes.map((entry) => entry.signature))].sort(),
 		);
+		const isCurrentSequence =
+			this.currentSequence?.toolName === call.name &&
+			this.currentSequence.toolSignature === toolSignature;
+		if (!isCurrentSequence) {
+			this.deferredSuccessfulOutcomes.set(
+				sequenceKey(call.name, toolSignature),
+				outputSignature,
+			);
+			return;
+		}
 		const previous = this.lastSuccessfulOutcome;
 		const currentGeneration = this.currentSequence?.generation;
 
@@ -476,6 +501,7 @@ export class LoopDetectionTracker {
 		this.pendingCalls.clear();
 		this.anonymousPendingCall = undefined;
 		this.batchOutcomes.clear();
+		this.deferredSuccessfulOutcomes.clear();
 		this.lastSuccessfulOutcome = undefined;
 	}
 }

--- a/sdk/packages/core/src/runtime/safety/loop-detection.ts
+++ b/sdk/packages/core/src/runtime/safety/loop-detection.ts
@@ -57,6 +57,16 @@ export function toolCallSignature(input: unknown): string {
 	}
 }
 
+function toolOutputSignature(output: unknown): string {
+	const type =
+		output === null ? "null" : Array.isArray(output) ? "array" : typeof output;
+	try {
+		return `${type}:${JSON.stringify(sortKeys(output))}`;
+	} catch {
+		return `${type}:${String(output)}`;
+	}
+}
+
 export interface LoopCheckResult {
 	softWarning: boolean;
 	hardEscalation: boolean;
@@ -253,7 +263,7 @@ export class LoopDetectionTracker {
 		if (batch === undefined) return;
 
 		if (outcome.successful) {
-			const outputSignature = toolCallSignature(outcome.output);
+			const outputSignature = toolOutputSignature(outcome.output);
 			batch.outcomes.add(outputSignature);
 			const step = progressStep(outputSignature);
 			if (

--- a/sdk/packages/core/src/runtime/safety/loop-detection.ts
+++ b/sdk/packages/core/src/runtime/safety/loop-detection.ts
@@ -273,6 +273,13 @@ interface InspectedCall {
 	toolSignature: string;
 }
 
+interface SignatureProgressState {
+	totalBatchCount: number;
+	latestOutcomeBatchId: number;
+	lastOutputSignature?: string;
+	progressVersion: number;
+}
+
 /**
  * Per-session repeated-tool-call detector.
  *
@@ -288,7 +295,7 @@ export class LoopDetectionTracker {
 				generation: number;
 				toolName: string;
 				toolSignature: string;
-				totalBatchCount: number;
+				observedProgressVersion: number;
 		  }
 		| undefined;
 	private nextGeneration = 1;
@@ -296,13 +303,10 @@ export class LoopDetectionTracker {
 	private readonly pendingCalls = new Map<string, InspectedCall>();
 	private anonymousPendingCall: InspectedCall | undefined;
 	private readonly batchOutcomes = new Map<number, ToolOutcomeFingerprint[]>();
-	private readonly deferredSuccessfulOutcomes = new Map<string, string>();
-	private lastSuccessfulOutcome:
-		| {
-				generation: number;
-				outputSignature: string;
-		  }
-		| undefined;
+	private readonly signatureProgress = new Map<
+		string,
+		SignatureProgressState
+	>();
 
 	constructor(config?: Partial<LoopDetectionConfig>) {
 		this.config = {
@@ -313,6 +317,16 @@ export class LoopDetectionTracker {
 
 	inspect(call: LoopDetectionCall): LoopDetectionVerdict {
 		const signature = toolCallSignature(call.input);
+		const progressKey = sequenceKey(call.name, signature);
+		let progress = this.signatureProgress.get(progressKey);
+		if (progress === undefined) {
+			progress = {
+				totalBatchCount: 0,
+				latestOutcomeBatchId: 0,
+				progressVersion: 0,
+			};
+			this.signatureProgress.set(progressKey, progress);
+		}
 		let sequence = this.currentSequence;
 		if (
 			sequence === undefined ||
@@ -323,22 +337,13 @@ export class LoopDetectionTracker {
 				generation: this.nextGeneration++,
 				toolName: call.name,
 				toolSignature: signature,
-				totalBatchCount: 0,
+				observedProgressVersion: progress.progressVersion,
 			};
 			this.currentSequence = sequence;
-			const deferredOutcome = this.deferredSuccessfulOutcomes.get(
-				sequenceKey(call.name, signature),
-			);
-			if (deferredOutcome !== undefined) {
-				this.lastSuccessfulOutcome = {
-					generation: sequence.generation,
-					outputSignature: deferredOutcome,
-				};
-				this.deferredSuccessfulOutcomes.delete(
-					sequenceKey(call.name, signature),
-				);
-			}
 			this.anonymousPendingCall = undefined;
+		} else if (sequence.observedProgressVersion !== progress.progressVersion) {
+			resetLoopDetectionState(this.state);
+			sequence.observedProgressVersion = progress.progressVersion;
 		}
 
 		const parallelCall =
@@ -377,7 +382,7 @@ export class LoopDetectionTracker {
 			return { kind: "ok" };
 		}
 
-		sequence.totalBatchCount++;
+		progress.totalBatchCount++;
 		const result = checkRepeatedToolCall(
 			this.state,
 			call.name,
@@ -386,7 +391,7 @@ export class LoopDetectionTracker {
 		);
 		if (
 			result.hardEscalation ||
-			sequence.totalBatchCount >= absoluteHardLimit ||
+			progress.totalBatchCount >= absoluteHardLimit ||
 			pendingBatchCallCount >= absoluteHardLimit
 		) {
 			return {
@@ -394,8 +399,8 @@ export class LoopDetectionTracker {
 				message:
 					pendingBatchCallCount >= absoluteHardLimit
 						? `Detected ${pendingBatchCallCount} identical calls to \`${call.name}\` still pending in one batch; stopping because earlier calls did not complete.`
-						: sequence.totalBatchCount >= absoluteHardLimit
-							? `Detected ${sequence.totalBatchCount} repeated batches of identical calls to \`${call.name}\` despite changing results; stopping to avoid a loop.`
+						: progress.totalBatchCount >= absoluteHardLimit
+							? `Detected ${progress.totalBatchCount} repeated batches of identical calls to \`${call.name}\` despite changing results; stopping to avoid a loop.`
 							: `Detected ${this.state.consecutiveIdenticalCount} consecutive identical calls to \`${call.name}\`; stopping to avoid a loop.`,
 			};
 		}
@@ -409,10 +414,10 @@ export class LoopDetectionTracker {
 	}
 
 	/**
-	 * Complete an inspected call. Parallel calls in the same batch can span a
-	 * temporarily interleaved tool sequence, so every still-relevant outcome can
-	 * contribute progress regardless of finish order. Failed outcomes only close
-	 * their pending call and never reset loop detection.
+	 * Complete an inspected call. Parallel calls in the same generation share a
+	 * batch, so every outcome contributes regardless of finish order. Completed
+	 * batches are applied by start order; a late older batch cannot masquerade as
+	 * fresh progress. Failed outcomes only close their pending call.
 	 */
 	observeOutcome(
 		call: LoopDetectionCall,
@@ -466,31 +471,24 @@ export class LoopDetectionTracker {
 		const outputSignature = JSON.stringify(
 			[...new Set(outcomes.map((entry) => entry.signature))].sort(),
 		);
-		const isCurrentSequence =
-			this.currentSequence?.toolName === call.name &&
-			this.currentSequence.toolSignature === toolSignature;
-		if (!isCurrentSequence) {
-			this.deferredSuccessfulOutcomes.set(
-				sequenceKey(call.name, toolSignature),
-				outputSignature,
-			);
+		const progress = this.signatureProgress.get(
+			sequenceKey(call.name, toolSignature),
+		);
+		if (
+			progress === undefined ||
+			inspected.batchId <= progress.latestOutcomeBatchId
+		) {
 			return;
 		}
-		const previous = this.lastSuccessfulOutcome;
-		const currentGeneration = this.currentSequence?.generation;
 
 		if (
-			previous !== undefined &&
-			previous.generation === currentGeneration &&
-			previous.outputSignature !== outputSignature
+			progress.lastOutputSignature !== undefined &&
+			progress.lastOutputSignature !== outputSignature
 		) {
-			resetLoopDetectionState(this.state);
+			progress.progressVersion++;
 		}
-
-		this.lastSuccessfulOutcome = {
-			generation: currentGeneration ?? inspected.generation,
-			outputSignature,
-		};
+		progress.latestOutcomeBatchId = inspected.batchId;
+		progress.lastOutputSignature = outputSignature;
 	}
 
 	/**
@@ -511,7 +509,6 @@ export class LoopDetectionTracker {
 		this.pendingCalls.clear();
 		this.anonymousPendingCall = undefined;
 		this.batchOutcomes.clear();
-		this.deferredSuccessfulOutcomes.clear();
-		this.lastSuccessfulOutcome = undefined;
+		this.signatureProgress.clear();
 	}
 }

--- a/sdk/packages/core/src/runtime/safety/loop-detection.ts
+++ b/sdk/packages/core/src/runtime/safety/loop-detection.ts
@@ -314,7 +314,6 @@ export class LoopDetectionTracker {
 	inspect(call: LoopDetectionCall): LoopDetectionVerdict {
 		const signature = toolCallSignature(call.input);
 		let sequence = this.currentSequence;
-		let startedNewSequence = false;
 		if (
 			sequence === undefined ||
 			sequence.toolName !== call.name ||
@@ -327,7 +326,6 @@ export class LoopDetectionTracker {
 				totalBatchCount: 0,
 			};
 			this.currentSequence = sequence;
-			startedNewSequence = true;
 			const deferredOutcome = this.deferredSuccessfulOutcomes.get(
 				sequenceKey(call.name, signature),
 			);
@@ -348,6 +346,7 @@ export class LoopDetectionTracker {
 				? undefined
 				: [...this.pendingCalls.values()].find(
 						(pending) =>
+							pending.generation === sequence.generation &&
 							pending.toolName === call.name &&
 							pending.toolSignature === signature,
 					);
@@ -368,7 +367,7 @@ export class LoopDetectionTracker {
 				(pending) => pending.batchId === inspected.batchId,
 			).length +
 			(this.anonymousPendingCall?.batchId === inspected.batchId ? 1 : 0);
-		if (parallelCall !== undefined && !startedNewSequence) {
+		if (parallelCall !== undefined) {
 			if (pendingBatchCallCount >= absoluteHardLimit) {
 				return {
 					kind: "hard",

--- a/sdk/packages/core/src/runtime/safety/loop-detection.ts
+++ b/sdk/packages/core/src/runtime/safety/loop-detection.ts
@@ -152,27 +152,8 @@ const LOG_OUTPUT_KEYS = new Set([
 	"tail",
 ]);
 
-const PROGRESS_OUTPUT_KEYS = new Set([
-	"complete",
-	"completed",
-	"current",
-	"done",
-	"percent",
-	"percentage",
-	"phase",
-	"progress",
-	"stage",
-	"state",
-	"status",
-	"success",
-	"succeeded",
-	"total",
-]);
-
 const PROGRESS_TEXT_PATTERN =
 	/\b(?:complete(?:d)?|done|failed|phase|progress|queued|running|stage|state|status|succeeded|success)\b|\b\d+(?:\.\d+)?%|\b\d+\s*\/\s*\d+\b/i;
-const PROGRESS_TEXT_TOKEN_PATTERN =
-	/\b(?:complete(?:d)?|done|failed|phase|progress|queued|running|stage|state|status|succeeded|success)\b|\b\d+(?:\.\d+)?%|\b\d+\s*\/\s*\d+\b/gi;
 
 function compactOutputKey(key: string): string {
 	return key.replaceAll(/[^a-z0-9]/gi, "").toLowerCase();
@@ -263,65 +244,20 @@ function normalizeToolOutcome(value: unknown, parentKey?: string): unknown {
 	return normalized;
 }
 
-function explicitProgressValue(value: unknown, parentKey?: string): unknown {
-	if (typeof value === "string") {
-		const normalized = normalizeOutputText(value, false);
-		const tokens = [...normalized.matchAll(PROGRESS_TEXT_TOKEN_PATTERN)].map(
-			(match) => match[0].toLowerCase().replaceAll(/\s+/g, ""),
-		);
-		return tokens.length > 0 ? [...new Set(tokens)] : undefined;
-	}
-	if (value == null || typeof value !== "object") {
-		return parentKey !== undefined &&
-			PROGRESS_OUTPUT_KEYS.has(compactOutputKey(parentKey))
-			? value
-			: undefined;
-	}
-	if (Array.isArray(value)) {
-		const entries = value
-			.map((entry) => explicitProgressValue(entry, parentKey))
-			.filter((entry) => entry !== undefined);
-		if (entries.length === 0) {
-			return undefined;
-		}
-		return [
-			...new Set(entries.map((entry) => JSON.stringify(entry) ?? "null")),
-		].sort();
-	}
-
-	const progress: Record<string, unknown> = {};
-	for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
-		const progressValue = PROGRESS_OUTPUT_KEYS.has(compactOutputKey(key))
-			? entry
-			: explicitProgressValue(entry, key);
-		if (progressValue !== undefined) {
-			progress[key] = progressValue;
-		}
-	}
-	return Object.keys(progress).length > 0 ? progress : undefined;
-}
-
 interface ToolOutcomeFingerprint {
 	signature: string;
-	progressSignature?: string;
 }
 
 function toolOutcomeFingerprint(output: unknown): ToolOutcomeFingerprint {
 	try {
 		const normalized = normalizeToolOutcome(output);
-		const progress = explicitProgressValue(normalized);
 		return {
 			signature: JSON.stringify(normalized) ?? "undefined",
-			progressSignature:
-				progress === undefined ? undefined : JSON.stringify(progress),
 		};
 	} catch {
 		const normalized = normalizeOutputText(String(output), false);
-		const progress = explicitProgressValue(normalized);
 		return {
 			signature: normalized,
-			progressSignature:
-				progress === undefined ? undefined : JSON.stringify(progress),
 		};
 	}
 }
@@ -348,11 +284,11 @@ export class LoopDetectionTracker {
 				generation: number;
 				toolName: string;
 				toolSignature: string;
-				nextBatchId: number;
 				totalBatchCount: number;
 		  }
 		| undefined;
 	private nextGeneration = 1;
+	private nextBatchId = 1;
 	private readonly pendingCalls = new Map<string, InspectedCall>();
 	private anonymousPendingCall: InspectedCall | undefined;
 	private readonly batchOutcomes = new Map<number, ToolOutcomeFingerprint[]>();
@@ -360,7 +296,6 @@ export class LoopDetectionTracker {
 		| {
 				generation: number;
 				outputSignature: string;
-				progressSignature?: string;
 		  }
 		| undefined;
 
@@ -374,6 +309,7 @@ export class LoopDetectionTracker {
 	inspect(call: LoopDetectionCall): LoopDetectionVerdict {
 		const signature = toolCallSignature(call.input);
 		let sequence = this.currentSequence;
+		let startedNewSequence = false;
 		if (
 			sequence === undefined ||
 			sequence.toolName !== call.name ||
@@ -383,23 +319,23 @@ export class LoopDetectionTracker {
 				generation: this.nextGeneration++,
 				toolName: call.name,
 				toolSignature: signature,
-				nextBatchId: 1,
 				totalBatchCount: 0,
 			};
 			this.currentSequence = sequence;
-			this.pendingCalls.clear();
+			startedNewSequence = true;
 			this.anonymousPendingCall = undefined;
-			this.batchOutcomes.clear();
 		}
 
 		const parallelCall =
 			call.id === undefined
 				? undefined
 				: [...this.pendingCalls.values()].find(
-						(pending) => pending.generation === sequence.generation,
+						(pending) =>
+							pending.toolName === call.name &&
+							pending.toolSignature === signature,
 					);
 		const inspected: InspectedCall = {
-			batchId: parallelCall?.batchId ?? sequence.nextBatchId++,
+			batchId: parallelCall?.batchId ?? this.nextBatchId++,
 			generation: sequence.generation,
 			toolName: call.name,
 			toolSignature: signature,
@@ -409,7 +345,19 @@ export class LoopDetectionTracker {
 		} else {
 			this.anonymousPendingCall = inspected;
 		}
-		if (parallelCall !== undefined) {
+		const absoluteHardLimit = this.config.hardThreshold * MAX_PROGRESS_WINDOWS;
+		const pendingBatchCallCount =
+			[...this.pendingCalls.values()].filter(
+				(pending) => pending.batchId === inspected.batchId,
+			).length +
+			(this.anonymousPendingCall?.batchId === inspected.batchId ? 1 : 0);
+		if (parallelCall !== undefined && !startedNewSequence) {
+			if (pendingBatchCallCount >= absoluteHardLimit) {
+				return {
+					kind: "hard",
+					message: `Detected ${pendingBatchCallCount} identical calls to \`${call.name}\` still pending in one batch; stopping because earlier calls did not complete.`,
+				};
+			}
 			return { kind: "ok" };
 		}
 
@@ -420,17 +368,19 @@ export class LoopDetectionTracker {
 			signature,
 			this.config,
 		);
-		const absoluteHardLimit = this.config.hardThreshold * MAX_PROGRESS_WINDOWS;
 		if (
 			result.hardEscalation ||
-			sequence.totalBatchCount >= absoluteHardLimit
+			sequence.totalBatchCount >= absoluteHardLimit ||
+			pendingBatchCallCount >= absoluteHardLimit
 		) {
 			return {
 				kind: "hard",
 				message:
-					sequence.totalBatchCount >= absoluteHardLimit
-						? `Detected ${sequence.totalBatchCount} repeated batches of identical calls to \`${call.name}\` despite changing results; stopping to avoid a loop.`
-						: `Detected ${this.state.consecutiveIdenticalCount} consecutive identical calls to \`${call.name}\`; stopping to avoid a loop.`,
+					pendingBatchCallCount >= absoluteHardLimit
+						? `Detected ${pendingBatchCallCount} identical calls to \`${call.name}\` still pending in one batch; stopping because earlier calls did not complete.`
+						: sequence.totalBatchCount >= absoluteHardLimit
+							? `Detected ${sequence.totalBatchCount} repeated batches of identical calls to \`${call.name}\` despite changing results; stopping to avoid a loop.`
+							: `Detected ${this.state.consecutiveIdenticalCount} consecutive identical calls to \`${call.name}\`; stopping to avoid a loop.`,
 			};
 		}
 		if (result.softWarning) {
@@ -443,10 +393,10 @@ export class LoopDetectionTracker {
 	}
 
 	/**
-	 * Complete an inspected call. Parallel calls in the same batch share a
-	 * generation, so every outcome can contribute progress regardless of finish
-	 * order. Failed outcomes only close their pending call and never reset loop
-	 * detection.
+	 * Complete an inspected call. Parallel calls in the same batch can span a
+	 * temporarily interleaved tool sequence, so every still-relevant outcome can
+	 * contribute progress regardless of finish order. Failed outcomes only close
+	 * their pending call and never reset loop detection.
 	 */
 	observeOutcome(
 		call: LoopDetectionCall,
@@ -464,10 +414,20 @@ export class LoopDetectionTracker {
 		}
 		const isCurrentCall =
 			inspected !== undefined &&
-			inspected.generation === this.currentSequence?.generation &&
+			this.currentSequence?.toolName === call.name &&
+			this.currentSequence.toolSignature === toolSignature &&
 			inspected.toolName === call.name &&
 			inspected.toolSignature === toolSignature;
 		if (!isCurrentCall) {
+			if (
+				inspected !== undefined &&
+				![...this.pendingCalls.values()].some(
+					(pending) => pending.batchId === inspected.batchId,
+				) &&
+				this.anonymousPendingCall?.batchId !== inspected.batchId
+			) {
+				this.batchOutcomes.delete(inspected.batchId);
+			}
 			return;
 		}
 
@@ -478,12 +438,8 @@ export class LoopDetectionTracker {
 		}
 		const hasPendingBatchCall =
 			[...this.pendingCalls.values()].some(
-				(pending) =>
-					pending.generation === inspected.generation &&
-					pending.batchId === inspected.batchId,
-			) ||
-			(this.anonymousPendingCall?.generation === inspected.generation &&
-				this.anonymousPendingCall.batchId === inspected.batchId);
+				(pending) => pending.batchId === inspected.batchId,
+			) || this.anonymousPendingCall?.batchId === inspected.batchId;
 		if (hasPendingBatchCall) {
 			return;
 		}
@@ -496,43 +452,27 @@ export class LoopDetectionTracker {
 		const outputSignature = JSON.stringify(
 			[...new Set(outcomes.map((entry) => entry.signature))].sort(),
 		);
-		const progressSignatures = [
-			...new Set(
-				outcomes
-					.map((entry) => entry.progressSignature)
-					.filter((entry): entry is string => entry !== undefined),
-			),
-		].sort();
-		const progressSignature =
-			progressSignatures.length === 0
-				? undefined
-				: JSON.stringify(progressSignatures);
 		const previous = this.lastSuccessfulOutcome;
+		const currentGeneration = this.currentSequence?.generation;
 
 		if (
-			previous?.generation === inspected.generation &&
+			previous !== undefined &&
+			previous.generation === currentGeneration &&
 			previous.outputSignature !== outputSignature
 		) {
 			resetLoopDetectionState(this.state);
-			if (
-				progressSignature !== undefined &&
-				progressSignature !== previous.progressSignature &&
-				this.currentSequence
-			) {
-				this.currentSequence.totalBatchCount = 0;
-			}
 		}
 
 		this.lastSuccessfulOutcome = {
-			generation: inspected.generation,
+			generation: currentGeneration ?? inspected.generation,
 			outputSignature,
-			progressSignature,
 		};
 	}
 
 	reset(): void {
 		resetLoopDetectionState(this.state);
 		this.currentSequence = undefined;
+		this.nextBatchId = 1;
 		this.pendingCalls.clear();
 		this.anonymousPendingCall = undefined;
 		this.batchOutcomes.clear();

--- a/sdk/packages/core/src/runtime/safety/loop-detection.ts
+++ b/sdk/packages/core/src/runtime/safety/loop-detection.ts
@@ -6,11 +6,11 @@
  *
  * The pure helpers (`createLoopDetectionState`, `resetLoopDetectionState`,
  * `toolCallSignature`, `checkRepeatedToolCall`) are ported verbatim. The
- * `LoopDetectionTracker` class is a thin wrapper that owns a
- * `LoopDetectionState` and exposes the `inspect()` / `reset()` surface that
- * `SessionRuntime` installs as a `beforeTool` hook per §3.2.3.
+ * `LoopDetectionTracker` owns the repeated-call state and groups parallel calls
+ * by agent iteration before `SessionRuntime` decides whether to warn or abort.
  */
 
+import { createHash } from "node:crypto";
 import type { LoopDetectionConfig } from "@cline/shared";
 
 // =============================================================================
@@ -56,6 +56,24 @@ export function toolCallSignature(input: unknown): string {
 	} catch {
 		return String(input);
 	}
+}
+
+function toolOutputSignature(output: unknown): string {
+	const type =
+		output === null ? "null" : Array.isArray(output) ? "array" : typeof output;
+	try {
+		const serialized = JSON.stringify(output);
+		if (serialized === undefined) return signatureHash(`${type}:undefined`);
+		return signatureHash(
+			`${type}:${JSON.stringify(sortKeys(JSON.parse(serialized)))}`,
+		);
+	} catch {
+		return signatureHash(`${type}:${String(output)}`);
+	}
+}
+
+function signatureHash(value: string): string {
+	return createHash("sha256").update(value).digest("hex");
 }
 
 export interface LoopCheckResult {
@@ -104,8 +122,9 @@ export interface LoopDetectionVerdict {
 	message?: string;
 }
 
-/** Minimal call shape the tracker needs; matches `AgentToolCallPart` subset. */
+/** Minimal runtime call shape needed by the tracker. */
 export interface LoopDetectionCall {
+	iteration: number;
 	name: string;
 	input: unknown;
 }
@@ -115,16 +134,113 @@ const DEFAULT_CONFIG: LoopDetectionConfig = {
 	hardThreshold: 5,
 };
 
+// Changed output may be real progress or volatile noise. The absolute ceiling
+// keeps either case bounded without guessing the meaning of arbitrary output.
+const ABSOLUTE_LIMIT_MULTIPLIER = 4;
+// Progress is normalized to the integer range 0..100. Permit the same bounded
+// number of renewals even when a multi-phase operation restarts at zero.
+const MAX_PROGRESS_CHANGES = 101;
+const MAX_SIGNATURE_STATES = 128;
+
+function callKey(toolName: string, toolSignature: string): string {
+	return signatureHash(JSON.stringify([toolName, toolSignature]));
+}
+
+function hashedToolCallSignature(input: unknown): string {
+	return signatureHash(toolCallSignature(input));
+}
+
+function explicitProgressStep(
+	value: unknown,
+	allowNumber = false,
+): number | undefined {
+	if (typeof value === "number") {
+		if (!allowNumber) return undefined;
+		const percentage = value <= 1 ? value * 100 : value;
+		return percentage >= 0 && percentage <= 100
+			? Math.floor(percentage)
+			: undefined;
+	}
+	if (typeof value !== "string") return undefined;
+
+	const percent = value.trim().match(/^(\d+(?:\.\d+)?)\s*%$/);
+	if (percent) {
+		const percentage = Number(percent[1]);
+		return percentage <= 100 ? Math.floor(percentage) : undefined;
+	}
+
+	const ratio = value.trim().match(/^(\d+)\s*\/\s*(\d+)$/);
+	if (!ratio) return undefined;
+	const current = Number(ratio[1]);
+	const total = Number(ratio[2]);
+	return total > 0 && current <= total
+		? Math.floor((current / total) * 100)
+		: undefined;
+}
+
+const PROGRESS_FIELDS = new Set([
+	"progress",
+	"percent",
+	"percentage",
+	"percentcomplete",
+]);
+
+function progressStep(output: unknown): number | undefined {
+	const direct = explicitProgressStep(output);
+	if (direct !== undefined) return direct;
+	if (output === null || typeof output !== "object") return undefined;
+
+	const seen = new WeakSet<object>();
+	const visit = (value: object): number | undefined => {
+		if (seen.has(value)) return undefined;
+		seen.add(value);
+		let highest: number | undefined;
+		for (const [key, candidate] of Object.entries(value)) {
+			const step = PROGRESS_FIELDS.has(key.toLowerCase())
+				? explicitProgressStep(candidate, true)
+				: candidate !== null && typeof candidate === "object"
+					? visit(candidate)
+					: undefined;
+			if (step !== undefined && (highest === undefined || step > highest)) {
+				highest = step;
+			}
+		}
+		return highest;
+	};
+	try {
+		return visit(output);
+	} catch {
+		return undefined;
+	}
+}
+
+interface ToolBatch {
+	iteration: number;
+	key: string;
+	pendingCount: number;
+	outcomes: Set<string>;
+	highestProgressStep?: number;
+}
+
+interface SignatureState {
+	totalBatchCount: number;
+	lastOutputSignature?: string;
+	lastProgressStep?: number;
+	progressChangeCount: number;
+	hasProgress: boolean;
+}
+
 /**
  * Per-session repeated-tool-call detector.
  *
- * `SessionRuntime` owns the instance and installs a `beforeTool` hook
- * (see `AgentRuntimeHooks.beforeTool`) that calls `inspect()` to decide
- * whether to return `{ skip, stop, reason }`.
+ * `SessionRuntime` owns the instance and calls `inspect()` for every
+ * `tool-started` event.
  */
 export class LoopDetectionTracker {
 	private readonly config: LoopDetectionConfig;
 	private readonly state: LoopDetectionState = createLoopDetectionState();
+	private readonly pendingBatches = new Map<string, ToolBatch>();
+	private readonly signatures = new Map<string, SignatureState>();
 
 	constructor(config?: Partial<LoopDetectionConfig>) {
 		this.config = {
@@ -134,18 +250,52 @@ export class LoopDetectionTracker {
 	}
 
 	inspect(call: LoopDetectionCall): LoopDetectionVerdict {
-		const signature = toolCallSignature(call.input);
+		this.finalizeCompletedBatchesBefore(call.iteration);
+		const signature = hashedToolCallSignature(call.input);
+		const key = callKey(call.name, signature);
+		const signatureState = this.getSignature(key);
+		if (signatureState.hasProgress) {
+			resetLoopDetectionState(this.state);
+			signatureState.hasProgress = false;
+		}
+
+		const batchId = JSON.stringify([call.iteration, key]);
+		let batch = this.pendingBatches.get(batchId);
+		const isNewBatch = batch === undefined;
+		if (batch === undefined) {
+			batch = {
+				iteration: call.iteration,
+				key,
+				pendingCount: 0,
+				outcomes: new Set(),
+			};
+			this.pendingBatches.set(batchId, batch);
+		}
+		batch.pendingCount++;
+		this.pruneSignatures();
+
+		const absoluteHardLimit =
+			this.config.hardThreshold * ABSOLUTE_LIMIT_MULTIPLIER;
+		if (batch.pendingCount >= absoluteHardLimit) {
+			return this.hard(
+				`Detected ${batch.pendingCount} identical calls to \`${call.name}\` still pending in one batch; stopping because earlier calls did not complete.`,
+			);
+		}
+
+		if (!isNewBatch) return { kind: "ok" };
+		const totalBatchCount = signatureState.totalBatchCount + 1;
 		const result = checkRepeatedToolCall(
 			this.state,
 			call.name,
 			signature,
 			this.config,
 		);
-		if (result.hardEscalation) {
-			return {
-				kind: "hard",
-				message: `Detected ${this.state.consecutiveIdenticalCount} consecutive identical calls to \`${call.name}\`; stopping to avoid a loop.`,
-			};
+		if (result.hardEscalation || totalBatchCount >= absoluteHardLimit) {
+			return this.hard(
+				totalBatchCount >= absoluteHardLimit
+					? `Detected ${totalBatchCount} repeated batches of identical calls to \`${call.name}\` despite changing results; stopping to avoid a loop.`
+					: `Detected ${this.state.consecutiveIdenticalCount} consecutive identical calls to \`${call.name}\`; stopping to avoid a loop.`,
+			);
 		}
 		if (result.softWarning) {
 			return {
@@ -156,7 +306,122 @@ export class LoopDetectionTracker {
 		return { kind: "ok" };
 	}
 
+	/**
+	 * Complete an inspected call. AgentRuntime finishes every tool in an
+	 * iteration before starting the next iteration, so iteration plus signature
+	 * is the complete parallel-batch identity.
+	 */
+	observeOutcome(
+		call: LoopDetectionCall,
+		outcome: { successful: boolean; output?: unknown },
+	): void {
+		const key = callKey(call.name, hashedToolCallSignature(call.input));
+		const batchId = JSON.stringify([call.iteration, key]);
+		const batch = this.pendingBatches.get(batchId);
+		if (batch === undefined) return;
+
+		if (outcome.successful) {
+			const outputSignature = toolOutputSignature(outcome.output);
+			batch.outcomes.add(outputSignature);
+			const step = progressStep(outcome.output);
+			if (
+				step !== undefined &&
+				(batch.highestProgressStep === undefined ||
+					step > batch.highestProgressStep)
+			) {
+				batch.highestProgressStep = step;
+			}
+		}
+		batch.pendingCount = Math.max(0, batch.pendingCount - 1);
+	}
+
+	/**
+	 * Finalize completed batches and drop calls that did not finish before their
+	 * runtime stopped. Unfinished batches never consume the completed-batch
+	 * fallback budget.
+	 */
+	clearPendingCalls(): void {
+		for (const batch of this.pendingBatches.values()) {
+			if (batch.pendingCount === 0) {
+				this.finalizeBatch(batch);
+			}
+		}
+		this.pendingBatches.clear();
+		this.pruneSignatures();
+	}
+
 	reset(): void {
 		resetLoopDetectionState(this.state);
+		this.pendingBatches.clear();
+		this.signatures.clear();
+	}
+
+	private getSignature(key: string): SignatureState {
+		let state = this.signatures.get(key);
+		if (state === undefined) {
+			state = {
+				totalBatchCount: 0,
+				progressChangeCount: 0,
+				hasProgress: false,
+			};
+		} else {
+			this.signatures.delete(key);
+		}
+		this.signatures.set(key, state);
+		return state;
+	}
+
+	private pruneSignatures(): void {
+		if (this.signatures.size <= MAX_SIGNATURE_STATES) return;
+		const pendingKeys = new Set(
+			[...this.pendingBatches.values()].map((batch) => batch.key),
+		);
+		for (const key of this.signatures.keys()) {
+			if (this.signatures.size <= MAX_SIGNATURE_STATES) break;
+			if (!pendingKeys.has(key)) {
+				this.signatures.delete(key);
+			}
+		}
+	}
+
+	private finalizeCompletedBatchesBefore(iteration: number): void {
+		for (const [batchId, batch] of this.pendingBatches) {
+			if (batch.iteration === iteration || batch.pendingCount > 0) continue;
+			this.pendingBatches.delete(batchId);
+			this.finalizeBatch(batch);
+		}
+	}
+
+	private finalizeBatch(batch: ToolBatch): void {
+		const signatureState = this.signatures.get(batch.key);
+		if (signatureState === undefined) return;
+		this.signatures.delete(batch.key);
+		this.signatures.set(batch.key, signatureState);
+		signatureState.totalBatchCount++;
+		if (batch.outcomes.size === 0) return;
+
+		const outputSignature = signatureHash(
+			JSON.stringify([...batch.outcomes].sort()),
+		);
+		if (
+			signatureState.lastOutputSignature !== undefined &&
+			signatureState.lastOutputSignature !== outputSignature
+		) {
+			signatureState.hasProgress = true;
+		}
+		if (
+			batch.highestProgressStep !== undefined &&
+			batch.highestProgressStep !== signatureState.lastProgressStep &&
+			signatureState.progressChangeCount < MAX_PROGRESS_CHANGES
+		) {
+			signatureState.lastProgressStep = batch.highestProgressStep;
+			signatureState.progressChangeCount++;
+			signatureState.totalBatchCount = 0;
+		}
+		signatureState.lastOutputSignature = outputSignature;
+	}
+
+	private hard(message: string): LoopDetectionVerdict {
+		return { kind: "hard", message };
 	}
 }


### PR DESCRIPTION
### Summary

Repeated polling is no longer treated as stalled when a successful result changes. The detector stays intentionally conservative and bounded:

- identical calls in one agent iteration form one parallel batch
- changed successful batch output resets the ordinary repeat counter
- failed operations never count as progress
- stable object serialization makes result order irrelevant
- arbitrary changing output stops after `hardThreshold * 4` batches
- explicit bounded numeric progress (`42%`, `3/10`, or a numeric `progress` field) renews that fallback budget

The implementation uses the runtime iteration as the batch boundary. It does not maintain call generations or interpret timestamps and log formats. Explicit progress is quantized to 0–100, so even the renewal path is finite.

### Why

The old detector inspected only tool name and input, so legitimate status polling could hit the hard loop limit while the underlying job was progressing.

### Validation

- `bun run build:sdk`
- 73 focused loop/orchestrator tests
- `bun -F @cline/core test:unit` — 1,451 passed, 4 skipped
- `bun run types`
- Biome and `git diff --check`

This PR is limited to loop detection and runtime wiring. Provider routing, retries, packaging, file indexing, and tool instructions are intentionally excluded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when agent runs abort during repeated tool use—a core runtime safety path—but behavior is bounded, conservative on failures, and covered by focused orchestrator and tracker tests.
> 
> **Overview**
> **Repeated identical tool calls are no longer treated as a stuck loop when successful results actually change**, so legitimate status polling can continue while real identical-output loops still hit warn/abort thresholds.
> 
> `LoopDetectionTracker` now batches calls by **agent iteration + tool signature**, records outcomes via **`observeOutcome`**, and resets the repeat counter when a completed batch’s successful output changes. **Failures** (tool errors, `success: false`, MCP `isError`) never count as progress; **explicit numeric progress** (`%`, ratios, `progress` fields) can extend the bounded fallback budget, while arbitrary changing output still caps at **`hardThreshold × 4`**. Unfinished batches are cleared on runtime drain via **`clearPendingCalls`** so orphaned `tool-started` events don’t poison continuations.
> 
> `SessionRuntime` wires **`tool-finished`** into the tracker (including structured failure detection) and passes **iteration** into **`inspect`**. New unit and orchestrator tests cover progress polling, continuations, and changing failure paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0a75a3605f68d840fcc035cbf28a381c632d43b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->