### PR TITLE
fix(vscode): convert nested MCP array schemas for Gemini tools (legacy)

### DIFF
--- a/apps/vscode/src/core/prompts/system-prompt/__tests__/spec.test.ts
+++ b/apps/vscode/src/core/prompts/system-prompt/__tests__/spec.test.ts
@@ -82,6 +82,127 @@ describe("toolSpecFunctionDeclarations (Gemini)", () => {
 	})
 })
 
+const makeNestedMcpTool = (): ClineToolSpec =>
+	makeTool({
+		name: "create_workflow",
+		description: "Create a workflow",
+		parameters: [
+			{
+				name: "definition",
+				required: ["rules", "steps"],
+				instruction: "The workflow definition",
+				type: "object",
+				properties: {
+					rules: {
+						type: "array",
+						items: {
+							type: "object",
+							properties: { rule_no: { type: "string", description: "The rule number" } },
+							required: ["rule_no"],
+						},
+					},
+					steps: {
+						type: "array",
+						items: {
+							type: "object",
+							properties: { step_no: { type: "string" } },
+							required: ["step_no"],
+						},
+					},
+				},
+			} as any,
+		],
+	})
+
+describe("toolSpecFunctionDeclarations (Gemini) nested MCP schemas", () => {
+	it("converts an array<object> parameter to the schema the issue expects", () => {
+		const result = toolSpecFunctionDeclarations(makeNestedMcpTool(), mockContext)
+
+		expect(result.parameters?.properties?.["definition"]).to.deep.equal({
+			type: "OBJECT",
+			description: "The workflow definition",
+			properties: {
+				rules: {
+					type: "ARRAY",
+					items: {
+						type: "OBJECT",
+						properties: { rule_no: { type: "STRING", description: "The rule number" } },
+						required: ["rule_no"],
+					},
+				},
+				steps: {
+					type: "ARRAY",
+					items: {
+						type: "OBJECT",
+						properties: { step_no: { type: "STRING" } },
+						required: ["step_no"],
+					},
+				},
+			},
+			required: ["rules", "steps"],
+		})
+	})
+
+	it("maps a nullable type union to its non-null member", () => {
+		const tool = makeTool({
+			parameters: [{ name: "note", required: false, instruction: "An optional note", type: ["string", "null"] } as any],
+		})
+		const result = toolSpecFunctionDeclarations(tool, mockContext)
+
+		const note = result.parameters?.properties?.["note"] as any
+		expect(note.type).to.equal("STRING")
+	})
+
+	it("carries items for a top-level array parameter", () => {
+		const tool = makeTool({
+			parameters: [
+				{
+					name: "tags",
+					required: true,
+					instruction: "A list of tags",
+					type: "array",
+					items: { type: "string" },
+				},
+			],
+		})
+		const result = toolSpecFunctionDeclarations(tool, mockContext)
+
+		const tags = result.parameters?.properties?.["tags"] as any
+		expect(tags.type).to.equal("ARRAY")
+		expect(tags.items).to.deep.equal({ type: "STRING" })
+	})
+
+	it("falls back to string items when an array declares none", () => {
+		const tool = makeTool({
+			parameters: [{ name: "tags", required: true, instruction: "A list of tags", type: "array" }],
+		})
+		const result = toolSpecFunctionDeclarations(tool, mockContext)
+
+		const tags = result.parameters?.properties?.["tags"] as any
+		expect(tags.type).to.equal("ARRAY")
+		expect(tags.items).to.deep.equal({ type: "STRING" })
+	})
+
+	it("describes a nested property from its own description, not the parent instruction", () => {
+		const tool = makeTool({
+			parameters: [
+				{
+					name: "config",
+					required: true,
+					instruction: "The parent instruction",
+					type: "object",
+					properties: { retries: { type: "integer", description: "How many times to retry" } },
+				},
+			],
+		})
+		const result = toolSpecFunctionDeclarations(tool, mockContext)
+
+		const retries = (result.parameters?.properties?.["config"] as any).properties.retries
+		expect(retries.type).to.equal("NUMBER")
+		expect(retries.description).to.equal("How many times to retry")
+	})
+})
+
 describe("Gemini and Anthropic parameter descriptions match", () => {
 	it("both converters produce the same description text", () => {
 		const tool = makeTool()

--- a/apps/vscode/src/core/prompts/system-prompt/spec.ts
+++ b/apps/vscode/src/core/prompts/system-prompt/spec.ts
@@ -233,7 +233,40 @@ const GOOGLE_TOOL_PARAM_MAP: Record<string, string> = {
 	integer: "NUMBER",
 	boolean: "BOOLEAN",
 	object: "OBJECT",
-	array: "STRING",
+	array: "ARRAY",
+}
+
+function toGoogleSchema(node: any): any {
+	const rawType = Array.isArray(node?.type) ? node.type.find((t: string) => t !== "null") : node?.type
+	const type = GOOGLE_TOOL_PARAM_MAP[rawType || "string"] || GoogleToolParamType.OBJECT
+	const schema: any = { type }
+
+	if (node?.description) {
+		schema.description = node.description
+	}
+
+	if (node?.enum) {
+		schema.enum = node.enum
+	}
+
+	if (type === GoogleToolParamType.ARRAY) {
+		schema.items = toGoogleSchema(node?.items)
+	}
+
+	if (node?.properties) {
+		schema.properties = {}
+		for (const [key, child] of Object.entries<any>(node.properties)) {
+			if (key !== "$schema") {
+				schema.properties[key] = toGoogleSchema(child)
+			}
+		}
+	}
+
+	if (Array.isArray(node?.required) && node.required.length > 0) {
+		schema.required = node.required
+	}
+
+	return schema
 }
 
 /**
@@ -266,33 +299,12 @@ export function toolSpecFunctionDeclarations(tool: ClineToolSpec, context: Syste
 				required.push(param.name)
 			}
 
-			const paramSchema: any = {
-				type: GOOGLE_TOOL_PARAM_MAP[param.type || "string"] || GoogleToolParamType.OBJECT,
-			}
+			const paramSchema: any = toGoogleSchema(param)
 
 			if (param.instruction) {
 				const desc = replacer(resolveInstruction(param.instruction, context), context)
 				if (desc) {
 					paramSchema.description = desc
-				}
-			}
-
-			if (param.properties) {
-				paramSchema.properties = {}
-				for (const [key, prop] of Object.entries<any>(param.properties)) {
-					// Skip $schema property
-					if (key === "$schema") {
-						continue
-					}
-					paramSchema.properties[key] = {
-						type: GOOGLE_TOOL_PARAM_MAP[prop.type || "string"] || GoogleToolParamType.OBJECT,
-						description: replacer(resolveInstruction(param.instruction, context), context),
-					}
-
-					// Handle enum values
-					if (prop.enum) {
-						paramSchema.properties[key].enum = prop.enum
-					}
 				}
 			}
 


### PR DESCRIPTION
### Related Issue

**Issue:** #12514

### Description

## The problem

`toolSpecFunctionDeclarations` converts a `ClineToolSpec` into a Gemini `FunctionDeclaration`. Its type map sent JSON Schema `array` to `STRING`, and its nested-property loop rebuilt every child as `{type, description}` (plus `enum`), so `items`, nested `properties` and nested `required` were all discarded one level down.

An MCP tool whose input schema contains `array<object>` fields reached the model like this:

```js
{ rules: { type: "STRING" }, steps: { type: "STRING" } }
```

The model was told those fields are strings, so it produced arguments the MCP server could not accept. The reporter confirmed with an extension-host debugger, and confirmed that flattening `$ref`/`$defs` does not help — the loss happens after the schema is already inline.

The data was intact on arrival: `mcpToolToClineToolSpec` in `registry/ClineToolSet.ts` already preserves `items` and nested `properties`. And the two sibling converters in the same file — `toolSpecFunctionDefinition` (OpenAI) and `toolSpecInputSchema` (Anthropic) — already carry both through. Only the Gemini branch dropped them, so this was an asymmetry rather than a deliberate limitation.

## The fix

`array` now maps to `ARRAY`, and a small recursive `toGoogleSchema` converts a JSON Schema node into a Gemini `Schema`, carrying `type`, `description`, `enum`, `items`, `properties` and `required` at every depth. The same schema from the issue now converts to:

```js
{
  definition: {
    type: "OBJECT",
    properties: {
      rules: { type: "ARRAY", items: { type: "OBJECT", properties: { rule_no: { type: "STRING" } }, required: ["rule_no"] } },
      steps: { type: "ARRAY", items: { type: "OBJECT", properties: { step_no: { type: "STRING" } }, required: ["step_no"] } }
    },
    required: ["rules", "steps"]
  }
}
```

Because the recursion replaced the old one-level rebuild, two adjacent losses in the same block go with it:

- **Nested descriptions came from the wrong node.** Each child's `description` was built from the *parent* parameter's `instruction` (added in #9681), so every child of a parameter shared one description. Children now use their own `description`.
- **Top-level `enum` was dropped.** The old nested branch copied `enum`, the top level did not, so `{type: "string", enum: [...]}` kept its enum when nested but lost it as a direct parameter — while OpenAI and Anthropic kept it at both levels.

## Technical approach and non-obvious details

- **`type` can be an array.** `{"type": ["string", "null"]}` is what `zod-to-json-schema` emits for a nullable field, which is what the official MCP TypeScript SDK produces. Indexing the map with that array stringifies it to `"string,null"`, misses, and falls through to `OBJECT` with no `properties` — the same class of silent mis-conversion as the reported bug, and the recursion would have spread it to every depth. It now resolves to the non-null member.
- **`ARRAY` always gets `items`.** Google's `Schema` documents `items` as the element schema for `ARRAY`; an `ARRAY` with no element schema tells the model nothing. When a schema declares `array` without `items`, the converter emits `items: {type: STRING}` rather than a bare `ARRAY`. That is a lossy default, and the honest alternative is to reject a tool declaration that cannot be represented and report the failing schema path. I kept the permissive fallback because it is strictly more information than the current `type: STRING` and changes no tool from working to unavailable, but I am happy to switch if you would rather fail loud.
- **`required` is polymorphic on `ClineToolSpecParameter`.** `mcpToolToClineToolSpec` sets `required` to a boolean, then its catch-all key loop copies the child schema's `required` array over the top, because `required` is not in that loop's exclusion list. The recursion guards with `Array.isArray` so it emits a nested `required` list only when there genuinely is one.

## What did not change

- Built-in (non-MCP) tools. Nothing under `system-prompt/tools/` declares `array`, `items`, nested `properties` or `enum`, so their declarations are byte-identical. `__snapshots__/vertex_gemini3.tools.snap` matches without updating.
- The OpenAI and Anthropic converters, and `mcpToolToClineToolSpec`.
- `main` is unaffected and needs no companion PR. The whole `system-prompt/` tree was removed there in 94f5a47a5; the SDK path builds Gemini tools through `jsonSchema()` with no type map, so this defect does not exist on that branch. This PR is legacy-extension only.

## Limitations / not addressed here

- **`param.required` truthiness.** Because of the clobbering above, `if (param.required)` marks a parameter required whenever its *nested* schema has a non-empty `required` list, even when the parameter itself is optional. It affects all three converters identically and needs a change in `ClineToolSet.ts`, so it is out of scope here. Happy to open a follow-up.
- `anyOf` and unresolved `$ref` nodes have no `type` and still fall through to `STRING`.
- `enum` values are passed through as-is. Google types `Schema.enum` as `string[]`, so a numeric enum is emitted as numbers. I did not coerce, because I could not confirm from the docs that the API rejects it, and rewriting a tool author's schema on an unverified assumption seemed worse than leaving it.

### Test Procedure

Five cases added to the existing `describe("toolSpecFunctionDeclarations (Gemini)")` neighbourhood in `__tests__/spec.test.ts`, all of which fail on the current branch and pass with this change. The first asserts the full converted schema with a single `deep.equal` against the shape transcribed from the issue, so a stray or missing key fails it.

```
cd apps/vscode
npm ci

# the changed file, before the fix: 6 passing, 5 failing
# after the fix: 11 passing, 0 failing
npx cross-env TS_NODE_PROJECT=./tsconfig.unit-test.json mocha --no-config \
  --require ts-node/register --require source-map-support/register \
  --require ./src/test/requires.ts --extension ts \
  src/core/prompts/system-prompt/__tests__/spec.test.ts

npm run test:unit    # 1572 passing, 4 pending, 0 failing (1567 on the branch tip, +5 new)
npx tsc --noEmit     # clean
npm run lint         # 1379 files, clean
```

`npm run test:unit` includes the system-prompt snapshot suite; `vertex_gemini3.tools.snap` matches without `--update-snapshots`.

I did not run `npm run format`, because it passes `--changed --since main` and this branch is based on `legacy-extension`, which makes the compared file set meaningless here. I ran biome directly on the two touched files instead, and it reported no changes needed.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore
-   [x] Tests are passing and code is formatted and linted
-   [x] I have reviewed contributor guidelines

### Screenshots

No visual change is intended.

### Additional Notes

Based on `legacy-extension`, not `main` — please review it against that base.