### PR TITLE
test(cli): make dialog cleanup assertion color-mode agnostic

### DIFF
--- a/apps/cli/src/tests/interactive/chat.test.ts
+++ b/apps/cli/src/tests/interactive/chat.test.ts
@@ -66,18 +66,58 @@ test.describe("Dialog dismissal - panel is fully removed", () => {
 		env: clineEnv("default"),
 	});
 
-	// The dialog panel's background is @opentui-ui/dialog's DEFAULT_STYLE
-	// (#262626), which xterm reports as this packed 24-bit color.
-	const DIALOG_PANEL_BG = 0x262626;
+	type Background = {
+		mode: number | undefined;
+		color: number | undefined;
+	};
+	type TerminalSnapshot = ReturnType<Terminal["serialize"]> & {
+		baseY: number;
+	};
+	const backgroundsEqual = (
+		left: Background | undefined,
+		right: Background | undefined,
+	): boolean => left?.mode === right?.mode && left?.color === right?.color;
+	const snapshotTerminal = (terminal: Terminal): TerminalSnapshot => ({
+		...terminal.serialize(),
+		baseY: terminal.getCursor().baseY,
+	});
 
-	const countPanelCells = (terminal: Terminal): number => {
-		let count = 0;
-		for (const shift of terminal.serialize().shifts.values()) {
-			if (shift.bgColor === DIALOG_PANEL_BG) {
-				count++;
+	const findTextPosition = (
+		terminal: Terminal,
+		text: string,
+	): { x: number; y: number } => {
+		const lines = terminal.getViewableBuffer();
+		for (let y = 0; y < lines.length; y++) {
+			const x = lines[y].join("").indexOf(text);
+			if (x !== -1) {
+				return { x, y };
 			}
 		}
-		return count;
+		throw new Error(`Unable to locate visible text: ${text}`);
+	};
+
+	const getCellBackground = (
+		snapshot: TerminalSnapshot,
+		position: { x: number; y: number },
+	): Background => {
+		const targetRow = snapshot.baseY + position.y;
+		let background: Background = { mode: undefined, color: undefined };
+
+		for (let y = snapshot.baseY; y <= targetRow; y++) {
+			for (let x = 0; x < TERMINAL_WIDE.columns; x++) {
+				const shift = snapshot.shifts.get(`${x},${y}`);
+				if (shift?.bgColorMode !== undefined) {
+					background = { mode: shift.bgColorMode, color: shift.bgColor };
+				}
+				if (x === position.x && y === targetRow) {
+					return background;
+				}
+			}
+		}
+
+		throw new Error(
+			`Cell is outside the visible terminal: ${position.x},${position.y}`,
+		);
 	};
 
 	// @opentui-ui/dialog is built against @opentui/core ^0.1.69, whose
@@ -91,21 +131,40 @@ test.describe("Dialog dismissal - panel is fully removed", () => {
 		terminal,
 	}) => {
 		await waitForChatReady(terminal);
+		const terminalBeforeDialog = snapshotTerminal(terminal);
 		await typeAndSubmit(terminal, "/help");
 		await expectVisible(terminal, "Keyboard Shortcuts");
-		expect(countPanelCells(terminal)).toBeGreaterThan(0);
+		const dialogPosition = findTextPosition(terminal, "Keyboard Shortcuts");
+		const backgroundAtDialogPosition = getCellBackground(
+			terminalBeforeDialog,
+			dialogPosition,
+		);
+		const dialogBackground = getCellBackground(
+			snapshotTerminal(terminal),
+			dialogPosition,
+		);
+		expect(dialogBackground).not.toEqual(backgroundAtDialogPosition);
 
 		terminal.keyEscape();
 		await expectNotVisible(terminal, "Keyboard Shortcuts");
 
-		// The panel unmounts a frame after its content; poll until the
-		// dialog's imperative box is detached rather than sampling once.
+		// The panel unmounts a frame after its content. Poll the title's former
+		// position until the background captured from the visible panel is gone.
 		const deadline = Date.now() + 10_000;
-		let remaining = countPanelCells(terminal);
-		while (remaining > 0 && Date.now() < deadline) {
+		let backgroundAfterDialog = getCellBackground(
+			snapshotTerminal(terminal),
+			dialogPosition,
+		);
+		while (
+			!backgroundsEqual(backgroundAfterDialog, backgroundAtDialogPosition) &&
+			Date.now() < deadline
+		) {
 			await new Promise((resolve) => setTimeout(resolve, 100));
-			remaining = countPanelCells(terminal);
+			backgroundAfterDialog = getCellBackground(
+				snapshotTerminal(terminal),
+				dialogPosition,
+			);
 		}
-		expect(remaining).toBe(0);
+		expect(backgroundAfterDialog).toEqual(backgroundAtDialogPosition);
 	});
 });


### PR DESCRIPTION
### Related Issue

**Issue:** N/A — CI failure surfaced while validating #12573.

### Description

The CLI dialog cleanup regression test assumed xterm represented the dialog's `#262626` background as the numeric RGB value `0x262626`. Current CI serializes the rendered panel as a background mode and colour tuple whose numeric colour is `0`, so the test failed before exercising dialog dismissal.

Capture the complete background state at the visible dialog title instead. The test now proves that opening the dialog changes that cell and dismissing it restores the same pre-dialog background, without depending on a specific terminal colour encoding.

### Test Procedure

```bash
bunx biome check apps/cli/src/tests/interactive/chat.test.ts
bunx tsc --noEmit --pretty false --moduleResolution bundler --module preserve --target esnext --skipLibCheck apps/cli/src/tests/interactive/chat.test.ts
bun -F @cline/cli test:e2e:cli:tui interactive/chat.test.ts
bun -F @cline/cli test:e2e:cli:tui
```

The focused suite passes all three tests. The dialog test also passes in the full four-worker suite. Reversing the `@opentui-ui/dialog` cleanup patch makes only the dialog test fail after Escape, confirming the test still detects the leaked-panel regression.

The full local suite encountered unrelated headless/auth process timeouts after the dialog test passed; CI will run the complete suite in the normal runner environment.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

This changes only the TUI regression test; production dialog behavior and dependencies are unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates an interactive CLI e2e test helper and assertions; no runtime or security impact.
> 
> **Overview**
> Fixes a flaky/failing TUI regression test for help-dialog teardown that hard-coded the dialog panel background as `0x262626`. CI serializes that cell as a **mode + color** pair (with color `0`), so the old “count grey cells” check never ran the dismissal logic.
> 
> The test now **snapshots the cell under “Keyboard Shortcuts”** before opening `/help`, asserts the background **changes** when the dialog opens, then **polls until that cell’s background matches the pre-dialog snapshot** after Escape—without assuming a specific RGB encoding.
> 
> **Scope:** test-only change in `chat.test.ts`; no production dialog behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 222f68fbacf6fc3adbe9ec2233bf94e0ef7e72ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->