### PR TITLE
fix(llms): substitute image content for models without image support

### DIFF
--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -29,6 +29,7 @@ import { extractErrorMessage } from "./format";
 import {
 	isAnthropicCompatibleModel,
 	isCerebrasProvider,
+	modelSupportsImageInput,
 	resolveModelFamily,
 } from "./model-facts";
 import {
@@ -80,6 +81,7 @@ function buildCachedAiSdkMessages(
 ) {
 	const aiMessages = toAiSdkMessages(request.messages, systemPrompt, {
 		includeReasoning: shouldIncludeReasoningHistory(request, context),
+		supportsImages: modelSupportsImageInput(context),
 	}) as Array<Record<string, unknown>>;
 	const includeAnthropic = isAnthropicCompatibleModel({
 		modelId: request.modelId,
@@ -280,7 +282,7 @@ async function ensureGatewayLangfuseTelemetry(
 function toAiSdkMessages(
 	messages: readonly AgentMessage[],
 	systemPrompt?: string,
-	options?: { includeReasoning?: boolean },
+	options?: { includeReasoning?: boolean; supportsImages?: boolean },
 ) {
 	const includeReasoning = options?.includeReasoning ?? true;
 	const normalizedMessages: AiSdkFormatterMessage[] = [];
@@ -387,6 +389,7 @@ function toAiSdkMessages(
 
 	return formatMessagesForAiSdk(systemPrompt, normalizedMessages, {
 		assistantToolCallArgKey: "input",
+		supportsImages: options?.supportsImages,
 	});
 }
 
@@ -1213,6 +1216,7 @@ function createAiSdkProvider(kind: ProviderModuleKind): GatewayProviderFactory {
 					? buildCachedAiSdkMessages(request, context, messagesSystemPrompt)
 					: toAiSdkMessages(request.messages, messagesSystemPrompt, {
 							includeReasoning: shouldIncludeReasoningHistory(request, context),
+							supportsImages: modelSupportsImageInput(context),
 						});
 				const providerOptions = composeAiSdkProviderOptions(
 					request,

--- a/sdk/packages/llms/src/providers/gateway.test.ts
+++ b/sdk/packages/llms/src/providers/gateway.test.ts
@@ -13,6 +13,7 @@ import {
 	type AgentModelEvent,
 	estimateRequestInputTokens,
 	type GatewayModelHandleOptions,
+	IMAGE_UNSUPPORTED_PLACEHOLDER,
 	type ITelemetryService,
 } from "@cline/shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -1213,6 +1214,159 @@ describe("sdk-gateway", () => {
 			{ role: "user", content: [{ type: "text", text: "tell me more" }] },
 		]);
 		expect(JSON.stringify(call?.messages)).not.toContain("reasoning");
+	});
+
+	describe("image capability gating", () => {
+		// Simulates a "wedged" history: an image entered the conversation at
+		// message N (user attachment + a tool result carrying an image), and
+		// every request built after that must stay valid for the target model.
+		const imageBase64 = Buffer.alloc(24, 7).toString("base64");
+		const imageHistory: AgentMessage[] = [
+			{
+				id: "user_1",
+				role: "user",
+				content: [{ type: "text", text: "Hello" }],
+				createdAt: Date.now(),
+			},
+			{
+				id: "user_2",
+				role: "user",
+				content: [
+					{ type: "text", text: "see this screenshot" },
+					{
+						type: "image",
+						image: `data:image/png;base64,${imageBase64}`,
+						mediaType: "image/png",
+					},
+				],
+				createdAt: Date.now(),
+			},
+			{
+				id: "assistant_1",
+				role: "assistant",
+				content: [
+					{
+						type: "tool-call",
+						toolCallId: "call_img",
+						toolName: "read_file",
+						input: { path: "/tmp/image.png" },
+					},
+				],
+				createdAt: Date.now(),
+			},
+			{
+				id: "user_3",
+				role: "user",
+				content: [
+					{
+						type: "tool-result",
+						toolCallId: "call_img",
+						toolName: "read_file",
+						output: [
+							{ type: "text", text: "Successfully read image" },
+							{ type: "image", data: imageBase64, mediaType: "image/png" },
+						],
+					},
+				],
+				createdAt: Date.now(),
+			},
+			{
+				id: "user_4",
+				role: "user",
+				content: [{ type: "text", text: "continue" }],
+				createdAt: Date.now(),
+			},
+		];
+
+		it("substitutes image content with placeholder text for models without image input", async () => {
+			mockSuccessfulStream();
+
+			const gateway = createGateway({
+				providerConfigs: [
+					{ providerId: "deepseek", apiKey: "deepseek-key" },
+				],
+			});
+
+			await collect(
+				await gateway.stream({
+					providerId: "deepseek",
+					// Catalog entry advertises no "images" capability.
+					modelId: "deepseek-chat",
+					messages: imageHistory,
+				}),
+			);
+
+			const call = streamTextSpy.mock.calls.at(-1)?.[0] as
+				| { messages?: unknown }
+				| undefined;
+			const serialized = JSON.stringify(call?.messages);
+			expect(serialized).toContain(IMAGE_UNSUPPORTED_PLACEHOLDER);
+			expect(serialized).not.toContain(imageBase64);
+			expect(serialized).not.toContain('"type":"image"');
+			expect(serialized).not.toContain('"type":"image-data"');
+		});
+
+		it("keeps image content for models that advertise image input", async () => {
+			mockSuccessfulStream();
+
+			const gateway = createGateway({
+				providerConfigs: [
+					{
+						providerId: "deepseek",
+						apiKey: "deepseek-key",
+						models: [
+							{
+								id: "deepseek-vision",
+								name: "DeepSeek Vision",
+								capabilities: ["text", "images"],
+							},
+						],
+					},
+				],
+			});
+
+			await collect(
+				await gateway.stream({
+					providerId: "deepseek",
+					modelId: "deepseek-vision",
+					messages: imageHistory,
+				}),
+			);
+
+			const call = streamTextSpy.mock.calls.at(-1)?.[0] as
+				| { messages?: unknown }
+				| undefined;
+			const serialized = JSON.stringify(call?.messages);
+			expect(serialized).toContain(imageBase64);
+			expect(serialized).not.toContain(IMAGE_UNSUPPORTED_PLACEHOLDER);
+		});
+
+		it("keeps image content for models with no capability data (fail open)", async () => {
+			mockSuccessfulStream();
+
+			const gateway = createGateway({
+				providerConfigs: [
+					{ providerId: "deepseek", apiKey: "deepseek-key" },
+				],
+			});
+
+			await collect(
+				await gateway.stream({
+					providerId: "deepseek",
+					// Not in the catalog: resolves to an unregistered model
+					// definition without capability data.
+					modelId: "some-unknown-model",
+					messages: imageHistory,
+				}),
+			);
+
+			const call = streamTextSpy.mock.calls.at(-1)?.[0] as
+				| { messages?: unknown }
+				| undefined;
+			const serialized = JSON.stringify(call?.messages);
+			expect(serialized).toContain(imageBase64);
+			expect(serialized).not.toContain(IMAGE_UNSUPPORTED_PLACEHOLDER);
+		});
 	});
 
 	it("reads Anthropic cache usage from provider metadata", async () => {

--- a/sdk/packages/llms/src/providers/model-facts.ts
+++ b/sdk/packages/llms/src/providers/model-facts.ts
@@ -311,6 +311,22 @@ export function isDeepSeekFamily(context: GatewayProviderContext): boolean {
 	return normalizedFamily(context).includes("deepseek");
 }
 
+/**
+ * Whether the resolved model advertises image input (`"images"` in its
+ * gateway capabilities). Models with no capability data at all (e.g. ids
+ * resolved outside any catalog) fail open: images are kept rather than
+ * hidden from a possibly capable model.
+ */
+export function modelSupportsImageInput(
+	context: GatewayProviderContext,
+): boolean {
+	const capabilities = context.model.capabilities;
+	if (!capabilities) {
+		return true;
+	}
+	return capabilities.includes("images");
+}
+
 export function getReasoningDefaultOnMetadata(
 	context: GatewayProviderContext,
 ): boolean | undefined {

--- a/sdk/packages/shared/src/index.browser.ts
+++ b/sdk/packages/shared/src/index.browser.ts
@@ -136,6 +136,7 @@ export {
 	DEFAULT_MAX_IMAGE_ENCODED_BYTES,
 	DEFAULT_MAX_TOTAL_MEDIA_BYTES,
 	IMAGE_OMITTED_PLACEHOLDER,
+	IMAGE_UNSUPPORTED_PLACEHOLDER,
 	type ImageMediaLimits,
 	type ImageMediaValidationFailure,
 	type ImageMediaValidationResult,

--- a/sdk/packages/shared/src/index.ts
+++ b/sdk/packages/shared/src/index.ts
@@ -152,6 +152,7 @@ export {
 	DEFAULT_MAX_IMAGE_ENCODED_BYTES,
 	DEFAULT_MAX_TOTAL_MEDIA_BYTES,
 	IMAGE_OMITTED_PLACEHOLDER,
+	IMAGE_UNSUPPORTED_PLACEHOLDER,
 	type ImageMediaLimits,
 	type ImageMediaValidationFailure,
 	type ImageMediaValidationResult,

--- a/sdk/packages/shared/src/llms/ai-sdk-format.test.ts
+++ b/sdk/packages/shared/src/llms/ai-sdk-format.test.ts
@@ -5,6 +5,7 @@ import {
 	sanitizeSurrogates,
 	toAiSdkToolResultOutput,
 } from "./ai-sdk-format";
+import { IMAGE_UNSUPPORTED_PLACEHOLDER } from "./media";
 
 describe("formatMessagesForAiSdk", () => {
 	const imageData = (byteLength: number, fill = 1) =>
@@ -1230,5 +1231,181 @@ describe("formatMessagesForAiSdk - surrogate sanitization", () => {
 			text: string;
 		}>;
 		expect(content[0]?.text).toContain("file \uFFFD");
+	});
+});
+
+describe("formatMessagesForAiSdk - models without image support", () => {
+	const imageData = (byteLength: number, fill = 1) =>
+		Buffer.alloc(byteLength, fill).toString("base64");
+
+	it("substitutes user image parts with placeholder text", () => {
+		const image = imageData(16);
+		const messages = formatMessagesForAiSdk(
+			undefined,
+			[
+				{
+					role: "user",
+					content: [
+						{ type: "text", text: "look at this" },
+						{ type: "image", image, mediaType: "image/png" },
+					],
+				},
+			],
+			{ supportsImages: false },
+		);
+
+		expect(messages).toEqual([
+			{
+				role: "user",
+				content: [
+					{ type: "text", text: "look at this" },
+					{ type: "text", text: IMAGE_UNSUPPORTED_PLACEHOLDER },
+				],
+			},
+		]);
+		expect(JSON.stringify(messages)).not.toContain(image);
+	});
+
+	it("keeps user image parts when supportsImages is explicitly true", () => {
+		const image = imageData(16);
+		const messages = formatMessagesForAiSdk(
+			undefined,
+			[
+				{
+					role: "user",
+					content: [{ type: "image", image, mediaType: "image/png" }],
+				},
+			],
+			{ supportsImages: true },
+		);
+
+		expect(messages).toEqual([
+			{
+				role: "user",
+				content: [{ type: "image", image, mediaType: "image/png" }],
+			},
+		]);
+	});
+
+	it("substitutes image blocks inside tool-result content arrays", () => {
+		const image = imageData(16);
+		const messages = formatMessagesForAiSdk(
+			undefined,
+			[
+				{
+					role: "user",
+					content: [
+						{
+							type: "tool-result",
+							toolCallId: "call_img",
+							toolName: "read_file",
+							output: [
+								{ type: "text", text: "Successfully read image" },
+								{ type: "image", data: image, mediaType: "image/jpeg" },
+							],
+						},
+					],
+				},
+			],
+			{ supportsImages: false },
+		);
+
+		expect(messages).toEqual([
+			{
+				role: "tool",
+				content: [
+					{
+						type: "tool-result",
+						toolCallId: "call_img",
+						toolName: "read_file",
+						output: {
+							type: "content",
+							value: [
+								{ type: "text", text: "Successfully read image" },
+								{ type: "text", text: IMAGE_UNSUPPORTED_PLACEHOLDER },
+							],
+						},
+					},
+				],
+			},
+		]);
+		expect(JSON.stringify(messages)).not.toContain(image);
+	});
+
+	it("substitutes nested images in structured tool results without hoisting", () => {
+		const image = imageData(16);
+		const messages = formatMessagesForAiSdk(
+			undefined,
+			[
+				{
+					role: "user",
+					content: [
+						{
+							type: "tool-result",
+							toolCallId: "call_img",
+							toolName: "read_files",
+							output: [
+								{
+									query: "/tmp/image.jpg",
+									result: [
+										{ type: "text", text: "Successfully read image" },
+										{ type: "image", data: image, mediaType: "image/jpeg" },
+									],
+									success: true,
+								},
+							],
+						},
+					],
+				},
+			],
+			{ supportsImages: false },
+		);
+
+		expect(messages).toEqual([
+			{
+				role: "tool",
+				content: [
+					{
+						type: "tool-result",
+						toolCallId: "call_img",
+						toolName: "read_files",
+						output: {
+							type: "json",
+							value: [
+								{
+									query: "/tmp/image.jpg",
+									result: [
+										"Successfully read image",
+										IMAGE_UNSUPPORTED_PLACEHOLDER,
+									],
+									success: true,
+								},
+							],
+						},
+					},
+				],
+			},
+		]);
+		const serialized = JSON.stringify(messages);
+		expect(serialized).not.toContain(image);
+		expect(serialized).not.toContain('"type":"image-data"');
+	});
+
+	it("uses the unsupported placeholder for error tool-result media too", () => {
+		const image = imageData(16);
+		const output = toAiSdkToolResultOutput(
+			[
+				{ type: "text", text: "boom" },
+				{ type: "image", data: image, mediaType: "image/jpeg" },
+			],
+			true,
+			undefined,
+			{ supportsImages: false },
+		);
+
+		expect(output).toEqual({
+			type: "error-json",
+			value: ["boom", IMAGE_UNSUPPORTED_PLACEHOLDER],
+		});
 	});
 });

--- a/sdk/packages/shared/src/llms/ai-sdk-format.ts
+++ b/sdk/packages/shared/src/llms/ai-sdk-format.ts
@@ -4,6 +4,7 @@ import {
 	DEFAULT_MAX_IMAGE_DECODED_BYTES,
 	DEFAULT_MAX_IMAGE_ENCODED_BYTES,
 	IMAGE_OMITTED_PLACEHOLDER,
+	IMAGE_UNSUPPORTED_PLACEHOLDER,
 	imageBase64LengthForDecodedBytes,
 	type MediaBudgetState,
 	reserveImageMediaBytes,
@@ -287,6 +288,17 @@ function toUserImagePart(
 	};
 }
 
+interface StripImagesOptions {
+	/**
+	 * When true, valid image blocks are collected into `images` for the
+	 * caller to hoist into native multimodal parts. When false, they are
+	 * replaced inline with `inlineImagePlaceholder` text instead (used for
+	 * error outputs and for models without image input support).
+	 */
+	hoistImages: boolean;
+	inlineImagePlaceholder: string;
+}
+
 /**
  * Recursively walk a tool-result `output` value, removing any AI-SDK image
  * content blocks (`{type:'image', data, mediaType}`) and collecting them
@@ -301,8 +313,9 @@ function stripImagesFromOutput(
 	value: unknown,
 	images: AiSdkImageContentBlock[],
 	state: MediaBudgetState,
-	hoistImages = true,
+	options: StripImagesOptions,
 ): StripImagesResult {
+	const { hoistImages, inlineImagePlaceholder } = options;
 	if (value == null || typeof value !== "object") {
 		return { value, changed: false, mediaChanged: false };
 	}
@@ -320,7 +333,7 @@ function stripImagesFromOutput(
 					typeof obj.mediaType === "string"
 				) {
 					if (!hoistImages) {
-						out.push(IMAGE_OMITTED_PLACEHOLDER);
+						out.push(inlineImagePlaceholder);
 						changed = true;
 						mediaChanged = true;
 						continue;
@@ -356,7 +369,7 @@ function stripImagesFromOutput(
 					continue;
 				}
 			}
-			const stripped = stripImagesFromOutput(item, images, state, hoistImages);
+			const stripped = stripImagesFromOutput(item, images, state, options);
 			out.push(stripped.value);
 			changed ||= stripped.changed;
 			mediaChanged ||= stripped.mediaChanged;
@@ -369,7 +382,7 @@ function stripImagesFromOutput(
 		if (typeof obj.data === "string" && typeof obj.mediaType === "string") {
 			if (!hoistImages) {
 				return {
-					value: IMAGE_OMITTED_PLACEHOLDER,
+					value: inlineImagePlaceholder,
 					changed: true,
 					mediaChanged: true,
 				};
@@ -405,7 +418,7 @@ function stripImagesFromOutput(
 	let changed = false;
 	let mediaChanged = false;
 	for (const [k, v] of Object.entries(obj)) {
-		const stripped = stripImagesFromOutput(v, images, state, hoistImages);
+		const stripped = stripImagesFromOutput(v, images, state, options);
 		out[k] = stripped.value;
 		changed ||= stripped.changed;
 		mediaChanged ||= stripped.mediaChanged;
@@ -436,7 +449,9 @@ export function toAiSdkToolResultOutput(
 	output: unknown,
 	isError = false,
 	mediaState: MediaBudgetState = createMediaBudgetState(),
+	options?: { supportsImages?: boolean },
 ): Record<string, unknown> {
+	const supportsImages = options?.supportsImages ?? true;
 	if (typeof output === "string") {
 		return {
 			type: isError ? "error-text" : "text",
@@ -450,12 +465,17 @@ export function toAiSdkToolResultOutput(
 	// falls through to the `json` branch below and the base64 image data
 	// is sent to the model as a JSON string — the model cannot see it and
 	// will hallucinate the image's contents.
+	// When the target model does not support image input, the image blocks
+	// are substituted with placeholder text instead so the model knows an
+	// image was there.
 	if (!isError && isAiSdkContentBlockArray(output)) {
 		return {
 			type: "content",
 			value: output.map((block) =>
 				block.type === "image"
-					? toImageDataPart(block, mediaState)
+					? supportsImages
+						? toImageDataPart(block, mediaState)
+						: { type: "text", text: IMAGE_UNSUPPORTED_PLACEHOLDER }
 					: { type: "text", text: sanitizeSurrogates(block.text) },
 			),
 		};
@@ -469,14 +489,16 @@ export function toAiSdkToolResultOutput(
 	// text block followed by the extracted images. Without this, the wire
 	// converter JSON-serialises the whole tree and the model receives the
 	// base64 bytes as opaque text.
+	// For models without image input support, images are replaced inline
+	// with placeholder text instead of being hoisted.
 	if (output !== null && typeof output === "object") {
 		const images: AiSdkImageContentBlock[] = [];
-		const stripped = stripImagesFromOutput(
-			output,
-			images,
-			mediaState,
-			!isError,
-		);
+		const stripped = stripImagesFromOutput(output, images, mediaState, {
+			hoistImages: !isError && supportsImages,
+			inlineImagePlaceholder: supportsImages
+				? IMAGE_OMITTED_PLACEHOLDER
+				: IMAGE_UNSUPPORTED_PLACEHOLDER,
+		});
 		if (!isError && images.length > 0) {
 			const headerText =
 				typeof stripped.value === "string"
@@ -523,9 +545,21 @@ export function toAiSdkToolResultOutput(
 export function formatMessagesForAiSdk(
 	systemContent: string | AiSdkMessagePart[] | undefined,
 	messages: readonly AiSdkFormatterMessage[],
-	options?: { assistantToolCallArgKey?: "args" | "input" },
+	options?: {
+		assistantToolCallArgKey?: "args" | "input";
+		/**
+		 * Whether the target model advertises image input. When false, image
+		 * parts (user-attached and inside tool results) are substituted with
+		 * `IMAGE_UNSUPPORTED_PLACEHOLDER` text so the request stays valid for
+		 * text-only models while the model still learns an image was there.
+		 * Defaults to true. The substitution happens here at request-build
+		 * time only — stored conversation history is never mutated.
+		 */
+		supportsImages?: boolean;
+	},
 ): AiSdkMessage[] {
 	const toolCallArgKey = options?.assistantToolCallArgKey ?? "input";
+	const supportsImages = options?.supportsImages ?? true;
 	const result: AiSdkMessage[] = [];
 	const mediaState = createMediaBudgetState();
 
@@ -591,7 +625,11 @@ export function formatMessagesForAiSdk(
 					});
 					break;
 				case "image":
-					messageParts.push(toUserImagePart(part, mediaState));
+					messageParts.push(
+						supportsImages
+							? toUserImagePart(part, mediaState)
+							: { type: "text", text: IMAGE_UNSUPPORTED_PLACEHOLDER },
+					);
 					break;
 				case "file":
 					messageParts.push({
@@ -624,6 +662,7 @@ export function formatMessagesForAiSdk(
 							part.output,
 							part.isError ?? false,
 							mediaState,
+							{ supportsImages },
 						),
 					});
 					break;

--- a/sdk/packages/shared/src/llms/media.ts
+++ b/sdk/packages/shared/src/llms/media.ts
@@ -1,6 +1,14 @@
 export const IMAGE_OMITTED_PLACEHOLDER =
 	"[media omitted: invalid or exceeds size limit]";
 
+/**
+ * Substituted for image content at request-build time when the target model
+ * does not advertise image input. The stored conversation history keeps the
+ * real image, so switching to an image-capable model restores it.
+ */
+export const IMAGE_UNSUPPORTED_PLACEHOLDER =
+	"[Image attached — this model cannot view images]";
+
 export const SUPPORTED_IMAGE_MEDIA_TYPES = [
 	"image/png",
 	"image/jpeg",


### PR DESCRIPTION
# Description

Production DeepSeek tasks on the SDK extension die with a request-deserialization 422 once any image enters the conversation:

```
Failed to deserialize the JSON body into the target type: messages[261]: unknown variant `image_url`, expected one of `text`, …
```

Once a user attaches a screenshot or a tool result carries an image, every subsequent request re-serializes it as an `image_url` content part, DeepSeek rejects the whole request, and the task is permanently wedged — retrying resends the same history.

## Root cause

DeepSeek catalog entries (models.dev-derived) do not advertise the `images` capability, but message assembly never consulted model capabilities: `toAiSdkMessages` / `formatMessagesForAiSdk` converted image parts unconditionally, and `splitToolImagesMiddleware` only restructures tool-result images (into a synthetic user message that *also* serializes to `image_url`) — it never removes them for text-only models. The legacy extension's per-provider handlers stripped/text-replaced image blocks for non-image models; the SDK path lost that gate.

## Fix

Add a capability gate at request-build time, centrally in the shared conversion layer (applies to every provider/model, not a DeepSeek special case):

- `@cline/shared` `formatMessagesForAiSdk` / `toAiSdkToolResultOutput` accept a `supportsImages` option. When false, image parts — user-attached, inside tool-result content-block arrays, and nested in structured tool outputs — are substituted with placeholder text (`[Image attached — this model cannot view images]`) instead of being converted/hoisted, so the model still learns an image was there.
- `@cline/llms` threads the resolved model's gateway capabilities into the conversion via a new `modelSupportsImageInput(context)` fact (`model-facts.ts`): gate applies only when the model's capability data exists and lacks `images`; models with no capability data at all (ids resolved outside any catalog) fail open and keep images.
- Stored conversation history is never mutated — substitution happens only while building the request, so switching to an image-capable model mid-task brings the images back.

## Trade-off: capability-data quality

If a catalog entry wrongly omits the `images` capability for a capable model, this gate hides images from it. Two mitigations keep that survivable: substitution-with-placeholder (the model is told an image existed, nothing silently disappears), and the fail-open path when capability data is absent entirely. User-configured custom models keep working too — the VS Code adapter maps the "supports images" setting into the `images` capability.

## Validation

Wire-level before/after through the real `@ai-sdk/openai-compatible` converter with a wedged history (user image attachment + tool-result image at message N, follow-up at N+1), provider `deepseek`, model `deepseek-chat`:

Before — the exact production failure shape (`image_url` parts on the wire, from both the attachment and the split-middleware synthetic user message):

```json
{ "type": "image_url", "image_url": { "url": "data:image/png;base64,…" } }
```

After — valid request, no `image_url`, no raw base64, placeholders in place:

```json
[
  { "role": "user", "content": "Hello" },
  { "role": "user", "content": [
      { "type": "text", "text": "see this screenshot" },
      { "type": "text", "text": "[Image attached — this model cannot view images]" } ] },
  { "role": "assistant", "content": null, "tool_calls": [ { "id": "call_img", "type": "function", "function": { "name": "read_file", "arguments": "{\"path\":\"/tmp/image.png\"}" } } ] },
  { "role": "tool", "tool_call_id": "call_img", "content": "[{\"type\":\"text\",\"text\":\"Successfully read image\"},{\"type\":\"text\",\"text\":\"[Image attached — this model cannot view images]\"}]" },
  { "role": "user", "content": "continue please" }
]
```

Tests:

- `@cline/shared`: unit tests for user image parts, tool-result content-block arrays, structured nested tool outputs, error outputs, and the explicit `supportsImages: true` passthrough — 301 passed.
- `@cline/llms`: gateway end-to-end tests (wedged history through the builtin `deepseek` provider): `deepseek-chat` → placeholder, no image parts; model advertising `images` → unchanged; unknown model with no capability data → fail open — 518 passed.
- `bun -F @cline/shared typecheck`, `bun -F @cline/llms typecheck`, root `bun run build:sdk`, `bun -F @cline/agents test` (58 passed), `bun -F @cline/core test:unit` (1554 passed; only failures are the documented cloud-env `workspace-manifest` git-remote artifact and two `beforeEach` hook timeouts under parallel load that pass in isolation).

# Test Procedure

- `cd sdk && bun run build:sdk`
- `bun -F @cline/shared test && bun -F @cline/llms test`
- `bun -F @cline/shared typecheck && bun -F @cline/llms typecheck`

# Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

# Pre-Submission Checklist

- [x] Self-review completed
- [x] Tests added/updated
- [x] Builds and typechecks cleanly