### PR TITLE
fix(vscode): suppress Claude Code max-turns exit code when response already yielded (legacy)

### DIFF
--- a/apps/vscode/src/integrations/claude-code/run.test.ts
+++ b/apps/vscode/src/integrations/claude-code/run.test.ts
@@ -3,7 +3,15 @@ import path from "path"
 import proxyquire from "proxyquire"
 import sinon from "sinon"
 
+const DEFAULT_OUTPUT_LINES = ['{"type":"text","text":"Hello"}', '{"type":"text","text":" world"}']
+
+// Mutable state the mock factories read, so individual tests can simulate
+// different CLI output streams and exit results.
+let mockOutputLines = DEFAULT_OUTPUT_LINES
+let mockProcessError: Error | null = null
+
 const createMockProcess = () => {
+	const exitCode = mockProcessError ? ((mockProcessError as any).exitCode ?? 1) : 0
 	const mockProcess = {
 		stdin: {
 			write: sinon.fake(),
@@ -18,15 +26,20 @@ const createMockProcess = () => {
 		},
 		on: sinon.fake((event, callback) => {
 			if (event === "close") {
-				setImmediate(() => callback(0))
+				setImmediate(() => callback(exitCode))
 			}
 			if (event === "error") {
 			}
 		}),
 		killed: false,
 		kill: sinon.fake(),
-		exitCode: 0,
-		then: (onResolve: (value: any) => void) => {
+		exitCode,
+		then: (onResolve: (value: any) => void, onReject?: (reason: any) => void) => {
+			// execa's process promise rejects on nonzero exit (default `reject: true`)
+			if (mockProcessError && onReject) {
+				setImmediate(() => onReject(mockProcessError))
+				return Promise.resolve()
+			}
 			setImmediate(() => onResolve({ exitCode: 0 }))
 			return Promise.resolve({ exitCode: 0 })
 		},
@@ -42,9 +55,8 @@ const createMockProcess = () => {
 const createMockReadlineInterface = () => {
 	const mockInterface = {
 		async *[Symbol.asyncIterator]() {
-			// Simulate Claude CLI JSON output - yield a few chunks then end
-			yield '{"type":"text","text":"Hello"}'
-			yield '{"type":"text","text":" world"}'
+			// Simulate Claude CLI JSON output - yield the configured chunks then end
+			yield* mockOutputLines
 			// Iterator ends naturally when function returns
 			return
 		},
@@ -79,6 +91,8 @@ describe("Claude Code Integration", () => {
 
 	afterEach(() => {
 		sinon.restore()
+		mockOutputLines = DEFAULT_OUTPUT_LINES
+		mockProcessError = null
 	})
 
 	const itCallsTheScriptWithAFile = (systemPrompt: string) => {
@@ -157,6 +171,62 @@ describe("Claude Code Integration", () => {
 				expect(params).to.not.be.null
 				expect(params.includes("--system-prompt-file")).to.be.false
 				expect(params.includes("--system-prompt")).to.be.true
+			})
+		})
+	})
+
+	describe("when the process exits with code 1", () => {
+		// Mimics execa's rejection: an Error carrying exitCode, whose message
+		// includes the full command after ": "
+		const createExitCodeOneError = () => {
+			const error = new Error("Command failed with exit code 1: claude --system-prompt aaa --verbose")
+			;(error as any).exitCode = 1
+			return error
+		}
+
+		const collectChunks = async () => {
+			const chunks: unknown[] = []
+			for await (const chunk of runClaudeCode({
+				systemPrompt: "test",
+				messages: [],
+				modelId: "test",
+				path: scriptPath,
+			})) {
+				chunks.push(chunk)
+			}
+			return chunks
+		}
+
+		describe("after a result chunk was streamed (max-turns exit)", () => {
+			beforeEach(() => {
+				mockOutputLines = [
+					'{"type":"assistant","message":{"content":[{"type":"text","text":"Hello"}]}}',
+					'{"type":"result","subtype":"success","is_error":false,"num_turns":1}',
+				]
+				mockProcessError = createExitCodeOneError()
+			})
+
+			it("suppresses the error and yields the full response", async () => {
+				const chunks = await collectChunks()
+
+				expect(chunks).to.have.length(2)
+				expect((chunks[1] as { type: string }).type).to.equal("result")
+			})
+		})
+
+		describe("without a result chunk", () => {
+			beforeEach(() => {
+				mockOutputLines = ['{"type":"assistant","message":{"content":[{"type":"text","text":"Hello"}]}}']
+				mockProcessError = createExitCodeOneError()
+			})
+
+			it("throws", async () => {
+				try {
+					await collectChunks()
+					expect.fail("expected runClaudeCode to throw")
+				} catch (error) {
+					expect((error as Error).message).to.include("Command failed with exit code 1")
+				}
 			})
 		})
 	})

--- a/apps/vscode/src/integrations/claude-code/run.ts
+++ b/apps/vscode/src/integrations/claude-code/run.ts
@@ -55,6 +55,13 @@ export async function* runClaudeCode(options: ClaudeCodeOptions): AsyncGenerator
 		partialData: null,
 	}
 
+	// Track whether we've received a result chunk from Claude Code.
+	// When --max-turns 1 is set and the model produces a tool_use response (native tool calling),
+	// Claude Code exits with code 1 ("Reached maximum number of turns"). But by that point,
+	// the assistant message and result have already been streamed and yielded. In that case,
+	// the exit code 1 is expected and we should not throw.
+	let hasReceivedResult = false
+
 	try {
 		cProcess.stderr.on("data", (data) => {
 			processState.stderrLogs += data.toString()
@@ -80,6 +87,11 @@ export async function* runClaudeCode(options: ClaudeCodeOptions): AsyncGenerator
 					continue
 				}
 
+				// Track result chunks so we know the response is complete
+				if (typeof chunk !== "string" && chunk.type === "result") {
+					hasReceivedResult = true
+				}
+
 				yield chunk
 			}
 		}
@@ -98,9 +110,30 @@ export async function* runClaudeCode(options: ClaudeCodeOptions): AsyncGenerator
 			)
 		}
 	} catch (err) {
+		// When --max-turns 1 is set and the model uses native tool calling instead of
+		// XML-formatted text tool calls, Claude Code exits with code 1 ("Reached maximum
+		// number of turns"). If we already received and yielded the result chunk, the
+		// response is complete — suppress the error and let the generator end normally.
+		if (hasReceivedResult && (err as any)?.exitCode === 1) {
+			Logger.log("Claude Code exited with max_turns limit — response already yielded, suppressing error.")
+			return
+		}
+
 		Logger.error(`Error during Claude Code execution:`, err)
 
-		if (processState.stderrLogs.includes("unknown option '--system-prompt-file'")) {
+		// Collect all available error details from multiple sources.
+		// execa attaches stderr/stdout to the error object, and we also capture stderr via our stream listener.
+		const execaStderr = (err as any)?.stderr?.trim?.() || ""
+		const execaStdout = (err as any)?.stdout?.trim?.() || ""
+		const collectedStderr = processState.stderrLogs?.trim() || ""
+		// Use the most informative stderr source available
+		const stderrContent = collectedStderr || execaStderr
+
+		Logger.error(
+			`Claude Code error details — stderr: ${stderrContent || "(empty)"}, stdout tail: ${execaStdout?.slice?.(-500) || "(empty)"}`,
+		)
+
+		if (stderrContent.includes("unknown option '--system-prompt-file'")) {
 			throw new Error(`The Claude Code executable is outdated. Please update it to the latest version.`, {
 				cause: err,
 			})
@@ -141,7 +174,13 @@ Anthropic is aware of this issue and is considering a fix: https://github.com/an
 			if (startOfCommand !== -1) {
 				const messageWithoutCommand = err.message.slice(0, startOfCommand).trim()
 
-				throw new Error(`${messageWithoutCommand}\n${processState.stderrLogs?.trim()}`, { cause: err })
+				// Build a descriptive error message using all available error sources
+				const errorDetails = stderrContent || execaStdout?.slice?.(-500) || ""
+				const errorSuffix = errorDetails
+					? `\n${errorDetails}`
+					: "\nNo error details available. Check the Output panel (Cline) for more information."
+
+				throw new Error(`${messageWithoutCommand}${errorSuffix}`, { cause: err })
 			}
 		}
 
@@ -164,7 +203,9 @@ Anthropic is aware of this issue and is considering a fix: https://github.com/an
 const claudeCodeTools = [
 	"Task",
 	"TaskOutput",
+	"TaskStop",
 	"Bash",
+	"PowerShell",
 	"Glob",
 	"Grep",
 	"Read",
@@ -174,9 +215,10 @@ const claudeCodeTools = [
 	"WebFetch",
 	"TodoWrite",
 	"WebSearch",
-	"TaskStop",
 	"AskUserQuestion",
 	"Skill",
+	"Monitor",
+	"ToolSearch",
 	"EnterPlanMode",
 	"ExitPlanMode",
 	"EnterWorktree",
@@ -184,7 +226,9 @@ const claudeCodeTools = [
 	"CronCreate",
 	"CronDelete",
 	"CronList",
-	"ToolSearch",
+	"PushNotification",
+	"RemoteTrigger",
+	"ScheduleWakeup",
 ].join(",")
 
 const CLAUDE_CODE_TIMEOUT = 600000 // 10 minutes


### PR DESCRIPTION
### Related Issue

**Issue:** #10135 (also reported in #10929)

This is a port of #11169 by @mathis1337 to `legacy-extension` (as suggested in https://github.com/cline/cline/pull/11169#issuecomment-5036067651 — the original PR targets `main`, where the CLI runner it patches no longer exists after the SDK rewrite). The same problem was also independently diagnosed and fixed in #10385 by @DanMarshall909, likewise stranded on a `main` that has since moved away from this code path. Thank you both for the investigation and the fixes — the commit here is cherry-picked from #11169 with original authorship preserved.

### Description

With Claude Code CLI 2.1.92+, models frequently answer with native tool calls. Cline invokes the CLI with `--max-turns 1`, so when that happens the CLI exits with code 1 ("Reached maximum number of turns") — *after* the complete assistant message and `result` chunk have already been streamed. `runClaudeCode` treats any nonzero exit as fatal, discarding a valid response and showing `{"message":"Command failed with exit code 1"}` on every request.

Changes (same as the original PR):
- Track whether a `result` chunk was received; when it was and the process exits with code 1, end the generator normally instead of throwing.
- Improve error diagnostics by also reading `stderr`/`stdout` off the execa error object, and log them.
- Add newer CLI built-in tools (`PowerShell`, `Monitor`, `PushNotification`, `RemoteTrigger`, `ScheduleWakeup`) to `--disallowedTools`, which reduces how often the model produces the native tool-use responses that trigger the max-turns exit in the first place.

The cherry-pick applied cleanly onto `legacy-extension` and is semantically sound there: the runner spawns via execa with default `reject: true`, so a nonzero exit surfaces in the `catch` block as an ExecaError carrying `exitCode` — exactly what the suppression condition reads.

**Note on the Greptile P2 from the original PR** (suppression condition broader than intended): the risk is narrower than it looks. Any exit-code-1 failure whose `result` chunk carries `is_error` and a `result` message is still surfaced to the user by the provider layer (`claude-code.ts` throws on `is_error` result chunks) — verified against a real CLI failure case (`Not logged in`, which exits 1 *and* emits an `is_error` result chunk). The suppression only silences exit-1 failures that first emit a well-formed non-error result, which is precisely the max-turns case. Kept faithful to the original PR; happy to tighten further (e.g. also match the max-turns reason) if preferred.

### Test Procedure

- `tsc --noEmit` clean, `biome lint --diagnostic-level=error` clean on the touched file.
- `vscode-test --grep "Claude Code Integration"`: 4/4 passing.
- Probed the real CLI (2.1.92) piping messages on stdin with `--output-format stream-json --max-turns 1`: confirmed it emits a `result` chunk and then exits with code 1 in failure scenarios, and that provider-level `is_error` handling still surfaces genuine errors when the new suppression is active.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing and code is formatted and linted
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
