### PR TITLE
fix(vscode): ship plugin sandbox bootstrap with the extension bundle

### DIFF
--- a/apps/vscode/esbuild.mjs
+++ b/apps/vscode/esbuild.mjs
@@ -1,4 +1,5 @@
 import fs from "node:fs"
+import { createRequire } from "node:module"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
 import * as esbuild from "esbuild"
@@ -172,6 +173,47 @@ const standaloneConfig = {
 	external: ["vscode", "@grpc/reflection", "grpc-health-check", "better-sqlite3"],
 }
 
+// Plugin sandbox bootstrap. @cline/core loads plugins by spawning a separate
+// node subprocess whose entry it resolves at runtime as
+// `<main bundle dir>/extensions/plugin-sandbox-bootstrap.js`. Bundling
+// @cline/core into extension.js leaves nothing on disk to spawn, so the
+// bootstrap must be emitted as its own file next to the main bundle —
+// otherwise every session silently runs without plugins.
+const pluginSandboxBootstrapEntry = path.resolve(
+	__dirname,
+	"../../sdk/packages/core/dist/extensions/plugin-sandbox-bootstrap.js",
+)
+
+const pluginSandboxBootstrapConfig = {
+	...baseConfig,
+	entryPoints: [pluginSandboxBootstrapEntry],
+	outfile: `${destDir}/extensions/plugin-sandbox-bootstrap.js`,
+	// jiti must stay external (shipped on disk at <destDir>/node_modules/jiti
+	// by copyJitiForPluginSandbox): the sandbox compiles plugin TypeScript
+	// through jiti's babel transform (dist/babel.cjs), which jiti's lazy
+	// loader resolves relative to its real on-disk package files.
+	external: ["jiti"],
+}
+
+function copyJitiForPluginSandbox() {
+	const requireFromCore = createRequire(pluginSandboxBootstrapEntry)
+	const jitiRoot = path.dirname(requireFromCore.resolve("jiti/package.json"))
+	const dest = path.resolve(__dirname, destDir, "node_modules", "jiti")
+	fs.rmSync(dest, { recursive: true, force: true })
+	fs.cpSync(jitiRoot, dest, { recursive: true, dereference: true })
+}
+
+async function buildPluginSandbox() {
+	if (!fs.existsSync(pluginSandboxBootstrapEntry)) {
+		throw new Error(
+			`Plugin sandbox bootstrap not found at ${pluginSandboxBootstrapEntry}. ` +
+				"Build the SDK packages first (bun run build:sdk from the repo root).",
+		)
+	}
+	await esbuild.build(pluginSandboxBootstrapConfig)
+	copyJitiForPluginSandbox()
+}
+
 // E2E build script configuration
 const e2eBuildConfig = {
 	...baseConfig,
@@ -184,6 +226,9 @@ const e2eBuildConfig = {
 
 async function main() {
 	const config = standalone ? standaloneConfig : e2eBuild ? e2eBuildConfig : extensionConfig
+	if (!e2eBuild) {
+		await buildPluginSandbox()
+	}
 	const extensionCtx = await esbuild.context(config)
 	if (watch) {
 		await extensionCtx.watch()


### PR DESCRIPTION
## Problem

Marketplace plugins don't work in the SDK-based VS Code extension: installing a plugin succeeds and it shows under Plugins → Installed, but its tools/commands/hooks never reach the agent. The agent simply doesn't have the plugin's tools:

![Before: installed plugin](https://cursor.com/artifacts/c/art-1d0ca9d2-4b26-4729-b29d-ac9f29d4b54c)

## Root cause

`@cline/core` loads plugins in a sandbox subprocess. `resolveBootstrap()` in `plugin-sandbox.ts` resolves the subprocess entry at runtime as `<main bundle dir>/extensions/plugin-sandbox-bootstrap.js`. The CLI build copies that file next to its binary (`apps/cli/script/build.ts`), but the VS Code esbuild step bundles everything into a single `dist/extension.js` and ships nothing to spawn. The loader then falls back to an inline jiti script, which can't resolve `jiti` (or the non-existent `.ts` bootstrap) from the bundled extension, and the sandbox dies:

```
plugin loading failed; continuing without plugins (plugin-sandbox process exited (code=1):
Error: Cannot find module 'jiti'
Require stack:
- /workspace/[eval]
```

The error is swallowed in `local-runtime-bootstrap.ts` (one Output-channel log line), so every session silently runs with zero plugins while the marketplace UI reports them installed.

## Fix

In `apps/vscode/esbuild.mjs`:

- Bundle `@cline/core`'s built `dist/extensions/plugin-sandbox-bootstrap.js` into a self-contained CJS file at `<destDir>/extensions/plugin-sandbox-bootstrap.js`, which is exactly where `resolveBootstrap()` looks relative to the main bundle.
- Ship `jiti` on disk at `<destDir>/node_modules/jiti`. It must stay external rather than bundled: the sandbox compiles TypeScript plugin entries through jiti's babel transform (`dist/babel.cjs`), which jiti's lazy loader (and core's `loadJitiBabelTransform`) resolve relative to jiti's real package files on disk.

This runs for both the extension (`dist/`) and standalone (`dist-standalone/`) builds, so every packaging path gets it: `compile`, `package`, `ci:build`, watch mode, and the rollout stitch (which copies the whole `dist/` payload). Verified `vsce ls` includes `dist/extensions/plugin-sandbox-bootstrap.js` and `dist/node_modules/jiti/**` in the VSIX.

## Testing

- Reproduced before the fix in the extension dev host: installed "Background Terminal" from the marketplace, agent reported NONE of `start_background_command` / `get_background_command` / `delete_background_command` available; Cline output channel showed the sandbox exit above.
- After the fix: fresh install of "Background Terminal" through the marketplace UI, then a task that uses `start_background_command` and `get_background_command` end-to-end — both tools executed successfully (job started, exit 0 confirmed, proof file written):

![After: plugin installed from marketplace and its tools used successfully in a task](https://cursor.com/artifacts/c/art-eb4266ff-f684-4211-a6b7-526e0fa7ac74)

- Forked the emitted bootstrap directly over IPC (as `SubprocessSandbox` does) and confirmed `initialize` loads the TypeScript plugin through the shipped jiti copy and returns all three tool contributions.
- `bun run lint` and `bun run test:unit` (1005 tests) pass; `bun esbuild.mjs --standalone` emits the same layout in `dist-standalone/`.

## Notes

- The sandbox spawns whatever `node` is on `PATH` (`resolveSubprocessRuntimeExecutable` falls back to bare `node` since the extension host's `process.execPath` is Electron). Machines without node on PATH would still fail to load plugins; that pre-existing behavior is unchanged here and matches how stdio MCP servers already rely on `node`/`npx`.