### PR TITLE
fix(ui): harden search combobox interactions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -733,7 +733,7 @@
     },
     "sdk/packages/ui": {
       "name": "@cline/ui",
-      "version": "0.2.0-next.1",
+      "version": "0.2.0-next.2",
       "devDependencies": {
         "@fontsource-variable/schibsted-grotesk": "^5.2.8",
         "@fontsource/azeret-mono": "^5.2.9",

--- a/sdk/packages/ui/components/search-combobox.css
+++ b/sdk/packages/ui/components/search-combobox.css
@@ -121,6 +121,7 @@
 	flex-direction: column;
 	gap: 0.125rem;
 	overflow-y: auto;
+	overscroll-behavior: contain;
 	padding: 0.375rem;
 }
 
@@ -134,6 +135,8 @@
 	border-radius: var(--radius-md);
 	background: transparent;
 	color: var(--foreground);
+	contain-intrinsic-block-size: auto 2rem;
+	content-visibility: auto;
 	font: inherit;
 	padding: 0.375rem 0.5rem;
 	text-align: left;

--- a/sdk/packages/ui/components/search-combobox.tsx
+++ b/sdk/packages/ui/components/search-combobox.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import {
+	type KeyboardEvent as ReactKeyboardEvent,
+	type ReactNode,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 
 export interface SearchComboboxOption {
 	description?: string;
@@ -43,6 +50,7 @@ export function SearchCombobox({
 	const [open, setOpen] = useState(false);
 	const [search, setSearch] = useState("");
 	const containerRef = useRef<HTMLDivElement>(null);
+	const triggerRef = useRef<HTMLButtonElement>(null);
 
 	useEffect(() => {
 		if (!open) {
@@ -74,6 +82,15 @@ export function SearchCombobox({
 		if (disabled) return;
 		if (option.value !== value) onValueChange(option.value);
 		setOpen(false);
+		triggerRef.current?.focus();
+	};
+
+	const handlePanelKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+		if (event.key !== "Escape") return;
+		event.preventDefault();
+		event.stopPropagation();
+		setOpen(false);
+		triggerRef.current?.focus();
 	};
 
 	return (
@@ -88,6 +105,7 @@ export function SearchCombobox({
 					.join(" ")}
 				disabled={disabled}
 				onClick={() => setOpen((current) => !current)}
+				ref={triggerRef}
 				title={displayedValue}
 				type="button"
 			>
@@ -105,6 +123,7 @@ export function SearchCombobox({
 						`cline-ui-search-combobox__panel--${align}`,
 						`cline-ui-search-combobox__panel--${placement}`,
 					].join(" ")}
+					onKeyDown={handlePanelKeyDown}
 					role="dialog"
 				>
 					<div className="cline-ui-search-combobox__search-row">
@@ -124,11 +143,13 @@ export function SearchCombobox({
 							</svg>
 							<input
 								aria-label={searchPlaceholder}
+								autoComplete="off"
 								// biome-ignore lint/a11y/noAutofocus: opening the picker focuses search
 								autoFocus
 								className="cline-ui-search-combobox__search"
 								onChange={(event) => setSearch(event.target.value)}
 								placeholder={searchPlaceholder}
+								spellCheck={false}
 								value={search}
 							/>
 						</div>

--- a/sdk/packages/ui/package.json
+++ b/sdk/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cline/ui",
-	"version": "0.2.0-next.1",
+	"version": "0.2.0-next.2",
 	"description": "Shared Cline web theme and reusable agent UI components",
 	"repository": {
 		"type": "git",

--- a/sdk/packages/ui/tests/search-combobox.test.tsx
+++ b/sdk/packages/ui/tests/search-combobox.test.tsx
@@ -66,6 +66,7 @@ describe("SearchCombobox", () => {
 
 		expect(onValueChange).toHaveBeenCalledWith("core-platform");
 		expect(trigger?.getAttribute("aria-expanded")).toBe("false");
+		expect(document.activeElement).toBe(trigger);
 	});
 
 	it("renders loading and disabled states", async () => {
@@ -95,5 +96,39 @@ describe("SearchCombobox", () => {
 		await act(async () => render(true, true));
 		expect(container.textContent).toContain("Loading models…");
 		expect(container.querySelector("button")?.disabled).toBe(true);
+	});
+
+	it("closes on Escape without dismissing an ancestor overlay", async () => {
+		const onValueChange = vi.fn();
+		const ancestorEscape = vi.fn();
+		document.addEventListener("keydown", ancestorEscape);
+		try {
+			await act(async () =>
+				root.render(
+					<SearchCombobox
+						ariaLabel="Repository"
+						onValueChange={onValueChange}
+						options={options}
+					/>,
+				),
+			);
+
+			const trigger = container.querySelector("button");
+			await act(async () => trigger?.click());
+			const search = container.querySelector("input");
+			expect(search).not.toBeNull();
+			await act(async () =>
+				search?.dispatchEvent(
+					new KeyboardEvent("keydown", { bubbles: true, key: "Escape" }),
+				),
+			);
+
+			expect(ancestorEscape).not.toHaveBeenCalled();
+			expect(container.querySelector('[role="dialog"]')).toBeNull();
+			expect(trigger?.getAttribute("aria-expanded")).toBe("false");
+			expect(document.activeElement).toBe(trigger);
+		} finally {
+			document.removeEventListener("keydown", ancestorEscape);
+		}
 	});
 });

--- a/sdk/packages/ui/tests/theme.test.ts
+++ b/sdk/packages/ui/tests/theme.test.ts
@@ -235,4 +235,14 @@ describe("@cline/ui theme contract", () => {
 			expect(existsSync(join(packageRoot, target ?? ""))).toBe(true);
 		}
 	});
+
+	it("contains large combobox option lists", () => {
+		const combobox = readComponent("search-combobox.css");
+		expect(block(combobox, ".cline-ui-search-combobox__options")).toContain(
+			"overscroll-behavior: contain",
+		);
+		expect(block(combobox, ".cline-ui-search-combobox__option")).toContain(
+			"content-visibility: auto",
+		);
+	});
 });


### PR DESCRIPTION
### Related Issue

Related to [cline/core-platform#3057](https://github.com/cline/core-platform/pull/3057).

### Description

`SearchCombobox` currently lets Escape bubble into ancestor overlays, so dismissing its search panel can also close the containing modal. Large result sets also render without browser-level layout/paint containment.

This change:

- handles Escape inside the panel, closes only the combobox, and restores focus to its trigger
- restores focus after option selection
- contains scrolling and applies `content-visibility: auto` to large option lists
- disables autocomplete and spellcheck for search inputs
- prepares `@cline/ui@0.2.0-next.2` for the dashboard consumer

### Test Procedure

- `bun --cwd sdk/packages/ui test` — 27 tests passed
- `bun --filter @cline/ui typecheck`
- `bun --filter @cline/ui build`
- `bun --filter @cline/ui build-storybook`
- `bun --cwd sdk/packages/ui test:package` — verified Bun/React 19 and npm/Node/React 18 installs
- `bun --filter @cline/shared build`
- `bun --filter @cline/code test:chat-ui` — 49 tests passed
- Biome check on all changed UI files

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing and code is formatted and linted
-   [x] I have reviewed the contributor guidelines

### Screenshots

Not applicable; behavior and rendering-performance fixes have no intended visual change.

### Additional Notes

Publishing is intentionally not triggered by this PR. After merge, the `ui-publish` workflow must publish `0.2.0-next.2` with the `next` tag before the dashboard can consume it.
