### PR TITLE
docs: move ACP editor integration to a dedicated Usage page

### DIFF
--- a/docs/cli/cli-reference.mdx
+++ b/docs/cli/cli-reference.mdx
@@ -81,7 +81,7 @@ Commands:
 | `--thinking <level>` | Set reasoning effort: `none\|low\|medium\|high\|xhigh` (default `medium`) |
 | `--retries <count>` | Maximum consecutive mistakes (retries) before halting |
 | `--hooks-dir <path>` | Directory path to additional hooks for runtime hook injection (default: `~/.cline/hooks`) |
-| `--acp` | Run in Agent Client Protocol (ACP) mode for [editor integration](/usage/cli-overview#editor-integration-acp) |
+| `--acp` | Run in Agent Client Protocol (ACP) mode for [editor integration](/usage/acp) |
 | `-i, --tui` | Open the terminal user interface (TUI) for interactive sessions |
 | `--id <session-id>` | Resume an existing session by ID |
 | `-k, --key <api-key>` | API key override for this run |

--- a/docs/cline-overview.mdx
+++ b/docs/cline-overview.mdx
@@ -64,7 +64,7 @@ The SDK is Cline's agent core—use it to build your own applications, automatio
 
 ## Other IDE Supports
 
-Cline works across all major editors: **VS Code**, **Cursor**, **Windsurf**, **JetBrains** (IntelliJ, PyCharm, WebStorm), **Antigravity**, and **Zed**, **Neovim** via ACP mode.
+Cline works across all major editors: **VS Code**, **Cursor**, **Windsurf**, **JetBrains** (IntelliJ, PyCharm, WebStorm), **Antigravity**, and **Zed**, **Neovim** via [ACP mode](/usage/acp).
 
 
 ## Enterprise Solutions

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -124,6 +124,7 @@
 									}
 								]
 							},
