### PR TITLE
fix(webview): keep hook-type dropdown menu opaque

### DIFF
--- a/apps/vscode/webview-ui/src/components/cline-rules/NewRuleRow.tsx
+++ b/apps/vscode/webview-ui/src/components/cline-rules/NewRuleRow.tsx
@@ -153,20 +153,21 @@ const NewRuleRow: React.FC<NewRuleRowProps> = ({ isGlobal, ruleType, existingHoo
 	return (
 		<>
 			<div
-				className={cn("mb-2.5 transition-all duration-300 ease-in-out", {
-					"opacity-100": isExpanded,
-					"opacity-70 hover:opacity-100": !isExpanded,
-				})}
+				className="mb-2.5"
 				onClick={() => !isExpanded && ruleType !== "hook" && setIsExpanded(true)}
 				ref={(node) => {
 					componentRef.current = node
 					setDropdownContainer(node)
 				}}>
+				{/* The dimming styles live here rather than on the outer div: the
+				    outer div is the portal container for the hook-type dropdown,
+				    and opacity there would make the dropdown menu translucent. */}
 				<div
 					className={cn(
 						"flex items-center px-2 py-4 rounded bg-input-background transition-all duration-300 ease-in-out h-5",
 						{
-							"shadow-sm": isExpanded,
+							"shadow-sm opacity-100": isExpanded,
+							"opacity-70 hover:opacity-100": !isExpanded,
 						},
 					)}>
 					{ruleType === "hook" ? (


### PR DESCRIPTION
### Related Issue

Follow-up to #12676 (no separate issue).

### Description

#12676 switched the hook-type dropdown in the rules modal to the themed Radix `Select`, portaling its menu into `NewRuleRow`'s outer div so option clicks don't trigger the modal's click-away handler. That outer div also carries the `opacity-70` dimming style for collapsed rows, so the portaled menu inherited 70% opacity and the modal's description text bled through the open menu. The `hover:opacity-100` escape hatch never applies while the menu is open because Radix sets `pointer-events: none` on outside content, which suppresses hover matching.

Fix: move the dimming styles from the outer (portal container) div to the inner row div, which is not an ancestor of the portaled menu. Row appearance and hover behavior are unchanged.

### Test Procedure

- Manually tested in the extension dev host: opened the Customize popup → Hooks tab, opened the "New hook..." dropdown (now fully opaque), selected `PreToolUse` — the popup stays open and the hook row is created.
- Regression-checked the other dropdowns touched by #12676 in the same session: the OpenAI Compatible "Model ID" dropdown (lists fetched models, selection sticks, "Use custom model ID…" reveals the custom field) and the Preferred Language dropdown.
- `webview-ui` vitest suite: 359 tests, all passing.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Before — modal text bleeds through the open menu:

![Before: hook dropdown translucent](https://cursor.com/artifacts/c/art-fea3e6a6-cf20-4b5f-b783-1034a9cfc123)

After — menu is fully opaque:

![After: hook dropdown opaque](https://cursor.com/artifacts/c/art-71fecf8a-d640-4969-9b55-8b26f61ef602)

### Additional Notes

The dropdown is intentionally still portaled into the component (not `document.body`) so clicking options doesn't close the rules modal via its click-away handler; this change only relocates the dimming styles.