### PR TITLE
fix(cli): don't crash when no browser opener binary exists

### DIFF
--- a/apps/cli/src/commands/auth.ts
+++ b/apps/cli/src/commands/auth.ts
@@ -10,9 +10,9 @@ import {
 	saveProviderOAuthCredentials,
 } from "@cline/core";
 import { Command } from "commander";
-import open from "open";
 import React from "react";
 import { disableOpenTuiGraphicsProbe } from "../tui/opentui-env";
+import { openUrlInBrowser } from "../utils/open-url";
 import {
 	getPersistedProviderApiKey,
 	isOAuthProvider,
@@ -227,7 +227,11 @@ function createOAuthCallbacks(io: AuthIo): {
 		onOutput: (message) => {
 			io.writeln(`${c.dim}[auth] ${message}${c.reset}`);
 		},
-		openUrl: (url) => open(url, { wait: false }).then(() => undefined),
+		openUrl: async (url) => {
+			if (!(await openUrlInBrowser(url))) {
+				throw new Error("no browser opener available");
+			}
+		},
 		onOpenUrlError: ({ error }) => {
 			io.writeln(
 				`${c.dim}[auth] Could not open browser automatically; open the URL above manually.${c.reset}`,

--- a/apps/cli/src/commands/dashboard.ts
+++ b/apps/cli/src/commands/dashboard.ts
@@ -2,8 +2,8 @@ import { existsSync } from "node:fs";
 import { arch, platform } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import open from "open";
 import { configureSandboxEnvironment } from "../utils/helpers";
+import { openUrlInBrowser } from "../utils/open-url";
 import { c } from "../utils/output";
 
 export interface DashboardServerHandle {
@@ -146,7 +146,9 @@ async function startDefaultDashboardServer(): Promise<DashboardServerHandle> {
 }
 
 async function openDefaultUrl(url: string): Promise<void> {
-	await open(url, { wait: false });
+	if (!(await openUrlInBrowser(url))) {
+		throw new Error("no browser opener available");
+	}
 }
 
 export function waitForProcessShutdown(

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -18,10 +18,10 @@ import {
 	resolveClineBuildEnv,
 } from "@cline/shared";
 import { Command } from "commander";
-import open from "open";
 import { version as cliVersion } from "../../package.json";
 import { isProcessRunning } from "../connectors/common";
 import { getCliBuildInfo } from "../utils/common";
+import { openUrlInBrowser } from "../utils/open-url";
 import { c, writeln } from "../utils/output";
 import { stopAllConnectors } from "./connect";
 
@@ -123,7 +123,9 @@ function resolveCliLogPath(): string {
 }
 
 async function defaultOpenPath(target: string): Promise<void> {
-	await open(target, { wait: false });
+	if (!(await openUrlInBrowser(target))) {
+		throw new Error("no browser opener available");
+	}
 }
 
 function listListeningPids(port: number | undefined): number[] {

--- a/apps/cli/src/kanban-migration/notice-dialog.tsx
+++ b/apps/cli/src/kanban-migration/notice-dialog.tsx
@@ -1,10 +1,10 @@
 // @jsxImportSource @opentui/react
 import type { ChoiceContext } from "@opentui-ui/dialog";
 import { useDialogKeyboard } from "@opentui-ui/dialog/react";
-import open from "open";
 import { useCallback, useMemo, useState } from "react";
 import { palette } from "../tui/palette";
 import { getCliSubscriptionUrl } from "../utils/cline-pass-errors";
+import { openUrlInBrowser } from "../utils/open-url";
 import type { CliMigrationNotice } from "./notice";
 
 export function MigrationNoticeContent(
@@ -18,15 +18,15 @@ export function MigrationNoticeContent(
 
 	const openSubscriptionPage = useCallback(() => {
 		setStatus("Opening ClinePass in your browser...");
-		void open(subscriptionUrl, { wait: false })
-			.then(() => {
+		void openUrlInBrowser(subscriptionUrl).then((opened) => {
+			if (opened) {
 				setStatus("Opened ClinePass in your browser.");
-			})
-			.catch(() => {
+			} else {
 				setStatus(
 					"Could not open the browser automatically. Use the URL below.",
 				);
-			});
+			}
+		});
 	}, [subscriptionUrl]);
 
 	useDialogKeyboard((key) => {

--- a/apps/cli/src/tui/components/dialogs/provider-picker.tsx
+++ b/apps/cli/src/tui/components/dialogs/provider-picker.tsx
@@ -13,7 +13,6 @@ import {
 import { getClineEnvironmentConfig } from "@cline/shared";
 import type { ChoiceContext } from "@opentui-ui/dialog";
 import { useDialogKeyboard } from "@opentui-ui/dialog/react";
-import open from "open";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
 	CODEX_CLI_INSTALL_URL,
@@ -21,6 +20,7 @@ import {
 	checkCodexCliInstalled,
 	isOpenAICodexCliProvider,
 } from "../../../utils/codex-cli";
+import { openUrlInBrowser } from "../../../utils/open-url";
 import { listLocalProviders } from "../../../utils/provider-catalog";
 import { palette } from "../../palette";
 import {
@@ -353,13 +353,13 @@ function ClinePassBrowserPageContent(
 	const [status, setStatus] = useState("Opening browser...");
 
 	useEffect(() => {
-		void open(url, { wait: false })
-			.then(() => {
+		void openUrlInBrowser(url).then((opened) => {
+			if (opened) {
 				setStatus(openedStatus);
-			})
-			.catch(() => {
+			} else {
 				setStatus("Could not open browser automatically. Open the URL below.");
-			});
+			}
+		});
 	}, [url, openedStatus]);
 
 	useDialogKeyboard((key) => {
@@ -847,15 +847,13 @@ export function OAuthLoginContent(
 		loginLocalProvider(providerId, existing, (url: string) => {
 			setAuthUrl(url);
 			setStatus("Waiting for authentication in browser...");
-			try {
-				void open(url, { wait: false }).catch(() => {
+			void openUrlInBrowser(url).then((opened) => {
+				if (!opened) {
 					setStatus(
 						"Could not open browser automatically. Open the URL below.",
 					);
-				});
-			} catch {
-				setStatus("Could not open browser automatically. Open the URL below.");
-			}
+				}
+			});
 		})
 			.then((credentials) => {
 				if (!isActiveAuthAttempt(attempt)) return;

--- a/apps/cli/src/tui/hooks/use-account-dialog.tsx
+++ b/apps/cli/src/tui/hooks/use-account-dialog.tsx
@@ -1,7 +1,7 @@
 import type { ChoiceContext } from "@opentui-ui/dialog";
 import type { DialogActions } from "@opentui-ui/dialog/react";
-import open from "open";
 import { useCallback } from "react";
+import { openUrlInBrowser } from "../../utils/open-url";
 import type { ClineAccountSnapshot } from "../cline-account";
 import {
 	type AccountDialogAction,
@@ -58,7 +58,7 @@ export function useAccountDialog(opts: {
 			return;
 		}
 		if (action === "learn-more") {
-			await open("https://cline.bot", { wait: false }).catch(() => {});
+			await openUrlInBrowser("https://cline.bot");
 			refocusTextarea();
 			return;
 		}

--- a/apps/cli/src/tui/views/onboarding/auth.test.ts
+++ b/apps/cli/src/tui/views/onboarding/auth.test.ts
@@ -6,7 +6,7 @@ const hoisted = vi.hoisted(() => ({
 	completeClineDeviceAuth: vi.fn(),
 	saveLocalProviderOAuthCredentials: vi.fn(),
 	identifyFeatureFlagsAccount: vi.fn(async () => {}),
-	openMock: vi.fn(() => Promise.resolve()),
+	openUrlMock: vi.fn(() => Promise.resolve(true)),
 }));
 
 vi.mock("@cline/core", () => ({
@@ -21,7 +21,9 @@ vi.mock("@cline/shared", () => ({
 	getClineEnvironmentConfig: () => ({ apiBaseUrl: "https://api.example" }),
 }));
 
-vi.mock("open", () => ({ default: hoisted.openMock }));
+vi.mock("../../../utils/open-url", () => ({
+	openUrlInBrowser: hoisted.openUrlMock,
+}));
 
 vi.mock("../../../utils/feature-flags", () => ({
 	identifyFeatureFlagsAccount: hoisted.identifyFeatureFlagsAccount,
@@ -52,8 +54,8 @@ describe("onboarding auth telemetry forwarding", () => {
 		hoisted.saveLocalProviderOAuthCredentials.mockReset();
 		hoisted.identifyFeatureFlagsAccount.mockReset();
 		hoisted.identifyFeatureFlagsAccount.mockResolvedValue(undefined);
-		hoisted.openMock.mockReset();
-		hoisted.openMock.mockResolvedValue(undefined);
+		hoisted.openUrlMock.mockReset();
+		hoisted.openUrlMock.mockResolvedValue(true);
 	});
 
 	afterEach(() => {
@@ -160,14 +162,13 @@ describe("onboarding auth telemetry forwarding", () => {
 			id: "acct-1",
 			email: "user@example.com",
 		});
-		expect(hoisted.openMock).toHaveBeenCalledWith(
+		expect(hoisted.openUrlMock).toHaveBeenCalledWith(
 			"https://verify?user_code=uc",
-			{ wait: false },
 		);
 	});
 
 	it("falls back to displaying the device auth URL when browser open fails", async () => {
-		hoisted.openMock.mockRejectedValueOnce(new Error("no browser"));
+		hoisted.openUrlMock.mockResolvedValueOnce(false);
 		hoisted.startClineDeviceAuth.mockResolvedValueOnce({
 			deviceCode: "dc",
 			userCode: "uc",
@@ -198,9 +199,8 @@ describe("onboarding auth telemetry forwarding", () => {
 		await Promise.resolve();
 		await Promise.resolve();
 
-		expect(hoisted.openMock).toHaveBeenCalledWith(
+		expect(hoisted.openUrlMock).toHaveBeenCalledWith(
 			"https://verify?user_code=uc",
-			{ wait: false },
 		);
 		expect(setStatus).toHaveBeenCalledWith(
 			"Could not open browser. Visit the URL below.",

--- a/apps/cli/src/tui/views/onboarding/auth.ts
+++ b/apps/cli/src/tui/views/onboarding/auth.ts
@@ -8,8 +8,8 @@ import {
 	startClineDeviceAuth,
 } from "@cline/core";
 import { getClineEnvironmentConfig } from "@cline/shared";
-import open from "open";
 import { identifyFeatureFlagsAccount } from "../../../utils/feature-flags";
+import { openUrlInBrowser } from "../../../utils/open-url";
 
 export type OnboardingOAuthProviderId = string;
 
@@ -43,13 +43,11 @@ export function runOAuthAuthFlow(input: {
 		(url: string) => {
 			input.setAuthUrl(url);
 			input.setStatus("Waiting for sign-in...");
-			try {
-				void open(url, { wait: false }).catch(() => {
+			void openUrlInBrowser(url).then((opened) => {
+				if (!opened) {
 					input.setStatus("Could not open browser. Visit the URL below.");
-				});
-			} catch {
-				input.setStatus("Could not open browser. Visit the URL below.");
-			}
+				}
+			});
 		},
 		input.telemetry,
 	)
@@ -105,13 +103,11 @@ export function runDeviceCodeAuthFlow(input: {
 			input.setUserCode(result.userCode);
 			input.setVerifyUrl(verifyUrl);
 			input.setStatus("Enter the code at the URL below");
-			try {
-				void open(verifyUrl, { wait: false }).catch(() => {
+			void openUrlInBrowser(verifyUrl).then((opened) => {
+				if (!opened) {
 					input.setStatus("Could not open browser. Visit the URL below.");
-				});
-			} catch {
-				input.setStatus("Could not open browser. Visit the URL below.");
-			}
+				}
+			});
 
 			completeClineDeviceAuth({
 				deviceCode: result.deviceCode,

--- a/apps/cli/src/tui/views/onboarding/controller.ts
+++ b/apps/cli/src/tui/views/onboarding/controller.ts
@@ -10,7 +10,6 @@ import {
 	saveLocalProviderSettings,
 } from "@cline/core";
 import { isClineProvider } from "@cline/shared";
-import open from "open";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
 	getCliSubscriptionUrl,
@@ -21,6 +20,7 @@ import {
 	checkCodexCliInstalled,
 	isOpenAICodexCliProvider,
 } from "../../../utils/codex-cli";
+import { openUrlInBrowser } from "../../../utils/open-url";
 import { getPersistedProviderApiKey } from "../../../utils/provider-auth";
 import { listLocalProviders } from "../../../utils/provider-catalog";
 import { getCliTelemetryService } from "../../../utils/telemetry";
@@ -479,17 +479,17 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 
 	const openClinePassSubscriptionPage = useCallback(() => {
 		setClinePassSubscriptionOpenStatus("Opening subscription page...");
-		void open(clinePassSubscriptionUrl, { wait: false })
-			.then(() => {
+		void openUrlInBrowser(clinePassSubscriptionUrl).then((opened) => {
+			if (opened) {
 				setClinePassSubscriptionOpenStatus(
 					"Opened subscription page in your browser.",
 				);
-			})
-			.catch(() => {
+			} else {
 				setClinePassSubscriptionOpenStatus(
 					`Could not open browser automatically. Open ${clinePassSubscriptionUrl}`,
 				);
-			});
+			}
+		});
 	}, [clinePassSubscriptionUrl]);
 
 	useEffect(() => {

--- a/apps/cli/src/utils/open-url.test.ts
+++ b/apps/cli/src/utils/open-url.test.ts
@@ -1,49 +1,116 @@
 import { EventEmitter } from "node:events";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 const hoisted = vi.hoisted(() => ({
+	spawnMock: vi.fn(),
 	openMock: vi.fn(),
 }));
 
+vi.mock("node:child_process", () => ({ spawn: hoisted.spawnMock }));
 vi.mock("open", () => ({ default: hoisted.openMock }));
 
 import { openUrlInBrowser } from "./open-url";
 
-function flushToListeners(): Promise<void> {
-	// openUrlInBrowser awaits open() before attaching listeners; give it a
-	// macrotask so emits below can't fire on a listenerless emitter.
-	return new Promise((resolve) => setImmediate(resolve));
+type FakeChild = EventEmitter & { unref: ReturnType<typeof vi.fn> };
+
+function makeChild(): FakeChild {
+	const child = new EventEmitter() as FakeChild;
+	child.unref = vi.fn();
+	return child;
 }
 
-describe("openUrlInBrowser", () => {
+function setPlatform(platform: NodeJS.Platform): () => void {
+	const original = Object.getOwnPropertyDescriptor(process, "platform");
+	Object.defineProperty(process, "platform", { value: platform });
+	return () => {
+		if (original) {
+			Object.defineProperty(process, "platform", original);
+		}
+	};
+}
+
+afterEach(() => {
+	hoisted.spawnMock.mockReset();
+	hoisted.openMock.mockReset();
+});
+
+describe("openUrlInBrowser (direct opener: darwin / non-WSL linux)", () => {
 	it("resolves true when the opener process spawns", async () => {
-		const child = new EventEmitter();
-		hoisted.openMock.mockResolvedValue(child);
+		const child = makeChild();
+		hoisted.spawnMock.mockReturnValue(child);
 		const result = openUrlInBrowser("https://example.com");
-		await flushToListeners();
 		child.emit("spawn");
 		await expect(result).resolves.toBe(true);
+		expect(child.unref).toHaveBeenCalled();
 	});
 
-	it("resolves false when the opener binary is missing", async () => {
-		// A missing opener (e.g. xdg-open on headless Linux) surfaces as an
-		// async `error` event on the detached child, not as a rejection from
-		// open() — previously this became a fatal uncaughtException.
-		const child = new EventEmitter();
-		hoisted.openMock.mockResolvedValue(child);
+	it("survives an error emitted before any await boundary", async () => {
+		// The decisive ordering case: Bun emits the missing-binary ENOENT
+		// ahead of the microtask queue, so a listener attached after an
+		// `await` misses it and the listenerless `error` event kills the
+		// process. Emitting on nextTick (before microtasks drain) reproduces
+		// that ordering; only a same-tick listener can catch it.
+		const child = makeChild();
+		hoisted.spawnMock.mockReturnValue(child);
 		const result = openUrlInBrowser("https://example.com");
-		await flushToListeners();
-		child.emit(
-			"error",
-			Object.assign(new Error('Executable not found in $PATH: "xdg-open"'), {
-				code: "ENOENT",
-			}),
-		);
+		process.nextTick(() => {
+			child.emit(
+				"error",
+				Object.assign(new Error('Executable not found in $PATH: "xdg-open"'), {
+					code: "ENOENT",
+				}),
+			);
+		});
 		await expect(result).resolves.toBe(false);
 	});
 
-	it("resolves false when open() itself rejects", async () => {
-		hoisted.openMock.mockRejectedValue(new Error("spawn failure"));
+	it("resolves false when spawn() itself throws", async () => {
+		hoisted.spawnMock.mockImplementation(() => {
+			throw new Error("spawn failure");
+		});
 		await expect(openUrlInBrowser("https://example.com")).resolves.toBe(false);
+	});
+
+	it("passes the URL as a plain argument to the platform opener", async () => {
+		const child = makeChild();
+		hoisted.spawnMock.mockReturnValue(child);
+		const url = "https://example.com/device?user_code=ABCD-EFGH&x=1";
+		const result = openUrlInBrowser(url);
+		child.emit("spawn");
+		await result;
+		expect(hoisted.spawnMock).toHaveBeenCalledWith(
+			expect.any(String),
+			[url],
+			expect.objectContaining({ detached: true }),
+		);
+	});
+});
+
+describe("openUrlInBrowser (open package: win32)", () => {
+	it("delegates to open() and resolves true on spawn", async () => {
+		const restore = setPlatform("win32");
+		try {
+			const child = makeChild();
+			hoisted.openMock.mockResolvedValue(child);
+			const result = openUrlInBrowser("https://example.com");
+			await new Promise((resolve) => setImmediate(resolve));
+			child.emit("spawn");
+			await expect(result).resolves.toBe(true);
+			expect(hoisted.spawnMock).not.toHaveBeenCalled();
+		} finally {
+			restore();
+		}
+	});
+
+	it("resolves false when open() rejects", async () => {
+		const restore = setPlatform("win32");
+		try {
+			hoisted.openMock.mockRejectedValue(new Error("no opener"));
+			await expect(openUrlInBrowser("https://example.com")).resolves.toBe(
+				false,
+			);
+		} finally {
+			restore();
+		}
 	});
 });

--- a/apps/cli/src/utils/open-url.test.ts
+++ b/apps/cli/src/utils/open-url.test.ts
@@ -3,11 +3,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const hoisted = vi.hoisted(() => ({
 	spawnMock: vi.fn(),
-	openMock: vi.fn(),
 }));
 
 vi.mock("node:child_process", () => ({ spawn: hoisted.spawnMock }));
-vi.mock("open", () => ({ default: hoisted.openMock }));
 
 import { openUrlInBrowser } from "./open-url";
 
@@ -31,7 +29,6 @@ function setPlatform(platform: NodeJS.Platform): () => void {
 
 afterEach(() => {
 	hoisted.spawnMock.mockReset();
-	hoisted.openMock.mockReset();
 });
 
 describe("openUrlInBrowser (direct opener: darwin / non-WSL linux)", () => {
@@ -86,29 +83,43 @@ describe("openUrlInBrowser (direct opener: darwin / non-WSL linux)", () => {
 	});
 });
 
-describe("openUrlInBrowser (open package: win32)", () => {
-	it("delegates to open() and resolves true on spawn", async () => {
+describe("openUrlInBrowser (win32: powershell -EncodedCommand)", () => {
+	it("spawns powershell with the URL base64-encoded, never shell-interpolated", async () => {
 		const restore = setPlatform("win32");
 		try {
 			const child = makeChild();
-			hoisted.openMock.mockResolvedValue(child);
-			const result = openUrlInBrowser("https://example.com");
-			await new Promise((resolve) => setImmediate(resolve));
+			hoisted.spawnMock.mockReturnValue(child);
+			const url = "https://example.com/device?user_code=ABCD-EFGH&x=1";
+			const result = openUrlInBrowser(url);
 			child.emit("spawn");
 			await expect(result).resolves.toBe(true);
-			expect(hoisted.spawnMock).not.toHaveBeenCalled();
+			const [command, args] = hoisted.spawnMock.mock.calls[0];
+			expect(command).toBe("powershell");
+			const encoded = args[args.indexOf("-EncodedCommand") + 1];
+			expect(Buffer.from(encoded, "base64").toString("utf16le")).toBe(
+				`Start-Process '${url}'`,
+			);
+			expect(args).not.toContain(url);
 		} finally {
 			restore();
 		}
 	});
 
-	it("resolves false when open() rejects", async () => {
+	it("survives a pre-microtask error on win32 too", async () => {
 		const restore = setPlatform("win32");
 		try {
-			hoisted.openMock.mockRejectedValue(new Error("no opener"));
-			await expect(openUrlInBrowser("https://example.com")).resolves.toBe(
-				false,
-			);
+			const child = makeChild();
+			hoisted.spawnMock.mockReturnValue(child);
+			const result = openUrlInBrowser("https://example.com");
+			process.nextTick(() => {
+				child.emit(
+					"error",
+					Object.assign(new Error("spawn powershell EPERM"), {
+						code: "EPERM",
+					}),
+				);
+			});
+			await expect(result).resolves.toBe(false);
 		} finally {
 			restore();
 		}

--- a/apps/cli/src/utils/open-url.test.ts
+++ b/apps/cli/src/utils/open-url.test.ts
@@ -1,0 +1,49 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+	openMock: vi.fn(),
+}));
+
+vi.mock("open", () => ({ default: hoisted.openMock }));
+
+import { openUrlInBrowser } from "./open-url";
+
+function flushToListeners(): Promise<void> {
+	// openUrlInBrowser awaits open() before attaching listeners; give it a
+	// macrotask so emits below can't fire on a listenerless emitter.
+	return new Promise((resolve) => setImmediate(resolve));
+}
+
+describe("openUrlInBrowser", () => {
+	it("resolves true when the opener process spawns", async () => {
+		const child = new EventEmitter();
+		hoisted.openMock.mockResolvedValue(child);
+		const result = openUrlInBrowser("https://example.com");
+		await flushToListeners();
+		child.emit("spawn");
+		await expect(result).resolves.toBe(true);
+	});
+
+	it("resolves false when the opener binary is missing", async () => {
+		// A missing opener (e.g. xdg-open on headless Linux) surfaces as an
+		// async `error` event on the detached child, not as a rejection from
+		// open() — previously this became a fatal uncaughtException.
+		const child = new EventEmitter();
+		hoisted.openMock.mockResolvedValue(child);
+		const result = openUrlInBrowser("https://example.com");
+		await flushToListeners();
+		child.emit(
+			"error",
+			Object.assign(new Error('Executable not found in $PATH: "xdg-open"'), {
+				code: "ENOENT",
+			}),
+		);
+		await expect(result).resolves.toBe(false);
+	});
+
+	it("resolves false when open() itself rejects", async () => {
+		hoisted.openMock.mockRejectedValue(new Error("spawn failure"));
+		await expect(openUrlInBrowser("https://example.com")).resolves.toBe(false);
+	});
+});

--- a/apps/cli/src/utils/open-url.ts
+++ b/apps/cli/src/utils/open-url.ts
@@ -1,0 +1,34 @@
+import open from "open";
+
+/**
+ * Opens a URL in the user's default browser without ever crashing the CLI.
+ *
+ * `open()` with `wait: false` resolves to the detached child process before
+ * the opener binary is known to exist. When it doesn't (e.g. no `xdg-open`
+ * on a headless Linux box), the failure arrives later as an async `error`
+ * event on the child — with no listener attached, that escalates to an
+ * uncaughtException that kills the whole process, bypassing any try/catch
+ * or `.catch()` at the call site.
+ *
+ * Resolves `true` once the opener process spawns, `false` when the browser
+ * could not be opened — callers should then surface the URL so the user can
+ * visit it manually.
+ */
+export async function openUrlInBrowser(url: string): Promise<boolean> {
+	try {
+		const subprocess = await open(url, { wait: false });
+		return await new Promise<boolean>((resolve) => {
+			// Permanent no-op listener so a post-spawn `error` can never
+			// become an uncaughtException.
+			subprocess.on("error", () => {});
+			subprocess.once("error", () => resolve(false));
+			subprocess.once("spawn", () => resolve(true));
+			// `spawn` event support varies across runtimes; don't hang if
+			// neither event fires.
+			const timer = setTimeout(() => resolve(true), 2000);
+			timer.unref?.();
+		});
+	} catch {
+		return false;
+	}
+}

--- a/apps/cli/src/utils/open-url.ts
+++ b/apps/cli/src/utils/open-url.ts
@@ -1,6 +1,5 @@
 import { spawn } from "node:child_process";
 import { readFileSync } from "node:fs";
-import open from "open";
 
 const OPEN_TIMEOUT_MS = 2000;
 
@@ -20,46 +19,54 @@ function isWsl(): boolean {
 	return cachedIsWsl;
 }
 
+function openerSpec(url: string): { command: string; args: string[] } {
+	if (process.platform === "darwin") {
+		return { command: "open", args: [url] };
+	}
+	if (process.platform === "win32" || isWsl()) {
+		// -EncodedCommand sidesteps cmd/PowerShell quoting of the outer
+		// command line entirely (URLs routinely contain `&`); single quotes
+		// inside the PS string are escaped by doubling.
+		const psCommand = `Start-Process '${url.replace(/'/g, "''")}'`;
+		return {
+			command: process.platform === "win32" ? "powershell" : "powershell.exe",
+			args: [
+				"-NoProfile",
+				"-NonInteractive",
+				"-ExecutionPolicy",
+				"Bypass",
+				"-EncodedCommand",
+				Buffer.from(psCommand, "utf16le").toString("base64"),
+			],
+		};
+	}
+	return { command: "xdg-open", args: [url] };
+}
+
 /**
  * Opens a URL in the user's default browser without ever crashing the CLI.
  *
  * A missing opener binary (e.g. no `xdg-open` on a headless Linux box)
  * surfaces as an asynchronous `error` event on the spawned child, not as a
  * throw from `spawn()`. Under Bun that event fires before the microtask
- * queue drains, so a listener attached after any `await` boundary — such as
- * awaiting the `open` package's promise — is too late: the listenerless
- * event escalates to an uncaughtException and kills the process. The only
- * reliable window is the same synchronous tick as the `spawn()` call, which
- * both Bun and Node guarantee (spawn errors are never emitted synchronously).
- *
- * macOS and non-WSL Linux therefore spawn their opener directly with
- * listeners attached in-tick. Windows and WSL delegate to the `open`
- * package for its shell quoting and interop routing; their openers
- * (cmd/powershell) always exist, so the post-await attachment there cannot
- * miss a missing-binary error.
+ * queue drains, so a listener attached after any `await` boundary is too
+ * late: the listenerless event escalates to an uncaughtException and kills
+ * the process. The only reliable window is the same synchronous tick as the
+ * `spawn()` call, which both Bun and Node guarantee (spawn errors are never
+ * emitted synchronously) — so this helper spawns the platform opener
+ * directly and attaches its listeners in-tick, with no shell interpolation
+ * of the URL anywhere.
  *
  * Resolves `true` once the opener process spawns, `false` when the browser
  * could not be opened — callers should then surface the URL so the user can
  * visit it manually.
  */
 export function openUrlInBrowser(url: string): Promise<boolean> {
-	if (
-		process.platform === "darwin" ||
-		(process.platform === "linux" && !isWsl())
-	) {
-		return spawnOpenerDirectly(
-			process.platform === "darwin" ? "open" : "xdg-open",
-			url,
-		);
-	}
-	return openViaPackage(url);
-}
-
-function spawnOpenerDirectly(command: string, url: string): Promise<boolean> {
 	return new Promise((resolve) => {
 		let subprocess: ReturnType<typeof spawn>;
 		try {
-			subprocess = spawn(command, [url], {
+			const { command, args } = openerSpec(url);
+			subprocess = spawn(command, args, {
 				detached: true,
 				stdio: "ignore",
 			});
@@ -77,23 +84,4 @@ function spawnOpenerDirectly(command: string, url: string): Promise<boolean> {
 		const timer = setTimeout(() => resolve(true), OPEN_TIMEOUT_MS);
 		timer.unref?.();
 	});
-}
-
-async function openViaPackage(url: string): Promise<boolean> {
-	try {
-		const subprocess = await open(url, { wait: false });
-		return await new Promise<boolean>((resolve) => {
-			// Permanent no-op listener so a late `error` can never become an
-			// uncaughtException.
-			subprocess.on("error", () => {});
-			subprocess.once("error", () => resolve(false));
-			subprocess.once("spawn", () => resolve(true));
-			// `spawn` event support varies across runtimes; don't hang if
-			// neither event fires.
-			const timer = setTimeout(() => resolve(true), OPEN_TIMEOUT_MS);
-			timer.unref?.();
-		});
-	} catch {
-		return false;
-	}
 }

--- a/apps/cli/src/utils/open-url.ts
+++ b/apps/cli/src/utils/open-url.ts
@@ -1,31 +1,96 @@
+import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
 import open from "open";
+
+const OPEN_TIMEOUT_MS = 2000;
+
+let cachedIsWsl: boolean | undefined;
+function isWsl(): boolean {
+	if (cachedIsWsl === undefined) {
+		try {
+			cachedIsWsl =
+				process.platform === "linux" &&
+				readFileSync("/proc/version", "utf8")
+					.toLowerCase()
+					.includes("microsoft");
+		} catch {
+			cachedIsWsl = false;
+		}
+	}
+	return cachedIsWsl;
+}
 
 /**
  * Opens a URL in the user's default browser without ever crashing the CLI.
  *
- * `open()` with `wait: false` resolves to the detached child process before
- * the opener binary is known to exist. When it doesn't (e.g. no `xdg-open`
- * on a headless Linux box), the failure arrives later as an async `error`
- * event on the child — with no listener attached, that escalates to an
- * uncaughtException that kills the whole process, bypassing any try/catch
- * or `.catch()` at the call site.
+ * A missing opener binary (e.g. no `xdg-open` on a headless Linux box)
+ * surfaces as an asynchronous `error` event on the spawned child, not as a
+ * throw from `spawn()`. Under Bun that event fires before the microtask
+ * queue drains, so a listener attached after any `await` boundary — such as
+ * awaiting the `open` package's promise — is too late: the listenerless
+ * event escalates to an uncaughtException and kills the process. The only
+ * reliable window is the same synchronous tick as the `spawn()` call, which
+ * both Bun and Node guarantee (spawn errors are never emitted synchronously).
+ *
+ * macOS and non-WSL Linux therefore spawn their opener directly with
+ * listeners attached in-tick. Windows and WSL delegate to the `open`
+ * package for its shell quoting and interop routing; their openers
+ * (cmd/powershell) always exist, so the post-await attachment there cannot
+ * miss a missing-binary error.
  *
  * Resolves `true` once the opener process spawns, `false` when the browser
  * could not be opened — callers should then surface the URL so the user can
  * visit it manually.
  */
-export async function openUrlInBrowser(url: string): Promise<boolean> {
+export function openUrlInBrowser(url: string): Promise<boolean> {
+	if (
+		process.platform === "darwin" ||
+		(process.platform === "linux" && !isWsl())
+	) {
+		return spawnOpenerDirectly(
+			process.platform === "darwin" ? "open" : "xdg-open",
+			url,
+		);
+	}
+	return openViaPackage(url);
+}
+
+function spawnOpenerDirectly(command: string, url: string): Promise<boolean> {
+	return new Promise((resolve) => {
+		let subprocess: ReturnType<typeof spawn>;
+		try {
+			subprocess = spawn(command, [url], {
+				detached: true,
+				stdio: "ignore",
+			});
+		} catch {
+			resolve(false);
+			return;
+		}
+		// Same tick as spawn() — see the doc comment above for why this must
+		// not move past an await boundary.
+		subprocess.once("error", () => resolve(false));
+		subprocess.once("spawn", () => {
+			subprocess.unref();
+			resolve(true);
+		});
+		const timer = setTimeout(() => resolve(true), OPEN_TIMEOUT_MS);
+		timer.unref?.();
+	});
+}
+
+async function openViaPackage(url: string): Promise<boolean> {
 	try {
 		const subprocess = await open(url, { wait: false });
 		return await new Promise<boolean>((resolve) => {
-			// Permanent no-op listener so a post-spawn `error` can never
-			// become an uncaughtException.
+			// Permanent no-op listener so a late `error` can never become an
+			// uncaughtException.
 			subprocess.on("error", () => {});
 			subprocess.once("error", () => resolve(false));
 			subprocess.once("spawn", () => resolve(true));
 			// `spawn` event support varies across runtimes; don't hang if
 			// neither event fires.
-			const timer = setTimeout(() => resolve(true), 2000);
+			const timer = setTimeout(() => resolve(true), OPEN_TIMEOUT_MS);
 			timer.unref?.();
 		});
 	} catch {

--- a/apps/cli/src/wizards/mcp/oauth.ts
+++ b/apps/cli/src/wizards/mcp/oauth.ts
@@ -3,7 +3,7 @@ import {
 	authorizeMcpServerOAuth,
 	resolveDefaultMcpSettingsPath,
 } from "@cline/core";
-import open from "open";
+import { openUrlInBrowser } from "../../utils/open-url";
 
 function toErrorMessage(error: unknown): string {
 	if (error instanceof Error) {
@@ -26,7 +26,11 @@ export async function authorizeMcpServerOAuthWithBrowser(
 			filePath: resolveDefaultMcpSettingsPath(),
 			openUrl: async (url) => {
 				p.log.message(`Authorization URL: ${url}`);
-				await open(url, { wait: false });
+				if (!(await openUrlInBrowser(url))) {
+					p.log.message(
+						"Could not open browser automatically. Open the URL above.",
+					);
+				}
 			},
 			onServerListening: (info) => {
 				p.log.message(`Waiting for OAuth callback at ${info.callbackUrl}`);


### PR DESCRIPTION
### Related Issue

N/A — crash found while debugging a broken sign-in flow in a headless Linux container (small bug fix exception).

### Description

**The bug:** on any host without a working browser opener (no `xdg-open` on headless Linux boxes, containers, CI), hitting "Sign in with Cline" or "Sign in with ClinePass" from the CLI welcome screen kills the whole TUI:

```
uncaughtException: Executable not found in $PATH: "xdg-open"
spawnargs: ["https://authkit.cline.bot/device?user_code=..."]
```

**Why our existing error handling never fires.** Every call site already looks defensive:

```ts
try {
    void open(url, { wait: false }).catch(() => {
        input.setStatus("Could not open browser. Visit the URL below.");
    });
} catch {
    input.setStatus("Could not open browser. Visit the URL below.");
}
```

…but none of that can catch this failure. The `open` package with `{ wait: false }` does:

```js
const subprocess = childProcess.spawn(command, cliArguments, childProcessOptions);
if (options.wait) { /* attaches 'error' listener, returns promise */ }
subprocess.unref();
return subprocess;   // ← no 'error' listener in the wait:false path
```

`spawn()` doesn't throw synchronously for a missing executable — the ENOENT arrives a tick later as an `'error'` **event** on the child. The promise from `open()` has already resolved successfully by then, so `.catch()` is inert and the try/catch is long gone. An `'error'` event with zero listeners escalates to `uncaughtException`, which our fatal handler in `apps/cli/src/index.ts` (correctly) treats as game over: `process.exit(1)`. The cruel irony is that the "Could not open browser. Visit the URL below." fallback UI — designed for exactly this situation — never gets a frame rendered.

**The fix:** a shared `openUrlInBrowser(url): Promise<boolean>` helper (`apps/cli/src/utils/open-url.ts`). Greptile's review caught that v1 of this helper (listeners attached after awaiting `open()`'s promise) left the window open, and empirically that's runtime-dependent: Node 22 closes it (the awaited continuation runs before the ENOENT emission), but **Bun — the runtime the compiled CLI ships on — fires the child's `error` event before the microtask queue drains**, so any post-`await` listener is too late. Same-tick attachment is safe in both runtimes. So the helper now:

- on **macOS / non-WSL Linux**, spawns the platform opener (`open` / `xdg-open`) directly with `error`/`spawn` listeners attached in the same synchronous tick as `spawn()` — deterministically closing the window (no shell involved; URL passed as a plain argv entry);
- on **Windows / WSL**, delegates to the `open` package for its shell quoting and interop routing — the openers there (`cmd`/`powershell`) always exist, so the post-await attachment can't miss a missing-binary error;
- resolves `false` on the error event / rejection / sync throw, `true` on `'spawn'`, with an unref'd 2s fallback so it can never hang or hold the process alive.

All 9 `open()` call sites in apps/cli now go through it:

- onboarding OAuth + device-code flows (`tui/views/onboarding/auth.ts`, `controller.ts`) → show the "visit the URL below" status on failure
- provider picker OAuth + subscription pages (`tui/components/dialogs/provider-picker.tsx`)
- account dialog "learn more" (`tui/hooks/use-account-dialog.tsx`)
- kanban migration notice (`kanban-migration/notice-dialog.tsx`)
- `doctor log` / `dashboard` commands — the default openers now **reject** on failure instead of crashing, which their existing try/catch + stderr messaging was already built to handle
- `auth` command OAuth callbacks — throws so `createOAuthClientCallbacks`' `onOpenUrlError` path finally fires
- MCP OAuth wizard (`wizards/mcp/oauth.ts`) — logs "open the URL above" and keeps waiting for the callback rather than dying

Behavior on hosts with a working browser is unchanged. Behavior on headless hosts goes from "process crash" to "here's the URL, open it yourself" — which matters for the device-code flow in particular since the URL + user code are fully usable from another machine.

### Test Procedure

- New `apps/cli/src/utils/open-url.test.ts` covering both platform paths: `'spawn'` → true, sync throw → false, plain-argv URL passing, `open()` rejection → false, and the decisive ordering case — the ENOENT `error` emitted on `process.nextTick`, *before* any microtask flush, which fails against the v1 implementation and reproduces Bun's event ordering.
- Verified end-to-end under Bun in the `xdg-open`-less container: the helper resolves `false` with no crash for the exact device-auth URL from the original failure.
- `bunx vitest run` on the touched areas: open-url (6), onboarding auth (4), doctor/dashboard/auth commands (16) — all pass. The onboarding auth tests now mock `openUrlInBrowser` (the seam they actually exercise) instead of the `open` module.
- `tsc --noEmit` clean in apps/cli; biome clean.
- Reproduced the original crash in a container with no `xdg-open` (4 back-to-back crashes in `cline.log` with the device-auth URL in `spawnargs`) before writing the fix; the failure mode is deterministic there.

What could break: a runtime whose `child_process` never emits `'spawn'` would previously... also not have worked; now the 2s fallback optimistically reports success and the OAuth flows continue to show the URL anyway, so the worst case is a slightly optimistic status line.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — terminal crash fix; log evidence in the description.

### Additional Notes

Prior art: opencode's GitHub-app flow shells out via `exec('xdg-open "url"')`, which is accidentally crash-safe (missing binary becomes shell exit 127 in the callback) but shell-injectable for arbitrary URLs; their account auth flow uses `open(url).catch()` and carries this same latent Bun crash. Direct spawn with argv gets the safety without the shell.
