### PR TITLE
fix(core): resolve the selected model's metadata when knownModels omi…

### DIFF
--- a/sdk/packages/core/src/services/llms/handler-factory.test.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.test.ts
@@ -10,12 +10,13 @@ const gatewayMock = vi.hoisted(() => {
 		// registered handler" so existing tests exercise the gateway path.
 		hasRegisteredHandler: vi.fn(() => false),
 		createHandlerAsync: vi.fn(),
+		modelCollections: {} as Record<string, { models: Record<string, unknown> }>,
 	};
 });
 
 vi.mock("@cline/llms", () => ({
 	createGateway: gatewayMock.createGateway,
-	MODEL_COLLECTIONS_BY_PROVIDER_ID: {},
+	MODEL_COLLECTIONS_BY_PROVIDER_ID: gatewayMock.modelCollections,
 	hasRegisteredHandler: gatewayMock.hasRegisteredHandler,
 	createHandlerAsync: gatewayMock.createHandlerAsync,
 	normalizeProviderId: (id: string) => id,
@@ -31,6 +32,9 @@ describe("createAgentModelFromConfig", () => {
 		gatewayMock.hasRegisteredHandler.mockReset();
 		gatewayMock.hasRegisteredHandler.mockReturnValue(false);
 		gatewayMock.createHandlerAsync.mockReset();
+		for (const providerId of Object.keys(gatewayMock.modelCollections)) {
+			delete gatewayMock.modelCollections[providerId];
+		}
 	});
 
 	it("forwards effective telemetry into the gateway", async () => {
@@ -374,6 +378,80 @@ describe("createAgentModelFromConfig", () => {
 				],
 			}),
 		);
+	});
+
+	it("falls back to the provider registry when providerConfig.knownModels omits the selected model", async () => {
+		const { resolveKnownModelsFromConfig } = await import("./handler-factory");
+
+		gatewayMock.modelCollections["openai-compatible"] = {
+			models: {
+				"glm-5.2": {
+					id: "glm-5.2",
+					name: "glm-5.2",
+					contextWindow: 1_048_576,
+					maxInputTokens: 1_048_576,
+				},
+			},
+		};
+		const builtinSnapshot = {
+			"gpt-4o": {
+				id: "gpt-4o",
+				name: "gpt-4o",
+				contextWindow: 128_000,
+				maxInputTokens: 128_000,
+			},
+		};
+
+		const resolved = resolveKnownModelsFromConfig({
+			providerId: "openai-compatible",
+			modelId: "glm-5.2",
+			systemPrompt: "",
+			tools: [],
+			knownModels: builtinSnapshot,
+			providerConfig: {
+				providerId: "openai-compatible",
+				modelId: "glm-5.2",
+				knownModels: builtinSnapshot,
+			},
+		} as unknown as AgentConfig);
+
+		expect(resolved?.["glm-5.2"]?.contextWindow).toBe(1_048_576);
+	});
+
+	it("keeps providerConfig.knownModels authoritative when it defines the selected model", async () => {
+		const { resolveKnownModelsFromConfig } = await import("./handler-factory");
+
+		gatewayMock.modelCollections["openai-compatible"] = {
+			models: {
+				"glm-5.2": {
+					id: "glm-5.2",
+					name: "glm-5.2",
+					contextWindow: 1_048_576,
+					maxInputTokens: 1_048_576,
+				},
+			},
+		};
+
+		const resolved = resolveKnownModelsFromConfig({
+			providerId: "openai-compatible",
+			modelId: "glm-5.2",
+			systemPrompt: "",
+			tools: [],
+			providerConfig: {
+				providerId: "openai-compatible",
+				modelId: "glm-5.2",
+				knownModels: {
+					"glm-5.2": {
+						id: "glm-5.2",
+						name: "glm-5.2",
+						contextWindow: 200_000,
+						maxInputTokens: 200_000,
+					},
+				},
+			},
+		} as unknown as AgentConfig);
+
+		expect(resolved?.["glm-5.2"]?.contextWindow).toBe(200_000);
 	});
 
 	it("surfaces a caller-supplied modelInfo for the selected model as a gateway model definition", async () => {

--- a/sdk/packages/core/src/services/llms/handler-factory.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.ts
@@ -87,15 +87,26 @@ function readPositiveInteger(value: unknown): number | undefined {
 		: undefined;
 }
 
+function selectKnownModels(
+	config: AgentConfig,
+	pc: ProviderConfig | undefined,
+): Record<string, ModelInfo> | undefined {
+	const sources = [
+		pc?.knownModels,
+		config.knownModels,
+		MODEL_COLLECTIONS_BY_PROVIDER_ID[config.providerId]?.models,
+	];
+	return (
+		sources.find((source) => source?.[config.modelId]) ??
+		sources.find((source) => source !== undefined)
+	);
+}
+
 export function resolveKnownModelsFromConfig(
 	config: AgentConfig,
 ): Record<string, ModelInfo> | undefined {
 	const pc = config.providerConfig as ProviderConfig | undefined;
-	const knownModels = pc?.knownModels
-		? pc.knownModels
-		: (config.knownModels ??
-			MODEL_COLLECTIONS_BY_PROVIDER_ID[config.providerId]?.models ??
-			undefined);
+	const knownModels = selectKnownModels(config, pc);
 	// Caller-configured limits are authoritative for the selected model —
 	// surface them to the gateway so the resolved model definition carries
 	// the right limits (e.g. Ollama's num_ctx derives from the resolved


### PR DESCRIPTION
### Related Issue

**Issue:** #12520 (partial - see Limitations)

### Description

**Problem:** on the CLI with an `openai-compatible` provider, auto-compaction fires at ~115.2k
tokens no matter what context window the model declares. That number is exactly
`DEFAULT_MAX_INPUT_TOKENS` (128_000) x `COMPACTION_TRIGGER_RATIO` (0.9) = 115_200, so the configured
window is being dropped and the default used.

**Root cause:** `resolveKnownModelsFromConfig` picked its model map by testing *truthiness*:

    const knownModels = pc?.knownModels ? pc.knownModels : (config.knownModels ?? REGISTRY[...])

For the builtin `openai-compatible` id that map is always populated but wrong-keyed.
`fallbackModelInfo` (`sdk/packages/llms/src/providers/builtins.ts`) hard-codes `contextWindow:
128_000` for the `openai-compatible` family, and the spec's `defaultModelId` is `gpt-4o`. That
`{gpt-4o: 128_000}` snapshot reaches **both** `config.knownModels` and `providerConfig.knownModels`
(`provider-defaults.ts` `BUILTIN_PROVIDER_MANIFESTS` -> `apps/cli/src/main.ts` ->
`local-runtime-bootstrap.ts` -> `local-runtime-host.ts`). Being truthy, it short-circuited the chain,
so the *selected* model was never looked up anywhere else. `tryGetModelInfo`
(`session-runtime-orchestrator.ts`) then returned `undefined`, and compaction used the 128k default.

**Fix:** prefer the first source that actually *defines* the selected model, falling back to the
first defined source when none do.

**What did NOT change:** when the configured `knownModels` already contains the selected model, the
resolved map is identical - `providerConfig.knownModels` stays authoritative, and the providers.json
`contextWindow` -> `maxInputTokens` projection below it is untouched. An empty `{}` still resolves to
`{}` as before. The only behavior delta is the case where an earlier source exists but omits the
active model, which previously resolved to metadata for a model that wasn't being used.

**Why not other approaches considered:** merging all three sources unconditionally would work, but it
changes precedence for every provider and widens the gateway's `models:` list on paths that are
working fine today. Preferring the defining source keeps the blast radius at the broken case.

#### Non-obvious detail

The registry lookup has to stay lazy. `MODEL_COLLECTIONS_BY_PROVIDER_ID` is a Proxy that resolves
through `getProviderFromCache` on each access, whereas `BUILTIN_PROVIDER_MANIFESTS` is a
module-eval-time snapshot captured before `ensureCustomProvidersLoadedSync` runs in
`ProviderSettingsManager`'s constructor. That ordering is why the snapshot can't see a models.json
registration and the proxy can.

### Test Procedure

Two tests added to `sdk/packages/core/src/services/llms/handler-factory.test.ts`:

- `falls back to the provider registry when providerConfig.knownModels omits the selected model` -
  builds the CLI-shaped config (both `knownModels` and `providerConfig.knownModels` set to the
  `{gpt-4o: 128_000}` snapshot) and asserts the declared 1_048_576 window is resolved.
  **Fails on main** with `expected undefined to be 1048576`; passes with this change.
- `keeps providerConfig.knownModels authoritative when it defines the selected model` - pins the
  existing precedence. Passes both before and after.

    cd sdk/packages/core
    bunx vitest run src/services/llms/handler-factory.test.ts

17 passed (15 pre-existing + 2 new). Reverting only `handler-factory.ts` and re-running gives
1 failed | 16 passed, confirming the new test is genuinely red on unmodified main.

    cd sdk/packages/core && bun tsc --noEmit          # exit 0
    bunx biome check sdk/packages/core/src/services/llms/handler-factory.ts sdk/packages/core/src/services/llms/handler-factory.test.ts

Full `@cline/core` suite: 12 failures, identical set to unmodified `upstream/main` (verified by
stashing the change and re-running) - all pre-existing and unrelated
(`workspace-manifest`, `hub-runtime-host`, `fetch-wiring`, `runtime-builder`,
`local-runtime-bootstrap`).

### Limitations

This covers models.json entries whose `provider` block is complete (both `name` and `baseUrl`), which
register via `registerProvider` into `CUSTOM_PROVIDERS` and are therefore visible to
`MODEL_COLLECTIONS_BY_PROVIDER_ID`. Entries **without** a complete provider block route through
`registerModel` into `CUSTOM_MODELS`, which that proxy does not read - those need a separate change,
so I've used `Refs` rather than `Closes` on the issue. I don't have the reporter's models.json to
tell which case they hit, and I've asked on the issue.

I could not find a public PR to name as the origin: the truthiness expression predates the folder
restructure that landed this file at its current path.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bug, or refactor
- [x] Tests added for the fixed behavior
- [x] No new lint/type errors introduced

### Screenshots

No visual change is intended.