### PR TITLE
feat(llms): retry empty Ollama responses at the model boundary

### DIFF
--- a/sdk/packages/llms/src/providers/middleware/retry-empty-response.test.ts
+++ b/sdk/packages/llms/src/providers/middleware/retry-empty-response.test.ts
@@ -1,0 +1,153 @@
+import type {
+	LanguageModelV3StreamPart,
+	LanguageModelV3StreamResult,
+} from "@ai-sdk/provider";
+import { describe, expect, it, vi } from "vitest";
+import { createRetryEmptyResponseMiddleware } from "./retry-empty-response";
+
+function streamOf(
+	parts: LanguageModelV3StreamPart[],
+): LanguageModelV3StreamResult {
+	return {
+		stream: new ReadableStream<LanguageModelV3StreamPart>({
+			start(controller) {
+				for (const part of parts) {
+					controller.enqueue(part);
+				}
+				controller.close();
+			},
+		}),
+	} as LanguageModelV3StreamResult;
+}
+
+const usage = { inputTokens: 1, outputTokens: 1, totalTokens: 2 } as never;
+
+const streamStart: LanguageModelV3StreamPart = {
+	type: "stream-start",
+	warnings: [],
+};
+function finish(finishReason = "stop"): LanguageModelV3StreamPart {
+	return { type: "finish", finishReason, usage } as LanguageModelV3StreamPart;
+}
+const textParts: LanguageModelV3StreamPart[] = [
+	streamStart,
+	{ type: "text-start", id: "t" },
+	{ type: "text-delta", id: "t", delta: "hello" },
+	{ type: "text-end", id: "t" },
+	finish(),
+];
+const emptyParts: LanguageModelV3StreamPart[] = [streamStart, finish()];
+const toolCallParts: LanguageModelV3StreamPart[] = [
+	streamStart,
+	{
+		type: "tool-call",
+		toolCallId: "c1",
+		toolName: "read_file",
+		input: '{"path":"a.ts"}',
+	} as LanguageModelV3StreamPart,
+	finish("tool-calls"),
+];
+
+async function collect(
+	result: LanguageModelV3StreamResult,
+): Promise<LanguageModelV3StreamPart[]> {
+	const out: LanguageModelV3StreamPart[] = [];
+	const reader = result.stream.getReader();
+	while (true) {
+		const { done, value } = await reader.read();
+		if (done) break;
+		out.push(value);
+	}
+	return out;
+}
+
+function run(
+	doStream: () => Promise<LanguageModelV3StreamResult>,
+	options: Parameters<typeof createRetryEmptyResponseMiddleware>[0] = {},
+) {
+	const middleware = createRetryEmptyResponseMiddleware({
+		retryDelayMs: 0,
+		...options,
+	});
+	// biome-ignore lint/style/noNonNullAssertion: wrapStream is always defined here
+	return middleware.wrapStream!({
+		doStream,
+		doGenerate: vi.fn() as never,
+		params: {} as never,
+		model: { modelId: "llama3.2" } as never,
+	});
+}
+
+describe("createRetryEmptyResponseMiddleware", () => {
+	it("streams a non-empty response through without retrying", async () => {
+		const doStream = vi.fn(async () => streamOf(textParts));
+		const parts = await collect(await run(doStream));
+		expect(doStream).toHaveBeenCalledTimes(1);
+		expect(
+			parts.some((p) => p.type === "text-delta" && p.delta === "hello"),
+		).toBe(true);
+		expect(parts.filter((p) => p.type === "finish")).toHaveLength(1);
+	});
+
+	it("retries an empty response and forwards the successful attempt", async () => {
+		const doStream = vi
+			.fn()
+			.mockResolvedValueOnce(streamOf(emptyParts))
+			.mockResolvedValueOnce(streamOf(textParts));
+		const parts = await collect(await run(doStream));
+		expect(doStream).toHaveBeenCalledTimes(2);
+		// Exactly one stream-start survives across attempts.
+		expect(parts.filter((p) => p.type === "stream-start")).toHaveLength(1);
+		expect(
+			parts.some((p) => p.type === "text-delta" && p.delta === "hello"),
+		).toBe(true);
+		expect(parts.filter((p) => p.type === "finish")).toHaveLength(1);
+	});
+
+	it("does not retry a tool-call-only turn (it is not empty)", async () => {
+		const doStream = vi.fn(async () => streamOf(toolCallParts));
+		const parts = await collect(await run(doStream));
+		expect(doStream).toHaveBeenCalledTimes(1);
+		expect(parts.some((p) => p.type === "tool-call")).toBe(true);
+	});
+
+	it("gives up after maxAttempts and forwards the final empty finish", async () => {
+		const doStream = vi.fn(async () => streamOf(emptyParts));
+		const parts = await collect(await run(doStream, { maxAttempts: 3 }));
+		expect(doStream).toHaveBeenCalledTimes(3);
+		expect(parts.filter((p) => p.type === "finish")).toHaveLength(1);
+		expect(parts.some((p) => p.type === "text-delta")).toBe(false);
+	});
+
+	it("does not retry when the empty turn hit the token limit", async () => {
+		const doStream = vi.fn(async () =>
+			streamOf([streamStart, finish("length")]),
+		);
+		const parts = await collect(await run(doStream));
+		expect(doStream).toHaveBeenCalledTimes(1);
+		expect(parts.filter((p) => p.type === "finish")).toHaveLength(1);
+	});
+
+	it("does not retry when the turn surfaced an error", async () => {
+		const doStream = vi.fn(async () =>
+			streamOf([streamStart, { type: "error", error: "boom" }, finish()]),
+		);
+		const parts = await collect(await run(doStream));
+		expect(doStream).toHaveBeenCalledTimes(1);
+		expect(parts.some((p) => p.type === "error")).toBe(true);
+	});
+
+	it("logs a warning on each retry", async () => {
+		const log = vi.fn();
+		const doStream = vi
+			.fn()
+			.mockResolvedValueOnce(streamOf(emptyParts))
+			.mockResolvedValueOnce(streamOf(textParts));
+		await collect(await run(doStream, { logger: { log } }));
+		expect(log).toHaveBeenCalledTimes(1);
+		expect(log).toHaveBeenCalledWith(
+			expect.stringContaining("empty response"),
+			expect.objectContaining({ severity: "warn", attempt: 1 }),
+		);
+	});
+});

