### PR TITLE
fix(core): probe LiteLLM /v1/models when management routes are forbidden

### DIFF
--- a/sdk/packages/core/src/services/llms/provider-defaults.test.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.test.ts
@@ -622,6 +622,52 @@ describe("resolveProviderConfig", () => {
 		);
 	});
 
+	it("falls back to /v1/models when LiteLLM management routes are forbidden", async () => {
+		const forbidden = () => new Response("forbidden", { status: 403 });
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(forbidden())
+			.mockResolvedValueOnce(forbidden())
+			.mockResolvedValueOnce(forbidden())
+			.mockResolvedValueOnce(forbidden())
+			.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						data: [{ id: "gpt-full", object: "model", owned_by: "openai" }],
+					}),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				),
+			);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const resolved = await resolveProviderConfig(
+			"litellm",
+			{ failOnError: true, cacheTtlMs: 0 },
+			{
+				providerId: "litellm",
+				modelId: "",
+				apiKey: "litellm-key",
+				baseUrl: "http://localhost:4000/v1/",
+			},
+		);
+
+		expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
+			"http://localhost:4000/v1/model/info",
+			"http://localhost:4000/v1/model/info",
+			"http://localhost:4000/model/info",
+			"http://localhost:4000/model/info",
+			"http://localhost:4000/v1/models",
+		]);
+		expect(resolved?.knownModels?.["gpt-full"]).toEqual(
+			expect.objectContaining({
+				id: "gpt-full",
+				name: "gpt-full",
+				status: "active",
+			}),
+		);
+		expect(Object.keys(resolved?.knownModels ?? {})).toEqual(["gpt-full"]);
+	});
+
 	it("derives ChatGPT subscription models from the generated OpenAI catalog", async () => {
 		const resolved = await resolveProviderConfig("openai-codex");
 		const openAiResolved = await resolveProviderConfig("openai-native");

--- a/sdk/packages/core/src/services/llms/provider-defaults.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.ts
@@ -2,6 +2,7 @@
 
 import * as Llms from "@cline/llms";
 import {
+	extractModelIdsFromPayload,
 	fetchModelIdsFromSource,
 	resolveModelsSourceUrl,
 } from "../providers/model-source";
@@ -552,7 +553,11 @@ function normalizeLiteLlmBaseUrl(baseUrl: string | undefined): string {
 }
 
 function buildLiteLlmModelInfoUrls(baseUrl: string): string[] {
-	return [`${baseUrl}/v1/model/info`, `${baseUrl}/model/info`];
+	return [
+		`${baseUrl}/v1/model/info`,
+		`${baseUrl}/model/info`,
+		`${baseUrl}/v1/models`,
+	];
 }
 
 async function describeLiteLlmHttpFailure(response: Response): Promise<string> {
@@ -617,6 +622,11 @@ async function fetchLiteLlmPrivateModels(
 								id: displayName,
 								name: displayName,
 							};
+						}
+					}
+					if (Object.keys(models).length === 0) {
+						for (const id of extractModelIdsFromPayload(payload, "litellm")) {
+							models[id] = buildModelFromPrivateSource(id, { name: id });
 						}
 					}
 					return models;


### PR DESCRIPTION
### Related Issue

**Issue:** #12406
Fixes #12406

### Update 2026-08-19
Still applies cleanly to `main` at `dfa34ece`, no rebase needed, all checks green.

Worth flagging that #13293 (merged 18 Aug) decided the exact question this PR depends on. `resolveSelection` in `apps/vscode/src/sdk/model-catalog/store.ts` now carries:

// Private catalogs belong to the customer's configured endpoint.
// Persisted snapshot therefore remains authoritative after the live cache.

  and `litellm` is registered in `PRIVATE_PROVIDER_MODEL_FETCHERS`, so `isPrivateModelCatalogProvider("litellm")` is true. For a virtual key that authoritative path is currently unreachable: the private fetch 403s on both management routes, `resolveModels("litellm")` comes back empty, and the branch #13293 just added never runs. This PR is what makes it run.

One consequence to name. Since #13293 a live-catalog hint outranks the static SDK catalog, so a `/v1/models` id that collides with a static catalog id now resolves through `openAiModelInfoSafeDefaults` (128k window, `maxTokens: -1`) rather than the static entry. I have left that alone, since #13293's own comment says the customer's endpoint should win.

I also checked #13317, since it filters non-chat models out of the pickers. `isChatCompatibleModel` keys only on `operation` and `modalities`, and both-undefined stays chat-compatible by design, so the id-only models this PR registers still reach the picker. `filterImageOutputModels` is the one lossy filter and it sits behind `providerId === "cline"`, which litellm short-circuits past at `provider-defaults.ts:152`.

### Description

LiteLLM's recommended per-developer credential is a **virtual key**, which is scoped to
`llm_api_routes` by default. #11705 routed LiteLLM model fetches through the SDK and built the
probe list as exactly two URLs, `/v1/model/info` and `/model/info`, and both of those are
LiteLLM *management* routes. A virtual key is forbidden from calling either one.

## The problem

`fetchLiteLlmPrivateModels` walks those 2 URLs across 2 auth headers, and when all four attempts
fail it throws `LiteLLM model refresh failed`. `No production caller opts into `failOnError`
(`apps/vscode/src/sdk/model-catalog/catalog.ts`, `apps/cli/src/main.ts`, `use-model-selector.tsx`,
`onboarding/controller.ts`, `local-provider-service.ts`), so `resolveProviderConfig` swallows the
throw and returns `knownModels: {}`. Since #11773 made `mergeKnownModels` return the private list
for `litellm` with no catalog fallback, deliberately, because the proxy is the authoritative
allowlist, the result is a **permanently empty model picker with no error surfaced**.
`tryGetModelInfo` also returns undefined, so a hand-typed model id gets no contextWindow or
capabilities.

The reporter confirmed that `/v1/models` works on the same key while `/model/info`,
`/v1/model/info` and `/v2/model/info` all do not.

## The fix

Append `/v1/models` as a **third** probe, and when the LiteLLM-shaped parse of a 200 response
yields zero models, re-parse the same payload with `extractModelIdsFromPayload` and register the
id-only entries through `buildModelFromPrivateSource(id, { name: id })`.

Both helpers already exist. `extractModelIdsFromPayload`
(`sdk/packages/core/src/services/providers/model-source.ts`) already handles OpenAI-shaped
`{data:[{id}]}` payloads, and `buildModelFromPrivateSource(id, { name: id })` is byte-identical to
how `getPublicProviderModels` already registers id-only models for Ollama and LM Studio. The import
from `../providers/model-source` was already there. Net change is +11/-1 in the source file.

#### Non-obvious details

**Probe order is load-bearing, not incidental.** The two management routes carry
`max_output_tokens`, `supports_vision`, `supports_prompt_caching` and `supports_reasoning`;
`/v1/models` carries only `id`. Probing rich-first means an admin key still resolves on request one
and keeps all its metadata, it pays zero extra requests and its behavior is byte-identical. The
new test pins the exact 5-call sequence rather than just asserting `/v1/models` is present, so a
future reorder fails loudly.

**The empty-result guard, not an endpoint check.** The fallback keys on
`Object.keys(models).length === 0` inside the `response.ok` branch, so it is endpoint-agnostic and
also rescues a `/model/info` that returns id-only entries. It cannot mask a partial parse:
`extractModelIdsFromPayload` reads top-level `id`/`name`/`model`, and LiteLLM `/model/info` entries
carry `model_name`/`litellm_params`/`model_info` instead, so any entry the LiteLLM-shaped loop
skips could not have been rescued by the generic parser anyway.

**One fix site covers both worlds.** `apps/vscode`'s `refreshLiteLlmModels` delegates to
`getProviderCatalog().resolveModels("litellm")`, which routes into this same SDK fetcher. There is
no second probe site to patch.

### What does not change

- The two `/model/info` probes still run first, in the same order. Any working admin-key setup is
  byte-identical.
- `/v1/models` is only reached after both management routes fail on both auth headers.
- The id-only parse only runs when the LiteLLM-shaped parse produced nothing, so a successful
  `/model/info` response is untouched.
- No change to `mergeKnownModels` or to the empty-list-is-authoritative policy from #11773.

### Regression risk / limitations

- **Models discovered via `/v1/models` have no capability metadata.** The OpenAI shape carries only
  `id`, so `contextWindow` and `maxTokens` come back undefined and fall through to the existing
  defaults (128k / -1 in `shape-adapter.ts`). Concretely: because
  `buildModelFromPrivateSource` always emits a non-empty `capabilities: ["streaming","tools"]`, a
  vision-capable model discovered this way gets `supportsImages: false` in the VS Code UI, whereas
  the same model via `/model/info` keeps images. This is unavoidable for id-only discovery and is
  strictly better than the current empty picker, but it is a real tradeoff worth naming.
- **The failure path now costs 6 requests instead of 4.** With
  `DEFAULT_PRIVATE_MODELS_REQUEST_TIMEOUT_MS = 5000`, a fully unreachable proxy goes from ~20s to
  ~30s worst case. This only affects users whose picker is already broken, and the admin-key path still returns on request one.

### Why not other approaches considered

- **Fix it LiteLLM-side** by adding the management routes to `llm_api_routes`. This is the
  reporter's own preference and it does work, but it requires every team to re-scope the credential
  type LiteLLM itself recommends. Cline should degrade gracefully instead.
- **Give `litellm` a `modelsSourceUrl`** so the public-source path handles it. Dead end twice:
  `fetchModelIdsFromSource` issues an unauthenticated `fetch(url)` that a virtual key rejects, and
  `mergeKnownModels` returns only `privateModels` for `litellm`, discarding public models entirely.

### Out of scope

The issue also asks for an error to be surfaced when the list comes back empty. The reporter
describes that as a feature request himself, so it is deliberately not bundled here.

### Test Procedure

1. New regression test `falls back to /v1/models when LiteLLM management routes are forbidden`
   mocks 403 on both auth headers for `/v1/model/info` and `/model/info`, then 200 on `/v1/models`
   returning `{"data":[{"id":"gpt-full","object":"model","owned_by":"openai"}]}`.

2. **Fails on main, passes with this change.** On `main` it records exactly 4 calls, never reaches
   `/v1/models`, and rejects with `LiteLLM model refresh failed`.

       cd sdk/packages/core
       bunx vitest run --config vitest.config.ts src/services/llms/provider-defaults.test.ts

   `Test Files 1 passed (1)` / `Tests 18 passed (18)` - the 17 pre-existing cases (including all
   four existing LiteLLM cases) plus the new one.

3. Verified the test is not vacuous by mutation, in both directions: deleting the 5-line fallback
   fails it, and moving `/v1/models` to the front of the probe list also fails it.

4. Typecheck and lint from the repo root:

       bun run types
       bun run lint

   Both exit 0.

5. Caveat: the full `@cline/core` suite is not a clean signal on my Windows machine, it fails tests with `EPERM` on temp directories on an unmodified `main` as well, and the count varies per run. CI is the authority here, and the `Test (windows-latest, Node 24.x)` and `Test (ubuntu-latest, Node 24.x)` jobs both pass on this branch.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots

No visual change is intended.

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bug, or refactor
- [x] Tests added and passing
- [x] Lint and typecheck pass locally