### PR TITLE
fix(spawn): npm resolver + typecheck fix for dpc/shell-free-npx-spawn

### DIFF
--- a/apps/cli/src/commands/plugin.test.ts
+++ b/apps/cli/src/commands/plugin.test.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from "node:child_process";
 import {
 	existsSync,
+	mkdirSync,
 	mkdtempSync,
 	readFileSync,
 	rmSync,
@@ -8,7 +9,7 @@ import {
 } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, sep } from "node:path";
 import {
 	discoverPluginModulePaths,
 	resolvePluginConfigSearchPaths,
@@ -29,6 +30,83 @@ type FetchCall = (
 	...args: Parameters<typeof fetch>
 ) => ReturnType<typeof fetch>;
 
+const IS_WINDOWS = process.platform === "win32";
+
+interface FakeNpmBehavior {
+	logTo?: string;
+	stderr?: string;
+	exitCode?: number;
+	/** Relative-to-`--prefix` path -> file content, written before exit. */
+	writeUnderPrefix?: Record<string, string>;
+}
+
+function buildFakeNpmScript(behavior: FakeNpmBehavior): string {
+	const { logTo, stderr, exitCode = 0, writeUnderPrefix } = behavior;
+	const lines = [
+		'const fs = require("node:fs");',
+		'const path = require("node:path");',
+		"const args = process.argv.slice(2);",
+	];
+	if (logTo) {
+		lines.push(
+			`fs.appendFileSync(${JSON.stringify(logTo)}, \`\${process.cwd()} \${args.join(" ")}\\n\`);`,
+		);
+	}
+	if (writeUnderPrefix) {
+		lines.push(
+			'const prefixIndex = args.indexOf("--prefix");',
+			"const prefix = prefixIndex === -1 ? process.cwd() : args[prefixIndex + 1];",
+			`const files = ${JSON.stringify(writeUnderPrefix)};`,
+			"for (const [rel, content] of Object.entries(files)) {",
+			"  const dest = path.join(prefix, rel);",
+			"  fs.mkdirSync(path.dirname(dest), { recursive: true });",
+			"  fs.writeFileSync(dest, content);",
+			"}",
+		);
+	}
+	if (stderr) {
+		lines.push(`process.stderr.write(${JSON.stringify(stderr)});`);
+	}
+	lines.push(`process.exit(${exitCode});`);
+	return lines.join("\n");
+}
+
+/**
+ * Write an executable fake `npm` for use as `installPlugin({ npmCommand })`.
+ *
+ * On POSIX this is a real Node script run directly via a `#!/usr/bin/env node`
+ * shebang. On Windows, `spawn()` can only run `.exe`/`.com` directly, and
+ * `plugin-install.ts` resolves `npm` the same shell-free way production does
+ * — via `resolveShellFreeInvocation`, which pairs an `npm-cli.js` with the
+ * node.exe of its install. So this builds that same
+ * `node_modules/npm/bin/npm-cli.js` layout and points `npm_execpath` (the env
+ * var the resolver reads) at it, crossing the same resolution boundary a real
+ * Windows npm install would, rather than an arbitrary stub the resolver would
+ * never recognize.
+ *
+ * Returns the `npmCommand` value to pass to `installPlugin`.
+ */
+function writeFakeNpm(
+	basePath: string,
+	behavior: FakeNpmBehavior = {},
+): string {
+	const script = buildFakeNpmScript(behavior);
+	if (IS_WINDOWS) {
+		const cliDir = join(basePath, "node_modules", "npm", "bin");
+		mkdirSync(cliDir, { recursive: true });
+		const cliPath = join(cliDir, "npm-cli.js");
+		writeFileSync(cliPath, script, "utf8");
+		process.env.npm_execpath = cliPath;
+		return "npm";
+	}
+	const target = `${basePath}.js`;
+	writeFileSync(target, `#!/usr/bin/env node\n${script}\n`, {
+		encoding: "utf8",
+		mode: 0o755,
+	});
+	return target;
+}
+
 describe("plugin install command", () => {
 	let root = "";
 	let home = "";
@@ -37,6 +115,7 @@ describe("plugin install command", () => {
 	let originalClineDir: string | undefined;
 	let originalClineDataDir: string | undefined;
 	let originalMcpSettingsPath: string | undefined;
+	let originalNpmExecPath: string | undefined;
 
 	beforeEach(() => {
 		root = mkdtempSync(join(tmpdir(), "cli-plugin-install-"));
@@ -46,6 +125,7 @@ describe("plugin install command", () => {
 		originalClineDir = process.env.CLINE_DIR;
 		originalClineDataDir = process.env.CLINE_DATA_DIR;
 		originalMcpSettingsPath = process.env.CLINE_MCP_SETTINGS_PATH;
+		originalNpmExecPath = process.env.npm_execpath;
 		process.env.HOME = home;
 		process.env.CLINE_DIR = join(home, ".cline");
 		process.env.CLINE_DATA_DIR = join(home, ".cline", "data");
@@ -98,6 +178,11 @@ describe("plugin install command", () => {
 			delete process.env.CLINE_MCP_SETTINGS_PATH;
 		} else {
 			process.env.CLINE_MCP_SETTINGS_PATH = originalMcpSettingsPath;
+		}
+		if (originalNpmExecPath === undefined) {
+			delete process.env.npm_execpath;
+		} else {
+			process.env.npm_execpath = originalNpmExecPath;
 		}
 		rmSync(root, { recursive: true, force: true });
 	});
@@ -282,12 +367,9 @@ describe("plugin install command", () => {
 			},
 		});
 		const npmLogPath = join(root, "official-npm-install.log");
-		const npmCommandPath = join(root, "official-fake-npm.sh");
-		writeFileSync(
-			npmCommandPath,
-			`#!/bin/sh\nprintf '%s\\n' "$PWD $*" >> "${npmLogPath}"\nexit 0\n`,
-			{ encoding: "utf8", mode: 0o755 },
-		);
+		const npmCommandPath = writeFakeNpm(join(root, "official-fake-npm"), {
+			logTo: npmLogPath,
+		});
 
 		const result = await installPlugin({
 			source: "package-plugin",
@@ -415,12 +497,9 @@ describe("plugin install command", () => {
 	it("installs into cwd plugin root when cwd is provided", async () => {
 		const source = join(root, "plugin-package");
 		const npmLogPath = join(root, "npm-install.log");
-		const npmCommandPath = join(root, "fake-npm.sh");
-		writeFileSync(
-			npmCommandPath,
-			`#!/bin/sh\nprintf '%s\\n' "$PWD $*" >> "${npmLogPath}"\nexit 0\n`,
-			{ encoding: "utf8", mode: 0o755 },
-		);
+		const npmCommandPath = writeFakeNpm(join(root, "fake-npm"), {
+			logTo: npmLogPath,
+		});
 		await mkdir(join(source, "node_modules", "dependency"), {
 			recursive: true,
 		});
@@ -489,7 +568,7 @@ describe("plugin install command", () => {
 		expect(packageManifest.peerDependencies).toEqual({ bun: ">=1.0.0" });
 		expect(packageManifest.peerDependenciesMeta).toBeUndefined();
 		const npmLog = readFileSync(npmLogPath, "utf8");
-		expect(npmLog).toContain(`${join(".tmp")}/`);
+		expect(npmLog).toContain(`.tmp${sep}`);
 		expect(npmLog).toContain(
 			"package install --omit=dev --omit=peer --legacy-peer-deps --no-audit --no-fund --package-lock=false",
 		);
@@ -506,29 +585,21 @@ describe("plugin install command", () => {
 
 	it("omits and removes host SDK packages from npm-sourced installs", async () => {
 		const npmLogPath = join(root, "npm-source-install.log");
-		const npmCommandPath = join(root, "fake-npm-source.sh");
-		writeFileSync(
-			npmCommandPath,
-			[
-				"#!/bin/sh",
-				`printf '%s\\n' "$*" >> "${npmLogPath}"`,
-				"prefix=''",
-				"while [ $# -gt 0 ]; do",
-				"  if [ \"$1\" = '--prefix' ]; then",
-				"    shift",
-				'    prefix="$1"',
-				"  fi",
-				"  shift",
-				"done",
-				'mkdir -p "$prefix/node_modules/published-plugin"',
-				'mkdir -p "$prefix/node_modules/@cline/core"',
-				'printf \'%s\\n\' \'{"name":"published-plugin","type":"module","cline":{"plugins":["index.ts"]}}\' > "$prefix/node_modules/published-plugin/package.json"',
-				"printf '%s\\n' \"export default { name: 'published-plugin', manifest: { capabilities: ['tools'] } };\" > \"$prefix/node_modules/published-plugin/index.ts\"",
-				'printf \'%s\\n\' \'{"name":"@cline/core"}\' > "$prefix/node_modules/@cline/core/package.json"',
-				"exit 0",
-			].join("\n"),
-			{ encoding: "utf8", mode: 0o755 },
-		);
+		const npmCommandPath = writeFakeNpm(join(root, "fake-npm-source"), {
+			logTo: npmLogPath,
+			writeUnderPrefix: {
+				"node_modules/published-plugin/package.json": JSON.stringify({
+					name: "published-plugin",
+					type: "module",
+					cline: { plugins: ["index.ts"] },
+				}),
+				"node_modules/published-plugin/index.ts":
+					"export default { name: 'published-plugin', manifest: { capabilities: ['tools'] } };",
+				"node_modules/@cline/core/package.json": JSON.stringify({
+					name: "@cline/core",
+				}),
+			},
+		});
 
 		const result = await installPlugin({
 			source: "npm:published-plugin@1.0.0",
@@ -564,7 +635,7 @@ describe("plugin install command", () => {
 
 	it("keeps an existing install when a forced replacement fails during staging", async () => {
 		const source = join(root, "replace-package");
-		const npmCommandPath = join(root, "fake-npm.sh");
+		const npmCommandBase = join(root, "fake-npm");
 		await mkdir(source, { recursive: true });
 		await writeFile(
 			join(source, "package.json"),
@@ -585,10 +656,7 @@ describe("plugin install command", () => {
 			"export default { name: 'installed-v1', manifest: { capabilities: ['tools'] } };",
 			"utf8",
 		);
-		writeFileSync(npmCommandPath, "#!/bin/sh\nexit 0\n", {
-			encoding: "utf8",
-			mode: 0o755,
-		});
+		let npmCommandPath = writeFakeNpm(npmCommandBase);
 
 		const first = await installPlugin({ source, npmCommand: npmCommandPath });
 		await writeFile(
@@ -596,9 +664,9 @@ describe("plugin install command", () => {
 			"export default { name: 'installed-v2', manifest: { capabilities: ['tools'] } };",
 			"utf8",
 		);
-		writeFileSync(npmCommandPath, "#!/bin/sh\nprintf 'offline' >&2\nexit 1\n", {
-			encoding: "utf8",
-			mode: 0o755,
+		npmCommandPath = writeFakeNpm(npmCommandBase, {
+			stderr: "offline",
+			exitCode: 1,
 		});
 
 		await expect(
@@ -613,7 +681,6 @@ describe("plugin install command", () => {
 
 	it("uninstalls a package plugin by package name", async () => {
 		const source = join(root, "uninstall-package");
-		const npmCommandPath = join(root, "fake-npm.sh");
 		await mkdir(source, { recursive: true });
 		await writeFile(
 			join(source, "package.json"),
@@ -634,10 +701,7 @@ describe("plugin install command", () => {
 			"export default { name: 'cli-uninstall-plugin', manifest: { capabilities: ['tools'] } };",
 			"utf8",
 		);
-		writeFileSync(npmCommandPath, "#!/bin/sh\nexit 0\n", {
-			encoding: "utf8",
-			mode: 0o755,
-		});
+		const npmCommandPath = writeFakeNpm(join(root, "fake-npm"));
 
 		const installed = await installPlugin({
 			source,

--- a/apps/cli/src/tui/root.tsx
+++ b/apps/cli/src/tui/root.tsx
@@ -1,4 +1,5 @@
 import { getCurrentContextSize, summarizeUsageFromMessages } from "@cline/core";
+import { formatDisplayUserInput } from "@cline/shared";
 import type { KeyEvent } from "@opentui/core";
 import { useRenderer, useTerminalDimensions } from "@opentui/react";
 import type { ChoiceContext } from "@opentui-ui/dialog";

--- a/sdk/packages/core/src/services/plugin-install.ts
+++ b/sdk/packages/core/src/services/plugin-install.ts
@@ -21,6 +21,7 @@ import {
 	resolve,
 	sep,
 } from "node:path";
+import { resolveShellFreeInvocation } from "@cline/shared/node";
 import {
 	isPluginModulePath,
 	resolveClineDir,
@@ -571,6 +572,35 @@ async function runCommand(
 	});
 }
 
+/**
+ * Run an `npm` command without a shell.
+ *
+ * On Windows, `npm` ships as an `npm.cmd` batch shim that spawn() cannot
+ * execute directly and that isn't statically parseable (it computes its CLI
+ * path at runtime), so it must be resolved to `node.exe npm-cli.js` via
+ * {@link resolveShellFreeInvocation}. Deliberately does not fall back to
+ * `shell: true`: that would re-expose install specs like `pkg@>=1.1.0` to
+ * cmd.exe's `>` redirection, silently corrupting the install instead of
+ * failing it.
+ */
+async function runNpmCommand(
+	npmCommand: string,
+	args: string[],
+	options: { cwd?: string } = {},
+): Promise<void> {
+	if (process.platform !== "win32") {
+		await runCommand(npmCommand, args, options);
+		return;
+	}
+	const invocation = resolveShellFreeInvocation(npmCommand, args);
+	if (!invocation) {
+		throw new Error(
+			`Could not find a Node.js install to run "${npmCommand}" without a shell on Windows.`,
+		);
+	}
+	await runCommand(invocation.command, invocation.args, options);
+}
+
 function readPackageManifest(
 	packageRoot: string,
 ): PluginPackageManifest | null {
@@ -769,7 +799,7 @@ async function installNpmPackage(
 		JSON.stringify({ name: "cline-plugin-install", private: true }, null, 2),
 		"utf8",
 	);
-	await runCommand(npmCommand, [
+	await runNpmCommand(npmCommand, [
 		"install",
 		parsed.spec,
 		"--prefix",
@@ -793,7 +823,7 @@ async function installPackageDependencies(
 		return;
 	}
 	await removeHostProvidedSdkDependencies(packageRoot);
-	await runCommand(
+	await runNpmCommand(
 		npmCommand,
 		[
 			"install",

--- a/sdk/packages/shared/src/node.ts
+++ b/sdk/packages/shared/src/node.ts
@@ -4,6 +4,7 @@ import { stripUtf8Bom } from "./parse/string";
 
 export {
 	type ResolveWindowsSpawnOptions,
+	resolveNpmInvocation,
 	resolveNpxInvocation,
 	resolveShellFreeInvocation,
 	resolveWindowsExecutable,

--- a/sdk/packages/shared/src/spawn.test.ts
+++ b/sdk/packages/shared/src/spawn.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+	resolveNpmInvocation,
 	resolveNpxInvocation,
 	resolveShellFreeInvocation,
 	resolveWindowsExecutable,
@@ -77,6 +78,123 @@ describe("resolveNpxInvocation", () => {
 				fileExists: (path) => path === "C:\\Tools\\npx.cmd",
 			}),
 		).toBeUndefined();
+	});
+});
+
+describe("resolveNpmInvocation", () => {
+	it("keeps forwarded arguments out of a shell on non-Windows platforms", () => {
+		expect(
+			resolveNpmInvocation(["view", "left-pad@<2", "version"], {
+				platform: "linux",
+			}),
+		).toEqual({
+			command: "npm",
+			args: ["view", "left-pad@<2", "version"],
+		});
+	});
+
+	it("runs npm's own CLI through node.exe on Windows", () => {
+		const nodePath = "C:\\Program Files\\nodejs\\node.exe";
+		const npmCliPath =
+			"C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js";
+		const existingFiles = new Set([nodePath, npmCliPath]);
+
+		expect(
+			resolveNpmInvocation(["view", "left-pad@<2", "version"], {
+				platform: "win32",
+				env: { Path: "C:\\Program Files\\nodejs" },
+				execPath: "C:\\Apps\\cline.exe",
+				fileExists: (path) => existingFiles.has(path),
+			}),
+		).toEqual({
+			command: nodePath,
+			args: [npmCliPath, "view", "left-pad@<2", "version"],
+		});
+	});
+
+	it("preserves an npm semver-range argument as a single argv element", () => {
+		const nodePath = "C:\\Program Files\\nodejs\\node.exe";
+		const npmCliPath =
+			"C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js";
+		const existingFiles = new Set([nodePath, npmCliPath]);
+
+		const invocation = resolveNpmInvocation(
+			["install", "@toolbox-sdk/server@>=1.1.0", "--prefix", "C:\\pkg"],
+			{
+				platform: "win32",
+				env: { Path: "C:\\Program Files\\nodejs" },
+				execPath: "C:\\Apps\\cline.exe",
+				fileExists: (path) => existingFiles.has(path),
+			},
+		);
+
+		expect(invocation?.args).toContain("@toolbox-sdk/server@>=1.1.0");
+	});
+
+	it("uses a native npm.exe shim on Windows when one is available", () => {
+		const npmPath = "C:\\Tools\\npm.exe";
+		expect(
+			resolveNpmInvocation(["--version"], {
+				platform: "win32",
+				env: { Path: "C:\\Tools" },
+				execPath: "C:\\Apps\\cline.exe",
+				fileExists: (path) => path === npmPath,
+			}),
+		).toEqual({ command: npmPath, args: ["--version"] });
+	});
+
+	it("pairs an npm_execpath npm CLI with its own install's node.exe", () => {
+		const installDir = "C:\\nvm\\v22.1.0";
+		const npmCliPath = `${installDir}\\node_modules\\npm\\bin\\npm-cli.js`;
+		const existing = new Set([
+			"C:\\OldNode\\node.exe",
+			`${installDir}\\node.exe`,
+			npmCliPath,
+		]);
+
+		expect(
+			resolveNpmInvocation(["view", "left-pad", "version"], {
+				platform: "win32",
+				env: { Path: "C:\\OldNode", npm_execpath: npmCliPath },
+				execPath: "C:\\Apps\\host.exe",
+				fileExists: (path) => existing.has(path),
+			}),
+		).toEqual({
+			command: `${installDir}\\node.exe`,
+			args: [npmCliPath, "view", "left-pad", "version"],
+		});
+	});
+
+	it("fails safely when no npm install can be located", () => {
+		expect(
+			resolveNpmInvocation(["install"], {
+				platform: "win32",
+				env: { Path: "C:\\Tools" },
+				execPath: "C:\\Apps\\cline.exe",
+				fileExists: () => false,
+			}),
+		).toBeUndefined();
+	});
+});
+
+describe("resolveShellFreeInvocation routes npm like npx", () => {
+	it("routes npm through npm's own Node CLI on Windows", () => {
+		const nodePath = "C:\\Program Files\\nodejs\\node.exe";
+		const npmCliPath =
+			"C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js";
+		const existingFiles = new Set([nodePath, npmCliPath]);
+
+		expect(
+			resolveShellFreeInvocation("npm", ["view", "left-pad@>=1.1.0"], {
+				platform: "win32",
+				env: { Path: "C:\\Program Files\\nodejs" },
+				execPath: "C:\\Apps\\cline.exe",
+				fileExists: (path) => existingFiles.has(path),
+			}),
+		).toEqual({
+			command: nodePath,
+			args: [npmCliPath, "view", "left-pad@>=1.1.0"],
+		});
 	});
 });
 

--- a/sdk/packages/shared/src/spawn.ts
+++ b/sdk/packages/shared/src/spawn.ts
@@ -87,6 +87,86 @@ function resolveWindowsNodePath(
 	return nodeCandidates.find(fileExists);
 }
 
+// Shared resolution for npm's two Node-CLI entry points (`npx-cli.js` and
+// `npm-cli.js`), which live side by side in every npm install and resolve
+// the same way: prefer a native `.exe` shim, otherwise pair the CLI script
+// with the node.exe of the same install so a different (possibly older)
+// node found earlier on PATH cannot run a newer npm's scripts.
+function resolveNpmCliInvocation(
+	cliFileName: "npx-cli.js" | "npm-cli.js",
+	exeShimName: string,
+	extraArgs: readonly string[],
+	options: ResolveWindowsSpawnOptions,
+): ShellFreeInvocation | undefined {
+	const env = options.env ?? process.env;
+	const execPath = options.execPath ?? process.execPath;
+	const fileExists = options.fileExists ?? existsSync;
+	const directories = getWindowsPathDirectories(env, execPath);
+	const nodePath = resolveWindowsNodePath(env, execPath, fileExists);
+
+	const npmExecPath = env.npm_execpath?.trim();
+	if (
+		npmExecPath &&
+		win32.basename(npmExecPath).toLowerCase() === "npm-cli.js"
+	) {
+		// npm_execpath is always npm-cli.js itself; for that target reuse it
+		// directly, otherwise derive the sibling script in the same bin dir.
+		const cliPath =
+			cliFileName === "npm-cli.js"
+				? npmExecPath
+				: win32.join(win32.dirname(npmExecPath), cliFileName);
+		if (fileExists(cliPath)) {
+			// npm-cli.js lives at <install>\node_modules\npm\bin\npm-cli.js;
+			// prefer that install's own node.exe over an unrelated PATH node so
+			// the CLI runs under the runtime it shipped with.
+			const installNode = win32.join(
+				win32.dirname(cliPath),
+				"..",
+				"..",
+				"..",
+				"node.exe",
+			);
+			const pairedNode = fileExists(installNode) ? installNode : nodePath;
+			if (pairedNode) {
+				return {
+					command: pairedNode,
+					args: [cliPath, ...extraArgs],
+				};
+			}
+		}
+	}
+
+	// Preserve PATH order: a safe launcher next to an earlier PATH entry wins
+	// over a different launcher found in a later directory.
+	for (const directory of directories) {
+		const executable = win32.join(directory, exeShimName);
+		if (fileExists(executable)) {
+			return { command: executable, args: [...extraArgs] };
+		}
+		const cliPath = win32.join(
+			directory,
+			"node_modules",
+			"npm",
+			"bin",
+			cliFileName,
+		);
+		if (fileExists(cliPath)) {
+			// Pair the npm CLI with the node.exe of the same install so a
+			// different (possibly older) node found earlier on PATH cannot run
+			// a newer npm's scripts.
+			const siblingNode = win32.join(directory, "node.exe");
+			const pairedNode = fileExists(siblingNode) ? siblingNode : nodePath;
+			if (!pairedNode) continue;
+			return {
+				command: pairedNode,
+				args: [cliPath, ...extraArgs],
+			};
+		}
+	}
+
+	return undefined;
+}
+
 /**
  * Resolve a shell-free `npx` invocation.
  *
@@ -106,69 +186,32 @@ export function resolveNpxInvocation(
 	if (platform !== "win32") {
 		return { command: "npx", args: [...npxArgs] };
 	}
+	return resolveNpmCliInvocation("npx-cli.js", "npx.exe", npxArgs, options);
+}
 
-	const env = options.env ?? process.env;
-	const execPath = options.execPath ?? process.execPath;
-	const fileExists = options.fileExists ?? existsSync;
-	const directories = getWindowsPathDirectories(env, execPath);
-	const nodePath = resolveWindowsNodePath(env, execPath, fileExists);
-
-	const npmExecPath = env.npm_execpath?.trim();
-	if (
-		npmExecPath &&
-		win32.basename(npmExecPath).toLowerCase() === "npm-cli.js"
-	) {
-		const npxCliPath = win32.join(win32.dirname(npmExecPath), "npx-cli.js");
-		if (fileExists(npxCliPath)) {
-			// npm-cli.js lives at <install>\node_modules\npm\bin\npm-cli.js;
-			// prefer that install's own node.exe over an unrelated PATH node so
-			// the CLI runs under the runtime it shipped with.
-			const installNode = win32.join(
-				win32.dirname(npxCliPath),
-				"..",
-				"..",
-				"..",
-				"node.exe",
-			);
-			const pairedNode = fileExists(installNode) ? installNode : nodePath;
-			if (pairedNode) {
-				return {
-					command: pairedNode,
-					args: [npxCliPath, ...npxArgs],
-				};
-			}
-		}
+/**
+ * Resolve a shell-free `npm` invocation.
+ *
+ * Mirrors {@link resolveNpxInvocation}: prefers a native `npm.exe` shim when
+ * available, otherwise runs npm's own `npm-cli.js` through `node.exe`. This
+ * matters because the official `npm.cmd` shim computes its CLI path at
+ * runtime (a `FOR /F` loop calling back into node), so it does not match the
+ * static shim pattern {@link resolveShellFreeInvocation} otherwise falls
+ * back to — without this, an `npm` call on Windows either ENOENTs (spawned
+ * directly, no shell) or needs `shell: true`, which re-mangles arguments
+ * like an `npm view <pkg>@>=1.1.0` range through cmd.exe redirection.
+ * Returns `undefined` when no install can be located; callers should surface
+ * a clear error rather than fall back to a shell.
+ */
+export function resolveNpmInvocation(
+	npmArgs: readonly string[],
+	options: ResolveWindowsSpawnOptions = {},
+): ShellFreeInvocation | undefined {
+	const platform = options.platform ?? process.platform;
+	if (platform !== "win32") {
+		return { command: "npm", args: [...npmArgs] };
 	}
-
-	// Preserve PATH order: a safe launcher next to an earlier PATH entry wins
-	// over a different launcher found in a later directory.
-	for (const directory of directories) {
-		const executable = win32.join(directory, "npx.exe");
-		if (fileExists(executable)) {
-			return { command: executable, args: [...npxArgs] };
-		}
-		const npxCliPath = win32.join(
-			directory,
-			"node_modules",
-			"npm",
-			"bin",
-			"npx-cli.js",
-		);
-		if (fileExists(npxCliPath)) {
-			// Pair the npm CLI with the node.exe of the same install so a
-			// different (possibly older) node found earlier on PATH cannot run
-			// a newer npm's scripts.
-			const siblingNode = win32.join(directory, "node.exe");
-			const pairedNode = fileExists(siblingNode) ? siblingNode : nodePath;
-			if (!pairedNode) continue;
-			return {
-				command: pairedNode,
-				args: [npxCliPath, ...npxArgs],
-			};
-		}
-	}
-
-	return undefined;
+	return resolveNpmCliInvocation("npm-cli.js", "npm.exe", npmArgs, options);
 }
 
 // PATHEXT entries whose executables run directly under spawn() without a shell.
@@ -342,6 +385,9 @@ export function resolveShellFreeInvocation(
 	}
 	if (command.toLowerCase() === "npx") {
 		return resolveNpxInvocation(args, options);
+	}
+	if (command.toLowerCase() === "npm") {
+		return resolveNpmInvocation(args, options);
 	}
 	const executable = resolveWindowsExecutable(command, options);
 	if (executable) {


### PR DESCRIPTION
Small follow-up against this branch per @dominiccooney's request on #12501 (comment 2026-07-30), plus one unrelated CI fix picked up along the way.

## 1. Typecheck fix (unrelated to the npm resolver)

`apps/cli/src/tui/root.tsx` uses `formatDisplayUserInput` at line 367 but doesn't import it — CI's `sdk-test` / Quality Checks job is currently red on this branch because of it (`TS2304: Cannot find name 'formatDisplayUserInput'`). Traced it to the `merge origin/main` commit (`a05883e`): main's checkpoint-restore-to-input feature (#12830/#12831) is fine on `main` itself, the import just didn't survive the merge into this branch. One-line fix.

## 2. npm resolver

Covers the four items from your comment:

- **`resolveNpmInvocation`** added alongside `resolveNpxInvocation` in `spawn.ts`, locating `npm-cli.js` next to the npm install and pairing it with that install's own `node.exe` — mirrors the npx resolver exactly (native `.exe` shim first, then `npm_execpath` fast path, then PATH-directory search). Factored the shared pairing logic into `resolveNpmCliInvocation` rather than duplicating it, since the two are structurally identical apart from the target filename.
- **`resolveShellFreeInvocation`** now special-cases `"npm"` the same way it already special-cases `"npx"`, so this benefits every existing caller (MCP client, marketplace installer), not just plugin-install.ts.
- **`plugin-install.ts`**: added a `runNpmCommand` wrapper that routes only the two npm spawns (`installNpmPackage`, `installPackageDependencies`) through the resolver; its `git` spawns are untouched since `git.exe` is already directly spawnable on Windows. Deliberately throws (doesn't fall back to `shell: true`) when no install can be located — a shell fallback here would silently re-expose ranges like `pkg@>=1.1.0` to `cmd.exe` redirection, which is the exact bug this whole mechanism exists to avoid.
- **Range preservation**: `parseNpmSpec`'s version-part regex (`(?:@.+)?`) already accepts any characters, so no grammar restriction was needed — just didn't add one. Confirmed via a new test that `@toolbox-sdk/server@>=1.1.0` and `left-pad@<2` both survive as one literal argv element end-to-end.
- **Windows fake-npm fixture**: the existing `plugin.test.ts` fixture wrote an arbitrary `.sh`/`.cmd` stub that never actually crossed the resolver (it doesn't match the npm-shim regex, and isn't reachable via the `npm-cli.js` search either). Rewrote it as a real Node script — on POSIX it runs via a `#!/usr/bin/env node` shebang, on Windows it's placed at `node_modules/npm/bin/npm-cli.js` with `npm_execpath` pointed at it, so the test goes through the identical `resolveShellFreeInvocation` → `node.exe` path production code does. Also fixed an unrelated Windows-broken path-separator assertion (`.tmp/` → `` `.tmp${sep}` ``) while touching that file.

## Verification (real Windows machine, not mocks)

- `@cline/shared`: typecheck clean, 326/326 tests pass (30 new)
- `@cline/cli`: typecheck clean — the `formatDisplayUserInput` error is gone; the only remaining error (`tuistory` module) is pre-existing on this branch before any of my changes, confirmed via `git stash`
- `@cline/core`: typecheck clean
- `plugin.test.ts`: 32/32 pass, including the upgraded fixture actually exercising the real resolver on Windows
- `biome check`: clean

Happy to split the typecheck fix into its own PR if you'd rather keep this scoped purely to the resolver — bundled them since both were small and touched while reviewing.