### PR TITLE
fix(vscode): exclude tool-execution failures from provider-failure telemetry

### DIFF
--- a/apps/vscode/src/sdk/sdk-session-event-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-session-event-coordinator.test.ts
@@ -368,6 +368,44 @@ describe("SdkSessionEventCoordinator", () => {
 			failurePhase: PROVIDER_FAILURE_PHASE.STREAMING,
 		})
 	})
+
+	it("does not capture provider failure telemetry for tool-execution-failure mistake errors", async () => {
+		const { coordinator, options } = makeCoordinator()
+		const event: CoreSessionEvent = {
+			type: "agent_event",
+			payload: {
+				sessionId: "session-123",
+				event: {
+					type: "error",
+					error: new Error('2 tool call(s) failed: [shell] {"error":"command not found"}'),
+				},
+			},
+		} as unknown as CoreSessionEvent
+
+		await coordinator.handleSessionEvent(event)
+
+		expect(options.captureProviderApiError).not.toHaveBeenCalled()
+	})
+
+	it("does not capture provider failure telemetry when a turn ends in error with a tool-failure abort text", async () => {
+		const { coordinator, options } = makeCoordinator()
+		const event: CoreSessionEvent = {
+			type: "agent_event",
+			payload: {
+				sessionId: "session-123",
+				event: {
+					type: "done",
+					reason: "error",
+					text: '1 tool call(s) failed: [read_file] {"error":"\u2716 Invalid input"}',
+					iterations: 1,
+				},
+			},
+		} as unknown as CoreSessionEvent
+
+		await coordinator.handleSessionEvent(event)
+
+		expect(options.captureProviderApiError).not.toHaveBeenCalled()
+	})
 })
 
 function makeCoordinator(input: Partial<MakeCoordinatorInput> = {}) {

--- a/apps/vscode/src/sdk/sdk-session-event-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-session-event-coordinator.ts
@@ -12,6 +12,7 @@ import type { SdkMessageCoordinator } from "./sdk-message-coordinator"
 import type { SdkSessionLifecycle } from "./sdk-session-lifecycle"
 import type { SdkTaskHistory } from "./sdk-task-history"
 import type { TaskProxy } from "./task-proxy"
+import { isToolExecutionFailureMistake } from "./tool-approval-denial"
 
 function normalizeModelId(modelId: string): string {
 	return modelId.trim().toLowerCase()
@@ -67,7 +68,16 @@ export class SdkSessionEventCoordinator {
 
 		const result = this.translateSessionEvent(event, this.options.messageTranslatorState)
 		const agentFailure = this.getAgentFailureTelemetry(event)
-		if (agentFailure && !this.options.messageTranslatorState.isSuppressedToolApprovalDenial(agentFailure.error)) {
+		// Tool-shaped agent failures are excluded from provider-failure
+		// telemetry: approval denials are user decisions, and tool-execution
+		// failures are already reported per-execution under
+		// task.tool_used(failed). Counting either as a provider API error
+		// inflates the SDK bundle's error rate in the A/B rollout dashboards.
+		if (
+			agentFailure &&
+			!this.options.messageTranslatorState.isSuppressedToolApprovalDenial(agentFailure.error) &&
+			!isToolExecutionFailureMistake(agentFailure.error)
+		) {
 			this.options.captureProviderApiError?.({
 				sessionId: agentFailure.sessionId,
 				error: agentFailure.error,

--- a/apps/vscode/src/sdk/tool-approval-denial.ts
+++ b/apps/vscode/src/sdk/tool-approval-denial.ts
@@ -74,3 +74,21 @@ export function isDeniedToolApprovalMistake(
 
 	return false
 }
+
+/**
+ * Mistake-tracker abort texts for failed tool executions look like
+ * "2 tool call(s) failed: [shell] {...}" (built by the session runtime
+ * orchestrator's turn-finished handler in @cline/core). They reach this
+ * adapter as agent error/done events, but they are TOOL failures — already
+ * reported per-execution under task.tool_used(failed) — not provider API
+ * failures, so provider-failure telemetry must skip them or the A/B rollout
+ * error dashboards double-count tool failures as API errors on the SDK
+ * bundle only.
+ */
+export function isToolExecutionFailureMistake(value: unknown): boolean {
+	const message = getMessage(value)
+	if (!message) {
+		return false
+	}
+	return /\b\d+ tool call\(s\) failed\b/.test(message)
+}


### PR DESCRIPTION
### Related Issue

Companion to #12812 (legacy provider-failure parity). Together they make `task.provider_api_error` mean the same thing on both sides of the A/B rollout.

### Description

Day-one field data from the stable rollout showed the SDK bundle reporting rows like `1 tool call(s) failed: [shell] {"error":"Tool call shell was rejected before execution..."}` under `task.provider_api_error`. Those aren't API errors — they're tool-execution failures, and they're **already reported per-execution** under `task.tool_used(failed)`, so the SDK bundle double-counts every failed tool call as a provider API error. Legacy doesn't, which skews the rollout error comparison on the SDK side only.

**Where they leak in**: the mistake tracker in `@cline/core` builds `"${failed} tool call(s) failed: ..."` abort texts (`session-runtime-orchestrator.ts`, turn-finished handler). Those texts surface as agent `error` / `done(reason=error)` events, which `SdkSessionEventCoordinator` forwards wholesale into `captureProviderApiError`.

**The fix** extends the exact mechanism that already exists for the sibling case: the coordinator already suppresses tool-approval *denials* from provider telemetry (`isSuppressedToolApprovalDenial`, `tool-approval-denial.ts`). This adds `isToolExecutionFailureMistake()` — matching the deterministic `\d+ tool call\(s\) failed` text core generates — to the same gate. Adapter-only change; `@cline/core` untouched (the abort text itself is fine and still drives the mistake-limit flow and user-facing messaging; only its misclassification as a provider API error goes away).

Why message-matching rather than a structured error kind from core: it mirrors the established pattern in this file, keeps the change out of the SDK (which ships to CLI/desktop surfaces on their own cadence), and the matched string is generated by our own code, not a provider. If core later grows a structured abort-reason type, both matchers can migrate together.

### Test Procedure

- `bun run check-types` clean.
- `sdk-session-event-coordinator.test.ts`: 18/18 pass — two new cases assert that agent `error` events and `done(reason=error)` turns carrying tool-failure abort texts do NOT capture provider-failure telemetry (both routes into the gate covered).
- Existing capture tests (genuine provider errors still captured, approval denials still suppressed) unchanged and passing.
