### PR TITLE
Disable feature tips by default in the VS Code extension

### DIFF
--- a/.changeset/tidy-crabs-rest.md
+++ b/.changeset/tidy-crabs-rest.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Disable feature tips by default; they can be enabled in Settings → Features → "Feature Tips"

--- a/apps/vscode/src/shared/storage/state-keys.ts
+++ b/apps/vscode/src/shared/storage/state-keys.ts
@@ -282,7 +282,7 @@ const USER_SETTINGS_FIELDS = {
 	focusChainSettings: { default: DEFAULT_FOCUS_CHAIN_SETTINGS as FocusChainSettings },
 	backgroundEditEnabled: { default: false as boolean },
 	optOutOfRemoteConfig: { default: false as boolean },
-	showFeatureTips: { default: true as boolean },
+	showFeatureTips: { default: false as boolean },
 
 	// OpenTelemetry configuration
 	openTelemetryEnabled: { default: true as boolean },

--- a/apps/vscode/webview-ui/src/components/chat/ChatRow.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatRow.tsx
@@ -883,7 +883,7 @@ export const ChatRowContent = memo(
 									showTitle={true}
 									title={isReasoningStreaming ? "Thinking..." : "Thinking"}
 								/>
-								{isReasoningStreaming && showFeatureTips !== false && <FeatureTip />}
+								{isReasoningStreaming && showFeatureTips === true && <FeatureTip />}
 							</div>
 						)
 					}

--- a/apps/vscode/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/apps/vscode/webview-ui/src/context/ExtensionStateContext.tsx
@@ -312,7 +312,7 @@ export const ExtensionStateContextProvider: React.FC<{
 		foregroundCommandRunning: false,
 		lastDismissedCliBannerVersion: 0,
 		backgroundEditEnabled: false,
-		showFeatureTips: true,
+		showFeatureTips: false,
 		globalSkillsToggles: {},
 		localSkillsToggles: {},
 


### PR DESCRIPTION
### Related Issue

N/A — small default-behavior change.

### Description

Makes the "Feature Tips" feature (rotating tips shown during the thinking phase) opt-in instead of opt-out in the VS Code extension:

- `showFeatureTips` default flipped from `true` to `false` in the extension state store (`src/shared/storage/state-keys.ts`) and in the webview's initial context state (`ExtensionStateContext.tsx`).
- `ChatRow.tsx` now renders `FeatureTip` only when `showFeatureTips === true` (previously `!== false`, which showed tips when the value was undefined).

Users can still enable tips via Settings → Features → "Feature Tips"; existing users who explicitly set the toggle keep their stored value.

### Test Procedure

- `bun run test:unit` in `apps/vscode`: 1021 tests pass.
- Webview `FeatureSettingsSection.spec.tsx` (Vitest): 6 tests pass.
- Manual test: built the webview + extension bundle, launched an Extension Development Host with a completely fresh user profile (and no persisted `showFeatureTips` in file storage), and verified in Cline Settings → Features that the "Feature Tips" toggle is OFF by default.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Fresh-profile Extension Development Host, Cline Settings → Features — "Feature Tips" is off by default:

![Feature Tips toggle off by default in Cline settings](https://cursor.com/artifacts/c/art-5df76e13-eea5-46dd-b579-b6bb0be5ae8f)

### Additional Notes

A changeset (`claude-dev` patch) is included.