### PR TITLE
docs: correct auto-approve settings after menu simplification

### DIFF
--- a/docs/features/auto-approve.mdx
+++ b/docs/features/auto-approve.mdx
@@ -20,51 +20,33 @@ If you find yourself repeatedly clicking approve for the same safe operations, A
 
 ## How It Works
 
-Auto Approve is evaluated per tool call. When Cline is about to read a file, edit a file, run a command, or use the browser, it checks your Auto Approve settings for that category.
+Auto Approve is evaluated per tool call. When Cline is about to read a file, edit a file, run a command, or fetch web content, it checks your Auto Approve settings for that category.
 
 A few details matter:
 
-- **Workspace vs outside workspace**: "Read all files" and "Edit all files" only extend the base toggle. If the base toggle is off, the "all files" option does nothing.
-- **Terminal commands**: Cline treats commands as either safe or requiring approval. "Execute safe commands" covers safe commands. "Execute all commands" extends to commands flagged as requiring approval.
+- **Terminal commands**: "Execute commands" is all or nothing. It covers every command Cline runs, and it is off by default.
 - **Notifications**: If enabled, Cline sends OS-level notifications when approval is required, and when an auto-approved terminal command has been running for 30 seconds.
 
 ## Permissions
 
 | Setting | What It Allows |
 |---------|----------------|
-| Read project files | Read files, list files, search in your workspace |
-| Read all files | Read files outside your workspace (requires base toggle) |
-| Edit project files | Create and edit files in your workspace |
-| Edit all files | Edit files outside your workspace (requires base toggle) |
-| Execute safe commands | Run terminal commands marked safe |
-| Execute all commands | Run commands requiring approval (requires base toggle) |
-| Use the browser | Browser tool for web fetching and searching |
+| Read files | Read files, list files, and search your codebase |
+| Edit files | Create, edit, and delete files |
+| Execute commands | Run terminal commands |
+| Fetch web content | Web fetching and searching |
 | Use MCP servers | MCP tools and resources |
 | Enable notifications | Notifies you about long-running commands |
 
 <Warning>
-"Read all files" and "Edit all files" only matter if their base toggle is enabled. They extend access outside your workspace.
+"Execute commands" approves every command Cline runs, including destructive ones such as `rm -rf`, `git reset --hard`, or `git commit --amend`. Cline does not classify commands as safe or unsafe.
 </Warning>
-
-## Safe vs Approval-Required Commands
-
-Cline does not use a fixed allowlist. The model marks each command with a `requires_approval` flag based on the command and arguments. These are examples, not guarantees.
-
-**Commonly treated as safe:**
-- `npm run build`, `npm test` - Build/test output
-- `git status`, `ls -la`, `cat package.json` - Read-only commands
-
-**Commonly requires approval:**
-- `npm install <pkg>` - Modifies dependencies
-- `rm -rf <path>` - Deletes files
-- `mv <a> <b>` - Moves files (can overwrite)
-- `sed -i ...` - In-place file edits
 
 ## Recommendations
 
 A good default setup:
-- Enable **Read project files**
-- Leave edits, commands, browser, and MCP off until you have a specific reason
+- Enable **Read files**
+- Leave edits, commands, web fetching, and MCP off until you have a specific reason
 
 If you enable edits, use [Checkpoints](/core-workflows/checkpoints) so you can roll back quickly.
 

--- a/docs/features/auto-approve.mdx
+++ b/docs/features/auto-approve.mdx
@@ -24,7 +24,8 @@ Auto Approve is evaluated per tool call. When Cline is about to read a file, edi
 
 A few details matter:
 
