### PR TITLE
feat(sdk): detect and recover from context-window overflow errors

### DIFF
--- a/sdk/packages/agents/src/agent-runtime.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.test.ts
@@ -166,6 +166,138 @@ describe("AgentRuntime", () => {
 		expect(addedMessages.map((message) => message.role)).toEqual(["user"]);
 	});
 
+	it("recovers from a context-window overflow with a forced compaction and one retry", async () => {
+		const longPrompt = `Please review this: ${"lots of context ".repeat(50)}`;
+		const overflowEvent: AgentModelEvent = {
+			type: "finish",
+			reason: "error",
+			error: "prompt is too long: 213462 tokens > 200000 maximum",
+			errorClass: "context_window_exceeded",
+		};
+		const model = new ScriptedModel([
+			() => [overflowEvent],
+			() => [
+				{ type: "text-delta", text: "recovered" },
+				{ type: "finish", reason: "stop" },
+			],
+		]);
+		const compactedMessages: AgentMessage[] = [
+			{ role: "user", content: [{ type: "text", text: "compacted" }] },
+		];
+		const prepareTurn = vi.fn(
+			async (context: { overflowRecovery?: boolean }) =>
+				context.overflowRecovery ? { messages: compactedMessages } : undefined,
+		);
+		const statusNotices: Array<{ message: string; metadata?: unknown }> = [];
+		const runtime = new AgentRuntime({ model, prepareTurn });
+		runtime.subscribe((event) => {
+			if (event.type === "status-notice") {
+				statusNotices.push({
+					message: event.message,
+					metadata: event.metadata,
+				});
+			}
+		});
+
+		const result = await runtime.run(longPrompt);
+
+		expect(result.status).toBe("completed");
+		expect(result.outputText).toBe("recovered");
+		expect(model.requests).toHaveLength(2);
+		expect(prepareTurn).toHaveBeenCalledTimes(2);
+		expect(prepareTurn.mock.calls[0]?.[0].overflowRecovery).toBeUndefined();
+		expect(prepareTurn.mock.calls[1]?.[0].overflowRecovery).toBe(true);
+		// The retried request uses the compacted transcript.
+		expect(model.requests[1]?.messages).toEqual(compactedMessages);
+		expect(statusNotices).toContainEqual(
+			expect.objectContaining({
+				message: "context window exceeded — compacting and retrying",
+				metadata: expect.objectContaining({
+					kind: "context_overflow_recovery",
+				}),
+			}),
+		);
+	});
+
+	it("fails with an actionable message when overflow recovery has nothing to compact", async () => {
+		const model = new ScriptedModel([
+			() => [
+				{
+					type: "finish",
+					reason: "error",
+					error: "input is too long for requested model",
+					errorClass: "context_window_exceeded",
+				},
+			],
+		]);
+		const prepareTurn = vi.fn(async () => undefined);
+		const runtime = new AgentRuntime({ model, prepareTurn });
+
+		const result = await runtime.run("Hi");
+
+		expect(result.status).toBe("failed");
+		expect(result.error?.message).toContain(
+			"no conversation history to compact",
+		);
+		expect(result.error?.message).toContain(
+			"input is too long for requested model",
+		);
+		// The doomed request is not re-sent.
+		expect(model.requests).toHaveLength(1);
+	});
+
+	it("fails with guidance when overflow occurs and no prepare-turn pipeline exists", async () => {
+		const model = new ScriptedModel([
+			() => [
+				{
+					type: "finish",
+					reason: "error",
+					error: "prompt is too long",
+					errorClass: "context_window_exceeded",
+				},
+			],
+		]);
+		const runtime = new AgentRuntime({ model });
+
+		const result = await runtime.run("Hi");
+
+		expect(result.status).toBe("failed");
+		expect(result.error?.message).toContain(
+			"exceeds the model's context window",
+		);
+		expect(model.requests).toHaveLength(1);
+	});
+
+	it("does not retry a second consecutive overflow in the same run", async () => {
+		const overflow = (): AgentModelEvent[] => [
+			{
+				type: "finish",
+				reason: "error",
+				error: "prompt is too long",
+				errorClass: "context_window_exceeded",
+			},
+		];
+		const model = new ScriptedModel([overflow, overflow]);
+		const compactedMessages: AgentMessage[] = [
+			{ role: "user", content: [{ type: "text", text: "x" }] },
+		];
+		const prepareTurn = vi.fn(
+			async (context: { overflowRecovery?: boolean }) =>
+				context.overflowRecovery ? { messages: compactedMessages } : undefined,
+		);
+		const runtime = new AgentRuntime({ model, prepareTurn });
+
+		const result = await runtime.run(
+			`A long request ${"with plenty of transcript ".repeat(30)}`,
+		);
+
+		expect(result.status).toBe("failed");
+		expect(result.error?.message).toContain(
+			"still exceeds the model's context window",
+		);
+		expect(model.requests).toHaveLength(2);
+	});
+
 	it("does not complete or persist history when the model returns no content", async () => {
 		const model = new ScriptedModel([
 			() => [{ type: "finish", reason: "stop" }],

--- a/sdk/packages/agents/src/agent-runtime.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.test.ts
@@ -219,6 +219,62 @@ describe("AgentRuntime", () => {
 		);
 	});
 
+	it("recovers from an unclassified overflow by classifying the finish message", async () => {
+		// Models that do not classify at their own error boundary (custom
+		// AgentModel implementations, adapters carrying only a flattened
+		// message) must still reach recovery.
+		const model = new ScriptedModel([
+			() => [
+				{
+					type: "finish",
+					reason: "error",
+					error: "prompt is too long: 213462 tokens > 200000 maximum",
+				},
+			],
+			() => [
+				{ type: "text-delta", text: "recovered" },
+				{ type: "finish", reason: "stop" },
+			],
+		]);
+		const compactedMessages: AgentMessage[] = [
+			{ role: "user", content: [{ type: "text", text: "compacted" }] },
+		];
+		const prepareTurn = vi.fn(
+			async (context: { overflowRecovery?: boolean }) =>
+				context.overflowRecovery ? { messages: compactedMessages } : undefined,
+		);
+		const runtime = new AgentRuntime({ model, prepareTurn });
+
+		const result = await runtime.run(
+			`Please review ${"lots of context ".repeat(50)}`,
+		);
+
+		expect(result.status).toBe("completed");
+		expect(result.outputText).toBe("recovered");
+		expect(model.requests).toHaveLength(2);
+		expect(prepareTurn.mock.calls[1]?.[0].overflowRecovery).toBe(true);
+	});
+
+	it("does not treat an unrelated stream failure as an overflow", async () => {
+		const model = new ScriptedModel([
+			() => [
+				{
+					type: "finish",
+					reason: "error",
+					error: "fetch failed: socket closed",
+				},
+			],
+		]);
+		const prepareTurn = vi.fn(async () => undefined);
+		const runtime = new AgentRuntime({ model, prepareTurn });
+
+		const result = await runtime.run("Hi");
+
+		expect(result.status).toBe("failed");
+		expect(result.error?.message).toBe("fetch failed: socket closed");
+		expect(model.requests).toHaveLength(1);
+	});
+
 	it("fails with an actionable message when overflow recovery has nothing to compact", async () => {
 		const model = new ScriptedModel([
 			() => [

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -1,4 +1,8 @@
-import { createGateway, type GatewayProviderSettings } from "@cline/llms";
+import {
+	classifyProviderError,
+	createGateway,
+	type GatewayProviderSettings,
+} from "@cline/llms";
 import type {
 	AgentAfterToolResult,
 	AgentBeforeModelResult,
@@ -21,6 +25,7 @@ import type {
 	AgentUsage,
 	AgentRuntimeConfig as BaseAgentRuntimeConfig,
 	CaptureTaskLifecycleEventInput,
+	ProviderErrorClass,
 	TelemetryProperties,
 	ToolApprovalResult,
 	ToolPolicy,
@@ -44,6 +49,40 @@ import { nanoid } from "nanoid";
 
 const MAX_TOKENS_INCOMPLETE_TURN_MESSAGE =
 	"Model reached the maximum output token limit before completing the turn";
+
+/**
+ * Terminal message when a context-window overflow cannot be recovered because
+ * there is no conversation history to compact — the system prompt, tools, and
+ * current input alone exceed the window.
+ */
+export const CONTEXT_WINDOW_OVERFLOW_NOTHING_TO_COMPACT_MESSAGE =
+	"The request exceeds the model's context window and there is no conversation history to compact — the system prompt, tools, and current input alone are too large. Reduce attached content or switch to a model with a larger context window.";
+
+/**
+ * Terminal message when a context-window overflow persists after the runtime
+ * already compacted the conversation and retried once.
+ */
+export const CONTEXT_WINDOW_OVERFLOW_RECOVERY_FAILED_MESSAGE =
+	"The conversation still exceeds the model's context window after compacting it. Start a new session or switch to a model with a larger context window.";
+
+/**
+ * Terminal message when no compaction pipeline is available to recover from a
+ * context-window overflow (e.g. compaction disabled).
+ */
+export const CONTEXT_WINDOW_OVERFLOW_NO_RECOVERY_MESSAGE =
+	"The conversation exceeds the model's context window. Compact the conversation, start a new session, or switch to a model with a larger context window.";
+
+/** Thrown when overflow recovery cannot proceed; carries the terminal text. */
+class ContextWindowOverflowError extends Error {
+	constructor(message: string, providerError: string | undefined) {
+		super(
+			providerError?.trim()
+				? `${message} (provider reported: ${providerError.trim()})`
+				: message,
+		);
+		this.name = "ContextWindowOverflowError";
+	}
+}
 
 // Local `createUID` helper. The clinee source imports this from
 // `@cline/shared` (see `packages/shared/dist/identifier.ts`), but
@@ -419,7 +458,10 @@ export class AgentRuntime {
 		pendingToolCalls: [] as string[],
 		usage: cloneUsage(DEFAULT_USAGE),
 		lastError: undefined as string | undefined,
+		lastErrorClass: undefined as ProviderErrorClass | undefined,
 	};
+	/** One automatic overflow-recovery attempt per run. */
+	private overflowRecoveryAttempted = false;
 	private initialization?: Promise<void>;
 	private abortController?: AbortController;
 	private readonly telemetryProviderId?: string;
@@ -495,6 +537,7 @@ export class AgentRuntime {
 		this.state.pendingToolCalls = [];
 		this.state.usage = cloneUsage(DEFAULT_USAGE);
 		this.state.lastError = undefined;
+		this.state.lastErrorClass = undefined;
 		this.state.messages = cloneMessages(messages);
 		this.config = {
 			...this.config,
@@ -515,6 +558,7 @@ export class AgentRuntime {
 			pendingToolCalls: [...this.state.pendingToolCalls],
 			usage: cloneUsage(this.state.usage),
 			lastError: this.state.lastError,
+			lastErrorClass: this.state.lastErrorClass,
 		};
 	}
 
@@ -606,7 +650,9 @@ export class AgentRuntime {
 		this.state.iteration = 0;
 		this.state.pendingToolCalls = [];
 		this.state.lastError = undefined;
+		this.state.lastErrorClass = undefined;
 		this.state.usage = cloneUsage(DEFAULT_USAGE);
+		this.overflowRecoveryAttempted = false;
 
 		try {
 			await this.callBeforeRunHooks();
@@ -641,7 +687,8 @@ export class AgentRuntime {
 					iteration: this.state.iteration,
 				});
 
-				const { message, finishReason } = await this.generateAssistantMessage();
+				const { message, finishReason } =
+					await this.generateAssistantMessageWithOverflowRecovery();
 				if (finishReason === "aborted") {
 					throw this.normalizeAbortError();
 				}
@@ -750,8 +797,17 @@ export class AgentRuntime {
 			const isControlledStop = normalized instanceof ControlledStopError;
 			const isAborted = this.abortController.signal.aborted || isControlledStop;
 			const status = isAborted ? "aborted" : "failed";
+			// Read before overwriting lastError below: the class only applies
+			// when the run failed on the provider error it was recorded for.
+			const errorClass =
+				normalized instanceof ContextWindowOverflowError
+					? ("context_window_exceeded" as const)
+					: normalized.message === this.state.lastError
+						? this.state.lastErrorClass
+						: undefined;
 			this.state.status = status;
 			this.state.lastError = normalized.message;
+			this.state.lastErrorClass = errorClass;
 			const lastAssistantMessage = this.findLastAssistantMessage();
 			const result: AgentRunResult = {
 				agentId: this.state.agentId,
@@ -781,6 +837,7 @@ export class AgentRuntime {
 					type: "run-failed",
 					snapshot: this.snapshot(),
 					error: normalized,
+					errorClass,
 				});
 			} else {
 				await this.emit({
@@ -810,7 +867,75 @@ export class AgentRuntime {
 		}
 	}
 
-	private async generateAssistantMessage(): Promise<{
+	/**
+	 * Run a model turn, recovering once per run from a provider-rejected
+	 * context-window overflow: force a compaction through `prepareTurn` and
+	 * retry the request. Terminal (unrecoverable) overflow states throw with
+	 * an actionable message instead of the raw provider error.
+	 */
+	private async generateAssistantMessageWithOverflowRecovery(): Promise<{
+		message: AgentMessage;
+		finishReason: AgentModelFinishReason;
+	}> {
+		const first = await this.generateAssistantMessage();
+		if (!this.isRecoverableOverflowTurn(first)) {
+			return first;
+		}
+		this.overflowRecoveryAttempted = true;
+		const providerError = this.state.lastError;
+		if (!this.config.prepareTurn) {
+			throw new ContextWindowOverflowError(
+				CONTEXT_WINDOW_OVERFLOW_NO_RECOVERY_MESSAGE,
+				providerError,
+			);
+		}
+		await this.emit({
+			type: "status-notice",
+			snapshot: this.snapshot(),
+			message: "context window exceeded — compacting and retrying",
+			metadata: {
+				kind: "context_overflow_recovery",
+				reason: "context_overflow_recovery",
+				phase: "started",
+				iteration: this.state.iteration,
+				providerError,
+			},
+		});
+		const retry = await this.generateAssistantMessage({
+			overflowRecovery: true,
+		});
+		if (
+			retry.finishReason === "error" &&
+			this.state.lastErrorClass === "context_window_exceeded"
+		) {
+			throw new ContextWindowOverflowError(
+				CONTEXT_WINDOW_OVERFLOW_RECOVERY_FAILED_MESSAGE,
+				this.state.lastError,
+			);
+		}
+		return retry;
+	}
+
+	private isRecoverableOverflowTurn(turn: {
+		message: AgentMessage;
+		finishReason: AgentModelFinishReason;
+	}): boolean {
+		if (
+			turn.finishReason !== "error" ||
+			this.state.lastErrorClass !== "context_window_exceeded" ||
+			this.overflowRecoveryAttempted
+		) {
+			return false;
+		}
+		// An errored stream that still produced tool calls proceeds through the
+		// normal loop (matching existing behavior); a retry would discard that
+		// partial work.
+		return !turn.message.content.some((part) => part.type === "tool-call");
+	}
+
+	private async generateAssistantMessage(options?: {
+		overflowRecovery?: boolean;
+	}): Promise<{
 		message: AgentMessage;
 		finishReason: AgentModelFinishReason;
 	}> {
@@ -853,7 +978,7 @@ export class AgentRuntime {
 			}
 		}
 
-		request = await this.prepareTurnForModelRequest(request);
+		request = await this.prepareTurnForModelRequest(request, options);
 		this.throwIfAborted();
 
 		for (const hook of this.hooks.beforeModel) {
@@ -1010,6 +1135,7 @@ export class AgentRuntime {
 					finishReason = event.reason;
 					if (event.error) {
 						this.state.lastError = event.error;
+						this.state.lastErrorClass = event.errorClass;
 					}
 					break;
 				}
@@ -1137,6 +1263,7 @@ export class AgentRuntime {
 		this.captureTaskLifecycle(TASK_PROVIDER_STREAM_FAILED_EVENT, {
 			durationMs,
 			error,
+			errorClass: classifyProviderError(error),
 			phase,
 		});
 	}
@@ -1209,11 +1336,13 @@ export class AgentRuntime {
 
 	private async prepareTurnForModelRequest(
 		request: AgentModelRequest,
+		options?: { overflowRecovery?: boolean },
 	): Promise<AgentModelRequest> {
 		if (!this.config.prepareTurn) {
 			return request;
 		}
 
+		const overflowRecovery = options?.overflowRecovery === true;
 		const result = await this.config.prepareTurn({
 			agentId: this.state.agentId,
 			conversationId: this.config.conversationId,
@@ -1227,6 +1356,7 @@ export class AgentRuntime {
 				provider: this.config.messageModelInfo?.provider,
 			},
 			signal: request.signal,
+			overflowRecovery: overflowRecovery || undefined,
 			emitStatusNotice: (message, metadata) => {
 				void this.emit({
 					type: "status-notice",
@@ -1236,6 +1366,20 @@ export class AgentRuntime {
 				});
 			},
 		});
+		if (overflowRecovery) {
+			// Only retry a provider-rejected overflow with a request that is
+			// actually smaller — anything else is guaranteed to fail again.
+			const shrunk =
+				result?.messages !== undefined &&
+				JSON.stringify(result.messages).length <
+					JSON.stringify(request.messages).length;
+			if (!shrunk) {
+				throw new ContextWindowOverflowError(
+					CONTEXT_WINDOW_OVERFLOW_NOTHING_TO_COMPACT_MESSAGE,
+					this.state.lastError,
+				);
+			}
+		}
 		if (!result) {
 			return request;
 		}

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -1135,7 +1135,13 @@ export class AgentRuntime {
 					finishReason = event.reason;
 					if (event.error) {
 						this.state.lastError = event.error;
-						this.state.lastErrorClass = event.errorClass;
+						// Models that classify at their own error boundary (where the
+						// raw provider error is still structured) win. Anything else —
+						// custom `AgentModel` implementations, adapters that carry only
+						// a flattened message — is classified from the message so it
+						// stays eligible for overflow recovery.
+						this.state.lastErrorClass =
+							event.errorClass ?? classifyProviderError(event.error);
 					}
 					break;
 				}
@@ -1369,6 +1375,16 @@ export class AgentRuntime {
 		if (overflowRecovery) {
 			// Only retry a provider-rejected overflow with a request that is
 			// actually smaller — anything else is guaranteed to fail again.
+			//
+			// Serialized length is a coarse proxy for tokens, which is all this
+			// backstop needs: it answers "did anything get removed at all" for
+			// arbitrary `prepareTurn` implementations, and the shared estimator
+			// is itself linear in character count, so switching units would not
+			// change the verdict. Authoritative token budgeting (against the
+			// model's limit) happens inside the compaction pipeline.
+			// TODO: have `prepareTurn` report the token estimates it already
+			// computed (before/after) so this decision can use real numbers
+			// instead of re-deriving a proxy here.
 			const shrunk =
 				result?.messages !== undefined &&
 				JSON.stringify(result.messages).length <

--- a/sdk/packages/core/src/extensions/context/basic-compaction.ts
+++ b/sdk/packages/core/src/extensions/context/basic-compaction.ts
@@ -650,7 +650,9 @@ export function runBasicCompaction(options: {
 		reason:
 			options.context.mode === "manual"
 				? "manual_compaction"
-				: "auto_compaction",
+				: options.context.mode === "overflow_recovery"
+					? "overflow_recovery_compaction"
+					: "auto_compaction",
 		displayRole: "system",
 		messagesRemoved:
 			prior.messagesRemoved + (originalMessages.length - mergedMessages.length),

--- a/sdk/packages/core/src/extensions/context/compaction.test.ts
+++ b/sdk/packages/core/src/extensions/context/compaction.test.ts
@@ -2327,9 +2327,13 @@ describe("createContextCompactionPrepareTurn", () => {
 	});
 
 	it("uses a successful custom compactor during overflow recovery", async () => {
+		const abortSignal = new AbortController().signal;
 		const compacted = [{ role: "user" as const, content: "custom fold" }];
 		const compact = vi.fn(async (context: CoreCompactionContext) => {
 			expect(context.mode).toBe("overflow_recovery");
+			// Custom compactors receive the turn's abort signal so a stalled
+			// external call can be cancelled instead of blocking recovery.
+			expect(context.abortSignal).toBe(abortSignal);
 			return { messages: compacted };
 		});
 		const prepareTurn = createContextCompactionPrepareTurn({
@@ -2348,7 +2352,7 @@ describe("createContextCompactionPrepareTurn", () => {
 			conversationId: "conv-1",
 			parentAgentId: null,
 			iteration: 1,
-			abortSignal: new AbortController().signal,
+			abortSignal,
 			overflowRecovery: true,
 			systemPrompt: "You are helpful.",
 			tools: [],

--- a/sdk/packages/core/src/extensions/context/compaction.test.ts
+++ b/sdk/packages/core/src/extensions/context/compaction.test.ts
@@ -2403,6 +2403,45 @@ describe("createContextCompactionPrepareTurn", () => {
 		assertBasicCompactionResult(result);
 	});
 
+	it("falls back to basic compaction when a custom compactor does not shrink during overflow recovery", async () => {
+		// Echoes its input back — "succeeds" without removing anything, which
+		// the runtime would reject as a non-shrinking retry.
+		const compact = vi.fn(async (context: CoreCompactionContext) => ({
+			messages: context.messages,
+		}));
+		const prepareTurn = createContextCompactionPrepareTurn({
+			providerId: "anthropic",
+			modelId: "mock-model",
+			providerConfig: {
+				providerId: "anthropic",
+				modelId: "mock-model",
+			} as LlmsProviders.ProviderConfig,
+			compaction: { enabled: true, compact },
+			logger: undefined,
+		});
+
+		const result = await prepareTurn?.({
+			agentId: "agent-1",
+			conversationId: "conv-1",
+			parentAgentId: null,
+			iteration: 1,
+			abortSignal: new AbortController().signal,
+			overflowRecovery: true,
+			systemPrompt: "You are helpful.",
+			tools: [],
+			messages: overflowRecoveryTranscript(),
+			apiMessages: overflowRecoveryTranscript(),
+			model: {
+				id: "mock-model",
+				provider: "anthropic",
+				info: { id: "mock-model", maxInputTokens: 1_000_000 },
+			},
+		});
+
+		expect(compact).toHaveBeenCalledTimes(1);
+		assertBasicCompactionResult(result);
+	});
+
 	it("falls back to basic compaction when a custom compactor declines during overflow recovery", async () => {
 		const compact = vi.fn(async () => undefined);
 		const prepareTurn = createContextCompactionPrepareTurn({

--- a/sdk/packages/core/src/extensions/context/compaction.test.ts
+++ b/sdk/packages/core/src/extensions/context/compaction.test.ts
@@ -2326,6 +2326,118 @@ describe("createContextCompactionPrepareTurn", () => {
 		);
 	});
 
+	it("uses a successful custom compactor during overflow recovery", async () => {
+		const compacted = [{ role: "user" as const, content: "custom fold" }];
+		const compact = vi.fn(async (context: CoreCompactionContext) => {
+			expect(context.mode).toBe("overflow_recovery");
+			return { messages: compacted };
+		});
+		const prepareTurn = createContextCompactionPrepareTurn({
+			providerId: "anthropic",
+			modelId: "mock-model",
+			providerConfig: {
+				providerId: "anthropic",
+				modelId: "mock-model",
+			} as LlmsProviders.ProviderConfig,
+			compaction: { enabled: true, compact },
+			logger: undefined,
+		});
+
+		const result = await prepareTurn?.({
+			agentId: "agent-1",
+			conversationId: "conv-1",
+			parentAgentId: null,
+			iteration: 1,
+			abortSignal: new AbortController().signal,
+			overflowRecovery: true,
+			systemPrompt: "You are helpful.",
+			tools: [],
+			messages: overflowRecoveryTranscript(),
+			apiMessages: overflowRecoveryTranscript(),
+			model: {
+				id: "mock-model",
+				provider: "anthropic",
+				info: { id: "mock-model", maxInputTokens: 1_000_000 },
+			},
+		});
+
+		expect(compact).toHaveBeenCalledTimes(1);
+		expect(result?.messages).toEqual(compacted);
+	});
+
+	it("falls back to basic compaction when a custom compactor fails during overflow recovery", async () => {
+		const compact = vi.fn(async () => {
+			throw new Error("custom compactor overflowed too");
+		});
+		const prepareTurn = createContextCompactionPrepareTurn({
+			providerId: "anthropic",
+			modelId: "mock-model",
+			providerConfig: {
+				providerId: "anthropic",
+				modelId: "mock-model",
+			} as LlmsProviders.ProviderConfig,
+			compaction: { enabled: true, compact },
+			logger: undefined,
+		});
+
+		const result = await prepareTurn?.({
+			agentId: "agent-1",
+			conversationId: "conv-1",
+			parentAgentId: null,
+			iteration: 1,
+			abortSignal: new AbortController().signal,
+			overflowRecovery: true,
+			systemPrompt: "You are helpful.",
+			tools: [],
+			messages: overflowRecoveryTranscript(),
+			apiMessages: overflowRecoveryTranscript(),
+			model: {
+				id: "mock-model",
+				provider: "anthropic",
+				info: { id: "mock-model", maxInputTokens: 1_000_000 },
+			},
+		});
+
+		expect(compact).toHaveBeenCalledTimes(1);
+		expect(createHandlerMock).not.toHaveBeenCalled();
+		assertBasicCompactionResult(result);
+	});
+
+	it("falls back to basic compaction when a custom compactor declines during overflow recovery", async () => {
+		const compact = vi.fn(async () => undefined);
+		const prepareTurn = createContextCompactionPrepareTurn({
+			providerId: "anthropic",
+			modelId: "mock-model",
+			providerConfig: {
+				providerId: "anthropic",
+				modelId: "mock-model",
+			} as LlmsProviders.ProviderConfig,
+			compaction: { enabled: true, compact },
+			logger: undefined,
+		});
+
+		const result = await prepareTurn?.({
+			agentId: "agent-1",
+			conversationId: "conv-1",
+			parentAgentId: null,
+			iteration: 1,
+			abortSignal: new AbortController().signal,
+			overflowRecovery: true,
+			systemPrompt: "You are helpful.",
+			tools: [],
+			messages: overflowRecoveryTranscript(),
+			apiMessages: overflowRecoveryTranscript(),
+			model: {
+				id: "mock-model",
+				provider: "anthropic",
+				info: { id: "mock-model", maxInputTokens: 1_000_000 },
+			},
+		});
+
+		expect(compact).toHaveBeenCalledTimes(1);
+		assertBasicCompactionResult(result);
+	});
+
 	it("triggers compaction when input reaches exactly 90 percent", async () => {
 		const compact = vi.fn((_context: CoreCompactionContext) => ({
 			messages: [{ role: "user" as const, content: "Compacted at 90%" }],

--- a/sdk/packages/core/src/extensions/context/compaction.test.ts
+++ b/sdk/packages/core/src/extensions/context/compaction.test.ts
@@ -48,6 +48,64 @@ function totalJsonTokens(messages: LlmsProviders.Message[]): number {
 	);
 }
 
+/** Multi-turn transcript with prunable tool output for basic-compaction tests. */
+function overflowRecoveryTranscript(): MessageWithMetadata[] {
+	return [
+		{ role: "user", content: "Initial request that should survive" },
+		{
+			role: "assistant",
+			content: [
+				{ type: "text", text: "Older assistant explanation" },
+				{
+					type: "tool_use",
+					id: "tool-1",
+					name: "read_files",
+					input: { file_paths: ["/tmp/example.ts"] },
+				},
+			],
+		},
+		{
+			role: "user",
+			content: [
+				{
+					type: "tool_result",
+					tool_use_id: "tool-1",
+					name: "tool",
+					content: "tool output that should be removed",
+				},
+			],
+		},
+		{ role: "user", content: "Most recent user turn" },
+		{
+			role: "assistant",
+			content: [{ type: "text", text: "Most recent assistant reply" }],
+		},
+	];
+}
+
+/** The compaction produced messages and pruned the marked tool output. */
+function assertBasicCompactionResult(
+	result: { messages: MessageWithMetadata[] } | undefined,
+): void {
+	expect(result?.messages).toBeDefined();
+	expect(result?.messages.length).toBeGreaterThan(0);
+	for (const message of result?.messages ?? []) {
+		if (typeof message.content === "string") {
+			expect(message.content).not.toContain(
+				"tool output that should be removed",
+			);
+		} else {
+			for (const block of message.content) {
+				if (block.type === "text") {
+					expect(block.text).not.toContain(
+						"tool output that should be removed",
+					);
+				}
+			}
+		}
+	}
+}
+
 describe("createTokenEstimator", () => {
 	it("does not treat cumulative request metrics as per-message token counts", () => {
 		const estimateMessageTokens = createTokenEstimator();
@@ -2159,24 +2217,113 @@ describe("createContextCompactionPrepareTurn", () => {
 				reason: "auto_compaction",
 			}),
 		);
-		expect(result?.messages).toBeDefined();
-		expect(result?.messages.length).toBeGreaterThan(0);
-		// Compacted messages should not contain tool_result content that was pruned.
-		for (const message of result?.messages ?? []) {
-			if (typeof message.content === "string") {
-				expect(message.content).not.toContain(
-					"tool output that should be removed",
-				);
-			} else {
-				for (const block of message.content) {
-					if (block.type === "text") {
-						expect(block.text).not.toContain(
-							"tool output that should be removed",
-						);
-					}
-				}
-			}
-		}
+		assertBasicCompactionResult(result);
+	});
+
+	it("forces a basic compaction on overflow recovery, bypassing the estimate gate", async () => {
+		const emitStatusNotice = vi.fn();
+		const prepareTurn = createContextCompactionPrepareTurn({
+			providerId: "anthropic",
+			modelId: "mock-model",
+			providerConfig: {
+				providerId: "anthropic",
+				modelId: "mock-model",
+			} as LlmsProviders.ProviderConfig,
+			compaction: {
+				enabled: true,
+				// Agentic is configured, but recovery must not depend on a
+				// summarizer call succeeding.
+				strategy: "agentic",
+			},
+			logger: undefined,
+		});
+
+		const result = await prepareTurn?.({
+			agentId: "agent-1",
+			conversationId: "conv-1",
+			parentAgentId: null,
+			iteration: 1,
+			abortSignal: new AbortController().signal,
+			emitStatusNotice,
+			overflowRecovery: true,
+			systemPrompt: "You are helpful.",
+			tools: [],
+			messages: overflowRecoveryTranscript(),
+			apiMessages: overflowRecoveryTranscript(),
+			model: {
+				id: "mock-model",
+				provider: "anthropic",
+				// Large window: the estimate-based trigger would not fire, yet
+				// the provider said otherwise — recovery must compact anyway.
+				info: { id: "mock-model", maxInputTokens: 1_000_000 },
+			},
+		});
+
+		expect(createHandlerMock).not.toHaveBeenCalled();
+		expect(emitStatusNotice).toHaveBeenCalledWith(
+			"overflow-recovery-compacting",
+			expect.objectContaining({
+				kind: "overflow_recovery_compaction",
+				reason: "overflow_recovery_compaction",
+			}),
+		);
+		expect(emitStatusNotice).toHaveBeenCalledWith(
+			"overflow-recovery-compacted",
+			expect.objectContaining({
+				kind: "overflow_recovery_compaction",
+				phase: "completed",
+			}),
+		);
+		assertBasicCompactionResult(result);
+	});
+
+	it("skips overflow-recovery compaction when there is nothing to remove", async () => {
+		const emitStatusNotice = vi.fn();
+		const prepareTurn = createContextCompactionPrepareTurn({
+			providerId: "anthropic",
+			modelId: "mock-model",
+			providerConfig: {
+				providerId: "anthropic",
+				modelId: "mock-model",
+			} as LlmsProviders.ProviderConfig,
+			compaction: {
+				enabled: true,
+				strategy: "agentic",
+			},
+			logger: undefined,
+		});
+
+		const messages: MessageWithMetadata[] = [
+			{ role: "user", content: "A single oversized first prompt" },
+		];
+		const result = await prepareTurn?.({
+			agentId: "agent-1",
+			conversationId: "conv-1",
+			parentAgentId: null,
+			iteration: 1,
+			abortSignal: new AbortController().signal,
+			emitStatusNotice,
+			overflowRecovery: true,
+			systemPrompt: "You are helpful.",
+			tools: [],
+			messages,
+			apiMessages: messages,
+			model: {
+				id: "mock-model",
+				provider: "anthropic",
+				info: { id: "mock-model", maxInputTokens: 1_000_000 },
+			},
+		});
+
+		expect(result).toBeUndefined();
+		expect(createHandlerMock).not.toHaveBeenCalled();
+		expect(emitStatusNotice).toHaveBeenCalledWith(
+			"overflow-recovery-compaction-skipped",
+			expect.objectContaining({
+				kind: "overflow_recovery_compaction",
+				phase: "skipped",
+			}),
+		);
 	});
 
 	it("triggers compaction when input reaches exactly 90 percent", async () => {

--- a/sdk/packages/core/src/extensions/context/compaction.test.ts
+++ b/sdk/packages/core/src/extensions/context/compaction.test.ts
@@ -2442,6 +2442,46 @@ describe("createContextCompactionPrepareTurn", () => {
 		assertBasicCompactionResult(result);
 	});
 
+	it("falls back to basic compaction when a custom compactor shrinks but misses the recovery target", async () => {
+		// Drops only the short final message — strictly smaller, but far above
+		// the ~50% recovery target, so the retry would still not fit.
+		const compact = vi.fn(async (context: CoreCompactionContext) => ({
+			messages: context.messages.slice(0, -1),
+		}));
+		const prepareTurn = createContextCompactionPrepareTurn({
+			providerId: "anthropic",
+			modelId: "mock-model",
+			providerConfig: {
+				providerId: "anthropic",
+				modelId: "mock-model",
+			} as LlmsProviders.ProviderConfig,
+			compaction: { enabled: true, compact },
+			logger: undefined,
+		});
+
+		const result = await prepareTurn?.({
+			agentId: "agent-1",
+			conversationId: "conv-1",
+			parentAgentId: null,
+			iteration: 1,
+			abortSignal: new AbortController().signal,
+			overflowRecovery: true,
+			systemPrompt: "You are helpful.",
+			tools: [],
+			messages: overflowRecoveryTranscript(),
+			apiMessages: overflowRecoveryTranscript(),
+			model: {
+				id: "mock-model",
+				provider: "anthropic",
+				info: { id: "mock-model", maxInputTokens: 1_000_000 },
+			},
+		});
+
+		expect(compact).toHaveBeenCalledTimes(1);
+		expect(createHandlerMock).not.toHaveBeenCalled();
+		assertBasicCompactionResult(result);
+	});
+
 	it("falls back to basic compaction when a custom compactor declines during overflow recovery", async () => {
 		const compact = vi.fn(async () => undefined);
 		const prepareTurn = createContextCompactionPrepareTurn({

--- a/sdk/packages/core/src/extensions/context/compaction.test.ts
+++ b/sdk/packages/core/src/extensions/context/compaction.test.ts
@@ -2442,6 +2442,43 @@ describe("createContextCompactionPrepareTurn", () => {
 		assertBasicCompactionResult(result);
 	});
 
+	it("falls back to basic compaction when a custom compactor returns an empty transcript", async () => {
+		// An empty result is trivially "smaller" and under target, but would
+		// erase the very request the retry is supposed to re-send.
+		const compact = vi.fn(async () => ({ messages: [] }));
+		const prepareTurn = createContextCompactionPrepareTurn({
+			providerId: "anthropic",
+			modelId: "mock-model",
+			providerConfig: {
+				providerId: "anthropic",
+				modelId: "mock-model",
+			} as LlmsProviders.ProviderConfig,
+			compaction: { enabled: true, compact },
+			logger: undefined,
+		});
+
+		const result = await prepareTurn?.({
+			agentId: "agent-1",
+			conversationId: "conv-1",
+			parentAgentId: null,
+			iteration: 1,
+			abortSignal: new AbortController().signal,
+			overflowRecovery: true,
+			systemPrompt: "You are helpful.",
+			tools: [],
+			messages: overflowRecoveryTranscript(),
+			apiMessages: overflowRecoveryTranscript(),
+			model: {
+				id: "mock-model",
+				provider: "anthropic",
+				info: { id: "mock-model", maxInputTokens: 1_000_000 },
+			},
+		});
+
+		expect(compact).toHaveBeenCalledTimes(1);
+		assertBasicCompactionResult(result);
+	});
+
 	it("falls back to basic compaction when a custom compactor shrinks but misses the recovery target", async () => {
 		// Drops only the short final message — strictly smaller, but far above
 		// the ~50% recovery target, so the retry would still not fit.

--- a/sdk/packages/core/src/extensions/context/compaction.ts
+++ b/sdk/packages/core/src/extensions/context/compaction.ts
@@ -437,10 +437,13 @@ export function createContextCompactionPrepareTurn(
 			// overflow the same window (its input budgeting trusts the same
 			// estimator that just undercounted). A custom compactor gets first
 			// shot — it sees mode "overflow_recovery" and owns its transcript
-			// invariants — but if it throws, declines, or fails to shrink the
-			// transcript (the runtime refuses to retry with a request that is
-			// not smaller), basic compaction runs so recovery never depends on
-			// another successful LLM request.
+			// invariants — but its result is held to the same bar basic
+			// compaction aims for: strictly smaller than the input (the runtime
+			// refuses to retry with a request that is not smaller) AND within
+			// the recovery token target. A marginal shrink would spend the
+			// run's single retry on a request that still cannot fit. On throw,
+			// decline, or an insufficient result, basic compaction runs so
+			// recovery never depends on another successful LLM request.
 			if (userCompaction?.compact) {
 				try {
 					result = await userCompaction.compact(compactionContext);
@@ -457,15 +460,25 @@ export function createContextCompactionPrepareTurn(
 					);
 					result = undefined;
 				}
-				if (
-					result?.messages &&
-					safeJsonSize(result.messages) >= safeJsonSize(context.messages)
-				) {
-					config.logger?.log(
-						"Custom compaction did not shrink the transcript during overflow recovery; falling back to basic compaction",
-						{ severity: "warn" },
+				if (result?.messages) {
+					const customMessageTokens = result.messages.reduce(
+						(total: number, message) => total + estimateMessageTokens(message),
+						0,
 					);
-					result = undefined;
+					const shrunk =
+						safeJsonSize(result.messages) < safeJsonSize(context.messages);
+					if (!shrunk || customMessageTokens > messageTargetTokens) {
+						config.logger?.log(
+							"Custom compaction did not reach the overflow-recovery target; falling back to basic compaction",
+							{
+								severity: "warn",
+								shrunk,
+								customMessageTokens,
+								messageTargetTokens,
+							},
+						);
+						result = undefined;
+					}
 				}
 			}
 			if (!result?.messages) {

--- a/sdk/packages/core/src/extensions/context/compaction.ts
+++ b/sdk/packages/core/src/extensions/context/compaction.ts
@@ -431,15 +431,37 @@ export function createContextCompactionPrepareTurn(
 		};
 		let executedStrategy = telemetryStrategy;
 		let result: CoreCompactionResult | undefined;
-		if (userCompaction?.compact) {
-			result = await userCompaction.compact(compactionContext);
-		} else if (effectiveMode === "overflow_recovery") {
-			// The provider already rejected the request, so recovery must be
-			// deterministic: the agentic strategy's own summarizer call could
+		if (effectiveMode === "overflow_recovery") {
+			// The provider already rejected the request, so recovery must end
+			// deterministically: the agentic strategy's own summarizer call could
 			// overflow the same window (its input budgeting trusts the same
-			// estimator that just undercounted).
-			executedStrategy = "basic";
-			result = await BUILTIN_COMPACTION_STRATEGIES.basic(builtinOptions);
+			// estimator that just undercounted). A custom compactor gets first
+			// shot — it sees mode "overflow_recovery" and owns its transcript
+			// invariants — but if it throws or declines, basic compaction runs
+			// so recovery never depends on another successful LLM request.
+			if (userCompaction?.compact) {
+				try {
+					result = await userCompaction.compact(compactionContext);
+				} catch (error) {
+					if (isCompactionCancellation(error, context.abortSignal)) {
+						throw error;
+					}
+					config.logger?.log(
+						"Custom compaction failed during overflow recovery; falling back to basic compaction",
+						{
+							severity: "warn",
+							...describeCompactionError(error),
+						},
+					);
+					result = undefined;
+				}
+			}
+			if (!result?.messages) {
+				executedStrategy = "basic";
+				result = await BUILTIN_COMPACTION_STRATEGIES.basic(builtinOptions);
+			}
+		} else if (userCompaction?.compact) {
+			result = await userCompaction.compact(compactionContext);
 		} else {
 			try {
 				result = await runBuiltinStrategy(builtinOptions);

--- a/sdk/packages/core/src/extensions/context/compaction.ts
+++ b/sdk/packages/core/src/extensions/context/compaction.ts
@@ -437,8 +437,10 @@ export function createContextCompactionPrepareTurn(
 			// overflow the same window (its input budgeting trusts the same
 			// estimator that just undercounted). A custom compactor gets first
 			// shot — it sees mode "overflow_recovery" and owns its transcript
-			// invariants — but if it throws or declines, basic compaction runs
-			// so recovery never depends on another successful LLM request.
+			// invariants — but if it throws, declines, or fails to shrink the
+			// transcript (the runtime refuses to retry with a request that is
+			// not smaller), basic compaction runs so recovery never depends on
+			// another successful LLM request.
 			if (userCompaction?.compact) {
 				try {
 					result = await userCompaction.compact(compactionContext);
@@ -452,6 +454,16 @@ export function createContextCompactionPrepareTurn(
 							severity: "warn",
 							...describeCompactionError(error),
 						},
+					);
+					result = undefined;
+				}
+				if (
+					result?.messages &&
+					safeJsonSize(result.messages) >= safeJsonSize(context.messages)
+				) {
+					config.logger?.log(
+						"Custom compaction did not shrink the transcript during overflow recovery; falling back to basic compaction",
+						{ severity: "warn" },
 					);
 					result = undefined;
 				}

--- a/sdk/packages/core/src/extensions/context/compaction.ts
+++ b/sdk/packages/core/src/extensions/context/compaction.ts
@@ -471,10 +471,12 @@ export function createContextCompactionPrepareTurn(
 					// retried), strictly smaller than the input (the runtime
 					// refuses a retry that is not smaller), and within the
 					// recovery token target (a marginal shrink spends the run's
-					// single retry on a request that still cannot fit).
+					// single retry on a request that still cannot fit). Both size
+					// comparisons use the token estimator rather than serialized
+					// length so they are expressed in the same unit as the target.
 					const acceptable =
 						result.messages.length > 0 &&
-						safeJsonSize(result.messages) < safeJsonSize(context.messages) &&
+						customMessageTokens < messageInputTokens &&
 						customMessageTokens <= messageTargetTokens;
 					if (!acceptable) {
 						config.logger?.log(

--- a/sdk/packages/core/src/extensions/context/compaction.ts
+++ b/sdk/packages/core/src/extensions/context/compaction.ts
@@ -465,14 +465,22 @@ export function createContextCompactionPrepareTurn(
 						(total: number, message) => total + estimateMessageTokens(message),
 						0,
 					);
-					const shrunk =
-						safeJsonSize(result.messages) < safeJsonSize(context.messages);
-					if (!shrunk || customMessageTokens > messageTargetTokens) {
+					// The full acceptance bar, covering every degenerate size: a
+					// non-empty transcript (an empty one erases the request being
+					// retried), strictly smaller than the input (the runtime
+					// refuses a retry that is not smaller), and within the
+					// recovery token target (a marginal shrink spends the run's
+					// single retry on a request that still cannot fit).
+					const acceptable =
+						result.messages.length > 0 &&
+						safeJsonSize(result.messages) < safeJsonSize(context.messages) &&
+						customMessageTokens <= messageTargetTokens;
+					if (!acceptable) {
 						config.logger?.log(
-							"Custom compaction did not reach the overflow-recovery target; falling back to basic compaction",
+							"Custom compaction did not produce an acceptable overflow-recovery transcript; falling back to basic compaction",
 							{
 								severity: "warn",
-								shrunk,
+								customMessageCount: result.messages.length,
 								customMessageTokens,
 								messageTargetTokens,
 							},

--- a/sdk/packages/core/src/extensions/context/compaction.ts
+++ b/sdk/packages/core/src/extensions/context/compaction.ts
@@ -41,6 +41,14 @@ export interface ContextPipelinePrepareTurnInput {
 	systemPrompt: string;
 	tools: unknown[];
 	model: CoreCompactionContext["model"];
+	/**
+	 * Set by the runtime when the provider rejected the previous request as
+	 * exceeding the model's context window. Forces a compaction regardless of
+	 * the token-estimate trigger (the estimate just proved wrong) and uses the
+	 * deterministic basic strategy — recovery must not depend on another
+	 * successful LLM request.
+	 */
+	overflowRecovery?: boolean;
 	emitStatusNotice?: (
 		message: string,
 		metadata?: Record<string, unknown>,
@@ -282,6 +290,9 @@ export function createContextCompactionPrepareTurn(
 		: strategy;
 
 	return async (context) => {
+		const effectiveMode: CoreCompactionMode = context.overflowRecovery
+			? "overflow_recovery"
+			: mode;
 		const apiMessageTokens = context.apiMessages.reduce(
 			(total: number, message) => total + estimateMessageTokens(message),
 			0,
@@ -311,7 +322,7 @@ export function createContextCompactionPrepareTurn(
 		);
 		const shouldCompact = requestInputTokens >= requestTriggerTokens;
 		config.logger?.debug("Context compaction diagnostics", {
-			mode,
+			mode: effectiveMode,
 			strategy,
 			iteration: context.iteration,
 			providerId: config.providerId,
@@ -330,12 +341,12 @@ export function createContextCompactionPrepareTurn(
 			apiMessagesJsonChars: safeJsonSize(context.apiMessages),
 			...summarizeToolResults(context.apiMessages),
 		});
-		if (mode === "auto" && !shouldCompact) {
+		if (effectiveMode === "auto" && !shouldCompact) {
 			return undefined;
 		}
 		let requestTargetTokens: number;
 		let messageTargetTokens: number;
-		if (mode === "auto") {
+		if (effectiveMode === "auto") {
 			requestTargetTokens = resolveAutoRequestTargetTokens({
 				maxInputTokens,
 				modelMaxTokens: context.model.info?.maxTokens,
@@ -362,7 +373,7 @@ export function createContextCompactionPrepareTurn(
 			iteration: context.iteration,
 			messages: context.messages,
 			model: context.model,
-			mode,
+			mode: effectiveMode,
 			budget: {
 				request: {
 					inputTokens: requestInputTokens,
@@ -383,20 +394,27 @@ export function createContextCompactionPrepareTurn(
 		};
 
 		const statusReason =
-			mode === "manual" ? "manual_compaction" : "auto_compaction";
-		context.emitStatusNotice?.(
-			mode === "manual" ? "compacting" : "auto-compacting",
-			{
-				kind: statusReason,
-				reason: statusReason,
-				phase: "started",
-				iteration: context.iteration,
-				triggerTokens: requestTriggerTokens,
-				targetTokens: requestTargetTokens,
-				maxInputTokens,
-				messageTargetTokens,
-			},
-		);
+			effectiveMode === "manual"
+				? "manual_compaction"
+				: effectiveMode === "overflow_recovery"
+					? "overflow_recovery_compaction"
+					: "auto_compaction";
+		const noticePrefix =
+			effectiveMode === "manual"
+				? ""
+				: effectiveMode === "overflow_recovery"
+					? "overflow-recovery-"
+					: "auto-";
+		context.emitStatusNotice?.(`${noticePrefix}compacting`, {
+			kind: statusReason,
+			reason: statusReason,
+			phase: "started",
+			iteration: context.iteration,
+			triggerTokens: requestTriggerTokens,
+			targetTokens: requestTargetTokens,
+			maxInputTokens,
+			messageTargetTokens,
+		});
 
 		const beforeMessageCount = context.messages.length;
 		const startedAt = Date.now();
@@ -415,6 +433,13 @@ export function createContextCompactionPrepareTurn(
 		let result: CoreCompactionResult | undefined;
 		if (userCompaction?.compact) {
 			result = await userCompaction.compact(compactionContext);
+		} else if (effectiveMode === "overflow_recovery") {
+			// The provider already rejected the request, so recovery must be
+			// deterministic: the agentic strategy's own summarizer call could
+			// overflow the same window (its input budgeting trusts the same
+			// estimator that just undercounted).
+			executedStrategy = "basic";
+			result = await BUILTIN_COMPACTION_STRATEGIES.basic(builtinOptions);
 		} else {
 			try {
 				result = await runBuiltinStrategy(builtinOptions);
@@ -473,24 +498,21 @@ export function createContextCompactionPrepareTurn(
 				messagesAfter: result.messages.length,
 				messagesRemoved: beforeMessageCount - result.messages.length,
 			} as Record<string, unknown>);
-			context.emitStatusNotice?.(
-				mode === "manual" ? "compacted" : "auto-compacted",
-				{
-					kind: statusReason,
-					reason: statusReason,
-					phase: "completed",
-					iteration: context.iteration,
-					tokensBefore: requestInputTokens,
-					tokensAfter: afterRequestTokens,
-					messagesBefore: beforeMessageCount,
-					messagesAfter: result.messages.length,
-					maxInputTokens,
-				},
-			);
+			context.emitStatusNotice?.(`${noticePrefix}compacted`, {
+				kind: statusReason,
+				reason: statusReason,
+				phase: "completed",
+				iteration: context.iteration,
+				tokensBefore: requestInputTokens,
+				tokensAfter: afterRequestTokens,
+				messagesBefore: beforeMessageCount,
+				messagesAfter: result.messages.length,
+				maxInputTokens,
+			});
 			captureCompactionExecuted(config.telemetry, {
 				ulid: telemetryUlid,
 				strategy: executedStrategy,
-				mode,
+				mode: effectiveMode,
 				messagesBefore: beforeMessageCount,
 				messagesAfter: result.messages.length,
 				messagesRemoved: beforeMessageCount - result.messages.length,
@@ -514,7 +536,7 @@ export function createContextCompactionPrepareTurn(
 				captureCompactionBudgetEmergency(config.telemetry, {
 					ulid: telemetryUlid,
 					strategy: executedStrategy,
-					mode,
+					mode: effectiveMode,
 					policyIntent: result.budget.policyIntent,
 					actionCount: result.budget.actionCount,
 					warningCount: result.budget.warningCount,
@@ -533,20 +555,17 @@ export function createContextCompactionPrepareTurn(
 				});
 			}
 		} else {
-			context.emitStatusNotice?.(
-				mode === "manual" ? "compaction-skipped" : "auto-compaction-skipped",
-				{
-					kind: statusReason,
-					reason: statusReason,
-					phase: "skipped",
-					iteration: context.iteration,
-					maxInputTokens,
-				},
-			);
+			context.emitStatusNotice?.(`${noticePrefix}compaction-skipped`, {
+				kind: statusReason,
+				reason: statusReason,
+				phase: "skipped",
+				iteration: context.iteration,
+				maxInputTokens,
+			});
 			captureCompactionSkipped(config.telemetry, {
 				ulid: telemetryUlid,
 				strategy: executedStrategy,
-				mode,
+				mode: effectiveMode,
 				reason: "no_result",
 				tokensBefore: requestInputTokens,
 				triggerTokens: requestTriggerTokens,

--- a/sdk/packages/core/src/extensions/context/compaction.ts
+++ b/sdk/packages/core/src/extensions/context/compaction.ts
@@ -374,6 +374,7 @@ export function createContextCompactionPrepareTurn(
 			messages: context.messages,
 			model: context.model,
 			mode: effectiveMode,
+			abortSignal: context.abortSignal,
 			budget: {
 				request: {
 					inputTokens: requestInputTokens,

--- a/sdk/packages/core/src/runtime/orchestration/runtime-event-adapter.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-event-adapter.ts
@@ -251,6 +251,7 @@ export class RuntimeEventAdapter {
 					{
 						type: "error",
 						error: event.error,
+						errorClass: event.errorClass,
 						recoverable: false,
 						iteration: event.snapshot.iteration,
 					},

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
@@ -1020,6 +1020,7 @@ export class SessionRuntime {
 					provider: this.config.providerId,
 					info: modelInfo,
 				},
+				overflowRecovery: context.overflowRecovery,
 				emitStatusNotice: context.emitStatusNotice,
 			});
 			if (!result) {

--- a/sdk/packages/core/src/services/llms/apihandler-agent-model-adapter.test.ts
+++ b/sdk/packages/core/src/services/llms/apihandler-agent-model-adapter.test.ts
@@ -194,6 +194,66 @@ describe("createAgentModelFromApiHandler", () => {
 		});
 	});
 
+	it("classifies a context-window overflow thrown by the handler", async () => {
+		// Registered handlers (e.g. VS Code LM) reject over-window requests by
+		// throwing; the classification has to survive the flattening to a
+		// message string or the runtime cannot start overflow recovery.
+		const overflow = Object.assign(new Error("Bad Request"), {
+			statusCode: 400,
+			responseBody: JSON.stringify({
+				error: {
+					message: "prompt is too long: 213462 tokens > 200000 maximum",
+				},
+			}),
+		});
+		const handler: ApiHandler = {
+			getMessages: () => [],
+			getModel: (): HandlerModelInfo => ({ id: "m", info: { id: "m" } }),
+			// eslint-disable-next-line require-yield
+			async *createMessage(): AsyncGenerator<ApiStreamChunk> {
+				throw overflow;
+			},
+		};
+		const model = createAgentModelFromApiHandler(handler);
+		const events = await collect(model.stream(baseRequest));
+		expect(events.at(-1)).toMatchObject({
+			type: "finish",
+			reason: "error",
+			errorClass: "context_window_exceeded",
+		});
+	});
+
+	it("classifies a context-window overflow reported by a failed done chunk", async () => {
+		const handler = fakeHandler([
+			{
+				type: "done",
+				success: false,
+				error: "This model's maximum context length is 40960 tokens.",
+				id: "x",
+			},
+		]);
+		const model = createAgentModelFromApiHandler(handler);
+		const events = await collect(model.stream(baseRequest));
+		expect(events.at(-1)).toMatchObject({
+			type: "finish",
+			reason: "error",
+			errorClass: "context_window_exceeded",
+		});
+	});
+
+	it("leaves unrelated handler failures unclassified", async () => {
+		const handler = fakeHandler([{ type: "text", text: "x", id: "x" }], {
+			throwAfter: 0,
+		});
+		const model = createAgentModelFromApiHandler(handler);
+		const events = await collect(model.stream(baseRequest));
+		expect(events.at(-1)).toMatchObject({
+			type: "finish",
+			reason: "error",
+			errorClass: "unknown",
+		});
+	});
+
 	it("does not emit a second finish when the handler throws after a done chunk", async () => {
 		// done -> finish, then the handler throws while flushing.
 		const handler = fakeHandler([{ type: "done", success: true, id: "x" }], {
@@ -225,7 +285,12 @@ describe("createAgentModelFromApiHandler", () => {
 		const model = createAgentModelFromApiHandler(factory);
 		const events = await collect(model.stream(baseRequest));
 		expect(events).toEqual([
-			{ type: "finish", reason: "error", error: "no vscode.lm" },
+			{
+				type: "finish",
+				reason: "error",
+				error: "no vscode.lm",
+				errorClass: "unknown",
+			},
 		]);
 	});
 });

--- a/sdk/packages/core/src/services/llms/apihandler-agent-model-adapter.test.ts
+++ b/sdk/packages/core/src/services/llms/apihandler-agent-model-adapter.test.ts
@@ -10,7 +10,7 @@ import { createAgentModelFromApiHandler } from "./apihandler-agent-model-adapter
 
 function fakeHandler(
 	chunks: ApiStreamChunk[],
-	opts?: { throwAfter?: number },
+	opts?: { throwAfter?: number; error?: unknown },
 ): ApiHandler & { aborts: (AbortSignal | undefined)[] } {
 	const aborts: (AbortSignal | undefined)[] = [];
 	return {
@@ -28,7 +28,7 @@ function fakeHandler(
 			let i = 0;
 			for (const chunk of chunks) {
 				if (opts?.throwAfter !== undefined && i === opts.throwAfter) {
-					throw new Error("boom");
+					throw opts.error ?? new Error("boom");
 				}
 				yield chunk;
 				i++;
@@ -206,14 +206,10 @@ describe("createAgentModelFromApiHandler", () => {
 				},
 			}),
 		});
-		const handler: ApiHandler = {
-			getMessages: () => [],
-			getModel: (): HandlerModelInfo => ({ id: "m", info: { id: "m" } }),
-			// eslint-disable-next-line require-yield
-			async *createMessage(): AsyncGenerator<ApiStreamChunk> {
-				throw overflow;
-			},
-		};
+		const handler = fakeHandler([{ type: "text", text: "x", id: "x" }], {
+			throwAfter: 0,
+			error: overflow,
+		});
 		const model = createAgentModelFromApiHandler(handler);
 		const events = await collect(model.stream(baseRequest));
 		expect(events.at(-1)).toMatchObject({

--- a/sdk/packages/core/src/services/llms/apihandler-agent-model-adapter.ts
+++ b/sdk/packages/core/src/services/llms/apihandler-agent-model-adapter.ts
@@ -13,7 +13,11 @@
  * `@cline/llms` `compat.ts`.
  */
 
-import type { ApiHandler, ApiStreamChunk } from "@cline/llms";
+import {
+	type ApiHandler,
+	type ApiStreamChunk,
+	classifyProviderError,
+} from "@cline/llms";
 import type {
 	AgentModel,
 	AgentModelEvent,
@@ -80,6 +84,13 @@ function toAgentModelEvents(chunk: ApiStreamChunk): AgentModelEvent[] {
 					type: "finish",
 					reason: doneFinishReason(chunk),
 					error: chunk.error,
+					// Handlers report failures as an already-flattened message, so
+					// classification works from the text alone here. Keeps registered
+					// handlers (e.g. VS Code LM) eligible for the runtime's
+					// context-overflow recovery.
+					...(chunk.error
+						? { errorClass: classifyProviderError(chunk.error) }
+						: {}),
 				},
 			];
 		default:
@@ -159,10 +170,16 @@ export function createAgentModelFromApiHandler(
 				}
 			} catch (error) {
 				if (!sawFinish) {
+					const aborted = request.signal?.aborted === true;
 					yield {
 						type: "finish",
-						reason: request.signal?.aborted ? "aborted" : "error",
+						reason: aborted ? "aborted" : "error",
 						error: error instanceof Error ? error.message : String(error),
+						// Classify while the raw error is still structured — the
+						// message alone can hide the provider's detail (status codes,
+						// response bodies). Without this, an overflow rejection from a
+						// registered handler would never reach recovery.
+						...(aborted ? {} : { errorClass: classifyProviderError(error) }),
 					};
 				}
 			}

--- a/sdk/packages/core/src/services/telemetry/core-events.ts
+++ b/sdk/packages/core/src/services/telemetry/core-events.ts
@@ -528,8 +528,6 @@ export function captureProviderApiError(
 		provider?: string;
 		errorStatus?: number;
 		requestId?: string;
-		/** Classification of the provider error (e.g. context_window_exceeded). */
-		errorClass?: string;
 	} & Partial<TelemetryAgentIdentityProperties>,
 ): void {
 	emit(telemetry, CORE_TELEMETRY_EVENTS.TASK.PROVIDER_API_ERROR, {

--- a/sdk/packages/core/src/services/telemetry/core-events.ts
+++ b/sdk/packages/core/src/services/telemetry/core-events.ts
@@ -528,6 +528,8 @@ export function captureProviderApiError(
 		provider?: string;
 		errorStatus?: number;
 		requestId?: string;
+		/** Classification of the provider error (e.g. context_window_exceeded). */
+		errorClass?: string;
 	} & Partial<TelemetryAgentIdentityProperties>,
 ): void {
 	emit(telemetry, CORE_TELEMETRY_EVENTS.TASK.PROVIDER_API_ERROR, {
@@ -730,8 +732,10 @@ export type TelemetryCompactionStrategy = "basic" | "agentic" | "custom";
  * - `auto`   — fired automatically by `createContextCompactionPrepareTurn`
  *   when input tokens reach the fixed compaction threshold.
  * - `manual` — user-initiated (e.g. CLI `/compact`).
+ * - `overflow_recovery` — forced by the runtime after a provider rejected
+ *   the request as exceeding the model's context window.
  */
-export type TelemetryCompactionMode = "auto" | "manual";
+export type TelemetryCompactionMode = "auto" | "manual" | "overflow_recovery";
 
 export interface CaptureCompactionExecutedProperties {
 	ulid: string;

--- a/sdk/packages/core/src/types/config.ts
+++ b/sdk/packages/core/src/types/config.ts
@@ -99,6 +99,12 @@ export interface CoreCompactionContext {
 	};
 	mode: CoreCompactionMode;
 	budget: CoreCompactionBudget;
+	/**
+	 * Aborted when the turn is cancelled. Custom `compact` implementations
+	 * that call models or external services should observe it so a cancelled
+	 * or recovering turn is not blocked on a stalled compaction.
+	 */
+	abortSignal?: AbortSignal;
 }
 
 // Mirrors BudgetPolicyIntent in extensions/context/budget-projection/types.ts.

--- a/sdk/packages/core/src/types/config.ts
+++ b/sdk/packages/core/src/types/config.ts
@@ -59,7 +59,7 @@ export interface CoreRuntimeFeatures {
 	yolo?: boolean;
 }
 
-export type CoreCompactionMode = "auto" | "manual";
+export type CoreCompactionMode = "auto" | "manual" | "overflow_recovery";
 
 export interface CoreCompactionBudget {
 	request: {

--- a/sdk/packages/llms/src/index.ts
+++ b/sdk/packages/llms/src/index.ts
@@ -64,6 +64,7 @@ export {
 	ClineNotSubscribedError,
 	ClineOrgIndividualInferenceSubscriptionError,
 	ClinePassLimitError,
+	classifyProviderError,
 	createHandler,
 	createHandlerAsync,
 	extractClineFreeModelLimitResetTime,

--- a/sdk/packages/llms/src/providers.ts
+++ b/sdk/packages/llms/src/providers.ts
@@ -34,6 +34,7 @@ import {
 	type ProviderConfig,
 } from "./providers/types";
 
+export { classifyProviderError } from "./providers/error-classification";
 export {
 	ClineFreeModelLimitError,
 	ClineNotSubscribedError,

--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -6,6 +6,7 @@ import type {
 	GatewayProviderFactory,
 	GatewayResolvedProviderConfig,
 	GatewayStreamRequest,
+	ProviderErrorClass,
 } from "@cline/shared";
 import {
 	type AiSdkFormatterMessage,
@@ -17,6 +18,7 @@ import {
 } from "@cline/shared";
 import { type CallSettings, jsonSchema, NoSuchToolError, streamText } from "ai";
 import { nanoid } from "nanoid";
+import { classifyProviderError } from "./error-classification";
 import { extractErrorMessage } from "./format";
 import {
 	isAnthropicCompatibleModel,
@@ -905,17 +907,35 @@ function extractGoogleThoughtMetadata(
 	return Object.keys(metadata).length > 0 ? metadata : undefined;
 }
 
+/**
+ * A stream error captured while the raw provider error object is still in
+ * hand: the flattened display message plus its classification. Both are
+ * derived here because the structure needed to classify does not survive
+ * `extractErrorMessage`.
+ */
+interface CapturedStreamError {
+	message: string;
+	errorClass: ProviderErrorClass;
+}
+
+function captureStreamError(error: unknown): CapturedStreamError {
+	return {
+		message: extractErrorMessage(error),
+		errorClass: classifyProviderError(error),
+	};
+}
+
 async function* emitAiSdkEvents(
 	stream: AiSdkStreamResult,
 	request: GatewayStreamRequest,
 	context: GatewayProviderContext,
 	pricingValue?: unknown,
-	capturedError?: { current: string | undefined },
+	capturedError?: { current: CapturedStreamError | undefined },
 ): AsyncIterable<AgentModelEvent> {
 	let sawToolCalls = false;
 	const emittedToolCallIds = new Set<string>();
 	let finishReason: unknown;
-	let streamError: string | undefined;
+	let streamError: CapturedStreamError | undefined;
 	let finishUsage: unknown;
 	let finishProviderMetadata: unknown;
 
@@ -1025,7 +1045,7 @@ async function* emitAiSdkEvents(
 
 				if (part.type === "error") {
 					streamError =
-						capturedError?.current ?? extractErrorMessage(part.error);
+						capturedError?.current ?? captureStreamError(part.error);
 					break;
 				}
 
@@ -1042,7 +1062,7 @@ async function* emitAiSdkEvents(
 	} catch (error) {
 		// Prefer the real provider error from onError over the generic
 		// NoOutputGeneratedError the AI SDK throws when 0 steps are recorded.
-		streamError = capturedError?.current ?? extractErrorMessage(error);
+		streamError = capturedError?.current ?? captureStreamError(error);
 	}
 
 	// Prefer stream.usage (has raw cost data) over finish part usage.
@@ -1057,7 +1077,7 @@ async function* emitAiSdkEvents(
 			usageToEmit = await stream.usage;
 		} catch (error) {
 			if (!streamError) {
-				streamError = capturedError?.current ?? extractErrorMessage(error);
+				streamError = capturedError?.current ?? captureStreamError(error);
 			}
 			usageToEmit = finishUsage;
 			metadataToUse = finishProviderMetadata;
@@ -1077,7 +1097,8 @@ async function* emitAiSdkEvents(
 	yield {
 		type: "finish",
 		reason: streamError ? "error" : mapFinishReason(finishReason, sawToolCalls),
-		error: streamError,
+		error: streamError?.message,
+		errorClass: streamError?.errorClass,
 	};
 }
 
@@ -1159,7 +1180,7 @@ function createAiSdkProvider(kind: ProviderModuleKind): GatewayProviderFactory {
 		async *stream(request, context) {
 			const log = context.logger;
 			let stream: AiSdkStreamResult | undefined;
-			const capturedError: { current: string | undefined } = {
+			const capturedError: { current: CapturedStreamError | undefined } = {
 				current: undefined,
 			};
 			try {
@@ -1222,8 +1243,9 @@ function createAiSdkProvider(kind: ProviderModuleKind): GatewayProviderFactory {
 					providerOptions,
 					...requestConfig,
 					onError: ({ error: streamError }) => {
-						const msg = extractErrorMessage(streamError);
-						capturedError.current = msg;
+						const captured = captureStreamError(streamError);
+						const msg = captured.message;
+						capturedError.current = captured;
 						if (log?.error) {
 							log.error("[ai-sdk] stream error", {
 								providerId: request.providerId,
@@ -1269,7 +1291,8 @@ function createAiSdkProvider(kind: ProviderModuleKind): GatewayProviderFactory {
 				suppressDanglingStreamPromises(stream);
 				// Prefer the real provider error captured in onError over the generic
 				// NoOutputGeneratedError that the AI SDK throws when 0 steps are recorded.
-				const msg = capturedError.current ?? extractErrorMessage(error);
+				const captured = capturedError.current ?? captureStreamError(error);
+				const msg = captured.message;
 				if (log?.error) {
 					log.error("[ai-sdk] provider error", {
 						providerId: request.providerId,
@@ -1299,6 +1322,7 @@ function createAiSdkProvider(kind: ProviderModuleKind): GatewayProviderFactory {
 					type: "finish",
 					reason: "error",
 					error: msg,
+					errorClass: captured.errorClass,
 				};
 			}
 		},

--- a/sdk/packages/llms/src/providers/error-classification.test.ts
+++ b/sdk/packages/llms/src/providers/error-classification.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest";
+import { classifyProviderError } from "./error-classification";
+
+describe("classifyProviderError", () => {
+	describe("context_window_exceeded", () => {
+		it("classifies the gateway-forwarded Alibaba Qwen rejection (captured shape)", () => {
+			// Same payload format.test.ts verifies extractErrorMessage against.
+			expect(
+				classifyProviderError({
+					code: "error",
+					message: "Stream error occurred",
+					name: "AI_TypeValidationError",
+					cause: {
+						name: "ZodError",
+						message:
+							'[\n  {\n    "code": "invalid_union",\n    "path": [],\n    "message": "Invalid input"\n  }\n]',
+					},
+					value: {
+						error_type: "validation_error",
+						error_message: JSON.stringify({
+							error: {
+								message:
+									"This model's maximum context length is 40960 tokens. However, you requested 100 output tokens and your prompt contains at least 40861 input tokens.",
+								code: 400,
+							},
+						}),
+					},
+				}),
+			).toBe("context_window_exceeded");
+		});
+
+		it("classifies an AI SDK APICallError-shaped 400 with context detail in responseBody", () => {
+			const error = Object.assign(new Error("Bad Request"), {
+				name: "AI_APICallError",
+				statusCode: 400,
+				responseBody: JSON.stringify({
+					error: {
+						message:
+							"This model's maximum context length is 128000 tokens. However, your messages resulted in 130000 tokens.",
+						type: "invalid_request_error",
+						code: "context_length_exceeded",
+					},
+				}),
+			});
+			expect(classifyProviderError(error)).toBe("context_window_exceeded");
+		});
+
+		it("classifies by explicit context_length_exceeded code alone", () => {
+			expect(
+				classifyProviderError({
+					error: { code: "context_length_exceeded" },
+				}),
+			).toBe("context_window_exceeded");
+		});
+
+		it("classifies Anthropic prompt-too-long rejections", () => {
+			expect(
+				classifyProviderError({
+					status: 400,
+					error: {
+						type: "invalid_request_error",
+						message: "prompt is too long: 213462 tokens > 200000 maximum",
+					},
+				}),
+			).toBe("context_window_exceeded");
+		});
+
+		it("classifies Bedrock input-too-long validation errors", () => {
+			const error = Object.assign(new Error("Bad Request"), {
+				name: "AI_APICallError",
+				statusCode: 400,
+				responseBody: JSON.stringify({
+					message: "Input is too long for requested model.",
+				}),
+			});
+			expect(classifyProviderError(error)).toBe("context_window_exceeded");
+		});
+
+		it("classifies Cerebras reduce-the-length rejections", () => {
+			expect(
+				classifyProviderError({
+					statusCode: 400,
+					message: "Please reduce the length of the messages or completion.",
+				}),
+			).toBe("context_window_exceeded");
+		});
+
+		it("classifies OpenRouter errors JSON-encoded into the message string", () => {
+			expect(
+				classifyProviderError(
+					new Error(
+						'Provider returned error: {"error":{"message":"This endpoint\'s maximum context length is 65536 tokens.","code":400}}',
+					),
+				),
+			).toBe("context_window_exceeded");
+		});
+
+		it("classifies an already-flattened message string", () => {
+			expect(
+				classifyProviderError(
+					"input length and max_tokens exceed context limit: 199999 + 8192 > 200000",
+				),
+			).toBe("context_window_exceeded");
+		});
+	});
+
+	describe("unknown", () => {
+		it("vetoes token-per-minute rate limits despite token wording", () => {
+			expect(
+				classifyProviderError({
+					status: 429,
+					error: {
+						type: "rate_limit_error",
+						message:
+							"Number of request tokens has exceeded your per-minute rate limit.",
+					},
+				}),
+			).toBe("unknown");
+		});
+
+		it("vetoes rate-limit wording even without a status", () => {
+			expect(
+				classifyProviderError(
+					new Error("Rate limit reached for gpt-4o on tokens per min (TPM)"),
+				),
+			).toBe("unknown");
+		});
+
+		it("vetoes context wording on a non-invalid-request status", () => {
+			expect(
+				classifyProviderError({
+					statusCode: 500,
+					message: "internal error computing context length",
+				}),
+			).toBe("unknown");
+		});
+
+		it("leaves auth errors unclassified", () => {
+			expect(
+				classifyProviderError({
+					statusCode: 401,
+					message: "invalid x-api-key",
+				}),
+			).toBe("unknown");
+		});
+
+		it("leaves generic stream failures unclassified", () => {
+			expect(
+				classifyProviderError(new Error("fetch failed: other side closed")),
+			).toBe("unknown");
+		});
+
+		it("handles null, primitives, and empty objects", () => {
+			expect(classifyProviderError(null)).toBe("unknown");
+			expect(classifyProviderError(undefined)).toBe("unknown");
+			expect(classifyProviderError(42)).toBe("unknown");
+			expect(classifyProviderError({})).toBe("unknown");
+		});
+
+		it("survives self-referential error objects", () => {
+			const cyclic: Record<string, unknown> = { message: "boom" };
+			cyclic.cause = cyclic;
+			expect(classifyProviderError(cyclic)).toBe("unknown");
+		});
+	});
+});

--- a/sdk/packages/llms/src/providers/error-classification.ts
+++ b/sdk/packages/llms/src/providers/error-classification.ts
@@ -1,0 +1,197 @@
+import { type ProviderErrorClass, safeJsonParse } from "@cline/shared";
+
+/**
+ * Provider codes that unambiguously identify a context-window overflow
+ * (OpenAI-family `error.code`).
+ */
+const CONTEXT_WINDOW_CODES = new Set(["context_length_exceeded"]);
+
+/**
+ * Message shapes providers use for context-window overflow. Sourced from the
+ * legacy extension's per-provider detectors (OpenAI, OpenRouter, Anthropic,
+ * Cerebras, Bedrock, Vercel gateway / Alibaba Qwen) — the wire messages are
+ * provider-authored and identical on the SDK arch; only the surrounding
+ * error-object structure changed (handled by the signal walk below).
+ */
+const CONTEXT_WINDOW_PATTERNS = [
+	/\bcontext\s*(?:length|window|limit)\b/i,
+	/\bmaximum\s*context\b/i,
+	/\b(?:input\s*)?tokens?\s+exceeds?\b/i,
+	/\btoo\s*many\s*tokens?\b/i,
+	/\binput\s+is\s+too\s+long\b/i,
+	/\bprompt\s+is\s+too\s+long\b/i,
+	/reduce\s+the\s+length\s+of\s+the\s+messages\s+or\s+completion/i,
+	/requested\s+input\s+length\s+.*exceeds\s+.*maximum/i,
+];
+
+/**
+ * Signals that the request failed for throughput/quota reasons rather than
+ * size. Token-per-minute limit messages also talk about tokens being
+ * "exceeded", so these veto a context-window match.
+ */
+const RATE_LIMIT_PATTERNS = [/rate[\s_-]?limit/i, /per[\s_-]?minute\b/i];
+
+/** Overflow rejections arrive as invalid-request-family statuses. */
+const CONTEXT_WINDOW_STATUSES = new Set([400, 413, 422]);
+const RATE_LIMIT_STATUS = 429;
+
+const MAX_WALK_DEPTH = 8;
+
+/**
+ * Object keys whose values carry further error detail — human-readable text
+ * (message/detail/error_message; strings are recorded by the string branch)
+ * or nested error structures the providers and gateways wrap around them.
+ */
+const DETAIL_KEYS = [
+	"message",
+	"detail",
+	"error_message",
+	"error",
+	"errors",
+	"cause",
+	"responseBody",
+	"data",
+	"value",
+	"param",
+] as const;
+
+/** Object keys that may carry an HTTP status. */
+const STATUS_KEYS = ["status", "statusCode", "code"] as const;
+
+interface ErrorSignals {
+	messages: string[];
+	statuses: Set<number>;
+	codes: Set<string>;
+}
+
+function recordStatus(signals: ErrorSignals, value: unknown): void {
+	const numeric =
+		typeof value === "number"
+			? value
+			: typeof value === "string" && /^\d{3}$/.test(value.trim())
+				? Number(value.trim())
+				: undefined;
+	if (numeric !== undefined && numeric >= 100 && numeric <= 599) {
+		signals.statuses.add(numeric);
+	}
+}
+
+function collectSignals(
+	value: unknown,
+	signals: ErrorSignals,
+	visited: Set<unknown>,
+	depth: number,
+): void {
+	if (value == null || depth > MAX_WALK_DEPTH) {
+		return;
+	}
+	if (typeof value === "string") {
+		const text = value.trim();
+		if (!text) {
+			return;
+		}
+		signals.messages.push(text);
+		// Providers and gateways JSON-encode upstream rejections into message
+		// strings (OpenRouter mid-stream errors, Vercel `value.error_message`);
+		// parse so embedded status/code fields become structured signals.
+		const parsed = safeJsonParse<unknown>(text);
+		if (parsed !== undefined && typeof parsed === "object") {
+			collectSignals(parsed, signals, visited, depth + 1);
+		} else {
+			// Not full JSON — still mine embedded `"code": 400` / `"status": 400`.
+			const embedded = text.match(/"(?:code|status)"\s*:\s*"?(\d{3})"?/);
+			if (embedded) {
+				recordStatus(signals, embedded[1]);
+			}
+		}
+		return;
+	}
+	if (typeof value !== "object") {
+		return;
+	}
+	if (visited.has(value)) {
+		return;
+	}
+	visited.add(value);
+
+	if (Array.isArray(value)) {
+		for (const item of value) {
+			collectSignals(item, signals, visited, depth + 1);
+		}
+		return;
+	}
+
+	const record = value as Record<string, unknown>;
+	for (const key of STATUS_KEYS) {
+		recordStatus(signals, record[key]);
+	}
+	for (const key of ["code", "type", "name"]) {
+		const candidate = record[key];
+		if (typeof candidate === "string" && candidate.trim()) {
+			signals.codes.add(candidate.trim());
+		}
+	}
+	for (const key of DETAIL_KEYS) {
+		const nested = record[key];
+		if (
+			nested !== undefined &&
+			nested !== value &&
+			typeof nested !== "number"
+		) {
+			collectSignals(nested, signals, visited, depth + 1);
+		}
+	}
+}
+
+/**
+ * Classify a raw provider error (or an already-flattened error message) into
+ * a {@link ProviderErrorClass}. Call this where the structured error object
+ * is still available — `extractErrorMessage` discards the structure this
+ * classification relies on.
+ *
+ * Detection is deliberately conservative: a context-window verdict requires
+ * an overflow message pattern (or explicit provider code), no rate-limit
+ * signal, and — when any HTTP status is visible — an invalid-request-family
+ * status.
+ */
+export function classifyProviderError(error: unknown): ProviderErrorClass {
+	const signals: ErrorSignals = {
+		messages: [],
+		statuses: new Set(),
+		codes: new Set(),
+	};
+	try {
+		collectSignals(error, signals, new Set(), 0);
+	} catch {
+		return "unknown";
+	}
+
+	if ([...signals.codes].some((code) => CONTEXT_WINDOW_CODES.has(code))) {
+		return "context_window_exceeded";
+	}
+
+	if (signals.statuses.has(RATE_LIMIT_STATUS)) {
+		return "unknown";
+	}
+	if (
+		signals.messages.some((message) =>
+			RATE_LIMIT_PATTERNS.some((pattern) => pattern.test(message)),
+		)
+	) {
+		return "unknown";
+	}
+	if (
+		signals.statuses.size > 0 &&
+		![...signals.statuses].some((status) => CONTEXT_WINDOW_STATUSES.has(status))
+	) {
+		return "unknown";
+	}
+	if (
+		signals.messages.some((message) =>
+			CONTEXT_WINDOW_PATTERNS.some((pattern) => pattern.test(message)),
+		)
+	) {
+		return "context_window_exceeded";
+	}
+	return "unknown";
+}

--- a/sdk/packages/llms/src/providers/gateway.test.ts
+++ b/sdk/packages/llms/src/providers/gateway.test.ts
@@ -757,6 +757,7 @@ describe("sdk-gateway", () => {
 			type: "finish",
 			reason: "error",
 			error: "Invalid API key",
+			errorClass: "unknown",
 		});
 	});
 
@@ -871,8 +872,48 @@ describe("sdk-gateway", () => {
 				type: "finish",
 				reason: "error",
 				error: "Invalid API key",
+				errorClass: "unknown",
 			},
 		]);
+	});
+
+	it("classifies context-window overflow errors on the finish event", async () => {
+		const overflowError = Object.assign(new Error("Bad Request"), {
+			statusCode: 400,
+			responseBody: JSON.stringify({
+				error: {
+					message: "prompt is too long: 213462 tokens > 200000 maximum",
+					type: "invalid_request_error",
+				},
+			}),
+		});
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([{ type: "error", error: overflowError }]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [
+				{
+					providerId: "openai-native",
+					apiKey: "test",
+				},
+			],
+		});
+
+		const events = await collect(
+			await gateway.stream({
+				providerId: "openai-native",
+				modelId: "gpt-5-mini",
+				messages: baseMessages,
+			}),
+		);
+
+		expect(events.at(-1)).toEqual({
+			type: "finish",
+			reason: "error",
+			error: "prompt is too long: 213462 tokens > 200000 maximum",
+			errorClass: "context_window_exceeded",
+		});
 	});
 
 	it("surfaces API detail fields from OpenAI-compatible error bodies", async () => {
@@ -907,6 +948,7 @@ describe("sdk-gateway", () => {
 			type: "finish",
 			reason: "error",
 			error: "Instructions are required",
+			errorClass: "unknown",
 		});
 	});
 
@@ -4065,35 +4107,32 @@ describe("sdk-gateway", () => {
 			"qwen-plus-latest",
 			"https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
 		],
-	])(
-		"routes %s to the %s regional endpoint when options.apiLine is set",
-		async (providerId, apiLine, modelId, expectedBaseUrl) => {
-			streamTextSpy.mockReturnValue({
-				fullStream: makeStreamParts([
-					{ type: "text-delta", textDelta: "Regional" },
-					{ type: "finish", usage: { inputTokens: 2, outputTokens: 1 } },
-				]),
-			});
+	])("routes %s to the %s regional endpoint when options.apiLine is set", async (providerId, apiLine, modelId, expectedBaseUrl) => {
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([
+				{ type: "text-delta", textDelta: "Regional" },
+				{ type: "finish", usage: { inputTokens: 2, outputTokens: 1 } },
+			]),
+		});
 
-			const gateway = createGateway({
-				providerConfigs: [
-					{ providerId, apiKey: "test-key", options: { apiLine } },
-				],
-			});
+		const gateway = createGateway({
+			providerConfigs: [
+				{ providerId, apiKey: "test-key", options: { apiLine } },
+			],
+		});
 
-			await collect(
-				await gateway.stream({
-					providerId,
-					modelId,
-					messages: baseMessages,
-				}),
-			);
+		await collect(
+			await gateway.stream({
+				providerId,
+				modelId,
+				messages: baseMessages,
+			}),
+		);
 
-			expect(openaiCompatibleFactorySpy).toHaveBeenCalledWith(
-				expect.objectContaining({ baseURL: expectedBaseUrl }),
-			);
-		},
-	);
+		expect(openaiCompatibleFactorySpy).toHaveBeenCalledWith(
+			expect.objectContaining({ baseURL: expectedBaseUrl }),
+		);
+	});
 
 	it("lets an explicit base URL win over options.apiLine", async () => {
 		streamTextSpy.mockReturnValue({

--- a/sdk/packages/shared/src/agent.ts
+++ b/sdk/packages/shared/src/agent.ts
@@ -137,6 +137,8 @@ export interface AgentRuntimeStateSnapshot {
 	pendingToolCalls: readonly string[];
 	usage: AgentUsage;
 	lastError?: string;
+	/** Classification of `lastError` when it came from a provider stream. */
+	lastErrorClass?: ProviderErrorClass;
 }
 
 // =============================================================================
@@ -211,6 +213,12 @@ export interface AgentRuntimePrepareTurnContext {
 		info?: ModelInfo;
 	};
 	signal?: AbortSignal;
+	/**
+	 * Set when the previous model request was rejected as exceeding the
+	 * model's context window; asks the prepare-turn pipeline to force a
+	 * compaction rather than trust its token estimates.
+	 */
+	overflowRecovery?: boolean;
 	emitStatusNotice?: (
 		message: string,
 		metadata?: Record<string, unknown>,
@@ -228,6 +236,14 @@ export type AgentModelFinishReason =
 	| "max-tokens"
 	| "aborted"
 	| "error";
+
+/**
+ * Coarse classification of a provider error, derived from the raw provider
+ * error object before it is flattened into a display string. Shared by the
+ * runtime's recovery policy and telemetry (`error_class`). Extend with new
+ * classes (auth, rate_limit, billing, ...) as consumers need them.
+ */
+export type ProviderErrorClass = "context_window_exceeded" | "unknown";
 
 export type AgentModelEvent =
 	| { type: "text-delta"; text: string }
@@ -254,6 +270,7 @@ export type AgentModelEvent =
 			type: "finish";
 			reason: AgentModelFinishReason;
 			error?: string;
+			errorClass?: ProviderErrorClass;
 	  };
 
 export interface AgentModel {
@@ -547,6 +564,8 @@ export type AgentRuntimeEvent =
 			type: "run-failed";
 			snapshot: AgentRuntimeStateSnapshot;
 			error: Error;
+			/** Classification of the provider error that failed the run. */
+			errorClass?: ProviderErrorClass;
 	  };
 
 // =============================================================================

--- a/sdk/packages/shared/src/agents/types.ts
+++ b/sdk/packages/shared/src/agents/types.ts
@@ -11,7 +11,11 @@
  */
 
 import { z } from "zod";
-import type { AgentRuntimeHooks, AgentTool } from "../agent";
+import type {
+	AgentRuntimeHooks,
+	AgentTool,
+	ProviderErrorClass,
+} from "../agent";
 import type { ExtensionContext } from "../extensions/context";
 import type {
 	AgentExtensionApi,
@@ -197,6 +201,8 @@ export interface AgentErrorEvent extends AgentEventMetadata {
 	type: "error";
 	/** The error that occurred */
 	error: Error;
+	/** Classification of the provider error, when known. */
+	errorClass?: ProviderErrorClass;
 	/** Whether the error is recoverable */
 	recoverable: boolean;
 	/** Current iteration when error occurred */
@@ -594,6 +600,12 @@ export interface AgentPrepareTurnContext {
 		provider: string;
 		info?: ModelInfo;
 	};
+	/**
+	 * Set when the previous model request was rejected as exceeding the
+	 * model's context window; asks the prepare-turn pipeline to force a
+	 * compaction rather than trust its token estimates.
+	 */
+	overflowRecovery?: boolean;
 	emitStatusNotice?: (
 		message: string,
 		metadata?: Record<string, unknown>,

--- a/sdk/packages/shared/src/services/telemetry.ts
+++ b/sdk/packages/shared/src/services/telemetry.ts
@@ -82,6 +82,11 @@ export interface CaptureTaskLifecycleEventInput {
 	durationMs?: number;
 	eventType?: string;
 	error?: unknown;
+	/**
+	 * Classification of `error` (e.g. context_window_exceeded), emitted as
+	 * `error_class` alongside the normalized error fields.
+	 */
+	errorClass?: string;
 	messageLimit?: number;
 }
 
@@ -183,6 +188,7 @@ export function captureTaskLifecycleEvent(
 			...(input.error === undefined
 				? {}
 				: normalizeSdkError(input.error, input.messageLimit)),
+			error_class: input.errorClass,
 		}),
 	});
 }


### PR DESCRIPTION
Fixes https://linear.app/cline-bot/issue/ENG-2394.

## Problem

When a prompt exceeds a model's context window, providers reject the request — and the SDK arch treats this as a generic unclassified stream error: no detection, no recovery, raw provider dump (or Zod noise) shown to the user. The legacy arch had a complete mechanism (`checkContextWindowExceededError` + auto-truncate-and-retry in the legacy task loop) that the SDK arch never got, so this is a regression. Root-cause investigation: [ENG-2394](https://linear.app/cline-bot/issue/ENG-2394/vercel-ai-gateway-stream-error-occurred-on-final-response-synthesis).

## Design

Classification and recovery live in different layers, connected by a typed result:

- **Classify in `llms`** (new `classifyProviderError`), at the same sites as `extractErrorMessage` — the only place the structured provider error still exists before being flattened to a display string. It walks AI-SDK wrapper shapes (`statusCode`, `responseBody`, `cause` chains, the gateway `value.error_message` shape from #12800) and reuses the legacy detectors' message patterns, with two guards: rate-limit wording/429 vetoes a match (TPM-limit messages also say "tokens exceeded"), and a visible non-invalid-request HTTP status vetoes it too.
- **Typed channel in `shared`**: `ProviderErrorClass` (`"context_window_exceeded" | "unknown"`, extensible), carried on the model `finish` event, the runtime snapshot, and the `run-failed` event.
- **Classify on every model path.** The gateway/AI-SDK providers classify from the raw error. Registered `ApiHandler` models (VS Code LM and any other host-supplied provider, via `createAgentModelFromApiHandler`) classify at their own error boundary, for both thrown errors and failed `done` chunks — that adapter flattens failures to a message string, so without this those paths could never reach recovery. As a backstop the runtime classifies from the finish message when a model supplies no class, which covers custom `AgentModel` implementations too.
- **Recover in the `agents` runtime**, once per run: on a classified overflow, force a compaction through `prepareTurn` and retry the request. The user sees a status notice ("context window exceeded — compacting and retrying"), not an error. A new user message starts a new run and re-arms recovery, mirroring the legacy "retry truncates again" behavior without new UI.
- **Forced compaction in `core`**: a per-turn `overflowRecovery` flag on the prepare-turn context bypasses the token-estimate trigger (the estimate is exactly what just proved wrong) and runs the deterministic **basic** strategy directly — recovery must not depend on another successful LLM request (the agentic summarizer call budgets with the same estimator that undercounted, so it could overflow too). Runs as a new `overflow_recovery` compaction mode in notices/telemetry and composes with the compaction-state-aware wrapper.

### Terminal states (actionable message instead of a raw provider dump)

- **Nothing to compact** (single oversized first prompt — system prompt + tools + input alone exceed the window; legacy called this "bricked"): fail *before* re-sending the doomed request, with guidance to reduce content or switch models. The retry is only sent when forced compaction actually shrank the request.
- **No prepare-turn pipeline** (compaction unavailable): fail with guidance to compact / new session / larger model.
- **Retry still overflows**: fail with guidance; the one recovery attempt per run is spent.

All three append the original provider message (`… (provider reported: prompt is too long: 213462 tokens > 200000 maximum)`).

A custom `compaction.compact` still gets first shot during recovery (it sees `mode: "overflow_recovery"` and owns its transcript invariants), but its result is accepted only when non-empty, strictly smaller, and within the recovery token target; otherwise basic compaction runs, so recovery always ends deterministically. `CoreCompactionContext` now also carries the turn's abort signal so a custom compactor can observe cancellation.

## Telemetry

The classification doubles as the error-class the follow-up asked for, so overflow becomes countable:

- `task.provider_stream_failed` gains `error_class` (always classified; it is definitionally a provider failure).
- Compaction events now distinguish `mode: overflow_recovery` from `auto`/`manual`.
- `task.provider_api_error` is untouched here: #12820 removed core's capture site for it, so host adapters own that event now. The classification still reaches them — `AgentErrorEvent.errorClass` is populated on the terminal `error` event the VS Code adapter consumes — and forwarding it into `ProviderFailureTelemetry` is a one-line fast-follow I'll open after this lands (noted on #12820).

## Notes / follow-ups

- Errored streams that produced tool calls keep today's behavior (proceed with the tool calls) — recovery only intercepts turns that would otherwise fail the run.
- Recovery compaction notices use kind `overflow_recovery_compaction`; the CLI/VS Code compaction dividers key on `auto_compaction`/`manual_compaction`, so recovery renders as a plain status notice for now. Host-side rendering can be added later.
- `task.provider_stream_failed` still only fires for *thrown* stream errors (pre-existing); mid-stream finish-event errors reach hosts as the runtime's terminal `error` event instead.
- Auth retry (`isLikelyAuthError`) is unaffected — overflow messages don't match its patterns, and the recovery path resolves before the run fails.
- The runtime's "did the retry actually shrink" backstop compares serialized length, a proxy for tokens. That is all it needs (it only answers "was anything removed", and the shared estimator is itself linear in character count, so the verdict is identical), and authoritative token budgeting happens inside the compaction pipeline. TODO in code to surface the estimates `prepareTurn` already computes instead.

## Testing

All headless, per package (`tsc --noEmit` clean in all four):
- `llms`: 15 new classifier tests (captured Vercel/Alibaba payload from #12800, AI-SDK `APICallError` shapes, Anthropic/Bedrock/Cerebras/OpenRouter messages, rate-limit and status vetoes, cycle safety) + a gateway-level finish-event classification test — 497 pass.
- `core`: forced recovery bypasses the estimate gate without touching the summarizer and skips cleanly when there is nothing to remove; custom-compactor recovery results are accepted only when non-empty/smaller/within target (throw, decline, unchanged, empty, and marginal-shrink cases each fall back to basic); `ApiHandler` adapter classifies thrown overflows and failed `done` chunks — 1545 pass.
- `agents`: recovery retry with compacted transcript + status notice, unclassified overflow message still recovers via the runtime backstop, unrelated stream failures are not treated as overflow, fail-fast when nothing to compact (doomed request not re-sent), no-pipeline guidance, retry-once cap — 58 pass.
- `shared`: 296 pass.
