### PR TITLE
fix(cline-hub): keep non-dialog MCP fields when a server is edited

### DIFF
--- a/apps/cline-hub/src/server/mcp.test.ts
+++ b/apps/cline-hub/src/server/mcp.test.ts
@@ -1,0 +1,220 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { upsertMcpServer } from "./mcp";
+import type { JsonRecord } from "./types";
+
+describe("upsertMcpServer", () => {
+	const tempRoots: string[] = [];
+	const envSnapshot = {
+		CLINE_MCP_SETTINGS_PATH: process.env.CLINE_MCP_SETTINGS_PATH,
+	};
+
+	afterEach(async () => {
+		if (envSnapshot.CLINE_MCP_SETTINGS_PATH === undefined) {
+			delete process.env.CLINE_MCP_SETTINGS_PATH;
+		} else {
+			process.env.CLINE_MCP_SETTINGS_PATH = envSnapshot.CLINE_MCP_SETTINGS_PATH;
+		}
+		await Promise.all(
+			tempRoots.map((dir) => rm(dir, { recursive: true, force: true })),
+		);
+		tempRoots.length = 0;
+	});
+
+	async function seedSettings(servers: JsonRecord): Promise<string> {
+		const tempRoot = await mkdtemp(join(tmpdir(), "cline-hub-mcp-"));
+		tempRoots.push(tempRoot);
+		const settingsPath = join(tempRoot, "cline_mcp_settings.json");
+		process.env.CLINE_MCP_SETTINGS_PATH = settingsPath;
+		writeFileSync(
+			settingsPath,
+			`${JSON.stringify({ mcpServers: servers }, null, 2)}\n`,
+		);
+		return settingsPath;
+	}
+
+	function readStoredServers(settingsPath: string): JsonRecord {
+		const parsed = JSON.parse(readFileSync(settingsPath, "utf8")) as JsonRecord;
+		return parsed.mcpServers as JsonRecord;
+	}
+
+	it("preserves metadata and oauth when an existing server is edited", async () => {
+		const settingsPath = await seedSettings({
+			docs: {
+				transport: { type: "stdio", command: "old-command", args: ["--old"] },
+				disabled: false,
+				metadata: { source: "marketplace", id: "docs-server" },
+				oauth: { tokens: { access_token: "token-123" } },
+			},
+		});
+
+		upsertMcpServer({
+			name: "docs",
+			transportType: "stdio",
+			command: "new-command",
+			args: ["--new"],
+		});
+
+		const stored = readStoredServers(settingsPath).docs as JsonRecord;
+		expect((stored.transport as JsonRecord).command).toBe("new-command");
+		expect(stored.metadata).toEqual({
+			source: "marketplace",
+			id: "docs-server",
+		});
+		expect(stored.oauth).toEqual({ tokens: { access_token: "token-123" } });
+	});
+
+	it("carries preserved fields across a rename", async () => {
+		const settingsPath = await seedSettings({
+			docs: {
+				transport: { type: "stdio", command: "old-command" },
+				disabled: false,
+				metadata: { source: "marketplace" },
+				oauth: { tokens: { access_token: "token-123" } },
+			},
+		});
+
+		upsertMcpServer({
+			name: "docs-renamed",
+			previousName: "docs",
+			transportType: "stdio",
+			command: "new-command",
+		});
+
+		const servers = readStoredServers(settingsPath);
+		const renamed = servers["docs-renamed"] as JsonRecord;
+		expect(servers.docs).toBeUndefined();
+		expect(renamed.metadata).toEqual({ source: "marketplace" });
+		expect(renamed.oauth).toEqual({ tokens: { access_token: "token-123" } });
+	});
+
+	it("clears legacy flat transport fields when editing a legacy entry", async () => {
+		const settingsPath = await seedSettings({
+			docs: {
+				command: "old-command",
+				args: ["--old-a", "--old-b"],
+				cwd: "/old/cwd",
+				env: { OLD_SECRET: "leftover" },
+				disabled: false,
+				autoApprove: ["read_file"],
+				metadata: { source: "marketplace" },
+			},
+		});
+
+		upsertMcpServer({
+			name: "docs",
+			transportType: "stdio",
+			command: "new-command",
+		});
+
+		const stored = readStoredServers(settingsPath).docs as JsonRecord;
+		expect(stored.command).toBeUndefined();
+		expect(stored.args).toBeUndefined();
+		expect(stored.cwd).toBeUndefined();
+		expect(stored.env).toBeUndefined();
+		expect((stored.transport as JsonRecord).command).toBe("new-command");
+		expect(stored.autoApprove).toEqual(["read_file"]);
+		expect(stored.metadata).toEqual({ source: "marketplace" });
+	});
+
+	it("drops oauth when a remote server is pointed at a different url", async () => {
+		const settingsPath = await seedSettings({
+			docs: {
+				transport: {
+					type: "streamableHttp",
+					url: "https://trusted.example.com/mcp",
+				},
+				disabled: false,
+				metadata: { source: "marketplace" },
+				oauth: { tokens: { access_token: "token-123" } },
+			},
+		});
+
+		upsertMcpServer({
+			name: "docs",
+			transportType: "streamableHttp",
+			url: "https://other.example.com/mcp",
+		});
+
+		const stored = readStoredServers(settingsPath).docs as JsonRecord;
+		expect((stored.transport as JsonRecord).url).toBe(
+			"https://other.example.com/mcp",
+		);
+		expect(stored.oauth).toBeUndefined();
+		expect(stored.metadata).toEqual({ source: "marketplace" });
+	});
+
+	it("keeps oauth when a remote server keeps the same url", async () => {
+		const settingsPath = await seedSettings({
+			docs: {
+				transport: {
+					type: "streamableHttp",
+					url: "https://trusted.example.com/mcp",
+					headers: { "X-Old": "1" },
+				},
+				disabled: false,
+				oauth: { tokens: { access_token: "token-123" } },
+			},
+		});
+
+		upsertMcpServer({
+			name: "docs",
+			transportType: "streamableHttp",
+			url: "https://trusted.example.com/mcp",
+			headers: { "X-New": "2" },
+		});
+
+		const stored = readStoredServers(settingsPath).docs as JsonRecord;
+		expect(stored.oauth).toEqual({ tokens: { access_token: "token-123" } });
+	});
+
+	it("applies a metadata edit supplied by the caller", async () => {
+		const settingsPath = await seedSettings({
+			docs: {
+				transport: { type: "stdio", command: "old-command" },
+				disabled: false,
+				metadata: { source: "marketplace" },
+			},
+		});
+
+		upsertMcpServer({
+			name: "docs",
+			transportType: "stdio",
+			command: "old-command",
+			metadata: { source: "hand-edited", note: "user typed this" },
+		});
+
+		const stored = readStoredServers(settingsPath).docs as JsonRecord;
+		expect(stored.metadata).toEqual({
+			source: "hand-edited",
+			note: "user typed this",
+		});
+	});
+
+	it("leaves no stdio remnant when a server switches to sse", async () => {
+		const settingsPath = await seedSettings({
+			docs: {
+				transport: { type: "stdio", command: "old-command", args: ["--old"] },
+				disabled: false,
+				metadata: { source: "marketplace" },
+			},
+		});
+
+		upsertMcpServer({
+			name: "docs",
+			transportType: "sse",
+			url: "https://example.com/sse",
+		});
+
+		const stored = readStoredServers(settingsPath).docs as JsonRecord;
+		const transport = stored.transport as JsonRecord;
+		expect(transport.type).toBe("sse");
+		expect(transport.url).toBe("https://example.com/sse");
+		expect(transport.command).toBeUndefined();
+		expect(transport.args).toBeUndefined();
+		expect(stored.metadata).toEqual({ source: "marketplace" });
+	});
+});

