### PR TITLE
fix(vscode): stop Preferred Language from silently resetting on settings mount

### DIFF
--- a/apps/vscode/src/shared/Languages.ts
+++ b/apps/vscode/src/shared/Languages.ts
@@ -40,7 +40,7 @@ export type LanguageDisplay =
 
 export const DEFAULT_LANGUAGE_SETTINGS: LanguageKey = "en"
 
-const languageOptions: { key: LanguageKey; display: LanguageDisplay }[] = [
+export const languageOptions: { key: LanguageKey; display: LanguageDisplay }[] = [
 	{ key: "en", display: "English" },
 	{ key: "ar", display: "Arabic - العربية" },
 	{ key: "pt-BR", display: "Portuguese - Português (Brasil)" },

--- a/apps/vscode/webview-ui/src/components/settings/PreferredLanguageSetting.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/PreferredLanguageSetting.tsx
@@ -1,46 +1,31 @@
-import { VSCodeDropdown, VSCodeOption } from "@vscode/webview-ui-toolkit/react"
+import { languageOptions } from "@shared/Languages"
 import React from "react"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { updateSetting } from "./utils/settingsHandlers"
 
 const PreferredLanguageSetting: React.FC = () => {
 	const { preferredLanguage } = useExtensionState()
 
-	const handleLanguageChange = (newLanguage: string) => {
-		updateSetting("preferredLanguage", newLanguage)
-	}
-
 	return (
-		<div style={{}}>
+		<div>
 			<label className="block mb-1 text-base font-medium" htmlFor="preferred-language-dropdown">
 				Preferred Language
 			</label>
-			<VSCodeDropdown
-				currentValue={preferredLanguage || "English"}
-				id="preferred-language-dropdown"
-				onChange={(e: any) => {
-					handleLanguageChange(e.target.value)
-				}}
-				style={{ width: "100%" }}>
-				<VSCodeOption value="English">English</VSCodeOption>
-				<VSCodeOption value="Arabic - العربية">Arabic - العربية</VSCodeOption>
-				<VSCodeOption value="Portuguese - Português (Brasil)">Portuguese - Português (Brasil)</VSCodeOption>
-				<VSCodeOption value="Czech - Čeština">Czech - Čeština</VSCodeOption>
-				<VSCodeOption value="French - Français">French - Français</VSCodeOption>
-				<VSCodeOption value="German - Deutsch">German - Deutsch</VSCodeOption>
-				<VSCodeOption value="Hindi - हिन्दी">Hindi - हिन्दी</VSCodeOption>
-				<VSCodeOption value="Hungarian - Magyar">Hungarian - Magyar</VSCodeOption>
-				<VSCodeOption value="Italian - Italiano">Italian - Italiano</VSCodeOption>
-				<VSCodeOption value="Japanese - 日本語">Japanese - 日本語</VSCodeOption>
-				<VSCodeOption value="Korean - 한국어">Korean - 한국어</VSCodeOption>
-				<VSCodeOption value="Polish - Polski">Polish - Polski</VSCodeOption>
-				<VSCodeOption value="Portuguese - Português (Portugal)">Portuguese - Português (Portugal)</VSCodeOption>
-				<VSCodeOption value="Russian - Русский">Russian - Русский</VSCodeOption>
-				<VSCodeOption value="Simplified Chinese - 简体中文">Simplified Chinese - 简体中文</VSCodeOption>
-				<VSCodeOption value="Spanish - Español">Spanish - Español</VSCodeOption>
-				<VSCodeOption value="Traditional Chinese - 繁體中文">Traditional Chinese - 繁體中文</VSCodeOption>
-				<VSCodeOption value="Turkish - Türkçe">Turkish - Türkçe</VSCodeOption>
-			</VSCodeDropdown>
+			<Select
+				onValueChange={(newLanguage) => updateSetting("preferredLanguage", newLanguage)}
+				value={preferredLanguage || "English"}>
+				<SelectTrigger className="w-full" id="preferred-language-dropdown">
+					<SelectValue />
+				</SelectTrigger>
+				<SelectContent>
+					{languageOptions.map(({ key, display }) => (
+						<SelectItem key={key} value={display}>
+							{display}
+						</SelectItem>
+					))}
+				</SelectContent>
+			</Select>
 			<p className="text-sm text-description mt-1">The language that Cline should use for communication.</p>
 		</div>
 	)


### PR DESCRIPTION
## Problem

Setting **Preferred Language** to any language that is not near the top of the list (e.g. "German - Deutsch"), reloading the window, and opening Settings → General silently rewrites the persisted value to **"Portuguese - Português (Brasil)"** — a value the user never chose. Reproduced twice with on-disk evidence (`~/.cline/data/globalState.json` flipped from `German - Deutsch` to `Portuguese - Português (Brasil)` after reload + settings mount). Found during the July 2026 pre-launch upgrade QA (not in the `qa-fleet-2026-07` ticket index).

## Root cause

`PreferredLanguageSetting.tsx` used `@vscode/webview-ui-toolkit`'s `VSCodeDropdown` with a `currentValue` prop and an unguarded `onChange`. While the dropdown's slotted options initialize after a webview (re)mount, it emits a spurious `change` event carrying the wrong option — index 2, which is Portuguese (Brasil) — and the handler persisted `e.target.value` unconditionally via `updateSetting("preferredLanguage", …)`.

## Fix

- Replace the toolkit dropdown with the `Select` component from `@/components/ui/select` — the same widget already used by the other settings dropdowns (Auto Compact Strategy, MCP Display Mode), which only fires `onValueChange` on real user selections. Those dropdowns passed the same reload round-trip tests that this one failed.
- Render options from the shared `languageOptions` list in `src/shared/Languages.ts` (now exported) instead of a hardcoded duplicate of all 18 languages.
- Persisted value semantics unchanged (still the display string, e.g. `"Spanish - Español"`), so existing user state is unaffected.

## Testing

- Manual round-trip on a real VS Code window with the packaged VSIX over migrated legacy user state: Spanish → German → **Developer: Reload Window** → German persists → second reload → German persists → back to Spanish → reload → Spanish persists. Disk state verified at each step. The identical sequence reproduced the Portuguese corruption twice on the unfixed build.
- `webview-ui`: `bun run test` — 44 files, 325 tests pass.
- `apps/vscode`: `bun run test:unit` — 64 files, 984 tests pass.
- `check-types` + `lint` pass (run as part of `vsce package`).

![German selected in the new Select widget](https://cursor.com/artifacts/c/art-116ff348-0ae0-4cc7-b3d9-352e8f12d15c)
![German still selected after Developer: Reload Window](https://cursor.com/artifacts/c/art-bbbac474-259d-4b36-9b17-679a1276cff7)