### PR TITLE
Fix Text rendering when restarting ACP sessions

### DIFF
--- a/apps/cli/src/acp/session-load.test.ts
+++ b/apps/cli/src/acp/session-load.test.ts
@@ -1,5 +1,6 @@
 import type { AgentSideConnection } from "@agentclientprotocol/sdk";
 import { describe, expect, it, vi } from "vitest";
+import { ACT_MODE_CONTINUATION_PROMPT } from "../runtime/interactive/mode";
 import {
 	replaySessionHistory,
 	translateHistoricalMessage,
@@ -22,6 +23,96 @@ describe("translateHistoricalMessage", () => {
 			{
 				sessionUpdate: "agent_message_chunk",
 				content: { type: "text", text: "hello" },
+			},
+		]);
+	});
+
+	it("strips the <user_input> wrapper from replayed user text", () => {
+		// Persisted user messages keep their runtime-generated wrapper. Replaying
+		// it verbatim leaked markup to the client, which rendered the unknown
+		// element as bare text (a one-word prompt showed up as just its content
+		// with the wrapper swallowed).
+		expect(
+			translateHistoricalMessage({
+				role: "user",
+				content: '<user_input mode="act">s</user_input>',
+			}),
+		).toEqual([
+			{
+				sessionUpdate: "user_message_chunk",
+				content: { type: "text", text: "s" },
+			},
+		]);
+
+		expect(
+			translateHistoricalMessage({
+				role: "user",
+				content: [
+					{
+						type: "text",
+						text: '<user_input mode="plan">lets do it</user_input>',
+					},
+				],
+			}),
+		).toEqual([
+			{
+				sessionUpdate: "user_message_chunk",
+				content: { type: "text", text: "lets do it" },
+			},
+		]);
+	});
+
+	it("strips mode notices and formats slash commands for display", () => {
+		expect(
+			translateHistoricalMessage({
+				role: "user",
+				content:
+					'<user_input mode="plan"><mode_notice>The user switched from act mode to plan mode before sending this message.</mode_notice>\nare you okay?</user_input>',
+			}),
+		).toEqual([
+			{
+				sessionUpdate: "user_message_chunk",
+				content: { type: "text", text: "are you okay?" },
+			},
+		]);
+
+		expect(
+			translateHistoricalMessage({
+				role: "user",
+				content:
+					'<user_command slash="team">spawn a team of agents for the following task: inspect rpc startup</user_command>',
+			}),
+		).toEqual([
+			{
+				sessionUpdate: "user_message_chunk",
+				content: { type: "text", text: "/team inspect rpc startup" },
+			},
+		]);
+	});
+
+	it("does not replay the synthetic act-mode continuation prompt", () => {
+		expect(
+			translateHistoricalMessage({
+				role: "user",
+				content: `<user_input mode="act">${ACT_MODE_CONTINUATION_PROMPT}</user_input>`,
+			}),
+		).toEqual([]);
+	});
+
+	it("leaves assistant text untouched", () => {
+		// Only user text carries the wrapper; agent output must replay verbatim.
+		expect(
+			translateHistoricalMessage({
+				role: "assistant",
+				content: 'Use <user_input mode="act"> to wrap prompts.',
+			}),
+		).toEqual([
+			{
+				sessionUpdate: "agent_message_chunk",
+				content: {
+					type: "text",
+					text: 'Use <user_input mode="act"> to wrap prompts.',
+				},
 			},
 		]);
 	});

--- a/apps/cli/src/acp/session-load.ts
+++ b/apps/cli/src/acp/session-load.ts
@@ -2,8 +2,23 @@ import type {
 	AgentSideConnection,
 	SessionUpdate,
 } from "@agentclientprotocol/sdk";
-import type { ContentBlock, Message, ToolResultContent } from "@cline/shared";
+import {
+	type ContentBlock,
+	formatDisplayUserInput,
+	type Message,
+	type ToolResultContent,
+} from "@cline/shared";
+import { ACT_MODE_CONTINUATION_PROMPT } from "../runtime/interactive/mode";
 import { buildToolTitle, mapToolKind } from "./tool-utils";
+
+/**
+ * The act-mode continuation prompt is runtime-generated, not typed by the
+ * user, so it must not replay as a user turn. Mirrors the TUI transcript
+ * hydration filter in tui/utils/hydrate-messages.ts.
+ */
+function isSyntheticUserText(text: string): boolean {
+	return text === ACT_MODE_CONTINUATION_PROMPT;
+}
 
 /**
  * Replay a persisted conversation to the client as session/update
@@ -35,12 +50,25 @@ export function translateHistoricalMessage(message: Message): SessionUpdate[] {
 		switch (block.type) {
 			case "text": {
 				if (!block.text) break;
-				const content = { type: "text" as const, text: block.text };
-				updates.push(
-					message.role === "user"
-						? { sessionUpdate: "user_message_chunk", content }
-						: { sessionUpdate: "agent_message_chunk", content },
-				);
+				if (message.role !== "user") {
+					updates.push({
+						sessionUpdate: "agent_message_chunk",
+						content: { type: "text", text: block.text },
+					});
+					break;
+				}
+				// Display boundary: persisted user text keeps its runtime-generated
+				// <user_input mode="..."> wrapper and <mode_notice> elements (they are
+				// the durable record of the mode each turn was sent in). Replaying them
+				// verbatim leaks markup to the client, which renders the unknown
+				// element as bare text — so `s` shows up as `s` with the wrapper
+				// swallowed. Strip them the same way every other surface does.
+				const text = formatDisplayUserInput(block.text);
+				if (!text || isSyntheticUserText(text)) break;
+				updates.push({
+					sessionUpdate: "user_message_chunk",
+					content: { type: "text", text },
+				});
 				break;
 			}
 			case "thinking": {


### PR DESCRIPTION
Before:
<img width="887" height="411" alt="image" src="https://github.com/user-attachments/assets/536f43f7-30ff-4dba-b1aa-b946e42d4b75" />

After:
<img width="875" height="422" alt="image" src="https://github.com/user-attachments/assets/f1422cd9-c483-4bad-b6fa-ef1d1ba0fe5b" />

