### PR TITLE
fix(llms): omit synthesized Groq output cap

### DIFF
--- a/sdk/packages/llms/src/providers/compat.test.ts
+++ b/sdk/packages/llms/src/providers/compat.test.ts
@@ -402,6 +402,33 @@ describe("createGatewayApiHandler.createMessage", () => {
 		);
 	});
 
+	it("omits the synthesized maxOutputTokens for Groq requests", async () => {
+		streamTextSpy.mockReturnValue({
+			fullStream: (async function* () {
+				yield { type: "finish", finishReason: "stop" };
+			})(),
+			usage: Promise.resolve({ inputTokens: 1, outputTokens: 1 }),
+		});
+
+		const handler = createGatewayApiHandler({
+			providerId: "groq",
+			clientType: "openai-compatible",
+			modelId: "openai/gpt-oss-20b",
+			apiKey: "test-key",
+		});
+
+		for await (const _chunk of handler.createMessage("", [
+			{ role: "user", content: "Hello" },
+		])) {
+			// Drain the stream so the provider request is executed.
+		}
+
+		const call = streamTextSpy.mock.calls.at(-1)?.[0] as
+			| { maxOutputTokens?: unknown }
+			| undefined;
+		expect(call).not.toHaveProperty("maxOutputTokens");
+	});
+
 	it("sends configured OpenAI-compatible maxOutputTokens to the provider request", async () => {
 		streamTextSpy.mockReturnValue({
 			fullStream: (async function* () {

--- a/sdk/packages/llms/src/providers/vendors/openai-compatible-options.test.ts
+++ b/sdk/packages/llms/src/providers/vendors/openai-compatible-options.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest"
+import { resolveOpenAICompatibleMaxOutputTokens } from "./openai-compatible-options"
+
+describe("resolveOpenAICompatibleMaxOutputTokens", () => {
+	it("omits gateway-synthesized Groq limits", () => {
+		expect(resolveOpenAICompatibleMaxOutputTokens("groq", 32_000, true)).toBeUndefined()
+	})
+
+	it("preserves explicit Groq limits", () => {
+		expect(resolveOpenAICompatibleMaxOutputTokens("groq", 4_096, false)).toBe(4_096)
+	})
+
+	it("preserves synthesized limits for other compatible providers", () => {
+		expect(resolveOpenAICompatibleMaxOutputTokens("openrouter", 32_000, true)).toBe(32_000)
+	})
+})

--- a/sdk/packages/llms/src/providers/vendors/openai-compatible-options.ts
+++ b/sdk/packages/llms/src/providers/vendors/openai-compatible-options.ts
@@ -1,0 +1,9 @@
+export function resolveOpenAICompatibleMaxOutputTokens(
+	providerId: string,
+	maxTokens: number | undefined,
+	defaultedMaxTokens: boolean | undefined,
+): number | undefined {
+	// Groq counts a requested completion budget toward TPM before generation.
+	// Let it choose the model default unless the caller explicitly set a cap.
+	return providerId === "groq" && defaultedMaxTokens === true ? undefined : maxTokens
+}

--- a/sdk/packages/llms/src/providers/vendors/openai-compatible.ts
+++ b/sdk/packages/llms/src/providers/vendors/openai-compatible.ts
@@ -7,6 +7,7 @@ import type {
 import { wrapLanguageModel } from "ai";
 import { ensureFetch, resolveApiKey } from "../http";
 import { splitToolImagesMiddleware } from "../middleware/split-tool-images";
+import { resolveOpenAICompatibleMaxOutputTokens } from "./openai-compatible-options";
 import type { ProviderFactoryResult } from "./types";
 
 type FetchInput = Parameters<typeof fetch>[0];
@@ -130,6 +131,17 @@ export async function createOpenAICompatibleProviderModule(
 		includeUsage: true,
 	} as never);
 	return {
+		buildStreamConfig: (request, streamContext) => {
+			const maxOutputTokens = resolveOpenAICompatibleMaxOutputTokens(
+				streamContext.provider.id,
+				request.maxTokens,
+				request.defaultedMaxTokens,
+			);
+			return {
+				...(maxOutputTokens !== undefined ? { maxOutputTokens } : {}),
+				temperature: request.temperature,
+			};
+		},
 		// Wrap each constructed model with `splitToolImagesMiddleware` so
 		// `role:"tool"` messages whose `output.type === 'content'` carries
 		// image-data parts get split into a placeholder text + a synthetic


### PR DESCRIPTION
## Summary
- omit the gateway-synthesized 32k output cap from Groq requests so it is not counted against TPM on fresh tasks
- preserve explicit caller-configured Groq output limits
- retain synthesized output limits for other OpenAI-compatible providers
- add policy and compatibility regression coverage

Fixes #12507

## Testing
- `bunx vitest run src/providers/vendors/openai-compatible-options.test.ts` (3 passed)
- `bunx vitest run src/providers/compat.test.ts` (blocked before collection by existing Zod runtime resolution, `z.enum` is undefined)
- `bun run typecheck` (blocked by existing SAP `requestConfig` type incompatibility)
