### PR TITLE
ci(desktop): gate desktop publish secrets behind PublishDesktop environment

### DIFF
--- a/.cline/skills/publish-desktop/SKILL.md
+++ b/.cline/skills/publish-desktop/SKILL.md
@@ -90,9 +90,23 @@ gh workflow run desktop-publish.yml -f git_tag=desktop-vX.Y.Z -f confirm_publish
 gh run list --workflow=desktop-publish.yml --limit=1 --json url,status,conclusion,createdAt --jq '.[0]'
 ```
 
+**The run pauses for approval.** `validate` runs immediately, then the `build`
+job waits on the `PublishDesktop` environment until a required reviewer approves
+it — the run sits in `waiting`, which is expected, not a hang. Approve it in the
+run's web UI ("Review deployments"), or:
+
+```sh
+gh api repos/cline/cline/actions/runs/<run-id>/pending_deployments \
+  --method POST -f state=approved -f comment="desktop vX.Y.Z" \
+  -F 'environment_ids[]=19152605990'   # PublishDesktop
+```
+
+Both matrix legs wait on the same environment, so one approval releases both.
+Nothing after `validate` runs — and no signing key is readable — until then.
+
 The workflow builds both architectures in parallel (aarch64 native, x86_64 cross-compiled), signs with the Developer ID certificate, notarizes with the App Store Connect API key, signs updater artifacts with the Tauri updater key, creates the GitHub release, refreshes `desktop-latest/latest.json`, and posts to Slack. Notarization typically adds 2–10 minutes.
 
-If the workflow fails on missing credentials, see "Repo secrets (one-time setup)" below.
+If the workflow fails on missing credentials, see "Publish secrets (one-time setup)" below.
 
 9. Verify the update feed after the run succeeds.
 
@@ -106,11 +120,18 @@ The `version` field must be the new release and both `darwin-aarch64` and `darwi
 
 Report: version, tag, changelog updated, commit hash, what was pushed, workflow URL, and the feed verification result.
 
-## Repo secrets (one-time setup)
+## Publish secrets (one-time setup)
 
