### PR TITLE
fix(vscode): authenticate account UI from manual Cline API key in providers.json

### DIFF
--- a/apps/vscode/src/sdk/auth-service.test.ts
+++ b/apps/vscode/src/sdk/auth-service.test.ts
@@ -9,6 +9,7 @@
 // - workos: prefix handling
 
 import { getValidClineCredentials, type ITelemetryService, type OAuthCredentials } from "@cline/core"
+import axios from "axios"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { AuthService, type ClineAuthInfo, LogoutReason } from "./auth-service"
 
@@ -547,6 +548,158 @@ describe("AuthService", () => {
 
 			expect(testAccess(authService)._authenticated).toBe(false)
 			expect(testAccess(authService)._clineAuthInfo).toBeNull()
+		})
+	})
+
+	describe("manual API key authentication (providers.json settings.apiKey)", () => {
+		const apiKeyUserInfo = {
+			id: "user-apikey",
+			email: "apikey@example.com",
+			displayName: "Api Key User",
+			organizations: [],
+		}
+
+		function mockUserInfoFetchSuccess() {
+			vi.mocked(axios.get).mockResolvedValue({
+				status: 200,
+				data: { data: apiKeyUserInfo },
+			})
+		}
+
+		it("restores authenticated state from a manual API key when no OAuth session exists", async () => {
+			mockProviderSettings.set("cline", { provider: "cline", apiKey: "manual-cline-key" })
+			mockUserInfoFetchSuccess()
+
+			await authService.restoreRefreshTokenAndRetrieveAuthInfo()
+
+			expect(testAccess(authService)._authenticated).toBe(true)
+			expect(testAccess(authService)._clineAuthInfo?.idToken).toBe("manual-cline-key")
+			expect(testAccess(authService)._clineAuthInfo?.authMethod).toBe("apiKey")
+			expect(testAccess(authService)._clineAuthInfo?.apiKeyProviderId).toBe("cline")
+			expect(testAccess(authService)._clineAuthInfo?.userInfo).toEqual(apiKeyUserInfo)
+			expect(authService.getInfo().user?.email).toBe("apikey@example.com")
+		})
+
+		it("sends the API key as a raw bearer token without the workos: prefix", async () => {
+			mockProviderSettings.set("cline", { provider: "cline", apiKey: "manual-cline-key" })
+			mockUserInfoFetchSuccess()
+
+			await authService.restoreRefreshTokenAndRetrieveAuthInfo()
+
+			expect(axios.get).toHaveBeenCalledWith(
+				"https://api.cline.bot/api/v1/users/me",
+				expect.objectContaining({
+					headers: expect.objectContaining({ Authorization: "Bearer manual-cline-key" }),
+				}),
+			)
+		})
+
+		it("falls back to a cline-pass API key when the cline provider has none", async () => {
+			mockProviderSettings.set("cline-pass", { provider: "cline-pass", apiKey: "manual-pass-key" })
+			mockUserInfoFetchSuccess()
+
+			await authService.restoreRefreshTokenAndRetrieveAuthInfo()
+
+			expect(testAccess(authService)._authenticated).toBe(true)
+			expect(testAccess(authService)._clineAuthInfo?.idToken).toBe("manual-pass-key")
+			expect(testAccess(authService)._clineAuthInfo?.apiKeyProviderId).toBe("cline-pass")
+		})
+
+		it("prefers OAuth credentials over a manual API key when both exist", async () => {
+			mockProviderSettings.set("cline", {
+				provider: "cline",
+				apiKey: "manual-cline-key",
+				auth: { accessToken: "workos:oauth-token", refreshToken: "r", accountId: "user-123" },
+			})
+			vi.mocked(getValidClineCredentials).mockResolvedValue({
+				access: "oauth-token",
+				refresh: "r",
+				expires: Date.now() + 3600 * 1000,
+				accountId: "user-123",
+				email: "test@example.com",
+			})
+
+			await authService.restoreRefreshTokenAndRetrieveAuthInfo()
+
+			expect(testAccess(authService)._authenticated).toBe(true)
+			expect(testAccess(authService)._clineAuthInfo?.idToken).toBe("oauth-token")
+			expect(testAccess(authService)._clineAuthInfo?.authMethod).not.toBe("apiKey")
+		})
+
+		it("falls back to the manual API key when the stored OAuth session is unrecoverable", async () => {
+			mockProviderSettings.set("cline", {
+				provider: "cline",
+				apiKey: "manual-cline-key",
+				auth: { accessToken: "workos:stale", refreshToken: "stale-refresh", accountId: "user-123" },
+			})
+			vi.mocked(getValidClineCredentials).mockResolvedValue(null)
+			mockUserInfoFetchSuccess()
+
+			await authService.restoreRefreshTokenAndRetrieveAuthInfo()
+
+			expect(testAccess(authService)._authenticated).toBe(true)
+			expect(testAccess(authService)._clineAuthInfo?.idToken).toBe("manual-cline-key")
+			expect(testAccess(authService)._clineAuthInfo?.authMethod).toBe("apiKey")
+			// The stale OAuth auth block is cleared, but the API key survives.
+			expect(mockProviderSettings.get("cline")?.auth).toBeUndefined()
+			expect(mockProviderSettings.get("cline")?.apiKey).toBe("manual-cline-key")
+		})
+
+		it("stays signed out when the API key cannot be validated", async () => {
+			mockProviderSettings.set("cline", { provider: "cline", apiKey: "invalid-key" })
+			vi.mocked(axios.get).mockRejectedValue(new Error("401 Unauthorized"))
+
+			await authService.restoreRefreshTokenAndRetrieveAuthInfo()
+
+			expect(testAccess(authService)._authenticated).toBe(false)
+			expect(testAccess(authService)._clineAuthInfo).toBeNull()
+			// The key must not be deleted — it may be a transient network failure.
+			expect(mockProviderSettings.get("cline")?.apiKey).toBe("invalid-key")
+		})
+
+		it("getAuthToken() returns the raw API key without the workos: prefix", async () => {
+			testAccess(authService)._clineAuthInfo = createTestAuthInfo({
+				idToken: "manual-cline-key",
+				refreshToken: undefined,
+				expiresAt: undefined,
+				authMethod: "apiKey",
+				apiKeyProviderId: "cline",
+			})
+			testAccess(authService)._authenticated = true
+
+			expect(await authService.getAuthToken()).toBe("manual-cline-key")
+		})
+
+		it("handleDeauth() removes the manual API key so logout sticks", async () => {
+			mockProviderSettings.set("cline", { provider: "cline", apiKey: "manual-cline-key", model: "some-model" })
+			testAccess(authService)._clineAuthInfo = createTestAuthInfo({
+				idToken: "manual-cline-key",
+				authMethod: "apiKey",
+				apiKeyProviderId: "cline",
+			})
+			testAccess(authService)._authenticated = true
+
+			await authService.handleDeauth(LogoutReason.USER_INITIATED)
+
+			expect(testAccess(authService)._authenticated).toBe(false)
+			expect(mockProviderSettings.get("cline")?.apiKey).toBeUndefined()
+			// Other provider settings survive logout.
+			expect(mockProviderSettings.get("cline")?.model).toBe("some-model")
+		})
+
+		it("handleDeauth() leaves manual API keys alone for OAuth sessions", async () => {
+			mockProviderSettings.set("cline", {
+				provider: "cline",
+				apiKey: "manual-cline-key",
+				auth: { accessToken: "workos:oauth-token" },
+			})
+			testAccess(authService)._clineAuthInfo = createTestAuthInfo()
+			testAccess(authService)._authenticated = true
+
+			await authService.handleDeauth(LogoutReason.USER_INITIATED)
+
+			expect(mockProviderSettings.get("cline")?.auth).toBeUndefined()
+			expect(mockProviderSettings.get("cline")?.apiKey).toBe("manual-cline-key")
 		})
 	})
 

