### PR TITLE
docs: fix double space in README CLI example

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Run Cline with zero interaction for scripting and automation. Pipe input, get JS
 
 ```bash
 cline "Run tests and fix any failures"
-git diff origin/main | cline  "Review these changes for issues"
+git diff origin/main | cline "Review these changes for issues"
 cline --json "List all TODO comments" | jq -r 'select(.type == "agent_event" and .event.text) | .event.text'
 ```
 


### PR DESCRIPTION
Removes a stray double space in the headless CLI example in `README.md` so the piped `git diff` command reads `git diff origin/main | cline "Review these changes for issues"`.

Docs-only change; no code paths affected.