--- a/apps/cline-hub/src/server/mcp.test.ts
+++ b/apps/cline-hub/src/server/mcp.test.ts
@@ -194,6 +194,94 @@ describe("upsertMcpServer", () => {
 		});
 	});
 
+	it("preserves metadata when the caller omits it", async () => {
+		const settingsPath = await seedSettings({
+			docs: {
+				transport: { type: "stdio", command: "old-command" },
+				disabled: false,
+				metadata: { source: "marketplace" },
+			},
+		});
+
+		upsertMcpServer({
+			name: "docs",
+			transportType: "stdio",
+			command: "new-command",
+		});
+
+		const stored = readStoredServers(settingsPath).docs as JsonRecord;
+		expect(stored.metadata).toEqual({ source: "marketplace" });
+	});
+
+	it("clears metadata when the caller sends null", async () => {
+		const settingsPath = await seedSettings({
+			docs: {
+				transport: { type: "stdio", command: "old-command" },
+				disabled: false,
+				metadata: { source: "marketplace" },
+				oauth: { tokens: { access_token: "token-123" } },
+			},
+		});
+
+		upsertMcpServer({
+			name: "docs",
+			transportType: "stdio",
+			command: "old-command",
+			metadata: null,
+		});
+
+		const stored = readStoredServers(settingsPath).docs as JsonRecord;
+		expect("metadata" in stored).toBe(false);
+		expect(stored.oauth).toEqual({ tokens: { access_token: "token-123" } });
+	});
+
+	it("rejects metadata that is not a JSON object", async () => {
+		const settingsPath = await seedSettings({
+			docs: {
+				transport: { type: "stdio", command: "old-command" },
+				disabled: false,
+				metadata: { source: "marketplace" },
+			},
+		});
+
+		for (const invalid of [[], 42, "text", true]) {
+			expect(() =>
+				upsertMcpServer({
+					name: "docs",
+					transportType: "stdio",
+					command: "new-command",
+					metadata: invalid,
+				}),
+			).toThrow(/metadata must be a JSON object/);
+		}
+
+		const stored = readStoredServers(settingsPath).docs as JsonRecord;
+		expect((stored.transport as JsonRecord).command).toBe("old-command");
+		expect(stored.metadata).toEqual({ source: "marketplace" });
+	});
+
+	it("keeps oauth when a legacy http entry keeps the same url", async () => {
+		const settingsPath = await seedSettings({
+			docs: {
+				transportType: "http",
+				url: "https://trusted.example.com/mcp",
+				disabled: false,
+				oauth: { tokens: { access_token: "token-123" } },
+			},
+		});
+
+		upsertMcpServer({
+			name: "docs",
+			transportType: "streamableHttp",
+			url: "https://trusted.example.com/mcp",
+		});
+
+		const stored = readStoredServers(settingsPath).docs as JsonRecord;
+		expect(stored.oauth).toEqual({ tokens: { access_token: "token-123" } });
+		expect((stored.transport as JsonRecord).type).toBe("streamableHttp");
+		expect(stored.transportType).toBeUndefined();
+	});
+
 	it("leaves no stdio remnant when a server switches to sse", async () => {
 		const settingsPath = await seedSettings({
 			docs: {

--- a/apps/cline-hub/src/server/mcp.test.ts
+++ b/apps/cline-hub/src/server/mcp.test.ts
@@ -282,6 +282,71 @@ describe("upsertMcpServer", () => {
 		expect(stored.transportType).toBeUndefined();
 	});
 
+	it("keeps oauth when only the url casing changes", async () => {
+		const settingsPath = await seedSettings({
+			docs: {
+				transport: {
+					type: "streamableHttp",
+					url: "https://Trusted.Example.COM/mcp",
+				},
+				disabled: false,
+				oauth: { tokens: { access_token: "token-123" } },
+			},
+		});
+
+		upsertMcpServer({
+			name: "docs",
+			transportType: "streamableHttp",
+			url: "https://trusted.example.com/mcp",
+		});
+
+		const stored = readStoredServers(settingsPath).docs as JsonRecord;
+		expect(stored.oauth).toEqual({ tokens: { access_token: "token-123" } });
+	});
+
+	it("still drops oauth when the host actually changes", async () => {
+		const settingsPath = await seedSettings({
+			docs: {
+				transport: {
+					type: "streamableHttp",
+					url: "https://trusted.example.com/mcp",
+				},
+				disabled: false,
+				oauth: { tokens: { access_token: "token-123" } },
+			},
+		});
+
+		upsertMcpServer({
+			name: "docs",
+			transportType: "streamableHttp",
+			url: "https://other.example.com/mcp",
+		});
+
+		const stored = readStoredServers(settingsPath).docs as JsonRecord;
+		expect(stored.oauth).toBeUndefined();
+	});
+
+	it("does not throw when a stored url cannot be parsed", async () => {
+		const settingsPath = await seedSettings({
+			docs: {
+				transport: { type: "streamableHttp", url: "not a url" },
+				disabled: false,
+				oauth: { tokens: { access_token: "token-123" } },
+			},
+		});
+
+		expect(() =>
+			upsertMcpServer({
+				name: "docs",
+				transportType: "streamableHttp",
+				url: "not a url",
+			}),
+		).not.toThrow();
+
+		const stored = readStoredServers(settingsPath).docs as JsonRecord;
+		expect(stored.oauth).toEqual({ tokens: { access_token: "token-123" } });
+	});
+
 	it("leaves no stdio remnant when a server switches to sse", async () => {
 		const settingsPath = await seedSettings({
 			docs: {

--- a/apps/cline-hub/src/server/mcp.ts
+++ b/apps/cline-hub/src/server/mcp.ts
@@ -3,6 +3,34 @@ import { updateMcpSettingsFileSync } from "@cline/core";
 import { resolveMcpSettingsPath } from "@cline/shared/storage";
 import type { JsonRecord } from "./types";
 
+const LEGACY_TRANSPORT_FIELDS = [
+	"command",
+	"args",
+	"cwd",
+	"env",
+	"url",
+	"headers",
+	"type",
+	"transportType",
+] as const;
+
+function resolveEndpointIdentity(record: JsonRecord): string {
+	const transport =
+		record.transport && typeof record.transport === "object"
+			? (record.transport as JsonRecord)
+			: undefined;
+	const type = String(
+		transport?.type ?? record.transportType ?? record.type ?? "stdio",
+	).trim();
+	const target =
+		typeof transport?.url === "string"
+			? transport.url
+			: typeof record.url === "string"
+				? record.url
+				: "";
+	return `${type} ${target}`;
+}
+
 export function readMcpServersResponse(): JsonRecord {
 	const settingsPath = resolveMcpSettingsPath();
 	if (!existsSync(settingsPath)) {
@@ -126,15 +154,33 @@ export function upsertMcpServer(input: JsonRecord): JsonRecord {
 					},
 					disabled: input.disabled === true,
 				};
+	if (input.metadata !== undefined) {
+		next.metadata = input.metadata;
+	}
 	// Hold the cross-process lock across read-modify-write so a concurrent writer
 	// cannot clobber this upsert.
 	updateMcpSettingsFileSync(resolveMcpSettingsPath(), (settings) => {
 		const servers = ((settings.mcpServers as JsonRecord | undefined) ??
 			{}) as JsonRecord;
+		const previous = servers[previousName || name];
 		if (previousName && previousName !== name) {
 			delete servers[previousName];
 		}
-		servers[name] = next;
+		if (previous && typeof previous === "object") {
+			const merged: JsonRecord = { ...(previous as JsonRecord), ...next };
+			for (const field of LEGACY_TRANSPORT_FIELDS) {
+				delete merged[field];
+			}
+			if (
+				resolveEndpointIdentity(previous as JsonRecord) !==
+				resolveEndpointIdentity(next)
+			) {
+				delete merged.oauth;
+			}
+			servers[name] = merged;
+		} else {
+			servers[name] = next;
+		}
 		settings.mcpServers = servers;
 	});
 	return readMcpServersResponse();

--- a/apps/cline-hub/src/server/mcp.ts
+++ b/apps/cline-hub/src/server/mcp.ts
@@ -22,13 +22,18 @@ function resolveEndpointIdentity(record: JsonRecord): string {
 	const type = String(
 		transport?.type ?? record.transportType ?? record.type ?? "stdio",
 	).trim();
+	const canonicalType = type === "http" ? "streamableHttp" : type;
 	const target =
 		typeof transport?.url === "string"
 			? transport.url
 			: typeof record.url === "string"
 				? record.url
 				: "";
-	return `${type} ${target}`;
+	return `${canonicalType} ${target}`;
+}
+
+function isMetadataRecord(value: unknown): boolean {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 export function readMcpServersResponse(): JsonRecord {
@@ -154,7 +159,11 @@ export function upsertMcpServer(input: JsonRecord): JsonRecord {
 					},
 					disabled: input.disabled === true,
 				};
-	if (input.metadata !== undefined) {
+	const clearsMetadata = input.metadata === null;
+	if (input.metadata !== undefined && !clearsMetadata) {
+		if (!isMetadataRecord(input.metadata)) {
+			throw new Error("server metadata must be a JSON object");
+		}
 		next.metadata = input.metadata;
 	}
 	// Hold the cross-process lock across read-modify-write so a concurrent writer
@@ -176,6 +185,9 @@ export function upsertMcpServer(input: JsonRecord): JsonRecord {
 				resolveEndpointIdentity(next)
 			) {
 				delete merged.oauth;
+			}
+			if (clearsMetadata) {
+				delete merged.metadata;
 			}
 			servers[name] = merged;
 		} else {

--- a/apps/cline-hub/src/server/mcp.ts
+++ b/apps/cline-hub/src/server/mcp.ts
@@ -29,7 +29,18 @@ function resolveEndpointIdentity(record: JsonRecord): string {
 			: typeof record.url === "string"
 				? record.url
 				: "";
-	return `${canonicalType} ${target}`;
+	return `${canonicalType} ${canonicalizeUrl(target)}`;
+}
+
+function canonicalizeUrl(value: string): string {
+	if (!value) {
+		return value;
+	}
+	try {
+		return new URL(value).href;
+	} catch {
+		return value;
+	}
 }
 
 function isMetadataRecord(value: unknown): boolean {

--- a/apps/cline-hub/src/webview/src/components/views/settings/mcp-view.tsx
+++ b/apps/cline-hub/src/webview/src/components/views/settings/mcp-view.tsx
@@ -282,8 +282,7 @@ export function McpServersContent() {
 			return acc;
 		}, {});
 		const metadataText = form.metadataText.trim();
-		const metadata =
-			metadataText.length > 0 ? JSON.parse(metadataText) : undefined;
+		const metadata = metadataText.length > 0 ? JSON.parse(metadataText) : null;
 		if (form.transportType === "stdio") {
 			const command = form.command.trim();
 			if (!command) {


### PR DESCRIPTION
### Related Issue

Fixes #12680

### Description

Editing an MCP server in cline-hub wiped every field the edit dialog does not own.
`upsertMcpServer` built a fresh `{ transport, disabled }` object and assigned it over the whole
entry, so `metadata`, `oauth` and `autoApprove` were destroyed on save. `oauth` carries the
client registration and tokens, so a user who had already signed into a remote server was
silently de-authenticated by an unrelated edit.

`setMcpServerDisabled`, in the same file, already merges instead of replacing
(`servers[name] = { ...current, disabled }`). This makes `upsertMcpServer` consistent with it.

@dominiccooney called this out in #12546 ("Worth a separate issue") while unifying MCP timeouts.
It also means the per-server `timeout` that #12546 adds would be wiped by a hub edit; merging
fixes that ahead of it, without touching #12546's files.

#### Non-obvious details

**Flat entries.** `McpHub.addRemoteServer` writes flat records (`{ url, type, disabled,
autoApprove }`, no nested `transport`), and `readMcpServersResponse` falls back per field
(`transport?.args ?? record.args`). A plain `{ ...previous, ...next }` therefore leaves the old
flat `command`/`args`/`env` beside the new nested `transport`, the dialog repopulates from that
mixture, and the next save writes the stale values back into `transport` - resurrecting args and
env the user had just cleared. So the merge explicitly clears the keys the new `transport` owns.

**OAuth across a re-point.** Preserving `oauth` means tokens now survive an edit. If the server
is aimed at a different URL, the bearer issued by the old host would be sent to the new one.
`resolveEndpointIdentity` compares transport type plus URL and drops `oauth` when they differ, so
re-pointing forces re-auth. This mirrors `McpHub.clearOAuthForConnection` on the delete path.
Changing only headers, or a stdio server's command, keeps the tokens.

**Metadata.** `input.metadata` was never read, so the dialog's Metadata box was a no-op. It is
now applied when supplied, and left alone when omitted. The assignment is conditional on purpose:
a bare `metadata: input.metadata` would put an explicit `undefined` into the spread and delete the
stored value.

### Test Procedure

New file `apps/cline-hub/src/server/mcp.test.ts`, seven cases: metadata/oauth survive an edit;
they follow a rename; legacy flat fields are cleared; oauth dropped on a URL change; oauth kept on
the same URL; a supplied metadata edit lands; stdio to sse leaves no command remnant.

All seven fail on main and pass with this change (verified by stashing the production file):

    cd apps/cline-hub && bunx vitest run --config vitest.config.ts src/server/mcp.test.ts
    # with the fix:    Test Files 1 passed (1)  |  Tests 7 passed (7)
    # fix stashed:     Test Files 1 failed (1)  |  Tests 7 failed (7)

    bun -F @cline/cline-hub test        # Test Files 8 passed (8) | Tests 111 passed (111)
    bun -F @cline/cline-hub typecheck   # exit 0
    bun biome check --diagnostic-level=error apps/cline-hub/   # Checked 154 files, no errors

**What did not change:** creating a new server is byte-identical to before (no previous record,
so the original object is stored as-is). `transport` is replaced wholesale, never partially
merged, so a transport-type switch leaves no remnant. Lock scope is untouched - the merge stays
inside the existing `updateMcpSettingsFileSync` callback and the mutator is still pure.

**Considered and rejected:** listing `metadata`/`oauth`/`timeout` explicitly. That re-introduces
the same bug for the next field added, so preserve-by-default with an explicit
transport-owned-key clear is the safer direction.

**Residual, not addressed here:** renaming onto an existing server name still clobbers the target
(pre-existing), and `disabled: input.disabled === true` still force-overwrites when a caller omits
it. Happy to file either separately.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore
-   [x] Tests are passing and code is formatted and linted
-   [x] I have reviewed contributor guidelines

### Screenshots

No visual change is intended.