### PR TITLE
fix(cli): offer configured providers in the ACP provider selector

### DIFF
--- a/apps/cli/src/acp/acpAgent.ts
+++ b/apps/cli/src/acp/acpAgent.ts
@@ -28,10 +28,11 @@ import {
 	type ClineCore,
 	Llms,
 	ProviderSettingsManager,
+	resolveProviderApiKeyFromSettings,
 	SessionSource,
 } from "@cline/core";
 import { isLikelyAuthError, type MessageWithMetadata } from "@cline/shared";
-import { getPersistedProviderApiKey } from "../commands/auth";
+import { getPersistedProviderApiKey, isOAuthProvider } from "../commands/auth";
 import { resolveSystemPrompt } from "../runtime/prompt";
 import { subscribeToAgentEvents } from "../runtime/session-events";
 import { createCliCore } from "../session/session";
@@ -61,6 +62,15 @@ import {
 	usesClineAccount,
 } from "./organizations";
 import { requestAcpToolApproval } from "./permissions";
+import {
+	type AcpProviderChoice,
+	type AcpProviderState,
+	buildProviderConfigOption,
+	PROVIDER_CONFIG_ID,
+	requiresAcpProviderAuth,
+	resolveAcpProviderApiKey,
+	selectableAcpProviders,
+} from "./providers";
 import { replaySessionHistory } from "./session-load";
 import {
 	describeAgentError,
@@ -234,7 +244,7 @@ export class AcpAgent implements Agent {
 				currentModelId: defaultModelId,
 			},
 			configOptions: [
-				await buildProviderConfigOption(providerId),
+				await this.providerConfigOption(providerId),
 				buildModelConfigOption(defaultModelId, providerModels),
 				buildModeConfigOption(defaultMode),
 				buildAutoApproveConfigOption(this.defaultAutoApproveTools),
@@ -318,7 +328,7 @@ export class AcpAgent implements Agent {
 				availableModels,
 				currentModelId: session.currentModelId,
 			},
-			configOptions: await buildAllConfigOptions(session),
+			configOptions: await this.buildAllConfigOptions(session),
 		};
 	}
 
