### PR TITLE
fix(cli): send a valid hook payload when a hub-backed run fails

### DIFF
--- a/apps/cli/src/utils/hooks.test.ts
+++ b/apps/cli/src/utils/hooks.test.ts
@@ -29,6 +29,7 @@ vi.mock("./events", () => ({
 	closeInlineStreamIfNeeded: eventMocks.closeInlineStreamIfNeeded,
 }));
 
+import { parseHookEventPayload } from "@cline/shared";
 import { createRuntimeHooks } from "./hooks";
 
 async function emitRunStartAndPrompt(
@@ -231,5 +232,164 @@ describe("createRuntimeHooks", () => {
 
 		expect(dispatchHookEvent).not.toHaveBeenCalled();
 		expect(outputMocks.write).not.toHaveBeenCalled();
+	});
+
+	describe("afterRun", () => {
+		function acrossHubWire(value: unknown) {
+			return JSON.parse(JSON.stringify(value));
+		}
+
+		function snapshotFor(
+			status: "completed" | "aborted" | "failed",
+			lastError?: string,
+		) {
+			return {
+				agentId: "agent-1",
+				conversationId: "conversation-1",
+				runId: "run-1",
+				parentAgentId: null,
+				status,
+				iteration: 3,
+				messages: [],
+				pendingToolCalls: [],
+				usage: {
+					inputTokens: 0,
+					outputTokens: 0,
+					cacheReadTokens: 0,
+					cacheWriteTokens: 0,
+				},
+				lastError,
+			};
+		}
+
+		function hooksWithSpy() {
+			const dispatchHookEvent = vi.fn().mockResolvedValue(undefined);
+			const runtimeHooks = createRuntimeHooks({
+				yolo: false,
+				cwd: "/workspace",
+				workspaceRoot: "/workspace",
+				dispatchHookEvent,
+			});
+			return { dispatchHookEvent, hooks: runtimeHooks.hooks! };
+		}
+
+		it("keeps the failure reason when the hub wire flattens the run error", async () => {
+			const { dispatchHookEvent, hooks } = hooksWithSpy();
+			const result = acrossHubWire({
+				agentId: "agent-1",
+				runId: "run-1",
+				status: "failed",
+				iterations: 3,
+				outputText: "",
+				messages: [],
+				usage: {
+					inputTokens: 0,
+					outputTokens: 0,
+					cacheReadTokens: 0,
+					cacheWriteTokens: 0,
+				},
+				error: new Error("The operation timed out."),
+			});
+			expect(result.error).toEqual({});
+
+			await hooks.afterRun?.({
+				snapshot: snapshotFor("failed", "The operation timed out."),
+				result,
+			});
+
+			const dispatched = dispatchHookEvent.mock.calls[0][0];
+			expect(dispatched.hookName).toBe("agent_error");
+			expect(dispatched.error.name).toBe("Error");
+			expect(dispatched.error.message).toBe("The operation timed out.");
+			expect(parseHookEventPayload(acrossHubWire(dispatched))).toBeDefined();
+		});
+
+		it("reports an aborted run as agent_abort carrying its reason", async () => {
+			const { dispatchHookEvent, hooks } = hooksWithSpy();
+			const result = acrossHubWire({
+				agentId: "agent-1",
+				runId: "run-1",
+				status: "aborted",
+				iterations: 2,
+				outputText: "",
+				messages: [],
+				usage: {
+					inputTokens: 0,
+					outputTokens: 0,
+					cacheReadTokens: 0,
+					cacheWriteTokens: 0,
+				},
+				error: undefined,
+			});
+			expect(result.error).toBeUndefined();
+
+			await hooks.afterRun?.({
+				snapshot: snapshotFor("aborted", "session_stop"),
+				result,
+			});
+
+			const dispatched = dispatchHookEvent.mock.calls[0][0];
+			expect(dispatched.hookName).toBe("agent_abort");
+			expect(dispatched.reason).toBe("session_stop");
+			expect(parseHookEventPayload(acrossHubWire(dispatched))).toBeDefined();
+		});
+
+		it("preserves the name and stack of a real Error off the wire", async () => {
+			const { dispatchHookEvent, hooks } = hooksWithSpy();
+			const result = {
+				agentId: "agent-1",
+				runId: "run-1",
+				status: "failed" as const,
+				iterations: 1,
+				outputText: "",
+				messages: [],
+				usage: {
+					inputTokens: 0,
+					outputTokens: 0,
+					cacheReadTokens: 0,
+					cacheWriteTokens: 0,
+				},
+				error: new TypeError("boom"),
+			};
+
+			await hooks.afterRun?.({
+				snapshot: snapshotFor("failed", "boom"),
+				result,
+			});
+
+			const dispatched = dispatchHookEvent.mock.calls[0][0];
+			expect(dispatched.error.name).toBe("TypeError");
+			expect(dispatched.error.message).toBe("boom");
+			expect(typeof dispatched.error.stack).toBe("string");
+			expect(parseHookEventPayload(acrossHubWire(dispatched))).toBeDefined();
+		});
+
+		it("still emits a valid agent_end payload for a completed run", async () => {
+			const { dispatchHookEvent, hooks } = hooksWithSpy();
+			const result = acrossHubWire({
+				agentId: "agent-1",
+				runId: "run-1",
+				status: "completed",
+				iterations: 1,
+				outputText: "all done",
+				messages: [],
+				usage: {
+					inputTokens: 0,
+					outputTokens: 0,
+					cacheReadTokens: 0,
+					cacheWriteTokens: 0,
+				},
+			});
+
+			await hooks.afterRun?.({
+				snapshot: snapshotFor("completed"),
+				result,
+			});
+
+			const dispatched = dispatchHookEvent.mock.calls[0][0];
+			expect(dispatched.hookName).toBe("agent_end");
+			expect(dispatched.error).toBeUndefined();
+			expect(parseHookEventPayload(acrossHubWire(dispatched))).toBeDefined();
+		});
 	});
 });

