### PR TITLE
﻿fix(mcp): keep the toggle state when enabling a server cannot reconnect

### DIFF
--- a/apps/vscode/src/services/mcp/McpHub.ts
+++ b/apps/vscode/src/services/mcp/McpHub.ts
@@ -1339,8 +1339,14 @@ export class McpHub {
 			// deleteConnection preserves OAuth state.
 			const mcpServers = config.mcpServers as Record<string, McpServerConfig>
 			const newConfig = mcpServers[serverName]
-			await this.deleteConnection(serverName)
-			await this.connectToServer(serverName, newConfig, "rpc")
+			try {
+				await this.deleteConnection(serverName)
+				await this.connectToServer(serverName, newConfig, "rpc")
+			} catch (error) {
+				Logger.error(`Failed to rebuild connection for ${serverName} after toggle:`, error)
+				// connectToServer registered a disconnected entry carrying
+				// the error; the webview must be told about it.
+			}
 
 			// Refresh the SDK session's tool list to reflect the server
 			// appearing or disappearing.

--- a/apps/vscode/src/services/mcp/__tests__/McpHub.connectFailure.test.ts
+++ b/apps/vscode/src/services/mcp/__tests__/McpHub.connectFailure.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { StateManager } from "@core/storage/StateManager"
 import sinon from "sinon"
+import { HostProvider } from "@/hosts/host-provider"
 import { McpHub } from "../McpHub"
 
 /**
@@ -90,5 +94,53 @@ describe("McpHub connect failure", () => {
 		// The final notification must fire so the webview leaves "connecting"
 		// and shows the errored entry.
 		expect(((hub as any).notifyWebviewOfServerChanges as sinon.SinonStub).callCount).toBeGreaterThanOrEqual(2)
+	})
+
+	it("keeps the server enabled when enabling it cannot reconnect", async () => {
+		const tempDir = await mkdtemp(join(tmpdir(), "mcp-toggle-connect-failure-"))
+		try {
+			const serverConfig = {
+				type: "stdio",
+				command: "this-command-does-not-exist-anywhere",
+				args: [],
+				timeout: 60,
+				disabled: true,
+			}
+			const settingsPath = join(tempDir, "cline_mcp_settings.json")
+			await writeFile(settingsPath, JSON.stringify({ mcpServers: { "broken-server": serverConfig } }), "utf8")
+
+			// A regression that restores the rethrow lands in the outer catch, which
+			// calls HostProvider.window.showMessage; stub the static getter so that
+			// failure reports the connection error rather than an uninitialized host.
+			sandbox.stub(HostProvider, "window").get(() => ({ showMessage: sinon.stub().resolves({}) }))
+
+			const hub = createHub()
+			;(hub as any).getSettingsDirectoryPath = async () => tempDir
+			;(hub as any).connections = [
+				{
+					server: {
+						name: "broken-server",
+						config: JSON.stringify(serverConfig),
+						status: "disconnected",
+						disabled: true,
+					},
+					client: null,
+					transport: null,
+				},
+			]
+
+			const servers = await hub.toggleServerDisabledRPC("broken-server", false)
+
+			const server = servers.find((entry) => entry.name === "broken-server")
+			expect(server).toBeDefined()
+			expect(server?.disabled).toBe(false)
+			expect(server?.status).toBe("disconnected")
+			expect((server?.error ?? "").length).toBeGreaterThan(0)
+
+			const persisted = JSON.parse(await readFile(settingsPath, "utf8"))
+			expect(persisted.mcpServers["broken-server"].disabled).toBe(false)
+		} finally {
+			await rm(tempDir, { recursive: true, force: true })
+		}
 	})
 })


### PR DESCRIPTION
### Related Issue

**Issue:** #12013

This addresses one of the two problems reported there, not both. See Description.

### Description

The issue reports two things and this PR only fixes one of them.

The `MCP error -32000: Connection closed` string is not Cline's. It is a raw
`McpError(ErrorCode.ConnectionClosed)` from the MCP TypeScript SDK, so why a given server's
transport dies is out of scope here. That is why this links the issue rather than closing it.

What this does fix is the second half, the part that makes the failure unrecoverable: after a
failed enable, the persisted setting and the UI disagree.

**Root cause.** `McpHub.toggleServerDisabledRPC` writes `disabled` to `cline_mcp_settings.json`
under the cross-process lock, and that write succeeds. It then rebuilds the connection via
`deleteConnection` + `connectToServer`. `connectToServer`'s outer catch sets
`status = "disconnected"`, appends the error, and rethrows every non-OAuth failure, so
`notifyWebviewOfServerChanges()` and the `return this.getSortedMcpServers(...)` never run.

Two consequences:

- The modal says `Failed to update server state`, which is inaccurate. The state was persisted;
  only the reconnect failed.
- `toggleMcpServer` rethrows to the webview, where `handleToggleMcpServer` in `ServerRow.tsx` only
  `console.error`s and never calls `setMcpServers`. The toggle snaps back to off while the file on
  disk says `disabled: false`. That is the reported "remains disconnected and cannot be enabled".

**Why this looks like an oversight rather than a deliberate choice.** The four other
connection-rebuild paths all swallow connect failures and still notify the webview:

| Method | On connect failure |
|---|---|
| `restartConnectionRPC` | `Logger.error`, falls through |
| `restartConnection` | `Logger.error` + modal, falls through |
| `updateServerConnectionsRPC` | `Logger.error`, sets `connectionChangesOccurred` |
| `updateServerConnections` | same |

`toggleServerDisabledRPC` is the only one that rethrows.

In #11529 the `catch`/modal/`throw` block appears as unchanged context. Before that PR the `try`
body held only the read, the write and an in-memory flag flip: there was no `connectToServer` call
inside it at all. #11529 moved the rebuild into a `try` whose `catch` had been written for
settings-write failures.

#12546 then added to the two `updateServerConnections*` paths the comment "connectToServer
registered a disconnected entry carrying the error; the webview must be told about it", and
hardened `callTool` for exactly that residual state. So the disconnected-entry steady state is
already designed for. The toggle just never got the same treatment.

**The change.** Wrap only `deleteConnection` + `connectToServer` in a local try/catch that logs and
falls through. The settings-write and server-not-found paths keep their existing throw and modal,
since those are the cases where the state genuinely did not change.

No modal is added for the reconnect failure, matching `restartConnectionRPC`. The discriminator
between the siblings is the return channel: `restartConnection` returns `Promise<void>` and is
driven by the file watcher, so it has no way to reach the webview and narrates in modals.
`restartConnectionRPC` and `toggleServerDisabledRPC` both return `McpServer[]` to the same
`ServerRow`, which renders the error text, a red status dot and a Retry Connection button. That
inline channel carries more than the modal did.

### Test Procedure

Added a case to `apps/vscode/src/services/mcp/__tests__/McpHub.connectFailure.test.ts`. It seeds a
real temp `cline_mcp_settings.json` with the server disabled, then enables a server whose `command`
cannot spawn, so the real transport failure path runs rather than a stub. It asserts the RPC
resolves, that the returned server is `disabled: false` / `status: "disconnected"` with non-empty
error text, and that the settings file on disk persisted `disabled: false`.

```
cd apps/vscode && bun test src/services/mcp/__tests__/McpHub.connectFailure.test.ts
```

On main it fails, rejecting with the issue's own error out of the SDK's stdio transport:

```
McpError: MCP error -32000: Connection closed
 code: -32000,
      at fromError (@modelcontextprotocol/sdk/dist/esm/types.js:2048:20)
      at _onclose (@modelcontextprotocol/sdk/dist/esm/shared/protocol.js:356:13)
      at @modelcontextprotocol/sdk/dist/esm/client/stdio.js:160:109
 2 pass
 1 fail
```

With this change: `3 pass, 0 fail`.

**What could break and how I checked.** The concern is swallowing something that should surface.
`deleteConnection` is inside the new try, but it already swallows its own transport/client close
errors and its remaining statements cannot throw, so it adds no swallow surface. The outer catch
still guards the mutator's "server not found" throw and the post-write validation throw, both of
which happen before the new try, and `finally { this.isConnecting = false }` is untouched. The
disable direction is unaffected because `connectToServer` returns early for a disabled config and
cannot throw there.

Ran the other six MCP suites per file (the runner spawns one process per file):
`McpHub.callTool` 24, `McpHub.deleteServerRPC` 5, `McpHub.timeoutReconnect` 2,
`McpHub.toolListChange` 19, `schemas` 15, `StreamableHttpReconnectHandler` 14, all passing.
`bun run ci:check-all` is clean.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Refactor Changes
-   [ ] Cosmetic Changes
-   [ ] Documentation update
-   [ ] Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Backend/state change with no UI code touched, so terminal output rather than screenshots. The
before/after is in the Test Procedure section above.

The user-visible effect: enabling a server that cannot connect previously showed a
"Failed to update server state" modal and the toggle flipped back to off while
`cline_mcp_settings.json` said `disabled: false`. Now the toggle stays on and the row shows the
transport error with the existing Retry Connection button.

### Additional Notes

`toggleLocalMarketplaceInstalledEntry` also calls this RPC, and its webview handler uses the
rejection as its only failure signal. That path cannot currently request an enable:
`McpHub.getServers()` filters out disabled servers, so every MCP marketplace entry reports
`enabled: true` and both switches can only send `disabled: true`, which cannot throw. Flagging it
since it would matter if that visibility behaviour ever changes.

Unrelated observation while working here: `__tests__/McpHub.toggleServerDisabledRPC.test.ts`
imports from `mocha`, and no configured runner picks it up. `run-bun-unit-tests.ts` keeps only
`bun:test` files, `.vscode-test.mjs` excludes `src/**/__tests__/**`, and `vitest.config.ts` lists
only `settingsLock.test.ts` from that directory. Left alone here, but a regression test added to
that file would silently never run.