### PR TITLE
fix(core): exclude storage metadata from compaction token estimates

### DIFF
--- a/sdk/packages/core/src/extensions/context/compaction-shared.ts
+++ b/sdk/packages/core/src/extensions/context/compaction-shared.ts
@@ -2,6 +2,7 @@ import type { ModelInfo, ToolResultContent } from "@cline/llms";
 import {
 	CHARS_PER_TOKEN,
 	estimateTokens,
+	type Message,
 	type MessageWithMetadata,
 } from "@cline/shared";
 
@@ -176,6 +177,17 @@ export function serializeConversation(messages: MessageWithMetadata[]): string {
 	return messages.map(serializeMessage).join("\n\n").trim();
 }
 
+/**
+ * Reduce a stored message to the shape that actually reaches the provider.
+ *
+ * `MessageWithMetadata` extends `Message` with storage/history fields (`id`,
+ * `sessionId`, `metadata`, `modelInfo`, `metrics`, `ts`) that are stripped
+ * before the request is built, so token accounting must ignore them.
+ */
+export function toPayloadMessage(message: MessageWithMetadata): Message {
+	return { role: message.role, content: message.content };
+}
+
 export function createTokenEstimator(): EstimateMessageTokens {
 	const cache = new WeakMap<object, number>();
 	return (message) => {
@@ -186,7 +198,7 @@ export function createTokenEstimator(): EstimateMessageTokens {
 		}
 		let serialized: string;
 		try {
-			serialized = JSON.stringify(message);
+			serialized = JSON.stringify(toPayloadMessage(message));
 		} catch {
 			serialized = serializeMessage(message);
 		}

--- a/sdk/packages/core/src/extensions/context/compaction.test.ts
+++ b/sdk/packages/core/src/extensions/context/compaction.test.ts
@@ -16,6 +16,7 @@ import {
 	createContextCompactionPrepareTurn,
 } from "./compaction";
 import {
+	buildSummaryMessage,
 	createTokenEstimator,
 	estimateTokens,
 	resolveEffectiveMaxInputTokens,
@@ -60,9 +61,25 @@ describe("createTokenEstimator", () => {
 				outputTokens: 7,
 			},
 		};
+		const heavierMetrics: MessageWithMetadata = {
+			role: "assistant",
+			content: "short",
+			metrics: {
+				inputTokens: 900_000,
+				cacheReadTokens: 800_000,
+				outputTokens: 70_000,
+			},
+		};
 
 		expect(estimateMessageTokens(message)).toBe(
-			Math.ceil(JSON.stringify(message).length / 3),
+			Math.ceil(
+				JSON.stringify({ role: "assistant", content: "short" }).length / 3,
+			),
+		);
+		// The contract is content, not metrics: identical content costs the same
+		// no matter what usage numbers the message happens to carry.
+		expect(estimateMessageTokens(heavierMetrics)).toBe(
+			estimateMessageTokens(message),
 		);
 	});
 
@@ -75,9 +92,45 @@ describe("createTokenEstimator", () => {
 				inputTokens: 12,
 			},
 		};
+		const withoutMetrics: MessageWithMetadata = {
+			role: "assistant",
+			content: "short",
+		};
 
 		expect(estimateMessageTokens(message)).toBe(
-			Math.ceil(JSON.stringify(message).length / 3),
+			Math.ceil(
+				JSON.stringify({ role: "assistant", content: "short" }).length / 3,
+			),
+		);
+		expect(estimateMessageTokens(withoutMetrics)).toBe(
+			estimateMessageTokens(message),
+		);
+	});
+
+	it("bills a compaction summary once, not twice via its metadata copy", () => {
+		const estimateMessageTokens = createTokenEstimator();
+		const summary = "## Goal\nShip the fix\n\n## Files\nsrc/index.ts";
+		const summaryMessage = buildSummaryMessage({
+			summary,
+			fileOps: { readFiles: ["src/index.ts"], modifiedFiles: [] },
+			tokensBefore: 4_096,
+			userRunSpan: 3,
+		});
+
+		// buildSummaryMessage writes the summary into content[0].text and copies
+		// the same string into metadata.summary. Only the content half is sent to
+		// the provider, so charging for both inflates tokensAfter and can report
+		// a compaction as growth.
+		expect(estimateMessageTokens(summaryMessage)).toBe(
+			Math.ceil(
+				JSON.stringify({
+					role: summaryMessage.role,
+					content: summaryMessage.content,
+				}).length / 3,
+			),
+		);
+		expect(estimateMessageTokens(summaryMessage)).toBeLessThan(
+			Math.ceil(JSON.stringify(summaryMessage).length / 3),
 		);
 	});
 });
