### PR TITLE
feat(cli): add rename action to session history TUI

### DIFF
--- a/apps/cli/src/commands/history.test.ts
+++ b/apps/cli/src/commands/history.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { SessionHistoryRecord } from "@cline/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { applySessionRename, rawSessionTitle } from "../utils/history-format";
 import {
 	formatCheckpointDetail,
 	formatHistoryListLine,
@@ -192,6 +193,76 @@ describe("formatHistoryListLine", () => {
 			updatedAt: "2026-01-01T00:02:00.000Z",
 			metadata: { title: "hydrated title", totalCost: 0.25 },
 		});
+	});
+});
+
+describe("rawSessionTitle", () => {
+	it("prefers an explicit title over the prompt", () => {
+		const row = createHistoryRow({
+			metadata: { title: "  My renamed session  " },
+			prompt: "original first message",
+		});
+		expect(rawSessionTitle(row)).toBe("My renamed session");
+	});
+
+	it("falls back to the prompt when there is no title", () => {
+		const row = createHistoryRow({
+			metadata: undefined,
+			prompt: "  original first message  ",
+		});
+		expect(rawSessionTitle(row)).toBe("original first message");
+	});
+
+	it("returns an empty string when neither title nor prompt is set", () => {
+		const row = createHistoryRow({ metadata: undefined, prompt: undefined });
+		expect(rawSessionTitle(row)).toBe("");
+	});
+});
+
+describe("applySessionRename", () => {
+	it("sets the title on the matching row", () => {
+		const rows = [
+			createHistoryRow({ sessionId: "sess_1", metadata: { title: "old" } }),
+			createHistoryRow({ sessionId: "sess_2", metadata: { title: "other" } }),
+		];
+
+		const renamed = applySessionRename(rows, "sess_1", "new title");
+
+		expect(renamed[0]?.metadata?.title).toBe("new title");
+		expect(renamed[1]?.metadata?.title).toBe("other");
+	});
+
+	it("preserves other metadata fields on the renamed row", () => {
+		const rows = [
+			createHistoryRow({
+				sessionId: "sess_1",
+				metadata: { title: "old", totalCost: 0.42 },
+			}),
+		];
+
+		const [renamed] = applySessionRename(rows, "sess_1", "new title");
+
+		expect(renamed?.metadata).toEqual({ title: "new title", totalCost: 0.42 });
+	});
+
+	it("sets a title even when the row previously had no metadata", () => {
+		const rows = [
+			createHistoryRow({ sessionId: "sess_1", metadata: undefined }),
+		];
+
+		const [renamed] = applySessionRename(rows, "sess_1", "new title");
+
+		expect(renamed?.metadata).toEqual({ title: "new title" });
+	});
+
+	it("leaves rows unchanged when the session id does not match", () => {
+		const rows = [
+			createHistoryRow({ sessionId: "sess_1", metadata: { title: "old" } }),
+		];
+
+		const renamed = applySessionRename(rows, "does-not-exist", "new title");
+
+		expect(renamed).toEqual(rows);
 	});
 });
 

--- a/apps/cli/src/tui/history-standalone.tsx
+++ b/apps/cli/src/tui/history-standalone.tsx
@@ -2,7 +2,7 @@ import type { SessionHistoryRecord } from "@cline/core";
 import { createCliRenderer } from "@opentui/core";
 import { createRoot } from "@opentui/react";
 import React from "react";
