### PR TITLE
fix(sdk): cross-process settings locks and storage-aware Cline token refresh

### DIFF
--- a/apps/cli/src/tui/cline-account.test.ts
+++ b/apps/cli/src/tui/cline-account.test.ts
@@ -57,6 +57,9 @@ vi.mock("@cline/core", async (importOriginal) => {
 			saveProviderSettings(settings: unknown, options?: unknown) {
 				coreMocks.saveProviderSettings(settings, options);
 			}
+			getFilePath() {
+				return `${process.env.TMPDIR ?? "/tmp"}/cline-account-test-providers.json`;
+			}
 		},
 	};
 });

--- a/apps/cli/src/tui/cline-account.ts
+++ b/apps/cli/src/tui/cline-account.ts
@@ -2,17 +2,16 @@ import {
 	type ClineAccountBalance,
 	type ClineAccountOrganization,
 	type ClineAccountOrganizationBalance,
-	type ClineSubscriptionPlan,
-	type UserCurrentPlan,
 	ClineAccountService,
 	type ClineAccountUser,
+	type ClineSubscriptionPlan,
 	formatProviderOAuthApiKey,
 	getPersistedProviderApiKey,
 	getProviderOAuthCredentialsFromSettings,
-	getValidClineCredentials,
 	type ProviderSettings,
 	ProviderSettingsManager,
-	saveLocalProviderOAuthCredentials,
+	refreshProviderOAuthCredentialsFromStore,
+	type UserCurrentPlan,
 } from "@cline/core";
 import { getClineEnvironmentConfig } from "@cline/shared";
 import { formatCreditBalance, normalizeCreditBalance } from "../utils/output";
