### PR TITLE
fix(vscode): split SDK provider-failure telemetry from task.provider_api_error

### DIFF
--- a/.cline/skills/publish-extension/SKILL.md
+++ b/.cline/skills/publish-extension/SKILL.md
@@ -37,6 +37,8 @@ All three publish paths gate on tests before publishing: nightly and ab-package 
      | python3 -c "import json,sys; v=json.load(sys.stdin)['results'][0]['extensions'][0]['versions'][0]; print(v['version'], v['lastUpdated'])"
    ```
 
+   `ext-vscode-ab-package` also enforces this automatically for `publish=true` runs: a preflight job validates the version format (plain `X.Y.Z`) and hard-fails unless it exceeds the live Marketplace version, and the publish job re-checks right before publishing (the approval wait can last days — a legacy hotfix landing in between is caught). Still run the query yourself when *choosing* the version.
+
 2. **Check the flag BEFORE any stable combined publish.** `ext-sdk-bundle-rollout` is **shared between nightly and stable** — the loader sends only a machine id to `/decide`, no channel property, so there is no per-channel targeting. If the flag is high (nightly dogfooding) and you publish stable, stable users get the next bundle at that same percentage. Verify the effective percentage empirically (no PostHog admin needed — sample `/decide` with random ids using the key inlined in any shipped loader):
 
    ```bash
