### PR TITLE
fix: surface upstream provider error from gateway-forwarded stream failures

### DIFF
--- a/sdk/packages/llms/src/providers/format.test.ts
+++ b/sdk/packages/llms/src/providers/format.test.ts
@@ -63,6 +63,49 @@ describe("extractErrorMessage", () => {
 			}),
 		).toBe("Missing upstream API key");
 	});
+
+	it("unwraps gateway-forwarded upstream errors from value.error_message", () => {
+		// Exact shape streamed by Vercel AI Gateway when the upstream provider
+		// (Alibaba Qwen) rejects a request: the gateway's own parse failure sits
+		// in message/cause, the real rejection is JSON-encoded in
+		// value.error_message.
+		const contextLengthMessage =
+			"This model's maximum context length is 40960 tokens. However, you requested 100 output tokens and your prompt contains at least 40861 input tokens.";
+		expect(
+			extractErrorMessage({
+				code: "error",
+				message: "Stream error occurred",
+				name: "AI_TypeValidationError",
+				cause: {
+					name: "ZodError",
+					message:
+						'[\n  {\n    "code": "invalid_union",\n    "path": [],\n    "message": "Invalid input"\n  }\n]',
+				},
+				value: {
+					error_type: "validation_error",
+					error_message: JSON.stringify({
+						error: {
+							message: contextLengthMessage,
+							code: 400,
+						},
+					}),
+				},
+			}),
+		).toBe(contextLengthMessage);
+	});
+
+	it("handles a plain-string value.error_message", () => {
+		expect(
+			extractErrorMessage({
+				message: "Stream error occurred",
+				value: { error_message: "upstream rejected the request" },
+			}),
+		).toBe("upstream rejected the request");
+	});
+
+	it("falls back to JSON instead of [object Object] for opaque objects", () => {
+		expect(extractErrorMessage({ status: 502 })).toBe('{"status":502}');
+	});
 });
 
 describe("ClineNotSubscribedError", () => {

--- a/sdk/packages/llms/src/providers/format.ts
+++ b/sdk/packages/llms/src/providers/format.ts
@@ -16,6 +16,7 @@ export function extractErrorMessage(error: unknown): string {
 			errors?: unknown;
 			detail?: string;
 			responseBody?: unknown;
+			value?: unknown;
 		};
 		if (typeof payload.error === "string" && payload.error.trim()) {
 			return payload.error;
@@ -37,6 +38,23 @@ export function extractErrorMessage(error: unknown): string {
 				if (nested) {
 					return nested;
 				}
+			}
+		}
+		// Some gateways forward the upstream provider's rejection under `value`,
+		// with the original response body JSON-encoded in `value.error_message`
+		// (e.g. Vercel AI Gateway relaying Alibaba Qwen context-length errors,
+		// where the top-level message is just "Stream error occurred" and the
+		// cause is an unrelated internal ZodError).
+		if (
+			payload.value &&
+			typeof payload.value === "object" &&
+			"error_message" in payload.value
+		) {
+			const nested = extractStructuredMessage(
+				(payload.value as { error_message?: unknown }).error_message,
+			);
+			if (nested) {
+				return nested;
 			}
 		}
 		if ("responseBody" in payload && payload.responseBody !== value) {
@@ -123,5 +141,17 @@ export function extractErrorMessage(error: unknown): string {
 		return structuredMessage;
 	}
 
+	// String() on a plain object yields "[object Object]" — JSON is at least
+	// actionable for the user and for error-classification downstream.
+	if (typeof error === "object" && error !== null) {
+		try {
+			const json = JSON.stringify(error);
+			if (json && json !== "{}") {
+				return json;
+			}
+		} catch {
+			// Circular payload — fall through to String(error).
+		}
+	}
 	return String(error);
 }

--- a/sdk/packages/llms/src/providers/format.ts
+++ b/sdk/packages/llms/src/providers/format.ts
@@ -1,3 +1,5 @@
+import { safeJsonParse, safeJsonStringify } from "@cline/shared";
+
 export function extractErrorMessage(error: unknown): string {
 	// Generic SDK wrappers carry no signal of their own — when present we prefer
 	// the underlying cause/detail (e.g. AI SDK's AI_NoOutputGeneratedError).
@@ -6,6 +8,11 @@ export function extractErrorMessage(error: unknown): string {
 	]);
 	const isGenericWrapperMessage = (message: string): boolean =>
 		GENERIC_WRAPPER_MESSAGES.has(message.trim().toLowerCase());
+
+	const hasErrorMessage = (
+		value: unknown,
+	): value is { error_message: unknown } =>
+		typeof value === "object" && value !== null && "error_message" in value;
 
 	// Pulls a human-readable message out of structured provider fields
 	// (error/detail/errors/responseBody) without falling back to a top-level
@@ -45,14 +52,8 @@ export function extractErrorMessage(error: unknown): string {
 		// (e.g. Vercel AI Gateway relaying Alibaba Qwen context-length errors,
 		// where the top-level message is just "Stream error occurred" and the
 		// cause is an unrelated internal ZodError).
-		if (
-			payload.value &&
-			typeof payload.value === "object" &&
-			"error_message" in payload.value
-		) {
-			const nested = extractStructuredMessage(
-				(payload.value as { error_message?: unknown }).error_message,
-			);
+		if (hasErrorMessage(payload.value)) {
+			const nested = extractStructuredMessage(payload.value.error_message);
 			if (nested) {
 				return nested;
 			}
@@ -71,11 +72,13 @@ export function extractErrorMessage(error: unknown): string {
 			return undefined;
 		}
 		if (typeof value === "string") {
-			try {
-				return extractStructuredMessage(JSON.parse(value));
-			} catch {
-				return value.trim() || undefined;
+			// JSON.parse never yields undefined, so undefined here means the
+			// string wasn't JSON — fall back to the trimmed string itself.
+			const parsed = safeJsonParse<unknown>(value);
+			if (parsed !== undefined) {
+				return extractStructuredMessage(parsed);
 			}
+			return value.trim() || undefined;
 		}
 		if (typeof value !== "object") {
 			return undefined;
@@ -144,13 +147,9 @@ export function extractErrorMessage(error: unknown): string {
 	// String() on a plain object yields "[object Object]" — JSON is at least
 	// actionable for the user and for error-classification downstream.
 	if (typeof error === "object" && error !== null) {
-		try {
-			const json = JSON.stringify(error);
-			if (json && json !== "{}") {
-				return json;
-			}
-		} catch {
-			// Circular payload — fall through to String(error).
+		const json = safeJsonStringify(error);
+		if (json && json !== "{}" && json !== "null") {
+			return json;
 		}
 	}
 	return String(error);


### PR DESCRIPTION
## Problem

When an upstream provider rejects a request mid-stream through Vercel AI Gateway (e.g. Alibaba Qwen context-length errors), the gateway streams its own internal parse failure: top-level `error.message` is just "Stream error occurred", `error.cause` is an internal ZodError, and the real rejection is JSON-encoded in `error.value.error_message`. Our extraction walked into the ZodError cause, so users saw a raw Zod `invalid_union` issue dump (or "Stream error occurred") instead of *"This model's maximum context length is 40960 tokens…"*.

Root-cause investigation: [ENG-2394](https://linear.app/cline-bot/issue/ENG-2394/vercel-ai-gateway-stream-error-occurred-on-final-response-synthesis) (reproduced against the live gateway; the error chunk shape in the new test is captured byte-for-byte from that repro).

## Fix

- `extractErrorMessage`: unwrap `value.error_message` (checked in the structured-detail pass, so it wins over the ZodError `cause`). The legacy arch's `context-error-handling.ts` already knew this exact shape — this ports the unwrapping half; detection/recovery is a separate follow-up.
- Final fallback now JSON-stringifies opaque object errors so the UI never renders `[object Object]`.

## Testing

- New unit tests in `format.test.ts` incl. the exact captured Vercel/Alibaba payload.
- `vitest run src/providers` in `sdk/packages/llms`: 22 files, 449 tests pass.