### PR TITLE
Fix ignored China/international endpoint toggles for Qwen, Moonshot, Z AI (ENG-2340)

### DIFF
--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -422,6 +422,64 @@ describe("buildSessionConfig", () => {
 		})
 	})
 
+	it("forwards the regional API line from legacy state so the gateway can route to the regional endpoint", async () => {
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "zai",
+			actModeApiModelId: "glm-5.2",
+			zaiApiKey: "zai-key",
+			zaiApiLine: "china",
+		} as any)
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+
+		expect(config.providerId).toBe("zai")
+		expect(config.providerConfig).toMatchObject({
+			providerId: "zai",
+			apiLine: "china",
+		})
+		// No explicit base URL: the SDK gateway resolves the China endpoint
+		// (open.bigmodel.cn) from apiLine; a pre-filled base URL would win
+		// over that resolution.
+		expect(config.baseUrl).toBeUndefined()
+	})
+
+	it("falls back to the providers.json apiLine when legacy state has none", async () => {
+		mocks.providerSettingsManager.getProviderSettings.mockImplementation((providerId?: string) => {
+			if (providerId !== "moonshot") {
+				return undefined
+			}
+			return {
+				provider: "moonshot",
+				apiKey: "moonshot-key",
+				apiLine: "china",
+			} as any
+		})
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "moonshot",
+			actModeApiModelId: "kimi-k3",
+		} as any)
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+
+		expect(config.providerConfig).toMatchObject({
+			providerId: "moonshot",
+			apiLine: "china",
+		})
+	})
+
+	it("omits apiLine for unrecognized values", async () => {
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "qwen",
+			actModeApiModelId: "qwen-plus-latest",
+			qwenApiKey: "qwen-key",
+			qwenApiLine: "mars",
+		} as any)
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+
+		expect(config.providerConfig).not.toHaveProperty("apiLine")
+	})
+
 	it("exposes knownModels at the top level so manual compaction can budget against the model catalog", async () => {
 		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
 

--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -467,6 +467,47 @@ describe("buildSessionConfig", () => {
 		})
 	})
 
