### PR TITLE
Fix delay when switching to ClinePass provider in settings

### DIFF
--- a/apps/vscode/src/core/controller/models/__tests__/handleClinePassProviderSelection.test.ts
+++ b/apps/vscode/src/core/controller/models/__tests__/handleClinePassProviderSelection.test.ts
@@ -1,9 +1,13 @@
-import * as assert from "assert"
-import { afterEach, beforeEach, describe, it } from "mocha"
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
 import sinon from "sinon"
 import { Logger } from "@/shared/services/Logger"
 import type { Controller } from "../../index"
 import { clearOrganizationForClinePassProviderSelection } from "../handleClinePassProviderSelection"
+
+/** Let the fire-and-forget switchAccount promise chain settle. */
+function flushMicrotasks(): Promise<void> {
+	return new Promise((resolve) => setImmediate(resolve))
+}
 
 describe("clearOrganizationForClinePassProviderSelection", () => {
 	let sandbox: sinon.SinonSandbox
@@ -25,36 +29,37 @@ describe("clearOrganizationForClinePassProviderSelection", () => {
 		} as unknown as Controller
 	}
 
-	it("does nothing when ClinePass is not selected", async () => {
-		await clearOrganizationForClinePassProviderSelection(createController(), {
+	it("does nothing when ClinePass is not selected", () => {
+		clearOrganizationForClinePassProviderSelection(createController(), {
 			planModeApiProvider: "cline",
 			actModeApiProvider: "openrouter",
 		})
 
-		assert.strictEqual(switchAccount.callCount, 0)
+		expect(switchAccount.callCount).toBe(0)
 	})
 
-	it("switches to the personal account when ClinePass is selected", async () => {
-		await clearOrganizationForClinePassProviderSelection(createController(), {
+	it("switches to the personal account when ClinePass is selected without blocking the caller", () => {
+		clearOrganizationForClinePassProviderSelection(createController(), {
 			planModeApiProvider: "cline-pass",
 			actModeApiProvider: "openrouter",
 		})
 
-		assert.strictEqual(switchAccount.callCount, 1)
-		assert.strictEqual(switchAccount.firstCall.args[0], null)
+		expect(switchAccount.callCount).toBe(1)
+		expect(switchAccount.firstCall.args[0]).toBeUndefined()
 	})
 
 	it("logs and swallows account switch failures", async () => {
 		const error = new Error("not signed in")
 		switchAccount.rejects(error)
 
-		await clearOrganizationForClinePassProviderSelection(createController(), {
+		clearOrganizationForClinePassProviderSelection(createController(), {
 			planModeApiProvider: "cline",
 			actModeApiProvider: "cline-pass",
 		})
+		await flushMicrotasks()
 
-		assert.strictEqual(switchAccount.callCount, 1)
-		assert.strictEqual(switchAccount.firstCall.args[0], null)
-		assert.ok((Logger.debug as sinon.SinonStub).calledOnce)
+		expect(switchAccount.callCount).toBe(1)
+		expect(switchAccount.firstCall.args[0]).toBeUndefined()
+		expect((Logger.debug as sinon.SinonStub).calledOnce).toBe(true)
 	})
 })

--- a/apps/vscode/src/core/controller/models/handleClinePassProviderSelection.ts
+++ b/apps/vscode/src/core/controller/models/handleClinePassProviderSelection.ts
@@ -7,13 +7,18 @@ export const CLINE_PASS_PROVIDER_ID = "cline-pass"
 /**
  * ClinePass always uses the user's personal Cline account balance.
  *
+ * The account switch is a network round-trip (plus a possible token refresh),
+ * so it runs fire-and-forget: callers must not block the config update — or
+ * the state post that re-renders the settings UI — on it. Auth state changes
+ * propagate to the webview separately once the switch completes.
+ *
  * This is intentionally best-effort: selecting the provider should still be
  * saved even if the account switch fails.
  */
-export async function clearOrganizationForClinePassProviderSelection(
+export function clearOrganizationForClinePassProviderSelection(
 	controller: Controller,
 	apiConfiguration: Pick<ApiConfiguration, "planModeApiProvider" | "actModeApiProvider">,
-): Promise<void> {
+): void {
 	if (
 		apiConfiguration.planModeApiProvider !== CLINE_PASS_PROVIDER_ID &&
 		apiConfiguration.actModeApiProvider !== CLINE_PASS_PROVIDER_ID
@@ -21,9 +26,7 @@ export async function clearOrganizationForClinePassProviderSelection(
 		return
 	}
 
-	try {
-		await controller.accountService.switchAccount(undefined)
-	} catch (error) {
+	controller.accountService.switchAccount(undefined).catch((error) => {
 		Logger.debug("Failed to switch ClinePass to personal account", { error })
-	}
+	})
 }

--- a/apps/vscode/src/core/controller/models/updateApiConfiguration.ts
+++ b/apps/vscode/src/core/controller/models/updateApiConfiguration.ts
@@ -145,7 +145,7 @@ export async function updateApiConfiguration(controller: Controller, request: Up
 					options,
 				),
 			)
-			await clearOrganizationForClinePassProviderSelection(controller, controller.stateManager.getApiConfiguration())
+			clearOrganizationForClinePassProviderSelection(controller, controller.stateManager.getApiConfiguration())
 		}
 
 		// Update the task's API model shim if there's an active task

--- a/apps/vscode/src/core/controller/models/updateApiConfigurationPartial.ts
+++ b/apps/vscode/src/core/controller/models/updateApiConfigurationPartial.ts
@@ -45,7 +45,7 @@ export async function updateApiConfigurationPartial(
 
 		// Update storage and task API model shim
 		controller.stateManager.setApiConfiguration(normalizedConfig)
-		await clearOrganizationForClinePassProviderSelection(controller, normalizedConfig)
+		clearOrganizationForClinePassProviderSelection(controller, normalizedConfig)
 		if (controller.task) {
 			const currentMode = controller.stateManager.getGlobalSettingsKey("mode")
 			const modelId = resolveActiveModelIdFromApiConfiguration(normalizedConfig, currentMode)

--- a/apps/vscode/src/core/controller/models/updateApiConfigurationProto.ts
+++ b/apps/vscode/src/core/controller/models/updateApiConfigurationProto.ts
@@ -141,7 +141,7 @@ export async function updateApiConfigurationProto(
 
 		// Update the API configuration in storage
 		controller.stateManager.setApiConfiguration(normalizedApiConfiguration)
-		await clearOrganizationForClinePassProviderSelection(controller, normalizedApiConfiguration)
+		clearOrganizationForClinePassProviderSelection(controller, normalizedApiConfiguration)
 
 		// Update the task's API handler if there's an active task
 		if (controller.task) {


### PR DESCRIPTION
### Related Issue

**Issue:** N/A (reported directly: switching the provider in settings to Cline Pass shows a delay before the provider panel opens)

### Description

Selecting ClinePass in the settings provider dropdown felt slow: the panel kept showing the previous provider (e.g. OpenRouter) for a noticeable moment before switching.

The webview renders `selectedProvider` from extension state, so it only switches after `postStateToWebview()`. But `updateApiConfigurationProto` (and the other two config-update handlers) `await`ed `clearOrganizationForClinePassProviderSelection` — a `PUT /active-account` network round-trip plus a possible token refresh — **before** posting state. The whole account switch latency was on the critical path of the settings re-render.

The fix makes the personal-account switch fire-and-forget:

- `clearOrganizationForClinePassProviderSelection` now returns `void` and runs `switchAccount` in the background, logging failures. It was already documented as best-effort (selection is saved even if the switch fails), and auth state changes propagate to the webview separately via `sendAuthStatusUpdate` once the switch completes.
- `updateApiConfiguration`, `updateApiConfigurationPartial`, and `updateApiConfigurationProto` no longer await it, so `postStateToWebview()` runs immediately.

Also fixes the helper's test suite, which previously never ran: it imported `mocha` but lives under `__tests__`, which is excluded by both the bun unit runner (only picks up `bun:test` files) and the `.vscode-test.mjs` glob (excludes `__tests__`). It's now a `bun:test` suite picked up by `bun run test:unit`, and its stale `null`-vs-`undefined` assertion (left over from the SDK migration changing `switchAccount(null)` to `switchAccount(undefined)`) is corrected.

### Test Procedure

- `bun run test:unit` — all 70 files pass (1025 tests, 0 failures), including the converted ClinePass suite with a new assertion that `switchAccount` fires without blocking the caller and that failures are still swallowed/logged.
- `bun run check-types` passes (extension + webview + vscode-compat).
- Manual test in the extension dev host with a temporary 2.5s delay injected into `switchAccount` to simulate a signed-in user's network round-trip: before the fix the panel visibly stalls on OpenRouter for ~2.5–3s after picking ClinePass (dropdown text even snaps back to the old provider); after the fix the ClinePass panel renders immediately while the account switch completes in the background. The temporary delay was removed before committing.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Before the fix — ~2.5s after selecting ClinePass in the dropdown, the panel still shows the OpenRouter fields (simulated network latency on the account switch):

![Before: panel still shows OpenRouter after selecting ClinePass](https://cursor.com/artifacts/c/art-4abc8f7e-8573-4db2-aaa9-52ea02a2b959)

After the fix — the ClinePass panel renders immediately after selection, with the same simulated latency still injected:

![After: ClinePass panel renders immediately](https://cursor.com/artifacts/c/art-18c335fb-2d3d-4e32-bb10-523611a72ac1)

### Additional Notes

The trigger condition is unchanged: the switch still fires on any config update while ClinePass is selected in either mode, preserving the existing "ClinePass always uses the personal account" behavior — it just no longer blocks the UI.