### PR TITLE
Fix AskSage custom API URL being ignored at inference time

### DIFF
--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -264,6 +264,13 @@ describe("normalizeSdkBaseUrl", () => {
 	it("preserves explicit user paths", () => {
 		expect(normalizeSdkBaseUrl("openai", " https://example.com/custom ")).toBe("https://example.com/custom")
 	})
+
+	it("inherits the AskSage default /server path when the custom URL has no path", () => {
+		expect(normalizeSdkBaseUrl("asksage", "https://asksage.internal.example")).toBe("https://asksage.internal.example/server")
+		expect(normalizeSdkBaseUrl("asksage", "https://asksage.internal.example/custom")).toBe(
+			"https://asksage.internal.example/custom",
+		)
+	})
 })
 
 // ---------------------------------------------------------------------------
@@ -452,6 +459,52 @@ describe("buildSessionConfig", () => {
 		expect(config.providerConfig).toMatchObject({
 			providerId: "openai-compatible",
 			baseUrl: "http://127.0.0.1:4141/v1",
+		})
+	})
+
+	it("resolves the AskSage base URL from the legacy asksageApiUrl state field", async () => {
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "asksage",
+			actModeApiModelId: "gpt-4o",
+			asksageApiKey: "asksage-key",
+			asksageApiUrl: "https://asksage.internal.example/server",
+		} as any)
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+
+		expect(config.providerId).toBe("asksage")
+		// Without this mapping the custom URL saved in legacy state was
+		// silently ignored and requests went to the builtin default
+		// (https://api.asksage.ai/server).
+		expect(config.baseUrl).toBe("https://asksage.internal.example/server")
+		expect(config.providerConfig).toMatchObject({
+			providerId: "asksage",
+			baseUrl: "https://asksage.internal.example/server",
+		})
+	})
+
+	it("falls back to the providers.json AskSage base URL when legacy state has none", async () => {
+		mocks.providerSettingsManager.getProviderSettings.mockImplementation((providerId?: string) => {
+			if (providerId !== "asksage") {
+				return undefined
+			}
+			return {
+				provider: "asksage",
+				apiKey: "asksage-key",
+				baseUrl: "https://asksage.migrated.example/server",
+			} as any
+		})
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "asksage",
+			actModeApiModelId: "gpt-4o",
+		} as any)
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+
+		expect(config.baseUrl).toBe("https://asksage.migrated.example/server")
+		expect(config.providerConfig).toMatchObject({
+			providerId: "asksage",
+			baseUrl: "https://asksage.migrated.example/server",
 		})
 	})
 

--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -631,6 +631,7 @@ export function resolveBaseUrl(providerId: string, config: ApiConfiguration): st
 		gemini: "geminiBaseUrl",
 		requesty: "requestyBaseUrl",
 		litellm: "liteLlmBaseUrl",
+		asksage: "asksageApiUrl",
 		oca: "ocaBaseUrl",
 		aihubmix: "aihubmixBaseUrl",
 		dify: "difyBaseUrl",

--- a/apps/vscode/webview-ui/src/components/settings/providers/AskSageProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/AskSageProvider.tsx
@@ -2,6 +2,7 @@ import { type ModelInfo } from "@shared/api"
 import { Mode } from "@shared/storage/types"
 import { useEffect, useState } from "react"
 import { useExtensionState } from "@/context/ExtensionStateContext"
+import { useProviderConfig } from "@/hooks/useProviderConfig"
 import { useStaticProviderSelection } from "@/hooks/useStaticProviderSelection"
 import { ApiKeyField } from "../common/ApiKeyField"
 import { DebouncedTextField } from "../common/DebouncedTextField"