--- a/apps/cli/src/utils/hooks.ts
+++ b/apps/cli/src/utils/hooks.ts
@@ -103,16 +103,27 @@ function isAbortReason(reason?: string): boolean {
 	);
 }
 
-function serializeHookError(error: Error): {
+function serializeHookError(
+	error: unknown,
+	fallbackMessage: string,
+): {
 	name: string;
 	message: string;
 	stack?: string;
 } {
-	return {
-		name: error.name,
-		message: error.message,
-		stack: error.stack,
+	const source = (error ?? {}) as {
+		name?: unknown;
+		message?: unknown;
+		stack?: unknown;
 	};
+	const name =
+		typeof source.name === "string" && source.name ? source.name : "Error";
+	const message =
+		typeof source.message === "string" && source.message
+			? source.message
+			: fallbackMessage;
+	const stack = typeof source.stack === "string" ? source.stack : undefined;
+	return { name, message, stack };
 }
 
 function basePayload(
@@ -300,15 +311,17 @@ export function createRuntimeHooks(options: {
 					);
 					return;
 				}
-				const hookName = isAbortReason(result.error?.message)
-					? "agent_abort"
-					: "agent_error";
+				const reason = result.error?.message || snapshot.lastError;
+				const hookName =
+					result.status === "aborted" || isAbortReason(reason)
+						? "agent_abort"
+						: "agent_error";
 				await dispatchHookPayload(
 					hookName === "agent_abort"
 						? {
 								...basePayload(base, { cwd, workspaceRoot }),
 								hookName,
-								reason: result.error?.message,
+								reason,
 								taskCancel: { taskMetadata: {} },
 							}
 						: {
@@ -316,7 +329,8 @@ export function createRuntimeHooks(options: {
 								hookName,
 								iteration: result.iterations,
 								error: serializeHookError(
-									result.error ?? new Error("Agent run failed"),
+									result.error,
+									reason || "Agent run failed",
 								),
 								taskCancel: { taskMetadata: {} },
 							},


### PR DESCRIPTION
### Related Issue

Fixes #11821

### Description

## The problem

On a hub-backed session the agent runs in the hub daemon, so the CLI's `afterRun` hook is invoked
remotely via `createHookProxies` and the frame is serialized with a plain `JSON.stringify`
(`sdk/packages/core/src/hub/client/index.ts:726`). An `Error` does not survive that: `name`, `message`
and `stack` are not enumerable own properties, so `JSON.stringify(new Error("x")) === "{}"`. There is
no Error-aware replacer anywhere on the hub path.

The CLI therefore receives `result.error === {}`, and two things go wrong in `afterRun`:

1. `serializeHookError(result.error ?? new Error("Agent run failed"))` looks safe but is not. `{}` is
   truthy, so the `??` fallback never fires. The function returned
   `{name: undefined, message: undefined, stack: undefined}`, `JSON.stringify` stripped those keys,
   and `HookEventPayloadSchema` requires `error.name` and `error.message` as strings. The hub replied
   `invalid_hook_payload`, which the CLI printed as `hook dispatch failed`. For scripted or CI use
   this is a false-failure signal that cannot be told apart from a real failure without reading the
   hub's own log.
2. Aborted runs were mislabelled. `agent-runtime.ts` builds the result with
   `error: status === "failed" ? normalized : undefined`, so on an abort `result.error` is undefined
   by construction. `isAbortReason(result.error?.message)` saw nothing and classified every abort as
   `agent_error` carrying the invented message `Agent run failed`.

Worth stating plainly, since the issue assumed otherwise: the run had not succeeded. The `completed`
branch emits an `agent_end` payload with no `error` field at all, so it cannot fail validation. An
`invalid_hook_payload` reply proves the run ended `failed` or `aborted`. The `ok:true` on `run.start`
means the hub command succeeded, not the agent run.

## The fix

Stop deriving hook classification and error text from a field that does not survive the hub boundary.

- `reason` now falls back to `snapshot.lastError`, a plain `string` on the runtime snapshot that
  crosses JSON intact. It is set on exactly the failing paths and read live by `snapshot()`, and
  `execute()` clears it at the start of each run, so it cannot be stale from a previous one.
- Classification is `result.status === "aborted" || isAbortReason(reason)`. This is not a new
  convention: it is what `sdk/packages/core/src/hooks/subprocess.ts:483` and
  `hook-file-hooks.ts:608` already do. The CLI was the odd one out.
- `serializeHookError` takes `unknown` plus an explicit fallback and always returns the strings the
  schema requires. Truthiness rather than `??`, so an empty `message` also falls back instead of
  satisfying `z.string()` with nothing useful.

`result.error` is typed `Error`, but the value arriving off the wire is not one. The fix narrows at
the value level rather than casting the declared type away.

## What did not change

The `completed` branch returns before any modified line and is untouched, with a test guarding it.
The payload schema is not loosened: making `error.name` and `error.message` optional would silence
the symptom while permanently discarding the failure reason for every hook consumer. The hub's wire
serializer is not modified either, though it is the deeper cause; see Additional Notes.

### Test Procedure

`apps/cli/src/utils/hooks.test.ts` had no `afterRun` coverage at all, which is why this shipped. Four
cases added.

1. Focused suite:

```bash
cd apps/cli && bunx vitest run --config vitest.config.ts src/utils/hooks.test.ts
```

Result: 1 file, 10 tests passed (6 pre-existing, 4 new), exit 0.

2. Everything that consumes `createRuntimeHooks`:

```bash
cd apps/cli && bunx vitest run --config vitest.config.ts src/utils/hooks.test.ts src/runtime/run-agent.test.ts src/runtime/interactive/session-runtime.test.ts
```

Result: 3 files, 43 tests passed, exit 0.

3. Types:

```bash
cd apps/cli && bun run typecheck
```

Result: clean, exit 0.

4. Lint and format:

```bash
bun run lint
bunx biome format apps/cli/src/utils/hooks.ts apps/cli/src/utils/hooks.test.ts
```

`bun run lint` is clean (exit 0), and both changed files pass `biome format` with no fixes applied.
One honest caveat: repo-wide `bun run format` currently exits 1 on this base for 17 files that this
PR does not touch (`sdk/packages/llms/src/providers/builtins.ts`,
`apps/cli/src/utils/cline-pass-errors.ts` and others), so I checked my two files directly rather than
claiming a green repo-wide run.

The regression test round-trips the result through `JSON.parse(JSON.stringify(...))` so the `Error`
degrades to `{}` exactly as the wire does. This matters: a test that hands `afterRun` a live `Error`
passes on unfixed code and proves nothing, because that is the bug. Confirmed red before the fix
(`error.name` undefined, and the abort case classified `agent_error`), green after. I also mutation
checked the two new predicates: deleting `result.status === "aborted" ||` fails the abort test, and
hard-coding `name` or dropping `stack` fails the real-`Error` test, so neither assertion is vacuous.

A second honest caveat on CI: a PR touching only `apps/cli/**` does not run the CLI suite here.
`sdk-test.yml` is path-filtered to `sdk/**`, and the required `test` check is the aggregator job in
`ext-vscode-test.yml`, which exits early when no vscode or testing-platform paths changed. So these
tests are proven locally only. That gap is plausibly why this went uncovered in the first place, but
changing the workflow is outside this PR.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing and the changed files are formatted and linted (see the caveat under Test Procedure about pre-existing repo-wide `format` failures)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

No visual change is intended.

### Additional Notes

**Behaviour to watch after merge.** Aborted runs now emit `agent_abort` where they previously emitted
`agent_error`. `deriveSubsessionStatus` (`sdk/packages/core/src/session/models/session-graph.ts:69`)
handles `agent_end`, `agent_error` and `session_shutdown` but has no `agent_abort` case, so it falls
through to `default: return "running"`. For a subagent run that aborts, the child session row would
stay non-terminal rather than becoming `failed`.

I deliberately did not fix that here, because the gap is pre-existing rather than introduced by this
change: `subprocess.ts:483`, `hook-file-hooks.ts:608` and `hook-file-hooks.ts:925` already classify on
`result.status === "aborted"`, so those paths already emit `agent_abort` today and already reach the
same default. This PR makes the CLI consistent with them. The likely fix is a one-line
`case "agent_abort": return "cancelled";` in `session-graph.ts`, but that is a shared-core change in a
different subsystem and I would rather not bundle it. Happy to open it as a follow-up, or to include
it here if you would prefer one PR. Root CLI sessions are unaffected either way, since
`replaySubagentHookEvent` only touches session rows when `parent_agent_id` is set.

**Out of scope.** The hub wire never serializes `Error` in a recoverable form, which is the deeper
cause and would need an Error-aware replacer in shared core. That changes the wire format for every
consumer including the VS Code extension, so it wants a maintainer's call rather than a drive-by fix.

Separately, and this answers the reporter's main open question: `apps/cli/script/build.ts` omits the
`process.env.NODE_ENV` define that `apps/cli/bun.mts:87` has. In the `bun.mts` build that define folds
`isDev` to a constant `false` and the print at `hooks.ts:158` is dropped entirely, but the shipped
platform binaries are built by `script/build.ts`, whose `define` block only inlines the telemetry and
OTEL variables. That is why the `hook dispatch failed` line is still reachable in a released binary.
It is a build-config issue rather than a logic one, so it is not fixed here.