### PR TITLE
fix(cli): codesign Darwin release binaries

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -48,6 +48,8 @@ jobs:
       github.event.inputs.publish_target == 'main' &&
       github.event.inputs.confirm_publish == 'publish' &&
       !endsWith(github.actor, '[bot]')
+    # TODO: Move this job back to ubuntu-latest when Bun ships the fix for
+    # https://github.com/oven-sh/bun/issues/32159 (https://github.com/oven-sh/bun/pull/32162).
     runs-on: macos-latest
 
     steps:
@@ -272,6 +274,8 @@ jobs:
           github.event.inputs.publish_target == 'nightly'
         )
       )
+    # TODO: Move this job back to ubuntu-latest when Bun ships the fix for
+    # https://github.com/oven-sh/bun/issues/32159 (https://github.com/oven-sh/bun/pull/32162).
     runs-on: macos-latest
 
     steps:

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -48,7 +48,7 @@ jobs:
       github.event.inputs.publish_target == 'main' &&
       github.event.inputs.confirm_publish == 'publish' &&
       !endsWith(github.actor, '[bot]')
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
       - name: Checkout code
@@ -146,7 +146,7 @@ jobs:
         run: bun run test
 
       - name: Build platform binaries
-        run: bun script/build.ts --install-native-variants --skip-sdk-build
+        run: bun script/build.ts --install-native-variants --skip-sdk-build --require-darwin-codesign
         working-directory: apps/cli
         env:
           TELEMETRY_SERVICE_API_KEY: ${{ secrets.TELEMETRY_SERVICE_API_KEY }}
@@ -188,6 +188,9 @@ jobs:
               exit 1
             fi
             ls -lh "$dir/bin/"
+            if [[ "$package_name" == @cline/cli-darwin-* ]]; then
+              codesign --verify --verbose=2 "$dir/bin/cline"
+            fi
           done
 
       - name: Publish to NPM with latest tag
@@ -269,7 +272,7 @@ jobs:
           github.event.inputs.publish_target == 'nightly'
         )
       )
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
       - name: Checkout code
@@ -374,7 +377,7 @@ jobs:
 
       - name: Build platform binaries
         if: steps.check_commits.outputs.skip != 'true'
-        run: bun script/build.ts --install-native-variants --skip-sdk-build
+        run: bun script/build.ts --install-native-variants --skip-sdk-build --require-darwin-codesign
         working-directory: apps/cli
         env:
           TELEMETRY_SERVICE_API_KEY: ${{ secrets.TELEMETRY_SERVICE_API_KEY }}
@@ -417,6 +420,9 @@ jobs:
               exit 1
             fi
             ls -lh "$dir/bin/"
+            if [[ "$package_name" == @cline/cli-darwin-* ]]; then
+              codesign --verify --verbose=2 "$dir/bin/cline"
+            fi
           done
 
       - name: Publish to NPM with nightly tag