@@ -103,25 +102,23 @@ async function resolveValidClineAccountAuthToken(input: {
 		? getProviderOAuthCredentialsFromSettings("cline", settings)
 		: null;
 	if (settings && credentials) {
-		const nextCredentials = await getValidClineCredentials(credentials, {
+		// Rotate through the shared store helper: cross-process lock + re-read
+		// from disk + adopt-on-invalid-grant, and persistence handled inside.
+		const outcome = await refreshProviderOAuthCredentialsFromStore({
+			manager: input.manager,
+			providerId: "cline",
 			apiBaseUrl: input.apiBaseUrl,
 		});
-		if (!nextCredentials) {
+		if (outcome.status === "reauth_required") {
 			throw new Error(
 				"Cline account requires re-authentication. Run cline auth cline.",
 			);
 		}
-		const nextAccessToken = formatProviderOAuthApiKey("cline", nextCredentials);
-		if (nextCredentials !== credentials) {
-			saveLocalProviderOAuthCredentials(
-				input.manager,
-				"cline",
-				settings,
-				nextCredentials,
-				{ setLastUsed: false },
-			);
+		if (outcome.status === "ok") {
+			return formatProviderOAuthApiKey("cline", outcome.credentials);
 		}
-		return nextAccessToken;
+		// no_credentials: the store had nothing (settings came from elsewhere) —
+		// fall through to the persisted/config token below.
 	}
 	return resolveClineAccountAuthToken({
 		config: input.config,

--- a/apps/cline-hub/src/server/desktop-commands.ts
+++ b/apps/cline-hub/src/server/desktop-commands.ts
@@ -8,7 +8,6 @@ import {
 	getLocalProviderModels,
 	getPersistedProviderApiKey,
 	getProviderOAuthCredentialsFromSettings,
-	getValidClineCredentials,
 	listLocalProviders,
 	loginAndSaveLocalProviderOAuthCredentials,
 	markLocalProviderEnabled,
@@ -18,7 +17,7 @@ import {
 	type ProviderProtocol,
 	type ProviderSettings,
 	readGlobalSettings,
-	saveLocalProviderOAuthCredentials,
+	refreshProviderOAuthCredentialsFromStore,
 	saveLocalProviderSettings,
 	setAutoUpdateEnabledGlobally,
 	setDisabledPlugin,
@@ -75,26 +74,23 @@ async function resolveHubClineAccountAuthToken(input: {
 		return getPersistedProviderApiKey("cline", input.settings);
 	}
 
-	const nextCredentials = await getValidClineCredentials(credentials, {
+	// Rotate through the shared store helper: cross-process lock + re-read
+	// from disk + adopt-on-invalid-grant, and persistence handled inside.
+	const outcome = await refreshProviderOAuthCredentialsFromStore({
+		manager: providerSettingsManager,
+		providerId: "cline",
 		apiBaseUrl: input.apiBaseUrl,
 	});
-	if (!nextCredentials) {
+	if (outcome.status === "reauth_required") {
 		throw new Error(
 			"Cline account requires re-authentication. Run cline auth cline.",
 		);
 	}
-
-	if (nextCredentials !== credentials) {
-		saveLocalProviderOAuthCredentials(
-			providerSettingsManager,
-			"cline",
-			input.settings,
-			nextCredentials,
-			{ setLastUsed: false },
-		);
+	if (outcome.status === "no_credentials") {
+		return getPersistedProviderApiKey("cline", input.settings);
 	}
 
-	return formatProviderOAuthApiKey("cline", nextCredentials);
+	return formatProviderOAuthApiKey("cline", outcome.credentials);
 }
 
 export async function handleDesktopCommand(

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -532,8 +532,10 @@ ${ctx.cellJson || "{}"}
 				// Secret was added or updated - restore auth info (login from another window)
 				authService?.restoreRefreshTokenAndRetrieveAuthInfo()
 			} else {
-				// Secret was removed - handle logout for all windows
-				authService?.handleDeauth(LogoutReason.CROSS_WINDOW_SYNC)
+				// Secret was removed. Only the legacy extension writes this secret,
+				// and it also clears it when IT loses a refresh-token race — so
+				// reconcile against providers.json instead of deauthing blindly.
+				authService?.syncAuthStateFromDisk(LogoutReason.CROSS_WINDOW_SYNC)
 			}
 		}
 	})

--- a/apps/vscode/src/sdk/auth-service.test.ts
+++ b/apps/vscode/src/sdk/auth-service.test.ts
@@ -107,6 +107,7 @@ vi.mock("axios", () => ({
 }))
 
 const mockLoginClineOAuth = vi.hoisted(() => vi.fn())
+const mockRefreshFromStore = vi.hoisted(() => vi.fn())
 
 // Mock @cline/core OAuth functions
 vi.mock("@cline/core", async () => ({
@@ -129,6 +130,7 @@ vi.mock("@cline/core", async () => ({
 	loginOpenAICodex: vi.fn(),
 	refreshClineToken: vi.fn(),
 	getValidClineCredentials: vi.fn(),
+	refreshProviderOAuthCredentialsFromStore: mockRefreshFromStore,
 }))
 
 // Stateful in-memory provider-settings store. Cline credentials are persisted
@@ -484,12 +486,17 @@ describe("AuthService", () => {
 					accountId: "user-123",
 				},
 			})
-			vi.mocked(getValidClineCredentials).mockResolvedValue({
-				access: "persisted-access-token",
-				refresh: "persisted-refresh-token",
-				expires: Date.now() + 3600 * 1000,
-				accountId: "user-123",
-				email: "test@example.com",
+			mockRefreshFromStore.mockResolvedValue({
+				status: "ok",
+				refreshed: false,
+				settings: { provider: "cline" },
+				credentials: {
+					access: "persisted-access-token",
+					refresh: "persisted-refresh-token",
+					expires: Date.now() + 3600 * 1000,
+					accountId: "user-123",
+					email: "test@example.com",
+				},
 			})
 
 			await authService.restoreRefreshTokenAndRetrieveAuthInfo()
@@ -556,14 +563,66 @@ describe("AuthService", () => {
 				provider: "cline",
 				auth: { accessToken: "workos:stale", refreshToken: "stale-refresh", accountId: "user-123" },
 			})
-			// getValidClineCredentials returning null models an unrecoverable token.
-			vi.mocked(getValidClineCredentials).mockResolvedValue(null)
+			// reauth_required models a refresh token the server rejected even after
+			// the helper's adopt-from-disk recovery — the only genuine logout.
+			mockRefreshFromStore.mockResolvedValue({ status: "reauth_required" })
 
 			await authService.restoreRefreshTokenAndRetrieveAuthInfo()
 
 			expect(testAccess(authService)._authenticated).toBe(false)
 			expect(testAccess(authService)._clineAuthInfo).toBeNull()
 			expect(mockProviderSettings.get("cline")?.auth).toBeUndefined()
+		})
+
+		it("keeps persisted credentials when the refresh fails transiently", async () => {
+			mockProviderSettings.set("cline", {
+				provider: "cline",
+				auth: { accessToken: "workos:stale", refreshToken: "stale-refresh", accountId: "user-123" },
+			})
+			// Transient failures (network, 5xx) THROW from the store helper.
+			mockRefreshFromStore.mockRejectedValue(new Error("fetch failed"))
+
+			await authService.restoreRefreshTokenAndRetrieveAuthInfo()
+
+			expect(testAccess(authService)._authenticated).toBe(false)
+			// Credentials must survive for the next attempt.
+			expect(mockProviderSettings.get("cline")?.auth).toBeDefined()
+		})
+	})
+
+	describe("syncAuthStateFromDisk()", () => {
+		it("restores instead of deauthing when credentials are still on disk", async () => {
+			mockProviderSettings.set("cline", {
+				provider: "cline",
+				auth: { accessToken: "workos:live", refreshToken: "live-refresh", accountId: "user-123" },
+			})
+			mockRefreshFromStore.mockResolvedValue({
+				status: "ok",
+				refreshed: false,
+				settings: { provider: "cline" },
+				credentials: {
+					access: "live",
+					refresh: "live-refresh",
+					expires: Date.now() + 3600 * 1000,
+					accountId: "user-123",
+				},
+			})
+
+			await authService.syncAuthStateFromDisk(LogoutReason.CROSS_WINDOW_SYNC)
+
+			expect(testAccess(authService)._authenticated).toBe(true)
+			expect(mockProviderSettings.get("cline")?.auth).toBeDefined()
+		})
+
+		it("deauths when the disk really has no credentials", async () => {
+			const authInfo = createTestAuthInfo()
+			testAccess(authService)._clineAuthInfo = authInfo
+			testAccess(authService)._authenticated = true
+
+			await authService.syncAuthStateFromDisk(LogoutReason.CROSS_WINDOW_SYNC)
+
+			expect(testAccess(authService)._authenticated).toBe(false)
+			expect(testAccess(authService)._clineAuthInfo).toBeNull()
 		})
 	})
 
@@ -573,12 +632,17 @@ describe("AuthService", () => {
 				provider: "cline",
 				auth: { accessToken: "workos:raw-access-token", refreshToken: "r", accountId: "user-123" },
 			})
-			vi.mocked(getValidClineCredentials).mockResolvedValue({
-				access: "raw-access-token",
-				refresh: "r",
-				expires: Date.now() + 3600 * 1000,
-				accountId: "user-123",
-				email: "test@example.com",
+			mockRefreshFromStore.mockResolvedValue({
+				status: "ok",
+				refreshed: false,
+				settings: { provider: "cline" },
+				credentials: {
+					access: "raw-access-token",
+					refresh: "r",
+					expires: Date.now() + 3600 * 1000,
+					accountId: "user-123",
+					email: "test@example.com",
+				},
 			})
 
 			await authService.restoreRefreshTokenAndRetrieveAuthInfo()

--- a/apps/vscode/src/sdk/auth-service.test.ts
+++ b/apps/vscode/src/sdk/auth-service.test.ts
@@ -507,10 +507,11 @@ describe("AuthService", () => {
 			expect(
 				(mockProviderSettings.get("cline")?.auth as { metadata?: Record<string, unknown> } | undefined)?.metadata,
 			).toBeUndefined()
-			expect(getValidClineCredentials).toHaveBeenCalledWith(
-				expect.any(Object),
-				expect.objectContaining({ telemetry: mockSdkTelemetry }),
-				expect.any(Object),
+			expect(mockRefreshFromStore).toHaveBeenCalledWith(
+				expect.objectContaining({
+					providerId: "cline",
+					telemetry: mockSdkTelemetry,
+				}),
 			)
 		})
 

--- a/apps/vscode/src/sdk/auth-service.ts
+++ b/apps/vscode/src/sdk/auth-service.ts
@@ -11,11 +11,11 @@
 import type { ITelemetryService, OAuthCredentials, ProviderSettings } from "@cline/core"
 import {
 	createOAuthClientCallbacks,
-	getValidClineCredentials,
 	hashSecret,
 	loginClineOAuth,
 	loginOcaOAuth,
 	loginOpenAICodex,
+	refreshProviderOAuthCredentialsFromStore,
 	sdkDebug,
 } from "@cline/core"
 import type { ApiProvider } from "@shared/api"
@@ -324,32 +324,6 @@ export class AuthService {
 		}
 	}
 
-	private toOAuthCredentials(authInfo: ClineAuthInfo): OAuthCredentials {
-		return {
-			access: authInfo.idToken,
-			refresh: authInfo.refreshToken ?? "",
-			expires: authInfo.expiresAt ? authInfo.expiresAt * 1000 : 0,
-			accountId: authInfo.userInfo.id || undefined,
-			email: authInfo.userInfo.email || undefined,
-			metadata: authInfo.startedAt ? { sessionStartedAtMs: authInfo.startedAt } : undefined,
-		}
-	}
-
-	private async resolveValidClineCredentials(
-		authInfo: ClineAuthInfo,
-		options?: { forceRefresh?: boolean },
-	): Promise<OAuthCredentials | null> {
-		if (options?.forceRefresh && !authInfo.refreshToken) {
-			return null
-		}
-
-		return getValidClineCredentials(
-			this.toOAuthCredentials(authInfo),
-			{ apiBaseUrl: ClineEnv.config().apiBaseUrl, telemetry: this._telemetry },
-			{ forceRefresh: options?.forceRefresh },
-		)
-	}
-
 	// ---- Public API (used by gRPC handlers) ----
 
 	/**
@@ -405,9 +379,21 @@ export class AuthService {
 				if (!currentInfo) {
 					return undefined
 				}
-				const newCredentials = await this.resolveValidClineCredentials(currentInfo, { forceRefresh: true })
-				if (!newCredentials) {
-					sdkDebug("[SdkAuthService] refreshAccessToken: refresh returned null — clearing credentials")
+				// Refresh against the shared store (providers.json) rather than our
+				// in-memory snapshot: the helper re-reads the file inside a
+				// cross-process lock, so a token that another window or the CLI
+				// already rotated is adopted instead of presenting a consumed
+				// refresh token upstream. Transient failures THROW (handled by the
+				// catch below) and leave stored credentials untouched; a non-"ok"
+				// outcome means the refresh token itself was rejected.
+				const outcome = await refreshProviderOAuthCredentialsFromStore({
+					manager: getProviderSettingsManager(),
+					providerId: "cline",
+					forceRefresh: true,
+					apiBaseUrl: ClineEnv.config().apiBaseUrl,
+				})
+				if (outcome.status !== "ok") {
+					sdkDebug(`[SdkAuthService] refreshAccessToken: ${outcome.status} — clearing credentials`)
 					this._clineAuthInfo = null
 					this._authenticated = false
 					clearClineCredentials()
@@ -416,6 +402,7 @@ export class AuthService {
 					})
 					return undefined
 				}
+				const newCredentials = outcome.credentials
 
 				const credentialsChanged =
 					newCredentials.access !== currentInfo.idToken ||
@@ -440,14 +427,8 @@ export class AuthService {
 					sdkDebug(
 						`[SdkAuthService] refreshAccessToken: credentials changed (newTokenHash=${hashSecret(newCredentials.access)})`,
 					)
-					writeClineCredentials({
-						accessToken: newCredentials.access,
-						refreshToken: newCredentials.refresh,
-						expiresAt: newCredentials.expires,
-						accountId: this._clineAuthInfo.userInfo.id,
-						metadata: newCredentials.metadata,
-						sessionStartedAtMs: readSessionStartedAtMs(newCredentials.metadata),
-					})
+					// refreshProviderOAuthCredentialsFromStore already persisted the
+					// rotated tokens to providers.json (atomically, inside the lock).
 
 					setImmediate(() => {
 						this.sendAuthStatusUpdate().catch((err) => {
@@ -837,6 +818,25 @@ export class AuthService {
 	}
 
 	/**
+	 * Reconcile auth state with providers.json after a cross-window signal.
+	 *
+	 * The cline:clineAccountId secret is only ever written by the LEGACY
+	 * extension; its removal historically triggered an unconditional deauth
+	 * here. But the legacy extension also clears that secret when it loses a
+	 * refresh race (its own bug), which used to cascade a healthy new-stack
+	 * session into a hard logout. Disk is the source of truth: if credentials
+	 * are still there, validate and adopt them; only deauth when they are gone.
+	 */
+	async syncAuthStateFromDisk(reason: LogoutReason): Promise<void> {
+		if (readClineCredentials()) {
+			sdkDebug("[SdkAuthService] syncAuthStateFromDisk: credentials on disk — restoring instead of deauthing")
+			await this.restoreRefreshTokenAndRetrieveAuthInfo()
+		} else {
+			await this.handleDeauth(reason)
+		}
+	}
+
+	/**
 	 * Handle auth callback from URI handler.
 	 * This is called when the browser redirects back to the extension after OAuth.
 	 */
@@ -962,23 +962,25 @@ export class AuthService {
 				startedAt: creds.sessionStartedAtMs,
 			}
 
-			const validCredentials = await this.resolveValidClineCredentials(restoredAuthInfo)
-			if (!validCredentials) {
+			const outcome = await refreshProviderOAuthCredentialsFromStore({
+				manager: getProviderSettingsManager(),
+				providerId: "cline",
+				apiBaseUrl: ClineEnv.config().apiBaseUrl,
+			})
+			if (outcome.status !== "ok") {
 				this._authenticated = false
 				this._clineAuthInfo = null
-				clearClineCredentials()
+				if (outcome.status === "reauth_required") {
+					// The stored refresh token was rejected — a genuine logout.
+					// (Transient failures throw and are handled by the outer catch,
+					// which keeps the stored credentials for the next attempt.)
+					clearClineCredentials()
+				}
 				await this.sendAuthStatusUpdate()
 				return
 			}
-
-			writeClineCredentials({
-				accessToken: validCredentials.access,
-				refreshToken: validCredentials.refresh,
-				expiresAt: validCredentials.expires,
-				accountId: validCredentials.accountId ?? restoredAuthInfo.userInfo.id,
-				metadata: validCredentials.metadata,
-				sessionStartedAtMs: readSessionStartedAtMs(validCredentials.metadata),
-			})
+			const validCredentials = outcome.credentials
+			// Helper already persisted any rotation to providers.json.
 
 			this._clineAuthInfo = {
 				idToken: validCredentials.access,

--- a/apps/vscode/src/sdk/auth-service.ts
+++ b/apps/vscode/src/sdk/auth-service.ts
@@ -391,6 +391,7 @@ export class AuthService {
 					providerId: "cline",
 					forceRefresh: true,
 					apiBaseUrl: ClineEnv.config().apiBaseUrl,
+					telemetry: this._telemetry,
 				})
 				if (outcome.status !== "ok") {
 					sdkDebug(`[SdkAuthService] refreshAccessToken: ${outcome.status} — clearing credentials`)
@@ -966,6 +967,7 @@ export class AuthService {
 				manager: getProviderSettingsManager(),
 				providerId: "cline",
 				apiBaseUrl: ClineEnv.config().apiBaseUrl,
+				telemetry: this._telemetry,
 			})
 			if (outcome.status !== "ok") {
 				this._authenticated = false

--- a/apps/vscode/src/test/cline-core-vitest-stub.ts
+++ b/apps/vscode/src/test/cline-core-vitest-stub.ts
@@ -481,6 +481,10 @@ export async function getValidClineCredentials(): Promise<OAuthCredentials | und
 	return undefined
 }
 
+export async function refreshProviderOAuthCredentialsFromStore(): Promise<{ status: string }> {
+	return { status: "no_credentials" }
+}
+
 export async function loginClineOAuth(): Promise<OAuthCredentials> {
 	return {}
 }

--- a/sdk/packages/core/src/auth/cline.ts
+++ b/sdk/packages/core/src/auth/cline.ts
@@ -50,6 +50,13 @@ export type ClineTokenResolution = {
 	forceRefresh?: boolean;
 	refreshBufferMs?: number;
 	retryableTokenGraceMs?: number;
+	/**
+	 * When false, suppresses the AUTH_LOGGED_OUT telemetry event on an
+	 * invalid-grant refresh failure. Callers that recover from invalid_grant
+	 * (e.g. by adopting credentials another process rotated on disk) own the
+	 * logged-out decision and emit the event themselves.
+	 */
+	emitLoggedOutTelemetry?: boolean;
 };
 
 interface ClineAuthApiUser {
@@ -822,17 +829,19 @@ export async function getValidClineCredentials(
 			sdkDebug(
 				`cline.getCredentials outcome=invalid_grant status=${error.status} errorCode=${error.errorCode ?? "none"}`,
 			);
-			captureAuthLoggedOut(
-				providerOptions.telemetry,
-				providerOptions.provider ?? "cline",
-				"invalid_grant",
-				{
-					status: error.status,
-					errorCode: error.errorCode,
-					...requestIdDetails,
-					...authTelemetryDetails,
-				},
-			);
+			if (options?.emitLoggedOutTelemetry !== false) {
+				captureAuthLoggedOut(
+					providerOptions.telemetry,
+					providerOptions.provider ?? "cline",
+					"invalid_grant",
+					{
+						status: error.status,
+						errorCode: error.errorCode,
+						...requestIdDetails,
+						...authTelemetryDetails,
+					},
+				);
+			}
 			return null;
 		}
 		if (currentCredentials.expires - Date.now() > retryableTokenGraceMs) {

--- a/sdk/packages/core/src/auth/provider-auth-registry.store-refresh.test.ts
+++ b/sdk/packages/core/src/auth/provider-auth-registry.store-refresh.test.ts
@@ -1,0 +1,252 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ProviderSettingsManager } from "../services/storage/provider-settings-manager";
+import { withSettingsRefreshLock } from "../services/storage/settings-file-lock";
+import { refreshProviderOAuthCredentialsFromStore } from "./provider-auth-registry";
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const API_BASE = "https://auth.example.com";
+
+function tokenResponse(generation: number): Response {
+	return new Response(
+		JSON.stringify({
+			success: true,
+			data: {
+				accessToken: `access-${generation}`,
+				refreshToken: `refresh-${generation}`,
+				tokenType: "Bearer",
+				expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+				userInfo: {
+					subject: "sub-1",
+					email: "user@example.com",
+					name: "User",
+					clineUserId: "acct-1",
+					accounts: [],
+				},
+			},
+		}),
+		{ status: 200, headers: { "Content-Type": "application/json" } },
+	);
+}
+
+function invalidGrantResponse(): Response {
+	return new Response(
+		JSON.stringify({
+			error: "invalid_grant",
+			error_description: "refresh token already used",
+		}),
+		{ status: 400, headers: { "Content-Type": "application/json" } },
+	);
+}
+
+describe("refreshProviderOAuthCredentialsFromStore", () => {
+	let dir: string;
+	let manager: ProviderSettingsManager;
+	let capture: ReturnType<typeof vi.fn>;
+	let telemetry: never;
+
+	const seed = (refreshToken: string, options?: { expiresAt?: number }) => {
+		manager.saveProviderSettings(
+			{
+				provider: "cline",
+				baseUrl: API_BASE,
+				auth: {
+					accessToken: "workos:access-old",
+					refreshToken,
+					accountId: "acct-1",
+					expiresAt: options?.expiresAt ?? Date.now() - 1_000,
+				},
+			},
+			{ tokenSource: "oauth", setLastUsed: false },
+		);
+	};
+
+	const capturedEvents = () =>
+		capture.mock.calls.map((c) => (c[0] as { event: string }).event);
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "store-refresh-test-"));
+		manager = new ProviderSettingsManager({
+			filePath: join(dir, "providers.json"),
+		});
+		// lastUsedProvider baseline that refreshes must not disturb
+		manager.saveProviderSettings(
+			{ provider: "openrouter", apiKey: "or-key" },
+			{ setLastUsed: true },
+		);
+		capture = vi.fn();
+		telemetry = { capture } as never;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = ORIGINAL_FETCH;
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("refreshes, persists, and leaves lastUsedProvider untouched", async () => {
+		seed("refresh-old");
+		globalThis.fetch = vi.fn(async () =>
+			tokenResponse(1),
+		) as unknown as typeof fetch;
+
+		const outcome = await refreshProviderOAuthCredentialsFromStore({
+			manager,
+			providerId: "cline",
+			telemetry,
+		});
+
+		expect(outcome.status).toBe("ok");
+		if (outcome.status !== "ok") return;
+		expect(outcome.refreshed).toBe(true);
+		expect(outcome.credentials.refresh).toBe("refresh-1");
+
+		const onDisk = JSON.parse(readFileSync(manager.getFilePath(), "utf8"));
+		expect(onDisk.providers.cline.settings.auth.refreshToken).toBe("refresh-1");
+		expect(onDisk.providers.cline.settings.auth.accessToken).toBe(
+			"workos:access-1",
+		);
+		expect(onDisk.lastUsedProvider).toBe("openrouter");
+		expect(capturedEvents()).not.toContain("user.auth_logged_out");
+	});
+
+	it("adopts credentials rotated on disk when the refresh comes back invalid_grant", async () => {
+		seed("refresh-old");
+		const fetchMock = vi.fn(
+			async (_url: unknown, init?: { body?: unknown }) => {
+				const body = JSON.parse(String(init?.body ?? "{}")) as {
+					refreshToken?: string;
+				};
+				if (body.refreshToken === "refresh-old") {
+					// Simulate a non-cooperating process (legacy extension) that already
+					// rotated: our token is consumed, but the fresh one is on disk.
+					seed("refresh-rotated");
+					return invalidGrantResponse();
+				}
+				expect(body.refreshToken).toBe("refresh-rotated");
+				return tokenResponse(2);
+			},
+		);
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const outcome = await refreshProviderOAuthCredentialsFromStore({
+			manager,
+			providerId: "cline",
+			forceRefresh: true,
+			telemetry,
+		});
+
+		expect(outcome.status).toBe("ok");
+		if (outcome.status !== "ok") return;
+		expect(outcome.credentials.refresh).toBe("refresh-2");
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(capturedEvents()).toContain("user.auth_refresh_recovered");
+		expect(capturedEvents()).not.toContain("user.auth_logged_out");
+	});
+
+	it("skips its own rotation when another process rotated while it waited for the lock", async () => {
+		seed("refresh-old");
+		const fetchMock = vi.fn();
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		// Queue ahead of the helper on the same lock: by the time the helper's
+		// body runs, disk holds freshly-rotated, unexpired credentials.
+		const winner = withSettingsRefreshLock(manager.getFilePath(), async () => {
+			seed("refresh-rotated", { expiresAt: Date.now() + 3_600_000 });
+		});
+		const outcomePromise = refreshProviderOAuthCredentialsFromStore({
+			manager,
+			providerId: "cline",
+			forceRefresh: true,
+			telemetry,
+		});
+		await winner;
+		const outcome = await outcomePromise;
+
+		expect(outcome.status).toBe("ok");
+		if (outcome.status !== "ok") return;
+		expect(outcome.credentials.refresh).toBe("refresh-rotated");
+		expect(outcome.refreshed).toBe(false);
+		// The winner's tokens were still valid — no network call at all.
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(capturedEvents()).toContain("user.auth_refresh_recovered");
+		expect(capturedEvents()).not.toContain("user.auth_logged_out");
+	});
+
+	it("returns reauth_required with one logged-out event when the on-disk token is truly rejected", async () => {
+		seed("refresh-old");
+		globalThis.fetch = vi.fn(async () =>
+			invalidGrantResponse(),
+		) as unknown as typeof fetch;
+
+		const outcome = await refreshProviderOAuthCredentialsFromStore({
+			manager,
+			providerId: "cline",
+			forceRefresh: true,
+			telemetry,
+		});
+
+		expect(outcome.status).toBe("reauth_required");
+		expect(
+			capturedEvents().filter((e) => e === "user.auth_logged_out"),
+		).toHaveLength(1);
+		// Credentials stay on disk — clients decide what to do with reauth_required.
+		const onDisk = JSON.parse(readFileSync(manager.getFilePath(), "utf8"));
+		expect(onDisk.providers.cline.settings.auth.refreshToken).toBe(
+			"refresh-old",
+		);
+	});
+
+	it("throws on transient failure and leaves the store byte-identical", async () => {
+		seed("refresh-old");
+		const before = readFileSync(manager.getFilePath(), "utf8");
+		globalThis.fetch = vi.fn(
+			async () =>
+				new Response(
+					JSON.stringify({ error: "server_error", message: "boom" }),
+					{
+						status: 500,
+						headers: { "Content-Type": "application/json" },
+					},
+				),
+		) as unknown as typeof fetch;
+
+		await expect(
+			refreshProviderOAuthCredentialsFromStore({
+				manager,
+				providerId: "cline",
+				forceRefresh: true,
+				telemetry,
+			}),
+		).rejects.toThrow("Token refresh failed: 500");
+
+		expect(readFileSync(manager.getFilePath(), "utf8")).toBe(before);
+		expect(capturedEvents()).not.toContain("user.auth_logged_out");
+	});
+
+	it("returns no_credentials when another process logged out while it waited", async () => {
+		seed("refresh-old");
+		const fetchMock = vi.fn();
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const winner = withSettingsRefreshLock(manager.getFilePath(), async () => {
+			const existing = manager.getProviderSettings("cline");
+			manager.saveProviderSettings(
+				{ ...existing, provider: "cline", auth: undefined },
+				{ tokenSource: "manual" },
+			);
+		});
+		const outcomePromise = refreshProviderOAuthCredentialsFromStore({
+			manager,
+			providerId: "cline",
+			forceRefresh: true,
+			telemetry,
+		});
+		await winner;
+		const outcome = await outcomePromise;
+
+		expect(outcome.status).toBe("no_credentials");
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+});

--- a/sdk/packages/core/src/auth/provider-auth-registry.ts
+++ b/sdk/packages/core/src/auth/provider-auth-registry.ts
@@ -3,7 +3,13 @@ import {
 	getClineEnvironmentConfig,
 	type ITelemetryService,
 } from "@cline/shared";
+import { hashSecret, sdkDebug } from "../logging/early-logger";
 import type { ProviderSettingsManager } from "../services/storage/provider-settings-manager";
+import { withSettingsRefreshLock } from "../services/storage/settings-file-lock";
+import {
+	captureAuthLoggedOut,
+	captureAuthRefreshRecovered,
+} from "../services/telemetry/core-events";
 import type { ProviderSettings } from "../types/provider-settings";
 import {
 	type ClineOAuthCredentials,
@@ -29,6 +35,13 @@ export interface ProviderAuthRefreshInput {
 	credentials: ProviderOAuthCredentials;
 	forceRefresh?: boolean;
 	telemetry?: ITelemetryService;
+	/**
+	 * Set by refreshProviderOAuthCredentialsFromStore, which owns the
+	 * logged-out decision (it can recover from invalid_grant by adopting
+	 * credentials rotated by another process). Handlers that emit logged-out
+	 * telemetry should skip it when this is true.
+	 */
+	suppressLoggedOutTelemetry?: boolean;
 }
 
 export interface ProviderAuthSaveCredentialsInput {
@@ -227,7 +240,13 @@ function createClineAuthHandler(input: {
 				callbacks,
 				telemetry,
 			}),
-		refresh: ({ settings, credentials, forceRefresh, telemetry }) =>
+		refresh: ({
+			settings,
+			credentials,
+			forceRefresh,
+			telemetry,
+			suppressLoggedOutTelemetry,
+		}) =>
 			getValidClineCredentials(
 				credentials as ClineOAuthCredentials,
 				{
@@ -235,7 +254,10 @@ function createClineAuthHandler(input: {
 						settings.baseUrl?.trim() || getClineEnvironmentConfig().apiBaseUrl,
 					telemetry,
 				},
-				{ forceRefresh },
+				{
+					forceRefresh,
+					emitLoggedOutTelemetry: suppressLoggedOutTelemetry !== true,
+				},
 			),
 	});
 }
@@ -390,4 +412,179 @@ export function formatProviderOAuthApiKey(
 			auth: { accessToken: credentials.access },
 		}) ?? credentials.access
 	);
+}
+
+export type ProviderOAuthRefreshOutcome =
+	| {
+			status: "ok";
+			settings: ProviderSettings;
+			credentials: ProviderOAuthCredentials;
+			refreshed: boolean;
+	  }
+	| { status: "no_credentials" }
+	| { status: "reauth_required" };
+
+function credentialsEqual(
+	a: ProviderOAuthCredentials,
+	b: ProviderOAuthCredentials,
+): boolean {
+	return (
+		a.access === b.access &&
+		a.refresh === b.refresh &&
+		a.expires === b.expires &&
+		a.accountId === b.accountId
+	);
+}
+
+/**
+ * Refresh a provider's OAuth credentials against the shared settings store
+ * (providers.json). This is the ONLY correct way to rotate tokens: refresh
+ * tokens are single-use upstream and the store is shared by every Cline
+ * process on the machine (CLI, extension, hub), so rotation must be
+ * serialized and recoverable.
+ *
+ * Inside a cross-process lock this: re-reads the store (adopting a rotation
+ * that finished while we waited), refreshes, and — if the refresh comes back
+ * invalid_grant — re-checks the store once more before concluding the session
+ * is dead, in case a non-cooperating process (e.g. the legacy extension)
+ * rotated the token mid-flight. `reauth_required` is returned only when the
+ * on-disk refresh token itself was rejected; that is the single place the
+ * logged-out decision is made.
+ *
+ * Returns `no_credentials` when the store has no usable credentials, and
+ * THROWS on transient refresh failures (network/5xx) — the store is left
+ * untouched in that case.
+ */
+export async function refreshProviderOAuthCredentialsFromStore(input: {
+	manager: ProviderSettingsManager;
+	providerId: string;
+	forceRefresh?: boolean;
+	telemetry?: ITelemetryService;
+	/** Fallback API base URL when the stored settings carry no baseUrl. */
+	apiBaseUrl?: string;
+}): Promise<ProviderOAuthRefreshOutcome> {
+	const handler = getProviderAuthHandler(input.providerId);
+	if (!handler) {
+		return { status: "no_credentials" };
+	}
+	const storageProviderId = handler.storageProviderId;
+
+	const readStore = (): {
+		settings?: ProviderSettings;
+		credentials: ProviderOAuthCredentials | null;
+	} => {
+		let settings = input.manager.getProviderSettings(storageProviderId);
+		if (settings && input.apiBaseUrl && !settings.baseUrl?.trim()) {
+			settings = { ...settings, baseUrl: input.apiBaseUrl };
+		}
+		const credentials = settings
+			? createCredentialsFromSettings(settings, {
+					normalizeAccessToken: handler.normalizeStoredAccessToken,
+				})
+			: null;
+		return { settings, credentials };
+	};
+
+	const preLock = readStore();
+	if (!preLock.settings || !preLock.credentials) {
+		return { status: "no_credentials" };
+	}
+
+	return withSettingsRefreshLock(input.manager.getFilePath(), async () => {
+		let { settings, credentials } = readStore();
+		if (!settings || !credentials) {
+			// Another process logged out while we waited — do not resurrect.
+			return { status: "no_credentials" };
+		}
+
+		let forceRefresh = input.forceRefresh;
+		if (credentials.refresh !== preLock.credentials?.refresh) {
+			// Another process rotated while we waited for the lock. Its tokens
+			// are newer than the ones our caller wanted to force-rotate;
+			// validate them instead of burning a rotation.
+			sdkDebug(
+				`oauth.refreshFromStore providerId=${input.providerId} adopted_rotation_while_waiting refreshTokenHash=${hashSecret(credentials.refresh)}`,
+			);
+			captureAuthRefreshRecovered(
+				input.telemetry,
+				input.providerId,
+				"rotated_while_waiting_for_lock",
+			);
+			forceRefresh = false;
+		}
+
+		let next = await handler.refresh({
+			settings,
+			credentials,
+			forceRefresh,
+			telemetry: input.telemetry,
+			suppressLoggedOutTelemetry: true,
+		});
+
+		if (!next) {
+			// Invalid grant. Before concluding the session is dead, check
+			// whether a non-cooperating rotator beat us mid-flight: if the
+			// on-disk refresh token differs from the one that just failed,
+			// adopt it and retry once.
+			const retry = readStore();
+			if (
+				retry.settings &&
+				retry.credentials &&
+				retry.credentials.refresh !== credentials.refresh
+			) {
+				sdkDebug(
+					`oauth.refreshFromStore providerId=${input.providerId} adopt_disk_after_invalid_grant refreshTokenHash=${hashSecret(retry.credentials.refresh)}`,
+				);
+				captureAuthRefreshRecovered(
+					input.telemetry,
+					input.providerId,
+					"adopted_disk_after_invalid_grant",
+				);
+				settings = retry.settings;
+				credentials = retry.credentials;
+				next = await handler.refresh({
+					settings,
+					credentials,
+					forceRefresh: false,
+					telemetry: input.telemetry,
+					suppressLoggedOutTelemetry: true,
+				});
+			}
+			if (!next) {
+				sdkDebug(
+					`oauth.refreshFromStore providerId=${input.providerId} outcome=reauth_required refreshTokenHash=${hashSecret(credentials.refresh)}`,
+				);
+				captureAuthLoggedOut(
+					input.telemetry,
+					input.providerId,
+					"invalid_grant",
+				);
+				return { status: "reauth_required" };
+			}
+		}
+
+		const refreshed = !credentialsEqual(next, credentials);
+		const nextSettings = handler.saveCredentials({
+			manager: input.manager,
+			settings,
+			credentials: next,
+			setLastUsed: false,
+			save: false,
+		});
+		if (refreshed) {
+			sdkDebug(
+				`oauth.refreshFromStore providerId=${input.providerId} outcome=refreshed newRefreshTokenHash=${hashSecret(next.refresh)}`,
+			);
+			input.manager.saveProviderSettings(nextSettings, {
+				setLastUsed: false,
+				tokenSource: "oauth",
+			});
+		}
+		return {
+			status: "ok",
+			settings: nextSettings,
+			credentials: next,
+			refreshed,
+		};
+	});
 }

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -176,6 +176,8 @@ export {
 	type ProviderAuthRefreshInput,
 	type ProviderAuthSaveCredentialsInput,
 	type ProviderOAuthCredentials,
+	type ProviderOAuthRefreshOutcome,
+	refreshProviderOAuthCredentialsFromStore,
 	resolveProviderApiKeyFromSettings,
 	saveProviderOAuthCredentials,
 } from "./auth/provider-auth-registry";

--- a/sdk/packages/core/src/runtime/orchestration/runtime-oauth-token-manager.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-oauth-token-manager.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	OAuthReauthRequiredError,
@@ -54,6 +57,8 @@ describe("RuntimeOAuthTokenManager", () => {
 			providerSettingsManager: {
 				getProviderSettings,
 				saveProviderSettings,
+				getFilePath: () =>
+					join(mkdtempSync(join(tmpdir(), "oauth-test-")), "providers.json"),
 			} as never,
 		});
 
@@ -103,6 +108,8 @@ describe("RuntimeOAuthTokenManager", () => {
 			providerSettingsManager: {
 				getProviderSettings,
 				saveProviderSettings,
+				getFilePath: () =>
+					join(mkdtempSync(join(tmpdir(), "oauth-test-")), "providers.json"),
 			} as never,
 		});
 
@@ -117,7 +124,7 @@ describe("RuntimeOAuthTokenManager", () => {
 				refresh: "refresh-old",
 			}),
 			expect.objectContaining({ apiBaseUrl: "https://api.cline.test" }),
-			{ forceRefresh: false },
+			{ forceRefresh: false, emitLoggedOutTelemetry: false },
 		);
 		expect(result).toMatchObject({
 			apiKey: "workos:access-new",
@@ -151,6 +158,8 @@ describe("RuntimeOAuthTokenManager", () => {
 					},
 				}),
 				saveProviderSettings: vi.fn(),
+				getFilePath: () =>
+					join(mkdtempSync(join(tmpdir(), "oauth-test-")), "providers.json"),
 			} as never,
 		});
 
@@ -180,6 +189,8 @@ describe("RuntimeOAuthTokenManager", () => {
 					},
 				}),
 				saveProviderSettings: vi.fn(),
+				getFilePath: () =>
+					join(mkdtempSync(join(tmpdir(), "oauth-test-")), "providers.json"),
 			} as never,
 		});
 

--- a/sdk/packages/core/src/runtime/orchestration/runtime-oauth-token-manager.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-oauth-token-manager.ts
@@ -1,32 +1,12 @@
 import type { ITelemetryService } from "@cline/shared";
-import { hashSecret, sdkDebug } from "../../logging/early-logger";
 import {
 	getProviderAuthHandler,
-	getProviderOAuthCredentialsFromSettings,
-	saveProviderOAuthCredentials,
+	refreshProviderOAuthCredentialsFromStore,
 } from "../../auth/provider-auth-registry";
+import { sdkDebug } from "../../logging/early-logger";
 import { ProviderSettingsManager } from "../../services/storage/provider-settings-manager";
-import type { ProviderSettings } from "../../types/provider-settings";
 
 type ManagedOAuthProviderId = string;
-
-function authSettingsEqual(
-	a: ProviderSettings["auth"] | undefined,
-	b: ProviderSettings["auth"] | undefined,
-): boolean {
-	const aExpiry = (
-		a as (ProviderSettings["auth"] & { expiresAt?: number }) | undefined
-	)?.expiresAt;
-	const bExpiry = (
-		b as (ProviderSettings["auth"] & { expiresAt?: number }) | undefined
-	)?.expiresAt;
-	return (
-		a?.accessToken === b?.accessToken &&
-		a?.refreshToken === b?.refreshToken &&
-		a?.accountId === b?.accountId &&
-		aExpiry === bExpiry
-	);
-}
 
 export class OAuthReauthRequiredError extends Error {
 	public readonly providerId: ManagedOAuthProviderId;
@@ -87,11 +67,7 @@ export class RuntimeOAuthTokenManager {
 		if (currentInFlight) {
 			return currentInFlight;
 		}
-		const pending = this.resolveProviderApiKeyInternal(
-			providerId,
-			storageProviderId,
-			forceRefresh,
-		)
+		const pending = this.resolveProviderApiKeyInternal(providerId, forceRefresh)
 			.catch((error) => {
 				throw error;
 			})
@@ -104,75 +80,41 @@ export class RuntimeOAuthTokenManager {
 
 	private async resolveProviderApiKeyInternal(
 		providerId: ManagedOAuthProviderId,
-		storageProviderId: ManagedOAuthProviderId,
 		forceRefresh: boolean,
 	): Promise<RuntimeOAuthResolution | null> {
 		const handler = getProviderAuthHandler(providerId);
 		if (!handler) {
 			return null;
 		}
-		const settings =
-			this.providerSettingsManager.getProviderSettings(storageProviderId);
-		if (!settings) {
-			sdkDebug(
-				`oauth.resolve providerId=${providerId} storageProviderId=${storageProviderId} outcome=no_settings`,
-			);
-			return null;
-		}
-
-		const currentCredentials = getProviderOAuthCredentialsFromSettings(
-			providerId,
-			settings,
-		);
-		if (!currentCredentials) {
-			sdkDebug(
-				`oauth.resolve providerId=${providerId} storageProviderId=${storageProviderId} outcome=no_credentials`,
-			);
-			return null;
-		}
-
 		sdkDebug(
-			`oauth.resolve.start providerId=${providerId} storageProviderId=${storageProviderId} forceRefresh=${forceRefresh} accessTokenHash=${hashSecret(currentCredentials.access)} refreshTokenHash=${hashSecret(currentCredentials.refresh)}`,
+			`oauth.resolve.start providerId=${providerId} storageProviderId=${handler.storageProviderId} forceRefresh=${forceRefresh}`,
 		);
 
-		const nextCredentials = await handler.refresh({
-			settings,
-			credentials: currentCredentials,
+		const outcome = await refreshProviderOAuthCredentialsFromStore({
+			manager: this.providerSettingsManager,
+			providerId,
 			forceRefresh,
 			telemetry: this.telemetry,
 		});
-		if (!nextCredentials) {
+
+		if (outcome.status === "no_credentials") {
+			sdkDebug(`oauth.resolve providerId=${providerId} outcome=no_credentials`);
+			return null;
+		}
+		if (outcome.status === "reauth_required") {
 			sdkDebug(
-				`oauth.resolve providerId=${providerId} outcome=refresh_returned_null`,
+				`oauth.resolve providerId=${providerId} outcome=reauth_required`,
 			);
 			throw new OAuthReauthRequiredError(providerId);
 		}
 
-		const nextSettings: ProviderSettings = saveProviderOAuthCredentials({
-			manager: this.providerSettingsManager,
-			providerId,
-			settings,
-			credentials: nextCredentials,
-			setLastUsed: false,
-			save: false,
-		});
-		const wasRefreshed = !authSettingsEqual(settings.auth, nextSettings.auth);
-		if (wasRefreshed) {
-			sdkDebug(
-				`oauth.resolve.refreshed providerId=${providerId} newAccessTokenHash=${hashSecret(nextCredentials.access)} newRefreshTokenHash=${hashSecret(nextCredentials.refresh)} savingToDisk=true`,
-			);
-			this.providerSettingsManager.saveProviderSettings(nextSettings, {
-				setLastUsed: false,
-				tokenSource: "oauth",
-			});
-		} else {
-			sdkDebug(`oauth.resolve providerId=${providerId} outcome=not_refreshed`);
-		}
-
+		sdkDebug(
+			`oauth.resolve providerId=${providerId} outcome=ok refreshed=${outcome.refreshed}`,
+		);
 		return {
-			apiKey: handler.getApiKey(nextSettings) ?? nextCredentials.access,
-			accountId: nextCredentials.accountId,
-			refreshed: wasRefreshed,
+			apiKey: handler.getApiKey(outcome.settings) ?? outcome.credentials.access,
+			accountId: outcome.credentials.accountId,
+			refreshed: outcome.refreshed,
 		};
 	}
 }

--- a/sdk/packages/core/src/services/storage/provider-settings-manager.ts
+++ b/sdk/packages/core/src/services/storage/provider-settings-manager.ts
@@ -28,6 +28,7 @@ import {
 	registerConfiguredProvidersFromSettings,
 } from "../providers/local-provider-registry";
 import { migrateLegacyProviderSettings } from "./provider-settings-legacy-migration";
+import { withSettingsMutationLockSync } from "./settings-file-lock";
 
 function nowIso(): string {
 	return new Date().toISOString();
@@ -150,6 +151,19 @@ export class ProviderSettingsManager {
 		options: SaveProviderSettingsOptions = {},
 	): StoredProviderSettings {
 		const validatedSettings = ProviderSettingsSchema.parse(settings);
+		// The read→merge→write below must not interleave with another process's
+		// save: a merge built from a stale read writes the OLD cline auth entry
+		// back over a freshly rotated (single-use) refresh token, killing the
+		// session for every process sharing this file.
+		return withSettingsMutationLockSync(this.filePath, () =>
+			this.saveProviderSettingsLocked(validatedSettings, options),
+		);
+	}
+
+	private saveProviderSettingsLocked(
+		validatedSettings: ProviderSettings,
+		options: SaveProviderSettingsOptions,
+	): StoredProviderSettings {
 		const previous = this.read();
 		const providerId = validatedSettings.provider;
 		const shouldSetLastUsed = options.setLastUsed !== false;

--- a/sdk/packages/core/src/services/storage/settings-file-lock.test.ts
+++ b/sdk/packages/core/src/services/storage/settings-file-lock.test.ts
@@ -1,0 +1,116 @@
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	rmSync,
+	utimesSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { withSettingsRefreshLock } from "./settings-file-lock";
+
+describe("withSettingsRefreshLock", () => {
+	let dir: string;
+	let settingsPath: string;
+	let lockDir: string;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "settings-lock-test-"));
+		settingsPath = join(dir, "providers.json");
+		lockDir = `${settingsPath}.oauth.lock`;
+	});
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("runs the body and cleans up the lock directory", async () => {
+		let sawLock = false;
+		const result = await withSettingsRefreshLock(settingsPath, async () => {
+			sawLock = existsSync(lockDir);
+			return 42;
+		});
+		expect(result).toBe(42);
+		expect(sawLock).toBe(true);
+		expect(existsSync(lockDir)).toBe(false);
+	});
+
+	it("releases the lock when the body throws", async () => {
+		await expect(
+			withSettingsRefreshLock(settingsPath, async () => {
+				throw new Error("boom");
+			}),
+		).rejects.toThrow("boom");
+		expect(existsSync(lockDir)).toBe(false);
+	});
+
+	it("never overlaps two concurrent bodies", async () => {
+		const order: string[] = [];
+		const body = (name: string) => async () => {
+			order.push(`${name}:enter`);
+			await new Promise((r) => setTimeout(r, 30));
+			order.push(`${name}:exit`);
+			return name;
+		};
+		const [a, b] = await Promise.all([
+			withSettingsRefreshLock(settingsPath, body("a")),
+			withSettingsRefreshLock(settingsPath, body("b")),
+		]);
+		expect([a, b].sort()).toEqual(["a", "b"]);
+		// enter/exit pairs must not interleave
+		expect(order).toEqual(["a:enter", "a:exit", "b:enter", "b:exit"]);
+	});
+
+	it("queues same-process callers even when one rejects", async () => {
+		const order: string[] = [];
+		const results = await Promise.allSettled([
+			withSettingsRefreshLock(settingsPath, async () => {
+				order.push("first");
+				throw new Error("first failed");
+			}),
+			withSettingsRefreshLock(settingsPath, async () => {
+				order.push("second");
+				return "ok";
+			}),
+		]);
+		expect(order).toEqual(["first", "second"]);
+		expect(results[0].status).toBe("rejected");
+		expect(results[1]).toEqual({ status: "fulfilled", value: "ok" });
+		expect(existsSync(lockDir)).toBe(false);
+	});
+
+	it("reclaims a stale lock left by a crashed holder", async () => {
+		// Simulate a crashed holder: a populated lock dir with an old mtime.
+		mkdirSync(lockDir, { recursive: true });
+		writeFileSync(join(lockDir, "owner.stale"), "stale");
+		const old = new Date(Date.now() - 120_000);
+		utimesSync(lockDir, old, old);
+
+		const result = await withSettingsRefreshLock(
+			settingsPath,
+			async () => "reclaimed",
+			{ staleMs: 1_000, pollMs: 5, timeoutMs: 2_000 },
+		);
+		expect(result).toBe("reclaimed");
+		expect(existsSync(lockDir)).toBe(false);
+	});
+
+	it("does not remove a fresh lock held by another owner, and falls through on timeout", async () => {
+		mkdirSync(lockDir, { recursive: true });
+		writeFileSync(join(lockDir, "owner.other"), "other");
+
+		// Fresh foreign lock + tiny timeout → body still runs (degrade, don't fail).
+		const result = await withSettingsRefreshLock(
+			settingsPath,
+			async () => "ran-unlocked",
+			{ staleMs: 60_000, pollMs: 5, timeoutMs: 50 },
+		);
+		expect(result).toBe("ran-unlocked");
+		// The foreign owner's lock must be untouched.
+		expect(existsSync(lockDir)).toBe(true);
+		expect(readdirSync(lockDir)).toEqual(["owner.other"]);
+	});
+});

--- a/sdk/packages/core/src/services/storage/settings-file-lock.ts
+++ b/sdk/packages/core/src/services/storage/settings-file-lock.ts
@@ -1,0 +1,238 @@
+import { randomUUID } from "node:crypto";
+import {
+	existsSync,
+	mkdirSync,
+	renameSync,
+	rmdirSync,
+	rmSync,
+	statSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { sdkDebug } from "../../logging/early-logger";
+
+/**
+ * Cross-process lock serializing OAuth token rotation against a settings file
+ * (providers.json). Same populated-directory algorithm as the MCP settings
+ * lock (extensions/mcp/config-loader.ts): acquisition stages a directory with
+ * a unique owner marker and renames it into place, release removes only our
+ * marker, stale takeover renames the directory aside. Portable mkdir/rename/
+ * rmdir only — works on Windows and POSIX.
+ *
+ * Differences from the MCP lock, both deliberate:
+ * - The lock is held ACROSS the refresh network call. Refresh tokens are
+ *   single-use upstream, so two processes must never rotate concurrently;
+ *   serializing only the file write would not prevent that. staleMs must
+ *   therefore stay greater than the refresh HTTP timeout (30s) so a healthy
+ *   in-flight holder is never reclaimed.
+ * - Contention degrades instead of throwing: same-process callers queue on a
+ *   promise chain, cross-process waiters poll, and an acquisition timeout
+ *   falls through to running the body WITHOUT the lock. Failing the user's
+ *   request over lock trouble would be worse than an unserialized refresh —
+ *   the adopt-disk recovery in the refresh helper is the safety net for that
+ *   path.
+ */
+
+const OAUTH_LOCK_STALE_MS = 60_000;
+const OAUTH_LOCK_POLL_MS = 25;
+const OAUTH_LOCK_TIMEOUT_MS = 45_000;
+
+// The mutation lock guards only an in-memory read-modify-write plus one file
+// write (milliseconds), so its thresholds are far tighter than the refresh
+// lock's.
+const MUTATION_LOCK_STALE_MS = 2_000;
+const MUTATION_LOCK_POLL_MS = 5;
+const MUTATION_LOCK_TIMEOUT_MS = 3_000;
+
+type LockOptions = {
+	staleMs?: number;
+	pollMs?: number;
+	timeoutMs?: number;
+};
+
+interface AcquiredLock {
+	lockDir: string;
+	ownerFile: string;
+}
+
+const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+const syncSleepBuffer = new Int32Array(new SharedArrayBuffer(4));
+function sleepSync(ms: number): void {
+	Atomics.wait(syncSleepBuffer, 0, 0, ms);
+}
+
+function makeLockToken(): string {
+	return `${process.pid}.${Date.now()}.${randomUUID()}`;
+}
+
+function tryAcquireLock(
+	lockDir: string,
+	token: string,
+): AcquiredLock | undefined {
+	mkdirSync(dirname(lockDir), { recursive: true });
+	const stagingDir = `${lockDir}.tmp.${token}`;
+	rmSync(stagingDir, { recursive: true, force: true });
+	mkdirSync(stagingDir, { recursive: true });
+	writeFileSync(join(stagingDir, `owner.${token}`), token, {
+		encoding: "utf8",
+		flag: "wx",
+	});
+	try {
+		renameSync(stagingDir, lockDir);
+		return { lockDir, ownerFile: join(lockDir, `owner.${token}`) };
+	} catch (error) {
+		rmSync(stagingDir, { recursive: true, force: true });
+		if (existsSync(lockDir)) {
+			return undefined;
+		}
+		throw error;
+	}
+}
+
+function reclaimStaleLock(lockDir: string, staleMs: number): void {
+	let ageMs: number;
+	try {
+		ageMs = Date.now() - statSync(lockDir).mtimeMs;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+			return;
+		}
+		throw error;
+	}
+	if (ageMs < staleMs) {
+		return;
+	}
+	sdkDebug(`oauth.lock stale lock at ${lockDir} (age ${ageMs}ms); reclaiming`);
+	const staleDir = `${lockDir}.stale.${makeLockToken()}`;
+	try {
+		renameSync(lockDir, staleDir);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+			return;
+		}
+		throw error;
+	}
+	rmSync(staleDir, { recursive: true, force: true });
+}
+
+function releaseLock(lock: AcquiredLock): void {
+	try {
+		unlinkSync(lock.ownerFile);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+			throw error;
+		}
+	}
+	try {
+		rmdirSync(lock.lockDir);
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code !== "ENOENT" && code !== "ENOTEMPTY" && code !== "EEXIST") {
+			throw error;
+		}
+	}
+}
+
+// Same-process refresh attempts queue here instead of spinning on the
+// directory (the extension runs two independent refreshers: AuthService and
+// the embedded RuntimeOAuthTokenManager).
+const inProcessQueues = new Map<string, Promise<unknown>>();
+
+export async function withSettingsRefreshLock<T>(
+	settingsFilePath: string,
+	fn: () => Promise<T>,
+	options?: LockOptions,
+): Promise<T> {
+	const lockDir = `${settingsFilePath}.oauth.lock`;
+	const staleMs = options?.staleMs ?? OAUTH_LOCK_STALE_MS;
+	const pollMs = options?.pollMs ?? OAUTH_LOCK_POLL_MS;
+	const timeoutMs = options?.timeoutMs ?? OAUTH_LOCK_TIMEOUT_MS;
+
+	const run = async (): Promise<T> => {
+		const token = makeLockToken();
+		const startedAt = Date.now();
+		let lock: AcquiredLock | undefined;
+		while (!lock) {
+			lock = tryAcquireLock(lockDir, token);
+			if (lock) {
+				break;
+			}
+			if (Date.now() - startedAt > timeoutMs) {
+				sdkDebug(
+					`oauth.lock timed out waiting for ${lockDir} after ${timeoutMs}ms; proceeding without lock`,
+				);
+				break;
+			}
+			reclaimStaleLock(lockDir, staleMs);
+			await delay(pollMs);
+		}
+		try {
+			return await fn();
+		} finally {
+			if (lock) {
+				releaseLock(lock);
+			}
+		}
+	};
+
+	const previous = inProcessQueues.get(lockDir) ?? Promise.resolve();
+	const chained = previous.then(run, run);
+	const tracked = chained.catch(() => {});
+	inProcessQueues.set(lockDir, tracked);
+	void tracked.finally(() => {
+		if (inProcessQueues.get(lockDir) === tracked) {
+			inProcessQueues.delete(lockDir);
+		}
+	});
+	return chained;
+}
+
+/**
+ * Serialize a synchronous read-modify-write of the settings file across
+ * processes. Without this, ANY settings save racing a token rotation can
+ * write back a merge built from a stale read — reverting the freshly rotated
+ * (single-use!) refresh token on disk, which the next refresher then burns.
+ *
+ * Uses a `.write.lock` directory distinct from the refresh lock: mutators
+ * must never wait on a lock held across a 30s network call, and the refresh
+ * helper's own save takes this lock nested inside its refresh lock (different
+ * directories, ordered acquisition, no deadlock). Contention degrades to
+ * running unlocked after `timeoutMs` — same rationale as the refresh lock.
+ */
+export function withSettingsMutationLockSync<T>(
+	settingsFilePath: string,
+	fn: () => T,
+	options?: LockOptions,
+): T {
+	const lockDir = `${settingsFilePath}.write.lock`;
+	const staleMs = options?.staleMs ?? MUTATION_LOCK_STALE_MS;
+	const pollMs = options?.pollMs ?? MUTATION_LOCK_POLL_MS;
+	const timeoutMs = options?.timeoutMs ?? MUTATION_LOCK_TIMEOUT_MS;
+
+	const token = makeLockToken();
+	const startedAt = Date.now();
+	let lock: AcquiredLock | undefined;
+	while (!lock) {
+		lock = tryAcquireLock(lockDir, token);
+		if (lock) {
+			break;
+		}
+		if (Date.now() - startedAt > timeoutMs) {
+			sdkDebug(
+				`settings.write.lock timed out waiting for ${lockDir} after ${timeoutMs}ms; proceeding without lock`,
+			);
+			break;
+		}
+		reclaimStaleLock(lockDir, staleMs);
+		sleepSync(pollMs);
+	}
+	try {
+		return fn();
+	} finally {
+		if (lock) {
+			releaseLock(lock);
+		}
+	}
+}

--- a/sdk/packages/core/src/services/telemetry/core-events.ts
+++ b/sdk/packages/core/src/services/telemetry/core-events.ts
@@ -57,6 +57,7 @@ export const CORE_TELEMETRY_EVENTS = {
 		AUTH_LOGGED_OUT: "user.auth_logged_out",
 		AUTH_REFRESH_SOFT_FAILURE: "user.auth_refresh_soft_failure",
 		AUTH_RUN_RETRY: "user.auth_run_retry",
+		AUTH_REFRESH_RECOVERED: "user.auth_refresh_recovered",
 		PROVIDER_CONFIGURED: "user.provider_configured",
 		TELEMETRY_OPT_OUT: "user.opt_out",
 	},
@@ -334,6 +335,23 @@ export function captureAuthRunRetry(
 	emit(telemetry, CORE_TELEMETRY_EVENTS.USER.AUTH_RUN_RETRY, {
 		provider,
 		recovered: details?.recovered,
+	});
+}
+
+/**
+ * Fires when a refresh that failed (or would have failed) with invalid_grant
+ * was recovered by adopting credentials another process had already rotated on
+ * disk. Production evidence for the cross-process refresh-token race: every
+ * one of these events used to be a hard logout.
+ */
+export function captureAuthRefreshRecovered(
+	telemetry: ITelemetryService | undefined,
+	provider?: string,
+	recovery?: string,
+): void {
+	emit(telemetry, CORE_TELEMETRY_EVENTS.USER.AUTH_REFRESH_RECOVERED, {
+		provider,
+		recovery,
 	});
 }
 


### PR DESCRIPTION
### Related Issue

Follow-up to #12255 / #12256 — this is the remainder of the hard-logout investigation those PRs came from. Related to the recurring "Unauthorized: Please make sure you're using the latest version of Cline and re-authenticate" reports.

### Description

This lands the rest of the auth hard-logout fix. #12255 fixed the highest-frequency cause (transient refresh failures misclassified as `invalid_grant`), but two whole classes of credential loss remained, and both are storage races, not auth-protocol problems.

**The problem, empirically.** I built a harness that runs the *real* SDK refresh/settings code as separate OS processes sharing one `CLINE_DIR` (N CLI workers running `RuntimeOAuthTokenManager.resolveProviderApiKey`, one extension-style worker, one settings-churn writer, one torn-read probe) against a mock refresh endpoint with switchable semantics (no rotation / rotate-reuse-ok / rotate-single-use / revoke-on-reuse, plus 500-outage injection). Baseline on unfixed main: **4 of 5 scenarios ended hard-logged-out.** Two mechanisms survived #12255:

1. **Lost-update wipes.** `saveProviderSettings` is read→merge→write with no cross-process coordination. Any writer whose read predates another process's save silently resurrects stale state on disk. The nastiest observed interleaving: extension rotates to token gen66; **1ms later** a settings writer's unlocked read-merge-write puts gen65 back on disk; the next refresher presents the consumed gen65 → genuine `invalid_grant` → truthful-looking logout. The probe missed it because gen66 lived ~1ms on disk. (This same mechanism eats *any* provider setting — I watched it delete a freshly saved API key from `providers.json` in real time while diagnosing a broken CLI setup, which is what pushed this branch to the front of the queue.)
2. **Refresh-token races.** Multiple processes each hold in-memory copies of the same refresh token. Under rotate-single-use semantics, whoever refreshes second presents a consumed token → `invalid_grant` → wipe, even though a perfectly valid rotated credential exists on disk, written by the winner.

**The fix, in layers:**

- **`settings-file-lock.ts` (new):** minimal cross-process lock built on `mkdir` atomicity with stale-lock detection. Two flavors: a short sync mutation lock wrapped around `saveProviderSettings`' read-merge-write (kills mechanism 1), and an async refresh lock held *across the refresh network call* (60s stale threshold > 30s HTTP timeout; degrades to unlocked after a 45s acquire timeout rather than deadlocking).
- **`refreshProviderOAuthCredentialsFromStore` (new, `provider-auth-registry.ts`):** the one true rotation path. Take lock → **re-read disk** (adopt a rotation that won while we waited; skip our own refresh entirely if the winner's token is fresh) → refresh → on `invalid_grant`, re-read disk once more and retry with adopted credentials → only then report `reauth_required` and emit a single `AUTH_LOGGED_OUT`. Emits `AUTH_REFRESH_RECOVERED` when adoption saves the day — a production counter where each event was previously a hard logout, so we get real-world evidence for free.
- **Callers unified on it:** `RuntimeOAuthTokenManager` (CLI runtime), vscode `auth-service.ts` (which now wipes credentials only on genuine `reauth_required` — transient failures keep stored credentials for the next attempt), CLI `cline-account.ts`, and cline-hub `desktop-commands.ts` all delete their hand-rolled rotators. Before this, we had four independent implementations of "refresh the cline token", each with its own subtle wipe conditions.

With the full stack in place the harness goes **5/5 green** (`hardLogout=false, tornReads=0, reuseSeenByServer=0` across three full runs). That last number matters: the server never sees a refresh-token reuse at all, so even if WorkOS *does* revoke sessions on reuse (the theft hypothesis from the original Slack investigation — real mechanism, wrong emphasis), we can no longer trip it.

**Rebase archaeology, for reviewers:** this work originally lived on `saoudrizwan/auth-refresh-races` (5 commits, mid-July). Two commits landed then as #12255/#12256 squashes; the other four sat unmerged while main moved ~180 commits. Two things fell out of the cherry-pick worth knowing:

- The #12255 squash **dropped the `emitLoggedOutTelemetry` option** on `ClineTokenResolution` that the adopt-disk path depends on (the helper must suppress the logged-out event on the first `invalid_grant` because it's about to retry with adopted credentials and owns that decision). Re-ported here as its own commit.
- Main's ENG-2213 debug logging (`hashSecret` token-hash tracing) lived inside the hand-rolled refresh bodies this PR deletes; the helper has its own `sdkDebug` tracing of outcomes, and vscode now forwards telemetry into the helper so the funnel events keep flowing (there's a test pinning that).

### Test Procedure

- Race harness (out-of-repo): baseline 4/5 scenarios wiped → fixed 5/5 green, three full runs. Scenarios: transient-outage, rotation-race, revoke-on-reuse, write-churn, churn + single-use rotation.
- New unit tests riding along: settings-file-lock (6), store-refresh helper (6), settings-manager atomicity (2), cline.ts transient/telemetry behavior, vscode transient-keep + `syncAuthStateFromDisk` suites.
- Full `sdk/packages/core` vitest suite on this exact branch: **1539 passed / 4 skipped, 0 failures.**
- apps/vscode `auth-service.test.ts`: 34/34. apps/cli `cline-account.test.ts`: 9/9.
- `tsc --noEmit` clean in sdk/core, apps/vscode, apps/cli, apps/cline-hub.

What could break and why I think it doesn't: the refresh lock adds a cross-process wait on the token path — bounded by the 45s acquire timeout with explicit degrade-to-unlocked (i.e., worst case is today's behavior, not a hang). `getValidClineCredentials` changed publicly in #12255 (throws on transient instead of returning null); this PR doesn't change that contract further, it adds an optional field.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — backend/storage change; harness numbers above are the evidence.

### Additional Notes

- Legacy extension (secrets.json-based) can still rotate the shared token invisibly to the adopt-disk logic when its credentials live only in secrets — with this PR that becomes a clean, truthful logout instead of a corrupted-state one. Porting locks to the `legacy-extension` branch is a follow-up.
- Watch `user.auth_refresh_recovered` in PostHog after this ships: every event is a prevented hard logout.
