### PR TITLE
Publish @cline/ui nightly builds automatically

### DIFF
--- a/.cline/skills/publish-ui/SKILL.md
+++ b/.cline/skills/publish-ui/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: publish-ui
-description: Prepare, validate, and publish standalone @cline/ui npm releases. Use when bumping the UI package version, publishing latest or next through ui-publish.yml, checking UI release readiness, or completing the one-time npm trusted-publishing bootstrap.
+description: Prepare, validate, and publish standalone @cline/ui npm releases. Use when bumping the UI package version, publishing latest, next, or nightly through ui-publish.yml, checking UI release readiness, or completing the one-time npm trusted-publishing bootstrap.
 ---
 
 # Publish UI
@@ -15,13 +15,17 @@ Release `@cline/ui` independently from the Cline SDK runtime packages.
   version/publish scripts. It is still a public npm package because
   `private: false` and `publishConfig.access: public` control npm publication.
 - `latest` is the production channel. `next` is an opt-in preview channel.
+  `nightly` is the automated daily channel.
 - Use prerelease versions such as `0.2.0-next.0` for `next`; do not publish a
   version intended for `latest` under the preview tag because npm versions
   cannot be republished.
-- There is no UI Git tag, GitHub release, schedule, or Slack announcement.
-- The workflow runs only by manual dispatch. Every release attempt runs the UI
-  quality checks before publishing and requires `confirm_publish=publish` from
-  `main`.
+- There is no UI Git tag, GitHub release, or Slack announcement.
+- The workflow runs nightly at 03:00 UTC and supports manual dispatch. Scheduled
+  runs publish `<base-version>-nightly.<unix-timestamp>` with the `nightly`
+  dist-tag without committing a version bump. Manual releases require
+  `confirm_publish=publish` from `main`.
+- Every scheduled and manual release attempt runs the UI quality checks before
+  publishing.
 - The publish job and npm trust relationship use the protected `Publish`
   environment.
 - Every npm publication needs a new semver version; npm versions are immutable.
@@ -149,6 +153,21 @@ npm trust github @cline/ui \
 ```sh
 npm view @cline/ui dist-tags versions --json
 npm trust list @cline/ui
+```
+
+## Nightly releases
+
+The scheduled workflow strips any prerelease suffix from the checked-in package
+version before generating the nightly version. For example, a checked-in
+`0.2.0-next.0` becomes `0.2.0-nightly.<unix-timestamp>`. Nightlies publish only
+to npm under the `nightly` dist-tag; they do not create Git tags, GitHub
+releases, or Slack announcements.
+
+To verify the latest nightly:
+
+```sh
+npm view @cline/ui dist-tags.nightly
+npm view @cline/ui@nightly version
 ```
 
 ## Final report

--- a/.cline/skills/publish-ui/SKILL.md
+++ b/.cline/skills/publish-ui/SKILL.md
@@ -163,6 +163,11 @@ version before generating the nightly version. For example, a checked-in
 to npm under the `nightly` dist-tag; they do not create Git tags, GitHub
 releases, or Slack announcements.
 
