### PR TITLE
fix(settings): persist custom base URL checkbox state and stop keystroke loss in URL fields

### DIFF
--- a/apps/vscode/webview-ui/src/components/settings/common/BaseUrlField.test.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/common/BaseUrlField.test.tsx
@@ -1,0 +1,77 @@
+import { act, fireEvent, render, screen } from "@testing-library/react"
+import type { ChangeEventHandler, ReactNode } from "react"
+import { describe, expect, it, vi } from "vitest"
+import { BaseUrlField } from "./BaseUrlField"
+
+vi.mock("@vscode/webview-ui-toolkit/react", () => ({
+	VSCodeCheckbox: ({
+		checked,
+		children,
+		onChange,
+	}: {
+		checked?: boolean
+		children?: ReactNode
+		onChange?: ChangeEventHandler<HTMLInputElement>
+	}) => (
+		<label>
+			<input checked={checked} onChange={onChange} type="checkbox" />
+			{children}
+		</label>
+	),
+	VSCodeTextField: ({
+		onInput,
+		placeholder,
+		value,
+	}: {
+		onInput?: ChangeEventHandler<HTMLInputElement>
+		placeholder?: string
+		value?: string
+	}) => <input onChange={onInput} placeholder={placeholder} value={value} />,
+}))
+
+async function flushDebounce() {
+	await act(async () => {
+		await new Promise((resolve) => setTimeout(resolve, 150))
+	})
+}
+
+describe("BaseUrlField", () => {
+	it("checks the box and shows the URL once the saved value loads asynchronously", () => {
+		// Provider config is fetched after mount, so the saved base URL
+		// arrives as an initialValue update rather than at first render.
+		const onChange = vi.fn()
+		const { rerender } = render(<BaseUrlField initialValue={undefined} onChange={onChange} />)
+
+		expect(screen.getByRole("checkbox")).not.toBeChecked()
+
+		rerender(<BaseUrlField initialValue="https://proxy.example.com" onChange={onChange} />)
+
+		expect(screen.getByRole("checkbox")).toBeChecked()
+		expect(screen.getByRole("textbox")).toHaveValue("https://proxy.example.com")
+		expect(onChange).not.toHaveBeenCalled()
+	})
+
+	it("stays unchecked after the user unchecks it, even if a stale value echoes back", () => {
+		const onChange = vi.fn()
+		const { rerender } = render(<BaseUrlField initialValue="https://proxy.example.com" onChange={onChange} />)
+
+		fireEvent.click(screen.getByRole("checkbox"))
+		expect(screen.getByRole("checkbox")).not.toBeChecked()
+		expect(onChange).toHaveBeenCalledWith("")
+
+		// A stale echo of the old config must not re-check the box.
+		rerender(<BaseUrlField initialValue="https://proxy.example.com" onChange={onChange} />)
+		expect(screen.getByRole("checkbox")).not.toBeChecked()
+	})
+
+	it("saves the trimmed URL after typing", async () => {
+		const onChange = vi.fn()
+		render(<BaseUrlField initialValue={undefined} onChange={onChange} />)
+
+		fireEvent.click(screen.getByRole("checkbox"))
+		fireEvent.change(screen.getByRole("textbox"), { target: { value: "https://proxy.example.com " } })
+
+		await flushDebounce()
+		expect(onChange).toHaveBeenLastCalledWith("https://proxy.example.com")
+	})
+})

