### PR TITLE
feat(vscode): Support gemini 3.5 flash lite and gemini 3.6 flash

### DIFF
--- a/apps/vscode/src/shared/api.ts
+++ b/apps/vscode/src/shared/api.ts
@@ -1971,6 +1971,34 @@ export const openAiModelInfoSaneDefaults: OpenAiCompatibleModelInfo = {
 export type GeminiModelId = keyof typeof geminiModels
 export const geminiDefaultModelId: GeminiModelId = "gemini-3.1-pro-preview"
 export const geminiModels = {
+	"gemini-3.6-flash": {
+		maxTokens: 65536,
+		contextWindow: 1_048_576,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 1.5,
+		outputPrice: 7.5,
+		cacheReadsPrice: 0.15,
+		supportsReasoning: true,
+		thinkingConfig: {
+			geminiThinkingLevel: "low",
+			supportsThinkingLevel: true,
+		},
+	},
+	"gemini-3.5-flash-lite": {
+		maxTokens: 65536,
+		contextWindow: 1_048_576,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 0.3,
+		outputPrice: 2.5,
+		cacheReadsPrice: 0.03,
+		supportsReasoning: true,
+		thinkingConfig: {
+			geminiThinkingLevel: "low",
+			supportsThinkingLevel: true,
+		},
+	},
 	"gemini-3.5-flash": {
 		maxTokens: 65536,
 		contextWindow: 1_048_576,


### PR DESCRIPTION
### Related Issue

**Issue:** #12474

### Description

Add gemini-3.5-flash-lite and gemini-3.6-lite to the list or supported models.

### Test Procedure

Tested manually, it's a minor change

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

Some tests are not passing, but I'm almost certain that's unrelated to my change and instead it's related to my host system:

```
  Hostbridge - Window - getVisibleTabs
    ✔ should return empty array when no visible editors are open
    6) should return paths of visible text editors
    7) should only return visible editors, not all open tabs
    8) should return only visible editors from multiple columns with multiple files
...
```

### Screenshots

<img width="409" height="940" alt="Bildschirmfoto vom 2026-07-30 22-38-34" src="https://github.com/user-attachments/assets/0c510ea5-da9c-41f7-80e7-c307a865ea41" />


### Additional Notes

