### PR TITLE
fix(settings): persist base URL and API key edits typed before provider config loads

### DIFF
--- a/apps/vscode/webview-ui/src/components/settings/providers/LiteLlmProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/LiteLlmProvider.tsx
@@ -48,7 +48,6 @@ export const LiteLlmProvider = ({ showModelOptions, isPopup, currentMode }: Lite
 	)
 	const { savedApiKeyMask, handleApiKeyChange } = useProviderApiKeyField({
 		apiKeyLength: config?.apiKeyLength,
-		canWrite: config !== undefined,
 		providerName: "LiteLLM",
 		write,
 	})
@@ -64,11 +63,11 @@ export const LiteLlmProvider = ({ showModelOptions, isPopup, currentMode }: Lite
 		await refresh()
 	}
 
+	// Writes are safe before the initial config read resolves: write() does not
+	// depend on loaded config, and useProviderConfig drops the stale read
+	// response. Gating on `config` here would silently discard text typed right
+	// after the settings view mounts.
 	const handleBaseUrlChange = (value: string) => {
-		if (!config) {
-			return
-		}
-
 		void write({ baseUrl: value }).catch((err) => console.error("Failed to update LiteLLM base URL:", err))
 	}
 

--- a/apps/vscode/webview-ui/src/components/settings/providers/OpenAICompatible.test.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/OpenAICompatible.test.tsx
@@ -241,6 +241,26 @@ describe("OpenAICompatibleProvider", () => {
 		expect(screen.getByLabelText("OpenAI Compatible API key")).toHaveValue("••••••••••••")
 	})
 
