### PR TITLE
fix(openai-compatible): persist model-config toggles and actually apply R1 messages format

### DIFF
--- a/apps/vscode/webview-ui/src/components/settings/providers/OpenAICompatible.test.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/OpenAICompatible.test.tsx
@@ -450,6 +450,93 @@ describe("OpenAICompatibleProvider", () => {
 		})
 	})
 
+	it("persists unchecking Supports Images as an explicit false override", async () => {
+		setCommittedSelection({ supportsVision: true }, { supportsImages: true })
+		renderProvider()
+		await act(async () => {})
+		fireEvent.click(screen.getByText("Model Configuration"))
+		expect(screen.getByRole("checkbox", { name: "Supports Images" })).toBeChecked()
+
+		fireEvent.click(screen.getByRole("checkbox", { name: "Supports Images" }))
+
+		expect(mocks.commitSelection).toHaveBeenCalledWith("act", {
+			providerId: "custom-openai",
+			modelId: "custom-model",
+			overrides: { supportsVision: false },
+		})
+	})
+
+	it("persists unchecking the R1 checkbox as an explicit false override", async () => {
+		setCommittedSelection({ isR1FormatRequired: true })
+		renderProvider()
+		await act(async () => {})
+		fireEvent.click(screen.getByText("Model Configuration"))
+		expect(screen.getByRole("checkbox", { name: "Enable R1 messages format" })).toBeChecked()
+
+		fireEvent.click(screen.getByRole("checkbox", { name: "Enable R1 messages format" }))
+
+		expect(mocks.commitSelection).toHaveBeenCalledWith("act", {
+			providerId: "custom-openai",
+			modelId: "custom-model",
+			overrides: { isR1FormatRequired: false },
+		})
+	})
+
+	// The FAST-based VSCodeCheckbox fires a synthetic `change` whenever React
+	// re-syncs its `checked` property against the DOM. If a re-render during
+	// the commit round-trip painted the stale resolved value, that synthetic
+	// change would re-commit the stale value over the user's edit. These
+	// tests pin the invariant that breaks the loop: while a checkbox commit
+	// is in flight, re-renders keep showing the user's pending value.
+	it("keeps Supports Images rendering the pending uncheck across a stale re-render", async () => {
+		const commit = deferred<void>()
+		mocks.commitSelection.mockReturnValueOnce(commit.promise)
+		setCommittedSelection({ supportsVision: true }, { supportsImages: true })
+		const view = render(<OpenAICompatibleProvider currentMode="act" providerId="custom-openai" showModelOptions={false} />)
+		await act(async () => {})
+		fireEvent.click(screen.getByText("Model Configuration"))
+
+		fireEvent.click(screen.getByRole("checkbox", { name: "Supports Images" }))
+		expect(mocks.commitSelection).toHaveBeenCalledWith("act", {
+			providerId: "custom-openai",
+			modelId: "custom-model",
+			overrides: { supportsVision: false },
+		})
+
+		// A state push re-renders with the same stale committed snapshot
+		// (supportsVision still true) while the commit is outstanding.
+		view.rerender(<OpenAICompatibleProvider currentMode="act" providerId="custom-openai" showModelOptions={false} />)
+		expect(screen.getByRole("checkbox", { name: "Supports Images" })).not.toBeChecked()
+
+		await act(async () => {
+			commit.resolve(undefined)
+		})
+	})
+
+	it("keeps the R1 checkbox rendering the pending check across a stale re-render", async () => {
+		const commit = deferred<void>()
+		mocks.commitSelection.mockReturnValueOnce(commit.promise)
+		const view = renderProvider()
+		await act(async () => {})
+		fireEvent.click(screen.getByText("Model Configuration"))
+
+		fireEvent.click(screen.getByRole("checkbox", { name: "Enable R1 messages format" }))
+		expect(mocks.commitSelection).toHaveBeenCalledWith("act", {
+			providerId: "custom-openai",
+			modelId: "custom-model",
+			overrides: { isR1FormatRequired: true },
+		})
+
+		// A state push re-renders with the same stale committed snapshot
+		// (no R1 override) while the commit is outstanding.
+		view.rerender(<OpenAICompatibleProvider currentMode="act" providerId="custom-openai" showModelOptions={false} />)
+		expect(screen.getByRole("checkbox", { name: "Enable R1 messages format" })).toBeChecked()
+
+		await act(async () => {
+			commit.resolve(undefined)
+		})
+	})
+
 	it("restores the R1 checkbox from authored override readback", async () => {
 		setCommittedSelection({ isR1FormatRequired: true })
 		renderProvider()

--- a/apps/vscode/webview-ui/src/components/settings/providers/OpenAICompatible.test.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/OpenAICompatible.test.tsx
@@ -537,6 +537,31 @@ describe("OpenAICompatibleProvider", () => {
 		})
 	})
 
