### PR TITLE
Suport cline-free models in the legacy extension

### DIFF
--- a/apps/vscode/src/core/api/providers/cline.ts
+++ b/apps/vscode/src/core/api/providers/cline.ts
@@ -9,6 +9,7 @@ import { ClineAccountService } from "@/services/account/ClineAccountService"
 import { AuthService } from "@/services/auth/AuthService"
 import { buildClineExtraHeaders } from "@/services/EnvUtils"
 import { CLINE_ACCOUNT_AUTH_ERROR_MESSAGE } from "@/shared/ClineAccount"
+import { isClineFreeModelId } from "@/shared/cline/free-models"
 import { CLINE_RECOMMENDED_MODELS_FALLBACK } from "@/shared/cline/recommended-models"
 import type { ClineStorageMessage } from "@/shared/messages/content"
 import { fetch, getAxiosSettings } from "@/shared/net"
@@ -41,6 +42,10 @@ const CLINE_FREE_MODEL_IDS = new Set([
 	...CLINE_RECOMMENDED_MODELS_FALLBACK.free.map((model) => normalizeModelId(model.id)),
 	...Object.keys(clinePassModels).map((modelId) => normalizeModelId(modelId)),
 ])
+
+function isFreeClineModel(modelId: string, freeModelIds: Set<string>): boolean {
+	return isClineFreeModelId(modelId) || freeModelIds.has(normalizeModelId(modelId))
+}
 
 function getCacheReadTokens(usage: any): number {
 	return usage?.prompt_tokens_details?.cached_tokens || usage?.cache_read_input_tokens || 0
@@ -242,7 +247,7 @@ export class ClineHandler implements ApiHandler {
 					// @ts-expect-error-next-line
 					let totalCost = (chunk.usage.cost || 0) + (chunk.usage.cost_details?.upstream_inference_cost || 0)
 					const modelId = this.getModel().id
-					const isFreeModel = freeModelIds.has(normalizeModelId(modelId))
+					const isFreeModel = isFreeClineModel(modelId, freeModelIds)
 					const cacheReadTokens = getCacheReadTokens(chunk.usage)
 					const cacheWriteTokens = getCacheWriteTokens(chunk.usage)
 
@@ -299,7 +304,7 @@ export class ClineHandler implements ApiHandler {
 				const generation = response.data
 				let totalCost = generation?.total_cost || 0
 				const modelId = this.getModel().id
-				const isFreeModel = resolvedFreeModelIds.has(normalizeModelId(modelId))
+				const isFreeModel = isFreeClineModel(modelId, resolvedFreeModelIds)
 
 				if (isFreeModel) {
 					totalCost = 0

--- a/apps/vscode/src/core/api/retry.ts
+++ b/apps/vscode/src/core/api/retry.ts
@@ -40,8 +40,9 @@ export function withRetry(options: RetryOptions = {}) {
 				} catch (error: any) {
 					const isRateLimit = error?.status === 429 || error instanceof RetriableError
 					const isLastAttempt = attempt === maxRetries - 1
-
-					if ((!isRateLimit && !retryAllErrors) || isLastAttempt) {
+					const isCapLimitError = error?.code === "INFERENCE_CAP_ERROR"
+					// We shouldn't retry cap limits because they mean the user needs to wait for longer
+					if ((!isRateLimit && !retryAllErrors) || isLastAttempt || isCapLimitError) {
 						throw error
 					}
 

--- a/apps/vscode/src/core/api/retry.ts
+++ b/apps/vscode/src/core/api/retry.ts
@@ -26,6 +26,26 @@ export class RetriableError extends Error {
 	}
 }
 
+const INFERENCE_CAP_ERROR_CODE = "INFERENCE_CAP_ERROR"
+
+/**
+ * Inference cap errors mean the user is out of quota until it resets, so retrying
+ * only burns backoff. Providers surface the code in a few shapes: directly on the
+ * error, nested under `error`/`details`, or embedded in a wrapped message string
+ * (see ClineHandler, which rethrows stream errors as `Cline API Error <code>: ...`).
+ */
+function isInferenceCapError(error: any): boolean {
+	if (
+		error?.code === INFERENCE_CAP_ERROR_CODE ||
+		error?.error?.code === INFERENCE_CAP_ERROR_CODE ||
+		error?.details?.code === INFERENCE_CAP_ERROR_CODE
+	) {
+		return true
+	}
+
+	return typeof error?.message === "string" && error.message.includes(INFERENCE_CAP_ERROR_CODE)
+}
+
 export function withRetry(options: RetryOptions = {}) {
 	const { maxRetries, baseDelay, maxDelay, retryAllErrors } = { ...DEFAULT_OPTIONS, ...options }
 
@@ -40,8 +60,8 @@ export function withRetry(options: RetryOptions = {}) {
 				} catch (error: any) {
 					const isRateLimit = error?.status === 429 || error instanceof RetriableError
 					const isLastAttempt = attempt === maxRetries - 1
-					const isCapLimitError = error?.code === "INFERENCE_CAP_ERROR"
 					// We shouldn't retry cap limits because they mean the user needs to wait for longer
+					const isCapLimitError = isInferenceCapError(error)
 					if ((!isRateLimit && !retryAllErrors) || isLastAttempt || isCapLimitError) {
 						throw error
 					}

--- a/apps/vscode/src/core/controller/models/refreshClineModels.ts
+++ b/apps/vscode/src/core/controller/models/refreshClineModels.ts
@@ -24,6 +24,7 @@ import {
 	openRouterClaudeSonnet451mModelId,
 	openRouterClaudeSonnet461mModelId,
 } from "@/shared/api"
+import { formatClineFreeModelName, isClineFreeModelId, zeroPricedModelInfo } from "@/shared/cline/free-models"
 import { getAxiosSettings } from "@/shared/net"
 import { FeatureFlag } from "@/shared/services/feature-flags/feature-flags"
 import { Logger } from "@/shared/services/Logger"
@@ -315,6 +316,16 @@ async function fetchAndCacheClineModels(): Promise<Record<string, ModelInfo>> {
 					modelInfo.maxTokens || GEMINI_FLASH_MAX_OUTPUT_TOKENS,
 					GEMINI_FLASH_MAX_OUTPUT_TOKENS,
 				)
+			}
+
+			// cline-free/ models are promotional: they always bill at $0 and are marked
+			// "(free)" so users can tell them apart from the paid model of the same slug.
+			if (isClineFreeModelId(rawModel.id)) {
+				models[rawModel.id] = zeroPricedModelInfo({
+					...modelInfo,
+					name: formatClineFreeModelName(rawModel.id, modelInfo.name),
+				})
+				continue
 			}
 
 			models[rawModel.id] = modelInfo

--- a/apps/vscode/src/core/task/index.ts
+++ b/apps/vscode/src/core/task/index.ts
@@ -2472,6 +2472,11 @@ export class Task {
 				const isClinePassLimitError = clineError.isErrorType(
 					ClineErrorType.ClinePassLimit,
 				);
+				// Daily Cline free-model limits reset in hours — same reasoning as
+				// ClinePass limits: surface the actionable UI instead of retrying.
+				const isClineFreeModelLimitError = clineError.isErrorType(
+					ClineErrorType.ClineFreeModelLimit,
+				);
 
 				// Check if this is a Cline provider insufficient credits error - don't auto-retry these
 				const isClineProviderInsufficientCredits = (() => {
@@ -2500,6 +2505,7 @@ export class Task {
 					!isEntitlementError &&
 					!isOrgClinePassRestrictionError &&
 					!isClinePassLimitError &&
+					!isClineFreeModelLimitError &&
 					this.taskState.autoRetryAttempts < 3;
 				if (shouldRetry) {
 					// Auto-retry enabled with max 3 attempts: automatically approve the retry

--- a/apps/vscode/src/core/task/index.ts
+++ b/apps/vscode/src/core/task/index.ts
@@ -3608,14 +3608,10 @@ export class Task {
 					const isStreamingClineFreeModelLimitError = clineError.isErrorType(
 						ClineErrorType.ClineFreeModelLimit,
 					);
-					const isStreamingClineModelNotFoundError = clineError.isErrorType(
-						ClineErrorType.ClineModelNotFound,
-					);
 					const isStreamingNonRetriableError =
 						isStreamingSpendLimitError ||
 						isStreamingQuotaExceededError ||
-						isStreamingClineFreeModelLimitError ||
-						isStreamingClineModelNotFoundError;
+						isStreamingClineFreeModelLimitError;
 					// Auto-retry for streaming failures (skip for non-retriable errors)
 					if (
 						!isStreamingNonRetriableError &&

--- a/apps/vscode/src/core/task/index.ts
+++ b/apps/vscode/src/core/task/index.ts
@@ -2570,7 +2570,8 @@ export class Task {
 						!quotaExceeded &&
 						!isEntitlementError &&
 						!isOrgClinePassRestrictionError &&
-						!isClinePassLimitError;
+						!isClinePassLimitError &&
+						!isClineFreeModelLimitError;
 					if (showRetry) {
 						await this.say(
 							"error_retry",
@@ -3598,9 +3599,26 @@ export class Task {
 					const isStreamingSpendLimitError = clineError.isErrorType(
 						ClineErrorType.SpendLimit,
 					);
-					// Auto-retry for streaming failures (skip for spend limit errors)
+					// Inference cap and daily free-model limits reset in hours, so
+					// retrying only burns backoff before surfacing the actionable UI.
+					// Mirrors the non-streaming gating in attemptApiRequest.
+					const isStreamingQuotaExceededError = clineError.isErrorType(
+						ClineErrorType.QuotaExceeded,
+					);
+					const isStreamingClineFreeModelLimitError = clineError.isErrorType(
+						ClineErrorType.ClineFreeModelLimit,
+					);
+					const isStreamingClineModelNotFoundError = clineError.isErrorType(
+						ClineErrorType.ClineModelNotFound,
+					);
+					const isStreamingNonRetriableError =
+						isStreamingSpendLimitError ||
+						isStreamingQuotaExceededError ||
+						isStreamingClineFreeModelLimitError ||
+						isStreamingClineModelNotFoundError;
+					// Auto-retry for streaming failures (skip for non-retriable errors)
 					if (
-						!isStreamingSpendLimitError &&
+						!isStreamingNonRetriableError &&
 						this.taskState.autoRetryAttempts < 3
 					) {
 						this.taskState.autoRetryAttempts++;
@@ -3634,7 +3652,7 @@ export class Task {
 							}
 						});
 					} else if (
-						!isStreamingSpendLimitError &&
+						!isStreamingNonRetriableError &&
 						this.taskState.autoRetryAttempts >= 3
 					) {
 						// Show error_retry with failed flag to indicate all retries exhausted

--- a/apps/vscode/src/services/error/ClineError.ts
+++ b/apps/vscode/src/services/error/ClineError.ts
@@ -71,9 +71,6 @@ const CLINE_PASS_LIMIT_SUFFIX = "please try again later.";
 // reset window is extracted from the trailing "try again in" clause.
 const CLINE_FREE_MODEL_LIMIT_MARKER = "free limit reached on model";
 const CLINE_FREE_MODEL_LIMIT_RETRY_MARKER = "try again in ";
-// Once a free promotion ends the cline-free/ model is deleted upstream, so the API
-// answers "model not found" instead of a limit message.
-const CLINE_MODEL_NOT_FOUND_MARKER = "model not found";
 
 function findClinePassLimitMessageBounds(
 	text: string,
@@ -110,10 +107,6 @@ export function extractClinePassLimitMessage(
 
 export function isClineFreeModelLimitMessage(text: string): boolean {
 	return text.toLowerCase().includes(CLINE_FREE_MODEL_LIMIT_MARKER);
-}
-
-export function isClineModelNotFoundMessage(text: string): boolean {
-	return text.toLowerCase().includes(CLINE_MODEL_NOT_FOUND_MARKER);
 }
 
 /**

--- a/apps/vscode/src/services/error/ClineError.ts
+++ b/apps/vscode/src/services/error/ClineError.ts
@@ -11,6 +11,7 @@ export enum ClineErrorType {
 	Entitlement = "entitlement",
 	OrgClinePassRestriction = "orgClinePassRestriction",
 	ClinePassLimit = "clinePassLimit",
+	ClineFreeModelLimit = "clineFreeModelLimit",
 }
 
 interface ErrorDetails {
@@ -65,6 +66,15 @@ const CLINE_PASS_LIMIT_PREFIX = "you have reached your";
 const CLINE_PASS_LIMIT_MARKER = "clinepass limit";
 const CLINE_PASS_LIMIT_SUFFIX = "please try again later.";
 
+// The daily Cline free-model limit message is dynamic ("Daily free limit reached on
+// model <id>. Try again in 23h 59m"), so it is matched by its fixed marker and the
+// reset window is extracted from the trailing "try again in" clause.
+const CLINE_FREE_MODEL_LIMIT_MARKER = "free limit reached on model";
+const CLINE_FREE_MODEL_LIMIT_RETRY_MARKER = "try again in ";
+// Once a free promotion ends the cline-free/ model is deleted upstream, so the API
+// answers "model not found" instead of a limit message.
+const CLINE_MODEL_NOT_FOUND_MARKER = "model not found";
+
 function findClinePassLimitMessageBounds(
 	text: string,
 ): { start: number; end: number } | undefined {
@@ -96,6 +106,33 @@ export function extractClinePassLimitMessage(
 ): string | undefined {
 	const bounds = findClinePassLimitMessageBounds(text);
 	return bounds ? text.slice(bounds.start, bounds.end) : undefined;
+}
+
+export function isClineFreeModelLimitMessage(text: string): boolean {
+	return text.toLowerCase().includes(CLINE_FREE_MODEL_LIMIT_MARKER);
+}
+
+export function isClineModelNotFoundMessage(text: string): boolean {
+	return text.toLowerCase().includes(CLINE_MODEL_NOT_FOUND_MARKER);
+}
+
+/**
+ * Extracts the reset window ("23h 59m") out of a daily free-limit message so the UI
+ * can tell the user when the model becomes available again.
+ */
+export function extractClineFreeModelLimitResetTime(
+	text: string,
+): string | undefined {
+	const message = text.toLowerCase();
+	const resetStart = message.indexOf(CLINE_FREE_MODEL_LIMIT_RETRY_MARKER);
+	if (resetStart === -1) {
+		return undefined;
+	}
+
+	const resetTime = message
+		.slice(resetStart + CLINE_FREE_MODEL_LIMIT_RETRY_MARKER.length)
+		.trim();
+	return resetTime || undefined;
 }
 
 export class ClineError extends Error {
@@ -248,6 +285,17 @@ export class ClineError extends Error {
 		// handling below or the 429 rate-limit patterns.
 		const detailMessage =
 			typeof details?.message === "string" ? details.message : undefined;
+
+		// Daily Cline free-model limits are a different remedy than the ClinePass
+		// limit (pick another model / switch to the paid twin, not usage billing),
+		// so classify them first and keep them off the 429 rate-limit path.
+		if (
+			isClineFreeModelLimitMessage(detailMessage ?? "") ||
+			isClineFreeModelLimitMessage(message ?? "")
+		) {
+			return ClineErrorType.ClineFreeModelLimit;
+		}
+
 		if (
 			isClinePassLimitMessage(detailMessage ?? "") ||
 			isClinePassLimitMessage(message ?? "")

--- a/apps/vscode/src/services/error/__tests__/ClineError.test.ts
+++ b/apps/vscode/src/services/error/__tests__/ClineError.test.ts
@@ -3,7 +3,10 @@ import "should";
 import {
 	ClineError,
 	ClineErrorType,
+	extractClineFreeModelLimitResetTime,
 	extractClinePassLimitMessage,
+	isClineFreeModelLimitMessage,
+	isClineModelNotFoundMessage,
 	isClinePassLimitMessage,
 } from "../ClineError";
 
@@ -125,6 +128,92 @@ describe("ClineError", () => {
 			});
 
 			ClineError.getErrorType(err)!.should.equal(ClineErrorType.ClinePassLimit);
+		});
+
+		it("should classify daily Cline free model limits separately", () => {
+			const err = new ClineError(
+				"Error: Error 429: Daily free limit reached on model deepseek/deepseek-v4-flash. Try again in 23h 59m",
+			);
+
+			ClineError.getErrorType(err)!.should.equal(
+				ClineErrorType.ClineFreeModelLimit,
+			);
+		});
+
+		it("should classify nested daily Cline free model limits as ClineFreeModelLimit", () => {
+			// ClineError maps `error.error` into `details`, matching the real provider error shape.
+			const err = new ClineError({
+				message: "429 Error 429",
+				error: {
+					message:
+						"Daily free limit reached on model deepseek/deepseek-v4-flash. Try again in 5h 12m",
+				},
+			});
+
+			ClineError.getErrorType(err)!.should.equal(
+				ClineErrorType.ClineFreeModelLimit,
+			);
+		});
+
+		it("should prefer ClineFreeModelLimit over the generic rate-limit patterns", () => {
+			// The message carries "429", which the RATE_LIMIT_PATTERNS would otherwise match.
+			const err = new ClineError({
+				message:
+					"Error 429: Daily free limit reached on model deepseek/deepseek-v4-flash. Try again in 23h 59m",
+				status: 429,
+			});
+
+			const result = ClineError.getErrorType(err);
+			result!.should.equal(ClineErrorType.ClineFreeModelLimit);
+			(result !== ClineErrorType.RateLimit).should.be.true();
+		});
+	});
+
+	describe("isClineFreeModelLimitMessage", () => {
+		it("matches daily and generic free-limit messages", () => {
+			isClineFreeModelLimitMessage(
+				"Daily free limit reached on model deepseek/deepseek-v4-flash. Try again in 23h 59m",
+			).should.be.true();
+			isClineFreeModelLimitMessage(
+				"Free limit reached on model cline-free/glm-5",
+			).should.be.true();
+		});
+
+		it("does not match unrelated messages", () => {
+			isClineFreeModelLimitMessage(
+				"You have reached your weekly Clinepass limit. The limit resets in 7d, please try again later.",
+			).should.be.false();
+			isClineFreeModelLimitMessage("some other error").should.be.false();
+		});
+	});
+
+	describe("isClineModelNotFoundMessage", () => {
+		it("matches the message returned once a free promotion ends", () => {
+			isClineModelNotFoundMessage(
+				"Error 404: Model not found",
+			).should.be.true();
+		});
+
+		it("does not match unrelated messages", () => {
+			isClineModelNotFoundMessage(
+				"Error 500: internal error",
+			).should.be.false();
+		});
+	});
+
+	describe("extractClineFreeModelLimitResetTime", () => {
+		it("extracts the reset window out of the limit message", () => {
+			extractClineFreeModelLimitResetTime(
+				"Daily free limit reached on model deepseek/deepseek-v4-flash. Try again in 23h 59m",
+			)!.should.equal("23h 59m");
+		});
+
+		it("returns undefined when there is no reset window", () => {
+			(
+				extractClineFreeModelLimitResetTime(
+					"Daily free limit reached on model deepseek/deepseek-v4-flash.",
+				) === undefined
+			).should.be.true();
 		});
 	});
 

--- a/apps/vscode/src/services/error/__tests__/ClineError.test.ts
+++ b/apps/vscode/src/services/error/__tests__/ClineError.test.ts
@@ -6,7 +6,6 @@ import {
 	extractClineFreeModelLimitResetTime,
 	extractClinePassLimitMessage,
 	isClineFreeModelLimitMessage,
-	isClineModelNotFoundMessage,
 	isClinePassLimitMessage,
 } from "../ClineError";
 
@@ -184,20 +183,6 @@ describe("ClineError", () => {
 				"You have reached your weekly Clinepass limit. The limit resets in 7d, please try again later.",
 			).should.be.false();
 			isClineFreeModelLimitMessage("some other error").should.be.false();
-		});
-	});
-
-	describe("isClineModelNotFoundMessage", () => {
-		it("matches the message returned once a free promotion ends", () => {
-			isClineModelNotFoundMessage(
-				"Error 404: Model not found",
-			).should.be.true();
-		});
-
-		it("does not match unrelated messages", () => {
-			isClineModelNotFoundMessage(
-				"Error 500: internal error",
-			).should.be.false();
 		});
 	});
 

--- a/apps/vscode/src/shared/__tests__/free-models.test.ts
+++ b/apps/vscode/src/shared/__tests__/free-models.test.ts
@@ -1,0 +1,122 @@
+import { expect } from "chai";
+import type { ModelInfo } from "../api";
+import {
+	findPaidClineModelId,
+	formatClineFreeModelName,
+	getClineFreeModelSlug,
+	isClineFreeModelId,
+	zeroPricedModelInfo,
+} from "../cline/free-models";
+
+describe("Cline free models", () => {
+	describe("isClineFreeModelId", () => {
+		it("matches cline-free ids case-insensitively", () => {
+			expect(isClineFreeModelId("cline-free/deepseek-v4-flash")).to.equal(true);
+			expect(isClineFreeModelId("Cline-Free/GLM-5")).to.equal(true);
+		});
+
+		it("does not match paid or ClinePass ids", () => {
+			expect(isClineFreeModelId("deepseek/deepseek-v4-flash")).to.equal(false);
+			expect(isClineFreeModelId("cline-pass/glm-5.2")).to.equal(false);
+			expect(isClineFreeModelId(undefined)).to.equal(false);
+		});
+	});
+
+	describe("getClineFreeModelSlug", () => {
+		it("returns the slug after the cline-free prefix", () => {
+			expect(getClineFreeModelSlug("cline-free/deepseek-v4-flash")).to.equal(
+				"deepseek-v4-flash",
+			);
+		});
+
+		it("returns undefined for non-free ids and empty slugs", () => {
+			expect(getClineFreeModelSlug("deepseek/deepseek-v4-flash")).to.equal(
+				undefined,
+			);
+			expect(getClineFreeModelSlug("cline-free/")).to.equal(undefined);
+		});
+	});
+
+	describe("formatClineFreeModelName", () => {
+		it("appends (free) to free model names", () => {
+			expect(formatClineFreeModelName("cline-free/glm-5", "GLM 5")).to.equal(
+				"GLM 5 (free)",
+			);
+		});
+
+		it("falls back to the model id when no name is given", () => {
+			expect(formatClineFreeModelName("cline-free/glm-5")).to.equal(
+				"cline-free/glm-5 (free)",
+			);
+		});
+
+		it("does not double up the (free) marker", () => {
+			expect(
+				formatClineFreeModelName("cline-free/glm-5", "GLM 5 (free)"),
+			).to.equal("GLM 5 (free)");
+		});
+
+		it("leaves paid model names untouched", () => {
+			expect(formatClineFreeModelName("z-ai/glm-5", "GLM 5")).to.equal("GLM 5");
+		});
+	});
+
+	describe("zeroPricedModelInfo", () => {
+		it("zeroes every price while preserving capabilities", () => {
+			const info: ModelInfo = {
+				name: "GLM 5",
+				maxTokens: 8_192,
+				contextWindow: 128_000,
+				supportsImages: true,
+				supportsPromptCache: true,
+				inputPrice: 1.5,
+				outputPrice: 3,
+				cacheReadsPrice: 0.5,
+				cacheWritesPrice: 2,
+			};
+
+			expect(zeroPricedModelInfo(info)).to.deep.equal({
+				...info,
+				inputPrice: 0,
+				outputPrice: 0,
+				cacheReadsPrice: 0,
+				cacheWritesPrice: 0,
+			});
+		});
+	});
+
+	describe("findPaidClineModelId", () => {
+		const clineModelIds = [
+			"cline-free/deepseek-v4-flash",
+			"deepseek/deepseek-v4-flash",
+			"z-ai/glm-5",
+			"anthropic/claude-sonnet-5",
+		];
+
+		it("finds the paid counterpart by model slug", () => {
+			expect(
+				findPaidClineModelId("cline-free/deepseek-v4-flash", clineModelIds),
+			).to.equal("deepseek/deepseek-v4-flash");
+		});
+
+		it("never returns another free model id", () => {
+			expect(
+				findPaidClineModelId("cline-free/deepseek-v4-flash", [
+					"cline-free/deepseek-v4-flash",
+				]),
+			).to.equal(undefined);
+		});
+
+		it("returns undefined for non-free ids or when no counterpart exists", () => {
+			expect(
+				findPaidClineModelId("deepseek/deepseek-v4-flash", clineModelIds),
+			).to.equal(undefined);
+			expect(
+				findPaidClineModelId("cline-free/unknown-model", clineModelIds),
+			).to.equal(undefined);
+			expect(findPaidClineModelId(undefined, clineModelIds)).to.equal(
+				undefined,
+			);
+		});
+	});
+});

--- a/apps/vscode/src/shared/__tests__/free-models.test.ts
+++ b/apps/vscode/src/shared/__tests__/free-models.test.ts
@@ -1,65 +1,55 @@
-import { expect } from "chai";
-import type { ModelInfo } from "../api";
+import { expect } from "chai"
+import type { ModelInfo } from "../api"
 import {
 	findPaidClineModelId,
 	formatClineFreeModelName,
 	getClineFreeModelSlug,
 	isClineFreeModelId,
 	zeroPricedModelInfo,
-} from "../cline/free-models";
+} from "../cline/free-models"
 
 describe("Cline free models", () => {
 	describe("isClineFreeModelId", () => {
 		it("matches cline-free ids case-insensitively", () => {
-			expect(isClineFreeModelId("cline-free/deepseek-v4-flash")).to.equal(true);
-			expect(isClineFreeModelId("Cline-Free/GLM-5")).to.equal(true);
-		});
+			expect(isClineFreeModelId("cline-free/deepseek-v4-flash")).to.equal(true)
+			expect(isClineFreeModelId("Cline-Free/GLM-5")).to.equal(true)
+		})
 
 		it("does not match paid or ClinePass ids", () => {
-			expect(isClineFreeModelId("deepseek/deepseek-v4-flash")).to.equal(false);
-			expect(isClineFreeModelId("cline-pass/glm-5.2")).to.equal(false);
-			expect(isClineFreeModelId(undefined)).to.equal(false);
-		});
-	});
+			expect(isClineFreeModelId("deepseek/deepseek-v4-flash")).to.equal(false)
+			expect(isClineFreeModelId("cline-pass/glm-5.2")).to.equal(false)
+			expect(isClineFreeModelId(undefined)).to.equal(false)
+		})
+	})
 
 	describe("getClineFreeModelSlug", () => {
 		it("returns the slug after the cline-free prefix", () => {
-			expect(getClineFreeModelSlug("cline-free/deepseek-v4-flash")).to.equal(
-				"deepseek-v4-flash",
-			);
-		});
+			expect(getClineFreeModelSlug("cline-free/deepseek-v4-flash")).to.equal("deepseek-v4-flash")
+		})
 
 		it("returns undefined for non-free ids and empty slugs", () => {
-			expect(getClineFreeModelSlug("deepseek/deepseek-v4-flash")).to.equal(
-				undefined,
-			);
-			expect(getClineFreeModelSlug("cline-free/")).to.equal(undefined);
-		});
-	});
+			expect(getClineFreeModelSlug("deepseek/deepseek-v4-flash")).to.equal(undefined)
+			expect(getClineFreeModelSlug("cline-free/")).to.equal(undefined)
+		})
+	})
 
 	describe("formatClineFreeModelName", () => {
 		it("appends (free) to free model names", () => {
-			expect(formatClineFreeModelName("cline-free/glm-5", "GLM 5")).to.equal(
-				"GLM 5 (free)",
-			);
-		});
+			expect(formatClineFreeModelName("cline-free/glm-5", "GLM 5")).to.equal("GLM 5 (free)")
+		})
 
 		it("falls back to the model id when no name is given", () => {
-			expect(formatClineFreeModelName("cline-free/glm-5")).to.equal(
-				"cline-free/glm-5 (free)",
-			);
-		});
+			expect(formatClineFreeModelName("cline-free/glm-5")).to.equal("cline-free/glm-5 (free)")
+		})
 
 		it("does not double up the (free) marker", () => {
-			expect(
-				formatClineFreeModelName("cline-free/glm-5", "GLM 5 (free)"),
-			).to.equal("GLM 5 (free)");
-		});
+			expect(formatClineFreeModelName("cline-free/glm-5", "GLM 5 (free)")).to.equal("GLM 5 (free)")
+		})
 
 		it("leaves paid model names untouched", () => {
-			expect(formatClineFreeModelName("z-ai/glm-5", "GLM 5")).to.equal("GLM 5");
-		});
-	});
+			expect(formatClineFreeModelName("z-ai/glm-5", "GLM 5")).to.equal("GLM 5")
+		})
+	})
 
 	describe("zeroPricedModelInfo", () => {
 		it("zeroes every price while preserving capabilities", () => {
@@ -73,7 +63,7 @@ describe("Cline free models", () => {
 				outputPrice: 3,
 				cacheReadsPrice: 0.5,
 				cacheWritesPrice: 2,
-			};
+			}
 
 			expect(zeroPricedModelInfo(info)).to.deep.equal({
 				...info,
@@ -81,9 +71,9 @@ describe("Cline free models", () => {
 				outputPrice: 0,
 				cacheReadsPrice: 0,
 				cacheWritesPrice: 0,
-			});
-		});
-	});
+			})
+		})
+	})
 
 	describe("findPaidClineModelId", () => {
 		const clineModelIds = [
@@ -91,32 +81,20 @@ describe("Cline free models", () => {
 			"deepseek/deepseek-v4-flash",
 			"z-ai/glm-5",
 			"anthropic/claude-sonnet-5",
-		];
+		]
 
 		it("finds the paid counterpart by model slug", () => {
-			expect(
-				findPaidClineModelId("cline-free/deepseek-v4-flash", clineModelIds),
-			).to.equal("deepseek/deepseek-v4-flash");
-		});
+			expect(findPaidClineModelId("cline-free/deepseek-v4-flash", clineModelIds)).to.equal("deepseek/deepseek-v4-flash")
+		})
 
 		it("never returns another free model id", () => {
-			expect(
-				findPaidClineModelId("cline-free/deepseek-v4-flash", [
-					"cline-free/deepseek-v4-flash",
-				]),
-			).to.equal(undefined);
-		});
+			expect(findPaidClineModelId("cline-free/deepseek-v4-flash", ["cline-free/deepseek-v4-flash"])).to.equal(undefined)
+		})
 
 		it("returns undefined for non-free ids or when no counterpart exists", () => {
-			expect(
-				findPaidClineModelId("deepseek/deepseek-v4-flash", clineModelIds),
-			).to.equal(undefined);
-			expect(
-				findPaidClineModelId("cline-free/unknown-model", clineModelIds),
-			).to.equal(undefined);
-			expect(findPaidClineModelId(undefined, clineModelIds)).to.equal(
-				undefined,
-			);
-		});
-	});
-});
+			expect(findPaidClineModelId("deepseek/deepseek-v4-flash", clineModelIds)).to.equal(undefined)
+			expect(findPaidClineModelId("cline-free/unknown-model", clineModelIds)).to.equal(undefined)
+			expect(findPaidClineModelId(undefined, clineModelIds)).to.equal(undefined)
+		})
+	})
+})

