### PR TITLE
fix(core): report run_commands timeouts as a wait limit, not a failure

### DIFF
--- a/sdk/packages/core/src/extensions/tools/definitions.test.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.test.ts
@@ -1310,6 +1310,26 @@ describe("default run_commands tool", () => {
 		});
 	});
 
+	it("reports a timeout as a tool-side wait limit, not a command failure", async () => {
+		const execute = vi.fn(async () => {
+			throw new TimeoutError("Command timed out after 5000ms", 5000);
+		});
+		const tool = createShellTool(execute, { bashTimeoutMs: 5000 });
+
+		const result = await tool.execute({ commands: ["sleep 31"] } as never, {
+			agentId: "agent-1",
+			conversationId: "conv-1",
+			iteration: 1,
+		});
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.success).toBe(false);
+		expect(result[0]?.error).not.toContain("Command failed");
+		expect(result[0]?.error).toBe(
+			"Command timed out after 5000ms. This is the tool's wait limit, not an error reported by the command; the command may have been terminated. For long-running work, start it in the background and redirect its output to a file you can read later.",
+		);
+	});
+
 	it("emits timeout telemetry on the default bash tool path", async () => {
 		const telemetry = createTelemetryStub();
 		// Never resolves, so the configured timeout deterministically wins the

--- a/sdk/packages/core/src/extensions/tools/definitions.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.ts
@@ -231,6 +231,12 @@ async function executeShellCommands(
 							commandCount: commands.length,
 							durationMs: Date.now() - startedAt,
 						});
+						return {
+							query,
+							result: "",
+							error: `${error.message}. This is the tool's wait limit, not an error reported by the command; the command may have been terminated. For long-running work, start it in the background and redirect its output to a file you can read later.`,
+							success: false,
+						};
 					}
 					if (error instanceof CommandExitError) {
 						return {


### PR DESCRIPTION
### Related Issue

Fixes #10549

### Description

## The problem

`run_commands` tells the model something untrue when a command exceeds the wait limit:

```
Command failed: Command timed out after 30000ms
```

The command did not fail. The tool stopped waiting. The reporter measured the cost: the agent concludes the process crashed and spends turns inventing workarounds (`nohup`, `screen`, writing scripts to files) for a non-problem.

## The mechanism

`sdk/packages/core/src/extensions/tools/definitions.ts`, `executeShellCommands`. The catch block has three error shapes but only two returns:

- `TimeoutError` fires timeout telemetry and **does not return**
- `CommandExitError` returns its captured output
- everything else returns `Command failed: ${formatError(error)}`

Because the first branch falls through, every timeout lands in the third. `formatError` returns `error.message`, which for a `TimeoutError` is already `Command timed out after 30000ms`, producing the doubled string above.

Two earlier commits touched this exact block and neither closed it. `db99718` (#11149) **added** the fall-through branch to measure timeouts. `6c52bdc` (#11508) added the `CommandExitError` return, which does not cover `TimeoutError`.

## The fix

Give the timeout branch its own return. The message leads with the original `error.message` so a custom executor's own timeout text is preserved, then names the constraint the issue asks for.

## Non-obvious detail: why the message does not say the process is still running

The obvious wording is "the tool stopped waiting, the process may still be running". That is misleading in the default setup. There are two independent timers with the same message and the same default:

- `definitions.ts` `config.bashTimeoutMs ?? 30000`, feeding `withTimeout`, a bare `Promise.race`
- `executors/bash.ts` the executor's own `timeoutMs`, whose callback runs `killProcessTree`

`executor(...)` is evaluated as an argument before `withTimeout` registers its timer, so with equal delays the executor's timer is registered first and fires first. Its callback SIGKILLs the entire process group (`process.kill(-childPid, "SIGKILL")` on POSIX, `taskkill /T /F` on Windows). That matches the experiment in the issue exactly: plain `&` children die, `setsid` children survive because they leave the group.

But a host can set the tool timeout below the executor's, and `vscode-runtime-builder.ts` already gives them different values in one mode. At the catch site the two cases are indistinguishable, so the message says "may have been terminated", which is true either way and stops the model polling for output that will never arrive.

## What did not change

- Timeout telemetry from #11149 is untouched and still fires on every timeout, before the new return.
- `success: false` and `result: ""` are unchanged; only the `error` text differs.
- The `CommandExitError` path and the generic path are untouched.
- `read_files` and `search_codebase` have the same `X failed: X timed out` shape. They are not what this issue reports, so they are left alone.

## Out of scope

The issue bundles three asks; this PR is the first only.

| Ask | Status |
|---|---|
| Honest timeout message | this PR |
| Per-call `timeout_ms` | out. `RunCommandsInputSchema` is `{ commands: string[] }`, pinned by an existing test, so this widens a model-facing tool schema. That is a feature. |
| Async launch and poll | out. Feature. |

Also out: attaching the partially captured stdout. `TimeoutError` carries only `message` and `timeoutMs`, and `withTimeout` is a bare `Promise.race` that abandons the executor promise, so surfacing that output needs changes in `helpers.ts` and `bash.ts` plus a decision about the two timers. Worth its own PR.

## Blast radius

`error` here is not model-facing only. The CLI TUI renders it through `getToolErrorPresentation` (`apps/cli/src/tui/utils/tool-errors.ts`), which truncates the collapsed summary to 140 characters and shows the full text on click. The load-bearing correction is the first 121 characters, so it survives the collapsed view intact and only the trailing advice is cut:

```
Command timed out after 30000ms. This is the tool's wait limit, not an error reported by the command; the command may have been ...
```

No production code string-matches `Command failed`. The tests that contain it (`message-translator.test.ts`, `compat.test.ts`) build their own fixtures and never call `executeShellCommands`. The message still contains `timed out`, so the eval classifier pattern in `evals/analysis/patterns/cline-failures.yaml` still matches it.

### Test Procedure

The new test is red on `main` and green with the fix. Red output before the change, which is the exact string from the issue:

```
AssertionError: expected 'Command failed: Command timed out aft…' not to contain 'Command failed'
Expected: "Command failed"
Received: "Command failed: Command timed out after 5000ms"
```

It pins the full expected string with `toBe`, so any future wording change has to be a deliberate test edit rather than a silent drift. This closes a real gap: the four existing timeout tests assert only on telemetry or on `success: false`, so nothing pinned the user-visible timeout text.

1. Target file plus the executor suite:

```
cd sdk/packages/core && bunx vitest run --config vitest.config.ts src/extensions/tools/definitions.test.ts src/extensions/tools/executors/bash.test.ts
```

`2 files, 88 tests pass, 4 skipped.` `definitions.test.ts` is 64 tests, up from 63.

2. Typecheck as a separate step:

```
cd sdk && bun -F @cline/core typecheck
```

Exit 0.

3. Format and lint the touched files:

```
bun biome check --files-ignore-unknown=true sdk/packages/core/src/extensions/tools/definitions.ts sdk/packages/core/src/extensions/tools/definitions.test.ts
```

`Checked 2 files. No fixes applied.`

4. Whole package, `bun -F @cline/core test:unit`: 1550 pass. A handful of files fail on my Windows checkout for environmental reasons (a temp dir reporting `vcsType: git`, and some timing-sensitive runtime-builder specs). I confirmed these are not mine by running the suite with the change stashed and unstashed: the failing set is identical, and it drifts between runs on the same tree. Nothing under `src/extensions/tools/` fails either way.

What could break: only the wording of one tool result on the timeout path, plus its truncated form in the CLI TUI summary, both covered above.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore
-   [x] Tests are passing and code is formatted and linted
-   [x] I have reviewed contributor guidelines

### Screenshots

No visual change is intended. The one user-visible surface is the CLI TUI error line, quoted in the Blast radius section above.

### Additional Notes

Rebased on `bd218aa7`. Resolved against #13179, which restructured the same function to add per-command `emitUpdate` tagging; that plumbing is untouched here and the timeout fall-through it left in place is what this PR fixes.