### PR TITLE
feat(hub): reclaim ask-question contributions

### DIFF
--- a/sdk/ARCHITECTURE.md
+++ b/sdk/ARCHITECTURE.md
@@ -145,6 +145,7 @@ event payload and `source` field.
 4. Hosts attach and detach from shared sessions without stopping the authority runtime, so another client can keep streaming or resume the same session later.
 5. The hub-hosted runtime executes the agent loop using `@cline/agents` and `@cline/llms`.
 6. `@cline/core` hub services broker sessions, events, approvals, schedules, and client-owned runtime capabilities such as session-local tool executors.
+   Abrupt client disconnects retain pending `askQuestion` capability requests and their ownership for a 30-second reclaim window. A registered replacement client can explicitly claim and replay them; expiry, session deletion, or Hub shutdown clears the retained state. Explicit `session.detach` remains a deliberate abandonment and cancels pending requests immediately.
 7. Hub event forwarding preserves structured streaming lifecycle boundaries: text/reasoning deltas, final text/reasoning completion, tool start/finish, and agent done events are translated across the hub transport so host UIs can reliably close loading/streaming state.
 8. Hub client adapters exported from `@cline/core/hub` (`NodeHubClient`, `HubSessionClient`, `HubUIClient`, `connectToHub`) translate command/reply and event streams into host-facing APIs.
 9. Hub `session.get` records include both canonical root-session usage and explicit aggregate usage from the hub-owned `RuntimeHost`, so attached clients can intentionally render either root-only or root-plus-teammate costs without replaying event streams.

