### PR TITLE
refactor(ui): extract desktop session status

### DIFF
--- a/apps/examples/desktop-app/webview/app/globals.css
+++ b/apps/examples/desktop-app/webview/app/globals.css
@@ -3,6 +3,7 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "@cline/ui/theme/index.css";
+@import "@cline/ui/components.css";
 @import "@cline/ui/components/agent-chat.css";
 
 @source "../../node_modules/streamdown/dist";

--- a/apps/examples/desktop-app/webview/components/agent-header.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-header.tsx
@@ -1,7 +1,8 @@
 "use client";
 
+import { SessionStatus } from "@cline/ui";
 import { MoreHorizontal, Plus, Trash2 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { type CSSProperties, useEffect, useMemo, useState } from "react";
 import type { ChatSessionStatus } from "@/lib/chat-schema";
 import { cn } from "@/lib/utils";
 import { Button } from "./ui/button";
@@ -52,6 +53,18 @@ export function AgentHeader({
 	const additions = diff?.additions ?? 0;
 	const deletions = diff?.deletions ?? 0;
 	const hasChanges = additions + deletions > 0;
+	const statusTone =
+		status === "running"
+			? "running"
+			: status === "failed"
+				? "error"
+				: "neutral";
+	const statusColor =
+		status === "running"
+			? "var(--color-green-500)"
+			: status === "failed"
+				? "var(--color-red-500)"
+				: "var(--color-gray-500)";
 	const threadTitle = useMemo(
 		() => normalizeTitle(title?.trim()) || "New Session",
 		[title],
@@ -86,16 +99,16 @@ export function AgentHeader({
 		<header className="flex h-12 items-center justify-between gap-2 px-4 max-md:pl-12">
 			{/* Left: thread title */}
 			<div className="flex min-w-0 flex-1 items-center gap-2">
-				<output
-					aria-label={`Session status: ${status}`}
-					className={cn(
-						"size-2 shrink-0 rounded font-mono",
-						status === "running"
-							? "bg-green-500"
-							: status === "failed"
-								? "bg-red-500"
-								: "bg-gray-500",
-					)}
+				<SessionStatus
+					className="shrink-0 font-mono"
+					label={`Session status: ${status}`}
+					showLabel={false}
+					style={
+						{
+							"--cline-ui-session-status-color": statusColor,
+						} as CSSProperties
+					}
+					tone={statusTone}
 				/>
 				{isEditingTitle ? (
 					<form

--- a/sdk/packages/ui/ADOPTION.md
+++ b/sdk/packages/ui/ADOPTION.md
@@ -63,6 +63,7 @@ pass once their runtime and Markdown adapters are mapped explicitly.
 | Goal | Import | Tailwind required | React required |
 | --- | --- | --- | --- |
 | Use only light/dark CSS variables | `@cline/ui/theme/tokens.css` | No | No |
+| Render shared session status | `@cline/ui/theme/tokens.css`, `@cline/ui/components.css`, and `@cline/ui` | No | React 18.3 or 19 |
 | Use tokens through Tailwind utilities | `tokens.css` then `theme.css` | Tailwind v4 | No |
 | Use the complete theme and shared base behavior | `@cline/ui/theme/index.css` | Tailwind v4 | No |
 | Compose shared agent-chat presentation | `@cline/ui/components/agent-chat` plus its CSS | No, if tokens are mapped in plain CSS | React 18.3 or 19 |
@@ -70,8 +71,8 @@ pass once their runtime and Markdown adapters are mapped explicitly.
 The package exports `base.css` separately for consumers that want its global,
 Markdown, scrollbar, selection, cursor, and native `color-scheme` behavior.
 
-There is no root JavaScript export and no `@cline/ui/theme` shorthand. Use the
-explicit paths documented here so dependencies remain visible.
+There is no `@cline/ui/theme` shorthand. Use the explicit paths documented here
+so dependencies remain visible.
 
 ## Install inside the Cline monorepo
 
@@ -101,7 +102,7 @@ The package is ESM. Its React entry point targets browser applications. Install
 only the prerequisites for the layer being adopted:
 
 ```bash
-# Required only for agent-chat components
+# Required for React components
 bun add react@^19 react-dom@^19
 
 # Required for the documented Tailwind-backed theme and Cline fonts

--- a/sdk/packages/ui/README.md
+++ b/sdk/packages/ui/README.md
@@ -27,6 +27,8 @@ Use `@cline/ui@next` only for deliberate previews. Monorepo consumers use
 
 | Import | Contents | Runtime requirement |
 | --- | --- | --- |
+| `@cline/ui` | Session-status React primitive | React 18.3 or 19 |
+| `@cline/ui/components.css` | Styles for the root React primitives | Theme tokens |
 | `@cline/ui/theme/tokens.css` | Light/dark custom properties only | CSS |
 | `@cline/ui/theme/scoped-tokens.css` | Light/dark custom properties scoped to `.cline-ui-theme` | CSS |
 | `@cline/ui/theme/theme.css` | Tailwind v4 semantic mapping and dark variant | Tailwind v4 |
@@ -35,6 +37,10 @@ Use `@cline/ui@next` only for deliberate previews. Monorepo consumers use
 | `@cline/ui/theme/index.css` | Complete theme: tokens, Tailwind mapping, and base styles | Tailwind v4 |
 | `@cline/ui/components/agent-chat` | Conversation, message, reasoning, action, and tool-activity React primitives | React 18.3 or 19 |
 | `@cline/ui/components/agent-chat.css` | Framework-neutral styles for the agent-chat primitives | Theme tokens |
+
+`SessionStatus` uses semantic tone colors by default. Set
+`--cline-ui-session-status-color` on the component to override its dot color
+for a host-specific status palette.
 
 The token entry point has no React, Tailwind, font-package, or desktop runtime
 dependency. Apps provide Schibsted Grotesk and Azeret Mono themselves, which

--- a/sdk/packages/ui/components.css
+++ b/sdk/packages/ui/components.css
@@ -1,0 +1,1 @@
+@import "./components/session-status.css";

--- a/sdk/packages/ui/components/index.ts
+++ b/sdk/packages/ui/components/index.ts
@@ -1,0 +1,7 @@
+"use client";
+
+export {
+	SessionStatus,
+	type SessionStatusProps,
+	type SessionStatusTone,
+} from "./session-status.js";

--- a/sdk/packages/ui/components/session-status.css
+++ b/sdk/packages/ui/components/session-status.css
@@ -1,0 +1,38 @@
+.cline-ui-sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+}
+
+.cline-ui-session-status {
+	--cline-ui-session-status-color: var(--muted-foreground);
+
+	display: inline-flex;
+	align-items: center;
+	gap: 0.375rem;
+	color: var(--muted-foreground);
+	font-size: var(--text-xs);
+	line-height: 1;
+}
+
+.cline-ui-session-status__dot {
+	width: 0.5rem;
+	height: 0.5rem;
+	flex: none;
+	border-radius: 999px;
+	background: var(--cline-ui-session-status-color);
+}
+
+.cline-ui-session-status--running {
+	--cline-ui-session-status-color: var(--primary);
+}
+
+.cline-ui-session-status--error {
+	--cline-ui-session-status-color: var(--destructive);
+}

--- a/sdk/packages/ui/components/session-status.tsx
+++ b/sdk/packages/ui/components/session-status.tsx
@@ -1,0 +1,36 @@
+import type { OutputHTMLAttributes } from "react";
+
+export type SessionStatusTone = "neutral" | "running" | "error";
+
+export interface SessionStatusProps
+	extends OutputHTMLAttributes<HTMLOutputElement> {
+	label: string;
+	showLabel?: boolean;
+	tone?: SessionStatusTone;
+}
+
+export function SessionStatus({
+	className,
+	label,
+	showLabel = true,
+	tone = "neutral",
+	...props
+}: SessionStatusProps) {
+	return (
+		<output
+			className={[
+				"cline-ui-session-status",
+				`cline-ui-session-status--${tone}`,
+				className,
+			]
+				.filter(Boolean)
+				.join(" ")}
+			{...props}
+		>
+			<span aria-hidden="true" className="cline-ui-session-status__dot" />
+			<span className={showLabel ? undefined : "cline-ui-sr-only"}>
+				{label}
+			</span>
+		</output>
+	);
+}

--- a/sdk/packages/ui/package.json
+++ b/sdk/packages/ui/package.json
@@ -14,6 +14,11 @@
 	},
 	"type": "module",
 	"exports": {
+		".": {
+			"types": "./dist/components/index.d.ts",
+			"import": "./dist/components/index.js"
+		},
+		"./components.css": "./components.css",
 		"./components/agent-chat": {
 			"types": "./dist/components/agent-chat/index.d.ts",
 			"import": "./dist/components/agent-chat/index.js"
@@ -28,15 +33,20 @@
 		"./package.json": "./package.json"
 	},
 	"files": [
+		"components.css",
 		"components/agent-chat/agent-chat.css",
 		"components/agent-chat/index.tsx",
 		"components/markdown.css",
+		"components/index.ts",
+		"components/session-status.css",
+		"components/session-status.tsx",
 		"dist",
 		"theme",
 		"ADOPTION.md",
 		"README.md"
 	],
 	"sideEffects": [
+		"./components.css",
 		"./components/**/*.css",
 		"./theme/*.css"
 	],

--- a/sdk/packages/ui/scripts/smoke-package.ts
+++ b/sdk/packages/ui/scripts/smoke-package.ts
@@ -12,9 +12,11 @@ const packageRoot = join(import.meta.dir, "..");
 const importCheck = `
 import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import { SessionStatus } from "@cline/ui";
 import { Conversation, Message } from "@cline/ui/components/agent-chat";
 
 for (const specifier of [
+	"@cline/ui/components.css",
 	"@cline/ui/components/markdown.css",
 	"@cline/ui/theme/scoped-tokens.css",
 ]) {
@@ -25,7 +27,9 @@ for (const specifier of [
 
 const css = import.meta.resolve("@cline/ui/components/agent-chat.css");
 const tokens = import.meta.resolve("@cline/ui/theme/tokens.css");
-if (!Conversation || !Message || !css || !tokens) process.exit(1);
+if (!SessionStatus || !Conversation || !Message || !css || !tokens) {
+	process.exit(1);
+}
 `;
 
 async function run(command: string[], cwd: string): Promise<void> {

--- a/sdk/packages/ui/scripts/validate-theme.ts
+++ b/sdk/packages/ui/scripts/validate-theme.ts
@@ -59,6 +59,7 @@ if (
 	throw new Error("theme entry point must compose tokens, theme, and base CSS");
 }
 for (const subpath of [
+	"./components.css",
 	"./components/markdown.css",
 	"./theme/index.css",
 	"./theme/scoped-tokens.css",

--- a/sdk/packages/ui/tests/session-status.test.tsx
+++ b/sdk/packages/ui/tests/session-status.test.tsx
@@ -1,0 +1,26 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { SessionStatus } from "../components/index.js";
+
+describe("SessionStatus", () => {
+	it("uses hidden content as dot-only status text without duplicating it", () => {
+		const markup = renderToStaticMarkup(
+			<SessionStatus label="Running" showLabel={false} tone="running" />,
+		);
+
+		expect(markup).toContain("<output");
+		expect(markup).not.toContain("aria-label");
+		expect(markup).toContain("cline-ui-session-status--running");
+		expect(markup).toContain("cline-ui-sr-only");
+		expect(markup).toContain(">Running</span>");
+	});
+
+	it("shows the label by default", () => {
+		const markup = renderToStaticMarkup(
+			<SessionStatus label="Ready" tone="neutral" />,
+		);
+
+		expect(markup).not.toContain("cline-ui-sr-only");
+		expect(markup).toContain(">Ready</span>");
+	});
+});


### PR DESCRIPTION
## Summary

- extract the desktop session-status indicator into `@cline/ui`
- migrate desktop `AgentHeader` to the shared component without changing its 8px green/red/gray presentation
- export its CSS and verify the packed React entry point in React 18.3 and 19 consumers

## Scope

This PR contains `SessionStatus` only. The status dot is deliberately static to preserve existing desktop behavior; the earlier pulse/ring treatment is not part of this extraction.

The broad Tailwind Button remains app-local. A future dedicated parity refactor can move it once the complete desktop variant surface can be preserved; core-platform should keep its existing button system until then. No loading behavior, dialogs, comboboxes, composer controls, publishing policy, or runtime behavior is included.

This clean one-commit draft replaces #12592 after #12439 merged.

## Coordination

- based on current `main`, including Saoud’s merged #12568 animation changes; this PR only adds a top-level `globals.css` import
- no source-file overlap with Bee’s work
- does not touch `components/agent-chat/**`

## Validation

- `bun -F @cline/ui test` — 14 passing
- `bun -F @cline/ui typecheck`
- `bun -F @cline/ui test:package` — packed consumers verified with React 18.3 and 19
- desktop `bun run typecheck`
- focused desktop `AgentHeader` integration test — 1 passing
- desktop production Next.js build
- `bun biome check` on changed UI and desktop files
- `git diff --check`