+Scheduled runs skip publishing when `main` has no commits in the last 24 hours,
+so identical code is not republished nightly. Manual dispatches are never
+skipped by this check. To force a nightly after a quiet day, dispatch the
+workflow manually or wait for the next commit to `main`.
+
 To verify the latest nightly:
 
 ```sh

--- a/.github/workflows/ui-publish.yml
+++ b/.github/workflows/ui-publish.yml
@@ -1,6 +1,9 @@
 name: ui-publish
 
 on:
+  schedule:
+    # Publish @cline/ui nightly at 3:00 AM UTC, after the SDK nightly.
+    - cron: "0 3 * * *"
   workflow_dispatch:
     inputs:
       npm_tag:
@@ -27,6 +30,9 @@ jobs:
   quality:
     name: UI quality and package checks
     runs-on: ubuntu-latest
+    outputs:
+      npm_tag: ${{ steps.release.outputs.npm_tag }}
+      version: ${{ steps.release.outputs.version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -45,6 +51,37 @@ jobs:
 
       - name: Install dependencies
         run: bun install --filter @cline/ui --filter @cline/code --frozen-lockfile
+
+      - name: Prepare package release
+        id: release
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_NPM_TAG: ${{ inputs.npm_tag }}
+        run: |
+          set -euo pipefail
+          base_version=$(node -p "require('./sdk/packages/ui/package.json').version")
+
+          if [ "$EVENT_NAME" = "schedule" ]; then
+            version="${base_version%%-*}-nightly.$(date +%s)"
+            npm_tag="nightly"
+
+            VERSION="$version" node -e '
+              const fs = require("node:fs");
+              const path = "sdk/packages/ui/package.json";
+              const pkg = JSON.parse(fs.readFileSync(path, "utf8"));
+              pkg.version = process.env.VERSION;
+              fs.writeFileSync(path, `${JSON.stringify(pkg, null, "\t")}\n`);
+            '
+          else
+            version="$base_version"
+            npm_tag="$INPUT_NPM_TAG"
+          fi
+
+          echo "Package version: $version"
+          echo "npm tag: $npm_tag"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "npm_tag=$npm_tag" >> "$GITHUB_OUTPUT"
 
       - name: Typecheck UI
         run: bun -F @cline/ui typecheck
@@ -90,11 +127,16 @@ jobs:
   publish:
     name: Publish @cline/ui
     if: >-
-      github.event_name == 'workflow_dispatch' &&
       github.repository == 'cline/cline' &&
       github.ref == 'refs/heads/main' &&
-      inputs.confirm_publish == 'publish' &&
-      !endsWith(github.actor, '[bot]')
+      (
+        github.event_name == 'schedule' ||
+        (
+          github.event_name == 'workflow_dispatch' &&
+          inputs.confirm_publish == 'publish' &&
+          !endsWith(github.actor, '[bot]')
+        )
+      )
     needs: quality
     runs-on: ubuntu-latest
     environment: Publish
@@ -126,7 +168,8 @@ jobs:
         shell: bash
         env:
           NPM_CONFIG_PROVENANCE: "true"
-          NPM_TAG: ${{ inputs.npm_tag }}
+          EXPECTED_VERSION: ${{ needs.quality.outputs.version }}
+          NPM_TAG: ${{ needs.quality.outputs.npm_tag }}
         run: |
           set -euo pipefail
           archive=$(find "$RUNNER_TEMP/ui-npm-pack" -maxdepth 1 -name '*.tgz' -print -quit)
@@ -136,6 +179,11 @@ jobs:
           fi
 
           version=$(tar -xOf "$archive" package/package.json | node -e 'let input=""; process.stdin.on("data", chunk => input += chunk); process.stdin.on("end", () => process.stdout.write(JSON.parse(input).version))')
+          if [ "$version" != "$EXPECTED_VERSION" ]; then
+            echo "Expected @cline/ui@${EXPECTED_VERSION}, but artifact contains ${version}"
+            exit 1
+          fi
+
           if npm view "@cline/ui@${version}" version >/dev/null 2>&1; then
             echo "@cline/ui@${version} already exists; bump sdk/packages/ui/package.json before publishing"
             exit 1

--- a/.github/workflows/ui-publish.yml
+++ b/.github/workflows/ui-publish.yml
@@ -27,8 +27,43 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  check:
+    name: Check for recent commits
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.recent.outputs.skip }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Skip nightly when main is unchanged
+        id: recent
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          # Manual releases always publish; only the nightly cron is gated.
+          if [ "$EVENT_NAME" != "schedule" ]; then
+            echo "Manual dispatch, proceeding with publish"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$(git rev-list --count HEAD --since='24 hours ago')" -eq 0 ]; then
+            echo "No commits in last 24 hours, skipping nightly publish"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Found recent commits, proceeding with publish"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
   quality:
     name: UI quality and package checks
+    needs: check
+    if: needs.check.outputs.skip != 'true'
     runs-on: ubuntu-latest
     outputs:
       npm_tag: ${{ steps.release.outputs.npm_tag }}


### PR DESCRIPTION
### Related Issue

No linked issue.

### Description

Schedules `@cline/ui` publication each night at 03:00 UTC. Scheduled runs derive an immutable `<base-version>-nightly.<unix-timestamp>` version, publish it with the `nightly` npm dist-tag, and do not create Git tags, GitHub releases, or Slack announcements.

A `check` job skips the scheduled nightly when `main` has no commits in the last 24 hours, matching the SDK nightly behavior. Manual dispatches always proceed.

Manual `next` and `latest` publishing remains unchanged. The release artifact version is checked before publication.

### Test Procedure

- `actionlint .github/workflows/ui-publish.yml`
- Simulated the scheduled version derivation from checked-in `0.2.0-next.0`; verified `0.2.0-nightly.1722222222` and the expected semver pattern.
- Simulated the commit-recency gate: dispatch always publishes; schedule skips at 0 commits and proceeds otherwise.
- `bun -F @cline/ui typecheck`
- `bun -F @cline/ui test` (5 files, 16 tests)
- `bun -F @cline/ui test:package` (packed package verified with Bun/React 19 and npm/Node/React 18)
- `bun -F @cline/ui build-storybook`
- `bun -F @cline/code test:chat-ui` (48 tests)

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Focused tests, package checks, builds, and workflow lint are passing
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable; this is a publishing workflow change.

### Additional Notes

The npm trusted-publishing workflow and protected `Publish` environment remain unchanged.