+	it("inherits the base provider's legacy apiLine for coding variants", async () => {
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "zai-coding-plan",
+			actModeApiModelId: "glm-5.2",
+			zaiApiKey: "zai-key",
+			zaiApiLine: "china",
+		} as any)
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+
+		expect(config.providerConfig).toMatchObject({
+			providerId: "zai-coding-plan",
+			apiLine: "china",
+		})
+	})
+
+	it("prefers the coding variant's own providers.json apiLine over the shared legacy field", async () => {
+		mocks.providerSettingsManager.getProviderSettings.mockImplementation((providerId?: string) => {
+			if (providerId !== "qwen-code") {
+				return undefined
+			}
+			return {
+				provider: "qwen-code",
+				apiKey: "qwen-code-key",
+				apiLine: "international",
+			} as any
+		})
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "qwen-code",
+			actModeApiModelId: "qwen3-coder-plus",
+			qwenApiLine: "china",
+		} as any)
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+
+		expect(config.providerConfig).toMatchObject({
+			providerId: "qwen-code",
+			apiLine: "international",
+		})
+	})
+
 	it("omits apiLine for unrecognized values", async () => {
 		mocks.stateManager.getApiConfiguration.mockReturnValue({
 			actModeApiProvider: "qwen",

--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -17,10 +17,11 @@ import {
 	resolveProviderApiKeyFromSettings,
 	type StartSessionResult,
 } from "@cline/core"
-import type { ModelInfo as SdkModelInfo } from "@cline/llms"
+import type { ModelInfo as SdkModelInfo, ProviderApiLine } from "@cline/llms"
 import {
 	getGeneratedModelsForProvider,
 	getModelsForProvider,
+	isProviderApiLine,
 	MODEL_COLLECTIONS_BY_PROVIDER_ID,
 	OLLAMA_DEFAULT_CONTEXT_WINDOW,
 } from "@cline/llms"
@@ -649,6 +650,41 @@ export function resolveBaseUrl(providerId: string, config: ApiConfiguration): st
 	return undefined
 }
 
+/**
+ * Resolve the regional API line ("china" | "international") for providers with
+ * regional endpoints (Qwen, Moonshot, Z AI, MiniMax). Legacy StateManager
+ * fields win (mirroring resolveBaseUrl), with providers.json `apiLine` as the
+ * SDK-store fallback. The SDK gateway maps the line to the provider's regional
+ * base URL when no explicit base URL is configured.
+ */
+export function resolveApiLine(providerId: string, config: ApiConfiguration): ProviderApiLine | undefined {
+	const apiLineMap: Record<string, keyof ApiConfiguration> = {
+		qwen: "qwenApiLine",
+		moonshot: "moonshotApiLine",
+		zai: "zaiApiLine",
+		minimax: "minimaxApiLine",
+	}
+
+	const field = apiLineMap[providerId]
+	if (field) {
+		const fromState = config[field]
+		if (isProviderApiLine(fromState)) {
+			return fromState
+		}
+	}
+
+	try {
+		const settingsApiLine = getProviderSettingsManager().getProviderSettings(providerSettingsProviderId(providerId))?.apiLine
+		if (isProviderApiLine(settingsApiLine)) {
+			return settingsApiLine
+		}
+	} catch {
+		Logger.warn(`[SessionFactory] Failed to read ${providerId} API line from providers.json`)
+	}
+
+	return undefined
+}
+
 // ---------------------------------------------------------------------------
 // Session config builder
 // ---------------------------------------------------------------------------
@@ -677,6 +713,7 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 	let modelId: string | undefined
 	let apiKey: string | undefined
 	let baseUrl: string | undefined
+	let apiLine: ProviderApiLine | undefined
 	let apiConfig: ApiConfiguration | undefined
 	// Cloud-provider structured options. The core runtime reads these from
 	// CoreSessionConfig.providerConfig; without them the SDK gateway never receives
@@ -706,6 +743,11 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 
 			// Resolve base URL
 			baseUrl = resolveBaseUrl(providerId, apiConfig)
+
+			// Resolve the regional API line (Qwen/Moonshot/Z AI/MiniMax). The
+			// SDK gateway routes to the line's regional endpoint when no
+			// explicit base URL is set.
+			apiLine = resolveApiLine(providerId, apiConfig)
 
 			// Resolve Bedrock region + AWS authentication options from the legacy
 			// ApiConfiguration (StateManager is the VSCode source of truth, not
@@ -754,6 +796,7 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 				modelId = lastUsed.model
 				apiKey = lastUsed.apiKey
 				baseUrl = lastUsed.baseUrl
+				apiLine = isProviderApiLine(lastUsed.apiLine) ? lastUsed.apiLine : undefined
 				Logger.log(`[SessionFactory] Using SDK provider fallback: ${providerId}/${modelId}`)
 			}
 		} catch (error) {
@@ -875,6 +918,7 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 		modelId,
 		...(apiKey ? { apiKey } : {}),
 		...(baseUrl !== undefined ? { baseUrl } : {}),
+		...(apiLine !== undefined ? { apiLine } : {}),
 		...(knownModels && Object.keys(knownModels).length > 0 ? { knownModels } : {}),
 		fetch,
 	}

--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -652,10 +652,18 @@ export function resolveBaseUrl(providerId: string, config: ApiConfiguration): st
 
 /**
  * Resolve the regional API line ("china" | "international") for providers with
- * regional endpoints (Qwen, Moonshot, Z AI, MiniMax). Legacy StateManager
- * fields win (mirroring resolveBaseUrl), with providers.json `apiLine` as the
- * SDK-store fallback. The SDK gateway maps the line to the provider's regional
- * base URL when no explicit base URL is configured.
+ * regional endpoints (Qwen, Moonshot, Z AI, MiniMax and their coding
+ * variants). Resolution order:
+ *
+ * 1. The provider's own legacy StateManager field (mirroring resolveBaseUrl).
+ * 2. The provider's own providers.json `apiLine` (SDK-store fallback).
+ * 3. For coding variants without their own legacy field or stored line, the
+ *    base provider's legacy field (qwen-code shares Qwen's DashScope region,
+ *    zai-coding-plan shares Z AI's account region) — so a variant-specific
+ *    providers.json setting still wins over the shared field.
+ *
+ * The SDK gateway maps the line to the provider's regional base URL when no
+ * explicit base URL is configured.
  */
 export function resolveApiLine(providerId: string, config: ApiConfiguration): ProviderApiLine | undefined {
 	const apiLineMap: Record<string, keyof ApiConfiguration> = {
@@ -663,6 +671,10 @@ export function resolveApiLine(providerId: string, config: ApiConfiguration): Pr
 		moonshot: "moonshotApiLine",
 		zai: "zaiApiLine",
 		minimax: "minimaxApiLine",
+	}
+	const sharedApiLineMap: Record<string, keyof ApiConfiguration> = {
+		"qwen-code": "qwenApiLine",
+		"zai-coding-plan": "zaiApiLine",
 	}
 
 	const field = apiLineMap[providerId]
@@ -680,6 +692,14 @@ export function resolveApiLine(providerId: string, config: ApiConfiguration): Pr
 		}
 	} catch {
 		Logger.warn(`[SessionFactory] Failed to read ${providerId} API line from providers.json`)
+	}
+
+	const sharedField = sharedApiLineMap[providerId]
+	if (sharedField) {
+		const fromSharedState = config[sharedField]
+		if (isProviderApiLine(fromSharedState)) {
+			return fromSharedState
+		}
 	}
 
 	return undefined

