### PR TITLE
docs: small README cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Run Cline with zero interaction for scripting and automation. Pipe input, get JS
 
 ```bash
 cline "Run tests and fix any failures"
-git diff origin/main | cline  "Review these changes for issues"
+git diff origin/main | cline "Review these changes for issues"
 cline --json "List all TODO comments" | jq -r 'select(.type == "agent_event" and .event.text) | .event.text'
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ The open source coding agent in your IDE and terminal.
 </p>
 
 <div align="center">
-
-<div align="center">
 <table>
 <tbody>
 <td align="center">
@@ -30,8 +28,6 @@ The open source coding agent in your IDE and terminal.
 </td>
 </tbody>
 </table>
-</div>
-
 </div>
 
 <br>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Related Issue

No linked issue — typo/cosmetic corrections, which the template lists as an allowed exception to the prior-discussion requirement.

### Description

Two small cleanups to the root `README.md`:

1. The headless CLI example had a stray double space between `cline` and its prompt argument (`cline  "Review these changes for issues"`), now a single space so it matches the surrounding examples.
2. The top nav table (Docs / Discord / r/cline / Feature Requests / Join us) was wrapped in two identical nested `<div align="center">` elements. Removed the redundant outer wrapper; the inner one already centers the table, so the rendered output is unchanged.

### Test Procedure

Documentation-only changes: one whitespace character inside a fenced code block, and removal of a duplicate wrapper element that had no rendering effect. Verified via `git diff` that both commits touch only `README.md` and that the remaining markup is balanced (`<div align="center">` opens and `</div>` closes the nav table exactly once).

### Type of Change

-   [x] 💅 Cosmetic Changes
-   [x] 📚 Documentation update

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable — no UI change, and the nav table renders identically before and after.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5614eed-aea7-4ef4-b735-b023488a4989"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5614eed-aea7-4ef4-b735-b023488a4989"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

