### PR TITLE
docs: fix double space in headless CLI example

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Run Cline with zero interaction for scripting and automation. Pipe input, get JS
 
 ```bash
 cline "Run tests and fix any failures"
-git diff origin/main | cline  "Review these changes for issues"
+git diff origin/main | cline "Review these changes for issues"
 cline --json "List all TODO comments" | jq -r 'select(.type == "agent_event" and .event.text) | .event.text'
 ```
 


### PR DESCRIPTION
### Description

Small README fix: the "Headless CLI for CI/CD" example had a stray double space between `cline` and the prompt string, which is visible in the rendered code block on GitHub.

```diff
-git diff origin/main | cline  "Review these changes for issues"
+git diff origin/main | cline "Review these changes for issues"
```

### Verification

Rendered `README.md` with the VS Code Markdown preview in the cloud VM.

![README rendered in VS Code markdown preview](https://cursor.com/artifacts/c/art-19e3506c-6c36-438c-bbee-aaf1b7269168)

![Headless CLI section with the corrected single space](https://cursor.com/artifacts/c/art-bb1aeb33-3ffa-4cff-8ca9-8ad28444dcec)