### PR TITLE
fix(vscode): show catalog-driven reasoning effort selector for xAI, ZAI, and Moonshot

### DIFF
--- a/apps/vscode/webview-ui/src/components/settings/providers/MoonshotProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/MoonshotProvider.tsx
@@ -2,11 +2,13 @@ import { UpdateApiConfigurationRequestNew } from "@shared/proto/index.cline"
 import { Mode } from "@shared/storage/types"
 import { VSCodeDropdown, VSCodeOption } from "@vscode/webview-ui-toolkit/react"
 import { useExtensionState } from "@/context/ExtensionStateContext"
+import { useProviderConfig } from "@/hooks/useProviderConfig"
 import { useStaticProviderSelection } from "@/hooks/useStaticProviderSelection"
 import { ModelsServiceClient } from "@/services/grpc-client"
 import { ApiKeyField } from "../common/ApiKeyField"
 import { ModelInfoView } from "../common/ModelInfoView"
 import { DropdownContainer, ModelSelector } from "../common/ModelSelector"
+import ReasoningEffortSelector from "../ReasoningEffortSelector"
 
 /**
  * Props for the MoonshotProvider component
@@ -22,6 +24,7 @@ interface MoonshotProviderProps {
  */
 export const MoonshotProvider = ({ showModelOptions, isPopup, currentMode }: MoonshotProviderProps) => {
 	const { apiConfiguration } = useExtensionState()
+	const { write } = useProviderConfig("moonshot")
 
 	// Get the normalized configuration
 	const { models, selectedModelId, selectedModelInfo, hideUsageCost } = useStaticProviderSelection(
@@ -107,6 +110,17 @@ export const MoonshotProvider = ({ showModelOptions, isPopup, currentMode }: Moo
 						}}
 						selectedModelId={selectedModelId}
 					/>
+
+					{selectedModelInfo.supportsReasoning === true && (
+						<ReasoningEffortSelector
+							currentMode={currentMode}
+							onEffortChange={(effort) => {
+								void write({
+									reasoning: { enabled: effort !== "none", effort: effort !== "none" ? effort : undefined },
+								}).catch((err) => console.error("Failed to update Moonshot reasoning effort:", err))
+							}}
+						/>
+					)}
 
 					<ModelInfoView
 						hideUsageCost={hideUsageCost}

--- a/apps/vscode/webview-ui/src/components/settings/providers/XaiProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/XaiProvider.tsx
@@ -1,17 +1,13 @@
 import { openAiModelInfoSafeDefaults } from "@shared/api"
 import { Mode } from "@shared/storage/types"
-import { VSCodeCheckbox, VSCodeDropdown, VSCodeOption } from "@vscode/webview-ui-toolkit/react"
-import { useState } from "react"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { useProviderConfig } from "@/hooks/useProviderConfig"
 import { useProviderModelSelection } from "@/hooks/useProviderModelSelection"
 import { useStaticProviderSelection } from "@/hooks/useStaticProviderSelection"
-import { DROPDOWN_Z_INDEX } from "../ApiOptions"
 import { ApiKeyField } from "../common/ApiKeyField"
 import { ModelInfoView } from "../common/ModelInfoView"
-import { DropdownContainer, ModelSelector } from "../common/ModelSelector"
-import { getModeSpecificFields } from "../utils/providerUtils"
-import { useApiConfigurationHandlers } from "../utils/useApiConfigurationHandlers"
+import { ModelSelector } from "../common/ModelSelector"
+import ReasoningEffortSelector from "../ReasoningEffortSelector"
 import { useProviderApiKeyField } from "../utils/useProviderApiKeyField"
 
 const PROVIDER_ID = "xai"
@@ -38,10 +34,7 @@ interface XaiProviderProps {
 
 export const XaiProvider = ({ showModelOptions, isPopup, currentMode }: XaiProviderProps) => {
 	const { apiConfiguration } = useExtensionState()
-	const { handleModeFieldChange } = useApiConfigurationHandlers()
 	const { config, write, commitSelection } = useProviderConfig(PROVIDER_ID)
-
-	const modeFields = getModeSpecificFields(apiConfiguration, currentMode)
 
 	// Get the normalized configuration
 	const {
@@ -59,8 +52,6 @@ export const XaiProvider = ({ showModelOptions, isPopup, currentMode }: XaiProvi
 		fallbackModelInfo: legacySelectedModelInfo,
 	})
 
-	// Local state for reasoning effort toggle
-	const [reasoningEffortSelected, setReasoningEffortSelected] = useState(!!modeFields.reasoningEffort)
 	const { savedApiKeyMask, handleApiKeyChange } = useProviderApiKeyField({
 		apiKeyLength: config?.apiKeyLength,
 		providerName: "X AI",
@@ -82,17 +73,9 @@ export const XaiProvider = ({ showModelOptions, isPopup, currentMode }: XaiProvi
 	}
 
 	const handleReasoningEffortChange = (effort: string) => {
-		void write({ reasoning: { enabled: true, effort } }).catch((err) =>
-			console.error("Failed to update X AI reasoning effort:", err),
-		)
-		handleModeFieldChange({ plan: "planModeReasoningEffort", act: "actModeReasoningEffort" }, effort, currentMode)
-	}
-
-	const handleReasoningEffortDisabled = () => {
-		void write({ reasoning: { enabled: false, effort: "none" } }).catch((err) =>
-			console.error("Failed to disable X AI reasoning effort:", err),
-		)
-		handleModeFieldChange({ plan: "planModeReasoningEffort", act: "actModeReasoningEffort" }, "", currentMode)
+		void write({
+			reasoning: { enabled: effort !== "none", effort: effort !== "none" ? effort : undefined },
+		}).catch((err) => console.error("Failed to update X AI reasoning effort:", err))
 	}
 
 	return (
@@ -126,48 +109,8 @@ export const XaiProvider = ({ showModelOptions, isPopup, currentMode }: XaiProvi
 						selectedModelId={selectedModelId}
 					/>
 
-					{selectedModelId && selectedModelId.includes("3-mini") && (
-						<>
-							<VSCodeCheckbox
-								checked={reasoningEffortSelected}
-								onChange={(e: any) => {
-									const isChecked = e.target.checked === true
-									setReasoningEffortSelected(isChecked)
-									if (!isChecked) {
-										handleReasoningEffortDisabled()
-									}
-								}}
-								style={{ marginTop: 0 }}>
-								Modify reasoning effort
-							</VSCodeCheckbox>
-
-							{reasoningEffortSelected && (
-								<div>
-									<label htmlFor="reasoning-effort-dropdown">
-										<span style={{}}>Reasoning Effort</span>
-									</label>
-									<DropdownContainer className="dropdown-container" zIndex={DROPDOWN_Z_INDEX - 100}>
-										<VSCodeDropdown
-											id="reasoning-effort-dropdown"
-											onChange={(event) => handleReasoningEffortChange(getEventValue(event))}
-											style={{ width: "100%", marginTop: 3 }}
-											value={modeFields.reasoningEffort || "high"}>
-											<VSCodeOption value="low">low</VSCodeOption>
-											<VSCodeOption value="high">high</VSCodeOption>
-										</VSCodeDropdown>
-									</DropdownContainer>
-									<p
-										style={{
-											fontSize: "12px",
-											marginTop: 3,
-											marginBottom: 0,
-											color: "var(--vscode-descriptionForeground)",
-										}}>
-										High effort may produce more thorough analysis but takes longer and uses more tokens.
-									</p>
-								</div>
-							)}
-						</>
+					{selectedModelInfo.supportsReasoning === true && (
+						<ReasoningEffortSelector currentMode={currentMode} onEffortChange={handleReasoningEffortChange} />
 					)}
 
 					<ModelInfoView

--- a/apps/vscode/webview-ui/src/components/settings/providers/ZAiProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/ZAiProvider.tsx
@@ -8,6 +8,7 @@ import { useStaticProviderSelection } from "@/hooks/useStaticProviderSelection"
 import { ApiKeyField } from "../common/ApiKeyField"
 import { ModelInfoView } from "../common/ModelInfoView"
 import { DropdownContainer, ModelSelector } from "../common/ModelSelector"
+import ReasoningEffortSelector from "../ReasoningEffortSelector"
 import { useProviderApiKeyField } from "../utils/useProviderApiKeyField"
 
 const PROVIDER_ID = "zai"
@@ -128,6 +129,17 @@ export const ZAiProvider = ({ showModelOptions, isPopup, currentMode }: ZAiProvi
 						onChange={(event: Event) => handleModelChange(getEventValue(event))}
 						selectedModelId={selectedModelId}
 					/>
+
+					{selectedModelInfo.supportsReasoning === true && (
+						<ReasoningEffortSelector
+							currentMode={currentMode}
+							onEffortChange={(effort) => {
+								void write({
+									reasoning: { enabled: effort !== "none", effort: effort !== "none" ? effort : undefined },
+								}).catch((err) => console.error("Failed to update Z AI reasoning effort:", err))
+							}}
+						/>
+					)}
 
 					<ModelInfoView
 						hideUsageCost={hideUsageCost}

--- a/apps/vscode/webview-ui/src/components/settings/providers/providerReasoningControls.test.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/providerReasoningControls.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from "@testing-library/react"
+import type { ChangeEventHandler, ReactNode } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { useProviderConfig } from "@/hooks/useProviderConfig"
+import { useProviderModels } from "@/hooks/useProviderModels"
+import { MoonshotProvider } from "./MoonshotProvider"
+import { XaiProvider } from "./XaiProvider"
+import { ZAiProvider } from "./ZAiProvider"
+
+vi.mock("@/hooks/useProviderModels", () => ({
+	useProviderModels: vi.fn(),
+}))
+
+vi.mock("@/hooks/useProviderUsageCostDisplay", () => ({
+	useProviderUsageCostDisplay: () => "show",
+}))
+
+vi.mock("@/hooks/useProviderConfig", () => ({
+	useProviderConfig: vi.fn(),
+}))
+
+vi.mock("@/context/ExtensionStateContext", () => ({
+	useExtensionState: () => ({ apiConfiguration: {}, planActSeparateModelsSetting: false }),
+}))
+
+vi.mock("@/services/grpc-client", () => ({
+	ModelsServiceClient: { updateApiConfiguration: vi.fn(async () => undefined) },
+	StateServiceClient: { updateSettings: vi.fn(async () => undefined) },
+}))
+
+// Render the dropdown web components as native elements so value/change
+// behavior is observable in jsdom. Other toolkit components stay real.
+vi.mock("@vscode/webview-ui-toolkit/react", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@vscode/webview-ui-toolkit/react")>()
+	return {
+		...actual,
+		VSCodeDropdown: ({
+			children,
+			id,
+			onChange,
+			value,
+		}: {
+			children?: ReactNode
+			id?: string
+			onChange?: ChangeEventHandler<HTMLSelectElement>
+			value?: string
+		}) => (
+			<select id={id} onChange={onChange} value={value}>
+				{children}
+			</select>
+		),
+		VSCodeOption: ({ children, value }: { children?: ReactNode; value?: string }) => (
+			<option value={value}>{children}</option>
+		),
+	}
+})
+
+function mockModels(models: Record<string, object>, defaultModelId: string) {
+	vi.mocked(useProviderModels).mockReturnValue({
+		models: models as never,
+		defaultModelId,
+		isLoading: false,
+		isStale: false,
+		error: undefined,
+		refresh: vi.fn(),
+		fingerprint: "fingerprint",
+	})
+}
+
+const REASONING_MODELS = {
+	"reasoning-model": { name: "Reasoning Model", contextWindow: 128_000, supportsReasoning: true },
+	"plain-model": { name: "Plain Model", contextWindow: 128_000 },
+}
+
+beforeEach(() => {
+	vi.mocked(useProviderConfig).mockReturnValue({
+		config: undefined,
+		write: vi.fn(async () => undefined),
+		commitSelection: vi.fn(async () => undefined),
+	} as never)
+})
+
+// The reasoning-effort selector must be driven by the catalog's
+// `supportsReasoning` flag for providers with dedicated settings components,
+// the same as GenericProviderSettings-backed providers.
+describe.each([
+	["XaiProvider", XaiProvider],
+	["ZAiProvider", ZAiProvider],
+	["MoonshotProvider", MoonshotProvider],
+] as const)("%s reasoning controls", (_name, Provider) => {
+	it("shows the reasoning effort selector for reasoning-capable models", () => {
+		mockModels(REASONING_MODELS, "reasoning-model")
+
+		render(<Provider currentMode="act" showModelOptions={true} />)
+
+		expect(screen.getByText("Reasoning Effort")).toBeInTheDocument()
+	})
+
+	it("hides the reasoning effort selector for non-reasoning models", () => {
+		mockModels(REASONING_MODELS, "plain-model")
+
+		render(<Provider currentMode="act" showModelOptions={true} />)
+
+		expect(screen.queryByText("Reasoning Effort")).not.toBeInTheDocument()
+	})
+})


### PR DESCRIPTION

The xAI, Z AI, and Moonshot settings components were never wired to the catalog's reasoning capability: xAI only offered a legacy low/high checkbox hardcoded to grok-3-mini model ids, and Z AI / Moonshot had no reasoning control at all, even though models.dev marks grok-4.5, glm-5, kimi-k2-thinking, etc. as reasoning models. Every catalog-driven provider (GenericProviderSettings, OpenRouter/Vercel/Requesty pickers) already gates ReasoningEffortSelector on supportsReasoning.

Render the shared ReasoningEffortSelector in these three components when the selected model's catalog info advertises reasoning, persisting the choice to the provider config the same way GenericProviderSettings does.

<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
