### PR TITLE
refactor(ui): extract desktop quick actions

### DIFF
--- a/apps/examples/desktop-app/webview/components/views/chat/welcome-chat.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/welcome-chat.test.tsx
@@ -30,6 +30,7 @@ afterEach(async () => {
 async function renderWelcomeScreen({
 	workspaceRoot,
 	workspaces,
+	onStartChat = vi.fn(),
 	selectChat = vi.fn(async () => true),
 	onListGitBranches = vi.fn(async () => ({
 		current: "main",
@@ -38,6 +39,7 @@ async function renderWelcomeScreen({
 }: {
 	workspaceRoot: string;
 	workspaces: string[];
+	onStartChat?: (prompt: string) => void;
 	selectChat?: () => Promise<boolean>;
 	onListGitBranches?: () => Promise<{
 		current: string;
@@ -63,7 +65,7 @@ async function renderWelcomeScreen({
 					composer={null}
 					gitBranch="main"
 					onListGitBranches={onListGitBranches}
-					onStartChat={vi.fn()}
+					onStartChat={onStartChat}
 					onSwitchGitBranch={vi.fn(async () => true)}
 					quickActions={[]}
 				/>
@@ -86,6 +88,21 @@ async function clickButton(text: string, last = false): Promise<void> {
 }
 
 describe("WelcomeScreen", () => {
+	it("starts chat with the selected quick-action prompt", async () => {
+		const onStartChat = vi.fn();
+		await renderWelcomeScreen({
+			onStartChat,
+			workspaceRoot: "/projects/project-1",
+			workspaces: ["/projects/project-1"],
+		});
+
+		await clickButton("Check for build errors");
+
+		expect(onStartChat).toHaveBeenCalledWith(
+			"Check this project for build errors and help me fix any failures.",
+		);
+	});
+
 	it("renders every known project in the opened workspace menu", async () => {
 		const workspaces = Array.from(
 			{ length: 6 },

--- a/apps/examples/desktop-app/webview/components/views/chat/welcome-chat.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/welcome-chat.tsx
@@ -1,7 +1,10 @@
 "use client";
 
-import { AgentHeroHeading } from "@cline/ui";
-import { ArrowRight } from "lucide-react";
+import {
+	AgentHeroHeading,
+	type AgentQuickAction,
+	AgentQuickActions,
+} from "@cline/ui";
 import type { ReactNode } from "react";
 import { useEffect } from "react";
 import { AuroraBackground } from "@/components/ui/aurora-bg";
@@ -9,25 +12,18 @@ import { useWorkspace } from "@/contexts/workspace-context";
 import { cn } from "@/lib/utils";
 import { WelcomeWorkspaceControls } from "./welcome-workspace-controls";
 
-interface QuickAction {
-	id: string;
-	label: string;
-	description: string;
-	prompt: string;
-}
-
-const DEFAULT_QUICK_ACTIONS: QuickAction[] = [
+const DEFAULT_QUICK_ACTIONS: AgentQuickAction[] = [
 	{
 		id: "review-changes",
 		label: "Review changes",
 		description: "Review the current changes and call out anything risky.",
-		prompt: "Review the current changes and call out anything risky.",
+		value: "Review the current changes and call out anything risky.",
 	},
 	{
 		id: "check-build",
 		label: "Check for build errors",
 		description: "Run the relevant checks and help me fix any failures.",
-		prompt: "Check this project for build errors and help me fix any failures.",
+		value: "Check this project for build errors and help me fix any failures.",
 	},
 ];
 
@@ -45,7 +41,7 @@ export function WelcomeScreen({
 	body: ReactNode;
 	composer: ReactNode;
 	onStartChat: (prompt: string) => void;
-	quickActions: QuickAction[];
+	quickActions: AgentQuickAction[];
 	gitBranch: string;
 	onListGitBranches: () => Promise<{ current: string; branches: string[] }>;
 	onSwitchGitBranch: (branch: string) => Promise<boolean>;
@@ -123,28 +119,11 @@ export function WelcomeScreen({
 					</div>
 
 					{active ? (
-						<div className="mt-11 w-full divide-y divide-border/80 overflow-hidden rounded-xl border border-border/60 bg-background/95 px-2 shadow-sm">
-							{actions.map((action) => (
-								<button
-									className="group flex w-full items-center justify-between gap-5 px-3 py-3 text-left transition-colors hover:bg-background/55 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
-									key={action.id}
-									onClick={() => onStartChat(action.prompt)}
-									type="button"
-								>
-									<span className="min-w-0">
-										<span className="block text-[15px] font-medium text-foreground">
-											{action.label}
-										</span>
-										<span className="mt-0.5 block truncate text-sm text-muted-foreground">
-											{action.description}
-										</span>
-									</span>
-									<span className="flex size-7 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary transition-colors group-hover:bg-primary group-hover:text-primary-foreground">
-										<ArrowRight className="size-3" />
-									</span>
-								</button>
-							))}
-						</div>
+						<AgentQuickActions
+							actions={actions}
+							className="mt-11"
+							onSelect={(action) => onStartChat(action.value)}
+						/>
 					) : null}
 				</div>
 			</div>

--- a/sdk/packages/ui/ADOPTION.md
+++ b/sdk/packages/ui/ADOPTION.md
@@ -63,7 +63,7 @@ pass once their runtime and Markdown adapters are mapped explicitly.
 | Goal | Import | Tailwind required | React required |
 | --- | --- | --- | --- |
 | Use only light/dark CSS variables | `@cline/ui/theme/tokens.css` | No | No |
-| Render shared hero heading or session status | `@cline/ui/theme/tokens.css`, `@cline/ui/components.css`, and `@cline/ui` | No | React 18.3 or 19 |
+| Render shared hero heading, quick actions, or session status | `@cline/ui/theme/tokens.css`, `@cline/ui/components.css`, and `@cline/ui` | No | React 18.3 or 19 |
 | Use tokens through Tailwind utilities | `tokens.css` then `theme.css` | Tailwind v4 | No |
 | Use the complete theme and shared base behavior | `@cline/ui/theme/index.css` | Tailwind v4 | No |
 | Compose shared agent-chat presentation | `@cline/ui/components/agent-chat` plus its CSS | No, if tokens are mapped in plain CSS | React 18.3 or 19 |

--- a/sdk/packages/ui/README.md
+++ b/sdk/packages/ui/README.md
@@ -27,7 +27,7 @@ Use `@cline/ui@next` only for deliberate previews. Monorepo consumers use
 
 | Import | Contents | Runtime requirement |
 | --- | --- | --- |
-| `@cline/ui` | Agent hero-heading and session-status React primitives | React 18.3 or 19 |
+| `@cline/ui` | Agent hero-heading, quick-action, and session-status React primitives | React 18.3 or 19 |
 | `@cline/ui/components.css` | Styles for the root React primitives | Theme tokens |
 | `@cline/ui/theme/tokens.css` | Light/dark custom properties only | CSS |
 | `@cline/ui/theme/scoped-tokens.css` | Light/dark custom properties scoped to `.cline-ui-theme` | CSS |
@@ -44,6 +44,8 @@ for a host-specific status palette.
 
 `AgentHeroHeading` renders the shared cycling “What would you like to …?”
 welcome heading and respects reduced-motion preferences.
+
+`AgentQuickActions` renders prompt shortcuts and reports selection to the host.
 
 The token entry point has no React, Tailwind, font-package, or desktop runtime
 dependency. Apps provide Schibsted Grotesk and Azeret Mono themselves, which

--- a/sdk/packages/ui/components.css
+++ b/sdk/packages/ui/components.css
@@ -1,2 +1,3 @@
 @import "./components/agent-hero-heading.css";
+@import "./components/agent-quick-actions.css";
 @import "./components/session-status.css";

--- a/sdk/packages/ui/components/agent-quick-actions.css
+++ b/sdk/packages/ui/components/agent-quick-actions.css
@@ -64,6 +64,7 @@
 	margin-top: 0.125rem;
 	color: var(--muted-foreground);
 	font-size: var(--text-sm);
+	line-height: var(--text-sm--line-height);
 	text-overflow: ellipsis;
 	white-space: nowrap;
 }

--- a/sdk/packages/ui/components/agent-quick-actions.css
+++ b/sdk/packages/ui/components/agent-quick-actions.css
@@ -1,0 +1,96 @@
+.cline-ui-agent-quick-actions {
+	width: 100%;
+	overflow: hidden;
+	box-sizing: border-box;
+	border: 1px solid color-mix(in oklab, var(--border) 60%, transparent);
+	border-radius: var(--radius-xl);
+	background: color-mix(in oklab, var(--background) 95%, transparent);
+	padding-inline: 0.5rem;
+	box-shadow:
+		0 1px 3px 0 rgb(0 0 0 / 10%),
+		0 1px 2px -1px rgb(0 0 0 / 10%);
+}
+
+.cline-ui-agent-quick-actions__item {
+	display: flex;
+	width: 100%;
+	align-items: center;
+	justify-content: space-between;
+	gap: 1.25rem;
+	box-sizing: border-box;
+	border: 0;
+	border-radius: 0;
+	background: transparent;
+	color: inherit;
+	padding: 0.75rem;
+	font: inherit;
+	text-align: left;
+	cursor: pointer;
+	transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.cline-ui-agent-quick-actions__item:not(:last-child) {
+	border-bottom: 1px solid color-mix(in oklab, var(--border) 80%, transparent);
+}
+
+.cline-ui-agent-quick-actions__item:hover:not(:disabled) {
+	background: color-mix(in oklab, var(--background) 55%, transparent);
+}
+
+.cline-ui-agent-quick-actions__item:focus-visible {
+	outline: none;
+	box-shadow: inset 0 0 0 2px var(--ring);
+}
+
+.cline-ui-agent-quick-actions__item:disabled {
+	cursor: not-allowed;
+	opacity: 0.5;
+}
+
+.cline-ui-agent-quick-actions__copy {
+	min-width: 0;
+}
+
+.cline-ui-agent-quick-actions__label {
+	display: block;
+	color: var(--foreground);
+	font-size: 0.9375rem;
+	font-weight: var(--font-weight-medium);
+}
+
+.cline-ui-agent-quick-actions__description {
+	display: block;
+	overflow: hidden;
+	margin-top: 0.125rem;
+	color: var(--muted-foreground);
+	font-size: var(--text-sm);
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.cline-ui-agent-quick-actions__arrow {
+	display: flex;
+	width: 1.75rem;
+	height: 1.75rem;
+	flex: none;
+	align-items: center;
+	justify-content: center;
+	border-radius: var(--radius-md);
+	background: color-mix(in oklab, var(--primary) 10%, transparent);
+	color: var(--primary);
+	transition:
+		background-color 150ms cubic-bezier(0.4, 0, 0.2, 1),
+		color 150ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.cline-ui-agent-quick-actions__arrow svg {
+	display: block;
+	width: 0.75rem;
+	height: 0.75rem;
+}
+
+.cline-ui-agent-quick-actions__item:hover:not(:disabled)
+	.cline-ui-agent-quick-actions__arrow {
+	background: var(--primary);
+	color: var(--primary-foreground);
+}

--- a/sdk/packages/ui/components/agent-quick-actions.tsx
+++ b/sdk/packages/ui/components/agent-quick-actions.tsx
@@ -46,14 +46,17 @@ export function AgentQuickActions({
 						aria-hidden="true"
 						className="cline-ui-agent-quick-actions__arrow"
 					>
-						<svg aria-hidden="true" fill="none" viewBox="0 0 24 24">
-							<path
-								d="M5 12h14M12 5l7 7-7 7"
-								stroke="currentColor"
-								strokeLinecap="round"
-								strokeLinejoin="round"
-								strokeWidth="2"
-							/>
+						<svg
+							aria-hidden="true"
+							fill="none"
+							stroke="currentColor"
+							strokeLinecap="round"
+							strokeLinejoin="round"
+							strokeWidth="2"
+							viewBox="0 0 24 24"
+						>
+							<path d="M5 12h14" />
+							<path d="m12 5 7 7-7 7" />
 						</svg>
 					</span>
 				</button>

--- a/sdk/packages/ui/components/agent-quick-actions.tsx
+++ b/sdk/packages/ui/components/agent-quick-actions.tsx
@@ -1,0 +1,63 @@
+export interface AgentQuickAction {
+	description: string;
+	id: string;
+	label: string;
+	value: string;
+}
+
+export interface AgentQuickActionsProps {
+	actions: AgentQuickAction[];
+	className?: string;
+	disabled?: boolean;
+	onSelect: (action: AgentQuickAction) => void;
+}
+
+export function AgentQuickActions({
+	actions,
+	className,
+	disabled = false,
+	onSelect,
+}: AgentQuickActionsProps) {
+	if (actions.length === 0) return null;
+
+	return (
+		<div
+			className={["cline-ui-agent-quick-actions", className]
+				.filter(Boolean)
+				.join(" ")}
+		>
+			{actions.map((action) => (
+				<button
+					className="cline-ui-agent-quick-actions__item"
+					disabled={disabled}
+					key={action.id}
+					onClick={() => onSelect(action)}
+					type="button"
+				>
+					<span className="cline-ui-agent-quick-actions__copy">
+						<span className="cline-ui-agent-quick-actions__label">
+							{action.label}
+						</span>
+						<span className="cline-ui-agent-quick-actions__description">
+							{action.description}
+						</span>
+					</span>
+					<span
+						aria-hidden="true"
+						className="cline-ui-agent-quick-actions__arrow"
+					>
+						<svg aria-hidden="true" fill="none" viewBox="0 0 24 24">
+							<path
+								d="M5 12h14M12 5l7 7-7 7"
+								stroke="currentColor"
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								strokeWidth="2"
+							/>
+						</svg>
+					</span>
+				</button>
+			))}
+		</div>
+	);
+}

--- a/sdk/packages/ui/components/index.ts
+++ b/sdk/packages/ui/components/index.ts
@@ -2,6 +2,11 @@
 
 export { AgentHeroHeading } from "./agent-hero-heading.js";
 export {
+	type AgentQuickAction,
+	AgentQuickActions,
+	type AgentQuickActionsProps,
+} from "./agent-quick-actions.js";
+export {
 	SessionStatus,
 	type SessionStatusProps,
 	type SessionStatusTone,

--- a/sdk/packages/ui/package.json
+++ b/sdk/packages/ui/package.json
@@ -38,6 +38,8 @@
 		"components/agent-chat/index.tsx",
 		"components/agent-hero-heading.css",
 		"components/agent-hero-heading.tsx",
+		"components/agent-quick-actions.css",
+		"components/agent-quick-actions.tsx",
 		"components/markdown.css",
 		"components/index.ts",
 		"components/session-status.css",

--- a/sdk/packages/ui/scripts/smoke-package.ts
+++ b/sdk/packages/ui/scripts/smoke-package.ts
@@ -12,7 +12,7 @@ const packageRoot = join(import.meta.dir, "..");
 const importCheck = `
 import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { AgentHeroHeading, SessionStatus } from "@cline/ui";
+import { AgentHeroHeading, AgentQuickActions, SessionStatus } from "@cline/ui";
 import { Conversation, Message } from "@cline/ui/components/agent-chat";
 
 for (const specifier of [
@@ -29,6 +29,7 @@ const css = import.meta.resolve("@cline/ui/components/agent-chat.css");
 const tokens = import.meta.resolve("@cline/ui/theme/tokens.css");
 if (
 	!AgentHeroHeading ||
+	!AgentQuickActions ||
 	!SessionStatus ||
 	!Conversation ||
 	!Message ||

--- a/sdk/packages/ui/tests/agent-quick-actions.test.tsx
+++ b/sdk/packages/ui/tests/agent-quick-actions.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	type AgentQuickAction,
+	AgentQuickActions,
+} from "../components/index.js";
+
+const action: AgentQuickAction = {
+	description: "Review the current changes and call out anything risky.",
+	id: "review-changes",
+	label: "Review changes",
+	value: "Review the current changes and call out anything risky.",
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+	Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	root = createRoot(container);
+});
+
+afterEach(async () => {
+	await act(async () => root.unmount());
+	container.remove();
+	vi.restoreAllMocks();
+});
+
+describe("AgentQuickActions", () => {
+	it("reports the selected action without owning task state", async () => {
+		const onSelect = vi.fn();
+		await act(async () =>
+			root.render(<AgentQuickActions actions={[action]} onSelect={onSelect} />),
+		);
+
+		await act(async () =>
+			container.querySelector<HTMLButtonElement>("button")?.click(),
+		);
+
+		expect(onSelect).toHaveBeenCalledWith(action);
+	});
+
+	it("does not render empty actions and disables populated actions", async () => {
+		await act(async () =>
+			root.render(
+				<AgentQuickActions actions={[action]} disabled onSelect={vi.fn()} />,
+			),
+		);
+		expect(container.querySelector("button")?.disabled).toBe(true);
+
+		await act(async () =>
+			root.render(<AgentQuickActions actions={[]} onSelect={vi.fn()} />),
+		);
+		expect(container.firstElementChild).toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary

- Extract the existing desktop welcome quick-action list into `@cline/ui`.
- Migrate the real desktop welcome screen without changing labels, prompts, layout, or behavior.
- Ship and verify the component source, styles, root export, and packed artifact.

## Scope

`AgentQuickActions` only: controlled actions, disabled state, and selection callback. No Aurora, combobox, composer, Button, approval UI, app state, or publishing changes.

This is directly needed by `cline/core-platform#2927`.

## Coordination

- Stacked on #12609 while that PR is open.
- No file or semantic overlap with Bee or Saoud’s currently active work.

## Validation

- `@cline/ui`: 18/18 tests, typecheck, packed-package smoke with React 18.3 and 19
- desktop WelcomeScreen: 3/3 tests, typecheck, production build
- Biome and `git diff --check`
- real sidecar + desktop webview onboarding/New Session E2E: 2 shared actions, expected copy, zero browser errors
- stable reduced-motion component crop: 0 of 130,416 pixels differ from the pre-extraction desktop component