### PR TITLE
fix(vscode): run Store PowerShell profiles correctly

### DIFF
--- a/apps/vscode/src/test/e2e/fixtures/server/api.ts
+++ b/apps/vscode/src/test/e2e/fixtures/server/api.ts
@@ -50,6 +50,17 @@ export const E2E_MOCK_EDITOR_TOOL_CALL = {
 	},
 }
 
+/** Windows PowerShell diagnostic executed by the real background shell tool. */
+export const E2E_MOCK_POWERSHELL_TOOL_CALL = {
+	id: "call_e2e_powershell_1",
+	name: "run_commands",
+	arguments: {
+		commands: [
+			"Write-Output ('VERSION=' + $PSVersionTable.PSVersion); Write-Output ('PSHOME=' + $PSHOME); Write-Output 'UNICODE=中文'",
+		],
+	},
+}
+
 const edit_request_complete = `I successfully replaced "john" with "cline" in the test.ts file. The change has been completed and the file now contains:
 
 \`\`\`typescript
@@ -64,6 +75,8 @@ export const E2E_MOCK_API_RESPONSES = {
 	EDIT_REQUEST_LEAD_IN: `I'll replace "john" with "cline" in the test.ts file.`,
 	/** Turn-ending text streamed after the SDK reports the editor tool result. */
 	EDIT_REQUEST_COMPLETE: edit_request_complete,