@@ -460,17 +470,38 @@ export class AcpAgent implements Agent {
 		const value = params.value as string;
 
 		switch (params.configId) {
-			case "provider": {
+			case PROVIDER_CONFIG_ID: {
 				if (process.env.CLINE_PROVIDER) {
 					throw RequestError.invalidParams(
 						undefined,
 						"Cannot change provider: CLINE_PROVIDER environment variable is set",
 					);
 				}
-				if (!isAcpAuthMethodId(value)) {
+				const choices = await this.resolveProviderChoices();
+				if (
+					!selectableAcpProviders(choices).some((choice) => choice.id === value)
+				) {
 					throw RequestError.invalidParams(
 						undefined,
 						`Unknown provider: ${value}`,
+					);
+				}
+				if (
+					requiresAcpProviderAuth({
+						isOAuthProvider: isOAuthProvider(value),
+						isConfigured: choices.configured.some(
+							(choice) => choice.id === value,
+						),
+						envApiKey: process.env.CLINE_API_KEY,
+						persistedApiKey: resolveProviderApiKeyFromSettings(
+							this.providerSettingsManager,
+							value,
+						),
+					})
+				) {
+					throw RequestError.authRequired(
+						undefined,
+						`Not signed in to provider: ${value}`,
 					);
 				}
 
@@ -484,15 +515,21 @@ export class AcpAgent implements Agent {
 				// current one when it's offered there too, otherwise fall back to the
 				// provider's declared default rather than whichever model happens to
 				// be listed first (for cline-pass that is an unrelated free model).
+				// Providers that discover their models at runtime (ollama, lmstudio)
+				// ship an empty catalog, so fall back to the stored model before
+				// leaving the session without one.
 				const providerModels = await Llms.getModelsForProvider(
 					value,
 					CHAT_MODEL_QUERY_OPTIONS,
 				);
-				session.currentModelId = await resolveDefaultModelId(
-					value,
-					session.currentModelId,
-					providerModels,
-				);
+				session.currentModelId =
+					(await resolveDefaultModelId(
+						value,
+						session.currentModelId,
+						providerModels,
+					)) ||
+					this.providerSettingsManager.getProviderSettings(value)?.model ||
+					"";
 				break;
 			}
 
@@ -559,7 +596,7 @@ export class AcpAgent implements Agent {
 				);
 		}
 
-		const configOptions = await buildAllConfigOptions(session);
+		const configOptions = await this.buildAllConfigOptions(session);
 		const organizationOption = await this.getOrganizationConfigOption(
 			session.currentProviderId,
 		);
@@ -608,6 +645,46 @@ export class AcpAgent implements Agent {
 
 	private get accountApiKey(): string {
 		return process.env.CLINE_API_KEY ?? this.authResult?.apiKey ?? "";
+	}
+
+	private async resolveProviderChoices(): Promise<
+		Pick<AcpProviderState, "authMethods" | "configured">
+	> {
+		const configuredIds = Object.keys(
+			this.providerSettingsManager.read().providers,
+		);
+		const [authMethods, configured] = await Promise.all([
+			Promise.all(ACP_AUTH_METHODS.map((m) => toAcpProviderChoice(m.id))),
+			Promise.all(configuredIds.map(toAcpProviderChoice)),
+		]);
+		return { authMethods, configured };
+	}
+
+	private async providerConfigOption(
+		currentProviderId: string,
+	): Promise<SessionConfigOption> {
+		return buildProviderConfigOption({
+			...(await this.resolveProviderChoices()),
+			currentProviderId,
+		});
+	}
+
+	private async buildAllConfigOptions(
+		session: SessionState,
+	): Promise<SessionConfigOption[]> {
+		const [providerOption, providerModels] = await Promise.all([
+			this.providerConfigOption(session.currentProviderId),
+			Llms.getModelsForProvider(
+				session.currentProviderId,
+				CHAT_MODEL_QUERY_OPTIONS,
+			),
+		]);
+		return [
+			providerOption,
+			buildModelConfigOption(session.currentModelId, providerModels),
+			buildModeConfigOption(session.currentMode),
+			buildAutoApproveConfigOption(session.autoApproveTools),
+		];
 	}
 
 	private async getOrganizationConfigOption(
@@ -763,7 +840,16 @@ export class AcpAgent implements Agent {
 		const workspaceRoot = resolveWorkspaceRoot(cwd);
 		// Resolve credentials: env vars take precedence, then session provider.
 		const providerId = process.env.CLINE_PROVIDER ?? session.currentProviderId;
-		const apiKey = process.env.CLINE_API_KEY ?? this.authResult?.apiKey ?? "";
+		const apiKey = resolveAcpProviderApiKey({
+			providerId,
+			envApiKey: process.env.CLINE_API_KEY,
+			persistedApiKey: resolveProviderApiKeyFromSettings(
+				this.providerSettingsManager,
+				providerId,
+			),
+			authProviderId: this.authResult?.providerId,
+			authApiKey: this.authResult?.apiKey,
+		});
 		const systemPrompt = await resolveSystemPrompt({
 			cwd,
 			providerId,
@@ -851,27 +937,9 @@ function toAcpPromptError(error: Error): RequestError {
 		: RequestError.internalError({ message }, message);
 }
 
-async function buildProviderConfigOption(
-	currentProviderId: string,
-): Promise<SessionConfigOption> {
-	const options = await Promise.all(
-		ACP_AUTH_METHODS.map(async (m) => {
-			const provider = await Llms.getProvider(m.id);
-			return {
-				value: m.id,
-				name: provider?.name ?? m.id,
-			};
-		}),
-	);
-	return {
-		type: "select",
-		id: "provider",
-		name: "Provider",
-		description: "The authentication provider to use",
-		category: "model",
-		currentValue: currentProviderId,
-		options,
-	};
+async function toAcpProviderChoice(id: string): Promise<AcpProviderChoice> {
+	const provider = await Llms.getProvider(id);
+	return { id, name: provider?.name ?? id };
 }
 
 function buildModelConfigOption(
@@ -914,24 +982,6 @@ function buildModeConfigOption(currentMode: string): SessionConfigOption {
 			},
 		],
 	};
-}
-
-async function buildAllConfigOptions(
-	session: SessionState,
-): Promise<SessionConfigOption[]> {
-	const [providerOption, providerModels] = await Promise.all([
-		buildProviderConfigOption(session.currentProviderId),
-		Llms.getModelsForProvider(
-			session.currentProviderId,
-			CHAT_MODEL_QUERY_OPTIONS,
-		),
-	]);
-	return [
-		providerOption,
-		buildModelConfigOption(session.currentModelId, providerModels),
-		buildModeConfigOption(session.currentMode),
-		buildAutoApproveConfigOption(session.autoApproveTools),
-	];
 }
 
 function extractTextFromContentBlocks(blocks: ContentBlock[]): string {

--- a/apps/cli/src/acp/auth.ts
+++ b/apps/cli/src/acp/auth.ts
@@ -6,8 +6,8 @@ import { writeDiagnostic } from "../utils/output";
 /**
  * Supported ACP OAuth provider IDs.
  *
- * This list doubles as the set of selectable providers (see
- * `setSessionConfigOption`)
+ * Returned from `initialize` as the client's sign-in options. The selectable
+ * providers are a superset of this list (see `selectableAcpProviders`).
  */
 export const ACP_AUTH_METHODS = [
 	{ id: "cline", name: "Sign in with Cline" },

--- a/apps/cli/src/acp/providers.test.ts
+++ b/apps/cli/src/acp/providers.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildProviderConfigOption,
+	requiresAcpProviderAuth,
+	resolveAcpProviderApiKey,
+	selectableAcpProviders,
+} from "./providers";
+
+const authMethods = [
+	{ id: "cline", name: "Cline Usage-Billing" },
+	{ id: "cline-pass", name: "ClinePass" },
+	{ id: "openai-codex", name: "OpenAI ChatGPT Subscription" },
+];
+
+describe("selectableAcpProviders", () => {
+	it("offers a provider configured with an API key", () => {
+		const selectable = selectableAcpProviders({
+			authMethods,
+			configured: [{ id: "mistral", name: "Mistral" }],
+		});
+		expect(selectable.map((choice) => choice.id)).toEqual([
+			"cline",
+			"cline-pass",
+			"openai-codex",
+			"mistral",
+		]);
+	});
+
+	it("lists a provider that is both an auth method and configured once, in auth-method order", () => {
+		const selectable = selectableAcpProviders({
+			authMethods,
+			configured: [
+				{ id: "mistral", name: "Mistral" },
+				{ id: "cline", name: "Cline Usage-Billing" },
+			],
+		});
+		expect(selectable.map((choice) => choice.id)).toEqual([
+			"cline",
+			"cline-pass",
+			"openai-codex",
+			"mistral",
+		]);
+	});
+
+	it("falls back to the sign-in methods when nothing is configured", () => {
+		expect(selectableAcpProviders({ authMethods, configured: [] })).toEqual(
+			authMethods,
+		);
+	});
+});
+
+describe("buildProviderConfigOption", () => {
+	it("lists the sign-in methods followed by the configured providers", () => {
+		const option = buildProviderConfigOption({
+			authMethods: [{ id: "cline", name: "Cline Usage-Billing" }],
+			configured: [{ id: "mistral", name: "Mistral" }],
+			currentProviderId: "mistral",
+		});
+		expect(option.id).toBe("provider");
+		if (option.type !== "select") {
+			throw new Error(`expected a select option, got ${option.type}`);
+		}
+		expect(option.currentValue).toBe("mistral");
+		expect(option.options).toEqual([
+			{ value: "cline", name: "Cline Usage-Billing" },
+			{ value: "mistral", name: "Mistral" },
+		]);
+	});
+
+	it("preserves the current provider when it is a sign-in method", () => {
+		const option = buildProviderConfigOption({
+			authMethods: [{ id: "cline", name: "Cline Usage-Billing" }],
+			configured: [],
+			currentProviderId: "cline",
+		});
+		if (option.type !== "select") {
+			throw new Error(`expected a select option, got ${option.type}`);
+		}
+		expect(option.currentValue).toBe("cline");
+	});
+});
+
+describe("requiresAcpProviderAuth", () => {
+	it("requires a sign-in for an OAuth provider with no stored credentials", () => {
+		expect(
+			requiresAcpProviderAuth({ isOAuthProvider: true, isConfigured: false }),
+		).toBe(true);
+	});
+
+	it("still requires a sign-in when an OAuth provider has a credential-free entry", () => {
+		expect(
+			requiresAcpProviderAuth({ isOAuthProvider: true, isConfigured: true }),
+		).toBe(true);
+	});
+
+	it("allows a configured provider that needs no key", () => {
+		expect(
+			requiresAcpProviderAuth({ isOAuthProvider: false, isConfigured: true }),
+		).toBe(false);
+	});
+
+	it("allows an OAuth provider once its key is stored", () => {
+		expect(
+			requiresAcpProviderAuth({
+				isOAuthProvider: true,
+				isConfigured: false,
+				persistedApiKey: "stored-key",
+			}),
+		).toBe(false);
+	});
+
+	it("allows anything when the environment supplies a key", () => {
+		expect(
+			requiresAcpProviderAuth({
+				isOAuthProvider: true,
+				isConfigured: false,
+				envApiKey: "env-key",
+			}),
+		).toBe(false);
+	});
+
+	it("rejects an unconfigured provider that is not an auth method", () => {
+		expect(
+			requiresAcpProviderAuth({ isOAuthProvider: false, isConfigured: false }),
+		).toBe(true);
+	});
+});
+
+describe("resolveAcpProviderApiKey", () => {
+	it("never hands the sign-in key to a different provider", () => {
+		expect(
+			resolveAcpProviderApiKey({
+				providerId: "mistral",
+				authProviderId: "cline",
+				authApiKey: "cline-oauth-token",
+			}),
+		).toBe("");
+	});
+
+	it("uses the persisted key of the selected provider", () => {
+		expect(
+			resolveAcpProviderApiKey({
+				providerId: "mistral",
+				persistedApiKey: "mistral-key",
+				authProviderId: "cline",
+				authApiKey: "cline-oauth-token",
+			}),
+		).toBe("mistral-key");
+	});
+
+	it("falls back to the sign-in key only for the provider that signed in", () => {
+		expect(
+			resolveAcpProviderApiKey({
+				providerId: "cline",
+				authProviderId: "cline",
+				authApiKey: "cline-oauth-token",
+			}),
+		).toBe("cline-oauth-token");
+	});
+
+	it("returns an empty key for a keyless local provider", () => {
+		expect(
+			resolveAcpProviderApiKey({
+				providerId: "ollama",
+				authProviderId: "cline",
+				authApiKey: "cline-oauth-token",
+			}),
+		).toBe("");
+	});
+
+	it("lets the environment override everything", () => {
+		expect(
+			resolveAcpProviderApiKey({
+				providerId: "mistral",
+				envApiKey: "env-key",
+				persistedApiKey: "mistral-key",
+			}),
+		).toBe("env-key");
+	});
+});

--- a/apps/cli/src/acp/providers.ts
+++ b/apps/cli/src/acp/providers.ts
@@ -1,0 +1,80 @@
+import type { SessionConfigOption } from "@agentclientprotocol/sdk";
+
+export const PROVIDER_CONFIG_ID = "provider";
+
+export interface AcpProviderChoice {
+	id: string;
+	name: string;
+}
+
+export interface AcpProviderState {
+	authMethods: readonly AcpProviderChoice[];
+	configured: readonly AcpProviderChoice[];
+	currentProviderId: string;
+}
+
+export function selectableAcpProviders(
+	state: Pick<AcpProviderState, "authMethods" | "configured">,
+): AcpProviderChoice[] {
+	const selectable: AcpProviderChoice[] = [];
+	const seen = new Set<string>();
+	for (const choice of [...state.authMethods, ...state.configured]) {
+		if (seen.has(choice.id)) {
+			continue;
+		}
+		seen.add(choice.id);
+		selectable.push(choice);
+	}
+	return selectable;
+}
+
+export function requiresAcpProviderAuth(input: {
+	isOAuthProvider: boolean;
+	isConfigured: boolean;
+	envApiKey?: string;
+	persistedApiKey?: string;
+}): boolean {
+	if (input.envApiKey || input.persistedApiKey) {
+		return false;
+	}
+	if (input.isOAuthProvider) {
+		return true;
+	}
+	return !input.isConfigured;
+}
+
+export function resolveAcpProviderApiKey(input: {
+	providerId: string;
+	envApiKey?: string;
+	persistedApiKey?: string;
+	authProviderId?: string;
+	authApiKey?: string;
+}): string {
+	if (input.envApiKey) {
+		return input.envApiKey;
+	}
+	if (input.persistedApiKey) {
+		return input.persistedApiKey;
+	}
+	if (input.authProviderId === input.providerId && input.authApiKey) {
+		return input.authApiKey;
+	}
+	return "";
+}
+
+export function buildProviderConfigOption(
+	state: AcpProviderState,
+): SessionConfigOption {
+	return {
+		type: "select",
+		id: PROVIDER_CONFIG_ID,
+		name: "Provider",
+		description: "The provider to use for this session",
+		category: "model",
+		currentValue: state.currentProviderId,
+		options: selectableAcpProviders(state).map((choice) => ({
+			value: choice.id,
+			name: choice.name,
+		})),
+	};
+}


### PR DESCRIPTION
### Related Issue

Fixes #12043

### Description

The ACP provider select is built from `ACP_AUTH_METHODS` (`apps/cli/src/acp/auth.ts`), the OAuth
sign-in list returned by `initialize()`. `buildProviderConfigOption` mapped that same constant, and
`setSessionConfigOption` rejected anything outside it with `Unknown provider`, so a provider
configured with an API key through `cline auth` was structurally unreachable from Zed. The session
then stayed on the hosted Cline tier with no error, which is how the reporter ended up billed for
claude-sonnet-4.6 while believing Mistral was in use. The CLI's own TUI never had this limit, because
it sources its list from the stored provider settings.

That constant was doing two unrelated jobs. This splits them: `ACP_AUTH_METHODS` still backs
`initialize()`'s `authMethods`, and a new `apps/cli/src/acp/providers.ts` builds the selector by
merging the sign-in methods with providers that have stored settings, deduped by id.

Two things had to come with it, or the new option would just fail a different way:

- `buildConfig` took `providerId` from the session but `apiKey` from `this.authResult`. That is
  harmless today because `syncOAuthCredentials` re-resolves the key before every turn, but it only
  runs for `isOAuthProvider`, so a non-OAuth provider would have been handed the Cline token and hit
  a terminal 401. The key is now resolved for the selected provider, and the sign-in token is never
  passed to a different one.
- Selecting a provider with no stored credentials now returns `auth_required` instead of letting a
  wrong key reach the endpoint. Providers that legitimately need no key (ollama, lmstudio) are
  unaffected.

One more that this change exposes: providers discovering their models at runtime ship an empty
catalog, so `resolveDefaultModelId` returns `""` for them. That path was unreachable while only the
three auth methods were selectable; the model now falls back to the one stored for that provider.

**What does not change:** `initialize()`'s `authMethods` stays OAuth-only. Session auth gating
(`isSessionReady` / `tryRestoreAuth`) is untouched, so a session still requires signing in first.
The organization option, `authenticate()`, and the mode/model options are untouched, and
`session-load.ts` / `session-updates.ts` / `tool-utils.ts` / `permissions.ts` / `index.ts` are not
referenced.

### Test Procedure

`apps/cli/src/acp/providers.test.ts` covers the merge/dedupe, the credential predicate, and the key
resolution, including that the sign-in token is never returned for another provider. Written against
the old behaviour first: 3 failed, then green.

    cd apps/cli
    bun vitest run --config vitest.config.ts src/acp/     # 4 files, 31 tests passed
    bun tsc --noEmit                                      # exit 0
    bunx biome check src/acp/                             # no diagnostics

Worth flagging that CI will not cover this. `sdk-test.yml` only triggers on `sdk/**`, and
`ext-vscode-test.yml`'s paths-filter lists `apps/vscode/**`, `bun.lock` and `sdk/packages/**` but not
`apps/cli/**` — so its aggregate `test` job takes the "No root test paths changed" branch and exits 0
without running anything. The numbers above are local.

I also checked for collateral damage: `src/runtime/interactive/config-data.test.ts`,
`src/commands/update.test.ts` and `src/commands/doctor.test.ts` fail here (5 tests), but they fail
identically on a clean `main` with none of this applied, and nothing outside `src/acp/` imports it
(`main.ts` reaches it via a dynamic import behind `--acp`).

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore
-   [x] Tests are passing and code is formatted and linted
-   [x] I have reviewed contributor guidelines

### Screenshots

No visual change in this repo; the affected UI is the ACP client's own selector.

### Additional Notes

Deliberately narrow. Two things from the issue are left out:

- Zed's `default_config_options` (the second half of #12043) is still not consumed by `newSession`,
  which reads only `cwd` and `mcpServers`. Separate change.
- A user whose only credential is an API-key provider still cannot start a session, because
  `isSessionReady` / `tryRestoreAuth` scan only the OAuth methods. Widening that is an auth-gating
  decision I did not want to make unasked, happy to follow up if you want it.

The open question from the issue thread is still unanswered: is ACP intentionally scoped to the OAuth
sign-in providers? I assumed not. If it is, say so and I'll close this.