-- **Terminal commands**: "Execute commands" is all or nothing. It covers every command Cline runs, and it is off by default.
+- **Which build you have**: Cline currently ships the new SDK-based extension and the previous one together in a single install, and a loader picks one per window. Their auto-approve menus differ. The quickest tell is the command toggle: "Execute safe commands" means the previous build, "Execute commands" means the new one. To choose explicitly, set `cline.rollout.bundleOverride` to `next` or `legacy` in VS Code settings and reload the window; `auto` follows the rollout.
+- **Terminal commands**: the two builds decide command approval differently. See [Terminal commands](#terminal-commands) below.
 - **Notifications**: If enabled, Cline sends OS-level notifications when approval is required, and when an auto-approved terminal command has been running for 30 seconds.
 
 ## Permissions
@@ -38,8 +39,18 @@ A few details matter:
 | Use MCP servers | MCP tools and resources |
 | Enable notifications | Notifies you about long-running commands |
 
+On the previous build these are named "Read project files", "Edit project files", "Execute safe commands" and "Use the browser", and three of them have a second checkbox that widens them: "Read all files" and "Edit all files" extend access outside your workspace, and "Execute all commands" is described below. A sub-toggle does nothing unless its base toggle is on.
+
+## Terminal commands
+
+How a command gets approved depends on which build you are running.
+
+**Previous build.** Cline asks the model to mark each command with a `requires_approval` flag. "Execute safe commands" auto-approves the commands the model marked safe, and "Execute all commands" additionally auto-approves the rest. There is no fixed allowlist, so this is the model's judgement rather than a guarantee: a command such as `git commit --amend` can be marked safe and run without prompting. "Execute safe commands" is on by default.
+
+**New build.** There is no safe-versus-unsafe distinction. "Execute commands" approves every command Cline runs, and it is off by default.
+
 <Warning>
-"Execute commands" approves every command Cline runs, including destructive ones such as `rm -rf`, `git reset --hard`, or `git commit --amend`. Cline does not classify commands as safe or unsafe.
+On either build, an enabled command toggle can run destructive commands such as `rm -rf`, `git reset --hard` or `git commit --amend` without asking you first.
 </Warning>
 
 ## Recommendations

--- a/docs/features/auto-approve.mdx
+++ b/docs/features/auto-approve.mdx
@@ -24,7 +24,7 @@ Auto Approve is evaluated per tool call. When Cline is about to read a file, edi
 
 A few details matter:
 
-- **Which build you have**: Cline currently ships the new SDK-based extension and the previous one together in a single install, and a loader picks one per window. Their auto-approve menus differ. The quickest tell is the command toggle: "Execute safe commands" means the previous build, "Execute commands" means the new one. To choose explicitly, set `cline.rollout.bundleOverride` to `next` or `legacy` in VS Code settings and reload the window; `auto` follows the rollout.
+- **Which build you have**: Cline currently ships the new SDK-based extension and the previous one together in a single install, and a loader picks one per window. Their auto-approve menus differ. The quickest tell is the command toggle: "Execute safe commands" means the previous build, "Execute commands" means the new one. To choose explicitly, set `cline.rollout.bundleOverride` to `next` or `legacy` in VS Code settings and reload the window; `auto` follows the rollout. On the Cline Nightly build the setting is `cline-nightly.rollout.bundleOverride`.
 - **Terminal commands**: the two builds decide command approval differently. See [Terminal commands](#terminal-commands) below.
 - **Notifications**: If enabled, Cline sends OS-level notifications when approval is required, and when an auto-approved terminal command has been running for 30 seconds.
 

--- a/docs/features/subagents.mdx
+++ b/docs/features/subagents.mdx
@@ -43,7 +43,7 @@ You can also run only one subagent when the task is small enough that parallel d
 
 ## Auto-Approve Behavior
 
-Subagents follow the **Read project files** auto-approve permission. If you have "Read project files" enabled in [Auto Approve](/features/auto-approve), subagent launches will be auto-approved.
+Subagents follow the **Read files** auto-approve permission. If you have "Read files" enabled in [Auto Approve](/features/auto-approve), subagent launches will be auto-approved.
 
 If auto-approve is off, Cline will ask for your approval before launching subagents, showing you the prompts it plans to send.
 

--- a/docs/features/subagents.mdx
+++ b/docs/features/subagents.mdx
@@ -43,7 +43,7 @@ You can also run only one subagent when the task is small enough that parallel d
 
 ## Auto-Approve Behavior
 
-Subagents follow the **Read files** auto-approve permission. If you have "Read files" enabled in [Auto Approve](/features/auto-approve), subagent launches will be auto-approved.
+Subagents follow the **Read project files** auto-approve permission. If you have "Read project files" enabled in [Auto Approve](/features/auto-approve), subagent launches will be auto-approved.
 
 If auto-approve is off, Cline will ask for your approval before launching subagents, showing you the prompts it plans to send.
 


### PR DESCRIPTION
### Related Issue

Refs #12133

### Description

`docs/features/auto-approve.mdx` describes one auto-approve menu, but Cline currently ships two.

4.1.x is a combined A/B VSIX: a loader plus the new SDK-based extension (`next`, built from `main`) and the previous one (`legacy`, built from the `legacy-extension` branch). `decideBundle` defaults to `legacy` and only promotes on a PostHog percentage flag (`apps/vscode-rollout/src/cohort.ts`), so most installs are on the previous extension today. The two have different menu labels and genuinely different command-approval behavior, and this page documents only the previous one without saying so. It is linked straight from the auto-approve modal (`AutoApproveModal.tsx:74`).

This surfaced on #12133: a user on 4.1.3 reported still seeing "Execute safe commands" after the rename, which is correct for the legacy bundle and baffling without this context.

What changed:

**Says which build you are on, and how to switch.** The command toggle is the quickest tell ("Execute safe commands" vs "Execute commands"), and `cline.rollout.bundleOverride` forces either. That setting is already user-visible: `gen-manifest.mjs` injects it into the manifest with a `markdownDescription`, so it appears in the VS Code settings UI.

**Documents both command-approval models**, which is the real difference:

- Legacy: the model marks each command with `requires_approval` and the two toggles gate on it (`ExecuteCommandToolHandler.ts:225-226`); `executeSafeCommands` defaults to true.
- Next: no classification at all, `isToolAutoApproved` returns one boolean and never reads the command (`sdk-tool-policies.ts:55-57`); defaults to false.

**Uses the new names in the table with one line mapping them to the old ones**, rather than picking a bundle and being wrong for users of the other.

**What did not change:** no code, no settings, no defaults. The intro, video, notifications bullet, Recommendations and the entire YOLO Mode section are untouched. The removed `## Safe vs Approval-Required Commands` heading is not linked from anywhere (`grep -rn "safe-vs-approval" docs/` returns nothing) and the modal's `#auto-approve` anchor still resolves.

### Test Procedure

Docs-only, so no suite covers it.

1. Menu labels checked against `auto-approve-menu/constants.ts` on both refs (`main` and `legacy-extension`).
2. Command approval read from `apps/vscode/src/sdk/sdk-tool-policies.ts` on main, and `tools/handlers/ExecuteCommandToolHandler.ts` plus `tools/autoApprove.ts` on `legacy-extension`.
3. Defaults from `AutoApprovalSettings.ts` on both refs: `executeSafeCommands` is `false` on main, `true` on `legacy-extension`.
4. Rollout behavior from `apps/vscode-rollout/src/cohort.ts` and its tests (`decideBundle` returns `legacy` with no cached assignment), and the setting schema from `apps/vscode-rollout/scripts/gen-manifest.mjs`.
5. Link targets confirmed present. I could not run `mintlify broken-links` locally because `docs/node_modules` is not installed; this adds one in-page anchor (`#terminal-commands`, matching the new heading) and removes none.

The required `test` check passes trivially here: `ext-vscode-test.yml`'s `test` job early-exits when no `apps/vscode` paths change, so green is not evidence anything was exercised.

If documenting the rollout isn't wanted in user-facing docs, say so and I'll cut this back to just the command-approval section.

### Type of Change

- [x] Documentation update

### Screenshots

No change to the extension UI.