--- a/sdk/packages/core/src/services/llms/provider-settings.test.ts
+++ b/sdk/packages/core/src/services/llms/provider-settings.test.ts
@@ -36,4 +36,46 @@ describe("provider settings", () => {
 			}),
 		);
 	});
+
+	it("resolves the regional endpoint from apiLine when no base URL is set", () => {
+		expect(
+			toProviderConfig({ provider: "zai", apiLine: "china" }),
+		).toMatchObject({
+			apiLine: "china",
+			baseUrl: "https://open.bigmodel.cn/api/paas/v4",
+		});
+
+		expect(
+			toProviderConfig({ provider: "moonshot", apiLine: "china" }),
+		).toMatchObject({
+			baseUrl: "https://api.moonshot.cn/v1",
+		});
+
+		expect(
+			toProviderConfig({ provider: "qwen", apiLine: "international" }),
+		).toMatchObject({
+			baseUrl: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+		});
+	});
+
+	it("lets an explicit base URL win over apiLine", () => {
+		expect(
+			toProviderConfig({
+				provider: "zai",
+				apiLine: "china",
+				baseUrl: "https://proxy.example.com/v4",
+			}),
+		).toMatchObject({
+			baseUrl: "https://proxy.example.com/v4",
+		});
+	});
+
+	it("keeps the provider default base URL when no apiLine is set", () => {
+		expect(toProviderConfig({ provider: "zai" })).toMatchObject({
+			baseUrl: "https://api.z.ai/api/paas/v4",
+		});
+		expect(toProviderConfig({ provider: "moonshot" })).toMatchObject({
+			baseUrl: "https://api.moonshot.ai/v1",
+		});
+	});
 });

