### PR TITLE
Remove vestigial MCP server-key machinery from McpHub

### DIFF
--- a/apps/vscode/src/services/mcp/McpHub.ts
+++ b/apps/vscode/src/services/mcp/McpHub.ts
@@ -28,7 +28,6 @@ import { convertMcpServersToProtoMcpServers } from "@shared/proto-conversions/mc
 import chokidar, { type FSWatcher } from "chokidar"
 import deepEqual from "fast-deep-equal"
 import * as fs from "fs/promises"
-import { nanoid } from "nanoid"
 import ReconnectingEventSource from "reconnecting-eventsource"
 import { z } from "zod"
 import { HostProvider } from "@/hosts/host-provider"
@@ -94,11 +93,6 @@ export class McpHub {
 	 */
 	private lastConnectionFingerprint?: string
 
-	/**
-	 * Map of unique keys to each connected server names
-	 */
-	private static mcpServerKeys = new Map<string, string>()
-
 	// Store notifications for display in chat
 	private pendingNotifications: Array<{
 		serverName: string
@@ -141,33 +135,6 @@ export class McpHub {
 		// Only return enabled servers
 
 		return this.connections.filter((conn) => !conn.server.disabled).map((conn) => conn.server)
-	}
-
-	/**
-	 * Get the MCP server name from its unique key.
-	 * If the key is not found, return the key itself.
-	 */
-	public static getMcpServerByKey(key: string): string {
-		return McpHub.mcpServerKeys.get(key) || key
-	}
-
-	/**
-	 * Create a unique key for an MCP server based on its name.
-	 * This avoids making a tool name too long while still ensuring uniqueness.
-	 */
-	private getMcpServerKey(server: string): string {
-		// Reuse existing key if server is already registered
-		for (const [existingKey, existingServer] of McpHub.mcpServerKeys.entries()) {
-			if (existingServer === server) {
-				return existingKey
-			}
-		}
-		// Generate a short 6-character unique ID for the server
-		// Add c prefix to ensure it starts with a letter (for compatibility with Gemini)
-		// Only use the first 5 characters of nanoid to keep it short
-		const uid = "c" + nanoid(5)
-		McpHub.mcpServerKeys.set(uid, server)
-		return uid
 	}
 
 	/**
@@ -497,7 +464,6 @@ export class McpHub {
 						const connection = this.findConnection(name, source)
 						if (connection) {
 							connection.server.status = "disconnected"
-							McpHub.mcpServerKeys.delete(connection.server.uid || name)
 							this.appendErrorMessage(connection, error instanceof Error ? error.message : `${error}`)
 						}
 						await this.notifyWebviewOfServerChanges()
@@ -507,7 +473,6 @@ export class McpHub {
 						const connection = this.findConnection(name, source)
 						if (connection) {
 							connection.server.status = "disconnected"
-							McpHub.mcpServerKeys.delete(connection.server.uid || name)
 						}
 						await this.notifyWebviewOfServerChanges()
 					}
@@ -579,7 +544,6 @@ export class McpHub {
 						const connection = this.findConnection(name, source)
 						if (connection) {
 							connection.server.status = "disconnected"
-							McpHub.mcpServerKeys.delete(connection.server.uid || name)
 							this.appendErrorMessage(connection, error instanceof Error ? error.message : `${error}`)
 						}
 						await this.notifyWebviewOfServerChanges()
@@ -622,7 +586,6 @@ export class McpHub {
 						connectToServer: () => this.connectToServer(name, config, source),
 						notifyWebviewOfServerChanges: () => this.notifyWebviewOfServerChanges(),
 						appendErrorMessage: (conn, msg) => this.appendErrorMessage(conn as McpConnection, msg),
-						deleteServerKey: (uid) => McpHub.mcpServerKeys.delete(uid),
 						delay: (ms) => setTimeoutPromise(ms),
 					})
 
@@ -639,7 +602,6 @@ export class McpHub {
 					config: configForStorage,
 					status: "connecting",
 					disabled: config.disabled,
-					uid: this.getMcpServerKey(name),
 					oauthRequired: false,
 					oauthAuthStatus: "authenticated",
 				},
@@ -666,7 +628,6 @@ export class McpHub {
 							oauthRequired: true,
 							oauthAuthStatus: "unauthenticated",
 							error: "This MCP server requires authentication to get started.",
-							uid: this.getMcpServerKey(name),
 						},
 						client,
 						transport,
@@ -771,7 +732,6 @@ export class McpHub {
 						config: JSON.stringify(config),
 						status: "disconnected",
 						disabled: config.disabled,
-						uid: this.getMcpServerKey(name),
 					},
 					client: null as unknown as Client,
 					transport: null as unknown as Transport,

--- a/apps/vscode/src/services/mcp/StreamableHttpReconnectHandler.ts
+++ b/apps/vscode/src/services/mcp/StreamableHttpReconnectHandler.ts
@@ -6,7 +6,7 @@ import { Logger } from "@/shared/services/Logger"
  */
 export interface ReconnectCallbacks {
 	/** Returns the current connection object, or undefined if it no longer exists */
-	findConnection: () => { server: { status: string; disabled?: boolean; uid?: string } } | undefined
+	findConnection: () => { server: { status: string; disabled?: boolean } } | undefined
 	/** Tears down the existing connection */
 	deleteConnection: () => Promise<void>
 	/** Establishes a new connection */
@@ -15,8 +15,6 @@ export interface ReconnectCallbacks {
 	notifyWebviewOfServerChanges: () => Promise<void>
 	/** Appends an error message to the connection's server object */
 	appendErrorMessage: (connection: { server: { status: string } }, message: string) => void
-	/** Removes the server key from the global registry */
-	deleteServerKey: (uid: string) => void
 	/** Awaitable delay — injected so tests can substitute a zero-delay or fake timer */
 	delay: (ms: number) => Promise<void>
 }
@@ -94,7 +92,6 @@ export class StreamableHttpReconnectHandler {
 					`exhausted for "${this.serverName}". Server marked as disconnected.`,
 			)
 			connection.server.status = "disconnected"
-			this.callbacks.deleteServerKey(connection.server.uid || this.serverName)
 			this.callbacks.appendErrorMessage(connection, error instanceof Error ? error.message : `${error}`)
 			await this.callbacks.notifyWebviewOfServerChanges()
 			return
@@ -157,7 +154,6 @@ export class StreamableHttpReconnectHandler {
 		const exhaustedConnection = this.callbacks.findConnection()
 		if (exhaustedConnection) {
 			exhaustedConnection.server.status = "disconnected"
-			this.callbacks.deleteServerKey(exhaustedConnection.server.uid || this.serverName)
 			this.callbacks.appendErrorMessage(exhaustedConnection, error instanceof Error ? error.message : `${error}`)
 		}
 		await this.callbacks.notifyWebviewOfServerChanges()

--- a/apps/vscode/src/services/mcp/__tests__/StreamableHttpReconnectHandler.test.ts
+++ b/apps/vscode/src/services/mcp/__tests__/StreamableHttpReconnectHandler.test.ts
@@ -9,12 +9,11 @@ import {
 } from "../StreamableHttpReconnectHandler"
 
 /** Build a mock connection object whose status can be inspected. */
-function makeConnection(overrides: Partial<{ status: string; disabled: boolean; uid: string }> = {}) {
+function makeConnection(overrides: Partial<{ status: string; disabled: boolean }> = {}) {
 	return {
 		server: {
 			status: overrides.status ?? "connected",
 			disabled: overrides.disabled ?? false,
-			uid: overrides.uid ?? "uid-123",
 		},
 	}
 }
@@ -31,7 +30,6 @@ function makeCallbacks(connection?: ReturnType<typeof makeConnection>): Reconnec
 		connectToServer: sinon.stub().resolves(),
 		notifyWebviewOfServerChanges: sinon.stub().resolves(),
 		appendErrorMessage: sinon.stub(),
-		deleteServerKey: sinon.stub(),
 		delay: sinon.stub().resolves(), // instant — no real waiting in tests
 	}
 	return { ...(stubs as unknown as ReconnectCallbacks), stubs }
@@ -148,7 +146,7 @@ describe("StreamableHttpReconnectHandler", () => {
 
 		// After deleteConnection, findConnection returns undefined (old conn deleted)
 		// but connectToServer may leave a partial connection, so simulate that
-		const partialConn = makeConnection({ uid: "uid-partial" })
+		const partialConn = makeConnection()
 		let deleted = false
 		cbs.stubs.findConnection.callsFake(() => {
 			if (!deleted) return conn
@@ -170,7 +168,6 @@ describe("StreamableHttpReconnectHandler", () => {
 
 		// The partial connection should be marked disconnected
 		partialConn.server.status.should.equal("disconnected")
-		cbs.stubs.deleteServerKey.calledWith("uid-partial").should.be.true()
 		cbs.stubs.appendErrorMessage.calledOnce.should.be.true()
 		cbs.stubs.appendErrorMessage.firstCall.args[1].should.equal("transport error")
 	})
@@ -207,7 +204,6 @@ describe("StreamableHttpReconnectHandler", () => {
 		await handler.handleError(new Error("final error"))
 
 		conn.server.status.should.equal("disconnected")
-		cbs.stubs.deleteServerKey.calledWith("uid-123").should.be.true()
 		cbs.stubs.appendErrorMessage.calledOnce.should.be.true()
 		cbs.stubs.connectToServer.called.should.be.false()
 	})
@@ -240,7 +236,7 @@ describe("StreamableHttpReconnectHandler", () => {
 
 	it("should abort reconnect if connection was replaced during delay", async () => {
 		const conn = makeConnection()
-		const differentConn = makeConnection({ uid: "uid-replaced" })
+		const differentConn = makeConnection()
 		const cbs = makeCallbacks(conn)
 		// After the delay, findConnection returns a different object
 		cbs.stubs.findConnection.onFirstCall().returns(conn)

--- a/apps/vscode/src/shared/mcp.ts
+++ b/apps/vscode/src/shared/mcp.ts
@@ -24,7 +24,6 @@ export type McpServer = {
 	prompts?: McpPrompt[]
 	disabled?: boolean
 	timeout?: number
-	uid?: string
 	oauthRequired?: boolean
 	oauthAuthStatus?: McpOAuthAuthStatus
 }


### PR DESCRIPTION
### Related Issue

#8087, supersedes #10254

### Description

McpHub still carries a static `mcpServerKeys` registry that mints a random `c${nanoid(5)}` uid per server. Those uids were minted to route native tool calls: tool function names embedded the uid (`cXYZ0mcp0toolName`) and `getMcpServerByKey` decoded it back to a server at dispatch. Because the uid was random and in-memory, a restart or reconnect changed it while the model still held old tool names — that is issue #8087, and PR #10254 proposed fixing it with a deterministic hash.

That encode/decode path no longer exists. Since the extension-host demolition (c4c126bee), MCP tool names come from the SDK's `defaultMcpToolNameTransform` (`serverName__toolName`, deterministically hashed only when sanitization or the 64-char cap requires it) and execution closes over the server name directly. `getMcpServerByKey` has zero callers; the registry is write-only state. So #8087 is already fixed on main by architecture, and the right change is deletion, not a better hash.

Removes the registry, `getMcpServerKey`/`getMcpServerByKey`, the `McpServer.uid` field (never carried over proto to the webview), and the `deleteServerKey` callback plumbing in `StreamableHttpReconnectHandler`.

### Test Procedure

```
cd apps/vscode
bun test src/services/mcp/__tests__/          # 83 pass; toggleServerDisabledRPC fails identically on main (pre-existing mocha-shim issue)
bun run check-types                           # passes
```

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes
