### PR TITLE
fix(llms): send reasoning_effort=none for direct OpenAI chat completions

### DIFF
--- a/sdk/packages/llms/src/providers/model-facts.ts
+++ b/sdk/packages/llms/src/providers/model-facts.ts
@@ -446,6 +446,21 @@ export function isOllamaQwen3ModelIdFallback(
 	);
 }
 
+const OPENAI_NONE_EFFORT_MODEL_ID = /^gpt-5[.-]6(?:[-.]|$)/;
+
+export function isOpenAiDirectNoneEffortModel(options: {
+	request: Pick<GatewayStreamRequest, "modelId">;
+	context: GatewayProviderContext;
+}): boolean {
+	// models.dev advertises "none" as an effort value for the GPT-5.6 family
+	// only, so this mirrors that catalog fact for models typed into an
+	// OpenAI-compatible provider, which carry no catalog entry to read it from.
+	return (
+		isProviderBaseOrigin(options.context, "https://api.openai.com") &&
+		OPENAI_NONE_EFFORT_MODEL_ID.test(normalizedModelId(options.request))
+	);
+}
+
 export function isCerebrasProvider(
 	request: Pick<GatewayStreamRequest, "providerId">,
 	context: GatewayProviderContext,

--- a/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
@@ -7,6 +7,7 @@ import {
 	isKimiK26Family as isKimiK26FamilyFact,
 	isMiniMaxM3Model,
 	isMoonshotKimiModelIdFallback,
+	isOpenAiDirectNoneEffortModel,
 	providerReasoningRouteMatches,
 } from "../model-facts";
 import { buildGatewayReasoningOptions } from "./anthropic-compatible";
@@ -443,6 +444,26 @@ const ollamaNativeOptionsRule: ProviderOptionRule = {
 	},
 };
 
+const openAiCompatibleDisabledReasoningRule: ProviderOptionRule = {
+	id: "provider.openai-compatible.openai-origin.disable-none",
+	phase: "provider-reasoning",
+	description:
+		"api.openai.com chat/completions rejects function tools for GPT-5.6 unless reasoning_effort is none, and the portable reasoning option deliberately drops none, so send it through provider options.",
+	applies: (input) =>
+		input.target === "openai-compatible" &&
+		input.request.reasoning?.enabled === false &&
+		isOpenAiDirectNoneEffortModel({
+			request: input.request,
+			context: input.context,
+		}),
+	build: (input) =>
+		buildProviderAndAliasPatch({
+			providerId: input.request.providerId,
+			providerOptionsKey: input.providerOptionsKey,
+			bucketOptions: { reasoningEffort: "none" },
+		}),
+};
+
 const nonGlmProviderRoutingSuppressionRule: ProviderOptionRule = {
 	id: "provider.routing.glm-thinking.non-glm.suppress-generic-thinking",
 	phase: "provider",
@@ -525,6 +546,7 @@ export const PROVIDER_OPTION_RULES: ReadonlyArray<ProviderOptionRule> = [
 	kimiK26ThinkingRule,
 	deepSeekThinkingRule,
 	ollamaNativeOptionsRule,
+	openAiCompatibleDisabledReasoningRule,
 	nonGlmProviderRoutingSuppressionRule,
 	nativeZaiGlmThinkingRule,
 	miniMaxThinkingRule,

--- a/sdk/packages/llms/src/providers/routing/provider-options.test.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-options.test.ts
@@ -29,6 +29,7 @@ type ContextOverrides = {
 	modelMetadata?: NonNullable<GatewayProviderContext["model"]["metadata"]>;
 	capabilities?: GatewayProviderContext["model"]["capabilities"];
 	metadata?: GatewayProviderContext["provider"]["metadata"];
+	baseUrl?: string;
 	/** Test helper escape hatch for Claude-like models that should not get an auto-injected Anthropic reasoning route. */
 	disableAutoAnthropicRouting?: boolean;
 };
@@ -99,7 +100,10 @@ function makeContext(options?: ContextOverrides): GatewayProviderContext {
 			capabilities: options?.capabilities,
 			metadata: modelMetadata,
 		},
-		config: { providerId },
+		config: {
+			providerId,
+			...(options?.baseUrl ? { baseUrl: options.baseUrl } : {}),
+		},
 	};
 }
 
