### PR TITLE
fix(desktop): order sessions by last activity and unify status color

### DIFF
--- a/apps/examples/desktop-app/webview/components/agent-header.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-header.tsx
@@ -4,6 +4,7 @@ import { SessionStatus } from "@cline/ui";
 import { MoreHorizontal, Plus, Trash2 } from "lucide-react";
 import { type CSSProperties, useEffect, useMemo, useState } from "react";
 import type { ChatSessionStatus } from "@/lib/chat-schema";
+import { sessionStatusColor, sessionStatusTone } from "@/lib/session-status";
 import { cn } from "@/lib/utils";
 import { Button } from "./ui/button";
 import {
@@ -53,18 +54,8 @@ export function AgentHeader({
 	const additions = diff?.additions ?? 0;
 	const deletions = diff?.deletions ?? 0;
 	const hasChanges = additions + deletions > 0;
-	const statusTone =
-		status === "running"
-			? "running"
-			: status === "failed"
-				? "error"
-				: "neutral";
-	const statusColor =
-		status === "running"
-			? "var(--color-green-500)"
-			: status === "failed"
-				? "var(--color-red-500)"
-				: "var(--color-gray-500)";
+	const statusTone = sessionStatusTone(status);
+	const statusColor = sessionStatusColor(status);
 	const threadTitle = useMemo(
 		() => normalizeTitle(title?.trim()) || "New Session",
 		[title],

--- a/apps/examples/desktop-app/webview/components/views/sessions/sessions-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/sessions/sessions-view.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { SessionStatus } from "@cline/ui";
 import {
 	ArrowUpDown,
 	Check,
@@ -13,7 +14,7 @@ import {
 	Trash2,
 	X,
 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { type CSSProperties, useMemo, useState } from "react";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -40,25 +41,18 @@ import {
 	basenamePath,
 	formatCostUsd,
 	formatRelativeTime,
-	parseTimestamp,
 	type SessionThread,
+	sessionActivityTimestamp,
 	type UseSessionHistoryResult,
 } from "@/hooks/use-session-history";
 import type { SessionHistoryItem } from "@/lib/session-history";
+import { sessionStatusColor, sessionStatusTone } from "@/lib/session-status";
 import { cn } from "@/lib/utils";
 
 type SessionsViewProps = {
 	activeSessionId?: string | null;
 	history: UseSessionHistoryResult;
 };
-
-function statusTone(status?: string): string {
-	if (status === "running") return "bg-green-500";
-	if (status === "completed") return "bg-emerald-400";
-	if (status === "failed") return "bg-destructive";
-	if (status === "cancelled") return "bg-yellow-500";
-	return "bg-muted-foreground";
-}
 
 function modelLabel(thread: SessionThread): string {
 	if (thread.provider && thread.model) {
@@ -89,7 +83,10 @@ function sessionFilterDetails(
 }
 
 function sortTimestamp(session?: SessionHistoryItem) {
-	const timestamp = parseTimestamp(session?.endedAt || session?.startedAt);
+	if (!session) {
+		return 0;
+	}
+	const timestamp = sessionActivityTimestamp(session);
 	return Number.isFinite(timestamp) ? timestamp : 0;
 }
 
@@ -415,14 +412,18 @@ export function SessionsView({ activeSessionId, history }: SessionsViewProps) {
 										>
 											<span className="flex min-w-0 items-center gap-3 font-semibold">
 												<span className="sr-only">Open session: </span>
-												<span
-													className={cn(
-														"size-1.5 shrink-0 rounded-full",
-														statusTone(thread.status),
-													)}
-													aria-hidden="true"
+												<SessionStatus
+													className="shrink-0"
+													label={`Session status: ${thread.status}`}
+													showLabel={false}
+													style={
+														{
+															"--cline-ui-session-status-color":
+																sessionStatusColor(thread.status),
+														} as CSSProperties
+													}
+													tone={sessionStatusTone(thread.status)}
 												/>
-												<span className="sr-only">{thread.status}: </span>
 												<span className="truncate">{thread.title}</span>
 											</span>
 											<span className="flex min-w-0 items-center gap-2 text-muted-foreground">

--- a/apps/examples/desktop-app/webview/hooks/use-session-history.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-session-history.ts
@@ -113,11 +113,21 @@ export function parseTimestamp(value?: string): number {
 	return Number.isNaN(parsed) ? Number.NEGATIVE_INFINITY : parsed;
 }
 
-function compareSessionsByStartedAtDesc(
+export function sessionActivityTimestamp(session: SessionHistoryItem): number {
+	const endedAt = parseTimestamp(session.endedAt);
+	const startedAt = parseTimestamp(session.startedAt);
+	return Math.max(endedAt, startedAt);
+}
+
+// Order by last activity, not by start time: a long-running session that was
+// resumed today must outrank one that started later but has been idle for
+// days. This is also the timestamp both the sidebar and the sessions view
+// render, so the list order matches the "1d"/"3d" labels next to each row.
+function compareSessionsByActivityDesc(
 	a: SessionHistoryItem,
 	b: SessionHistoryItem,
 ): number {
-	const timeDelta = parseTimestamp(b.startedAt) - parseTimestamp(a.startedAt);
+	const timeDelta = sessionActivityTimestamp(b) - sessionActivityTimestamp(a);
 	if (timeDelta !== 0) {
 		return timeDelta;
 	}
@@ -552,7 +562,7 @@ export function useSessionHistory({
 					.filter((session) => Boolean(session.sessionId))
 					.filter(isValidHistorySession)
 					.filter((session) => !session.isSubagent && !session.parentSessionId)
-					.sort(compareSessionsByStartedAtDesc);
+					.sort(compareSessionsByActivityDesc);
 				const mergedSessions = mergeDiscoveredSessions(
 					sessionsRef.current,
 					topLevelSessions,

--- a/apps/examples/desktop-app/webview/lib/session-status.test.ts
+++ b/apps/examples/desktop-app/webview/lib/session-status.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { sessionStatusColor, sessionStatusTone } from "@/lib/session-status";
+
+describe("sessionStatusTone", () => {
+	it("marks running sessions as running", () => {
+		expect(sessionStatusTone("running")).toBe("running");
+	});
+
+	it("marks failed and error sessions as errors", () => {
+		expect(sessionStatusTone("failed")).toBe("error");
+		expect(sessionStatusTone("error")).toBe("error");
+	});
+
+	it("treats every other status as neutral", () => {
+		for (const status of [
+			"idle",
+			"starting",
+			"stopping",
+			"pending",
+			"completed",
+			"cancelled",
+			undefined,
+		]) {
+			expect(sessionStatusTone(status)).toBe("neutral");
+		}
+	});
+});
+
+describe("sessionStatusColor", () => {
+	it("uses one color per tone", () => {
+		expect(sessionStatusColor("running")).toBe("var(--color-green-500)");
+		expect(sessionStatusColor("failed")).toBe("var(--color-red-500)");
+		expect(sessionStatusColor("completed")).toBe("var(--color-gray-500)");
+	});
+});

--- a/apps/examples/desktop-app/webview/lib/session-status.ts
+++ b/apps/examples/desktop-app/webview/lib/session-status.ts
@@ -1,0 +1,27 @@
+import type { SessionStatusTone } from "@cline/ui";
+
+/**
+ * Session status presentation shared by every surface that renders a status
+ * dot (chat header, sessions view, sidebar). Keeping the mapping in one place
+ * means a session cannot look green in one view and grey in another.
+ */
+export function sessionStatusTone(status?: string): SessionStatusTone {
+	if (status === "running") {
+		return "running";
+	}
+	if (status === "failed" || status === "error") {
+		return "error";
+	}
+	return "neutral";
+}
+
+export function sessionStatusColor(status?: string): string {
+	switch (sessionStatusTone(status)) {
+		case "running":
+			return "var(--color-green-500)";
+		case "error":
+			return "var(--color-red-500)";
+		default:
+			return "var(--color-gray-500)";
+	}
+}


### PR DESCRIPTION


<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Issues

- The sidebar and the Sessions view showed different sessions in a different order, despite reading the same data.
- A session labeled "3d" ranked above sessions labeled "1d" in the sidebar.
- Status dots in the Sessions view rendered red on first paint, then turned green a moment later — and only for the top few rows.
- Opening one of those green sessions showed a gray dot in the chat header.

### Root Causes

- **Two sort keys.** `useSessionHistory` sorted by `startedAt`, and the sidebar renders that array as-is; the Sessions view re-sorted by `endedAt || startedAt`. Because the sidebar only shows the first 10 threads, the two keys yield two different top-10 sets.
- **Label and order read different fields.** Each row's relative time comes from `endedAt || startedAt`, but ordering came from `startedAt`. A session started 5 days ago and last active yesterday ("1d") sorted below one started 3 days ago and idle since ("3d").
- **Sessions that don't exit cleanly persist as `failed`.** The Sessions view painted `failed` red; a background effect then reads the transcript and flips `failed` → `completed` when the last meaningful message is from the assistant, which the view painted green. That effect only runs for the 4 most recent non-active sessions, so the remaining rows stayed red.
- **Two palettes.** The Sessions view mapped `completed` → emerald and `cancelled` → yellow; `agent-header` treated everything except `running`/`failed` as gray. The same session was green in one surface and gray in the other.

### Fixes

- Sort sessions by last activity (`max(endedAt, startedAt)`) in `useSessionHistory`, exported as `sessionActivityTimestamp`; the Sessions view reuses it for its newest/oldest toggle. Order now matches the timestamp both surfaces display.
- Add `lib/session-status.ts` as the single status→color mapping (`running` → green-500, `failed`/`error` → red-500, everything else → gray-500), consumed by `agent-header` and the Sessions view.
- Render the Sessions view dot with the shared `SessionStatus` component instead of local Tailwind classes, so the list and the header cannot drift apart again.
- Add unit coverage for the status mapping.

### Not addressed

The brief red flash is a data problem, not a color problem: sessions genuinely persist as `failed` and are only corrected after the transcript is read. With the unified palette it is now red → gray, and it still self-corrects only for the 4 most recent sessions. Fixing it on first paint requires correcting the persisted status at session teardown (sidecar-side).

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

Makes sure the session listed in sidebar matches the one in the session history view

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
