### PR TITLE
docs: fix double space in README headless CLI example

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Run Cline with zero interaction for scripting and automation. Pipe input, get JS
 
 ```bash
 cline "Run tests and fix any failures"
-git diff origin/main | cline  "Review these changes for issues"
+git diff origin/main | cline "Review these changes for issues"
 cline --json "List all TODO comments" | jq -r 'select(.type == "agent_event" and .event.text) | .event.text'
 ```
 


### PR DESCRIPTION
### Related Issue

N/A — small typo correction (allowed without prior discussion per the template's limited exceptions).

### Description

The "Headless CLI for CI/CD" snippet in `README.md` had a stray double space between `cline` and its prompt argument:

```bash
git diff origin/main | cline  "Review these changes for issues"
```

Collapsed it to a single space so the example matches the two surrounding `cline` invocations in the same block.

### Test Procedure

Docs-only whitespace change inside a fenced code block; no code, build, or runtime behavior is touched. Verified the rendered snippet is otherwise unchanged via `git diff` (one line, one character removed).

### Type of Change

-   [x] 📚 Documentation update

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`) — N/A, Markdown prose only
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable — no UI changes.