### PR TITLE
Clarify desktop app auto-update setting: it governs the CLI, not the app

### DIFF
--- a/apps/examples/desktop-app/webview/components/views/settings/settings-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/settings-view.tsx
@@ -715,19 +715,21 @@ function GeneralSettingsContent() {
 				<div className="flex min-h-20 items-center justify-between gap-5 border-b max-[720px]:flex-col max-[720px]:items-stretch max-[720px]:py-4">
 					<div>
 						<p className="text-[17px] font-semibold text-foreground">
-							Auto update
+							Keep CLI up to date
 						</p>
 						<p className="mt-1 text-[15px] text-muted-foreground">
-							Automatically install Cline updates on startup.
+							Automatically update the cline terminal command, which shares
+							your sessions and settings with this app. The app itself updates
+							separately.
 						</p>
 						{autoUpdateError ? (
 							<p className="mt-2 text-xs text-destructive" role="alert">
-								Failed to update auto update setting: {autoUpdateError}
+								Failed to update CLI auto-update setting: {autoUpdateError}
 							</p>
 						) : null}
 					</div>
 					<Switch
-						aria-label="Auto update"
+						aria-label="Keep CLI up to date"
 						checked={autoUpdateEnabled}
 						disabled={autoUpdateLoading || autoUpdateSaving}
 						onCheckedChange={(checked) => void updateAutoUpdateEnabled(checked)}

--- a/apps/examples/desktop-app/webview/components/views/settings/settings-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/settings-view.tsx
@@ -718,7 +718,7 @@ function GeneralSettingsContent() {
 							Auto update
 						</p>
 						<p className="mt-1 text-[15px] text-muted-foreground">
-							Automatically install Cline CLI updates on startup.
+							Automatically install Cline updates on startup.
 						</p>
 						{autoUpdateError ? (
 							<p className="mt-2 text-xs text-destructive" role="alert">


### PR DESCRIPTION
### Related Issue

N/A — minor wording improvement.

### Description

The Auto update setting in the desktop app's Settings view described itself as "Automatically install Cline CLI updates on startup.", which read oddly in a desktop app. On investigation, the toggle writes the global `autoUpdateEnabled` setting in `~/.cline`, whose only consumer is the CLI's startup self-update (`autoUpdateOnStartup` in `apps/cli/src/commands/update.ts`). The desktop app's own Tauri updater runs unconditionally and is not affected by this toggle.

The row is now titled "Keep CLI up to date" with the description: "Automatically update the cline terminal command, which shares your sessions and settings with this app. The app itself updates separately." This makes the actual scope of the setting explicit and explains why the CLI is relevant to desktop users (shared Hub, sessions, and `~/.cline` settings).

### Test Procedure

Ran the desktop app headless (`bun run dev:sidecar` + `bun run dev:web`), opened the Settings view in a browser, and verified the row renders with the new title and description and the toggle works as before.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

![Settings view showing the clarified Keep CLI up to date setting](https://cursor.com/artifacts/c/art-9e52ba54-f56a-4c43-a9fb-a79ac215c27f)

### Additional Notes

Behavior is unchanged — only the copy. The underlying setting remains the global `autoUpdateEnabled` shared with the CLI.