### PR TITLE
Resolve display names for Cline free models in the CLI and extension model pickers

### DIFF
--- a/apps/vscode/src/shared/api.ts
+++ b/apps/vscode/src/shared/api.ts
@@ -175,6 +175,22 @@ export function resolveClinePassModelInfo(modelId: string, modelInfoByName?: Rec
 	return modelInfoByName?.[getModelSlug(modelId)] ?? clinePassModelInfoSaneDefaults
 }
 
+/**
+ * Resolves a human-readable model name for featured model cards. The Cline
+ * recommended-models endpoint only sends slug-like names (e.g.
+ * "deepseek-v4-flash"), so prefer the display name from the provider model
+ * catalog, then any endpoint-provided fallback, then the raw id. Featured
+ * sections render their own FREE chip, so OpenRouter's "(free)" / ":free"
+ * markers are stripped as redundant.
+ */
+export function resolveDisplayModelName(modelId: string, models?: Record<string, ModelInfo>, fallbackName?: string): string {
+	const displayName = models?.[modelId]?.name?.trim() || fallbackName?.trim() || modelId
+	return displayName
+		.replace(/\s*\(free\)\s*$/i, "")
+		.replace(/:free$/i, "")
+		.trim()
+}
+
 export const openAiModelInfoSafeDefaults: OpenAiCompatibleModelInfo = {
 	maxTokens: -1,
 	contextWindow: 128_000,

--- a/apps/vscode/webview-ui/src/components/onboarding/useOnboardingModels.ts
+++ b/apps/vscode/webview-ui/src/components/onboarding/useOnboardingModels.ts
@@ -1,4 +1,4 @@
-import { buildModelInfoNameMap, type ModelInfo, resolveClinePassModelInfo } from "@shared/api"
+import { buildModelInfoNameMap, type ModelInfo, resolveClinePassModelInfo, resolveDisplayModelName } from "@shared/api"
 import { CLINE_ONBOARDING_MODELS } from "@shared/cline/onboarding"
 import { EmptyRequest } from "@shared/proto/cline/common"
 import type { ClineRecommendedModel } from "@shared/proto/cline/models"
@@ -28,7 +28,8 @@ function toOnboardingModel(
 
 	return {
 		id: rec.id,
-		name: rec.name || rec.id,
+		// The endpoint sends slug-like names, so prefer the catalog display name
+		name: resolveDisplayModelName(rec.id, modelCatalog, rec.name),
 		group,
 		badge,
 		score: 0,

--- a/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.test.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.test.tsx
@@ -99,13 +99,51 @@ describe("ClineModelPicker", () => {
 	it("commits Cline model selections through provider config so providers.json is updated", async () => {
 		render(<ClineModelPicker currentMode="act" />)
 
-		fireEvent.click(await screen.findByText("cline-next"))
+		// Featured cards render the catalog display name, but selection still
+		// commits the underlying model id.
+		fireEvent.click(await screen.findByText("Cline Next"))
 
 		await waitFor(() => expect(mocks.commitSelection).toHaveBeenCalledTimes(1))
 		expect(mocks.commitSelection).toHaveBeenCalledWith("act", {
 			providerId: "cline",
 			modelId: "cline-next",
 		})
+	})
+
+	it("resolves featured model display names from the provider catalog", async () => {
+		mocks.makeUnaryRequest.mockResolvedValueOnce({
+			recommended: [{ id: "anthropic/claude-opus-5", description: "Frontier model", tags: ["NEW"] }],
+			free: [
+				{ id: "deepseek/deepseek-v4-flash", description: "Fast and efficient", tags: [] },
+				{ id: "poolside/laguna-s-2.1:free", description: "Latest coding agent model", tags: [] },
+				{ id: "unknown/mystery-model", description: "Not in the catalog", tags: [] },
+			],
+		})
+		vi.mocked(useProviderModels).mockReturnValue({
+			models: {
+				"anthropic/claude-opus-5": { name: "Claude Opus 5", supportsPromptCache: true },
+				"deepseek/deepseek-v4-flash": { name: "DeepSeek V4 Flash", supportsPromptCache: true },
+				"poolside/laguna-s-2.1:free": { name: "Laguna S 2.1 (free)", supportsPromptCache: false },
+			},
+			defaultModelId: "anthropic/claude-opus-5",
+			isLoading: false,
+			isStale: false,
+			error: undefined,
+			refresh: vi.fn(),
+			fingerprint: "fingerprint",
+		})
+
+		render(<ClineModelPicker currentMode="act" />)
+
+		expect(await screen.findByText("Claude Opus 5")).toBeInTheDocument()
+
+		fireEvent.click(screen.getByText("Free"))
+
+		expect(await screen.findByText("DeepSeek V4 Flash")).toBeInTheDocument()
+		// The FREE chip already says it, so the "(free)" marker is stripped
+		expect(screen.getByText("Laguna S 2.1")).toBeInTheDocument()
+		// Models missing from the catalog fall back to their raw id
+		expect(screen.getByText("unknown/mystery-model")).toBeInTheDocument()
 	})
 
 	it("hydrates the selected Cline model from provider config when legacy settings are empty", () => {

--- a/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.test.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.test.tsx
@@ -116,7 +116,8 @@ describe("ClineModelPicker", () => {
 			free: [
 				{ id: "deepseek/deepseek-v4-flash", description: "Fast and efficient", tags: [] },
 				{ id: "poolside/laguna-s-2.1:free", description: "Latest coding agent model", tags: [] },
-				{ id: "unknown/mystery-model", description: "Not in the catalog", tags: [] },
+				{ id: "unknown/named-model", name: "named-model", description: "Not in the catalog", tags: [] },
+				{ id: "unknown/mystery-model", description: "No catalog or endpoint name", tags: [] },
 			],
 		})
 		vi.mocked(useProviderModels).mockReturnValue({
@@ -142,7 +143,9 @@ describe("ClineModelPicker", () => {
 		expect(await screen.findByText("DeepSeek V4 Flash")).toBeInTheDocument()
 		// The FREE chip already says it, so the "(free)" marker is stripped
 		expect(screen.getByText("Laguna S 2.1")).toBeInTheDocument()
-		// Models missing from the catalog fall back to their raw id
+		// Models missing from the catalog fall back to the endpoint-provided name
+		expect(screen.getByText("named-model")).toBeInTheDocument()
+		// ...and to the raw id only when there is no endpoint name either
 		expect(screen.getByText("unknown/mystery-model")).toBeInTheDocument()
 	})
 

--- a/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.tsx
@@ -1,4 +1,4 @@
-import { openAiModelInfoSafeDefaults } from "@shared/api"
+import { openAiModelInfoSafeDefaults, resolveDisplayModelName } from "@shared/api"
 import { CLINE_RECOMMENDED_MODELS_FALLBACK } from "@shared/cline/recommended-models"
 import { EmptyRequest, StringRequest } from "@shared/proto/cline/common"
 import { type ClineRecommendedModel, ClineRecommendedModelsResponse } from "@shared/proto/cline/models"
@@ -442,10 +442,10 @@ const ClineModelPicker: React.FC<ClineModelPickerProps> = ({ isPopup, currentMod
 						recommendedModels.map((model) => (
 							<FeaturedModelCard
 								description={model.description}
+								displayName={resolveDisplayModelName(model.id, effectiveClineModels)}
 								isSelected={selectedModelId === model.id}
 								key={model.id}
 								label={model.label}
-								modelId={model.id}
 								onClick={() => {
 									handleModelChange(model.id)
 									setIsDropdownVisible(false)
@@ -456,10 +456,10 @@ const ClineModelPicker: React.FC<ClineModelPickerProps> = ({ isPopup, currentMod
 						freeModels.map((model) => (
 							<FeaturedModelCard
 								description={model.description}
+								displayName={resolveDisplayModelName(model.id, effectiveClineModels)}
 								isSelected={selectedModelId === model.id}
 								key={model.id}
 								label={model.label}
-								modelId={model.id}
 								onClick={() => {
 									handleModelChange(model.id)
 									setIsDropdownVisible(false)

--- a/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.tsx
@@ -56,6 +56,7 @@ interface ClineModelPickerProps {
 
 interface FeaturedModelCardEntry {
 	id: string
+	name?: string
 	description: string
 	label: string
 }
@@ -67,7 +68,7 @@ function normalizeModelId(modelId: string): string {
 }
 
 function toFeaturedModelCardEntry(
-	model: Pick<ClineRecommendedModel, "id" | "description" | "tags">,
+	model: Pick<ClineRecommendedModel, "id" | "name" | "description" | "tags">,
 	fallbackLabel: string,
 ): FeaturedModelCardEntry | null {
 	if (!model.id) {
@@ -79,6 +80,7 @@ function toFeaturedModelCardEntry(
 
 	return {
 		id: model.id,
+		name: model.name,
 		description: model.description || (fallbackLabel === "FREE" ? "Free model" : "Recommended model"),
 		label: normalizedLabel || fallbackLabel,
 	}
@@ -442,7 +444,7 @@ const ClineModelPicker: React.FC<ClineModelPickerProps> = ({ isPopup, currentMod
 						recommendedModels.map((model) => (
 							<FeaturedModelCard
 								description={model.description}
-								displayName={resolveDisplayModelName(model.id, effectiveClineModels)}
+								displayName={resolveDisplayModelName(model.id, effectiveClineModels, model.name)}
 								isSelected={selectedModelId === model.id}
 								key={model.id}
 								label={model.label}
@@ -456,7 +458,7 @@ const ClineModelPicker: React.FC<ClineModelPickerProps> = ({ isPopup, currentMod
 						freeModels.map((model) => (
 							<FeaturedModelCard
 								description={model.description}
-								displayName={resolveDisplayModelName(model.id, effectiveClineModels)}
+								displayName={resolveDisplayModelName(model.id, effectiveClineModels, model.name)}
 								isSelected={selectedModelId === model.id}
 								key={model.id}
 								label={model.label}

--- a/apps/vscode/webview-ui/src/components/settings/FeaturedModelCard.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/FeaturedModelCard.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import styled from "styled-components"
 
 interface FeaturedModelCardProps {
-	modelId: string
+	displayName: string
 	description: string
 	onClick: () => void
 	isSelected: boolean
@@ -50,11 +50,11 @@ const Description = styled.div`
 	line-height: 1.2;
 `
 
-const FeaturedModelCard: React.FC<FeaturedModelCardProps> = ({ modelId, description, onClick, isSelected, label }) => {
+const FeaturedModelCard: React.FC<FeaturedModelCardProps> = ({ displayName, description, onClick, isSelected, label }) => {
 	return (
 		<CardContainer isSelected={isSelected} onClick={onClick}>
 			<ModelHeader>
-				<ModelName>{modelId}</ModelName>
+				<ModelName>{displayName}</ModelName>
 				<Label>{label}</Label>
 			</ModelHeader>
 			<Description>{description}</Description>

--- a/apps/vscode/webview-ui/src/components/settings/providers/ClinePassProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/ClinePassProvider.tsx
@@ -1,5 +1,5 @@
 import type { ModelInfo } from "@shared/api"
-import { openAiModelInfoSafeDefaults } from "@shared/api"
+import { openAiModelInfoSafeDefaults, resolveDisplayModelName } from "@shared/api"
 import { CLINE_RECOMMENDED_MODELS_FALLBACK } from "@shared/cline/recommended-models"
 import { EmptyRequest } from "@shared/proto/cline/common"
 import { type ClineRecommendedModel, ClineRecommendedModelsResponse } from "@shared/proto/cline/models"
@@ -46,28 +46,35 @@ function clinePassFallbackModelInfo(modelId: string): ModelInfo {
 	}
 }
 
-function toSubscribedEntry(model: Pick<ClineRecommendedModel, "id" | "description">): FeaturedTabEntry | null {
+function toSubscribedEntry(
+	model: Pick<ClineRecommendedModel, "id" | "description">,
+	models?: Record<string, ModelInfo>,
+): FeaturedTabEntry | null {
 	if (!model.id) {
 		return null
 	}
-	// The whole list is included with the plan, so no per-card label chip
+	// The whole list is included with the plan, so no per-card label chip.
+	// The endpoint sends slug-like names, so resolve the display name from the
+	// provider catalog, falling back to the id without its cline-pass/ prefix.
 	return {
 		id: model.id,
-		displayName: model.id.replace(CLINE_PASS_MODEL_ID_PREFIX, ""),
+		displayName: resolveDisplayModelName(model.id, models, model.id.replace(CLINE_PASS_MODEL_ID_PREFIX, "")),
 		description: model.description || "",
 		label: "",
 	}
 }
 
-function toFreeEntry(model: Pick<ClineRecommendedModel, "id" | "name" | "description" | "tags">): FeaturedTabEntry | null {
+function toFreeEntry(
+	model: Pick<ClineRecommendedModel, "id" | "name" | "description" | "tags">,
+	models?: Record<string, ModelInfo>,
+): FeaturedTabEntry | null {
 	if (!model.id) {
 		return null
 	}
 	const firstTag = model.tags?.[0]
 	return {
 		id: model.id,
-		// The FREE chip already says it, so drop OpenRouter's :free marker
-		displayName: (model.name || model.id).replace(/:free$/i, ""),
+		displayName: resolveDisplayModelName(model.id, models, model.name),
 		description: model.description || "",
 		label: typeof firstTag === "string" && firstTag.length > 0 ? firstTag.toUpperCase() : "FREE",
 	}
@@ -94,8 +101,8 @@ export const ClinePassProvider = ({ showModelOptions, isPopup, currentMode }: Cl
 		customModelInfo: clinePassFallbackModelInfo,
 	})
 	const { clineUser } = useClineAuth()
-	const [subscribedEntries, setSubscribedEntries] = useState<FeaturedTabEntry[]>([])
-	const [freeEntries, setFreeEntries] = useState<FeaturedTabEntry[]>([])
+	const [subscribedModels, setSubscribedModels] = useState<ClineRecommendedModel[]>([])
+	const [freeModels, setFreeModels] = useState<ClineRecommendedModel[]>([])
 	const [activeTab, setActiveTab] = useState<"subscribed" | "free">("subscribed")
 
 	useEffect(() => {
@@ -111,14 +118,8 @@ export const ClinePassProvider = ({ showModelOptions, isPopup, currentMode }: Cl
 				if (cancelled) {
 					return
 				}
-				setSubscribedEntries(
-					(response.clinePass ?? [])
-						.map(toSubscribedEntry)
-						.filter((entry): entry is FeaturedTabEntry => entry !== null),
-				)
-				setFreeEntries(
-					(response.free ?? []).map(toFreeEntry).filter((entry): entry is FeaturedTabEntry => entry !== null),
-				)
+				setSubscribedModels(response.clinePass ?? [])
+				setFreeModels(response.free ?? [])
 			} catch (err) {
 				console.error("Failed to refresh ClinePass recommended models:", err)
 			}
@@ -130,25 +131,24 @@ export const ClinePassProvider = ({ showModelOptions, isPopup, currentMode }: Cl
 	}, [])
 
 	// Fall back to the provider catalog (subscribed) and the bundled free list
-	// until the endpoint responds
+	// until the endpoint responds. Cards are built here (not at fetch time) so
+	// display names re-resolve once the provider model catalog loads.
 	const subscribedCards = useMemo(() => {
-		if (subscribedEntries.length > 0) {
-			return subscribedEntries
+		if (subscribedModels.length > 0) {
+			return subscribedModels
+				.map((model) => toSubscribedEntry(model, models))
+				.filter((entry): entry is FeaturedTabEntry => entry !== null)
 		}
 		return Object.keys(models ?? {})
 			.filter((id) => id.startsWith(CLINE_PASS_MODEL_ID_PREFIX))
-			.map((id) => toSubscribedEntry({ id, description: models[id]?.description ?? "" }))
+			.map((id) => toSubscribedEntry({ id, description: models[id]?.description ?? "" }, models))
 			.filter((entry): entry is FeaturedTabEntry => entry !== null)
-	}, [subscribedEntries, models])
+	}, [subscribedModels, models])
 
 	const freeCards = useMemo(() => {
-		if (freeEntries.length > 0) {
-			return freeEntries
-		}
-		return CLINE_RECOMMENDED_MODELS_FALLBACK.free
-			.map(toFreeEntry)
-			.filter((entry): entry is FeaturedTabEntry => entry !== null)
-	}, [freeEntries])
+		const source = freeModels.length > 0 ? freeModels : CLINE_RECOMMENDED_MODELS_FALLBACK.free
+		return source.map((model) => toFreeEntry(model, models)).filter((entry): entry is FeaturedTabEntry => entry !== null)
+	}, [freeModels, models])
 
 	// Land on the tab containing the configured model
 	useEffect(() => {
@@ -201,10 +201,10 @@ export const ClinePassProvider = ({ showModelOptions, isPopup, currentMode }: Cl
 						{activeCards.map((entry) => (
 							<FeaturedModelCard
 								description={entry.description}
+								displayName={entry.displayName}
 								isSelected={selectedModel.modelId === entry.id}
 								key={entry.id}
 								label={entry.label}
-								modelId={entry.displayName}
 								onClick={() => handleFeaturedModelSelect(entry.id)}
 							/>
 						))}

--- a/sdk/packages/llms/src/catalog/catalog-cline-recommended.ts
+++ b/sdk/packages/llms/src/catalog/catalog-cline-recommended.ts
@@ -96,10 +96,16 @@ export function normalizeClineRecommendedProviderModels(
 		const capabilities =
 			openRouterModels?.[entry.id] ??
 			findORModelCapabilities(entry, openRouterModelsByName);
-		const entryName = capabilities.name?.trim() || entry.name?.trim();
+		// The recommended-models endpoint only sends slug-like names (e.g.
+		// "deepseek-v4-flash"), so prefer the OpenRouter catalog's display name
+		// for every free entry. Without this, the free overlay overwrites the
+		// nice OpenRouter names in the merged cline/cline-pass catalogs and the
+		// pickers end up rendering raw model ids for the Free section.
+		const entryName =
+			capabilities.name?.trim() || entry.name?.trim() || entry.id;
 		const name = entry.id.startsWith("cline-free/")
 			? `${entryName} (free)`
-			: entry.name;
+			: entryName;
 
 		const modelInfo = {
 			...capabilities,

--- a/sdk/packages/llms/src/catalog/catalog-live.test.ts
+++ b/sdk/packages/llms/src/catalog/catalog-live.test.ts
@@ -367,6 +367,52 @@ describe("models-dev-catalog", () => {
 		});
 	});
 
+	it("resolves OpenRouter display names for free models with full catalog ids", () => {
+		// The recommended-models endpoint sends slug-like names (e.g.
+		// "deepseek-v4-flash"); the overlay must keep the OpenRouter display
+		// name so merged cline/cline-pass catalogs don't show raw ids.
+		const result = normalizeClineRecommendedProviderModels(
+			{
+				free: [
+					{ id: "deepseek/deepseek-v4-flash", name: "deepseek-v4-flash" },
+					{ id: "poolside/laguna-s-2.1:free", name: "laguna-s-2.1:free" },
+					{ id: "unknown/mystery-model", name: "mystery-model" },
+				],
+			},
+			{
+				"deepseek/deepseek-v4-flash": {
+					id: "deepseek/deepseek-v4-flash",
+					name: "DeepSeek V4 Flash",
+					contextWindow: 1_000_000,
+					maxInputTokens: 800_000,
+					maxTokens: 128_000,
+					capabilities: ["tools", "reasoning"],
+					pricing: { input: 3, output: 15, cacheRead: 0, cacheWrite: 0 },
+				},
+				"poolside/laguna-s-2.1:free": {
+					id: "poolside/laguna-s-2.1:free",
+					name: "Laguna S 2.1 (free)",
+					contextWindow: 262_144,
+					maxInputTokens: 262_144,
+					maxTokens: 32_768,
+					capabilities: ["tools"],
+					pricing: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				},
+			},
+		);
+
+		expect(result.cline?.["deepseek/deepseek-v4-flash"]).toMatchObject({
+			id: "deepseek/deepseek-v4-flash",
+			name: "DeepSeek V4 Flash",
+			pricing: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		});
+		expect(result.cline?.["poolside/laguna-s-2.1:free"]?.name).toBe(
+			"Laguna S 2.1 (free)",
+		);
+		// Without a catalog match, fall back to the endpoint-provided name.
+		expect(result.cline?.["unknown/mystery-model"]?.name).toBe("mystery-model");
+	});
+
 	it("uses input limits as the model request context window", () => {
 		expect(resolveMaxInputTokens(undefined)).toBe(128_000);
 		expect(


### PR DESCRIPTION
### Related Issue

N/A — reported directly: the Free section of the Cline / ClinePass model pickers shows raw model ids (e.g. `deepseek-v4-flash`, `cline-free/glm-5.2`, `laguna-s-2.1:free`) while the rest of the models show proper display names.

### Description

**Root cause:** the `recommended-models` endpoint only sends slug-like `name` values. In `normalizeClineRecommendedProviderModels` (`@cline/llms`), the free-model overlay already looks up each entry in the OpenRouter catalog (which has the proper display names) but only used that resolved name for ids starting with `cline-free/` — every other free model kept the raw API slug. Since the overlay is merged *after* the OpenRouter catalog for the `cline`/`cline-pass` providers, it overwrote the good names, so the CLI picker (which resolves names from `knownModels`) rendered slugs for the Free section while Recommended entries resolved fine.

**Changes:**

- `@cline/llms`: `normalizeClineRecommendedProviderModels` now prefers the OpenRouter catalog display name for **all** free entries (falling back to the endpoint name, then the id). This fixes the CLI pickers (`cline` + `cline-pass`, model selector and onboarding) since they resolve names from the merged catalog, which every runtime path loads live (`loadLatestOnInit: true`).
- VS Code webview: the featured model cards never resolved names at all — `ClineModelPicker` rendered the raw `model.id` and `ClinePassProvider` used the endpoint slug. Added a shared `resolveDisplayModelName` helper (`@shared/api`) that resolves from the provider model catalog and strips redundant `(free)` / `:free` markers, and wired it into `ClineModelPicker`, `ClinePassProvider` (cards now re-resolve once the catalog loads), and `useOnboardingModels`. Renamed `FeaturedModelCard`'s `modelId` prop to `displayName` to match what it renders.

**Intentionally not included:** regenerating `catalog.generated.ts` — a full regen pulls ~26k lines of unrelated models.dev churn. The baked snapshot's three `cline` free entries keep slug names until the next routine catalog regen; at runtime the live catalog (fetched with the fixed normalization) takes precedence everywhere.

### Test Procedure

- New unit test in `catalog-live.test.ts` covering OpenRouter-name resolution for full-id free models, `(free)`-marker handling, and the raw-id fallback for unknown models; full `@cline/llms` suite passes (475 tests).
- New webview test in `ClineModelPicker.test.tsx` asserting featured cards resolve catalog display names (both tabs), strip free markers, and fall back to the id when the catalog misses; full webview suite passes (388 tests) and `bun run test:unit` passes (1027 tests).
- Manually verified before/after in the CLI (`/model` picker on `cline` and `cline-pass`) and in the extension dev host (Cline provider Recommended/Free tabs) — screenshots below.
- `bunx tsc -b` (webview), `bun run check-types` (extension), and biome checks pass.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

CLI `/model` picker, Cline provider — before (left) vs after (right):

![CLI free models before and after](https://cursor.com/artifacts/c/art-f32b6149-0bb0-4146-b06a-d0ea7d5b9127)

CLI `/model` picker, ClinePass provider — after (Subscribed and Free both resolved):

![CLI ClinePass picker after](https://cursor.com/artifacts/c/art-567e697e-4391-4ab9-80eb-3e60b15a7b0e)

VS Code extension, Cline provider Free tab — before (left) vs after (right):

![VS Code free tab before and after](https://cursor.com/artifacts/c/art-2ddad1ad-b37e-4cae-af63-7e78e6b0c8ce)

VS Code extension, Recommended tab — before (left) vs after (right):

![VS Code recommended tab before and after](https://cursor.com/artifacts/c/art-505d1820-3c5c-4125-830b-a5f15be67363)

### Additional Notes

The `name` values coming from the `recommended-models` endpoint itself are slugs for every bucket; if the endpoint ever starts returning display names, they are used as the fallback automatically.