--- a/apps/vscode/src/sdk/auth-service.ts
+++ b/apps/vscode/src/sdk/auth-service.ts
@@ -50,6 +50,15 @@ export interface ClineAuthInfo {
 	userInfo: ClineAccountUserInfo
 	provider: string
 	startedAt?: number
+	/**
+	 * How the user authenticated. "oauth" (default) uses WorkOS tokens with
+	 * refresh; "apiKey" uses a manually configured Cline API key from
+	 * providers.json (e.g. `cline auth --apikey` in the CLI), which never
+	 * expires and must be sent as a raw bearer token (no `workos:` prefix).
+	 */
+	authMethod?: "oauth" | "apiKey"
+	/** Provider entry in providers.json the manual API key was read from. */
+	apiKeyProviderId?: string
 }
 
 export interface ClineAccountUserInfo {
@@ -226,6 +235,52 @@ function clearClineCredentials(): void {
 	}
 }
 
+/**
+ * Read a manually configured Cline account API key from providers.json.
+ *
+ * The CLI's quick auth (`cline auth --apikey <key>`) stores the key at
+ * `providers.<id>.settings.apiKey` rather than under `auth` (which holds
+ * OAuth tokens). Both the `cline` and `cline-pass` providers bill against
+ * the same Cline account, so either key authenticates the account UI.
+ */
+function readClineManualApiKey(): { apiKey: string; providerId: string } | null {
+	try {
+		const manager = getProviderSettingsManager()
+		for (const providerId of ["cline", "cline-pass"]) {
+			const apiKey = manager.getProviderSettings(providerId)?.apiKey?.trim()
+			if (apiKey) {
+				sdkDebug(
+					`[SdkAuthService] readClineManualApiKey: found manual API key on "${providerId}" (keyHash=${hashSecret(apiKey)})`,
+				)
+				return { apiKey, providerId }
+			}
+		}
+	} catch (error) {
+		Logger.error("[SdkAuthService] Failed to read manual API key from providers.json:", error)
+	}
+	return null
+}
+
+/**
+ * Remove a manually configured Cline API key from providers.json.
+ * Used on logout when the session was authenticated via API key, so that
+ * signing out actually stops the account from being used.
+ */
+function clearClineManualApiKey(providerId: string): void {
+	try {
+		const manager = getProviderSettingsManager()
+		const existing = manager.getProviderSettings(providerId)
+		if (existing?.apiKey) {
+			sdkDebug(`[SdkAuthService] clearClineManualApiKey: clearing apiKey from "${providerId}"`)
+			manager.saveProviderSettings({ ...existing, provider: providerId, apiKey: undefined } as ProviderSettings, {
+				tokenSource: "manual",
+			})
+		}
+	} catch (error) {
+		Logger.error("[SdkAuthService] Failed to clear manual API key from providers.json:", error)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // AuthService
 // ---------------------------------------------------------------------------
@@ -297,14 +352,22 @@ export class AuthService {
 
 	/**
 	 * Fetch user info from the Cline API using an access token.
+	 *
+	 * OAuth access tokens are sent with the `workos:` prefix so the backend
+	 * routes verification to WorkOS. Manual API keys must be sent raw
+	 * (`options.rawBearerToken`) — prefixing them breaks verification.
 	 */
-	private async fetchUserInfoFromApi(accessToken: string): Promise<ClineAccountUserInfo | null> {
+	private async fetchUserInfoFromApi(
+		accessToken: string,
+		options?: { rawBearerToken?: boolean },
+	): Promise<ClineAccountUserInfo | null> {
 		try {
 			const apiBaseUrl = ClineEnv.config().apiBaseUrl
 			// Ensure the token has the workos: prefix for the API
-			const bearerToken = accessToken.toLowerCase().startsWith(WORKOS_TOKEN_PREFIX)
-				? accessToken
-				: `${WORKOS_TOKEN_PREFIX}${accessToken}`
+			const bearerToken =
+				options?.rawBearerToken || accessToken.toLowerCase().startsWith(WORKOS_TOKEN_PREFIX)
+					? accessToken
+					: `${WORKOS_TOKEN_PREFIX}${accessToken}`
 			sdkDebug(
 				`[SdkAuthService] fetchUserInfoFromApi: GET ${apiBaseUrl}/api/v1/users/me (tokenHash=${hashSecret(accessToken)})`,
 			)
@@ -361,6 +424,11 @@ export class AuthService {
 			return null
 		}
 
+		// Manual API keys never expire and are sent raw (no workos: prefix).
+		if (this._clineAuthInfo.authMethod === "apiKey") {
+			return this._clineAuthInfo.idToken
+		}
+
 		// Check if we need to refresh
 		const expiresAt = this._clineAuthInfo.expiresAt
 		if (expiresAt) {
@@ -388,6 +456,11 @@ export class AuthService {
 	 * Persists refreshed credentials to providers.json when credentials change.
 	 */
 	private async refreshAccessToken(): Promise<boolean> {
+		// Manual API keys have no refresh flow — they are always valid until revoked.
+		if (this._clineAuthInfo?.authMethod === "apiKey") {
+			return true
+		}
+
 		if (this._refreshPromise) {
 			await this._refreshPromise
 			return this._clineAuthInfo?.idToken !== undefined
@@ -801,9 +874,16 @@ export class AuthService {
 	async handleDeauth(reason: LogoutReason = LogoutReason.UNKNOWN): Promise<void> {
 		try {
 			telemetryService.captureAuthLoggedOut("cline", reason)
+			const previousAuthInfo = this._clineAuthInfo
 			this._clineAuthInfo = null
 			this._authenticated = false
 			clearClineCredentials()
+			// When the session was authenticated via a manual API key, logout
+			// must also remove that key — otherwise the next restore would
+			// silently sign the user back in from providers.json.
+			if (previousAuthInfo?.authMethod === "apiKey" && previousAuthInfo.apiKeyProviderId) {
+				clearClineManualApiKey(previousAuthInfo.apiKeyProviderId)
+			}
 			await this.sendAuthStatusUpdate()
 
 			// Notify BannerService of auth change (mirrors classic AuthService)
@@ -921,6 +1001,13 @@ export class AuthService {
 		try {
 			const creds = readClineCredentials()
 			if (!creds) {
+				// No OAuth session — fall back to a manually configured API key
+				// (e.g. provisioned via the CLI's `cline auth --apikey`). Without
+				// this, the account UI shows signed-out while inference happily
+				// bills against the key.
+				if (await this.restoreFromManualApiKey()) {
+					return
+				}
 				this._authenticated = false
 				this._clineAuthInfo = null
 				return
@@ -945,6 +1032,11 @@ export class AuthService {
 				this._authenticated = false
 				this._clineAuthInfo = null
 				clearClineCredentials()
+				// The OAuth session is unrecoverable, but a manual API key may
+				// still authenticate the account.
+				if (await this.restoreFromManualApiKey()) {
+					return
+				}
 				await this.sendAuthStatusUpdate()
 				return
 			}
@@ -994,6 +1086,50 @@ export class AuthService {
 			this._authenticated = false
 			this._clineAuthInfo = null
 		}
+	}
+
+	/**
+	 * Authenticate from a manually configured Cline API key in providers.json.
+	 *
+	 * Validates the key by fetching the user profile from the Cline API; on
+	 * success the account UI shows the signed-in account exactly as it would
+	 * for an OAuth session. Returns false (leaving the signed-out state
+	 * untouched) when no key exists or the key cannot be validated.
+	 */
+	private async restoreFromManualApiKey(): Promise<boolean> {
+		const manual = readClineManualApiKey()
+		if (!manual) {
+			return false
+		}
+
+		const userInfo = await this.fetchUserInfoFromApi(manual.apiKey, { rawBearerToken: true })
+		if (!userInfo) {
+			Logger.warn(
+				`[SdkAuthService] Found a manual Cline API key on "${manual.providerId}" but could not fetch user info — account UI will show signed-out`,
+			)
+			return false
+		}
+
+		sdkDebug(
+			`[SdkAuthService] restoreFromManualApiKey: authenticated via manual API key on "${manual.providerId}" (keyHash=${hashSecret(manual.apiKey)})`,
+		)
+		this._clineAuthInfo = {
+			idToken: manual.apiKey,
+			userInfo,
+			provider: "cline",
+			authMethod: "apiKey",
+			apiKeyProviderId: manual.providerId,
+		}
+		this._authenticated = true
+
+		await this.sendAuthStatusUpdate()
+
+		// Notify BannerService of auth change (mirrors the OAuth restore path)
+		BannerService.onAuthUpdate(userInfo.id || null).catch((error) => {
+			Logger.error("[SdkAuthService] Banner update failed after API key restore", error)
+		})
+
+		return true
 	}
 
 	// ---- Streaming subscriptions ----


### PR DESCRIPTION
### Related Issue

Pre-launch QA fleet finding (July 2026): "Cline account card shows 'Sign Up with Cline' while a working API key is active." Distinct from ENG-2332 (store divergence misrouting billing) and ENG-2346 (re-onboarding).

### Description

A Cline account API key provisioned outside the extension — e.g. `cline auth --apikey <key>` in the CLI — is stored at `providers.<id>.settings.apiKey` in the shared `~/.cline/data/settings/providers.json`. Inference happily uses and bills that key, but `AuthService.restoreRefreshTokenAndRetrieveAuthInfo()` only restored OAuth tokens from the `auth` block, so the settings account card kept rendering "Sign Up with Cline" and the Account view was unreachable while the account was actively spending.

Changes in `apps/vscode/src/sdk/auth-service.ts`:

- Restore now falls back to a manual API key on the `cline` or `cline-pass` provider when there is no OAuth session (or the stored OAuth session is unrecoverable). The key is validated by fetching the user profile; on success the account UI shows the signed-in account exactly as for OAuth.
- `fetchUserInfoFromApi()` gained a `rawBearerToken` option: manual API keys are sent as raw bearer tokens, while OAuth tokens keep the `workos:` prefix.
- `getAuthToken()` returns the raw key for API-key sessions (no `workos:` prefix, no refresh/expiry logic), so balance/usage RPCs in the account service work unchanged.
- `handleDeauth()` removes the manual key from `providers.json` when the session was authenticated via API key, so logging out actually sticks instead of silently re-authenticating on the next restore.

OAuth continues to take precedence when both credential types exist. An unvalidatable key (revoked, or transient network failure) leaves the signed-out state untouched and does not delete the key.

### Test Procedure

- 9 new unit tests in `auth-service.test.ts`: API-key restore, raw-bearer header, `cline-pass` fallback, OAuth precedence, fallback when OAuth is unrecoverable, invalid-key handling, `getAuthToken()` raw return, logout removing the key, and OAuth logout leaving manual keys alone. Full file: 38/38 pass.
- `bun run test:unit` (989 pass), `bun run test:vitest` (869 pass), `tsc --noEmit` clean, biome lint clean.
- Manual verification in a VS Code Extension Development Host with a real Cline API key provisioned via `cline auth cline --apikey ...` (no OAuth session, env vars stripped):
  - Account card shows "View Billing & Usage" instead of "Sign Up with Cline".
  - Account view loads the real profile (name, email), current balance, and usage history via the raw-bearer token path.
  - Chat inference works against the same key ("PONG" round-trip).
  - Logout returns the card to "Sign Up with Cline" and removes `apiKey` from `providers.json` (verified on disk; the configured model is preserved).

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Signed-in account card restored from a CLI-provisioned API key (previously showed "Sign Up with Cline"):

![Account card shows View Billing & Usage with manual API key](https://cursor.com/artifacts/c/art-7caa0772-cd38-4ab4-af9f-30174df4e603)

Account view loading profile, balance, and usage history through the API-key bearer token:

![Account view with balance and usage history](https://cursor.com/artifacts/c/art-940d2397-427b-4366-a7d1-4b93aada99dc)

After logout: signed-out card, and `providers.json` no longer contains the key:

![Account card signed out after logout](https://cursor.com/artifacts/c/art-5b5df9be-aac0-406e-9e27-794f7483f016)