### PR TITLE
fix(cli): sign Darwin artifacts without dropping Linux smoke tests

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -36,8 +36,145 @@ defaults:
     working-directory: .
 
 jobs:
+  build-darwin:
+    name: Build signed Darwin artifacts
+    if: |
+      github.repository == 'cline/cline' &&
+      github.ref == 'refs/heads/main' &&
+      (
+        (
+          github.event_name == 'workflow_dispatch' &&
+          github.event.inputs.publish_target == 'main' &&
+          github.event.inputs.confirm_publish == 'publish' &&
+          !endsWith(github.actor, '[bot]')
+        ) ||
+        github.event_name == 'schedule' ||
+        (
+          github.event_name == 'workflow_dispatch' &&
+          github.event.inputs.publish_target == 'nightly'
+        )
+      )
+    runs-on: macos-latest
+    outputs:
+      skip: ${{ steps.prepare.outputs.skip }}
+      version: ${{ steps.prepare.outputs.version }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.publish_target == 'main' && github.event.inputs.git_tag || github.sha }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24.x"
+
+      - name: Prepare build version
+        id: prepare
+        env:
+          FORCE_PUBLISH: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force_nightly_publish == 'true' }}
+          TAG: ${{ github.event.inputs.git_tag }}
+          TARGET: ${{ github.event_name == 'schedule' && 'nightly' || github.event.inputs.publish_target }}
+        run: |
+          if [ "$TARGET" = "main" ]; then
+            if [ -z "$TAG" ]; then
+              echo "git_tag is required when publish_target=main"
+              exit 1
+            fi
+            VERSION="${TAG#cli-v}"
+            PACKAGE_VERSION=$(node -p "require('./apps/cli/package.json').version")
+            if [ "$PACKAGE_VERSION" != "$VERSION" ]; then
+              echo "apps/cli/package.json version ${PACKAGE_VERSION} does not match ${TAG}"
+              exit 1
+            fi
+          else
+            if [ "$FORCE_PUBLISH" != "true" ] && [ "$(git rev-list --count HEAD --since='24 hours ago')" -eq 0 ]; then
+              echo "No commits in last 24 hours, skipping publish"
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            BASE_VERSION=$(node -p "require('./apps/cli/package.json').version")
+            VERSION="${BASE_VERSION}-nightly.$(date +%s)"
+          fi
+
+          echo "Building Darwin artifacts for ${VERSION}"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Bun
+        if: steps.prepare.outputs.skip != 'true'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.13"
+
+      - name: Install dependencies
+        if: steps.prepare.outputs.skip != 'true'
+        run: bun install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update nightly package version
+        if: steps.prepare.outputs.skip != 'true' && (github.event_name == 'schedule' || github.event.inputs.publish_target == 'nightly')
+        env:
+          VERSION: ${{ steps.prepare.outputs.version }}
+        run: |
+          node -e '
+            const fs = require("node:fs");
+            const path = "apps/cli/package.json";
+            const pkg = JSON.parse(fs.readFileSync(path, "utf8"));
+            pkg.version = process.env.VERSION;
+            fs.writeFileSync(path, `${JSON.stringify(pkg, null, "\t")}\n`);
+          '
+
+      - name: Build SDK packages
+        if: steps.prepare.outputs.skip != 'true'
+        run: bun run build:sdk
+        env:
+          TELEMETRY_SERVICE_API_KEY: ${{ secrets.TELEMETRY_SERVICE_API_KEY }}
+          ERROR_SERVICE_API_KEY: ${{ secrets.ERROR_SERVICE_API_KEY }}
+          OTEL_TELEMETRY_ENABLED: ${{ secrets.OTEL_TELEMETRY_ENABLED }}
+          OTEL_LOGS_EXPORTER: otlp
+          OTEL_METRICS_EXPORTER: otlp
+          OTEL_EXPORTER_OTLP_PROTOCOL: ${{ secrets.OTEL_EXPORTER_OTLP_PROTOCOL }}
+          OTEL_EXPORTER_OTLP_ENDPOINT: ${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT }}
+          OTEL_EXPORTER_OTLP_HEADERS: ${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }}
+
+      - name: Build and sign Darwin binaries
+        if: steps.prepare.outputs.skip != 'true'
+        run: bun script/build.ts --target-os darwin --install-native-variants --skip-sdk-build
+        working-directory: apps/cli
+        env:
+          TELEMETRY_SERVICE_API_KEY: ${{ secrets.TELEMETRY_SERVICE_API_KEY }}
+          ERROR_SERVICE_API_KEY: ${{ secrets.ERROR_SERVICE_API_KEY }}
+          OTEL_TELEMETRY_ENABLED: ${{ secrets.OTEL_TELEMETRY_ENABLED }}
+          OTEL_LOGS_EXPORTER: otlp
+          OTEL_METRICS_EXPORTER: otlp
+          OTEL_EXPORTER_OTLP_PROTOCOL: ${{ secrets.OTEL_EXPORTER_OTLP_PROTOCOL }}
+          OTEL_EXPORTER_OTLP_ENDPOINT: ${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT }}
+          OTEL_EXPORTER_OTLP_HEADERS: ${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }}
+
+      - name: Archive signed Darwin artifacts
+        if: steps.prepare.outputs.skip != 'true'
+        run: |
+          tar -C apps/cli/dist -czf "$RUNNER_TEMP/cli-darwin.tgz" \
+            cli-darwin-arm64 \
+            cli-darwin-x64
+
+      - name: Upload signed Darwin artifacts
+        if: steps.prepare.outputs.skip != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: cli-darwin-${{ github.run_id }}
+          path: ${{ runner.temp }}/cli-darwin.tgz
+          if-no-files-found: error
+          retention-days: 1
+
   publish-main:
     name: Publish cline