--- a/sdk/packages/llms/src/providers/middleware/retry-empty-response.ts
+++ b/sdk/packages/llms/src/providers/middleware/retry-empty-response.ts
@@ -1,0 +1,199 @@
+// LanguageModelV3 middleware that retries an Ollama stream when the model
+// returns an *empty* turn — no text, no reasoning, and no tool call.
+//
+// Background: local backends (Ollama especially) intermittently return a
+// response that finishes normally but carries no content at all. In Cline's
+// runtime an empty assistant turn is a hard failure ("Model returned empty
+// response"), so a single flaky generation kills the whole task. The
+// `ai-sdk-ollama` provider ships a "reliability" layer for this, but it lives
+// in `doGenerate` and *owns the tool loop* (it executes tools itself and
+// force-synthesizes a final text answer). That is fundamentally incompatible
+// with Cline, which streams via `doStream` and runs its own tool loop — a
+// tool-call-only turn is the correct, desired outcome here, not something to
+// "complete". So instead of adopting that layer, this middleware adds the one
+// piece that is safe for a streaming, self-looping host: retry only when a
+// turn produced genuinely nothing.
+//
+// Safety properties:
+//   * A tool-call-only turn counts as content, so it is never retried.
+//   * Non-empty turns stream through live, chunk by chunk, with zero added
+//     latency — the retry logic only ever engages after an empty turn ends,
+//     at which point nothing has been surfaced to the consumer yet, so
+//     swapping in a fresh attempt is seamless.
+//   * Turns that finish with an error or hit the token limit are passed
+//     through unchanged (retrying wouldn't help and could mask the cause).
+
+import type {
+	LanguageModelV3Middleware,
+	LanguageModelV3StreamPart,
+	LanguageModelV3StreamResult,
+} from "@ai-sdk/provider";
+
+/** Minimal logger surface (a subset of `BasicLogger`). */
+interface RetryLogger {
+	log?(message: string, meta?: Record<string, unknown>): void;
+}
+
+export interface RetryEmptyResponseOptions {
+	/** Total attempts including the first (so `3` means up to 2 retries). */
+	maxAttempts?: number;
+	/** Delay before each retry, in milliseconds. */
+	retryDelayMs?: number;
+	logger?: RetryLogger;
+}
+
+/** Default total attempts (first try + 2 retries). */
+export const DEFAULT_EMPTY_RESPONSE_MAX_ATTEMPTS = 3;
+/** Default delay before a retry. */
+export const DEFAULT_EMPTY_RESPONSE_RETRY_DELAY_MS = 250;
+
+/**
+ * Finish reasons that indicate a "normal" completion where an empty body is a
+ * transient provider glitch worth retrying. `error` (upstream failure),
+ * `length` (token limit — retrying re-hits it), and `content-filter` are left
+ * alone.
+ */
+const RETRYABLE_FINISH_REASONS = new Set(["stop", "other", "unknown"]);
+
+/**
+ * A stream part counts as real model output. Notably a `tool-call` (or its
+ * streaming `tool-input-*` parts) counts, so a tool-call-only turn — the
+ * normal shape when the model wants to act — is never treated as empty.
+ * Structural markers (`text-start`/`-end`, `stream-start`, `response-metadata`,
+ * `finish`, `raw`) do not count.
+ */
+function isContentPart(part: LanguageModelV3StreamPart): boolean {
+	switch (part.type) {
+		case "text-delta":
+		case "reasoning-delta":
+			return part.delta.length > 0;
+		case "tool-call":
+		case "tool-input-start":
+		case "tool-input-delta":
+		case "tool-input-end":
+		case "tool-result":
+		case "tool-approval-request":
+		case "file":
+		case "source":
+			return true;
+		default:
+			return false;
+	}
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Create a middleware that retries empty Ollama responses. Apply it as the
+ * outermost middleware (first in the `wrapLanguageModel` array) so each retry
+ * re-runs the full request.
+ */
+export function createRetryEmptyResponseMiddleware(
+	options: RetryEmptyResponseOptions = {},
+): LanguageModelV3Middleware {
+	const maxAttempts = Math.max(
+		1,
+		options.maxAttempts ?? DEFAULT_EMPTY_RESPONSE_MAX_ATTEMPTS,
+	);
+	const retryDelayMs = Math.max(
+		0,
+		options.retryDelayMs ?? DEFAULT_EMPTY_RESPONSE_RETRY_DELAY_MS,
+	);
+	const logger = options.logger;
+
+	return {
+		specificationVersion: "v3",
+		wrapStream: async ({ doStream, model }) => {
+			// Kick off the first attempt eagerly, matching normal doStream timing.
+			const firstResult = await doStream();
+
+			const stream = new ReadableStream<LanguageModelV3StreamPart>({
+				async start(controller) {
+					let result: LanguageModelV3StreamResult = firstResult;
+					let streamStartForwarded = false;
+
+					for (let attempt = 1; ; attempt++) {
+						const reader = result.stream.getReader();
+						let hadContent = false;
+						let sawError = false;
+						let pendingFinish: Extract<
+							LanguageModelV3StreamPart,
+							{ type: "finish" }
+						> | null = null;
+
+						try {
+							while (true) {
+								const { done, value } = await reader.read();
+								if (done) {
+									break;
+								}
+								if (value.type === "stream-start") {
+									// Forward warnings exactly once across all attempts.
+									if (!streamStartForwarded) {
+										controller.enqueue(value);
+										streamStartForwarded = true;
+									}
+									continue;
+								}
+								if (value.type === "finish") {
+									pendingFinish = value;
+									continue;
+								}
+								if (value.type === "error") {
+									sawError = true;
+								} else if (isContentPart(value)) {
+									hadContent = true;
+								}
+								controller.enqueue(value);
+							}
+						} catch (error) {
+							controller.error(error);
+							return;
+						} finally {
+							reader.releaseLock();
+						}
+
+						const finishReason = String(
+							pendingFinish?.finishReason ?? "unknown",
+						);
+						const canRetry =
+							!hadContent &&
+							!sawError &&
+							attempt < maxAttempts &&
+							RETRYABLE_FINISH_REASONS.has(finishReason);
+
+						if (!canRetry) {
+							if (pendingFinish) {
+								controller.enqueue(pendingFinish);
+							}
+							controller.close();
+							return;
+						}
+
+						logger?.log?.("Ollama returned an empty response; retrying", {
+							severity: "warn",
+							modelId: model.modelId,
+							attempt,
+							maxAttempts,
+							finishReason,
+						});
+
+						if (retryDelayMs > 0) {
+							await sleep(retryDelayMs);
+						}
+						try {
+							result = await doStream();
+						} catch (error) {
+							controller.error(error);
+							return;
+						}
+					}
+				},
+			});
+
+			return { ...firstResult, stream };
+		},
+	};
+}

--- a/sdk/packages/llms/src/providers/vendors/ollama.ts
+++ b/sdk/packages/llms/src/providers/vendors/ollama.ts
@@ -18,6 +18,7 @@ import { wrapLanguageModel } from "ai";
 import { createOllama } from "ai-sdk-ollama";
 import { OLLAMA_DEFAULT_CONTEXT_WINDOW } from "../builtins";
 import { ensureFetch, resolveApiKey } from "../http";
+import { createRetryEmptyResponseMiddleware } from "../middleware/retry-empty-response";
 import { splitToolImagesMiddleware } from "../middleware/split-tool-images";
 import type { ProviderFactoryResult } from "./types";
 
@@ -135,16 +136,21 @@ export async function createOllamaProviderModule(
 		),
 	});
 	const numCtx = readOllamaNumCtx(context);
