### PR TITLE
Remove CLI Promo Code

### DIFF
--- a/apps/cli/src/kanban-migration/notice-dialog.tsx
+++ b/apps/cli/src/kanban-migration/notice-dialog.tsx
@@ -48,7 +48,7 @@ export function MigrationNoticeContent(
 					latest open-weight coding models with enough quota for day-to-day
 					work, at a much lower cost than paying API costs directly.
 				</text>
-				<text selectable>Try it now with a limited-time promo for $1.99.</text>
+				<text selectable>Try it now with a limited-time promo for $4.99.</text>
 			</box>
 			<box flexDirection="row">
 				<text fg={palette.act} selectable>

--- a/apps/cli/src/runtime/run-agent.test.ts
+++ b/apps/cli/src/runtime/run-agent.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getCliSubscriptionUrl } from "../utils/cline-pass-errors";
 
 const sessionManagerMocks = vi.hoisted(() => ({
 	start: vi.fn(),
@@ -39,10 +40,8 @@ const sessionEventsMocks = vi.hoisted(() => ({
 
 const CLINE_PASS_SUBSCRIPTION_URL =
 	"https://app.cline.bot/dashboard/subscription?personal=true";
-const CLI_SUBSCRIPTION_URL =
-	"https://app.cline.bot/promo?code=CLI-8OFF&personal=true";
 const SDK_CLINE_PASS_SUBSCRIPTION_MESSAGE = `No access to ClinePass subscription models yet. Subscribe to ClinePass, the low cost open weights model coding plan: ${CLINE_PASS_SUBSCRIPTION_URL}`;
-const CLI_CLINE_PASS_SUBSCRIPTION_MESSAGE = `No access to ClinePass subscription models yet. Subscribe to ClinePass, the low cost open weights model coding plan: ${CLI_SUBSCRIPTION_URL}`;
+const CLI_CLINE_PASS_SUBSCRIPTION_MESSAGE = `No access to ClinePass subscription models yet. Subscribe to ClinePass, the low cost open weights model coding plan: ${getCliSubscriptionUrl()}`;
 const CLINE_PASS_LIMIT_DETAIL_MESSAGE =
 	"You have reached your 5-hour Clinepass limit. The limit resets in 5h, please try again later.";
 const CLI_CLINE_PASS_LIMIT_MESSAGE = [

--- a/apps/cli/src/tui/components/dialogs/provider-picker-helpers.ts
+++ b/apps/cli/src/tui/components/dialogs/provider-picker-helpers.ts
@@ -53,6 +53,8 @@ export function buildClinePassSubscriptionPageUrl(
 		appBaseUrl || DEFAULT_APP_BASE_URL,
 	);
 	url.searchParams.set("personal", "true");
-	url.searchParams.set("code", CLI_PROMO_CODE);
+	if(CLI_PROMO_CODE) {
+		url.searchParams.set("code", CLI_PROMO_CODE);
+	}
 	return url.toString();
 }

--- a/apps/cli/src/tui/components/dialogs/provider-picker.test.ts
+++ b/apps/cli/src/tui/components/dialogs/provider-picker.test.ts
@@ -14,17 +14,21 @@ import {
 
 describe("buildClinePassSubscriptionPageUrl", () => {
 	it("opens the personal subscription page on production by default", () => {
-		expect(buildClinePassSubscriptionPageUrl(undefined)).toBe(
-			"https://app.cline.bot/dashboard/subscription?personal=true&code=CLI-8OFF",
-		);
+		expect(
+			buildClinePassSubscriptionPageUrl(undefined).startsWith(
+				"https://app.cline.bot/dashboard/subscription?personal=true",
+			),
+		).toBe(true);
 	});
 
 	it("keeps the configured app base URL", () => {
 		expect(
-			buildClinePassSubscriptionPageUrl("https://staging-app.cline.bot"),
-		).toBe(
-			"https://staging-app.cline.bot/dashboard/subscription?personal=true&code=CLI-8OFF",
-		);
+			buildClinePassSubscriptionPageUrl(
+				"https://staging-app.cline.bot",
+			).startsWith(
+				"https://staging-app.cline.bot/dashboard/subscription?personal=true",
+			),
+		).toBe(true);
 	});
 });
 

--- a/apps/cli/src/utils/cline-pass-errors.test.ts
+++ b/apps/cli/src/utils/cline-pass-errors.test.ts
@@ -6,7 +6,6 @@ import {
 	getCliNotSubscribedMessage,
 	getClineOrgIndividualInferenceSubscriptionMessage,
 	getClinePassLimitDetailMessage,
-	getCliSubscriptionUrl,
 	isClineFreeModelLimitErrorMessage,
 	isClineFreePromotionEndedErrorMessage,
 	isClineOrgIndividualInferenceSubscriptionErrorMessage,

--- a/apps/cli/src/utils/cline-pass-errors.test.ts
+++ b/apps/cli/src/utils/cline-pass-errors.test.ts
@@ -29,13 +29,7 @@ describe("cline-pass-errors", () => {
 		expect(isClinePassSubscriptionError(formatted)).toBe(true);
 		expect(formatCliErrorMessage(new Error(sdkFormatted))).toBe(formatted);
 		expect(formatCliErrorMessage(new Error(formatted))).toBe(formatted);
-	});
-
-	it("formats the ClinePass subscription URL", () => {
-		expect(getCliSubscriptionUrl()).toBe(
-			"https://app.cline.bot/promo?code=CLI-8OFF&personal=true",
-		);
-	});
+	});	
 
 	it("recognizes and formats organization account individual subscription errors", () => {
 		const raw =

--- a/apps/cli/src/utils/cline-pass-errors.ts
+++ b/apps/cli/src/utils/cline-pass-errors.ts
@@ -18,9 +18,16 @@ import { getClineEnvironmentConfig } from "@cline/shared";
 
 export { getClineOrgIndividualInferenceSubscriptionMessage };
 
-export const CLI_PROMO_CODE = "CLI-8OFF";
+export const CLI_PROMO_CODE = "";
 
 export function getCliSubscriptionUrl(): string {
+	if(!CLI_PROMO_CODE) {
+		return new URL(
+			`/dashboard/subscription?personal=true`,
+			getClineEnvironmentConfig().appBaseUrl,
+		).toString()
+	}
+
 	return `${new URL(
 		`/promo?code=${CLI_PROMO_CODE}&personal=true`,
 		getClineEnvironmentConfig().appBaseUrl,

--- a/apps/vscode/src/services/error/__tests__/ClineError.test.ts
+++ b/apps/vscode/src/services/error/__tests__/ClineError.test.ts
@@ -11,7 +11,7 @@ describe("ClineError", () => {
 
 		it("should return Entitlement for the SDK ClinePass subscription message", () => {
 			const err = new ClineError(
-				"No access to ClinePass subscription models yet. Subscribe to ClinePass, the low cost open weights model coding plan: https://app.cline.bot/promo?code=CLI-8OFF&personal=true",
+				"No access to ClinePass subscription models yet. Subscribe to ClinePass, the low cost open weights model coding plan:",
 			)
 
 			ClineError.getErrorType(err)!.should.equal(ClineErrorType.Entitlement)
@@ -19,7 +19,7 @@ describe("ClineError", () => {
 
 		it("should return Entitlement for the SDK ClinePass subscription message with a different app URL", () => {
 			const err = new ClineError(
-				"No access to ClinePass subscription models yet. Subscribe to ClinePass, the low cost open weights model coding plan: https://staging-app.cline.bot/promo?code=CLI-8OFF&personal=true",
+				"No access to ClinePass subscription models yet. Subscribe to ClinePass, the low cost open weights model coding plan:",
 			)
 
 			ClineError.getErrorType(err)!.should.equal(ClineErrorType.Entitlement)

--- a/apps/vscode/webview-ui/src/components/chat/ErrorRow.stories.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ErrorRow.stories.tsx
@@ -220,7 +220,7 @@ export const ClinePassEntitlementError: Story = {
 		message: createMockMessage(),
 		errorType: "error",
 		apiRequestFailedMessage:
-			"No access to ClinePass subscription models yet. Subscribe to ClinePass, the low cost open weights model coding plan: https://app.cline.bot/promo?code=CLI-8OFF&personal=true",
+			"No access to ClinePass subscription models yet. Subscribe to ClinePass, the low cost open weights model coding plan:",
 	},
 	parameters: {
 		docs: {

--- a/apps/vscode/webview-ui/src/components/chat/ErrorRow.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ErrorRow.test.tsx
@@ -196,7 +196,7 @@ describe("ErrorRow", () => {
 
 		it("renders entitlement error when ClineError detects ClineNotSubscribedError", async () => {
 			const cliMessage =
-				"No access to ClinePass subscription models yet. Subscribe to ClinePass, the low cost open weights model coding plan: https://app.cline.bot/promo?code=CLI-8OFF&personal=true"
+				"No access to ClinePass subscription models yet. Subscribe to ClinePass, the low cost open weights model coding plan:"
 			const mockClineError = {
 				message: cliMessage,
 				isErrorType: vi.fn((type) => type === "entitlement"),

--- a/sdk/packages/llms/src/providers/format.test.ts
+++ b/sdk/packages/llms/src/providers/format.test.ts
@@ -90,7 +90,7 @@ describe("ClineNotSubscribedError", () => {
 	it("detects the formatted ClinePass subscription message regardless of URL", () => {
 		expect(
 			isClineNotSubscribedMessage(
-				"No access to ClinePass subscription models yet. Subscribe to ClinePass, the low cost open weights model coding plan: https://staging-app.cline.bot/promo?code=CLI-8OFF&personal=true",
+				"No access to ClinePass subscription models yet. Subscribe to ClinePass, the low cost open weights model coding plan:",
 			),
 		).toBe(true);
 	});


### PR DESCRIPTION
### Description

This PR removes the CLI promo code by making it optional. It leaves it defined for when we want to run another promo.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [X] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)