@@ -2972,6 +3025,85 @@ describe("createContextCompactionPrepareTurn", () => {
 		expect(result?.messages).toEqual([
 			{ role: "user", content: "Compacted manually" },
 		]);
+	});
+
+	it("keeps request overhead free of message metadata", async () => {
+		const compact = vi.fn((_context: CoreCompactionContext) => ({
+			messages: [{ role: "user" as const, content: "Compacted manually" }],
+		}));
+		const prepareTurn = createContextCompactionPrepareTurn(
+			{
+				providerId: "anthropic",
+				modelId: "mock-model",
+				providerConfig: {
+					providerId: "anthropic",
+					modelId: "mock-model",
+				} as LlmsProviders.ProviderConfig,
+				compaction: { enabled: true, compact },
+				logger: undefined,
+			},
+			{ mode: "manual" },
+		);
+
+		// Mirrors apps/vscode/src/sdk/sdk-compaction.ts, which compacts with an
+		// empty system prompt and no tools. Overhead is the difference between
+		// the whole-request estimate and the summed per-message estimates, so
+		// both sides have to measure the same thing or storage-only fields land
+		// in the overhead term and shrink the message budget.
+		const messages: MessageWithMetadata[] = [
+			{
+				role: "user",
+				content: "Review the attached file",
+				id: "msg-1",
+				sessionId: "session-1",
+				ts: 1_753_000_000_000,
+				metadata: { source: "at-mention", path: "src/index.ts" },
+			},
+			{
+				role: "assistant",
+				content: "Reviewed it.",
+				id: "msg-2",
+				sessionId: "session-1",
+				ts: 1_753_000_000_001,
+				modelInfo: { id: "mock-model", provider: "anthropic" },
+				metrics: {
+					inputTokens: 2_800,
+					outputTokens: 120,
+					cacheReadTokens: 2_400,
+				},
+			},
+		];
+
+		await prepareTurn?.({
+			agentId: "agent-1",
+			conversationId: "conv-1",
+			parentAgentId: null,
+			iteration: 1,
+			abortSignal: new AbortController().signal,
+			systemPrompt: "",
+			tools: [],
+			messages,
+			apiMessages: messages,
+			model: {
+				id: "mock-model",
+				provider: "anthropic",
+				info: { id: "mock-model", maxInputTokens: 100 },
+			},
+		});
+
+		expect(compact).toHaveBeenCalledTimes(1);
+		const context = compact.mock.calls[0]?.[0];
+		// With no system prompt and no tools, the only honest remainder is the
+		// JSON framing around an empty request, plus at most one rounding token
+		// per message.
+		const framingOnly = estimateRequestInputTokens({
+			systemPrompt: "",
+			messages: [],
+			tools: [],
+		});
+		expect(context?.budget.request.overheadTokens).toBeLessThanOrEqual(
+			framingOnly + messages.length,
+		);
 	});
 
 	it("manual mode lowers the agentic preserve budget below the default floor", async () => {

--- a/sdk/packages/core/src/extensions/context/compaction.ts
+++ b/sdk/packages/core/src/extensions/context/compaction.ts
@@ -28,6 +28,7 @@ import {
 	DEFAULT_PRESERVE_RECENT_TOKENS,
 	DEFAULT_TARGET_RATIO,
 	resolveEffectiveMaxInputTokens,
+	toPayloadMessage,
 } from "./compaction-shared";
 
 export interface ContextPipelinePrepareTurnInput {
@@ -286,9 +287,12 @@ export function createContextCompactionPrepareTurn(
 			(total: number, message) => total + estimateMessageTokens(message),
 			0,
 		);
+		// Project to the provider payload so this matches apiMessageTokens above:
+		// requestOverheadTokens is their difference and only isolates the system
+		// prompt and tools when both sides measure the same thing.
 		const requestInputTokens = estimateRequestInputTokens({
 			systemPrompt: context.systemPrompt,
-			messages: context.apiMessages,
+			messages: context.apiMessages.map(toPayloadMessage),
 			tools: context.tools,
 		});
 		const messageInputTokens = context.messages.reduce(


### PR DESCRIPTION
### Related Issue

Refs #12703

This fixes the token-accounting half of that report. The message-count half is a
separate mechanism and is not addressed here, so the issue should stay open.

### Description

## The problem

Compacting a short conversation could report the context growing rather than
shrinking. In #12703 our QA saw a manual compaction move the count from 2.8K to
3.4K.

`createTokenEstimator` in `sdk/packages/core/src/extensions/context/compaction-shared.ts`
measures a message with `JSON.stringify(message).length / 3` over the whole
`MessageWithMetadata`. But `MessageWithMetadata` extends `Message` purely to add
storage fields — `id`, `agent`, `sessionId`, `metadata`, `modelInfo`, `metrics`,
`ts` — under its own docstring, "used for storage/history". None of them reach
the model: `toAiSdkMessages` in `sdk/packages/llms/src/providers/ai-sdk.ts` pushes
`{ role, content }` and nothing else.

That over-count is not uniform, which is what turns it into visible growth.
`buildSummaryMessage` writes the summary into `content[0].text` and copies the
same string into `metadata.summary`, then adds `details`, `tokensBefore`,
`generatedAt`, `kind`, `displayRole` and `userRunSpan`. `runAgenticCompaction`
computes `tokensBefore` over the original messages and `tokensAfter` over
`[summary, ...messages.slice(cutIndex)]` using that same estimator, so the new
summary is billed far above its real cost while the messages it replaced were
billed closer to theirs. Measured on a representative summary: real prompt cost
40 tokens, estimated 123.

## The fix

Add `toPayloadMessage()`, which reduces a stored message to the base `Message`
shape, and estimate that instead.

The second half is not optional. `requestOverheadTokens` is computed as
`requestInputTokens - apiMessageTokens`, and that subtraction only isolates the
system prompt and tools because both sides currently serialize whole message
objects. Changing only the per-message estimator makes the overhead term absorb
the entire metadata mass, which then flows through
`translateRequestBudgetToMessages` into `messageTriggerTokens` and
`messageTargetTokens`. So `estimateRequestInputTokens` is fed the same
projection.

I measured that intermediate state rather than assuming it: with only the
estimator changed, overhead on a two-message transcript went from 15 to 114
tokens, which drives `translateRequestBudgetToMessages(90, 114)` to its floor of
1. The added test `keeps request overhead free of message metadata` is there to
keep the two sides from drifting apart again.

## Non-obvious details

- The `catch` fallback in `createTokenEstimator` already called
  `serializeMessage`, which only ever walked `role` and `content`. The fallback
  path was payload-only all along; the primary path was the outlier. This makes
  the two agree.
- The `WeakMap` cache still keys off the original `message` reference, not the
  projection, so caching behaviour is unchanged.
- `toPayloadMessage` stays in `@cline/core` rather than moving next to
  `estimateRequestInputTokens` in `@cline/shared`, since both call sites are in
  `compaction.ts` and this avoids widening a published package's public surface.

## What could break

`shouldCompact` is `requestInputTokens >= requestTriggerTokens`, and
`requestInputTokens` now drops by the metadata mass, so **auto-compaction
triggers slightly later than before**. That is the intended correction, and the
safety margin is preserved twice over: `CHARS_PER_TOKEN` is 3 rather than the
conventional 4, and `COMPACTION_TRIGGER_RATIO` is 0.9. The estimate is still
deliberately conservative, just no longer conservative about bytes that are
never sent.

## What did not change

- No change to `CHARS_PER_TOKEN`, `estimateTokens`, or `estimateRequestInputTokens`
  itself.
- No change to `findCutIndex`, the cut-boundary safety rules, or tool_use /
  tool_result pairing.
- No change to `buildSummaryMessage`. `metadata.summary` is still written,
  because `getCompactionSummaryMetadata` reads it and the webview renders it. It
  is simply no longer billed as prompt tokens.
- No change to the display layer. In particular the `tokensAfter / tokensBefore`
  ratio in `getApiMetrics.ts` is still deliberately unclamped, per the comment
  there.

## Out of scope

The "message count remains unchanged" half of #12703 is a different mechanism:
`resolveManualMessageTargetTokens` sets the manual target at half the transcript,
and when an at-mentioned file makes the first message dominate, `findCutIndex`
lands the cut at index 1 and `runAgenticCompaction` returns
`[summary, ...messages.slice(1)]`, so N messages in gives N out. That needs a
change to the cut logic and belongs in its own PR, so this one links the issue
without closing it.

### Test Procedure

Added a regression test that pins the actual defect, and a guard test for the
overhead coupling. The two existing `createTokenEstimator` tests asserted
`estimateMessageTokens(message) === Math.ceil(JSON.stringify(message).length / 3)`.
Their names and fixtures are unchanged; the expected value now uses the payload
projection, and each gained an assertion that identical content costs the same
regardless of the metrics attached. That is the contract #12022 described when it
added them ("keep basic compaction's per-message estimator based on serialized
message content"), now enforced structurally rather than by convention.

Red-to-green, run at each stage:

| Stage | `bills a compaction summary once` | `keeps request overhead free of message metadata` |
| --- | --- | --- |
| Before any change | FAIL (123 vs 40) | pass |
| Estimator projected, request estimator not | pass | FAIL (114, bound 17) |
| Both projected (this PR) | pass | pass |

```
cd sdk/packages/core
bunx vitest run --config vitest.config.ts src/extensions/context/compaction.test.ts
# Test Files  1 passed (1)
# Tests  66 passed (66)

bun run types
# exit 0, all workspaces

bun run lint
# exit 0, 0 errors
```

Note on the wider `bun -F @cline/core test:unit` suite: it has a pre-existing
flaky failure set in the process/Git/SQLite-backed tests (plugin-loader, bash
executor, runtime-builder, handler-factory, local-runtime-bootstrap,
settings-service and similar). I confirmed those are not from this change by
stashing the diff and re-running the same files on an unmodified checkout, where
they fail at least as often. Nothing under `src/extensions/context/` is affected.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Refactor Changes
-   [ ] Cosmetic Changes
-   [ ] Documentation update
-   [ ] Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

No visual change is intended. The fix changes the numbers reported on the
compaction divider row, not the UI that renders them.

### Additional Notes

Diff is 17 added and 2 removed lines across two source files, plus the tests.