### PR TITLE
fix(vscode): cancel Cline task on signout

### DIFF
--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -1605,6 +1605,8 @@ export class Controller {
 	// ---- Auth callbacks ----
 
 	async handleSignOut(): Promise<void> {
+		const sessionProviderId = this.getSessionProviderId() ?? this.getActiveProviderId()
+		await this.taskControl.cancelClineTaskOnSignOut(isClineManagedProvider(sessionProviderId))
 		await this.authService.handleDeauth(LogoutReason.USER_INITIATED)
 		clearRemoteConfig()
 		await this.setRemoteConfigCoreIntegration(undefined)

--- a/apps/vscode/src/sdk/sdk-task-control-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-task-control-coordinator.test.ts
@@ -32,6 +32,26 @@ describe("SdkTaskControlCoordinator", () => {
 		expect(options.postStateToWebview).toHaveBeenCalledOnce()
 	})
 
+	it("cancels a running Cline task when the user signs out", async () => {
+		const activeSession = makeActiveSession()
+		const { coordinator, options } = makeCoordinator({ activeSession })
+
+		await coordinator.cancelClineTaskOnSignOut(true)
+
+		expect(activeSession.sdkHost.abort).toHaveBeenCalledWith("session-123")
+		expect(options.sessions.setRunning).toHaveBeenCalledWith(false)
+	})
+
+	it("does not cancel a non-Cline task when the user signs out", async () => {
+		const activeSession = makeActiveSession()
+		const { coordinator, options } = makeCoordinator({ activeSession })
+
+		await coordinator.cancelClineTaskOnSignOut(false)
+
+		expect(activeSession.sdkHost.abort).not.toHaveBeenCalled()
+		expect(options.sessions.setRunning).not.toHaveBeenCalled()
+	})
+
 	it("raises the cancel fence BEFORE aborting the session (so stragglers are fenced)", async () => {
 		const activeSession = makeActiveSession()
 		const { coordinator, options } = makeCoordinator({ activeSession })

--- a/apps/vscode/src/sdk/sdk-task-control-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-task-control-coordinator.ts
@@ -44,6 +44,15 @@ export class SdkTaskControlCoordinator {
 
 	constructor(private readonly options: SdkTaskControlCoordinatorOptions) {}
 
+	async cancelClineTaskOnSignOut(isClineManagedProvider: boolean): Promise<void> {
+		const activeSession = this.options.sessions.getActiveSession()
+		if (!isClineManagedProvider || !activeSession?.isRunning) {
+			return
+		}
+
+		await this.cancelTask()
+	}
+
 	async cancelTask(): Promise<void> {
 		this.options.interactions.clearPending("Task cancelled")
 


### PR DESCRIPTION
## Summary
- abort a running Cline or ClinePass task before clearing account credentials
- preserve active BYOK tasks when the user signs out of their Cline account
- cover managed-provider and non-managed-provider signout behavior

Fixes #12509

## Testing
- regression cases added to `sdk-task-control-coordinator.test.ts`
- `bun test src/sdk/sdk-task-control-coordinator.test.ts` (blocked before collection by the existing missing generated `ModelOverrides` export)
