### PR TITLE
fix(settings): persist Qwen/Moonshot API line to providers.json so CLI/desktop pick up the regional endpoint

### DIFF
--- a/apps/vscode/src/sdk/model-catalog/store.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/store.test.ts
@@ -183,6 +183,26 @@ describe("createProviderConfigStore", () => {
 		expect(store.read(providerId).baseUrl).toBeUndefined()
 	})
 
+	// Changing the regional API line in the settings UI goes through
+	// store.write. It must land in providers.json (the CLI and desktop app
+	// bake the regional base URL from its stored apiLine) AND mirror to the
+	// legacy state key (the VS Code session factory's resolveApiLine reads
+	// legacy state first).
+	it.each([
+		["qwen", "qwenApiLine"],
+		["moonshot", "moonshotApiLine"],
+	] as const)("mirrors %s apiLine writes to both providers.json and the legacy state key", async (provider, legacyKey) => {
+		const { createProviderConfigStore } = await import("./store")
+		const store = createProviderConfigStore()
+		const providerId = parseProviderId(provider)
+
+		store.write(providerId, { apiLine: "china" })
+
+		expect(mocks.getSavedProviderSettings(provider)).toMatchObject({ provider, apiLine: "china" })
+		expect(mocks.getApiConfiguration()[legacyKey]).toBe("china")
+		expect(store.read(providerId).apiLine).toBe("china")
+	})
+
 	it("round-trips commitSelection then readSelection for provider-specific model info", async () => {
 		const { createProviderConfigStore } = await import("./store")
 		const store = createProviderConfigStore()

--- a/apps/vscode/webview-ui/src/components/settings/providers/MoonshotProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/MoonshotProvider.tsx
@@ -24,7 +24,7 @@ interface MoonshotProviderProps {
  */
 export const MoonshotProvider = ({ showModelOptions, isPopup, currentMode }: MoonshotProviderProps) => {
 	const { apiConfiguration } = useExtensionState()
-	const { write } = useProviderConfig("moonshot")
+	const { config, write } = useProviderConfig("moonshot")
 
 	// Get the normalized configuration
 	const { models, selectedModelId, selectedModelInfo, hideUsageCost } = useStaticProviderSelection(
@@ -32,6 +32,17 @@ export const MoonshotProvider = ({ showModelOptions, isPopup, currentMode }: Moo
 		apiConfiguration,
 		currentMode,
 	)
+
+	// The SDK provider config (providers.json) is the source of truth shared
+	// with other hosts (CLI, desktop app); the legacy state field keeps the
+	// dropdown accurate before the async config read completes.
+	const selectedEntrypoint = config?.apiLine || apiConfiguration?.moonshotApiLine || "international"
+
+	const handleApiLineChange = (value: string) => {
+		// write() persists to providers.json and mirrors to the legacy
+		// `moonshotApiLine` state key host-side, keeping both stores in sync.
+		void write({ apiLine: value }).catch((err) => console.error("Failed to update Moonshot entrypoint:", err))
+	}
 
 	return (
 		<div>
@@ -41,24 +52,14 @@ export const MoonshotProvider = ({ showModelOptions, isPopup, currentMode }: Moo
 				</label>
 				<VSCodeDropdown
 					id="moonshot-entrypoint"
-					onChange={async (e) => {
-						const value = (e.target as any).value
-						await ModelsServiceClient.updateApiConfiguration(
-							UpdateApiConfigurationRequestNew.create({
-								updates: {
-									options: {
-										moonshotApiLine: value,
-									},
-								},
-								updateMask: ["options.moonshotApiLine"],
-							}),
-						)
+					onChange={(e) => {
+						handleApiLineChange((e.target as any).value)
 					}}
 					style={{
 						minWidth: 130,
 						position: "relative",
 					}}
-					value={apiConfiguration?.moonshotApiLine || "international"}>
+					value={selectedEntrypoint}>
 					<VSCodeOption value="international">api.moonshot.ai</VSCodeOption>
 					<VSCodeOption value="china">api.moonshot.cn</VSCodeOption>
 				</VSCodeDropdown>
@@ -80,7 +81,7 @@ export const MoonshotProvider = ({ showModelOptions, isPopup, currentMode }: Moo
 				}}
 				providerName="Moonshot"
 				signupUrl={
-					apiConfiguration?.moonshotApiLine === "china"
+					selectedEntrypoint === "china"
 						? "https://platform.moonshot.cn/console/api-keys"
 						: "https://platform.moonshot.ai/console/api-keys"
 				}

--- a/apps/vscode/webview-ui/src/components/settings/providers/QwenProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/QwenProvider.tsx
@@ -39,7 +39,17 @@ export const QwenProvider = ({ showModelOptions, isPopup, currentMode }: QwenPro
 		apiConfiguration,
 		currentMode,
 	)
-	const { write } = useProviderConfig("qwen")
+	const { config, write } = useProviderConfig("qwen")
+	// The SDK provider config (providers.json) is the source of truth shared
+	// with other hosts (CLI, desktop app); the legacy state field keeps the
+	// dropdown accurate before the async config read completes.
+	const selectedApiLine = config?.apiLine || apiConfiguration?.qwenApiLine || qwenApiOptions[0]
+
+	const handleApiLineChange = (value: string) => {
+		// write() persists to providers.json and mirrors to the legacy
+		// `qwenApiLine` state key host-side, keeping both stores in sync.
+		void write({ apiLine: value }).catch((err) => console.error("Failed to update Qwen API line:", err))
+	}
 
 	return (
 		<div>
@@ -49,12 +59,12 @@ export const QwenProvider = ({ showModelOptions, isPopup, currentMode }: QwenPro
 				</label>
 				<VSCodeDropdown
 					id="qwen-line-provider"
-					onChange={(e: any) => handleFieldChange("qwenApiLine", e.target.value as QwenApiRegions)}
+					onChange={(e: any) => handleApiLineChange(e.target.value as QwenApiRegions)}
 					style={{
 						minWidth: 130,
 						position: "relative",
 					}}
-					value={apiConfiguration?.qwenApiLine || qwenApiOptions[0]}>
+					value={selectedApiLine}>
 					{qwenApiOptions.map((line) => (
 						<VSCodeOption key={line} value={line}>
 							{line.charAt(0).toUpperCase() + line.slice(1)} API

--- a/apps/vscode/webview-ui/src/components/settings/providers/providerApiLineDropdowns.test.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/providerApiLineDropdowns.test.tsx
@@ -1,0 +1,134 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import type { ChangeEventHandler, ReactNode } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { useProviderConfig } from "@/hooks/useProviderConfig"
+import { useProviderModels } from "@/hooks/useProviderModels"
+import { MoonshotProvider } from "./MoonshotProvider"
+import { QwenProvider } from "./QwenProvider"
+
+vi.mock("@/hooks/useProviderModels", () => ({
+	useProviderModels: vi.fn(),
+}))
+
+vi.mock("@/hooks/useProviderUsageCostDisplay", () => ({
+	useProviderUsageCostDisplay: () => "show",
+}))
+
+vi.mock("@/hooks/useProviderConfig", () => ({
+	useProviderConfig: vi.fn(),
+}))
+
+const mockExtensionState = vi.hoisted(() => ({
+	state: { apiConfiguration: {} as Record<string, unknown>, planActSeparateModelsSetting: false },
+}))
+
+vi.mock("@/context/ExtensionStateContext", () => ({
+	useExtensionState: () => mockExtensionState.state,
+}))
+
+vi.mock("@/services/grpc-client", () => ({
+	ModelsServiceClient: {
+		updateApiConfiguration: vi.fn(async () => undefined),
+		updateApiConfigurationProto: vi.fn(async () => undefined),
+	},
+	StateServiceClient: { updateSettings: vi.fn(async () => undefined) },
+}))
+
+// Render the dropdown web components as native elements so value/change
+// behavior is observable in jsdom. Other toolkit components stay real.
+vi.mock("@vscode/webview-ui-toolkit/react", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@vscode/webview-ui-toolkit/react")>()
+	return {
+		...actual,
+		VSCodeDropdown: ({
+			children,
+			id,
+			onChange,
+			value,
+		}: {
+			children?: ReactNode
+			id?: string
+			onChange?: ChangeEventHandler<HTMLSelectElement>
+			value?: string
+		}) => (
+			<select id={id} onChange={onChange} value={value}>
+				{children}
+			</select>
+		),
+		VSCodeOption: ({ children, value }: { children?: ReactNode; value?: string }) => (
+			<option value={value}>{children}</option>
+		),
+	}
+})
+
+const writeMock = vi.fn(async () => undefined)
+
+function mockProviderConfig(config: { apiLine?: string } | undefined) {
+	vi.mocked(useProviderConfig).mockReturnValue({
+		config,
+		write: writeMock,
+		commitSelection: vi.fn(async () => undefined),
+	} as never)
+}
+
+beforeEach(() => {
+	vi.clearAllMocks()
+	mockExtensionState.state = { apiConfiguration: {}, planActSeparateModelsSetting: false }
+	mockProviderConfig(undefined)
+	vi.mocked(useProviderModels).mockReturnValue({
+		models: { "some-model": { name: "Some Model", contextWindow: 128_000 } } as never,
+		defaultModelId: "some-model",
+		isLoading: false,
+		isStale: false,
+		error: undefined,
+		refresh: vi.fn(),
+		fingerprint: "fingerprint",
+	})
+})
+
+// The regional API line must persist through useProviderConfig's write()
+// (WriteProviderConfig gRPC), which updates providers.json — shared with the
+// CLI and desktop app — and mirrors to the legacy state key host-side. A
+// legacy-state-only write leaves providers.json stale and sends other hosts
+// to the wrong regional endpoint.
+describe.each([
+	{
+		name: "QwenProvider",
+		Provider: QwenProvider,
+		label: "Alibaba API Line",
+		legacyKey: "qwenApiLine",
+	},
+	{
+		name: "MoonshotProvider",
+		Provider: MoonshotProvider,
+		label: "Moonshot Entrypoint",
+		legacyKey: "moonshotApiLine",
+	},
+] as const)("$name API line dropdown", ({ Provider, label, legacyKey }) => {
+	it("writes apiLine through the SDK provider config on change", () => {
+		render(<Provider currentMode="act" showModelOptions={false} />)
+
+		fireEvent.change(screen.getByLabelText(label), { target: { value: "china" } })
+
+		expect(writeMock).toHaveBeenCalledTimes(1)
+		expect(writeMock).toHaveBeenCalledWith({ apiLine: "china" })
+	})
+
+	it("renders the SDK provider config's apiLine once loaded", () => {
+		mockProviderConfig({ apiLine: "china" })
+		mockExtensionState.state = { apiConfiguration: { [legacyKey]: "international" }, planActSeparateModelsSetting: false }
+
+		render(<Provider currentMode="act" showModelOptions={false} />)
+
+		expect(screen.getByLabelText(label)).toHaveValue("china")
+	})
+
+	it("falls back to the legacy state value before the SDK config loads", () => {
+		mockProviderConfig(undefined)
+		mockExtensionState.state = { apiConfiguration: { [legacyKey]: "china" }, planActSeparateModelsSetting: false }
+
+		render(<Provider currentMode="act" showModelOptions={false} />)
+
+		expect(screen.getByLabelText(label)).toHaveValue("china")
+	})
+})


### PR DESCRIPTION
### Related Issue

Found in an audit following the Anthropic base URL fix (#12834).

### Description

**Problem:** The Qwen and Moonshot "API line" dropdowns (china/international) in the VS Code settings wrote only to the legacy StateManager (`qwenApiLine`/`moonshotApiLine`), never to the SDK's `providers.json`:

- `QwenProvider.tsx` used `handleFieldChange("qwenApiLine", ...)` — legacy-only.
- `MoonshotProvider.tsx` used `ModelsServiceClient.updateApiConfiguration` with `updateMask: ["options.moonshotApiLine"]` — also legacy-only.

The VS Code runtime itself is not broken (`resolveApiLine` in `apps/vscode/src/sdk/cline-session-factory.ts` resolves the line legacy-state-first), but `providers.json` goes stale. Other hosts boot from `providers.json`: the CLI and desktop app bake the regional base URL from its stored `apiLine` (`toProviderConfig` in `sdk/packages/core/src/services/llms/provider-settings.ts`), so after changing the line in VS Code they keep hitting the old regional endpoint.

**Fix:** Convert both dropdowns to the pattern already used by `ZAiProvider.tsx`: `useProviderConfig(providerId).write({ apiLine: value })`. The host store (`apps/vscode/src/sdk/model-catalog/store.ts`, `writeStateFields` with the `providerConfigStateKeys.apiLine` map, which already includes `qwen` and `moonshot`) mirrors that write back to the legacy state key — so one `write()` updates both stores. The displayed dropdown value follows the same fallback chain as Z AI (`config?.apiLine || apiConfiguration?.<legacyKey> || default`), so it renders correctly before the async config read completes, and write errors are logged via `.catch(console.error)` like the other providers.

**Out of scope — OCA mode:** the OCA internal/external toggle in `OcaProvider.tsx` has the same class of issue (writes legacy `ocaMode` only, so `providers.json`'s `oca.mode` — set once by migration — goes stale). It is not fixed here because `WriteProviderConfigPatch` (`apps/vscode/proto/cline/models.proto`) has no field for a provider mode, so fixing it requires extending the proto and the store write path; that should be its own PR.

### Test Procedure

- Added `apps/vscode/src/sdk/model-catalog/store.test.ts` cases pinning that `store.write(providerId, { apiLine: "china" })` for `qwen` and `moonshot` lands in both `providers.json` and the legacy state key.
- Added `apps/vscode/webview-ui/src/components/settings/providers/providerApiLineDropdowns.test.tsx`: for both dropdowns, a change event calls `write({ apiLine })`, the loaded SDK config value wins over legacy state, and legacy state is used as the fallback before the config loads.
- `bun run test` in `apps/vscode/webview-ui`: 51 files / 403 tests pass.
- `bun run test:unit` in `apps/vscode`: 70 files / 1029 tests pass.
- `bun run test:vitest` in `apps/vscode` (covers `store.test.ts`): 76 files / 981 tests pass.
- Webview typecheck (`bunx tsc -p tsconfig.app.json --noEmit`) and Biome on the changed files: clean.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

No visual changes — the dropdowns look and behave the same in the webview; only the persistence path changed.

### Additional Notes

User impact: changing the Qwen/Moonshot regional API line in VS Code now propagates to the shared `providers.json`, so the Cline CLI and desktop app switch to the selected regional endpoint instead of keeping the old one.