### PR TITLE
fix(vscode): surface a clear error when a provider has no API key

### DIFF
--- a/apps/vscode/src/sdk/message-translator.ts
+++ b/apps/vscode/src/sdk/message-translator.ts
@@ -45,6 +45,7 @@ import type {
 } from "@shared/ExtensionMessage"
 import { Logger } from "@shared/services/Logger"
 import { MessageIdMinter } from "./message-id-minter"
+import { describeMissingCredentialError } from "./provider-credential-error"
 import { isSyntheticSdkUserMessage } from "./sdk-user-message-mapping"
 import { isDeniedToolApprovalMistake, isKnownToolApprovalDenial } from "./tool-approval-denial"
 
@@ -2443,6 +2444,10 @@ export function reshapeErrorForWebview(
 					message: rawMessage,
 				},
 			})
+		}
+		const credentialMessage = describeMissingCredentialError(rawMessage, providerId)
+		if (credentialMessage) {
+			return credentialMessage
 		}
 		const notFoundMessage = describeModelNotFoundError(rawMessage)
 		if (notFoundMessage) {

--- a/apps/vscode/src/sdk/message-translator.ts
+++ b/apps/vscode/src/sdk/message-translator.ts
@@ -2382,10 +2382,12 @@ function describeModelNotFoundError(rawMessage: string): string | undefined {
  * ErrorRow expects (`code`, `providerId`, `details`), extracting structured
  * info from the error message when present and falling back to raw text.
  */
-export function reshapeErrorForWebview(
-	error: { message?: string; status?: number; code?: string },
-	providerId = "cline",
-): string {
+export function reshapeErrorForWebview(error: { message?: string; status?: number; code?: string }, providerId?: string): string {
+	// The ClineError-JSON branches below are cline-provider flows (balance,
+	// spend limit), so "cline" stays their fallback id. The missing-credential
+	// message instead gets the raw value: defaulting there would name the wrong
+	// provider when the active provider id is unknown.
+	const clineErrorProviderId = providerId ?? "cline"
 	const rawMessage = error.message ?? "Unknown error"
 
 	// Try to extract structured error info from the error message.
@@ -2427,7 +2429,7 @@ export function reshapeErrorForWebview(
 			return JSON.stringify({
 				message: rawMessage,
 				code: "insufficient_credits",
-				providerId,
+				providerId: clineErrorProviderId,
 				details: {
 					current_balance: balance,
 					message: rawMessage,
@@ -2438,7 +2440,7 @@ export function reshapeErrorForWebview(
 			return JSON.stringify({
 				message: rawMessage,
 				code: "SPEND_LIMIT_EXCEEDED",
-				providerId,
+				providerId: clineErrorProviderId,
 				details: {
 					code: "SPEND_LIMIT_EXCEEDED",
 					message: rawMessage,
@@ -2463,7 +2465,7 @@ export function reshapeErrorForWebview(
 		return JSON.stringify({
 			message: (parsed.message as string) ?? rawMessage,
 			code: "insufficient_credits",
-			providerId,
+			providerId: clineErrorProviderId,
 			details: {
 				current_balance: parsed.current_balance,
 				total_spent: parsed.total_spent,
@@ -2479,7 +2481,7 @@ export function reshapeErrorForWebview(
 		return JSON.stringify({
 			message: (parsed.message as string) ?? rawMessage,
 			code: "SPEND_LIMIT_EXCEEDED",
-			providerId,
+			providerId: clineErrorProviderId,
 			details: {
 				code: "SPEND_LIMIT_EXCEEDED",
 				limit_scope: parsed.limit_scope,

--- a/apps/vscode/src/sdk/provider-credential-error.test.ts
+++ b/apps/vscode/src/sdk/provider-credential-error.test.ts
@@ -15,6 +15,12 @@ describe("describeMissingCredentialError", () => {
 		)
 	})
 
+	it("does not name a provider when the id is unknown", () => {
+		expect(describeMissingCredentialError("Missing Authorization header")).toBe(
+			"Missing API key for the active provider. Add credentials in Settings, or switch providers.",
+		)
+	})
+
 	it.each([
 		"No Authorization header",
 		"Authorization header is required",
@@ -47,5 +53,11 @@ describe("reshapeErrorForWebview - missing credentials", () => {
 
 	it("passes an invalid-key error through unchanged", () => {
 		expect(reshapeErrorForWebview({ message: "Invalid API key" }, "openai")).toBe("Invalid API key")
+	})
+
+	it("does not blame the cline provider when the active provider id is unknown", () => {
+		expect(reshapeErrorForWebview({ message: "Missing Authorization header" })).toBe(
+			"Missing API key for the active provider. Add credentials in Settings, or switch providers.",
+		)
 	})
 })

--- a/apps/vscode/src/sdk/provider-credential-error.test.ts
+++ b/apps/vscode/src/sdk/provider-credential-error.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest"
+import { reshapeErrorForWebview } from "./message-translator"
+import { describeMissingCredentialError } from "./provider-credential-error"
+
+describe("describeMissingCredentialError", () => {
+	it("rewrites a missing Authorization header error into actionable guidance", () => {
+		expect(describeMissingCredentialError("Missing Authorization header", "vercel-ai-gateway")).toBe(
+			'Missing API key for provider "vercel-ai-gateway". Add credentials in Settings, or switch providers.',
+		)
+	})
+
+	it("names the provider it was given", () => {
+		expect(describeMissingCredentialError("Missing Authorization header", "openrouter")).toBe(
+			'Missing API key for provider "openrouter". Add credentials in Settings, or switch providers.',
+		)
+	})
+
+	it.each([
+		"No Authorization header",
+		"Authorization header is required",
+		"missing authorization HEADER",
+		"AI Gateway error: Missing Authorization header (401)",
+	])("matches the no-header signature in %j", (rawMessage) => {
+		expect(describeMissingCredentialError(rawMessage, "vercel-ai-gateway")).toBe(
+			'Missing API key for provider "vercel-ai-gateway". Add credentials in Settings, or switch providers.',
+		)
+	})
+
+	it.each([
+		"Invalid API key",
+		"Unauthorized",
+		"authentication failed",
+		"invalid_api_key",
+		"Model not found",
+		"",
+	])("leaves %j untouched so a wrong key is never relabelled as missing", (rawMessage) => {
+		expect(describeMissingCredentialError(rawMessage, "openai")).toBeUndefined()
+	})
+})
+
+describe("reshapeErrorForWebview - missing credentials", () => {
+	it("surfaces actionable guidance instead of the raw provider 401", () => {
+		expect(reshapeErrorForWebview({ message: "Missing Authorization header" }, "vercel-ai-gateway")).toBe(
+			'Missing API key for provider "vercel-ai-gateway". Add credentials in Settings, or switch providers.',
+		)
+	})
+
+	it("passes an invalid-key error through unchanged", () => {
+		expect(reshapeErrorForWebview({ message: "Invalid API key" }, "openai")).toBe("Invalid API key")
+	})
+})

--- a/apps/vscode/src/sdk/provider-credential-error.ts
+++ b/apps/vscode/src/sdk/provider-credential-error.ts
@@ -1,8 +1,11 @@
 const MISSING_AUTH_HEADER = /\b(?:missing|no)\s+authorization\s+header\b|\bauthorization\s+header\s+is\s+required\b/i
 
-export function describeMissingCredentialError(rawMessage: string, providerId: string): string | undefined {
+export function describeMissingCredentialError(rawMessage: string, providerId?: string): string | undefined {
 	if (!MISSING_AUTH_HEADER.test(rawMessage)) {
 		return undefined
 	}
-	return `Missing API key for provider "${providerId}". Add credentials in Settings, or switch providers.`
+	// Only name the provider when the caller actually knows it — a fallback id
+	// here would blame the wrong provider for the missing key.
+	const subject = providerId ? `Missing API key for provider "${providerId}".` : "Missing API key for the active provider."
+	return `${subject} Add credentials in Settings, or switch providers.`
 }

--- a/apps/vscode/src/sdk/provider-credential-error.ts
+++ b/apps/vscode/src/sdk/provider-credential-error.ts
@@ -1,0 +1,8 @@
+const MISSING_AUTH_HEADER = /\b(?:missing|no)\s+authorization\s+header\b|\bauthorization\s+header\s+is\s+required\b/i
+
+export function describeMissingCredentialError(rawMessage: string, providerId: string): string | undefined {
+	if (!MISSING_AUTH_HEADER.test(rawMessage)) {
+		return undefined
+	}
+	return `Missing API key for provider "${providerId}". Add credentials in Settings, or switch providers.`
+}


### PR DESCRIPTION
### Related Issue

Fixes #12775

### Description

Selecting a key-based provider without ever entering an API key produced a raw upstream 401 in the chat panel ("Missing Authorization header") with no indication that the cause was an unconfigured key.

**Mechanism.** `resolveApiKey` (`sdk/packages/llms/src/providers/http.ts:13-35`) returns `undefined` without throwing, and `@ai-sdk/openai-compatible` then drops the `Authorization` entry entirely rather than sending `Bearer undefined` — which is what produces the gateway's 401. That string travels untouched from there: `agent-runtime.ts` emits `run-failed` with the message intact, `runtime-event-adapter.ts:249-257` passes `event.error` straight through, and `reshapeErrorForWebview` falls through every branch to `return rawMessage`. `git grep "Missing Authorization"` is zero hits repo-wide, and `ClineError`'s three `authErrorRegex` patterns don't match it either (and the error carries no HTTP status), so nothing classifies it anywhere.

**Fix.** A small matcher alongside the existing `describeModelNotFoundError` in the same function, rewriting the no-header signature into `Missing API key for provider "<id>". Add credentials in Settings, or switch providers.` This follows the shape of `resolveCredentialError` in `apps/examples/desktop-app`.

**Why not a preflight.** I tried that first and backed off. `getProviderConfigFields(id).authMethod === "api-key"` isn't a safe predicate: it has only three values, `"oauth"` covers 4 ids and `"local"` covers only `openai-codex-cli`, so ollama, lmstudio, litellm, vscode-lm, claude-code and opencode all land in the api-key bucket (`provider-config-fields.test.ts:19-40` asserts this). On top of that, 175 of the 179 builtin providers declare an `apiKeyEnv` fallback that the extension cannot observe from `config.apiKey`, since the VS Code `resolveApiKey` has no `process.env` lookup. A key-presence guard would have blocked users who work today. Classifying after the failure has no false-positive risk and keeps `llms` unopinionated, per the stance documented at `provider-config-fields.ts:206-209` and `openai-compatible.ts:111-114`.

**What did not change.** No request is blocked and no provider gains or loses a credential requirement. `sdk/packages/llms` and `sdk/packages/core` are untouched. The match is deliberately narrow — only the no-header wording, not `invalid api key` / `unauthorized` — so a present-but-wrong key is never relabelled as missing.

**Out of scope.** The four key-blind `usesClineAccountAuth(...) && !config.apiKey` preflights (`sdk-task-start-coordinator.ts:97`, `sdk-mode-coordinator.ts:292`, `SdkController.ts:1410` and `:1521`) are unchanged; widening those is a separate auth-critical change. This also does not prevent the keyless request being sent — it only makes the resulting error legible. Happy to do the preflight instead if you'd rather stop the request.

Note #12584 touches the same preflight region for the opposite side of that predicate (Cline-account providers, #12530). There is no file overlap with this PR.

### Test Procedure

New suite `apps/vscode/src/sdk/provider-credential-error.test.ts` (14 tests): the missing-header rewrite, three wording variants plus mixed case and embedded text, six negative cases proving `Invalid API key` / `Unauthorized` / `authentication failed` pass through untouched, and two integration cases through `reshapeErrorForWebview`.

```bash
cd apps/vscode

bunx vitest run --config vitest.config.ts src/sdk/provider-credential-error.test.ts
# 1 file / 14 tests pass

bun run test:vitest
# 77 files / 1000 tests pass

bun run ci:check-all
# check-types, lint (1186 files), format all clean
```

Verified the new test fails before the change (module not found) and passes after.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bug fix, or refactor
-   [x] Tests added for the new behaviour, including negative cases
-   [x] Existing tests pass locally

### Screenshots

No visual change beyond the error text itself.