### PR TITLE
Fix malformed follow-up options crashing the webview

### DIFF
--- a/apps/vscode/webview-ui/src/components/chat/ChatRow.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatRow.tsx
@@ -1043,7 +1043,7 @@ export const ChatRowContent = memo(
 						try {
 							const parsedMessage = JSON.parse(message.text || "{}") as ClineAskQuestion
 							question = parsedMessage.question
-							options = parsedMessage.options
+							options = Array.isArray(parsedMessage.options) ? parsedMessage.options : undefined
 							selected = parsedMessage.selected
 						} catch (_e) {
 							// legacy messages would pass question directly

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/utils/messageUtils.test.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/utils/messageUtils.test.ts
@@ -91,6 +91,18 @@ describe("filterVisibleMessages", () => {
 
 		expect(visible).toEqual([askMessage, userMessage])
 	})
+
+	it("keeps feedback when a persisted follow-up has malformed options", () => {
+		const askMessage: ClineMessage = {
+			type: "ask",
+			ask: "followup",
+			text: JSON.stringify({ question: "Pick one", options: { first: "Use this" } }),
+			ts: 1,
+		}
+		const userMessage = createUserFeedbackMessage(2, "Use this")
+
+		expect(filterVisibleMessages([askMessage, userMessage])).toEqual([askMessage, userMessage])
+	})
 })
 
 describe("canRestoreWorkspaceFromMessage", () => {

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/utils/messageUtils.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/utils/messageUtils.ts
@@ -63,7 +63,7 @@ function isDuplicateAskOptionEcho(message: ClineMessage, previousMessage: ClineM
 
 	try {
 		const parsed = JSON.parse(previousMessage.text || "{}") as ClineAskQuestion | ClinePlanModeResponse
-		if (!parsed.options?.includes(responseText)) {
+		if (!Array.isArray(parsed.options) || !parsed.options.includes(responseText)) {
 			return false
 		}
 


### PR DESCRIPTION
## Summary
- validate persisted follow-up options before using array methods
- render malformed question payloads without option buttons instead of crashing the chat
- add regression coverage for malformed options payloads

Fixes #12786

## Testing
- `bun test src/components/chat/chat-view/utils/messageUtils.test.ts`
- `bun run build` is blocked by pre-existing generated proto/client drift (`PLAN_COMPLETION_RESULT`, `COMPACTION`, `ModelOverrides`, and missing generated client methods)