### PR TITLE
fix(ollama): raise the response-start timeout default to 5 minutes so model cold loads don't error

### DIFF
--- a/apps/vscode/src/sdk/sdk-api-handler.test.ts
+++ b/apps/vscode/src/sdk/sdk-api-handler.test.ts
@@ -82,4 +82,40 @@ describe("buildSdkProviderConfig", () => {
 		})
 		expect(mocks.providerSettingsManager.getProviderSettings).toHaveBeenCalledWith("v0")
 	})
+
+	it("forwards the Ollama request timeout and context window to standalone handlers", () => {
+		mocks.providerSettingsManager.getProviderSettings.mockReturnValue(undefined)
+
+		const providerConfig = buildSdkProviderConfig(
+			{
+				actModeApiProvider: "ollama",
+				actModeOllamaModelId: "qwen2.5:7b",
+				requestTimeoutMs: 45_000,
+				ollamaApiOptionsCtxNum: "16384",
+			},
+			"act",
+		)
+
+		expect(providerConfig).toMatchObject({
+			providerId: "ollama",
+			modelId: "qwen2.5:7b",
+			timeoutMs: 45_000,
+			modelInfo: { id: "qwen2.5:7b", contextWindow: 16384 },
+		})
+	})
+
+	it("omits timeoutMs for Ollama when no explicit timeout is configured", () => {
+		mocks.providerSettingsManager.getProviderSettings.mockReturnValue(undefined)
+
+		const providerConfig = buildSdkProviderConfig(
+			{
+				actModeApiProvider: "ollama",
+				actModeOllamaModelId: "qwen2.5:7b",
+			},
+			"act",
+		)
+
+		expect(providerConfig.providerId).toBe("ollama")
+		expect("timeoutMs" in providerConfig).toBe(false)
+	})
 })

--- a/apps/vscode/src/sdk/sdk-api-handler.ts
+++ b/apps/vscode/src/sdk/sdk-api-handler.ts
@@ -13,7 +13,13 @@ import type { Mode } from "@shared/storage/types"
 import { reasoningEffortFromThinkingBudget } from "@shared/utils/reasoning-support"
 import { fetch } from "@/shared/net"
 import { buildBedrockProviderConfig } from "./bedrock-config"
