### PR TITLE
fix(vscode): keep plan/act input border in sync with actual textarea focus

### DIFF
--- a/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -587,7 +587,11 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					event.preventDefault()
 
 					if (!sendingDisabled) {
-						setIsTextAreaFocused(false)
+						// Note: don't set isTextAreaFocused to false here. The textarea keeps
+						// DOM focus after sending, and clearing the flag without an actual
+						// blur desyncs it permanently (programmatic .focus() on an
+						// already-focused element never re-fires onFocus), which hides the
+						// plan/act mode outline until a real blur/refocus cycle.
 						onSend()
 					}
 				}
@@ -1581,7 +1585,6 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 								data-testid="send-button"
 								onClick={() => {
 									if (!sendingDisabled) {
-										setIsTextAreaFocused(false)
 										onSend()
 									}
 								}}


### PR DESCRIPTION
### Related Issue

N/A — reported directly (chat input Plan/Act focus border frequently missing).

### Description

The chat input's mode-colored focus outline (yellow in Plan mode, blue in Act mode) frequently failed to appear, and toggling Plan/Act mode would "fix" it.

Root cause: sending a message (Enter or the send button) called `setIsTextAreaFocused(false)` without actually blurring the textarea. The DOM element stayed focused, so `onFocus` never re-fired — programmatic `.focus()` on an already-focused element is a no-op — leaving the React focus flag permanently out of sync and the outline hidden (the inline `outline: none` also suppresses the global `textarea:focus` CSS fallback in `main.css`). Toggling Plan/Act happened to restore it because the switch steals focus and then re-focuses the textarea after 100ms, forcing a real blur→focus cycle.

Fix: stop clearing the flag on send. Real blurs are already handled by the `onBlur` handler (the send button is a non-focusable `div`, so clicking it triggers a genuine blur anyway).

### Test Procedure

- Built the webview (`bun run build:webview`) and extension bundle (`bun esbuild.mjs`).
- `bun run test:webview`: 397/397 passing. `bun run test:unit`: 1029/1029 passing. `biome check` on the changed file reports no new diagnostics.
- Manually tested in a VS Code extension development host: focused the input in Plan mode (yellow outline), sent a message with Enter — the outline now persists after sending (previously it disappeared here and stayed gone). Switched to Act mode — outline turns blue — and sent again; the blue outline also persists after send.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Plan mode — yellow outline still visible immediately after sending with Enter:

![Plan mode yellow border persists after send](https://cursor.com/artifacts/c/art-8abf40db-8c63-4ce5-8ba1-44a71426fff6)

Act mode — blue outline still visible immediately after sending with Enter:

![Act mode blue border persists after send](https://cursor.com/artifacts/c/art-b78cac76-6fc9-49df-b76e-39ae13b982aa)

### Additional Notes