+	it("renders newly committed checkbox overrides when no local commit is pending", async () => {
+		setCommittedSelection(
+			{ isR1FormatRequired: false, supportsVision: false },
+			{ apiFormat: ApiFormat.OPENAI_RESPONSES, supportsImages: false },
+		)
+		const view = renderProvider()
+		await act(async () => {})
+		fireEvent.click(screen.getByText("Model Configuration"))
+		expect(screen.getByRole("checkbox", { name: "Supports Images" })).not.toBeChecked()
+		expect(screen.getByRole("checkbox", { name: "Enable R1 messages format" })).not.toBeChecked()
+
+		// Simulate a committed-state update from another settings surface.
+		// With no local commit pending, the committed snapshot must win over
+		// the matching (but now stale) ref entry from the preceding render.
+		setCommittedSelection(
+			{ isR1FormatRequired: true, supportsVision: true },
+			{ apiFormat: ApiFormat.R1_CHAT, supportsImages: true },
+		)
+		view.rerender(<OpenAICompatibleProvider currentMode="act" providerId="custom-openai" showModelOptions={false} />)
+
+		expect(screen.getByRole("checkbox", { name: "Supports Images" })).toBeChecked()
+		expect(screen.getByRole("checkbox", { name: "Enable R1 messages format" })).toBeChecked()
+		expect(mocks.commitSelection).not.toHaveBeenCalled()
+	})
+
 	it("restores the R1 checkbox from authored override readback", async () => {
 		setCommittedSelection({ isR1FormatRequired: true })
 		renderProvider()

--- a/apps/vscode/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
@@ -163,8 +163,9 @@ export const OpenAICompatibleProvider = ({
 		[commitOpenAiSelection, currentMode, selectedModelId],
 	)
 
-	// Checkbox-backed overrides must render from the pending accumulator
-	// (the user's latest intent), not from the resolved/committed snapshot.
+	// Checkbox-backed overrides render from the pending accumulator only
+	// while this mode has a local commit in flight. Otherwise the committed
+	// snapshot is authoritative (and may have changed externally).
 	// The FAST-based VSCodeCheckbox emits a synthetic `change` whenever its
 	// `checked` property changes — including programmatic React re-syncs
 	// (FormAssociatedCheckbox.checkedChanged fires $emit("change") for any
@@ -175,7 +176,9 @@ export const OpenAICompatibleProvider = ({
 	// guard against the same echo class in updateNumericModelOverride.
 	const displayedOverrides = (() => {
 		const pending = selectedModelOverridesRef.current[currentMode]
-		return pending.modelId === selectedModelId ? pending.overrides : selectedModelOverrides
+		return pendingCommitsRef.current[currentMode] > 0 && pending.modelId === selectedModelId
+			? pending.overrides
+			: selectedModelOverrides
 	})()
 
 	const updateNumericModelOverride = useCallback(

--- a/apps/vscode/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
@@ -163,6 +163,21 @@ export const OpenAICompatibleProvider = ({
 		[commitOpenAiSelection, currentMode, selectedModelId],
 	)
 
+	// Checkbox-backed overrides must render from the pending accumulator
+	// (the user's latest intent), not from the resolved/committed snapshot.
+	// The FAST-based VSCodeCheckbox emits a synthetic `change` whenever its
+	// `checked` property changes — including programmatic React re-syncs
+	// (FormAssociatedCheckbox.checkedChanged fires $emit("change") for any
+	// prev !== undefined transition). Rendering from a stale resolved
+	// snapshot during the commit round-trip would flip the element back,
+	// fire that synthetic change, and re-commit the stale value over the
+	// user's edit (the toggle then appears to "not persist"). Text fields
+	// guard against the same echo class in updateNumericModelOverride.
+	const displayedOverrides = (() => {
+		const pending = selectedModelOverridesRef.current[currentMode]
+		return pending.modelId === selectedModelId ? pending.overrides : selectedModelOverrides
+	})()
+
 	const updateNumericModelOverride = useCallback(
 		(key: NumericModelOverrideKey, label: string, value: string) => {
 			const parsed = parseOptionalFiniteNumber(value)
@@ -555,13 +570,13 @@ export const OpenAICompatibleProvider = ({
 			{modelConfigurationSelected && (
 				<>
 					<VSCodeCheckbox
-						checked={!!openAiModelInfo?.supportsImages}
+						checked={displayedOverrides.supportsVision ?? !!openAiModelInfo?.supportsImages}
 						onChange={(e: any) => updateModelOverride("supportsVision", e.target.checked === true)}>
 						Supports Images
 					</VSCodeCheckbox>
 
 					<VSCodeCheckbox
-						checked={selectedModelOverrides.isR1FormatRequired ?? openAiModelInfo.apiFormat === ApiFormat.R1_CHAT}
+						checked={displayedOverrides.isR1FormatRequired ?? openAiModelInfo.apiFormat === ApiFormat.R1_CHAT}
 						onChange={(e: any) => updateModelOverride("isR1FormatRequired", e.target.checked === true)}>
 						Enable R1 messages format
 					</VSCodeCheckbox>

--- a/sdk/packages/core/src/services/llms/handler-factory.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.ts
@@ -175,6 +175,10 @@ function toGatewayConfiguredModel(
 			pricing: model.pricing,
 			status: model.status,
 			releaseDate: model.releaseDate,
+			// Carry the wire-format selector so provider modules can apply
+			// format-specific request shaping (e.g. the OpenAI-compatible R1
+			// message transform) from `context.model.metadata`.
+			apiFormat: model.apiFormat,
 		},
 	};
 }

--- a/sdk/packages/llms/src/providers/middleware/r1-format.test.ts
+++ b/sdk/packages/llms/src/providers/middleware/r1-format.test.ts
@@ -1,0 +1,134 @@
+import type {
+	LanguageModelV3CallOptions,
+	LanguageModelV3Message,
+} from "@ai-sdk/provider";
+import { describe, expect, it } from "vitest";
+import { convertPromptToR1, r1FormatMiddleware } from "./r1-format";
+
+describe("convertPromptToR1", () => {
+	it("demotes the system message to the first user turn", () => {
+		const prompt: LanguageModelV3Message[] = [
+			{ role: "system", content: "you are helpful" },
+			{ role: "user", content: [{ type: "text", text: "hi" }] },
+		];
+
+		const out = convertPromptToR1(prompt);
+
+		expect(out.mutated).toBe(true);
+		expect(out.prompt).toEqual([
+			// system text and the first user turn merge into one user message,
+			// newline-joined.
+			{ role: "user", content: [{ type: "text", text: "you are helpful\nhi" }] },
+		]);
+	});
+
+	it("merges consecutive same-role turns and keeps strict alternation", () => {
+		const prompt: LanguageModelV3Message[] = [
+			{ role: "system", content: "sys" },
+			{ role: "user", content: [{ type: "text", text: "u1" }] },
+			{ role: "assistant", content: [{ type: "text", text: "a1" }] },
+			{ role: "assistant", content: [{ type: "text", text: "a2" }] },
+			{ role: "user", content: [{ type: "text", text: "u2" }] },
+		];
+
+		const out = convertPromptToR1(prompt);
+
+		expect(out.prompt).toEqual([
+			{ role: "user", content: [{ type: "text", text: "sys\nu1" }] },
+			{ role: "assistant", content: [{ type: "text", text: "a1\na2" }] },
+			{ role: "user", content: [{ type: "text", text: "u2" }] },
+		]);
+		// Result strictly alternates and carries no system role.
+		expect(out.prompt.map((m) => m.role)).toEqual(["user", "assistant", "user"]);
+		expect(out.prompt.some((m) => m.role === "system")).toBe(false);
+	});
+
+	it("preserves image/file parts while coalescing only adjacent text", () => {
+		const prompt: LanguageModelV3Message[] = [
+			{ role: "system", content: "sys" },
+			{
+				role: "user",
+				content: [
+					{ type: "text", text: "look" },
+					{ type: "file", data: "https://img/x.png", mediaType: "image/png" },
+				],
+			},
+		];
+
+		const out = convertPromptToR1(prompt);
+
+		expect(out.prompt).toEqual([
+			{
+				role: "user",
+				content: [
+					{ type: "text", text: "sys\nlook" },
+					{ type: "file", data: "https://img/x.png", mediaType: "image/png" },
+				],
+			},
+		]);
+	});
+
+	it("leaves an already-R1-shaped prompt unmutated", () => {
+		const prompt: LanguageModelV3Message[] = [
+			{ role: "user", content: [{ type: "text", text: "u1" }] },
+			{ role: "assistant", content: [{ type: "text", text: "a1" }] },
+			{ role: "user", content: [{ type: "text", text: "u2" }] },
+		];
+
+		const out = convertPromptToR1(prompt);
+
+		expect(out.mutated).toBe(false);
+		expect(out.prompt).toEqual(prompt);
+	});
+
+	it("does not mutate the caller's message objects", () => {
+		const firstUser: LanguageModelV3Message = {
+			role: "user",
+			content: [{ type: "text", text: "u1" }],
+		};
+		const prompt: LanguageModelV3Message[] = [
+			firstUser,
+			{ role: "user", content: [{ type: "text", text: "u2" }] },
+		];
+
+		convertPromptToR1(prompt);
+
+		// The original first-user message must be untouched by the merge.
+		expect(firstUser.content).toEqual([{ type: "text", text: "u1" }]);
+	});
+});
+
+describe("r1FormatMiddleware", () => {
+	it("returns the same params reference when no reshape is needed", async () => {
+		const params: LanguageModelV3CallOptions = {
+			prompt: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+		};
+
+		const out = await r1FormatMiddleware.transformParams?.({
+			type: "stream",
+			params,
+			model: undefined as never,
+		});
+
+		expect(out).toBe(params);
+	});
+
+	it("returns reshaped params when a system message is present", async () => {
+		const params: LanguageModelV3CallOptions = {
+			prompt: [
+				{ role: "system", content: "sys" },
+				{ role: "user", content: [{ type: "text", text: "hi" }] },
+			],
+		};
+
+		const out = await r1FormatMiddleware.transformParams?.({
+			type: "stream",
+			params,
+			model: undefined as never,
+		});
+
+		expect(out?.prompt).toEqual([
+			{ role: "user", content: [{ type: "text", text: "sys\nhi" }] },
+		]);
+	});
+});

--- a/sdk/packages/llms/src/providers/middleware/r1-format.ts
+++ b/sdk/packages/llms/src/providers/middleware/r1-format.ts
@@ -1,0 +1,119 @@
+// LanguageModelV3 middleware that reshapes the prompt into the "R1" chat
+// format required by DeepSeek-R1-style endpoints (and self-hosted R1-distill
+// chat templates served via vLLM / llama.cpp / SGLang). Those backends reject
+// a `role:"system"` message and reject back-to-back same-role messages,
+// returning a hard 400. This middleware:
+//
+//   1. Demotes the leading `role:"system"` message to a `role:"user"` message
+//      (its text becomes the first user turn).
+//   2. Merges consecutive same-role user/assistant messages into one, so the
+//      outgoing conversation strictly alternates user/assistant.
+//
+// It operates on the typed `LanguageModelV3Prompt` produced by the AI SDK
+// (after `streamText` folds the `system` option into a system message and
+// before the `@ai-sdk/openai-compatible` chat-messages converter serializes
+// the wire body). It is a direct port of classic Cline's `convertToR1Format`
+// (`src/core/api/transform/r1-format.ts` on origin/legacy-extension), which
+// prepended the system prompt as a user message and merged consecutive
+// same-role turns.
+//
+// Scope: endpoints that need R1 format are simple chat/completions endpoints
+// that do not do native tool calling, so this transform intentionally only
+// merges `user` and `assistant` text/file content. `tool`-role messages and
+// assistant messages carrying tool calls are passed through unchanged (they
+// break strict alternation, but only occur on native-tool paths that never
+// need R1 format). Applied only when the resolved model's `apiFormat` is
+// `"r1"`; see `createOpenAICompatibleProviderModule`.
+
+import type {
+	LanguageModelV3CallOptions,
+	LanguageModelV3FilePart,
+	LanguageModelV3Message,
+	LanguageModelV3Middleware,
+	LanguageModelV3TextPart,
+} from "@ai-sdk/provider";
+
+type UserContentPart = LanguageModelV3TextPart | LanguageModelV3FilePart;
+
+/**
+ * Collapse adjacent text parts into a single newline-joined text part, leaving
+ * non-text parts (images/files) untouched and in order. Matches classic
+ * Cline's newline joining of merged R1 text so the wire body carries one text
+ * block per turn rather than many fragments.
+ */
+function coalesceAdjacentText(parts: readonly UserContentPart[]): UserContentPart[] {
+	const out: UserContentPart[] = [];
+	for (const part of parts) {
+		const prev = out[out.length - 1];
+		if (part.type === "text" && prev?.type === "text") {
+			out[out.length - 1] = { ...prev, text: `${prev.text}\n${part.text}` };
+		} else {
+			out.push(part);
+		}
+	}
+	return out;
+}
+
+/**
+ * Reshape a prompt into R1 format: system demoted to user, consecutive
+ * same-role user/assistant turns merged. Returns the (possibly new) prompt and
+ * a `mutated` flag for test/observation use. Never mutates the input messages.
+ */
+export function convertPromptToR1(prompt: readonly LanguageModelV3Message[]): {
+	prompt: LanguageModelV3Message[];
+	mutated: boolean;
+} {
+	const merged: LanguageModelV3Message[] = [];
+	let mutated = false;
+
+	for (const original of prompt) {
+		// Demote system -> user. Everything else keeps its role.
+		const message: LanguageModelV3Message =
+			original.role === "system"
+				? { role: "user", content: [{ type: "text", text: original.content }] }
+				: original;
+		if (original.role === "system") {
+			mutated = true;
+		}
+
+		const last = merged[merged.length - 1];
+		const mergeable = message.role === "user" || message.role === "assistant";
+		if (last && last.role === message.role && mergeable) {
+			// Same role as the previous merged turn: concatenate content. Only
+			// user/assistant reach here; their content arrays are compatible
+			// enough to concatenate and re-coalesce adjacent text.
+			const combined = [
+				...(last.content as UserContentPart[]),
+				...(message.content as UserContentPart[]),
+			];
+			last.content = coalesceAdjacentText(combined) as typeof last.content;
+			mutated = true;
+			continue;
+		}
+
+		// New turn: push a shallow clone with a fresh content array so we never
+		// mutate the caller's message objects when a later turn merges into it.
+		merged.push({ ...message, content: [...message.content] } as LanguageModelV3Message);
+	}
+
+	return { prompt: merged, mutated };
+}
+
+/**
+ * Apply via
+ * `wrapLanguageModel({ model, middleware: r1FormatMiddleware })`
+ * for OpenAI-compatible models whose resolved `apiFormat` is `"r1"`.
+ */
+export const r1FormatMiddleware: LanguageModelV3Middleware = {
+	specificationVersion: "v3",
+	transformParams: async ({ params }) => {
+		const { prompt: newPrompt, mutated } = convertPromptToR1(params.prompt);
+		if (!mutated) {
+			return params;
+		}
+		return {
+			...params,
+			prompt: newPrompt,
+		} satisfies LanguageModelV3CallOptions;
+	},
+};

--- a/sdk/packages/llms/src/providers/vendors/openai-compatible.ts
+++ b/sdk/packages/llms/src/providers/vendors/openai-compatible.ts
@@ -6,6 +6,7 @@ import type {
 } from "@cline/shared";
 import { wrapLanguageModel } from "ai";
 import { ensureFetch, resolveApiKey } from "../http";
+import { r1FormatMiddleware } from "../middleware/r1-format";
 import { splitToolImagesMiddleware } from "../middleware/split-tool-images";
 import type { ProviderFactoryResult } from "./types";
 
@@ -129,6 +130,17 @@ export async function createOpenAICompatibleProviderModule(
 		...(providerFetch ? { fetch: providerFetch } : {}),
 		includeUsage: true,
 	} as never);
+	// DeepSeek-R1-style endpoints (and self-hosted R1-distill chat templates)
+	// reject a system role and non-alternating messages. When the resolved
+	// model declares `apiFormat: "r1"`, prepend the R1 reshape middleware so
+	// the outgoing prompt has its system message demoted to user and
+	// consecutive same-role turns merged. Stacks before splitToolImages; both
+	// are prompt `transformParams` transforms and order is not significant
+	// here (R1 endpoints don't carry multimodal tool results).
+	const useR1Format = context.model.metadata?.apiFormat === "r1";
+	const middleware = useR1Format
+		? [r1FormatMiddleware, splitToolImagesMiddleware]
+		: splitToolImagesMiddleware;
 	return {
 		// Wrap each constructed model with `splitToolImagesMiddleware` so
 		// `role:"tool"` messages whose `output.type === 'content'` carries
@@ -146,7 +158,7 @@ export async function createOpenAICompatibleProviderModule(
 		model: (modelId) =>
 			wrapLanguageModel({
 				model: provider(modelId) as LanguageModelV3,
-				middleware: splitToolImagesMiddleware,
+				middleware,
 			}),
 	};
 }


### PR DESCRIPTION
### Related Issue

Found during a live QA parity sweep of the OpenAI-Compatible provider (`openai`) comparing the SDK rewrite (`main`) against the shipping `legacy-extension` build. Two provider-specific regressions where behavior that worked on legacy is broken on `main`.

### Description

Two related bugs in the OpenAI-Compatible provider's Model Configuration, both affecting behavior that works on `legacy-extension` but not on `main`.

**1. Boolean model-config toggles don't persist (`Supports images`, `Enable R1 messages format`).**
Unchecking either toggle reverts on settings reopen; `~/.cline/data/settings/models.json` keeps the old value. Numeric fields (context window, prices) persisted fine, which is why this went unnoticed.

Root cause: the FAST-based `VSCodeCheckbox` emits a synthetic `change` event whenever React re-syncs its `checked` property (`FormAssociatedCheckbox.checkedChanged` calls `$emit("change")` on any `prev !== undefined` transition). Both checkboxes rendered `checked` from the resolved/committed model-info snapshot. During the commit round-trip a re-render painted the stale value, flipped the DOM element back, and the synthetic `change` re-committed the stale value over the user's edit. Verified live with instrumentation: a single toggle produced two `commitModelSelection` RPCs 62 ms apart — the first with the user's value, the second with the stale one.

Fix: render both checkboxes from the pending-override accumulator (the user's latest intent, updated synchronously in the change handler) instead of the resolved snapshot, so re-renders can never flip the DOM against the user and no spurious synthetic change fires. This mirrors the anti-echo guard the numeric fields already use in `updateNumericModelOverride`.

**2. `Enable R1 messages format` was a no-op on the SDK path.**
The toggle was fully plumbed (`isR1FormatRequired` → `apiFormat: "r1"` on the SDK model info) but nothing in `@cline/llms` consumed it. The OpenAI-compatible request path always sent a `system` role and non-alternating messages, so DeepSeek-R1-style endpoints and self-hosted R1-distill chat templates that reject those would 400 — on legacy the same toggle applied `convertToR1Format` and worked.

Fix: add `r1FormatMiddleware`, a `LanguageModelV3` `transformParams` middleware that demotes the leading `system` message to the first `user` turn and merges consecutive same-role user/assistant turns, mirroring legacy's `convertToR1Format`. It is applied in the OpenAI-compatible vendor factory only when the resolved model's `apiFormat` is `"r1"`, stacked ahead of the existing `splitToolImages` middleware. `apiFormat` is carried through the gateway model metadata (`toGatewayConfiguredModel`) so the vendor factory can read it from `context.model.metadata`. The middleware runs on the typed prompt after `streamText` folds the `system` option into a system message and before the wire converter, so it reshapes the exact request that goes on the wire.

This keeps the split explicit per `@cline/llms` guidance: model fact (`apiFormat: "r1"`) → vendor-factory decision → wire-format middleware.

### Test Procedure

Automated:
- New unit tests for `convertPromptToR1` / `r1FormatMiddleware` (system demotion, same-role merge with strict alternation preserved, image/file parts kept while adjacent text is coalesced, no-op on already-R1 prompts, caller objects not mutated): 7 passing.
- New webview tests pinning the persistence invariant: unchecking `Supports images` / `Enable R1 messages format` commits an explicit `false`, and a stale re-render mid-commit keeps rendering the user's pending value. Full `OpenAICompatible` suite: 29 passing.
- `@cline/llms` full suite (447), `@cline/core` unit (only the pre-existing cloud-env git `insteadOf` artifact fails, unrelated), `apps/vscode` host unit (1005), and typechecks across `@cline/llms`, `@cline/core`, and the VS Code host + webview all pass.

Manual (built the VSIX, live OpenRouter endpoint):
- Persistence: flipping `Supports images` and `Enable R1 messages format`, closing and reopening settings — both now retain the flipped state (previously reverted).
- R1 wire proof: routed the provider base URL through a local logging reverse-proxy in front of OpenRouter and ran an identical short task with the toggle off then on. The captured outbound bodies for `deepseek/deepseek-r1-0528`:

```
R1 OFF -> roles=["system","user"]
R1 ON  -> roles=["user"]      (system prompt merged into the first user turn)
```

With R1 on, the first user message's content begins with the full system prompt ("You are Cline, an AI coding agent…"), confirming the reshape reaches the wire. Both tasks returned normal replies.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Both toggles retained their state after closing and reopening settings (base URL points at the QA logging proxy; API key masked):

![Supports Images and Enable R1 messages format both persisted checked after reopen](https://cursor.com/artifacts/c/art-2b4e310a-4805-4d9e-b903-469721d659a2)

### Additional Notes

Scope note on the R1 middleware: endpoints that require R1 format are simple chat/completions endpoints that do not do native tool calling, so the transform intentionally only merges `user`/`assistant` text/file content and passes `tool`-role messages and assistant tool-call messages through unchanged (same scope as legacy's `convertToR1Format`). The persistence fix's root cause (default-true resolution for unknown custom models) is why `supportsImages` in particular snapped back; rendering from the pending accumulator addresses the general class for every boolean override on this screen.