### PR TITLE
Show thinking indicator immediately after chat submit

### DIFF
--- a/apps/vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -1,7 +1,6 @@
 import { combineApiRequests } from "@shared/combineApiRequests"
 import { combineCommandSequences } from "@shared/combineCommandSequences"
 import { combineHookSequences } from "@shared/combineHookSequences"
-import type { ClineMessage } from "@shared/ExtensionMessage"
 import { getApiMetrics, getLastApiReqTotalTokens } from "@shared/getApiMetrics"
 import { BooleanRequest, StringRequest } from "@shared/proto/cline/common"
 import { useCallback, useEffect, useMemo, useRef } from "react"
@@ -12,6 +11,11 @@ import { useNormalizedApiConfiguration } from "@/hooks/useNormalizedApiConfigura
 import { FileServiceClient, UiServiceClient } from "@/services/grpc-client"
 import { Navbar } from "../menu/Navbar"
 import AutoApproveBar from "./auto-approve-menu/AutoApproveBar"
+import {
+	hasPendingMessageConfirmation,
+	isPendingResponseUnconfirmed,
+	withPendingUserMessage,
+} from "./chat-view/utils/pendingResponse"
 // Import utilities and hooks from the new structure
 import {
 	ActionButtons,
@@ -42,25 +46,6 @@ interface ChatViewProps {
 const MAX_IMAGES_AND_FILES_PER_MESSAGE = CHAT_CONSTANTS.MAX_IMAGES_AND_FILES_PER_MESSAGE
 const QUICK_WINS_HISTORY_THRESHOLD = 3
 
-const sameUserMessage = (left: ClineMessage, right: ClineMessage) => {
-	const leftImages = left.images ?? []
-	const rightImages = right.images ?? []
-	const leftFiles = left.files ?? []
-	const rightFiles = right.files ?? []
-
-	return (
-		left.type === "say" &&
-		left.say === "user_feedback" &&
-		right.type === "say" &&
-		right.say === "user_feedback" &&
-		left.text === right.text &&
-		leftImages.length === rightImages.length &&
-		leftImages.every((image, index) => image === rightImages[index]) &&
-		leftFiles.length === rightFiles.length &&
-		leftFiles.every((file, index) => file === rightFiles[index])
-	)
-}
-
 const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryView }: ChatViewProps) => {
 	const showNavbar = useShowNavbar()
 	const {
@@ -73,6 +58,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 		hooksEnabled,
 		checkpointRestoreInput,
 		queuedPrompts,
+		turnState,
 	} = useExtensionState()
 	const isProdHostedApp = userInfo?.apiBaseUrl === "https://app.cline.bot"
 	const shouldShowQuickWins = isProdHostedApp && (!taskHistory || taskHistory.length < QUICK_WINS_HISTORY_THRESHOLD)
@@ -91,34 +77,28 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 		setExpandedRows,
 		pendingUserMessage,
 		setPendingUserMessage,
+		pendingResponse,
+		setPendingResponse,
 		textAreaRef,
 	} = chatState
 
