### PR TITLE
fix(vscode): flush dirty editor buffers before SDK edits to prevent silent data loss

### DIFF
--- a/apps/vscode/src/sdk/sdk-diff-edit-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-diff-edit-coordinator.test.ts
@@ -4,7 +4,7 @@ import * as os from "os"
 import * as path from "path"
 import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "vitest"
 import { buildEditPreviewAnimation, EditPreview, type EditPreviewContent } from "@/integrations/editor/EditPreview"
-import { computeNewEditorContent, SdkDiffEditCoordinator } from "./sdk-diff-edit-coordinator"
+import { computeNewEditorContent, patchTargetPaths, SdkDiffEditCoordinator } from "./sdk-diff-edit-coordinator"
 
 /** Records open/close calls; previews are purely visual so no other behavior is needed. */
 class FakeEditPreview extends EditPreview {
@@ -484,5 +484,134 @@ describe("SdkDiffEditCoordinator", () => {
 		expect(result).toBe("fallback apply_patch result")
 		expect(fallbackApplyPatch).toHaveBeenCalledOnce()
 		expect(previews).toHaveLength(0)
+	})
+
+	// Everything below guards against the dirty-buffer data-loss bug: the edit pipeline
+	// is disk-based, so unsaved editor changes must be flushed to disk before any read
+	// or write, or the user's unsaved work is silently destroyed.
+	describe("dirty-buffer flush", () => {
+		it("flushes the target file before reading the preview baseline", async () => {
+			const absolutePath = await writeFile("a.ts", "line1\nline2\n")
+			// Simulate an open dirty buffer: the flush persists newer content to disk.
+			const saveDirtyDocument = vi.fn(async (savedPath: string) => {
+				expect(savedPath).toBe(absolutePath)
+				await fs.writeFile(absolutePath, "line1\nline2\nUNSAVED USER LINE\n")
+			})
+			coordinator = makeCoordinator({ saveDirtyDocument })
+
+			await coordinator.openForApproval("tc1", "editor", { path: "a.ts", old_text: "line1", new_text: "changed" })
+
+			expect(saveDirtyDocument).toHaveBeenCalledExactlyOnceWith(absolutePath)
+			expect(previews[0].opened).toMatchObject({
+				leftContent: "line1\nline2\nUNSAVED USER LINE\n",
+				rightContent: "changed\nline2\nUNSAVED USER LINE\n",
+			})
+		})
+
+		it("flushes again before the executor writes, so the write baseline is current", async () => {
+			const absolutePath = await writeFile("a.ts", "old content")
+			const callOrder: string[] = []
+			const saveDirtyDocument = vi.fn(async () => {
+				callOrder.push("flush")
+			})
+			fallbackEditor.mockImplementation(async () => {
+				callOrder.push("write")
+				return "fallback editor result"
+			})
+			coordinator = makeCoordinator({ saveDirtyDocument })
+			const input = { path: "a.ts", old_text: "old", new_text: "new" }
+			await coordinator.openForApproval("tc1", "editor", input)
+
+			const result = await coordinator.executeEditorTool(input, tempDir, makeContext("tc1"))
+
+			expect(result).toBe("fallback editor result")
+			// Once at preview time, once right before the write — always before it.
+			expect(saveDirtyDocument).toHaveBeenCalledTimes(2)
+			expect(saveDirtyDocument).toHaveBeenLastCalledWith(absolutePath)
+			expect(callOrder).toEqual(["flush", "flush", "write"])
+		})
+
+		it("skips the preview but never throws when the flush fails at approval time", async () => {
+			await writeFile("a.ts", "content")
+			coordinator = makeCoordinator({
+				saveDirtyDocument: vi.fn().mockRejectedValue(new Error("save vetoed")),
+			})
+
+			await coordinator.openForApproval("tc1", "editor", { path: "a.ts", old_text: "content", new_text: "x" })
+
+			expect(previews).toHaveLength(0)
+		})
+
+		it("aborts the write when the flush fails at execution time (no silent clobber)", async () => {
+			await writeFile("a.ts", "content")
+			coordinator = makeCoordinator({
+				saveDirtyDocument: vi.fn().mockRejectedValue(new Error("save vetoed")),
+			})
+			const input = { path: "a.ts", old_text: "content", new_text: "x" }
+
+			await expect(coordinator.executeEditorTool(input, tempDir, makeContext("tc1"))).rejects.toThrow("save vetoed")
+			expect(fallbackEditor).not.toHaveBeenCalled()
+		})
+
+		it("skips invalid paths so the executor still produces its canonical error", async () => {
+			const saveDirtyDocument = vi.fn().mockResolvedValue(undefined)
+			coordinator = makeCoordinator({ saveDirtyDocument })
+			fallbackEditor.mockRejectedValueOnce(new Error("Path must stay within cwd: ../outside.ts"))
+			const input = { path: "../outside.ts", old_text: "a", new_text: "b" }
+
+			await expect(coordinator.executeEditorTool(input, tempDir, makeContext("tc1"))).rejects.toThrow(
+				"Path must stay within cwd",
+			)
+			expect(saveDirtyDocument).not.toHaveBeenCalled()
+		})
+
+		it("flushes every file an apply_patch updates or deletes, before preview and write", async () => {
+			const updatedPath = await writeFile("patched.ts", "line one\nline two\n")
+			const deletedPath = await writeFile("gone.ts", "bye")
+			const saveDirtyDocument = vi.fn().mockResolvedValue(undefined)
+			coordinator = makeCoordinator({ saveDirtyDocument })
+			const patch = [
+				"*** Begin Patch",
+				"*** Update File: patched.ts",
+				"@@",
+				"-line one",
+				"+line ONE",
+				"*** Delete File: gone.ts",
+				"*** Add File: brand-new.ts",
+				"+hello",
+				"*** End Patch",
+			].join("\n")
+
+			await coordinator.openForApproval("tc1", "apply_patch", { input: patch })
+			expect(saveDirtyDocument.mock.calls.map(([p]) => p)).toEqual([updatedPath, deletedPath])
+
+			saveDirtyDocument.mockClear()
+			await coordinator.executeApplyPatchTool({ input: patch }, tempDir, makeContext("tc1"))
+			// Added files are not flushed: there is no existing buffer to protect.
+			expect(saveDirtyDocument.mock.calls.map(([p]) => p)).toEqual([updatedPath, deletedPath])
+		})
+	})
+})
+
+describe("patchTargetPaths", () => {
+	it("returns update and delete targets, excluding added files", () => {
+		const patch = [
+			"*** Begin Patch",
+			"*** Update File: src/a.ts",
+			"@@",
+			"-x",
+			"+y",
+			"*** Delete File: src/b.ts",
+			"*** Add File: src/c.ts",
+			"+new",
+			"*** End Patch",
+		].join("\n")
+		expect(patchTargetPaths(patch)).toEqual(["src/a.ts", "src/b.ts"])
+	})
+
+	it("returns an empty list for malformed or non-string input", () => {
+		expect(patchTargetPaths("")).toEqual([])
+		expect(patchTargetPaths(undefined)).toEqual([])
+		expect(patchTargetPaths("not a patch")).toEqual([])
 	})
 })

