### PR TITLE
fix(shared): honour caller supplied image media types in ai-sdk forma…

### DIFF
--- a/sdk/packages/shared/src/llms/ai-sdk-format.test.ts
+++ b/sdk/packages/shared/src/llms/ai-sdk-format.test.ts
@@ -805,6 +805,104 @@ describe("formatMessagesForAiSdk", () => {
 		expect(serialized).not.toContain("application/octet-stream");
 	});
 
+	it("keeps webp binary image parts when no supported media types are given", () => {
+		const image = new Uint8Array([1, 2, 3, 4]);
+		const messages = formatMessagesForAiSdk(undefined, [
+			{
+				role: "user",
+				content: [{ type: "image", image, mediaType: "image/webp" }],
+			},
+		]);
+
+		expect(messages).toEqual([
+			{
+				role: "user",
+				content: [{ type: "image", image, mediaType: "image/webp" }],
+			},
+		]);
+	});
+
+	it("replaces webp binary image parts when the provider excludes webp", () => {
+		const image = new Uint8Array([1, 2, 3, 4]);
+		const messages = formatMessagesForAiSdk(
+			undefined,
+			[
+				{
+					role: "user",
+					content: [{ type: "image", image, mediaType: "image/webp" }],
+				},
+			],
+			{ supportedImageMediaTypes: ["image/png", "image/jpeg"] },
+		);
+
+		const serialized = JSON.stringify(messages);
+		expect(serialized).toContain(
+			"[media omitted: invalid or exceeds size limit]",
+		);
+		expect(serialized).not.toContain("image/webp");
+	});
+
+	it("replaces webp data-url string images when the provider excludes webp", () => {
+		const image = `data:image/webp;base64,${imageData(8)}`;
+		const messages = formatMessagesForAiSdk(
+			undefined,
+			[
+				{
+					role: "user",
+					content: [{ type: "image", image, mediaType: "image/webp" }],
+				},
+			],
+			{ supportedImageMediaTypes: ["image/png", "image/jpeg"] },
+		);
+
+		const serialized = JSON.stringify(messages);
+		expect(serialized).toContain(
+			"[media omitted: invalid or exceeds size limit]",
+		);
+		expect(serialized).not.toContain("image/webp");
+	});
+
+	it("replaces webp data-url URL images when the provider excludes webp", () => {
+		const image = new URL(`data:image/webp;base64,${imageData(8)}`);
+		const messages = formatMessagesForAiSdk(
+			undefined,
+			[
+				{
+					role: "user",
+					content: [{ type: "image", image, mediaType: "image/webp" }],
+				},
+			],
+			{ supportedImageMediaTypes: ["image/png", "image/jpeg"] },
+		);
+
+		const serialized = JSON.stringify(messages);
+		expect(serialized).toContain(
+			"[media omitted: invalid or exceeds size limit]",
+		);
+		expect(serialized).not.toContain("image/webp");
+	});
+
+	it("keeps webp images when the provider supports webp", () => {
+		const image = new Uint8Array([1, 2, 3, 4]);
+		const messages = formatMessagesForAiSdk(
+			undefined,
+			[
+				{
+					role: "user",
+					content: [{ type: "image", image, mediaType: "image/webp" }],
+				},
+			],
+			{ supportedImageMediaTypes: ["image/png", "image/webp"] },
+		);
+
+		expect(messages).toEqual([
+			{
+				role: "user",
+				content: [{ type: "image", image, mediaType: "image/webp" }],
+			},
+		]);
+	});
+
 	it("replaces over-budget binary image parts", () => {
 		const oversizedImage = new Uint8Array(6 * 1024 * 1024 + 1);
 		const messages = formatMessagesForAiSdk(undefined, [

--- a/sdk/packages/shared/src/llms/ai-sdk-format.test.ts
+++ b/sdk/packages/shared/src/llms/ai-sdk-format.test.ts
@@ -1011,6 +1011,104 @@ describe("formatMessagesForAiSdk", () => {
 		expect(serialized).not.toContain("application/octet-stream");
 	});
 
+	it("keeps webp binary image parts when no supported media types are given", () => {
+		const image = new Uint8Array([1, 2, 3, 4]);
+		const messages = formatMessagesForAiSdk(undefined, [
+			{
+				role: "user",
+				content: [{ type: "image", image, mediaType: "image/webp" }],
+			},
+		]);
+
+		expect(messages).toEqual([
+			{
+				role: "user",
+				content: [{ type: "file", data: image, mediaType: "image/webp" }],
+			},
+		]);
+	});
+
+	it("replaces webp binary image parts when the provider excludes webp", () => {
+		const image = new Uint8Array([1, 2, 3, 4]);
+		const messages = formatMessagesForAiSdk(
+			undefined,
+			[
+				{
+					role: "user",
+					content: [{ type: "image", image, mediaType: "image/webp" }],
+				},
+			],
+			{ supportedImageMediaTypes: ["image/png", "image/jpeg"] },
+		);
+
+		const serialized = JSON.stringify(messages);
+		expect(serialized).toContain(
+			"[media omitted: invalid or exceeds size limit]",
+		);
+		expect(serialized).not.toContain("image/webp");
+	});
+
+	it("replaces webp data-url string images when the provider excludes webp", () => {
+		const image = `data:image/webp;base64,${imageData(8)}`;
+		const messages = formatMessagesForAiSdk(
+			undefined,
+			[
+				{
+					role: "user",
+					content: [{ type: "image", image, mediaType: "image/webp" }],
+				},
+			],
+			{ supportedImageMediaTypes: ["image/png", "image/jpeg"] },
+		);
+
+		const serialized = JSON.stringify(messages);
+		expect(serialized).toContain(
+			"[media omitted: invalid or exceeds size limit]",
+		);
+		expect(serialized).not.toContain("image/webp");
+	});
+
+	it("replaces webp data-url URL images when the provider excludes webp", () => {
+		const image = new URL(`data:image/webp;base64,${imageData(8)}`);
+		const messages = formatMessagesForAiSdk(
+			undefined,
+			[
+				{
+					role: "user",
+					content: [{ type: "image", image, mediaType: "image/webp" }],
+				},
+			],
+			{ supportedImageMediaTypes: ["image/png", "image/jpeg"] },
+		);
+
+		const serialized = JSON.stringify(messages);
+		expect(serialized).toContain(
+			"[media omitted: invalid or exceeds size limit]",
+		);
+		expect(serialized).not.toContain("image/webp");
+	});
+
+	it("keeps webp images when the provider supports webp", () => {
+		const image = new Uint8Array([1, 2, 3, 4]);
+		const messages = formatMessagesForAiSdk(
+			undefined,
+			[
+				{
+					role: "user",
+					content: [{ type: "image", image, mediaType: "image/webp" }],
+				},
+			],
+			{ supportedImageMediaTypes: ["image/png", "image/webp"] },
+		);
+
+		expect(messages).toEqual([
+			{
+				role: "user",
+				content: [{ type: "file", data: image, mediaType: "image/webp" }],
+			},
+		]);
+	});
+
 	it("replaces over-budget binary image parts", () => {
 		const oversizedImage = new Uint8Array(6 * 1024 * 1024 + 1);
 		const messages = formatMessagesForAiSdk(undefined, [

--- a/sdk/packages/shared/src/llms/ai-sdk-format.ts
+++ b/sdk/packages/shared/src/llms/ai-sdk-format.ts
@@ -250,6 +250,7 @@ function userMediaPart(
 function toUserImagePart(
 	image: Extract<AiSdkFormatterPart, { type: "image" }>,
 	state: MediaBudgetState,
+	supportedMediaTypes?: readonly string[],
 ): AiSdkMessagePart {
 	if (image.image instanceof URL) {
 		if (image.image.protocol === "data:") {
@@ -261,6 +262,7 @@ function toUserImagePart(
 					maxImageDecodedBytes: DEFAULT_MAX_IMAGE_DECODED_BYTES,
 				},
 				state,
+				supportedMediaTypes,
 			);
 			if (!validation.ok) {
 				return imageOmittedTextPart();
@@ -297,6 +299,7 @@ function toUserImagePart(
 				maxImageDecodedBytes: DEFAULT_MAX_IMAGE_DECODED_BYTES,
 			},
 			state,
+			supportedMediaTypes,
 		);
 		if (!validation.ok) {
 			return imageOmittedTextPart();
@@ -312,9 +315,10 @@ function toUserImagePart(
 	const decodedBytes = image.image.byteLength;
 	const encodedBytes = imageBase64LengthForDecodedBytes(decodedBytes);
 	const mediaType = image.mediaType?.toLowerCase() ?? "image/png";
-	const supportedMediaTypes: readonly string[] = SUPPORTED_IMAGE_MEDIA_TYPES;
+	const effectiveMediaTypes: readonly string[] =
+		supportedMediaTypes ?? SUPPORTED_IMAGE_MEDIA_TYPES;
 	if (
-		!supportedMediaTypes.includes(mediaType) ||
+		!effectiveMediaTypes.includes(mediaType) ||
 		reserveImageMediaBytes(
 			encodedBytes,
 			decodedBytes,
@@ -650,6 +654,7 @@ export function formatMessagesForAiSdk(
 		 * time only — stored conversation history is never mutated.
 		 */
 		supportedInputModalities?: readonly string[];
+		supportedImageMediaTypes?: readonly string[];
 	},
 ): AiSdkMessage[] {
 	const toolCallArgKey = options?.assistantToolCallArgKey ?? "input";
@@ -774,7 +779,11 @@ export function formatMessagesForAiSdk(
 					} else {
 						messageParts.push(
 							supportsImages
-								? toUserImagePart(part, mediaState)
+								? toUserImagePart(
+										part,
+										mediaState,
+										options?.supportedImageMediaTypes,
+									)
 								: { type: "text", text: IMAGE_UNSUPPORTED_PLACEHOLDER },
 						);
 					}

--- a/sdk/packages/shared/src/llms/ai-sdk-format.ts
+++ b/sdk/packages/shared/src/llms/ai-sdk-format.ts
@@ -192,6 +192,7 @@ function toImageDataPart(
 function toUserImagePart(
 	image: Extract<AiSdkFormatterPart, { type: "image" }>,
 	state: MediaBudgetState,
+	supportedMediaTypes?: readonly string[],
 ): AiSdkMessagePart {
 	if (image.image instanceof URL) {
 		if (image.image.protocol === "data:") {
@@ -203,6 +204,7 @@ function toUserImagePart(
 					maxImageDecodedBytes: DEFAULT_MAX_IMAGE_DECODED_BYTES,
 				},
 				state,
+				supportedMediaTypes,
 			);
 			if (!validation.ok) {
 				return imageOmittedTextPart();
@@ -248,6 +250,7 @@ function toUserImagePart(
 				maxImageDecodedBytes: DEFAULT_MAX_IMAGE_DECODED_BYTES,
 			},
 			state,
+			supportedMediaTypes,
 		);
 		if (!validation.ok) {
 			return imageOmittedTextPart();
@@ -264,9 +267,10 @@ function toUserImagePart(
 	const decodedBytes = image.image.byteLength;
 	const encodedBytes = imageBase64LengthForDecodedBytes(decodedBytes);
 	const mediaType = image.mediaType?.toLowerCase() ?? "image/png";
-	const supportedMediaTypes: readonly string[] = SUPPORTED_IMAGE_MEDIA_TYPES;
+	const effectiveMediaTypes: readonly string[] =
+		supportedMediaTypes ?? SUPPORTED_IMAGE_MEDIA_TYPES;
 	if (
-		!supportedMediaTypes.includes(mediaType) ||
+		!effectiveMediaTypes.includes(mediaType) ||
 		reserveImageMediaBytes(
 			encodedBytes,
 			decodedBytes,
@@ -523,7 +527,10 @@ export function toAiSdkToolResultOutput(
 export function formatMessagesForAiSdk(
 	systemContent: string | AiSdkMessagePart[] | undefined,
 	messages: readonly AiSdkFormatterMessage[],
-	options?: { assistantToolCallArgKey?: "args" | "input" },
+	options?: {
+		assistantToolCallArgKey?: "args" | "input";
+		supportedImageMediaTypes?: readonly string[];
+	},
 ): AiSdkMessage[] {
 	const toolCallArgKey = options?.assistantToolCallArgKey ?? "input";
 	const result: AiSdkMessage[] = [];
@@ -591,7 +598,13 @@ export function formatMessagesForAiSdk(
 					});
 					break;
 				case "image":
-					messageParts.push(toUserImagePart(part, mediaState));
+					messageParts.push(
+						toUserImagePart(
+							part,
+							mediaState,
+							options?.supportedImageMediaTypes,
+						),
+					);
 					break;
 				case "file":
 					messageParts.push({

--- a/sdk/packages/shared/src/llms/media.test.ts
+++ b/sdk/packages/shared/src/llms/media.test.ts
@@ -67,6 +67,18 @@ describe("image media validation", () => {
 		).toMatchObject({ ok: false, reason: "decoded_limit" });
 	});
 
+	it("honours caller supplied supported media types", () => {
+		const state = createMediaBudgetState();
+		expect(
+			validateAndReserveImageMedia("image/webp", "aGVsbG8=", {}, state, [
+				"image/png",
+			]),
+		).toMatchObject({ ok: false, reason: "unsupported_media_type" });
+		expect(
+			validateAndReserveImageMedia("image/webp", "aGVsbG8=", {}, state),
+		).toMatchObject({ ok: true, mediaType: "image/webp" });
+	});
+
 	it("rejects oversized encoded payloads before base64 syntax validation", () => {
 		expect(
 			validateImageMedia("image/png", "not-base64-and-too-long", {

--- a/sdk/packages/shared/src/llms/media.test.ts
+++ b/sdk/packages/shared/src/llms/media.test.ts
@@ -121,6 +121,18 @@ describe("media validation", () => {
 		).toMatchObject({ ok: false, reason: "decoded_limit" });
 	});
 
+	it("honours caller supplied supported media types", () => {
+		const state = createMediaBudgetState();
+		expect(
+			validateAndReserveImageMedia("image/webp", "aGVsbG8=", {}, state, [
+				"image/png",
+			]),
+		).toMatchObject({ ok: false, reason: "unsupported_media_type" });
+		expect(
+			validateAndReserveImageMedia("image/webp", "aGVsbG8=", {}, state),
+		).toMatchObject({ ok: true, mediaType: "image/webp" });
+	});
+
 	it("rejects oversized encoded payloads before base64 syntax validation", () => {
 		expect(
 			validateImageMedia("image/png", "not-base64-and-too-long", {

--- a/sdk/packages/shared/src/llms/media.ts
+++ b/sdk/packages/shared/src/llms/media.ts
@@ -354,10 +354,12 @@ export function validateAndReserveImageMedia(
 	data: string,
 	budget: MediaBudgetOptions,
 	state: MediaBudgetState,
+	supportedMediaTypes?: readonly string[],
 ): ImageMediaValidationResult {
 	const validation = validateImageMedia(mediaType, data, {
 		maxEncodedBytes: budget.maxImageEncodedBytes,
 		maxDecodedBytes: budget.maxImageDecodedBytes,
+		supportedMediaTypes,
 	});
 	if (!validation.ok) {
 		recordOmittedImage(state, validation.reason);

--- a/sdk/packages/shared/src/llms/media.ts
+++ b/sdk/packages/shared/src/llms/media.ts
@@ -482,10 +482,12 @@ export function validateAndReserveImageMedia(
 	data: string,
 	budget: MediaBudgetOptions,
 	state: MediaBudgetState,
+	supportedMediaTypes?: readonly string[],
 ): ImageMediaValidationResult {
 	const validation = validateImageMedia(mediaType, data, {
 		maxEncodedBytes: budget.maxImageEncodedBytes,
 		maxDecodedBytes: budget.maxImageDecodedBytes,
+		supportedMediaTypes,
 	});
 	if (!validation.ok) {
 		recordOmittedImage(state, validation.reason);


### PR DESCRIPTION
### Related Issue

**Issue:** #9902 (partial - `Refs #9902`, see Additional Notes for why this does not close it)

### Description

`image/webp` is forwarded to every provider unconditionally, so LM Studio's OpenAI-compatible endpoint (llama.cpp backend, PNG/JPEG only) rejects the request with `400 'url' field must be a base64 encoded image`.

The hook to prevent this already exists and is simply never fed. `validateImageMedia` honours `limits.supportedMediaTypes ?? SUPPORTED_IMAGE_MEDIA_TYPES` (`media.ts:278`), but every caller drops the field: `validateAndReserveImageMedia` builds the limits object from the byte budget only, and `toUserImagePart` hardcodes `SUPPORTED_IMAGE_MEDIA_TYPES` on the binary path. `formatMessagesForAiSdk` had no option to carry a list, so `ai-sdk.ts:380`, the one call site that knows which provider is being used, had nothing to pass.

This threads an optional `supportedImageMediaTypes` from `formatMessagesForAiSdk` down into all three user-image gating sites (URL `data:`, string `data:`, and binary), making the existing hook reachable.

**Prior attempt:** #11522 targeted the browser `ToolExecutor` path, which the SDK migration removed. Per @dominiccooney's follow-up on that thread (2026-07-25), this retargets the same problem at the SDK media-validation layer he identified.

**What did NOT change.** Behaviour is identical for every existing caller. With the option absent, `undefined` flows through to `?? SUPPORTED_IMAGE_MEDIA_TYPES` on all three paths, so the same list is consulted as before. No production caller populates the option yet, that is deliberate.

**Why not the alternative.** The obvious shortcut is a hardcoded `PROVIDERS_WITHOUT_WEBP_SUPPORT` set, which is what #11522 did. I avoided it: hand-written provider data is the thing that got #12365 closed in favour of generation from models.dev, and I would rather you pick the source than have me invent one.

### Test Procedure

Red/green was verified explicitly, not assumed. Reverting only the two source files and re-running leaves the three new negative tests failing with the webp passed straight through (`Received: "...image/webp..."`), 3 failed / 280 passed. With the change, 284/284.

    bun -F @cline/shared test     # 26 files, 284 tests pass
    bun -F @cline/llms test       # 26 files pass, 4 skipped; 422 tests pass, 4 skipped
    cd sdk/packages/shared && bun tsc --noEmit     # clean
    bunx biome check sdk/packages/shared/src/llms/    # clean

Six tests added: three asserting webp is replaced by the placeholder when the caller excludes it (one per branch), two asserting webp survives when the option is absent or includes it (the default-behaviour guards this change rests on), and one directly on `validateAndReserveImageMedia`'s new parameter.

### Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore
-   [x] Tests are passing and code is formatted and linted
-   [x] I have reviewed the contributor guidelines

### Screenshots

No visual change is intended.

### Additional Notes

**Why `Refs` and not `Fixes`.** This makes the hook reachable; it does not yet decide where the per-provider list is sourced from. You named the hook but deliberately not the source, so I have left that to you and asked on #9902: provider registration in `provider-keys.ts`, the models.dev generated catalog capabilities, or vendor-local? Happy to wire it up in this PR once you say which.

**Not addressed here (deliberate boundary).** The tool-result image path has the same omission and is still unwired: `toImageDataPart` (`ai-sdk-format.ts:173`), `split-tool-images.ts:302` and `:326`, and `message-builder.ts:1458`. It has a live webp producer (`file-read.ts:26` maps `.webp` → `image/webp`), so an agent *reading* a `.webp` would still hit the 400 even once the option is populated. I left it out because threading it crosses into `@cline/llms` and `@cline/core` and roughly triples the diff. Happy to do it as a follow-up, or here if you prefer one PR.

**Two sharp edges for whoever populates the option.** `[] ?? DEFAULT` is `[]`, so passing an empty array means "drop every image" silently, worth guarding if the value is sourced from a capability field that defaults to empty. And matching is case-sensitive exact, so `["image/JPEG"]` matches nothing. I did not normalise either, as that goes beyond making the hook reachable.

**Residual risk.** The two remote `http`/`https` branches intentionally bypass the filter, since a remote URL's `mediaType` is unverified caller metadata and the provider fetches the bytes itself. Also, an option-driven drop on the binary path short-circuits before `recordOmittedImage`, so it will not appear in `omittedReasons`, pre-existing, but that branch becomes newly reachable for valid user images with this change.