### PR TITLE
fix(vscode): match Customize icon to the JetBrains navbar

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -140,7 +140,7 @@
 			{
 				"command": "cline.marketplaceButtonClicked",
 				"title": "Customize",
-				"icon": "$(wrench)"
+				"icon": "$(extensions)"
 			},
 			{
 				"command": "cline.historyButtonClicked",


### PR DESCRIPTION
### Related Issue

Fixes #11893

### Description

The "Customize" button shows a wrench in VS Code and a puzzle piece in JetBrains, because the two hosts source that button from different places:

- **VS Code** renders the sidebar title bar from the extension manifest. `apps/vscode/package.json:143` declares `cline.marketplaceButtonClicked` with `"icon": "$(wrench)"`, surfaced through `contributes.menus."view/title"` at `navigation@2`.
- **JetBrains** never reads the manifest. It renders `webview-ui/src/components/menu/Navbar.tsx`, where the `customize` tab uses lucide `PuzzleIcon` (`:39`). `platform-configs.json` sets `showNavbar: false` for `vscode` and `true` for `standalone`, and `ChatView.tsx:381` is the only render site, so exactly one of the two applies per host.

Both lines were introduced by the same commit, d055b0941 "feat(vscode): add marketplace (#11816)". This is an inconsistency born inside one PR, not drift between two teams.

Customize is the only one of the five title-bar buttons that disagrees:

| Order | VS Code | JetBrains | |
|---|---|---|---|
| `navigation@1` | New Task `$(add)` | `chat` `PlusIcon` | match |
| **`navigation@2`** | **Customize `$(wrench)`** | **`customize` `PuzzleIcon`** | **mismatch** |
| `navigation@3` | History `$(history)` | `history` `HistoryIcon` | match |
| `navigation@5` | Account `$(account)` | `account` `UserCircleIcon` | match |
| `navigation@6` | Settings `$(settings-gear)` | `settings` `SettingsIcon` | match |

Both entry points resolve to the same destination - `extension.ts:139` fires `sendMarketplaceButtonClickedEvent()`, which the webview turns into `navigateToMarketplace()`, exactly what `Navbar.tsx:40` calls directly - so the other four already follow a convention this one breaks.

**On the glyph, honestly:** there is no puzzle-piece codicon. `$(extensions)` is the closest available and is semantically correct (the button opens the marketplace), but its SVG is the four-square Extensions mark, not a jigsaw. So this makes the two surfaces *consistent*, not pixel-identical. If exact parity is what you want, a `contributes.icons` entry would do it - there is precedent at `package.json:49-57` for the `cline-icon` font. Happy to switch, and equally happy to close this if you would rather keep the wrench and change the navbar instead.

**What did not change.** No behaviour, no command wiring, no webview code, and `Navbar.tsx` is untouched so JetBrains is unaffected. Note `$(wrench)` was never broken - it is a registered codicon (an alias of `symbol-property` at U+EB65, which VS Code itself uses for its Refactor code actions) and rendered fine. This is a wrong-shape glyph, not a missing one.

### Test Procedure

Manual. There is no automated seam for this: nothing in the repo reads or asserts codicon ids from `contributes`, and no icon-or-title change in this repo's history has shipped a test.

Quality gate:

```
cd apps/vscode
bun run ci:check-all
```
Passes (check-types + lint + format).

```
bunx biome format --config-path ./biome.jsonc package.json
```
`Checked 1 file. No fixes applied.` Run explicitly because `bun run format` uses `--changed --since main`, which reports 0 files when the checkout is a git worktree.

Manifest still resolves:

```
node -e "console.log(require('./package.json').contributes.commands.find(c=>c.command==='cline.marketplaceButtonClicked').icon)"
# $(extensions)
```

Suites:

```
bun run test:vitest    # 76 files, 986 tests passed
bun run test:unit      # 71 files, 1034 passed, 1 failed
```

The one `test:unit` failure is `src/test/shell.test.ts` ("expands and selects the first configured profile path when it exists"), which asserts a Windows path with exact casing and fails identically on unmodified `main` on this machine because `%SystemRoot%` reports `C:\WINDOWS` rather than `C:\Windows`. Unrelated to this change; verified by re-running the file with the diff stashed.

Visually confirmed by launching the Extension Development Host (F5) and checking the Cline sidebar title bar - see screenshots.

Not run: `test:integration`. It needs a real VS Code Electron host and does not touch a manifest icon value.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

**Before:**
<img width="476" height="509" alt="image" src="https://github.com/user-attachments/assets/9430bcde-f88f-496e-8c8b-15356880e3d7" />
 
**After:**
<img width="479" height="510" alt="image" src="https://github.com/user-attachments/assets/29210f00-c87a-416c-9d07-e2709c65a994" />

### Additional Notes

Out of scope, noticed while tracing this and deliberately not fixed here:

- The wrench already means something else: `webview-ui/src/components/settings/SettingsView.tsx:74` uses lucide `Wrench` for Settings → General. Another argument that VS Code was the side that had drifted.
- `cline.mcpButtonClicked` is titled "MCP Servers" with `$(server)`, but its handler navigates to the Marketplace. It is palette-only (not in `view/title`), so it is invisible in the title bar, but the title and behaviour are out of sync.
- A third control tooltipped "Customize" uses `codicon-law` (`cline-rules/ClineRulesToggleModal.tsx:397`).

Happy to file these separately if they are worth tracking.