### PR TITLE
fix(vscode): label editor insert_line edits as edits, not new-file creations

### DIFF
--- a/apps/vscode/src/sdk/message-translator.test.ts
+++ b/apps/vscode/src/sdk/message-translator.test.ts
@@ -2963,6 +2963,30 @@ describe("sdkToolToClineSayTool — editor diff rendering (S6-48)", () => {
 		expect(tool.content).toBe("export const x = 1")
 	})
 
+	it("editor with insert_line is an edit of an existing file, not a new-file creation", () => {
+		const state = new MessageTranslatorState()
+		const event: CoreSessionEvent = {
+			type: "agent_event",
+			payload: {
+				sessionId: "session-1",
+				event: {
+					type: "content_start",
+					contentType: "tool",
+					toolName: "editor",
+					toolCallId: "call-insert",
+					// A prepend/insert: new_text present, no old_text, but insert_line set.
+					// The SDK editor executor requires the file to already exist for insert,
+					// so this must map to editedExistingFile (not newFileCreated).
+					input: { path: "/src/existing.ts", new_text: "// prepended", insert_line: 1 },
+				} as AgentEvent,
+			},
+		}
+		const result = translateSessionEvent(event, state)
+		const tool = JSON.parse(result.messages[0].text!)
+		expect(tool.tool).toBe("editedExistingFile")
+		expect(tool.path).toBe("/src/existing.ts")
+	})
+
 	it("S6-48: editor with old_str/new_str also builds search/replace diff", () => {
 		const state = new MessageTranslatorState()
 		const event: CoreSessionEvent = {

--- a/apps/vscode/src/sdk/message-translator.ts
+++ b/apps/vscode/src/sdk/message-translator.ts
@@ -508,7 +508,11 @@ function sdkToolToClineSayTool(toolName: string, input?: unknown): ClineSayTool 
 				getStringField(parsedInput, "content")
 			const patch = getStringField(parsedInput, "patch") ?? getStringField(parsedInput, "diff")
 			const oldText = getStringField(parsedInput, "old_text") ?? getStringField(parsedInput, "old_str")
-			const isEdit = toolName === "replace_in_file" || !!oldText
+			// `insert_line` inserts into an existing file (the SDK editor executor requires
+			// the file to already exist), so it is an edit — not a new-file creation. Without
+			// this the card mislabels a prepend/insert as "Cline wants to create a new file".
+			const insertLine = getNumberField(parsedInput, "insert_line")
+			const isEdit = toolName === "replace_in_file" || !!oldText || insertLine != null
 
 			// When the SDK provides both old and new text, build a search/replace
 			// diff in the format DiffEditRow expects. ChatRow passes `content` to


### PR DESCRIPTION
### Related Issue

Pre-launch migration QA finding (differential test matrix vs `legacy-extension`). Not yet ticketed on its own — sibling to the QA fleet index (label `qa-fleet-2026-07`). Happy to file/link a dedicated ENG issue if preferred.

### Description

When Cline modifies an **existing** file with the `editor` tool using `insert_line` (for example, prepending a line), the approval card in the webview incorrectly reads **"Cline wants to create a new file:"** instead of **"Cline wants to edit this file:"**.

Root cause is in `sdkToolToClineSayTool()` (`apps/vscode/src/sdk/message-translator.ts`), which classifies an `editor` call as an edit only when `old_text`/`old_str` is present (or the tool is `replace_in_file`):

```ts
const isEdit = toolName === "replace_in_file" || !!oldText
```

An `insert_line` call has `new_text` but no `old_text`, so it fell through to `newFileCreated`, and `ChatRow.tsx` renders the "create a new file" header. The SDK editor executor (`sdk/packages/core/src/extensions/tools/executors/editor.ts`) requires the target file to already exist for an insert, so `insert_line` is definitionally an edit of an existing file.

Fix: treat `insert_line` as an edit as well.

```ts
const insertLine = getNumberField(parsedInput, "insert_line")
const isEdit = toolName === "replace_in_file" || !!oldText || insertLine != null
```

The remaining ambiguous case (`editor` with only `new_text` and no `old_text`/`insert_line`) genuinely maps to a create — the SDK creates the file if missing, or errors requiring `old_text` if it exists — so it is left unchanged.

### Test Procedure

- Added a focused unit test in `message-translator.test.ts` asserting that an `editor` `content_start` with `{ path, new_text, insert_line: 1 }` maps to `editedExistingFile` (not `newFileCreated`).
- `bun scripts/run-bun-unit-tests.ts` — all 984 unit tests pass, including the new case.
- `bunx tsc --noEmit -p tsconfig.json` — clean.
- `biome lint --diagnostic-level=error` on the changed files — clean.
- Live "before" state captured during QA (screenshot below): prepending `// qa-clean-approve` to the existing `readme.md` shows the mislabeled "Cline wants to create a new file:" header. A fresh live "after" capture was blocked in-session by unrelated model tool-selection behavior (the model repeatedly used shell `sed` instead of the editor tool — see the QA fleet's ENG-2322), so the fix is verified deterministically by the unit test that exercises the exact translator path the card reads from.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] 💅 Cosmetic Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed contributor guidelines

### Screenshots

Before (bug) — a prepend/insert into the existing `readme.md` is mislabeled as a new-file creation:

![Before: edit card mislabeled as create-a-new-file for an existing-file insert](https://cursor.com/artifacts/c/art-f041ed05-88b6-46d4-ab5b-2f8619a8fc79)

After the fix, the same `editor` + `insert_line` input classifies as `editedExistingFile`, so the card reads "Cline wants to edit this file:" (asserted by the new unit test).

### Additional Notes

Scope is intentionally minimal: only the create-vs-edit classification for `insert_line`. No behavior change to the actual write path, diff preview, or approval flow.