### PR TITLE
feat(vscode): enable Cline Pass for everyone (remove ext-cline-pass flag)

### DIFF
--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -38,10 +38,8 @@ import { stringifyVsCodeLmModelSelector } from "@shared/vsCodeSelectorUtils"
 import { StateManager } from "@/core/storage/StateManager"
 import { HostProvider } from "@/hosts/host-provider"
 import { ExtensionRegistryInfo } from "@/registry"
-import { getFeatureFlagsService } from "@/services/feature-flags"
 import { getDistinctId } from "@/services/logging/distinctId"
 import { fetch } from "@/shared/net"
-import { FeatureFlag } from "@/shared/services/feature-flags/feature-flags"
 import { type BedrockProviderConfig, buildBedrockProviderConfig } from "./bedrock-config"
 import { buildAgentHooks } from "./hooks-adapter"
 import { readTaskHistory, resolveDataDir } from "./legacy-state-reader"
@@ -806,7 +804,7 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 			const dataDir = resolveDataDir()
 			const manager = getProviderSettingsManager(dataDir)
 			const lastUsed = manager.getLastUsedProviderSettings({
-				isClinePassEnabled: getFeatureFlagsService().getBooleanFlagEnabled(FeatureFlag.CLINE_PASS),
+				isClinePassEnabled: true,
 			})
 
 			if (lastUsed?.provider && lastUsed?.apiKey) {

--- a/apps/vscode/src/sdk/model-catalog/catalog.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/catalog.test.ts
@@ -551,7 +551,7 @@ describe("ProviderCatalog Phase 3.5 listProviders", () => {
 		})
 		expect(listings[0]).not.toHaveProperty("models")
 		expect(mocks.listLocalProviders).toHaveBeenCalledTimes(1)
-		expect(mocks.listLocalProviders).toHaveBeenCalledWith(expect.anything(), { isClinePassEnabled: false })
+		expect(mocks.listLocalProviders).toHaveBeenCalledWith(expect.anything(), { isClinePassEnabled: true })
 	})
 
 	it("caches provider listings per catalog instance without reading provider config", async () => {

--- a/apps/vscode/src/sdk/model-catalog/catalog.ts
+++ b/apps/vscode/src/sdk/model-catalog/catalog.ts
@@ -1,8 +1,6 @@
 import { listLocalProviders, type ModelCatalogConfig, resolveProviderConfig } from "@cline/core"
 import { type ProviderConfig, resolveProviderUsageCostDisplay } from "@cline/llms"
 import { type ProviderListItem } from "@cline/shared"
-import { getFeatureFlagsService } from "@/services/feature-flags"
-import { FeatureFlag } from "@/shared/services/feature-flags/feature-flags"
 import { getProviderSettingsManager } from "../provider-migration"
 import type {
 	CatalogError,
@@ -192,9 +190,8 @@ function toProviderListing(provider: ProviderListItem): ProviderListing {
 
 async function listSdkProviderListings(): Promise<ReadonlyArray<ProviderListing>> {
 	const manager = getProviderSettingsManager()
-	const featureFlags = getFeatureFlagsService()
 	const { providers } = await listLocalProviders(manager, {
-		isClinePassEnabled: featureFlags.getBooleanFlagEnabled(FeatureFlag.CLINE_PASS),
+		isClinePassEnabled: true,
 	})
 	return providers.map(toProviderListing)
 }

--- a/apps/vscode/src/shared/services/feature-flags/feature-flags.ts
+++ b/apps/vscode/src/shared/services/feature-flags/feature-flags.ts
@@ -14,8 +14,6 @@ export enum FeatureFlag {
 	// Rollout flag for Cline provider model sourcing:
 	// off => OpenRouter model list, on => Cline endpoint model list.
 	EXTENSION_CLINE_MODELS_ENDPOINT = "extension_cline_models_endpoint",
-	// Enables ClinePass provider/model list exposure.
-	CLINE_PASS = "ext-cline-pass",
 	// Rollout flag for fetching recommended Cline models from the upstream endpoint.
 	CLINE_RECOMMENDED_MODELS_UPSTREAM = "cline_recommended_models_upstream",
 	// Use the websocket mode for OpenAI native Responses API format
@@ -29,7 +27,6 @@ export const FeatureFlagDefaultValue: Partial<Record<FeatureFlag, FeatureFlagPay
 	[FeatureFlag.EXTENSION_REMOTE_BANNERS_TTL]: 24 * 60 * 60 * 1000,
 	[FeatureFlag.REMOTE_WELCOME_BANNERS]: process.env.E2E_TEST === "true" || process.env.IS_DEV === "true",
 	[FeatureFlag.EXTENSION_CLINE_MODELS_ENDPOINT]: false,
-	[FeatureFlag.CLINE_PASS]: false,
 	[FeatureFlag.CLINE_RECOMMENDED_MODELS_UPSTREAM]: false,
 	[FeatureFlag.OPENAI_RESPONSES_WEBSOCKET_MODE]: false,
 }

--- a/apps/vscode/webview-ui/src/components/onboarding/OnboardingView.tsx
+++ b/apps/vscode/webview-ui/src/components/onboarding/OnboardingView.tsx
@@ -9,9 +9,7 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Item, ItemContent, ItemDescription, ItemHeader, ItemMedia, ItemTitle } from "@/components/ui/item"
-import { CLINE_PASS_FEATURE_FLAG } from "@/constants/featureFlags"
 import { useExtensionState } from "@/context/ExtensionStateContext"
-import { useHasFeatureFlag } from "@/hooks/useFeatureFlag"
 import { useProviderConfig } from "@/hooks/useProviderConfig"
 import { useProviderModels } from "@/hooks/useProviderModels"
 import { cn } from "@/lib/utils"
@@ -358,7 +356,6 @@ const OnboardingStepContent = ({
 const OnboardingViewContent = ({ onboardingModels }: { onboardingModels: OnboardingModelGroup }) => {
 	const { handleFieldsChange } = useApiConfigurationHandlers()
 	const { openRouterModels, hideSettings, hideAccount, setShowWelcome } = useExtensionState()
-	const isClinePassEnabled = useHasFeatureFlag(CLINE_PASS_FEATURE_FLAG)
 	const { models: clineModels } = useProviderModels("cline")
 	const { commitSelection } = useProviderConfig("cline")
 	const loginAttemptIdRef = useRef(0)
@@ -373,8 +370,8 @@ const OnboardingViewContent = ({ onboardingModels }: { onboardingModels: Onboard
 	const [searchTerm, setSearchTerm] = useState("")
 
 	const models = useMemo(() => getClineUIOnboardingGroups(onboardingModels), [onboardingModels])
-	// Gate on models too, so a fallback/empty response can't route flagged users into the dead-end empty step.
-	const showClinePass = isClinePassEnabled && models.clinePass.length > 0
+	// Gate on models so a fallback/empty response can't route users into the dead-end empty step.
+	const showClinePass = models.clinePass.length > 0
 	const userTypeSelections = useMemo(() => getUserTypeSelections(showClinePass), [showClinePass])
 	// ClinePass model IDs (e.g. "cline-pass/glm-5.2") aren't keyed in openRouterModels,
 	// so resolve their info via the slug-based lookup used by ClinePassProvider.

--- a/apps/vscode/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/ApiOptions.tsx
@@ -6,9 +6,7 @@ import styled from "styled-components"
 
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { PLATFORM_CONFIG, PlatformType } from "@/config/platform.config"
-import { CLINE_PASS_FEATURE_FLAG } from "@/constants/featureFlags"
 import { useExtensionState } from "@/context/ExtensionStateContext"
-import { useHasFeatureFlag } from "@/hooks/useFeatureFlag"
 import { useProviderListings } from "@/hooks/useProviderListings"
 import { OPENROUTER_MODEL_PICKER_Z_INDEX } from "./OpenRouterModelPicker"
 import { AIhubmixProvider } from "./providers/AihubmixProvider"
@@ -93,12 +91,9 @@ const ApiOptions = ({
 }: ApiOptionsProps) => {
 	// Use full context state for immediate save payload
 	const { apiConfiguration, remoteConfigSettings } = useExtensionState()
-	const isClinePassEnabled = useHasFeatureFlag(CLINE_PASS_FEATURE_FLAG)
 
-	const selectedProviderRaw =
+	const selectedProvider =
 		(currentMode === "plan" ? apiConfiguration?.planModeApiProvider : apiConfiguration?.actModeApiProvider) || "anthropic"
-	// Fall back from cline-pass to cline when the feature flag is off.
-	const selectedProvider = selectedProviderRaw === "cline-pass" && !isClinePassEnabled ? "cline" : selectedProviderRaw
 	const { providers: catalogProviderListings } = useProviderListings()
 	const catalogProviderListing = useMemo(
 		() => catalogProviderListings.find((provider) => provider.id === selectedProvider),
@@ -133,9 +128,6 @@ const ApiOptions = ({
 			value: provider.id,
 			label: provider.name,
 		}))
-		if (!isClinePassEnabled) {
-			providers = providers.filter((option) => option.value !== "cline-pass")
-		}
 		// Filter by platform
 		if (PLATFORM_CONFIG.type !== PlatformType.VSCODE) {
 			// Don't include VS Code LM API for non-VSCode platforms
@@ -149,7 +141,7 @@ const ApiOptions = ({
 		}
 
 		return providers
-	}, [catalogProviderListings, isClinePassEnabled, remoteConfigSettings])
+	}, [catalogProviderListings, remoteConfigSettings])
 
 	const currentProviderLabel = useMemo(() => {
 		return providerOptions.find((option) => option.value === selectedProvider)?.label || selectedProvider
@@ -369,7 +361,7 @@ const ApiOptions = ({
 				/>
 			)}
 
-			{apiConfiguration && isClinePassEnabled && selectedProvider === "cline-pass" && (
+			{apiConfiguration && selectedProvider === "cline-pass" && (
 				<ClinePassProvider currentMode={currentMode} isPopup={isPopup} showModelOptions={showModelOptions} />
 			)}
 

--- a/apps/vscode/webview-ui/src/constants/featureFlags.ts
+++ b/apps/vscode/webview-ui/src/constants/featureFlags.ts
@@ -1,3 +1,0 @@
-// Webview copies of feature-flag strings. Must match the extension's FeatureFlag
-// enum, which can't be imported here (it pulls in Node-only deps).
-export const CLINE_PASS_FEATURE_FLAG = "ext-cline-pass"


### PR DESCRIPTION
### Related Issue

Ports the intent of #11987 ("Remove feature flag from the extension", legacy branch) to main.

### Description

Cline Pass was un-gated on the `legacy-extension` branch back in June (#11987, `4d8f9ea1a`), but that commit never landed on main — so the main extension still hides Cline Pass behind the `ext-cline-pass` PostHog flag, whose hardcoded default is `false`. Anyone whose flag payload doesn't resolve to `true` (dev builds, telemetry off, PostHog unreachable, or simply not in the rollout cohort) never sees the provider at all.

This removes the flag entirely and makes Cline Pass unconditionally available, matching what the legacy extension has shipped for a month.

There were **four** gate sites on main — two more than the legacy port had, because the SDK-backed architecture grew host-side gates after the branches diverged:

**Webview:**
- `ApiOptions.tsx` — filtered `cline-pass` out of the provider dropdown, silently rewrote a saved `cline-pass` selection back to `cline`, and refused to render `ClinePassProvider`
- `OnboardingView.tsx` — hid the Cline Pass user-type option during onboarding

**Extension host (new since the legacy fork):**
- `sdk/model-catalog/catalog.ts` — passed the flag into `listLocalProviders`, dropping `cline-pass` from the SDK provider listing entirely
- `sdk/cline-session-factory.ts` — same for `getLastUsedProviderSettings` in the last-used-provider fallback

The host-side pair is the important one: even with the webview un-gated, the SDK catalog would still omit the provider, so all four had to flip together.

Since nothing reads the flag anymore, `FeatureFlag.CLINE_PASS` and its default are removed from the extension's flag enum, and the webview-side `constants/featureFlags.ts` (whose only export was the flag string) is deleted along with its now-unused `useHasFeatureFlag` call sites.

Behavior notes:
- The onboarding Cline Pass option is still gated on the curated model list being non-empty (`models.clinePass.length > 0`), so an empty/fallback onboarding-models response can't route users into a dead-end empty step. That guard predates this PR and is kept.
- The "rewrite saved `cline-pass` selection back to `cline`" fallback in `ApiOptions.tsx` is gone — a saved Cline Pass selection now stays selected, which is the point.

### Test Procedure

- `bunx tsc --noEmit` clean for both the extension host and the webview
- `bunx vitest run src/sdk/model-catalog/catalog.test.ts` — 29 passed (updated the assertion that pinned `isClinePassEnabled: false`)
- `bunx vitest run src/components/onboarding` (webview) — 9 passed
- `biome lint` clean on all touched files
- Grepped for remaining `ext-cline-pass` / `FeatureFlag.CLINE_PASS` / `isClinePassEnabled` references under `apps/vscode` — only the intentional hardcoded `true` at the two SDK call sites remains (the SDK's `ListLocalProvidersOptions.isClinePassEnabled` option itself is untouched, since the CLI still resolves its own flag)

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
