### PR TITLE
chore: remove dead host-side capture methods for core-owned telemetry events

### DIFF
--- a/apps/vscode/src/services/telemetry/TelemetryService.ts
+++ b/apps/vscode/src/services/telemetry/TelemetryService.ts
@@ -267,8 +267,6 @@ export class TelemetryService {
 		WORKSPACE: {
 			// Track workspace initialization
 			INITIALIZED: "workspace.initialized",
-			// Track initialization errors
-			INIT_ERROR: "workspace.init_error",
 			// Track VCS detection
 			VCS_DETECTED: "workspace.vcs_detected",
 			// Track multi-root checkpoint operations
@@ -307,8 +305,6 @@ export class TelemetryService {
 			LEGACY_TASK_MIGRATION: "task.legacy_task_migration",
 			// Tracks when the retry button is clicked for failed operations
 			RETRY_CLICKED: "task.retry_clicked",
-			// Tracks when a diff edit (replace_in_file) operation fails
-			DIFF_EDIT_FAILED: "task.diff_edit_failed",
 			// Tracks when the browser tool is started
 			BROWSER_TOOL_START: "task.browser_tool_start",
 			// Tracks when the browser tool is completed
@@ -1196,27 +1192,6 @@ export class TelemetryService {
 	}
 
 	/**
-	 * Records when a diff edit (replace_in_file) operation fails
-	 * @param ulid Unique identifier for the task
-	 * @param modelId The model ID being used
-	 * @param provider The API provider being used
-	 * @param errorType Type of error that occurred (e.g., "search_not_found", "invalid_format")
-	 * @param isNativeToolCall Whether the diff edit was invoked by a native tool call
-	 */
-	public captureDiffEditFailure(ulid: string, modelId: string, provider: string, errorType?: string, isNativeToolCall = false) {
-		this.capture({
-			event: TelemetryService.EVENTS.TASK.DIFF_EDIT_FAILED,
-			properties: {
-				ulid,
-				errorType,
-				modelId,
-				provider,
-				isNativeToolCall,
-			},
-		})
-	}
-
-	/**
 	 * Records when a different model is selected for use
 	 * @param model Name of the selected model
 	 * @param provider Provider of the selected model
@@ -1912,24 +1887,6 @@ export class TelemetryService {
 		// Retire the previous series to avoid leaking gauge entries when the flag flips.
 		this.recordGauge("cline.workspace.active_roots", null, {
 			is_multi_root: !isMultiRoot,
-		})
-	}
-
-	/**
-	 * Records workspace initialization errors
-	 * @param error The error that occurred
-	 * @param fallbackMode Whether system fell back to single-root mode
-	 * @param workspaceCount Number of workspace folders detected
-	 */
-	public captureWorkspaceInitError(error: Error, fallbackMode: boolean, workspaceCount?: number) {
-		this.capture({
-			event: TelemetryService.EVENTS.WORKSPACE.INIT_ERROR,
-			properties: {
-				error_type: error.constructor.name,
-				error_message: error.message.substring(0, MAX_ERROR_MESSAGE_LENGTH),
-				fallback_to_single_root: fallbackMode,
-				workspace_count: workspaceCount ?? 0,
-			},
 		})
 	}
 


### PR DESCRIPTION
## Description

`TelemetryService.captureDiffEditFailure` and `TelemetryService.captureWorkspaceInitError` have **zero callers** — SDK core is the sole emitter of `task.diff_edit_failed` and `workspace.init_error` (via `handleAgentEvent` and `workspace-telemetry.ts` respectively). This removes the two dead methods and their event-name constants (only referenced by the removed methods).

## Why now

Keeping callable host-side capture APIs for core-owned events is exactly how the `task.provider_api_error` double-emission happened: both layers offered a plausible capture API and both eventually got wired, silently doubling the event's counts with no type error or failing test. Deleting the unused APIs makes re-introducing a host emitter a deliberate, reviewable act instead of a one-line accident.

Part of [ENG-2396](https://linear.app/cline-bot/issue/ENG-2396/telemetry-ownership-cleanup-for-the-sdk-architecture) (telemetry ownership cleanup, work item 3).

## Test plan

- `bunx tsc --noEmit` clean in `apps/vscode`
- `bun test src/services/telemetry/__tests__/TelemetryService.metrics.test.ts` — 16 pass
- `grep -rn 'captureDiffEditFailure\|captureWorkspaceInitError\|DIFF_EDIT_FAILED\|INIT_ERROR' apps/vscode/src` — no remaining references (SDK-core emitters untouched)