### PR TITLE
Resolve recommended-model display names once in the SDK feed

### DIFF
--- a/apps/cli/src/tui/components/model-selector/cline-model-entries.ts
+++ b/apps/cli/src/tui/components/model-selector/cline-model-entries.ts
@@ -93,14 +93,3 @@ export function freeTierDescriptionFor(
 	);
 	return isClinePassPicker ? CLINE_PASS_FREE_SECTION_DESCRIPTION : undefined;
 }
-
-// OpenRouter marks free variants with "(free)" in names and ":free" in ids to
-// disambiguate them from their paid twins. Inside the sectioned pickers the
-// Free header already says it, so the markers are redundant — but keep them in
-// flat lists (e.g. browse-all), where both variants appear side by side.
-export function stripFreeMarker(displayName: string): string {
-	return displayName
-		.replace(/\s*\(free\)\s*$/i, "")
-		.replace(/:free$/i, "")
-		.trim();
-}

--- a/apps/cli/src/tui/components/model-selector/cline-model-picker.test.ts
+++ b/apps/cli/src/tui/components/model-selector/cline-model-picker.test.ts
@@ -3,7 +3,6 @@ import {
 	buildFeaturedModelEntries,
 	CLINE_PASS_FREE_SECTION_DESCRIPTION,
 	freeTierDescriptionFor,
-	stripFreeMarker,
 } from "./cline-model-entries";
 
 const model = (id: string) => ({ id, name: id, description: "", tags: [] });
@@ -85,14 +84,5 @@ describe("cline model picker entries", () => {
 		expect(
 			freeTierDescriptionFor(buildFeaturedModelEntries("cline", data)),
 		).toBe(undefined);
-	});
-
-	it("strips redundant free markers from display names", () => {
-		expect(stripFreeMarker("Laguna M.1 (free)")).toBe("Laguna M.1");
-		expect(stripFreeMarker("Trinity Large Preview (FREE)")).toBe(
-			"Trinity Large Preview",
-		);
-		expect(stripFreeMarker("laguna-m.1:free")).toBe("laguna-m.1");
-		expect(stripFreeMarker("DeepSeek V4 Flash")).toBe("DeepSeek V4 Flash");
 	});
 });

