### PR TITLE
fix(desktop): prevent long-running chat turns from timing out

### DIFF
--- a/apps/examples/desktop-app/webview/hooks/chat-session/types.ts
+++ b/apps/examples/desktop-app/webview/hooks/chat-session/types.ts
@@ -87,6 +87,19 @@ export type ChatApiResult = {
 	messages?: unknown[];
 };
 
+export type ChatSessionCommandResponse = {
+	sessionId?: string;
+	cwd?: string;
+	workspaceRoot?: string;
+	result?: ChatApiResult;
+	ok?: boolean;
+	queued?: boolean;
+	promptsInQueue?: PromptInQueue[];
+	prompt?: PromptInQueue;
+	updated?: boolean;
+	removed?: boolean;
+};
+
 export type ChatWsResponseEvent = {
 	type: "chat_response";
 	requestId: string;

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
@@ -104,6 +104,16 @@ describe("useChatSession", () => {
 				config: expect.objectContaining({ cwd: "", workspaceRoot: "" }),
 			}),
 		});
+		expect(invokeMock).toHaveBeenCalledWith(
+			"chat_session_command",
+			{
+				request: expect.objectContaining({
+					action: "send",
+					prompt: "Start the task",
+				}),
+			},
+			{ timeoutMs: null },
+		);
 	});
 
 	it("preserves server validation errors", async () => {

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
@@ -18,6 +18,7 @@ import type {
 	AgentChunkEvent,
 	AskQuestionRequestItem,
 	ChatApiResult,
+	ChatSessionCommandResponse,
 	ChatSessionHookEvent,
 	ChatTransportState,
 	CoreLogChunk,
@@ -329,18 +330,18 @@ export function useChatSession() {
 	// ---- Data fetching ----
 
 	const postSession = useCallback(async (body: Record<string, unknown>) => {
-		return await desktopClient.invoke<{
-			sessionId?: string;
-			cwd?: string;
-			workspaceRoot?: string;
-			result?: ChatApiResult;
-			ok?: boolean;
-			queued?: boolean;
-			promptsInQueue?: PromptInQueue[];
-			prompt?: PromptInQueue;
-			updated?: boolean;
-			removed?: boolean;
-		}>("chat_session_command", { request: body });
+		const request = { request: body };
+		if (body.action === "send") {
+			return await desktopClient.invoke<ChatSessionCommandResponse>(
+				"chat_session_command",
+				request,
+				{ timeoutMs: null },
+			);
+		}
+		return await desktopClient.invoke<ChatSessionCommandResponse>(
+			"chat_session_command",
+			request,
+		);
 	}, []);
 
 	const refreshPromptsInQueue = useCallback(

--- a/apps/examples/desktop-app/webview/lib/desktop-client.test.ts
+++ b/apps/examples/desktop-app/webview/lib/desktop-client.test.ts
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type SentDesktopRequest = {
+	id: string;
+	command: string;
+};
+
+class FakeWebSocket {
+	static readonly CONNECTING = 0;
+	static readonly OPEN = 1;
+	static readonly CLOSING = 2;
+	static readonly CLOSED = 3;
+
+	readonly sent: string[] = [];
+	readyState = FakeWebSocket.CONNECTING;
+	onopen: (() => void) | null = null;
+	onmessage: ((event: { data: string }) => void) | null = null;
+	onerror: (() => void) | null = null;
+	onclose: (() => void) | null = null;
+
+	constructor(readonly url: string) {
+		sockets.push(this);
+	}
+
+	open(): void {
+		this.readyState = FakeWebSocket.OPEN;
+		this.onopen?.();
+	}
+
+	send(data: string): void {
+		this.sent.push(data);
+	}
+
+	close(): void {
+		this.readyState = FakeWebSocket.CLOSED;
+		this.onclose?.();
+	}
+
+	respond(result: unknown): void {
+		const request = this.lastRequest();
+		this.onmessage?.({
+			data: JSON.stringify({
+				type: "response",
+				id: request.id,
+				ok: true,
+				result,
+			}),
+		});
+	}
+
+	lastRequest(): SentDesktopRequest {
+		const raw = this.sent.at(-1);
+		if (!raw) {
+			throw new Error("No desktop request was sent");
+		}
+		return JSON.parse(raw) as SentDesktopRequest;
+	}
+}
+
+const sockets: FakeWebSocket[] = [];
+const originalWebSocket = globalThis.WebSocket;
+
+async function connectLatestSocket(): Promise<FakeWebSocket> {
+	await Promise.resolve();
+	await Promise.resolve();
+	const socket = sockets.at(-1);
+	if (!socket) {
+		throw new Error("Desktop client did not create a WebSocket");
+	}
+	socket.open();
+	for (let attempt = 0; attempt < 10 && socket.sent.length === 0; attempt++) {
+		await Promise.resolve();
+	}
+	return socket;
+}
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	vi.resetModules();
+	sockets.length = 0;
+	globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+	(window as unknown as Record<string, unknown>).__SIDECAR_WS_ENDPOINT__ =
+		"ws://127.0.0.1:3126/transport";
+});
+
+afterEach(() => {
+	vi.clearAllTimers();
+	vi.useRealTimers();
+	globalThis.WebSocket = originalWebSocket;
+	delete (window as unknown as Record<string, unknown>).__SIDECAR_WS_ENDPOINT__;
+});
+
+describe("DesktopClient command deadlines", () => {
+	it("keeps an explicitly unbounded command pending past the default deadline", async () => {
+		const { desktopClient } = await import("./desktop-client");
+		let settled = false;
+		const invocation = desktopClient
+			.invoke<{ ok: boolean }>(
+				"chat_session_command",
+				{ request: { action: "send" } },
+				{ timeoutMs: null },
+			)
+			.finally(() => {
+				settled = true;
+			});
+		const socket = await connectLatestSocket();
+
+		await vi.advanceTimersByTimeAsync(10 * 60_000);
+		expect(settled).toBe(false);
+
+		socket.respond({ ok: true });
+		await expect(invocation).resolves.toEqual({ ok: true });
+	});
+
+	it("retains the default deadline for ordinary commands", async () => {
+		const { desktopClient } = await import("./desktop-client");
+		const invocation = desktopClient.invoke("get_process_context");
+		await connectLatestSocket();
+		const rejection = expect(invocation).rejects.toThrow(
+			"Desktop command timed out waiting for get_process_context",
+		);
+
+		await vi.advanceTimersByTimeAsync(120_000);
+		await rejection;
+	});
+
+	it("rejects an unbounded command when the transport closes", async () => {
+		const { desktopClient } = await import("./desktop-client");
+		const invocation = desktopClient.invoke(
+			"chat_session_command",
+			{ request: { action: "send" } },
+			{ timeoutMs: null },
+		);
+		const socket = await connectLatestSocket();
+		const rejection = expect(invocation).rejects.toThrow(
+			"Desktop backend transport closed",
+		);
+
+		socket.close();
+		await rejection;
+	});
+});

--- a/apps/examples/desktop-app/webview/lib/desktop-client.test.ts
+++ b/apps/examples/desktop-app/webview/lib/desktop-client.test.ts
@@ -15,6 +15,7 @@ class FakeWebSocket {
 
 	readonly sent: string[] = [];
 	readyState = FakeWebSocket.CONNECTING;
+	sendError: Error | null = null;
 	onopen: (() => void) | null = null;
 	onmessage: ((event: { data: string }) => void) | null = null;
 	onerror: (() => void) | null = null;
@@ -30,6 +31,9 @@ class FakeWebSocket {
 	}
 
 	send(data: string): void {
+		if (this.sendError) {
+			throw this.sendError;
+		}
 		this.sent.push(data);
 	}
 
@@ -62,13 +66,16 @@ class FakeWebSocket {
 const sockets: FakeWebSocket[] = [];
 const originalWebSocket = globalThis.WebSocket;
 
-async function connectLatestSocket(): Promise<FakeWebSocket> {
+async function connectLatestSocket(options?: {
+	sendError?: Error;
+}): Promise<FakeWebSocket> {
 	await Promise.resolve();
 	await Promise.resolve();
 	const socket = sockets.at(-1);
 	if (!socket) {
 		throw new Error("Desktop client did not create a WebSocket");
 	}
+	socket.sendError = options?.sendError ?? null;
 	socket.open();
 	for (let attempt = 0; attempt < 10 && socket.sent.length === 0; attempt++) {
 		await Promise.resolve();
@@ -140,5 +147,26 @@ describe("DesktopClient command deadlines", () => {
 
 		socket.close();
 		await rejection;
+	});
+
+	it("removes an unbounded request when WebSocket.send throws", async () => {
+		const { desktopClient } = await import("./desktop-client");
+		const invocation = desktopClient.invoke(
+			"chat_session_command",
+			{ request: { action: "send" } },
+			{ timeoutMs: null },
+		);
+		await connectLatestSocket({
+			sendError: new Error("WebSocket send failed"),
+		});
+
+		await expect(invocation).rejects.toThrow("WebSocket send failed");
+		expect(
+			(
+				desktopClient as unknown as {
+					pending: Map<string, unknown>;
+				}
+			).pending.size,
+		).toBe(0);
 	});
 });

--- a/apps/examples/desktop-app/webview/lib/desktop-client.ts
+++ b/apps/examples/desktop-app/webview/lib/desktop-client.ts
@@ -87,11 +87,19 @@ export async function resolveDesktopBackendHttpEndpoint(): Promise<string> {
 type PendingRequest = {
 	resolve: (value: unknown) => void;
 	reject: (error: Error) => void;
-	timeoutId: ReturnType<typeof setTimeout>;
+	timeoutId?: ReturnType<typeof setTimeout>;
 };
 
 type EventHandler = (payload: unknown) => void;
 type TransportStateHandler = (state: DesktopTransportState) => void;
+
+export type DesktopInvokeOptions = {
+	/**
+	 * Override the default command deadline. Use `null` for commands whose
+	 * response represents completion of a legitimately long-running operation.
+	 */
+	timeoutMs?: number | null;
+};
 
 const REQUEST_TIMEOUT_MS = 120_000;
 const RECONNECT_BASE_DELAY_MS = 400;
@@ -144,7 +152,9 @@ class DesktopClient {
 
 	private rejectPending(errorMessage: string) {
 		for (const [requestId, pending] of this.pending.entries()) {
-			clearTimeout(pending.timeoutId);
+			if (pending.timeoutId !== undefined) {
+				clearTimeout(pending.timeoutId);
+			}
 			this.pending.delete(requestId);
 			pending.reject(new Error(errorMessage));
 		}
@@ -178,7 +188,9 @@ class DesktopClient {
 		if (!pending) {
 			return;
 		}
-		clearTimeout(pending.timeoutId);
+		if (pending.timeoutId !== undefined) {
+			clearTimeout(pending.timeoutId);
+		}
 		this.pending.delete(response.id);
 		if (!response.ok) {
 			pending.reject(new Error(response.error || "Desktop command failed"));
@@ -265,7 +277,11 @@ class DesktopClient {
 		return this.connectPromise;
 	}
 
-	async invoke<T>(command: string, args?: Record<string, unknown>): Promise<T> {
+	async invoke<T>(
+		command: string,
+		args?: Record<string, unknown>,
+		options?: DesktopInvokeOptions,
+	): Promise<T> {
 		// Route native OS commands (directory picker, file opener) through Tauri
 		// only when running inside the full Tauri app shell. In sidecar/web mode
 		// these are handled by the sidecar over WebSocket.
@@ -288,16 +304,23 @@ class DesktopClient {
 		};
 
 		return await new Promise<T>((resolve, reject) => {
-			const timeoutId = setTimeout(() => {
-				const pending = this.pending.get(id);
-				if (!pending) {
-					return;
-				}
-				this.pending.delete(id);
-				pending.reject(
-					new Error(`Desktop command timed out waiting for ${command}`),
-				);
-			}, REQUEST_TIMEOUT_MS);
+			const timeoutMs =
+				options?.timeoutMs === undefined
+					? REQUEST_TIMEOUT_MS
+					: options.timeoutMs;
+			const timeoutId =
+				timeoutMs === null
+					? undefined
+					: setTimeout(() => {
+							const pending = this.pending.get(id);
+							if (!pending) {
+								return;
+							}
+							this.pending.delete(id);
+							pending.reject(
+								new Error(`Desktop command timed out waiting for ${command}`),
+							);
+						}, timeoutMs);
 			this.pending.set(id, {
 				resolve: (value) => resolve(value as T),
 				reject,

--- a/apps/examples/desktop-app/webview/lib/desktop-client.ts
+++ b/apps/examples/desktop-app/webview/lib/desktop-client.ts
@@ -150,13 +150,21 @@ class DesktopClient {
 		return this.endpoint;
 	}
 
+	private takePending(requestId: string): PendingRequest | undefined {
+		const pending = this.pending.get(requestId);
+		if (!pending) {
+			return undefined;
+		}
+		if (pending.timeoutId !== undefined) {
+			clearTimeout(pending.timeoutId);
+		}
+		this.pending.delete(requestId);
+		return pending;
+	}
+
 	private rejectPending(errorMessage: string) {
-		for (const [requestId, pending] of this.pending.entries()) {
-			if (pending.timeoutId !== undefined) {
-				clearTimeout(pending.timeoutId);
-			}
-			this.pending.delete(requestId);
-			pending.reject(new Error(errorMessage));
+		for (const requestId of this.pending.keys()) {
+			this.takePending(requestId)?.reject(new Error(errorMessage));
 		}
 	}
 
@@ -184,14 +192,10 @@ class DesktopClient {
 		}
 
 		const response = parsed as DesktopTransportResponse;
-		const pending = this.pending.get(response.id);
+		const pending = this.takePending(response.id);
 		if (!pending) {
 			return;
 		}
-		if (pending.timeoutId !== undefined) {
-			clearTimeout(pending.timeoutId);
-		}
-		this.pending.delete(response.id);
 		if (!response.ok) {
 			pending.reject(new Error(response.error || "Desktop command failed"));
 			return;
@@ -312,11 +316,10 @@ class DesktopClient {
 				timeoutMs === null
 					? undefined
 					: setTimeout(() => {
-							const pending = this.pending.get(id);
+							const pending = this.takePending(id);
 							if (!pending) {
 								return;
 							}
-							this.pending.delete(id);
 							pending.reject(
 								new Error(`Desktop command timed out waiting for ${command}`),
 							);
@@ -326,7 +329,12 @@ class DesktopClient {
 				reject,
 				timeoutId,
 			});
-			socket.send(JSON.stringify(request));
+			try {
+				socket.send(JSON.stringify(request));
+			} catch (error) {
+				this.takePending(id);
+				throw error;
+			}
 		});
 	}
 


### PR DESCRIPTION

<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Add per-invocation timeout options to the desktop client and disable the deadline for long-running chat send requests. Extract the shared command response type and verify send commands use the timeout override.


### Problem

Desktop chat turns longer than two minutes displayed `Desktop command timed out waiting for chat_session_command`, even though the agent could still be running normally.

### Root cause

The desktop transport applied a fixed 120-second timeout to every command, while chat `send` requests remain open until the full `ClineCore.send()` turn completes.

### Changes

- Add per-invocation timeout options to the desktop client.
- Disable the transport deadline for long-running chat `send` requests.
- Preserve the default timeout for ordinary commands.
- Continue rejecting unbounded requests when the transport disconnects.
- Extract the shared chat command response type.
- Add regression tests for timeout, unbounded, and disconnect behavior.


### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

- 396 desktop Vitest tests passed.
- 3 Bun-native tests passed.
- Desktop TypeScript typecheck passed.
- Biome checks passed.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
