### PR TITLE
fix(vscode): wait for task history persistence

### DIFF
--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -1530,7 +1530,7 @@ export class Controller {
 	 * to the welcome screen (S6-6/S6-23 fix).
 	 *
 	 * Instead, we:
-	 * 1. Silently tear down the active session (unsubscribe + stop in background)
+	 * 1. Silently tear down the active session and wait for message persistence
 	 * 2. Create the new task proxy with loaded messages BEFORE any state push
 	 * 3. Only then push state to the webview
 	 */

--- a/apps/vscode/src/sdk/sdk-task-control-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-task-control-coordinator.test.ts
@@ -81,7 +81,7 @@ describe("SdkTaskControlCoordinator", () => {
 		await coordinator.showTaskWithId("task-1")
 
 		expect(options.taskHistory.findHistoryItem).toHaveBeenCalledWith("task-1")
-		expect(options.sessions.endActiveSession).toHaveBeenCalledWith("showTaskWithId")
+		expect(options.sessions.endActiveSession).toHaveBeenCalledWith("showTaskWithId", { awaitStop: true })
 		expect(existingTask.messageStateHandler.clear).toHaveBeenCalledOnce()
 		expect(options.resetMessageTranslator).toHaveBeenCalledOnce()
 		expect(state.task?.taskId).toBe("task-1")
@@ -92,6 +92,25 @@ describe("SdkTaskControlCoordinator", () => {
 			expect.objectContaining({ type: "ask", ask: "resume_completed_task" }),
 		])
 		expect(options.postStateToWebview).toHaveBeenCalledOnce()
+	})
+
+	it("waits for the interrupted session to persist before loading its messages", async () => {
+		let resolveStop: (() => void) | undefined
+		const stopDeferred = new Promise<void>((resolve) => {
+			resolveStop = resolve
+		})
+		const { coordinator, options } = makeCoordinator({ hasHistoryItem: true })
+		options.sessions.endActiveSession.mockReturnValueOnce(stopDeferred)
+
+		const inFlight = coordinator.showTaskWithId("task-1")
+		await Promise.resolve()
+
+		expect(options.taskHistory.getClineMessages).not.toHaveBeenCalled()
+
+		resolveStop?.()
+		await inFlight
+
+		expect(options.taskHistory.getClineMessages).toHaveBeenCalledWith("task-1")
 	})
 
 	it("shows a legacy task with a warning and a resume ask", async () => {

--- a/apps/vscode/src/sdk/sdk-task-control-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-task-control-coordinator.ts
@@ -98,7 +98,9 @@ export class SdkTaskControlCoordinator {
 				}
 			}
 
-			await this.options.sessions.endActiveSession("showTaskWithId")
+			// stop() flushes the session's persisted messages. Reading history before
+			// it settles can reopen an interrupted task with an empty conversation.
+			await this.options.sessions.endActiveSession("showTaskWithId", { awaitStop: true })
 
 			const currentTask = this.options.getTask()
 			if (currentTask) {


### PR DESCRIPTION
## Summary
- wait for the active SDK session to stop and flush persisted messages before reading task history
- keep the existing task proxy visible while interrupted-task history is loading
- add regression coverage that prevents history reads from racing the persistence flush

Fixes #12413

## Testing
- focused test added to `sdk-task-control-coordinator.test.ts`
- `bun test src/sdk/sdk-task-control-coordinator.test.ts src/sdk/sdk-session-lifecycle.test.ts` (blocked before collection by stale SDK `dist` missing `isClineFreeModelLimitMessage`)
- `bun run build:sdk` (blocked by existing `@cline/ui` React type definitions and SAP `requestConfig` type error on current main)
