### PR TITLE
fix(llms): preserve tool names on tool-result parts (Gemini "Name cannot be empty")

### DIFF
--- a/apps/vscode/src/sdk/legacy-task-handling.test.ts
+++ b/apps/vscode/src/sdk/legacy-task-handling.test.ts
@@ -1,0 +1,117 @@
+import type { ToolResultContent, ToolUseContent } from "@cline/shared"
+import type { HistoryItem } from "@shared/HistoryItem"
+import { describe, expect, it } from "vitest"
+import { legacyApiHistoryToSdkMessages } from "./legacy-task-handling"
+
+/**
+ * Legacy (Anthropic-format) `tool_result` blocks carry no `name` field. The
+ * conversion must backfill each result's tool name from the paired
+ * `tool_use` block, otherwise a resumed legacy task sends
+ * `functionResponse.name: ""` to Gemini, which rejects the request with
+ * "Name cannot be empty." (production task-killer for the SDK extension).
+ */
+
+const HISTORY_ITEM = {
+	id: "task-1",
+	ts: 1,
+	task: "read a file",
+	tokensIn: 0,
+	tokensOut: 0,
+	totalCost: 0,
+} as HistoryItem
+
+function findBlocks<T extends { type: string }>(
+	messages: ReturnType<typeof legacyApiHistoryToSdkMessages>,
+	type: T["type"],
+): T[] {
+	const blocks: T[] = []
+	for (const message of messages) {
+		if (!Array.isArray(message.content)) {
+			continue
+		}
+		for (const block of message.content) {
+			if (block.type === type) {
+				blocks.push(block as unknown as T)
+			}
+		}
+	}
+	return blocks
+}
+
+describe("legacyApiHistoryToSdkMessages tool_result names", () => {
+	it("backfills tool_result names from the paired tool_use block", () => {
+		const messages = legacyApiHistoryToSdkMessages(
+			[
+				{ role: "user", content: [{ type: "text", text: "read the readme" }] },
+				{
+					role: "assistant",
+					content: [
+						{ type: "tool_use", id: "toolu_1", name: "read_file", input: { path: "README.md" } },
+						{ type: "tool_use", id: "toolu_2", name: "list_files", input: { path: "." } },
+					],
+				},
+				{
+					role: "user",
+					content: [
+						// Anthropic-format tool_result blocks: no `name` field.
+						{ type: "tool_result", tool_use_id: "toolu_1", content: "# README" },
+						{ type: "tool_result", tool_use_id: "toolu_2", content: "README.md\nsrc/" },
+					],
+				},
+			],
+			HISTORY_ITEM,
+		)
+
+		const results = findBlocks<ToolResultContent>(messages, "tool_result")
+		expect(results.map((block) => block.name)).toEqual(["read_file", "list_files"])
+	})
+
+	it("keeps an explicit tool_result name when present", () => {
+		const messages = legacyApiHistoryToSdkMessages(
+			[
+				{
+					role: "assistant",
+					content: [{ type: "tool_use", id: "toolu_1", name: "read_file", input: {} }],
+				},
+				{
+					role: "user",
+					content: [{ type: "tool_result", tool_use_id: "toolu_1", name: "stored_name", content: "ok" }],
+				},
+			],
+			HISTORY_ITEM,
+		)
+
+		const results = findBlocks<ToolResultContent>(messages, "tool_result")
+		expect(results.map((block) => block.name)).toEqual(["stored_name"])
+	})
+
+	it("leaves the name empty when no paired tool_use exists", () => {
+		const messages = legacyApiHistoryToSdkMessages(
+			[
+				{
+					role: "user",
+					content: [{ type: "tool_result", tool_use_id: "toolu_missing", content: "orphaned" }],
+				},
+			],
+			HISTORY_ITEM,
+		)
+
+		const results = findBlocks<ToolResultContent>(messages, "tool_result")
+		expect(results.map((block) => block.name)).toEqual([""])
+	})
+
+	it("still converts tool_use blocks unchanged", () => {
+		const messages = legacyApiHistoryToSdkMessages(
+			[
+				{
+					role: "assistant",
+					content: [{ type: "tool_use", id: "toolu_1", name: "read_file", input: { path: "a.txt" } }],
+				},
+			],
+			HISTORY_ITEM,
+		)
+
+		const uses = findBlocks<ToolUseContent>(messages, "tool_use")
+		expect(uses).toMatchObject([{ id: "toolu_1", name: "read_file", input: { path: "a.txt" } }])
+	})
+})