--- a/sdk/packages/core/src/hub/server/boundary.test.ts
+++ b/sdk/packages/core/src/hub/server/boundary.test.ts
@@ -56,6 +56,14 @@ describe("HubServerTransport boundaries", () => {
 		return (transport as unknown as { ctx: HubTransportContext }).ctx;
 	}
 
+	function deferred<T>() {
+		let resolve!: (value: T) => void;
+		const promise = new Promise<T>((next) => {
+			resolve = next;
+		});
+		return { promise, resolve };
+	}
+
 	it("continues publishing when one listener throws", () => {
 		const transport = createTransport();
 		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
@@ -1037,6 +1045,187 @@ describe("HubServerTransport boundaries", () => {
 		});
 	});
 
+	it("rejects a superseded owner after a capability is rebound", async () => {
+		const transport = createTransport();
+		const ctx = getContext(transport);
+		const state = ensureSessionState(
+			ctx,
+			"session-1",
+			"owner-client",
+			"creator",
+		);
+		state.clientContributionOwners = new Map([
+			["tool_executor.askQuestion", "owner-client"],
+		]);
+		for (const clientId of ["owner-client", "reconnected-client"]) {
+			await transport.handleCommand({
+				version: "v1",
+				command: "client.register",
+				clientId,
+				payload: { clientId, clientType: "web" },
+			});
+		}
+		const events: HubEventEnvelope[] = [];
+		transport.subscribe("reconnected-client", (event) => events.push(event));
+		const response = ctx.requestCapability(
+			"session-1",
+			"tool_executor.askQuestion",
+			{ question: "Continue?" },
+			"owner-client",
+		);
+		await Promise.resolve();
+		const requestId = String(
+			events.find((event) => event.event === "capability.requested")?.payload
+				?.requestId ?? "",
+		);
+
+		await transport.handleCommand({
+			version: "v1",
+			command: "session.claim_client_contributions",
+			clientId: "reconnected-client",
+			sessionId: "session-1",
+			payload: { capabilityNames: ["tool_executor.askQuestion"] },
+		});
+		const staleReply = await transport.handleCommand({
+			version: "v1",
+			command: "capability.respond",
+			clientId: "owner-client",
+			sessionId: "session-1",
+			payload: { requestId, ok: true, payload: { result: "stale" } },
+		});
+		expect(staleReply).toMatchObject({
+			ok: false,
+			error: { code: "capability_wrong_client" },
+		});
+
+		await transport.handleCommand({
+			version: "v1",
+			command: "capability.respond",
+			clientId: "reconnected-client",
+			sessionId: "session-1",
+			payload: { requestId, ok: false },
+		});
+		await expect(response).rejects.toThrow("rejected by reconnected-client");
+	});
+
+	it("keeps contribution state while a claim validates the session", async () => {
+		vi.useFakeTimers();
+		try {
+			const lookup = deferred<Record<string, unknown>>();
+			const getSession = vi.fn(() => lookup.promise);
+			const transport = createTransport({ sessionHost: { getSession } });
+			const ctx = getContext(transport);
+			const state = ensureSessionState(
+				ctx,
+				"session-1",
+				"owner-client",
+				"creator",
+			);
+			state.clientContributionOwners = new Map([
+				["tool_executor.askQuestion", "owner-client"],
+			]);
+			for (const clientId of ["owner-client", "reconnected-client"]) {
+				await transport.handleCommand({
+					version: "v1",
+					command: "client.register",
+					clientId,
+					payload: { clientId, clientType: "web" },
+				});
+			}
+			await transport.handleCommand({
+				version: "v1",
+				command: "client.unregister",
+				clientId: "owner-client",
+			});
+
+			const claim = transport.handleCommand({
+				version: "v1",
+				command: "session.claim_client_contributions",
+				clientId: "reconnected-client",
+				sessionId: "session-1",
+				payload: { capabilityNames: ["tool_executor.askQuestion"] },
+			});
+			await vi.waitFor(() => expect(getSession).toHaveBeenCalled());
+			await vi.advanceTimersByTimeAsync(30_000);
+			expect(ctx.sessionState.has("session-1")).toBe(true);
+
+			lookup.resolve({
+				sessionId: "session-1",
+				status: "completed",
+				startedAt: new Date(0).toISOString(),
+				updatedAt: new Date(0).toISOString(),
+				workspaceRoot: "/tmp/project",
+				cwd: "/tmp/project",
+			});
+			expect((await claim).ok).toBe(true);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("rejects a claimant that disconnects during session validation", async () => {
+		vi.useFakeTimers();
+		try {
+			const lookup = deferred<Record<string, unknown>>();
+			const getSession = vi.fn(() => lookup.promise);
+			const transport = createTransport({ sessionHost: { getSession } });
+			const ctx = getContext(transport);
+			const state = ensureSessionState(
+				ctx,
+				"session-1",
+				"owner-client",
+				"creator",
+			);
+			state.clientContributionOwners = new Map([
+				["tool_executor.askQuestion", "owner-client"],
+			]);
+			for (const clientId of ["owner-client", "reconnected-client"]) {
+				await transport.handleCommand({
+					version: "v1",
+					command: "client.register",
+					clientId,
+					payload: { clientId, clientType: "web" },
+				});
+			}
+			await transport.handleCommand({
+				version: "v1",
+				command: "client.unregister",
+				clientId: "owner-client",
+			});
+			const claim = transport.handleCommand({
+				version: "v1",
+				command: "session.claim_client_contributions",
+				clientId: "reconnected-client",
+				sessionId: "session-1",
+				payload: { capabilityNames: ["tool_executor.askQuestion"] },
+			});
+			await vi.waitFor(() => expect(getSession).toHaveBeenCalled());
+			await transport.handleCommand({
+				version: "v1",
+				command: "client.unregister",
+				clientId: "reconnected-client",
+			});
+			lookup.resolve({
+				sessionId: "session-1",
+				status: "completed",
+				startedAt: new Date(0).toISOString(),
+				updatedAt: new Date(0).toISOString(),
+				workspaceRoot: "/tmp/project",
+				cwd: "/tmp/project",
+			});
+
+			expect(await claim).toMatchObject({
+				ok: false,
+				error: { code: "client_not_found" },
+			});
+			expect(state.participants.has("reconnected-client")).toBe(false);
+			await vi.advanceTimersByTimeAsync(30_000);
+			expect(ctx.sessionState.has("session-1")).toBe(false);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it("allows claims against sessions without registered contributions", async () => {
 		const transport = createTransport();
 		await transport.handleCommand({
@@ -1117,6 +1306,23 @@ describe("HubServerTransport boundaries", () => {
 
 			await vi.advanceTimersByTimeAsync(30_000);
 			expect(ctx.sessionState.has("session-1")).toBe(false);
+			await transport.handleCommand({
+				version: "v1",
+				command: "client.register",
+				clientId: "late-client",
+				payload: { clientId: "late-client", clientType: "web" },
+			});
+			const claimReply = await transport.handleCommand({
+				version: "v1",
+				command: "session.claim_client_contributions",
+				clientId: "late-client",
+				sessionId: "session-1",
+				payload: { capabilityNames: ["tool_executor.askQuestion"] },
+			});
+			expect(claimReply).toMatchObject({
+				ok: true,
+				payload: { capabilityNames: [] },
+			});
 		} finally {
 			vi.useRealTimers();
 		}
@@ -1669,6 +1875,85 @@ describe("HubServerTransport boundaries", () => {
 
 			await vi.advanceTimersByTimeAsync(30_000);
 			expect(resolved).toHaveBeenCalledOnce();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("cleans stale Hub state only when the session is absent", async () => {
+		for (const sessionStillExists of [false, true]) {
+			const deleteSession = vi.fn().mockResolvedValue(false);
+			const getSession = vi.fn().mockResolvedValue(
+				sessionStillExists
+					? {
+							sessionId: "session-1",
+							status: "completed",
+							startedAt: new Date(0).toISOString(),
+							updatedAt: new Date(0).toISOString(),
+							workspaceRoot: "/tmp/project",
+							cwd: "/tmp/project",
+						}
+					: undefined,
+			);
+			const transport = createTransport({
+				sessionHost: { deleteSession, getSession },
+			});
+			const ctx = getContext(transport);
+			ensureSessionState(ctx, "session-1", "owner-client", "creator");
+			const resolved = vi.fn();
+			ctx.pendingCapabilityRequests.set("capreq-delete", {
+				sessionId: "session-1",
+				targetClientId: "owner-client",
+				capabilityName: "tool_executor.askQuestion",
+				resolve: resolved,
+			});
+
+			const reply = await transport.handleCommand({
+				version: "v1",
+				command: "session.delete",
+				sessionId: "session-1",
+			});
+
+			expect(reply).toMatchObject({ ok: true, payload: { deleted: false } });
+			expect(ctx.sessionState.has("session-1")).toBe(sessionStillExists);
+			expect(ctx.pendingCapabilityRequests.has("capreq-delete")).toBe(
+				sessionStillExists,
+			);
+			expect(resolved).toHaveBeenCalledTimes(sessionStillExists ? 0 : 1);
+		}
+	});
+
+	it("clears contribution eviction timers when the transport stops", async () => {
+		vi.useFakeTimers();
+		try {
+			const transport = createTransport();
+			const ctx = getContext(transport);
+			const state = ensureSessionState(
+				ctx,
+				"session-1",
+				"owner-client",
+				"creator",
+			);
+			state.clientContributionOwners = new Map([
+				["tool_executor.askQuestion", "owner-client"],
+			]);
+			await transport.handleCommand({
+				version: "v1",
+				command: "client.register",
+				clientId: "owner-client",
+				payload: { clientId: "owner-client", clientType: "web" },
+			});
+			await transport.handleCommand({
+				version: "v1",
+				command: "client.unregister",
+				clientId: "owner-client",
+			});
+			expect(state.contributionOwnerEvictionTimer).toBeDefined();
+
+			await transport.stop();
+			expect(state.contributionOwnerEvictionTimer).toBeUndefined();
+			await vi.advanceTimersByTimeAsync(30_000);
+			expect(ctx.sessionState.has("session-1")).toBe(true);
 		} finally {
 			vi.useRealTimers();
 		}

--- a/sdk/packages/core/src/hub/server/boundary.test.ts
+++ b/sdk/packages/core/src/hub/server/boundary.test.ts
@@ -744,7 +744,7 @@ describe("HubServerTransport boundaries", () => {
 		await expect(answerPromise).resolves.toBe("Use hub");
 	});
 
-	it("does not transfer capability ownership to attached clients", async () => {
+	it("transfers client contribution ownership only after an explicit claim", async () => {
 		let createdSessionId = "";
 		const startSession = vi.fn(async (input: StartSessionInput) => {
 			createdSessionId = input.config.sessionId?.trim() || "missing-session";
@@ -797,6 +797,15 @@ describe("HubServerTransport boundaries", () => {
 		});
 		const events: HubEventEnvelope[] = [];
 		transport.subscribe("owner-client", (event) => events.push(event));
+		for (const clientId of ["owner-client", "viewer-client"]) {
+			await transport.handleCommand({
+				version: "v1",
+				requestId: `req-register-${clientId}`,
+				command: "client.register",
+				clientId,
+				payload: { clientId, clientType: "web" },
+			});
+		}
 
 		await transport.handleCommand({
 			version: "v1",
@@ -858,6 +867,190 @@ describe("HubServerTransport boundaries", () => {
 		});
 
 		await expect(answerPromise).resolves.toBe("Use hub");
+
+		const claimReply = await transport.handleCommand({
+			version: "v1",
+			requestId: "req-claim",
+			command: "session.claim_client_contributions",
+			clientId: "viewer-client",
+			sessionId: createdSessionId,
+			payload: {
+				capabilityNames: ["tool_executor.askQuestion", "missing.capability"],
+			},
+		});
+		expect(claimReply).toMatchObject({
+			ok: true,
+			payload: {
+				sessionId: createdSessionId,
+				capabilityNames: ["tool_executor.askQuestion"],
+			},
+		});
+
+		const claimedAnswerPromise = askQuestion("Continue?", ["Yes"], {
+			agentId: "agent-1",
+			conversationId: "conv-1",
+			iteration: 2,
+		});
+		await Promise.resolve();
+		const claimedRequest = [...events]
+			.reverse()
+			.find((event) => event.event === "capability.requested");
+		expect(claimedRequest?.payload?.targetClientId).toBe("viewer-client");
+		await transport.handleCommand({
+			version: "v1",
+			requestId: "req-claimed-response",
+			command: "capability.respond",
+			clientId: "viewer-client",
+			sessionId: createdSessionId,
+			payload: {
+				requestId: String(claimedRequest?.payload?.requestId ?? ""),
+				ok: true,
+				payload: { result: "Yes" },
+			},
+		});
+		await expect(claimedAnswerPromise).resolves.toBe("Yes");
+	});
+
+	it("retains and replays askQuestion while a new client claims the session", async () => {
+		const transport = createTransport();
+		const ctx = getContext(transport);
+		const state = ensureSessionState(
+			ctx,
+			"session-1",
+			"owner-client",
+			"creator",
+		);
+		state.clientContributionOwners = new Map([
+			["tool_executor.askQuestion", "owner-client"],
+		]);
+		for (const clientId of ["owner-client", "reconnected-client"]) {
+			await transport.handleCommand({
+				version: "v1",
+				command: "client.register",
+				clientId,
+				payload: { clientId, clientType: "web" },
+			});
+		}
+		const resolve = vi.fn();
+		ctx.pendingCapabilityRequests.set("capreq-reload", {
+			sessionId: "session-1",
+			targetClientId: "owner-client",
+			capabilityName: "tool_executor.askQuestion",
+			payload: { question: "Continue?", options: ["Yes"] },
+			resolve,
+		});
+		const replayed: HubEventEnvelope[] = [];
+		transport.subscribe("reconnected-client", (event) => replayed.push(event));
+
+		await transport.handleCommand({
+			version: "v1",
+			command: "client.unregister",
+			clientId: "owner-client",
+		});
+		expect(ctx.pendingCapabilityRequests.has("capreq-reload")).toBe(true);
+		expect(ctx.clients.has("reconnected-client")).toBe(true);
+
+		const claimReply = await transport.handleCommand({
+			version: "v1",
+			command: "session.claim_client_contributions",
+			clientId: "reconnected-client",
+			sessionId: "session-1",
+			payload: { capabilityNames: ["tool_executor.askQuestion"] },
+		});
+		expect(claimReply.ok).toBe(true);
+		expect(replayed).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					event: "capability.requested",
+					payload: expect.objectContaining({
+						requestId: "capreq-reload",
+						targetClientId: "reconnected-client",
+						payload: { question: "Continue?", options: ["Yes"] },
+					}),
+				}),
+			]),
+		);
+		const replayCount = replayed.filter(
+			(event) => event.event === "capability.requested",
+		).length;
+		await transport.handleCommand({
+			version: "v1",
+			command: "session.claim_client_contributions",
+			clientId: "reconnected-client",
+			sessionId: "session-1",
+			payload: { capabilityNames: ["tool_executor.askQuestion"] },
+		});
+		expect(
+			replayed.filter((event) => event.event === "capability.requested"),
+		).toHaveLength(replayCount);
+
+		const response = await transport.handleCommand({
+			version: "v1",
+			command: "capability.respond",
+			clientId: "reconnected-client",
+			sessionId: "session-1",
+			payload: {
+				requestId: "capreq-reload",
+				ok: true,
+				payload: { result: "Yes" },
+			},
+		});
+		expect(response.ok).toBe(true);
+		expect(resolve).toHaveBeenCalledWith({
+			ok: true,
+			payload: { result: "Yes" },
+			error: undefined,
+		});
+	});
+
+	it("allows claims against sessions without registered contributions", async () => {
+		const transport = createTransport();
+		await transport.handleCommand({
+			version: "v1",
+			command: "client.register",
+			clientId: "viewer-client",
+			payload: { clientId: "viewer-client", clientType: "web" },
+		});
+
+		const reply = await transport.handleCommand({
+			version: "v1",
+			command: "session.claim_client_contributions",
+			clientId: "viewer-client",
+			sessionId: "session-1",
+			payload: { capabilityNames: ["tool_executor.askQuestion"] },
+		});
+
+		expect(reply).toMatchObject({
+			ok: true,
+			payload: { sessionId: "session-1", capabilityNames: [] },
+		});
+	});
+
+	it("bounds askQuestion requests targeting a disconnected owner", async () => {
+		vi.useFakeTimers();
+		try {
+			const transport = createTransport();
+			await transport.handleCommand({
+				version: "v1",
+				command: "client.register",
+				clientId: "remaining-client",
+				payload: { clientId: "remaining-client", clientType: "web" },
+			});
+
+			const response = getContext(transport).requestCapability(
+				"session-1",
+				"tool_executor.askQuestion",
+				{ question: "Continue?" },
+				"disconnected-owner",
+			);
+			const rejection = expect(response).rejects.toThrow(
+				"did not reconnect before the grace period expired",
+			);
+			await vi.advanceTimersByTimeAsync(30_000);
+			await rejection;
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	it("rejects capability responses from non-owner clients", async () => {

--- a/sdk/packages/core/src/hub/server/boundary.test.ts
+++ b/sdk/packages/core/src/hub/server/boundary.test.ts
@@ -64,6 +64,88 @@ describe("HubServerTransport boundaries", () => {
 		return { promise, resolve };
 	}
 
+	const SESSION_RECORD = {
+		sessionId: "session-1",
+		status: "completed",
+		startedAt: new Date(0).toISOString(),
+		updatedAt: new Date(0).toISOString(),
+		workspaceRoot: "/tmp/project",
+		cwd: "/tmp/project",
+	};
+
+	async function registerClients(
+		transport: HubServerTransport,
+		...clientIds: string[]
+	) {
+		for (const clientId of clientIds) {
+			await transport.handleCommand({
+				version: "v1",
+				command: "client.register",
+				clientId,
+				payload: { clientId, clientType: "web" },
+			});
+		}
+	}
+
+	async function unregisterClient(
+		transport: HubServerTransport,
+		clientId: string,
+	) {
+		await transport.handleCommand({
+			version: "v1",
+			command: "client.unregister",
+			clientId,
+		});
+	}
+
+	function claimContributions(
+		transport: HubServerTransport,
+		clientId: string,
+		sessionId: string,
+		capabilityNames: string[] = ["tool_executor.askQuestion"],
+	) {
+		return transport.handleCommand({
+			version: "v1",
+			command: "session.claim_client_contributions",
+			clientId,
+			sessionId,
+			payload: { capabilityNames },
+		});
+	}
+
+	function seedOwnerState(
+		ctx: HubTransportContext,
+		sessionId: string,
+		ownerClientId: string,
+		capabilityNames: string[] = ["tool_executor.askQuestion"],
+	) {
+		const state = ensureSessionState(ctx, sessionId, ownerClientId, "creator");
+		state.clientContributionOwners = new Map(
+			capabilityNames.map((name) => [name, ownerClientId]),
+		);
+		return state;
+	}
+
+	function seedPendingAsk(
+		ctx: HubTransportContext,
+		requestId: string,
+		targetClientId: string,
+		options: {
+			capabilityName?: string;
+			payload?: Record<string, unknown>;
+		} = {},
+	) {
+		const resolve = vi.fn();
+		ctx.pendingCapabilityRequests.set(requestId, {
+			sessionId: "session-1",
+			targetClientId,
+			capabilityName: options.capabilityName ?? "tool_executor.askQuestion",
+			...(options.payload ? { payload: options.payload } : {}),
+			resolve,
+		});
+		return resolve;
+	}
+
 	it("continues publishing when one listener throws", () => {
 		const transport = createTransport();
 		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
@@ -805,15 +887,12 @@ describe("HubServerTransport boundaries", () => {
 		});
 		const events: HubEventEnvelope[] = [];
 		transport.subscribe("owner-client", (event) => events.push(event));
-		for (const clientId of ["owner-client", "viewer-client", "last-client"]) {
-			await transport.handleCommand({
-				version: "v1",
-				requestId: `req-register-${clientId}`,
-				command: "client.register",
-				clientId,
-				payload: { clientId, clientType: "web" },
-			});
-		}
+		await registerClients(
+			transport,
+			"owner-client",
+			"viewer-client",
+			"last-client",
+		);
 
 		await transport.handleCommand({
 			version: "v1",
@@ -881,20 +960,12 @@ describe("HubServerTransport boundaries", () => {
 
 		await expect(answerPromise).resolves.toBe("Use hub");
 
-		const claimReply = await transport.handleCommand({
-			version: "v1",
-			requestId: "req-claim",
-			command: "session.claim_client_contributions",
-			clientId: "viewer-client",
-			sessionId: createdSessionId,
-			payload: {
-				capabilityNames: [
-					"tool_executor.askQuestion",
-					"hook.beforeRun",
-					"missing.capability",
-				],
-			},
-		});
+		const claimReply = await claimContributions(
+			transport,
+			"viewer-client",
+			createdSessionId,
+			["tool_executor.askQuestion", "hook.beforeRun", "missing.capability"],
+		);
 		expect(claimReply).toMatchObject({
 			ok: true,
 			payload: {
@@ -908,14 +979,11 @@ describe("HubServerTransport boundaries", () => {
 				?.clientContributionOwners?.get("hook.beforeRun"),
 		).toBe("owner-client");
 
-		const lastClaimReply = await transport.handleCommand({
-			version: "v1",
-			requestId: "req-last-claim",
-			command: "session.claim_client_contributions",
-			clientId: "last-client",
-			sessionId: createdSessionId,
-			payload: { capabilityNames: ["tool_executor.askQuestion"] },
-		});
+		const lastClaimReply = await claimContributions(
+			transport,
+			"last-client",
+			createdSessionId,
+		);
 		expect(lastClaimReply).toMatchObject({
 			ok: true,
 			payload: { capabilityNames: ["tool_executor.askQuestion"] },
@@ -949,49 +1017,23 @@ describe("HubServerTransport boundaries", () => {
 	it("retains and replays askQuestion while a new client claims the session", async () => {
 		const transport = createTransport();
 		const ctx = getContext(transport);
-		const state = ensureSessionState(
-			ctx,
-			"session-1",
-			"owner-client",
-			"creator",
-		);
-		state.clientContributionOwners = new Map([
-			["tool_executor.askQuestion", "owner-client"],
-		]);
-		for (const clientId of ["owner-client", "reconnected-client"]) {
-			await transport.handleCommand({
-				version: "v1",
-				command: "client.register",
-				clientId,
-				payload: { clientId, clientType: "web" },
-			});
-		}
-		const resolve = vi.fn();
-		ctx.pendingCapabilityRequests.set("capreq-reload", {
-			sessionId: "session-1",
-			targetClientId: "owner-client",
-			capabilityName: "tool_executor.askQuestion",
+		seedOwnerState(ctx, "session-1", "owner-client");
+		await registerClients(transport, "owner-client", "reconnected-client");
+		const resolve = seedPendingAsk(ctx, "capreq-reload", "owner-client", {
 			payload: { question: "Continue?", options: ["Yes"] },
-			resolve,
 		});
 		const replayed: HubEventEnvelope[] = [];
 		transport.subscribe("reconnected-client", (event) => replayed.push(event));
 
-		await transport.handleCommand({
-			version: "v1",
-			command: "client.unregister",
-			clientId: "owner-client",
-		});
+		await unregisterClient(transport, "owner-client");
 		expect(ctx.pendingCapabilityRequests.has("capreq-reload")).toBe(true);
 		expect(ctx.clients.has("reconnected-client")).toBe(true);
 
-		const claimReply = await transport.handleCommand({
-			version: "v1",
-			command: "session.claim_client_contributions",
-			clientId: "reconnected-client",
-			sessionId: "session-1",
-			payload: { capabilityNames: ["tool_executor.askQuestion"] },
-		});
+		const claimReply = await claimContributions(
+			transport,
+			"reconnected-client",
+			"session-1",
+		);
 		expect(claimReply.ok).toBe(true);
 		expect(claimReply.payload?.pendingRequests).toEqual([
 			{
@@ -1015,13 +1057,7 @@ describe("HubServerTransport boundaries", () => {
 		const replayCount = replayed.filter(
 			(event) => event.event === "capability.requested",
 		).length;
-		await transport.handleCommand({
-			version: "v1",
-			command: "session.claim_client_contributions",
-			clientId: "reconnected-client",
-			sessionId: "session-1",
-			payload: { capabilityNames: ["tool_executor.askQuestion"] },
-		});
+		await claimContributions(transport, "reconnected-client", "session-1");
 		expect(
 			replayed.filter((event) => event.event === "capability.requested"),
 		).toHaveLength(replayCount);
@@ -1048,23 +1084,8 @@ describe("HubServerTransport boundaries", () => {
 	it("rejects a superseded owner after a capability is rebound", async () => {
 		const transport = createTransport();
 		const ctx = getContext(transport);
-		const state = ensureSessionState(
-			ctx,
-			"session-1",
-			"owner-client",
-			"creator",
-		);
-		state.clientContributionOwners = new Map([
-			["tool_executor.askQuestion", "owner-client"],
-		]);
-		for (const clientId of ["owner-client", "reconnected-client"]) {
-			await transport.handleCommand({
-				version: "v1",
-				command: "client.register",
-				clientId,
-				payload: { clientId, clientType: "web" },
-			});
-		}
+		seedOwnerState(ctx, "session-1", "owner-client");
+		await registerClients(transport, "owner-client", "reconnected-client");
 		const events: HubEventEnvelope[] = [];
 		transport.subscribe("reconnected-client", (event) => events.push(event));
 		const response = ctx.requestCapability(
@@ -1079,13 +1100,7 @@ describe("HubServerTransport boundaries", () => {
 				?.requestId ?? "",
 		);
 
-		await transport.handleCommand({
-			version: "v1",
-			command: "session.claim_client_contributions",
-			clientId: "reconnected-client",
-			sessionId: "session-1",
-			payload: { capabilityNames: ["tool_executor.askQuestion"] },
-		});
+		await claimContributions(transport, "reconnected-client", "session-1");
 		const staleReply = await transport.handleCommand({
 			version: "v1",
 			command: "capability.respond",
@@ -1115,48 +1130,20 @@ describe("HubServerTransport boundaries", () => {
 			const getSession = vi.fn(() => lookup.promise);
 			const transport = createTransport({ sessionHost: { getSession } });
 			const ctx = getContext(transport);
-			const state = ensureSessionState(
-				ctx,
-				"session-1",
-				"owner-client",
-				"creator",
-			);
-			state.clientContributionOwners = new Map([
-				["tool_executor.askQuestion", "owner-client"],
-			]);
-			for (const clientId of ["owner-client", "reconnected-client"]) {
-				await transport.handleCommand({
-					version: "v1",
-					command: "client.register",
-					clientId,
-					payload: { clientId, clientType: "web" },
-				});
-			}
-			await transport.handleCommand({
-				version: "v1",
-				command: "client.unregister",
-				clientId: "owner-client",
-			});
+			const state = seedOwnerState(ctx, "session-1", "owner-client");
+			await registerClients(transport, "owner-client", "reconnected-client");
+			await unregisterClient(transport, "owner-client");
 
-			const claim = transport.handleCommand({
-				version: "v1",
-				command: "session.claim_client_contributions",
-				clientId: "reconnected-client",
-				sessionId: "session-1",
-				payload: { capabilityNames: ["tool_executor.askQuestion"] },
-			});
+			const claim = claimContributions(
+				transport,
+				"reconnected-client",
+				"session-1",
+			);
 			await vi.waitFor(() => expect(getSession).toHaveBeenCalled());
 			await vi.advanceTimersByTimeAsync(30_000);
-			expect(ctx.sessionState.has("session-1")).toBe(true);
+			expect(ctx.sessionState.get("session-1")).toBe(state);
 
-			lookup.resolve({
-				sessionId: "session-1",
-				status: "completed",
-				startedAt: new Date(0).toISOString(),
-				updatedAt: new Date(0).toISOString(),
-				workspaceRoot: "/tmp/project",
-				cwd: "/tmp/project",
-			});
+			lookup.resolve(SESSION_RECORD);
 			expect((await claim).ok).toBe(true);
 		} finally {
 			vi.useRealTimers();
@@ -1170,49 +1157,17 @@ describe("HubServerTransport boundaries", () => {
 			const getSession = vi.fn(() => lookup.promise);
 			const transport = createTransport({ sessionHost: { getSession } });
 			const ctx = getContext(transport);
-			const state = ensureSessionState(
-				ctx,
+			const state = seedOwnerState(ctx, "session-1", "owner-client");
+			await registerClients(transport, "owner-client", "reconnected-client");
+			await unregisterClient(transport, "owner-client");
+			const claim = claimContributions(
+				transport,
+				"reconnected-client",
 				"session-1",
-				"owner-client",
-				"creator",
 			);
-			state.clientContributionOwners = new Map([
-				["tool_executor.askQuestion", "owner-client"],
-			]);
-			for (const clientId of ["owner-client", "reconnected-client"]) {
-				await transport.handleCommand({
-					version: "v1",
-					command: "client.register",
-					clientId,
-					payload: { clientId, clientType: "web" },
-				});
-			}
-			await transport.handleCommand({
-				version: "v1",
-				command: "client.unregister",
-				clientId: "owner-client",
-			});
-			const claim = transport.handleCommand({
-				version: "v1",
-				command: "session.claim_client_contributions",
-				clientId: "reconnected-client",
-				sessionId: "session-1",
-				payload: { capabilityNames: ["tool_executor.askQuestion"] },
-			});
 			await vi.waitFor(() => expect(getSession).toHaveBeenCalled());
-			await transport.handleCommand({
-				version: "v1",
-				command: "client.unregister",
-				clientId: "reconnected-client",
-			});
-			lookup.resolve({
-				sessionId: "session-1",
-				status: "completed",
-				startedAt: new Date(0).toISOString(),
-				updatedAt: new Date(0).toISOString(),
-				workspaceRoot: "/tmp/project",
-				cwd: "/tmp/project",
-			});
+			await unregisterClient(transport, "reconnected-client");
+			lookup.resolve(SESSION_RECORD);
 
 			expect(await claim).toMatchObject({
 				ok: false,
@@ -1228,20 +1183,13 @@ describe("HubServerTransport boundaries", () => {
 
 	it("allows claims against sessions without registered contributions", async () => {
 		const transport = createTransport();
-		await transport.handleCommand({
-			version: "v1",
-			command: "client.register",
-			clientId: "viewer-client",
-			payload: { clientId: "viewer-client", clientType: "web" },
-		});
+		await registerClients(transport, "viewer-client");
 
-		const reply = await transport.handleCommand({
-			version: "v1",
-			command: "session.claim_client_contributions",
-			clientId: "viewer-client",
-			sessionId: "session-1",
-			payload: { capabilityNames: ["tool_executor.askQuestion"] },
-		});
+		const reply = await claimContributions(
+			transport,
+			"viewer-client",
+			"session-1",
+		);
 
 		expect(reply).toMatchObject({
 			ok: true,
@@ -1254,22 +1202,8 @@ describe("HubServerTransport boundaries", () => {
 		try {
 			const transport = createTransport();
 			const ctx = getContext(transport);
-			const state = ensureSessionState(
-				ctx,
-				"session-1",
-				"owner-client",
-				"creator",
-			);
-			state.clientContributionOwners = new Map([
-				["tool_executor.askQuestion", "owner-client"],
-			]);
-			const resolve = vi.fn();
-			ctx.pendingCapabilityRequests.set("capreq-detach", {
-				sessionId: "session-1",
-				targetClientId: "owner-client",
-				capabilityName: "tool_executor.askQuestion",
-				resolve,
-			});
+			seedOwnerState(ctx, "session-1", "owner-client");
+			const resolve = seedPendingAsk(ctx, "capreq-detach", "owner-client");
 
 			const reply = await transport.handleCommand({
 				version: "v1",
@@ -1298,42 +1232,17 @@ describe("HubServerTransport boundaries", () => {
 		try {
 			const transport = createTransport();
 			const ctx = getContext(transport);
-			const state = ensureSessionState(
-				ctx,
-				"session-1",
-				"owner-client",
-				"creator",
-			);
-			state.clientContributionOwners = new Map([
-				["tool_executor.askQuestion", "owner-client"],
-				["hook.beforeRun", "owner-client"],
+			seedOwnerState(ctx, "session-1", "owner-client", [
+				"tool_executor.askQuestion",
+				"hook.beforeRun",
 			]);
-			await transport.handleCommand({
-				version: "v1",
-				command: "client.register",
-				clientId: "owner-client",
-				payload: { clientId: "owner-client", clientType: "web" },
-			});
-			const askResolve = vi.fn();
-			const hookResolve = vi.fn();
-			ctx.pendingCapabilityRequests.set("capreq-ask", {
-				sessionId: "session-1",
-				targetClientId: "owner-client",
-				capabilityName: "tool_executor.askQuestion",
-				resolve: askResolve,
-			});
-			ctx.pendingCapabilityRequests.set("capreq-hook", {
-				sessionId: "session-1",
-				targetClientId: "owner-client",
+			await registerClients(transport, "owner-client");
+			const askResolve = seedPendingAsk(ctx, "capreq-ask", "owner-client");
+			const hookResolve = seedPendingAsk(ctx, "capreq-hook", "owner-client", {
 				capabilityName: "hook.beforeRun",
-				resolve: hookResolve,
 			});
 
-			await transport.handleCommand({
-				version: "v1",
-				command: "client.unregister",
-				clientId: "owner-client",
-			});
+			await unregisterClient(transport, "owner-client");
 
 			expect(ctx.pendingCapabilityRequests.has("capreq-ask")).toBe(true);
 			expect(
@@ -1355,12 +1264,7 @@ describe("HubServerTransport boundaries", () => {
 		vi.useFakeTimers();
 		try {
 			const transport = createTransport();
-			await transport.handleCommand({
-				version: "v1",
-				command: "client.register",
-				clientId: "remaining-client",
-				payload: { clientId: "remaining-client", clientType: "web" },
-			});
+			await registerClients(transport, "remaining-client");
 
 			const response = getContext(transport).requestCapability(
 				"session-1",
@@ -1378,102 +1282,41 @@ describe("HubServerTransport boundaries", () => {
 		}
 	});
 
-	it("evicts participant-less contribution state after the grace period", async () => {
+	it("evicts contribution state after the grace period unless a client claims", async () => {
 		vi.useFakeTimers();
 		try {
 			const transport = createTransport();
 			const ctx = getContext(transport);
-			const state = ensureSessionState(
-				ctx,
-				"session-1",
-				"owner-client",
-				"creator",
-			);
-			state.clientContributionOwners = new Map([
-				["tool_executor.askQuestion", "owner-client"],
-			]);
-			await transport.handleCommand({
-				version: "v1",
-				command: "client.register",
-				clientId: "owner-client",
-				payload: { clientId: "owner-client", clientType: "web" },
-			});
+			seedOwnerState(ctx, "session-1", "owner-client");
+			seedOwnerState(ctx, "session-2", "owner-client");
+			await registerClients(transport, "owner-client", "reconnected-client");
 
-			await transport.handleCommand({
-				version: "v1",
-				command: "client.unregister",
-				clientId: "owner-client",
-			});
+			await unregisterClient(transport, "owner-client");
 			expect(ctx.sessionState.has("session-1")).toBe(true);
-
-			await vi.advanceTimersByTimeAsync(30_000);
-			expect(ctx.sessionState.has("session-1")).toBe(false);
-			await transport.handleCommand({
-				version: "v1",
-				command: "client.register",
-				clientId: "late-client",
-				payload: { clientId: "late-client", clientType: "web" },
-			});
-			const claimReply = await transport.handleCommand({
-				version: "v1",
-				command: "session.claim_client_contributions",
-				clientId: "late-client",
-				sessionId: "session-1",
-				payload: { capabilityNames: ["tool_executor.askQuestion"] },
-			});
-			expect(claimReply).toMatchObject({
-				ok: true,
-				payload: { capabilityNames: [] },
-			});
-		} finally {
-			vi.useRealTimers();
-		}
-	});
-
-	it("keeps contribution state when a client claims within the grace period", async () => {
-		vi.useFakeTimers();
-		try {
-			const transport = createTransport();
-			const ctx = getContext(transport);
-			const state = ensureSessionState(
-				ctx,
-				"session-1",
-				"owner-client",
-				"creator",
+			const claimReply = await claimContributions(
+				transport,
+				"reconnected-client",
+				"session-2",
 			);
-			state.clientContributionOwners = new Map([
-				["tool_executor.askQuestion", "owner-client"],
-			]);
-			for (const clientId of ["owner-client", "reconnected-client"]) {
-				await transport.handleCommand({
-					version: "v1",
-					command: "client.register",
-					clientId,
-					payload: { clientId, clientType: "web" },
-				});
-			}
-
-			await transport.handleCommand({
-				version: "v1",
-				command: "client.unregister",
-				clientId: "owner-client",
-			});
-			const claimReply = await transport.handleCommand({
-				version: "v1",
-				command: "session.claim_client_contributions",
-				clientId: "reconnected-client",
-				sessionId: "session-1",
-				payload: { capabilityNames: ["tool_executor.askQuestion"] },
-			});
 			expect(claimReply.ok).toBe(true);
 
 			await vi.advanceTimersByTimeAsync(30_000);
-			expect(ctx.sessionState.has("session-1")).toBe(true);
+			expect(ctx.sessionState.has("session-1")).toBe(false);
 			expect(
 				ctx.sessionState
-					.get("session-1")
+					.get("session-2")
 					?.clientContributionOwners?.get("tool_executor.askQuestion"),
 			).toBe("reconnected-client");
+
+			const lateClaim = await claimContributions(
+				transport,
+				"reconnected-client",
+				"session-1",
+			);
+			expect(lateClaim).toMatchObject({
+				ok: true,
+				payload: { capabilityNames: [] },
+			});
 		} finally {
 			vi.useRealTimers();
 		}
@@ -1937,31 +1780,16 @@ describe("HubServerTransport boundaries", () => {
 		);
 	});
 
-	it("clears retained capability requests when a session is deleted", async () => {
+	it("cleans up retained requests and state only when session.delete removes the record", async () => {
 		vi.useFakeTimers();
 		try {
 			const deleteSession = vi.fn().mockResolvedValue(true);
 			const transport = createTransport({ sessionHost: { deleteSession } });
 			const ctx = getContext(transport);
-			await transport.handleCommand({
-				version: "v1",
-				command: "client.register",
-				clientId: "owner-client",
-				payload: { clientId: "owner-client", clientType: "web" },
-			});
-			const resolved = vi.fn();
-			ctx.pendingCapabilityRequests.set("capreq-delete", {
-				sessionId: "session-1",
-				targetClientId: "owner-client",
-				capabilityName: "tool_executor.askQuestion",
-				resolve: resolved,
-			});
+			await registerClients(transport, "owner-client");
+			const resolved = seedPendingAsk(ctx, "capreq-delete", "owner-client");
 
-			await transport.handleCommand({
-				version: "v1",
-				command: "client.unregister",
-				clientId: "owner-client",
-			});
+			await unregisterClient(transport, "owner-client");
 			expect(
 				ctx.pendingCapabilityRequests.get("capreq-delete")?.disconnectTimer,
 			).toBeDefined();
@@ -1980,35 +1808,18 @@ describe("HubServerTransport boundaries", () => {
 		} finally {
 			vi.useRealTimers();
 		}
-	});
 
-	it("cleans stale Hub state only when the session is absent", async () => {
 		for (const sessionStillExists of [false, true]) {
 			const deleteSession = vi.fn().mockResolvedValue(false);
-			const getSession = vi.fn().mockResolvedValue(
-				sessionStillExists
-					? {
-							sessionId: "session-1",
-							status: "completed",
-							startedAt: new Date(0).toISOString(),
-							updatedAt: new Date(0).toISOString(),
-							workspaceRoot: "/tmp/project",
-							cwd: "/tmp/project",
-						}
-					: undefined,
-			);
+			const getSession = vi
+				.fn()
+				.mockResolvedValue(sessionStillExists ? SESSION_RECORD : undefined);
 			const transport = createTransport({
 				sessionHost: { deleteSession, getSession },
 			});
 			const ctx = getContext(transport);
 			ensureSessionState(ctx, "session-1", "owner-client", "creator");
-			const resolved = vi.fn();
-			ctx.pendingCapabilityRequests.set("capreq-delete", {
-				sessionId: "session-1",
-				targetClientId: "owner-client",
-				capabilityName: "tool_executor.askQuestion",
-				resolve: resolved,
-			});
+			const resolved = seedPendingAsk(ctx, "capreq-delete", "owner-client");
 
 			const reply = await transport.handleCommand({
 				version: "v1",
@@ -2030,26 +1841,9 @@ describe("HubServerTransport boundaries", () => {
 		try {
 			const transport = createTransport();
 			const ctx = getContext(transport);
-			const state = ensureSessionState(
-				ctx,
-				"session-1",
-				"owner-client",
-				"creator",
-			);
-			state.clientContributionOwners = new Map([
-				["tool_executor.askQuestion", "owner-client"],
-			]);
-			await transport.handleCommand({
-				version: "v1",
-				command: "client.register",
-				clientId: "owner-client",
-				payload: { clientId: "owner-client", clientType: "web" },
-			});
-			await transport.handleCommand({
-				version: "v1",
-				command: "client.unregister",
-				clientId: "owner-client",
-			});
+			const state = seedOwnerState(ctx, "session-1", "owner-client");
+			await registerClients(transport, "owner-client");
+			await unregisterClient(transport, "owner-client");
 			expect(state.contributionOwnerEvictionTimer).toBeDefined();
 
 			await transport.stop();

--- a/sdk/packages/core/src/hub/server/boundary.test.ts
+++ b/sdk/packages/core/src/hub/server/boundary.test.ts
@@ -1249,6 +1249,108 @@ describe("HubServerTransport boundaries", () => {
 		});
 	});
 
+	it("cancels detached requests and later evicts contribution state", async () => {
+		vi.useFakeTimers();
+		try {
+			const transport = createTransport();
+			const ctx = getContext(transport);
+			const state = ensureSessionState(
+				ctx,
+				"session-1",
+				"owner-client",
+				"creator",
+			);
+			state.clientContributionOwners = new Map([
+				["tool_executor.askQuestion", "owner-client"],
+			]);
+			const resolve = vi.fn();
+			ctx.pendingCapabilityRequests.set("capreq-detach", {
+				sessionId: "session-1",
+				targetClientId: "owner-client",
+				capabilityName: "tool_executor.askQuestion",
+				resolve,
+			});
+
+			const reply = await transport.handleCommand({
+				version: "v1",
+				command: "session.detach",
+				clientId: "owner-client",
+				sessionId: "session-1",
+			});
+
+			expect(reply.ok).toBe(true);
+			expect(ctx.pendingCapabilityRequests.has("capreq-detach")).toBe(false);
+			expect(resolve).toHaveBeenCalledWith({
+				ok: false,
+				error:
+					"Capability owner client owner-client detached before request was resolved.",
+			});
+			expect(ctx.sessionState.has("session-1")).toBe(true);
+			await vi.advanceTimersByTimeAsync(30_000);
+			expect(ctx.sessionState.has("session-1")).toBe(false);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("retains only reconnectable requests on a mixed disconnect", async () => {
+		vi.useFakeTimers();
+		try {
+			const transport = createTransport();
+			const ctx = getContext(transport);
+			const state = ensureSessionState(
+				ctx,
+				"session-1",
+				"owner-client",
+				"creator",
+			);
+			state.clientContributionOwners = new Map([
+				["tool_executor.askQuestion", "owner-client"],
+				["hook.beforeRun", "owner-client"],
+			]);
+			await transport.handleCommand({
+				version: "v1",
+				command: "client.register",
+				clientId: "owner-client",
+				payload: { clientId: "owner-client", clientType: "web" },
+			});
+			const askResolve = vi.fn();
+			const hookResolve = vi.fn();
+			ctx.pendingCapabilityRequests.set("capreq-ask", {
+				sessionId: "session-1",
+				targetClientId: "owner-client",
+				capabilityName: "tool_executor.askQuestion",
+				resolve: askResolve,
+			});
+			ctx.pendingCapabilityRequests.set("capreq-hook", {
+				sessionId: "session-1",
+				targetClientId: "owner-client",
+				capabilityName: "hook.beforeRun",
+				resolve: hookResolve,
+			});
+
+			await transport.handleCommand({
+				version: "v1",
+				command: "client.unregister",
+				clientId: "owner-client",
+			});
+
+			expect(ctx.pendingCapabilityRequests.has("capreq-ask")).toBe(true);
+			expect(
+				ctx.pendingCapabilityRequests.get("capreq-ask")?.disconnectTimer,
+			).toBeDefined();
+			expect(askResolve).not.toHaveBeenCalled();
+			expect(ctx.pendingCapabilityRequests.has("capreq-hook")).toBe(false);
+			expect(hookResolve).toHaveBeenCalledWith({
+				ok: false,
+				error:
+					"Capability owner client owner-client disconnected before request was resolved.",
+			});
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it("bounds askQuestion requests targeting a disconnected owner", async () => {
 		vi.useFakeTimers();
 		try {

--- a/sdk/packages/core/src/hub/server/boundary.test.ts
+++ b/sdk/packages/core/src/hub/server/boundary.test.ts
@@ -985,6 +985,13 @@ describe("HubServerTransport boundaries", () => {
 			payload: { capabilityNames: ["tool_executor.askQuestion"] },
 		});
 		expect(claimReply.ok).toBe(true);
+		expect(claimReply.payload?.pendingRequests).toEqual([
+			{
+				requestId: "capreq-reload",
+				capabilityName: "tool_executor.askQuestion",
+				payload: { question: "Continue?", options: ["Yes"] },
+			},
+		]);
 		expect(replayed).toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({
@@ -1075,6 +1082,90 @@ describe("HubServerTransport boundaries", () => {
 			);
 			await vi.advanceTimersByTimeAsync(30_000);
 			await rejection;
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("evicts participant-less contribution state after the grace period", async () => {
+		vi.useFakeTimers();
+		try {
+			const transport = createTransport();
+			const ctx = getContext(transport);
+			const state = ensureSessionState(
+				ctx,
+				"session-1",
+				"owner-client",
+				"creator",
+			);
+			state.clientContributionOwners = new Map([
+				["tool_executor.askQuestion", "owner-client"],
+			]);
+			await transport.handleCommand({
+				version: "v1",
+				command: "client.register",
+				clientId: "owner-client",
+				payload: { clientId: "owner-client", clientType: "web" },
+			});
+
+			await transport.handleCommand({
+				version: "v1",
+				command: "client.unregister",
+				clientId: "owner-client",
+			});
+			expect(ctx.sessionState.has("session-1")).toBe(true);
+
+			await vi.advanceTimersByTimeAsync(30_000);
+			expect(ctx.sessionState.has("session-1")).toBe(false);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("keeps contribution state when a client claims within the grace period", async () => {
+		vi.useFakeTimers();
+		try {
+			const transport = createTransport();
+			const ctx = getContext(transport);
+			const state = ensureSessionState(
+				ctx,
+				"session-1",
+				"owner-client",
+				"creator",
+			);
+			state.clientContributionOwners = new Map([
+				["tool_executor.askQuestion", "owner-client"],
+			]);
+			for (const clientId of ["owner-client", "reconnected-client"]) {
+				await transport.handleCommand({
+					version: "v1",
+					command: "client.register",
+					clientId,
+					payload: { clientId, clientType: "web" },
+				});
+			}
+
+			await transport.handleCommand({
+				version: "v1",
+				command: "client.unregister",
+				clientId: "owner-client",
+			});
+			const claimReply = await transport.handleCommand({
+				version: "v1",
+				command: "session.claim_client_contributions",
+				clientId: "reconnected-client",
+				sessionId: "session-1",
+				payload: { capabilityNames: ["tool_executor.askQuestion"] },
+			});
+			expect(claimReply.ok).toBe(true);
+
+			await vi.advanceTimersByTimeAsync(30_000);
+			expect(ctx.sessionState.has("session-1")).toBe(true);
+			expect(
+				ctx.sessionState
+					.get("session-1")
+					?.clientContributionOwners?.get("tool_executor.askQuestion"),
+			).toBe("reconnected-client");
 		} finally {
 			vi.useRealTimers();
 		}

--- a/sdk/packages/core/src/hub/server/boundary.test.ts
+++ b/sdk/packages/core/src/hub/server/boundary.test.ts
@@ -797,7 +797,7 @@ describe("HubServerTransport boundaries", () => {
 		});
 		const events: HubEventEnvelope[] = [];
 		transport.subscribe("owner-client", (event) => events.push(event));
-		for (const clientId of ["owner-client", "viewer-client"]) {
+		for (const clientId of ["owner-client", "viewer-client", "last-client"]) {
 			await transport.handleCommand({
 				version: "v1",
 				requestId: `req-register-${clientId}`,
@@ -829,6 +829,11 @@ describe("HubServerTransport boundaries", () => {
 							kind: "toolExecutor",
 							executor: "askQuestion",
 							capabilityName: "tool_executor.askQuestion",
+						},
+						{
+							kind: "hook",
+							name: "beforeRun",
+							capabilityName: "hook.beforeRun",
 						},
 					],
 				},
@@ -875,7 +880,11 @@ describe("HubServerTransport boundaries", () => {
 			clientId: "viewer-client",
 			sessionId: createdSessionId,
 			payload: {
-				capabilityNames: ["tool_executor.askQuestion", "missing.capability"],
+				capabilityNames: [
+					"tool_executor.askQuestion",
+					"hook.beforeRun",
+					"missing.capability",
+				],
 			},
 		});
 		expect(claimReply).toMatchObject({
@@ -884,6 +893,24 @@ describe("HubServerTransport boundaries", () => {
 				sessionId: createdSessionId,
 				capabilityNames: ["tool_executor.askQuestion"],
 			},
+		});
+		expect(
+			getContext(transport)
+				.sessionState.get(createdSessionId)
+				?.clientContributionOwners?.get("hook.beforeRun"),
+		).toBe("owner-client");
+
+		const lastClaimReply = await transport.handleCommand({
+			version: "v1",
+			requestId: "req-last-claim",
+			command: "session.claim_client_contributions",
+			clientId: "last-client",
+			sessionId: createdSessionId,
+			payload: { capabilityNames: ["tool_executor.askQuestion"] },
+		});
+		expect(lastClaimReply).toMatchObject({
+			ok: true,
+			payload: { capabilityNames: ["tool_executor.askQuestion"] },
 		});
 
 		const claimedAnswerPromise = askQuestion("Continue?", ["Yes"], {
@@ -895,12 +922,12 @@ describe("HubServerTransport boundaries", () => {
 		const claimedRequest = [...events]
 			.reverse()
 			.find((event) => event.event === "capability.requested");
-		expect(claimedRequest?.payload?.targetClientId).toBe("viewer-client");
+		expect(claimedRequest?.payload?.targetClientId).toBe("last-client");
 		await transport.handleCommand({
 			version: "v1",
 			requestId: "req-claimed-response",
 			command: "capability.respond",
-			clientId: "viewer-client",
+			clientId: "last-client",
 			sessionId: createdSessionId,
 			payload: {
 				requestId: String(claimedRequest?.payload?.requestId ?? ""),
@@ -1509,6 +1536,51 @@ describe("HubServerTransport boundaries", () => {
 				}),
 			]),
 		);
+	});
+
+	it("clears retained capability requests when a session is deleted", async () => {
+		vi.useFakeTimers();
+		try {
+			const deleteSession = vi.fn().mockResolvedValue(true);
+			const transport = createTransport({ sessionHost: { deleteSession } });
+			const ctx = getContext(transport);
+			await transport.handleCommand({
+				version: "v1",
+				command: "client.register",
+				clientId: "owner-client",
+				payload: { clientId: "owner-client", clientType: "web" },
+			});
+			const resolved = vi.fn();
+			ctx.pendingCapabilityRequests.set("capreq-delete", {
+				sessionId: "session-1",
+				targetClientId: "owner-client",
+				capabilityName: "tool_executor.askQuestion",
+				resolve: resolved,
+			});
+
+			await transport.handleCommand({
+				version: "v1",
+				command: "client.unregister",
+				clientId: "owner-client",
+			});
+			expect(
+				ctx.pendingCapabilityRequests.get("capreq-delete")?.disconnectTimer,
+			).toBeDefined();
+
+			const reply = await transport.handleCommand({
+				version: "v1",
+				command: "session.delete",
+				sessionId: "session-1",
+			});
+			expect(reply).toMatchObject({ ok: true, payload: { deleted: true } });
+			expect(ctx.pendingCapabilityRequests.has("capreq-delete")).toBe(false);
+			expect(resolved).toHaveBeenCalledOnce();
+
+			await vi.advanceTimersByTimeAsync(30_000);
+			expect(resolved).toHaveBeenCalledOnce();
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	it("returns session_not_found when a run starts against a stale active session", async () => {

--- a/sdk/packages/core/src/hub/server/handlers/capability-handlers.ts
+++ b/sdk/packages/core/src/hub/server/handlers/capability-handlers.ts
@@ -193,11 +193,12 @@ export function retainPendingCapabilityRequestsForReconnect(
 	let retained = 0;
 	for (const [requestId, pending] of ctx.pendingCapabilityRequests.entries()) {
 		if (!filter({ requestId, ...pending }) || pending.disconnectTimer) continue;
+		const requestReason = `${reason} (session ${pending.sessionId})`;
 		pending.disconnectTimer = setTimeout(() => {
 			cancelPendingCapabilityRequests(
 				ctx,
 				(request) => request.requestId === requestId,
-				reason,
+				requestReason,
 			);
 		}, timeoutMs);
 		retained += 1;
@@ -205,13 +206,25 @@ export function retainPendingCapabilityRequestsForReconnect(
 	return retained;
 }
 
+export type ClaimedCapabilityRequest = {
+	requestId: string;
+	capabilityName: string;
+	payload: Record<string, unknown>;
+};
+
+/**
+ * Rebinds matching pending requests to the claiming client. Returns every
+ * matched request (replayed or not) so the claim reply can carry them; the
+ * reply is the reliable channel for claimers whose subscription may not have
+ * been live when the replay event was published.
+ */
 export function claimPendingCapabilityRequests(
 	ctx: HubTransportContext,
 	sessionId: string,
 	capabilityNames: ReadonlySet<string>,
 	targetClientId: string,
-): number {
-	let claimed = 0;
+): ClaimedCapabilityRequest[] {
+	const claimed: ClaimedCapabilityRequest[] = [];
 	for (const [requestId, pending] of ctx.pendingCapabilityRequests.entries()) {
 		if (
 			pending.sessionId !== sessionId ||
@@ -226,6 +239,11 @@ export function claimPendingCapabilityRequests(
 			pending.disconnectTimer = undefined;
 		}
 		pending.targetClientId = targetClientId;
+		claimed.push({
+			requestId,
+			capabilityName: pending.capabilityName,
+			payload: pending.payload ?? {},
+		});
 		if (!shouldReplay) continue;
 		ctx.publish(
 			ctx.buildEvent(
@@ -239,7 +257,6 @@ export function claimPendingCapabilityRequests(
 				sessionId,
 			),
 		);
-		claimed += 1;
 	}
 	return claimed;
 }

--- a/sdk/packages/core/src/hub/server/handlers/capability-handlers.ts
+++ b/sdk/packages/core/src/hub/server/handlers/capability-handlers.ts
@@ -4,7 +4,12 @@ import {
 	HUB_TOOL_EXECUTOR_CAPABILITY_PREFIX,
 } from "@cline/shared";
 import { logHubMessage } from "../hub-server-logging";
-import { errorReply, type HubTransportContext, okReply } from "./context";
+import {
+	errorReply,
+	type HubTransportContext,
+	okReply,
+	type PendingCapabilityRequest,
+} from "./context";
 
 export const CAPABILITY_RECONNECT_GRACE_MS = 30_000;
 
@@ -29,7 +34,7 @@ export async function requestCapability(
 		targetClientId,
 	});
 	return await new Promise((resolve, reject) => {
-		ctx.pendingCapabilityRequests.set(requestId, {
+		const pending: PendingCapabilityRequest = {
 			sessionId,
 			targetClientId,
 			capabilityName,
@@ -40,7 +45,7 @@ export async function requestCapability(
 					requestId,
 					sessionId,
 					capabilityName,
-					targetClientId,
+					targetClientId: pending.targetClientId,
 					ok: result.ok,
 					error: result.error,
 					durationMs: Math.round(performance.now() - startedAt),
@@ -49,14 +54,15 @@ export async function requestCapability(
 					reject(
 						new Error(
 							result.error ||
-								`Capability ${capabilityName} was rejected by ${targetClientId}.`,
+								`Capability ${capabilityName} was rejected by ${pending.targetClientId}.`,
 						),
 					);
 					return;
 				}
 				resolve(result.payload);
 			},
-		});
+		};
+		ctx.pendingCapabilityRequests.set(requestId, pending);
 		ctx.publish(
 			ctx.buildEvent(
 				"capability.requested",

--- a/sdk/packages/core/src/hub/server/handlers/capability-handlers.ts
+++ b/sdk/packages/core/src/hub/server/handlers/capability-handlers.ts
@@ -1,7 +1,16 @@
 import type { HubCommandEnvelope, HubReplyEnvelope } from "@cline/shared";
-import { createSessionId } from "@cline/shared";
+import {
+	createSessionId,
+	HUB_TOOL_EXECUTOR_CAPABILITY_PREFIX,
+} from "@cline/shared";
 import { logHubMessage } from "../hub-server-logging";
 import { errorReply, type HubTransportContext, okReply } from "./context";
+
+export const CAPABILITY_RECONNECT_GRACE_MS = 30_000;
+
+export function isReconnectableCapability(capabilityName: string): boolean {
+	return capabilityName === `${HUB_TOOL_EXECUTOR_CAPABILITY_PREFIX}askQuestion`;
+}
 
 export async function requestCapability(
 	ctx: HubTransportContext,
@@ -24,6 +33,7 @@ export async function requestCapability(
 			sessionId,
 			targetClientId,
 			capabilityName,
+			payload,
 			onProgress,
 			resolve: (result) => {
 				logHubMessage(result.ok ? "info" : "warn", "capability.request.end", {
@@ -65,6 +75,17 @@ export async function requestCapability(
 			capabilityName,
 			targetClientId,
 		});
+		if (
+			!ctx.clients.has(targetClientId) &&
+			isReconnectableCapability(capabilityName)
+		) {
+			retainPendingCapabilityRequestsForReconnect(
+				ctx,
+				(request) => request.requestId === requestId,
+				CAPABILITY_RECONNECT_GRACE_MS,
+				`Capability owner client ${targetClientId} did not reconnect before the grace period expired.`,
+			);
+		}
 	});
 }
 
@@ -130,6 +151,7 @@ export function cancelPendingCapabilityRequests(
 			continue;
 		}
 		ctx.pendingCapabilityRequests.delete(requestId);
+		if (pending.disconnectTimer) clearTimeout(pending.disconnectTimer);
 		logHubMessage("warn", "capability.request.cancelled", {
 			requestId,
 			sessionId: pending.sessionId,
@@ -155,6 +177,71 @@ export function cancelPendingCapabilityRequests(
 		cancelled += 1;
 	}
 	return cancelled;
+}
+
+export function retainPendingCapabilityRequestsForReconnect(
+	ctx: HubTransportContext,
+	filter: (request: {
+		requestId: string;
+		sessionId: string;
+		targetClientId: string;
+		capabilityName: string;
+	}) => boolean,
+	timeoutMs: number,
+	reason: string,
+): number {
+	let retained = 0;
+	for (const [requestId, pending] of ctx.pendingCapabilityRequests.entries()) {
+		if (!filter({ requestId, ...pending }) || pending.disconnectTimer) continue;
+		pending.disconnectTimer = setTimeout(() => {
+			cancelPendingCapabilityRequests(
+				ctx,
+				(request) => request.requestId === requestId,
+				reason,
+			);
+		}, timeoutMs);
+		retained += 1;
+	}
+	return retained;
+}
+
+export function claimPendingCapabilityRequests(
+	ctx: HubTransportContext,
+	sessionId: string,
+	capabilityNames: ReadonlySet<string>,
+	targetClientId: string,
+): number {
+	let claimed = 0;
+	for (const [requestId, pending] of ctx.pendingCapabilityRequests.entries()) {
+		if (
+			pending.sessionId !== sessionId ||
+			!capabilityNames.has(pending.capabilityName)
+		) {
+			continue;
+		}
+		const shouldReplay =
+			pending.targetClientId !== targetClientId || !!pending.disconnectTimer;
+		if (pending.disconnectTimer) {
+			clearTimeout(pending.disconnectTimer);
+			pending.disconnectTimer = undefined;
+		}
+		pending.targetClientId = targetClientId;
+		if (!shouldReplay) continue;
+		ctx.publish(
+			ctx.buildEvent(
+				"capability.requested",
+				{
+					requestId,
+					targetClientId,
+					capabilityName: pending.capabilityName,
+					payload: pending.payload ?? {},
+				},
+				sessionId,
+			),
+		);
+		claimed += 1;
+	}
+	return claimed;
 }
 
 export async function handleCapabilityRequest(
@@ -238,6 +325,7 @@ export function handleCapabilityRespond(
 		);
 	}
 	ctx.pendingCapabilityRequests.delete(requestId);
+	if (pending.disconnectTimer) clearTimeout(pending.disconnectTimer);
 	const payload =
 		envelope.payload?.payload &&
 		typeof envelope.payload.payload === "object" &&

--- a/sdk/packages/core/src/hub/server/handlers/context.ts
+++ b/sdk/packages/core/src/hub/server/handlers/context.ts
@@ -33,6 +33,8 @@ export type PendingCapabilityRequest = {
 	sessionId: string;
 	targetClientId: string;
 	capabilityName: string;
+	payload?: Record<string, unknown>;
+	disconnectTimer?: ReturnType<typeof setTimeout>;
 	onProgress?: (payload: Record<string, unknown>) => void;
 	resolve: (result: {
 		ok: boolean;

--- a/sdk/packages/core/src/hub/server/handlers/context.ts
+++ b/sdk/packages/core/src/hub/server/handlers/context.ts
@@ -178,6 +178,54 @@ export async function readCoreSessionSnapshot(
 	});
 }
 
+export function cancelContributionOwnerEviction(state: HubSessionState): void {
+	if (state.contributionOwnerEvictionTimer) {
+		clearTimeout(state.contributionOwnerEvictionTimer);
+		state.contributionOwnerEvictionTimer = undefined;
+	}
+}
+
+/**
+ * Session state without participants is kept alive only so a reconnecting
+ * client can reclaim its contributions; evict it once the grace passes so a
+ * long-lived hub does not accumulate an entry per disconnected session.
+ */
+export function scheduleContributionOwnerEviction(
+	ctx: HubTransportContext,
+	sessionId: string,
+	timeoutMs: number,
+): void {
+	const state = ctx.sessionState.get(sessionId);
+	if (
+		!state ||
+		state.participants.size > 0 ||
+		!state.clientContributionOwners?.size ||
+		state.contributionOwnerEvictionTimer
+	) {
+		return;
+	}
+	state.contributionOwnerEvictionTimer = setTimeout(() => {
+		state.contributionOwnerEvictionTimer = undefined;
+		if (
+			ctx.sessionState.get(sessionId) === state &&
+			state.participants.size === 0
+		) {
+			ctx.sessionState.delete(sessionId);
+		}
+	}, timeoutMs);
+}
+
+export function deleteSessionState(
+	ctx: HubTransportContext,
+	sessionId: string,
+): void {
+	const state = ctx.sessionState.get(sessionId);
+	if (state) {
+		cancelContributionOwnerEviction(state);
+	}
+	ctx.sessionState.delete(sessionId);
+}
+
 export function ensureSessionState(
 	ctx: HubTransportContext,
 	sessionId: string,
@@ -187,6 +235,7 @@ export function ensureSessionState(
 ): HubSessionState {
 	const existing = ctx.sessionState.get(sessionId);
 	if (existing) {
+		cancelContributionOwnerEviction(existing);
 		if (options.interactive !== undefined) {
 			existing.interactive = options.interactive;
 		}
@@ -229,6 +278,7 @@ export function ensureSessionParticipant(
 ): HubSessionState {
 	const existing = ctx.sessionState.get(sessionId);
 	if (existing) {
+		cancelContributionOwnerEviction(existing);
 		if (options.interactive !== undefined) {
 			existing.interactive = options.interactive;
 		}

--- a/sdk/packages/core/src/hub/server/handlers/session-handlers.ts
+++ b/sdk/packages/core/src/hub/server/handlers/session-handlers.ts
@@ -28,6 +28,7 @@ import { toHubSessionRecord } from "../hub-session-records";
 import {
 	cancelPendingCapabilityRequests,
 	claimPendingCapabilityRequests,
+	isReconnectableCapability,
 } from "./capability-handlers";
 import {
 	asPlainRecord,
@@ -812,8 +813,10 @@ export async function handleSessionClaimClientContributions(
 		clientId,
 		"participant",
 	);
-	const claimedCapabilityNames = capabilityNames.filter((capabilityName) =>
-		state.clientContributionOwners?.has(capabilityName),
+	const claimedCapabilityNames = capabilityNames.filter(
+		(capabilityName) =>
+			isReconnectableCapability(capabilityName) &&
+			state.clientContributionOwners?.has(capabilityName),
 	);
 	for (const capabilityName of claimedCapabilityNames) {
 		state.clientContributionOwners?.set(capabilityName, clientId);
@@ -1114,6 +1117,11 @@ export async function handleSessionDelete(
 ): Promise<HubReplyEnvelope> {
 	const sessionId = extractSessionId(envelope);
 	const deleted = await ctx.sessionHost.deleteSession(sessionId);
+	cancelPendingCapabilityRequests(
+		ctx,
+		(request) => request.sessionId === sessionId,
+		`Session ${sessionId} was deleted before capability request was resolved.`,
+	);
 	ctx.sessionState.delete(sessionId);
 	return okReply(envelope, { deleted });
 }

--- a/sdk/packages/core/src/hub/server/handlers/session-handlers.ts
+++ b/sdk/packages/core/src/hub/server/handlers/session-handlers.ts
@@ -25,7 +25,10 @@ import {
 } from "../hub-client-contributions";
 import { logHubMessage } from "../hub-server-logging";
 import { toHubSessionRecord } from "../hub-session-records";
-import { cancelPendingCapabilityRequests } from "./capability-handlers";
+import {
+	cancelPendingCapabilityRequests,
+	claimPendingCapabilityRequests,
+} from "./capability-handlers";
 import {
 	asPlainRecord,
 	ensureSessionParticipant,
@@ -39,6 +42,41 @@ import {
 } from "./context";
 
 const CAPABILITY_OWNER_METADATA_KEY = "hubCapabilityOwnerClientId";
+
+function createClaimableClientContributionRuntime(
+	ctx: HubTransportContext,
+	input: {
+		sessionId: string;
+		clientId: string;
+		contributions: ReturnType<typeof parseHubClientContributions>;
+		sessionConfig?: Partial<RuntimeSessionConfig>;
+	},
+) {
+	const owners = new Map(
+		input.contributions.map((item) => [item.capabilityName, input.clientId]),
+	);
+	const runtime = createHubClientContributionRuntime({
+		sessionId: input.sessionId,
+		targetClientId: input.clientId,
+		contributions: input.contributions,
+		sessionConfig: input.sessionConfig,
+		requestCapability: (
+			sessionId,
+			capabilityName,
+			payload,
+			_targetClientId,
+			onProgress,
+		) =>
+			ctx.requestCapability(
+				sessionId,
+				capabilityName,
+				payload,
+				owners.get(capabilityName) ?? input.clientId,
+				onProgress,
+			),
+	});
+	return { owners, runtime };
+}
 
 function readConnectionString(value: unknown): string | undefined {
 	return typeof value === "string" && value.trim().length > 0
@@ -232,13 +270,13 @@ export async function handleSessionCreate(
 		sessionId,
 		configExtensionCount: configExtensions?.length ?? 0,
 	});
-	const clientContributionRuntime = createHubClientContributionRuntime({
+	const clientContribution = createClaimableClientContributionRuntime(ctx, {
 		sessionId,
-		targetClientId: clientId,
+		clientId,
 		contributions: clientContributions,
 		sessionConfig,
-		requestCapability: ctx.requestCapability,
 	});
+	const clientContributionRuntime = clientContribution.runtime;
 	logHubMessage("info", "session.create.start_session.begin", {
 		...baseLogContext,
 		sessionId,
@@ -356,9 +394,18 @@ export async function handleSessionCreate(
 		elapsedMs: Math.round(performance.now() - startedAt),
 		hasImmediateResult: !!started.result,
 	});
-	ensureSessionState(ctx, started.sessionId, clientId, "creator", {
-		interactive: metadata.interactive !== false,
-	});
+	const sessionState = ensureSessionState(
+		ctx,
+		started.sessionId,
+		clientId,
+		"creator",
+		{
+			interactive: metadata.interactive !== false,
+		},
+	);
+	if (clientContribution.owners.size > 0) {
+		sessionState.clientContributionOwners = clientContribution.owners;
+	}
 	logHubMessage("info", "session.create.read_records.begin", {
 		...baseLogContext,
 		sessionId: started.sessionId,
@@ -484,13 +531,13 @@ export async function handleSessionRestore(
 		const configExtensions = parseRuntimeConfigExtensions(
 			runtimeOptions.configExtensions,
 		);
-		const clientContributionRuntime = createHubClientContributionRuntime({
+		const clientContribution = createClaimableClientContributionRuntime(ctx, {
 			sessionId,
-			targetClientId: clientId,
+			clientId,
 			contributions: clientContributions,
 			sessionConfig,
-			requestCapability: ctx.requestCapability,
 		});
+		const clientContributionRuntime = clientContribution.runtime;
 		const service = new SessionVersioningService();
 		const result = await service.restoreCheckpoint({
 			sessionId: sourceSessionId,
@@ -635,9 +682,18 @@ export async function handleSessionRestore(
 				"Checkpoint restore did not start a session",
 			);
 		}
-		ensureSessionState(ctx, started.sessionId, clientId, "creator", {
-			interactive: metadata.interactive !== false,
-		});
+		const sessionState = ensureSessionState(
+			ctx,
+			started.sessionId,
+			clientId,
+			"creator",
+			{
+				interactive: metadata.interactive !== false,
+			},
+		);
+		if (clientContribution.owners.size > 0) {
+			sessionState.clientContributionOwners = clientContribution.owners;
+		}
 		const [session, snapshot] = await Promise.all([
 			readHubSessionRecord(ctx, started.sessionId),
 			readCoreSessionSnapshot(ctx, started.sessionId),
@@ -712,6 +768,68 @@ export async function handleSessionAttach(
 	return okReply(envelope, { session: attachedSession ?? session });
 }
 
+export async function handleSessionClaimClientContributions(
+	ctx: HubTransportContext,
+	envelope: HubCommandEnvelope,
+): Promise<HubReplyEnvelope> {
+	const sessionId = extractSessionId(envelope);
+	const capabilityNames = Array.isArray(envelope.payload?.capabilityNames)
+		? [
+				...new Set(
+					envelope.payload.capabilityNames
+						.filter((name): name is string => typeof name === "string")
+						.map((name) => name.trim())
+						.filter(Boolean),
+				),
+			]
+		: [];
+	if (!sessionId || capabilityNames.length === 0) {
+		return errorReply(
+			envelope,
+			"invalid_contribution_claim",
+			"session.claim_client_contributions requires sessionId and capabilityNames",
+		);
+	}
+	const clientId = envelope.clientId?.trim() || "";
+	if (!clientId || !ctx.clients.has(clientId)) {
+		return errorReply(
+			envelope,
+			"client_not_found",
+			"Client is not registered with this hub.",
+		);
+	}
+	const session = await readHubSessionRecord(ctx, sessionId);
+	if (!session) {
+		return errorReply(
+			envelope,
+			"session_not_found",
+			`Unknown session: ${sessionId}`,
+		);
+	}
+	const state = ensureSessionParticipant(
+		ctx,
+		sessionId,
+		clientId,
+		"participant",
+	);
+	const claimedCapabilityNames = capabilityNames.filter((capabilityName) =>
+		state.clientContributionOwners?.has(capabilityName),
+	);
+	for (const capabilityName of claimedCapabilityNames) {
+		state.clientContributionOwners?.set(capabilityName, clientId);
+	}
+	claimPendingCapabilityRequests(
+		ctx,
+		sessionId,
+		new Set(claimedCapabilityNames),
+		clientId,
+	);
+	return okReply(envelope, {
+		sessionId,
+		capabilityNames: claimedCapabilityNames,
+	});
+}
+
 export async function handleSessionDetach(
 	ctx: HubTransportContext,
 	envelope: HubCommandEnvelope,
@@ -731,7 +849,10 @@ export async function handleSessionDetach(
 		if (state.createdByClientId === clientId) {
 			state.createdByClientId = undefined;
 		}
-		if (state.participants.size === 0) {
+		if (
+			state.participants.size === 0 &&
+			!state.clientContributionOwners?.size
+		) {
 			ctx.sessionState.delete(sessionId);
 		}
 	}

--- a/sdk/packages/core/src/hub/server/handlers/session-handlers.ts
+++ b/sdk/packages/core/src/hub/server/handlers/session-handlers.ts
@@ -26,12 +26,14 @@ import {
 import { logHubMessage } from "../hub-server-logging";
 import { toHubSessionRecord } from "../hub-session-records";
 import {
+	CAPABILITY_RECONNECT_GRACE_MS,
 	cancelPendingCapabilityRequests,
 	claimPendingCapabilityRequests,
 	isReconnectableCapability,
 } from "./capability-handlers";
 import {
 	asPlainRecord,
+	deleteSessionState,
 	ensureSessionParticipant,
 	ensureSessionState,
 	errorReply,
@@ -40,6 +42,7 @@ import {
 	okReply,
 	readCoreSessionSnapshot,
 	readHubSessionRecord,
+	scheduleContributionOwnerEviction,
 } from "./context";
 
 const CAPABILITY_OWNER_METADATA_KEY = "hubCapabilityOwnerClientId";
@@ -821,15 +824,22 @@ export async function handleSessionClaimClientContributions(
 	for (const capabilityName of claimedCapabilityNames) {
 		state.clientContributionOwners?.set(capabilityName, clientId);
 	}
-	claimPendingCapabilityRequests(
+	const pendingRequests = claimPendingCapabilityRequests(
 		ctx,
 		sessionId,
 		new Set(claimedCapabilityNames),
 		clientId,
 	);
+	logHubMessage("info", "session.claim_client_contributions", {
+		sessionId,
+		clientId,
+		capabilityNames: claimedCapabilityNames,
+		pendingRequestCount: pendingRequests.length,
+	});
 	return okReply(envelope, {
 		sessionId,
 		capabilityNames: claimedCapabilityNames,
+		pendingRequests,
 	});
 }
 
@@ -852,11 +862,16 @@ export async function handleSessionDetach(
 		if (state.createdByClientId === clientId) {
 			state.createdByClientId = undefined;
 		}
-		if (
-			state.participants.size === 0 &&
-			!state.clientContributionOwners?.size
-		) {
-			ctx.sessionState.delete(sessionId);
+		if (state.participants.size === 0) {
+			if (state.clientContributionOwners?.size) {
+				scheduleContributionOwnerEviction(
+					ctx,
+					sessionId,
+					CAPABILITY_RECONNECT_GRACE_MS,
+				);
+			} else {
+				ctx.sessionState.delete(sessionId);
+			}
 		}
 	}
 	cancelPendingCapabilityRequests(
@@ -1117,12 +1132,14 @@ export async function handleSessionDelete(
 ): Promise<HubReplyEnvelope> {
 	const sessionId = extractSessionId(envelope);
 	const deleted = await ctx.sessionHost.deleteSession(sessionId);
-	cancelPendingCapabilityRequests(
-		ctx,
-		(request) => request.sessionId === sessionId,
-		`Session ${sessionId} was deleted before capability request was resolved.`,
-	);
-	ctx.sessionState.delete(sessionId);
+	if (deleted) {
+		cancelPendingCapabilityRequests(
+			ctx,
+			(request) => request.sessionId === sessionId,
+			`Session ${sessionId} was deleted before capability request was resolved.`,
+		);
+		deleteSessionState(ctx, sessionId);
+	}
 	return okReply(envelope, { deleted });
 }
 

--- a/sdk/packages/core/src/hub/server/handlers/session-handlers.ts
+++ b/sdk/packages/core/src/hub/server/handlers/session-handlers.ts
@@ -33,6 +33,7 @@ import {
 } from "./capability-handlers";
 import {
 	asPlainRecord,
+	cancelContributionOwnerEviction,
 	deleteSessionState,
 	ensureSessionParticipant,
 	ensureSessionState,
@@ -802,12 +803,38 @@ export async function handleSessionClaimClientContributions(
 			"Client is not registered with this hub.",
 		);
 	}
-	const session = await readHubSessionRecord(ctx, sessionId);
+	const existingState = ctx.sessionState.get(sessionId);
+	if (existingState) cancelContributionOwnerEviction(existingState);
+	const session = await readHubSessionRecord(ctx, sessionId).catch((error) => {
+		scheduleContributionOwnerEviction(
+			ctx,
+			sessionId,
+			CAPABILITY_RECONNECT_GRACE_MS,
+		);
+		throw error;
+	});
 	if (!session) {
+		scheduleContributionOwnerEviction(
+			ctx,
+			sessionId,
+			CAPABILITY_RECONNECT_GRACE_MS,
+		);
 		return errorReply(
 			envelope,
 			"session_not_found",
 			`Unknown session: ${sessionId}`,
+		);
+	}
+	if (!ctx.clients.has(clientId)) {
+		scheduleContributionOwnerEviction(
+			ctx,
+			sessionId,
+			CAPABILITY_RECONNECT_GRACE_MS,
+		);
+		return errorReply(
+			envelope,
+			"client_not_found",
+			"Client disconnected before its contribution claim completed.",
 		);
 	}
 	const state = ensureSessionParticipant(
@@ -1132,7 +1159,9 @@ export async function handleSessionDelete(
 ): Promise<HubReplyEnvelope> {
 	const sessionId = extractSessionId(envelope);
 	const deleted = await ctx.sessionHost.deleteSession(sessionId);
-	if (deleted) {
+	const sessionAbsent =
+		deleted || !(await ctx.sessionHost.getSession(sessionId));
+	if (sessionAbsent) {
 		cancelPendingCapabilityRequests(
 			ctx,
 			(request) => request.sessionId === sessionId,

--- a/sdk/packages/core/src/hub/server/hub-server-transport.ts
+++ b/sdk/packages/core/src/hub/server/hub-server-transport.ts
@@ -51,6 +51,7 @@ import {
 	okReply,
 	type PendingApproval,
 	type PendingCapabilityRequest,
+	scheduleContributionOwnerEviction,
 } from "./handlers/context";
 import {
 	handleRunAbort,
@@ -566,11 +567,16 @@ export class HubServerTransport implements NativeHubTransport {
 			if (state.createdByClientId === clientId) {
 				state.createdByClientId = undefined;
 			}
-			if (
-				state.participants.size === 0 &&
-				!state.clientContributionOwners?.size
-			) {
-				this.sessionState.delete(sessionId);
+			if (state.participants.size === 0) {
+				if (state.clientContributionOwners?.size) {
+					scheduleContributionOwnerEviction(
+						this.ctx,
+						sessionId,
+						CAPABILITY_RECONNECT_GRACE_MS,
+					);
+				} else {
+					this.sessionState.delete(sessionId);
+				}
 			}
 		}
 		retainPendingCapabilityRequestsForReconnect(

--- a/sdk/packages/core/src/hub/server/hub-server-transport.ts
+++ b/sdk/packages/core/src/hub/server/hub-server-transport.ts
@@ -29,11 +29,14 @@ import {
 	resolvePendingApproval,
 } from "./handlers/approval-handlers";
 import {
+	CAPABILITY_RECONNECT_GRACE_MS,
 	cancelPendingCapabilityRequests,
 	handleCapabilityProgress,
 	handleCapabilityRequest,
 	handleCapabilityRespond,
+	isReconnectableCapability,
 	requestCapability as requestCapabilityHandler,
+	retainPendingCapabilityRequestsForReconnect,
 } from "./handlers/capability-handlers";
 import {
 	handleClientList,
@@ -57,6 +60,7 @@ import {
 import { projectSessionEvent } from "./handlers/session-event-projector";
 import {
 	handleSessionAttach,
+	handleSessionClaimClientContributions,
 	handleSessionCompactionGet,
 	handleSessionCompactionUpdate,
 	handleSessionCreate,
@@ -359,6 +363,8 @@ export class HubServerTransport implements NativeHubTransport {
 				);
 			case "session.attach":
 				return await handleSessionAttach(this.ctx, envelope);
+			case "session.claim_client_contributions":
+				return await handleSessionClaimClientContributions(this.ctx, envelope);
 			case "session.detach":
 				return await handleSessionDetach(this.ctx, envelope);
 			case "session.get":
@@ -560,13 +566,26 @@ export class HubServerTransport implements NativeHubTransport {
 			if (state.createdByClientId === clientId) {
 				state.createdByClientId = undefined;
 			}
-			if (state.participants.size === 0) {
+			if (
+				state.participants.size === 0 &&
+				!state.clientContributionOwners?.size
+			) {
 				this.sessionState.delete(sessionId);
 			}
 		}
+		retainPendingCapabilityRequestsForReconnect(
+			this.ctx,
+			(request) =>
+				request.targetClientId === clientId &&
+				isReconnectableCapability(request.capabilityName),
+			CAPABILITY_RECONNECT_GRACE_MS,
+			`Capability owner client ${clientId} did not reconnect before the grace period expired.`,
+		);
 		cancelPendingCapabilityRequests(
 			this.ctx,
-			(request) => request.targetClientId === clientId,
+			(request) =>
+				request.targetClientId === clientId &&
+				!isReconnectableCapability(request.capabilityName),
 			`Capability owner client ${clientId} disconnected before request was resolved.`,
 		);
 	}

--- a/sdk/packages/core/src/hub/server/hub-server-transport.ts
+++ b/sdk/packages/core/src/hub/server/hub-server-transport.ts
@@ -47,6 +47,7 @@ import {
 import { handleConnectorCommand } from "./handlers/connector-handlers";
 import {
 	buildHubEvent,
+	cancelContributionOwnerEviction,
 	type HubTransportContext,
 	okReply,
 	type PendingApproval,
@@ -304,6 +305,9 @@ export class HubServerTransport implements NativeHubTransport {
 			() => true,
 			"Hub shutting down before capability request was resolved.",
 		);
+		for (const state of this.sessionState.values()) {
+			cancelContributionOwnerEviction(state);
+		}
 		await this.sessionHost.dispose("hub_server_stop");
 		await this.schedules.dispose();
 		if (this.cronService) {

--- a/sdk/packages/core/src/hub/server/hub-session-records.ts
+++ b/sdk/packages/core/src/hub/server/hub-session-records.ts
@@ -9,6 +9,8 @@ import type { SessionRecord as LocalSessionRecord } from "../../types/sessions";
 export type HubSessionState = {
 	createdByClientId?: string;
 	clientContributionOwners?: Map<string, string>;
+	// Evicts participant-less state kept alive only for contribution reclaims.
+	contributionOwnerEvictionTimer?: ReturnType<typeof setTimeout>;
 	interactive: boolean;
 	participants: Map<string, SessionParticipant>;
 };

--- a/sdk/packages/core/src/hub/server/hub-session-records.ts
+++ b/sdk/packages/core/src/hub/server/hub-session-records.ts
@@ -8,6 +8,7 @@ import type { SessionRecord as LocalSessionRecord } from "../../types/sessions";
 
 export type HubSessionState = {
 	createdByClientId?: string;
+	clientContributionOwners?: Map<string, string>;
 	interactive: boolean;
 	participants: Map<string, SessionParticipant>;
 };

--- a/sdk/packages/shared/src/hub.ts
+++ b/sdk/packages/shared/src/hub.ts
@@ -409,6 +409,7 @@ export type HubCommandName =
 	| "session.list"
 	| "session.create"
 	| "session.attach"
+	| "session.claim_client_contributions"
 	| "session.detach"
 	| "session.get"
 	| "session.messages"


### PR DESCRIPTION
## Summary

- add an explicit `session.claim_client_contributions` command for reconnecting ask-question clients
- rebind future `tool_executor.askQuestion` requests to the claiming client
- replay pending questions during a bounded 30-second reconnect grace
- clean retained requests and ownership on expiry, session deletion, and Hub shutdown

## Scope

This is limited to the existing `askQuestion` tool-executor contribution. Unrelated capabilities retain their current immediate-disconnect cancellation behavior. Claims use the existing authenticated Hub-client trust boundary and explicit last-claim-wins ownership.

An abrupt client disconnect retains pending questions for 30 seconds so a registered replacement client can explicitly claim them. Expiry removes claimability. Explicit `session.detach` remains deliberate abandonment and cancels pending requests immediately.

The core-platform UI integration is separate and depends on this command.

## Staging reproduction — September 17

A controlled test against staging build `staging-20260917-954-b2d4a0279` reproduced pending-question loss in a disposable session: an `askQuestion` prompt was visible, the actual WebSocket was closed (native close callback confirmed code 4001), and after automatic reconnect the options were absent and the run completed. No answer was submitted; the assistant emitted the unique marker requested if the question failed or was cancelled. This verifies loss of the question across that disconnect, but browser evidence alone does not identify the server's internal cancellation/error reason.

The deployed runtime returned `unsupported_command` for `session.claim_client_contributions`, so this reproduces existing behavior, **not validation of this PR's fix**. An earlier browser-only close left the underlying server connection alive and accepted an answer; that result was excluded as evidence of real-disconnect recovery, and the test was corrected before the reproduction above.

[core-platform#3396](https://github.com/cline/core-platform/pull/3396) contains the related dashboard recovery integration and compatibility fallback. Preserving questions requires a runtime with this command and client integration; deploying the dashboard alone cannot provide retention on the tested legacy runtime. End-to-end staging verification of the combined changes remains outstanding. Production was untouched.

## Validation

- focused Hub boundary tests: 42/42
- full core unit suite: 1,541 passed, 4 skipped
- core typecheck and smoke typecheck
- Biome and git diff checks