-The workflow needs these repository secrets. The Apple ones come from the same
-Apple Developer account used for manual signing (see the app README's "macOS
-signing & notarization" section for how to obtain them):
+These live on the **`PublishDesktop` environment**, not at repository level, so
+only the `build` job can read them and only after an approval. Set them under
+Settings → Environments → PublishDesktop → Environment secrets. The environment
+also restricts deployments to `main` and requires a reviewer.
+
+Adding one of these as a *repository* secret instead is the common mistake — the
+job would not see it, and the preflight check in `build` fails the run naming the
+missing entries. The Apple values come from the same Apple Developer account used
+for manual signing (see the app README's "macOS signing & notarization" section
+for how to obtain them):
 
 | Secret | Value |
 | --- | --- |
@@ -124,4 +145,8 @@ signing & notarization" section for how to obtain them):
 | `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | Password for that key |
 
 The Slack + telemetry secrets (`SLACK_RELEASE_BOT_TOKEN`, `TELEMETRY_SERVICE_API_KEY`,
-OTEL settings) are shared with the CLI publish workflow and already configured.
+`ERROR_SERVICE_API_KEY`, OTEL settings) are shared with the CLI, SDK, and extension
+publish workflows and already configured. **Do not move these into
+`PublishDesktop`** — scoping them to this environment empties them in every other
+publish workflow, silently, with no error beyond missing telemetry and a failed
+Slack post.

--- a/.cline/skills/publish-desktop/SKILL.md
+++ b/.cline/skills/publish-desktop/SKILL.md
@@ -127,11 +127,17 @@ only the `build` job can read them and only after an approval. Set them under
 Settings → Environments → PublishDesktop → Environment secrets. The environment
 also restricts deployments to `main` and requires a reviewer.
 
-Adding one of these as a *repository* secret instead is the common mistake — the
-job would not see it, and the preflight check in `build` fails the run naming the
-missing entries. The Apple values come from the same Apple Developer account used
-for manual signing (see the app README's "macOS signing & notarization" section
-for how to obtain them):
+Adding one of these as a *repository* secret is the common mistake. The build
+would still succeed — an environment-gated job resolves repository secrets too,
+with environment values simply taking precedence — so the credential would sit
+repo-wide while everything looked fine. `validate` therefore fails the run if any
+of them resolves in a job with no environment. If you hit that, delete the
+repository-level copy rather than duplicating it.
+
+If a secret is missing everywhere, the preflight in `build` fails the run naming
+the missing entries. The Apple values come from the same Apple Developer account
+used for manual signing (see the app README's "macOS signing & notarization"
+section for how to obtain them):
 
 | Secret | Value |
 | --- | --- |

--- a/.github/workflows/desktop-publish.yml
+++ b/.github/workflows/desktop-publish.yml
@@ -31,6 +31,45 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
     steps:
+      # Companion to the presence check in `build`, and the half that actually
+      # establishes scope. This job declares no environment, so a signing secret
+      # that resolves here can only be a repository or organization secret —
+      # meaning it is still readable by every workflow in the repo, which is the
+      # thing the PublishDesktop environment exists to prevent. Neither check
+      # proves provenance alone (an environment-gated job resolves repository
+      # secrets too, with environment values merely taking precedence), but
+      # together they do: empty here plus present in `build` means the value came
+      # from the environment.
+      - name: Verify signing secrets are not repository-scoped
+        env:
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY_CONTENT }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          unscoped=()
+          for name in APPLE_API_ISSUER APPLE_API_KEY APPLE_API_KEY_CONTENT \
+                      APPLE_CERTIFICATE APPLE_CERTIFICATE_PASSWORD APPLE_SIGNING_IDENTITY \
+                      TAURI_SIGNING_PRIVATE_KEY TAURI_SIGNING_PRIVATE_KEY_PASSWORD; do
+            [ -z "${!name}" ] || unscoped+=("$name")
+          done
+
+          if [ ${#unscoped[@]} -gt 0 ]; then
+            echo "These signing secrets resolve in a job with no environment:"
+            printf '  - %s\n' "${unscoped[@]}"
+            echo
+            echo "That means they are still repository or organization secrets and"
+            echo "are readable by any workflow in this repo. Delete them at that"
+            echo "level and add them to the PublishDesktop environment instead."
+            exit 1
+          fi
+
+          echo "No signing secret resolves outside the PublishDesktop environment."
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -129,12 +168,16 @@ jobs:
             printf '  - %s\n' "${missing[@]}"
             echo
             echo "Check that every secret above is set on the PublishDesktop"
-            echo "environment (not at repository level) and that this job still"
-            echo "declares 'environment: PublishDesktop'."
+            echo "environment and that this job still declares"
+            echo "'environment: PublishDesktop'."
             exit 1
           fi
 
-          echo "All 8 signing secrets resolved from the PublishDesktop environment."
+          # Deliberately not phrased as "resolved from PublishDesktop": a
+          # non-empty value here could also be a repository or organization
+          # secret. The repository-scope check in `validate` is what rules that
+          # out.
+          echo "All 8 signing secrets are present."
 
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/desktop-publish.yml
+++ b/.github/workflows/desktop-publish.yml
@@ -81,6 +81,14 @@ jobs:
   build:
     name: Build macOS (${{ matrix.arch }})
     needs: validate
+    # The Apple signing/notarization and Tauri updater secrets live in the
+    # PublishDesktop environment rather than at repository level, so they are
+    # readable only by this job and only once a required reviewer approves the
+    # run. Defense in depth: this `if` is advisory because a dispatched branch
+    # runs its own copy of this file; the enforced gate is the PublishDesktop
+    # environment's deployment-branch policy, which must also allow only main.
+    if: github.ref == 'refs/heads/main'
+    environment: PublishDesktop
     runs-on: macos-latest
     timeout-minutes: 90
     strategy:
@@ -92,6 +100,42 @@ jobs:
           - target: x86_64-apple-darwin
             arch: x86_64
     steps:
+      # A secret missing here is dangerous rather than merely broken: Tauri skips
+      # code signing when APPLE_CERTIFICATE is empty and skips notarization when
+      # APPLE_API_KEY is empty, both silently, so the build would still succeed
+      # and publish an unsigned, un-notarized bundle. Only the missing updater
+      # key is caught later (by the .sig check in "Collect artifacts"). Fail up
+      # front instead, before any build work, if the environment is misconfigured.
+      - name: Verify PublishDesktop secrets are present
+        env:
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY_CONTENT }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          missing=()
+          for name in APPLE_API_ISSUER APPLE_API_KEY APPLE_API_KEY_CONTENT \
+                      APPLE_CERTIFICATE APPLE_CERTIFICATE_PASSWORD APPLE_SIGNING_IDENTITY \
+                      TAURI_SIGNING_PRIVATE_KEY TAURI_SIGNING_PRIVATE_KEY_PASSWORD; do
+            [ -n "${!name}" ] || missing+=("$name")
+          done
+
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "Missing from the PublishDesktop environment:"
+            printf '  - %s\n' "${missing[@]}"
+            echo
+            echo "Check that every secret above is set on the PublishDesktop"
+            echo "environment (not at repository level) and that this job still"
+            echo "declares 'environment: PublishDesktop'."
+            exit 1
+          fi
+
+          echo "All 8 signing secrets resolved from the PublishDesktop environment."
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
### Related Issue

**Issue:** n/a — release pipeline hardening.

### Description

The desktop publish workflow's signing and notarization secrets were repository-level, which makes them readable more broadly than a release pipeline needs. This moves them to a dedicated `PublishDesktop` environment with a required reviewer and a deployment branch policy, and points the `build` job at it. A review of existing releases found no evidence of misuse — this is hardening, not incident response.

Also adds a preflight check to `build`. A missing signing secret doesn't fail the build outright; parts of the signing and notarization chain are skipped when their inputs are absent, so a misconfigured environment could otherwise produce a green run with an incorrectly signed artifact. The new step verifies the required secrets are present and fails fast, before any build work, naming whatever is missing.

Notes on scope:

- Only the desktop-exclusive secrets moved. The workflow also reads several secrets shared with the CLI, SDK, and extension publish workflows; scoping those to this environment would silently empty them elsewhere. The skill doc now says so explicitly.
- `validate` stays ungated so a bad tag fails immediately rather than after an approval, matching the ungated-build/gated-publish split in `ext-vscode-ab-package`.
- `release` stays ungated — it doesn't read any of the moved secrets. Keeping the environment on `build` alone means one approval per run, immediately before the signing step.
- The advisory `if` on `build` mirrors `ext-vscode-publish-nightly`; the environment's branch policy is the enforced gate.

### Test Procedure

The macOS bundle only builds in CI, so verification was structural plus a local harness for the new logic:

- Environment configuration verified against the API rather than assumed (reviewers, self-review setting, branch policy).
- Workflow YAML parsed and asserted post-edit: the environment is attached to `build`, the preflight is its first step, and `validate`/`release` remain ungated.
- The preflight script was extracted from the parsed YAML — so the test ran the real step body, not a copy — and exercised with all secrets present (passes), with some missing (fails, names them), and with none set, simulating a future edit dropping the environment (fails, names all of them).

Not verified end-to-end until the next desktop release, since the approval flow can't be exercised without one. Both matrix legs wait on the same environment, so one approval should release both; if it prompts twice that's cosmetic.

Worth merging before the next desktop release — the secrets have already been relocated, so the workflow needs this change to find them.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

The `publish-desktop` skill is updated in the same PR since it's what the next release will be driven from: it described the old secret location and didn't mention the approval pause, so a release would have looked like it was hanging. It now covers the wait, how to approve, where the secrets live, and which ones must not be moved.
