### PR TITLE
docs: fix double space in README headless CLI example

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Run Cline with zero interaction for scripting and automation. Pipe input, get JS
 
 ```bash
 cline "Run tests and fix any failures"
-git diff origin/main | cline  "Review these changes for issues"
+git diff origin/main | cline "Review these changes for issues"
 cline --json "List all TODO comments" | jq -r 'select(.type == "agent_event" and .event.text) | .event.text'
 ```
 


### PR DESCRIPTION
### Related Issue

N/A — typo correction, which the PR template lists as an exception that can be submitted directly.

### Description

The "Headless CLI for CI/CD" section of the root `README.md` had a stray double space between `cline` and its prompt argument in one of the three example commands:

```bash
git diff origin/main | cline  "Review these changes for issues"
```

The two neighboring examples on the lines above and below use single spacing, so this was inconsistent formatting inside a copy-pasteable code block. Changed it to a single space.

### Test Procedure

Documentation-only change to a fenced code block, so there is nothing to execute. Verified that:

- The diff touches exactly one line of `README.md` and no code.
- `bun run lint` exits 0 (only pre-existing warnings in `apps/cli` and elsewhere, none from this change).

Nothing can break here: the string is inside a fenced `bash` block and the extra space was purely cosmetic. Shells treat consecutive spaces as one delimiter, so even a reader who copied the old line got identical behavior.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable — no UI changes.

### Additional Notes

The task was an open-ended request for a small README fix, so this was chosen as a real inconsistency rather than an arbitrary edit.