### PR TITLE
fix(core): honor MCP server tool timeouts

### DIFF
--- a/sdk/packages/core/src/extensions/mcp/client.ts
+++ b/sdk/packages/core/src/extensions/mcp/client.ts
@@ -360,7 +360,7 @@ class StdioMcpClient implements McpServerClient {
 	private async request(
 		method: string,
 		params?: Record<string, unknown>,
-		timeoutMs = MCP_REQUEST_TIMEOUT_MS,
+		timeoutMs = this.registration.timeoutMs ?? MCP_REQUEST_TIMEOUT_MS,
 	): Promise<unknown> {
 		const child = this.process;
 		if (!child?.stdin.writable) {

--- a/sdk/packages/core/src/extensions/mcp/config-loader.test.ts
+++ b/sdk/packages/core/src/extensions/mcp/config-loader.test.ts
@@ -209,6 +209,26 @@ describe("mcp config loader", () => {
 		]);
 	});
 
+	it("converts per-server timeout seconds to milliseconds", async () => {
+		const tempRoot = await mkdtemp(join(tmpdir(), "core-mcp-config-loader-"));
+		tempRoots.push(tempRoot);
+		const filePath = join(tempRoot, "cline_mcp_settings.json");
+		await writeFile(
+			filePath,
+			JSON.stringify({
+				mcpServers: {
+					docs: { command: "node", timeout: 300 },
+				},
+			}),
+			"utf8",
+		);
+
+		expect(resolveMcpServerRegistrations({ filePath })[0]).toMatchObject({
+			name: "docs",
+			timeoutMs: 300_000,
+		});
+	});
+
 	it("accepts legacy flat url format and preserves explicit transportType", async () => {
 		const tempRoot = await mkdtemp(join(tmpdir(), "core-mcp-config-loader-"));
 		tempRoots.push(tempRoot);

--- a/sdk/packages/core/src/extensions/mcp/config-loader.ts
+++ b/sdk/packages/core/src/extensions/mcp/config-loader.ts
@@ -24,6 +24,7 @@ import type {
 
 const stringRecordSchema = z.record(z.string(), z.string());
 const metadataSchema = z.record(z.string(), z.unknown());
+const timeoutSecondsSchema = z.number().positive().optional();
 const oauthStateSchema = z
 	.object({
 		clientInformation: z.record(z.string(), z.unknown()).optional(),
@@ -62,12 +63,18 @@ const mcpTransportSchema = z.discriminatedUnion("type", [
 	streamableHttpTransportSchema,
 ]);
 
-const nestedRegistrationBodySchema = z.object({
-	transport: mcpTransportSchema,
-	disabled: z.boolean().optional(),
-	metadata: metadataSchema.optional(),
-	oauth: oauthStateSchema.optional(),
-});
+const nestedRegistrationBodySchema = z
+	.object({
+		transport: mcpTransportSchema,
+		timeout: timeoutSecondsSchema,
+		disabled: z.boolean().optional(),
+		metadata: metadataSchema.optional(),
+		oauth: oauthStateSchema.optional(),
+	})
+	.transform(({ timeout, ...value }) => ({
+		...value,
+		...(timeout !== undefined ? { timeoutMs: timeout * 1_000 } : {}),
+	}));
 
 const legacyTransportTypeSchema = z
 	.enum(["stdio", "sse", "http", "streamableHttp"])
@@ -77,6 +84,7 @@ const legacyRegistrationBaseSchema = z.object({
 	type: z.enum(["stdio", "sse", "streamableHttp"]).optional(),
 	transportType: legacyTransportTypeSchema,
 	disabled: z.boolean().optional(),
+	timeout: timeoutSecondsSchema,
 	metadata: metadataSchema.optional(),
 	oauth: oauthStateSchema.optional(),
 });
@@ -119,6 +127,7 @@ const legacyStdioRegistrationSchema = legacyRegistrationBaseSchema
 			cwd: value.cwd,
 			env: value.env,
 		},
+		...(value.timeout !== undefined ? { timeoutMs: value.timeout * 1_000 } : {}),
 		disabled: value.disabled,
 		metadata: value.metadata,
 		oauth: value.oauth,
@@ -151,6 +160,7 @@ const legacyUrlRegistrationSchema = legacyRegistrationBaseSchema
 					url: value.url,
 					headers: value.headers,
 				},
+				...(value.timeout !== undefined ? { timeoutMs: value.timeout * 1_000 } : {}),
 				disabled: value.disabled,
 				metadata: value.metadata,
 				oauth: value.oauth,
@@ -162,6 +172,7 @@ const legacyUrlRegistrationSchema = legacyRegistrationBaseSchema
 				url: value.url,
 				headers: value.headers,
 			},
+			...(value.timeout !== undefined ? { timeoutMs: value.timeout * 1_000 } : {}),
 			disabled: value.disabled,
 			metadata: value.metadata,
 			oauth: value.oauth,
@@ -683,6 +694,7 @@ export function resolveMcpServerRegistrations(
 	return Object.entries(config.mcpServers).map(([name, value]) => ({
 		name,
 		transport: value.transport,
+		...(value.timeoutMs !== undefined ? { timeoutMs: value.timeoutMs } : {}),
 		disabled: value.disabled,
 		metadata: value.metadata,
 		oauth: value.oauth,

--- a/sdk/packages/core/src/extensions/mcp/types.ts
+++ b/sdk/packages/core/src/extensions/mcp/types.ts
@@ -74,6 +74,7 @@ export interface McpServerOAuthState {
 export interface McpServerRegistration {
 	name: string;
 	transport: McpServerTransportConfig;
+	timeoutMs?: number;
 	disabled?: boolean;
 	metadata?: Record<string, unknown>;
 	oauth?: McpServerOAuthState;

--- a/sdk/packages/core/src/runtime/orchestration/runtime-builder.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-builder.ts
@@ -217,7 +217,11 @@ async function loadConfiguredMcpTools(logger?: BasicLogger): Promise<{
 	const enabled = registrations.filter((r) => r.disabled !== true);
 	const results = await Promise.allSettled(
 		enabled.map((r) =>
-			createMcpTools({ serverName: r.name, provider: manager }),
+			createMcpTools({
+				serverName: r.name,
+				provider: manager,
+				timeoutMs: r.timeoutMs,
+			}),
 		),
 	);
 	const tools: AgentTool[] = [];


### PR DESCRIPTION
## Summary
- parse per-server MCP `timeout` values from both legacy and nested settings formats
- apply the configured timeout to stdio JSON-RPC requests
- use the same timeout for generated MCP agent tools

Fixes #12576

## Testing
- `git diff --check`
- `bun -F @cline/core test:unit src/extensions/mcp/config-loader.test.ts` (blocked before collection: the workspace resolves a Zod runtime where `z.record` is undefined)
- `bun -F @cline/core typecheck` (blocked by the pre-existing SAP provider type error in `sdk/packages/llms/src/providers/vendors/community.ts:364`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is opt-in via settings; default timeouts remain when `timeout` is omitted. Misconfigured very large timeouts could delay failures but do not affect auth or data paths.
> 
> **Overview**
> Per-server **`timeout`** values in MCP settings (seconds, in nested `transport` blocks and legacy flat server entries) are now parsed, converted to **`timeoutMs`**, and carried on **`McpServerRegistration`**.
> 
> **Stdio** JSON-RPC requests (`tools/list`, `tools/call`, etc.) use that registration timeout instead of the fixed 5s default; connect still uses the shorter connect timeout. When MCP tools are built for the runtime, the same **`timeoutMs`** is passed into **`createMcpTools`** so agent tool execution matches the configured server limit.
> 
> A unit test covers seconds-to-milliseconds conversion for legacy command-based entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd9b4b5ffd10ccd6dba0b6c8091ffdb4fb91f603. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->