+    needs: build-darwin
     permissions:
       contents: write
       id-token: write
@@ -146,7 +283,7 @@ jobs:
         run: bun run test
 
       - name: Build platform binaries
-        run: bun script/build.ts --install-native-variants --skip-sdk-build
+        run: bun script/build.ts --target-os linux --target-os win32 --install-native-variants --skip-sdk-build
         working-directory: apps/cli
         env:
           TELEMETRY_SERVICE_API_KEY: ${{ secrets.TELEMETRY_SERVICE_API_KEY }}
@@ -157,6 +294,15 @@ jobs:
           OTEL_EXPORTER_OTLP_PROTOCOL: ${{ secrets.OTEL_EXPORTER_OTLP_PROTOCOL }}
           OTEL_EXPORTER_OTLP_ENDPOINT: ${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT }}
           OTEL_EXPORTER_OTLP_HEADERS: ${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }}
+
+      - name: Download signed Darwin artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: cli-darwin-${{ github.run_id }}
+          path: ${{ runner.temp }}/cli-darwin
+
+      - name: Extract signed Darwin artifacts
+        run: tar -C apps/cli/dist -xzf "$RUNNER_TEMP/cli-darwin/cli-darwin.tgz"
 
       - name: Verify build output
         env:
@@ -256,6 +402,7 @@ jobs:
 
   publish-nightly:
     name: Publish cline nightly
+    needs: build-darwin
     permissions:
       contents: read
       id-token: write
@@ -280,21 +427,10 @@ jobs:
       - name: Check for recent commits
         id: check_commits
         env:
-          FORCE_PUBLISH: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force_nightly_publish == 'true' }}
+          SKIP: ${{ needs.build-darwin.outputs.skip }}
         run: |
-          if [ "$FORCE_PUBLISH" = "true" ]; then
-            echo "force_nightly_publish enabled, proceeding with publish"
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [ "$(git rev-list --count HEAD --since='24 hours ago')" -eq 0 ]; then
-            echo "No commits in last 24 hours, skipping publish"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Found recent commits, proceeding with publish"
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
+          echo "skip=${SKIP}" >> "$GITHUB_OUTPUT"
+          echo "Darwin build skip=${SKIP}"
 
       - name: Setup Bun
         if: steps.check_commits.outputs.skip != 'true'
@@ -348,14 +484,10 @@ jobs:
       - name: Generate nightly version
         if: steps.check_commits.outputs.skip != 'true'
         id: version
