### PR TITLE
ci: delete coding-agent promo comments on PRs

### DIFF
--- a/.github/workflows/repo-delete-agent-promo-comments.yml
+++ b/.github/workflows/repo-delete-agent-promo-comments.yml
@@ -1,0 +1,54 @@
+# Some coding-agent GitHub Apps advertise themselves by auto-commenting on every
+# new PR ("<Tool> Agent can help with this pull request. Just @<tool> ..."). The
+# app needs pull_requests:write for its real job (pushing branches, opening PRs),
+# and GitHub offers no per-behavior control over an installed App, so the ad
+# cannot be disabled at the source. This deletes those promo comments as they
+# appear. Genuine agent output comments (work results, reviews) don't match the
+# promo pattern and are left alone.
+#
+# No checkout, API-calls-only — comment text is only ever handled as data inside
+# the script, never interpolated into the workflow definition.
+name: repo-delete-agent-promo-comments
+on:
+    issue_comment:
+        types: [created]
+
+jobs:
+    delete:
+        runs-on: ubuntu-latest
+        timeout-minutes: 2
+        # Prefilter so a runner only spins up for bot comments that look like the
+        # ad; the script re-verifies before deleting.
+        if: >-
+            github.event.issue.pull_request &&
+            endsWith(github.event.comment.user.login, '[bot]') &&
+            contains(github.event.comment.body, 'can help with this pull request')
+        permissions:
+            issues: write
+        steps:
+            # Pinned to a commit SHA (not the mutable v7 tag) because this job holds
+            # write permissions and fires on attacker-postable events.
+            - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+              with:
+                  script: |
+                      const comment = context.payload.comment
+
+                      // Belt and suspenders on top of the job-level prefilter: only
+                      // delete when the author is a real GitHub App bot AND the body
+                      // matches the self-promotion shape ("... can help with this
+                      // pull request. Just @<handle> ..."). A human quoting the ad
+                      // text is not a Bot; a bot posting real work output doesn't
+                      // match the promo shape.
+                      const isBot = comment.user.type === "Bot"
+                      const isPromo = /\bcan help with this pull request\b[\s\S]*@\w/i.test(comment.body || "")
+
+                      if (!isBot || !isPromo) {
+                          core.info("not an agent promo comment, leaving it alone")
+                          return
+                      }
+
+                      await github.rest.issues.deleteComment({
+                          ...context.repo,
+                          comment_id: comment.id,
+                      })
+                      core.info(`deleted promo comment ${comment.id} by ${comment.user.login} on #${context.payload.issue.number}`)


### PR DESCRIPTION
### Related Issue

None — CI/workflow-only, companion to #12588.

### Description

Coding-agent GitHub Apps advertise themselves by auto-commenting on every new PR ("<Tool> Agent can help with this pull request. Just `@<tool>` in comments…"). This can't be turned off at the source: the App legitimately needs `pull_requests: write` for its actual job (pushing branches, opening PRs), GitHub offers no per-behavior control over an installed App, and the vendor dashboard exposes no toggle for it (checked). Uninstalling the App would kill the agent integration entirely.

### Test Procedure

Matcher tested offline against the **real** `cursor[bot]` comment body from #12603 (fetched via `gh api`) plus synthetics:

- real ad → matched
- hypothetical other-vendor ad with the same shape → matched
- review-bot summary comment → not matched
- genuine agent work-output comment → not matched
- human quoting the ad → regex matches, but fails both bot checks → left alone
- empty body → not matched

YAML validated (parses; `if`/permissions/timeout verified).

**Caveat:** `issue_comment` workflows only run from the default branch, so this can't fire until merged — first live validation is the first bot promo comment after merge. Worst-case failure mode is the job doing nothing and the ad staying visible, i.e. the status quo.

### Type of Change

-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)