+							"usage/acp",
 							{
 								"group": "Kanban",
 								"pages": [
@@ -768,7 +769,7 @@
 		},
 		{
 			"source": "/cline-cli/acp-editor-integrations",
-			"destination": "/usage/cli-overview#editor-integration-acp"
+			"destination": "/usage/acp"
 		},
 		{
 			"source": "/cline-cli/samples/github-issue-rca",

--- a/docs/usage/acp.mdx
+++ b/docs/usage/acp.mdx
@@ -1,0 +1,114 @@
+---
+title: "ACP"
+sidebarTitle: "ACP"
+description: "Use Cline as the coding agent in Zed, JetBrains IDEs, Neovim, Emacs, and any other ACP-capable client."
+---
+
+Cline CLI speaks the [Agent Client Protocol (ACP)](https://agentclientprotocol.com), an open standard that lets editors and other tools drive terminal-based coding agents. Any ACP-capable client can use Cline as its coding agent without a dedicated extension — the same agent you use in the terminal, embedded in the tool you're already working in.
+
+## Prerequisites
+
+- Cline CLI installed (install via `npm i -g cline`)
+- Credentials are optional up front — most clients let you sign in when the first session starts, and credentials saved by `cline auth` are reused automatically
+
+## How it works
+
+ACP mode is started with the `--acp` flag:
+
+```bash
+cline --acp
+```
+
+You don't run this yourself — the client launches the command and talks to Cline over stdio. Configure the client to run it, then start a thread from its agent UI.
+
+<Tip>
+If a client can't spawn the agent, it may not inherit your shell's `PATH`. Use the absolute path from `which cline` as the command.
+</Tip>
+
+## Clients
+
+ACP is supported by a growing ecosystem of editors, IDEs, and other tools. Setup for the most popular clients is below; the [ACP client directory](https://agentclientprotocol.com/get-started/clients) maintains the full list.
+
+### Zed
+
+Add Cline as a custom agent in Zed's `settings.json`:
+
+```json
+{
+  "agent_servers": {
+    "Cline": {
+      "type": "custom",
+      "command": "cline",
+      "args": ["--acp"],
+      "env": {}
+    }
+  }
+}
+```
+
+Open the Agent Panel, start a new thread, and select **Cline**.
+
+### JetBrains IDEs
+
+AI Assistant in JetBrains IDEs (IntelliJ IDEA, PyCharm, WebStorm, and others) supports [ACP agents](https://www.jetbrains.com/help/ai-assistant/acp.html). In the AI Chat tool window, select **Add Custom Agent** — this creates `~/.jetbrains/acp.json` — then add Cline:
+
+```json
+{
+  "agent_servers": {
+    "Cline": {
+      "command": "cline",
+      "args": ["--acp"],
+      "env": {}
+    }
+  }
+}
+```
+
+Cline then appears in the AI Chat agent selector.
+
+### Neovim
+
+The [CodeCompanion](https://codecompanion.olimorris.dev/configuration/adapters-acp) plugin ships a built-in `cline_cli` ACP adapter that runs `cline --acp`. Set it as your chat adapter:
+
+```lua
+require("codecompanion").setup({
+  strategies = {
+    chat = { adapter = "cline_cli" },
+  },
+})
+```
+
+Other Neovim ACP clients, such as [avante.nvim](https://github.com/yetone/avante.nvim) and [agentic.nvim](https://github.com/carlos-algms/agentic.nvim), can also launch Cline via `cline --acp`.
+
+### Emacs
+
+[agent-shell](https://github.com/xenodium/agent-shell) drives ACP agents from a native Emacs buffer. Configure a custom agent that runs `cline --acp` per the agent-shell docs.
+
+### Other clients
+
+Anything that speaks ACP can run Cline the same way — point it at `cline --acp`. The [client directory](https://agentclientprotocol.com/get-started/clients) includes note-taking apps like Obsidian, notebooks like marimo, mobile clients, and chat bridges for Slack, Discord, and Telegram.
+
+## What works over ACP
+
+- **Sign-in from the client** — if no credentials are found, the client prompts you to sign in with Cline, ClinePass, or a ChatGPT subscription. Credentials saved by `cline auth` are reused automatically.
+- **Plan/Act modes** — switch between [Plan and Act](/core-workflows/plan-and-act) from the client's mode selector.
+- **Model and provider selection** — pick any model from the active provider's catalog, or switch providers, from the client's model picker.
+- **Permission prompts** — file edits and commands are approved through the client's permission UI; nothing is auto-approved.
+- **Session resume** — conversations are persisted, so clients that support session loading can restore a thread after a restart.
+- **Images** — prompts can include images for vision-capable models.
+- **Organization switching** — Cline team accounts can switch between personal and organization billing.
+
+## Environment variables
+
+Set these under `env` in the client's agent server config to preconfigure the agent:
+
+| Variable | Effect |
+|---|---|
+| `CLINE_API_KEY` | Authenticate with an API key instead of interactive sign-in |
+| `CLINE_PROVIDER` | Pin the provider (disables provider switching in the client) |
+| `CLINE_MODEL` | Default model for new sessions |
+
+## Next Steps
+
+- [CLI Overview](/usage/cli-overview)
+- [CLI Reference](/cli/cli-reference)

--- a/docs/usage/cli-overview.mdx
+++ b/docs/usage/cli-overview.mdx
@@ -140,61 +140,6 @@ cline "fix the UI shown in @./design-mockup.png"
 cline --timeout 600 "run full test suite"
 ```
 
-## Editor Integration (ACP)
-
-Cline CLI speaks the [Agent Client Protocol (ACP)](https://agentclientprotocol.com), an open standard that lets editors drive terminal-based coding agents. Any ACP-capable client — Zed, Neovim plugins, Emacs, and others — can use Cline as its coding agent without a dedicated extension.
-
-ACP mode is started with the `--acp` flag:
-
-```bash
-cline --acp
-```
-
-You don't run this yourself — your editor launches the command and talks to Cline over stdio. Configure the editor to run it, then start a thread from the editor's agent UI.
-
-### Zed
-
-Add Cline as a custom agent in Zed's `settings.json`:
-
-```json
-{
-  "agent_servers": {
-    "Cline": {
-      "type": "custom",
-      "command": "cline",
-      "args": ["--acp"],
-      "env": {}
-    }
-  }
-}
-```
-
-Open the Agent Panel, start a new thread, and select **Cline**.
-
-<Tip>
-If Zed can't spawn the agent, it may not inherit your shell's `PATH`. Use the absolute path from `which cline` as the `command` value.
-</Tip>
-
-### What works over ACP
-
-- **Sign-in from the editor** — if no credentials are found, the editor prompts you to sign in with Cline, ClinePass, or a ChatGPT subscription. Credentials saved by `cline auth` are reused automatically.
-- **Plan/Act modes** — switch between [Plan and Act](/core-workflows/plan-and-act) from the editor's mode selector.
-- **Model and provider selection** — pick any model from the active provider's catalog, or switch providers, from the editor's model picker.
-- **Permission prompts** — file edits and commands are approved through the editor's permission UI; nothing is auto-approved.
-- **Session resume** — conversations are persisted, so editors that support session loading can restore a thread after a restart.
-- **Images** — prompts can include images for vision-capable models.
-- **Organization switching** — Cline team accounts can switch between personal and organization billing.
-
-### Environment variables
-
-Set these under `env` in the editor's agent server config to preconfigure the agent:
-
-| Variable | Effect |
-|---|---|
-| `CLINE_API_KEY` | Authenticate with an API key instead of interactive sign-in |
-| `CLINE_PROVIDER` | Pin the provider (disables provider switching in the editor) |
-| `CLINE_MODEL` | Default model for new sessions |
-
 ## JSON Output Schema
 
 When using `--json`, each line is a JSON message object.
@@ -216,3 +161,4 @@ When using `--json`, each line is a JSON message object.
 ## Next Steps
 
 - [CLI Reference](/cli/cli-reference)
+- [ACP](/usage/acp) — use Cline as the coding agent in Zed, JetBrains IDEs, Neovim, and other ACP clients


### PR DESCRIPTION
### Related Issue

N/A — docs-only change. Follow-up to #12808.

### Description

#12808 added ACP documentation as a section inside the CLI Overview page. Per feedback, ACP deserves its own surface rather than living in the CLI overview, so this PR moves it to a dedicated **ACP** page under **Usage** (`/usage/acp`, alongside IDE, TUI, CLI, and Kanban) and expands it to cover the client ecosystem beyond Zed:

- **Zed** — existing `agent_servers` custom-agent config, unchanged
- **JetBrains IDEs** — AI Assistant custom agent via `~/.jetbrains/acp.json` (per the [JetBrains ACP docs](https://www.jetbrains.com/help/ai-assistant/acp.html))
- **Neovim** — CodeCompanion ships a built-in `cline_cli` ACP adapter that runs `cline --acp`; avante.nvim and agentic.nvim also noted
- **Emacs** — agent-shell custom agent
- **Other clients** — pointer to the [ACP client directory](https://agentclientprotocol.com/get-started/clients) (Obsidian, marimo, mobile clients, chat bridges, etc.)

The "What works over ACP" and environment-variable reference carry over from the original section, reworded from "editor" to "client" since ACP surfaces aren't just editors.

Also:

- Removes the Editor Integration (ACP) section from `docs/usage/cli-overview.mdx`, leaving a one-line pointer in Next Steps
- Repoints the `--acp` flag link in `docs/cli/cli-reference.mdx` and the `/cline-cli/acp-editor-integrations` redirect at `/usage/acp`
- Links the "ACP mode" mention in `docs/cline-overview.mdx` to the new page

### Test Procedure

- `mintlify broken-links` passes with no broken links
- Rendered locally with `mint dev` and verified the new page, its sidebar placement under Usage, all three client config code blocks, and that CLI Overview no longer contains the ACP section (screenshots below)

### Type of Change

-   [x] 📚 Documentation update

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

![New ACP page under Usage with sidebar placement](https://cursor.com/artifacts/c/art-8526059d-74f2-4c3d-8c60-575ccc7c3d80)

![Clients section with Zed and JetBrains setup](https://cursor.com/artifacts/c/art-d4947551-b6b2-4f40-91ea-816c35f8f4b2)