### PR TITLE
fix(vscode): require local auth before task start

### DIFF
--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -568,6 +568,7 @@ export class Controller {
 			loadInitialMessages: (reader, taskId) => this.sessionHistory.loadInitialMessages(reader, taskId),
 			resolveContextMentions: (text) => this.resolveContextMentions(text),
 			isClineManagedProviderActive: () => this.isClineManagedProviderActive(),
+			isClineAccountAuthenticated: () => Boolean(this.authService.getInfo().user),
 			emitClineAuthError: (task) => this.emitClineAuthErrorWithTelemetry(task),
 			captureProviderApiError: (event) => this.captureProviderFailure(event),
 			postStateToWebview: () => this.postStateToWebview(),

--- a/apps/vscode/src/sdk/sdk-task-start-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-task-start-coordinator.test.ts
@@ -71,8 +71,11 @@ describe("SdkTaskStartCoordinator", () => {
 		)
 	})
 
-	it("emits a Cline auth error instead of starting when the cline provider has no token", async () => {
-		const { coordinator, options } = makeCoordinator({ config: { providerId: "cline", modelId: "model", apiKey: "" } })
+	it("does not start a Cline task when this IDE is logged out but shared storage has a token", async () => {
+		const { coordinator, options } = makeCoordinator({
+			config: { providerId: "cline", modelId: "model", apiKey: "shared-token" },
+			isClineAccountAuthenticated: false,
+		})
 
 		const sessionId = await coordinator.initTask("needs auth")
 
@@ -83,7 +86,10 @@ describe("SdkTaskStartCoordinator", () => {
 	})
 
 	it("emits a Cline auth error instead of starting when ClinePass has no token", async () => {
-		const { coordinator, options } = makeCoordinator({ config: { providerId: "cline-pass", modelId: "model", apiKey: "" } })
+		const { coordinator, options } = makeCoordinator({
+			config: { providerId: "cline-pass", modelId: "model", apiKey: "" },
+			isClineAccountAuthenticated: true,
+		})
 
 		const sessionId = await coordinator.initTask("needs clinepass auth")
 
@@ -281,6 +287,7 @@ function makeCoordinator(input: Partial<MakeCoordinatorInput> = {}) {
 		loadInitialMessages: vi.fn().mockResolvedValue([{ role: "user", content: "hello" }]),
 		resolveContextMentions: vi.fn(async (text: string) => `resolved: ${text}`),
 		isClineManagedProviderActive: vi.fn(() => false),
+		isClineAccountAuthenticated: vi.fn(() => input.isClineAccountAuthenticated ?? true),
 		emitClineAuthError: vi.fn(),
 		captureProviderApiError: vi.fn(),
 		postStateToWebview: vi.fn().mockResolvedValue(undefined),
@@ -306,6 +313,7 @@ function makeCoordinator(input: Partial<MakeCoordinatorInput> = {}) {
 		loadInitialMessages: ReturnType<typeof vi.fn>
 		resolveContextMentions: ReturnType<typeof vi.fn>
 		isClineManagedProviderActive: ReturnType<typeof vi.fn>
+		isClineAccountAuthenticated: ReturnType<typeof vi.fn>
 		emitClineAuthError: ReturnType<typeof vi.fn>
 		captureProviderApiError: ReturnType<typeof vi.fn>
 		postStateToWebview: ReturnType<typeof vi.fn>
@@ -328,4 +336,5 @@ interface MakeCoordinatorInput {
 	}
 	historyItem: HistoryItem
 	hasHistoryItem: boolean
+	isClineAccountAuthenticated: boolean
 }

--- a/apps/vscode/src/sdk/sdk-task-start-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-task-start-coordinator.ts
@@ -53,6 +53,7 @@ export interface SdkTaskStartCoordinatorOptions {
 	loadInitialMessages: (reader: SdkSessionHost, taskId: string) => Promise<unknown[] | undefined>
 	resolveContextMentions: (text: string) => Promise<string>
 	isClineManagedProviderActive: () => boolean
+	isClineAccountAuthenticated: () => boolean
 	emitClineAuthError: (task?: string) => void
 	captureProviderApiError?: (event: ProviderFailureTelemetry) => void
 	postStateToWebview: () => Promise<void>
@@ -94,9 +95,9 @@ export class SdkTaskStartCoordinator {
 				`[SdkController] Session config: provider=${config.providerId}, model=${config.modelId}, hasApiKey=${!!config.apiKey}`,
 			)
 
-			if (usesClineAccountAuth(config.providerId) && !config.apiKey) {
+			if (usesClineAccountAuth(config.providerId) && (!this.options.isClineAccountAuthenticated() || !config.apiKey)) {
 				Logger.warn(
-					`[SdkController] ${config.providerId} provider selected but no Cline auth token — emitting auth error`,
+					`[SdkController] ${config.providerId} provider selected but Cline account is not authenticated — emitting auth error`,
 				)
 				// No task/session id exists yet, so this preflight auth UI path is
 				// intentionally not recorded as task-joinable provider error telemetry.


### PR DESCRIPTION
## Summary
- require the local VS Code Cline account state before starting Cline or ClinePass tasks
- keep the existing resolved-token check for missing credentials
- cover the cross-IDE case where shared provider storage contains a token while VS Code remains logged out

Fixes #12530

## Testing
- `bun test src/sdk/sdk-task-start-coordinator.test.ts` (9 passed)
- `bunx tsc --noEmit --pretty false` (blocked by existing generated proto mismatches, including missing `ModelOverrides` and `ClineSay.COMPACTION`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication gating for managed provider task start; scope is narrow but touches auth-critical preflight behavior.
> 
> **Overview**
> **Cline/ClinePass task start** now blocks when this VS Code window is not signed into a Cline account, even if shared provider storage still has an API token from another client.
> 
> `SdkTaskStartCoordinator` adds an `isClineAccountAuthenticated` gate alongside the existing `config.apiKey` check for providers that use Cline account auth. `SdkController` wires that to `authService.getInfo().user`. Failed preflight still shows the sign-in auth UI via `emitClineAuthError` and does not start a session.
> 
> Tests cover the cross-IDE case (shared token + local logged out) and keep the ClinePass missing-token case explicit with local auth on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dc23550e6f325921cc83bad2eaa32eec7722783. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->