--- a/apps/vscode/src/shared/__tests__/free-models.test.ts
+++ b/apps/vscode/src/shared/__tests__/free-models.test.ts
@@ -5,6 +5,7 @@ import {
 	formatClineFreeModelName,
 	getClineFreeModelSlug,
 	isClineFreeModelId,
+	resolveClineFreeModelInfo,
 	zeroPricedModelInfo,
 } from "../cline/free-models"
 
@@ -95,6 +96,48 @@ describe("Cline free models", () => {
 			expect(findPaidClineModelId("deepseek/deepseek-v4-flash", clineModelIds)).to.equal(undefined)
 			expect(findPaidClineModelId("cline-free/unknown-model", clineModelIds)).to.equal(undefined)
 			expect(findPaidClineModelId(undefined, clineModelIds)).to.equal(undefined)
+		})
+	})
+
+	describe("resolveClineFreeModelInfo", () => {
+		// cline-free/ ids are never published in the models catalog, so capabilities
+		// have to come from the paid twin sharing the slug.
+		const clineModels: Record<string, ModelInfo> = {
+			"deepseek/deepseek-v4-flash": {
+				name: "DeepSeek V4 Flash",
+				maxTokens: 393_216,
+				contextWindow: 1_048_576,
+				supportsImages: false,
+				supportsPromptCache: true,
+				inputPrice: 1,
+				outputPrice: 2,
+				cacheReadsPrice: 0.1,
+				cacheWritesPrice: 0.2,
+			},
+		}
+
+		it("borrows the paid twin's capabilities and zeroes the pricing", () => {
+			const info = resolveClineFreeModelInfo("cline-free/deepseek-v4-flash", clineModels)
+
+			expect(info?.contextWindow).to.equal(1_048_576)
+			expect(info?.maxTokens).to.equal(393_216)
+			expect(info?.supportsPromptCache).to.equal(true)
+			expect(info?.inputPrice).to.equal(0)
+			expect(info?.outputPrice).to.equal(0)
+			expect(info?.cacheReadsPrice).to.equal(0)
+			expect(info?.cacheWritesPrice).to.equal(0)
+			expect(info?.name).to.equal("DeepSeek V4 Flash (free)")
+		})
+
+		it("returns undefined when there is no paid twin to borrow from", () => {
+			expect(resolveClineFreeModelInfo("cline-free/unknown-model", clineModels)).to.equal(undefined)
+			expect(resolveClineFreeModelInfo("cline-free/deepseek-v4-flash", {})).to.equal(undefined)
+			expect(resolveClineFreeModelInfo("cline-free/deepseek-v4-flash", undefined)).to.equal(undefined)
+		})
+
+		it("ignores non-free ids", () => {
+			expect(resolveClineFreeModelInfo("deepseek/deepseek-v4-flash", clineModels)).to.equal(undefined)
+			expect(resolveClineFreeModelInfo(undefined, clineModels)).to.equal(undefined)
 		})
 	})
 })

