### PR TITLE
fix(vscode): stop sending the task title as new user instructions on …

### DIFF
--- a/apps/vscode/src/sdk/sdk-followup-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-followup-coordinator.test.ts
@@ -302,6 +302,37 @@ describe("SdkFollowupCoordinator", () => {
 		expect(options.postStateToWebview).toHaveBeenCalledOnce()
 	})
 
+	it("does not present the original task text as new user instructions on a bare resume", async () => {
+		const task = makeTask("task-1")
+		const historyItem = {
+			id: "task-1",
+			ts: 1,
+			task: "Original task",
+			tokensIn: 0,
+			tokensOut: 0,
+			totalCost: 0,
+			cwdOnTaskInitialization: "/task-cwd",
+		}
+		const { coordinator, options } = makeCoordinator({ task, historyItem })
+
+		await coordinator.askResponse(undefined)
+
+		expect(options.sessions.fireAndForgetSend).toHaveBeenCalledWith(
+			expect.anything(),
+			"resumed-session",
+			expect.not.stringContaining("New instructions from the user"),
+			undefined,
+			undefined,
+		)
+		expect(options.sessions.fireAndForgetSend).toHaveBeenCalledWith(
+			expect.anything(),
+			"resumed-session",
+			expect.not.stringContaining("Original task"),
+			undefined,
+			undefined,
+		)
+	})
+
 	it("ends a resumed session without mutating a task selected while start was pending", async () => {
 		const task = makeTask("task-1")
 		const replacementTask = makeTask("task-2")

--- a/apps/vscode/src/sdk/sdk-followup-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-followup-coordinator.ts
@@ -227,7 +227,7 @@ export class SdkFollowupCoordinator {
 			const effectivePrompt =
 				prompt?.trim() ||
 				(historyItem
-					? `[TASK RESUMPTION] This task was interrupted. It may or may not be complete, so please reassess the task context. The conversation history has been preserved. New instructions from the user: ${historyItem.task}`
+					? "[TASK RESUMPTION] This task was interrupted. It may or may not be complete, so please reassess the task context. The conversation history has been preserved."
 					: "[TASK RESUMPTION] Please continue where you left off.")
 			const resolvedPrompt = await this.options.resolveContextMentions(effectivePrompt)
 			if (this.options.getTask()?.taskId !== taskId) {


### PR DESCRIPTION
### Related Issue

Fixes #12377

### Description

## The problem

Resuming a task with an empty composer feeds the task's own **title** back to the model labelled as a brand-new user instruction. The model reads its own title as a fresh request and restarts or drifts back to earlier work instead of continuing.

`apps/vscode/src/sdk/sdk-followup-coordinator.ts`:

```ts
const effectivePrompt =
    prompt?.trim() ||
    (historyItem
        ? `[TASK RESUMPTION] ... The conversation history has been preserved. New instructions from the user: ${historyItem.task}`
        : "[TASK RESUMPTION] Please continue where you left off.")
```

`historyItem.task` is not an instruction, it is a display string. `sdk-task-history.ts` builds it as `formatDisplayUserInput(metadataString(metadata, "title") ?? item.prompt ?? "")`. `message-translator.ts` documents `formatDisplayUserInput` as the display boundary, explicitly contrasted with `normalizeUserInput`, which is the one that also sanitizes model-bound prompts. So a display-formatted string is being fed into a model-bound prompt, under a label asserting the user just typed it.

**Introduced in 94f5a47a5** ("sdk migration: squashed pre-2026-06-02 work"). `git log -S "New instructions from the user"` points at that commit as the single origin.

#### Why this is a porting regression, not a wording choice

The legacy builder did not do this. `responses.taskResumption` in `apps/vscode/src/core/prompts/responses.ts` returns a **two-element tuple**:

```ts
return [taskResumptionMessage, userResponseMessage]
```

The second slot is the user's new message, and it is only populated `if (responseText)`. On a bare act-mode resume it is the empty string, so nothing was ever presented as new instructions. The SDK port collapsed those two slots into one string and backfilled the empty slot with the title. The label survived the port; the thing it was labelling did not.

(`responses.taskResumption` now has no remaining callers. Removing it is a separate concern and is deliberately not part of this PR.)

## The fix

Drop the trailing clause so the branch ends at the preserved-history sentence. One line, no new prompt wording invented, and it restores the legacy contract of "no new message means no new-instructions text".

**Why not the other approach considered:** collapsing both branches to the existing `"[TASK RESUMPTION] Please continue where you left off."` would also remove the false sentence, but it discards the reassess-the-task-context guidance that the legacy builder emitted too. The minimal delete keeps that guidance intact.

## What did NOT change

- The resumption context sentence itself is untouched, so the model still gets the interrupted/reassess/history-preserved framing. The existing "echoes attachments on an attachment-only resume" test pins that prefix on this same branch and still passes.
- The no-`historyItem` branch is untouched.
- The typed-text path is untouched. If the user types anything, `prompt?.trim()` wins and this branch never evaluates.

**Regression risk.** One behavioral side effect worth naming: `effectivePrompt` is passed to `resolveContextMentions`, which runs `resolveSlashCommands` and then `parseMentions` when an `@` is present. Previously a task *title* containing `@something` or a slash command would be expanded on a bare resume, pulling file or URL content into the prompt purely because of the title text. With the title gone the prompt is a constant, so that no longer happens. That is a narrowing, not a widening, but it is a real difference in behavior.

## Expectations / limitations

This fixes the **bare resume** path, where the composer is empty. That is adjacent to, but not identical to, the repro in the issue:

- If the user types text before resuming, `prompt?.trim()` is truthy and the defective branch never runs, so this change does not affect that flow.
- `resume_completed_task` presents "Start New Task" as its primary button (`buttonConfig.ts`), so the literal completed-task case named in the issue title is reached differently.

I am raising this as the mechanism I could confirm from the code rather than claiming it covers every path in the report.

### Test Procedure

Added one regression test in `sdk-followup-coordinator.test.ts`. It reuses the existing `makeCoordinator` / `makeTask` helpers and the same `historyItem` fixture the neighbouring resume tests already use, so no new fixture was introduced.

**It fails on main and passes with this change.** Both assertions were verified failing independently before the fix, not just the first one:

```
× does not present the original task text as new user instructions on a bare resume
  - StringNotContaining "New instructions from the user"
  + "resolved: [TASK RESUMPTION] This task was interrupted. It may or may not be
     complete, so please reassess the task context. The conversation history has
     been preserved. New instructions from the user: Original task"
```

1. Target suite, narrowest filter:

```
cd apps/vscode && npx vitest run --config vitest.config.ts src/sdk/sdk-followup-coordinator.test.ts
```

19 tests passed before the new test was added; 20 pass after the fix

2. Full vitest config for the extension:

```
cd apps/vscode && npx vitest run --config vitest.config.ts
```

74 files, 933 tests, all passing

3. Typecheck, both projects:

```
cd apps/vscode && bunx tsc --noEmit
cd apps/vscode && bunx tsc --project tsconfig.vscode-compat.json --noEmit
```

Both exit 0 with no output.

4. Formatting and lint on the changed files:

```
cd apps/vscode && bunx biome check --config-path ./biome.jsonc --semicolons=as-needed src/sdk/sdk-followup-coordinator.ts src/sdk/sdk-followup-coordinator.test.ts
```

Checked 2 files, no fixes applied.

**Honest caveat on the wider suite.** `bun run test:unit` in `apps/vscode` reports 67 files, 1004 pass, 1 fail on my machine, exiting 1. That failure is pre-existing and environmental on Windows, not from this change: `src/test/shell.test.ts` fails a path-casing assertion (`C:\WINDOWS\Sysnative\cmd.exe` vs `C:\Windows\Sysnative\cmd.exe`). I confirmed it by stashing the diff and re-running at the base commit, where it fails identically, and that file is untouched by both this PR and #12002. It is not in `src/sdk`.

### Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing and code is formatted and linted
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

No visual change is intended. This only affects the prompt text sent to the model on a bare resume.

### Additional Notes

Rebased onto main after #12002 landed. That PR relocated this exact `effectivePrompt` block into the new `try` in `resumeSessionFromTask` without changing the string, so the bug survived the refactor and the fix simply moved with it. The regression test was re-verified failing on the rebased base before the fix, and all four tests #12002 added to this file are preserved.

Diff is 2 files, +32/-1: one line of production code and one test.