### PR TITLE
Restyle compact-task confirmation as a bordered card with even spacing

### DIFF
--- a/apps/vscode/webview-ui/src/components/chat/task-header/ContextWindow.stories.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/task-header/ContextWindow.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { createStorybookDecorator } from "@/config/StorybookDecorator"
+import ContextWindow from "./ContextWindow"
+
+const meta: Meta<typeof ContextWindow> = {
+	title: "Views/Components/ContextWindow",
+	component: ContextWindow,
+	parameters: {
+		layout: "padded",
+		docs: {
+			description: {
+				component:
+					"ContextWindow shows token usage against the model's context window and hosts the compact-task button with its inline confirmation card. The decorator mimics the expanded TaskHeader card so spacing and contrast are representative.",
+			},
+		},
+	},
+	decorators: [
+		createStorybookDecorator(
+			undefined,
+			// Mirror TaskHeader's expanded card surface so the compact
+			// confirmation is previewed against its real background.
+			"rounded-sm border-1 pt-2 pb-2 px-2 bg-(--vscode-toolbar-hoverBackground)/65",
+		),
+	],
+	argTypes: {
+		contextWindow: { control: "number", description: "Model context window size" },
+		lastApiReqTotalTokens: { control: "number", description: "Tokens used by the last request" },
+	},
+}
+
+export default meta
+type Story = StoryObj<typeof ContextWindow>
+
+export const HighUsage: Story = {
+	args: {
+		contextWindow: 200_000,
+		lastApiReqTotalTokens: 146_000,
+		tokensIn: 45_000,
+		tokensOut: 28_000,
+		cacheWrites: 5_200,
+		cacheReads: 3_800,
+		useAutoCondense: false,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: "High context usage. Click the fold icon to open the compact-task confirmation card.",
+			},
+		},
+	},
+}

--- a/apps/vscode/webview-ui/src/components/chat/task-header/ContextWindow.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/task-header/ContextWindow.test.tsx
@@ -67,7 +67,7 @@ describe("ContextWindow compact button", () => {
 		)
 
 		fireEvent.click(screen.getByRole("button", { name: /compact task/i }))
-		fireEvent.click(screen.getByRole("button", { name: /yes/i }))
+		fireEvent.click(screen.getByRole("button", { name: /^compact$/i }))
 
 		await waitFor(() => expect(condense).toHaveBeenCalledWith({ value: "compact" }))
 		expect(onSendMessage).not.toHaveBeenCalled()

--- a/apps/vscode/webview-ui/src/components/chat/task-header/ContextWindow.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/task-header/ContextWindow.tsx
@@ -29,9 +29,12 @@ const ConfirmationDialog = memo<{
 	onConfirm: (e: React.MouseEvent) => void
 	onCancel: (e: React.MouseEvent) => void
 }>(({ onConfirm, onCancel }) => (
-	<div className="text-sm my-2 flex items-center gap-0 justify-between">
-		<span className="font-semibold text-sm">Compact the current task?</span>
-		<span className="flex gap-1">
+	<div className="mt-2 flex flex-col gap-2 rounded-sm border border-border-panel bg-code p-2 text-sm">
+		<span className="font-semibold">Compact the current task?</span>
+		<span className="text-xs text-description">
+			Replaces the conversation history with a summary to free up context window space.
+		</span>
+		<span className="flex justify-end gap-1.5">
 			<VSCodeButton
 				appearance="secondary"
 				className="text-sm"
@@ -47,7 +50,7 @@ const ConfirmationDialog = memo<{
 				onClick={onConfirm}
 				title="Yes, compact the task"
 				type="button">
-				Yes
+				Compact
 			</VSCodeButton>
 		</span>
 	</div>
@@ -144,7 +147,7 @@ const ContextWindow: React.FC<ContextWindowProgressProps> = ({
 	}
 
 	return (
-		<div className="flex flex-col my-1.5" onMouseLeave={debounceCloseHover}>
+		<div className="flex flex-col mt-1.5" onMouseLeave={debounceCloseHover}>
 			<div className="flex gap-1 flex-row @max-xs:flex-col @max-xs:items-start items-center text-sm">
 				<div className="flex items-center gap-1.5 flex-1 whitespace-nowrap">
 					<span className="cursor-pointer text-sm" title="Current tokens used in this request">


### PR DESCRIPTION
### Related Issue

N/A — small cosmetic fix.

### Description

Clicking the compact button in the task header showed a bare, unstyled confirmation row ("Compact the current task?" with Cancel/Yes) whose stray bottom margin (`my-2`) stacked on the header card's own bottom padding, leaving a dead gap under the buttons.

Changes in `ContextWindow.tsx`:

- The confirmation is now a distinct bordered card (`bg-code` editor background against the header's toolbar surface) with a bold title, a short muted description of what compacting does, and right-aligned Cancel / Compact buttons.
- The dialog's bottom margin is removed and the `ContextWindow` wrapper's `my-1.5` becomes `mt-1.5`, so spacing above and below the card is symmetric and the extra padding under it is gone.
- The confirm button label changes from "Yes" to "Compact".

Also adds `ContextWindow.stories.tsx` — a Storybook story that mirrors the expanded TaskHeader surface so the context window row and its confirmation can be previewed in isolation (the TaskHeader stories can't render this row because the model-info gRPC call doesn't resolve in Storybook).

### Test Procedure

- Updated `ContextWindow.test.tsx` for the renamed confirm button; full webview-ui suite passes (49 files, 386 tests).
- `tsc -b` and `biome check` clean on the touched files.
- Manually exercised open / cancel / re-open in the new Storybook story.

Before:

![Compact confirmation before: bare row with dead space below the buttons](https://cursor.com/artifacts/c/art-fd35e203-1e52-41ce-a3b3-ab0562b6c967)

After:

![Compact confirmation after: bordered card with title, description, and even spacing](https://cursor.com/artifacts/c/art-da3209e1-a093-44d7-b63a-6762eb20ff28)

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

See before/after above.

### Additional Notes

None.