### PR TITLE
Add data dirs when running specific environments

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -51,7 +51,8 @@
 			"env": {
 				"IS_DEV": "true",
 				"DEV_WORKSPACE_FOLDER": "${workspaceFolder}/apps/vscode",
-				"CLINE_ENVIRONMENT": "staging"
+				"CLINE_ENVIRONMENT": "staging",
+				"CLINE_DIR": "${userHome}/.cline_staging"
 			}
 		},
 		{
@@ -75,7 +76,8 @@
 			"env": {
 				"IS_DEV": "true",
 				"DEV_WORKSPACE_FOLDER": "${workspaceFolder}/apps/vscode",
-				"CLINE_ENVIRONMENT": "local"
+				"CLINE_ENVIRONMENT": "local",
+				"CLINE_DIR": "${userHome}/.cline_local"
 			}
 		},
 		{


### PR DESCRIPTION
I want to be able to run vscode testing against staging or local envs without polluting my main prod data dir. This PR enforces a default.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only VS Code launch environment variables; no production or runtime behavior change for shipped builds.
> 
> **Overview**
> VS Code **Run Extension (staging)** and **Run Extension (local)** launch configs now set **`CLINE_DIR`** so dev runs use separate data directories instead of the default `~/.cline`.
> 
> Staging uses `~/.cline_staging` and local uses `~/.cline_local`, matching the intent to test against staging or local backends without overwriting production Cline data (settings, secrets, auth).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e7ca1158ea8887cfebff9e8aa59e89bc46d4b7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->