--- a/apps/vscode/src/sdk/legacy-task-handling.ts
+++ b/apps/vscode/src/sdk/legacy-task-handling.ts
@@ -6,7 +6,38 @@ import { sanitizeInitialMessagesForSessionStart } from "./initial-message-saniti
 export const LEGACY_RESUME_MODEL_WARNING =
 	"Warning: this is a legacy conversation, which means tool names may have changed. Please use the most up-to-date tools you are aware of."
 
-function anthropicContentBlockToSdkBlock(block: unknown): ContentBlock | undefined {
+/**
+ * Legacy (Anthropic-format) `tool_result` blocks carry no `name` field, but
+ * SDK tool results must name their originating tool: providers such as
+ * Gemini require `functionResponse.name` to match the paired function call
+ * and reject the whole request when it is empty. Index the history's
+ * `tool_use` blocks so each converted `tool_result` can recover its tool
+ * name from the paired call.
+ */
+function collectToolUseNames(apiHistory: unknown[]): Map<string, string> {
+	const names = new Map<string, string>()
+	for (const raw of apiHistory) {
+		if (!raw || typeof raw !== "object") {
+			continue
+		}
+		const content = (raw as { content?: unknown }).content
+		if (!Array.isArray(content)) {
+			continue
+		}
+		for (const block of content) {
+			if (!block || typeof block !== "object") {
+				continue
+			}
+			const record = block as Record<string, unknown>
+			if (record.type === "tool_use" && typeof record.id === "string" && typeof record.name === "string") {
+				names.set(record.id, record.name)
+			}
+		}
+	}
+	return names
+}
+
+function anthropicContentBlockToSdkBlock(block: unknown, toolUseNames: ReadonlyMap<string, string>): ContentBlock | undefined {
 	if (!block || typeof block !== "object") {
 		return undefined
 	}
@@ -28,7 +59,10 @@ function anthropicContentBlockToSdkBlock(block: unknown): ContentBlock | undefin
 				? {
 						type: "tool_result",
 						tool_use_id: record.tool_use_id,
-						name: typeof record.name === "string" ? record.name : "",
+						name:
+							typeof record.name === "string" && record.name.length > 0
+								? record.name
+								: (toolUseNames.get(record.tool_use_id) ?? ""),
 						content: typeof record.content === "string" ? record.content : JSON.stringify(record.content ?? ""),
 						is_error: typeof record.is_error === "boolean" ? record.is_error : undefined,
 					}
@@ -80,6 +114,7 @@ export function appendLegacyResumeWarning<T extends { role: string; content: unk
 }
 
 export function legacyApiHistoryToSdkMessages(apiHistory: unknown[], historyItem: HistoryItem): MessageWithMetadata[] {
+	const toolUseNames = collectToolUseNames(apiHistory)
 	const messages = apiHistory.flatMap((raw): MessageWithMetadata[] => {
 		if (!raw || typeof raw !== "object") {
 			return []
@@ -101,7 +136,7 @@ export function legacyApiHistoryToSdkMessages(apiHistory: unknown[], historyItem
 
 		if (Array.isArray(record.content)) {
 			const content = record.content.flatMap((block) => {
-				const converted = anthropicContentBlockToSdkBlock(block)
+				const converted = anthropicContentBlockToSdkBlock(block, toolUseNames)
 				if (role === "user" && converted?.type === "text") {
 					return [{ ...converted, text: formatDisplayUserInput(converted.text) }]
 				}

--- a/sdk/packages/llms/src/providers/ai-sdk.tool-result-names.test.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.tool-result-names.test.ts
@@ -1,0 +1,220 @@
+import type {
+	AgentMessage,
+	BasicLogger,
+	GatewayProviderContext,
+	GatewayStreamRequest,
+} from "@cline/shared";
+import { describe, expect, it, vi } from "vitest";
+import { createGoogleProvider } from "./ai-sdk";
+
+/**
+ * Regression tests for the Gemini "function_response.name: Name cannot be
+ * empty." 400 (production, SDK extension).
+ *
+ * Tool-result parts restored from persisted histories can carry an empty or
+ * missing `toolName`:
+ *   - tasks imported from the legacy extension store Anthropic-format
+ *     `tool_result` blocks, which have no `name` field, and
+ *   - SDK sessions persisted before `ToolResultContent.name` existed
+ *     deserialize with `name: undefined`.
+ *
+ * `@ai-sdk/google` serializes `functionResponse.name` verbatim from the
+ * tool-result part's `toolName`, and the Generative Language API rejects the
+ * whole request when it is empty. These tests drive the real Google provider
+ * adapter with a capturing fetch stub and assert the wire payload carries the
+ * originating tool-call's name on every functionResponse part.
+ */
+
+const GOOGLE_SSE_RESPONSE = `data: ${JSON.stringify({
+	candidates: [
+		{
+			content: { parts: [{ text: "done" }], role: "model" },
+			finishReason: "STOP",
+			index: 0,
+		},
+	],
+	usageMetadata: {
+		promptTokenCount: 10,
+		candidatesTokenCount: 2,
+		totalTokenCount: 12,
+	},
+})}\n\ndata: [DONE]\n\n`;
+
+interface CapturedGoogleRequest {
+	contents: Array<{
+		role: string;
+		parts: Array<Record<string, unknown>>;
+	}>;
+}
+
+async function streamAndCaptureGoogleRequest(
+	messages: AgentMessage[],
+	logger?: BasicLogger,
+): Promise<CapturedGoogleRequest> {
+	let capturedBody: string | undefined;
+	const config = {
+		providerId: "google",
+		apiKey: "test-key",
+		fetch: (async (_input: unknown, init?: RequestInit) => {
+			capturedBody =
+				typeof init?.body === "string" ? init.body : String(init?.body);
+			return new Response(GOOGLE_SSE_RESPONSE, {
+				status: 200,
+				headers: { "content-type": "text/event-stream" },
+			});
+		}) as unknown as typeof fetch,
+	};
+	const provider = await createGoogleProvider(config as never);
+	const model = {
+		id: "gemini-2.5-flash",
+		providerId: "google",
+		name: "Gemini 2.5 Flash",
+	};
+	const context = {
+		provider: {
+			id: "google",
+			name: "Google",
+			defaultModelId: model.id,
+			models: [model],
+		},
+		model,
+		config,
+		logger,
+	} as unknown as GatewayProviderContext;
+	const request = {
+		providerId: "google",
+		modelId: model.id,
+		messages,
+	} as unknown as GatewayStreamRequest;
+
+	for await (const _event of await provider.stream(request, context)) {
+		// Drain the stream so the request is issued.
+	}
+
+	expect(capturedBody).toBeDefined();
+	return JSON.parse(capturedBody ?? "{}") as CapturedGoogleRequest;
+}
+
+function collectFunctionResponseNames(body: CapturedGoogleRequest): string[] {
+	const names: string[] = [];
+	for (const content of body.contents ?? []) {
+		for (const part of content.parts ?? []) {
+			const functionResponse = part.functionResponse as
+				| { name?: unknown }
+				| undefined;
+			if (functionResponse !== undefined) {
+				names.push(
+					typeof functionResponse.name === "string"
+						? functionResponse.name
+						: "",
+				);
+			}
+		}
+	}
+	return names;
+}
+
+function conversationWithToolResultName(
+	toolName: string | undefined,
+): AgentMessage[] {
+	const createdAt = Date.now();
+	return [
+		{
+			id: "msg_user",
+			role: "user",
+			content: [{ type: "text", text: "read the readme" }],
+			createdAt,
+		},
+		{
+			id: "msg_assistant",
+			role: "assistant",
+			content: [
+				{
+					type: "tool-call",
+					toolCallId: "toolu_1",
+					toolName: "read_files",
+					input: { files: [{ path: "README.md" }] },
+				},
+			],
+			createdAt,
+		},
+		{
+			id: "msg_tool",
+			role: "tool",
+			content: [
+				{
+					type: "tool-result",
+					toolCallId: "toolu_1",
+					// Restored histories can violate the non-optional type.
+					toolName: toolName as string,
+					output: "# README\ncontents",
+				},
+			],
+			createdAt,
+		},
+	];
+}
+
+describe("google tool-result name serialization", () => {
+	it("keeps the tool name carried on the tool-result part", async () => {
+		const body = await streamAndCaptureGoogleRequest(
+			conversationWithToolResultName("read_files"),
+		);
+		expect(collectFunctionResponseNames(body)).toEqual(["read_files"]);
+	});
+
+	it("backfills an empty tool name from the paired tool call (legacy extension import)", async () => {
+		const body = await streamAndCaptureGoogleRequest(
+			conversationWithToolResultName(""),
+		);
+		expect(collectFunctionResponseNames(body)).toEqual(["read_files"]);
+	});
+
+	it("backfills a missing tool name from the paired tool call (pre-name persisted session)", async () => {
+		const body = await streamAndCaptureGoogleRequest(
+			conversationWithToolResultName(undefined),
+		);
+		expect(collectFunctionResponseNames(body)).toEqual(["read_files"]);
+	});
+
+	it("logs when the backfill engages", async () => {
+		const log = vi.fn();
+		const logger: BasicLogger = { debug: vi.fn(), log };
+		await streamAndCaptureGoogleRequest(
+			conversationWithToolResultName(""),
+			logger,
+		);
+		expect(log).toHaveBeenCalledWith(
+			expect.stringContaining("backfilled missing tool name"),
+			expect.objectContaining({ toolName: "read_files" }),
+		);
+	});
+
+	it("falls back to a placeholder name for an orphaned tool-result", async () => {
+		const createdAt = Date.now();
+		const body = await streamAndCaptureGoogleRequest([
+			{
+				id: "msg_user",
+				role: "user",
+				content: [{ type: "text", text: "hello" }],
+				createdAt,
+			},
+			{
+				id: "msg_tool",
+				role: "tool",
+				content: [
+					{
+						type: "tool-result",
+						toolCallId: "toolu_orphan",
+						toolName: "" as string,
+						output: "orphaned result",
+					},
+				],
+				createdAt,
+			},
+		]);
+		const names = collectFunctionResponseNames(body);
+		expect(names).toHaveLength(1);
+		expect(names[0]).not.toBe("");
+	});
+});

--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -2,6 +2,8 @@ import type {
 	AgentMessage,
 	AgentModelEvent,
 	AgentModelFinishReason,
+	AgentToolResultPart,
+	BasicLogger,
 	GatewayProviderContext,
 	GatewayProviderFactory,
 	GatewayResolvedProviderConfig,
@@ -80,6 +82,7 @@ function buildCachedAiSdkMessages(
 ) {
 	const aiMessages = toAiSdkMessages(request.messages, systemPrompt, {
 		includeReasoning: shouldIncludeReasoningHistory(request, context),
+		logger: context.logger,
 	}) as Array<Record<string, unknown>>;
 	const includeAnthropic = isAnthropicCompatibleModel({
 		modelId: request.modelId,
@@ -277,13 +280,74 @@ async function ensureGatewayLangfuseTelemetry(
 	}
 }
 
+const FALLBACK_TOOL_RESULT_NAME = "tool";
+
+/**
+ * Build a `toolCallId -> toolName` index from the tool-call parts in the
+ * conversation so tool-result parts can recover their originating tool's
+ * name when it was lost upstream.
+ */
+function collectToolNamesByCallId(
+	messages: readonly AgentMessage[],
+): Map<string, string> {
+	const names = new Map<string, string>();
+	for (const message of messages) {
+		for (const part of message.content) {
+			if (
+				part.type === "tool-call" &&
+				typeof part.toolName === "string" &&
+				part.toolName.length > 0
+			) {
+				names.set(part.toolCallId, part.toolName);
+			}
+		}
+	}
+	return names;
+}
+
+/**
+ * Tool-result parts restored from persisted histories can carry an
+ * empty/missing `toolName` despite the type: tasks imported from the legacy
+ * extension store Anthropic-format `tool_result` blocks (which have no name
+ * field), and SDK sessions persisted before `ToolResultContent.name` existed
+ * deserialize without one. Google's Generative Language API requires
+ * `functionResponse.name` to match the originating `functionCall` name and
+ * rejects the whole request with "Name cannot be empty." otherwise, so
+ * backfill the name from the paired tool call before the AI SDK serializes
+ * it. An orphaned result (no paired call in the transcript) gets a
+ * placeholder so no provider ever sees an empty name.
+ */
+function resolveToolResultName(
+	part: AgentToolResultPart,
+	toolNamesByCallId: ReadonlyMap<string, string>,
+	logger: BasicLogger | undefined,
+): string {
+	if (typeof part.toolName === "string" && part.toolName.length > 0) {
+		return part.toolName;
+	}
+	const paired = toolNamesByCallId.get(part.toolCallId);
+	const resolved = paired ?? FALLBACK_TOOL_RESULT_NAME;
+	logger?.log(
+		paired
+			? "[ai-sdk] backfilled missing tool name on tool-result part from paired tool call"
+			: "[ai-sdk] backfilled missing tool name on tool-result part with placeholder (no paired tool call)",
+		{
+			severity: "warn",
+			toolName: resolved,
+			toolCallId: part.toolCallId,
+		},
+	);
+	return resolved;
+}
+
 function toAiSdkMessages(
 	messages: readonly AgentMessage[],
 	systemPrompt?: string,
-	options?: { includeReasoning?: boolean },
+	options?: { includeReasoning?: boolean; logger?: BasicLogger },
 ) {
 	const includeReasoning = options?.includeReasoning ?? true;
 	const normalizedMessages: AiSdkFormatterMessage[] = [];
+	const toolNamesByCallId = collectToolNamesByCallId(messages);
 
 	for (const message of messages) {
 		const content: AiSdkFormatterPart[] = [];
@@ -365,7 +429,11 @@ function toAiSdkMessages(
 				content.push({
 					type: "tool-result",
 					toolCallId: part.toolCallId,
-					toolName: part.toolName,
+					toolName: resolveToolResultName(
+						part,
+						toolNamesByCallId,
+						options?.logger,
+					),
 					output: part.output,
 					isError: part.isError ?? false,
 				});
@@ -1213,6 +1281,7 @@ function createAiSdkProvider(kind: ProviderModuleKind): GatewayProviderFactory {
 					? buildCachedAiSdkMessages(request, context, messagesSystemPrompt)
 					: toAiSdkMessages(request.messages, messagesSystemPrompt, {
 							includeReasoning: shouldIncludeReasoningHistory(request, context),
+							logger: context.logger,
 						});
 				const providerOptions = composeAiSdkProviderOptions(
 					request,


### PR DESCRIPTION
## Problem

Gemini tasks on the SDK extension die mid-run with a 400-class validation error once the conversation contains tool results:

```
* GenerateContentRequest.contents[2].parts[0].function_response.name: Name cannot be empty.
```

Production telemetry (2026-08-02→03, stable rollout) shows this only on the "next" (SDK) variant — legacy shows zero — and it kills the task on the first request that carries a tool result, so affected users cannot use tools with Gemini at all.

## Root cause (serialization chain)

The Google Generative Language API requires `functionResponse.name` to equal the paired `functionCall`'s declared name. `@ai-sdk/google` (v4.0.31, `appendToolResultParts` in `convertToGoogleGenerativeAIMessages`) copies `name: toolName` verbatim from the tool-result message part — it never derives it from the paired call. So any tool-result part that reaches the provider with an empty/missing `toolName` produces exactly this error.

Two upstream paths produce such parts:

1. **Legacy-extension task imports** (the production hits). `legacyApiHistoryToSdkMessages` in `apps/vscode/src/sdk/legacy-task-handling.ts` converts the old extension's Anthropic-format `api_conversation_history`, whose `tool_result` blocks have **no `name` field** — and it filled in `name: ""` for every converted result. Resuming any legacy task that used tools, then continuing it on Gemini, sends `functionResponse.name: ""` for every restored tool result. `contents[2]` is the restored history's first function response (`contents[0]` user, `contents[1]` functionCall, `contents[2]` functionResponse), and the error repeats per restored result — matching the truncated production message.
2. **Pre-`name` persisted SDK sessions.** `ToolResultContent.name` was only added 2026-05-22 (0c8971684). Session JSON has no schema validation on restore, so older records deserialize with `name: undefined` → `toolName: undefined` on the `AgentToolResultPart` (which even breaks AI SDK prompt validation before the request is issued).

The path from history to wire: restored `Message` → `messagesToAgentMessages` codec (`toolName: block.name`, no backfill) → `toAiSdkMessages` in `sdk/packages/llms/src/providers/ai-sdk.ts` (passed `part.toolName` through verbatim) → `formatMessagesForAiSdk` → `@ai-sdk/google`. The gateway path was already immune: `toGatewayRequestMessages` re-derives the name from the paired `tool_use` block with a `"tool"` fallback — which is why the legacy variant and gateway providers never showed this error.

## Repro

`sdk/packages/llms/src/providers/ai-sdk.tool-result-names.test.ts` drives the real `createGoogleProvider` adapter with a capturing fetch stub. Before the fix, a conversation whose tool-result part carries `toolName: ""` (the legacy-resume shape) serialized `functionResponse.name: ""` on the wire:

```
AssertionError: expected [ '' ] to deeply equal [ 'read_files' ]
```

and the `toolName: undefined` shape (pre-`name` session) failed before the request was even issued. 4 of the 5 new tests failed pre-fix.

## Fix

Invariant enforced: every tool-result part sent to a provider carries the same non-empty tool name as its originating tool call.

- **`sdk/packages/llms/src/providers/ai-sdk.ts`** (assembly-time backfill, covers all `createAiSdkProvider` kinds — google, vertex, anthropic, etc.): `toAiSdkMessages` now indexes `toolCallId → toolName` from the conversation's tool-call parts and backfills any empty/missing `toolName` on tool-result parts from the paired call. An orphaned result (no paired call in the transcript) gets a `"tool"` placeholder, consistent with the existing gateway behavior. The backfill logs a warning through `context.logger` when it engages.
- **`apps/vscode/src/sdk/legacy-task-handling.ts`** (fix at the source): the legacy import now indexes the history's `tool_use` blocks and recovers each converted `tool_result`'s `name` from its paired call instead of writing `""`.

No change to the Google vendor itself, and no change to `split-tool-images.ts` — it spreads `...part` and was verified to preserve `toolName`.

## Validation

- `sdk/packages/llms`: `bun run test` (520 passed / 4 skipped, includes the 5 new wire-capture tests) and `bun run typecheck` clean.
- `bun run build:sdk` clean; `@cline/shared` and `@cline/agents` suites pass; `@cline/core` unit suite shows only the documented cloud-env git artifacts (`workspace-manifest`, `checkpoint-restore` timeout), identical without this change.
- `apps/vscode`: new `legacy-task-handling.test.ts` (4 tests) passes; `bun run test:unit` fully green (1061 pass); the SDK bun-test suite shows the same 35 pre-existing failures as unmodified `main` (verified via stash baseline: 922 pass / 35 fail there vs 926 pass / 35 fail here — the delta is exactly the new tests).