### PR TITLE
Add persistent sidebar update indicator for staged desktop app updates

### DIFF
--- a/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
@@ -36,6 +36,7 @@ import {
 	useRef,
 	useState,
 } from "react";
+import { AppUpdateIndicator } from "@/components/app-update-indicator";
 import { ClineLogo } from "@/components/cline-logo";
 import {
 	AlertDialog,
@@ -586,54 +587,61 @@ export function AgentSidebar({
 						isCollapsed && "px-1.5",
 					)}
 				>
-					<HoverCard
-						closeDelay={100}
-						openDelay={0}
-						onOpenChange={(open) => {
-							if (open) {
-								void loadProcessContext();
-							}
-						}}
-					>
-						<HoverCardTrigger asChild>
-							<button
-								aria-label="Cline home"
-								className="flex size-8 shrink-0 items-center justify-center rounded-md text-sidebar-foreground transition-colors hover:bg-sidebar-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring"
-								onClick={openHome}
-								title="Home"
-								type="button"
+					<div className="flex min-w-0 items-center gap-0.5">
+						<HoverCard
+							closeDelay={100}
+							openDelay={0}
+							onOpenChange={(open) => {
+								if (open) {
+									void loadProcessContext();
+								}
+							}}
+						>
+							<HoverCardTrigger asChild>
+								<button
+									aria-label="Cline home"
+									className="flex size-8 shrink-0 items-center justify-center rounded-md text-sidebar-foreground transition-colors hover:bg-sidebar-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring"
+									onClick={openHome}
+									title="Home"
+									type="button"
+								>
+									<ClineLogo className="size-6" />
+								</button>
+							</HoverCardTrigger>
+							<HoverCardContent
+								align="start"
+								className="w-64 p-3"
+								side="bottom"
 							>
-								<ClineLogo className="size-6" />
-							</button>
-						</HoverCardTrigger>
-						<HoverCardContent align="start" className="w-64 p-3" side="bottom">
-							<p className="text-sm font-medium">Cline Code</p>
-							<p className="mt-0.5 text-xs text-muted-foreground">
-								{appVersion ? `Version ${appVersion}` : "Version unavailable"}
-							</p>
-							<div className="mt-3 border-border border-t pt-3">
-								<div className="flex items-center gap-2 text-xs">
-									<span
-										aria-hidden="true"
-										className={cn(
-											"h-2 w-2 shrink-0 rounded-full",
-											hubStatus?.connected
-												? "bg-emerald-500"
-												: "bg-muted-foreground",
-										)}
-									/>
-									<span className="font-medium">
-										Cline Hub @{hubPort(hubStatus?.url ?? null) ?? "unknown"}
-									</span>
+								<p className="text-sm font-medium">Cline Code</p>
+								<p className="mt-0.5 text-xs text-muted-foreground">
+									{appVersion ? `Version ${appVersion}` : "Version unavailable"}
+								</p>
+								<div className="mt-3 border-border border-t pt-3">
+									<div className="flex items-center gap-2 text-xs">
+										<span
+											aria-hidden="true"
+											className={cn(
+												"h-2 w-2 shrink-0 rounded-full",
+												hubStatus?.connected
+													? "bg-emerald-500"
+													: "bg-muted-foreground",
+											)}
+										/>
+										<span className="font-medium">
+											Cline Hub @{hubPort(hubStatus?.url ?? null) ?? "unknown"}
+										</span>
+									</div>
+									{hubStatus && !hubStatus.connected && (
+										<p className="mt-1 text-[11px] text-destructive">
+											{hubStatus.error ?? "Cline Hub is not connected."}
+										</p>
+									)}
 								</div>
-								{hubStatus && !hubStatus.connected && (
-									<p className="mt-1 text-[11px] text-destructive">
-										{hubStatus.error ?? "Cline Hub is not connected."}
-									</p>
-								)}
-							</div>
-						</HoverCardContent>
-					</HoverCard>
+							</HoverCardContent>
+						</HoverCard>
+						{!isCollapsed ? <AppUpdateIndicator /> : null}
+					</div>
 					{!isCollapsed ? (
 						<Button
 							aria-label="New Session"
@@ -650,6 +658,7 @@ export function AgentSidebar({
 
 				{isCollapsed ? (
 					<div className="mt-2 flex min-h-0 flex-1 flex-col items-center gap-1 px-1.5">
+						<AppUpdateIndicator className="mx-auto size-9" />
 						{view === "settings" ? (
 							<SettingsSectionNavigation
 								activeSection={settingsSection}

--- a/apps/examples/desktop-app/webview/components/app-update-indicator.tsx
+++ b/apps/examples/desktop-app/webview/components/app-update-indicator.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { CircleArrowUp, Loader2 } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+	restartToApplyUpdate,
+	useAppUpdateStatus,
+} from "@/hooks/use-app-update";
+import { cn } from "@/lib/utils";
+
+/**
+ * Persistent "update ready" indicator for the sidebar. Renders nothing until
+ * the auto-updater has staged an update, then shows an accented button that
+ * opens a popover with the new version and a restart action — so the update
+ * stays reachable after the one-time toast is dismissed.
+ */
+export function AppUpdateIndicator({ className }: { className?: string }) {
+	const status = useAppUpdateStatus();
+	const [restarting, setRestarting] = useState(false);
+
+	if (status.state !== "ready" || !status.version) {
+		return null;
+	}
+
+	return (
+		<Popover>
+			<PopoverTrigger asChild>
+				<Button
+					aria-label={`Update ready: v${status.version}`}
+					className={cn(
+						"relative size-8 shrink-0 justify-center px-0 text-blue-500 hover:text-blue-400",
+						className,
+					)}
+					title={`Update ready: v${status.version}`}
+					type="button"
+					variant="sidebarItem"
+				>
+					<CircleArrowUp className="size-4" />
+				</Button>
+			</PopoverTrigger>
+			<PopoverContent align="start" className="w-64 p-3" side="bottom">
+				<p className="text-sm font-medium">Update ready: v{status.version}</p>
+				<p className="mt-1 text-xs text-muted-foreground">
+					The new version has been downloaded and will be used the next time the
+					app starts. Restart now to switch to it right away.
+				</p>
+				<Button
+					className="mt-3 w-full"
+					disabled={restarting}
+					onClick={() => {
+						setRestarting(true);
+						restartToApplyUpdate();
+					}}
+					size="sm"
+					type="button"
+				>
+					{restarting ? (
+						<>
+							<Loader2 className="size-4 animate-spin" />
+							Restarting...
+						</>
+					) : (
+						"Restart now"
+					)}
+				</Button>
+			</PopoverContent>
+		</Popover>
+	);
+}

--- a/apps/examples/desktop-app/webview/components/app-update-indicator.tsx
+++ b/apps/examples/desktop-app/webview/components/app-update-indicator.tsx
@@ -55,7 +55,11 @@ export function AppUpdateIndicator({ className }: { className?: string }) {
 					disabled={restarting}
 					onClick={() => {
 						setRestarting(true);
-						restartToApplyUpdate();
+						void restartToApplyUpdate().then((ok) => {
+							if (!ok) {
+								setRestarting(false);
+							}
+						});
 					}}
 					size="sm"
 					type="button"

--- a/apps/examples/desktop-app/webview/hooks/use-app-update.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-app-update.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useSyncExternalStore } from "react";
 import { ToastAction } from "@/components/ui/toast";
 import { toast } from "@/hooks/use-toast";
 import { desktopClient, isTauriAvailable } from "@/lib/desktop-client";
@@ -13,6 +13,64 @@ export type AppUpdateStatus = {
 
 const POLL_INTERVAL_MS = 30_000;
 
+const IDLE_STATUS: AppUpdateStatus = { state: "idle" };
+
+// Module-scoped store so the toast (page shell) and the sidebar update
+// indicator observe the same polled status without extra polling loops.
+let currentStatus: AppUpdateStatus = IDLE_STATUS;
+const statusListeners = new Set<() => void>();
+
+function statusesEqual(a: AppUpdateStatus, b: AppUpdateStatus): boolean {
+	return (
+		a.state === b.state &&
+		(a.version ?? null) === (b.version ?? null) &&
+		(a.error ?? null) === (b.error ?? null)
+	);
+}
+
+function setUpdateStatus(status: AppUpdateStatus) {
+	if (statusesEqual(currentStatus, status)) {
+		return;
+	}
+	currentStatus = status;
+	for (const listener of statusListeners) {
+		listener();
+	}
+}
+
+function subscribeToUpdateStatus(listener: () => void): () => void {
+	statusListeners.add(listener);
+	return () => {
+		statusListeners.delete(listener);
+	};
+}
+
+function getUpdateStatusSnapshot(): AppUpdateStatus {
+	return currentStatus;
+}
+
+function getUpdateStatusServerSnapshot(): AppUpdateStatus {
+	return IDLE_STATUS;
+}
+
+/**
+ * Read the latest auto-updater status. Reflects the polling performed by
+ * `useAppUpdate()` (mounted once in the page shell); stays "idle" in
+ * web/sidecar mode where there is no app bundle to update.
+ */
+export function useAppUpdateStatus(): AppUpdateStatus {
+	return useSyncExternalStore(
+		subscribeToUpdateStatus,
+		getUpdateStatusSnapshot,
+		getUpdateStatusServerSnapshot,
+	);
+}
+
+/** Restart the app so the staged update takes effect. */
+export function restartToApplyUpdate() {
+	void desktopClient.invoke("restart_to_apply_update");
+}
+
 // Module-scoped so a page remount does not re-toast an update the user
 // already dismissed while the Rust side still reports it as "ready".
 let notifiedVersion: string | null = null;
@@ -21,9 +79,10 @@ let notifiedVersion: string | null = null;
  * Watches the Tauri shell's auto-updater. Updates are checked, downloaded, and
  * installed in the background by the Rust side; once one is staged this hook
  * surfaces a persistent toast offering a one-click restart into the new
- * version. Ignoring the toast is fine too — the staged update takes effect on
- * the next launch. No-op in web/sidecar mode where there is no app bundle to
- * update.
+ * version. Dismissing the toast is fine too — the staged update stays
+ * reachable from the sidebar update indicator and takes effect on the next
+ * launch regardless. No-op in web/sidecar mode where there is no app bundle
+ * to update.
  */
 export function useAppUpdate() {
 	useEffect(() => {
@@ -42,7 +101,11 @@ export function useAppUpdate() {
 				// Update status is best-effort; ignore transient bridge failures.
 				return;
 			}
-			if (cancelled || status.state !== "ready" || !status.version) {
+			if (cancelled) {
+				return;
+			}
+			setUpdateStatus(status);
+			if (status.state !== "ready" || !status.version) {
 				return;
 			}
 			if (notifiedVersion === status.version) {
@@ -52,13 +115,13 @@ export function useAppUpdate() {
 			toast({
 				title: `Update ready: v${status.version}`,
 				description:
-					"The new version has been downloaded and will be used the next time the app starts.",
+					"The new version has been downloaded. Restart now, or later from the update button next to the Cline logo.",
 				duration: Number.POSITIVE_INFINITY,
 				action: (
 					<ToastAction
 						altText="Restart now"
 						onClick={() => {
-							void desktopClient.invoke("restart_to_apply_update");
+							restartToApplyUpdate();
 						}}
 					>
 						Restart now

--- a/apps/examples/desktop-app/webview/hooks/use-app-update.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-app-update.tsx
@@ -66,9 +66,23 @@ export function useAppUpdateStatus(): AppUpdateStatus {
 	);
 }
 
-/** Restart the app so the staged update takes effect. */
-export function restartToApplyUpdate() {
-	void desktopClient.invoke("restart_to_apply_update");
+/**
+ * Restart the app so the staged update takes effect. Resolves false (after
+ * surfacing a toast) if the restart command fails, so callers can reset
+ * pending UI.
+ */
+export async function restartToApplyUpdate(): Promise<boolean> {
+	try {
+		await desktopClient.invoke("restart_to_apply_update");
+		return true;
+	} catch (error) {
+		toast({
+			variant: "destructive",
+			title: "Restart failed",
+			description: error instanceof Error ? error.message : String(error),
+		});
+		return false;
+	}
 }
 
 // Module-scoped so a page remount does not re-toast an update the user
@@ -121,7 +135,7 @@ export function useAppUpdate() {
 					<ToastAction
 						altText="Restart now"
 						onClick={() => {
-							restartToApplyUpdate();
+							void restartToApplyUpdate();
 						}}
 					>
 						Restart now


### PR DESCRIPTION
### Related Issue

N/A — follow-up to the desktop auto-update toast: once the user dismissed it, there was no way left in the UI to see that an update was staged or to restart into it.

### Description

The Tauri shell downloads and stages updates in the background and surfaces a one-time "Update ready" toast. Dismissing that toast left no indicator and no manual way to apply the update until the next app launch.

This PR adds a persistent update indicator to the left sidebar, right next to the Cline logo:

- `use-app-update.tsx` now keeps the polled updater status in a small module-level store (`useSyncExternalStore`), so the existing toast and the new indicator share one polling loop. `restartToApplyUpdate()` is exported for both call sites; it surfaces a destructive toast and resolves `false` if the restart command fails so callers can reset pending UI. The update toast copy now points at the sidebar button.
- New `AppUpdateIndicator` component (`app-update-indicator.tsx`): renders nothing until an update is staged (`state === "ready"`), then shows a blue `CircleArrowUp` icon button. Clicking it opens a popover with the new version number and a "Restart now" action (with a "Restarting..." spinner) that invokes the existing `restart_to_apply_update` Tauri command.
- `AgentSidebar` renders the indicator next to the Cline logo when expanded, and at the top of the icon column when collapsed. In web/sidecar mode the status stays `idle`, so nothing renders.

### Test Procedure

- `bun run typecheck` in `apps/examples/desktop-app` passes.
- Manual GUI testing in headless dev mode (`dev:sidecar` + `dev:web`) with a temporary local mock forcing the updater status to `ready` (the real updater only runs in release Tauri builds; the mock was not committed). Verified end-to-end: the toast appears on load; dismissing it via its X leaves the blue indicator next to the logo; hovering shows the "Update ready: v0.0.6" tooltip; collapsing the sidebar (Ctrl+B) moves the indicator into the icon column; clicking the indicator opens the popover with version + description; clicking "Restart now" shows the disabled "Restarting..." spinner. Also verified that with the mock removed, the app loads cleanly with no toast, no indicator, and no console errors in web mode.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Update toast plus the new persistent indicator next to the Cline logo (top-left):

![Update toast and sidebar indicator](https://cursor.com/artifacts/c/art-37f6a9d4-592d-4429-8b39-1db17cc695d9)

Indicator tooltip after the toast is dismissed:

![Sidebar indicator tooltip closeup](https://cursor.com/artifacts/c/art-e7c6d20b-4309-4532-bc24-05885754ac7c)

Popover with the restart action, and the pending state after clicking:

![Update popover with Restart now](https://cursor.com/artifacts/c/art-5c8ec29b-91c6-4291-83af-d66e57edb06c)
![Restarting state](https://cursor.com/artifacts/c/art-66318ded-00b8-48dc-b615-4d5a8a8f4e7e)

Collapsed sidebar keeps the indicator below the logo:

![Collapsed sidebar indicator closeup](https://cursor.com/artifacts/c/art-77bbfd18-1f62-4c59-9d22-0ff7bba94faf)

### Additional Notes

The indicator only appears once an update is fully downloaded and staged, matching when the toast fires; during `downloading` nothing is shown since there is no user action available yet.