@@ -31,12 +32,22 @@ const askSageDefaultURL = "https://api.asksage.ai/server"
 export const AskSageProvider = ({ showModelOptions, isPopup, currentMode }: AskSageProviderProps) => {
 	const { apiConfiguration } = useExtensionState()
 	const { handleFieldChange, handleModeFieldChange } = useApiConfigurationHandlers()
+	const { write } = useProviderConfig("asksage")
 	const { models, selectedModelId, selectedModelInfo, hideUsageCost } = useStaticProviderSelection(
 		"asksage",
 		apiConfiguration,
 		currentMode,
 	)
 	const [availableModels, setAvailableModels] = useState<Record<string, ModelInfo>>(models)
+
+	// Write through the SDK provider-config store so providers.json stays in
+	// sync for CLI/desktop hosts. The store mirrors `baseUrl` back to the
+	// legacy `asksageApiUrl` state key (even when providers.json validation
+	// rejects a partially-typed URL), so the legacy readers — including the
+	// /get-models fetch keyed on apiConfiguration.asksageApiUrl — keep working.
+	const handleApiUrlChange = (value: string) => {
+		void write({ baseUrl: value }).catch((err) => console.error("Failed to update AskSage API URL:", err))
+	}
 
 	useEffect(() => {
 		const fetchModels = async () => {
@@ -87,7 +98,7 @@ export const AskSageProvider = ({ showModelOptions, isPopup, currentMode }: AskS
 
 			<DebouncedTextField
 				initialValue={apiConfiguration?.asksageApiUrl || askSageDefaultURL}
-				onChange={(value) => handleFieldChange("asksageApiUrl", value)}
+				onChange={handleApiUrlChange}
 				placeholder="Enter AskSage API URL..."
 				style={{ width: "100%" }}
 				type="text">


### PR DESCRIPTION
### Related Issue

Found in an audit following the Anthropic base URL fix (#12834).

### Description

In the SDK-based extension, a custom AskSage API URL set in provider settings was saved and displayed, but silently ignored at inference time — requests went to the builtin default `https://api.asksage.ai/server`.

Root cause: the runtime `baseUrlMap` in `resolveBaseUrl()` (`apps/vscode/src/sdk/cline-session-factory.ts`) was missing the `asksage -> asksageApiUrl` entry, so the URL saved in legacy state was never read and the function fell through to the providers.json fallback, which only holds a stale one-time-migrated value or nothing. The mapping already existed in every other layer (`model-catalog/store.ts`, `model-catalog/effective-config.ts`, and the legacy migration) — only the runtime map lacked it.

Changes:

- Add `asksage: "asksageApiUrl"` to the `baseUrlMap` in `resolveBaseUrl()`. The existing `normalizeSdkBaseUrl()` behavior applies as with other providers (trims; a host-only custom URL inherits the default's `/server` path).
- `AskSageProvider.tsx`: write the URL through the SDK provider-config store (`useProviderConfig("asksage").write({ baseUrl })`, mirroring `AnthropicProvider.tsx`) so providers.json stays in sync for CLI/desktop hosts. The store mirrors `baseUrl` back to the legacy `asksageApiUrl` state key before providers.json validation runs, so legacy readers — including the component's `/get-models` fetch keyed on `apiConfiguration.asksageApiUrl` — keep working, even for partially-typed URLs that fail the store's URL validation (write errors are caught like in `AnthropicProvider`).

### Test Procedure

- New unit tests in `cline-session-factory.test.ts`: AskSage base URL resolves from the legacy `asksageApiUrl` state field; falls back to the providers.json `baseUrl` when legacy state has none; `normalizeSdkBaseUrl("asksage", ...)` inherits the default `/server` path for host-only URLs and preserves explicit paths.
- `bun run test:unit` in `apps/vscode`: 70 files, 1029 tests, all pass.
- `bun run test` in `apps/vscode/webview-ui`: 50 files, 397 tests, all pass.
- `bunx tsc -p tsconfig.app.json --noEmit` (webview) and `bun run check-types` (extension host): clean.
- Biome on changed files: clean.
- Manual verification in an Extension Development Host: selected AskSage as the provider and entered `https://asksage.internal.example/server` in the "AskSage API URL" field. Confirmed the value landed in both stores — `~/.cline/data/settings/providers.json` now contains `"provider": "asksage", "baseUrl": "https://asksage.internal.example/server"` and the legacy `globalState.json` contains `asksageApiUrl = "https://asksage.internal.example/server"` — so the runtime `resolveBaseUrl()` map and the providers.json fallback both see the custom URL.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

![Cline settings showing the AskSage provider configured with the custom API URL](https://cursor.com/artifacts/c/art-a27d9862-f117-4794-83f9-331c45b10ed1)

### Additional Notes

User impact: AskSage users' custom API URL (e.g. self-hosted or gov-cloud deployments) was shown in the UI but never used for requests in the new SDK-based extension.