### PR TITLE
fix(mcp): refresh lists on list_changed notifications instead of toasting

### DIFF
--- a/apps/vscode/src/services/mcp/McpHub.ts
+++ b/apps/vscode/src/services/mcp/McpHub.ts
@@ -636,7 +636,16 @@ export class McpHub {
 								return true
 							}
 							const serverConfig = (settings.mcpServers as Record<string, McpServerConfig> | undefined)?.[name]
-							return !!serverConfig && !serverConfig.disabled
+							if (!serverConfig || serverConfig.disabled) {
+								return false
+							}
+							// A retry reconnects with the config captured when this
+							// connection was created. If settings now define a
+							// different connection-relevant config, the settings
+							// watcher owns reconnection — retrying here would
+							// resurrect the obsolete config (and displace the
+							// watcher's failed attempt at the new one).
+							return !this.configsRequireRestart(config, serverConfig)
 						},
 					})
 

--- a/apps/vscode/src/services/mcp/McpHub.ts
+++ b/apps/vscode/src/services/mcp/McpHub.ts
@@ -628,6 +628,16 @@ export class McpHub {
 						notifyWebviewOfServerChanges: () => this.notifyWebviewOfServerChanges(),
 						appendErrorMessage: (conn, msg) => this.appendErrorMessage(conn as McpConnection, msg),
 						delay: (ms) => setTimeoutPromise(ms),
+						isStillWanted: async () => {
+							const settings = await this.readAndValidateMcpSettingsFile()
+							if (!settings) {
+								// Can't read settings — don't kill the reconnect
+								// chain over a transient read failure
+								return true
+							}
+							const serverConfig = (settings.mcpServers as Record<string, McpServerConfig> | undefined)?.[name]
+							return !!serverConfig && !serverConfig.disabled
+						},
 					})
 
 					transport.onerror = (error) => reconnectHandler.handleError(error)
