### PR TITLE
fix: stop Ollama model picker polling /api/tags once per second forever (ENG-2344)

### DIFF
--- a/apps/vscode/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/ApiOptions.tsx
@@ -1,9 +1,7 @@
-import { StringRequest } from "@shared/proto/cline/common"
 import type { Mode } from "@shared/storage/types"
 import { VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
 import Fuse from "fuse.js"
-import { type KeyboardEvent, useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { useInterval } from "react-use"
+import { type KeyboardEvent, useEffect, useMemo, useRef, useState } from "react"
 import styled from "styled-components"
 
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
@@ -12,7 +10,6 @@ import { CLINE_PASS_FEATURE_FLAG } from "@/constants/featureFlags"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { useHasFeatureFlag } from "@/hooks/useFeatureFlag"
 import { useProviderListings } from "@/hooks/useProviderListings"
-import { ModelsServiceClient } from "@/services/grpc-client"
 import { OPENROUTER_MODEL_PICKER_Z_INDEX } from "./OpenRouterModelPicker"
 import { AIhubmixProvider } from "./providers/AihubmixProvider"
 import { AnthropicProvider } from "./providers/AnthropicProvider"
@@ -119,33 +116,6 @@ const ApiOptions = ({
 			getFallbackGenericProviderSettings(selectedProvider))
 
 	const { handleModeFieldChange } = useApiConfigurationHandlers()
-
-	const [_ollamaModels, setOllamaModels] = useState<string[]>([])
-
-	// Poll ollama/vscode-lm models
-	const requestLocalModels = useCallback(async () => {
-		if (selectedProvider === "ollama") {
-			try {
-				const response = await ModelsServiceClient.getOllamaModels(
-					StringRequest.create({
-						value: apiConfiguration?.ollamaBaseUrl || "",
-					}),
-				)
-				if (response && response.values) {
-					setOllamaModels(response.values)
-				}
-			} catch (error) {
-				console.error("Failed to fetch Ollama models:", error)
-				setOllamaModels([])
-			}
-		}
-	}, [selectedProvider, apiConfiguration?.ollamaBaseUrl])
-	useEffect(() => {
-		if (selectedProvider === "ollama") {
-			requestLocalModels()
-		}
-	}, [selectedProvider, requestLocalModels])
-	useInterval(requestLocalModels, selectedProvider === "ollama" ? 2000 : null)
 
 	// Provider search state
 	const [searchTerm, setSearchTerm] = useState("")

--- a/apps/vscode/webview-ui/src/components/settings/OllamaModelPicker.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/OllamaModelPicker.tsx
@@ -10,6 +10,8 @@ interface OllamaModelPickerProps {
 	ollamaModels: string[]
 	selectedModelId: string
 	onModelChange: (modelId: string) => void
+	/** Called when the search field gains focus, e.g. to refresh the model list on demand. */
+	onFocus?: () => void
 	placeholder?: string
 }
 
@@ -17,6 +19,7 @@ const OllamaModelPicker: React.FC<OllamaModelPickerProps> = ({
 	ollamaModels,
 	selectedModelId,
 	onModelChange,
+	onFocus,
 	placeholder = "Search and select a model...",
 }) => {
 	const [searchTerm, setSearchTerm] = useState(selectedModelId || "")
@@ -131,7 +134,10 @@ const OllamaModelPicker: React.FC<OllamaModelPickerProps> = ({
 			<DropdownWrapper ref={dropdownRef}>
 				<VSCodeTextField
 					id="ollama-model-search"
-					onFocus={() => setIsDropdownVisible(true)}
+					onFocus={() => {
+						setIsDropdownVisible(true)
+						onFocus?.()
+					}}
 					onInput={(e) => {
 						const value = (e.target as HTMLInputElement)?.value || ""
 						handleModelChange(value)

--- a/apps/vscode/webview-ui/src/components/settings/providers/LMStudioProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/LMStudioProvider.tsx
@@ -2,7 +2,6 @@ import { type ModelInfo, openAiModelInfoSafeDefaults } from "@shared/api"
 import type { Mode } from "@shared/storage/types"
 import { VSCodeDropdown, VSCodeLink, VSCodeOption, VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
 import { useCallback, useEffect, useMemo, useState } from "react"
-import { useInterval } from "react-use"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { useProviderConfig } from "@/hooks/useProviderConfig"
 import { useProviderModelSelection } from "@/hooks/useProviderModelSelection"
@@ -103,7 +102,8 @@ export const LMStudioProvider = ({ currentMode }: LMStudioProviderProps) => {
 		[commitModelSelection, lmStudioModels, toLmStudioModelInfo],
 	)
 
-	// Poll LM Studio models
+	// Fetch LM Studio models on mount and whenever the endpoint changes (no
+	// interval polling — the endpoint is user-configurable, see ENG-2344)
 	const requestLmStudioModels = useCallback(async () => {
 		await ModelsServiceClient.getLmStudioModels({
 			value: endpoint,
@@ -145,8 +145,6 @@ export const LMStudioProvider = ({ currentMode }: LMStudioProviderProps) => {
 		apiConfiguration?.lmStudioMaxTokens,
 		handleFieldChange,
 	])
-
-	useInterval(requestLmStudioModels, 6000)
 
 	return (
 		<div className="flex flex-col gap-2">

--- a/apps/vscode/webview-ui/src/components/settings/providers/LMStudioProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/LMStudioProvider.tsx
@@ -102,8 +102,10 @@ export const LMStudioProvider = ({ currentMode }: LMStudioProviderProps) => {
 		[commitModelSelection, lmStudioModels, toLmStudioModelInfo],
 	)
 
-	// Fetch LM Studio models on mount and whenever the endpoint changes (no
-	// interval polling — the endpoint is user-configurable, see ENG-2344)
+	// Fetch LM Studio models on mount, whenever the endpoint changes, and when
+	// the model control gains focus (no interval polling — the endpoint is
+	// user-configurable, see ENG-2344), so a server started after mount is
+	// still discovered.
 	const requestLmStudioModels = useCallback(async () => {
 		await ModelsServiceClient.getLmStudioModels({
 			value: endpoint,
@@ -157,7 +159,7 @@ export const LMStudioProvider = ({ currentMode }: LMStudioProviderProps) => {
 
 			<div className="font-semibold">Model</div>
 			{lmStudioModels.length > 0 ? (
-				<DropdownContainer className="dropdown-container" zIndex={10}>
+				<DropdownContainer className="dropdown-container" onFocusCapture={() => void requestLmStudioModels()} zIndex={10}>
 					<VSCodeDropdown
 						className="w-full mb-3"
 						onChange={(e: any) => {
@@ -175,12 +177,14 @@ export const LMStudioProvider = ({ currentMode }: LMStudioProviderProps) => {
 					</VSCodeDropdown>
 				</DropdownContainer>
 			) : (
-				<DebouncedTextField
-					initialValue={displayedSelectedModelId || ""}
-					onChange={handleModelChange}
-					placeholder={"e.g. meta-llama-3.1-8b-instruct"}
-					style={{ width: "100%" }}
-				/>
+				<div onFocusCapture={() => void requestLmStudioModels()}>
+					<DebouncedTextField
+						initialValue={displayedSelectedModelId || ""}
+						onChange={handleModelChange}
+						placeholder={"e.g. meta-llama-3.1-8b-instruct"}
+						style={{ width: "100%" }}
+					/>
+				</div>
 			)}
 
 			<div className="font-semibold">Context Window</div>

--- a/apps/vscode/webview-ui/src/components/settings/providers/OllamaProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/OllamaProvider.tsx
@@ -3,7 +3,6 @@ import { StringRequest } from "@shared/proto/cline/common"
 import { Mode } from "@shared/storage/types"
 import { VSCodeLink } from "@vscode/webview-ui-toolkit/react"
 import { useCallback, useEffect, useMemo, useState } from "react"
-import { useInterval } from "react-use"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { useProviderConfig } from "@/hooks/useProviderConfig"
 import { useProviderModelSelection } from "@/hooks/useProviderModelSelection"
@@ -68,7 +67,10 @@ export const OllamaProvider = ({ showModelOptions, isPopup, currentMode }: Ollam
 		[write],
 	)
 
-	// Poll ollama models
+	// Fetch ollama models on mount and whenever the base URL changes. The
+	// picker also refetches on focus — do NOT poll on an interval: the base
+	// URL is user-configurable, so an unbounded poll can hammer a remote or
+	// metered endpoint for as long as the settings pane is open (ENG-2344).
 	const requestOllamaModels = useCallback(async () => {
 		try {
 			const response = await ModelsServiceClient.getOllamaModels(
@@ -88,8 +90,6 @@ export const OllamaProvider = ({ showModelOptions, isPopup, currentMode }: Ollam
 	useEffect(() => {
 		requestOllamaModels()
 	}, [requestOllamaModels])
-
-	useInterval(requestOllamaModels, 2000)
 
 	return (
 		<div className="flex flex-col gap-2">
@@ -116,6 +116,7 @@ export const OllamaProvider = ({ showModelOptions, isPopup, currentMode }: Ollam
 			</label>
 			<OllamaModelPicker
 				ollamaModels={ollamaModels}
+				onFocus={requestOllamaModels}
 				onModelChange={(modelId) => {
 					const trimmedModelId = modelId.trim()
 					if (!trimmedModelId) {

--- a/apps/vscode/webview-ui/src/components/settings/providers/VSCodeLmProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/VSCodeLmProvider.tsx
@@ -3,7 +3,6 @@ import type { Mode } from "@shared/storage/types"
 import { parseVsCodeLmModelSelector, stringifyVsCodeLmModelSelector } from "@shared/vsCodeSelectorUtils"
 import { VSCodeDropdown, VSCodeOption } from "@vscode/webview-ui-toolkit/react"
 import { useCallback, useEffect, useState } from "react"
-import { useInterval } from "react-use"
 import type * as vscodemodels from "vscode"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { useProviderConfig } from "@/hooks/useProviderConfig"
@@ -28,7 +27,7 @@ export const VSCodeLmProvider = ({ currentMode }: VSCodeLmProviderProps) => {
 		? stringifyVsCodeLmModelSelector(vsCodeLmModelSelector)
 		: (committedSelection?.modelId ?? "")
 
-	// Poll VS Code LM models
+	// Fetch VS Code LM models once on mount (no interval polling — ENG-2344)
 	const requestVsCodeLmModels = useCallback(async () => {
 		try {
 			const response = await ModelsServiceClient.getVsCodeLmModels(EmptyRequest.create({}))
@@ -44,8 +43,6 @@ export const VSCodeLmProvider = ({ currentMode }: VSCodeLmProviderProps) => {
 	useEffect(() => {
 		requestVsCodeLmModels()
 	}, [requestVsCodeLmModels])
-
-	useInterval(requestVsCodeLmModels, 2000)
 
 	const handleModelSelect = (modelId: string) => {
 		if (!modelId) {

--- a/apps/vscode/webview-ui/src/components/settings/providers/VSCodeLmProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/VSCodeLmProvider.tsx
@@ -1,7 +1,7 @@
 import { EmptyRequest } from "@shared/proto/cline/common"
 import type { Mode } from "@shared/storage/types"
 import { parseVsCodeLmModelSelector, stringifyVsCodeLmModelSelector } from "@shared/vsCodeSelectorUtils"
-import { VSCodeDropdown, VSCodeOption } from "@vscode/webview-ui-toolkit/react"
+import { VSCodeDropdown, VSCodeLink, VSCodeOption } from "@vscode/webview-ui-toolkit/react"
 import { useCallback, useEffect, useState } from "react"
 import type * as vscodemodels from "vscode"
 import { useExtensionState } from "@/context/ExtensionStateContext"
@@ -27,7 +27,9 @@ export const VSCodeLmProvider = ({ currentMode }: VSCodeLmProviderProps) => {
 		? stringifyVsCodeLmModelSelector(vsCodeLmModelSelector)
 		: (committedSelection?.modelId ?? "")
 
-	// Fetch VS Code LM models once on mount (no interval polling — ENG-2344)
+	// Fetch VS Code LM models on mount, when the dropdown is focused, and via
+	// the explicit refresh link (no interval polling — ENG-2344), so models
+	// registered after mount (e.g. Copilot enabled later) are still discovered.
 	const requestVsCodeLmModels = useCallback(async () => {
 		try {
 			const response = await ModelsServiceClient.getVsCodeLmModels(EmptyRequest.create({}))
@@ -70,7 +72,10 @@ export const VSCodeLmProvider = ({ currentMode }: VSCodeLmProviderProps) => {
 
 	return (
 		<div>
-			<DropdownContainer className="dropdown-container" zIndex={DROPDOWN_Z_INDEX - 2}>
+			<DropdownContainer
+				className="dropdown-container"
+				onFocusCapture={() => void requestVsCodeLmModels()}
+				zIndex={DROPDOWN_Z_INDEX - 2}>
 				<label htmlFor="vscode-lm-model">
 					<span style={{ fontWeight: 500 }}>Language Model</span>
 				</label>
@@ -101,7 +106,13 @@ export const VSCodeLmProvider = ({ currentMode }: VSCodeLmProviderProps) => {
 						is GitHub Copilot — install the{" "}
 						<a href="https://marketplace.visualstudio.com/items?itemName=GitHub.copilot">Copilot extension</a> and
 						enable models in Copilot settings — but any extension that registers a language model provider will appear
-						here.
+						here.{" "}
+						<VSCodeLink
+							onClick={() => void requestVsCodeLmModels()}
+							style={{ display: "inline", fontSize: "inherit" }}>
+							Refresh the model list
+						</VSCodeLink>{" "}
+						after enabling models.
 					</p>
 				)}
 			</DropdownContainer>


### PR DESCRIPTION
### Related Issue

**Issue:** [ENG-2344](https://linear.app/cline-bot/issue/ENG-2344/ollama-model-picker-polls-apitags-about-once-per-second-forever) — Ollama model picker polls `/api/tags` about once per second, forever

### Description

Opening the Ollama provider form started an unbounded poll of `${baseUrl}/api/tags` at ~1 req/s that only stopped when the user navigated away. The measured "two requests every two seconds" came from **two** simultaneous 2s intervals:

- `OllamaProvider.tsx` — `useInterval(requestOllamaModels, 2000)`
- `ApiOptions.tsx` — a duplicate poll whose result (`_ollamaModels`) was **never read**, i.e. dead code

Since the base URL is user-configurable, this could sustain 1 req/s against a remote or metered endpoint from every open settings pane.

Changes:

- Remove all `useInterval` model polling from `OllamaProvider`, `VSCodeLmProvider` (same pattern, flagged in the ticket), and `LMStudioProvider` (same pattern at 6s). Models are still fetched on mount and whenever the base URL / endpoint changes.
- Delete the dead `_ollamaModels` poll block in `ApiOptions.tsx` and its now-unused imports.
- Preserve the "server started after the pane opened" UX: `OllamaModelPicker` now accepts an optional `onFocus` callback, and `OllamaProvider` uses it to refresh the model list whenever the model search field gains focus — one request per explicit user interaction instead of an interval.

### Test Procedure

Verified end-to-end in a real extension development host against a mock Ollama server on `127.0.0.1:11434` that logs every timestamped request.

- **Reproduced on `main` first:** with the Ollama settings pane open and idle, the mock server logged **90 requests in 90 seconds** (1.0 req/s), in pairs every 2s — matching the ticket's measurements exactly.
- **With this fix:** same scenario logged **0 requests in 90 seconds** while idle. Focusing the Model field triggered exactly one `GET /api/tags` each time, the dropdown listed the mock server's models, and selecting a model worked.
- `webview-ui` unit tests: all 120 settings component tests pass (`vitest run src/components/settings`), including the existing `OllamaModelPicker` spec.
- `tsc -b && vite build` (webview) and `bun esbuild.mjs` (extension bundle) both pass; biome format/lint clean on the changed files.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Fixed build, Ollama settings pane open; the integrated terminal tails the mock server's request log. While idle, no new `GET /api/tags` lines appear (last entry is from the earlier explicit fetch):

![Ollama settings pane idle with no polling requests in the tailed log](https://cursor.com/artifacts/c/art-8ef4dcd4-7aae-4037-b610-9dfa4a906b95)

Focusing the Model field triggers exactly one `GET /api/tags` (04:17:32 line in the terminal) and populates the dropdown from the mock server:

![Single request on focus, dropdown populated](https://cursor.com/artifacts/c/art-9d673b53-c36c-4b7b-a09b-5e17809666ab)

### Additional Notes

While testing I noticed the model dropdown fuzzy-filters by the currently selected model id on focus (e.g. `qwen2.5-coder:7b` hidden while the search term is `llama3.1:latest`) — that's pre-existing `OllamaModelPicker` behavior and matches the "adjacent picker defects" already listed in ENG-2344, so it is intentionally not addressed here.