### PR TITLE
fix(cli): restore the formatDisplayUserInput import in root.tsx

### DIFF
--- a/apps/cli/src/tui/root.tsx
+++ b/apps/cli/src/tui/root.tsx
@@ -1,4 +1,5 @@
 import { getCurrentContextSize, summarizeUsageFromMessages } from "@cline/core";
+import { formatDisplayUserInput } from "@cline/shared";
 import type { KeyEvent } from "@opentui/core";
 import { useRenderer, useTerminalDimensions } from "@opentui/react";
 import type { ChoiceContext } from "@opentui-ui/dialog";


### PR DESCRIPTION
apps/cli typecheck fails on main with `src/tui/root.tsx(367,29): error TS2304: Cannot find name 'formatDisplayUserInput'`, which fails the sdk-test Quality Checks job on every PR that touches `sdk/**` (e.g. [run 30721234318](https://github.com/cline/cline/actions/runs/30721234318)). #12831 removed the import while rewriting checkpoint restore; #12830 landed on top adding a usage that assumed the import was still there. Main's own sdk-test run stayed green because the workflow's path filter (`sdk/**`) skipped both commits.

This restores the one-line import.

## Test plan

```bash
bun run build:sdk
cd apps/cli && bunx tsc --noEmit   # fails on main, clean with this change
```