### PR TITLE
fix: use generic settings for Atomic Chat

### DIFF
--- a/apps/vscode/src/sdk/model-catalog/custom-model-ids.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/custom-model-ids.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest"
+import { providerAllowsCustomModelIds } from "./custom-model-ids"
+
+describe("providerAllowsCustomModelIds", () => {
+	it("allows Atomic Chat model IDs outside the generated catalog", () => {
+		expect(providerAllowsCustomModelIds("atomic-chat")).toBe(true)
+	})
+})

--- a/apps/vscode/src/sdk/model-catalog/custom-model-ids.ts
+++ b/apps/vscode/src/sdk/model-catalog/custom-model-ids.ts
@@ -2,11 +2,12 @@ import { toSdkProviderId } from "./sdk-provider-id"
 
 // Providers whose model id is user-supplied free text rather than a fixed
 // catalog selection. The SDK catalog for these either has no curated model
-// list (openai-compatible: bring-your-own base URL + model) or a host-fetched
-// list that the user can also bypass (ollama/lmstudio/litellm). For these,
-// the picker must allow arbitrary model ids and model resolution must honor
-// the requested id instead of coercing to the catalog default.
-const CUSTOM_MODEL_ID_PROVIDER_IDS = new Set(["openai-compatible", "ollama", "lmstudio", "litellm"])
+// list (openai-compatible: bring-your-own base URL + model) or a bundled /
+// host-fetched list that the user can bypass
+// (ollama/lmstudio/atomic-chat/litellm). For these, the picker must allow
+// arbitrary model ids and model resolution must honor the requested id instead
+// of coercing to the catalog default.
+const CUSTOM_MODEL_ID_PROVIDER_IDS = new Set(["openai-compatible", "ollama", "lmstudio", "atomic-chat", "litellm"])
 
 /**
  * Whether a provider id accepts a user-supplied (custom) model id.

--- a/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.test.ts
+++ b/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.test.ts
@@ -5,6 +5,7 @@ import {
 	getGenericProviderSettings,
 	hasCustomProviderSettings,
 	isGenericProviderListing,
+	isKnownGenericProvider,
 } from "./providerSettingsRegistry"
 
 function listing(overrides: Partial<ProviderListing>): ProviderListing {
@@ -39,6 +40,27 @@ describe("providerSettingsRegistry", () => {
 			providerName: "Google Gemini",
 			signupUrl: "https://aistudio.google.com/apikey",
 		})
+	})
+
+	it("uses generic catalog-backed settings for Atomic Chat", () => {
+		const settings = {
+			allowsCustomIds: true,
+			baseUrlField: {
+				label: "Use custom base URL",
+				placeholder: "Default: http://127.0.0.1:1337/v1",
+			},
+			providerId: "atomic-chat",
+			providerName: "Atomic Chat",
+		}
+
+		expect(isKnownGenericProvider("atomic-chat")).toBe(true)
+		expect(
+			getGenericProviderSettings(
+				"atomic-chat",
+				listing({ id: "atomic-chat", name: "Atomic Chat", allowsCustomModelIds: true }),
+			),
+		).toEqual(settings)
+		expect(getFallbackGenericProviderSettings("atomic-chat")).toEqual(settings)
 	})
 
 	it("keeps provider-specific UIs as explicit custom overrides", () => {

--- a/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.ts
+++ b/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.ts
@@ -36,6 +36,13 @@ const CUSTOM_PROVIDER_SETTINGS_IDS = new Set([
 ])
 
 const GENERIC_PROVIDER_PRESENTATION_OVERRIDES: Record<string, GenericProviderPresentationOverride> = {
+	"atomic-chat": {
+		allowsCustomIds: true,
+		baseUrlField: {
+			label: "Use custom base URL",
+			placeholder: "Default: http://127.0.0.1:1337/v1",
+		},
+	},
 	baseten: {
 		signupUrl: "https://app.baseten.co/settings/api_keys",
 	},
@@ -148,6 +155,7 @@ export function getGenericProviderSettings(
 }
 
 const FALLBACK_GENERIC_PROVIDER_NAMES = {
+	"atomic-chat": "Atomic Chat",
 	deepseek: "DeepSeek",
 	doubao: "Doubao",
 	gemini: "Gemini",

--- a/docs/provider-config/atomic-chat.mdx
+++ b/docs/provider-config/atomic-chat.mdx
@@ -11,7 +11,7 @@ description: "Use local models through Atomic Chat's OpenAI-compatible API."
 2. Download or load a model in the app.
 3. In Cline Settings, choose **Atomic Chat** as the provider.
 4. Keep the default base URL `http://127.0.0.1:1337/v1` unless you changed Atomic Chat's server port.
-5. Pick a model from the dropdown (models are fetched from `GET /v1/models`).
+5. Pick a model from the models.dev-backed dropdown. If your loaded model is not listed, choose **Use custom model ID…** and enter its ID.
 
 ## API key
 

--- a/docs/running-models-locally/overview.mdx
+++ b/docs/running-models-locally/overview.mdx
@@ -98,12 +98,13 @@ Run Cline with local inference on your machine.
     1. Open Cline Settings
     2. Select provider: **Atomic Chat**
     3. Base URL: `http://127.0.0.1:1337/v1` (default)
-    4. Select your model from the dropdown
+    4. Select your model from the models.dev-backed dropdown
+       - If your loaded model is not listed, choose **Use custom model ID…** and enter its ID
 
     ### 5) Troubleshooting
     - Make sure Atomic Chat is running before sending prompts
     - If connection fails, verify `http://127.0.0.1:1337/v1/models`
-    - If the model list is empty, load a model in Atomic Chat first
+    - Confirm the model ID in Cline matches the model loaded in Atomic Chat
   </Tab>
 </Tabs>
 


### PR DESCRIPTION
### Related Issue

**Issue:** #11453

### Description

Current `main` already generates the Atomic Chat provider and model catalog from models.dev through #12204. This PR keeps the remaining integration on that shared path:

- Render Atomic Chat with the existing generic catalog-backed settings UI.
- Expose the generated default base URL as an optional override.
- Allow custom model IDs for locally loaded models that are not in the generated catalog.
- Update the Atomic Chat docs so they no longer claim Cline polls `/v1/models`.

This replaces #12175 without adding Atomic-specific proto fields, legacy state migration, model polling RPCs, or a bespoke settings component.

### Test Procedure

- `bun run build:sdk` — passed.
- `bun run check-types` in `apps/vscode` — passed.
- `bunx tsc --noEmit` in `apps/vscode` and `apps/vscode/webview-ui` — passed.
- Focused Biome check for all changed TypeScript files — passed.
- Direct smoke assertions for Atomic Chat generic settings, custom model IDs, and the generated provider/model catalog — passed.
- Focused Vitest collection is blocked in this checkout by existing dependency-loader failures (`isStream is not a function` and `LRUCache is not a constructor`).
- `bun run build:webview` completes TypeScript compilation and transforms 4,307 modules, then is blocked by an unrelated `rehype-react` / `property-information` dependency-resolution error.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not included. This reuses the existing generic provider settings and model picker rather than adding a new UI.

### Additional Notes

This is the narrow follow-up requested in the latest discussion on #12175. The generated Atomic Chat entry currently supplies the OpenAI-compatible family, `http://127.0.0.1:1337/v1` default, and models.dev-backed model list; this PR only fills the host presentation and local custom-model gap.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized provider-settings and model-ID allowlist changes plus documentation; no auth, data, or core inference path changes.
> 
> **Overview**
> **Atomic Chat** now uses the shared **generic catalog-backed settings UI** instead of a bespoke flow, with presentation overrides for an optional custom base URL (default `http://127.0.0.1:1337/v1`) and **custom model IDs** for locally loaded models missing from the models.dev list.
> 
> The extension treats `atomic-chat` like other bypassable-catalog providers in `providerAllowsCustomModelIds`, so the model picker and resolution honor user-entered IDs. Docs no longer describe polling `GET /v1/models`; they point users at the catalog dropdown and **Use custom model ID…**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6157975049c4b39ed0352db3033e3bc5e45fd509. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->