-import { resolveApiKey, resolveBaseUrl, resolveModelId, resolveVertexProviderConfig } from "./cline-session-factory"
+import {
+	resolveApiKey,
+	resolveBaseUrl,
+	resolveModelId,
+	resolveOllamaProviderConfig,
+	resolveVertexProviderConfig,
+} from "./cline-session-factory"
 import { toSdkProviderId } from "./model-catalog/sdk-provider-id"
 
 export interface BuildApiHandlerOptions {
@@ -71,6 +77,11 @@ export function buildSdkProviderConfig(
 		// Bedrock needs its region + structured AWS auth options forwarded to the
 		// SDK gateway. Without these, a pasted Bedrock API key / region is dropped.
 		...(providerId === "bedrock" ? buildBedrockProviderConfig(configuration, mode) : {}),
+		// Ollama carries the user's request timeout and context window
+		// (`num_ctx`) on the provider config; without this, standalone callers
+		// ignore an explicit Request Timeout setting and load models with
+		// Ollama's 4096-token server default.
+		...(providerId === "ollama" ? resolveOllamaProviderConfig(configuration, modelId) : {}),
 	}
 
 	if (options?.disableReasoning) {

--- a/apps/vscode/webview-ui/src/components/settings/providers/OllamaProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/OllamaProvider.tsx
@@ -195,9 +195,7 @@ export const OllamaProvider = ({ showModelOptions, isPopup, currentMode }: Ollam
 						<span className="font-semibold">Request Timeout (ms)</span>
 					</DebouncedTextField>
 					<p className="text-xs mt-0 text-description">
-						Maximum time in milliseconds to wait for the response to start. The default is generous because
-						Ollama loads the model into memory on the first request, which can take minutes for large
-						models.
+						Maximum time in milliseconds to wait for API responses before timing out.
 					</p>
 				</>
 			)}

--- a/apps/vscode/webview-ui/src/components/settings/providers/OllamaProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/OllamaProvider.tsx
@@ -182,7 +182,7 @@ export const OllamaProvider = ({ showModelOptions, isPopup, currentMode }: Ollam
 			{showModelOptions && (
 				<>
 					<DebouncedTextField
-						initialValue={apiConfiguration?.requestTimeoutMs ? apiConfiguration.requestTimeoutMs.toString() : "30000"}
+						initialValue={apiConfiguration?.requestTimeoutMs ? apiConfiguration.requestTimeoutMs.toString() : "300000"}
 						onChange={(value) => {
 							// Convert to number, with validation
 							const numValue = Number.parseInt(value, 10)
@@ -190,12 +190,14 @@ export const OllamaProvider = ({ showModelOptions, isPopup, currentMode }: Ollam
 								handleFieldChange("requestTimeoutMs", numValue)
 							}
 						}}
-						placeholder="Default: 30000 (30 seconds)"
+						placeholder="Default: 300000 (5 minutes)"
 						style={{ width: "100%" }}>
 						<span className="font-semibold">Request Timeout (ms)</span>
 					</DebouncedTextField>
 					<p className="text-xs mt-0 text-description">
-						Maximum time in milliseconds to wait for API responses before timing out.
+						Maximum time in milliseconds to wait for the response to start. The default is generous because
+						Ollama loads the model into memory on the first request, which can take minutes for large
+						models.
 					</p>
 				</>
 			)}

--- a/sdk/packages/llms/src/providers/vendors/ollama.test.ts
+++ b/sdk/packages/llms/src/providers/vendors/ollama.test.ts
@@ -142,9 +142,7 @@ describe("withOllamaResponseTimeout", () => {
 
 		expect(APICallError.isInstance(error)).toBe(true);
 		expect((error as APICallError).isRetryable).toBe(true);
-		expect((error as APICallError).url).toBe(
-			"http://localhost:11434/api/chat",
-		);
+		expect((error as APICallError).url).toBe("http://localhost:11434/api/chat");
 	});
 
 	it("does not abort once the response has started", async () => {

--- a/sdk/packages/llms/src/providers/vendors/ollama.test.ts
+++ b/sdk/packages/llms/src/providers/vendors/ollama.test.ts
@@ -1,3 +1,4 @@
+import { APICallError } from "@ai-sdk/provider";
 import type {
 	GatewayProviderContext,
 	GatewayResolvedProviderConfig,
@@ -10,6 +11,8 @@ import {
 	OLLAMA_DEFAULT_TIMEOUT_MS,
 	readOllamaNumCtx,
 	readOllamaTimeoutMs,
+	restoreApiCallError,
+	restoreOllamaApiCallErrorMiddleware,
 	withOllamaResponseTimeout,
 } from "./ollama";
 
@@ -122,6 +125,28 @@ describe("withOllamaResponseTimeout", () => {
 		await assertion;
 	});
 
+	it("rejects timeouts as retryable APICallErrors so the AI SDK retries them", async () => {
+		const hangingFetch = ((_input, init) =>
+			new Promise((_resolve, reject) => {
+				init?.signal?.addEventListener("abort", () =>
+					reject(init.signal?.reason),
+				);
+			})) as typeof fetch;
+
+		const wrapped = withOllamaResponseTimeout(hangingFetch, 1000);
+		const pending = wrapped("http://localhost:11434/api/chat").catch(
+			(error) => error,
+		);
+		await vi.advanceTimersByTimeAsync(1001);
+		const error = await pending;
+
+		expect(APICallError.isInstance(error)).toBe(true);
+		expect((error as APICallError).isRetryable).toBe(true);
+		expect((error as APICallError).url).toBe(
+			"http://localhost:11434/api/chat",
+		);
+	});
+
 	it("does not abort once the response has started", async () => {
 		let requestSignal: AbortSignal | undefined;
 		const immediateFetch = (async (_input, init) => {
@@ -154,6 +179,75 @@ describe("withOllamaResponseTimeout", () => {
 		const assertion = expect(pending).rejects.toThrow("user cancelled");
 		upstream.abort(new Error("user cancelled"));
 		await assertion;
+	});
+
+	it("does not convert upstream aborts into retryable errors", async () => {
+		const hangingFetch = ((_input, init) =>
+			new Promise((_resolve, reject) => {
+				init?.signal?.addEventListener("abort", () =>
+					reject(init.signal?.reason),
+				);
+			})) as typeof fetch;
+
+		const upstream = new AbortController();
+		const wrapped = withOllamaResponseTimeout(hangingFetch, 60_000);
+		const pending = wrapped("http://localhost:11434/api/chat", {
+			signal: upstream.signal,
+		}).catch((error) => error);
+		upstream.abort(new Error("user cancelled"));
+		const error = await pending;
+
+		expect(APICallError.isInstance(error)).toBe(false);
+		expect((error as Error).message).toBe("user cancelled");
+	});
+});
+
+describe("restoreApiCallError", () => {
+	it("returns a bare APICallError as-is", () => {
+		const apiError = retryableApiCallError();
+		expect(restoreApiCallError(apiError)).toBe(apiError);
+	});
+
+	it("restores an APICallError buried in a cause chain (OllamaError wrapping)", () => {
+		const apiError = retryableApiCallError();
+		const wrapped = new Error("Ollama request failed", { cause: apiError });
+		expect(restoreApiCallError(wrapped)).toBe(apiError);
+	});
+
+	it("returns the original error when no APICallError is present", () => {
+		const plain = new Error("connection refused");
+		expect(restoreApiCallError(plain)).toBe(plain);
+	});
+
+	it("handles non-Error values", () => {
+		expect(restoreApiCallError("boom")).toBe("boom");
+		expect(restoreApiCallError(undefined)).toBeUndefined();
+	});
+});
+
+describe("restoreOllamaApiCallErrorMiddleware", () => {
+	it("rethrows the buried APICallError from wrapStream failures", async () => {
+		const apiError = retryableApiCallError();
+		const doStream = vi
+			.fn()
+			.mockRejectedValue(new Error("wrapped", { cause: apiError }));
+
+		await expect(
+			restoreOllamaApiCallErrorMiddleware.wrapStream?.({
+				doStream,
+			} as never),
+		).rejects.toBe(apiError);
+	});
+
+	it("passes successful streams through untouched", async () => {
+		const result = { stream: "stream" };
+		const doStream = vi.fn().mockResolvedValue(result);
+
+		await expect(
+			restoreOllamaApiCallErrorMiddleware.wrapStream?.({
+				doStream,
+			} as never),
+		).resolves.toBe(result);
 	});
 });
 
@@ -212,6 +306,15 @@ describe("createOllamaProviderModule", () => {
 		expect(call.apiKey).toBeUndefined();
 	});
 });
+
+function retryableApiCallError(): APICallError {
+	return new APICallError({
+		message: "Ollama request timed out after 30 seconds",
+		url: "http://localhost:11434/api/chat",
+		requestBodyValues: {},
+		isRetryable: true,
+	});
+}
 
 function config(
 	overrides: Partial<GatewayResolvedProviderConfig>,

--- a/sdk/packages/llms/src/providers/vendors/ollama.test.ts
+++ b/sdk/packages/llms/src/providers/vendors/ollama.test.ts
@@ -1,4 +1,3 @@
-import { APICallError } from "@ai-sdk/provider";
 import type {
 	GatewayProviderContext,
 	GatewayResolvedProviderConfig,
@@ -11,8 +10,6 @@ import {
 	OLLAMA_DEFAULT_TIMEOUT_MS,
 	readOllamaNumCtx,
 	readOllamaTimeoutMs,
-	restoreApiCallError,
-	restoreOllamaApiCallErrorMiddleware,
 	withOllamaResponseTimeout,
 } from "./ollama";
 
@@ -97,6 +94,12 @@ describe("readOllamaTimeoutMs", () => {
 			OLLAMA_DEFAULT_TIMEOUT_MS,
 		);
 	});
+
+	it("defaults to 5 minutes so model cold loads don't hit a timeout error", () => {
+		// Ollama only sends response headers once the model is loaded, so the
+		// response-start budget must cover a cold load (cline/cline#12829).
+		expect(OLLAMA_DEFAULT_TIMEOUT_MS).toBe(300_000);
+	});
 });
 
 describe("withOllamaResponseTimeout", () => {
@@ -123,26 +126,6 @@ describe("withOllamaResponseTimeout", () => {
 		);
 		await vi.advanceTimersByTimeAsync(1001);
 		await assertion;
-	});
-
-	it("rejects timeouts as retryable APICallErrors so the AI SDK retries them", async () => {
-		const hangingFetch = ((_input, init) =>
-			new Promise((_resolve, reject) => {
-				init?.signal?.addEventListener("abort", () =>
-					reject(init.signal?.reason),
-				);
-			})) as typeof fetch;
-
-		const wrapped = withOllamaResponseTimeout(hangingFetch, 1000);
-		const pending = wrapped("http://localhost:11434/api/chat").catch(
-			(error) => error,
-		);
-		await vi.advanceTimersByTimeAsync(1001);
-		const error = await pending;
-
-		expect(APICallError.isInstance(error)).toBe(true);
-		expect((error as APICallError).isRetryable).toBe(true);
-		expect((error as APICallError).url).toBe("http://localhost:11434/api/chat");
 	});
 
 	it("does not abort once the response has started", async () => {
@@ -177,75 +160,6 @@ describe("withOllamaResponseTimeout", () => {
 		const assertion = expect(pending).rejects.toThrow("user cancelled");
 		upstream.abort(new Error("user cancelled"));
 		await assertion;
-	});
-
-	it("does not convert upstream aborts into retryable errors", async () => {
-		const hangingFetch = ((_input, init) =>
-			new Promise((_resolve, reject) => {
-				init?.signal?.addEventListener("abort", () =>
-					reject(init.signal?.reason),
-				);
-			})) as typeof fetch;
-
-		const upstream = new AbortController();
-		const wrapped = withOllamaResponseTimeout(hangingFetch, 60_000);
-		const pending = wrapped("http://localhost:11434/api/chat", {
-			signal: upstream.signal,
-		}).catch((error) => error);
-		upstream.abort(new Error("user cancelled"));
-		const error = await pending;
-
-		expect(APICallError.isInstance(error)).toBe(false);
-		expect((error as Error).message).toBe("user cancelled");
-	});
-});
-
-describe("restoreApiCallError", () => {
-	it("returns a bare APICallError as-is", () => {
-		const apiError = retryableApiCallError();
-		expect(restoreApiCallError(apiError)).toBe(apiError);
-	});
-
-	it("restores an APICallError buried in a cause chain (OllamaError wrapping)", () => {
-		const apiError = retryableApiCallError();
-		const wrapped = new Error("Ollama request failed", { cause: apiError });
-		expect(restoreApiCallError(wrapped)).toBe(apiError);
-	});
-
-	it("returns the original error when no APICallError is present", () => {
-		const plain = new Error("connection refused");
-		expect(restoreApiCallError(plain)).toBe(plain);
-	});
-
-	it("handles non-Error values", () => {
-		expect(restoreApiCallError("boom")).toBe("boom");
-		expect(restoreApiCallError(undefined)).toBeUndefined();
-	});
-});
-
-describe("restoreOllamaApiCallErrorMiddleware", () => {
-	it("rethrows the buried APICallError from wrapStream failures", async () => {
-		const apiError = retryableApiCallError();
-		const doStream = vi
-			.fn()
-			.mockRejectedValue(new Error("wrapped", { cause: apiError }));
-
-		await expect(
-			restoreOllamaApiCallErrorMiddleware.wrapStream?.({
-				doStream,
-			} as never),
-		).rejects.toBe(apiError);
-	});
-
-	it("passes successful streams through untouched", async () => {
-		const result = { stream: "stream" };
-		const doStream = vi.fn().mockResolvedValue(result);
-
-		await expect(
-			restoreOllamaApiCallErrorMiddleware.wrapStream?.({
-				doStream,
-			} as never),
-		).resolves.toBe(result);
 	});
 });
 
@@ -304,15 +218,6 @@ describe("createOllamaProviderModule", () => {
 		expect(call.apiKey).toBeUndefined();
 	});
 });
-
-function retryableApiCallError(): APICallError {
-	return new APICallError({
-		message: "Ollama request timed out after 30 seconds",
-		url: "http://localhost:11434/api/chat",
-		requestBodyValues: {},
-		isRetryable: true,
-	});
-}
 
 function config(
 	overrides: Partial<GatewayResolvedProviderConfig>,

--- a/sdk/packages/llms/src/providers/vendors/ollama.ts
+++ b/sdk/packages/llms/src/providers/vendors/ollama.ts
@@ -9,7 +9,11 @@
 // `options.num_ctx` per request; this boundary maps the provider-neutral
 // model `contextWindow` onto it.
 
-import type { LanguageModelV3 } from "@ai-sdk/provider";
+import type {
+	LanguageModelV3,
+	LanguageModelV3Middleware,
+} from "@ai-sdk/provider";
+import { APICallError } from "@ai-sdk/provider";
 import type {
 	GatewayProviderContext,
 	GatewayResolvedProviderConfig,
@@ -85,6 +89,17 @@ export function readOllamaTimeoutMs(
  * arrive the timer is cleared — streaming the body is never interrupted.
  * Mirrors the legacy handler, which raced the chat call (stream start)
  * against a timeout rather than bounding the whole generation.
+ *
+ * A timeout rejects with a **retryable `APICallError`** so the AI SDK's
+ * built-in `streamText` retry (default 2 retries with backoff) re-issues the
+ * request. This matters for local servers: Ollama holds `/api/chat` open
+ * while it cold-loads the model and only sends response headers once loading
+ * finishes, so a large model routinely blows the response-start budget on the
+ * first attempt. A timed-out attempt doesn't cancel the server-side load —
+ * retrying converges on the loaded model, which is how the pre-SDK handler
+ * (`withRetry({ retryAllErrors: true })`) rode out cold loads without ever
+ * surfacing an error. Only OUR timer is converted: upstream aborts (user
+ * cancellation) propagate untouched and stay non-retryable.
  */
 export function withOllamaResponseTimeout(
 	baseFetch: typeof fetch,
@@ -92,15 +107,7 @@ export function withOllamaResponseTimeout(
 ): typeof fetch {
 	return (async (input, init) => {
 		const timeoutController = new AbortController();
-		const timer = setTimeout(
-			() =>
-				timeoutController.abort(
-					new Error(
-						`Ollama request timed out after ${timeoutMs / 1000} seconds`,
-					),
-				),
-			timeoutMs,
-		);
+		const timer = setTimeout(() => timeoutController.abort(), timeoutMs);
 		// AbortSignal.any keeps upstream cancellation live for the entire
 		// request (including body streaming after the timer is cleared) and
 		// cleans up its own listeners — no manual listener management.
@@ -110,11 +117,70 @@ export function withOllamaResponseTimeout(
 			: timeoutController.signal;
 		try {
 			return await baseFetch(input, { ...init, signal });
+		} catch (error) {
+			// Convert only when our timer fired and the caller didn't abort
+			// (checked instead of matching the thrown error because abort-reason
+			// propagation differs across fetch implementations).
+			if (timeoutController.signal.aborted && !upstreamSignal?.aborted) {
+				throw new APICallError({
+					message: `Ollama request timed out after ${timeoutMs / 1000} seconds`,
+					url: typeof input === "string" ? input : String(input),
+					requestBodyValues: {},
+					isRetryable: true,
+					cause: error,
+				});
+			}
+			throw error;
 		} finally {
 			clearTimeout(timer);
 		}
 	}) as typeof fetch;
 }
+
+/**
+ * Restore the innermost `APICallError` from an error's `cause` chain.
+ *
+ * `ai-sdk-ollama` wraps every `doStream`/`doGenerate` failure in its own
+ * `OllamaError` (a plain `Error` subclass, original error as `cause`). The
+ * AI SDK's retry predicate only retries `APICallError` instances with
+ * `isRetryable === true`, so the wrapper would otherwise hide the retryable
+ * timeout produced by {@link withOllamaResponseTimeout} and no retry would
+ * ever happen. Returns the original error unchanged when no `APICallError`
+ * is buried in the chain.
+ */
+export function restoreApiCallError(error: unknown): unknown {
+	let candidate: unknown = error;
+	for (let depth = 0; depth < 5 && candidate; depth++) {
+		if (APICallError.isInstance(candidate)) {
+			return candidate;
+		}
+		candidate = (candidate as { cause?: unknown }).cause;
+	}
+	return error;
+}
+
+/**
+ * Middleware applying {@link restoreApiCallError} to model call failures, so
+ * retryable errors reach the AI SDK retry loop as themselves rather than
+ * wrapped in `OllamaError`.
+ */
+export const restoreOllamaApiCallErrorMiddleware: LanguageModelV3Middleware = {
+	specificationVersion: "v3",
+	wrapStream: async ({ doStream }) => {
+		try {
+			return await doStream();
+		} catch (error) {
+			throw restoreApiCallError(error);
+		}
+	},
+	wrapGenerate: async ({ doGenerate }) => {
+		try {
+			return await doGenerate();
+		} catch (error) {
+			throw restoreApiCallError(error);
+		}
+	},
+};
 
 export async function createOllamaProviderModule(
 	config: GatewayResolvedProviderConfig,
@@ -136,15 +202,20 @@ export async function createOllamaProviderModule(
 	});
 	const numCtx = readOllamaNumCtx(context);
 	return {
-		// `splitToolImagesMiddleware` for the same reason as the
-		// OpenAI-compatible vendor: the downstream converter stringifies
+		// `restoreOllamaApiCallErrorMiddleware` so retryable response-start
+		// timeouts survive ai-sdk-ollama's OllamaError wrapping and engage the
+		// AI SDK retry loop. `splitToolImagesMiddleware` for the same reason as
+		// the OpenAI-compatible vendor: the downstream converter stringifies
 		// multimodal tool-result content, losing image bytes.
 		model: (modelId) =>
 			wrapLanguageModel({
 				model: provider(modelId, {
 					options: { num_ctx: numCtx },
 				}) as LanguageModelV3,
-				middleware: splitToolImagesMiddleware,
+				middleware: [
+					restoreOllamaApiCallErrorMiddleware,
+					splitToolImagesMiddleware,
+				],
 			}),
 	};
 }

--- a/sdk/packages/llms/src/providers/vendors/ollama.ts
+++ b/sdk/packages/llms/src/providers/vendors/ollama.ts
@@ -9,11 +9,7 @@
 // `options.num_ctx` per request; this boundary maps the provider-neutral
 // model `contextWindow` onto it.
 
-import type {
-	LanguageModelV3,
-	LanguageModelV3Middleware,
-} from "@ai-sdk/provider";
-import { APICallError } from "@ai-sdk/provider";
+import type { LanguageModelV3 } from "@ai-sdk/provider";
 import type {
 	GatewayProviderContext,
 	GatewayResolvedProviderConfig,
@@ -62,13 +58,25 @@ export function readOllamaNumCtx(context: GatewayProviderContext): number {
 
 /**
  * Time to wait for the response to start when no timeout is configured.
- * Matches the pre-SDK-migration Ollama handler default.
+ *
+ * Deliberately generous: Ollama holds `/api/chat` open while it cold-loads
+ * the model and only sends response headers once loading finishes, so with a
+ * large model (or a large `num_ctx`, which this vendor requests) the first
+ * request of a session routinely takes minutes before the stream starts.
+ * A tight budget here turns every cold load into a user-facing timeout error
+ * (see cline/cline#12829 — the legacy handler's 30s default was only
+ * tolerable because its retry decorator silently re-issued the request until
+ * the model was loaded). Unreachable servers are not this timeout's job:
+ * connection-level failures (refused, DNS) reject on their own immediately,
+ * and users can always cancel a request from the UI. This only bounds the
+ * accepted-but-silent case, and 5 minutes matches the header-timeout default
+ * other AI SDK-based agents use.
  */
-export const OLLAMA_DEFAULT_TIMEOUT_MS = 30_000;
+export const OLLAMA_DEFAULT_TIMEOUT_MS = 300_000;
 
 /**
- * Read the configured request timeout, mirroring the legacy handler's
- * `requestTimeoutMs || 30000` (zero/invalid values fall back to the default).
+ * Read the configured request timeout (the legacy `requestTimeoutMs`
+ * setting); zero/invalid values fall back to the default.
  */
 export function readOllamaTimeoutMs(
 	config: GatewayResolvedProviderConfig,
@@ -89,17 +97,6 @@ export function readOllamaTimeoutMs(
  * arrive the timer is cleared — streaming the body is never interrupted.
  * Mirrors the legacy handler, which raced the chat call (stream start)
  * against a timeout rather than bounding the whole generation.
- *
- * A timeout rejects with a **retryable `APICallError`** so the AI SDK's
- * built-in `streamText` retry (default 2 retries with backoff) re-issues the
- * request. This matters for local servers: Ollama holds `/api/chat` open
- * while it cold-loads the model and only sends response headers once loading
- * finishes, so a large model routinely blows the response-start budget on the
- * first attempt. A timed-out attempt doesn't cancel the server-side load —
- * retrying converges on the loaded model, which is how the pre-SDK handler
- * (`withRetry({ retryAllErrors: true })`) rode out cold loads without ever
- * surfacing an error. Only OUR timer is converted: upstream aborts (user
- * cancellation) propagate untouched and stay non-retryable.
  */
 export function withOllamaResponseTimeout(
 	baseFetch: typeof fetch,
@@ -107,7 +104,15 @@ export function withOllamaResponseTimeout(
 ): typeof fetch {
 	return (async (input, init) => {
 		const timeoutController = new AbortController();
-		const timer = setTimeout(() => timeoutController.abort(), timeoutMs);
+		const timer = setTimeout(
+			() =>
+				timeoutController.abort(
+					new Error(
+						`Ollama request timed out after ${timeoutMs / 1000} seconds`,
+					),
+				),
+			timeoutMs,
+		);
 		// AbortSignal.any keeps upstream cancellation live for the entire
 		// request (including body streaming after the timer is cleared) and
 		// cleans up its own listeners — no manual listener management.
@@ -117,70 +122,11 @@ export function withOllamaResponseTimeout(
 			: timeoutController.signal;
 		try {
 			return await baseFetch(input, { ...init, signal });
-		} catch (error) {
-			// Convert only when our timer fired and the caller didn't abort
-			// (checked instead of matching the thrown error because abort-reason
-			// propagation differs across fetch implementations).
-			if (timeoutController.signal.aborted && !upstreamSignal?.aborted) {
-				throw new APICallError({
-					message: `Ollama request timed out after ${timeoutMs / 1000} seconds`,
-					url: typeof input === "string" ? input : String(input),
-					requestBodyValues: {},
-					isRetryable: true,
-					cause: error,
-				});
-			}
-			throw error;
 		} finally {
 			clearTimeout(timer);
 		}
 	}) as typeof fetch;
 }
-
-/**
- * Restore the innermost `APICallError` from an error's `cause` chain.
- *
- * `ai-sdk-ollama` wraps every `doStream`/`doGenerate` failure in its own
- * `OllamaError` (a plain `Error` subclass, original error as `cause`). The
- * AI SDK's retry predicate only retries `APICallError` instances with
- * `isRetryable === true`, so the wrapper would otherwise hide the retryable
- * timeout produced by {@link withOllamaResponseTimeout} and no retry would
- * ever happen. Returns the original error unchanged when no `APICallError`
- * is buried in the chain.
- */
-export function restoreApiCallError(error: unknown): unknown {
-	let candidate: unknown = error;
-	for (let depth = 0; depth < 5 && candidate; depth++) {
-		if (APICallError.isInstance(candidate)) {
-			return candidate;
-		}
-		candidate = (candidate as { cause?: unknown }).cause;
-	}
-	return error;
-}
-
-/**
- * Middleware applying {@link restoreApiCallError} to model call failures, so
- * retryable errors reach the AI SDK retry loop as themselves rather than
- * wrapped in `OllamaError`.
- */
-export const restoreOllamaApiCallErrorMiddleware: LanguageModelV3Middleware = {
-	specificationVersion: "v3",
-	wrapStream: async ({ doStream }) => {
-		try {
-			return await doStream();
-		} catch (error) {
-			throw restoreApiCallError(error);
-		}
-	},
-	wrapGenerate: async ({ doGenerate }) => {
-		try {
-			return await doGenerate();
-		} catch (error) {
-			throw restoreApiCallError(error);
-		}
-	},
-};
 
 export async function createOllamaProviderModule(
 	config: GatewayResolvedProviderConfig,
@@ -202,20 +148,15 @@ export async function createOllamaProviderModule(
 	});
 	const numCtx = readOllamaNumCtx(context);
 	return {
-		// `restoreOllamaApiCallErrorMiddleware` so retryable response-start
-		// timeouts survive ai-sdk-ollama's OllamaError wrapping and engage the
-		// AI SDK retry loop. `splitToolImagesMiddleware` for the same reason as
-		// the OpenAI-compatible vendor: the downstream converter stringifies
+		// `splitToolImagesMiddleware` for the same reason as the
+		// OpenAI-compatible vendor: the downstream converter stringifies
 		// multimodal tool-result content, losing image bytes.
 		model: (modelId) =>
 			wrapLanguageModel({
 				model: provider(modelId, {
 					options: { num_ctx: numCtx },
 				}) as LanguageModelV3,
-				middleware: [
-					restoreOllamaApiCallErrorMiddleware,
-					splitToolImagesMiddleware,
-				],
+				middleware: splitToolImagesMiddleware,
 			}),
 	};
 }


### PR DESCRIPTION
### Related Issue

Investigation of #12829 — "Regression in v4.1.2: Stuck on 'Thinking...' with local Ollama models (v4.0.11 works fine)".

### Description

**The regression.** Ollama holds `/api/chat` open while it cold-loads the model and only sends response headers once loading finishes (verified against a real server — its access log doesn't even print the request line until the request completes, which is why the reporter saw "no /api/chat in the logs"). With a large model — or a large `num_ctx`, which this vendor deliberately requests since #12286 — the first request of a session routinely takes well over 30 seconds before the stream starts.

The legacy (pre-SDK) extension had the same 30s response-start default but masked it: `withRetry({ retryAllErrors: true })` plus task-level auto-retry silently re-issued the request until the model was loaded, so users just saw a slow first response. The SDK extension kept the 30s guillotine but lost every retry layer (the AI SDK only retries `APICallError` with `isRetryable`, and `ai-sdk-ollama` wraps all failures in its own plain `OllamaError` — so `streamText`'s built-in retries never engage). Net effect: every cold load fails the first message with "Ollama request timed out after 30 seconds" and a manual Retry button.

**The fix: stop killing a healthy request instead of retrying around the kill.** `OLLAMA_DEFAULT_TIMEOUT_MS` goes from 30s to 5 minutes:

- Unreachable servers are not this timeout's job — connection-level failures (refused, DNS) reject immediately on their own, and the user can always cancel from the UI. The tight budget only ever guillotined the one case where waiting is correct.
- This matches what other AI SDK-based agents do: opencode has **no** response-start timeout at all for custom/local providers, and its only per-provider default (OpenAI) is the same 300s.
- An explicitly configured `requestTimeoutMs` is still honored (the legacy setting migrates over and overrides the default), so fail-fast behavior remains available to anyone who wants it. The Ollama settings UI text is updated to the new default and explains why it's generous.

No retry machinery, no error-type surgery — a constant, doc comments, a pinning test, and settings copy.

### Test Procedure

**Unit** (`bun -F @cline/llms test` — 482 passed): existing timeout suite (fires at the configured budget, cleared once headers arrive, upstream aborts propagate) plus a test pinning the 5-minute default with the cold-load rationale.

**End-to-end**: fresh extension-development host built from this branch, against a proxy that simulates a 45-second Ollama model cold load (serves `/api/tags` normally, holds the first `/api/chat` for 45s like a loading model, then streams a normal NDJSON response). A ticking clock terminal on screen proves elapsed time. Result — exactly one request, held through the full load, no client abort, no retry churn, and **no error ever shown**; the response streams once the "load" completes:

```
[proxy 22:09:36] received POST /api/chat
[proxy 22:09:36] model 'load' started; holding /api/chat for 45.0s
[proxy 22:10:22] served canned /api/chat response
```

![35 seconds after send (past the old 30s limit): still a clean Thinking state, no error](https://cursor.com/artifacts/c/art-80eb34df-9865-48c4-a6ed-b8228e07444c)
![Response streamed at clock 22:10:39 with no timeout error ever displayed](https://cursor.com/artifacts/c/art-24590730-daaa-4b0e-9022-82b76ba04083)
![Ollama settings showing the new 300000ms default and updated description](https://cursor.com/artifacts/c/art-1e4fcc2a-90b5-498a-9ba4-ea2da7599d03)

For contrast, the same scenario on the shipped 4.1.2 SDK bundle fails the first message at 30s with "Ollama request timed out after 30 seconds" and a manual Retry button.

Branch history note: the first two commits implemented a retry-based approach (making the timeout a retryable `APICallError` plus a middleware unwrapping it from `OllamaError`); the final commit replaces it with this simpler root-cause fix after comparing with how opencode handles local providers.

Note: `bun run types` at the SDK root currently fails in `@cline/cli` (`root.tsx(367): Cannot find name 'formatDisplayUserInput'`) — pre-existing on `main` from #12830, unrelated to this change; `@cline/llms` builds and typechecks clean.