### PR TITLE
fix(core): hub daemon fails to spawn when @cline/core is bundled

### DIFF
--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -161,7 +161,8 @@ function listStaleHubPids(currentHubPids: number[]): number[] {
 	const current = new Set(currentHubPids.filter((pid) => pid > 0));
 	const patterns = [
 		"/sdk/packages/core/src/hub/daemon/entry.ts",
-		"/sdk/packages/core/dist/hub/daemon/entry.js",
+		// Matches monorepo and installed @cline/core dist daemons.
+		"/dist/hub/daemon/entry.js",
 		"--cline-hub-daemon",
 	];
 	const records = new Map<number, ProcessRecord>();

--- a/sdk/packages/core/src/hub/daemon/index.test.ts
+++ b/sdk/packages/core/src/hub/daemon/index.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const {
 	spawn,
 	closeSync,
+	existsSync,
 	mkdirSync,
 	openSync,
 	rememberRecoverableLocalHubUrl,
@@ -21,6 +22,7 @@ const {
 } = vi.hoisted(() => ({
 	spawn: vi.fn(() => ({ unref: vi.fn() })),
 	closeSync: vi.fn(),
+	existsSync: vi.fn(() => true),
 	mkdirSync: vi.fn(),
 	openSync: vi.fn(() => 17),
 	rememberRecoverableLocalHubUrl: vi.fn((url: string) => url),
@@ -53,6 +55,7 @@ vi.mock("node:child_process", () => ({
 
 vi.mock("node:fs", () => ({
 	closeSync,
+	existsSync,
 	mkdirSync,
 	openSync,
 }));
@@ -99,6 +102,8 @@ describe("ensureDetachedHubServer", () => {
 		spawn.mockReset();
 		spawn.mockImplementation(() => ({ unref: vi.fn() }));
 		closeSync.mockReset();
+		existsSync.mockReset();
+		existsSync.mockImplementation(() => true);
 		mkdirSync.mockReset();
 		openSync.mockReset();
 		openSync.mockImplementation(() => 17);

--- a/sdk/packages/core/src/hub/daemon/index.ts
+++ b/sdk/packages/core/src/hub/daemon/index.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { closeSync, mkdirSync, openSync } from "node:fs";
+import { closeSync, existsSync, mkdirSync, openSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -31,7 +31,6 @@ import {
 	resolveProductionHubOwnerContext,
 	resolveSharedHubOwnerContext,
 } from "../discovery/workspace";
-
 const HUB_STARTUP_TIMEOUT_MS = 8_000;
 const HUB_STARTUP_POLL_MS = 200;
 const HUB_RETIRE_TIMEOUT_MS = 3_000;
@@ -163,7 +162,19 @@ async function retireLegacySharedHub(owner: HubOwnerContext): Promise<void> {
 
 function resolveDaemonEntryPath(): string {
 	const extension = import.meta.url.endsWith(".ts") ? "ts" : "js";
-	return fileURLToPath(new URL(`./entry.${extension}`, import.meta.url));
+	const siblingEntryPath = fileURLToPath(
+		new URL(`./entry.${extension}`, import.meta.url),
+	);
+	// Compiled Bun binaries ("/$bunfs/" virtual paths, handled by the caller)
+	// and on-disk source/dist layouts keep the entry module next to this one.
+	if (siblingEntryPath.startsWith("/$bunfs/") || existsSync(siblingEntryPath)) {
+		return siblingEntryPath;
+	}
+	// When a host app bundles @cline/core into a single output file (e.g. the
+	// kanban CLI), no sibling entry exists on disk and spawning it would die
+	// with MODULE_NOT_FOUND (#12153). Resolve the installed package export
+	// instead.
+	return fileURLToPath(import.meta.resolve("@cline/core/hub/daemon-entry"));
 }
 
 function resolveLaunchCommand(

--- a/sdk/packages/core/src/services/feature-flags/FeatureFlagsService.ts
+++ b/sdk/packages/core/src/services/feature-flags/FeatureFlagsService.ts
@@ -13,7 +13,8 @@ import {
 	type FeatureFlag,
 	FeatureFlagDefaultValue,
 } from "@cline/shared";
-import { CORE_TELEMETRY_EVENTS } from "../..";
+// Not from "../.." — the root barrel breaks the dist/hub bundles (#12153).
+import { CORE_TELEMETRY_EVENTS } from "../telemetry/core-events";
 
 const DEFAULT_CACHE_TTL_MS = 60 * 60 * 1000;
 const DEFAULT_PERSISTENT_CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;

--- a/sdk/packages/core/src/services/storage/provider-settings-manager.ts
+++ b/sdk/packages/core/src/services/storage/provider-settings-manager.ts
@@ -9,7 +9,8 @@ import {
 } from "node:fs";
 import { basename, dirname } from "node:path";
 import { resolveProviderSettingsPath } from "@cline/shared/storage";
-import { getLiveModelsCatalog } from "../..";
+// Not from "../.." — the root barrel breaks the dist/hub bundles (#12153).
+import { getLiveModelsCatalog } from "../llms/provider-defaults";
 import { getProviderAuthHandler } from "../../auth/provider-auth-registry";
 import { hashSecret, sdkDebug } from "../../logging/early-logger";
 import {


### PR DESCRIPTION
## Problem

Fixes #12153. When a host app bundles `@cline/core` into a single output file (the kanban CLI does this), the hub daemon spawn resolves its entry module relative to `import.meta.url` — which is the bundle itself — producing a nonexistent path like `kanban/dist/entry.js`. The detached child dies instantly with `MODULE_NOT_FOUND` (visible only in `hub-daemon.log`) and callers hang into `Timed out waiting for detached hub startup.` / `session.create timed out` errors, with `EADDRINUSE` churn on the shared hub.

Separately, even with a correct path the spawned daemon would crash: two hub-graph modules imported from the package root barrel (`"../.."`), and including the barrel as a non-entry module makes Bun's bundler emit a dangling `__reExport(..., storage)` for `export * from "@cline/shared/storage"`. The published `@cline/core@0.0.65` ships this — `node -e "import('@cline/core/hub')"` fails with `h00 is not defined`.

## Fix (+25/−6)

- `resolveDaemonEntryPath()` keeps the sibling/`/$bunfs/` behavior, and when no sibling entry exists on disk (the bundled case) falls back to `import.meta.resolve("@cline/core/hub/daemon-entry")`.
- `provider-settings-manager.ts` / `FeatureFlagsService.ts` import their two symbols from concrete modules instead of the root barrel, unbreaking `dist/hub/*` under plain Node.
- `cline doctor` stale-daemon pattern now also matches daemons launched from an installed `@cline/core` dist.

## Verification

Kanban-style simulation (app calling `ensureDetachedHubServer`, bundled to a single `dist/cli.js` with `@cline/core` installed next to it, run under plain Node with isolated `CLINE_DATA_DIR`):

Before:
```
HUB_START_FAILED Timed out waiting for detached hub startup.
hub-daemon.log: Error: Cannot find module '/workspace/tmp-repro/dist/entry.js'
```

After:
```
HUB_READY {"url":"ws://127.0.0.1:25992/hub","authToken":"…"}
```

`@cline/core` unit tests pass (sole failure is the AGENTS.md-documented cloud-VM git `insteadOf` artifact), `@cline/cli` 895 passed, `@cline/cline-hub` 98 passed, typecheck/lint/format clean, and the CLI dev flow still spawns a healthy hub and completes a full agent turn.