### PR TITLE
Clarify shell command input shape

### DIFF
--- a/sdk/packages/core/src/extensions/tools/definitions.test.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.test.ts
@@ -479,6 +479,21 @@ describe("default apply_patch tool", () => {
 });
 
 describe("run_commands tool description", () => {
+	it("states the string-only input contract once for every shell family", () => {
+		const contract =
+			'Pass commands as JSON strings, never as objects. Valid: {"commands":["pwd","git status --short"]}. Invalid: {"commands":[{"command":"pwd"}]}. ';
+
+		for (const [shellKind, isWindows] of [
+			["posix", false],
+			["wsl", true],
+			["powershell", true],
+			["cmd", true],
+		] as const) {
+			const description = buildRunCommandsDescription(shellKind, isWindows);
+			expect(description.split(contract)).toHaveLength(2);
+		}
+	});
+
 	it("names PowerShell with ';' sequencing for PowerShell shells", () => {
 		const description = buildRunCommandsDescription("powershell", true);
 		expect(description).toContain("Commands run through PowerShell");

--- a/sdk/packages/core/src/extensions/tools/definitions.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.ts
@@ -399,7 +399,8 @@ export function createSearchTool(
 
 const RUN_COMMANDS_SHARED_INSTRUCTIONS =
 	"Use for listing files, checking git status, running builds, executing tests, etc. " +
-	"Commands must be non-interactive. Commands that require follow-up input like pagers should be skipped or used with supported flags/env (e.g. git --no-pager, --non-interactive) to bypass the interaction steps. ";
+	"Commands must be non-interactive. Commands that require follow-up input like pagers should be skipped or used with supported flags/env (e.g. git --no-pager, --non-interactive) to bypass the interaction steps. " +
+	'Pass commands as JSON strings, never as objects. Valid: {"commands":["pwd","git status --short"]}. Invalid: {"commands":[{"command":"pwd"}]}. ';
 
 /**
  * Build the run_commands tool description for the shell that will actually


### PR DESCRIPTION
## Summary

- clarify that every `run_commands.commands` entry must be a JSON string, not an object
- include adjacent valid and invalid request examples in the shared tool description
- verify the contract is emitted exactly once for POSIX, WSL, PowerShell, and cmd

## Root cause

DeepSeek V4 Pro repeatedly produced a plausible but schema-invalid shape such as `{"commands":[{"command":"pwd"}]}`. Those calls are rejected before execution, after which the model can repeat the same mistake and consume turns, tokens, and the consecutive-mistake budget. The schema type was already correct; the model needed a concrete positive/negative example at the generation boundary.

## Evaluation

We evaluated the retained change under a fixed 89-task Terminal-Bench 2.1 protocol: `openrouter:deepseek/deepseek-v4-pro`, Cline CLI, reasoning effort `none`, Modal, one attempt, and identical task resources, timeouts, and retry policy.

| Metric | Baseline (2 runs) | Candidate (4 unchanged runs) | Change |
| --- | ---: | ---: | ---: |
| Score | 44, 44 (mean 44/89) | 48, 47, 48, 45 (mean 47/89) | +3 tasks mean |
| Malformed shell calls | 1,739.5 mean | 106.5 mean | -93.9% |
| Trials affected by malformed calls | 27.5 mean | 5.75 mean | -79.1% |
| Input tokens | 369.6M mean | 293.0M mean | -20.7% |
| Cached input tokens | 365.2M mean | 289.1M mean | -20.8% |
| Output tokens | 2.732M mean | 2.484M mean | -9.1% |
| Cost | $5.788 mean | $5.247 mean | -9.3% |
| Error-bearing trials | 8.5 mean | 7.0 mean | -17.6% |

Every candidate run scored above both fresh baseline runs, but run-to-run task variance remains material; this is replicated evidence, not a claim that every future run gains exactly three tasks.

The evaluated commit was `75c63aac4f8569b5eb9b51a025c71cf5af0ea2b6` (tree `c81ab01ef8751d2bba775f680a8a045b2a055a05`). This PR applies the identical two-file change to current `main` as `7ae5a5088d078e17be7d5a454f1f2d830f1e0c0d`.

## Validation

- `bunx vitest run --config vitest.config.ts --testTimeout=15000` in `sdk/packages/core`: 1,546 passed, 14 skipped
- `bun run typecheck` in `sdk/packages/core`: passed
- `bun run types` in `sdk`: passed
- Biome check on both changed files: passed
- `git diff --check`: passed
