### PR TITLE
feat(cli): allow forcing the TUI light/dark theme via CLINE_FORCE_THEME

### DIFF
--- a/apps/cli/src/tui/index.test.ts
+++ b/apps/cli/src/tui/index.test.ts
@@ -22,6 +22,8 @@ const reactMock = vi.hoisted(() => ({
 	createRoot: vi.fn(() => rootMock),
 }));
 
+const rootPropsCaptured = vi.hoisted(() => [] as Array<Record<string, unknown>>);
+
 vi.mock("@opentui/core", () => ({
 	createCliRenderer: vi.fn(async () => rendererMock),
 }));
@@ -31,7 +33,10 @@ vi.mock("@opentui/react", () => ({
 }));
 
 vi.mock("./root", () => ({
-	Root: () => null,
+	Root: (props: Record<string, unknown>) => {
+		rootPropsCaptured.push(props);
+		return null;
+	},
 }));
 
 describe("renderOpenTui", () => {
@@ -39,6 +44,7 @@ describe("renderOpenTui", () => {
 
 	beforeEach(() => {
 		destroyHandlers.length = 0;
+		rootPropsCaptured.length = 0;
 		rendererMock.isDestroyed = false;
 		rendererMock.destroy.mockReset();
 		rendererMock.setTerminalTitle.mockReset();
@@ -133,4 +139,26 @@ describe("renderOpenTui", () => {
 
 		expect(rendererMock.setTerminalTitle).not.toHaveBeenCalled();
 	});
+
+	it("passes CLINE_FORCE_THEME=dark through to Root as a dark background", async () => {
+		rendererMock.getPalette.mockResolvedValueOnce({
+			defaultBackground: "#f2f7fb",
+			defaultForeground: "#2c3a4d",
+		});
+		process.env.CLINE_FORCE_THEME = "dark";
+		try {
+			const { renderOpenTui } = await import("./index");
+			await renderOpenTui({} as TuiProps);
+		} finally {
+			delete process.env.CLINE_FORCE_THEME;
+		}
+
+		const rootProps = rootPropsCaptured[0] as {
+			terminalBackground?: string | null;
+			terminalForeground?: string | null;
+		};
+		expect(rootProps?.terminalBackground).toBe("#000000");
+		expect(rootProps?.terminalForeground).toBe("#f0f0f0");
+	});
+
 });

--- a/apps/cli/src/tui/index.tsx
+++ b/apps/cli/src/tui/index.tsx
@@ -1,5 +1,6 @@
 import { createCliRenderer } from "@opentui/core";
 import { createRoot } from "@opentui/react";
+import { resolveTerminalColors } from "./palette";
 import { Root } from "./root";
 import { installTuiStdioCapture } from "./stdio-capture";
 import type { TuiProps } from "./types";
@@ -19,8 +20,17 @@ export async function renderOpenTui(
 	const detectedPalette = await renderer
 		.getPalette({ timeout: 150 })
 		.catch(() => null);
-	const terminalBackground = detectedPalette?.defaultBackground ?? null;
-	const terminalForeground = detectedPalette?.defaultForeground ?? null;
+	const detectedBackground = detectedPalette?.defaultBackground ?? null;
+	const detectedForeground = detectedPalette?.defaultForeground ?? null;
+	// Allow pinning the TUI to a fixed light/dark scheme instead of trusting the
+	// terminal's auto-detected background (unreadable on some light terminals).
+	const forcedThemeColors = resolveTerminalColors(
+		detectedBackground,
+		detectedForeground,
+		process.env.CLINE_FORCE_THEME,
+	);
+	const terminalBackground = forcedThemeColors.background;
+	const terminalForeground = forcedThemeColors.foreground;
 
 	let root: ReturnType<typeof createRoot>;
 	try {

--- a/apps/cli/src/tui/palette.test.ts
+++ b/apps/cli/src/tui/palette.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { getModeAccent, getSuccessColor, getTerminalTheme } from "./palette";
+import {
+	getModeAccent,
+	getSuccessColor,
+	getTerminalTheme,
+	resolveTerminalColors,
+} from "./palette";
 
 describe("getTerminalTheme", () => {
 	it("detects light terminals from the default background", () => {
@@ -19,6 +24,45 @@ describe("getTerminalTheme", () => {
 
 	it("defaults to the existing dark theme when detection is unavailable", () => {
 		expect(getTerminalTheme(null, null)).toBe("dark");
+	});
+});
+
+describe("resolveTerminalColors", () => {
+	it("passes detected colors through when no theme is forced", () => {
+		expect(resolveTerminalColors("#f2f7fb", "#2c3a4d", undefined)).toEqual({
+			background: "#f2f7fb",
+			foreground: "#2c3a4d",
+		});
+	});
+
+	it("passes detected colors through for the auto/unknown values", () => {
+		expect(resolveTerminalColors("#f2f7fb", "#2c3a4d", "auto")).toEqual({
+			background: "#f2f7fb",
+			foreground: "#2c3a4d",
+		});
+		expect(resolveTerminalColors("#f2f7fb", "#2c3a4d", "  ")).toEqual({
+			background: "#f2f7fb",
+			foreground: "#2c3a4d",
+		});
+	});
+
+	it("forces a dark scheme (and classifies as dark) when dark is requested", () => {
+		const colors = resolveTerminalColors("#f2f7fb", "#2c3a4d", "dark");
+		expect(colors).toEqual({ background: "#000000", foreground: "#f0f0f0" });
+		expect(getTerminalTheme(colors.background)).toBe("dark");
+	});
+
+	it("forces a light scheme (and classifies as light) when light is requested", () => {
+		const colors = resolveTerminalColors("#000000", "#f0f0f0", "light");
+		expect(colors).toEqual({ background: "#ffffff", foreground: "#1a1a1a" });
+		expect(getTerminalTheme(colors.background)).toBe("light");
+	});
+
+	it("matches the forced theme case-insensitively", () => {
+		expect(resolveTerminalColors(null, null, "DARK")).toEqual({
+			background: "#000000",
+			foreground: "#f0f0f0",
+		});
 	});
 });
 

--- a/apps/cli/src/tui/palette.ts
+++ b/apps/cli/src/tui/palette.ts
@@ -126,6 +126,37 @@ export function getTerminalTheme(
 	return "dark";
 }
 
+/**
+ * Values accepted by the user-facing theme override (`CLINE_FORCE_THEME`).
+ * `"auto"` (default) keeps auto-detection from the terminal background.
+ */
+export type ForcedTheme = "auto" | "dark" | "light";
+
+/**
+ * Resolve the terminal colors the TUI should render with.
+ *
+ * When the user forces a theme (`forcedTheme` is `"dark"`/`"light"`), return a
+ * fixed background/foreground pair that the palette adaptors in this module
+ * then classify and derive colors from — so a bright terminal that reports a
+ * light background can still render the TUI in a stable dark scheme (or vice
+ * versa). When nothing is forced (or `"auto"`), the detected colors pass
+ * through unchanged and auto-detection is preserved.
+ */
+export function resolveTerminalColors(
+	background: string | null,
+	foreground: string | null,
+	forcedTheme: string | undefined | null,
+): { background: string | null; foreground: string | null } {
+	switch (forcedTheme?.trim().toLowerCase()) {
+		case "dark":
+			return { background: "#000000", foreground: "#f0f0f0" };
+		case "light":
+			return { background: "#ffffff", foreground: "#1a1a1a" };
+		default:
+			return { background, foreground };
+	}
+}
+
 export function getDefaultForeground(
 	terminalBg: string | null,
 ): string | undefined {


### PR DESCRIPTION
## Summary

Allows pinning the Cline TUI to a fixed `light` or `dark` theme, independent of what the terminal reports.

The TUI auto-detects the terminal's background via OpenTUI's `getPalette()` (`apps/cli/src/tui/index.tsx`) and adapts colors in `apps/cli/src/tui/palette.ts`. On terminals that report a very light background, the auto-detected light palette can be hard to read, and there was previously no way to override it.

## Changes

- `apps/cli/src/tui/palette.ts`: add `resolveTerminalColors(background, foreground, forcedTheme)` — returns a fixed dark/light pair when a theme is forced (`#000000/#f0f0f0` or `#ffffff/#1a1a1a`), otherwise passes the detected colors through unchanged.
- `apps/cli/src/tui/index.tsx`: reads the new `CLINE_FORCE_THEME` env var (`dark|light|auto`) and feeds it into the resolver before rendering `<Root>`.
- Tests for `resolveTerminalColors` (`palette.test.ts`) and for the `CLINE_FORCE_THEME=dark` → `<Root>` wiring (`index.test.ts`).

## Usage

```bash
CLINE_FORCE_THEME=dark cline -i    # force a dark TUI on a light terminal
CLINE_FORCE_THEME=light cline -i
CLINE_FORCE_THEME=auto cline -i    # default: keep auto-detection
```

## Notes

- The env-var approach follows the existing `CLINE_*` env convention already used throughout the CLI.
- Behavior is a no-op unless `CLINE_FORCE_THEME` is set, so auto-detection is preserved by default.
- Validation: `bunx vitest run palette.test.ts` → 11/11 passing (includes the 5 new `resolveTerminalColors` cases).

Closes #12872
