### PR TITLE
feat(desktop): show token usage in input toolbar

### DIFF
--- a/apps/examples/desktop-app/webview/app/page.tsx
+++ b/apps/examples/desktop-app/webview/app/page.tsx
@@ -488,6 +488,8 @@ function ChatThreadPane({
 	const [providerCredentials, setProviderCredentials] = useState<
 		Record<string, { apiKey: string }>
 	>({});
+	const [providerModelContextWindows, setProviderModelContextWindows] =
+		useState<Record<string, Record<string, number>>>({});
 	const [providersLoaded, setProvidersLoaded] = useState(false);
 	// History paths lead each merge: they are ordered by session recency, so
 	// stored or stale entries only append after them.
@@ -545,6 +547,7 @@ function ChatThreadPane({
 					return;
 				}
 				const next: Record<string, { apiKey: string }> = {};
+				const nextContextWindows: Record<string, Record<string, number>> = {};
 				for (const provider of payload.providers ?? []) {
 					const id = provider.id?.trim();
 					if (!id) {
@@ -553,8 +556,21 @@ function ChatThreadPane({
 					next[id] = {
 						apiKey: provider.apiKey?.trim() ?? "",
 					};
+					const contextWindows: Record<string, number> = {};
+					for (const model of provider.modelList ?? []) {
+						if (
+							model.id &&
+							typeof model.contextWindow === "number" &&
+							Number.isFinite(model.contextWindow) &&
+							model.contextWindow > 0
+						) {
+							contextWindows[model.id] = model.contextWindow;
+						}
+					}
+					nextContextWindows[id] = contextWindows;
 				}
 				setProviderCredentials(next);
+				setProviderModelContextWindows(nextContextWindows);
 			} catch {
 				// Keep current config if provider catalog cannot be read.
 			} finally {
@@ -567,6 +583,9 @@ function ChatThreadPane({
 			cancelled = true;
 		};
 	}, []);
+
+	const modelContextWindow =
+		providerModelContextWindows[config.provider.trim()]?.[config.model.trim()];
 
 	useEffect(() => {
 		const selected = providerCredentials[config.provider];
@@ -1325,6 +1344,7 @@ function ChatThreadPane({
 			onSend={(prompt) => void handleSend(prompt)}
 			gitBranch={gitBranch}
 			model={config.model}
+			modelContextWindow={modelContextWindow}
 			mode={config.mode}
 			promptsInQueue={promptsInQueue}
 			promptDraft={promptDraft}

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.test.tsx
@@ -186,7 +186,7 @@ describe("ChatInputBar", () => {
 		expect(workspaceFooterSlot?.className).not.toContain("truncate");
 		expect(workspaceFooterSlot?.className).not.toContain("hidden");
 		expect(workspaceFooterSlot?.className).not.toContain("max-w-");
-		const rightControls = workspaceFooterSlot?.parentElement;
+		const rightControls = workspaceFooterSlot?.parentElement?.parentElement;
 		expect(rightControls?.contains(workspaceTrigger ?? null)).toBe(true);
 		expect(
 			rightControls?.contains(
@@ -483,6 +483,7 @@ describe("ChatInputBar token ring", () => {
 		);
 		expect(trigger?.textContent).toBe("");
 		const ring = trigger?.querySelector("svg");
+		expect(ring?.classList.contains("size-5")).toBe(true);
 		expect(ring?.getAttribute("height")).toBe("22");
 		expect(ring?.getAttribute("width")).toBe("22");
 		const progressCircle = trigger?.querySelector("circle.stroke-primary");
@@ -494,6 +495,8 @@ describe("ChatInputBar token ring", () => {
 
 		const workspaceSelector = container.querySelector("#git-branch-btn");
 		expect(workspaceSelector).not.toBeNull();
+		expect(trigger?.parentElement?.classList.contains("gap-0")).toBe(true);
+		expect(trigger?.parentElement?.contains(workspaceSelector)).toBe(true);
 		expect(
 			Boolean(
 				trigger?.compareDocumentPosition(workspaceSelector as Node) &

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.test.tsx
@@ -135,8 +135,11 @@ describe("ChatInputBar", () => {
 		const promptInput = container.querySelector<HTMLTextAreaElement>(
 			'textarea[role="combobox"]',
 		);
-		expect(promptInput?.className).toContain("overflow-y-hidden");
-		expect(promptInput?.className).not.toContain("overflow-y-auto");
+		expect(promptInput?.rows).toBe(2);
+		expect(promptInput?.className).toContain("field-sizing-content");
+		expect(promptInput?.className).toContain("overflow-y-auto");
+		expect(promptInput?.style.minHeight).toBe("2.5rem");
+		expect(promptInput?.style.maxHeight).toBe("6.25rem");
 
 		await act(async () => {
 			if (!promptInput) return;
@@ -147,7 +150,7 @@ describe("ChatInputBar", () => {
 			setValue?.call(promptInput, "first line\nsecond line");
 			promptInput.dispatchEvent(new Event("input", { bubbles: true }));
 		});
-		expect(promptInput?.className).toContain("overflow-y-auto");
+		expect(promptInput?.rows).toBe(2);
 
 		await render("starting");
 		expect(container.querySelector('[aria-label="Stop agent"]')).toBeNull();
@@ -188,11 +191,12 @@ describe("ChatInputBar", () => {
 		expect(workspaceFooterSlot?.className).not.toContain("max-w-");
 		const rightControls = workspaceFooterSlot?.parentElement?.parentElement;
 		expect(rightControls?.contains(workspaceTrigger ?? null)).toBe(true);
-		expect(
-			rightControls?.contains(
-				container.querySelector('[aria-label="Send message"]'),
-			),
-		).toBe(true);
+		const sendTrigger = container.querySelector('[aria-label="Send message"]');
+		const stopTrigger = container.querySelector('[aria-label="Stop agent"]');
+		expect(promptInput?.parentElement?.className).toContain("items-end");
+		expect(promptInput?.parentElement?.contains(sendTrigger)).toBe(true);
+		expect(promptInput?.parentElement?.contains(stopTrigger)).toBe(true);
+		expect(rightControls?.contains(sendTrigger)).toBe(false);
 		expect(leftControls?.parentElement).toBe(rightControls?.parentElement);
 	});
 
@@ -483,7 +487,7 @@ describe("ChatInputBar token ring", () => {
 		);
 		expect(trigger?.textContent).toBe("");
 		const ring = trigger?.querySelector("svg");
-		expect(ring?.classList.contains("size-5")).toBe(true);
+		expect(ring?.classList.contains("size-3.5")).toBe(true);
 		expect(ring?.getAttribute("height")).toBe("22");
 		expect(ring?.getAttribute("width")).toBe("22");
 		const progressCircle = trigger?.querySelector("circle.stroke-primary");

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.test.tsx
@@ -392,3 +392,150 @@ describe("ChatInputBar", () => {
 		expect(onRemovePromptInQueue).toHaveBeenCalledWith("queued-prompt-1");
 	});
 });
+
+describe("ChatInputBar token ring", () => {
+	const renderTokenUsage = async (
+		summary: Parameters<typeof ChatInputBar>[0]["summary"],
+		modelContextWindow?: number,
+	) => {
+		await act(async () => {
+			root.render(
+				<WorkspaceProvider
+					value={{
+						workspaceRoot: "/workspace/cline",
+						workspaces: ["/workspace/cline"],
+						listWorkspaces: vi.fn(async () => ["/workspace/cline"]),
+						refreshWorkspaces: vi.fn(async () => undefined),
+						switchWorkspace: vi.fn(async () => true),
+						pickWorkspaceDirectory: vi.fn(async () => null),
+						selectChat: vi.fn(async () => true),
+					}}
+				>
+					<ChatInputBar
+						attachments={[]}
+						gitBranch="main"
+						mode="act"
+						model="test-model"
+						modelContextWindow={modelContextWindow}
+						onAbort={vi.fn()}
+						onAttachFiles={vi.fn()}
+						onEditPromptInQueue={vi.fn()}
+						onListGitBranches={vi.fn(async () => ({
+							current: "main",
+							branches: ["main"],
+						}))}
+						onModeToggle={vi.fn()}
+						onModelChange={vi.fn()}
+						onPromptInputChange={vi.fn()}
+						onProviderChange={vi.fn()}
+						onReasoningChange={vi.fn()}
+						onRemoveAttachment={vi.fn()}
+						onRemovePromptInQueue={vi.fn()}
+						onSend={vi.fn()}
+						onSteerPromptInQueue={vi.fn()}
+						onSwitchGitBranch={vi.fn(async () => true)}
+						promptDraft={{ version: 0, value: "" }}
+						promptsInQueue={[]}
+						provider="cline"
+						reasoningEffort="low"
+						status="idle"
+						summary={summary}
+						thinking
+					/>
+				</WorkspaceProvider>,
+			);
+			await Promise.resolve();
+		});
+		return container.querySelector<HTMLButtonElement>("#token-usage");
+	};
+
+	it("waits for input usage and model context metadata", async () => {
+		expect(
+			await renderTokenUsage({
+				toolCalls: 0,
+				tokensIn: 500,
+				tokensOut: 0,
+			}),
+		).toBeNull();
+		expect(
+			await renderTokenUsage(
+				{
+					toolCalls: 0,
+					tokensIn: 0,
+					tokensOut: 500,
+				},
+				2000,
+			),
+		).toBeNull();
+	});
+
+	it("fills from input only and sits immediately before the workspace selector", async () => {
+		const trigger = await renderTokenUsage(
+			{
+				toolCalls: 0,
+				tokensIn: 1000,
+				tokensOut: 500,
+			},
+			2000,
+		);
+		expect(trigger?.getAttribute("aria-label")).toBe(
+			"Context window: 1,000 of 2,000 input tokens used (50%)",
+		);
+		expect(trigger?.textContent).toBe("");
+		const ring = trigger?.querySelector("svg");
+		expect(ring?.getAttribute("height")).toBe("22");
+		expect(ring?.getAttribute("width")).toBe("22");
+		const progressCircle = trigger?.querySelector("circle.stroke-primary");
+		expect(progressCircle?.getAttribute("stroke-width")).toBe("4");
+		const circumference = 2 * Math.PI * 8.5;
+		expect(
+			Number(progressCircle?.getAttribute("stroke-dashoffset")),
+		).toBeCloseTo(circumference * 0.5);
+
+		const workspaceSelector = container.querySelector("#git-branch-btn");
+		expect(workspaceSelector).not.toBeNull();
+		expect(
+			Boolean(
+				trigger?.compareDocumentPosition(workspaceSelector as Node) &
+					Node.DOCUMENT_POSITION_FOLLOWING,
+			),
+		).toBe(true);
+		expect(container.textContent).not.toContain("1,500 tokens");
+	});
+
+	it("opens only supported usage details on click", async () => {
+		const trigger = await renderTokenUsage(
+			{
+				toolCalls: 0,
+				tokensIn: 500_000,
+				tokensOut: 500,
+				totalCostUsd: 0.0142,
+			},
+			1_000_000,
+		);
+		await act(async () => {
+			trigger?.click();
+		});
+
+		const panel = document.querySelector("#token-usage-panel");
+		expect(panel?.textContent).toContain("Context window500k / 1.0M (50%)");
+		expect(panel?.textContent).toContain("Output tokens500");
+		expect(panel?.textContent).toContain("Cost$0.014");
+		expect(panel?.textContent).not.toContain("Total");
+		expect(panel?.textContent).not.toContain("usage limit");
+	});
+
+	it("saturates at 100% without switching to a destructive style", async () => {
+		const trigger = await renderTokenUsage(
+			{
+				toolCalls: 0,
+				tokensIn: 130_000,
+				tokensOut: 5_000,
+			},
+			128_000,
+		);
+		const progressCircle = trigger?.querySelector("circle.stroke-primary");
+		expect(progressCircle?.getAttribute("stroke-dashoffset")).toBe("0");
+		expect(trigger?.querySelector(".stroke-destructive")).toBeNull();
+	});
+});

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
@@ -10,7 +10,6 @@ import {
 	ChevronRight,
 	CircleStop,
 	Clock3,
-	Coins,
 	Cpu,
 	Paperclip,
 	Pencil,
@@ -26,6 +25,12 @@ import {
 	useRef,
 	useState,
 } from "react";
+import { Button } from "@/components/ui/button";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
 import {
 	Select,
 	SelectContent,
@@ -35,6 +40,7 @@ import {
 } from "@/components/ui/select";
 import { useWorkspace } from "@/contexts/workspace-context";
 import type { PromptInQueue } from "@/hooks/chat-session/types";
+import { formatCostUsd } from "@/hooks/use-session-history";
 import type { ChatSessionConfig, ChatSessionStatus } from "@/lib/chat-schema";
 import { desktopClient } from "@/lib/desktop-client";
 import {
@@ -216,6 +222,7 @@ type ChatInputBarProps = {
 	status: ChatSessionStatus;
 	provider: string;
 	model: string;
+	modelContextWindow?: number;
 	mode: "act" | "plan";
 	thinking: ChatSessionConfig["thinking"];
 	reasoningEffort: ChatSessionConfig["reasoningEffort"];
@@ -246,6 +253,7 @@ type ChatInputBarProps = {
 		toolCalls: number;
 		tokensIn: number;
 		tokensOut: number;
+		totalCostUsd?: number;
 	};
 };
 
@@ -254,6 +262,7 @@ export function ChatInputBar({
 	status,
 	provider,
 	model,
+	modelContextWindow,
 	mode,
 	thinking,
 	reasoningEffort,
@@ -390,13 +399,6 @@ export function ChatInputBar({
 	const [queueExpanded, setQueueExpanded] = useState(false);
 	const queuedPromptsId = useId();
 
-	const tokensSummary = useMemo(() => {
-		const total = summary.tokensIn + summary.tokensOut;
-		if (total === 0) {
-			return undefined;
-		}
-		return `${total.toLocaleString()} tokens`;
-	}, [summary.tokensIn, summary.tokensOut]);
 	const effortIndex = useMemo(
 		() => resolveEffortIndex(thinking, reasoningEffort),
 		[reasoningEffort, thinking],
@@ -1194,45 +1196,46 @@ export function ChatInputBar({
 							))}
 						</SelectContent>
 					</Select>
-					{tokensSummary ? (
-						<span className="max-[900px]:hidden">
-							<StatusItem
-								icon={Coins}
-								label={tokensSummary}
-								hasOption={false}
-							/>
-						</span>
-					) : null}
 				</div>
 
 				<div className="ml-auto flex min-w-0 items-center gap-2 max-[560px]:shrink-0">
 					{variant === "conversation" ? (
-						<div className="min-w-0 overflow-visible">
-							<WorkspaceSelector
-								currentBranch={gitBranch}
-								disabled
-								onListGitBranches={onListGitBranches}
-								onRefreshWorkspaces={onRefreshWorkspaces}
-								onPickWorkspaceDirectory={onPickWorkspaceDirectory}
-								onSwitchGitBranch={onSwitchGitBranch}
-								onSwitchWorkspace={onSwitchWorkspace}
-								workspaces={workspaces}
-								workspaceRoot={workspaceRoot}
+						<>
+							<TokenUsageRing
+								usage={{
+									contextWindow: modelContextWindow,
+									tokensIn: summary.tokensIn,
+									tokensOut: summary.tokensOut,
+									totalCost: summary.totalCostUsd,
+								}}
 							/>
-						</div>
+							<div className="min-w-0 overflow-visible">
+								<WorkspaceSelector
+									currentBranch={gitBranch}
+									disabled
+									onListGitBranches={onListGitBranches}
+									onRefreshWorkspaces={onRefreshWorkspaces}
+									onPickWorkspaceDirectory={onPickWorkspaceDirectory}
+									onSwitchGitBranch={onSwitchGitBranch}
+									onSwitchWorkspace={onSwitchWorkspace}
+									workspaces={workspaces}
+									workspaceRoot={workspaceRoot}
+								/>
+							</div>
+						</>
 					) : null}
 					<div className="flex shrink-0 items-center gap-2">
 						{canAbort && (
 							<button
 								aria-label="Stop agent"
 								className={cn(
-									"bg-foreground p-1.5 text-background transition-colors hover:bg-foreground/80",
+									"bg-foreground p-0 text-background transition-colors hover:bg-primary/80",
 									variant === "welcome" ? "rounded-md" : "rounded-full",
 								)}
 								onClick={onAbort}
 								type="button"
 							>
-								<CircleStop className="h-4 w-4" />
+								<CircleStop className="size-2" />
 							</button>
 						)}
 						{(!isBusy || canSend) && (
@@ -1242,13 +1245,13 @@ export function ChatInputBar({
 									"p-1.5 transition-colors disabled:cursor-not-allowed disabled:opacity-50",
 									variant === "welcome"
 										? "rounded-md bg-[linear-gradient(145deg,var(--primary-emphasis),var(--primary))] text-white shadow-sm hover:brightness-110"
-										: "rounded-full bg-foreground text-background hover:bg-foreground/80",
+										: "rounded-full bg-primary text-background hover:bg-primary/80",
 								)}
 								disabled={!canSend}
 								onClick={handleSend}
 								type="button"
 							>
-								<ArrowUp className="h-4 w-4" />
+								<ArrowUp className="size-2" />
 							</button>
 						)}
 					</div>
@@ -1612,40 +1615,121 @@ const ModelSelector = memo(function ModelSelector({
 	);
 });
 
-function StatusItem({
-	icon: Icon,
-	label,
-	onClick,
-	disabled,
-	hasOption = true,
-}: {
-	icon?: React.ComponentType<{ className?: string }>;
-	label: string;
-	onClick?: () => void;
-	disabled?: boolean;
-	hasOption?: boolean;
-}) {
-	const content = (
-		<>
-			{Icon ? <Icon className="h-3 w-3" /> : null}
-			<span className="max-[560px]:sr-only">{label}</span>
-			{hasOption ? <ChevronDown className="h-2.5 w-2.5" /> : null}
-		</>
-	);
-	if (!onClick) {
-		return <span className="flex items-center gap-1">{content}</span>;
+type TokenUsage = {
+	tokensIn: number;
+	tokensOut: number;
+	totalCost?: number;
+	contextWindow?: number;
+};
+
+/** Current input context relative to the selected model's context window. */
+function TokenUsageRing({ usage }: { usage: TokenUsage }) {
+	const contextWindow = usage.contextWindow;
+	if (usage.tokensIn <= 0 || !contextWindow || contextWindow <= 0) {
+		return null;
 	}
-	return (
-		<button
-			className={cn(
-				"flex items-center gap-1 transition-colors",
-				disabled ? "cursor-not-allowed opacity-60" : "hover:text-foreground",
-			)}
-			disabled={disabled}
-			onClick={onClick}
-			type="button"
-		>
-			{content}
-		</button>
+
+	const ratio = Math.min(
+		Math.max(usage.tokensIn / Math.max(contextWindow, 1), 0),
+		1,
 	);
+	const percent = Math.round(ratio * 100);
+	const cost = formatCostUsd(usage.totalCost);
+	const contextUsageLabel = `${formatCompactTokens(usage.tokensIn)} / ${formatCompactTokens(contextWindow)} (${percent}%)`;
+	const radius = 8.5;
+	const circumference = 2 * Math.PI * radius;
+
+	return (
+		<Popover>
+			<PopoverTrigger asChild>
+				<Button
+					aria-label={`Context window: ${usage.tokensIn.toLocaleString()} of ${contextWindow.toLocaleString()} input tokens used (${percent}%)`}
+					className="size-7 shrink-0 p-0 text-muted-foreground data-[state=open]:bg-accent"
+					id="token-usage"
+					size="icon-sm"
+					type="button"
+					variant="ghost"
+				>
+					<svg
+						aria-hidden="true"
+						className="-rotate-90"
+						height="22"
+						viewBox="0 0 22 22"
+						width="22"
+					>
+						<circle
+							className="stroke-muted-foreground/20"
+							cx="11"
+							cy="11"
+							fill="none"
+							r={radius}
+							strokeWidth="4"
+						/>
+						<circle
+							className="stroke-primary transition-[stroke-dashoffset] duration-200"
+							cx="11"
+							cy="11"
+							fill="none"
+							r={radius}
+							strokeDasharray={circumference}
+							strokeDashoffset={circumference * (1 - ratio)}
+							strokeLinecap="round"
+							strokeWidth="4"
+						/>
+					</svg>
+				</Button>
+			</PopoverTrigger>
+			<PopoverContent
+				align="end"
+				className="w-80 p-0"
+				id="token-usage-panel"
+				side="top"
+				sideOffset={8}
+			>
+				<div className="px-3 py-3">
+					<div className="flex items-center justify-between gap-4 text-sm">
+						<span className="text-muted-foreground">Context window</span>
+						<span className="font-mono text-xs text-foreground">
+							{contextUsageLabel}
+						</span>
+					</div>
+					<div className="mt-2 h-1 overflow-hidden rounded-full bg-muted">
+						<div
+							aria-hidden="true"
+							className="h-full rounded-full bg-primary transition-[width] duration-200"
+							style={{ width: `${percent}%` }}
+						/>
+					</div>
+				</div>
+				<div className="border-t border-border/70 px-3 py-2.5 text-xs">
+					<div className="flex items-center justify-between gap-4">
+						<span className="text-muted-foreground">Output tokens</span>
+						<span className="font-mono text-foreground">
+							{usage.tokensOut.toLocaleString()}
+						</span>
+					</div>
+					{cost ? (
+						<div className="mt-2 flex items-center justify-between gap-4">
+							<span className="text-muted-foreground">Cost</span>
+							<span className="font-mono text-foreground">{cost}</span>
+						</div>
+					) : null}
+				</div>
+			</PopoverContent>
+		</Popover>
+	);
+}
+
+function formatCompactTokens(value: number): string {
+	if (value >= 1_000_000) {
+		return `${(value / 1_000_000).toFixed(1)}M`;
+	}
+	if (value >= 1_000) {
+		return `${formatCompactUnit(value / 1_000)}k`;
+	}
+	return value.toLocaleString();
+}
+
+function formatCompactUnit(value: number): string {
+	return value.toFixed(1).replace(/\.0$/, "");
 }

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
@@ -1200,7 +1200,7 @@ export function ChatInputBar({
 
 				<div className="ml-auto flex min-w-0 items-center gap-2 max-[560px]:shrink-0">
 					{variant === "conversation" ? (
-						<>
+						<div className="flex min-w-0 items-center gap-0">
 							<TokenUsageRing
 								usage={{
 									contextWindow: modelContextWindow,
@@ -1222,7 +1222,7 @@ export function ChatInputBar({
 									workspaceRoot={workspaceRoot}
 								/>
 							</div>
-						</>
+						</div>
 					) : null}
 					<div className="flex shrink-0 items-center gap-2">
 						{canAbort && (
@@ -1652,7 +1652,7 @@ function TokenUsageRing({ usage }: { usage: TokenUsage }) {
 				>
 					<svg
 						aria-hidden="true"
-						className="-rotate-90"
+						className="-rotate-90 size-3.5"
 						height="22"
 						viewBox="0 0 22 22"
 						width="22"

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
@@ -118,7 +118,9 @@ const EFFORT_LEVELS: ReasoningEffortOption[] = [
 	{ label: "Extra", value: "xhigh" },
 ];
 const PROMPT_INPUT_COLLAPSED_ROWS = 1;
-const PROMPT_INPUT_FOCUSED_ROWS = 5;
+const PROMPT_INPUT_EXPANDED_ROWS = 2;
+const PROMPT_INPUT_MAX_ROWS = 5;
+const PROMPT_INPUT_LINE_HEIGHT_REM = 1.25;
 
 function resolveEffortIndex(
 	thinking: ChatSessionConfig["thinking"],
@@ -411,6 +413,10 @@ export function ChatInputBar({
 			: !hasExplicitReasoningSelection && modelSupportsReasoning === false
 				? "None"
 				: (EFFORT_LEVELS[effortIndex]?.label ?? "Reasoning");
+	const promptInputRows =
+		variant === "welcome" || promptInputFocused
+			? PROMPT_INPUT_EXPANDED_ROWS
+			: PROMPT_INPUT_COLLAPSED_ROWS;
 	const handleEffortChange = useCallback(
 		(value: string) => {
 			if (modelSupportsReasoning !== true) {
@@ -947,7 +953,7 @@ export function ChatInputBar({
 						className={cn(
 							"flex items-end gap-2 rounded-lg border border-border bg-background px-3 py-2.5 transition-all focus-within:border-primary/50 focus-within:ring-1 focus-within:ring-primary/20",
 							variant === "welcome" &&
-								"min-h-16 items-start rounded-none border-0 bg-transparent px-0 py-0 focus-within:ring-0",
+								"min-h-16 rounded-none border-0 bg-transparent px-0 py-0 focus-within:ring-0",
 						)}
 					>
 						<textarea
@@ -969,10 +975,7 @@ export function ChatInputBar({
 							aria-expanded={slashOpen || mentionOpen}
 							aria-haspopup="listbox"
 							className={cn(
-								"max-h-60 min-h-5 flex-1 resize-none bg-transparent text-sm leading-5 text-foreground placeholder:text-muted-foreground outline-none",
-								promptInput.includes("\n")
-									? "overflow-y-auto"
-									: "overflow-y-hidden",
+								"field-sizing-content flex-1 resize-none overflow-y-auto bg-transparent text-sm leading-5 text-foreground placeholder:text-muted-foreground outline-none",
 							)}
 							onChange={(e) => {
 								setPromptInput(e.target.value);
@@ -1068,15 +1071,44 @@ export function ChatInputBar({
 							}
 							ref={promptInputRef}
 							role="combobox"
-							rows={
-								variant === "welcome"
-									? 2
-									: promptInputFocused
-										? PROMPT_INPUT_FOCUSED_ROWS
-										: PROMPT_INPUT_COLLAPSED_ROWS
-							}
+							rows={promptInputRows}
+							style={{
+								maxHeight: `${PROMPT_INPUT_MAX_ROWS * PROMPT_INPUT_LINE_HEIGHT_REM}rem`,
+								minHeight: `${promptInputRows * PROMPT_INPUT_LINE_HEIGHT_REM}rem`,
+							}}
 							value={promptInput}
 						/>
+						<div className="flex shrink-0 items-center gap-2">
+							{canAbort && (
+								<button
+									aria-label="Stop agent"
+									className={cn(
+										"bg-foreground p-0 text-background transition-colors hover:bg-primary/80",
+										variant === "welcome" ? "rounded-md" : "rounded-full",
+									)}
+									onClick={onAbort}
+									type="button"
+								>
+									<CircleStop className="size-2" />
+								</button>
+							)}
+							{(!isBusy || canSend) && (
+								<button
+									aria-label="Send message"
+									className={cn(
+										"p-1.5 transition-colors disabled:cursor-not-allowed disabled:opacity-50",
+										variant === "welcome"
+											? "rounded-md bg-[linear-gradient(145deg,var(--primary-emphasis),var(--primary))] text-white shadow-sm hover:brightness-110"
+											: "rounded-full bg-primary text-background hover:bg-primary/80",
+									)}
+									disabled={!canSend}
+									onClick={handleSend}
+									type="button"
+								>
+									<ArrowUp className="size-2" />
+								</button>
+							)}
+						</div>
 					</div>
 				</div>
 				{attachments.length > 0 && (
@@ -1101,7 +1133,7 @@ export function ChatInputBar({
 				)}
 			</div>
 
-			{/* Composer settings and submit */}
+			{/* Composer settings */}
 			<div className="flex min-w-0 items-center justify-between gap-x-3 gap-y-2 border-t border-border px-3 py-2 text-[11px] text-muted-foreground">
 				<div className="flex min-w-0 flex-auto flex-wrap items-center gap-2 max-[560px]:flex-nowrap">
 					<button
@@ -1201,14 +1233,6 @@ export function ChatInputBar({
 				<div className="ml-auto flex min-w-0 items-center gap-2 max-[560px]:shrink-0">
 					{variant === "conversation" ? (
 						<div className="flex min-w-0 items-center gap-0">
-							<TokenUsageRing
-								usage={{
-									contextWindow: modelContextWindow,
-									tokensIn: summary.tokensIn,
-									tokensOut: summary.tokensOut,
-									totalCost: summary.totalCostUsd,
-								}}
-							/>
 							<div className="min-w-0 overflow-visible">
 								<WorkspaceSelector
 									currentBranch={gitBranch}
@@ -1222,39 +1246,16 @@ export function ChatInputBar({
 									workspaceRoot={workspaceRoot}
 								/>
 							</div>
+							<TokenUsageRing
+								usage={{
+									contextWindow: modelContextWindow,
+									tokensIn: summary.tokensIn,
+									tokensOut: summary.tokensOut,
+									totalCost: summary.totalCostUsd,
+								}}
+							/>
 						</div>
 					) : null}
-					<div className="flex shrink-0 items-center gap-2">
-						{canAbort && (
-							<button
-								aria-label="Stop agent"
-								className={cn(
-									"bg-foreground p-0 text-background transition-colors hover:bg-primary/80",
-									variant === "welcome" ? "rounded-md" : "rounded-full",
-								)}
-								onClick={onAbort}
-								type="button"
-							>
-								<CircleStop className="size-2" />
-							</button>
-						)}
-						{(!isBusy || canSend) && (
-							<button
-								aria-label="Send message"
-								className={cn(
-									"p-1.5 transition-colors disabled:cursor-not-allowed disabled:opacity-50",
-									variant === "welcome"
-										? "rounded-md bg-[linear-gradient(145deg,var(--primary-emphasis),var(--primary))] text-white shadow-sm hover:brightness-110"
-										: "rounded-full bg-primary text-background hover:bg-primary/80",
-								)}
-								disabled={!canSend}
-								onClick={handleSend}
-								type="button"
-							>
-								<ArrowUp className="size-2" />
-							</button>
-						)}
-					</div>
 				</div>
 			</div>
 		</div>

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
@@ -1156,7 +1156,7 @@ export function ChatInputBar({
 						ref={fileInputRef}
 						type="file"
 					/>
-					<div className="hidden flex shrink-0 items-center rounded-md bg-muted p-0.5">
+					<div className="hidden shrink-0 items-center rounded-md bg-muted p-0.5">
 						<button
 							aria-pressed={mode === "plan"}
 							className={cn(

--- a/apps/examples/desktop-app/webview/hooks/chat-session/types.ts
+++ b/apps/examples/desktop-app/webview/hooks/chat-session/types.ts
@@ -21,6 +21,15 @@ export type ReasoningDeltaEvent = {
 	redacted?: boolean;
 };
 
+export type ChatUsageEvent = {
+	/** Tokens consumed by the latest model request. */
+	inputTokens?: number;
+	/** Tokens produced by the latest model request. */
+	outputTokens?: number;
+	/** Cost of the latest model request. */
+	cost?: number;
+};
+
 export type ToolCallStartEvent = {
 	toolCallId?: string;
 	toolName?: string;

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
@@ -7,7 +7,10 @@ import { useChatSession } from "./use-chat-session";
 
 const { invokeMock, subscribeMock } = vi.hoisted(() => ({
 	invokeMock: vi.fn(),
-	subscribeMock: vi.fn(() => () => undefined),
+	subscribeMock: vi.fn(
+		(_eventName: string, _handler: (payload: unknown) => void) => () =>
+			undefined,
+	),
 }));
 
 vi.mock("@/lib/desktop-client", () => ({
@@ -585,7 +588,7 @@ describe("useChatSession", () => {
 		expect(current.summary.totalCostUsd).toBeCloseTo(0.03);
 	});
 
-	it("does not add completed turn cost after receiving its streamed deltas", async () => {
+	it("preserves queued usage while the preceding turn is persisted", async () => {
 		type SendResponse = {
 			ok: true;
 			result: {
@@ -686,7 +689,7 @@ describe("useChatSession", () => {
 			resolveSend?.({
 				ok: true,
 				result: {
-					text: "",
+					text: "Completed turn",
 					finishReason: "completed",
 					usage: {
 						inputTokens: 13_000,

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
@@ -525,6 +525,139 @@ describe("useChatSession", () => {
 		).toBe(thinkingTimestamp);
 	});
 
+	it("updates current token usage from live usage events", async () => {
+		invokeMock.mockImplementation(
+			async (command: string, args?: Record<string, unknown>) => {
+				if (command === "get_process_context") {
+					return { cwd: "/workspace/cline", workspaceRoot: "/workspace/cline" };
+				}
+				if (command === "chat_session_command") {
+					const request = args?.request as
+						| { action?: string; config?: { sessionId?: string } }
+						| undefined;
+					if (request?.action === "start") {
+						return { sessionId: request.config?.sessionId };
+					}
+					if (request?.action === "send") {
+						return { ok: true };
+					}
+				}
+				return [];
+			},
+		);
+
+		await act(async () => {
+			await current.sendPrompt("Track this turn");
+		});
+		const chatEventHandler = subscribeMock.mock.calls.find(
+			([eventName]) => eventName === "chat_event",
+		)?.[1] as ((payload: unknown) => void) | undefined;
+
+		await act(async () => {
+			chatEventHandler?.({
+				sessionId: current.sessionId,
+				stream: "chat_usage",
+				chunk: JSON.stringify({
+					inputTokens: 12_000,
+					outputTokens: 500,
+					cost: 0.01,
+				}),
+				ts: Date.now(),
+				index: 1,
+			});
+			chatEventHandler?.({
+				sessionId: current.sessionId,
+				stream: "chat_usage",
+				chunk: JSON.stringify({
+					inputTokens: 13_000,
+					outputTokens: 700,
+					cost: 0.02,
+				}),
+				ts: Date.now(),
+				index: 2,
+			});
+		});
+
+		expect(current.summary).toMatchObject({
+			tokensIn: 13_000,
+			tokensOut: 700,
+		});
+		expect(current.summary.totalCostUsd).toBeCloseTo(0.03);
+	});
+
+	it("hydrates current token usage and cumulative cost from messages", async () => {
+		const hydratedSessionId = "session-with-usage";
+		invokeMock.mockImplementation(
+			async (command: string, args?: Record<string, unknown>) => {
+				if (command === "get_process_context") {
+					return { cwd: "/workspace/cline", workspaceRoot: "/workspace/cline" };
+				}
+				if (command === "read_session_messages") {
+					return [
+						{
+							id: "assistant-1",
+							sessionId: hydratedSessionId,
+							role: "assistant",
+							content: "First response",
+							createdAt: 1,
+							meta: {
+								inputTokens: 10_000,
+								outputTokens: 500,
+								totalCost: 0.01,
+							},
+						},
+						{
+							id: "assistant-2",
+							sessionId: hydratedSessionId,
+							role: "assistant",
+							content: "Latest response",
+							createdAt: 2,
+							meta: {
+								inputTokens: 24_000,
+								outputTokens: 1_000,
+								totalCost: 0.02,
+							},
+						},
+					];
+				}
+				if (command === "read_session_hooks") return [];
+				if (command === "chat_session_command") {
+					const request = args?.request as { action?: string } | undefined;
+					if (request?.action === "attach") {
+						return {
+							sessionId: hydratedSessionId,
+							status: "completed",
+							provider: "cline",
+							model: "test-model",
+							cwd: "/workspace/cline",
+							workspaceRoot: "/workspace/cline",
+						};
+					}
+					return { promptsInQueue: [] };
+				}
+				return [];
+			},
+		);
+
+		await act(async () => {
+			await current.hydrateSession({
+				sessionId: hydratedSessionId,
+				status: "completed",
+				provider: "cline",
+				model: "test-model",
+				cwd: "/workspace/cline",
+				workspaceRoot: "/workspace/cline",
+				startedAt: "2026-07-31T00:00:00.000Z",
+			});
+		});
+
+		expect(current.summary).toMatchObject({
+			tokensIn: 24_000,
+			tokensOut: 1_000,
+		});
+		expect(current.summary.totalCostUsd).toBeCloseTo(0.03);
+	});
+
 	it("returns to a completed status when a queued turn finishes via chat_done", async () => {
 		invokeMock.mockImplementation(
 			async (command: string, args?: Record<string, unknown>) => {

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
@@ -588,7 +588,7 @@ describe("useChatSession", () => {
 		expect(current.summary.totalCostUsd).toBeCloseTo(0.03);
 	});
 
-	it("preserves queued usage while the preceding turn is persisted", async () => {
+	it("preserves consecutive queued costs while the preceding turn is persisted", async () => {
 		type SendResponse = {
 			ok: true;
 			result: {
@@ -686,6 +686,34 @@ describe("useChatSession", () => {
 		expect(current.summary.totalCostUsd).toBeCloseTo(0.04);
 
 		await act(async () => {
+			chatEventHandler?.({
+				sessionId: current.sessionId,
+				stream: "chat_done",
+				chunk: JSON.stringify({ reason: "completed" }),
+				ts: Date.now(),
+				index: 5,
+			});
+			chatEventHandler?.({
+				sessionId: current.sessionId,
+				stream: "chat_queued_prompt_start",
+				chunk: JSON.stringify({
+					promptId: "queued-after-next",
+					prompt: "Turn after next",
+				}),
+				ts: Date.now(),
+				index: 6,
+			});
+			chatEventHandler?.({
+				sessionId: current.sessionId,
+				stream: "chat_usage",
+				chunk: JSON.stringify({ cost: 0.02 }),
+				ts: Date.now(),
+				index: 7,
+			});
+		});
+		expect(current.summary.totalCostUsd).toBeCloseTo(0.06);
+
+		await act(async () => {
 			resolveSend?.({
 				ok: true,
 				result: {
@@ -705,7 +733,7 @@ describe("useChatSession", () => {
 			tokensIn: 13_000,
 			tokensOut: 700,
 		});
-		expect(current.summary.totalCostUsd).toBeCloseTo(0.04);
+		expect(current.summary.totalCostUsd).toBeCloseTo(0.06);
 	});
 
 	it("hydrates current token usage and cumulative cost from messages", async () => {

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
@@ -585,6 +585,102 @@ describe("useChatSession", () => {
 		expect(current.summary.totalCostUsd).toBeCloseTo(0.03);
 	});
 
+	it("does not add completed turn cost after receiving its streamed deltas", async () => {
+		type SendResponse = {
+			ok: true;
+			result: {
+				text: string;
+				finishReason: "completed";
+				usage: {
+					inputTokens: number;
+					outputTokens: number;
+					totalCost: number;
+				};
+			};
+		};
+		let resolveSend: ((response: SendResponse) => void) | undefined;
+		const sendResponse = new Promise<SendResponse>((resolve) => {
+			resolveSend = resolve;
+		});
+		invokeMock.mockImplementation(
+			async (command: string, args?: Record<string, unknown>) => {
+				if (command === "get_process_context") {
+					return { cwd: "/workspace/cline", workspaceRoot: "/workspace/cline" };
+				}
+				if (command === "chat_session_command") {
+					const request = args?.request as
+						| { action?: string; config?: { sessionId?: string } }
+						| undefined;
+					if (request?.action === "start") {
+						return { sessionId: request.config?.sessionId };
+					}
+					if (request?.action === "send") {
+						return await sendResponse;
+					}
+				}
+				return [];
+			},
+		);
+
+		let sendTask: Promise<void> | undefined;
+		await act(async () => {
+			sendTask = current.sendPrompt("Track this completed turn");
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+		const chatEventHandler = subscribeMock.mock.calls.find(
+			([eventName]) => eventName === "chat_event",
+		)?.[1] as ((payload: unknown) => void) | undefined;
+
+		await act(async () => {
+			chatEventHandler?.({
+				sessionId: current.sessionId,
+				stream: "chat_usage",
+				chunk: JSON.stringify({
+					inputTokens: 12_000,
+					outputTokens: 500,
+					cost: 0.01,
+				}),
+				ts: Date.now(),
+				index: 1,
+			});
+			chatEventHandler?.({
+				sessionId: current.sessionId,
+				stream: "chat_usage",
+				chunk: JSON.stringify({
+					inputTokens: 13_000,
+					outputTokens: 700,
+					cost: 0.02,
+				}),
+				ts: Date.now(),
+				index: 2,
+			});
+		});
+		expect(current.summary.totalCostUsd).toBeCloseTo(0.03);
+
+		await act(async () => {
+			resolveSend?.({
+				ok: true,
+				result: {
+					text: "",
+					finishReason: "completed",
+					usage: {
+						inputTokens: 13_000,
+						outputTokens: 700,
+						totalCost: 0.03,
+					},
+				},
+			});
+			await sendTask;
+		});
+
+		expect(current.summary).toMatchObject({
+			tokensIn: 13_000,
+			tokensOut: 700,
+		});
+		expect(current.summary.totalCostUsd).toBeCloseTo(0.03);
+	});
+
 	it("hydrates current token usage and cumulative cost from messages", async () => {
 		const hydratedSessionId = "session-with-usage";
 		invokeMock.mockImplementation(

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
@@ -658,6 +658,30 @@ describe("useChatSession", () => {
 		});
 		expect(current.summary.totalCostUsd).toBeCloseTo(0.03);
 
+		// The runtime may begin draining the next queued prompt before the prior
+		// send response reaches the webview. Its deltas must not affect the prior
+		// turn's completion reconciliation.
+		await act(async () => {
+			chatEventHandler?.({
+				sessionId: current.sessionId,
+				stream: "chat_queued_prompt_start",
+				chunk: JSON.stringify({
+					promptId: "queued-next",
+					prompt: "Next turn",
+				}),
+				ts: Date.now(),
+				index: 3,
+			});
+			chatEventHandler?.({
+				sessionId: current.sessionId,
+				stream: "chat_usage",
+				chunk: JSON.stringify({ cost: 0.01 }),
+				ts: Date.now(),
+				index: 4,
+			});
+		});
+		expect(current.summary.totalCostUsd).toBeCloseTo(0.04);
+
 		await act(async () => {
 			resolveSend?.({
 				ok: true,
@@ -678,7 +702,7 @@ describe("useChatSession", () => {
 			tokensIn: 13_000,
 			tokensOut: 700,
 		});
-		expect(current.summary.totalCostUsd).toBeCloseTo(0.03);
+		expect(current.summary.totalCostUsd).toBeCloseTo(0.04);
 	});
 
 	it("hydrates current token usage and cumulative cost from messages", async () => {

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
@@ -349,7 +349,12 @@ export function useChatSession() {
 		}
 		setTokensIn(persistedTokensIn);
 		setTokensOut(persistedTokensOut);
-		setTotalCostUsd(persistedTotalCostUsd);
+		// A queued turn may already be streaming when the preceding turn's
+		// message metadata is persisted. Preserve that newer, unpersisted cost.
+		setTotalCostUsd(
+			persistedTotalCostUsd +
+				(activeTurnCostTrackerRef.current?.streamedCostUsd ?? 0),
+		);
 	}, [persistedTokensIn, persistedTokensOut, persistedTotalCostUsd]);
 	useEffect(() => {
 		promptsInQueueRef.current = promptsInQueue;

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
@@ -193,6 +193,10 @@ type SessionUsageSummary = {
 	totalCostUsd: number;
 };
 
+type TurnCostTracker = {
+	streamedCostUsd: number;
+};
+
 /**
  * Read current context usage and cumulative cost from persisted chat messages.
  *
@@ -306,7 +310,7 @@ export function useChatSession() {
 	const sessionStartPromiseRef = useRef<Promise<string> | null>(null);
 	const promptDispatchTailRef = useRef<Promise<void>>(Promise.resolve());
 	const activePromptSubmissionsRef = useRef(0);
-	const streamedTurnCostUsdRef = useRef(0);
+	const activeTurnCostTrackerRef = useRef<TurnCostTracker | null>(null);
 	const [chatTransportState, setChatTransportState] =
 		useState<ChatTransportState>(desktopClient.getTransportState());
 	const [chatTransportError, setChatTransportError] = useState<string | null>(
@@ -384,7 +388,7 @@ export function useChatSession() {
 	}, []);
 
 	const resetCounters = useCallback(() => {
-		streamedTurnCostUsdRef.current = 0;
+		activeTurnCostTrackerRef.current = null;
 		setToolCalls(0);
 		setTokensIn(0);
 		setTokensOut(0);
@@ -903,7 +907,7 @@ export function useChatSession() {
 			flushPendingStream();
 
 			if (payload.stream === "chat_queued_prompt_start") {
-				streamedTurnCostUsdRef.current = 0;
+				activeTurnCostTrackerRef.current = { streamedCostUsd: 0 };
 				let parsed: {
 					promptId?: string;
 					prompt?: string;
@@ -989,7 +993,11 @@ export function useChatSession() {
 				}
 				const cost = usage.cost;
 				if (typeof cost === "number") {
-					streamedTurnCostUsdRef.current += cost;
+					const tracker = activeTurnCostTrackerRef.current ?? {
+						streamedCostUsd: 0,
+					};
+					tracker.streamedCostUsd += cost;
+					activeTurnCostTrackerRef.current = tracker;
 					setTotalCostUsd((previous) => previous + cost);
 				}
 				return;
@@ -1336,6 +1344,9 @@ export function useChatSession() {
 				(hasEarlierPromptSubmission ||
 					Boolean(pendingSessionStart) ||
 					BUSY_STATUSES.has(status));
+			const turnCostTracker: TurnCostTracker | undefined = shouldQueue
+				? undefined
+				: { streamedCostUsd: 0 };
 			const optimisticQueuedPromptId = shouldQueue
 				? makeId("queued_prompt")
 				: null;
@@ -1462,7 +1473,7 @@ export function useChatSession() {
 				}
 				if (!shouldQueue) {
 					activeSessionIdRef.current = activeSessionId;
-					streamedTurnCostUsdRef.current = 0;
+					activeTurnCostTrackerRef.current = turnCostTracker ?? null;
 					setStatus("starting");
 				}
 				await precedingPromptDispatch;
@@ -1610,8 +1621,10 @@ export function useChatSession() {
 					typeof result?.usage?.totalCost === "number"
 						? result.usage.totalCost
 						: undefined;
-				const streamedTurnCostUsd = streamedTurnCostUsdRef.current;
-				streamedTurnCostUsdRef.current = 0;
+				const streamedTurnCostUsd = turnCostTracker?.streamedCostUsd ?? 0;
+				if (activeTurnCostTrackerRef.current === turnCostTracker) {
+					activeTurnCostTrackerRef.current = null;
+				}
 				if (typeof totalCost === "number") {
 					setTotalCostUsd(
 						(previous) => previous + totalCost - streamedTurnCostUsd,

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
@@ -21,6 +21,7 @@ import type {
 	ChatSessionCommandResponse,
 	ChatSessionHookEvent,
 	ChatTransportState,
+	ChatUsageEvent,
 	CoreLogChunk,
 	ProcessContext,
 	PromptInQueue,
@@ -186,6 +187,54 @@ function updateMessageById(
 	return changed ? next : messages;
 }
 
+type SessionUsageSummary = {
+	tokensIn: number;
+	tokensOut: number;
+	totalCostUsd: number;
+};
+
+/**
+ * Read current context usage and cumulative cost from persisted chat messages.
+ *
+ * Each assistant message contains metrics for one model request. The latest
+ * request represents current context-window pressure; summing every request's
+ * input would instead measure lifetime traffic and make the ring saturate even
+ * after context compaction. Cost remains a session-wide sum.
+ */
+function summarizeSessionUsage(
+	messages: ChatMessage[],
+): SessionUsageSummary | undefined {
+	let tokensIn: number | undefined;
+	let tokensOut: number | undefined;
+	let totalCostUsd = 0;
+	let hasCost = false;
+
+	for (const message of messages) {
+		const meta = message.meta;
+		if (!meta) continue;
+		if (
+			typeof meta.inputTokens === "number" ||
+			typeof meta.outputTokens === "number"
+		) {
+			tokensIn = meta.inputTokens ?? 0;
+			tokensOut = meta.outputTokens ?? 0;
+		}
+		if (typeof meta.totalCost === "number") {
+			totalCostUsd += meta.totalCost;
+			hasCost = true;
+		}
+	}
+
+	if (tokensIn === undefined && tokensOut === undefined && !hasCost) {
+		return undefined;
+	}
+	return {
+		tokensIn: tokensIn ?? 0,
+		tokensOut: tokensOut ?? 0,
+		totalCostUsd,
+	};
+}
+
 // ---------------------------------------------------------------------------
 // Core log dispatcher — avoids repeated if/else chains
 // ---------------------------------------------------------------------------
@@ -224,6 +273,7 @@ export function useChatSession() {
 	const [toolCalls, setToolCalls] = useState(0);
 	const [tokensIn, setTokensIn] = useState(0);
 	const [tokensOut, setTokensOut] = useState(0);
+	const [totalCostUsd, setTotalCostUsd] = useState(0);
 	const [fileDiffs, setFileDiffs] = useState<SessionFileDiff[]>([]);
 	const [diffSummary, setDiffSummary] =
 		useState<SessionDiffSummary>(EMPTY_DIFF_SUMMARY);
@@ -261,6 +311,18 @@ export function useChatSession() {
 	const [chatTransportError, setChatTransportError] = useState<string | null>(
 		desktopClient.getTransportError(),
 	);
+	const persistedUsage = useMemo(
+		() =>
+			sessionId
+				? summarizeSessionUsage(
+						messages.filter((message) => message.sessionId === sessionId),
+					)
+				: undefined,
+		[messages, sessionId],
+	);
+	const persistedTokensIn = persistedUsage?.tokensIn;
+	const persistedTokensOut = persistedUsage?.tokensOut;
+	const persistedTotalCostUsd = persistedUsage?.totalCostUsd;
 	// ---- Ref syncs ----
 
 	useEffect(() => {
@@ -272,6 +334,18 @@ export function useChatSession() {
 	useEffect(() => {
 		messagesRef.current = messages;
 	}, [messages]);
+	useEffect(() => {
+		if (
+			persistedTokensIn === undefined ||
+			persistedTokensOut === undefined ||
+			persistedTotalCostUsd === undefined
+		) {
+			return;
+		}
+		setTokensIn(persistedTokensIn);
+		setTokensOut(persistedTokensOut);
+		setTotalCostUsd(persistedTotalCostUsd);
+	}, [persistedTokensIn, persistedTokensOut, persistedTotalCostUsd]);
 	useEffect(() => {
 		promptsInQueueRef.current = promptsInQueue;
 	}, [promptsInQueue]);
@@ -312,6 +386,7 @@ export function useChatSession() {
 		setToolCalls(0);
 		setTokensIn(0);
 		setTokensOut(0);
+		setTotalCostUsd(0);
 		setFileDiffs([]);
 		setDiffSummary(EMPTY_DIFF_SUMMARY);
 	}, []);
@@ -388,8 +463,6 @@ export function useChatSession() {
 							e.hookEventName === "tool_call" || e.hookName === "tool_call",
 					).length,
 				);
-				setTokensIn(events.reduce((sum, e) => sum + (e.inputTokens ?? 0), 0));
-				setTokensOut(events.reduce((sum, e) => sum + (e.outputTokens ?? 0), 0));
 			} catch {
 				// Ignore in non-Tauri mode.
 			}
@@ -898,8 +971,22 @@ export function useChatSession() {
 			}
 
 			if (payload.stream === "chat_usage") {
-				// Usage is still finalized from the send() response to avoid
-				// double-counting when both stream and response include it.
+				let usage: ChatUsageEvent;
+				try {
+					usage = JSON.parse(payload.chunk) as ChatUsageEvent;
+				} catch {
+					return;
+				}
+				if (typeof usage.inputTokens === "number") {
+					setTokensIn(usage.inputTokens);
+				}
+				if (typeof usage.outputTokens === "number") {
+					setTokensOut(usage.outputTokens);
+				}
+				const cost = usage.cost;
+				if (typeof cost === "number") {
+					setTotalCostUsd((previous) => previous + cost);
+				}
 				return;
 			}
 
@@ -1506,17 +1593,20 @@ export function useChatSession() {
 				// Token / cost bookkeeping
 				const inputTokens = result?.usage?.inputTokens ?? result?.inputTokens;
 				if (typeof inputTokens === "number") {
-					setTokensIn((prev) => prev + inputTokens);
+					setTokensIn(inputTokens);
 				}
 				const outputTokens =
 					result?.usage?.outputTokens ?? result?.outputTokens;
 				if (typeof outputTokens === "number") {
-					setTokensOut((prev) => prev + outputTokens);
+					setTokensOut(outputTokens);
 				}
 				const totalCost =
 					typeof result?.usage?.totalCost === "number"
 						? result.usage.totalCost
 						: undefined;
+				if (typeof totalCost === "number") {
+					setTotalCostUsd((prev) => prev + totalCost);
+				}
 				const assistantMessageId = activeAssistantMessageIdRef.current;
 				if (
 					assistantMessageId &&
@@ -2043,6 +2133,7 @@ export function useChatSession() {
 			toolCalls,
 			tokensIn,
 			tokensOut,
+			totalCostUsd,
 			additions: diffSummary.additions,
 			deletions: diffSummary.deletions,
 		}),
@@ -2051,6 +2142,7 @@ export function useChatSession() {
 			diffSummary.deletions,
 			tokensIn,
 			tokensOut,
+			totalCostUsd,
 			toolCalls,
 		],
 	);

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
@@ -306,6 +306,7 @@ export function useChatSession() {
 	const sessionStartPromiseRef = useRef<Promise<string> | null>(null);
 	const promptDispatchTailRef = useRef<Promise<void>>(Promise.resolve());
 	const activePromptSubmissionsRef = useRef(0);
+	const streamedTurnCostUsdRef = useRef(0);
 	const [chatTransportState, setChatTransportState] =
 		useState<ChatTransportState>(desktopClient.getTransportState());
 	const [chatTransportError, setChatTransportError] = useState<string | null>(
@@ -383,6 +384,7 @@ export function useChatSession() {
 	}, []);
 
 	const resetCounters = useCallback(() => {
+		streamedTurnCostUsdRef.current = 0;
 		setToolCalls(0);
 		setTokensIn(0);
 		setTokensOut(0);
@@ -901,7 +903,9 @@ export function useChatSession() {
 			flushPendingStream();
 
 			if (payload.stream === "chat_queued_prompt_start") {
+				streamedTurnCostUsdRef.current = 0;
 				let parsed: {
+					promptId?: string;
 					prompt?: string;
 					attachmentCount?: number;
 					userImages?: string[];
@@ -985,6 +989,7 @@ export function useChatSession() {
 				}
 				const cost = usage.cost;
 				if (typeof cost === "number") {
+					streamedTurnCostUsdRef.current += cost;
 					setTotalCostUsd((previous) => previous + cost);
 				}
 				return;
@@ -1457,6 +1462,7 @@ export function useChatSession() {
 				}
 				if (!shouldQueue) {
 					activeSessionIdRef.current = activeSessionId;
+					streamedTurnCostUsdRef.current = 0;
 					setStatus("starting");
 				}
 				await precedingPromptDispatch;
@@ -1604,8 +1610,12 @@ export function useChatSession() {
 					typeof result?.usage?.totalCost === "number"
 						? result.usage.totalCost
 						: undefined;
+				const streamedTurnCostUsd = streamedTurnCostUsdRef.current;
+				streamedTurnCostUsdRef.current = 0;
 				if (typeof totalCost === "number") {
-					setTotalCostUsd((prev) => prev + totalCost);
+					setTotalCostUsd(
+						(previous) => previous + totalCost - streamedTurnCostUsd,
+					);
 				}
 				const assistantMessageId = activeAssistantMessageIdRef.current;
 				if (

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
@@ -311,6 +311,8 @@ export function useChatSession() {
 	const promptDispatchTailRef = useRef<Promise<void>>(Promise.resolve());
 	const activePromptSubmissionsRef = useRef(0);
 	const activeTurnCostTrackerRef = useRef<TurnCostTracker | null>(null);
+	const unpersistedCostUsdRef = useRef(0);
+	const lastPersistedCostUsdRef = useRef(0);
 	const [chatTransportState, setChatTransportState] =
 		useState<ChatTransportState>(desktopClient.getTransportState());
 	const [chatTransportError, setChatTransportError] = useState<string | null>(
@@ -349,12 +351,19 @@ export function useChatSession() {
 		}
 		setTokensIn(persistedTokensIn);
 		setTokensOut(persistedTokensOut);
-		// A queued turn may already be streaming when the preceding turn's
-		// message metadata is persisted. Preserve that newer, unpersisted cost.
-		setTotalCostUsd(
-			persistedTotalCostUsd +
-				(activeTurnCostTrackerRef.current?.streamedCostUsd ?? 0),
+		// Move newly persisted spend out of the live ledger. Multiple queued turns
+		// may finish before their message metadata is hydrated, so this ledger is
+		// session-wide rather than tied only to the currently active turn.
+		const newlyPersistedCostUsd = Math.max(
+			0,
+			persistedTotalCostUsd - lastPersistedCostUsdRef.current,
 		);
+		unpersistedCostUsdRef.current = Math.max(
+			0,
+			unpersistedCostUsdRef.current - newlyPersistedCostUsd,
+		);
+		lastPersistedCostUsdRef.current = persistedTotalCostUsd;
+		setTotalCostUsd(persistedTotalCostUsd + unpersistedCostUsdRef.current);
 	}, [persistedTokensIn, persistedTokensOut, persistedTotalCostUsd]);
 	useEffect(() => {
 		promptsInQueueRef.current = promptsInQueue;
@@ -394,6 +403,8 @@ export function useChatSession() {
 
 	const resetCounters = useCallback(() => {
 		activeTurnCostTrackerRef.current = null;
+		unpersistedCostUsdRef.current = 0;
+		lastPersistedCostUsdRef.current = 0;
 		setToolCalls(0);
 		setTokensIn(0);
 		setTokensOut(0);
@@ -1003,6 +1014,7 @@ export function useChatSession() {
 					};
 					tracker.streamedCostUsd += cost;
 					activeTurnCostTrackerRef.current = tracker;
+					unpersistedCostUsdRef.current += cost;
 					setTotalCostUsd((previous) => previous + cost);
 				}
 				return;
@@ -1631,9 +1643,9 @@ export function useChatSession() {
 					activeTurnCostTrackerRef.current = null;
 				}
 				if (typeof totalCost === "number") {
-					setTotalCostUsd(
-						(previous) => previous + totalCost - streamedTurnCostUsd,
-					);
+					const unstreamedCostUsd = totalCost - streamedTurnCostUsd;
+					unpersistedCostUsdRef.current += unstreamedCostUsd;
+					setTotalCostUsd((previous) => previous + unstreamedCostUsd);
 				}
 				const assistantMessageId = activeAssistantMessageIdRef.current;
 				if (

--- a/apps/examples/desktop-app/webview/lib/provider-schema.ts
+++ b/apps/examples/desktop-app/webview/lib/provider-schema.ts
@@ -1,6 +1,7 @@
 export interface ProviderModel {
 	id: string;
 	name: string;
+	contextWindow?: number;
 	supportsAttachments?: boolean;
 	supportsVision?: boolean;
 	supportsReasoning?: boolean;

--- a/sdk/packages/core/src/services/providers/local-provider-registry.ts
+++ b/sdk/packages/core/src/services/providers/local-provider-registry.ts
@@ -215,15 +215,17 @@ export async function writeModelsFile(
 
 export function toProviderModel(
 	modelId: string,
-	info: {
-		name?: string;
-		capabilities?: string[];
-		thinkingConfig?: unknown;
-	},
+	info: Pick<
+		ModelInfo,
+		"name" | "contextWindow" | "capabilities" | "thinkingConfig"
+	>,
 ): ProviderModel {
 	return {
 		id: modelId,
 		name: info.name ?? modelId,
+		...(info.contextWindow !== undefined
+			? { contextWindow: info.contextWindow }
+			: {}),
 		supportsAttachments: info.capabilities?.includes("files"),
 		supportsVision: info.capabilities?.includes("images"),
 		supportsReasoning:

--- a/sdk/packages/core/src/services/providers/local-provider-service.test.ts
+++ b/sdk/packages/core/src/services/providers/local-provider-service.test.ts
@@ -11,6 +11,7 @@ import {
 	readModelsFile,
 	registerCustomProvider,
 	resolveModelsRegistryPath,
+	toProviderModel,
 } from "./local-provider-registry";
 import {
 	addLocalProvider,
@@ -746,6 +747,19 @@ describe("addLocalProvider – capabilities", () => {
 	});
 
 	afterEach(() => cleanup());
+
+	it("exposes the model context window to provider catalog consumers", () => {
+		expect(
+			toProviderModel("wide-model", {
+				name: "Wide Model",
+				contextWindow: 1_000_000,
+			}),
+		).toMatchObject({
+			id: "wide-model",
+			name: "Wide Model",
+			contextWindow: 1_000_000,
+		});
+	});
 
 	it("sets supportsVision and supportsAttachments when capability is 'vision'", async () => {
 		await addLocalProvider(manager, {

--- a/sdk/packages/shared/src/rpc/runtime.ts
+++ b/sdk/packages/shared/src/rpc/runtime.ts
@@ -145,6 +145,7 @@ export type EnterpriseStatusResponse = EnterpriseSyncResponse;
 export interface ProviderModel {
 	id: string;
 	name: string;
+	contextWindow?: number;
 	supportsAttachments?: boolean;
 	supportsVision?: boolean;
 	supportsReasoning?: boolean;


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Load per-model context window sizes from the provider catalog and pass the active model's limit down to ChatInputBar. Render a token ring that visualizes current token usage against the model's context window, and hydrate token usage plus cumulative cost from messages and chat_usage events so the indicator stays accurate across turns and session reloads. Add tests covering the ring rendering and usage hydration.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

<img width="602" height="186" alt="image" src="https://github.com/user-attachments/assets/509cd50b-71ba-46bc-8e25-8a78041886b3" />

Moved submit button to text aera

<img width="308" height="127" alt="image" src="https://github.com/user-attachments/assets/1f44e3cf-646b-4264-b6af-f606b40a805f" />


<img width="373" height="189" alt="image" src="https://github.com/user-attachments/assets/4ea6e3f0-23e6-4225-bd0a-ba2306ef6a58" />



### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
