### PR TITLE
docs: add Editor Integration (ACP) section to CLI overview

### DIFF
--- a/docs/cli/cli-reference.mdx
+++ b/docs/cli/cli-reference.mdx
@@ -81,7 +81,7 @@ Commands:
 | `--thinking <level>` | Set reasoning effort: `none\|low\|medium\|high\|xhigh` (default `medium`) |
 | `--retries <count>` | Maximum consecutive mistakes (retries) before halting |
 | `--hooks-dir <path>` | Directory path to additional hooks for runtime hook injection (default: `~/.cline/hooks`) |
-| `--acp` | Run in Agent Client Protocol (ACP) mode for editor integration |
+| `--acp` | Run in Agent Client Protocol (ACP) mode for [editor integration](/usage/cli-overview#editor-integration-acp) |
 | `-i, --tui` | Open the terminal user interface (TUI) for interactive sessions |
 | `--id <session-id>` | Resume an existing session by ID |
 | `-k, --key <api-key>` | API key override for this run |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -768,7 +768,7 @@
 		},
 		{
 			"source": "/cline-cli/acp-editor-integrations",
-			"destination": "/cli/cli-reference"
+			"destination": "/usage/cli-overview#editor-integration-acp"
 		},
 		{
 			"source": "/cline-cli/samples/github-issue-rca",

--- a/docs/usage/cli-overview.mdx
+++ b/docs/usage/cli-overview.mdx
@@ -140,6 +140,61 @@ cline "fix the UI shown in @./design-mockup.png"
 cline --timeout 600 "run full test suite"
 ```
 
+## Editor Integration (ACP)
+
+Cline CLI speaks the [Agent Client Protocol (ACP)](https://agentclientprotocol.com), an open standard that lets editors drive terminal-based coding agents. Any ACP-capable client — Zed, Neovim plugins, Emacs, and others — can use Cline as its coding agent without a dedicated extension.
+
+ACP mode is started with the `--acp` flag:
+
+```bash
+cline --acp
+```
+
+You don't run this yourself — your editor launches the command and talks to Cline over stdio. Configure the editor to run it, then start a thread from the editor's agent UI.
+
+### Zed
+
+Add Cline as a custom agent in Zed's `settings.json`:
+
+```json
+{
+  "agent_servers": {
+    "Cline": {
+      "type": "custom",
+      "command": "cline",
+      "args": ["--acp"],
+      "env": {}
+    }
+  }
+}
+```
+
+Open the Agent Panel, start a new thread, and select **Cline**.
+
+<Tip>
+If Zed can't spawn the agent, it may not inherit your shell's `PATH`. Use the absolute path from `which cline` as the `command` value.
+</Tip>
+
+### What works over ACP
+
+- **Sign-in from the editor** — if no credentials are found, the editor prompts you to sign in with Cline, ClinePass, or a ChatGPT subscription. Credentials saved by `cline auth` are reused automatically.
+- **Plan/Act modes** — switch between [Plan and Act](/core-workflows/plan-and-act) from the editor's mode selector.
+- **Model and provider selection** — pick any model from the active provider's catalog, or switch providers, from the editor's model picker.
+- **Permission prompts** — file edits and commands are approved through the editor's permission UI; nothing is auto-approved.
+- **Session resume** — conversations are persisted, so editors that support session loading can restore a thread after a restart.
+- **Images** — prompts can include images for vision-capable models.
+- **Organization switching** — Cline team accounts can switch between personal and organization billing.
+
+### Environment variables
+
+Set these under `env` in the editor's agent server config to preconfigure the agent:
+
+| Variable | Effect |
+|---|---|
+| `CLINE_API_KEY` | Authenticate with an API key instead of interactive sign-in |
+| `CLINE_PROVIDER` | Pin the provider (disables provider switching in the editor) |
+| `CLINE_MODEL` | Default model for new sessions |
+
 ## JSON Output Schema
 
 When using `--json`, each line is a JSON message object.


### PR DESCRIPTION
### Related Issue

N/A — docs-only change.

### Description

Adds documentation for using Cline CLI in editors via the Agent Client Protocol (ACP), which was previously undocumented aside from the `--acp` flag listing in the CLI reference.

Rather than a standalone page (a previous attempt, #12315, was drafted but never merged, and an earlier page was reverted), this adds an **Editor Integration (ACP)** section to the existing CLI Overview page:

- What ACP mode is and that editors launch `cline --acp` over stdio
- Zed setup example using the current `agent_servers` custom-agent config format
- What works over ACP, matching the current `apps/cli/src/acp` implementation: editor sign-in (Cline / ClinePass / ChatGPT subscription), Plan/Act modes, model and provider selection, editor-side permission prompts, session resume, image prompts, and organization switching
- `CLINE_API_KEY` / `CLINE_PROVIDER` / `CLINE_MODEL` environment variables for preconfiguring the agent

Also:

- Links the `--acp` rows in `docs/cli/cli-reference.mdx` to the new section
- Repoints the stale `/cline-cli/acp-editor-integrations` redirect (currently landing on the generic CLI reference) at the new anchor

### Test Procedure

- `mintlify broken-links` passes with no broken links
- Rendered locally with `mint dev` and verified the `#editor-integration-acp` anchor navigation and section content in the browser (screenshots below)

### Type of Change

-   [x] 📚 Documentation update

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

![Editor Integration (ACP) section with Zed setup](https://cursor.com/artifacts/c/art-30f54794-9cd8-452b-bfdb-0f5788fd59e6)

![What works over ACP and environment variables](https://cursor.com/artifacts/c/art-24eb0a99-6508-4561-844f-4bbe5175a708)