### PR TITLE
Remove dead Reconstruct Task History command

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -228,11 +228,6 @@
 				"command": "cline.openWalkthrough",
 				"title": "Open Walkthrough",
 				"category": "Cline"
-			},
-			{
-				"command": "cline.reconstructTaskHistory",
-				"title": "Reconstruct Task History",
-				"category": "Cline"
 			}
 		],
 		"keybindings": [

--- a/apps/vscode/src/registry.ts
+++ b/apps/vscode/src/registry.ts
@@ -26,7 +26,6 @@ const ClineCommands = {
 	Walkthrough: prefix + ".openWalkthrough",
 	GenerateCommit: prefix + ".generateGitCommitMessage",
 	AbortCommit: prefix + ".abortGitCommitMessage",
-	ReconstructTaskHistory: prefix + ".reconstructTaskHistory",
 	// Jupyter Notebook commands
 	JupyterGenerateCell: prefix + ".jupyterGenerateCell",
 	JupyterExplainCell: prefix + ".jupyterExplainCell",


### PR DESCRIPTION
### Related Issue

**Issue:** N/A — removes an unimplemented command discovered during pre-launch QA.

### Description

Removes the `Cline: Reconstruct Task History` command contribution and its unused registry entry. The command had no registered handler and silently did nothing when invoked.

### Test Procedure

- `bun run build:sdk`
- `cd apps/vscode && bun run package`
- Confirmed no `reconstructTaskHistory` references remain in `apps/vscode`.
- Launched a fresh Extension Development Host and verified the removed command returns “No matching results” while other Cline commands remain available.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [x] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing and code is formatted and linted
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

![Command Palette no longer lists Reconstruct Task History](https://cursor.com/artifacts/c/art-98ddb96a-d587-48c2-8c0a-9db388d07f5d)

### Additional Notes

The underlying task-history storage and History view are unchanged.