### PR TITLE
Fix thinking indicator flashing when a turn completes

### DIFF
--- a/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/MessagesArea.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/MessagesArea.tsx
@@ -5,8 +5,8 @@ import { Virtuoso } from "react-virtuoso"
 import { StickyUserMessage } from "@/components/chat/task-header/StickyUserMessage"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { cn } from "@/lib/utils"
+import { useThinkingLoaderRow } from "../../hooks/useThinkingLoaderRow"
 import type { ChatState, MessageHandlers, ScrollBehavior } from "../../types/chatTypes"
-import { isToolGroup } from "../../utils/messageUtils"
 import { createMessageRenderer } from "../messages/MessageRenderer"
 
 // Sentinel ts for the synthetic "Thinking..." placeholder row. Not a real message; ignored when
@@ -77,109 +77,16 @@ export const MessagesArea: React.FC<MessagesAreaProps> = ({
 		return Array.isArray(lastRow) ? lastRow.at(-1) : lastRow
 	}, [lastVisibleRow])
 
-	// Show "Thinking..." until real content starts streaming.
-	// This is the sole early loading indicator - RequestStartRow does NOT duplicate it.
-	// Covers: pre-api_req_started (backend processing) AND post-api_req_started (waiting for model).
-	// Hides once reasoning, tools, text, or any other content message appears.
-	const isWaitingForResponse = useMemo(() => {
-		const lastMsg = modifiedMessages[modifiedMessages.length - 1]
-
-		// AUTHORITATIVE PATH: when the backend provides a TurnState, the agent is only "thinking"
-		// while phase === "streaming". Any other phase (awaiting_approval/followup, completed,
-		// error, resumable, idle) is never a thinking state — this is what makes the footer
-		// immune to trailing bookkeeping messages and prevents the stuck-"Thinking" bug (RC1).
-		// During streaming we still suppress the footer loader once a partial content row is
-		// actually rendering, to avoid a duplicate spinner (handled by the legacy sub-logic
-		// below, which only runs in the streaming case).
-		if (turnState) {
-			if (turnState.phase !== "streaming") {
-				return false
-			}
-			// phase === streaming: show Thinking until a visible content row is streaming.
-			if (groupedMessages.length === 0 || !lastVisibleMessage) {
-				return true
-			}
-			if (lastVisibleRow && isToolGroup(lastVisibleRow)) {
-				return true
-			}
-			return lastVisibleMessage.partial !== true
-		}
-
-		// LEGACY PATH (no TurnState — classic/older state): infer from the message tail.
-		// Never show thinking while waiting on user input (any ask state).
-		// This includes completion_result, tool approvals, followups, and resume asks.
-		if (lastRawMessage?.type === "ask") {
-			return false
-		}
-		// attempt_completion emits a final say("completion_result") before ask("completion_result").
-		// Treat that final completion message as non-waiting to avoid a brief footer flicker.
-		if (lastRawMessage?.type === "say" && lastRawMessage.say === "completion_result") {
-			return false
-		}
-		if (lastRawMessage?.type === "say" && lastRawMessage.say === "api_req_started") {
-			try {
-				const info = JSON.parse(lastRawMessage.text || "{}")
-				if (info.cancelReason === "user_cancelled") {
-					return false
-				}
-			} catch {
-				// ignore parse errors
-			}
-		}
-
-		// Always show while task has started but no visible rows are rendered yet.
-		if (groupedMessages.length === 0) {
-			return true
-		}
-
-		// Defensive guard for transient states where a grouped row exists
-		// but we still cannot resolve a concrete visible message.
-		if (!lastVisibleMessage) {
-			return true
-		}
-
-		// Always show when the last rendered row is a toolgroup.
-		if (lastVisibleRow && isToolGroup(lastVisibleRow)) {
-			return true
-		}
-
-		// User-requested behavior:
-		// if the last visible row is not actively partial, always show Thinking in the footer.
-		// (some rows like checkpoint_created don't set `partial`, and should be treated as non-partial)
-		if (lastVisibleMessage.partial !== true) {
-			return true
-		}
-
-		if (!lastMsg) {
-			// No messages after the initial task message - new task just started
-			return true
-		}
-		if (lastMsg.say === "user_feedback" || lastMsg.say === "user_feedback_diff") return true
-		if (lastMsg.say === "api_req_started") {
-			try {
-				const info = JSON.parse(lastMsg.text || "{}")
-				// Still in progress (no cost) and nothing has streamed after it yet
-				return info.cost == null
-			} catch {
-				return true
-			}
-		}
-		return false
-	}, [turnState, lastRawMessage, groupedMessages.length, lastVisibleMessage, lastVisibleRow, modifiedMessages])
-
-	// Keep loader in the message flow (not footer). During handoff from waiting -> reasoning stream,
-	// keep the loader mounted until a real reasoning row is visible.
-	const showThinkingLoaderRow = useMemo(() => {
-		const handoffToReasoningPending =
-			lastRawMessage?.type === "say" &&
-			lastRawMessage.say === "reasoning" &&
-			lastRawMessage.partial === true &&
-			lastVisibleMessage?.say !== "reasoning"
-
-		// Mirror the old footer behavior exactly: show whenever waiting logic says so.
-		// Plus a brief handoff guard while grouped rows catch up to raw reasoning stream.
-		return isWaitingForResponse || handoffToReasoningPending
-	}, [isWaitingForResponse, lastRawMessage, lastVisibleMessage?.say])
+	// Keep loader in the message flow (not footer). Show/hide logic (waiting heuristic,
+	// waiting -> reasoning handoff guard, and anti-flash debounce on turn end) lives in the hook.
+	const showThinkingLoaderRow = useThinkingLoaderRow({
+		turnState,
+		lastRawMessage,
+		groupedMessages,
+		lastVisibleRow,
+		lastVisibleMessage,
+		modifiedMessages,
+	})
 
 	const displayedGroupedMessages = useMemo<(ClineMessage | ClineMessage[])[]>(() => {
 		if (!showThinkingLoaderRow) {

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/index.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/index.ts
@@ -5,3 +5,4 @@
 export { useChatState } from "./useChatState"
 export { useMessageHandlers } from "./useMessageHandlers"
 export { useScrollBehavior } from "./useScrollBehavior"
+export { useThinkingLoaderRow } from "./useThinkingLoaderRow"

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useThinkingLoaderRow.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useThinkingLoaderRow.test.tsx
@@ -1,0 +1,149 @@
+import type { ClineMessage, TurnState } from "@shared/ExtensionMessage"
+import { act, renderHook } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import {
+	computeIsWaitingForResponse,
+	THINKING_LOADER_GRACE_MS,
+	type ThinkingLoaderInputs,
+	useThinkingLoaderRow,
+} from "./useThinkingLoaderRow"
+
+function say(ts: number, sayType: ClineMessage["say"], partial?: boolean, text = ""): ClineMessage {
+	return { ts, type: "say", say: sayType, text, partial }
+}
+
+function streaming(seq = 1): TurnState {
+	return { phase: "streaming", seq }
+}
+
+function inputsFor(messages: ClineMessage[], turnState: TurnState | undefined): ThinkingLoaderInputs {
+	return {
+		turnState,
+		lastRawMessage: messages.at(-1),
+		groupedMessages: messages,
+		lastVisibleRow: messages.at(-1),
+		lastVisibleMessage: messages.at(-1),
+		modifiedMessages: messages,
+	}
+}
+
+describe("computeIsWaitingForResponse (turnState path)", () => {
+	it("waits while streaming with no visible rows yet", () => {
+		expect(computeIsWaitingForResponse(inputsFor([], streaming()))).toBe(true)
+	})
+
+	it("does not wait while a content row is actively streaming", () => {
+		expect(computeIsWaitingForResponse(inputsFor([say(1, "text", true)], streaming()))).toBe(false)
+	})
+
+	it("waits when the last visible row is no longer partial while streaming", () => {
+		expect(computeIsWaitingForResponse(inputsFor([say(1, "text", false)], streaming()))).toBe(true)
+	})
+
+	it("never waits outside the streaming phase", () => {
+		expect(computeIsWaitingForResponse(inputsFor([say(1, "text", false)], { phase: "awaiting_followup", seq: 2 }))).toBe(
+			false,
+		)
+		expect(computeIsWaitingForResponse(inputsFor([say(1, "text", false)], { phase: "completed", seq: 2 }))).toBe(false)
+	})
+
+	it("does not wait on a final completion_result even while phase is still streaming", () => {
+		// attempt_completion's say("completion_result") lands before the done event flips the
+		// phase to "completed"; the loader must not flash during that gap.
+		expect(computeIsWaitingForResponse(inputsFor([say(1, "completion_result", false)], streaming()))).toBe(false)
+	})
+})
+
+describe("computeIsWaitingForResponse (legacy path)", () => {
+	it("does not wait when the last raw message is an ask", () => {
+		const ask: ClineMessage = { ts: 1, type: "ask", ask: "followup", text: "?", partial: false }
+		expect(computeIsWaitingForResponse(inputsFor([ask], undefined))).toBe(false)
+	})
+
+	it("does not wait on a final completion_result", () => {
+		expect(computeIsWaitingForResponse(inputsFor([say(1, "completion_result", false)], undefined))).toBe(false)
+	})
+
+	it("waits when the last visible row is not actively partial", () => {
+		expect(computeIsWaitingForResponse(inputsFor([say(1, "text", false)], undefined))).toBe(true)
+	})
+})
+
+describe("useThinkingLoaderRow anti-flash debounce", () => {
+	beforeEach(() => {
+		vi.useFakeTimers()
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+	})
+
+	function renderLoader(initial: ThinkingLoaderInputs) {
+		return renderHook((inputs: ThinkingLoaderInputs) => useThinkingLoaderRow(inputs), { initialProps: initial })
+	}
+
+	it("does not flash when the turn completes right after the tail message finalizes", () => {
+		// Streaming text row: loader hidden.
+		const { result, rerender } = renderLoader(inputsFor([say(1, "text", true)], streaming()))
+		expect(result.current).toBe(false)
+
+		// Tail finalizes (partial -> false) while turnState still says "streaming":
+		// the loader must NOT appear immediately.
+		rerender(inputsFor([say(1, "text", false)], streaming()))
+		expect(result.current).toBe(false)
+
+		// The done event flips the phase before the grace period elapses: no flash.
+		act(() => {
+			vi.advanceTimersByTime(THINKING_LOADER_GRACE_MS - 100)
+		})
+		rerender(inputsFor([say(1, "text", false)], { phase: "awaiting_followup", seq: 2 }))
+		act(() => {
+			vi.advanceTimersByTime(THINKING_LOADER_GRACE_MS)
+		})
+		expect(result.current).toBe(false)
+	})
+
+	it("shows the loader after the grace period when the wait is real (mid-turn)", () => {
+		const { result, rerender } = renderLoader(inputsFor([say(1, "text", true)], streaming()))
+		expect(result.current).toBe(false)
+
+		rerender(inputsFor([say(1, "text", false)], streaming()))
+		expect(result.current).toBe(false)
+
+		act(() => {
+			vi.advanceTimersByTime(THINKING_LOADER_GRACE_MS)
+		})
+		expect(result.current).toBe(true)
+	})
+
+	it("shows the loader immediately at turn start (no finalizing tail involved)", () => {
+		const userMessage = say(1, "user_feedback", false, "do the thing")
+		const { result, rerender } = renderLoader(inputsFor([userMessage], { phase: "awaiting_followup", seq: 1 }))
+		expect(result.current).toBe(false)
+
+		rerender(inputsFor([userMessage], streaming(2)))
+		expect(result.current).toBe(true)
+	})
+
+	it("hides the loader as soon as new content starts streaming during the wait", () => {
+		const { result, rerender } = renderLoader(inputsFor([say(1, "text", false)], streaming()))
+		act(() => {
+			vi.advanceTimersByTime(THINKING_LOADER_GRACE_MS)
+		})
+		expect(result.current).toBe(true)
+
+		rerender(inputsFor([say(1, "text", false), say(2, "reasoning", true, "hmm")], streaming()))
+		expect(result.current).toBe(false)
+	})
+
+	it("does not flash on attempt_completion turns even without the debounce timing", () => {
+		const { result, rerender } = renderLoader(inputsFor([say(1, "completion_result", true)], streaming()))
+		expect(result.current).toBe(false)
+
+		rerender(inputsFor([say(1, "completion_result", false)], streaming()))
+		act(() => {
+			vi.advanceTimersByTime(THINKING_LOADER_GRACE_MS)
+		})
+		expect(result.current).toBe(false)
+	})
+})

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useThinkingLoaderRow.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useThinkingLoaderRow.ts
@@ -1,0 +1,202 @@
+import type { ClineMessage, TurnState } from "@shared/ExtensionMessage"
+import { useEffect, useMemo, useRef, useState } from "react"
+import { isToolGroup } from "../utils/messageUtils"
+
+/**
+ * Grace period before showing the "Thinking..." loader row when its trigger is the tail
+ * message finishing streaming (partial -> false). That signal is ambiguous: mid-turn it means
+ * "waiting on the model's next content block / API request" (loader wanted), but at the end of
+ * a turn it arrives via the fast partial-message stream moments before the `done` event flips
+ * turnState out of "streaming" via a full state post. Showing instantly in that window makes
+ * the loader flash in and out on every turn completion, so hold off briefly — a real wait
+ * outlives the grace period, while the turn-end phase change cancels it.
+ */
+export const THINKING_LOADER_GRACE_MS = 500
+
+export interface ThinkingLoaderInputs {
+	turnState: TurnState | undefined
+	/** Tail of the raw clineMessages array. */
+	lastRawMessage: ClineMessage | undefined
+	groupedMessages: (ClineMessage | ClineMessage[])[]
+	/** Tail of groupedMessages. */
+	lastVisibleRow: ClineMessage | ClineMessage[] | undefined
+	/** Tail message of lastVisibleRow (last element when it is a group). */
+	lastVisibleMessage: ClineMessage | undefined
+	modifiedMessages: ClineMessage[]
+}
+
+/**
+ * Whether the agent is presumed to be working with nothing visibly streaming yet, i.e. the
+ * "Thinking..." loader row should be requested. This is the sole early loading indicator -
+ * RequestStartRow does NOT duplicate it.
+ * Covers: pre-api_req_started (backend processing) AND post-api_req_started (waiting for model).
+ * Hides once reasoning, tools, text, or any other content message appears.
+ */
+export function computeIsWaitingForResponse({
+	turnState,
+	lastRawMessage,
+	groupedMessages,
+	lastVisibleRow,
+	lastVisibleMessage,
+	modifiedMessages,
+}: ThinkingLoaderInputs): boolean {
+	const lastMsg = modifiedMessages[modifiedMessages.length - 1]
+
+	// AUTHORITATIVE PATH: when the backend provides a TurnState, the agent is only "thinking"
+	// while phase === "streaming". Any other phase (awaiting_approval/followup, completed,
+	// error, resumable, idle) is never a thinking state — this is what makes the footer
+	// immune to trailing bookkeeping messages and prevents the stuck-"Thinking" bug (RC1).
+	// During streaming we still suppress the footer loader once a partial content row is
+	// actually rendering, to avoid a duplicate spinner (handled by the legacy sub-logic
+	// below, which only runs in the streaming case).
+	if (turnState) {
+		if (turnState.phase !== "streaming") {
+			return false
+		}
+		// attempt_completion emits a final say("completion_result") a beat before the `done`
+		// event flips the phase to "completed". Treat it as non-waiting so the loader doesn't
+		// flash during that gap (same anti-flicker guard as the legacy path below).
+		if (lastRawMessage?.type === "say" && lastRawMessage.say === "completion_result") {
+			return false
+		}
+		// phase === streaming: show Thinking until a visible content row is streaming.
+		if (groupedMessages.length === 0 || !lastVisibleMessage) {
+			return true
+		}
+		if (lastVisibleRow && isToolGroup(lastVisibleRow)) {
+			return true
+		}
+		return lastVisibleMessage.partial !== true
+	}
+
+	// LEGACY PATH (no TurnState — classic/older state): infer from the message tail.
+	// Never show thinking while waiting on user input (any ask state).
+	// This includes completion_result, tool approvals, followups, and resume asks.
+	if (lastRawMessage?.type === "ask") {
+		return false
+	}
+	// attempt_completion emits a final say("completion_result") before ask("completion_result").
+	// Treat that final completion message as non-waiting to avoid a brief footer flicker.
+	if (lastRawMessage?.type === "say" && lastRawMessage.say === "completion_result") {
+		return false
+	}
+	if (lastRawMessage?.type === "say" && lastRawMessage.say === "api_req_started") {
+		try {
+			const info = JSON.parse(lastRawMessage.text || "{}")
+			if (info.cancelReason === "user_cancelled") {
+				return false
+			}
+		} catch {
+			// ignore parse errors
+		}
+	}
+
+	// Always show while task has started but no visible rows are rendered yet.
+	if (groupedMessages.length === 0) {
+		return true
+	}
+
+	// Defensive guard for transient states where a grouped row exists
+	// but we still cannot resolve a concrete visible message.
+	if (!lastVisibleMessage) {
+		return true
+	}
+
+	// Always show when the last rendered row is a toolgroup.
+	if (lastVisibleRow && isToolGroup(lastVisibleRow)) {
+		return true
+	}
+
+	// User-requested behavior:
+	// if the last visible row is not actively partial, always show Thinking in the footer.
+	// (some rows like checkpoint_created don't set `partial`, and should be treated as non-partial)
+	if (lastVisibleMessage.partial !== true) {
+		return true
+	}
+
+	if (!lastMsg) {
+		// No messages after the initial task message - new task just started
+		return true
+	}
+	if (lastMsg.say === "user_feedback" || lastMsg.say === "user_feedback_diff") return true
+	if (lastMsg.say === "api_req_started") {
+		try {
+			const info = JSON.parse(lastMsg.text || "{}")
+			// Still in progress (no cost) and nothing has streamed after it yet
+			return info.cost == null
+		} catch {
+			return true
+		}
+	}
+	return false
+}
+
+/**
+ * Debounced visibility for the in-list "Thinking..." loader row.
+ *
+ * Shows immediately for unambiguous triggers (turn start, new message appended, tool group
+ * tail). When the trigger is the current tail message transitioning partial -> non-partial,
+ * showing is delayed by THINKING_LOADER_GRACE_MS: at turn end that transition happens just
+ * before the phase flips out of "streaming", and an instant loader would flash in and out.
+ */
+export function useDebouncedLoaderVisibility(shouldShow: boolean, tailTs: number | undefined, tailIsPartial: boolean): boolean {
+	const [visible, setVisible] = useState(false)
+	const prevTailRef = useRef<{ ts: number | undefined; partial: boolean }>({ ts: undefined, partial: false })
+
+	useEffect(() => {
+		const prevTail = prevTailRef.current
+		prevTailRef.current = { ts: tailTs, partial: tailIsPartial }
+
+		if (!shouldShow) {
+			setVisible(false)
+			return
+		}
+
+		const tailJustFinishedStreaming = tailTs !== undefined && prevTail.ts === tailTs && prevTail.partial && !tailIsPartial
+		if (!tailJustFinishedStreaming) {
+			setVisible(true)
+			return
+		}
+
+		const timer = setTimeout(() => setVisible(true), THINKING_LOADER_GRACE_MS)
+		return () => clearTimeout(timer)
+	}, [shouldShow, tailTs, tailIsPartial])
+
+	return visible
+}
+
+/**
+ * Whether the in-list "Thinking..." loader row should currently be rendered.
+ * Combines the waiting heuristic, the waiting -> reasoning handoff guard, and the
+ * anti-flash debounce for tail-finalization triggers.
+ */
+export function useThinkingLoaderRow(inputs: ThinkingLoaderInputs): boolean {
+	const { turnState, lastRawMessage, groupedMessages, lastVisibleRow, lastVisibleMessage, modifiedMessages } = inputs
+
+	const isWaitingForResponse = useMemo(
+		() =>
+			computeIsWaitingForResponse({
+				turnState,
+				lastRawMessage,
+				groupedMessages,
+				lastVisibleRow,
+				lastVisibleMessage,
+				modifiedMessages,
+			}),
+		[turnState, lastRawMessage, groupedMessages, lastVisibleRow, lastVisibleMessage, modifiedMessages],
+	)
+
+	// During handoff from waiting -> reasoning stream, keep the loader mounted until a real
+	// reasoning row is visible in the grouped list.
+	const handoffToReasoningPending =
+		lastRawMessage?.type === "say" &&
+		lastRawMessage.say === "reasoning" &&
+		lastRawMessage.partial === true &&
+		lastVisibleMessage?.say !== "reasoning"
+
+	return useDebouncedLoaderVisibility(
+		isWaitingForResponse || handoffToReasoningPending,
+		lastVisibleMessage?.ts,
+		lastVisibleMessage?.partial === true,
+	)
+}


### PR DESCRIPTION
### Related Issue

N/A — reported directly: when the assistant finishes a turn, the "Thinking..." indicator flashes in for a split second and immediately hides.

### Description

At turn end, the final message is finalized (`partial: false`) via the fast partial-message stream a moment before the `done` event flips `turnState` out of `"streaming"` via a full state post. During that gap, the in-list "Thinking..." loader row in `MessagesArea` was shown (its rule: show while streaming whenever the last visible row is no longer partial), then immediately hidden when the phase changed — a flash on every turn completion (~100ms, confirmed frame-by-frame from a 60fps screen recording).

Changes:
- Extracted the loader show/hide logic from `MessagesArea.tsx` into a testable `useThinkingLoaderRow` hook (logic unchanged apart from the fixes below).
- Debounced the loader when its trigger is the tail message finishing streaming (partial → non-partial): mid-turn a real wait outlives the 500ms grace period, while the turn-end phase change cancels it before the loader ever shows. All other triggers (turn start, new message appended) still show immediately.
- Added the legacy path's `say("completion_result")` anti-flicker guard to the turnState path, so `attempt_completion` turns never flash regardless of timing.

### Test Procedure

- New unit tests in `useThinkingLoaderRow.test.tsx` cover the waiting heuristic (turnState + legacy paths) and the anti-flash debounce (no flash when the phase flips within the grace period; loader still appears for real mid-turn waits; immediate show at turn start; completion_result guard).
- Full webview-ui suite passes (44 files, 335 tests) plus `tsc -b` and biome on the changed files.
- Manually verified in the extension dev host (OpenRouter / gpt-4o-mini): recorded a full turn at 60fps before and after the fix and inspected the frames around turn completion. Before: "Thinking..." appears below the completed answer for ~6 frames (~100ms) and vanishes. After: no loader appears in any frame after the answer completes; the initial pre-answer "Thinking..." indicator still works as expected.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Frames extracted from 60fps screen recordings of the same completed turn, right after the answer finished streaming:

| Before (flash frame) | After (fixed) |
| --- | --- |
| ![Before: Thinking... flashes below the completed answer](https://cursor.com/artifacts/c/art-98f5a2f7-61b4-4d0f-a830-2f25bb1d4a9f) | ![After: no Thinking indicator after the answer completes](https://cursor.com/artifacts/c/art-d1b5053e-ebb1-4c72-90ad-ba6a5182cad5) |

### Additional Notes

The 500ms grace period only delays the loader in the ambiguous "tail message just finished streaming" case; unambiguous waits (task start, after approvals, new messages) are unaffected.