### PR TITLE
fix(migration): fall back to the default Cline model for unknown legacy model ids

### DIFF
--- a/sdk/packages/core/src/services/storage/provider-settings-legacy-migration.test.ts
+++ b/sdk/packages/core/src/services/storage/provider-settings-legacy-migration.test.ts
@@ -611,16 +611,18 @@ describe("migrateLegacyProviderSettings", () => {
 		);
 	});
 
-	it("keeps a legacy Cline model id served by the OpenRouter-backed runtime catalog", () => {
-		// The runtime Cline catalog is OpenRouter-backed; some of its ids are
-		// not in the curated Cline collection. Those must survive migration.
-		const runtimeOnlyModelId = Object.keys(
-			LlmsModels.getGeneratedModelsForProvider("openrouter"),
-		).find(
-			(modelId) =>
-				!LlmsModels.getProviderCollectionSync("cline")?.models?.[modelId],
+	it("folds legacy alias Cline model ids onto their canonical catalog ids", () => {
+		// Legacy state stores OpenRouter spellings (e.g. `z-ai/...`) that the
+		// runtime catalog canonicalizes (to `zai/...`). Migration must keep the
+		// user's model under the canonical id instead of defaulting it away.
+		const catalogModels =
+			LlmsModels.getProviderCollectionSync("cline")?.models ?? {};
+		const canonicalModelId = Object.keys(catalogModels).find((modelId) =>
+			modelId.startsWith("zai/"),
 		);
-		expect(runtimeOnlyModelId).toBeTruthy();
+		expect(canonicalModelId).toBeTruthy();
+		const aliasModelId = `z-ai/${canonicalModelId?.slice("zai/".length)}`;
+		expect(catalogModels[aliasModelId]).toBeUndefined();
 
 		const tempDir = mkdtempSync(
 			path.join(os.tmpdir(), "core-legacy-provider-"),
@@ -635,7 +637,7 @@ describe("migrateLegacyProviderSettings", () => {
 				{
 					mode: "act",
 					actModeApiProvider: "cline",
-					actModeClineModelId: runtimeOnlyModelId,
+					actModeClineModelId: aliasModelId,
 				},
 				null,
 				2,
@@ -651,9 +653,7 @@ describe("migrateLegacyProviderSettings", () => {
 			dataDir: tempDir,
 		});
 
-		expect(manager.getProviderSettings("cline")?.model).toBe(
-			runtimeOnlyModelId,
-		);
+		expect(manager.getProviderSettings("cline")?.model).toBe(canonicalModelId);
 	});
 
 	it("migrates legacy OpenAI-compatible config into the openai-compatible provider", () => {

--- a/sdk/packages/core/src/services/storage/provider-settings-legacy-migration.test.ts
+++ b/sdk/packages/core/src/services/storage/provider-settings-legacy-migration.test.ts
@@ -576,6 +576,86 @@ describe("migrateLegacyProviderSettings", () => {
 		expect(manager.getProviderSettings("cline")?.model).toBe("openai/gpt-5.5");
 	});
 
+	it("falls back to the default Cline model for suffixed variant ids like :1m", () => {
+		const tempDir = mkdtempSync(
+			path.join(os.tmpdir(), "core-legacy-provider-"),
+		);
+		tempDirs.push(tempDir);
+		const providersPath = path.join(tempDir, "provider-settings.json");
+		const manager = new ProviderSettingsManager({ filePath: providersPath });
+
+		writeFileSync(
+			path.join(tempDir, "globalState.json"),
+			JSON.stringify(
+				{
+					mode: "act",
+					actModeApiProvider: "cline",
+					actModeClineModelId: "anthropic/claude-sonnet-4.5:1m",
+				},
+				null,
+				2,
+			),
+		);
+		writeFileSync(
+			path.join(tempDir, "secrets.json"),
+			JSON.stringify({ clineApiKey: "legacy-cline-key" }, null, 2),
+		);
+
+		migrateLegacyProviderSettings({
+			providerSettingsManager: manager,
+			dataDir: tempDir,
+		});
+
+		expect(manager.getProviderSettings("cline")?.model).toBe(
+			LlmsModels.getProviderCollectionSync("cline")?.provider.defaultModelId,
+		);
+	});
+
+	it("keeps a legacy Cline model id served by the OpenRouter-backed runtime catalog", () => {
+		// The runtime Cline catalog is OpenRouter-backed; some of its ids are
+		// not in the curated Cline collection. Those must survive migration.
+		const runtimeOnlyModelId = Object.keys(
+			LlmsModels.getGeneratedModelsForProvider("openrouter"),
+		).find(
+			(modelId) =>
+				!LlmsModels.getProviderCollectionSync("cline")?.models?.[modelId],
+		);
+		expect(runtimeOnlyModelId).toBeTruthy();
+
+		const tempDir = mkdtempSync(
+			path.join(os.tmpdir(), "core-legacy-provider-"),
+		);
+		tempDirs.push(tempDir);
+		const providersPath = path.join(tempDir, "provider-settings.json");
+		const manager = new ProviderSettingsManager({ filePath: providersPath });
+
+		writeFileSync(
+			path.join(tempDir, "globalState.json"),
+			JSON.stringify(
+				{
+					mode: "act",
+					actModeApiProvider: "cline",
+					actModeClineModelId: runtimeOnlyModelId,
+				},
+				null,
+				2,
+			),
+		);
+		writeFileSync(
+			path.join(tempDir, "secrets.json"),
+			JSON.stringify({ clineApiKey: "legacy-cline-key" }, null, 2),
+		);
+
+		migrateLegacyProviderSettings({
+			providerSettingsManager: manager,
+			dataDir: tempDir,
+		});
+
+		expect(manager.getProviderSettings("cline")?.model).toBe(
+			runtimeOnlyModelId,
+		);
+	});
+
 	it("migrates legacy OpenAI-compatible config into the openai-compatible provider", () => {
 		const tempDir = mkdtempSync(
 			path.join(os.tmpdir(), "core-legacy-provider-"),

--- a/sdk/packages/core/src/services/storage/provider-settings-legacy-migration.test.ts
+++ b/sdk/packages/core/src/services/storage/provider-settings-legacy-migration.test.ts
@@ -446,6 +446,11 @@ describe("migrateLegacyProviderSettings", () => {
 				refreshToken: "legacy-refresh",
 				accountId: "acct_123",
 			},
+			// No legacy model id: the migration lands on the declared catalog
+			// default so the entry never ships without a model.
+			model:
+				LlmsModels.getProviderCollectionSync("openai-codex")?.provider
+					.defaultModelId,
 		});
 		expect(manager.read().providers["openai-codex"]?.tokenSource).toBe(
 			"migration",
@@ -500,6 +505,75 @@ describe("migrateLegacyProviderSettings", () => {
 			accountId: "user-123",
 		});
 		expect(manager.read().providers.cline?.tokenSource).toBe("migration");
+	});
+
+	it("falls back to the default Cline model when the legacy model id is unknown", () => {
+		const tempDir = mkdtempSync(
+			path.join(os.tmpdir(), "core-legacy-provider-"),
+		);
+		tempDirs.push(tempDir);
+		const providersPath = path.join(tempDir, "provider-settings.json");
+		const manager = new ProviderSettingsManager({ filePath: providersPath });
+
+		writeFileSync(
+			path.join(tempDir, "globalState.json"),
+			JSON.stringify(
+				{
+					mode: "act",
+					actModeApiProvider: "cline",
+					actModeClineModelId: "some-model/that-no-longer-exists",
+				},
+				null,
+				2,
+			),
+		);
+		writeFileSync(
+			path.join(tempDir, "secrets.json"),
+			JSON.stringify({ clineApiKey: "legacy-cline-key" }, null, 2),
+		);
+
+		migrateLegacyProviderSettings({
+			providerSettingsManager: manager,
+			dataDir: tempDir,
+		});
+
+		const expectedDefault =
+			LlmsModels.getProviderCollectionSync("cline")?.provider.defaultModelId;
+		expect(expectedDefault).toBeTruthy();
+		expect(manager.getProviderSettings("cline")?.model).toBe(expectedDefault);
+	});
+
+	it("keeps a legacy Cline model id the catalog knows", () => {
+		const tempDir = mkdtempSync(
+			path.join(os.tmpdir(), "core-legacy-provider-"),
+		);
+		tempDirs.push(tempDir);
+		const providersPath = path.join(tempDir, "provider-settings.json");
+		const manager = new ProviderSettingsManager({ filePath: providersPath });
+
+		writeFileSync(
+			path.join(tempDir, "globalState.json"),
+			JSON.stringify(
+				{
+					mode: "act",
+					actModeApiProvider: "cline",
+					actModeClineModelId: "openai/gpt-5.5",
+				},
+				null,
+				2,
+			),
+		);
+		writeFileSync(
+			path.join(tempDir, "secrets.json"),
+			JSON.stringify({ clineApiKey: "legacy-cline-key" }, null, 2),
+		);
+
+		migrateLegacyProviderSettings({
+			providerSettingsManager: manager,
+			dataDir: tempDir,
+		});
+
+		expect(manager.getProviderSettings("cline")?.model).toBe("openai/gpt-5.5");
 	});
 
 	it("migrates legacy OpenAI-compatible config into the openai-compatible provider", () => {

--- a/sdk/packages/core/src/services/storage/provider-settings-legacy-migration.ts
+++ b/sdk/packages/core/src/services/storage/provider-settings-legacy-migration.ts
@@ -460,8 +460,11 @@ function getDefaultModelForProvider(providerId: string): string | undefined {
 
 /**
  * Cline is a fixed-catalog provider: an unknown legacy model id (retired
- * model, corrupted state) would otherwise be carried into inference requests
- * as-is. Drop it so the caller falls back to the catalog default.
+ * model, a suffixed variant like `...:1m`, corrupted state) would otherwise
+ * be carried into inference requests as-is. Drop it so the caller falls back
+ * to the catalog default. The known set mirrors the runtime catalog
+ * (`buildClineModels` in @cline/llms): the Cline collection plus the
+ * OpenRouter-backed generated models and their Vercel AI Gateway alias ids.
  */
 function dropUnknownClineModel(
 	providerId: string,
@@ -472,7 +475,9 @@ function dropUnknownClineModel(
 	}
 	const isKnown =
 		LlmsModels.getGeneratedModelsForProvider(providerId)[modelId] ||
-		LlmsModels.getProviderCollectionSync(providerId)?.models?.[modelId];
+		LlmsModels.getProviderCollectionSync(providerId)?.models?.[modelId] ||
+		LlmsModels.getGeneratedModelsForProvider("openrouter")[modelId] ||
+		LlmsModels.getGeneratedModelsForProvider("vercel-ai-gateway")[modelId];
 	return isKnown ? modelId : undefined;
 }
 

--- a/sdk/packages/core/src/services/storage/provider-settings-legacy-migration.ts
+++ b/sdk/packages/core/src/services/storage/provider-settings-legacy-migration.ts
@@ -443,12 +443,37 @@ function getDefaultModelForProvider(providerId: string): string | undefined {
 	const builtInModels = LlmsModels.getGeneratedModelsForProvider(providerId);
 	const providerCollection = LlmsModels.getProviderCollectionSync(providerId);
 	const defaultModelId = providerCollection?.provider.defaultModelId;
-	if (defaultModelId && builtInModels[defaultModelId]) {
+	// The declared default may live only in the collection's model list (e.g.
+	// Cline's generated block holds a few free models while its default,
+	// anthropic/claude-sonnet-5, comes from the collection catalog).
+	if (
+		defaultModelId &&
+		(builtInModels[defaultModelId] ||
+			providerCollection?.models?.[defaultModelId])
+	) {
 		return defaultModelId;
 	}
 
 	const firstModelId = Object.keys(builtInModels)[0];
 	return firstModelId ?? undefined;
+}
+
+/**
+ * Cline is a fixed-catalog provider: an unknown legacy model id (retired
+ * model, corrupted state) would otherwise be carried into inference requests
+ * as-is. Drop it so the caller falls back to the catalog default.
+ */
+function dropUnknownClineModel(
+	providerId: string,
+	modelId: string | undefined,
+): string | undefined {
+	if (!modelId || providerId !== "cline") {
+		return modelId;
+	}
+	const isKnown =
+		LlmsModels.getGeneratedModelsForProvider(providerId)[modelId] ||
+		LlmsModels.getProviderCollectionSync(providerId)?.models?.[modelId];
+	return isKnown ? modelId : undefined;
 }
 
 function buildLegacyProviderSettings(
@@ -467,11 +492,14 @@ function buildLegacyProviderSettings(
 		? normalizeLegacyProviderId(rawActiveProviderForMode)
 		: undefined;
 	const model =
-		resolveModelForProvider(
-			legacyGlobalState,
-			providerId,
-			mode,
-			activeProviderForMode,
+		dropUnknownClineModel(
+			targetProviderId,
+			resolveModelForProvider(
+				legacyGlobalState,
+				providerId,
+				mode,
+				activeProviderForMode,
+			),
 		) ?? getDefaultModelForProvider(targetProviderId);
 	const reasoning = resolveReasoning(legacyGlobalState, targetProviderId, mode);
 	const timeout =

--- a/sdk/packages/core/src/services/storage/provider-settings-legacy-migration.ts
+++ b/sdk/packages/core/src/services/storage/provider-settings-legacy-migration.ts
@@ -461,24 +461,37 @@ function getDefaultModelForProvider(providerId: string): string | undefined {
 /**
  * Cline is a fixed-catalog provider: an unknown legacy model id (retired
  * model, a suffixed variant like `...:1m`, corrupted state) would otherwise
- * be carried into inference requests as-is. Drop it so the caller falls back
- * to the catalog default. The known set mirrors the runtime catalog
- * (`buildClineModels` in @cline/llms): the Cline collection plus the
- * OpenRouter-backed generated models and their Vercel AI Gateway alias ids.
+ * be carried into inference requests as-is. Resolve the legacy id against the
+ * runtime catalog (the collection model list, which `buildClineModels` in
+ * @cline/llms mirrors), folding alias spellings onto their canonical ids
+ * (e.g. OpenRouter's `z-ai/...` -> `zai/...`) so those users keep their
+ * model. Returns undefined for unavailable models so the caller falls back
+ * to the catalog default.
  */
-function dropUnknownClineModel(
+function resolveKnownClineModel(
 	providerId: string,
 	modelId: string | undefined,
 ): string | undefined {
 	if (!modelId || providerId !== "cline") {
 		return modelId;
 	}
-	const isKnown =
-		LlmsModels.getGeneratedModelsForProvider(providerId)[modelId] ||
-		LlmsModels.getProviderCollectionSync(providerId)?.models?.[modelId] ||
-		LlmsModels.getGeneratedModelsForProvider("openrouter")[modelId] ||
-		LlmsModels.getGeneratedModelsForProvider("vercel-ai-gateway")[modelId];
-	return isKnown ? modelId : undefined;
+	const catalogModels = LlmsModels.getProviderCollectionSync(providerId)?.models;
+	if (!catalogModels) {
+		return modelId;
+	}
+	if (catalogModels[modelId]) {
+		return modelId;
+	}
+	for (const rule of LlmsModels.VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES) {
+		if (!modelId.startsWith(rule.aliasPrefix)) {
+			continue;
+		}
+		const canonicalModelId = `${rule.canonicalPrefix}${modelId.slice(rule.aliasPrefix.length)}`;
+		if (catalogModels[canonicalModelId]) {
+			return canonicalModelId;
+		}
+	}
+	return undefined;
 }
 
 function buildLegacyProviderSettings(
@@ -497,7 +510,7 @@ function buildLegacyProviderSettings(
 		? normalizeLegacyProviderId(rawActiveProviderForMode)
 		: undefined;
 	const model =
-		dropUnknownClineModel(
+		resolveKnownClineModel(
 			targetProviderId,
 			resolveModelForProvider(
 				legacyGlobalState,


### PR DESCRIPTION
## Context

During the 1% rollout of the new extension, error telemetry showed a few users making Cline provider inference requests with a model id the new extension doesn't have (e.g. suffixed variants like `...:1m`). The legacy migration carried the stored model id over verbatim and never applied a default.

## Changes

One file, small fixes in the provider settings migration (`provider-settings-legacy-migration.ts`):

- **Drop unknown legacy Cline model ids.** If the migrated model id isn't one the new extension can serve, the entry falls back to the default Cline model (`anthropic/claude-sonnet-5`) instead of carrying the unknown id into inference requests. The known set mirrors the runtime catalog (`buildClineModels` in `@cline/llms`): the Cline collection plus the OpenRouter-backed generated models and their Vercel AI Gateway alias ids — so runtime-served ids outside the curated collection (e.g. the `z-ai/glm-5` family) survive migration, while retired/suffixed ids like `anthropic/claude-sonnet-4.5:1m` default.
- **Make the default actually resolve.** `getDefaultModelForProvider` only accepted a default present in the generated model block. Cline's generated block holds a few free models while its declared default (`anthropic/claude-sonnet-5`) lives in the collection catalog — so the fallback previously landed on an arbitrary free model (`poolside/laguna-s-2.1:free`) instead of Sonnet 5. It now also checks the collection catalog. (Side effect: migrated OpenAI Codex entries now carry their declared default, `gpt-5.4`, instead of no model.)

## Blast radius

- Only the `cline` provider entry is validated; all other providers migrate verbatim.
- Migration is one-time (sentinel-gated) and only writes `providers.json` (the committed selection used by the CLI/hub and by the extension's fallback/display paths). The VS Code globalState mode slots are not rewritten.

## Testing

- New tests: unknown legacy Cline model → default; `...:1m` variant → default; curated-collection model preserved; runtime-catalog-only (OpenRouter-backed) model preserved.
- `bun -F @cline/core test:unit`: migration file 31/31 pass; full suite passes with only the documented cloud-VM git `insteadOf` environment artifact (`workspace-manifest.test.ts`) and one load-flaky checkpoint test that passes in isolation.