-import { deleteSession } from "../session/session";
+import { deleteSession, updateSession } from "../session/session";
 import { HistoryStandaloneContent } from "./views/history-view";
 
 export async function renderHistoryStandalone(input: {
@@ -63,6 +63,10 @@ export async function renderHistoryStandalone(input: {
 				onDelete: async (sessionId: string) => {
 					const result = await deleteSession(sessionId);
 					return result.deleted;
+				},
+				onRename: async (sessionId: string, title: string) => {
+					const result = await updateSession(sessionId, { title });
+					return result.updated;
 				},
 				onDismiss: () => settle(0),
 			}),

--- a/apps/cli/src/tui/views/history-view.tsx
+++ b/apps/cli/src/tui/views/history-view.tsx
@@ -10,8 +10,12 @@ import { useKeyboard, useTerminalDimensions } from "@opentui/react";
 import type { ChoiceContext } from "@opentui-ui/dialog";
 import { useDialogKeyboard } from "@opentui-ui/dialog/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { listSessions } from "../../session/session";
-import { mergeHistoryStatusRows } from "../../utils/history-format";
+import { listSessions, updateSession } from "../../session/session";
+import {
+	applySessionRename,
+	mergeHistoryStatusRows,
+	rawSessionTitle,
+} from "../../utils/history-format";
 import { formatUsd } from "../../utils/output";
 import { shouldShowCliUsageCost } from "../../utils/usage-cost-display";
 import { palette } from "../palette";
@@ -53,6 +57,7 @@ type HistoryListActions = {
 	onDismiss: () => void;
 	onExport?: (sessionId: string) => Promise<string | undefined>;
 	onDelete?: (sessionId: string) => Promise<boolean>;
+	onRename?: (sessionId: string, title: string) => Promise<boolean>;
 };
 
 type HistoryKeyEvent = {
@@ -80,8 +85,9 @@ function HistoryListContent({
 	onDismiss,
 	onExport,
 	onDelete,
+	onRename,
 	emptyMessage = "No sessions found",
-	footerText = "\u2191/\u2193 navigate, Enter to resume, Esc to close",
+	footerText = "\u2191/\u2193 navigate, Enter to resume, r to rename, Esc to close",
 	title = "Session History",
 	loadRows = false,
 	refreshRows,
@@ -95,6 +101,9 @@ function HistoryListContent({
 	const [selected, setSelected] = useState(0);
 	const [loading, setLoading] = useState(loadRows);
 	const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+	const [renaming, setRenaming] = useState<string | null>(null);
+	const [renameInputKey, setRenameInputKey] = useState(0);
+	const renameValueRef = useRef("");
 	const [statusMessage, setStatusMessage] = useState<string | null>(null);
 	const handlerRef = useRef<(key: HistoryKeyEvent | undefined) => void>(
 		() => {},
@@ -229,6 +238,39 @@ function HistoryListContent({
 			return;
 		}
 
+		if (renaming) {
+			if (key.name === "escape") {
+				setRenaming(null);
+				return;
+			}
+			if (key.name === "return" || key.name === "enter") {
+				const sessionId = renaming;
+				const nextTitle = renameValueRef.current.trim();
+				setRenaming(null);
+				if (!nextTitle) {
+					return;
+				}
+				setStatusMessage(`Renaming ${sessionId}...`);
+				void onRename?.(sessionId, nextTitle)
+					.then((updated) => {
+						if (!updated) {
+							setStatusMessage(`Session ${sessionId} not found`);
+							return;
+						}
+						setRows((currentRows) =>
+							applySessionRename(currentRows, sessionId, nextTitle),
+						);
+						setStatusMessage(`Renamed ${sessionId} to "${nextTitle}"`);
+					})
+					.catch((error) => {
+						setStatusMessage(
+							error instanceof Error ? error.message : String(error),
+						);
+					});
+			}
+			return;
+		}
+
 		if (key.name === "escape") {
 			onDismiss();
 			return;
@@ -259,6 +301,16 @@ function HistoryListContent({
 			const row = rowsRef.current[selectedRef.current];
 			if (row?.sessionId && onDelete) {
 				setConfirmDelete(row.sessionId);
+			}
+			return;
+		}
+		if (key.name === "r") {
+			const row = rowsRef.current[selectedRef.current];
+			if (row?.sessionId && onRename) {
+				setStatusMessage(null);
+				renameValueRef.current = rawSessionTitle(row);
+				setRenameInputKey((k) => k + 1);
+				setRenaming(row.sessionId);
 			}
 			return;
 		}
@@ -327,6 +379,7 @@ function HistoryListContent({
 				{window.items.map((row, i) => {
 					const absIdx = window.startIndex + i;
 					const isSel = absIdx === safeSelected;
+					const isRenaming = renaming === row.sessionId;
 					const cost = row.metadata?.totalCost;
 					const showCost = shouldShowCliUsageCost(row.provider);
 					const title = formatTitle(row, titleMaxLen);
@@ -348,12 +401,25 @@ function HistoryListContent({
 							>
 								{isSel ? "\u276f " : "  "}
 							</text>
-							<text
-								fg={isSel ? palette.textOnSelection : undefined}
-								flexGrow={1}
-							>
-								{title}
-							</text>
+							{isRenaming ? (
+								<input
+									key={renameInputKey}
+									value={rawSessionTitle(row)}
+									onInput={(v: string) => {
+										renameValueRef.current = v;
+									}}
+									placeholder="New title..."
+									flexGrow={1}
+									focused
+								/>
+							) : (
+								<text
+									fg={isSel ? palette.textOnSelection : undefined}
+									flexGrow={1}
+								>
+									{title}
+								</text>
+							)}
 							{showCost && cost != null && cost > 0 && (
 								<text
 									fg={isSel ? palette.textOnSelection : "gray"}
@@ -388,7 +454,9 @@ function HistoryListContent({
 						statusMessage.startsWith("Exported") ||
 						statusMessage.startsWith("Exporting") ||
 						statusMessage.startsWith("Deleted") ||
-						statusMessage.startsWith("Deleting")
+						statusMessage.startsWith("Deleting") ||
+						statusMessage.startsWith("Renamed") ||
+						statusMessage.startsWith("Renaming")
 							? palette.success
 							: "red"
 					}
@@ -419,11 +487,17 @@ export function HistoryDialogContent(props: ChoiceContext<string>) {
 
 	useDialogKeyboard((key) => keyHandler?.(key), dialogId);
 
+	const handleRename = useCallback(async (sessionId: string, title: string) => {
+		const result = await updateSession(sessionId, { title });
+		return result.updated;
+	}, []);
+
 	return (
 		<HistoryListContent
 			loadRows
 			onResolve={resolve}
 			onDismiss={dismiss}
+			onRename={handleRename}
 			registerKeyHandler={registerKeyHandler}
 		/>
 	);
@@ -457,12 +531,13 @@ export function HistoryStandaloneContent(
 			onDismiss={props.onDismiss}
 			onExport={props.onExport}
 			onDelete={props.onDelete}
+			onRename={props.onRename}
 			refreshRows={props.refreshRows}
 			refreshIntervalMs={props.refreshIntervalMs}
 			title={props.title ?? "History"}
 			footerText={
 				props.footerText ??
-				"\u2191/\u2193 navigate, Enter to resume, \u2190 delete, \u2192 export, Esc to close"
+				"\u2191/\u2193 navigate, Enter to resume, r to rename, \u2190 delete, \u2192 export, Esc to close"
 			}
 			registerKeyHandler={registerKeyHandler}
 		/>

--- a/apps/cli/src/tui/views/history-view.tsx
+++ b/apps/cli/src/tui/views/history-view.tsx
@@ -103,6 +103,7 @@ function HistoryListContent({
 	const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
 	const [renaming, setRenaming] = useState<string | null>(null);
 	const [renameInputKey, setRenameInputKey] = useState(0);
+	const [renamePrefill, setRenamePrefill] = useState("");
 	const renameValueRef = useRef("");
 	const [statusMessage, setStatusMessage] = useState<string | null>(null);
 	const handlerRef = useRef<(key: HistoryKeyEvent | undefined) => void>(
@@ -307,8 +308,10 @@ function HistoryListContent({
 		if (key.name === "r") {
 			const row = rowsRef.current[selectedRef.current];
 			if (row?.sessionId && onRename) {
+				const initialValue = rawSessionTitle(row);
 				setStatusMessage(null);
-				renameValueRef.current = rawSessionTitle(row);
+				renameValueRef.current = initialValue;
+				setRenamePrefill(initialValue);
 				setRenameInputKey((k) => k + 1);
 				setRenaming(row.sessionId);
 			}
@@ -391,7 +394,10 @@ function HistoryListContent({
 							flexDirection="row"
 							paddingX={1}
 							backgroundColor={isSel ? palette.selection : undefined}
-							onMouseDown={() => onResolve(row.sessionId)}
+							onMouseDown={() => {
+								if (isRenaming) return;
+								onResolve(row.sessionId);
+							}}
 							overflow="hidden"
 							height={1}
 						>
@@ -404,7 +410,7 @@ function HistoryListContent({
 							{isRenaming ? (
 								<input
 									key={renameInputKey}
-									value={rawSessionTitle(row)}
+									value={renamePrefill}
 									onInput={(v: string) => {
 										renameValueRef.current = v;
 									}}

--- a/apps/cli/src/utils/history-format.ts
+++ b/apps/cli/src/utils/history-format.ts
@@ -9,6 +9,22 @@ export function formatSessionStatusLabel(
 	return status?.trim() || "unknown";
 }
 
+export function rawSessionTitle(row: SessionHistoryRecord): string {
+	return row.metadata?.title?.trim() || row.prompt?.trim() || "";
+}
+
+export function applySessionRename(
+	rows: SessionHistoryRecord[],
+	sessionId: string,
+	title: string,
+): SessionHistoryRecord[] {
+	return rows.map((row) =>
+		row.sessionId === sessionId
+			? { ...row, metadata: { ...row.metadata, title } }
+			: row,
+	);
+}
+
 export function mergeHistoryStatusRows(
 	currentRows: SessionHistoryRecord[],
 	refreshedRows: SessionHistoryRecord[],


### PR DESCRIPTION
### Related Issue

**Issue:** #12408

### Description

The CLI already supports renaming a saved session from a plain shell
(`cline history update --session-id <id> --title "..."`), but there was no
way to do this from inside the interactive TUI — `/history` only supported
resume and dismiss, and the standalone `cline history` view only had
delete/export wired up.

This adds a rename action to the shared session history list component,
reachable from both entry points:

- **`/history`** (interactive dialog, mid-session)
- **`cline history`** (standalone command)

Press `r` on a selected session to edit its title inline (prefilled with
the current title), `Enter` to save, `Esc` to cancel. Saving calls the
existing `updateSession()` path — no backend or protocol changes were
needed, since that function already worked and was already used by the
shell command.

The rename logic itself (`rawSessionTitle`, `applySessionRename`) is
extracted as pure functions in `utils/history-format.ts`, next to the
existing `mergeHistoryStatusRows()`, so it's unit-testable independent of
the terminal rendering.

### Test Procedure

Manual (interactive TUI, `bun run dev` from `apps/cli`):
- Sent a message to create a session, opened `/history`, pressed `r` on the
  selected row, confirmed the title became an editable field prefilled with
  the current title.
- Typed a new title, pressed `Enter` — row updated immediately, status line
  showed `Renamed <id> to "<title>"`. Closed and reopened `/history` to
  confirm the new title persisted to disk (not just local UI state).
- Pressed `r`, typed a new value, then pressed `Esc` instead of `Enter` —
  confirmed the title reverted, nothing was saved.
- Repeated the same flow from the standalone `cline history` command
  (outside an active session) to confirm the second wiring path works too.

Automated:
- Added unit tests for `rawSessionTitle` and `applySessionRename` in
  `src/commands/history.test.ts`, alongside the existing
  `mergeHistoryStatusRows` tests and reusing its `createHistoryRow` fixture.
  Cover: preferring an explicit title over the prompt fallback, updating
  only the targeted row, preserving other metadata fields (e.g.
  `totalCost`), handling a row with no prior metadata, and no-op when the
  session id doesn't match.
- Note: `bunx vitest run` on this file currently fails locally with an
  unrelated, pre-existing `z.enum is not a function` error triggered by
  `commands/history.ts`'s other imports (not by anything this PR touches —
  `history-format.ts` only imports `SessionHistoryRecord` as a type). I
  confirmed this failure is identical with and without this diff (compared
  against `main` via `git stash`), so it's a local environment issue, not a
  regression from this change. I additionally verified the new functions'
  behavior directly with a standalone script (bypassing vitest) and all
  assertions passed.
- `bun -F @cline/cli typecheck` passes clean.
- `biome check` on the changed files is clean (one pre-existing
  `noStaticElementInteractions` warning on an unrelated line, confirmed
  present on `main` before this change too).

### Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

https://github.com/user-attachments/assets/22f5067f-b505-423e-8281-e7160b29aa3f

### Additional Notes

Left the existing delete/export/fork status messages (which show raw
session IDs) as-is for consistency, and matched that same convention for
rename's confirmation message rather than introducing a different style
in the same list.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only TUI and small pure helpers; persistence reuses the existing local `updateSession` path with no protocol or backend changes.
> 
> **Overview**
> Adds **inline session rename** to the shared session history list used by **`/history`** and **`cline history`**, matching the existing shell `history update --title` behavior.
> 
> Press **`r`** on a row to edit the title (prefilled via new **`rawSessionTitle`**), **Enter** persists through **`updateSession`**, **Esc** cancels. The list updates optimistically with **`applySessionRename`** after a successful save. Standalone history wires **`onRename`** the same way as delete/export.
> 
> Footers and status styling now mention rename; unit tests cover the new helpers in **`history-format.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 556dd4d283aaaed052fd5c28230adaa700ea64b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->