### PR TITLE
fix(core): make compaction sidecar persistence reliable

### DIFF
--- a/sdk/packages/core/src/extensions/context/compaction.test.ts
+++ b/sdk/packages/core/src/extensions/context/compaction.test.ts
@@ -4,7 +4,10 @@ import {
 	type MessageWithMetadata,
 } from "@cline/shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createSessionCompactionState } from "../../session/models/session-compaction";
+import {
+	createSessionCompactionState,
+	projectSessionCompactionState,
+} from "../../session/models/session-compaction";
 import type { CoreCompactionContext } from "../../types/config";
 import { buildAgenticSummaryInputBudget } from "./agentic-compaction";
 import { runBasicCompaction } from "./basic-compaction";
@@ -3766,5 +3769,51 @@ describe("createContextCompactionPrepareTurn", () => {
 			expect.objectContaining({ messages: currentMessages }),
 		);
 		expect(saveState).not.toHaveBeenCalled();
+	});
+
+	it("passes the exact source messages to saveState so hosts can validate against them", async () => {
+		// Regression: local-runtime-host validated the persist by projecting the
+		// state against agent.getMessages(), which mid-turn can legally differ
+		// from the transcript the prepareTurn context carries (the state's hash
+		// input) — so auto-compaction persists were spuriously skipped as stale.
+		// saveState must receive the same messages the hash was computed over.
+		const compact = vi.fn().mockResolvedValue({
+			messages: [{ role: "user", content: "summary" }],
+		});
+		const saveState = vi.fn();
+		const prepareTurn = createCompactionStateAwarePrepareTurn({
+			compact,
+			getState: () => undefined,
+			saveState,
+		});
+		const currentMessages: LlmsProviders.Message[] = [
+			{ role: "user", content: "task" },
+			{ role: "assistant", content: "answer" },
+			{ role: "user", content: "follow-up" },
+		];
+
+		await prepareTurn({
+			agentId: "agent-1",
+			conversationId: "conv-1",
+			parentAgentId: null,
+			iteration: 1,
+			abortSignal: new AbortController().signal,
+			systemPrompt: "",
+			tools: [],
+			messages: currentMessages,
+			apiMessages: currentMessages,
+			model: {
+				id: "mock-model",
+				provider: "anthropic",
+				info: { id: "mock-model", maxInputTokens: 100_000 },
+			},
+		});
+
+		expect(saveState).toHaveBeenCalledTimes(1);
+		const [savedState, sourceMessages] = saveState.mock.calls[0];
+		expect(sourceMessages).toBe(currentMessages);
+		expect(
+			projectSessionCompactionState(savedState, currentMessages),
+		).toBeDefined();
 	});
 });

