### PR TITLE
fix(llms): treat zero reasoning budgets as disabled

### DIFF
--- a/sdk/packages/llms/src/providers/gateway.test.ts
+++ b/sdk/packages/llms/src/providers/gateway.test.ts
@@ -3790,12 +3790,19 @@ describe("sdk-gateway", () => {
 			expected: { effort: "high" },
 		},
 		{
-			name: "drops a zero legacy budget",
+			name: "treats a zero structured budget as disabled",
+			options: {
+				reasoning: { effort: "high", budgetTokens: 0 },
+			},
+			expected: { effort: "none" },
+		},
+		{
+			name: "treats a zero legacy budget as disabled",
 			options: {
 				reasoning: { effort: "high" },
 				thinkingBudgetTokens: 0,
 			},
-			expected: { effort: "high" },
+			expected: { effort: "none" },
 		},
 		{
 			name: "validates handle defaults before merging requested reasoning",

--- a/sdk/packages/llms/src/providers/gateway.ts
+++ b/sdk/packages/llms/src/providers/gateway.ts
@@ -40,7 +40,7 @@ function mergeRequestMetadata(
 }
 
 function normalizeReasoningBudgetTokens(value: unknown): number | undefined {
-	return typeof value === "number" && Number.isInteger(value) && value > 0
+	return typeof value === "number" && Number.isInteger(value) && value >= 0
 		? value
 		: undefined;
 }

--- a/sdk/packages/llms/src/providers/model-facts.ts
+++ b/sdk/packages/llms/src/providers/model-facts.ts
@@ -37,7 +37,7 @@ export function getModelReasoningControls(
 		budget,
 		toggle,
 		efforts: ACTIVE_REASONING_EFFORTS.filter((value) => advertised.has(value)),
-		supportsOff: toggle || advertised.has("none"),
+		supportsOff: toggle || advertised.has("none") || budget?.min === 0,
 		supportsDefault: advertised.has("default"),
 	};
 }

--- a/sdk/packages/llms/src/providers/routing/provider-options.test.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-options.test.ts
@@ -2172,6 +2172,25 @@ describe("composeAiSdkProviderOptions: provider-specific overlays", () => {
 		expect(withoutEffort).not.toHaveProperty("google");
 	});
 
+	it("treats a zero Gemini reasoning budget as disabled thinking", () => {
+		const result = composeAiSdkProviderOptions(
+			makeRequest({
+				providerId: "gemini",
+				modelId: "gemini-2.5-flash",
+				reasoning: { budgetTokens: 0 },
+			}),
+			makeContext({
+				providerId: "gemini",
+				modelId: "gemini-2.5-flash",
+				reasoningOptions: [{ type: "budget_tokens", min: 0, max: 24_576 }],
+			}),
+		);
+
+		expect(result.google).toEqual({
+			thinkingConfig: { thinkingBudget: 0, includeThoughts: false },
+		});
+	});
+
 	it("maps unsupported Gemini 3 Pro levels to the nearest supported level", () => {
 		const withMinimal = composeAiSdkProviderOptions(
 			makeRequest({

--- a/sdk/packages/llms/src/providers/routing/reasoning-options.test.ts
+++ b/sdk/packages/llms/src/providers/routing/reasoning-options.test.ts
@@ -156,6 +156,21 @@ describe("normalizeReasoningRequest", () => {
 		).toBeUndefined();
 	});
 
+	it("treats a zero budget as off only when the model advertises it", () => {
+		expect(
+			normalizeReasoningRequest(
+				makeRequest({ budgetTokens: 0 }),
+				makeContext([{ type: "budget_tokens", min: 0, max: 24_576 }]),
+			).reasoning,
+		).toEqual({ enabled: false });
+		expect(
+			normalizeReasoningRequest(
+				makeRequest({ budgetTokens: 0 }),
+				makeContext([{ type: "budget_tokens", min: 128, max: 32_768 }]),
+			).reasoning,
+		).toBeUndefined();
+	});
+
 	it("ignores Cline Fable's advertised off control because backend reasoning is mandatory", () => {
 		const controls: ModelReasoningOption[] = [
 			{ type: "toggle" },

--- a/sdk/packages/llms/src/providers/routing/reasoning-options.ts
+++ b/sdk/packages/llms/src/providers/routing/reasoning-options.ts
@@ -38,7 +38,10 @@ export function normalizeReasoningRequest(
 	request: GatewayStreamRequest,
 	context: GatewayProviderContext,
 ): GatewayStreamRequest {
-	const reasoning = request.reasoning;
+	const reasoning =
+		request.reasoning?.budgetTokens === 0
+			? { enabled: false as const }
+			: request.reasoning;
 	if (!reasoning) {
 		return request;
 	}


### PR DESCRIPTION
### Related Issue

**Issue:** Follow-up to #12542

### Description

Treat a zero reasoning token budget as an explicit request to disable reasoning.

Previously, the gateway rejected zero as an invalid budget while lower-level routing could forward it as an enabled budget. This produced different behavior depending on which request path supplied `budgetTokens: 0`.

This change:

- preserves zero through gateway option validation;
- recognizes a models.dev budget with `min: 0` as an advertised off control;
- normalizes a zero budget to `{ enabled: false }`;
- lets existing provider encoding emit Gemini `thinkingBudget: 0` with `includeThoughts: false`; and
- continues omitting disable controls for models that do not advertise off support.

### Test Procedure

- `bun run build:sdk`
- `bun run --cwd sdk/packages/llms typecheck`
- `bun run --cwd sdk/packages/llms test src/providers/routing/reasoning-options.test.ts src/providers/routing/provider-options.test.ts` — 126 passed
- `bun run --cwd sdk/packages/llms test src/providers/gateway.test.ts -t zero` — 3 passed
- `bunx biome check` on the five scoped source/test files without pre-existing file-wide findings
- `git diff --check`

The full local `@cline/llms` run reached 467 passing tests and 4 skipped tests. It also reproduced three unrelated `openai-codex-cli` tool-stream failures and the existing worktree-specific `isStream is not a function` import failure in `community.test.ts`; none intersects the changed reasoning paths.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable; this changes SDK/provider routing behavior only.

### Additional Notes

This addresses Beatrix's non-blocking review question about whether a zero reasoning budget should mean off.
