### PR TITLE
fix(vscode): keep webview alive when moved between primary and secondary sidebars

### DIFF
--- a/apps/vscode/src/hosts/vscode/VscodeWebviewProvider.ts
+++ b/apps/vscode/src/hosts/vscode/VscodeWebviewProvider.ts
@@ -91,11 +91,15 @@ export class VscodeWebviewProvider extends WebviewProvider implements vscode.Web
 			this.disposables,
 		)
 
-		// Listen for when the view is disposed
-		// This happens when the user closes the view or when the view is closed programmatically
+		// Listen for when the view is disposed. This happens when the user moves the
+		// view between the primary and secondary sidebars: VS Code destroys the old
+		// WebviewView and calls resolveWebviewView again on this same provider with a
+		// new one. Only release view-scoped resources here — the controller must stay
+		// alive so the re-resolved view keeps working. The controller is disposed on
+		// extension deactivation (tearDown -> WebviewProvider.disposeAllInstances).
 		webviewView.onDidDispose(
-			async () => {
-				await this.dispose()
+			() => {
+				this.disposeView()
 			},
 			null,
 			this.disposables,
@@ -181,7 +185,12 @@ export class VscodeWebviewProvider extends WebviewProvider implements vscode.Web
 		return this.webview?.webview.postMessage(message)
 	}
 
-	override async dispose() {
+	/**
+	 * Releases resources tied to the current WebviewView without tearing down the
+	 * controller, so this provider can be re-resolved with a new WebviewView (e.g.
+	 * when the user moves the view to the other sidebar).
+	 */
+	private disposeView() {
 		// WebviewView doesn't have a dispose method, it's managed by VSCode
 		// We just need to clean up our disposables
 		while (this.disposables.length) {
@@ -190,6 +199,11 @@ export class VscodeWebviewProvider extends WebviewProvider implements vscode.Web
 				x.dispose()
 			}
 		}
-		super.dispose()
+		this.webview = undefined
+	}
+
+	override async dispose() {
+		this.disposeView()
+		await super.dispose()
 	}
 }

--- a/apps/vscode/src/hosts/vscode/VscodeWebviewProvider.ts
+++ b/apps/vscode/src/hosts/vscode/VscodeWebviewProvider.ts
@@ -21,6 +21,7 @@ export class VscodeWebviewProvider extends WebviewProvider implements vscode.Web
 
 	private webview?: vscode.WebviewView
 	private disposables: vscode.Disposable[] = []
