### PR TITLE
Remove the attempt_completion tool and bound run iterations

### DIFF
--- a/apps/vscode/src/core/prompts/responses.ts
+++ b/apps/vscode/src/core/prompts/responses.ts
@@ -30,18 +30,6 @@ export const formatResponse = {
 	permissionDeniedError: (reason: string) =>
 		`Command execution blocked by CLINE_COMMAND_PERMISSIONS: ${reason}. You must try a different approach or ask the user to update the permission settings.`,
 
-	noToolsUsed: (usingNativeToolCalls: boolean) =>
-		`[ERROR] You did not use a tool in your previous response! Please retry with a tool use.
-
-${usingNativeToolCalls ? "" : toolUseInstructionsReminder}
-
-# Next Steps
-
-If you have completed the user's task, use the attempt_completion tool. 
-If you require additional information from the user, use the ask_followup_question tool. 
-Otherwise, if you have not completed the task and do not need additional information, then proceed with the next step of the task. 
-(This is an automated message, so do not respond to it conversationally.)`,
-
 	tooManyMistakes: (feedback?: string) =>
 		`You seem to be having trouble proceeding. The user has provided the following feedback to help guide you:\n<feedback>\n${feedback}\n</feedback>`,
 
@@ -374,9 +362,7 @@ Tool uses are formatted using XML-style tags. The tool name is enclosed in openi
 ...
 </tool_name>
 For example:
-<attempt_completion>
-<result>
-I have completed the task...
-</result>
-</attempt_completion>
+<read_file>
+<path>src/main.js</path>
+</read_file>
 Always adhere to this format for all tool uses to ensure proper parsing and execution.`

--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -422,6 +422,16 @@ describe("buildSessionConfig", () => {
 		})
 	})
 
+	it("bounds the agent loop with a finite maxIterations", async () => {
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+
+		// An undefined maxIterations lets a run loop on model requests forever
+		// (ENG-2331: 1,000+ requests observed in a single task).
+		expect(config.maxIterations).toBeDefined()
+		expect(Number.isFinite(config.maxIterations)).toBe(true)
+		expect(config.maxIterations).toBeGreaterThan(0)
+	})
+
 	it("exposes knownModels at the top level so manual compaction can budget against the model catalog", async () => {
 		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
 

--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -380,6 +380,15 @@ const PROVIDER_MODEL_ID_MAP: Record<string, { plan: keyof ApiConfiguration; act:
 const DEFAULT_PROVIDER_ID = "cline"
 
 /**
+ * Defensive ceiling on model requests per run (one run = one user turn).
+ * Legitimate agentic turns stay far below this; hitting it surfaces an error
+ * row and the user can continue with a new message. Without a bound, a model
+ * stuck in a tool loop issues requests indefinitely (observed 1,000+ requests
+ * per task before this was capped).
+ */
+const MAX_ITERATIONS_PER_RUN = 200
+
+/**
  * Providers whose model list comes from a live local endpoint (Ollama's
  * `/api/tags`, LM Studio's `/v1/models`). Their installed models are the only
  * meaningful catalog; a bundled-catalog default would silently select a model
@@ -911,7 +920,7 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 		...reasoningConfig,
 		...(maxTokensPerTurn !== undefined ? { maxTokensPerTurn } : {}),
 		...(temperature !== undefined ? { temperature } : {}),
-		maxIterations: undefined,
+		maxIterations: MAX_ITERATIONS_PER_RUN,
 		logger: sdkLogger,
 		extensionContext: {
 			user: distinctId ? { distinctId } : undefined,

--- a/apps/vscode/src/sdk/vscode-runtime-builder.test.ts
+++ b/apps/vscode/src/sdk/vscode-runtime-builder.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest"
+import type { McpHub } from "@/services/mcp/McpHub"
+import { createVscodeExtraTools } from "./vscode-runtime-builder"
+
+describe("createVscodeExtraTools", () => {
+	it("marks attempt_completion as completing the run", async () => {
+		const mcpHub = { getServers: () => [] } as unknown as McpHub
+
+		const tools = await createVscodeExtraTools(mcpHub)
+		const attemptCompletion = tools.find((tool) => tool.name === "attempt_completion")
+
+		expect(attemptCompletion).toBeDefined()
+		// Without lifecycle.completesRun the runtime loops back for another
+		// model request after every attempt_completion instead of ending the
+		// run (ENG-2331): an extra request per task, and an unbounded loop when
+		// the model keeps calling the tool.
+		expect(attemptCompletion?.lifecycle?.completesRun).toBe(true)
+	})
+})

--- a/apps/vscode/src/sdk/vscode-runtime-builder.test.ts
+++ b/apps/vscode/src/sdk/vscode-runtime-builder.test.ts
@@ -3,17 +3,16 @@ import type { McpHub } from "@/services/mcp/McpHub"
 import { createVscodeExtraTools } from "./vscode-runtime-builder"
 
 describe("createVscodeExtraTools", () => {
-	it("marks attempt_completion as completing the run", async () => {
+	it("does not register the removed attempt_completion tool", async () => {
 		const mcpHub = { getServers: () => [] } as unknown as McpHub
 
 		const tools = await createVscodeExtraTools(mcpHub)
-		const attemptCompletion = tools.find((tool) => tool.name === "attempt_completion")
 
-		expect(attemptCompletion).toBeDefined()
-		// Without lifecycle.completesRun the runtime loops back for another
-		// model request after every attempt_completion instead of ending the
-		// run (ENG-2331): an extra request per task, and an unbounded loop when
-		// the model keeps calling the tool.
-		expect(attemptCompletion?.lifecycle?.completesRun).toBe(true)
+		// attempt_completion was removed (ENG-2331): models rarely called it, and
+		// when they did the run never ended because the tool lacked
+		// lifecycle.completesRun — costing an extra model request per task and
+		// allowing unbounded request loops. Runs now end when the model finishes
+		// a turn without tool calls.
+		expect(tools.some((tool) => tool.name === "attempt_completion")).toBe(false)
 	})
 })

--- a/apps/vscode/src/sdk/vscode-runtime-builder.ts
+++ b/apps/vscode/src/sdk/vscode-runtime-builder.ts
@@ -84,6 +84,13 @@ function createAttemptCompletionTool(options: { cwd?: string } = {}): AgentTool 
 			},
 			required: ["result"],
 		},
+		// Ends the agent run after a successful call. Without this the runtime
+		// loops back for another model request after every attempt_completion —
+		// wasting a request per task at best, and looping unboundedly if the
+		// model keeps calling attempt_completion.
+		lifecycle: {
+			completesRun: true,
+		},
 		execute: async (input: unknown, context: AgentToolContext) => {
 			const parsedInput = input && typeof input === "object" ? (input as Record<string, unknown>) : {}
 			const resultText = typeof parsedInput.result === "string" ? parsedInput.result : "Task completed."

--- a/apps/vscode/src/sdk/vscode-runtime-builder.ts
+++ b/apps/vscode/src/sdk/vscode-runtime-builder.ts
@@ -1,5 +1,5 @@
-import { createDefaultShellExecutor, createMcpTools } from "@cline/core"
-import { type AgentTool, type AgentToolContext, createTool } from "@cline/shared"
+import { createMcpTools } from "@cline/core"
+import type { AgentTool, AgentToolContext } from "@cline/shared"
 import type { VscodeTerminalManager } from "@/hosts/vscode/terminal/VscodeTerminalManager"
 import type { McpHub } from "@/services/mcp/McpHub"
 import { Logger } from "@/shared/services/Logger"
@@ -44,84 +44,6 @@ class McpHubToolProvider {
 	}
 }
 
-/**
- * Lazily-created shell executor for attempt_completion commands.
- * Re-uses the SDK's built-in shell executor which
- * already handles cross-platform shells, timeout, abort signals, and output truncation.
- */
-const getCompletionCommandExecutor = (() => {
-	let executor: ReturnType<typeof createDefaultShellExecutor> | undefined
-	return () => {
-		if (!executor) {
-			executor = createDefaultShellExecutor({
-				timeoutMs: 15_000, // showcase commands, not long-running builds
-				maxOutputBytes: 256_000,
-			})
-		}
-		return executor!
-	}
-})()
-
-function createAttemptCompletionTool(options: { cwd?: string } = {}): AgentTool {
-	return createTool({
-		name: "attempt_completion",
-		description:
-			"Once you've completed the user's task, use this tool to present the result to the user. " +
-			"The user may provide feedback if they are not satisfied, which you can use to make improvements and try again.",
-		inputSchema: {
-			type: "object",
-			properties: {
-				result: {
-					type: "string",
-					description: "A clear, brief summary of the final result of the task.",
-				},
-				command: {
-					type: "string",
-					description:
-						"An optional terminal command to showcase the result (e.g. open a dev server). " +
-						"Do not use commands like echo or cat that merely print text.",
-				},
-			},
-			required: ["result"],
-		},
-		// Ends the agent run after a successful call. Without this the runtime
-		// loops back for another model request after every attempt_completion —
-		// wasting a request per task at best, and looping unboundedly if the
-		// model keeps calling attempt_completion.
-		lifecycle: {
-			completesRun: true,
-		},
-		execute: async (input: unknown, context: AgentToolContext) => {
-			const parsedInput = input && typeof input === "object" ? (input as Record<string, unknown>) : {}
-			const resultText = typeof parsedInput.result === "string" ? parsedInput.result : "Task completed."
-			const command = typeof parsedInput.command === "string" ? parsedInput.command.trim() : undefined
-
-			if (!command) {
-				return resultText
-			}
-
-			// Execute the command and include its output in the result
-			const cwd = options.cwd || process.cwd()
-			Logger.log(`[attempt_completion] Executing command: ${command} (cwd: ${cwd})`)
-
-			try {
-				const shellExecutor = getCompletionCommandExecutor()
-				const commandOutput = await shellExecutor(command, cwd, context)
-				const trimmedOutput = commandOutput.trim()
-
-				if (trimmedOutput) {
-					return `${resultText}\n\n[Command: ${command}]\n${trimmedOutput}`
-				}
-				return `${resultText}\n\n[Command executed: ${command}]`
-			} catch (error) {
-				const errorMsg = error instanceof Error ? error.message : String(error)
-				Logger.warn(`[attempt_completion] Command failed: ${errorMsg}`)
-				return `${resultText}\n\n[Command failed: ${command}]\n${errorMsg}`
-			}
-		},
-	})
-}
-
 export interface VscodeExtraToolsOptions {
 	cwd?: string
 	/**
@@ -156,7 +78,11 @@ export async function createVscodeExtraTools(mcpHub: McpHub, options?: VscodeExt
 		}),
 	)
 
-	const tools: AgentTool[] = [createAttemptCompletionTool({ cwd: options?.cwd }), ...mcpTools.flat()]
+	// Note: the legacy attempt_completion tool is intentionally NOT registered.
+	// Runs end when the model finishes a turn without tool calls; the message
+	// translator still renders completion_result rows for historical tasks
+	// (and the SDK's submit_and_exit) recorded before the tool was removed.
+	const tools: AgentTool[] = [...mcpTools.flat()]
 
 	// Add the custom run_commands tool when a terminal manager is available.
 	// This replaces the SDK's built-in run_commands, which is suppressed via


### PR DESCRIPTION
> [!NOTE]
> **Alternative PR.** The cloud-agent branch `saoudrizwan/sdk-turn-end-completion-ui-5e66` ("Cline agent UI feedback") removes `attempt_completion` with the *same* edit but also redesigns the completion UX — it infers turn-final text in `message-translator.ts` and styles it as a completion feedback row (proto + task history + webview changes). This PR is the **minimal alternative**: merge this one if we don't want those design changes. Under this PR, new tasks simply end in the awaiting-reply state with no completion card. If the other PR is preferred instead, it should cherry-pick the `maxIterations` bound and dead-prompt cleanup from here (it currently has neither).

### Related Issue

**Issue:** [ENG-2331](https://linear.app/cline-bot/issue/ENG-2331/attempt-completion-never-ends-a-run-every-task-costs-an-extra-request) — `attempt_completion` never ends a run; every task costs an extra request

### Description

The VS Code extension registered a legacy `attempt_completion` tool in every session but never set `lifecycle: { completesRun: true }`, so when the model called it the agent loop issued **another** model request instead of ending the run — surfacing as a red "Model returned empty response" row under the green "Task Completed" card (one wasted request per task), and looping unboundedly when the model kept calling it (QA measured 1,000+ requests in one task).

Rather than fixing the flag, this PR **removes the tool and its prompting entirely** (per discussion): in practice models rarely call it, and runs already end the standard way — when the model finishes a turn without tool calls.

1. `vscode-runtime-builder.ts`: drop the `attempt_completion` registration and its command shell executor. The tool is no longer advertised to models.
2. `core/prompts/responses.ts`: delete the dead `noToolsUsed` prompt (the only text instructing the model to use `attempt_completion`; never referenced) and swap the `<attempt_completion>` XML example in the legacy tool-use reminder for a generic one.
3. `cline-session-factory.ts`: replace `maxIterations: undefined` with a defensive ceiling of 200 model requests per run as the loop safety net.
4. The message translator, `completion_result` rendering, and turn-phase logic are intentionally kept so **historical tasks still render their green "Task Completed" cards** (and the SDK's `submit_and_exit` still works).

Behavior change to be aware of (decides [ENG-2352](https://linear.app/cline-bot/issue/ENG-2352/decision-no-visible-task-completed-state-unless-the-model-calls)): new tasks never show the green "Task Completed" card or the "Start New Task" footer state; every turn now ends in the awaiting-followup state. (The alternative branch mentioned in the note restores a completion presentation via turn-end inference instead.)

### Test Procedure

- Unit: `vscode-runtime-builder.test.ts` asserts `attempt_completion` is no longer registered; `cline-session-factory.test.ts` asserts a finite positive `maxIterations`. Full vitest suite (862 tests), bun unit suite (989 tests), and `bun run check-types` all pass.
- Manual E2E in a real extension development host against a mock OpenAI-compatible provider that logs every request and the advertised tool list:
  - New task: exactly **1** upstream request; request log shows `contains attempt_completion: false` (advertised tools: `read_files, search_codebase, fetch_web_content, apply_patch, ask_question, run_commands`); plain-text answer renders; turn ends cleanly with no error row.
  - Old task opened from history still renders its green "Task Completed" cards.
  - Real OpenRouter provider (`aion-labs/aion-2.0`, reasoning enabled): "Reply with exactly the word: pong" streams reasoning + "pong" and ends cleanly.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

New task after removal — plain-text ending, one request, no error row (and, by design, no green card):

![New task ends with a plain-text answer and no error row](https://cursor.com/artifacts/c/art-e88aecfd-cdec-435a-8e15-0788c919016a)

Old task opened from history — green "Task Completed" cards still render:

![Historical task still shows its green Task Completed cards](https://cursor.com/artifacts/c/art-0d49038c-c848-42e7-80ab-ed598a598bde)

Real OpenRouter task on the new build — reasoning + "pong", clean ending:

![Real OpenRouter task completes cleanly on the new build](https://cursor.com/artifacts/c/art-6d949eb4-b7e9-492d-b58d-abd29af3cee5)