### PR TITLE
fix(cli): deliver Telegram slash commands to the connector command host

### DIFF
--- a/apps/cli/src/connectors/adapters/telegram.test.ts
+++ b/apps/cli/src/connectors/adapters/telegram.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import type { ConnectTelegramOptions } from "@cline/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CONNECT_ALREADY_RUNNING_EXIT_CODE } from "../common";
+import { handleConnectorUserTurn } from "../connector-host";
 import { __test__, telegramConnector } from "./telegram";
 
 const mocks = vi.hoisted(() => ({
@@ -466,5 +467,324 @@ describe("telegram binding lookup", () => {
 		);
 
 		expect(result).toBeUndefined();
+	});
+});
+
+type SlashTestState = Record<string, unknown>;
+
+function createSlashTestThread(input: {
+	id: string;
+	channelId: string;
+	isDM: boolean;
+	initialState?: SlashTestState;
+}) {
+	let state: SlashTestState = { ...(input.initialState ?? {}) };
+	const posts: unknown[] = [];
+	let subscribed = false;
+	const thread = {
+		id: input.id,
+		channelId: input.channelId,
+		isDM: input.isDM,
+		get state() {
+			return Promise.resolve(state);
+		},
+		async setState(nextState: SlashTestState) {
+			state = { ...nextState };
+		},
+		async subscribe() {
+			subscribed = true;
+		},
+		async post(message: unknown) {
+			posts.push(message);
+			const sentMessage = {
+				edit: async (nextMessage: unknown) => {
+					posts.push(nextMessage);
+					return sentMessage;
+				},
+				delete: async () => undefined,
+			};
+			return sentMessage;
+		},
+		async startTyping() {},
+		toJSON() {
+			return {
+				id: input.id,
+				channelId: input.channelId,
+				isDM: input.isDM,
+				state,
+			};
+		},
+	};
+	return {
+		thread,
+		posts,
+		getState: () => state,
+		isSubscribed: () => subscribed,
+	};
+}
+
+function slashTestStartRequest() {
+	return {
+		enableTools: false,
+		autoApproveTools: false,
+		cwd: "/tmp/work",
+		workspaceRoot: "/tmp/work",
+		systemPrompt: "system",
+		provider: "cline",
+		model: "test-model",
+		mode: "act",
+	};
+}
+
+describe("telegram slash command delivery", () => {
+	it("receives bot_command updates intercepted by the telegram chat library", async () => {
+		// The Telegram Bot API tags any leading-slash message with a
+		// `bot_command` entity, and @chat-adapter/telegram diverts those
+		// updates away from the mention/subscribed-message handlers. This
+		// pins the delivery contract: an intercepted update must still reach
+		// the connector turn handler through the slash-command path.
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response(JSON.stringify({ ok: true, result: {} }), {
+						status: 200,
+					}),
+			),
+		);
+		const { createTelegramAdapter } = await import("@chat-adapter/telegram");
+		const { Chat, ConsoleLogger } = await import("chat");
+		const { InMemoryStateAdapter } = await import("../stores/memory-state");
+		const telegram = createTelegramAdapter({
+			mode: "polling",
+			botToken: "123456:TEST-TOKEN",
+			userName: "test_bot",
+			logger: new ConsoleLogger("error", "telegram-slash-test"),
+		});
+		const bot = new Chat({
+			userName: "test_bot",
+			adapters: { telegram },
+			state: new InMemoryStateAdapter(),
+			logger: new ConsoleLogger("error", "telegram-slash-test"),
+		});
+		// bot.initialize() assigns this reference before polling starts; set
+		// it directly to avoid the real getMe/long-polling network calls.
+		(telegram as unknown as { chat: unknown }).chat = bot;
+
+		const dir = mkdtempSync(join(tmpdir(), "cline-telegram-slash-"));
+		tempDataDirs.push(dir);
+		const turns: Array<{ threadId: string; isDM: boolean; text: string }> = [];
+		bot.onSlashCommand(
+			__test__.createTelegramSlashCommandHandler({
+				bot,
+				bindingsPath: join(dir, "threads.json"),
+				baseStartRequest: slashTestStartRequest() as never,
+				handleTurn: async (thread, text) => {
+					turns.push({ threadId: thread.id, isDM: thread.isDM, text });
+				},
+			}) as never,
+		);
+
+		const completions: Promise<unknown>[] = [];
+		(
+			telegram as unknown as {
+				processUpdate: (update: unknown, options?: unknown) => void;
+			}
+		).processUpdate(
+			{
+				update_id: 1,
+				message: {
+					message_id: 42,
+					date: Math.floor(Date.now() / 1000),
+					chat: { id: 555, type: "private" },
+					from: {
+						id: 999,
+						is_bot: false,
+						first_name: "Alice",
+						username: "alice",
+					},
+					text: "/clear",
+					entities: [{ type: "bot_command", offset: 0, length: 6 }],
+				},
+			},
+			{
+				waitUntil: (task: Promise<unknown>) =>
+					completions.push(task.catch(() => undefined)),
+			},
+		);
+		await Promise.all(completions);
+		await vi.waitFor(() => {
+			expect(turns).toHaveLength(1);
+		});
+
+		expect(turns[0]).toEqual({
+			threadId: "telegram:555",
+			isDM: true,
+			text: "/clear",
+		});
+	});
+
+	it("routes intercepted slash commands into the connector turn handler", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "cline-telegram-slash-"));
+		tempDataDirs.push(dir);
+		const bindingsPath = join(dir, "threads.json");
+		const { thread, isSubscribed, getState } = createSlashTestThread({
+			id: "telegram:12345",
+			channelId: "telegram:12345",
+			isDM: true,
+		});
+		const botThread = vi.fn(() => thread);
+		const handleTurn = vi.fn(async () => undefined);
+		const handler = __test__.createTelegramSlashCommandHandler({
+			bot: { thread: botThread } as never,
+			bindingsPath,
+			baseStartRequest: slashTestStartRequest() as never,
+			handleTurn: handleTurn as never,
+		});
+
+		await handler({
+			channel: { id: "telegram:12345" },
+			command: "/clear",
+			text: "",
+			raw: {
+				message_id: 7,
+				chat: { id: 12345, type: "private" },
+				from: { id: 999, username: "alice", first_name: "Alice" },
+				text: "/clear",
+				entities: [{ type: "bot_command", offset: 0, length: 6 }],
+			},
+		});
+
+		expect(botThread).toHaveBeenCalledWith("telegram:12345");
+		expect(isSubscribed()).toBe(true);
+		expect(handleTurn).toHaveBeenCalledWith(thread, "/clear");
+		expect(getState().participantKey).toBe("telegram:id:999");
+	});
+
+	it("preserves group-chat bot addressing in the forwarded command text", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "cline-telegram-slash-"));
+		tempDataDirs.push(dir);
+		const { thread } = createSlashTestThread({
+			id: "telegram:-100200",
+			channelId: "telegram:-100200",
+			isDM: false,
+		});
+		const handleTurn = vi.fn(async () => undefined);
+		const handler = __test__.createTelegramSlashCommandHandler({
+			bot: { thread: () => thread } as never,
+			bindingsPath: join(dir, "threads.json"),
+			baseStartRequest: slashTestStartRequest() as never,
+			handleTurn: handleTurn as never,
+		});
+
+		// The chat adapter strips "@test_bot" into command targeting before
+		// invoking slash handlers; the raw message text keeps it so the
+		// connector host can enforce group addressing rules.
+		await handler({
+			channel: { id: "telegram:-100200" },
+			command: "/tools",
+			text: "on",
+			raw: {
+				message_id: 8,
+				chat: { id: -100200, type: "supergroup" },
+				from: { id: 999, username: "alice" },
+				text: "/tools@test_bot on",
+				entities: [{ type: "bot_command", offset: 0, length: 15 }],
+			},
+		});
+
+		expect(handleTurn).toHaveBeenCalledWith(thread, "/tools@test_bot on");
+	});
+
+	it("falls back to the parsed command when the raw payload has no text", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "cline-telegram-slash-"));
+		tempDataDirs.push(dir);
+		const { thread } = createSlashTestThread({
+			id: "telegram:12345",
+			channelId: "telegram:12345",
+			isDM: true,
+		});
+		const handleTurn = vi.fn(async () => undefined);
+		const handler = __test__.createTelegramSlashCommandHandler({
+			bot: { thread: () => thread } as never,
+			bindingsPath: join(dir, "threads.json"),
+			baseStartRequest: slashTestStartRequest() as never,
+			handleTurn: handleTurn as never,
+		});
+
+		await handler({
+			channel: { id: "telegram:12345" },
+			command: "/cwd",
+			text: "/tmp",
+			raw: undefined,
+		});
+
+		expect(handleTurn).toHaveBeenCalledWith(thread, "/cwd /tmp");
+	});
+
+	it("delivers intercepted slash commands to the chat command host", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "cline-telegram-slash-"));
+		tempDataDirs.push(dir);
+		const bindingsPath = join(dir, "threads.json");
+		const { thread, posts } = createSlashTestThread({
+			id: "telegram:777",
+			channelId: "telegram:777",
+			isDM: true,
+			initialState: {
+				sessionId: "session-1",
+				participantKey: "telegram:id:999",
+				participantLabel: "alice",
+				welcomeSentAt: "2026-03-17T00:00:00.000Z",
+			},
+		});
+		const stopRuntimeSession = vi.fn(async () => undefined);
+		const deleteSession = vi.fn(async () => undefined);
+		const baseStartRequest = slashTestStartRequest();
+		const handler = __test__.createTelegramSlashCommandHandler({
+			bot: { thread: () => thread } as never,
+			bindingsPath,
+			baseStartRequest: baseStartRequest as never,
+			handleTurn: (async (
+				turnThread: typeof thread,
+				text: string,
+			): Promise<void> => {
+				await handleConnectorUserTurn({
+					thread: turnThread as never,
+					text,
+					client: { stopRuntimeSession, deleteSession } as never,
+					pendingApprovals: new Map(),
+					baseStartRequest: baseStartRequest as never,
+					explicitSystemPrompt: undefined,
+					clientId: "client-1",
+					logger: {
+						core: { debug: vi.fn(), log: vi.fn(), error: vi.fn() },
+					} as never,
+					transport: "telegram",
+					botUserName: "test_bot",
+					requestStop: vi.fn(),
+					bindingsPath,
+					systemRules: "rules",
+					errorLabel: "Telegram",
+					getSessionMetadata: () => ({}),
+					reusedLogMessage: "reused",
+				});
+			}) as never,
+		});
+
+		await handler({
+			channel: { id: "telegram:777" },
+			command: "/clear",
+			text: "",
+			raw: {
+				message_id: 9,
+				chat: { id: 777, type: "private" },
+				from: { id: 999, username: "alice" },
+				text: "/clear",
+				entities: [{ type: "bot_command", offset: 0, length: 6 }],
+			},
+		});
+
+		expect(deleteSession).toHaveBeenCalledWith("session-1", true);
+		expect(posts).toContainEqual({ raw: "Started a fresh session." });
 	});
 });

