### PR TITLE
Fix queued prompt row alignment and auto-scroll when queueing a message

### DIFF
--- a/apps/vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -339,6 +339,30 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 
 	// Use scroll behavior hook
 	const scrollBehavior = useScrollBehavior(displayMessages, visibleMessages, groupedMessages, expandedRows, setExpandedRows)
+	const { scrollToBottomSmooth, scrollToBottomAuto, disableAutoScrollRef } = scrollBehavior
+
+	// When a prompt gets queued, the queue banner mounts (or grows) in the footer, which
+	// shrinks the messages area and visually covers the bottom of the conversation. No new
+	// chat row is added, so the list-length-based auto-scroll never fires — re-pin to the
+	// bottom here so the latest content stays visible.
+	const queuedPromptCount = queuedPrompts?.length ?? 0
+	const prevQueuedPromptCountRef = useRef(queuedPromptCount)
+	useEffect(() => {
+		const previousCount = prevQueuedPromptCountRef.current
+		prevQueuedPromptCountRef.current = queuedPromptCount
+		if (queuedPromptCount <= previousCount) {
+			return
+		}
+		// Queueing is a deliberate send, so re-engage bottom pinning like handleSendMessage does.
+		disableAutoScrollRef.current = false
+		scrollToBottomSmooth()
+		// Settle with an instant scroll once the footer's layout change has landed.
+		setTimeout(() => {
+			if (!disableAutoScrollRef.current) {
+				scrollToBottomAuto()
+			}
+		}, 50)
+	}, [queuedPromptCount, scrollToBottomSmooth, scrollToBottomAuto, disableAutoScrollRef])
 
 	const placeholderText = useMemo(() => {
 		const text = task ? "Type a message..." : "Type your task here..."

--- a/apps/vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -346,11 +346,17 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 	// chat row is added, so the list-length-based auto-scroll never fires — re-pin to the
 	// bottom here so the latest content stays visible.
 	const queuedPromptCount = queuedPrompts?.length ?? 0
+	const taskTs = task?.ts
 	const prevQueuedPromptCountRef = useRef(queuedPromptCount)
+	const prevQueuedPromptTaskTsRef = useRef(taskTs)
 	useEffect(() => {
 		const previousCount = prevQueuedPromptCountRef.current
+		const previousTaskTs = prevQueuedPromptTaskTsRef.current
 		prevQueuedPromptCountRef.current = queuedPromptCount
-		if (queuedPromptCount <= previousCount) {
+		prevQueuedPromptTaskTsRef.current = taskTs
+		// A task switch can grow the count without a send from this webview (the newly
+		// displayed task may already have queued prompts) — don't hijack its scroll position.
+		if (taskTs !== previousTaskTs || queuedPromptCount <= previousCount) {
 			return
 		}
 		// Queueing is a deliberate send, so re-engage bottom pinning like handleSendMessage does.
@@ -362,7 +368,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 				scrollToBottomAuto()
 			}
 		}, 50)
-	}, [queuedPromptCount, scrollToBottomSmooth, scrollToBottomAuto, disableAutoScrollRef])
+	}, [queuedPromptCount, taskTs, scrollToBottomSmooth, scrollToBottomAuto, disableAutoScrollRef])
 
 	const placeholderText = useMemo(() => {
 		const text = task ? "Type a message..." : "Type your task here..."

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/QueuedPrompts.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/QueuedPrompts.tsx
@@ -64,25 +64,30 @@ export function QueuedPrompts({ items = [] }: QueuedPromptsProps) {
 					const attachments = attachmentLabel(item.attachmentCount)
 					const isSteer = item.delivery === "steer"
 					const isCancelling = cancellingIds.has(item.id)
+					// The prompt text renders in spans whose line boxes are 5 spacing units tall
+					// (the global `span { @apply leading-5 }` base style), so every control in the
+					// row is sized/offset against that same 5-unit first line to stay vertically
+					// centered with it: the dot ((5 - 1.5) / 2 units), the h-5 badges, and the
+					// size-5 (26px) cancel button pulled in by -my-1.5 ((5u - size-5) / 2).
 					return (
 						<div
-							className="flex items-start gap-2 rounded-[3px] bg-input-background/40 px-2 py-1.5 text-xs leading-snug"
+							className="flex items-start gap-2 rounded-[3px] bg-input-background/40 px-2 py-1.5 text-xs"
 							key={item.id}>
-							<span aria-hidden="true" className="mt-[5px] size-1.5 shrink-0 rounded-full bg-description/70" />
+							<span aria-hidden="true" className="mt-1.75 size-1.5 shrink-0 rounded-full bg-description/70" />
 							<span className="min-w-0 flex-1 break-words text-foreground">{truncatePrompt(item.prompt)}</span>
 							{isSteer && (
-								<span className="shrink-0 rounded-[3px] border border-editor-group-border px-1.5 py-[1px] text-[10px] leading-4 text-description">
+								<span className="flex h-5 shrink-0 items-center rounded-[3px] border border-editor-group-border px-1.5 text-[10px] leading-none text-description">
 									Steer
 								</span>
 							)}
 							{attachments && (
-								<span className="shrink-0 rounded-[3px] border border-editor-group-border px-1.5 py-[1px] text-[10px] leading-4 text-description">
+								<span className="flex h-5 shrink-0 items-center rounded-[3px] border border-editor-group-border px-1.5 text-[10px] leading-none text-description">
 									{attachments}
 								</span>
 							)}
 							<button
 								aria-label="Cancel queued message"
-								className="mt-[-2px] flex size-5 shrink-0 items-center justify-center rounded-[3px] text-description hover:bg-toolbar-hover-background hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
+								className="-my-1.5 flex size-5 shrink-0 items-center justify-center rounded-[3px] text-description hover:bg-toolbar-hover-background hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
 								disabled={isCancelling}
 								onClick={() => cancelQueuedPrompt(item.id)}
 								title="Cancel queued message"


### PR DESCRIPTION
### Related Issue

N/A — small UI bug fix.

### Description

Two fixes for the message queue UI in the VS Code extension chat view:

1. **Vertical alignment in queue rows.** The prompt text was not vertically aligned with the ✕ (cancel) button. The webview theme makes `--size-5` equal to `2 × var(--vscode-font-size)` (26px at the default 13px font), while a text line box is 5 spacing units (16.25px, via the global `span { @apply leading-5 }` base style), so the ✕ icon's center sat ~3px below the text's first-line center. Every control in the row is now sized/offset against that same 5-unit first line: the leading dot uses `mt-1.75` (`(5u − 1.5u) / 2`), the Steer/attachment badges are exactly `h-5` with flex centering, and the 26px cancel button is pulled in with `-my-1.5` (`(5u − size-5) / 2`). Since both `--spacing` and `--size-5` are proportional to the VS Code font size, the centering is exact at any font-size setting, and it holds for wrapped multi-line prompts (controls stay centered on the first line).

2. **Auto-scroll when a message is queued.** Queueing a prompt mounts (or grows) the queue banner in the footer, which shrinks the messages area and visually covered the bottom of the conversation — and since no new chat row is added, the existing list-length-based auto-scroll never fired. `ChatView` now watches the queued prompt count and, when it grows, re-engages bottom pinning and scrolls the chat to the bottom (smooth scroll plus an instant settle scroll after the footer layout change lands), matching what `handleSendMessage` does for normal sends.

### Test Procedure

- Measured the row geometry in a Chrome harness using the built webview CSS: text first-line center, dot center, badge center, and ✕ icon center all land at exactly the same y offset (13.00px from the row top at the default font size) in every row, including wrapped two-line prompts.
- Verified live in the extension development host with a real task (OpenRouter provider): approved a `sleep 120` command, queued two messages mid-run (one single-line, one that wraps to three lines), plus cancelled a queued row via its ✕ button. The queue banner rows render with text, badges, and ✕ aligned; the chat view scrolls to the bottom when each prompt is queued so the running command row and action buttons stay visible above the banner; and the queued prompts are delivered once the turn ends.
- `bunx vitest run` for `chat-view/components/layout` and `chat-view/hooks` — 53 tests pass, including the existing `QueuedPrompts` and scroll-behavior tests.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Before (X button sits below the text centerline):

![Queue rows before the fix, X button misaligned](https://cursor.com/artifacts/c/art-518f6b2a-4821-4ce4-a4c4-9db8384e4603)

After — live in the extension host, dot/text/✕ centered on the first line for both single-line and wrapped rows:

![Queue rows after the fix, aligned](https://cursor.com/artifacts/c/art-ca15d6c3-6c24-4f2a-8a38-2bd5a48890a3)

After — chat stays pinned to the bottom when prompts are queued (running command row and buttons fully visible above the banner):

![Cline sidebar with two queued messages and chat scrolled to bottom](https://cursor.com/artifacts/c/art-efa870c5-7bf7-4237-8e45-5ac0ebedabed)

### Additional Notes

None.