--- a/sdk/packages/core/src/extensions/context/compaction.ts
+++ b/sdk/packages/core/src/extensions/context/compaction.ts
@@ -566,7 +566,17 @@ export function createContextCompactionPrepareTurn(
 export function createCompactionStateAwarePrepareTurn(input: {
 	compact?: ContextPipelinePrepareTurn;
 	getState?: () => SessionCompactionState | undefined;
-	saveState?: (state: SessionCompactionState) => void | Promise<void>;
+	/**
+	 * Persist a freshly-computed compaction state. `sourceMessages` are the
+	 * exact canonical messages the state's source-prefix hash was computed
+	 * over; hosts must validate projection against these rather than a
+	 * separately derived transcript, which can legally differ mid-turn and
+	 * spuriously reject the write.
+	 */
+	saveState?: (
+		state: SessionCompactionState,
+		sourceMessages: CoreCompactionContext["messages"],
+	) => void | Promise<void>;
 }): ContextPipelinePrepareTurn {
 	return async (context) => {
 		const existingState = input.getState?.();
@@ -593,7 +603,7 @@ export function createCompactionStateAwarePrepareTurn(input: {
 					conversationId: context.conversationId,
 					systemPrompt,
 				});
-				await input.saveState?.(nextState);
+				await input.saveState?.(nextState, context.messages);
 				return {
 					...result,
 					...(systemPrompt !== undefined ? { systemPrompt } : {}),
@@ -616,7 +626,7 @@ export function createCompactionStateAwarePrepareTurn(input: {
 				conversationId: context.conversationId,
 				systemPrompt: result.systemPrompt,
 			});
-			await input.saveState?.(nextState);
+			await input.saveState?.(nextState, context.messages);
 		}
 		return result;
 	};

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
@@ -5094,6 +5094,153 @@ describe("LocalRuntimeHost", () => {
 		}
 	});
 
+	it("persists auto-compaction state against runtime messages and replaces an invalid older sidecar", async () => {
+		// Regression: the orchestrator appends the follow-up user turn to the
+		// conversation store WITHOUT id/ts while the runtime's working
+		// transcript (which prepareTurn sees, and which the compaction state's
+		// source-prefix hash is computed over) carries codec-generated id/ts.
+		// Validating the persist against agent.getMessages() therefore skipped
+		// every auto-compaction write ("Skipped stale session compaction
+		// state") and forced a full re-compaction on every subsequent turn.
+		// Additionally, an unprojectable older sidecar (e.g. invalidated by
+		// resume-time identity churn) must not permanently block a newer valid
+		// state just because its source count is larger.
+		const sessionId = "sess-compaction-auto-persist";
+		const manifest = createManifest(sessionId);
+		const priorMessages: MessageWithMetadata[] = [
+			{ role: "user", content: "task", id: "m1", ts: 1 },
+			{ role: "assistant", content: "working", id: "m2", ts: 2 },
+		];
+		// What the conversation store holds mid-turn: prior transcript plus the
+		// just-appended follow-up WITHOUT identity fields.
+		const storeMessages: MessageWithMetadata[] = [
+			...priorMessages,
+			{ role: "user", content: [{ type: "text", text: "follow-up" }] },
+		];
+		// What the runtime's prepareTurn context carries: the same transcript
+		// with codec-assigned id/ts on the follow-up.
+		const runtimeMessages: MessageWithMetadata[] = [
+			...priorMessages,
+			{
+				role: "user",
+				content: [{ type: "text", text: "follow-up" }],
+				id: "msg_generated_1",
+				ts: 3,
+			},
+		];
+		const sessionService = {
+			ensureSessionsDir: vi.fn().mockReturnValue("/tmp/sessions"),
+			createRootSessionWithArtifacts: vi.fn().mockResolvedValue({
+				manifestPath: "/tmp/manifest-compaction-auto-persist.json",
+				messagesPath: "/tmp/messages-compaction-auto-persist.json",
+				manifest,
+			}),
+			persistSessionMessages: vi.fn(),
+			persistSessionCompactionState: vi.fn(),
+			updateSessionStatus: vi.fn().mockResolvedValue({ updated: true }),
+			writeSessionManifest: vi.fn(),
+			listSessions: vi.fn().mockResolvedValue([]),
+			deleteSession: vi.fn().mockResolvedValue({ deleted: true }),
+		};
+		const createAgent = vi.fn().mockReturnValue({
+			run: vi.fn().mockResolvedValue(createResult()),
+			continue: vi.fn(),
+			abort: vi.fn(),
+			subscribeEvents: vi.fn().mockReturnValue(() => {}),
+			canStartRun: vi.fn().mockReturnValue(true),
+			getAgentId: vi.fn().mockReturnValue("agent-root-1"),
+			getConversationId: vi.fn().mockReturnValue(sessionId),
+			restore: vi.fn(),
+			shutdown: vi.fn().mockResolvedValue(undefined),
+			getMessages: vi.fn().mockReturnValue(storeMessages),
+			messages: storeMessages,
+		});
+		const manager = new RuntimeHostUnderTest({
+			distinctId,
+			sessionService: sessionService as never,
+			runtimeBuilder: {
+				build: vi.fn().mockReturnValue({
+					tools: [],
+					shutdown: vi.fn(),
+				}),
+			},
+			createAgent: createAgent as never,
+		});
+
+		await manager.startSession(
+			normalizeStartInput({
+				config: createConfig({
+					sessionId,
+					compaction: {
+						enabled: true,
+						strategy: "basic",
+						compact: vi.fn().mockResolvedValue({
+							messages: [{ role: "user", content: "summary" }],
+						}),
+					},
+				}),
+				initialMessages: priorMessages,
+				interactive: true,
+			}),
+		);
+
+		// Simulate an invalid older sidecar squatting in the session: it covers
+		// MORE messages than the live transcript (so it can never project), and
+		// under a count-first stale guard it would block every replacement.
+		const staleState = createSessionCompactionState({
+			sourceMessages: [
+				...runtimeMessages,
+				{ role: "assistant", content: "old extra message", id: "m4", ts: 4 },
+			],
+			compactedMessages: [{ role: "user", content: "stale summary" }],
+			conversationId: sessionId,
+			updatedAt: "2026-01-01T00:00:00.000Z",
+		});
+		const activeSessions = Reflect.get(manager as object, "sessions") as Map<
+			string,
+			{ compactionState?: typeof staleState }
+		>;
+		const activeSession = activeSessions.get(sessionId);
+		expect(activeSession).toBeDefined();
+		if (!activeSession) {
+			throw new Error("expected active session");
+		}
+		activeSession.compactionState = staleState;
+
+		const prepareTurn = createAgent.mock.calls[0]?.[0]?.prepareTurn;
+		expect(prepareTurn).toBeDefined();
+
+		const result = await prepareTurn({
+			agentId: "agent-root-1",
+			conversationId: sessionId,
+			parentAgentId: null,
+			iteration: 1,
+			abortSignal: new AbortController().signal,
+			systemPrompt: "",
+			tools: [],
+			messages: runtimeMessages,
+			apiMessages: runtimeMessages,
+			model: {
+				id: "mock-model",
+				provider: "mock-provider",
+				// Tiny budget so the auto trigger always fires.
+				info: { id: "mock-model", maxInputTokens: 10 },
+			},
+		});
+		expect(result?.messages).toEqual([{ role: "user", content: "summary" }]);
+
+		// The sidecar write must validate against the exact source messages the
+		// state was computed from, not the store's id-less mid-turn shapes.
+		expect(sessionService.persistSessionCompactionState).toHaveBeenCalledWith(
+			sessionId,
+			expect.objectContaining({
+				conversation_id: sessionId,
+				source_message_count: runtimeMessages.length,
+				messages: [{ role: "user", content: "summary" }],
+			}),
+		);
+	});
+
 	it("orders equal-length compaction updates by parsed timestamp", async () => {
 		const sessionId = "inactive-session";
 		const tempCwd = mkdtempSync(join(tmpdir(), "compaction-stale-"));

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -585,7 +585,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 		const prepareTurn = createCompactionStateAwarePrepareTurn({
 			compact,
 			getState: () => activeSessionRef?.compactionState,
-			saveState: async (state) => {
+			saveState: async (state, sourceMessages) => {
 				const activeSession = activeSessionRef;
 				if (!activeSession) return;
 				const stateForSession = {
@@ -593,9 +593,15 @@ export class LocalRuntimeHost implements RuntimeHost {
 					conversation_id: activeSession.sessionId,
 				};
 				try {
+					// Validate against the exact messages the state's hash was
+					// computed from. Mid-turn, `agent.getMessages()` (the
+					// conversation store) can legally differ from the runtime's
+					// working transcript, so validating against the store would
+					// spuriously reject the write.
 					const result = await this.persistActiveSessionCompactionState(
 						activeSession,
 						stateForSession,
+						sourceMessages,
 					);
 					if (!result.updated) {
 						configWithProvider.logger?.debug?.(
@@ -1283,7 +1289,25 @@ export class LocalRuntimeHost implements RuntimeHost {
 			return { updated: false };
 		}
 		return await this.enqueueCompactionStateWrite(session, async () => {
-			if (isIncomingCompactionStateStale(state, session.compactionState)) {
+			const currentState = session.compactionState;
+			const currentStateStillProjects =
+				currentState !== undefined &&
+				projectSessionCompactionState(
+					currentState,
+					sourceMessages ?? session.agent.getMessages(),
+				) !== undefined;
+			// The count-based stale guard exists to stop an old write from
+			// clobbering a newer one, which only makes sense while the stored
+			// state is still valid. An unprojectable state (e.g. invalidated by
+			// message-identity churn on resume, or a hash-format change) must
+			// not permanently block its replacement, so fall back to comparing
+			// timestamps and let the newer state win.
+			if (
+				currentState &&
+				(currentStateStillProjects
+					? isIncomingCompactionStateStale(state, currentState)
+					: Date.parse(state.updated_at) < Date.parse(currentState.updated_at))
+			) {
 				return { updated: false };
 			}
 			await this.invoke<void>(

--- a/sdk/packages/core/src/session/models/session-compaction.test.ts
+++ b/sdk/packages/core/src/session/models/session-compaction.test.ts
@@ -23,6 +23,65 @@ describe("session compaction state", () => {
 		).toThrow("Message role cannot contain ':'");
 	});
 
+	it("projects when transport identity (id/ts) was regenerated on round-trip", () => {
+		// Regression: the message codec regenerates id/ts on wire/storage
+		// round-trips (a store's just-appended user turn has none yet, and
+		// consolidated parallel tool results are re-split with minted ids on
+		// resume). The fingerprint must cover content, not the envelope, or
+		// persistence is rejected for semantically identical prefixes.
+		const toolResult = (toolUseId: string, id: string, ts: number) => ({
+			id,
+			ts,
+			role: "user" as const,
+			content: [
+				{
+					type: "tool_result" as const,
+					tool_use_id: toolUseId,
+					name: "read_files",
+					content: `result ${toolUseId}`,
+				},
+			],
+		});
+		const sourceMessages = [
+			{ id: "u1", ts: 1, role: "user" as const, content: "read three files" },
+			{
+				id: "a1",
+				ts: 2,
+				role: "assistant" as const,
+				content: ["a", "b", "c"].map((id) => ({
+					type: "tool_use" as const,
+					id,
+					name: "read_files",
+					input: { files: [`${id}.txt`] },
+				})),
+			},
+			toolResult("a", "tool-a", 3),
+			toolResult("b", "tool-b", 4),
+			toolResult("c", "tool-c", 5),
+		];
+		const compactedMessages = [
+			{ id: "summary", role: "user" as const, content: "summary" },
+		];
+		const state = createSessionCompactionState({
+			sourceMessages,
+			compactedMessages,
+			updatedAt: "2026-01-01T00:00:00.000Z",
+		});
+		// Same content after a resume round-trip: the typed turn lost its
+		// id/ts and the split tool results carry freshly minted identity.
+		const resumedMessages = [
+			{ role: "user" as const, content: "read three files" },
+			{ ...sourceMessages[1], id: "a1-regenerated", ts: 20 },
+			toolResult("a", "tool-a_tool_a", 30),
+			toolResult("b", "tool-a_tool_b", 30),
+			toolResult("c", "tool-a_tool_c", 30),
+		];
+
+		expect(projectSessionCompactionState(state, resumedMessages)).toEqual(
+			compactedMessages,
+		);
+	});
+
 	it("rejects projection when the canonical prefix was edited before the boundary", () => {
 		const sourceMessages = [
 			{ id: "u1", role: "user" as const, content: "original detail" },

--- a/sdk/packages/core/src/session/models/session-compaction.ts
+++ b/sdk/packages/core/src/session/models/session-compaction.ts
@@ -75,19 +75,25 @@ function assertBoundaryRole(role: MessageWithMetadata["role"]): void {
 
 // Hash the persisted message shape in a fixed top-level field order. Nested
 // objects keep their persisted JSON order because transcript writes are append-only.
+//
+// `id` and `ts` are deliberately NOT hashed: they are transport identity that
+// the message codec regenerates on every wire/storage round-trip (a store's
+// just-appended user turn has no id/ts yet, and consolidated parallel tool
+// results are re-split with freshly minted ids on resume). Hashing them made
+// projection fail for semantically identical prefixes, so persistence was
+// silently rejected every turn. The fingerprint covers what was said — role,
+// content, and durable metadata — not the envelope.
 function sourceMessageHashInput(message: MessageWithMetadata): unknown[] {
 	const normalized = normalizeMessageForSourceHash(message);
 	assertBoundaryRole(normalized.role);
 	return [
 		["role", normalized.role],
 		["content", normalized.content],
-		["id", normalized.id ?? null],
 		["agent", normalized.agent ?? null],
 		["sessionId", normalized.sessionId ?? null],
 		["metadata", normalized.metadata ?? null],
 		["modelInfo", normalized.modelInfo ?? null],
 		["metrics", normalized.metrics ?? null],
-		["ts", normalized.ts ?? null],
 	];
 }
 
@@ -113,7 +119,10 @@ function sourcePrefixHash(
 	count = messages.length,
 ): string {
 	const hash = createHash("sha256");
-	hash.update("cline-session-compaction-source-v1\n");
+	// v2: dropped volatile id/ts from the per-message hash input. Sidecars
+	// written with v1 fail projection once and are replaced by the next
+	// compaction (the stale-write guard permits replacing unprojectable state).
+	hash.update("cline-session-compaction-source-v2\n");
 	hash.update(`${count}\n`);
 	for (const message of messages.slice(0, count)) {
 		hash.update(JSON.stringify(sourceMessageHashInput(message)));


### PR DESCRIPTION
### Related Issue

**Issue:** N/A — root-caused during live verification of auto-compaction (context: #12739).

### Description

Auto-compaction state was silently rejected on every save (`Skipped stale session compaction state` in debug logs), forcing a full re-compaction — an extra summarizer LLM call — on every turn past the trigger. Separately, resume-time message-identity churn could leave a dead sidecar permanently blocking all replacements until the file was deleted by hand. Affects every host (the CLI ships with agentic compaction on by default; VS Code behind `useAutoCondense`).

Root cause: the sidecar's source-prefix hash included message `id`/`ts` — transport identity that core's own codec regenerates on every wire/storage round-trip — and the persist path validated the hash against a different transcript copy (`agent.getMessages()`) than the one it was computed over.

Three changes, all in `sdk/packages/core`:

1. `session-compaction.ts` — drop `id`/`ts` from the source-prefix hash; the fingerprint covers role, content, and durable metadata. Hash seed bumped to `v2`: sidecars written with `v1` fail projection once and are replaced by the next compaction (no migration needed, enabled by change 3).
2. `compaction.ts` + `local-runtime-host.ts` — `saveState` receives the exact source messages the state was computed over, and the host validates the persist against them instead of the store's mid-turn shape.
3. `local-runtime-host.ts` — the count-based stale-write guard only applies while the stored state still projects; an unprojectable state can be replaced by a newer-timestamped one, so invalidated sidecars self-heal instead of deadlocking.

### Test Procedure

- Three new regression tests, each verified red on `main` and green with the fix:
  - `session-compaction.test.ts` › "projects when transport identity (id/ts) was regenerated on round-trip"
  - `compaction.test.ts` › "passes the exact source messages to saveState so hosts can validate against them"
  - `local-runtime-host.test.ts` › "persists auto-compaction state against runtime messages and replaces an invalid older sidecar"
- Focused suites: 141/141 pass across the three touched test files; existing hash-contract tests (content/metadata edits still reject projection) unchanged and passing.
- `@cline/core` typecheck and SDK build pass; biome shows no new diagnostics.
- Equivalent fixes were previously verified live end-to-end in a VS Code Extension Development Host (sidecar written once, reused across turns and a window reload, zero `Skipped stale session compaction state` log entries).

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — SDK-only change; evidence is the red/green regression tests above.

### Additional Notes

This intentionally fixes only sidecar persistence. The related cut-selection issue (trailing parallel tool blocks compacting into net growth) is tracked separately; a reference implementation for both exists on `saoudrizwan/auto-compact-sdk-fixes-ffe2`.