### PR TITLE
feat(vscode): show Legacy/Next extension variant in the settings About page

### DIFF
--- a/apps/vscode/src/core/controller/state/getStateToPostToWebview.ts
+++ b/apps/vscode/src/core/controller/state/getStateToPostToWebview.ts
@@ -12,6 +12,7 @@ import { ExtensionRegistryInfo } from "@/registry"
 import { BannerService } from "@/services/banner/BannerService"
 import { featureFlagsService } from "@/services/feature-flags"
 import { getDistinctId } from "@/services/logging/distinctId"
+import { getExtensionVariant } from "@/services/telemetry/rollout-metadata"
 import { getLatestAnnouncementId } from "@/utils/announcements"
 import { getClineOnboardingModels } from "../models/getClineOnboardingModels"
 
@@ -109,6 +110,7 @@ export async function getStateToPostToWebview(controller: {
 
 	return {
 		version,
+		extensionVariant: getExtensionVariant(),
 		apiConfiguration,
 		currentTaskItem,
 		clineMessages,

--- a/apps/vscode/src/services/telemetry/rollout-metadata.test.ts
+++ b/apps/vscode/src/services/telemetry/rollout-metadata.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it } from "bun:test"
-import { getRolloutErrorProperties, getRolloutTelemetryMetadata, ROLLOUT_ERROR_MESSAGE_LIMIT } from "./rollout-metadata"
+import {
+	getExtensionVariant,
+	getRolloutErrorProperties,
+	getRolloutTelemetryMetadata,
+	ROLLOUT_ERROR_MESSAGE_LIMIT,
+} from "./rollout-metadata"
 
 const originalVariant = process.env.CLINE_ROLLOUT_VARIANT
 
@@ -22,6 +27,20 @@ describe("rollout telemetry metadata", () => {
 
 		process.env.CLINE_ROLLOUT_VARIANT = "invalid"
 		expect(getRolloutTelemetryMetadata()).toEqual({})
+	})
+
+	it("exposes the variant for rollout builds only", () => {
+		process.env.CLINE_ROLLOUT_VARIANT = "legacy"
+		expect(getExtensionVariant()).toBe("legacy")
+
+		process.env.CLINE_ROLLOUT_VARIANT = "next"
+		expect(getExtensionVariant()).toBe("next")
+
+		delete process.env.CLINE_ROLLOUT_VARIANT
+		expect(getExtensionVariant()).toBeUndefined()
+
+		process.env.CLINE_ROLLOUT_VARIANT = "invalid"
+		expect(getExtensionVariant()).toBeUndefined()
 	})
 
 	it("bounds fallback errors without including stacks", () => {

--- a/apps/vscode/src/services/telemetry/rollout-metadata.ts
+++ b/apps/vscode/src/services/telemetry/rollout-metadata.ts
@@ -14,15 +14,19 @@ export interface RolloutBundleActivation {
 export const ROLLOUT_BUNDLE_ACTIVATED_EVENT = "extension.rollout.bundle_activated"
 export const ROLLOUT_ERROR_MESSAGE_LIMIT = 500
 
+/**
+ * The rollout variant this bundle was built as, or undefined for ordinary builds.
+ * CLINE_ROLLOUT_VARIANT is inlined at build time by the combined rollout workflow only.
+ */
+export function getExtensionVariant(): ExtensionVariant | undefined {
+	const variant = process.env.CLINE_ROLLOUT_VARIANT
+	return variant === "legacy" || variant === "next" ? variant : undefined
+}
+
 /** Return rollout metadata only for bundles built by the combined rollout workflow. */
 export function getRolloutTelemetryMetadata(): Partial<RolloutTelemetryMetadata> {
-	const variant = process.env.CLINE_ROLLOUT_VARIANT
-
-	if (variant !== "legacy" && variant !== "next") {
-		return {}
-	}
-
-	return { extension_variant: variant }
+	const variant = getExtensionVariant()
+	return variant ? { extension_variant: variant } : {}
 }
 
 export function getRolloutErrorProperties(error: unknown): {

--- a/apps/vscode/src/shared/ExtensionMessage.ts
+++ b/apps/vscode/src/shared/ExtensionMessage.ts
@@ -100,6 +100,11 @@ export interface ExtensionState {
 	lastCompletedCommandTs?: number
 	userInfo?: UserInfo
 	version: string
+	/**
+	 * Which rollout bundle this build is ("legacy" or "next"). Only present for
+	 * bundles built by the combined rollout workflow; undefined for ordinary builds.
+	 */
+	extensionVariant?: "legacy" | "next"
 	distinctId: string
 	globalClineRulesToggles: ClineRulesToggles
 	localClineRulesToggles: ClineRulesToggles

--- a/apps/vscode/webview-ui/src/components/settings/SettingsView.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/SettingsView.tsx
@@ -137,7 +137,7 @@ const SettingsView = ({ onDone, targetSection }: SettingsViewProps) => {
 		[],
 	) // Empty deps - these imports never change
 
-	const { version, environment, settingsInitialModelTab } = useExtensionState()
+	const { version, extensionVariant, environment, settingsInitialModelTab } = useExtensionState()
 	const { activeOrganization, clineUser } = useClineAuth()
 
 	const [activeTab, setActiveTab] = useState<string>(targetSection || SETTINGS_TABS[0].id)
@@ -240,12 +240,13 @@ const SettingsView = ({ onDone, targetSection }: SettingsViewProps) => {
 			props.onResetState = handleResetState
 		} else if (activeTab === "about") {
 			props.version = version
+			props.extensionVariant = extensionVariant
 		} else if (activeTab === "api-config") {
 			props.initialModelTab = settingsInitialModelTab
 		}
 
 		return <Component {...props} />
-	}, [activeTab, handleResetState, settingsInitialModelTab, version, TAB_CONTENT_MAP])
+	}, [activeTab, handleResetState, settingsInitialModelTab, version, extensionVariant, TAB_CONTENT_MAP])
 
 	return (
 		<Tab>

--- a/apps/vscode/webview-ui/src/components/settings/sections/AboutSection.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/sections/AboutSection.tsx
@@ -3,15 +3,29 @@ import Section from "../Section"
 
 interface AboutSectionProps {
 	version: string
+	extensionVariant?: "legacy" | "next"
 	renderSectionHeader: (tabId: string) => JSX.Element | null
 }
-const AboutSection = ({ version, renderSectionHeader }: AboutSectionProps) => {
+
+const VARIANT_LABELS: Record<"legacy" | "next", string> = {
+	legacy: "Legacy",
+	next: "Next",
+}
+
+const AboutSection = ({ version, extensionVariant, renderSectionHeader }: AboutSectionProps) => {
 	return (
 		<div>
 			{renderSectionHeader("about")}
 			<Section>
 				<div className="flex px-4 flex-col gap-2">
-					<h2 className="text-lg font-semibold">Cline v{version}</h2>
+					<h2 className="text-lg font-semibold">
+						Cline v{version}
+						{extensionVariant && (
+							<span className="ml-2 text-sm font-normal text-description">
+								({VARIANT_LABELS[extensionVariant]})
+							</span>
+						)}
+					</h2>
 					<p>
 						An AI assistant that can use your CLI and Editor. Cline can handle complex software development tasks
 						step-by-step with tools that let him create & edit files, explore large projects, use the browser, and


### PR DESCRIPTION
### Related Issue

N/A — small internal supportability improvement for the combined A/B rollout.

### Description

Since the stable extension switched to the combined Legacy+Next A/B VSIX, there has been no way to tell from the UI which bundle actually activated for a given install — the About tab just says "Cline v4.1.1" regardless of which side of the rollout flag you landed on. That makes support threads and bug reports ambiguous: "I'm on 4.1.1" no longer identifies the code that's running.

The recent rollout-telemetry work already solved the hard part: the combined package workflows (`ext-vscode-ab-package.yml`, `ext-vscode-publish-nightly.yml`) build each bundle with `CLINE_ROLLOUT_VARIANT=next` / `legacy`, and `esbuild.mjs` inlines it via `define`, which is what stamps `extension_variant` on every telemetry event. This PR just surfaces that same build-time value in the settings About page.

Changes:

- `rollout-metadata.ts`: extracted the env-var validation into a `getExtensionVariant(): "legacy" | "next" | undefined` helper; `getRolloutTelemetryMetadata()` now delegates to it, so telemetry behavior is unchanged.
- `getStateToPostToWebview.ts` → `ExtensionState.extensionVariant` (optional field) → `SettingsView` about-tab props → `AboutSection` renders a muted `(Next)` / `(Legacy)` span next to `Cline v{version}`.

Deliberate behaviors:

- **Ordinary builds show nothing.** Dev builds, F5 sessions, and any VSIX not produced by the combined rollout workflow have no `CLINE_ROLLOUT_VARIANT` inlined, so `getExtensionVariant()` returns `undefined` and the About header renders exactly as before. Only rollout-built bundles get the badge — which is precisely the population where the question "which variant am I on?" is meaningful.
- Validation is strict (`legacy`/`next` only), matching the existing telemetry guard, so a garbage env value at build time can't leak into the UI.

The legacy bundle is built from the `legacy-extension` branch, so it gets the same treatment in a sibling PR targeting that branch: #12776. Once both merge, the next combined VSIX will show the badge on whichever bundle the loader picks.

### Test Procedure

- `bun test src/services/telemetry/rollout-metadata.test.ts` — 4 pass, including a new case asserting `getExtensionVariant()` returns the variant for `legacy`/`next` and `undefined` for unset/invalid values.
- `bun run check-types` (protos + extension tsc + vscode-compat tsc + webview tsc) — clean.
- Telemetry regression surface: `getRolloutTelemetryMetadata()` is behavior-identical (same guard, same return shape); the existing metadata tests still pass unchanged.
- The webview side is plumbing plus a conditional span; when `extensionVariant` is undefined the render output is byte-identical to before.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Rollout builds render the About header as **Cline v4.1.1 (Next)** (or **(Legacy)**), with the badge in the smaller description-foreground style; ordinary builds are unchanged.

### Additional Notes

`CLINE_ROLLOUT_VARIANT` is read at build time (esbuild `define`), not runtime — there is no way for a user or extension host env to spoof the badge after packaging.