+	// Retry empty responses (a common local-backend glitch that otherwise
+	// hard-fails the task). Outermost so each retry re-runs the whole request.
+	// `splitToolImagesMiddleware` is inner, for the same reason as the
+	// OpenAI-compatible vendor: the downstream converter stringifies
+	// multimodal tool-result content, losing image bytes.
+	const retryEmptyResponseMiddleware = createRetryEmptyResponseMiddleware({
+		logger: context.logger,
+	});
 	return {
-		// `splitToolImagesMiddleware` for the same reason as the
-		// OpenAI-compatible vendor: the downstream converter stringifies
-		// multimodal tool-result content, losing image bytes.
 		model: (modelId) =>
 			wrapLanguageModel({
 				model: provider(modelId, {
 					options: { num_ctx: numCtx },
 				}) as LanguageModelV3,
-				middleware: splitToolImagesMiddleware,
+				middleware: [retryEmptyResponseMiddleware, splitToolImagesMiddleware],
 			}),
 	};
 }


### PR DESCRIPTION
### Related Issue

**Issue:** N/A — internal SDK reliability work (local-model / Ollama robustness).

### Description

**What problem does this PR solve?**

Local backends — Ollama especially — intermittently return a turn that finishes normally but carries **no content at all**: no text, no reasoning, and no tool call. In the SDK runtime an empty assistant turn is a hard failure (`agent-runtime` throws `"Model returned empty response"`), so a single flaky generation kills the whole task. This is the exact "reliability" gap that motivated pointing at `ai-sdk-ollama`'s reliability features.

