### PR TITLE
refactor(llms): classify typed AI SDK errors before the structural walk

### DIFF
--- a/sdk/packages/llms/src/providers/error-classification.test.ts
+++ b/sdk/packages/llms/src/providers/error-classification.test.ts
@@ -222,6 +222,28 @@ describe("classifyProviderError", () => {
 			expect(classifyProviderError(error)).toBe("unknown");
 		});
 
+		it("treats the typed statusCode as authoritative: an explicit overflow code cannot override it", () => {
+			const withStatus = (statusCode: number) =>
+				new APICallError({
+					message: "Request failed",
+					url: "https://api.openai.com/v1/chat/completions",
+					requestBodyValues: {},
+					statusCode,
+					responseBody: JSON.stringify({
+						error: {
+							message: "This model's maximum context length is 128000 tokens.",
+							code: "context_length_exceeded",
+						},
+					}),
+				});
+			expect(classifyProviderError(withStatus(429))).toBe("unknown");
+			expect(classifyProviderError(withStatus(500))).toBe("unknown");
+			// The gate must not swallow genuine overflow rejections.
+			expect(classifyProviderError(withStatus(400))).toBe(
+				"context_window_exceeded",
+			);
+		});
+
 		it("unwraps a RetryError to its last attempt's error", () => {
 			const error = new RetryError({
 				message: "Failed after 3 attempts.",

--- a/sdk/packages/llms/src/providers/error-classification.test.ts
+++ b/sdk/packages/llms/src/providers/error-classification.test.ts
@@ -231,6 +231,55 @@ describe("classifyProviderError", () => {
 			expect(classifyProviderError(error)).toBe("context_window_exceeded");
 		});
 
+		it("classifies an untyped final RetryError attempt without earlier attempts vetoing it", () => {
+			// Attempt 1 was a retryable 429; the final attempt is a plain
+			// (untyped) overflow rejection. The earlier rate limit must not
+			// veto the final attempt's verdict.
+			const error = new RetryError({
+				message: "Failed after 2 attempts.",
+				reason: "errorNotRetryable",
+				errors: [
+					new APICallError({
+						message: "Too Many Requests",
+						url: "https://api.anthropic.com/v1/messages",
+						requestBodyValues: {},
+						statusCode: 429,
+						responseBody: JSON.stringify({
+							error: {
+								type: "rate_limit_error",
+								message: "Rate limit reached.",
+							},
+						}),
+					}),
+					{
+						status: 400,
+						error: {
+							type: "invalid_request_error",
+							message: "prompt is too long: 213462 tokens > 200000 maximum",
+						},
+					},
+				],
+			});
+			expect(classifyProviderError(error)).toBe("context_window_exceeded");
+		});
+
+		it("does not let earlier RetryError attempts fake an overflow for an untyped final attempt", () => {
+			const error = new RetryError({
+				message: "Failed after 2 attempts.",
+				reason: "errorNotRetryable",
+				errors: [
+					{
+						status: 400,
+						error: {
+							message: "prompt is too long: 213462 tokens > 200000 maximum",
+						},
+					},
+					new Error("fetch failed: other side closed"),
+				],
+			});
+			expect(classifyProviderError(error)).toBe("unknown");
+		});
+
 		it("classifies a TypeValidationError by the gateway payload in value", () => {
 			// A real instance of the ENG-2394 failure: the Vercel gateway streams
 			// the upstream rejection as the value that failed schema validation.

--- a/sdk/packages/llms/src/providers/error-classification.test.ts
+++ b/sdk/packages/llms/src/providers/error-classification.test.ts
@@ -1,3 +1,9 @@
+import {
+	APICallError,
+	NoOutputGeneratedError,
+	RetryError,
+	TypeValidationError,
+} from "ai";
 import { describe, expect, it } from "vitest";
 import { classifyProviderError } from "./error-classification";
 
@@ -161,6 +167,100 @@ describe("classifyProviderError", () => {
 			const cyclic: Record<string, unknown> = { message: "boom" };
 			cyclic.cause = cyclic;
 			expect(classifyProviderError(cyclic)).toBe("unknown");
+		});
+	});
+
+	describe("typed AI SDK error instances", () => {
+		const overflowApiCallError = () =>
+			new APICallError({
+				message: "Bad Request",
+				url: "https://api.anthropic.com/v1/messages",
+				requestBodyValues: {},
+				statusCode: 400,
+				responseBody: JSON.stringify({
+					type: "error",
+					error: {
+						type: "invalid_request_error",
+						message: "prompt is too long: 213462 tokens > 200000 maximum",
+					},
+				}),
+			});
+
+		it("classifies an APICallError 400 with a prompt-too-long body", () => {
+			expect(classifyProviderError(overflowApiCallError())).toBe(
+				"context_window_exceeded",
+			);
+		});
+
+		it("treats the typed statusCode as authoritative: 429 vetoes token wording", () => {
+			const error = new APICallError({
+				message: "Too Many Requests",
+				url: "https://api.anthropic.com/v1/messages",
+				requestBodyValues: {},
+				statusCode: 429,
+				responseBody: JSON.stringify({
+					error: {
+						message: "Request tokens exceed your available quota.",
+					},
+				}),
+			});
+			expect(classifyProviderError(error)).toBe("unknown");
+		});
+
+		it("treats the typed statusCode as authoritative: 500 vetoes context wording", () => {
+			const error = new APICallError({
+				message: "Internal Server Error",
+				url: "https://api.openai.com/v1/chat/completions",
+				requestBodyValues: {},
+				statusCode: 500,
+				responseBody: JSON.stringify({
+					error: {
+						message: "internal error computing maximum context length",
+					},
+				}),
+			});
+			expect(classifyProviderError(error)).toBe("unknown");
+		});
+
+		it("unwraps a RetryError to its last attempt's error", () => {
+			const error = new RetryError({
+				message: "Failed after 3 attempts.",
+				reason: "maxRetriesExceeded",
+				errors: [new Error("fetch failed"), overflowApiCallError()],
+			});
+			expect(classifyProviderError(error)).toBe("context_window_exceeded");
+		});
+
+		it("classifies a TypeValidationError by the gateway payload in value", () => {
+			// A real instance of the ENG-2394 failure: the Vercel gateway streams
+			// the upstream rejection as the value that failed schema validation.
+			const error = new TypeValidationError({
+				value: {
+					error_type: "validation_error",
+					error_message: JSON.stringify({
+						error: {
+							message:
+								"This model's maximum context length is 40960 tokens. However, you requested 100 output tokens and your prompt contains at least 40861 input tokens.",
+							code: 400,
+						},
+					}),
+				},
+				cause: Object.assign(
+					new Error(
+						'[\n  {\n    "code": "invalid_union",\n    "path": [],\n    "message": "Invalid input"\n  }\n]',
+					),
+					{ name: "ZodError" },
+				),
+			});
+			expect(classifyProviderError(error)).toBe("context_window_exceeded");
+		});
+
+		it("recurses through a generic AISDKError wrapper's cause", () => {
+			const error = new NoOutputGeneratedError({
+				message: "No output generated.",
+				cause: overflowApiCallError(),
+			});
+			expect(classifyProviderError(error)).toBe("context_window_exceeded");
 		});
 	});
 });

--- a/sdk/packages/llms/src/providers/error-classification.ts
+++ b/sdk/packages/llms/src/providers/error-classification.ts
@@ -230,16 +230,21 @@ function classifyTypedError(
 		);
 	}
 	if (APICallError.isInstance(error)) {
+		// The typed statusCode is the sole authoritative status and gates the
+		// whole verdict: nothing in the payload — not even an explicit
+		// overflow code echoed inside a rate-limit or server-failure body —
+		// out-votes the HTTP layer. Absent a statusCode, the payload decides.
+		const status =
+			typeof error.statusCode === "number" ? error.statusCode : undefined;
+		if (status !== undefined && !CONTEXT_WINDOW_STATUSES.has(status)) {
+			return "unknown";
+		}
 		const signals = collectSignalsFrom([
 			error.message,
 			error.responseBody,
 			error.data,
 		]);
-		// The typed statusCode is the sole authoritative status: statuses
-		// quoted inside the response text must not out-vote the HTTP layer.
-		signals.statuses = new Set(
-			typeof error.statusCode === "number" ? [error.statusCode] : [],
-		);
+		signals.statuses = new Set(status !== undefined ? [status] : []);
 		return verdictFromSignals(signals);
 	}
 	if (TypeValidationError.isInstance(error)) {

--- a/sdk/packages/llms/src/providers/error-classification.ts
+++ b/sdk/packages/llms/src/providers/error-classification.ts
@@ -216,8 +216,18 @@ function classifyTypedError(
 	// Specific classes before the generic guard — every AI SDK error
 	// subclasses AISDKError, so the generic check would swallow them.
 	if (RetryError.isInstance(error)) {
+		// Only the final attempt decides the verdict: earlier attempts were
+		// retried away (typically rate limits) and must neither veto nor fake
+		// its classification — so an untyped final error is walked alone
+		// rather than falling back to the whole wrapper's `errors` array.
 		const last = error.lastError ?? error.errors[error.errors.length - 1];
-		return classifyTypedError(last, depth + 1);
+		if (last == null) {
+			return undefined;
+		}
+		return (
+			classifyTypedError(last, depth + 1) ??
+			verdictFromSignals(collectSignalsFrom([last]))
+		);
 	}
 	if (APICallError.isInstance(error)) {
 		const signals = collectSignalsFrom([

--- a/sdk/packages/llms/src/providers/error-classification.ts
+++ b/sdk/packages/llms/src/providers/error-classification.ts
@@ -1,4 +1,5 @@
 import { type ProviderErrorClass, safeJsonParse } from "@cline/shared";
+import { AISDKError, APICallError, RetryError, TypeValidationError } from "ai";
 
 /**
  * Provider codes that unambiguously identify a context-window overflow
@@ -144,28 +145,13 @@ function collectSignals(
 }
 
 /**
- * Classify a raw provider error (or an already-flattened error message) into
- * a {@link ProviderErrorClass}. Call this where the structured error object
- * is still available — `extractErrorMessage` discards the structure this
- * classification relies on.
- *
- * Detection is deliberately conservative: a context-window verdict requires
- * an overflow message pattern (or explicit provider code), no rate-limit
- * signal, and — when any HTTP status is visible — an invalid-request-family
- * status.
+ * Apply the detection rules to collected signals. Shared between the typed
+ * AI SDK pre-pass and the structural walk so both paths classify identically:
+ * a context-window verdict requires an overflow message pattern (or explicit
+ * provider code), no rate-limit signal, and — when any HTTP status is
+ * visible — an invalid-request-family status.
  */
-export function classifyProviderError(error: unknown): ProviderErrorClass {
-	const signals: ErrorSignals = {
-		messages: [],
-		statuses: new Set(),
-		codes: new Set(),
-	};
-	try {
-		collectSignals(error, signals, new Set(), 0);
-	} catch {
-		return "unknown";
-	}
-
+function verdictFromSignals(signals: ErrorSignals): ProviderErrorClass {
 	if ([...signals.codes].some((code) => CONTEXT_WINDOW_CODES.has(code))) {
 		return "context_window_exceeded";
 	}
@@ -194,4 +180,100 @@ export function classifyProviderError(error: unknown): ProviderErrorClass {
 		return "context_window_exceeded";
 	}
 	return "unknown";
+}
+
+function collectSignalsFrom(values: readonly unknown[]): ErrorSignals {
+	const signals: ErrorSignals = {
+		messages: [],
+		statuses: new Set(),
+		codes: new Set(),
+	};
+	const visited = new Set<unknown>();
+	for (const value of values) {
+		collectSignals(value, signals, visited, 0);
+	}
+	return signals;
+}
+
+/**
+ * Classify errors that are real AI SDK error instances, using their typed
+ * fields instead of guessing at shape. Returns `undefined` when the error is
+ * not a recognized instance (or a typed wrapper leads nowhere), so the caller
+ * falls back to the structural walk.
+ *
+ * `isInstance()` is the AI SDK's symbol-based guard, so it holds across
+ * duplicated package copies — but it can never match gateway-forwarded plain
+ * JSON payloads that merely *name* an AI SDK error (ENG-2394); those stay the
+ * structural walk's job.
+ */
+function classifyTypedError(
+	error: unknown,
+	depth: number,
+): ProviderErrorClass | undefined {
+	if (depth > MAX_WALK_DEPTH) {
+		return undefined;
+	}
+	// Specific classes before the generic guard — every AI SDK error
+	// subclasses AISDKError, so the generic check would swallow them.
+	if (RetryError.isInstance(error)) {
+		const last = error.lastError ?? error.errors[error.errors.length - 1];
+		return classifyTypedError(last, depth + 1);
+	}
+	if (APICallError.isInstance(error)) {
+		const signals = collectSignalsFrom([
+			error.message,
+			error.responseBody,
+			error.data,
+		]);
+		// The typed statusCode is the sole authoritative status: statuses
+		// quoted inside the response text must not out-vote the HTTP layer.
+		signals.statuses = new Set(
+			typeof error.statusCode === "number" ? [error.statusCode] : [],
+		);
+		return verdictFromSignals(signals);
+	}
+	if (TypeValidationError.isInstance(error)) {
+		// `value` holds the payload that failed validation — for gateway
+		// streams, the upstream provider rejection.
+		const verdict = verdictFromSignals(collectSignalsFrom([error.value]));
+		return verdict === "context_window_exceeded" ? verdict : undefined;
+	}
+	if (AISDKError.isInstance(error)) {
+		const verdict = classifyTypedError(error.cause, depth + 1);
+		return verdict === "context_window_exceeded" ? verdict : undefined;
+	}
+	return undefined;
+}
+
+/**
+ * Classify a raw provider error (or an already-flattened error message) into
+ * a {@link ProviderErrorClass}. Call this where the structured error object
+ * is still available — `extractErrorMessage` discards the structure this
+ * classification relies on.
+ *
+ * Typed AI SDK error instances are classified first via their typed fields;
+ * everything else — including plain JSON payloads that only *look* like AI
+ * SDK errors — goes through the conservative structural walk.
+ */
+export function classifyProviderError(error: unknown): ProviderErrorClass {
+	try {
+		const typed = classifyTypedError(error, 0);
+		if (typed !== undefined) {
+			return typed;
+		}
+	} catch {
+		// Fall through to the structural walk.
+	}
+
+	const signals: ErrorSignals = {
+		messages: [],
+		statuses: new Set(),
+		codes: new Set(),
+	};
+	try {
+		collectSignals(error, signals, new Set(), 0);
+	} catch {
+		return "unknown";
+	}
+	return verdictFromSignals(signals);
 }


### PR DESCRIPTION
> [!NOTE]
> Originally stacked on #12804 (now merged); rebased onto `main`.

## Description

Follow-up to #12804 agreed in [ENG-2394](https://linear.app/cline-bot/issue/ENG-2394/vercel-ai-gateway-stream-error-occurred-on-final-response-synthesis) (stemming from abeatrix's review of #12800): lean on the AI SDK's [typed error classes](https://ai-sdk.dev/docs/reference/ai-sdk-errors) in the provider-error classifier instead of only probing shapes.

`classifyProviderError` now runs a typed pre-pass before the structural walk, matching real `ai` error instances via their symbol-based `isInstance()` guards (safe across duplicated package copies):

- **`RetryError`** → only the final attempt decides. It's classified via the typed pre-pass when it's a typed error, or by a structural walk of *that attempt alone* when it's untyped — earlier retried-away attempts (typically rate limits) can neither veto nor fake the verdict.
- **`APICallError`** → the typed `statusCode` gates the whole verdict: a status outside the invalid-request family ({400, 413, 422}) is `unknown` immediately, so nothing in the payload — wording or an explicit overflow code echoed in a rate-limit/server-failure body — out-votes the HTTP layer. Otherwise (or with no `statusCode`) the shared verdict runs against `message` / `responseBody` / `data`.
- **`TypeValidationError`** → evaluate the payload in `value` (for gateway streams, that's the upstream provider rejection).
- **any other `AISDKError`** (e.g. `NoOutputGeneratedError`) → recurse into `cause`, falling through to the walk if that yields nothing.

The specific classes are checked before the generic `AISDKError` guard since everything subclasses it, and recursion is depth-bounded.

The detection rules themselves (overflow patterns, provider codes, rate-limit vetoes, invalid-request status gate) are unchanged — they're extracted into a shared `verdictFromSignals` used identically by both paths. This is a refactor of signal *collection*, not of detection rules. The one deliberate asymmetry: the typed branch's statusCode gate applies only where the status is known-authoritative; in the structural walk, collected statuses are unattributed ambient signals, so its code-first ordering stays as shipped in #12804.

The structural walk stays as the fallback at full strength: the ENG-2394 failing payload is plain JSON streamed by the Vercel gateway (`"name": "AI_TypeValidationError"` as a string, not an instance), which `isInstance()` can never match. All pre-existing tests use plain shapes and pass unchanged.

## Test Procedure

New tests construct real `ai@6` error instances:

- APICallError 400 + prompt-too-long body → `context_window_exceeded`; 429 with token wording and 500 with context wording → `unknown` (typed status is authoritative).
- APICallError with an explicit `context_length_exceeded` code in the body: `unknown` at 429/500, `context_window_exceeded` at 400 (the gate doesn't swallow genuine overflows).
- RetryError wrapping an overflow APICallError → `context_window_exceeded`; an untyped final overflow attempt isn't vetoed by an earlier 429 attempt → `context_window_exceeded`; an earlier overflow attempt can't fake a verdict for an unrelated untyped final attempt → `unknown`.
- TypeValidationError carrying the captured ENG-2394 gateway `value` payload (JSON-encoded Alibaba Qwen context-length rejection) with a ZodError-like cause → `context_window_exceeded`.
- NoOutputGeneratedError with an overflow APICallError cause → `context_window_exceeded`.

Checks:

- `bun x vitest run` in `sdk/packages/llms`: 506 passed, 4 skipped (15 pre-existing classifier tests unchanged).
- `bun run typecheck` in `sdk/packages/llms`: clean.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] ♻️ Refactor Suggestion
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow changes

## Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