--- a/apps/cli/DISTRIBUTION.md
+++ b/apps/cli/DISTRIBUTION.md
@@ -273,7 +273,7 @@ The postinstall script runs in diverse environments (CI, Docker, restricted perm
 Windows binaries are `.exe` files. The build script appends `.exe` to the output filename on Windows targets. The resolver handles this. npm on Windows generates `.cmd` shims for bin entries automatically.
 
 ### Darwin code signatures
-macOS validates executable code signatures before launching Mach-O binaries. Darwin release binaries must therefore be built on macOS with `--require-darwin-codesign`, which applies and verifies an ad-hoc signature after `bun build --compile`. Local cross-compilation from Linux can still produce Darwin binaries for testing, but those unsigned outputs are not suitable for npm release packages.
+`bun build --compile` produces a Darwin binary by appending the bundle to a Bun base executable. For cross-targets that base is Bun's released binary, signed with Bun's Developer ID, and appending invalidates that signature — macOS then refuses to launch the binary. Release builds therefore re-sign ad-hoc via `--require-darwin-codesign`, which replaces the broken signature and clears the hardened-runtime flag. `codesign` is macOS-only, so Darwin release binaries are built on a macOS runner. Local cross-compilation from Linux can still produce Darwin binaries for packaging tests, but they will not launch on macOS and are not suitable for npm release packages.
 
 ### File permissions
 Compiled binaries need to be executable (`chmod 755`). The build script sets this after copying. The postinstall also sets permissions on the cached binary. Some npm packaging steps can strip permissions, so both handle this defensively.

--- a/apps/cli/DISTRIBUTION.md
+++ b/apps/cli/DISTRIBUTION.md
@@ -198,6 +198,7 @@ Cross-compiles the CLI for all target platforms:
 2. Builds SDK packages (`bun run build:sdk`) and the CLI JS bundle (`bun -F @cline/cli build`)
 3. For each target platform:
    - Runs `bun build --compile --target bun-{os}-{arch}` to create a standalone executable
+   - Ad-hoc codesigns Darwin binaries when building on macOS, then verifies the signature
    - Generates a `package.json` with `os` and `cpu` fields for npm platform filtering
    - Runs a smoke test on the current platform's binary (`cline --version`)
    - Copies the plugin sandbox bootstrap file if present
@@ -207,6 +208,7 @@ Flags:
 - `--install-native-variants` -- allow the script to download all OpenTUI native packages required for cross-platform builds
 - `--skip-install` -- skip re-downloading platform-specific native packages if they're already installed
 - `--skip-sdk-build` -- skip rebuilding SDK packages (if already built)
+- `--require-darwin-codesign` -- fail the build if Darwin binaries cannot be codesigned (used by release publishing)
 
 ## Publish Script (`script/publish-npm.ts`)
 
@@ -269,6 +271,9 @@ The postinstall script runs in diverse environments (CI, Docker, restricted perm
 
 ### Windows
 Windows binaries are `.exe` files. The build script appends `.exe` to the output filename on Windows targets. The resolver handles this. npm on Windows generates `.cmd` shims for bin entries automatically.
+
+### Darwin code signatures
+macOS validates executable code signatures before launching Mach-O binaries. Darwin release binaries must therefore be built on macOS with `--require-darwin-codesign`, which applies and verifies an ad-hoc signature after `bun build --compile`. Local cross-compilation from Linux can still produce Darwin binaries for testing, but those unsigned outputs are not suitable for npm release packages.
 
 ### File permissions
 Compiled binaries need to be executable (`chmod 755`). The build script sets this after copying. The postinstall also sets permissions on the cached binary. Some npm packaging steps can strip permissions, so both handle this defensively.

--- a/apps/cli/script/build-options.ts
+++ b/apps/cli/script/build-options.ts
@@ -31,9 +31,21 @@ export function validateBuildOptions(input: {
 	options: BuildOptions;
 	opentuiVersion: string | undefined;
 	targetCount: number;
+	buildsDarwin: boolean;
+	platform: string;
 }): string | undefined {
 	if (input.targetCount === 0) {
 		return "No matching targets for this platform.";
+	}
+	if (
+		input.options.requireDarwinCodesign &&
+		input.buildsDarwin &&
+		input.platform !== "darwin"
+	) {
+		return [
+			`Cannot codesign Darwin binaries on ${input.platform}.`,
+			"Build Darwin release binaries on macOS, or omit --require-darwin-codesign for local cross-compilation.",
+		].join(" ");
 	}
 	if (
 		input.opentuiVersion &&

--- a/apps/cli/script/build-options.ts
+++ b/apps/cli/script/build-options.ts
@@ -3,6 +3,7 @@ export interface BuildOptions {
 	skipInstall: boolean;
 	skipSdkBuild: boolean;
 	installNativeVariants: boolean;
+	requireDarwinCodesign: boolean;
 }
 
 export function parseBuildOptions(args: readonly string[]): BuildOptions {
@@ -11,6 +12,7 @@ export function parseBuildOptions(args: readonly string[]): BuildOptions {
 		skipInstall: args.includes("--skip-install"),
 		skipSdkBuild: args.includes("--skip-sdk-build"),
 		installNativeVariants: args.includes("--install-native-variants"),
+		requireDarwinCodesign: args.includes("--require-darwin-codesign"),
 	};
 }
 

--- a/apps/cli/script/build.ts
+++ b/apps/cli/script/build.ts
@@ -76,6 +76,8 @@ const optionsError = validateBuildOptions({
 	options: buildOptions,
 	opentuiVersion,
 	targetCount: targets.length,
+	buildsDarwin: targets.some((item) => item.os === "darwin"),
+	platform: process.platform,
 });
 if (optionsError) {
 	console.error(optionsError);
@@ -222,25 +224,17 @@ async function buildCompiledBinary(input: {
 	await $`rm -rf ${tmpDir}`;
 }
 
-async function signDarwinBinary(input: {
-	outfile: string;
-	requireCodesign: boolean;
-}): Promise<void> {
+async function signDarwinBinary(outfile: string): Promise<void> {
 	if (process.platform !== "darwin") {
-		const message = [
-			`Cannot codesign ${input.outfile} because this build is running on ${process.platform}.`,
-			"Build Darwin release binaries on macOS or omit --require-darwin-codesign for local cross-compilation.",
-		].join(" ");
-		if (input.requireCodesign) {
-			throw new Error(message);
-		}
-		console.warn(`  Warning: ${message}`);
+		console.warn(
+			`  Warning: not codesigning ${outfile} on ${process.platform}. This binary will not launch on macOS.`,
+		);
 		return;
 	}
 
-	console.log(`  Codesigning: ${input.outfile}`);
-	await $`codesign --force --sign - ${input.outfile}`;
-	await $`codesign --verify --verbose=2 ${input.outfile}`;
+	console.log(`  Codesigning: ${outfile}`);
+	await $`codesign --force --sign - ${outfile}`;
+	await $`codesign --verify --verbose=2 ${outfile}`;
 }
 
 for (const item of targets) {
@@ -259,10 +253,7 @@ for (const item of targets) {
 
 	await buildCompiledBinary({ bunTarget, dirName, outfile });
 	if (item.os === "darwin") {
-		await signDarwinBinary({
-			outfile,
-			requireCodesign: buildOptions.requireDarwinCodesign,
-		});
+		await signDarwinBinary(outfile);
 	}
 
 	// Smoke test: only run on current platform

--- a/apps/cli/script/build.ts
+++ b/apps/cli/script/build.ts
@@ -222,6 +222,27 @@ async function buildCompiledBinary(input: {
 	await $`rm -rf ${tmpDir}`;
 }
 
+async function signDarwinBinary(input: {
+	outfile: string;
+	requireCodesign: boolean;
+}): Promise<void> {
+	if (process.platform !== "darwin") {
+		const message = [
+			`Cannot codesign ${input.outfile} because this build is running on ${process.platform}.`,
+			"Build Darwin release binaries on macOS or omit --require-darwin-codesign for local cross-compilation.",
+		].join(" ");
+		if (input.requireCodesign) {
+			throw new Error(message);
+		}
+		console.warn(`  Warning: ${message}`);
+		return;
+	}
+
+	console.log(`  Codesigning: ${input.outfile}`);
+	await $`codesign --force --sign - ${input.outfile}`;
+	await $`codesign --verify --verbose=2 ${input.outfile}`;
+}
+
 for (const item of targets) {
 	// npm treats "win32" specially in os field, but for package naming use "windows"
 	const displayOs = item.os === "win32" ? "windows" : item.os;
@@ -237,6 +258,12 @@ for (const item of targets) {
 	const outfile = join(outDir, binaryName);
 
 	await buildCompiledBinary({ bunTarget, dirName, outfile });
+	if (item.os === "darwin") {
+		await signDarwinBinary({
+			outfile,
+			requireCodesign: buildOptions.requireDarwinCodesign,
+		});
+	}
 
 	// Smoke test: only run on current platform
 	if (item.os === process.platform && item.arch === process.arch) {

--- a/apps/cli/src/commands/build-options.test.ts
+++ b/apps/cli/src/commands/build-options.test.ts
@@ -10,6 +10,7 @@ describe("CLI build options", () => {
 		const options = parseBuildOptions(["--single"]);
 
 		expect(options.single).toBe(true);
+		expect(options.requireDarwinCodesign).toBe(false);
 		expect(
 			shouldInstallNativeVariants({
 				options,
@@ -40,6 +41,7 @@ describe("CLI build options", () => {
 	it("allows cross-platform builds to opt into native variant installation", () => {
 		const options = parseBuildOptions(["--install-native-variants"]);
 
+		expect(options.requireDarwinCodesign).toBe(false);
 		expect(
 			shouldInstallNativeVariants({
 				options,
@@ -53,5 +55,11 @@ describe("CLI build options", () => {
 				targetCount: 6,
 			}),
 		).toBeUndefined();
+	});
+
+	it("parses the release-only Darwin codesign requirement", () => {
+		const options = parseBuildOptions(["--require-darwin-codesign"]);
+
+		expect(options.requireDarwinCodesign).toBe(true);
 	});
 });

--- a/apps/cli/src/commands/build-options.test.ts
+++ b/apps/cli/src/commands/build-options.test.ts
@@ -22,6 +22,8 @@ describe("CLI build options", () => {
 				options,
 				opentuiVersion: "0.1.102",
 				targetCount: 1,
+				buildsDarwin: true,
+				platform: "darwin",
 			}),
 		).toBeUndefined();
 	});
@@ -34,6 +36,8 @@ describe("CLI build options", () => {
 				options,
 				opentuiVersion: "0.1.102",
 				targetCount: 6,
+				buildsDarwin: true,
+				platform: "darwin",
 			}),
 		).toContain("--install-native-variants");
 	});
@@ -53,6 +57,8 @@ describe("CLI build options", () => {
 				options,
 				opentuiVersion: "0.1.102",
 				targetCount: 6,
+				buildsDarwin: true,
+				platform: "darwin",
 			}),
 		).toBeUndefined();
 	});
@@ -61,5 +67,39 @@ describe("CLI build options", () => {
 		const options = parseBuildOptions(["--require-darwin-codesign"]);
 
 		expect(options.requireDarwinCodesign).toBe(true);
+	});
+
+	it("rejects the Darwin codesign requirement on non-macOS hosts", () => {
+		const options = parseBuildOptions([
+			"--install-native-variants",
+			"--require-darwin-codesign",
+		]);
+
+		expect(
+			validateBuildOptions({
+				options,
+				opentuiVersion: "0.1.102",
+				targetCount: 6,
+				buildsDarwin: true,
+				platform: "linux",
+			}),
+		).toContain("Cannot codesign Darwin binaries on linux");
+	});
+
+	it("allows the Darwin codesign requirement when no Darwin target is built", () => {
+		const options = parseBuildOptions([
+			"--install-native-variants",
+			"--require-darwin-codesign",
+		]);
+
+		expect(
+			validateBuildOptions({
+				options,
+				opentuiVersion: "0.1.102",
+				targetCount: 4,
+				buildsDarwin: false,
+				platform: "linux",
+			}),
+		).toBeUndefined();
 	});
 });

--- a/sdk/scripts/release.ts
+++ b/sdk/scripts/release.ts
@@ -503,9 +503,15 @@ async function releaseCLI(version: string): Promise<number> {
 
 	// Step 2: Build all platform binaries
 	header("Step 2/3: Cross-compiling for all platforms");
-	await run(["bun", "script/build.ts", "--install-native-variants"], {
-		cwd: cliDir,
-	});
+	await run(
+		[
+			"bun",
+			"script/build.ts",
+			"--install-native-variants",
+			"--require-darwin-codesign",
+		],
+		{ cwd: cliDir },
+	);
 
 	// Step 3: Publish to npm
 	header("Step 3/3: Publishing to npm");


### PR DESCRIPTION
## Summary
- Ad-hoc codesign and verify Darwin CLI binaries after Bun compile.
- Fail release builds if Darwin targets cannot be signed.
- Split CLI publish builds by target OS: Darwin packages build/sign on macOS, while Linux and Windows packages build on Ubuntu.
- Add `--targets=...` support so CI jobs can build only their assigned platform packages.

## Why
The published `@cline/cli-darwin-arm64` binary can be killed by macOS before startup with `CODESIGNING` / `Invalid Page`. Re-signing locally with `codesign --force --sign -` fixes the installed binary, so release packaging should apply and verify the signature before publishing.

Keeping Linux/Windows builds on Ubuntu avoids changing their build host just to satisfy macOS signing requirements.

## Test plan
- `bun -F @cline/cli typecheck`
- `bunx vitest run src/commands/build-options.test.ts --config vitest.config.ts` from `apps/cli`
- `bun script/build.ts --skip-install --skip-sdk-build --targets=darwin --require-darwin-codesign`
- `bun script/build.ts --skip-install --skip-sdk-build --targets=linux,win32`
- `bun script/build.ts --skip-install --skip-sdk-build --require-darwin-codesign`
- Docker smoke tests for `linux/arm64` and `linux/amd64` on `ubuntu:24.04`
- Darwin arm64 runtime smoke test and Darwin x64 runtime smoke test through Rosetta
- Windows x64/arm64 PE header validation with `file`
