### PR TITLE
fix(mcp): honor per-server timeout (seconds) across all clients

### DIFF
--- a/apps/cli/src/runtime/interactive/config-data.test.ts
+++ b/apps/cli/src/runtime/interactive/config-data.test.ts
@@ -1012,9 +1012,9 @@ Review with the bundled skill.`,
 		const linear = data.mcp.find((item) => item.name === "linear");
 		const docs = data.mcp.find((item) => item.name === "docs");
 
-		expect(linear?.description).toBe("streamableHttp, oauth error");
+		expect(linear?.description).toBe("streamableHttp, oauth error, timeout 60s");
 		expect(linear?.loadError).toBe("OAuth authorization failed");
-		expect(docs?.description).toBe("sse, oauth authorized");
+		expect(docs?.description).toBe("sse, oauth authorized, timeout 60s");
 		expect(docs?.loadError).toBeUndefined();
 	});
 

--- a/apps/cli/src/tui/interactive-config.test.ts
+++ b/apps/cli/src/tui/interactive-config.test.ts
@@ -32,4 +32,14 @@ describe("getMcpDescription", () => {
 			}),
 		).toBe("streamableHttp, no auth, timeout 60s");
 	});
+
+	it("reports malformed programmatic timeouts as unconfigured", () => {
+		expect(
+			getMcpDescription({
+				name: "local",
+				transport: { type: "stdio", command: "node" },
+				timeoutSeconds: Number.NaN,
+			}),
+		).toBe("stdio, local, request timeout 60s, initialize probe 1.5s");
+	});
 });

--- a/apps/cli/src/tui/interactive-config.test.ts
+++ b/apps/cli/src/tui/interactive-config.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { getMcpDescription } from "./interactive-config";
+
+describe("getMcpDescription", () => {
+	it("discloses the fast initialize probe for unconfigured stdio servers", () => {
+		expect(
+			getMcpDescription({
+				name: "local",
+				transport: { type: "stdio", command: "node" },
+			}),
+		).toBe("stdio, local, request timeout 60s, initialize probe 1.5s");
+	});
+
+	it("shows one configured timeout when it also applies to initialize", () => {
+		expect(
+			getMcpDescription({
+				name: "local",
+				transport: { type: "stdio", command: "node" },
+				timeoutSeconds: 120,
+			}),
+		).toBe("stdio, local, timeout 120s");
+	});
+
+	it("shows the request default for URL transports", () => {
+		expect(
+			getMcpDescription({
+				name: "remote",
+				transport: {
+					type: "streamableHttp",
+					url: "https://mcp.example.test",
+				},
+			}),
+		).toBe("streamableHttp, no auth, timeout 60s");
+	});
+});

--- a/apps/cli/src/tui/interactive-config.ts
+++ b/apps/cli/src/tui/interactive-config.ts
@@ -175,10 +175,15 @@ function getMcpAuthLabel(registration: McpServerRegistration): string {
 	return "no auth";
 }
 
-function getMcpDescription(registration: McpServerRegistration): string {
+export function getMcpDescription(registration: McpServerRegistration): string {
 	const timeoutSeconds =
 		registration.timeoutSeconds ?? DEFAULT_MCP_TIMEOUT_SECONDS;
-	return `${registration.transport.type}, ${getMcpAuthLabel(registration)}, timeout ${timeoutSeconds}s`;
+	const timeoutDescription =
+		registration.transport.type === "stdio" &&
+		registration.timeoutSeconds === undefined
+			? `request timeout ${timeoutSeconds}s, initialize probe 1.5s`
+			: `timeout ${timeoutSeconds}s`;
+	return `${registration.transport.type}, ${getMcpAuthLabel(registration)}, ${timeoutDescription}`;
 }
 
 function loadAgentConfigItems(workspaceRoot: string): InteractiveConfigItem[] {

--- a/apps/cli/src/tui/interactive-config.ts
+++ b/apps/cli/src/tui/interactive-config.ts
@@ -27,6 +27,7 @@ import {
 	type UserInstructionConfigService,
 	type WorkflowConfig,
 } from "@cline/core";
+import { DEFAULT_MCP_TIMEOUT_SECONDS } from "@cline/shared";
 import { readFileSyncStrippingUtf8Bom } from "@cline/shared/node";
 import { getToolCatalog } from "../runtime/tools";
 import {
@@ -175,7 +176,9 @@ function getMcpAuthLabel(registration: McpServerRegistration): string {
 }
 
 function getMcpDescription(registration: McpServerRegistration): string {
-	return `${registration.transport.type}, ${getMcpAuthLabel(registration)}`;
+	const timeoutSeconds =
+		registration.timeoutSeconds ?? DEFAULT_MCP_TIMEOUT_SECONDS;
+	return `${registration.transport.type}, ${getMcpAuthLabel(registration)}, timeout ${timeoutSeconds}s`;
 }
 
 function loadAgentConfigItems(workspaceRoot: string): InteractiveConfigItem[] {

--- a/apps/cli/src/tui/interactive-config.ts
+++ b/apps/cli/src/tui/interactive-config.ts
@@ -27,7 +27,10 @@ import {
 	type UserInstructionConfigService,
 	type WorkflowConfig,
 } from "@cline/core";
-import { DEFAULT_MCP_TIMEOUT_SECONDS } from "@cline/shared";
+import {
+	isMcpTimeoutConfigured,
+	resolveMcpTimeoutSeconds,
+} from "@cline/shared";
 import { readFileSyncStrippingUtf8Bom } from "@cline/shared/node";
 import { getToolCatalog } from "../runtime/tools";
 import {
@@ -176,11 +179,10 @@ function getMcpAuthLabel(registration: McpServerRegistration): string {
 }
 
 export function getMcpDescription(registration: McpServerRegistration): string {
-	const timeoutSeconds =
-		registration.timeoutSeconds ?? DEFAULT_MCP_TIMEOUT_SECONDS;
+	const timeoutSeconds = resolveMcpTimeoutSeconds(registration.timeoutSeconds);
 	const timeoutDescription =
 		registration.transport.type === "stdio" &&
-		registration.timeoutSeconds === undefined
+		!isMcpTimeoutConfigured(registration.timeoutSeconds)
 			? `request timeout ${timeoutSeconds}s, initialize probe 1.5s`
 			: `timeout ${timeoutSeconds}s`;
 	return `${registration.transport.type}, ${getMcpAuthLabel(registration)}, ${timeoutDescription}`;

--- a/apps/vscode/src/sdk/vscode-runtime-builder.test.ts
+++ b/apps/vscode/src/sdk/vscode-runtime-builder.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test"
+import sinon from "sinon"
+import { McpHubToolProvider } from "./vscode-runtime-builder"
+
+describe("McpHubToolProvider", () => {
+	it("forwards the agent abort signal to McpHub", async () => {
+		const callTool = sinon.stub().resolves({ content: [] })
+		const provider = new McpHubToolProvider({ callTool } as never)
+		const controller = new AbortController()
+
+		await provider.callTool({
+			serverName: "server",
+			toolName: "slow-tool",
+			context: {
+				agentId: "agent",
+				iteration: 1,
+				signal: controller.signal,
+			},
+		})
+
+		expect(callTool.calledOnce).toBe(true)
+		expect(callTool.firstCall.args[4]).toBe(controller.signal)
+	})
+})

--- a/apps/vscode/src/sdk/vscode-runtime-builder.test.ts
+++ b/apps/vscode/src/sdk/vscode-runtime-builder.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "bun:test"
 import sinon from "sinon"
+import { describe, expect, it } from "vitest"
 import { McpHubToolProvider } from "./vscode-runtime-builder"
 
 describe("McpHubToolProvider", () => {

--- a/apps/vscode/src/sdk/vscode-runtime-builder.ts
+++ b/apps/vscode/src/sdk/vscode-runtime-builder.ts
@@ -13,7 +13,7 @@ interface McpToolDescriptor {
 	inputSchema: Record<string, unknown>
 }
 
-class McpHubToolProvider {
+export class McpHubToolProvider {
 	constructor(private readonly mcpHub: McpHub) {}
 
 	async listTools(serverName: string): Promise<readonly McpToolDescriptor[]> {
@@ -41,7 +41,7 @@ class McpHubToolProvider {
 		context?: AgentToolContext
 	}): Promise<unknown> {
 		const ulid = `sdk-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`
-		return this.mcpHub.callTool(request.serverName, request.toolName, request.arguments ?? {}, ulid)
+		return this.mcpHub.callTool(request.serverName, request.toolName, request.arguments ?? {}, ulid, request.context?.signal)
 	}
 }
 

--- a/apps/vscode/src/sdk/vscode-runtime-builder.ts
+++ b/apps/vscode/src/sdk/vscode-runtime-builder.ts
@@ -2,6 +2,7 @@ import { createMcpTools } from "@cline/core"
 import type { AgentTool, AgentToolContext } from "@cline/shared"
 import type { VscodeTerminalManager } from "@/hosts/vscode/terminal/VscodeTerminalManager"
 import type { McpHub } from "@/services/mcp/McpHub"
+import { resolveMcpServerTimeoutMs } from "@/services/mcp/timeout"
 import { Logger } from "@/shared/services/Logger"
 import type { SdkForegroundCommandCoordinator } from "./sdk-foreground-command-coordinator"
 import { createVscodeRunCommandsTool, VSCODE_FOREGROUND_RUN_COMMANDS_TIMEOUT_MS } from "./vscode-run-commands-tool"
@@ -66,6 +67,9 @@ export async function createVscodeExtraTools(mcpHub: McpHub, options?: VscodeExt
 				return await createMcpTools({
 					serverName: server.name,
 					provider,
+					// Keep the tool wrapper timeout in agreement with the MCP
+					// request timeout: both derive from the server's config.
+					timeoutMs: resolveMcpServerTimeoutMs(server.config),
 				})
 			} catch (error) {
 				Logger.warn(

--- a/apps/vscode/src/services/mcp/McpHub.ts
+++ b/apps/vscode/src/services/mcp/McpHub.ts
@@ -939,7 +939,7 @@ export class McpHub {
 				this.configsRequireRestart(JSON.parse(currentConnection.server.config), config) ||
 				this.serverGainedOAuthTokens(currentConnection, config)
 			) {
-				// Existing server with changed connection config (excludes Cline-specific settings),
+				// Existing server with changed connection config,
 				// or an unauthenticated server whose OAuth tokens just appeared (e.g. CLI authorized it)
 				try {
 					if (config.type === "stdio") {
@@ -1012,7 +1012,7 @@ export class McpHub {
 				this.configsRequireRestart(JSON.parse(currentConnection.server.config), config) ||
 				this.serverGainedOAuthTokens(currentConnection, config)
 			) {
-				// Existing server with changed connection config (excludes Cline-specific settings),
+				// Existing server with changed connection config,
 				// or an unauthenticated server whose OAuth tokens just appeared in the settings
 				// file (e.g. the CLI or another window completed authorization for it)
 				try {
@@ -1060,14 +1060,13 @@ export class McpHub {
 
 	/**
 	 * Compares two MCP server configs to determine if a restart is required.
-	 * Excludes Cline-specific settings since they don't affect the MCP server transport connection.
+	 * Excludes Cline-specific settings that don't affect the MCP client.
 	 *
 	 * ## Cline-specific settings (don't require restart):
 	 * - `autoApprove`: tool approval list (UI setting)
-	 * - `timeout`: request timeout (read at request time, not connection time)
 	 *
-	 * ## MCP SDK connection settings (require restart):
-	 * - `type`, `command`, `args`, `cwd`, `env`, `url`, `headers`, `disabled`
+	 * ## MCP client settings (require restart):
+	 * - `type`, `command`, `args`, `cwd`, `env`, `url`, `headers`, `disabled`, `timeout`
 	 *
 	 * ## Adding new Cline-specific settings:
 	 * When adding a new setting that doesn't require server restart:
@@ -1086,7 +1085,6 @@ export class McpHub {
 		// serverGainedOAuthTokens in updateServerConnections.
 		const {
 			autoApprove: _oldAutoApprove,
-			timeout: _oldTimeout,
 			remoteConfigured: _oldRemoteConfigured,
 			oauth: _oldOauth,
 			metadata: _oldMetadata,
@@ -1094,7 +1092,6 @@ export class McpHub {
 		} = oldConfig as McpServerConfig & { oauth?: unknown; metadata?: unknown }
 		const {
 			autoApprove: _newAutoApprove,
-			timeout: _newTimeout,
 			remoteConfigured: _newRemoteConfigured,
 			oauth: _newOauth,
 			metadata: _newMetadata,
@@ -1699,14 +1696,7 @@ export class McpHub {
 				return parsed
 			})
 			const config = await this.readPostWriteMcpSettings()
-
-			// Update in-memory config to reflect the new timeout
-			const connection = this.connections.find((conn) => conn.server.name === serverName)
-			if (connection) {
-				const currentConfig = JSON.parse(connection.server.config)
-				currentConfig.timeout = timeout
-				connection.server.config = JSON.stringify(currentConfig)
-			}
+			await this.updateServerConnectionsRPC(config.mcpServers as Record<string, McpServerConfig>)
 
 			const serverOrder = Object.keys(config.mcpServers || {})
 			return this.getSortedMcpServers(serverOrder)

--- a/apps/vscode/src/services/mcp/McpHub.ts
+++ b/apps/vscode/src/services/mcp/McpHub.ts
@@ -17,7 +17,7 @@ import {
 	ReadResourceResultSchema,
 } from "@modelcontextprotocol/sdk/types.js"
 import {
-	DEFAULT_MCP_TIMEOUT_SECONDS,
+	MAX_MCP_TIMEOUT_SECONDS,
 	type McpPrompt,
 	type McpPromptResponse,
 	type McpResource,
@@ -29,7 +29,6 @@ import {
 	MIN_MCP_TIMEOUT_SECONDS,
 } from "@shared/mcp"
 import { convertMcpServersToProtoMcpServers } from "@shared/proto-conversions/mcp/mcp-server-conversion"
-import { secondsToMs } from "@utils/time"
 import chokidar, { type FSWatcher } from "chokidar"
 import deepEqual from "fast-deep-equal"
 import * as fs from "fs/promises"
@@ -42,11 +41,11 @@ import { ShowMessageType } from "@/shared/proto/host/window"
 import { Logger } from "@/shared/services/Logger"
 import { expandEnvironmentVariables } from "@/utils/envExpansion"
 import type { TelemetryService } from "../telemetry/TelemetryService"
-import { DEFAULT_REQUEST_TIMEOUT_MS } from "./constants"
 import { McpOAuthManager } from "./McpOAuthManager"
-import { updateMcpSettingsFile } from "./settingsLock"
 import { StreamableHttpReconnectHandler } from "./StreamableHttpReconnectHandler"
 import { BaseConfigSchema, McpSettingsSchema, ServerConfigSchema } from "./schemas"
+import { updateMcpSettingsFile } from "./settingsLock"
+import { augmentMcpTimeoutError, resolveMcpServerTimeoutMs } from "./timeout"
 import type { McpConnection, McpServerConfig, Transport } from "./types"
 export class McpHub {
 	getMcpServersPath: () => Promise<string>
@@ -776,7 +775,7 @@ export class McpHub {
 			}
 
 			const response = await connection.client.request({ method: "tools/list" }, ListToolsResultSchema, {
-				timeout: DEFAULT_REQUEST_TIMEOUT_MS,
+				timeout: resolveMcpServerTimeoutMs(connection.server.config),
 			})
 
 			// Get autoApprove settings
@@ -808,7 +807,7 @@ export class McpHub {
 			}
 
 			const response = await connection.client.request({ method: "resources/list" }, ListResourcesResultSchema, {
-				timeout: DEFAULT_REQUEST_TIMEOUT_MS,
+				timeout: resolveMcpServerTimeoutMs(connection.server.config),
 			})
 			return response?.resources || []
 		} catch (_error) {
@@ -830,7 +829,7 @@ export class McpHub {
 				{ method: "resources/templates/list" },
 				ListResourceTemplatesResultSchema,
 				{
-					timeout: DEFAULT_REQUEST_TIMEOUT_MS,
+					timeout: resolveMcpServerTimeoutMs(connection.server.config),
 				},
 			)
 
@@ -851,7 +850,7 @@ export class McpHub {
 			}
 
 			const response = await connection.client.request({ method: "prompts/list" }, ListPromptsResultSchema, {
-				timeout: DEFAULT_REQUEST_TIMEOUT_MS,
+				timeout: resolveMcpServerTimeoutMs(connection.server.config),
 			})
 
 			return (response?.prompts || []).map((prompt) => ({
@@ -1360,6 +1359,9 @@ export class McpHub {
 				},
 			},
 			ReadResourceResultSchema,
+			{
+				timeout: resolveMcpServerTimeoutMs(connection.server.config),
+			},
 		)
 	}
 
@@ -1389,7 +1391,7 @@ export class McpHub {
 			},
 			GetPromptResultSchema,
 			{
-				timeout: DEFAULT_REQUEST_TIMEOUT_MS,
+				timeout: resolveMcpServerTimeoutMs(connection.server.config),
 			},
 		)
 
@@ -1419,15 +1421,9 @@ export class McpHub {
 			throw new Error(`Server "${serverName}" is disabled and cannot be used`)
 		}
 
-		let timeout = secondsToMs(DEFAULT_MCP_TIMEOUT_SECONDS) // sdk expects ms
-
-		try {
-			const config = JSON.parse(connection.server.config)
-			const parsedConfig = ServerConfigSchema.parse(config)
-			timeout = secondsToMs(parsedConfig.timeout)
-		} catch (error) {
-			Logger.error(`Failed to parse timeout configuration for server ${serverName}: ${error}`)
-		}
+		// The config is re-resolved on each call, so a changed timeout takes
+		// effect on the next request.
+		const timeout = resolveMcpServerTimeoutMs(connection.server.config) // sdk expects ms
 
 		this.telemetryService.captureMcpToolCall(
 			ulid,
@@ -1475,7 +1471,7 @@ export class McpHub {
 				error instanceof Error ? error.message : String(error),
 				toolArguments ? Object.keys(toolArguments) : undefined,
 			)
-			throw error
+			throw augmentMcpTimeoutError(error, serverName, timeout)
 		}
 	}
 
@@ -1668,6 +1664,11 @@ export class McpHub {
 			const setConfigResult = BaseConfigSchema.shape.timeout.safeParse(timeout)
 			if (!setConfigResult.success) {
 				throw new Error(`Invalid timeout value: ${timeout}. Must be at minimum ${MIN_MCP_TIMEOUT_SECONDS} seconds.`)
+			}
+			if (timeout > MAX_MCP_TIMEOUT_SECONDS) {
+				throw new Error(
+					`Invalid timeout value: ${timeout}. The "timeout" field is in seconds; the maximum is ${MAX_MCP_TIMEOUT_SECONDS}.`,
+				)
 			}
 
 			const settingsPath = await getMcpSettingsFilePathHelper(await this.getSettingsDirectoryPath())

--- a/apps/vscode/src/services/mcp/McpHub.ts
+++ b/apps/vscode/src/services/mcp/McpHub.ts
@@ -43,7 +43,7 @@ import { expandEnvironmentVariables } from "@/utils/envExpansion"
 import type { TelemetryService } from "../telemetry/TelemetryService"
 import { McpOAuthManager } from "./McpOAuthManager"
 import { StreamableHttpReconnectHandler } from "./StreamableHttpReconnectHandler"
-import { BaseConfigSchema, McpSettingsSchema, ServerConfigSchema } from "./schemas"
+import { McpSettingsSchema, McpTimeoutSecondsSchema, ServerConfigSchema } from "./schemas"
 import { updateMcpSettingsFile } from "./settingsLock"
 import { augmentMcpTimeoutError, resolveMcpServerTimeoutMs } from "./timeout"
 import type { McpConnection, McpServerConfig, Transport } from "./types"
@@ -638,7 +638,8 @@ export class McpHub {
 
 			// Connect - wrap in try-catch to detect OAuth requirement
 			try {
-				await client.connect(transport)
+				const timeout = resolveMcpServerTimeoutMs(connection.server.config)
+				await client.connect(transport, { timeout })
 			} catch (error) {
 				if (error instanceof UnauthorizedError) {
 					// Server requires OAuth authentication
@@ -664,8 +665,10 @@ export class McpHub {
 					await this.notifyWebviewOfServerChanges()
 					return // Don't throw, just mark as needs auth
 				}
-				// Re-throw other errors
-				throw error
+				await client.close().catch(() => {})
+				// Re-throw other errors with the same actionable timeout detail as
+				// post-initialize requests.
+				throw augmentMcpTimeoutError(error, name, resolveMcpServerTimeoutMs(connection.server.config))
 			}
 
 			connection.server.status = "connected"
@@ -792,7 +795,11 @@ export class McpHub {
 
 			return tools
 		} catch (error) {
-			Logger.error(`Failed to fetch tools for ${serverName}:`, error)
+			const connection = this.connections.find((conn) => conn.server.name === serverName)
+			const effectiveError = connection
+				? augmentMcpTimeoutError(error, serverName, resolveMcpServerTimeoutMs(connection.server.config))
+				: error
+			Logger.error(`Failed to fetch tools for ${serverName}:`, effectiveError)
 			return []
 		}
 	}
@@ -1351,18 +1358,21 @@ export class McpHub {
 			throw new Error(`Server "${serverName}" is disabled`)
 		}
 
-		return await connection.client.request(
-			{
-				method: "resources/read",
-				params: {
-					uri,
+		const timeout = resolveMcpServerTimeoutMs(connection.server.config)
+		try {
+			return await connection.client.request(
+				{
+					method: "resources/read",
+					params: {
+						uri,
+					},
 				},
-			},
-			ReadResourceResultSchema,
-			{
-				timeout: resolveMcpServerTimeoutMs(connection.server.config),
-			},
-		)
+				ReadResourceResultSchema,
+				{ timeout },
+			)
+		} catch (error) {
+			throw augmentMcpTimeoutError(error, serverName, timeout)
+		}
 	}
 
 	async getPrompt(
@@ -1381,19 +1391,22 @@ export class McpHub {
 			throw new Error(`No client available for server: ${serverName}`)
 		}
 
-		const response = await connection.client.request(
-			{
-				method: "prompts/get",
-				params: {
-					name: promptName,
-					arguments: promptArguments,
+		const timeout = resolveMcpServerTimeoutMs(connection.server.config)
+		const response = await connection.client
+			.request(
+				{
+					method: "prompts/get",
+					params: {
+						name: promptName,
+						arguments: promptArguments,
+					},
 				},
-			},
-			GetPromptResultSchema,
-			{
-				timeout: resolveMcpServerTimeoutMs(connection.server.config),
-			},
-		)
+				GetPromptResultSchema,
+				{ timeout },
+			)
+			.catch((error) => {
+				throw augmentMcpTimeoutError(error, serverName, timeout)
+			})
 
 		return {
 			description: response.description,
@@ -1661,13 +1674,11 @@ export class McpHub {
 	public async updateServerTimeoutRPC(serverName: string, timeout: number): Promise<McpServer[]> {
 		try {
 			// Validate timeout against schema
-			const setConfigResult = BaseConfigSchema.shape.timeout.safeParse(timeout)
+			const setConfigResult = McpTimeoutSecondsSchema.safeParse(timeout)
 			if (!setConfigResult.success) {
-				throw new Error(`Invalid timeout value: ${timeout}. Must be at minimum ${MIN_MCP_TIMEOUT_SECONDS} seconds.`)
-			}
-			if (timeout > MAX_MCP_TIMEOUT_SECONDS) {
 				throw new Error(
-					`Invalid timeout value: ${timeout}. The "timeout" field is in seconds; the maximum is ${MAX_MCP_TIMEOUT_SECONDS}.`,
+					`Invalid timeout value: ${timeout}. The "timeout" field must be a finite number from ` +
+						`${MIN_MCP_TIMEOUT_SECONDS} to ${MAX_MCP_TIMEOUT_SECONDS} seconds.`,
 				)
 			}
 

--- a/apps/vscode/src/services/mcp/McpHub.ts
+++ b/apps/vscode/src/services/mcp/McpHub.ts
@@ -47,6 +47,23 @@ import { McpSettingsSchema, McpTimeoutSecondsSchema, ServerConfigSchema } from "
 import { updateMcpSettingsFile } from "./settingsLock"
 import { augmentMcpTimeoutError, resolveMcpServerTimeoutMs } from "./timeout"
 import type { McpConnection, McpServerConfig, Transport } from "./types"
+
+function stableJsonStringify(value: unknown): string {
+	if (value === undefined) {
+		return "null"
+	}
+	if (value === null || typeof value !== "object") {
+		return JSON.stringify(value)
+	}
+	if (Array.isArray(value)) {
+		return `[${value.map(stableJsonStringify).join(",")}]`
+	}
+	return `{${Object.entries(value as Record<string, unknown>)
+		.sort(([left], [right]) => left.localeCompare(right))
+		.map(([key, entryValue]) => `${JSON.stringify(key)}:${stableJsonStringify(entryValue)}`)
+		.join(",")}}`
+}
+
 export class McpHub {
 	getMcpServersPath: () => Promise<string>
 	private getSettingsDirectoryPath: () => Promise<string>
@@ -971,6 +988,10 @@ export class McpHub {
 			}
 		}
 
+		// MCP agent tools snapshot server metadata and timeout when a session is
+		// built. Reconciliation must enroll that snapshot boundary even when the
+		// set of tool names is unchanged.
+		this.checkToolListChanged()
 		this.isConnecting = false
 	}
 
@@ -1419,6 +1440,7 @@ export class McpHub {
 		toolName: string,
 		toolArguments: Record<string, unknown> | undefined,
 		ulid: string,
+		signal?: AbortSignal,
 	): Promise<McpToolCallResponse> {
 		const connection = this.connections.find((conn) => conn.server.name === serverName)
 		if (!connection) {
@@ -1456,6 +1478,7 @@ export class McpHub {
 				CallToolResultSchema,
 				{
 					timeout,
+					signal,
 				},
 			)
 
@@ -1771,10 +1794,10 @@ export class McpHub {
 	/**
 	 * Compute a fingerprint of the current tool list.
 	 *
-	 * The fingerprint is a sorted, deterministic string of
-	 * "serverName:toolName" pairs for all connected, non-disabled servers.
-	 * Changes to this fingerprint indicate that the agent's available
-	 * tool set has changed and a session restart may be needed.
+	 * The fingerprint is a sorted, deterministic representation of every value
+	 * captured by createMcpTools: server name, tool name, description, input
+	 * schema, and timeout. A change to any captured value must rebuild the active
+	 * session even when the set of tool names is unchanged.
 	 */
 	computeToolFingerprint(): string {
 		const entries: string[] = []
@@ -1782,12 +1805,21 @@ export class McpHub {
 			if (conn.server.disabled || conn.server.status !== "connected") {
 				continue
 			}
+			const timeoutMs = resolveMcpServerTimeoutMs(conn.server.config)
 			for (const tool of conn.server.tools ?? []) {
-				entries.push(`${conn.server.name}:${tool.name}`)
+				entries.push(
+					stableJsonStringify([
+						conn.server.name,
+						tool.name,
+						tool.description ?? null,
+						tool.inputSchema ?? {},
+						timeoutMs,
+					]),
+				)
 			}
 		}
 		entries.sort()
-		return entries.join("|")
+		return JSON.stringify(entries)
 	}
 
 	/**

--- a/apps/vscode/src/services/mcp/McpHub.ts
+++ b/apps/vscode/src/services/mcp/McpHub.ts
@@ -9,19 +9,15 @@ import { getDefaultEnvironment, StdioClientTransport } from "@modelcontextprotoc
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
 import {
 	CallToolResultSchema,
-	GetPromptResultSchema,
 	ListPromptsResultSchema,
 	ListResourcesResultSchema,
 	ListResourceTemplatesResultSchema,
 	ListToolsResultSchema,
-	ReadResourceResultSchema,
 } from "@modelcontextprotocol/sdk/types.js"
 import {
 	MAX_MCP_TIMEOUT_SECONDS,
 	type McpPrompt,
-	type McpPromptResponse,
 	type McpResource,
-	type McpResourceResponse,
 	type McpResourceTemplate,
 	type McpServer,
 	type McpTool,
@@ -761,10 +757,7 @@ export class McpHub {
 			}
 
 			// Initial fetch of tools, resources, and prompts
-			connection.server.tools = await this.fetchToolsList(name)
-			connection.server.resources = await this.fetchResourcesList(name)
-			connection.server.resourceTemplates = await this.fetchResourceTemplatesList(name)
-			connection.server.prompts = await this.fetchPromptsList(name)
+			await this.fetchServerCapabilities(connection)
 		} catch (error) {
 			// Update status with error
 			const connection = this.findConnection(name, source)
@@ -779,6 +772,28 @@ export class McpHub {
 	private appendErrorMessage(connection: McpConnection, error: string) {
 		const newError = connection.server.error ? `${connection.server.error}\n${error}` : error
 		connection.server.error = newError //.slice(0, 800)
+	}
+
+	/**
+	 * Fetches the server's tools, resources, resource templates, and prompts
+	 * onto the connection. The four list requests run in parallel so a server
+	 * that hangs after initialize costs one timeout bound rather than four;
+	 * the MCP client correlates concurrent requests by JSON-RPC id. Each
+	 * fetch helper swallows its own errors and returns an empty list, so a
+	 * failure in one capability cannot reject the others.
+	 */
+	private async fetchServerCapabilities(connection: McpConnection): Promise<void> {
+		const name = connection.server.name
+		const [tools, resources, resourceTemplates, prompts] = await Promise.all([
+			this.fetchToolsList(name),
+			this.fetchResourcesList(name),
+			this.fetchResourceTemplatesList(name),
+			this.fetchPromptsList(name),
+		])
+		connection.server.tools = tools
+		connection.server.resources = resources
+		connection.server.resourceTemplates = resourceTemplates
+		connection.server.prompts = prompts
 	}
 
 	private async fetchToolsList(serverName: string): Promise<McpTool[]> {
@@ -1364,74 +1379,6 @@ export class McpHub {
 			throw error
 		} finally {
 			this.isConnecting = false
-		}
-	}
-
-	async readResource(serverName: string, uri: string): Promise<McpResourceResponse> {
-		const connection = this.connections.find((conn) => conn.server.name === serverName)
-		if (!connection) {
-			throw new Error(`No connection found for server: ${serverName}`)
-		}
-		if (connection.server.disabled) {
-			throw new Error(`Server "${serverName}" is disabled`)
-		}
-
-		const timeout = resolveMcpServerTimeoutMs(connection.server.config)
-		try {
-			return await connection.client.request(
-				{
-					method: "resources/read",
-					params: {
-						uri,
-					},
-				},
-				ReadResourceResultSchema,
-				{ timeout },
-			)
-		} catch (error) {
-			throw augmentMcpTimeoutError(error, serverName, timeout)
-		}
-	}
-
-	async getPrompt(
-		serverName: string,
-		promptName: string,
-		promptArguments?: Record<string, string>,
-	): Promise<McpPromptResponse> {
-		const connection = this.connections.find((conn) => conn.server.name === serverName)
-		if (!connection) {
-			throw new Error(`No connection found for server: ${serverName}`)
-		}
-		if (connection.server.disabled) {
-			throw new Error(`Server "${serverName}" is disabled`)
-		}
-		if (!connection.client) {
-			throw new Error(`No client available for server: ${serverName}`)
-		}
-
-		const timeout = resolveMcpServerTimeoutMs(connection.server.config)
-		const response = await connection.client
-			.request(
-				{
-					method: "prompts/get",
-					params: {
-						name: promptName,
-						arguments: promptArguments,
-					},
-				},
-				GetPromptResultSchema,
-				{ timeout },
-			)
-			.catch((error) => {
-				throw augmentMcpTimeoutError(error, serverName, timeout)
-			})
-
-		return {
-			description: response.description,
-			messages: response.messages.map((msg) => ({
-				role: msg.role,
-				content: msg.content as McpPromptResponse["messages"][0]["content"],
-			})),
 		}
 	}
 

--- a/apps/vscode/src/services/mcp/McpHub.ts
+++ b/apps/vscode/src/services/mcp/McpHub.ts
@@ -1421,6 +1421,14 @@ export class McpHub {
 			throw new Error(`Server "${serverName}" is disabled and cannot be used`)
 		}
 
+		// A failed (re)connect leaves an entry with no client so the server
+		// stays visible in the list; a tool wrapper captured by an active
+		// session can still target it, and must get a controlled error.
+		if (!connection.client) {
+			const detail = connection.server.error ? ` Last error: ${connection.server.error}` : ""
+			throw new Error(`Server "${serverName}" is not connected and cannot be used.${detail}`)
+		}
+
 		// The config is re-resolved on each call, so a changed timeout takes
 		// effect on the next request.
 		const timeout = resolveMcpServerTimeoutMs(connection.server.config) // sdk expects ms

--- a/apps/vscode/src/services/mcp/McpHub.ts
+++ b/apps/vscode/src/services/mcp/McpHub.ts
@@ -759,12 +759,27 @@ export class McpHub {
 			// Initial fetch of tools, resources, and prompts
 			await this.fetchServerCapabilities(connection)
 		} catch (error) {
-			// Update status with error
-			const connection = this.findConnection(name, source)
-			if (connection) {
-				connection.server.status = "disconnected"
-				this.appendErrorMessage(connection, error instanceof Error ? error.message : String(error))
+			// Update status with error. A failure before the connection was
+			// registered (e.g. the transport failed to start) must still leave
+			// an entry, so the server stays visible in the list with its error
+			// rather than silently disappearing.
+			let connection = this.findConnection(name, source)
+			if (!connection) {
+				connection = {
+					server: {
+						name,
+						config: JSON.stringify(config),
+						status: "disconnected",
+						disabled: config.disabled,
+						uid: this.getMcpServerKey(name),
+					},
+					client: null as unknown as Client,
+					transport: null as unknown as Transport,
+				}
+				this.connections.push(connection)
 			}
+			connection.server.status = "disconnected"
+			this.appendErrorMessage(connection, error instanceof Error ? error.message : String(error))
 			throw error
 		}
 	}
@@ -1043,6 +1058,9 @@ export class McpHub {
 					connectionChangesOccurred = true
 				} catch (error) {
 					Logger.error(`Failed to connect to new MCP server ${name}:`, error)
+					// connectToServer registered a disconnected entry carrying
+					// the error; the webview must be told about it.
+					connectionChangesOccurred = true
 				}
 			} else if (
 				this.configsRequireRestart(JSON.parse(currentConnection.server.config), config) ||
@@ -1066,6 +1084,9 @@ export class McpHub {
 					connectionChangesOccurred = true
 				} catch (error) {
 					Logger.error(`Failed to reconnect MCP server ${name}:`, error)
+					// connectToServer registered a disconnected entry carrying
+					// the error; the webview must be told about it.
+					connectionChangesOccurred = true
 				}
 			} else {
 				// Only Cline-specific settings changed - update in-memory state without restart

--- a/apps/vscode/src/services/mcp/__tests__/McpHub.callTool.test.ts
+++ b/apps/vscode/src/services/mcp/__tests__/McpHub.callTool.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, it } from "bun:test"
 import "should"
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js"
 import sinon from "sinon"
 import { McpHub } from "../McpHub"
 
@@ -165,6 +166,78 @@ describe("McpHub.callTool", () => {
 			requestOptions.should.have.property("timeout")
 			requestOptions.timeout.should.be.a.Number()
 			requestOptions.timeout.should.be.above(0)
+		})
+	})
+
+	// ── Per-server timeout resolution ─────────────────────────────────
+
+	describe("timeout resolution", () => {
+		it("should pass the configured per-server timeout (seconds) as ms", async () => {
+			const { hub, client } = createMcpHub({
+				config: JSON.stringify({ type: "stdio", command: "test", timeout: 120 }),
+			})
+
+			await hub.callTool("test-server", "slow_tool", undefined, "ulid-t01")
+
+			const requestOptions = client.request.firstCall.args[2]
+			requestOptions.timeout.should.equal(120_000)
+		})
+
+		it("should clamp a milliseconds/seconds mix-up to the maximum", async () => {
+			const { hub, client } = createMcpHub({
+				config: JSON.stringify({ type: "stdio", command: "test", timeout: 60000 }),
+			})
+
+			await hub.callTool("test-server", "slow_tool", undefined, "ulid-t02")
+
+			const requestOptions = client.request.firstCall.args[2]
+			requestOptions.timeout.should.equal(3_600_000)
+		})
+
+		it("should fall back to the default when the config is malformed", async () => {
+			const { hub, client } = createMcpHub({ config: "not-json" })
+
+			await hub.callTool("test-server", "slow_tool", undefined, "ulid-t03")
+
+			const requestOptions = client.request.firstCall.args[2]
+			requestOptions.timeout.should.equal(60_000)
+		})
+
+		it("should apply the per-server timeout to metadata requests (tools/list)", async () => {
+			const { hub, client } = createMcpHub({
+				client: createMockClient({ tools: [] }),
+				config: JSON.stringify({ type: "stdio", command: "test", timeout: 120 }),
+			})
+
+			await (hub as any).fetchToolsList("test-server")
+
+			client.request.calledOnce.should.be.true()
+			const requestArgs = client.request.firstCall.args[0]
+			requestArgs.method.should.equal("tools/list")
+			const requestOptions = client.request.firstCall.args[2]
+			requestOptions.timeout.should.equal(120_000)
+		})
+
+		it("should augment request-timeout errors with how to raise the bound", async () => {
+			const failingClient = {
+				request: sinon.stub().rejects(new McpError(ErrorCode.RequestTimeout, "Request timed out")),
+			}
+			const { hub } = createMcpHub({
+				client: failingClient,
+				config: JSON.stringify({ type: "stdio", command: "test", timeout: 120 }),
+			})
+
+			let thrown: any
+			try {
+				await hub.callTool("test-server", "slow_tool", undefined, "ulid-t04")
+			} catch (error) {
+				thrown = error
+			}
+
+			thrown.should.be.instanceOf(McpError)
+			thrown.code.should.equal(ErrorCode.RequestTimeout)
+			thrown.message.should.match(/timed out after 120s/)
+			thrown.message.should.match(/"timeout" field \(in seconds\)/)
 		})
 	})
 

--- a/apps/vscode/src/services/mcp/__tests__/McpHub.callTool.test.ts
+++ b/apps/vscode/src/services/mcp/__tests__/McpHub.callTool.test.ts
@@ -167,6 +167,15 @@ describe("McpHub.callTool", () => {
 			requestOptions.timeout.should.be.a.Number()
 			requestOptions.timeout.should.be.above(0)
 		})
+
+		it("should pass the abort signal in request options", async () => {
+			const { hub, client } = createMcpHub()
+			const controller = new AbortController()
+
+			await hub.callTool("test-server", "slow_tool", undefined, "ulid-signal", controller.signal)
+
+			client.request.firstCall.args[2].signal.should.equal(controller.signal)
+		})
 	})
 
 	// ── Per-server timeout resolution ─────────────────────────────────

--- a/apps/vscode/src/services/mcp/__tests__/McpHub.callTool.test.ts
+++ b/apps/vscode/src/services/mcp/__tests__/McpHub.callTool.test.ts
@@ -314,6 +314,26 @@ describe("McpHub.callTool", () => {
 			threw.should.be.true()
 		})
 
+		it("should throw a controlled error when the connection has no client (failed reconnect)", async () => {
+			// A failed (re)connect registers a disconnected entry with a null
+			// client; a tool wrapper captured by an active session can still
+			// call it and must get a controlled error, not a TypeError.
+			const { hub, connection } = createMcpHub()
+			connection.server.status = "disconnected"
+			;(connection.server as any).error = "spawn broken-command ENOENT"
+			;(connection as any).client = null
+
+			let threw = false
+			try {
+				await hub.callTool("test-server", "some_tool", undefined, "ulid-018")
+			} catch (error: any) {
+				threw = true
+				error.message.should.containEql('Server "test-server" is not connected')
+				error.message.should.containEql("spawn broken-command ENOENT")
+			}
+			threw.should.be.true()
+		})
+
 		it("should capture error telemetry when client.request fails", async () => {
 			const client = createMockClient()
 			client.request.rejects(new Error("Network timeout"))

--- a/apps/vscode/src/services/mcp/__tests__/McpHub.callTool.test.ts
+++ b/apps/vscode/src/services/mcp/__tests__/McpHub.callTool.test.ts
@@ -227,6 +227,41 @@ describe("McpHub.callTool", () => {
 			requestOptions.timeout.should.equal(120_000)
 		})
 
+		it("should fetch the four capability lists in parallel", async () => {
+			// Each request resolves on the next macrotask and records how many
+			// requests were in flight when it started. Sequential awaits would
+			// observe one in-flight request each; parallel dispatch observes all
+			// four before the first resolves.
+			let inFlight = 0
+			const inFlightAtStart: number[] = []
+			const client = {
+				request: sinon.stub().callsFake((request: { method: string }) => {
+					inFlight += 1
+					inFlightAtStart.push(inFlight)
+					return new Promise((resolve) => {
+						setTimeout(() => {
+							inFlight -= 1
+							resolve(
+								request.method === "tools/list"
+									? { tools: [] }
+									: request.method === "resources/list"
+										? { resources: [] }
+										: request.method === "resources/templates/list"
+											? { resourceTemplates: [] }
+											: { prompts: [] },
+							)
+						}, 0)
+					})
+				}),
+			}
+			const { hub, connection } = createMcpHub({ client: client as never })
+
+			await (hub as any).fetchServerCapabilities(connection)
+
+			client.request.callCount.should.equal(4)
+			Math.max(...inFlightAtStart).should.equal(4)
+		})
+
 		it("should augment request-timeout errors with how to raise the bound", async () => {
 			const failingClient = {
 				request: sinon.stub().rejects(new McpError(ErrorCode.RequestTimeout, "Request timed out")),

--- a/apps/vscode/src/services/mcp/__tests__/McpHub.connectFailure.test.ts
+++ b/apps/vscode/src/services/mcp/__tests__/McpHub.connectFailure.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { StateManager } from "@core/storage/StateManager"
+import sinon from "sinon"
+import { McpHub } from "../McpHub"
+
+/**
+ * A server whose connection attempt fails must remain visible in the
+ * in-memory server list as a disconnected entry carrying the error, and
+ * reconciliation must notify the webview of that state. These tests drive
+ * the real `connectToServer` failure path (a stdio command that cannot
+ * spawn) rather than stubbing it.
+ */
+
+describe("McpHub connect failure", () => {
+	let sandbox: sinon.SinonSandbox
+
+	beforeEach(() => {
+		sandbox = sinon.createSandbox()
+		sandbox.stub(StateManager, "get").returns({
+			getRemoteConfigSettings: () => ({}),
+		} as unknown as StateManager)
+	})
+
+	afterEach(() => {
+		sandbox.restore()
+	})
+
+	function createHub() {
+		const hub = Object.create(McpHub.prototype) as McpHub
+		;(hub as any).connections = []
+		;(hub as any).isConnecting = false
+		;(hub as any).clientVersion = "0.0.0"
+		sandbox.stub(hub as any, "notifyWebviewOfServerChanges").resolves()
+		return hub
+	}
+
+	it("keeps a failed server visible as disconnected with its error", async () => {
+		const hub = createHub()
+		const config = {
+			type: "stdio" as const,
+			command: "this-command-does-not-exist-anywhere",
+			args: [],
+			autoApprove: [],
+			disabled: false,
+			timeout: 60,
+		}
+
+		await expect((hub as any).connectToServer("broken-server", config, "internal")).rejects.toThrow()
+
+		const connection = (hub as any).connections.find((conn: any) => conn.server.name === "broken-server")
+		expect(connection).toBeDefined()
+		expect(connection.server.status).toBe("disconnected")
+		expect(connection.server.error.length).toBeGreaterThan(0)
+	})
+
+	it("notifies the webview when a reconnect after a config change fails", async () => {
+		const hub = createHub()
+		sandbox.stub(hub as any, "removeAllFileWatchers")
+		sandbox.stub(hub as any, "setupFileWatcher")
+		sandbox.stub(hub as any, "deleteConnection").callsFake(async () => {
+			;(hub as any).connections = []
+		})
+		;(hub as any).connections = [
+			{
+				server: {
+					name: "broken-server",
+					config: JSON.stringify({ type: "stdio", command: "old-command", timeout: 60 }),
+					status: "connected",
+					disabled: false,
+				},
+				client: {},
+				transport: {},
+			},
+		]
+
+		await hub.updateServerConnections({
+			"broken-server": {
+				type: "stdio",
+				command: "this-command-does-not-exist-anywhere",
+				args: [],
+				autoApprove: [],
+				disabled: false,
+				timeout: 60,
+			} as any,
+		})
+
+		const connection = (hub as any).connections.find((conn: any) => conn.server.name === "broken-server")
+		expect(connection).toBeDefined()
+		expect(connection.server.status).toBe("disconnected")
+		// The final notification must fire so the webview leaves "connecting"
+		// and shows the errored entry.
+		expect(((hub as any).notifyWebviewOfServerChanges as sinon.SinonStub).callCount).toBeGreaterThanOrEqual(2)
+	})
+})

--- a/apps/vscode/src/services/mcp/__tests__/McpHub.timeoutReconnect.test.ts
+++ b/apps/vscode/src/services/mcp/__tests__/McpHub.timeoutReconnect.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "bun:test"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import sinon from "sinon"
+import { McpHub } from "../McpHub"
+
+describe("McpHub timeout reconciliation", () => {
+	it("rebuilds a connection when only its timeout changes", async () => {
+		const hub = Object.create(McpHub.prototype) as McpHub
+		const oldConnection = {
+			server: {
+				name: "slow-server",
+				config: JSON.stringify({ type: "stdio", command: "node", timeout: 60 }),
+				status: "connected",
+				disabled: false,
+			},
+			client: {},
+			transport: {},
+		}
+		;(hub as any).connections = [oldConnection]
+		;(hub as any).isConnecting = false
+		const deleteConnection = sinon.stub(hub as any, "deleteConnection").callsFake(async () => {
+			;(hub as any).connections = []
+		})
+		const connectToServer = sinon.stub(hub as any, "connectToServer").resolves()
+		sinon.stub(hub as any, "removeAllFileWatchers")
+		sinon.stub(hub as any, "setupFileWatcher")
+
+		await hub.updateServerConnectionsRPC({
+			"slow-server": {
+				type: "stdio",
+				command: "node",
+				timeout: 120,
+			},
+		})
+
+		expect(deleteConnection.calledOnce).toBe(true)
+		expect(connectToServer.calledOnce).toBe(true)
+		expect(connectToServer.firstCall.args[1]).toMatchObject({ timeout: 120 })
+	})
+
+	it("reconciles the persisted timeout after an RPC update", async () => {
+		const tempDir = await mkdtemp(join(tmpdir(), "mcp-timeout-rpc-"))
+		try {
+			await writeFile(
+				join(tempDir, "cline_mcp_settings.json"),
+				JSON.stringify({
+					mcpServers: {
+						"slow-server": {
+							type: "stdio",
+							command: "node",
+							timeout: 60,
+						},
+					},
+				}),
+				"utf8",
+			)
+			const hub = Object.create(McpHub.prototype) as McpHub
+			;(hub as any).getSettingsDirectoryPath = async () => tempDir
+			;(hub as any).connections = [
+				{
+					server: {
+						name: "slow-server",
+						config: JSON.stringify({ type: "stdio", command: "node", timeout: 60 }),
+						status: "connected",
+						disabled: false,
+					},
+					client: {},
+					transport: {},
+				},
+			]
+			const reconcile = sinon.stub(hub, "updateServerConnectionsRPC").resolves()
+
+			await hub.updateServerTimeoutRPC("slow-server", 120)
+
+			expect(reconcile.calledOnce).toBe(true)
+			expect(reconcile.firstCall.args[0]).toMatchObject({
+				"slow-server": { timeout: 120 },
+			})
+		} finally {
+			await rm(tempDir, { recursive: true, force: true })
+		}
+	})
+})

--- a/apps/vscode/src/services/mcp/__tests__/McpHub.timeoutReconnect.test.ts
+++ b/apps/vscode/src/services/mcp/__tests__/McpHub.timeoutReconnect.test.ts
@@ -8,22 +8,27 @@ import { McpHub } from "../McpHub"
 describe("McpHub timeout reconciliation", () => {
 	it("rebuilds a connection when only its timeout changes", async () => {
 		const hub = Object.create(McpHub.prototype) as McpHub
-		const oldConnection = {
+		const makeConnection = (timeout: number) => ({
 			server: {
 				name: "slow-server",
-				config: JSON.stringify({ type: "stdio", command: "node", timeout: 60 }),
+				config: JSON.stringify({ type: "stdio", command: "node", timeout }),
 				status: "connected",
 				disabled: false,
+				tools: [{ name: "slow-tool", inputSchema: { type: "object" } }],
 			},
 			client: {},
 			transport: {},
-		}
-		;(hub as any).connections = [oldConnection]
+		})
+		;(hub as any).connections = [makeConnection(60)]
 		;(hub as any).isConnecting = false
+		const toolListChanged = sinon.stub()
+		hub.setToolListChangeCallback(toolListChanged)
 		const deleteConnection = sinon.stub(hub as any, "deleteConnection").callsFake(async () => {
 			;(hub as any).connections = []
 		})
-		const connectToServer = sinon.stub(hub as any, "connectToServer").resolves()
+		const connectToServer = sinon.stub(hub as any, "connectToServer").callsFake(async () => {
+			;(hub as any).connections = [makeConnection(120)]
+		})
 		sinon.stub(hub as any, "removeAllFileWatchers")
 		sinon.stub(hub as any, "setupFileWatcher")
 
@@ -38,6 +43,8 @@ describe("McpHub timeout reconciliation", () => {
 		expect(deleteConnection.calledOnce).toBe(true)
 		expect(connectToServer.calledOnce).toBe(true)
 		expect(connectToServer.firstCall.args[1]).toMatchObject({ timeout: 120 })
+		await new Promise((resolve) => setTimeout(resolve, 350))
+		expect(toolListChanged.calledOnce).toBe(true)
 	})
 
 	it("reconciles the persisted timeout after an RPC update", async () => {

--- a/apps/vscode/src/services/mcp/__tests__/McpHub.toolListChange.test.ts
+++ b/apps/vscode/src/services/mcp/__tests__/McpHub.toolListChange.test.ts
@@ -6,12 +6,13 @@
  * 2. The toolListChangeCallback fires only when the tool list actually changes
  * 3. The callback does NOT fire on mere status updates (error messages, etc.)
  *
- * We avoid importing McpHub directly (too many transitive deps for unit tests).
- * Instead we extract the pure logic and test it in isolation.
+ * Fingerprint assertions call the production McpHub method so the session
+ * rebuild boundary cannot drift from a test-only implementation.
  */
 import { describe, it } from "bun:test"
 import "should"
 import sinon from "sinon"
+import { McpHub } from "../McpHub"
 
 // ---------------------------------------------------------------------------
 // Extract the pure logic from McpHub for testing
@@ -21,24 +22,17 @@ import sinon from "sinon"
 interface MinimalConnection {
 	server: {
 		name: string
+		config: string
 		status: string
 		disabled?: boolean
-		tools?: Array<{ name: string }>
+		tools?: Array<{ name: string; description?: string; inputSchema?: object }>
 	}
 }
 
 function computeToolFingerprint(connections: MinimalConnection[]): string {
-	const entries: string[] = []
-	for (const conn of connections) {
-		if (conn.server.disabled || conn.server.status !== "connected") {
-			continue
-		}
-		for (const tool of conn.server.tools ?? []) {
-			entries.push(`${conn.server.name}:${tool.name}`)
-		}
-	}
-	entries.sort()
-	return entries.join("|")
+	const hub = Object.create(McpHub.prototype) as McpHub
+	;(hub as unknown as { connections: MinimalConnection[] }).connections = connections
+	return hub.computeToolFingerprint()
 }
 
 /**
@@ -71,13 +65,21 @@ function createToolListChangeTracker() {
 	}
 }
 
-function makeConnection(name: string, status: string, tools: string[], disabled = false): MinimalConnection {
+function makeConnection(
+	name: string,
+	status: string,
+	tools: string[],
+	disabled = false,
+	timeout = 60,
+	toolOverrides: Record<string, Partial<{ description: string; inputSchema: object }>> = {},
+): MinimalConnection {
 	return {
 		server: {
 			name,
+			config: JSON.stringify({ type: "stdio", command: "node", timeout }),
 			status,
 			disabled,
-			tools: tools.map((t) => ({ name: t })),
+			tools: tools.map((toolName) => ({ name: toolName, ...toolOverrides[toolName] })),
 		},
 	}
 }
@@ -89,14 +91,16 @@ function makeConnection(name: string, status: string, tools: string[], disabled 
 describe("McpHub tool list change detection", () => {
 	describe("computeToolFingerprint", () => {
 		it("should return empty string when no servers are connected", () => {
-			computeToolFingerprint([]).should.equal("")
+			computeToolFingerprint([]).should.equal("[]")
 		})
 
 		it("should include tools from connected, non-disabled servers", () => {
 			const connections = [makeConnection("server-a", "connected", ["tool1", "tool2"])]
-			const fp = computeToolFingerprint(connections)
-			fp.should.containEql("server-a:tool1")
-			fp.should.containEql("server-a:tool2")
+			const entries = JSON.parse(computeToolFingerprint(connections)).map((entry: string) => JSON.parse(entry))
+			entries.should.deepEqual([
+				["server-a", "tool1", null, {}, 60_000],
+				["server-a", "tool2", null, {}, 60_000],
+			])
 		})
 
 		it("should exclude tools from disconnected servers", () => {
@@ -104,19 +108,18 @@ describe("McpHub tool list change detection", () => {
 				makeConnection("server-a", "connected", ["tool1"]),
 				makeConnection("server-b", "disconnected", ["tool2"]),
 			]
-			const fp = computeToolFingerprint(connections)
-			fp.should.containEql("server-a:tool1")
-			fp.should.not.containEql("server-b:tool2")
+			const entries = JSON.parse(computeToolFingerprint(connections)).map((entry: string) => JSON.parse(entry))
+			entries.should.deepEqual([["server-a", "tool1", null, {}, 60_000]])
 		})
 
 		it("should exclude tools from disabled servers", () => {
 			const connections = [makeConnection("server-a", "connected", ["tool1"], true)]
-			computeToolFingerprint(connections).should.equal("")
+			computeToolFingerprint(connections).should.equal("[]")
 		})
 
 		it("should exclude tools from connecting servers", () => {
 			const connections = [makeConnection("server-a", "connecting", ["tool1"])]
-			computeToolFingerprint(connections).should.equal("")
+			computeToolFingerprint(connections).should.equal("[]")
 		})
 
 		it("should produce sorted, deterministic output regardless of insertion order", () => {
@@ -135,6 +138,42 @@ describe("McpHub tool list change detection", () => {
 			const fp1 = computeToolFingerprint([makeConnection("s", "connected", ["tool1"])])
 			const fp2 = computeToolFingerprint([makeConnection("s", "connected", ["tool2"])])
 			fp1.should.not.equal(fp2)
+		})
+
+		it("should produce different fingerprints for different wrapper timeouts", () => {
+			const fp1 = computeToolFingerprint([makeConnection("s", "connected", ["tool1"], false, 60)])
+			const fp2 = computeToolFingerprint([makeConnection("s", "connected", ["tool1"], false, 120)])
+			fp1.should.not.equal(fp2)
+		})
+
+		it("should produce different fingerprints for different descriptions", () => {
+			const fp1 = computeToolFingerprint([makeConnection("s", "connected", ["tool1"])])
+			const fp2 = computeToolFingerprint([
+				makeConnection("s", "connected", ["tool1"], false, 60, {
+					tool1: { description: "updated" },
+				}),
+			])
+			fp1.should.not.equal(fp2)
+		})
+
+		it("should fingerprint schemas deterministically and detect schema changes", () => {
+			const fp1 = computeToolFingerprint([
+				makeConnection("s", "connected", ["tool1"], false, 60, {
+					tool1: { inputSchema: { type: "object", properties: { a: { type: "string" } } } },
+				}),
+			])
+			const sameSchemaDifferentKeyOrder = computeToolFingerprint([
+				makeConnection("s", "connected", ["tool1"], false, 60, {
+					tool1: { inputSchema: { properties: { a: { type: "string" } }, type: "object" } },
+				}),
+			])
+			const changedSchema = computeToolFingerprint([
+				makeConnection("s", "connected", ["tool1"], false, 60, {
+					tool1: { inputSchema: { type: "object", properties: { b: { type: "number" } } } },
+				}),
+			])
+			fp1.should.equal(sameSchemaDifferentKeyOrder)
+			fp1.should.not.equal(changedSchema)
 		})
 	})
 

--- a/apps/vscode/src/services/mcp/__tests__/McpHub.toolListChange.test.ts
+++ b/apps/vscode/src/services/mcp/__tests__/McpHub.toolListChange.test.ts
@@ -90,7 +90,7 @@ function makeConnection(
 
 describe("McpHub tool list change detection", () => {
 	describe("computeToolFingerprint", () => {
-		it("should return empty string when no servers are connected", () => {
+		it("should return an empty structured fingerprint when no servers are connected", () => {
 			computeToolFingerprint([]).should.equal("[]")
 		})
 

--- a/apps/vscode/src/services/mcp/__tests__/schemas.test.ts
+++ b/apps/vscode/src/services/mcp/__tests__/schemas.test.ts
@@ -253,6 +253,26 @@ describe("McpSettingsSchema", () => {
 			result.data!.mcpServers["cliServer"].type.should.equal("streamableHttp")
 			result.data!.mcpServers["extensionServer"].type.should.equal("stdio")
 		})
+
+		it("normalises malformed and out-of-range timeouts without rejecting siblings", () => {
+			const result = McpSettingsSchema.safeParse({
+				mcpServers: {
+					malformed: {
+						transport: { type: "stdio", command: "node" },
+						timeout: "120",
+					},
+					tooSmall: { command: "node", timeout: 0 },
+					tooLarge: { command: "node", timeout: 60_000 },
+					valid: { command: "node", timeout: 120 },
+				},
+			})
+
+			result.success.should.be.true()
+			result.data!.mcpServers.malformed.timeout.should.equal(60)
+			result.data!.mcpServers.tooSmall.timeout.should.equal(1)
+			result.data!.mcpServers.tooLarge.timeout.should.equal(3600)
+			result.data!.mcpServers.valid.timeout.should.equal(120)
+		})
 	})
 
 	// -------------------------------------------------------------------------

--- a/apps/vscode/src/services/mcp/constants.ts
+++ b/apps/vscode/src/services/mcp/constants.ts
@@ -1,10 +1,4 @@
 /**
- * Default timeout for internal MCP data requests in milliseconds.
- * This is not the same as the user facing timeout stored as DEFAULT_MCP_TIMEOUT_SECONDS.
- */
-export const DEFAULT_REQUEST_TIMEOUT_MS = 5000
-
-/**
  * Custom error message for better user feedback when server type validation fails.
  */
 export const TYPE_ERROR_MESSAGE = "Server type must be one of: 'stdio', 'sse', or 'streamableHttp'"

--- a/apps/vscode/src/services/mcp/schemas.ts
+++ b/apps/vscode/src/services/mcp/schemas.ts
@@ -1,13 +1,23 @@
-import { DEFAULT_MCP_TIMEOUT_SECONDS, MIN_MCP_TIMEOUT_SECONDS } from "@shared/mcp"
+import {
+	DEFAULT_MCP_TIMEOUT_SECONDS,
+	MAX_MCP_TIMEOUT_SECONDS,
+	MIN_MCP_TIMEOUT_SECONDS,
+	resolveMcpTimeoutSeconds,
+} from "@shared/mcp"
 import { z } from "zod"
 import { TYPE_ERROR_MESSAGE } from "./constants"
 
 const AutoApproveSchema = z.array(z.string()).default([])
 
+// Settings reads are tolerant: a malformed optional timeout must not reject
+// every MCP server. Writes use the strict schema exported below.
+const ReadTimeoutSchema = z.preprocess(resolveMcpTimeoutSeconds, z.number()).optional().default(DEFAULT_MCP_TIMEOUT_SECONDS)
+export const McpTimeoutSecondsSchema = z.number().finite().min(MIN_MCP_TIMEOUT_SECONDS).max(MAX_MCP_TIMEOUT_SECONDS)
+
 export const BaseConfigSchema = z.object({
 	autoApprove: AutoApproveSchema.optional(),
 	disabled: z.boolean().optional(),
-	timeout: z.number().min(MIN_MCP_TIMEOUT_SECONDS).optional().default(DEFAULT_MCP_TIMEOUT_SECONDS),
+	timeout: ReadTimeoutSchema,
 	// Marker for servers that were added by remote config sync.
 	// Used to identify which servers should be removed when they are no longer in the remote config.
 	remoteConfigured: z.boolean().optional(),
@@ -62,7 +72,7 @@ const nestedTransportConfigSchema = z
 		]),
 		disabled: z.boolean().optional(),
 		autoApprove: AutoApproveSchema.optional(),
-		timeout: z.number().min(MIN_MCP_TIMEOUT_SECONDS).optional().default(DEFAULT_MCP_TIMEOUT_SECONDS),
+		timeout: ReadTimeoutSchema,
 		remoteConfigured: z.boolean().optional(),
 		oauth: z.unknown().optional(),
 		metadata: z.unknown().optional(),

--- a/apps/vscode/src/services/mcp/timeout.ts
+++ b/apps/vscode/src/services/mcp/timeout.ts
@@ -1,0 +1,38 @@
+import { resolveMcpTimeoutSeconds } from "@cline/shared"
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js"
+import { secondsToMs } from "@utils/time"
+
+/**
+ * Resolve the per-server MCP request timeout (ms) from a raw server config
+ * JSON string (the `timeout` field, in seconds). Never throws: a malformed
+ * config yields the shared default so one bad value cannot break a server.
+ *
+ * This is the single resolver for every request the extension sends to an
+ * MCP server — tools/call, tools/list, resources/*, prompts/* — so all of
+ * them agree on the same bound. The config is re-read on each call, so a
+ * changed timeout takes effect on the next request.
+ */
+export function resolveMcpServerTimeoutMs(configJson: string): number {
+	try {
+		return secondsToMs(resolveMcpTimeoutSeconds(JSON.parse(configJson)?.timeout))
+	} catch {
+		return secondsToMs(resolveMcpTimeoutSeconds(undefined))
+	}
+}
+
+/**
+ * If `error` is an MCP request timeout, return an equivalent McpError whose
+ * message names the bound and how to raise it; otherwise return the error
+ * unchanged.
+ */
+export function augmentMcpTimeoutError(error: unknown, serverName: string, timeoutMs: number): unknown {
+	if (!(error instanceof McpError) || error.code !== ErrorCode.RequestTimeout) {
+		return error
+	}
+	return new McpError(
+		error.code,
+		`MCP request to "${serverName}" timed out after ${Math.round(timeoutMs / 1000)}s. ` +
+			`Increase the "timeout" field (in seconds) for this server in cline_mcp_settings.json.`,
+		error.data,
+	)
+}

--- a/apps/vscode/src/services/mcp/timeout.ts
+++ b/apps/vscode/src/services/mcp/timeout.ts
@@ -1,5 +1,6 @@
+export { augmentMcpTimeoutError } from "@cline/core"
+
 import { resolveMcpTimeoutSeconds } from "@cline/shared"
-import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js"
 import { secondsToMs } from "@utils/time"
 
 /**
@@ -18,21 +19,4 @@ export function resolveMcpServerTimeoutMs(configJson: string): number {
 	} catch {
 		return secondsToMs(resolveMcpTimeoutSeconds(undefined))
 	}
-}
-
-/**
- * If `error` is an MCP request timeout, return an equivalent McpError whose
- * message names the bound and how to raise it; otherwise return the error
- * unchanged.
- */
-export function augmentMcpTimeoutError(error: unknown, serverName: string, timeoutMs: number): unknown {
-	if (!(error instanceof McpError) || error.code !== ErrorCode.RequestTimeout) {
-		return error
-	}
-	return new McpError(
-		error.code,
-		`MCP request to "${serverName}" timed out after ${Math.round(timeoutMs / 1000)}s. ` +
-			`Increase the "timeout" field (in seconds) for this server in cline_mcp_settings.json.`,
-		error.data,
-	)
 }

--- a/apps/vscode/src/shared/mcp.ts
+++ b/apps/vscode/src/shared/mcp.ts
@@ -2,9 +2,15 @@
  * Identifier for the MCP tools that are used in native tool calls,
  * where each tool name is the combination of the server name + identifier + tool name.
  * This enables to uniquely identify which MCP server a tool belongs to.
+ *
+ * The timeout constants are re-exported from @cline/shared so the extension,
+ * CLI, and standalone core all resolve the same default and bounds.
  */
-export const DEFAULT_MCP_TIMEOUT_SECONDS = 60 // matches Anthropic's default timeout in their MCP SDK
-export const MIN_MCP_TIMEOUT_SECONDS = 1
+export {
+	DEFAULT_MCP_TIMEOUT_SECONDS,
+	MAX_MCP_TIMEOUT_SECONDS,
+	MIN_MCP_TIMEOUT_SECONDS,
+} from "@cline/shared"
 
 export type McpServer = {
 	name: string

--- a/apps/vscode/src/shared/mcp.ts
+++ b/apps/vscode/src/shared/mcp.ts
@@ -10,6 +10,7 @@ export {
 	DEFAULT_MCP_TIMEOUT_SECONDS,
 	MAX_MCP_TIMEOUT_SECONDS,
 	MIN_MCP_TIMEOUT_SECONDS,
+	resolveMcpTimeoutSeconds,
 } from "@cline/shared"
 
 export type McpServer = {

--- a/apps/vscode/src/shared/mcp.ts
+++ b/apps/vscode/src/shared/mcp.ts
@@ -65,51 +65,6 @@ export type McpPrompt = {
 	arguments?: McpPromptArgument[]
 }
 
-type McpPromptMessageContent =
-	| {
-			type: "text"
-			text: string
-	  }
-	| {
-			type: "image"
-			data: string
-			mimeType: string
-	  }
-	| {
-			type: "audio"
-			data: string
-			mimeType: string
-	  }
-	| {
-			type: "resource"
-			resource: {
-				uri: string
-				mimeType?: string
-				text?: string
-				blob?: string
-			}
-	  }
-
-type McpPromptMessage = {
-	role: "user" | "assistant"
-	content: McpPromptMessageContent
-}
-
-export type McpPromptResponse = {
-	description?: string
-	messages: McpPromptMessage[]
-}
-
-export type McpResourceResponse = {
-	_meta?: Record<string, any>
-	contents: Array<{
-		uri: string
-		mimeType?: string
-		text?: string
-		blob?: string
-	}>
-}
-
 export type McpToolCallResponse = {
 	_meta?: Record<string, any>
 	content: Array<

--- a/apps/vscode/src/test/cline-core-vitest-stub.ts
+++ b/apps/vscode/src/test/cline-core-vitest-stub.ts
@@ -102,6 +102,7 @@ export function createShellExecutor() {
 	return async () => ""
 }
 
+export { augmentMcpTimeoutError } from "../../../../sdk/packages/core/src/extensions/mcp/timeout"
 // The real createShellTool, so tests exercise the actual description
 // building and shell classification (getShellKind) rather than a stub that
 // would have to duplicate those invariants.

--- a/apps/vscode/webview-ui/src/components/mcp/configuration/tabs/installed/server-row/ServerRow.tsx
+++ b/apps/vscode/webview-ui/src/components/mcp/configuration/tabs/installed/server-row/ServerRow.tsx
@@ -393,6 +393,10 @@ const ServerRow = ({
 							<VSCodeDropdown className="w-full" onChange={handleTimeoutChange} value={timeoutValue}>
 								{TimeoutOptions}
 							</VSCodeDropdown>
+							<p className="mt-1 mb-0 text-xs text-description">
+								Applies to every request this server handles, in VS Code and the CLI. For other values, set
+								"timeout" (seconds) in cline_mcp_settings.json.
+							</p>
 						</div>
 						<Button
 							className="w-[calc(100%-14px)] mt-1 mx-1.5 mb-3"

--- a/sdk/packages/core/src/extensions/mcp/client-url.test.ts
+++ b/sdk/packages/core/src/extensions/mcp/client-url.test.ts
@@ -1,0 +1,114 @@
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const clientState = vi.hoisted(() => ({
+	connectOptions: undefined as unknown,
+	listToolsOptions: undefined as unknown,
+	callToolOptions: undefined as unknown,
+	callToolError: undefined as unknown,
+	connectError: undefined as unknown,
+	closeCount: 0,
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+	Client: class {
+		async connect(_transport: unknown, options: unknown): Promise<void> {
+			clientState.connectOptions = options;
+			if (clientState.connectError) {
+				throw clientState.connectError;
+			}
+		}
+
+		async close(): Promise<void> {
+			clientState.closeCount += 1;
+		}
+
+		async listTools(_params: unknown, options: unknown) {
+			clientState.listToolsOptions = options;
+			return { tools: [] };
+		}
+
+		async callTool(
+			_request: unknown,
+			_resultSchema: unknown,
+			options: unknown,
+		) {
+			clientState.callToolOptions = options;
+			if (clientState.callToolError) {
+				throw clientState.callToolError;
+			}
+			return { content: [] };
+		}
+	},
+}));
+
+import { createDefaultMcpServerClientFactory } from "./client";
+
+describe("SDK URL MCP client timeout", () => {
+	beforeEach(() => {
+		clientState.connectOptions = undefined;
+		clientState.listToolsOptions = undefined;
+		clientState.callToolOptions = undefined;
+		clientState.callToolError = undefined;
+		clientState.connectError = undefined;
+		clientState.closeCount = 0;
+	});
+
+	async function createClient(timeoutSeconds = 12) {
+		return createDefaultMcpServerClientFactory()({
+			name: "remote",
+			transport: {
+				type: "streamableHttp",
+				url: "https://mcp.example.test",
+			},
+			timeoutSeconds,
+		});
+	}
+
+	it("uses one timeout snapshot for initialize, list, and call", async () => {
+		const client = await createClient();
+		const controller = new AbortController();
+
+		await client.connect();
+		await client.listTools();
+		await client.callTool({
+			name: "slow",
+			context: {
+				agentId: "test-agent",
+				iteration: 1,
+				signal: controller.signal,
+			},
+		});
+
+		expect(clientState.connectOptions).toEqual({ timeout: 12_000 });
+		expect(clientState.listToolsOptions).toEqual({ timeout: 12_000 });
+		expect(clientState.callToolOptions).toEqual({
+			timeout: 12_000,
+			signal: controller.signal,
+		});
+	});
+
+	it("adds the effective bound and setting hint to timeout errors", async () => {
+		const client = await createClient();
+		await client.connect();
+		clientState.callToolError = new McpError(
+			ErrorCode.RequestTimeout,
+			"Request timed out",
+		);
+
+		await expect(client.callTool({ name: "slow" })).rejects.toThrow(
+			/timed out after 12s.*"timeout" field \(in seconds\)/s,
+		);
+	});
+
+	it("closes the SDK client when initialize times out", async () => {
+		clientState.connectError = new McpError(
+			ErrorCode.RequestTimeout,
+			"Request timed out",
+		);
+		const client = await createClient();
+
+		await expect(client.connect()).rejects.toThrow(/timed out after 12s/);
+		expect(clientState.closeCount).toBe(1);
+	});
+});

--- a/sdk/packages/core/src/extensions/mcp/client.test.ts
+++ b/sdk/packages/core/src/extensions/mcp/client.test.ts
@@ -1,0 +1,185 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createDefaultMcpServerClientFactory } from "./client";
+import type { McpServerRegistration } from "./types";
+
+/**
+ * Integration tests for MCP client request timeouts against a real stdio
+ * child process. The fake server is a Node script speaking newline-delimited
+ * JSON-RPC with an env-controlled response delay, so the tests cross the
+ * actual process/stdio boundary where the timeout risk lives.
+ */
+
+const FAKE_SERVER_SCRIPT = `
+let buffer = "";
+process.stdin.on("data", (chunk) => {
+	buffer += chunk.toString("utf8");
+	let idx;
+	while ((idx = buffer.indexOf("\\n")) >= 0) {
+		const line = buffer.slice(0, idx).trim();
+		buffer = buffer.slice(idx + 1);
+		if (!line) continue;
+		let msg;
+		try {
+			msg = JSON.parse(line);
+		} catch {
+			// Tolerate the framed-mode probe attempt: its Content-Length header
+			// line is not JSON, but the embedded body line is handled next.
+			continue;
+		}
+		if (msg.id === undefined || !msg.method || msg.method.startsWith("notifications/")) continue;
+		const delay = Number(
+			msg.method === "initialize"
+				? (process.env.FAKE_MCP_INIT_DELAY_MS ?? "0")
+				: (process.env.FAKE_MCP_DELAY_MS ?? "0"),
+		);
+		setTimeout(() => {
+			let result;
+			if (msg.method === "initialize") {
+				result = {
+					protocolVersion: "2024-11-05",
+					capabilities: {},
+					serverInfo: { name: "fake", version: "0.0.0" },
+				};
+			} else if (msg.method === "tools/list") {
+				result = { tools: [] };
+			} else if (msg.method === "tools/call") {
+				result = { content: [{ type: "text", text: "ok" }] };
+			} else {
+				result = {};
+			}
+			process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result }) + "\\n");
+		}, delay);
+	}
+});
+process.stdin.on("end", () => process.exit(0));
+`;
+
+let tempRoot: string;
+
+beforeAll(() => {
+	tempRoot = mkdtempSync(join(tmpdir(), "mcp-client-test-"));
+	writeFileSync(join(tempRoot, "fake-server.js"), FAKE_SERVER_SCRIPT, "utf8");
+});
+
+afterAll(() => {
+	rmSync(tempRoot, { recursive: true, force: true });
+});
+
+function fakeServerRegistration(options: {
+	timeoutSeconds?: number;
+	delayMs: number;
+	initDelayMs?: number;
+}): McpServerRegistration {
+	return {
+		name: "fake-server",
+		transport: {
+			type: "stdio",
+			// Quoted for the win32 shell:true spawn path, where the runtime may
+			// live under a directory containing spaces.
+			command:
+				process.platform === "win32"
+					? `"${process.execPath}"`
+					: process.execPath,
+			args: [join(tempRoot, "fake-server.js")],
+			env: {
+				FAKE_MCP_DELAY_MS: String(options.delayMs),
+				...(options.initDelayMs === undefined
+					? {}
+					: { FAKE_MCP_INIT_DELAY_MS: String(options.initDelayMs) }),
+			},
+		},
+		...(options.timeoutSeconds === undefined
+			? {}
+			: { timeoutSeconds: options.timeoutSeconds }),
+	};
+}
+
+describe("mcp client request timeout", () => {
+	it("lets a slow server respond beyond the old 5s default when configured higher", async () => {
+		const factory = createDefaultMcpServerClientFactory();
+		const client = await factory(
+			fakeServerRegistration({ timeoutSeconds: 30, delayMs: 6_000 }),
+		);
+		try {
+			await client.connect();
+			const tools = await client.listTools();
+			expect(tools).toEqual([]);
+		} finally {
+			await client.disconnect();
+		}
+	}, 30_000);
+
+	it("times out with a message naming the bound and the field to change", async () => {
+		const factory = createDefaultMcpServerClientFactory();
+		const client = await factory(
+			fakeServerRegistration({ timeoutSeconds: 1, delayMs: 5_000 }),
+		);
+		try {
+			await client.connect();
+			await expect(client.callTool({ name: "anything" })).rejects.toThrow(
+				/timed out for "fake-server" \(tools\/call\) after 1s.*"timeout" field \(in seconds\)/s,
+			);
+		} finally {
+			await client.disconnect();
+		}
+	}, 30_000);
+
+	it("raises the initialize probe budget when a timeout is configured", async () => {
+		const factory = createDefaultMcpServerClientFactory();
+		// 3s of startup work would fail the old 1.5s probe; the configured
+		// 10s timeout lets initialize finish.
+		const client = await factory(
+			fakeServerRegistration({
+				timeoutSeconds: 10,
+				delayMs: 0,
+				initDelayMs: 3_000,
+			}),
+		);
+		try {
+			await client.connect();
+			const tools = await client.listTools();
+			expect(tools).toEqual([]);
+		} finally {
+			await client.disconnect();
+		}
+	}, 30_000);
+
+	it("keeps the fast probe default when no timeout is configured", async () => {
+		const factory = createDefaultMcpServerClientFactory();
+		// 3s of startup work exceeds the 1.5s default probe, so connect must
+		// fail quickly instead of stalling startup.
+		const client = await factory(
+			fakeServerRegistration({ delayMs: 0, initDelayMs: 3_000 }),
+		);
+		const startedAt = Date.now();
+		try {
+			await expect(client.connect()).rejects.toThrow(/timed out/);
+			expect(Date.now() - startedAt).toBeLessThan(8_000);
+		} finally {
+			await client.disconnect();
+		}
+	}, 30_000);
+
+	it("fails initialize with the timeout hint when the server never responds", async () => {
+		const factory = createDefaultMcpServerClientFactory();
+		const client = await factory(
+			fakeServerRegistration({
+				timeoutSeconds: 1,
+				delayMs: 0,
+				initDelayMs: 10_000,
+			}),
+		);
+		const startedAt = Date.now();
+		try {
+			await expect(client.connect()).rejects.toThrow(
+				/timed out.*"timeout" field \(in seconds\)/s,
+			);
+			expect(Date.now() - startedAt).toBeLessThan(8_000);
+		} finally {
+			await client.disconnect();
+		}
+	}, 30_000);
+});

--- a/sdk/packages/core/src/extensions/mcp/client.test.ts
+++ b/sdk/packages/core/src/extensions/mcp/client.test.ts
@@ -1,4 +1,10 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -13,7 +19,11 @@ import type { McpServerRegistration } from "./types";
  */
 
 const FAKE_SERVER_SCRIPT = `
