### PR TITLE
feat(telemetry): report legacy provider API failures with SDK-extension-parity schema

### DIFF
--- a/apps/vscode/src/core/task/index.ts
+++ b/apps/vscode/src/core/task/index.ts
@@ -3619,7 +3619,13 @@ export class Task {
 					// Mirror the SDK extension's provider-failure reporting for
 					// mid-stream failures (see attemptApiRequest for the
 					// first-chunk equivalent). One event per failed attempt.
-					{
+					// isWaitingForFirstChunk gate: first-chunk failures are
+					// already reported inside attemptApiRequest's catch, and a
+					// declined retry rethrows a generic error that unwinds to
+					// this catch — the flag is only cleared after the first
+					// chunk yields, so it cleanly excludes those re-thrown
+					// pre-stream failures from being counted twice.
+					if (!this.taskState.isWaitingForFirstChunk) {
 						const { providerId: midStreamProviderId } =
 							this.getCurrentProviderInfo();
 						telemetryService.captureProviderApiError({

--- a/apps/vscode/src/core/task/index.ts
+++ b/apps/vscode/src/core/task/index.ts
@@ -2516,7 +2516,14 @@ export class Task {
 				// provider layer retries transients silently before any event
 				// exists. Context-window overruns are also excluded — they are
 				// recovered by truncation, not a provider failure.
-				if (!isContextWindowExceededError && !shouldRetry) {
+				// (`abort` gate: a user cancel unwinds through this catch as a
+				// generic "Cline instance aborted" error — never a provider
+				// failure, and the SDK extension doesn't report cancels either.)
+				if (
+					!isContextWindowExceededError &&
+					!shouldRetry &&
+					!this.taskState.abort
+				) {
 					telemetryService.captureProviderApiError({
 						ulid: this.ulid,
 						model: model.id,
@@ -3652,7 +3659,8 @@ export class Task {
 					// pre-stream failures from being counted twice.
 					if (
 						!this.taskState.isWaitingForFirstChunk &&
-						!willAutoRetryStreamingFailure
+						!willAutoRetryStreamingFailure &&
+						!this.taskState.abort
 					) {
 						const { providerId: midStreamProviderId } =
 							this.getCurrentProviderInfo();

--- a/apps/vscode/src/core/task/index.ts
+++ b/apps/vscode/src/core/task/index.ts
@@ -2511,11 +2511,11 @@ export class Task {
 				// Mirror the SDK extension's provider-failure reporting: same
 				// errorType/failurePhase schema so error rates are comparable
 				// across the A/B rollout cohorts. Emitted once per failed
-				// attempt; `terminal` marks whether this failure will surface
+				// attempt; `fatal` marks whether this failure will surface
 				// to the user (no auto-retry follows) — the SDK extension only
-				// ever reports terminal failures (transient errors are retried
+				// ever reports fatal failures (transient errors are retried
 				// inside its provider layer before any event fires), so
-				// cross-cohort comparisons must filter to terminal = true.
+				// cross-cohort comparisons must filter to fatal = true.
 				// Context-window overruns are excluded — they are recovered by
 				// truncation, not a provider failure.
 				if (!isContextWindowExceededError) {
@@ -2528,7 +2528,7 @@ export class Task {
 						requestId: clineError._error?.request_id,
 						errorType: ClineError.getErrorType(clineError),
 						failurePhase: "streaming",
-						terminal: !shouldRetry,
+						fatal: !shouldRetry,
 					});
 				}
 
@@ -3644,7 +3644,7 @@ export class Task {
 
 					// Mirror the SDK extension's provider-failure reporting for
 					// mid-stream failures (see attemptApiRequest for the
-					// first-chunk equivalent, including what `terminal` means and
+					// first-chunk equivalent, including what `fatal` means and
 					// why cross-cohort comparisons must filter on it).
 					// isWaitingForFirstChunk gate: first-chunk failures are
 					// already reported inside attemptApiRequest's catch, and a
@@ -3664,7 +3664,7 @@ export class Task {
 							requestId: clineError._error?.request_id,
 							errorType: ClineError.getErrorType(clineError),
 							failurePhase: "streaming",
-							terminal: !willAutoRetryStreamingFailure,
+							fatal: !willAutoRetryStreamingFailure,
 						});
 					}
 

--- a/apps/vscode/src/core/task/index.ts
+++ b/apps/vscode/src/core/task/index.ts
@@ -2402,25 +2402,6 @@ export class Task {
 			// Capture provider failure telemetry using clineError
 			ErrorService.get().logMessage(clineError.message);
 
-			// Mirror the SDK extension's provider-failure reporting: emit one
-			// task.provider_api_error per failed request attempt (auto-retries
-			// included), with the same errorType/failurePhase schema, so error
-			// rates are comparable across the A/B rollout cohorts. Context-window
-			// overruns are excluded — they are recovered by truncation, not a
-			// provider failure.
-			if (!isContextWindowExceededError) {
-				telemetryService.captureProviderApiError({
-					ulid: this.ulid,
-					model: model.id,
-					provider: providerId,
-					errorMessage: clineError.message,
-					errorStatus: clineError._error?.status,
-					requestId: clineError._error?.request_id,
-					errorType: ClineError.getErrorType(clineError),
-					failurePhase: "streaming",
-				});
-			}
-
 			if (
 				isContextWindowExceededError &&
 				!this.taskState.didAutomaticallyRetryFailedApiRequest
@@ -2526,6 +2507,31 @@ export class Task {
 					!isClinePassLimitError &&
 					!isClineFreeModelLimitError &&
 					this.taskState.autoRetryAttempts < 3;
+
+				// Mirror the SDK extension's provider-failure reporting: same
+				// errorType/failurePhase schema so error rates are comparable
+				// across the A/B rollout cohorts. Emitted once per failed
+				// attempt; `terminal` marks whether this failure will surface
+				// to the user (no auto-retry follows) — the SDK extension only
+				// ever reports terminal failures (transient errors are retried
+				// inside its provider layer before any event fires), so
+				// cross-cohort comparisons must filter to terminal = true.
+				// Context-window overruns are excluded — they are recovered by
+				// truncation, not a provider failure.
+				if (!isContextWindowExceededError) {
+					telemetryService.captureProviderApiError({
+						ulid: this.ulid,
+						model: model.id,
+						provider: providerId,
+						errorMessage: clineError.message,
+						errorStatus: clineError._error?.status,
+						requestId: clineError._error?.request_id,
+						errorType: ClineError.getErrorType(clineError),
+						failurePhase: "streaming",
+						terminal: !shouldRetry,
+					});
+				}
+
 				if (shouldRetry) {
 					// Auto-retry enabled with max 3 attempts: automatically approve the retry
 					this.taskState.autoRetryAttempts++;
@@ -3616,9 +3622,30 @@ export class Task {
 					);
 					const errorMessage = clineError.serialize();
 
+					const isStreamingSpendLimitError = clineError.isErrorType(
+						ClineErrorType.SpendLimit,
+					);
+					// Inference cap and daily free-model limits reset in hours, so
+					// retrying only burns backoff before surfacing the actionable UI.
+					// Mirrors the non-streaming gating in attemptApiRequest.
+					const isStreamingQuotaExceededError = clineError.isErrorType(
+						ClineErrorType.QuotaExceeded,
+					);
+					const isStreamingClineFreeModelLimitError = clineError.isErrorType(
+						ClineErrorType.ClineFreeModelLimit,
+					);
+					const isStreamingNonRetriableError =
+						isStreamingSpendLimitError ||
+						isStreamingQuotaExceededError ||
+						isStreamingClineFreeModelLimitError;
+					const willAutoRetryStreamingFailure =
+						!isStreamingNonRetriableError &&
+						this.taskState.autoRetryAttempts < 3;
+
 					// Mirror the SDK extension's provider-failure reporting for
 					// mid-stream failures (see attemptApiRequest for the
-					// first-chunk equivalent). One event per failed attempt.
+					// first-chunk equivalent, including what `terminal` means and
+					// why cross-cohort comparisons must filter on it).
 					// isWaitingForFirstChunk gate: first-chunk failures are
 					// already reported inside attemptApiRequest's catch, and a
 					// declined retry rethrows a generic error that unwinds to
@@ -3637,30 +3664,12 @@ export class Task {
 							requestId: clineError._error?.request_id,
 							errorType: ClineError.getErrorType(clineError),
 							failurePhase: "streaming",
+							terminal: !willAutoRetryStreamingFailure,
 						});
 					}
 
-					const isStreamingSpendLimitError = clineError.isErrorType(
-						ClineErrorType.SpendLimit,
-					);
-					// Inference cap and daily free-model limits reset in hours, so
-					// retrying only burns backoff before surfacing the actionable UI.
-					// Mirrors the non-streaming gating in attemptApiRequest.
-					const isStreamingQuotaExceededError = clineError.isErrorType(
-						ClineErrorType.QuotaExceeded,
-					);
-					const isStreamingClineFreeModelLimitError = clineError.isErrorType(
-						ClineErrorType.ClineFreeModelLimit,
-					);
-					const isStreamingNonRetriableError =
-						isStreamingSpendLimitError ||
-						isStreamingQuotaExceededError ||
-						isStreamingClineFreeModelLimitError;
 					// Auto-retry for streaming failures (skip for non-retriable errors)
-					if (
-						!isStreamingNonRetriableError &&
-						this.taskState.autoRetryAttempts < 3
-					) {
+					if (willAutoRetryStreamingFailure) {
 						this.taskState.autoRetryAttempts++;
 
 						// Calculate exponential backoff for streaming failures: 2s, 4s, 8s

--- a/apps/vscode/src/core/task/index.ts
+++ b/apps/vscode/src/core/task/index.ts
@@ -2402,6 +2402,25 @@ export class Task {
 			// Capture provider failure telemetry using clineError
 			ErrorService.get().logMessage(clineError.message);
 
+			// Mirror the SDK extension's provider-failure reporting: emit one
+			// task.provider_api_error per failed request attempt (auto-retries
+			// included), with the same errorType/failurePhase schema, so error
+			// rates are comparable across the A/B rollout cohorts. Context-window
+			// overruns are excluded — they are recovered by truncation, not a
+			// provider failure.
+			if (!isContextWindowExceededError) {
+				telemetryService.captureProviderApiError({
+					ulid: this.ulid,
+					model: model.id,
+					provider: providerId,
+					errorMessage: clineError.message,
+					errorStatus: clineError._error?.status,
+					requestId: clineError._error?.request_id,
+					errorType: ClineError.getErrorType(clineError),
+					failurePhase: "streaming",
+				});
+			}
+
 			if (
 				isContextWindowExceededError &&
 				!this.taskState.didAutomaticallyRetryFailedApiRequest
@@ -3596,6 +3615,25 @@ export class Task {
 						this.api.getModel().id,
 					);
 					const errorMessage = clineError.serialize();
+
+					// Mirror the SDK extension's provider-failure reporting for
+					// mid-stream failures (see attemptApiRequest for the
+					// first-chunk equivalent). One event per failed attempt.
+					{
+						const { providerId: midStreamProviderId } =
+							this.getCurrentProviderInfo();
+						telemetryService.captureProviderApiError({
+							ulid: this.ulid,
+							model: this.api.getModel().id,
+							provider: midStreamProviderId,
+							errorMessage: clineError.message,
+							errorStatus: clineError._error?.status,
+							requestId: clineError._error?.request_id,
+							errorType: ClineError.getErrorType(clineError),
+							failurePhase: "streaming",
+						});
+					}
+
 					const isStreamingSpendLimitError = clineError.isErrorType(
 						ClineErrorType.SpendLimit,
 					);

--- a/apps/vscode/src/core/task/index.ts
+++ b/apps/vscode/src/core/task/index.ts
@@ -2510,15 +2510,13 @@ export class Task {
 
 				// Mirror the SDK extension's provider-failure reporting: same
 				// errorType/failurePhase schema so error rates are comparable
-				// across the A/B rollout cohorts. Emitted once per failed
-				// attempt; `fatal` marks whether this failure will surface
-				// to the user (no auto-retry follows) — the SDK extension only
-				// ever reports fatal failures (transient errors are retried
-				// inside its provider layer before any event fires), so
-				// cross-cohort comparisons must filter to fatal = true.
-				// Context-window overruns are excluded — they are recovered by
-				// truncation, not a provider failure.
-				if (!isContextWindowExceededError) {
+				// across the A/B rollout cohorts. Only failures that actually
+				// surface to the user are reported — attempts an auto-retry
+				// absorbs emit nothing, matching the SDK extension, whose
+				// provider layer retries transients silently before any event
+				// exists. Context-window overruns are also excluded — they are
+				// recovered by truncation, not a provider failure.
+				if (!isContextWindowExceededError && !shouldRetry) {
 					telemetryService.captureProviderApiError({
 						ulid: this.ulid,
 						model: model.id,
@@ -2528,7 +2526,6 @@ export class Task {
 						requestId: clineError._error?.request_id,
 						errorType: ClineError.getErrorType(clineError),
 						failurePhase: "streaming",
-						fatal: !shouldRetry,
 					});
 				}
 
@@ -3644,15 +3641,19 @@ export class Task {
 
 					// Mirror the SDK extension's provider-failure reporting for
 					// mid-stream failures (see attemptApiRequest for the
-					// first-chunk equivalent, including what `fatal` means and
-					// why cross-cohort comparisons must filter on it).
+					// first-chunk equivalent). Only failures that surface to
+					// the user are reported — auto-retried attempts emit
+					// nothing, matching the SDK extension.
 					// isWaitingForFirstChunk gate: first-chunk failures are
 					// already reported inside attemptApiRequest's catch, and a
 					// declined retry rethrows a generic error that unwinds to
 					// this catch — the flag is only cleared after the first
 					// chunk yields, so it cleanly excludes those re-thrown
 					// pre-stream failures from being counted twice.
-					if (!this.taskState.isWaitingForFirstChunk) {
+					if (
+						!this.taskState.isWaitingForFirstChunk &&
+						!willAutoRetryStreamingFailure
+					) {
 						const { providerId: midStreamProviderId } =
 							this.getCurrentProviderInfo();
 						telemetryService.captureProviderApiError({
@@ -3664,7 +3665,6 @@ export class Task {
 							requestId: clineError._error?.request_id,
 							errorType: ClineError.getErrorType(clineError),
 							failurePhase: "streaming",
-							fatal: !willAutoRetryStreamingFailure,
 						});
 					}
 
@@ -3909,15 +3909,20 @@ export class Task {
 				const { model, providerId } = this.getCurrentProviderInfo();
 				const reqId = this.getApiRequestIdSafe();
 
-				// Minimal diagnostics: structured log and telemetry
-				telemetryService.captureProviderApiError({
-					ulid: this.ulid,
-					model: model.id,
-					provider: providerId,
-					errorMessage: "empty_assistant_message",
-					requestId: reqId,
-					isNativeToolCall: this.useNativeToolCalls,
-				});
+				// Minimal diagnostics: structured log and telemetry. Reported
+				// only when no auto-retry follows, consistent with the other
+				// provider-failure sites — occurrences an auto-retry absorbs
+				// emit nothing.
+				if (this.taskState.autoRetryAttempts >= 3) {
+					telemetryService.captureProviderApiError({
+						ulid: this.ulid,
+						model: model.id,
+						provider: providerId,
+						errorMessage: "empty_assistant_message",
+						requestId: reqId,
+						isNativeToolCall: this.useNativeToolCalls,
+					});
+				}
 
 				const baseErrorMessage =
 					"Invalid API Response: The provider returned an empty or unparsable response. This is a provider-side issue where the model failed to generate valid output or returned tool calls that Cline cannot process. Retrying the request may help resolve this issue.";

--- a/apps/vscode/src/services/telemetry/TelemetryService.ts
+++ b/apps/vscode/src/services/telemetry/TelemetryService.ts
@@ -1412,9 +1412,13 @@ export class TelemetryService {
 		// dashboards can compare cohorts on identical event shapes.
 		// errorType follows ClineErrorType values ("auth", "balance",
 		// "rateLimit", ...); failurePhase follows the SDK extension's
-		// vocabulary ("preflight" | "streaming").
+		// vocabulary ("preflight" | "streaming"). terminal is false for
+		// attempts that will be auto-retried — the SDK extension only reports
+		// terminal failures, so cross-cohort comparisons must filter
+		// terminal = true.
 		errorType?: string | undefined
 		failurePhase?: string | undefined
+		terminal?: boolean
 		isNativeToolCall?: boolean
 	}) {
 		this.capture({

--- a/apps/vscode/src/services/telemetry/TelemetryService.ts
+++ b/apps/vscode/src/services/telemetry/TelemetryService.ts
@@ -1412,13 +1412,12 @@ export class TelemetryService {
 		// dashboards can compare cohorts on identical event shapes.
 		// errorType follows ClineErrorType values ("auth", "balance",
 		// "rateLimit", ...); failurePhase follows the SDK extension's
-		// vocabulary ("preflight" | "streaming"). fatal is false for
-		// attempts that will be auto-retried — the SDK extension only reports
-		// fatal failures, so cross-cohort comparisons must filter
-		// fatal = true.
+		// vocabulary ("preflight" | "streaming"). Call sites only report
+		// failures that surfaced to the user (no auto-retry followed) — the
+		// SDK extension can only ever see those, so this keeps the cohorts
+		// comparable without any query-side filtering.
 		errorType?: string | undefined
 		failurePhase?: string | undefined
-		fatal?: boolean
 		isNativeToolCall?: boolean
 	}) {
 		this.capture({

--- a/apps/vscode/src/services/telemetry/TelemetryService.ts
+++ b/apps/vscode/src/services/telemetry/TelemetryService.ts
@@ -1408,6 +1408,13 @@ export class TelemetryService {
 		provider?: string
 		errorStatus?: number | undefined
 		requestId?: string | undefined
+		// Mirror the SDK extension's provider-failure schema so the A/B rollout
+		// dashboards can compare cohorts on identical event shapes.
+		// errorType follows ClineErrorType values ("auth", "balance",
+		// "rateLimit", ...); failurePhase follows the SDK extension's
+		// vocabulary ("preflight" | "streaming").
+		errorType?: string | undefined
+		failurePhase?: string | undefined
 		isNativeToolCall?: boolean
 	}) {
 		this.capture({
@@ -1424,12 +1431,16 @@ export class TelemetryService {
 			model: args.model,
 			provider: args.provider,
 			error_status: args.errorStatus,
+			error_type: args.errorType,
+			failure_phase: args.failurePhase,
 		})
 		const errorAttributes = {
 			ulid: args.ulid,
 			model: args.model,
 			provider: args.provider,
 			error_status: args.errorStatus,
+			error_type: args.errorType,
+			failure_phase: args.failurePhase,
 		}
 		const errorCount = this.incrementTaskCounter(this.taskErrorCounts, args.ulid)
 		this.recordHistogram(TelemetryService.METRICS.ERRORS.PER_TASK, errorCount, errorAttributes)

--- a/apps/vscode/src/services/telemetry/TelemetryService.ts
+++ b/apps/vscode/src/services/telemetry/TelemetryService.ts
@@ -1412,13 +1412,13 @@ export class TelemetryService {
 		// dashboards can compare cohorts on identical event shapes.
 		// errorType follows ClineErrorType values ("auth", "balance",
 		// "rateLimit", ...); failurePhase follows the SDK extension's
-		// vocabulary ("preflight" | "streaming"). terminal is false for
+		// vocabulary ("preflight" | "streaming"). fatal is false for
 		// attempts that will be auto-retried — the SDK extension only reports
-		// terminal failures, so cross-cohort comparisons must filter
-		// terminal = true.
+		// fatal failures, so cross-cohort comparisons must filter
+		// fatal = true.
 		errorType?: string | undefined
 		failurePhase?: string | undefined
-		terminal?: boolean
+		fatal?: boolean
 		isNativeToolCall?: boolean
 	}) {
 		this.capture({

--- a/apps/vscode/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
+++ b/apps/vscode/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
@@ -343,7 +343,16 @@ describe("TelemetryService metrics", () => {
 			errorMessage: "boom",
 			provider: "anthropic",
 			errorStatus: 500,
+			errorType: "auth",
+			failurePhase: "streaming",
 		})
+
+		// The event carries the SDK-extension-parity schema fields so the A/B
+		// rollout dashboards can compare cohorts on identical shapes.
+		const failureEvent = provider.logs.find((entry) => entry.event === "task.provider_api_error")
+		assert.ok(failureEvent, "expected task.provider_api_error event")
+		assert.strictEqual(failureEvent?.properties?.errorType, "auth")
+		assert.strictEqual(failureEvent?.properties?.failurePhase, "streaming")
 
 		assert.strictEqual(provider.counters.length, 1)
 		const entry = provider.counters[0]
@@ -353,6 +362,8 @@ describe("TelemetryService metrics", () => {
 		assert.strictEqual(entry.attributes.provider, "anthropic")
 		assert.strictEqual(entry.attributes.model, "claude")
 		assert.strictEqual(entry.attributes.error_status, 500)
+		assert.strictEqual(entry.attributes.error_type, "auth")
+		assert.strictEqual(entry.attributes.failure_phase, "streaming")
 		assert.strictEqual(provider.histograms.length, 1)
 		const errorHistogram = provider.histograms[0]
 		assert.strictEqual(errorHistogram.name, TelemetryService.METRICS.ERRORS.PER_TASK)
@@ -361,6 +372,8 @@ describe("TelemetryService metrics", () => {
 		assert.strictEqual(errorHistogram.attributes.provider, "anthropic")
 		assert.strictEqual(errorHistogram.attributes.model, "claude")
 		assert.strictEqual(errorHistogram.attributes.error_status, 500)
+		assert.strictEqual(errorHistogram.attributes.error_type, "auth")
+		assert.strictEqual(errorHistogram.attributes.failure_phase, "streaming")
 	})
 
 	it("captureTaskCompleted records completion payload with TTFT and duration histograms", () => {

--- a/apps/vscode/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
+++ b/apps/vscode/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
@@ -345,7 +345,6 @@ describe("TelemetryService metrics", () => {
 			errorStatus: 500,
 			errorType: "auth",
 			failurePhase: "streaming",
-			fatal: true,
 		})
 
 		// The event carries the SDK-extension-parity schema fields so the A/B
@@ -354,7 +353,6 @@ describe("TelemetryService metrics", () => {
 		assert.ok(failureEvent, "expected task.provider_api_error event")
 		assert.strictEqual(failureEvent?.properties?.errorType, "auth")
 		assert.strictEqual(failureEvent?.properties?.failurePhase, "streaming")
-		assert.strictEqual(failureEvent?.properties?.fatal, true)
 
 		assert.strictEqual(provider.counters.length, 1)
 		const entry = provider.counters[0]

--- a/apps/vscode/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
+++ b/apps/vscode/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
@@ -345,7 +345,7 @@ describe("TelemetryService metrics", () => {
 			errorStatus: 500,
 			errorType: "auth",
 			failurePhase: "streaming",
-			terminal: true,
+			fatal: true,
 		})
 
 		// The event carries the SDK-extension-parity schema fields so the A/B
@@ -354,7 +354,7 @@ describe("TelemetryService metrics", () => {
 		assert.ok(failureEvent, "expected task.provider_api_error event")
 		assert.strictEqual(failureEvent?.properties?.errorType, "auth")
 		assert.strictEqual(failureEvent?.properties?.failurePhase, "streaming")
-		assert.strictEqual(failureEvent?.properties?.terminal, true)
+		assert.strictEqual(failureEvent?.properties?.fatal, true)
 
 		assert.strictEqual(provider.counters.length, 1)
 		const entry = provider.counters[0]

--- a/apps/vscode/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
+++ b/apps/vscode/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
@@ -345,6 +345,7 @@ describe("TelemetryService metrics", () => {
 			errorStatus: 500,
 			errorType: "auth",
 			failurePhase: "streaming",
+			terminal: true,
 		})
 
 		// The event carries the SDK-extension-parity schema fields so the A/B
@@ -353,6 +354,7 @@ describe("TelemetryService metrics", () => {
 		assert.ok(failureEvent, "expected task.provider_api_error event")
 		assert.strictEqual(failureEvent?.properties?.errorType, "auth")
 		assert.strictEqual(failureEvent?.properties?.failurePhase, "streaming")
+		assert.strictEqual(failureEvent?.properties?.terminal, true)
 
 		assert.strictEqual(provider.counters.length, 1)
 		const entry = provider.counters[0]


### PR DESCRIPTION
### Related Issue

Day-one monitoring of the stable A/B rollout (claude-dev 4.1.x). Supersedes the closed #12809, which took the opposite approach (renaming next's event) before we changed direction.

### Description

**The problem.** Dash 17 compares error rates between the rollout cohorts under `task.provider_api_error`, split by `extension_variant`. Day one showed next at **36.25% of tasks vs legacy at 4.22%** — which looked like a catastrophic SDK-extension regression and is actually a measurement artifact: the two codebases emit that event with completely different coverage.

- **Legacy** (before this PR) had exactly ONE task-scoped emission site, firing only for empty/unparsable assistant responses (`empty_assistant_message`). Real API failures — 401s, 429s, balance errors, network failures — flow through the `api_req_failed` / streaming-retry paths, which emitted **no telemetry at all**. Notably this means legacy had NO baseline for auth-error incidence: during the investigation of a cluster of Cline-auth errors on promoted machines ("Please sign in to Cline", "Missing Authentication header" — ~5% of next tasks), "legacy shows zero" turned out to be structural blindness, not evidence.
- **Next** reports every provider failure surfaced by the SDK session layer, with `errorType`/`failurePhase` classification.

**The fix (this PR): bring legacy's reporting up to next's coverage** rather than dumbing next's down. Two new emission sites, both at points where a `ClineError` is already constructed:

1. **First-chunk failure** (`attemptApiRequest` catch): fires when a request fails and no auto-retry follows. Context-window-exceeded errors are excluded: they're recovered by truncation and are not provider failures.
2. **Mid-stream failure** (`recursivelyMakeClineRequests` stream catch, non-abandoned path): same schema and rule, covering failures after streaming began.

**Surfaced-failures-only rule (the comparability keystone — simplified from an earlier `fatal` flag revision).** Legacy's retry loop sees every attempt; next's provider layer (ai-sdk inside `@cline/llms`) silently retries transients and only ever surfaces run-deaths. Reported raw per-attempt, identical user experiences would make legacy read worse (it counts a recovered 429, next counts nothing). Rather than stamping a `fatal` flag and requiring every query to filter on it, all emission sites simply **emit nothing when an auto-retry absorbs the failure** — only failures the user actually experienced are reported, which is the only thing next can report. Both cohorts measure the same quantity by construction; no query-side filtering, no dbt column, no dashboard changes needed. The pre-existing empty-response site is gated by the same rule (auto-retried occurrences no longer emit); its schema is otherwise untouched.

**Schema parity.** `captureProviderApiError` gains optional `errorType` and `failurePhase`, mirrored into the `errors.total` counter and per-task histogram attributes exactly as next does. `errorType` comes from the existing `ClineError.getErrorType()` classification (`auth`, `balance`, `rateLimit`, `quotaExceeded`, ...) — legacy's taxonomy is actually richer than next's here, and critically it emits `auth`, which gives us the missing legacy-side auth baseline. `failurePhase` uses next's vocabulary (`"streaming"` for both sites; legacy has no session-preflight equivalent).

**What this deliberately does NOT do:**
- No new events, no renames — dash 17/19 and the gold models keep working unchanged (`error_type`/`failure_phase` appear as new attributes, additive).
- No changes to user-facing behavior: telemetry only. The retry logic, error UI, and ask flows are untouched.
- Next's wrapping of tool-call failures under this event is NOT replicated — legacy already reports those under `task.tool_used(failed)`. That residual asymmetry is small and arguably next's bug; noted for a future cleanup on main.
- No `preflight`/task-init instrumentation on legacy (no equivalent lifecycle stage).

### Dashboard/rollout implications (@max)

- When this ships (inside the next combined 4.1.x release — the legacy bundle is built from this branch's tip, no standalone legacy publish needed), the **Legacy error-rate line on dash 17 steps UP sharply** — from ~4% to presumably the same neighborhood as next's ~36%. That's this PR turning the lights on, not a regression. Needs an annotation/heads-up so nobody panics.
- The "(Prod)" cards (variant-less standalone 4.0.12 users) keep the old narrow semantics until those users migrate to 4.1.x — expect Prod and Legacy-variant to diverge on this event from here on. The Legacy-variant line becomes the meaningful baseline.
- After a day or two of data, the next-vs-legacy comparison on this event becomes genuinely meaningful for the first time — including an apples-to-apples read on the auth-error cluster (if legacy shows a similar background rate of `errorType=auth`, the promotion-auth investigation downgrades to "pre-existing background noise, newly visible").
- The dbt silver/gold error tables already ingest `errorType` (it lands as `error_subtype`), so legacy's classification flows through automatically. No dbt or dashboard-card changes are needed — the surfaced-failures-only rule makes the existing cards apples-to-apples on their own.

### Test Procedure

- `tsc --noEmit` clean on the legacy tsconfig.
- Extended the existing `captureProviderApiError` unit test: asserts the event carries `errorType`/`failurePhase` and that both counter and histogram attributes include `error_type`/`failure_phase` — passing via the legacy mocha runner (full unit suite: 1557 passing).
- Both new emission sites reuse the already-constructed `ClineError` at each catch (no new error handling, no behavior change); `_error.status`/`_error.request_id` access follows the existing pattern in `ClineError.getErrorType`.
- ⚠️ Reminder for reviewers: PRs targeting `legacy-extension` skip the real test workflows (the green "Run Tests" check is a no-op for non-main targets) — the verification above was run locally; the full npm suite runs for real in `ext-vscode-ab-package`'s `test-legacy` gate before any release ships this.