--- a/apps/cli/src/tui/components/model-selector/cline-model-picker.tsx
+++ b/apps/cli/src/tui/components/model-selector/cline-model-picker.tsx
@@ -12,7 +12,6 @@ import {
 	CLINE_MODEL_PICKER_TIER_LABELS,
 	type ClineModelPickerEntry,
 	freeTierDescriptionFor,
-	stripFreeMarker,
 } from "./cline-model-entries";
 
 export {
@@ -23,31 +22,12 @@ export {
 	type ClineModelPickerItem,
 	type ClineModelPickerTier,
 	freeTierDescriptionFor,
-	stripFreeMarker,
 } from "./cline-model-entries";
 
 function tagColor(tag: string): string {
 	if (tag === "FREE") return palette.success;
 	if (tag === "BEST") return "magenta";
 	return palette.act;
-}
-
-function resolveDisplayName(
-	modelId: string,
-	knownModels?: Record<string, unknown>,
-): string {
-	if (knownModels) {
-		const candidates = [modelId, modelId.split("/").pop()];
-		for (const key of candidates) {
-			if (!key) continue;
-			const hit = knownModels[key] as { name?: string } | undefined;
-			if (hit?.name) return stripFreeMarker(hit.name);
-		}
-	}
-	const fallback = modelId.includes("/")
-		? (modelId.split("/").pop() ?? modelId)
-		: modelId;
-	return stripFreeMarker(fallback);
 }
 
 export function useClineRecommendedModels() {
@@ -75,10 +55,9 @@ export function ClineModelPicker(props: {
 	entries: ClineModelPickerEntry[];
 	selected: number;
 	loading?: boolean;
-	knownModels?: Record<string, unknown>;
 	currentModelId?: string;
 }) {
-	const { entries, selected, loading, knownModels, currentModelId } = props;
+	const { entries, selected, loading, currentModelId } = props;
 
 	if (loading) {
 		return (
@@ -122,7 +101,8 @@ export function ClineModelPicker(props: {
 			}
 
 			const tags = entry.model.tags;
-			const name = resolveDisplayName(entry.model.id, knownModels);
+			// Names arrive display-ready from fetchClineRecommendedModels
+			const name = entry.model.name || entry.model.id;
 			const isCurrent = currentModelId === entry.model.id;
 			rows.push(
 				<box

--- a/apps/cli/src/tui/components/model-selector/cline-model-selector.tsx
+++ b/apps/cli/src/tui/components/model-selector/cline-model-selector.tsx
@@ -7,7 +7,6 @@ import {
 	CLINE_MODEL_PICKER_TIER_LABELS,
 	type ClineModelPickerEntry,
 	freeTierDescriptionFor,
-	stripFreeMarker,
 } from "./cline-model-picker";
 import { CHANGE_PROVIDER_ACTION } from "./model-selector";
 import { ProviderRow } from "./provider-row";
@@ -25,29 +24,10 @@ function tagColor(tag: string): string {
 	return palette.act;
 }
 
-function resolveDisplayName(
-	modelId: string,
-	knownModels?: Record<string, unknown>,
-): string {
-	if (knownModels) {
-		const candidates = [modelId, modelId.split("/").pop()];
-		for (const key of candidates) {
-			if (!key) continue;
-			const hit = knownModels[key] as { name?: string } | undefined;
-			if (hit?.name) return stripFreeMarker(hit.name);
-		}
-	}
-	const fallback = modelId.includes("/")
-		? (modelId.split("/").pop() ?? modelId)
-		: modelId;
-	return stripFreeMarker(fallback);
-}
-
 export function ClineModelSelectorContent(
 	props: ChoiceContext<string> & {
 		currentModel: string;
 		currentProviderName: string;
-		knownModels?: Record<string, unknown>;
 		entries: ClineModelPickerEntry[];
 	},
 ) {
@@ -57,7 +37,6 @@ export function ClineModelSelectorContent(
 		dialogId,
 		currentModel,
 		currentProviderName,
-		knownModels,
 		entries,
 	} = props;
 	const [selected, setSelected] = useState(0);
@@ -95,7 +74,8 @@ export function ClineModelSelectorContent(
 				rows.push({
 					key: entry.model.id,
 					kind: "model",
-					label: resolveDisplayName(entry.model.id, knownModels),
+					// Names arrive display-ready from fetchClineRecommendedModels
+					label: entry.model.name || entry.model.id,
 					tags: entry.model.tags,
 					isCurrent: currentModel === entry.model.id,
 					entryIndex: i,
@@ -112,7 +92,7 @@ export function ClineModelSelectorContent(
 			}
 		}
 		return rows;
-	}, [entries, knownModels, currentModel]);
+	}, [entries, currentModel]);
 
 	useDialogKeyboard((key) => {
 		if (key.name === "escape") {
@@ -238,7 +218,6 @@ export function ClineModelSelectorDialogContent(
 	props: ChoiceContext<string> & {
 		currentModel: string;
 		currentProviderName: string;
-		knownModels?: Record<string, unknown>;
 		loadEntries: () => Promise<ClineModelPickerEntry[]>;
 	},
 ) {

--- a/apps/cli/src/tui/hooks/use-model-selector.tsx
+++ b/apps/cli/src/tui/hooks/use-model-selector.tsx
@@ -444,7 +444,6 @@ export function useModelSelector(opts: {
 								{...ctx}
 								currentModel={config.modelId}
 								currentProviderName={providerDisplayName}
-								knownModels={config.knownModels as Record<string, unknown>}
 								loadEntries={async () =>
 									buildFeaturedModelEntries(
 										featuredProviderId,

--- a/apps/cli/src/tui/views/onboarding/controller.ts
+++ b/apps/cli/src/tui/views/onboarding/controller.ts
@@ -219,13 +219,11 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 	const [clineModelReasoningIds, setClineModelReasoningIds] = useState<
 		Set<string>
 	>(new Set());
-	const [clineKnownModels, setClineKnownModels] = useState<
-		Record<string, unknown> | undefined
-	>(undefined);
 
 	useEffect(() => {
-		// The featured picker serves both cline and cline-pass, so pool reasoning
-		// support and display names from both catalogs
+		// The featured picker serves both cline and cline-pass, so pool
+		// reasoning support from both catalogs. Display names need no catalog
+		// here: fetchClineRecommendedModels resolves them.
 		void Promise.allSettled(
 			["cline", "cline-pass"].map((providerId) =>
 				getLocalProviderModels(providerId),
@@ -239,21 +237,6 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 				}
 			}
 			setClineModelReasoningIds(ids);
-		});
-		void Promise.allSettled(
-			["cline", "cline-pass"].map((providerId) =>
-				resolveProviderConfig(providerId),
-			),
-		).then((results) => {
-			const merged: Record<string, unknown> = {};
-			for (const result of results) {
-				if (result.status === "fulfilled" && result.value?.knownModels) {
-					Object.assign(merged, result.value.knownModels);
-				}
-			}
-			if (Object.keys(merged).length > 0) {
-				setClineKnownModels(merged);
-			}
 		});
 	}, []);
 
@@ -838,7 +821,6 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 		codexCliChecking,
 		codexCliStatus,
 		clineEntries,
-		clineKnownModels,
 		clineModelSelected,
 		clinePassCurrentPlanName,
 		clinePassPlanFeatures,

--- a/apps/cli/src/tui/views/onboarding/screens.tsx
+++ b/apps/cli/src/tui/views/onboarding/screens.tsx
@@ -447,7 +447,6 @@ export function OnboardingProviderPickerScreen(props: {
 
 export function OnboardingClineModelScreen(props: {
 	clineEntries: ClineModelPickerEntry[];
-	clineKnownModels: Record<string, unknown> | undefined;
 	clineModelSelected: number;
 	compact: boolean;
 	contentWidth: number;
@@ -472,7 +471,6 @@ export function OnboardingClineModelScreen(props: {
 				entries={props.clineEntries}
 				selected={props.clineModelSelected}
 				loading={props.recommendedLoading}
-				knownModels={props.clineKnownModels}
 			/>
 
 			<text fg="gray" paddingX={1}>

--- a/apps/cli/src/tui/views/onboarding/view.tsx
+++ b/apps/cli/src/tui/views/onboarding/view.tsx
@@ -112,7 +112,6 @@ export function OnboardingView(props: OnboardingViewProps) {
 		return (
 			<OnboardingClineModelScreen
 				clineEntries={state.clineEntries}
-				clineKnownModels={state.clineKnownModels}
 				clineModelSelected={state.clineModelSelected}
 				compact={compact}
 				contentWidth={contentWidth}

--- a/apps/vscode/src/shared/api.ts
+++ b/apps/vscode/src/shared/api.ts
@@ -175,22 +175,6 @@ export function resolveClinePassModelInfo(modelId: string, modelInfoByName?: Rec
 	return modelInfoByName?.[getModelSlug(modelId)] ?? clinePassModelInfoSaneDefaults
 }
 
-/**
- * Resolves a human-readable model name for featured model cards. The Cline
- * recommended-models endpoint only sends slug-like names (e.g.
- * "deepseek-v4-flash"), so prefer the display name from the provider model
- * catalog, then any endpoint-provided fallback, then the raw id. Featured
- * sections render their own FREE chip, so OpenRouter's "(free)" / ":free"
- * markers are stripped as redundant.
- */
-export function resolveDisplayModelName(modelId: string, models?: Record<string, ModelInfo>, fallbackName?: string): string {
-	const displayName = models?.[modelId]?.name?.trim() || fallbackName?.trim() || modelId
-	return displayName
-		.replace(/\s*\(free\)\s*$/i, "")
-		.replace(/:free$/i, "")
-		.trim()
-}
-
 export const openAiModelInfoSafeDefaults: OpenAiCompatibleModelInfo = {
 	maxTokens: -1,
 	contextWindow: 128_000,

--- a/apps/vscode/webview-ui/src/components/onboarding/useOnboardingModels.ts
+++ b/apps/vscode/webview-ui/src/components/onboarding/useOnboardingModels.ts
@@ -1,4 +1,4 @@
-import { buildModelInfoNameMap, type ModelInfo, resolveClinePassModelInfo, resolveDisplayModelName } from "@shared/api"
+import { buildModelInfoNameMap, type ModelInfo, resolveClinePassModelInfo } from "@shared/api"
 import { CLINE_ONBOARDING_MODELS } from "@shared/cline/onboarding"
 import { EmptyRequest } from "@shared/proto/cline/common"
 import type { ClineRecommendedModel } from "@shared/proto/cline/models"
@@ -28,8 +28,8 @@ function toOnboardingModel(
 
 	return {
 		id: rec.id,
-		// The endpoint sends slug-like names, so prefer the catalog display name
-		name: resolveDisplayModelName(rec.id, modelCatalog, rec.name),
+		// Names arrive display-ready from the recommended-models RPC
+		name: rec.name || rec.id,
 		group,
 		badge,
 		score: 0,

--- a/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.test.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.test.tsx
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
 		recommended: [
 			{
 				id: "cline-next",
+				name: "Cline Next",
 				description: "Next Cline model",
 				tags: ["recommended"],
 			},
@@ -99,8 +100,8 @@ describe("ClineModelPicker", () => {
 	it("commits Cline model selections through provider config so providers.json is updated", async () => {
 		render(<ClineModelPicker currentMode="act" />)
 
-		// Featured cards render the catalog display name, but selection still
-		// commits the underlying model id.
+		// Featured cards render the display name from the RPC, but selection
+		// still commits the underlying model id.
 		fireEvent.click(await screen.findByText("Cline Next"))
 
 		await waitFor(() => expect(mocks.commitSelection).toHaveBeenCalledTimes(1))
@@ -110,28 +111,15 @@ describe("ClineModelPicker", () => {
 		})
 	})
 
-	it("resolves featured model display names from the provider catalog", async () => {
+	it("renders RPC-provided display names on featured cards, falling back to ids", async () => {
+		// Names arrive display-ready: the extension host resolves them against
+		// the model catalog in fetchClineRecommendedModels.
 		mocks.makeUnaryRequest.mockResolvedValueOnce({
-			recommended: [{ id: "anthropic/claude-opus-5", description: "Frontier model", tags: ["NEW"] }],
+			recommended: [{ id: "anthropic/claude-opus-5", name: "Claude Opus 5", description: "Frontier model", tags: ["NEW"] }],
 			free: [
-				{ id: "deepseek/deepseek-v4-flash", description: "Fast and efficient", tags: [] },
-				{ id: "poolside/laguna-s-2.1:free", description: "Latest coding agent model", tags: [] },
-				{ id: "unknown/named-model", name: "named-model", description: "Not in the catalog", tags: [] },
-				{ id: "unknown/mystery-model", description: "No catalog or endpoint name", tags: [] },
+				{ id: "deepseek/deepseek-v4-flash", name: "DeepSeek V4 Flash", description: "Fast and efficient", tags: [] },
+				{ id: "unknown/mystery-model", name: "", description: "No display name", tags: [] },
 			],
-		})
-		vi.mocked(useProviderModels).mockReturnValue({
-			models: {
-				"anthropic/claude-opus-5": { name: "Claude Opus 5", supportsPromptCache: true },
-				"deepseek/deepseek-v4-flash": { name: "DeepSeek V4 Flash", supportsPromptCache: true },
-				"poolside/laguna-s-2.1:free": { name: "Laguna S 2.1 (free)", supportsPromptCache: false },
-			},
-			defaultModelId: "anthropic/claude-opus-5",
-			isLoading: false,
-			isStale: false,
-			error: undefined,
-			refresh: vi.fn(),
-			fingerprint: "fingerprint",
 		})
 
 		render(<ClineModelPicker currentMode="act" />)
@@ -141,11 +129,7 @@ describe("ClineModelPicker", () => {
 		fireEvent.click(screen.getByText("Free"))
 
 		expect(await screen.findByText("DeepSeek V4 Flash")).toBeInTheDocument()
-		// The FREE chip already says it, so the "(free)" marker is stripped
-		expect(screen.getByText("Laguna S 2.1")).toBeInTheDocument()
-		// Models missing from the catalog fall back to the endpoint-provided name
-		expect(screen.getByText("named-model")).toBeInTheDocument()
-		// ...and to the raw id only when there is no endpoint name either
+		// A missing display name degrades to the raw id
 		expect(screen.getByText("unknown/mystery-model")).toBeInTheDocument()
 	})
 

--- a/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/ClineModelPicker.tsx
@@ -1,4 +1,4 @@
-import { openAiModelInfoSafeDefaults, resolveDisplayModelName } from "@shared/api"
+import { openAiModelInfoSafeDefaults } from "@shared/api"
 import { CLINE_RECOMMENDED_MODELS_FALLBACK } from "@shared/cline/recommended-models"
 import { EmptyRequest, StringRequest } from "@shared/proto/cline/common"
 import { type ClineRecommendedModel, ClineRecommendedModelsResponse } from "@shared/proto/cline/models"
@@ -444,7 +444,7 @@ const ClineModelPicker: React.FC<ClineModelPickerProps> = ({ isPopup, currentMod
 						recommendedModels.map((model) => (
 							<FeaturedModelCard
 								description={model.description}
-								displayName={resolveDisplayModelName(model.id, effectiveClineModels, model.name)}
+								displayName={model.name || model.id}
 								isSelected={selectedModelId === model.id}
 								key={model.id}
 								label={model.label}
@@ -458,7 +458,7 @@ const ClineModelPicker: React.FC<ClineModelPickerProps> = ({ isPopup, currentMod
 						freeModels.map((model) => (
 							<FeaturedModelCard
 								description={model.description}
-								displayName={resolveDisplayModelName(model.id, effectiveClineModels, model.name)}
+								displayName={model.name || model.id}
 								isSelected={selectedModelId === model.id}
 								key={model.id}
 								label={model.label}

--- a/apps/vscode/webview-ui/src/components/settings/providers/ClinePassProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/ClinePassProvider.tsx
@@ -1,5 +1,5 @@
 import type { ModelInfo } from "@shared/api"
-import { openAiModelInfoSafeDefaults, resolveDisplayModelName } from "@shared/api"
+import { openAiModelInfoSafeDefaults } from "@shared/api"
 import { CLINE_RECOMMENDED_MODELS_FALLBACK } from "@shared/cline/recommended-models"
 import { EmptyRequest } from "@shared/proto/cline/common"
 import { type ClineRecommendedModel, ClineRecommendedModelsResponse } from "@shared/proto/cline/models"
@@ -46,35 +46,30 @@ function clinePassFallbackModelInfo(modelId: string): ModelInfo {
 	}
 }
 
-function toSubscribedEntry(
-	model: Pick<ClineRecommendedModel, "id" | "description">,
-	models?: Record<string, ModelInfo>,
-): FeaturedTabEntry | null {
+// Names arrive display-ready from the recommended-models RPC (the extension
+// host resolves them against the model catalog in fetchClineRecommendedModels)
+
+function toSubscribedEntry(model: Pick<ClineRecommendedModel, "id" | "name" | "description">): FeaturedTabEntry | null {
 	if (!model.id) {
 		return null
 	}
-	// The whole list is included with the plan, so no per-card label chip.
-	// The endpoint sends slug-like names, so resolve the display name from the
-	// provider catalog, falling back to the id without its cline-pass/ prefix.
+	// The whole list is included with the plan, so no per-card label chip
 	return {
 		id: model.id,
-		displayName: resolveDisplayModelName(model.id, models, model.id.replace(CLINE_PASS_MODEL_ID_PREFIX, "")),
+		displayName: model.name || model.id.replace(CLINE_PASS_MODEL_ID_PREFIX, ""),
 		description: model.description || "",
 		label: "",
 	}
 }
 
-function toFreeEntry(
-	model: Pick<ClineRecommendedModel, "id" | "name" | "description" | "tags">,
-	models?: Record<string, ModelInfo>,
-): FeaturedTabEntry | null {
+function toFreeEntry(model: Pick<ClineRecommendedModel, "id" | "name" | "description" | "tags">): FeaturedTabEntry | null {
 	if (!model.id) {
 		return null
 	}
 	const firstTag = model.tags?.[0]
 	return {
 		id: model.id,
-		displayName: resolveDisplayModelName(model.id, models, model.name),
+		displayName: model.name || model.id,
 		description: model.description || "",
 		label: typeof firstTag === "string" && firstTag.length > 0 ? firstTag.toUpperCase() : "FREE",
 	}
@@ -131,24 +126,21 @@ export const ClinePassProvider = ({ showModelOptions, isPopup, currentMode }: Cl
 	}, [])
 
 	// Fall back to the provider catalog (subscribed) and the bundled free list
-	// until the endpoint responds. Cards are built here (not at fetch time) so
-	// display names re-resolve once the provider model catalog loads.
+	// until the endpoint responds
 	const subscribedCards = useMemo(() => {
 		if (subscribedModels.length > 0) {
-			return subscribedModels
-				.map((model) => toSubscribedEntry(model, models))
-				.filter((entry): entry is FeaturedTabEntry => entry !== null)
+			return subscribedModels.map(toSubscribedEntry).filter((entry): entry is FeaturedTabEntry => entry !== null)
 		}
 		return Object.keys(models ?? {})
 			.filter((id) => id.startsWith(CLINE_PASS_MODEL_ID_PREFIX))
-			.map((id) => toSubscribedEntry({ id, description: models[id]?.description ?? "" }, models))
+			.map((id) => toSubscribedEntry({ id, name: models[id]?.name ?? "", description: models[id]?.description ?? "" }))
 			.filter((entry): entry is FeaturedTabEntry => entry !== null)
 	}, [subscribedModels, models])
 
 	const freeCards = useMemo(() => {
 		const source = freeModels.length > 0 ? freeModels : CLINE_RECOMMENDED_MODELS_FALLBACK.free
-		return source.map((model) => toFreeEntry(model, models)).filter((entry): entry is FeaturedTabEntry => entry !== null)
-	}, [freeModels, models])
+		return source.map(toFreeEntry).filter((entry): entry is FeaturedTabEntry => entry !== null)
+	}, [freeModels])
 
 	// Land on the tab containing the configured model
 	useEffect(() => {

--- a/sdk/packages/core/src/services/llms/cline-recommended-models.test.ts
+++ b/sdk/packages/core/src/services/llms/cline-recommended-models.test.ts
@@ -31,6 +31,8 @@ const ENDPOINT_PAYLOAD = {
 		},
 		{ id: "vendor/named-model", name: "named-model", description: "" },
 		{ id: "vendor/unnamed-model", description: "" },
+		// Vercel-style id; the catalog keys this model under "z-ai/glm-5.2"
+		{ id: "zai/glm-5.2", name: "glm-5.2", description: "" },
 	],
 	free: [
 		{
@@ -54,6 +56,7 @@ const ENDPOINT_PAYLOAD = {
 const CATALOG = {
 	openrouter: {
 		"anthropic/claude-opus-5": model("anthropic/claude-opus-5", "Claude Opus 5"),
+		"z-ai/glm-5.2": model("z-ai/glm-5.2", "GLM-5.2"),
 	},
 	cline: {
 		"deepseek/deepseek-v4-flash": model(
@@ -88,9 +91,10 @@ describe("fetchClineRecommendedModels", () => {
 		});
 
 		expect(namesOf(data)).toEqual({
-			// Catalog name first; endpoint name when the catalog misses; the id
-			// slug when the endpoint name is just the id.
-			recommended: ["Claude Opus 5", "named-model", "unnamed-model"],
+			// Catalog name first (including via id aliases like zai/ -> z-ai/);
+			// endpoint name when the catalog misses; the id slug when the
+			// endpoint name is just the id.
+			recommended: ["Claude Opus 5", "named-model", "unnamed-model", "GLM-5.2"],
 			// Free markers are redundant next to the pickers' FREE chips.
 			free: ["DeepSeek V4 Flash", "GLM-5.2", "Laguna S 2.1"],
 			clinePass: ["GLM-5.2", "mystery"],
@@ -113,7 +117,7 @@ describe("fetchClineRecommendedModels", () => {
 		});
 
 		expect(namesOf(data)).toEqual({
-			recommended: ["claude-opus-5", "named-model", "unnamed-model"],
+			recommended: ["claude-opus-5", "named-model", "unnamed-model", "glm-5.2"],
 			free: ["deepseek-v4-flash", "glm-5.2", "laguna-s-2.1"],
 			clinePass: ["glm-5.2", "mystery"],
 		});

--- a/sdk/packages/core/src/services/llms/cline-recommended-models.test.ts
+++ b/sdk/packages/core/src/services/llms/cline-recommended-models.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import {
+	type ClineRecommendedModelsData,
+	FALLBACK_CLINE_RECOMMENDED_MODELS,
+	fetchClineRecommendedModels,
+} from "./cline-recommended-models";
+import type { ModelInfo } from "./provider-settings";
+
+const BASE_URL = "https://api.example.test";
+
+function jsonResponse(payload: unknown): typeof fetch {
+	return async () =>
+		new Response(JSON.stringify(payload), {
+			status: 200,
+			headers: { "Content-Type": "application/json" },
+		});
+}
+
+function model(id: string, name: string): ModelInfo {
+	return { id, name };
+}
+
+// The endpoint only sends slug-like names, mirroring production behavior.
+const ENDPOINT_PAYLOAD = {
+	recommended: [
+		{
+			id: "anthropic/claude-opus-5",
+			name: "claude-opus-5",
+			description: "",
+			tags: ["NEW"],
+		},
+		{ id: "vendor/named-model", name: "named-model", description: "" },
+		{ id: "vendor/unnamed-model", description: "" },
+	],
+	free: [
+		{
+			id: "deepseek/deepseek-v4-flash",
+			name: "deepseek-v4-flash",
+			description: "",
+		},
+		{ id: "cline-free/glm-5.2", name: "cline-free/glm-5.2", description: "" },
+		{
+			id: "poolside/laguna-s-2.1:free",
+			name: "laguna-s-2.1:free",
+			description: "",
+		},
+	],
+	clinePass: [
+		{ id: "cline-pass/glm-5.2", name: "cline-pass/glm-5.2", description: "" },
+		{ id: "cline-pass/mystery", name: "cline-pass/mystery", description: "" },
+	],
+};
+
+const CATALOG = {
+	openrouter: {
+		"anthropic/claude-opus-5": model("anthropic/claude-opus-5", "Claude Opus 5"),
+	},
+	cline: {
+		"deepseek/deepseek-v4-flash": model(
+			"deepseek/deepseek-v4-flash",
+			"DeepSeek V4 Flash",
+		),
+		"cline-free/glm-5.2": model("cline-free/glm-5.2", "GLM-5.2 (free)"),
+		"poolside/laguna-s-2.1:free": model(
+			"poolside/laguna-s-2.1:free",
+			"Laguna S 2.1 (free)",
+		),
+	},
+	"cline-pass": {
+		"cline-pass/glm-5.2": model("cline-pass/glm-5.2", "GLM-5.2"),
+	},
+};
+
+function namesOf(data: ClineRecommendedModelsData) {
+	return {
+		recommended: data.recommended.map((m) => m.name),
+		free: data.free.map((m) => m.name),
+		clinePass: data.clinePass.map((m) => m.name),
+	};
+}
+
+describe("fetchClineRecommendedModels", () => {
+	it("resolves display names from the models catalog", async () => {
+		const data = await fetchClineRecommendedModels({
+			baseUrl: BASE_URL,
+			fetchImpl: jsonResponse(ENDPOINT_PAYLOAD),
+			catalogLoader: async () => CATALOG,
+		});
+
+		expect(namesOf(data)).toEqual({
+			// Catalog name first; endpoint name when the catalog misses; the id
+			// slug when the endpoint name is just the id.
+			recommended: ["Claude Opus 5", "named-model", "unnamed-model"],
+			// Free markers are redundant next to the pickers' FREE chips.
+			free: ["DeepSeek V4 Flash", "GLM-5.2", "Laguna S 2.1"],
+			clinePass: ["GLM-5.2", "mystery"],
+		});
+		// Ids are preserved untouched.
+		expect(data.free.map((m) => m.id)).toEqual([
+			"deepseek/deepseek-v4-flash",
+			"cline-free/glm-5.2",
+			"poolside/laguna-s-2.1:free",
+		]);
+	});
+
+	it("degrades to endpoint names and id slugs when the catalog is unavailable", async () => {
+		const data = await fetchClineRecommendedModels({
+			baseUrl: BASE_URL,
+			fetchImpl: jsonResponse(ENDPOINT_PAYLOAD),
+			catalogLoader: async () => {
+				throw new Error("models.dev unreachable");
+			},
+		});
+
+		expect(namesOf(data)).toEqual({
+			recommended: ["claude-opus-5", "named-model", "unnamed-model"],
+			free: ["deepseek-v4-flash", "glm-5.2", "laguna-s-2.1"],
+			clinePass: ["glm-5.2", "mystery"],
+		});
+	});
+
+	it("does not wait for a hung catalog loader beyond the timeout", async () => {
+		const data = await fetchClineRecommendedModels({
+			baseUrl: BASE_URL,
+			fetchImpl: jsonResponse(ENDPOINT_PAYLOAD),
+			timeoutMs: 25,
+			catalogLoader: () => new Promise(() => {}),
+		});
+
+		expect(data.recommended[0]?.name).toBe("claude-opus-5");
+	});
+
+	it("returns the bundled fallback untouched when the endpoint fails", async () => {
+		const data = await fetchClineRecommendedModels({
+			baseUrl: BASE_URL,
+			fetchImpl: async () => new Response("nope", { status: 500 }),
+			catalogLoader: async () => CATALOG,
+		});
+
+		// Exact equality lets callers detect a transient failure (the VS Code
+		// controller compares against the fallback to skip caching it).
+		expect(data).toEqual(FALLBACK_CLINE_RECOMMENDED_MODELS);
+	});
+});

--- a/sdk/packages/core/src/services/llms/cline-recommended-models.test.ts
+++ b/sdk/packages/core/src/services/llms/cline-recommended-models.test.ts
@@ -55,7 +55,10 @@ const ENDPOINT_PAYLOAD = {
 
 const CATALOG = {
 	openrouter: {
-		"anthropic/claude-opus-5": model("anthropic/claude-opus-5", "Claude Opus 5"),
+		"anthropic/claude-opus-5": model(
+			"anthropic/claude-opus-5",
+			"Claude Opus 5",
+		),
 		"z-ai/glm-5.2": model("z-ai/glm-5.2", "GLM-5.2"),
 	},
 	cline: {
@@ -132,6 +135,57 @@ describe("fetchClineRecommendedModels", () => {
 		});
 
 		expect(data.recommended[0]?.name).toBe("claude-opus-5");
+	});
+
+	it("shares one timeout budget between the feed request and the catalog lookup", async () => {
+		// A feed response that consumes most of the window must not grant the
+		// hung catalog loader a fresh full window on top (which would roughly
+		// double the worst-case loading time).
+		const feedDelayMs = 400;
+		const timeoutMs = 500;
+		const slowFeed: typeof fetch = async () => {
+			await new Promise((resolve) => setTimeout(resolve, feedDelayMs));
+			return new Response(JSON.stringify(ENDPOINT_PAYLOAD), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		};
+
+		const startedAt = Date.now();
+		const data = await fetchClineRecommendedModels({
+			baseUrl: BASE_URL,
+			fetchImpl: slowFeed,
+			timeoutMs,
+			catalogLoader: () => new Promise(() => {}),
+		});
+		const elapsedMs = Date.now() - startedAt;
+
+		// Stacked windows would take ~feedDelayMs + timeoutMs (~900ms).
+		expect(elapsedMs).toBeLessThan(feedDelayMs + timeoutMs - 100);
+		expect(data.recommended[0]?.name).toBe("claude-opus-5");
+	});
+
+	it("still applies an instantly-resolving catalog when the budget is exhausted", async () => {
+		// Simulates a cached catalog: getLiveModelsCatalog resolves cached data
+		// on a microtask, which beats the zero-delay degradation timer even
+		// when the feed request consumed the whole window.
+		const timeoutMs = 50;
+		const slowFeed: typeof fetch = async () => {
+			await new Promise((resolve) => setTimeout(resolve, timeoutMs));
+			return new Response(JSON.stringify(ENDPOINT_PAYLOAD), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		};
+
+		const data = await fetchClineRecommendedModels({
+			baseUrl: BASE_URL,
+			fetchImpl: slowFeed,
+			timeoutMs,
+			catalogLoader: async () => CATALOG,
+		});
+
+		expect(data.recommended[0]?.name).toBe("Claude Opus 5");
 	});
 
 	it("returns the bundled fallback untouched when the endpoint fails", async () => {

--- a/sdk/packages/core/src/services/llms/cline-recommended-models.ts
+++ b/sdk/packages/core/src/services/llms/cline-recommended-models.ts
@@ -185,9 +185,13 @@ function catalogLookupIds(modelId: string): string[] {
 	const ids = [modelId];
 	for (const rule of VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES) {
 		if (modelId.startsWith(rule.canonicalPrefix)) {
-			ids.push(`${rule.aliasPrefix}${modelId.slice(rule.canonicalPrefix.length)}`);
+			ids.push(
+				`${rule.aliasPrefix}${modelId.slice(rule.canonicalPrefix.length)}`,
+			);
 		} else if (modelId.startsWith(rule.aliasPrefix)) {
-			ids.push(`${rule.canonicalPrefix}${modelId.slice(rule.aliasPrefix.length)}`);
+			ids.push(
+				`${rule.canonicalPrefix}${modelId.slice(rule.aliasPrefix.length)}`,
+			);
 		}
 	}
 	return ids;
@@ -267,13 +271,19 @@ async function resolveDisplayNames(
 export async function fetchClineRecommendedModels(
 	options: FetchClineRecommendedModelsOptions = {},
 ): Promise<ClineRecommendedModelsData> {
+	const timeoutMs = options.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+	// The feed request and the catalog lookup share one deadline so a slow
+	// endpoint plus a cold catalog cannot stack two full timeout windows. An
+	// already-cached catalog still applies with an exhausted budget: its
+	// promise resolves on a microtask, ahead of the zero-delay timer.
+	const deadline = Date.now() + timeoutMs;
 	try {
 		const base = getConfiguredApiBaseUrl(options);
 		const fetchImpl = options.fetchImpl ?? fetch;
 		const resp = await fetchWithTimeout(
 			fetchImpl,
 			`${base}/api/v1/ai/cline/recommended-models`,
-			options.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+			timeoutMs,
 		);
 		if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
 		const json: unknown = await resp.json();
@@ -282,7 +292,7 @@ export async function fetchClineRecommendedModels(
 			return await resolveDisplayNames(
 				data,
 				options.catalogLoader ?? getLiveModelsCatalog,
-				options.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+				Math.max(0, deadline - Date.now()),
 			);
 		}
 	} catch {

--- a/sdk/packages/core/src/services/llms/cline-recommended-models.ts
+++ b/sdk/packages/core/src/services/llms/cline-recommended-models.ts
@@ -1,3 +1,4 @@
+import { VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES } from "@cline/llms";
 import { getClineEnvironmentConfig } from "@cline/shared";
 import { ProviderSettingsManager } from "../storage/provider-settings-manager";
 import { getLiveModelsCatalog } from "./provider-defaults";
@@ -177,14 +178,31 @@ function stripFreeMarkers(name: string): string {
 		.trim();
 }
 
+// The recommendation feed can use Vercel-style ids (e.g. "zai/glm-5.2") while
+// the catalog keys the same model under its OpenRouter alias ("z-ai/glm-5.2"),
+// so look up both spellings.
+function catalogLookupIds(modelId: string): string[] {
+	const ids = [modelId];
+	for (const rule of VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES) {
+		if (modelId.startsWith(rule.canonicalPrefix)) {
+			ids.push(`${rule.aliasPrefix}${modelId.slice(rule.canonicalPrefix.length)}`);
+		} else if (modelId.startsWith(rule.aliasPrefix)) {
+			ids.push(`${rule.canonicalPrefix}${modelId.slice(rule.aliasPrefix.length)}`);
+		}
+	}
+	return ids;
+}
+
 function resolveEntryDisplayName(
 	entry: ClineRecommendedModel,
 	catalogs: Array<Record<string, ModelInfo> | undefined>,
 ): string {
 	for (const catalog of catalogs) {
-		const catalogName = catalog?.[entry.id]?.name?.trim();
-		if (catalogName) {
-			return stripFreeMarkers(catalogName);
+		for (const lookupId of catalogLookupIds(entry.id)) {
+			const catalogName = catalog?.[lookupId]?.name?.trim();
+			if (catalogName) {
+				return stripFreeMarkers(catalogName);
+			}
 		}
 	}
 	// The endpoint's own names are slug-like; still better than a full id.

--- a/sdk/packages/core/src/services/llms/cline-recommended-models.ts
+++ b/sdk/packages/core/src/services/llms/cline-recommended-models.ts
@@ -1,8 +1,11 @@
 import { getClineEnvironmentConfig } from "@cline/shared";
 import { ProviderSettingsManager } from "../storage/provider-settings-manager";
+import { getLiveModelsCatalog } from "./provider-defaults";
+import type { ModelInfo } from "./provider-settings";
 
 export interface ClineRecommendedModel {
 	id: string;
+	/** Display-ready model name, resolved against the model catalog. */
 	name: string;
 	description: string;
 	tags: string[];
@@ -14,6 +17,8 @@ export interface ClineRecommendedModelsData {
 	clinePass: ClineRecommendedModel[];
 }
 
+type ModelsCatalog = Record<string, Record<string, ModelInfo>>;
+
 export interface FetchClineRecommendedModelsOptions {
 	baseUrl?: string;
 	fetchImpl?: typeof fetch;
@@ -22,6 +27,11 @@ export interface FetchClineRecommendedModelsOptions {
 		"getProviderSettings"
 	>;
 	timeoutMs?: number;
+	/**
+	 * Loader for the live models catalog used to resolve display names.
+	 * Defaults to the shared live-catalog cache; injectable for tests.
+	 */
+	catalogLoader?: () => Promise<ModelsCatalog>;
 }
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 5_000;
@@ -158,6 +168,84 @@ async function fetchWithTimeout(
 	}
 }
 
+// The featured pickers render these names next to their own FREE chips and
+// section headers, so OpenRouter's free markers are redundant there.
+function stripFreeMarkers(name: string): string {
+	return name
+		.replace(/\s*\(free\)\s*$/i, "")
+		.replace(/:free$/i, "")
+		.trim();
+}
+
+function resolveEntryDisplayName(
+	entry: ClineRecommendedModel,
+	catalogs: Array<Record<string, ModelInfo> | undefined>,
+): string {
+	for (const catalog of catalogs) {
+		const catalogName = catalog?.[entry.id]?.name?.trim();
+		if (catalogName) {
+			return stripFreeMarkers(catalogName);
+		}
+	}
+	// The endpoint's own names are slug-like; still better than a full id.
+	const endpointName = entry.name?.trim();
+	if (endpointName && endpointName !== entry.id) {
+		return stripFreeMarkers(endpointName);
+	}
+	const slug = entry.id.split("/").at(-1) ?? entry.id;
+	return stripFreeMarkers(slug);
+}
+
+async function loadCatalogWithTimeout(
+	catalogLoader: () => Promise<ModelsCatalog>,
+	timeoutMs: number,
+): Promise<ModelsCatalog | undefined> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		// Race instead of abort: the shared live-catalog loader caches its
+		// in-flight promise, so a slow fetch still completes and warms the
+		// cache for the next call.
+		return await Promise.race([
+			catalogLoader(),
+			new Promise<undefined>((resolve) => {
+				timer = setTimeout(() => resolve(undefined), timeoutMs);
+			}),
+		]);
+	} catch {
+		return undefined;
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+/**
+ * Resolves display-ready names for every entry so consumers can render
+ * `entry.name` directly instead of re-joining ids against the model catalog
+ * in each picker. Preference order: catalog display name, endpoint-provided
+ * name, id slug.
+ */
+async function resolveDisplayNames(
+	data: ClineRecommendedModelsData,
+	catalogLoader: () => Promise<ModelsCatalog>,
+	timeoutMs: number,
+): Promise<ClineRecommendedModelsData> {
+	const catalog = await loadCatalogWithTimeout(catalogLoader, timeoutMs);
+	const withNames = (
+		models: ClineRecommendedModel[],
+		catalogs: Array<Record<string, ModelInfo> | undefined>,
+	) =>
+		models.map((model) => ({
+			...model,
+			name: resolveEntryDisplayName(model, catalogs),
+		}));
+
+	return {
+		recommended: withNames(data.recommended, [catalog?.openrouter]),
+		free: withNames(data.free, [catalog?.cline, catalog?.openrouter]),
+		clinePass: withNames(data.clinePass, [catalog?.["cline-pass"]]),
+	};
+}
+
 export async function fetchClineRecommendedModels(
 	options: FetchClineRecommendedModelsOptions = {},
 ): Promise<ClineRecommendedModelsData> {
@@ -172,10 +260,20 @@ export async function fetchClineRecommendedModels(
 		if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
 		const json: unknown = await resp.json();
 		const data = normalizeResponse(json);
-		if (data) return data;
+		if (data) {
+			return await resolveDisplayNames(
+				data,
+				options.catalogLoader ?? getLiveModelsCatalog,
+				options.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+			);
+		}
 	} catch {
 		// Fall back to the bundled list when the remote source is unavailable.
 	}
 
+	// The bundled fallback already carries display names; it is intentionally
+	// returned as-is so callers can detect it by equality with
+	// FALLBACK_CLINE_RECOMMENDED_MODELS (e.g. to avoid caching a transient
+	// failure).
 	return cloneRecommendedModels(FALLBACK_CLINE_RECOMMENDED_MODELS);
 }


### PR DESCRIPTION
### Related Issue

Follow-up to #12801, addressing review feedback: display-name resolution was happening "in too many places" — the id→name join should live in the data the pickers consume, not be recomputed in every component.

### Description

After #12801 there were seven render-site lookups joining recommended-model ids against the model catalog: two duplicated `resolveDisplayName` helpers in the CLI pickers and five `resolveDisplayModelName` calls in the webview (`ClineModelPicker` ×2, `ClinePassProvider` ×2, `useOnboardingModels`).

This PR moves that join into the one place both apps already share:

- `@cline/core`: `fetchClineRecommendedModels` now returns display-ready `name`s. Each entry resolves as catalog display name → endpoint-provided name → id slug, with redundant `(free)` / `:free` markers stripped (every featured surface renders its own FREE chip / section header). Details:
  - The catalog comes from the shared live-catalog cache (`getLiveModelsCatalog`), raced against the request timeout so a cold or hung models.dev fetch can't stall the picker — it degrades to endpoint names and still warms the cache for next time.
  - Lookups go through `VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES`, so Vercel-style feed ids (`zai/glm-5.2`) match the catalog's OpenRouter key (`z-ai/glm-5.2`).
  - The bundled fallback list is returned untouched: it already carries display names, and the VS Code controller detects transient failures by equality with `FALLBACK_CLINE_RECOMMENDED_MODELS`.
- CLI: both `resolveDisplayName` copies, the `knownModels` picker props, the onboarding controller's `clineKnownModels` state + `resolveProviderConfig` merging effect, and the now-unused `stripFreeMarker` helper are deleted. Pickers render `entry.model.name`.
- VS Code webview: `ClineModelPicker`, `ClinePassProvider`, and `useOnboardingModels` render the RPC-provided `name` directly; `resolveDisplayModelName` is removed from `@shared/api`.

Net for the refactor commit: +39 / −163 lines.

### Test Procedure

- New `cline-recommended-models.test.ts` in `@cline/core` covering catalog resolution (including the `zai/` ↔ `z-ai/` alias), marker stripping, endpoint-name and slug fallbacks, the catalog-loader timeout, and the untouched bundled fallback.
- Updated `ClineModelPicker.test.tsx` to the new contract (cards render RPC names, falling back to ids).
- Full suites pass: `@cline/core` llms tests, `@cline/cli` unit (972), webview (388), extension `test:unit` (1027). Typechecks green (`bun run types` in the SDK, `check-types` + webview `tsc -b` in the extension); biome clean on changed files.
- Manually verified the CLI `/model` picker (cline + cline-pass) and the extension's Recommended/Free tabs render identically to #12801. The manual pass caught the `zai/glm-5.2` alias case, which is what added the alias lookup.

### Type of Change

-   [x] ♻️ Refactor Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- Drag in the four screenshots from the agent artifacts:
CLI cline picker, CLI ClinePass picker, VS Code Recommended tab, VS Code Free tab -->

### Additional Notes

The true fix remains the backend returning display names from `recommended-models`; when that happens the endpoint-name fallback picks them up automatically and the catalog lookup becomes a no-op. Degraded mode (catalog unreachable at fetch time) shows endpoint slugs, same as before this change.