### PR TITLE
fix(core): omit workspace hint for filesystem root paths

### DIFF
--- a/sdk/packages/core/src/services/workspace/workspace-manifest.test.ts
+++ b/sdk/packages/core/src/services/workspace/workspace-manifest.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, parse } from "node:path";
+import { emptyWorkspaceManifest, upsertWorkspaceInfo } from "@cline/shared";
 import simpleGit from "simple-git";
 import { afterEach, describe, expect, test } from "vitest";
 import {
@@ -127,6 +128,19 @@ describe("generateWorkspaceInfoWithDiagnostics", () => {
 		expect(result.error).toBeUndefined();
 		expect(result.info.latestGitCommitHash).toBeTruthy();
 		expect(result.info.latestGitBranchName).toBeTruthy();
+	});
+
+	test("filesystem root omits the hint and passes manifest validation", async () => {
+		// basename of a root path ("/", "C:\\") is "", which WorkspaceInfoSchema
+		// rejects — the hint must be omitted, not empty, or upsertWorkspaceInfo
+		// throws for every session rooted there.
+		const root = parse(tmpdir()).root;
+		const { info } = await generateWorkspaceInfoWithDiagnostics(root);
+		expect(info.rootPath).toBe(root);
+		expect(info.hint).toBeUndefined();
+		expect(() =>
+			upsertWorkspaceInfo(emptyWorkspaceManifest(), info),
+		).not.toThrow();
 	});
 
 	test("nonexistent workspace path still reports an error", async () => {

--- a/sdk/packages/core/src/services/workspace/workspace-manifest.ts
+++ b/sdk/packages/core/src/services/workspace/workspace-manifest.ts
@@ -125,7 +125,9 @@ export async function generateWorkspaceInfoWithDiagnostics(
 	const rootPath = normalizeWorkspacePath(workspacePath);
 	const info: WorkspaceInfo = {
 		rootPath,
-		hint: basename(rootPath),
+		// basename("/") and basename("C:\\") are "", which WorkspaceInfoSchema
+		// rejects — omit the hint for root paths instead.
+		hint: basename(rootPath) || undefined,
 	};
 	const gitState: GitWorkspaceState = {};
 	let firstError: { errorType: string; message: string } | undefined;


### PR DESCRIPTION
## Problem

When a session's workspace root is the filesystem root — e.g. the desktop app launched from the Dock, whose cwd is `/` — running any command surfaces a raw ZodError in the chat and the command never executes:

```
[{"origin":"string","code":"too_small","minimum":1,"inclusive":true,"path":["workspaces","/","hint"],"message":"Too small: expected string to have >=1 characters"}]
```

`generateWorkspaceInfoWithDiagnostics` sets `hint: basename(rootPath)`, and Node's `path.basename("/")` returns `""`. `upsertWorkspaceInfo` then validates the manifest against `WorkspaceInfoSchema`, where `hint` is `z.string().min(1).optional()` — present-but-empty fails and the error propagates to the UI. Windows drive roots (`C:\`) hit the same path.

## Fix

Omit the hint when the basename is empty, rather than storing an empty string. Regression test added: it exercises the platform root via `parse(tmpdir()).root` and asserts the generated info passes `upsertWorkspaceInfo` validation (fails on the old code, passes now).

Affects every ClineCore consumer (desktop app, CLI, VS Code SDK arch, JetBrains bundled core).

Tracked in [ENG-2392](https://linear.app/cline-bot/issue/ENG-2392/workspace-root-crashes-session-with-zod-error-empty-workspace-hint).