-	const displayMessages = useMemo(() => {
-		if (
-			!pendingUserMessage ||
-			messages.some(
-				(message) => message.ts > pendingUserMessage.afterTs && sameUserMessage(message, pendingUserMessage.message),
-			)
-		) {
-			return messages
-		}
-		return [...messages, pendingUserMessage.message]
-	}, [messages, pendingUserMessage])
+	const displayMessages = useMemo(() => withPendingUserMessage(messages, pendingUserMessage), [messages, pendingUserMessage])
 
 	useEffect(() => {
-		if (
-			pendingUserMessage &&
-			messages.some(
-				(message) => message.ts > pendingUserMessage.afterTs && sameUserMessage(message, pendingUserMessage.message),
-			)
-		) {
-			setPendingUserMessage(undefined)
+		if (pendingUserMessage && hasPendingMessageConfirmation(messages, pendingUserMessage)) {
+			setPendingUserMessage((current) => (current === pendingUserMessage ? undefined : current))
 		}
 	}, [messages, pendingUserMessage, setPendingUserMessage])
 
+	useEffect(() => {
+		if (!pendingResponse || isPendingResponseUnconfirmed(pendingResponse, turnState, messages.length)) {
+			return
+		}
+		setPendingResponse((current) => (current?.id === pendingResponse.id ? undefined : current))
+	}, [messages.length, pendingResponse, setPendingResponse, turnState])
+
 	//const task = messages.length > 0 ? (messages[0].say === "task" ? messages[0] : undefined) : undefined) : undefined
-	const task = useMemo(() => messages.at(0), [messages]) // leaving this less safe version here since if the first message is not a task, then the extension is in a bad state and needs to be debugged (see Cline.abort)
+	const task = useMemo(() => displayMessages.at(0), [displayMessages]) // leaving this less safe version here since if the first message is not a task, then the extension is in a bad state and needs to be debugged (see Cline.abort)
 	const modifiedMessages = useMemo(() => {
 		const slicedMessages = displayMessages.slice(1)
 		// Only combine hook sequences if hooks are enabled

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/MessagesArea.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/MessagesArea.tsx
@@ -7,6 +7,7 @@ import { useExtensionState } from "@/context/ExtensionStateContext"
 import { cn } from "@/lib/utils"
 import { useThinkingLoaderRow } from "../../hooks/useThinkingLoaderRow"
 import type { ChatState, MessageHandlers, ScrollBehavior } from "../../types/chatTypes"
+import { isPendingResponseUnconfirmed } from "../../utils/pendingResponse"
 import { createMessageRenderer } from "../messages/MessageRenderer"
 
 // Sentinel ts for the synthetic "Thinking..." placeholder row. Not a real message; ignored when
@@ -76,6 +77,7 @@ export const MessagesArea: React.FC<MessagesAreaProps> = ({
 		}
 		return Array.isArray(lastRow) ? lastRow.at(-1) : lastRow
 	}, [lastVisibleRow])
+	const forcePendingResponseLoader = isPendingResponseUnconfirmed(chatState.pendingResponse, turnState, clineMessages.length)
 
 	// Keep loader in the message flow (not footer). Show/hide logic (waiting heuristic,
 	// waiting -> reasoning handoff guard, and anti-flash debounce on turn end) lives in the hook.
@@ -86,6 +88,7 @@ export const MessagesArea: React.FC<MessagesAreaProps> = ({
 		lastVisibleRow,
 		lastVisibleMessage,
 		modifiedMessages,
+		forceShow: forcePendingResponseLoader,
 	})
 
 	const displayedGroupedMessages = useMemo<(ClineMessage | ClineMessage[])[]>(() => {

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useChatState.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useChatState.ts
@@ -1,6 +1,6 @@
 import { ClineMessage } from "@shared/ExtensionMessage"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { ChatState, PendingUserMessage } from "../types/chatTypes"
+import { ChatState, PendingResponse, PendingUserMessage } from "../types/chatTypes"
 
 /**
  * Custom hook for managing chat state
@@ -21,6 +21,7 @@ export function useChatState(messages: ClineMessage[]): ChatState {
 	const [secondaryButtonText, setSecondaryButtonText] = useState<string | undefined>("Reject")
 	const [expandedRows, setExpandedRows] = useState<Record<number, boolean>>({})
 	const [pendingUserMessage, setPendingUserMessage] = useState<PendingUserMessage | undefined>(undefined)
+	const [pendingResponse, setPendingResponse] = useState<PendingResponse | undefined>(undefined)
 
 	// Refs
 	const textAreaRef = useRef<HTMLTextAreaElement>(null)
@@ -78,6 +79,8 @@ export function useChatState(messages: ClineMessage[]): ChatState {
 		setExpandedRows,
 		pendingUserMessage,
 		setPendingUserMessage,
+		pendingResponse,
+		setPendingResponse,
 
 		// Refs
 		textAreaRef,

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.test.tsx
@@ -75,6 +75,8 @@ function makeChatState(messages: ClineMessage[], overrides: Partial<ChatState> =
 		setExpandedRows: vi.fn(),
 		pendingUserMessage: undefined,
 		setPendingUserMessage: vi.fn(),
+		pendingResponse: undefined,
+		setPendingResponse: vi.fn(),
 		textAreaRef: { current: null },
 		lastMessage: last,
 		secondLastMessage: messages.at(-2),
@@ -214,6 +216,7 @@ describe("useMessageHandlers — send routing", () => {
 		const setSelectedFiles = vi.fn()
 		const setEnableButtons = vi.fn()
 		const setPendingUserMessage = vi.fn()
+		const setPendingResponse = vi.fn()
 		const chatState = makeChatState(completedConversation, {
 			activeQuote: "selected context",
 			sendingDisabled: false,
@@ -225,6 +228,7 @@ describe("useMessageHandlers — send routing", () => {
 			setSelectedFiles,
 			setEnableButtons,
 			setPendingUserMessage,
+			setPendingResponse,
 		})
 		const { result } = renderHook(() => useMessageHandlers(completedConversation, chatState))
 
@@ -261,6 +265,11 @@ describe("useMessageHandlers — send routing", () => {
 				}),
 			}),
 		)
+		expect(setPendingResponse).toHaveBeenCalledWith({
+			id: 1,
+			turnStateSeq: 7,
+			messageCount: completedConversation.length,
+		})
 
 		await act(async () => {
 			resolveAskResponse()
@@ -278,6 +287,7 @@ describe("useMessageHandlers — send routing", () => {
 		const setSelectedFiles = vi.fn()
 		const setEnableButtons = vi.fn()
 		const setPendingUserMessage = vi.fn()
+		const setPendingResponse = vi.fn()
 		const chatState = makeChatState(completedConversation, {
 			activeQuote: "selected context",
 			sendingDisabled: false,
@@ -289,6 +299,7 @@ describe("useMessageHandlers — send routing", () => {
 			setSelectedFiles,
 			setEnableButtons,
 			setPendingUserMessage,
+			setPendingResponse,
 		})
 		const { result } = renderHook(() => useMessageHandlers(completedConversation, chatState))
 		askResponse.mockRejectedValueOnce(error)
@@ -326,7 +337,16 @@ describe("useMessageHandlers — send routing", () => {
 				}),
 			}),
 		)
-		expect(setPendingUserMessage).toHaveBeenLastCalledWith(undefined)
+		const optimisticMessage = setPendingUserMessage.mock.calls[0][0]
+		const rollbackMessage = setPendingUserMessage.mock.calls.at(-1)?.[0]
+		expect(rollbackMessage(optimisticMessage)).toBeUndefined()
+		const newerMessage = { afterTs: 3, message: { ...optimisticMessage.message, ts: 4 } }
+		expect(rollbackMessage(newerMessage)).toBe(newerMessage)
+		const pendingResponse = setPendingResponse.mock.calls[0][0]
+		const rollbackResponse = setPendingResponse.mock.calls.at(-1)?.[0]
+		expect(rollbackResponse(pendingResponse)).toBeUndefined()
+		const newerResponse = { ...pendingResponse, id: 2 }
+		expect(rollbackResponse(newerResponse)).toBe(newerResponse)
 	})
 
 	it("does not show a pending chat bubble for a streaming follow-up that will be queued", async () => {
@@ -336,8 +356,12 @@ describe("useMessageHandlers — send routing", () => {
 			{ ts: 2, type: "say", say: "text", text: "working", partial: true },
 		]
 		const setPendingUserMessage = vi.fn()
+		const setPendingResponse = vi.fn()
 		const { result } = renderHook(() =>
-			useMessageHandlers(streamingConversation, makeChatState(streamingConversation, { setPendingUserMessage })),
+			useMessageHandlers(
+				streamingConversation,
+				makeChatState(streamingConversation, { setPendingUserMessage, setPendingResponse }),
+			),
 		)
 
 		await act(async () => {
@@ -346,6 +370,7 @@ describe("useMessageHandlers — send routing", () => {
 
 		expect(askResponse).toHaveBeenCalledTimes(1)
 		expect(setPendingUserMessage).not.toHaveBeenCalled()
+		expect(setPendingResponse).not.toHaveBeenCalled()
 	})
 
 	it("rejects a pending approval when the composer is submitted with typed feedback", async () => {
@@ -380,7 +405,10 @@ describe("useMessageHandlers — send routing", () => {
 
 	it("phase awaiting_followup also routes a follow-up to askResponse", async () => {
 		mockTurnState = { phase: "awaiting_followup", seq: 3 }
-		const { result } = renderHook(() => useMessageHandlers(completedConversation, makeChatState(completedConversation)))
+		const setPendingResponse = vi.fn()
+		const { result } = renderHook(() =>
+			useMessageHandlers(completedConversation, makeChatState(completedConversation, { setPendingResponse })),
+		)
 
 		await act(async () => {
 			await result.current.handleSendMessage("more info", [], [])
@@ -388,6 +416,11 @@ describe("useMessageHandlers — send routing", () => {
 
 		expect(newTask).not.toHaveBeenCalled()
 		expect(askResponse).toHaveBeenCalledTimes(1)
+		expect(setPendingResponse).toHaveBeenCalledWith({
+			id: 1,
+			turnStateSeq: 3,
+			messageCount: completedConversation.length,
+		})
 	})
 
 	it("does not show a pending chat bubble when answering an active follow-up question with freeform text", async () => {
@@ -419,7 +452,11 @@ describe("useMessageHandlers — send routing", () => {
 
 	it("an empty transcript still starts a NEW task (unchanged behavior)", async () => {
 		mockTurnState = { phase: "idle", seq: 1 }
-		const { result } = renderHook(() => useMessageHandlers([], makeChatState([])))
+		const setPendingUserMessage = vi.fn()
+		const setPendingResponse = vi.fn()
+		const { result } = renderHook(() =>
+			useMessageHandlers([], makeChatState([], { setPendingUserMessage, setPendingResponse })),
+		)
 
 		await act(async () => {
 			await result.current.handleSendMessage("brand new task", [], [])
@@ -427,6 +464,16 @@ describe("useMessageHandlers — send routing", () => {
 
 		expect(newTask).toHaveBeenCalledTimes(1)
 		expect(askResponse).not.toHaveBeenCalled()
+		expect(setPendingResponse).toHaveBeenCalledWith({ id: 1, turnStateSeq: 1, messageCount: 0 })
+		expect(setPendingUserMessage).toHaveBeenCalledWith({
+			afterTs: 0,
+			message: expect.objectContaining({
+				type: "say",
+				say: "task",
+				text: "brand new task",
+				partial: false,
+			}),
+		})
 		expect(trackIntent).toHaveBeenCalledWith(
 			expect.objectContaining({
 				action: "prompt_submitted",
@@ -449,6 +496,8 @@ describe("useMessageHandlers — send routing", () => {
 		const setSelectedImages = vi.fn()
 		const setSelectedFiles = vi.fn()
 		const setEnableButtons = vi.fn()
+		const setPendingUserMessage = vi.fn()
+		const setPendingResponse = vi.fn()
 		const chatState = makeChatState([], {
 			activeQuote: "selected context",
 			sendingDisabled: false,
@@ -459,6 +508,8 @@ describe("useMessageHandlers — send routing", () => {
 			setSelectedImages,
 			setSelectedFiles,
 			setEnableButtons,
+			setPendingUserMessage,
+			setPendingResponse,
 		})
 		const { result } = renderHook(() => useMessageHandlers([], chatState))
 		newTask.mockRejectedValueOnce(error)
@@ -492,6 +543,12 @@ describe("useMessageHandlers — send routing", () => {
 		expect(setSelectedFiles).toHaveBeenLastCalledWith(["a.ts"])
 		expect(setEnableButtons).toHaveBeenNthCalledWith(1, false)
 		expect(setEnableButtons).toHaveBeenLastCalledWith(true)
+		const optimisticMessage = setPendingUserMessage.mock.calls[0][0]
+		const rollbackMessage = setPendingUserMessage.mock.calls.at(-1)?.[0]
+		expect(rollbackMessage(optimisticMessage)).toBeUndefined()
+		const pendingResponse = setPendingResponse.mock.calls[0][0]
+		const rollbackResponse = setPendingResponse.mock.calls.at(-1)?.[0]
+		expect(rollbackResponse(pendingResponse)).toBeUndefined()
 	})
 
 	// The webview does not gate sends on provider usability: submission always

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.ts
@@ -25,10 +25,12 @@ export function useMessageHandlers(messages: ClineMessage[], chatState: ChatStat
 		enableButtons,
 		setEnableButtons,
 		setPendingUserMessage,
+		setPendingResponse,
 		clineAsk,
 		lastMessage,
 	} = chatState
 	const cancelInFlightRef = useRef(false)
+	const pendingResponseIdRef = useRef(0)
 
 	// Handle sending a message
 	const handleSendMessage = useCallback(
@@ -100,33 +102,61 @@ export function useMessageHandlers(messages: ClineMessage[], chatState: ChatStat
 					setSelectedFiles(files)
 					setEnableButtons(enableButtons)
 				}
+				const beginPendingResponse = (pendingMessage?: ClineMessage) => {
+					const id = ++pendingResponseIdRef.current
+					// A follow-up submitted during an active stream is queued/steering feedback.
+					// The authoritative streaming UI is already current, so forcing a loader could
+					// duplicate it alongside content that is still visibly streaming.
+					if (turnState?.phase !== "streaming") {
+						setPendingResponse({
+							id,
+							turnStateSeq: turnState?.seq,
+							messageCount: messages.length,
+						})
+					}
+					const optimisticMessage = pendingMessage
+						? {
+								afterTs: Math.max(0, ...messages.map((message) => message.ts)),
+								message: pendingMessage,
+							}
+						: undefined
+					if (optimisticMessage) {
+						setPendingUserMessage(optimisticMessage)
+					}
+					return { id, optimisticMessage }
+				}
+				const rollbackPendingResponse = (
+					id: number,
+					optimisticMessage: ReturnType<typeof beginPendingResponse>["optimisticMessage"],
+				) => {
+					setPendingResponse((current) => (current?.id === id ? undefined : current))
+					if (optimisticMessage) {
+						setPendingUserMessage((current) => (current === optimisticMessage ? undefined : current))
+					}
+				}
 				const sendAskResponseWithPendingState = async (
 					request: ReturnType<typeof AskResponseRequest.create>,
 					options: { showPendingMessage?: boolean } = {},
 				) => {
 					trackPromptSubmitted(true)
 					clearSentMessageState()
-					if (options.showPendingMessage) {
-						const afterTs = Math.max(0, ...messages.map((message) => message.ts))
-						setPendingUserMessage({
-							afterTs,
-							message: {
-								ts: Date.now(),
-								type: "say",
-								say: "user_feedback",
-								text: request.text ?? "",
-								images: request.images,
-								files: request.files,
-								partial: false,
-							},
-						})
-					}
+					const { id, optimisticMessage } = beginPendingResponse(
+						options.showPendingMessage
+							? {
+									ts: Date.now(),
+									type: "say",
+									say: "user_feedback",
+									text: request.text ?? "",
+									images: request.images,
+									files: request.files,
+									partial: false,
+								}
+							: undefined,
+					)
 					try {
 						await TaskServiceClient.askResponse(request)
 					} catch (error) {
-						if (options.showPendingMessage) {
-							setPendingUserMessage(undefined)
-						}
+						rollbackPendingResponse(id, optimisticMessage)
 						restorePendingMessageState()
 						throw error
 					}
@@ -140,9 +170,19 @@ export function useMessageHandlers(messages: ClineMessage[], chatState: ChatStat
 					})
 					clearSentMessageState()
 					trackPromptSubmitted(false)
+					const { id, optimisticMessage } = beginPendingResponse({
+						ts: Date.now(),
+						type: "say",
+						say: "task",
+						text: messageToSend,
+						images,
+						files,
+						partial: false,
+					})
 					try {
 						await TaskServiceClient.newTask(request)
 					} catch (error) {
+						rollbackPendingResponse(id, optimisticMessage)
 						restorePendingMessageState()
 						throw error
 					}
@@ -272,6 +312,7 @@ export function useMessageHandlers(messages: ClineMessage[], chatState: ChatStat
 			enableButtons,
 			setEnableButtons,
 			setPendingUserMessage,
+			setPendingResponse,
 			chatState,
 		],
 	)

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useThinkingLoaderRow.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useThinkingLoaderRow.test.tsx
@@ -147,3 +147,43 @@ describe("useThinkingLoaderRow anti-flash debounce", () => {
 		expect(result.current).toBe(false)
 	})
 })
+
+describe("useThinkingLoaderRow optimistic response handoff", () => {
+	function renderLoader(initial: ThinkingLoaderInputs) {
+		return renderHook((inputs: ThinkingLoaderInputs) => useThinkingLoaderRow(inputs), { initialProps: initial })
+	}
+
+	it.each([
+		"idle",
+		"completed",
+		"awaiting_followup",
+	] as const)("shows immediately while the webview still has the stale %s phase", (phase) => {
+		const { result } = renderLoader({ ...inputsFor([], { phase, seq: 1 }), forceShow: true })
+		expect(result.current).toBe(true)
+	})
+
+	it("hands off without a gap when the fresh streaming state arrives", () => {
+		const task = say(1, "task", false, "do the thing")
+		const withoutVisibleRows = (turnState: TurnState, forceShow: boolean): ThinkingLoaderInputs => ({
+			...inputsFor([], turnState),
+			lastRawMessage: task,
+			forceShow,
+		})
+		const { result, rerender } = renderLoader(withoutVisibleRows({ phase: "idle", seq: 1 }, true))
+		expect(result.current).toBe(true)
+
+		rerender(withoutVisibleRows(streaming(2), false))
+		expect(result.current).toBe(true)
+	})
+
+	it("does not leave a forced loader after a fresh terminal state", () => {
+		const { result, rerender } = renderLoader({
+			...inputsFor([say(1, "text", false)], { phase: "completed", seq: 1 }),
+			forceShow: true,
+		})
+		expect(result.current).toBe(true)
+
+		rerender({ ...inputsFor([say(1, "text", false)], { phase: "error", seq: 2 }), forceShow: false })
+		expect(result.current).toBe(false)
+	})
+})

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useThinkingLoaderRow.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useThinkingLoaderRow.ts
@@ -23,6 +23,8 @@ export interface ThinkingLoaderInputs {
 	/** Tail message of lastVisibleRow (last element when it is a group). */
 	lastVisibleMessage: ClineMessage | undefined
 	modifiedMessages: ClineMessage[]
+	/** A response RPC was submitted before the backend published its next TurnState. */
+	forceShow?: boolean
 }
 
 /**
@@ -181,7 +183,7 @@ export function useDebouncedLoaderVisibility(shouldShow: boolean, tailTs: number
  * anti-flash debounce for tail-finalization triggers.
  */
 export function useThinkingLoaderRow(inputs: ThinkingLoaderInputs): boolean {
-	const { turnState, lastRawMessage, groupedMessages, lastVisibleRow, lastVisibleMessage, modifiedMessages } = inputs
+	const { turnState, lastRawMessage, groupedMessages, lastVisibleRow, lastVisibleMessage, modifiedMessages, forceShow } = inputs
 
 	const isWaitingForResponse = useMemo(
 		() =>
@@ -205,7 +207,7 @@ export function useThinkingLoaderRow(inputs: ThinkingLoaderInputs): boolean {
 		lastVisibleMessage?.say !== "reasoning"
 
 	return useDebouncedLoaderVisibility(
-		isWaitingForResponse || handoffToReasoningPending,
+		forceShow === true || isWaitingForResponse || handoffToReasoningPending,
 		lastVisibleMessage?.ts,
 		lastVisibleMessage?.partial === true,
 	)

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/types/chatTypes.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/types/chatTypes.ts
@@ -11,6 +11,15 @@ export interface PendingUserMessage {
 	afterTs: number
 }
 
+export interface PendingResponse {
+	/** Locally unique submission id, used to avoid an older RPC clearing newer state. */
+	id: number
+	/** TurnState sequence observed when the RPC was sent. */
+	turnStateSeq: number | undefined
+	/** Raw backend message count observed when the RPC was sent (legacy fallback). */
+	messageCount: number
+}
+
 /**
  * Chat state interface
  */
@@ -38,6 +47,8 @@ export interface ChatState {
 	setExpandedRows: React.Dispatch<React.SetStateAction<Record<number, boolean>>>
 	pendingUserMessage: PendingUserMessage | undefined
 	setPendingUserMessage: React.Dispatch<React.SetStateAction<PendingUserMessage | undefined>>
+	pendingResponse: PendingResponse | undefined
+	setPendingResponse: React.Dispatch<React.SetStateAction<PendingResponse | undefined>>
 
 	// Refs
 	textAreaRef: React.RefObject<HTMLTextAreaElement>

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/utils/pendingResponse.test.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/utils/pendingResponse.test.ts
@@ -1,0 +1,50 @@
+import type { ClineMessage } from "@shared/ExtensionMessage"
+import { describe, expect, it } from "vitest"
+import type { PendingResponse } from "../types/chatTypes"
+import { isPendingResponseUnconfirmed, withPendingUserMessage } from "./pendingResponse"
+
+const pending: PendingResponse = { id: 1, turnStateSeq: 7, messageCount: 2 }
+
+describe("isPendingResponseUnconfirmed", () => {
+	it("stays pending while the backend TurnState is unchanged", () => {
+		expect(isPendingResponseUnconfirmed(pending, { phase: "completed", seq: 7 }, 2)).toBe(true)
+	})
+
+	it("retires on any fresher TurnState so terminal failures cannot leave a forced loader", () => {
+		expect(isPendingResponseUnconfirmed(pending, { phase: "streaming", seq: 8 }, 2)).toBe(false)
+		expect(isPendingResponseUnconfirmed(pending, { phase: "error", seq: 8 }, 2)).toBe(false)
+	})
+
+	it("retires when TurnState first appears after a legacy submission", () => {
+		expect(isPendingResponseUnconfirmed({ ...pending, turnStateSeq: undefined }, { phase: "streaming", seq: 1 }, 2)).toBe(
+			false,
+		)
+	})
+
+	it("uses backend message growth as the fallback when TurnState is unavailable", () => {
+		expect(isPendingResponseUnconfirmed(pending, undefined, 2)).toBe(true)
+		expect(isPendingResponseUnconfirmed(pending, undefined, 3)).toBe(false)
+	})
+})
+
+describe("withPendingUserMessage", () => {
+	it("provides an immediate task row before the backend transcript exists", () => {
+		const task: ClineMessage = { ts: 10, type: "say", say: "task", text: "new task", partial: false }
+
+		expect(withPendingUserMessage([], { afterTs: 0, message: task })).toEqual([task])
+	})
+
+	it("replaces the optimistic task with its backend confirmation without duplication", () => {
+		const optimistic: ClineMessage = { ts: 10, type: "say", say: "task", text: "new task", partial: false }
+		const confirmed: ClineMessage = { ...optimistic, ts: 11 }
+
+		expect(withPendingUserMessage([confirmed], { afterTs: 0, message: optimistic })).toEqual([confirmed])
+	})
+
+	it("keeps a follow-up bubble until the matching backend message arrives", () => {
+		const task: ClineMessage = { ts: 1, type: "say", say: "task", text: "task" }
+		const followup: ClineMessage = { ts: 3, type: "say", say: "user_feedback", text: "more" }
+
+		expect(withPendingUserMessage([task], { afterTs: 1, message: followup })).toEqual([task, followup])
+	})
+})

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/utils/pendingResponse.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/utils/pendingResponse.ts
@@ -1,0 +1,48 @@
+import type { ClineMessage, TurnState } from "@shared/ExtensionMessage"
+import type { PendingResponse, PendingUserMessage } from "../types/chatTypes"
+
+function sameOptimisticMessage(left: ClineMessage, right: ClineMessage): boolean {
+	const leftImages = left.images ?? []
+	const rightImages = right.images ?? []
+	const leftFiles = left.files ?? []
+	const rightFiles = right.files ?? []
+	const optimisticSay = left.say === "task" || left.say === "user_feedback"
+
+	return (
+		left.type === "say" &&
+		right.type === "say" &&
+		optimisticSay &&
+		left.say === right.say &&
+		left.text === right.text &&
+		leftImages.length === rightImages.length &&
+		leftImages.every((image, index) => image === rightImages[index]) &&
+		leftFiles.length === rightFiles.length &&
+		leftFiles.every((file, index) => file === rightFiles[index])
+	)
+}
+
+export function hasPendingMessageConfirmation(messages: ClineMessage[], pending: PendingUserMessage): boolean {
+	return messages.some((message) => message.ts > pending.afterTs && sameOptimisticMessage(message, pending.message))
+}
+
+export function withPendingUserMessage(messages: ClineMessage[], pending: PendingUserMessage | undefined): ClineMessage[] {
+	return !pending || hasPendingMessageConfirmation(messages, pending) ? messages : [...messages, pending.message]
+}
+
+/**
+ * Keep the optimistic loader only until the backend acknowledges this submission.
+ * TurnState sequence is authoritative when available; message growth is the legacy fallback.
+ */
+export function isPendingResponseUnconfirmed(
+	pendingResponse: PendingResponse | undefined,
+	turnState: TurnState | undefined,
+	messageCount: number,
+): boolean {
+	if (!pendingResponse) {
+		return false
+	}
+	if (turnState) {
+		return pendingResponse.turnStateSeq !== undefined && turnState.seq <= pendingResponse.turnStateSeq
+	}
+	return messageCount <= pendingResponse.messageCount
+}


### PR DESCRIPTION
### Related Issue

**Issue:** N/A

### Description

Shows the Thinking indicator optimistically as soon as a new task or terminal-state follow-up is submitted. New tasks receive a temporary task row so the chat area mounts immediately, and both task and follow-up submissions hand off to the next authoritative backend turn state without flicker. Failed RPCs roll back only their own optimistic state.

Follow-ups submitted during an already-streaming turn retain the authoritative streaming UI instead of forcing a duplicate loader.

### Test Procedure

- Targeted webview tests: 39 passed across message routing, loader handoff, and optimistic response state.
- `bun run check-types`: passed.
- `bun run lint`: passed across 1,175 files.
- `bun run format`: passed across all 10 changed files.
- `bun run build:webview && bun esbuild.mjs`: passed.
- Manual extension-host walkthrough: verified immediate Thinking state for both a new task and a follow-up, followed by successful file reads and responses.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Targeted tests, type checking, linting, formatting, and build are passing
- [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

![Completed new task and follow-up in the VS Code extension](https://cursor.com/artifacts/c/art-92b7f847-516d-416f-97bb-df8f9e06c441)

### Additional Notes

Optimistic state is sequence-guarded so any newer backend turn state—streaming, completed, idle, or error—retires it cleanly.