@@ -2024,6 +2028,109 @@ describe("composeAiSdkProviderOptions: family/provider thinking patches", () => 
 					lacks: ["think", "reasoningEffort", "reasoning"],
 				},
 				{ bucket: "openaiCompatible", lacks: ["think", "reasoning"] },
+			],
+		},
+		// api.openai.com over chat/completions rejects function tools for
+		// GPT-5.6 unless reasoning_effort is none, and the portable reasoning
+		// option drops none, so it has to travel through provider options.
+		// models.dev advertises none for the GPT-5.6 family only.
+		{
+			name: "openai-compatible direct OpenAI gpt-5.6 disabled -> reasoningEffort none",
+			request: {
+				providerId: "openai-compatible",
+				modelId: "gpt-5.6-luna",
+				reasoning: { enabled: false },
+			},
+			context: { baseUrl: "https://api.openai.com/v1" },
+			expect: [
+				{ bucket: "openai-compatible", has: { reasoningEffort: "none" } },
+				{ bucket: "openaiCompatible", has: { reasoningEffort: "none" } },
+			],
+		},
+		{
+			name: "openai-compatible direct OpenAI dashed gpt-5-6 id disabled -> reasoningEffort none",
+			request: {
+				providerId: "openai-compatible",
+				modelId: "gpt-5-6-terra",
+				reasoning: { enabled: false },
+			},
+			context: { baseUrl: "https://api.openai.com/v1" },
+			expect: [
+				{ bucket: "openai-compatible", has: { reasoningEffort: "none" } },
+			],
+		},
+		{
+			name: "openai-compatible non-OpenAI base url disabled -> no reasoningEffort",
+			request: {
+				providerId: "litellm",
+				modelId: "gpt-5.6-luna",
+				reasoning: { enabled: false },
+			},
+			context: { baseUrl: "https://proxy.internal.example/v1" },
+			expect: [
+				{ bucket: "litellm", lacks: ["reasoningEffort"] },
+				{ bucket: "openaiCompatible", lacks: ["reasoningEffort"] },
+			],
+		},
+		{
+			name: "non-compatible target on an OpenAI base url disabled -> no reasoningEffort",
+			request: {
+				providerId: "dify",
+				modelId: "gpt-5.6-luna",
+				reasoning: { enabled: false },
+			},
+			context: { baseUrl: "https://api.openai.com/v1" },
+			expect: [{ bucket: "dify", lacks: ["reasoningEffort"] }],
+		},
+		{
+			name: "openai-compatible direct OpenAI gpt-5.5 disabled -> no reasoningEffort",
+			request: {
+				providerId: "openai-compatible",
+				modelId: "gpt-5.5",
+				reasoning: { enabled: false },
+			},
+			context: { baseUrl: "https://api.openai.com/v1" },
+			expect: [
+				{ bucket: "openai-compatible", lacks: ["reasoningEffort"] },
+				{ bucket: "openaiCompatible", lacks: ["reasoningEffort"] },
+			],
+		},
+		{
+			name: "openai-compatible direct OpenAI o-series disabled -> no reasoningEffort",
+			request: {
+				providerId: "openai-compatible",
+				modelId: "o3-mini",
+				reasoning: { enabled: false },
+			},
+			context: { baseUrl: "https://api.openai.com/v1" },
+			expect: [
+				{ bucket: "openai-compatible", lacks: ["reasoningEffort"] },
+				{ bucket: "openaiCompatible", lacks: ["reasoningEffort"] },
+			],
+		},
+		{
+			name: "openai-compatible direct OpenAI unset reasoning -> no reasoningEffort",
+			request: {
+				providerId: "openai-compatible",
+				modelId: "gpt-5.6-luna",
+			},
+			context: { baseUrl: "https://api.openai.com/v1" },
+			expect: [
+				{ bucket: "openai-compatible", lacks: ["reasoningEffort"] },
+				{ bucket: "openaiCompatible", lacks: ["reasoningEffort"] },
+			],
+		},
+		{
+			name: "openai-compatible direct OpenAI enabled reasoning -> no reasoningEffort",
+			request: {
+				providerId: "openai-compatible",
+				modelId: "gpt-5.6-luna",
+				reasoning: { enabled: true, effort: "high" },
+			},
+			context: { baseUrl: "https://api.openai.com/v1" },
+			expect: [
+				{ bucket: "openai-compatible", lacks: ["reasoningEffort"] },
+				{ bucket: "openaiCompatible", lacks: ["reasoningEffort"] },
 			],
 		},
 	]);