--- a/apps/vscode/src/shared/cline/free-models.ts
+++ b/apps/vscode/src/shared/cline/free-models.ts
@@ -1,0 +1,96 @@
+import type { ModelInfo } from "@shared/api";
+
+/**
+ * Cline free models are exposed by the recommended-models endpoint under a
+ * dedicated namespace (for example `cline-free/deepseek-v4-flash`). They hit the
+ * same Cline API as paid models but are always billed at $0, and they disappear
+ * once their promotion ends.
+ */
+export const CLINE_FREE_MODEL_ID_PREFIX = "cline-free/";
+
+const CLINE_FREE_MODEL_NAME_SUFFIX = " (free)";
+
+function normalizeModelId(modelId: string): string {
+	return modelId.trim().toLowerCase();
+}
+
+export function isClineFreeModelId(modelId: string | undefined): boolean {
+	return normalizeModelId(modelId ?? "").startsWith(CLINE_FREE_MODEL_ID_PREFIX);
+}
+
+/**
+ * Returns the model slug of a `cline-free/` id (the part after the prefix), or
+ * undefined when the id is not a Cline free model id.
+ */
+export function getClineFreeModelSlug(
+	modelId: string | undefined,
+): string | undefined {
+	if (!isClineFreeModelId(modelId)) {
+		return undefined;
+	}
+
+	const modelSlug = (modelId as string)
+		.trim()
+		.slice(CLINE_FREE_MODEL_ID_PREFIX.length);
+	return modelSlug.length > 0 ? modelSlug : undefined;
+}
+
+/**
+ * Free models are explicitly marked in the UI so users can tell them apart from
+ * their paid counterparts, which share the same underlying model slug.
+ */
+export function formatClineFreeModelName(
+	modelId: string,
+	name?: string,
+): string {
+	const resolvedName = name?.trim() || modelId;
+	if (
+		!isClineFreeModelId(modelId) ||
+		resolvedName.toLowerCase().endsWith(CLINE_FREE_MODEL_NAME_SUFFIX)
+	) {
+		return resolvedName;
+	}
+
+	return `${resolvedName}${CLINE_FREE_MODEL_NAME_SUFFIX}`;
+}
+
+/**
+ * Free models ride usage billing at $0, so never display or accumulate cost for them.
+ */
+export function zeroPricedModelInfo(info: ModelInfo): ModelInfo {
+	return {
+		...info,
+		inputPrice: 0,
+		outputPrice: 0,
+		cacheReadsPrice: 0,
+		cacheWritesPrice: 0,
+	};
+}
+
+/**
+ * Free model ids are `cline-free/<model-slug>`; their paid counterpart is the
+ * catalog model with the same slug under its lab prefix (for example
+ * `cline-free/deepseek-v4-flash` -> `deepseek/deepseek-v4-flash`).
+ */
+export function findPaidClineModelId(
+	freeModelId: string | undefined,
+	clineModelIds: string[],
+): string | undefined {
+	const modelSlug = getClineFreeModelSlug(freeModelId);
+	if (!modelSlug) {
+		return undefined;
+	}
+
+	const normalizedModelSlug = normalizeModelId(modelSlug);
+	return clineModelIds.find((modelId) => {
+		if (isClineFreeModelId(modelId)) {
+			return false;
+		}
+
+		const normalizedModelId = normalizeModelId(modelId);
+		return (
+			normalizedModelId === normalizedModelSlug ||
+			normalizedModelId.endsWith(`/${normalizedModelSlug}`)
+		);
+	});
+}

