### PR TITLE
fix(cli): silence "dialog-container is not a child of __root__" warning on exit

### DIFF
--- a/patches/@opentui-ui%2Fdialog@0.1.2.patch
+++ b/patches/@opentui-ui%2Fdialog@0.1.2.patch
@@ -12,28 +12,26 @@ index fa1f29023479d5df2daf399c42f1d492365365aa..9a576b394c551269e6944bbb08fb43f7
  			this.updateBackdropVisibility();
  			this.updateBackdropStyle();
 diff --git a/dist/react.mjs b/dist/react.mjs
-index 157bd9c3ba3101810e02da720b8763425fd7b0fd..70bb55028ff815a82fea84205c61fb85d2aac03a 100644
+index 157bd9c3ba3101810e02da720b8763425fd7b0fd..72b2249b64db9c947bdb0bdd65d9cd63894ae83b 100644
 --- a/dist/react.mjs
 +++ b/dist/react.mjs
-@@ -169,7 +169,7 @@ function DialogProvider(props) {
+@@ -169,7 +169,6 @@ function DialogProvider(props) {
  		renderer.root.add(container);
  		return () => {
  			container.destroyRecursively();
 -			renderer.root.remove(container.id);
-+			renderer.root.remove(container);
  			manager.destroy();
  		};
  	}, [
 diff --git a/dist/solid.mjs b/dist/solid.mjs
-index 2aea0ede350d79b5a8e533323fe70480bbd7f3ce..f075087a57c68875f341baa9ada67231fcc9cb10 100644
+index 2aea0ede350d79b5a8e533323fe70480bbd7f3ce..d3f518b3d77c10c06aa1ae2b591f995fe2ebda68 100644
 --- a/dist/solid.mjs
 +++ b/dist/solid.mjs
-@@ -192,7 +192,7 @@ function DialogProvider(props) {
+@@ -192,7 +192,6 @@ function DialogProvider(props) {
  		unsubscribe();
  		portalItemCache.clear();
  		container.destroyRecursively();
 -		renderer.root.remove(container.id);
-+		renderer.root.remove(container);
  		manager.destroy();
  	});
  	createEffect(() => {


### PR DESCRIPTION
### Related Issue

**Issue:** N/A (reported directly: exiting the CLI after opening a dialog, e.g. switching providers in `/settings`, prints `Renderable with id dialog-container is not a child of __root__, skipping remove`)

### Description

On CLI exit, `renderOpenTui`'s `destroy()` unmounts the React root and then destroys the renderer in a microtask. `renderer.destroy()` runs `root.destroyRecursively()`, which detaches and destroys the `dialog-container` renderable. React only flushes the `DialogProvider`'s passive `useEffect` cleanup afterwards (on a macrotask), and that cleanup called `renderer.root.remove(container)` on a container that was no longer a child of root — triggering OpenTUI core's `Renderable with id dialog-container is not a child of __root__, skipping remove` warning.

The fix updates the existing `patches/@opentui-ui%2Fdialog@0.1.2.patch` to drop the explicit `renderer.root.remove(...)` call from the `DialogProvider` cleanup in both the react and solid entry points. It is redundant and unsafe:

- `Renderable.destroy()` already calls `this.parent.remove(this)` when the container is still attached (normal mid-session unmount), so removal stays correct.
- When the renderer teardown has already destroyed the container (CLI exit), `destroyRecursively()` no-ops via the `_isDestroyed` guard instead of warning.

### Test Procedure

- Reproduced the warning before the fix: configured a provider, ran `bun run cli -i` in tmux, opened `/settings`, switched provider Anthropic → OpenRouter, closed the dialog, exited with Ctrl+C — the warning printed after teardown.
- Traced the source by temporarily adding a stack trace to OpenTUI core's warning: it fired from the `DialogProvider` unmount cleanup in `@opentui-ui/dialog/dist/react.mjs`, after `renderer.destroy()` had already detached the container (instrumentation reverted).
- Verified after the fix with the exact same flow (settings → switch provider to OpenRouter → close → exit): exit output is clean, no warning.

Before:

```
$ CLINE_BUILD_ENV=development bun --conditions=development ./src/index.ts -i
Renderable with id dialog-container is not a child of __root__, skipping remove
```

After:

```
$ CLINE_BUILD_ENV=development bun --conditions=development ./src/index.ts -i
```

- Confirmed the edited patch still applies cleanly with a fresh `bun install`.
- `bun -F @cline/cli test:unit`: 122 files, 974 tests, all passing.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Terminal-only change; before/after exit output shown in the Test Procedure section.

### Additional Notes

The dropped `renderer.root.remove(container.id)` line was already broken upstream (core's `remove()` expects a renderable object, not an id, and throws on strings) — the existing patch had converted it to `remove(container)`, but any ordering of an explicit remove still warns in one of the two teardown scenarios, so removing the call entirely is the correct fix for both.