+if (process.env.FAKE_MCP_PID_FILE) {
+	require("node:fs").writeFileSync(process.env.FAKE_MCP_PID_FILE, String(process.pid));
+}
 let buffer = "";
+const responseTimers = new Set();
 process.stdin.on("data", (chunk) => {
 	buffer += chunk.toString("utf8");
 	let idx;
@@ -35,7 +45,8 @@ process.stdin.on("data", (chunk) => {
 				? (process.env.FAKE_MCP_INIT_DELAY_MS ?? "0")
 				: (process.env.FAKE_MCP_DELAY_MS ?? "0"),
 		);
-		setTimeout(() => {
+		const responseTimer = setTimeout(() => {
+			responseTimers.delete(responseTimer);
 			let result;
 			if (msg.method === "initialize") {
 				result = {
@@ -52,9 +63,13 @@ process.stdin.on("data", (chunk) => {
 			}
 			process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result }) + "\\n");
 		}, delay);
+		responseTimers.add(responseTimer);
 	}
 });
-process.stdin.on("end", () => process.exit(0));
+process.stdin.on("end", () => {
+	for (const responseTimer of responseTimers) clearTimeout(responseTimer);
+	process.exit(0);
+});
 `;
 
 let tempRoot: string;
@@ -72,6 +87,7 @@ function fakeServerRegistration(options: {
 	timeoutSeconds?: number;
 	delayMs: number;
 	initDelayMs?: number;
+	pidFile?: string;
 }): McpServerRegistration {
 	return {
 		name: "fake-server",
@@ -89,12 +105,37 @@ function fakeServerRegistration(options: {
 				...(options.initDelayMs === undefined
 					? {}
 					: { FAKE_MCP_INIT_DELAY_MS: String(options.initDelayMs) }),
+				...(options.pidFile === undefined
+					? {}
+					: { FAKE_MCP_PID_FILE: options.pidFile }),
 			},
 		},
 		...(options.timeoutSeconds === undefined
 			? {}
 			: { timeoutSeconds: options.timeoutSeconds }),
 	};
+}
+
+async function waitFor(
+	predicate: () => boolean,
+	timeoutMs = 5_000,
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (!predicate()) {
+		if (Date.now() >= deadline) {
+			throw new Error("Timed out waiting for condition");
+		}
+		await new Promise((resolve) => setTimeout(resolve, 25));
+	}
+}
+
+function isProcessRunning(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		return (error as NodeJS.ErrnoException).code !== "ESRCH";
+	}
 }
 
 describe("mcp client request timeout", () => {
@@ -178,6 +219,47 @@ describe("mcp client request timeout", () => {
 				/timed out.*"timeout" field \(in seconds\)/s,
 			);
 			expect(Date.now() - startedAt).toBeLessThan(8_000);
+		} finally {
+			await client.disconnect();
+		}
+	}, 30_000);
+
+	it("terminates the real child when the final initialize attempt fails", async () => {
+		const pidFile = join(tempRoot, `failed-init-${Date.now()}.pid`);
+		const factory = createDefaultMcpServerClientFactory();
+		const client = await factory(
+			fakeServerRegistration({
+				timeoutSeconds: 1,
+				delayMs: 0,
+				initDelayMs: 10_000,
+				pidFile,
+			}),
+		);
+
+		await expect(client.connect()).rejects.toThrow(/timed out/);
+		await waitFor(() => existsSync(pidFile));
+		const pid = Number(readFileSync(pidFile, "utf8"));
+		await waitFor(() => !isProcessRunning(pid));
+	}, 30_000);
+
+	it("aborts a long stdio tool call without waiting for its timeout", async () => {
+		const factory = createDefaultMcpServerClientFactory();
+		const client = await factory(
+			fakeServerRegistration({ timeoutSeconds: 30, delayMs: 10_000 }),
+		);
+		const controller = new AbortController();
+		try {
+			await client.connect();
+			const call = client.callTool({
+				name: "anything",
+				context: {
+					agentId: "test-agent",
+					iteration: 1,
+					signal: controller.signal,
+				},
+			});
+			controller.abort();
+			await expect(call).rejects.toMatchObject({ name: "AbortError" });
 		} finally {
 			await client.disconnect();
 		}

--- a/sdk/packages/core/src/extensions/mcp/client.test.ts
+++ b/sdk/packages/core/src/extensions/mcp/client.test.ts
@@ -9,6 +9,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createDefaultMcpServerClientFactory } from "./client";
+import { resolveMcpServerRegistrations } from "./config-loader";
 import type { McpServerRegistration } from "./types";
 
 /**
@@ -195,6 +196,35 @@ describe("mcp client request timeout", () => {
 		const client = await factory(
 			fakeServerRegistration({ delayMs: 0, initDelayMs: 3_000 }),
 		);
+		const startedAt = Date.now();
+		try {
+			await expect(client.connect()).rejects.toThrow(/timed out/);
+			expect(Date.now() - startedAt).toBeLessThan(8_000);
+		} finally {
+			await client.disconnect();
+		}
+	}, 30_000);
+
+	it("keeps the fast probe when a malformed settings timeout is ignored", async () => {
+		const filePath = join(tempRoot, `malformed-timeout-${Date.now()}.json`);
+		writeFileSync(
+			filePath,
+			JSON.stringify({
+				mcpServers: {
+					"fake-server": {
+						transport: fakeServerRegistration({
+							delayMs: 0,
+							initDelayMs: 3_000,
+						}).transport,
+						timeout: "60",
+					},
+				},
+			}),
+			"utf8",
+		);
+		const [registration] = resolveMcpServerRegistrations({ filePath });
+		expect(registration.timeoutSeconds).toBeUndefined();
+		const client = await createDefaultMcpServerClientFactory()(registration);
 		const startedAt = Date.now();
 		try {
 			await expect(client.connect()).rejects.toThrow(/timed out/);

--- a/sdk/packages/core/src/extensions/mcp/client.test.ts
+++ b/sdk/packages/core/src/extensions/mcp/client.test.ts
@@ -224,6 +224,25 @@ describe("mcp client request timeout", () => {
 		}
 	}, 30_000);
 
+	it("shares one configured initialize timeout across both protocol probes", async () => {
+		const factory = createDefaultMcpServerClientFactory();
+		const client = await factory(
+			fakeServerRegistration({
+				timeoutSeconds: 2,
+				delayMs: 0,
+				initDelayMs: 10_000,
+			}),
+		);
+		const startedAt = Date.now();
+		try {
+			await expect(client.connect()).rejects.toThrow(/after 2s/);
+			// Two independent 2s probes would exceed this bound.
+			expect(Date.now() - startedAt).toBeLessThan(3_500);
+		} finally {
+			await client.disconnect();
+		}
+	}, 30_000);
+
 	it("terminates the real child when the final initialize attempt fails", async () => {
 		const pidFile = join(tempRoot, `failed-init-${Date.now()}.pid`);
 		const factory = createDefaultMcpServerClientFactory();

--- a/sdk/packages/core/src/extensions/mcp/client.test.ts
+++ b/sdk/packages/core/src/extensions/mcp/client.test.ts
@@ -36,8 +36,6 @@ process.stdin.on("data", (chunk) => {
 		try {
 			msg = JSON.parse(line);
 		} catch {
-			// Tolerate the framed-mode probe attempt: its Content-Length header
-			// line is not JSON, but the embedded body line is handled next.
 			continue;
 		}
 		if (msg.id === undefined || !msg.method || msg.method.startsWith("notifications/")) continue;
@@ -254,7 +252,7 @@ describe("mcp client request timeout", () => {
 		}
 	}, 30_000);
 
-	it("shares one configured initialize timeout across both protocol probes", async () => {
+	it("uses the full configured timeout for the initialize request", async () => {
 		const factory = createDefaultMcpServerClientFactory();
 		const client = await factory(
 			fakeServerRegistration({
@@ -266,7 +264,6 @@ describe("mcp client request timeout", () => {
 		const startedAt = Date.now();
 		try {
 			await expect(client.connect()).rejects.toThrow(/after 2s/);
-			// Two independent 2s probes would exceed this bound.
 			expect(Date.now() - startedAt).toBeLessThan(3_500);
 		} finally {
 			await client.disconnect();

--- a/sdk/packages/core/src/extensions/mcp/client.test.ts
+++ b/sdk/packages/core/src/extensions/mcp/client.test.ts
@@ -103,6 +103,30 @@ process.stdin.on("data", (chunk) => {
 });
 `;
 
+// Rejects every newline-delimited request with a JSON-RPC error and never
+// answers framed input (the framed body carries no trailing newline, so it
+// stays buffered), making the two initialize attempts fail differently.
+const NEWLINE_REJECTING_SERVER_SCRIPT = `
+let buffer = "";
+process.stdin.on("data", (chunk) => {
+	buffer += chunk.toString("utf8");
+	let idx;
+	while ((idx = buffer.indexOf("\\n")) >= 0) {
+		const line = buffer.slice(0, idx).trim();
+		buffer = buffer.slice(idx + 1);
+		if (!line) continue;
+		let msg;
+		try {
+			msg = JSON.parse(line);
+		} catch {
+			continue;
+		}
+		if (msg.id === undefined) continue;
+		process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: msg.id, error: { code: -32000, message: "newline framing rejected" } }) + "\\n");
+	}
+});
+`;
+
 let tempRoot: string;
 
 beforeAll(() => {
@@ -111,6 +135,11 @@ beforeAll(() => {
 	writeFileSync(
 		join(tempRoot, "framed-server.js"),
 		FRAMED_SERVER_SCRIPT,
+		"utf8",
+	);
+	writeFileSync(
+		join(tempRoot, "newline-rejecting-server.js"),
+		NEWLINE_REJECTING_SERVER_SCRIPT,
 		"utf8",
 	);
 });
@@ -326,6 +355,27 @@ describe("mcp client request timeout", () => {
 			expect(await client.listTools()).toEqual([]);
 			expect(Date.now() - startedAt).toBeGreaterThanOrEqual(4_500);
 			expect(Date.now() - startedAt).toBeLessThan(7_000);
+		} finally {
+			await client.disconnect();
+		}
+	}, 30_000);
+
+	it("names both framing attempts when they fail differently", async () => {
+		const command =
+			process.platform === "win32" ? `"${process.execPath}"` : process.execPath;
+		const client = await createDefaultMcpServerClientFactory()({
+			name: "rejecting-server",
+			transport: {
+				type: "stdio",
+				command,
+				args: [join(tempRoot, "newline-rejecting-server.js")],
+			},
+			timeoutSeconds: 1,
+		});
+		try {
+			await expect(client.connect()).rejects.toThrow(
+				/Newline-delimited attempt: newline framing rejected.*Content-Length framed attempt: .*timed out/s,
+			);
 		} finally {
 			await client.disconnect();
 		}

--- a/sdk/packages/core/src/extensions/mcp/client.test.ts
+++ b/sdk/packages/core/src/extensions/mcp/client.test.ts
@@ -71,11 +71,47 @@ process.stdin.on("end", () => {
 });
 `;
 
+const FRAMED_SERVER_SCRIPT = `
+let buffer = "";
+function write(payload) {
+	const body = JSON.stringify(payload);
+	process.stdout.write("Content-Length: " + Buffer.byteLength(body, "utf8") + "\\r\\n\\r\\n" + body);
+}
+process.stdin.on("data", (chunk) => {
+	buffer += chunk.toString("utf8");
+	while (true) {
+		const separator = buffer.indexOf("\\r\\n\\r\\n");
+		if (separator < 0) break;
+		const header = buffer.slice(0, separator);
+		const match = header.match(/Content-Length:\\s*(\\d+)/i);
+		if (!match) throw new Error("missing content length");
+		const length = Number(match[1]);
+		const start = separator + 4;
+		const end = start + length;
+		if (buffer.length < end) break;
+		const message = JSON.parse(buffer.slice(start, end));
+		buffer = buffer.slice(end);
+		if (message.method === "notifications/initialized") continue;
+		const result = message.method === "initialize"
+			? { protocolVersion: "2024-11-05", capabilities: {}, serverInfo: { name: "framed", version: "0.0.0" } }
+			: message.method === "tools/list"
+				? { tools: [] }
+				: { content: [] };
+		write({ jsonrpc: "2.0", id: message.id, result });
+	}
+});
+`;
+
 let tempRoot: string;
 
 beforeAll(() => {
 	tempRoot = mkdtempSync(join(tmpdir(), "mcp-client-test-"));
 	writeFileSync(join(tempRoot, "fake-server.js"), FAKE_SERVER_SCRIPT, "utf8");
+	writeFileSync(
+		join(tempRoot, "framed-server.js"),
+		FRAMED_SERVER_SCRIPT,
+		"utf8",
+	);
 });
 
 afterAll(() => {
@@ -160,7 +196,7 @@ describe("mcp client request timeout", () => {
 		try {
 			await client.connect();
 			await expect(client.callTool({ name: "anything" })).rejects.toThrow(
-				/timed out for "fake-server" \(tools\/call\) after 1s.*"timeout" field \(in seconds\)/s,
+				/request to "fake-server" \(tools\/call\) timed out after 1s.*"timeout" field \(in seconds\)/s,
 			);
 		} finally {
 			await client.disconnect();
@@ -264,6 +300,28 @@ describe("mcp client request timeout", () => {
 		const startedAt = Date.now();
 		try {
 			await expect(client.connect()).rejects.toThrow(/after 2s/);
+			expect(Date.now() - startedAt).toBeLessThan(4_500);
+		} finally {
+			await client.disconnect();
+		}
+	}, 30_000);
+
+	it("preserves the bounded Content-Length compatibility fallback", async () => {
+		const command =
+			process.platform === "win32" ? `"${process.execPath}"` : process.execPath;
+		const client = await createDefaultMcpServerClientFactory()({
+			name: "framed-server",
+			transport: {
+				type: "stdio",
+				command,
+				args: [join(tempRoot, "framed-server.js")],
+			},
+			timeoutSeconds: 1,
+		});
+		const startedAt = Date.now();
+		try {
+			await client.connect();
+			expect(await client.listTools()).toEqual([]);
 			expect(Date.now() - startedAt).toBeLessThan(3_500);
 		} finally {
 			await client.disconnect();

--- a/sdk/packages/core/src/extensions/mcp/client.test.ts
+++ b/sdk/packages/core/src/extensions/mcp/client.test.ts
@@ -73,6 +73,7 @@ process.stdin.on("end", () => {
 
 const FRAMED_SERVER_SCRIPT = `
 let buffer = "";
+const initializeDelayMs = Number(process.env.FAKE_MCP_INIT_DELAY_MS ?? "0");
 function write(payload) {
 	const body = JSON.stringify(payload);
 	process.stdout.write("Content-Length: " + Buffer.byteLength(body, "utf8") + "\\r\\n\\r\\n" + body);
@@ -97,7 +98,7 @@ process.stdin.on("data", (chunk) => {
 			: message.method === "tools/list"
 				? { tools: [] }
 				: { content: [] };
-		write({ jsonrpc: "2.0", id: message.id, result });
+		setTimeout(() => write({ jsonrpc: "2.0", id: message.id, result }), message.method === "initialize" ? initializeDelayMs : 0);
 	}
 });
 `;
@@ -306,7 +307,7 @@ describe("mcp client request timeout", () => {
 		}
 	}, 30_000);
 
-	it("preserves the bounded Content-Length compatibility fallback", async () => {
+	it("applies the configured timeout to the Content-Length compatibility request", async () => {
 		const command =
 			process.platform === "win32" ? `"${process.execPath}"` : process.execPath;
 		const client = await createDefaultMcpServerClientFactory()({
@@ -315,14 +316,16 @@ describe("mcp client request timeout", () => {
 				type: "stdio",
 				command,
 				args: [join(tempRoot, "framed-server.js")],
+				env: { FAKE_MCP_INIT_DELAY_MS: "2000" },
 			},
-			timeoutSeconds: 1,
+			timeoutSeconds: 3,
 		});
 		const startedAt = Date.now();
 		try {
 			await client.connect();
 			expect(await client.listTools()).toEqual([]);
-			expect(Date.now() - startedAt).toBeLessThan(3_500);
+			expect(Date.now() - startedAt).toBeGreaterThanOrEqual(4_500);
+			expect(Date.now() - startedAt).toBeLessThan(7_000);
 		} finally {
 			await client.disconnect();
 		}

--- a/sdk/packages/core/src/extensions/mcp/client.ts
+++ b/sdk/packages/core/src/extensions/mcp/client.ts
@@ -1,6 +1,6 @@
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { StringDecoder } from "node:string_decoder";
-import { resolveMcpTimeoutSeconds } from "@cline/shared";
+import type { AgentToolContext } from "@cline/shared";
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { FetchLike } from "@modelcontextprotocol/sdk/shared/transport.js";
@@ -9,6 +9,7 @@ import {
 	createMcpSdkTransport,
 	type McpOAuthProviderContext,
 } from "./oauth";
+import { augmentMcpTimeoutError, resolveMcpRequestTimeoutMs } from "./timeout";
 import type {
 	McpServerClient,
 	McpServerClientFactory,
@@ -139,6 +140,8 @@ class StdioMcpClient implements McpServerClient {
 			resolve: (value: unknown) => void;
 			reject: (error: Error) => void;
 			timeout: ReturnType<typeof setTimeout>;
+			signal?: AbortSignal;
+			onAbort?: () => void;
 		}
 	>();
 	private framedParser = new FramedMessageParser();
@@ -151,8 +154,9 @@ class StdioMcpClient implements McpServerClient {
 
 	constructor(registration: McpServerRegistration) {
 		this.registration = registration;
-		this.requestTimeoutMs =
-			resolveMcpTimeoutSeconds(registration.timeoutSeconds) * 1000;
+		this.requestTimeoutMs = resolveMcpRequestTimeoutMs(
+			registration.timeoutSeconds,
+		);
 		// Keep the fast probe default unless the user opted into patience:
 		// an unconfigured server must not stall startup longer than it did
 		// before per-server timeouts existed.
@@ -199,6 +203,7 @@ class StdioMcpClient implements McpServerClient {
 				lastError = error instanceof Error ? error : new Error(String(error));
 			}
 		}
+		await this.disconnect().catch(() => {});
 
 		throw (
 			lastError ??
@@ -250,11 +255,17 @@ class StdioMcpClient implements McpServerClient {
 	async callTool(request: {
 		name: string;
 		arguments?: Record<string, unknown>;
+		context?: AgentToolContext;
 	}): Promise<McpToolCallResult> {
-		return this.request("tools/call", {
-			name: request.name,
-			arguments: request.arguments ?? {},
-		});
+		return this.request(
+			"tools/call",
+			{
+				name: request.name,
+				arguments: request.arguments ?? {},
+			},
+			undefined,
+			request.context?.signal,
+		);
 	}
 
 	private spawnProcess(protocolMode: StdioProtocolMode): void {
@@ -335,12 +346,10 @@ class StdioMcpClient implements McpServerClient {
 				if (typeof message.id !== "number") {
 					continue;
 				}
-				const pending = this.pending.get(message.id);
+				const pending = this.takePending(message.id);
 				if (!pending) {
 					continue;
 				}
-				this.pending.delete(message.id);
-				clearTimeout(pending.timeout);
 				if (message.error) {
 					const errorMessage =
 						message.error.message ||
@@ -378,6 +387,7 @@ class StdioMcpClient implements McpServerClient {
 		method: string,
 		params?: Record<string, unknown>,
 		timeoutMs = this.requestTimeoutMs,
+		signal?: AbortSignal,
 	): Promise<unknown> {
 		const child = this.process;
 		if (!child?.stdin.writable) {
@@ -396,7 +406,7 @@ class StdioMcpClient implements McpServerClient {
 
 		const resultPromise = new Promise<unknown>((resolve, reject) => {
 			const timeout = setTimeout(() => {
-				this.pending.delete(id);
+				this.takePending(id);
 				// One decimal place so sub-second probe budgets print accurately.
 				const seconds = Math.round(timeoutMs / 100) / 10;
 				reject(
@@ -406,8 +416,35 @@ class StdioMcpClient implements McpServerClient {
 					),
 				);
 			}, timeoutMs);
-			this.pending.set(id, { resolve, reject, timeout });
+			const onAbort = signal
+				? () => {
+						const pending = this.takePending(id);
+						if (!pending) {
+							return;
+						}
+						const error =
+							signal.reason instanceof Error
+								? signal.reason
+								: Object.assign(
+										new Error(
+											`MCP request aborted for "${this.registration.name}" (${method}).`,
+										),
+										{ name: "AbortError" },
+									);
+						pending.reject(error);
+					}
+				: undefined;
+			this.pending.set(id, { resolve, reject, timeout, signal, onAbort });
+			if (signal && onAbort) {
+				signal.addEventListener("abort", onAbort, { once: true });
+				if (signal.aborted) {
+					onAbort();
+				}
+			}
 		});
+		if (!this.pending.has(id)) {
+			return resultPromise;
+		}
 
 		try {
 			child.stdin.write(
@@ -416,12 +453,12 @@ class StdioMcpClient implements McpServerClient {
 					: encodeNewlineMessage(payload),
 			);
 		} catch (error) {
-			const pending = this.pending.get(id);
+			const pending = this.takePending(id);
 			if (pending) {
-				clearTimeout(pending.timeout);
-				this.pending.delete(id);
+				pending.reject(
+					error instanceof Error ? error : new Error(String(error)),
+				);
 			}
-			throw error;
 		}
 
 		return resultPromise;
@@ -445,11 +482,34 @@ class StdioMcpClient implements McpServerClient {
 	}
 
 	private failAllPending(error: Error): void {
-		for (const [id, pending] of this.pending) {
-			clearTimeout(pending.timeout);
-			this.pending.delete(id);
+		for (const id of [...this.pending.keys()]) {
+			const pending = this.takePending(id);
+			if (!pending) {
+				continue;
+			}
 			pending.reject(error);
 		}
+	}
+
+	private takePending(id: number):
+		| {
+				resolve: (value: unknown) => void;
+				reject: (error: Error) => void;
+				timeout: ReturnType<typeof setTimeout>;
+				signal?: AbortSignal;
+				onAbort?: () => void;
+		  }
+		| undefined {
+		const pending = this.pending.get(id);
+		if (!pending) {
+			return undefined;
+		}
+		this.pending.delete(id);
+		clearTimeout(pending.timeout);
+		if (pending.signal && pending.onAbort) {
+			pending.signal.removeEventListener("abort", pending.onAbort);
+		}
+		return pending;
 	}
 }
 
@@ -469,8 +529,9 @@ class SdkUrlMcpClient implements McpServerClient {
 		private readonly registration: McpServerRegistration,
 		private readonly options: DefaultMcpServerClientFactoryOptions,
 	) {
-		this.requestTimeoutMs =
-			resolveMcpTimeoutSeconds(registration.timeoutSeconds) * 1000;
+		this.requestTimeoutMs = resolveMcpRequestTimeoutMs(
+			registration.timeoutSeconds,
+		);
 	}
 
 	async connect(): Promise<void> {
@@ -490,8 +551,9 @@ class SdkUrlMcpClient implements McpServerClient {
 				this.registration.oauth?.redirectUrl ?? DEFAULT_HTTP_MCP_REDIRECT_URL,
 		});
 		this.authContext = authContext;
+		let client: Client | undefined;
 		try {
-			const client = new Client({
+			client = new Client({
 				name: this.options.clientName?.trim() || "@cline/core",
 				version: this.options.clientVersion?.trim() || "0.0.0",
 			});
@@ -504,12 +566,18 @@ class SdkUrlMcpClient implements McpServerClient {
 			await authContext.clearError();
 			this.client = client;
 		} catch (error) {
+			await client?.close().catch(() => {});
+			const effectiveError = augmentMcpTimeoutError(
+				error,
+				this.registration.name,
+				this.requestTimeoutMs,
+			);
 			const message =
 				error instanceof UnauthorizedError
 					? this.formatUnauthorizedMessage(
 							authContext.getLastAuthorizationUrl(),
 						)
-					: toErrorMessage(error);
+					: toErrorMessage(effectiveError);
 			await authContext.markError(message);
 			throw new Error(message);
 		}
@@ -545,6 +613,7 @@ class SdkUrlMcpClient implements McpServerClient {
 	async callTool(request: {
 		name: string;
 		arguments?: Record<string, unknown>;
+		context?: AgentToolContext;
 	}): Promise<McpToolCallResult> {
 		const client = await this.ensureConnectedClient();
 		try {
@@ -554,7 +623,10 @@ class SdkUrlMcpClient implements McpServerClient {
 					arguments: request.arguments ?? {},
 				},
 				undefined,
-				{ timeout: this.requestTimeoutMs },
+				{
+					timeout: this.requestTimeoutMs,
+					signal: request.context?.signal,
+				},
 			);
 		} catch (error) {
 			return await this.handleOperationError(error);
@@ -590,10 +662,15 @@ class SdkUrlMcpClient implements McpServerClient {
 				redirectUrl:
 					this.registration.oauth?.redirectUrl ?? DEFAULT_HTTP_MCP_REDIRECT_URL,
 			});
+		const effectiveError = augmentMcpTimeoutError(
+			error,
+			this.registration.name,
+			this.requestTimeoutMs,
+		);
 		const message =
 			error instanceof UnauthorizedError
 				? this.formatUnauthorizedMessage(authContext.getLastAuthorizationUrl())
-				: toErrorMessage(error);
+				: toErrorMessage(effectiveError);
 		await authContext.markError(message);
 		throw new Error(message);
 	}

--- a/sdk/packages/core/src/extensions/mcp/client.ts
+++ b/sdk/packages/core/src/extensions/mcp/client.ts
@@ -1,6 +1,6 @@
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { StringDecoder } from "node:string_decoder";
-import type { AgentToolContext } from "@cline/shared";
+import { type AgentToolContext, isMcpTimeoutConfigured } from "@cline/shared";
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { FetchLike } from "@modelcontextprotocol/sdk/shared/transport.js";
@@ -160,10 +160,11 @@ class StdioMcpClient implements McpServerClient {
 		// Keep the fast probe default unless the user opted into patience:
 		// an unconfigured server must not stall startup longer than it did
 		// before per-server timeouts existed.
-		this.connectAttemptTimeoutMs =
-			registration.timeoutSeconds === undefined
-				? MCP_CONNECT_PROBE_TIMEOUT_MS
-				: this.requestTimeoutMs;
+		this.connectAttemptTimeoutMs = isMcpTimeoutConfigured(
+			registration.timeoutSeconds,
+		)
+			? this.requestTimeoutMs
+			: MCP_CONNECT_PROBE_TIMEOUT_MS;
 	}
 
 	async connect(): Promise<void> {
@@ -180,10 +181,11 @@ class StdioMcpClient implements McpServerClient {
 		let lastError: Error | undefined;
 		// An explicit timeout is the total initialize budget across both protocol
 		// encodings. Omitted timeouts preserve the legacy 1.5s budget per probe.
-		const connectDeadline =
-			this.registration.timeoutSeconds === undefined
-				? undefined
-				: Date.now() + this.connectAttemptTimeoutMs;
+		const connectDeadline = isMcpTimeoutConfigured(
+			this.registration.timeoutSeconds,
+		)
+			? Date.now() + this.connectAttemptTimeoutMs
+			: undefined;
 
 		for (const [attemptIndex, protocolMode] of attempts.entries()) {
 			const attemptTimeoutMs =

--- a/sdk/packages/core/src/extensions/mcp/client.ts
+++ b/sdk/packages/core/src/extensions/mcp/client.ts
@@ -1,5 +1,6 @@
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { StringDecoder } from "node:string_decoder";
+import { resolveMcpTimeoutSeconds } from "@cline/shared";
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { FetchLike } from "@modelcontextprotocol/sdk/shared/transport.js";
@@ -38,8 +39,13 @@ type JsonRpcMessage = {
 type StdioProtocolMode = "newline" | "framed";
 
 const MCP_PROTOCOL_VERSION = "2024-11-05";
-const MCP_REQUEST_TIMEOUT_MS = 5_000;
-const MCP_CONNECT_TIMEOUT_MS = 1_500;
+// Probe budget per initialize attempt when no timeout is configured. Modern
+// MCP servers accept both protocol encodings and answer immediately; this
+// only bounds how long we wait for a legacy server that is silent on the
+// encoding it does not speak. A configured `timeout` raises it, which is
+// what lets slow-starting servers (e.g. uvx downloading on first run) get
+// through initialize.
+const MCP_CONNECT_PROBE_TIMEOUT_MS = 1_500;
 const DEFAULT_HTTP_MCP_REDIRECT_URL =
 	"http://127.0.0.1:1456/mcp/oauth/callback";
 
@@ -140,9 +146,20 @@ class StdioMcpClient implements McpServerClient {
 	private stderrBuffer = "";
 	private connected = false;
 	private protocolMode: StdioProtocolMode = "newline";
+	private readonly requestTimeoutMs: number;
+	private readonly connectAttemptTimeoutMs: number;
 
 	constructor(registration: McpServerRegistration) {
 		this.registration = registration;
+		this.requestTimeoutMs =
+			resolveMcpTimeoutSeconds(registration.timeoutSeconds) * 1000;
+		// Keep the fast probe default unless the user opted into patience:
+		// an unconfigured server must not stall startup longer than it did
+		// before per-server timeouts existed.
+		this.connectAttemptTimeoutMs =
+			registration.timeoutSeconds === undefined
+				? MCP_CONNECT_PROBE_TIMEOUT_MS
+				: this.requestTimeoutMs;
 	}
 
 	async connect(): Promise<void> {
@@ -172,7 +189,7 @@ class StdioMcpClient implements McpServerClient {
 							version: "0.0.0",
 						},
 					},
-					MCP_CONNECT_TIMEOUT_MS,
+					this.connectAttemptTimeoutMs,
 				);
 				this.notify("notifications/initialized");
 				this.connected = true;
@@ -360,7 +377,7 @@ class StdioMcpClient implements McpServerClient {
 	private async request(
 		method: string,
 		params?: Record<string, unknown>,
-		timeoutMs = MCP_REQUEST_TIMEOUT_MS,
+		timeoutMs = this.requestTimeoutMs,
 	): Promise<unknown> {
 		const child = this.process;
 		if (!child?.stdin.writable) {
@@ -380,9 +397,12 @@ class StdioMcpClient implements McpServerClient {
 		const resultPromise = new Promise<unknown>((resolve, reject) => {
 			const timeout = setTimeout(() => {
 				this.pending.delete(id);
+				// One decimal place so sub-second probe budgets print accurately.
+				const seconds = Math.round(timeoutMs / 100) / 10;
 				reject(
 					new Error(
-						`MCP request timed out for "${this.registration.name}" (${method}).`,
+						`MCP request timed out for "${this.registration.name}" (${method}) after ${seconds}s. ` +
+							`Increase the "timeout" field (in seconds) for this server in cline_mcp_settings.json.`,
 					),
 				);
 			}, timeoutMs);
@@ -443,11 +463,15 @@ export interface DefaultMcpServerClientFactoryOptions {
 class SdkUrlMcpClient implements McpServerClient {
 	private client?: Client;
 	private authContext?: McpOAuthProviderContext;
+	private readonly requestTimeoutMs: number;
 
 	constructor(
 		private readonly registration: McpServerRegistration,
 		private readonly options: DefaultMcpServerClientFactoryOptions,
-	) {}
+	) {
+		this.requestTimeoutMs =
+			resolveMcpTimeoutSeconds(registration.timeoutSeconds) * 1000;
+	}
 
 	async connect(): Promise<void> {
 		if (this.client) {
@@ -476,7 +500,7 @@ class SdkUrlMcpClient implements McpServerClient {
 				oauthProvider: authContext.provider,
 				fetch: this.options.fetch,
 			});
-			await client.connect(transport);
+			await client.connect(transport, { timeout: this.requestTimeoutMs });
 			await authContext.clearError();
 			this.client = client;
 		} catch (error) {
@@ -500,7 +524,9 @@ class SdkUrlMcpClient implements McpServerClient {
 	async listTools(): Promise<readonly McpToolDescriptor[]> {
 		const client = await this.ensureConnectedClient();
 		try {
-			const result = await client.listTools();
+			const result = await client.listTools(undefined, {
+				timeout: this.requestTimeoutMs,
+			});
 			return result.tools.map((tool) => ({
 				name: tool.name,
 				description: tool.description,
@@ -522,10 +548,14 @@ class SdkUrlMcpClient implements McpServerClient {
 	}): Promise<McpToolCallResult> {
 		const client = await this.ensureConnectedClient();
 		try {
-			return await client.callTool({
-				name: request.name,
-				arguments: request.arguments ?? {},
-			});
+			return await client.callTool(
+				{
+					name: request.name,
+					arguments: request.arguments ?? {},
+				},
+				undefined,
+				{ timeout: this.requestTimeoutMs },
+			);
 		} catch (error) {
 			return await this.handleOperationError(error);
 		}

--- a/sdk/packages/core/src/extensions/mcp/client.ts
+++ b/sdk/packages/core/src/extensions/mcp/client.ts
@@ -178,8 +178,28 @@ class StdioMcpClient implements McpServerClient {
 
 		const attempts: StdioProtocolMode[] = ["newline", "framed"];
 		let lastError: Error | undefined;
+		// An explicit timeout is the total initialize budget across both protocol
+		// encodings. Omitted timeouts preserve the legacy 1.5s budget per probe.
+		const connectDeadline =
+			this.registration.timeoutSeconds === undefined
+				? undefined
+				: Date.now() + this.connectAttemptTimeoutMs;
 
-		for (const protocolMode of attempts) {
+		for (const [attemptIndex, protocolMode] of attempts.entries()) {
+			const attemptTimeoutMs =
+				connectDeadline === undefined
+					? this.connectAttemptTimeoutMs
+					: Math.floor(
+							Math.max(0, connectDeadline - Date.now()) /
+								(attempts.length - attemptIndex),
+						);
+			if (attemptTimeoutMs <= 0) {
+				lastError = this.createTimeoutError(
+					"initialize",
+					this.connectAttemptTimeoutMs,
+				);
+				break;
+			}
 			await this.disconnect().catch(() => {});
 			this.spawnProcess(protocolMode);
 			try {
@@ -193,6 +213,8 @@ class StdioMcpClient implements McpServerClient {
 							version: "0.0.0",
 						},
 					},
+					attemptTimeoutMs,
+					undefined,
 					this.connectAttemptTimeoutMs,
 				);
 				this.notify("notifications/initialized");
@@ -388,6 +410,7 @@ class StdioMcpClient implements McpServerClient {
 		params?: Record<string, unknown>,
 		timeoutMs = this.requestTimeoutMs,
 		signal?: AbortSignal,
+		timeoutMessageMs = timeoutMs,
 	): Promise<unknown> {
 		const child = this.process;
 		if (!child?.stdin.writable) {
@@ -407,14 +430,7 @@ class StdioMcpClient implements McpServerClient {
 		const resultPromise = new Promise<unknown>((resolve, reject) => {
 			const timeout = setTimeout(() => {
 				this.takePending(id);
-				// One decimal place so sub-second probe budgets print accurately.
-				const seconds = Math.round(timeoutMs / 100) / 10;
-				reject(
-					new Error(
-						`MCP request timed out for "${this.registration.name}" (${method}) after ${seconds}s. ` +
-							`Increase the "timeout" field (in seconds) for this server in cline_mcp_settings.json.`,
-					),
-				);
+				reject(this.createTimeoutError(method, timeoutMessageMs));
 			}, timeoutMs);
 			const onAbort = signal
 				? () => {
@@ -462,6 +478,15 @@ class StdioMcpClient implements McpServerClient {
 		}
 
 		return resultPromise;
+	}
+
+	private createTimeoutError(method: string, timeoutMs: number): Error {
+		// One decimal place so sub-second probe budgets print accurately.
+		const seconds = Math.round(timeoutMs / 100) / 10;
+		return new Error(
+			`MCP request timed out for "${this.registration.name}" (${method}) after ${seconds}s. ` +
+				`Increase the "timeout" field (in seconds) for this server in cline_mcp_settings.json.`,
+		);
 	}
 
 	private notify(method: string, params?: Record<string, unknown>): void {

--- a/sdk/packages/core/src/extensions/mcp/client.ts
+++ b/sdk/packages/core/src/extensions/mcp/client.ts
@@ -1,6 +1,10 @@
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { StringDecoder } from "node:string_decoder";
-import { type AgentToolContext, isMcpTimeoutConfigured } from "@cline/shared";
+import {
+	type AgentToolContext,
+	formatMcpTimeoutErrorMessage,
+	isMcpTimeoutConfigured,
+} from "@cline/shared";
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { FetchLike } from "@modelcontextprotocol/sdk/shared/transport.js";
@@ -53,6 +57,50 @@ function encodeNewlineMessage(message: Record<string, unknown>): Buffer {
 	return Buffer.from(`${JSON.stringify(message)}\n`, "utf8");
 }
 
+function encodeFramedMessage(message: Record<string, unknown>): Buffer {
+	const body = Buffer.from(JSON.stringify(message), "utf8");
+	return Buffer.concat([
+		Buffer.from(`Content-Length: ${body.byteLength}\r\n\r\n`, "utf8"),
+		body,
+	]);
+}
+
+type StdioProtocolMode = "newline" | "framed";
+
+class FramedMessageParser {
+	private buffer = "";
+	private readonly decoder = new StringDecoder("utf8");
+
+	push(chunk: Buffer): string[] {
+		this.buffer += this.decoder.write(chunk);
+		const messages: string[] = [];
+		while (true) {
+			const separatorIndex = this.buffer.indexOf("\r\n\r\n");
+			if (separatorIndex < 0) {
+				break;
+			}
+			const headerText = this.buffer.slice(0, separatorIndex);
+			const contentLengthMatch = headerText.match(
+				/(?:^|\r\n)Content-Length:\s*(\d+)(?:\r\n|$)/i,
+			);
+			if (!contentLengthMatch) {
+				throw new Error(
+					"Invalid MCP stdio frame: missing Content-Length header.",
+				);
+			}
+			const contentLength = Number.parseInt(contentLengthMatch[1], 10);
+			const bodyStart = separatorIndex + 4;
+			const bodyEnd = bodyStart + contentLength;
+			if (this.buffer.length < bodyEnd) {
+				break;
+			}
+			messages.push(this.buffer.slice(bodyStart, bodyEnd));
+			this.buffer = this.buffer.slice(bodyEnd);
+		}
+		return messages;
+	}
+}
+
 class NewlineMessageParser {
 	private buffer = "";
 	private readonly decoder = new StringDecoder("utf8");
@@ -91,9 +139,11 @@ class StdioMcpClient implements McpServerClient {
 			onAbort?: () => void;
 		}
 	>();
+	private framedParser = new FramedMessageParser();
 	private newlineParser = new NewlineMessageParser();
 	private stderrBuffer = "";
 	private connected = false;
+	private protocolMode: StdioProtocolMode = "newline";
 	private readonly requestTimeoutMs: number;
 	private readonly connectAttemptTimeoutMs: number;
 
@@ -122,26 +172,34 @@ class StdioMcpClient implements McpServerClient {
 			);
 		}
 
-		this.spawnProcess();
+		const initializeParams = {
+			protocolVersion: MCP_PROTOCOL_VERSION,
+			capabilities: {},
+			clientInfo: { name: "@cline/core", version: "0.0.0" },
+		};
+		this.spawnProcess("newline");
 		try {
 			await this.request(
 				"initialize",
-				{
-					protocolVersion: MCP_PROTOCOL_VERSION,
-					capabilities: {},
-					clientInfo: {
-						name: "@cline/core",
-						version: "0.0.0",
-					},
-				},
+				initializeParams,
 				this.connectAttemptTimeoutMs,
 			);
-			this.notify("notifications/initialized");
-			this.connected = true;
-		} catch (error) {
+		} catch (primaryError) {
 			await this.disconnect().catch(() => {});
-			throw error;
+			this.spawnProcess("framed");
+			try {
+				await this.request(
+					"initialize",
+					initializeParams,
+					MCP_CONNECT_PROBE_TIMEOUT_MS,
+				);
+			} catch {
+				await this.disconnect().catch(() => {});
+				throw primaryError;
+			}
 		}
+		this.notify("notifications/initialized");
+		this.connected = true;
 	}
 
 	async disconnect(): Promise<void> {
@@ -201,7 +259,7 @@ class StdioMcpClient implements McpServerClient {
 		);
 	}
 
-	private spawnProcess(): void {
+	private spawnProcess(protocolMode: StdioProtocolMode): void {
 		const transport = this.registration.transport;
 		if (transport.type !== "stdio") {
 			throw new Error(
@@ -209,8 +267,10 @@ class StdioMcpClient implements McpServerClient {
 			);
 		}
 
+		this.framedParser = new FramedMessageParser();
 		this.newlineParser = new NewlineMessageParser();
 		this.stderrBuffer = "";
+		this.protocolMode = protocolMode;
 
 		const platformOptions =
 			process.platform === "win32"
@@ -267,7 +327,10 @@ class StdioMcpClient implements McpServerClient {
 
 	private handleStdout(chunk: Buffer): void {
 		try {
-			const messages = this.newlineParser.push(chunk);
+			const messages =
+				this.protocolMode === "framed"
+					? this.framedParser.push(chunk)
+					: this.newlineParser.push(chunk);
 
 			for (const messageText of messages) {
 				const message = JSON.parse(messageText) as JsonRpcMessage;
@@ -368,7 +431,11 @@ class StdioMcpClient implements McpServerClient {
 		}
 
 		try {
-			child.stdin.write(encodeNewlineMessage(payload));
+			child.stdin.write(
+				this.protocolMode === "framed"
+					? encodeFramedMessage(payload)
+					: encodeNewlineMessage(payload),
+			);
 		} catch (error) {
 			const pending = this.takePending(id);
 			if (pending) {
@@ -382,11 +449,8 @@ class StdioMcpClient implements McpServerClient {
 	}
 
 	private createTimeoutError(method: string, timeoutMs: number): Error {
-		// One decimal place so sub-second probe budgets print accurately.
-		const seconds = Math.round(timeoutMs / 100) / 10;
 		return new Error(
-			`MCP request timed out for "${this.registration.name}" (${method}) after ${seconds}s. ` +
-				`Increase the "timeout" field (in seconds) for this server in cline_mcp_settings.json.`,
+			formatMcpTimeoutErrorMessage(this.registration.name, timeoutMs, method),
 		);
 	}
 
@@ -400,7 +464,11 @@ class StdioMcpClient implements McpServerClient {
 			method,
 			...(params ? { params } : {}),
 		};
-		child.stdin.write(encodeNewlineMessage(payload));
+		child.stdin.write(
+			this.protocolMode === "framed"
+				? encodeFramedMessage(payload)
+				: encodeNewlineMessage(payload),
+		);
 	}
 
 	private failAllPending(error: Error): void {

--- a/sdk/packages/core/src/extensions/mcp/client.ts
+++ b/sdk/packages/core/src/extensions/mcp/client.ts
@@ -37,15 +37,10 @@ type JsonRpcMessage = {
 	};
 };
 
-type StdioProtocolMode = "newline" | "framed";
-
 const MCP_PROTOCOL_VERSION = "2024-11-05";
-// Probe budget per initialize attempt when no timeout is configured. Modern
-// MCP servers accept both protocol encodings and answer immediately; this
-// only bounds how long we wait for a legacy server that is silent on the
-// encoding it does not speak. A configured `timeout` raises it, which is
-// what lets slow-starting servers (e.g. uvx downloading on first run) get
-// through initialize.
+// Initialize budget when no timeout is configured. A configured `timeout`
+// raises it, which lets slow-starting servers (e.g. uvx downloading on first
+// run) get through initialize.
 const MCP_CONNECT_PROBE_TIMEOUT_MS = 1_500;
 const DEFAULT_HTTP_MCP_REDIRECT_URL =
 	"http://127.0.0.1:1456/mcp/oauth/callback";
@@ -54,56 +49,8 @@ function toErrorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
 }
 
-function encodeFramedMessage(message: Record<string, unknown>): Buffer {
-	const body = Buffer.from(JSON.stringify(message), "utf8");
-	const header = Buffer.from(
-		`Content-Length: ${body.byteLength}\r\n\r\n`,
-		"utf8",
-	);
-	return Buffer.concat([header, body]);
-}
-
 function encodeNewlineMessage(message: Record<string, unknown>): Buffer {
 	return Buffer.from(`${JSON.stringify(message)}\n`, "utf8");
-}
-
-class FramedMessageParser {
-	private buffer = "";
-	private readonly decoder = new StringDecoder("utf8");
-
-	push(chunk: Buffer): string[] {
-		this.buffer += this.decoder.write(chunk);
-		const messages: string[] = [];
-
-		while (true) {
-			const separatorIndex = this.buffer.indexOf("\r\n\r\n");
-			if (separatorIndex < 0) {
-				break;
-			}
-
-			const headerText = this.buffer.slice(0, separatorIndex);
-			const contentLengthMatch = headerText.match(
-				/(?:^|\r\n)Content-Length:\s*(\d+)(?:\r\n|$)/i,
-			);
-			if (!contentLengthMatch) {
-				throw new Error(
-					"Invalid MCP stdio frame: missing Content-Length header.",
-				);
-			}
-
-			const contentLength = Number.parseInt(contentLengthMatch[1], 10);
-			const bodyStart = separatorIndex + 4;
-			const bodyEnd = bodyStart + contentLength;
-			if (this.buffer.length < bodyEnd) {
-				break;
-			}
-
-			messages.push(this.buffer.slice(bodyStart, bodyEnd));
-			this.buffer = this.buffer.slice(bodyEnd);
-		}
-
-		return messages;
-	}
 }
 
 class NewlineMessageParser {
@@ -144,11 +91,9 @@ class StdioMcpClient implements McpServerClient {
 			onAbort?: () => void;
 		}
 	>();
-	private framedParser = new FramedMessageParser();
 	private newlineParser = new NewlineMessageParser();
 	private stderrBuffer = "";
 	private connected = false;
-	private protocolMode: StdioProtocolMode = "newline";
 	private readonly requestTimeoutMs: number;
 	private readonly connectAttemptTimeoutMs: number;
 
@@ -177,62 +122,26 @@ class StdioMcpClient implements McpServerClient {
 			);
 		}
 
-		const attempts: StdioProtocolMode[] = ["newline", "framed"];
-		let lastError: Error | undefined;
-		// An explicit timeout is the total initialize budget across both protocol
-		// encodings. Omitted timeouts preserve the legacy 1.5s budget per probe.
-		const connectDeadline = isMcpTimeoutConfigured(
-			this.registration.timeoutSeconds,
-		)
-			? Date.now() + this.connectAttemptTimeoutMs
-			: undefined;
-
-		for (const [attemptIndex, protocolMode] of attempts.entries()) {
-			const attemptTimeoutMs =
-				connectDeadline === undefined
-					? this.connectAttemptTimeoutMs
-					: Math.floor(
-							Math.max(0, connectDeadline - Date.now()) /
-								(attempts.length - attemptIndex),
-						);
-			if (attemptTimeoutMs <= 0) {
-				lastError = this.createTimeoutError(
-					"initialize",
-					this.connectAttemptTimeoutMs,
-				);
-				break;
-			}
-			await this.disconnect().catch(() => {});
-			this.spawnProcess(protocolMode);
-			try {
-				await this.request(
-					"initialize",
-					{
-						protocolVersion: MCP_PROTOCOL_VERSION,
-						capabilities: {},
-						clientInfo: {
-							name: "@cline/core",
-							version: "0.0.0",
-						},
+		this.spawnProcess();
+		try {
+			await this.request(
+				"initialize",
+				{
+					protocolVersion: MCP_PROTOCOL_VERSION,
+					capabilities: {},
+					clientInfo: {
+						name: "@cline/core",
+						version: "0.0.0",
 					},
-					attemptTimeoutMs,
-					undefined,
-					this.connectAttemptTimeoutMs,
-				);
-				this.notify("notifications/initialized");
-				this.connected = true;
-				this.protocolMode = protocolMode;
-				return;
-			} catch (error) {
-				lastError = error instanceof Error ? error : new Error(String(error));
-			}
+				},
+				this.connectAttemptTimeoutMs,
+			);
+			this.notify("notifications/initialized");
+			this.connected = true;
+		} catch (error) {
+			await this.disconnect().catch(() => {});
+			throw error;
 		}
-		await this.disconnect().catch(() => {});
-
-		throw (
-			lastError ??
-			new Error(`Failed to connect to MCP server "${this.registration.name}".`)
-		);
 	}
 
 	async disconnect(): Promise<void> {
@@ -292,7 +201,7 @@ class StdioMcpClient implements McpServerClient {
 		);
 	}
 
-	private spawnProcess(protocolMode: StdioProtocolMode): void {
+	private spawnProcess(): void {
 		const transport = this.registration.transport;
 		if (transport.type !== "stdio") {
 			throw new Error(
@@ -300,10 +209,8 @@ class StdioMcpClient implements McpServerClient {
 			);
 		}
 
-		this.framedParser = new FramedMessageParser();
 		this.newlineParser = new NewlineMessageParser();
 		this.stderrBuffer = "";
-		this.protocolMode = protocolMode;
 
 		const platformOptions =
 			process.platform === "win32"
@@ -360,10 +267,7 @@ class StdioMcpClient implements McpServerClient {
 
 	private handleStdout(chunk: Buffer): void {
 		try {
-			const messages =
-				this.protocolMode === "framed"
-					? this.framedParser.push(chunk)
-					: this.newlineParser.push(chunk);
+			const messages = this.newlineParser.push(chunk);
 
 			for (const messageText of messages) {
 				const message = JSON.parse(messageText) as JsonRpcMessage;
@@ -412,7 +316,6 @@ class StdioMcpClient implements McpServerClient {
 		params?: Record<string, unknown>,
 		timeoutMs = this.requestTimeoutMs,
 		signal?: AbortSignal,
-		timeoutMessageMs = timeoutMs,
 	): Promise<unknown> {
 		const child = this.process;
 		if (!child?.stdin.writable) {
@@ -432,7 +335,7 @@ class StdioMcpClient implements McpServerClient {
 		const resultPromise = new Promise<unknown>((resolve, reject) => {
 			const timeout = setTimeout(() => {
 				this.takePending(id);
-				reject(this.createTimeoutError(method, timeoutMessageMs));
+				reject(this.createTimeoutError(method, timeoutMs));
 			}, timeoutMs);
 			const onAbort = signal
 				? () => {
@@ -465,11 +368,7 @@ class StdioMcpClient implements McpServerClient {
 		}
 
 		try {
-			child.stdin.write(
-				this.protocolMode === "framed"
-					? encodeFramedMessage(payload)
-					: encodeNewlineMessage(payload),
-			);
+			child.stdin.write(encodeNewlineMessage(payload));
 		} catch (error) {
 			const pending = this.takePending(id);
 			if (pending) {
@@ -501,11 +400,7 @@ class StdioMcpClient implements McpServerClient {
 			method,
 			...(params ? { params } : {}),
 		};
-		child.stdin.write(
-			this.protocolMode === "framed"
-				? encodeFramedMessage(payload)
-				: encodeNewlineMessage(payload),
-		);
+		child.stdin.write(encodeNewlineMessage(payload));
 	}
 
 	private failAllPending(error: Error): void {

--- a/sdk/packages/core/src/extensions/mcp/client.ts
+++ b/sdk/packages/core/src/extensions/mcp/client.ts
@@ -191,7 +191,7 @@ class StdioMcpClient implements McpServerClient {
 				await this.request(
 					"initialize",
 					initializeParams,
-					MCP_CONNECT_PROBE_TIMEOUT_MS,
+					this.connectAttemptTimeoutMs,
 				);
 			} catch {
 				await this.disconnect().catch(() => {});

--- a/sdk/packages/core/src/extensions/mcp/client.ts
+++ b/sdk/packages/core/src/extensions/mcp/client.ts
@@ -53,6 +53,31 @@ function toErrorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
 }
 
+/**
+ * Both stdio framings were tried during connect and both failed. When the two
+ * attempts failed the same way (typically both timed out), the shared message
+ * is the whole story and the newline error is rethrown unchanged; otherwise
+ * each framing's error is named so neither diagnostic is lost.
+ */
+function combineInitializeErrors(
+	serverName: string,
+	newlineError: unknown,
+	framedError: unknown,
+): Error {
+	const newlineMessage = toErrorMessage(newlineError);
+	const framedMessage = toErrorMessage(framedError);
+	if (newlineMessage === framedMessage) {
+		return newlineError instanceof Error
+			? newlineError
+			: new Error(newlineMessage);
+	}
+	return new Error(
+		`MCP server "${serverName}" failed to initialize. ` +
+			`Newline-delimited attempt: ${newlineMessage} ` +
+			`Content-Length framed attempt: ${framedMessage}`,
+	);
+}
+
 function encodeNewlineMessage(message: Record<string, unknown>): Buffer {
 	return Buffer.from(`${JSON.stringify(message)}\n`, "utf8");
 }
@@ -184,7 +209,7 @@ class StdioMcpClient implements McpServerClient {
 				initializeParams,
 				this.connectAttemptTimeoutMs,
 			);
-		} catch (primaryError) {
+		} catch (newlineError) {
 			await this.disconnect().catch(() => {});
 			this.spawnProcess("framed");
 			try {
@@ -193,9 +218,13 @@ class StdioMcpClient implements McpServerClient {
 					initializeParams,
 					this.connectAttemptTimeoutMs,
 				);
-			} catch {
+			} catch (framedError) {
 				await this.disconnect().catch(() => {});
-				throw primaryError;
+				throw combineInitializeErrors(
+					this.registration.name,
+					newlineError,
+					framedError,
+				);
 			}
 		}
 		this.notify("notifications/initialized");

--- a/sdk/packages/core/src/extensions/mcp/config-loader.test.ts
+++ b/sdk/packages/core/src/extensions/mcp/config-loader.test.ts
@@ -159,7 +159,7 @@ describe("mcp config loader", () => {
 		expect(byName.get("tooSmall")?.timeoutSeconds).toBe(1);
 	});
 
-	it("defaults malformed timeout values without rejecting valid sibling servers", async () => {
+	it("preserves malformed timeout values as unconfigured without rejecting valid sibling servers", async () => {
 		const tempRoot = await mkdtemp(join(tmpdir(), "core-mcp-config-loader-"));
 		tempRoots.push(tempRoot);
 		const filePath = join(tempRoot, "cline_mcp_settings.json");
@@ -184,7 +184,7 @@ describe("mcp config loader", () => {
 		expect(registrations).toHaveLength(2);
 		expect(
 			registrations.map((registration) => registration.timeoutSeconds),
-		).toEqual([60, 60]);
+		).toEqual([undefined, undefined]);
 	});
 
 	it("registers loaded servers with an mcp manager", async () => {

--- a/sdk/packages/core/src/extensions/mcp/config-loader.test.ts
+++ b/sdk/packages/core/src/extensions/mcp/config-loader.test.ts
@@ -159,6 +159,34 @@ describe("mcp config loader", () => {
 		expect(byName.get("tooSmall")?.timeoutSeconds).toBe(1);
 	});
 
+	it("defaults malformed timeout values without rejecting valid sibling servers", async () => {
+		const tempRoot = await mkdtemp(join(tmpdir(), "core-mcp-config-loader-"));
+		tempRoots.push(tempRoot);
+		const filePath = join(tempRoot, "cline_mcp_settings.json");
+		await writeFile(
+			filePath,
+			JSON.stringify({
+				mcpServers: {
+					malformed: {
+						transport: { type: "stdio", command: "node" },
+						timeout: "120",
+					},
+					valid: {
+						command: "node",
+						timeout: null,
+					},
+				},
+			}),
+			"utf8",
+		);
+
+		const registrations = resolveMcpServerRegistrations({ filePath });
+		expect(registrations).toHaveLength(2);
+		expect(
+			registrations.map((registration) => registration.timeoutSeconds),
+		).toEqual([60, 60]);
+	});
+
 	it("registers loaded servers with an mcp manager", async () => {
 		const tempRoot = await mkdtemp(join(tmpdir(), "core-mcp-config-loader-"));
 		tempRoots.push(tempRoot);

--- a/sdk/packages/core/src/extensions/mcp/config-loader.test.ts
+++ b/sdk/packages/core/src/extensions/mcp/config-loader.test.ts
@@ -16,13 +16,13 @@ import {
 	hasMcpSettingsFile,
 	listMcpServerOAuthStatuses,
 	loadMcpSettingsFile,
+	McpSettingsMutatorPurityError,
 	registerMcpServersFromSettingsFile,
 	resolveMcpServerRegistrations,
 	setMcpServerDisabled,
 	updateMcpServerOAuthState,
 	updateMcpSettingsFile,
 	updateMcpSettingsFileSync,
-	McpSettingsMutatorPurityError,
 } from "./config-loader";
 
 describe("mcp config loader", () => {
@@ -97,6 +97,66 @@ describe("mcp config loader", () => {
 				oauth: undefined,
 			},
 		]);
+	});
+
+	it("parses per-server timeout (seconds) in nested and legacy formats", async () => {
+		const tempRoot = await mkdtemp(join(tmpdir(), "core-mcp-config-loader-"));
+		tempRoots.push(tempRoot);
+		const filePath = join(tempRoot, "cline_mcp_settings.json");
+		await writeFile(
+			filePath,
+			JSON.stringify({
+				mcpServers: {
+					nested: {
+						transport: { type: "stdio", command: "npx" },
+						timeout: 120,
+					},
+					legacy: {
+						type: "stdio",
+						command: "npx",
+						timeout: 45,
+					},
+					unset: {
+						transport: { type: "stdio", command: "npx" },
+					},
+				},
+			}),
+			"utf8",
+		);
+
+		const registrations = resolveMcpServerRegistrations({ filePath });
+		const byName = new Map(registrations.map((r) => [r.name, r]));
+		expect(byName.get("nested")?.timeoutSeconds).toBe(120);
+		expect(byName.get("legacy")?.timeoutSeconds).toBe(45);
+		expect(byName.get("unset")?.timeoutSeconds).toBeUndefined();
+	});
+
+	it("clamps out-of-range timeout values instead of failing the file", async () => {
+		const tempRoot = await mkdtemp(join(tmpdir(), "core-mcp-config-loader-"));
+		tempRoots.push(tempRoot);
+		const filePath = join(tempRoot, "cline_mcp_settings.json");
+		await writeFile(
+			filePath,
+			JSON.stringify({
+				mcpServers: {
+					// A milliseconds/seconds mix-up clamps to the max.
+					milliseconds: {
+						transport: { type: "stdio", command: "npx" },
+						timeout: 60000,
+					},
+					tooSmall: {
+						transport: { type: "stdio", command: "npx" },
+						timeout: 0,
+					},
+				},
+			}),
+			"utf8",
+		);
+
+		const registrations = resolveMcpServerRegistrations({ filePath });
+		const byName = new Map(registrations.map((r) => [r.name, r]));
+		expect(byName.get("milliseconds")?.timeoutSeconds).toBe(3600);
+		expect(byName.get("tooSmall")?.timeoutSeconds).toBe(1);
 	});
 
 	it("registers loaded servers with an mcp manager", async () => {

--- a/sdk/packages/core/src/extensions/mcp/config-loader.ts
+++ b/sdk/packages/core/src/extensions/mcp/config-loader.ts
@@ -13,7 +13,10 @@ import {
 import { dirname, join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import type { BasicLogger } from "@cline/shared";
-import { resolveMcpTimeoutSeconds } from "@cline/shared";
+import {
+	isMcpTimeoutConfigured,
+	resolveMcpTimeoutSeconds,
+} from "@cline/shared";
 import { resolveMcpSettingsPath } from "@cline/shared/storage";
 import { z } from "zod";
 import type {
@@ -26,12 +29,14 @@ import type {
 const stringRecordSchema = z.record(z.string(), z.string());
 const metadataSchema = z.record(z.string(), z.unknown());
 
-// Preserve omission for the fast stdio initialize probe. Every present value
-// uses the shared resolver, so malformed input falls back and finite numbers
-// clamp without rejecting otherwise valid servers in the settings file.
+// Preserve omission and malformed values for the fast stdio initialize probe.
+// Finite numbers clamp through the shared resolver without rejecting otherwise
+// valid servers in the settings file. Ordinary requests resolve undefined to
+// the shared default later, while initialize can still distinguish whether the
+// user explicitly configured a timeout.
 const timeoutFieldSchema = z.preprocess(
 	(value) =>
-		value === undefined ? undefined : resolveMcpTimeoutSeconds(value),
+		isMcpTimeoutConfigured(value) ? resolveMcpTimeoutSeconds(value) : undefined,
 	z.number().optional(),
 );
 const oauthStateSchema = z

--- a/sdk/packages/core/src/extensions/mcp/config-loader.ts
+++ b/sdk/packages/core/src/extensions/mcp/config-loader.ts
@@ -13,7 +13,7 @@ import {
 import { dirname, join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import type { BasicLogger } from "@cline/shared";
-import { clampMcpTimeoutSeconds } from "@cline/shared";
+import { resolveMcpTimeoutSeconds } from "@cline/shared";
 import { resolveMcpSettingsPath } from "@cline/shared/storage";
 import { z } from "zod";
 import type {
@@ -26,15 +26,14 @@ import type {
 const stringRecordSchema = z.record(z.string(), z.string());
 const metadataSchema = z.record(z.string(), z.unknown());
 
-// The `timeout` field is in seconds (see @cline/shared). Any finite number is
-// accepted here and clamped to [MIN, MAX] at resolution time, so a
-// milliseconds/seconds mix-up cannot become hours and a bad value cannot
-// reject the whole settings file.
-const timeoutFieldSchema = z.number().finite().optional();
-
-function toTimeoutSeconds(timeout: number | undefined): number | undefined {
-	return timeout === undefined ? undefined : clampMcpTimeoutSeconds(timeout);
-}
+// Preserve omission for the fast stdio initialize probe. Every present value
+// uses the shared resolver, so malformed input falls back and finite numbers
+// clamp without rejecting otherwise valid servers in the settings file.
+const timeoutFieldSchema = z.preprocess(
+	(value) =>
+		value === undefined ? undefined : resolveMcpTimeoutSeconds(value),
+	z.number().optional(),
+);
 const oauthStateSchema = z
 	.object({
 		clientInformation: z.record(z.string(), z.unknown()).optional(),
@@ -84,7 +83,7 @@ const nestedRegistrationBodySchema = z
 	.transform((value) => ({
 		transport: value.transport,
 		disabled: value.disabled,
-		timeoutSeconds: toTimeoutSeconds(value.timeout),
+		timeoutSeconds: value.timeout,
 		metadata: value.metadata,
 		oauth: value.oauth,
 	}));
@@ -141,7 +140,7 @@ const legacyStdioRegistrationSchema = legacyRegistrationBaseSchema
 			env: value.env,
 		},
 		disabled: value.disabled,
-		timeoutSeconds: toTimeoutSeconds(value.timeout),
+		timeoutSeconds: value.timeout,
 		metadata: value.metadata,
 		oauth: value.oauth,
 	}));
@@ -174,7 +173,7 @@ const legacyUrlRegistrationSchema = legacyRegistrationBaseSchema
 					headers: value.headers,
 				},
 				disabled: value.disabled,
-				timeoutSeconds: toTimeoutSeconds(value.timeout),
+				timeoutSeconds: value.timeout,
 				metadata: value.metadata,
 				oauth: value.oauth,
 			};
@@ -186,7 +185,7 @@ const legacyUrlRegistrationSchema = legacyRegistrationBaseSchema
 				headers: value.headers,
 			},
 			disabled: value.disabled,
-			timeoutSeconds: toTimeoutSeconds(value.timeout),
+			timeoutSeconds: value.timeout,
 			metadata: value.metadata,
 			oauth: value.oauth,
 		};

--- a/sdk/packages/core/src/extensions/mcp/config-loader.ts
+++ b/sdk/packages/core/src/extensions/mcp/config-loader.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import {
 	existsSync,
 	mkdirSync,
@@ -9,10 +10,10 @@ import {
 	unlinkSync,
 	writeFileSync,
 } from "node:fs";
-import { randomUUID } from "node:crypto";
 import { dirname, join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import type { BasicLogger } from "@cline/shared";
+import { clampMcpTimeoutSeconds } from "@cline/shared";
 import { resolveMcpSettingsPath } from "@cline/shared/storage";
 import { z } from "zod";
 import type {
@@ -24,6 +25,16 @@ import type {
 
 const stringRecordSchema = z.record(z.string(), z.string());
 const metadataSchema = z.record(z.string(), z.unknown());
+
+// The `timeout` field is in seconds (see @cline/shared). Any finite number is
+// accepted here and clamped to [MIN, MAX] at resolution time, so a
+// milliseconds/seconds mix-up cannot become hours and a bad value cannot
+// reject the whole settings file.
+const timeoutFieldSchema = z.number().finite().optional();
+
+function toTimeoutSeconds(timeout: number | undefined): number | undefined {
+	return timeout === undefined ? undefined : clampMcpTimeoutSeconds(timeout);
+}
 const oauthStateSchema = z
 	.object({
 		clientInformation: z.record(z.string(), z.unknown()).optional(),
@@ -62,12 +73,21 @@ const mcpTransportSchema = z.discriminatedUnion("type", [
 	streamableHttpTransportSchema,
 ]);
 
-const nestedRegistrationBodySchema = z.object({
-	transport: mcpTransportSchema,
-	disabled: z.boolean().optional(),
-	metadata: metadataSchema.optional(),
-	oauth: oauthStateSchema.optional(),
-});
+const nestedRegistrationBodySchema = z
+	.object({
+		transport: mcpTransportSchema,
+		disabled: z.boolean().optional(),
+		timeout: timeoutFieldSchema,
+		metadata: metadataSchema.optional(),
+		oauth: oauthStateSchema.optional(),
+	})
+	.transform((value) => ({
+		transport: value.transport,
+		disabled: value.disabled,
+		timeoutSeconds: toTimeoutSeconds(value.timeout),
+		metadata: value.metadata,
+		oauth: value.oauth,
+	}));
 
 const legacyTransportTypeSchema = z
 	.enum(["stdio", "sse", "http", "streamableHttp"])
@@ -77,6 +97,7 @@ const legacyRegistrationBaseSchema = z.object({
 	type: z.enum(["stdio", "sse", "streamableHttp"]).optional(),
 	transportType: legacyTransportTypeSchema,
 	disabled: z.boolean().optional(),
+	timeout: timeoutFieldSchema,
 	metadata: metadataSchema.optional(),
 	oauth: oauthStateSchema.optional(),
 });
@@ -120,6 +141,7 @@ const legacyStdioRegistrationSchema = legacyRegistrationBaseSchema
 			env: value.env,
 		},
 		disabled: value.disabled,
+		timeoutSeconds: toTimeoutSeconds(value.timeout),
 		metadata: value.metadata,
 		oauth: value.oauth,
 	}));
@@ -152,6 +174,7 @@ const legacyUrlRegistrationSchema = legacyRegistrationBaseSchema
 					headers: value.headers,
 				},
 				disabled: value.disabled,
+				timeoutSeconds: toTimeoutSeconds(value.timeout),
 				metadata: value.metadata,
 				oauth: value.oauth,
 			};
@@ -163,6 +186,7 @@ const legacyUrlRegistrationSchema = legacyRegistrationBaseSchema
 				headers: value.headers,
 			},
 			disabled: value.disabled,
+			timeoutSeconds: toTimeoutSeconds(value.timeout),
 			metadata: value.metadata,
 			oauth: value.oauth,
 		};
@@ -684,6 +708,7 @@ export function resolveMcpServerRegistrations(
 		name,
 		transport: value.transport,
 		disabled: value.disabled,
+		timeoutSeconds: value.timeoutSeconds,
 		metadata: value.metadata,
 		oauth: value.oauth,
 	}));

--- a/sdk/packages/core/src/extensions/mcp/index.ts
+++ b/sdk/packages/core/src/extensions/mcp/index.ts
@@ -2,9 +2,9 @@ export type { DefaultMcpServerClientFactoryOptions } from "./client";
 export { createDefaultMcpServerClientFactory } from "./client";
 export type {
 	LoadMcpSettingsOptions,
+	McpSettingsFile,
 	McpSettingsLockOptions,
 	McpSettingsMutator,
-	McpSettingsFile,
 	RegisterMcpServersFromSettingsOptions,
 	SetMcpServerDisabledOptions,
 } from "./config-loader";
@@ -13,6 +13,9 @@ export {
 	hasMcpSettingsFile,
 	listMcpServerOAuthStatuses,
 	loadMcpSettingsFile,
+	McpSettingsLockTimeoutError,
+	McpSettingsMutatorPurityError,
+	McpSettingsUpdateSkippedError,
 	registerMcpServersFromSettingsFile,
 	resolveDefaultMcpSettingsPath,
 	resolveMcpServerRegistrations,
@@ -21,9 +24,6 @@ export {
 	updateMcpServerOAuthStateAsync,
 	updateMcpSettingsFile,
 	updateMcpSettingsFileSync,
-	McpSettingsLockTimeoutError,
-	McpSettingsMutatorPurityError,
-	McpSettingsUpdateSkippedError,
 } from "./config-loader";
 export { InMemoryMcpManager } from "./manager";
 export type {
@@ -46,6 +46,7 @@ export {
 	createDisabledMcpToolPolicies,
 	createDisabledMcpToolPolicy,
 } from "./policies";
+export { augmentMcpTimeoutError } from "./timeout";
 export { createMcpTools } from "./tools";
 export type {
 	CreateMcpToolsOptions,

--- a/sdk/packages/core/src/extensions/mcp/manager.test.ts
+++ b/sdk/packages/core/src/extensions/mcp/manager.test.ts
@@ -102,4 +102,28 @@ describe("InMemoryMcpManager", () => {
 			}),
 		).rejects.toThrow(/disabled/i);
 	});
+
+	it("retains and disconnects a client whose initialization fails", async () => {
+		const connectError = new Error("initialize failed");
+		const client = createClient({
+			connect: vi.fn(async () => {
+				throw connectError;
+			}),
+		});
+		const manager = new InMemoryMcpManager({
+			clientFactory: async () => client,
+		});
+		await manager.registerServer({
+			name: "slow-start",
+			transport: { type: "stdio", command: "node" },
+		});
+
+		await expect(manager.connectServer("slow-start")).rejects.toBe(
+			connectError,
+		);
+		expect(client.disconnect).toHaveBeenCalledTimes(1);
+
+		await manager.dispose();
+		expect(client.disconnect).toHaveBeenCalledTimes(2);
+	});
 });

--- a/sdk/packages/core/src/extensions/mcp/manager.test.ts
+++ b/sdk/packages/core/src/extensions/mcp/manager.test.ts
@@ -126,4 +126,52 @@ describe("InMemoryMcpManager", () => {
 		await manager.dispose();
 		expect(client.disconnect).toHaveBeenCalledTimes(2);
 	});
+
+	it("replaces the client when its timeout snapshot changes", async () => {
+		const firstClient = createClient();
+		const secondClient = createClient();
+		const clientFactory = vi
+			.fn()
+			.mockResolvedValueOnce(firstClient)
+			.mockResolvedValueOnce(secondClient);
+		const manager = new InMemoryMcpManager({ clientFactory });
+		const registration = {
+			name: "timeout-change",
+			transport: {
+				type: "stdio" as const,
+				command: "node",
+			},
+		};
+
+		await manager.registerServer(registration);
+		await manager.connectServer(registration.name);
+		await manager.registerServer({ ...registration, timeoutSeconds: 60 });
+
+		expect(firstClient.disconnect).toHaveBeenCalledTimes(1);
+		await manager.connectServer(registration.name);
+		expect(clientFactory).toHaveBeenCalledTimes(2);
+		expect(secondClient.connect).toHaveBeenCalledTimes(1);
+	});
+
+	it("preserves the client when re-registration keeps the same timeout snapshot", async () => {
+		const client = createClient();
+		const clientFactory = vi.fn(async () => client);
+		const manager = new InMemoryMcpManager({ clientFactory });
+		const registration = {
+			name: "same-timeout",
+			transport: {
+				type: "stdio" as const,
+				command: "node",
+			},
+			timeoutSeconds: 60_000,
+		};
+
+		await manager.registerServer(registration);
+		await manager.connectServer(registration.name);
+		await manager.registerServer({ ...registration, timeoutSeconds: 3_600 });
+
+		expect(client.disconnect).not.toHaveBeenCalled();
+		await manager.connectServer(registration.name);
+		expect(clientFactory).toHaveBeenCalledTimes(1);
+	});
 });

--- a/sdk/packages/core/src/extensions/mcp/manager.ts
+++ b/sdk/packages/core/src/extensions/mcp/manager.ts
@@ -1,3 +1,4 @@
+import { resolveMcpTimeoutSeconds } from "@cline/shared";
 import type {
 	McpConnectionStatus,
 	McpManager,
@@ -63,10 +64,18 @@ export class InMemoryMcpManager implements McpManager {
 			const didTransportChange =
 				JSON.stringify(existing.registration.transport) !==
 				JSON.stringify(registration.transport);
+			// A client snapshots the timeout at construction. Preserve omission as
+			// distinct from an explicit default because stdio initialize uses the
+			// fast compatibility probe only when timeoutSeconds is undefined.
+			const didTimeoutChange =
+				(existing.registration.timeoutSeconds === undefined) !==
+					(registration.timeoutSeconds === undefined) ||
+				resolveMcpTimeoutSeconds(existing.registration.timeoutSeconds) !==
+					resolveMcpTimeoutSeconds(registration.timeoutSeconds);
 			existing.registration = { ...registration };
 			existing.updatedAt = nowMs();
 
-			if (didTransportChange) {
+			if (didTransportChange || didTimeoutChange) {
 				await this.disconnectState(existing);
 				existing.client = undefined;
 				existing.toolCache = undefined;

--- a/sdk/packages/core/src/extensions/mcp/manager.ts
+++ b/sdk/packages/core/src/extensions/mcp/manager.ts
@@ -1,4 +1,7 @@
-import { resolveMcpTimeoutSeconds } from "@cline/shared";
+import {
+	isMcpTimeoutConfigured,
+	resolveMcpTimeoutSeconds,
+} from "@cline/shared";
 import type {
 	McpConnectionStatus,
 	McpManager,
@@ -64,12 +67,13 @@ export class InMemoryMcpManager implements McpManager {
 			const didTransportChange =
 				JSON.stringify(existing.registration.transport) !==
 				JSON.stringify(registration.transport);
-			// A client snapshots the timeout at construction. Preserve omission as
-			// distinct from an explicit default because stdio initialize uses the
-			// fast compatibility probe only when timeoutSeconds is undefined.
+			// A client snapshots the timeout at construction. Preserve an
+			// unconfigured or malformed value as distinct from an explicit default
+			// because stdio initialize uses the fast compatibility probe only when
+			// the timeout is not explicitly configured.
 			const didTimeoutChange =
-				(existing.registration.timeoutSeconds === undefined) !==
-					(registration.timeoutSeconds === undefined) ||
+				isMcpTimeoutConfigured(existing.registration.timeoutSeconds) !==
+					isMcpTimeoutConfigured(registration.timeoutSeconds) ||
 				resolveMcpTimeoutSeconds(existing.registration.timeoutSeconds) !==
 					resolveMcpTimeoutSeconds(registration.timeoutSeconds);
 			existing.registration = { ...registration };

--- a/sdk/packages/core/src/extensions/mcp/manager.ts
+++ b/sdk/packages/core/src/extensions/mcp/manager.ts
@@ -195,15 +195,18 @@ export class InMemoryMcpManager implements McpManager {
 		}
 		state.status = "connecting";
 		state.updatedAt = nowMs();
+		let client = state.client;
 		try {
-			const client =
-				state.client ?? (await this.clientFactory(state.registration));
-			await client.connect();
+			client ??= await this.clientFactory(state.registration);
+			// Ownership transfers before connect: a failed initialize must still
+			// be reachable for cleanup, retry, and manager disposal.
 			state.client = client;
+			await client.connect();
 			state.status = "connected";
 			state.lastError = undefined;
 			state.updatedAt = nowMs();
 		} catch (error) {
+			await client?.disconnect().catch(() => {});
 			state.status = "disconnected";
 			state.lastError = error instanceof Error ? error.message : String(error);
 			state.updatedAt = nowMs();

--- a/sdk/packages/core/src/extensions/mcp/oauth-timeout.test.ts
+++ b/sdk/packages/core/src/extensions/mcp/oauth-timeout.test.ts
@@ -1,0 +1,71 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const clientState = vi.hoisted(() => ({
+	connectOptions: [] as unknown[],
+	listToolsOptions: [] as unknown[],
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+	Client: class {
+		async connect(_transport: unknown, options: unknown): Promise<void> {
+			clientState.connectOptions.push(options);
+		}
+
+		async listTools(_params: unknown, options: unknown) {
+			clientState.listToolsOptions.push(options);
+			return { tools: [] };
+		}
+
+		async close(): Promise<void> {}
+	},
+}));
+
+import { authorizeMcpServerOAuth } from "./oauth";
+
+describe("interactive MCP OAuth timeout", () => {
+	const tempRoots: string[] = [];
+
+	afterEach(async () => {
+		clientState.connectOptions.length = 0;
+		clientState.listToolsOptions.length = 0;
+		await Promise.all(
+			tempRoots.map((directory) =>
+				rm(directory, { recursive: true, force: true }),
+			),
+		);
+		tempRoots.length = 0;
+	});
+
+	it("uses the registration timeout for the authorization probe", async () => {
+		const tempRoot = await mkdtemp(join(tmpdir(), "core-mcp-oauth-timeout-"));
+		tempRoots.push(tempRoot);
+		const filePath = join(tempRoot, "cline_mcp_settings.json");
+		await writeFile(
+			filePath,
+			JSON.stringify({
+				mcpServers: {
+					remote: {
+						transport: {
+							type: "streamableHttp",
+							url: "https://mcp.example.test",
+						},
+						timeout: 12,
+					},
+				},
+			}),
+			"utf8",
+		);
+
+		await authorizeMcpServerOAuth({
+			serverName: "remote",
+			filePath,
+			callbackPorts: [0],
+		});
+
+		expect(clientState.connectOptions).toEqual([{ timeout: 12_000 }]);
+		expect(clientState.listToolsOptions).toEqual([{ timeout: 12_000 }]);
+	});
+});

--- a/sdk/packages/core/src/extensions/mcp/oauth.ts
+++ b/sdk/packages/core/src/extensions/mcp/oauth.ts
@@ -23,6 +23,7 @@ import {
 	normalizeMcpServerOAuthState,
 	updateMcpServerOAuthState,
 } from "./config-loader";
+import { augmentMcpTimeoutError, resolveMcpRequestTimeoutMs } from "./timeout";
 import type { McpServerOAuthState, McpServerRegistration } from "./types";
 
 const DEFAULT_MCP_OAUTH_CALLBACK_PATH = "/mcp/oauth/callback";
@@ -297,6 +298,9 @@ export async function authorizeMcpServerOAuth(
 			`MCP server "${serverName}" uses stdio transport and does not support OAuth browser flow.`,
 		);
 	}
+	const requestTimeoutMs = resolveMcpRequestTimeoutMs(
+		registration.timeoutSeconds,
+	);
 
 	const callbackServer = await startLocalOAuthServer({
 		host: options.callbackHost,
@@ -332,8 +336,8 @@ export async function authorizeMcpServerOAuth(
 			fetch: options.fetch,
 		});
 		try {
-			await client.connect(transport);
-			await client.listTools();
+			await client.connect(transport, { timeout: requestTimeoutMs });
+			await client.listTools(undefined, { timeout: requestTimeoutMs });
 			await oauthContext.clearError();
 			return {
 				serverName,
@@ -381,8 +385,10 @@ export async function authorizeMcpServerOAuth(
 				oauthProvider: oauthContext.provider,
 				fetch: options.fetch,
 			});
-			await retryClient.connect(retryTransport);
-			await retryClient.listTools();
+			await retryClient.connect(retryTransport, {
+				timeout: requestTimeoutMs,
+			});
+			await retryClient.listTools(undefined, { timeout: requestTimeoutMs });
 			await oauthContext.clearError();
 			return {
 				serverName,
@@ -391,7 +397,9 @@ export async function authorizeMcpServerOAuth(
 			};
 		}
 	} catch (error) {
-		const message = toErrorMessage(error);
+		const message = toErrorMessage(
+			augmentMcpTimeoutError(error, serverName, requestTimeoutMs),
+		);
 		await oauthContext.markError(message);
 		throw new Error(message);
 	} finally {

--- a/sdk/packages/core/src/extensions/mcp/timeout.ts
+++ b/sdk/packages/core/src/extensions/mcp/timeout.ts
@@ -1,4 +1,7 @@
-import { resolveMcpTimeoutSeconds } from "@cline/shared";
+import {
+	formatMcpTimeoutErrorMessage,
+	resolveMcpTimeoutSeconds,
+} from "@cline/shared";
 import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
 
 export function resolveMcpRequestTimeoutMs(timeoutSeconds: unknown): number {
@@ -15,8 +18,7 @@ export function augmentMcpTimeoutError(
 	}
 	return new McpError(
 		error.code,
-		`MCP request to "${serverName}" timed out after ${Math.round(timeoutMs / 1000)}s. ` +
-			`Increase the "timeout" field (in seconds) for this server in cline_mcp_settings.json.`,
+		formatMcpTimeoutErrorMessage(serverName, timeoutMs),
 		error.data,
 	);
 }

--- a/sdk/packages/core/src/extensions/mcp/timeout.ts
+++ b/sdk/packages/core/src/extensions/mcp/timeout.ts
@@ -1,0 +1,22 @@
+import { resolveMcpTimeoutSeconds } from "@cline/shared";
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+
+export function resolveMcpRequestTimeoutMs(timeoutSeconds: unknown): number {
+	return resolveMcpTimeoutSeconds(timeoutSeconds) * 1000;
+}
+
+export function augmentMcpTimeoutError(
+	error: unknown,
+	serverName: string,
+	timeoutMs: number,
+): unknown {
+	if (!(error instanceof McpError) || error.code !== ErrorCode.RequestTimeout) {
+		return error;
+	}
+	return new McpError(
+		error.code,
+		`MCP request to "${serverName}" timed out after ${Math.round(timeoutMs / 1000)}s. ` +
+			`Increase the "timeout" field (in seconds) for this server in cline_mcp_settings.json.`,
+		error.data,
+	);
+}

--- a/sdk/packages/core/src/extensions/mcp/types.ts
+++ b/sdk/packages/core/src/extensions/mcp/types.ts
@@ -79,7 +79,7 @@ export interface McpServerRegistration {
 	 * Per-server request timeout in seconds, from the `timeout` field in
 	 * cline_mcp_settings.json. Undefined means the shared default for ordinary
 	 * requests; the stdio client preserves its fast compatibility probe for
-	 * initialize until a timeout is explicitly configured. Registrations are
+	 * initialize until a finite timeout is explicitly configured. Registrations are
 	 * resolved when the runtime is built, so changes take effect on the next
 	 * session.
 	 */

--- a/sdk/packages/core/src/extensions/mcp/types.ts
+++ b/sdk/packages/core/src/extensions/mcp/types.ts
@@ -75,6 +75,14 @@ export interface McpServerRegistration {
 	name: string;
 	transport: McpServerTransportConfig;
 	disabled?: boolean;
+	/**
+	 * Per-server request timeout in seconds, from the `timeout` field in
+	 * cline_mcp_settings.json. Undefined means the shared default
+	 * (DEFAULT_MCP_TIMEOUT_SECONDS). Applies to every JSON-RPC request,
+	 * including initialize; registrations are resolved when the runtime is
+	 * built, so changes take effect on the next session.
+	 */
+	timeoutSeconds?: number;
 	metadata?: Record<string, unknown>;
 	oauth?: McpServerOAuthState;
 }

--- a/sdk/packages/core/src/extensions/mcp/types.ts
+++ b/sdk/packages/core/src/extensions/mcp/types.ts
@@ -77,10 +77,11 @@ export interface McpServerRegistration {
 	disabled?: boolean;
 	/**
 	 * Per-server request timeout in seconds, from the `timeout` field in
-	 * cline_mcp_settings.json. Undefined means the shared default
-	 * (DEFAULT_MCP_TIMEOUT_SECONDS). Applies to every JSON-RPC request,
-	 * including initialize; registrations are resolved when the runtime is
-	 * built, so changes take effect on the next session.
+	 * cline_mcp_settings.json. Undefined means the shared default for ordinary
+	 * requests; the stdio client preserves its fast compatibility probe for
+	 * initialize until a timeout is explicitly configured. Registrations are
+	 * resolved when the runtime is built, so changes take effect on the next
+	 * session.
 	 */
 	timeoutSeconds?: number;
 	metadata?: Record<string, unknown>;

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -282,6 +282,7 @@ export {
 export {
 	type AuthorizeMcpServerOAuthOptions,
 	type AuthorizeMcpServerOAuthResult,
+	augmentMcpTimeoutError,
 	authorizeMcpServerOAuth,
 	type CreateDisabledMcpToolPoliciesOptions,
 	type CreateDisabledMcpToolPolicyOptions,

--- a/sdk/packages/core/src/runtime/orchestration/runtime-builder.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-builder.test.ts
@@ -486,8 +486,7 @@ process.stdin.on("data", (chunk) => {
 			serverPath,
 			`let buffer = "";
 function write(payload) {
-  const body = JSON.stringify(payload);
-  process.stdout.write("Content-Length: " + Buffer.byteLength(body, "utf8") + "\\r\\n\\r\\n" + body);
+  process.stdout.write(JSON.stringify(payload) + "\\n");
 }
 function handle(message) {
   if (message.method === "initialize") {
@@ -504,19 +503,12 @@ function handle(message) {
 }
 process.stdin.on("data", (chunk) => {
   buffer += chunk.toString("utf8");
-  while (true) {
-    const separator = buffer.indexOf("\\r\\n\\r\\n");
-    if (separator < 0) break;
-    const header = buffer.slice(0, separator);
-    const match = header.match(/Content-Length:\\s*(\\d+)/i);
-    if (!match) throw new Error("missing content length");
-    const length = Number(match[1]);
-    const start = separator + 4;
-    const end = start + length;
-    if (buffer.length < end) break;
-    const body = buffer.slice(start, end);
-    buffer = buffer.slice(end);
-    const message = JSON.parse(body);
+  let newline;
+  while ((newline = buffer.indexOf("\\n")) >= 0) {
+    const line = buffer.slice(0, newline).trim();
+    buffer = buffer.slice(newline + 1);
+    if (!line) continue;
+    const message = JSON.parse(line);
     if (message.method === "notifications/initialized") continue;
     handle(message);
   }
@@ -565,7 +557,7 @@ process.stdin.on("data", (chunk) => {
 		writeFileSync(
 			serverPath,
 			`process.stdin.once("data", () => {
-  process.stdout.write("Content-Length: 2\\r\\n\\r\\n{]");
+  process.stdout.write("{]\\n");
 });`,
 			"utf8",
 		);

--- a/sdk/packages/core/src/runtime/orchestration/runtime-builder.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-builder.ts
@@ -4,7 +4,10 @@ import type {
 	RuntimeConfigExtensionKind,
 	TeamTeammateSpec,
 } from "@cline/shared";
-import { hasRuntimeConfigExtension } from "@cline/shared";
+import {
+	hasRuntimeConfigExtension,
+	resolveMcpTimeoutSeconds,
+} from "@cline/shared";
 import { nanoid } from "nanoid";
 import { createUserInstructionConfigService } from "../../extensions/config";
 import {
@@ -217,7 +220,13 @@ async function loadConfiguredMcpTools(logger?: BasicLogger): Promise<{
 	const enabled = registrations.filter((r) => r.disabled !== true);
 	const results = await Promise.allSettled(
 		enabled.map((r) =>
-			createMcpTools({ serverName: r.name, provider: manager }),
+			createMcpTools({
+				serverName: r.name,
+				provider: manager,
+				// Keep the tool wrapper timeout in agreement with the MCP
+				// request timeout: both derive from the server's registration.
+				timeoutMs: resolveMcpTimeoutSeconds(r.timeoutSeconds) * 1000,
+			}),
 		),
 	);
 	const tools: AgentTool[] = [];

--- a/sdk/packages/shared/src/index.browser.ts
+++ b/sdk/packages/shared/src/index.browser.ts
@@ -212,6 +212,7 @@ export {
 	type BasicLogMetadata,
 	noopBasicLogger,
 } from "./logging/logger";
+export * from "./mcp";
 export {
 	normalizeJsonLikeStringsForSchema,
 	parseJsonStream,

--- a/sdk/packages/shared/src/index.ts
+++ b/sdk/packages/shared/src/index.ts
@@ -228,6 +228,7 @@ export {
 	type BasicLogMetadata,
 	noopBasicLogger,
 } from "./logging/logger";
+export * from "./mcp";
 export {
 	normalizeJsonLikeStringsForSchema,
 	parseJsonStream,

--- a/sdk/packages/shared/src/mcp.test.ts
+++ b/sdk/packages/shared/src/mcp.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+	clampMcpTimeoutSeconds,
+	DEFAULT_MCP_TIMEOUT_SECONDS,
+	MAX_MCP_TIMEOUT_SECONDS,
+	MIN_MCP_TIMEOUT_SECONDS,
+	resolveMcpTimeoutSeconds,
+} from "./mcp";
+
+describe("resolveMcpTimeoutSeconds", () => {
+	it("returns the default for missing or non-numeric values", () => {
+		expect(resolveMcpTimeoutSeconds(undefined)).toBe(
+			DEFAULT_MCP_TIMEOUT_SECONDS,
+		);
+		expect(resolveMcpTimeoutSeconds(null)).toBe(DEFAULT_MCP_TIMEOUT_SECONDS);
+		expect(resolveMcpTimeoutSeconds("120")).toBe(DEFAULT_MCP_TIMEOUT_SECONDS);
+		expect(resolveMcpTimeoutSeconds(Number.NaN)).toBe(
+			DEFAULT_MCP_TIMEOUT_SECONDS,
+		);
+		expect(resolveMcpTimeoutSeconds(Infinity)).toBe(
+			DEFAULT_MCP_TIMEOUT_SECONDS,
+		);
+	});
+
+	it("passes through valid values unchanged", () => {
+		expect(resolveMcpTimeoutSeconds(60)).toBe(60);
+		expect(resolveMcpTimeoutSeconds(1)).toBe(1);
+		expect(resolveMcpTimeoutSeconds(3600)).toBe(3600);
+	});
+
+	it("clamps values outside the bounds", () => {
+		expect(resolveMcpTimeoutSeconds(0)).toBe(MIN_MCP_TIMEOUT_SECONDS);
+		expect(resolveMcpTimeoutSeconds(-5)).toBe(MIN_MCP_TIMEOUT_SECONDS);
+		// A milliseconds/seconds mix-up (60000 meaning 60s) clamps instead of
+		// becoming ~16 hours.
+		expect(resolveMcpTimeoutSeconds(60000)).toBe(MAX_MCP_TIMEOUT_SECONDS);
+	});
+});
+
+describe("clampMcpTimeoutSeconds", () => {
+	it("clamps into [MIN, MAX]", () => {
+		expect(clampMcpTimeoutSeconds(0)).toBe(MIN_MCP_TIMEOUT_SECONDS);
+		expect(clampMcpTimeoutSeconds(120)).toBe(120);
+		expect(clampMcpTimeoutSeconds(999999)).toBe(MAX_MCP_TIMEOUT_SECONDS);
+	});
+});

--- a/sdk/packages/shared/src/mcp.test.ts
+++ b/sdk/packages/shared/src/mcp.test.ts
@@ -3,6 +3,7 @@ import {
 	clampMcpTimeoutSeconds,
 	DEFAULT_MCP_TIMEOUT_SECONDS,
 	formatMcpTimeoutErrorMessage,
+	isMcpTimeoutConfigured,
 	MAX_MCP_TIMEOUT_SECONDS,
 	MIN_MCP_TIMEOUT_SECONDS,
 	resolveMcpTimeoutSeconds,
@@ -35,6 +36,17 @@ describe("resolveMcpTimeoutSeconds", () => {
 		// A milliseconds/seconds mix-up (60000 meaning 60s) clamps instead of
 		// becoming ~16 hours.
 		expect(resolveMcpTimeoutSeconds(60000)).toBe(MAX_MCP_TIMEOUT_SECONDS);
+	});
+});
+
+describe("isMcpTimeoutConfigured", () => {
+	it("accepts only finite numeric values", () => {
+		expect(isMcpTimeoutConfigured(60)).toBe(true);
+		expect(isMcpTimeoutConfigured(undefined)).toBe(false);
+		expect(isMcpTimeoutConfigured(null)).toBe(false);
+		expect(isMcpTimeoutConfigured("60")).toBe(false);
+		expect(isMcpTimeoutConfigured(Number.NaN)).toBe(false);
+		expect(isMcpTimeoutConfigured(Infinity)).toBe(false);
 	});
 });
 

--- a/sdk/packages/shared/src/mcp.test.ts
+++ b/sdk/packages/shared/src/mcp.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
 	clampMcpTimeoutSeconds,
 	DEFAULT_MCP_TIMEOUT_SECONDS,
+	formatMcpTimeoutErrorMessage,
 	MAX_MCP_TIMEOUT_SECONDS,
 	MIN_MCP_TIMEOUT_SECONDS,
 	resolveMcpTimeoutSeconds,
@@ -42,5 +43,13 @@ describe("clampMcpTimeoutSeconds", () => {
 		expect(clampMcpTimeoutSeconds(0)).toBe(MIN_MCP_TIMEOUT_SECONDS);
 		expect(clampMcpTimeoutSeconds(120)).toBe(120);
 		expect(clampMcpTimeoutSeconds(999999)).toBe(MAX_MCP_TIMEOUT_SECONDS);
+	});
+});
+
+describe("formatMcpTimeoutErrorMessage", () => {
+	it("names the server, effective bound, and setting to change", () => {
+		expect(formatMcpTimeoutErrorMessage("slow-server", 120_000)).toBe(
+			'MCP request to "slow-server" timed out after 120s. Increase the "timeout" field (in seconds) for this server in cline_mcp_settings.json.',
+		);
 	});
 });

--- a/sdk/packages/shared/src/mcp.test.ts
+++ b/sdk/packages/shared/src/mcp.test.ts
@@ -64,4 +64,12 @@ describe("formatMcpTimeoutErrorMessage", () => {
 			'MCP request to "slow-server" timed out after 120s. Increase the "timeout" field (in seconds) for this server in cline_mcp_settings.json.',
 		);
 	});
+
+	it("can include method context and sub-second precision", () => {
+		expect(
+			formatMcpTimeoutErrorMessage("slow-server", 1_500, "initialize"),
+		).toBe(
+			'MCP request to "slow-server" (initialize) timed out after 1.5s. Increase the "timeout" field (in seconds) for this server in cline_mcp_settings.json.',
+		);
+	});
 });

--- a/sdk/packages/shared/src/mcp.ts
+++ b/sdk/packages/shared/src/mcp.ts
@@ -11,6 +11,10 @@ export const DEFAULT_MCP_TIMEOUT_SECONDS = 60; // matches Anthropic's default ti
 export const MIN_MCP_TIMEOUT_SECONDS = 1;
 export const MAX_MCP_TIMEOUT_SECONDS = 3600;
 
+export function isMcpTimeoutConfigured(value: unknown): value is number {
+	return typeof value === "number" && Number.isFinite(value);
+}
+
 /**
  * Clamp a timeout in seconds into [MIN_MCP_TIMEOUT_SECONDS, MAX_MCP_TIMEOUT_SECONDS].
  */
@@ -27,7 +31,7 @@ export function clampMcpTimeoutSeconds(value: number): number {
  * field cannot take down a whole settings file.
  */
 export function resolveMcpTimeoutSeconds(value: unknown): number {
-	if (typeof value !== "number" || !Number.isFinite(value)) {
+	if (!isMcpTimeoutConfigured(value)) {
 		return DEFAULT_MCP_TIMEOUT_SECONDS;
 	}
 	return clampMcpTimeoutSeconds(value);

--- a/sdk/packages/shared/src/mcp.ts
+++ b/sdk/packages/shared/src/mcp.ts
@@ -32,3 +32,13 @@ export function resolveMcpTimeoutSeconds(value: unknown): number {
 	}
 	return clampMcpTimeoutSeconds(value);
 }
+
+export function formatMcpTimeoutErrorMessage(
+	serverName: string,
+	timeoutMs: number,
+): string {
+	return (
+		`MCP request to "${serverName}" timed out after ${Math.round(timeoutMs / 1000)}s. ` +
+		`Increase the "timeout" field (in seconds) for this server in cline_mcp_settings.json.`
+	);
+}

--- a/sdk/packages/shared/src/mcp.ts
+++ b/sdk/packages/shared/src/mcp.ts
@@ -1,0 +1,34 @@
+/**
+ * Per-server MCP request timeout contract, in seconds.
+ *
+ * The `timeout` field in cline_mcp_settings.json is in SECONDS. Every client
+ * (VSCode extension, CLI, JetBrains) resolves it through this module so all
+ * apply the same default and bounds. Values above MAX are almost always a
+ * milliseconds/seconds mix-up (e.g. `timeout: 60000` meaning 60s), so they
+ * clamp instead of silently becoming hours.
+ */
+export const DEFAULT_MCP_TIMEOUT_SECONDS = 60; // matches Anthropic's default timeout in their MCP SDK
+export const MIN_MCP_TIMEOUT_SECONDS = 1;
+export const MAX_MCP_TIMEOUT_SECONDS = 3600;
+
+/**
+ * Clamp a timeout in seconds into [MIN_MCP_TIMEOUT_SECONDS, MAX_MCP_TIMEOUT_SECONDS].
+ */
+export function clampMcpTimeoutSeconds(value: number): number {
+	return Math.min(
+		Math.max(value, MIN_MCP_TIMEOUT_SECONDS),
+		MAX_MCP_TIMEOUT_SECONDS,
+	);
+}
+
+/**
+ * Resolve a raw `timeout` value from MCP settings to seconds. Never throws:
+ * missing or non-numeric values fall back to the default, so one malformed
+ * field cannot take down a whole settings file.
+ */
+export function resolveMcpTimeoutSeconds(value: unknown): number {
+	if (typeof value !== "number" || !Number.isFinite(value)) {
+		return DEFAULT_MCP_TIMEOUT_SECONDS;
+	}
+	return clampMcpTimeoutSeconds(value);
+}

--- a/sdk/packages/shared/src/mcp.ts
+++ b/sdk/packages/shared/src/mcp.ts
@@ -40,9 +40,12 @@ export function resolveMcpTimeoutSeconds(value: unknown): number {
 export function formatMcpTimeoutErrorMessage(
 	serverName: string,
 	timeoutMs: number,
+	method?: string,
 ): string {
+	const methodText = method ? ` (${method})` : "";
+	const seconds = Math.round(timeoutMs / 100) / 10;
 	return (
-		`MCP request to "${serverName}" timed out after ${Math.round(timeoutMs / 1000)}s. ` +
+		`MCP request to "${serverName}"${methodText} timed out after ${seconds}s. ` +
 		`Increase the "timeout" field (in seconds) for this server in cline_mcp_settings.json.`
 	);
 }


### PR DESCRIPTION
### Related Issue

**Issue:** #7635, #12344

### Description

The per-server `timeout` field in `cline_mcp_settings.json` already exists, has a UI, and defaults to 60s but only the VS Code extension's `tools/call` path reads it. Everywhere else uses hardcoded constants: the SDK client (CLI, JetBrains, standalone core) times out **all** requests at 5s and `initialize` at 1.5s, and the extension's metadata requests (`tools/list`, `resources/*`, `prompts/*`) time out at 5s. Servers behind proxies or doing slow work fail despite a configured timeout (#7635, #12344), and each prior fix attempt patched only one site (#10014, #11330, #12165, #12363).

This PR resolves the timeout once per client and applies it to every request:

- **`@cline/shared`** exports the default (60s) and bounds (1s-3600s) plus a shared resolver. The max means a milliseconds/seconds mix-up like `timeout: 60000` clamps to 1 hour instead of silently becoming ~16 hours (that exact value appears in #7635's config sample).
- **SDK** config-loader parses `timeout` into `McpServerRegistration.timeoutSeconds`; `StdioMcpClient` and `SdkUrlMcpClient` apply it to `initialize`, `tools/list`, and `tools/call`. Unconfigured servers keep the fast 1.5s initialize probe. A configured timeout applies to each initialize request: the standards-compliant newline request first, then the shipped Content-Length compatibility request if needed. Unconfigured or malformed values retain the 1.5s budget per request (#12344).
- **Extension** routes every request (including metadata) through one resolver, deleting the hardcoded 5s `DEFAULT_REQUEST_TIMEOUT_MS`.
- `createMcpTools` derives the agent tool `timeoutMs` from the same value on both call sites, so the wrapper can't silently cap a raised timeout.
- Timeout errors now name the bound and the field to increase; the VS Code server row and the CLI server list show the effective timeout and how to change it.

Deliberate behavior notes:

- Out-of-range `timeout` values clamp to [1s, 3600s] at read time; the write path (`updateMcpTimeout` RPC) rejects values outside that range.
- In VS Code, changes rebuild the MCP connection immediately; an active SDK session rebuilds its captured MCP tool wrappers when it is idle. In the CLI, changes take effect on the next session because registrations are resolved when the runtime is built.

### Test Procedure

```bash
bun run build:sdk
cd sdk/packages/shared && bunx vitest run src/mcp.test.ts
cd sdk/packages/core && bunx vitest run src/extensions/mcp
cd apps/vscode && bun test src/services/mcp/__tests__/
```

- New SDK client integration tests spawn a real newline-delimited stdio MCP server (no stub) and prove: a >5s response succeeds at a configured 30s; timeout errors name the bound and field to change; a configured timeout applies in full to initialize; malformed values retain the unconfigured 1.5s probe; failed initialization cleans up the child; cancellation settles promptly.
- New extension tests prove `tools/call` and `tools/list` send the per-server timeout, out-of-range values clamp, and request-timeout errors get the how-to-fix message.
- Full suites: `sdk/packages/core` unit (1431 pass; the 8 failures are pre-existing Windows/bash environment artifacts, unchanged from `origin/main`), extension bun MCP suite (70 pass), `bun run check-types`, webview build, and the esbuild bundle all pass. `bun run lint` passes with warnings only.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

UI change is a one-line hint under the MCP server row's Request Timeout dropdown, plus the timeout shown per server in the CLI config list. Screenshots to be added before this leaves draft.

### Additional Notes

Supersedes #10014, #11330, #12165, #12363 each patched one timeout site; this fixes the shared root cause so all request sites and both clients agree. Happy to coordinate with those authors.

Known pre-existing limitation (not introduced here): the cline-hub `upsertMcpServer` dialog rebuilds server entries from dialog fields, so editing a server there drops non-dialog fields including `timeout` same as `metadata`/`oauth` today. Worth a separate issue.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core MCP connection, tool-call, and session-rebuild paths across clients; behavior changes for slow servers and timeout edits are intentional but broad.
> 
> **Overview**
> Unifies MCP request timeouts so the per-server **`timeout`** field in `cline_mcp_settings.json` (seconds) drives **initialize**, metadata calls, and **`tools/call`** in the SDK, VS Code extension, and CLI—not just one code path.
> 
> **Shared contract (`@cline/shared`)** adds default (60s), bounds (1s–3600s), resolution/clamping (so values like `60000` don’t become hours), and consistent timeout error text pointing users to the settings field.
> 
> **SDK** parses `timeoutSeconds` on registrations, applies one snapshot to stdio and URL clients, keeps the **1.5s initialize probe** for unconfigured stdio servers, forwards **abort signals** on tool calls, and aligns **`createMcpTools`** wrapper `timeoutMs` with the server timeout.
> 
> **VS Code `McpHub`** removes the hardcoded 5s metadata timeout, uses the same resolver for connect and all RPCs, treats **timeout changes as connection-level** (reconnect + broader tool fingerprint so sessions rebuild), and passes abort signals through **`McpHubToolProvider`**.
> 
> **UX**: CLI MCP rows and the VS Code server row document effective timeouts (including initialize probe vs configured timeout).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c50ad0f6dd52010627af7d9f5d5ef486e77be92d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->