--- a/apps/vscode/src/sdk/sdk-diff-edit-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-diff-edit-coordinator.ts
@@ -35,6 +35,11 @@ export interface SdkDiffEditCoordinatorOptions {
 	fallbackApplyPatchExecutor?: ApplyPatchExecutor
 	/** Test seam: overrides the auto-approve preview linger. */
 	autoApprovePreviewLingerMs?: number
+	/**
+	 * Saves the file's editor document to disk if it is open with unsaved changes.
+	 * Injectable for tests. Defaults to the host bridge's saveOpenDocumentIfDirty.
+	 */
+	saveDirtyDocument?: (absolutePath: string) => Promise<void>
 }
 
 interface DiffEditSession {
@@ -47,11 +52,16 @@ interface DiffEditSession {
  * Shows a read-only diff preview of SDK edit-tool changes (editor / apply_patch).
  *
  * The preview is a virtual-document diff — both sides are virtual, the real file is
- * never opened or modified by the preview — so opening it has no side effects,
- * rejecting an edit only closes a tab, and multiple previews (even of the same file)
- * can't interfere with each other. The actual write is always the SDK's default
- * disk-writing executor, which the overridden executors delegate to after closing
- * the preview; its results and error strings reach the model unchanged.
+ * never opened or modified by the preview — so rejecting an edit only closes a tab,
+ * and multiple previews (even of the same file) can't interfere with each other. The
+ * actual write is always the SDK's default disk-writing executor, which the overridden
+ * executors delegate to after closing the preview; its results and error strings reach
+ * the model unchanged.
+ *
+ * Because that whole pipeline reads and writes the filesystem, any unsaved editor
+ * changes in a target file are flushed to disk first (see flushDirtyTargets) — both
+ * when a preview's baseline is read and again just before the executor writes —
+ * otherwise the write would silently destroy the user's unsaved work.
  *
  * Previews open at approval time (the SDK surfaces tool input only after the model's
  * stream completes, so the approval callback is the only pre-execution point with
@@ -63,11 +73,41 @@ export class SdkDiffEditCoordinator {
 	private readonly fallbackEditorExecutor: EditorExecutor
 	private readonly fallbackApplyPatchExecutor: ApplyPatchExecutor
 	private readonly autoApprovePreviewLingerMs: number
+	private readonly saveDirtyDocument: (absolutePath: string) => Promise<void>
 
 	constructor(private readonly options: SdkDiffEditCoordinatorOptions) {
 		this.fallbackEditorExecutor = options.fallbackEditorExecutor ?? createEditorExecutor()
 		this.fallbackApplyPatchExecutor = options.fallbackApplyPatchExecutor ?? createApplyPatchExecutor()
 		this.autoApprovePreviewLingerMs = options.autoApprovePreviewLingerMs ?? AUTO_APPROVE_PREVIEW_LINGER_MS
+		this.saveDirtyDocument = options.saveDirtyDocument ?? saveDirtyDocumentViaHost
+	}
+
+	/**
+	 * Flushes unsaved editor changes for the edit's target file(s) to disk before the
+	 * edit pipeline touches them. The whole pipeline is disk-based — the preview
+	 * baseline, the executor's read, and the executor's write all use the filesystem —
+	 * so an open dirty buffer would otherwise be invisible to the edit and then
+	 * silently overwritten when the write lands (permanent loss of the user's unsaved
+	 * work). Flushing first makes the buffer content the edit's baseline, matching the
+	 * legacy DiffViewProvider, which saved dirty documents before reading the file.
+	 *
+	 * Failures propagate: aborting the tool call with an error the model can see is
+	 * always preferable to destroying the user's unsaved changes.
+	 */
+	private async flushDirtyTargets(cwd: string, inputPaths: unknown[]): Promise<void> {
+		for (const inputPath of inputPaths) {
+			if (typeof inputPath !== "string" || inputPath.length === 0) {
+				continue
+			}
+			let absolutePath: string
+			try {
+				// Invalid paths are skipped so the executor still produces its canonical error.
+				absolutePath = resolveEditPath(cwd, inputPath)
+			} catch {
+				continue
+			}
+			await this.saveDirtyDocument(absolutePath)
+		}
 	}
 
 	/**
@@ -100,6 +140,10 @@ export class SdkDiffEditCoordinator {
 		const toolCallId = context.toolCallId ?? ""
 		const hadPreApprovalPreview = this.sessions.has(toolCallId)
 		try {
+			// The user may have typed into the target file at any point up to approval;
+			// flush right before the write so those changes become the edit's baseline
+			// instead of being clobbered by the disk-based executor.
+			await this.flushDirtyTargets(cwd, [input?.path])
 			if (!hadPreApprovalPreview && !this.options.isBackgroundEditEnabled()) {
 				// Auto-approved (or hook-approved) edit: no preview was opened at approval
 				// time, so show one now. Best-effort — never blocks the edit.
@@ -130,6 +174,9 @@ export class SdkDiffEditCoordinator {
 		const toolCallId = context.toolCallId ?? ""
 		const hadPreApprovalPreview = this.sessions.has(toolCallId)
 		try {
+			// Same dirty-buffer flush as executeEditorTool, for every file the patch
+			// updates or deletes (added files have no existing buffer to protect).
+			await this.flushDirtyTargets(cwd, patchTargetPaths(input?.input))
 			if (hadPreApprovalPreview) {
 				await this.discardPreview(toolCallId)
 			} else if (!this.options.isBackgroundEditEnabled()) {
@@ -181,6 +228,9 @@ export class SdkDiffEditCoordinator {
 		}
 		const cwd = await this.options.getCwd()
 		const absolutePath = resolveEditPath(cwd, input.path)
+		// Flush unsaved editor changes first so the preview's baseline (and the diff the
+		// user approves) reflects what is actually in their buffer, not stale disk state.
+		await this.flushDirtyTargets(cwd, [input.path])
 		let originalContent: string | undefined
 		try {
 			originalContent = await fs.readFile(absolutePath, "utf-8")
@@ -209,6 +259,9 @@ export class SdkDiffEditCoordinator {
 			return
 		}
 		const cwd = await this.options.getCwd()
+		// Flush unsaved editor changes for the patch's targets before computePatchChanges
+		// reads them from disk, so the preview baseline matches the user's buffers.
+		await this.flushDirtyTargets(cwd, patchTargetPaths(input.input))
 		const { changes } = await computePatchChanges(input.input, cwd)
 		// Preview the first file the patch creates or updates. Multi-file patches are
 		// uncommon; any remaining files apply without a preview.
@@ -323,6 +376,39 @@ export function computeNewEditorContent(
 		throw new Error(`No replacement performed: multiple occurrences of text found in ${filePath}.`)
 	}
 	return originalContent.replace(input.old_text, input.new_text ?? "")
+}
+
+/**
+ * Extracts the existing files an apply_patch input touches (Update/Delete headers).
+ * Added files are excluded: they have no existing editor buffer to protect. Returns
+ * an empty list for malformed input, letting the executor produce its canonical error.
+ */
+export function patchTargetPaths(patchText: unknown): string[] {
+	if (typeof patchText !== "string" || patchText.length === 0) {
+		return []
+	}
+	const paths: string[] = []
+	const header = /^\s*\*\*\* (?:Update|Delete) File: (.+)$/gm
+	let match: RegExpExecArray | null = header.exec(patchText)
+	while (match !== null) {
+		const filePath = match[1].trim()
+		if (filePath.length > 0) {
+			paths.push(filePath)
+		}
+		match = header.exec(patchText)
+	}
+	return paths
+}
+
+/**
+ * Default dirty-buffer flush: saves the file's open editor document if it has unsaved
+ * changes. No-ops when the host bridge isn't up (unit tests) or the file isn't open.
+ */
+async function saveDirtyDocumentViaHost(absolutePath: string): Promise<void> {
+	if (!HostProvider.isInitialized()) {
+		return
+	}
+	await HostProvider.workspace.saveOpenDocumentIfDirty({ filePath: absolutePath })
 }
 
 /** Mirrors the SDK executor's resolveFilePath (restrictToCwd=true): absolute paths pass through. */


### PR DESCRIPTION
### Related Issue

**Issue:** found in the July 2026 pre-launch QA fleet A/B run (legacy 4.0.11 vs SDK extension); this specific dirty-buffer data-loss finding had no ticket yet (nearest sibling: ENG-2329, which covers write-after-reject in the same disk-based pipeline).

### Description

The SDK edit pipeline (`editor` / `apply_patch`) is entirely disk-based: the diff-preview baseline (`SdkDiffEditCoordinator.openEditorPreview` / `openPatchPreview`), the executor's read, and the executor's write all go through Node `fs`. When the target file is open in the editor with **unsaved changes**, those changes are invisible to the edit — the diff the user approves is built from stale disk content — and the executor's `fs.writeFile` then overwrites the buffer's file on disk. When the (now clean-looking) document reloads, the user's unsaved work is permanently gone, with no warning. Legacy did not have this bug: its `DiffViewProvider.open` called `saveOpenDocumentIfDirty` before reading the file, so the dirty buffer became the edit's baseline.

This PR restores those semantics at the coordinator level, keeping the SDK's default executors host-agnostic:

- New `SdkDiffEditCoordinator.flushDirtyTargets` saves the target file's open dirty document to disk (via the existing host-bridge `workspace.saveOpenDocumentIfDirty`, which was still implemented but had no callers on the edit path).
- Called at all four disk-read/write points: `openEditorPreview` and `openPatchPreview` (so the preview baseline and the diff the user approves reflect the real buffer), and `executeEditorTool` / `executeApplyPatchTool` right before the fallback executors write (the user may have kept typing between approval and execution).
- For `apply_patch`, every `*** Update File:` / `*** Delete File:` target is flushed (new `patchTargetPaths` helper); added files are skipped since there is no existing buffer to protect.
- Flush failures at execution time **abort the tool call** — an error the model can see is always preferable to silently destroying the user's work. At preview time they are best-effort (callers already treat preview failures as non-fatal). Invalid/out-of-cwd paths are skipped so the executors still produce their canonical errors.
- The default flush no-ops when `HostProvider` isn't initialized (unit tests), and is injectable via a new `saveDirtyDocument` option, matching the coordinator's existing test seams.

### Test Procedure

- **Unit tests:** 9 new vitest cases in `sdk-diff-edit-coordinator.test.ts` covering: preview baseline read after flush (unsaved content appears in left/right), flush-before-write ordering, flush failure at approval time (preview skipped, no throw), flush failure at execution time (write aborted, executor never called), invalid paths skipped, apply_patch flushing update+delete but not add targets, and `patchTargetPaths` parsing. Full suite: `bunx vitest run` → 70 files, 851 tests, all passing. `tsc --noEmit` and `biome lint` clean.
- **Manual end-to-end (exact repro from the QA run):** built a VSIX from this branch, installed it, opened `readme.md` in the p-limit test repo, typed `MY UNSAVED USER EDIT - DO NOT LOSE` at the end **without saving**, then ran the task "Add a comment to the top of readme.md briefly noting this file was reviewed. Change nothing else."
  - Before this fix: the diff's right side ended at line 174 (unsaved line absent) and after Save the line was gone from disk (`grep -c` → 0).
  - With this fix: the diff's right side shows the unsaved line at 176, and after Save the file contains **both** the review comment at the top and the user's line at the end (`git diff` shows exactly those two additions).

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

**Before (bug):** diff scrolled to the bottom — the right side ends at the `[More…]` line; the user's unsaved line 175 is missing from the baseline, and approving destroyed it:

![Before: diff bottom missing the unsaved line](https://cursor.com/artifacts/c/art-5117e0ab-06ec-43f2-af64-539a84a0b658)

**After (fixed build):** same scenario — the diff's right side now includes the unsaved line at 176:

![After: diff bottom shows the unsaved line preserved](https://cursor.com/artifacts/c/art-de8f69fc-bef9-495e-9a31-9d2ee3061ef6)

**After Save:** the file on disk keeps the user's line at the end and the new comment at the top:

![Saved file end with user line preserved](https://cursor.com/artifacts/c/art-2702cbc2-7347-44ae-a9e2-2a8649b0bbcc)

![Saved file top with review comment added](https://cursor.com/artifacts/c/art-725c3577-c357-4294-9a5b-b03ac2f3c75e)

### Additional Notes

`read_files` still reads from disk, so a model can plan an edit from stale content while a buffer is dirty — with this fix that now fails safely (the executor's `old_text` won't match the flushed content and the model re-reads), instead of silently clobbering. Making reads buffer-aware is a possible follow-up, but it is not needed to close the data-loss hole.