### PR TITLE
fix(context): require a context-specific message for Anthropic context-window detection

### DIFF
--- a/apps/vscode/src/core/context/context-management/__tests__/context-error-handling.test.ts
+++ b/apps/vscode/src/core/context/context-management/__tests__/context-error-handling.test.ts
@@ -1,5 +1,6 @@
+import { APIError } from "@anthropic-ai/sdk"
 import { expect } from "chai"
-import { checkContextWindowExceededError } from "../context-error-handling"
+import { checkContextWindowExceededError, checkIsAnthropicContextWindowError } from "../context-error-handling"
 
 describe("checkContextWindowExceededError", () => {
 	it("detects OpenRouter context errors using structured status", () => {
@@ -27,5 +28,143 @@ describe("checkContextWindowExceededError", () => {
 		const error = new Error("OpenRouter API Error 400: Invalid API key")
 
 		expect(checkContextWindowExceededError(error)).to.equal(false)
+	})
+
+	it("classifies a real Anthropic overflow error as a context window failure", () => {
+		expect(
+			checkContextWindowExceededError(makeAnthropicError("prompt is too long: 213462 tokens > 200000 maximum")),
+		).to.equal(true)
+	})
+
+	it("does not classify an unrelated Anthropic invalid_request_error as a context window failure", () => {
+		const error = makeAnthropicError("tools.0.custom.input_schema: Extra inputs are not permitted")
+
+		expect(checkContextWindowExceededError(error)).to.equal(false)
+	})
+})
+
+/**
+ * Builds the shape an Anthropic API rejection has by the time it reaches the detector: the SDK's
+ * `APIError` carries the parsed response body on `error`, so the provider's own error object is
+ * nested at `error.error`.
+ */
+function makeAnthropicError(message: string, type = "invalid_request_error", status = 400) {
+	return {
+		status,
+		message: `${status} ${JSON.stringify({ type: "error", error: { type, message } })}`,
+		error: {
+			type: "error",
+			error: { type, message },
+		},
+	}
+}
+
+describe("checkIsAnthropicContextWindowError", () => {
+	describe("real overflow rejections still auto-truncate", () => {
+		// Anthropic's current overflow message, emitted when the rendered prompt alone exceeds the
+		// model's context window.
+		it("matches 'prompt is too long' with the token counts", () => {
+			expect(
+				checkIsAnthropicContextWindowError(makeAnthropicError("prompt is too long: 213462 tokens > 200000 maximum")),
+			).to.equal(true)
+		})
+
+		// Emitted when the prompt fits but prompt + max_tokens does not.
+		it("matches 'input length and max_tokens exceed context limit'", () => {
+			const error = makeAnthropicError(
+				"input length and max_tokens exceed context limit: 197000 + 8192 > 200000, decrease input length or max_tokens and try again",
+			)
+
+			expect(checkIsAnthropicContextWindowError(error)).to.equal(true)
+		})
+
+		it("matches the older 'input is too long' phrasing", () => {
+			expect(checkIsAnthropicContextWindowError(makeAnthropicError("input is too long for requested model"))).to.equal(true)
+		})
+
+		it("matches when only the SDK's JSON-stringified message carries the overflow text", () => {
+			const error = makeAnthropicError("prompt is too long: 213462 tokens > 200000 maximum")
+			// Some wrappers hand us the error object without the provider message on the inner error.
+			delete (error.error.error as { message?: string }).message
+
+			expect(checkIsAnthropicContextWindowError(error)).to.equal(true)
+		})
+
+		it("matches an error constructed by the Anthropic SDK itself", () => {
+			const body = {
+				type: "error",
+				error: { type: "invalid_request_error", message: "prompt is too long: 213462 tokens > 200000 maximum" },
+			}
+			const error = APIError.generate(400, body, undefined, new Headers())
+
+			expect(checkIsAnthropicContextWindowError(error)).to.equal(true)
+		})
+	})
+
+	describe("unrelated invalid_request_error rejections are not overflows", () => {
+		// Each of these previously matched on the error type alone, triggering a conversation
+		// truncation and a retry that then failed again for the original reason.
+		const UNRELATED_MESSAGES = [
+			"tools.0.custom.input_schema: Extra inputs are not permitted",
+			"messages.1.content.0.image.source.base64: image exceeds 5 MB maximum: 6291456 bytes > 5242880 bytes",
+			"model: claude-not-a-real-model",
+			"max_tokens: 100000 > 64000, which is the maximum allowed number of output tokens for claude-sonnet-4-5",
+			"messages: at least one message is required",
+			"messages.0: all messages must have non-empty content except for the optional final assistant message",
+			"temperature: Input should be less than or equal to 1",
+		]
+
+		for (const message of UNRELATED_MESSAGES) {
+			it(`does not match: ${message}`, () => {
+				expect(checkIsAnthropicContextWindowError(makeAnthropicError(message))).to.equal(false)
+			})
+		}
+
+		it("does not match an invalid_request_error with no message at all", () => {
+			expect(
+				checkIsAnthropicContextWindowError({ error: { type: "error", error: { type: "invalid_request_error" } } }),
+			).to.equal(false)
+		})
+
+		it("does not match an invalid_request_error with a non-string message", () => {
+			const error = makeAnthropicError("unused")
+			;(error.error.error as { message?: unknown }).message = { detail: "structured" }
+			error.message = ""
+
+			expect(checkIsAnthropicContextWindowError(error)).to.equal(false)
+		})
+	})
+
+	describe("non-invalid_request_error inputs", () => {
+		it("does not match other Anthropic error types even with overflow-shaped text", () => {
+			const error = makeAnthropicError("prompt is too long: 213462 tokens > 200000 maximum", "rate_limit_error", 429)
+
+			expect(checkIsAnthropicContextWindowError(error)).to.equal(false)
+		})
+
+		it("does not match an overloaded_error", () => {
+			expect(checkIsAnthropicContextWindowError(makeAnthropicError("Overloaded", "overloaded_error", 529))).to.equal(false)
+		})
+
+		for (const [label, value] of [
+			["null", null],
+			["undefined", undefined],
+			["a plain string", "prompt is too long: 213462 tokens > 200000 maximum"],
+			["an object with no error property", { message: "prompt is too long: 213462 tokens > 200000 maximum" }],
+		] as const) {
+			it(`does not match ${label}`, () => {
+				expect(checkIsAnthropicContextWindowError(value)).to.equal(false)
+			})
+		}
+
+		it("does not throw when property access throws", () => {
+			const error = {
+				get error(): never {
+					throw new Error("boom")
+				},
+			}
+
+			expect(checkIsAnthropicContextWindowError(error)).to.equal(false)
+		})
 	})
 })

--- a/apps/vscode/src/core/context/context-management/context-error-handling.ts
+++ b/apps/vscode/src/core/context/context-management/context-error-handling.ts
@@ -58,9 +58,29 @@ function checkIsOpenAIContextWindowError(error: unknown): boolean {
 	}
 }
 
-function checkIsAnthropicContextWindowError(response: any): boolean {
+export function checkIsAnthropicContextWindowError(response: any): boolean {
 	try {
-		return response?.error?.error?.type === "invalid_request_error"
+		// Anthropic returns `invalid_request_error` for many conditions that have nothing to do with
+		// context size (malformed params, invalid tool schema, oversized image, unknown model id), so
+		// the error type alone cannot identify an overflow — it needs a context-specific message too.
+		if (response?.error?.error?.type !== "invalid_request_error") {
+			return false
+		}
+
+		// The Anthropic SDK puts the response body on `error` and, when that body has no top-level
+		// `message`, JSON-stringifies it into the APIError's own `message` — so either path can carry
+		// the overflow text depending on how the error reached us.
+		const messages: unknown[] = [response?.error?.error?.message, response?.message].filter((msg) => msg != null)
+
+		// Anthropic-authored overflow wire messages, matching the patterns the Vercel and Bedrock
+		// branches in this file already use for the same provider messages.
+		const CONTEXT_ERROR_PATTERNS = [
+			/prompt is too long.*tokens?\s*>\s*\d+\s*maximum/i,
+			/input is too long/i,
+			/input length and max_tokens exceed context limit/i,
+		] as const
+
+		return messages.some((msg) => CONTEXT_ERROR_PATTERNS.some((pattern) => pattern.test(String(msg))))
 	} catch {
 		return false
 	}


### PR DESCRIPTION
Follow-up to the non-blocking review comment on #12825.

## Problem

`checkIsAnthropicContextWindowError` treated **every** nested Anthropic `invalid_request_error` as a context-window overflow:

```ts
return response?.error?.error?.type === "invalid_request_error"
```

Anthropic uses `invalid_request_error` for a large family of rejections that have nothing to do with context size — invalid tool schema, oversized image, unknown model id, out-of-range `max_tokens`, malformed `messages`, out-of-range `temperature`. Every sibling detector in this file (OpenAI, OpenRouter, Cerebras, Bedrock, Vercel) gates on a status/type **and** a context-specific message pattern. The Anthropic branch was the only one that did not.

Two consequences, of different severity:

1. **Recovery bug (pre-existing).** `checkContextWindowExceededError` gates `handleContextWindowExceededError()` in the legacy task loop, so an unrelated Anthropic invalid request triggered a conversation truncation and a retry — which then failed again for the original reason, having already discarded conversation history. Silent, and it left the user worse off than a plain error would have.
2. **Telemetry (new since #12825).** `errorClass` on `task.provider_api_error` is derived from this same detector, so those unrelated failures were labeled `error_class = "context_window_exceeded"`, inflating the exact bucket #12825 exists to make countable — [ENG-2394](https://linear.app/cline-bot/issue/ENG-2394/vercel-ai-gateway-stream-error-occurred-on-final-response-synthesis).

**Note this changes recovery behavior, not just classification** — unlike #12825, which was observability-only. That is the point of the fix, but it means the blast radius is the truncate-and-retry path, not a dashboard.

## Change

Keep the existing type gate, then additionally require a context-specific message:

```ts
const CONTEXT_ERROR_PATTERNS = [
    /prompt is too long.*tokens?\s*>\s*\d+\s*maximum/i,
    /input is too long/i,
    /input length and max_tokens exceed context limit/i,
] as const
```

All three are reused rather than invented — the first two are already in `checkIsVercelContextWindowError`, the third in `checkIsBedrockContextWindowError`. All three are Anthropic-authored wire messages; Bedrock and the Vercel gateway just relay them, which is why they already appear in those branches.

Both the provider message (`error.error.message`) and the error's own `message` are checked. The Anthropic SDK sets `APIError.error` to the parsed response body and, because that body has no top-level `message`, JSON-stringifies the whole body into `APIError.message` — so depending on how the error reached us either path can be the one carrying the overflow text.

## Tradeoff

Narrowing means a genuine overflow whose message shape isn't matched loses auto-truncate recovery. Weighing the two directions:

- **False positive (status quo):** silent history loss plus a retry that cannot succeed, on *any* malformed-request bug. High frequency — it fires on developer errors and on ordinary user mistakes like attaching an oversized image — and the failure is invisible to the user.
- **Missed recovery (new risk):** the user sees the real overflow error and has to condense the conversation themselves. Lower frequency, and it degrades to the normal error path rather than corrupting state.

The false positive is both more likely and more damaging, so requiring the message is the right default. The residual risk is bounded: the three patterns cover every overflow message shape Anthropic currently emits, and matching the JSON-stringified `message` as well as the structured one means a wrapper that reshapes the error still matches.

Worth flagging for whoever touches this next: the pattern here is deliberately the strict Vercel one (`prompt is too long` **plus** the `tokens > N maximum` tail). The SDK arch uses a looser bare `\bprompt is too long\b`. If we ever see missed recoveries in the wild, relaxing to the looser form is the first knob — nothing else in Anthropic's error vocabulary says "prompt is too long", so it costs little in precision.

## SDK arch

Not affected, and deliberately not touched here (legacy-only fix). `classifyProviderError` in `sdk/packages/llms/src/providers/error-classification.ts` (added by #12804) already requires a status in `{400, 413, 422}` **and** a message pattern, plus a rate-limit veto. It has no bare-type match, so the over-broad shape does not exist there.

## Tests

The Anthropic branch had **zero** coverage in `context-error-handling.test.ts`, so these are net-new (+23 tests):

- **Positive** — one per real overflow message shape (`prompt is too long: … tokens > … maximum`, `input length and max_tokens exceed context limit: …`, `input is too long …`), plus a case where only the SDK's JSON-stringified `message` carries the text, plus one error constructed by the actual Anthropic SDK via `APIError.generate` so the shape assumption is pinned to the real dependency rather than to a hand-rolled fixture.
- **Negative** — the seven unrelated `invalid_request_error` payloads above, an `invalid_request_error` with no message at all, one with a non-string message, other Anthropic error types carrying overflow-shaped text, and `null` / `undefined` / string / no-`error`-property / throwing-getter inputs.

Two cases also run through the public `checkContextWindowExceededError` to confirm no sibling branch picks up an unrelated Anthropic rejection.

Checked against the pre-fix implementation: exactly the 10 negative assertions fail and all 5 positives still pass, so the fixtures pin the actual behavior change rather than just passing.

## Verification

From `apps/vscode`:

- `npx tsc --noEmit` — clean
- unit suite — 1592 passing / 4 pending / 0 failing (1567 before this change; +23 here, +2 from #12825)
- `npm-run-all -p lint format` — clean
