### PR TITLE
feat: add Pioneer as an inference provider

### DIFF
--- a/apps/vscode/src/sdk/model-catalog/provider-id.ts
+++ b/apps/vscode/src/sdk/model-catalog/provider-id.ts
@@ -42,6 +42,7 @@ const KNOWN_API_PROVIDERS = {
 	sapaicore: true,
 	groq: true,
 	poolside: true,
+	pioneer: true,
 	huggingface: true,
 	"huawei-cloud-maas": true,
 	dify: true,

--- a/apps/vscode/src/shared/api.ts
+++ b/apps/vscode/src/shared/api.ts
@@ -34,6 +34,7 @@ export type ApiProvider =
 	| "sapaicore"
 	| "groq"
 	| "poolside"
+	| "pioneer"
 	| "huggingface"
 	| "huawei-cloud-maas"
 	| "dify"

--- a/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.ts
+++ b/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.ts
@@ -52,6 +52,9 @@ const GENERIC_PROVIDER_PRESENTATION_OVERRIDES: Record<string, GenericProviderPre
 		signupUrl: "https://console.groq.com/keys",
 	},
 	poolside: {},
+	pioneer: {
+		signupUrl: "https://agent.pioneer.ai/",
+	},
 	cerebras: {
 		signupUrl: "https://cloud.cerebras.ai/",
 	},
