### PR TITLE
fix(vscode): remove attachments from edited messages

### DIFF
--- a/apps/vscode/webview-ui/src/components/chat/UserMessage.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/UserMessage.tsx
@@ -18,12 +18,16 @@ interface UserMessageProps {
 const UserMessage: React.FC<UserMessageProps> = ({ text, images, files, messageTs, canRestoreWorkspace = true }) => {
 	const [isEditing, setIsEditing] = useState(false)
 	const [editedText, setEditedText] = useState(text ?? "")
+	const [editedImages, setEditedImages] = useState(images ?? [])
+	const [editedFiles, setEditedFiles] = useState(files ?? [])
 	const [savingMode, setSavingMode] = useState<"chat" | "workspace" | undefined>()
 	const [errorMessage, setErrorMessage] = useState<string | undefined>()
 	const highlightedText = useMemo(() => highlightText(text), [text])
 
 	const startEditing = () => {
 		setEditedText(text ?? "")
+		setEditedImages(images ?? [])
+		setEditedFiles(files ?? [])
 		setErrorMessage(undefined)
 		setIsEditing(true)
 	}
@@ -56,8 +60,8 @@ const UserMessage: React.FC<UserMessageProps> = ({ text, images, files, messageT
 				EditMessageAndRegenerateRequest.create({
 					messageTs,
 					text: editedText,
-					images: images ?? [],
-					files: files ?? [],
+					images: editedImages,
+					files: editedFiles,
 					restoreWorkspace,
 				}),
 			)
@@ -120,6 +124,14 @@ const UserMessage: React.FC<UserMessageProps> = ({ text, images, files, messageT
 						rows={Math.max(3, editedText.split("\n").length)}
 						value={editedText}
 					/>
+					{(editedImages.length > 0 || editedFiles.length > 0) && (
+						<Thumbnails
+							files={editedFiles}
+							images={editedImages}
+							setFiles={setEditedFiles}
+							setImages={setEditedImages}
+						/>
+					)}
 					{errorMessage && <div className="text-xs text-(--vscode-errorForeground)">{errorMessage}</div>}
 					<div className="flex items-center justify-between gap-1.5">
 						<button

--- a/apps/vscode/webview-ui/src/components/chat/__tests__/UserMessage.ime.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/__tests__/UserMessage.ime.test.tsx
@@ -118,4 +118,21 @@ describe("UserMessage – IME composition handling", () => {
 			}),
 		)
 	})
+
+	it("removes an image before regenerating an edited message", async () => {
+		const user = userEvent.setup()
+		render(<UserMessage images={["image.png"]} messageTs={123} text="Update this" />)
+
+		await user.click(screen.getByText("Update this"))
+		const thumbnail = screen.getByAltText("Thumbnail image-1")
+		fireEvent.mouseEnter(thumbnail.parentElement as HTMLElement)
+		const removeButton = thumbnail.parentElement?.querySelector(".codicon-close")?.parentElement
+		expect(removeButton).not.toBeNull()
+		await user.click(removeButton as HTMLElement)
+
+		expect(screen.queryByAltText("Thumbnail image-1")).not.toBeInTheDocument()
+		await user.click(screen.getByRole("button", { name: "Reset Chat" }))
+		await waitFor(() => expect(TaskServiceClient.editMessageAndRegenerate).toHaveBeenCalledTimes(1))
+		expect(TaskServiceClient.editMessageAndRegenerate).toHaveBeenCalledWith(expect.objectContaining({ images: [] }))
+	})
 })


### PR DESCRIPTION
## Summary
- show existing image and file attachments while editing a user message
- make those attachments removable before resetting chat or code
- submit the edited attachment list instead of the original message payload

Fixes #12560

## Testing
- `bun run test src/components/chat/__tests__/UserMessage.ime.test.tsx` (4 tests passed)
- `bun run build` (blocked by existing generated-proto/API mismatches, including missing `ClineSay.COMPACTION`, `ModelOverrides`, and `TaskServiceClient.proceedWhileRunningCommand`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to VS Code webview chat edit UI; no auth, backend, or persistence changes beyond the existing regenerate API payload.
> 
> **Overview**
> When editing a user message to **reset chat** or **reset code**, attachments can now be changed—not only the text.
> 
> `UserMessage` tracks **`editedImages`** and **`editedFiles`** while editing, shows the existing **`Thumbnails`** UI with remove controls, and passes that edited list into **`editMessageAndRegenerate`** instead of the original message’s images/files.
> 
> A test covers removing an image before **Reset Chat** and verifying **`images: []`** is sent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b988b95b894b243b1c68a1810f7be8697b7b4171. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->