### PR TITLE
docs(readme): point VS Code extension index entry at apps/vscode

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ npm install @cline/sdk
 |---------|------------|--------------|--------------|
 | **SDK** | Node.js programmatic agent API and extension exports. | [`sdk/`](https://github.com/cline/cline/tree/main/sdk) | [CHANGELOG.md](https://github.com/cline/cline/blob/main/sdk/CHANGELOG.md) |
 | **CLI** | Terminal UI, headless mode, shell commands, and CLI-specific flows. | [`apps/cli/`](https://github.com/cline/cline/tree/main/apps/cli) | [CHANGELOG.md](https://github.com/cline/cline/blob/main/apps/cli/CHANGELOG.md) |
-| **VS Code Extension** | The Marketplace extension and extension host integration. | [`/`](https://github.com/cline/cline/tree/main) (WIP migrating) | [CHANGELOG.md](https://github.com/cline/cline/blob/main/CHANGELOG.md) |
+| **VS Code Extension** | The Marketplace extension and extension host integration. | [`apps/vscode/`](https://github.com/cline/cline/tree/main/apps/vscode) | [CHANGELOG.md](https://github.com/cline/cline/blob/main/CHANGELOG.md) |
 | **JetBrains Plugin** | JetBrains-hosted client that talks to the shared agent core. | Currently we are not open-sourcing JetBrains plugins | - |
 | **Kanban** | Web-based multi-agent task board. | [`cline/kanban`](https://github.com/cline/kanban) | [CHANGELOG.md](https://github.com/cline/kanban/blob/main/CHANGELOG.md) |
 | **Docs site** | Public documentation pages. | [`docs/`](https://docs.cline.bot/) | - |
@@ -226,7 +226,7 @@ Run Cline with zero interaction for scripting and automation. Pipe input, get JS
 
 ```bash
 cline "Run tests and fix any failures"
-git diff origin/main | cline  "Review these changes for issues"
+git diff origin/main | cline "Review these changes for issues"
 cline --json "List all TODO comments" | jq -r 'select(.type == "agent_event" and .event.text) | .event.text'
 ```
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Related Issue

No linked issue — small documentation fix (typo/stale-link category, per the template's limited exceptions).

### Description

The **Index** table in the root `README.md` still listed the VS Code extension as living at the repo root with a `(WIP migrating)` caveat. That migration is done: the extension now lives entirely in `apps/vscode/` (that's where `package.json` for `claude-dev`, `src/`, `webview-ui/`, `esbuild.mjs`, and `proto/` are). The stale entry sends contributors to the repo root instead of the actual package.

Changes:

- `VS Code Extension` row now links `apps/vscode/` and drops the `(WIP migrating)` note. Its CHANGELOG link is left pointing at the root `CHANGELOG.md`, which is still where that changelog lives (there is no `apps/vscode/CHANGELOG.md`).
- Removed a stray double space in the headless CLI example (`cline  "Review these changes..."`).

No code, config, or build changes — `README.md` only.

### Test Procedure

Rendered the updated `README.md` through GitHub's own GFM markdown API (`gh api -X POST /markdown -f mode=gfm -f context=cline/cline`) wrapped in `github-markdown-css`, so the preview matches what github.com will show, and read through the whole document in a browser to confirm nothing else regressed.

The Index table renders correctly with the corrected location:

![Rendered README index table showing the VS Code Extension row pointing at apps/vscode/](https://cursor.com/artifacts/c/art-0dda948a-fff9-4bd0-b70c-44e7acbef24d)

The rest of the README (header, product cards, tables, code blocks) is unaffected:

![Top of the rendered README with header and product cards](https://cursor.com/artifacts/c/art-64253d2f-57ac-4a8f-ac9b-5a0a3c7fb5a2)

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

Markdown-only change, so no test suite is exercised by it; the pre-commit `lint-staged` hook reported no configured tasks for `README.md`.

### Additional Notes

Verified there is no `apps/vscode/CHANGELOG.md`, so the CHANGELOG column intentionally still points at the root `CHANGELOG.md`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dccf925a-4912-49d6-bd1b-6199ea1a5290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dccf925a-4912-49d6-bd1b-6199ea1a5290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

