### PR TITLE
docs: add API Token Sale Anthropic setup

### DIFF
--- a/docs/provider-config/anthropic.mdx
+++ b/docs/provider-config/anthropic.mdx
@@ -29,6 +29,17 @@ description: "Configure Anthropic API keys or Claude Code subscription with Clin
 4.  **Select Model:** Choose your desired Claude model from the "Model" dropdown.
 5.  **(Optional) Custom Base URL:** If you need to use a custom base URL for the Anthropic API, check "Use custom base URL" and enter the URL. Most users won't need to adjust this setting.
 
+### Using an Anthropic-Compatible Provider
+
+Cline can also connect to third-party services that implement the Anthropic Messages API. For example, to use [API Token Sale](https://apitoken.sale/):
+
+1.  Select **Anthropic** as the API Provider.
+2.  Paste the API key issued by the provider into the **Anthropic API Key** field.
+3.  Enable **Use custom base URL** and enter `https://api.apitoken.sale`.
+4.  Select `claude-sonnet-4-6` from the **Model** dropdown.
+
+API Token Sale is an independent provider and is not affiliated with Anthropic or Cline. Third-party services have their own billing, privacy, and availability terms.
+
 ## Claude Code (Subscription)
 
 Use this path if you already have Claude Max/Pro and want to use subscription-based access in Cline.


### PR DESCRIPTION
### Related Issue

**Issue:** N/A — documentation-only change using Cline’s existing custom Anthropic base URL.

### Description

Documents how to connect Cline’s built-in Anthropic provider to API Token Sale, an independent Anthropic-compatible provider. The change adds setup steps, the tested model ID, and an explicit third-party disclaimer. No provider or runtime code changes are required.

### Test Procedure

- `@cline/llms` live streaming/usage smoke test with `claude-sonnet-4-6`
- `@cline/llms` live tool-use smoke test
- Mintlify broken-link validation
- `git diff --check` and repository pre-commit gitleaks hook

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [x] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore
- [ ] Full `bun test` suite was not run because this is an MDX-only change; the relevant live provider and docs checks passed
- [x] I have reviewed the contributor guidelines

### Screenshots

Not applicable — documentation-only change.

### Additional Notes

API Token Sale is an independent provider and is not affiliated with Anthropic or Cline.