### PR TITLE
fix(vscode): preserve history task dates

### DIFF
--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -81,7 +81,7 @@ import { SdkSessionHistoryLoader } from "./sdk-session-history-loader"
 import { SdkSessionLifecycle } from "./sdk-session-lifecycle"
 import { SdkSessionRebuildScheduler } from "./sdk-session-rebuild-scheduler"
 import { SdkTaskControlCoordinator } from "./sdk-task-control-coordinator"
-import { SdkTaskHistory, sessionHistoryRecordToHistoryItem } from "./sdk-task-history"
+import { SdkTaskHistory, sessionHistoryDisplayTimestamp, sessionHistoryRecordToHistoryItem } from "./sdk-task-history"
 import { SdkTaskStartCoordinator } from "./sdk-task-start-coordinator"
 import { createVscodeSdkTelemetryHandle, type VscodeSdkTelemetryHandle } from "./sdk-telemetry"
 import { SdkTerminalExecutionModeCoordinator } from "./sdk-terminal-execution-mode-coordinator"
@@ -126,14 +126,6 @@ function metadataBoolean(metadata: SessionHistoryRecord["metadata"] | undefined,
 function metadataString(metadata: SessionHistoryRecord["metadata"] | undefined, key: string): string | undefined {
 	const value = metadata?.[key]
 	return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined
-}
-
-function dateStringToTimestamp(value: string | null | undefined): number {
-	if (!value) {
-		return 0
-	}
-	const timestamp = Date.parse(value)
-	return Number.isFinite(timestamp) ? timestamp : 0
 }
 
 function historyItemToTaskResponse(item: HistoryItem): TaskResponse {
@@ -1639,7 +1631,7 @@ export class Controller {
 		})
 
 		let filteredTasks = sessionHistory.filter((item) => {
-			const ts = dateStringToTimestamp(item.updatedAt ?? item.endedAt ?? item.startedAt)
+			const ts = sessionHistoryDisplayTimestamp(item)
 			const task = metadataString(item.metadata, "title") ?? item.prompt ?? ""
 
 			if (!ts || !task) {
@@ -1673,10 +1665,7 @@ export class Controller {
 		filteredTasks.sort((a, b) => {
 			switch (sortBy) {
 				case "oldest":
-					return (
-						dateStringToTimestamp(a.updatedAt ?? a.endedAt ?? a.startedAt) -
-						dateStringToTimestamp(b.updatedAt ?? b.endedAt ?? b.startedAt)
-					)
+					return sessionHistoryDisplayTimestamp(a) - sessionHistoryDisplayTimestamp(b)
 				case "mostExpensive":
 					return (metadataNumber(b.metadata, "totalCost") ?? 0) - (metadataNumber(a.metadata, "totalCost") ?? 0)
 				case "mostTokens":
@@ -1691,10 +1680,7 @@ export class Controller {
 							(metadataNumber(a.metadata, "cacheReads") ?? 0))
 					)
 				default:
-					return (
-						dateStringToTimestamp(b.updatedAt ?? b.endedAt ?? b.startedAt) -
-						dateStringToTimestamp(a.updatedAt ?? a.endedAt ?? a.startedAt)
-					)
+					return sessionHistoryDisplayTimestamp(b) - sessionHistoryDisplayTimestamp(a)
 			}
 		})
 
@@ -1704,7 +1690,7 @@ export class Controller {
 			return {
 				id: item.sessionId,
 				task: formatDisplayUserInput(metadataString(metadata, "title") ?? item.prompt ?? ""),
-				ts: dateStringToTimestamp(item.updatedAt ?? item.endedAt ?? item.startedAt),
+				ts: sessionHistoryDisplayTimestamp(item),
 				isFavorited: metadataBoolean(metadata, "isFavorited") ?? metadataBoolean(metadata, "is_favorited") ?? false,
 				size: metadataNumber(metadata, "size") ?? 0,
 				totalCost: metadataNumber(metadata, "totalCost") ?? 0,

--- a/apps/vscode/src/sdk/sdk-task-history.test.ts
+++ b/apps/vscode/src/sdk/sdk-task-history.test.ts
@@ -121,6 +121,18 @@ describe("SdkTaskHistory", () => {
 		expect(result.ts).toBeGreaterThan(0)
 	})
 
+	it("keeps the original session date after metadata updates", () => {
+		const result = sessionHistoryRecordToHistoryItem(
+			makeSessionRecord("task-1", {
+				startedAt: "2026-01-01T00:00:00.000Z",
+				updatedAt: "2026-07-28T00:00:00.000Z",
+				metadata: { isFavorited: true },
+			}),
+		)
+
+		expect(result.ts).toBe(Date.parse("2026-01-01T00:00:00.000Z"))
+	})
+
 	it("converts SDK persisted conversation messages to Cline messages", () => {
 		const result = sdkMessagesToClineMessages([
 			{ role: "user", content: "Build the feature" },

--- a/apps/vscode/src/sdk/sdk-task-history.ts
+++ b/apps/vscode/src/sdk/sdk-task-history.ts
@@ -70,6 +70,10 @@ function dateStringToTimestamp(value: string | null | undefined): number {
 	return Number.isFinite(timestamp) ? timestamp : 0
 }
 
+export function sessionHistoryDisplayTimestamp(item: SessionHistoryRecord): number {
+	return dateStringToTimestamp(item.startedAt ?? item.endedAt ?? item.updatedAt)
+}
+
 /**
  * Sort comparator for session history records by recency: newest first.
  *
@@ -155,7 +159,7 @@ export function sessionHistoryRecordToHistoryItem(item: SessionHistoryRecord): H
 	const metadata = item.metadata
 	return {
 		id: item.sessionId,
-		ts: dateStringToTimestamp(item.updatedAt ?? item.endedAt ?? item.startedAt),
+		ts: sessionHistoryDisplayTimestamp(item),
 		task: formatDisplayUserInput(metadataString(metadata, "title") ?? item.prompt ?? ""),
 		tokensIn: metadataNumber(metadata, "tokensIn") ?? 0,
 		tokensOut: metadataNumber(metadata, "tokensOut") ?? 0,


### PR DESCRIPTION
## Summary
- use stable session start times for history display dates and date grouping
- keep metadata update timestamps internal to cache recency
- prevent favoriting an old task from moving it into Today after history refresh

Fixes #11760

## Testing
- `bun test src/sdk/sdk-task-history.test.ts` (31 tests passed)
- repository `test:unit` wrapper also ran all 65 files: 678 tests passed; 25 unrelated files failed on the existing missing generated `ModelOverrides` export
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to timestamp derivation for history UI and API responses; cache sort logic unchanged. Low risk with a targeted unit test for metadata-update scenarios.
> 
> **Overview**
> Fixes history showing old tasks under **Today** after metadata-only updates (e.g. favoriting) by using a stable **session start** time for display and date grouping instead of `updatedAt`.
> 
> Introduces shared `sessionHistoryDisplayTimestamp` (`startedAt` → `endedAt` → `updatedAt`) and uses it in `sessionHistoryRecordToHistoryItem` and `SdkController.getTaskHistory` for filtering, sorting by date, and the `ts` field on task rows. Removes the duplicate `dateStringToTimestamp` helper from `SdkController`.
> 
> **List recency** in `SdkTaskHistory` cache sorting still prefers `updatedAt` so metadata writes can reorder the cached list without changing what users see as the task date.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f5ed93f7175e411538a2102874ae4851b5b073b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->