### PR TITLE
fix(cli): stop saving Bedrock profile auth with no profile

### DIFF
--- a/apps/cli/src/tui/components/dialogs/provider-picker.tsx
+++ b/apps/cli/src/tui/components/dialogs/provider-picker.tsx
@@ -26,7 +26,7 @@ import { palette } from "../../palette";
 import {
 	getDefaultAwsRegion,
 	type ProviderConfigValues,
-	resolveProviderConfigAwsRegion,
+	resolveProviderConfigAws,
 	resolveProviderConfigAzure,
 	resolveProviderConfigGcp,
 	resolveProviderConfigSap,
@@ -551,7 +551,6 @@ export function ProviderConfigInputContent(
 
 	const submit = () => {
 		const apiKey = values.apiKey?.trim();
-		const awsProfile = values.awsProfile?.trim();
 		const hasAzureFields = config.fields.azureApiVersion;
 		const hasAwsFields = config.fields.awsRegion || config.fields.awsProfile;
 		const hasGcpFields = config.fields.gcpProjectId || config.fields.gcpRegion;
@@ -566,13 +565,7 @@ export function ProviderConfigInputContent(
 			apiKey: config.fields.apiKey ? apiKey : undefined,
 			baseUrl: config.fields.baseUrl ? values.baseUrl?.trim() : undefined,
 			azure: hasAzureFields ? resolveProviderConfigAzure(values) : undefined,
-			aws: hasAwsFields
-				? {
-						region: resolveProviderConfigAwsRegion(values),
-						authentication: apiKey ? "api-key" : "profile",
-						profile: apiKey ? undefined : awsProfile || undefined,
-					}
-				: undefined,
+			aws: hasAwsFields ? resolveProviderConfigAws(values) : undefined,
 			gcp: hasGcpFields ? resolveProviderConfigGcp(values) : undefined,
 			sap: hasSapFields ? resolveProviderConfigSap(values) : undefined,
 		});

--- a/apps/cli/src/tui/utils/provider-config-values.test.ts
+++ b/apps/cli/src/tui/utils/provider-config-values.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
 	getDefaultAwsRegion,
+	resolveProviderConfigAws,
 	resolveProviderConfigAwsRegion,
 	resolveProviderConfigAzure,
 	resolveProviderConfigGcp,
@@ -66,6 +67,57 @@ describe("provider config values", () => {
 				awsRegion: "",
 			}),
 		).toBe("us-west-2");
+	});
+
+	it("uses API-key auth and clears any stored profile when a key is entered", () => {
+		expect(
+			resolveProviderConfigAws({
+				awsRegion: "us-east-1",
+				apiKey: " bedrock-key ",
+				awsProfile: "bedrock",
+			}),
+		).toStrictEqual({
+			region: "us-east-1",
+			authentication: "api-key",
+			profile: undefined,
+		});
+	});
+
+	it("uses the entered AWS profile name for profile auth", () => {
+		expect(
+			resolveProviderConfigAws({
+				awsRegion: "us-east-1",
+				awsProfile: " bedrock ",
+			}),
+		).toStrictEqual({
+			region: "us-east-1",
+			authentication: "profile",
+			profile: "bedrock",
+		});
+	});
+
+	it("leaves AWS_PROFILE to the credential chain instead of pinning it at save time", () => {
+		process.env.AWS_PROFILE = "bedrock";
+
+		expect(
+			resolveProviderConfigAws({ awsRegion: "us-east-1", awsProfile: "  " }),
+		).toStrictEqual({
+			region: "us-east-1",
+			authentication: "iam",
+			profile: undefined,
+		});
+	});
+
+	it("does not claim profile auth when no profile name resolves", () => {
+		delete process.env.AWS_PROFILE;
+
+		expect(
+			resolveProviderConfigAws({ awsRegion: "us-east-1", awsProfile: "" }),
+		).toStrictEqual({
+			region: "us-east-1",
+			authentication: "iam",
+			profile: undefined,
+		});
 	});
 
 	it("resolves Vertex GCP field values into GCP settings", () => {

--- a/apps/cli/src/tui/utils/provider-config-values.ts
+++ b/apps/cli/src/tui/utils/provider-config-values.ts
@@ -21,6 +21,21 @@ export function resolveProviderConfigAwsRegion(
 	return values.awsRegion?.trim() || getDefaultAwsRegion(values.awsProfile);
 }
 
+export function resolveProviderConfigAws(values: ProviderConfigValues): {
+	region: string;
+	authentication: "api-key" | "profile" | "iam";
+	profile: string | undefined;
+} {
+	const region = resolveProviderConfigAwsRegion(values);
+	if (values.apiKey?.trim()) {
+		return { region, authentication: "api-key", profile: undefined };
+	}
+	const profile = values.awsProfile?.trim();
+	return profile
+		? { region, authentication: "profile", profile }
+		: { region, authentication: "iam", profile: undefined };
+}
+
 export function resolveProviderConfigGcp(values: ProviderConfigValues):
 	| {
 			projectId?: string;

--- a/apps/cli/src/tui/views/onboarding/controller.ts
+++ b/apps/cli/src/tui/views/onboarding/controller.ts
@@ -41,7 +41,7 @@ import { palette } from "../../palette";
 import {
 	getDefaultAwsRegion,
 	type ProviderConfigValues,
-	resolveProviderConfigAwsRegion,
+	resolveProviderConfigAws,
 	resolveProviderConfigAzure,
 	resolveProviderConfigSap,
 	updateProviderConfigValue,
@@ -596,7 +596,6 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 		// the provider's own auth response is the authoritative error and is
 		// surfaced when the model picker / first turn runs.
 		const apiKey = byoValues.apiKey?.trim();
-		const awsProfile = byoValues.awsProfile?.trim();
 		const hasAzureFields = byoFields.azureApiVersion;
 		const hasAwsFields = byoFields.awsRegion || byoFields.awsProfile;
 		const hasSapFields =
@@ -611,13 +610,7 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 			apiKey: byoFields.apiKey ? apiKey : undefined,
 			baseUrl: byoFields.baseUrl ? byoValues.baseUrl?.trim() : undefined,
 			azure: hasAzureFields ? resolveProviderConfigAzure(byoValues) : undefined,
-			aws: hasAwsFields
-				? {
-						region: resolveProviderConfigAwsRegion(byoValues),
-						authentication: apiKey ? "api-key" : "profile",
-						profile: apiKey ? undefined : awsProfile || undefined,
-					}
-				: undefined,
+			aws: hasAwsFields ? resolveProviderConfigAws(byoValues) : undefined,
 			sap: hasSapFields ? resolveProviderConfigSap(byoValues) : undefined,
 		});
 		// Emit a single `user.provider_configured` event mirroring the


### PR DESCRIPTION
### Related Issue

Fixes #10930

### Description

## The problem

Both CLI provider-config save paths wrote the same `aws` literal - `saveByoConfig` (`apps/cli/src/tui/views/onboarding/controller.ts:614-620`) and the `/provider` dialog's `submit` (`apps/cli/src/tui/components/dialogs/provider-picker.tsx:569-575`):

```ts
authentication: apiKey ? "api-key" : "profile",
profile: apiKey ? undefined : awsProfile || undefined,
```

With no API key, `authentication` was hardcoded to `"profile"` regardless of whether a profile name had ever been entered. Saving with the optional "AWS Profile Name" field blank therefore persisted a config that claimed profile auth and named no profile - exactly the `providers.json` pasted in #10930.

At runtime `sdk/packages/llms/src/providers/vendors/bedrock.ts:103-110` sees `authentication === "profile"`, finds no profile, and builds `fromNodeProviderChain({ ignoreCache: true, clientConfig: { region } })`. That resolves `AWS_PROFILE` or `[default]`, so a user whose credentials live in a named profile gets "Could not load credentials from any providers".

Worth saying plainly: `credential_process` is not broken. `@aws-sdk/credential-provider-process` is in the dependency tree and the node chain handles it. The chain simply never looks at the user's profile, because the saved config names none.

## The fix

Extract the shared literal into a pure `resolveProviderConfigAws` in `apps/cli/src/tui/utils/provider-config-values.ts`, beside the existing `resolveProviderConfigGcp` / `Sap` / `Azure`, and call it from both save paths. When there is no API key and no profile name it writes `authentication: "iam"` instead of asserting profile auth - `"iam"` being the default-chain path that already ran in that case anyway.

## Technical approach and non-obvious details

- **Why `"iam"` rather than omitting `authentication`.** The field is optional in the type, but `hasAwsCredentials` (`apps/cli/src/utils/provider-readiness.ts:16-28`) only counts a Bedrock config as having credentials for `authentication` in {`iam`, `profile`}, a named profile, or access+secret keys. Omitting it would make `isProviderSettingsUsable` return false for a config the CLI had just written. `"iam"` is also this codebase's existing spelling for the default chain - `sdk/packages/llms/src/providers/builtins.ts` defaults to it, and the legacy migration maps the old `"credentials"` onto it.
- **`profile` is returned present-but-`undefined` deliberately.** `applySettingsObjectPatch` (`sdk/packages/core/src/services/providers/local-provider-service.ts:777`) deletes any key whose patch value is `undefined` or `""`, and `saveLocalProviderSettings` merges rather than replaces `aws`. Returning an object without the key would silently begin preserving stale profile names. The `toStrictEqual` assertions pin this, since vitest fails when a key is present-with-`undefined` on only one side.
- **No `AWS_PROFILE` fallback at save time, on purpose.** An earlier draft resolved a blank field from `process.env.AWS_PROFILE`. I dropped it: `fromNodeProviderChain` already reads `AWS_PROFILE` at resolution time, so persisting it would only pin a value that used to be dynamic - silently ignoring a later `AWS_PROFILE=other cline` - and would make the field unclearable, since it is seeded from the persisted value. There is a regression test for this.

## What did not change

- `provider-readiness.ts` is untouched, so no existing config flips usable/unusable.
- Enter still saves from any field. Changing that affects every provider's config form and is a product decision, not part of this fix.
- `bedrock.ts` and the rest of `@cline/llms` are untouched.
- The `api-key` and named-profile paths are behaviourally identical. Two of the four new tests pin that, and they stay green when the helper body is reverted to the old inline logic.

## Behaviour to watch after merge

Both only affect the case with no API key and no profile name.

1. `bedrock.ts` now takes line 116 rather than line 103, so `ignoreCache: true` is no longer passed. Per the AWS SDK that flag means "always reload credentials from the file system instead of using cached values", so a credentials file rotated mid-process may not be re-read within a single CLI process.
2. If the shared settings file already holds `aws.accessKey` / `aws.secretKey` (for instance migrated from the VS Code extension), those static keys will now sign requests - `handler-factory.ts:56` maps them to `accessKeyId`. Previously the false `"profile"` claim made `resolveCredentialProvider` return a chain provider before reaching the `hasDirectCredentials` check, so stored keys were ignored in favour of the ambient chain. The new precedence is the one already pinned by `bedrock.test.ts` in "uses direct IAM credentials and disables bearer-token env fallback", with the no-keys case covered by "uses the default AWS SDK credential chain when no static credentials are configured". Honouring credentials the user actually configured seems more correct than ignoring them, but flagging it since it is a credential-source change.

## Limitations

This stops the CLI persisting a config that misdescribes its own auth, and that part is covered by tests. It does not prove `credential_process` end to end: that needs a real AWS account and a real `credential_process` binary, and a mocked test can only show which arguments are passed, never that the SDK resolves process credentials.

It also does not by itself guarantee the reporter's setup succeeds. With no `AWS_*` variables set, their profile name still has to reach the config, which means reaching the profile field. Bedrock's fields are `[awsRegion, apiKey, awsProfile]`, focus starts on `awsRegion`, and `screens.tsx:323` wires `onSubmit` to every input, so the profile box is two Tabs away and easy to skip past. Making Enter advance instead of save would close that half, but it changes Enter semantics for every provider config form, so I left it out. Happy to follow up if you want it.

Related: #10943 fixed the legacy-migration side of this area and does not cover the fresh-config path.

### Test Procedure

From the repo root unless noted.

1. `bun run types` - exit 0 (whole workspace).
2. `bun run lint` - exit 0.
3. `cd apps/cli && bunx tsc --noEmit` - exit 0.
4. `cd apps/cli && bunx vitest run --config vitest.config.ts src/tui/utils/provider-config-values.test.ts` - 11 tests pass (7 existing, 4 new).
5. `cd apps/cli && bunx vitest run --config vitest.config.ts src/tui/ src/utils/` - 65 files, 425 tests, 423 pass.

Caveat on step 5, stated honestly: two failures remain - `open.test.ts > open wrapper (linux) > passes through untouched when xdg-open is on PATH` and `worktree.test.ts > createTaskWorktree > rejects when cwd is not a git repository`. Both fail identically on a pristine checkout of this branch's base with the change stashed, and both are environment-dependent on Windows. I did not run the full `apps/cli` suite locally: it is serial (`pool: "forks"`, `maxWorkers: 1`, `fileParallelism: false`) and hangs on Windows in `src/commands/` tests that spawn subprocesses, none of which this diff touches.

To confirm the new tests are not vacuous: replacing the helper body with the previous inline logic turns exactly the two regression tests red and leaves the `api-key` and named-profile tests green.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots

No visual change is intended.

### Additional Notes

The two call sites had duplicated the same `aws` literal behind different `FIELD_ORDER` arrays, so fixing one would have left the bug reachable from the other entry point.