--- a/apps/vscode/src/shared/cline/free-models.ts
+++ b/apps/vscode/src/shared/cline/free-models.ts
@@ -57,6 +57,26 @@ export function zeroPricedModelInfo(info: ModelInfo): ModelInfo {
 	}
 }
 
+export function resolveClineFreeModelInfo(
+	freeModelId: string | undefined,
+	clineModels: Record<string, ModelInfo> | undefined | null,
+): ModelInfo | undefined {
+	if (!isClineFreeModelId(freeModelId) || !clineModels) {
+		return undefined
+	}
+
+	const paidModelId = findPaidClineModelId(freeModelId, Object.keys(clineModels))
+	const paidModelInfo = paidModelId ? clineModels[paidModelId] : undefined
+	if (!paidModelInfo) {
+		return undefined
+	}
+
+	return zeroPricedModelInfo({
+		...paidModelInfo,
+		name: formatClineFreeModelName(freeModelId as string, paidModelInfo.name),
+	})
+}
+
 /**
  * Free model ids are `cline-free/<model-slug>`; their paid counterpart is the
  * catalog model with the same slug under its lab prefix (for example

--- a/apps/vscode/src/shared/cline/free-models.ts
+++ b/apps/vscode/src/shared/cline/free-models.ts
@@ -1,4 +1,4 @@
-import type { ModelInfo } from "@shared/api";
+import type { ModelInfo } from "@shared/api"
 
 /**
  * Cline free models are exposed by the recommended-models endpoint under a
@@ -6,52 +6,42 @@ import type { ModelInfo } from "@shared/api";
  * same Cline API as paid models but are always billed at $0, and they disappear
  * once their promotion ends.
  */
-export const CLINE_FREE_MODEL_ID_PREFIX = "cline-free/";
+export const CLINE_FREE_MODEL_ID_PREFIX = "cline-free/"
 
-const CLINE_FREE_MODEL_NAME_SUFFIX = " (free)";
+const CLINE_FREE_MODEL_NAME_SUFFIX = " (free)"
 
 function normalizeModelId(modelId: string): string {
-	return modelId.trim().toLowerCase();
+	return modelId.trim().toLowerCase()
 }
 
 export function isClineFreeModelId(modelId: string | undefined): boolean {
-	return normalizeModelId(modelId ?? "").startsWith(CLINE_FREE_MODEL_ID_PREFIX);
+	return normalizeModelId(modelId ?? "").startsWith(CLINE_FREE_MODEL_ID_PREFIX)
 }
 
 /**
  * Returns the model slug of a `cline-free/` id (the part after the prefix), or
  * undefined when the id is not a Cline free model id.
  */