**Why not just enable `ai-sdk-ollama`'s reliability wrappers?**

We already use `ai-sdk-ollama` as the Ollama vendor, but its reliability layer is **not usable here**, and I confirmed this by reading the compiled provider:

- It lives in `doGenerate` (non-streaming). Our gateway streams via `doStream`, which has no reliability path at all — so setting `reliableToolCalling` would do nothing for us today.
- More importantly, that layer **owns the tool loop**: on a tool-call-only turn it executes the tools itself (`tool.execute`) and runs a `forceCompletion` follow-up to synthesize a final text answer. Cline runs its *own* tool loop and *wants* tool-call-only turns — routing through that layer would hijack tool calling and break the agent loop for Ollama.

**The approach.**

Instead of adopting an incompatible loop-owning layer, this PR adds the one piece that is safe for a streaming, self-looping host: a `LanguageModelV3` middleware that **retries the stream only when a turn produced genuinely nothing**, wired as the outermost middleware on the Ollama vendor (inner middleware `splitToolImagesMiddleware` is unchanged).

Safety properties:
- A **tool-call-only turn counts as content**, so it is never retried — the normal "model wants to act" shape is untouched.
- **Non-empty turns stream through live**, chunk by chunk, with zero added latency. The retry only ever engages *after* an empty turn ends, at which point nothing has been surfaced to the consumer yet, so swapping in a fresh attempt is seamless (`stream-start` warnings are forwarded exactly once).
- Turns that **error** or hit the **token limit** are passed through unchanged (retrying wouldn't help and could mask the cause).
- Bounded: default 3 total attempts (2 retries) with a small delay; each retry is logged via the provider `logger` for rollout visibility.

This is intentionally a small, low-risk change we can ship and gather user feedback on before doing more.

### Test Procedure

- **New unit tests** (`retry-empty-response.test.ts`, 7 cases): non-empty streams through without retry; an empty turn retries and forwards the successful attempt with exactly one `stream-start`; a tool-call-only turn is **not** retried; gives up after `maxAttempts` and forwards the final empty finish; no retry on token-limit or on a surfaced error; a warning is logged per retry.
- **Existing Ollama vendor tests** (`ollama.test.ts`) still pass with the middleware composed in.
- Full `@cline/llms` suite green (492 tests, 4 skipped), SDK-wide typecheck (`bun run types`) clean, and Biome clean on all touched files.
- What could break: only Ollama requests are affected, and only the empty-turn path changes behavior — normal streaming and tool-call turns take the identical path as before (verified by the "streams through without retry" and "tool-call-only" tests).

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

Backend-only change; no UI. This is separate from the XML tool-calling work — it hardens the *native* Ollama path so users who stay on native tool calling get fewer empty-response task failures.