+	POWERSHELL_REQUEST_LEAD_IN: "I'll inspect the PowerShell process used for background execution.",
+	POWERSHELL_REQUEST_COMPLETE: "PowerShell background execution diagnostic completed.",
 }
 
 export const E2E_MOCK_CLINE_RECOMMENDED_MODELS = {

--- a/apps/vscode/src/test/e2e/fixtures/server/index.ts
+++ b/apps/vscode/src/test/e2e/fixtures/server/index.ts
@@ -484,7 +484,7 @@ export class ClineApiServerMock {
 						// Scope tool-result routing to the mock scenarios that issued a tool
 						// call so unrelated conversations retain the default response.
 						const hasToolResult =
-							(body.includes("edit_request") || body.includes("powershell_store_request")) &&
+							(body.includes("edit_request") || body.includes("powershell_background_request")) &&
 							Array.isArray(messages) &&
 							messages.some((m: { role?: string }) => m?.role === "tool")
 
@@ -492,11 +492,11 @@ export class ClineApiServerMock {
 						let toolCall: typeof E2E_MOCK_EDITOR_TOOL_CALL | typeof E2E_MOCK_POWERSHELL_TOOL_CALL | undefined
 						log("Chat completion mock selection:", {
 							isEditRequest: body.includes("edit_request"),
-							isPowerShellRequest: body.includes("powershell_store_request"),
+							isPowerShellRequest: body.includes("powershell_background_request"),
 							hasToolResult,
 						})
 						if (hasToolResult) {
-							responseText = body.includes("powershell_store_request")
+							responseText = body.includes("powershell_background_request")
 								? E2E_MOCK_API_RESPONSES.POWERSHELL_REQUEST_COMPLETE
 								: E2E_MOCK_API_RESPONSES.EDIT_REQUEST_COMPLETE
 						} else if (body.includes("edit_request")) {
@@ -505,7 +505,7 @@ export class ClineApiServerMock {
 							// the SDK runtime executes.
 							responseText = E2E_MOCK_API_RESPONSES.EDIT_REQUEST_LEAD_IN
 							toolCall = E2E_MOCK_EDITOR_TOOL_CALL
-						} else if (body.includes("powershell_store_request")) {
+						} else if (body.includes("powershell_background_request")) {
 							responseText = E2E_MOCK_API_RESPONSES.POWERSHELL_REQUEST_LEAD_IN
 							toolCall = E2E_MOCK_POWERSHELL_TOOL_CALL
 						}

--- a/apps/vscode/src/test/e2e/fixtures/server/index.ts
+++ b/apps/vscode/src/test/e2e/fixtures/server/index.ts
@@ -7,6 +7,7 @@ import {
 	E2E_MOCK_CLINE_MODELS,
 	E2E_MOCK_CLINE_RECOMMENDED_MODELS,
 	E2E_MOCK_EDITOR_TOOL_CALL,
+	E2E_MOCK_POWERSHELL_TOOL_CALL,
 	E2E_REGISTERED_MOCK_ENDPOINTS,
 } from "./api"
 import { ClineDataMock } from "./data"
@@ -480,27 +481,33 @@ export class ClineApiServerMock {
 						// a `role: "tool"` message. Detect that follow-up first — the
 						// original "edit_request" user prompt is still present in the
 						// conversation history of the follow-up request, so order matters.
-						// Scoped to edit_request conversations so tool results from other
-						// (future) scenarios don't mis-route to EDIT_REQUEST_COMPLETE.
+						// Scope tool-result routing to the mock scenarios that issued a tool
+						// call so unrelated conversations retain the default response.
 						const hasToolResult =
-							body.includes("edit_request") &&
+							(body.includes("edit_request") || body.includes("powershell_store_request")) &&
 							Array.isArray(messages) &&
 							messages.some((m: { role?: string }) => m?.role === "tool")
 
 						let responseText = E2E_MOCK_API_RESPONSES.DEFAULT
-						let includeEditorToolCall = false
+						let toolCall: typeof E2E_MOCK_EDITOR_TOOL_CALL | typeof E2E_MOCK_POWERSHELL_TOOL_CALL | undefined
 						log("Chat completion mock selection:", {
 							isEditRequest: body.includes("edit_request"),
+							isPowerShellRequest: body.includes("powershell_store_request"),
 							hasToolResult,
 						})
 						if (hasToolResult) {
-							responseText = E2E_MOCK_API_RESPONSES.EDIT_REQUEST_COMPLETE
+							responseText = body.includes("powershell_store_request")
+								? E2E_MOCK_API_RESPONSES.POWERSHELL_REQUEST_COMPLETE
+								: E2E_MOCK_API_RESPONSES.EDIT_REQUEST_COMPLETE
 						} else if (body.includes("edit_request")) {
 							// Stream lead-in text followed by a structured `editor` tool
 							// call (OpenAI tool_calls deltas) — the only tool-call syntax
 							// the SDK runtime executes.
 							responseText = E2E_MOCK_API_RESPONSES.EDIT_REQUEST_LEAD_IN
-							includeEditorToolCall = true
+							toolCall = E2E_MOCK_EDITOR_TOOL_CALL
+						} else if (body.includes("powershell_store_request")) {
+							responseText = E2E_MOCK_API_RESPONSES.POWERSHELL_REQUEST_LEAD_IN
+							toolCall = E2E_MOCK_POWERSHELL_TOOL_CALL
 						}
 						const generationId = `gen_${++controller.generationCounter}_${Date.now()}`
 
@@ -523,16 +530,16 @@ export class ClineApiServerMock {
 							// for a tool_calls index must carry `id` + `function.name`;
 							// `function.arguments` accumulates as string fragments. Split
 							// the arguments JSON to exercise fragment reassembly.
-							const argumentsJson = JSON.stringify(E2E_MOCK_EDITOR_TOOL_CALL.arguments)
+							const argumentsJson = toolCall ? JSON.stringify(toolCall.arguments) : ""
 							const argsSplitAt = Math.floor(argumentsJson.length / 2)
-							const toolCallDeltas = includeEditorToolCall
+							const toolCallDeltas = toolCall
 								? [
 										[
 											{
 												index: 0,
-												id: E2E_MOCK_EDITOR_TOOL_CALL.id,
+												id: toolCall.id,
 												type: "function",
-												function: { name: E2E_MOCK_EDITOR_TOOL_CALL.name, arguments: "" },
+												function: { name: toolCall.name, arguments: "" },
 											},
 										],
 										[
@@ -600,7 +607,7 @@ export class ClineApiServerMock {
 											{
 												index: 0,
 												delta: {},
-												finish_reason: includeEditorToolCall ? "tool_calls" : "stop",
+												finish_reason: toolCall ? "tool_calls" : "stop",
 											},
 										],
 										usage: {
@@ -711,7 +718,11 @@ export class ClineApiServerMock {
 
 			handleRequest().catch((err) => {
 				console.error("Request handling error:", err)
-				sendApiError("Internal server error", 500)
+				if (!res.headersSent) {
+					sendApiError("Internal server error", 500)
+				} else if (!res.writableEnded) {
+					res.end()
+				}
 			})
 		})
 

--- a/apps/vscode/src/test/e2e/powershell-background.test.ts
+++ b/apps/vscode/src/test/e2e/powershell-background.test.ts
@@ -1,0 +1,52 @@
+import { existsSync, lstatSync } from "node:fs"
+import * as path from "node:path"
+import { expect } from "@playwright/test"
+import { e2e } from "./utils/helpers"
+
+e2e("Terminal - background execution uses Store-installed PowerShell 7", async ({ helper, page, sidebar }, testInfo) => {
+	e2e.skip(process.platform !== "win32", "PowerShell Store installation is Windows-specific")
+	const programFiles = process.env.ProgramW6432 || process.env.ProgramFiles || "C:\\Program Files"
+	const storeAlias = path.join(process.env.LOCALAPPDATA ?? "", "Microsoft", "WindowsApps", "pwsh.exe")
+	const hasPreferredInstall = [
+		path.join(programFiles, "PowerShell", "7", "pwsh.exe"),
+		path.join(programFiles, "PowerShell", "6", "pwsh.exe"),
+	].some(existsSync)
+	let hasStoreAlias = false
+	try {
+		hasStoreAlias = lstatSync(storeAlias).isSymbolicLink()
+	} catch {
+		// The Store alias is not installed or enabled.
+	}
+	e2e.skip(!hasStoreAlias || hasPreferredInstall, "Requires a Store-only PowerShell 7 installation")
+
+	await helper.signin(sidebar)
+
+	await page.getByRole("button", { name: "Settings", exact: true }).click()
+	await sidebar.getByTestId("tab-terminal").click()
+	await expect(sidebar.getByText("Terminal Settings", { exact: true })).toBeVisible()
+
+	const executionMode = sidebar.locator("#terminal-execution-mode")
+	await executionMode.click()
+	await sidebar.getByRole("option", { name: "Background Exec" }).click()
+
+	const terminalProfile = sidebar.locator("#default-terminal-profile")
+	await terminalProfile.click()
+	await sidebar.getByRole("option", { name: "PowerShell 7" }).click()
+
+	await expect(executionMode).toHaveAttribute("current-value", "backgroundExec")
+	await expect(terminalProfile).toHaveAttribute("current-value", "powershell-7")
+	await page.screenshot({ path: testInfo.outputPath("powershell-background-settings.png"), fullPage: true })
+
+	await sidebar.getByRole("button", { name: "Done" }).click()
+	const inputbox = sidebar.getByTestId("chat-input")
+	await inputbox.fill("powershell_store_request")
+	await sidebar.getByTestId("send-button").click()
+	await sidebar.getByRole("button", { name: "Run Command" }).click()
+
+	const commandOutput = sidebar.locator("code").filter({ hasText: /VERSION=7\./ })
+	await expect(commandOutput).toBeVisible({ timeout: 30_000 })
+	await expect(commandOutput).toContainText(/PSHOME=.*WindowsApps.*Microsoft\.PowerShell_/i)
+	await expect(commandOutput).toContainText("UNICODE=中文")
+	await expect(sidebar.getByText("PowerShell background execution diagnostic completed.")).toBeVisible()
+	await page.screenshot({ path: testInfo.outputPath("powershell-background-success.png"), fullPage: true })
+})

--- a/apps/vscode/src/test/e2e/powershell-background.test.ts
+++ b/apps/vscode/src/test/e2e/powershell-background.test.ts
@@ -3,50 +3,74 @@ import * as path from "node:path"
 import { expect } from "@playwright/test"
 import { e2e } from "./utils/helpers"
 
-e2e("Terminal - background execution uses Store-installed PowerShell 7", async ({ helper, page, sidebar }, testInfo) => {
-	e2e.skip(process.platform !== "win32", "PowerShell Store installation is Windows-specific")
-	const programFiles = process.env.ProgramW6432 || process.env.ProgramFiles || "C:\\Program Files"
-	const storeAlias = path.join(process.env.LOCALAPPDATA ?? "", "Microsoft", "WindowsApps", "pwsh.exe")
-	const hasPreferredInstall = [
-		path.join(programFiles, "PowerShell", "7", "pwsh.exe"),
-		path.join(programFiles, "PowerShell", "6", "pwsh.exe"),
-	].some(existsSync)
-	let hasStoreAlias = false
-	try {
-		hasStoreAlias = lstatSync(storeAlias).isSymbolicLink()
-	} catch {
-		// The Store alias is not installed or enabled.
-	}
-	e2e.skip(!hasStoreAlias || hasPreferredInstall, "Requires a Store-only PowerShell 7 installation")
+const profiles = [
+	{
+		name: "Windows PowerShell 5.1",
+		profileId: "powershell-legacy",
+		profileName: "Windows PowerShell",
+		version: /^VERSION=5\.1/,
+		psHome: [/PSHOME=.*WindowsPowerShell/i, /v1\.0/i],
+	},
+	{
+		name: "Store-installed PowerShell 7",
+		profileId: "powershell-7",
+		profileName: "PowerShell 7",
+		version: /^VERSION=7\./,
+		psHome: [/PSHOME=.*WindowsApps.*Microsoft\.PowerShell_/i],
+		storeOnly: true,
+	},
+] as const
 
-	await helper.signin(sidebar)
+for (const profile of profiles) {
+	e2e(`Terminal - background execution uses ${profile.name}`, async ({ helper, page, sidebar }, testInfo) => {
+		e2e.skip(process.platform !== "win32", "PowerShell background execution is Windows-specific")
+		if ("storeOnly" in profile) {
+			const programFiles = process.env.ProgramW6432 || process.env.ProgramFiles || "C:\\Program Files"
+			const storeAlias = path.join(process.env.LOCALAPPDATA ?? "", "Microsoft", "WindowsApps", "pwsh.exe")
+			const hasPreferredInstall = [
+				path.join(programFiles, "PowerShell", "7", "pwsh.exe"),
+				path.join(programFiles, "PowerShell", "6", "pwsh.exe"),
+			].some(existsSync)
+			let hasStoreAlias = false
+			try {
+				hasStoreAlias = lstatSync(storeAlias).isSymbolicLink()
+			} catch {
+				// The Store alias is not installed or enabled.
+			}
+			e2e.skip(!hasStoreAlias || hasPreferredInstall, "Requires a Store-only PowerShell 7 installation")
+		}
 
-	await page.getByRole("button", { name: "Settings", exact: true }).click()
-	await sidebar.getByTestId("tab-terminal").click()
-	await expect(sidebar.getByText("Terminal Settings", { exact: true })).toBeVisible()
+		await helper.signin(sidebar)
 
-	const executionMode = sidebar.locator("#terminal-execution-mode")
-	await executionMode.click()
-	await sidebar.getByRole("option", { name: "Background Exec" }).click()
+		await page.getByRole("button", { name: "Settings", exact: true }).click()
+		await sidebar.getByTestId("tab-terminal").click()
+		await expect(sidebar.getByText("Terminal Settings", { exact: true })).toBeVisible()
 
-	const terminalProfile = sidebar.locator("#default-terminal-profile")
-	await terminalProfile.click()
-	await sidebar.getByRole("option", { name: "PowerShell 7" }).click()
+		const executionMode = sidebar.locator("#terminal-execution-mode")
+		await executionMode.click()
+		await sidebar.getByRole("option", { name: "Background Exec" }).click()
 
-	await expect(executionMode).toHaveAttribute("current-value", "backgroundExec")
-	await expect(terminalProfile).toHaveAttribute("current-value", "powershell-7")
-	await page.screenshot({ path: testInfo.outputPath("powershell-background-settings.png"), fullPage: true })
+		const terminalProfile = sidebar.locator("#default-terminal-profile")
+		await terminalProfile.click()
+		await sidebar.getByRole("option", { name: profile.profileName, exact: true }).click()
 
-	await sidebar.getByRole("button", { name: "Done" }).click()
-	const inputbox = sidebar.getByTestId("chat-input")
-	await inputbox.fill("powershell_store_request")
-	await sidebar.getByTestId("send-button").click()
-	await sidebar.getByRole("button", { name: "Run Command" }).click()
+		await expect(executionMode).toHaveAttribute("current-value", "backgroundExec")
+		await expect(terminalProfile).toHaveAttribute("current-value", profile.profileId)
+		await page.screenshot({ path: testInfo.outputPath("powershell-background-settings.png"), fullPage: true })
 
-	const commandOutput = sidebar.locator("code").filter({ hasText: /VERSION=7\./ })
-	await expect(commandOutput).toBeVisible({ timeout: 30_000 })
-	await expect(commandOutput).toContainText(/PSHOME=.*WindowsApps.*Microsoft\.PowerShell_/i)
-	await expect(commandOutput).toContainText("UNICODE=中文")
-	await expect(sidebar.getByText("PowerShell background execution diagnostic completed.")).toBeVisible()
-	await page.screenshot({ path: testInfo.outputPath("powershell-background-success.png"), fullPage: true })
-})
+		await sidebar.getByRole("button", { name: "Done" }).click()
+		const inputbox = sidebar.getByTestId("chat-input")
+		await inputbox.fill("powershell_background_request")
+		await sidebar.getByTestId("send-button").click()
+		await sidebar.getByRole("button", { name: "Run Command" }).click()
+
+		const commandOutput = sidebar.locator("code").filter({ hasText: profile.version })
+		await expect(commandOutput).toBeVisible({ timeout: 30_000 })
+		for (const expectedPathPart of profile.psHome) {
+			await expect(commandOutput).toContainText(expectedPathPart)
+		}
+		await expect(commandOutput).toContainText("UNICODE=中文")
+		await expect(sidebar.getByText("PowerShell background execution diagnostic completed.")).toBeVisible()
+		await page.screenshot({ path: testInfo.outputPath("powershell-background-success.png"), fullPage: true })
+	})
+}

--- a/apps/vscode/src/test/shell.test.ts
+++ b/apps/vscode/src/test/shell.test.ts
@@ -21,12 +21,14 @@ mock.module("node:os", osMock)
 // control which PowerShell installs "exist" regardless of the host machine.
 let existsSyncImpl: typeof actualFs.existsSync = actualFs.existsSync
 const existsSyncDelegate = ((path: unknown) => existsSyncImpl(path as string)) as typeof actualFs.existsSync
-const fsMockNamespace = { ...actualFs, existsSync: existsSyncDelegate }
+let lstatSyncImpl: typeof actualFs.lstatSync = actualFs.lstatSync
+const lstatSyncDelegate = ((path: unknown) => lstatSyncImpl(path as string)) as typeof actualFs.lstatSync
+const fsMockNamespace = { ...actualFs, existsSync: existsSyncDelegate, lstatSync: lstatSyncDelegate }
 const fsMock = () => ({ ...fsMockNamespace, default: fsMockNamespace })
 mock.module("fs", fsMock)
 mock.module("node:fs", fsMock)
 
-import { getShell } from "@utils/shell"
+import { getShell, getShellForProfile } from "@utils/shell"
 
 describe("Shell Detection Tests", () => {
 	let originalPlatform: string
@@ -34,6 +36,7 @@ describe("Shell Detection Tests", () => {
 	let originalGetConfig: typeof vscode.workspace.getConfiguration
 	let originalUserInfo: typeof actualOs.userInfo
 	let originalExistsSync: typeof actualFs.existsSync
+	let originalLstatSync: typeof actualFs.lstatSync
 
 	// Helper to mock VS Code configuration
 	function mockVsCodeConfig(platformKey: string, defaultProfileName: string | null, profiles: Record<string, any>) {
@@ -58,6 +61,7 @@ describe("Shell Detection Tests", () => {
 		originalGetConfig = vscode.workspace.getConfiguration
 		originalUserInfo = userInfoImpl
 		originalExistsSync = existsSyncImpl
+		originalLstatSync = lstatSyncImpl
 
 		// Clear environment variables for a clean test
 		delete process.env.SHELL
@@ -68,6 +72,9 @@ describe("Shell Detection Tests", () => {
 		// Default: PowerShell 7 is not installed, so the Windows default
 		// resolves to legacy Windows PowerShell.
 		existsSyncImpl = (() => false) as any
+		lstatSyncImpl = (() => {
+			throw new Error("ENOENT")
+		}) as typeof actualFs.lstatSync
 	})
 
 	afterEach(() => {
@@ -77,6 +84,7 @@ describe("Shell Detection Tests", () => {
 		vscode.workspace.getConfiguration = originalGetConfig
 		userInfoImpl = originalUserInfo
 		existsSyncImpl = originalExistsSync
+		lstatSyncImpl = originalLstatSync
 	})
 
 	// --------------------------------------------------------------------------
@@ -146,10 +154,43 @@ describe("Shell Detection Tests", () => {
 		})
 
 		it("uses PowerShell 7 path if source is 'PowerShell' but no explicit path", () => {
+			existsSyncImpl = ((candidate: actualFs.PathLike) =>
+				candidate === "C:\\Program Files\\PowerShell\\7\\pwsh.exe") as typeof actualFs.existsSync
 			mockVsCodeConfig("windows", "PowerShell", {
 				PowerShell: { source: "PowerShell" },
 			})
 			expect(getShell()).to.equal("C:\\Program Files\\PowerShell\\7\\pwsh.exe")
+		})
+
+		it("uses Store-installed pwsh for a source-based PowerShell profile", () => {
+			process.env.LOCALAPPDATA = "C:\\Users\\Test\\AppData\\Local"
+			const storePwsh = "C:\\Users\\Test\\AppData\\Local\\Microsoft\\WindowsApps\\pwsh.exe"
+			existsSyncImpl = (() => false) as typeof actualFs.existsSync
+			lstatSyncImpl = ((candidate: actualFs.PathLike) => {
+				if (candidate !== storePwsh) {
+					throw new Error("ENOENT")
+				}
+				return { isSymbolicLink: () => true } as actualFs.Stats
+			}) as typeof actualFs.lstatSync
+			mockVsCodeConfig("windows", "PowerShell", {
+				PowerShell: { source: "PowerShell" },
+			})
+
+			expect(getShell()).to.equal(storePwsh)
+		})
+
+		it("uses Store-installed pwsh for Cline's PowerShell 7 profile", () => {
+			process.env.LOCALAPPDATA = "C:\\Users\\Test\\AppData\\Local"
+			const storePwsh = "C:\\Users\\Test\\AppData\\Local\\Microsoft\\WindowsApps\\pwsh.exe"
+			existsSyncImpl = (() => false) as typeof actualFs.existsSync
+			lstatSyncImpl = ((candidate: actualFs.PathLike) => {
+				if (candidate !== storePwsh) {
+					throw new Error("ENOENT")
+				}
+				return { isSymbolicLink: () => true } as actualFs.Stats
+			}) as typeof actualFs.lstatSync
+
+			expect(getShellForProfile("powershell-7")).to.equal(storePwsh)
 		})
 
 		it("falls back to legacy PowerShell if profile includes 'powershell' but no path/source", () => {

--- a/apps/vscode/src/utils/shell.ts
+++ b/apps/vscode/src/utils/shell.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "fs"
+import { existsSync, lstatSync } from "fs"
 import { userInfo } from "os"
 import * as nodePath from "path"
 import * as vscode from "vscode"
@@ -191,8 +191,10 @@ function getWindowsShellFromVSCode(): string | null {
 			return configuredShell
 		}
 		if (profile?.source === "PowerShell") {
-			// If the profile is sourced from PowerShell, assume the newest
-			return SHELL_PATHS.POWERSHELL_7
+			// A source-based profile delegates install detection to VS Code.
+			// Mirror that detection for background execution rather than assuming
+			// PowerShell 7 was installed to the MSI path.
+			return getWindowsDefaultShell()
 		}
 		// Otherwise, assume legacy Windows PowerShell
 		return SHELL_PATHS.POWERSHELL_LEGACY
@@ -287,7 +289,7 @@ export function getAvailableTerminalProfiles(): TerminalProfile[] {
 			{
 				id: "powershell-7",
 				name: "PowerShell 7",
-				path: SHELL_PATHS.POWERSHELL_7,
+				path: getInstalledWindowsPwsh() ?? SHELL_PATHS.POWERSHELL_7,
 				description: "PowerShell 7 (pwsh.exe)",
 			},
 			{
@@ -398,6 +400,22 @@ export function getWindowsPwshInstallPaths(): string[] {
 	]
 }
 
+/** Returns an installed modern PowerShell executable, if one can be found. */
+function getInstalledWindowsPwsh(): string | undefined {
+	return getWindowsPwshInstallPaths().find((candidate) => {
+		if (existsSync(candidate)) {
+			return true
+		}
+		try {
+			// Microsoft Store App Execution Aliases are zero-byte reparse points.
+			// Node can spawn them, but existsSync() reports false.
+			return lstatSync(candidate).isSymbolicLink()
+		} catch {
+			return false
+		}
+	})
+}
+
 /**
  * The shell VS Code launches on Windows when the user has not configured a
  * default terminal profile: its built-in default is PowerShell (pwsh when
@@ -406,8 +424,7 @@ export function getWindowsPwshInstallPaths(): string[] {
  * run in a visible VS Code terminal or a background child process.
  */
 function getWindowsDefaultShell(): string {
-	const pwsh = getWindowsPwshInstallPaths().find((candidate) => existsSync(candidate))
-	return pwsh ?? SHELL_PATHS.POWERSHELL_LEGACY
+	return getInstalledWindowsPwsh() ?? SHELL_PATHS.POWERSHELL_LEGACY
 }
 
 export function getShell(): string {

--- a/sdk/packages/core/src/extensions/tools/executors/bash.test.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/bash.test.ts
@@ -329,6 +329,23 @@ describe("createShellExecutor", () => {
 });
 
 describe.runIf(process.platform === "win32")("createWindowsExecutor", () => {
+	it("preserves Unicode through PowerShell command input and output", async () => {
+		const executor = createShellExecutor();
+		const output = await executor("Write-Output '中文'", process.cwd(), ctx);
+		expect(output.trim()).toBe("中文");
+	});
+
+	it("runs PowerShell commands beyond the Windows command-line limit", async () => {
+		const executor = createShellExecutor();
+		const payload = "x".repeat(40_000);
+		const output = await executor(
+			`Write-Output '${payload.length}'; $null = '${payload}'`,
+			process.cwd(),
+			ctx,
+		);
+		expect(output.trim()).toBe("40000");
+	});
+
 	it("runs structured commands without shell parsing", async () => {
 		const executor = createShellExecutor();
 		const output = await executor(

--- a/sdk/packages/core/src/extensions/tools/executors/bash.test.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/bash.test.ts
@@ -1,4 +1,4 @@
-import { access, mkdtemp, rm } from "node:fs/promises";
+import { access, copyFile, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentToolContext } from "@cline/shared";
@@ -344,6 +344,20 @@ describe.runIf(process.platform === "win32")("createWindowsExecutor", () => {
 			ctx,
 		);
 		expect(output.trim()).toBe("40000");
+	});
+
+	it("rejects safely when PowerShell exits without reading command input", async () => {
+		const tempDir = await mkdtemp(join(tmpdir(), "shell-stdin-error-"));
+		const fakePowerShell = join(tempDir, "pwsh.exe");
+		try {
+			await copyFile(process.execPath, fakePowerShell);
+			const executor = createShellExecutor({ shell: fakePowerShell });
+			await expect(
+				executor(`Write-Output '${"x".repeat(5_000_000)}'`, process.cwd(), ctx),
+			).rejects.toThrow();
+		} finally {
+			await rm(tempDir, { recursive: true, force: true });
+		}
 	});
 
 	it("runs structured commands without shell parsing", async () => {

--- a/sdk/packages/core/src/extensions/tools/executors/bash.test.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/bash.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { access, copyFile, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -329,11 +330,71 @@ describe("createShellExecutor", () => {
 });
 
 describe.runIf(process.platform === "win32")("createWindowsExecutor", () => {
-	it("preserves Unicode through PowerShell command input and output", async () => {
-		const executor = createShellExecutor();
-		const output = await executor("Write-Output '中文'", process.cwd(), ctx);
-		expect(output.trim()).toBe("中文");
-	});
+	const hasPwsh =
+		spawnSync("where.exe", ["pwsh.exe"], {
+			stdio: "ignore",
+			windowsHide: true,
+		}).status === 0;
+	for (const shell of ["powershell.exe", "pwsh.exe"]) {
+		it.runIf(shell === "powershell.exe" || hasPwsh)(
+			`preserves Unicode through ${shell} command input and output`,
+			async () => {
+				const executor = createShellExecutor({ shell });
+				const output = await executor(
+					"Write-Output '中文'",
+					process.cwd(),
+					ctx,
+				);
+				expect(output.trim()).toBe("中文");
+			},
+		);
+
+		it.runIf(shell === "powershell.exe" || hasPwsh)(
+			`reports a failed final native command through ${shell}`,
+			async () => {
+				const executor = createShellExecutor({ shell });
+				let error: unknown;
+				try {
+					await executor("cmd /c exit 5", process.cwd(), ctx);
+				} catch (caught) {
+					error = caught;
+				}
+				expect(error).toBeInstanceOf(CommandExitError);
+				// Direct PowerShell -Command normalizes a failed final command to 1.
+				expect((error as CommandExitError).exitCode).toBe(1);
+			},
+		);
+
+		it.runIf(shell === "powershell.exe" || hasPwsh)(
+			`reports a PowerShell failure after a native command through ${shell}`,
+			async () => {
+				const executor = createShellExecutor({ shell });
+				let error: unknown;
+				try {
+					await executor("cmd /c exit 5; Write-Error boom", process.cwd(), ctx);
+				} catch (caught) {
+					error = caught;
+				}
+				expect(error).toBeInstanceOf(CommandExitError);
+				expect((error as CommandExitError).exitCode).toBe(1);
+			},
+		);
+
+		it.runIf(shell === "powershell.exe" || hasPwsh)(
+			`preserves an explicit exit code through ${shell}`,
+			async () => {
+				const executor = createShellExecutor({ shell });
+				let error: unknown;
+				try {
+					await executor("exit 7", process.cwd(), ctx);
+				} catch (caught) {
+					error = caught;
+				}
+				expect(error).toBeInstanceOf(CommandExitError);
+				expect((error as CommandExitError).exitCode).toBe(7);
+			},
+		);
+	}
 
 	it("runs PowerShell commands beyond the Windows command-line limit", async () => {
 		const executor = createShellExecutor();

--- a/sdk/packages/core/src/extensions/tools/executors/bash.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/bash.ts
@@ -148,7 +148,6 @@ function spawnAndCollect(
 			windowsHide: true,
 		});
 		const childPid = child.pid;
-		child.stdin?.end(config.input, "utf8");
 
 		const stdout = createRollingCollector(maxOutputChars);
 		const stderr = createRollingCollector(maxOutputChars);
@@ -293,6 +292,14 @@ function spawnAndCollect(
 				reject(new Error(`Failed to execute command: ${error.message}`)),
 			);
 		});
+
+		child.stdin?.on("error", (error) => {
+			if (killed || settled) return;
+			killAndReject(
+				new Error(`Failed to write command input: ${error.message}`),
+			);
+		});
+		child.stdin?.end(config.input, "utf8");
 	});
 }
 

--- a/sdk/packages/core/src/extensions/tools/executors/bash.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/bash.ts
@@ -9,7 +9,7 @@ import { StringDecoder } from "node:string_decoder";
 import {
 	type AgentToolContext,
 	getDefaultShell,
-	getShellArgs,
+	getShellInvocation,
 } from "@cline/shared";
 import { TimeoutError } from "../helpers";
 import type { ShellExecutor } from "../types";
@@ -77,6 +77,7 @@ interface SpawnConfig {
 	args: string[];
 	cwd: string;
 	env: Record<string, string>;
+	input?: string;
 }
 
 /**
@@ -147,6 +148,7 @@ function spawnAndCollect(
 			windowsHide: true,
 		});
 		const childPid = child.pid;
+		child.stdin?.end(config.input, "utf8");
 
 		const stdout = createRollingCollector(maxOutputChars);
 		const stderr = createRollingCollector(maxOutputChars);
@@ -323,14 +325,16 @@ export function createShellExecutor(
 
 	return (command, cwd, context) => {
 		const isStructured = typeof command !== "string";
+		const invocation = isStructured
+			? { args: command.args ?? [] }
+			: getShellInvocation(shell, command);
 		return spawnAndCollect(
 			{
 				executable: isStructured ? command.command : shell,
-				args: isStructured
-					? (command.args ?? [])
-					: getShellArgs(shell, command),
+				args: invocation.args,
 				cwd,
 				env,
+				input: invocation.input,
 			},
 			context,
 			timeoutMs,

--- a/sdk/packages/shared/src/index.browser.ts
+++ b/sdk/packages/shared/src/index.browser.ts
@@ -234,7 +234,9 @@ export { type OmitUndefinedValues, omitUndefinedValues } from "./parse/object";
 export {
 	getDefaultShell,
 	getShellArgs,
+	getShellInvocation,
 	getShellKind,
+	type ShellInvocation,
 	type ShellKind,
 } from "./parse/shell";
 export {

--- a/sdk/packages/shared/src/index.ts
+++ b/sdk/packages/shared/src/index.ts
@@ -250,7 +250,9 @@ export { type OmitUndefinedValues, omitUndefinedValues } from "./parse/object";
 export {
 	getDefaultShell,
 	getShellArgs,
+	getShellInvocation,
 	getShellKind,
+	type ShellInvocation,
 	type ShellKind,
 } from "./parse/shell";
 export {

--- a/sdk/packages/shared/src/parse/shell.test.ts
+++ b/sdk/packages/shared/src/parse/shell.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { getDefaultShell, getShellArgs, getShellKind } from "./shell";
+import {
+	getDefaultShell,
+	getShellArgs,
+	getShellInvocation,
+	getShellKind,
+} from "./shell";
 
 describe("shell helpers", () => {
 	it("selects PowerShell on Windows and bash elsewhere", () => {
@@ -8,19 +13,27 @@ describe("shell helpers", () => {
 		expect(getDefaultShell("linux")).toBe("/bin/bash");
 	});
 
-	it("uses PowerShell flags for PowerShell executables", () => {
+	it("uses an ASCII bootstrap with Unicode-safe PowerShell stdin", () => {
+		const command = "Write-Output '中文'";
+		for (const shell of [
+			"powershell",
+			"C:\\Program Files\\PowerShell\\7\\pwsh.exe",
+		]) {
+			const { args, input } = getShellInvocation(shell, command);
+			expect(args.slice(0, 3)).toEqual([
+				"-NoProfile",
+				"-NonInteractive",
+				"-Command",
+			]);
+			expect(
+				[...args[3]].every((character) => character.charCodeAt(0) <= 0x7f),
+			).toBe(true);
+			expect(input).toBe(command);
+		}
+	});
+
+	it("keeps getShellArgs self-contained for PowerShell callers", () => {
 		expect(getShellArgs("powershell", "Write-Output 'hi'")).toEqual([
-			"-NoProfile",
-			"-NonInteractive",
-			"-Command",
-			"Write-Output 'hi'",
-		]);
-		expect(
-			getShellArgs(
-				"C:\\Program Files\\PowerShell\\7\\pwsh.exe",
-				"Write-Output 'hi'",
-			),
-		).toEqual([
 			"-NoProfile",
 			"-NonInteractive",
 			"-Command",

--- a/sdk/packages/shared/src/parse/shell.ts
+++ b/sdk/packages/shared/src/parse/shell.ts
@@ -49,19 +49,51 @@ export function getShellKind(shell: string): ShellKind {
 	return "posix";
 }
 
-export function getShellArgs(shell: string, command: string): string[] {
+export interface ShellInvocation {
+	args: string[];
+	input?: string;
+}
+
+export function getShellInvocation(
+	shell: string,
+	command: string,
+): ShellInvocation {
 	switch (getShellKind(shell)) {
 		case "powershell":
-			return ["-NoProfile", "-NonInteractive", "-Command", command];
+			// PowerShell's command-line parser decodes -Command through the active
+			// Windows code page. Keep the command line ASCII-only, send the command
+			// through UTF-8 stdin, and make redirected output UTF-8. Stdin also avoids
+			// reducing Windows' process command-line limit with base64 expansion.
+			return {
+				args: [
+					"-NoProfile",
+					"-NonInteractive",
+					"-Command",
+					"[Console]::InputEncoding=[Text.UTF8Encoding]::new();" +
+						"[Console]::OutputEncoding=[Text.UTF8Encoding]::new();" +
+						"$c=[Console]::In.ReadToEnd();& ([ScriptBlock]::Create($c))",
+				],
+				input: command,
+			};
 		case "cmd":
-			return ["/d", "/s", "/c", command];
+			return { args: ["/d", "/s", "/c", command] };
 		// wsl.exe is the Windows launcher for the default WSL distro, not a shell
 		// itself. Run the command through the guest's bash so operators like `|`
 		// and `;` are handled by bash rather than treated as wsl.exe arguments.
 		// wsl.exe translates the Windows cwd to its /mnt mount automatically.
 		case "wsl":
-			return ["bash", "-c", command];
+			return { args: ["bash", "-c", command] };
 		case "posix":
-			return ["-c", command];
+			return { args: ["-c", command] };
 	}
+}
+
+export function getShellArgs(shell: string, command: string): string[] {
+	if (getShellKind(shell) === "powershell") {
+		// Preserve the public helper's self-contained argument contract. Callers
+		// that can write stdin should use getShellInvocation() for Unicode and
+		// commands beyond Windows' process command-line limit.
+		return ["-NoProfile", "-NonInteractive", "-Command", command];
+	}
+	return getShellInvocation(shell, command).args;
 }

--- a/sdk/packages/shared/src/parse/shell.ts
+++ b/sdk/packages/shared/src/parse/shell.ts
@@ -71,7 +71,9 @@ export function getShellInvocation(
 					"-Command",
 					"[Console]::InputEncoding=[Text.UTF8Encoding]::new();" +
 						"[Console]::OutputEncoding=[Text.UTF8Encoding]::new();" +
-						"$c=[Console]::In.ReadToEnd();& ([ScriptBlock]::Create($c))",
+						"$c=[Console]::In.ReadToEnd();" +
+						"$c+=[Environment]::NewLine+'if(-not $?){exit 1}';" +
+						"& ([ScriptBlock]::Create($c))",
 				],
 				input: command,
 			};
@@ -88,6 +90,10 @@ export function getShellInvocation(
 	}
 }
 
+/**
+ * @deprecated Use getShellInvocation() when executing commands so PowerShell
+ * source can travel through Unicode-safe stdin.
+ */
 export function getShellArgs(shell: string, command: string): string[] {
 	if (getShellKind(shell) === "powershell") {
 		// Preserve the public helper's self-contained argument contract. Callers


### PR DESCRIPTION
### Related Issue

**Issue:** #12437

### Description

VS Code can resolve a source-based PowerShell profile or Cline's explicit PowerShell 7 profile to a Microsoft Store installation. Store App Execution Aliases are launchable reparse points, but Node's `existsSync()` reports them as missing, so background execution fell back to the nonexistent MSI path. PowerShell command text also crossed the Windows code page through `-Command`, corrupting non-ASCII source and output.

This change makes foreground configuration, model prompting, and background execution select the same launchable PowerShell. It recognizes Store aliases and sends PowerShell scripts through UTF-8 stdin with an ASCII bootstrap that works under both Windows PowerShell 5.1's .NET Framework runtime and modern PowerShell 7. The bootstrap preserves direct PowerShell exit semantics: a failed final operation exits 1, while an explicit `exit N` remains N.

The executor now closes stdin for every shell invocation. Commands that read stdin receive EOF instead of blocking indefinitely, and stdin write failures enter the same process-tree cleanup path as cancellation and timeout.

Packaged Windows VS Code E2Es select Background Exec through the real settings UI and verify both the Windows PowerShell 5.1 and Store PowerShell 7 profiles, including version, `PSHOME`, and `UNICODE=中文` in the rendered result.

### Test Procedure

```powershell
cd sdk/packages/shared
bun run test:unit -- src/parse/shell.test.ts
bun run typecheck

cd ../core
bun run test:unit -- src/extensions/tools/executors/bash.test.ts

cd ../../../apps/vscode
bun test src/test/shell.test.ts
bun x vitest run src/sdk/vscode-run-commands-tool.test.ts --config vitest.config.ts
```

On Windows:

```powershell
cd apps/vscode
bun run test:e2e:build
node src/test/e2e/utils/build.mjs
bun x playwright test -c playwright.config.ts powershell-background.test.ts --project="e2e tests" --headed --reporter=list --retries=0
```

Expected: the packaged Windows PowerShell 5.1 E2E passes with `VERSION=5.1`, a `PSHOME` under `WindowsPowerShell\v1.0`, and `UNICODE=中文`. On a Store-only PowerShell 7 host, the second E2E also passes with `VERSION=7.x` and a `PSHOME` under `WindowsApps`; otherwise that Store-specific case skips.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

`getShellArgs` remains self-contained for compatibility but is now deprecated for command execution; the repository's executor uses the Unicode-safe `{ args, input }` invocation contract. A repository-wide grep found no remaining execution callers of `getShellArgs`.

The packaged E2E records the full settings and command workflows and saves local screenshots for both PowerShell profiles.