### PR TITLE
fix(core): resolve incomplete custom model metadata

### DIFF
--- a/sdk/packages/core/src/services/llms/handler-factory.test.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.test.ts
@@ -16,6 +16,7 @@ const gatewayMock = vi.hoisted(() => {
 vi.mock("@cline/llms", () => ({
 	createGateway: gatewayMock.createGateway,
 	MODEL_COLLECTIONS_BY_PROVIDER_ID: {},
+	getModelsForProviderSync: vi.fn(() => undefined),
 	hasRegisteredHandler: gatewayMock.hasRegisteredHandler,
 	createHandlerAsync: gatewayMock.createHandlerAsync,
 	normalizeProviderId: (id: string) => id,

--- a/sdk/packages/core/src/services/llms/handler-factory.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.ts
@@ -1,8 +1,8 @@
 import {
 	createGateway,
 	createHandlerAsync,
+	getModelsForProviderSync,
 	hasRegisteredHandler,
-	MODEL_COLLECTIONS_BY_PROVIDER_ID,
 	normalizeProviderId,
 } from "@cline/llms";
 import type {
@@ -94,7 +94,7 @@ export function resolveKnownModelsFromConfig(
 	const knownModels = pc?.knownModels
 		? pc.knownModels
 		: (config.knownModels ??
-			MODEL_COLLECTIONS_BY_PROVIDER_ID[config.providerId]?.models ??
+			getModelsForProviderSync(config.providerId) ??
 			undefined);
 	// Caller-configured limits are authoritative for the selected model —
 	// surface them to the gateway so the resolved model definition carries

--- a/sdk/packages/core/src/services/providers/local-provider-service.test.ts
+++ b/sdk/packages/core/src/services/providers/local-provider-service.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import * as LlmsModels from "@cline/llms";
 import { CLINE_DEFAULT_MODEL_ID } from "@cline/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveKnownModelsFromConfig } from "../llms/handler-factory";
 import { clearLiveModelsCatalogCache } from "../llms/provider-defaults";
 import { ProviderSettingsManager } from "../storage/provider-settings-manager";
 import {
@@ -57,6 +58,54 @@ afterEach(() => {
 });
 
 describe("models registry parsing", () => {
+	it("resolves incomplete-provider model metadata through the synchronous config path", () => {
+		registerCustomProvider("openai-compatible", {
+			models: {
+				"custom-model": {
+					contextWindow: 1_048_576,
+					maxInputTokens: 1_000_000,
+					inputPrice: 1.25,
+					outputPrice: 3.5,
+				},
+			},
+		});
+
+		const knownModels = resolveKnownModelsFromConfig({
+			providerId: "openai-compatible",
+			modelId: "custom-model",
+			systemPrompt: "",
+			tools: [],
+		});
+
+		expect(knownModels?.["custom-model"]).toMatchObject({
+			contextWindow: 1_048_576,
+			maxInputTokens: 1_000_000,
+			pricing: {
+				input: 1.25,
+				output: 3.5,
+			},
+		});
+
+		const explicitKnownModels = resolveKnownModelsFromConfig({
+			providerId: "openai-compatible",
+			modelId: "custom-model",
+			systemPrompt: "",
+			tools: [],
+			providerConfig: {
+				providerId: "openai-compatible",
+				modelId: "custom-model",
+				knownModels: {
+					"custom-model": {
+						id: "custom-model",
+						contextWindow: 4096,
+					},
+				},
+			},
+		});
+
+		expect(explicitKnownModels?.["custom-model"]?.contextWindow).toBe(4096);
+	});
+
 	it("accepts model entries that use the record key as the model id", async () => {
 		const parsed = parseModelsFile({
 			version: 1,
@@ -111,6 +160,19 @@ describe("models registry parsing", () => {
 				},
 				temperature: 0.2,
 				apiFormat: "r1",
+			},
+		});
+		expect(
+			resolveKnownModelsFromConfig({
+				providerId: "schema-provider",
+				modelId: "alpha",
+				systemPrompt: "",
+				tools: [],
+			})?.alpha,
+		).toMatchObject({
+			pricing: {
+				input: 1.25,
+				output: 3.5,
 			},
 		});
 	});

--- a/sdk/packages/llms/src/index.browser.ts
+++ b/sdk/packages/llms/src/index.browser.ts
@@ -13,6 +13,7 @@ export {
 	getAllProviders,
 	getGeneratedModelsForProvider,
 	getModelsForProvider,
+	getModelsForProviderSync,
 	getProvider,
 	getProviderCollection,
 	getProviderCollectionSync,

--- a/sdk/packages/llms/src/index.ts
+++ b/sdk/packages/llms/src/index.ts
@@ -18,6 +18,7 @@ export {
 	getGeneratedModelsForProvider,
 	getGeneratedProviderModels,
 	getModelsForProvider,
+	getModelsForProviderSync,
 	getProvider,
 	getProviderCollection,
 	getProviderCollectionSync,

--- a/sdk/packages/llms/src/models.ts
+++ b/sdk/packages/llms/src/models.ts
@@ -24,6 +24,7 @@ export type {
 export {
 	getAllProviders,
 	getModelsForProvider,
+	getModelsForProviderSync,
 	getProvider,
 	getProviderCollection,
 	getProviderCollectionSync,

--- a/sdk/packages/llms/src/providers/model-registry.test.ts
+++ b/sdk/packages/llms/src/providers/model-registry.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	getModelsForProviderSync,
+	MODEL_COLLECTIONS_BY_PROVIDER_ID,
+	registerModel,
+	registerProvider,
+	resetRegistry,
+} from "./model-registry";
+
+afterEach(() => {
+	resetRegistry();
+});
+
+describe("getModelsForProviderSync", () => {
+	it("merges separately registered models without widening the provider collection", () => {
+		registerModel("openai-compatible", "local-model", {
+			id: "local-model",
+			contextWindow: 1_048_576,
+		});
+
+		expect(
+			getModelsForProviderSync("openai-compatible")?.["local-model"],
+		).toMatchObject({
+			contextWindow: 1_048_576,
+		});
+		expect(
+			MODEL_COLLECTIONS_BY_PROVIDER_ID["openai-compatible"].models[
+				"local-model"
+			],
+		).toBeUndefined();
+	});
+
+	it("preserves custom-model precedence over a complete provider collection", () => {
+		registerProvider({
+			provider: {
+				id: "custom-provider",
+				name: "Custom Provider",
+				baseUrl: "https://example.invalid/v1",
+				defaultModelId: "shared-model",
+				protocol: "openai-chat",
+				client: "openai-compatible",
+			},
+			models: {
+				"shared-model": {
+					id: "shared-model",
+					contextWindow: 8192,
+				},
+			},
+		});
+		registerModel("custom-provider", "shared-model", {
+			id: "shared-model",
+			contextWindow: 16_384,
+		});
+
+		expect(
+			getModelsForProviderSync("custom-provider")?.["shared-model"],
+		).toMatchObject({
+			contextWindow: 16_384,
+		});
+		expect(
+			MODEL_COLLECTIONS_BY_PROVIDER_ID["custom-provider"].models[
+				"shared-model"
+			],
+		).toMatchObject({
+			contextWindow: 8192,
+		});
+	});
+});

--- a/sdk/packages/llms/src/providers/model-registry.ts
+++ b/sdk/packages/llms/src/providers/model-registry.ts
@@ -62,9 +62,18 @@ export async function getProviderCollection(
 export async function getModelsForProvider(
 	providerId: string,
 ): Promise<Record<string, ModelInfo>> {
+	return getModelsForProviderSync(providerId) ?? {};
+}
+
+export function getModelsForProviderSync(
+	providerId: string,
+): Record<string, ModelInfo> | undefined {
 	const collection = getProviderFromCache(providerId);
-	const builtInModels = collection?.models ?? {};
 	const customModels = CUSTOM_MODELS.get(providerId);
+	if (!collection && !customModels) {
+		return undefined;
+	}
+	const builtInModels = collection?.models ?? {};
 	if (customModels) {
 		return { ...builtInModels, ...Object.fromEntries(customModels) };
 	}


### PR DESCRIPTION
## Summary

- expose the existing custom-model merge as a synchronous LLM registry lookup
- use that lookup when Core resolves fallback `knownModels` for runtime configuration
- retain explicit `providerConfig.knownModels` and `config.knownModels` precedence
- keep `MODEL_COLLECTIONS_BY_PROVIDER_ID` unchanged so unrelated provider model lists are not widened

## Root cause

`registerCustomProvider` intentionally sends `models.json` entries without both `provider.name` and `provider.baseUrl` through `registerModel`, which stores them in `CUSTOM_MODELS`.

The runtime configuration path is synchronous and resolved fallback metadata through `MODEL_COLLECTIONS_BY_PROVIDER_ID`. That proxy reads `CUSTOM_PROVIDERS` and the provider cache, but not `CUSTOM_MODELS`, so an incomplete-provider model could register successfully while its `contextWindow`, `maxInputTokens`, and pricing remained invisible to compaction and cost resolution.

This is separate from #12643, which covers entries with complete provider metadata registered through `CUSTOM_PROVIDERS`.

## Tests

- focused regression first reproduced the missing metadata through `resolveKnownModelsFromConfig`
- `@cline/llms`: 438 passed, 4 skipped
- `@cline/core` unit: 1,469 passed, 4 skipped
- focused Core registry/config tests: 84 passed
- affected package typechecks passed
- Biome check passed on all changed files
- SDK build passed

## Scope

This refs #12520 but does not claim to resolve every configuration shape described there. It specifically covers the remaining incomplete/missing provider metadata path that #12643 intentionally leaves out.