@@ -62,7 +64,7 @@ All three publish paths gate on tests before publishing: nightly and ab-package 
 
 4. **Changelog lives at the repo ROOT** (`CHANGELOG.md`), on the branch being released — not `apps/vscode/CHANGELOG.md` (doesn't exist). The legacy and stable workflows hard-fail unless the first heading is exactly `## [<version>]`.
 
-5. **Stuck concurrency groups**: `ext-vscode-ab-package` groups on the version with `cancel-in-progress: false`. A run left `waiting` on environment approval blocks every later dispatch of the same version — cancel it (`gh run cancel <id>`) before re-dispatching.
+5. **Stuck concurrency groups**: `ext-vscode-ab-package` groups on the version with `cancel-in-progress: false`. Only `publish=true` runs wait on environment approval (build-only rehearsals run ungated to completion), but a publish run left `waiting` still blocks every later dispatch of the same version — cancel it (`gh run cancel <id>`) before re-dispatching.
 
 ## Stable release (combined A/B VSIX) — the current stable path
 
@@ -92,14 +94,13 @@ Release prep on `main` (PR, not direct push):
 ```bash
 gh workflow run ext-vscode-ab-package.yml --ref main \
   -f version=<VERSION> -f next-ref=main -f legacy-ref=legacy-extension -f publish=true
-# publish=false builds an installable .vsix artifact without publishing, but the
-# package job still requires the same Publish environment approval — an
-# unapproved rehearsal sits in `waiting` and blocks that version's concurrency
-# group (rule 5).
+# publish=false builds an installable .vsix artifact without publishing and
+# needs NO environment approval — the ungated build job uploads the artifact
+# and the run completes.
 gh run list --workflow=ext-vscode-ab-package.yml --limit 1
 ```
 
-Both test suites run first (no approval needed); the gated `package` job then **waits for `Publish` environment approval** (Actions → run → "Review deployments"). Both bundles build the exact revisions their test gates ran against (branch names are resolved once — commits landing on either branch mid-run or during the approval wait are not picked up); `publish=true` is additionally refused for any `next-ref` other than `main` (the bun gate only tests main — non-main next-refs are for build-only artifact rehearsals). Check what a run is waiting on:
+Preflight (version format + monotonicity) and both test suites run first, then the ungated `build` job packages and uploads the VSIX; for `publish=true` the `publish` job then **waits for `Publish` environment approval** (Actions → run → "Review deployments"). Both bundles build the exact revisions their test gates ran against (branch names are resolved once — commits landing on either branch mid-run or during the approval wait are not picked up); `publish=true` is additionally refused for any `next-ref` other than `main` (the bun gate only tests main — non-main next-refs are for build-only artifact rehearsals). Check what a run is waiting on:
 
 ```bash
 gh api repos/cline/cline/actions/runs/<run-id>/pending_deployments
@@ -107,7 +108,11 @@ gh api repos/cline/cline/actions/runs/<run-id>/pending_deployments
 
 ### Post-publish
 
-1. Verify the marketplace serves the new version (query from rule 1) — expect minutes-to-an-hour of validation lag after "Published" appears in the logs.
+1. Verify the marketplace serves the new version (query from rule 1) — expect minutes-to-an-hour of validation lag after "Published" appears in the logs. Also verify Open VSX:
+
+   ```bash
+   curl -s "https://open-vsx.org/api/saoudrizwan/claude-dev" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['version'], d['timestamp'])"
+   ```
 2. Tag, GitHub Release (with the .vsix attached), and the Slack release-bot post happen **automatically** after a real publish (all `continue-on-error` — the publish itself already succeeded, so bookkeeping failures leave the run green). Verify they landed; the known failure is the tag push when the built commit touches `.github/workflows/**` (default token cannot create such refs — no grantable permission fixes it). Manual fallback:
 
    ```bash
@@ -124,7 +129,6 @@ gh api repos/cline/cline/actions/runs/<run-id>/pending_deployments
 
 ### Known caveats of this path
 
-- **Marketplace only** — no Open VSX step (both standalone workflows have one). Open VSX users stay on the last standalone version until a standalone publish or the cutover.
 - **`engines.vscode` unions upward** (main's floor wins, e.g. `^1.101.0` vs legacy's `^1.84.0`): users on older VS Code are never offered the combined VSIX. Fail-safe during rollout; must be resolved before 100%.
 - A red run can still mean a successful publish on paths that tag (see Gotchas).
 
@@ -163,7 +167,7 @@ When the next bundle has held at 100% long enough to trust:
 
 1. **Resolve the engines floor**: decide whether stranding VS Code < main's `engines.vscode` on the last combined version is acceptable, or lower main's floor first.
 2. Bump `apps/vscode/package.json` on `main` above everything ever published; root `CHANGELOG.md` entry to match (both are enforced by the workflow).
-3. Ship standalone from main: `gh workflow run ext-vscode-publish-stable.yml --ref main` — tests main, tags `v<version>` itself, creates the GitHub release, publishes Marketplace + Open VSX (this also heals the Open VSX gap).
+3. Ship standalone from main: `gh workflow run ext-vscode-publish-stable.yml --ref main` — tests main, tags `v<version>` itself, creates the GitHub release, publishes Marketplace + Open VSX.
 4. Watch the same rollout telemetry through the transition — `extension_variant` disappears from events as users leave combined builds, which is itself the adoption signal.
 5. Only after the standalone version dominates: retire `legacy-extension` (keep for history), delete `ext-vscode-publish-legacy.yml` and `ext-vscode-ab-package.yml`, convert the nightly workflow back to a plain build of main, remove `apps/vscode-rollout/`, and archive the `ext-sdk-bundle-rollout` flag in PostHog (harmless to machines still on a combined VSIX: absent flag fails safe to... nothing changing until they update, but their loader treats a deleted flag as legacy — leave the flag at 100% until combined-VSIX activations flatline, then archive).
 6. Update this skill: delete the combined-era sections and keep the standalone flow.
@@ -174,5 +178,5 @@ When the next bundle has held at 100% long enough to trust:
 - `bun run package` in `apps/vscode` does not build `@cline/*` workspace deps — fresh checkouts need `bun run build:sdk` first (workflows handle this).
 - Job-level `if:` ref checks in workflow YAML are advisory (a dispatched branch runs its own copy of the file); the enforced boundary is each environment's deployment-branch policy in repo settings.
 - Marketplace PATs (`VSCE_PAT`/`OVSX_PAT`) are only mounted into publish steps; neither publish workflow has an untrusted trigger surface.
-- Environment-approval runs left waiting don't time out quickly — they sit for days and (for ab-package) block their version's concurrency group.
+- Environment-approval runs left waiting don't time out quickly — they sit for days and (for ab-package publish runs) block their version's concurrency group.
 - Local forcing for manual testing: `CLINE_BUNDLE_OVERRIDE=next|legacy` env (launch VS Code fresh from a terminal) or the `<prefix>.rollout.bundleOverride` setting + reload; both report as `override` in telemetry so they don't pollute cohort data.

--- a/.github/workflows/ext-vscode-ab-package.yml
+++ b/.github/workflows/ext-vscode-ab-package.yml
@@ -49,9 +49,16 @@ jobs:
         name: Validate inputs
         runs-on: ubuntu-latest
         steps:
+            # The input reaches the shell ONLY via env here (never inline
+            # expression interpolation, which is evaluated before bash runs and
+            # would allow script injection from the dispatch form). Because
+            # every later job `needs` preflight, passing this regex is what
+            # makes the plain-string `${{ inputs.version }}` interpolations
+            # downstream safe.
             - name: Validate version format
+              env:
+                  VERSION: ${{ github.event.inputs.version }}
               run: |
-                  VERSION="${{ github.event.inputs.version }}"
                   if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
                     echo "Error: version must be plain X.Y.Z with no leading 'v' and no suffix (got '$VERSION')."
                     echo "It is stamped verbatim into the union manifest and both bundle manifests."
@@ -77,8 +84,9 @@ jobs:
             # land in between. Keep both copies of this check in sync.
             - name: Verify version exceeds the live Marketplace version
               if: ${{ github.event.inputs.publish == 'true' }}
+              env:
+                  VERSION: ${{ github.event.inputs.version }}
               run: |
-                  VERSION="${{ github.event.inputs.version }}"
                   LIVE=$(curl -sf --retry 3 -X POST "https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery" \
                     -H "Content-Type: application/json" -H "Accept: application/json;api-version=3.0-preview.1" \
                     --data '{"filters":[{"criteria":[{"filterType":7,"value":"saoudrizwan.claude-dev"}]}],"flags":16}' \
@@ -406,8 +414,9 @@ jobs:
             # would otherwise be silently superseded by this older code line.
             # Keep in sync with the preflight copy of this check.
             - name: Re-verify version exceeds the live Marketplace version
+              env:
+                  VERSION: ${{ github.event.inputs.version }}
               run: |
-                  VERSION="${{ github.event.inputs.version }}"
                   LIVE=$(curl -sf --retry 3 -X POST "https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery" \
                     -H "Content-Type: application/json" -H "Accept: application/json;api-version=3.0-preview.1" \
                     --data '{"filters":[{"criteria":[{"filterType":7,"value":"saoudrizwan.claude-dev"}]}],"flags":16}' \
@@ -427,7 +436,15 @@ jobs:
                   ' "$VERSION" "$LIVE"
                   echo "Version ok: $VERSION exceeds live Marketplace version $LIVE"
 
-            - name: Publish to Marketplace and Open VSX
+            # Both PATs are verified BEFORE the first irreversible publish so a
+            # missing Open VSX token can't strand us half-published. The two
+            # registries are separate steps: if Open VSX fails after the
+            # Marketplace accepted the VSIX, the run goes red (so the operator
+            # notices Open VSX lagged) but the bookkeeping below still runs —
+            # it is keyed off the Marketplace outcome, which is what "shipped"
+            # means for this listing.
+            - name: Publish to Marketplace
+              id: publish_marketplace
               working-directory: staging
               env:
                   VSCE_PAT: ${{ secrets.VSCE_PAT }}
@@ -442,19 +459,27 @@ jobs:
                     exit 1
                   fi
                   vsce publish --no-dependencies --packagePath "claude-dev-${{ github.event.inputs.version }}.vsix"
-                  npx ovsx publish --packagePath "claude-dev-${{ github.event.inputs.version }}.vsix" --pat "$OVSX_PAT"
+
+            - name: Publish to Open VSX
+              working-directory: staging
+              env:
+                  OVSX_PAT: ${{ secrets.OVSX_PAT }}
+              run: npx ovsx publish --packagePath "claude-dev-${{ github.event.inputs.version }}.vsix" --pat "$OVSX_PAT"
 
             # ---- Post-publish bookkeeping (tag / GitHub Release / Slack) ----
             # Mirrors the standalone publish workflows. Every step here is
-            # continue-on-error: the Marketplace publish above already happened,
-            # and a red run after a successful publish is exactly the confusion
-            # the nightly workflow taught us to avoid (tag pushes fail whenever
-            # the built commit touches .github/workflows/** — no grantable
-            # permission fixes that; push the tag manually in that case, see
-            # the publish-extension skill).
+            # continue-on-error, and gated on the MARKETPLACE outcome rather
+            # than plain step ordering: the Marketplace publish already
+            # happened, so bookkeeping must still run when only the Open VSX
+            # step failed, and a red run after a successful publish is exactly
+            # the confusion the nightly workflow taught us to avoid (tag pushes
+            # fail whenever the built commit touches .github/workflows/** — no
+            # grantable permission fixes that; push the tag manually in that
+            # case, see the publish-extension skill).
 
             - name: Extract changelog entry
               id: changelog
+              if: ${{ !cancelled() && steps.publish_marketplace.outcome == 'success' }}
               continue-on-error: true
               run: |
                   CONTENT=$(awk '/^## \[/{if(found) exit; found=1; next} found{print}' CHANGELOG.md)
@@ -466,6 +491,7 @@ jobs:
 
             - name: Resolve previous release tag
               id: prev_tag
+              if: ${{ !cancelled() && steps.publish_marketplace.outcome == 'success' }}
               continue-on-error: true
               run: |
                   # ls-remote needs no local tag objects; take the highest v* tag
@@ -478,6 +504,7 @@ jobs:
                   echo "prev_tag=$PREV" >> "$GITHUB_OUTPUT"
 
             - name: Create and push release tag
+              if: ${{ !cancelled() && steps.publish_marketplace.outcome == 'success' }}
               continue-on-error: true
               run: |
                   TAG="v${{ github.event.inputs.version }}"
@@ -486,6 +513,7 @@ jobs:
                   echo "Pushed $TAG at $(git rev-parse HEAD)"
 
             - name: Create GitHub Release
+              if: ${{ !cancelled() && steps.publish_marketplace.outcome == 'success' }}
               continue-on-error: true
               uses: softprops/action-gh-release@v1
               with:
@@ -499,6 +527,7 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Post release to Slack
+              if: ${{ !cancelled() && steps.publish_marketplace.outcome == 'success' }}
               continue-on-error: true
               uses: slackapi/slack-github-action@v3.0.1
               with:

--- a/.github/workflows/ext-vscode-ab-package.yml
+++ b/.github/workflows/ext-vscode-ab-package.yml
@@ -5,6 +5,11 @@ name: ext-vscode-ab-package
 # `legacy/` from the legacy-extension branch. Cohort selection happens at
 # runtime via PostHog flags; see apps/vscode-rollout/README.md for the design
 # and the rollout runbook.
+#
+# Job layout: cheap input gates (preflight) and the two bundle test suites run
+# ungated; the build job packages the VSIX with no environment attached, so
+# publish=false rehearsals complete without any approval; only the publish job
+# — Marketplace + Open VSX + bookkeeping — waits on the `publish` environment.
 
 on:
     workflow_dispatch:
@@ -24,7 +29,7 @@ on:
                 default: "legacy-extension"
                 type: string
             publish:
-                description: "Publish to the VS Code Marketplace (unchecked: just build the .vsix artifact)"
+                description: "Publish to the VS Code Marketplace and Open VSX (unchecked: just build the .vsix artifact)"
                 required: true
                 default: false
                 type: boolean
@@ -37,18 +42,72 @@ concurrency:
     cancel-in-progress: false
 
 jobs:
+    # Input gates that need no checkout: fail in seconds — before the test
+    # suites, the ~20-minute build, and the environment approval — instead of
+    # at publish time.
+    preflight:
+        name: Validate inputs
+        runs-on: ubuntu-latest
+        steps:
+            - name: Validate version format
+              run: |
+                  VERSION="${{ github.event.inputs.version }}"
+                  if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                    echo "Error: version must be plain X.Y.Z with no leading 'v' and no suffix (got '$VERSION')."
+                    echo "It is stamped verbatim into the union manifest and both bundle manifests."
+                    exit 1
+                  fi
+                  echo "Version format ok: $VERSION"
+
+            # The reusable bun suite tests the dispatch revision (main), so
+            # publishing any other next-ref would ship an untested bundle.
+            # Build-only runs (publish=false) may still use arbitrary next-refs
+            # for artifact rehearsals.
+            - name: Refuse to publish an untested next-ref
+              if: ${{ github.event.inputs.publish == 'true' && github.event.inputs.next-ref != 'main' }}
+              run: |
+                  echo "Error: publish=true requires next-ref=main — the test gate only covers main."
+                  exit 1
+
+            # Marketplace versions are monotonic and cannot be unpublished:
+            # every publish must exceed the highest version ever published to
+            # the claude-dev listing FROM ANY BRANCH (combined stable or legacy
+            # hotfix). The publish job re-checks right before publishing — the
+            # environment-approval wait can last days and a legacy hotfix can
+            # land in between. Keep both copies of this check in sync.
+            - name: Verify version exceeds the live Marketplace version
+              if: ${{ github.event.inputs.publish == 'true' }}
+              run: |
+                  VERSION="${{ github.event.inputs.version }}"
+                  LIVE=$(curl -sf --retry 3 -X POST "https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery" \
+                    -H "Content-Type: application/json" -H "Accept: application/json;api-version=3.0-preview.1" \
+                    --data '{"filters":[{"criteria":[{"filterType":7,"value":"saoudrizwan.claude-dev"}]}],"flags":16}' \
+                    | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{process.stdout.write(JSON.parse(d).results[0].extensions[0].versions[0].version)})')
+                  if [[ -z "$LIVE" ]]; then
+                    echo "Error: could not resolve the live Marketplace version for saoudrizwan.claude-dev."
+                    exit 1
+                  fi
+                  node -e '
+                    const [next, live] = process.argv.slice(1).map((v) => v.split(".").map(Number));
+                    for (let i = 0; i < 3; i++) {
+                      if (next[i] > live[i]) process.exit(0);
+                      if (next[i] < live[i]) break;
+                    }
+                    console.error(`Error: version ${process.argv[1]} does not exceed the live Marketplace version ${process.argv[2]}.`);
+                    process.exit(1);
+                  ' "$VERSION" "$LIVE"
+                  echo "Version ok: $VERSION exceeds live Marketplace version $LIVE"
+
     # Gate the build/publish on BOTH bundles' own test suites, mirroring the two
     # standalone publish paths (nightly gates on the bun suite via the same
-    # reusable workflow; the legacy publish inlines the npm suite). The gated
-    # `package` job requests its `publish` environment approval only after both
-    # suites pass.
+    # reusable workflow; the legacy publish inlines the npm suite).
     #
     # Caveat (shared with the nightly workflow): the reusable bun suite tests the
     # DISPATCH revision — main's tip at dispatch, since this workflow is only
-    # dispatched from main — not `next-ref`. The package job therefore pins the
+    # dispatched from main — not `next-ref`. The build job therefore pins the
     # default next-ref checkout to that same revision (tested == built) and
-    # refuses publish=true for any other next-ref; build-only artifact runs may
-    # still build untested refs.
+    # preflight refuses publish=true for any other next-ref; build-only artifact
+    # runs may still build untested refs.
     test-next:
         name: Test next (SDK) bundle
         permissions:
@@ -62,11 +121,10 @@ jobs:
     test-legacy:
         name: Test legacy bundle
         runs-on: ubuntu-latest
-        # The tested revision, exported so the package job builds EXACTLY what
+        # The tested revision, exported so the build job builds EXACTLY what
         # this suite ran against. legacy-ref is a mutable branch name and the
-        # package job starts much later (test phase + environment-approval wait,
-        # potentially days) — re-resolving the name there could pick up commits
-        # this gate never saw.
+        # build job starts later — re-resolving the name there could pick up
+        # commits this gate never saw.
         outputs:
             tested-sha: ${{ steps.rev.outputs.sha }}
         defaults:
@@ -121,27 +179,11 @@ jobs:
                   cd webview-ui
                   npm run test:coverage
 
-    package:
+    build:
         name: Build combined (legacy + next) VSIX
-        needs: [test-next, test-legacy]
+        needs: [preflight, test-next, test-legacy]
         runs-on: ubuntu-latest
-        environment: publish
-        # contents: write is required by the post-publish bookkeeping (tag +
-        # GitHub Release), mirroring the standalone publish workflows.
-        permissions:
-            contents: write
         steps:
-            # Refuse to publish a next bundle the test-next gate did not cover.
-            # The reusable suite tests the dispatch revision (main), so publishing
-            # any other next-ref would ship an untested bundle. Build-only runs
-            # (publish=false) may still use arbitrary next-refs for artifact
-            # rehearsals.
-            - name: Refuse to publish an untested next-ref
-              if: ${{ github.event.inputs.publish == 'true' && github.event.inputs.next-ref != 'main' }}
-              run: |
-                  echo "Error: publish=true requires next-ref=main — the test gate only covers main."
-                  exit 1
-
             # For the default next-ref (main), pin the checkout to the exact
             # revision the test-next gate ran against: a moving branch name could
             # otherwise drift past the tested commit during the test phase.
@@ -185,9 +227,12 @@ jobs:
               with:
                   node-version: 22
 
+            # --frozen-lockfile so the built bundle resolves the exact
+            # dependency set the test-next gate ran against (the reusable suite
+            # installs frozen too) — a bare install could silently re-resolve.
             - name: Install next workspace dependencies
               working-directory: next-src
-              run: bun install
+              run: bun install --frozen-lockfile
 
             # @cline/* are local workspace symlinks to source packages; apps/vscode's
             # `package` script does NOT build them, so without this the esbuild step
@@ -195,6 +240,17 @@ jobs:
             - name: Build SDK packages
               working-directory: next-src
               run: bun run build:sdk
+
+            - name: Assert better-sqlite3 native binary present
+              working-directory: next-src/apps/vscode
+              run: |
+                  NODE_FILE="node_modules/better-sqlite3/build/Release/better_sqlite3.node"
+                  if [ ! -f "$NODE_FILE" ]; then
+                    echo "ERROR: better-sqlite3 native binary missing at apps/vscode/$NODE_FILE"
+                    echo "(bun trustedDependencies postinstall likely did not run)"
+                    exit 1
+                  fi
+                  echo "Found better-sqlite3 native binary: $NODE_FILE"
 
             # Stamp the combined version into each bundle's package.json AFTER
             # install and BEFORE its build: the About tab and telemetry
@@ -312,17 +368,81 @@ jobs:
                   path: staging/claude-dev-${{ github.event.inputs.version }}.vsix
                   if-no-files-found: error
 
-            - name: Publish to Marketplace
-              if: ${{ github.event.inputs.publish == 'true' }}
+    publish:
+        name: Publish to Marketplace and Open VSX
+        needs: build
+        if: ${{ github.event.inputs.publish == 'true' }}
+        runs-on: ubuntu-latest
+        environment: publish
+        # contents: write is required by the post-publish bookkeeping (tag +
+        # GitHub Release), mirroring the standalone publish workflows.
+        permissions:
+            contents: write
+        steps:
+            # The built next revision: preflight refused publish=true for any
+            # next-ref other than main, and the build job pinned main to the
+            # dispatch SHA — so github.sha IS the published commit. Used for the
+            # changelog, the release tag, and the previous-tag lookup.
+            - uses: actions/checkout@v4
+              with:
+                  ref: ${{ github.sha }}
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+
+            - name: Download VSIX artifact
+              uses: actions/download-artifact@v4
+              with:
+                  name: claude-dev-${{ github.event.inputs.version }}
+                  path: staging
+
+            - name: Install Publishing Tools
+              run: npm install -g @vscode/vsce ovsx
+
+            # Re-check monotonicity at the last moment: the environment-approval
+            # wait can last days, and a legacy hotfix published in the meantime
+            # would otherwise be silently superseded by this older code line.
+            # Keep in sync with the preflight copy of this check.
+            - name: Re-verify version exceeds the live Marketplace version
+              run: |
+                  VERSION="${{ github.event.inputs.version }}"
+                  LIVE=$(curl -sf --retry 3 -X POST "https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery" \
+                    -H "Content-Type: application/json" -H "Accept: application/json;api-version=3.0-preview.1" \
+                    --data '{"filters":[{"criteria":[{"filterType":7,"value":"saoudrizwan.claude-dev"}]}],"flags":16}' \
+                    | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{process.stdout.write(JSON.parse(d).results[0].extensions[0].versions[0].version)})')
+                  if [[ -z "$LIVE" ]]; then
+                    echo "Error: could not resolve the live Marketplace version for saoudrizwan.claude-dev."
+                    exit 1
+                  fi
+                  node -e '
+                    const [next, live] = process.argv.slice(1).map((v) => v.split(".").map(Number));
+                    for (let i = 0; i < 3; i++) {
+                      if (next[i] > live[i]) process.exit(0);
+                      if (next[i] < live[i]) break;
+                    }
+                    console.error(`Error: version ${process.argv[1]} does not exceed the live Marketplace version ${process.argv[2]}.`);
+                    process.exit(1);
+                  ' "$VERSION" "$LIVE"
+                  echo "Version ok: $VERSION exceeds live Marketplace version $LIVE"
+
+            - name: Publish to Marketplace and Open VSX
               working-directory: staging
               env:
                   VSCE_PAT: ${{ secrets.VSCE_PAT }}
+                  OVSX_PAT: ${{ secrets.OVSX_PAT }}
               run: |
                   if [[ -z "$VSCE_PAT" ]]; then
                     echo "Error: VSCE_PAT is required to publish."
                     exit 1
                   fi
+                  if [[ -z "$OVSX_PAT" ]]; then
+                    echo "Error: OVSX_PAT is required to publish to Open VSX."
+                    exit 1
+                  fi
                   vsce publish --no-dependencies --packagePath "claude-dev-${{ github.event.inputs.version }}.vsix"
+                  npx ovsx publish --packagePath "claude-dev-${{ github.event.inputs.version }}.vsix" --pat "$OVSX_PAT"
 
             # ---- Post-publish bookkeeping (tag / GitHub Release / Slack) ----
             # Mirrors the standalone publish workflows. Every step here is
@@ -335,9 +455,7 @@ jobs:
 
             - name: Extract changelog entry
               id: changelog
-              if: ${{ github.event.inputs.publish == 'true' }}
               continue-on-error: true
-              working-directory: next-src
               run: |
                   CONTENT=$(awk '/^## \[/{if(found) exit; found=1; next} found{print}' CHANGELOG.md)
                   {
@@ -348,9 +466,7 @@ jobs:
 
             - name: Resolve previous release tag
               id: prev_tag
-              if: ${{ github.event.inputs.publish == 'true' }}
               continue-on-error: true
-              working-directory: next-src
               run: |
                   # ls-remote needs no local tag objects; take the highest v* tag
                   # below the one being released.
@@ -362,9 +478,7 @@ jobs:
                   echo "prev_tag=$PREV" >> "$GITHUB_OUTPUT"
 
             - name: Create and push release tag
-              if: ${{ github.event.inputs.publish == 'true' }}
               continue-on-error: true
-              working-directory: next-src
               run: |
                   TAG="v${{ github.event.inputs.version }}"
                   git tag "$TAG" HEAD
@@ -372,7 +486,6 @@ jobs:
                   echo "Pushed $TAG at $(git rev-parse HEAD)"
 
             - name: Create GitHub Release
-              if: ${{ github.event.inputs.publish == 'true' }}
               continue-on-error: true
               uses: softprops/action-gh-release@v1
               with:
@@ -386,7 +499,6 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Post release to Slack
-              if: ${{ github.event.inputs.publish == 'true' }}
               continue-on-error: true
               uses: slackapi/slack-github-action@v3.0.1
               with:

--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -587,7 +587,7 @@ export class Controller {
 			resolveContextMentions: (text) => this.resolveContextMentions(text),
 			isClineManagedProviderActive: () => this.isClineManagedProviderActive(),
 			emitClineAuthError: (task) => this.emitClineAuthErrorWithTelemetry(task),
-			captureProviderApiError: (event) => this.captureProviderFailure(event),
+			captureProviderFailure: (event) => this.captureProviderFailure(event),
 			postStateToWebview: () => this.postStateToWebview(),
 		})
 		this.compaction = new SdkCompactionCoordinator({
@@ -613,7 +613,7 @@ export class Controller {
 			postStateToWebview: () => this.postStateToWebview(),
 			setTurnPhase: (phase, anchorTs) => this.turnStateTracker.set(phase, anchorTs),
 			getTurnPhase: () => this.turnStateTracker.currentPhase,
-			captureProviderApiError: (event) => this.captureProviderFailure(event),
+			captureProviderFailure: (event) => this.captureProviderFailure(event),
 			beginProviderFailureTelemetryTurn: () => this.beginProviderFailureTelemetryTurn(),
 		})
 		// Subscribe to MCP tool list changes so we can restart the SDK session
@@ -1044,7 +1044,7 @@ export class Controller {
 		const model = event.modelId ?? this.getSessionModelId(event.sessionId) ?? this.getTaskModelId() ?? "unknown"
 		const clineError = ClineError.transform(event.error, model, provider)
 
-		telemetryService.captureProviderApiError({
+		telemetryService.captureProviderFailure({
 			ulid,
 			model,
 			provider,

--- a/apps/vscode/src/sdk/sdk-session-event-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-session-event-coordinator.test.ts
@@ -319,7 +319,7 @@ describe("SdkSessionEventCoordinator", () => {
 
 		await coordinator.handleSessionEvent(event)
 
-		expect(options.captureProviderApiError).toHaveBeenCalledWith({
+		expect(options.captureProviderFailure).toHaveBeenCalledWith({
 			sessionId: "session-123",
 			error,
 			errorType: PROVIDER_FAILURE_ERROR_TYPE.SDK_AGENT_ERROR,
@@ -341,7 +341,7 @@ describe("SdkSessionEventCoordinator", () => {
 
 		await coordinator.handleSessionEvent(event)
 
-		expect(options.captureProviderApiError).not.toHaveBeenCalled()
+		expect(options.captureProviderFailure).not.toHaveBeenCalled()
 	})
 
 	it("captures provider failure telemetry when the SDK finishes a turn with reason error", async () => {
@@ -361,7 +361,7 @@ describe("SdkSessionEventCoordinator", () => {
 
 		await coordinator.handleSessionEvent(event)
 
-		expect(options.captureProviderApiError).toHaveBeenCalledWith({
+		expect(options.captureProviderFailure).toHaveBeenCalledWith({
 			sessionId: "session-123",
 			error: "stream failed before assistant output",
 			errorType: PROVIDER_FAILURE_ERROR_TYPE.SDK_AGENT_DONE_ERROR,
@@ -395,7 +395,7 @@ function makeCoordinator(input: Partial<MakeCoordinatorInput> = {}) {
 		postStateToWebview: vi.fn().mockResolvedValue(undefined),
 		setTurnPhase: vi.fn(),
 		getTurnPhase: vi.fn(() => input.turnPhase ?? "streaming"),
-		captureProviderApiError: vi.fn(),
+		captureProviderFailure: vi.fn(),
 		beginProviderFailureTelemetryTurn: vi.fn(),
 		translateSessionEvent: vi.fn(() => input.translation ?? { messages: [], sessionEnded: false, turnComplete: false }),
 		isClineFreeModel: input.isClineFreeModel,
@@ -407,7 +407,7 @@ function makeCoordinator(input: Partial<MakeCoordinatorInput> = {}) {
 		messages: SdkSessionEventCoordinatorOptions["messages"] & { appendAndEmit: ReturnType<typeof vi.fn> }
 		taskHistory: SdkSessionEventCoordinatorOptions["taskHistory"] & { updateTaskUsage: ReturnType<typeof vi.fn> }
 		postStateToWebview: ReturnType<typeof vi.fn>
-		captureProviderApiError: ReturnType<typeof vi.fn>
+		captureProviderFailure: ReturnType<typeof vi.fn>
 		beginProviderFailureTelemetryTurn: ReturnType<typeof vi.fn>
 		translateSessionEvent: ReturnType<typeof vi.fn>
 		messageTranslatorState: MessageTranslatorState

--- a/apps/vscode/src/sdk/sdk-session-event-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-session-event-coordinator.ts
@@ -37,7 +37,7 @@ export interface SdkSessionEventCoordinatorOptions {
 	setTurnPhase?: (phase: TurnPhase, anchorTs?: number) => void
 	/** Current authoritative UI turn phase, from the controller's TurnStateTracker. */
 	getTurnPhase?: () => TurnPhase