--- a/sdk/packages/core/src/services/llms/provider-settings.ts
+++ b/sdk/packages/core/src/services/llms/provider-settings.ts
@@ -222,8 +222,11 @@ export function toProviderConfig(
 	const generatedDefaultModelId = Object.keys(generatedKnownModels)[0];
 
 	const apiKey = getPersistedProviderApiKey(normalizedProviderId, settings);
+	// Precedence: explicit base URL > regional API line endpoint (e.g.
+	// Qwen/Moonshot/Z.AI "china" vs "international") > provider default.
 	const resolvedBaseUrl =
 		settings.baseUrl ??
+		Llms.resolveProviderApiLineBaseUrl(normalizedProviderId, settings.apiLine) ??
 		(normalizedProviderId === "oca"
 			? settings.oca?.mode === "internal"
 				? DEFAULT_INTERNAL_OCA_BASE_URL

--- a/sdk/packages/llms/src/index.ts
+++ b/sdk/packages/llms/src/index.ts
@@ -79,11 +79,14 @@ export {
 	isClineOrgIndividualInferenceSubscriptionMessage,
 	isClinePassLimitError,
 	isClinePassLimitMessage,
+	isProviderApiLine,
 	isRegisteredHandlerAsync,
 	normalizeProviderId,
 	OLLAMA_DEFAULT_CONTEXT_WINDOW,
+	type ProviderApiLine,
 	registerAsyncHandler,
 	registerHandler,
+	resolveProviderApiLineBaseUrl,
 } from "./providers";
 export {
 	type ProviderUsageCostDisplay,

--- a/sdk/packages/llms/src/providers.ts
+++ b/sdk/packages/llms/src/providers.ts
@@ -1,4 +1,9 @@
-export { OLLAMA_DEFAULT_CONTEXT_WINDOW } from "./providers/builtins";
+export {
+	isProviderApiLine,
+	OLLAMA_DEFAULT_CONTEXT_WINDOW,
+	type ProviderApiLine,
+	resolveProviderApiLineBaseUrl,
+} from "./providers/builtins";
 export {
 	type ApiHandler,
 	BUILT_IN_PROVIDER,

--- a/sdk/packages/llms/src/providers/builtin-types.ts
+++ b/sdk/packages/llms/src/providers/builtin-types.ts
@@ -25,6 +25,8 @@ export type ProviderFamily =
 	| "ollama"
 	| "sap-ai-core";
 
+export type ProviderApiLine = "china" | "international";
+
 export interface BuiltinSpec {
 	id: string;
 	name: string;
@@ -42,6 +44,13 @@ export interface BuiltinSpec {
 	modelsSourceUrl?: string;
 	docsUrl?: string;
 	defaults?: GatewayProviderSettings;
+	/**
+	 * Regional endpoint routing facts: base URL per API line. Used when the
+	 * caller selects an `apiLine` without an explicit base URL. The line that
+	 * matches `defaults.baseUrl` is included so the mapping is exhaustive and
+	 * self-documenting.
+	 */
+	apiLineBaseUrls?: Readonly<Partial<Record<ProviderApiLine, string>>>;
 	configFields?: readonly ProviderConfigField[];
 	metadata?: GatewayProviderMetadata;
 }

--- a/sdk/packages/llms/src/providers/builtins-runtime.ts
+++ b/sdk/packages/llms/src/providers/builtins-runtime.ts
@@ -98,6 +98,17 @@ export const BUILTIN_PROVIDER_REGISTRATIONS: GatewayProviderRegistration[] =
 			...spec.defaults,
 			apiKeyEnv: spec.apiKeyEnv,
 			baseUrl: spec.defaults?.baseUrl,
+			// Surface the regional endpoint facts as a default option so the
+			// registry can resolve a base URL from a caller-selected
+			// `options.apiLine` (see GatewayRegistry.createProvider).
+			...(spec.apiLineBaseUrls
+				? {
+						options: {
+							...(spec.defaults?.options ?? {}),
+							apiLineBaseUrls: spec.apiLineBaseUrls,
+						},
+					}
+				: {}),
 		},
 		loadProvider: async () => ({
 			createProvider: await loadFamilyFactory(resolveRuntimeFamily(spec)),

--- a/sdk/packages/llms/src/providers/builtins.test.ts
+++ b/sdk/packages/llms/src/providers/builtins.test.ts
@@ -4,7 +4,7 @@ import {
 	CLINE_ENVIRONMENTS,
 } from "@cline/shared";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { BUILTIN_SPECS } from "./builtins";
+import { BUILTIN_SPECS, resolveProviderApiLineBaseUrl } from "./builtins";
 import { getModelsForProvider, getProvider } from "./model-registry";
 import { GENERATED_PROVIDER_SPECS } from "./providers.generated";
 
@@ -143,6 +143,9 @@ describe("built-in provider metadata", () => {
 	});
 
 	it("uses generated specs directly when no runtime override is required", () => {
+		// moonshot is intentionally absent: it carries a Cline-specific
+		// regional routing override (apiLineBaseUrls) on top of its generated
+		// spec.
 		const generatedOnlyProviderIds = [
 			"fireworks",
 			"poolside",
@@ -150,7 +153,6 @@ describe("built-in provider metadata", () => {
 			"baseten",
 			"requesty",
 			"huggingface",
-			"moonshot",
 			"wandb",
 			"xiaomi",
 			"tencent-tokenhub",
@@ -250,5 +252,73 @@ describe("built-in provider metadata", () => {
 				},
 			},
 		});
+	});
+});
+
+describe("regional API line base URLs", () => {
+	it("exposes china/international endpoints on regional provider specs", () => {
+		const expectations: Record<
+			string,
+			{ china: string; international: string }
+		> = {
+			qwen: {
+				china: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+				international: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+			},
+			"qwen-code": {
+				china: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+				international: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+			},
+			moonshot: {
+				china: "https://api.moonshot.cn/v1",
+				international: "https://api.moonshot.ai/v1",
+			},
+			zai: {
+				china: "https://open.bigmodel.cn/api/paas/v4",
+				international: "https://api.z.ai/api/paas/v4",
+			},
+			"zai-coding-plan": {
+				china: "https://open.bigmodel.cn/api/coding/paas/v4",
+				international: "https://api.z.ai/api/coding/paas/v4",
+			},
+			minimax: {
+				china: "https://api.minimaxi.com/anthropic/v1",
+				international: "https://api.minimax.io/anthropic/v1",
+			},
+		};
+
+		for (const [providerId, expected] of Object.entries(expectations)) {
+			const spec = BUILTIN_SPECS.find((s) => s.id === providerId);
+			expect(spec?.apiLineBaseUrls, providerId).toEqual(expected);
+		}
+	});
+
+	it("resolves the regional base URL for a selected api line", () => {
+		expect(resolveProviderApiLineBaseUrl("zai", "china")).toBe(
+			"https://open.bigmodel.cn/api/paas/v4",
+		);
+		expect(resolveProviderApiLineBaseUrl("moonshot", "china")).toBe(
+			"https://api.moonshot.cn/v1",
+		);
+		expect(resolveProviderApiLineBaseUrl("qwen", "international")).toBe(
+			"https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+		);
+	});
+
+	it("returns undefined for unknown lines and non-regional providers", () => {
+		expect(resolveProviderApiLineBaseUrl("zai", undefined)).toBeUndefined();
+		expect(resolveProviderApiLineBaseUrl("zai", "mars")).toBeUndefined();
+		expect(
+			resolveProviderApiLineBaseUrl("anthropic", "china"),
+		).toBeUndefined();
+	});
+
+	it("keeps the international line consistent with the spec default base URL for zai and moonshot", () => {
+		for (const providerId of ["zai", "moonshot", "minimax"]) {
+			const spec = BUILTIN_SPECS.find((s) => s.id === providerId);
+			expect(spec?.apiLineBaseUrls?.international, providerId).toBe(
+				spec?.defaults?.baseUrl,
+			);
+		}
 	});
 });

--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -23,7 +23,7 @@ import type {
 	ProviderClient,
 	ProviderProtocol,
 } from "../catalog/types";
-import type { BuiltinSpec } from "./builtin-types";
+import type { BuiltinSpec, ProviderApiLine } from "./builtin-types";
 import {
 	ClineNotSubscribedError,
 	ClineOrgIndividualInferenceSubscriptionError,
@@ -32,6 +32,7 @@ import {
 	isClineNotSubscribedMessage,
 	isClineOrgIndividualInferenceSubscriptionMessage,
 } from "./errors";
+import { normalizeProviderId } from "./ids";
 import { filterOpenAICodexModels } from "./openai-codex-models";
 import { GENERATED_PROVIDER_SPECS } from "./providers.generated";
 import {
@@ -65,7 +66,11 @@ const OPENROUTER_STICKY_SESSION_METADATA: GatewayProviderMetadata = {
  */
 export const OLLAMA_DEFAULT_CONTEXT_WINDOW = 32768;
 
-export type { BuiltinSpec, ProviderFamily } from "./builtin-types";
+export type {
+	BuiltinSpec,
+	ProviderApiLine,
+	ProviderFamily,
+} from "./builtin-types";
 
 type BuiltinSpecOverride = Pick<BuiltinSpec, "id"> &
 	Partial<Omit<BuiltinSpec, "id">>;
@@ -207,6 +212,11 @@ const OCA_CONFIG_FIELDS: readonly ProviderConfigField[] = [
 		type: "boolean",
 	},
 ];
+
+const QWEN_API_LINE_BASE_URLS: Readonly<Record<ProviderApiLine, string>> = {
+	china: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+	international: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+};
 
 const QWEN_CONFIG_FIELDS: readonly ProviderConfigField[] = [
 	API_KEY_FIELD,
@@ -784,6 +794,7 @@ const OPENAI_COMPATIBLE_SPEC_OVERRIDES: BuiltinSpecOverride[] = [
 		apiKeyEnv: ["QWEN_API_KEY"],
 		modelsProviderId: "qwen",
 		defaults: { baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1" },
+		apiLineBaseUrls: QWEN_API_LINE_BASE_URLS,
 		configFields: QWEN_CONFIG_FIELDS,
 		metadata: QWEN_CACHE_ROUTING_METADATA,
 	},
@@ -796,8 +807,18 @@ const OPENAI_COMPATIBLE_SPEC_OVERRIDES: BuiltinSpecOverride[] = [
 		defaultModelId: "qwen3-coder-plus",
 		modelsProviderId: "qwen-code",
 		defaults: { baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1" },
+		apiLineBaseUrls: QWEN_API_LINE_BASE_URLS,
 		configFields: QWEN_CONFIG_FIELDS,
 		metadata: QWEN_CACHE_ROUTING_METADATA,
+	},
+	{
+		// Fully described by models.dev except for the regional endpoint
+		// routing policy (`apiLineBaseUrls`), which is Cline-specific.
+		id: "moonshot",
+		apiLineBaseUrls: {
+			china: "https://api.moonshot.cn/v1",
+			international: "https://api.moonshot.ai/v1",
+		},
 	},
 	{
 		id: "doubao",
@@ -820,6 +841,10 @@ const OPENAI_COMPATIBLE_SPEC_OVERRIDES: BuiltinSpecOverride[] = [
 		apiKeyEnv: ["ZHIPU_API_KEY"],
 		modelsProviderId: "zai",
 		defaults: { baseUrl: "https://api.z.ai/api/paas/v4" },
+		apiLineBaseUrls: {
+			china: "https://open.bigmodel.cn/api/paas/v4",
+			international: "https://api.z.ai/api/paas/v4",
+		},
 		metadata: GLM_THINKING_ROUTING_METADATA,
 	},
 	{
@@ -832,6 +857,10 @@ const OPENAI_COMPATIBLE_SPEC_OVERRIDES: BuiltinSpecOverride[] = [
 		apiKeyEnv: ["ZHIPU_API_KEY"],
 		modelsProviderId: "zai-coding-plan",
 		defaults: { baseUrl: "https://api.z.ai/api/coding/paas/v4" },
+		apiLineBaseUrls: {
+			china: "https://open.bigmodel.cn/api/coding/paas/v4",
+			international: "https://api.z.ai/api/coding/paas/v4",
+		},
 		metadata: GLM_THINKING_ROUTING_METADATA,
 	},
 	{
@@ -1049,6 +1078,10 @@ const BUILTIN_SPEC_OVERRIDES: BuiltinSpecOverride[] = [
 		apiKeyEnv: ["MINIMAX_API_KEY"],
 		modelsProviderId: "minimax",
 		defaults: { baseUrl: "https://api.minimax.io/anthropic/v1" },
+		apiLineBaseUrls: {
+			china: "https://api.minimaxi.com/anthropic/v1",
+			international: "https://api.minimax.io/anthropic/v1",
+		},
 		metadata: MINIMAX_THINKING_ROUTING_METADATA,
 	},
 	{
@@ -1090,6 +1123,37 @@ export const BUILTIN_SPECS: BuiltinSpec[] = mergeBuiltinSpecs(
 	GENERATED_PROVIDER_SPECS,
 	BUILTIN_SPEC_OVERRIDES,
 );
+
+const API_LINE_BASE_URLS_BY_PROVIDER_ID: ReadonlyMap<
+	string,
+	Readonly<Partial<Record<ProviderApiLine, string>>>
+> = new Map(
+	BUILTIN_SPECS.flatMap((spec) =>
+		spec.apiLineBaseUrls ? [[spec.id, spec.apiLineBaseUrls] as const] : [],
+	),
+);
+
+export function isProviderApiLine(value: unknown): value is ProviderApiLine {
+	return value === "china" || value === "international";
+}
+
+/**
+ * Resolve the regional base URL for a provider's selected API line (e.g.
+ * Qwen/Moonshot/Z.AI/MiniMax "china" vs "international" endpoints). Returns
+ * undefined when the provider has no regional endpoints or the api line is
+ * not a recognized value. Callers must let an explicit user-configured base
+ * URL win over this resolution.
+ */
+export function resolveProviderApiLineBaseUrl(
+	providerId: string,
+	apiLine: unknown,
+): string | undefined {
+	if (!isProviderApiLine(apiLine)) {
+		return undefined;
+	}
+	return API_LINE_BASE_URLS_BY_PROVIDER_ID.get(normalizeProviderId(providerId))
+		?.[apiLine];
+}
 
 function getModels(spec: BuiltinSpec): Record<string, ModelInfo> {
 	if (spec.modelsFactory) {

--- a/sdk/packages/llms/src/providers/gateway.test.ts
+++ b/sdk/packages/llms/src/providers/gateway.test.ts
@@ -3796,6 +3796,116 @@ describe("sdk-gateway", () => {
 		});
 	});
 
+	it.each([
+		["zai", "china", "glm-5.2", "https://open.bigmodel.cn/api/paas/v4"],
+		["zai", "international", "glm-5.2", "https://api.z.ai/api/paas/v4"],
+		["moonshot", "china", "kimi-k3", "https://api.moonshot.cn/v1"],
+		["moonshot", "international", "kimi-k3", "https://api.moonshot.ai/v1"],
+		[
+			"qwen",
+			"china",
+			"qwen-plus-latest",
+			"https://dashscope.aliyuncs.com/compatible-mode/v1",
+		],
+		[
+			"qwen",
+			"international",
+			"qwen-plus-latest",
+			"https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+		],
+	])(
+		"routes %s to the %s regional endpoint when options.apiLine is set",
+		async (providerId, apiLine, modelId, expectedBaseUrl) => {
+			streamTextSpy.mockReturnValue({
+				fullStream: makeStreamParts([
+					{ type: "text-delta", textDelta: "Regional" },
+					{ type: "finish", usage: { inputTokens: 2, outputTokens: 1 } },
+				]),
+			});
+
+			const gateway = createGateway({
+				providerConfigs: [
+					{ providerId, apiKey: "test-key", options: { apiLine } },
+				],
+			});
+
+			await collect(
+				await gateway.stream({
+					providerId,
+					modelId,
+					messages: baseMessages,
+				}),
+			);
+
+			expect(openaiCompatibleFactorySpy).toHaveBeenCalledWith(
+				expect.objectContaining({ baseURL: expectedBaseUrl }),
+			);
+		},
+	);
+
+	it("lets an explicit base URL win over options.apiLine", async () => {
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([
+				{ type: "text-delta", textDelta: "Explicit" },
+				{ type: "finish", usage: { inputTokens: 2, outputTokens: 1 } },
+			]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [
+				{
+					providerId: "zai",
+					apiKey: "test-key",
+					baseUrl: "https://proxy.example.com/v4",
+					options: { apiLine: "china" },
+				},
+			],
+		});
+
+		await collect(
+			await gateway.stream({
+				providerId: "zai",
+				modelId: "glm-5.2",
+				messages: baseMessages,
+			}),
+		);
+
+		expect(openaiCompatibleFactorySpy).toHaveBeenCalledWith(
+			expect.objectContaining({ baseURL: "https://proxy.example.com/v4" }),
+		);
+	});
+
+	it("ignores unrecognized apiLine values and keeps the provider default", async () => {
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([
+				{ type: "text-delta", textDelta: "Default" },
+				{ type: "finish", usage: { inputTokens: 2, outputTokens: 1 } },
+			]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [
+				{
+					providerId: "zai",
+					apiKey: "test-key",
+					options: { apiLine: "mars" },
+				},
+			],
+		});
+
+		await collect(
+			await gateway.stream({
+				providerId: "zai",
+				modelId: "glm-5.2",
+				messages: baseMessages,
+			}),
+		);
+
+		expect(openaiCompatibleFactorySpy).toHaveBeenCalledWith(
+			expect.objectContaining({ baseURL: "https://api.z.ai/api/paas/v4" }),
+		);
+	});
+
 	it("allows unregistered model ids on known providers", async () => {
 		streamTextSpy.mockReturnValue({
 			fullStream: makeStreamParts([

--- a/sdk/packages/llms/src/providers/registry.ts
+++ b/sdk/packages/llms/src/providers/registry.ts
@@ -83,6 +83,29 @@ function mergeProviderMetadata(
 	return Object.keys(metadata).length > 0 ? metadata : undefined;
 }
 
+/**
+ * Resolve a regional base URL from merged provider options: `apiLine` is the
+ * caller-selected line ("china" | "international") and `apiLineBaseUrls` maps
+ * lines to endpoints (registered as a builtin default from the provider
+ * manifest). Explicit caller base URLs always win over this resolution.
+ */
+function resolveApiLineBaseUrl(
+	options: Record<string, unknown>,
+): string | undefined {
+	const apiLine = options.apiLine;
+	if (apiLine !== "china" && apiLine !== "international") {
+		return undefined;
+	}
+	const baseUrls = options.apiLineBaseUrls;
+	if (typeof baseUrls !== "object" || baseUrls === null) {
+		return undefined;
+	}
+	const baseUrl = (baseUrls as Record<string, unknown>)[apiLine];
+	return typeof baseUrl === "string" && baseUrl.trim().length > 0
+		? baseUrl
+		: undefined;
+}
+
 function createUnregisteredModel(
 	provider: GatewayProviderManifest,
 	modelId: string,
@@ -251,6 +274,10 @@ export class GatewayRegistry {
 			record.defaults?.metadata,
 			config?.metadata,
 		);
+		const options = {
+			...(record.defaults?.options ?? {}),
+			...(config?.options ?? {}),
+		};
 
 		return {
 			manifest,
@@ -260,17 +287,17 @@ export class GatewayRegistry {
 				apiKeyResolver:
 					config?.apiKeyResolver ?? record.defaults?.apiKeyResolver,
 				apiKeyEnv: config?.apiKeyEnv ?? record.defaults?.apiKeyEnv,
-				baseUrl: config?.baseUrl ?? record.defaults?.baseUrl,
+				baseUrl:
+					config?.baseUrl ??
+					resolveApiLineBaseUrl(options) ??
+					record.defaults?.baseUrl,
 				headers: {
 					...(record.defaults?.headers ?? {}),
 					...(config?.headers ?? {}),
 				},
 				timeoutMs: config?.timeoutMs ?? record.defaults?.timeoutMs,
 				fetch: config?.fetch ?? record.defaults?.fetch ?? this.fallbackFetch,
-				options: {
-					...(record.defaults?.options ?? {}),
-					...(config?.options ?? {}),
-				},
+				options,
 				metadata,
 			},
 			createProvider: record.createProvider,


### PR DESCRIPTION
## Problem

[ENG-2340](https://linear.app/cline-bot/issue/ENG-2340/chinainternational-endpoint-toggles-for-qwen-moonshot-and-z-ai-are): the regional entrypoint toggles for Qwen, Moonshot, and Z AI are persisted through both storage layers (`providers.json` `apiLine` and legacy `*ApiLine` global state) but never affect the outbound request. China-line users are silently routed to international hosts and vice versa. TLS SNI captures in the ticket confirmed the wrong host for all three providers.

Root cause spanned three layers:

- `@cline/llms` had no china/international endpoint facts — no vendor or the gateway read `options.apiLine`.
- `@cline/core` `toProviderConfig` resolved `baseUrl` only from `settings.baseUrl` or the static provider default, ignoring `settings.apiLine`.
- The VS Code session factory never even included `apiLine` in the provider config it hands to core.

## Fix

- **`@cline/llms`**: regional base URLs are recorded as routing facts on the builtin provider specs (`apiLineBaseUrls` for `qwen`, `qwen-code`, `moonshot`, `zai`, `zai-coding-plan`, `minimax`, matching the legacy handlers' endpoints). `BUILTIN_PROVIDER_REGISTRATIONS` surfaces them as a default option, and `GatewayRegistry.createProvider` resolves `options.apiLine` against them — with an explicit configured base URL always winning. A `resolveProviderApiLineBaseUrl` helper is exported for hosts.
- **`@cline/core`**: `toProviderConfig` now resolves the base URL with precedence explicit `baseUrl` > regional API-line endpoint > provider default. This covers the CLI/core `providers.json` path.
- **VS Code** (`cline-session-factory.ts`): `buildSessionConfig` resolves the API line from legacy state (`qwenApiLine`/`moonshotApiLine`/`zaiApiLine`/`minimaxApiLine`) with a `providers.json` fallback, and forwards it on the provider config so the gateway routes regionally.

## Verification

**Wire capture before/after** — a script drives the real `toProviderConfig` → `createAgentModelFromConfig` → gateway stack with an injected `fetch` recording the request host, for both the providers.json path and the VS Code-shaped provider config. On unfixed `main` it reproduces the ticket exactly (zai/moonshot china → international hosts, qwen international → china host); on this branch all 10 scenarios route correctly, including explicit-base-URL precedence:

- Before: [wire_capture_before_fix.txt](/opt/cursor/artifacts/wire_capture_before_fix.txt)
- After: [wire_capture_after_fix.txt](/opt/cursor/artifacts/wire_capture_after_fix.txt)

**End-to-end in the real extension, at the TLS layer** (same methodology as the ticket): redirected `open.bigmodel.cn`/`api.z.ai` to a local TLS ClientHello SNI logger via `/etc/hosts`, ran the dev-host extension, configured Z AI with the **open.bigmodel.cn** entrypoint, and sent a message. The extension emitted `SNI=open.bigmodel.cn` ×3 — the ticket's pre-fix capture showed `SNI=api.z.ai` ×3 for the same configuration ([capture log](/opt/cursor/artifacts/vscode_extension_sni_capture_china.log)).

![Z AI provider settings with the open.bigmodel.cn (China) entrypoint selected](https://cursor.com/artifacts/c/art-46b06704-477d-4411-8cbd-407941873188)
![Request attempted against the redirected China endpoint (expected connection error from the local capture server)](https://cursor.com/artifacts/c/art-038a5c3a-374b-4055-a3fa-fa91601fedd3)

**Tests**

- New: gateway apiLine routing tests (6 provider/line combos + explicit-URL precedence + unknown-value fallback), builtin spec/helper tests, core `toProviderConfig` tests, VS Code `buildSessionConfig` tests (legacy state, providers.json fallback, invalid value).
- Full suites: `@cline/llms` 432 passed, `@cline/core` 1438 passed (1 known cloud-VM git `insteadOf` artifact per AGENTS.md), VS Code `test:unit` 989 passed, `bun run types` clean, biome lint clean on changed files.