--- a/apps/cli/src/connectors/adapters/telegram.ts
+++ b/apps/cli/src/connectors/adapters/telegram.ts
@@ -266,6 +266,55 @@ async function persistTelegramThreadContext(input: {
 	);
 }
 
+type TelegramSlashCommandEvent = {
+	channel: { id: string };
+	command: string;
+	text: string;
+	raw: unknown;
+};
+
+/**
+ * The Telegram chat adapter intercepts any message whose leading entity is a
+ * `bot_command` and delivers it to slash-command handlers instead of the
+ * normal mention/subscribed-message handlers. Without a registered handler
+ * the command is consumed and dropped, so connector commands like /clear
+ * never reach the chat command host. Rebuild the originating chat thread and
+ * forward the original message text (preserving any `@bot` addressing used
+ * in group chats) into the same turn pipeline as regular messages.
+ */
+function createTelegramSlashCommandHandler(input: {
+	bot: Pick<Chat, "thread">;
+	bindingsPath: string;
+	baseStartRequest: ChatStartSessionRequest;
+	handleTurn: (
+		thread: Thread<TelegramThreadState>,
+		text: string,
+	) => Promise<void>;
+}): (event: TelegramSlashCommandEvent) => Promise<void> {
+	return async (event) => {
+		const raw = asRecord(event.raw);
+		const commandText =
+			readString(raw?.text) ??
+			readString(raw?.caption) ??
+			[event.command.trim(), event.text.trim()].filter(Boolean).join(" ");
+		if (!commandText) {
+			return;
+		}
+		const thread = input.bot.thread(
+			event.channel.id,
+		) as Thread<TelegramThreadState>;
+		await thread.subscribe();
+		await persistTelegramThreadContext({
+			thread,
+			bindingsPath: input.bindingsPath,
+			baseStartRequest: input.baseStartRequest,
+			rawMessage: event.raw,
+			errorLabel: "Telegram",
+		});
+		await input.handleTurn(thread, commandText);
+	};
+}
+
 async function deliverScheduledResult(input: {
 	bot: Chat;
 	client: HubSessionClient;
@@ -1007,6 +1056,15 @@ class TelegramConnector extends ConnectorBase<
 			await handleTurn(thread, message.text);
 		});
 
