### PR TITLE
fix(cli): show plain text when prefilling a restored checkpoint message

### DIFF
--- a/apps/cli/src/tui/root.tsx
+++ b/apps/cli/src/tui/root.tsx
@@ -416,7 +416,11 @@ function App(props: TuiProps) {
 			session.replaceEntries(entries);
 			session.setHasSubmitted(entries.length > 0);
 			setAppView(entries.length > 0 ? "chat" : "home");
-			populateInputRef.current(picked.fullText);
+			// Prefill the display form of the rewound message, not the raw
+			// stored text: the runtime wraps outbound prompts in a
+			// <user_input mode="..."> envelope, which must not leak into the
+			// input box the user is about to edit and re-send.
+			populateInputRef.current(formatDisplayUserInput(picked.fullText));
 			showToast("Restored to checkpoint", "success");
 		} catch (error) {
 			const message = `Checkpoint restore failed: ${error instanceof Error ? error.message : String(error)}`;


### PR DESCRIPTION
### Related Issue

**Issue:** N/A — small UI polish bug found during checkpoint QA.

### Description

After a checkpoint restore in the CLI (`/undo` or Esc-Esc), the rewound user message is dropped back into the input box so you can edit and re-send it. It was being prefilled from the message's **raw stored text**, which the runtime wraps in a `<user_input mode="...">` envelope before sending to the model. So instead of the text you typed, the input showed:

```
<user_input mode="act">Now change app.txt to exactly VERSION-3 and notes.txt to exactly DRAFT-2. No other changes.</user_input>
```

The fix prefills the **display form** via `formatDisplayUserInput()` — the same helper already used a few lines above to render the checkpoint picker preview, and already imported in this file — which strips the envelope and preserves slash-command display form (e.g. `/compact`). One-line change in the restore handler in `apps/cli/src/tui/root.tsx`.

### Test Procedure

- Verified the exact leaked string from the repro round-trips to clean text through `formatDisplayUserInput` (`<user_input mode="act">…</user_input>` → the plain sentence), that plain text is untouched, and that `<user_command slash="compact">` → `/compact`.
- `tsc --noEmit` on `apps/cli` is clean for `root.tsx` (the only pre-existing errors are in the unrelated `cli.tuistory.e2e.test.ts`, present on `main` too).
- No behavior change beyond the prefilled input string; the restore itself is unchanged.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore
-   [x] Tests are passing and code is formatted and linted
-   [x] I have reviewed the contributor guidelines