### PR TITLE
Fix hidden plan/act mode-switch prompts reappearing when resuming a task from history

### DIFF
--- a/.changeset/hidden-mode-prompts-history.md
+++ b/.changeset/hidden-mode-prompts-history.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix hidden plan/act mode-switch and task-resumption prompts reappearing as user messages when a task is reopened from history

--- a/apps/vscode/src/sdk/message-translator.ts
+++ b/apps/vscode/src/sdk/message-translator.ts
@@ -45,6 +45,7 @@ import type {
 } from "@shared/ExtensionMessage"
 import { Logger } from "@shared/services/Logger"
 import { MessageIdMinter } from "./message-id-minter"
+import { isSyntheticSdkUserMessage } from "./sdk-user-message-mapping"
 import { isDeniedToolApprovalMistake, isKnownToolApprovalDenial } from "./tool-approval-denial"
 
 // ---------------------------------------------------------------------------
@@ -2238,18 +2239,22 @@ export function sdkMessagesToClineMessages(
 		if (typeof message.content === "string") {
 			const text = message.content.trim()
 			if (text) {
-				// Visible user text marks a turn boundary: drop the preceding turn's outcome
+				// User text marks a turn boundary: drop the preceding turn's outcome
 				// signals (its text is NOT retagged — see endFinalTurn) and pick up the mode
-				// of the NEW turn from this message's wrapper.
+				// of the NEW turn from this message's wrapper. Synthetic runtime prompts
+				// (task resumption, plan -> act auto-continue) still advance the turn/mode
+				// state but never had a visible bubble live, so don't emit one here either.
 				state.clearTurnOutcome()
 				currentMode = message.uiMode ?? currentMode
-				clineMessages.push({
-					ts: state.nextTs(),
-					type: "say",
-					say: clineMessages.length === 0 ? "task" : "user_feedback",
-					text,
-					partial: false,
-				})
+				if (!isSyntheticSdkUserMessage(message)) {
+					clineMessages.push({
+						ts: state.nextTs(),
+						type: "say",
+						say: clineMessages.length === 0 ? "task" : "user_feedback",
+						text,
+						partial: false,
+					})
+				}
 			}
 			continue
 		}
@@ -2258,13 +2263,15 @@ export function sdkMessagesToClineMessages(
 		if (userText) {
 			state.clearTurnOutcome()
 			currentMode = message.uiMode ?? currentMode
-			clineMessages.push({
-				ts: state.nextTs(),
-				type: "say",
-				say: clineMessages.length === 0 ? "task" : "user_feedback",
-				text: userText,
-				partial: false,
-			})
+			if (!isSyntheticSdkUserMessage(message)) {
+				clineMessages.push({
+					ts: state.nextTs(),
+					type: "say",
+					say: clineMessages.length === 0 ? "task" : "user_feedback",
+					text: userText,
+					partial: false,
+				})
+			}
 		}
 
 		for (const block of message.content) {

--- a/apps/vscode/src/sdk/sdk-mode-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-mode-coordinator.ts
@@ -10,6 +10,7 @@ import type { SdkMessageCoordinator } from "./sdk-message-coordinator"
 import type { SdkSessionConfigBuilder } from "./sdk-session-config-builder"
 import { isAbortError, type SdkSessionLifecycle } from "./sdk-session-lifecycle"
 import type { SdkSessionRebuildScheduler } from "./sdk-session-rebuild-scheduler"
+import { ACT_MODE_CONTINUATION_PROMPT } from "./sdk-user-message-mapping"
 import type { SdkSessionHost } from "./session-host"
 import type { TaskProxy } from "./task-proxy"
 import type { VscodeSessionHost } from "./vscode-session-host"
@@ -22,7 +23,7 @@ function usesClineAccountAuth(providerId: string): boolean {
 	return getProviderAuthStorageId(providerId) === "cline"
 }
 
-export const ACT_MODE_CONTINUATION_PROMPT = "The user approved switching to act mode. Continue with the approved plan now."
+export { ACT_MODE_CONTINUATION_PROMPT }
 
 export interface SdkModeCoordinatorOptions {
 	stateManager: StateManager

--- a/apps/vscode/src/sdk/sdk-task-history.test.ts
+++ b/apps/vscode/src/sdk/sdk-task-history.test.ts
@@ -259,6 +259,49 @@ describe("SdkTaskHistory", () => {
 		expect(result).toContainEqual(expect.objectContaining({ type: "say", say: "text", text: "Built." }))
 	})
 
+	it("hides the plan -> act auto-continuation prompt when rehydrating from history", async () => {
+		// Live, the canned continuation is sent with fireAndForgetSend and never echoed
+		// as user_feedback; reopening the task from history must not resurface it.
+		const { history, readMessages } = makeHistory([makeSessionRecord("task-1")])
+		readMessages.mockResolvedValueOnce([
+			{ role: "user", content: '<user_input mode="plan">plan the feature</user_input>' },
+			{ role: "assistant", content: [{ type: "text", text: "Here is the plan." }] },
+			{
+				role: "user",
+				content:
+					'<user_input mode="act"><mode_notice>The user switched from plan mode to act mode before sending this message.</mode_notice>The user approved switching to act mode. Continue with the approved plan now.</user_input>',
+			},
+			{ role: "assistant", content: [{ type: "text", text: "Implemented." }] },
+		] as never)
+
+		const result = await history.getClineMessages("task-1")
+
+		expect(result.filter((m) => m.say === "user_feedback")).toHaveLength(0)
+		expect(result.map((m) => m.text).join("\n")).not.toContain("The user approved switching to act mode")
+		// The hidden prompt still carries the turn's mode: the final completion row
+		// must render as an act-mode completion, not a plan box.
+		expect(result).toContainEqual(expect.objectContaining({ type: "say", say: "completion_result", text: "Implemented." }))
+	})
+
+	it("hides [TASK RESUMPTION] prompts when rehydrating from history", async () => {
+		const { history, readMessages } = makeHistory([makeSessionRecord("task-1")])
+		readMessages.mockResolvedValueOnce([
+			{ role: "user", content: '<user_input mode="act">build the feature</user_input>' },
+			{ role: "assistant", content: [{ type: "text", text: "Partway done." }] },
+			{
+				role: "user",
+				content: '<user_input mode="act">[TASK RESUMPTION] Please continue where you left off.</user_input>',
+			},
+			{ role: "assistant", content: [{ type: "text", text: "Finished." }] },
+		] as never)
+
+		const result = await history.getClineMessages("task-1")
+
+		expect(result.filter((m) => m.say === "user_feedback")).toHaveLength(0)
+		expect(result.map((m) => m.text).join("\n")).not.toContain("[TASK RESUMPTION]")
+		expect(result).toContainEqual(expect.objectContaining({ type: "say", say: "completion_result", text: "Finished." }))
+	})
+
 	it("retags the terminal text of a session whose record says it completed", async () => {
 		// "completed" is written by the runtime host when the session is released after a
 		// clean final turn (task switch / clear / extension dispose).

--- a/apps/vscode/src/sdk/sdk-user-message-mapping.test.ts
+++ b/apps/vscode/src/sdk/sdk-user-message-mapping.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
-import { ACT_MODE_CONTINUATION_PROMPT } from "./sdk-mode-coordinator"
 import {
+	ACT_MODE_CONTINUATION_PROMPT,
 	extractSdkUserText,
 	findSdkUserMessageIndexByOrdinal,
 	getSdkCheckpointRunCountForMessageIndex,

--- a/apps/vscode/src/sdk/sdk-user-message-mapping.ts
+++ b/apps/vscode/src/sdk/sdk-user-message-mapping.ts
@@ -1,5 +1,12 @@
 import { normalizeUserInput, stripModeNotices } from "@cline/shared"
-import { ACT_MODE_CONTINUATION_PROMPT } from "./sdk-mode-coordinator"
+
+/**
+ * Canned prompt SdkModeCoordinator sends to drive the plan -> act
+ * auto-continuation. Defined here (a leaf module) rather than in the
+ * coordinator so display-layer consumers (message-translator, ordinal
+ * mapping) don't pull the coordinator's heavy import graph into their tests.
+ */
+export const ACT_MODE_CONTINUATION_PROMPT = "The user approved switching to act mode. Continue with the approved plan now."
 
 export type SdkUserMessage = {
 	role?: unknown


### PR DESCRIPTION
### Related Issue

N/A (reported directly)

### Description

When switching between plan and act modes (and when a task auto-resumes), the runtime sends synthetic prompts to the agent — the plan → act auto-continuation (`The user approved switching to act mode. Continue with the approved plan now.`) and `[TASK RESUMPTION] …` prompts. Live, these are deliberately sent via `fireAndForgetSend` without a `user_feedback` echo, so they never show in chat. But they are persisted in SDK session history, and when a task is reopened from history, `sdkMessagesToClineMessages` converted every persisted user message into a visible `user_feedback` row — so the hidden prompts reappeared in the chat view.

Fix:
- `sdkMessagesToClineMessages` (`apps/vscode/src/sdk/message-translator.ts`) now skips emitting a chat row for synthetic user prompts, reusing the existing `isSyntheticSdkUserMessage` contract (which already governs edit/regenerate ordinal mapping — this also brings history-rehydrated transcripts back in line with that mapping). Turn/mode bookkeeping is preserved so the final completion row still styles by the correct plan/act mode.
- Moved `ACT_MODE_CONTINUATION_PROMPT` into the leaf module `sdk-user-message-mapping.ts` (re-exported from `sdk-mode-coordinator.ts`) so the display layer doesn't pull the coordinator's heavy import graph into its tests.

This mirrors the fix the CLI already has in `apps/cli/src/tui/utils/hydrate-messages.ts`.

### Test Procedure

- Added two regression tests in `sdk-task-history.test.ts` covering the full `getClineMessages` rehydration pipeline: the plan → act auto-continuation (including its `<mode_notice>` wrapper) and `[TASK RESUMPTION]` prompts no longer surface as `user_feedback`, while the final act-mode completion row still renders correctly.
- Full SDK-adapter vitest suite: 61 files / 921 tests pass. Full bun unit suite: 69 files / 1022 tests pass. `tsc --noEmit` clean.
- Manually verified end-to-end in the VS Code extension dev host: ran a plan-mode task via OpenRouter, approved the switch to act mode (hidden continuation prompt sent and persisted to SDK history), let the task complete, then reopened it from history — with the pre-fix build the hidden prompt leaked into the chat as a user bubble; with this fix it no longer appears.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Before (pre-fix build): reopening the task from history leaks the hidden continuation prompt as a user bubble between the plan and the act-mode tool calls.

![Before: hidden prompt leaks into history view](https://cursor.com/artifacts/c/art-481585b2-22f7-4ea9-88c6-213db9963d96)

After (this fix): the same task reopened from history — no synthetic user bubble; plan, tool calls, and completion render unchanged.

![After: history reopen shows no hidden prompt](https://cursor.com/artifacts/c/art-a30c1038-4c85-4403-9bfe-19461321409d)

### Additional Notes

The synthetic prompts intentionally remain in the SDK/LLM conversation history (the model still needs them); this change only affects how persisted history is rendered back into the chat view.