+        env:
+          VERSION: ${{ needs.build-darwin.outputs.version }}
         run: |
-          BASE_VERSION=$(node -p "require('./apps/cli/package.json').version")
-          TIMESTAMP=$(date +%s)
-          VERSION="${BASE_VERSION}-nightly.${TIMESTAMP}"
-
-          echo "Base version: ${BASE_VERSION}"
           echo "Generated nightly version: ${VERSION}"
-          echo "base_version=${BASE_VERSION}" >> "$GITHUB_OUTPUT"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Update nightly package version
@@ -374,7 +506,7 @@ jobs:
 
       - name: Build platform binaries
         if: steps.check_commits.outputs.skip != 'true'
-        run: bun script/build.ts --install-native-variants --skip-sdk-build
+        run: bun script/build.ts --target-os linux --target-os win32 --install-native-variants --skip-sdk-build
         working-directory: apps/cli
         env:
           TELEMETRY_SERVICE_API_KEY: ${{ secrets.TELEMETRY_SERVICE_API_KEY }}
@@ -385,6 +517,17 @@ jobs:
           OTEL_EXPORTER_OTLP_PROTOCOL: ${{ secrets.OTEL_EXPORTER_OTLP_PROTOCOL }}
           OTEL_EXPORTER_OTLP_ENDPOINT: ${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT }}
           OTEL_EXPORTER_OTLP_HEADERS: ${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }}
+
+      - name: Download signed Darwin artifacts
+        if: steps.check_commits.outputs.skip != 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: cli-darwin-${{ github.run_id }}
+          path: ${{ runner.temp }}/cli-darwin
+
+      - name: Extract signed Darwin artifacts
+        if: steps.check_commits.outputs.skip != 'true'
+        run: tar -C apps/cli/dist -xzf "$RUNNER_TEMP/cli-darwin/cli-darwin.tgz"
 
       - name: Verify build output
         if: steps.check_commits.outputs.skip != 'true'

--- a/apps/cli/DISTRIBUTION.md
+++ b/apps/cli/DISTRIBUTION.md
@@ -204,9 +204,12 @@ Cross-compiles the CLI for all target platforms:
 
 Flags:
 - `--single` -- build only for the current platform (faster for local testing)
+- `--target-os <darwin|linux|win32>` -- build both architectures for one operating system; repeat the flag to select more than one
 - `--install-native-variants` -- allow the script to download all OpenTUI native packages required for cross-platform builds
 - `--skip-install` -- skip re-downloading platform-specific native packages if they're already installed
 - `--skip-sdk-build` -- skip rebuilding SDK packages (if already built)
+
+Darwin binaries are ad-hoc signed and verified after compilation. Building Darwin targets on a non-macOS host fails by default so an invalid binary cannot be published accidentally. Set `CLINE_ALLOW_UNSIGNED_DARWIN_BINARIES=1` only for local cross-builds that will not be published.
 
 ## Publish Script (`script/publish-npm.ts`)
 

--- a/apps/cli/script/build-options.ts
+++ b/apps/cli/script/build-options.ts
@@ -1,16 +1,42 @@
+const BUILD_TARGET_OSES = ["darwin", "linux", "win32"] as const;
+
+type BuildTargetOs = (typeof BUILD_TARGET_OSES)[number];
+
 export interface BuildOptions {
 	single: boolean;
 	skipInstall: boolean;
 	skipSdkBuild: boolean;
 	installNativeVariants: boolean;
+	targetOs: BuildTargetOs[];
 }
 
 export function parseBuildOptions(args: readonly string[]): BuildOptions {
+	const targetOs: BuildTargetOs[] = [];
+	for (let index = 0; index < args.length; index += 1) {
+		if (args[index] !== "--target-os") {
+			continue;
+		}
+
+		const value = args[index + 1];
+		if (
+			!value ||
+			!BUILD_TARGET_OSES.includes(value as (typeof BUILD_TARGET_OSES)[number])
+		) {
+			throw new Error(
+				`--target-os requires one of: ${BUILD_TARGET_OSES.join(", ")}`,
+			);
+		}
+
+		targetOs.push(value as BuildTargetOs);
+		index += 1;
+	}
+
 	return {
 		single: args.includes("--single"),
 		skipInstall: args.includes("--skip-install"),
 		skipSdkBuild: args.includes("--skip-sdk-build"),
 		installNativeVariants: args.includes("--install-native-variants"),
+		targetOs,
 	};
 }
 