+	it("persists base URL and API key edits made before config loads", async () => {
+		// The initial provider-config read resolves asynchronously; edits made
+		// in that window must still be written, not silently dropped.
+		mocks.useProviderConfig.mockReturnValue({
+			config: undefined,
+			commitSelection: mocks.commitSelection,
+			write: mocks.write,
+		})
+		renderProvider()
+		await act(async () => {})
+
+		fireEvent.change(screen.getByPlaceholderText("Enter base URL..."), {
+			target: { value: "http://early.example:1234/v1" },
+		})
+		fireEvent.change(screen.getByLabelText("OpenAI Compatible API key"), { target: { value: "early-secret" } })
+
+		expect(mocks.write).toHaveBeenCalledWith({ baseUrl: "http://early.example:1234/v1" })
+		expect(mocks.write).toHaveBeenCalledWith({ apiKey: "early-secret" })
+	})
+
 	it("writes a newly entered API key without echoing a stored key into config", async () => {
 		renderProvider()
 		await act(async () => {})

--- a/apps/vscode/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
@@ -291,7 +291,6 @@ export const OpenAICompatibleProvider = ({
 
 	const { savedApiKeyMask, handleApiKeyChange } = useProviderApiKeyField({
 		apiKeyLength: config?.apiKeyLength,
-		canWrite: config !== undefined,
 		onApiKeyChange: (apiKey) => {
 			latestOpenAiApiKeyRef.current = apiKey
 			debouncedRefreshOpenAiModels(latestOpenAiBaseUrlRef.current, apiKey)
@@ -314,11 +313,11 @@ export const OpenAICompatibleProvider = ({
 						<DebouncedTextField
 							disabled={remoteConfigSettings?.openAiBaseUrl !== undefined}
 							initialValue={config?.baseUrl || ""}
+							// Intentionally not gated on `config` having loaded:
+							// write() works before the initial read resolves, and a
+							// guard here would silently discard text typed right
+							// after mount, which the late resync then wipes.
 							onChange={(value) => {
-								if (!config) {
-									return
-								}
-
 								latestOpenAiBaseUrlRef.current = value
 								void write({ baseUrl: value }).catch((error) => handleProviderConfigWriteError("base URL", error))
 								debouncedRefreshOpenAiModels(value, latestOpenAiApiKeyRef.current)

--- a/apps/vscode/webview-ui/src/components/settings/providers/ProviderConfigLateLoad.test.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/ProviderConfigLateLoad.test.tsx
@@ -1,0 +1,237 @@
+import { act, fireEvent, render, screen } from "@testing-library/react"
+import type { ChangeEventHandler, ReactNode } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { LiteLlmProvider } from "./LiteLlmProvider"
+import { OpenAICompatibleProvider } from "./OpenAICompatible"
+
+// Regression tests for edits made while the provider config is still loading:
+// the initial readProviderConfig round trip is in flight, so `config` is
+// undefined. Typed text must be written to the backend, and the late-arriving
+// stored config must not roll the field back. These tests use the real
+// useProviderConfig, DebouncedTextField/useDebouncedInput, and API key
+// plumbing; only the gRPC transport and unrelated UI is mocked.
+
+const mocks = vi.hoisted(() => ({
+	readProviderConfig: vi.fn(),
+	refreshOpenAiModels: vi.fn(),
+	writeProviderConfig: vi.fn(),
+}))
+
+vi.mock("@/services/grpc-client", () => ({
+	ModelsServiceClient: {
+		readProviderConfig: mocks.readProviderConfig,
+		refreshOpenAiModels: mocks.refreshOpenAiModels,
+		writeProviderConfig: mocks.writeProviderConfig,
+	},
+}))
+
+vi.mock("@/context/ExtensionStateContext", () => ({
+	useExtensionState: () => ({ apiConfiguration: {}, remoteConfigSettings: undefined }),
+}))
+
+vi.mock("@/hooks/useDynamicProviderSelection", () => ({
+	useDynamicProviderSelection: () => ({ selectedModelId: "", selectedModelInfo: undefined, hideUsageCost: false }),
+}))
+
+vi.mock("@/hooks/useProviderModels", () => ({
+	useProviderModels: () => ({
+		models: {},
+		defaultModelId: undefined,
+		isLoading: false,
+		isStale: false,
+		error: undefined,
+		refresh: vi.fn(),
+	}),
+}))
+
+vi.mock("@/hooks/useProviderModelSelection", () => ({
+	useProviderModelSelection: () => ({
+		selectedModelId: "",
+		selectedModelInfo: undefined,
+		commitModelSelection: vi.fn(),
+	}),
+}))
+
+vi.mock("../utils/useApiConfigurationHandlers", () => ({
+	useApiConfigurationHandlers: () => ({ handleFieldChange: vi.fn(), handleModeFieldChange: vi.fn() }),
+}))
+
+vi.mock("@radix-ui/react-tooltip", () => ({
+	TooltipContent: () => null,
+	TooltipTrigger: ({ children }: { children?: ReactNode }) => <>{children}</>,
+}))
+
+vi.mock("@/components/ui/tooltip", () => ({
+	Tooltip: ({ children }: { children?: ReactNode }) => <>{children}</>,
+	TooltipContent: () => null,
+	TooltipTrigger: ({ children }: { children?: ReactNode }) => <>{children}</>,
+}))
+
+vi.mock("@vscode/webview-ui-toolkit/react", () => ({
+	VSCodeButton: ({ children, disabled, onClick }: { children?: ReactNode; disabled?: boolean; onClick?: () => void }) => (
+		<button disabled={disabled} onClick={onClick} type="button">
+			{children}
+		</button>
+	),
+	VSCodeCheckbox: ({
+		checked,
+		children,
+		onChange,
+	}: {
+		checked?: boolean
+		children?: ReactNode
+		onChange?: ChangeEventHandler<HTMLInputElement>
+	}) => (
+		<label>
+			<input checked={checked} onChange={onChange} type="checkbox" />
+			{children}
+		</label>
+	),
+	VSCodeDropdown: ({ children, onChange, value }: { children?: ReactNode; onChange?: ChangeEventHandler; value?: string }) => (
+		<select onChange={onChange} value={value}>
+			{children}
+		</select>
+	),
+	VSCodeLink: ({ children, href }: { children?: ReactNode; href?: string }) => <a href={href}>{children}</a>,
+	VSCodeOption: ({ children, value }: { children?: ReactNode; value?: string }) => <option value={value}>{children}</option>,
+	VSCodeTextField: ({
+		children,
+		disabled,
+		onInput,
+		placeholder,
+		type,
+		value,
+	}: {
+		children?: ReactNode
+		disabled?: boolean
+		onInput?: ChangeEventHandler<HTMLInputElement>
+		placeholder?: string
+		type?: string
+		value?: string
+	}) => (
+		<label>
+			{children}
+			<input disabled={disabled} onChange={onInput} placeholder={placeholder} type={type ?? "text"} value={value} />
+		</label>
+	),
+}))
+
+vi.mock("../common/ModelAutocomplete", () => ({ ModelAutocomplete: () => null }))
+vi.mock("../common/ModelInfoView", () => ({ ModelInfoView: () => null }))
+vi.mock("../ReasoningEffortSelector", () => ({ default: () => null }))
+
+function deferred<T>() {
+	let resolve!: (value: T) => void
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise
+	})
+	return { promise, resolve }
+}
+
+async function flushDebounce() {
+	await act(async () => {
+		await new Promise((resolvePromise) => setTimeout(resolvePromise, 150))
+	})
+}
+
+type WriteRequest = {
+	providerId: string
+	patch?: { apiKey?: string; baseUrl?: string }
+}
+
+function storedConfig(providerId: string) {
+	return { providerId, apiKeyLength: 10, baseUrl: "http://stored.example/v1", headers: {} }
+}
+
+describe("provider settings edits made before config loads", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		mocks.refreshOpenAiModels.mockResolvedValue({ values: [] })
+		mocks.writeProviderConfig.mockImplementation(async (request: WriteRequest) => ({
+			providerId: request.providerId,
+			baseUrl: request.patch?.baseUrl || "",
+			apiKeyLength: request.patch?.apiKey ? request.patch.apiKey.length : 0,
+			headers: {},
+		}))
+	})
+
+	it("OpenAI Compatible: persists a base URL typed before the initial read resolves", async () => {
+		const initialRead = deferred<ReturnType<typeof storedConfig>>()
+		mocks.readProviderConfig.mockReturnValue(initialRead.promise)
+		render(<OpenAICompatibleProvider currentMode="act" providerId="custom-openai" showModelOptions={false} />)
+
+		const baseUrlInput = screen.getByPlaceholderText("Enter base URL...")
+		fireEvent.change(baseUrlInput, { target: { value: "http://typed.example:1234/v1" } })
+		await flushDebounce()
+
+		expect(mocks.writeProviderConfig).toHaveBeenCalledTimes(1)
+		expect(mocks.writeProviderConfig.mock.calls[0][0].patch.baseUrl).toBe("http://typed.example:1234/v1")
+
+		// The slow initial read lands with the pre-edit stored config; it is
+		// stale (an older request than the write) and must not roll back the
+		// field.
+		await act(async () => {
+			initialRead.resolve(storedConfig("custom-openai"))
+		})
+
+		expect(baseUrlInput).toHaveValue("http://typed.example:1234/v1")
+	})
+
+	it("OpenAI Compatible: persists an API key typed before the initial read resolves", async () => {
+		const initialRead = deferred<ReturnType<typeof storedConfig>>()
+		mocks.readProviderConfig.mockReturnValue(initialRead.promise)
+		render(<OpenAICompatibleProvider currentMode="act" providerId="custom-openai" showModelOptions={false} />)
+
+		fireEvent.change(screen.getByPlaceholderText("Enter API Key..."), { target: { value: "early-secret" } })
+		await flushDebounce()
+
+		expect(mocks.writeProviderConfig).toHaveBeenCalledTimes(1)
+		expect(mocks.writeProviderConfig.mock.calls[0][0].patch.apiKey).toBe("early-secret")
+
+		await act(async () => {
+			initialRead.resolve(storedConfig("custom-openai"))
+		})
+
+		// The write's read-back reports the new key's length, so the field
+		// shows the saved-key mask for the key just typed — not the stale
+		// stored key's mask.
+		expect(screen.getByPlaceholderText("Enter API Key...")).toHaveValue("•".repeat("early-secret".length))
+	})
+
+	it("LiteLLM: persists a base URL typed before the initial read resolves", async () => {
+		const initialRead = deferred<ReturnType<typeof storedConfig>>()
+		mocks.readProviderConfig.mockReturnValue(initialRead.promise)
+		render(<LiteLlmProvider currentMode="act" showModelOptions={false} />)
+
+		const baseUrlInput = screen.getByPlaceholderText("Default: http://localhost:4000")
+		fireEvent.change(baseUrlInput, { target: { value: "http://typed.example:4000" } })
+		await flushDebounce()
+
+		expect(mocks.writeProviderConfig).toHaveBeenCalledTimes(1)
+		expect(mocks.writeProviderConfig.mock.calls[0][0].patch.baseUrl).toBe("http://typed.example:4000")
+
+		await act(async () => {
+			initialRead.resolve(storedConfig("litellm"))
+		})
+
+		expect(baseUrlInput).toHaveValue("http://typed.example:4000")
+	})
+
+	it("LiteLLM: persists an API key typed before the initial read resolves", async () => {
+		const initialRead = deferred<ReturnType<typeof storedConfig>>()
+		mocks.readProviderConfig.mockReturnValue(initialRead.promise)
+		render(<LiteLlmProvider currentMode="act" showModelOptions={false} />)
+
+		fireEvent.change(screen.getByPlaceholderText("Default: noop"), { target: { value: "sk-early" } })
+		await flushDebounce()
+
+		expect(mocks.writeProviderConfig).toHaveBeenCalledTimes(1)
+		expect(mocks.writeProviderConfig.mock.calls[0][0].patch.apiKey).toBe("sk-early")
+
+		await act(async () => {
+			initialRead.resolve(storedConfig("litellm"))
+		})
+
+		expect(screen.getByPlaceholderText("Default: noop")).toHaveValue("•".repeat("sk-early".length))
+	})
+})

--- a/apps/vscode/webview-ui/src/components/settings/utils/useProviderApiKeyField.ts
+++ b/apps/vscode/webview-ui/src/components/settings/utils/useProviderApiKeyField.ts
@@ -3,27 +3,19 @@ import { getSavedApiKeyMask, sanitizeMaskedApiKeyInput } from "./apiKeyMasking"
 
 interface UseProviderApiKeyFieldOptions {
 	apiKeyLength?: number
-	canWrite?: boolean
 	onApiKeyChange?: (apiKey: string) => void
 	providerName: string
 	write: (patch: { apiKey: string }) => Promise<unknown>
 }
 
-export function useProviderApiKeyField({
-	apiKeyLength,
-	canWrite = true,
-	onApiKeyChange,
-	providerName,
-	write,
-}: UseProviderApiKeyFieldOptions) {
+export function useProviderApiKeyField({ apiKeyLength, onApiKeyChange, providerName, write }: UseProviderApiKeyFieldOptions) {
 	const savedApiKeyMask = getSavedApiKeyMask(apiKeyLength)
 
+	// Intentionally no "config loaded" gate: keys typed while the provider
+	// config is still loading must persist, not be silently dropped and then
+	// wiped by the late initialValue resync.
 	const handleApiKeyChange = useCallback(
 		(value: string) => {
-			if (!canWrite) {
-				return
-			}
-
 			const apiKey = sanitizeMaskedApiKeyInput(value, savedApiKeyMask)
 
 			if (apiKey === undefined) {
@@ -33,7 +25,7 @@ export function useProviderApiKeyField({
 			onApiKeyChange?.(apiKey)
 			void write({ apiKey }).catch((err) => console.error(`Failed to update ${providerName} API key:`, err))
 		},
-		[canWrite, onApiKeyChange, providerName, savedApiKeyMask, write],
+		[onApiKeyChange, providerName, savedApiKeyMask, write],
 	)
 
 	return { savedApiKeyMask, handleApiKeyChange }


### PR DESCRIPTION
### Related Issue

Same bug class as #12834 ("letters disappearing while typing" in provider settings) — this covers the remaining window where the provider config hasn't loaded yet.

### Description

In the OpenAI Compatible and LiteLLM provider settings, text typed into the Base URL (and API key) fields immediately after the settings screen mounts could be silently dropped and then visibly wiped.

These components load their provider config asynchronously via `useProviderConfig()` — `config` starts `undefined` and arrives after a gRPC round trip. The Base URL `onChange` in `OpenAICompatible.tsx` did `if (!config) { return }` (and the API key field passed `canWrite: config !== undefined` into `useProviderApiKeyField`); `LiteLlmProvider.tsx` had the same pattern. Because the shared debounce hook (`useDebouncedInput`) clears its pending-user-edit flag before invoking `onChange`, an edit made before config arrived would: fire the debounce, no-op in `onChange`, and then get overwritten by the stored value when the config read landed — the user's text vanished and nothing was saved.

The guards were purely defensive: `write()` from `useProviderConfig` never reads the loaded config, and the hook's request-sequence counter already drops a stale initial read that resolves after a user-triggered write (an older response never rolls back a newer one). Every other provider using `useProviderApiKeyField` (OpenRouter, xAI, Z-AI, generic) already writes without a config gate. So the fix removes the `!config` guards and deletes the now-unused `canWrite` option entirely, making the write path work before local config state exists. `useDebouncedInput` is intentionally untouched.

Changes:
- `webview-ui/src/components/settings/providers/OpenAICompatible.tsx`: remove the `!config` guard from the Base URL `onChange` and the `canWrite` gate on the API key field
- `webview-ui/src/components/settings/providers/LiteLlmProvider.tsx`: same for `handleBaseUrlChange` and the API key field
- `webview-ui/src/components/settings/utils/useProviderApiKeyField.ts`: remove the `canWrite` option (no callers remain)

### Test Procedure

**Automated.** New regression tests fail on the unfixed code (5/5) and pass with the fix:

- `ProviderConfigLateLoad.test.tsx` (new): integration-style tests using the real `useProviderConfig`, `DebouncedTextField`/`useDebouncedInput`, and API key plumbing with only the gRPC transport mocked. For both providers, they keep the initial `readProviderConfig` unresolved, type into the Base URL / API key field, and assert `writeProviderConfig` is called with the typed value; then they resolve the stale initial read with the pre-edit stored config and assert the field is not rolled back (base URL keeps the typed text; the API key field shows the mask for the newly saved key, proving persistence).
- `OpenAICompatible.test.tsx`: added a unit test that base URL and API key edits made while `config` is `undefined` reach `write()`.

Verified locally from `apps/vscode/webview-ui`:
- `bun run test` — 51 files, 402 tests passed (including the 5 new ones)
- `bunx tsc -p tsconfig.app.json --noEmit` — clean
- `bunx biome check --config-path ./biome.jsonc --no-errors-on-unmatched --files-ignore-unknown=true --diagnostic-level=error <changed files>` — clean

**Manual (blast radius).** Built the webview + extension bundle with this change and ran it in a real VS Code Extension Development Host, exercising every surface the change touches:

- OpenAI Compatible: typed Base URL, API key, and Model ID during first-run provider setup; completed onboarding; reopened settings — all three values persisted (key shown as the saved-key mask).
- LiteLLM: edited Base URL and retyped the API key; closed settings with Done and reopened — both persisted.
- xAI (shares the modified `useProviderApiKeyField` hook, previously without `canWrite`): typed an API key, closed and reopened settings — key persisted as a mask, confirming no regression in the shared hook.

No wiped text, empty fields, or console errors were observed in any flow.

What could break and why it doesn't: the only behavior change is that writes are now issued while config is still loading. The race with the in-flight initial read is already handled by `useProviderConfig`'s sequence counter (stale read responses are dropped), which the new tests exercise explicitly. All existing OpenAI Compatible tests (masked-key echo protection, override merging, mode-switch isolation, debounced model refresh) still pass unchanged.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Settings reopened after editing in the dev host — LiteLLM Base URL and masked API key persisted:

![Cline settings showing persisted LiteLLM base URL and masked API key after reopening settings](https://cursor.com/artifacts/c/art-ddad0510-ced1-4eaa-bb3a-e33357988eb8)

### Additional Notes

The behavior of `useDebouncedInput` (pending edits surviving external resyncs, flush on unmount) is deliberately unchanged; other fields depend on those semantics. The exact race this fixes (typing during the sub-second window before the async config read resolves) isn't reliably reproducible by hand, which is why it's pinned down by the deterministic `ProviderConfigLateLoad` tests instead.