### PR TITLE
fix(vscode): read the live transcript when mapping an edited message

### DIFF
--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -77,7 +77,7 @@ import { SdkModeCoordinator } from "./sdk-mode-coordinator"
 import { SdkProviderChangeCoordinator } from "./sdk-provider-change-coordinator"
 import { SdkSessionConfigBuilder } from "./sdk-session-config-builder"
 import { SdkSessionEventCoordinator } from "./sdk-session-event-coordinator"
-import { SdkSessionHistoryLoader } from "./sdk-session-history-loader"
+import { readSessionMessagesPreferringLive, SdkSessionHistoryLoader } from "./sdk-session-history-loader"
 import { SdkSessionLifecycle } from "./sdk-session-lifecycle"
 import { SdkSessionRebuildScheduler } from "./sdk-session-rebuild-scheduler"
 import { SdkTaskControlCoordinator } from "./sdk-task-control-coordinator"
@@ -1359,7 +1359,7 @@ export class Controller {
 		let tempHost: VscodeSessionHost | undefined
 		const sessionHost = activeSession?.sdkHost ?? (tempHost = await VscodeSessionHost.create({ mcpHub: this.mcpHub }))
 		try {
-			sdkMessages = (await sessionHost.readMessages(sourceSessionId)) as SdkUserMessage[]
+			sdkMessages = (await readSessionMessagesPreferringLive(sessionHost, sourceSessionId)) as SdkUserMessage[]
 			const sdkTargetIndex = findSdkUserMessageIndexByOrdinal(sdkMessages, userOrdinal)
 			if (sdkTargetIndex === -1) {
 				throw new Error("Could not map edited message to persisted conversation history")

--- a/apps/vscode/src/sdk/sdk-session-history-loader.test.ts
+++ b/apps/vscode/src/sdk/sdk-session-history-loader.test.ts
@@ -1,8 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { SdkSessionHistoryLoader } from "./sdk-session-history-loader"
+import { readSessionMessagesPreferringLive, SdkSessionHistoryLoader } from "./sdk-session-history-loader"
+import { findSdkUserMessageIndexByOrdinal } from "./sdk-user-message-mapping"
 import type { SdkSessionHost } from "./session-host"
 
-const getSavedApiConversationHistory = vi.fn().mockResolvedValue([])
+const { getSavedApiConversationHistory } = vi.hoisted(() => ({
+	getSavedApiConversationHistory: vi.fn().mockResolvedValue([]),
+}))
 
 vi.mock("@core/storage/disk", () => ({
 	getSavedApiConversationHistory,
@@ -93,5 +96,41 @@ describe("SdkSessionHistoryLoader", () => {
 		const result = await new SdkSessionHistoryLoader().loadInitialMessages(reader, "task-1")
 
 		expect(result).toBeUndefined()
+	})
+})
+
+describe("readSessionMessagesPreferringLive", () => {
+	const persistedDuringTurn = [
+		{ role: "user", content: "add a readme" },
+		{ role: "assistant", content: "added it" },
+	]
+	const followUp = { role: "user", content: "now add a licence too" }
+	const liveDuringTurn = [...persistedDuringTurn, followUp]
+
+	it("maps the follow-up ordinal that the persisted transcript cannot resolve yet", async () => {
+		const sessionHost = {
+			readLiveMessages: vi.fn().mockResolvedValue(liveDuringTurn),
+			readMessages: vi.fn().mockResolvedValue(persistedDuringTurn),
+		} as unknown as SdkSessionHost
+
+		expect(findSdkUserMessageIndexByOrdinal(persistedDuringTurn, 2)).toBe(-1)
+
+		const messages = await readSessionMessagesPreferringLive(sessionHost, "task-1")
+
+		expect(sessionHost.readLiveMessages).toHaveBeenCalledWith("task-1")
+		expect(sessionHost.readMessages).not.toHaveBeenCalled()
+		expect(messages).toEqual(liveDuringTurn)
+		expect(findSdkUserMessageIndexByOrdinal(messages, 2)).toBe(2)
+	})
+
+	it("falls back to the persisted conversation when the host has no live read", async () => {
+		const sessionHost = {
+			readMessages: vi.fn().mockResolvedValue(persistedDuringTurn),
+		} as unknown as SdkSessionHost
+
+		const messages = await readSessionMessagesPreferringLive(sessionHost, "task-1")
+
+		expect(sessionHost.readMessages).toHaveBeenCalledWith("task-1")
+		expect(messages).toEqual(persistedDuringTurn)
 	})
 })

--- a/apps/vscode/src/sdk/sdk-session-history-loader.ts
+++ b/apps/vscode/src/sdk/sdk-session-history-loader.ts
@@ -2,14 +2,20 @@ import { Logger } from "@/shared/services/Logger"
 import { sanitizeInitialMessagesForSessionStart } from "./initial-message-sanitizer"
 import type { SdkInitialMessages, SdkSessionHost } from "./session-host"
 
+/**
+ * Prefer the live in-memory conversation: the persisted transcript only catches
+ * up at assistant-message and turn boundaries, so a read during an in-flight or
+ * just-aborted turn would otherwise miss messages the UI already shows, or read
+ * an empty file entirely.
+ */
+export function readSessionMessagesPreferringLive(sessionHost: SdkSessionHost, sessionId: string): Promise<SdkInitialMessages> {
+	return sessionHost.readLiveMessages?.(sessionId) ?? sessionHost.readMessages(sessionId)
+}
+
 export class SdkSessionHistoryLoader {
 	async loadInitialMessages(sessionHost: SdkSessionHost, taskId: string): Promise<SdkInitialMessages | undefined> {
 		try {
-			// Prefer the live in-memory conversation: the persisted transcript
-			// only catches up at turn boundaries, so a rebuild right after
-			// aborting a turn (e.g. a plan/act mode switch mid-approval) would
-			// otherwise read an empty file and drop the task context.
-			const sdkMessages = await (sessionHost.readLiveMessages?.(taskId) ?? sessionHost.readMessages(taskId))
+			const sdkMessages = await readSessionMessagesPreferringLive(sessionHost, taskId)
 			if (sdkMessages.length > 0) {
 				const sanitizedMessages = sanitizeInitialMessagesForSessionStart(sdkMessages)
 				if (sanitizedMessages !== sdkMessages) {


### PR DESCRIPTION
### Related Issue

Fixes #12512

### Description

## The problem

`editMessageAndRegenerate` maps the edited bubble against two different transcripts. It counts `userOrdinal` over the **visible** transcript (`SdkController.ts:1353-1355`, `messageStateHandler.getClineMessages()`), then looks that ordinal up in the **persisted** transcript (`SdkController.ts:1362`, `sessionHost.readMessages(...)`).

Those two disagree while a turn is in flight. The follow-up bubble enters the visible transcript synchronously, before the send (`sdk-followup-coordinator.ts:250` and `:133` into `sdk-message-coordinator.ts:84`), but the persisted file only catches up when the turn's first assistant message flushes, and per #12622's own commit message, `abort()` does not flush at all. In that window the persisted transcript holds one fewer countable user message than the UI is showing, so `findSdkUserMessageIndexByOrdinal` returns `-1` and `:1365` throws `Could not map edited message to persisted conversation history`.

That matches the report exactly: step 3 sends the follow-up and step 4 clicks Reset Chat with no wait, which is why it reproduces "intermittently" rather than always.

The mapping helper itself is correct, I traced a full task + follow-up transcript through it and it maps ordinal 2 correctly given complete input. This is a stale read, not a reset bug.

## The fix

#12622 (`0e5cb433b`) already added `readLiveMessages` for exactly this lag and applied it at `sdk-session-history-loader.ts:12`. `SdkController.ts:1362` was never converted. This PR pulls that read-preference into `readSessionMessagesPreferringLive()` and uses it at both call sites.

#### Non-obvious details

- The helper is deliberately **not** `async`, so it returns the callee's promise rather than a wrapper. A rejected `readLiveMessages` still propagates into the existing `try` in `loadInitialMessages` and still falls back to classic API history. Behaviour there is unchanged.
- The `?.` on `readLiveMessages` is load-bearing: it is optional on `SdkSessionHost` (`session-host.ts:42`) and absent on hub-backed hosts. The second test pins it.
- An empty array is not nullish, so `??` does not fall back on it. That is intentional: `LocalRuntimeHost.readLiveSessionMessages` already falls back to the persisted read when the resident agent has no messages, so the VS Code layer must not second-guess it.
- `sdk-session-history-loader.test.ts` needed `vi.hoisted()` for its existing `@core/storage/disk` mock. Importing `sdk-user-message-mapping` reaches that module eagerly, which made the hoisted `vi.mock` factory run before the top-level const initialised and failed the file intermittently. No assertion was changed.

**What did NOT change:** the other two `readMessages` callers keep persisted semantics on purpose, matching #12622's note that `readSessionMessages` stays persisted for existing callers. `sdk-compaction-coordinator.ts:207` bails on `isRunning` first and writes a rewritten transcript back, so seeding it from an unflushed turn would risk persisting over in-flight work. `sdk-task-history.ts:452` builds the History display, which should reflect the persisted record. `loadInitialMessages` behaviour is byte-identical; that hunk is a pure refactor.

**Regression risk:** the only behavioural change is which transcript the edit path reads. Downstream, `initialMessages = sdkMessages.slice(0, sdkTargetIndex)` always ends immediately before the edited user message, so any in-flight trailing assistant content in the live read is discarded anyway. No visual change.

**Alternative considered:** inlining `readLiveMessages?.(id) ?? readMessages(id)` at `:1362` would be a one-line, one-file diff. I extracted instead because the precedence is a rule rather than an expression, and duplicating it puts the next caller one copy-paste away from dropping the `?.` and breaking hub hosts. Happy to inline it if you would rather keep `SdkController` untouched.

### Test Procedure

From `apps/vscode`:

1. `bunx vitest run --config vitest.config.ts src/sdk/sdk-session-history-loader.test.ts`, 7 passed (was 5).
2. `bunx vitest run --config vitest.config.ts`, 74 files, 934 tests passed.
3. `bunx tsc --noEmit`, clean.
4. `bun run lint`, clean.

I confirmed the new tests are not vacuous by removing the live preference from the helper: 2 tests fail on real assertions (mine plus the pre-existing "prefers the live in-memory conversation" test), then pass again once restored. Ran the target file 5 times to confirm the `vi.hoisted()` change removed the intermittency.

**Honest limitations:** `Controller.editMessageAndRegenerate` has no test harness today (`SdkController.test.ts` covers only two pure helpers), so no test can guard line 1362 directly, the tests cover the read-preference and the ordinal desync it resolves. I also could not reproduce this in a running extension; the mechanism is traced from source and matches the reported steps, but if the reporter's click landed after the turn fully completed, this would not cover their exact take.

**Residual risk, not claimed as fixed:** `sdk-followup-coordinator.ts:132-137` emits the visible row before `resolveContextMentions`, so a slow `@url` mention can still let the visible ordinal lead the in-memory conversation briefly. This closes the dominant window (the whole assistant turn), not that one. Separately, `initial-message-sanitizer.ts` collapses a span of consecutive user messages in its `userSpan > 1` branch; if two visible user messages ever land in one span the ordinal would desync permanently. I did not construct a transcript that triggers it and did not touch it here.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore
-   [x] Tests are passing and code is formatted and linted
-   [x] I have reviewed contributor guidelines

### Screenshots

No visual change is intended.

### Additional Notes

Standalone PR, based on `main` at `912c4678`. Three files, +54/-9. Read `sdk-session-history-loader.ts` first, then the one-line change in `SdkController.ts`.