@@ -1168,6 +1178,12 @@ export class McpHub {
 		}
 		const connection = this.connections.find((conn) => conn.server.name === name)
 		if (connection) {
+			// Remove from published state BEFORE awaiting the close handshake:
+			// concurrent publishers (list refreshes finishing their fetch,
+			// notifyWebviewOfServerChanges callers) read this.connections after
+			// their own suspension points, and must not see — or re-publish —
+			// a connection that is being torn down.
+			this.connections = this.connections.filter((conn) => conn.server.name !== name)
 			try {
 				// Only close transport and client if they exist (disabled servers don't have them)
 				if (connection.transport) {
@@ -1179,7 +1195,6 @@ export class McpHub {
 			} catch (error) {
 				Logger.error(`Failed to close transport for ${name}:`, error)
 			}
-			this.connections = this.connections.filter((conn) => conn.server.name !== name)
 		}
 	}
 

--- a/apps/vscode/src/services/mcp/McpHub.ts
+++ b/apps/vscode/src/services/mcp/McpHub.ts
@@ -13,6 +13,9 @@ import {
 	ListResourcesResultSchema,
 	ListResourceTemplatesResultSchema,
 	ListToolsResultSchema,
+	PromptListChangedNotificationSchema,
+	ResourceListChangedNotificationSchema,
+	ToolListChangedNotificationSchema,
 } from "@modelcontextprotocol/sdk/types.js"
 import {
 	MAX_MCP_TIMEOUT_SECONDS,
@@ -115,6 +118,12 @@ export class McpHub {
 	// (status change, tools discovered, etc.). Without debouncing, the callback
 	// fires multiple times causing duplicate messages (S6-28).
 	private toolListChangeDebounceTimer?: ReturnType<typeof setTimeout>
+	// Debounce timers for list_changed notification refreshes, keyed by
+	// "<serverName>:<kind>". Servers emit these notifications in bursts
+	// (e.g. a toolset change or shutdown can produce a dozen
+	// notifications/tools/list_changed at once), so refreshes are coalesced
+	// per server and list kind.
+	private listChangedRefreshTimers: Map<string, ReturnType<typeof setTimeout>> = new Map()
 
 	constructor(
 		getMcpServersPath: () => Promise<string>,
@@ -702,17 +711,26 @@ export class McpHub {
 				})
 				//Logger.log(`[MCP Debug] Successfully set notifications/message handler for ${name}`)
 
-				// Also set a fallback handler for any other notification types
-				connection.client.fallbackNotificationHandler = async (notification: any) => {
-					//Logger.log(`[MCP Fallback Notification] ${name}:`, JSON.stringify(notification, null, 2))
+				// When the server reports that a list changed, refresh the cached
+				// list instead of surfacing the notification to the user.
+				connection.client.setNotificationHandler(ToolListChangedNotificationSchema, async () => {
+					this.scheduleListChangedRefresh(name, "tools")
+				})
+				connection.client.setNotificationHandler(ResourceListChangedNotificationSchema, async () => {
+					this.scheduleListChangedRefresh(name, "resources")
+				})
+				connection.client.setNotificationHandler(PromptListChangedNotificationSchema, async () => {
+					this.scheduleListChangedRefresh(name, "prompts")
+				})
 
-					// Show in VS Code for visibility
-					HostProvider.window.showMessage({
-						type: ShowMessageType.INFORMATION,
-						message: `MCP ${name}: ${notification.method || "unknown"} - ${JSON.stringify(notification.params || {})}`,
-					})
+				// Log any other unhandled notification types instead of toasting
+				// them: servers can emit these at any time and a toast per
+				// notification quickly floods the user.
+				connection.client.fallbackNotificationHandler = async (notification: any) => {
+					Logger.log(
+						`[MCP] ${name}: unhandled notification ${notification.method || "unknown"} - ${JSON.stringify(notification.params || {})}`,
+					)
 				}
-				//Logger.log(`[MCP Debug] Successfully set fallback notification handler for ${name}`)
 			} catch (error) {
 				Logger.error(`[MCP Debug] Error setting notification handlers for ${name}:`, error)
 			}
@@ -880,6 +898,55 @@ export class McpHub {
 		} catch (_error) {
 			return []
 		}
+	}
+
+	/**
+	 * Debounced entry point for notifications/<kind>/list_changed. Servers
+	 * emit these in bursts (a toolset change or shutdown can produce a dozen
+	 * notifications/tools/list_changed at once), so refreshes are coalesced
+	 * per server and list kind.
+	 */
+	private scheduleListChangedRefresh(serverName: string, kind: "tools" | "resources" | "prompts"): void {
+		const key = `${serverName}:${kind}`
+		const existingTimer = this.listChangedRefreshTimers.get(key)
+		if (existingTimer) {
+			clearTimeout(existingTimer)
+		}
+		this.listChangedRefreshTimers.set(
+			key,
+			setTimeout(() => {
+				this.listChangedRefreshTimers.delete(key)
+				this.refreshChangedList(serverName, kind).catch((error) => {
+					Logger.error(`[MCP] Failed to refresh ${kind} for ${serverName} after list_changed notification:`, error)
+				})
+			}, 300),
+		)
+	}
+
+	private async refreshChangedList(serverName: string, kind: "tools" | "resources" | "prompts"): Promise<void> {
+		// Look the connection up fresh: it may have been deleted (or replaced
+		// by a reconnect) while the debounce timer was pending.
+		const connection = this.connections.find((conn) => conn.server.name === serverName)
+		if (!connection || connection.server.disabled || !connection.client) {
+			return
+		}
+
+		switch (kind) {
+			case "tools":
+				connection.server.tools = await this.fetchToolsList(serverName)
+				break
+			case "resources":
+				connection.server.resources = await this.fetchResourcesList(serverName)
+				connection.server.resourceTemplates = await this.fetchResourceTemplatesList(serverName)
+				break
+			case "prompts":
+				connection.server.prompts = await this.fetchPromptsList(serverName)
+				break
+		}
+
+		// Push the refreshed lists to the webview; for tools this also runs
+		// the tool-list change check that notifies the SDK controller.
+		await this.notifyWebviewOfServerChanges()
 	}
 
 	async deleteConnection(name: string): Promise<void> {
@@ -1863,6 +1930,10 @@ export class McpHub {
 	}
 
 	async dispose(): Promise<void> {
+		for (const timer of this.listChangedRefreshTimers.values()) {
+			clearTimeout(timer)
+		}
+		this.listChangedRefreshTimers.clear()
 		this.removeAllFileWatchers()
 		for (const connection of this.connections) {
 			try {

--- a/apps/vscode/src/services/mcp/McpHub.ts
+++ b/apps/vscode/src/services/mcp/McpHub.ts
@@ -62,6 +62,12 @@ function stableJsonStringify(value: unknown): string {
 		.join(",")}}`
 }
 
+// Debounce window that coalesces a burst of list_changed notifications into
+// one refresh, and the bounded backoff used when that refresh's fetch fails.
+const LIST_CHANGED_DEBOUNCE_MS = 300
+const LIST_CHANGED_MAX_RETRIES = 3
+const LIST_CHANGED_RETRY_BASE_DELAY_MS = 1000
+
 export class McpHub {
 	getMcpServersPath: () => Promise<string>
 	private getSettingsDirectoryPath: () => Promise<string>
@@ -917,13 +923,21 @@ export class McpHub {
 	 * emit these in bursts (a toolset change or shutdown can produce a dozen
 	 * notifications/tools/list_changed at once), so refreshes are coalesced
 	 * per server and list kind.
+	 *
+	 * A refresh whose fetch fails is retried with exponential backoff up to
+	 * LIST_CHANGED_MAX_RETRIES times: the notification already consumed the
+	 * server's change signal, so giving up immediately would leave the cached
+	 * list stale until the next notification or reconnect. A fresh
+	 * notification (retryAttempt 0) supersedes any pending retry and resets
+	 * the backoff.
 	 */
-	private scheduleListChangedRefresh(serverName: string, kind: "tools" | "resources" | "prompts"): void {
+	private scheduleListChangedRefresh(serverName: string, kind: "tools" | "resources" | "prompts", retryAttempt = 0): void {
 		const key = `${serverName}:${kind}`
 		const existingTimer = this.listChangedRefreshTimers.get(key)
 		if (existingTimer) {
 			clearTimeout(existingTimer)
 		}
+		const delayMs = retryAttempt === 0 ? LIST_CHANGED_DEBOUNCE_MS : LIST_CHANGED_RETRY_BASE_DELAY_MS * 2 ** (retryAttempt - 1)
 		this.listChangedRefreshTimers.set(
 			key,
 			setTimeout(() => {
@@ -934,6 +948,11 @@ export class McpHub {
 				const previous = this.listChangedRefreshInFlight.get(key) ?? Promise.resolve()
 				const run = previous
 					.then(() => this.refreshChangedList(serverName, kind))
+					.then((outcome) => {
+						if (outcome === "failed" && retryAttempt < LIST_CHANGED_MAX_RETRIES) {
+							this.scheduleListChangedRefresh(serverName, kind, retryAttempt + 1)
+						}
+					})
 					.catch((error) => {
 						Logger.error(`[MCP] Failed to refresh ${kind} for ${serverName} after list_changed notification:`, error)
 					})
@@ -943,16 +962,25 @@ export class McpHub {
 						this.listChangedRefreshInFlight.delete(key)
 					}
 				})
-			}, 300),
+			}, delayMs),
 		)
 	}
 
-	private async refreshChangedList(serverName: string, kind: "tools" | "resources" | "prompts"): Promise<void> {
+	/**
+	 * Refreshes the given cached list. Returns "failed" when a fetch failed
+	 * (the caller retries), "skipped" when the connection is gone or was
+	 * replaced (no retry: a replacement fetched fresh lists at connect time),
+	 * and "refreshed" on success.
+	 */
+	private async refreshChangedList(
+		serverName: string,
+		kind: "tools" | "resources" | "prompts",
+	): Promise<"refreshed" | "failed" | "skipped"> {
 		// Look the connection up fresh: it may have been deleted (or replaced
 		// by a reconnect) while the debounce timer was pending.
 		const connection = this.connections.find((conn) => conn.server.name === serverName)
 		if (!connection || connection.server.disabled || !connection.client) {
-			return
+			return "skipped"
 		}
 
 		// A failed fetch returns undefined; keep the previous cached list in
@@ -962,24 +990,28 @@ export class McpHub {
 		let resources: McpResource[] | undefined
 		let resourceTemplates: McpResourceTemplate[] | undefined
 		let prompts: McpPrompt[] | undefined
+		let fetchFailed = false
 		switch (kind) {
 			case "tools":
 				tools = await this.fetchToolsList(serverName)
 				if (tools === undefined) {
-					return
+					return "failed"
 				}
 				break
 			case "resources":
 				resources = await this.fetchResourcesList(serverName)
 				resourceTemplates = await this.fetchResourceTemplatesList(serverName)
 				if (resources === undefined && resourceTemplates === undefined) {
-					return
+					return "failed"
 				}
+				// Half of the pair failed: publish the successful half now and
+				// still retry so the other half doesn't stay stale.
+				fetchFailed = resources === undefined || resourceTemplates === undefined
 				break
 			case "prompts":
 				prompts = await this.fetchPromptsList(serverName)
 				if (prompts === undefined) {
-					return
+					return "failed"
 				}
 				break
 		}
@@ -991,7 +1023,7 @@ export class McpHub {
 		// result to it could overwrite newer data.
 		const current = this.connections.find((conn) => conn.server.name === serverName)
 		if (current !== connection) {
-			return
+			return "skipped"
 		}
 
 		if (tools !== undefined) {
@@ -1010,6 +1042,7 @@ export class McpHub {
 		// Push the refreshed lists to the webview; for tools this also runs
 		// the tool-list change check that notifies the SDK controller.
 		await this.notifyWebviewOfServerChanges()
+		return fetchFailed ? "failed" : "refreshed"
 	}
 
 	async deleteConnection(name: string): Promise<void> {

--- a/apps/vscode/src/services/mcp/McpHub.ts
+++ b/apps/vscode/src/services/mcp/McpHub.ts
@@ -124,6 +124,10 @@ export class McpHub {
 	// notifications/tools/list_changed at once), so refreshes are coalesced
 	// per server and list kind.
 	private listChangedRefreshTimers: Map<string, ReturnType<typeof setTimeout>> = new Map()
+	// In-flight list_changed refreshes, keyed like listChangedRefreshTimers.
+	// A new refresh for the same key chains onto the in-flight one so
+	// overlapping fetches can't complete out of order and publish stale lists.
+	private listChangedRefreshInFlight: Map<string, Promise<void>> = new Map()
 
 	constructor(
 		getMcpServersPath: () => Promise<string>,
@@ -772,8 +776,9 @@ export class McpHub {
 	 * onto the connection. The four list requests run in parallel so a server
 	 * that hangs after initialize costs one timeout bound rather than four;
 	 * the MCP client correlates concurrent requests by JSON-RPC id. Each
-	 * fetch helper swallows its own errors and returns an empty list, so a
-	 * failure in one capability cannot reject the others.
+	 * fetch helper swallows its own errors and resolves (undefined on
+	 * failure, mapped to an empty list here), so a failure in one capability
+	 * cannot reject the others.
 	 */
 	private async fetchServerCapabilities(connection: McpConnection): Promise<void> {
 		const name = connection.server.name
@@ -783,13 +788,17 @@ export class McpHub {
 			this.fetchResourceTemplatesList(name),
 			this.fetchPromptsList(name),
 		])
-		connection.server.tools = tools
-		connection.server.resources = resources
-		connection.server.resourceTemplates = resourceTemplates
-		connection.server.prompts = prompts
+		connection.server.tools = tools ?? []
+		connection.server.resources = resources ?? []
+		connection.server.resourceTemplates = resourceTemplates ?? []
+		connection.server.prompts = prompts ?? []
 	}
 
-	private async fetchToolsList(serverName: string): Promise<McpTool[]> {
+	/**
+	 * Fetches the server's tool list. Returns undefined when the fetch fails,
+	 * so callers can distinguish an error from a genuinely empty list.
+	 */
+	private async fetchToolsList(serverName: string): Promise<McpTool[] | undefined> {
 		try {
 			const connection = this.connections.find((conn) => conn.server.name === serverName)
 
@@ -825,11 +834,12 @@ export class McpHub {
 				? augmentMcpTimeoutError(error, serverName, resolveMcpServerTimeoutMs(connection.server.config))
 				: error
 			Logger.error(`Failed to fetch tools for ${serverName}:`, effectiveError)
-			return []
+			return undefined
 		}
 	}
 
-	private async fetchResourcesList(serverName: string): Promise<McpResource[]> {
+	/** Returns undefined when the fetch fails (vs. a genuinely empty list). */
+	private async fetchResourcesList(serverName: string): Promise<McpResource[] | undefined> {
 		try {
 			const connection = this.connections.find((conn) => conn.server.name === serverName)
 
@@ -844,11 +854,12 @@ export class McpHub {
 			return response?.resources || []
 		} catch (_error) {
 			// Logger.error(`Failed to fetch resources for ${serverName}:`, error)
-			return []
+			return undefined
 		}
 	}
 
-	private async fetchResourceTemplatesList(serverName: string): Promise<McpResourceTemplate[]> {
+	/** Returns undefined when the fetch fails (vs. a genuinely empty list). */
+	private async fetchResourceTemplatesList(serverName: string): Promise<McpResourceTemplate[] | undefined> {
 		try {
 			const connection = this.connections.find((conn) => conn.server.name === serverName)
 
@@ -868,11 +879,12 @@ export class McpHub {
 			return response?.resourceTemplates || []
 		} catch (_error) {
 			// Logger.error(`Failed to fetch resource templates for ${serverName}:`, error)
-			return []
+			return undefined
 		}
 	}
 
-	private async fetchPromptsList(serverName: string): Promise<McpPrompt[]> {
+	/** Returns undefined when the fetch fails (vs. a genuinely empty list). */
+	private async fetchPromptsList(serverName: string): Promise<McpPrompt[] | undefined> {
 		try {
 			const connection = this.connections.find((conn) => conn.server.name === serverName)
 
@@ -896,7 +908,7 @@ export class McpHub {
 				})),
 			}))
 		} catch (_error) {
-			return []
+			return undefined
 		}
 	}
 
@@ -916,8 +928,20 @@ export class McpHub {
 			key,
 			setTimeout(() => {
 				this.listChangedRefreshTimers.delete(key)
-				this.refreshChangedList(serverName, kind).catch((error) => {
-					Logger.error(`[MCP] Failed to refresh ${kind} for ${serverName} after list_changed notification:`, error)
+				// Chain onto any refresh still in flight for this key: two
+				// concurrent refreshes could otherwise complete out of order
+				// and let a stale response overwrite a newer list.
+				const previous = this.listChangedRefreshInFlight.get(key) ?? Promise.resolve()
+				const run = previous
+					.then(() => this.refreshChangedList(serverName, kind))
+					.catch((error) => {
+						Logger.error(`[MCP] Failed to refresh ${kind} for ${serverName} after list_changed notification:`, error)
+					})
+				this.listChangedRefreshInFlight.set(key, run)
+				run.finally(() => {
+					if (this.listChangedRefreshInFlight.get(key) === run) {
+						this.listChangedRefreshInFlight.delete(key)
+					}
 				})
 			}, 300),
 		)
@@ -931,17 +955,40 @@ export class McpHub {
 			return
 		}
 
+		// A failed fetch returns undefined; keep the previous cached list in
+		// that case rather than publishing an empty one, and skip the webview
+		// notification entirely when nothing was refreshed.
 		switch (kind) {
-			case "tools":
-				connection.server.tools = await this.fetchToolsList(serverName)
+			case "tools": {
+				const tools = await this.fetchToolsList(serverName)
+				if (tools === undefined) {
+					return
+				}
+				connection.server.tools = tools
 				break
-			case "resources":
-				connection.server.resources = await this.fetchResourcesList(serverName)
-				connection.server.resourceTemplates = await this.fetchResourceTemplatesList(serverName)
+			}
+			case "resources": {
+				const resources = await this.fetchResourcesList(serverName)
+				const resourceTemplates = await this.fetchResourceTemplatesList(serverName)
+				if (resources === undefined && resourceTemplates === undefined) {
+					return
+				}
+				if (resources !== undefined) {
+					connection.server.resources = resources
+				}
+				if (resourceTemplates !== undefined) {
+					connection.server.resourceTemplates = resourceTemplates
+				}
 				break
-			case "prompts":
-				connection.server.prompts = await this.fetchPromptsList(serverName)
+			}
+			case "prompts": {
+				const prompts = await this.fetchPromptsList(serverName)
+				if (prompts === undefined) {
+					return
+				}
+				connection.server.prompts = prompts
 				break
+			}
 		}
 
 		// Push the refreshed lists to the webview; for tools this also runs

--- a/apps/vscode/src/services/mcp/McpHub.ts
+++ b/apps/vscode/src/services/mcp/McpHub.ts
@@ -1147,11 +1147,15 @@ export class McpHub {
 	}
 
 	async deleteConnection(name: string): Promise<void> {
-		// Cancel pending list_changed refresh timers for this server: either
+		// Cancel pending list_changed refresh timers for this server (either
 		// it's going away, or a replacement connection will fetch fresh lists
-		// itself. Generation entries are kept — they must stay monotonic so
-		// an in-flight refresh from the old connection can't mistake a
-		// post-reconnect generation for its own.
+		// itself) and bump the generation to supersede any refresh already in
+		// flight: the connection stays in this.connections while the close
+		// calls below are awaited, so without the bump a refresh completing in
+		// that window would pass its identity check and publish state for a
+		// connection that's being torn down. Bumping (never resetting) keeps
+		// generations monotonic, so an in-flight refresh from the old
+		// connection can't mistake a post-reconnect generation for its own.
 		for (const kind of ["tools", "resources", "prompts"]) {
 			const key = `${name}:${kind}`
 			const timer = this.listChangedRefreshTimers.get(key)
@@ -1160,6 +1164,7 @@ export class McpHub {
 				this.listChangedRefreshTimers.delete(key)
 			}
 			this.listChangedRefreshDeadlines.delete(key)
+			this.listChangedRefreshGeneration.set(key, (this.listChangedRefreshGeneration.get(key) ?? 0) + 1)
 		}
 		const connection = this.connections.find((conn) => conn.server.name === name)
 		if (connection) {

--- a/apps/vscode/src/services/mcp/McpHub.ts
+++ b/apps/vscode/src/services/mcp/McpHub.ts
@@ -958,37 +958,53 @@ export class McpHub {
 		// A failed fetch returns undefined; keep the previous cached list in
 		// that case rather than publishing an empty one, and skip the webview
 		// notification entirely when nothing was refreshed.
+		let tools: McpTool[] | undefined
+		let resources: McpResource[] | undefined
+		let resourceTemplates: McpResourceTemplate[] | undefined
+		let prompts: McpPrompt[] | undefined
 		switch (kind) {
-			case "tools": {
-				const tools = await this.fetchToolsList(serverName)
+			case "tools":
+				tools = await this.fetchToolsList(serverName)
 				if (tools === undefined) {
 					return
 				}
-				connection.server.tools = tools
 				break
-			}
-			case "resources": {
-				const resources = await this.fetchResourcesList(serverName)
-				const resourceTemplates = await this.fetchResourceTemplatesList(serverName)
+			case "resources":
+				resources = await this.fetchResourcesList(serverName)
+				resourceTemplates = await this.fetchResourceTemplatesList(serverName)
 				if (resources === undefined && resourceTemplates === undefined) {
 					return
 				}
-				if (resources !== undefined) {
-					connection.server.resources = resources
-				}
-				if (resourceTemplates !== undefined) {
-					connection.server.resourceTemplates = resourceTemplates
-				}
 				break
-			}
-			case "prompts": {
-				const prompts = await this.fetchPromptsList(serverName)
+			case "prompts":
+				prompts = await this.fetchPromptsList(serverName)
 				if (prompts === undefined) {
 					return
 				}
-				connection.server.prompts = prompts
 				break
-			}
+		}
+
+		// The connection may have been deleted or replaced by a reconnect
+		// while the fetches were in flight. Drop the result in that case: a
+		// replacement connection fetched fresh lists when it connected, after
+		// the change that produced this notification, so writing this (older)
+		// result to it could overwrite newer data.
+		const current = this.connections.find((conn) => conn.server.name === serverName)
+		if (current !== connection) {
+			return
+		}
+
+		if (tools !== undefined) {
+			current.server.tools = tools
+		}
+		if (resources !== undefined) {
+			current.server.resources = resources
+		}
+		if (resourceTemplates !== undefined) {
+			current.server.resourceTemplates = resourceTemplates
+		}
+		if (prompts !== undefined) {
+			current.server.prompts = prompts
 		}
 
 		// Push the refreshed lists to the webview; for tools this also runs

--- a/apps/vscode/src/services/mcp/McpHub.ts
+++ b/apps/vscode/src/services/mcp/McpHub.ts
@@ -9,10 +9,12 @@ import { getDefaultEnvironment, StdioClientTransport } from "@modelcontextprotoc
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
 import {
 	CallToolResultSchema,
+	ErrorCode,
 	ListPromptsResultSchema,
 	ListResourcesResultSchema,
 	ListResourceTemplatesResultSchema,
 	ListToolsResultSchema,
+	McpError,
 	PromptListChangedNotificationSchema,
 	ResourceListChangedNotificationSchema,
 	ToolListChangedNotificationSchema,
@@ -63,8 +65,11 @@ function stableJsonStringify(value: unknown): string {
 }
 
 // Debounce window that coalesces a burst of list_changed notifications into
-// one refresh, and the bounded backoff used when that refresh's fetch fails.
+// one refresh, the cap on how long a sustained stream of notifications can
+// keep deferring that refresh, and the bounded backoff used when the
+// refresh's fetch fails.
 const LIST_CHANGED_DEBOUNCE_MS = 300
+const LIST_CHANGED_MAX_WAIT_MS = 2000
 const LIST_CHANGED_MAX_RETRIES = 3
 const LIST_CHANGED_RETRY_BASE_DELAY_MS = 1000
 
@@ -139,6 +144,10 @@ export class McpHub {
 	// publish has been superseded by a newer notification — it drops its
 	// result instead of briefly publishing an obsolete list.
 	private listChangedRefreshGeneration: Map<string, number> = new Map()
+	// Deadline per key that caps how long re-debouncing can defer a refresh:
+	// without it, a sustained stream of notifications arriving faster than
+	// the debounce window would starve the refresh indefinitely.
+	private listChangedRefreshDeadlines: Map<string, number> = new Map()
 
 	constructor(
 		getMcpServersPath: () => Promise<string>,
@@ -490,7 +499,11 @@ export class McpHub {
 							connection.server.status = "disconnected"
 							this.appendErrorMessage(connection, error instanceof Error ? error.message : `${error}`)
 						}
-						await this.notifyWebviewOfServerChanges()
+						// onerror's promise is discarded, so a rejection here
+						// would surface as an unhandled rejection
+						await this.notifyWebviewOfServerChanges().catch((notifyError) => {
+							Logger.error(`Failed to publish server state for "${name}":`, notifyError)
+						})
 					}
 
 					transport.onclose = async () => {
@@ -570,7 +583,11 @@ export class McpHub {
 							connection.server.status = "disconnected"
 							this.appendErrorMessage(connection, error instanceof Error ? error.message : `${error}`)
 						}
-						await this.notifyWebviewOfServerChanges()
+						// onerror's promise is discarded, so a rejection here
+						// would surface as an unhandled rejection
+						await this.notifyWebviewOfServerChanges().catch((notifyError) => {
+							Logger.error(`Failed to publish server state for "${name}":`, notifyError)
+						})
 					}
 					break
 				}
@@ -806,6 +823,25 @@ export class McpHub {
 	}
 
 	/**
+	 * A server that never declared a capability has an authoritatively empty
+	 * list for it — not a transient failure worth retrying. Undefined
+	 * capabilities (not yet negotiated) are treated as supported.
+	 */
+	private static serverSupports(connection: McpConnection, capability: "tools" | "resources" | "prompts"): boolean {
+		const capabilities = connection.client?.getServerCapabilities?.()
+		return capabilities === undefined || capabilities[capability] !== undefined
+	}
+
+	/**
+	 * Like serverSupports, for servers that declare a capability but answer a
+	 * specific list request with "method not found" (common for
+	 * resources/templates/list): also an authoritatively empty list.
+	 */
+	private static isMethodNotFound(error: unknown): boolean {
+		return error instanceof McpError && error.code === ErrorCode.MethodNotFound
+	}
+
+	/**
 	 * Fetches the server's tool list. Returns undefined when the fetch fails,
 	 * so callers can distinguish an error from a genuinely empty list.
 	 */
@@ -819,6 +855,10 @@ export class McpHub {
 
 			// Disabled servers don't have clients, so return empty tools list
 			if (connection.server.disabled || !connection.client) {
+				return []
+			}
+
+			if (!McpHub.serverSupports(connection, "tools")) {
 				return []
 			}
 
@@ -840,6 +880,9 @@ export class McpHub {
 
 			return tools
 		} catch (error) {
+			if (McpHub.isMethodNotFound(error)) {
+				return []
+			}
 			const connection = this.connections.find((conn) => conn.server.name === serverName)
 			const effectiveError = connection
 				? augmentMcpTimeoutError(error, serverName, resolveMcpServerTimeoutMs(connection.server.config))
@@ -859,11 +902,18 @@ export class McpHub {
 				return []
 			}
 
+			if (!McpHub.serverSupports(connection, "resources")) {
+				return []
+			}
+
 			const response = await connection.client.request({ method: "resources/list" }, ListResourcesResultSchema, {
 				timeout: resolveMcpServerTimeoutMs(connection.server.config),
 			})
 			return response?.resources || []
-		} catch (_error) {
+		} catch (error) {
+			if (McpHub.isMethodNotFound(error)) {
+				return []
+			}
 			// Logger.error(`Failed to fetch resources for ${serverName}:`, error)
 			return undefined
 		}
@@ -879,6 +929,10 @@ export class McpHub {
 				return []
 			}
 
+			if (!McpHub.serverSupports(connection, "resources")) {
+				return []
+			}
+
 			const response = await connection.client.request(
 				{ method: "resources/templates/list" },
 				ListResourceTemplatesResultSchema,
@@ -888,7 +942,10 @@ export class McpHub {
 			)
 
 			return response?.resourceTemplates || []
-		} catch (_error) {
+		} catch (error) {
+			if (McpHub.isMethodNotFound(error)) {
+				return []
+			}
 			// Logger.error(`Failed to fetch resource templates for ${serverName}:`, error)
 			return undefined
 		}
@@ -901,6 +958,10 @@ export class McpHub {
 
 			// Disabled servers don't have clients, so return empty prompts list
 			if (!connection || connection.server.disabled || !connection.client) {
+				return []
+			}
+
+			if (!McpHub.serverSupports(connection, "prompts")) {
 				return []
 			}
 
@@ -918,7 +979,10 @@ export class McpHub {
 					required: arg.required,
 				})),
 			}))
-		} catch (_error) {
+		} catch (error) {
+			if (McpHub.isMethodNotFound(error)) {
+				return []
+			}
 			return undefined
 		}
 	}
@@ -948,11 +1012,23 @@ export class McpHub {
 		const generation = (this.listChangedRefreshGeneration.get(key) ?? 0) + 1
 		this.listChangedRefreshGeneration.set(key, generation)
 		const superseded = () => this.listChangedRefreshGeneration.get(key) !== generation
-		const delayMs = retryAttempt === 0 ? LIST_CHANGED_DEBOUNCE_MS : LIST_CHANGED_RETRY_BASE_DELAY_MS * 2 ** (retryAttempt - 1)
+		let delayMs: number
+		if (retryAttempt === 0) {
+			// Debounce, but cap the total deferral: a sustained stream of
+			// notifications re-arming the timer would otherwise starve the
+			// refresh indefinitely.
+			const now = Date.now()
+			const deadline = this.listChangedRefreshDeadlines.get(key) ?? now + LIST_CHANGED_MAX_WAIT_MS
+			this.listChangedRefreshDeadlines.set(key, deadline)
+			delayMs = Math.max(0, Math.min(LIST_CHANGED_DEBOUNCE_MS, deadline - now))
+		} else {
+			delayMs = LIST_CHANGED_RETRY_BASE_DELAY_MS * 2 ** (retryAttempt - 1)
+		}
 		this.listChangedRefreshTimers.set(
 			key,
 			setTimeout(() => {
 				this.listChangedRefreshTimers.delete(key)
+				this.listChangedRefreshDeadlines.delete(key)
 				// Chain onto any refresh still in flight for this key: two
 				// concurrent refreshes could otherwise complete out of order
 				// and let a stale response overwrite a newer list.
@@ -998,6 +1074,15 @@ export class McpHub {
 			return "skipped"
 		}
 
+		// This run is stale once the connection was deleted/replaced (a
+		// replacement fetched fresh lists at connect time, after the change
+		// that produced this notification) or a newer notification superseded
+		// it (that refresh will fetch fresher data). A stale run must neither
+		// publish its (older) result nor retry — hence "skipped", including
+		// for fetch failures, which staleness explains (e.g. the transport
+		// was torn down mid-flight by a reconnect).
+		const stale = () => superseded() || this.connections.find((conn) => conn.server.name === serverName) !== connection
+
 		// A failed fetch returns undefined; keep the previous cached list in
 		// that case rather than publishing an empty one, and skip the webview
 		// notification entirely when nothing was refreshed.
@@ -1010,14 +1095,14 @@ export class McpHub {
 			case "tools":
 				tools = await this.fetchToolsList(serverName)
 				if (tools === undefined) {
-					return "failed"
+					return stale() ? "skipped" : "failed"
 				}
 				break
 			case "resources":
 				resources = await this.fetchResourcesList(serverName)
 				resourceTemplates = await this.fetchResourceTemplatesList(serverName)
 				if (resources === undefined && resourceTemplates === undefined) {
-					return "failed"
+					return stale() ? "skipped" : "failed"
 				}
 				// Half of the pair failed: publish the successful half now and
 				// still retry so the other half doesn't stay stale.
@@ -1026,42 +1111,56 @@ export class McpHub {
 			case "prompts":
 				prompts = await this.fetchPromptsList(serverName)
 				if (prompts === undefined) {
-					return "failed"
+					return stale() ? "skipped" : "failed"
 				}
 				break
 		}
 
-		// The connection may have been deleted or replaced by a reconnect, or
-		// this refresh superseded by a newer notification, while the fetches
-		// were in flight. Drop the result in either case: a replacement
-		// connection fetched fresh lists when it connected, and a superseding
-		// refresh will fetch fresher data — publishing this (older) result
-		// would briefly expose an obsolete list.
-		const current = this.connections.find((conn) => conn.server.name === serverName)
-		if (current !== connection || superseded()) {
+		if (stale()) {
 			return "skipped"
 		}
 
 		if (tools !== undefined) {
-			current.server.tools = tools
+			connection.server.tools = tools
 		}
 		if (resources !== undefined) {
-			current.server.resources = resources
+			connection.server.resources = resources
 		}
 		if (resourceTemplates !== undefined) {
-			current.server.resourceTemplates = resourceTemplates
+			connection.server.resourceTemplates = resourceTemplates
 		}
 		if (prompts !== undefined) {
-			current.server.prompts = prompts
+			connection.server.prompts = prompts
 		}
 
 		// Push the refreshed lists to the webview; for tools this also runs
-		// the tool-list change check that notifies the SDK controller.
-		await this.notifyWebviewOfServerChanges()
+		// the tool-list change check that notifies the SDK controller. A
+		// publish failure counts as "failed" so the caller retries: the cache
+		// is updated but consumers haven't seen it yet.
+		try {
+			await this.notifyWebviewOfServerChanges()
+		} catch (error) {
+			Logger.error(`[MCP] Failed to publish refreshed ${kind} for ${serverName}:`, error)
+			return "failed"
+		}
 		return fetchFailed ? "failed" : "refreshed"
 	}
 
 	async deleteConnection(name: string): Promise<void> {
+		// Cancel pending list_changed refresh timers for this server: either
+		// it's going away, or a replacement connection will fetch fresh lists
+		// itself. Generation entries are kept — they must stay monotonic so
+		// an in-flight refresh from the old connection can't mistake a
+		// post-reconnect generation for its own.
+		for (const kind of ["tools", "resources", "prompts"]) {
+			const key = `${name}:${kind}`
+			const timer = this.listChangedRefreshTimers.get(key)
+			if (timer) {
+				clearTimeout(timer)
+				this.listChangedRefreshTimers.delete(key)
+			}
+			this.listChangedRefreshDeadlines.delete(key)
+		}
 		const connection = this.connections.find((conn) => conn.server.name === name)
 		if (connection) {
 			try {
@@ -2047,6 +2146,11 @@ export class McpHub {
 		}
 		this.listChangedRefreshTimers.clear()
 		this.listChangedRefreshGeneration.clear()
+		this.listChangedRefreshDeadlines.clear()
+		if (this.toolListChangeDebounceTimer) {
+			clearTimeout(this.toolListChangeDebounceTimer)
+			this.toolListChangeDebounceTimer = undefined
+		}
 		this.removeAllFileWatchers()
 		for (const connection of this.connections) {
 			try {

--- a/apps/vscode/src/services/mcp/McpHub.ts
+++ b/apps/vscode/src/services/mcp/McpHub.ts
@@ -134,6 +134,11 @@ export class McpHub {
 	// A new refresh for the same key chains onto the in-flight one so
 	// overlapping fetches can't complete out of order and publish stale lists.
 	private listChangedRefreshInFlight: Map<string, Promise<void>> = new Map()
+	// Generation counter per key: every (re)schedule starts a new generation,
+	// and a refresh whose generation is no longer current when it would
+	// publish has been superseded by a newer notification — it drops its
+	// result instead of briefly publishing an obsolete list.
+	private listChangedRefreshGeneration: Map<string, number> = new Map()
 
 	constructor(
 		getMcpServersPath: () => Promise<string>,
@@ -937,6 +942,12 @@ export class McpHub {
 		if (existingTimer) {
 			clearTimeout(existingTimer)
 		}
+		// Supersede any refresh already in flight for this key: its result is
+		// older than the change signal that got us here, so publishing it
+		// would briefly expose an obsolete list before this refresh corrects it.
+		const generation = (this.listChangedRefreshGeneration.get(key) ?? 0) + 1
+		this.listChangedRefreshGeneration.set(key, generation)
+		const superseded = () => this.listChangedRefreshGeneration.get(key) !== generation
 		const delayMs = retryAttempt === 0 ? LIST_CHANGED_DEBOUNCE_MS : LIST_CHANGED_RETRY_BASE_DELAY_MS * 2 ** (retryAttempt - 1)
 		this.listChangedRefreshTimers.set(
 			key,
@@ -947,9 +958,9 @@ export class McpHub {
 				// and let a stale response overwrite a newer list.
 				const previous = this.listChangedRefreshInFlight.get(key) ?? Promise.resolve()
 				const run = previous
-					.then(() => this.refreshChangedList(serverName, kind))
+					.then(() => this.refreshChangedList(serverName, kind, superseded))
 					.then((outcome) => {
-						if (outcome === "failed" && retryAttempt < LIST_CHANGED_MAX_RETRIES) {
+						if (outcome === "failed" && retryAttempt < LIST_CHANGED_MAX_RETRIES && !superseded()) {
 							this.scheduleListChangedRefresh(serverName, kind, retryAttempt + 1)
 						}
 					})
@@ -968,18 +979,22 @@ export class McpHub {
 
 	/**
 	 * Refreshes the given cached list. Returns "failed" when a fetch failed
-	 * (the caller retries), "skipped" when the connection is gone or was
-	 * replaced (no retry: a replacement fetched fresh lists at connect time),
-	 * and "refreshed" on success.
+	 * (the caller retries), "skipped" when the refresh was superseded or the
+	 * connection is gone or was replaced (no retry: a newer refresh or the
+	 * replacement connection's connect-time fetch covers it), and "refreshed"
+	 * on success.
 	 */
 	private async refreshChangedList(
 		serverName: string,
 		kind: "tools" | "resources" | "prompts",
+		superseded: () => boolean,
 	): Promise<"refreshed" | "failed" | "skipped"> {
 		// Look the connection up fresh: it may have been deleted (or replaced
-		// by a reconnect) while the debounce timer was pending.
+		// by a reconnect) while the debounce timer was pending. A superseded
+		// run (a newer notification re-scheduled this key) skips the fetch
+		// outright — the newer refresh will fetch fresher data.
 		const connection = this.connections.find((conn) => conn.server.name === serverName)
-		if (!connection || connection.server.disabled || !connection.client) {
+		if (!connection || connection.server.disabled || !connection.client || superseded()) {
 			return "skipped"
 		}
 
@@ -1016,13 +1031,14 @@ export class McpHub {
 				break
 		}
 
-		// The connection may have been deleted or replaced by a reconnect
-		// while the fetches were in flight. Drop the result in that case: a
-		// replacement connection fetched fresh lists when it connected, after
-		// the change that produced this notification, so writing this (older)
-		// result to it could overwrite newer data.
+		// The connection may have been deleted or replaced by a reconnect, or
+		// this refresh superseded by a newer notification, while the fetches
+		// were in flight. Drop the result in either case: a replacement
+		// connection fetched fresh lists when it connected, and a superseding
+		// refresh will fetch fresher data — publishing this (older) result
+		// would briefly expose an obsolete list.
 		const current = this.connections.find((conn) => conn.server.name === serverName)
-		if (current !== connection) {
+		if (current !== connection || superseded()) {
 			return "skipped"
 		}
 
@@ -2030,6 +2046,7 @@ export class McpHub {
 			clearTimeout(timer)
 		}
 		this.listChangedRefreshTimers.clear()
+		this.listChangedRefreshGeneration.clear()
 		this.removeAllFileWatchers()
 		for (const connection of this.connections) {
 			try {

--- a/apps/vscode/src/services/mcp/McpHub.ts
+++ b/apps/vscode/src/services/mcp/McpHub.ts
@@ -9,11 +9,13 @@ import { getDefaultEnvironment, StdioClientTransport } from "@modelcontextprotoc
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
 import {
 	CallToolResultSchema,
+	ErrorCode,
 	GetPromptResultSchema,
 	ListPromptsResultSchema,
 	ListResourcesResultSchema,
 	ListResourceTemplatesResultSchema,
 	ListToolsResultSchema,
+	McpError,
 	PromptListChangedNotificationSchema,
 	ReadResourceResultSchema,
 	ResourceListChangedNotificationSchema,
@@ -53,8 +55,11 @@ import { BaseConfigSchema, McpSettingsSchema, ServerConfigSchema } from "./schem
 import type { McpConnection, McpServerConfig, Transport } from "./types"
 
 // Debounce window that coalesces a burst of list_changed notifications into
-// one refresh, and the bounded backoff used when that refresh's fetch fails.
+// one refresh, the cap on how long a sustained stream of notifications can
+// keep deferring that refresh, and the bounded backoff used when the
+// refresh's fetch fails.
 const LIST_CHANGED_DEBOUNCE_MS = 300
+const LIST_CHANGED_MAX_WAIT_MS = 2000
 const LIST_CHANGED_MAX_RETRIES = 3
 const LIST_CHANGED_RETRY_BASE_DELAY_MS = 1000
 
@@ -134,6 +139,10 @@ export class McpHub {
 	// publish has been superseded by a newer notification — it drops its
 	// result instead of briefly publishing an obsolete list.
 	private listChangedRefreshGeneration: Map<string, number> = new Map()
+	// Deadline per key that caps how long re-debouncing can defer a refresh:
+	// without it, a sustained stream of notifications arriving faster than
+	// the debounce window would starve the refresh indefinitely.
+	private listChangedRefreshDeadlines: Map<string, number> = new Map()
 
 	constructor(
 		getMcpServersPath: () => Promise<string>,
@@ -513,7 +522,11 @@ export class McpHub {
 							McpHub.mcpServerKeys.delete(connection.server.uid || name)
 							this.appendErrorMessage(connection, error instanceof Error ? error.message : `${error}`)
 						}
-						await this.notifyWebviewOfServerChanges()
+						// onerror's promise is discarded, so a rejection here
+						// would surface as an unhandled rejection
+						await this.notifyWebviewOfServerChanges().catch((notifyError) => {
+							Logger.error(`Failed to publish server state for "${name}":`, notifyError)
+						})
 					}
 
 					transport.onclose = async () => {
@@ -595,7 +608,11 @@ export class McpHub {
 							McpHub.mcpServerKeys.delete(connection.server.uid || name)
 							this.appendErrorMessage(connection, error instanceof Error ? error.message : `${error}`)
 						}
-						await this.notifyWebviewOfServerChanges()
+						// onerror's promise is discarded, so a rejection here
+						// would surface as an unhandled rejection
+						await this.notifyWebviewOfServerChanges().catch((notifyError) => {
+							Logger.error(`Failed to publish server state for "${name}":`, notifyError)
+						})
 					}
 					break
 				}
@@ -797,6 +814,25 @@ export class McpHub {
 	}
 
 	/**
+	 * A server that never declared a capability has an authoritatively empty
+	 * list for it — not a transient failure worth retrying. Undefined
+	 * capabilities (not yet negotiated) are treated as supported.
+	 */
+	private static serverSupports(connection: McpConnection, capability: "tools" | "resources" | "prompts"): boolean {
+		const capabilities = connection.client?.getServerCapabilities()
+		return capabilities === undefined || capabilities[capability] !== undefined
+	}
+
+	/**
+	 * Like serverSupports, for servers that declare a capability but answer a
+	 * specific list request with "method not found" (common for
+	 * resources/templates/list): also an authoritatively empty list.
+	 */
+	private static isMethodNotFound(error: unknown): boolean {
+		return error instanceof McpError && error.code === ErrorCode.MethodNotFound
+	}
+
+	/**
 	 * Fetches the server's tool list. Returns undefined when the fetch fails,
 	 * so callers can distinguish an error from a genuinely empty list.
 	 */
@@ -810,6 +846,10 @@ export class McpHub {
 
 			// Disabled servers don't have clients, so return empty tools list
 			if (connection.server.disabled || !connection.client) {
+				return []
+			}
+
+			if (!McpHub.serverSupports(connection, "tools")) {
 				return []
 			}
 
@@ -831,6 +871,9 @@ export class McpHub {
 
 			return tools
 		} catch (error) {
+			if (McpHub.isMethodNotFound(error)) {
+				return []
+			}
 			Logger.error(`Failed to fetch tools for ${serverName}:`, error)
 			return undefined
 		}
@@ -846,11 +889,18 @@ export class McpHub {
 				return []
 			}
 
+			if (!McpHub.serverSupports(connection, "resources")) {
+				return []
+			}
+
 			const response = await connection.client.request({ method: "resources/list" }, ListResourcesResultSchema, {
 				timeout: DEFAULT_REQUEST_TIMEOUT_MS,
 			})
 			return response?.resources || []
-		} catch (_error) {
+		} catch (error) {
+			if (McpHub.isMethodNotFound(error)) {
+				return []
+			}
 			// Logger.error(`Failed to fetch resources for ${serverName}:`, error)
 			return undefined
 		}
@@ -866,6 +916,10 @@ export class McpHub {
 				return []
 			}
 
+			if (!McpHub.serverSupports(connection, "resources")) {
+				return []
+			}
+
 			const response = await connection.client.request(
 				{ method: "resources/templates/list" },
 				ListResourceTemplatesResultSchema,
@@ -875,7 +929,10 @@ export class McpHub {
 			)
 
 			return response?.resourceTemplates || []
-		} catch (_error) {
+		} catch (error) {
+			if (McpHub.isMethodNotFound(error)) {
+				return []
+			}
 			// Logger.error(`Failed to fetch resource templates for ${serverName}:`, error)
 			return undefined
 		}
@@ -888,6 +945,10 @@ export class McpHub {
 
 			// Disabled servers don't have clients, so return empty prompts list
 			if (!connection || connection.server.disabled || !connection.client) {
+				return []
+			}
+
+			if (!McpHub.serverSupports(connection, "prompts")) {
 				return []
 			}
 
@@ -905,7 +966,10 @@ export class McpHub {
 					required: arg.required,
 				})),
 			}))
-		} catch (_error) {
+		} catch (error) {
+			if (McpHub.isMethodNotFound(error)) {
+				return []
+			}
 			return undefined
 		}
 	}
@@ -935,11 +999,23 @@ export class McpHub {
 		const generation = (this.listChangedRefreshGeneration.get(key) ?? 0) + 1
 		this.listChangedRefreshGeneration.set(key, generation)
 		const superseded = () => this.listChangedRefreshGeneration.get(key) !== generation
-		const delayMs = retryAttempt === 0 ? LIST_CHANGED_DEBOUNCE_MS : LIST_CHANGED_RETRY_BASE_DELAY_MS * 2 ** (retryAttempt - 1)
+		let delayMs: number
+		if (retryAttempt === 0) {
+			// Debounce, but cap the total deferral: a sustained stream of
+			// notifications re-arming the timer would otherwise starve the
+			// refresh indefinitely.
+			const now = Date.now()
+			const deadline = this.listChangedRefreshDeadlines.get(key) ?? now + LIST_CHANGED_MAX_WAIT_MS
+			this.listChangedRefreshDeadlines.set(key, deadline)
+			delayMs = Math.max(0, Math.min(LIST_CHANGED_DEBOUNCE_MS, deadline - now))
+		} else {
+			delayMs = LIST_CHANGED_RETRY_BASE_DELAY_MS * 2 ** (retryAttempt - 1)
+		}
 		this.listChangedRefreshTimers.set(
 			key,
 			setTimeout(() => {
 				this.listChangedRefreshTimers.delete(key)
+				this.listChangedRefreshDeadlines.delete(key)
 				// Chain onto any refresh still in flight for this key: two
 				// concurrent refreshes could otherwise complete out of order
 				// and let a stale response overwrite a newer list.
@@ -985,6 +1061,15 @@ export class McpHub {
 			return "skipped"
 		}
 
+		// This run is stale once the connection was deleted/replaced (a
+		// replacement fetched fresh lists at connect time, after the change
+		// that produced this notification) or a newer notification superseded
+		// it (that refresh will fetch fresher data). A stale run must neither
+		// publish its (older) result nor retry — hence "skipped", including
+		// for fetch failures, which staleness explains (e.g. the transport
+		// was torn down mid-flight by a reconnect).
+		const stale = () => superseded() || this.connections.find((conn) => conn.server.name === serverName) !== connection
+
 		// A failed fetch returns undefined; keep the previous cached list in
 		// that case rather than publishing an empty one, and skip the webview
 		// notification entirely when nothing was refreshed.
@@ -997,14 +1082,14 @@ export class McpHub {
 			case "tools":
 				tools = await this.fetchToolsList(serverName)
 				if (tools === undefined) {
-					return "failed"
+					return stale() ? "skipped" : "failed"
 				}
 				break
 			case "resources":
 				resources = await this.fetchResourcesList(serverName)
 				resourceTemplates = await this.fetchResourceTemplatesList(serverName)
 				if (resources === undefined && resourceTemplates === undefined) {
-					return "failed"
+					return stale() ? "skipped" : "failed"
 				}
 				// Half of the pair failed: publish the successful half now and
 				// still retry so the other half doesn't stay stale.
@@ -1013,42 +1098,56 @@ export class McpHub {
 			case "prompts":
 				prompts = await this.fetchPromptsList(serverName)
 				if (prompts === undefined) {
-					return "failed"
+					return stale() ? "skipped" : "failed"
 				}
 				break
 		}
 
-		// The connection may have been deleted or replaced by a reconnect, or
-		// this refresh superseded by a newer notification, while the fetches
-		// were in flight. Drop the result in either case: a replacement
-		// connection fetched fresh lists when it connected, and a superseding
-		// refresh will fetch fresher data — publishing this (older) result
-		// would briefly expose an obsolete list.
-		const current = this.connections.find((conn) => conn.server.name === serverName)
-		if (current !== connection || superseded()) {
+		if (stale()) {
 			return "skipped"
 		}
 
 		if (tools !== undefined) {
-			current.server.tools = tools
+			connection.server.tools = tools
 		}
 		if (resources !== undefined) {
-			current.server.resources = resources
+			connection.server.resources = resources
 		}
 		if (resourceTemplates !== undefined) {
-			current.server.resourceTemplates = resourceTemplates
+			connection.server.resourceTemplates = resourceTemplates
 		}
 		if (prompts !== undefined) {
-			current.server.prompts = prompts
+			connection.server.prompts = prompts
 		}
 
 		// Push the refreshed lists to the webview; for tools this also runs
-		// the tool-list change check that notifies the SDK controller.
-		await this.notifyWebviewOfServerChanges()
+		// the tool-list change check that notifies the SDK controller. A
+		// publish failure counts as "failed" so the caller retries: the cache
+		// is updated but consumers haven't seen it yet.
+		try {
+			await this.notifyWebviewOfServerChanges()
+		} catch (error) {
+			Logger.error(`[MCP] Failed to publish refreshed ${kind} for ${serverName}:`, error)
+			return "failed"
+		}
 		return fetchFailed ? "failed" : "refreshed"
 	}
 
 	async deleteConnection(name: string): Promise<void> {
+		// Cancel pending list_changed refresh timers for this server: either
+		// it's going away, or a replacement connection will fetch fresh lists
+		// itself. Generation entries are kept — they must stay monotonic so
+		// an in-flight refresh from the old connection can't mistake a
+		// post-reconnect generation for its own.
+		for (const kind of ["tools", "resources", "prompts"]) {
+			const key = `${name}:${kind}`
+			const timer = this.listChangedRefreshTimers.get(key)
+			if (timer) {
+				clearTimeout(timer)
+				this.listChangedRefreshTimers.delete(key)
+			}
+			this.listChangedRefreshDeadlines.delete(key)
+		}
 		const connection = this.connections.find((conn) => conn.server.name === name)
 		if (connection) {
 			try {
@@ -2077,6 +2176,11 @@ export class McpHub {
 		}
 		this.listChangedRefreshTimers.clear()
 		this.listChangedRefreshGeneration.clear()
+		this.listChangedRefreshDeadlines.clear()
+		if (this.toolListChangeDebounceTimer) {
+			clearTimeout(this.toolListChangeDebounceTimer)
+			this.toolListChangeDebounceTimer = undefined
+		}
 		this.removeAllFileWatchers()
 		for (const connection of this.connections) {
 			try {

--- a/apps/vscode/src/services/mcp/McpHub.ts
+++ b/apps/vscode/src/services/mcp/McpHub.ts
@@ -51,6 +51,13 @@ import { updateMcpSettingsFile } from "./settingsLock"
 import { StreamableHttpReconnectHandler } from "./StreamableHttpReconnectHandler"
 import { BaseConfigSchema, McpSettingsSchema, ServerConfigSchema } from "./schemas"
 import type { McpConnection, McpServerConfig, Transport } from "./types"
+
+// Debounce window that coalesces a burst of list_changed notifications into
+// one refresh, and the bounded backoff used when that refresh's fetch fails.
+const LIST_CHANGED_DEBOUNCE_MS = 300
+const LIST_CHANGED_MAX_RETRIES = 3
+const LIST_CHANGED_RETRY_BASE_DELAY_MS = 1000
+
 export class McpHub {
 	getMcpServersPath: () => Promise<string>
 	private getSettingsDirectoryPath: () => Promise<string>
@@ -903,13 +910,21 @@ export class McpHub {
 	 * emit these in bursts (a toolset change or shutdown can produce a dozen
 	 * notifications/tools/list_changed at once), so refreshes are coalesced
 	 * per server and list kind.
+	 *
+	 * A refresh whose fetch fails is retried with exponential backoff up to
+	 * LIST_CHANGED_MAX_RETRIES times: the notification already consumed the
+	 * server's change signal, so giving up immediately would leave the cached
+	 * list stale until the next notification or reconnect. A fresh
+	 * notification (retryAttempt 0) supersedes any pending retry and resets
+	 * the backoff.
 	 */
-	private scheduleListChangedRefresh(serverName: string, kind: "tools" | "resources" | "prompts"): void {
+	private scheduleListChangedRefresh(serverName: string, kind: "tools" | "resources" | "prompts", retryAttempt = 0): void {
 		const key = `${serverName}:${kind}`
 		const existingTimer = this.listChangedRefreshTimers.get(key)
 		if (existingTimer) {
 			clearTimeout(existingTimer)
 		}
+		const delayMs = retryAttempt === 0 ? LIST_CHANGED_DEBOUNCE_MS : LIST_CHANGED_RETRY_BASE_DELAY_MS * 2 ** (retryAttempt - 1)
 		this.listChangedRefreshTimers.set(
 			key,
 			setTimeout(() => {
@@ -920,6 +935,11 @@ export class McpHub {
 				const previous = this.listChangedRefreshInFlight.get(key) ?? Promise.resolve()
 				const run = previous
 					.then(() => this.refreshChangedList(serverName, kind))
+					.then((outcome) => {
+						if (outcome === "failed" && retryAttempt < LIST_CHANGED_MAX_RETRIES) {
+							this.scheduleListChangedRefresh(serverName, kind, retryAttempt + 1)
+						}
+					})
 					.catch((error) => {
 						Logger.error(`[MCP] Failed to refresh ${kind} for ${serverName} after list_changed notification:`, error)
 					})
@@ -929,16 +949,25 @@ export class McpHub {
 						this.listChangedRefreshInFlight.delete(key)
 					}
 				})
-			}, 300),
+			}, delayMs),
 		)
 	}
 
-	private async refreshChangedList(serverName: string, kind: "tools" | "resources" | "prompts"): Promise<void> {
+	/**
+	 * Refreshes the given cached list. Returns "failed" when a fetch failed
+	 * (the caller retries), "skipped" when the connection is gone or was
+	 * replaced (no retry: a replacement fetched fresh lists at connect time),
+	 * and "refreshed" on success.
+	 */
+	private async refreshChangedList(
+		serverName: string,
+		kind: "tools" | "resources" | "prompts",
+	): Promise<"refreshed" | "failed" | "skipped"> {
 		// Look the connection up fresh: it may have been deleted (or replaced
 		// by a reconnect) while the debounce timer was pending.
 		const connection = this.connections.find((conn) => conn.server.name === serverName)
 		if (!connection || connection.server.disabled || !connection.client) {
-			return
+			return "skipped"
 		}
 
 		// A failed fetch returns undefined; keep the previous cached list in
@@ -948,24 +977,28 @@ export class McpHub {
 		let resources: McpResource[] | undefined
 		let resourceTemplates: McpResourceTemplate[] | undefined
 		let prompts: McpPrompt[] | undefined
+		let fetchFailed = false
 		switch (kind) {
 			case "tools":
 				tools = await this.fetchToolsList(serverName)
 				if (tools === undefined) {
-					return
+					return "failed"
 				}
 				break
 			case "resources":
 				resources = await this.fetchResourcesList(serverName)
 				resourceTemplates = await this.fetchResourceTemplatesList(serverName)
 				if (resources === undefined && resourceTemplates === undefined) {
-					return
+					return "failed"
 				}
+				// Half of the pair failed: publish the successful half now and
+				// still retry so the other half doesn't stay stale.
+				fetchFailed = resources === undefined || resourceTemplates === undefined
 				break
 			case "prompts":
 				prompts = await this.fetchPromptsList(serverName)
 				if (prompts === undefined) {
-					return
+					return "failed"
 				}
 				break
 		}
@@ -977,7 +1010,7 @@ export class McpHub {
 		// result to it could overwrite newer data.
 		const current = this.connections.find((conn) => conn.server.name === serverName)
 		if (current !== connection) {
-			return
+			return "skipped"
 		}
 
 		if (tools !== undefined) {
@@ -996,6 +1029,7 @@ export class McpHub {
 		// Push the refreshed lists to the webview; for tools this also runs
 		// the tool-list change check that notifies the SDK controller.
 		await this.notifyWebviewOfServerChanges()
+		return fetchFailed ? "failed" : "refreshed"
 	}
 
 	async deleteConnection(name: string): Promise<void> {

--- a/apps/vscode/src/services/mcp/McpHub.ts
+++ b/apps/vscode/src/services/mcp/McpHub.ts
@@ -944,37 +944,53 @@ export class McpHub {
 		// A failed fetch returns undefined; keep the previous cached list in
 		// that case rather than publishing an empty one, and skip the webview
 		// notification entirely when nothing was refreshed.
+		let tools: McpTool[] | undefined
+		let resources: McpResource[] | undefined
+		let resourceTemplates: McpResourceTemplate[] | undefined
+		let prompts: McpPrompt[] | undefined
 		switch (kind) {
-			case "tools": {
-				const tools = await this.fetchToolsList(serverName)
+			case "tools":
+				tools = await this.fetchToolsList(serverName)
 				if (tools === undefined) {
 					return
 				}
-				connection.server.tools = tools
 				break
-			}
-			case "resources": {
-				const resources = await this.fetchResourcesList(serverName)
-				const resourceTemplates = await this.fetchResourceTemplatesList(serverName)
+			case "resources":
+				resources = await this.fetchResourcesList(serverName)
+				resourceTemplates = await this.fetchResourceTemplatesList(serverName)
 				if (resources === undefined && resourceTemplates === undefined) {
 					return
 				}
-				if (resources !== undefined) {
-					connection.server.resources = resources
-				}
-				if (resourceTemplates !== undefined) {
-					connection.server.resourceTemplates = resourceTemplates
-				}
 				break
-			}
-			case "prompts": {
-				const prompts = await this.fetchPromptsList(serverName)
+			case "prompts":
+				prompts = await this.fetchPromptsList(serverName)
 				if (prompts === undefined) {
 					return
 				}
-				connection.server.prompts = prompts
 				break
-			}
+		}
+
+		// The connection may have been deleted or replaced by a reconnect
+		// while the fetches were in flight. Drop the result in that case: a
+		// replacement connection fetched fresh lists when it connected, after
+		// the change that produced this notification, so writing this (older)
+		// result to it could overwrite newer data.
+		const current = this.connections.find((conn) => conn.server.name === serverName)
+		if (current !== connection) {
+			return
+		}
+
+		if (tools !== undefined) {
+			current.server.tools = tools
+		}
+		if (resources !== undefined) {
+			current.server.resources = resources
+		}
+		if (resourceTemplates !== undefined) {
+			current.server.resourceTemplates = resourceTemplates
+		}
+		if (prompts !== undefined) {
+			current.server.prompts = prompts
 		}
 
 		// Push the refreshed lists to the webview; for tools this also runs

--- a/apps/vscode/src/services/mcp/McpHub.ts
+++ b/apps/vscode/src/services/mcp/McpHub.ts
@@ -14,7 +14,10 @@ import {
 	ListResourcesResultSchema,
 	ListResourceTemplatesResultSchema,
 	ListToolsResultSchema,
+	PromptListChangedNotificationSchema,
 	ReadResourceResultSchema,
+	ResourceListChangedNotificationSchema,
+	ToolListChangedNotificationSchema,
 } from "@modelcontextprotocol/sdk/types.js"
 import {
 	DEFAULT_MCP_TIMEOUT_SECONDS,
@@ -109,6 +112,12 @@ export class McpHub {
 	// (status change, tools discovered, etc.). Without debouncing, the callback
 	// fires multiple times causing duplicate messages (S6-28).
 	private toolListChangeDebounceTimer?: ReturnType<typeof setTimeout>
+	// Debounce timers for list_changed notification refreshes, keyed by
+	// "<serverName>:<kind>". Servers emit these notifications in bursts
+	// (e.g. a toolset change or shutdown can produce a dozen
+	// notifications/tools/list_changed at once), so refreshes are coalesced
+	// per server and list kind.
+	private listChangedRefreshTimers: Map<string, ReturnType<typeof setTimeout>> = new Map()
 
 	constructor(
 		getMcpServersPath: () => Promise<string>,
@@ -726,17 +735,26 @@ export class McpHub {
 				})
 				//Logger.log(`[MCP Debug] Successfully set notifications/message handler for ${name}`)
 
-				// Also set a fallback handler for any other notification types
-				connection.client.fallbackNotificationHandler = async (notification: any) => {
-					//Logger.log(`[MCP Fallback Notification] ${name}:`, JSON.stringify(notification, null, 2))
+				// When the server reports that a list changed, refresh the cached
+				// list instead of surfacing the notification to the user.
+				connection.client.setNotificationHandler(ToolListChangedNotificationSchema, async () => {
+					this.scheduleListChangedRefresh(name, "tools")
+				})
+				connection.client.setNotificationHandler(ResourceListChangedNotificationSchema, async () => {
+					this.scheduleListChangedRefresh(name, "resources")
+				})
+				connection.client.setNotificationHandler(PromptListChangedNotificationSchema, async () => {
+					this.scheduleListChangedRefresh(name, "prompts")
+				})
 
-					// Show in VS Code for visibility
-					HostProvider.window.showMessage({
-						type: ShowMessageType.INFORMATION,
-						message: `MCP ${name}: ${notification.method || "unknown"} - ${JSON.stringify(notification.params || {})}`,
-					})
+				// Log any other unhandled notification types instead of toasting
+				// them: servers can emit these at any time and a toast per
+				// notification quickly floods the user.
+				connection.client.fallbackNotificationHandler = async (notification: any) => {
+					Logger.log(
+						`[MCP] ${name}: unhandled notification ${notification.method || "unknown"} - ${JSON.stringify(notification.params || {})}`,
+					)
 				}
-				//Logger.log(`[MCP Debug] Successfully set fallback notification handler for ${name}`)
 			} catch (error) {
 				Logger.error(`[MCP Debug] Error setting notification handlers for ${name}:`, error)
 			}
@@ -867,6 +885,55 @@ export class McpHub {
 		} catch (_error) {
 			return []
 		}
+	}
+
+	/**
+	 * Debounced entry point for notifications/<kind>/list_changed. Servers
+	 * emit these in bursts (a toolset change or shutdown can produce a dozen
+	 * notifications/tools/list_changed at once), so refreshes are coalesced
+	 * per server and list kind.
+	 */
+	private scheduleListChangedRefresh(serverName: string, kind: "tools" | "resources" | "prompts"): void {
+		const key = `${serverName}:${kind}`
+		const existingTimer = this.listChangedRefreshTimers.get(key)
+		if (existingTimer) {
+			clearTimeout(existingTimer)
+		}
+		this.listChangedRefreshTimers.set(
+			key,
+			setTimeout(() => {
+				this.listChangedRefreshTimers.delete(key)
+				this.refreshChangedList(serverName, kind).catch((error) => {
+					Logger.error(`[MCP] Failed to refresh ${kind} for ${serverName} after list_changed notification:`, error)
+				})
+			}, 300),
+		)
+	}
+
+	private async refreshChangedList(serverName: string, kind: "tools" | "resources" | "prompts"): Promise<void> {
+		// Look the connection up fresh: it may have been deleted (or replaced
+		// by a reconnect) while the debounce timer was pending.
+		const connection = this.connections.find((conn) => conn.server.name === serverName)
+		if (!connection || connection.server.disabled || !connection.client) {
+			return
+		}
+
+		switch (kind) {
+			case "tools":
+				connection.server.tools = await this.fetchToolsList(serverName)
+				break
+			case "resources":
+				connection.server.resources = await this.fetchResourcesList(serverName)
+				connection.server.resourceTemplates = await this.fetchResourceTemplatesList(serverName)
+				break
+			case "prompts":
+				connection.server.prompts = await this.fetchPromptsList(serverName)
+				break
+		}
+
+		// Push the refreshed lists to the webview; for tools this also runs
+		// the tool-list change check that notifies the SDK controller.
+		await this.notifyWebviewOfServerChanges()
 	}
 
 	async deleteConnection(name: string): Promise<void> {
@@ -1893,6 +1960,10 @@ export class McpHub {
 	}
 
 	async dispose(): Promise<void> {
+		for (const timer of this.listChangedRefreshTimers.values()) {
+			clearTimeout(timer)
+		}
+		this.listChangedRefreshTimers.clear()
 		this.removeAllFileWatchers()
 		for (const connection of this.connections) {
 			try {

--- a/apps/vscode/src/services/mcp/McpHub.ts
+++ b/apps/vscode/src/services/mcp/McpHub.ts
@@ -118,6 +118,10 @@ export class McpHub {
 	// notifications/tools/list_changed at once), so refreshes are coalesced
 	// per server and list kind.
 	private listChangedRefreshTimers: Map<string, ReturnType<typeof setTimeout>> = new Map()
+	// In-flight list_changed refreshes, keyed like listChangedRefreshTimers.
+	// A new refresh for the same key chains onto the in-flight one so
+	// overlapping fetches can't complete out of order and publish stale lists.
+	private listChangedRefreshInFlight: Map<string, Promise<void>> = new Map()
 
 	constructor(
 		getMcpServersPath: () => Promise<string>,
@@ -760,10 +764,10 @@ export class McpHub {
 			}
 
 			// Initial fetch of tools, resources, and prompts
-			connection.server.tools = await this.fetchToolsList(name)
-			connection.server.resources = await this.fetchResourcesList(name)
-			connection.server.resourceTemplates = await this.fetchResourceTemplatesList(name)
-			connection.server.prompts = await this.fetchPromptsList(name)
+			connection.server.tools = (await this.fetchToolsList(name)) ?? []
+			connection.server.resources = (await this.fetchResourcesList(name)) ?? []
+			connection.server.resourceTemplates = (await this.fetchResourceTemplatesList(name)) ?? []
+			connection.server.prompts = (await this.fetchPromptsList(name)) ?? []
 		} catch (error) {
 			// Update status with error
 			const connection = this.findConnection(name, source)
@@ -780,7 +784,11 @@ export class McpHub {
 		connection.server.error = newError //.slice(0, 800)
 	}
 
-	private async fetchToolsList(serverName: string): Promise<McpTool[]> {
+	/**
+	 * Fetches the server's tool list. Returns undefined when the fetch fails,
+	 * so callers can distinguish an error from a genuinely empty list.
+	 */
+	private async fetchToolsList(serverName: string): Promise<McpTool[] | undefined> {
 		try {
 			const connection = this.connections.find((conn) => conn.server.name === serverName)
 
@@ -812,11 +820,12 @@ export class McpHub {
 			return tools
 		} catch (error) {
 			Logger.error(`Failed to fetch tools for ${serverName}:`, error)
-			return []
+			return undefined
 		}
 	}
 
-	private async fetchResourcesList(serverName: string): Promise<McpResource[]> {
+	/** Returns undefined when the fetch fails (vs. a genuinely empty list). */
+	private async fetchResourcesList(serverName: string): Promise<McpResource[] | undefined> {
 		try {
 			const connection = this.connections.find((conn) => conn.server.name === serverName)
 
@@ -831,11 +840,12 @@ export class McpHub {
 			return response?.resources || []
 		} catch (_error) {
 			// Logger.error(`Failed to fetch resources for ${serverName}:`, error)
-			return []
+			return undefined
 		}
 	}
 
-	private async fetchResourceTemplatesList(serverName: string): Promise<McpResourceTemplate[]> {
+	/** Returns undefined when the fetch fails (vs. a genuinely empty list). */
+	private async fetchResourceTemplatesList(serverName: string): Promise<McpResourceTemplate[] | undefined> {
 		try {
 			const connection = this.connections.find((conn) => conn.server.name === serverName)
 
@@ -855,11 +865,12 @@ export class McpHub {
 			return response?.resourceTemplates || []
 		} catch (_error) {
 			// Logger.error(`Failed to fetch resource templates for ${serverName}:`, error)
-			return []
+			return undefined
 		}
 	}
 
-	private async fetchPromptsList(serverName: string): Promise<McpPrompt[]> {
+	/** Returns undefined when the fetch fails (vs. a genuinely empty list). */
+	private async fetchPromptsList(serverName: string): Promise<McpPrompt[] | undefined> {
 		try {
 			const connection = this.connections.find((conn) => conn.server.name === serverName)
 
@@ -883,7 +894,7 @@ export class McpHub {
 				})),
 			}))
 		} catch (_error) {
-			return []
+			return undefined
 		}
 	}
 
@@ -903,8 +914,20 @@ export class McpHub {
 			key,
 			setTimeout(() => {
 				this.listChangedRefreshTimers.delete(key)
-				this.refreshChangedList(serverName, kind).catch((error) => {
-					Logger.error(`[MCP] Failed to refresh ${kind} for ${serverName} after list_changed notification:`, error)
+				// Chain onto any refresh still in flight for this key: two
+				// concurrent refreshes could otherwise complete out of order
+				// and let a stale response overwrite a newer list.
+				const previous = this.listChangedRefreshInFlight.get(key) ?? Promise.resolve()
+				const run = previous
+					.then(() => this.refreshChangedList(serverName, kind))
+					.catch((error) => {
+						Logger.error(`[MCP] Failed to refresh ${kind} for ${serverName} after list_changed notification:`, error)
+					})
+				this.listChangedRefreshInFlight.set(key, run)
+				run.finally(() => {
+					if (this.listChangedRefreshInFlight.get(key) === run) {
+						this.listChangedRefreshInFlight.delete(key)
+					}
 				})
 			}, 300),
 		)
@@ -918,17 +941,40 @@ export class McpHub {
 			return
 		}
 
+		// A failed fetch returns undefined; keep the previous cached list in
+		// that case rather than publishing an empty one, and skip the webview
+		// notification entirely when nothing was refreshed.
 		switch (kind) {
-			case "tools":
-				connection.server.tools = await this.fetchToolsList(serverName)
+			case "tools": {
+				const tools = await this.fetchToolsList(serverName)
+				if (tools === undefined) {
+					return
+				}
+				connection.server.tools = tools
 				break
-			case "resources":
-				connection.server.resources = await this.fetchResourcesList(serverName)
-				connection.server.resourceTemplates = await this.fetchResourceTemplatesList(serverName)
+			}
+			case "resources": {
+				const resources = await this.fetchResourcesList(serverName)
+				const resourceTemplates = await this.fetchResourceTemplatesList(serverName)
+				if (resources === undefined && resourceTemplates === undefined) {
+					return
+				}
+				if (resources !== undefined) {
+					connection.server.resources = resources
+				}
+				if (resourceTemplates !== undefined) {
+					connection.server.resourceTemplates = resourceTemplates
+				}
 				break
-			case "prompts":
-				connection.server.prompts = await this.fetchPromptsList(serverName)
+			}
+			case "prompts": {
+				const prompts = await this.fetchPromptsList(serverName)
+				if (prompts === undefined) {
+					return
+				}
+				connection.server.prompts = prompts
 				break
+			}
 		}
 
 		// Push the refreshed lists to the webview; for tools this also runs

--- a/apps/vscode/src/services/mcp/McpHub.ts
+++ b/apps/vscode/src/services/mcp/McpHub.ts
@@ -129,6 +129,11 @@ export class McpHub {
 	// A new refresh for the same key chains onto the in-flight one so
 	// overlapping fetches can't complete out of order and publish stale lists.
 	private listChangedRefreshInFlight: Map<string, Promise<void>> = new Map()
+	// Generation counter per key: every (re)schedule starts a new generation,
+	// and a refresh whose generation is no longer current when it would
+	// publish has been superseded by a newer notification — it drops its
+	// result instead of briefly publishing an obsolete list.
+	private listChangedRefreshGeneration: Map<string, number> = new Map()
 
 	constructor(
 		getMcpServersPath: () => Promise<string>,
@@ -924,6 +929,12 @@ export class McpHub {
 		if (existingTimer) {
 			clearTimeout(existingTimer)
 		}
+		// Supersede any refresh already in flight for this key: its result is
+		// older than the change signal that got us here, so publishing it
+		// would briefly expose an obsolete list before this refresh corrects it.
+		const generation = (this.listChangedRefreshGeneration.get(key) ?? 0) + 1
+		this.listChangedRefreshGeneration.set(key, generation)
+		const superseded = () => this.listChangedRefreshGeneration.get(key) !== generation
 		const delayMs = retryAttempt === 0 ? LIST_CHANGED_DEBOUNCE_MS : LIST_CHANGED_RETRY_BASE_DELAY_MS * 2 ** (retryAttempt - 1)
 		this.listChangedRefreshTimers.set(
 			key,
@@ -934,9 +945,9 @@ export class McpHub {
 				// and let a stale response overwrite a newer list.
 				const previous = this.listChangedRefreshInFlight.get(key) ?? Promise.resolve()
 				const run = previous
-					.then(() => this.refreshChangedList(serverName, kind))
+					.then(() => this.refreshChangedList(serverName, kind, superseded))
 					.then((outcome) => {
-						if (outcome === "failed" && retryAttempt < LIST_CHANGED_MAX_RETRIES) {
+						if (outcome === "failed" && retryAttempt < LIST_CHANGED_MAX_RETRIES && !superseded()) {
 							this.scheduleListChangedRefresh(serverName, kind, retryAttempt + 1)
 						}
 					})
@@ -955,18 +966,22 @@ export class McpHub {
 
 	/**
 	 * Refreshes the given cached list. Returns "failed" when a fetch failed
-	 * (the caller retries), "skipped" when the connection is gone or was
-	 * replaced (no retry: a replacement fetched fresh lists at connect time),
-	 * and "refreshed" on success.
+	 * (the caller retries), "skipped" when the refresh was superseded or the
+	 * connection is gone or was replaced (no retry: a newer refresh or the
+	 * replacement connection's connect-time fetch covers it), and "refreshed"
+	 * on success.
 	 */
 	private async refreshChangedList(
 		serverName: string,
 		kind: "tools" | "resources" | "prompts",
+		superseded: () => boolean,
 	): Promise<"refreshed" | "failed" | "skipped"> {
 		// Look the connection up fresh: it may have been deleted (or replaced
-		// by a reconnect) while the debounce timer was pending.
+		// by a reconnect) while the debounce timer was pending. A superseded
+		// run (a newer notification re-scheduled this key) skips the fetch
+		// outright — the newer refresh will fetch fresher data.
 		const connection = this.connections.find((conn) => conn.server.name === serverName)
-		if (!connection || connection.server.disabled || !connection.client) {
+		if (!connection || connection.server.disabled || !connection.client || superseded()) {
 			return "skipped"
 		}
 
@@ -1003,13 +1018,14 @@ export class McpHub {
 				break
 		}
 
-		// The connection may have been deleted or replaced by a reconnect
-		// while the fetches were in flight. Drop the result in that case: a
-		// replacement connection fetched fresh lists when it connected, after
-		// the change that produced this notification, so writing this (older)
-		// result to it could overwrite newer data.
+		// The connection may have been deleted or replaced by a reconnect, or
+		// this refresh superseded by a newer notification, while the fetches
+		// were in flight. Drop the result in either case: a replacement
+		// connection fetched fresh lists when it connected, and a superseding
+		// refresh will fetch fresher data — publishing this (older) result
+		// would briefly expose an obsolete list.
 		const current = this.connections.find((conn) => conn.server.name === serverName)
-		if (current !== connection) {
+		if (current !== connection || superseded()) {
 			return "skipped"
 		}
 
@@ -2060,6 +2076,7 @@ export class McpHub {
 			clearTimeout(timer)
 		}
 		this.listChangedRefreshTimers.clear()
+		this.listChangedRefreshGeneration.clear()
 		this.removeAllFileWatchers()
 		for (const connection of this.connections) {
 			try {

--- a/apps/vscode/src/services/mcp/StreamableHttpReconnectHandler.ts
+++ b/apps/vscode/src/services/mcp/StreamableHttpReconnectHandler.ts
@@ -6,7 +6,7 @@ import { Logger } from "@/shared/services/Logger"
  */
 export interface ReconnectCallbacks {
 	/** Returns the current connection object, or undefined if it no longer exists */
-	findConnection: () => { server: { status: string; disabled?: boolean } } | undefined
+	findConnection: () => { server: { status: string; disabled?: boolean }; client?: unknown } | undefined
 	/** Tears down the existing connection */
 	deleteConnection: () => Promise<void>
 	/** Establishes a new connection */
@@ -167,9 +167,13 @@ export class StreamableHttpReconnectHandler {
 			// transport) or resurrect a server the user removed. Our own
 			// original connection and the "disconnected" husk left behind by
 			// our own failed connectToServer() attempt are not replacements —
-			// keep retrying past those.
+			// keep retrying past those. The husk is recognized by having no
+			// client (its creation sites set client: null); a "disconnected"
+			// connection that HOLDS a client is an OAuth-required replacement
+			// retaining its client/transport/authProvider for authentication,
+			// and displacing it would orphan that session.
 			const existing = this.callbacks.findConnection()
-			if (existing && existing !== connection && existing.server.status !== "disconnected") {
+			if (existing && existing !== connection && (existing.server.status !== "disconnected" || existing.client != null)) {
 				Logger.log(
 					`StreamableHTTP reconnect aborted for "${this.serverName}": ` +
 						`another path installed a replacement connection (status: ${existing.server.status})`,

--- a/apps/vscode/src/services/mcp/StreamableHttpReconnectHandler.ts
+++ b/apps/vscode/src/services/mcp/StreamableHttpReconnectHandler.ts
@@ -126,13 +126,6 @@ export class StreamableHttpReconnectHandler {
 		while (this.attempts <= this.config.maxAttempts) {
 			try {
 				await this.callbacks.connectToServer()
-				Logger.log(`StreamableHTTP reconnect succeeded for "${this.serverName}"`)
-				this.attempts = 0
-				// connectToServer() loads fresh lists but doesn't publish them;
-				// without this, the webview keeps showing "connecting" and
-				// consumers keep the pre-reconnect capabilities.
-				await this.callbacks.notifyWebviewOfServerChanges()
-				return
 			} catch (reconnectError) {
 				Logger.error(`StreamableHTTP reconnect failed for "${this.serverName}":`, reconnectError)
 				if (this.attempts < this.config.maxAttempts) {
@@ -143,10 +136,24 @@ export class StreamableHttpReconnectHandler {
 							`for "${this.serverName}" in ${retryDelay / 1000}s...`,
 					)
 					await this.callbacks.delay(retryDelay)
-				} else {
-					break
+					continue
 				}
+				break
 			}
+
+			Logger.log(`StreamableHTTP reconnect succeeded for "${this.serverName}"`)
+			this.attempts = 0
+			// connectToServer() loads fresh lists but doesn't publish them;
+			// without this, the webview keeps showing "connecting" and
+			// consumers keep the pre-reconnect capabilities. Kept outside the
+			// connect try/catch: a publication failure must not be treated as
+			// a transport failure and restart the already-live connection.
+			try {
+				await this.callbacks.notifyWebviewOfServerChanges()
+			} catch (notifyError) {
+				Logger.error(`Failed to publish server state after reconnect for "${this.serverName}":`, notifyError)
+			}
+			return
 		}
 
 		// All retry attempts exhausted during the connect loop.

--- a/apps/vscode/src/services/mcp/StreamableHttpReconnectHandler.ts
+++ b/apps/vscode/src/services/mcp/StreamableHttpReconnectHandler.ts
@@ -17,6 +17,14 @@ export interface ReconnectCallbacks {
 	appendErrorMessage: (connection: { server: { status: string } }, message: string) => void
 	/** Awaitable delay — injected so tests can substitute a zero-delay or fake timer */
 	delay: (ms: number) => Promise<void>
+	/**
+	 * Reads current settings fresh and returns whether this server is still
+	 * configured and enabled. Checked before every reconnect attempt so a
+	 * retry can't resurrect a server the user removed or disabled during a
+	 * backoff delay. Should return true when settings can't be read — a
+	 * transient read failure must not kill the reconnect chain.
+	 */
+	isStillWanted: () => Promise<boolean>
 }
 
 /**
@@ -151,6 +159,28 @@ export class StreamableHttpReconnectHandler {
 		await this.callbacks.deleteConnection()
 
 		while (this.attempts <= this.config.maxAttempts) {
+			// Revalidate before every attempt: during the preceding await
+			// (teardown or a backoff delay) another path — the settings
+			// watcher, an RPC — may have installed a replacement connection,
+			// or settings may have removed/disabled the server. Proceeding
+			// would displace the replacement without closing it (leaking its
+			// transport) or resurrect a server the user removed. Our own
+			// original connection and the "disconnected" husk left behind by
+			// our own failed connectToServer() attempt are not replacements —
+			// keep retrying past those.
+			const existing = this.callbacks.findConnection()
+			if (existing && existing !== connection && existing.server.status !== "disconnected") {
+				Logger.log(
+					`StreamableHTTP reconnect aborted for "${this.serverName}": ` +
+						`another path installed a replacement connection (status: ${existing.server.status})`,
+				)
+				return
+			}
+			if (!(await this.callbacks.isStillWanted())) {
+				Logger.log(`StreamableHTTP reconnect aborted for "${this.serverName}": server no longer configured or disabled`)
+				return
+			}
+
 			try {
 				await this.callbacks.connectToServer()
 			} catch (reconnectError) {

--- a/apps/vscode/src/services/mcp/StreamableHttpReconnectHandler.ts
+++ b/apps/vscode/src/services/mcp/StreamableHttpReconnectHandler.ts
@@ -35,6 +35,10 @@ export const DEFAULT_RECONNECT_CONFIG: ReconnectConfig = {
 	getDelayMs: (attempt: number) => 2000 * 2 ** attempt,
 }
 
+/** Attempts/delay for publishing server state after a successful reconnect. */
+const PUBLISH_ATTEMPTS = 3
+const PUBLISH_RETRY_DELAY_MS = 1000
+
 /**
  * Manages reconnection logic for a single StreamableHTTP MCP transport.
  *
@@ -70,6 +74,27 @@ export class StreamableHttpReconnectHandler {
 	}
 
 	/**
+	 * Publish server state to the webview, retrying transient failures up to
+	 * `attempts` times. Never throws: handleError runs from transport.onerror
+	 * with its promise discarded, so a rejection here would surface as an
+	 * unhandled rejection — and a publication failure must never be confused
+	 * with a transport failure.
+	 */
+	private async publishServerChanges(attempts = 1): Promise<void> {
+		for (let attempt = 1; attempt <= attempts; attempt++) {
+			try {
+				await this.callbacks.notifyWebviewOfServerChanges()
+				return
+			} catch (error) {
+				Logger.error(`Failed to publish server state for "${this.serverName}" (attempt ${attempt}/${attempts}):`, error)
+				if (attempt < attempts) {
+					await this.callbacks.delay(PUBLISH_RETRY_DELAY_MS)
+				}
+			}
+		}
+	}
+
+	/**
 	 * Handle a transport error. Call this from `transport.onerror`.
 	 */
 	async handleError(error: unknown): Promise<void> {
@@ -93,7 +118,9 @@ export class StreamableHttpReconnectHandler {
 			)
 			connection.server.status = "disconnected"
 			this.callbacks.appendErrorMessage(connection, error instanceof Error ? error.message : `${error}`)
-			await this.callbacks.notifyWebviewOfServerChanges()
+			// Terminal state: no further publish will come from this handler,
+			// so retry rather than risk leaving consumers on "connecting"
+			await this.publishServerChanges(PUBLISH_ATTEMPTS)
 			return
 		}
 
@@ -107,7 +134,7 @@ export class StreamableHttpReconnectHandler {
 		)
 
 		connection.server.status = "connecting"
-		await this.callbacks.notifyWebviewOfServerChanges()
+		await this.publishServerChanges()
 
 		await this.callbacks.delay(initialDelay)
 
@@ -146,13 +173,11 @@ export class StreamableHttpReconnectHandler {
 			// connectToServer() loads fresh lists but doesn't publish them;
 			// without this, the webview keeps showing "connecting" and
 			// consumers keep the pre-reconnect capabilities. Kept outside the
-			// connect try/catch: a publication failure must not be treated as
-			// a transport failure and restart the already-live connection.
-			try {
-				await this.callbacks.notifyWebviewOfServerChanges()
-			} catch (notifyError) {
-				Logger.error(`Failed to publish server state after reconnect for "${this.serverName}":`, notifyError)
-			}
+			// connect try/catch — a publication failure must not be treated
+			// as a transport failure and restart the already-live connection —
+			// and retried so a transient failure doesn't leave consumers
+			// stuck on "connecting" with pre-reconnect capabilities.
+			await this.publishServerChanges(PUBLISH_ATTEMPTS)
 			return
 		}
 
@@ -167,6 +192,7 @@ export class StreamableHttpReconnectHandler {
 			exhaustedConnection.server.status = "disconnected"
 			this.callbacks.appendErrorMessage(exhaustedConnection, error instanceof Error ? error.message : `${error}`)
 		}
-		await this.callbacks.notifyWebviewOfServerChanges()
+		// Terminal state — same rationale as the early-exhausted path above
+		await this.publishServerChanges(PUBLISH_ATTEMPTS)
 	}
 }

--- a/apps/vscode/src/services/mcp/StreamableHttpReconnectHandler.ts
+++ b/apps/vscode/src/services/mcp/StreamableHttpReconnectHandler.ts
@@ -6,7 +6,7 @@ import { Logger } from "@/shared/services/Logger"
  */
 export interface ReconnectCallbacks {
 	/** Returns the current connection object, or undefined if it no longer exists */
-	findConnection: () => { server: { status: string; disabled?: boolean }; client?: unknown } | undefined
+	findConnection: () => { server: { status: string; disabled?: boolean; oauthRequired?: boolean } } | undefined
 	/** Tears down the existing connection */
 	deleteConnection: () => Promise<void>
 	/** Establishes a new connection */
@@ -164,16 +164,17 @@ export class StreamableHttpReconnectHandler {
 			// watcher, an RPC — may have installed a replacement connection,
 			// or settings may have removed/disabled the server. Proceeding
 			// would displace the replacement without closing it (leaking its
-			// transport) or resurrect a server the user removed. Our own
-			// original connection and the "disconnected" husk left behind by
-			// our own failed connectToServer() attempt are not replacements —
-			// keep retrying past those. The husk is recognized by having no
-			// client (its creation sites set client: null); a "disconnected"
-			// connection that HOLDS a client is an OAuth-required replacement
-			// retaining its client/transport/authProvider for authentication,
+			// transport) or resurrect a server the user removed. Ordinary
+			// "disconnected" connections are NOT replacements: a failed
+			// connectToServer() (our own retry or another path's attempt)
+			// leaves one behind with its client already closed, so retrying
+			// past it displaces nothing live. The exception is an
+			// OAuth-required connection (oauthRequired: true): it is also
+			// "disconnected" but deliberately retains a live
+			// client/transport/authProvider for when the user authenticates,
 			// and displacing it would orphan that session.
 			const existing = this.callbacks.findConnection()
-			if (existing && existing !== connection && (existing.server.status !== "disconnected" || existing.client != null)) {
+			if (existing && existing !== connection && (existing.server.status !== "disconnected" || existing.server.oauthRequired)) {
 				Logger.log(
 					`StreamableHTTP reconnect aborted for "${this.serverName}": ` +
 						`another path installed a replacement connection (status: ${existing.server.status})`,

--- a/apps/vscode/src/services/mcp/StreamableHttpReconnectHandler.ts
+++ b/apps/vscode/src/services/mcp/StreamableHttpReconnectHandler.ts
@@ -128,6 +128,10 @@ export class StreamableHttpReconnectHandler {
 				await this.callbacks.connectToServer()
 				Logger.log(`StreamableHTTP reconnect succeeded for "${this.serverName}"`)
 				this.attempts = 0
+				// connectToServer() loads fresh lists but doesn't publish them;
+				// without this, the webview keeps showing "connecting" and
+				// consumers keep the pre-reconnect capabilities.
+				await this.callbacks.notifyWebviewOfServerChanges()
 				return
 			} catch (reconnectError) {
 				Logger.error(`StreamableHTTP reconnect failed for "${this.serverName}":`, reconnectError)

--- a/apps/vscode/src/services/mcp/StreamableHttpReconnectHandler.ts
+++ b/apps/vscode/src/services/mcp/StreamableHttpReconnectHandler.ts
@@ -19,10 +19,13 @@ export interface ReconnectCallbacks {
 	delay: (ms: number) => Promise<void>
 	/**
 	 * Reads current settings fresh and returns whether this server is still
-	 * configured and enabled. Checked before every reconnect attempt so a
-	 * retry can't resurrect a server the user removed or disabled during a
-	 * backoff delay. Should return true when settings can't be read — a
-	 * transient read failure must not kill the reconnect chain.
+	 * configured, enabled, and defined with the same connection-relevant
+	 * config this handler's connectToServer callback would reconnect with.
+	 * Checked before every reconnect attempt so a retry can't resurrect a
+	 * server the user removed or disabled — or an obsolete config the user
+	 * changed — during a backoff delay. Should return true when settings
+	 * can't be read: a transient read failure must not kill the reconnect
+	 * chain.
 	 */
 	isStillWanted: () => Promise<boolean>
 }

--- a/apps/vscode/src/services/mcp/StreamableHttpReconnectHandler.ts
+++ b/apps/vscode/src/services/mcp/StreamableHttpReconnectHandler.ts
@@ -131,6 +131,10 @@ export class StreamableHttpReconnectHandler {
 				await this.callbacks.connectToServer()
 				Logger.log(`StreamableHTTP reconnect succeeded for "${this.serverName}"`)
 				this.attempts = 0
+				// connectToServer() loads fresh lists but doesn't publish them;
+				// without this, the webview keeps showing "connecting" and
+				// consumers keep the pre-reconnect capabilities.
+				await this.callbacks.notifyWebviewOfServerChanges()
 				return
 			} catch (reconnectError) {
 				Logger.error(`StreamableHTTP reconnect failed for "${this.serverName}":`, reconnectError)

--- a/apps/vscode/src/services/mcp/StreamableHttpReconnectHandler.ts
+++ b/apps/vscode/src/services/mcp/StreamableHttpReconnectHandler.ts
@@ -37,6 +37,10 @@ export const DEFAULT_RECONNECT_CONFIG: ReconnectConfig = {
 	getDelayMs: (attempt: number) => 2000 * 2 ** attempt,
 }
 
+/** Attempts/delay for publishing server state after a successful reconnect. */
+const PUBLISH_ATTEMPTS = 3
+const PUBLISH_RETRY_DELAY_MS = 1000
+
 /**
  * Manages reconnection logic for a single StreamableHTTP MCP transport.
  *
@@ -72,6 +76,27 @@ export class StreamableHttpReconnectHandler {
 	}
 
 	/**
+	 * Publish server state to the webview, retrying transient failures up to
+	 * `attempts` times. Never throws: handleError runs from transport.onerror
+	 * with its promise discarded, so a rejection here would surface as an
+	 * unhandled rejection — and a publication failure must never be confused
+	 * with a transport failure.
+	 */
+	private async publishServerChanges(attempts = 1): Promise<void> {
+		for (let attempt = 1; attempt <= attempts; attempt++) {
+			try {
+				await this.callbacks.notifyWebviewOfServerChanges()
+				return
+			} catch (error) {
+				Logger.error(`Failed to publish server state for "${this.serverName}" (attempt ${attempt}/${attempts}):`, error)
+				if (attempt < attempts) {
+					await this.callbacks.delay(PUBLISH_RETRY_DELAY_MS)
+				}
+			}
+		}
+	}
+
+	/**
 	 * Handle a transport error. Call this from `transport.onerror`.
 	 */
 	async handleError(error: unknown): Promise<void> {
@@ -96,7 +121,9 @@ export class StreamableHttpReconnectHandler {
 			connection.server.status = "disconnected"
 			this.callbacks.deleteServerKey(connection.server.uid || this.serverName)
 			this.callbacks.appendErrorMessage(connection, error instanceof Error ? error.message : `${error}`)
-			await this.callbacks.notifyWebviewOfServerChanges()
+			// Terminal state: no further publish will come from this handler,
+			// so retry rather than risk leaving consumers on "connecting"
+			await this.publishServerChanges(PUBLISH_ATTEMPTS)
 			return
 		}
 
@@ -110,7 +137,7 @@ export class StreamableHttpReconnectHandler {
 		)
 
 		connection.server.status = "connecting"
-		await this.callbacks.notifyWebviewOfServerChanges()
+		await this.publishServerChanges()
 
 		await this.callbacks.delay(initialDelay)
 
@@ -149,13 +176,11 @@ export class StreamableHttpReconnectHandler {
 			// connectToServer() loads fresh lists but doesn't publish them;
 			// without this, the webview keeps showing "connecting" and
 			// consumers keep the pre-reconnect capabilities. Kept outside the
-			// connect try/catch: a publication failure must not be treated as
-			// a transport failure and restart the already-live connection.
-			try {
-				await this.callbacks.notifyWebviewOfServerChanges()
-			} catch (notifyError) {
-				Logger.error(`Failed to publish server state after reconnect for "${this.serverName}":`, notifyError)
-			}
+			// connect try/catch — a publication failure must not be treated
+			// as a transport failure and restart the already-live connection —
+			// and retried so a transient failure doesn't leave consumers
+			// stuck on "connecting" with pre-reconnect capabilities.
+			await this.publishServerChanges(PUBLISH_ATTEMPTS)
 			return
 		}
 
@@ -171,6 +196,7 @@ export class StreamableHttpReconnectHandler {
 			this.callbacks.deleteServerKey(exhaustedConnection.server.uid || this.serverName)
 			this.callbacks.appendErrorMessage(exhaustedConnection, error instanceof Error ? error.message : `${error}`)
 		}
-		await this.callbacks.notifyWebviewOfServerChanges()
+		// Terminal state — same rationale as the early-exhausted path above
+		await this.publishServerChanges(PUBLISH_ATTEMPTS)
 	}
 }

--- a/apps/vscode/src/services/mcp/StreamableHttpReconnectHandler.ts
+++ b/apps/vscode/src/services/mcp/StreamableHttpReconnectHandler.ts
@@ -129,13 +129,6 @@ export class StreamableHttpReconnectHandler {
 		while (this.attempts <= this.config.maxAttempts) {
 			try {
 				await this.callbacks.connectToServer()
-				Logger.log(`StreamableHTTP reconnect succeeded for "${this.serverName}"`)
-				this.attempts = 0
-				// connectToServer() loads fresh lists but doesn't publish them;
-				// without this, the webview keeps showing "connecting" and
-				// consumers keep the pre-reconnect capabilities.
-				await this.callbacks.notifyWebviewOfServerChanges()
-				return
 			} catch (reconnectError) {
 				Logger.error(`StreamableHTTP reconnect failed for "${this.serverName}":`, reconnectError)
 				if (this.attempts < this.config.maxAttempts) {
@@ -146,10 +139,24 @@ export class StreamableHttpReconnectHandler {
 							`for "${this.serverName}" in ${retryDelay / 1000}s...`,
 					)
 					await this.callbacks.delay(retryDelay)
-				} else {
-					break
+					continue
 				}
+				break
 			}
+
+			Logger.log(`StreamableHTTP reconnect succeeded for "${this.serverName}"`)
+			this.attempts = 0
+			// connectToServer() loads fresh lists but doesn't publish them;
+			// without this, the webview keeps showing "connecting" and
+			// consumers keep the pre-reconnect capabilities. Kept outside the
+			// connect try/catch: a publication failure must not be treated as
+			// a transport failure and restart the already-live connection.
+			try {
+				await this.callbacks.notifyWebviewOfServerChanges()
+			} catch (notifyError) {
+				Logger.error(`Failed to publish server state after reconnect for "${this.serverName}":`, notifyError)
+			}
+			return
 		}
 
 		// All retry attempts exhausted during the connect loop.

--- a/apps/vscode/src/services/mcp/__tests__/McpHub.listChangedRefresh.test.ts
+++ b/apps/vscode/src/services/mcp/__tests__/McpHub.listChangedRefresh.test.ts
@@ -239,4 +239,55 @@ describe("McpHub list_changed notification refresh", () => {
 		replacement.server.tools.should.deepEqual([{ name: "fresh-from-connect" }])
 		notifyWebviewOfServerChanges.called.should.be.false()
 	})
+
+	it("retries a failed refresh with backoff and applies the eventual result", async () => {
+		const { hub, connection, fetchToolsList, notifyWebviewOfServerChanges } = createMcpHub()
+		connection.server.tools = [{ name: "existing" }]
+		fetchToolsList.onFirstCall().resolves(undefined)
+		fetchToolsList.onSecondCall().resolves([{ name: "tool1" }])
+		;(hub as any).scheduleListChangedRefresh("test-server", "tools")
+
+		await clock.tickAsync(300)
+		fetchToolsList.calledOnce.should.be.true()
+		connection.server.tools.should.deepEqual([{ name: "existing" }])
+
+		// First retry fires after the 1s backoff and succeeds
+		await clock.tickAsync(1000)
+		fetchToolsList.calledTwice.should.be.true()
+		connection.server.tools.should.deepEqual([{ name: "tool1" }])
+		notifyWebviewOfServerChanges.calledOnce.should.be.true()
+	})
+
+	it("stops retrying after the retry budget is exhausted", async () => {
+		const { hub, fetchToolsList, notifyWebviewOfServerChanges } = createMcpHub()
+		fetchToolsList.resolves(undefined)
+		;(hub as any).scheduleListChangedRefresh("test-server", "tools")
+
+		// Initial attempt plus 3 retries at 1s/2s/4s backoff, then nothing more
+		await clock.tickAsync(300)
+		await clock.tickAsync(1000)
+		await clock.tickAsync(2000)
+		await clock.tickAsync(4000)
+		await clock.tickAsync(60000)
+
+		fetchToolsList.callCount.should.equal(4)
+		notifyWebviewOfServerChanges.called.should.be.false()
+	})
+
+	it("lets a fresh notification supersede a pending retry", async () => {
+		const { hub, connection, fetchToolsList } = createMcpHub()
+		fetchToolsList.onFirstCall().resolves(undefined)
+		fetchToolsList.onSecondCall().resolves([{ name: "tool1" }])
+		;(hub as any).scheduleListChangedRefresh("test-server", "tools")
+		await clock.tickAsync(300)
+		fetchToolsList.calledOnce.should.be.true()
+
+		// New notification arrives while the 1s retry is pending: it replaces
+		// the retry timer and runs on the normal debounce delay instead
+		;(hub as any).scheduleListChangedRefresh("test-server", "tools")
+		await clock.tickAsync(300)
+
+		fetchToolsList.calledTwice.should.be.true()
+		connection.server.tools.should.deepEqual([{ name: "tool1" }])
+	})
 })

--- a/apps/vscode/src/services/mcp/__tests__/McpHub.listChangedRefresh.test.ts
+++ b/apps/vscode/src/services/mcp/__tests__/McpHub.listChangedRefresh.test.ts
@@ -38,6 +38,7 @@ function createMcpHub(serverName = "test-server", options: { disabled?: boolean 
 	;(hub as any).connections = [connection]
 	;(hub as any).listChangedRefreshTimers = new Map()
 	;(hub as any).listChangedRefreshInFlight = new Map()
+	;(hub as any).listChangedRefreshGeneration = new Map()
 
 	const fetchToolsList = sinon.stub().resolves([{ name: "tool1" }])
 	const fetchResourcesList = sinon.stub().resolves([{ name: "resource1" }])
@@ -238,6 +239,37 @@ describe("McpHub list_changed notification refresh", () => {
 		// The in-flight result must not overwrite the replacement's newer data
 		replacement.server.tools.should.deepEqual([{ name: "fresh-from-connect" }])
 		notifyWebviewOfServerChanges.called.should.be.false()
+	})
+
+	it("does not publish the result of an in-flight refresh superseded by a newer notification", async () => {
+		const { hub, connection, fetchToolsList, notifyWebviewOfServerChanges } = createMcpHub()
+		let resolveFirstFetch: (tools: Array<{ name: string }>) => void = () => {}
+		fetchToolsList.onFirstCall().returns(
+			new Promise((resolve) => {
+				resolveFirstFetch = resolve
+			}),
+		)
+		fetchToolsList.onSecondCall().resolves([{ name: "fresh" }])
+
+		// First refresh fires and its fetch hangs in flight
+		;(hub as any).scheduleListChangedRefresh("test-server", "tools")
+		await clock.tickAsync(300)
+		fetchToolsList.calledOnce.should.be.true()
+
+		// A newer notification supersedes the in-flight refresh
+		;(hub as any).scheduleListChangedRefresh("test-server", "tools")
+		resolveFirstFetch([{ name: "stale" }])
+		await clock.tickAsync(0)
+		await clock.tickAsync(0)
+
+		// The superseded run completed but must not publish its stale result
+		connection.server.tools.should.deepEqual([])
+		notifyWebviewOfServerChanges.called.should.be.false()
+
+		// The superseding refresh publishes the fresh result
+		await clock.tickAsync(300)
+		connection.server.tools.should.deepEqual([{ name: "fresh" }])
+		notifyWebviewOfServerChanges.calledOnce.should.be.true()
 	})
 
 	it("retries a failed refresh with backoff and applies the eventual result", async () => {

--- a/apps/vscode/src/services/mcp/__tests__/McpHub.listChangedRefresh.test.ts
+++ b/apps/vscode/src/services/mcp/__tests__/McpHub.listChangedRefresh.test.ts
@@ -378,6 +378,48 @@ describe("McpHub list_changed notification refresh", () => {
 		fetchToolsList.called.should.be.true()
 	})
 
+	it("supersedes an in-flight refresh during connection teardown", async () => {
+		const { hub, connection, fetchToolsList, notifyWebviewOfServerChanges } = createMcpHub()
+		let resolveFetch: (tools: Array<{ name: string }>) => void = () => {}
+		fetchToolsList.returns(
+			new Promise((resolve) => {
+				resolveFetch = resolve
+			}),
+		)
+		let resolveClose: () => void = () => {}
+		;(connection as any).transport = {
+			close: sinon.stub().returns(
+				new Promise<void>((resolve) => {
+					resolveClose = resolve
+				}),
+			),
+		}
+		;(connection as any).client = { close: sinon.stub().resolves() }
+
+		// Refresh fires and its fetch hangs in flight
+		;(hub as any).scheduleListChangedRefresh("test-server", "tools")
+		await clock.tickAsync(300)
+		fetchToolsList.calledOnce.should.be.true()
+
+		// deleteConnection starts and blocks awaiting transport.close(); the
+		// connection is still in this.connections during that window
+		const deletion = hub.deleteConnection("test-server")
+		await clock.tickAsync(0)
+		;(hub as any).connections.length.should.equal(1)
+
+		// The fetch completes inside the teardown window: its result must be
+		// dropped, not published against the connection being torn down
+		resolveFetch([{ name: "stale" }])
+		await clock.tickAsync(0)
+		await clock.tickAsync(0)
+		connection.server.tools.should.deepEqual([])
+		notifyWebviewOfServerChanges.called.should.be.false()
+
+		resolveClose()
+		await deletion
+		;(hub as any).connections.length.should.equal(0)
+	})
+
 	it("cancels pending refreshes when the connection is deleted", async () => {
 		const { hub, connection, fetchToolsList } = createMcpHub()
 		;(connection as any).transport = { close: sinon.stub().resolves() }

--- a/apps/vscode/src/services/mcp/__tests__/McpHub.listChangedRefresh.test.ts
+++ b/apps/vscode/src/services/mcp/__tests__/McpHub.listChangedRefresh.test.ts
@@ -209,4 +209,34 @@ describe("McpHub list_changed notification refresh", () => {
 		fetchToolsList.calledTwice.should.be.true()
 		connection.server.tools.should.deepEqual([{ name: "newer" }])
 	})
+
+	it("drops the refresh when the connection was replaced by a reconnect mid-fetch", async () => {
+		const { hub, connection, fetchToolsList, notifyWebviewOfServerChanges } = createMcpHub()
+		let resolveFetch: (tools: Array<{ name: string }>) => void = () => {}
+		fetchToolsList.returns(
+			new Promise((resolve) => {
+				resolveFetch = resolve
+			}),
+		)
+		;(hub as any).scheduleListChangedRefresh("test-server", "tools")
+		await clock.tickAsync(300)
+		fetchToolsList.calledOnce.should.be.true()
+
+		// Simulate a reconnect while the fetch is in flight: the connection
+		// object is replaced by a new one that fetched fresh lists at connect
+		const replacement = {
+			server: { ...connection.server, tools: [{ name: "fresh-from-connect" }] },
+			client: {},
+			transport: {},
+		}
+		;(hub as any).connections = [replacement]
+
+		resolveFetch([{ name: "stale-from-old-connection" }])
+		await clock.tickAsync(0)
+		await clock.tickAsync(0)
+
+		// The in-flight result must not overwrite the replacement's newer data
+		replacement.server.tools.should.deepEqual([{ name: "fresh-from-connect" }])
+		notifyWebviewOfServerChanges.called.should.be.false()
+	})
 })

--- a/apps/vscode/src/services/mcp/__tests__/McpHub.listChangedRefresh.test.ts
+++ b/apps/vscode/src/services/mcp/__tests__/McpHub.listChangedRefresh.test.ts
@@ -402,10 +402,10 @@ describe("McpHub list_changed notification refresh", () => {
 		fetchToolsList.calledOnce.should.be.true()
 
 		// deleteConnection starts and blocks awaiting transport.close(); the
-		// connection is still in this.connections during that window
+		// connection must already be gone from published state in that window
 		const deletion = hub.deleteConnection("test-server")
 		await clock.tickAsync(0)
-		;(hub as any).connections.length.should.equal(1)
+		;(hub as any).connections.length.should.equal(0)
 
 		// The fetch completes inside the teardown window: its result must be
 		// dropped, not published against the connection being torn down

--- a/apps/vscode/src/services/mcp/__tests__/McpHub.listChangedRefresh.test.ts
+++ b/apps/vscode/src/services/mcp/__tests__/McpHub.listChangedRefresh.test.ts
@@ -37,6 +37,7 @@ function createMcpHub(serverName = "test-server", options: { disabled?: boolean 
 	const hub = Object.create(McpHub.prototype) as McpHub
 	;(hub as any).connections = [connection]
 	;(hub as any).listChangedRefreshTimers = new Map()
+	;(hub as any).listChangedRefreshInFlight = new Map()
 
 	const fetchToolsList = sinon.stub().resolves([{ name: "tool1" }])
 	const fetchResourcesList = sinon.stub().resolves([{ name: "resource1" }])
@@ -153,5 +154,59 @@ describe("McpHub list_changed notification refresh", () => {
 
 		// Would surface as an unhandled rejection if the error weren't caught
 		await clock.tickAsync(300)
+	})
+
+	it("keeps the previous cached list when the fetch fails", async () => {
+		const { hub, connection, fetchToolsList, notifyWebviewOfServerChanges } = createMcpHub()
+		connection.server.tools = [{ name: "existing" }]
+		// The fetch helpers signal failure by resolving to undefined
+		fetchToolsList.resolves(undefined)
+		;(hub as any).scheduleListChangedRefresh("test-server", "tools")
+		await clock.tickAsync(300)
+
+		connection.server.tools.should.deepEqual([{ name: "existing" }])
+		notifyWebviewOfServerChanges.called.should.be.false()
+	})
+
+	it("applies the successful half of a resources refresh when the other half fails", async () => {
+		const { hub, connection, fetchResourcesList, fetchResourceTemplatesList, notifyWebviewOfServerChanges } = createMcpHub()
+		connection.server.resources = [{ name: "existing-resource" }]
+		fetchResourcesList.resolves(undefined)
+		fetchResourceTemplatesList.resolves([{ name: "template1" }])
+		;(hub as any).scheduleListChangedRefresh("test-server", "resources")
+		await clock.tickAsync(300)
+
+		connection.server.resources.should.deepEqual([{ name: "existing-resource" }])
+		connection.server.resourceTemplates.should.deepEqual([{ name: "template1" }])
+		notifyWebviewOfServerChanges.calledOnce.should.be.true()
+	})
+
+	it("serializes overlapping refreshes so a stale response cannot overwrite a newer one", async () => {
+		const { hub, connection, fetchToolsList } = createMcpHub()
+		let resolveFirstFetch: (tools: Array<{ name: string }>) => void = () => {}
+		fetchToolsList.onFirstCall().returns(
+			new Promise((resolve) => {
+				resolveFirstFetch = resolve
+			}),
+		)
+		fetchToolsList.onSecondCall().resolves([{ name: "newer" }])
+
+		// First refresh fires and its fetch hangs in flight
+		;(hub as any).scheduleListChangedRefresh("test-server", "tools")
+		await clock.tickAsync(300)
+		fetchToolsList.calledOnce.should.be.true()
+
+		// Second notification arrives while the first fetch is still pending:
+		// its refresh must wait for the first to finish, not run concurrently
+		;(hub as any).scheduleListChangedRefresh("test-server", "tools")
+		await clock.tickAsync(300)
+		fetchToolsList.calledOnce.should.be.true()
+
+		resolveFirstFetch([{ name: "older" }])
+		await clock.tickAsync(0)
+		await clock.tickAsync(0)
+
+		fetchToolsList.calledTwice.should.be.true()
+		connection.server.tools.should.deepEqual([{ name: "newer" }])
 	})
 })

--- a/apps/vscode/src/services/mcp/__tests__/McpHub.listChangedRefresh.test.ts
+++ b/apps/vscode/src/services/mcp/__tests__/McpHub.listChangedRefresh.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, it } from "bun:test"
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js"
 import "should"
 import sinon from "sinon"
 import { McpHub } from "../McpHub"
@@ -39,6 +40,7 @@ function createMcpHub(serverName = "test-server", options: { disabled?: boolean 
 	;(hub as any).listChangedRefreshTimers = new Map()
 	;(hub as any).listChangedRefreshInFlight = new Map()
 	;(hub as any).listChangedRefreshGeneration = new Map()
+	;(hub as any).listChangedRefreshDeadlines = new Map()
 
 	const fetchToolsList = sinon.stub().resolves([{ name: "tool1" }])
 	const fetchResourcesList = sinon.stub().resolves([{ name: "resource1" }])
@@ -272,6 +274,47 @@ describe("McpHub list_changed notification refresh", () => {
 		notifyWebviewOfServerChanges.calledOnce.should.be.true()
 	})
 
+	it("treats method-not-found and undeclared capabilities as authoritatively empty lists", async () => {
+		// Exercises the real fetch helpers (not the stubbed ones) with a fake
+		// client: a permanent "this server doesn't do that" answer must come
+		// back as [] — publishable, no retry — not as a failure (undefined)
+		const makeHubWithClient = (client: any) => {
+			const hub = Object.create(McpHub.prototype) as McpHub
+			;(hub as any).connections = [
+				{
+					server: { name: "test-server", config: "{}", status: "connected", disabled: false },
+					client,
+					transport: {},
+				},
+			]
+			return hub
+		}
+
+		// Server declares the resources capability but doesn't implement
+		// resources/templates/list
+		const methodNotFound = makeHubWithClient({
+			getServerCapabilities: () => ({ resources: {} }),
+			request: sinon.stub().rejects(new McpError(ErrorCode.MethodNotFound, "Method not found")),
+		})
+		;((await (methodNotFound as any).fetchResourceTemplatesList("test-server")) as any).should.deepEqual([])
+
+		// Server never declared the prompts capability: no request is made
+		const noCapability = makeHubWithClient({
+			getServerCapabilities: () => ({ tools: {} }),
+			request: sinon.stub().rejects(new Error("should not be called")),
+		})
+		;((await (noCapability as any).fetchPromptsList("test-server")) as any).should.deepEqual([])
+		noCapability.connections[0].client &&
+			(noCapability.connections[0].client as any).request.called.should.be.false()
+
+		// A transient error is still a failure (undefined), not an empty list
+		const transient = makeHubWithClient({
+			getServerCapabilities: () => ({ resources: {} }),
+			request: sinon.stub().rejects(new Error("timeout")),
+		})
+		;((await (transient as any).fetchResourcesList("test-server")) === undefined).should.be.true()
+	})
+
 	it("retries a failed refresh with backoff and applies the eventual result", async () => {
 		const { hub, connection, fetchToolsList, notifyWebviewOfServerChanges } = createMcpHub()
 		connection.server.tools = [{ name: "existing" }]
@@ -304,6 +347,47 @@ describe("McpHub list_changed notification refresh", () => {
 
 		fetchToolsList.callCount.should.equal(4)
 		notifyWebviewOfServerChanges.called.should.be.false()
+	})
+
+	it("retries when the fetch succeeded but publishing failed", async () => {
+		const { hub, connection, fetchToolsList, notifyWebviewOfServerChanges } = createMcpHub()
+		fetchToolsList.resolves([{ name: "tool1" }])
+		notifyWebviewOfServerChanges.onFirstCall().rejects(new Error("settings read failed"))
+		;(hub as any).scheduleListChangedRefresh("test-server", "tools")
+
+		// First attempt: fetch succeeds and updates the cache, but consumers
+		// never saw it because the publish failed — so it must retry
+		await clock.tickAsync(300)
+		connection.server.tools.should.deepEqual([{ name: "tool1" }])
+		notifyWebviewOfServerChanges.calledOnce.should.be.true()
+
+		await clock.tickAsync(1000)
+		notifyWebviewOfServerChanges.calledTwice.should.be.true()
+	})
+
+	it("caps how long a sustained notification stream can defer the refresh", async () => {
+		const { hub, fetchToolsList } = createMcpHub()
+
+		// Notifications arriving every 200ms would re-arm the 300ms debounce
+		// forever; the 2s max-wait forces the refresh through regardless
+		for (let i = 0; i < 10; i++) {
+			;(hub as any).scheduleListChangedRefresh("test-server", "tools")
+			await clock.tickAsync(200)
+		}
+
+		fetchToolsList.called.should.be.true()
+	})
+
+	it("cancels pending refreshes when the connection is deleted", async () => {
+		const { hub, connection, fetchToolsList } = createMcpHub()
+		;(connection as any).transport = { close: sinon.stub().resolves() }
+		;(connection as any).client = { close: sinon.stub().resolves() }
+		;(hub as any).scheduleListChangedRefresh("test-server", "tools")
+
+		await hub.deleteConnection("test-server")
+		await clock.tickAsync(300)
+
+		fetchToolsList.called.should.be.false()
 	})
 
 	it("lets a fresh notification supersede a pending retry", async () => {

--- a/apps/vscode/src/services/mcp/__tests__/McpHub.listChangedRefresh.test.ts
+++ b/apps/vscode/src/services/mcp/__tests__/McpHub.listChangedRefresh.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, it } from "bun:test"
+import "should"
+import sinon from "sinon"
+import { McpHub } from "../McpHub"
+
+/**
+ * Unit tests for McpHub's handling of MCP list_changed notifications
+ * (notifications/tools/list_changed etc.).
+ *
+ * Servers emit these in bursts (a toolset change or shutdown can produce a
+ * dozen at once). Instead of toasting each one, McpHub debounces them per
+ * server and list kind, then refreshes the corresponding cached list and
+ * notifies the webview once.
+ *
+ * These tests exercise the real scheduleListChangedRefresh/refreshChangedList
+ * implementations by building a partially-initialized `McpHub` instance
+ * (bypassing the constructor's filesystem side-effects, same pattern as
+ * McpHub.callTool.test.ts) and stubbing the fetch/notify collaborators.
+ */
+
+function createMcpHub(serverName = "test-server", options: { disabled?: boolean } = {}) {
+	const connection = {
+		server: {
+			name: serverName,
+			config: JSON.stringify({ type: "stdio", command: "test", timeout: 60 }),
+			status: "connected",
+			disabled: options.disabled ?? false,
+			tools: [] as Array<{ name: string }>,
+			resources: [] as Array<{ name: string }>,
+			resourceTemplates: [] as Array<{ name: string }>,
+			prompts: [] as Array<{ name: string }>,
+		},
+		client: {},
+		transport: {},
+	}
+
+	const hub = Object.create(McpHub.prototype) as McpHub
+	;(hub as any).connections = [connection]
+	;(hub as any).listChangedRefreshTimers = new Map()
+
+	const fetchToolsList = sinon.stub().resolves([{ name: "tool1" }])
+	const fetchResourcesList = sinon.stub().resolves([{ name: "resource1" }])
+	const fetchResourceTemplatesList = sinon.stub().resolves([{ name: "template1" }])
+	const fetchPromptsList = sinon.stub().resolves([{ name: "prompt1" }])
+	const notifyWebviewOfServerChanges = sinon.stub().resolves()
+	;(hub as any).fetchToolsList = fetchToolsList
+	;(hub as any).fetchResourcesList = fetchResourcesList
+	;(hub as any).fetchResourceTemplatesList = fetchResourceTemplatesList
+	;(hub as any).fetchPromptsList = fetchPromptsList
+	;(hub as any).notifyWebviewOfServerChanges = notifyWebviewOfServerChanges
+
+	return {
+		hub,
+		connection,
+		fetchToolsList,
+		fetchResourcesList,
+		fetchResourceTemplatesList,
+		fetchPromptsList,
+		notifyWebviewOfServerChanges,
+	}
+}
+
+describe("McpHub list_changed notification refresh", () => {
+	let clock: sinon.SinonFakeTimers
+
+	beforeEach(() => {
+		clock = sinon.useFakeTimers()
+	})
+
+	afterEach(() => {
+		clock.restore()
+	})
+
+	it("coalesces a burst of tools/list_changed into a single refresh", async () => {
+		const { hub, connection, fetchToolsList, notifyWebviewOfServerChanges } = createMcpHub()
+
+		for (let i = 0; i < 12; i++) {
+			;(hub as any).scheduleListChangedRefresh("test-server", "tools")
+		}
+		fetchToolsList.called.should.be.false()
+
+		await clock.tickAsync(300)
+
+		fetchToolsList.calledOnce.should.be.true()
+		notifyWebviewOfServerChanges.calledOnce.should.be.true()
+		connection.server.tools.should.deepEqual([{ name: "tool1" }])
+	})
+
+	it("refreshes resources and resource templates on resources/list_changed", async () => {
+		const { hub, connection, fetchResourcesList, fetchResourceTemplatesList } = createMcpHub()
+		;(hub as any).scheduleListChangedRefresh("test-server", "resources")
+		await clock.tickAsync(300)
+
+		fetchResourcesList.calledOnce.should.be.true()
+		fetchResourceTemplatesList.calledOnce.should.be.true()
+		connection.server.resources.should.deepEqual([{ name: "resource1" }])
+		connection.server.resourceTemplates.should.deepEqual([{ name: "template1" }])
+	})
+
+	it("refreshes prompts on prompts/list_changed", async () => {
+		const { hub, connection, fetchPromptsList } = createMcpHub()
+		;(hub as any).scheduleListChangedRefresh("test-server", "prompts")
+		await clock.tickAsync(300)
+
+		fetchPromptsList.calledOnce.should.be.true()
+		connection.server.prompts.should.deepEqual([{ name: "prompt1" }])
+	})
+
+	it("debounces per server and kind independently", async () => {
+		const { hub, fetchToolsList, fetchPromptsList, notifyWebviewOfServerChanges } = createMcpHub()
+		;(hub as any).scheduleListChangedRefresh("test-server", "tools")
+		;(hub as any).scheduleListChangedRefresh("test-server", "prompts")
+		await clock.tickAsync(300)
+
+		fetchToolsList.calledOnce.should.be.true()
+		fetchPromptsList.calledOnce.should.be.true()
+		notifyWebviewOfServerChanges.calledTwice.should.be.true()
+	})
+
+	it("refreshes again for notifications arriving after a flush", async () => {
+		const { hub, fetchToolsList } = createMcpHub()
+		;(hub as any).scheduleListChangedRefresh("test-server", "tools")
+		await clock.tickAsync(300)
+		;(hub as any).scheduleListChangedRefresh("test-server", "tools")
+		await clock.tickAsync(300)
+
+		fetchToolsList.calledTwice.should.be.true()
+	})
+
+	it("skips the refresh when the connection was deleted before the timer fired", async () => {
+		const { hub, fetchToolsList, notifyWebviewOfServerChanges } = createMcpHub()
+		;(hub as any).scheduleListChangedRefresh("test-server", "tools")
+		;(hub as any).connections = []
+		await clock.tickAsync(300)
+
+		fetchToolsList.called.should.be.false()
+		notifyWebviewOfServerChanges.called.should.be.false()
+	})
+
+	it("skips the refresh when the server is disabled", async () => {
+		const { hub, fetchToolsList, notifyWebviewOfServerChanges } = createMcpHub("test-server", { disabled: true })
+		;(hub as any).scheduleListChangedRefresh("test-server", "tools")
+		await clock.tickAsync(300)
+
+		fetchToolsList.called.should.be.false()
+		notifyWebviewOfServerChanges.called.should.be.false()
+	})
+
+	it("does not reject when the refresh fails", async () => {
+		const { hub, fetchToolsList } = createMcpHub()
+		fetchToolsList.rejects(new Error("server went away"))
+		;(hub as any).scheduleListChangedRefresh("test-server", "tools")
+
+		// Would surface as an unhandled rejection if the error weren't caught
+		await clock.tickAsync(300)
+	})
+})

--- a/apps/vscode/src/services/mcp/__tests__/StreamableHttpReconnectHandler.test.ts
+++ b/apps/vscode/src/services/mcp/__tests__/StreamableHttpReconnectHandler.test.ts
@@ -129,6 +129,22 @@ describe("StreamableHttpReconnectHandler", () => {
 		cbs.stubs.notifyWebviewOfServerChanges.lastCall.calledAfter(cbs.stubs.connectToServer.lastCall).should.be.true()
 	})
 
+	it("should not restart a live connection when post-reconnect publication fails", async () => {
+		const conn = makeConnection()
+		const cbs = makeCallbacks(conn)
+		// First call publishes "connecting" fine; the post-reconnect publish fails
+		cbs.stubs.notifyWebviewOfServerChanges.onSecondCall().rejects(new Error("settings read failed"))
+		const handler = new StreamableHttpReconnectHandler("test-server", cbs, TEST_CONFIG)
+
+		await handler.handleError(new Error("connection lost"))
+
+		// The reconnect succeeded, so a publication failure must not tear the
+		// connection down again or count as another attempt
+		cbs.stubs.connectToServer.calledOnce.should.be.true()
+		cbs.stubs.deleteConnection.calledOnce.should.be.true()
+		handler.attemptCount.should.equal(0)
+	})
+
 	it("should use the configured delay for each attempt", async () => {
 		const conn = makeConnection()
 		const cbs = makeCallbacks(conn)

--- a/apps/vscode/src/services/mcp/__tests__/StreamableHttpReconnectHandler.test.ts
+++ b/apps/vscode/src/services/mcp/__tests__/StreamableHttpReconnectHandler.test.ts
@@ -115,6 +115,20 @@ describe("StreamableHttpReconnectHandler", () => {
 		cbs.stubs.notifyWebviewOfServerChanges.called.should.be.true()
 	})
 
+	it("should publish server state after a successful reconnect", async () => {
+		const conn = makeConnection()
+		const cbs = makeCallbacks(conn)
+		const handler = new StreamableHttpReconnectHandler("test-server", cbs, TEST_CONFIG)
+
+		await handler.handleError(new Error("connection lost"))
+
+		// Once for the "connecting" status, once after connectToServer
+		// succeeded — the second publishes the freshly fetched lists and
+		// "connected" status that connectToServer loads but doesn't send.
+		cbs.stubs.notifyWebviewOfServerChanges.calledTwice.should.be.true()
+		cbs.stubs.notifyWebviewOfServerChanges.lastCall.calledAfter(cbs.stubs.connectToServer.lastCall).should.be.true()
+	})
+
 	it("should use the configured delay for each attempt", async () => {
 		const conn = makeConnection()
 		const cbs = makeCallbacks(conn)

--- a/apps/vscode/src/services/mcp/__tests__/StreamableHttpReconnectHandler.test.ts
+++ b/apps/vscode/src/services/mcp/__tests__/StreamableHttpReconnectHandler.test.ts
@@ -202,8 +202,9 @@ describe("StreamableHttpReconnectHandler", () => {
 		const cbs = makeCallbacks(conn)
 		// An OAuth-required connection is "disconnected" but retains its
 		// client/transport/authProvider for when the user authenticates —
-		// unlike our own failed-connect husk, which has client: null
-		const oauthReplacement = { server: { status: "disconnected" }, client: {} }
+		// oauthRequired: true is what distinguishes it from an ordinary
+		// failed connection
+		const oauthReplacement = { server: { status: "disconnected", oauthRequired: true }, client: {} }
 		let deleted = false
 		let attempts = 0
 		cbs.stubs.findConnection.callsFake(() => {
@@ -285,10 +286,11 @@ describe("StreamableHttpReconnectHandler", () => {
 
 		// After deleteConnection, findConnection returns undefined (old conn deleted)
 		// but connectToServer may leave a partial connection, so simulate that.
-		// A partial connection from a failed connectToServer is always marked
-		// "disconnected" (its error path sets that before throwing) — which is
-		// also what lets the retry loop distinguish it from a live replacement.
-		const partialConn = makeConnection({ status: "disconnected" })
+		// A partial connection from a failed connectToServer is marked
+		// "disconnected" with its (already-closed) client still attached and
+		// oauthRequired false — the retry loop must keep retrying past it, not
+		// mistake it for an OAuth-required replacement.
+		const partialConn = { ...makeConnection({ status: "disconnected" }), client: {} }
 		let deleted = false
 		cbs.stubs.findConnection.callsFake(() => {
 			if (!deleted) return conn

--- a/apps/vscode/src/services/mcp/__tests__/StreamableHttpReconnectHandler.test.ts
+++ b/apps/vscode/src/services/mcp/__tests__/StreamableHttpReconnectHandler.test.ts
@@ -197,6 +197,35 @@ describe("StreamableHttpReconnectHandler", () => {
 		replacement.server.status.should.equal("connected")
 	})
 
+	it("should abort retries when a disconnected OAuth-required replacement holds a live client", async () => {
+		const conn = makeConnection()
+		const cbs = makeCallbacks(conn)
+		// An OAuth-required connection is "disconnected" but retains its
+		// client/transport/authProvider for when the user authenticates —
+		// unlike our own failed-connect husk, which has client: null
+		const oauthReplacement = { server: { status: "disconnected" }, client: {} }
+		let deleted = false
+		let attempts = 0
+		cbs.stubs.findConnection.callsFake(() => {
+			if (!deleted) return conn
+			return attempts >= 1 ? oauthReplacement : undefined
+		})
+		cbs.stubs.deleteConnection.callsFake(async () => {
+			deleted = true
+		})
+		cbs.stubs.connectToServer.callsFake(async () => {
+			attempts += 1
+			throw new Error("still broken")
+		})
+
+		const handler = new StreamableHttpReconnectHandler("test-server", cbs, TEST_CONFIG)
+		await handler.handleError(new Error("transport error"))
+
+		// The retry must not displace the OAuth replacement — connectToServer
+		// would drop it without closing, orphaning its session and auth state
+		attempts.should.equal(1)
+	})
+
 	it("should retry a transiently failing post-reconnect publication", async () => {
 		const conn = makeConnection()
 		const cbs = makeCallbacks(conn)

--- a/apps/vscode/src/services/mcp/__tests__/StreamableHttpReconnectHandler.test.ts
+++ b/apps/vscode/src/services/mcp/__tests__/StreamableHttpReconnectHandler.test.ts
@@ -31,6 +31,7 @@ function makeCallbacks(connection?: ReturnType<typeof makeConnection>): Reconnec
 		notifyWebviewOfServerChanges: sinon.stub().resolves(),
 		appendErrorMessage: sinon.stub(),
 		delay: sinon.stub().resolves(), // instant — no real waiting in tests
+		isStillWanted: sinon.stub().resolves(true),
 	}
 	return { ...(stubs as unknown as ReconnectCallbacks), stubs }
 }
@@ -145,6 +146,57 @@ describe("StreamableHttpReconnectHandler", () => {
 		handler.attemptCount.should.equal(0)
 	})
 
+	it("should abort retries when the server is removed from settings during a later delay", async () => {
+		const conn = makeConnection()
+		const cbs = makeCallbacks(conn)
+		cbs.stubs.connectToServer.rejects(new Error("still broken"))
+		// After deleteConnection the old connection is gone
+		let deleted = false
+		cbs.stubs.findConnection.callsFake(() => (deleted ? undefined : conn))
+		cbs.stubs.deleteConnection.callsFake(async () => {
+			deleted = true
+		})
+		// Attempt 1 is still wanted; during its backoff the user removes the server
+		cbs.stubs.isStillWanted.onFirstCall().resolves(true)
+		cbs.stubs.isStillWanted.onSecondCall().resolves(false)
+
+		const handler = new StreamableHttpReconnectHandler("test-server", cbs, TEST_CONFIG)
+		await handler.handleError(new Error("transport error"))
+
+		// The retry after the removal must not run — it would resurrect the server
+		cbs.stubs.connectToServer.calledOnce.should.be.true()
+	})
+
+	it("should abort retries when another path installed a replacement connection during a later delay", async () => {
+		const conn = makeConnection()
+		const cbs = makeCallbacks(conn)
+		cbs.stubs.connectToServer.rejects(new Error("still broken"))
+		// After our deleteConnection: nothing at first, then a live replacement
+		// appears (e.g. the settings watcher reconnected with a new config)
+		const replacement = makeConnection({ status: "connected" })
+		let deleted = false
+		let attempts = 0
+		cbs.stubs.findConnection.callsFake(() => {
+			if (!deleted) return conn
+			return attempts >= 1 ? replacement : undefined
+		})
+		cbs.stubs.deleteConnection.callsFake(async () => {
+			deleted = true
+		})
+		cbs.stubs.connectToServer.callsFake(async () => {
+			attempts += 1
+			throw new Error("still broken")
+		})
+
+		const handler = new StreamableHttpReconnectHandler("test-server", cbs, TEST_CONFIG)
+		await handler.handleError(new Error("transport error"))
+
+		// The retry must not displace the live replacement (connectToServer
+		// would drop it from the list without closing it)
+		attempts.should.equal(1)
+		replacement.server.status.should.equal("connected")
+	})
+
 	it("should retry a transiently failing post-reconnect publication", async () => {
 		const conn = makeConnection()
 		const cbs = makeCallbacks(conn)
@@ -203,8 +255,11 @@ describe("StreamableHttpReconnectHandler", () => {
 		cbs.stubs.connectToServer.rejects(new Error("still broken"))
 
 		// After deleteConnection, findConnection returns undefined (old conn deleted)
-		// but connectToServer may leave a partial connection, so simulate that
-		const partialConn = makeConnection()
+		// but connectToServer may leave a partial connection, so simulate that.
+		// A partial connection from a failed connectToServer is always marked
+		// "disconnected" (its error path sets that before throwing) — which is
+		// also what lets the retry loop distinguish it from a live replacement.
+		const partialConn = makeConnection({ status: "disconnected" })
 		let deleted = false
 		cbs.stubs.findConnection.callsFake(() => {
 			if (!deleted) return conn

--- a/apps/vscode/src/services/mcp/__tests__/StreamableHttpReconnectHandler.test.ts
+++ b/apps/vscode/src/services/mcp/__tests__/StreamableHttpReconnectHandler.test.ts
@@ -145,6 +145,34 @@ describe("StreamableHttpReconnectHandler", () => {
 		handler.attemptCount.should.equal(0)
 	})
 
+	it("should retry a transiently failing post-reconnect publication", async () => {
+		const conn = makeConnection()
+		const cbs = makeCallbacks(conn)
+		// Call 1 publishes "connecting"; call 2 (post-reconnect) fails; call 3 succeeds
+		cbs.stubs.notifyWebviewOfServerChanges.onSecondCall().rejects(new Error("settings read failed"))
+		const handler = new StreamableHttpReconnectHandler("test-server", cbs, TEST_CONFIG)
+
+		await handler.handleError(new Error("connection lost"))
+
+		// The failed publish was retried until it succeeded, so consumers
+		// aren't left on "connecting" with pre-reconnect capabilities
+		cbs.stubs.notifyWebviewOfServerChanges.callCount.should.equal(3)
+	})
+
+	it("should not throw when every post-reconnect publication attempt fails", async () => {
+		const conn = makeConnection()
+		const cbs = makeCallbacks(conn)
+		cbs.stubs.notifyWebviewOfServerChanges.rejects(new Error("persistent failure"))
+		const handler = new StreamableHttpReconnectHandler("test-server", cbs, TEST_CONFIG)
+
+		// handleError runs from transport.onerror with its promise discarded,
+		// so it must never reject — even when publication never succeeds
+		await handler.handleError(new Error("connection lost"))
+
+		cbs.stubs.connectToServer.calledOnce.should.be.true()
+		handler.attemptCount.should.equal(0)
+	})
+
 	it("should use the configured delay for each attempt", async () => {
 		const conn = makeConnection()
 		const cbs = makeCallbacks(conn)

--- a/apps/vscode/src/services/mcp/__tests__/StreamableHttpReconnectHandler.test.ts
+++ b/apps/vscode/src/services/mcp/__tests__/StreamableHttpReconnectHandler.test.ts
@@ -227,6 +227,39 @@ describe("StreamableHttpReconnectHandler", () => {
 		attempts.should.equal(1)
 	})
 
+	it("should retry past its own failed attempt's registered connection and succeed", async () => {
+		const conn = makeConnection()
+		const cbs = makeCallbacks(conn)
+		// A failed non-OAuth connectToServer() registers a connection, closes
+		// its client on failure, but leaves the (closed) client attached and
+		// the connection in the list, marked "disconnected". The guard must
+		// recognize it as our own failed attempt — not a replacement — and
+		// let the next retry proceed.
+		const failedAttempt = { ...makeConnection({ status: "disconnected" }), client: {} }
+		let deleted = false
+		let attempts = 0
+		cbs.stubs.findConnection.callsFake(() => {
+			if (!deleted) return conn
+			return attempts >= 1 ? failedAttempt : undefined
+		})
+		cbs.stubs.deleteConnection.callsFake(async () => {
+			deleted = true
+		})
+		cbs.stubs.connectToServer.callsFake(async () => {
+			attempts += 1
+			if (attempts === 1) {
+				throw new Error("connect failed")
+			}
+		})
+
+		const handler = new StreamableHttpReconnectHandler("test-server", cbs, TEST_CONFIG)
+		await handler.handleError(new Error("transport error"))
+
+		// Second attempt ran and succeeded; counter reset
+		cbs.stubs.connectToServer.callCount.should.equal(2)
+		handler.attemptCount.should.equal(0)
+	})
+
 	it("should retry a transiently failing post-reconnect publication", async () => {
 		const conn = makeConnection()
 		const cbs = makeCallbacks(conn)

--- a/apps/vscode/src/services/mcp/__tests__/StreamableHttpReconnectHandler.test.ts
+++ b/apps/vscode/src/services/mcp/__tests__/StreamableHttpReconnectHandler.test.ts
@@ -117,6 +117,20 @@ describe("StreamableHttpReconnectHandler", () => {
 		cbs.stubs.notifyWebviewOfServerChanges.called.should.be.true()
 	})
 
+	it("should publish server state after a successful reconnect", async () => {
+		const conn = makeConnection()
+		const cbs = makeCallbacks(conn)
+		const handler = new StreamableHttpReconnectHandler("test-server", cbs, TEST_CONFIG)
+
+		await handler.handleError(new Error("connection lost"))
+
+		// Once for the "connecting" status, once after connectToServer
+		// succeeded — the second publishes the freshly fetched lists and
+		// "connected" status that connectToServer loads but doesn't send.
+		cbs.stubs.notifyWebviewOfServerChanges.calledTwice.should.be.true()
+		cbs.stubs.notifyWebviewOfServerChanges.lastCall.calledAfter(cbs.stubs.connectToServer.lastCall).should.be.true()
+	})
+
 	it("should use the configured delay for each attempt", async () => {
 		const conn = makeConnection()
 		const cbs = makeCallbacks(conn)

--- a/apps/vscode/src/services/mcp/__tests__/StreamableHttpReconnectHandler.test.ts
+++ b/apps/vscode/src/services/mcp/__tests__/StreamableHttpReconnectHandler.test.ts
@@ -131,6 +131,22 @@ describe("StreamableHttpReconnectHandler", () => {
 		cbs.stubs.notifyWebviewOfServerChanges.lastCall.calledAfter(cbs.stubs.connectToServer.lastCall).should.be.true()
 	})
 
+	it("should not restart a live connection when post-reconnect publication fails", async () => {
+		const conn = makeConnection()
+		const cbs = makeCallbacks(conn)
+		// First call publishes "connecting" fine; the post-reconnect publish fails
+		cbs.stubs.notifyWebviewOfServerChanges.onSecondCall().rejects(new Error("settings read failed"))
+		const handler = new StreamableHttpReconnectHandler("test-server", cbs, TEST_CONFIG)
+
+		await handler.handleError(new Error("connection lost"))
+
+		// The reconnect succeeded, so a publication failure must not tear the
+		// connection down again or count as another attempt
+		cbs.stubs.connectToServer.calledOnce.should.be.true()
+		cbs.stubs.deleteConnection.calledOnce.should.be.true()
+		handler.attemptCount.should.equal(0)
+	})
+
 	it("should use the configured delay for each attempt", async () => {
 		const conn = makeConnection()
 		const cbs = makeCallbacks(conn)

--- a/apps/vscode/src/services/mcp/__tests__/StreamableHttpReconnectHandler.test.ts
+++ b/apps/vscode/src/services/mcp/__tests__/StreamableHttpReconnectHandler.test.ts
@@ -147,6 +147,34 @@ describe("StreamableHttpReconnectHandler", () => {
 		handler.attemptCount.should.equal(0)
 	})
 
+	it("should retry a transiently failing post-reconnect publication", async () => {
+		const conn = makeConnection()
+		const cbs = makeCallbacks(conn)
+		// Call 1 publishes "connecting"; call 2 (post-reconnect) fails; call 3 succeeds
+		cbs.stubs.notifyWebviewOfServerChanges.onSecondCall().rejects(new Error("settings read failed"))
+		const handler = new StreamableHttpReconnectHandler("test-server", cbs, TEST_CONFIG)
+
+		await handler.handleError(new Error("connection lost"))
+
+		// The failed publish was retried until it succeeded, so consumers
+		// aren't left on "connecting" with pre-reconnect capabilities
+		cbs.stubs.notifyWebviewOfServerChanges.callCount.should.equal(3)
+	})
+
+	it("should not throw when every post-reconnect publication attempt fails", async () => {
+		const conn = makeConnection()
+		const cbs = makeCallbacks(conn)
+		cbs.stubs.notifyWebviewOfServerChanges.rejects(new Error("persistent failure"))
+		const handler = new StreamableHttpReconnectHandler("test-server", cbs, TEST_CONFIG)
+
+		// handleError runs from transport.onerror with its promise discarded,
+		// so it must never reject — even when publication never succeeds
+		await handler.handleError(new Error("connection lost"))
+
+		cbs.stubs.connectToServer.calledOnce.should.be.true()
+		handler.attemptCount.should.equal(0)
+	})
+
 	it("should use the configured delay for each attempt", async () => {
 		const conn = makeConnection()
 		const cbs = makeCallbacks(conn)


### PR DESCRIPTION
## Problem

McpHub's `fallbackNotificationHandler` forwards every unhandled MCP notification to `HostProvider.window.showMessage`, as `MCP <name>: <method> - <params>`. Servers emit `notifications/tools/list_changed` in bursts — a toolset change or server shutdown can produce a dozen at once — so the user gets a dozen+ identical toasts, and the cached tool list is never actually refreshed. Found while testing the JetBrains IDE MCP server integration (ENG-2298).

## Fix

- Register typed handlers for `tools`, `resources`, and `prompts` `list_changed` notifications (schemas from `@modelcontextprotocol/sdk/types.js`) that refresh the corresponding cached lists — `resources` also refreshes resource templates — instead of surfacing anything to the user.
- Debounce refreshes 300ms per server + list kind, so a notification burst collapses into a single list refetch. Timers are cleaned up in `dispose()`.
- After refreshing, `notifyWebviewOfServerChanges()` pushes the update to the webview and runs the existing tool-list change check, so the SDK session picks up the new tool list.
- The refresh looks the connection up fresh by name when the timer fires (safe across delete/reconnect races) and skips disabled servers.
- Downgrade remaining unhandled notification types from a toast to `Logger.log`.

## Tests

New `McpHub.listChangedRefresh.test.ts` (8 tests, same `Object.create(McpHub.prototype)` injection pattern as the callTool tests): burst coalescing, per-kind refresh targets, per-server+kind debounce independence, re-arming after a flush, deleted/disabled-server races, and error containment.

`tsc --noEmit`, biome lint, and the bun-owned MCP unit suites all pass.

## Notes

`legacy-extension` has the identical toasting fallback and needs an analogous fix; ~that will be a separate PR.~