--- a/apps/vscode/webview-ui/src/components/settings/common/BaseUrlField.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/common/BaseUrlField.tsx
@@ -1,5 +1,5 @@
 import { VSCodeCheckbox, VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
-import { useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { useDebouncedInput } from "../utils/useDebouncedInput"
 
 /**
@@ -27,10 +27,21 @@ export const BaseUrlField = ({
 	showLockIcon = false,
 }: BaseUrlFieldProps) => {
 	const [isEnabled, setIsEnabled] = useState(!!initialValue)
-	const [localValue, setLocalValue] = useDebouncedInput(initialValue || "", onChange)
+	const userToggledRef = useRef(false)
+	const [localValue, setLocalValue] = useDebouncedInput(initialValue || "", (value: string) => onChange(value.trim()))
+
+	// Provider config loads asynchronously, so a saved base URL usually arrives
+	// after mount (initialValue starts undefined). Reflect it in the checkbox
+	// once it lands, unless the user has already toggled the box themselves.
+	useEffect(() => {
+		if (!userToggledRef.current) {
+			setIsEnabled(!!initialValue)
+		}
+	}, [initialValue])
 
 	const handleToggle = (e: any) => {
 		const checked = e.target.checked === true
+		userToggledRef.current = true
 		setIsEnabled(checked)
 		if (!checked) {
 			setLocalValue("")
@@ -50,7 +61,7 @@ export const BaseUrlField = ({
 			{isEnabled && (
 				<VSCodeTextField
 					disabled={disabled}
-					onInput={(e: any) => setLocalValue(e.target.value.trim())}
+					onInput={(e: any) => setLocalValue(e.target.value)}
 					placeholder={placeholder}
 					style={{ width: "100%", marginTop: 3 }}
 					type="text"

--- a/apps/vscode/webview-ui/src/components/settings/utils/__tests__/useDebouncedInput.test.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/utils/__tests__/useDebouncedInput.test.tsx
@@ -76,4 +76,72 @@ describe("useDebouncedInput", () => {
 		expect(values.at(-1)).toBe("second")
 		expect(onChange).not.toHaveBeenCalled()
 	})
+
+	it("does not clobber a pending user edit when an earlier save echoes back", async () => {
+		// Saves round-trip through the backend and update initialValue. While
+		// the user is still typing, an in-flight save can echo back an older
+		// prefix; resyncing to it would delete the newest keystrokes.
+		const onChange = vi.fn()
+		const values: string[] = []
+		let latestSetValue: (value: string) => void = () => {}
+		const { rerender } = render(
+			<Harness
+				initialValue=""
+				onChange={onChange}
+				onRender={(value, setValue) => {
+					values.push(value)
+					latestSetValue = setValue
+				}}
+			/>,
+		)
+
+		act(() => latestSetValue("https://proxy"))
+		// Echo of an earlier, shorter write arrives while the edit is pending.
+		rerender(
+			<Harness
+				initialValue="https://p"
+				onChange={onChange}
+				onRender={(value, setValue) => {
+					values.push(value)
+					latestSetValue = setValue
+				}}
+			/>,
+		)
+
+		expect(values.at(-1)).toBe("https://proxy")
+
+		await flushDebounce()
+		expect(onChange).toHaveBeenCalledTimes(1)
+		expect(onChange).toHaveBeenCalledWith("https://proxy")
+	})
+
+	it("flushes a pending edit on unmount", async () => {
+		const onChange = vi.fn()
+		let latestSetValue: (value: string) => void = () => {}
+		const { unmount } = render(
+			<Harness
+				initialValue=""
+				onChange={onChange}
+				onRender={(_, setValue) => {
+					latestSetValue = setValue
+				}}
+			/>,
+		)
+
+		act(() => latestSetValue("typed-then-closed"))
+		// Unmount before the debounce fires (e.g. clicking Done in settings).
+		unmount()
+
+		expect(onChange).toHaveBeenCalledTimes(1)
+		expect(onChange).toHaveBeenCalledWith("typed-then-closed")
+	})
+
+	it("does not flush on unmount without a pending edit", async () => {
+		const onChange = vi.fn()
+		const { unmount } = render(<Harness initialValue="saved" onChange={onChange} onRender={() => {}} />)
+
+		unmount()
+
+		expect(onChange).not.toHaveBeenCalled()
+	})
 })

--- a/apps/vscode/webview-ui/src/components/settings/utils/useDebouncedInput.ts
+++ b/apps/vscode/webview-ui/src/components/settings/utils/useDebouncedInput.ts
@@ -37,12 +37,17 @@ export function useDebouncedInput<T>(
 		setLocalValueState(value)
 	}, [])
 
-	// Sync local state when initialValue changes externally (e.g., when switching Plan/Act tabs)
+	// Sync local state when initialValue changes externally (e.g., when switching
+	// Plan/Act tabs). Skip the resync while a user edit is pending: because each
+	// debounced save round-trips through the backend and updates initialValue,
+	// an in-flight save can echo back an older value while the user is still
+	// typing, and resyncing would visibly delete their newest keystrokes.
 	useEffect(() => {
 		if (prevInitialValueRef.current !== initialValue) {
-			hasPendingUserEditRef.current = false
-			setLocalValueState(initialValue)
 			prevInitialValueRef.current = initialValue
+			if (!hasPendingUserEditRef.current) {
+				setLocalValueState(initialValue)
+			}
 		}
 	}, [initialValue])
 
@@ -57,6 +62,20 @@ export function useDebouncedInput<T>(
 		},
 		debounceMs,
 		[localValue],
+	)
+
+	// Flush a pending edit on unmount so keystrokes typed within the debounce
+	// window still save when the view closes (e.g. clicking Done in settings).
+	const latestRef = useRef({ localValue, onChange })
+	latestRef.current = { localValue, onChange }
+	useEffect(
+		() => () => {
+			if (hasPendingUserEditRef.current) {
+				hasPendingUserEditRef.current = false
+				latestRef.current.onChange(latestRef.current.localValue)
+			}
+		},
+		[],
 	)
 
 	return [localValue, setLocalValue]

--- a/apps/vscode/webview-ui/src/hooks/useProviderConfig.test.ts
+++ b/apps/vscode/webview-ui/src/hooks/useProviderConfig.test.ts
@@ -173,4 +173,60 @@ describe("useProviderConfig", () => {
 		).rejects.toThrow("selection providerId openrouter does not match hook providerId deepseek")
 		expect(ModelsServiceClient.commitModelSelection).not.toHaveBeenCalled()
 	})
+
+	it("drops a stale read response that resolves after a newer write was issued", async () => {
+		// Repro: settings mounts (slow read in flight), the user immediately
+		// edits a field (write issued). The stale pre-write read must not
+		// apply — it would roll the UI back while the write is pending.
+		let resolveRead: (value: ProviderConfigResponse) => void = () => {}
+		vi.mocked(ModelsServiceClient.readProviderConfig).mockReturnValue(
+			new Promise<ProviderConfigResponse>((resolve) => {
+				resolveRead = resolve
+			}),
+		)
+		let resolveWrite: (value: ProviderConfigResponse) => void = () => {}
+		vi.mocked(ModelsServiceClient.writeProviderConfig).mockReturnValue(
+			new Promise<ProviderConfigResponse>((resolve) => {
+				resolveWrite = resolve
+			}),
+		)
+
+		const { result } = renderHook(() => useProviderConfig("deepseek"))
+
+		let writePromise: Promise<unknown> = Promise.resolve()
+		act(() => {
+			writePromise = result.current.write({ baseUrl: "https://new.example/v1" })
+		})
+
+		// The stale mount read resolves while the write is in flight.
+		await act(async () => {
+			resolveRead(config("deepseek", "https://old.example/v1"))
+		})
+		expect(result.current.config).toBeUndefined()
+
+		await act(async () => {
+			resolveWrite(config("deepseek", "https://new.example/v1"))
+			await writePromise
+		})
+		expect(result.current.config?.baseUrl).toBe("https://new.example/v1")
+	})
+
+	it("re-reads after a failed write so config converges instead of staying stale", async () => {
+		// Writes can fail host-side (e.g. base URL rejected by schema
+		// validation while a partial URL is typed). The failed write is the
+		// latest request, so no response will ever apply for it — the hook
+		// must re-read or config could remain stale (or undefined) forever.
+		vi.mocked(ModelsServiceClient.readProviderConfig).mockResolvedValue(config("deepseek", "https://saved.example/v1"))
+		vi.mocked(ModelsServiceClient.writeProviderConfig).mockRejectedValue(new Error("invalid url"))
+
+		const { result } = renderHook(() => useProviderConfig("deepseek"))
+		await waitFor(() => expect(result.current.config?.baseUrl).toBe("https://saved.example/v1"))
+
+		await act(async () => {
+			await expect(result.current.write({ baseUrl: "h" })).rejects.toThrow("invalid url")
+		})
+
+		await waitFor(() => expect(ModelsServiceClient.readProviderConfig).toHaveBeenCalledTimes(2))
+		expect(result.current.config?.baseUrl).toBe("https://saved.example/v1")
+	})
 })

--- a/apps/vscode/webview-ui/src/hooks/useProviderConfig.test.ts
+++ b/apps/vscode/webview-ui/src/hooks/useProviderConfig.test.ts
@@ -229,4 +229,48 @@ describe("useProviderConfig", () => {
 		await waitFor(() => expect(ModelsServiceClient.readProviderConfig).toHaveBeenCalledTimes(2))
 		expect(result.current.config?.baseUrl).toBe("https://saved.example/v1")
 	})
+
+	it("skips the failure recovery read when a newer write is already in flight", async () => {
+		// If an older write fails while a newer write is pending, a recovery
+		// read would take over the latest request seq, discard the newer
+		// write's response, and could pin a pre-write snapshot host-side.
+		// The newer write's own response (or failure recovery) supersedes.
+		vi.mocked(ModelsServiceClient.readProviderConfig).mockResolvedValue(config("deepseek", "https://saved.example/v1"))
+		let rejectFirstWrite: (error: unknown) => void = () => {}
+		let resolveSecondWrite: (value: ProviderConfigResponse) => void = () => {}
+		vi.mocked(ModelsServiceClient.writeProviderConfig)
+			.mockReturnValueOnce(
+				new Promise<ProviderConfigResponse>((_, reject) => {
+					rejectFirstWrite = reject
+				}),
+			)
+			.mockReturnValueOnce(
+				new Promise<ProviderConfigResponse>((resolve) => {
+					resolveSecondWrite = resolve
+				}),
+			)
+
+		const { result } = renderHook(() => useProviderConfig("deepseek"))
+		await waitFor(() => expect(result.current.config).toBeDefined())
+
+		let firstWrite: Promise<unknown> = Promise.resolve()
+		let secondWrite: Promise<unknown> = Promise.resolve()
+		act(() => {
+			firstWrite = result.current.write({ baseUrl: "h" })
+			secondWrite = result.current.write({ baseUrl: "https://new.example/v1" })
+		})
+
+		await act(async () => {
+			rejectFirstWrite(new Error("invalid url"))
+			await expect(firstWrite).rejects.toThrow("invalid url")
+		})
+		// No recovery read: the mount read must remain the only one.
+		expect(ModelsServiceClient.readProviderConfig).toHaveBeenCalledTimes(1)
+
+		await act(async () => {
+			resolveSecondWrite(config("deepseek", "https://new.example/v1"))
+			await secondWrite
+		})
+		expect(result.current.config?.baseUrl).toBe("https://new.example/v1")
+	})
 })

--- a/apps/vscode/webview-ui/src/hooks/useProviderConfig.ts
+++ b/apps/vscode/webview-ui/src/hooks/useProviderConfig.ts
@@ -94,8 +94,14 @@ export function useProviderConfig(providerId: ProviderId) {
 				// its failure means no response will ever apply for this seq —
 				// without a re-read, older dropped responses could leave config
 				// stale (or undefined) forever. Re-read to converge on the
-				// backend's actual state.
-				void read().catch(() => {})
+				// backend's actual state, but only if this write is still the
+				// latest request: when a newer request is already in flight, its
+				// response (or its own failure recovery) supersedes this one,
+				// and a recovery read issued now could race ahead of the newer
+				// write host-side and pin a pre-write snapshot as the latest.
+				if (seq === requestSeqRef.current) {
+					void read().catch(() => {})
+				}
 				throw error
 			}
 		},

--- a/apps/vscode/webview-ui/src/hooks/useProviderConfig.ts
+++ b/apps/vscode/webview-ui/src/hooks/useProviderConfig.ts
@@ -11,7 +11,7 @@ import {
 	type ProviderModelOverrides,
 	toProtobufModelOverrides as toProtobufProviderModelOverrides,
 } from "@shared/proto-conversions/models/modelOverrides"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import type { ProviderId } from "@/context/ExtensionStateContext"
 import { ModelsServiceClient } from "@/services/grpc-client"
 
@@ -54,11 +54,26 @@ function toWriteProviderConfigPatch(patch: ProviderConfigWritePatch): WriteProvi
 export function useProviderConfig(providerId: ProviderId) {
 	const [config, setConfig] = useState<ProviderConfigResponse | undefined>(undefined)
 
-	const read = useCallback(async () => {
-		const response = await ModelsServiceClient.readProviderConfig(StringRequest.create({ value: providerId }))
+	// Reads and writes resolve asynchronously and can complete out of order
+	// (e.g. a slow initial read landing after a user-triggered write). Only
+	// apply a response if no newer request has been applied, so stale
+	// responses can't roll the UI state back.
+	const requestSeqRef = useRef(0)
+	const appliedSeqRef = useRef(0)
+	const applyConfig = useCallback((seq: number, response: ProviderConfigResponse) => {
+		if (seq < appliedSeqRef.current) {
+			return
+		}
+		appliedSeqRef.current = seq
 		setConfig(response)
+	}, [])
+
+	const read = useCallback(async () => {
+		const seq = ++requestSeqRef.current
+		const response = await ModelsServiceClient.readProviderConfig(StringRequest.create({ value: providerId }))
+		applyConfig(seq, response)
 		return response
-	}, [providerId])
+	}, [providerId, applyConfig])
 
 	useEffect(() => {
 		void read()
@@ -66,16 +81,17 @@ export function useProviderConfig(providerId: ProviderId) {
 
 	const write = useCallback(
 		async (patch: ProviderConfigWritePatch) => {
+			const seq = ++requestSeqRef.current
 			const response = await ModelsServiceClient.writeProviderConfig(
 				WriteProviderConfigRequest.create({
 					providerId,
 					patch: toWriteProviderConfigPatch(patch),
 				}),
 			)
-			setConfig(response)
+			applyConfig(seq, response)
 			return response
 		},
-		[providerId],
+		[providerId, applyConfig],
 	)
 
 	const commitSelection = useCallback(

--- a/apps/vscode/webview-ui/src/hooks/useProviderConfig.ts
+++ b/apps/vscode/webview-ui/src/hooks/useProviderConfig.ts
@@ -56,15 +56,13 @@ export function useProviderConfig(providerId: ProviderId) {
 
 	// Reads and writes resolve asynchronously and can complete out of order
 	// (e.g. a slow initial read landing after a user-triggered write). Only
-	// apply a response if no newer request has been applied, so stale
-	// responses can't roll the UI state back.
+	// the latest issued request may apply its response; anything older is
+	// stale and would roll the UI state back.
 	const requestSeqRef = useRef(0)
-	const appliedSeqRef = useRef(0)
 	const applyConfig = useCallback((seq: number, response: ProviderConfigResponse) => {
-		if (seq < appliedSeqRef.current) {
+		if (seq !== requestSeqRef.current) {
 			return
 		}
-		appliedSeqRef.current = seq
 		setConfig(response)
 	}, [])
 
@@ -82,16 +80,26 @@ export function useProviderConfig(providerId: ProviderId) {
 	const write = useCallback(
 		async (patch: ProviderConfigWritePatch) => {
 			const seq = ++requestSeqRef.current
-			const response = await ModelsServiceClient.writeProviderConfig(
-				WriteProviderConfigRequest.create({
-					providerId,
-					patch: toWriteProviderConfigPatch(patch),
-				}),
-			)
-			applyConfig(seq, response)
-			return response
+			try {
+				const response = await ModelsServiceClient.writeProviderConfig(
+					WriteProviderConfigRequest.create({
+						providerId,
+						patch: toWriteProviderConfigPatch(patch),
+					}),
+				)
+				applyConfig(seq, response)
+				return response
+			} catch (error) {
+				// A failed write may still have partially applied host-side, and
+				// its failure means no response will ever apply for this seq —
+				// without a re-read, older dropped responses could leave config
+				// stale (or undefined) forever. Re-read to converge on the
+				// backend's actual state.
+				void read().catch(() => {})
+				throw error
+			}
 		},
-		[providerId, applyConfig],
+		[providerId, applyConfig, read],
 	)
 
 	const commitSelection = useCallback(


### PR DESCRIPTION
### Related Issue

**Issue:** #12811

### Description

Users reported that after entering a custom base URL for the Anthropic provider and clicking Done, reopening settings showed the "Use custom base URL" checkbox unchecked. Typing into the URL input also visibly dropped characters.

**Important context:** the base URL *was* being saved and used correctly the whole time. The SDK's Anthropic handler passes `baseURL` to `createAnthropic()` (`sdk/packages/llms/src/providers/vendors/anthropic.ts`), the save path whitelists `baseUrl` into both legacy state (`anthropicBaseUrl`) and `providers.json`, and `resolveBaseUrl()` in `cline-session-factory.ts` reads both at inference time. Existing users' saved base URLs were never lost or ignored — the settings UI just displayed the wrong state. Three webview bugs caused the symptoms:

1. **Checkbox never hydrated** — `BaseUrlField` initialized `isEnabled` once from `initialValue`, but provider config loads asynchronously after mount (`initialValue` starts `undefined`), so the checkbox stayed unchecked forever even with a saved URL. Fixed by syncing the checkbox to `initialValue` once it loads, unless the user has already toggled it.

2. **Keystrokes clobbered by save echoes** — each debounced save round-trips through `writeProviderConfig` and updates `config`, which feeds back into `initialValue`. `useDebouncedInput` unconditionally resynced local state on `initialValue` changes, so an in-flight save echoing an older prefix deleted the newest keystrokes. Fixed by skipping the resync while a user edit is pending. Also, pending edits are now flushed on unmount so keystrokes typed within the 100ms debounce window still save when clicking Done.

3. **Out-of-order response races** — `useProviderConfig` applied every read/write response to state, so a slow initial read or an older write response could roll the UI back. Added a sequence guard so stale responses are dropped.

These fixes apply to every settings field built on `BaseUrlField` / `useDebouncedInput` (all providers' base URL fields, API key fields, etc.), not just Anthropic.

### Test Procedure

- Added unit tests: `BaseUrlField.test.tsx` (async hydration checks the box and shows the URL, user uncheck survives stale echoes, value trimmed on save) and extended `useDebouncedInput.test.tsx` (pending edits survive echoed resyncs, pending edits flush on unmount, no spurious flush without edits).
- Full webview suite passes: 50 files, 394 tests. Typecheck (`tsc`) and lint (`biome check`) clean.
- Manually reproduced the issue flow in the Extension Development Host: selected Anthropic, checked "Use custom base URL", typed `https://my-proxy.example.com/v1` (no characters dropped), clicked Done, reopened settings — checkbox checked and full URL present.
- Verified on-disk persistence after the flow: `providers.json` has `"baseUrl": "https://my-proxy.example.com/v1"` under `providers.anthropic.settings`, and legacy global state has `anthropicBaseUrl` with the same value — the exact value `createAnthropic({ baseURL })` receives.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Settings reopened after clicking Done — checkbox persisted and URL populated:

![Reopened settings showing Use custom base URL checked with the saved URL](https://cursor.com/artifacts/c/art-03fb5f44-92dc-4111-b178-5a5e69bd7bac)

### Additional Notes

A separate, pre-existing rough edge not addressed here: `ProviderSettingsSchema` validates `baseUrl` with `z.string().url()`, so debounced saves of very early keystroke prefixes (`"h"`, `"ht"`, `"https:/"`) are rejected server-side (harmless — the next valid prefix saves), and legacy state is written before the `providers.json` write validates. Worth a follow-up if we want silent intermediate saves to never error.