-export function getClineFreeModelSlug(
-	modelId: string | undefined,
-): string | undefined {
+export function getClineFreeModelSlug(modelId: string | undefined): string | undefined {
 	if (!isClineFreeModelId(modelId)) {
-		return undefined;
+		return undefined
 	}
 
-	const modelSlug = (modelId as string)
-		.trim()
-		.slice(CLINE_FREE_MODEL_ID_PREFIX.length);
-	return modelSlug.length > 0 ? modelSlug : undefined;
+	const modelSlug = (modelId as string).trim().slice(CLINE_FREE_MODEL_ID_PREFIX.length)
+	return modelSlug.length > 0 ? modelSlug : undefined
 }
 
 /**
  * Free models are explicitly marked in the UI so users can tell them apart from
  * their paid counterparts, which share the same underlying model slug.
  */
-export function formatClineFreeModelName(
-	modelId: string,
-	name?: string,
-): string {
-	const resolvedName = name?.trim() || modelId;
-	if (
-		!isClineFreeModelId(modelId) ||
-		resolvedName.toLowerCase().endsWith(CLINE_FREE_MODEL_NAME_SUFFIX)
-	) {
-		return resolvedName;
+export function formatClineFreeModelName(modelId: string, name?: string): string {
+	const resolvedName = name?.trim() || modelId
+	if (!isClineFreeModelId(modelId) || resolvedName.toLowerCase().endsWith(CLINE_FREE_MODEL_NAME_SUFFIX)) {
+		return resolvedName
 	}
 
-	return `${resolvedName}${CLINE_FREE_MODEL_NAME_SUFFIX}`;
+	return `${resolvedName}${CLINE_FREE_MODEL_NAME_SUFFIX}`
 }
 
 /**
@@ -64,7 +54,7 @@ export function zeroPricedModelInfo(info: ModelInfo): ModelInfo {
 		outputPrice: 0,
 		cacheReadsPrice: 0,
 		cacheWritesPrice: 0,
-	};
+	}
 }
 
 /**
@@ -72,25 +62,19 @@ export function zeroPricedModelInfo(info: ModelInfo): ModelInfo {
  * catalog model with the same slug under its lab prefix (for example
  * `cline-free/deepseek-v4-flash` -> `deepseek/deepseek-v4-flash`).
  */
-export function findPaidClineModelId(
-	freeModelId: string | undefined,
-	clineModelIds: string[],
-): string | undefined {
-	const modelSlug = getClineFreeModelSlug(freeModelId);
+export function findPaidClineModelId(freeModelId: string | undefined, clineModelIds: string[]): string | undefined {
+	const modelSlug = getClineFreeModelSlug(freeModelId)
 	if (!modelSlug) {
-		return undefined;
+		return undefined
 	}
 
-	const normalizedModelSlug = normalizeModelId(modelSlug);
+	const normalizedModelSlug = normalizeModelId(modelSlug)
 	return clineModelIds.find((modelId) => {
 		if (isClineFreeModelId(modelId)) {
-			return false;
+			return false
 		}
 
-		const normalizedModelId = normalizeModelId(modelId);
-		return (
-			normalizedModelId === normalizedModelSlug ||
-			normalizedModelId.endsWith(`/${normalizedModelSlug}`)
-		);
-	});
+		const normalizedModelId = normalizeModelId(modelId)
+		return normalizedModelId === normalizedModelSlug || normalizedModelId.endsWith(`/${normalizedModelSlug}`)
+	})
 }

--- a/apps/vscode/src/shared/utils/model-filters.ts
+++ b/apps/vscode/src/shared/utils/model-filters.ts
@@ -1,4 +1,5 @@
 import type { ApiProvider } from "@shared/api"
+import { isClineFreeModelId } from "@shared/cline/free-models"
 
 function normalizeModelId(modelId: string): string {
 	return modelId.trim().toLowerCase()
@@ -13,8 +14,9 @@ export function isClineFreeModelException(modelId: string): boolean {
 
 /**
  * Filters OpenRouter model IDs based on provider-specific rules.
- * For Cline provider: excludes :free models (except known exception models)
- * For OpenRouter/Vercel: excludes cline/ prefixed models
+ * For Cline provider: excludes :free models (except known exception models and
+ * explicit cline-free/ models)
+ * For OpenRouter/Vercel: excludes cline/ prefixed models (including cline-free/)
  * @param modelIds Array of model IDs to filter
  * @param provider The current API provider
  * @param allowedFreeModelIds Optional list of Cline free model IDs to keep visible
@@ -33,6 +35,10 @@ export function filterOpenRouterModelIds(
 			if (allowedFreeIdSet.has(normalizedModelId)) {
 				return true
 			}
+			// Explicit Cline free models are always selectable on the Cline routes
+			if (isClineFreeModelId(normalizedModelId)) {
+				return true
+			}
 			if (isClineFreeModelException(normalizedModelId)) {
 				return true
 			}
@@ -42,5 +48,5 @@ export function filterOpenRouterModelIds(
 	}
 
 	// For OpenRouter and Vercel AI Gateway providers: exclude Cline-specific models
-	return modelIds.filter((id) => !id.startsWith("cline/"))
+	return modelIds.filter((id) => !id.startsWith("cline/") && !isClineFreeModelId(id))
 }

--- a/apps/vscode/webview-ui/src/components/chat/ChatRow.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatRow.tsx
@@ -68,6 +68,15 @@ import UserMessage from "./UserMessage"
 
 const HEADER_CLASSNAMES = "flex items-center gap-2.5 mb-3"
 
+function parseErrorMessage(message: string) {
+	try {
+		return JSON.parse(message)
+	} catch {
+		// ignore errors
+		return {}
+	}
+}
+
 interface ChatRowProps {
 	message: ClineMessage
 	isExpanded: boolean
@@ -1062,6 +1071,12 @@ export const ChatRowContent = memo(
 							const retryInfo = JSON.parse(message.text || "{}")
 							const { attempt, maxAttempts, delaySeconds, failed, errorMessage } = retryInfo
 							const isFailed = failed === true
+
+							const details = parseErrorMessage(errorMessage)
+							
+							if(details && details.code === "INFERENCE_CAP_ERROR") {
+								return null;
+							}
 
 							return (
 								<div className="flex flex-col gap-2">

--- a/apps/vscode/webview-ui/src/components/chat/ChatRow.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatRow.tsx
@@ -68,15 +68,6 @@ import UserMessage from "./UserMessage"
 
 const HEADER_CLASSNAMES = "flex items-center gap-2.5 mb-3"
 
-function parseErrorMessage(message: string) {
-	try {
-		return JSON.parse(message)
-	} catch {
-		// ignore errors
-		return {}
-	}
-}
-
 interface ChatRowProps {
 	message: ClineMessage
 	isExpanded: boolean
@@ -1071,12 +1062,6 @@ export const ChatRowContent = memo(
 							const retryInfo = JSON.parse(message.text || "{}")
 							const { attempt, maxAttempts, delaySeconds, failed, errorMessage } = retryInfo
 							const isFailed = failed === true
-
-							const details = parseErrorMessage(errorMessage)
-							
-							if(details && details.code === "INFERENCE_CAP_ERROR") {
-								return null;
-							}
 
 							return (
 								<div className="flex flex-col gap-2">

--- a/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1,3 +1,4 @@
+import { getClineFreeModelSlug, isClineFreeModelId } from "@shared/cline/free-models"
 import { mentionRegex, mentionRegexGlobal } from "@shared/context-mentions"
 import { StringRequest } from "@shared/proto/cline/common"
 import { FileSearchRequest, FileSearchType, RelativePathsRequest } from "@shared/proto/cline/file"
@@ -1105,12 +1106,19 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			}
 			switch (selectedProvider) {
 				case "cline":
-					return `${selectedProvider}:${selectedModelId}`
+					// cline-free/ ids already carry their own namespace, so don't double
+					// up the provider prefix in the badge
+					return isClineFreeModelId(selectedModelId)
+						? `cline:${getClineFreeModelSlug(selectedModelId)} (free)`
+						: `${selectedProvider}:${selectedModelId}`
 				case "cline-pass":
 					// Free models selected on ClinePass go through Cline usage billing,
 					// so label them the same way as the cline provider
-					return selectedModelId.startsWith("cline-pass/")
-						? `${selectedProvider}:${selectedModelId.replace(/^cline-pass\//, "")}`
+					if (selectedModelId.startsWith("cline-pass/")) {
+						return `${selectedProvider}:${selectedModelId.replace(/^cline-pass\//, "")}`
+					}
+					return isClineFreeModelId(selectedModelId)
+						? `cline:${getClineFreeModelSlug(selectedModelId)} (free)`
 						: `cline:${selectedModelId}`
 				case "openai":
 					return `openai-compat:${selectedModelId}`

--- a/apps/vscode/webview-ui/src/components/chat/ClineFreeModelLimitError.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ClineFreeModelLimitError.tsx
@@ -1,31 +1,29 @@
-import { openRouterDefaultModelInfo } from "@shared/api";
-import { findPaidClineModelId } from "@shared/cline/free-models";
-import type { Mode } from "@shared/storage/types";
-import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
-import { useMemo, useState } from "react";
-import { getModeSpecificFields } from "@/components/settings/utils/providerUtils";
-import { useApiConfigurationHandlers } from "@/components/settings/utils/useApiConfigurationHandlers";
-import { useExtensionState } from "@/context/ExtensionStateContext";
-import { extractClineFreeModelLimitResetTime } from "../../../../src/services/error/ClineError";
+import { openRouterDefaultModelInfo } from "@shared/api"
+import { findPaidClineModelId } from "@shared/cline/free-models"
+import type { Mode } from "@shared/storage/types"
+import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
+import { useMemo, useState } from "react"
+import { getModeSpecificFields } from "@/components/settings/utils/providerUtils"
+import { useApiConfigurationHandlers } from "@/components/settings/utils/useApiConfigurationHandlers"
+import { useExtensionState } from "@/context/ExtensionStateContext"
+import { extractClineFreeModelLimitResetTime } from "../../../../src/services/error/ClineError"
 
 interface ClineFreeModelLimitErrorProps {
-	message: string;
+	message: string
 }
 
-const CLINE_PROVIDER_ID = "cline";
+const CLINE_PROVIDER_ID = "cline"
 
-const ClineFreeModelLimitError = ({
-	message,
-}: ClineFreeModelLimitErrorProps) => {
-	const { apiConfiguration, mode, clineModels } = useExtensionState();
-	const { handleModeFieldsChange } = useApiConfigurationHandlers();
-	const [isSwitching, setIsSwitching] = useState(false);
-	const [didSwitch, setDidSwitch] = useState(false);
-	const [switchError, setSwitchError] = useState<string | undefined>();
+const ClineFreeModelLimitError = ({ message }: ClineFreeModelLimitErrorProps) => {
+	const { apiConfiguration, mode, clineModels } = useExtensionState()
+	const { handleModeFieldsChange } = useApiConfigurationHandlers()
+	const [isSwitching, setIsSwitching] = useState(false)
+	const [didSwitch, setDidSwitch] = useState(false)
+	const [switchError, setSwitchError] = useState<string | undefined>()
 
-	const resetTime = extractClineFreeModelLimitResetTime(message);
-	const currentMode: Mode = mode ?? "act";
-	const modeFields = getModeSpecificFields(apiConfiguration, currentMode);
+	const resetTime = extractClineFreeModelLimitResetTime(message)
+	const currentMode: Mode = mode ?? "act"
+	const modeFields = getModeSpecificFields(apiConfiguration, currentMode)
 	// Free models are selectable on both the cline and cline-pass providers, so
 	// read the model id from whichever provider is currently selected.
 	const selectedFreeModelId =
@@ -33,24 +31,23 @@ const ClineFreeModelLimitError = ({
 			? modeFields.clinePassModelId
 			: modeFields.apiProvider === CLINE_PROVIDER_ID
 				? modeFields.clineModelId
-				: undefined;
+				: undefined
 	const paidModelId = useMemo(
-		() =>
-			findPaidClineModelId(selectedFreeModelId, Object.keys(clineModels ?? {})),
+		() => findPaidClineModelId(selectedFreeModelId, Object.keys(clineModels ?? {})),
 		[selectedFreeModelId, clineModels],
-	);
+	)
 
 	const handleSwitchToPaidModel = async () => {
 		if (!paidModelId) {
-			return;
+			return
 		}
-		setIsSwitching(true);
-		setSwitchError(undefined);
+		setIsSwitching(true)
+		setSwitchError(undefined)
 		try {
 			const modelInfo = clineModels?.[paidModelId] ?? {
 				...openRouterDefaultModelInfo,
 				name: paidModelId,
-			};
+			}
 
 			await handleModeFieldsChange(
 				{
@@ -73,61 +70,49 @@ const ClineFreeModelLimitError = ({
 					clineModelInfo: modelInfo,
 				},
 				currentMode,
-			);
-			setDidSwitch(true);
+			)
+			setDidSwitch(true)
 		} catch (error) {
-			console.error("Failed to switch to the paid model:", error);
-			setSwitchError(
-				`Failed to switch model. Select ${paidModelId} in API Configuration settings.`,
-			);
+			console.error("Failed to switch to the paid model:", error)
+			setSwitchError(`Failed to switch model. Select ${paidModelId} in API Configuration settings.`)
 		} finally {
-			setIsSwitching(false);
+			setIsSwitching(false)
 		}
-	};
+	}
 
 	return (
 		<div
 			className="p-2 border-none rounded-md mb-2 bg-(--vscode-textBlockQuote-background)"
-			data-testid="cline-free-model-limit-error"
-		>
+			data-testid="cline-free-model-limit-error">
 			<div className="text-error mb-2">Daily free model limit reached</div>
 			<div className="text-(--vscode-descriptionForeground) text-xs wrap-anywhere">
 				You've reached today's free usage limit for this model.
 			</div>
 			<div className="text-(--vscode-descriptionForeground) text-xs mt-2">
-				{resetTime ? `Try again in ${resetTime}` : "Try again later"} or select
-				another model.
+				{resetTime ? `Try again in ${resetTime}` : "Try again later"} or select another model.
 			</div>
 			{paidModelId && (
 				<>
 					<div className="text-(--vscode-descriptionForeground) text-xs mt-2 wrap-anywhere">
-						Or switch to the paid version of this model ({paidModelId}) with
-						usage-based billing.
+						Or switch to the paid version of this model ({paidModelId}) with usage-based billing.
 					</div>
 					<VSCodeButton
 						appearance="primary"
 						className="w-full mt-3"
 						disabled={isSwitching || didSwitch}
-						onClick={handleSwitchToPaidModel}
-					>
-						{isSwitching
-							? "Switching..."
-							: didSwitch
-								? "Switched to the paid model"
-								: "Switch to the paid model"}
+						onClick={handleSwitchToPaidModel}>
+						{isSwitching ? "Switching..." : didSwitch ? "Switched to the paid model" : "Switch to the paid model"}
 					</VSCodeButton>
 					{didSwitch && (
 						<div className="text-(--vscode-descriptionForeground) text-xs mt-2">
 							Retry the request after switching.
 						</div>
 					)}
-					{switchError && (
-						<div className="text-error text-xs mt-2">{switchError}</div>
-					)}
+					{switchError && <div className="text-error text-xs mt-2">{switchError}</div>}
 				</>
 			)}
 		</div>
-	);
-};
+	)
+}
 
-export default ClineFreeModelLimitError;
+export default ClineFreeModelLimitError

--- a/apps/vscode/webview-ui/src/components/chat/ClineFreeModelLimitError.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ClineFreeModelLimitError.tsx
@@ -1,0 +1,133 @@
+import { openRouterDefaultModelInfo } from "@shared/api";
+import { findPaidClineModelId } from "@shared/cline/free-models";
+import type { Mode } from "@shared/storage/types";
+import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
+import { useMemo, useState } from "react";
+import { getModeSpecificFields } from "@/components/settings/utils/providerUtils";
+import { useApiConfigurationHandlers } from "@/components/settings/utils/useApiConfigurationHandlers";
+import { useExtensionState } from "@/context/ExtensionStateContext";
+import { extractClineFreeModelLimitResetTime } from "../../../../src/services/error/ClineError";
+
+interface ClineFreeModelLimitErrorProps {
+	message: string;
+}
+
+const CLINE_PROVIDER_ID = "cline";
+
+const ClineFreeModelLimitError = ({
+	message,
+}: ClineFreeModelLimitErrorProps) => {
+	const { apiConfiguration, mode, clineModels } = useExtensionState();
+	const { handleModeFieldsChange } = useApiConfigurationHandlers();
+	const [isSwitching, setIsSwitching] = useState(false);
+	const [didSwitch, setDidSwitch] = useState(false);
+	const [switchError, setSwitchError] = useState<string | undefined>();
+
+	const resetTime = extractClineFreeModelLimitResetTime(message);
+	const currentMode: Mode = mode ?? "act";
+	const modeFields = getModeSpecificFields(apiConfiguration, currentMode);
+	// Free models are selectable on both the cline and cline-pass providers, so
+	// read the model id from whichever provider is currently selected.
+	const selectedFreeModelId =
+		modeFields.apiProvider === "cline-pass"
+			? modeFields.clinePassModelId
+			: modeFields.apiProvider === CLINE_PROVIDER_ID
+				? modeFields.clineModelId
+				: undefined;
+	const paidModelId = useMemo(
+		() =>
+			findPaidClineModelId(selectedFreeModelId, Object.keys(clineModels ?? {})),
+		[selectedFreeModelId, clineModels],
+	);
+
+	const handleSwitchToPaidModel = async () => {
+		if (!paidModelId) {
+			return;
+		}
+		setIsSwitching(true);
+		setSwitchError(undefined);
+		try {
+			const modelInfo = clineModels?.[paidModelId] ?? {
+				...openRouterDefaultModelInfo,
+				name: paidModelId,
+			};
+
+			await handleModeFieldsChange(
+				{
+					apiProvider: {
+						plan: "planModeApiProvider",
+						act: "actModeApiProvider",
+					},
+					clineModelId: {
+						plan: "planModeClineModelId",
+						act: "actModeClineModelId",
+					},
+					clineModelInfo: {
+						plan: "planModeClineModelInfo",
+						act: "actModeClineModelInfo",
+					},
+				},
+				{
+					apiProvider: CLINE_PROVIDER_ID,
+					clineModelId: paidModelId,
+					clineModelInfo: modelInfo,
+				},
+				currentMode,
+			);
+			setDidSwitch(true);
+		} catch (error) {
+			console.error("Failed to switch to the paid model:", error);
+			setSwitchError(
+				`Failed to switch model. Select ${paidModelId} in API Configuration settings.`,
+			);
+		} finally {
+			setIsSwitching(false);
+		}
+	};
+
+	return (
+		<div
+			className="p-2 border-none rounded-md mb-2 bg-(--vscode-textBlockQuote-background)"
+			data-testid="cline-free-model-limit-error"
+		>
+			<div className="text-error mb-2">Daily free model limit reached</div>
+			<div className="text-(--vscode-descriptionForeground) text-xs wrap-anywhere">
+				You've reached today's free usage limit for this model.
+			</div>
+			<div className="text-(--vscode-descriptionForeground) text-xs mt-2">
+				{resetTime ? `Try again in ${resetTime}` : "Try again later"} or select
+				another model.
+			</div>
+			{paidModelId && (
+				<>
+					<div className="text-(--vscode-descriptionForeground) text-xs mt-2 wrap-anywhere">
+						Or switch to the paid version of this model ({paidModelId}) with
+						usage-based billing.
+					</div>
+					<VSCodeButton
+						appearance="primary"
+						className="w-full mt-3"
+						disabled={isSwitching || didSwitch}
+						onClick={handleSwitchToPaidModel}
+					>
+						{isSwitching
+							? "Switching..."
+							: didSwitch
+								? "Switched to the paid model"
+								: "Switch to the paid model"}
+					</VSCodeButton>
+					{didSwitch && (
+						<div className="text-(--vscode-descriptionForeground) text-xs mt-2">
+							Retry the request after switching.
+						</div>
+					)}
+					{switchError && (
+						<div className="text-error text-xs mt-2">{switchError}</div>
+					)}
+				</>
+			)}
+		</div>
+	);
+};
+
+export default ClineFreeModelLimitError;

--- a/apps/vscode/webview-ui/src/components/chat/ErrorRow.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ErrorRow.test.tsx
@@ -12,6 +12,18 @@ const mockApiConfiguration = vi.hoisted(() => ({
 	planModeClinePassModelId: "cline-pass/test-plan-model",
 	actModeClinePassModelId: "cline-pass/test-act-model",
 }));
+// The free-model limit card offers the paid twin of the selected free model, which
+// it resolves out of the Cline catalog by model slug.
+const mockClineModels = vi.hoisted(() => ({
+	"deepseek/deepseek-v4-flash": {
+		name: "DeepSeek V4 Flash",
+		maxTokens: 8_192,
+		contextWindow: 128_000,
+		supportsPromptCache: false,
+		inputPrice: 1,
+		outputPrice: 2,
+	},
+}));
 
 // Mock the auth context
 vi.mock("@/context/ClineAuthContext", () => ({
@@ -41,6 +53,8 @@ vi.mock("@/components/chat/EntitlementError", () => ({
 vi.mock("@/context/ExtensionStateContext", () => ({
 	useExtensionState: () => ({
 		apiConfiguration: mockApiConfiguration,
+		mode: "act",
+		clineModels: mockClineModels,
 	}),
 }));
 
@@ -65,8 +79,17 @@ vi.mock("../../../../src/services/error/ClineError", () => ({
 		Entitlement: "entitlement",
 		OrgClinePassRestriction: "orgClinePassRestriction",
 		ClinePassLimit: "clinePassLimit",
+		ClineFreeModelLimit: "clineFreeModelLimit",
 	},
 	extractClinePassLimitMessage: vi.fn((text: string) => text),
+	extractClineFreeModelLimitResetTime: vi.fn((text: string) => {
+		const marker = "try again in ";
+		const start = text.toLowerCase().indexOf(marker);
+		if (start === -1) {
+			return undefined;
+		}
+		return text.slice(start + marker.length).trim() || undefined;
+	}),
 }));
 
 describe("ErrorRow", () => {
@@ -361,6 +384,96 @@ describe("ErrorRow", () => {
 				screen.queryByTestId("cline-pass-limit-error"),
 			).not.toBeInTheDocument();
 			expect(screen.getByText(limitMessage)).toBeInTheDocument();
+		});
+
+		it("renders a daily free model limit without usage-billing guidance", async () => {
+			const limitMessage =
+				"Daily free limit reached on model deepseek/deepseek-v4-flash. Try again in 23h 59m";
+			const mockClineError = {
+				message: limitMessage,
+				isErrorType: vi.fn((type) => type === "clineFreeModelLimit"),
+				providerId: "cline",
+				_error: { message: limitMessage },
+			};
+
+			const { ClineError } = await import(
+				"../../../../src/services/error/ClineError"
+			);
+			vi.mocked(ClineError.parse).mockReturnValue(mockClineError as any);
+
+			render(
+				<ErrorRow
+					apiRequestFailedMessage={limitMessage}
+					errorType="error"
+					message={mockMessage}
+				/>,
+			);
+
+			expect(
+				screen.getByTestId("cline-free-model-limit-error"),
+			).toBeInTheDocument();
+			expect(
+				screen.getByText(
+					/You've reached today's free usage limit for this model/,
+				),
+			).toBeInTheDocument();
+			expect(screen.getByText(/Try again in 23h 59m/)).toBeInTheDocument();
+			// The raw backend message (including the model id) is replaced by the copy above
+			expect(screen.queryByText(limitMessage)).not.toBeInTheDocument();
+			expect(
+				screen.queryByText(/Switch to Usage-Based billing/i),
+			).not.toBeInTheDocument();
+		});
+
+		it("offers the paid twin of the selected free model", async () => {
+			const limitMessage =
+				"Daily free limit reached on model cline-free/deepseek-v4-flash. Try again in 23h 59m";
+			const mockClineError = {
+				message: limitMessage,
+				isErrorType: vi.fn((type) => type === "clineFreeModelLimit"),
+				providerId: "cline",
+				_error: { message: limitMessage },
+			};
+
+			const { ClineError } = await import(
+				"../../../../src/services/error/ClineError"
+			);
+			vi.mocked(ClineError.parse).mockReturnValue(mockClineError as any);
+			// The configured provider drives which model id the card reads
+			mockApiConfiguration.actModeApiProvider = "cline";
+			(mockApiConfiguration as Record<string, unknown>).actModeClineModelId =
+				"cline-free/deepseek-v4-flash";
+
+			try {
+				render(
+					<ErrorRow
+						apiRequestFailedMessage={limitMessage}
+						errorType="error"
+						message={mockMessage}
+					/>,
+				);
+
+				expect(
+					screen.getByText(/deepseek\/deepseek-v4-flash/),
+				).toBeInTheDocument();
+
+				fireEvent.click(screen.getByText("Switch to the paid model"));
+
+				await waitFor(() =>
+					expect(mockUpdateApiConfigurationProto).toHaveBeenCalledTimes(1),
+				);
+				const request = mockUpdateApiConfigurationProto.mock.calls[0][0];
+				expect(request.apiConfiguration.actModeApiProvider).toBe(
+					ApiProvider.CLINE,
+				);
+				expect(request.apiConfiguration.actModeClineModelId).toBe(
+					"deepseek/deepseek-v4-flash",
+				);
+			} finally {
+				mockApiConfiguration.actModeApiProvider = "cline-pass";
+				delete (mockApiConfiguration as Record<string, unknown>)
+					.actModeClineModelId;
+			}
 		});
 
 		it("renders friendly logged-out message and sign in button when user is not signed in", async () => {

--- a/apps/vscode/webview-ui/src/components/chat/ErrorRow.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ErrorRow.tsx
@@ -1,6 +1,7 @@
 import type { ClineMessage } from "@shared/ExtensionMessage";
 import { isClineProvider } from "@shared/utils/cline";
 import { memo } from "react";
+import ClineFreeModelLimitError from "@/components/chat/ClineFreeModelLimitError";
 import ClinePassLimitError from "@/components/chat/ClinePassLimitError";
 import CreditLimitError from "@/components/chat/CreditLimitError";
 import EntitlementError from "@/components/chat/EntitlementError";
@@ -103,6 +104,15 @@ const ErrorRow = memo(
 							const limitMessage =
 								extractClinePassLimitMessage(detailMessage) ?? detailMessage;
 							return <ClinePassLimitError message={limitMessage} />;
+						}
+
+						// Daily free-model limits have their own remedy (wait for the
+						// reset, pick another model, or switch to the paid twin), so
+						// they get dedicated copy instead of the raw backend message.
+						if (clineError?.isErrorType(ClineErrorType.ClineFreeModelLimit)) {
+							const detailMessage =
+								clineError?._error?.details?.message || errorMessage;
+							return <ClineFreeModelLimitError message={detailMessage} />;
 						}
 
 						if (clineError?.isErrorType(ClineErrorType.RateLimit)) {

--- a/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.tsx
@@ -302,10 +302,7 @@ const ClineModelPicker: React.FC<ClineModelPickerProps> = ({
 				: normalizedSelection
 		// Explicit cline-free/ ids are free even before the recommended-models
 		// response lands, so check the namespace as well as the fetched free list.
-		if (
-			isClineFreeModelId(selected.selectedModelId) ||
-			freeClineModelIdSet.has(normalizeModelId(selected.selectedModelId))
-		) {
+		if (isClineFreeModelId(selected.selectedModelId) || freeClineModelIdSet.has(normalizeModelId(selected.selectedModelId))) {
 			return {
 				...selected,
 				selectedModelInfo: zeroPricedModelInfo({

--- a/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.tsx
@@ -1,5 +1,10 @@
 import { type ApiConfiguration, buildModelInfoNameMap, CLAUDE_SONNET_1M_SUFFIX, type ModelInfo } from "@shared/api"
-import { formatClineFreeModelName, isClineFreeModelId, zeroPricedModelInfo } from "@shared/cline/free-models"
+import {
+	formatClineFreeModelName,
+	isClineFreeModelId,
+	resolveClineFreeModelInfo,
+	zeroPricedModelInfo,
+} from "@shared/cline/free-models"
 import { CLINE_RECOMMENDED_MODELS_FALLBACK } from "@shared/cline/recommended-models"
 import { EmptyRequest, StringRequest } from "@shared/proto/cline/common"
 import { type ClineRecommendedModel, ClineRecommendedModelsResponse } from "@shared/proto/cline/models"
@@ -268,6 +273,12 @@ const ClineModelPicker: React.FC<ClineModelPickerProps> = ({
 		setSearchTerm(newModelId)
 
 		const newModelInfo = resolvedModels?.[newModelId]
+		// cline-free/ ids are not published in the models catalog, so borrow the paid
+		// twin's capabilities. Without this the handler would fall back to
+		// openRouterDefaultModelInfo and use Claude Sonnet's limits for another model.
+		const freeModelInfo = isClineFreeModelId(newModelId)
+			? (newModelInfo ?? resolveClineFreeModelInfo(newModelId, resolvedModels))
+			: undefined
 
 		handleModeFieldsChange(
 			{
@@ -278,13 +289,12 @@ const ClineModelPicker: React.FC<ClineModelPickerProps> = ({
 				clineModelId: newModelId,
 				// Free models ride usage billing at $0, so persist them zero-priced and
 				// with the explicit "(free)" name so cost UI never shows paid rates.
-				clineModelInfo:
-					newModelInfo && isClineFreeModelId(newModelId)
-						? zeroPricedModelInfo({
-								...newModelInfo,
-								name: formatClineFreeModelName(newModelId, newModelInfo.name),
-							})
-						: newModelInfo,
+				clineModelInfo: freeModelInfo
+					? zeroPricedModelInfo({
+							...freeModelInfo,
+							name: formatClineFreeModelName(newModelId, freeModelInfo.name),
+						})
+					: newModelInfo,
 			},
 			currentMode,
 		)
@@ -303,11 +313,18 @@ const ClineModelPicker: React.FC<ClineModelPickerProps> = ({
 		// Explicit cline-free/ ids are free even before the recommended-models
 		// response lands, so check the namespace as well as the fetched free list.
 		if (isClineFreeModelId(selected.selectedModelId) || freeClineModelIdSet.has(normalizeModelId(selected.selectedModelId))) {
+			// cline-free/ ids are absent from the catalog, so normalizeApiConfiguration
+			// can only supply the default info. Prefer the paid twin's real capabilities
+			// so the info panel and context-window UI don't show Claude Sonnet's limits.
+			const freeModelInfo =
+				resolvedModels?.[selected.selectedModelId] ??
+				resolveClineFreeModelInfo(selected.selectedModelId, resolvedModels) ??
+				selected.selectedModelInfo
 			return {
 				...selected,
 				selectedModelInfo: zeroPricedModelInfo({
-					...selected.selectedModelInfo,
-					name: formatClineFreeModelName(selected.selectedModelId, selected.selectedModelInfo?.name),
+					...freeModelInfo,
+					name: formatClineFreeModelName(selected.selectedModelId, freeModelInfo?.name),
 				}),
 			}
 		}

--- a/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.tsx
@@ -1,4 +1,5 @@
 import { type ApiConfiguration, buildModelInfoNameMap, CLAUDE_SONNET_1M_SUFFIX, type ModelInfo } from "@shared/api"
+import { formatClineFreeModelName, isClineFreeModelId, zeroPricedModelInfo } from "@shared/cline/free-models"
 import { CLINE_RECOMMENDED_MODELS_FALLBACK } from "@shared/cline/recommended-models"
 import { EmptyRequest, StringRequest } from "@shared/proto/cline/common"
 import { type ClineRecommendedModel, ClineRecommendedModelsResponse } from "@shared/proto/cline/models"
@@ -266,6 +267,8 @@ const ClineModelPicker: React.FC<ClineModelPickerProps> = ({
 		const newModelId = models && !(rawModelId in models) ? resolveModelId(rawModelId) : rawModelId
 		setSearchTerm(newModelId)
 
+		const newModelInfo = resolvedModels?.[newModelId]
+
 		handleModeFieldsChange(
 			{
 				clineModelId: modelIdFieldPair,
@@ -273,7 +276,15 @@ const ClineModelPicker: React.FC<ClineModelPickerProps> = ({
 			},
 			{
 				clineModelId: newModelId,
-				clineModelInfo: resolvedModels?.[newModelId],
+				// Free models ride usage billing at $0, so persist them zero-priced and
+				// with the explicit "(free)" name so cost UI never shows paid rates.
+				clineModelInfo:
+					newModelInfo && isClineFreeModelId(newModelId)
+						? zeroPricedModelInfo({
+								...newModelInfo,
+								name: formatClineFreeModelName(newModelId, newModelInfo.name),
+							})
+						: newModelInfo,
 			},
 			currentMode,
 		)
@@ -289,16 +300,18 @@ const ClineModelPicker: React.FC<ClineModelPickerProps> = ({
 						selectedModelInfo: resolvedModels?.[resolvedModelId] ?? normalizedSelection.selectedModelInfo,
 					}
 				: normalizedSelection
-		if (freeClineModelIdSet.has(normalizeModelId(selected.selectedModelId))) {
+		// Explicit cline-free/ ids are free even before the recommended-models
+		// response lands, so check the namespace as well as the fetched free list.
+		if (
+			isClineFreeModelId(selected.selectedModelId) ||
+			freeClineModelIdSet.has(normalizeModelId(selected.selectedModelId))
+		) {
 			return {
 				...selected,
-				selectedModelInfo: {
+				selectedModelInfo: zeroPricedModelInfo({
 					...selected.selectedModelInfo,
-					inputPrice: 0,
-					outputPrice: 0,
-					cacheReadsPrice: 0,
-					cacheWritesPrice: 0,
-				},
+					name: formatClineFreeModelName(selected.selectedModelId, selected.selectedModelInfo?.name),
+				}),
 			}
 		}
 		return selected

--- a/apps/vscode/webview-ui/src/components/settings/providers/ClinePassProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/ClinePassProvider.tsx
@@ -3,9 +3,11 @@ import {
 	clinePassDefaultModelId,
 	clinePassModelInfoSaneDefaults,
 	clinePassModels,
+	getModelSlug,
 	type ModelInfo,
 	resolveClinePassModelInfo,
 } from "@shared/api"
+import { formatClineFreeModelName, zeroPricedModelInfo } from "@shared/cline/free-models"
 import { CLINE_RECOMMENDED_MODELS_FALLBACK } from "@shared/cline/recommended-models"
 import { EmptyRequest } from "@shared/proto/cline/common"
 import type { ClineRecommendedModel } from "@shared/proto/cline/models"
@@ -36,22 +38,18 @@ const CLINE_PASS_MODEL_FIELD_PAIRS = {
 const FREE_TAB_DESCRIPTION =
 	"Try these models with limited free usage, included at no cost and separate from your ClinePass quota."
 
-function zeroPriced(info: ModelInfo): ModelInfo {
-	return {
-		...info,
-		inputPrice: 0,
-		outputPrice: 0,
-		cacheReadsPrice: 0,
-		cacheWritesPrice: 0,
-	}
+// Cline free models come back as either full OpenRouter-style ids or cline-free/ ids,
+// so resolve capabilities by full id first and fall back to the slug map (cline-free
+// ids share their slug with the paid catalog entry).
+function resolveFreeModelInfo(
+	modelId: string,
+	modelCatalog: Record<string, ModelInfo>,
+	modelCatalogByName: Record<string, ModelInfo>,
+): ModelInfo {
+	return modelCatalog[modelId] ?? modelCatalogByName[getModelSlug(modelId)] ?? clinePassModelInfoSaneDefaults
 }
 
-export const ClinePassProvider = ({
-	showModelOptions,
-	isPopup,
-	currentMode,
-	showAccountCard = true,
-}: ClinePassProviderProps) => {
+export const ClinePassProvider = ({ showModelOptions, isPopup, currentMode, showAccountCard = true }: ClinePassProviderProps) => {
 	const { apiConfiguration, openRouterModels, clineModels, refreshClineModels } = useExtensionState()
 	const openRouterModelsByName = useMemo(() => buildModelInfoNameMap(openRouterModels), [openRouterModels])
 	const [clinePassRawModels, setClinePassRawModels] = useState<ClineRecommendedModel[]>([])
@@ -104,20 +102,24 @@ export const ClinePassProvider = ({
 		[clineFreeModels],
 	)
 
-	// Free models are OpenRouter-style ids billed at $0, so resolve their info by full id
-	// from the dynamic catalogs and store them zero-priced.
+	// Free models are OpenRouter-style ids or cline-free/ ids billed at $0, so resolve
+	// their info from the dynamic catalogs and store them zero-priced.
 	const freeModelEntries = useMemo(() => {
 		const modelCatalog: Record<string, ModelInfo> = { ...openRouterModels, ...clineModels }
+		const modelCatalogByName = buildModelInfoNameMap(modelCatalog)
 		return Object.fromEntries(
 			freeRecommendedModels
 				.filter((model) => model.id)
 				.map((model) => {
-					const base = modelCatalog[model.id] ?? clinePassModelInfoSaneDefaults
+					const base = resolveFreeModelInfo(model.id, modelCatalog, modelCatalogByName)
+					const name = model.name || base.name || model.id
 					return [
 						model.id,
-						zeroPriced({
+						zeroPricedModelInfo({
 							...base,
-							name: model.name || base.name || model.id,
+							// cline-free/ models are explicitly marked so they can be told
+							// apart from their paid counterpart, which shares the slug
+							name: formatClineFreeModelName(model.id, name),
 							// The info panel shows the full catalog description; the endpoint's
 							// short blurb is only for the featured cards
 							description: base.description || model.description,

--- a/apps/vscode/webview-ui/src/utils/validate.ts
+++ b/apps/vscode/webview-ui/src/utils/validate.ts
@@ -1,4 +1,5 @@
 import { ApiConfiguration, clinePassDefaultModelId, clinePassModels, ModelInfo, openRouterDefaultModelId } from "@shared/api"
+import { isClineFreeModelId } from "@shared/cline/free-models"
 import { CLINE_RECOMMENDED_MODELS_FALLBACK } from "@shared/cline/recommended-models"
 import { Mode } from "@shared/storage/types"
 import { getModeSpecificFields } from "@/components/settings/utils/providerUtils"
@@ -209,7 +210,13 @@ export function validateModelId(
 				if (!clineResolvedModelId) {
 					return "You must provide a model ID."
 				}
-				if (clineModels && !Object.keys(clineModels).includes(clineResolvedModelId)) {
+				if (
+					clineModels &&
+					!Object.keys(clineModels).includes(clineResolvedModelId) &&
+					// Cline free models live in their own namespace and are not part of the
+					// paid catalog, so they'd otherwise be rejected here
+					!isClineFreeModelId(clineResolvedModelId)
+				) {
 					return "The model ID you provided is not available. Please choose a different model."
 				}
 				break
@@ -224,7 +231,9 @@ export function validateModelId(
 				if (
 					!Object.keys(clinePassModels).includes(clinePassResolvedModelId) &&
 					!clinePassResolvedModelId.startsWith("cline-pass/") &&
-					// ClinePass users may also select Cline free models (OpenRouter-style ids)
+					// ClinePass users may also select Cline free models (OpenRouter-style
+					// ids, or ids in the dedicated cline-free/ namespace)
+					!isClineFreeModelId(clinePassResolvedModelId) &&
 					!(clineModels && Object.keys(clineModels).includes(clinePassResolvedModelId)) &&
 					!CLINE_RECOMMENDED_MODELS_FALLBACK.free.some((model) => model.id === clinePassResolvedModelId)
 				) {


### PR DESCRIPTION
This PR somewhat copies what we do in main for cline-free models into the legacy extension. Because we will offset the legacy extension soon, some things are kinda hacky, but work great:
<img width="301" height="889" alt="image" src="https://github.com/user-attachments/assets/83568ed6-4dea-4eb7-83c2-808031be1bea" />
