### PR TITLE
Stand down Cline-account auth in legacy straggler windows

### DIFF
--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -74,8 +74,12 @@ export async function activate(context: vscode.ExtensionContext) {
 	setupHostProvider(context)
 
 	// Give the rollout stand-down check access to the loader's cohort memento
-	// (no-op outside combined rollout builds — see rollout-standdown.ts).
-	initializeRolloutStanddown(context)
+	// (no-op outside combined rollout builds — see rollout-standdown.ts). The
+	// reload action is injected here because direct vscode.commands usage is
+	// restricted to this file by the host-bridge lint rules.
+	initializeRolloutStanddown(context, () => {
+		vscode.commands.executeCommand("workbench.action.reloadWindow")
+	})
 
 	// 2. Clean up legacy data patterns within VSCode's native storage.
 	// Moves workspace→global keys, task history→file, custom instructions→rules, etc.

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -51,6 +51,7 @@ import { VscodeWebviewProvider } from "./hosts/vscode/VscodeWebviewProvider"
 import { exportVSCodeStorageToSharedFiles } from "./hosts/vscode/vscode-to-file-migration"
 import { ExtensionRegistryInfo } from "./registry"
 import { AuthService } from "./services/auth/AuthService"
+import { initializeRolloutStanddown } from "./services/auth/rollout-standdown"
 import { LogoutReason } from "./services/auth/types"
 import { telemetryService } from "./services/telemetry"
 import type { RolloutBundleActivation } from "./services/telemetry/rollout-metadata"
@@ -71,6 +72,10 @@ export async function activate(context: vscode.ExtensionContext) {
 	// 1. Set up HostProvider for VSCode
 	// IMPORTANT: This must be done before any service can be registered
 	setupHostProvider(context)
+
+	// Give the rollout stand-down check access to the loader's cohort memento
+	// (no-op outside combined rollout builds — see rollout-standdown.ts).
+	initializeRolloutStanddown(context)
 
 	// 2. Clean up legacy data patterns within VSCode's native storage.
 	// Moves workspace→global keys, task history→file, custom instructions→rules, etc.

--- a/apps/vscode/src/services/auth/AuthService.ts
+++ b/apps/vscode/src/services/auth/AuthService.ts
@@ -12,6 +12,7 @@ import { BannerService } from "../banner/BannerService"
 import { AuthInvalidTokenError, AuthNetworkError } from "../error/ClineError"
 import { featureFlagsService } from "../feature-flags"
 import { ClineAuthProvider } from "./providers/ClineAuthProvider"
+import { notifyRolloutStanddown, shouldStandDownAuth } from "./rollout-standdown"
 import { LogoutReason } from "./types"
 
 export type ServiceConfig = {
@@ -256,6 +257,15 @@ export class AuthService {
 		if (strict && this._authenticated) {
 			this.sendAuthStatusUpdate()
 			return String.create({ value: "Already authenticated" })
+		}
+
+		// Rollout stand-down: signing in from a legacy straggler window would
+		// create a token family the next bundle never sees (its credential
+		// migration runs only once). Point the user at the window reload that
+		// switches them to the next bundle instead.
+		if (shouldStandDownAuth()) {
+			notifyRolloutStanddown()
+			return String.create({ value: "Reload this window to sign in on the new version of Cline" })
 		}
 
 		const callbackUrl = await HostProvider.get().getCallbackUrl("/auth")

--- a/apps/vscode/src/services/auth/AuthService.ts
+++ b/apps/vscode/src/services/auth/AuthService.ts
@@ -259,10 +259,11 @@ export class AuthService {
 			return String.create({ value: "Already authenticated" })
 		}
 
-		// Rollout stand-down: signing in from a legacy straggler window would
-		// create a token family the next bundle never sees (its credential
-		// migration runs only once). Point the user at the window reload that
-		// switches them to the next bundle instead.
+		// Rollout stand-down: the next bundle already holds Cline credentials
+		// on this machine, so signing in from this legacy straggler window
+		// would create a competing token family next never adopts (its
+		// migration never overwrites an existing cline entry). Point the user
+		// at the window reload that switches them to the next bundle instead.
 		if (shouldStandDownAuth()) {
 			notifyRolloutStanddown()
 			return String.create({ value: "Reload this window to sign in on the new version of Cline" })

--- a/apps/vscode/src/services/auth/__tests__/rollout-standdown.test.ts
+++ b/apps/vscode/src/services/auth/__tests__/rollout-standdown.test.ts
@@ -1,15 +1,21 @@
-import * as assert from "assert"
-import { decideStanddown, resetRolloutStanddownForTests, shouldStandDownAuth } from "../rollout-standdown"
+import * as assert from "node:assert"
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
+import {
+	decideStanddown,
+	nextBundleOwnsClineAccount,
+	resetRolloutStanddownForTests,
+	shouldStandDownAuth,
+} from "../rollout-standdown"
 
 const originalVariant = process.env.CLINE_ROLLOUT_VARIANT
+const originalDataDir = process.env.CLINE_DATA_DIR
 
 afterEach(() => {
 	resetRolloutStanddownForTests()
-	if (originalVariant === undefined) {
-		delete process.env.CLINE_ROLLOUT_VARIANT
-	} else {
-		process.env.CLINE_ROLLOUT_VARIANT = originalVariant
-	}
+	restoreEnv("CLINE_ROLLOUT_VARIANT", originalVariant)
+	restoreEnv("CLINE_DATA_DIR", originalDataDir)
 })
 
 describe("rollout auth stand-down", () => {
@@ -18,6 +24,7 @@ describe("rollout auth stand-down", () => {
 		settingOverride: undefined,
 		cached: undefined,
 		previousFailure: false,
+		nextOwnsClineAccount: true,
 	}
 
 	it("stands down only when the cached cohort assignment is next", () => {
@@ -25,6 +32,15 @@ describe("rollout auth stand-down", () => {
 		assert.strictEqual(decideStanddown({ ...base, cached: "legacy" }), false)
 		assert.strictEqual(decideStanddown({ ...base, cached: undefined }), false)
 		assert.strictEqual(decideStanddown({ ...base, cached: "garbage" }), false)
+	})
+
+	it("never stands down until the next bundle holds the Cline credentials", () => {
+		// Single-window case: the cohort flag flipped mid-session, but next has
+		// never activated (or holds no cline refresh token) — this window is the
+		// sole owner of the token family and must keep working untouched.
+		assert.strictEqual(decideStanddown({ ...base, cached: "next", nextOwnsClineAccount: false }), false)
+		// Both conditions hold: straggler alongside an active next bundle.
+		assert.strictEqual(decideStanddown({ ...base, cached: "next", nextOwnsClineAccount: true }), true)
 	})
 
 	it("never stands down when the user forced a bundle (mirrors the loader's precedence)", () => {
@@ -57,3 +73,74 @@ describe("rollout auth stand-down", () => {
 		assert.strictEqual(shouldStandDownAuth(), false)
 	})
 })
+
+describe("nextBundleOwnsClineAccount", () => {
+	let tempDir: string
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "standdown-probe-"))
+		process.env.CLINE_DATA_DIR = tempDir
+	})
+
+	afterEach(() => {
+		fs.rmSync(tempDir, { recursive: true, force: true })
+	})
+
+	function writeProvidersFile(contents: string): void {
+		const dir = path.join(tempDir, "settings")
+		fs.mkdirSync(dir, { recursive: true })
+		fs.writeFileSync(path.join(dir, "providers.json"), contents)
+	}
+
+	it("is false when providers.json does not exist (next never activated)", () => {
+		assert.strictEqual(nextBundleOwnsClineAccount(), false)
+	})
+
+	it("is false when the cline entry has no auth (e.g. CLI picked a model but never signed in)", () => {
+		writeProvidersFile(
+			JSON.stringify({
+				version: 1,
+				providers: {
+					cline: {
+						settings: { provider: "cline", model: "anthropic/claude-sonnet-4.6" },
+						updatedAt: "2026-01-01T00:00:00Z",
+						tokenSource: "manual",
+					},
+				},
+			}),
+		)
+		assert.strictEqual(nextBundleOwnsClineAccount(), false)
+	})
+
+	it("is true when the cline entry holds a refresh token (migrated or signed in on next)", () => {
+		writeProvidersFile(
+			JSON.stringify({
+				version: 1,
+				providers: {
+					cline: {
+						settings: {
+							provider: "cline",
+							auth: { accessToken: "at", refreshToken: "rt-1", accountId: "user_1" },
+						},
+						updatedAt: "2026-01-01T00:00:00Z",
+						tokenSource: "migration",
+					},
+				},
+			}),
+		)
+		assert.strictEqual(nextBundleOwnsClineAccount(), true)
+	})
+
+	it("fails open on malformed json", () => {
+		writeProvidersFile("{not json")
+		assert.strictEqual(nextBundleOwnsClineAccount(), false)
+	})
+})
+
+function restoreEnv(key: "CLINE_ROLLOUT_VARIANT" | "CLINE_DATA_DIR", value: string | undefined): void {
+	if (value === undefined) {
+		delete process.env[key]
+	} else {
+		process.env[key] = value
+	}
+}

--- a/apps/vscode/src/services/auth/__tests__/rollout-standdown.test.ts
+++ b/apps/vscode/src/services/auth/__tests__/rollout-standdown.test.ts
@@ -1,0 +1,59 @@
+import * as assert from "assert"
+import { decideStanddown, resetRolloutStanddownForTests, shouldStandDownAuth } from "../rollout-standdown"
+
+const originalVariant = process.env.CLINE_ROLLOUT_VARIANT
+
+afterEach(() => {
+	resetRolloutStanddownForTests()
+	if (originalVariant === undefined) {
+		delete process.env.CLINE_ROLLOUT_VARIANT
+	} else {
+		process.env.CLINE_ROLLOUT_VARIANT = originalVariant
+	}
+})
+
+describe("rollout auth stand-down", () => {
+	const base = {
+		envOverride: undefined,
+		settingOverride: undefined,
+		cached: undefined,
+		previousFailure: false,
+	}
+
+	it("stands down only when the cached cohort assignment is next", () => {
+		assert.strictEqual(decideStanddown({ ...base, cached: "next" }), true)
+		assert.strictEqual(decideStanddown({ ...base, cached: "legacy" }), false)
+		assert.strictEqual(decideStanddown({ ...base, cached: undefined }), false)
+		assert.strictEqual(decideStanddown({ ...base, cached: "garbage" }), false)
+	})
+
+	it("never stands down when the user forced a bundle (mirrors the loader's precedence)", () => {
+		// Forced legacy: the user deliberately keeps this window on legacy.
+		assert.strictEqual(decideStanddown({ ...base, cached: "next", envOverride: "legacy" }), false)
+		assert.strictEqual(decideStanddown({ ...base, cached: "next", settingOverride: "legacy" }), false)
+		// Forced next: the loader would never have activated this bundle; be safe anyway.
+		assert.strictEqual(decideStanddown({ ...base, cached: "next", envOverride: "next" }), false)
+		assert.strictEqual(decideStanddown({ ...base, cached: "next", settingOverride: "next" }), false)
+		// "auto" is not an override.
+		assert.strictEqual(decideStanddown({ ...base, cached: "next", settingOverride: "auto" }), true)
+	})
+
+	it("never stands down when the loader crash-pinned this VSIX version to legacy", () => {
+		assert.strictEqual(decideStanddown({ ...base, cached: "next", previousFailure: true }), false)
+	})
+
+	it("shouldStandDownAuth is inert outside combined rollout legacy builds", () => {
+		// Standalone/marketplace/dev builds have no CLINE_ROLLOUT_VARIANT: a
+		// leftover loader memento must never disable auth there.
+		delete process.env.CLINE_ROLLOUT_VARIANT
+		assert.strictEqual(shouldStandDownAuth(), false)
+
+		process.env.CLINE_ROLLOUT_VARIANT = "next"
+		assert.strictEqual(shouldStandDownAuth(), false)
+	})
+
+	it("shouldStandDownAuth is inert before initialization even in rollout legacy builds", () => {
+		process.env.CLINE_ROLLOUT_VARIANT = "legacy"
+		assert.strictEqual(shouldStandDownAuth(), false)
+	})
+})

--- a/apps/vscode/src/services/auth/providers/ClineAuthProvider.ts
+++ b/apps/vscode/src/services/auth/providers/ClineAuthProvider.ts
@@ -11,6 +11,7 @@ import { fetch, getAxiosSettings } from "@/shared/net"
 import { Logger } from "@/shared/services/Logger"
 import { type ClineAccountUserInfo, type ClineAuthInfo } from "../AuthService"
 import { parseJwtPayload } from "../oca/utils/utils"
+import { notifyRolloutStanddown, shouldStandDownAuth } from "../rollout-standdown"
 
 interface ClineAuthApiUser {
 	subject: string | null
@@ -188,6 +189,22 @@ export class ClineAuthProvider {
 			}
 
 			if (await this.shouldRefreshIdToken(storedAuthData.refreshToken, storedAuthData.expiresAt)) {
+				// Rollout stand-down: this machine is assigned to the next
+				// bundle, so this legacy window must never rotate the shared
+				// refresh token again (the next bundle owns the token family
+				// now — a rotation from here would strand it with a consumed
+				// token). Keep using the current access token until it truly
+				// expires, then surface a "reload this window" notice instead
+				// of refreshing. The stored blob is deliberately left intact.
+				if (shouldStandDownAuth()) {
+					if (this.timeUntilExpiry(storedAuthData.idToken) > 30) {
+						return storedAuthData
+					}
+					Logger.debug("Rollout stand-down: suppressing token refresh in legacy straggler window")
+					notifyRolloutStanddown()
+					return null
+				}
+
 				// If the token hasn't expired yet,
 				// and it failed the first refresh attempt
 				// with something other than invalid token

--- a/apps/vscode/src/services/auth/providers/ClineAuthProvider.ts
+++ b/apps/vscode/src/services/auth/providers/ClineAuthProvider.ts
@@ -190,12 +190,13 @@ export class ClineAuthProvider {
 
 			if (await this.shouldRefreshIdToken(storedAuthData.refreshToken, storedAuthData.expiresAt)) {
 				// Rollout stand-down: this machine is assigned to the next
-				// bundle, so this legacy window must never rotate the shared
-				// refresh token again (the next bundle owns the token family
-				// now — a rotation from here would strand it with a consumed
-				// token). Keep using the current access token until it truly
-				// expires, then surface a "reload this window" notice instead
-				// of refreshing. The stored blob is deliberately left intact.
+				// bundle AND next already holds a copy of these credentials,
+				// so this legacy window must never rotate the shared refresh
+				// token again (a rotation from here would strand next with a
+				// consumed token). Keep using the current access token until
+				// it truly expires, then surface a "reload this window" notice
+				// instead of refreshing. The stored blob is deliberately left
+				// intact.
 				if (shouldStandDownAuth()) {
 					if (this.timeUntilExpiry(storedAuthData.idToken) > 30) {
 						return storedAuthData

--- a/apps/vscode/src/services/auth/rollout-standdown.ts
+++ b/apps/vscode/src/services/auth/rollout-standdown.ts
@@ -1,0 +1,146 @@
+import * as vscode from "vscode"
+import { getExtensionVariant } from "@/services/telemetry/rollout-metadata"
+import { Logger } from "@/shared/services/Logger"
+
+// ---------------------------------------------------------------------------
+// Rollout auth stand-down
+//
+// During the combined-VSIX A/B rollout, this (legacy) bundle and the next
+// (SDK) bundle keep Cline-account credentials in different stores, and the
+// refresh endpoint ROTATES the refresh token: whichever bundle refreshes
+// last strands the other with a consumed token and a hard logout.
+//
+// Once this machine is assigned to the next cohort, any still-open legacy
+// window is a straggler that will be replaced by next on its reload. Instead
+// of letting it keep rotating the shared refresh token (and eventually
+// logging the user out everywhere with a confusing auth error), it stands
+// down: it never refreshes/rotates again, keeps working until its current
+// access token naturally expires, and then presents a clear "reload this
+// window to continue on the new version" message.
+//
+// Critically, standing down NEVER clears the stored credential blob — the
+// next bundle's one-time migration reads it, and a demotion back to legacy
+// must find it intact.
+// ---------------------------------------------------------------------------
+
+/**
+ * Loader-owned state and settings, mirrored from apps/vscode-rollout on main
+ * (src/cohort.ts) — keep in sync. The loader shares this extension's
+ * globalState, so the memento keys are directly readable here.
+ */
+export const COHORT_STATE_KEY = "cline.rollout.bundle"
+export const FAILED_VERSION_STATE_KEY = "cline.rollout.nextActivationFailedVersion"
+export const BUNDLE_OVERRIDE_ENV = "CLINE_BUNDLE_OVERRIDE"
+export const SETTING_BUNDLE_OVERRIDE = "bundleOverride"
+const NIGHTLY_EXTENSION_NAME = "cline-nightly"
+
+export interface StanddownInputs {
+	/** CLINE_BUNDLE_OVERRIDE, if set. Beats everything (mirrors the loader). */
+	envOverride: string | undefined
+	/** The <prefix>.rollout.bundleOverride user setting ("auto" = no override). */
+	settingOverride: string | undefined
+	/** The loader's cached cohort assignment ("next" | "legacy" | undefined). */
+	cached: string | undefined
+	/** The next bundle failed to activate on this VSIX version (loader pinned legacy). */
+	previousFailure: boolean
+}
+
+function asBundle(value: unknown): "next" | "legacy" | undefined {
+	return value === "next" || value === "legacy" ? value : undefined
+}
+
+/**
+ * Whether a legacy window should stand down its Cline-account auth. Mirrors
+ * the loader's decideBundle(): the answer is "the next window reload on this
+ * machine will activate the next bundle". Overrides and the crash pin keep
+ * this window fully functional — the user (or the loader's safety net)
+ * explicitly chose legacy in those cases.
+ */
+export function decideStanddown(inputs: StanddownInputs): boolean {
+	const forced = asBundle(inputs.envOverride) ?? asBundle(inputs.settingOverride)
+	if (forced) {
+		return false // forced legacy keeps working; forced next never activates this bundle
+	}
+	if (inputs.previousFailure) {
+		return false
+	}
+	return inputs.cached === "next"
+}
+
+let extensionContext: vscode.ExtensionContext | undefined
+let notified = false
+
+/** Called once from activate() so the cohort memento can be read later. */
+export function initializeRolloutStanddown(context: vscode.ExtensionContext): void {
+	extensionContext = context
+}
+
+function readInputs(context: vscode.ExtensionContext): StanddownInputs {
+	const packageJSON = (context.extension?.packageJSON ?? {}) as {
+		name?: string
+		version?: string
+	}
+	const prefix = packageJSON.name === NIGHTLY_EXTENSION_NAME ? "cline-nightly" : "cline"
+	return {
+		envOverride: process.env[BUNDLE_OVERRIDE_ENV],
+		settingOverride: vscode.workspace.getConfiguration(`${prefix}.rollout`).get<string>(SETTING_BUNDLE_OVERRIDE),
+		cached: context.globalState.get<string>(COHORT_STATE_KEY),
+		previousFailure:
+			packageJSON.version !== undefined &&
+			context.globalState.get<string>(FAILED_VERSION_STATE_KEY) === packageJSON.version,
+	}
+}
+
+/**
+ * True when this window is a legacy straggler on a machine assigned to the
+ * next cohort. Re-reads the loader's memento on every call so a demotion
+ * (flag dialed back down) re-enables auth without a reload.
+ *
+ * Only ever true for bundles built by the combined rollout workflow
+ * (CLINE_ROLLOUT_VARIANT="legacy") — standalone/marketplace legacy builds and
+ * dev builds never stand down, even if a loader memento is present.
+ */
+export function shouldStandDownAuth(): boolean {
+	if (getExtensionVariant() !== "legacy") {
+		return false
+	}
+	const context = extensionContext
+	if (!context) {
+		return false
+	}
+	try {
+		return decideStanddown(readInputs(context))
+	} catch (error) {
+		Logger.error("[RolloutStanddown] Failed to evaluate cohort state:", error)
+		return false
+	}
+}
+
+/**
+ * One-time-per-window notice shown when auth actually stands down (token
+ * expired and refresh was suppressed, or the user tried to sign in here).
+ */
+export function notifyRolloutStanddown(): void {
+	if (notified) {
+		return
+	}
+	notified = true
+	const reload = "Reload Window"
+	vscode.window
+		.showWarningMessage(
+			"You've been signed out in this window because this machine was upgraded to the new version of Cline. " +
+				"Reload the window to keep using your account on the new version.",
+			reload,
+		)
+		.then((choice) => {
+			if (choice === reload) {
+				vscode.commands.executeCommand("workbench.action.reloadWindow")
+			}
+		})
+}
+
+/** Test-only: reset module state between tests. */
+export function resetRolloutStanddownForTests(): void {
+	extensionContext = undefined
+	notified = false
+}

--- a/apps/vscode/src/services/auth/rollout-standdown.ts
+++ b/apps/vscode/src/services/auth/rollout-standdown.ts
@@ -1,3 +1,6 @@
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
 import * as vscode from "vscode"
 import { getExtensionVariant } from "@/services/telemetry/rollout-metadata"
 import { Logger } from "@/shared/services/Logger"
@@ -10,17 +13,30 @@ import { Logger } from "@/shared/services/Logger"
 // refresh endpoint ROTATES the refresh token: whichever bundle refreshes
 // last strands the other with a consumed token and a hard logout.
 //
-// Once this machine is assigned to the next cohort, any still-open legacy
-// window is a straggler that will be replaced by next on its reload. Instead
-// of letting it keep rotating the shared refresh token (and eventually
-// logging the user out everywhere with a confusing auth error), it stands
-// down: it never refreshes/rotates again, keeps working until its current
-// access token naturally expires, and then presents a clear "reload this
-// window to continue on the new version" message.
+// That hazard needs TWO holders of the same token family. The second holder
+// is born when the next bundle first activates on this machine and its
+// credential migration copies the legacy blob into providers.json (or the
+// user signs in on next directly). So a legacy window stands down only when
+// BOTH are true:
+//
+//   1. the loader's cached cohort assignment says this machine's next window
+//      reload activates the next bundle, and
+//   2. next demonstrably holds Cline-account credentials on this machine
+//      (providers.json has a cline entry with a refresh token).
+//
+// Until (2), the user may be sitting in their one and only window after the
+// cohort flag flipped mid-session — that window is the SOLE owner of the
+// token family, its rotations are harmless, and they keep the blob fresh for
+// the eventual migration. It must keep working untouched, indefinitely.
+//
+// Once both hold, the straggler stands down: it never refreshes/rotates
+// again, keeps working until its current access token naturally expires, and
+// then presents a clear "reload this window to continue on the new version"
+// message.
 //
 // Critically, standing down NEVER clears the stored credential blob — the
-// next bundle's one-time migration reads it, and a demotion back to legacy
-// must find it intact.
+// next bundle's migration reads it, and a demotion back to legacy must find
+// it intact.
 // ---------------------------------------------------------------------------
 
 /**
@@ -43,6 +59,8 @@ export interface StanddownInputs {
 	cached: string | undefined
 	/** The next bundle failed to activate on this VSIX version (loader pinned legacy). */
 	previousFailure: boolean
+	/** The next bundle holds Cline-account credentials on this machine (see nextBundleOwnsClineAccount). */
+	nextOwnsClineAccount: boolean
 }
 
 function asBundle(value: unknown): "next" | "legacy" | undefined {
@@ -51,10 +69,12 @@ function asBundle(value: unknown): "next" | "legacy" | undefined {
 
 /**
  * Whether a legacy window should stand down its Cline-account auth. Mirrors
- * the loader's decideBundle(): the answer is "the next window reload on this
- * machine will activate the next bundle". Overrides and the crash pin keep
- * this window fully functional — the user (or the loader's safety net)
- * explicitly chose legacy in those cases.
+ * the loader's decideBundle() precedence, then additionally requires that the
+ * next bundle has actually taken co-ownership of the Cline account: "the next
+ * window reload on this machine activates next AND next already holds the
+ * credentials". Overrides and the crash pin keep this window fully
+ * functional — the user (or the loader's safety net) explicitly chose legacy
+ * in those cases.
  */
 export function decideStanddown(inputs: StanddownInputs): boolean {
 	const forced = asBundle(inputs.envOverride) ?? asBundle(inputs.settingOverride)
@@ -64,7 +84,49 @@ export function decideStanddown(inputs: StanddownInputs): boolean {
 	if (inputs.previousFailure) {
 		return false
 	}
-	return inputs.cached === "next"
+	return inputs.cached === "next" && inputs.nextOwnsClineAccount
+}
+
+/**
+ * Where the next (SDK) bundle keeps its data. Mirrors the SDK's
+ * resolveDataDirFromEnv() on main (apps/vscode/src/shared/storage/
+ * storage-context.ts) — keep in sync: CLINE_DATA_DIR > CLINE_DIR/data >
+ * ~/.cline/data.
+ */
+function resolveNextDataDir(): string {
+	const envDataDir = process.env.CLINE_DATA_DIR?.trim()
+	if (envDataDir) {
+		return envDataDir
+	}
+	const clineDir = process.env.CLINE_DIR?.trim() || path.join(os.homedir(), ".cline")
+	return path.join(clineDir, "data")
+}
+
+/**
+ * True when the next bundle demonstrably co-owns the Cline account on this
+ * machine: its providers.json has a cline entry holding a refresh token —
+ * written either by its credential migration on first activation (which
+ * copies this legacy blob) or by a sign-in performed on next (including the
+ * CLI, which shares the same store and also rotates).
+ *
+ * A cline entry WITHOUT auth (e.g. the CLI configured a model but never
+ * signed in) does not count: whoever holds no refresh token cannot rotate,
+ * so this window rotating strands nobody.
+ *
+ * Deliberately fail-open: no file, unreadable, or malformed → false, auth
+ * keeps working.
+ */
+export function nextBundleOwnsClineAccount(): boolean {
+	try {
+		const file = path.join(resolveNextDataDir(), "settings", "providers.json")
+		const parsed = JSON.parse(fs.readFileSync(file, "utf8")) as {
+			providers?: Record<string, { settings?: { auth?: { refreshToken?: unknown } } }>
+		}
+		const refreshToken = parsed?.providers?.cline?.settings?.auth?.refreshToken
+		return typeof refreshToken === "string" && refreshToken.length > 0
+	} catch {
+		return false
+	}
 }
 
 let extensionContext: vscode.ExtensionContext | undefined
@@ -88,13 +150,17 @@ function readInputs(context: vscode.ExtensionContext): StanddownInputs {
 		previousFailure:
 			packageJSON.version !== undefined &&
 			context.globalState.get<string>(FAILED_VERSION_STATE_KEY) === packageJSON.version,
+		nextOwnsClineAccount: nextBundleOwnsClineAccount(),
 	}
 }
 
 /**
  * True when this window is a legacy straggler on a machine assigned to the
- * next cohort. Re-reads the loader's memento on every call so a demotion
- * (flag dialed back down) re-enables auth without a reload.
+ * next cohort AND the next bundle already holds the Cline credentials.
+ * Re-reads the loader's memento and providers.json on every call, so both a
+ * demotion (flag dialed back down) and next releasing the credentials
+ * re-enable auth without a reload — and a next window activating alongside
+ * this one engages the stand-down without a reload.
  *
  * Only ever true for bundles built by the combined rollout workflow
  * (CLINE_ROLLOUT_VARIANT="legacy") — standalone/marketplace legacy builds and

--- a/apps/vscode/src/services/auth/rollout-standdown.ts
+++ b/apps/vscode/src/services/auth/rollout-standdown.ts
@@ -2,7 +2,9 @@ import * as fs from "node:fs"
 import * as os from "node:os"
 import * as path from "node:path"
 import * as vscode from "vscode"
+import { HostProvider } from "@/hosts/host-provider"
 import { getExtensionVariant } from "@/services/telemetry/rollout-metadata"
+import { ShowMessageType } from "@/shared/proto/host/window"
 import { Logger } from "@/shared/services/Logger"
 
 // ---------------------------------------------------------------------------
@@ -130,11 +132,18 @@ export function nextBundleOwnsClineAccount(): boolean {
 }
 
 let extensionContext: vscode.ExtensionContext | undefined
+let reloadWindowCallback: (() => void) | undefined
 let notified = false
 
-/** Called once from activate() so the cohort memento can be read later. */
-export function initializeRolloutStanddown(context: vscode.ExtensionContext): void {
+/**
+ * Called once from activate() so the cohort memento can be read later.
+ * The window reload is injected as a callback because direct
+ * vscode.commands usage is restricted to extension.ts by the host-bridge
+ * lint rules (src/dev/grit/vscode-api.grit).
+ */
+export function initializeRolloutStanddown(context: vscode.ExtensionContext, reloadWindow?: () => void): void {
 	extensionContext = context
+	reloadWindowCallback = reloadWindow
 }
 
 function readInputs(context: vscode.ExtensionContext): StanddownInputs {
@@ -192,21 +201,27 @@ export function notifyRolloutStanddown(): void {
 	}
 	notified = true
 	const reload = "Reload Window"
-	vscode.window
-		.showWarningMessage(
-			"You've been signed out in this window because this machine was upgraded to the new version of Cline. " +
+	HostProvider.window
+		.showMessage({
+			type: ShowMessageType.WARNING,
+			message:
+				"You've been signed out in this window because this machine was upgraded to the new version of Cline. " +
 				"Reload the window to keep using your account on the new version.",
-			reload,
-		)
-		.then((choice) => {
-			if (choice === reload) {
-				vscode.commands.executeCommand("workbench.action.reloadWindow")
+			options: { items: [reload] },
+		})
+		.then((response) => {
+			if (response.selectedOption === reload) {
+				reloadWindowCallback?.()
 			}
+		})
+		.catch((error) => {
+			Logger.error("[RolloutStanddown] Failed to show stand-down notice:", error)
 		})
 }
 
 /** Test-only: reset module state between tests. */
 export function resetRolloutStanddownForTests(): void {
 	extensionContext = undefined
+	reloadWindowCallback = undefined
 	notified = false
 }


### PR DESCRIPTION
### Related Issue

Internal investigation — Cline-account auth errors on `extension_variant='next'` in the `ext-sdk-bundle-rollout` stable cohort.

### Description

**Root cause.** The combined A/B VSIX runs the legacy and next bundles against two different credential stores (legacy's `cline:clineAccountId` blob vs next's `providers.json`), bridged only by a one-shot migration at first promotion. `/api/v1/auth/refresh` ROTATES the refresh token (one-time use), so after a machine is promoted, a still-open legacy window and the next bundle each hold a copy of the same token family — whichever refreshes first strands the other with a consumed token. That produces the `Unauthorized: … re-authenticate your Cline account` / `Please sign in to Cline` cluster on next, and silent hard-logouts in legacy windows (invisible in `provider_api_error`, which legacy doesn't emit for auth failures). Reproduced end-to-end with the shipped 4.1.2 VSIX against a mock gateway with rotating tokens.

**Approach: one active bundle per machine.** Rather than reconcile two stores, the legacy straggler stands down. Once the loader's cached cohort assignment says this machine's next reload activates the next bundle (and no `CLINE_BUNDLE_OVERRIDE`, `bundleOverride` setting, or crash pin forces legacy), a legacy window:

- never refreshes/rotates the token again — the guard sits at the single rotation site (`ClineAuthProvider.retrieveClineAuthInfo`), covering startup restore and the cross-window secret handler too;
- keeps working normally on its current access token until it naturally expires;
- at expiry, shows a one-time notice — "You've been signed out in this window because this machine was upgraded to the new version of Cline. Reload the window to keep using your account on the new version." with a Reload Window button — instead of dying with a raw `Unauthorized` error;
- blocks new sign-ins from that window with the same guidance;
- never clears the stored credential blob (next's first-promotion migration must read it; a demotion must find it intact).

The decision mirrors the loader's `decideBundle()` precedence exactly (constants mirrored from `apps/vscode-rollout/src/cohort.ts` on main). It re-reads the memento on every check, so a demotion re-enables legacy auth without a reload. The whole feature is gated on the build-time `CLINE_ROLLOUT_VARIANT="legacy"` stamp, so standalone/marketplace and dev builds are completely unaffected.

**Not fixed here (documented):** two small next-side bugs on `main` still produce a slice of the cluster on their own (a task-resume path that sends a request with no Authorization header → `Missing Authentication header`, and `getAuthToken` discarding a successful refresh of an expired token). The CLI sharing `~/.cline` can still rotate past a legacy window (pre-existing).

### Test Procedure

- **Unit tests** (`src/services/auth/__tests__/rollout-standdown.test.ts`): cohort gating, loader-precedence mirroring (overrides/crash pin never stand down), inertness outside rollout builds. Full legacy unit suite passes (1567 tests); `tsc --noEmit` clean.
- **Live end-to-end** with a real combined VSIX (this branch's legacy bundle stitched with main's next bundle via `apps/vscode-rollout`), driven through the actual loader against a mock gateway with rotating one-time-use refresh tokens and a mock `/dec