### PR TITLE
Fix duplicate "index" entry for installed marketplace plugins

### DIFF
--- a/apps/cli/src/commands/config.ts
+++ b/apps/cli/src/commands/config.ts
@@ -5,6 +5,7 @@ import {
 	type BuiltinToolAvailabilityContext,
 	createUserInstructionConfigService,
 	discoverPluginModulePaths,
+	getPluginDisplayName,
 	hasMcpSettingsFile,
 	listHookConfigFiles,
 	listPluginTools,
@@ -270,7 +271,7 @@ async function runPluginsConfigCommand(
 					continue;
 				}
 				pluginsByPath.set(filePath, {
-					name: basename(filePath, extname(filePath)),
+					name: getPluginDisplayName(filePath, directory),
 					path: filePath,
 				});
 			}

--- a/apps/cli/src/tui/interactive-config.ts
+++ b/apps/cli/src/tui/interactive-config.ts
@@ -1,7 +1,6 @@
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import {
 	basename,
-	dirname,
 	extname,
 	isAbsolute,
 	join,
@@ -11,6 +10,7 @@ import {
 import {
 	type BuiltinToolAvailabilityContext,
 	discoverPluginModulePaths,
+	getPluginDisplayName,
 	hasMcpSettingsFile,
 	listHookConfigFiles,
 	listPluginToolsWithDiagnostics,
@@ -241,40 +241,6 @@ function loadAgentConfigItems(workspaceRoot: string): InteractiveConfigItem[] {
 	}
 
 	return [...agentsById.values()];
-}
-
-function readPackageName(packageJsonPath: string): string | undefined {
-	try {
-		const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
-			name?: unknown;
-		};
-		return typeof packageJson.name === "string" && packageJson.name.trim()
-			? packageJson.name.trim()
-			: undefined;
-	} catch {
-		return undefined;
-	}
-}
-
-function getPluginDisplayName(filePath: string, searchRoot: string): string {
-	let current = dirname(filePath);
-	const root = resolve(searchRoot);
-	while (isPathWithin(root, current)) {
-		const packageJsonPath = join(current, "package.json");
-		if (existsSync(packageJsonPath)) {
-			const packageName = readPackageName(packageJsonPath);
-			if (packageName) {
-				return packageName;
-			}
-			break;
-		}
-		const parent = resolve(current, "..");
-		if (parent === current) {
-			break;
-		}
-		current = parent;
-	}
-	return basename(filePath, extname(filePath));
 }
 
 function isPathWithin(parentPath: string, childPath: string): boolean {

--- a/apps/cline-hub/src/server/user-instructions.ts
+++ b/apps/cline-hub/src/server/user-instructions.ts
@@ -1,17 +1,10 @@
-import { existsSync, readdirSync, readFileSync } from "node:fs";
-import {
-	dirname,
-	extname,
-	isAbsolute,
-	join,
-	basename as pathBasename,
-	relative,
-	resolve,
-} from "node:path";
+import { existsSync, readdirSync } from "node:fs";
+import { extname, join, basename as pathBasename } from "node:path";
 import {
 	createUserInstructionConfigService,
 	discoverPluginModulePaths,
 	getCoreBuiltinToolCatalog,
+	getPluginDisplayName,
 	listHookConfigFiles,
 	listPluginTools,
 	readGlobalSettings,
@@ -24,48 +17,6 @@ import type { JsonRecord } from "./types";
 
 function resolveAgentConfigSearchPaths(workspaceRoot?: string): string[] {
 	return resolveSharedAgentConfigSearchPaths(workspaceRoot);
-}
-
-function readPackageName(packageJsonPath: string): string | undefined {
-	try {
-		const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
-			name?: unknown;
-		};
-		return typeof packageJson.name === "string" && packageJson.name.trim()
-			? packageJson.name.trim()
-			: undefined;
-	} catch {
-		return undefined;
-	}
-}
-
-function isPathWithin(parentPath: string, childPath: string): boolean {
-	const relativePath = relative(resolve(parentPath), resolve(childPath));
-	return (
-		relativePath === "" ||
-		(!relativePath.startsWith("..") && !isAbsolute(relativePath))
-	);
-}
-
-function getPluginDisplayName(filePath: string, searchRoot: string): string {
-	let current = dirname(filePath);
-	const root = resolve(searchRoot);
-	while (isPathWithin(root, current)) {
-		const packageJsonPath = join(current, "package.json");
-		if (existsSync(packageJsonPath)) {
-			const packageName = readPackageName(packageJsonPath);
-			if (packageName) {
-				return packageName;
-			}
-			break;
-		}
-		const parent = resolve(current, "..");
-		if (parent === current) {
-			break;
-		}
-		current = parent;
-	}
-	return pathBasename(filePath, extname(filePath));
 }
 
 export async function listUserInstructionConfigs(

--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -25,6 +25,7 @@ import {
 	executeClineAccountAction,
 	getCoreBuiltinToolCatalog,
 	getLocalProviderModels,
+	getPluginDisplayName,
 	listHookConfigFiles,
 	listLocalProviders,
 	listPluginTools,
@@ -829,7 +830,7 @@ async function listUserInstructionConfigs(
 						continue;
 					}
 					pluginsByPath.set(filePath, {
-						name: basename(filePath, extname(filePath)),
+						name: getPluginDisplayName(filePath, directory),
 						path: filePath,
 						enabled: !disabledPlugins.has(filePath),
 					});

--- a/apps/vscode/src/core/controller/marketplace/marketplace-helpers.ts
+++ b/apps/vscode/src/core/controller/marketplace/marketplace-helpers.ts
@@ -1,11 +1,12 @@
 import { spawn } from "node:child_process"
 import { createHash } from "node:crypto"
-import { existsSync, readFileSync } from "node:fs"
+import { existsSync } from "node:fs"
 import { homedir, platform } from "node:os"
-import { basename, dirname, extname, isAbsolute, join, relative, resolve } from "node:path"
+import { isAbsolute, join, relative, resolve } from "node:path"
 import {
 	disablePluginMcpServersInSettings,
 	discoverPluginModulePaths,
+	getPluginDisplayName,
 	installMcpServer,
 	installPlugin,
 	isMarketplaceSkillInstalled,
@@ -406,15 +407,6 @@ export async function uninstallMarketplaceEntryFromCatalog(
 	return toProtoMarketplaceInstallResult(result)
 }
 
-function readPackageName(packageJsonPath: string): string | undefined {
-	try {
-		const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as { name?: unknown }
-		return typeof packageJson.name === "string" && packageJson.name.trim() ? packageJson.name.trim() : undefined
-	} catch {
-		return undefined
-	}
-}
-
 function isPathWithin(parentPath: string, childPath: string): boolean {
 	const relativePath = relative(resolve(parentPath), resolve(childPath))
 	return relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath))
@@ -423,23 +415,6 @@ function isPathWithin(parentPath: string, childPath: string): boolean {
 function isGlobalClinePath(filePath: string | undefined): boolean {
 	if (!filePath || filePath.startsWith("remote:")) return false
 	return [resolveClineHome(), join(homedir(), ".agents", "skills")].some((root) => isPathWithin(root, filePath))
-}
-
-function getPluginDisplayName(filePath: string, searchRoot: string): string {
-	let current = dirname(filePath)
-	const root = resolve(searchRoot)
-	while (isPathWithin(root, current)) {
-		const packageJsonPath = join(current, "package.json")
-		if (existsSync(packageJsonPath)) {
-			const packageName = readPackageName(packageJsonPath)
-			if (packageName) return packageName
-			break
-		}
-		const parent = resolve(current, "..")
-		if (parent === current) break
-		current = parent
-	}
-	return basename(filePath, extname(filePath))
 }
 
 async function listPluginLocalEntries(): Promise<MarketplaceLocalInstalledEntry[]> {

--- a/sdk/packages/core/src/extensions/index.ts
+++ b/sdk/packages/core/src/extensions/index.ts
@@ -1,6 +1,7 @@
 export type { ResolveAgentPluginPathsOptions } from "./plugin/plugin-config-loader";
 export {
 	discoverPluginModulePaths,
+	getPluginDisplayName,
 	resolveAgentPluginPaths,
 	resolveAndLoadAgentPlugins,
 	resolvePluginConfigSearchPaths,

--- a/sdk/packages/core/src/extensions/plugin/plugin-config-loader.ts
+++ b/sdk/packages/core/src/extensions/plugin/plugin-config-loader.ts
@@ -7,6 +7,7 @@ import type {
 } from "@cline/shared";
 import {
 	discoverPluginModulePaths as discoverPluginModulePathsFromShared,
+	getPluginDisplayName as getPluginDisplayNameFromShared,
 	resolveConfiguredPluginModulePaths,
 	resolvePluginConfigSearchPaths as resolvePluginConfigSearchPathsFromShared,
 	SKILLS_CONFIG_DIRECTORY_NAME,
@@ -30,6 +31,13 @@ export function resolvePluginConfigSearchPaths(
 
 export function discoverPluginModulePaths(directoryPath: string): string[] {
 	return discoverPluginModulePathsFromShared(directoryPath);
+}
+
+export function getPluginDisplayName(
+	filePath: string,
+	searchRoot?: string,
+): string {
+	return getPluginDisplayNameFromShared(filePath, searchRoot);
 }
 
 export interface ResolveAgentPluginPathsOptions {

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -233,6 +233,7 @@ export type {
 } from "./extensions";
 export {
 	discoverPluginModulePaths,
+	getPluginDisplayName,
 	loadAgentPluginFromPath,
 	loadAgentPluginsFromPaths,
 	loadAgentPluginsFromPathsWithDiagnostics,

--- a/sdk/packages/core/src/settings/settings-service.ts
+++ b/sdk/packages/core/src/settings/settings-service.ts
@@ -1,13 +1,5 @@
-import { existsSync, readFileSync } from "node:fs";
-import {
-	basename,
-	dirname,
-	extname,
-	isAbsolute,
-	join,
-	relative,
-	resolve,
-} from "node:path";
+import { existsSync } from "node:fs";
+import { basename, isAbsolute, relative, resolve } from "node:path";
 import {
 	createUserInstructionConfigService,
 	type RuleConfig,
@@ -23,6 +15,7 @@ import {
 	setMcpServerDisabled,
 } from "../extensions/mcp";
 import {
+	getPluginDisplayName,
 	resolveAgentPluginPaths,
 	resolvePluginSkillDirectoriesFromPaths,
 } from "../extensions/plugin/plugin-config-loader";
@@ -67,39 +60,6 @@ function isPathWithin(parentPath: string, childPath: string): boolean {
 		relativePath === "" ||
 		(!relativePath.startsWith("..") && !isAbsolute(relativePath))
 	);
-}
-
-function readPackageName(packageJsonPath: string): string | undefined {
-	try {
-		const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
-			name?: unknown;
-		};
-		return typeof packageJson.name === "string" && packageJson.name.trim()
-			? packageJson.name.trim()
-			: undefined;
-	} catch {
-		return undefined;
-	}
-}
-
-function getPluginDisplayName(filePath: string): string {
-	let current = dirname(filePath);
-	while (true) {
-		const packageJsonPath = join(current, "package.json");
-		if (existsSync(packageJsonPath)) {
-			const packageName = readPackageName(packageJsonPath);
-			if (packageName) {
-				return packageName;
-			}
-			break;
-		}
-		const parent = dirname(current);
-		if (parent === current) {
-			break;
-		}
-		current = parent;
-	}
-	return basename(filePath, extname(filePath));
 }
 
 type PluginSkillOwner = {

--- a/sdk/packages/shared/src/storage/index.ts
+++ b/sdk/packages/shared/src/storage/index.ts
@@ -11,6 +11,7 @@ export {
 	ensureFileExists,
 	ensureHookLogDir,
 	ensureParentDir,
+	getPluginDisplayName,
 	HOOKS_CONFIG_DIRECTORY_NAME,
 	isChatWorkspacePath,
 	isPluginModulePath,

--- a/sdk/packages/shared/src/storage/paths.test.ts
+++ b/sdk/packages/shared/src/storage/paths.test.ts
@@ -1,3 +1,5 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -6,6 +8,7 @@ import {
 	CLINE_CONNECTOR_SETTINGS_FILE_NAME,
 	CLINE_MCP_SETTINGS_FILE_NAME,
 	CLINE_WORKSPACES_DIRECTORY_NAME,
+	getPluginDisplayName,
 	HOOKS_CONFIG_DIRECTORY_NAME,
 	isChatWorkspacePath,
 	RULES_CONFIG_DIRECTORY_NAME,
@@ -276,5 +279,82 @@ describe("chat workspace paths", () => {
 		"/home/user/.cline/data/workspaces",
 	])("rejects non-chat workspace path %s", (path) => {
 		expect(isChatWorkspacePath(path)).toBe(false);
+	});
+});
+
+describe("getPluginDisplayName", () => {
+	let pluginsRoot = "";
+
+	afterEach(() => {
+		if (pluginsRoot) {
+			rmSync(pluginsRoot, { recursive: true, force: true });
+			pluginsRoot = "";
+		}
+	});
+
+	function createPluginsRoot(): string {
+		pluginsRoot = mkdtempSync(join(tmpdir(), "cline-plugin-name-"));
+		return pluginsRoot;
+	}
+
+	it("uses the nearest package.json name", () => {
+		const root = createPluginsRoot();
+		const packageDir = join(
+			root,
+			"_installed",
+			"official",
+			"my-plugin-abc123",
+			"package",
+		);
+		mkdirSync(packageDir, { recursive: true });
+		writeFileSync(
+			join(packageDir, "package.json"),
+			JSON.stringify({ name: "agent-browser" }),
+		);
+		const entryPath = join(packageDir, "index.ts");
+		writeFileSync(entryPath, "export default {};");
+
+		expect(getPluginDisplayName(entryPath, root)).toBe("agent-browser");
+	});
+
+	it("skips nameless package.json files and uses the install wrapper name", () => {
+		const root = createPluginsRoot();
+		const installDir = join(root, "_installed", "official", "my-plugin-abc123");
+		const packageDir = join(installDir, "package");
+		mkdirSync(packageDir, { recursive: true });
+		writeFileSync(
+			join(packageDir, "package.json"),
+			JSON.stringify({ private: true }),
+		);
+		writeFileSync(
+			join(installDir, "package.json"),
+			JSON.stringify({ name: "my-plugin", private: true }),
+		);
+		const entryPath = join(packageDir, "index.ts");
+		writeFileSync(entryPath, "export default {};");
+
+		expect(getPluginDisplayName(entryPath, root)).toBe("my-plugin");
+	});
+
+	it("does not read package.json files above the search root", () => {
+		const root = createPluginsRoot();
+		writeFileSync(
+			join(root, "package.json"),
+			JSON.stringify({ name: "outside-root" }),
+		);
+		const pluginDir = join(root, "plugins");
+		mkdirSync(pluginDir, { recursive: true });
+		const entryPath = join(pluginDir, "standalone.ts");
+		writeFileSync(entryPath, "export default {};");
+
+		expect(getPluginDisplayName(entryPath, pluginDir)).toBe("standalone");
+	});
+
+	it("falls back to the entry file basename without a package name", () => {
+		const root = createPluginsRoot();
+		const entryPath = join(root, "index.ts");
+		writeFileSync(entryPath, "export default {};");
+
+		expect(getPluginDisplayName(entryPath, root)).toBe("index");
 	});
 });

--- a/sdk/packages/shared/src/storage/paths.ts
+++ b/sdk/packages/shared/src/storage/paths.ts
@@ -8,7 +8,15 @@ import {
 	statSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import {
+	basename,
+	dirname,
+	extname,
+	isAbsolute,
+	join,
+	relative,
+	resolve,
+} from "node:path";
 import type { PluginManifest } from "..";
 import {
 	CLINE_CHAT_WORKSPACE_DIRECTORY_NAME,
@@ -583,6 +591,57 @@ export function discoverPluginModulePaths(directoryPath: string): string[] {
 		}
 	}
 	return discovered.sort((a, b) => a.localeCompare(b));
+}
+
+function readPluginPackageName(packageJsonPath: string): string | undefined {
+	try {
+		const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+			name?: unknown;
+		};
+		return typeof packageJson.name === "string" && packageJson.name.trim()
+			? packageJson.name.trim()
+			: undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function isPathWithin(parentPath: string, childPath: string): boolean {
+	const relativePath = relative(resolve(parentPath), resolve(childPath));
+	return (
+		relativePath === "" ||
+		(!relativePath.startsWith("..") && !isAbsolute(relativePath))
+	);
+}
+
+/**
+ * Resolves a human-readable name for a plugin entry module by walking up from
+ * the entry file toward `searchRoot` (or the filesystem root when omitted) and
+ * returning the first `package.json` `name` found. Nameless `package.json`
+ * files are skipped so installed plugins still pick up the wrapper manifest
+ * name written by `cline plugin install`. Falls back to the entry file's
+ * basename when no named package is found.
+ */
+export function getPluginDisplayName(
+	filePath: string,
+	searchRoot?: string,
+): string {
+	const root = searchRoot ? resolve(searchRoot) : undefined;
+	let current = dirname(resolve(filePath));
+	while (!root || isPathWithin(root, current)) {
+		const packageName = readPluginPackageName(
+			join(current, PLUGIN_PACKAGE_JSON_FILE_NAME),
+		);
+		if (packageName) {
+			return packageName;
+		}
+		const parent = dirname(current);
+		if (parent === current) {
+			break;
+		}
+		current = parent;
+	}
+	return basename(filePath, extname(filePath));
 }
 
 export function resolveConfiguredPluginModulePaths(


### PR DESCRIPTION
## Problem

After installing a plugin from the marketplace (e.g. Agent Browser), the Installed Plugins list showed two entries: the correct marketplace entry and a second one called `index`, pointing at the plugin's `package/index.ts` entry file.

## Root cause

The desktop-app sidecar (and the CLI `cline config plugins` listing) named discovered plugins after their entry file basename (`index`) instead of resolving the plugin's package name. Because the local item's name never matched the marketplace entry's id/name/install args, the marketplace view's dedupe logic treated it as a separate, local-only plugin and rendered both cards.

## Fix

- Add `getPluginDisplayName(filePath, searchRoot?)` to `@cline/shared/storage` (re-exported through `@cline/core`): walks up from the plugin entry module to the nearest `package.json` `name`, skipping nameless manifests so the install-wrapper name written by `cline plugin install` is used, and falls back to the entry file basename.
- Use it in the desktop-app sidecar (`loadPlugins`) and the CLI `config` command, which previously used the raw file basename.
- Replace the duplicated per-app copies of this logic in the hub server, CLI interactive config, VS Code marketplace helpers, and core `settings-service` with the shared helper.
- Add unit tests covering nearest-name resolution, nameless-manifest skipping, search-root bounding, and the basename fallback.

## Testing

- `bun -F @cline/shared test` (297 passed, includes new `getPluginDisplayName` tests)
- `bun -F @cline/core test:unit` (1496 passed; 1 pre-existing cloud-VM git-remote artifact failure documented in AGENTS.md)
- `bun -F @cline/cline-hub test` (104 passed), `bun -F @cline/cli test:unit` (957 passed), `apps/vscode bun run test:unit` (1021 passed)
- `bun run types` (all packages)
- Manual verification: installed `agent-browser` via `cline plugin install`, ran the desktop app (sidecar + web UI), and confirmed the Plugins settings page shows a single deduped "agent-browser" entry under Installed (count 1), with no extra "index" entry:

![Plugins settings page showing a single installed agent-browser entry](https://cursor.com/artifacts/c/art-e73a4c14-3ada-413f-8391-5939cd0e1d78)