-	captureProviderApiError?: (event: ProviderFailureTelemetry) => void
+	captureProviderFailure?: (event: ProviderFailureTelemetry) => void
 	beginProviderFailureTelemetryTurn?: () => void
 }
 
@@ -68,7 +68,7 @@ export class SdkSessionEventCoordinator {
 		const result = this.translateSessionEvent(event, this.options.messageTranslatorState)
 		const agentFailure = this.getAgentFailureTelemetry(event)
 		if (agentFailure && !this.options.messageTranslatorState.isSuppressedToolApprovalDenial(agentFailure.error)) {
-			this.options.captureProviderApiError?.({
+			this.options.captureProviderFailure?.({
 				sessionId: agentFailure.sessionId,
 				error: agentFailure.error,
 				errorType: agentFailure.errorType,

--- a/apps/vscode/src/sdk/sdk-task-start-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-task-start-coordinator.test.ts
@@ -83,7 +83,7 @@ describe("SdkTaskStartCoordinator", () => {
 
 		expect(sessionId).toBeUndefined()
 		expect(options.emitClineAuthError).toHaveBeenCalledWith("needs auth")
-		expect(options.captureProviderApiError).not.toHaveBeenCalled()
+		expect(options.captureProviderFailure).not.toHaveBeenCalled()
 		expect(options.sessions.startNewSession).not.toHaveBeenCalled()
 	})
 
@@ -94,7 +94,7 @@ describe("SdkTaskStartCoordinator", () => {
 
 		expect(sessionId).toBeUndefined()
 		expect(options.emitClineAuthError).toHaveBeenCalledWith("needs clinepass auth")
-		expect(options.captureProviderApiError).not.toHaveBeenCalled()
+		expect(options.captureProviderFailure).not.toHaveBeenCalled()
 		expect(options.sessions.startNewSession).not.toHaveBeenCalled()
 	})
 
@@ -107,7 +107,7 @@ describe("SdkTaskStartCoordinator", () => {
 
 		expect(sessionId).toBeUndefined()
 		expect(options.emitClineAuthError).not.toHaveBeenCalled()
-		expect(options.captureProviderApiError).toHaveBeenCalledWith({
+		expect(options.captureProviderFailure).toHaveBeenCalledWith({
 			sessionId: state.task?.taskId,
 			error,
 			providerId: "anthropic",
@@ -288,7 +288,7 @@ function makeCoordinator(input: Partial<MakeCoordinatorInput> = {}) {
 		resolveContextMentions: vi.fn(async (text: string) => `resolved: ${text}`),
 		isClineManagedProviderActive: vi.fn(() => false),
 		emitClineAuthError: vi.fn(),
-		captureProviderApiError: vi.fn(),
+		captureProviderFailure: vi.fn(),
 		postStateToWebview: vi.fn().mockResolvedValue(undefined),
 	} as unknown as SdkTaskStartCoordinatorOptions & {
 		sessions: SdkTaskStartCoordinatorOptions["sessions"] & {
@@ -313,7 +313,7 @@ function makeCoordinator(input: Partial<MakeCoordinatorInput> = {}) {
 		resolveContextMentions: ReturnType<typeof vi.fn>
 		isClineManagedProviderActive: ReturnType<typeof vi.fn>
 		emitClineAuthError: ReturnType<typeof vi.fn>
-		captureProviderApiError: ReturnType<typeof vi.fn>
+		captureProviderFailure: ReturnType<typeof vi.fn>
 		postStateToWebview: ReturnType<typeof vi.fn>
 	}
 

--- a/apps/vscode/src/sdk/sdk-task-start-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-task-start-coordinator.ts
@@ -54,7 +54,7 @@ export interface SdkTaskStartCoordinatorOptions {
 	resolveContextMentions: (text: string) => Promise<string>
 	isClineManagedProviderActive: () => boolean
 	emitClineAuthError: (task?: string) => void
-	captureProviderApiError?: (event: ProviderFailureTelemetry) => void
+	captureProviderFailure?: (event: ProviderFailureTelemetry) => void
 	postStateToWebview: () => Promise<void>
 }
 
@@ -158,7 +158,7 @@ export class SdkTaskStartCoordinator {
 			Logger.log(`[SdkController] Task initialized: ${taskSessionId}`)
 			return taskSessionId
 		} catch (error) {
-			this.options.captureProviderApiError?.({
+			this.options.captureProviderFailure?.({
 				sessionId: taskSessionId,
 				error,
 				providerId,

--- a/apps/vscode/src/services/telemetry/TelemetryService.ts
+++ b/apps/vscode/src/services/telemetry/TelemetryService.ts
@@ -317,8 +317,18 @@ export class TelemetryService {
 			BROWSER_ERROR: "task.browser_error",
 			// Tracks Gemini API specific performance metrics
 			GEMINI_API_PERFORMANCE: "task.gemini_api_performance",
-			// Tracks when API providers return errors
+			// RESERVED for parity with the legacy extension, which emits this
+			// event ONLY for empty/unparsable assistant responses — NOT general
+			// API failures. During the A/B rollout dashboards compare error
+			// rates per extension_variant under matching event names, so this
+			// name must not be reused with wider semantics. The SDK extension's
+			// provider-failure firehose is PROVIDER_FAILURE below.
 			PROVIDER_API_ERROR: "task.provider_api_error",
+			// Tracks every provider failure surfaced by the SDK session layer:
+			// failed attempts (including auto-retried ones), preflight/task-init
+			// errors, and agent-run failures. Deliberately broader than the
+			// legacy extension's PROVIDER_API_ERROR — hence the separate name.
+			PROVIDER_FAILURE: "task.provider_failure",
 			// Tracks when users enable the focus chain feature
 			FOCUS_CHAIN_ENABLED: "task.focus_chain_enabled",
 			// Tracks when users disable the focus chain feature
@@ -1467,7 +1477,15 @@ export class TelemetryService {
 	}
 
 	/**
-	 * Records telemetry when an API provider returns an error
+	 * Records telemetry for any provider failure surfaced by the SDK session
+	 * layer — failed attempts (including auto-retried ones), preflight/task-init
+	 * errors, and agent-run failures.
+	 *
+	 * Emits task.provider_failure, NOT task.provider_api_error: the legacy
+	 * extension emits the latter only for empty/unparsable assistant responses,
+	 * and the A/B rollout dashboards compare variants under matching event
+	 * names. Emitting this firehose under the legacy name made the SDK bundle
+	 * read as ~9x the "API error rate" of legacy on identical user behavior.
 	 * @param ulid Unique identifier for the task
 	 * @param model Identifier of the model used
 	 * @param requestId Unique identifier for the specific API request
@@ -1475,7 +1493,7 @@ export class TelemetryService {
 	 * @param errorStatus HTTP status code of the error response, if available
 	 * @param collect Optional flag to determine if the event should be collected for batch sending
 	 */
-	public captureProviderApiError(args: {
+	public captureProviderFailure(args: {
 		ulid: string
 		model: string
 		errorMessage: string
@@ -1487,7 +1505,7 @@ export class TelemetryService {
 		isNativeToolCall?: boolean
 	}) {
 		this.capture({
-			event: TelemetryService.EVENTS.TASK.PROVIDER_API_ERROR,
+			event: TelemetryService.EVENTS.TASK.PROVIDER_FAILURE,
 			properties: {
 				...args,
 				errorMessage: args.errorMessage.substring(0, MAX_ERROR_MESSAGE_LENGTH), // Truncate long error messages

--- a/apps/vscode/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
+++ b/apps/vscode/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
@@ -335,11 +335,11 @@ describe("TelemetryService metrics", () => {
 		assert.strictEqual(updatedEntry.attributes.is_multi_root, false)
 	})
 
-	it("captureProviderApiError increments error counter", () => {
+	it("captureProviderFailure increments error counter", () => {
 		const provider = new FakeProvider()
 		const service = createTelemetryService(provider)
 
-		service.captureProviderApiError({
+		service.captureProviderFailure({
 			ulid: "task-3",
 			model: "claude",
 			errorMessage: "boom",
@@ -348,6 +348,18 @@ describe("TelemetryService metrics", () => {
 			errorType: PROVIDER_FAILURE_ERROR_TYPE.SDK_AGENT_DONE_ERROR,
 			failurePhase: PROVIDER_FAILURE_PHASE.STREAMING,
 		})
+
+		// Pinned: the SDK provider-failure firehose must emit its OWN event name.
+		// task.provider_api_error is reserved for legacy-extension parity (it
+		// means "empty/unparsable assistant response" there) and the rollout
+		// dashboards compare variants by event name.
+		const failureEvent = provider.logs.find((entry) => entry.event === "task.provider_failure")
+		assert.ok(failureEvent, "expected task.provider_failure event")
+		assert.strictEqual(
+			provider.logs.some((entry) => entry.event === "task.provider_api_error"),
+			false,
+			"task.provider_api_error must not be emitted by the SDK provider-failure path",
+		)
 
 		assert.strictEqual(provider.counters.length, 1)
 		const entry = provider.counters[0]


### PR DESCRIPTION
### Related Issue

Day-one monitoring of the stable A/B rollout (claude-dev 4.1.x, #12253 machinery).

### Description

**The problem.** Dash 17's error cards compare error rates between the rollout cohorts by event name and `extension_variant`. Day one of the stable 1% rollout showed `task.provider_api_error` touching **36.25% of next-variant tasks vs 4.22% of legacy-variant tasks** — a 9× gap that looked like a catastrophic regression. It isn't. The two codebases emit that event with completely different semantics:

- **Legacy** has exactly ONE task-scoped emission site (`core/task/index.ts:3860` on the `legacy-extension` branch), and it fires only for **empty/unparsable assistant responses** (`empty_assistant_message` diagnostics). Real API failures — 401s, 429s, network errors — flow through the `api_req_failed` ask path, which emits **no telemetry at all**.
- **Next** (the SDK extension) funnels every provider failure surfaced by the SDK session layer into the same event name: failed attempts including auto-retried ones, preflight/task-init errors, agent-run failures, and even tool-call failures the SDK wraps as agent errors (day-one field data shows `"1 tool call(s) failed: [shell] ..."` rows under this event).

Same name, different meanings — so the A/B comparison was structurally meaningless, and would have stayed meaningless (and alarming) for the entire ramp.

**The fix** is the structural one: next's firehose moves to its own event, `task.provider_failure`, and `task.provider_api_error` is reserved (documented in `TelemetryService.EVENTS`) for legacy-parity semantics. Since main has no equivalent of legacy's empty-response diagnostic path, next simply stops emitting the legacy-named event — which is honest: the SDK layer handles empty responses through entirely different machinery.

Renames follow the semantics: `TelemetryService.captureProviderApiError` → `captureProviderFailure`, and the coordinator option `captureProviderApiError` → `captureProviderFailure` (`sdk-session-event-coordinator`, `sdk-task-start-coordinator`, `SdkController` wiring). Properties, the `errors.total` counter, and the per-task error histogram are unchanged — only the event name changes.

**Deliberately NOT "emit less."** The chatty emission is the only reason we caught a real signal on day one (a cluster of Cline-auth errors on promoted machines, under separate investigation). Legacy's terminal-only telemetry is structurally blind to transient failures; next keeps full visibility — just under a name that can't pollute the A/B.

### Coordination required before/at merge (@max)

- **Dash 17/19 + gold models**: `gold_error_events_daily` / `gold_error_metrics_daily` group by `error_event`. Once this ships, next's rows move from `task.provider_api_error` to `task.provider_failure`. If the dbt models or any card hardcodes an event list, `task.provider_failure` needs adding — otherwise next's provider failures silently vanish from the error dashboards (worse than the current overcount).
- **Discontinuity marker**: when the release carrying this lands, the Next error-rate lines on dash 17 will step DOWN sharply. That's this rename, not a real improvement. Worth an annotation or a note in the channel so nobody celebrates (or later, reading the chart backwards, panics).

### Test Procedure

- `bun run check-types` clean.
- Coordinator vitest suites: 25/25 pass (option rename covered by existing mocks/assertions).
- `TelemetryService.metrics.test.ts`: 16/16 pass, extended with a pin that the provider-failure path emits `task.provider_failure` and asserts `task.provider_api_error` is NOT emitted — so nobody can quietly re-merge the two names without a test failing.
- Grepped `apps/vscode/src` for stragglers of the old method/option name: none (legacy branch untouched by design — it ships to 99% and its semantics are the reference point).

Field verification after this ships in the next 4.1.x release: dash 17's next-variant `task.provider_api_error` rate should drop to ~zero and `task.provider_failure` should carry the prior volume; the A/B comparison then happens on genuinely comparable events (`task.mistake_limit_reached` remains the cleanest cross-variant metric, deliberately ported to both codebases in #12354/#12402).
