### PR TITLE
fix(vscode): suppress lifecycle teardown denials when replaying task history

### DIFF
--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -102,6 +102,7 @@ import { buildDisabledWorkflowNames, expandSlashCommands } from "./slash-command
 import { StatePostDebouncer } from "./state-post-debouncer"
 import { createTaskProxy, type TaskProxy } from "./task-proxy"
 import { syncTelemetrySettingFromSharedGlobalSettings } from "./telemetry-settings-sync"
+import { MESSAGE_EDIT_SUPERSEDED_DENIAL_REASON } from "./tool-approval-denial"
 import { TurnStateTracker } from "./turn-state-tracker"
 import { createWorkspaceFileReadExecutor } from "./vscode-file-read-executor"
 import { VscodeSessionHost } from "./vscode-session-host"
@@ -1618,7 +1619,7 @@ export class Controller {
 			// approval / ask_question exactly like cancelTask does. Without this,
 			// the old run stays suspended forever on a promise nothing can
 			// resolve, and the stale parked resolver intercepts later responses.
-			this.interactions.clearPending("Superseded by an edited message")
+			this.interactions.clearPending(MESSAGE_EDIT_SUPERSEDED_DENIAL_REASON)
 
 			const { startResult, sdkHost } = await this.sessions.startNewSession(startInput)
 

--- a/apps/vscode/src/sdk/message-translator-approval-denial.test.ts
+++ b/apps/vscode/src/sdk/message-translator-approval-denial.test.ts
@@ -2,7 +2,15 @@ import type { CoreSessionEvent } from "@cline/core"
 import type { AgentEvent } from "@cline/shared"
 import { describe, expect, it } from "vitest"
 import { MessageTranslatorState, translateSessionEvent } from "./message-translator"
-import { DEFAULT_TOOL_APPROVAL_DENIAL_REASON, USER_MESSAGE_TOOL_APPROVAL_DENIAL_REASON } from "./tool-approval-denial"
+import {
+	DEFAULT_TOOL_APPROVAL_DENIAL_REASON,
+	MESSAGE_EDIT_SUPERSEDED_DENIAL_REASON,
+	MODE_CHANGED_DENIAL_REASON,
+	TASK_CANCELLED_DENIAL_REASON,
+	TASK_CLEARED_DENIAL_REASON,
+	TASK_SWITCHED_DENIAL_REASON,
+	USER_MESSAGE_TOOL_APPROVAL_DENIAL_REASON,
+} from "./tool-approval-denial"
 
 describe("translateSessionEvent - user-message tool approval denial", () => {
 	it("suppresses tool lifecycle events for approval replies routed as user feedback", () => {
@@ -109,5 +117,47 @@ describe("translateSessionEvent - user-message tool approval denial", () => {
 
 		expect(result.messages).toHaveLength(0)
 		expect(result.turnComplete).toBe(false)
+	})
+})
+
+describe("translateSessionEvent - task lifecycle tool approval denial", () => {
+	const toolEndEvent = (error: string): CoreSessionEvent => ({
+		type: "agent_event",
+		payload: {
+			sessionId: "session-1",
+			event: {
+				type: "content_end",
+				contentType: "tool",
+				toolName: "editor",
+				toolCallId: "call-1",
+				error,
+			} as AgentEvent,
+		},
+	})
+
+	it.each([
+		["task cleared", TASK_CLEARED_DENIAL_REASON],
+		["task cancelled", TASK_CANCELLED_DENIAL_REASON],
+		["task switched", TASK_SWITCHED_DENIAL_REASON],
+		["mode changed", MODE_CHANGED_DENIAL_REASON],
+		["message edit superseded", MESSAGE_EDIT_SUPERSEDED_DENIAL_REASON],
+	])("suppresses a %s denial replayed without prior denial state", (_label, reason) => {
+		const state = new MessageTranslatorState()
+
+		const result = translateSessionEvent(toolEndEvent(JSON.stringify({ error: reason })), state)
+
+		expect(result.messages).toHaveLength(0)
+	})
+
+	it.each([
+		["a bare reason outside the persisted envelope", TASK_CLEARED_DENIAL_REASON],
+		["an envelope that merely contains a reason", `prefix ${JSON.stringify({ error: TASK_CLEARED_DENIAL_REASON })}`],
+		["an unrelated tool failure", JSON.stringify({ error: "ENOENT: no such file or directory" })],
+	])("still renders %s as a tool error row", (_label, error) => {
+		const state = new MessageTranslatorState()
+
+		const result = translateSessionEvent(toolEndEvent(error), state)
+
+		expect(result.messages.some((message) => message.say === "error" && message.text === error)).toBe(true)
 	})
 })

--- a/apps/vscode/src/sdk/message-translator.ts
+++ b/apps/vscode/src/sdk/message-translator.ts
@@ -50,7 +50,7 @@ import { CLINE_FREE_PROMOTION_ENDED_ERROR_CODE, isClineFreePromotionEndedMessage
 import { MessageIdMinter } from "./message-id-minter"
 import { describeMissingCredentialError } from "./provider-credential-error"
 import { extractPersistedHookContextChips, isSyntheticSdkUserMessage, isSyntheticUserPrompt } from "./sdk-user-message-mapping"
-import { isDeniedToolApprovalMistake, isKnownToolApprovalDenial } from "./tool-approval-denial"
+import { isDeniedToolApprovalMistake, isKnownToolApprovalDenial, isTaskLifecycleToolApprovalDenial } from "./tool-approval-denial"
 
 // ---------------------------------------------------------------------------
 // Translation result
@@ -1529,7 +1529,11 @@ function translateAgentEvent(event: AgentEvent, state: MessageTranslatorState): 
 					// turn-final response — drop the retag candidate.
 					state.clearTurnFinalText()
 
-					if (state.checkDeniedToolApproval(event.toolCallId) || isKnownToolApprovalDenial(event.error)) {
+					if (
+						state.checkDeniedToolApproval(event.toolCallId) ||
+						isKnownToolApprovalDenial(event.error) ||
+						isTaskLifecycleToolApprovalDenial(event.error)
+					) {
 						state.clearStreamingTool()
 						break
 					}

--- a/apps/vscode/src/sdk/sdk-mode-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-mode-coordinator.ts
@@ -13,6 +13,7 @@ import type { SdkSessionRebuildScheduler } from "./sdk-session-rebuild-scheduler
 import { ACT_MODE_CONTINUATION_PROMPT } from "./sdk-user-message-mapping"
 import type { SdkSessionHost } from "./session-host"
 import type { TaskProxy } from "./task-proxy"
+import { MODE_CHANGED_DENIAL_REASON } from "./tool-approval-denial"
 import type { VscodeSessionHost } from "./vscode-session-host"
 
 type StartInput = Parameters<VscodeSessionHost["start"]>[0]
@@ -391,7 +392,7 @@ export class SdkModeCoordinator {
 	}
 
 	private async cancelRunningTurnForModeChange(oldManager: SdkSessionHost, oldSessionId: string): Promise<void> {
-		this.options.interactions.clearPending("Mode changed")
+		this.options.interactions.clearPending(MODE_CHANGED_DENIAL_REASON)
 		this.options.messages.cancelPendingSave()
 		try {
 			await oldManager.abort(oldSessionId)

--- a/apps/vscode/src/sdk/sdk-task-control-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-task-control-coordinator.ts
@@ -6,6 +6,7 @@ import type { SdkMessageCoordinator } from "./sdk-message-coordinator"
 import { isAbortError, type SdkSessionLifecycle } from "./sdk-session-lifecycle"
 import type { SdkTaskHistory } from "./sdk-task-history"
 import { createTaskProxy, type TaskProxy } from "./task-proxy"
+import { TASK_CANCELLED_DENIAL_REASON, TASK_CLEARED_DENIAL_REASON, TASK_SWITCHED_DENIAL_REASON } from "./tool-approval-denial"
 
 export interface SdkTaskControlCoordinatorOptions {
 	sessions: SdkSessionLifecycle
@@ -65,7 +66,7 @@ export class SdkTaskControlCoordinator {
 	}
 
 	async cancelTask(): Promise<void> {
-		this.options.interactions.clearPending("Task cancelled")
+		this.options.interactions.clearPending(TASK_CANCELLED_DENIAL_REASON)
 
 		const activeSession = this.options.sessions.getActiveSession()
 		if (!activeSession) {
@@ -111,7 +112,7 @@ export class SdkTaskControlCoordinator {
 		// Supersede any in-flight showTaskWithId so it cannot re-install a task
 		// after the user cleared the view (e.g. clicked New Task).
 		this.taskViewGeneration++
-		this.options.interactions.clearPending("Task cleared")
+		this.options.interactions.clearPending(TASK_CLEARED_DENIAL_REASON)
 
 		await this.options.sessions.endActiveSession("clearTask")
 
@@ -175,7 +176,7 @@ export class SdkTaskControlCoordinator {
 			// resolvers live on the shared interaction coordinator, so ending the session
 			// alone does not discard them; if one leaks across this task switch, the first
 			// message sent in the newly selected task is consumed as the old task's response.
-			this.options.interactions.clearPending("Task switched")
+			this.options.interactions.clearPending(TASK_SWITCHED_DENIAL_REASON)
 
 			// When reopening the task that is currently active, wait for its stop to
 			// land so the persisted session status read below reflects how the last

--- a/apps/vscode/src/sdk/sdk-task-history.test.ts
+++ b/apps/vscode/src/sdk/sdk-task-history.test.ts
@@ -8,6 +8,7 @@ import { deleteLegacyTask, readApiConversationHistory, readTaskHistory, readUiMe
 import { sdkMessagesToClineMessages } from "./message-translator"
 import type { SdkSessionLifecycle } from "./sdk-session-lifecycle"
 import { SdkTaskHistory, sessionHistoryRecordToHistoryItem } from "./sdk-task-history"
+import { TASK_CLEARED_DENIAL_REASON } from "./tool-approval-denial"
 import type { VscodeSessionHost } from "./vscode-session-host"
 
 vi.mock("@/core/storage/disk", () => ({
@@ -217,6 +218,47 @@ describe("SdkTaskHistory", () => {
 			tool: "editedExistingFile",
 			path: "/Users/maxpaulus/c/c2/README.md",
 		})
+	})
+
+	it("renders no tool row for an approval a task lifecycle teardown denied", () => {
+		const clearedToolResult = JSON.stringify({ error: TASK_CLEARED_DENIAL_REASON })
+
+		const result = sdkMessagesToClineMessages([
+			{ role: "user", content: "add a joke" },
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "tool_use",
+						id: "toolu_1",
+						name: "editor",
+						input: {
+							path: "/Users/maxpaulus/c/c2/README.md",
+							old_text: "## License",
+							new_text: "## A Note from Cline",
+						},
+					},
+				],
+			},
+			{
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "toolu_1",
+						name: "editor",
+						content: clearedToolResult,
+						is_error: true,
+					},
+				],
+			},
+		])
+
+		expect(result).toMatchObject([
+			{ type: "say", say: "task", text: "add a joke", partial: false },
+			{ type: "ask", ask: "completion_result", partial: false },
+		])
+		expect(result.map((message) => message.text).join("\n")).not.toContain(clearedToolResult)
 	})
 
 	it("retags only the final turn's text, styled by the mode recovered from user_input wrappers", async () => {

--- a/apps/vscode/src/sdk/tool-approval-denial.ts
+++ b/apps/vscode/src/sdk/tool-approval-denial.ts
@@ -5,6 +5,12 @@ export const USER_MESSAGE_TOOL_APPROVAL_DENIAL_REASON = "Tool execution was canc
 export const EDIT_TOOL_APPROVAL_DENIAL_REASON =
 	"The user denied this edit. The file was NOT modified and still contains its original content."
 
+export const TASK_CLEARED_DENIAL_REASON = "Task cleared"
+export const TASK_CANCELLED_DENIAL_REASON = "Task cancelled"
+export const TASK_SWITCHED_DENIAL_REASON = "Task switched"
+export const MODE_CHANGED_DENIAL_REASON = "Mode changed"
+export const MESSAGE_EDIT_SUPERSEDED_DENIAL_REASON = "Superseded by an edited message"
+
 /**
  * Builds the model-facing reason for a denied tool approval.
  *
@@ -51,6 +57,21 @@ export function isKnownToolApprovalDenial(value: unknown): boolean {
 		message.includes(DEFAULT_TOOL_APPROVAL_DENIAL_REASON) ||
 		message.includes(EDIT_TOOL_APPROVAL_DENIAL_REASON)
 	)
+}
+
+const TASK_LIFECYCLE_DENIAL_PAYLOADS = new Set(
+	[
+		TASK_CLEARED_DENIAL_REASON,
+		TASK_CANCELLED_DENIAL_REASON,
+		TASK_SWITCHED_DENIAL_REASON,
+		MODE_CHANGED_DENIAL_REASON,
+		MESSAGE_EDIT_SUPERSEDED_DENIAL_REASON,
+	].map((reason) => JSON.stringify({ error: reason })),
+)
+
+export function isTaskLifecycleToolApprovalDenial(value: unknown): boolean {
+	const message = getMessage(value)
+	return message !== undefined && TASK_LIFECYCLE_DENIAL_PAYLOADS.has(message)
 }
 
 export function isDeniedToolApprovalMistake(


### PR DESCRIPTION
### Related Issue

Fixes #11362

### Description

Reopening a task from History that was left with a pending tool approval renders a raw `{"error":"Task cleared"}` row. The live view renders nothing at all for that same teardown, so this is a history-replay divergence rather than a real tool failure surfacing.

**Mechanism.** Clicking Start New Task with an approval pending reaches `SdkTaskControlCoordinator.clearTask()`, which calls `interactions.clearPending("Task cleared")`. That resolves the pending approval as denied; `AgentRuntime` turns the reason into `skipReason` and emits `output: { error: "Task cleared" }` with `isError` set; the codec persists it as `content: JSON.stringify(output)` with `is_error: true`.

Live, the row is suppressed because `clearPending` also calls `recordDeniedToolApproval`, so `state.checkDeniedToolApproval(toolCallId)` is true at the guard in `message-translator.ts`. On replay, `sdkMessagesToClineMessages` builds a fresh `MessageTranslatorState`, so that operand is false, and `isKnownToolApprovalDenial` only matches the three user-facing denial reasons. Both operands fail and the raw JSON renders.

Four other lifecycle teardowns call `clearPending` and hit the identical path: `Task cancelled`, `Task switched`, `Mode changed`, and `Superseded by an edited message`.

**The fix.** A separate `isTaskLifecycleToolApprovalDenial` matcher added as a third operand of that guard, plus five exported constants replacing the bare string literals at the five `clearPending` producers, so the reason a producer emits and the reason the matcher recognises cannot drift apart silently.

**Why a separate matcher rather than widening `isKnownToolApprovalDenial`.** That function matches on substrings and feeds four live sites: the render guard, the consecutive-mistake accounting, and two `isSuppressedToolApprovalDenial` sites reaching it through `isDeniedToolApprovalMistake`. Loosening it would change live error suppression. The new matcher compares exactly, against the persisted `{"error":<reason>}` envelope, which is the only form these reasons take: `AgentRuntime` always emits the object and the live and persisted paths stringify it identically. Substring matching here would silently hide an unrelated tool failure whose message merely contained one of these phrases.

**What did not change.** `isKnownToolApprovalDenial` is untouched, so its four consumers keep their current behaviour. The new matcher is referenced in exactly two places: its import and the guard.

**One asymmetry, stated deliberately.** `isKnownToolApprovalDenial` is wired into both the render guard and the `toolError` accounting; the new matcher is wired into the guard only. Live, `clearPending` records the denial before resolving, so `isToolApprovalDenied` already covers the accounting for these reasons, and the replay path never reads `toolError`. Happy to add it there if you would rather the two families look symmetric.

**Alternative considered and rejected.** The issue asks for a friendly user-facing message in place of the raw JSON. I suppressed the row entirely instead, because that is what the live view does for these teardowns, and it matches how #12769 handled mode-switch prompts leaking into rehydrated history. Glad to render a placeholder row if you prefer.

### Test Procedure
```
cd apps/vscode
bunx vitest run --config vitest.config.ts src/sdk/sdk-task-history.test.ts src/sdk/message-translator-approval-denial.test.ts
```
2 files / 50 tests pass.

Red/green: with the `message-translator.ts` guard reverted, all six new cases fail for the right reason (`expected [...] to have a length of +0 but got 2`, and `expected true to be false` on the replay test).

Exactness is mutation-tested, not just asserted: replacing the `Set.has` comparison with a loose `reasons.some((r) => message.includes(r))` makes the two negative cases fail. The three negative cases exist to prove the matcher cannot over-suppress.

Full gates:
```
cd apps/vscode
bun run check-types # clean
bun run lint # clean, 1184 files
bun run test:vitest # 76 files / 995 tests
```

On one heavily loaded local run `src/sdk/model-catalog/catalog.test.ts` hit a 60s hook timeout. It passes 29/29 in isolation and imports nothing this PR touches.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore
-   [x] Tests are passing and code is formatted and linted
-   [x] I have reviewed contributor guidelines

### Screenshots

No visual change other than the removal of the raw error row described above.

### Additional Notes

Seven files, but only two carry logic; the other three source files are one-line literal-to-constant swaps that keep the producers and the matcher in sync. Happy to split the constant swap into a follow-up PR if that is easier to review.

No changeset added, per maintainers owning versioning.


