### PR TITLE
chore(vscode): remove dead next-gen model classifier

### DIFF
--- a/apps/vscode/src/utils/__tests__/model-utils.test.ts
+++ b/apps/vscode/src/utils/__tests__/model-utils.test.ts
@@ -8,8 +8,6 @@ import {
 	isGLMModelFamily,
 	isGPT5ModelFamily,
 	isGptOssModelFamily,
-	isNextGenModelFamily,
-	isPoolsideModelFamily,
 	modelDoesntSupportWebp,
 	shouldSkipReasoningForModel,
 } from "../model-utils"
@@ -115,24 +113,6 @@ describe("isGptOssModelFamily", () => {
 		isGptOssModelFamily("gpt-5").should.equal(false)
 		isGptOssModelFamily("gpt-4o").should.equal(false)
 		isGptOssModelFamily("claude-sonnet-4").should.equal(false)
-	})
-})
-
-describe("isPoolsideModelFamily", () => {
-	it("should return true for Laguna model IDs", () => {
-		isPoolsideModelFamily("poolside/laguna-m.1").should.equal(true)
-		isPoolsideModelFamily("laguna-enterprise").should.equal(true)
-		isPoolsideModelFamily("LAGUNA").should.equal(true)
-	})
-
-	it("should return false for non-Poolside model IDs", () => {
-		isPoolsideModelFamily("gpt-5").should.equal(false)
-		isPoolsideModelFamily("deepseek-chat").should.equal(false)
-		isPoolsideModelFamily("claude-sonnet-4").should.equal(false)
-	})
-
-	it("should qualify Laguna models for next-gen paths", () => {
-		isNextGenModelFamily("poolside/laguna-m.1").should.equal(true)
 	})
 })
 

--- a/apps/vscode/src/utils/model-utils.ts
+++ b/apps/vscode/src/utils/model-utils.ts
@@ -56,16 +56,6 @@ export function isClaude4PlusModelFamily(id: string): boolean {
 	return version >= 4
 }
 
-function isGemini2dot5ModelFamily(id: string): boolean {
-	const modelId = normalize(id)
-	return modelId.includes("gemini-2.5")
-}
-
-function isGrok4ModelFamily(id: string): boolean {
-	const modelId = normalize(id)
-	return modelId.includes("grok-4")
-}
-
 export function isGPT5ModelFamily(id: string): boolean {
 	const modelId = normalize(id)
 	return modelId.includes("gpt-5") || modelId.includes("gpt5")
@@ -90,24 +80,9 @@ export function isGLMModelFamily(id: string): boolean {
 	)
 }
 
-function isMinimaxModelFamily(id: string): boolean {
-	const modelId = normalize(id)
-	return modelId.includes("minimax")
-}
-
-function isNextGenOpenSourceModelFamily(id: string): boolean {
-	const modelId = normalize(id)
-	return ["kimi-k2"].some((substring) => modelId.includes(substring))
-}
-
 function isDevstralModelFamily(id: string): boolean {
 	const modelId = normalize(id)
 	return modelId.includes("devstral")
-}
-
-function isGemini3ModelFamily(id: string): boolean {
-	const modelId = normalize(id)
-	return modelId.includes("gemini3") || modelId.includes("gemini-3")
 }
 
 export function isGeminiFlashModel(id: string): boolean {
@@ -115,38 +90,6 @@ export function isGeminiFlashModel(id: string): boolean {
 	const isGooglePrefixedGemini = modelId.startsWith("google/gemini")
 	const isDirectGemini = modelId.startsWith("gemini-")
 	return (isGooglePrefixedGemini || isDirectGemini) && modelId.includes("flash")
-}
-
-function isDeepSeek32ModelFamily(id: string): boolean {
-	const modelId = normalize(id)
-	return modelId.includes("deepseek") && modelId.includes("3.2") && !modelId.includes("speciale")
-}
-
-function isDeepSeekNativeModelFamily(id: string): boolean {
-	const modelId = normalize(id)
-	return modelId.includes("deepseek-chat") || modelId.includes("deepseek-reasoner")
-}
-
-export function isPoolsideModelFamily(id: string): boolean {
-	const modelId = normalize(id)
-	return modelId.includes("laguna")
-}
-
-export function isNextGenModelFamily(id: string): boolean {
-	const modelId = normalize(id)
-	return (
-		isClaude4PlusModelFamily(modelId) ||
-		isGemini2dot5ModelFamily(modelId) ||
-		isGrok4ModelFamily(modelId) ||
-		isGPT5ModelFamily(modelId) ||
-		isGptOssModelFamily(modelId) ||
-		isMinimaxModelFamily(modelId) ||
-		isGemini3ModelFamily(modelId) ||
-		isNextGenOpenSourceModelFamily(modelId) ||
-		isDeepSeek32ModelFamily(modelId) ||
-		isDeepSeekNativeModelFamily(modelId) ||
-		isPoolsideModelFamily(modelId)
-	)
 }
 
 /**


### PR DESCRIPTION
### Related Issue

**Issue:** Review follow-up from #11269

### Description

The VS Code SDK migration removed every production caller of `isNextGenModelFamily`, while model capabilities moved into the SDK catalog. The old classifier and its private model-name helpers remained alongside tests that only exercised those dead exports.

Remove that uncalled classifier chain so stale handwritten model policy cannot be mistaken for active SDK behavior. This cleanup was identified while reviewing #11269: https://github.com/cline/cline/pull/11269#issuecomment-5171223918

### Test Procedure

- `bun test apps/vscode/src/utils/__tests__/model-utils.test.ts`
- `cd apps/vscode && bunx biome check --diagnostic-level=error src/utils/model-utils.ts src/utils/__tests__/model-utils.test.ts`
- `cd apps/vscode && bunx tsc --noEmit`
- `cd apps/vscode && bunx tsc --project tsconfig.vscode-compat.json --noEmit`
- `cd apps/vscode/webview-ui && bunx tsc --noEmit`
- `git diff --check`

### Type of Change

-   [x] ♻️ Refactor Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

Inventory review found no remaining callers or changed runtime boundary. The diff contains 77 deletions and no additions.
