### PR TITLE
fix(vscode): restore macOS E2E launch on legacy

### DIFF
--- a/apps/vscode/src/test/e2e/utils/helpers.ts
+++ b/apps/vscode/src/test/e2e/utils/helpers.ts
@@ -1,5 +1,5 @@
 import type { ChildProcess } from "node:child_process"
-import { mkdtempSync, type PathLike, type RmOptions, readdirSync, rmSync } from "node:fs"
+import { existsSync, mkdtempSync, type PathLike, type RmOptions, readdirSync, rmSync } from "node:fs"
 import * as os from "node:os"
 import * as path from "node:path"
 import { type ElectronApplication, expect, type Frame, type Page, test } from "@playwright/test"
@@ -59,6 +59,37 @@ export class E2ETestHelper {
 		const projectSuffix = projectName && projectName !== "e2e tests" ? `_${E2ETestHelper.escapeToPath(projectName)}` : ""
 
 		return `${baseName}${projectSuffix}`
+	}
+
+	/**
+	 * Resolves the real VS Code executable for `_electron.launch()`.
+	 *
+	 * `@vscode/test-electron` hardcodes the macOS entry point as
+	 * `Visual Studio Code.app/Contents/MacOS/Electron`, but recent VS Code builds
+	 * ship that binary as `Code` instead, so launching fails with ENOENT.
+	 * See https://github.com/microsoft/vscode-test/issues/355.
+	 *
+	 * When the reported path is missing, fall back to the bundle's real executable
+	 * name(s) so E2E works on both the old and new layouts.
+	 */
+	public static resolveVSCodeExecutablePath(executablePath: string): string {
+		if (existsSync(executablePath)) {
+			return executablePath
+		}
+
+		if (process.platform !== "darwin") {
+			return executablePath
+		}
+
+		const macOSDir = path.dirname(executablePath)
+		for (const candidate of ["Code", "Code - Insiders"]) {
+			const candidatePath = path.join(macOSDir, candidate)
+			if (existsSync(candidatePath)) {
+				return candidatePath
+			}
+		}
+
+		return executablePath
 	}
 
 	public static async waitUntil(predicate: () => boolean | Promise<boolean>, maxDelay = 10000): Promise<void> {
@@ -373,7 +404,9 @@ export const e2e = test
 	})
 	.extend<{ openVSCode: (workspacePath: string) => Promise<ElectronApplication> }>({
 		openVSCode: async ({ userDataDir, channel }, use, testInfo) => {
-			const executablePath = await downloadAndUnzipVSCode(channel, undefined, new SilentReporter())
+			const executablePath = E2ETestHelper.resolveVSCodeExecutablePath(
+				await downloadAndUnzipVSCode(channel, undefined, new SilentReporter()),
+			)
 
 			await use(async (workspacePath: string) => {
 				// Create isolated Cline data directory for this test


### PR DESCRIPTION
### Related Issue

Ports https://github.com/cline/cline/pull/12726 ("fix(vscode): restore macOS E2E launch") from `main` to `legacy-extension`. Upstream root cause: [microsoft/vscode-test#355](https://github.com/microsoft/vscode-test/issues/355).

### Description

`e2e (macos)` fails on **every** PR targeting `legacy-extension`, and has done since VS Code stable rolled forward. All six specs die identically before any extension code runs:

```
Error: electron.launch: Failed to launch: Error: spawn
  .../.vscode-test/vscode-darwin-arm64-1.131.0/Visual Studio Code.app/Contents/MacOS/Electron ENOENT
```

`@vscode/test-electron` hardcodes the macOS entry point as `Visual Studio Code.app/Contents/MacOS/Electron`, but recent VS Code builds ship that binary as `Code`. Nothing changed on this branch — VS Code moved underneath it. `main` received the compat shim in #12726; `legacy-extension` never did.

This is a straight port of that commit: `E2ETestHelper.resolveVSCodeExecutablePath()` returns the reported path when it exists, and otherwise (macOS only) falls back to `Code` / `Code - Insiders` inside the same bundle, so it works on both the old and new layouts. The `openVSCode` fixture wraps its `downloadAndUnzipVSCode` result in it.

Deliberately **not** included from main's current version of this file: the adjacent `CLINE_DATA_DIR` env line, which is SDK-arch storage isolation and does not apply here. The diff is identical to #12726's and nothing else.

### Why it matters

The failure is harness-only, so it has been merged past — [#12812](https://github.com/cline/cline/pull/12812) and [#12825](https://github.com/cline/cline/pull/12825) both shipped with `e2e (macos)` red. That is the problem: a permanently-red required-looking check trains reviewers to ignore the one signal that would catch a real macOS regression. `e2e (ubuntu)` and `e2e (windows)` pass throughout, which is what has made this safe to ignore so far.

### Test Procedure

- `tsc --noEmit` clean; `biome lint` clean at error level on the touched file.
- Real verification is this PR's own `e2e (macos)` job: it should go green, where it is red on every other PR against this branch.
- Test harness only — no product code, no extension behavior, no telemetry touched.
