### PR TITLE
feat(telemetry): tag context-window overflow on legacy provider failure events

### DIFF
--- a/apps/vscode/src/core/task/index.ts
+++ b/apps/vscode/src/core/task/index.ts
@@ -2514,16 +2514,18 @@ export class Task {
 				// surface to the user are reported — attempts an auto-retry
 				// absorbs emit nothing, matching the SDK extension, whose
 				// provider layer retries transients silently before any event
-				// exists. Context-window overruns are also excluded — they are
-				// recovered by truncation, not a provider failure.
+				// exists. Truncation-recovered context-window overruns are
+				// likewise unreported: they take the branch above and never
+				// reach here, so reaching this point with an overflow means the
+				// overrun survived a truncation and is surfacing to the user.
+				// It is reported and tagged (see errorClass) rather than
+				// dropped, so it stays countable without inflating the
+				// cohort error rate — dashboards comparing cohorts exclude
+				// error_class = 'context_window_exceeded'.
 				// (`abort` gate: a user cancel unwinds through this catch as a
 				// generic "Cline instance aborted" error — never a provider
 				// failure, and the SDK extension doesn't report cancels either.)
-				if (
-					!isContextWindowExceededError &&
-					!shouldRetry &&
-					!this.taskState.abort
-				) {
+				if (!shouldRetry && !this.taskState.abort) {
 					telemetryService.captureProviderApiError({
 						ulid: this.ulid,
 						model: model.id,
@@ -2533,6 +2535,12 @@ export class Task {
 						requestId: clineError._error?.request_id,
 						errorType: ClineError.getErrorType(clineError),
 						failurePhase: "streaming",
+						// A failure awaiting the provider's first chunk is
+						// definitionally a provider failure, so it is always
+						// classified.
+						errorClass: isContextWindowExceededError
+							? "context_window_exceeded"
+							: "unknown",
 					});
 				}
 
@@ -3673,6 +3681,13 @@ export class Task {
 							requestId: clineError._error?.request_id,
 							errorType: ClineError.getErrorType(clineError),
 							failurePhase: "streaming",
+							// This catch also wraps post-stream processing, so a
+							// failure here is not necessarily a provider error;
+							// only a positive detector match is a confident
+							// classification.
+							...(checkContextWindowExceededError(error)
+								? { errorClass: "context_window_exceeded" as const }
+								: {}),
 						});
 					}
 

--- a/apps/vscode/src/services/telemetry/TelemetryService.ts
+++ b/apps/vscode/src/services/telemetry/TelemetryService.ts
@@ -1436,6 +1436,12 @@ export class TelemetryService {
 			},
 		})
 