@@ -156,6 +159,7 @@ const FALLBACK_GENERIC_PROVIDER_NAMES = {
 	mistral: "Mistral",
 	nousResearch: "NousResearch",
 	poolside: "Poolside",
+	pioneer: "Pioneer",
 	together: "Together",
 	v0: "Vercel v0",
 	wandb: "W&B",

--- a/apps/vscode/webview-ui/src/hooks/useProviderModelSelection.test.ts
+++ b/apps/vscode/webview-ui/src/hooks/useProviderModelSelection.test.ts
@@ -64,6 +64,32 @@ describe("useProviderModelSelection", () => {
 		expect(result.current.selectedModel.modelInfo.contextWindow).toBe(200_000)
 	})
 
+	it("keeps a $0 committed snapshot that carries user overrides", () => {
+		const commitSelection = vi.fn(async () => undefined)
+		// Legitimately free model, but the user has an override (context window).
+		const models = { "free-model": { name: "Fresh Free", contextWindow: 1_000, inputPrice: 0, outputPrice: 0, maxTokens: 1 } }
+		const config = {
+			actSelection: {
+				modelId: "free-model",
+				modelInfo: {
+					name: "Committed Free",
+					contextWindow: 50_000,
+					maxTokens: 8_192,
+					inputPrice: 0,
+					outputPrice: 0,
+					tiers: [],
+				},
+				overrides: { capabilities: [], contextWindow: 50_000 },
+			},
+		} as unknown as ProviderConfigResponse
+
+		const { result } = renderHook(() => useProviderModelSelection("provider", "act", { models, config, commitSelection }))
+
+		// User override is preserved even though pricing is $0 and the model is in the list.
+		expect(result.current.selectedModel.modelInfo.name).toBe("Committed Free")
+		expect(result.current.selectedModel.modelInfo.contextWindow).toBe(50_000)
+	})
+
 	it("falls back to the committed snapshot when the model is absent from the catalog", () => {
 		const commitSelection = vi.fn(async () => undefined)
 		const config = {

--- a/apps/vscode/webview-ui/src/hooks/useProviderModelSelection.test.ts
+++ b/apps/vscode/webview-ui/src/hooks/useProviderModelSelection.test.ts
@@ -1,9 +1,91 @@
-import { ApiFormat } from "@shared/proto/cline/models"
+import { ApiFormat, type ProviderConfigResponse } from "@shared/proto/cline/models"
 import { act, renderHook } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 import { useProviderModelSelection } from "./useProviderModelSelection"
 
 describe("useProviderModelSelection", () => {
+	it("uses the fresh catalog entry when the committed snapshot is a $0 placeholder", () => {
+		const commitSelection = vi.fn(async () => undefined)
+		const models = {
+			"gpt-5.6-sol": {
+				name: "GPT-5.6 Sol",
+				contextWindow: 1_050_000,
+				maxTokens: 128_000,
+				supportsPromptCache: true,
+				inputPrice: 5,
+				outputPrice: 30,
+			},
+		}
+		// Placeholder snapshot: a generic provider's live-only model absent from
+		// the static catalog resolves to $0/no-pricing.
+		const config = {
+			actSelection: {
+				modelId: "gpt-5.6-sol",
+				modelInfo: {
+					name: "GPT-5.6 Sol",
+					contextWindow: 128_000,
+					maxTokens: -1,
+					inputPrice: 0,
+					outputPrice: 0,
+					tiers: [],
+				},
+			},
+		} as unknown as ProviderConfigResponse
+
+		const { result } = renderHook(() => useProviderModelSelection("pioneer", "act", { models, config, commitSelection }))
+
+		expect(result.current.selectedModel.modelInfo.inputPrice).toBe(5)
+		expect(result.current.selectedModel.modelInfo.outputPrice).toBe(30)
+		expect(result.current.selectedModel.modelInfo.contextWindow).toBe(1_050_000)
+	})
+
+	it("keeps a committed snapshot that has pricing (does not override with the fresh entry)", () => {
+		const commitSelection = vi.fn(async () => undefined)
+		// User/override snapshot with real pricing; the fresh entry differs.
+		const models = { "some-model": { name: "Fresh", contextWindow: 111, inputPrice: 9, outputPrice: 9, maxTokens: 1 } }
+		const config = {
+			actSelection: {
+				modelId: "some-model",
+				modelInfo: {
+					name: "Committed",
+					contextWindow: 200_000,
+					maxTokens: 8_192,
+					inputPrice: 2,
+					outputPrice: 8,
+					tiers: [],
+				},
+			},
+		} as unknown as ProviderConfigResponse
+
+		const { result } = renderHook(() => useProviderModelSelection("provider", "act", { models, config, commitSelection }))
+
+		// Committed pricing wins — the fresh entry must not clobber it.
+		expect(result.current.selectedModel.modelInfo.inputPrice).toBe(2)
+		expect(result.current.selectedModel.modelInfo.contextWindow).toBe(200_000)
+	})
+
+	it("falls back to the committed snapshot when the model is absent from the catalog", () => {
+		const commitSelection = vi.fn(async () => undefined)
+		const config = {
+			actSelection: {
+				modelId: "dropped-model",
+				modelInfo: {
+					name: "Dropped",
+					contextWindow: 200_000,
+					maxTokens: 8_192,
+					inputPrice: 2,
+					outputPrice: 8,
+					tiers: [],
+				},
+			},
+		} as unknown as ProviderConfigResponse
+
+		const { result } = renderHook(() => useProviderModelSelection("pioneer", "act", { models: {}, config, commitSelection }))
+
+		expect(result.current.selectedModel.modelId).toBe("dropped-model")
+		expect(result.current.selectedModel.modelInfo.inputPrice).toBe(2)
+	})
+
 	it("does not turn custom fallback model info into persisted overrides", async () => {
 		const commitSelection = vi.fn(async () => undefined)
 		const customModelInfo = {

--- a/apps/vscode/webview-ui/src/hooks/useProviderModelSelection.ts
+++ b/apps/vscode/webview-ui/src/hooks/useProviderModelSelection.ts
@@ -38,11 +38,19 @@ export function useProviderModelSelection(
 	const committedSelection = currentMode === "plan" ? config?.planSelection : config?.actSelection
 	const fallbackModelId = defaultModelId || Object.keys(models)[0] || ""
 	const selectedModelId = committedSelection?.modelId ?? fallbackModelId
-	const selectedModelInfo = committedSelection?.modelInfo
-		? fromProtobufModelInfo(committedSelection.modelInfo)
-		: (models[selectedModelId] ??
-			(selectedModelId && customModelInfo ? customModelInfo(selectedModelId) : undefined) ??
-			fallbackModelInfo)
+	const committedModelInfo = committedSelection?.modelInfo ? fromProtobufModelInfo(committedSelection.modelInfo) : undefined
+	const freshModelInfo = models[selectedModelId]
+	// The committed snapshot normally wins (it carries user per-model overrides).
+	// But a generic provider's live-only models (e.g. most of Pioneer's catalog)
+	// aren't in the static catalog, so their committed snapshot resolves to a
+	// $0/no-metadata placeholder. In that case only — a snapshot with no pricing —
+	// fall through to the freshly-resolved catalog entry so live pricing/metadata
+	// show correctly. Snapshots that already carry pricing are left untouched.
+	const committedHasPricing = Boolean(committedModelInfo?.inputPrice || committedModelInfo?.outputPrice)
+	const selectedModelInfo =
+		(committedHasPricing ? committedModelInfo : (freshModelInfo ?? committedModelInfo)) ??
+		(selectedModelId && customModelInfo ? customModelInfo(selectedModelId) : undefined) ??
+		fallbackModelInfo
 
 	const selectedModel: DisplayProviderModelSelection = {
 		providerId,

--- a/apps/vscode/webview-ui/src/hooks/useProviderModelSelection.ts
+++ b/apps/vscode/webview-ui/src/hooks/useProviderModelSelection.ts
@@ -1,10 +1,22 @@
 import { type ModelInfo, openAiModelInfoSafeDefaults } from "@shared/api"
-import type { ProviderConfigResponse } from "@shared/proto/cline/models"
+import type { ModelOverrides, ProviderConfigResponse } from "@shared/proto/cline/models"
 import { fromProtobufModelInfo } from "@shared/proto-conversions/models/typeConversion"
 import type { Mode } from "@shared/storage/types"
 import { useCallback } from "react"
 import type { ProviderId } from "@/context/ExtensionStateContext"
 import type { ProviderModelSelection } from "./useProviderConfig"
+
+/** True when the user has authored any per-model override on this selection. */
+function hasUserOverrides(overrides: ModelOverrides | undefined): boolean {
+	if (!overrides) {
+		return false
+	}
+	const { capabilities, ...scalar } = overrides
+	if (capabilities && capabilities.length > 0) {
+		return true
+	}
+	return Object.values(scalar).some((value) => value !== undefined)
+}
 
 type ProviderModelSelectionInput =
 	| (Omit<ProviderModelSelection, "providerId"> & { modelInfo?: ModelInfo })
@@ -43,12 +55,14 @@ export function useProviderModelSelection(
 	// The committed snapshot normally wins (it carries user per-model overrides).
 	// But a generic provider's live-only models (e.g. most of Pioneer's catalog)
 	// aren't in the static catalog, so their committed snapshot resolves to a
-	// $0/no-metadata placeholder. In that case only — a snapshot with no pricing —
-	// fall through to the freshly-resolved catalog entry so live pricing/metadata
-	// show correctly. Snapshots that already carry pricing are left untouched.
-	const committedHasPricing = Boolean(committedModelInfo?.inputPrice || committedModelInfo?.outputPrice)
+	// $0/no-metadata placeholder. Only in that case — a snapshot the user has NOT
+	// overridden and that carries no pricing — fall through to the freshly-resolved
+	// catalog entry so live pricing/metadata show correctly. A snapshot with user
+	// overrides (even for a legitimately $0 model) or with real pricing is kept.
+	const committedIsPlaceholder =
+		!hasUserOverrides(committedSelection?.overrides) && !committedModelInfo?.inputPrice && !committedModelInfo?.outputPrice
 	const selectedModelInfo =
-		(committedHasPricing ? committedModelInfo : (freshModelInfo ?? committedModelInfo)) ??
+		(committedIsPlaceholder ? (freshModelInfo ?? committedModelInfo) : committedModelInfo) ??
 		(selectedModelId && customModelInfo ? customModelInfo(selectedModelId) : undefined) ??
 		fallbackModelInfo
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -91,6 +91,7 @@
 											"provider-config/openai",
 											"provider-config/openai-compatible",
 											"provider-config/openrouter",
+											"provider-config/pioneer",
 											"provider-config/poolside",
 											"provider-config/zai",
 											"provider-config/other-30-plus-providers"

--- a/docs/provider-config/pioneer.mdx
+++ b/docs/provider-config/pioneer.mdx
@@ -1,0 +1,29 @@
+---
+title: "Pioneer"
+description: "Learn how to configure and use Pioneer models with Cline."
+---
+
+Pioneer provides a broad catalog of coding and general-purpose AI models through an OpenAI-compatible API.
+
+**Website:** [https://pioneer.ai/](https://pioneer.ai/)
+
+### Get API Credentials
+
+1.  **Sign Up/Sign In:** Go to the [Pioneer Platform](https://agent.pioneer.ai/) and create an account or sign in.
+2.  **Navigate to API Keys:** Open the **API Keys** tab.
+3.  **Create a Key:** Click **New key** to create an API key.
+4.  **Copy the Key:** Copy the API key immediately and store it securely.
+
+### Configuration in Cline
+
+> See [Authorization & Model Selection](/getting-started/authorizing-with-cline#menu).
+
+1.  **Open Cline Settings:** Click the settings icon (⚙️) in the Cline panel.
+2.  **Select Provider:** Choose "Pioneer" from the "API Provider" dropdown.
+3.  **Enter API Key:** Paste your Pioneer API key into the "Pioneer API Key" field.
+4.  **Select Provider Model:** Choose your desired model from the "Model" dropdown.
+
+### Tips and Notes
+
+-   **Model Access:** Choose from the Pioneer models in the "Model" dropdown. Availability depends on your Pioneer account.
+-   **OpenAI-Compatible API:** Cline connects to Pioneer's OpenAI-compatible endpoint and configures the base URL (`https://api.pioneer.ai/v1`) automatically when you select Pioneer.

--- a/sdk/packages/core/src/services/llms/provider-defaults.test.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.test.ts
@@ -500,6 +500,114 @@ describe("resolveProviderConfig", () => {
 		);
 	});
 
+	it("loads Pioneer models and collapses anthropic/pioneer aliases", async () => {
+		const fetchMock = vi.fn(async () => {
+			return new Response(
+				JSON.stringify({
+					data: [
+						// Anthropic-format alias listed FIRST — the canonical bare id
+						// below must still win the slot and keep its rich metadata.
+						{
+							id: "anthropic/pioneer/gpt-5.4",
+							display_name: "GPT-5.4 (anthropic route)",
+							max_input_tokens: 400_000,
+							max_tokens: 128_000,
+							deprecated: false,
+							capabilities: {},
+						},
+						{
+							id: "gpt-5.4",
+							display_name: "GPT-5.4",
+							max_input_tokens: 400_000,
+							max_tokens: 128_000,
+							deprecated: false,
+							capabilities: {
+								image_input: { supported: true },
+								thinking: { supported: true },
+								structured_outputs: { supported: true },
+							},
+							input_price_per_million: 1.25,
+							output_price_per_million: 10,
+							cache_read_price_per_million: 0.125,
+							cache_write_price_per_million: 1.5,
+						},
+						// Alias with no bare twin — surfaced under its canonical id.
+						{
+							id: "anthropic/pioneer/only-alias-model",
+							display_name: "Alias Only",
+							max_input_tokens: 200_000,
+							max_tokens: 8192,
+							deprecated: false,
+							capabilities: {},
+						},
+						// Deprecated models are skipped entirely.
+						{ id: "retired-model", display_name: "Retired", deprecated: true },
+					],
+				}),
+				{
+					status: 200,
+					headers: { "content-type": "application/json" },
+				},
+			);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const resolved = await resolveProviderConfig(
+			"pioneer",
+			{ failOnError: true, cacheTtlMs: 0 },
+			{
+				providerId: "pioneer",
+				modelId: "gpt-5.4",
+				apiKey: "pioneer-key",
+				baseUrl: "https://api.pioneer.ai/v1",
+			},
+		);
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			"https://api.pioneer.ai/v1/models",
+			expect.objectContaining({
+				method: "GET",
+				headers: expect.objectContaining({
+					Authorization: "Bearer pioneer-key",
+				}),
+			}),
+		);
+
+		const models = resolved?.knownModels ?? {};
+		// Canonical model keeps rich metadata (alias did not clobber it).
+		expect(models["gpt-5.4"]).toEqual(
+			expect.objectContaining({
+				name: "GPT-5.4",
+				contextWindow: 400_000,
+				maxInputTokens: 400_000,
+				maxTokens: 128_000,
+				capabilities: expect.arrayContaining([
+					"streaming",
+					"tools",
+					"images",
+					"reasoning",
+					"structured_output",
+					"prompt-cache",
+				]),
+				pricing: expect.objectContaining({
+					input: 1.25,
+					output: 10,
+					cacheRead: 0.125,
+					cacheWrite: 1.5,
+				}),
+				status: "active",
+			}),
+		);
+		// No anthropic/pioneer/* duplicate keys survive.
+		expect(
+			Object.keys(models).some((id) => id.startsWith("anthropic/pioneer/")),
+		).toBe(false);
+		// Orphan alias (no bare twin) is surfaced under its canonical id.
+		expect(models["only-alias-model"]?.name).toBe("Alias Only");
+		// Deprecated model is dropped.
+		expect(models["retired-model"]).toBeUndefined();
+	});
+
 	it("falls back to /model/info for LiteLLM private models", async () => {
 		const fetchMock = vi
 			.fn()

--- a/sdk/packages/core/src/services/llms/provider-defaults.test.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.test.ts
@@ -540,7 +540,7 @@ describe("resolveProviderConfig", () => {
 							deprecated: false,
 							capabilities: {},
 						},
-						// Deprecated models are skipped entirely.
+						// A live-only deprecated model is not added to the catalog.
 						{ id: "retired-model", display_name: "Retired", deprecated: true },
 					],
 				}),
@@ -604,7 +604,8 @@ describe("resolveProviderConfig", () => {
 		).toBe(false);
 		// Orphan alias (no bare twin) is surfaced under its canonical id.
 		expect(models["only-alias-model"]?.name).toBe("Alias Only");
-		// Deprecated model is dropped.
+		// Live-only deprecated model is not added (a deprecated model already in
+		// the bundled catalog would remain until the catalog is regenerated).
 		expect(models["retired-model"]).toBeUndefined();
 	});
 

--- a/sdk/packages/core/src/services/llms/provider-defaults.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.ts
@@ -528,6 +528,137 @@ async function fetchPoolsidePrivateModels(
 	return models;
 }
 
+interface PioneerModelResponse {
+	id?: string;
+	display_name?: string;
+	description?: string;
+	max_input_tokens?: number;
+	max_tokens?: number;
+	deprecated?: boolean;
+	capabilities?: {
+		image_input?: { supported?: boolean };
+		thinking?: { supported?: boolean };
+		structured_outputs?: { supported?: boolean };
+	};
+	input_price_per_million?: number;
+	output_price_per_million?: number;
+	cache_read_price_per_million?: number;
+	cache_write_price_per_million?: number;
+}
+
+// Pioneer's gateway lists every model twice: once under its canonical
+// OpenAI-style id (e.g. "gpt-5.4", "pioneer/auto") and once under an
+// Anthropic-format routing alias ("anthropic/pioneer/gpt-5.4",
+// "anthropic/pioneer-auto"). No real model id begins with "anthropic/", so we
+// drop that whole namespace to avoid duplicate picker entries — both within
+// the live list and against the bundled models.dev catalog, whose ids are the
+// canonical form. The "anthropic/pioneer/<id>" slash form is additionally
+// recovered to its canonical "<id>" so any alias lacking a bare twin still
+// surfaces once.
+const PIONEER_ROUTING_ALIAS_PREFIX = "anthropic/";
+const PIONEER_MODEL_ID_ALIAS_PREFIX = "anthropic/pioneer/";
+
+function buildPioneerModel(model: PioneerModelResponse, id: string): ModelInfo {
+	const capabilities: NonNullable<ModelInfo["capabilities"]> = [
+		"streaming",
+		"tools",
+	];
+	includeCapability(
+		capabilities,
+		"images",
+		Boolean(model.capabilities?.image_input?.supported),
+	);
+	includeCapability(
+		capabilities,
+		"reasoning",
+		Boolean(model.capabilities?.thinking?.supported),
+	);
+	includeCapability(
+		capabilities,
+		"structured_output",
+		Boolean(model.capabilities?.structured_outputs?.supported),
+	);
+	const cacheRead = parseOptionalNumber(model.cache_read_price_per_million);
+	const cacheWrite = parseOptionalNumber(model.cache_write_price_per_million);
+	includeCapability(
+		capabilities,
+		"prompt-cache",
+		cacheRead !== undefined || cacheWrite !== undefined,
+	);
+	const pricing = {
+		input: parseOptionalNumber(model.input_price_per_million),
+		output: parseOptionalNumber(model.output_price_per_million),
+		cacheRead,
+		cacheWrite,
+	};
+	const hasPricing = Object.values(pricing).some(
+		(value) => value !== undefined,
+	);
+	return {
+		id,
+		name: model.display_name ?? id,
+		description: model.description,
+		contextWindow: model.max_input_tokens,
+		maxInputTokens: model.max_input_tokens,
+		maxTokens: model.max_tokens,
+		capabilities,
+		pricing: hasPricing ? pricing : undefined,
+		status: "active",
+	};
+}
+
+async function fetchPioneerPrivateModels(
+	config: ProviderConfig,
+	token: string,
+): Promise<Record<string, ModelInfo>> {
+	const baseUrl =
+		normalizeBaseUrl(config.baseUrl) || "https://api.pioneer.ai/v1";
+	const endpoint = `${baseUrl.replace(/\/+$/, "")}/models`;
+	const response = await fetchWithTimeout(endpoint, {
+		method: "GET",
+		headers: {
+			Authorization: `Bearer ${token}`,
+			accept: "application/json",
+		},
+	});
+	if (!response.ok) {
+		throw new Error(`Pioneer model refresh failed: HTTP ${response.status}`);
+	}
+
+	const payload = (await response.json()) as { data?: PioneerModelResponse[] };
+	const entries = payload?.data ?? [];
+	const models: Record<string, ModelInfo> = {};
+	// Pass 1: canonical (non-"anthropic/") ids. These always win the slot.
+	for (const model of entries) {
+		const id = model.id?.trim();
+		if (!id || model.deprecated) {
+			continue;
+		}
+		if (id.startsWith(PIONEER_ROUTING_ALIAS_PREFIX)) {
+			continue;
+		}
+		models[id] = buildPioneerModel(model, id);
+	}
+	// Pass 2: recover any "anthropic/pioneer/<id>" slash alias whose canonical
+	// "<id>" has no bare twin. All other "anthropic/" routing aliases are
+	// dropped as duplicates.
+	for (const model of entries) {
+		const id = model.id?.trim();
+		if (!id || model.deprecated) {
+			continue;
+		}
+		if (!id.startsWith(PIONEER_MODEL_ID_ALIAS_PREFIX)) {
+			continue;
+		}
+		const canonicalId = id.slice(PIONEER_MODEL_ID_ALIAS_PREFIX.length);
+		if (!canonicalId || canonicalId in models) {
+			continue;
+		}
+		models[canonicalId] = buildPioneerModel(model, canonicalId);
+	}
+	return models;
+}
+
 interface LiteLlmModelInfoResponse {
 	model_name?: string;
 	litellm_params?: {
@@ -652,6 +783,7 @@ const PRIVATE_PROVIDER_MODEL_FETCHERS: Record<
 	hicap: fetchHicapPrivateModels,
 	litellm: fetchLiteLlmPrivateModels,
 	poolside: fetchPoolsidePrivateModels,
+	pioneer: fetchPioneerPrivateModels,
 };
 
 const PUBLIC_MODELS_CACHE = new Map<

--- a/sdk/packages/core/src/services/llms/provider-defaults.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.ts
@@ -628,6 +628,12 @@ async function fetchPioneerPrivateModels(
 	const payload = (await response.json()) as { data?: PioneerModelResponse[] };
 	const entries = payload?.data ?? [];
 	const models: Record<string, ModelInfo> = {};
+	// Deprecated models are omitted from the live list so they are not added to
+	// the picker. Note this only prevents live-only deprecated models from
+	// appearing: mergeKnownModels overlays this map onto the bundled models.dev
+	// catalog, so a model that is deprecated upstream but still present in the
+	// bundled snapshot remains selectable until the catalog is regenerated
+	// (there is no tombstone mechanism to remove generated entries here).
 	// Pass 1: canonical (non-"anthropic/") ids. These always win the slot.
 	for (const model of entries) {
 		const id = model.id?.trim();

--- a/sdk/packages/llms/src/providers/builtins.test.ts
+++ b/sdk/packages/llms/src/providers/builtins.test.ts
@@ -146,6 +146,7 @@ describe("built-in provider metadata", () => {
 		const generatedOnlyProviderIds = [
 			"fireworks",
 			"poolside",
+			"pioneer",
 			"nebius",
 			"baseten",
 			"requesty",

--- a/sdk/packages/llms/src/providers/ids.test.ts
+++ b/sdk/packages/llms/src/providers/ids.test.ts
@@ -147,6 +147,28 @@ describe("provider-ids", () => {
 		});
 	});
 
+	it("registers Pioneer as an OpenAI-compatible built-in provider", async () => {
+		expect(BUILT_IN_PROVIDER_IDS).toContain("pioneer");
+		const defaultModelId = generatedProviderDefault("pioneer");
+
+		await expect(getProvider("pioneer")).resolves.toMatchObject({
+			id: "pioneer",
+			name: "Pioneer",
+			baseUrl: "https://api.pioneer.ai/v1",
+			defaultModelId,
+			client: "openai-compatible",
+		});
+		const models = await getModelsForProvider("pioneer");
+		expect(Object.hasOwn(models, defaultModelId)).toBe(true);
+
+		const registration = BUILTIN_PROVIDER_REGISTRATIONS.find(
+			(item) => item.manifest.id === "pioneer",
+		);
+		await expect(registration?.loadProvider?.()).resolves.toMatchObject({
+			createProvider: createOpenAICompatibleProvider,
+		});
+	});
+
 	it("routes Responses API built-ins through the OpenAI provider factory", async () => {
 		const provider = await getProvider("litellm");
 		expect(provider).toMatchObject({

--- a/sdk/packages/llms/src/providers/ids.ts
+++ b/sdk/packages/llms/src/providers/ids.ts
@@ -34,6 +34,7 @@ export enum BUILT_IN_PROVIDER {
 	FIREWORKS = "fireworks",
 	GROQ = "groq",
 	POOLSIDE = "poolside",
+	PIONEER = "pioneer",
 	CEREBRAS = "cerebras",
 	SAMBANOVA = "sambanova",
 	NEBIUS = "nebius",

--- a/sdk/packages/llms/src/providers/provider-keys.ts
+++ b/sdk/packages/llms/src/providers/provider-keys.ts
@@ -79,6 +79,11 @@ const PROVIDER_IDS_MAP: ReadonlyArray<{
 		runtimeProviderId: "poolside",
 	},
 	{
+		modelsDevKey: "pioneer",
+		generatedProviderId: "pioneer",
+		runtimeProviderId: "pioneer",
+	},
+	{
 		modelsDevKey: "cerebras",
 		generatedProviderId: "cerebras",
 		runtimeProviderId: "cerebras",


### PR DESCRIPTION
# feat: add Pioneer as an inference provider

Feature request: #12645 (https://github.com/cline/cline/discussions/12645)

## What this does
Adds **Pioneer** (https://pioneer.ai) as a native inference provider. Pioneer is an OpenAI-compatible gateway already published to models.dev (`pioneer`, base URL `https://api.pioneer.ai/v1`, `PIONEER_API_KEY`). Mirrors the Poolside provider (#10956).

Two commits:
1. **feat: add Pioneer as an inference provider** — registration + live model discovery + docs.
2. **fix: show live pricing for live-only models in the provider model picker** — a general model-picker fix (also benefits Poolside); see below.

## Changes
**Registration**
- `sdk/packages/llms/src/providers/ids.ts` — `PIONEER` enum
- `sdk/packages/llms/src/providers/provider-keys.ts` — models.dev → runtime mapping
- `apps/vscode/src/shared/api.ts` — `ApiProvider` union
- `apps/vscode/src/sdk/model-catalog/provider-id.ts` — `KNOWN_API_PROVIDERS`
- `apps/vscode/webview-ui/.../providerSettingsRegistry.ts` — generic settings form + fallback name

**Live model discovery**
- `sdk/packages/core/src/services/llms/provider-defaults.ts` — `fetchPioneerPrivateModels`, registered in `PRIVATE_PROVIDER_MODEL_FETCHERS` (same pattern as Poolside/Baseten/Hicap). Fetches Pioneer's `/v1/models`, maps its schema (`display_name`, `max_input_tokens`, `capabilities.*.supported`, `*_price_per_million`) into `ModelInfo`, merged over the models.dev catalog. Pioneer lists each model twice — once canonically and once under an `anthropic/` routing alias — so the fetcher drops the `anthropic/` namespace (recovering any `anthropic/pioneer/<id>` slash alias lacking a bare twin) to prevent duplicate picker entries.

**Model-picker display fix (`useProviderModelSelection`)**
Generic providers resolve most of their models only from the live catalog fetch; a live-only model absent from the static catalog gets a committed model-info snapshot of `$0`/no-metadata, and the picker preferred that snapshot over the freshly-resolved entry — so the model showed as "Free" with no context window. The picker now prefers the fresh catalog entry **only when the committed snapshot has no pricing**. Snapshots with pricing (all other providers) and user per-model overrides are untouched; runtime resolution is unaffected. This also fixes the same latent issue for Poolside.

**Docs**: `docs/provider-config/pioneer.mdx` + nav in `docs/docs.json`.

## Behavior / breaking changes
- Additive for the provider itself; no other provider's behavior changes.
- The picker fix only affects the pricing-less-placeholder case (live-only models). No runtime behavior change.
- Known limitation (not a regression): a model Pioneer serves that isn't in models.dev yet will show correct pricing in the picker but `$0` in the in-task cost meter until it lands in models.dev and the catalog regenerates. Tracked under the existing `sdk-consolidation` work (same gap Vercel/Groq handlers note).

## How to test
1. Settings → API Provider → **Pioneer**; enter a `PIONEER_API_KEY`.
2. The model picker populates from the live catalog — correct pricing/context, one entry per model, no `anthropic/…` duplicates.
3. Without a key, the picker shows the bundled models.dev catalog.

## Tests
- `sdk/.../provider-defaults.test.ts` — live fetch, real-schema parsing, `anthropic/` alias dedup, deprecated-model skip.
- `sdk/.../ids.test.ts`, `builtins.test.ts` — registration.
- `apps/vscode/webview-ui/.../useProviderModelSelection.test.ts` — placeholder→fresh, committed-with-pricing preserved, absent-model fallback.

## Screenshots
<img width="323" height="594" alt="image" src="https://github.com/user-attachments/assets/493d6911-6fd2-4f31-bf68-98aa87aff341" />

<img width="287" height="333" alt="image" src="https://github.com/user-attachments/assets/bc43f22c-55eb-4c14-80df-cdd4816621f9" />

<img width="409" height="898" alt="image" src="https://github.com/user-attachments/assets/d11542d7-64fa-45df-94f6-c371b4cbbd78" />


---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
