### PR TITLE
fix(webview): render mixed-direction Markdown correctly

### DIFF
--- a/apps/vscode/webview-ui/package.json
+++ b/apps/vscode/webview-ui/package.json
@@ -16,6 +16,7 @@
 		"build-storybook": "storybook build"
 	},
 	"dependencies": {
+		"@bidilens/markdown": "0.3.2",
 		"@cline/shared": "workspace:*",
 		"@cline/ui": "workspace:*",
 		"@floating-ui/react": "^0.27.4",

--- a/apps/vscode/webview-ui/src/components/common/MarkdownBlock.test.tsx
+++ b/apps/vscode/webview-ui/src/components/common/MarkdownBlock.test.tsx
@@ -1,0 +1,53 @@
+import { render } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("@/components/common/MermaidBlock", () => ({
+	default: ({ code }: { code: string }) => <pre>{code}</pre>,
+}))
+
+vi.mock("@/components/common/UnsafeImage", () => ({
+	default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => <img alt={props.alt ?? ""} {...props} />,
+}))
+
+vi.mock("@/context/ExtensionStateContext", () => ({
+	useExtensionState: () => ({ mode: "act" }),
+}))
+
+vi.mock("@/services/grpc-client", () => ({
+	FileServiceClient: {
+		ifFileExistsRelativePath: vi.fn().mockResolvedValue({ value: false }),
+		openFileRelativePath: vi.fn(),
+	},
+	StateServiceClient: {
+		togglePlanActModeProto: vi.fn(),
+	},
+}))
+
+import MarkdownBlock from "./MarkdownBlock"
+
+describe("MarkdownBlock bidirectional text", () => {
+	it("uses content-majority direction and isolates an English identifier in Persian prose", () => {
+		const { container } = render(<MarkdownBlock markdown="React یک کتابخانه جاوااسکریپت بسیار محبوب است." />)
+		const paragraph = container.querySelector("p")
+		const isolate = paragraph?.querySelector("bdi")
+
+		expect(paragraph?.getAttribute("dir")).toBe("rtl")
+		expect(isolate?.getAttribute("dir")).toBe("ltr")
+		expect(isolate?.textContent).toBe("React")
+	})
+
+	it("uses LTR direction for English-majority prose containing Persian", () => {
+		const { container } = render(<MarkdownBlock markdown="React is a popular کتابخانه for the web." />)
+
+		expect(container.querySelector("p")?.getAttribute("dir")).toBe("ltr")
+	})
+
+	it("does not annotate pure LTR prose", () => {
+		const { container } = render(<MarkdownBlock markdown="React is a popular JavaScript library." />)
+		const paragraph = container.querySelector("p")
+
+		expect(paragraph?.hasAttribute("dir")).toBe(false)
+		expect(paragraph?.hasAttribute("data-bidilens-block")).toBe(false)
+		expect(paragraph?.querySelector("bdi")).toBeNull()
+	})
+})

--- a/apps/vscode/webview-ui/src/components/common/MarkdownBlock.tsx
+++ b/apps/vscode/webview-ui/src/components/common/MarkdownBlock.tsx
@@ -1,3 +1,4 @@
+import { rehypeBidi } from "@bidilens/markdown"
 import { StringRequest } from "@shared/proto/cline/common"
 import { PlanActMode, TogglePlanActModeRequest } from "@shared/proto/cline/state"
 import { SquareArrowOutUpRightIcon } from "lucide-react"
@@ -76,7 +77,7 @@ const MemoizedMarkdownBlock = memo(
 					},
 					img: (props) => <UnsafeImage {...props} />,
 				}}
