### PR TITLE
docs: restore "open Cline in right sidebar" guide as a section of the IDE usage page

### DIFF
--- a/apps/vscode/README.marketplace.md
+++ b/apps/vscode/README.marketplace.md
@@ -34,7 +34,7 @@ Thanks to [Claude Sonnet's agentic coding capabilities](https://www.anthropic.c
 4. When a task is completed, Cline will present the result to you with a terminal command like `open -a "Google Chrome" index.html`, which you run with a click of a button.
 
 > [!TIP]
-> Follow [this guide](https://docs.cline.bot/features/customization/opening-cline-in-sidebar) to open Cline on the right side of your editor. This lets you use Cline side-by-side with your file explorer, and see how he changes your workspace more clearly.
+> Follow [this guide](https://docs.cline.bot/usage/ide#move-cline-to-the-right-sidebar) to open Cline on the right side of your editor. This lets you use Cline side-by-side with your file explorer, and see how he changes your workspace more clearly.
 
 ---
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -632,7 +632,7 @@
 		},
 		{
 			"source": "/features/customization/opening-cline-in-sidebar",
-			"destination": "/getting-started/installing-cline"
+			"destination": "/usage/ide#move-cline-to-the-right-sidebar"
 		},
 		{
 			"source": "/prompting/prompt-engineering-guide/clineignore-file-guide",

--- a/docs/usage/ide.mdx
+++ b/docs/usage/ide.mdx
@@ -65,6 +65,50 @@ The Cline panel is a chat interface where you communicate with Cline. You need t
   </Tab>
 </Tabs>
 
+### Move Cline to the Right Sidebar
+
+This step is optional, but recommended. By default, Cline opens in the left sidebar, replacing your file explorer. Moving Cline to the right sidebar lets you keep your project files visible on the left while chatting with Cline on the right, so you can watch your workspace change as Cline works. (JetBrains already opens Cline on the right, so no setup is needed there.)
+
+<Tabs>
+  <Tab title="VS Code / Windsurf">
+    <Steps>
+      <Step title="Open the secondary sidebar">
+        Click the button in the top-right of the editor that toggles the right side panel (typically used for GitHub Copilot chat), or use the `Option/Alt + Cmd/Ctrl + B` shortcut.
+      </Step>
+      <Step title="Drag the Cline icon">
+        Drag the Cline icon from the Activity Bar on the left over to the top of the right panel.
+      </Step>
+    </Steps>
+
+    <Frame>
+      <img
+        src="https://storage.googleapis.com/cline_public_images/vscode_right_view.gif"
+        alt="Moving Cline to the right sidebar in VS Code"
+      />
+    </Frame>
+  </Tab>
+  <Tab title="Cursor">
+    <Steps>
+      <Step title="Switch to a vertical Activity Bar">
+        Cursor uses a horizontal activity bar by default ([details](https://cursor.com/docs/configuration/migrations/vscode#activity-bar-orientation)). To switch to vertical, open Settings (`Cmd/Ctrl + Shift + P` → "Preferences: Open Settings (UI)"), search for `workbench.activityBar.orientation`, set it to `vertical`, and restart Cursor.
+      </Step>
+      <Step title="Open the AI Pane">
+        Click the Cursor cube icon in the top-right that opens Cursor's agent panel on the right.
+      </Step>
+      <Step title="Drag Cline into the AI Pane">
+        Drag the Cline icon from the Activity Bar directly into the AI Pane sidebar.
+      </Step>
+    </Steps>
+
+    <Frame>
+      <img
+        src="https://storage.googleapis.com/cline_public_images/Cursor-sidebar.gif"
+        alt="Moving Cline to the right sidebar in Cursor"
+      />
+    </Frame>
+  </Tab>
+</Tabs>
+
 ## Step 3: Give Cline a Task
 
 Now you'll tell Cline what to build. You communicate with Cline by typing messages in the text input box, just like a chat app.


### PR DESCRIPTION
### Related Issue

N/A — small docs fix (broken link from the VS Code marketplace README).

### Description

The VS Code marketplace README contains a tip linking to `https://docs.cline.bot/features/customization/opening-cline-in-sidebar`, but that page was removed in the docs overhaul ([#9280](https://github.com/cline/cline/pull/9280)) and its redirect points to the Installing Cline page, which doesn't actually cover the sidebar setup.

Rather than restoring it as a standalone page, this PR brings the content back as a subsection of the IDE usage page, where panel placement guidance fits naturally:

- `docs/usage/ide.mdx`: new "Move Cline to the Right Sidebar" subsection under "Step 2: Open the Cline Panel", with tabs for VS Code / Windsurf and Cursor (including the `workbench.activityBar.orientation` steps for Cursor) and the original setup GIFs, which are still hosted.
- `docs/docs.json`: the existing redirect for `/features/customization/opening-cline-in-sidebar` now points to `/usage/ide#move-cline-to-the-right-sidebar` instead of `/getting-started/installing-cline`.
- `apps/vscode/README.marketplace.md`: the tip now links to the new anchor.

### Test Procedure

- Verified both GIF URLs still return 200 from `storage.googleapis.com/cline_public_images`.
- Ran `mintlify broken-links` in `docs/` — no broken links.
- Ran `mintlify dev` locally and verified in a browser: the anchor scrolls to the new section, both tabs render with their steps and GIFs, and navigating to the old URL `/features/customization/opening-cline-in-sidebar` redirects to `/usage/ide#move-cline-to-the-right-sidebar`.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

New section rendered locally with `mintlify dev`:

VS Code / Windsurf tab:

![VS Code / Windsurf tab of the new Move Cline to the Right Sidebar section](https://cursor.com/artifacts/c/art-4837fdd9-217a-4e90-9db4-a4c07c80da66)

Cursor tab:

![Cursor tab of the new Move Cline to the Right Sidebar section](https://cursor.com/artifacts/c/art-de9aff2c-c03e-4958-858f-cc62ae0ca6cc)

### Additional Notes

The old page content was recovered from git history (`docs/features/customization/opening-cline-in-sidebar.mdx`, removed in #9280) and condensed to fit the new docs style.