### PR TITLE
feat(telemetry): classify context-window overflow on legacy provider error events

### DIFF
--- a/apps/vscode/src/core/task/index.ts
+++ b/apps/vscode/src/core/task/index.ts
@@ -2401,6 +2401,17 @@ export class Task {
 
 			// Capture provider failure telemetry using clineError
 			ErrorService.get().logMessage(clineError.message);
+			telemetryService.captureProviderApiError({
+				ulid: this.ulid,
+				model: model.id,
+				provider: providerId,
+				errorMessage: clineError.message,
+				requestId: this.getApiRequestIdSafe(),
+				isNativeToolCall: this.useNativeToolCalls,
+				errorClass: isContextWindowExceededError
+					? "context_window_exceeded"
+					: "unknown",
+			});
 
 			if (
 				isContextWindowExceededError &&
@@ -3596,6 +3607,17 @@ export class Task {
 						this.api.getModel().id,
 					);
 					const errorMessage = clineError.serialize();
+					telemetryService.captureProviderApiError({
+						ulid: this.ulid,
+						model: model.id,
+						provider: providerId,
+						errorMessage: clineError.message,
+						requestId: this.getApiRequestIdSafe(),
+						isNativeToolCall: this.useNativeToolCalls,
+						errorClass: checkContextWindowExceededError(error)
+							? "context_window_exceeded"
+							: "unknown",
+					});
 					const isStreamingSpendLimitError = clineError.isErrorType(
 						ClineErrorType.SpendLimit,
 					);

--- a/apps/vscode/src/core/task/index.ts
+++ b/apps/vscode/src/core/task/index.ts
@@ -3607,6 +3607,9 @@ export class Task {
 						this.api.getModel().id,
 					);
 					const errorMessage = clineError.serialize();
+					// This catch also wraps post-stream processing, so a generic
+					// failure here is not necessarily a provider error; only a
+					// positive overflow match is a confident classification.
 					telemetryService.captureProviderApiError({
 						ulid: this.ulid,
 						model: model.id,
@@ -3614,9 +3617,9 @@ export class Task {
 						errorMessage: clineError.message,
 						requestId: this.getApiRequestIdSafe(),
 						isNativeToolCall: this.useNativeToolCalls,
-						errorClass: checkContextWindowExceededError(error)
-							? "context_window_exceeded"
-							: "unknown",
+						...(checkContextWindowExceededError(error)
+							? { errorClass: "context_window_exceeded" as const }
+							: {}),
 					});
 					const isStreamingSpendLimitError = clineError.isErrorType(
 						ClineErrorType.SpendLimit,

--- a/apps/vscode/src/services/telemetry/TelemetryService.ts
+++ b/apps/vscode/src/services/telemetry/TelemetryService.ts
@@ -1399,6 +1399,7 @@ export class TelemetryService {
 	 * @param requestId Unique identifier for the specific API request
 	 * @param errorMessage Detailed error message from the API provider
 	 * @param errorStatus HTTP status code of the error response, if available
+	 * @param errorClass Classification of the error ("context_window_exceeded" | "unknown"); omit when no classification was attempted
 	 * @param collect Optional flag to determine if the event should be collected for batch sending
 	 */
 	public captureProviderApiError(args: {
@@ -1409,6 +1410,7 @@ export class TelemetryService {
 		errorStatus?: number | undefined
 		requestId?: string | undefined
 		isNativeToolCall?: boolean
+		errorClass?: "context_window_exceeded" | "unknown"
 	}) {
 		this.capture({
 			event: TelemetryService.EVENTS.TASK.PROVIDER_API_ERROR,

--- a/apps/vscode/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
+++ b/apps/vscode/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
@@ -363,6 +363,39 @@ describe("TelemetryService metrics", () => {
 		assert.strictEqual(errorHistogram.attributes.error_status, 500)
 	})
 
+	it("captureProviderApiError includes errorClass in the event properties when provided", () => {
+		const provider = new FakeProvider()
+		const service = createTelemetryService(provider)
+
+		service.captureProviderApiError({
+			ulid: "task-3",
+			model: "claude",
+			errorMessage: "prompt is too long",
+			provider: "anthropic",
+			errorClass: "context_window_exceeded",
+		})
+
+		const errorEvent = provider.logs.find((entry) => entry.event === "task.provider_api_error")
+		assert.ok(errorEvent)
+		assert.strictEqual(errorEvent?.properties?.errorClass, "context_window_exceeded")
+	})
+
+	it("captureProviderApiError omits errorClass from the event properties when not provided", () => {
+		const provider = new FakeProvider()
+		const service = createTelemetryService(provider)
+
+		service.captureProviderApiError({
+			ulid: "task-3",
+			model: "claude",
+			errorMessage: "empty_assistant_message",
+			provider: "anthropic",
+		})
+
+		const errorEvent = provider.logs.find((entry) => entry.event === "task.provider_api_error")
+		assert.ok(errorEvent)
+		assert.strictEqual("errorClass" in (errorEvent?.properties ?? {}), false)
+	})
+
 	it("captureTaskCompleted records completion payload with TTFT and duration histograms", () => {
 		const provider = new FakeProvider()
 		const service = createTelemetryService(provider)


### PR DESCRIPTION
## Problem

Context-window overflow failures on the legacy architecture are uncountable in PostHog: the legacy task loop detects them (`checkContextWindowExceededError`) and recovers (auto-truncate + retry), but the thrown provider-error paths never emit `task.provider_api_error` — that event only fired for empty assistant responses — so overflows land in no queryable bucket at all. Root-cause context: [ENG-2394](https://linear.app/cline-bot/issue/ENG-2394/vercel-ai-gateway-stream-error-occurred-on-final-response-synthesis).

This is the legacy-arch analogue of the telemetry half of https://github.com/cline/cline/pull/12804 (SDK arch). Recovery is intentionally untouched — legacy already has detection and auto-truncate-and-retry; only the telemetry classification was missing.

## Change

- `captureProviderApiError` gains an optional `errorClass` property (`"context_window_exceeded" | "unknown"`), matching the property name and value strings the SDK arch attaches to the same event, so one PostHog query covers both architectures.
- The two thrown provider-error sites in the legacy task loop now emit `task.provider_api_error` with `errorClass` derived from the existing `checkContextWindowExceededError` detector:
  - first-chunk failure in `attemptApiRequest` (the site that drives auto-truncate/retry), which already computed the detector result — always classified (`"context_window_exceeded" | "unknown"`), since an error awaiting the provider's first chunk is definitionally a provider failure;
  - mid-stream failure in `recursivelyMakeClineRequests` (the ENG-2394 shape — stream errors after the first chunk) — classified only on a positive overflow match, because this catch also wraps post-stream processing, so a generic failure there is not necessarily a provider error. This mirrors the SDK arch's convention for this event (`errorClass` set only when confidently classified; the event also covers non-provider failures).
- The pre-existing empty-response capture site omits `errorClass` (no error object; same convention).

No behavior change to error handling, retries, or truncation.

## Why no typed AI-SDK error matching (unlike #12804)

#12804's classifier in `llms` walks typed Vercel AI SDK wrapper shapes (`APICallError` `statusCode`/`responseBody`/`cause` chains) because on the SDK arch every provider call is routed through the AI SDK, which wraps the provider's error before Cline code ever sees it — the classifier must unwrap those layers to reach the provider payload.

The legacy arch has no such layer to unwrap:

- Legacy does not depend on `ai`/`@ai-sdk/*` at all. Each provider handler under `core/api/providers/` uses the provider's native client (`openai`, Anthropic, Bedrock, …), so the error object reaching the task loop **is** the provider-native error — exactly the shapes `checkContextWindowExceededError`'s per-provider detectors already match. Even the Vercel AI **Gateway** handler talks plain OpenAI-compatible HTTP; the gateway's serialized error shapes (including the `AI_APICallError` name string and the Qwen `value.error_message` nesting from ENG-2394) are already matched structurally by the existing detectors.
- Classifying telemetry with the same predicate that gates legacy recovery is deliberate: `errorClass="context_window_exceeded"` counts precisely the requests the legacy runtime treats (and auto-recovers) as overflow. A second, stricter ported classifier could disagree with runtime behavior, making the metric harder to interpret, and any detector gap is better fixed in `checkContextWindowExceededError` itself — which fixes recovery and telemetry together.

If legacy data later shows overflows landing in `errorClass="unknown"` for some provider, the fix is a new detector case in `checkContextWindowExceededError`, not a parallel classifier.

## Testing

- Two new unit tests in `TelemetryService.metrics.test.ts` (property passes through when provided; absent when not).
- Full legacy unit suite: `npm run test:unit` under `apps/vscode` — 1559 passing, 4 pending.
- `tsc --noEmit` clean; `biome lint` clean at error level.