+		bot.onSlashCommand(
+			createTelegramSlashCommandHandler({
+				bot,
+				bindingsPath,
+				baseStartRequest: startRequest,
+				handleTurn,
+			}),
+		);
+
 		await bot.initialize();
 		const stopTaskUpdateStream =
 			startConnectorTaskUpdateRelay<TelegramThreadState>({
@@ -1151,6 +1209,7 @@ export const telegramConnector: ConnectCommandDefinition =
 	new TelegramConnector();
 
 export const __test__ = {
+	createTelegramSlashCommandHandler,
 	fetchTelegramBotUsername,
 	readTelegramBotId,
 	resolveTelegramBotUsername,


### PR DESCRIPTION
### Related Issue

**Issue:** #12871

### Description

Sending `/clear` (or any other connector slash command) to a bot running `cline connect telegram` did nothing: no reply, no session reset. The `@chat-adapter/telegram` library intercepts any message whose leading entity is a Telegram `bot_command` in `handleSlashCommandUpdate` and routes it to registered slash-command handlers instead of the normal `onNewMention`/`onSubscribedMessage` path — and it does this unconditionally, whether or not a handler is registered. The Telegram connector registered no `onSlashCommand` handler (unlike `discord.ts` and `slack.ts`), so every slash message was consumed by the library and silently dropped before the connector ever saw it.

This PR registers a slash-command handler in `apps/cli/src/connectors/adapters/telegram.ts` that:

- rebuilds the originating chat thread via `bot.thread(...)` (which derives the correct thread id, channel id, and DM flag from the adapter, so the thread matches the binding used by regular messages in the same chat),
- subscribes the thread and persists the Telegram participant context, exactly like the mention/subscribed-message handlers do,
- forwards the **original raw message text** (falling back to the parsed `command + text`) into the existing `handleTurn` pipeline. Using the raw text preserves `@bot` addressing (e.g. `/clear@my_bot`), so the connector host's existing group-chat addressing, mute, and owner rules apply unchanged.

From there the command flows through `handleConnectorUserTurn` → `maybeHandleChatCommand` with the full command context (`reset`, `abort`, `stop`, `mute`/`unmute`, `describe`, `schedule`), so the whole connector command set (`/clear`, `/new`, `/abort`, `/mute`, `/unmute`, `/exit`, `/whereami`, `/tools`, `/yolo`, `/cwd`, `/help`, `/team`, `/schedule`) now works on Telegram. Discord/Slack already had this handler; whatsapp/gchat/linear adapters perform no slash interception, so they were never affected.

### Test Procedure

New tests in `apps/cli/src/connectors/adapters/telegram.test.ts` (the delivery-path coverage the issue flags as missing):

- **Library interception contract:** feeds a real `bot_command` update through the installed `@chat-adapter/telegram`'s `processUpdate` (with `fetch` stubbed) and asserts it reaches the connector turn handler with the right thread id, DM flag, and text. This test fails on the un-patched connector — I verified the pre-fix behavior with a repro script where the same update produced zero handler invocations.
- **Handler unit tests:** DM `/clear` routes to `handleTurn` with thread subscription and participant persistence; group-chat raw text keeps the `/tools@test_bot on` addressing; parsed-command fallback is used when the raw payload has no text.
- **Bridge to the command host:** a `/clear` slash event flows through the handler into the real `handleConnectorUserTurn` and executes — the old session is deleted and the thread receives "Started a fresh session."

Verification runs:

- `bun -F @cline/cli test:unit` — all 1008 tests in 126 files pass, including the 5 new ones.
- `bun run typecheck` (apps/cli) — clean.
- `bunx biome check` on the changed files — clean.

Pre-fix repro evidence (same simulated update, connector without the handler, via a throwaway script exercising the real library path):

```
handler invocations: []
CONFIRMED BUG SHAPE: /clear was consumed by the library and never reached the connector handlers
```

Post-fix, the identical update yields:

```
handleTurn invocations: [ { "threadId": "telegram:555", "isDM": true, "text": "/clear" } ]
PASS: /clear bot_command update reached the connector turn handler
```

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Backend/CLI change — see the terminal evidence in the Test Procedure section.

### Additional Notes

The secondary hazard called out in the issue (a handler that only supplies partial command context silently dropping `/clear`, `/abort`, `/exit`, `/mute`, `/unmute`) is avoided by design here: the handler feeds the shared `handleTurn` → `handleConnectorUserTurn` pipeline, which always builds the complete command context, rather than wiring a bespoke context.