-				rehypePlugins={[[rehypeHighlight as any, {} as Options]]}
+				rehypePlugins={[rehypeBidi, [rehypeHighlight as any, {} as Options]]}
 				remarkPlugins={[
 					[remarkGfm, { singleTilde: false }],
 					remarkPreventBoldFilenames,

--- a/bun.lock
+++ b/bun.lock
@@ -521,6 +521,7 @@
       "name": "webview-ui",
       "version": "0.3.0",
       "dependencies": {
+        "@bidilens/markdown": "0.3.2",
         "@cline/shared": "workspace:*",
         "@cline/ui": "workspace:*",
         "@floating-ui/react": "^0.27.4",
@@ -1014,6 +1015,10 @@
     "@base-ui/utils": ["@base-ui/utils@0.3.2", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@floating-ui/utils": "^0.2.12", "reselect": "^5.2.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ=="],
 
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
+
+    "@bidilens/core": ["@bidilens/core@0.3.2", "", {}, "sha512-EDRBaAP4LzEn8w+eFqeDD889ZwwLIsTwD6JOOnooDIuJ46cHI9bMeinuvlt8X/PJn0QHrTfRyg512pRAXYfxhA=="],
+
+    "@bidilens/markdown": ["@bidilens/markdown@0.3.2", "", { "dependencies": { "@bidilens/core": "0.3.2", "@types/hast": "^3.0.4", "@types/mdast": "^4.0.4", "unist-util-visit": "^5.0.0" }, "peerDependencies": { "markdown-it": "^13.0.2 || ^14.0.0 || ^15.0.0" }, "optionalPeers": ["markdown-it"] }, "sha512-zCOGP3h0XEiYHjyGa3V+MxAXK9/rFC2Bt8w+00aY44b+LqHnQfA632a97UJUTFyrIMXgaWFkFMEzin/z7l+PAA=="],
 
     "@biomejs/biome": ["@biomejs/biome@2.4.5", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.5", "@biomejs/cli-darwin-x64": "2.4.5", "@biomejs/cli-linux-arm64": "2.4.5", "@biomejs/cli-linux-arm64-musl": "2.4.5", "@biomejs/cli-linux-x64": "2.4.5", "@biomejs/cli-linux-x64-musl": "2.4.5", "@biomejs/cli-win32-arm64": "2.4.5", "@biomejs/cli-win32-x64": "2.4.5" }, "bin": { "biome": "bin/biome" } }, "sha512-OWNCyMS0Q011R6YifXNOg6qsOg64IVc7XX6SqGsrGszPbkVCoaO7Sr/lISFnXZ9hjQhDewwZ40789QmrG0GYgQ=="],
 


### PR DESCRIPTION
### Related Issue

**Issue:** #9605

### Description

Cline's chat Markdown currently relies on inherited direction plus a global paragraph isolate. That does not select a base direction per semantic block, so Arabic/Persian/Hebrew prose—especially an RTL-majority sentence beginning with an English identifier—can render in the wrong visual order.

This PR adds `@bidilens/markdown` 0.3.2's rehype plugin to the existing `ReactMarkdown` pipeline. It computes direction from block content, isolates opposite-direction inline runs with semantic `bdi` elements, keeps code LTR, and leaves pure-LTR prose unannotated. Source text and copy behavior remain unchanged.

Regression coverage includes:

- Persian-majority prose beginning with `React`: RTL block plus isolated LTR identifier
- English-majority prose containing Persian: LTR block
- Pure English: no `dir` or BidiLens metadata, preserving the current output

### Test Procedure

Validated after rebasing onto current upstream `main` with Cline's required Bun 1.3.13 toolchain:

- PASS: `bun install --frozen-lockfile`
- PASS: `bun run build:sdk`
- PASS: focused `MarkdownBlock.test.tsx` (3/3 tests)
- PASS: complete webview suite (59 files, 453 tests)
- PASS: VS Code `bun run check-types`
- PASS: VS Code `bun run build:webview` (production build)
- PASS: root `bun run lint` (1,224 files plus proto lint)
- PASS: root `bun run format`
- PASS: required pre-commit Gitleaks scan and staged-file checks
- PASS: `git diff --check`

Fresh hosted checks are running on commit `62d84984e`.

### Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Refactor Changes
-   [ ] Cosmetic Changes
-   [ ] Documentation update
-   [ ] Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Local tests, build, type checks, lint, formatting, and repository hooks pass
-   [x] I have reviewed contributor guidelines

### Screenshots

Not included: the regression is asserted at the generated DOM-semantics level (`dir` and `bdi`) across Persian-majority, English-majority, and pure-English identity cases.

### Additional Notes

I maintain BidiLens and am disclosing that relationship explicitly. The dependency is MIT-licensed, ESM-only, side-effect-free, and requires Node 22.12+, which is compatible with Cline's declared Node 22+ toolchain.