+		// Omit the key entirely when unclassified rather than passing
+		// undefined: the OTel provider stringifies undefined attribute values,
+		// which would bucket unclassified failures under a literal "undefined"
+		// instead of leaving the dimension absent.
+		const errorClassAttribute = args.errorClass ? { error_class: args.errorClass } : {}
+
 		this.recordCounter(TelemetryService.METRICS.ERRORS.TOTAL, 1, {
 			ulid: args.ulid,
 			model: args.model,
@@ -1443,7 +1449,7 @@ export class TelemetryService {
 			error_status: args.errorStatus,
 			error_type: args.errorType,
 			failure_phase: args.failurePhase,
-			error_class: args.errorClass,
+			...errorClassAttribute,
 		})
 		const errorAttributes = {
 			ulid: args.ulid,
@@ -1452,7 +1458,7 @@ export class TelemetryService {
 			error_status: args.errorStatus,
 			error_type: args.errorType,
 			failure_phase: args.failurePhase,
-			error_class: args.errorClass,
+			...errorClassAttribute,
 		}
 		const errorCount = this.incrementTaskCounter(this.taskErrorCounts, args.ulid)
 		this.recordHistogram(TelemetryService.METRICS.ERRORS.PER_TASK, errorCount, errorAttributes)

--- a/apps/vscode/src/services/telemetry/TelemetryService.ts
+++ b/apps/vscode/src/services/telemetry/TelemetryService.ts
@@ -1399,6 +1399,7 @@ export class TelemetryService {
 	 * @param requestId Unique identifier for the specific API request
 	 * @param errorMessage Detailed error message from the API provider
 	 * @param errorStatus HTTP status code of the error response, if available
+	 * @param errorClass Cross-architecture failure class ("context_window_exceeded" | "unknown")
 	 * @param collect Optional flag to determine if the event should be collected for batch sending
 	 */
 	public captureProviderApiError(args: {
@@ -1418,6 +1419,12 @@ export class TelemetryService {
 		// comparable without any query-side filtering.
 		errorType?: string | undefined
 		failurePhase?: string | undefined
+		// Failure class shared verbatim with the SDK extension (which attaches
+		// the same property to this event), so one query counts a class across
+		// both rollout cohorts. Orthogonal to errorType: that taxonomy covers
+		// account/transport failures and drives retry control flow, so it is
+		// deliberately not extended with a context-window value.
+		errorClass?: "context_window_exceeded" | "unknown"
 		isNativeToolCall?: boolean
 	}) {
 		this.capture({
@@ -1436,6 +1443,7 @@ export class TelemetryService {
 			error_status: args.errorStatus,
 			error_type: args.errorType,
 			failure_phase: args.failurePhase,
+			error_class: args.errorClass,
 		})
 		const errorAttributes = {
 			ulid: args.ulid,
@@ -1444,6 +1452,7 @@ export class TelemetryService {
 			error_status: args.errorStatus,
 			error_type: args.errorType,
 			failure_phase: args.failurePhase,
+			error_class: args.errorClass,
 		}
 		const errorCount = this.incrementTaskCounter(this.taskErrorCounts, args.ulid)
 		this.recordHistogram(TelemetryService.METRICS.ERRORS.PER_TASK, errorCount, errorAttributes)

--- a/apps/vscode/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
+++ b/apps/vscode/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
@@ -376,6 +376,47 @@ describe("TelemetryService metrics", () => {
 		assert.strictEqual(errorHistogram.attributes.failure_phase, "streaming")
 	})
 
+	it("captureProviderApiError carries errorClass on the event and metric attributes", () => {
+		const provider = new FakeProvider()
+		const service = createTelemetryService(provider)
+
+		service.captureProviderApiError({
+			ulid: "task-overflow",
+			model: "claude",
+			errorMessage: "prompt is too long: 213462 tokens > 200000 maximum",
+			provider: "anthropic",
+			errorType: undefined,
+			failurePhase: "streaming",
+			errorClass: "context_window_exceeded",
+		})
+
+		// errorClass uses the same property name and values as the SDK
+		// extension, so one query counts a class across both cohorts.
+		const failureEvent = provider.logs.find((entry) => entry.event === "task.provider_api_error")
+		assert.ok(failureEvent, "expected task.provider_api_error event")
+		assert.strictEqual(failureEvent?.properties?.errorClass, "context_window_exceeded")
+		assert.strictEqual(provider.counters[0].attributes.error_class, "context_window_exceeded")
+		assert.strictEqual(provider.histograms[0].attributes.error_class, "context_window_exceeded")
+	})
+
+	it("captureProviderApiError omits errorClass when the caller did not classify", () => {
+		const provider = new FakeProvider()
+		const service = createTelemetryService(provider)
+
+		service.captureProviderApiError({
+			ulid: "task-unclassified",
+			model: "claude",
+			errorMessage: "boom",
+			provider: "anthropic",
+			failurePhase: "streaming",
+		})
+
+		const failureEvent = provider.logs.find((entry) => entry.event === "task.provider_api_error")
+		assert.ok(failureEvent, "expected task.provider_api_error event")
+		assert.strictEqual("errorClass" in (failureEvent?.properties ?? {}), false)
+		assert.strictEqual(provider.counters[0].attributes.error_class, undefined)
+	})
+
 	it("captureTaskCompleted records completion payload with TTFT and duration histograms", () => {
 		const provider = new FakeProvider()
 		const service = createTelemetryService(provider)

--- a/apps/vscode/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
+++ b/apps/vscode/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
@@ -411,10 +411,14 @@ describe("TelemetryService metrics", () => {
 			failurePhase: "streaming",
 		})
 
+		// The key must be absent, not present-and-undefined: the OTel provider
+		// stringifies undefined values, which would create a literal
+		// "undefined" bucket instead of an absent dimension.
 		const failureEvent = provider.logs.find((entry) => entry.event === "task.provider_api_error")
 		assert.ok(failureEvent, "expected task.provider_api_error event")
 		assert.strictEqual("errorClass" in (failureEvent?.properties ?? {}), false)
-		assert.strictEqual(provider.counters[0].attributes.error_class, undefined)
+		assert.strictEqual("error_class" in provider.counters[0].attributes, false)
+		assert.strictEqual("error_class" in provider.histograms[0].attributes, false)
 	})
 
 	it("captureTaskCompleted records completion payload with TTFT and duration histograms", () => {


### PR DESCRIPTION
### Related Issue

[ENG-2394](https://linear.app/cline-bot/issue/ENG-2394/vercel-ai-gateway-stream-error-occurred-on-final-response-synthesis). Follow-up to #12812, which brought legacy's provider-failure reporting up to SDK-extension parity but left context-window overruns uncountable on this branch.

### Description

#12812 added `errorType`/`failurePhase` at both provider-failure sites and gated reporting to user-surfaced failures. Overflow, however, still cannot be counted on legacy:

- **First-chunk overruns emit nothing.** The `!isContextWindowExceededError` gate suppresses the capture entirely.
- **Mid-stream overruns emit an untagged event.** `ClineErrorType` has no context-window value, so `getErrorType` returns `undefined` and the failure lands in the untyped bucket, indistinguishable from any other unclassified error. That is exactly the ENG-2394 shape (a gateway failure after streaming began).
- **Cross-cohort comparison is impossible for this class.** The SDK extension attaches `errorClass` to this same event ([#12804](https://github.com/cline/cline/pull/12804)); legacy attaches nothing comparable, so the one-query-covers-both property #12812 established for `errorType`/`failurePhase` does not extend to overflow.

Two telemetry-only changes:

**1. `errorClass` on `task.provider_api_error`.** Values `"context_window_exceeded" | "unknown"`, mirrored into the `errors.total` counter and per-task histogram as `error_class`, alongside #12812's `error_type`/`failure_phase`. One deliberate difference from those two: the metric attribute is omitted entirely when unclassified rather than passed as `undefined`, because the OTel provider stringifies undefined attribute values (`OpenTelemetryTelemetryProvider.ts:374`) and would otherwise create a literal `"undefined"` bucket. (The sibling attributes have that pre-existing behavior; not changed here.) Derived from the existing `checkContextWindowExceededError` detector — the same predicate that gates legacy's auto-truncate recovery, so the metric counts precisely what the runtime treats as an overrun.

Per-site classification confidence follows the SDK extension's convention for this event:

- **First-chunk** (`attemptApiRequest`): always classified. A failure awaiting the provider's first chunk is definitionally a provider failure.
- **Mid-stream** (`recursivelyMakeClineRequests`): tagged only on a positive detector match, omitted otherwise. That catch also wraps post-stream processing, so a generic failure there is not necessarily a provider error.

`errorClass` is deliberately separate from `errorType` rather than a new `ClineErrorType` value: that enum drives retry control flow through `isErrorType()` in these same catch blocks, and extending it would risk a behavior change in a telemetry-only PR.

**2. First-chunk overflow exclusion narrowed from "all overruns" to "recovered overruns".** Truncation-recovered overruns take the `handleContextWindowExceededError` branch and never reach the capture, which sits in the `else`. The additional `!isContextWindowExceededError` guard therefore only suppressed overruns that **already survived one truncation** and are surfacing to the user — including the bricked case (conversation at ≤3 messages, nothing left to truncate), where the task dead-ends with "Context window exceeded. Click retry…" and reports nothing. Those are now reported and tagged.

This preserves #12812's semantics exactly: silently recovered failures still emit nothing, and cohort error-rate comparisons stay apples-to-apples by excluding surfaced overruns — `error_class != 'context_window_exceeded' or error_class is null`, one filter in exchange for the class being countable at all. (The `is null` half matters: mid-stream failures only carry the property on a positive match, and pre-#12812 events have no property at all.) The added slice should be small, since an overrun must survive a truncation to count.

### What this deliberately does NOT do

- No change to retry logic, recovery, truncation, or error UI — telemetry only.
- No new events and no renames; `error_class` is additive alongside #12812's attributes.
- No new classifier. The SDK extension classifies inside `llms` because the AI SDK wraps provider errors before Cline sees them; legacy has no such layer (no `@ai-sdk` dependency — each handler uses the provider's native client), so the errors reaching these catches are the provider-native shapes `checkContextWindowExceededError` already matches. Any detector gap is better fixed in that detector, which fixes recovery and telemetry together.
- `ClineErrorType` is not extended (see above).

### Test Procedure

- Two new unit tests in `TelemetryService.metrics.test.ts`: `errorClass` reaches the event plus both metric attribute sets; the key is absent when the caller does not classify. Passing via the legacy mocha runner.
- Full legacy unit suite: `npm run test:unit` under `apps/vscode` — 1559 passing, 4 pending.
- `tsc --noEmit` clean; `biome lint` clean at error level on the touched files.
- CI note, correcting the caveat carried over from #12812: the substantive workflows *do* run for `legacy-extension` PRs — `ext-vscode-test.yml` lists this branch in its `pull_request` filter, and `ext-vscode-test-e2e.yml` has no branch filter at all. Only the 3-second `test` check is a no-op here. Quality Checks, `vscode test` (both platforms), test-platform-integration, and e2e all ran green on this PR.
