### PR TITLE
fix(desktop): make agent header draggable

### DIFF
--- a/apps/examples/desktop-app/webview/components/agent-header.test.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-header.test.tsx
@@ -21,6 +21,18 @@ afterEach(async () => {
 	vi.restoreAllMocks();
 });
 
+describe("AgentHeader title bar", () => {
+	it("makes non-interactive header space draggable", async () => {
+		await act(async () => {
+			root.render(<AgentHeader status="completed" title="A session" />);
+		});
+
+		expect(
+			container.querySelector("header")?.getAttribute("data-tauri-drag-region"),
+		).toBe("deep");
+	});
+});
+
 describe("AgentHeader title editor", () => {
 	it("preserves the displayed title width when editing starts", async () => {
 		await act(async () => {

--- a/apps/examples/desktop-app/webview/components/agent-header.test.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-header.test.tsx
@@ -31,6 +31,19 @@ describe("AgentHeader title bar", () => {
 			container.querySelector("header")?.getAttribute("data-tauri-drag-region"),
 		).toBe("deep");
 	});
+
+	it("renders a read-only title as draggable text", async () => {
+		await act(async () => {
+			root.render(<AgentHeader status="completed" title="Read-only session" />);
+		});
+
+		expect(
+			container.querySelector('span[title="Read-only session"]'),
+		).not.toBeNull();
+		expect(
+			container.querySelector('button[title="Read-only session"]'),
+		).toBeNull();
+	});
 });
 
 describe("AgentHeader title editor", () => {

--- a/apps/examples/desktop-app/webview/components/agent-header.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-header.tsx
@@ -123,7 +123,10 @@ export function AgentHeader({
 	const triggerDeleteSession = () => onDeleteSession?.();
 
 	return (
-		<header className="flex h-12 items-center justify-between gap-2 px-4 max-md:h-7 max-md:pl-28 md:group-data-[state=collapsed]/sidebar-wrapper:pl-7">
+		<header
+			className="flex h-12 items-center justify-between gap-2 px-4 max-md:h-7 max-md:pl-28 md:group-data-[state=collapsed]/sidebar-wrapper:pl-7"
+			data-tauri-drag-region="deep"
+		>
 			{/* Left: thread title */}
 			<div className="flex min-w-0 flex-1 items-center gap-2">
 				<SessionStatus

--- a/apps/examples/desktop-app/webview/components/agent-header.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-header.tsx
@@ -140,7 +140,14 @@ export function AgentHeader({
 					}
 					tone={statusTone}
 				/>
-				{isEditingTitle ? (
+				{!canEditTitle ? (
+					<span
+						className="min-w-0 truncate text-sm font-medium text-foreground"
+						title={threadTitle}
+					>
+						{threadTitle}
+					</span>
+				) : isEditingTitle ? (
 					<form
 						className="m-0 min-w-0 max-w-full shrink-0"
 						onSubmit={(event) => {
@@ -174,7 +181,7 @@ export function AgentHeader({
 							canEditTitle &&
 								"rounded px-1 py-0.5 transition-colors hover:bg-accent",
 						)}
-						disabled={!canEditTitle || renamingTitle}
+						disabled={renamingTitle}
 						onClick={(event) => {
 							if (!canEditTitle || renamingTitle) {
 								return;


### PR DESCRIPTION
## Summary

- mark the desktop agent header as a deep Tauri drag region
- keep title editing and header actions interactive through Tauri clickable-element handling
- add focused regression coverage for the drag-region contract

https://github.com/user-attachments/assets/61d537e5-dad7-4c41-8ee7-d9bc348c3bc7


## Testing

- `bunx vitest run webview/components/agent-header.test.tsx --config vitest.config.ts` (30 tests)
- `bun run typecheck`
- `bunx biome check apps/examples/desktop-app/webview/components/agent-header.tsx apps/examples/desktop-app/webview/components/agent-header.test.tsx`
- manually launched the macOS Tauri app and verified the window can be moved from the right-side header