+	private hasResolvedView = false
 
 	override getWebviewUrl(path: string) {
 		if (!this.webview) {
@@ -52,6 +53,10 @@ export class VscodeWebviewProvider extends WebviewProvider implements vscode.Web
 	 * @returns A promise that resolves when the webview has been fully initialized
 	 */
 	public async resolveWebviewView(webviewView: vscode.WebviewView): Promise<void> {
+		// A newer view supersedes any previous one (VS Code re-resolves this same
+		// provider when the view is moved between sidebars). Release the previous
+		// view's listeners up front in case its onDidDispose fired late or not at all.
+		this.disposeView()
 		this.webview = webviewView
 
 		webviewView.webview.options = {
@@ -99,14 +104,24 @@ export class VscodeWebviewProvider extends WebviewProvider implements vscode.Web
 		// extension deactivation (tearDown -> WebviewProvider.disposeAllInstances).
 		webviewView.onDidDispose(
 			() => {
-				this.disposeView()
+				// resolveWebviewView awaits HTML generation, so an old view's dispose
+				// event can arrive after a newer view has already been resolved. Only
+				// tear down if this view is still the active one.
+				if (this.webview === webviewView) {
+					this.disposeView()
+				}
 			},
 			null,
 			this.disposables,
 		)
 
-		// if the extension is starting a new session, clear previous task state
-		this.controller.clearTask()
+		// Clear stale task state only when the view first loads after activation.
+		// Re-resolves (e.g. the view moved between sidebars) must not terminate an
+		// active task.
+		if (!this.hasResolvedView) {
+			this.hasResolvedView = true
+			this.controller.clearTask()
+		}
 
 		Logger.log("[VscodeWebviewProvider] Webview view resolved")
 

--- a/apps/vscode/src/hosts/vscode/hostbridge/client/host-grpc-client-base.test.ts
+++ b/apps/vscode/src/hosts/vscode/hostbridge/client/host-grpc-client-base.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test"
+
+// The module under test instantiates GrpcHandler, whose real implementation
+// pulls in the generated vscode host handlers (and therefore the `vscode`
+// module). Mock it before importing createGrpcClient.
+const handleRequestMock = mock()
+mock.module("@/hosts/vscode/hostbridge-grpc-handler", () => ({
+	GrpcHandler: class {
+		handleRequest = handleRequestMock
+	},
+}))
+
+import { createGrpcClient } from "./host-grpc-client-base"
+
+const testService = {
+	name: "TestService",
+	fullName: "host.TestService",
+	methods: {
+		subscribeToThing: {
+			name: "SubscribeToThing",
+			requestType: Object,
+			responseType: Object,
+			requestStream: false,
+			responseStream: true,
+			options: {},
+		},
+		getThing: {
+			name: "GetThing",
+			requestType: Object,
+			responseType: Object,
+			requestStream: false,
+			responseStream: false,
+			options: {},
+		},
+	},
+}
+
+async function flushMicrotasks(): Promise<void> {
+	for (let i = 0; i < 10; i++) {
+		await Promise.resolve()
+	}
+}
+
+describe("createGrpcClient", () => {
+	beforeEach(() => {
+		handleRequestMock.mockReset()
+	})
+
+	describe("streaming methods", () => {
+		it("returns a cancel function synchronously, not a Promise", () => {
+			// Regression test: the streaming client used to return the async IIFE's
+			// Promise. Callers storing it as an unsubscribe function then crashed
+			// with "... is not a function" (e.g. VscodeTelemetryPolicyService.dispose
+			// when the webview moved between sidebars).
+			handleRequestMock.mockResolvedValue(() => {})
+			const client = createGrpcClient(testService) as any
+
+			const unsubscribe = client.subscribeToThing({}, { onResponse: () => {} })
+
+			expect(typeof unsubscribe).toBe("function")
+			expect(unsubscribe).not.toBeInstanceOf(Promise)
+			// Must not throw when invoked immediately, before the underlying
+			// handler promise has resolved.
+			expect(() => unsubscribe()).not.toThrow()
+		})
+
+		it("invokes the underlying cancel function once it resolves", async () => {
+			const cancel = mock()
+			let resolveHandler: (value: () => void) => void = () => {}
+			handleRequestMock.mockReturnValue(
+				new Promise<() => void>((resolve) => {
+					resolveHandler = resolve
+				}),
+			)
+			const client = createGrpcClient(testService) as any
+
+			const unsubscribe = client.subscribeToThing({}, { onResponse: () => {} })
+			unsubscribe()
+			expect(cancel).toHaveBeenCalledTimes(0)
+
+			resolveHandler(cancel)
+			await flushMicrotasks()
+			expect(cancel).toHaveBeenCalledTimes(1)
+		})
+
+		it("reports handler errors through onError and still returns a safe cancel function", async () => {
+			const onError = mock()
+			handleRequestMock.mockRejectedValue(new Error("stream setup failed"))
+			const client = createGrpcClient(testService) as any
+
+			const unsubscribe = client.subscribeToThing({}, { onResponse: () => {}, onError })
+			await flushMicrotasks()
+
+			expect(onError).toHaveBeenCalledTimes(1)
+			expect(onError.mock.calls[0][0]).toBeInstanceOf(Error)
+			expect(() => unsubscribe()).not.toThrow()
+			await flushMicrotasks()
+		})
+	})
+
+	describe("unary methods", () => {
+		it("resolves with the handler response", async () => {
+			handleRequestMock.mockResolvedValue({ value: 42 })
+			const client = createGrpcClient(testService) as any
+
+			const response = await client.getThing({})
+
+			expect(response).toEqual({ value: 42 })
+			expect(handleRequestMock).toHaveBeenCalledWith("host.TestService", "getThing", {}, expect.any(String))
+		})
+	})
+})

--- a/apps/vscode/src/hosts/vscode/hostbridge/client/host-grpc-client-base.ts
+++ b/apps/vscode/src/hosts/vscode/hostbridge/client/host-grpc-client-base.ts
@@ -47,8 +47,13 @@ export function createGrpcClient<T extends ProtoService>(service: T): GrpcClient
 				// Use handleRequest with streaming callbacks
 				const requestId = uuidv4()
 
-				// We need to await the promise and then return the cancel function
-				return (async () => {
+				// handleRequest is async, but the client contract (GrpcClientType and the
+				// generated host-bridge-client-types) requires the cancel function to be
+				// returned synchronously. Returning the async IIFE directly would hand
+				// callers a Promise, and invoking it (e.g. `unsubscribe()`) throws
+				// "... is not a function". Resolve the real cancel function in the
+				// background and return a stable wrapper immediately.
+				const cancelPromise: Promise<() => void> = (async () => {
 					try {
 						const result = await grpcHandler.handleRequest<InstanceType<typeof method.responseType>>(
 							service.fullName,
@@ -74,6 +79,10 @@ export function createGrpcClient<T extends ProtoService>(service: T): GrpcClient
 						return () => {}
 					}
 				})()
+
+				return () => {
+					cancelPromise.then((cancel) => cancel()).catch((error) => Logger.error(`Error cancelling stream: ${error}`))
+				}
 			}) as any
 		} else {
 			// Unary method implementation


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Related Issue

Reported by a nightly-extension user: moving the Cline view from the left (primary) sidebar to the right (secondary) sidebar makes the extension view go blank, with the developer console showing `TypeError: this.unsubscribeHostTelemetrySettings is not a function`. This worked on the `legacy-extension` branch.

### Description

Moving a webview view between sidebars makes VS Code destroy the old `WebviewView` (firing `onDidDispose`) and then call `resolveWebviewView` again on the same registered provider with a fresh view. Two bugs broke this flow:

1. **Streaming host bridge client returned a Promise instead of the cancel function.** `createGrpcClient` in `apps/vscode/src/hosts/vscode/hostbridge/client/host-grpc-client-base.ts` returned the async IIFE's `Promise<() => void>` while its declared type (and the generated `host-bridge-client-types.ts` contract, which the standalone client honors) says streaming methods return `() => void` synchronously. The mismatch was hidden by an `as any` cast. `VscodeTelemetryPolicyService` stores that value as `unsubscribeHostTelemetrySettings` and invokes it in `dispose()`, throwing the reported TypeError. The client now returns a synchronous wrapper that resolves the real cancel function in the background.

2. **The whole Controller was disposed on view dispose, so the re-resolved view was dead.** `VscodeWebviewProvider`'s `onDidDispose` handler ran the full `dispose()`, which tears down `SdkController` (`isDisposed = true`, `StatePostDebouncer` disposed, sessions/MCP hub/telemetry disposed). After that, `postStateToWebview()` permanently no-ops, so the re-resolved webview never receives state and renders blank — even with bug 1 fixed. The legacy `Controller.dispose()` was benign (clear task + MCP hub), which is why this worked on `legacy-extension`. `onDidDispose` now only releases view-scoped resources (event listeners, the `webview` reference) via a new `disposeView()`; the controller is still fully disposed on extension deactivation through `tearDown()` → `WebviewProvider.disposeAllInstances()`.

### Test Procedure

- New unit tests in `host-grpc-client-base.test.ts` cover the streaming client contract: the cancel function is returned synchronously (regression test for the TypeError), it forwards to the real cancel once resolved, handler errors surface via `onError`, and unary calls still resolve. All 4 pass.
- `bunx vitest run src/sdk/sdk-telemetry.test.ts` — 17/17 pass (its mock already returned the unsubscribe function synchronously, matching the fixed contract).
- Full `bun run test:unit`: 947 pass; 3 storage test files failed in the parallel run but all pass when run individually (contention flake while the dev host was launching, unrelated to this change).
- `bun run check-types` passes; webview and extension bundle build cleanly.
- Manual GUI test in the extension development host: opened the Cline sidebar, moved the view to the secondary sidebar via right-click → Move To → Secondary Side Bar, and verified the webview re-renders with the full welcome UI, responds to interaction, and the developer console shows no `unsubscribeHostTelemetrySettings` TypeError.

<a href="https://cursor.com/agents/bc-e76347b4-e046-4cb0-979b-a59ed330b664/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmove_cline_sidebar_left_to_right.mp4"><img src="https://cursor.com/artifacts/c/art-875b863b-447f-4af2-8c26-53c28ec772a0" alt="move_cline_sidebar_left_to_right.mp4" /></a>

![Cline rendered in secondary sidebar after move](https://cursor.com/artifacts/c/art-11b5f22a-5393-4a19-a5c0-7861d4c4ac44)

![Developer console filtered for ](https://cursor.com/artifacts/c/art-3a6ad245-d3ef-4543-b9bc-81a838530ae5)

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

The telemetry providers that call `subscribeToTelemetrySettings` without using the return value (`PostHogTelemetryProvider`, `OpenTelemetryTelemetryProvider`, `PostHogErrorProvider`) are unaffected; `sdk-telemetry.ts` was the only consumer of the returned cancel function.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e76347b4-e046-4cb0-979b-a59ed330b664"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e76347b4-e046-4cb0-979b-a59ed330b664"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