### PR DESCRIPTION
### Related Issue

Fixes #12798

### Description

Selecting `gpt-5.6-luna` on the **OpenAI Compatible** provider fails with a 400 from OpenAI, and setting Reasoning Effort to None does not help:

> 400 Function tools with reasoning_effort are not supported for gpt-5.6-luna in /v1/chat/completions. To use function tools, use /v1/responses or set reasoning_effort to 'none'.

## The problem

OpenAI wants an **explicit** `reasoning_effort: "none"` here. Omitting the field is not the same thing: OpenAI then applies its own default and rejects the request.

Cline omits it. In `buildCompatibleEffortOptions` (`routing/generic-compatible.ts`), the `"none"` branch is gated on `controls?.effort?.values.includes("none")`, where `controls` is `getModelReasoningControls(context.model.reasoningOptions)`. That returns `undefined` whenever `reasoningOptions` is undefined, and `reasoningOptions` is only populated by the live models.dev fetch — `catalog.generated.ts` carries zero of them, and a model typed into OpenAI Compatible has no catalog entry at all. So on this route `controls` is always `undefined` and the branch can never fire.

The chain for "Reasoning Effort: None":

1. `normalizeProviderReasoningSettings` (`apps/vscode/src/sdk/cline-session-factory.ts`) maps None to `{ thinking: false }`, deliberately carrying no effort
2. that becomes `reasoning: { enabled: false }` on the gateway request
3. `buildCompatibleEffortOptions` returns `{}` because `controls` is `undefined`
4. nothing reaches the wire, OpenAI applies its default, the function tools are rejected

## The fix

One rule in `PROVIDER_OPTION_RULES` emitting `reasoningEffort: "none"`, which `@ai-sdk/openai-compatible` serialises as `reasoning_effort`. It fires only when all of:

- the options target is `openai-compatible`, so the native `openai-native` Responses route is untouched
- the resolved base URL origin is `https://api.openai.com`, via the existing `isProviderBaseOrigin` helper that `isCerebrasProvider` already uses
- the model id is in the GPT-5.6 family
- reasoning is **explicitly** disabled

## Why the scope is GPT-5.6 and not "OpenAI reasoning models"

Because that is what the catalog says. In models.dev, `gpt-5.6-sol` advertises `["none","low","medium","high","xhigh","max"]`, while `gpt-5.5`, `gpt-5.4`, `gpt-5`, `gpt-5.1`, `gpt-5-mini` and the whole o-series (`o1`, `o3`, `o3-mini`, `o4-mini`) advertise only `["low","medium","high"]`. `none` is a GPT-5.6-family value, not a general reasoning-model value.

That matters because the fallback has to agree with the catalog. When `reasoningOptions` **is** loaded, `getModelReasoningControls` already refuses to send `none` to a model that does not list it — that is exactly what the `includes("none")` guard is for. A wider id match would contradict the catalog whenever the catalog happens to be absent, and would turn a working `o3-mini` config into a differently-broken one. So the id list mirrors the catalog fact rather than inventing a second policy.

## Why not the obvious fix

Making `buildCompatibleEffortOptions` always emit `"none"` on disable would change the wire shape for every provider using the `openai-compatible` factory — groq, together, fireworks, deepseek, litellm, lmstudio, baseten, nebius, requesty and more — and many reject an unrecognised `reasoning_effort`. I verified this empirically: widening the guard turns two pre-existing MiniMax tests red on top of the new scope tests.

