### PR TITLE
fix(catalog): preserve MiniMax M3 video input capability

### DIFF
--- a/sdk/packages/llms/src/catalog/catalog-live.test.ts
+++ b/sdk/packages/llms/src/catalog/catalog-live.test.ts
@@ -433,7 +433,7 @@ describe("models-dev-catalog", () => {
 						structured_output: true,
 						temperature: true,
 						release_date: "2026-01-01",
-						modalities: { input: ["text", "image"] },
+						modalities: { input: ["text", "image", "video"] },
 						limit: { context: 1_000_000 },
 						cost: { input: 1, output: 2, cache_write: 0.8 },
 						status: "preview",
@@ -491,6 +491,7 @@ describe("models-dev-catalog", () => {
 					maxTokens: 4096,
 					capabilities: [
 						"images",
+						"video",
 						"tools",
 						"reasoning",
 						"structured_output",
@@ -590,6 +591,19 @@ describe("models-dev-catalog", () => {
 				"openai/gpt-5.3-codex"
 			]?.contextWindow,
 		).toBe(400_000);
+	});
+
+	it("includes video input for direct MiniMax M3 catalog entries", () => {
+		for (const providerId of [
+			"minimax",
+			"minimax-cn",
+			"minimax-coding-plan",
+			"minimax-cn-coding-plan",
+		]) {
+			expect(
+				getGeneratedModelsForProvider(providerId)["MiniMax-M3"]?.capabilities,
+			).toEqual(expect.arrayContaining(["images", "video"]));
+		}
 	});
 
 	it("fetches and normalizes models.dev payload", async () => {

--- a/sdk/packages/llms/src/catalog/catalog-live.ts
+++ b/sdk/packages/llms/src/catalog/catalog-live.ts
@@ -183,6 +183,9 @@ function toCapabilities(model: ModelsDevModel): ModelInfo["capabilities"] {
 	if (model.modalities?.input?.includes("image")) {
 		capabilities.push("images");
 	}
+	if (model.modalities?.input?.includes("video")) {
+		capabilities.push("video");
+	}
 	if (model.modalities?.input?.includes("pdf")) {
 		capabilities.push("files");
 	}

--- a/sdk/packages/llms/src/catalog/catalog.generated.ts
+++ b/sdk/packages/llms/src/catalog/catalog.generated.ts
@@ -41934,6 +41934,7 @@ export const GENERATED_PROVIDER_MODELS: {
       "maxTokens": 128000,
       "capabilities": [
         "images",
+        "video",
         "tools",
         "reasoning",
         "temperature",
@@ -42082,6 +42083,7 @@ export const GENERATED_PROVIDER_MODELS: {
       "maxTokens": 128000,
       "capabilities": [
         "images",
+        "video",
         "tools",
         "reasoning",
         "temperature",
@@ -42230,6 +42232,7 @@ export const GENERATED_PROVIDER_MODELS: {
       "maxTokens": 128000,
       "capabilities": [
         "images",
+        "video",
         "tools",
         "reasoning",
         "temperature"
@@ -42373,6 +42376,7 @@ export const GENERATED_PROVIDER_MODELS: {
       "maxTokens": 128000,
       "capabilities": [
         "images",
+        "video",
         "tools",
         "reasoning",
         "temperature"

--- a/sdk/packages/shared/src/llms/model-info.ts
+++ b/sdk/packages/shared/src/llms/model-info.ts
@@ -21,6 +21,7 @@ export const ApiFormat = {
 
 export const ModelCapabilitySchema = z.enum([
 	"images",
+	"video",
 	"tools",
 	"streaming",
 	"prompt-cache",


### PR DESCRIPTION
Reason: MiniMax M3 video input is omitted from the catalog capability schema and direct generated entries.

## Changes

- Add video to the shared model capability schema.
- Preserve video input during live catalog normalization.
- Update direct MiniMax M3 catalog entries and add focused coverage.

## Checks

- `bun -F @cline/llms test -- src/catalog/catalog-live.test.ts`
- `bun -F @cline/llms typecheck`
- `bun -F @cline/shared typecheck`
- `bun run build:sdk`
- `bunx --bun @biomejs/biome check --diagnostic-level=error sdk/packages/shared/src/llms/model-info.ts sdk/packages/llms/src/catalog/catalog-live.ts sdk/packages/llms/src/catalog/catalog-live.test.ts sdk/packages/llms/src/catalog/catalog.generated.ts`
- Regex secret scan of `origin/main...HEAD`
- `gitleaks git --no-banner --redact --log-opts='origin/main..HEAD' .`
