### PR TITLE
fix(desktop): stop rendering the first chat message twice

### DIFF
--- a/apps/examples/desktop-app/sidecar/context.test.ts
+++ b/apps/examples/desktop-app/sidecar/context.test.ts
@@ -222,6 +222,79 @@ describe("Code sidecar runtime capabilities", () => {
 		});
 	});
 
+	it("announces a queued prompt start once when drain emits both queue events", async () => {
+		const { createSidecarContext, initializeSessionManager } = await import(
+			"./context"
+		);
+		let onEvent: ((event: unknown) => void) | undefined;
+		createCoreMock.mockResolvedValue({
+			runtimeAddress: "ws://127.0.0.1:25463/hub",
+			subscribe: vi.fn((handler: (event: unknown) => void) => {
+				onEvent = handler;
+				return () => {};
+			}),
+			dispose: vi.fn(),
+		});
+
+		const ctx = createSidecarContext("/workspace/project");
+		ctx.wsClients.add({ send: vi.fn() });
+		await initializeSessionManager(ctx);
+		const session = {
+			config: {},
+			messages: [],
+			promptsInQueue: [
+				{ id: "prompt-1", prompt: "hi there", steer: false, attachmentCount: 0 },
+			],
+			busy: false,
+			startedAt: Date.now(),
+			status: "running",
+		} satisfies LiveSession;
+		ctx.liveSessions.set("session-1", session);
+
+		// PendingPromptService.drain() emits both events for the same prompt:
+		// a queue snapshot with the head removed, then the submitted event.
+		onEvent?.({
+			type: "pending_prompts",
+			payload: { sessionId: "session-1", prompts: [] },
+		});
+		onEvent?.({
+			type: "pending_prompt_submitted",
+			payload: {
+				sessionId: "session-1",
+				id: "prompt-1",
+				prompt: "hi there",
+				attachmentCount: 0,
+			},
+		});
+
+		const starts = readEvents(ctx).filter(
+			(message) =>
+				message.event.name === "chat_event" &&
+				(message.event.payload as { stream?: string }).stream ===
+					"chat_queued_prompt_start",
+		);
+		expect(starts).toHaveLength(1);
+
+		// A different prompt id must still be announced.
+		onEvent?.({
+			type: "pending_prompt_submitted",
+			payload: {
+				sessionId: "session-1",
+				id: "prompt-2",
+				prompt: "second",
+				attachmentCount: 0,
+			},
+		});
+		expect(
+			readEvents(ctx).filter(
+				(message) =>
+					message.event.name === "chat_event" &&
+					(message.event.payload as { stream?: string }).stream ===
+						"chat_queued_prompt_start",
+			),
+		).toHaveLength(2);
+	});
+
 	it("resolves askQuestion through the websocket request/response protocol", async () => {
 		const { createSidecarContext, initializeSessionManager } = await import(
 			"./context"

--- a/apps/examples/desktop-app/sidecar/context.ts
+++ b/apps/examples/desktop-app/sidecar/context.ts
@@ -325,6 +325,35 @@ function handleAgentEvent(
 // CoreSessionEvent routing
 // ---------------------------------------------------------------------------
 
+// The runtime's queue drain emits a pending_prompts snapshot (head removed)
+// and a pending_prompt_submitted event for the same prompt back-to-back, and
+// both are translated here into chat_queued_prompt_start — dedupe by prompt
+// id or the UI renders the user message twice.
+function emitQueuedPromptStart(
+	ctx: SidecarContext,
+	sessionId: string,
+	session: LiveSession | undefined,
+	input: {
+		promptId: string;
+		prompt: string;
+		attachmentCount: number;
+		userImages?: string[];
+	},
+): void {
+	if (session) {
+		if (session.lastQueuedPromptStartId === input.promptId) {
+			return;
+		}
+		session.lastQueuedPromptStartId = input.promptId;
+	}
+	emitChunk(
+		ctx,
+		sessionId,
+		"chat_queued_prompt_start",
+		serializeQueuedPromptStart(input),
+	);
+}
+
 function handleCoreSessionEvent(
 	ctx: SidecarContext,
 	event: CoreSessionEvent,
@@ -367,17 +396,12 @@ function handleCoreSessionEvent(
 					previous[0] &&
 					previous[0].id !== mapped[0]?.id
 				) {
-					emitChunk(
-						ctx,
-						sessionId,
-						"chat_queued_prompt_start",
-						serializeQueuedPromptStart({
-							promptId: previous[0].id,
-							prompt: previous[0].prompt,
-							attachmentCount: previous[0].attachmentCount ?? 0,
-							userImages: previous[0].userImages,
-						}),
-					);
+					emitQueuedPromptStart(ctx, sessionId, session, {
+						promptId: previous[0].id,
+						prompt: previous[0].prompt,
+						attachmentCount: previous[0].attachmentCount ?? 0,
+						userImages: previous[0].userImages,
+					});
 				}
 			}
 			sendPromptsInQueueSnapshot(ctx, sessionId);
@@ -386,18 +410,14 @@ function handleCoreSessionEvent(
 		case "pending_prompt_submitted": {
 			const { sessionId, id, prompt, attachmentCount, userImages } =
 				event.payload;
-			markQueuedAttachmentsSubmitted(ctx.liveSessions.get(sessionId), id);
-			emitChunk(
-				ctx,
-				sessionId,
-				"chat_queued_prompt_start",
-				serializeQueuedPromptStart({
-					promptId: id,
-					prompt,
-					attachmentCount: attachmentCount ?? 0,
-					userImages,
-				}),
-			);
+			const session = ctx.liveSessions.get(sessionId);
+			markQueuedAttachmentsSubmitted(session, id);
+			emitQueuedPromptStart(ctx, sessionId, session, {
+				promptId: id,
+				prompt,
+				attachmentCount: attachmentCount ?? 0,
+				userImages,
+			});
 			break;
 		}
 		case "ended": {

--- a/apps/examples/desktop-app/sidecar/types.ts
+++ b/apps/examples/desktop-app/sidecar/types.ts
@@ -60,6 +60,8 @@ export type LiveSession = {
 	attachedViaHub?: boolean;
 	/** Materialized attachment files for prompts still waiting in the queue. */
 	queuedAttachmentFiles?: Map<string, string[]>;
+	/** Last prompt id announced via chat_queued_prompt_start, to dedupe emits. */
+	lastQueuedPromptStartId?: string;
 	/** Materialized attachment files whose prompt was submitted; deleted when the turn ends. */
 	consumedAttachmentFiles?: Map<string, string[]>;
 };

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
@@ -478,6 +478,64 @@ describe("useChatSession", () => {
 		]);
 	});
 
+	it("re-keys the optimistic bubble when the runtime queues the same prompt", async () => {
+		invokeMock.mockImplementation(
+			async (command: string, args?: Record<string, unknown>) => {
+				if (command === "get_process_context") {
+					return { cwd: "/workspace/cline", workspaceRoot: "/workspace/cline" };
+				}
+				if (command === "chat_session_command") {
+					const request = args?.request as
+						| { action?: string; config?: { sessionId?: string } }
+						| undefined;
+					if (request?.action === "start") {
+						return { sessionId: request.config?.sessionId };
+					}
+					if (request?.action === "send") {
+						// A prompt the runtime consumed from its queue resolves
+						// without a turn result; chat_done ends the turn instead.
+						return { ok: true, result: {} };
+					}
+				}
+				return [];
+			},
+		);
+
+		await act(async () => {
+			await current.sendPrompt("hi there");
+		});
+		expect(
+			current.messages.filter((message) => message.content === "hi there"),
+		).toHaveLength(1);
+
+		const chatEventHandler = subscribeMock.mock.calls.find(
+			([eventName]) => eventName === "chat_event",
+		)?.[1] as ((payload: unknown) => void) | undefined;
+		expect(chatEventHandler).toBeDefined();
+
+		// The runtime queued the prompt during session startup, so the drain
+		// announces it as a queued prompt start for the same content.
+		await act(async () => {
+			chatEventHandler?.({
+				sessionId: current.sessionId,
+				stream: "chat_queued_prompt_start",
+				chunk: JSON.stringify({
+					promptId: "queued-prompt-1",
+					prompt: "hi there",
+					attachmentCount: 0,
+				}),
+				ts: Date.now(),
+				index: 1,
+			});
+		});
+
+		const userMessages = current.messages.filter(
+			(message) => message.role === "user" && message.content === "hi there",
+		);
+		expect(userMessages).toHaveLength(1);
+		expect(userMessages[0]?.id).toBe("queued_user_queued-prompt-1");
+	});
+
 	it("keeps live stream timestamps in milliseconds", async () => {
 		invokeMock.mockImplementation(
 			async (command: string, args?: Record<string, unknown>) => {

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
@@ -536,6 +536,70 @@ describe("useChatSession", () => {
 		expect(userMessages[0]?.id).toBe("queued_user_queued-prompt-1");
 	});
 
+	it("keeps a stale same-content bubble distinct from a new queued prompt", async () => {
+		invokeMock.mockImplementation(
+			async (command: string, args?: Record<string, unknown>) => {
+				if (command === "get_process_context") {
+					return { cwd: "/workspace/cline", workspaceRoot: "/workspace/cline" };
+				}
+				if (command === "chat_session_command") {
+					const request = args?.request as
+						| { action?: string; config?: { sessionId?: string } }
+						| undefined;
+					if (request?.action === "start") {
+						return { sessionId: request.config?.sessionId };
+					}
+					if (request?.action === "send") {
+						return { ok: true, result: {} };
+					}
+				}
+				return [];
+			},
+		);
+
+		// A prompt whose turn ended without assistant output (e.g. cancelled)
+		// leaves its optimistic bubble at the transcript tail.
+		await act(async () => {
+			await current.sendPrompt("something");
+		});
+		const chatEventHandler = subscribeMock.mock.calls.find(
+			([eventName]) => eventName === "chat_event",
+		)?.[1] as ((payload: unknown) => void) | undefined;
+		expect(chatEventHandler).toBeDefined();
+		await act(async () => {
+			chatEventHandler?.({
+				sessionId: current.sessionId,
+				stream: "chat_done",
+				chunk: JSON.stringify({ reason: "aborted" }),
+				ts: Date.now(),
+				index: 1,
+			});
+		});
+
+		// A later submission of the same text, queued while the agent was
+		// busy, has no optimistic bubble: its queued-start event must append
+		// a new message, not swallow the stale one.
+		await act(async () => {
+			chatEventHandler?.({
+				sessionId: current.sessionId,
+				stream: "chat_queued_prompt_start",
+				chunk: JSON.stringify({
+					promptId: "queued-prompt-2",
+					prompt: "something",
+					attachmentCount: 0,
+				}),
+				ts: Date.now(),
+				index: 2,
+			});
+		});
+
+		const userMessages = current.messages.filter(
+			(message) => message.role === "user" && message.content === "something",
+		);
+		expect(userMessages).toHaveLength(2);
+		expect(userMessages[1]?.id).toBe("queued_user_queued-prompt-2");
+	});
+
 	it("keeps live stream timestamps in milliseconds", async () => {
 		invokeMock.mockImplementation(
 			async (command: string, args?: Record<string, unknown>) => {

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
@@ -303,6 +303,10 @@ export function useChatSession() {
 	const messagesRef = useRef<ChatMessage[]>([]);
 	const promptsInQueueRef = useRef<PromptInQueue[]>([]);
 	const liveToolMessageIdsRef = useRef<Record<string, string>>({});
+	// Optimistic user bubbles whose prompt is still in flight, by message id.
+	// A chat_queued_prompt_start event may only re-key one of these — never a
+	// same-content message left over from an earlier turn (see the handler).
+	const outstandingOptimisticUserIdsRef = useRef<Set<string>>(new Set());
 	const liveToolInputsRef = useRef<Record<string, unknown>>({});
 	const activeSessionIdRef = useRef<string | null>(null);
 	const activeAssistantMessageIdRef = useRef<string | null>(null);
@@ -429,6 +433,7 @@ export function useChatSession() {
 
 	const setErrorState = useCallback(
 		(msg: string, sid: string | null = null) => {
+			outstandingOptimisticUserIdsRef.current.clear();
 			setError(msg);
 			setStatus("error");
 			setMessages((prev) =>
@@ -990,16 +995,20 @@ export function useChatSession() {
 						// an optimistic bubble from the send path; when the runtime
 						// routes that prompt through its queue, this event describes
 						// the same prompt. Re-key the optimistic bubble instead of
-						// rendering the message a second time.
+						// rendering the message a second time. Only bubbles whose
+						// prompt is still in flight are eligible — a same-content
+						// message left over from an earlier (e.g. cancelled) turn
+						// must stay distinct from the new submission.
 						for (let i = prev.length - 1; i >= 0; i--) {
 							const candidate = prev[i];
 							if (candidate.role !== "user") {
 								break;
 							}
 							if (
-								!candidate.id.startsWith("queued_user_") &&
+								outstandingOptimisticUserIdsRef.current.has(candidate.id) &&
 								candidate.content === userLabel
 							) {
+								outstandingOptimisticUserIdsRef.current.delete(candidate.id);
 								const next = [...prev];
 								next[i] = {
 									...candidate,
@@ -1061,6 +1070,10 @@ export function useChatSession() {
 			}
 
 			if (payload.stream === "chat_done") {
+				// The turn is over: any optimistic bubble still registered was
+				// consumed by a direct send and must not be re-keyed by a later
+				// queued prompt that happens to repeat the same text.
+				outstandingOptimisticUserIdsRef.current.clear();
 				clearLiveToolRefs();
 				// Prompts that the runtime consumed from the queue (for example the
 				// first prompt of a fresh session, which is queued while the
@@ -1411,6 +1424,7 @@ export function useChatSession() {
 			const plannedSessionId = activeSessionId ?? makeId("session");
 
 			if (optimisticUserMessageId) {
+				outstandingOptimisticUserIdsRef.current.add(optimisticUserMessageId);
 				addMessage({
 					id: optimisticUserMessageId,
 					sessionId: plannedSessionId,
@@ -1998,6 +2012,7 @@ export function useChatSession() {
 				msgs: ChatMessage[],
 				sessionStatus: typeof session.status,
 			) => {
+				outstandingOptimisticUserIdsRef.current.clear();
 				const mergedMessages = mergeHydratedMessagesWithLive({
 					hydrated: msgs,
 					current: messagesRef.current,

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
@@ -986,6 +986,29 @@ export function useChatSession() {
 							return prev;
 						}
 						const images = toChatMessageImages(userImages, userMessageId);
+						// A prompt dispatched while the session was idle already has
+						// an optimistic bubble from the send path; when the runtime
+						// routes that prompt through its queue, this event describes
+						// the same prompt. Re-key the optimistic bubble instead of
+						// rendering the message a second time.
+						for (let i = prev.length - 1; i >= 0; i--) {
+							const candidate = prev[i];
+							if (candidate.role !== "user") {
+								break;
+							}
+							if (
+								!candidate.id.startsWith("queued_user_") &&
+								candidate.content === userLabel
+							) {
+								const next = [...prev];
+								next[i] = {
+									...candidate,
+									id: userMessageId,
+									images: images.length > 0 ? images : candidate.images,
+								};
+								return sliceMessages(next);
+							}
+						}
 						return sliceMessages([
 							...prev,
 							{


### PR DESCRIPTION
## Problem

In the desktop app, the first message of a session (or any message the runtime routes through its pending-prompt queue) renders twice in the chat. Switching to another chat and back shows it once — history has the message a single time; the duplication happens only in the live stream.

There are two independent duplication sources, fixed in one commit each:

1. **Duplicate event emission (sidecar).** `PendingPromptService.drain()` emits a `pending_prompts` snapshot (head removed) and a `pending_prompt_submitted` event back-to-back for the same prompt. The sidecar translated *both* into a `chat_queued_prompt_start` chunk with the same promptId. The sidecar now tracks the last announced prompt id per live session and emits the start chunk once.

2. **Optimistic bubble never reconciled (webview).** The send path renders an optimistic user bubble under a random id when dispatching while idle. If the runtime then queues that prompt (typical during session startup), the `chat_queued_prompt_start` event appended a second bubble under `queued_user_<promptId>` — the id-based dedupe can't connect the two. The handler now re-keys the trailing optimistic bubble to the event's id instead of appending. This one is timing-dependent, which is why the bug looked intermittent.

## Tests

- Sidecar: feeding both drain events through the real handler yields exactly one `chat_queued_prompt_start` (and a different prompt id is still announced).
- Webview: an optimistic bubble followed by a queued-prompt-start for the same content stays a single message, re-keyed to `queued_user_<promptId>`; existing distinct-prompts and duplicate-event tests still pass.

Both new tests fail without their respective fix.

Note: `sidecar/chat-session.test.ts` and `sidecar/session-data/messages.test.ts` currently fail on `main` (7 tests, pre-existing, unrelated to this change).