### PR TITLE
fix(webview): use theme-colored dropdowns for remaining native select elements

### DIFF
--- a/apps/vscode/webview-ui/src/components/cline-rules/NewRuleRow.tsx
+++ b/apps/vscode/webview-ui/src/components/cline-rules/NewRuleRow.tsx
@@ -3,6 +3,7 @@ import { PlusIcon } from "lucide-react"
 import { useEffect, useMemo, useRef, useState } from "react"
 import { useClickAway } from "react-use"
 import { Button } from "@/components/ui/button"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { cn } from "@/lib/utils"
 import { FileServiceClient } from "@/services/grpc-client"
 
@@ -30,7 +31,11 @@ const NewRuleRow: React.FC<NewRuleRowProps> = ({ isGlobal, ruleType, existingHoo
 	const inputRef = useRef<HTMLInputElement>(null)
 	const [error, setError] = useState<string | null>(null)
 
-	const componentRef = useRef<HTMLDivElement>(null)
+	const componentRef = useRef<HTMLDivElement | null>(null)
+	// Portal target for the hook-type dropdown. Rendering the dropdown inside
+	// this component (instead of document.body) keeps clicks on its options
+	// from triggering the rules modal's click-away handler.
+	const [dropdownContainer, setDropdownContainer] = useState<HTMLDivElement | null>(null)
 
 	// Calculate available hook types by filtering out existing hooks
 	const availableHookTypes = useMemo(() => HOOK_TYPES.filter((type) => !existingHooks.includes(type.name)), [existingHooks])
@@ -153,7 +158,10 @@ const NewRuleRow: React.FC<NewRuleRowProps> = ({ isGlobal, ruleType, existingHoo
 					"opacity-70 hover:opacity-100": !isExpanded,
 				})}
 				onClick={() => !isExpanded && ruleType !== "hook" && setIsExpanded(true)}
-				ref={componentRef}>
+				ref={(node) => {
+					componentRef.current = node
+					setDropdownContainer(node)
+				}}>
 				<div
 					className={cn(
 						"flex items-center px-2 py-4 rounded bg-input-background transition-all duration-300 ease-in-out h-5",
@@ -170,37 +178,29 @@ const NewRuleRow: React.FC<NewRuleRowProps> = ({ isGlobal, ruleType, existingHoo
 								Choose a hook type to create. Hooks execute at specific points in Cline's lifecycle. Available:{" "}
 								{availableHookTypes.map((h) => h.name).join(", ")}
 							</span>
-							<select
-								aria-describedby="hook-select-description"
-								aria-label="Select hook type to create"
-								className="flex-1 bg-input-background text-input-foreground border-0 outline-0 rounded focus:outline-none focus:ring-0 focus:border-transparent px-2 cursor-pointer"
+							{/* Controlled with a constant empty value so the trigger
+							    resets to the placeholder after each hook is created. */}
+							<Select
 								disabled={availableHookTypes.length === 0}
-								id="hook-type-select"
-								onChange={(e) => {
-									if (e.target.value) {
-										handleCreateHook(e.target.value)
-										// Reset selection after creating
-										e.target.value = ""
-									}
-								}}
-								style={{
-									fontStyle: "italic",
-									appearance: "none",
-									backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23cccccc' d='M6 9L1 4h10z'/%3E%3C/svg%3E")`,
-									backgroundRepeat: "no-repeat",
-									backgroundPosition: "right 8px center",
-									paddingRight: "24px",
-								}}
+								onValueChange={(hookName) => handleCreateHook(hookName)}
 								value="">
-								<option disabled value="">
-									{availableHookTypes.length === 0 ? "All hooks created" : "New hook..."}
-								</option>
-								{availableHookTypes.map((hook) => (
-									<option key={hook.name} title={hook.description} value={hook.name}>
-										{hook.name}
-									</option>
-								))}
-							</select>
+								<SelectTrigger
+									aria-describedby="hook-select-description"
+									aria-label="Select hook type to create"
+									className="flex-1 data-[size=default]:h-5 min-h-0 border-0 bg-transparent px-2 py-0 rounded shadow-none italic text-input-foreground data-[placeholder]:text-input-foreground cursor-pointer focus-visible:ring-0"
+									id="hook-type-select">
+									<SelectValue
+										placeholder={availableHookTypes.length === 0 ? "All hooks created" : "New hook..."}
+									/>
+								</SelectTrigger>
+								<SelectContent container={dropdownContainer ?? undefined}>
+									{availableHookTypes.map((hook) => (
+										<SelectItem key={hook.name} title={hook.description} value={hook.name}>
+											{hook.name}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
 						</>
 					) : (
 						<form className="flex flex-1 items-center" onSubmit={handleSubmit}>

--- a/apps/vscode/webview-ui/src/components/settings/providers/OpenAICompatible.test.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/OpenAICompatible.test.tsx
@@ -57,6 +57,24 @@ vi.mock("@vscode/webview-ui-toolkit/react", () => ({
 			{children}
 		</button>
 	),
+	VSCodeDropdown: ({
+		children,
+		id,
+		onChange,
+		value,
+		"aria-label": ariaLabel,
+	}: {
+		children?: ReactNode
+		id?: string
+		onChange?: ChangeEventHandler<HTMLSelectElement>
+		value?: string
+		"aria-label"?: string
+	}) => (
+		<select aria-label={ariaLabel} id={id} onChange={onChange} value={value}>
+			{children}
+		</select>
+	),
+	VSCodeOption: ({ children, value }: { children?: ReactNode; value?: string }) => <option value={value}>{children}</option>,
 	VSCodeCheckbox: ({
 		checked,
 		children,

--- a/apps/vscode/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
@@ -3,7 +3,7 @@ import { azureOpenAiDefaultApiVersion, type OpenAiCompatibleModelInfo, openAiMod
 import { ApiFormat, OpenAiModelsRequest } from "@shared/proto/cline/models"
 import { fromProtobufModelInfo } from "@shared/proto-conversions/models/typeConversion"
 import type { Mode } from "@shared/storage/types"
-import { VSCodeButton, VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react"
+import { VSCodeButton, VSCodeCheckbox, VSCodeDropdown, VSCodeOption } from "@vscode/webview-ui-toolkit/react"
 import { useCallback, useEffect, useRef, useState } from "react"
 import { Tooltip } from "@/components/ui/tooltip"
 import { useExtensionState } from "@/context/ExtensionStateContext"
@@ -15,6 +15,7 @@ import { ApiKeyField } from "../common/ApiKeyField"
 import { BaseUrlField } from "../common/BaseUrlField"
 import { DebouncedTextField } from "../common/DebouncedTextField"
 import { ModelInfoView } from "../common/ModelInfoView"
+import { DropdownContainer } from "../common/ModelSelector"
 import ReasoningEffortSelector from "../ReasoningEffortSelector"
 import { useApiConfigurationHandlers } from "../utils/useApiConfigurationHandlers"
 import { useProviderApiKeyField } from "../utils/useProviderApiKeyField"
@@ -348,31 +349,38 @@ export const OpenAICompatibleProvider = ({
 						gap: 8,
 						marginBottom: 10,
 					}}>
-					<select
-						aria-label="Model ID"
-						id="openai-compatible-model-picker"
-						onChange={(event) => {
-							const modelId = event.target.value
-							if (modelId === "__custom__") {
-								setIsCustomOpenAiModelEntryVisible(true)
-								return
-							}
+					<DropdownContainer className="dropdown-container">
+						<VSCodeDropdown
+							aria-label="Model ID"
+							className="w-full"
+							id="openai-compatible-model-picker"
+							// Force VSCodeDropdown to re-initialize after async
+							// model-list/selection hydration, otherwise it ignores the
+							// value prop for dynamically rendered options.
+							// https://github.com/microsoft/vscode-webview-ui-toolkit/issues/433
+							key={`${selectedModelId ?? ""}:${isCustomOpenAiModelEntryVisible}:${availableOpenAiModels.join("\u0000")}`}
+							onChange={(event) => {
+								const modelId = (event.target as HTMLSelectElement).value
+								if (modelId === "__custom__") {
+									setIsCustomOpenAiModelEntryVisible(true)
+									return
+								}
 
-							setIsCustomOpenAiModelEntryVisible(false)
-							handleOpenAiModelSelection(modelId)
-						}}
-						style={{ width: "100%" }}
-						value={selectedModelId && availableOpenAiModels.includes(selectedModelId) ? selectedModelId : ""}>
-						{selectedModelId && !availableOpenAiModels.includes(selectedModelId) && (
-							<option value="">{selectedModelId} (not in current list)</option>
-						)}
-						{availableOpenAiModels.map((modelId) => (
-							<option key={modelId} value={modelId}>
-								{modelId}
-							</option>
-						))}
-						<option value="__custom__">Use custom model ID…</option>
-					</select>
+								setIsCustomOpenAiModelEntryVisible(false)
+								handleOpenAiModelSelection(modelId)
+							}}
+							value={selectedModelId && availableOpenAiModels.includes(selectedModelId) ? selectedModelId : ""}>
+							{selectedModelId && !availableOpenAiModels.includes(selectedModelId) && (
+								<VSCodeOption value="">{selectedModelId} (not in current list)</VSCodeOption>
+							)}
+							{availableOpenAiModels.map((modelId) => (
+								<VSCodeOption className="break-words whitespace-normal max-w-full" key={modelId} value={modelId}>
+									{modelId}
+								</VSCodeOption>
+							))}
+							<VSCodeOption value="__custom__">Use custom model ID…</VSCodeOption>
+						</VSCodeDropdown>
+					</DropdownContainer>
 
 					{(isCustomOpenAiModelEntryVisible ||
 						(selectedModelId && !availableOpenAiModels.includes(selectedModelId))) && (

--- a/apps/vscode/webview-ui/src/components/ui/select.tsx
+++ b/apps/vscode/webview-ui/src/components/ui/select.tsx
@@ -52,10 +52,13 @@ function SelectContent({
 	children,
 	position = "popper",
 	align = "center",
+	container,
 	...props
-}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+}: React.ComponentProps<typeof SelectPrimitive.Content> & {
+	container?: React.ComponentProps<typeof SelectPrimitive.Portal>["container"]
+}) {
 	return (
-		<SelectPrimitive.Portal>
+		<SelectPrimitive.Portal container={container}>
 			<SelectPrimitive.Content
 				align={align}
 				className={cn(


### PR DESCRIPTION
## Description

A sweep of the webview for native `<select>`/`<option>` elements whose option popups render with browser-default styling (white background, light gray text) instead of VS Code theme colors. #12554 fixed the custom autocomplete dropdown menus, but two native selects were left behind:

- **OpenAI Compatible provider model picker** (`OpenAICompatible.tsx`): replaced the raw `<select>` with the themed `VSCodeDropdown`/`VSCodeOption` wrapped in `DropdownContainer`, matching the convention used by every other provider's model picker (`ModelSelector`, `ModelPickerWithManualEntry`). Includes the standard `key` remount workaround for the toolkit's dynamic-options bug.
- **Hook-type picker in the rules modal** (`NewRuleRow.tsx`): replaced the raw `<select>` with the themed Radix `Select` (`@/components/ui/select`). The dropdown content is portaled into the component itself (new optional `container` prop on `SelectContent`) so clicks on options don't trigger the rules modal's click-away handler.

These were the only remaining native `<select>` usages in the webview outside of test mocks.

## Test Procedure

- `bun run test` in `webview-ui`: 45 files, 355 tests pass (includes updated `OpenAICompatible.test.tsx` mocks for `VSCodeDropdown`/`VSCodeOption`).
- `tsc -b && vite build` passes.
- Manual GUI testing in the extension dev host (dark theme): OpenAI Compatible model dropdown and the New hook dropdown both render with themed backgrounds/foregrounds.