### PR TITLE
fix(vscode): keep context actions in active task

### DIFF
--- a/apps/vscode/src/core/controller/commands/explainWithCline.ts
+++ b/apps/vscode/src/core/controller/commands/explainWithCline.ts
@@ -5,6 +5,7 @@ import { CommandContext, Empty } from "@/shared/proto/index.cline"
 import { ShowMessageType } from "@/shared/proto/index.host"
 import { Logger } from "@/shared/services/Logger"
 import { Controller } from "../index"
+import { sendContextMenuPrompt } from "./sendContextMenuPrompt"
 
 export async function explainWithCline(
 	controller: Controller,
@@ -30,7 +31,7 @@ export async function explainWithCline(
 		prompt += notebookContext
 	}
 
-	await controller.initTask(prompt)
+	await sendContextMenuPrompt(controller, prompt)
 	telemetryService.captureButtonClick("codeAction_explainCode", controller.task?.ulid)
 
 	return {}

--- a/apps/vscode/src/core/controller/commands/fixWithCline.ts
+++ b/apps/vscode/src/core/controller/commands/fixWithCline.ts
@@ -4,13 +4,15 @@ import { telemetryService } from "@/services/telemetry"
 import { CommandContext, Empty } from "@/shared/proto/index.cline"
 import { Logger } from "@/shared/services/Logger"
 import { Controller } from "../index"
+import { sendContextMenuPrompt } from "./sendContextMenuPrompt"
 
 export async function fixWithCline(controller: Controller, request: CommandContext): Promise<Empty> {
 	const filePath = request.filePath || ""
 	const fileMention = await getFileMentionFromPath(filePath)
 	const problemsString = await singleFileDiagnosticsToProblemsString(filePath, request.diagnostics)
 
-	await controller.initTask(
+	await sendContextMenuPrompt(
+		controller,
 		`Fix the following code in ${fileMention}
 \`\`\`\n${request.selectedText}\n\`\`\`\n\nProblems:\n${problemsString}`,
 	)

--- a/apps/vscode/src/core/controller/commands/improveWithCline.ts
+++ b/apps/vscode/src/core/controller/commands/improveWithCline.ts
@@ -5,6 +5,7 @@ import { CommandContext, Empty } from "@/shared/proto/index.cline"
 import { ShowMessageType } from "@/shared/proto/index.host"
 import { Logger } from "@/shared/services/Logger"
 import { Controller } from "../index"
+import { sendContextMenuPrompt } from "./sendContextMenuPrompt"
 
 export async function improveWithCline(
 	controller: Controller,
@@ -33,12 +34,7 @@ export async function improveWithCline(
 		prompt += `\n${notebookContext}`
 	}
 
-	// Send: notebooks go to existing task if available, non-notebooks always create new task
-	if (notebookContext && controller.task) {
-		await controller.task.handleWebviewAskResponse("messageResponse", prompt)
-	} else {
-		await controller.initTask(prompt)
-	}
+	await sendContextMenuPrompt(controller, prompt)
 
 	telemetryService.captureButtonClick("codeAction_improveCode", controller.task?.ulid)
 

--- a/apps/vscode/src/core/controller/commands/sendContextMenuPrompt.test.ts
+++ b/apps/vscode/src/core/controller/commands/sendContextMenuPrompt.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest"
+import type { Controller } from "../index"
+import { sendContextMenuPrompt } from "./sendContextMenuPrompt"
+
+describe("sendContextMenuPrompt", () => {
+	it("continues the active task", async () => {
+		const handleWebviewAskResponse = vi.fn().mockResolvedValue(undefined)
+		const initTask = vi.fn()
+		const controller = { task: { handleWebviewAskResponse }, initTask } as unknown as Controller
+
+		await sendContextMenuPrompt(controller, "explain this")
+
+		expect(handleWebviewAskResponse).toHaveBeenCalledWith("messageResponse", "explain this")
+		expect(initTask).not.toHaveBeenCalled()
+	})
+
+	it("starts a task when no task is active", async () => {
+		const initTask = vi.fn().mockResolvedValue(undefined)
+		const controller = { task: undefined, initTask } as unknown as Controller
+
+		await sendContextMenuPrompt(controller, "explain this")
+
+		expect(initTask).toHaveBeenCalledWith("explain this")
+	})
+})

--- a/apps/vscode/src/core/controller/commands/sendContextMenuPrompt.ts
+++ b/apps/vscode/src/core/controller/commands/sendContextMenuPrompt.ts
@@ -1,0 +1,10 @@
+import type { Controller } from "../index"
+
+export async function sendContextMenuPrompt(controller: Controller, prompt: string): Promise<void> {
+	if (controller.task) {
+		await controller.task.handleWebviewAskResponse("messageResponse", prompt)
+		return
+	}
+
+	await controller.initTask(prompt)
+}


### PR DESCRIPTION
## Summary
- send Explain, Improve, and Fix context-menu prompts to the active task when one exists
- retain new-task creation when no chat is active
- add focused coverage for both routing paths

Fixes #12590

## Testing
- `bun test src/core/controller/commands/sendContextMenuPrompt.test.ts` (2 passed)
