### PR TITLE
fix(vscode): remove misleading reasoning effort controls

### DIFF
--- a/apps/vscode/webview-ui/src/components/settings/providers/MoonshotProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/MoonshotProvider.tsx
@@ -2,13 +2,11 @@ import { UpdateApiConfigurationRequestNew } from "@shared/proto/index.cline"
 import { Mode } from "@shared/storage/types"
 import { VSCodeDropdown, VSCodeOption } from "@vscode/webview-ui-toolkit/react"
 import { useExtensionState } from "@/context/ExtensionStateContext"
-import { useProviderConfig } from "@/hooks/useProviderConfig"
 import { useStaticProviderSelection } from "@/hooks/useStaticProviderSelection"
 import { ModelsServiceClient } from "@/services/grpc-client"
 import { ApiKeyField } from "../common/ApiKeyField"
 import { ModelInfoView } from "../common/ModelInfoView"
 import { DropdownContainer, ModelSelector } from "../common/ModelSelector"
-import ReasoningEffortSelector from "../ReasoningEffortSelector"
 
 /**
  * Props for the MoonshotProvider component
@@ -24,7 +22,6 @@ interface MoonshotProviderProps {
  */
 export const MoonshotProvider = ({ showModelOptions, isPopup, currentMode }: MoonshotProviderProps) => {
 	const { apiConfiguration } = useExtensionState()
-	const { write } = useProviderConfig("moonshot")
 
 	// Get the normalized configuration
 	const { models, selectedModelId, selectedModelInfo, hideUsageCost } = useStaticProviderSelection(
@@ -110,17 +107,6 @@ export const MoonshotProvider = ({ showModelOptions, isPopup, currentMode }: Moo
 						}}
 						selectedModelId={selectedModelId}
 					/>
-
-					{selectedModelInfo.supportsReasoning === true && (
-						<ReasoningEffortSelector
-							currentMode={currentMode}
-							onEffortChange={(effort) => {
-								void write({
-									reasoning: { enabled: effort !== "none", effort: effort !== "none" ? effort : undefined },
-								}).catch((err) => console.error("Failed to update Moonshot reasoning effort:", err))
-							}}
-						/>
-					)}
 
 					<ModelInfoView
 						hideUsageCost={hideUsageCost}

--- a/apps/vscode/webview-ui/src/components/settings/providers/ZAiProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/ZAiProvider.tsx
@@ -8,7 +8,6 @@ import { useStaticProviderSelection } from "@/hooks/useStaticProviderSelection"
 import { ApiKeyField } from "../common/ApiKeyField"
 import { ModelInfoView } from "../common/ModelInfoView"
 import { DropdownContainer, ModelSelector } from "../common/ModelSelector"
-import ReasoningEffortSelector from "../ReasoningEffortSelector"
 import { useProviderApiKeyField } from "../utils/useProviderApiKeyField"
 
 const PROVIDER_ID = "zai"
@@ -129,17 +128,6 @@ export const ZAiProvider = ({ showModelOptions, isPopup, currentMode }: ZAiProvi
 						onChange={(event: Event) => handleModelChange(getEventValue(event))}
 						selectedModelId={selectedModelId}
 					/>
-
-					{selectedModelInfo.supportsReasoning === true && (
-						<ReasoningEffortSelector
-							currentMode={currentMode}
-							onEffortChange={(effort) => {
-								void write({
-									reasoning: { enabled: effort !== "none", effort: effort !== "none" ? effort : undefined },
-								}).catch((err) => console.error("Failed to update Z AI reasoning effort:", err))
-							}}
-						/>
-					)}
 
 					<ModelInfoView
 						hideUsageCost={hideUsageCost}

--- a/apps/vscode/webview-ui/src/components/settings/providers/providerReasoningControls.test.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/providerReasoningControls.test.tsx
@@ -80,24 +80,30 @@ beforeEach(() => {
 	} as never)
 })
 
-// The reasoning-effort selector must be driven by the catalog's
-// `supportsReasoning` flag for providers with dedicated settings components,
-// the same as GenericProviderSettings-backed providers.
-describe.each([
-	["XaiProvider", XaiProvider],
-	["ZAiProvider", ZAiProvider],
-	["MoonshotProvider", MoonshotProvider],
-] as const)("%s reasoning controls", (_name, Provider) => {
+describe("XaiProvider reasoning controls", () => {
 	it("shows the reasoning effort selector for reasoning-capable models", () => {
 		mockModels(REASONING_MODELS, "reasoning-model")
 
-		render(<Provider currentMode="act" showModelOptions={true} />)
+		render(<XaiProvider currentMode="act" showModelOptions={true} />)
 
 		expect(screen.getByText("Reasoning Effort")).toBeInTheDocument()
 	})
 
 	it("hides the reasoning effort selector for non-reasoning models", () => {
 		mockModels(REASONING_MODELS, "plain-model")
+
+		render(<XaiProvider currentMode="act" showModelOptions={true} />)
+
+		expect(screen.queryByText("Reasoning Effort")).not.toBeInTheDocument()
+	})
+})
+
+describe.each([
+	["ZAiProvider", ZAiProvider],
+	["MoonshotProvider", MoonshotProvider],
+] as const)("%s reasoning controls", (_name, Provider) => {
+	it("does not offer effort levels that the native provider routing cannot honor", () => {
+		mockModels(REASONING_MODELS, "reasoning-model")
 
 		render(<Provider currentMode="act" showModelOptions={true} />)
 


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Follow-up to #12754.

Removes the reasoning-effort selectors added for Moonshot and Z.AI. Their current native routing exposes reasoning as a boolean thinking control, so `low`, `medium`, `high`, and `xhigh` produced equivalent requests while implying different behavior in the UI.

xAI remains unchanged. Restoring Moonshot or Z.AI controls should happen only after the webview can distinguish catalog-advertised toggle, effort, and fixed-reasoning models.

### Test Procedure

- `bun run test -- src/components/settings/providers/providerReasoningControls.test.tsx` — 4 passed
- `bun run test` in `apps/vscode/webview-ui` — 49 files, 384 tests passed
- `bun run lint` in `apps/vscode` — passed
- `bun run build:sdk` — passed
- `bun run check-types` in `apps/vscode` — passed
- `bun run format --write` and `git diff --check` — passed

The focused test verifies that xAI retains its reasoning-effort selector while Moonshot and Z.AI do not expose effort levels their native routes cannot honor.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not included. This change only removes two misleading selectors, and the resulting visibility is covered by the focused component test.

### Additional Notes

This PR intentionally does not address the separate mode-specific UI versus provider-global persistence concern from #12754.
