### PR TITLE
ci: grant pull-requests write so promo-comment deletion works on PRs

### DIFF
--- a/.github/workflows/repo-delete-agent-promo-comments.yml
+++ b/.github/workflows/repo-delete-agent-promo-comments.yml
@@ -23,8 +23,14 @@ jobs:
             github.event.issue.pull_request &&
             endsWith(github.event.comment.user.login, '[bot]') &&
             contains(github.event.comment.body, 'can help with this pull request')
+        # Comment deletion goes through the issues API, but GitHub gates the
+        # endpoint by where the comment lives: issue comments need `issues`,
+        # PR-conversation comments need `pull-requests`. The prefilter restricts
+        # this job to PR comments, so pull-requests is the one that matters;
+        # issues is kept in case the prefilter is ever widened.
         permissions:
             issues: write
+            pull-requests: write
         steps:
             # Pinned to a commit SHA (not the mutable v7 tag) because this job holds
             # write permissions and fires on attacker-postable events.


### PR DESCRIPTION
### Related Issue

Follow-up to #12604, which shipped broken. First live firing on #12605: the workflow triggered 3s after the promo comment, matched it correctly, and then the delete call failed with `403 Resource not accessible by integration` (run 30315225404).

### Description

The job's token was scoped to `issues: write` on the reasoning that comment deletion goes through the issues REST API. That reasoning missed how GitHub actually gates the endpoint: it's keyed to where the comment lives, not which API surface serves it — comments on issues are governed by the `issues` permission, comments on **pull requests** by `pull-requests`. Since the job's own prefilter restricts it to PR comments (`github.event.issue.pull_request`), every comment it will ever touch needed the permission it didn't have.

One-line fix: add `pull-requests: write`. `issues: write` is kept in case the prefilter is ever widened to plain issues, with a comment in the file explaining the split so the next person doesn't repeat the mistake.

### Test Procedure

The failed run is itself the test of everything else: trigger, prefilter, and matcher all behaved exactly as designed on a real `cursor[bot]` comment — only the final API call was denied. The other run in the log (a non-promo bot comment, skipped in 2s by the prefilter) confirms the negative path too. With the permission added, the same call is the documented happy path for `GITHUB_TOKEN` with `pull-requests: write`.

Validation, as before, only completes live: `issue_comment` workflows run from the default branch, so the first promo comment after merge is the real test.

### Type of Change

-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable — workflow-only.

### Additional Notes

The promo comment currently sitting on #12605 predates this fix, so nothing will retro-delete it (the workflow only fires on `created`). It either gets deleted manually or stays as a monument.
