### PR TITLE
fix(cli): report correct default directories for --config and --data-dir in --help

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -260,7 +260,7 @@ Schedules can route results back to chat surfaces with `--delivery-adapter`, `--
 | `--compaction <agentic\|basic\|off>` | Context compaction mode. Defaults to `agentic`; use `basic` for local truncation or `off` to disable. |
 | `--retries <count>` | Maximum consecutive mistakes (retries) before halting (default: `3`) |
 | `--json` | Output NDJSON instead of styled text |
-| `--data-dir <path>` | Use isolated local state at `<path>` instead of `~/.cline` (enables sandbox mode automatically) |
+| `--data-dir <path>` | Use isolated local state at `<path>` instead of `~/.cline/data` (enables sandbox mode automatically) |
 | `--auto-approve [true\|false]` | Set tool auto-approval for all tools |
 | `--kanban` | Run the external `kanban` app |
 | `-y, --yolo` | Skip tool approval prompts, enable `submit_and_exit`, and disable spawn/team tools by default |

--- a/apps/cli/src/commands/program.test.ts
+++ b/apps/cli/src/commands/program.test.ts
@@ -1,0 +1,61 @@
+import { relative, sep } from "node:path";
+import {
+	resolveClineDataDir,
+	resolveClineDir,
+	setHomeDir,
+} from "@cline/shared/storage";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createProgram } from "./program";
+
+/** Render an absolute path under `home` the way help text does: `~/...`. */
+function tildePath(absolutePath: string, home: string): string {
+	return `~/${relative(home, absolutePath).split(sep).join("/")}`;
+}
+
+describe("root option help text", () => {
+	const FAKE_HOME = "/home/cline-help-test";
+	const savedEnv: Record<string, string | undefined> = {};
+
+	beforeAll(() => {
+		// Pin the resolver inputs so the defaults below are the true defaults
+		// (no CLINE_DIR/CLINE_DATA_DIR overrides, known home directory).
+		for (const key of ["CLINE_DIR", "CLINE_DATA_DIR"]) {
+			savedEnv[key] = process.env[key];
+			delete process.env[key];
+		}
+		setHomeDir(FAKE_HOME);
+	});
+
+	afterAll(() => {
+		for (const [key, value] of Object.entries(savedEnv)) {
+			if (value === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = value;
+			}
+		}
+	});
+
+	it("reports the actual resolver defaults for --config and --data-dir", () => {
+		// A wide help width keeps each option description on one line so the
+		// full default text can be matched.
+		const help = createProgram()
+			.configureHelp({ helpWidth: 500 })
+			.helpInformation();
+
+		const configDefault = tildePath(resolveClineDir(), FAKE_HOME);
+		const dataDirDefault = tildePath(resolveClineDataDir(), FAKE_HOME);
+
+		// Sanity-check the resolvers themselves so the assertions below can't
+		// silently drift along with a resolver regression.
+		expect(configDefault).toBe("~/.cline");
+		expect(dataDirDefault).toBe("~/.cline/data");
+
+		expect(help).toContain(
+			`Configuration directory (default: ${configDefault})`,
+		);
+		expect(help).toContain(
+			`Use isolated local state at this directory path (default: ${dataDirDefault})`,
+		);
+	});
+});

--- a/apps/cli/src/commands/program.ts
+++ b/apps/cli/src/commands/program.ts
@@ -64,13 +64,10 @@ export function addRootOptions(cmd: Command): Command {
 				"--acp",
 				"Run in Agent Client Protocol (ACP) mode for editor integration",
 			)
-			.option(
-				"--config <path>",
-				"Configuration directory (default: ~/.cline/data/settings)",
-			)
+			.option("--config <path>", "Configuration directory (default: ~/.cline)")
 			.option(
 				"--data-dir <path>",
-				"Use isolated local state at this directory path (default: ~/.cline)",
+				"Use isolated local state at this directory path (default: ~/.cline/data)",
 			)
 			.option(
 				"--hooks-dir <path>",


### PR DESCRIPTION
### Related Issue

**Issue:** #10858

### Description

`cline --help` reported swapped/wrong defaults for two root options:

- `--config` claimed `(default: ~/.cline/data/settings)` — but `--config` feeds `setClineDir()`, and `resolveClineDir()` defaults to `~/.cline`. (`~/.cline/data/settings` is only where `providers.json` and other settings files live.)
- `--data-dir` claimed `(default: ~/.cline)` — but without the flag, local state lives at `resolveClineDataDir()` = `~/.cline/data`.

This PR corrects both help strings in `apps/cli/src/commands/program.ts`, fixes the same `~/.cline` → `~/.cline/data` inaccuracy in the `--data-dir` row of `apps/cli/README.md`, and adds a regression test (`apps/cli/src/commands/program.test.ts`) that derives the expected `~/…` defaults from the actual resolvers (`resolveClineDir()` / `resolveClineDataDir()` in `@cline/shared/storage`) so the help text can't silently drift from resolver behavior again.

### Test Procedure

- Reproduced the wrong defaults on clean `main` via `bun run cli --help` before making the change.
- New regression test passes; when the fix was temporarily reverted, the test failed as expected, confirming it catches the defect.
- Full CLI unit suite: `bun -F @cline/cli test:unit` — 115 files, 896 tests, all passing.
- `tsc --noEmit` (CLI package typecheck) and `biome check` on touched files are clean.
- Verified live output after the fix:

```
  --config <path>               Configuration directory (default: ~/.cline)
  --data-dir <path>             Use isolated local state at this directory path
                                (default: ~/.cline/data)
```

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Terminal output evidence is included in the Test Procedure section (CLI-only change, no UI).

### Additional Notes

Help-text-only change: no option parsing or path-resolution behavior is modified.