--- a/apps/cli/script/build.ts
+++ b/apps/cli/script/build.ts
@@ -65,11 +65,16 @@ const allTargets: {
 	{ os: "win32", arch: "arm64" },
 ];
 
+const requestedTargets =
+	buildOptions.targetOs.length > 0
+		? allTargets.filter((item) => buildOptions.targetOs.includes(item.os))
+		: allTargets;
+
 const targets = buildOptions.single
-	? allTargets.filter(
+	? requestedTargets.filter(
 			(item) => item.os === process.platform && item.arch === process.arch,
 		)
-	: allTargets;
+	: requestedTargets;
 
 const opentuiVersion = pkg.dependencies["@opentui/core"];
 const optionsError = validateBuildOptions({
@@ -222,6 +227,35 @@ async function buildCompiledBinary(input: {
 	await $`rm -rf ${tmpDir}`;
 }
 
+async function signDarwinBinary(input: {
+	os: string;
+	name: string;
+	outfile: string;
+}): Promise<void> {
+	if (input.os !== "darwin") {
+		return;
+	}
+
+	if (process.platform !== "darwin") {
+		if (process.env.CLINE_ALLOW_UNSIGNED_DARWIN_BINARIES === "1") {
+			console.warn(
+				`  Skipping codesign for ${input.name}: host platform is ${process.platform}`,
+			);
+			return;
+		}
+
+		throw new Error(
+			`Darwin CLI binaries must be signed on macOS after compilation (${input.name}). ` +
+				"Run this build on macOS, exclude Darwin with --target-os, or set " +
+				"CLINE_ALLOW_UNSIGNED_DARWIN_BINARIES=1 for a local unsigned cross-build.",
+		);
+	}
+
+	console.log(`  Codesign: ${input.outfile}`);
+	await $`codesign --force --sign - ${input.outfile}`;
+	await $`codesign --verify --strict --verbose=2 ${input.outfile}`;
+}
+
 for (const item of targets) {
 	// npm treats "win32" specially in os field, but for package naming use "windows"
 	const displayOs = item.os === "win32" ? "windows" : item.os;
@@ -237,6 +271,7 @@ for (const item of targets) {
 	const outfile = join(outDir, binaryName);
 
 	await buildCompiledBinary({ bunTarget, dirName, outfile });
+	await signDarwinBinary({ os: item.os, name, outfile });
 
 	// Smoke test: only run on current platform
 	if (item.os === process.platform && item.arch === process.arch) {

--- a/apps/cli/src/commands/build-options.test.ts
+++ b/apps/cli/src/commands/build-options.test.ts
@@ -54,4 +54,24 @@ describe("CLI build options", () => {
 			}),
 		).toBeUndefined();
 	});
+
+	it("filters builds to one or more requested operating systems", () => {
+		const options = parseBuildOptions([
+			"--target-os",
+			"linux",
+			"--target-os",
+			"win32",
+		]);
+
+		expect(options.targetOs).toEqual(["linux", "win32"]);
+	});
+
+	it("rejects missing or unsupported target operating systems", () => {
+		expect(() => parseBuildOptions(["--target-os"])).toThrow(
+			"--target-os requires one of",
+		);
+		expect(() => parseBuildOptions(["--target-os", "android"])).toThrow(
+			"--target-os requires one of",
+		);
+	});
 });


### PR DESCRIPTION
### Related Issue

Fixes #12042.

Related draft: #11997. That PR identified the correct post-compile signing fix, but its current workflow moves all publishing to macOS and received a changes request because the exact Linux artifact would no longer be smoke-tested on Linux. This PR keeps the core signing fix and implements the requested split-artifact release flow.

### Reproduction

Verified on:

- macOS 27.0, build `26A5378j`
- Darwin kernel 27.0.0
- Apple Silicon / arm64
- npm global installation under `/opt/homebrew/lib/node_modules/cline`

The failure recurred after updates to Cline CLI 3.0.42, 3.0.46, and 3.0.47:

```text
cline --version
# SIGKILL, exit status 137
```

Both the installed platform binary and cached `bin/.cline` fail `codesign --verify --strict` with:

```text
invalid signature (code or signature have been modified)
```

I also downloaded the official `@cline/cli-darwin-arm64@3.0.47` npm tarball. Its unmodified binary has SHA-256:

```text
abf53737d84ab29638ff2d54b3406a6360bbc83b75a1312168bb58bf9c49baaf
```

The tarball binary fails strict signature validation and is killed with exit 137 before installation. Re-signing that exact binary with `codesign --force --sign -` makes strict validation pass and `--version` prints `3.0.47` with exit 0.

The temporary user-side workaround has been to re-sign both:

```text
/opt/homebrew/lib/node_modules/cline/bin/.cline
/opt/homebrew/lib/node_modules/cline/node_modules/@cline/cli-darwin-arm64/bin/cline
```

after every update. Both paths matter because postinstall creates a hard link, while `codesign --force` can replace one inode and leave the other path pointing at the old invalid binary.

### Root Cause

Bun's compiled Darwin executable has a linker-generated ad-hoc signature, but the final embedded binary bytes do not match that signature. macOS 27's AMFI enforcement rejects the invalid executable page and sends SIGKILL.

The permanent fix must happen in Cline's release pipeline after Bun has produced the final executable and before npm packaging.

### What Changed

- Add repeatable `--target-os <darwin|linux|win32>` filtering to the CLI build.
- Re-sign each final Darwin executable on macOS immediately after Bun compilation.
- Gate Darwin builds with `codesign --verify --strict --verbose=2`.
- Fail Darwin builds on non-macOS hosts unless `CLINE_ALLOW_UNSIGNED_DARWIN_BINARIES=1` is explicitly set for a non-publishing local cross-build.
- Build and sign only Darwin artifacts on `macos-latest`.
- Archive the complete Darwin package directories before artifact upload so executable modes and signed bytes are preserved.
- Keep Linux and Windows production builds in the Ubuntu publisher, preserving the existing exact `linux-x64` smoke test.
- Download and assemble the signed Darwin artifacts without rebuilding or modifying their binaries.
- Generate the nightly version once and pass it to both jobs so all six platform packages remain version-identical.
- Document the new target filter and signing behavior.

### Why the Artifact Split Matters

Running the entire publisher on macOS fixes Darwin signing but silently drops the existing Linux runtime gate and increases daily nightly runner cost. The split keeps macOS work limited to the two Darwin binaries while the exact Linux artifact that reaches npm is still executed on Ubuntu.

### Validation

- `bunx --bun vitest@4.0.18 run apps/cli/src/commands/build-options.test.ts --config /tmp/cline-vitest.config.mjs --root . --environment node --pool forks --maxWorkers 1 --no-file-parallelism`
  - 5 tests passed
- `bunx --bun @biomejs/biome@2.4.5 check --write ...`
  - Passed, no fixes required
- `actionlint 1.7.12 -ignore 'softprops/action-gh-release@v1' .github/workflows/cli-publish.yml`
  - Passed
  - The ignored `softprops/action-gh-release@v1` warning is pre-existing and unrelated
- `bun build apps/cli/script/build.ts --target=bun`
  - Passed
- `git diff --check`
  - Passed
- Signed-artifact round trip:
  - archived a repaired 3.0.47 Darwin executable
  - extracted it through the same tar flow
  - applied the publisher's permission normalization
  - strict signature verification still passed
  - `--version` returned 3.0.47 with exit 0

A full monorepo build was not run from the sparse checkout. The draft is intended to collect CI feedback on the release-job split before being marked ready.

### Type of Change

- [x] Bug fix
- [x] Workflow change
- [x] Tests
- [x] Documentation

### Pre-flight Checklist

- [x] Changes are limited to the CLI Darwin signing/release path
- [x] Focused tests, formatting, workflow lint, and script compilation pass
- [x] Existing issue and prior draft PR are linked
- [ ] Full monorepo test suite passes in CI