## What did NOT change

- The native **OpenAI** provider, already on `/v1/responses`. Covered by a dedicated test.
- Every other OpenAI-compatible vendor. A non-OpenAI base URL never matches (groq test, same model id).
- Every OpenAI model outside GPT-5.6, including the o-series (`gpt-5.5` and `o3-mini` tests).
- Requests that leave reasoning at its default — the rule needs an explicit `enabled === false`.
- An explicitly chosen effort. `{ enabled: true, effort: "high" }` still sends `high`.

## Impact / regression risk

The rule can only add `reasoningEffort: "none"` to a request already going to `api.openai.com` over chat/completions, for a GPT-5.6 model, with reasoning explicitly off. In that state the request fails today, so the worst case is that a failing request keeps failing. Nothing else reaches the new code path.

Known limitations:

- **Azure OpenAI** serves these models from `*.openai.azure.com`, so the origin check does not fire and Azure is unchanged.
- **The default state is not fixed.** The rule needs `reasoning.enabled === false` actually persisted. A fresh user sees "None" preselected in the OpenAI Compatible panel but nothing is written to `providers.json` until the value changes, so `request.reasoning` is `undefined` and the 400 persists. The reporter's case (they explicitly changed it to None) is fixed; the untouched-default case needs the settings panel to persist its initial value, which is a separate change. Flagging it so it is not a surprise if you test the default path.
- This does not make GPT-5.6 usable **with** reasoning over chat/completions — OpenAI does not allow that alongside function tools at all. It makes the documented `none` path reachable, which is what the Reasoning Effort control already implies.

### Test Procedure

Eight rows added to the table-driven matrix in `provider-options.test.ts`, plus one standalone test for the native route.

The regression test fails on `main` and passes here. On `main` the bucket holds only `{ strictJsonSchema: false }`:

    AssertionError: expected { strictJsonSchema: false } to deeply equal ObjectContaining{…}
    - ObjectContaining {
    -   "reasoningEffort": "none",
    + {
    +   "strictJsonSchema": false,

Commands, from the repo root:

    bun -F @cline/llms test -- src/providers/routing/provider-options.test.ts
    1 file, 122 tests pass (114 before this change)

    bun -F @cline/llms test
    28 files pass, 4 skipped; 497 tests pass, 4 skipped

    bun run --cwd sdk/packages/llms typecheck
    clean

    bunx biome check <the three changed files>
    Checked 3 files. No fixes applied.

I mutation-tested each guard to confirm no assertion passes for the wrong reason:

- widen the id match to `gpt-5|o[134]` → the `gpt-5.5` and `o3-mini` rows fail
- drop the `api.openai.com` origin check → the groq row and two pre-existing MiniMax rows fail
- drop `target === "openai-compatible"` → the native-route test fails
- relax `enabled === false` to `enabled !== true` → the unset-reasoning row fails

`bun run format` reports pre-existing formatting drift in `apps/cli/**` on current `main` (`cline-pass-errors.ts`, `config-data.test.ts`, `cline-pass-errors.test.ts`). `git diff --name-only main -- apps/cli/` is empty for this branch, so I have deliberately left those alone rather than widen the diff.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

No visual change is intended; this only affects the request body sent to OpenAI.

### Additional Notes

Two of the three things reported in #12798 are deliberately not addressed:

- **The model picker.** `gpt-5.6-luna`, `gpt-5.6-sol` and `gpt-5.6-terra` are already in `catalog.generated.ts`, including in the reporter's own v4.1.2 tag, so that reads as a stale live-catalog fetch rather than a missing entry.
- **Routing GPT-5.6 to `/v1/responses` on the Compatible provider.** The native provider is already on Responses; auto-routing by model id on the Compatible provider is a product decision, so I left it for maintainers.

Orthogonal to #12717, though both touch `model-facts.ts` and `provider-options.test.ts`. Happy to rebase if that lands first.