### PR TITLE
fix(vscode): settle pending tool approval when a message edit replaces the session

### DIFF
--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -1444,6 +1444,12 @@ export class Controller {
 				})
 			}
 
+			// The edit supersedes the old session — settle any pending tool
+			// approval / ask_question exactly like cancelTask does. Without this,
+			// the old run stays suspended forever on a promise nothing can
+			// resolve, and the stale parked resolver intercepts later responses.
+			this.interactions.clearPending("Superseded by an edited message")
+
 			const { startResult, sdkHost } = await this.sessions.startNewSession(startInput)
 
 			this.turnStateTracker.set("streaming")


### PR DESCRIPTION
## Summary

Editing a previous message while a tool approval prompt is pending leaves the old session's approval promise parked forever. The superseded agent run stays suspended on `await requestToolApproval(...)` — an answer that can never come — and the stale parked resolver keeps intercepting later ask responses in `SdkInteractionCoordinator`.

Every other session-replacement path (`cancelTask`, `clearTask`, task switch, mode change) already calls `interactions.clearPending(...)` before tearing down / replacing the session; `editMessageAndRegenerate` was the one that didn't. This adds the same call before `startNewSession`, so the old approval resolves as denied and the superseded run unwinds cleanly.

Found while investigating #12827 (command row stuck on "Skipped", footer stuck on "Thinking").

## Repro (on main)

1. Turn command auto-approval off.
2. Start a task that runs a command; wait for the "Run Command / Reject" prompt.
3. Without answering, edit your original message and resubmit.
4. The old session's approval promise is now leaked — that run stays suspended in the extension host forever, and the stale resolver swallows subsequent ask responses.

## Testing

- `apps/vscode` `bun run test:vitest` — 76 files, 979 passed.
- One-line behavior change, identical to what `cancelTask` already does on the same coordinator.

Ref #12827