### PR TITLE
Add support for `cline-free` models.

### DIFF
--- a/apps/cli/src/utils/free-model-cost.test.ts
+++ b/apps/cli/src/utils/free-model-cost.test.ts
@@ -39,6 +39,36 @@ describe("shouldZeroClineFreeModelCost", () => {
 		);
 	});
 
+	it("matches cline-free model ids from the free endpoint bucket exactly", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => {
+				return new Response(
+					JSON.stringify({
+						free: [{ id: "cline-free/deepseek-v4-flash" }],
+					}),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				);
+			}),
+		);
+
+		await expect(
+			shouldZeroClineFreeModelCost({
+				providerId: "cline",
+				modelId: "cline-free/deepseek-v4-flash",
+				baseUrl: "https://cline.test/api/v1",
+			}),
+		).resolves.toBe(true);
+
+		await expect(
+			shouldZeroClineFreeModelCost({
+				providerId: "cline-pass",
+				modelId: "deepseek-v4-flash",
+				baseUrl: "https://cline.test/api/v1",
+			}),
+		).resolves.toBe(false);
+	});
+
 	it("does not zero non-Cline providers", async () => {
 		const fetchMock = vi.fn();
 		vi.stubGlobal("fetch", fetchMock);

--- a/apps/vscode/src/core/controller/models/__tests__/refreshClineRecommendedModels.test.ts
+++ b/apps/vscode/src/core/controller/models/__tests__/refreshClineRecommendedModels.test.ts
@@ -27,7 +27,7 @@ describe("refreshClineRecommendedModels", () => {
 	it("delegates to the SDK fetch", async () => {
 		const sdkResult = {
 			recommended: [{ id: "anthropic/claude-sonnet-4.6", name: "Claude Sonnet 4.6", description: "Remote", tags: ["NEW"] }],
-			free: [{ id: "z-ai/glm-5", name: "GLM 5", description: "Remote free", tags: [] }],
+			free: [{ id: "cline-free/glm-5", name: "GLM 5", description: "Remote free", tags: [] }],
 			clinePass: [],
 		}
 		const sdkSpy = vi.spyOn(sdkCore, "fetchClineRecommendedModels").mockResolvedValue(sdkResult)

--- a/sdk/packages/core/src/services/llms/provider-defaults.test.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.test.ts
@@ -186,16 +186,16 @@ describe("resolveProviderConfig", () => {
 		expect(resolved?.knownModels?.["cline-free/live-free-model"]).toMatchObject(
 			{
 				id: "cline-free/live-free-model",
-				name: "Live Free Model",
+				name: "Live Free Model (free)",
 			},
 		);
 		expect(
 			resolved?.knownModels?.["cline-free/live-free-model"]?.pricing,
 		).toEqual({
-			input: 1,
-			output: 2,
-			cacheRead: 0.1,
-			cacheWrite: 0.2,
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
 		});
 	});
 
@@ -255,7 +255,7 @@ describe("resolveProviderConfig", () => {
 		expect(resolved?.knownModels?.["cline-free/live-free-model"]).toMatchObject(
 			{
 				id: "cline-free/live-free-model",
-				name: "Live Free Model",
+				name: "Live Free Model (free)",
 				contextWindow: 300_000,
 				maxInputTokens: 250_000,
 				maxTokens: 64_000,

--- a/sdk/packages/core/src/services/llms/provider-defaults.test.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.test.ts
@@ -259,7 +259,7 @@ describe("resolveProviderConfig", () => {
 				contextWindow: 300_000,
 				maxInputTokens: 250_000,
 				maxTokens: 64_000,
-				pricing: { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 0.2 },
+				pricing: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 			},
 		);
 	});

--- a/sdk/packages/core/src/services/llms/provider-defaults.test.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.test.ts
@@ -134,6 +134,12 @@ describe("resolveProviderConfig", () => {
 									name: "Live Free Model",
 									tool_call: true,
 									release_date: "2026-01-01",
+									cost: {
+										input: 1,
+										output: 2,
+										cache_read: 0.1,
+										cache_write: 0.2,
+									},
 								},
 							},
 						},
@@ -153,7 +159,7 @@ describe("resolveProviderConfig", () => {
 							name: "vendor/live-pass-model",
 						},
 					],
-					free: [{ id: "vendor/live-free-model" }],
+					free: [{ id: "cline-free/live-free-model" }],
 				}),
 				{
 					status: 200,
@@ -175,14 +181,87 @@ describe("resolveProviderConfig", () => {
 		// even when a free model has a newer release date.
 		expect(Object.keys(resolved?.knownModels ?? {})).toEqual([
 			"cline-pass/live-pass-model",
-			"vendor/live-free-model",
+			"cline-free/live-free-model",
 		]);
-		expect(resolved?.knownModels?.["vendor/live-free-model"]?.pricing).toEqual({
-			input: 0,
-			output: 0,
-			cacheRead: 0,
-			cacheWrite: 0,
+		expect(resolved?.knownModels?.["cline-free/live-free-model"]).toMatchObject(
+			{
+				id: "cline-free/live-free-model",
+				name: "Live Free Model",
+			},
+		);
+		expect(
+			resolved?.knownModels?.["cline-free/live-free-model"]?.pricing,
+		).toEqual({
+			input: 1,
+			output: 2,
+			cacheRead: 0.1,
+			cacheWrite: 0.2,
 		});
+	});
+
+	it("adds cline-free models from the recommended endpoint to the Cline catalog", async () => {
+		const fetchMock = vi.fn(async (url: string) => {
+			if (url === "https://models.test/api.json") {
+				return new Response(
+					JSON.stringify({
+						openrouter: {
+							models: {
+								"vendor/live-free-model": {
+									name: "Live Free Model",
+									tool_call: true,
+									reasoning: true,
+									limit: { context: 300_000, input: 250_000, output: 64_000 },
+									cost: {
+										input: 1,
+										output: 2,
+										cache_read: 0.1,
+										cache_write: 0.2,
+									},
+								},
+							},
+						},
+					}),
+					{
+						status: 200,
+						headers: { "content-type": "application/json" },
+					},
+				);
+			}
+
+			return new Response(
+				JSON.stringify({
+					free: [
+						{
+							id: "cline-free/live-free-model",
+						},
+					],
+				}),
+				{
+					status: 200,
+					headers: { "content-type": "application/json" },
+				},
+			);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const resolved = await resolveProviderConfig("cline", {
+			loadLatestOnInit: true,
+			failOnError: false,
+			cacheTtlMs: 0,
+			url: "https://models.test/api.json",
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(resolved?.knownModels?.["cline-free/live-free-model"]).toMatchObject(
+			{
+				id: "cline-free/live-free-model",
+				name: "Live Free Model",
+				contextWindow: 300_000,
+				maxInputTokens: 250_000,
+				maxTokens: 64_000,
+				pricing: { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 0.2 },
+			},
+		);
 	});
 
 	it("falls back to generated ClinePass models when no live ClinePass models are found", async () => {

--- a/sdk/packages/core/src/services/providers/local-provider-service.test.ts
+++ b/sdk/packages/core/src/services/providers/local-provider-service.test.ts
@@ -321,6 +321,12 @@ describe("addLocalProvider – model ID parsing via modelsSourceUrl", () => {
 									reasoning: true,
 									limit: { context: 256_000, input: 200_000, output: 32_000 },
 								},
+								"vendor/live-free-model": {
+									name: "Live Free Model",
+									tool_call: true,
+									reasoning: true,
+									limit: { context: 512_000, input: 400_000, output: 64_000 },
+								},
 							},
 						},
 					}),
@@ -339,6 +345,7 @@ describe("addLocalProvider – model ID parsing via modelsSourceUrl", () => {
 							name: "vendor/live-pass-model",
 						},
 					],
+					free: [{ id: "cline-free/live-free-model" }],
 				}),
 				{
 					status: 200,
@@ -351,12 +358,24 @@ describe("addLocalProvider – model ID parsing via modelsSourceUrl", () => {
 		const { models } = await getLocalProviderModels("cline-pass");
 
 		expect(fetchMock).toHaveBeenCalledTimes(2);
-		expect(models.map((model) => model.id)).toEqual([
-			"cline-pass/live-pass-model",
-		]);
-		expect(models[0]).toMatchObject({
+		expect(models.map((model) => model.id)).toEqual(
+			expect.arrayContaining([
+				"cline-pass/live-pass-model",
+				"cline-free/live-free-model",
+			]),
+		);
+		expect(
+			models.find((model) => model.id === "cline-pass/live-pass-model"),
+		).toMatchObject({
 			id: "cline-pass/live-pass-model",
 			name: "Live Pass Model",
+			supportsReasoning: true,
+		});
+		expect(
+			models.find((model) => model.id === "cline-free/live-free-model"),
+		).toMatchObject({
+			id: "cline-free/live-free-model",
+			name: "Live Free Model",
 			supportsReasoning: true,
 		});
 	});

--- a/sdk/packages/core/src/services/providers/local-provider-service.test.ts
+++ b/sdk/packages/core/src/services/providers/local-provider-service.test.ts
@@ -375,7 +375,7 @@ describe("addLocalProvider – model ID parsing via modelsSourceUrl", () => {
 			models.find((model) => model.id === "cline-free/live-free-model"),
 		).toMatchObject({
 			id: "cline-free/live-free-model",
-			name: "Live Free Model",
+			name: "Live Free Model (free)",
 			supportsReasoning: true,
 		});
 	});

--- a/sdk/packages/llms/src/catalog/catalog-cline-recommended.ts
+++ b/sdk/packages/llms/src/catalog/catalog-cline-recommended.ts
@@ -91,9 +91,13 @@ export function normalizeClineRecommendedProviderModels(
 		const capabilities =
 			openRouterModels?.[entry.id] ??
 			findORModelCapabilities(entry, openRouterModelsByName);
+		const entryName = entry.name?.trim();
+		const name = entry.id.includes("cline-free/")
+			? `${entryName} (free)`
+			: entry.name;
 
 		const modelInfo = {
-			name: entry.name,
+			name,
 			...capabilities,
 			id: entry.id,
 			description: entry.description,
@@ -112,7 +116,7 @@ export function normalizeClineRecommendedProviderModels(
 	if (Object.keys(clineFreeModels).length > 0) {
 		result[CLINE_PROVIDER_ID] = clineFreeModels;
 	}
-	if (Object.keys(models).length > 0) {
+	if (clinePass.length > 0) {
 		result[CLINE_PASS_PROVIDER_ID] = models;
 	}
 	return result;

--- a/sdk/packages/llms/src/catalog/catalog-cline-recommended.ts
+++ b/sdk/packages/llms/src/catalog/catalog-cline-recommended.ts
@@ -101,6 +101,7 @@ export function normalizeClineRecommendedProviderModels(
 			name,
 			id: entry.id,
 			description: entry.description,
+			pricing: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		};
 
 		clineFreeModels[entry.id] = modelInfo;

--- a/sdk/packages/llms/src/catalog/catalog-cline-recommended.ts
+++ b/sdk/packages/llms/src/catalog/catalog-cline-recommended.ts
@@ -101,7 +101,6 @@ export function normalizeClineRecommendedProviderModels(
 			name,
 			id: entry.id,
 			description: entry.description,
-			pricing: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		};
 
 		clineFreeModels[entry.id] = modelInfo;
@@ -110,7 +109,10 @@ export function normalizeClineRecommendedProviderModels(
 			return;
 		}
 
-		models[entry.id] = modelInfo;
+		models[entry.id] = {
+			...modelInfo,
+			pricing: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		};
 	});
 
 	const result: Record<string, Record<string, ModelInfo>> = {};

--- a/sdk/packages/llms/src/catalog/catalog-cline-recommended.ts
+++ b/sdk/packages/llms/src/catalog/catalog-cline-recommended.ts
@@ -103,7 +103,10 @@ export function normalizeClineRecommendedProviderModels(
 			description: entry.description,
 		};
 
-		clineFreeModels[entry.id] = modelInfo;
+		clineFreeModels[entry.id] = {
+			...modelInfo,
+			pricing: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		};
 
 		if (models[entry.id]) {
 			return;

--- a/sdk/packages/llms/src/catalog/catalog-cline-recommended.ts
+++ b/sdk/packages/llms/src/catalog/catalog-cline-recommended.ts
@@ -18,6 +18,7 @@ type ModelCapabilities = Pick<
 >;
 
 const CLINE_PASS_PROVIDER_ID = "cline-pass";
+const CLINE_PROVIDER_ID = "cline";
 
 const CLINE_PASS_MODEL_DEFAULTS = {
 	contextWindow: 128_000,
@@ -66,11 +67,8 @@ export function normalizeClineRecommendedProviderModels(
 	openRouterModels: Record<string, ModelInfo>,
 ): Record<string, Record<string, ModelInfo>> {
 	const clinePass = payload.clinePass ?? [];
-	if (clinePass.length === 0) {
-		return {};
-	}
-
 	const models: Record<string, ModelInfo> = {};
+	const clineFreeModels: Record<string, ModelInfo> = {};
 	const openRouterModelsByName = buildModelsNameMap(openRouterModels);
 
 	clinePass.forEach((entry) => {
@@ -87,31 +85,37 @@ export function normalizeClineRecommendedProviderModels(
 
 	// Cline free models are selectable on the ClinePass provider too (same API
 	// underneath; they ride usage billing at $0 instead of the subscription quota).
-	// Unlike pass models their ids are full OpenRouter-style ids, so look up
-	// capabilities by full id before falling back to the slug map.
+	// Unlike pass models their ids are full OpenRouter-style ids or cline-free ids,
+	// so look up capabilities by full id before falling back to the slug map.
 	(payload.free ?? []).forEach((entry) => {
-		if (models[entry.id]) {
-			return;
-		}
-
 		const capabilities =
 			openRouterModels?.[entry.id] ??
 			findORModelCapabilities(entry, openRouterModelsByName);
 
-		models[entry.id] = {
+		const modelInfo = {
 			name: entry.name,
 			...capabilities,
 			id: entry.id,
 			description: entry.description,
-			pricing: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		};
+
+		clineFreeModels[entry.id] = modelInfo;
+
+		if (models[entry.id]) {
+			return;
+		}
+
+		models[entry.id] = modelInfo;
 	});
 
-	if (Object.keys(models).length === 0) {
-		return {};
+	const result: Record<string, Record<string, ModelInfo>> = {};
+	if (Object.keys(clineFreeModels).length > 0) {
+		result[CLINE_PROVIDER_ID] = clineFreeModels;
 	}
-
-	return { [CLINE_PASS_PROVIDER_ID]: models };
+	if (Object.keys(models).length > 0) {
+		result[CLINE_PASS_PROVIDER_ID] = models;
+	}
+	return result;
 }
 
 export async function fetchClineRecommendedModelsPayload(

--- a/sdk/packages/llms/src/catalog/catalog-cline-recommended.ts
+++ b/sdk/packages/llms/src/catalog/catalog-cline-recommended.ts
@@ -91,14 +91,14 @@ export function normalizeClineRecommendedProviderModels(
 		const capabilities =
 			openRouterModels?.[entry.id] ??
 			findORModelCapabilities(entry, openRouterModelsByName);
-		const entryName = entry.name?.trim();
-		const name = entry.id.includes("cline-free/")
+		const entryName = capabilities.name?.trim() || entry.name?.trim();
+		const name = entry.id.startsWith("cline-free/")
 			? `${entryName} (free)`
 			: entry.name;
 
 		const modelInfo = {
-			name,
 			...capabilities,
+			name,
 			id: entry.id,
 			description: entry.description,
 		};

--- a/sdk/packages/llms/src/catalog/catalog-live.test.ts
+++ b/sdk/packages/llms/src/catalog/catalog-live.test.ts
@@ -251,7 +251,7 @@ describe("models-dev-catalog", () => {
 		expect(result.cline?.["cline-free/kat-coder-pro"]).toMatchObject({
 			id: "cline-free/kat-coder-pro",
 			name: "KAT Coder Pro (free)",
-			pricing: { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 0 },
+			pricing: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		});
 		expect(models["cline-free/kat-coder-pro"]).not.toBe(
 			result.cline?.["cline-free/kat-coder-pro"],
@@ -351,7 +351,7 @@ describe("models-dev-catalog", () => {
 					id: "cline-free/k2-think",
 					name: "K2 Think (free)",
 					contextWindow: 1_000_000,
-					pricing: { input: 3, output: 15, cacheRead: 0, cacheWrite: 0 },
+					pricing: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 				}),
 			},
 		});

--- a/sdk/packages/llms/src/catalog/catalog-live.test.ts
+++ b/sdk/packages/llms/src/catalog/catalog-live.test.ts
@@ -254,6 +254,36 @@ describe("models-dev-catalog", () => {
 		});
 	});
 
+	it("labels a Cline free model when its name matches a ClinePass model", () => {
+		const result = normalizeClineRecommendedProviderModels(
+			{
+				clinePass: [
+					{
+						id: "cline-pass/deepseek-v4-flash",
+						name: "DeepSeek V4 Flash",
+					},
+				],
+				free: [
+					{
+						id: "cline-free/deepseek-v4-flash",
+						name: "DeepSeek V4 Flash",
+					},
+				],
+			},
+			{},
+		);
+
+		expect(result["cline-pass"]?.["cline-pass/deepseek-v4-flash"]?.name).toBe(
+			"DeepSeek V4 Flash",
+		);
+		expect(result["cline-pass"]?.["cline-free/deepseek-v4-flash"]?.name).toBe(
+			"DeepSeek V4 Flash (free)",
+		);
+		expect(result.cline?.["cline-free/deepseek-v4-flash"]?.name).toBe(
+			"DeepSeek V4 Flash (free)",
+		);
+	});
+
 	it("resolves free-model capabilities by slug and preserves free-only Cline catalog payloads", () => {
 		const suffixed = normalizeClineRecommendedProviderModels(
 			{

--- a/sdk/packages/llms/src/catalog/catalog-live.test.ts
+++ b/sdk/packages/llms/src/catalog/catalog-live.test.ts
@@ -176,13 +176,12 @@ describe("models-dev-catalog", () => {
 		});
 	});
 
-	it("matches Cline recommended clinePass models against OpenRouter model names", () => {
+	it("matches Cline recommended clinePass models against OpenRouter model slugs", () => {
 		const result = normalizeClineRecommendedProviderModels(
 			{
 				clinePass: [
 					{
-						id: "cline-pass/cline-pass/glm-5.2",
-						name: "zai/glm-5.2",
+						id: "cline-pass/glm-5.2",
 					},
 				],
 			},
@@ -199,10 +198,8 @@ describe("models-dev-catalog", () => {
 			},
 		);
 
-		expect(
-			result["cline-pass"]?.["cline-pass/cline-pass/glm-5.2"],
-		).toMatchObject({
-			id: "cline-pass/cline-pass/glm-5.2",
+		expect(result["cline-pass"]?.["cline-pass/glm-5.2"]).toMatchObject({
+			id: "cline-pass/glm-5.2",
 			name: "GLM 5.2",
 			contextWindow: 256_000,
 			maxInputTokens: 200_000,
@@ -218,11 +215,11 @@ describe("models-dev-catalog", () => {
 		).toEqual({});
 	});
 
-	it("includes zero-priced Cline free models alongside ClinePass models", () => {
+	it("includes Cline free models alongside ClinePass models", () => {
 		const result = normalizeClineRecommendedProviderModels(
 			{
 				clinePass: [{ id: "cline-pass/glm-5.1", name: "glm-5.1" }],
-				free: [{ id: "kwaipilot/kat-coder-pro", name: "kat-coder-pro" }],
+				free: [{ id: "cline-free/kat-coder-pro", name: "kat-coder-pro" }],
 			},
 			{
 				"kwaipilot/kat-coder-pro": {
@@ -241,23 +238,27 @@ describe("models-dev-catalog", () => {
 		// ClinePass models stay first so the provider default remains a pass model
 		expect(Object.keys(models)).toEqual([
 			"cline-pass/glm-5.1",
-			"kwaipilot/kat-coder-pro",
+			"cline-free/kat-coder-pro",
 		]);
-		expect(models["kwaipilot/kat-coder-pro"]).toMatchObject({
-			id: "kwaipilot/kat-coder-pro",
+		expect(models["cline-free/kat-coder-pro"]).toMatchObject({
+			id: "cline-free/kat-coder-pro",
 			name: "KAT Coder Pro",
 			contextWindow: 256_000,
 			maxInputTokens: 200_000,
-			// free models are billed at $0 regardless of catalog pricing
-			pricing: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			pricing: { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 0 },
+		});
+		expect(result.cline?.["cline-free/kat-coder-pro"]).toMatchObject({
+			id: "cline-free/kat-coder-pro",
+			name: "KAT Coder Pro",
+			pricing: { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 0 },
 		});
 	});
 
-	it("resolves free-model capabilities by slug and ignores free-only payloads", () => {
+	it("resolves free-model capabilities by slug and preserves free-only Cline catalog payloads", () => {
 		const suffixed = normalizeClineRecommendedProviderModels(
 			{
 				clinePass: [{ id: "cline-pass/glm-5.1" }],
-				free: [{ id: "arcee-ai/trinity-large-preview:free" }],
+				free: [{ id: "cline-free/trinity-large-preview:free" }],
 			},
 			{
 				"arcee-ai/trinity-large-preview:free": {
@@ -272,19 +273,54 @@ describe("models-dev-catalog", () => {
 			},
 		);
 		expect(
-			suffixed["cline-pass"]?.["arcee-ai/trinity-large-preview:free"],
+			suffixed["cline-pass"]?.["cline-free/trinity-large-preview:free"],
+		).toMatchObject({
+			name: "Trinity Large Preview",
+			contextWindow: 512_000,
+		});
+		expect(
+			suffixed.cline?.["cline-free/trinity-large-preview:free"],
 		).toMatchObject({
 			name: "Trinity Large Preview",
 			contextWindow: 512_000,
 		});
 
-		// free bucket alone does not create a cline-pass catalog
-		expect(
-			normalizeClineRecommendedProviderModels(
-				{ free: [{ id: "kwaipilot/kat-coder-pro" }] },
-				{},
-			),
-		).toEqual({});
+		// free bucket alone updates the Cline provider catalog but does not rotate
+		// ClinePass away from its bundled subscription list/default.
+		const freeOnly = normalizeClineRecommendedProviderModels(
+			{ free: [{ id: "cline-free/kat-coder-pro" }] },
+			{},
+		);
+		expect(freeOnly.cline?.["cline-free/kat-coder-pro"]).toBeDefined();
+		expect(freeOnly["cline-pass"]).toBeUndefined();
+	});
+
+	it("normalizes cline-free ids from the free endpoint bucket", () => {
+		const result = normalizeClineRecommendedProviderModels(
+			{ free: [{ id: "cline-free/k2-think" }] },
+			{
+				"moonshotai/k2-think": {
+					id: "moonshotai/k2-think",
+					name: "K2 Think",
+					contextWindow: 1_000_000,
+					maxInputTokens: 800_000,
+					maxTokens: 128_000,
+					capabilities: ["tools", "reasoning"],
+					pricing: { input: 3, output: 15, cacheRead: 0, cacheWrite: 0 },
+				},
+			},
+		);
+
+		expect(result).toEqual({
+			cline: {
+				"cline-free/k2-think": expect.objectContaining({
+					id: "cline-free/k2-think",
+					name: "K2 Think",
+					contextWindow: 1_000_000,
+					pricing: { input: 3, output: 15, cacheRead: 0, cacheWrite: 0 },
+				}),
+			},
+		});
 	});
 
 	it("uses input limits as the model request context window", () => {

--- a/sdk/packages/llms/src/catalog/catalog-live.test.ts
+++ b/sdk/packages/llms/src/catalog/catalog-live.test.ts
@@ -245,7 +245,8 @@ describe("models-dev-catalog", () => {
 			name: "KAT Coder Pro",
 			contextWindow: 256_000,
 			maxInputTokens: 200_000,
-			pricing: { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 0 },
+			// free models are billed at $0 regardless of catalog pricing
+			pricing: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		});
 		expect(result.cline?.["cline-free/kat-coder-pro"]).toMatchObject({
 			id: "cline-free/kat-coder-pro",

--- a/sdk/packages/llms/src/catalog/catalog-live.test.ts
+++ b/sdk/packages/llms/src/catalog/catalog-live.test.ts
@@ -242,7 +242,7 @@ describe("models-dev-catalog", () => {
 		]);
 		expect(models["cline-free/kat-coder-pro"]).toMatchObject({
 			id: "cline-free/kat-coder-pro",
-			name: "KAT Coder Pro",
+			name: "KAT Coder Pro (free)",
 			contextWindow: 256_000,
 			maxInputTokens: 200_000,
 			// free models are billed at $0 regardless of catalog pricing
@@ -250,9 +250,12 @@ describe("models-dev-catalog", () => {
 		});
 		expect(result.cline?.["cline-free/kat-coder-pro"]).toMatchObject({
 			id: "cline-free/kat-coder-pro",
-			name: "KAT Coder Pro",
+			name: "KAT Coder Pro (free)",
 			pricing: { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 0 },
 		});
+		expect(models["cline-free/kat-coder-pro"]).not.toBe(
+			result.cline?.["cline-free/kat-coder-pro"],
+		);
 	});
 
 	it("labels a Cline free model when its name matches a ClinePass model", () => {
@@ -306,13 +309,13 @@ describe("models-dev-catalog", () => {
 		expect(
 			suffixed["cline-pass"]?.["cline-free/trinity-large-preview:free"],
 		).toMatchObject({
-			name: "Trinity Large Preview",
+			name: "Trinity Large Preview (free)",
 			contextWindow: 512_000,
 		});
 		expect(
 			suffixed.cline?.["cline-free/trinity-large-preview:free"],
 		).toMatchObject({
-			name: "Trinity Large Preview",
+			name: "Trinity Large Preview (free)",
 			contextWindow: 512_000,
 		});
 
@@ -346,7 +349,7 @@ describe("models-dev-catalog", () => {
 			cline: {
 				"cline-free/k2-think": expect.objectContaining({
 					id: "cline-free/k2-think",
-					name: "K2 Think",
+					name: "K2 Think (free)",
 					contextWindow: 1_000_000,
 					pricing: { input: 3, output: 15, cacheRead: 0, cacheWrite: 0 },
 				}),


### PR DESCRIPTION
### Description

This PR adds support for Cline-specific `free` models.
Free model list:
<img width="421" height="191" alt="image" src="https://github.com/user-attachments/assets/86831d0a-1d99-44ff-8fa4-a846ef9189f8" />

Actual model list:
<img width="428" height="200" alt="image" src="https://github.com/user-attachments/assets/6ab5baa8-902a-49e3-ad19-0c903a0d0398" />

The next PR has the UX around selecting the model, prompting the user to change to the paid one, etc.

### Test Procedure

Tested that inference works locally.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)