### PR TITLE
Fix ACP ClinePass authentication method

### DIFF
--- a/apps/cli/src/acp/auth-methods.ts
+++ b/apps/cli/src/acp/auth-methods.ts
@@ -1,0 +1,12 @@
+/** Supported ACP OAuth provider IDs. */
+export const ACP_AUTH_METHODS = [
+	{ id: "cline", name: "Sign in with Cline" },
+	{ id: "cline-pass", name: "Sign in with ClinePass" },
+	{ id: "openai-codex", name: "Sign in with ChatGPT Subscription" },
+] as const;
+
+export type AcpAuthMethodId = (typeof ACP_AUTH_METHODS)[number]["id"];
+
+export function isAcpAuthMethodId(id: string): id is AcpAuthMethodId {
+	return ACP_AUTH_METHODS.some((method) => method.id === id);
+}

--- a/apps/cli/src/acp/auth.test.ts
+++ b/apps/cli/src/acp/auth.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { ACP_AUTH_METHODS, isAcpAuthMethodId } from "./auth-methods";
+
+describe("ACP authentication methods", () => {
+	it("advertises and accepts ClinePass", () => {
+		expect(ACP_AUTH_METHODS).toContainEqual({
+			id: "cline-pass",
+			name: "Sign in with ClinePass",
+		});
+		expect(isAcpAuthMethodId("cline-pass")).toBe(true);
+	});
+});

--- a/apps/cli/src/acp/auth.ts
+++ b/apps/cli/src/acp/auth.ts
@@ -2,20 +2,10 @@ import type { ProviderSettingsManager } from "@cline/core";
 import { loginAndSaveProviderOAuthCredentials } from "@cline/core";
 import { getPersistedProviderApiKey } from "../commands/auth";
 import { writeDiagnostic } from "../utils/output";
+import type { AcpAuthMethodId } from "./auth-methods";
 
-/**
- * Supported ACP OAuth provider IDs.
- */
-export const ACP_AUTH_METHODS = [
-	{ id: "cline", name: "Sign in with Cline" },
-	{ id: "openai-codex", name: "Sign in with ChatGPT Subscription" },
-] as const;
-
-export type AcpAuthMethodId = (typeof ACP_AUTH_METHODS)[number]["id"];
-
-export function isAcpAuthMethodId(id: string): id is AcpAuthMethodId {
-	return ACP_AUTH_METHODS.some((m) => m.id === id);
-}
+export type { AcpAuthMethodId } from "./auth-methods";
+export { ACP_AUTH_METHODS, isAcpAuthMethodId } from "./auth-methods";
 
 /**
  * Perform an OAuth login for the given provider in ACP mode.


### PR DESCRIPTION
## Summary
- advertise ClinePass in the ACP initialization response
- accept and restore ClinePass through the shared ACP auth-method registry
- add a regression test for the advertised ClinePass method

Fixes #12738

## Testing
- `bunx vitest run src/acp/auth.test.ts`
- `bunx biome check --config-path ../../apps/vscode/biome.jsonc --no-errors-on-unmatched src/acp/auth-methods.ts src/acp/auth.ts src/acp/auth.test.ts`
- `bun run typecheck` is blocked by the pre-existing SAP provider type error in `sdk/packages/llms/src/providers/vendors/community.ts:361`