### PR TITLE
fix(webview): use radiogroup/radio ARIA roles for Plan/Act mode toggle

### DIFF
--- a/apps/vscode/src/test/e2e/README.md
+++ b/apps/vscode/src/test/e2e/README.md
@@ -140,8 +140,8 @@ await sidebar.getByTestId("send-button").click()
 
 #### Mode Switching
 ```typescript
-const actButton = sidebar.getByRole("switch", { name: "Act" })
-const planButton = sidebar.getByRole("switch", { name: "Plan" })
+const actButton = sidebar.getByRole("radio", { name: "Act" })
+const planButton = sidebar.getByRole("radio", { name: "Plan" })
 await actButton.click() // Switch to Plan mode
 ```
 

--- a/apps/vscode/src/test/e2e/chat.test.ts
+++ b/apps/vscode/src/test/e2e/chat.test.ts
@@ -25,8 +25,8 @@ e2e("Chat - can send messages and switch between modes", async ({ helper, sideba
 
 	// Makes sure the act and plan switches are working correctly
 	// Aria-checked state should be true for Act and false for Plan
-	const actButton = sidebar.getByRole("switch", { name: "Act" })
-	const planButton = sidebar.getByRole("switch", { name: "Plan" })
+	const actButton = sidebar.getByRole("radio", { name: "Act" })
+	const planButton = sidebar.getByRole("radio", { name: "Plan" })
 
 	// Act button should be active. It doesn't have c
 	await expect(actButton).toHaveAttribute("aria-checked", "true")

--- a/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1639,7 +1639,12 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 							</p>
 						</TooltipContent>
 						<TooltipTrigger>
-							<SwitchContainer data-testid="mode-switch" disabled={false} onClick={onModeToggle}>
+							<SwitchContainer
+								aria-label="Mode"
+								data-testid="mode-switch"
+								disabled={false}
+								onClick={onModeToggle}
+								role="radiogroup">
 								<Slider isAct={mode === "act"} isPlan={mode === "plan"} />
 								{["Plan", "Act"].map((m) => (
 									<div
@@ -1649,9 +1654,18 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 											mode === m.toLowerCase() ? "text-white" : "text-input-foreground",
 										)}
 										key={m}
+										onBlur={() => setShownTooltipMode(null)}
+										onFocus={() => setShownTooltipMode(m.toLowerCase() === "plan" ? "plan" : "act")}
+										onKeyDown={(e) => {
+											if (e.key === "Enter" || e.key === " ") {
+												e.preventDefault()
+												onModeToggle()
+											}
+										}}
 										onMouseLeave={() => setShownTooltipMode(null)}
 										onMouseOver={() => setShownTooltipMode(m.toLowerCase() === "plan" ? "plan" : "act")}
-										role="switch">
+										role="radio"
+										tabIndex={0}>
 										{m}
 									</div>
 								))}


### PR DESCRIPTION
## What
Fixes #4932. The Plan/Act mode toggle in `ChatTextArea.tsx` was two independent elements each with `role="switch"` and `aria-checked`, so screen readers announced two separate on/off switches instead of one mutually-exclusive selection between Plan and Act. Since Act mode lets the agent edit files directly, not being able to reliably tell which mode is active is a real problem for screen reader users.

## Change
- `SwitchContainer` (the outer clickable container): `role="radiogroup"`, `aria-label="Mode"`.
- Each Plan/Act `<div>`: `role="switch"` → `role="radio"`, keeping the existing `aria-checked={mode === m.toLowerCase()}`.
- The existing `onClick={onModeToggle}` on the container is unchanged and still works correctly. `onModeToggle` already just flips between plan/act based on current state regardless of which side was clicked, so no logic change was needed there.
- Added `tabIndex={0}` + an `onKeyDown` handler (Enter/Space → `onModeToggle()`) so the toggle is actually reachable and operable by keyboard, it wasn't focusable at all before this change.
- Added `onFocus`/`onBlur` mirroring the existing `onMouseOver`/`onMouseLeave` tooltip handlers, so a keyboard user tabbing to the control gets the same tooltip a mouse-hover user does. Caught this via the repo's own `biome check`: once the element became focusable, `lint/a11y/useKeyWithMouseEvents` correctly flagged the mouse-only tooltip trigger as an accessibility gap.

Not changed: `biome check` also suggests these could become native `<input type="radio">` elements (`lint/a11y/useSemanticElements`). That would need a larger restructure of this custom-styled slider toggle (checked-state handling, name grouping, different event model), so I kept the `role="radio"` `<div>` approach the linked issue itself describes as the fix, to keep this PR small and focused.

## Testing
No proto/backend changes. `onModeToggle`/`togglePlanActModeProto` are untouched, only the DOM/ARIA layer changed. Verified:
- `npx @biomejs/biome check` on the file: clean except the one `useSemanticElements` info noted above (info-level, not an error).
- `npx @biomejs/biome format`: no formatting changes needed.
- Grepped the rest of the webview-ui source for `mode-switch` / `role="switch"` / `SwitchContainer`: nothing else references the old markup, so no other tests or code needed updating.
- Manual accessibility check with an actual screen reader wasn't possible in my environment (no VS Code or screen reader available). The ARIA semantics themselves (`radiogroup`/`radio`/`aria-checked`/`aria-label`) follow the standard WAI-ARIA radio-group pattern, but a real screen-reader pass would be a good final check before merge.